### PR TITLE
refactor(python): centralize usage mapping into sigil_sdk/usage.py

### DIFF
--- a/python-frameworks/litellm/sigil_sdk_litellm/handler.py
+++ b/python-frameworks/litellm/sigil_sdk_litellm/handler.py
@@ -23,6 +23,7 @@ from sigil_sdk.models import (
     ToolDefinition,
     ToolResult,
 )
+from sigil_sdk.usage import from_openai_chat
 
 logger = logging.getLogger(__name__)
 
@@ -285,21 +286,10 @@ def _extract_detailed_usage(response_obj: Any, slo: dict[str, Any]) -> TokenUsag
     if resp_usage is None:
         return usage
 
-    prompt_details = getattr(resp_usage, "prompt_tokens_details", None)
-    if prompt_details is not None:
-        cached = getattr(prompt_details, "cached_tokens", None)
-        if cached is not None and isinstance(cached, int):
-            usage.cache_read_input_tokens = cached
-        cache_creation = getattr(prompt_details, "cache_creation_tokens", None)
-        if cache_creation is not None and isinstance(cache_creation, int):
-            usage.cache_creation_input_tokens = cache_creation
-
-    completion_details = getattr(resp_usage, "completion_tokens_details", None)
-    if completion_details is not None:
-        reasoning = getattr(completion_details, "reasoning_tokens", None)
-        if reasoning is not None and isinstance(reasoning, int):
-            usage.reasoning_tokens = reasoning
-
+    detail = from_openai_chat(resp_usage)
+    usage.cache_read_input_tokens = detail.cache_read_input_tokens
+    usage.cache_creation_input_tokens = detail.cache_creation_input_tokens
+    usage.reasoning_tokens = detail.reasoning_tokens
     return usage
 
 

--- a/python-providers/anthropic/sigil_sdk_anthropic/provider.py
+++ b/python-providers/anthropic/sigil_sdk_anthropic/provider.py
@@ -18,11 +18,11 @@ from sigil_sdk import (
     ModelRef,
     Part,
     PartKind,
-    TokenUsage,
     ToolCall,
     ToolDefinition,
     ToolResult,
 )
+from sigil_sdk.usage import from_anthropic
 
 if TYPE_CHECKING:
     from anthropic.types.message import Message as AnthropicMessage
@@ -167,7 +167,7 @@ def _messages_from_request_response(
     input_messages, system_prompt = _map_input_messages(request)
     output_message = _map_output_message(response)
     tools = _map_tools(_read(request, "tools"))
-    usage = _map_usage(_read(response, "usage"))
+    usage = from_anthropic(_read(response, "usage"))
     usage_metadata = _anthropic_usage_metadata(_read(response, "usage"))
 
     generation = Generation(
@@ -424,18 +424,6 @@ def _map_tools(raw_tools: Any) -> list[ToolDefinition]:
         )
 
     return tools
-
-
-def _map_usage(raw_usage: Any) -> TokenUsage:
-    usage = TokenUsage(
-        input_tokens=_as_int(_read(raw_usage, "input_tokens")),
-        output_tokens=_as_int(_read(raw_usage, "output_tokens")),
-        total_tokens=_as_int(_read(raw_usage, "total_tokens")),
-        cache_read_input_tokens=_as_int(_read(raw_usage, "cache_read_input_tokens")),
-        cache_write_input_tokens=_as_int(_read(raw_usage, "cache_write_input_tokens")),
-        cache_creation_input_tokens=_as_int(_read(raw_usage, "cache_creation_input_tokens")),
-    )
-    return usage.normalize()
 
 
 def _extract_stream_output_text(events: list[RawMessageStreamEvent]) -> str:

--- a/python-providers/gemini/sigil_sdk_gemini/provider.py
+++ b/python-providers/gemini/sigil_sdk_gemini/provider.py
@@ -20,11 +20,11 @@ from sigil_sdk import (
     ModelRef,
     Part,
     PartKind,
-    TokenUsage,
     ToolCall,
     ToolDefinition,
     ToolResult,
 )
+from sigil_sdk.usage import from_gemini
 
 if TYPE_CHECKING:
     from google.genai import types as genai_types
@@ -278,7 +278,7 @@ def _models_from_request_response(
 ) -> Generation:
     opts = options or GeminiOptions()
     request_controls = _request_controls(config)
-    usage = _map_usage(_read(response, "usage_metadata"))
+    usage = from_gemini(_read(response, "usage_metadata"))
     usage_metadata = _gemini_usage_metadata(_read(response, "usage_metadata"))
     output = _map_output_messages(response)
     if not output:
@@ -613,27 +613,6 @@ def _map_tools(config: GenerateContentConfig | None) -> list[ToolDefinition]:
             )
 
     return mapped
-
-
-def _map_usage(raw_usage: Any) -> TokenUsage:
-    input_tokens = _as_int(_read(raw_usage, "prompt_token_count"))
-    output_tokens = _as_int(_read(raw_usage, "candidates_token_count"))
-    total_tokens = _as_int(_read(raw_usage, "total_token_count"))
-    tool_use_prompt_tokens = _as_int(_read(raw_usage, "tool_use_prompt_token_count"))
-    reasoning_tokens = _as_int(_read(raw_usage, "thoughts_token_count"))
-    if total_tokens == 0:
-        total_tokens = input_tokens + output_tokens + tool_use_prompt_tokens + reasoning_tokens
-
-    usage = TokenUsage(
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        total_tokens=total_tokens,
-        cache_read_input_tokens=_as_int(_read(raw_usage, "cached_content_token_count")),
-        cache_write_input_tokens=_as_int(_read(raw_usage, "cache_write_input_token_count")),
-        cache_creation_input_tokens=_as_int(_read(raw_usage, "cache_creation_input_token_count")),
-        reasoning_tokens=reasoning_tokens,
-    )
-    return usage.normalize()
 
 
 def _response_stop_reason(response: GenerateContentResponse) -> str:

--- a/python-providers/openai/sigil_sdk_openai/provider.py
+++ b/python-providers/openai/sigil_sdk_openai/provider.py
@@ -20,11 +20,11 @@ from sigil_sdk import (
     ModelRef,
     Part,
     PartKind,
-    TokenUsage,
     ToolCall,
     ToolDefinition,
     ToolResult,
 )
+from sigil_sdk.usage import from_openai_chat, from_openai_responses
 
 if TYPE_CHECKING:
     from openai.types.chat import ChatCompletion
@@ -207,7 +207,7 @@ def _chat_from_request_response(
     input_messages, system_prompt = _map_chat_request_messages(request)
     output_messages = _map_chat_response_output(response)
     tools = _map_chat_tools(request)
-    usage = _map_chat_usage(_read(response, "usage"))
+    usage = from_openai_chat(_read(response, "usage"))
 
     max_tokens = _chat_request_max_tokens(request)
     temperature = _as_float_or_none(_read(request, "temperature"))
@@ -507,7 +507,7 @@ def _responses_from_request_response(
         input=request_payload["input"],
         output=_map_responses_output_items(_read(response, "output")),
         tools=request_payload["tools"],
-        usage=_map_responses_usage(_read(response, "usage")),
+        usage=from_openai_responses(_read(response, "usage")),
         stop_reason=_normalize_responses_stop_reason(response),
         tags=dict(opts.tags),
         metadata=_metadata_with_thinking_budget(opts.metadata, controls["thinking_budget"]),
@@ -782,17 +782,6 @@ def _map_chat_tools(request: ChatCreateRequest | ChatStreamRequest) -> list[Tool
     return out
 
 
-def _map_chat_usage(value: Any) -> TokenUsage:
-    usage = TokenUsage(
-        input_tokens=_as_int(_read(value, "prompt_tokens")),
-        output_tokens=_as_int(_read(value, "completion_tokens")),
-        total_tokens=_as_int(_read(value, "total_tokens")),
-        cache_read_input_tokens=_as_int(_read(_read(value, "prompt_tokens_details"), "cached_tokens")),
-        reasoning_tokens=_as_int(_read(_read(value, "completion_tokens_details"), "reasoning_tokens")),
-    )
-    return usage.normalize()
-
-
 def _chat_request_max_tokens(request: ChatCreateRequest | ChatStreamRequest) -> int | None:
     first = _as_int_or_none(_read(request, "max_completion_tokens"))
     if first is not None:
@@ -981,17 +970,6 @@ def _tool_result_message(value: Any, *, tool_call_id: str, name: str, is_error: 
     )
     part.metadata.provider_type = "tool_result"
     return Message(role=MessageRole.TOOL, parts=[part])
-
-
-def _map_responses_usage(value: Any) -> TokenUsage:
-    usage = TokenUsage(
-        input_tokens=_as_int(_read(value, "input_tokens")),
-        output_tokens=_as_int(_read(value, "output_tokens")),
-        total_tokens=_as_int(_read(value, "total_tokens")),
-        cache_read_input_tokens=_as_int(_read(_read(value, "input_tokens_details"), "cached_tokens")),
-        reasoning_tokens=_as_int(_read(_read(value, "output_tokens_details"), "reasoning_tokens")),
-    )
-    return usage.normalize()
 
 
 def _normalize_responses_stop_reason(response: ResponsesCreateResponse) -> str:

--- a/python/sigil_sdk/framework_handler.py
+++ b/python/sigil_sdk/framework_handler.py
@@ -22,10 +22,10 @@ from sigil_sdk import (
     ModelRef,
     Part,
     PartKind,
-    TokenUsage,
     ToolExecutionStart,
     user_text_message,
 )
+from sigil_sdk.usage import map_usage
 
 ProviderResolver = str | Callable[[str, dict[str, Any] | None, dict[str, Any] | None], str]
 
@@ -318,7 +318,7 @@ class SigilFrameworkHandlerBase:
         try:
             llm_output = _read(response, "llm_output")
             raw_usage = _read(llm_output, "token_usage") or _read(llm_output, "usage")
-            usage = _map_usage(raw_usage)
+            usage = map_usage(raw_usage)
             response_model = _as_str(_read(llm_output, "model_name"))
             stop_reason = _as_str(_read(llm_output, "finish_reason") or _read(llm_output, "stop_reason"))
 
@@ -1064,29 +1064,6 @@ def _normalize_role(role: str) -> MessageRole:
     if normalized == "tool":
         return MessageRole.TOOL
     return MessageRole.USER
-
-
-def _map_usage(raw_usage: Any) -> TokenUsage:
-    if raw_usage is None:
-        return TokenUsage()
-
-    input_tokens = _as_int(_read(raw_usage, "prompt_tokens"))
-    if input_tokens == 0:
-        input_tokens = _as_int(_read(raw_usage, "input_tokens"))
-
-    output_tokens = _as_int(_read(raw_usage, "completion_tokens"))
-    if output_tokens == 0:
-        output_tokens = _as_int(_read(raw_usage, "output_tokens"))
-
-    total_tokens = _as_int(_read(raw_usage, "total_tokens"))
-    if total_tokens == 0:
-        total_tokens = input_tokens + output_tokens
-
-    return TokenUsage(
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        total_tokens=total_tokens,
-    )
 
 
 def _read(value: Any, key: str) -> Any:

--- a/python/sigil_sdk/proto_mapping.py
+++ b/python/sigil_sdk/proto_mapping.py
@@ -42,6 +42,7 @@ def generation_to_proto(generation: Generation) -> sigil_pb2.Generation:
             total_tokens=generation.usage.total_tokens,
             cache_read_input_tokens=generation.usage.cache_read_input_tokens,
             cache_write_input_tokens=generation.usage.cache_write_input_tokens,
+            cache_creation_input_tokens=generation.usage.cache_creation_input_tokens,
             reasoning_tokens=generation.usage.reasoning_tokens,
         ),
         stop_reason=generation.stop_reason,

--- a/python/sigil_sdk/usage.py
+++ b/python/sigil_sdk/usage.py
@@ -1,0 +1,176 @@
+"""Centralised usage-mapping helpers for all known LLM response shapes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .models import TokenUsage
+
+
+def from_anthropic(raw: Any) -> TokenUsage:
+    """Extract usage from Anthropic's flat field layout."""
+    if raw is None:
+        return TokenUsage()
+    return TokenUsage(
+        input_tokens=_as_int(_read(raw, "input_tokens")),
+        output_tokens=_as_int(_read(raw, "output_tokens")),
+        total_tokens=_as_int(_read(raw, "total_tokens")),
+        cache_read_input_tokens=_as_int(_read(raw, "cache_read_input_tokens")),
+        cache_write_input_tokens=_as_int(_read(raw, "cache_write_input_tokens")),
+        cache_creation_input_tokens=_as_int(_read(raw, "cache_creation_input_tokens")),
+    ).normalize()
+
+
+def from_openai_chat(raw: Any) -> TokenUsage:
+    """Extract usage from OpenAI Chat Completions (prompt_tokens / completion_tokens + nested details)."""
+    if raw is None:
+        return TokenUsage()
+    return TokenUsage(
+        input_tokens=_as_int(_read(raw, "prompt_tokens")),
+        output_tokens=_as_int(_read(raw, "completion_tokens")),
+        total_tokens=_as_int(_read(raw, "total_tokens")),
+        cache_read_input_tokens=_as_int(
+            _read(_read(raw, "prompt_tokens_details"), "cached_tokens"),
+        ),
+        cache_creation_input_tokens=_as_int(
+            _read(_read(raw, "prompt_tokens_details"), "cache_creation_tokens"),
+        ),
+        reasoning_tokens=_as_int(
+            _read(_read(raw, "completion_tokens_details"), "reasoning_tokens"),
+        ),
+    ).normalize()
+
+
+def from_openai_responses(raw: Any) -> TokenUsage:
+    """Extract usage from OpenAI Responses API (input_tokens / output_tokens + nested details)."""
+    if raw is None:
+        return TokenUsage()
+    return TokenUsage(
+        input_tokens=_as_int(_read(raw, "input_tokens")),
+        output_tokens=_as_int(_read(raw, "output_tokens")),
+        total_tokens=_as_int(_read(raw, "total_tokens")),
+        cache_read_input_tokens=_as_int(
+            _read(_read(raw, "input_tokens_details"), "cached_tokens"),
+        ),
+        reasoning_tokens=_as_int(
+            _read(_read(raw, "output_tokens_details"), "reasoning_tokens"),
+        ),
+    ).normalize()
+
+
+def from_gemini(raw: Any) -> TokenUsage:
+    """Extract usage from Gemini's usage_metadata field names."""
+    if raw is None:
+        return TokenUsage()
+
+    input_tokens = _as_int(_read(raw, "prompt_token_count"))
+    output_tokens = _as_int(_read(raw, "candidates_token_count"))
+    total_tokens = _as_int(_read(raw, "total_token_count"))
+    tool_use_prompt_tokens = _as_int(_read(raw, "tool_use_prompt_token_count"))
+    reasoning_tokens = _as_int(_read(raw, "thoughts_token_count"))
+
+    if total_tokens == 0:
+        total_tokens = input_tokens + output_tokens + tool_use_prompt_tokens + reasoning_tokens
+
+    return TokenUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        cache_read_input_tokens=_as_int(_read(raw, "cached_content_token_count")),
+        cache_write_input_tokens=_as_int(_read(raw, "cache_write_input_token_count")),
+        cache_creation_input_tokens=_as_int(_read(raw, "cache_creation_input_token_count")),
+        reasoning_tokens=reasoning_tokens,
+    )
+
+
+def from_generic(raw: Any) -> TokenUsage:
+    """Best-effort extraction for payloads that don't match a known provider shape.
+
+    Tries both OpenAI-style (prompt_tokens) and Anthropic-style (input_tokens)
+    key families, plus flat cache/reasoning fields. Used by framework adapters
+    that may only expose a subset of counts.
+    """
+    if raw is None:
+        return TokenUsage()
+
+    prompt = _read(raw, "prompt_tokens")
+    input_tokens = _as_int(prompt) if prompt is not None else _as_int(_read(raw, "input_tokens"))
+    completion = _read(raw, "completion_tokens")
+    output_tokens = _as_int(completion) if completion is not None else _as_int(_read(raw, "output_tokens"))
+    total_tokens = _as_int(_read(raw, "total_tokens"))
+    if total_tokens == 0:
+        total_tokens = input_tokens + output_tokens
+
+    return TokenUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        cache_read_input_tokens=_as_int(_read(raw, "cache_read_input_tokens")),
+        cache_write_input_tokens=_as_int(_read(raw, "cache_write_input_tokens")),
+        cache_creation_input_tokens=_as_int(_read(raw, "cache_creation_input_tokens")),
+        reasoning_tokens=_as_int(_read(raw, "reasoning_tokens")),
+    )
+
+
+def map_usage(raw: Any) -> TokenUsage:
+    """Auto-detect the usage shape and dispatch to the appropriate extractor."""
+    if raw is None:
+        return TokenUsage()
+
+    if _read(raw, "prompt_token_count") is not None or _read(raw, "candidates_token_count") is not None:
+        return from_gemini(raw)
+
+    if _read(raw, "prompt_tokens") is not None:
+        return from_openai_chat(raw)
+
+    if _read(raw, "input_tokens_details") is not None or _read(raw, "output_tokens_details") is not None:
+        return from_openai_responses(raw)
+
+    if _read(raw, "input_tokens") is not None:
+        return from_anthropic(raw)
+
+    return from_generic(raw)
+
+
+def _read(value: Any, key: str, default: Any = None) -> Any:
+    if value is None:
+        return default
+
+    if isinstance(value, Mapping):
+        return value.get(key, default)
+
+    if hasattr(value, key):
+        return getattr(value, key)
+
+    return default
+
+
+def _as_int(value: Any) -> int:
+    converted = _as_int_or_none(value)
+    return converted if converted is not None else 0
+
+
+def _as_int_or_none(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+
+    if isinstance(value, int):
+        return value
+
+    if isinstance(value, float):
+        integer = int(value)
+        if float(integer) == value:
+            return integer
+        return None
+
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return int(text)
+        except ValueError:
+            return None
+
+    return None

--- a/python/tests/test_conformance.py
+++ b/python/tests/test_conformance.py
@@ -313,6 +313,7 @@ def test_conformance_sync_roundtrip_semantics() -> None:
         assert generation.usage.total_tokens == 19
         assert generation.usage.cache_read_input_tokens == 2
         assert generation.usage.cache_write_input_tokens == 1
+        assert generation.usage.cache_creation_input_tokens == 3
         assert generation.usage.reasoning_tokens == 4
         assert generation.stop_reason == "stop"
         assert generation.tags["tenant"] == "dev"

--- a/python/tests/test_transport.py
+++ b/python/tests/test_transport.py
@@ -446,6 +446,7 @@ def _assert_generation_json_payload(generation: dict[str, Any]) -> None:
     assert _proto_json_int(usage["total_tokens"]) == 162
     assert _proto_json_int(usage["cache_read_input_tokens"]) == 8
     assert _proto_json_int(usage["cache_write_input_tokens"]) == 4
+    assert _proto_json_int(usage["cache_creation_input_tokens"]) == 6
     assert _proto_json_int(usage["reasoning_tokens"]) == 5
 
     assert generation["stop_reason"] == "end_turn"
@@ -532,6 +533,7 @@ def _assert_generation_proto_payload(generation: sigil_pb2.Generation) -> None:
     assert generation.usage.total_tokens == 162
     assert generation.usage.cache_read_input_tokens == 8
     assert generation.usage.cache_write_input_tokens == 4
+    assert generation.usage.cache_creation_input_tokens == 6
     assert generation.usage.reasoning_tokens == 5
 
     assert generation.stop_reason == "end_turn"
@@ -678,6 +680,7 @@ def _payload_fixture() -> tuple[GenerationStart, Generation]:
             total_tokens=162,
             cache_read_input_tokens=8,
             cache_write_input_tokens=4,
+            cache_creation_input_tokens=6,
             reasoning_tokens=5,
         ),
         stop_reason="end_turn",

--- a/python/tests/test_usage.py
+++ b/python/tests/test_usage.py
@@ -1,0 +1,372 @@
+"""Tests for the centralised usage-mapping module."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from sigil_sdk.models import TokenUsage
+from sigil_sdk.usage import (
+    from_anthropic,
+    from_gemini,
+    from_generic,
+    from_openai_chat,
+    from_openai_responses,
+    map_usage,
+)
+
+
+class TestFromAnthropic:
+    def test_full(self):
+        raw = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "total_tokens": 0,
+            "cache_read_input_tokens": 10,
+            "cache_write_input_tokens": 5,
+            "cache_creation_input_tokens": 3,
+        }
+        usage = from_anthropic(raw)
+        assert usage.input_tokens == 100
+        assert usage.output_tokens == 50
+        assert usage.total_tokens == 150  # normalized
+        assert usage.cache_read_input_tokens == 10
+        assert usage.cache_write_input_tokens == 5
+        assert usage.cache_creation_input_tokens == 3
+        assert usage.reasoning_tokens == 0
+
+    def test_partial(self):
+        raw = {"input_tokens": 40, "output_tokens": 20}
+        usage = from_anthropic(raw)
+        assert usage.input_tokens == 40
+        assert usage.output_tokens == 20
+        assert usage.total_tokens == 60
+
+    def test_explicit_zeros(self):
+        raw = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_input_tokens": 0,
+        }
+        usage = from_anthropic(raw)
+        assert usage.input_tokens == 0
+        assert usage.output_tokens == 0
+        assert usage.total_tokens == 0
+        assert usage.cache_read_input_tokens == 0
+
+    def test_none(self):
+        assert from_anthropic(None) == TokenUsage()
+
+    def test_simplenamespace(self):
+        raw = SimpleNamespace(
+            input_tokens=80,
+            output_tokens=40,
+            cache_read_input_tokens=15,
+            cache_creation_input_tokens=7,
+        )
+        usage = from_anthropic(raw)
+        assert usage.input_tokens == 80
+        assert usage.output_tokens == 40
+        assert usage.total_tokens == 120
+        assert usage.cache_read_input_tokens == 15
+        assert usage.cache_creation_input_tokens == 7
+
+
+class TestFromOpenAIChat:
+    def test_full(self):
+        raw = {
+            "prompt_tokens": 200,
+            "completion_tokens": 100,
+            "total_tokens": 300,
+            "prompt_tokens_details": {
+                "cached_tokens": 50,
+                "cache_creation_tokens": 20,
+            },
+            "completion_tokens_details": {
+                "reasoning_tokens": 30,
+            },
+        }
+        usage = from_openai_chat(raw)
+        assert usage.input_tokens == 200
+        assert usage.output_tokens == 100
+        assert usage.total_tokens == 300
+        assert usage.cache_read_input_tokens == 50
+        assert usage.cache_creation_input_tokens == 20
+        assert usage.reasoning_tokens == 30
+
+    def test_missing_detail_objects(self):
+        raw = {
+            "prompt_tokens": 200,
+            "completion_tokens": 100,
+            "total_tokens": 300,
+        }
+        usage = from_openai_chat(raw)
+        assert usage.input_tokens == 200
+        assert usage.output_tokens == 100
+        assert usage.total_tokens == 300
+        assert usage.cache_read_input_tokens == 0
+        assert usage.reasoning_tokens == 0
+
+    def test_total_autofill(self):
+        raw = {
+            "prompt_tokens": 150,
+            "completion_tokens": 75,
+            "total_tokens": 0,
+        }
+        usage = from_openai_chat(raw)
+        assert usage.total_tokens == 225
+
+    def test_none(self):
+        assert from_openai_chat(None) == TokenUsage()
+
+    def test_simplenamespace_nested(self):
+        raw = SimpleNamespace(
+            prompt_tokens=200,
+            completion_tokens=100,
+            total_tokens=300,
+            prompt_tokens_details=SimpleNamespace(
+                cached_tokens=50,
+                cache_creation_tokens=10,
+            ),
+            completion_tokens_details=SimpleNamespace(
+                reasoning_tokens=25,
+            ),
+        )
+        usage = from_openai_chat(raw)
+        assert usage.cache_read_input_tokens == 50
+        assert usage.cache_creation_input_tokens == 10
+        assert usage.reasoning_tokens == 25
+
+
+class TestFromOpenAIResponses:
+    def test_full(self):
+        raw = {
+            "input_tokens": 300,
+            "output_tokens": 150,
+            "total_tokens": 450,
+            "input_tokens_details": {"cached_tokens": 80},
+            "output_tokens_details": {"reasoning_tokens": 40},
+        }
+        usage = from_openai_responses(raw)
+        assert usage.input_tokens == 300
+        assert usage.output_tokens == 150
+        assert usage.total_tokens == 450
+        assert usage.cache_read_input_tokens == 80
+        assert usage.reasoning_tokens == 40
+
+    def test_missing_detail_objects(self):
+        raw = {
+            "input_tokens": 300,
+            "output_tokens": 150,
+            "total_tokens": 450,
+        }
+        usage = from_openai_responses(raw)
+        assert usage.cache_read_input_tokens == 0
+        assert usage.reasoning_tokens == 0
+
+    def test_total_autofill(self):
+        raw = {"input_tokens": 200, "output_tokens": 80}
+        usage = from_openai_responses(raw)
+        assert usage.total_tokens == 280
+
+    def test_none(self):
+        assert from_openai_responses(None) == TokenUsage()
+
+
+class TestFromGemini:
+    def test_full(self):
+        raw = {
+            "prompt_token_count": 500,
+            "candidates_token_count": 250,
+            "total_token_count": 800,
+            "cached_content_token_count": 60,
+            "cache_write_input_token_count": 20,
+            "cache_creation_input_token_count": 10,
+            "thoughts_token_count": 35,
+            "tool_use_prompt_token_count": 15,
+        }
+        usage = from_gemini(raw)
+        assert usage.input_tokens == 500
+        assert usage.output_tokens == 250
+        assert usage.total_tokens == 800
+        assert usage.cache_read_input_tokens == 60
+        assert usage.cache_write_input_tokens == 20
+        assert usage.cache_creation_input_tokens == 10
+        assert usage.reasoning_tokens == 35
+
+    def test_total_autofill_includes_tool_use_and_thoughts(self):
+        raw = {
+            "prompt_token_count": 100,
+            "candidates_token_count": 50,
+            "total_token_count": 0,
+            "thoughts_token_count": 20,
+            "tool_use_prompt_token_count": 10,
+        }
+        usage = from_gemini(raw)
+        assert usage.total_tokens == 180  # 100 + 50 + 10 + 20
+
+    def test_partial(self):
+        raw = {
+            "prompt_token_count": 100,
+            "candidates_token_count": 50,
+        }
+        usage = from_gemini(raw)
+        assert usage.total_tokens == 150
+        assert usage.cache_read_input_tokens == 0
+
+    def test_none(self):
+        assert from_gemini(None) == TokenUsage()
+
+
+class TestMapUsage:
+    def test_none(self):
+        assert map_usage(None) == TokenUsage()
+
+    def test_empty_dict(self):
+        usage = map_usage({})
+        assert usage == TokenUsage()
+
+    def test_dispatches_gemini(self):
+        raw = {
+            "prompt_token_count": 100,
+            "candidates_token_count": 50,
+            "total_token_count": 150,
+        }
+        usage = map_usage(raw)
+        assert usage.input_tokens == 100
+        assert usage.output_tokens == 50
+
+    def test_dispatches_openai_chat(self):
+        raw = {
+            "prompt_tokens": 200,
+            "completion_tokens": 100,
+            "total_tokens": 300,
+            "prompt_tokens_details": {"cached_tokens": 50},
+            "completion_tokens_details": {"reasoning_tokens": 30},
+        }
+        usage = map_usage(raw)
+        assert usage.input_tokens == 200
+        assert usage.cache_read_input_tokens == 50
+        assert usage.reasoning_tokens == 30
+
+    def test_dispatches_openai_responses(self):
+        raw = {
+            "input_tokens": 300,
+            "output_tokens": 150,
+            "total_tokens": 450,
+            "input_tokens_details": {"cached_tokens": 80},
+            "output_tokens_details": {"reasoning_tokens": 40},
+        }
+        usage = map_usage(raw)
+        assert usage.cache_read_input_tokens == 80
+        assert usage.reasoning_tokens == 40
+
+    def test_dispatches_anthropic(self):
+        raw = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_read_input_tokens": 10,
+        }
+        usage = map_usage(raw)
+        assert usage.input_tokens == 100
+        assert usage.cache_read_input_tokens == 10
+
+    def test_legacy_fallback(self):
+        raw = SimpleNamespace()  # no matching keys at all
+        usage = map_usage(raw)
+        assert usage == TokenUsage()
+
+    def test_simplenamespace_dispatch(self):
+        raw = SimpleNamespace(
+            input_tokens=80,
+            output_tokens=40,
+            cache_read_input_tokens=15,
+        )
+        usage = map_usage(raw)
+        assert usage.input_tokens == 80
+        assert usage.cache_read_input_tokens == 15
+
+    def test_explicit_zero_preserved(self):
+        raw = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+            "cache_read_input_tokens": 0,
+        }
+        usage = map_usage(raw)
+        assert usage.input_tokens == 0
+        assert usage.cache_read_input_tokens == 0
+
+    def test_partial_total_only(self):
+        usage = map_usage({"total_tokens": 7})
+        assert usage.total_tokens == 7
+
+    def test_partial_completion_only(self):
+        usage = map_usage({"completion_tokens": 5})
+        assert usage.output_tokens == 5
+        assert usage.total_tokens == 5
+
+    def test_partial_output_only(self):
+        usage = map_usage({"output_tokens": 3})
+        assert usage.output_tokens == 3
+        assert usage.total_tokens == 3
+
+
+class TestFromGeneric:
+    def test_none(self):
+        assert from_generic(None) == TokenUsage()
+
+    def test_total_only(self):
+        usage = from_generic({"total_tokens": 42})
+        assert usage.total_tokens == 42
+        assert usage.input_tokens == 0
+
+    def test_mixed_key_families(self):
+        raw = {
+            "prompt_tokens": 10,
+            "output_tokens": 5,
+            "cache_read_input_tokens": 3,
+        }
+        usage = from_generic(raw)
+        assert usage.input_tokens == 10
+        assert usage.output_tokens == 5
+        assert usage.total_tokens == 15
+        assert usage.cache_read_input_tokens == 3
+
+    def test_prefers_prompt_tokens_over_input_tokens(self):
+        raw = {"prompt_tokens": 10, "input_tokens": 20}
+        usage = from_generic(raw)
+        assert usage.input_tokens == 10
+
+    def test_explicit_zero_prompt_tokens_not_overridden(self):
+        raw = {"prompt_tokens": 0, "input_tokens": 50}
+        usage = from_generic(raw)
+        assert usage.input_tokens == 0
+
+    def test_explicit_zero_completion_tokens_not_overridden(self):
+        raw = {"completion_tokens": 0, "output_tokens": 50}
+        usage = from_generic(raw)
+        assert usage.output_tokens == 0
+
+    def test_flat_reasoning_tokens(self):
+        raw = {"input_tokens": 100, "reasoning_tokens": 25}
+        usage = from_generic(raw)
+        assert usage.reasoning_tokens == 25
+
+
+class TestHelperEdgeCases:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (True, 0),  # bools → 0
+            (False, 0),
+            ("42", 42),  # string ints
+            ("", 0),
+            (3.0, 3),  # exact floats
+            (None, 0),
+        ],
+    )
+    def test_as_int_via_anthropic(self, value, expected):
+        raw = {"input_tokens": value}
+        usage = from_anthropic(raw)
+        assert usage.input_tokens == expected


### PR DESCRIPTION
The framework handler's _map_usage only read flat fields, silently dropping nested OpenAI usage structures (prompt_tokens_details, completion_tokens_details, etc.) that arrive when LangChain is backed by langchain-openai. Meanwhile, five near-identical usage mappers existed across the codebase.

Add sigil_sdk/usage.py with shape-specific extractors (from_anthropic, from_openai_chat, from_openai_responses, from_gemini) and an auto-detecting map_usage dispatcher. Replace all five local mappers with imports from this module.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches token-usage extraction across multiple providers/framework handlers; mistakes could silently skew usage metrics and cache/reasoning attribution.
> 
> **Overview**
> **Centralizes token-usage parsing** by introducing `sigil_sdk/usage.py` with provider-specific helpers (`from_anthropic`, `from_gemini`, `from_openai_chat`, `from_openai_responses`) plus an auto-detecting `map_usage` dispatcher.
> 
> **Refactors integrations to use the shared mappers** (OpenAI, Anthropic, Gemini providers; LangChain `framework_handler`; LiteLLM handler), removing duplicated local `_map_usage` implementations and ensuring OpenAI nested usage details (cache + reasoning) are captured consistently.
> 
> **Extends exported usage data** by wiring through `cache_creation_input_tokens` in `proto_mapping` and updating conformance/transport tests, plus adding a dedicated `test_usage.py` suite covering shape detection and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9555cd789585ec558cbbcbcb51e78b6b74896374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->