### PR TITLE
feat(claude-code): package sigil-cc as a Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "grafana-sigil",
+  "owner": {
+    "name": "Grafana Labs"
+  },
+  "plugins": [
+    {
+      "name": "sigil-cc",
+      "source": "./plugins/claude-code",
+      "description": "Send Claude Code session telemetry to Grafana Sigil",
+      "version": "0.1.0",
+      "author": {
+        "name": "Grafana Labs"
+      }
+    }
+  ]
+}

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "sigil-cc",
+  "version": "0.1.0",
+  "description": "Send Claude Code session telemetry to Grafana Sigil",
+  "author": {
+    "name": "Grafana Labs"
+  },
+  "repository": "https://github.com/grafana/sigil-sdk",
+  "homepage": "https://github.com/grafana/sigil-sdk/tree/main/plugins/claude-code",
+  "license": "Apache-2.0",
+  "keywords": ["telemetry", "observability", "sigil", "grafana"],
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sigil-cc",
+            "timeout": 10000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -6,13 +6,40 @@ Replaces the sigil-cc OTLP proxy with a simpler, more reliable approach: read th
 
 ## Install
 
+### Plugin (recommended)
+
+Install the binary, then add the plugin:
+
 ```bash
 go install github.com/grafana/sigil-sdk/plugins/claude-code/cmd/sigil-cc@latest
 ```
 
-## Configure
+From within Claude Code:
 
-Add to `~/.claude/settings.json`:
+```
+/plugin marketplace add grafana/sigil-sdk
+/plugin install sigil-cc@grafana-sigil
+```
+
+The Stop hook registers automatically. Set the required environment variables in `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "SIGIL_URL": "https://sigil.example.com",
+    "SIGIL_USER": "your-tenant-id",
+    "SIGIL_PASSWORD": "glc_..."
+  }
+}
+```
+
+### Manual
+
+Install the binary and configure everything in `~/.claude/settings.json`:
+
+```bash
+go install github.com/grafana/sigil-sdk/plugins/claude-code/cmd/sigil-cc@latest
+```
 
 ```json
 {


### PR DESCRIPTION
Add marketplace and plugin manifests so users can install via `/plugin marketplace add` instead of manually editing settings.json. The Stop hook auto-registers on install.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds Claude Code plugin/marketplace manifest files and documentation changes, with no changes to runtime telemetry capture logic beyond how the hook is installed/registered.
> 
> **Overview**
> Makes `sigil-cc` installable via Claude Code’s plugin marketplace by adding a top-level `.claude-plugin/marketplace.json` entry and a plugin manifest at `plugins/claude-code/.claude-plugin/plugin.json` that **auto-registers a `Stop` hook** to run `sigil-cc`.
> 
> Updates the `plugins/claude-code/README.md` install instructions to prefer plugin installation (marketplace add + plugin install) and clarifies that users only need to set required `SIGIL_*` environment variables, while keeping a manual `settings.json` configuration option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f14bef2579346c323be0457ea6dc22b5c7f2285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->