### PR TITLE
docs: add parent_generation_ids to OpenCode instrumentation skill

### DIFF
--- a/plugins/opencode/skills/sigil/SKILL.md
+++ b/plugins/opencode/skills/sigil/SKILL.md
@@ -56,6 +56,7 @@ On generation and tool spans, capture or preserve these when available:
   - `gen_ai.conversation.id`
   - `gen_ai.agent.name`
   - `gen_ai.agent.version`
+  - `sigil.generation.parent_generation_ids`
   - `sigil.sdk.name`
 - model:
   - `gen_ai.provider.name`
@@ -76,6 +77,19 @@ On generation and tool spans, capture or preserve these when available:
   - `gen_ai.usage.reasoning_tokens`
   - `gen_ai.response.finish_reasons`
   - error classification fields (`error.type`, `error.category`)
+
+## Multi-agent dependency tracking
+
+When instrumenting multi-agent pipelines where one agent's output feeds into another:
+
+- Set `parent_generation_ids` on the GenerationStart/seed with the generation ID(s) of the upstream agent(s) whose output this generation consumes.
+- This is a list: a generation can depend on multiple parents (fan-in).
+- Sigil uses these links to build a dependency DAG and propagate quality signals: if an upstream generation fails evaluation, all downstream dependents are flagged.
+
+Example: an orchestrator spawns agents A, B, C where C depends on A and B:
+- A: parent_generation_ids = [] (no parents)
+- B: parent_generation_ids = [] (no parents)
+- C: parent_generation_ids = [A.generation_id, B.generation_id]
 
 ## SDK locations and how to instrument
 


### PR DESCRIPTION
## Summary

- Adds `sigil.generation.parent_generation_ids` to the telemetry fields list in the OpenCode instrumentation skill
- Adds a "Multi-agent dependency tracking" section explaining how to wire parent generation IDs for dependency DAGs

## Context

Mirrors the same changes made in grafana/sigil for the Cursor/Claude Code/Copilot prompts. The OpenCode SKILL.md is the equivalent prompt for agents running in OpenCode.

## Test plan

- [ ] Verify SKILL.md content is consistent with the main auto-instrumentation prompt in grafana/sigil
- [ ] No runtime changes — docs only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only update that adds a new telemetry field and guidance; no runtime or instrumentation code changes.
> 
> **Overview**
> Updates the OpenCode Sigil instrumentation skill doc to prioritize the `sigil.generation.parent_generation_ids` telemetry field.
> 
> Adds a **Multi-agent dependency tracking** section describing how to set parent generation IDs (including fan-in) so Sigil can build a dependency DAG and propagate evaluation/quality signals downstream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52bcd5fc554f0404c5e7541100f8f4585d5edab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->