### PR TITLE
fix(java): include devex-emitter subproject in gradle settings

### DIFF
--- a/java/devex-emitter/build.gradle.kts
+++ b/java/devex-emitter/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
 
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation(libs.assertj.core)
 }
 

--- a/java/settings.gradle.kts
+++ b/java/settings.gradle.kts
@@ -6,6 +6,7 @@ include(":providers:anthropic")
 include(":providers:gemini")
 include(":frameworks:google-adk")
 include(":benchmarks")
+include(":devex-emitter")
 
 project(":providers:openai").projectDir = file("providers/openai")
 project(":providers:anthropic").projectDir = file("providers/anthropic")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: build configuration-only changes that mainly affect project inclusion and test execution for one submodule.
> 
> **Overview**
> Registers `:devex-emitter` in `java/settings.gradle.kts` so it is included in the multi-project Gradle build.
> 
> Updates `devex-emitter/build.gradle.kts` to add the JUnit Platform launcher as a `testRuntimeOnly` dependency, improving test runtime execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e8e05de8392bfc32e971c96efa4c4f2c675e5f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->