### PR TITLE
feat(python, go): strip conversation_title in MetadataOnly content capture mode

### DIFF
--- a/go/sigil/client.go
+++ b/go/sigil/client.go
@@ -441,43 +441,35 @@ func (c *Client) startGeneration(ctx context.Context, start GenerationStart, def
 	}
 	seed.StartedAt = startedAt
 
-	callCtx, span := c.startSpan(ctx, Generation{
-		ID:                seed.ID,
-		ConversationID:    seed.ConversationID,
-		ConversationTitle: seed.ConversationTitle,
-		UserID:            seed.UserID,
-		AgentName:         seed.AgentName,
-		AgentVersion:      seed.AgentVersion,
-		Mode:              seed.Mode,
-		OperationName:     seed.OperationName,
-		Model:             seed.Model,
-		MaxTokens:         cloneInt64Ptr(seed.MaxTokens),
-		Temperature:       cloneFloat64Ptr(seed.Temperature),
-		TopP:              cloneFloat64Ptr(seed.TopP),
-		ToolChoice:        cloneStringPtr(seed.ToolChoice),
-		ThinkingEnabled:   cloneBoolPtr(seed.ThinkingEnabled),
-	}, trace.SpanKindClient, startedAt)
-	span.SetAttributes(generationSpanAttributes(Generation{
-		ID:                seed.ID,
-		ConversationID:    seed.ConversationID,
-		ConversationTitle: seed.ConversationTitle,
-		UserID:            seed.UserID,
-		AgentName:         seed.AgentName,
-		AgentVersion:      seed.AgentVersion,
-		Mode:              seed.Mode,
-		OperationName:     seed.OperationName,
-		Model:             seed.Model,
-		MaxTokens:         cloneInt64Ptr(seed.MaxTokens),
-		Temperature:       cloneFloat64Ptr(seed.Temperature),
-		TopP:              cloneFloat64Ptr(seed.TopP),
-		ToolChoice:        cloneStringPtr(seed.ToolChoice),
-		ThinkingEnabled:   cloneBoolPtr(seed.ThinkingEnabled),
-	})...)
-
-	// Resolve content capture mode: per-recording > resolver > client default.
+	// Resolve content capture mode before the span starts so MetadataOnly never
+	// attaches sensitive content to live span attributes.
 	resolverMode := callContentCaptureResolver(c.config.ContentCaptureResolver, ctx, seed.Metadata)
 	clientMode := resolveClientContentCaptureMode(resolveContentCaptureMode(resolverMode, c.config.ContentCapture))
 	ccMode := resolveContentCaptureMode(seed.ContentCapture, clientMode)
+
+	spanGeneration := Generation{
+		ID:                seed.ID,
+		ConversationID:    seed.ConversationID,
+		ConversationTitle: seed.ConversationTitle,
+		UserID:            seed.UserID,
+		AgentName:         seed.AgentName,
+		AgentVersion:      seed.AgentVersion,
+		Mode:              seed.Mode,
+		OperationName:     seed.OperationName,
+		Model:             seed.Model,
+		MaxTokens:         cloneInt64Ptr(seed.MaxTokens),
+		Temperature:       cloneFloat64Ptr(seed.Temperature),
+		TopP:              cloneFloat64Ptr(seed.TopP),
+		ToolChoice:        cloneStringPtr(seed.ToolChoice),
+		ThinkingEnabled:   cloneBoolPtr(seed.ThinkingEnabled),
+	}
+	if ccMode == ContentCaptureModeMetadataOnly {
+		spanGeneration.ConversationTitle = ""
+	}
+
+	callCtx, span := c.startSpan(ctx, spanGeneration, trace.SpanKindClient, startedAt)
+	span.SetAttributes(generationSpanAttributes(spanGeneration)...)
+
 	callCtx = withContentCaptureMode(callCtx, ccMode)
 
 	return callCtx, &GenerationRecorder{
@@ -588,6 +580,24 @@ func (c *Client) StartToolExecution(ctx context.Context, start ToolExecutionStar
 	}
 	seed.StartedAt = startedAt
 
+	// Resolve content capture before the span starts so MetadataOnly never
+	// attaches sensitive content to live span attributes.
+	resolverMode := callContentCaptureResolver(c.config.ContentCaptureResolver, ctx, nil)
+	effectiveClientDefault := resolveContentCaptureMode(resolverMode, c.config.ContentCapture)
+	ctxMode, ctxSet := contentCaptureModeFromContext(ctx)
+	toolMode := resolveToolContentCaptureMode(seed.ContentCapture, ctxMode, ctxSet, effectiveClientDefault)
+
+	var includeContent bool
+	switch toolMode {
+	case ContentCaptureModeMetadataOnly:
+		seed.ConversationTitle = ""
+	case ContentCaptureModeFull:
+		includeContent = true
+	default:
+		// NoToolContent / Default: honor legacy IncludeContent opt-in.
+		includeContent = seed.IncludeContent
+	}
+
 	tracer := c.tracer
 	if tracer == nil {
 		tracer = otel.Tracer(instrumentationName)
@@ -598,14 +608,7 @@ func (c *Client) StartToolExecution(ctx context.Context, start ToolExecutionStar
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithTimestamp(startedAt),
 	)
-	attrs := toolSpanAttributes(seed)
-	span.SetAttributes(attrs...)
-
-	// Resolve content capture: per-tool > context (parent generation) > resolver > client default.
-	resolverMode := callContentCaptureResolver(c.config.ContentCaptureResolver, ctx, nil)
-	effectiveClientDefault := resolveContentCaptureMode(resolverMode, c.config.ContentCapture)
-	ctxMode, ctxSet := contentCaptureModeFromContext(ctx)
-	includeContent := shouldIncludeToolContent(seed.ContentCapture, ctxMode, ctxSet, effectiveClientDefault, seed.IncludeContent)
+	span.SetAttributes(toolSpanAttributes(seed)...)
 
 	return callCtx, &ToolExecutionRecorder{
 		client:         c,

--- a/go/sigil/content_capture.go
+++ b/go/sigil/content_capture.go
@@ -27,7 +27,7 @@ const (
 	ContentCaptureModeNoToolContent
 	// ContentCaptureModeMetadataOnly preserves message structure, tool names,
 	// usage, and timing but strips text, tool arguments, tool results,
-	// thinking, system prompts, and raw artifacts.
+	// thinking, system prompts, conversation titles, and raw artifacts.
 	//
 	// Note: user-provided Metadata and Tags are NOT stripped — callers are
 	// responsible for ensuring these maps do not contain sensitive content
@@ -112,6 +112,9 @@ func stripContent(g *Generation, errorCategory string) {
 	}
 	delete(g.Metadata, "call_error")
 
+	g.ConversationTitle = ""
+	delete(g.Metadata, spanAttrConversationTitle)
+
 	for i := range g.Input {
 		stripMessageContent(&g.Input[i])
 	}
@@ -138,10 +141,10 @@ func stripMessageContent(m *Message) {
 	}
 }
 
-// shouldIncludeToolContent determines whether tool execution content (arguments,
-// results) should be included in span attributes. It resolves the effective mode
-// from the explicit override, context, client default, and legacy IncludeContent.
-func shouldIncludeToolContent(toolMode, ctxMode ContentCaptureMode, ctxSet bool, clientDefault ContentCaptureMode, legacyInclude bool) bool {
+// resolveToolContentCaptureMode resolves the effective content capture mode for
+// a tool execution from the per-tool override, parent generation context, and
+// client default.
+func resolveToolContentCaptureMode(toolMode, ctxMode ContentCaptureMode, ctxSet bool, clientDefault ContentCaptureMode) ContentCaptureMode {
 	resolved := resolveClientContentCaptureMode(clientDefault)
 	if ctxSet {
 		resolved = ctxMode
@@ -149,15 +152,7 @@ func shouldIncludeToolContent(toolMode, ctxMode ContentCaptureMode, ctxSet bool,
 	if toolMode != ContentCaptureModeDefault {
 		resolved = toolMode
 	}
-	switch resolved {
-	case ContentCaptureModeMetadataOnly:
-		return false
-	case ContentCaptureModeFull:
-		return true
-	default:
-		// NoToolContent / Default: honor legacy IncludeContent opt-in.
-		return legacyInclude
-	}
+	return resolved
 }
 
 // String returns the string representation of a ContentCaptureMode.

--- a/go/sigil/content_capture_test.go
+++ b/go/sigil/content_capture_test.go
@@ -13,13 +13,14 @@ import (
 func TestStripContent(t *testing.T) {
 	makeGen := func() Generation {
 		return Generation{
-			ID:             "gen-1",
-			ConversationID: "conv-1",
-			AgentName:      "test-agent",
-			AgentVersion:   "1.0",
-			Mode:           GenerationModeSync,
-			Model:          ModelRef{Provider: "anthropic", Name: "claude-sonnet-4-5"},
-			SystemPrompt:   "You are helpful.",
+			ID:                "gen-1",
+			ConversationID:    "conv-1",
+			AgentName:         "test-agent",
+			AgentVersion:      "1.0",
+			ConversationTitle: "Weather chat",
+			Mode:              GenerationModeSync,
+			Model:             ModelRef{Provider: "anthropic", Name: "claude-sonnet-4-5"},
+			SystemPrompt:      "You are helpful.",
 			Input: []Message{
 				{Role: RoleUser, Parts: []Part{{Kind: PartKindText, Text: "What is the weather?"}}},
 				{Role: RoleTool, Parts: []Part{{Kind: PartKindToolResult, ToolResult: &ToolResult{
@@ -43,7 +44,7 @@ func TestStripContent(t *testing.T) {
 			StopReason: "end_turn",
 			CallError:  "rate limit exceeded: prompt too long for model",
 			Artifacts:  []Artifact{{Kind: "request", Payload: []byte("raw")}},
-			Metadata:   map[string]any{"sigil.sdk.name": "sdk-go", "call_error": "rate limit exceeded: prompt too long for model"},
+			Metadata:   map[string]any{"sigil.sdk.name": "sdk-go", "call_error": "rate limit exceeded: prompt too long for model", "sigil.conversation.title": "Weather chat"},
 		}
 	}
 
@@ -80,6 +81,12 @@ func TestStripContent(t *testing.T) {
 		}
 		if gen.Artifacts != nil {
 			t.Fatal("Artifacts not stripped")
+		}
+		if gen.ConversationTitle != "" {
+			t.Fatal("ConversationTitle not stripped")
+		}
+		if _, ok := gen.Metadata["sigil.conversation.title"]; ok {
+			t.Fatal("Metadata[sigil.conversation.title] should be deleted")
 		}
 	})
 
@@ -186,29 +193,31 @@ func TestGenerationContentCapture(t *testing.T) {
 	now := func() time.Time { return time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC) }
 
 	cases := []struct {
-		name         string
-		clientMode   ContentCaptureMode
-		genMode      ContentCaptureMode
-		wantStripped bool
-		wantMarker   string
+		name            string
+		clientMode      ContentCaptureMode
+		genMode         ContentCaptureMode
+		wantStripped    bool
+		wantMarker      string
+		wantTitleOnSpan bool
 	}{
-		{"client default, gen default — no_tool_content", ContentCaptureModeDefault, ContentCaptureModeDefault, false, contentCaptureModeValueNoToolContent},
-		{"client MetadataOnly, gen default — stripped", ContentCaptureModeMetadataOnly, ContentCaptureModeDefault, true, contentCaptureModeValueMetaOnly},
-		{"client Full, gen MetadataOnly — stripped", ContentCaptureModeFull, ContentCaptureModeMetadataOnly, true, contentCaptureModeValueMetaOnly},
-		{"client MetadataOnly, gen Full — full", ContentCaptureModeMetadataOnly, ContentCaptureModeFull, false, contentCaptureModeValueFull},
-		{"client Full, gen default — full", ContentCaptureModeFull, ContentCaptureModeDefault, false, contentCaptureModeValueFull},
+		{"client default, gen default — no_tool_content", ContentCaptureModeDefault, ContentCaptureModeDefault, false, contentCaptureModeValueNoToolContent, true},
+		{"client MetadataOnly, gen default — stripped", ContentCaptureModeMetadataOnly, ContentCaptureModeDefault, true, contentCaptureModeValueMetaOnly, false},
+		{"client Full, gen MetadataOnly — stripped", ContentCaptureModeFull, ContentCaptureModeMetadataOnly, true, contentCaptureModeValueMetaOnly, false},
+		{"client MetadataOnly, gen Full — full", ContentCaptureModeMetadataOnly, ContentCaptureModeFull, false, contentCaptureModeValueFull, true},
+		{"client Full, gen default — full", ContentCaptureModeFull, ContentCaptureModeDefault, false, contentCaptureModeValueFull, true},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			client, _, _ := newTestClient(t, Config{
+			client, spanRecorder, tp := newTestClient(t, Config{
 				ContentCapture: tc.clientMode,
 				Now:            now,
 			})
 
 			_, rec := client.StartGeneration(context.Background(), GenerationStart{
-				Model:          ModelRef{Provider: "anthropic", Name: "claude-sonnet-4-5"},
-				ContentCapture: tc.genMode,
+				Model:             ModelRef{Provider: "anthropic", Name: "claude-sonnet-4-5"},
+				ContentCapture:    tc.genMode,
+				ConversationTitle: "Sensitive topic",
 			})
 			rec.SetResult(Generation{
 				SystemPrompt: "You are helpful.",
@@ -240,6 +249,22 @@ func TestGenerationContentCapture(t *testing.T) {
 			if gen.Usage.InputTokens != 10 {
 				t.Fatal("Usage lost")
 			}
+
+			// Verify conversation title on span
+			_ = tp.ForceFlush(context.Background())
+			for _, s := range spanRecorder.Ended() {
+				if !strings.HasPrefix(s.Name(), "generate") {
+					continue
+				}
+				attrs := spanAttributeMap(s)
+				titleVal, hasTitle := attrs[spanAttrConversationTitle]
+				if tc.wantTitleOnSpan && (!hasTitle || titleVal.AsString() != "Sensitive topic") {
+					t.Fatalf("expected conversation title on span, got present=%v value=%q", hasTitle, titleVal.AsString())
+				}
+				if !tc.wantTitleOnSpan && hasTitle {
+					t.Fatalf("expected conversation title absent from span, got %q", titleVal.AsString())
+				}
+			}
 		})
 	}
 }
@@ -253,6 +278,7 @@ func TestToolExecutionContentCaptureInheritance(t *testing.T) {
 		toolOverride       ContentCaptureMode
 		toolIncludeContent bool
 		wantContent        bool
+		wantTitleOnSpan    bool
 	}{
 		{
 			name:               "parent MetadataOnly, tool inherits — suppressed",
@@ -260,6 +286,7 @@ func TestToolExecutionContentCaptureInheritance(t *testing.T) {
 			useParentCtx:       true,
 			toolIncludeContent: true,
 			wantContent:        false,
+			wantTitleOnSpan:    false,
 		},
 		{
 			name:               "parent MetadataOnly, tool explicit Full — included",
@@ -268,6 +295,7 @@ func TestToolExecutionContentCaptureInheritance(t *testing.T) {
 			toolOverride:       ContentCaptureModeFull,
 			toolIncludeContent: true,
 			wantContent:        true,
+			wantTitleOnSpan:    true,
 		},
 		{
 			name:               "parent Full (override client MetadataOnly), tool inherits — included",
@@ -276,6 +304,7 @@ func TestToolExecutionContentCaptureInheritance(t *testing.T) {
 			useParentCtx:       true,
 			toolIncludeContent: true,
 			wantContent:        true,
+			wantTitleOnSpan:    true,
 		},
 		{
 			name:               "no parent gen, client MetadataOnly — suppressed (fail-closed)",
@@ -283,6 +312,7 @@ func TestToolExecutionContentCaptureInheritance(t *testing.T) {
 			useParentCtx:       false,
 			toolIncludeContent: true,
 			wantContent:        false,
+			wantTitleOnSpan:    false,
 		},
 		{
 			name:               "no parent gen, client Full, legacy true — included",
@@ -290,6 +320,7 @@ func TestToolExecutionContentCaptureInheritance(t *testing.T) {
 			useParentCtx:       false,
 			toolIncludeContent: true,
 			wantContent:        true,
+			wantTitleOnSpan:    true,
 		},
 		{
 			name:               "no parent gen, client Full, legacy false — included",
@@ -297,6 +328,7 @@ func TestToolExecutionContentCaptureInheritance(t *testing.T) {
 			useParentCtx:       false,
 			toolIncludeContent: false,
 			wantContent:        true,
+			wantTitleOnSpan:    true,
 		},
 		{
 			name:               "parent Full, tool explicit MetadataOnly — suppressed",
@@ -305,6 +337,7 @@ func TestToolExecutionContentCaptureInheritance(t *testing.T) {
 			toolOverride:       ContentCaptureModeMetadataOnly,
 			toolIncludeContent: true,
 			wantContent:        false,
+			wantTitleOnSpan:    false,
 		},
 		// Backward compat: client Default (→ NoToolContent), legacy controls.
 		{
@@ -313,6 +346,7 @@ func TestToolExecutionContentCaptureInheritance(t *testing.T) {
 			useParentCtx:       false,
 			toolIncludeContent: false,
 			wantContent:        false,
+			wantTitleOnSpan:    true,
 		},
 		{
 			name:               "no parent gen, client Default, legacy true — included",
@@ -320,6 +354,7 @@ func TestToolExecutionContentCaptureInheritance(t *testing.T) {
 			useParentCtx:       false,
 			toolIncludeContent: true,
 			wantContent:        true,
+			wantTitleOnSpan:    true,
 		},
 	}
 
@@ -335,15 +370,17 @@ func TestToolExecutionContentCaptureInheritance(t *testing.T) {
 
 			if tc.useParentCtx {
 				ctx, genRec = client.StartGeneration(ctx, GenerationStart{
-					Model:          ModelRef{Provider: "anthropic", Name: "claude-sonnet-4-5"},
-					ContentCapture: tc.parentGenOverride,
+					Model:             ModelRef{Provider: "anthropic", Name: "claude-sonnet-4-5"},
+					ContentCapture:    tc.parentGenOverride,
+					ConversationTitle: "Sensitive topic",
 				})
 			}
 
 			_, toolRec := client.StartToolExecution(ctx, ToolExecutionStart{
-				ToolName:       "test_tool",
-				ContentCapture: tc.toolOverride,
-				IncludeContent: tc.toolIncludeContent,
+				ToolName:          "test_tool",
+				ContentCapture:    tc.toolOverride,
+				IncludeContent:    tc.toolIncludeContent,
+				ConversationTitle: "Sensitive topic",
 			})
 			toolRec.SetResult(ToolExecutionEnd{
 				Arguments: "args",
@@ -379,41 +416,40 @@ func TestToolExecutionContentCaptureInheritance(t *testing.T) {
 			if _, ok := attrs[spanAttrToolName]; !ok {
 				t.Fatal("tool name should always be present")
 			}
+
+			titleVal, hasTitle := attrs[spanAttrConversationTitle]
+			if tc.wantTitleOnSpan && (!hasTitle || titleVal.AsString() != "Sensitive topic") {
+				t.Fatalf("expected conversation title on tool span, got present=%v value=%q", hasTitle, titleVal.AsString())
+			}
+			if !tc.wantTitleOnSpan && hasTitle {
+				t.Fatalf("expected conversation title absent from tool span, got %q", titleVal.AsString())
+			}
 		})
 	}
 }
 
-func TestShouldIncludeToolContent(t *testing.T) {
+func TestResolveToolContentCaptureMode(t *testing.T) {
 	cases := []struct {
 		name          string
 		toolMode      ContentCaptureMode
 		ctxMode       ContentCaptureMode
 		ctxSet        bool
 		clientDefault ContentCaptureMode
-		legacy        bool
-		want          bool
+		want          ContentCaptureMode
 	}{
-		// Explicit Full client — legacy is irrelevant.
-		{"client Full, no ctx, legacy false", ContentCaptureModeDefault, ContentCaptureModeFull, false, ContentCaptureModeFull, false, true},
-		{"client Full, no ctx, legacy true", ContentCaptureModeDefault, ContentCaptureModeFull, false, ContentCaptureModeFull, true, true},
-		// Default client (resolves to NoToolContent) — legacy controls tool content.
-		{"client Default, no ctx, legacy false — suppressed", ContentCaptureModeDefault, ContentCaptureModeDefault, false, ContentCaptureModeDefault, false, false},
-		{"client Default, no ctx, legacy true — included", ContentCaptureModeDefault, ContentCaptureModeDefault, false, ContentCaptureModeDefault, true, true},
-		// Context and client overrides.
-		{"ctx MetadataOnly, legacy true", ContentCaptureModeDefault, ContentCaptureModeMetadataOnly, true, ContentCaptureModeFull, true, false},
-		{"ctx Full, client MetadataOnly — ctx wins", ContentCaptureModeDefault, ContentCaptureModeFull, true, ContentCaptureModeMetadataOnly, true, true},
-		{"ctx NoToolContent, legacy false — suppressed", ContentCaptureModeDefault, ContentCaptureModeNoToolContent, true, ContentCaptureModeFull, false, false},
-		{"ctx NoToolContent, legacy true — included", ContentCaptureModeDefault, ContentCaptureModeNoToolContent, true, ContentCaptureModeFull, true, true},
-		{"no ctx, client MetadataOnly — client wins", ContentCaptureModeDefault, ContentCaptureModeFull, false, ContentCaptureModeMetadataOnly, true, false},
-		// Per-tool overrides.
-		{"explicit Full overrides ctx MetadataOnly", ContentCaptureModeFull, ContentCaptureModeMetadataOnly, true, ContentCaptureModeFull, true, true},
-		{"explicit Full overrides ctx MetadataOnly, legacy false", ContentCaptureModeFull, ContentCaptureModeMetadataOnly, true, ContentCaptureModeFull, false, true},
-		{"explicit MetadataOnly overrides everything", ContentCaptureModeMetadataOnly, ContentCaptureModeFull, true, ContentCaptureModeFull, true, false},
+		{"client Full, no ctx", ContentCaptureModeDefault, ContentCaptureModeFull, false, ContentCaptureModeFull, ContentCaptureModeFull},
+		{"client Default, no ctx — resolves to NoToolContent", ContentCaptureModeDefault, ContentCaptureModeDefault, false, ContentCaptureModeDefault, ContentCaptureModeNoToolContent},
+		{"ctx MetadataOnly overrides client Full", ContentCaptureModeDefault, ContentCaptureModeMetadataOnly, true, ContentCaptureModeFull, ContentCaptureModeMetadataOnly},
+		{"ctx Full overrides client MetadataOnly", ContentCaptureModeDefault, ContentCaptureModeFull, true, ContentCaptureModeMetadataOnly, ContentCaptureModeFull},
+		{"ctx NoToolContent overrides client Full", ContentCaptureModeDefault, ContentCaptureModeNoToolContent, true, ContentCaptureModeFull, ContentCaptureModeNoToolContent},
+		{"no ctx, client MetadataOnly", ContentCaptureModeDefault, ContentCaptureModeFull, false, ContentCaptureModeMetadataOnly, ContentCaptureModeMetadataOnly},
+		{"explicit Full overrides ctx MetadataOnly", ContentCaptureModeFull, ContentCaptureModeMetadataOnly, true, ContentCaptureModeFull, ContentCaptureModeFull},
+		{"explicit MetadataOnly overrides everything", ContentCaptureModeMetadataOnly, ContentCaptureModeFull, true, ContentCaptureModeFull, ContentCaptureModeMetadataOnly},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := shouldIncludeToolContent(tc.toolMode, tc.ctxMode, tc.ctxSet, tc.clientDefault, tc.legacy)
+			got := resolveToolContentCaptureMode(tc.toolMode, tc.ctxMode, tc.ctxSet, tc.clientDefault)
 			if got != tc.want {
 				t.Fatalf("expected %v, got %v", tc.want, got)
 			}

--- a/python/sigil_sdk/client.py
+++ b/python/sigil_sdk/client.py
@@ -174,24 +174,18 @@ def _call_content_capture_resolver(
         return ContentCaptureMode.METADATA_ONLY
 
 
-def _should_include_tool_content(
+def _resolve_tool_content_capture_mode(
     tool_mode: ContentCaptureMode,
     ctx_mode: ContentCaptureMode | None,
     client_default: ContentCaptureMode,
-    legacy_include: bool,
-) -> bool:
-    """Determines whether tool content should be included in span attributes."""
+) -> ContentCaptureMode:
+    """Resolves the effective content capture mode for a tool execution."""
     resolved = _resolve_client_content_capture_mode(client_default)
     if ctx_mode is not None and ctx_mode != ContentCaptureMode.DEFAULT:
         resolved = ctx_mode
     if tool_mode != ContentCaptureMode.DEFAULT:
         resolved = tool_mode
-    if resolved == ContentCaptureMode.METADATA_ONLY:
-        return False
-    if resolved == ContentCaptureMode.FULL:
-        return True
-    # NO_TOOL_CONTENT / DEFAULT: honor legacy include_content opt-in.
-    return legacy_include
+    return resolved
 
 
 def _stamp_content_capture_metadata(generation: Generation, mode: ContentCaptureMode) -> None:
@@ -211,6 +205,9 @@ def _strip_content(generation: Generation, error_category: str) -> None:
     if generation.call_error != "":
         generation.call_error = error_category if error_category else "sdk_error"
     generation.metadata.pop("call_error", None)
+
+    generation.conversation_title = ""
+    generation.metadata.pop(_span_attr_conversation_title, None)
 
     for message in generation.input:
         _strip_message_content(message)
@@ -359,20 +356,28 @@ class Client:
         started_at = _to_utc(seed.started_at) if seed.started_at is not None else _to_utc(self._now())
         seed.started_at = started_at
 
+        # Resolve content capture before the span starts so MetadataOnly never
+        # attaches sensitive content to live span attributes.
+        resolver_mode = _call_content_capture_resolver(self._config.content_capture_resolver, {}, self._config.logger)
+        effective_client_default = _resolve_content_capture_mode(resolver_mode, self._config.content_capture)
+        ctx_mode = content_capture_mode_from_context()
+        tool_mode = _resolve_tool_content_capture_mode(seed.content_capture, ctx_mode, effective_client_default)
+
+        if tool_mode == ContentCaptureMode.METADATA_ONLY:
+            seed.conversation_title = ""
+            include_content = False
+        elif tool_mode == ContentCaptureMode.FULL:
+            include_content = True
+        else:
+            # NO_TOOL_CONTENT / DEFAULT: honor legacy include_content opt-in.
+            include_content = seed.include_content
+
         span = self._tracer.start_span(
             _tool_span_name(seed.tool_name),
             kind=SpanKind.INTERNAL,
             start_time=_datetime_to_ns(started_at),
         )
         _set_tool_span_attributes(span, seed)
-
-        # Resolve content capture: per-tool > context (parent generation) > resolver > client default.
-        resolver_mode = _call_content_capture_resolver(self._config.content_capture_resolver, {}, self._config.logger)
-        effective_client_default = _resolve_content_capture_mode(resolver_mode, self._config.content_capture)
-        ctx_mode = content_capture_mode_from_context()
-        include_content = _should_include_tool_content(
-            seed.content_capture, ctx_mode, effective_client_default, seed.include_content
-        )
 
         return ToolExecutionRecorder(
             client=self,
@@ -533,6 +538,20 @@ class Client:
         started_at = _to_utc(seed.started_at) if seed.started_at is not None else _to_utc(self._now())
         seed.started_at = started_at
 
+        # Resolve content capture mode before the span starts so MetadataOnly
+        # never attaches sensitive content to live span attributes.
+        resolver_mode = _call_content_capture_resolver(
+            self._config.content_capture_resolver, seed.metadata, self._config.logger
+        )
+        client_mode = _resolve_client_content_capture_mode(
+            _resolve_content_capture_mode(resolver_mode, self._config.content_capture)
+        )
+        ctx_mode = content_capture_mode_from_context()
+        if ctx_mode is not None:
+            client_mode = _resolve_content_capture_mode(ctx_mode, client_mode)
+        cc_mode = _resolve_content_capture_mode(seed.content_capture, client_mode)
+        span_title = "" if cc_mode == ContentCaptureMode.METADATA_ONLY else seed.conversation_title
+
         span = self._tracer.start_span(
             _generation_span_name(seed.operation_name, seed.model.name),
             kind=SpanKind.CLIENT,
@@ -543,7 +562,7 @@ class Client:
             Generation(
                 id=seed.id,
                 conversation_id=seed.conversation_id,
-                conversation_title=seed.conversation_title,
+                conversation_title=span_title,
                 user_id=seed.user_id,
                 agent_name=seed.agent_name,
                 agent_version=seed.agent_version,
@@ -557,18 +576,6 @@ class Client:
                 thinking_enabled=seed.thinking_enabled,
             ),
         )
-
-        # Resolve content capture mode: per-recording > context > resolver > client default.
-        resolver_mode = _call_content_capture_resolver(
-            self._config.content_capture_resolver, seed.metadata, self._config.logger
-        )
-        client_mode = _resolve_client_content_capture_mode(
-            _resolve_content_capture_mode(resolver_mode, self._config.content_capture)
-        )
-        ctx_mode = content_capture_mode_from_context()
-        if ctx_mode is not None:
-            client_mode = _resolve_content_capture_mode(ctx_mode, client_mode)
-        cc_mode = _resolve_content_capture_mode(seed.content_capture, client_mode)
 
         recorder = GenerationRecorder(
             client=self,

--- a/python/tests/test_content_capture.py
+++ b/python/tests/test_content_capture.py
@@ -106,9 +106,14 @@ def _full_generation() -> Generation:
         ],
         usage=TokenUsage(input_tokens=120, output_tokens=42),
         stop_reason="end_turn",
+        conversation_title="Weather chat",
         call_error="rate limit exceeded",
         artifacts=[],
-        metadata={"sigil.sdk.name": "sdk-python", "call_error": "rate limit exceeded"},
+        metadata={
+            "sigil.sdk.name": "sdk-python",
+            "call_error": "rate limit exceeded",
+            "sigil.conversation.title": "Weather chat",
+        },
     )
 
 
@@ -193,6 +198,8 @@ class TestContentStripping:
             assert gen.input[1].parts[0].tool_result.content_json == b""
             assert gen.tools[0].description == ""
             assert gen.tools[0].input_schema_json == b""
+            assert gen.conversation_title == ""
+            assert "sigil.conversation.title" not in gen.metadata
 
             # Preserved
             assert len(gen.input) == 2
@@ -252,6 +259,35 @@ class TestContentStripping:
             assert gen.call_error == "sdk_error"
         finally:
             client.shutdown()
+
+    def test_metadata_only_strips_conversation_title_from_span(self):
+        span_exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+        tracer = provider.get_tracer("sigil-test")
+        exporter = CapturingGenerationExporter()
+        client = _new_client(exporter, tracer=tracer, content_capture=ContentCaptureMode.METADATA_ONLY)
+        try:
+            rec = client.start_generation(
+                GenerationStart(
+                    model=ModelRef(provider="anthropic", name="claude-sonnet-4-5"),
+                    conversation_title="Sensitive topic",
+                )
+            )
+            rec.set_result(
+                Generation(
+                    input=[Message(role=MessageRole.USER, parts=[Part(kind=PartKind.TEXT, text="Hello")])],
+                    output=[Message(role=MessageRole.ASSISTANT, parts=[Part(kind=PartKind.TEXT, text="Hi")])],
+                    usage=TokenUsage(input_tokens=10, output_tokens=5),
+                )
+            )
+            rec.end()
+
+            gen_span = next(s for s in span_exporter.get_finished_spans() if s.name.startswith("generate"))
+            assert "sigil.conversation.title" not in gen_span.attributes
+        finally:
+            client.shutdown()
+            provider.shutdown()
 
     def test_full_mode_preserves_all_content(self):
         exporter = CapturingGenerationExporter()
@@ -506,11 +542,14 @@ class TestToolContentCapture:
     def test_client_metadata_only_suppresses_content(self):
         client, span_exporter, provider = self._make_tool_client(ContentCaptureMode.METADATA_ONLY)
         try:
-            with client.start_tool_execution(ToolExecutionStart(tool_name="test_tool", include_content=True)) as rec:
+            with client.start_tool_execution(
+                ToolExecutionStart(tool_name="test_tool", include_content=True, conversation_title="Sensitive topic")
+            ) as rec:
                 rec.set_result(arguments="args", result="result")
 
             span = self._get_tool_span(span_exporter)
             assert span.attributes.get("gen_ai.tool.call.arguments") is None
+            assert "sigil.conversation.title" not in span.attributes
         finally:
             client.shutdown()
             provider.shutdown()


### PR DESCRIPTION
Conversation titles can contain user-provided text (topic summaries, question fragments) so they should be treated as content, not structural metadata. Clear the field and remove the metadata key before span attributes are set in both Go and Python SDKs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts content-capture resolution and span initialization to avoid attaching potentially sensitive `conversation_title` to OTel span attributes, which could subtly change tracing output for generation/tool spans.
> 
> **Overview**
> **Privacy hardening for MetadataOnly content capture.** Both Go and Python SDKs now resolve the effective content capture mode *before* starting spans and omit `conversation_title` from generation/tool span attributes when running in `MetadataOnly`.
> 
> `stripContent` / `_strip_content` additionally clears `ConversationTitle` and removes the `sigil.conversation.title` metadata key, and tool capture logic is refactored to return an effective mode (`resolveToolContentCaptureMode` / `_resolve_tool_content_capture_mode`) then derive legacy `include_content` behavior from it. Tests are updated/added to assert titles are stripped from payloads and absent from spans under `MetadataOnly`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cd1e350b36d29b0c38cc631c2bf671412754885. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->