### PR TITLE
feat(claude-code): add SIGIL_EXTRA_TAGS env var for custom tags

### DIFF
--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -46,6 +46,7 @@ Add to `~/.claude/settings.json`:
 | `SIGIL_USER` | yes | Basic auth username (also `X-Scope-OrgID`) |
 | `SIGIL_PASSWORD` | yes | Basic auth password |
 | `SIGIL_CONTENT_CAPTURE` | no | `true` to include redacted conversation content (default: metadata-only) |
+| `SIGIL_EXTRA_TAGS` | no | Comma-separated `key=value` tags added to every generation (e.g. `account=work,env=dev`). Built-in tags (`git.branch`, `cwd`, `entrypoint`, `subagent`) take precedence on collision. |
 | `SIGIL_OTEL_ENDPOINT` | no | OTLP HTTP endpoint for metrics + traces (e.g. `https://otlp-gateway.grafana.net/otlp` or `host:4318`) |
 | `SIGIL_OTEL_USER` | no | OTLP auth username (defaults to `SIGIL_USER`) |
 | `SIGIL_OTEL_PASSWORD` | no | OTLP auth password (defaults to `SIGIL_PASSWORD`) |

--- a/plugins/claude-code/cmd/sigil-cc/main.go
+++ b/plugins/claude-code/cmd/sigil-cc/main.go
@@ -66,6 +66,7 @@ func run() {
 	}
 
 	contentCapture := strings.EqualFold(os.Getenv("SIGIL_CONTENT_CAPTURE"), "true")
+	extraTags := parseExtraTags(os.Getenv("SIGIL_EXTRA_TAGS"))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -123,6 +124,7 @@ func run() {
 		SessionID:      input.SessionID,
 		ContentCapture: contentCapture,
 		Logger:         logger,
+		ExtraTags:      extraTags,
 	}, r)
 
 	if len(gens) == 0 {
@@ -224,6 +226,33 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// parseExtraTags parses a comma-separated "key=value" string into a tag map.
+// Malformed entries (empty keys, missing '=', empty values) are silently skipped —
+// this runs in a stop hook where logging warnings adds noise for no user benefit.
+// Empty input returns nil so the mapper can short-circuit on the zero-extras path.
+func parseExtraTags(s string) map[string]string {
+	if s == "" {
+		return nil
+	}
+	out := make(map[string]string)
+	for _, pair := range strings.Split(s, ",") {
+		k, v, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if k == "" || v == "" {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // buildToolResultMap indexes tool results by their call ID across all generations.

--- a/plugins/claude-code/cmd/sigil-cc/main_test.go
+++ b/plugins/claude-code/cmd/sigil-cc/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -11,6 +12,34 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
+
+func TestParseExtraTags(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want map[string]string
+	}{
+		{"empty string", "", nil},
+		{"single pair", "k=v", map[string]string{"k": "v"}},
+		{"multiple pairs", "k1=v1,k2=v2", map[string]string{"k1": "v1", "k2": "v2"}},
+		{"whitespace trimmed", " k = v ", map[string]string{"k": "v"}},
+		{"whitespace around multiple pairs", " a = 1 , b = 2 ", map[string]string{"a": "1", "b": "2"}},
+		{"malformed entry missing equals", "bad", nil},
+		{"empty key skipped", "=v", nil},
+		{"empty value skipped", "k=", nil},
+		{"mix of good and bad", "good=yes,bad,=v,k=,also=ok", map[string]string{"good": "yes", "also": "ok"}},
+		{"value with equals preserved after first split", "url=a=b", map[string]string{"url": "a=b"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseExtraTags(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseExtraTags(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestBuildToolResultMap(t *testing.T) {
 	tests := []struct {

--- a/plugins/claude-code/internal/mapper/mapper.go
+++ b/plugins/claude-code/internal/mapper/mapper.go
@@ -22,9 +22,10 @@ const (
 
 // Options controls how transcript lines are mapped to generations.
 type Options struct {
-	SessionID      string      // authoritative session ID from the hook input
-	ContentCapture bool        // when true, include redacted Input/Output content
-	Logger         *log.Logger // debug logger (nil = silent)
+	SessionID      string            // authoritative session ID from the hook input
+	ContentCapture bool              // when true, include redacted Input/Output content
+	Logger         *log.Logger       // debug logger (nil = silent)
+	ExtraTags      map[string]string // user-supplied tags merged into every generation; built-in keys always win
 }
 
 func (o Options) logf(format string, args ...any) {
@@ -226,7 +227,7 @@ func processAssistantLine(line transcript.Line, uctx *userContext, _ *state.Sess
 		StopReason:  msg.StopReason,
 		StartedAt:   completedAt, // no real start time; set equal to avoid zero-value skip in SDK metrics
 		CompletedAt: completedAt,
-		Tags:        buildTags(line, isSidechain),
+		Tags:        buildTags(line, isSidechain, opts.ExtraTags),
 	}
 
 	toolNames := map[string]bool{}
@@ -259,11 +260,16 @@ func processAssistantLine(line transcript.Line, uctx *userContext, _ *state.Sess
 	return gen, true
 }
 
-func buildTags(line transcript.Line, subagent bool) map[string]string {
-	if line.GitBranch == "" && line.CWD == "" && line.Entrypoint == "" && !subagent {
+func buildTags(line transcript.Line, subagent bool, extras map[string]string) map[string]string {
+	if line.GitBranch == "" && line.CWD == "" && line.Entrypoint == "" && !subagent && len(extras) == 0 {
 		return nil
 	}
-	tags := make(map[string]string, 4)
+	tags := make(map[string]string, 4+len(extras))
+	// Extras go in first; built-ins written below overwrite any collisions
+	// so user-supplied keys can never shadow git.branch/cwd/entrypoint/subagent.
+	for k, v := range extras {
+		tags[k] = v
+	}
 	if line.GitBranch != "" {
 		tags["git.branch"] = line.GitBranch
 	}

--- a/plugins/claude-code/internal/mapper/mapper_test.go
+++ b/plugins/claude-code/internal/mapper/mapper_test.go
@@ -351,12 +351,34 @@ func TestProcess_Tags(t *testing.T) {
 		branch    string
 		cwd       string
 		entry     string
+		extras    map[string]string
 		wantNil   bool
 		wantCount int
+		wantTags  map[string]string // optional: assert specific key/value pairs
 	}{
-		{"all set", "feature/auth", "/project", "cli", false, 3},
-		{"all empty", "", "", "", true, 0},
-		{"partial", "main", "", "", false, 1},
+		{name: "all set", branch: "feature/auth", cwd: "/project", entry: "cli", wantCount: 3},
+		{name: "all empty", wantNil: true},
+		{name: "partial", branch: "main", wantCount: 1},
+		{
+			name:      "extras merged with built-ins",
+			branch:    "main",
+			extras:    map[string]string{"account": "work", "env": "dev"},
+			wantCount: 3,
+			wantTags:  map[string]string{"git.branch": "main", "account": "work", "env": "dev"},
+		},
+		{
+			name:      "extras only, no built-ins",
+			extras:    map[string]string{"account": "personal"},
+			wantCount: 1,
+			wantTags:  map[string]string{"account": "personal"},
+		},
+		{
+			name:      "built-in wins on collision",
+			branch:    "main",
+			extras:    map[string]string{"git.branch": "user-override", "account": "work"},
+			wantCount: 2,
+			wantTags:  map[string]string{"git.branch": "main", "account": "work"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -369,14 +391,19 @@ func TestProcess_Tags(t *testing.T) {
 			line.Entrypoint = tt.entry
 
 			st := &state.Session{}
-			gens := Process([]transcript.Line{line}, st, Options{SessionID: "sess-1"}, nil)
+			gens := Process([]transcript.Line{line}, st, Options{SessionID: "sess-1", ExtraTags: tt.extras}, nil)
 
 			tags := gens[0].Tags
 			if (tags == nil) != tt.wantNil {
 				t.Errorf("tags nil = %v, want %v", tags == nil, tt.wantNil)
 			}
 			if len(tags) != tt.wantCount {
-				t.Errorf("tags count = %d, want %d", len(tags), tt.wantCount)
+				t.Errorf("tags count = %d, want %d (got %v)", len(tags), tt.wantCount, tags)
+			}
+			for k, v := range tt.wantTags {
+				if tags[k] != v {
+					t.Errorf("tags[%q] = %q, want %q", k, tags[k], v)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
SIGIL_EXTRA_TAGS="account=work,env=dev" tags every generation so installs can be distinguished.

Built-in tags (git.branch, cwd, entrypoint, subagent) are written after extras, so user-supplied keys can't shadow the authoritative ones.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds optional tag parsing/merging with unit tests and does not change export/auth flows; main behavioral change is additional tags on generated telemetry when configured.
> 
> **Overview**
> Adds optional `SIGIL_EXTRA_TAGS` to `sigil-cc` so installs can attach custom comma-separated `key=value` tags to every exported Generation.
> 
> Implements `parseExtraTags` in `cmd/sigil-cc` (skipping malformed entries and returning `nil` for empty input), threads `ExtraTags` through `mapper.Options`, and merges them into `Generation.Tags` while ensuring built-in tags (`git.branch`, `cwd`, `entrypoint`, `subagent`) always override collisions. Documentation and tests are updated to cover parsing and tag-merging behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2716542ad55e9a04119e68d87c976cf87d7ee73c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->