### PR TITLE
fix(dotnet): set required Container member in DevExEmitter

### DIFF
--- a/dotnet/examples/Grafana.Sigil.DevExEmitter/Program.cs
+++ b/dotnet/examples/Grafana.Sigil.DevExEmitter/Program.cs
@@ -517,6 +517,7 @@ internal static class Program
             request,
             (_, _) => Task.FromResult<AnthropicMessage>(new AnthropicMessage
             {
+                Container = default!,
                 ID = $"dotnet-anthropic-sync-{context.Turn}",
                 Model = AnthropicModel.ClaudeSonnet4_5,
                 Content =
@@ -601,6 +602,7 @@ internal static class Program
             Type = JsonSerializer.SerializeToElement("message_start"),
             Message = new AnthropicMessage
             {
+                Container = default!,
                 ID = $"dotnet-anthropic-stream-{turn}",
                 Model = AnthropicModel.ClaudeSonnet4_5,
                 Content =
@@ -635,6 +637,7 @@ internal static class Program
             Type = JsonSerializer.SerializeToElement("message_delta"),
             Delta = new AnthropicDelta
             {
+                Container = default!,
                 StopReason = AnthropicStopReason.EndTurn,
                 StopSequence = null,
             },


### PR DESCRIPTION
Anthropic SDK bump added a required Container property to Message and Delta types.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the DevEx emitter example to satisfy a new required Anthropic SDK property, with no behavioral changes beyond object initialization.
> 
> **Overview**
> Fixes build/runtime compatibility with the bumped Anthropic SDK by populating the now-required `Container` field when constructing `AnthropicMessage` and `AnthropicDelta` in the DevEx emitter’s Anthropic sync and streaming paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 766add57a09d2405d54e8553e7c25f293901f45d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->