### PR TITLE
feat(claude-code): populate parent_generation_ids for subagent calls

### DIFF
--- a/plugins/claude-code/cmd/sigil-cc/main.go
+++ b/plugins/claude-code/cmd/sigil-cc/main.go
@@ -159,16 +159,17 @@ func run() {
 
 	for _, gen := range gens {
 		genStart := sigil.GenerationStart{
-			ID:                gen.ID,
-			ConversationID:    gen.ConversationID,
-			ConversationTitle: gen.ConversationTitle,
-			AgentName:         gen.AgentName,
-			AgentVersion:      gen.AgentVersion,
-			Mode:              gen.Mode,
-			OperationName:     gen.OperationName,
-			Model:             gen.Model,
-			Tags:              gen.Tags,
-			Metadata:          gen.Metadata,
+			ID:                  gen.ID,
+			ConversationID:      gen.ConversationID,
+			ConversationTitle:   gen.ConversationTitle,
+			AgentName:           gen.AgentName,
+			AgentVersion:        gen.AgentVersion,
+			Mode:                gen.Mode,
+			OperationName:       gen.OperationName,
+			Model:               gen.Model,
+			ParentGenerationIDs: gen.ParentGenerationIDs,
+			Tags:                gen.Tags,
+			Metadata:            gen.Metadata,
 		}
 
 		genCtx, rec := client.StartGeneration(ctx, genStart)

--- a/plugins/claude-code/internal/mapper/mapper.go
+++ b/plugins/claude-code/internal/mapper/mapper.go
@@ -110,27 +110,109 @@ func mergeAssistantGroup(lines []transcript.Line) transcript.Line {
 	return final
 }
 
+// agentCall holds the metadata captured from an Agent tool_use block.
+type agentCall struct {
+	parentGenID string    // generation that spawned this call
+	parentGen   sigil.Generation // copy for inheriting fields
+}
+
 // Process walks transcript lines and produces Generation records.
 // It updates st.Title with the conversation title if discovered.
+//
+// Claude Code subagents do not produce their own transcript lines — the only
+// evidence of their execution is the Agent tool_use (spawn) and the matching
+// tool_result (output). Process synthesises a generation for each completed
+// Agent call so that the Sigil dependency graph can display the DAG.
 func Process(lines []transcript.Line, st *state.Session, opts Options, r *redact.Redactor) []sigil.Generation {
 	var (
 		gens []sigil.Generation
 		uctx userContext
+		// agentCalls indexes Agent tool_use call IDs to the generation that
+		// emitted them, so we can synthesise subagent generations when the
+		// matching tool_result arrives.
+		agentCalls = make(map[string]agentCall)
 	)
 
 	for _, line := range lines {
 		switch line.Type {
 		case "user":
 			processUserLine(line, &uctx, st, r, opts)
+			// Synthesise subagent generations from Agent tool results.
+			gens = append(gens, synthesiseSubagentGens(line, &uctx, agentCalls, opts)...)
 
 		case "assistant":
 			if gen, ok := processAssistantLine(line, &uctx, st, opts, r); ok {
+				// Index Agent tool calls from this generation's output.
+				for _, msg := range gen.Output {
+					for _, part := range msg.Parts {
+						if part.ToolCall != nil && part.ToolCall.Name == "Agent" {
+							agentCalls[part.ToolCall.ID] = agentCall{
+								parentGenID: gen.ID,
+								parentGen:   gen,
+							}
+						}
+					}
+				}
 				gens = append(gens, gen)
 			}
 		}
 	}
 
 	return gens
+}
+
+// synthesiseSubagentGens creates a generation for each Agent tool result in
+// the user line, using the Agent tool_use input for metadata (model,
+// description) and the tool_result content as output.
+func synthesiseSubagentGens(line transcript.Line, uctx *userContext, calls map[string]agentCall, opts Options) []sigil.Generation {
+	var gens []sigil.Generation
+	for _, msg := range uctx.toolResults {
+		for _, part := range msg.Parts {
+			if part.ToolResult == nil {
+				continue
+			}
+			ac, ok := calls[part.ToolResult.ToolCallID]
+			if !ok {
+				continue
+			}
+
+			completedAt, _ := time.Parse(time.RFC3339Nano, line.Timestamp)
+
+			gen := sigil.Generation{
+				ID:                  subagentGenID(opts.SessionID, part.ToolResult.ToolCallID),
+				ConversationID:      opts.SessionID,
+				ConversationTitle:   opts.SessionID,
+				ParentGenerationIDs: []string{ac.parentGenID},
+				AgentName:           agentName + "/subagent",
+				AgentVersion:        ac.parentGen.AgentVersion,
+				Mode:                sigil.GenerationModeSync,
+				OperationName:       "generateText",
+				Model:               ac.parentGen.Model,
+				StopReason:          "end_turn",
+				StartedAt:           ac.parentGen.CompletedAt,
+				CompletedAt:         completedAt,
+				Tags:                buildTags(line, true, opts.ExtraTags),
+			}
+
+			// Use the tool result content as the output.
+			outputText := part.ToolResult.Content
+			if outputText != "" {
+				gen.Output = []sigil.Message{{
+					Role:  sigil.RoleAssistant,
+					Parts: []sigil.Part{{Kind: sigil.PartKindText, Text: outputText}},
+				}}
+			}
+
+			gens = append(gens, gen)
+		}
+	}
+	return gens
+}
+
+// subagentGenID produces a deterministic generation ID for a synthesised
+// subagent generation, namespaced by session and the Agent tool call ID.
+func subagentGenID(sessionID, toolCallID string) string {
+	return uuid.NewSHA1(uuid.NameSpaceDNS, []byte(sessionID+":subagent:"+toolCallID)).String()
 }
 
 func processUserLine(line transcript.Line, uctx *userContext, st *state.Session, r *redact.Redactor, opts Options) {

--- a/plugins/claude-code/internal/mapper/mapper_test.go
+++ b/plugins/claude-code/internal/mapper/mapper_test.go
@@ -63,8 +63,15 @@ func makeUserLine(content string) transcript.Line {
 }
 
 func makeToolResultLine(toolUseID, content string) transcript.Line {
-	contentJSON, _ := json.Marshal(content)
-	blocks := []transcript.UserContentBlock{{Type: "tool_result", ToolUseID: toolUseID, RawContent: contentJSON}}
+	return makeMultiToolResultLine(map[string]string{toolUseID: content})
+}
+
+func makeMultiToolResultLine(results map[string]string) transcript.Line {
+	var blocks []transcript.UserContentBlock
+	for id, content := range results {
+		contentJSON, _ := json.Marshal(content)
+		blocks = append(blocks, transcript.UserContentBlock{Type: "tool_result", ToolUseID: id, RawContent: contentJSON})
+	}
 	blocksJSON, _ := json.Marshal(blocks)
 	msg := transcript.UserMessage{Role: "user", Content: blocksJSON}
 	raw, _ := json.Marshal(msg)
@@ -669,6 +676,100 @@ func TestTruncateJSON(t *testing.T) {
 				var v any
 				if err := json.Unmarshal(result, &v); err != nil {
 					t.Errorf("result is not valid JSON: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestProcess_ParentGenerationIDs(t *testing.T) {
+	tests := []struct {
+		name         string
+		lines        []transcript.Line
+		wantGenCount int
+		// wantParents maps gen index → parent gen indices. Absent or nil means no parents.
+		wantParents map[int][]int
+		// wantAgentNames optionally checks AgentName per gen index.
+		wantAgentNames map[int]string
+	}{
+		{
+			name: "agent call synthesises subagent generation",
+			lines: []transcript.Line{
+				makeUserLine("research this"),
+				makeAssistantLine("claude-sonnet-4-20250514", 30, []transcript.ContentBlock{
+					{Type: "tool_use", ID: "agent_1", Name: "Agent", Input: json.RawMessage(`{"description":"test"}`)},
+				}, "tool_use"),
+				makeToolResultLine("agent_1", "agent result here"),
+				makeAssistantLine("claude-sonnet-4-20250514", 40, []transcript.ContentBlock{
+					{Type: "text", Text: "Based on the agent result..."},
+				}, "end_turn"),
+			},
+			// gen[0] = parent, gen[1] = synthetic subagent, gen[2] = continuation
+			wantGenCount:   3,
+			wantParents:    map[int][]int{1: {0}},
+			wantAgentNames: map[int]string{1: "claude-code/subagent"},
+		},
+		{
+			name: "parallel agent calls produce multiple subagent generations",
+			lines: []transcript.Line{
+				makeUserLine("run two agents"),
+				makeAssistantLine("claude-sonnet-4-20250514", 30, []transcript.ContentBlock{
+					{Type: "tool_use", ID: "agent_a", Name: "Agent", Input: json.RawMessage(`{"description":"A"}`)},
+					{Type: "tool_use", ID: "agent_b", Name: "Agent", Input: json.RawMessage(`{"description":"B"}`)},
+				}, "tool_use"),
+				makeMultiToolResultLine(map[string]string{"agent_a": "result A", "agent_b": "result B"}),
+				makeAssistantLine("claude-sonnet-4-20250514", 50, []transcript.ContentBlock{
+					{Type: "text", Text: "Both agents done."},
+				}, "end_turn"),
+			},
+			// gen[0] = parent, gen[1..2] = synthetic subagents, gen[3] = continuation
+			wantGenCount: 4,
+			wantParents:  map[int][]int{1: {0}, 2: {0}},
+		},
+		{
+			name: "non-agent tool calls do not synthesise",
+			lines: []transcript.Line{
+				makeUserLine("read a file"),
+				makeAssistantLine("claude-sonnet-4-20250514", 30, []transcript.ContentBlock{
+					{Type: "tool_use", ID: "tu_read", Name: "Read", Input: json.RawMessage(`{"path":"f.go"}`)},
+				}, "tool_use"),
+				makeToolResultLine("tu_read", "file contents"),
+				makeAssistantLine("claude-sonnet-4-20250514", 40, []transcript.ContentBlock{
+					{Type: "text", Text: "The file says..."},
+				}, "end_turn"),
+			},
+			wantGenCount: 2,
+			wantParents:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := &state.Session{}
+			gens := Process(tt.lines, st, Options{SessionID: "sess-1"}, nil)
+
+			if len(gens) != tt.wantGenCount {
+				t.Fatalf("got %d generations, want %d", len(gens), tt.wantGenCount)
+			}
+			for i, gen := range gens {
+				wantIdxs, hasEntry := tt.wantParents[i]
+				if !hasEntry {
+					if gen.ParentGenerationIDs != nil {
+						t.Errorf("gen[%d]: unexpected parent_generation_ids = %v", i, gen.ParentGenerationIDs)
+					}
+					continue
+				}
+				if len(gen.ParentGenerationIDs) != len(wantIdxs) {
+					t.Fatalf("gen[%d]: got %d parents, want %d", i, len(gen.ParentGenerationIDs), len(wantIdxs))
+				}
+				for j, idx := range wantIdxs {
+					if gen.ParentGenerationIDs[j] != gens[idx].ID {
+						t.Errorf("gen[%d].ParentGenerationIDs[%d] = %q, want gen[%d].ID = %q",
+							i, j, gen.ParentGenerationIDs[j], idx, gens[idx].ID)
+					}
+				}
+				if wantName, ok := tt.wantAgentNames[i]; ok && gen.AgentName != wantName {
+					t.Errorf("gen[%d].AgentName = %q, want %q", i, gen.AgentName, wantName)
 				}
 			}
 		})


### PR DESCRIPTION
Link generations that process Agent tool results back to the generation that spawned the subagent, using `tool_call_id` matching. Only Agent tool calls are tracked, regular tools are not linked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds synthesized subagent generations and populates `ParentGenerationIDs`, which changes generation counts/structure and could affect downstream dependency-graph/export assumptions.
> 
> **Overview**
> Adds tracking of `Agent` tool calls in the transcript mapper and **synthesizes a new subagent `sigil.Generation`** when the corresponding `tool_result` arrives, setting `ParentGenerationIDs` to the spawning generation and using the tool result content as output.
> 
> Updates the exporter (`sigil-cc` `main.go`) to **send `ParentGenerationIDs`** in `GenerationStart`, and extends tests to cover single and parallel Agent calls plus multi-tool-result user lines (non-Agent tools remain unlinked).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88a1cea514713b811666d07bcbd6bad387b2c50d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->