### PR TITLE
ci: add lint and test for Claude Code plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,3 +130,28 @@ jobs:
       - name: Test
         working-directory: java
         run: ./gradlew --no-daemon test
+
+  claude-code-plugin:
+    name: Claude Code Plugin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: plugins/claude-code/go.mod
+
+      - name: Setup mise
+        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
+        with:
+          install: true
+          install_args: golangci-lint
+          cache: true
+
+      - name: Lint
+        run: mise run lint:go:plugin-claude-code
+
+      - name: Test
+        run: mise run test:go:plugin-claude-code

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,6 @@
+[tools]
+golangci-lint = "2.11.4"
+
 [env]
 PYTHON_BIN = "python3"
 
@@ -44,6 +47,11 @@ while IFS= read -r moddir; do
   (cd "${moddir}" && GOWORK=off golangci-lint run ./...)
 done < <(find . -name go.mod -not -path './node_modules/*' -exec dirname {} \\; | sort)
 """
+
+[tasks."lint:go:plugin-claude-code"]
+description = "Lint Claude Code plugin"
+dir = "plugins/claude-code"
+run = "GOWORK=off golangci-lint run ./..."
 
 [tasks."lint:cs"]
 description = "Verify .NET SDK formatting and analyzer checks"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI/workflow and `mise` task wiring, with no production code or runtime behavior modified.
> 
> **Overview**
> **CI now validates the Claude Code plugin.** The GitHub Actions workflow adds a new `claude-code-plugin` job that sets up Go for `plugins/claude-code`, installs `golangci-lint` via `mise`, and runs plugin-specific lint and tests.
> 
> `mise.toml` pins `golangci-lint` and introduces a new `lint:go:plugin-claude-code` task to lint only that module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fb319b10762413a6a77079f56a1270a658ee081. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->