### PR TITLE
feat(go): add ContentCaptureMode for SDK-level content stripping

### DIFF
--- a/go/sigil/client.go
+++ b/go/sigil/client.go
@@ -26,6 +26,24 @@ type Config struct {
 	GenerationExport GenerationExportConfig
 	API              APIConfig
 	EmbeddingCapture EmbeddingCaptureConfig
+	// ContentCapture controls the default content capture mode for all
+	// generations and tool executions. Per-recording overrides take precedence.
+	ContentCapture ContentCaptureMode
+	// ContentCaptureResolver, when set, is called before each generation,
+	// tool execution, and rating submission to dynamically resolve the content
+	// capture mode. It receives the request context and the recording's
+	// metadata (nil when the recording type has no metadata, e.g. tool
+	// executions).
+	//
+	// Resolution precedence (highest → lowest):
+	//   1. Per-recording ContentCapture field (explicit override)
+	//   2. ContentCaptureResolver return value
+	//   3. Config.ContentCapture (static default)
+	//
+	// Returning ContentCaptureModeDefault defers to Config.ContentCapture.
+	// Panics are recovered and treated as ContentCaptureModeMetadataOnly
+	// (fail-closed).
+	ContentCaptureResolver func(ctx context.Context, metadata map[string]any) ContentCaptureMode
 	// Tracer is optional and mainly used for tests. If nil, the client uses the global OpenTelemetry tracer.
 	Tracer trace.Tracer
 	// Meter is optional and mainly used for tests. If nil, the client uses the global OpenTelemetry meter.
@@ -226,11 +244,12 @@ type Client struct {
 //
 // All methods are safe to call on a nil or no-op recorder.
 type GenerationRecorder struct {
-	client    *Client
-	ctx       context.Context
-	span      trace.Span
-	seed      GenerationStart
-	startedAt time.Time
+	client             *Client
+	ctx                context.Context
+	span               trace.Span
+	seed               GenerationStart
+	startedAt          time.Time
+	contentCaptureMode ContentCaptureMode
 
 	mu             sync.Mutex
 	ended          bool
@@ -455,12 +474,19 @@ func (c *Client) startGeneration(ctx context.Context, start GenerationStart, def
 		ThinkingEnabled:   cloneBoolPtr(seed.ThinkingEnabled),
 	})...)
 
+	// Resolve content capture mode: per-recording > resolver > client default.
+	resolverMode := callContentCaptureResolver(c.config.ContentCaptureResolver, ctx, seed.Metadata)
+	clientMode := resolveClientContentCaptureMode(resolveContentCaptureMode(resolverMode, c.config.ContentCapture))
+	ccMode := resolveContentCaptureMode(seed.ContentCapture, clientMode)
+	callCtx = withContentCaptureMode(callCtx, ccMode)
+
 	return callCtx, &GenerationRecorder{
-		client:    c,
-		ctx:       callCtx,
-		span:      span,
-		seed:      seed,
-		startedAt: startedAt,
+		client:             c,
+		ctx:                callCtx,
+		span:               span,
+		seed:               seed,
+		startedAt:          startedAt,
+		contentCaptureMode: ccMode,
 	}
 }
 
@@ -575,13 +601,19 @@ func (c *Client) StartToolExecution(ctx context.Context, start ToolExecutionStar
 	attrs := toolSpanAttributes(seed)
 	span.SetAttributes(attrs...)
 
+	// Resolve content capture: per-tool > context (parent generation) > resolver > client default.
+	resolverMode := callContentCaptureResolver(c.config.ContentCaptureResolver, ctx, nil)
+	effectiveClientDefault := resolveContentCaptureMode(resolverMode, c.config.ContentCapture)
+	ctxMode, ctxSet := contentCaptureModeFromContext(ctx)
+	includeContent := shouldIncludeToolContent(seed.ContentCapture, ctxMode, ctxSet, effectiveClientDefault, seed.IncludeContent)
+
 	return callCtx, &ToolExecutionRecorder{
 		client:         c,
 		ctx:            callCtx,
 		span:           span,
 		seed:           seed,
 		startedAt:      startedAt,
-		includeContent: seed.IncludeContent,
+		includeContent: includeContent,
 	}
 }
 
@@ -661,6 +693,11 @@ func (r *GenerationRecorder) End() {
 	normalized := r.normalizeGeneration(generation, completedAt, callErr)
 	applyTraceContextFromSpan(r.span, &normalized)
 
+	stampContentCaptureMetadata(&normalized, r.contentCaptureMode)
+	if r.contentCaptureMode == ContentCaptureModeMetadataOnly {
+		stripContent(&normalized, classifyErrorCategory(callErr, false))
+	}
+
 	r.span.SetName(generationSpanName(normalized))
 	r.span.SetAttributes(generationSpanAttributes(normalized)...)
 
@@ -668,7 +705,7 @@ func (r *GenerationRecorder) End() {
 	r.lastGeneration = cloneGeneration(normalized)
 	r.mu.Unlock()
 
-	enqueueErr := r.client.persistGeneration(r.ctx, normalized)
+	enqueueErr := r.client.persistGeneration(normalized)
 
 	// Record errors on span.
 	if callErr != nil {
@@ -1078,11 +1115,10 @@ func combineAllErrors(errs ...error) error {
 	return errors.Join(filtered...)
 }
 
-func (c *Client) persistGeneration(_ context.Context, generation Generation) error {
-	if err := ValidateGeneration(generation); err != nil {
+func (c *Client) persistGeneration(generation Generation) error {
+	if err := validateGeneration(generation); err != nil {
 		return fmt.Errorf("%w: %v", errGenerationValidation, err)
 	}
-
 	if err := c.enqueueGeneration(generation); err != nil {
 		return fmt.Errorf("%w: %w", errGenerationEnqueue, err)
 	}

--- a/go/sigil/client_test.go
+++ b/go/sigil/client_test.go
@@ -1086,59 +1086,57 @@ func TestStartToolExecutionSetsExecuteToolAttributes(t *testing.T) {
 }
 
 func TestToolExecutionRecorderContentCapture(t *testing.T) {
+	// Backward compat: Config{} with IncludeContent controls tool content.
 	client, recorder, _ := newTestClient(t, Config{})
 
-	_, withContent := client.StartToolExecution(context.Background(), ToolExecutionStart{
-		ToolName:       "weather",
-		IncludeContent: true,
-	})
-	withContent.SetResult(ToolExecutionEnd{
-		Arguments: map[string]any{"city": "Paris"},
-		Result:    map[string]any{"temp_c": 18},
-	})
-	withContent.End()
-	if err := withContent.Err(); err != nil {
-		t.Fatalf("end tool execution with content: %v", err)
-	}
-
-	_, withoutContent := client.StartToolExecution(context.Background(), ToolExecutionStart{
-		ToolName: "weather",
-	})
-	withoutContent.SetResult(ToolExecutionEnd{
-		Arguments: map[string]any{"city": "Paris"},
-		Result:    map[string]any{"temp_c": 18},
-	})
-	withoutContent.End()
-	if err := withoutContent.Err(); err != nil {
-		t.Fatalf("end tool execution without content: %v", err)
-	}
-
-	toolSpans := make([]sdktrace.ReadOnlySpan, 0, 2)
-	for _, span := range recorder.Ended() {
-		if isToolSpan(span) {
-			toolSpans = append(toolSpans, span)
+	execTool := func(t *testing.T, start ToolExecutionStart) sdktrace.ReadOnlySpan {
+		t.Helper()
+		start.ToolName = "weather"
+		_, rec := client.StartToolExecution(context.Background(), start)
+		rec.SetResult(ToolExecutionEnd{
+			Arguments: map[string]any{"city": "Paris"},
+			Result:    map[string]any{"temp_c": 18},
+		})
+		rec.End()
+		if err := rec.Err(); err != nil {
+			t.Fatalf("tool execution error: %v", err)
 		}
-	}
-	if len(toolSpans) != 2 {
-		t.Fatalf("expected 2 tool spans, got %d", len(toolSpans))
+		spans := recorder.Ended()
+		for i := len(spans) - 1; i >= 0; i-- {
+			if isToolSpan(spans[i]) {
+				return spans[i]
+			}
+		}
+		t.Fatal("tool span not found")
+		return nil
 	}
 
-	var sawWithContent, sawWithoutContent bool
-	for _, span := range toolSpans {
+	hasContent := func(span sdktrace.ReadOnlySpan) bool {
 		attrs := spanAttributeMap(span)
 		_, hasArgs := attrs[spanAttrToolCallArguments]
-		_, hasResult := attrs[spanAttrToolCallResult]
-		if hasArgs && hasResult {
-			sawWithContent = true
-		}
-		if !hasArgs && !hasResult {
-			sawWithoutContent = true
-		}
+		return hasArgs
 	}
 
-	if !sawWithContent || !sawWithoutContent {
-		t.Fatalf("expected both content and non-content tool spans")
-	}
+	t.Run("Config{} + bare ToolExecutionStart — no content", func(t *testing.T) {
+		span := execTool(t, ToolExecutionStart{})
+		if hasContent(span) {
+			t.Fatal("expected no tool content with default config and no IncludeContent")
+		}
+	})
+
+	t.Run("Config{} + IncludeContent:true — content included", func(t *testing.T) {
+		span := execTool(t, ToolExecutionStart{IncludeContent: true})
+		if !hasContent(span) {
+			t.Fatal("expected tool content with IncludeContent: true")
+		}
+	})
+
+	t.Run("Config{} + IncludeContent:false — no content", func(t *testing.T) {
+		span := execTool(t, ToolExecutionStart{IncludeContent: false})
+		if hasContent(span) {
+			t.Fatal("expected no tool content with IncludeContent: false")
+		}
+	})
 }
 
 func TestToolExecutionRecorderErrorSetsStatusAndType(t *testing.T) {

--- a/go/sigil/content_capture.go
+++ b/go/sigil/content_capture.go
@@ -1,0 +1,197 @@
+package sigil
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// ContentCaptureMode controls what content is included in exported generation
+// payloads and OTel span attributes.
+type ContentCaptureMode int
+
+const (
+	// ContentCaptureModeDefault uses the parent or client-level default.
+	// On Config this resolves to NoToolContent for backward compatibility.
+	// On GenerationStart this inherits from Config.
+	// On ToolExecutionStart this inherits from the parent generation context,
+	// falling back to Config.
+	ContentCaptureModeDefault ContentCaptureMode = iota
+	// ContentCaptureModeFull exports all content.
+	ContentCaptureModeFull
+	// ContentCaptureModeNoToolContent exports full generation content but
+	// excludes tool execution content (arguments and results) from span
+	// attributes unless explicitly opted in via IncludeContent or a per-tool
+	// ContentCapture override. This matches the pre-ContentCaptureMode SDK
+	// default behavior.
+	ContentCaptureModeNoToolContent
+	// ContentCaptureModeMetadataOnly preserves message structure, tool names,
+	// usage, and timing but strips text, tool arguments, tool results,
+	// thinking, system prompts, and raw artifacts.
+	//
+	// Note: user-provided Metadata and Tags are NOT stripped — callers are
+	// responsible for ensuring these maps do not contain sensitive content
+	// when using MetadataOnly mode.
+	ContentCaptureModeMetadataOnly
+)
+
+const (
+	metadataKeyContentCaptureMode        = "sigil.sdk.content_capture_mode"
+	contentCaptureModeValueFull          = "full"
+	contentCaptureModeValueNoToolContent = "no_tool_content"
+	contentCaptureModeValueMetaOnly      = "metadata_only"
+)
+
+// resolveContentCaptureMode returns the effective mode from an override and a
+// fallback. Default is transparent — it falls through to the fallback.
+func resolveContentCaptureMode(override, fallback ContentCaptureMode) ContentCaptureMode {
+	if override != ContentCaptureModeDefault {
+		return override
+	}
+	return fallback
+}
+
+// callContentCaptureResolver invokes the resolver callback safely, recovering
+// from panics. Returns ContentCaptureModeDefault when the resolver is nil.
+// Panics are treated as ContentCaptureModeMetadataOnly (fail-closed).
+func callContentCaptureResolver(resolver func(ctx context.Context, metadata map[string]any) ContentCaptureMode, ctx context.Context, metadata map[string]any) (mode ContentCaptureMode) {
+	if resolver == nil {
+		return ContentCaptureModeDefault
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			mode = ContentCaptureModeMetadataOnly
+		}
+	}()
+	return resolver(ctx, metadata)
+}
+
+// resolveClientContentCaptureMode resolves the effective mode for the client.
+// Default at the client level means NoToolContent (backward compatibility):
+// generation content is always captured, but tool content requires explicit
+// opt-in via IncludeContent or ContentCapture on ToolExecutionStart.
+func resolveClientContentCaptureMode(mode ContentCaptureMode) ContentCaptureMode {
+	if mode == ContentCaptureModeDefault {
+		return ContentCaptureModeNoToolContent
+	}
+	return mode
+}
+
+// stampContentCaptureMetadata sets the content capture mode marker on the generation.
+func stampContentCaptureMetadata(g *Generation, mode ContentCaptureMode) {
+	if g.Metadata == nil {
+		g.Metadata = map[string]any{}
+	}
+	g.Metadata[metadataKeyContentCaptureMode] = mode.String()
+}
+
+// isContentStripped reports whether the generation has been through MetadataOnly
+// stripping, based on the stamped metadata marker.
+func isContentStripped(g Generation) bool {
+	if g.Metadata == nil {
+		return false
+	}
+	v, _ := g.Metadata[metadataKeyContentCaptureMode].(string)
+	return v == contentCaptureModeValueMetaOnly
+}
+
+// stripContent removes sensitive content from a generation while preserving
+// message structure (roles, part kinds), tool names/IDs, usage, timing, and
+// all other metadata fields. errorCategory is the classified error category
+// (e.g. "rate_limit", "timeout") used to replace the raw CallError text.
+func stripContent(g *Generation, errorCategory string) {
+	g.SystemPrompt = ""
+	g.Artifacts = nil
+
+	if g.CallError != "" {
+		if errorCategory != "" {
+			g.CallError = errorCategory
+		} else {
+			g.CallError = "sdk_error"
+		}
+	}
+	delete(g.Metadata, "call_error")
+
+	for i := range g.Input {
+		stripMessageContent(&g.Input[i])
+	}
+	for i := range g.Output {
+		stripMessageContent(&g.Output[i])
+	}
+	for i := range g.Tools {
+		g.Tools[i].Description = ""
+		g.Tools[i].InputSchema = nil
+	}
+}
+
+func stripMessageContent(m *Message) {
+	for i := range m.Parts {
+		m.Parts[i].Text = ""
+		m.Parts[i].Thinking = ""
+		if m.Parts[i].ToolCall != nil {
+			m.Parts[i].ToolCall.InputJSON = nil
+		}
+		if m.Parts[i].ToolResult != nil {
+			m.Parts[i].ToolResult.Content = ""
+			m.Parts[i].ToolResult.ContentJSON = nil
+		}
+	}
+}
+
+// shouldIncludeToolContent determines whether tool execution content (arguments,
+// results) should be included in span attributes. It resolves the effective mode
+// from the explicit override, context, client default, and legacy IncludeContent.
+func shouldIncludeToolContent(toolMode, ctxMode ContentCaptureMode, ctxSet bool, clientDefault ContentCaptureMode, legacyInclude bool) bool {
+	resolved := resolveClientContentCaptureMode(clientDefault)
+	if ctxSet {
+		resolved = ctxMode
+	}
+	if toolMode != ContentCaptureModeDefault {
+		resolved = toolMode
+	}
+	switch resolved {
+	case ContentCaptureModeMetadataOnly:
+		return false
+	case ContentCaptureModeFull:
+		return true
+	default:
+		// NoToolContent / Default: honor legacy IncludeContent opt-in.
+		return legacyInclude
+	}
+}
+
+// String returns the string representation of a ContentCaptureMode.
+func (m ContentCaptureMode) String() string {
+	switch m {
+	case ContentCaptureModeFull:
+		return contentCaptureModeValueFull
+	case ContentCaptureModeNoToolContent:
+		return contentCaptureModeValueNoToolContent
+	case ContentCaptureModeMetadataOnly:
+		return contentCaptureModeValueMetaOnly
+	default:
+		return "default"
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler for ContentCaptureMode.
+func (m ContentCaptureMode) MarshalText() ([]byte, error) {
+	return []byte(m.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler for ContentCaptureMode.
+func (m *ContentCaptureMode) UnmarshalText(text []byte) error {
+	switch strings.ToLower(string(text)) {
+	case contentCaptureModeValueFull:
+		*m = ContentCaptureModeFull
+	case contentCaptureModeValueNoToolContent:
+		*m = ContentCaptureModeNoToolContent
+	case contentCaptureModeValueMetaOnly:
+		*m = ContentCaptureModeMetadataOnly
+	case "default", "":
+		*m = ContentCaptureModeDefault
+	default:
+		return fmt.Errorf("unknown content capture mode: %q", string(text))
+	}
+	return nil
+}

--- a/go/sigil/content_capture_test.go
+++ b/go/sigil/content_capture_test.go
@@ -1,0 +1,634 @@
+package sigil
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+func TestStripContent(t *testing.T) {
+	makeGen := func() Generation {
+		return Generation{
+			ID:             "gen-1",
+			ConversationID: "conv-1",
+			AgentName:      "test-agent",
+			AgentVersion:   "1.0",
+			Mode:           GenerationModeSync,
+			Model:          ModelRef{Provider: "anthropic", Name: "claude-sonnet-4-5"},
+			SystemPrompt:   "You are helpful.",
+			Input: []Message{
+				{Role: RoleUser, Parts: []Part{{Kind: PartKindText, Text: "What is the weather?"}}},
+				{Role: RoleTool, Parts: []Part{{Kind: PartKindToolResult, ToolResult: &ToolResult{
+					ToolCallID:  "call_1",
+					Name:        "weather",
+					Content:     "sunny 18C",
+					ContentJSON: json.RawMessage(`{"temp":18}`),
+				}}}},
+			},
+			Output: []Message{
+				{Role: RoleAssistant, Parts: []Part{
+					{Kind: PartKindThinking, Thinking: "let me think about weather"},
+					{Kind: PartKindToolCall, ToolCall: &ToolCall{ID: "call_1", Name: "weather", InputJSON: json.RawMessage(`{"city":"Paris"}`)}},
+					{Kind: PartKindText, Text: "It's 18C and sunny in Paris."},
+				}},
+			},
+			Tools: []ToolDefinition{
+				{Name: "weather", Description: "Get weather info", Type: "function", InputSchema: json.RawMessage(`{"type":"object"}`)},
+			},
+			Usage:      TokenUsage{InputTokens: 120, OutputTokens: 42},
+			StopReason: "end_turn",
+			CallError:  "rate limit exceeded: prompt too long for model",
+			Artifacts:  []Artifact{{Kind: "request", Payload: []byte("raw")}},
+			Metadata:   map[string]any{"sigil.sdk.name": "sdk-go", "call_error": "rate limit exceeded: prompt too long for model"},
+		}
+	}
+
+	t.Run("strips sensitive content", func(t *testing.T) {
+		gen := makeGen()
+		stripContent(&gen, "rate_limit")
+
+		if gen.SystemPrompt != "" {
+			t.Fatal("SystemPrompt not stripped")
+		}
+		if gen.Input[0].Parts[0].Text != "" {
+			t.Fatal("Input text not stripped")
+		}
+		if gen.Output[0].Parts[0].Thinking != "" {
+			t.Fatal("Thinking not stripped")
+		}
+		if gen.Output[0].Parts[1].ToolCall.InputJSON != nil {
+			t.Fatal("ToolCall.InputJSON not stripped")
+		}
+		if gen.Output[0].Parts[2].Text != "" {
+			t.Fatal("Output text not stripped")
+		}
+		if gen.Input[1].Parts[0].ToolResult.Content != "" {
+			t.Fatal("ToolResult.Content not stripped")
+		}
+		if gen.Input[1].Parts[0].ToolResult.ContentJSON != nil {
+			t.Fatal("ToolResult.ContentJSON not stripped")
+		}
+		if gen.Tools[0].Description != "" {
+			t.Fatal("Tool description not stripped")
+		}
+		if gen.Tools[0].InputSchema != nil {
+			t.Fatal("Tool InputSchema not stripped")
+		}
+		if gen.Artifacts != nil {
+			t.Fatal("Artifacts not stripped")
+		}
+	})
+
+	t.Run("preserves message structure", func(t *testing.T) {
+		gen := makeGen()
+		stripContent(&gen, "rate_limit")
+
+		if len(gen.Input) != 2 {
+			t.Fatalf("Input messages lost: got %d", len(gen.Input))
+		}
+		if len(gen.Output) != 1 {
+			t.Fatalf("Output messages lost: got %d", len(gen.Output))
+		}
+		if len(gen.Output[0].Parts) != 3 {
+			t.Fatalf("Output parts lost: got %d", len(gen.Output[0].Parts))
+		}
+		if gen.Input[0].Role != RoleUser {
+			t.Fatal("Input role changed")
+		}
+		if gen.Output[0].Parts[0].Kind != PartKindThinking {
+			t.Fatal("Part kind changed")
+		}
+		if gen.Output[0].Parts[1].ToolCall.Name != "weather" {
+			t.Fatal("Tool call name lost")
+		}
+		if gen.Output[0].Parts[1].ToolCall.ID != "call_1" {
+			t.Fatal("Tool call ID lost")
+		}
+		if gen.Input[1].Parts[0].ToolResult.ToolCallID != "call_1" {
+			t.Fatal("Tool result call ID lost")
+		}
+		if gen.Input[1].Parts[0].ToolResult.Name != "weather" {
+			t.Fatal("Tool result name lost")
+		}
+	})
+
+	t.Run("preserves operational metadata", func(t *testing.T) {
+		gen := makeGen()
+		stripContent(&gen, "rate_limit")
+
+		if gen.Tools[0].Name != "weather" {
+			t.Fatal("Tool name lost")
+		}
+		if gen.Usage.InputTokens != 120 || gen.Usage.OutputTokens != 42 {
+			t.Fatal("Usage lost")
+		}
+		if gen.StopReason != "end_turn" {
+			t.Fatal("StopReason lost")
+		}
+		if gen.Model.Name != "claude-sonnet-4-5" {
+			t.Fatal("Model lost")
+		}
+		if gen.Metadata["sigil.sdk.name"] != "sdk-go" {
+			t.Fatal("Metadata lost")
+		}
+	})
+
+	t.Run("replaces CallError with category", func(t *testing.T) {
+		gen := makeGen()
+		stripContent(&gen, "rate_limit")
+
+		if gen.CallError != "rate_limit" {
+			t.Fatalf("CallError = %q, want %q", gen.CallError, "rate_limit")
+		}
+		if _, ok := gen.Metadata["call_error"]; ok {
+			t.Fatal("Metadata[call_error] should be deleted")
+		}
+	})
+
+	t.Run("falls back to sdk_error without category", func(t *testing.T) {
+		gen := makeGen()
+		stripContent(&gen, "")
+
+		if gen.CallError != "sdk_error" {
+			t.Fatalf("CallError = %q, want %q", gen.CallError, "sdk_error")
+		}
+	})
+}
+
+func TestContentCaptureModeResolution(t *testing.T) {
+	cases := []struct {
+		name     string
+		fallback ContentCaptureMode
+		override ContentCaptureMode
+		want     ContentCaptureMode
+	}{
+		{"Full fallback, Default override", ContentCaptureModeFull, ContentCaptureModeDefault, ContentCaptureModeFull},
+		{"Full fallback, MetadataOnly override", ContentCaptureModeFull, ContentCaptureModeMetadataOnly, ContentCaptureModeMetadataOnly},
+		{"MetadataOnly fallback, Default override", ContentCaptureModeMetadataOnly, ContentCaptureModeDefault, ContentCaptureModeMetadataOnly},
+		{"MetadataOnly fallback, Full override", ContentCaptureModeMetadataOnly, ContentCaptureModeFull, ContentCaptureModeFull},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveContentCaptureMode(tc.override, tc.fallback)
+			if got != tc.want {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestGenerationContentCapture(t *testing.T) {
+	now := func() time.Time { return time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC) }
+
+	cases := []struct {
+		name         string
+		clientMode   ContentCaptureMode
+		genMode      ContentCaptureMode
+		wantStripped bool
+		wantMarker   string
+	}{
+		{"client default, gen default — no_tool_content", ContentCaptureModeDefault, ContentCaptureModeDefault, false, contentCaptureModeValueNoToolContent},
+		{"client MetadataOnly, gen default — stripped", ContentCaptureModeMetadataOnly, ContentCaptureModeDefault, true, contentCaptureModeValueMetaOnly},
+		{"client Full, gen MetadataOnly — stripped", ContentCaptureModeFull, ContentCaptureModeMetadataOnly, true, contentCaptureModeValueMetaOnly},
+		{"client MetadataOnly, gen Full — full", ContentCaptureModeMetadataOnly, ContentCaptureModeFull, false, contentCaptureModeValueFull},
+		{"client Full, gen default — full", ContentCaptureModeFull, ContentCaptureModeDefault, false, contentCaptureModeValueFull},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, _, _ := newTestClient(t, Config{
+				ContentCapture: tc.clientMode,
+				Now:            now,
+			})
+
+			_, rec := client.StartGeneration(context.Background(), GenerationStart{
+				Model:          ModelRef{Provider: "anthropic", Name: "claude-sonnet-4-5"},
+				ContentCapture: tc.genMode,
+			})
+			rec.SetResult(Generation{
+				SystemPrompt: "You are helpful.",
+				Input:        []Message{UserTextMessage("Hello")},
+				Output:       []Message{AssistantTextMessage("Hi there")},
+				Usage:        TokenUsage{InputTokens: 10, OutputTokens: 5},
+			}, nil)
+			rec.End()
+
+			gen := rec.lastGeneration
+
+			if gen.Metadata[metadataKeyContentCaptureMode] != tc.wantMarker {
+				t.Fatalf("marker: got %v, want %v", gen.Metadata[metadataKeyContentCaptureMode], tc.wantMarker)
+			}
+
+			if err := rec.Err(); err != nil {
+				t.Fatalf("unexpected recorder error: %v", err)
+			}
+
+			stripped := gen.Input[0].Parts[0].Text == ""
+			if stripped != tc.wantStripped {
+				t.Fatalf("content stripped: got %v, want %v", stripped, tc.wantStripped)
+			}
+
+			// Structure always preserved
+			if len(gen.Input) != 1 || gen.Input[0].Role != RoleUser {
+				t.Fatal("Input structure lost")
+			}
+			if gen.Usage.InputTokens != 10 {
+				t.Fatal("Usage lost")
+			}
+		})
+	}
+}
+
+func TestToolExecutionContentCaptureInheritance(t *testing.T) {
+	cases := []struct {
+		name               string
+		clientDefault      ContentCaptureMode
+		parentGenOverride  ContentCaptureMode
+		useParentCtx       bool
+		toolOverride       ContentCaptureMode
+		toolIncludeContent bool
+		wantContent        bool
+	}{
+		{
+			name:               "parent MetadataOnly, tool inherits — suppressed",
+			clientDefault:      ContentCaptureModeMetadataOnly,
+			useParentCtx:       true,
+			toolIncludeContent: true,
+			wantContent:        false,
+		},
+		{
+			name:               "parent MetadataOnly, tool explicit Full — included",
+			clientDefault:      ContentCaptureModeMetadataOnly,
+			useParentCtx:       true,
+			toolOverride:       ContentCaptureModeFull,
+			toolIncludeContent: true,
+			wantContent:        true,
+		},
+		{
+			name:               "parent Full (override client MetadataOnly), tool inherits — included",
+			clientDefault:      ContentCaptureModeMetadataOnly,
+			parentGenOverride:  ContentCaptureModeFull,
+			useParentCtx:       true,
+			toolIncludeContent: true,
+			wantContent:        true,
+		},
+		{
+			name:               "no parent gen, client MetadataOnly — suppressed (fail-closed)",
+			clientDefault:      ContentCaptureModeMetadataOnly,
+			useParentCtx:       false,
+			toolIncludeContent: true,
+			wantContent:        false,
+		},
+		{
+			name:               "no parent gen, client Full, legacy true — included",
+			clientDefault:      ContentCaptureModeFull,
+			useParentCtx:       false,
+			toolIncludeContent: true,
+			wantContent:        true,
+		},
+		{
+			name:               "no parent gen, client Full, legacy false — included",
+			clientDefault:      ContentCaptureModeFull,
+			useParentCtx:       false,
+			toolIncludeContent: false,
+			wantContent:        true,
+		},
+		{
+			name:               "parent Full, tool explicit MetadataOnly — suppressed",
+			clientDefault:      ContentCaptureModeFull,
+			useParentCtx:       true,
+			toolOverride:       ContentCaptureModeMetadataOnly,
+			toolIncludeContent: true,
+			wantContent:        false,
+		},
+		// Backward compat: client Default (→ NoToolContent), legacy controls.
+		{
+			name:               "no parent gen, client Default, legacy false — suppressed",
+			clientDefault:      ContentCaptureModeDefault,
+			useParentCtx:       false,
+			toolIncludeContent: false,
+			wantContent:        false,
+		},
+		{
+			name:               "no parent gen, client Default, legacy true — included",
+			clientDefault:      ContentCaptureModeDefault,
+			useParentCtx:       false,
+			toolIncludeContent: true,
+			wantContent:        true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, recorder, tp := newTestClient(t, Config{
+				ContentCapture: tc.clientDefault,
+				Now:            func() time.Time { return time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC) },
+			})
+
+			ctx := context.Background()
+			var genRec *GenerationRecorder
+
+			if tc.useParentCtx {
+				ctx, genRec = client.StartGeneration(ctx, GenerationStart{
+					Model:          ModelRef{Provider: "anthropic", Name: "claude-sonnet-4-5"},
+					ContentCapture: tc.parentGenOverride,
+				})
+			}
+
+			_, toolRec := client.StartToolExecution(ctx, ToolExecutionStart{
+				ToolName:       "test_tool",
+				ContentCapture: tc.toolOverride,
+				IncludeContent: tc.toolIncludeContent,
+			})
+			toolRec.SetResult(ToolExecutionEnd{
+				Arguments: "args",
+				Result:    "result",
+			})
+			toolRec.End()
+
+			if genRec != nil {
+				genRec.SetResult(Generation{Usage: TokenUsage{InputTokens: 1}}, nil)
+				genRec.End()
+			}
+
+			_ = tp.ForceFlush(context.Background())
+
+			spans := recorder.Ended()
+			var toolSpan sdktrace.ReadOnlySpan
+			for _, s := range spans {
+				if strings.HasPrefix(s.Name(), "execute_tool") {
+					toolSpan = s
+					break
+				}
+			}
+			if toolSpan == nil {
+				t.Fatal("tool execution span not found")
+			}
+
+			attrs := spanAttributeMap(toolSpan)
+			_, hasArgs := attrs[spanAttrToolCallArguments]
+			if hasArgs != tc.wantContent {
+				t.Fatalf("tool arguments: got present=%v, want present=%v", hasArgs, tc.wantContent)
+			}
+
+			if _, ok := attrs[spanAttrToolName]; !ok {
+				t.Fatal("tool name should always be present")
+			}
+		})
+	}
+}
+
+func TestShouldIncludeToolContent(t *testing.T) {
+	cases := []struct {
+		name          string
+		toolMode      ContentCaptureMode
+		ctxMode       ContentCaptureMode
+		ctxSet        bool
+		clientDefault ContentCaptureMode
+		legacy        bool
+		want          bool
+	}{
+		// Explicit Full client — legacy is irrelevant.
+		{"client Full, no ctx, legacy false", ContentCaptureModeDefault, ContentCaptureModeFull, false, ContentCaptureModeFull, false, true},
+		{"client Full, no ctx, legacy true", ContentCaptureModeDefault, ContentCaptureModeFull, false, ContentCaptureModeFull, true, true},
+		// Default client (resolves to NoToolContent) — legacy controls tool content.
+		{"client Default, no ctx, legacy false — suppressed", ContentCaptureModeDefault, ContentCaptureModeDefault, false, ContentCaptureModeDefault, false, false},
+		{"client Default, no ctx, legacy true — included", ContentCaptureModeDefault, ContentCaptureModeDefault, false, ContentCaptureModeDefault, true, true},
+		// Context and client overrides.
+		{"ctx MetadataOnly, legacy true", ContentCaptureModeDefault, ContentCaptureModeMetadataOnly, true, ContentCaptureModeFull, true, false},
+		{"ctx Full, client MetadataOnly — ctx wins", ContentCaptureModeDefault, ContentCaptureModeFull, true, ContentCaptureModeMetadataOnly, true, true},
+		{"ctx NoToolContent, legacy false — suppressed", ContentCaptureModeDefault, ContentCaptureModeNoToolContent, true, ContentCaptureModeFull, false, false},
+		{"ctx NoToolContent, legacy true — included", ContentCaptureModeDefault, ContentCaptureModeNoToolContent, true, ContentCaptureModeFull, true, true},
+		{"no ctx, client MetadataOnly — client wins", ContentCaptureModeDefault, ContentCaptureModeFull, false, ContentCaptureModeMetadataOnly, true, false},
+		// Per-tool overrides.
+		{"explicit Full overrides ctx MetadataOnly", ContentCaptureModeFull, ContentCaptureModeMetadataOnly, true, ContentCaptureModeFull, true, true},
+		{"explicit Full overrides ctx MetadataOnly, legacy false", ContentCaptureModeFull, ContentCaptureModeMetadataOnly, true, ContentCaptureModeFull, false, true},
+		{"explicit MetadataOnly overrides everything", ContentCaptureModeMetadataOnly, ContentCaptureModeFull, true, ContentCaptureModeFull, true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldIncludeToolContent(tc.toolMode, tc.ctxMode, tc.ctxSet, tc.clientDefault, tc.legacy)
+			if got != tc.want {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestContentCaptureModeString(t *testing.T) {
+	cases := []struct {
+		mode ContentCaptureMode
+		want string
+	}{
+		{ContentCaptureModeFull, "full"},
+		{ContentCaptureModeNoToolContent, "no_tool_content"},
+		{ContentCaptureModeMetadataOnly, "metadata_only"},
+		{ContentCaptureModeDefault, "default"},
+	}
+	for _, tc := range cases {
+		if got := tc.mode.String(); got != tc.want {
+			t.Fatalf("%d.String() = %q, want %q", tc.mode, got, tc.want)
+		}
+	}
+}
+
+func TestContentCaptureModeTextMarshaling(t *testing.T) {
+	cases := []struct {
+		text string
+		want ContentCaptureMode
+	}{
+		{"full", ContentCaptureModeFull},
+		{"metadata_only", ContentCaptureModeMetadataOnly},
+		{"default", ContentCaptureModeDefault},
+		{"", ContentCaptureModeDefault},
+	}
+
+	for _, tc := range cases {
+		var m ContentCaptureMode
+		if err := m.UnmarshalText([]byte(tc.text)); err != nil {
+			t.Fatalf("unmarshal %q: %v", tc.text, err)
+		}
+		if m != tc.want {
+			t.Fatalf("unmarshal %q: got %v, want %v", tc.text, m, tc.want)
+		}
+	}
+
+	var m ContentCaptureMode
+	if err := m.UnmarshalText([]byte("invalid")); err == nil {
+		t.Fatal("expected error for invalid mode")
+	}
+}
+
+func TestCallContentCaptureResolver(t *testing.T) {
+	cases := []struct {
+		name     string
+		resolver func(context.Context, map[string]any) ContentCaptureMode
+		metadata map[string]any
+		want     ContentCaptureMode
+	}{
+		{
+			name:     "nil resolver returns Default",
+			resolver: nil,
+			want:     ContentCaptureModeDefault,
+		},
+		{
+			name: "resolver returns MetadataOnly",
+			resolver: func(_ context.Context, _ map[string]any) ContentCaptureMode {
+				return ContentCaptureModeMetadataOnly
+			},
+			want: ContentCaptureModeMetadataOnly,
+		},
+		{
+			name: "resolver returns Full",
+			resolver: func(_ context.Context, _ map[string]any) ContentCaptureMode {
+				return ContentCaptureModeFull
+			},
+			want: ContentCaptureModeFull,
+		},
+		{
+			name: "resolver reads tenant_id from metadata",
+			resolver: func(_ context.Context, meta map[string]any) ContentCaptureMode {
+				if tid, _ := meta["tenant_id"].(string); tid == "opted-out" {
+					return ContentCaptureModeMetadataOnly
+				}
+				return ContentCaptureModeFull
+			},
+			metadata: map[string]any{"tenant_id": "opted-out"},
+			want:     ContentCaptureModeMetadataOnly,
+		},
+		{
+			name: "resolver receives nil metadata without panic",
+			resolver: func(_ context.Context, meta map[string]any) ContentCaptureMode {
+				if meta == nil {
+					return ContentCaptureModeMetadataOnly
+				}
+				return ContentCaptureModeFull
+			},
+			metadata: nil,
+			want:     ContentCaptureModeMetadataOnly,
+		},
+		{
+			name: "resolver panic recovers to MetadataOnly",
+			resolver: func(_ context.Context, _ map[string]any) ContentCaptureMode {
+				panic("resolver bug")
+			},
+			want: ContentCaptureModeMetadataOnly,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := callContentCaptureResolver(tc.resolver, context.Background(), tc.metadata)
+			if got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGenerationContentCaptureWithResolver(t *testing.T) {
+	now := func() time.Time { return time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC) }
+
+	cases := []struct {
+		name         string
+		clientMode   ContentCaptureMode
+		resolver     func(context.Context, map[string]any) ContentCaptureMode
+		genMode      ContentCaptureMode
+		wantStripped bool
+		wantMarker   string
+	}{
+		{
+			name:       "resolver MetadataOnly overrides client Full",
+			clientMode: ContentCaptureModeFull,
+			resolver: func(_ context.Context, _ map[string]any) ContentCaptureMode {
+				return ContentCaptureModeMetadataOnly
+			},
+			genMode:      ContentCaptureModeDefault,
+			wantStripped: true,
+			wantMarker:   contentCaptureModeValueMetaOnly,
+		},
+		{
+			name:       "per-generation Full overrides resolver MetadataOnly",
+			clientMode: ContentCaptureModeDefault,
+			resolver: func(_ context.Context, _ map[string]any) ContentCaptureMode {
+				return ContentCaptureModeMetadataOnly
+			},
+			genMode:      ContentCaptureModeFull,
+			wantStripped: false,
+			wantMarker:   contentCaptureModeValueFull,
+		},
+		{
+			name:       "resolver Default defers to client",
+			clientMode: ContentCaptureModeMetadataOnly,
+			resolver: func(_ context.Context, _ map[string]any) ContentCaptureMode {
+				return ContentCaptureModeDefault
+			},
+			genMode:      ContentCaptureModeDefault,
+			wantStripped: true,
+			wantMarker:   contentCaptureModeValueMetaOnly,
+		},
+		{
+			name:       "resolver Full overrides client MetadataOnly",
+			clientMode: ContentCaptureModeMetadataOnly,
+			resolver: func(_ context.Context, _ map[string]any) ContentCaptureMode {
+				return ContentCaptureModeFull
+			},
+			genMode:      ContentCaptureModeDefault,
+			wantStripped: false,
+			wantMarker:   contentCaptureModeValueFull,
+		},
+		{
+			name:       "panicking resolver fails closed, client Full → MetadataOnly",
+			clientMode: ContentCaptureModeFull,
+			resolver: func(_ context.Context, _ map[string]any) ContentCaptureMode {
+				panic("oops")
+			},
+			genMode:      ContentCaptureModeDefault,
+			wantStripped: true,
+			wantMarker:   contentCaptureModeValueMetaOnly,
+		},
+	}
+
+	tp := sdktrace.NewTracerProvider()
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := NewClient(Config{
+				ContentCapture:         tc.clientMode,
+				ContentCaptureResolver: tc.resolver,
+				Tracer:                 tp.Tracer("test"),
+				Now:                    now,
+				testDisableWorker:      true,
+			})
+
+			ctx, rec := client.StartGeneration(context.Background(), GenerationStart{
+				ContentCapture: tc.genMode,
+				Model:          ModelRef{Provider: "test", Name: "test-model"},
+				Metadata:       map[string]any{"tenant_id": "t1"},
+			})
+			_ = ctx
+			rec.SetResult(Generation{
+				Input:  []Message{UserTextMessage("hello")},
+				Output: []Message{AssistantTextMessage("world")},
+				Usage:  TokenUsage{InputTokens: 10, OutputTokens: 5},
+			}, nil)
+			rec.End()
+
+			gen := rec.lastGeneration
+			if gen.Metadata[metadataKeyContentCaptureMode] != tc.wantMarker {
+				t.Fatalf("marker: got %v, want %v", gen.Metadata[metadataKeyContentCaptureMode], tc.wantMarker)
+			}
+			inputStripped := len(gen.Input) > 0 && gen.Input[0].Parts[0].Text == ""
+			if inputStripped != tc.wantStripped {
+				t.Fatalf("stripped: got %v, want %v", inputStripped, tc.wantStripped)
+			}
+		})
+	}
+}

--- a/go/sigil/context.go
+++ b/go/sigil/context.go
@@ -7,6 +7,7 @@ type conversationTitleContextKey struct{}
 type userIDContextKey struct{}
 type agentNameContextKey struct{}
 type agentVersionContextKey struct{}
+type contentCaptureModeContextKey struct{}
 
 // WithConversationID stores a conversation ID in the context.
 // StartGeneration, StartStreamingGeneration, and StartToolExecution read it when
@@ -71,4 +72,17 @@ func WithAgentVersion(ctx context.Context, version string) context.Context {
 func AgentVersionFromContext(ctx context.Context) (string, bool) {
 	version, ok := ctx.Value(agentVersionContextKey{}).(string)
 	return version, ok && version != ""
+}
+
+// withContentCaptureMode stores the resolved ContentCaptureMode in the context.
+// StartToolExecution reads it to inherit the parent generation's mode.
+func withContentCaptureMode(ctx context.Context, mode ContentCaptureMode) context.Context {
+	return context.WithValue(ctx, contentCaptureModeContextKey{}, mode)
+}
+
+// contentCaptureModeFromContext retrieves the ContentCaptureMode stored by
+// withContentCaptureMode. Returns ContentCaptureModeDefault and false if not set.
+func contentCaptureModeFromContext(ctx context.Context) (ContentCaptureMode, bool) {
+	mode, ok := ctx.Value(contentCaptureModeContextKey{}).(ContentCaptureMode)
+	return mode, ok
 }

--- a/go/sigil/doc.go
+++ b/go/sigil/doc.go
@@ -20,6 +20,34 @@
 // Start returns a context for your provider call. End is a no-arg, no-return
 // finalizer safe for defer. It is idempotent and nil-safe.
 //
+// # Content Capture
+//
+// Config.ContentCapture sets the default ContentCaptureMode (Full or MetadataOnly).
+// MetadataOnly strips prompts, messages, tool arguments, and tool results before
+// export while preserving usage, timing, model info, and message structure.
+// Per-generation and per-tool-execution overrides are available via the
+// ContentCapture field on GenerationStart and ToolExecutionStart.
+// Tool executions inherit the parent generation's mode via context.
+//
+// Config.ContentCaptureResolver enables dynamic per-request resolution. When set,
+// the resolver is called before each generation start and rating submission with
+// the request context and recording metadata. This is the recommended integration
+// point for multi-tenant services that need to resolve content capture mode based
+// on tenant-level policies (e.g., data-sharing opt-out).
+//
+// Resolution precedence (highest to lowest):
+//   - Per-recording ContentCapture field (explicit override)
+//   - ContentCaptureResolver return value
+//   - Config.ContentCapture (static default)
+//
+// Resolver panics are recovered and treated as MetadataOnly (fail-closed).
+//
+// MetadataOnly does not filter user-provided Metadata or Tags maps.
+// Callers are responsible for not including sensitive content in those fields
+// when using MetadataOnly mode.
+//
+// # Linking
+//
 // Linking is bi-directional:
 //   - Generation.TraceID/SpanID point to the created span.
 //   - The span includes the generation ID in attribute "sigil.generation.id".

--- a/go/sigil/example_test.go
+++ b/go/sigil/example_test.go
@@ -64,7 +64,7 @@ func ExampleClient_StartToolExecution() {
 		ConversationID:  "conv-tools",
 		AgentName:       "assistant-core",
 		AgentVersion:    "1.0.0",
-		IncludeContent:  true,
+		ContentCapture:  sigil.ContentCaptureModeFull,
 	})
 	defer recorder.End()
 
@@ -75,4 +75,28 @@ func ExampleClient_StartToolExecution() {
 		Arguments: map[string]any{"city": "Paris"},
 		Result:    result,
 	})
+}
+
+func ExampleClient_StartGeneration_metadataOnly() {
+	client := sigil.NewClient(sigil.Config{
+		ContentCapture: sigil.ContentCaptureModeMetadataOnly,
+	})
+
+	ctx, recorder := client.StartGeneration(context.Background(), sigil.GenerationStart{
+		ConversationID: "conv-private",
+		AgentName:      "assistant-core",
+		AgentVersion:   "1.0.0",
+		Model:          sigil.ModelRef{Provider: "anthropic", Name: "claude-sonnet-4-5"},
+		ContentCapture: sigil.ContentCaptureModeMetadataOnly,
+	})
+	defer recorder.End()
+
+	_ = ctx
+
+	recorder.SetResult(sigil.Generation{
+		Input:  []sigil.Message{sigil.UserTextMessage("sensitive prompt")},
+		Output: []sigil.Message{sigil.AssistantTextMessage("sensitive response")},
+		Usage:  sigil.TokenUsage{InputTokens: 120, OutputTokens: 42},
+	}, nil)
+	// Content is stripped before export; only metadata (usage, timing, model) is sent.
 }

--- a/go/sigil/generation.go
+++ b/go/sigil/generation.go
@@ -97,6 +97,9 @@ type GenerationStart struct {
 	Tags              map[string]string
 	Metadata          map[string]any
 	StartedAt         time.Time
+	// ContentCapture overrides the client-level ContentCaptureMode for this
+	// generation. Default (zero value) inherits from Config.
+	ContentCapture ContentCaptureMode
 }
 
 func (g Generation) Validate() error {
@@ -166,6 +169,7 @@ func cloneGenerationStart(in GenerationStart) GenerationStart {
 		Tags:              cloneTags(in.Tags),
 		Metadata:          cloneMetadata(in.Metadata),
 		StartedAt:         in.StartedAt,
+		ContentCapture:    in.ContentCapture,
 	}
 }
 

--- a/go/sigil/rating.go
+++ b/go/sigil/rating.go
@@ -79,6 +79,13 @@ func (c *Client) SubmitConversationRating(ctx context.Context, conversationID st
 		return nil, fmt.Errorf("%w: conversation id is too long", ErrRatingValidationFailed)
 	}
 
+	// Check content capture resolver — strip comment when MetadataOnly.
+	resolverMode := callContentCaptureResolver(c.config.ContentCaptureResolver, ctx, input.Metadata)
+	effectiveMode := resolveContentCaptureMode(resolverMode, resolveClientContentCaptureMode(c.config.ContentCapture))
+	if effectiveMode == ContentCaptureModeMetadataOnly {
+		input.Comment = ""
+	}
+
 	normalizedInput, err := normalizeConversationRatingInput(input)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrRatingValidationFailed, err)

--- a/go/sigil/sigiltest/env.go
+++ b/go/sigil/sigiltest/env.go
@@ -33,7 +33,14 @@ type Env struct {
 	closeOnce      sync.Once
 }
 
-func NewEnv(t testing.TB) *Env {
+// NewEnv creates a test environment with a fake gRPC ingest server, span
+// recorder, and metric reader. The returned Client is configured to export
+// generations synchronously (batch size 1) to the fake server.
+//
+// Optional config modifiers are applied after the base test config is built.
+// Use this to inject a ContentCaptureResolver or override other Config fields
+// while keeping the test exporter and tracing infrastructure.
+func NewEnv(t testing.TB, opts ...func(*sigil.Config)) *Env {
 	t.Helper()
 
 	ingest := &capturingIngestServer{}
@@ -68,6 +75,9 @@ func NewEnv(t testing.TB) *Env {
 		InitialBackoff:  time.Millisecond,
 		MaxBackoff:      5 * time.Millisecond,
 		PayloadMaxBytes: 4 << 20,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 
 	env := &Env{

--- a/go/sigil/tool.go
+++ b/go/sigil/tool.go
@@ -18,7 +18,13 @@ type ToolExecutionStart struct {
 	RequestProvider string
 	StartedAt       time.Time
 	// IncludeContent enables gen_ai.tool.call.arguments and gen_ai.tool.call.result attributes.
+	// Deprecated: Use ContentCapture instead. ContentCapture takes precedence
+	// when set to a non-Default value. IncludeContent is only honored when
+	// the resolved mode is Full.
 	IncludeContent bool
+	// ContentCapture overrides the parent generation's content capture mode for
+	// this tool execution. Default (zero value) inherits from context.
+	ContentCapture ContentCaptureMode
 }
 
 // ToolExecutionEnd finalizes tool execution span attributes.

--- a/go/sigil/validation.go
+++ b/go/sigil/validation.go
@@ -7,6 +7,11 @@ import (
 )
 
 func ValidateGeneration(g Generation) error {
+	return validateGeneration(g)
+}
+
+func validateGeneration(g Generation) error {
+	contentStripped := isContentStripped(g)
 	if g.Mode != "" && g.Mode != GenerationModeSync && g.Mode != GenerationModeStream {
 		return errors.New("generation.mode must be one of SYNC|STREAM")
 	}
@@ -20,13 +25,13 @@ func ValidateGeneration(g Generation) error {
 	}
 
 	for i := range g.Input {
-		if err := validateMessage("generation.input", i, g.Input[i]); err != nil {
+		if err := validateMessage("generation.input", i, g.Input[i], contentStripped); err != nil {
 			return err
 		}
 	}
 
 	for i := range g.Output {
-		if err := validateMessage("generation.output", i, g.Output[i]); err != nil {
+		if err := validateMessage("generation.output", i, g.Output[i], contentStripped); err != nil {
 			return err
 		}
 	}
@@ -75,7 +80,7 @@ func ValidateEmbeddingResult(result EmbeddingResult) error {
 	return nil
 }
 
-func validateMessage(path string, index int, message Message) error {
+func validateMessage(path string, index int, message Message, contentStripped bool) error {
 	switch message.Role {
 	case RoleUser, RoleAssistant, RoleTool:
 	default:
@@ -87,7 +92,7 @@ func validateMessage(path string, index int, message Message) error {
 	}
 
 	for i := range message.Parts {
-		if err := validatePart(path, index, i, message.Role, message.Parts[i]); err != nil {
+		if err := validatePart(path, index, i, message.Role, message.Parts[i], contentStripped); err != nil {
 			return err
 		}
 	}
@@ -95,7 +100,7 @@ func validateMessage(path string, index int, message Message) error {
 	return nil
 }
 
-func validatePart(path string, messageIndex, partIndex int, role Role, part Part) error {
+func validatePart(path string, messageIndex, partIndex int, role Role, part Part, contentStripped bool) error {
 	switch part.Kind {
 	case PartKindText, PartKindThinking, PartKindToolCall, PartKindToolResult:
 	default:
@@ -116,20 +121,23 @@ func validatePart(path string, messageIndex, partIndex int, role Role, part Part
 		fieldCount++
 	}
 
-	if fieldCount != 1 {
+	// Stripped text/thinking parts have empty payloads — that's expected.
+	// ToolCall/ToolResult keep their struct pointers after stripping so fieldCount is still 1.
+	strippedTextOrThinking := contentStripped && (part.Kind == PartKindText || part.Kind == PartKindThinking)
+	if fieldCount != 1 && !strippedTextOrThinking {
 		return fmt.Errorf("%s[%d].parts[%d] must set exactly one payload field", path, messageIndex, partIndex)
 	}
 
 	switch part.Kind {
 	case PartKindText:
-		if part.Text == "" {
+		if !contentStripped && part.Text == "" {
 			return fmt.Errorf("%s[%d].parts[%d].text is required", path, messageIndex, partIndex)
 		}
 	case PartKindThinking:
 		if role != RoleAssistant {
 			return fmt.Errorf("%s[%d].parts[%d].thinking only allowed for assistant role", path, messageIndex, partIndex)
 		}
-		if part.Thinking == "" {
+		if !contentStripped && part.Thinking == "" {
 			return fmt.Errorf("%s[%d].parts[%d].thinking is required", path, messageIndex, partIndex)
 		}
 	case PartKindToolCall:

--- a/go/sigil/validation_test.go
+++ b/go/sigil/validation_test.go
@@ -140,6 +140,46 @@ func TestValidateGenerationAllowsConversationAndResponseFields(t *testing.T) {
 	}
 }
 
+func TestValidateStrippedGeneration(t *testing.T) {
+	base := Generation{
+		Model:    ModelRef{Provider: "anthropic", Name: "claude-sonnet-4-5"},
+		Metadata: map[string]any{metadataKeyContentCaptureMode: contentCaptureModeValueMetaOnly},
+	}
+
+	t.Run("stripped text and thinking parts are valid", func(t *testing.T) {
+		g := base
+		g.Input = []Message{{Role: RoleUser, Parts: []Part{{Kind: PartKindText}}}}
+		g.Output = []Message{{Role: RoleAssistant, Parts: []Part{{Kind: PartKindThinking}}}}
+		if err := validateGeneration(g); err != nil {
+			t.Fatalf("expected valid, got %v", err)
+		}
+	})
+
+	t.Run("nil ToolCall still fails when stripped", func(t *testing.T) {
+		g := base
+		g.Output = []Message{{Role: RoleAssistant, Parts: []Part{{Kind: PartKindToolCall}}}}
+		err := validateGeneration(g)
+		if err == nil {
+			t.Fatal("expected error for nil ToolCall even when stripped")
+		}
+		if !strings.Contains(err.Error(), "must set exactly one payload field") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("nil ToolResult still fails when stripped", func(t *testing.T) {
+		g := base
+		g.Input = []Message{{Role: RoleTool, Parts: []Part{{Kind: PartKindToolResult}}}}
+		err := validateGeneration(g)
+		if err == nil {
+			t.Fatal("expected error for nil ToolResult even when stripped")
+		}
+		if !strings.Contains(err.Error(), "must set exactly one payload field") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
 func TestValidateGenerationAllowsWhitespaceOnlyTextAndThinking(t *testing.T) {
 	g := Generation{
 		Model: ModelRef{


### PR DESCRIPTION
Callers now have a way to prevent text from leaving the process via the export pipeline or OTel attributes. `MetadataOnly` mode strips all text content at the SDK level while preserving message structure, tool names, usage, and timing.

The existing `IncludeContent` bool on `ToolExecutionStart` only controlled span attributes for individual tools. `ContentCapture` supersedes it with a mode that applies to the entire generation and propagates to child tool executions via context. `IncludeContent` continues to work for backward compatibility under the default `NoToolContent` mode.


### Modes

| Mode | Generations | Tool spans |
|------|------------|------------|
| `Full` | All content exported | Arguments and results in span attributes |
| `NoToolContent` (SDK default, same as before this PR) | All content exported | Excluded |
| `MetadataOnly` | Structure preserved, text stripped | Arguments and results excluded |


### Example

```go
// Client-level default
client := sigil.NewClient(sigil.Config{
    ContentCapture: sigil.ContentCaptureModeMetadataOnly,
})

// Per-generation override
ctx, rec := client.StartGeneration(ctx, sigil.GenerationStart{
    ContentCapture: sigil.ContentCaptureModeFull,
})

// Tool executions inherit from parent generation
_, toolRec := client.StartToolExecution(ctx, sigil.ToolExecutionStart{
    ToolName: "search",
})
```

---

### Dynamic resolution via ContentCaptureResolver

A callback on `sigil.Config` that resolves the capture mode per-recording at runtime. Useful for feature flags, per-tenant policies, or context-dependent decisions.
    
```go
client := sigil.NewClient(sigil.Config{
    ContentCaptureResolver: func(ctx context.Context, metadata map[string]any) sigil.ContentCaptureMode {
        if shouldStripContent(ctx, metadata) {
            return sigil.ContentCaptureModeMetadataOnly
        }
        return sigil.ContentCaptureModeDefault // fall through to Config.ContentCapture
    },
})
```

Resolution precedence (highest -> lowest):
1. Per-recording `ContentCapture` field (on `GenerationStart` / `ToolExecutionStart`)
2. `ContentCaptureResolver` return value
3. `Config.ContentCapture` (client default, resolves to `NoToolContent` when unset to preserve old behaviour)
                                         
Panics in the resolver are recovered and treated as `MetadataOnly`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what generation payloads and tool span attributes can contain (including new MetadataOnly stripping), which can affect downstream ingestion/observability and validation behavior. Defaults aim to preserve prior behavior, but misconfiguration could unintentionally drop content or export more than intended.
> 
> **Overview**
> Introduces `ContentCaptureMode` with client defaults (`Config.ContentCapture`), per-generation (`GenerationStart.ContentCapture`) and per-tool (`ToolExecutionStart.ContentCapture`) overrides, plus a `Config.ContentCaptureResolver` callback (panic-safe, fail-closed) to resolve capture policy per request.
> 
> When `MetadataOnly` is effective, generations are stamped with `sigil.sdk.content_capture_mode` and have prompts/messages/tool I/O/artifacts stripped before enqueue/export, while preserving structure and operational fields; tool executions also inherit the parent generation’s mode via context and only include arguments/results in span attributes when allowed (keeping `IncludeContent` as deprecated backward-compat opt-in under the default behavior).
> 
> Extends validation to accept stripped text/thinking parts, updates rating submission to drop `Comment` under `MetadataOnly`, and adds/updates docs, examples, and tests to cover mode resolution, inheritance, and stripping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed684ca3e5df9e87c5f41de277411b703462b3a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->