### PR TITLE
feat(js): add biome linter and formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,17 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Setup mise
+        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
+        with:
+          install: true
+          install_args: biome
+          cache: true
+
       - run: pnpm install
+
+      - name: Lint
+        run: mise run lint:ts:sdk-js
 
       - name: Typecheck
         run: pnpm --filter @grafana/sigil-sdk-js run typecheck

--- a/js/biome.json
+++ b/js/biome.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true,
+    "root": ".."
+  },
+  "files": {
+    "includes": ["src/**", "test/**", "!dist", "!.test-dist"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 120,
+    "lineEnding": "lf"
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "all",
+      "semicolons": "always",
+      "arrowParentheses": "always",
+      "bracketSpacing": true
+    }
+  },
+  "json": {
+    "formatter": {
+      "trailingCommas": "none"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedImports": "error"
+      },
+      "suspicious": {
+        "noExplicitAny": "off"
+      },
+      "style": {
+        "useImportType": "error",
+        "useNodejsImportProtocol": "off"
+      },
+      "complexity": {
+        "noForEach": "off",
+        "noUselessSwitchCase": "off"
+      }
+    }
+  }
+}

--- a/js/package.json
+++ b/js/package.json
@@ -50,7 +50,9 @@
     "typecheck": "tsc --project tsconfig.json --noEmit",
     "test:build": "rm -rf .test-dist && tsc --project tsconfig.test.json",
     "test": "pnpm run test:build && node --test test/**/*.test.mjs",
-    "test:ci": "pnpm run test"
+    "test:ci": "pnpm run test",
+    "lint": "biome check .",
+    "lint:fix": "biome check --fix ."
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1,3 +1,13 @@
+import {
+  type Histogram,
+  type Meter,
+  metrics,
+  type Span,
+  SpanKind,
+  SpanStatusCode,
+  type Tracer,
+  trace,
+} from '@opentelemetry/api';
 import { defaultLogger, mergeConfig } from './config.js';
 import {
   agentNameFromContext,
@@ -7,7 +17,6 @@ import {
   userIdFromContext,
 } from './context.js';
 import { createDefaultGenerationExporter } from './exporters/default.js';
-import { metrics, SpanKind, SpanStatusCode, trace, type Histogram, type Meter, type Span, type Tracer } from '@opentelemetry/api';
 import type {
   ConversationRating,
   ConversationRatingInput,
@@ -21,6 +30,7 @@ import type {
   GenerationMode,
   GenerationRecorder,
   GenerationResult,
+  GenerationStart,
   Message,
   RecorderCallback,
   RecorderWithError,
@@ -33,22 +43,21 @@ import type {
   ToolExecutionRecorder,
   ToolExecutionResult,
   ToolExecutionStart,
-  GenerationStart,
 } from './types.js';
 import {
   asError,
+  cloneArtifact,
   cloneEmbeddingResult,
   cloneEmbeddingStart,
   cloneGeneration,
   cloneGenerationResult,
   cloneGenerationStart,
+  cloneMessage,
   cloneModelRef,
   cloneToolDefinition,
-  cloneMessage,
-  cloneArtifact,
   cloneToolExecution,
-  cloneToolExecutionStart,
   cloneToolExecutionResult,
+  cloneToolExecutionStart,
   defaultOperationNameForMode,
   defaultSleep,
   encodedSizeBytes,
@@ -163,7 +172,8 @@ export class SigilClient {
     this.nowFn = this.config.now ?? (() => new Date());
     this.sleepFn = this.config.sleep ?? defaultSleep;
     this.logger = this.config.logger ?? defaultLogger;
-    this.generationExporter = this.config.generationExporter ?? createDefaultGenerationExporter(this.config.generationExport);
+    this.generationExporter =
+      this.config.generationExporter ?? createDefaultGenerationExporter(this.config.generationExport);
     this.tracer = this.config.tracer ?? trace.getTracer(instrumentationName);
     this.meter = this.config.meter ?? metrics.getMeter(instrumentationName);
     this.operationDurationHistogram = this.meter.createHistogram(metricOperationDuration, { unit: 's' });
@@ -189,11 +199,11 @@ export class SigilClient {
   startGeneration(start: GenerationStart): GenerationRecorder;
   startGeneration<TResult>(
     start: GenerationStart,
-    callback: RecorderCallback<GenerationRecorder, TResult>
+    callback: RecorderCallback<GenerationRecorder, TResult>,
   ): Promise<TResult>;
   startGeneration<TResult>(
     start: GenerationStart,
-    callback?: RecorderCallback<GenerationRecorder, TResult>
+    callback?: RecorderCallback<GenerationRecorder, TResult>,
   ): GenerationRecorder | Promise<TResult> {
     return this.startGenerationWithMode(start, 'SYNC', callback);
   }
@@ -208,11 +218,11 @@ export class SigilClient {
   startStreamingGeneration(start: GenerationStart): GenerationRecorder;
   startStreamingGeneration<TResult>(
     start: GenerationStart,
-    callback: RecorderCallback<GenerationRecorder, TResult>
+    callback: RecorderCallback<GenerationRecorder, TResult>,
   ): Promise<TResult>;
   startStreamingGeneration<TResult>(
     start: GenerationStart,
-    callback?: RecorderCallback<GenerationRecorder, TResult>
+    callback?: RecorderCallback<GenerationRecorder, TResult>,
   ): GenerationRecorder | Promise<TResult> {
     return this.startGenerationWithMode(start, 'STREAM', callback);
   }
@@ -227,11 +237,11 @@ export class SigilClient {
   startEmbedding(start: EmbeddingStart): EmbeddingRecorder;
   startEmbedding<TResult>(
     start: EmbeddingStart,
-    callback: RecorderCallback<EmbeddingRecorder, TResult>
+    callback: RecorderCallback<EmbeddingRecorder, TResult>,
   ): Promise<TResult>;
   startEmbedding<TResult>(
     start: EmbeddingStart,
-    callback?: RecorderCallback<EmbeddingRecorder, TResult>
+    callback?: RecorderCallback<EmbeddingRecorder, TResult>,
   ): EmbeddingRecorder | Promise<TResult> {
     this.assertOpen();
     const seed = cloneEmbeddingStart(start);
@@ -256,11 +266,11 @@ export class SigilClient {
   startToolExecution(start: ToolExecutionStart): ToolExecutionRecorder;
   startToolExecution<TResult>(
     start: ToolExecutionStart,
-    callback: RecorderCallback<ToolExecutionRecorder, TResult>
+    callback: RecorderCallback<ToolExecutionRecorder, TResult>,
   ): Promise<TResult>;
   startToolExecution<TResult>(
     start: ToolExecutionStart,
-    callback?: RecorderCallback<ToolExecutionRecorder, TResult>
+    callback?: RecorderCallback<ToolExecutionRecorder, TResult>,
   ): ToolExecutionRecorder | Promise<TResult> {
     this.assertOpen();
     const recorder: ToolExecutionRecorder =
@@ -274,7 +284,7 @@ export class SigilClient {
   /** Submits a user-facing conversation rating through Sigil HTTP API. */
   async submitConversationRating(
     conversationId: string,
-    input: ConversationRatingInput
+    input: ConversationRatingInput,
   ): Promise<SubmitConversationRatingResponse> {
     this.assertOpen();
 
@@ -290,7 +300,7 @@ export class SigilClient {
     const endpoint = buildConversationRatingEndpoint(
       this.config.api.endpoint,
       this.config.generationExport.insecure,
-      normalizedConversationId
+      normalizedConversationId,
     );
     const requestBody = {
       rating_id: normalizedInput.ratingId,
@@ -320,7 +330,7 @@ export class SigilClient {
     }
     if (!response.ok) {
       throw new Error(
-        `sigil conversation rating transport failed: status ${response.status}: ${ratingErrorText(responseText, response.status)}`
+        `sigil conversation rating transport failed: status ${response.status}: ${ratingErrorText(responseText, response.status)}`,
       );
     }
 
@@ -489,7 +499,7 @@ export class SigilClient {
     callError: string | undefined,
     validationError: Error | undefined,
     enqueueError: Error | undefined,
-    firstTokenAt: Date | undefined
+    firstTokenAt: Date | undefined,
   ): void {
     span.updateName(generationSpanName(generation.operationName, generation.model.name));
 
@@ -540,7 +550,7 @@ export class SigilClient {
     callError: Error | undefined,
     localError: Error | undefined,
     startedAt: Date,
-    completedAt: Date
+    completedAt: Date,
   ): void {
     span.updateName(embeddingSpanName(seed.model.name));
     setEmbeddingEndSpanAttributes(span, result, hasResult, this.config.embeddingCapture);
@@ -576,7 +586,11 @@ export class SigilClient {
     span.end(completedAt);
   }
 
-  internalFinalizeToolExecutionSpan(span: Span, toolExecution: ToolExecution, localError: Error | undefined): Error | undefined {
+  internalFinalizeToolExecutionSpan(
+    span: Span,
+    toolExecution: ToolExecution,
+    localError: Error | undefined,
+  ): Error | undefined {
     setToolSpanAttributes(span, toolExecution);
 
     if (toolExecution.includeContent) {
@@ -609,7 +623,10 @@ export class SigilClient {
       span.setStatus({ code: SpanStatusCode.OK });
     }
 
-    this.recordToolExecutionMetrics(toolExecution, localError ?? (toolExecution.callError !== undefined ? new Error(toolExecution.callError) : undefined));
+    this.recordToolExecutionMetrics(
+      toolExecution,
+      localError ?? (toolExecution.callError !== undefined ? new Error(toolExecution.callError) : undefined),
+    );
 
     span.end(toolExecution.completedAt);
     return localError;
@@ -619,7 +636,7 @@ export class SigilClient {
     generation: Generation,
     errorType: string,
     errorCategory: string,
-    firstTokenAt: Date | undefined
+    firstTokenAt: Date | undefined,
   ): void {
     const startedMs = generation.startedAt.getTime();
     const completedMs = generation.completedAt.getTime();
@@ -667,7 +684,7 @@ export class SigilClient {
     startedAt: Date,
     completedAt: Date,
     errorType: string,
-    errorCategory: string
+    errorCategory: string,
   ): void {
     const durationSeconds = Math.max(0, (completedAt.getTime() - startedAt.getTime()) / 1_000);
     this.operationDurationHistogram.record(durationSeconds, {
@@ -729,7 +746,7 @@ export class SigilClient {
   private startGenerationWithMode<TResult>(
     start: GenerationStart,
     mode: GenerationMode,
-    callback?: RecorderCallback<GenerationRecorder, TResult>
+    callback?: RecorderCallback<GenerationRecorder, TResult>,
   ): GenerationRecorder | Promise<TResult> {
     this.assertOpen();
     const recorder = new GenerationRecorderImpl(this, start, mode);
@@ -840,7 +857,7 @@ class GenerationRecorderImpl implements GenerationRecorder {
   constructor(
     private readonly client: SigilClient,
     seed: GenerationStart,
-    defaultMode: GenerationMode
+    defaultMode: GenerationMode,
   ) {
     this.seed = cloneGenerationStart(seed);
     if (!notEmpty(this.seed.conversationId)) {
@@ -929,7 +946,7 @@ class GenerationRecorderImpl implements GenerationRecorder {
 
     generation.conversationTitle = firstNonEmptyString(
       generation.conversationTitle,
-      metadataStringValue(generation.metadata, spanAttrConversationTitle)
+      metadataStringValue(generation.metadata, spanAttrConversationTitle),
     )?.trim();
     if (notEmpty(generation.conversationTitle)) {
       if (generation.metadata === undefined) {
@@ -941,7 +958,7 @@ class GenerationRecorderImpl implements GenerationRecorder {
     generation.userId = firstNonEmptyString(
       generation.userId,
       metadataStringValue(generation.metadata, metadataUserIDKey),
-      metadataStringValue(generation.metadata, metadataLegacyUserIDKey)
+      metadataStringValue(generation.metadata, metadataLegacyUserIDKey),
     )?.trim();
     if (notEmpty(generation.userId)) {
       if (generation.metadata === undefined) {
@@ -986,7 +1003,7 @@ class GenerationRecorderImpl implements GenerationRecorder {
       this.callError,
       validationError,
       enqueueError,
-      this.firstTokenAt
+      this.firstTokenAt,
     );
   }
 
@@ -1007,7 +1024,7 @@ class EmbeddingRecorderImpl implements EmbeddingRecorder {
 
   constructor(
     private readonly client: SigilClient,
-    seed: EmbeddingStart
+    seed: EmbeddingStart,
   ) {
     this.seed = cloneEmbeddingStart(seed);
     this.startedAt = this.seed.startedAt ?? this.client.internalNow();
@@ -1050,7 +1067,7 @@ class EmbeddingRecorderImpl implements EmbeddingRecorder {
       this.callError,
       localError,
       this.startedAt,
-      completedAt
+      completedAt,
     );
     this.localError = localError;
   }
@@ -1071,7 +1088,7 @@ class ToolExecutionRecorderImpl implements ToolExecutionRecorder {
 
   constructor(
     private readonly client: SigilClient,
-    seed: ToolExecutionStart
+    seed: ToolExecutionStart,
   ) {
     this.seed = cloneToolExecutionStart(seed);
     if (!notEmpty(this.seed.conversationId)) {
@@ -1159,7 +1176,7 @@ class NoopToolExecutionRecorder implements ToolExecutionRecorder {
 
 async function runWithRecorder<TRecorder extends RecorderWithError, TResult>(
   recorder: TRecorder,
-  callback: RecorderCallback<TRecorder, TResult>
+  callback: RecorderCallback<TRecorder, TResult>,
 ): Promise<TResult> {
   let callbackError: unknown;
   try {
@@ -1172,6 +1189,7 @@ async function runWithRecorder<TRecorder extends RecorderWithError, TResult>(
     recorder.end();
     const recorderError = recorder.getError();
     if (callbackError === undefined && recorderError !== undefined) {
+      // biome-ignore lint/correctness/noUnsafeFinally: intentional — only throws when callback succeeded but recorder detected an error
       throw recorderError;
     }
   }
@@ -1230,7 +1248,7 @@ function setGenerationSpanAttributes(
       cacheCreationInputTokens?: number;
       reasoningTokens?: number;
     };
-  }
+  },
 ): void {
   span.setAttribute(spanAttrOperationName, generation.operationName);
   span.setAttribute(spanAttrSDKName, sdkName);
@@ -1372,7 +1390,7 @@ function setEmbeddingEndSpanAttributes(
   span: Span,
   result: EmbeddingResult,
   hasResult: boolean,
-  captureConfig: SigilSdkConfig['embeddingCapture']
+  captureConfig: SigilSdkConfig['embeddingCapture'],
 ): void {
   if (hasResult) {
     span.setAttribute(spanAttrEmbeddingInputCount, result.inputCount);
@@ -1387,7 +1405,11 @@ function setEmbeddingEndSpanAttributes(
     span.setAttribute(spanAttrEmbeddingDimCount, result.dimensions);
   }
   if (captureConfig.captureInput && result.inputTexts !== undefined) {
-    const texts = captureEmbeddingInputTexts(result.inputTexts, captureConfig.maxInputItems, captureConfig.maxTextLength);
+    const texts = captureEmbeddingInputTexts(
+      result.inputTexts,
+      captureConfig.maxInputItems,
+      captureConfig.maxTextLength,
+    );
     if (texts.length > 0) {
       span.setAttribute(spanAttrEmbeddingInputTexts, texts);
     }
@@ -1407,7 +1429,7 @@ function setToolSpanAttributes(
     agentVersion?: string;
     requestProvider?: string;
     requestModel?: string;
-  }
+  },
 ): void {
   span.setAttribute(spanAttrOperationName, 'execute_tool');
   span.setAttribute(spanAttrToolName, tool.toolName);
@@ -1491,12 +1513,9 @@ function normalizeConversationRatingInput(input: ConversationRatingInput): Conve
   if (normalized.ratingId.length > maxRatingIdLen) {
     throw new Error('sigil conversation rating validation failed: ratingId is too long');
   }
-  if (
-    normalized.rating !== 'CONVERSATION_RATING_VALUE_GOOD' &&
-    normalized.rating !== 'CONVERSATION_RATING_VALUE_BAD'
-  ) {
+  if (normalized.rating !== 'CONVERSATION_RATING_VALUE_GOOD' && normalized.rating !== 'CONVERSATION_RATING_VALUE_BAD') {
     throw new Error(
-      'sigil conversation rating validation failed: rating must be CONVERSATION_RATING_VALUE_GOOD or CONVERSATION_RATING_VALUE_BAD'
+      'sigil conversation rating validation failed: rating must be CONVERSATION_RATING_VALUE_GOOD or CONVERSATION_RATING_VALUE_BAD',
     );
   }
   if (normalized.comment !== undefined && encodedSizeBytes(normalized.comment) > maxRatingCommentBytes) {
@@ -1734,7 +1753,7 @@ function firstNonEmptyString(...values: Array<string | undefined>): string | und
 
 function mergeStringRecords(
   left: Record<string, string> | undefined,
-  right: Record<string, string> | undefined
+  right: Record<string, string> | undefined,
 ): Record<string, string> | undefined {
   if (left === undefined && right === undefined) {
     return undefined;
@@ -1747,7 +1766,7 @@ function mergeStringRecords(
 
 function mergeUnknownRecords(
   left: Record<string, unknown> | undefined,
-  right: Record<string, unknown> | undefined
+  right: Record<string, unknown> | undefined,
 ): Record<string, unknown> | undefined {
   if (left === undefined && right === undefined) {
     return undefined;

--- a/js/src/config.ts
+++ b/js/src/config.ts
@@ -93,9 +93,7 @@ function mergeAPIConfig(config: Partial<ApiConfig> | undefined): ApiConfig {
   };
 }
 
-function mergeEmbeddingCaptureConfig(
-  config: Partial<EmbeddingCaptureConfig> | undefined
-): EmbeddingCaptureConfig {
+function mergeEmbeddingCaptureConfig(config: Partial<EmbeddingCaptureConfig> | undefined): EmbeddingCaptureConfig {
   return {
     ...defaultEmbeddingCaptureConfig,
     ...config,
@@ -112,7 +110,7 @@ function mergeAuthConfig(config: ExportAuthConfig | undefined): ExportAuthConfig
 function resolveHeadersWithAuth(
   headers: Record<string, string> | undefined,
   auth: ExportAuthConfig,
-  label: string
+  label: string,
 ): Record<string, string> | undefined {
   const mode = (auth.mode ?? 'none').trim().toLowerCase();
   const tenantId = auth.tenantId?.trim() ?? '';
@@ -175,7 +173,7 @@ function resolveHeadersWithAuth(
     const result: Record<string, string> = { ...(out ?? {}) };
     if (!hasHeaderKey(result, authorizationHeaderName)) {
       const encoded = new TextEncoder().encode(`${user}:${password}`);
-      result[authorizationHeaderName] = 'Basic ' + btoa(String.fromCharCode(...encoded));
+      result[authorizationHeaderName] = `Basic ${btoa(String.fromCharCode(...encoded))}`;
     }
     if (tenantId.length > 0 && !hasHeaderKey(result, tenantHeaderName)) {
       result[tenantHeaderName] = tenantId;

--- a/js/src/exporters/default.ts
+++ b/js/src/exporters/default.ts
@@ -16,7 +16,9 @@ export function createDefaultGenerationExporter(config: GenerationExportConfig):
     case 'none':
       return new NoopGenerationExporter();
     default:
-      return new UnavailableGenerationExporter(new Error(`unsupported generation export protocol: ${config.protocol as string}`));
+      return new UnavailableGenerationExporter(
+        new Error(`unsupported generation export protocol: ${config.protocol as string}`),
+      );
   }
 }
 

--- a/js/src/exporters/grpc.ts
+++ b/js/src/exporters/grpc.ts
@@ -10,14 +10,14 @@ import type {
   GenerationExporter,
   Message,
   MessagePart,
-  ToolDefinition,
   TokenUsage,
+  ToolDefinition,
 } from '../types.js';
 
 type ExportGenerationsMethod = (
   request: unknown,
   metadata: grpc.Metadata,
-  callback: (error: grpc.ServiceError | null, response: unknown) => void
+  callback: (error: grpc.ServiceError | null, response: unknown) => void,
 ) => void;
 
 type GRPCServiceClient = grpc.Client & {
@@ -162,10 +162,7 @@ function parseGRPCExportResponse(response: unknown, request: ExportGenerationsRe
 
       return {
         generationId:
-          asString(result.generationId) ??
-          asString(result.generation_id) ??
-          request.generations[index]?.id ??
-          '',
+          asString(result.generationId) ?? asString(result.generation_id) ?? request.generations[index]?.id ?? '',
         accepted: Boolean(result.accepted),
         error: asString(result.error),
       };
@@ -231,14 +228,14 @@ function mapMessagePartToProto(part: MessagePart): Record<string, unknown> {
         {
           text: part.text,
         },
-        part.metadata?.providerType
+        part.metadata?.providerType,
       );
     case 'thinking':
       return withPartMetadata(
         {
           thinking: part.thinking,
         },
-        part.metadata?.providerType
+        part.metadata?.providerType,
       );
     case 'tool_call':
       return withPartMetadata(
@@ -249,7 +246,7 @@ function mapMessagePartToProto(part: MessagePart): Record<string, unknown> {
             inputJson: toBytePayload(part.toolCall.inputJSON),
           },
         },
-        part.metadata?.providerType
+        part.metadata?.providerType,
       );
     case 'tool_result':
       return withPartMetadata(
@@ -262,7 +259,7 @@ function mapMessagePartToProto(part: MessagePart): Record<string, unknown> {
             isError: part.toolResult.isError ?? false,
           },
         },
-        part.metadata?.providerType
+        part.metadata?.providerType,
       );
   }
 }

--- a/js/src/exporters/http.ts
+++ b/js/src/exporters/http.ts
@@ -45,7 +45,7 @@ export class HTTPGenerationExporter implements GenerationExporter {
 
 function parseExportGenerationsResponse(
   payload: unknown,
-  request: ExportGenerationsRequest
+  request: ExportGenerationsRequest,
 ): ExportGenerationsResponse {
   if (!isRecord(payload) || !Array.isArray(payload.results)) {
     throw new Error('invalid generation export response payload');
@@ -153,14 +153,14 @@ function mapMessagePartToProtoJSON(part: MessagePart): Record<string, unknown> {
         {
           text: part.text,
         },
-        part.metadata?.providerType
+        part.metadata?.providerType,
       );
     case 'thinking':
       return withPartMetadata(
         {
           thinking: part.thinking,
         },
-        part.metadata?.providerType
+        part.metadata?.providerType,
       );
     case 'tool_call':
       return withPartMetadata(
@@ -171,7 +171,7 @@ function mapMessagePartToProtoJSON(part: MessagePart): Record<string, unknown> {
             input_json: toBase64Payload(part.toolCall.inputJSON),
           },
         },
-        part.metadata?.providerType
+        part.metadata?.providerType,
       );
     case 'tool_result':
       return withPartMetadata(
@@ -184,7 +184,7 @@ function mapMessagePartToProtoJSON(part: MessagePart): Record<string, unknown> {
             is_error: part.toolResult.isError ?? false,
           },
         },
-        part.metadata?.providerType
+        part.metadata?.providerType,
       );
   }
 }

--- a/js/src/frameworks/google-adk/index.ts
+++ b/js/src/frameworks/google-adk/index.ts
@@ -1,5 +1,5 @@
 import type { SigilClient } from '../../client.js';
-import { SigilFrameworkHandler, type FrameworkHandlerOptions } from '../shared.js';
+import { type FrameworkHandlerOptions, SigilFrameworkHandler } from '../shared.js';
 
 export type { FrameworkHandlerOptions };
 
@@ -69,22 +69,11 @@ type GoogleAdkPlugin = {
     invocationContext: GoogleAdkInvocationContext;
     userMessage: unknown;
   }): Promise<unknown>;
-  beforeRunCallback(params: {
-    invocationContext: GoogleAdkInvocationContext;
-  }): Promise<unknown>;
-  onEventCallback(params: {
-    invocationContext: GoogleAdkInvocationContext;
-    event: GoogleAdkEvent;
-  }): Promise<unknown>;
-  afterRunCallback(params: {
-    invocationContext: GoogleAdkInvocationContext;
-  }): Promise<void>;
-  beforeAgentCallback(params: {
-    callbackContext: GoogleAdkCallbackContext;
-  }): Promise<unknown>;
-  afterAgentCallback(params: {
-    callbackContext: GoogleAdkCallbackContext;
-  }): Promise<unknown>;
+  beforeRunCallback(params: { invocationContext: GoogleAdkInvocationContext }): Promise<unknown>;
+  onEventCallback(params: { invocationContext: GoogleAdkInvocationContext; event: GoogleAdkEvent }): Promise<unknown>;
+  afterRunCallback(params: { invocationContext: GoogleAdkInvocationContext }): Promise<void>;
+  beforeAgentCallback(params: { callbackContext: GoogleAdkCallbackContext }): Promise<unknown>;
+  afterAgentCallback(params: { callbackContext: GoogleAdkCallbackContext }): Promise<unknown>;
   beforeModelCallback(params: {
     callbackContext: GoogleAdkCallbackContext;
     llmRequest: GoogleAdkLlmRequest;
@@ -135,7 +124,7 @@ export class SigilGoogleAdkHandler extends SigilFrameworkHandler {
     extraParams?: Record<string, unknown>,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onLLMStart(serialized, prompts, runId, parentRunId, extraParams, tags, metadata, runName);
   }
@@ -148,7 +137,7 @@ export class SigilGoogleAdkHandler extends SigilFrameworkHandler {
     extraParams?: Record<string, unknown>,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onChatModelStart(serialized, messages, runId, parentRunId, extraParams, tags, metadata, runName);
   }
@@ -172,7 +161,7 @@ export class SigilGoogleAdkHandler extends SigilFrameworkHandler {
     parentRunId?: string,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onToolStart(serialized, input, runId, parentRunId, tags, metadata, runName);
   }
@@ -193,7 +182,7 @@ export class SigilGoogleAdkHandler extends SigilFrameworkHandler {
     tags?: string[],
     metadata?: Record<string, unknown>,
     runType?: string,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onChainStart(serialized, runId, parentRunId, tags, metadata, runType, runName);
   }
@@ -213,7 +202,7 @@ export class SigilGoogleAdkHandler extends SigilFrameworkHandler {
     parentRunId?: string,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onRetrieverStart(serialized, runId, parentRunId, tags, metadata, runName);
   }
@@ -258,9 +247,7 @@ class SigilGoogleAdkPlugin implements GoogleAdkPlugin {
     return undefined;
   }
 
-  async beforeRunCallback(params: {
-    invocationContext: GoogleAdkInvocationContext;
-  }): Promise<undefined> {
+  async beforeRunCallback(params: { invocationContext: GoogleAdkInvocationContext }): Promise<undefined> {
     const invocationContext = params.invocationContext;
     const invocationId = this.resolveInvocationId(invocationContext);
     const runId = `adk_invocation:${invocationId}`;
@@ -274,7 +261,7 @@ class SigilGoogleAdkPlugin implements GoogleAdkPlugin {
       undefined,
       this.metadataFromInvocation(invocationContext),
       'invocation',
-      this.resolveAgentName(invocationContext)
+      this.resolveAgentName(invocationContext),
     );
 
     return undefined;
@@ -308,9 +295,7 @@ class SigilGoogleAdkPlugin implements GoogleAdkPlugin {
     return undefined;
   }
 
-  async afterRunCallback(params: {
-    invocationContext: GoogleAdkInvocationContext;
-  }): Promise<void> {
+  async afterRunCallback(params: { invocationContext: GoogleAdkInvocationContext }): Promise<void> {
     const invocationId = this.resolveInvocationId(params.invocationContext);
     const runId = this.invocationRunIds.get(invocationId);
     if (runId !== undefined) {
@@ -327,9 +312,7 @@ class SigilGoogleAdkPlugin implements GoogleAdkPlugin {
     this.pendingUserMessages.delete(invocationId);
   }
 
-  async beforeAgentCallback(params: {
-    callbackContext: GoogleAdkCallbackContext;
-  }): Promise<undefined> {
+  async beforeAgentCallback(params: { callbackContext: GoogleAdkCallbackContext }): Promise<undefined> {
     const callbackContext = params.callbackContext;
     const invocationContext = callbackContext.invocationContext;
     const invocationId = this.resolveInvocationId(invocationContext, callbackContext);
@@ -348,14 +331,12 @@ class SigilGoogleAdkPlugin implements GoogleAdkPlugin {
       undefined,
       this.metadataFromInvocation(invocationContext, callbackContext),
       'agent',
-      agentName
+      agentName,
     );
     return undefined;
   }
 
-  async afterAgentCallback(params: {
-    callbackContext: GoogleAdkCallbackContext;
-  }): Promise<undefined> {
+  async afterAgentCallback(params: { callbackContext: GoogleAdkCallbackContext }): Promise<undefined> {
     const callbackContext = params.callbackContext;
     const invocationContext = callbackContext.invocationContext;
     const invocationId = this.resolveInvocationId(invocationContext, callbackContext);
@@ -383,11 +364,12 @@ class SigilGoogleAdkPlugin implements GoogleAdkPlugin {
     const llmRunId = `adk_llm:${invocationId}:${++this.sequence}`;
     const modelRunStack = this.llmRunStacks.get(invocationId) ?? [];
     const agentRunStack = this.agentRunStacks.get(invocationId) ?? [];
-    const parentRunId = modelRunStack.length > 0
-      ? modelRunStack[modelRunStack.length - 1]
-      : agentRunStack.length > 0
-        ? agentRunStack[agentRunStack.length - 1]
-        : this.invocationRunIds.get(invocationId);
+    const parentRunId =
+      modelRunStack.length > 0
+        ? modelRunStack[modelRunStack.length - 1]
+        : agentRunStack.length > 0
+          ? agentRunStack[agentRunStack.length - 1]
+          : this.invocationRunIds.get(invocationId);
     modelRunStack.push(llmRunId);
     this.llmRunStacks.set(invocationId, modelRunStack);
 
@@ -414,7 +396,7 @@ class SigilGoogleAdkPlugin implements GoogleAdkPlugin {
       },
       undefined,
       this.metadataFromInvocation(invocationContext, callbackContext),
-      agentName
+      agentName,
     );
 
     return undefined;
@@ -433,8 +415,7 @@ class SigilGoogleAdkPlugin implements GoogleAdkPlugin {
     }
 
     const text = extractContentText(params.llmResponse?.content);
-    const isPartial = asBoolean(params.llmResponse?.partial)
-      || params.llmResponse?.turnComplete === false;
+    const isPartial = asBoolean(params.llmResponse?.partial) || params.llmResponse?.turnComplete === false;
 
     if (isPartial) {
       if (text.length > 0 && this.llmTokenSources.get(llmRunId) !== 'event') {
@@ -451,9 +432,10 @@ class SigilGoogleAdkPlugin implements GoogleAdkPlugin {
     const output = {
       generations: text.length > 0 ? [[{ text }]] : [],
       llm_output: {
-        model_name: asString(params.llmResponse?.customMetadata?.model)
-          || asString(params.llmResponse?.customMetadata?.model_name)
-          || undefined,
+        model_name:
+          asString(params.llmResponse?.customMetadata?.model) ||
+          asString(params.llmResponse?.customMetadata?.model_name) ||
+          undefined,
         finish_reason: asString(params.llmResponse?.finishReason) || undefined,
         token_usage: {
           prompt_tokens: asNumber(usageMetadata?.promptTokenCount),
@@ -467,10 +449,7 @@ class SigilGoogleAdkPlugin implements GoogleAdkPlugin {
     return params.llmResponse;
   }
 
-  async onModelErrorCallback(params: {
-    callbackContext: GoogleAdkCallbackContext;
-    error: Error;
-  }): Promise<undefined> {
+  async onModelErrorCallback(params: { callbackContext: GoogleAdkCallbackContext; error: Error }): Promise<undefined> {
     const callbackContext = params.callbackContext;
     const invocationContext = callbackContext.invocationContext;
     const invocationId = this.resolveInvocationId(invocationContext, callbackContext);
@@ -491,9 +470,8 @@ class SigilGoogleAdkPlugin implements GoogleAdkPlugin {
     const invocationContext = toolContext.invocationContext;
     const invocationId = this.resolveInvocationId(invocationContext, toolContext);
     const callId = asString(toolContext.functionCallId);
-    const runId = callId.length > 0
-      ? `adk_tool:${invocationId}:${callId}`
-      : `adk_tool:${invocationId}:${++this.sequence}`;
+    const runId =
+      callId.length > 0 ? `adk_tool:${invocationId}:${callId}` : `adk_tool:${invocationId}:${++this.sequence}`;
     if (callId.length > 0) {
       this.toolRunIds.set(`${invocationId}:${callId}`, runId);
     } else {
@@ -514,16 +492,13 @@ class SigilGoogleAdkPlugin implements GoogleAdkPlugin {
       this.metadataFromInvocation(invocationContext, toolContext, {
         event_id: callId,
       }),
-      asString(params.tool?.name)
+      asString(params.tool?.name),
     );
 
     return undefined;
   }
 
-  async afterToolCallback(params: {
-    toolContext: GoogleAdkToolContext;
-    result: unknown;
-  }): Promise<unknown> {
+  async afterToolCallback(params: { toolContext: GoogleAdkToolContext; result: unknown }): Promise<unknown> {
     const toolContext = params.toolContext;
     const invocationContext = toolContext.invocationContext;
     const invocationId = this.resolveInvocationId(invocationContext, toolContext);
@@ -547,10 +522,7 @@ class SigilGoogleAdkPlugin implements GoogleAdkPlugin {
     return params.result;
   }
 
-  async onToolErrorCallback(params: {
-    toolContext: GoogleAdkToolContext;
-    error: Error;
-  }): Promise<undefined> {
+  async onToolErrorCallback(params: { toolContext: GoogleAdkToolContext; error: Error }): Promise<undefined> {
     const toolContext = params.toolContext;
     const invocationContext = toolContext.invocationContext;
     const invocationId = this.resolveInvocationId(invocationContext, toolContext);
@@ -576,10 +548,9 @@ class SigilGoogleAdkPlugin implements GoogleAdkPlugin {
 
   private resolveInvocationId(
     invocationContext?: GoogleAdkInvocationContext,
-    fallbackContext?: GoogleAdkCallbackContext | GoogleAdkToolContext
+    fallbackContext?: GoogleAdkCallbackContext | GoogleAdkToolContext,
   ): string {
-    const explicit = asString(invocationContext?.invocationId)
-      || asString(fallbackContext?.invocationId);
+    const explicit = asString(invocationContext?.invocationId) || asString(fallbackContext?.invocationId);
     if (explicit.length > 0) {
       return explicit;
     }
@@ -599,7 +570,7 @@ class SigilGoogleAdkPlugin implements GoogleAdkPlugin {
 
   private resolveStableInvocationContext(
     invocationContext?: GoogleAdkInvocationContext,
-    fallbackContext?: GoogleAdkCallbackContext | GoogleAdkToolContext
+    fallbackContext?: GoogleAdkCallbackContext | GoogleAdkToolContext,
   ): object | undefined {
     if (isRecord(invocationContext)) {
       return invocationContext;
@@ -615,16 +586,15 @@ class SigilGoogleAdkPlugin implements GoogleAdkPlugin {
 
   private resolveAgentName(
     invocationContext?: GoogleAdkInvocationContext,
-    callbackContext?: GoogleAdkCallbackContext
+    callbackContext?: GoogleAdkCallbackContext,
   ): string {
-    return asString(callbackContext?.agentName)
-      || asString(invocationContext?.agent?.name);
+    return asString(callbackContext?.agentName) || asString(invocationContext?.agent?.name);
   }
 
   private metadataFromInvocation(
     invocationContext?: GoogleAdkInvocationContext,
     callbackContext?: GoogleAdkCallbackContext | GoogleAdkToolContext,
-    extra?: AnyRecord
+    extra?: AnyRecord,
   ): AnyRecord {
     return {
       session_id: asString(invocationContext?.session?.id),
@@ -661,14 +631,14 @@ class SigilGoogleAdkPlugin implements GoogleAdkPlugin {
 
 export function createSigilGoogleAdkHandler(
   client: SigilClient,
-  options: FrameworkHandlerOptions = {}
+  options: FrameworkHandlerOptions = {},
 ): SigilGoogleAdkHandler {
   return new SigilGoogleAdkHandler(client, options);
 }
 
 export function createSigilGoogleAdkPlugin(
   client: SigilClient,
-  options: FrameworkHandlerOptions = {}
+  options: FrameworkHandlerOptions = {},
 ): GoogleAdkPlugin {
   return new SigilGoogleAdkPlugin(client, options);
 }
@@ -676,7 +646,7 @@ export function createSigilGoogleAdkPlugin(
 export function withSigilGoogleAdkPlugins<T extends PluginConfig>(
   config: T | undefined,
   client: SigilClient,
-  options: FrameworkHandlerOptions = {}
+  options: FrameworkHandlerOptions = {},
 ): T & { plugins: unknown[] } {
   const plugin = createSigilGoogleAdkPlugin(client, options);
   const base = { ...(config ?? {}) } as PluginConfig;
@@ -728,9 +698,8 @@ function mapAdkUserMessage(userMessage: unknown): Array<{ role: string; content:
   }
   if (isRecord(userMessage)) {
     const role = asString(read(userMessage, 'role')) || 'user';
-    const content = extractContentText(userMessage)
-      || asString(read(userMessage, 'text'))
-      || asString(read(userMessage, 'content'));
+    const content =
+      extractContentText(userMessage) || asString(read(userMessage, 'text')) || asString(read(userMessage, 'content'));
     if (content.length > 0) {
       return [{ role, content }];
     }
@@ -743,7 +712,7 @@ function mapAdkUserMessage(userMessage: unknown): Array<{ role: string; content:
 
 function mergeAdkUserMessages(
   requestMessages: Array<{ role: string; content: string }>,
-  pendingMessages: Array<{ role: string; content: string }>
+  pendingMessages: Array<{ role: string; content: string }>,
 ): Array<{ role: string; content: string }> {
   if (requestMessages.length === 0) {
     return pendingMessages;
@@ -757,7 +726,7 @@ function mergeAdkUserMessages(
     return pendingMessages;
   }
   const duplicate = pendingMessages.some(
-    (message) => message.role === firstRequest.role && message.content === firstRequest.content
+    (message) => message.role === firstRequest.role && message.content === firstRequest.content,
   );
   if (duplicate) {
     return requestMessages;
@@ -767,18 +736,19 @@ function mergeAdkUserMessages(
 
 function resolveRequestStream(
   llmRequest: GoogleAdkLlmRequest | undefined,
-  invocationContext: GoogleAdkInvocationContext | undefined
+  invocationContext: GoogleAdkInvocationContext | undefined,
 ): boolean {
   const config = isRecord(llmRequest?.config) ? llmRequest?.config : undefined;
   const generationConfig = isRecord(read(config, 'generationConfig')) ? read(config, 'generationConfig') : undefined;
-  const stream = read(llmRequest, 'stream')
-    ?? read(llmRequest, 'streaming')
-    ?? read(config, 'stream')
-    ?? read(config, 'streaming')
-    ?? read(generationConfig, 'stream')
-    ?? read(generationConfig, 'streaming')
-    ?? read(invocationContext, 'stream')
-    ?? read(invocationContext, 'streaming');
+  const stream =
+    read(llmRequest, 'stream') ??
+    read(llmRequest, 'streaming') ??
+    read(config, 'stream') ??
+    read(config, 'streaming') ??
+    read(generationConfig, 'stream') ??
+    read(generationConfig, 'streaming') ??
+    read(invocationContext, 'stream') ??
+    read(invocationContext, 'streaming');
   return asBoolean(stream);
 }
 
@@ -786,12 +756,14 @@ function extractEventText(event: GoogleAdkEvent | undefined): string {
   if (!event) {
     return '';
   }
-  return extractContentText(event.content)
-    || extractContentText(event.partial)
-    || asString(event.text)
-    || asString(event.delta)
-    || asString(read(event.content, 'text'))
-    || asString(read(event.partial, 'text'));
+  return (
+    extractContentText(event.content) ||
+    extractContentText(event.partial) ||
+    asString(event.text) ||
+    asString(event.delta) ||
+    asString(read(event.content, 'text')) ||
+    asString(read(event.partial, 'text'))
+  );
 }
 
 function extractContentText(content: unknown): string {

--- a/js/src/frameworks/langchain/index.ts
+++ b/js/src/frameworks/langchain/index.ts
@@ -1,5 +1,5 @@
 import type { SigilClient } from '../../client.js';
-import { SigilFrameworkHandler, type FrameworkHandlerOptions } from '../shared.js';
+import { type FrameworkHandlerOptions, SigilFrameworkHandler } from '../shared.js';
 
 export type { FrameworkHandlerOptions };
 
@@ -20,7 +20,7 @@ export class SigilLangChainHandler extends SigilFrameworkHandler {
     extraParams?: Record<string, unknown>,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onLLMStart(serialized, prompts, runId, parentRunId, extraParams, tags, metadata, runName);
   }
@@ -33,16 +33,12 @@ export class SigilLangChainHandler extends SigilFrameworkHandler {
     extraParams?: Record<string, unknown>,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onChatModelStart(serialized, messages, runId, parentRunId, extraParams, tags, metadata, runName);
   }
 
-  async handleLLMNewToken(
-    token: string,
-    _idx: unknown,
-    runId: string
-  ): Promise<void> {
+  async handleLLMNewToken(token: string, _idx: unknown, runId: string): Promise<void> {
     this.onLLMNewToken(token, runId);
   }
 
@@ -61,7 +57,7 @@ export class SigilLangChainHandler extends SigilFrameworkHandler {
     parentRunId?: string,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onToolStart(serialized, input, runId, parentRunId, tags, metadata, runName);
   }
@@ -82,7 +78,7 @@ export class SigilLangChainHandler extends SigilFrameworkHandler {
     tags?: string[],
     metadata?: Record<string, unknown>,
     runType?: string,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onChainStart(serialized, runId, parentRunId, tags, metadata, runType, runName);
   }
@@ -102,7 +98,7 @@ export class SigilLangChainHandler extends SigilFrameworkHandler {
     parentRunId?: string,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onRetrieverStart(serialized, runId, parentRunId, tags, metadata, runName);
   }
@@ -118,7 +114,7 @@ export class SigilLangChainHandler extends SigilFrameworkHandler {
 
 export function createSigilLangChainHandler(
   client: SigilClient,
-  options: FrameworkHandlerOptions = {}
+  options: FrameworkHandlerOptions = {},
 ): SigilLangChainHandler {
   return new SigilLangChainHandler(client, options);
 }
@@ -126,7 +122,7 @@ export function createSigilLangChainHandler(
 export function withSigilLangChainCallbacks<T extends CallbackConfig>(
   config: T | undefined,
   client: SigilClient,
-  options: FrameworkHandlerOptions = {}
+  options: FrameworkHandlerOptions = {},
 ): T & { callbacks: unknown[] } {
   const handler = createSigilLangChainHandler(client, options);
   const base = { ...(config ?? {}) } as CallbackConfig;

--- a/js/src/frameworks/langgraph/index.ts
+++ b/js/src/frameworks/langgraph/index.ts
@@ -1,5 +1,5 @@
 import type { SigilClient } from '../../client.js';
-import { SigilFrameworkHandler, type FrameworkHandlerOptions } from '../shared.js';
+import { type FrameworkHandlerOptions, SigilFrameworkHandler } from '../shared.js';
 
 export type { FrameworkHandlerOptions };
 
@@ -20,7 +20,7 @@ export class SigilLangGraphHandler extends SigilFrameworkHandler {
     extraParams?: Record<string, unknown>,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onLLMStart(serialized, prompts, runId, parentRunId, extraParams, tags, metadata, runName);
   }
@@ -33,16 +33,12 @@ export class SigilLangGraphHandler extends SigilFrameworkHandler {
     extraParams?: Record<string, unknown>,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onChatModelStart(serialized, messages, runId, parentRunId, extraParams, tags, metadata, runName);
   }
 
-  async handleLLMNewToken(
-    token: string,
-    _idx: unknown,
-    runId: string
-  ): Promise<void> {
+  async handleLLMNewToken(token: string, _idx: unknown, runId: string): Promise<void> {
     this.onLLMNewToken(token, runId);
   }
 
@@ -61,7 +57,7 @@ export class SigilLangGraphHandler extends SigilFrameworkHandler {
     parentRunId?: string,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onToolStart(serialized, input, runId, parentRunId, tags, metadata, runName);
   }
@@ -82,7 +78,7 @@ export class SigilLangGraphHandler extends SigilFrameworkHandler {
     tags?: string[],
     metadata?: Record<string, unknown>,
     runType?: string,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onChainStart(serialized, runId, parentRunId, tags, metadata, runType, runName);
   }
@@ -102,7 +98,7 @@ export class SigilLangGraphHandler extends SigilFrameworkHandler {
     parentRunId?: string,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onRetrieverStart(serialized, runId, parentRunId, tags, metadata, runName);
   }
@@ -118,7 +114,7 @@ export class SigilLangGraphHandler extends SigilFrameworkHandler {
 
 export function createSigilLangGraphHandler(
   client: SigilClient,
-  options: FrameworkHandlerOptions = {}
+  options: FrameworkHandlerOptions = {},
 ): SigilLangGraphHandler {
   return new SigilLangGraphHandler(client, options);
 }
@@ -126,7 +122,7 @@ export function createSigilLangGraphHandler(
 export function withSigilLangGraphCallbacks<T extends CallbackConfig>(
   config: T | undefined,
   client: SigilClient,
-  options: FrameworkHandlerOptions = {}
+  options: FrameworkHandlerOptions = {},
 ): T & { callbacks: unknown[] } {
   const handler = createSigilLangGraphHandler(client, options);
   const base = { ...(config ?? {}) } as CallbackConfig;

--- a/js/src/frameworks/llamaindex/index.ts
+++ b/js/src/frameworks/llamaindex/index.ts
@@ -1,7 +1,7 @@
 import { CallbackManager } from 'llamaindex';
 
 import type { SigilClient } from '../../client.js';
-import { SigilFrameworkHandler, type FrameworkHandlerOptions } from '../shared.js';
+import { type FrameworkHandlerOptions, SigilFrameworkHandler } from '../shared.js';
 
 export type { FrameworkHandlerOptions };
 
@@ -43,7 +43,7 @@ export class SigilLlamaIndexHandler extends SigilFrameworkHandler {
     extraParams?: Record<string, unknown>,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onLLMStart(serialized, prompts, runId, parentRunId, extraParams, tags, metadata, runName);
   }
@@ -56,7 +56,7 @@ export class SigilLlamaIndexHandler extends SigilFrameworkHandler {
     extraParams?: Record<string, unknown>,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onChatModelStart(serialized, messages, runId, parentRunId, extraParams, tags, metadata, runName);
   }
@@ -80,7 +80,7 @@ export class SigilLlamaIndexHandler extends SigilFrameworkHandler {
     parentRunId?: string,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onToolStart(serialized, input, runId, parentRunId, tags, metadata, runName);
   }
@@ -101,7 +101,7 @@ export class SigilLlamaIndexHandler extends SigilFrameworkHandler {
     tags?: string[],
     metadata?: Record<string, unknown>,
     runType?: string,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onChainStart(serialized, runId, parentRunId, tags, metadata, runType, runName);
   }
@@ -121,7 +121,7 @@ export class SigilLlamaIndexHandler extends SigilFrameworkHandler {
     parentRunId?: string,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onRetrieverStart(serialized, runId, parentRunId, tags, metadata, runName);
   }
@@ -137,7 +137,7 @@ export class SigilLlamaIndexHandler extends SigilFrameworkHandler {
 
 export function createSigilLlamaIndexHandler(
   client: SigilClient,
-  options: FrameworkHandlerOptions = {}
+  options: FrameworkHandlerOptions = {},
 ): SigilLlamaIndexHandler {
   return new SigilLlamaIndexHandler(client, options);
 }
@@ -145,7 +145,7 @@ export function createSigilLlamaIndexHandler(
 export function attachSigilLlamaIndexCallbacks(
   callbackManager: LlamaIndexCallbackManager,
   client: SigilClient,
-  options: FrameworkHandlerOptions = {}
+  options: FrameworkHandlerOptions = {},
 ): LlamaIndexCallbackRegistration {
   const existing = registrations.get(callbackManager);
   if (existing !== undefined) {
@@ -187,7 +187,7 @@ export function attachSigilLlamaIndexCallbacks(
         },
         undefined,
         buildMetadata(event, detail),
-        'llamaindex.llm'
+        'llamaindex.llm',
       );
     });
   };
@@ -196,9 +196,10 @@ export function attachSigilLlamaIndexCallbacks(
     safelyRun(async () => {
       const detail = asRecord(event.detail);
       const eventId = resolveEventId(detail);
-      const runId = eventId.length > 0
-        ? llmRunIds.get(eventId) ?? `llama_llm:${eventId}`
-        : llmFallbackRunIds[llmFallbackRunIds.length - 1];
+      const runId =
+        eventId.length > 0
+          ? (llmRunIds.get(eventId) ?? `llama_llm:${eventId}`)
+          : llmFallbackRunIds[llmFallbackRunIds.length - 1];
       if (runId === undefined) {
         return;
       }
@@ -214,9 +215,7 @@ export function attachSigilLlamaIndexCallbacks(
     safelyRun(async () => {
       const detail = asRecord(event.detail);
       const eventId = resolveEventId(detail);
-      const runId = eventId.length > 0
-        ? llmRunIds.get(eventId) ?? `llama_llm:${eventId}`
-        : llmFallbackRunIds.pop();
+      const runId = eventId.length > 0 ? (llmRunIds.get(eventId) ?? `llama_llm:${eventId}`) : llmFallbackRunIds.pop();
       if (runId === undefined) {
         return;
       }
@@ -242,7 +241,7 @@ export function attachSigilLlamaIndexCallbacks(
             token_usage: usage,
           },
         },
-        runId
+        runId,
       );
     });
   };
@@ -251,9 +250,7 @@ export function attachSigilLlamaIndexCallbacks(
     safelyRun(async () => {
       const detail = asRecord(event.detail);
       const eventId = resolveEventId(detail);
-      const runId = eventId.length > 0
-        ? llmRunIds.get(eventId) ?? `llama_llm:${eventId}`
-        : llmFallbackRunIds.pop();
+      const runId = eventId.length > 0 ? (llmRunIds.get(eventId) ?? `llama_llm:${eventId}`) : llmFallbackRunIds.pop();
       if (runId === undefined) {
         return;
       }
@@ -286,7 +283,7 @@ export function attachSigilLlamaIndexCallbacks(
         undefined,
         undefined,
         buildMetadata(event, detail, { event_id: callId }),
-        toolName
+        toolName,
       );
     });
   };
@@ -314,7 +311,7 @@ export function attachSigilLlamaIndexCallbacks(
         runType: 'query',
         name: 'llamaindex.query',
         queryField: 'query',
-      })
+      }),
     );
   };
 
@@ -329,7 +326,7 @@ export function attachSigilLlamaIndexCallbacks(
         runType: 'synthesize',
         name: 'llamaindex.synthesize',
         queryField: 'query',
-      })
+      }),
     );
   };
 
@@ -353,7 +350,7 @@ export function attachSigilLlamaIndexCallbacks(
         undefined,
         undefined,
         buildMetadata(event, detail),
-        'llamaindex.retrieve'
+        'llamaindex.retrieve',
       );
     });
   };
@@ -376,7 +373,7 @@ export function attachSigilLlamaIndexCallbacks(
         runType: 'agent',
         name: 'llamaindex.agent',
         idPath: ['startStep', 'id'],
-      })
+      }),
     );
   };
 
@@ -426,7 +423,7 @@ export function attachSigilLlamaIndexCallbacks(
 export function withSigilLlamaIndexCallbacks<T extends CallbackConfig>(
   config: T | undefined,
   client: SigilClient,
-  options: FrameworkHandlerOptions = {}
+  options: FrameworkHandlerOptions = {},
 ): T & { callbackManager: LlamaIndexCallbackManager } {
   const base = { ...(config ?? {}) } as CallbackConfig;
   const existingManager = base.callbackManager;
@@ -459,7 +456,7 @@ type ChainStartConfig = {
 async function runChainStart(
   handler: SigilLlamaIndexHandler,
   event: LlamaIndexEvent,
-  config: ChainStartConfig
+  config: ChainStartConfig,
 ): Promise<void> {
   const detail = asRecord(event.detail);
   const eventId = resolveEventId(detail, config.idPath);
@@ -483,7 +480,7 @@ async function runChainEnd(
   handler: SigilLlamaIndexHandler,
   event: LlamaIndexEvent,
   runPrefix: string,
-  idPath?: string[]
+  idPath?: string[],
 ): Promise<void> {
   const detail = asRecord(event.detail);
   const eventId = resolveEventId(detail, idPath);
@@ -494,11 +491,7 @@ async function runChainEnd(
   await handler.handleChainEnd(undefined, `${runPrefix}:${eventId}`);
 }
 
-function buildMetadata(
-  event: LlamaIndexEvent,
-  detail: AnyRecord | undefined,
-  extras?: AnyRecord
-): AnyRecord {
+function buildMetadata(event: LlamaIndexEvent, detail: AnyRecord | undefined, extras?: AnyRecord): AnyRecord {
   const eventId = resolveEventId(detail);
   const conversationId = resolveConversationId(detail);
 
@@ -583,10 +576,11 @@ function resolveModelName(response: AnyRecord | undefined): string {
 
 function resolveStopReason(response: AnyRecord | undefined): string | undefined {
   const raw = read(response, 'raw');
-  const finishReason = asString(read(response, 'finish_reason'))
-    || asString(read(response, 'finishReason'))
-    || asString(read(raw, 'finish_reason'))
-    || asString(read(raw, 'finishReason'));
+  const finishReason =
+    asString(read(response, 'finish_reason')) ||
+    asString(read(response, 'finishReason')) ||
+    asString(read(raw, 'finish_reason')) ||
+    asString(read(raw, 'finishReason'));
   return finishReason.length > 0 ? finishReason : undefined;
 }
 
@@ -598,8 +592,7 @@ function resolveUsage(response: AnyRecord | undefined): AnyRecord | undefined {
   }
 
   const promptTokens = asNumber(read(usage, 'prompt_tokens')) ?? asNumber(read(usage, 'promptTokens'));
-  const completionTokens = asNumber(read(usage, 'completion_tokens'))
-    ?? asNumber(read(usage, 'completionTokens'));
+  const completionTokens = asNumber(read(usage, 'completion_tokens')) ?? asNumber(read(usage, 'completionTokens'));
   const totalTokens = asNumber(read(usage, 'total_tokens')) ?? asNumber(read(usage, 'totalTokens'));
 
   if (promptTokens === undefined && completionTokens === undefined && totalTokens === undefined) {

--- a/js/src/frameworks/openai-agents/index.ts
+++ b/js/src/frameworks/openai-agents/index.ts
@@ -1,5 +1,5 @@
 import type { SigilClient } from '../../client.js';
-import { SigilFrameworkHandler, type FrameworkHandlerOptions } from '../shared.js';
+import { type FrameworkHandlerOptions, SigilFrameworkHandler } from '../shared.js';
 
 export type { FrameworkHandlerOptions };
 
@@ -30,7 +30,7 @@ export class SigilOpenAIAgentsHandler extends SigilFrameworkHandler {
     extraParams?: Record<string, unknown>,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onLLMStart(serialized, prompts, runId, parentRunId, extraParams, tags, metadata, runName);
   }
@@ -43,7 +43,7 @@ export class SigilOpenAIAgentsHandler extends SigilFrameworkHandler {
     extraParams?: Record<string, unknown>,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onChatModelStart(serialized, messages, runId, parentRunId, extraParams, tags, metadata, runName);
   }
@@ -67,7 +67,7 @@ export class SigilOpenAIAgentsHandler extends SigilFrameworkHandler {
     parentRunId?: string,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onToolStart(serialized, input, runId, parentRunId, tags, metadata, runName);
   }
@@ -88,7 +88,7 @@ export class SigilOpenAIAgentsHandler extends SigilFrameworkHandler {
     tags?: string[],
     metadata?: Record<string, unknown>,
     runType?: string,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onChainStart(serialized, runId, parentRunId, tags, metadata, runType, runName);
   }
@@ -108,7 +108,7 @@ export class SigilOpenAIAgentsHandler extends SigilFrameworkHandler {
     parentRunId?: string,
     tags?: string[],
     metadata?: Record<string, unknown>,
-    runName?: string
+    runName?: string,
   ): Promise<void> {
     this.onRetrieverStart(serialized, runId, parentRunId, tags, metadata, runName);
   }
@@ -124,7 +124,7 @@ export class SigilOpenAIAgentsHandler extends SigilFrameworkHandler {
 
 export function createSigilOpenAIAgentsHandler(
   client: SigilClient,
-  options: FrameworkHandlerOptions = {}
+  options: FrameworkHandlerOptions = {},
 ): SigilOpenAIAgentsHandler {
   return new SigilOpenAIAgentsHandler(client, options);
 }
@@ -132,11 +132,11 @@ export function createSigilOpenAIAgentsHandler(
 export function withSigilOpenAIAgentsHooks(
   target: OpenAIAgentsHookTarget,
   client: SigilClient,
-  options: FrameworkHandlerOptions = {}
+  options: FrameworkHandlerOptions = {},
 ): OpenAIAgentsHookRegistration {
   if (!isHookTarget(target)) {
     throw new Error(
-      'withSigilOpenAIAgentsHooks expects an OpenAI Agents Runner or Agent (RunHooks/AgentHooks emitter).'
+      'withSigilOpenAIAgentsHooks expects an OpenAI Agents Runner or Agent (RunHooks/AgentHooks emitter).',
     );
   }
 
@@ -176,10 +176,7 @@ export function withSigilOpenAIAgentsHooks(
     return created;
   };
 
-  const makeContextMetadata = (
-    context: unknown,
-    extras?: Record<string, unknown>
-  ): Record<string, unknown> => {
+  const makeContextMetadata = (context: unknown, extras?: Record<string, unknown>): Record<string, unknown> => {
     const conversationId = resolveConversationId(context);
     return {
       conversation_id: conversationId,
@@ -212,7 +209,7 @@ export function withSigilOpenAIAgentsHooks(
       },
       undefined,
       makeContextMetadata(context),
-      agentName
+      agentName,
     );
   };
 
@@ -235,7 +232,7 @@ export function withSigilOpenAIAgentsHooks(
           token_usage: usage,
         },
       },
-      runId
+      runId,
     );
 
     const contextId = getContextId(context);
@@ -264,11 +261,7 @@ export function withSigilOpenAIAgentsHooks(
     await handler.handleLLMError(error, runId);
   };
 
-  const onAgentHandoff = async (
-    context: unknown,
-    fromAgent: unknown,
-    toAgent: unknown
-  ): Promise<void> => {
+  const onAgentHandoff = async (context: unknown, fromAgent: unknown, toAgent: unknown): Promise<void> => {
     const stack = getStack(context);
     const parentRunId = stack.length > 0 ? stack[stack.length - 1] : undefined;
     const handoffRunId = nextRunId('openai_handoff');
@@ -285,17 +278,12 @@ export function withSigilOpenAIAgentsHooks(
       undefined,
       makeContextMetadata(context),
       'handoff',
-      'agent_handoff'
+      'agent_handoff',
     );
     await handler.handleChainEnd(undefined, handoffRunId);
   };
 
-  const onToolStart = async (
-    context: unknown,
-    _agent: unknown,
-    tool: unknown,
-    details: unknown
-  ): Promise<void> => {
+  const onToolStart = async (context: unknown, _agent: unknown, tool: unknown, details: unknown): Promise<void> => {
     const callId = resolveToolCallId(details);
     const contextId = getContextId(context);
     const runId = callId.length > 0 ? callId : nextRunId('openai_tool');
@@ -324,7 +312,7 @@ export function withSigilOpenAIAgentsHooks(
       makeContextMetadata(context, {
         event_id: callId,
       }),
-      toolName
+      toolName,
     );
   };
 
@@ -536,9 +524,7 @@ function normalizeOutputText(value: unknown): string {
   }
 
   if (Array.isArray(value)) {
-    const parts = value
-      .map((entry) => normalizeOutputText(entry))
-      .filter((entry) => entry.length > 0);
+    const parts = value.map((entry) => normalizeOutputText(entry)).filter((entry) => entry.length > 0);
     return parts.join(' ').trim();
   }
 
@@ -602,7 +588,7 @@ function resolveConversationId(context: unknown): string {
       asString(read(nestedContext, 'sessionId')),
       asString(read(nestedContext, 'session_id')),
       asString(read(nestedContext, 'groupId')),
-      asString(read(nestedContext, 'group_id'))
+      asString(read(nestedContext, 'group_id')),
     );
   }
 
@@ -623,9 +609,8 @@ function resolveModelName(agent: unknown): string {
 
   const nestedModel = read(agent, 'model');
   if (isRecord(nestedModel)) {
-    const nested = asString(read(nestedModel, 'model'))
-      || asString(read(nestedModel, 'name'))
-      || asString(read(nestedModel, 'id'));
+    const nested =
+      asString(read(nestedModel, 'model')) || asString(read(nestedModel, 'name')) || asString(read(nestedModel, 'id'));
     if (nested.length > 0) {
       return nested;
     }

--- a/js/src/frameworks/shared.ts
+++ b/js/src/frameworks/shared.ts
@@ -1,28 +1,12 @@
-import { SpanKind, SpanStatusCode, trace, type Span, type Tracer } from '@opentelemetry/api';
-import type {
-  GenerationRecorder,
-  GenerationResult,
-  Message,
-  TokenUsage,
-  ToolExecutionRecorder,
-} from '../types.js';
+import { type Span, SpanKind, SpanStatusCode, type Tracer, trace } from '@opentelemetry/api';
 import type { SigilClient } from '../client.js';
+import type { GenerationRecorder, GenerationResult, Message, TokenUsage, ToolExecutionRecorder } from '../types.js';
 
 type AnyRecord = Record<string, unknown>;
 
-type ProviderResolverFn = (context: {
-  modelName: string;
-  serialized?: unknown;
-  invocationParams?: unknown;
-}) => string;
+type ProviderResolverFn = (context: { modelName: string; serialized?: unknown; invocationParams?: unknown }) => string;
 
-type FrameworkName =
-  | 'langchain'
-  | 'langgraph'
-  | 'openai-agents'
-  | 'llamaindex'
-  | 'google-adk'
-  | 'vercel-ai-sdk';
+type FrameworkName = 'langchain' | 'langgraph' | 'openai-agents' | 'llamaindex' | 'google-adk' | 'vercel-ai-sdk';
 
 const frameworkInstrumentationName = 'github.com/grafana/sigil/sdks/js/frameworks';
 const spanAttrOperationName = 'gen_ai.operation.name';
@@ -100,7 +84,7 @@ export class SigilFrameworkHandler {
     private readonly client: SigilClient,
     private readonly frameworkName: FrameworkName,
     private readonly frameworkLanguage: 'javascript',
-    options: FrameworkHandlerOptions = {}
+    options: FrameworkHandlerOptions = {},
   ) {
     this.agentName = options.agentName;
     this.agentVersion = options.agentVersion;
@@ -120,7 +104,7 @@ export class SigilFrameworkHandler {
     extraParams?: AnyRecord,
     callbackTags?: string[],
     callbackMetadata?: AnyRecord,
-    runName?: string
+    runName?: string,
   ): void {
     const runKey = String(runId);
     if (runKey.length === 0 || this.runs.has(runKey)) {
@@ -145,9 +129,7 @@ export class SigilFrameworkHandler {
     });
 
     const payload = this.startPayload(runKey, provider, modelName, context);
-    const recorder = stream
-      ? this.client.startStreamingGeneration(payload)
-      : this.client.startGeneration(payload);
+    const recorder = stream ? this.client.startStreamingGeneration(payload) : this.client.startGeneration(payload);
 
     this.runs.set(runKey, {
       recorder,
@@ -166,7 +148,7 @@ export class SigilFrameworkHandler {
     extraParams?: AnyRecord,
     callbackTags?: string[],
     callbackMetadata?: AnyRecord,
-    runName?: string
+    runName?: string,
   ): void {
     const runKey = String(runId);
     if (runKey.length === 0 || this.runs.has(runKey)) {
@@ -191,9 +173,7 @@ export class SigilFrameworkHandler {
     });
 
     const payload = this.startPayload(runKey, provider, modelName, context);
-    const recorder = stream
-      ? this.client.startStreamingGeneration(payload)
-      : this.client.startGeneration(payload);
+    const recorder = stream ? this.client.startStreamingGeneration(payload) : this.client.startGeneration(payload);
 
     this.runs.set(runKey, {
       recorder,
@@ -296,7 +276,7 @@ export class SigilFrameworkHandler {
     callbackTags?: string[],
     callbackMetadata?: AnyRecord,
     runName?: string,
-    extraParams?: AnyRecord
+    extraParams?: AnyRecord,
   ): void {
     const runKey = String(runId);
     if (runKey.length === 0 || this.toolRuns.has(runKey)) {
@@ -385,7 +365,7 @@ export class SigilFrameworkHandler {
     callbackMetadata?: AnyRecord,
     callbackRunType?: string,
     runName?: string,
-    extraParams?: AnyRecord
+    extraParams?: AnyRecord,
   ): void {
     const runKey = String(runId);
     if (runKey.length === 0 || this.chainSpans.has(runKey)) {
@@ -427,7 +407,7 @@ export class SigilFrameworkHandler {
     callbackTags?: string[],
     callbackMetadata?: AnyRecord,
     runName?: string,
-    extraParams?: AnyRecord
+    extraParams?: AnyRecord,
   ): void {
     const runKey = String(runId);
     if (runKey.length === 0 || this.retrieverSpans.has(runKey)) {
@@ -462,7 +442,7 @@ export class SigilFrameworkHandler {
     this.endFrameworkSpan(this.retrieverSpans, runId, error);
   }
 
-  private startPayload(runId: string, provider: string, modelName: string, context: FrameworkContext) {
+  private startPayload(_runId: string, provider: string, modelName: string, context: FrameworkContext) {
     return {
       conversationId: context.conversationId,
       agentName: this.agentName,
@@ -513,11 +493,7 @@ export class SigilFrameworkHandler {
     }
   }
 
-  private endFrameworkSpan(
-    spans: Map<string, Span>,
-    runId: string,
-    error: unknown
-  ): void {
+  private endFrameworkSpan(spans: Map<string, Span>, runId: string, error: unknown): void {
     const runKey = String(runId);
     const span = spans.get(runKey);
     if (span === undefined) {
@@ -554,33 +530,34 @@ export class SigilFrameworkHandler {
       params.serialized,
       params.invocationParams,
       params.extraParams,
-      params.callbackMetadata
+      params.callbackMetadata,
     );
     const componentName = resolveComponentName(
       params.serialized,
       params.callbackMetadata,
       params.extraParams,
-      params.runName
+      params.runName,
     );
     const retryAttempt = resolveFrameworkRetryAttempt(
       params.callbackMetadata,
       params.extraParams,
       params.invocationParams,
-      params.serialized
+      params.serialized,
     );
     const parentRunId = normalizeRunID(params.parentRunId);
     const runType = params.runType.trim();
     const frameworkTags = normalizeFrameworkTags(
-      params.callbackTags ?? read(params.extraParams, 'tags') ?? read(params.callbackMetadata, 'tags')
+      params.callbackTags ?? read(params.extraParams, 'tags') ?? read(params.callbackMetadata, 'tags'),
     );
-    const langgraphNode = this.frameworkName === 'langgraph'
-      ? resolveLangGraphNode(params.callbackMetadata, params.extraParams, params.invocationParams, params.serialized)
-      : '';
+    const langgraphNode =
+      this.frameworkName === 'langgraph'
+        ? resolveLangGraphNode(params.callbackMetadata, params.extraParams, params.invocationParams, params.serialized)
+        : '';
     const eventId = resolveFrameworkEventID(
       params.callbackMetadata,
       params.extraParams,
       params.invocationParams,
-      params.serialized
+      params.serialized,
     );
 
     const rawMetadata: Record<string, unknown> = {
@@ -638,7 +615,7 @@ function resolveProvider(
   resolver: 'auto' | ProviderResolverFn,
   modelName: string,
   serialized: unknown,
-  invocationParams: unknown
+  invocationParams: unknown,
 ): string {
   const explicit = normalizeProvider(explicitProvider);
   if (explicit.length > 0) {
@@ -651,7 +628,7 @@ function resolveProvider(
         modelName,
         serialized,
         invocationParams,
-      })
+      }),
     );
     return resolved.length > 0 ? resolved : 'custom';
   }
@@ -702,7 +679,7 @@ function resolveFrameworkThreadId(
   serialized: unknown,
   invocationParams: AnyRecord | undefined,
   extraParams: AnyRecord | undefined,
-  callbackMetadata: AnyRecord | undefined
+  callbackMetadata: AnyRecord | undefined,
 ): string {
   for (const payload of [callbackMetadata, extraParams, invocationParams, serialized]) {
     const threadId = threadIdFromPayload(payload);
@@ -719,7 +696,7 @@ function resolveFrameworkConversationContext(
   serialized: unknown,
   invocationParams: AnyRecord | undefined,
   extraParams: AnyRecord | undefined,
-  callbackMetadata: AnyRecord | undefined
+  callbackMetadata: AnyRecord | undefined,
 ): { conversationId: string; threadId: string } {
   for (const payload of [callbackMetadata, extraParams, invocationParams, serialized]) {
     const conversationId = conversationIdFromPayload(payload);
@@ -806,7 +783,7 @@ function resolveComponentName(
   serialized: unknown,
   callbackMetadata: AnyRecord | undefined,
   extraParams: AnyRecord | undefined,
-  runName: string | undefined
+  runName: string | undefined,
 ): string {
   const candidates = [
     asString(read(serialized, 'name')),
@@ -829,7 +806,7 @@ function resolveLangGraphNode(
   callbackMetadata: AnyRecord | undefined,
   extraParams: AnyRecord | undefined,
   invocationParams: AnyRecord | undefined,
-  serialized: unknown
+  serialized: unknown,
 ): string {
   for (const payload of [callbackMetadata, extraParams, invocationParams, asRecord(serialized)]) {
     const candidate = langGraphNodeFromPayload(payload);
@@ -947,11 +924,7 @@ function normalizeFrameworkMetadata(raw: Record<string, unknown>): Record<string
   return out;
 }
 
-function normalizeFrameworkMetadataValue(
-  value: unknown,
-  depth: number,
-  seen: WeakSet<object>
-): unknown {
+function normalizeFrameworkMetadataValue(value: unknown, depth: number, seen: WeakSet<object>): unknown {
   if (depth > maxFrameworkMetadataDepth || value === undefined) {
     return undefined;
   }
@@ -1207,10 +1180,10 @@ function mapUsage(rawUsage: unknown): TokenUsage | undefined {
 function inferProviderFromModelName(modelName: string): string {
   const normalized = modelName.trim().toLowerCase();
   if (
-    normalized.startsWith('gpt-')
-    || normalized.startsWith('o1')
-    || normalized.startsWith('o3')
-    || normalized.startsWith('o4')
+    normalized.startsWith('gpt-') ||
+    normalized.startsWith('o1') ||
+    normalized.startsWith('o3') ||
+    normalized.startsWith('o4')
   ) {
     return 'openai';
   }

--- a/js/src/frameworks/vercel-ai-sdk/hooks.ts
+++ b/js/src/frameworks/vercel-ai-sdk/hooks.ts
@@ -1,10 +1,5 @@
-import type { SigilClient } from "../../client.js";
-import type {
-  GenerationMode,
-  GenerationRecorder,
-  Message,
-  ToolExecutionRecorder,
-} from "../../types.js";
+import type { SigilClient } from '../../client.js';
+import type { GenerationMode, GenerationRecorder, Message, ToolExecutionRecorder } from '../../types.js';
 import {
   buildFrameworkMetadata,
   buildFrameworkTags,
@@ -19,7 +14,7 @@ import {
   parseToolCallStart,
   resolveConversationId,
   shouldTreatStepAsError,
-} from "./mapping.js";
+} from './mapping.js';
 import type {
   CallOptions,
   ConversationResolution,
@@ -29,7 +24,7 @@ import type {
   StreamTextHooks,
   ToolCallFinishEvent,
   ToolCallStartEvent,
-} from "./types.js";
+} from './types.js';
 
 interface StepState {
   recorder?: GenerationRecorder;
@@ -65,7 +60,7 @@ export class SigilVercelAiSdkInstrumentation {
   private readonly captureOutputs: boolean;
   private readonly extraTags: Record<string, string>;
   private readonly extraMetadata: Record<string, unknown>;
-  private readonly resolveConversationIdFn: SigilVercelAiSdkOptions["resolveConversationId"];
+  private readonly resolveConversationIdFn: SigilVercelAiSdkOptions['resolveConversationId'];
   private callSequence = 0;
 
   constructor(
@@ -82,26 +77,16 @@ export class SigilVercelAiSdkInstrumentation {
   }
 
   generateTextHooks(callOptions: CallOptions = {}): GenerateTextHooks {
-    return this.createHooks(
-      "SYNC",
-      "generateText",
-      callOptions,
-      false,
-    ) as GenerateTextHooks;
+    return this.createHooks('SYNC', 'generateText', callOptions, false) as GenerateTextHooks;
   }
 
   streamTextHooks(callOptions: CallOptions = {}): StreamTextHooks {
-    return this.createHooks(
-      "STREAM",
-      "streamText",
-      callOptions,
-      true,
-    ) as StreamTextHooks;
+    return this.createHooks('STREAM', 'streamText', callOptions, true) as StreamTextHooks;
   }
 
   private createHooks(
     mode: GenerationMode,
-    operationName: "generateText" | "streamText",
+    operationName: 'generateText' | 'streamText',
     callOptions: CallOptions,
     includeStreamHandlers: boolean,
   ): GenerateTextHooks | StreamTextHooks {
@@ -114,11 +99,8 @@ export class SigilVercelAiSdkInstrumentation {
       nextSyntheticStepNumber: 0,
     };
 
-    const explicitConversationId = normalizeOptionalString(
-      callOptions.conversationId,
-    );
-    const callAgentName =
-      normalizeOptionalString(callOptions.agentName) ?? this.agentName;
+    const explicitConversationId = normalizeOptionalString(callOptions.conversationId);
+    const callAgentName = normalizeOptionalString(callOptions.agentName) ?? this.agentName;
     const mergedCallMetadata = {
       ...this.extraMetadata,
       ...(callOptions.extraMetadata ?? {}),
@@ -127,13 +109,10 @@ export class SigilVercelAiSdkInstrumentation {
     let streamObservedStartAt: Date | undefined;
     let hasCreatedStreamStepState = false;
     const noteStreamObservedStartAt = (timestamp: Date): void => {
-      if (mode !== "STREAM") {
+      if (mode !== 'STREAM') {
         return;
       }
-      if (
-        streamObservedStartAt === undefined ||
-        timestamp.getTime() < streamObservedStartAt.getTime()
-      ) {
+      if (streamObservedStartAt === undefined || timestamp.getTime() < streamObservedStartAt.getTime()) {
         streamObservedStartAt = timestamp;
       }
     };
@@ -143,7 +122,7 @@ export class SigilVercelAiSdkInstrumentation {
       startedAt: Date;
     }): GenerationRecorder => {
       const model = mapModelFromStepStart(params.stepStartEvent);
-      return mode === "STREAM"
+      return mode === 'STREAM'
         ? this.client.startStreamingGeneration({
             conversationId: params.conversationId,
             agentName: callAgentName,
@@ -155,11 +134,7 @@ export class SigilVercelAiSdkInstrumentation {
               name: model.modelName,
             },
             tags,
-            metadata: buildFrameworkMetadata(
-              mergedCallMetadata,
-              undefined,
-              undefined,
-            ),
+            metadata: buildFrameworkMetadata(mergedCallMetadata, undefined, undefined),
             startedAt: params.startedAt,
           })
         : this.client.startGeneration({
@@ -173,18 +148,11 @@ export class SigilVercelAiSdkInstrumentation {
               name: model.modelName,
             },
             tags,
-            metadata: buildFrameworkMetadata(
-              mergedCallMetadata,
-              undefined,
-              undefined,
-            ),
+            metadata: buildFrameworkMetadata(mergedCallMetadata, undefined, undefined),
             startedAt: params.startedAt,
           });
     };
-    const ensureStepRecorder = (
-      stepState: StepState,
-      conversationId: string,
-    ): GenerationRecorder => {
+    const ensureStepRecorder = (stepState: StepState, conversationId: string): GenerationRecorder => {
       if (stepState.recorder !== undefined) {
         return stepState.recorder;
       }
@@ -211,7 +179,7 @@ export class SigilVercelAiSdkInstrumentation {
 
       const stepState: StepState = {
         recorder:
-          mode === "STREAM" && hasStepStartModelRef(params.stepStartEvent)
+          mode === 'STREAM' && hasStepStartModelRef(params.stepStartEvent)
             ? createGenerationRecorder({
                 stepStartEvent: params.stepStartEvent,
                 conversationId: conversation.conversationId,
@@ -229,7 +197,7 @@ export class SigilVercelAiSdkInstrumentation {
         hasToolCalls: false,
       };
       state.stepStates.set(params.stepNumber, stepState);
-      if (mode === "STREAM") {
+      if (mode === 'STREAM') {
         hasCreatedStreamStepState = true;
       }
       return stepState;
@@ -238,10 +206,7 @@ export class SigilVercelAiSdkInstrumentation {
       eventStepNumber: unknown;
       responseModel: string | undefined;
     }): { stepNumber: number; stepState: StepState } => {
-      const resolvedStepNumber = resolveStepNumberForEvent(
-        state,
-        params.eventStepNumber,
-      );
+      const resolvedStepNumber = resolveStepNumberForEvent(state, params.eventStepNumber);
       if (resolvedStepNumber !== undefined) {
         const resolvedState = state.stepStates.get(resolvedStepNumber);
         if (resolvedState !== undefined) {
@@ -253,25 +218,15 @@ export class SigilVercelAiSdkInstrumentation {
         { stepNumber: params.eventStepNumber },
         state.nextSyntheticStepNumber,
       );
-      state.nextSyntheticStepNumber = Math.max(
-        state.nextSyntheticStepNumber + 1,
-        syntheticStepNumber + 1,
-      );
+      state.nextSyntheticStepNumber = Math.max(state.nextSyntheticStepNumber + 1, syntheticStepNumber + 1);
 
       const syntheticStepStartEvent: StepStartEvent = {
         stepNumber: syntheticStepNumber,
-        model:
-          params.responseModel !== undefined
-            ? { modelId: params.responseModel }
-            : undefined,
+        model: params.responseModel !== undefined ? { modelId: params.responseModel } : undefined,
       };
       const now = new Date();
       const syntheticStartedAt =
-        mode === "STREAM"
-          ? hasCreatedStreamStepState
-            ? now
-            : (streamObservedStartAt ?? callStartedAt)
-          : now;
+        mode === 'STREAM' ? (hasCreatedStreamStepState ? now : (streamObservedStartAt ?? callStartedAt)) : now;
       const syntheticStepState = createStepState({
         stepNumber: syntheticStepNumber,
         stepStartEvent: syntheticStepStartEvent,
@@ -284,10 +239,7 @@ export class SigilVercelAiSdkInstrumentation {
       eventStepNumber: unknown;
       observedAt: Date;
     }): { stepNumber: number; stepState: StepState } => {
-      const resolvedStepNumber = resolveStepNumberForEvent(
-        state,
-        params.eventStepNumber,
-      );
+      const resolvedStepNumber = resolveStepNumberForEvent(state, params.eventStepNumber);
       if (resolvedStepNumber !== undefined) {
         const resolvedState = state.stepStates.get(resolvedStepNumber);
         if (resolvedState !== undefined) {
@@ -299,10 +251,7 @@ export class SigilVercelAiSdkInstrumentation {
         { stepNumber: params.eventStepNumber },
         state.nextSyntheticStepNumber,
       );
-      state.nextSyntheticStepNumber = Math.max(
-        state.nextSyntheticStepNumber + 1,
-        syntheticStepNumber + 1,
-      );
+      state.nextSyntheticStepNumber = Math.max(state.nextSyntheticStepNumber + 1, syntheticStepNumber + 1);
 
       const syntheticStepStartEvent: StepStartEvent = {
         stepNumber: syntheticStepNumber,
@@ -316,7 +265,7 @@ export class SigilVercelAiSdkInstrumentation {
       return { stepNumber: syntheticStepNumber, stepState: syntheticStepState };
     };
     const parseJSONIfPossible = (value: string | undefined): unknown => {
-      if (typeof value !== "string") {
+      if (typeof value !== 'string') {
         return undefined;
       }
       const trimmed = value.trim();
@@ -363,11 +312,11 @@ export class SigilVercelAiSdkInstrumentation {
           continue;
         }
         for (const part of message.parts) {
-          if (part.type === "tool_call") {
+          if (part.type === 'tool_call') {
             toolCalls.push(part.toolCall);
             continue;
           }
-          if (part.type === "tool_result") {
+          if (part.type === 'tool_result') {
             toolResults.push(part.toolResult);
           }
         }
@@ -381,21 +330,13 @@ export class SigilVercelAiSdkInstrumentation {
       conversationId: string;
       output: Message[] | undefined;
     }): Error | undefined => {
-      const { toolCalls, toolResults } = extractToolPartsFromStepOutput(
-        params.output,
-      );
+      const { toolCalls, toolResults } = extractToolPartsFromStepOutput(params.output);
       if (toolResults.length === 0) {
         return undefined;
       }
 
-      const toolCallsByID = new Map<
-        string,
-        { id?: string; name: string; inputJSON?: string }
-      >();
-      const toolCallsByName = new Map<
-        string,
-        Array<{ id?: string; name: string; inputJSON?: string }>
-      >();
+      const toolCallsByID = new Map<string, { id?: string; name: string; inputJSON?: string }>();
+      const toolCallsByName = new Map<string, Array<{ id?: string; name: string; inputJSON?: string }>>();
       for (const toolCall of toolCalls) {
         if (toolCall.id !== undefined) {
           toolCallsByID.set(toolCall.id, toolCall);
@@ -408,16 +349,13 @@ export class SigilVercelAiSdkInstrumentation {
       let firstError: Error | undefined;
       for (const [index, toolResult] of toolResults.entries()) {
         let toolCallID = toolResult.toolCallId;
-        let matchedToolCall =
-          toolCallID !== undefined ? toolCallsByID.get(toolCallID) : undefined;
+        let matchedToolCall = toolCallID !== undefined ? toolCallsByID.get(toolCallID) : undefined;
         if (matchedToolCall === undefined && toolResult.name !== undefined) {
           const matchingByName = toolCallsByName.get(toolResult.name);
           matchedToolCall = matchingByName?.shift();
         }
         if (toolCallID === undefined || toolCallID.length === 0) {
-          toolCallID =
-            matchedToolCall?.id ??
-            `${callID}:step-${params.stepNumber}:tool-${index}`;
+          toolCallID = matchedToolCall?.id ?? `${callID}:step-${params.stepNumber}:tool-${index}`;
         }
 
         if (state.completedToolCallIds.has(toolCallID)) {
@@ -438,14 +376,10 @@ export class SigilVercelAiSdkInstrumentation {
               toolResultPayload.arguments = liveToolState.input;
             }
             if (this.captureOutputs) {
-              toolResultPayload.result =
-                parseJSONIfPossible(toolResult.contentJSON) ??
-                toolResult.content;
+              toolResultPayload.result = parseJSONIfPossible(toolResult.contentJSON) ?? toolResult.content;
             }
             if (toolResult.isError) {
-              liveToolState.recorder.setCallError(
-                toolResult.content ?? new Error("tool call failed"),
-              );
+              liveToolState.recorder.setCallError(toolResult.content ?? new Error('tool call failed'));
             }
             liveToolState.recorder.setResult(toolResultPayload);
           } finally {
@@ -453,11 +387,7 @@ export class SigilVercelAiSdkInstrumentation {
           }
 
           const recorderError = liveToolState.recorder.getError();
-          if (
-            firstError === undefined &&
-            recorderError !== undefined &&
-            !toolResult.isError
-          ) {
+          if (firstError === undefined && recorderError !== undefined && !toolResult.isError) {
             firstError = recorderError;
           }
           state.toolStates.delete(toolCallID);
@@ -467,8 +397,7 @@ export class SigilVercelAiSdkInstrumentation {
           continue;
         }
 
-        const resolvedToolName =
-          toolResult.name ?? matchedToolCall?.name ?? "framework_tool";
+        const resolvedToolName = toolResult.name ?? matchedToolCall?.name ?? 'framework_tool';
         const recorder = this.client.startToolExecution({
           toolName: resolvedToolName,
           toolCallId: toolCallID,
@@ -488,18 +417,13 @@ export class SigilVercelAiSdkInstrumentation {
             completedAt: new Date(),
           };
           if (this.captureInputs) {
-            toolResultPayload.arguments = parseJSONIfPossible(
-              matchedToolCall?.inputJSON,
-            );
+            toolResultPayload.arguments = parseJSONIfPossible(matchedToolCall?.inputJSON);
           }
           if (this.captureOutputs) {
-            toolResultPayload.result =
-              parseJSONIfPossible(toolResult.contentJSON) ?? toolResult.content;
+            toolResultPayload.result = parseJSONIfPossible(toolResult.contentJSON) ?? toolResult.content;
           }
           if (toolResult.isError) {
-            recorder.setCallError(
-              toolResult.content ?? new Error("tool call failed"),
-            );
+            recorder.setCallError(toolResult.content ?? new Error('tool call failed'));
           }
           recorder.setResult(toolResultPayload);
         } finally {
@@ -507,11 +431,7 @@ export class SigilVercelAiSdkInstrumentation {
         }
 
         const recorderError = recorder.getError();
-        if (
-          firstError === undefined &&
-          recorderError !== undefined &&
-          !toolResult.isError
-        ) {
+        if (firstError === undefined && recorderError !== undefined && !toolResult.isError) {
           firstError = recorderError;
         }
         state.completedToolCallIds.add(toolCallID);
@@ -525,17 +445,12 @@ export class SigilVercelAiSdkInstrumentation {
         noteStreamObservedStartAt(new Date());
         const fallbackStep = state.nextSyntheticStepNumber;
         const stepNumber = extractStepNumber(event, fallbackStep);
-        state.nextSyntheticStepNumber = Math.max(
-          state.nextSyntheticStepNumber + 1,
-          stepNumber + 1,
-        );
+        state.nextSyntheticStepNumber = Math.max(state.nextSyntheticStepNumber + 1, stepNumber + 1);
         if (state.stepStates.has(stepNumber)) {
           return;
         }
 
-        const inputMessages = this.captureInputs
-          ? mapInputMessages(event.messages)
-          : [];
+        const inputMessages = this.captureInputs ? mapInputMessages(event.messages) : [];
         createStepState({
           stepNumber,
           stepStartEvent: event,
@@ -550,15 +465,11 @@ export class SigilVercelAiSdkInstrumentation {
           responseModel: response.responseModel,
         });
         const conversation = stepState.conversation;
-        if (
-          stepState.recorder === undefined &&
-          response.responseModel !== undefined
-        ) {
+        if (stepState.recorder === undefined && response.responseModel !== undefined) {
           stepState.stepStartEvent = {
             ...stepState.stepStartEvent,
             model: {
-              ...(stepState.stepStartEvent.model !== null &&
-              typeof stepState.stepStartEvent.model === "object"
+              ...(stepState.stepStartEvent.model !== null && typeof stepState.stepStartEvent.model === 'object'
                 ? stepState.stepStartEvent.model
                 : {}),
               modelId: response.responseModel,
@@ -605,9 +516,7 @@ export class SigilVercelAiSdkInstrumentation {
             completedAt: new Date(),
           });
           if (isError) {
-            recorder.setCallError(
-              event.error ?? new Error("step finished with error"),
-            );
+            recorder.setCallError(event.error ?? new Error('step finished with error'));
           }
         } finally {
           recorder.end();
@@ -623,8 +532,8 @@ export class SigilVercelAiSdkInstrumentation {
         state.stepStates.delete(stepNumber);
         if (stepState.toolCallIds.size > 0) {
           const closeError = isError
-            ? (event.error ?? new Error("parent step failed"))
-            : new Error("tool call did not finish before step completion");
+            ? (event.error ?? new Error('parent step failed'))
+            : new Error('tool call did not finish before step completion');
           closeStepTools(state, stepState, closeError);
         }
         if (recorderError !== undefined) {
@@ -645,14 +554,13 @@ export class SigilVercelAiSdkInstrumentation {
         }
 
         const startedAt = new Date();
-        if (mode === "STREAM") {
+        if (mode === 'STREAM') {
           noteStreamObservedStartAt(startedAt);
         }
-        const { stepNumber, stepState } =
-          resolveOrCreateStepStateForObservedEvent({
-            eventStepNumber: event.stepNumber,
-            observedAt: startedAt,
-          });
+        const { stepNumber, stepState } = resolveOrCreateStepStateForObservedEvent({
+          eventStepNumber: event.stepNumber,
+          observedAt: startedAt,
+        });
 
         const recorder = this.client.startToolExecution({
           toolName: parsed.toolName,
@@ -685,9 +593,7 @@ export class SigilVercelAiSdkInstrumentation {
           return;
         }
         const completedAt =
-          parsed.durationMs !== undefined
-            ? new Date(toolState.startedAt.getTime() + parsed.durationMs)
-            : new Date();
+          parsed.durationMs !== undefined ? new Date(toolState.startedAt.getTime() + parsed.durationMs) : new Date();
 
         try {
           if (parsed.success) {
@@ -706,9 +612,7 @@ export class SigilVercelAiSdkInstrumentation {
             }
             toolState.recorder.setResult(result);
           } else {
-            toolState.recorder.setCallError(
-              parsed.error ?? new Error("tool call failed"),
-            );
+            toolState.recorder.setCallError(parsed.error ?? new Error('tool call failed'));
             toolState.recorder.setResult({ completedAt });
           }
         } finally {
@@ -730,8 +634,7 @@ export class SigilVercelAiSdkInstrumentation {
       const finalizeStreamFailure = (error: unknown): void => {
         const observedAt = new Date();
         const fallbackStreamStartedAt =
-          streamObservedStartAt ??
-          (hasCreatedStreamStepState ? observedAt : callStartedAt);
+          streamObservedStartAt ?? (hasCreatedStreamStepState ? observedAt : callStartedAt);
         noteStreamObservedStartAt(observedAt);
         if (state.stepStates.size === 0) {
           resolveOrCreateStepStateForObservedEvent({
@@ -746,14 +649,10 @@ export class SigilVercelAiSdkInstrumentation {
           let recorder = stepState.recorder;
           if (recorder === undefined) {
             try {
-              recorder = ensureStepRecorder(
-                stepState,
-                stepState.conversation.conversationId,
-              );
+              recorder = ensureStepRecorder(stepState, stepState.conversation.conversationId);
             } catch (error) {
               if (firstError === undefined) {
-                firstError =
-                  error instanceof Error ? error : new Error(String(error));
+                firstError = error instanceof Error ? error : new Error(String(error));
               }
               if (stepState.toolCallIds.size > 0) {
                 closeStepTools(state, stepState, error);
@@ -825,7 +724,7 @@ export class SigilVercelAiSdkInstrumentation {
 }
 
 function unwrapStreamError(event: unknown): unknown {
-  if (event === null || typeof event !== "object" || !("error" in event)) {
+  if (event === null || typeof event !== 'object' || !('error' in event)) {
     return event;
   }
   return (event as { error?: unknown }).error;
@@ -834,23 +733,19 @@ function unwrapStreamError(event: unknown): unknown {
 function unwrapStreamAbortError(event: unknown): unknown {
   const unwrapped = unwrapStreamError(event);
   if (unwrapped === undefined || unwrapped === null) {
-    return new Error("stream aborted");
+    return new Error('stream aborted');
   }
   if (unwrapped instanceof Error) {
     return unwrapped;
   }
-  if (typeof unwrapped === "string") {
+  if (typeof unwrapped === 'string') {
     const trimmed = unwrapped.trim();
-    return new Error(trimmed.length > 0 ? trimmed : "stream aborted");
+    return new Error(trimmed.length > 0 ? trimmed : 'stream aborted');
   }
-  return new Error("stream aborted");
+  return new Error('stream aborted');
 }
 
-function closeStepTools(
-  state: CallState,
-  stepState: StepState,
-  error: unknown,
-): void {
+function closeStepTools(state: CallState, stepState: StepState, error: unknown): void {
   for (const toolCallId of stepState.toolCallIds) {
     const toolState = state.toolStates.get(toolCallId);
     if (toolState === undefined) {
@@ -882,10 +777,7 @@ function closeAllTools(state: CallState, error: unknown): void {
   }
 }
 
-function resolveStepNumberForEvent(
-  state: CallState,
-  eventStepNumber: unknown,
-): number | undefined {
+function resolveStepNumberForEvent(state: CallState, eventStepNumber: unknown): number | undefined {
   const parsed = parseOptionalStepNumber(eventStepNumber);
   if (parsed !== undefined) {
     if (state.stepStates.has(parsed)) {
@@ -903,13 +795,13 @@ function resolveStepNumberForEvent(
 }
 
 function parseOptionalStepNumber(value: unknown): number | undefined {
-  if (typeof value === "number") {
+  if (typeof value === 'number') {
     if (!Number.isFinite(value) || value < 0) {
       return undefined;
     }
     return Math.trunc(value);
   }
-  if (typeof value === "string") {
+  if (typeof value === 'string') {
     const trimmed = value.trim();
     if (trimmed.length === 0) {
       return undefined;
@@ -925,25 +817,19 @@ function parseOptionalStepNumber(value: unknown): number | undefined {
 
 function hasStepStartModelRef(event: StepStartEvent): boolean {
   const model = event.model;
-  if (model === null || typeof model !== "object") {
+  if (model === null || typeof model !== 'object') {
     return false;
   }
   const modelRef = model as Record<string, unknown>;
-  return (
-    hasNonEmptyString(modelRef.modelId) ||
-    hasNonEmptyString(modelRef.id) ||
-    hasNonEmptyString(modelRef.name)
-  );
+  return hasNonEmptyString(modelRef.modelId) || hasNonEmptyString(modelRef.id) || hasNonEmptyString(modelRef.name);
 }
 
 function hasNonEmptyString(value: unknown): boolean {
-  return typeof value === "string" && value.trim().length > 0;
+  return typeof value === 'string' && value.trim().length > 0;
 }
 
-function normalizeOptionalString(
-  value: string | undefined,
-): string | undefined {
-  if (typeof value !== "string") {
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  if (typeof value !== 'string') {
     return undefined;
   }
   const trimmed = value.trim();

--- a/js/src/frameworks/vercel-ai-sdk/index.ts
+++ b/js/src/frameworks/vercel-ai-sdk/index.ts
@@ -2,6 +2,7 @@ import type { SigilClient } from '../../client.js';
 import { SigilVercelAiSdkInstrumentation } from './hooks.js';
 import type { SigilVercelAiSdkOptions } from './types.js';
 
+export { SigilVercelAiSdkInstrumentation } from './hooks.js';
 export {
   buildFrameworkMetadata,
   buildFrameworkTags,
@@ -18,7 +19,6 @@ export {
   parseToolCallStart,
   resolveConversationId,
 } from './mapping.js';
-export { SigilVercelAiSdkInstrumentation } from './hooks.js';
 export type {
   CallOptions,
   ConversationResolution,
@@ -36,7 +36,7 @@ export type {
 
 export function createSigilVercelAiSdk(
   client: SigilClient,
-  options: SigilVercelAiSdkOptions = {}
+  options: SigilVercelAiSdkOptions = {},
 ): SigilVercelAiSdkInstrumentation {
   return new SigilVercelAiSdkInstrumentation(client, options);
 }

--- a/js/src/frameworks/vercel-ai-sdk/mapping.ts
+++ b/js/src/frameworks/vercel-ai-sdk/mapping.ts
@@ -42,7 +42,7 @@ export function buildFrameworkTags(extraTags: Record<string, string> | undefined
 export function buildFrameworkMetadata(
   extraMetadata: Record<string, unknown> | undefined,
   stepType: string | undefined,
-  reasoningText: string | undefined
+  reasoningText: string | undefined,
 ): Record<string, unknown> {
   const raw: Record<string, unknown> = {
     ...(extraMetadata ?? {}),
@@ -145,20 +145,19 @@ export function mapUsageFromStepFinish(event: StepFinishEvent): TokenUsage | und
   const cacheCreationTokens = numberFromCandidates([inputDetails?.cacheCreationTokens]);
   const reasoningTokens = numberFromCandidates([outputDetails?.reasoningTokens]);
 
-  const hasUsagePayload = (
-    inputTokens !== undefined
-    || outputTokens !== undefined
-    || totalTokens !== undefined
-    || inputDetails !== undefined
-    || outputDetails !== undefined
-  );
+  const hasUsagePayload =
+    inputTokens !== undefined ||
+    outputTokens !== undefined ||
+    totalTokens !== undefined ||
+    inputDetails !== undefined ||
+    outputDetails !== undefined;
   if (!hasUsagePayload) {
     return undefined;
   }
 
   const resolvedInput = inputTokens ?? 0;
   const resolvedOutput = outputTokens ?? 0;
-  const resolvedTotal = totalTokens ?? (resolvedInput + resolvedOutput);
+  const resolvedTotal = totalTokens ?? resolvedInput + resolvedOutput;
 
   return {
     inputTokens: resolvedInput,
@@ -252,13 +251,15 @@ export function mapStepOutput(event: StepFinishEvent): StepOutputMapping {
   };
 }
 
-export function parseToolCallStart(event: ToolCallStartEvent): {
-  toolCallId: string;
-  toolName: string;
-  input: unknown;
-  toolType?: string;
-  description?: string;
-} | undefined {
+export function parseToolCallStart(event: ToolCallStartEvent):
+  | {
+      toolCallId: string;
+      toolName: string;
+      input: unknown;
+      toolType?: string;
+      description?: string;
+    }
+  | undefined {
   const toolCall = asRecord(event.toolCall);
   const toolCallId = asString(toolCall?.toolCallId);
   if (toolCallId.length === 0) {
@@ -279,13 +280,15 @@ export function parseToolCallStart(event: ToolCallStartEvent): {
   };
 }
 
-export function parseToolCallFinish(event: ToolCallFinishEvent): {
-  toolCallId: string;
-  success: boolean;
-  output: unknown;
-  error: unknown;
-  durationMs?: number;
-} | undefined {
+export function parseToolCallFinish(event: ToolCallFinishEvent):
+  | {
+      toolCallId: string;
+      success: boolean;
+      output: unknown;
+      error: unknown;
+      durationMs?: number;
+    }
+  | undefined {
   const toolCall = asRecord(event.toolCall);
   const toolCallId = asString(toolCall?.toolCallId);
   if (toolCallId.length === 0) {
@@ -431,10 +434,10 @@ function matchesProvider(value: string, providerPrefix: string): boolean {
 function inferProviderFromModel(modelName: string): string {
   const normalized = modelName.trim().toLowerCase();
   if (
-    normalized.startsWith('gpt-')
-    || normalized.startsWith('o1')
-    || normalized.startsWith('o3')
-    || normalized.startsWith('o4')
+    normalized.startsWith('gpt-') ||
+    normalized.startsWith('o1') ||
+    normalized.startsWith('o3') ||
+    normalized.startsWith('o4')
   ) {
     return 'openai';
   }

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -12,6 +12,9 @@ export {
   withConversationTitle,
   withUserId,
 } from './context.js';
+export * as anthropic from './providers/anthropic.js';
+export * as gemini from './providers/gemini.js';
+export * as openai from './providers/openai.js';
 export type {
   ApiConfig,
   Artifact,
@@ -27,8 +30,8 @@ export type {
   ExportGenerationsRequest,
   ExportGenerationsResponse,
   Generation,
-  GenerationExporter,
   GenerationExportConfig,
+  GenerationExporter,
   GenerationExportProtocol,
   GenerationMode,
   GenerationRecorder,
@@ -53,10 +56,6 @@ export type {
   ToolExecutionStart,
   ToolResultPart,
 } from './types.js';
-
-export * as openai from './providers/openai.js';
-export * as anthropic from './providers/anthropic.js';
-export * as gemini from './providers/gemini.js';
 
 import { SigilClient } from './client.js';
 import type { SigilSdkConfigInput } from './types.js';

--- a/js/src/providers/anthropic.ts
+++ b/js/src/providers/anthropic.ts
@@ -1,10 +1,10 @@
-import type { SigilClient } from '../client.js';
-import type { GenerationResult, Message, TokenUsage, ToolDefinition } from '../types.js';
 import type {
   Message as AnthropicMessage,
   MessageCreateParams,
   RawMessageStreamEvent,
 } from '@anthropic-ai/sdk/resources/messages';
+import type { SigilClient } from '../client.js';
+import type { GenerationResult, Message, TokenUsage, ToolDefinition } from '../types.js';
 
 const thinkingBudgetMetadataKey = 'sigil.gen_ai.request.thinking.budget_tokens';
 const usageServerToolUseWebSearchMetadataKey = 'sigil.gen_ai.usage.server_tool_use.web_search_requests';
@@ -38,7 +38,7 @@ async function anthropicMessagesCreate(
   client: SigilClient,
   request: MessagesCreateRequest,
   providerCall: (request: MessagesCreateRequest) => Promise<MessagesCreateResponse>,
-  options: AnthropicOptions = {}
+  options: AnthropicOptions = {},
 ): Promise<MessagesCreateResponse> {
   const mappedRequest = mapAnthropicRequest(request);
 
@@ -65,7 +65,7 @@ async function anthropicMessagesCreate(
       const response = await providerCall(request);
       recorder.setResult(anthropicMessagesFromRequestResponse(request, response, options));
       return response;
-    }
+    },
   );
 }
 
@@ -73,7 +73,7 @@ async function anthropicMessagesStream(
   client: SigilClient,
   request: MessagesCreateRequest,
   providerCall: (request: MessagesCreateRequest) => Promise<MessagesStreamSummary>,
-  options: AnthropicOptions = {}
+  options: AnthropicOptions = {},
 ): Promise<MessagesStreamSummary> {
   const mappedRequest = mapAnthropicRequest(request);
 
@@ -104,14 +104,14 @@ async function anthropicMessagesStream(
       }
       recorder.setResult(anthropicMessagesFromStream(request, summary, options));
       return summary;
-    }
+    },
   );
 }
 
 function anthropicMessagesFromRequestResponse(
   request: MessagesCreateRequest,
   response: MessagesCreateResponse,
-  options: AnthropicOptions = {}
+  options: AnthropicOptions = {},
 ): GenerationResult {
   const mappedRequest = mapAnthropicRequest(request);
   const output = mapAnthropicResponseOutput(response);
@@ -130,10 +130,7 @@ function anthropicMessagesFromRequestResponse(
     tools: mappedRequest.tools,
     usage: mapAnthropicUsage((response as AnyRecord).usage),
     stopReason: normalizeStopReason((response as AnyRecord).stop_reason),
-    metadata: mergeMetadata(
-      metadataWithThinkingBudget(options.metadata, mappedRequest.thinkingBudget),
-      usageMetadata
-    ),
+    metadata: mergeMetadata(metadataWithThinkingBudget(options.metadata, mappedRequest.thinkingBudget), usageMetadata),
     tags: options.tags ? { ...options.tags } : undefined,
   };
 
@@ -153,23 +150,22 @@ function anthropicMessagesFromRequestResponse(
 function anthropicMessagesFromStream(
   request: MessagesCreateRequest,
   summary: MessagesStreamSummary,
-  options: AnthropicOptions = {}
+  options: AnthropicOptions = {},
 ): GenerationResult {
   const mappedRequest = mapAnthropicRequest(request);
   const events = summary.events ?? [];
 
   const outputText = summary.outputText ?? extractAnthropicStreamText(events);
-  const fallbackOutput: Message[] = outputText.length > 0
-    ? [{ role: 'assistant', content: outputText }]
-    : [];
+  const fallbackOutput: Message[] = outputText.length > 0 ? [{ role: 'assistant', content: outputText }] : [];
   const streamUsageMetadata = anthropicStreamUsageMetadata(events);
 
   const result: GenerationResult = summary.finalResponse
     ? {
         ...anthropicMessagesFromRequestResponse(request, summary.finalResponse, options),
-        output: mapAnthropicResponseOutput(summary.finalResponse).length > 0
-          ? mapAnthropicResponseOutput(summary.finalResponse)
-          : fallbackOutput,
+        output:
+          mapAnthropicResponseOutput(summary.finalResponse).length > 0
+            ? mapAnthropicResponseOutput(summary.finalResponse)
+            : fallbackOutput,
       }
     : {
         responseModel: String((request as AnyRecord).model ?? ''),
@@ -183,7 +179,7 @@ function anthropicMessagesFromStream(
         tools: mappedRequest.tools,
         metadata: mergeMetadata(
           metadataWithThinkingBudget(options.metadata, mappedRequest.thinkingBudget),
-          streamUsageMetadata
+          streamUsageMetadata,
         ),
         tags: options.tags ? { ...options.tags } : undefined,
       };
@@ -295,13 +291,14 @@ function mapAnthropicContentParts(content: unknown, role: Message['role']): NonN
     }
 
     if (blockType === 'thinking' || blockType === 'redacted_thinking') {
-      const thinking = typeof rawBlock.thinking === 'string'
-        ? rawBlock.thinking
-        : typeof rawBlock.data === 'string'
-          ? rawBlock.data
-        : typeof rawBlock.text === 'string'
-          ? rawBlock.text
-          : '';
+      const thinking =
+        typeof rawBlock.thinking === 'string'
+          ? rawBlock.thinking
+          : typeof rawBlock.data === 'string'
+            ? rawBlock.data
+            : typeof rawBlock.text === 'string'
+              ? rawBlock.text
+              : '';
 
       if (thinking.trim().length > 0) {
         parts.push({
@@ -336,11 +333,12 @@ function mapAnthropicContentParts(content: unknown, role: Message['role']): NonN
       parts.push({
         type: 'tool_result',
         toolResult: {
-          toolCallId: typeof rawBlock.tool_use_id === 'string'
-            ? rawBlock.tool_use_id
-            : typeof rawBlock.tool_call_id === 'string'
-              ? rawBlock.tool_call_id
-              : undefined,
+          toolCallId:
+            typeof rawBlock.tool_use_id === 'string'
+              ? rawBlock.tool_use_id
+              : typeof rawBlock.tool_call_id === 'string'
+                ? rawBlock.tool_call_id
+                : undefined,
           name: typeof rawBlock.name === 'string' ? rawBlock.name : undefined,
           content: contentValue || undefined,
           contentJSON: jsonString(rawBlock.content),
@@ -567,7 +565,9 @@ function anthropicThinkingEnabled(value: unknown): boolean | undefined {
     if (typeof value.enabled === 'boolean') {
       return value.enabled;
     }
-    const mode = String(value.type ?? value.mode ?? '').trim().toLowerCase();
+    const mode = String(value.type ?? value.mode ?? '')
+      .trim()
+      .toLowerCase();
     if (mode === 'enabled' || mode === 'adaptive') {
       return true;
     }
@@ -595,7 +595,9 @@ function canonicalToolChoice(value: unknown): string | undefined {
     return normalized.length > 0 ? normalized : undefined;
   }
   if (isRecord(value) && 'value' in value) {
-    const normalized = String((value as { value: unknown }).value ?? '').trim().toLowerCase();
+    const normalized = String((value as { value: unknown }).value ?? '')
+      .trim()
+      .toLowerCase();
     return normalized.length > 0 ? normalized : undefined;
   }
   return jsonString(value);
@@ -661,7 +663,7 @@ function readNumberFromAny(value: unknown): number | undefined {
 
 function metadataWithThinkingBudget(
   metadata: Record<string, unknown> | undefined,
-  thinkingBudget: number | undefined
+  thinkingBudget: number | undefined,
 ): Record<string, unknown> | undefined {
   if (thinkingBudget === undefined) {
     return metadata ? { ...metadata } : undefined;
@@ -673,7 +675,7 @@ function metadataWithThinkingBudget(
 
 function mergeMetadata(
   base: Record<string, unknown> | undefined,
-  extra: Record<string, unknown> | undefined
+  extra: Record<string, unknown> | undefined,
 ): Record<string, unknown> | undefined {
   if (base === undefined) {
     return extra ? { ...extra } : undefined;

--- a/js/src/providers/gemini.ts
+++ b/js/src/providers/gemini.ts
@@ -1,6 +1,6 @@
+import type { Content, GenerateContentConfig, GenerateContentResponse } from '@google/genai';
 import type { SigilClient } from '../client.js';
 import type { EmbeddingResult, GenerationResult, Message, TokenUsage, ToolDefinition } from '../types.js';
-import type { Content, GenerateContentConfig, GenerateContentResponse } from '@google/genai';
 
 const thinkingBudgetMetadataKey = 'sigil.gen_ai.request.thinking.budget_tokens';
 const thinkingLevelMetadataKey = 'sigil.gen_ai.request.thinking.level';
@@ -37,12 +37,8 @@ async function geminiGenerateContent(
   model: string,
   contents: GeminiContents,
   config: GeminiConfig | undefined,
-  providerCall: (
-    model: string,
-    contents: GeminiContents,
-    config: GeminiConfig | undefined
-  ) => Promise<GeminiResponse>,
-  options: GeminiOptions = {}
+  providerCall: (model: string, contents: GeminiContents, config: GeminiConfig | undefined) => Promise<GeminiResponse>,
+  options: GeminiOptions = {},
 ): Promise<GeminiResponse> {
   const controls = mapGeminiRequestControls(config);
 
@@ -69,7 +65,7 @@ async function geminiGenerateContent(
       const response = await providerCall(model, contents, config);
       recorder.setResult(geminiFromRequestResponse(model, contents, config, response, options));
       return response;
-    }
+    },
   );
 }
 
@@ -81,9 +77,9 @@ async function geminiGenerateContentStream(
   providerCall: (
     model: string,
     contents: GeminiContents,
-    config: GeminiConfig | undefined
+    config: GeminiConfig | undefined,
   ) => Promise<ModelsStreamSummary>,
-  options: GeminiOptions = {}
+  options: GeminiOptions = {},
 ): Promise<ModelsStreamSummary> {
   const controls = mapGeminiRequestControls(config);
 
@@ -114,7 +110,7 @@ async function geminiGenerateContentStream(
       }
       recorder.setResult(geminiFromStream(model, contents, config, summary, options));
       return summary;
-    }
+    },
   );
 }
 
@@ -126,12 +122,13 @@ async function geminiEmbedContent(
   providerCall: (
     model: string,
     contents: GeminiContents,
-    config: GeminiEmbedConfig | undefined
+    config: GeminiEmbedConfig | undefined,
   ) => Promise<GeminiEmbedResponse>,
-  options: GeminiOptions = {}
+  options: GeminiOptions = {},
 ): Promise<GeminiEmbedResponse> {
-  const requestedDimensions = readIntFromAny((config as AnyRecord | undefined)?.outputDimensionality)
-    ?? readIntFromAny((config as AnyRecord | undefined)?.output_dimensionality);
+  const requestedDimensions =
+    readIntFromAny((config as AnyRecord | undefined)?.outputDimensionality) ??
+    readIntFromAny((config as AnyRecord | undefined)?.output_dimensionality);
 
   return client.startEmbedding(
     {
@@ -149,7 +146,7 @@ async function geminiEmbedContent(
       const response = await providerCall(model, contents, config);
       recorder.setResult(geminiEmbeddingFromResponse(model, contents, config, response));
       return response;
-    }
+    },
   );
 }
 
@@ -157,15 +154,16 @@ function geminiEmbeddingFromResponse(
   _model: string,
   contents: GeminiContents,
   config: GeminiEmbedConfig | undefined,
-  response: GeminiEmbedResponse | undefined
+  response: GeminiEmbedResponse | undefined,
 ): EmbeddingResult {
   const result: EmbeddingResult = {
     inputCount: embeddingInputCount(contents),
     inputTexts: embeddingInputTexts(contents),
   };
 
-  const requestedDimensions = readIntFromAny((config as AnyRecord | undefined)?.outputDimensionality)
-    ?? readIntFromAny((config as AnyRecord | undefined)?.output_dimensionality);
+  const requestedDimensions =
+    readIntFromAny((config as AnyRecord | undefined)?.outputDimensionality) ??
+    readIntFromAny((config as AnyRecord | undefined)?.output_dimensionality);
 
   if (!isRecord(response)) {
     if (requestedDimensions !== undefined && requestedDimensions > 0) {
@@ -203,7 +201,7 @@ function geminiFromRequestResponse(
   contents: GeminiContents,
   config: GeminiConfig | undefined,
   response: GeminiResponse,
-  options: GeminiOptions = {}
+  options: GeminiOptions = {},
 ): GenerationResult {
   const controls = mapGeminiRequestControls(config);
   const output = mapGeminiResponseOutput(response);
@@ -224,7 +222,7 @@ function geminiFromRequestResponse(
     stopReason: mapGeminiStopReason(response),
     metadata: mergeMetadata(
       metadataWithThinkingBudget(options.metadata, controls.thinkingBudget, controls.thinkingLevel),
-      usageMetadata
+      usageMetadata,
     ),
     tags: options.tags ? { ...options.tags } : undefined,
   };
@@ -247,24 +245,21 @@ function geminiFromStream(
   contents: GeminiContents,
   config: GeminiConfig | undefined,
   summary: ModelsStreamSummary,
-  options: GeminiOptions = {}
+  options: GeminiOptions = {},
 ): GenerationResult {
   const controls = mapGeminiRequestControls(config);
   const responses = summary.responses ?? [];
   const finalResponse = summary.finalResponse ?? (responses.length > 0 ? responses[responses.length - 1] : undefined);
 
   const outputText = summary.outputText ?? extractGeminiStreamText(responses);
-  const fallbackOutput: Message[] = outputText.length > 0
-    ? [{ role: 'assistant', content: outputText }]
-    : [];
+  const fallbackOutput: Message[] = outputText.length > 0 ? [{ role: 'assistant', content: outputText }] : [];
   const streamUsageMetadata = geminiStreamUsageMetadata(responses);
 
   const result: GenerationResult = finalResponse
     ? {
         ...geminiFromRequestResponse(model, contents, config, finalResponse, options),
-        output: mapGeminiResponseOutput(finalResponse).length > 0
-          ? mapGeminiResponseOutput(finalResponse)
-          : fallbackOutput,
+        output:
+          mapGeminiResponseOutput(finalResponse).length > 0 ? mapGeminiResponseOutput(finalResponse) : fallbackOutput,
       }
     : {
         responseModel: model,
@@ -278,7 +273,7 @@ function geminiFromStream(
         tools: mapGeminiTools(config),
         metadata: mergeMetadata(
           metadataWithThinkingBudget(options.metadata, controls.thinkingBudget, controls.thinkingLevel),
-          streamUsageMetadata
+          streamUsageMetadata,
         ),
         tags: options.tags ? { ...options.tags } : undefined,
       };
@@ -457,9 +452,7 @@ function mapGeminiParts(rawParts: unknown, role: Message['role']): NonNullable<M
           name: asString(rawPart.functionResponse.name) || undefined,
           content: extractText(responseValue) || undefined,
           contentJSON: jsonString(responseValue),
-          isError: typeof rawPart.functionResponse.isError === 'boolean'
-            ? rawPart.functionResponse.isError
-            : undefined,
+          isError: typeof rawPart.functionResponse.isError === 'boolean' ? rawPart.functionResponse.isError : undefined,
         },
         metadata: { providerType: 'function_response' },
       });
@@ -591,9 +584,8 @@ function mapGeminiRequestControls(config: GeminiConfig | undefined): {
   }
 
   const toolConfig = isRecord(config.toolConfig) ? config.toolConfig : undefined;
-  const functionCallingConfig = toolConfig && isRecord(toolConfig.functionCallingConfig)
-    ? toolConfig.functionCallingConfig
-    : undefined;
+  const functionCallingConfig =
+    toolConfig && isRecord(toolConfig.functionCallingConfig) ? toolConfig.functionCallingConfig : undefined;
   const thinkingConfig = isRecord(config.thinkingConfig) ? config.thinkingConfig : undefined;
 
   return {
@@ -601,9 +593,7 @@ function mapGeminiRequestControls(config: GeminiConfig | undefined): {
     temperature: readNumberFromAny(config.temperature),
     topP: readNumberFromAny(config.topP),
     toolChoice: canonicalToolChoice(functionCallingConfig?.mode),
-    thinkingEnabled: typeof thinkingConfig?.includeThoughts === 'boolean'
-      ? thinkingConfig.includeThoughts
-      : undefined,
+    thinkingEnabled: typeof thinkingConfig?.includeThoughts === 'boolean' ? thinkingConfig.includeThoughts : undefined,
     thinkingBudget: readIntFromAny(thinkingConfig?.thinkingBudget),
     thinkingLevel: geminiThinkingLevel(thinkingConfig?.thinkingLevel),
   };
@@ -678,7 +668,9 @@ function canonicalToolChoice(value: unknown): string | undefined {
     return normalized.length > 0 ? normalized : undefined;
   }
   if (isRecord(value) && 'value' in value) {
-    const normalized = String((value as { value: unknown }).value ?? '').trim().toLowerCase();
+    const normalized = String((value as { value: unknown }).value ?? '')
+      .trim()
+      .toLowerCase();
     return normalized.length > 0 ? normalized : undefined;
   }
   return jsonString(value);
@@ -687,7 +679,7 @@ function canonicalToolChoice(value: unknown): string | undefined {
 function metadataWithThinkingBudget(
   metadata: Record<string, unknown> | undefined,
   thinkingBudget: number | undefined,
-  thinkingLevel: string | undefined
+  thinkingLevel: string | undefined,
 ): Record<string, unknown> | undefined {
   if (thinkingBudget === undefined && thinkingLevel === undefined) {
     return metadata ? { ...metadata } : undefined;
@@ -734,7 +726,7 @@ function geminiStreamUsageMetadata(responses: GeminiResponse[]): Record<string, 
 
 function mergeMetadata(
   base: Record<string, unknown> | undefined,
-  extra: Record<string, unknown> | undefined
+  extra: Record<string, unknown> | undefined,
 ): Record<string, unknown> | undefined {
   if (base === undefined) {
     return extra ? { ...extra } : undefined;

--- a/js/src/providers/openai.ts
+++ b/js/src/providers/openai.ts
@@ -1,6 +1,6 @@
 import type OpenAI from 'openai';
-import type { EmbeddingResult, GenerationResult, Message, TokenUsage, ToolDefinition } from '../types.js';
 import type { SigilClient } from '../client.js';
+import type { EmbeddingResult, GenerationResult, Message, TokenUsage, ToolDefinition } from '../types.js';
 
 const thinkingBudgetMetadataKey = 'sigil.gen_ai.request.thinking.budget_tokens';
 type AnyRecord = Record<string, unknown>;
@@ -47,12 +47,12 @@ async function chatCompletionsCreate(
   client: SigilClient,
   request: ChatCreateRequest,
   providerCall: (request: ChatCreateRequest) => Promise<ChatResponse>,
-  options: OpenAIOptions = {}
+  options: OpenAIOptions = {},
 ): Promise<ChatResponse> {
   const requestMessages = mapChatRequestMessages(request);
   const mappedTools = mapChatTools(request);
-  const maxTokens = readIntFromAny((request as AnyRecord).max_completion_tokens)
-    ?? readIntFromAny((request as AnyRecord).max_tokens);
+  const maxTokens =
+    readIntFromAny((request as AnyRecord).max_completion_tokens) ?? readIntFromAny((request as AnyRecord).max_tokens);
   const temperature = readNumberFromAny((request as AnyRecord).temperature);
   const topP = readNumberFromAny((request as AnyRecord).top_p);
   const toolChoice = canonicalToolChoice((request as AnyRecord).tool_choice);
@@ -81,7 +81,7 @@ async function chatCompletionsCreate(
       const response = await providerCall(request);
       recorder.setResult(chatCompletionsFromRequestResponse(request, response, options));
       return response;
-    }
+    },
   );
 }
 
@@ -89,12 +89,12 @@ async function chatCompletionsStream(
   client: SigilClient,
   request: ChatStreamRequest,
   providerCall: (request: ChatStreamRequest) => Promise<ChatCompletionsStreamSummary>,
-  options: OpenAIOptions = {}
+  options: OpenAIOptions = {},
 ): Promise<ChatCompletionsStreamSummary> {
   const requestMessages = mapChatRequestMessages(request);
   const mappedTools = mapChatTools(request);
-  const maxTokens = readIntFromAny((request as AnyRecord).max_completion_tokens)
-    ?? readIntFromAny((request as AnyRecord).max_tokens);
+  const maxTokens =
+    readIntFromAny((request as AnyRecord).max_completion_tokens) ?? readIntFromAny((request as AnyRecord).max_tokens);
   const temperature = readNumberFromAny((request as AnyRecord).temperature);
   const topP = readNumberFromAny((request as AnyRecord).top_p);
   const toolChoice = canonicalToolChoice((request as AnyRecord).tool_choice);
@@ -127,19 +127,19 @@ async function chatCompletionsStream(
       }
       recorder.setResult(chatCompletionsFromStream(request, summary, options));
       return summary;
-    }
+    },
   );
 }
 
 function chatCompletionsFromRequestResponse(
   request: ChatCreateRequest,
   response: ChatResponse,
-  options: OpenAIOptions = {}
+  options: OpenAIOptions = {},
 ): GenerationResult {
   const requestMessages = mapChatRequestMessages(request);
   const mappedTools = mapChatTools(request);
-  const maxTokens = readIntFromAny((request as AnyRecord).max_completion_tokens)
-    ?? readIntFromAny((request as AnyRecord).max_tokens);
+  const maxTokens =
+    readIntFromAny((request as AnyRecord).max_completion_tokens) ?? readIntFromAny((request as AnyRecord).max_tokens);
   const temperature = readNumberFromAny((request as AnyRecord).temperature);
   const topP = readNumberFromAny((request as AnyRecord).top_p);
   const toolChoice = canonicalToolChoice((request as AnyRecord).tool_choice);
@@ -178,28 +178,27 @@ function chatCompletionsFromRequestResponse(
 function chatCompletionsFromStream(
   request: ChatStreamRequest,
   summary: ChatCompletionsStreamSummary,
-  options: OpenAIOptions = {}
+  options: OpenAIOptions = {},
 ): GenerationResult {
   const requestMessages = mapChatRequestMessages(request);
   const mappedTools = mapChatTools(request);
-  const maxTokens = readIntFromAny((request as AnyRecord).max_completion_tokens)
-    ?? readIntFromAny((request as AnyRecord).max_tokens);
+  const maxTokens =
+    readIntFromAny((request as AnyRecord).max_completion_tokens) ?? readIntFromAny((request as AnyRecord).max_tokens);
   const temperature = readNumberFromAny((request as AnyRecord).temperature);
   const topP = readNumberFromAny((request as AnyRecord).top_p);
   const toolChoice = canonicalToolChoice((request as AnyRecord).tool_choice);
   const thinkingBudget = openAIThinkingBudget((request as AnyRecord).reasoning);
 
   const outputText = summary.outputText ?? extractChatStreamText(summary.events ?? []);
-  const fallbackOutput: Message[] = outputText.length > 0
-    ? [{ role: 'assistant', content: outputText }]
-    : [];
+  const fallbackOutput: Message[] = outputText.length > 0 ? [{ role: 'assistant', content: outputText }] : [];
 
   const result: GenerationResult = summary.finalResponse
     ? {
         ...chatCompletionsFromRequestResponse(request as unknown as ChatCreateRequest, summary.finalResponse, options),
-        output: mapChatResponseOutput(summary.finalResponse).length > 0
-          ? mapChatResponseOutput(summary.finalResponse)
-          : fallbackOutput,
+        output:
+          mapChatResponseOutput(summary.finalResponse).length > 0
+            ? mapChatResponseOutput(summary.finalResponse)
+            : fallbackOutput,
       }
     : {
         responseModel: String((request as AnyRecord).model ?? ''),
@@ -234,7 +233,7 @@ async function responsesCreate(
   client: SigilClient,
   request: ResponsesCreateRequest,
   providerCall: (request: ResponsesCreateRequest) => Promise<ResponsesResponse>,
-  options: OpenAIOptions = {}
+  options: OpenAIOptions = {},
 ): Promise<ResponsesResponse> {
   const requestPayload = mapResponsesRequest(request);
   const controls = mapResponsesRequestControls(request);
@@ -262,7 +261,7 @@ async function responsesCreate(
       const response = await providerCall(request);
       recorder.setResult(responsesFromRequestResponse(request, response, options));
       return response;
-    }
+    },
   );
 }
 
@@ -270,7 +269,7 @@ async function responsesStream(
   client: SigilClient,
   request: ResponsesStreamRequest,
   providerCall: (request: ResponsesStreamRequest) => Promise<ResponsesStreamSummary>,
-  options: OpenAIOptions = {}
+  options: OpenAIOptions = {},
 ): Promise<ResponsesStreamSummary> {
   const requestPayload = mapResponsesRequest(request);
   const controls = mapResponsesRequestControls(request);
@@ -302,14 +301,14 @@ async function responsesStream(
       }
       recorder.setResult(responsesFromStream(request, summary, options));
       return summary;
-    }
+    },
   );
 }
 
 function responsesFromRequestResponse(
   request: ResponsesCreateRequest,
   response: ResponsesResponse,
-  options: OpenAIOptions = {}
+  options: OpenAIOptions = {},
 ): GenerationResult {
   const requestPayload = mapResponsesRequest(request);
   const controls = mapResponsesRequestControls(request);
@@ -347,7 +346,7 @@ function responsesFromRequestResponse(
 function responsesFromStream(
   request: ResponsesStreamRequest,
   summary: ResponsesStreamSummary,
-  options: OpenAIOptions = {}
+  options: OpenAIOptions = {},
 ): GenerationResult {
   const requestPayload = mapResponsesRequest(request);
   const controls = mapResponsesRequestControls(request);
@@ -360,11 +359,12 @@ function responsesFromStream(
   const result: GenerationResult = finalResponse
     ? {
         ...responsesFromRequestResponse(request as unknown as ResponsesCreateRequest, finalResponse, options),
-        output: mapResponsesOutputItems((finalResponse as AnyRecord).output).length > 0
-          ? mapResponsesOutputItems((finalResponse as AnyRecord).output)
-          : outputText.length > 0
-            ? [{ role: 'assistant', content: outputText }]
-            : [],
+        output:
+          mapResponsesOutputItems((finalResponse as AnyRecord).output).length > 0
+            ? mapResponsesOutputItems((finalResponse as AnyRecord).output)
+            : outputText.length > 0
+              ? [{ role: 'assistant', content: outputText }]
+              : [],
       }
     : {
         responseModel: String((request as AnyRecord).model ?? ''),
@@ -400,13 +400,11 @@ async function embeddingsCreate(
   client: SigilClient,
   request: EmbeddingsCreateRequest,
   providerCall: (request: EmbeddingsCreateRequest) => Promise<EmbeddingsCreateResponse>,
-  options: OpenAIOptions = {}
+  options: OpenAIOptions = {},
 ): Promise<EmbeddingsCreateResponse> {
   const dimensions = readIntFromAny((request as AnyRecord).dimensions);
   const rawEncodingFormat = (request as AnyRecord).encoding_format;
-  const encodingFormat = typeof rawEncodingFormat === 'string'
-    ? rawEncodingFormat.trim()
-    : '';
+  const encodingFormat = typeof rawEncodingFormat === 'string' ? rawEncodingFormat.trim() : '';
 
   return client.startEmbedding(
     {
@@ -425,13 +423,13 @@ async function embeddingsCreate(
       const response = await providerCall(request);
       recorder.setResult(embeddingsFromRequestResponse(request, response));
       return response;
-    }
+    },
   );
 }
 
 function embeddingsFromRequestResponse(
   request: EmbeddingsCreateRequest,
-  response: EmbeddingsCreateResponse | undefined
+  response: EmbeddingsCreateResponse | undefined,
 ): EmbeddingResult {
   const input = (request as AnyRecord).input;
   const result: EmbeddingResult = {
@@ -478,9 +476,7 @@ function mapChatRequestMessages(request: ChatCreateRequest | ChatStreamRequest):
   input: Message[];
   systemPrompt?: string;
 } {
-  const source = Array.isArray((request as AnyRecord).messages)
-    ? ((request as AnyRecord).messages as unknown[])
-    : [];
+  const source = Array.isArray((request as AnyRecord).messages) ? ((request as AnyRecord).messages as unknown[]) : [];
 
   const systemChunks: string[] = [];
   const input: Message[] = [];
@@ -490,7 +486,9 @@ function mapChatRequestMessages(request: ChatCreateRequest | ChatStreamRequest):
       continue;
     }
 
-    const role = String(rawMessage.role ?? '').trim().toLowerCase();
+    const role = String(rawMessage.role ?? '')
+      .trim()
+      .toLowerCase();
     const content = extractText(rawMessage.content);
 
     if (role === 'system' || role === 'developer') {
@@ -517,7 +515,7 @@ function mapChatRequestMessages(request: ChatCreateRequest | ChatStreamRequest):
         rawMessage.tool_call_id ?? rawMessage.toolCallId ?? rawMessage.id,
         rawMessage.name,
         rawMessage.is_error,
-        'tool_result'
+        'tool_result',
       );
       if (toolResult) {
         input.push(toolResult);
@@ -612,9 +610,8 @@ function mapChatToolCallParts(value: unknown): NonNullable<Message['parts']> {
       continue;
     }
 
-    const input = typeof functionCall.arguments === 'string'
-      ? functionCall.arguments
-      : jsonString(functionCall.arguments);
+    const input =
+      typeof functionCall.arguments === 'string' ? functionCall.arguments : jsonString(functionCall.arguments);
 
     parts.push({
       type: 'tool_call',
@@ -654,9 +651,7 @@ function mapChatTools(request: ChatCreateRequest | ChatStreamRequest): ToolDefin
         name,
         description: typeof rawTool.function.description === 'string' ? rawTool.function.description : undefined,
         type: 'function',
-        inputSchemaJSON: hasValue(rawTool.function.parameters)
-          ? jsonString(rawTool.function.parameters)
-          : undefined,
+        inputSchemaJSON: hasValue(rawTool.function.parameters) ? jsonString(rawTool.function.parameters) : undefined,
       });
       continue;
     }
@@ -779,7 +774,7 @@ function mapResponsesRequest(request: ResponsesCreateRequest | ResponsesStreamRe
           rawItem.call_id ?? rawItem.callId,
           rawItem.name,
           rawItem.is_error,
-          'tool_result'
+          'tool_result',
         );
         if (toolResult) {
           input.push(toolResult);
@@ -894,9 +889,7 @@ function mapResponsesOutputItems(value: unknown): Message[] {
 
     if (itemType === 'function_call') {
       const name = typeof rawItem.name === 'string' ? rawItem.name : '';
-      const args = typeof rawItem.arguments === 'string'
-        ? rawItem.arguments
-        : jsonString(rawItem.arguments);
+      const args = typeof rawItem.arguments === 'string' ? rawItem.arguments : jsonString(rawItem.arguments);
       if (name.trim().length > 0) {
         output.push({
           role: 'assistant',
@@ -923,7 +916,7 @@ function mapResponsesOutputItems(value: unknown): Message[] {
         rawItem.call_id ?? rawItem.callId,
         rawItem.name,
         rawItem.is_error,
-        'tool_result'
+        'tool_result',
       );
       if (toolResult) {
         output.push(toolResult);
@@ -980,7 +973,9 @@ function mapResponsesUsage(value: unknown): TokenUsage | undefined {
 function normalizeResponsesStopReason(response: ResponsesResponse): string | undefined {
   const status = typeof response.status === 'string' ? response.status.trim().toLowerCase() : '';
   const incomplete = isRecord(response.incomplete_details)
-    ? String(response.incomplete_details.reason ?? '').trim().toLowerCase()
+    ? String(response.incomplete_details.reason ?? '')
+        .trim()
+        .toLowerCase()
     : '';
 
   if (status === 'incomplete' && incomplete.length > 0) {
@@ -1001,7 +996,9 @@ function normalizeResponsesStopReasonFromEvents(events: ResponsesStreamEvent[]):
     const response = isRecord(event.response) ? event.response : undefined;
 
     if (eventType === 'response.incomplete' && response && isRecord(response.incomplete_details)) {
-      const reason = String(response.incomplete_details.reason ?? '').trim().toLowerCase();
+      const reason = String(response.incomplete_details.reason ?? '')
+        .trim()
+        .toLowerCase();
       if (reason.length > 0) {
         return reason;
       }
@@ -1072,7 +1069,10 @@ function extractText(value: unknown): string {
         continue;
       }
       const itemType = typeof item.type === 'string' ? item.type : '';
-      if ((itemType === 'text' || itemType === 'input_text' || itemType === 'output_text') && typeof item.text === 'string') {
+      if (
+        (itemType === 'text' || itemType === 'input_text' || itemType === 'output_text') &&
+        typeof item.text === 'string'
+      ) {
         if (item.text.trim().length > 0) {
           chunks.push(item.text.trim());
         }
@@ -1193,7 +1193,7 @@ function mapToolResultMessage(
   toolCallId: unknown,
   name: unknown,
   isError: unknown,
-  providerType: string
+  providerType: string,
 ): Message | undefined {
   const content = extractText(value);
   const contentJSON = jsonString(value);
@@ -1224,7 +1224,7 @@ function mapToolResultMessage(
 
 function metadataWithThinkingBudget(
   metadata: Record<string, unknown> | undefined,
-  thinkingBudget: number | undefined
+  thinkingBudget: number | undefined,
 ): Record<string, unknown> | undefined {
   if (thinkingBudget === undefined) {
     return metadata ? { ...metadata } : undefined;
@@ -1243,7 +1243,9 @@ function canonicalToolChoice(value: unknown): string | undefined {
     return normalized.length > 0 ? normalized : undefined;
   }
   if (isRecord(value) && 'value' in value) {
-    const normalized = String((value as { value: unknown }).value ?? '').trim().toLowerCase();
+    const normalized = String((value as { value: unknown }).value ?? '')
+      .trim()
+      .toLowerCase();
     return normalized.length > 0 ? normalized : undefined;
   }
   const encoded = jsonString(value);

--- a/js/src/utils.ts
+++ b/js/src/utils.ts
@@ -11,8 +11,8 @@ import type {
   ModelRef,
   ToolDefinition,
   ToolExecution,
-  ToolExecutionStart,
   ToolExecutionResult,
+  ToolExecutionStart,
 } from './types.js';
 
 const textEncoder = new TextEncoder();
@@ -300,7 +300,7 @@ function validatePart(
   messageIndex: number,
   partIndex: number,
   role: 'user' | 'assistant' | 'tool',
-  part: MessagePart
+  part: MessagePart,
 ): Error | undefined {
   const payloadFieldCount = payloadFieldsCount(part);
   if (payloadFieldCount !== 1) {

--- a/js/test/client.auth.config.test.mjs
+++ b/js/test/client.auth.config.test.mjs
@@ -12,7 +12,7 @@ test('invalid generation auth config throws at client init', () => {
           },
         },
       }),
-    /requires tenantId/
+    /requires tenantId/,
   );
 });
 
@@ -27,8 +27,8 @@ test('basic auth mode injects Authorization and X-Scope-OrgID headers', () => {
     },
   });
 
-  const expected = 'Basic ' + btoa('42:secret');
-  assert.equal(client.config.generationExport.headers?.['Authorization'], expected);
+  const expected = `Basic ${btoa('42:secret')}`;
+  assert.equal(client.config.generationExport.headers?.Authorization, expected);
   assert.equal(client.config.generationExport.headers?.['X-Scope-OrgID'], '42');
   client.shutdown();
 });
@@ -45,8 +45,8 @@ test('basic auth mode uses basicUser over tenantId for credential', () => {
     },
   });
 
-  const expected = 'Basic ' + btoa('probe-user:secret');
-  assert.equal(client.config.generationExport.headers?.['Authorization'], expected);
+  const expected = `Basic ${btoa('probe-user:secret')}`;
+  assert.equal(client.config.generationExport.headers?.Authorization, expected);
   assert.equal(client.config.generationExport.headers?.['X-Scope-OrgID'], '42');
   client.shutdown();
 });
@@ -62,7 +62,7 @@ test('basic auth mode requires basicPassword', () => {
           },
         },
       }),
-    /requires basicPassword/
+    /requires basicPassword/,
   );
 });
 
@@ -77,7 +77,7 @@ test('basic auth mode requires basicUser or tenantId', () => {
           },
         },
       }),
-    /requires basicUser or tenantId/
+    /requires basicUser or tenantId/,
   );
 });
 
@@ -92,7 +92,7 @@ test('none auth mode rejects basicUser', () => {
           },
         },
       }),
-    /does not allow credentials/
+    /does not allow credentials/,
   );
 });
 
@@ -107,7 +107,7 @@ test('none auth mode rejects basicPassword', () => {
           },
         },
       }),
-    /does not allow credentials/
+    /does not allow credentials/,
   );
 });
 
@@ -123,8 +123,8 @@ test('basic auth handles non-ASCII credentials via UTF-8 encoding', () => {
   });
 
   const encoded = Buffer.from('ユーザー:パスワード', 'utf-8').toString('base64');
-  const expected = 'Basic ' + encoded;
-  assert.equal(client.config.generationExport.headers?.['Authorization'], expected);
+  const expected = `Basic ${encoded}`;
+  assert.equal(client.config.generationExport.headers?.Authorization, expected);
   client.shutdown();
 });
 
@@ -143,7 +143,7 @@ test('basic auth explicit headers win over auth-derived headers', () => {
     },
   });
 
-  assert.equal(client.config.generationExport.headers?.['Authorization'], 'Basic override');
+  assert.equal(client.config.generationExport.headers?.Authorization, 'Basic override');
   assert.equal(client.config.generationExport.headers?.['X-Scope-OrgID'], 'override-tenant');
   client.shutdown();
 });

--- a/js/test/client.rating.test.mjs
+++ b/js/test/client.rating.test.mjs
@@ -35,7 +35,7 @@ test('submitConversationRating sends HTTP request and maps response', async () =
           latest_rated_at: '2026-02-13T12:00:00Z',
           has_bad_rating: true,
         },
-      })
+      }),
     );
   });
   await listen(server);
@@ -104,7 +104,7 @@ test('submitConversationRating maps 409 to conflict error', async () => {
           ratingId: 'rat-1',
           rating: 'CONVERSATION_RATING_VALUE_GOOD',
         }),
-      /conversation rating conflict/
+      /conversation rating conflict/,
     );
   } finally {
     await client.shutdown();
@@ -124,7 +124,7 @@ test('submitConversationRating validates required input', async () => {
           ratingId: '',
           rating: 'CONVERSATION_RATING_VALUE_GOOD',
         }),
-      /validation failed: ratingId is required/
+      /validation failed: ratingId is required/,
     );
   } finally {
     await client.shutdown();
@@ -156,7 +156,7 @@ test('submitConversationRating applies bearer auth header from config', async ()
           latest_rated_at: '2026-02-13T12:00:00Z',
           has_bad_rating: false,
         },
-      })
+      }),
     );
   });
   await listen(server);

--- a/js/test/client.runtime.test.mjs
+++ b/js/test/client.runtime.test.mjs
@@ -128,7 +128,7 @@ test('queue-full recorder local error is exposed and callback style throws', asy
       client.startGeneration(seedGeneration(8), async (callbackRecorder) => {
         callbackRecorder.setResult({ output: [{ role: 'assistant', content: 'callback' }] });
       }),
-      /queue is full/
+      /queue is full/,
     );
   } finally {
     await client.shutdown();
@@ -153,7 +153,7 @@ test('built-in HTTP exporter posts generation batches to configured endpoint', a
           generationId: generation.id,
           accepted: true,
         })),
-      })
+      }),
     );
   });
 

--- a/js/test/client.transport.test.mjs
+++ b/js/test/client.transport.test.mjs
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
 import { createServer } from 'node:http';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 import * as grpc from '@grpc/grpc-js';
 import * as protoLoader from '@grpc/proto-loader';
 import { trace } from '@opentelemetry/api';
@@ -40,7 +40,7 @@ test('HTTP transport roundtrip preserves full generation payload shape', async (
           generationId: generation.id,
           accepted: true,
         })),
-      })
+      }),
     );
   });
 
@@ -296,7 +296,7 @@ test('HTTP transport applies generation tenant auth header', async () => {
           generationId: generation.id,
           accepted: true,
         })),
-      })
+      }),
     );
   });
 
@@ -706,14 +706,14 @@ function canonicalizeProtoMessage(message) {
   return {
     role: fromProtoMessageRole(message.role),
     name: message.name ?? '',
-    content: (message.parts ?? [])
-      .map((part) => (typeof part.text === 'string' ? part.text : ''))
-      .join(''),
+    content: (message.parts ?? []).map((part) => (typeof part.text === 'string' ? part.text : '')).join(''),
   };
 }
 
 function normalizeSDKRole(role) {
-  const normalized = String(role ?? '').trim().toLowerCase();
+  const normalized = String(role ?? '')
+    .trim()
+    .toLowerCase();
   if (normalized === 'assistant' || normalized === 'tool') {
     return normalized;
   }

--- a/js/test/client.validation.test.mjs
+++ b/js/test/client.validation.test.mjs
@@ -46,7 +46,10 @@ test('validation rejects tool_call part for user role and reports input path', a
     });
     recorder.end();
 
-    assert.match(recorder.getError()?.message ?? '', /generation\.input\[0\].parts\[0\].tool_call only allowed for assistant role/);
+    assert.match(
+      recorder.getError()?.message ?? '',
+      /generation\.input\[0\].parts\[0\].tool_call only allowed for assistant role/,
+    );
     await client.flush();
     assert.equal(exporter.requests.length, 0);
   } finally {
@@ -84,7 +87,10 @@ test('validation rejects tool_result part for assistant role', async () => {
     });
     recorder.end();
 
-    assert.match(recorder.getError()?.message ?? '', /generation\.input\[0\].parts\[0\].tool_result only allowed for tool role/);
+    assert.match(
+      recorder.getError()?.message ?? '',
+      /generation\.input\[0\].parts\[0\].tool_result only allowed for tool role/,
+    );
     await client.flush();
     assert.equal(exporter.requests.length, 0);
   } finally {
@@ -119,7 +125,10 @@ test('validation rejects thinking part for non-assistant roles and reports outpu
     });
     recorder.end();
 
-    assert.match(recorder.getError()?.message ?? '', /generation\.output\[0\].parts\[0\].thinking only allowed for assistant role/);
+    assert.match(
+      recorder.getError()?.message ?? '',
+      /generation\.output\[0\].parts\[0\].thinking only allowed for assistant role/,
+    );
     await client.flush();
     assert.equal(exporter.requests.length, 0);
   } finally {

--- a/js/test/conformance.test.mjs
+++ b/js/test/conformance.test.mjs
@@ -1,15 +1,20 @@
 import assert from 'node:assert/strict';
 import { createServer } from 'node:http';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 import * as grpc from '@grpc/grpc-js';
 import * as protoLoader from '@grpc/proto-loader';
-import { AggregationTemporality, InMemoryMetricExporter, MeterProvider, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import {
+  AggregationTemporality,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
 import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import {
-  SigilClient,
   defaultConfig,
+  SigilClient,
   withAgentName,
   withAgentVersion,
   withConversationTitle,
@@ -147,7 +152,13 @@ test('conformance sync roundtrip semantics', async () => {
 });
 
 for (const testCase of [
-  { name: 'explicit wins', startTitle: 'Explicit', contextTitle: 'Context', metadataTitle: 'Meta', expected: 'Explicit' },
+  {
+    name: 'explicit wins',
+    startTitle: 'Explicit',
+    contextTitle: 'Context',
+    metadataTitle: 'Meta',
+    expected: 'Explicit',
+  },
   { name: 'context fallback', startTitle: '', contextTitle: 'Context', metadataTitle: '', expected: 'Context' },
   { name: 'metadata fallback', startTitle: '', contextTitle: '', metadataTitle: 'Meta', expected: 'Meta' },
   { name: 'whitespace trimmed', startTitle: '  Padded  ', contextTitle: '', metadataTitle: '', expected: 'Padded' },
@@ -161,7 +172,8 @@ for (const testCase of [
         const recorder = env.client.startGeneration({
           model: { provider: 'openai', name: 'gpt-5' },
           conversationTitle: testCase.startTitle,
-          metadata: testCase.metadataTitle.length > 0 ? { 'sigil.conversation.title': testCase.metadataTitle } : undefined,
+          metadata:
+            testCase.metadataTitle.length > 0 ? { 'sigil.conversation.title': testCase.metadataTitle } : undefined,
         });
         recorder.setResult({});
         recorder.end();
@@ -186,12 +198,54 @@ for (const testCase of [
 }
 
 for (const testCase of [
-  { name: 'explicit wins', startUserId: 'explicit', contextUserId: 'ctx', canonicalUserId: 'canonical', legacyUserId: 'legacy', expected: 'explicit' },
-  { name: 'context fallback', startUserId: '', contextUserId: 'ctx', canonicalUserId: '', legacyUserId: '', expected: 'ctx' },
-  { name: 'canonical metadata', startUserId: '', contextUserId: '', canonicalUserId: 'canonical', legacyUserId: '', expected: 'canonical' },
-  { name: 'legacy metadata', startUserId: '', contextUserId: '', canonicalUserId: '', legacyUserId: 'legacy', expected: 'legacy' },
-  { name: 'canonical beats legacy', startUserId: '', contextUserId: '', canonicalUserId: 'canonical', legacyUserId: 'legacy', expected: 'canonical' },
-  { name: 'whitespace trimmed', startUserId: '  padded  ', contextUserId: '', canonicalUserId: '', legacyUserId: '', expected: 'padded' },
+  {
+    name: 'explicit wins',
+    startUserId: 'explicit',
+    contextUserId: 'ctx',
+    canonicalUserId: 'canonical',
+    legacyUserId: 'legacy',
+    expected: 'explicit',
+  },
+  {
+    name: 'context fallback',
+    startUserId: '',
+    contextUserId: 'ctx',
+    canonicalUserId: '',
+    legacyUserId: '',
+    expected: 'ctx',
+  },
+  {
+    name: 'canonical metadata',
+    startUserId: '',
+    contextUserId: '',
+    canonicalUserId: 'canonical',
+    legacyUserId: '',
+    expected: 'canonical',
+  },
+  {
+    name: 'legacy metadata',
+    startUserId: '',
+    contextUserId: '',
+    canonicalUserId: '',
+    legacyUserId: 'legacy',
+    expected: 'legacy',
+  },
+  {
+    name: 'canonical beats legacy',
+    startUserId: '',
+    contextUserId: '',
+    canonicalUserId: 'canonical',
+    legacyUserId: 'legacy',
+    expected: 'canonical',
+  },
+  {
+    name: 'whitespace trimmed',
+    startUserId: '  padded  ',
+    contextUserId: '',
+    canonicalUserId: '',
+    legacyUserId: '',
+    expected: 'padded',
+  },
 ]) {
   test(`conformance user id semantics: ${testCase.name}`, async () => {
     const env = await createConformanceEnv();
@@ -526,7 +580,7 @@ async function createConformanceEnv(options = {}) {
   });
 
   let ratingPath = '';
-  let ratingPayload = undefined;
+  let ratingPayload;
   const ratingServer = createServer(async (request, response) => {
     ratingPath = request.url ?? '';
     const chunks = [];
@@ -551,7 +605,7 @@ async function createConformanceEnv(options = {}) {
           latest_rated_at: '2026-03-12T09:00:00Z',
           has_bad_rating: true,
         },
-      })
+      }),
     );
   });
   await listen(ratingServer);

--- a/js/test/devex-emitter.test.mjs
+++ b/js/test/devex-emitter.test.mjs
@@ -53,7 +53,6 @@ test('thread rotation resets turn and assigns a new conversation id', async () =
 test('framework emit path invokes all framework handlers for provider sources', async () => {
   const calls = [];
   class FakeHandler {
-    constructor(_client, _options) {}
     async handleChatModelStart(_serialized, _messages, runID) {
       calls.push(`start:${runID}`);
     }
@@ -80,7 +79,7 @@ test('framework emit path invokes all framework handlers for provider sources', 
       agentVersion: 'v1',
       tags: { 'sigil.devex.provider': 'openai' },
       metadata: { provider_shape: 'framework' },
-    }
+    },
   );
 
   assert.equal(calls.length, 10);
@@ -112,7 +111,7 @@ test('framework emit path skips non-provider custom source', async () => {
       agentVersion: 'v1',
       tags: { 'sigil.devex.provider': 'mistral' },
       metadata: { provider_shape: 'framework' },
-    }
+    },
   );
 
   assert.equal(called, false);

--- a/js/test/frameworks.additional.test.mjs
+++ b/js/test/frameworks.additional.test.mjs
@@ -2,30 +2,20 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { context, trace } from '@opentelemetry/api';
 import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
-
-import { defaultConfig, SigilClient } from '../.test-dist/index.js';
 import {
-  SigilLangChainHandler,
-  withSigilLangChainCallbacks,
-} from '../.test-dist/frameworks/langchain/index.js';
-import {
-  SigilLangGraphHandler,
-  withSigilLangGraphCallbacks,
-} from '../.test-dist/frameworks/langgraph/index.js';
-import {
-  SigilOpenAIAgentsHandler,
-  withSigilOpenAIAgentsHooks,
-} from '../.test-dist/frameworks/openai-agents/index.js';
-import {
-  SigilLlamaIndexHandler,
-  attachSigilLlamaIndexCallbacks,
-  withSigilLlamaIndexCallbacks,
-} from '../.test-dist/frameworks/llamaindex/index.js';
-import {
-  SigilGoogleAdkHandler,
   createSigilGoogleAdkPlugin,
+  SigilGoogleAdkHandler,
   withSigilGoogleAdkPlugins,
 } from '../.test-dist/frameworks/google-adk/index.js';
+import { SigilLangChainHandler, withSigilLangChainCallbacks } from '../.test-dist/frameworks/langchain/index.js';
+import { SigilLangGraphHandler, withSigilLangGraphCallbacks } from '../.test-dist/frameworks/langgraph/index.js';
+import {
+  attachSigilLlamaIndexCallbacks,
+  SigilLlamaIndexHandler,
+  withSigilLlamaIndexCallbacks,
+} from '../.test-dist/frameworks/llamaindex/index.js';
+import { SigilOpenAIAgentsHandler, withSigilOpenAIAgentsHooks } from '../.test-dist/frameworks/openai-agents/index.js';
+import { defaultConfig, SigilClient } from '../.test-dist/index.js';
 
 class CapturingExporter {
   requests = [];
@@ -78,7 +68,7 @@ for (const framework of frameworks) {
           conversation_id: 'framework-conversation-42',
           thread_id: 'framework-thread-42',
           event_id: 'framework-event-42',
-        }
+        },
       );
       await handler.handleLLMEnd(
         {
@@ -88,7 +78,7 @@ for (const framework of frameworks) {
             finish_reason: 'stop',
           },
         },
-        'run-sync'
+        'run-sync',
       );
     });
 
@@ -123,7 +113,7 @@ for (const framework of frameworks) {
         {
           conversation_id: 'framework-conversation-split-42',
           event_id: 'framework-event-split-42',
-        }
+        },
       );
       await handler.handleLLMEnd(
         {
@@ -133,7 +123,7 @@ for (const framework of frameworks) {
             finish_reason: 'stop',
           },
         },
-        'run-split'
+        'run-split',
       );
     });
 
@@ -146,19 +136,15 @@ for (const framework of frameworks) {
     const generation = await captureSingleGeneration(async (client) => {
       const handler = new framework.handlerCtor(client);
 
-      await handler.handleLLMStart(
-        { kwargs: { model: 'gpt-5' } },
-        ['hello'],
-        'run-fallback',
-        undefined,
-        { invocation_params: { model: 'gpt-5' } }
-      );
+      await handler.handleLLMStart({ kwargs: { model: 'gpt-5' } }, ['hello'], 'run-fallback', undefined, {
+        invocation_params: { model: 'gpt-5' },
+      });
       await handler.handleLLMEnd(
         {
           generations: [[{ text: 'ok' }]],
           llm_output: { model_name: 'gpt-5' },
         },
-        'run-fallback'
+        'run-fallback',
       );
     });
 
@@ -176,26 +162,22 @@ for (const framework of frameworks) {
         },
       });
 
-      await handler.handleLLMStart(
-        { kwargs: { model: 'gpt-5' } },
-        ['hello'],
-        'run-metadata',
-        undefined,
-        { invocation_params: { model: 'gpt-5' } }
-      );
+      await handler.handleLLMStart({ kwargs: { model: 'gpt-5' } }, ['hello'], 'run-metadata', undefined, {
+        invocation_params: { model: 'gpt-5' },
+      });
       await handler.handleLLMEnd(
         {
           generations: [[{ text: 'ok' }]],
           llm_output: { model_name: 'gpt-5' },
         },
-        'run-metadata'
+        'run-metadata',
       );
     });
 
     assert.equal(generation.metadata.timestamp, '2026-02-20T00:00:00.000Z');
     assert.deepEqual(generation.metadata.list, ['a', { nested: true }]);
     assert.deepEqual(generation.metadata.object, { child: { depth: 'ok' } });
-    assert.equal(Object.prototype.hasOwnProperty.call(generation.metadata, 'callable'), false);
+    assert.equal(Object.hasOwn(generation.metadata, 'callable'), false);
   });
 
   test(`${framework.name} handler drops invalid date metadata values`, async () => {
@@ -207,24 +189,20 @@ for (const framework of frameworks) {
         },
       });
 
-      await handler.handleLLMStart(
-        { kwargs: { model: 'gpt-5' } },
-        ['hello'],
-        'run-invalid-date',
-        undefined,
-        { invocation_params: { model: 'gpt-5' } }
-      );
+      await handler.handleLLMStart({ kwargs: { model: 'gpt-5' } }, ['hello'], 'run-invalid-date', undefined, {
+        invocation_params: { model: 'gpt-5' },
+      });
       await handler.handleLLMEnd(
         {
           generations: [[{ text: 'ok' }]],
           llm_output: { model_name: 'gpt-5' },
         },
-        'run-invalid-date'
+        'run-invalid-date',
       );
     });
 
     assert.equal(generation.metadata.validDate, '2026-02-20T00:00:00.000Z');
-    assert.equal(Object.prototype.hasOwnProperty.call(generation.metadata, 'invalidDate'), false);
+    assert.equal(Object.hasOwn(generation.metadata, 'invalidDate'), false);
   });
 
   test(`${framework.name} handler does not mark repeated non-cyclic metadata objects as circular`, async () => {
@@ -237,19 +215,15 @@ for (const framework of frameworks) {
         },
       });
 
-      await handler.handleLLMStart(
-        { kwargs: { model: 'gpt-5' } },
-        ['hello'],
-        'run-shared-metadata',
-        undefined,
-        { invocation_params: { model: 'gpt-5' } }
-      );
+      await handler.handleLLMStart({ kwargs: { model: 'gpt-5' } }, ['hello'], 'run-shared-metadata', undefined, {
+        invocation_params: { model: 'gpt-5' },
+      });
       await handler.handleLLMEnd(
         {
           generations: [[{ text: 'ok' }]],
           llm_output: { model_name: 'gpt-5' },
         },
-        'run-shared-metadata'
+        'run-shared-metadata',
       );
     });
 
@@ -298,14 +272,14 @@ for (const framework of frameworks) {
         {
           conversation_id: 'framework-conversation-lineage-42',
           thread_id: 'framework-thread-lineage-42',
-        }
+        },
       );
       await handler.handleLLMEnd(
         {
           generations: [[{ text: 'world' }]],
           llm_output: { model_name: 'gpt-5', finish_reason: 'stop' },
         },
-        'run-lineage'
+        'run-lineage',
       );
       parentSpan.end();
 
@@ -411,16 +385,11 @@ test('withSigilOpenAIAgentsHooks wires to hook emitter lifecycle', async () => {
       context,
       agent,
       { name: 'weather_tool' },
-      { toolCall: { callId: 'call-1', name: 'weather_tool', arguments: '{"city":"Paris"}' } }
+      { toolCall: { callId: 'call-1', name: 'weather_tool', arguments: '{"city":"Paris"}' } },
     );
-    hooks.emit(
-      'agent_tool_end',
-      context,
-      agent,
-      { name: 'weather_tool' },
-      '{"temp_c":18}',
-      { toolCall: { callId: 'call-1', name: 'weather_tool' } }
-    );
+    hooks.emit('agent_tool_end', context, agent, { name: 'weather_tool' }, '{"temp_c":18}', {
+      toolCall: { callId: 'call-1', name: 'weather_tool' },
+    });
     hooks.emit('agent_end', context, agent, 'world');
 
     registration.detach();
@@ -472,26 +441,29 @@ test('withSigilOpenAIAgentsHooks reads usage from output payload when context us
 
 test('withSigilOpenAIAgentsHooks handles agent_error and clears stack state', async () => {
   const generations = [];
-  await captureGenerations(async (client) => {
-    const hooks = new FakeHookEmitter();
-    const registration = withSigilOpenAIAgentsHooks(hooks, client);
+  await captureGenerations(
+    async (client) => {
+      const hooks = new FakeHookEmitter();
+      const registration = withSigilOpenAIAgentsHooks(hooks, client);
 
-    const context = {
-      context: {
-        conversationId: 'oa-conversation-error',
-      },
-    };
-    const agent = {
-      name: 'triage',
-      model: 'gpt-5',
-    };
+      const context = {
+        context: {
+          conversationId: 'oa-conversation-error',
+        },
+      };
+      const agent = {
+        name: 'triage',
+        model: 'gpt-5',
+      };
 
-    hooks.emit('agent_start', context, agent, [{ role: 'user', content: 'first' }]);
-    hooks.emit('agent_error', context, agent, new Error('boom'));
-    hooks.emit('agent_start', context, agent, [{ role: 'user', content: 'second' }]);
-    hooks.emit('agent_end', context, agent, 'ok');
-    registration.detach();
-  }, (generation) => generations.push(generation));
+      hooks.emit('agent_start', context, agent, [{ role: 'user', content: 'first' }]);
+      hooks.emit('agent_error', context, agent, new Error('boom'));
+      hooks.emit('agent_start', context, agent, [{ role: 'user', content: 'second' }]);
+      hooks.emit('agent_end', context, agent, 'ok');
+      registration.detach();
+    },
+    (generation) => generations.push(generation),
+  );
 
   const secondGeneration = generations.find((generation) => extractFirstText(generation.output) === 'ok');
   assert.ok(secondGeneration);
@@ -499,51 +471,49 @@ test('withSigilOpenAIAgentsHooks handles agent_error and clears stack state', as
 });
 
 test('withSigilOpenAIAgentsHooks closes tool runs when tool call id is missing', async () => {
-  await captureGenerations(async (client) => {
-    const hooks = new FakeHookEmitter();
-    const registration = withSigilOpenAIAgentsHooks(hooks, client);
+  await captureGenerations(
+    async (client) => {
+      const hooks = new FakeHookEmitter();
+      const registration = withSigilOpenAIAgentsHooks(hooks, client);
 
-    const startedRunIds = [];
-    const endedRunIds = [];
-    const originalToolStart = registration.handler.handleToolStart.bind(registration.handler);
-    const originalToolEnd = registration.handler.handleToolEnd.bind(registration.handler);
-    registration.handler.handleToolStart = async (...args) => {
-      startedRunIds.push(args[2]);
-      await originalToolStart(...args);
-    };
-    registration.handler.handleToolEnd = async (...args) => {
-      endedRunIds.push(args[1]);
-      await originalToolEnd(...args);
-    };
+      const startedRunIds = [];
+      const endedRunIds = [];
+      const originalToolStart = registration.handler.handleToolStart.bind(registration.handler);
+      const originalToolEnd = registration.handler.handleToolEnd.bind(registration.handler);
+      registration.handler.handleToolStart = async (...args) => {
+        startedRunIds.push(args[2]);
+        await originalToolStart(...args);
+      };
+      registration.handler.handleToolEnd = async (...args) => {
+        endedRunIds.push(args[1]);
+        await originalToolEnd(...args);
+      };
 
-    const context = { context: { conversationId: 'oa-no-call-id' } };
-    const agent = { name: 'triage', model: 'gpt-5' };
-    hooks.emit('agent_start', context, agent, [{ role: 'user', content: 'hello' }]);
-    hooks.emit(
-      'agent_tool_start',
-      context,
-      agent,
-      { name: 'weather_tool' },
-      { toolCall: { name: 'weather_tool', arguments: '{"city":"Paris"}' } }
-    );
-    hooks.emit(
-      'agent_tool_end',
-      context,
-      agent,
-      { name: 'weather_tool' },
-      '{"temp_c":18}',
-      { toolCall: { name: 'weather_tool' } }
-    );
-    hooks.emit('agent_end', context, agent, 'world');
+      const context = { context: { conversationId: 'oa-no-call-id' } };
+      const agent = { name: 'triage', model: 'gpt-5' };
+      hooks.emit('agent_start', context, agent, [{ role: 'user', content: 'hello' }]);
+      hooks.emit(
+        'agent_tool_start',
+        context,
+        agent,
+        { name: 'weather_tool' },
+        { toolCall: { name: 'weather_tool', arguments: '{"city":"Paris"}' } },
+      );
+      hooks.emit('agent_tool_end', context, agent, { name: 'weather_tool' }, '{"temp_c":18}', {
+        toolCall: { name: 'weather_tool' },
+      });
+      hooks.emit('agent_end', context, agent, 'world');
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
-    assert.equal(startedRunIds.length, 1);
-    assert.equal(endedRunIds.length, 1);
-    assert.equal(endedRunIds[0], startedRunIds[0]);
+      assert.equal(startedRunIds.length, 1);
+      assert.equal(endedRunIds.length, 1);
+      assert.equal(endedRunIds[0], startedRunIds[0]);
 
-    registration.detach();
-  }, () => undefined);
+      registration.detach();
+    },
+    () => undefined,
+  );
 });
 
 test('withSigilLlamaIndexCallbacks registers through callback manager API', async () => {
@@ -662,39 +632,42 @@ test('withSigilLlamaIndexCallbacks closes id-less llm runs', async () => {
 
 test('withSigilLlamaIndexCallbacks handles llm-error and clears run state', async () => {
   const generations = [];
-  await captureGenerations(async (client) => {
-    const callbackManager = new FakeCallbackManager();
-    withSigilLlamaIndexCallbacks({ callbackManager }, client);
+  await captureGenerations(
+    async (client) => {
+      const callbackManager = new FakeCallbackManager();
+      withSigilLlamaIndexCallbacks({ callbackManager }, client);
 
-    callbackManager.emit('llm-start', {
-      detail: {
-        id: 'llm-error-1',
-        conversation_id: 'llama-conversation-error',
-        messages: [{ role: 'user', content: 'first' }],
-      },
-    });
-    callbackManager.emit('llm-error', {
-      detail: {
-        id: 'llm-error-1',
-        error: new Error('boom'),
-      },
-    });
-    callbackManager.emit('llm-start', {
-      detail: {
-        id: 'llm-after-error-2',
-        conversation_id: 'llama-conversation-error',
-        messages: [{ role: 'user', content: 'second' }],
-      },
-    });
-    callbackManager.emit('llm-end', {
-      detail: {
-        id: 'llm-after-error-2',
-        response: {
-          message: { role: 'assistant', content: 'ok' },
+      callbackManager.emit('llm-start', {
+        detail: {
+          id: 'llm-error-1',
+          conversation_id: 'llama-conversation-error',
+          messages: [{ role: 'user', content: 'first' }],
         },
-      },
-    });
-  }, (generation) => generations.push(generation));
+      });
+      callbackManager.emit('llm-error', {
+        detail: {
+          id: 'llm-error-1',
+          error: new Error('boom'),
+        },
+      });
+      callbackManager.emit('llm-start', {
+        detail: {
+          id: 'llm-after-error-2',
+          conversation_id: 'llama-conversation-error',
+          messages: [{ role: 'user', content: 'second' }],
+        },
+      });
+      callbackManager.emit('llm-end', {
+        detail: {
+          id: 'llm-after-error-2',
+          response: {
+            message: { role: 'assistant', content: 'ok' },
+          },
+        },
+      });
+    },
+    (generation) => generations.push(generation),
+  );
 
   const errored = generations.find((generation) => generation.callError === 'boom');
   assert.ok(errored);
@@ -704,47 +677,50 @@ test('withSigilLlamaIndexCallbacks handles llm-error and clears run state', asyn
 });
 
 test('withSigilLlamaIndexCallbacks closes id-less tool runs', async () => {
-  await captureGenerations(async (client) => {
-    const callbackManager = new FakeCallbackManager();
-    const registration = attachSigilLlamaIndexCallbacks(callbackManager, client);
+  await captureGenerations(
+    async (client) => {
+      const callbackManager = new FakeCallbackManager();
+      const registration = attachSigilLlamaIndexCallbacks(callbackManager, client);
 
-    const startedRunIds = [];
-    const endedRunIds = [];
-    const originalToolStart = registration.handler.handleToolStart.bind(registration.handler);
-    const originalToolEnd = registration.handler.handleToolEnd.bind(registration.handler);
-    registration.handler.handleToolStart = async (...args) => {
-      startedRunIds.push(args[2]);
-      await originalToolStart(...args);
-    };
-    registration.handler.handleToolEnd = async (...args) => {
-      endedRunIds.push(args[1]);
-      await originalToolEnd(...args);
-    };
+      const startedRunIds = [];
+      const endedRunIds = [];
+      const originalToolStart = registration.handler.handleToolStart.bind(registration.handler);
+      const originalToolEnd = registration.handler.handleToolEnd.bind(registration.handler);
+      registration.handler.handleToolStart = async (...args) => {
+        startedRunIds.push(args[2]);
+        await originalToolStart(...args);
+      };
+      registration.handler.handleToolEnd = async (...args) => {
+        endedRunIds.push(args[1]);
+        await originalToolEnd(...args);
+      };
 
-    callbackManager.emit('llm-tool-call', {
-      detail: {
-        toolCall: {
-          name: 'weather_tool',
-          input: { city: 'Paris' },
+      callbackManager.emit('llm-tool-call', {
+        detail: {
+          toolCall: {
+            name: 'weather_tool',
+            input: { city: 'Paris' },
+          },
         },
-      },
-    });
-    callbackManager.emit('llm-tool-result', {
-      detail: {
-        toolCall: {
-          name: 'weather_tool',
+      });
+      callbackManager.emit('llm-tool-result', {
+        detail: {
+          toolCall: {
+            name: 'weather_tool',
+          },
+          toolResult: { temp_c: 18 },
         },
-        toolResult: { temp_c: 18 },
-      },
-    });
+      });
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
-    assert.equal(startedRunIds.length, 1);
-    assert.equal(endedRunIds.length, 1);
-    assert.equal(endedRunIds[0], startedRunIds[0]);
-    registration.detach();
-  }, () => undefined);
+      assert.equal(startedRunIds.length, 1);
+      assert.equal(endedRunIds.length, 1);
+      assert.equal(endedRunIds[0], startedRunIds[0]);
+      registration.detach();
+    },
+    () => undefined,
+  );
 });
 
 test('attachSigilLlamaIndexCallbacks reuses existing registration for same manager', () => {
@@ -820,42 +796,45 @@ test('withSigilGoogleAdkPlugins appends an ADK plugin callback implementation', 
 });
 
 test('google adk plugin closes tool runs when functionCallId is missing', async () => {
-  await captureGenerations(async (client) => {
-    const plugin = createSigilGoogleAdkPlugin(client);
+  await captureGenerations(
+    async (client) => {
+      const plugin = createSigilGoogleAdkPlugin(client);
 
-    const startedRunIds = [];
-    const endedRunIds = [];
-    const originalToolStart = plugin.handler.handleToolStart.bind(plugin.handler);
-    const originalToolEnd = plugin.handler.handleToolEnd.bind(plugin.handler);
-    plugin.handler.handleToolStart = async (...args) => {
-      startedRunIds.push(args[2]);
-      await originalToolStart(...args);
-    };
-    plugin.handler.handleToolEnd = async (...args) => {
-      endedRunIds.push(args[1]);
-      await originalToolEnd(...args);
-    };
+      const startedRunIds = [];
+      const endedRunIds = [];
+      const originalToolStart = plugin.handler.handleToolStart.bind(plugin.handler);
+      const originalToolEnd = plugin.handler.handleToolEnd.bind(plugin.handler);
+      plugin.handler.handleToolStart = async (...args) => {
+        startedRunIds.push(args[2]);
+        await originalToolStart(...args);
+      };
+      plugin.handler.handleToolEnd = async (...args) => {
+        endedRunIds.push(args[1]);
+        await originalToolEnd(...args);
+      };
 
-    const invocationContext = {
-      invocationId: 'inv-tool-no-call-id',
-      session: { id: 'conversation-tool-no-call-id' },
-      agent: { name: 'tool-agent' },
-    };
+      const invocationContext = {
+        invocationId: 'inv-tool-no-call-id',
+        session: { id: 'conversation-tool-no-call-id' },
+        agent: { name: 'tool-agent' },
+      };
 
-    await plugin.beforeToolCallback({
-      tool: { name: 'weather_tool' },
-      toolArgs: { city: 'Paris' },
-      toolContext: { invocationContext },
-    });
-    await plugin.afterToolCallback({
-      toolContext: { invocationContext },
-      result: { temp_c: 18 },
-    });
+      await plugin.beforeToolCallback({
+        tool: { name: 'weather_tool' },
+        toolArgs: { city: 'Paris' },
+        toolContext: { invocationContext },
+      });
+      await plugin.afterToolCallback({
+        toolContext: { invocationContext },
+        result: { temp_c: 18 },
+      });
 
-    assert.equal(startedRunIds.length, 1);
-    assert.equal(endedRunIds.length, 1);
-    assert.equal(endedRunIds[0], startedRunIds[0]);
-  }, () => undefined);
+      assert.equal(startedRunIds.length, 1);
+      assert.equal(endedRunIds.length, 1);
+      assert.equal(endedRunIds[0], startedRunIds[0]);
+    },
+    () => undefined,
+  );
 });
 
 test('google adk plugin uses onUserMessageCallback when llmRequest has no contents', async () => {
@@ -1036,7 +1015,7 @@ class FakeHookEmitter {
     const existing = this.listeners.get(event) ?? [];
     this.listeners.set(
       event,
-      existing.filter((entry) => entry !== listener)
+      existing.filter((entry) => entry !== listener),
     );
     return this;
   }
@@ -1063,7 +1042,7 @@ class FakeCallbackManager {
     const existing = this.listeners.get(event) ?? [];
     this.listeners.set(
       event,
-      existing.filter((entry) => entry !== listener)
+      existing.filter((entry) => entry !== listener),
     );
     return this;
   }

--- a/js/test/frameworks.langchain.test.mjs
+++ b/js/test/frameworks.langchain.test.mjs
@@ -2,8 +2,8 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { context, SpanStatusCode, trace } from '@opentelemetry/api';
 import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { defaultConfig, SigilClient } from '../.test-dist/index.js';
 import { SigilLangChainHandler } from '../.test-dist/frameworks/langchain/index.js';
+import { defaultConfig, SigilClient } from '../.test-dist/index.js';
 
 class CapturingExporter {
   requests = [];
@@ -39,7 +39,7 @@ test('langchain handler records sync lifecycle with framework tags', async () =>
       'parent-run-sync',
       { invocation_params: { model: 'gpt-5', retry_attempt: 2 } },
       ['prod', 'blue'],
-      { thread_id: 'chain-thread-42' }
+      { thread_id: 'chain-thread-42' },
     );
     await handler.handleLLMEnd(
       {
@@ -54,7 +54,7 @@ test('langchain handler records sync lifecycle with framework tags', async () =>
           },
         },
       },
-      'run-sync'
+      'run-sync',
     );
   });
 
@@ -85,13 +85,9 @@ test('langchain handler records stream mode and token fallback output', async ()
   const generation = await captureSingleGeneration(async (client) => {
     const handler = new SigilLangChainHandler(client);
 
-    await handler.handleLLMStart(
-      { kwargs: { model: 'claude-sonnet-4-5' } },
-      ['stream this'],
-      'run-stream',
-      undefined,
-      { invocation_params: { model: 'claude-sonnet-4-5', stream: true } }
-    );
+    await handler.handleLLMStart({ kwargs: { model: 'claude-sonnet-4-5' } }, ['stream this'], 'run-stream', undefined, {
+      invocation_params: { model: 'claude-sonnet-4-5', stream: true },
+    });
     await handler.handleLLMNewToken('hello', undefined, 'run-stream');
     await handler.handleLLMNewToken(' world', undefined, 'run-stream');
     await handler.handleLLMEnd({ llm_output: { model_name: 'claude-sonnet-4-5' } }, 'run-stream');
@@ -115,13 +111,9 @@ test('langchain handler records first token timestamp once per run', async () =>
 
   try {
     const handler = new SigilLangChainHandler(client);
-    await handler.handleLLMStart(
-      { kwargs: { model: 'gpt-5' } },
-      ['stream this'],
-      'run-ttft',
-      undefined,
-      { invocation_params: { model: 'gpt-5', stream: true } }
-    );
+    await handler.handleLLMStart({ kwargs: { model: 'gpt-5' } }, ['stream this'], 'run-ttft', undefined, {
+      invocation_params: { model: 'gpt-5', stream: true },
+    });
 
     const runState = handler.runs.get('run-ttft');
     assert.ok(runState);
@@ -181,14 +173,14 @@ test('langchain generation span tracks active parent span and preserves export l
       'parent-run-lineage',
       { invocation_params: { model: 'gpt-5' } },
       ['prod'],
-      { thread_id: 'chain-thread-lineage-42' }
+      { thread_id: 'chain-thread-lineage-42' },
     );
     await handler.handleLLMEnd(
       {
         generations: [[{ text: 'world' }]],
         llm_output: { model_name: 'gpt-5', finish_reason: 'stop' },
       },
-      'run-lineage'
+      'run-lineage',
     );
     parentSpan.end();
 
@@ -212,21 +204,30 @@ test('langchain generation span tracks active parent span and preserves export l
 test('langchain provider mapping covers openai anthopic gemini and fallback', async () => {
   const providers = [];
 
-  await captureGenerations(async (client) => {
-    const handler = new SigilLangChainHandler(client);
+  await captureGenerations(
+    async (client) => {
+      const handler = new SigilLangChainHandler(client);
 
-    await handler.handleLLMStart({}, ['x'], 'run-openai', undefined, { invocation_params: { model: 'gpt-5' } });
-    await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-openai');
+      await handler.handleLLMStart({}, ['x'], 'run-openai', undefined, { invocation_params: { model: 'gpt-5' } });
+      await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-openai');
 
-    await handler.handleLLMStart({}, ['x'], 'run-anthropic', undefined, { invocation_params: { model: 'claude-sonnet-4-5' } });
-    await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-anthropic');
+      await handler.handleLLMStart({}, ['x'], 'run-anthropic', undefined, {
+        invocation_params: { model: 'claude-sonnet-4-5' },
+      });
+      await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-anthropic');
 
-    await handler.handleLLMStart({}, ['x'], 'run-gemini', undefined, { invocation_params: { model: 'gemini-2.5-pro' } });
-    await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-gemini');
+      await handler.handleLLMStart({}, ['x'], 'run-gemini', undefined, {
+        invocation_params: { model: 'gemini-2.5-pro' },
+      });
+      await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-gemini');
 
-    await handler.handleLLMStart({}, ['x'], 'run-custom', undefined, { invocation_params: { model: 'mistral-large' } });
-    await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-custom');
-  }, (generation) => providers.push(generation.model.provider));
+      await handler.handleLLMStart({}, ['x'], 'run-custom', undefined, {
+        invocation_params: { model: 'mistral-large' },
+      });
+      await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-custom');
+    },
+    (generation) => providers.push(generation.model.provider),
+  );
 
   assert.deepEqual(providers, ['openai', 'anthropic', 'gemini', 'custom']);
 });
@@ -281,7 +282,7 @@ test('langchain handler maps tool callbacks and emits chain/retriever spans', as
       'tool-run',
       'parent-run',
       ['tools'],
-      { thread_id: 'chain-thread-42' }
+      { thread_id: 'chain-thread-42' },
     );
     await handler.handleToolEnd({ temp_c: 18 }, 'tool-run');
 
@@ -292,7 +293,7 @@ test('langchain handler maps tool callbacks and emits chain/retriever spans', as
       'parent-run',
       ['workflow'],
       { thread_id: 'chain-thread-42' },
-      'chain'
+      'chain',
     );
     await handler.handleChainEnd({}, 'chain-run');
 
@@ -302,7 +303,7 @@ test('langchain handler maps tool callbacks and emits chain/retriever spans', as
       'retriever-run',
       'parent-run',
       ['retriever'],
-      { thread_id: 'chain-thread-42' }
+      { thread_id: 'chain-thread-42' },
     );
     await handler.handleRetrieverError(new Error('retriever failed'), 'retriever-run');
 

--- a/js/test/frameworks.langgraph.test.mjs
+++ b/js/test/frameworks.langgraph.test.mjs
@@ -2,8 +2,8 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { context, SpanStatusCode, trace } from '@opentelemetry/api';
 import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { defaultConfig, SigilClient } from '../.test-dist/index.js';
 import { SigilLangGraphHandler } from '../.test-dist/frameworks/langgraph/index.js';
+import { defaultConfig, SigilClient } from '../.test-dist/index.js';
 
 class CapturingExporter {
   requests = [];
@@ -39,7 +39,7 @@ test('langgraph handler records sync lifecycle with framework tags', async () =>
       'parent-run-sync',
       { invocation_params: { model: 'gpt-5', retry_attempt: 2 } },
       ['prod', 'blue'],
-      { thread_id: 'graph-thread-42', langgraph_node: 'answer_node' }
+      { thread_id: 'graph-thread-42', langgraph_node: 'answer_node' },
     );
     await handler.handleLLMEnd(
       {
@@ -54,7 +54,7 @@ test('langgraph handler records sync lifecycle with framework tags', async () =>
           },
         },
       },
-      'run-sync'
+      'run-sync',
     );
   });
 
@@ -80,13 +80,9 @@ test('langgraph handler records stream mode and token fallback output', async ()
   const generation = await captureSingleGeneration(async (client) => {
     const handler = new SigilLangGraphHandler(client);
 
-    await handler.handleLLMStart(
-      { kwargs: { model: 'gemini-2.5-pro' } },
-      ['stream this'],
-      'run-stream',
-      undefined,
-      { invocation_params: { model: 'gemini-2.5-pro', streaming: true } }
-    );
+    await handler.handleLLMStart({ kwargs: { model: 'gemini-2.5-pro' } }, ['stream this'], 'run-stream', undefined, {
+      invocation_params: { model: 'gemini-2.5-pro', streaming: true },
+    });
     await handler.handleLLMNewToken('hello', undefined, 'run-stream');
     await handler.handleLLMNewToken(' world', undefined, 'run-stream');
     await handler.handleLLMEnd({ llm_output: { model_name: 'gemini-2.5-pro' } }, 'run-stream');
@@ -135,14 +131,14 @@ test('langgraph generation span tracks active parent span and preserves export l
       'parent-run-lineage',
       { invocation_params: { model: 'gpt-5' } },
       ['prod'],
-      { thread_id: 'graph-thread-lineage-42', langgraph_node: 'answer_node' }
+      { thread_id: 'graph-thread-lineage-42', langgraph_node: 'answer_node' },
     );
     await handler.handleLLMEnd(
       {
         generations: [[{ text: 'world' }]],
         llm_output: { model_name: 'gpt-5', finish_reason: 'stop' },
       },
-      'run-lineage'
+      'run-lineage',
     );
     parentSpan.end();
 
@@ -166,21 +162,30 @@ test('langgraph generation span tracks active parent span and preserves export l
 test('langgraph provider mapping covers openai anthopic gemini and fallback', async () => {
   const providers = [];
 
-  await captureGenerations(async (client) => {
-    const handler = new SigilLangGraphHandler(client);
+  await captureGenerations(
+    async (client) => {
+      const handler = new SigilLangGraphHandler(client);
 
-    await handler.handleLLMStart({}, ['x'], 'run-openai', undefined, { invocation_params: { model: 'o3-mini' } });
-    await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-openai');
+      await handler.handleLLMStart({}, ['x'], 'run-openai', undefined, { invocation_params: { model: 'o3-mini' } });
+      await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-openai');
 
-    await handler.handleLLMStart({}, ['x'], 'run-anthropic', undefined, { invocation_params: { model: 'claude-sonnet-4-5' } });
-    await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-anthropic');
+      await handler.handleLLMStart({}, ['x'], 'run-anthropic', undefined, {
+        invocation_params: { model: 'claude-sonnet-4-5' },
+      });
+      await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-anthropic');
 
-    await handler.handleLLMStart({}, ['x'], 'run-gemini', undefined, { invocation_params: { model: 'gemini-2.5-pro' } });
-    await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-gemini');
+      await handler.handleLLMStart({}, ['x'], 'run-gemini', undefined, {
+        invocation_params: { model: 'gemini-2.5-pro' },
+      });
+      await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-gemini');
 
-    await handler.handleLLMStart({}, ['x'], 'run-custom', undefined, { invocation_params: { model: 'mistral-large' } });
-    await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-custom');
-  }, (generation) => providers.push(generation.model.provider));
+      await handler.handleLLMStart({}, ['x'], 'run-custom', undefined, {
+        invocation_params: { model: 'mistral-large' },
+      });
+      await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-custom');
+    },
+    (generation) => providers.push(generation.model.provider),
+  );
 
   assert.deepEqual(providers, ['openai', 'anthropic', 'gemini', 'custom']);
 });
@@ -235,7 +240,7 @@ test('langgraph handler maps tool callbacks and emits chain/retriever spans', as
       'tool-run',
       'parent-run',
       ['tools'],
-      { thread_id: 'graph-thread-42', langgraph_node: 'tool_node' }
+      { thread_id: 'graph-thread-42', langgraph_node: 'tool_node' },
     );
     await handler.handleToolEnd({ temp_c: 18 }, 'tool-run');
 
@@ -246,7 +251,7 @@ test('langgraph handler maps tool callbacks and emits chain/retriever spans', as
       'parent-run',
       ['workflow'],
       { thread_id: 'graph-thread-42', langgraph_node: 'chain_node' },
-      'chain'
+      'chain',
     );
     await handler.handleChainEnd({}, 'chain-run');
 
@@ -256,7 +261,7 @@ test('langgraph handler maps tool callbacks and emits chain/retriever spans', as
       'retriever-run',
       'parent-run',
       ['retriever'],
-      { thread_id: 'graph-thread-42', langgraph_node: 'retriever_node' }
+      { thread_id: 'graph-thread-42', langgraph_node: 'retriever_node' },
     );
     await handler.handleRetrieverError(new Error('retriever failed'), 'retriever-run');
 

--- a/js/test/frameworks.vercel-ai-sdk.test.mjs
+++ b/js/test/frameworks.vercel-ai-sdk.test.mjs
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-
-import { defaultConfig, SigilClient } from '../.test-dist/index.js';
 import { createSigilVercelAiSdk } from '../.test-dist/frameworks/vercel-ai-sdk/index.js';
+import { defaultConfig, SigilClient } from '../.test-dist/index.js';
 
 class CapturingExporter {
   requests = [];
@@ -390,47 +389,50 @@ test('vercel ai sdk generateText hooks support multi-step loop and tool lifecycl
 });
 
 test('vercel ai sdk streamText hooks capture TTFT once and record streaming result', async () => {
-  const { generations, firstTokenCalls } = await captureSession(async (client) => {
-    const sigil = createSigilVercelAiSdk(client);
-    const hooks = sigil.streamTextHooks({ conversationId: 'conv-stream' });
+  const { generations, firstTokenCalls } = await captureSession(
+    async (client) => {
+      const sigil = createSigilVercelAiSdk(client);
+      const hooks = sigil.streamTextHooks({ conversationId: 'conv-stream' });
 
-    hooks.experimental_onStepStart?.({
-      stepNumber: 0,
-      model: { modelId: 'claude-sonnet-4-5' },
-      messages: [{ role: 'user', content: 'stream hello' }],
-    });
-    hooks.onChunk?.({
-      stepNumber: 0,
-      chunk: {
-        type: 'reasoning',
-        text: 'thinking',
-      },
-    });
-    hooks.onChunk?.({
-      stepNumber: 0,
-      chunk: {
-        type: 'text-delta',
-        text: 'hel',
-      },
-    });
-    hooks.onChunk?.({
-      stepNumber: 0,
-      chunk: {
-        type: 'text-delta',
-        text: 'lo',
-      },
-    });
-    hooks.onStepFinish?.({
-      stepNumber: 0,
-      stepType: 'initial',
-      text: 'hello',
-      finishReason: 'stop',
-      response: {
-        id: 'resp-stream',
-        modelId: 'claude-sonnet-4-5',
-      },
-    });
-  }, { countFirstTokenCalls: true });
+      hooks.experimental_onStepStart?.({
+        stepNumber: 0,
+        model: { modelId: 'claude-sonnet-4-5' },
+        messages: [{ role: 'user', content: 'stream hello' }],
+      });
+      hooks.onChunk?.({
+        stepNumber: 0,
+        chunk: {
+          type: 'reasoning',
+          text: 'thinking',
+        },
+      });
+      hooks.onChunk?.({
+        stepNumber: 0,
+        chunk: {
+          type: 'text-delta',
+          text: 'hel',
+        },
+      });
+      hooks.onChunk?.({
+        stepNumber: 0,
+        chunk: {
+          type: 'text-delta',
+          text: 'lo',
+        },
+      });
+      hooks.onStepFinish?.({
+        stepNumber: 0,
+        stepType: 'initial',
+        text: 'hello',
+        finishReason: 'stop',
+        response: {
+          id: 'resp-stream',
+          modelId: 'claude-sonnet-4-5',
+        },
+      });
+    },
+    { countFirstTokenCalls: true },
+  );
 
   assert.equal(firstTokenCalls, 1);
   assert.equal(generations.length, 1);
@@ -589,28 +591,31 @@ test('vercel ai sdk streamText synthetic step fallback does not reuse first-step
 });
 
 test('vercel ai sdk streamText synthetic step preserves pre-finish start timestamp', async () => {
-  const { generations, firstTokenCalls } = await captureSession(async (client) => {
-    const sigil = createSigilVercelAiSdk(client);
-    const hooks = sigil.streamTextHooks({ conversationId: 'conv-stream-synthetic-start' });
+  const { generations, firstTokenCalls } = await captureSession(
+    async (client) => {
+      const sigil = createSigilVercelAiSdk(client);
+      const hooks = sigil.streamTextHooks({ conversationId: 'conv-stream-synthetic-start' });
 
-    hooks.onChunk?.({
-      stepNumber: 0,
-      chunk: {
-        type: 'text-delta',
-        text: 'hel',
-      },
-    });
+      hooks.onChunk?.({
+        stepNumber: 0,
+        chunk: {
+          type: 'text-delta',
+          text: 'hel',
+        },
+      });
 
-    await new Promise((resolve) => setTimeout(resolve, 20));
+      await new Promise((resolve) => setTimeout(resolve, 20));
 
-    hooks.onStepFinish?.({
-      stepNumber: 0,
-      stepType: 'initial',
-      text: 'hello',
-      finishReason: 'stop',
-      response: { id: 'resp-stream-synthetic-start', modelId: 'gpt-5' },
-    });
-  }, { countFirstTokenCalls: true });
+      hooks.onStepFinish?.({
+        stepNumber: 0,
+        stepType: 'initial',
+        text: 'hello',
+        finishReason: 'stop',
+        response: { id: 'resp-stream-synthetic-start', modelId: 'gpt-5' },
+      });
+    },
+    { countFirstTokenCalls: true },
+  );
 
   assert.equal(generations.length, 1);
   assert.equal(firstTokenCalls, 1);

--- a/js/test/providers.test.mjs
+++ b/js/test/providers.test.mjs
@@ -44,7 +44,7 @@ test('anthropic messages wrapper maps strict request/response and records SYNC m
             web_search_requests: 2,
           },
         },
-      })
+      }),
     );
   });
 
@@ -104,7 +104,7 @@ test('gemini models wrapper maps strict request/response and records SYNC mode',
           thoughtsTokenCount: 6,
           toolUsePromptTokenCount: 5,
         },
-      })
+      }),
     );
   });
 
@@ -139,7 +139,7 @@ test('anthropic and gemini stream wrappers set STREAM mode and include artifacts
           { type: 'message_delta', usage: { server_tool_use: { web_search_requests: 1 } } },
         ],
       }),
-      { rawArtifacts: true }
+      { rawArtifacts: true },
     );
   });
 
@@ -153,7 +153,7 @@ test('anthropic and gemini stream wrappers set STREAM mode and include artifacts
   assert.ok(Array.isArray(anthropicGeneration.artifacts));
   assert.deepEqual(
     anthropicGeneration.artifacts.map((artifact) => artifact.type),
-    ['request', 'provider_event']
+    ['request', 'provider_event'],
   );
 
   const geminiGeneration = await captureSingleGeneration(async (client) => {
@@ -194,7 +194,7 @@ test('anthropic and gemini stream wrappers set STREAM mode and include artifacts
           },
         ],
       }),
-      { rawArtifacts: true }
+      { rawArtifacts: true },
     );
   });
 
@@ -208,7 +208,7 @@ test('anthropic and gemini stream wrappers set STREAM mode and include artifacts
   assert.ok(Array.isArray(geminiGeneration.artifacts));
   assert.deepEqual(
     geminiGeneration.artifacts.map((artifact) => artifact.type),
-    ['request', 'response', 'provider_event']
+    ['request', 'response', 'provider_event'],
   );
 });
 
@@ -250,7 +250,7 @@ test('openai chat completions wrapper maps strict request/response and records S
           prompt_tokens_details: { cached_tokens: 3 },
           completion_tokens_details: { reasoning_tokens: 4 },
         },
-      })
+      }),
     );
   });
 
@@ -288,7 +288,7 @@ test('openai chat completions stream wrapper records STREAM mode and stream even
           },
         ],
       }),
-      { rawArtifacts: true }
+      { rawArtifacts: true },
     );
   });
 
@@ -299,7 +299,7 @@ test('openai chat completions stream wrapper records STREAM mode and stream even
   assert.ok(Array.isArray(generation.artifacts));
   assert.deepEqual(
     generation.artifacts.map((artifact) => artifact.type),
-    ['request', 'provider_event']
+    ['request', 'provider_event'],
   );
 });
 
@@ -346,7 +346,7 @@ test('openai responses wrapper maps strict request/response and records SYNC mod
           input_tokens_details: { cached_tokens: 2 },
           output_tokens_details: { reasoning_tokens: 3 },
         },
-      })
+      }),
     );
   });
 
@@ -416,7 +416,7 @@ test('openai responses stream wrapper records STREAM mode with stream event arti
           },
         ],
       }),
-      { rawArtifacts: true }
+      { rawArtifacts: true },
     );
   });
 
@@ -442,7 +442,7 @@ test('openai embeddings wrapper records embedding span and does not enqueue gene
         model: 'text-embedding-3-small',
         usage: { prompt_tokens: 22 },
         data: [{ embedding: [0.1, 0.2, 0.3] }],
-      })
+      }),
     );
 
     await harness.client.flush();
@@ -476,7 +476,7 @@ test('openai embeddings wrapper treats token-array input as a single item', asyn
         model: 'text-embedding-3-small',
         usage: { prompt_tokens: 4 },
         data: [{ embedding: [0.1, 0.2] }],
-      })
+      }),
     );
 
     await harness.client.flush();
@@ -504,7 +504,7 @@ test('gemini embeddings wrapper maps usage and dimensions to embedding span', as
           { values: [0.1, 0.2, 0.3, 0.4], statistics: { tokenCount: 9 } },
           { values: [0.5, 0.6, 0.7, 0.8], statistics: { tokenCount: 6 } },
         ],
-      })
+      }),
     );
 
     await harness.client.flush();
@@ -536,9 +536,9 @@ test('embedding provider wrapper errors set provider_call_error span status', as
         },
         async () => {
           throw new Error('provider failure openai embedding');
-        }
+        },
       ),
-      /provider failure openai embedding/
+      /provider failure openai embedding/,
     );
 
     const span = singleEmbeddingSpan(harness.spanExporter);
@@ -551,88 +551,91 @@ test('embedding provider wrapper errors set provider_call_error span status', as
 
 test('provider mappers throw on missing provider responses and stream summaries', () => {
   assert.throws(
-    () => openai.chat.completions.fromRequestResponse(
-      {
-        model: 'gpt-5',
-        messages: [{ role: 'user', content: 'hello' }],
-      },
-      undefined
-    ),
-    /reading 'id'/
+    () =>
+      openai.chat.completions.fromRequestResponse(
+        {
+          model: 'gpt-5',
+          messages: [{ role: 'user', content: 'hello' }],
+        },
+        undefined,
+      ),
+    /reading 'id'/,
   );
   assert.throws(
-    () => openai.responses.fromRequestResponse(
-      {
-        model: 'gpt-5',
-        input: 'hello',
-      },
-      undefined
-    ),
-    /reading 'id'/
+    () =>
+      openai.responses.fromRequestResponse(
+        {
+          model: 'gpt-5',
+          input: 'hello',
+        },
+        undefined,
+      ),
+    /reading 'id'/,
   );
   assert.throws(
-    () => openai.chat.completions.fromStream(
-      {
-        model: 'gpt-5',
-        stream: true,
-        messages: [{ role: 'user', content: 'hello' }],
-      },
-      undefined
-    ),
-    /reading 'outputText'/
+    () =>
+      openai.chat.completions.fromStream(
+        {
+          model: 'gpt-5',
+          stream: true,
+          messages: [{ role: 'user', content: 'hello' }],
+        },
+        undefined,
+      ),
+    /reading 'outputText'/,
   );
   assert.throws(
-    () => openai.responses.fromStream(
-      {
-        model: 'gpt-5',
-        stream: true,
-        input: 'hello',
-      },
-      undefined
-    ),
-    /reading 'events'/
-  );
-
-  assert.throws(
-    () => anthropic.messages.fromRequestResponse(
-      {
-        model: 'claude-sonnet-4-5',
-        max_tokens: 128,
-        messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
-      },
-      undefined
-    ),
-    /reading 'content'/
-  );
-  assert.throws(
-    () => anthropic.messages.fromStream(
-      {
-        model: 'claude-sonnet-4-5',
-        max_tokens: 128,
-        messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
-      },
-      undefined
-    ),
-    /reading 'events'/
+    () =>
+      openai.responses.fromStream(
+        {
+          model: 'gpt-5',
+          stream: true,
+          input: 'hello',
+        },
+        undefined,
+      ),
+    /reading 'events'/,
   );
 
   assert.throws(
-    () => gemini.models.fromRequestResponse(
-      'gemini-2.5-pro',
-      [{ role: 'user', parts: [{ text: 'hello' }] }],
-      undefined,
-      undefined
-    ),
-    /reading 'candidates'/
+    () =>
+      anthropic.messages.fromRequestResponse(
+        {
+          model: 'claude-sonnet-4-5',
+          max_tokens: 128,
+          messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+        },
+        undefined,
+      ),
+    /reading 'content'/,
   );
   assert.throws(
-    () => gemini.models.fromStream(
-      'gemini-2.5-pro',
-      [{ role: 'user', parts: [{ text: 'hello' }] }],
-      undefined,
-      undefined
-    ),
-    /reading 'responses'/
+    () =>
+      anthropic.messages.fromStream(
+        {
+          model: 'claude-sonnet-4-5',
+          max_tokens: 128,
+          messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+        },
+        undefined,
+      ),
+    /reading 'events'/,
+  );
+
+  assert.throws(
+    () =>
+      gemini.models.fromRequestResponse(
+        'gemini-2.5-pro',
+        [{ role: 'user', parts: [{ text: 'hello' }] }],
+        undefined,
+        undefined,
+      ),
+    /reading 'candidates'/,
+  );
+  assert.throws(
+    () =>
+      gemini.models.fromStream('gemini-2.5-pro', [{ role: 'user', parts: [{ text: 'hello' }] }], undefined, undefined),
+    /reading 'responses'/,
   );
 });
 
@@ -648,7 +651,7 @@ test('provider wrappers surface mapper failures when provider payloads are missi
             model: 'gpt-5',
             messages: [{ role: 'user', content: 'hello' }],
           },
-          async () => undefined
+          async () => undefined,
         );
       },
     },
@@ -662,7 +665,7 @@ test('provider wrappers surface mapper failures when provider payloads are missi
             model: 'gpt-5',
             input: 'hello',
           },
-          async () => undefined
+          async () => undefined,
         );
       },
     },
@@ -677,7 +680,7 @@ test('provider wrappers surface mapper failures when provider payloads are missi
             max_tokens: 128,
             messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
           },
-          async () => undefined
+          async () => undefined,
         );
       },
     },
@@ -690,7 +693,7 @@ test('provider wrappers surface mapper failures when provider payloads are missi
           'gemini-2.5-pro',
           [{ role: 'user', parts: [{ text: 'hello' }] }],
           undefined,
-          async () => undefined
+          async () => undefined,
         );
       },
     },
@@ -720,40 +723,39 @@ test('provider wrappers propagate provider errors and persist callError', async 
     {
       name: 'anthropic',
       provider: 'anthropic',
-      run: (client) => anthropic.messages.create(
-        client,
-        {
-          model: 'claude-sonnet-4-5',
-          max_tokens: 128,
-          messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
-        },
-        async () => {
-          throw new Error('provider failure anthropic');
-        }
-      ),
+      run: (client) =>
+        anthropic.messages.create(
+          client,
+          {
+            model: 'claude-sonnet-4-5',
+            max_tokens: 128,
+            messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+          },
+          async () => {
+            throw new Error('provider failure anthropic');
+          },
+        ),
     },
     {
       name: 'gemini',
       provider: 'gemini',
-      run: (client) => gemini.models.generateContent(
-        client,
-        'gemini-2.5-pro',
-        [{ role: 'user', parts: [{ text: 'hello' }] }],
-        undefined,
-        async () => {
-          throw new Error('provider failure gemini');
-        }
-      ),
+      run: (client) =>
+        gemini.models.generateContent(
+          client,
+          'gemini-2.5-pro',
+          [{ role: 'user', parts: [{ text: 'hello' }] }],
+          undefined,
+          async () => {
+            throw new Error('provider failure gemini');
+          },
+        ),
     },
   ]) {
     const exporter = new CapturingExporter();
     const client = newClient(exporter);
 
     try {
-      await assert.rejects(
-        suite.run(client),
-        new RegExp(`provider failure ${suite.name}`)
-      );
+      await assert.rejects(suite.run(client), new RegExp(`provider failure ${suite.name}`));
 
       await client.flush();
       const generation = firstGeneration(exporter);
@@ -775,7 +777,7 @@ test('provider wrappers propagate provider errors and persist callError', async 
         },
         async () => {
           throw new Error('provider failure openai chat');
-        }
+        },
       );
     },
     async (client) => {
@@ -787,7 +789,7 @@ test('provider wrappers propagate provider errors and persist callError', async 
         },
         async () => {
           throw new Error('provider failure openai responses');
-        }
+        },
       );
     },
   ]) {
@@ -887,7 +889,7 @@ test('openai chat mapper aggregates system/developer, preserves tool role, and a
   });
   assert.deepEqual(
     mappedWithArtifacts.artifacts.map((artifact) => artifact.type),
-    ['request', 'response', 'tools']
+    ['request', 'response', 'tools'],
   );
 });
 
@@ -1000,7 +1002,7 @@ test('openai responses mapper maps input/output/usage and stream fallback from e
         },
       ],
     },
-    { rawArtifacts: true }
+    { rawArtifacts: true },
   );
 
   assert.equal(streamed.responseModel, 'gpt-5');
@@ -1010,7 +1012,7 @@ test('openai responses mapper maps input/output/usage and stream fallback from e
   assert.equal(streamed.output[0].content, 'delta-one delta-two');
   assert.deepEqual(
     streamed.artifacts.map((artifact) => artifact.type),
-    ['request', 'provider_event']
+    ['request', 'provider_event'],
   );
 });
 
@@ -1027,7 +1029,7 @@ test('provider mappers expose thinking disabled when explicitly configured', () 
       model: 'claude-sonnet',
       role: 'assistant',
       content: [{ type: 'text', text: 'ok' }],
-    }
+    },
   );
   assert.equal(anthropicMapped.thinkingEnabled, false);
 
@@ -1039,7 +1041,7 @@ test('provider mappers expose thinking disabled when explicitly configured', () 
       responseId: 'resp-gemini',
       modelVersion: 'gemini-pro',
       candidates: [{ content: { role: 'model', parts: [{ text: 'ok' }] } }],
-    }
+    },
   );
   assert.equal(geminiMapped.thinkingEnabled, false);
 });
@@ -1054,7 +1056,7 @@ test('embedding mappers extract input counts, texts, usage, and dimensions', () 
       model: 'text-embedding-3-small',
       usage: { prompt_tokens: 30 },
       data: [{ embedding: [0.1, 0.2, 0.3] }],
-    }
+    },
   );
   assert.equal(openAIMapped.inputCount, 3);
   assert.deepEqual(openAIMapped.inputTexts, ['hello', 'world']);
@@ -1071,7 +1073,7 @@ test('embedding mappers extract input counts, texts, usage, and dimensions', () 
       model: 'text-embedding-3-small',
       usage: { prompt_tokens: 3 },
       data: [{ embedding: [0.1, 0.2] }],
-    }
+    },
   );
   assert.equal(openAITokenizedSingle.inputCount, 1);
   assert.equal(openAITokenizedSingle.inputTexts, undefined);
@@ -1086,7 +1088,7 @@ test('embedding mappers extract input counts, texts, usage, and dimensions', () 
         { values: [0.1, 0.2], statistics: { tokenCount: 4 } },
         { values: [0.3, 0.4], statistics: { tokenCount: 5 } },
       ],
-    }
+    },
   );
   assert.equal(geminiMapped.inputCount, 2);
   assert.deepEqual(geminiMapped.inputTexts, ['alpha', 'beta']);
@@ -1165,7 +1167,9 @@ async function shutdownEmbeddingHarness(harness) {
 }
 
 function singleEmbeddingSpan(spanExporter) {
-  const spans = spanExporter.getFinishedSpans().filter((span) => span.attributes['gen_ai.operation.name'] === 'embeddings');
+  const spans = spanExporter
+    .getFinishedSpans()
+    .filter((span) => span.attributes['gen_ai.operation.name'] === 'embeddings');
   assert.equal(spans.length, 1);
   return spans[0];
 }

--- a/js/test/tooling.test.mjs
+++ b/js/test/tooling.test.mjs
@@ -14,6 +14,6 @@ test('sdk js package declares local TypeScript compiler tooling', async () => {
   assert.equal(
     typeof packageJson.devDependencies?.typescript,
     'string',
-    'sdks/js must declare a local typescript dependency'
+    'sdks/js must declare a local typescript dependency',
   );
 });

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,6 @@
+[tools]
+biome = "2.4.11"
+
 [env]
 PYTHON_BIN = "python3"
 
@@ -24,9 +27,14 @@ done < <(find . -name go.mod -not -path './node_modules/*' -exec dirname {} \\; 
 description = "Format .NET SDK code"
 run = "dotnet format dotnet/Sigil.DotNet.sln"
 
+[tasks."format:ts:sdk-js"]
+description = "Format TypeScript/JavaScript SDK code"
+depends = ["deps"]
+run = "pnpm --filter @grafana/sigil-sdk-js run lint:fix"
+
 [tasks.format]
 description = "Format all code"
-depends = ["format:go", "format:cs"]
+depends = ["format:go", "format:cs", "format:ts:sdk-js"]
 
 # --- Linting ---
 
@@ -49,9 +57,14 @@ done < <(find . -name go.mod -not -path './node_modules/*' -exec dirname {} \\; 
 description = "Verify .NET SDK formatting and analyzer checks"
 run = "dotnet format dotnet/Sigil.DotNet.sln --verify-no-changes"
 
+[tasks."lint:ts:sdk-js"]
+description = "Lint TypeScript/JavaScript SDK code"
+depends = ["deps"]
+run = "pnpm --filter @grafana/sigil-sdk-js run lint"
+
 [tasks.lint]
 description = "Run all linting"
-depends = ["lint:go", "lint:cs"]
+depends = ["lint:go", "lint:cs", "lint:ts:sdk-js"]
 
 # --- Type checking ---
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily tooling/formatting changes plus a new CI lint step; runtime behavior should be unchanged, but CI may start failing on newly enforced lint rules.
> 
> **Overview**
> Adds Biome to the JS SDK: introduces `js/biome.json`, adds `lint`/`lint:fix` scripts, and updates CI to install Biome via `mise` and run `mise run lint:ts:sdk-js`.
> 
> Applies widespread Biome-driven formatting and import-order fixes across the JS SDK (framework adapters, exporters, providers, and core client), including an explicit `biome-ignore` for an intentional throw in a `finally` block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8ea4b481ca5714b98fe71fe79be1f5800157789. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->