### PR TITLE
feat(java): add ContentCaptureMode for SDK-level content stripping

### DIFF
--- a/java/core/src/main/java/com/grafana/sigil/sdk/ContentCaptureMode.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/ContentCaptureMode.java
@@ -1,0 +1,51 @@
+package com.grafana.sigil.sdk;
+
+/**
+ * Controls what content is included in exported generation payloads and OTel
+ * span attributes.
+ */
+public enum ContentCaptureMode {
+    /**
+     * Uses the parent or client-level default. On config this resolves to
+     * {@link #NO_TOOL_CONTENT} for backward compatibility. On GenerationStart
+     * this inherits from config. On ToolExecutionStart this inherits from the
+     * parent generation context, falling back to config.
+     */
+    DEFAULT,
+    /** Exports all content. */
+    FULL,
+    /**
+     * Exports full generation content but excludes tool execution content
+     * (arguments and results) from span attributes unless explicitly opted in
+     * via {@code includeContent} or a per-tool ContentCapture override. This
+     * matches the pre-ContentCaptureMode SDK default behavior.
+     */
+    NO_TOOL_CONTENT,
+    /**
+     * Preserves message structure, tool names, token usage, and timing but
+     * strips message text, thinking, tool arguments and results, system
+     * prompts, raw artifacts, conversation titles, tool descriptions, tool
+     * input schemas, and reduces error messages to their error category.
+     *
+     * <p>Note: user-provided Metadata and Tags are NOT stripped — callers are
+     * responsible for ensuring these maps do not contain sensitive content when
+     * using MetadataOnly mode.</p>
+     */
+    METADATA_ONLY;
+
+    /**
+     * Returns the string used in generation metadata markers.
+     *
+     * @throws IllegalStateException if called on {@link #DEFAULT}, which is a
+     * placeholder for "inherit" and must be resolved before being stamped.
+     */
+    public String toMetadataValue() {
+        return switch (this) {
+            case FULL -> "full";
+            case NO_TOOL_CONTENT -> "no_tool_content";
+            case METADATA_ONLY -> "metadata_only";
+            case DEFAULT -> throw new IllegalStateException(
+                    "ContentCaptureMode.DEFAULT must be resolved before calling toMetadataValue()");
+        };
+    }
+}

--- a/java/core/src/main/java/com/grafana/sigil/sdk/ContentCaptureResolver.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/ContentCaptureResolver.java
@@ -1,0 +1,24 @@
+package com.grafana.sigil.sdk;
+
+import java.util.Map;
+
+/**
+ * Callback for dynamic per-request {@link ContentCaptureMode} resolution.
+ *
+ * <p>Configured via {@link SigilClientConfig#setContentCaptureResolver(ContentCaptureResolver)}.
+ * The resolver is invoked for each generation, tool execution, and conversation rating
+ * with the request metadata; its result feeds the resolution chain alongside the
+ * client-level mode.</p>
+ *
+ * <p>If the resolver throws, the SDK fails closed to {@link ContentCaptureMode#METADATA_ONLY}
+ * and logs a warning via the configured logger.</p>
+ */
+@FunctionalInterface
+public interface ContentCaptureResolver {
+    /**
+     * @param metadata Request metadata. May be {@code null} (e.g. for tool executions
+     *                 where no metadata is attached). Implementations should treat the
+     *                 map as read-only.
+     */
+    ContentCaptureMode resolve(Map<String, Object> metadata);
+}

--- a/java/core/src/main/java/com/grafana/sigil/sdk/GenerationRecorder.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/GenerationRecorder.java
@@ -2,6 +2,7 @@ package com.grafana.sigil.sdk;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Scope;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -14,6 +15,8 @@ public class GenerationRecorder implements AutoCloseable {
     private final GenerationStart seed;
     private final Span span;
     private final Instant startedAt;
+    private final ContentCaptureMode contentCaptureMode;
+    private final Scope contentCaptureScope;
 
     private final Object lock = new Object();
     private boolean ended;
@@ -23,11 +26,14 @@ public class GenerationRecorder implements AutoCloseable {
     private Throwable finalError;
     private Generation lastGeneration;
 
-    GenerationRecorder(SigilClient client, GenerationStart seed, Span span, Instant startedAt) {
+    GenerationRecorder(SigilClient client, GenerationStart seed, Span span, Instant startedAt,
+                       ContentCaptureMode contentCaptureMode, Scope contentCaptureScope) {
         this.client = client;
         this.seed = seed;
         this.span = span;
         this.startedAt = startedAt;
+        this.contentCaptureMode = contentCaptureMode;
+        this.contentCaptureScope = contentCaptureScope;
     }
 
     /** Sets the mapped generation result payload. */
@@ -74,65 +80,79 @@ public class GenerationRecorder implements AutoCloseable {
         }
 
         Instant completedAt = snapshotResult.getCompletedAt() == null ? client.now() : snapshotResult.getCompletedAt();
-        Generation generation = normalize(snapshotResult, completedAt, snapshotCallError);
-
-        if (span.getSpanContext().isValid()) {
-            generation.setTraceId(span.getSpanContext().getTraceId());
-            generation.setSpanId(span.getSpanContext().getSpanId());
-        }
-
-        span.updateName(SigilClient.generationSpanName(generation.getOperationName(), generation.getModel().getName()));
-        SigilClient.setGenerationSpanAttributes(span, generation);
-
+        Generation generation;
         Throwable localError = null;
         try {
-            GenerationValidator.validate(generation);
-        } catch (Throwable throwable) {
-            localError = throwable;
-        }
+            generation = normalize(snapshotResult, completedAt, snapshotCallError);
 
-        if (localError == null) {
+            SigilClient.stampContentCaptureMetadata(generation, contentCaptureMode);
+            if (contentCaptureMode == ContentCaptureMode.METADATA_ONLY) {
+                String errorCategory = SigilClient.errorCategoryFromThrowable(snapshotCallError, false);
+                SigilClient.stripContent(generation, errorCategory);
+            }
+
+            if (span.getSpanContext().isValid()) {
+                generation.setTraceId(span.getSpanContext().getTraceId());
+                generation.setSpanId(span.getSpanContext().getSpanId());
+            }
+
+            span.updateName(SigilClient.generationSpanName(generation.getOperationName(), generation.getModel().getName()));
+            SigilClient.setGenerationSpanAttributes(span, generation);
+
             try {
-                client.enqueueGeneration(generation);
+                GenerationValidator.validate(generation);
             } catch (Throwable throwable) {
                 localError = throwable;
             }
-        }
 
-        if (snapshotCallError != null) {
-            span.recordException(snapshotCallError);
-        }
-        if (localError != null) {
-            span.recordException(localError);
-        }
+            if (localError == null) {
+                try {
+                    client.enqueueGeneration(generation);
+                } catch (Throwable throwable) {
+                    localError = throwable;
+                }
+            }
 
-        String errorType = "";
-        String errorCategory = "";
-        if (snapshotCallError != null) {
-            errorType = "provider_call_error";
-            errorCategory = SigilClient.errorCategoryFromThrowable(snapshotCallError, true);
-            span.setAttribute(SigilClient.SPAN_ATTR_ERROR_TYPE, "provider_call_error");
-            span.setAttribute(SigilClient.SPAN_ATTR_ERROR_CATEGORY, errorCategory);
-            span.setStatus(StatusCode.ERROR, String.valueOf(snapshotCallError.getMessage()));
-        } else if (localError instanceof ValidationException) {
-            errorType = "validation_error";
-            errorCategory = "sdk_error";
-            span.setAttribute(SigilClient.SPAN_ATTR_ERROR_TYPE, "validation_error");
-            span.setAttribute(SigilClient.SPAN_ATTR_ERROR_CATEGORY, errorCategory);
-            span.setStatus(StatusCode.ERROR, String.valueOf(localError.getMessage()));
-        } else if (localError != null) {
-            errorType = "enqueue_error";
-            errorCategory = "sdk_error";
-            span.setAttribute(SigilClient.SPAN_ATTR_ERROR_TYPE, "enqueue_error");
-            span.setAttribute(SigilClient.SPAN_ATTR_ERROR_CATEGORY, errorCategory);
-            span.setStatus(StatusCode.ERROR, String.valueOf(localError.getMessage()));
-        } else {
-            span.setStatus(StatusCode.OK);
-        }
+            boolean isMetadataOnly = contentCaptureMode == ContentCaptureMode.METADATA_ONLY;
+            if (snapshotCallError != null && !isMetadataOnly) {
+                span.recordException(snapshotCallError);
+            }
+            if (localError != null && !isMetadataOnly) {
+                span.recordException(localError);
+            }
 
-        client.recordGenerationMetrics(generation, errorType, errorCategory, snapshotFirstTokenAt);
-        span.end(completedAt.toEpochMilli(), TimeUnit.MILLISECONDS);
-        client.recordGeneration(generation);
+            String errorType = "";
+            String errorCategory = "";
+            if (snapshotCallError != null) {
+                errorType = "provider_call_error";
+                errorCategory = SigilClient.errorCategoryFromThrowable(snapshotCallError, true);
+                span.setAttribute(SigilClient.SPAN_ATTR_ERROR_TYPE, "provider_call_error");
+                span.setAttribute(SigilClient.SPAN_ATTR_ERROR_CATEGORY, errorCategory);
+                span.setStatus(StatusCode.ERROR, isMetadataOnly ? errorCategory : String.valueOf(snapshotCallError.getMessage()));
+            } else if (localError instanceof ValidationException) {
+                errorType = "validation_error";
+                errorCategory = "sdk_error";
+                span.setAttribute(SigilClient.SPAN_ATTR_ERROR_TYPE, "validation_error");
+                span.setAttribute(SigilClient.SPAN_ATTR_ERROR_CATEGORY, errorCategory);
+                span.setStatus(StatusCode.ERROR, isMetadataOnly ? errorCategory : String.valueOf(localError.getMessage()));
+            } else if (localError != null) {
+                errorType = "enqueue_error";
+                errorCategory = "sdk_error";
+                span.setAttribute(SigilClient.SPAN_ATTR_ERROR_TYPE, "enqueue_error");
+                span.setAttribute(SigilClient.SPAN_ATTR_ERROR_CATEGORY, errorCategory);
+                span.setStatus(StatusCode.ERROR, isMetadataOnly ? errorCategory : String.valueOf(localError.getMessage()));
+            } else {
+                span.setStatus(StatusCode.OK);
+            }
+
+            client.recordGenerationMetrics(generation, errorType, errorCategory, snapshotFirstTokenAt);
+            span.end(completedAt.toEpochMilli(), TimeUnit.MILLISECONDS);
+            client.recordGeneration(generation);
+        } finally {
+            if (contentCaptureScope != null) {
+                contentCaptureScope.close();
+            }
+        }
 
         synchronized (lock) {
             finalError = localError;

--- a/java/core/src/main/java/com/grafana/sigil/sdk/GenerationStart.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/GenerationStart.java
@@ -27,6 +27,7 @@ public final class GenerationStart {
     private final List<ToolDefinition> tools = new ArrayList<>();
     private final Map<String, String> tags = new LinkedHashMap<>();
     private final Map<String, Object> metadata = new LinkedHashMap<>();
+    private ContentCaptureMode contentCapture = ContentCaptureMode.DEFAULT;
     private Instant startedAt;
 
     public String getId() {
@@ -212,6 +213,15 @@ public final class GenerationStart {
         return this;
     }
 
+    public ContentCaptureMode getContentCapture() {
+        return contentCapture;
+    }
+
+    public GenerationStart setContentCapture(ContentCaptureMode contentCapture) {
+        this.contentCapture = contentCapture == null ? ContentCaptureMode.DEFAULT : contentCapture;
+        return this;
+    }
+
     public Instant getStartedAt() {
         return startedAt;
     }
@@ -239,6 +249,7 @@ public final class GenerationStart {
                 .setToolChoice(toolChoice)
                 .setThinkingEnabled(thinkingEnabled)
                 .setParentGenerationIds(parentGenerationIds)
+                .setContentCapture(contentCapture)
                 .setStartedAt(startedAt);
         for (ToolDefinition tool : tools) {
             out.getTools().add(tool == null ? new ToolDefinition() : tool.copy());

--- a/java/core/src/main/java/com/grafana/sigil/sdk/GenerationValidator.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/GenerationValidator.java
@@ -7,6 +7,8 @@ final class GenerationValidator {
     }
 
     static void validate(Generation generation) {
+        boolean contentStripped = SigilClient.isContentStripped(generation);
+
         if (generation.getMode() != GenerationMode.SYNC && generation.getMode() != GenerationMode.STREAM) {
             throw new ValidationException("generation.mode must be one of SYNC|STREAM");
         }
@@ -17,8 +19,8 @@ final class GenerationValidator {
             throw new ValidationException("generation.model.name is required");
         }
 
-        validateMessages("generation.input", generation.getInput());
-        validateMessages("generation.output", generation.getOutput());
+        validateMessages("generation.input", generation.getInput(), contentStripped);
+        validateMessages("generation.output", generation.getOutput(), contentStripped);
 
         for (int i = 0; i < generation.getTools().size(); i++) {
             ToolDefinition tool = generation.getTools().get(i);
@@ -41,7 +43,7 @@ final class GenerationValidator {
         }
     }
 
-    private static void validateMessages(String path, List<Message> messages) {
+    private static void validateMessages(String path, List<Message> messages, boolean contentStripped) {
         for (int i = 0; i < messages.size(); i++) {
             Message message = messages.get(i);
             if (message == null || message.getRole() == null) {
@@ -51,15 +53,18 @@ final class GenerationValidator {
                 throw new ValidationException(path + "[" + i + "].parts must not be empty");
             }
             for (int j = 0; j < message.getParts().size(); j++) {
-                validatePart(path, i, j, message.getRole(), message.getParts().get(j));
+                validatePart(path, i, j, message.getRole(), message.getParts().get(j), contentStripped);
             }
         }
     }
 
-    private static void validatePart(String path, int messageIndex, int partIndex, MessageRole role, MessagePart part) {
+    private static void validatePart(String path, int messageIndex, int partIndex, MessageRole role, MessagePart part, boolean contentStripped) {
         if (part == null || part.getKind() == null) {
             throw new ValidationException(path + "[" + messageIndex + "].parts[" + partIndex + "].kind is invalid");
         }
+
+        boolean strippedTextOrThinking = contentStripped
+                && (part.getKind() == MessagePartKind.TEXT || part.getKind() == MessagePartKind.THINKING);
 
         int payloadFieldCount = 0;
         if (!part.getText().isBlank()) {
@@ -74,13 +79,13 @@ final class GenerationValidator {
         if (part.getToolResult() != null) {
             payloadFieldCount++;
         }
-        if (payloadFieldCount != 1) {
+        if (payloadFieldCount != 1 && !strippedTextOrThinking) {
             throw new ValidationException(path + "[" + messageIndex + "].parts[" + partIndex + "] must set exactly one payload field");
         }
 
         switch (part.getKind()) {
             case TEXT -> {
-                if (part.getText().isBlank()) {
+                if (part.getText().isBlank() && !contentStripped) {
                     throw new ValidationException(path + "[" + messageIndex + "].parts[" + partIndex + "].text is required");
                 }
             }
@@ -88,7 +93,7 @@ final class GenerationValidator {
                 if (role != MessageRole.ASSISTANT) {
                     throw new ValidationException(path + "[" + messageIndex + "].parts[" + partIndex + "].thinking only allowed for assistant role");
                 }
-                if (part.getThinking().isBlank()) {
+                if (part.getThinking().isBlank() && !contentStripped) {
                     throw new ValidationException(path + "[" + messageIndex + "].parts[" + partIndex + "].thinking is required");
                 }
             }

--- a/java/core/src/main/java/com/grafana/sigil/sdk/SigilClient.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/SigilClient.java
@@ -102,6 +102,7 @@ public final class SigilClient implements AutoCloseable {
     static final String SDK_NAME = "sdk-java";
     static final String METADATA_USER_ID_KEY = "sigil.user.id";
     static final String METADATA_LEGACY_USER_ID_KEY = "user.id";
+    static final String METADATA_KEY_CONTENT_CAPTURE_MODE = "sigil.sdk.content_capture_mode";
 
     private final SigilClientConfig config;
     private final GenerationExporter generationExporter;
@@ -318,13 +319,28 @@ public final class SigilClient implements AutoCloseable {
         Instant startedAt = seed.getStartedAt() == null ? now() : seed.getStartedAt();
         seed.setStartedAt(startedAt);
 
+        ContentCaptureMode resolverMode = callContentCaptureResolver(config.getContentCaptureResolver(), null, config.getLogger());
+        ContentCaptureMode effectiveClientDefault = resolveContentCaptureMode(resolverMode, config.getContentCapture());
+        ContentCaptureMode ctxMode = SigilContext.contentCaptureModeFromContext();
+        ContentCaptureMode resolvedToolMode = resolveToolContentCaptureMode(
+                seed.getContentCapture(),
+                ctxMode,
+                effectiveClientDefault);
+
+        if (resolvedToolMode == ContentCaptureMode.METADATA_ONLY) {
+            seed.setConversationTitle("");
+            seed.setToolDescription("");
+        }
+        @SuppressWarnings("deprecation")
+        boolean legacyIncludeContent = seed.isIncludeContent();
+
         Span span = tracer.spanBuilder(toolSpanName(seed.getToolName()))
                 .setSpanKind(SpanKind.INTERNAL)
                 .setStartTimestamp(startedAt)
                 .startSpan();
         setToolSpanAttributes(span, seed);
 
-        return new ToolExecutionRecorder(this, seed, span, startedAt);
+        return new ToolExecutionRecorder(this, seed, span, startedAt, resolvedToolMode, legacyIncludeContent);
     }
 
     /**
@@ -362,6 +378,13 @@ public final class SigilClient implements AutoCloseable {
         }
 
         SubmitConversationRatingRequest normalizedRequest = normalizeConversationRatingRequest(request);
+
+        ContentCaptureMode resolverMode = callContentCaptureResolver(config.getContentCaptureResolver(), normalizedRequest.getMetadata(), config.getLogger());
+        ContentCaptureMode effectiveMode = resolveContentCaptureMode(resolverMode, resolveClientContentCaptureMode(config.getContentCapture()));
+        if (effectiveMode == ContentCaptureMode.METADATA_ONLY) {
+            normalizedRequest.setComment("");
+        }
+
         String endpoint = conversationRatingEndpoint(config.getApi(), config.getGenerationExport(), normalizedConversationId);
 
         Map<String, Object> payload = new LinkedHashMap<>();
@@ -558,6 +581,10 @@ public final class SigilClient implements AutoCloseable {
         Instant startedAt = seed.getStartedAt() == null ? now() : seed.getStartedAt();
         seed.setStartedAt(startedAt);
 
+        ContentCaptureMode resolverMode = callContentCaptureResolver(config.getContentCaptureResolver(), seed.getMetadata(), config.getLogger());
+        ContentCaptureMode clientMode = resolveClientContentCaptureMode(resolveContentCaptureMode(resolverMode, config.getContentCapture()));
+        ContentCaptureMode ccMode = resolveContentCaptureMode(seed.getContentCapture(), clientMode);
+
         Span span = tracer.spanBuilder(generationSpanName(seed.getOperationName(), seed.getModel().getName()))
                 .setSpanKind(SpanKind.CLIENT)
                 .setStartTimestamp(startedAt)
@@ -579,9 +606,13 @@ public final class SigilClient implements AutoCloseable {
         initial.setToolChoice(seed.getToolChoice());
         initial.setThinkingEnabled(seed.getThinkingEnabled());
         initial.getParentGenerationIds().addAll(seed.getParentGenerationIds());
+        if (ccMode == ContentCaptureMode.METADATA_ONLY) {
+            initial.setConversationTitle("");
+        }
         setGenerationSpanAttributes(span, initial);
 
-        return new GenerationRecorder(this, seed, span, startedAt);
+        Scope contentCaptureScope = SigilContext.withContentCaptureMode(ccMode);
+        return new GenerationRecorder(this, seed, span, startedAt, ccMode, contentCaptureScope);
     }
 
     private void flushInternal() {
@@ -1409,5 +1440,104 @@ public final class SigilClient implements AutoCloseable {
             return text.substring(0, maxLength);
         }
         return text.substring(0, maxLength - 3) + "...";
+    }
+
+    // --- Content capture mode resolution ---
+
+    static ContentCaptureMode resolveContentCaptureMode(ContentCaptureMode override, ContentCaptureMode fallback) {
+        if (override != ContentCaptureMode.DEFAULT) {
+            return override;
+        }
+        return fallback;
+    }
+
+    static ContentCaptureMode resolveClientContentCaptureMode(ContentCaptureMode mode) {
+        if (mode == ContentCaptureMode.DEFAULT) {
+            return ContentCaptureMode.NO_TOOL_CONTENT;
+        }
+        return mode;
+    }
+
+    static ContentCaptureMode callContentCaptureResolver(
+            ContentCaptureResolver resolver,
+            Map<String, Object> metadata,
+            Logger logger) {
+        if (resolver == null) {
+            return ContentCaptureMode.DEFAULT;
+        }
+        try {
+            ContentCaptureMode result = resolver.resolve(metadata);
+            return result == null ? ContentCaptureMode.DEFAULT : result;
+        } catch (Exception exception) {
+            if (logger != null) {
+                logger.log(Level.WARNING, "sigil content capture resolver threw; falling back to METADATA_ONLY", exception);
+            }
+            return ContentCaptureMode.METADATA_ONLY;
+        }
+    }
+
+    static ContentCaptureMode resolveToolContentCaptureMode(
+            ContentCaptureMode toolMode,
+            ContentCaptureMode ctxMode,
+            ContentCaptureMode clientDefault) {
+        ContentCaptureMode resolved = resolveClientContentCaptureMode(clientDefault);
+        if (ctxMode != null) {
+            resolved = ctxMode;
+        }
+        if (toolMode != ContentCaptureMode.DEFAULT) {
+            resolved = toolMode;
+        }
+        return resolved;
+    }
+
+    static void stampContentCaptureMetadata(Generation generation, ContentCaptureMode mode) {
+        generation.getMetadata().put(METADATA_KEY_CONTENT_CAPTURE_MODE, mode.toMetadataValue());
+    }
+
+    static boolean isContentStripped(Generation generation) {
+        Object value = generation.getMetadata().get(METADATA_KEY_CONTENT_CAPTURE_MODE);
+        return "metadata_only".equals(value);
+    }
+
+    static void stripContent(Generation generation, String errorCategory) {
+        generation.setSystemPrompt("");
+        generation.getArtifacts().clear();
+
+        if (!generation.getCallError().isBlank()) {
+            if (errorCategory != null && !errorCategory.isBlank()) {
+                generation.setCallError(errorCategory);
+            } else {
+                generation.setCallError("sdk_error");
+            }
+        }
+        generation.getMetadata().remove("call_error");
+
+        generation.setConversationTitle("");
+        generation.getMetadata().remove(SPAN_ATTR_CONVERSATION_TITLE);
+
+        for (Message message : generation.getInput()) {
+            stripMessageContent(message);
+        }
+        for (Message message : generation.getOutput()) {
+            stripMessageContent(message);
+        }
+        for (ToolDefinition tool : generation.getTools()) {
+            tool.setDescription("");
+            tool.setInputSchemaJson(null);
+        }
+    }
+
+    private static void stripMessageContent(Message message) {
+        for (MessagePart part : message.getParts()) {
+            part.setText("");
+            part.setThinking("");
+            if (part.getToolCall() != null) {
+                part.getToolCall().setInputJson(null);
+            }
+            if (part.getToolResult() != null) {
+                part.getToolResult().setContent("");
+                part.getToolResult().setContentJson(null);
+            }
+        }
     }
 }

--- a/java/core/src/main/java/com/grafana/sigil/sdk/SigilClientConfig.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/SigilClientConfig.java
@@ -10,6 +10,8 @@ public final class SigilClientConfig {
     private GenerationExportConfig generationExport = new GenerationExportConfig();
     private ApiConfig api = new ApiConfig();
     private EmbeddingCaptureConfig embeddingCapture = new EmbeddingCaptureConfig();
+    private ContentCaptureMode contentCapture = ContentCaptureMode.DEFAULT;
+    private ContentCaptureResolver contentCaptureResolver;
     private GenerationExporter generationExporter;
     private Tracer tracer;
     private Meter meter;
@@ -40,6 +42,45 @@ public final class SigilClientConfig {
 
     public SigilClientConfig setEmbeddingCapture(EmbeddingCaptureConfig embeddingCapture) {
         this.embeddingCapture = embeddingCapture == null ? new EmbeddingCaptureConfig() : embeddingCapture;
+        return this;
+    }
+
+    public ContentCaptureMode getContentCapture() {
+        return contentCapture;
+    }
+
+    /**
+     * Sets the client-level {@link ContentCaptureMode}.
+     *
+     * <p>Resolution order for each recording: per-recording override on the
+     * {@code Start} object &gt; {@link ContentCaptureResolver} result &gt; OTel
+     * context inherited from the parent generation (tool executions only) &gt;
+     * this client-level mode. {@link ContentCaptureMode#DEFAULT} resolves to
+     * {@link ContentCaptureMode#NO_TOOL_CONTENT} for backward compatibility.</p>
+     *
+     * <p>{@code null} is treated as {@link ContentCaptureMode#DEFAULT}.</p>
+     */
+    public SigilClientConfig setContentCapture(ContentCaptureMode contentCapture) {
+        this.contentCapture = contentCapture == null ? ContentCaptureMode.DEFAULT : contentCapture;
+        return this;
+    }
+
+    public ContentCaptureResolver getContentCaptureResolver() {
+        return contentCaptureResolver;
+    }
+
+    /**
+     * Sets a callback invoked for each generation, tool execution, and conversation
+     * rating to dynamically choose a {@link ContentCaptureMode} based on request
+     * metadata (e.g. tenant id, feature flag).
+     *
+     * <p>The resolver fails closed: any thrown exception is logged at WARNING and
+     * the request is recorded as {@link ContentCaptureMode#METADATA_ONLY}.</p>
+     *
+     * <p>Pass {@code null} to clear the resolver.</p>
+     */
+    public SigilClientConfig setContentCaptureResolver(ContentCaptureResolver contentCaptureResolver) {
+        this.contentCaptureResolver = contentCaptureResolver;
         return this;
     }
 
@@ -93,6 +134,8 @@ public final class SigilClientConfig {
                 .setGenerationExport(generationExport.copy())
                 .setApi(api.copy())
                 .setEmbeddingCapture(embeddingCapture.copy())
+                .setContentCapture(contentCapture)
+                .setContentCaptureResolver(contentCaptureResolver)
                 .setGenerationExporter(generationExporter)
                 .setTracer(tracer)
                 .setMeter(meter)

--- a/java/core/src/main/java/com/grafana/sigil/sdk/SigilContext.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/SigilContext.java
@@ -11,6 +11,7 @@ public final class SigilContext {
     private static final ContextKey<String> USER_ID = ContextKey.named("sigil.user.id");
     private static final ContextKey<String> AGENT_NAME = ContextKey.named("sigil.agent.name");
     private static final ContextKey<String> AGENT_VERSION = ContextKey.named("sigil.agent.version");
+    private static final ContextKey<ContentCaptureMode> CONTENT_CAPTURE_MODE = ContextKey.named("sigil.content_capture_mode");
 
     private SigilContext() {
     }
@@ -83,6 +84,14 @@ public final class SigilContext {
     static String agentVersionFromContext() {
         String value = Context.current().get(AGENT_VERSION);
         return value == null ? "" : value;
+    }
+
+    static Scope withContentCaptureMode(ContentCaptureMode mode) {
+        return Context.current().with(CONTENT_CAPTURE_MODE, mode).makeCurrent();
+    }
+
+    static ContentCaptureMode contentCaptureModeFromContext() {
+        return Context.current().get(CONTENT_CAPTURE_MODE);
     }
 
     private static String emptyToBlank(String value) {

--- a/java/core/src/main/java/com/grafana/sigil/sdk/ToolExecutionRecorder.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/ToolExecutionRecorder.java
@@ -12,6 +12,9 @@ public class ToolExecutionRecorder implements AutoCloseable {
     private final ToolExecutionStart seed;
     private final Span span;
     private final Instant startedAt;
+    private final ContentCaptureMode contentCaptureMode;
+    private final boolean includeContent;
+    private final boolean metadataOnly;
 
     private final Object lock = new Object();
     private boolean ended;
@@ -19,11 +22,19 @@ public class ToolExecutionRecorder implements AutoCloseable {
     private ToolExecutionResult result;
     private Throwable finalError;
 
-    ToolExecutionRecorder(SigilClient client, ToolExecutionStart seed, Span span, Instant startedAt) {
+    ToolExecutionRecorder(SigilClient client, ToolExecutionStart seed, Span span, Instant startedAt,
+                          ContentCaptureMode contentCaptureMode, boolean legacyIncludeContent) {
         this.client = client;
         this.seed = seed;
         this.span = span;
         this.startedAt = startedAt;
+        this.contentCaptureMode = contentCaptureMode;
+        this.metadataOnly = contentCaptureMode == ContentCaptureMode.METADATA_ONLY;
+        this.includeContent = switch (contentCaptureMode) {
+            case METADATA_ONLY -> false;
+            case FULL -> true;
+            default -> legacyIncludeContent;
+        };
     }
 
     protected ToolExecutionRecorder() {
@@ -31,6 +42,9 @@ public class ToolExecutionRecorder implements AutoCloseable {
         this.seed = null;
         this.span = null;
         this.startedAt = null;
+        this.contentCaptureMode = ContentCaptureMode.NO_TOOL_CONTENT;
+        this.includeContent = false;
+        this.metadataOnly = false;
     }
 
     /** Sets tool execution arguments/result payload. */
@@ -74,14 +88,14 @@ public class ToolExecutionRecorder implements AutoCloseable {
                 .setConversationId(seed.getConversationId())
                 .setAgentName(seed.getAgentName())
                 .setAgentVersion(seed.getAgentVersion())
-                .setIncludeContent(seed.isIncludeContent())
+                .setIncludeContent(includeContent)
                 .setStartedAt(startedAt)
                 .setCompletedAt(completedAt)
                 .setArguments(snapshotResult.getArguments())
                 .setResult(snapshotResult.getResult())
                 .setCallError(snapshotCallError == null ? "" : String.valueOf(snapshotCallError.getMessage()));
 
-        if (seed.isIncludeContent()) {
+        if (includeContent) {
             try {
                 if (snapshotResult.getArguments() != null) {
                     span.setAttribute(SigilClient.SPAN_ATTR_TOOL_CALL_ARGUMENTS, Json.MAPPER.writeValueAsString(snapshotResult.getArguments()));
@@ -95,10 +109,13 @@ public class ToolExecutionRecorder implements AutoCloseable {
         }
 
         if (snapshotCallError != null) {
-            span.recordException(snapshotCallError);
+            String errorCategory = SigilClient.errorCategoryFromThrowable(snapshotCallError, true);
+            if (!metadataOnly) {
+                span.recordException(snapshotCallError);
+            }
             span.setAttribute(SigilClient.SPAN_ATTR_ERROR_TYPE, "tool_execution_error");
-            span.setAttribute(SigilClient.SPAN_ATTR_ERROR_CATEGORY, SigilClient.errorCategoryFromThrowable(snapshotCallError, true));
-            span.setStatus(StatusCode.ERROR, String.valueOf(snapshotCallError.getMessage()));
+            span.setAttribute(SigilClient.SPAN_ATTR_ERROR_CATEGORY, errorCategory);
+            span.setStatus(StatusCode.ERROR, metadataOnly ? errorCategory : String.valueOf(snapshotCallError.getMessage()));
         } else {
             span.setStatus(StatusCode.OK);
         }

--- a/java/core/src/main/java/com/grafana/sigil/sdk/ToolExecutionStart.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/ToolExecutionStart.java
@@ -14,6 +14,7 @@ public final class ToolExecutionStart {
     private String agentVersion = "";
     private String requestModel = "";
     private String requestProvider = "";
+    private ContentCaptureMode contentCapture = ContentCaptureMode.DEFAULT;
     private boolean includeContent;
     private Instant startedAt;
 
@@ -111,10 +112,23 @@ public final class ToolExecutionStart {
         return this;
     }
 
+    public ContentCaptureMode getContentCapture() {
+        return contentCapture;
+    }
+
+    public ToolExecutionStart setContentCapture(ContentCaptureMode contentCapture) {
+        this.contentCapture = contentCapture == null ? ContentCaptureMode.DEFAULT : contentCapture;
+        return this;
+    }
+
+    /** @deprecated Use {@link #setContentCapture(ContentCaptureMode)} instead. */
+    @Deprecated
     public boolean isIncludeContent() {
         return includeContent;
     }
 
+    /** @deprecated Use {@link #setContentCapture(ContentCaptureMode)} instead. */
+    @Deprecated
     public ToolExecutionStart setIncludeContent(boolean includeContent) {
         this.includeContent = includeContent;
         return this;
@@ -141,6 +155,7 @@ public final class ToolExecutionStart {
                 .setAgentVersion(agentVersion)
                 .setRequestModel(requestModel)
                 .setRequestProvider(requestProvider)
+                .setContentCapture(contentCapture)
                 .setIncludeContent(includeContent)
                 .setStartedAt(startedAt);
     }

--- a/java/core/src/test/java/com/grafana/sigil/sdk/ContentCaptureModeTest.java
+++ b/java/core/src/test/java/com/grafana/sigil/sdk/ContentCaptureModeTest.java
@@ -1,0 +1,928 @@
+package com.grafana.sigil.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ContentCaptureModeTest {
+
+    // --- Enum tests ---
+
+    @Test
+    void toMetadataValue() {
+        assertThat(ContentCaptureMode.FULL.toMetadataValue()).isEqualTo("full");
+        assertThat(ContentCaptureMode.NO_TOOL_CONTENT.toMetadataValue()).isEqualTo("no_tool_content");
+        assertThat(ContentCaptureMode.METADATA_ONLY.toMetadataValue()).isEqualTo("metadata_only");
+    }
+
+    @Test
+    void toMetadataValue_defaultThrows() {
+        assertThatThrownBy(ContentCaptureMode.DEFAULT::toMetadataValue)
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    // --- Resolution tests ---
+
+    @Test
+    void resolveContentCaptureMode_overrideWins() {
+        assertThat(SigilClient.resolveContentCaptureMode(ContentCaptureMode.METADATA_ONLY, ContentCaptureMode.FULL))
+                .isEqualTo(ContentCaptureMode.METADATA_ONLY);
+    }
+
+    @Test
+    void resolveContentCaptureMode_defaultFallsThrough() {
+        assertThat(SigilClient.resolveContentCaptureMode(ContentCaptureMode.DEFAULT, ContentCaptureMode.FULL))
+                .isEqualTo(ContentCaptureMode.FULL);
+    }
+
+    @Test
+    void resolveClientContentCaptureMode_defaultBecomesNoToolContent() {
+        assertThat(SigilClient.resolveClientContentCaptureMode(ContentCaptureMode.DEFAULT))
+                .isEqualTo(ContentCaptureMode.NO_TOOL_CONTENT);
+    }
+
+    @Test
+    void resolveClientContentCaptureMode_nonDefaultPassesThrough() {
+        assertThat(SigilClient.resolveClientContentCaptureMode(ContentCaptureMode.FULL))
+                .isEqualTo(ContentCaptureMode.FULL);
+        assertThat(SigilClient.resolveClientContentCaptureMode(ContentCaptureMode.METADATA_ONLY))
+                .isEqualTo(ContentCaptureMode.METADATA_ONLY);
+    }
+
+    // --- Resolver tests ---
+
+    @Test
+    void callContentCaptureResolver_nullResolverReturnsDefault() {
+        assertThat(SigilClient.callContentCaptureResolver(null, null, null))
+                .isEqualTo(ContentCaptureMode.DEFAULT);
+    }
+
+    @Test
+    void callContentCaptureResolver_returnsResolverResult() {
+        ContentCaptureResolver resolver = meta -> ContentCaptureMode.METADATA_ONLY;
+        assertThat(SigilClient.callContentCaptureResolver(resolver, null, null))
+                .isEqualTo(ContentCaptureMode.METADATA_ONLY);
+    }
+
+    @Test
+    void callContentCaptureResolver_readsMetadata() {
+        ContentCaptureResolver resolver = meta -> {
+            if (meta != null && "opted-out".equals(meta.get("tenant_id"))) {
+                return ContentCaptureMode.METADATA_ONLY;
+            }
+            return ContentCaptureMode.FULL;
+        };
+        assertThat(SigilClient.callContentCaptureResolver(resolver, Map.of("tenant_id", "opted-out"), null))
+                .isEqualTo(ContentCaptureMode.METADATA_ONLY);
+        assertThat(SigilClient.callContentCaptureResolver(resolver, Map.of("tenant_id", "normal"), null))
+                .isEqualTo(ContentCaptureMode.FULL);
+    }
+
+    @Test
+    void callContentCaptureResolver_exceptionFailsClosed() {
+        ContentCaptureResolver resolver = meta -> {
+            throw new RuntimeException("resolver bug");
+        };
+        assertThat(SigilClient.callContentCaptureResolver(resolver, null, null))
+                .isEqualTo(ContentCaptureMode.METADATA_ONLY);
+    }
+
+    @Test
+    void callContentCaptureResolver_nullReturnBecomesDefault() {
+        ContentCaptureResolver resolver = meta -> null;
+        assertThat(SigilClient.callContentCaptureResolver(resolver, null, null))
+                .isEqualTo(ContentCaptureMode.DEFAULT);
+    }
+
+    // --- stripContent tests ---
+
+    @Test
+    void stripContent_stripsSensitiveFields() {
+        Generation gen = makeGeneration();
+        SigilClient.stripContent(gen, "rate_limit");
+
+        assertThat(gen.getSystemPrompt()).isEmpty();
+        assertThat(gen.getArtifacts()).isEmpty();
+        assertThat(gen.getCallError()).isEqualTo("rate_limit");
+        assertThat(gen.getMetadata()).doesNotContainKey("call_error");
+        assertThat(gen.getConversationTitle()).isEmpty();
+        assertThat(gen.getMetadata()).doesNotContainKey("sigil.conversation.title");
+
+        // Input text stripped
+        assertThat(gen.getInput().get(0).getParts().get(0).getText()).isEmpty();
+        // Tool result content stripped
+        assertThat(gen.getInput().get(1).getParts().get(0).getToolResult().getContent()).isEmpty();
+        assertThat(gen.getInput().get(1).getParts().get(0).getToolResult().getContentJson()).isEmpty();
+
+        // Output thinking stripped
+        assertThat(gen.getOutput().get(0).getParts().get(0).getThinking()).isEmpty();
+        // Tool call inputJson stripped
+        assertThat(gen.getOutput().get(0).getParts().get(1).getToolCall().getInputJson()).isEmpty();
+        // Output text stripped
+        assertThat(gen.getOutput().get(0).getParts().get(2).getText()).isEmpty();
+
+        // Tool definitions stripped
+        assertThat(gen.getTools().get(0).getDescription()).isEmpty();
+        assertThat(gen.getTools().get(0).getInputSchemaJson()).isEmpty();
+    }
+
+    @Test
+    void stripContent_preservesStructure() {
+        Generation gen = makeGeneration();
+        SigilClient.stripContent(gen, "rate_limit");
+
+        assertThat(gen.getInput()).hasSize(2);
+        assertThat(gen.getOutput()).hasSize(1);
+        assertThat(gen.getOutput().get(0).getParts()).hasSize(3);
+
+        assertThat(gen.getInput().get(0).getRole()).isEqualTo(MessageRole.USER);
+        assertThat(gen.getOutput().get(0).getParts().get(0).getKind()).isEqualTo(MessagePartKind.THINKING);
+        assertThat(gen.getOutput().get(0).getParts().get(1).getToolCall().getName()).isEqualTo("weather");
+        assertThat(gen.getOutput().get(0).getParts().get(1).getToolCall().getId()).isEqualTo("call_1");
+        assertThat(gen.getInput().get(1).getParts().get(0).getToolResult().getToolCallId()).isEqualTo("call_1");
+        assertThat(gen.getInput().get(1).getParts().get(0).getToolResult().getName()).isEqualTo("weather");
+    }
+
+    @Test
+    void stripContent_preservesOperationalMetadata() {
+        Generation gen = makeGeneration();
+        SigilClient.stripContent(gen, "rate_limit");
+
+        assertThat(gen.getTools().get(0).getName()).isEqualTo("weather");
+        assertThat(gen.getUsage().getInputTokens()).isEqualTo(120);
+        assertThat(gen.getUsage().getOutputTokens()).isEqualTo(42);
+        assertThat(gen.getStopReason()).isEqualTo("end_turn");
+        assertThat(gen.getModel().getName()).isEqualTo("claude-sonnet-4-5");
+        assertThat(gen.getMetadata().get("sigil.sdk.name")).isEqualTo("sdk-java");
+    }
+
+    @Test
+    void stripContent_noCategory_fallsBackToSdkError() {
+        Generation gen = makeGeneration();
+        SigilClient.stripContent(gen, "");
+
+        assertThat(gen.getCallError()).isEqualTo("sdk_error");
+    }
+
+    @Test
+    void stripContent_noCallError_remainsEmpty() {
+        Generation gen = makeGeneration();
+        gen.setCallError("");
+        gen.getMetadata().remove("call_error");
+        SigilClient.stripContent(gen, "rate_limit");
+
+        assertThat(gen.getCallError()).isEmpty();
+    }
+
+    // --- Integration: generation content capture mode stamping and stripping ---
+
+    @Test
+    void generation_defaultConfig_stampsNoToolContent() {
+        try (SigilClient client = newTestClient(ContentCaptureMode.DEFAULT, null)) {
+            GenerationRecorder recorder = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("anthropic").setName("claude-sonnet-4-5")));
+            recorder.setResult(minimalResult());
+            recorder.end();
+
+            Generation gen = recorder.lastGeneration().orElseThrow();
+            assertThat(gen.getMetadata().get(SigilClient.METADATA_KEY_CONTENT_CAPTURE_MODE))
+                    .isEqualTo("no_tool_content");
+            assertThat(gen.getInput().get(0).getParts().get(0).getText()).isEqualTo("Hello");
+        }
+    }
+
+    @Test
+    void generation_clientMetadataOnly_stripsContent() {
+        try (SigilClient client = newTestClient(ContentCaptureMode.METADATA_ONLY, null)) {
+            GenerationRecorder recorder = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("anthropic").setName("claude-sonnet-4-5")));
+            recorder.setResult(minimalResult());
+            recorder.end();
+
+            Generation gen = recorder.lastGeneration().orElseThrow();
+            assertThat(gen.getMetadata().get(SigilClient.METADATA_KEY_CONTENT_CAPTURE_MODE))
+                    .isEqualTo("metadata_only");
+            assertThat(gen.getInput().get(0).getParts().get(0).getText()).isEmpty();
+            assertThat(gen.getInput().get(0).getRole()).isEqualTo(MessageRole.USER);
+            assertThat(gen.getUsage().getInputTokens()).isEqualTo(10);
+        }
+    }
+
+    @Test
+    void generation_perGenOverride_overridesClient() {
+        try (SigilClient client = newTestClient(ContentCaptureMode.METADATA_ONLY, null)) {
+            GenerationRecorder recorder = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("anthropic").setName("claude-sonnet-4-5"))
+                    .setContentCapture(ContentCaptureMode.FULL));
+            recorder.setResult(minimalResult());
+            recorder.end();
+
+            Generation gen = recorder.lastGeneration().orElseThrow();
+            assertThat(gen.getMetadata().get(SigilClient.METADATA_KEY_CONTENT_CAPTURE_MODE))
+                    .isEqualTo("full");
+            assertThat(gen.getInput().get(0).getParts().get(0).getText()).isEqualTo("Hello");
+        }
+    }
+
+    @Test
+    void generation_clientFull_genMetadataOnly_stripsContent() {
+        try (SigilClient client = newTestClient(ContentCaptureMode.FULL, null)) {
+            GenerationRecorder recorder = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("anthropic").setName("claude-sonnet-4-5"))
+                    .setContentCapture(ContentCaptureMode.METADATA_ONLY));
+            recorder.setResult(minimalResult());
+            recorder.end();
+
+            Generation gen = recorder.lastGeneration().orElseThrow();
+            assertThat(gen.getMetadata().get(SigilClient.METADATA_KEY_CONTENT_CAPTURE_MODE))
+                    .isEqualTo("metadata_only");
+            assertThat(gen.getInput().get(0).getParts().get(0).getText()).isEmpty();
+        }
+    }
+
+    @Test
+    void generation_clientFull_genDefault_preservesContent() {
+        try (SigilClient client = newTestClient(ContentCaptureMode.FULL, null)) {
+            GenerationRecorder recorder = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("anthropic").setName("claude-sonnet-4-5")));
+            recorder.setResult(minimalResult());
+            recorder.end();
+
+            Generation gen = recorder.lastGeneration().orElseThrow();
+            assertThat(gen.getMetadata().get(SigilClient.METADATA_KEY_CONTENT_CAPTURE_MODE))
+                    .isEqualTo("full");
+            assertThat(gen.getInput().get(0).getParts().get(0).getText()).isEqualTo("Hello");
+        }
+    }
+
+    // --- Integration: resolver ---
+
+    @Test
+    void resolver_metadataOnlyOverridesClientFull() {
+        ContentCaptureResolver resolver = meta -> ContentCaptureMode.METADATA_ONLY;
+        try (SigilClient client = newTestClient(ContentCaptureMode.FULL, resolver)) {
+            GenerationRecorder recorder = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("test").setName("test-model")));
+            recorder.setResult(minimalResult());
+            recorder.end();
+
+            Generation gen = recorder.lastGeneration().orElseThrow();
+            assertThat(gen.getMetadata().get(SigilClient.METADATA_KEY_CONTENT_CAPTURE_MODE))
+                    .isEqualTo("metadata_only");
+            assertThat(gen.getInput().get(0).getParts().get(0).getText()).isEmpty();
+        }
+    }
+
+    @Test
+    void resolver_perGenFullOverridesResolverMetadataOnly() {
+        ContentCaptureResolver resolver = meta -> ContentCaptureMode.METADATA_ONLY;
+        try (SigilClient client = newTestClient(ContentCaptureMode.DEFAULT, resolver)) {
+            GenerationRecorder recorder = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("test").setName("test-model"))
+                    .setContentCapture(ContentCaptureMode.FULL));
+            recorder.setResult(minimalResult());
+            recorder.end();
+
+            Generation gen = recorder.lastGeneration().orElseThrow();
+            assertThat(gen.getMetadata().get(SigilClient.METADATA_KEY_CONTENT_CAPTURE_MODE))
+                    .isEqualTo("full");
+            assertThat(gen.getInput().get(0).getParts().get(0).getText()).isEqualTo("Hello");
+        }
+    }
+
+    @Test
+    void resolver_defaultDefersToClient() {
+        ContentCaptureResolver resolver = meta -> ContentCaptureMode.DEFAULT;
+        try (SigilClient client = newTestClient(ContentCaptureMode.METADATA_ONLY, resolver)) {
+            GenerationRecorder recorder = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("test").setName("test-model")));
+            recorder.setResult(minimalResult());
+            recorder.end();
+
+            Generation gen = recorder.lastGeneration().orElseThrow();
+            assertThat(gen.getMetadata().get(SigilClient.METADATA_KEY_CONTENT_CAPTURE_MODE))
+                    .isEqualTo("metadata_only");
+        }
+    }
+
+    @Test
+    void resolver_panicFailsClosedToMetadataOnly() {
+        ContentCaptureResolver resolver = meta -> {
+            throw new RuntimeException("oops");
+        };
+        try (SigilClient client = newTestClient(ContentCaptureMode.FULL, resolver)) {
+            GenerationRecorder recorder = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("test").setName("test-model")));
+            recorder.setResult(minimalResult());
+            recorder.end();
+
+            Generation gen = recorder.lastGeneration().orElseThrow();
+            assertThat(gen.getMetadata().get(SigilClient.METADATA_KEY_CONTENT_CAPTURE_MODE))
+                    .isEqualTo("metadata_only");
+            assertThat(gen.getInput().get(0).getParts().get(0).getText()).isEmpty();
+        }
+    }
+
+    // --- Integration: tool content capture inheritance ---
+
+    @Test
+    void tool_parentMetadataOnly_inherits_suppressed() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.METADATA_ONLY, null, spanExporter)) {
+            GenerationRecorder genRec = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("anthropic").setName("claude-sonnet-4-5")));
+
+            @SuppressWarnings("deprecation")
+            ToolExecutionRecorder toolRec = client.startToolExecution(new ToolExecutionStart()
+                    .setToolName("test_tool")
+                    .setIncludeContent(true));
+            toolRec.setResult(new ToolExecutionResult().setArguments("args").setResult("result"));
+            toolRec.end();
+
+            genRec.setResult(minimalResult());
+            genRec.end();
+        }
+
+        SpanData toolSpan = findToolSpan(spanExporter.getFinishedSpanItems());
+        assertThat(toolSpan).isNotNull();
+        assertThat(toolSpan.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_TOOL_CALL_ARGUMENTS))).isNull();
+        assertThat(toolSpan.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_TOOL_NAME))).isEqualTo("test_tool");
+    }
+
+    @Test
+    void tool_parentMetadataOnly_explicitFull_included() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.METADATA_ONLY, null, spanExporter)) {
+            GenerationRecorder genRec = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("anthropic").setName("claude-sonnet-4-5")));
+
+            ToolExecutionRecorder toolRec = client.startToolExecution(new ToolExecutionStart()
+                    .setToolName("test_tool")
+                    .setContentCapture(ContentCaptureMode.FULL));
+            toolRec.setResult(new ToolExecutionResult().setArguments("args").setResult("result"));
+            toolRec.end();
+
+            genRec.setResult(minimalResult());
+            genRec.end();
+        }
+
+        SpanData toolSpan = findToolSpan(spanExporter.getFinishedSpanItems());
+        assertThat(toolSpan.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_TOOL_CALL_ARGUMENTS)))
+                .isEqualTo("\"args\"");
+    }
+
+    @Test
+    void tool_parentFull_overridesClientMetadataOnly_included() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.METADATA_ONLY, null, spanExporter)) {
+            GenerationRecorder genRec = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("anthropic").setName("claude-sonnet-4-5"))
+                    .setContentCapture(ContentCaptureMode.FULL));
+
+            @SuppressWarnings("deprecation")
+            ToolExecutionRecorder toolRec = client.startToolExecution(new ToolExecutionStart()
+                    .setToolName("test_tool")
+                    .setIncludeContent(true));
+            toolRec.setResult(new ToolExecutionResult().setArguments("args").setResult("result"));
+            toolRec.end();
+
+            genRec.setResult(minimalResult());
+            genRec.end();
+        }
+
+        SpanData toolSpan = findToolSpan(spanExporter.getFinishedSpanItems());
+        assertThat(toolSpan.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_TOOL_CALL_ARGUMENTS)))
+                .isEqualTo("\"args\"");
+    }
+
+    @Test
+    void tool_noParentGen_clientMetadataOnly_suppressed() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.METADATA_ONLY, null, spanExporter)) {
+            @SuppressWarnings("deprecation")
+            ToolExecutionRecorder toolRec = client.startToolExecution(new ToolExecutionStart()
+                    .setToolName("test_tool")
+                    .setIncludeContent(true));
+            toolRec.setResult(new ToolExecutionResult().setArguments("args").setResult("result"));
+            toolRec.end();
+        }
+
+        SpanData toolSpan = findToolSpan(spanExporter.getFinishedSpanItems());
+        assertThat(toolSpan.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_TOOL_CALL_ARGUMENTS))).isNull();
+    }
+
+    @Test
+    void tool_noParentGen_clientFull_included() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.FULL, null, spanExporter)) {
+            ToolExecutionRecorder toolRec = client.startToolExecution(new ToolExecutionStart()
+                    .setToolName("test_tool"));
+            toolRec.setResult(new ToolExecutionResult().setArguments("args").setResult("result"));
+            toolRec.end();
+        }
+
+        SpanData toolSpan = findToolSpan(spanExporter.getFinishedSpanItems());
+        assertThat(toolSpan.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_TOOL_CALL_ARGUMENTS)))
+                .isEqualTo("\"args\"");
+    }
+
+    @Test
+    void tool_backwardCompat_clientDefault_legacyFalse_suppressed() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.DEFAULT, null, spanExporter)) {
+            @SuppressWarnings("deprecation")
+            ToolExecutionRecorder toolRec = client.startToolExecution(new ToolExecutionStart()
+                    .setToolName("test_tool")
+                    .setIncludeContent(false));
+            toolRec.setResult(new ToolExecutionResult().setArguments("args").setResult("result"));
+            toolRec.end();
+        }
+
+        SpanData toolSpan = findToolSpan(spanExporter.getFinishedSpanItems());
+        assertThat(toolSpan.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_TOOL_CALL_ARGUMENTS))).isNull();
+    }
+
+    @Test
+    void tool_backwardCompat_clientDefault_legacyTrue_included() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.DEFAULT, null, spanExporter)) {
+            @SuppressWarnings("deprecation")
+            ToolExecutionRecorder toolRec = client.startToolExecution(new ToolExecutionStart()
+                    .setToolName("test_tool")
+                    .setIncludeContent(true));
+            toolRec.setResult(new ToolExecutionResult().setArguments("args").setResult("result"));
+            toolRec.end();
+        }
+
+        SpanData toolSpan = findToolSpan(spanExporter.getFinishedSpanItems());
+        assertThat(toolSpan.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_TOOL_CALL_ARGUMENTS)))
+                .isEqualTo("\"args\"");
+    }
+
+    @Test
+    void tool_parentFull_explicitMetadataOnly_suppressed() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.FULL, null, spanExporter)) {
+            GenerationRecorder genRec = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("anthropic").setName("claude-sonnet-4-5")));
+
+            @SuppressWarnings("deprecation")
+            ToolExecutionRecorder toolRec = client.startToolExecution(new ToolExecutionStart()
+                    .setToolName("test_tool")
+                    .setContentCapture(ContentCaptureMode.METADATA_ONLY)
+                    .setIncludeContent(true));
+            toolRec.setResult(new ToolExecutionResult().setArguments("args").setResult("result"));
+            toolRec.end();
+
+            genRec.setResult(minimalResult());
+            genRec.end();
+        }
+
+        SpanData toolSpan = findToolSpan(spanExporter.getFinishedSpanItems());
+        assertThat(toolSpan.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_TOOL_CALL_ARGUMENTS))).isNull();
+    }
+
+    // --- Validation accepts stripped payloads ---
+
+    @Test
+    void validation_acceptsStrippedGeneration() {
+        try (SigilClient client = newTestClient(ContentCaptureMode.METADATA_ONLY, null)) {
+            GenerationRecorder recorder = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("anthropic").setName("claude-sonnet-4-5")));
+
+            GenerationResult result = new GenerationResult()
+                    .setUsage(new TokenUsage().setInputTokens(10).setOutputTokens(5));
+            result.getInput().add(new Message()
+                    .setRole(MessageRole.USER)
+                    .setParts(List.of(MessagePart.text("Hello"))));
+            result.getOutput().add(new Message()
+                    .setRole(MessageRole.ASSISTANT)
+                    .setParts(List.of(
+                            MessagePart.thinking("thinking..."),
+                            MessagePart.text("World"))));
+            recorder.setResult(result);
+            recorder.end();
+
+            assertThat(recorder.error()).isEmpty();
+            Generation gen = recorder.lastGeneration().orElseThrow();
+            assertThat(gen.getInput().get(0).getParts().get(0).getText()).isEmpty();
+            assertThat(gen.getOutput().get(0).getParts().get(0).getThinking()).isEmpty();
+            assertThat(gen.getOutput().get(0).getParts().get(1).getText()).isEmpty();
+        }
+    }
+
+    // --- Rating comment stripping ---
+
+    @Test
+    void rating_metadataOnly_stripsComment() throws Exception {
+        java.util.concurrent.atomic.AtomicReference<com.fasterxml.jackson.databind.JsonNode> payload =
+                new java.util.concurrent.atomic.AtomicReference<>();
+
+        com.sun.net.httpserver.HttpServer server = com.sun.net.httpserver.HttpServer.create(
+                new java.net.InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/v1/conversations/conv-1/ratings", exchange -> {
+            byte[] body = exchange.getRequestBody().readAllBytes();
+            payload.set(Json.MAPPER.readTree(body));
+
+            byte[] response = """
+                    {
+                      "rating":{"rating_id":"rat-1","conversation_id":"conv-1","rating":"CONVERSATION_RATING_VALUE_BAD","created_at":"2026-02-13T12:00:00Z"},
+                      "summary":{"total_count":1,"good_count":0,"bad_count":1,"latest_rating":"CONVERSATION_RATING_VALUE_BAD","latest_rated_at":"2026-02-13T12:00:00Z","has_bad_rating":true}
+                    }
+                    """.getBytes();
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, response.length);
+            try (java.io.OutputStream os = exchange.getResponseBody()) {
+                os.write(response);
+            }
+        });
+        server.start();
+
+        SigilClientConfig config = new SigilClientConfig()
+                .setGenerationExporter(new TestFixtures.CapturingExporter())
+                .setContentCapture(ContentCaptureMode.METADATA_ONLY)
+                .setApi(new ApiConfig().setEndpoint("http://127.0.0.1:" + server.getAddress().getPort()))
+                .setGenerationExport(new GenerationExportConfig()
+                        .setProtocol(GenerationExportProtocol.HTTP)
+                        .setEndpoint("http://127.0.0.1:" + server.getAddress().getPort() + "/api/v1/generations:export")
+                        .setBatchSize(1)
+                        .setFlushInterval(java.time.Duration.ofMinutes(10))
+                        .setMaxRetries(0));
+
+        try (SigilClient client = new SigilClient(config)) {
+            client.submitConversationRating("conv-1",
+                    new SubmitConversationRatingRequest()
+                            .setRatingId("rat-1")
+                            .setRating(ConversationRatingValue.BAD)
+                            .setComment("this answer was terrible"));
+        } finally {
+            server.stop(0);
+        }
+
+        assertThat(payload.get().has("comment")).isFalse();
+    }
+
+    @Test
+    void rating_full_preservesComment() throws Exception {
+        java.util.concurrent.atomic.AtomicReference<com.fasterxml.jackson.databind.JsonNode> payload =
+                new java.util.concurrent.atomic.AtomicReference<>();
+
+        com.sun.net.httpserver.HttpServer server = com.sun.net.httpserver.HttpServer.create(
+                new java.net.InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/v1/conversations/conv-1/ratings", exchange -> {
+            byte[] body = exchange.getRequestBody().readAllBytes();
+            payload.set(Json.MAPPER.readTree(body));
+
+            byte[] response = """
+                    {
+                      "rating":{"rating_id":"rat-1","conversation_id":"conv-1","rating":"CONVERSATION_RATING_VALUE_BAD","created_at":"2026-02-13T12:00:00Z"},
+                      "summary":{"total_count":1,"good_count":0,"bad_count":1,"latest_rating":"CONVERSATION_RATING_VALUE_BAD","latest_rated_at":"2026-02-13T12:00:00Z","has_bad_rating":true}
+                    }
+                    """.getBytes();
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, response.length);
+            try (java.io.OutputStream os = exchange.getResponseBody()) {
+                os.write(response);
+            }
+        });
+        server.start();
+
+        SigilClientConfig config = new SigilClientConfig()
+                .setGenerationExporter(new TestFixtures.CapturingExporter())
+                .setContentCapture(ContentCaptureMode.FULL)
+                .setApi(new ApiConfig().setEndpoint("http://127.0.0.1:" + server.getAddress().getPort()))
+                .setGenerationExport(new GenerationExportConfig()
+                        .setProtocol(GenerationExportProtocol.HTTP)
+                        .setEndpoint("http://127.0.0.1:" + server.getAddress().getPort() + "/api/v1/generations:export")
+                        .setBatchSize(1)
+                        .setFlushInterval(java.time.Duration.ofMinutes(10))
+                        .setMaxRetries(0));
+
+        try (SigilClient client = new SigilClient(config)) {
+            client.submitConversationRating("conv-1",
+                    new SubmitConversationRatingRequest()
+                            .setRatingId("rat-1")
+                            .setRating(ConversationRatingValue.BAD)
+                            .setComment("this answer was terrible"));
+        } finally {
+            server.stop(0);
+        }
+
+        assertThat(payload.get().path("comment").asText()).isEqualTo("this answer was terrible");
+    }
+
+    // --- Context propagation ---
+
+    @Test
+    void contextPropagation_setAndGet() {
+        try (Scope scope = SigilContext.withContentCaptureMode(ContentCaptureMode.METADATA_ONLY)) {
+            assertThat(SigilContext.contentCaptureModeFromContext())
+                    .isEqualTo(ContentCaptureMode.METADATA_ONLY);
+        }
+        assertThat(SigilContext.contentCaptureModeFromContext()).isNull();
+    }
+
+    // --- Conversation title stripping from spans ---
+
+    @Test
+    void generation_metadataOnly_stripsConversationTitleFromSpan() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.METADATA_ONLY, null, spanExporter)) {
+            GenerationRecorder recorder = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("anthropic").setName("claude-sonnet-4-5"))
+                    .setConversationTitle("My secret conversation"));
+            recorder.setResult(minimalResult());
+            recorder.end();
+        }
+
+        SpanData genSpan = findGenerationSpan(spanExporter.getFinishedSpanItems());
+        assertThat(genSpan).isNotNull();
+        assertThat(genSpan.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_CONVERSATION_TITLE))).isNull();
+    }
+
+    @Test
+    void generation_full_preservesConversationTitleOnSpan() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.FULL, null, spanExporter)) {
+            GenerationRecorder recorder = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("anthropic").setName("claude-sonnet-4-5"))
+                    .setConversationTitle("My conversation"));
+            recorder.setResult(minimalResult());
+            recorder.end();
+        }
+
+        SpanData genSpan = findGenerationSpan(spanExporter.getFinishedSpanItems());
+        assertThat(genSpan).isNotNull();
+        assertThat(genSpan.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_CONVERSATION_TITLE)))
+                .isEqualTo("My conversation");
+    }
+
+    @Test
+    void tool_metadataOnly_stripsConversationTitleFromSpan() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.METADATA_ONLY, null, spanExporter)) {
+            GenerationRecorder genRec = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("anthropic").setName("claude-sonnet-4-5")));
+
+            ToolExecutionRecorder toolRec = client.startToolExecution(new ToolExecutionStart()
+                    .setToolName("test_tool")
+                    .setConversationTitle("My secret conversation"));
+            toolRec.end();
+
+            genRec.setResult(minimalResult());
+            genRec.end();
+        }
+
+        SpanData toolSpan = findToolSpan(spanExporter.getFinishedSpanItems());
+        assertThat(toolSpan).isNotNull();
+        assertThat(toolSpan.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_CONVERSATION_TITLE))).isNull();
+    }
+
+    @Test
+    void tool_full_preservesConversationTitleOnSpan() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.FULL, null, spanExporter)) {
+            ToolExecutionRecorder toolRec = client.startToolExecution(new ToolExecutionStart()
+                    .setToolName("test_tool")
+                    .setConversationTitle("My conversation"));
+            toolRec.end();
+        }
+
+        SpanData toolSpan = findToolSpan(spanExporter.getFinishedSpanItems());
+        assertThat(toolSpan).isNotNull();
+        assertThat(toolSpan.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_CONVERSATION_TITLE)))
+                .isEqualTo("My conversation");
+    }
+
+    @Test
+    void tool_metadataOnly_stripsToolDescriptionFromSpan() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.METADATA_ONLY, null, spanExporter)) {
+            ToolExecutionRecorder toolRec = client.startToolExecution(new ToolExecutionStart()
+                    .setToolName("test_tool")
+                    .setToolDescription("Internal usage hint with example payloads"));
+            toolRec.end();
+        }
+
+        SpanData toolSpan = findToolSpan(spanExporter.getFinishedSpanItems());
+        assertThat(toolSpan).isNotNull();
+        assertThat(toolSpan.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_TOOL_DESCRIPTION))).isNull();
+    }
+
+    @Test
+    void tool_full_preservesToolDescriptionOnSpan() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.FULL, null, spanExporter)) {
+            ToolExecutionRecorder toolRec = client.startToolExecution(new ToolExecutionStart()
+                    .setToolName("test_tool")
+                    .setToolDescription("Public tool description"));
+            toolRec.end();
+        }
+
+        SpanData toolSpan = findToolSpan(spanExporter.getFinishedSpanItems());
+        assertThat(toolSpan).isNotNull();
+        assertThat(toolSpan.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_TOOL_DESCRIPTION)))
+                .isEqualTo("Public tool description");
+    }
+
+    // --- Span error sanitization ---
+
+    @Test
+    void generation_metadataOnly_sanitizesSpanErrors() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.METADATA_ONLY, null, spanExporter)) {
+            GenerationRecorder recorder = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("anthropic").setName("claude-sonnet-4-5")));
+            recorder.setCallError(new RuntimeException("sensitive prompt text leaked in error"));
+            recorder.setResult(minimalResult());
+            recorder.end();
+        }
+
+        SpanData genSpan = findGenerationSpan(spanExporter.getFinishedSpanItems());
+        assertThat(genSpan).isNotNull();
+        assertThat(genSpan.getStatus().getStatusCode()).isEqualTo(StatusCode.ERROR);
+        assertThat(genSpan.getStatus().getDescription()).doesNotContain("sensitive prompt text");
+        assertThat(genSpan.getEvents()).isEmpty();
+    }
+
+    @Test
+    void generation_full_preservesRawSpanErrors() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.FULL, null, spanExporter)) {
+            GenerationRecorder recorder = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("anthropic").setName("claude-sonnet-4-5")));
+            recorder.setCallError(new RuntimeException("detailed error message"));
+            recorder.setResult(minimalResult());
+            recorder.end();
+        }
+
+        SpanData genSpan = findGenerationSpan(spanExporter.getFinishedSpanItems());
+        assertThat(genSpan).isNotNull();
+        assertThat(genSpan.getStatus().getStatusCode()).isEqualTo(StatusCode.ERROR);
+        assertThat(genSpan.getStatus().getDescription()).contains("detailed error message");
+        assertThat(genSpan.getEvents()).isNotEmpty();
+    }
+
+    @Test
+    void tool_metadataOnly_sanitizesSpanErrors() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.METADATA_ONLY, null, spanExporter)) {
+            GenerationRecorder genRec = client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("anthropic").setName("claude-sonnet-4-5")));
+
+            ToolExecutionRecorder toolRec = client.startToolExecution(new ToolExecutionStart()
+                    .setToolName("test_tool"));
+            toolRec.setCallError(new RuntimeException("sensitive tool error with user data"));
+            toolRec.end();
+
+            genRec.setResult(minimalResult());
+            genRec.end();
+        }
+
+        SpanData toolSpan = findToolSpan(spanExporter.getFinishedSpanItems());
+        assertThat(toolSpan).isNotNull();
+        assertThat(toolSpan.getStatus().getStatusCode()).isEqualTo(StatusCode.ERROR);
+        assertThat(toolSpan.getStatus().getDescription()).doesNotContain("sensitive tool error");
+        assertThat(toolSpan.getEvents()).isEmpty();
+    }
+
+    @Test
+    void tool_full_preservesRawSpanErrors() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SigilClient client = newSpanTestClient(ContentCaptureMode.FULL, null, spanExporter)) {
+            ToolExecutionRecorder toolRec = client.startToolExecution(new ToolExecutionStart()
+                    .setToolName("test_tool"));
+            toolRec.setCallError(new RuntimeException("detailed tool error"));
+            toolRec.end();
+        }
+
+        SpanData toolSpan = findToolSpan(spanExporter.getFinishedSpanItems());
+        assertThat(toolSpan).isNotNull();
+        assertThat(toolSpan.getStatus().getStatusCode()).isEqualTo(StatusCode.ERROR);
+        assertThat(toolSpan.getStatus().getDescription()).contains("detailed tool error");
+        assertThat(toolSpan.getEvents()).isNotEmpty();
+    }
+
+    // --- Helpers ---
+
+    private static SigilClient newTestClient(ContentCaptureMode mode,
+                                             ContentCaptureResolver resolver) {
+        TestFixtures.CapturingExporter exporter = new TestFixtures.CapturingExporter();
+        SigilClientConfig config = new SigilClientConfig()
+                .setGenerationExporter(exporter)
+                .setContentCapture(mode)
+                .setContentCaptureResolver(resolver)
+                .setGenerationExport(new GenerationExportConfig()
+                        .setBatchSize(1)
+                        .setFlushInterval(Duration.ofMinutes(10))
+                        .setMaxRetries(0));
+        return new SigilClient(config);
+    }
+
+    private static SigilClient newSpanTestClient(ContentCaptureMode mode,
+                                                 ContentCaptureResolver resolver,
+                                                 InMemorySpanExporter spanExporter) {
+        SdkTracerProvider provider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+                .build();
+        TestFixtures.CapturingExporter exporter = new TestFixtures.CapturingExporter();
+        SigilClientConfig config = new SigilClientConfig()
+                .setTracer(provider.get("test"))
+                .setGenerationExporter(exporter)
+                .setContentCapture(mode)
+                .setContentCaptureResolver(resolver)
+                .setGenerationExport(new GenerationExportConfig()
+                        .setBatchSize(1)
+                        .setFlushInterval(Duration.ofMinutes(10))
+                        .setMaxRetries(0));
+        return new SigilClient(config);
+    }
+
+    private static GenerationResult minimalResult() {
+        GenerationResult result = new GenerationResult()
+                .setUsage(new TokenUsage().setInputTokens(10).setOutputTokens(5));
+        result.getInput().add(new Message()
+                .setRole(MessageRole.USER)
+                .setParts(List.of(MessagePart.text("Hello"))));
+        result.getOutput().add(new Message()
+                .setRole(MessageRole.ASSISTANT)
+                .setParts(List.of(MessagePart.text("Hi there"))));
+        return result;
+    }
+
+    private static Generation makeGeneration() {
+        Generation gen = new Generation()
+                .setMode(GenerationMode.SYNC)
+                .setModel(new ModelRef().setProvider("anthropic").setName("claude-sonnet-4-5"))
+                .setSystemPrompt("You are helpful.")
+                .setConversationTitle("My secret conversation");
+        gen.setUsage(new TokenUsage().setInputTokens(120).setOutputTokens(42));
+        gen.setStopReason("end_turn");
+        gen.setCallError("rate limit exceeded: prompt too long for model");
+        gen.getMetadata().put("sigil.sdk.name", "sdk-java");
+        gen.getMetadata().put("call_error", "rate limit exceeded: prompt too long for model");
+        gen.getMetadata().put("sigil.conversation.title", "My secret conversation");
+
+        gen.getInput().add(new Message()
+                .setRole(MessageRole.USER)
+                .setParts(List.of(MessagePart.text("What is the weather?"))));
+        gen.getInput().add(new Message()
+                .setRole(MessageRole.TOOL)
+                .setParts(List.of(MessagePart.toolResult(new ToolResultPart()
+                        .setToolCallId("call_1")
+                        .setName("weather")
+                        .setContent("sunny 18C")
+                        .setContentJson("{\"temp\":18}".getBytes())))));
+
+        gen.getOutput().add(new Message()
+                .setRole(MessageRole.ASSISTANT)
+                .setParts(List.of(
+                        MessagePart.thinking("let me think about weather"),
+                        MessagePart.toolCall(new ToolCall()
+                                .setId("call_1")
+                                .setName("weather")
+                                .setInputJson("{\"city\":\"Paris\"}".getBytes())),
+                        MessagePart.text("It's 18C and sunny in Paris."))));
+
+        gen.getTools().add(new ToolDefinition()
+                .setName("weather")
+                .setDescription("Get weather info")
+                .setType("function")
+                .setInputSchemaJson("{\"type\":\"object\"}".getBytes()));
+
+        gen.getArtifacts().add(new Artifact()
+                .setKind(ArtifactKind.REQUEST)
+                .setPayload("raw".getBytes()));
+
+        return gen;
+    }
+
+    private static SpanData findGenerationSpan(List<SpanData> spans) {
+        for (SpanData span : spans) {
+            if (!span.getName().startsWith("execute_tool")) {
+                return span;
+            }
+        }
+        return null;
+    }
+
+    private static SpanData findToolSpan(List<SpanData> spans) {
+        for (SpanData span : spans) {
+            if (span.getName().startsWith("execute_tool")) {
+                return span;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
- Add `ContentCaptureMode` (`FULL`, `NO_TOOL_CONTENT`, `METADATA_ONLY`) to control what content leaves the process via generation export and OTel spans
- Config-level defaults, per-recording overrides, resolver callbacks, OTel context propagation to child tool executions
- `METADATA_ONLY` strips all sensitive content from payloads and spans: text, thinking, tool I/O, artifacts, conversation titles, raw error messages
- Backward-compatible: `DEFAULT` resolves to `NO_TOOL_CONTENT`; legacy `includeContent` still works

#### Resolution precedence

1. Per-recording `contentCapture` on `GenerationStart` / `ToolExecutionStart`
2. `contentCaptureResolver` callback
3. OTel context from parent generation
4. `SigilClientConfig.contentCapture`

Resolver exceptions fail-closed to `METADATA_ONLY`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core generation/tool recording and OTel span/error handling, so mis-resolution could lead to unintended data capture or over-stripping; changes are well-covered by comprehensive tests.
> 
> **Overview**
> Introduces `ContentCaptureMode` (`FULL`, `NO_TOOL_CONTENT`, `METADATA_ONLY`, plus inheriting `DEFAULT`) and a `ContentCaptureResolver` hook to dynamically choose capture policy per request.
> 
> Plumbs content-capture resolution through `SigilClient` for generations, tool executions, and conversation ratings, including OTel context propagation from parent generations to child tool spans, backward-compatible defaulting to `NO_TOOL_CONTENT`, and deprecating `ToolExecutionStart.includeContent` in favor of per-tool `contentCapture`.
> 
> When `METADATA_ONLY` is effective, the SDK now **strips sensitive fields** from exported generation payloads (text/thinking/tool I/O/artifacts/prompts/titles/tool schemas) and **sanitizes spans** by suppressing exception events and using error categories instead of raw messages; validation is relaxed to accept stripped message parts. Extensive new tests cover resolution, stripping, inheritance, and span behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3b2f2c2396ae1132fc20d7673c09d0fd0a1040d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->