### PR TITLE
fix(js): add explicit rootDir for TypeScript 6 compatibility

### DIFF
--- a/js/tsconfig.build.json
+++ b/js/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
+    "rootDir": "./src",
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
TypeScript 6.0 [changed](https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/#up-front-adjustments) rootDir behavior: it no longer infers rootDir from the common source directory of input files and instead it defaults to the tsconfig directory, so we need to set it explicitly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change; it only affects how TypeScript determines the source root during builds and should not alter runtime behavior.
> 
> **Overview**
> Build compilation now explicitly sets `compilerOptions.rootDir` to `./src` in `js/tsconfig.build.json`, avoiding TypeScript 6’s new default of using the config directory as the root and preventing unexpected output/declaration path changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86cafed9a1b3dea7e424931396dfecb97004ef60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->