### PR TITLE
fix(claude-code): use cumulative temporality for OTLP metrics

### DIFF
--- a/plugins/claude-code/internal/otel/otel.go
+++ b/plugins/claude-code/internal/otel/otel.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
@@ -150,9 +149,6 @@ func Setup(ctx context.Context, cfg Config) (*Providers, error) {
 	metricOpts := []otlpmetrichttp.Option{
 		otlpmetrichttp.WithEndpoint(host),
 		otlpmetrichttp.WithHeaders(headers),
-		otlpmetrichttp.WithTemporalitySelector(func(_ sdkmetric.InstrumentKind) metricdata.Temporality {
-			return metricdata.DeltaTemporality
-		}),
 	}
 	if metricPath != "" {
 		metricOpts = append(metricOpts, otlpmetrichttp.WithURLPath(metricPath))


### PR DESCRIPTION
Delta temporality histograms are rejected by Grafana Cloud's OTLP gateway, so `gen_ai.*` histogram metrics emitted by the claude code plugin never reached Prometheus.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk telemetry-only change; it alters metric temporality/output format which could affect downstream dashboards/alerts but not application behavior.
> 
> **Overview**
> Stops forcing OTLP HTTP metrics to use *delta* temporality by removing the custom `WithTemporalitySelector` configuration (and the `metricdata` dependency), so the exporter uses the default *cumulative* temporality for better compatibility with backends like Grafana Cloud OTLP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89e4578cecaefde1e18c0130705dfa69cc4a9699. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->