### PR TITLE
feat(js): add ContentCaptureMode for SDK-level content stripping

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -12,12 +12,15 @@ import { defaultLogger, mergeConfig } from './config.js';
 import {
   agentNameFromContext,
   agentVersionFromContext,
+  contentCaptureModeFromContext,
   conversationIdFromContext,
   conversationTitleFromContext,
   userIdFromContext,
+  withContentCaptureMode,
 } from './context.js';
 import { createDefaultGenerationExporter } from './exporters/default.js';
 import type {
+  ContentCaptureMode,
   ConversationRating,
   ConversationRatingInput,
   ConversationRatingSummary,
@@ -32,6 +35,7 @@ import type {
   GenerationResult,
   GenerationStart,
   Message,
+  MessagePart,
   RecorderCallback,
   RecorderWithError,
   SigilDebugSnapshot,
@@ -138,6 +142,7 @@ const sdkName = 'sdk-js';
 const defaultEmbeddingOperationName = 'embeddings';
 const metadataUserIDKey = 'sigil.user.id';
 const metadataLegacyUserIDKey = 'user.id';
+const metadataKeyContentCaptureMode = 'sigil.sdk.content_capture_mode';
 
 export class SigilClient {
   private readonly config: SigilSdkConfig;
@@ -296,6 +301,18 @@ export class SigilClient {
       throw new Error('sigil conversation rating validation failed: conversationId is too long');
     }
 
+    const resolverMode = callContentCaptureResolver(this.config.contentCaptureResolver, input.metadata, (msg, err) =>
+      this.logWarn(msg, err),
+    );
+    let effectiveMode = resolveEffectiveContentCaptureMode('default', resolverMode, this.config.contentCapture);
+    const ctx = contentCaptureModeFromContext();
+    if (ctx.set && ctx.mode !== 'default') {
+      effectiveMode = ctx.mode;
+    }
+    if (effectiveMode === 'metadata_only') {
+      input = { ...input, comment: '' };
+    }
+
     const normalizedInput = normalizeConversationRatingInput(input);
     const endpoint = buildConversationRatingEndpoint(
       this.config.api.endpoint,
@@ -393,6 +410,16 @@ export class SigilClient {
 
   internalNow(): Date {
     return this.nowFn();
+  }
+
+  internalContentCapture(): ContentCaptureMode {
+    return this.config.contentCapture;
+  }
+
+  internalContentCaptureResolver():
+    | ((metadata: Record<string, unknown> | undefined) => ContentCaptureMode)
+    | undefined {
+    return this.config.contentCaptureResolver;
   }
 
   internalRecordGeneration(generation: Generation): void {
@@ -589,11 +616,17 @@ export class SigilClient {
   internalFinalizeToolExecutionSpan(
     span: Span,
     toolExecution: ToolExecution,
+    includeContent: boolean,
+    isMetadataOnly: boolean,
     localError: Error | undefined,
   ): Error | undefined {
     setToolSpanAttributes(span, toolExecution);
 
-    if (toolExecution.includeContent) {
+    if (isMetadataOnly) {
+      span.setAttribute(spanAttrToolDescription, '');
+    }
+
+    if (includeContent) {
       const argumentsResult = serializeToolContent(toolExecution.arguments);
       if (argumentsResult.error !== undefined && localError === undefined) {
         localError = argumentsResult.error;
@@ -753,7 +786,7 @@ export class SigilClient {
     if (callback === undefined) {
       return recorder;
     }
-    return runWithRecorder(recorder, callback);
+    return withContentCaptureMode(recorder.resolvedContentCaptureMode(), () => runWithRecorder(recorder, callback));
   }
 
   private triggerAsyncFlush(): void {
@@ -848,6 +881,7 @@ class GenerationRecorderImpl implements GenerationRecorder {
   private readonly startedAt: Date;
   private readonly mode: GenerationMode;
   private readonly span: Span;
+  private readonly contentCaptureMode: ContentCaptureMode;
   private ended = false;
   private result?: GenerationResult;
   private callError?: string;
@@ -881,6 +915,21 @@ class GenerationRecorderImpl implements GenerationRecorder {
     this.mode = this.seed.mode ?? defaultMode;
     this.startedAt = this.seed.startedAt ?? this.client.internalNow();
     this.span = this.client.internalStartGenerationSpan(this.seed, this.mode, this.startedAt);
+
+    const resolverMode = callContentCaptureResolver(
+      this.client.internalContentCaptureResolver(),
+      this.seed.metadata,
+      (msg, err) => this.client.internalLogWarn(msg, err),
+    );
+    this.contentCaptureMode = resolveEffectiveContentCaptureMode(
+      this.seed.contentCapture ?? 'default',
+      resolverMode,
+      this.client.internalContentCapture(),
+    );
+  }
+
+  resolvedContentCaptureMode(): ContentCaptureMode {
+    return this.contentCaptureMode;
   }
 
   setResult(result: GenerationResult): void {
@@ -977,6 +1026,11 @@ class GenerationRecorderImpl implements GenerationRecorder {
       generation.metadata = {};
     }
     generation.metadata[spanAttrSDKName] = sdkName;
+
+    stampContentCaptureMetadata(generation, this.contentCaptureMode);
+    if (this.contentCaptureMode === 'metadata_only') {
+      stripContent(generation, classifyCallErrorCategory(this.callError, false));
+    }
 
     this.client.internalSyncGenerationSpan(this.span, generation);
     this.client.internalApplyTraceContextFromSpan(this.span, generation);
@@ -1081,6 +1135,8 @@ class ToolExecutionRecorderImpl implements ToolExecutionRecorder {
   private readonly seed: ToolExecutionStart;
   private readonly startedAt: Date;
   private readonly span: Span;
+  private readonly includeContent: boolean;
+  private readonly isMetadataOnly: boolean;
   private ended = false;
   private result?: ToolExecutionResult;
   private callError?: string;
@@ -1105,6 +1161,21 @@ class ToolExecutionRecorderImpl implements ToolExecutionRecorder {
     }
     this.startedAt = this.seed.startedAt ?? this.client.internalNow();
     this.span = this.client.internalStartToolExecutionSpan(this.seed, this.startedAt);
+
+    const resolverMode = callContentCaptureResolver(
+      this.client.internalContentCaptureResolver(),
+      undefined,
+      (msg, err) => this.client.internalLogWarn(msg, err),
+    );
+    const effectiveClientDefault = resolveContentCaptureMode(resolverMode, this.client.internalContentCapture());
+    const ctx = contentCaptureModeFromContext();
+    const resolvedMode = resolveToolContentCaptureMode(
+      this.seed.contentCapture ?? 'default',
+      ctx.mode,
+      effectiveClientDefault,
+    );
+    this.isMetadataOnly = resolvedMode === 'metadata_only';
+    this.includeContent = shouldIncludeToolContent(resolvedMode, this.seed.includeContent ?? false);
   }
 
   setResult(result: ToolExecutionResult): void {
@@ -1140,6 +1211,7 @@ class ToolExecutionRecorderImpl implements ToolExecutionRecorder {
       requestModel: this.seed.requestModel,
       requestProvider: this.seed.requestProvider,
       includeContent: this.seed.includeContent ?? false,
+      contentCapture: this.seed.contentCapture,
       startedAt: new Date(this.startedAt),
       completedAt: new Date(this.result?.completedAt ?? this.client.internalNow()),
       arguments: this.result?.arguments,
@@ -1154,7 +1226,13 @@ class ToolExecutionRecorderImpl implements ToolExecutionRecorder {
     } else {
       this.client.internalRecordToolExecution(toolExecution);
     }
-    this.localError = this.client.internalFinalizeToolExecutionSpan(this.span, toolExecution, this.localError);
+    this.localError = this.client.internalFinalizeToolExecutionSpan(
+      this.span,
+      toolExecution,
+      this.includeContent,
+      this.isMetadataOnly,
+      this.localError,
+    );
   }
 
   getError(): Error | undefined {
@@ -1881,4 +1959,133 @@ function isJSON(value: string): boolean {
 
 function notEmpty(value: string | undefined): value is string {
   return value !== undefined && value.trim().length > 0;
+}
+
+// --- Content capture helpers ---
+
+function resolveContentCaptureMode(override: ContentCaptureMode, fallback: ContentCaptureMode): ContentCaptureMode {
+  if (override !== 'default') {
+    return override;
+  }
+  return fallback;
+}
+
+function resolveClientContentCaptureMode(mode: ContentCaptureMode): ContentCaptureMode {
+  if (mode === 'default') {
+    return 'no_tool_content';
+  }
+  return mode;
+}
+
+function resolveEffectiveContentCaptureMode(
+  override: ContentCaptureMode,
+  resolverMode: ContentCaptureMode,
+  clientMode: ContentCaptureMode,
+): ContentCaptureMode {
+  const base = resolveClientContentCaptureMode(resolveContentCaptureMode(resolverMode, clientMode));
+  return resolveContentCaptureMode(override, base);
+}
+
+const validContentCaptureModes = new Set<string>(['default', 'full', 'no_tool_content', 'metadata_only']);
+
+function callContentCaptureResolver(
+  resolver: ((metadata: Record<string, unknown> | undefined) => ContentCaptureMode) | undefined,
+  metadata: Record<string, unknown> | undefined,
+  logWarn?: (message: string, error?: unknown) => void,
+): ContentCaptureMode {
+  if (resolver === undefined) {
+    return 'default';
+  }
+  try {
+    const result = resolver(metadata);
+    if (!validContentCaptureModes.has(result)) {
+      logWarn?.(`sigil contentCaptureResolver returned invalid mode '${String(result)}', defaulting to metadata_only`);
+      return 'metadata_only';
+    }
+    return result;
+  } catch (error) {
+    logWarn?.('sigil contentCaptureResolver threw, defaulting to metadata_only', error);
+    return 'metadata_only';
+  }
+}
+
+function stampContentCaptureMetadata(generation: Generation, mode: ContentCaptureMode): void {
+  if (generation.metadata === undefined) {
+    generation.metadata = {};
+  }
+  generation.metadata[metadataKeyContentCaptureMode] = mode === 'default' ? 'no_tool_content' : mode;
+}
+
+function stripContent(generation: Generation, errorCategory: string): void {
+  generation.systemPrompt = '';
+  generation.artifacts = undefined;
+
+  if (generation.callError !== undefined && generation.callError.length > 0) {
+    generation.callError = errorCategory.length > 0 ? errorCategory : 'sdk_error';
+  }
+  delete generation.metadata?.call_error;
+
+  for (const message of generation.input ?? []) {
+    stripMessageContent(message);
+  }
+  for (const message of generation.output ?? []) {
+    stripMessageContent(message);
+  }
+  for (const tool of generation.tools ?? []) {
+    tool.description = undefined;
+    tool.inputSchemaJSON = undefined;
+  }
+}
+
+function stripMessageContent(message: Message): void {
+  message.content = '';
+  for (const part of message.parts ?? []) {
+    stripPart(part);
+  }
+}
+
+function stripPart(part: MessagePart): void {
+  switch (part.type) {
+    case 'text':
+      part.text = '';
+      break;
+    case 'thinking':
+      part.thinking = '';
+      break;
+    case 'tool_call':
+      part.toolCall.inputJSON = undefined;
+      break;
+    case 'tool_result':
+      part.toolResult.content = undefined;
+      part.toolResult.contentJSON = undefined;
+      break;
+  }
+}
+
+function resolveToolContentCaptureMode(
+  toolMode: ContentCaptureMode,
+  ctxMode: ContentCaptureMode,
+  clientDefault: ContentCaptureMode,
+): ContentCaptureMode {
+  const base = resolveClientContentCaptureMode(clientDefault);
+  const withCtx = resolveContentCaptureMode(ctxMode, base);
+  return resolveContentCaptureMode(toolMode, withCtx);
+}
+
+function shouldIncludeToolContent(resolved: ContentCaptureMode, legacyInclude: boolean): boolean {
+  switch (resolved) {
+    case 'metadata_only':
+      return false;
+    case 'full':
+      return true;
+    default:
+      return legacyInclude;
+  }
+}
+
+function classifyCallErrorCategory(callError: string | undefined, fallbackSDK: boolean): string {
+  if (callError === undefined) {
+    return fallbackSDK ? 'sdk_error' : '';
+  }
+  return errorCategoryFromError(callError, fallbackSDK);
 }

--- a/js/src/config.ts
+++ b/js/src/config.ts
@@ -56,6 +56,7 @@ export function defaultConfig(): SigilSdkConfig {
     generationExport: cloneGenerationExportConfig(defaultGenerationExportConfig),
     api: cloneAPIConfig(defaultAPIConfig),
     embeddingCapture: cloneEmbeddingCaptureConfig(defaultEmbeddingCaptureConfig),
+    contentCapture: 'default',
   };
 }
 
@@ -64,6 +65,8 @@ export function mergeConfig(config: SigilSdkConfigInput): SigilSdkConfig {
     generationExport: mergeGenerationExportConfig(config.generationExport),
     api: mergeAPIConfig(config.api),
     embeddingCapture: mergeEmbeddingCaptureConfig(config.embeddingCapture),
+    contentCapture: config.contentCapture ?? 'default',
+    contentCaptureResolver: config.contentCaptureResolver,
     generationExporter: config.generationExporter,
     tracer: config.tracer,
     meter: config.meter,

--- a/js/src/context.ts
+++ b/js/src/context.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import type { ContentCaptureMode } from './types.js';
 
 type SigilContextValues = {
   conversationId?: string;
@@ -6,6 +7,7 @@ type SigilContextValues = {
   userId?: string;
   agentName?: string;
   agentVersion?: string;
+  contentCaptureMode?: ContentCaptureMode;
 };
 
 const storage = new AsyncLocalStorage<SigilContextValues>();
@@ -50,17 +52,31 @@ export function agentVersionFromContext(): string | undefined {
   return normalizedString(storage.getStore()?.agentVersion);
 }
 
-function runWithContext<T>(nextValues: SigilContextValues, callback: () => T): T {
+export function withContentCaptureMode<T>(mode: ContentCaptureMode, callback: () => T): T {
+  const currentValues = storage.getStore() ?? {};
+  const mergedValues: SigilContextValues = { ...currentValues, contentCaptureMode: mode };
+  return storage.run(mergedValues, callback);
+}
+
+export function contentCaptureModeFromContext(): { mode: ContentCaptureMode; set: boolean } {
+  const value = storage.getStore()?.contentCaptureMode;
+  if (value === undefined) {
+    return { mode: 'default', set: false };
+  }
+  return { mode: value, set: true };
+}
+
+function runWithContext<T>(nextValues: Omit<SigilContextValues, 'contentCaptureMode'>, callback: () => T): T {
   const currentValues = storage.getStore() ?? {};
   const mergedValues: SigilContextValues = { ...currentValues };
 
   for (const [key, value] of Object.entries(nextValues)) {
-    const normalized = normalizedString(value);
+    const normalized = normalizedString(value as string | undefined);
     if (normalized === undefined) {
-      delete mergedValues[key as keyof SigilContextValues];
+      delete mergedValues[key as keyof typeof nextValues];
       continue;
     }
-    mergedValues[key as keyof SigilContextValues] = normalized;
+    mergedValues[key as keyof typeof nextValues] = normalized;
   }
 
   return storage.run(mergedValues, callback);

--- a/js/src/frameworks/shared.ts
+++ b/js/src/frameworks/shared.ts
@@ -296,6 +296,7 @@ export class SigilFrameworkHandler {
       callbackMetadata,
     });
     const toolName = resolveToolName(serialized, context.componentName);
+    const parentRun = parentRunId ? this.runs.get(String(parentRunId)) : undefined;
     const recorder = this.client.startToolExecution({
       toolName,
       toolDescription: resolveToolDescription(serialized),
@@ -303,6 +304,7 @@ export class SigilFrameworkHandler {
       agentName: this.agentName,
       agentVersion: this.agentVersion,
       includeContent: this.captureInputs || this.captureOutputs,
+      contentCapture: parentRun?.recorder.resolvedContentCaptureMode(),
     });
 
     this.toolRuns.set(runKey, {

--- a/js/src/frameworks/vercel-ai-sdk/hooks.ts
+++ b/js/src/frameworks/vercel-ai-sdk/hooks.ts
@@ -405,6 +405,7 @@ export class SigilVercelAiSdkInstrumentation {
           agentName: callAgentName,
           agentVersion: this.agentVersion,
           includeContent: this.captureInputs || this.captureOutputs,
+          contentCapture: params.stepState.recorder?.resolvedContentCaptureMode(),
           startedAt: params.stepState.startedAt,
         });
 
@@ -571,6 +572,7 @@ export class SigilVercelAiSdkInstrumentation {
           agentName: callAgentName,
           agentVersion: this.agentVersion,
           includeContent: this.captureInputs || this.captureOutputs,
+          contentCapture: stepState.recorder?.resolvedContentCaptureMode(),
           startedAt,
         });
         state.toolStates.set(parsed.toolCallId, {

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -3,11 +3,13 @@ export { defaultConfig } from './config.js';
 export {
   agentNameFromContext,
   agentVersionFromContext,
+  contentCaptureModeFromContext,
   conversationIdFromContext,
   conversationTitleFromContext,
   userIdFromContext,
   withAgentName,
   withAgentVersion,
+  withContentCaptureMode,
   withConversationId,
   withConversationTitle,
   withUserId,
@@ -18,6 +20,7 @@ export * as openai from './providers/openai.js';
 export type {
   ApiConfig,
   Artifact,
+  ContentCaptureMode,
   ConversationRating,
   ConversationRatingInput,
   ConversationRatingSummary,

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -7,6 +7,19 @@ export type GenerationMode = 'SYNC' | 'STREAM';
 /** Supported auth modes for transport exports. */
 export type ExportAuthMode = 'none' | 'tenant' | 'bearer' | 'basic';
 
+/**
+ * Controls what content is included in exported generation payloads and OTel
+ * span attributes.
+ *
+ * - `'default'` — inherits from parent or client-level default
+ *   (resolves to `'no_tool_content'` at the client level).
+ * - `'full'` — all content exported.
+ * - `'no_tool_content'` — full generation content, but tool execution
+ *   arguments/results excluded from span attributes unless opted in.
+ * - `'metadata_only'` — structure preserved, all text stripped.
+ */
+export type ContentCaptureMode = 'default' | 'full' | 'no_tool_content' | 'metadata_only';
+
 /** Per-export auth configuration. */
 export interface ExportAuthConfig {
   mode: ExportAuthMode;
@@ -141,6 +154,8 @@ export interface SigilSdkConfig {
   generationExport: GenerationExportConfig;
   api: ApiConfig;
   embeddingCapture: EmbeddingCaptureConfig;
+  contentCapture: ContentCaptureMode;
+  contentCaptureResolver?: (metadata: Record<string, unknown> | undefined) => ContentCaptureMode;
   generationExporter?: GenerationExporter;
   tracer?: Tracer;
   meter?: Meter;
@@ -154,6 +169,8 @@ export interface SigilSdkConfigInput {
   generationExport?: Partial<GenerationExportConfig>;
   api?: Partial<ApiConfig>;
   embeddingCapture?: Partial<EmbeddingCaptureConfig>;
+  contentCapture?: ContentCaptureMode;
+  contentCaptureResolver?: (metadata: Record<string, unknown> | undefined) => ContentCaptureMode;
   generationExporter?: GenerationExporter;
   tracer?: Tracer;
   meter?: Meter;
@@ -259,6 +276,7 @@ export interface GenerationStart {
   tags?: Record<string, string>;
   metadata?: Record<string, unknown>;
   startedAt?: Date;
+  contentCapture?: ContentCaptureMode;
 }
 
 /** Final generation result fields. */
@@ -356,7 +374,12 @@ export interface ToolExecutionStart {
   requestModel?: string;
   /** The provider that served the model (e.g. "openai"). */
   requestProvider?: string;
+  /**
+   * @deprecated Use `contentCapture` instead. Only honored when the resolved
+   * mode is `'no_tool_content'` (the default).
+   */
   includeContent?: boolean;
+  contentCapture?: ContentCaptureMode;
   startedAt?: Date;
 }
 
@@ -380,6 +403,7 @@ export interface ToolExecution {
   requestModel?: string;
   requestProvider?: string;
   includeContent: boolean;
+  contentCapture?: ContentCaptureMode;
   startedAt: Date;
   completedAt: Date;
   arguments?: unknown;
@@ -397,6 +421,7 @@ export interface EmbeddingRecorder {
 
 /** Recorder API for generation lifecycle. */
 export interface GenerationRecorder {
+  resolvedContentCaptureMode(): ContentCaptureMode;
   setResult(result: GenerationResult): void;
   setCallError(error: unknown): void;
   setFirstTokenAt(firstTokenAt: Date): void;

--- a/js/src/utils.ts
+++ b/js/src/utils.ts
@@ -26,6 +26,8 @@ export function defaultOperationNameForMode(mode: GenerationMode): string {
 }
 
 export function validateGeneration(generation: Generation): Error | undefined {
+  const contentStripped = isContentStripped(generation);
+
   if (generation.id.trim().length === 0) {
     return new Error('generation id is required');
   }
@@ -39,13 +41,13 @@ export function validateGeneration(generation: Generation): Error | undefined {
     return new Error('generation model name is required');
   }
   for (let index = 0; index < (generation.input ?? []).length; index++) {
-    const error = validateMessage('generation.input', index, generation.input?.[index]);
+    const error = validateMessage('generation.input', index, generation.input?.[index], contentStripped);
     if (error !== undefined) {
       return error;
     }
   }
   for (let index = 0; index < (generation.output ?? []).length; index++) {
-    const error = validateMessage('generation.output', index, generation.output?.[index]);
+    const error = validateMessage('generation.output', index, generation.output?.[index], contentStripped);
     if (error !== undefined) {
       return error;
     }
@@ -66,6 +68,13 @@ export function validateGeneration(generation: Generation): Error | undefined {
     return new Error('generation completedAt must not be earlier than startedAt');
   }
   return undefined;
+}
+
+function isContentStripped(generation: Generation): boolean {
+  if (generation.metadata === undefined) {
+    return false;
+  }
+  return generation.metadata['sigil.sdk.content_capture_mode'] === 'metadata_only';
 }
 
 export function validateToolExecution(toolExecution: ToolExecution): Error | undefined {
@@ -265,7 +274,12 @@ function cloneMessagePart(part: MessagePart): MessagePart {
   }
 }
 
-function validateMessage(path: string, index: number, message: Message | undefined): Error | undefined {
+function validateMessage(
+  path: string,
+  index: number,
+  message: Message | undefined,
+  contentStripped: boolean,
+): Error | undefined {
   if (message === undefined) {
     return new Error(`${path}[${index}] is required`);
   }
@@ -277,7 +291,7 @@ function validateMessage(path: string, index: number, message: Message | undefin
 
   const hasContent = typeof message.content === 'string' && message.content.trim().length > 0;
   const parts = message.parts ?? [];
-  if (parts.length === 0 && !hasContent) {
+  if (parts.length === 0 && !hasContent && !contentStripped) {
     return new Error(`${path}[${index}].parts must not be empty`);
   }
 
@@ -286,7 +300,7 @@ function validateMessage(path: string, index: number, message: Message | undefin
     if (part === undefined) {
       return new Error(`${path}[${index}].parts[${partIndex}] is required`);
     }
-    const error = validatePart(path, index, partIndex, role, part);
+    const error = validatePart(path, index, partIndex, role, part, contentStripped);
     if (error !== undefined) {
       return error;
     }
@@ -301,15 +315,17 @@ function validatePart(
   partIndex: number,
   role: 'user' | 'assistant' | 'tool',
   part: MessagePart,
+  contentStripped: boolean,
 ): Error | undefined {
   const payloadFieldCount = payloadFieldsCount(part);
-  if (payloadFieldCount !== 1) {
+  const strippedTextOrThinking = contentStripped && (part.type === 'text' || part.type === 'thinking');
+  if (payloadFieldCount !== 1 && !strippedTextOrThinking) {
     return new Error(`${path}[${messageIndex}].parts[${partIndex}] must set exactly one payload field`);
   }
 
   switch (part.type) {
     case 'text':
-      if (part.text.trim().length === 0) {
+      if (!contentStripped && part.text.trim().length === 0) {
         return new Error(`${path}[${messageIndex}].parts[${partIndex}].text is required`);
       }
       return undefined;
@@ -317,7 +333,7 @@ function validatePart(
       if (role !== 'assistant') {
         return new Error(`${path}[${messageIndex}].parts[${partIndex}].thinking only allowed for assistant role`);
       }
-      if (part.thinking.trim().length === 0) {
+      if (!contentStripped && part.thinking.trim().length === 0) {
         return new Error(`${path}[${messageIndex}].parts[${partIndex}].thinking is required`);
       }
       return undefined;

--- a/js/test/content-capture.test.mjs
+++ b/js/test/content-capture.test.mjs
@@ -1,0 +1,971 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import test from 'node:test';
+import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import {
+  contentCaptureModeFromContext,
+  defaultConfig,
+  SigilClient,
+  withContentCaptureMode,
+} from '../.test-dist/index.js';
+
+// --- Test helpers ---
+
+class CapturingExporter {
+  requests = [];
+
+  async exportGenerations(request) {
+    this.requests.push(structuredClone(request));
+    return {
+      results: request.generations.map((g) => ({
+        generationId: g.id,
+        accepted: true,
+      })),
+    };
+  }
+}
+
+function newHarness(overrides = {}) {
+  const spanExporter = new InMemorySpanExporter();
+  const traceProvider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(spanExporter)],
+  });
+  const tracer = traceProvider.getTracer('sigil-sdk-js-test');
+  const generationExporter = new CapturingExporter();
+  const defaults = defaultConfig();
+
+  const client = new SigilClient({
+    tracer,
+    generationExport: {
+      ...defaults.generationExport,
+      batchSize: 100,
+      flushIntervalMs: 60_000,
+      maxRetries: 1,
+      initialBackoffMs: 1,
+      maxBackoffMs: 1,
+    },
+    generationExporter,
+    ...overrides,
+  });
+
+  return { client, spanExporter, traceProvider, generationExporter };
+}
+
+function singleGeneration(client) {
+  const snapshot = client.debugSnapshot();
+  assert.equal(snapshot.generations.length, 1);
+  return snapshot.generations[0];
+}
+
+function _generationSpans(spanExporter) {
+  return spanExporter.getFinishedSpans().filter((span) => {
+    const op = span.attributes['gen_ai.operation.name'];
+    return op !== 'execute_tool' && op !== 'embeddings';
+  });
+}
+
+function toolSpans(spanExporter) {
+  return spanExporter.getFinishedSpans().filter((span) => span.attributes['gen_ai.operation.name'] === 'execute_tool');
+}
+
+function singleToolSpan(spanExporter) {
+  const spans = toolSpans(spanExporter);
+  assert.equal(spans.length, 1);
+  return spans[0];
+}
+
+async function shutdownHarness(harness) {
+  await harness.client.shutdown();
+  await harness.traceProvider.shutdown();
+}
+
+// --- Content capture mode resolution tests ---
+
+test('default resolution: client default + gen default → no_tool_content marker', async () => {
+  const harness = newHarness();
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'test', name: 'test-model' },
+    });
+    recorder.setResult({
+      input: [{ role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+      output: [{ role: 'assistant', parts: [{ type: 'text', text: 'Hi' }] }],
+    });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+
+    const gen = singleGeneration(harness.client);
+    assert.equal(gen.metadata['sigil.sdk.content_capture_mode'], 'no_tool_content');
+    assert.equal(gen.input[0].parts[0].text, 'Hello');
+    assert.equal(gen.output[0].parts[0].text, 'Hi');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('full mode: client full preserves all content', async () => {
+  const harness = newHarness({ contentCapture: 'full' });
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'test', name: 'test-model' },
+      systemPrompt: 'You are helpful.',
+    });
+    recorder.setResult({
+      input: [{ role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+      output: [{ role: 'assistant', parts: [{ type: 'text', text: 'Hi' }] }],
+    });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+
+    const gen = singleGeneration(harness.client);
+    assert.equal(gen.metadata['sigil.sdk.content_capture_mode'], 'full');
+    assert.equal(gen.systemPrompt, 'You are helpful.');
+    assert.equal(gen.input[0].parts[0].text, 'Hello');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('metadata_only strips content but preserves structure', async () => {
+  const harness = newHarness({ contentCapture: 'metadata_only' });
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'test', name: 'test-model' },
+      systemPrompt: 'You are helpful.',
+      tools: [{ name: 'weather', description: 'Get weather', inputSchemaJSON: '{"type":"object"}' }],
+    });
+    recorder.setResult({
+      input: [
+        { role: 'user', parts: [{ type: 'text', text: 'What is the weather?' }] },
+        {
+          role: 'tool',
+          parts: [
+            {
+              type: 'tool_result',
+              toolResult: { toolCallId: 'call_1', name: 'weather', content: 'sunny', contentJSON: '{"temp":18}' },
+            },
+          ],
+        },
+      ],
+      output: [
+        {
+          role: 'assistant',
+          parts: [
+            { type: 'thinking', thinking: 'let me think' },
+            { type: 'tool_call', toolCall: { id: 'call_1', name: 'weather', inputJSON: '{"city":"Paris"}' } },
+            { type: 'text', text: 'It is sunny.' },
+          ],
+        },
+      ],
+      artifacts: [{ type: 'request', payload: 'raw data' }],
+      usage: { inputTokens: 120, outputTokens: 42 },
+      stopReason: 'end_turn',
+    });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+
+    const gen = singleGeneration(harness.client);
+    assert.equal(gen.metadata['sigil.sdk.content_capture_mode'], 'metadata_only');
+
+    // Stripped content
+    assert.equal(gen.systemPrompt, '');
+    assert.equal(gen.input[0].parts[0].text, '');
+    assert.equal(gen.output[0].parts[0].thinking, '');
+    assert.equal(gen.output[0].parts[1].toolCall.inputJSON, undefined);
+    assert.equal(gen.output[0].parts[2].text, '');
+    assert.equal(gen.input[1].parts[0].toolResult.content, undefined);
+    assert.equal(gen.input[1].parts[0].toolResult.contentJSON, undefined);
+    assert.equal(gen.artifacts, undefined);
+    assert.equal(gen.tools[0].description, undefined);
+    assert.equal(gen.tools[0].inputSchemaJSON, undefined);
+
+    // Preserved structure
+    assert.equal(gen.input.length, 2);
+    assert.equal(gen.output.length, 1);
+    assert.equal(gen.output[0].parts.length, 3);
+    assert.equal(gen.input[0].role, 'user');
+    assert.equal(gen.output[0].parts[0].type, 'thinking');
+    assert.equal(gen.output[0].parts[1].toolCall.name, 'weather');
+    assert.equal(gen.output[0].parts[1].toolCall.id, 'call_1');
+    assert.equal(gen.input[1].parts[0].toolResult.toolCallId, 'call_1');
+    assert.equal(gen.input[1].parts[0].toolResult.name, 'weather');
+    assert.equal(gen.tools[0].name, 'weather');
+    assert.equal(gen.usage.inputTokens, 120);
+    assert.equal(gen.usage.outputTokens, 42);
+    assert.equal(gen.stopReason, 'end_turn');
+    assert.equal(gen.model.name, 'test-model');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('metadata_only replaces callError with category', async () => {
+  const harness = newHarness({ contentCapture: 'metadata_only' });
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'test', name: 'test-model' },
+    });
+    recorder.setResult({
+      input: [{ role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+      output: [{ role: 'assistant', parts: [{ type: 'text', text: 'Hi' }] }],
+    });
+    recorder.setCallError(new Error('rate limit exceeded: got 429'));
+    recorder.end();
+
+    const gen = singleGeneration(harness.client);
+    assert.equal(gen.callError, 'rate_limit');
+    assert.equal(gen.metadata.call_error, undefined);
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('metadata_only falls back to sdk_error without status code', async () => {
+  const harness = newHarness({ contentCapture: 'metadata_only' });
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'test', name: 'test-model' },
+    });
+    recorder.setResult({
+      input: [{ role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+      output: [{ role: 'assistant', parts: [{ type: 'text', text: 'Hi' }] }],
+    });
+    recorder.setCallError(new Error('something broke'));
+    recorder.end();
+
+    const gen = singleGeneration(harness.client);
+    assert.equal(gen.callError, 'sdk_error');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+// --- Per-generation override ---
+
+test('per-generation override: client full, gen metadata_only → stripped', async () => {
+  const harness = newHarness({ contentCapture: 'full' });
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'test', name: 'test-model' },
+      contentCapture: 'metadata_only',
+    });
+    recorder.setResult({
+      input: [{ role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+      output: [{ role: 'assistant', parts: [{ type: 'text', text: 'Hi' }] }],
+    });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+
+    const gen = singleGeneration(harness.client);
+    assert.equal(gen.metadata['sigil.sdk.content_capture_mode'], 'metadata_only');
+    assert.equal(gen.input[0].parts[0].text, '');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('per-generation override: client metadata_only, gen full → preserved', async () => {
+  const harness = newHarness({ contentCapture: 'metadata_only' });
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'test', name: 'test-model' },
+      contentCapture: 'full',
+    });
+    recorder.setResult({
+      input: [{ role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+      output: [{ role: 'assistant', parts: [{ type: 'text', text: 'Hi' }] }],
+    });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+
+    const gen = singleGeneration(harness.client);
+    assert.equal(gen.metadata['sigil.sdk.content_capture_mode'], 'full');
+    assert.equal(gen.input[0].parts[0].text, 'Hello');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+// --- Resolver callback ---
+
+test('resolver callback: resolver MetadataOnly overrides client Full', async () => {
+  const harness = newHarness({
+    contentCapture: 'full',
+    contentCaptureResolver: () => 'metadata_only',
+  });
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'test', name: 'test-model' },
+    });
+    recorder.setResult({
+      input: [{ role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+      output: [{ role: 'assistant', parts: [{ type: 'text', text: 'Hi' }] }],
+    });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+
+    const gen = singleGeneration(harness.client);
+    assert.equal(gen.metadata['sigil.sdk.content_capture_mode'], 'metadata_only');
+    assert.equal(gen.input[0].parts[0].text, '');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('resolver callback: per-generation Full overrides resolver MetadataOnly', async () => {
+  const harness = newHarness({
+    contentCapture: 'default',
+    contentCaptureResolver: () => 'metadata_only',
+  });
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'test', name: 'test-model' },
+      contentCapture: 'full',
+    });
+    recorder.setResult({
+      input: [{ role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+      output: [{ role: 'assistant', parts: [{ type: 'text', text: 'Hi' }] }],
+    });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+
+    const gen = singleGeneration(harness.client);
+    assert.equal(gen.metadata['sigil.sdk.content_capture_mode'], 'full');
+    assert.equal(gen.input[0].parts[0].text, 'Hello');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('resolver callback: resolver default defers to client', async () => {
+  const harness = newHarness({
+    contentCapture: 'metadata_only',
+    contentCaptureResolver: () => 'default',
+  });
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'test', name: 'test-model' },
+    });
+    recorder.setResult({
+      input: [{ role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+      output: [{ role: 'assistant', parts: [{ type: 'text', text: 'Hi' }] }],
+    });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+
+    const gen = singleGeneration(harness.client);
+    assert.equal(gen.metadata['sigil.sdk.content_capture_mode'], 'metadata_only');
+    assert.equal(gen.input[0].parts[0].text, '');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('resolver callback: resolver receives generation metadata', async () => {
+  let receivedMetadata;
+  const harness = newHarness({
+    contentCaptureResolver: (metadata) => {
+      receivedMetadata = metadata;
+      if (metadata?.tenant_id === 'opted-out') {
+        return 'metadata_only';
+      }
+      return 'full';
+    },
+  });
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'test', name: 'test-model' },
+      metadata: { tenant_id: 'opted-out' },
+    });
+    recorder.setResult({
+      input: [{ role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+      output: [{ role: 'assistant', parts: [{ type: 'text', text: 'Hi' }] }],
+    });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+
+    assert.equal(receivedMetadata.tenant_id, 'opted-out');
+    const gen = singleGeneration(harness.client);
+    assert.equal(gen.metadata['sigil.sdk.content_capture_mode'], 'metadata_only');
+    assert.equal(gen.input[0].parts[0].text, '');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+// --- Resolver exception fail-closed ---
+
+test('resolver exception: panicking resolver fails closed to metadata_only', async () => {
+  const harness = newHarness({
+    contentCapture: 'full',
+    contentCaptureResolver: () => {
+      throw new Error('resolver bug');
+    },
+  });
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'test', name: 'test-model' },
+    });
+    recorder.setResult({
+      input: [{ role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+      output: [{ role: 'assistant', parts: [{ type: 'text', text: 'Hi' }] }],
+    });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+
+    const gen = singleGeneration(harness.client);
+    assert.equal(gen.metadata['sigil.sdk.content_capture_mode'], 'metadata_only');
+    assert.equal(gen.input[0].parts[0].text, '');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+// --- Backward compat: includeContent ---
+
+test('backward compat: includeContent=true with default mode includes tool content in spans', async () => {
+  const harness = newHarness();
+  try {
+    const toolRec = harness.client.startToolExecution({
+      toolName: 'test_tool',
+      includeContent: true,
+    });
+    toolRec.setResult({ arguments: 'tool args', result: 'tool result' });
+    toolRec.end();
+    assert.equal(toolRec.getError(), undefined);
+
+    const span = singleToolSpan(harness.spanExporter);
+    assert.equal(span.attributes['gen_ai.tool.call.arguments'], '"tool args"');
+    assert.equal(span.attributes['gen_ai.tool.call.result'], '"tool result"');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('backward compat: includeContent=false with default mode excludes tool content from spans', async () => {
+  const harness = newHarness();
+  try {
+    const toolRec = harness.client.startToolExecution({
+      toolName: 'test_tool',
+      toolDescription: 'A test tool',
+      includeContent: false,
+    });
+    toolRec.setResult({ arguments: 'tool args', result: 'tool result' });
+    toolRec.end();
+    assert.equal(toolRec.getError(), undefined);
+
+    const span = singleToolSpan(harness.spanExporter);
+    assert.equal(span.attributes['gen_ai.tool.call.arguments'], undefined);
+    assert.equal(span.attributes['gen_ai.tool.call.result'], undefined);
+    assert.equal(span.attributes['gen_ai.tool.description'], 'A test tool', 'no_tool_content preserves description');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('includeContent ignored under metadata_only', async () => {
+  const harness = newHarness({ contentCapture: 'metadata_only' });
+  try {
+    const toolRec = harness.client.startToolExecution({
+      toolName: 'test_tool',
+      includeContent: true,
+    });
+    toolRec.setResult({ arguments: 'tool args', result: 'tool result' });
+    toolRec.end();
+    assert.equal(toolRec.getError(), undefined);
+
+    const span = singleToolSpan(harness.spanExporter);
+    assert.equal(span.attributes['gen_ai.tool.call.arguments'], undefined);
+    assert.equal(span.attributes['gen_ai.tool.call.result'], undefined);
+    assert.equal(span.attributes['gen_ai.tool.name'], 'test_tool');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+// --- Per-tool override ---
+
+test('per-tool override: tool full overrides client metadata_only', async () => {
+  const harness = newHarness({ contentCapture: 'metadata_only' });
+  try {
+    const toolRec = harness.client.startToolExecution({
+      toolName: 'test_tool',
+      contentCapture: 'full',
+      includeContent: true,
+    });
+    toolRec.setResult({ arguments: 'tool args', result: 'tool result' });
+    toolRec.end();
+    assert.equal(toolRec.getError(), undefined);
+
+    const span = singleToolSpan(harness.spanExporter);
+    assert.equal(span.attributes['gen_ai.tool.call.arguments'], '"tool args"');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('per-tool override: tool metadata_only suppresses even under client full', async () => {
+  const harness = newHarness({ contentCapture: 'full' });
+  try {
+    const toolRec = harness.client.startToolExecution({
+      toolName: 'test_tool',
+      contentCapture: 'metadata_only',
+      includeContent: true,
+    });
+    toolRec.setResult({ arguments: 'tool args', result: 'tool result' });
+    toolRec.end();
+    assert.equal(toolRec.getError(), undefined);
+
+    const span = singleToolSpan(harness.spanExporter);
+    assert.equal(span.attributes['gen_ai.tool.call.arguments'], undefined);
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+// --- Client full mode: tool content always included ---
+
+test('client full mode includes tool content regardless of includeContent', async () => {
+  const harness = newHarness({ contentCapture: 'full' });
+  try {
+    const toolRec = harness.client.startToolExecution({
+      toolName: 'test_tool',
+      includeContent: false,
+    });
+    toolRec.setResult({ arguments: 'tool args', result: 'tool result' });
+    toolRec.end();
+    assert.equal(toolRec.getError(), undefined);
+
+    const span = singleToolSpan(harness.spanExporter);
+    assert.equal(span.attributes['gen_ai.tool.call.arguments'], '"tool args"');
+    assert.equal(span.attributes['gen_ai.tool.call.result'], '"tool result"');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+// --- Validation accepts stripped content ---
+
+test('validation accepts stripped generation', async () => {
+  const harness = newHarness({ contentCapture: 'metadata_only' });
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'test', name: 'test-model' },
+    });
+    recorder.setResult({
+      input: [
+        { role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
+        {
+          role: 'tool',
+          parts: [
+            {
+              type: 'tool_result',
+              toolResult: { toolCallId: 'call_1', name: 'tool', content: 'data' },
+            },
+          ],
+        },
+      ],
+      output: [
+        {
+          role: 'assistant',
+          parts: [
+            { type: 'thinking', thinking: 'hmm' },
+            { type: 'tool_call', toolCall: { id: 'call_1', name: 'tool' } },
+            { type: 'text', text: 'result' },
+          ],
+        },
+      ],
+    });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+// --- Rating comment stripped under metadata_only ---
+
+test('rating comment stripped under metadata_only resolver', async () => {
+  // We test that the resolver affects the rating by ensuring the
+  // input comment is cleared before sending.
+  let resolverCalls = 0;
+  const harness = newHarness({
+    contentCaptureResolver: () => {
+      resolverCalls++;
+      return 'metadata_only';
+    },
+  });
+
+  // submitConversationRating will fail due to no real server, but we
+  // can verify the resolver was called by checking the resolverCalls count.
+  // Instead, let's check via a more integrated approach by mocking the fetch.
+  // For simplicity, we just verify the resolver is wired up for ratings.
+  try {
+    assert.equal(resolverCalls, 0);
+    // The rating method will throw because there's no real API,
+    // but the resolver should still be called.
+    await harness.client
+      .submitConversationRating('conv-1', {
+        ratingId: 'r1',
+        rating: 'CONVERSATION_RATING_VALUE_GOOD',
+        comment: 'great job',
+      })
+      .catch(() => {});
+    assert.ok(resolverCalls > 0, 'resolver was called for rating');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+// --- Context propagation ---
+
+test('context propagation: withContentCaptureMode sets and reads from context', () => {
+  const before = contentCaptureModeFromContext();
+  assert.equal(before.set, false);
+  assert.equal(before.mode, 'default');
+
+  withContentCaptureMode('metadata_only', () => {
+    const inside = contentCaptureModeFromContext();
+    assert.equal(inside.set, true);
+    assert.equal(inside.mode, 'metadata_only');
+  });
+
+  const after = contentCaptureModeFromContext();
+  assert.equal(after.set, false);
+});
+
+test('context propagation: generation callback sets mode for child tool executions', async () => {
+  const harness = newHarness({ contentCapture: 'metadata_only' });
+  try {
+    await harness.client.startGeneration({ model: { provider: 'test', name: 'test-model' } }, async (recorder) => {
+      // Inside the callback, the content capture mode should be set
+      const ctx = contentCaptureModeFromContext();
+      assert.equal(ctx.set, true);
+      assert.equal(ctx.mode, 'metadata_only');
+
+      const toolRec = harness.client.startToolExecution({
+        toolName: 'test_tool',
+        includeContent: true,
+      });
+      toolRec.setResult({ arguments: 'args', result: 'result' });
+      toolRec.end();
+
+      recorder.setResult({
+        input: [{ role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+        output: [{ role: 'assistant', parts: [{ type: 'text', text: 'Hi' }] }],
+      });
+    });
+
+    // Tool span should not have content (inherited metadata_only)
+    const span = singleToolSpan(harness.spanExporter);
+    assert.equal(span.attributes['gen_ai.tool.call.arguments'], undefined);
+    assert.equal(span.attributes['gen_ai.tool.name'], 'test_tool');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('context propagation: generation full callback allows child tool content', async () => {
+  const harness = newHarness({ contentCapture: 'full' });
+  try {
+    await harness.client.startGeneration({ model: { provider: 'test', name: 'test-model' } }, async (recorder) => {
+      const toolRec = harness.client.startToolExecution({
+        toolName: 'test_tool',
+        includeContent: true,
+      });
+      toolRec.setResult({ arguments: 'args', result: 'result' });
+      toolRec.end();
+
+      recorder.setResult({
+        input: [{ role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+        output: [{ role: 'assistant', parts: [{ type: 'text', text: 'Hi' }] }],
+      });
+    });
+
+    const span = singleToolSpan(harness.spanExporter);
+    assert.equal(span.attributes['gen_ai.tool.call.arguments'], '"args"');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+// --- ToolExecution type preserves contentCapture ---
+
+test('ToolExecution snapshot preserves contentCapture field', async () => {
+  const harness = newHarness();
+  try {
+    const toolRec = harness.client.startToolExecution({
+      toolName: 'test_tool',
+      contentCapture: 'full',
+    });
+    toolRec.setResult({ arguments: 'args', result: 'result' });
+    toolRec.end();
+    assert.equal(toolRec.getError(), undefined);
+
+    const snapshot = harness.client.debugSnapshot();
+    assert.equal(snapshot.toolExecutions.length, 1);
+    assert.equal(snapshot.toolExecutions[0].contentCapture, 'full');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+// --- Multiple modes table test ---
+
+const generationModeTests = [
+  {
+    name: 'client default, gen default → no_tool_content',
+    clientMode: undefined,
+    genMode: undefined,
+    wantStripped: false,
+    wantMarker: 'no_tool_content',
+  },
+  {
+    name: 'client metadata_only, gen default → stripped',
+    clientMode: 'metadata_only',
+    genMode: undefined,
+    wantStripped: true,
+    wantMarker: 'metadata_only',
+  },
+  {
+    name: 'client full, gen metadata_only → stripped',
+    clientMode: 'full',
+    genMode: 'metadata_only',
+    wantStripped: true,
+    wantMarker: 'metadata_only',
+  },
+  {
+    name: 'client metadata_only, gen full → full',
+    clientMode: 'metadata_only',
+    genMode: 'full',
+    wantStripped: false,
+    wantMarker: 'full',
+  },
+  {
+    name: 'client full, gen default → full',
+    clientMode: 'full',
+    genMode: undefined,
+    wantStripped: false,
+    wantMarker: 'full',
+  },
+];
+
+for (const tc of generationModeTests) {
+  test(`generation mode resolution: ${tc.name}`, async () => {
+    const harness = newHarness(tc.clientMode ? { contentCapture: tc.clientMode } : {});
+    try {
+      const recorder = harness.client.startGeneration({
+        model: { provider: 'test', name: 'test-model' },
+        contentCapture: tc.genMode,
+      });
+      recorder.setResult({
+        input: [{ role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+        output: [{ role: 'assistant', parts: [{ type: 'text', text: 'Hi' }] }],
+        usage: { inputTokens: 10, outputTokens: 5 },
+      });
+      recorder.end();
+      assert.equal(recorder.getError(), undefined);
+
+      const gen = singleGeneration(harness.client);
+      assert.equal(gen.metadata['sigil.sdk.content_capture_mode'], tc.wantMarker);
+      const stripped = gen.input[0].parts[0].text === '';
+      assert.equal(stripped, tc.wantStripped);
+
+      // Structure always preserved
+      assert.equal(gen.input.length, 1);
+      assert.equal(gen.input[0].role, 'user');
+      assert.equal(gen.usage.inputTokens, 10);
+    } finally {
+      await shutdownHarness(harness);
+    }
+  });
+}
+
+// --- message.content shorthand stripping ---
+
+test('metadata_only strips message.content shorthand field', async () => {
+  const harness = newHarness({ contentCapture: 'metadata_only' });
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'test', name: 'test-model' },
+    });
+    recorder.setResult({
+      input: [{ role: 'user', content: 'Hello secret data', parts: [{ type: 'text', text: 'Hello text' }] }],
+      output: [{ role: 'assistant', content: 'Secret response', parts: [{ type: 'text', text: 'Response text' }] }],
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+
+    const gen = singleGeneration(harness.client);
+    // message.content shorthand must be stripped
+    assert.equal(gen.input[0].content, '');
+    assert.equal(gen.output[0].content, '');
+    // parts also stripped
+    assert.equal(gen.input[0].parts[0].text, '');
+    assert.equal(gen.output[0].parts[0].text, '');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('metadata_only validates content-only messages (no parts) after stripping', async () => {
+  const harness = newHarness({ contentCapture: 'metadata_only' });
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'test', name: 'test-model' },
+    });
+    recorder.setResult({
+      input: [{ role: 'user', content: 'Hello with no parts' }],
+      output: [{ role: 'assistant', parts: [{ type: 'text', text: 'Response' }] }],
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+    recorder.end();
+    // Should not fail validation even though message.content is now '' and parts is empty
+    assert.equal(recorder.getError(), undefined);
+
+    const gen = singleGeneration(harness.client);
+    assert.equal(gen.input[0].content, '');
+    assert.equal(gen.input[0].parts, undefined);
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+// --- Rating context propagation ---
+
+test('rating comment stripped when called inside withContentCaptureMode context', async () => {
+  let receivedBody = {};
+  const server = createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    receivedBody = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(
+      JSON.stringify({
+        rating: {
+          rating_id: 'r1',
+          conversation_id: 'conv-1',
+          rating: 'CONVERSATION_RATING_VALUE_GOOD',
+          created_at: '2026-01-01T00:00:00Z',
+        },
+        summary: {
+          total_count: 1,
+          good_count: 1,
+          bad_count: 0,
+          latest_rating: 'CONVERSATION_RATING_VALUE_GOOD',
+          latest_rated_at: '2026-01-01T00:00:00Z',
+          has_bad_rating: false,
+        },
+      }),
+    );
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+
+  const harness = newHarness({
+    contentCapture: 'full',
+    api: { endpoint: `http://127.0.0.1:${address.port}` },
+  });
+  try {
+    await withContentCaptureMode('metadata_only', async () => {
+      await harness.client.submitConversationRating('conv-1', {
+        ratingId: 'r1',
+        rating: 'CONVERSATION_RATING_VALUE_GOOD',
+        comment: 'should be stripped',
+      });
+    });
+    assert.equal(receivedBody.comment, '', 'context metadata_only should strip rating comment');
+  } finally {
+    await shutdownHarness(harness);
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+// --- Tool description span suppression ---
+
+test('metadata_only suppresses tool description on span', async () => {
+  const harness = newHarness({ contentCapture: 'metadata_only' });
+  try {
+    const tool = harness.client.startToolExecution({
+      toolName: 'search',
+      toolDescription: 'Searches the web for information',
+      includeContent: true,
+    });
+    tool.setResult({ result: 'some result', completedAt: new Date() });
+    tool.end();
+
+    const span = singleToolSpan(harness.spanExporter);
+    assert.equal(span.attributes['gen_ai.tool.description'], '', 'tool description should be cleared on span');
+    assert.equal(span.attributes['gen_ai.tool.call.arguments'], undefined, 'arguments should not be on span');
+    assert.equal(span.attributes['gen_ai.tool.call.result'], undefined, 'result should not be on span');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+// --- Resolver validation ---
+
+test('resolver returning invalid mode defaults to metadata_only', async () => {
+  let warnMessage = '';
+  const harness = newHarness({
+    contentCaptureResolver: () => 'not_a_valid_mode',
+    logger: {
+      warn: (msg) => {
+        warnMessage = msg;
+      },
+    },
+  });
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'test', name: 'test-model' },
+    });
+    recorder.setResult({
+      input: [{ role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+      output: [{ role: 'assistant', parts: [{ type: 'text', text: 'Hi' }] }],
+    });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+
+    const gen = singleGeneration(harness.client);
+    assert.equal(gen.metadata['sigil.sdk.content_capture_mode'], 'metadata_only');
+    assert.equal(gen.input[0].parts[0].text, '');
+    assert.ok(warnMessage.includes('invalid mode'), 'should warn about invalid mode');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('resolver throwing defaults to metadata_only with warning', async () => {
+  let warnMessage = '';
+  const harness = newHarness({
+    contentCaptureResolver: () => {
+      throw new Error('resolver broken');
+    },
+    logger: {
+      warn: (msg) => {
+        warnMessage = msg;
+      },
+    },
+  });
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'test', name: 'test-model' },
+    });
+    recorder.setResult({
+      input: [{ role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+      output: [{ role: 'assistant', parts: [{ type: 'text', text: 'Hi' }] }],
+    });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+
+    const gen = singleGeneration(harness.client);
+    assert.equal(gen.metadata['sigil.sdk.content_capture_mode'], 'metadata_only');
+    assert.equal(gen.input[0].parts[0].text, '');
+    assert.ok(warnMessage.includes('contentCaptureResolver threw'), 'should warn about thrown exception');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});


### PR DESCRIPTION
Add ContentCaptureMode support to JS/TS SDK. Adds
full/no_tool_content/metadata_only modes with config-level defaults, per-recording overrides, resolver callbacks, AsyncLocalStorage context propagation, and generation content stripping.

The SDK default resolves to no_tool_content, preserving backward compatibility with the existing includeContent flag on tool executions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what generation/tool content is recorded and exported based on new capture-mode resolution (including a fail-closed resolver), which can affect telemetry payloads and span attributes across integrations.
> 
> **Overview**
> Adds a new `ContentCaptureMode` (`full`/`no_tool_content`/`metadata_only`) to control how much generation and tool content is included in exported payloads and OTel spans, configurable at the client level and overridable per generation/tool.
> 
> Implements mode resolution and propagation via `AsyncLocalStorage` (`withContentCaptureMode`), stamps `sigil.sdk.content_capture_mode` metadata, and when in `metadata_only` actively strips prompts/messages/tool schemas and categorizes `callError` while suppressing tool span details.
> 
> Extends SDK config to include `contentCapture` plus a `contentCaptureResolver` (validated and fail-closed to `metadata_only`), wires this into conversation rating submission (strips comments under `metadata_only`), updates framework integrations to pass parent generation capture mode to tools, relaxes validation to accept stripped messages, and adds comprehensive tests for resolution/propagation/back-compat with `includeContent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9adf69e21ff56304a7a97722f284aee8b9089fee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->