### PR TITLE
feat(dotnet): add ContentCaptureMode for SDK-level content stripping

### DIFF
--- a/dotnet/src/Grafana.Sigil/CompilerPolyfills.cs
+++ b/dotnet/src/Grafana.Sigil/CompilerPolyfills.cs
@@ -1,0 +1,7 @@
+#if NETSTANDARD2_0
+namespace System.Runtime.CompilerServices;
+
+internal static class IsExternalInit
+{
+}
+#endif

--- a/dotnet/src/Grafana.Sigil/Config.cs
+++ b/dotnet/src/Grafana.Sigil/Config.cs
@@ -52,6 +52,8 @@ public sealed class SigilClientConfig
     public GenerationExportConfig GenerationExport { get; set; } = new();
     public ApiConfig Api { get; set; } = new();
     public EmbeddingCaptureConfig EmbeddingCapture { get; set; } = new();
+    public ContentCaptureMode ContentCapture { get; set; } = ContentCaptureMode.Default;
+    public Func<IReadOnlyDictionary<string, object?>?, ContentCaptureMode>? ContentCaptureResolver { get; set; }
     public Action<string>? Logger { get; set; }
     public Func<DateTimeOffset>? UtcNow { get; set; }
     public Func<TimeSpan, CancellationToken, Task>? SleepAsync { get; set; }

--- a/dotnet/src/Grafana.Sigil/GenerationValidator.cs
+++ b/dotnet/src/Grafana.Sigil/GenerationValidator.cs
@@ -4,6 +4,8 @@ public static class GenerationValidator
 {
     public static void Validate(Generation generation)
     {
+        var contentStripped = SigilClient.IsContentStripped(generation);
+
         if (generation.Mode is not null && generation.Mode is not (GenerationMode.Sync or GenerationMode.Stream))
         {
             throw new ArgumentException("generation.mode must be one of SYNC|STREAM");
@@ -21,12 +23,12 @@ public static class GenerationValidator
 
         for (var i = 0; i < generation.Input.Count; i++)
         {
-            ValidateMessage("generation.input", i, generation.Input[i]);
+            ValidateMessage("generation.input", i, generation.Input[i], contentStripped);
         }
 
         for (var i = 0; i < generation.Output.Count; i++)
         {
-            ValidateMessage("generation.output", i, generation.Output[i]);
+            ValidateMessage("generation.output", i, generation.Output[i], contentStripped);
         }
 
         for (var i = 0; i < generation.Tools.Count; i++)
@@ -43,7 +45,7 @@ public static class GenerationValidator
         }
     }
 
-    private static void ValidateMessage(string path, int messageIndex, Message message)
+    private static void ValidateMessage(string path, int messageIndex, Message message, bool contentStripped)
     {
         if (message.Role is not (MessageRole.User or MessageRole.Assistant or MessageRole.Tool))
         {
@@ -57,11 +59,11 @@ public static class GenerationValidator
 
         for (var i = 0; i < message.Parts.Count; i++)
         {
-            ValidatePart(path, messageIndex, i, message.Role, message.Parts[i]);
+            ValidatePart(path, messageIndex, i, message.Role, message.Parts[i], contentStripped);
         }
     }
 
-    private static void ValidatePart(string path, int messageIndex, int partIndex, MessageRole role, Part part)
+    private static void ValidatePart(string path, int messageIndex, int partIndex, MessageRole role, Part part, bool contentStripped)
     {
         if (part.Kind is not (PartKind.Text or PartKind.Thinking or PartKind.ToolCall or PartKind.ToolResult))
         {
@@ -89,14 +91,16 @@ public static class GenerationValidator
             fieldCount++;
         }
 
-        if (fieldCount != 1)
+        // Stripped text/thinking parts have empty payloads — that's expected.
+        var strippedTextOrThinking = contentStripped && part.Kind is PartKind.Text or PartKind.Thinking;
+        if (fieldCount != 1 && !strippedTextOrThinking)
         {
             throw new ArgumentException($"{path}[{messageIndex}].parts[{partIndex}] must set exactly one payload field");
         }
 
         switch (part.Kind)
         {
-            case PartKind.Text when string.IsNullOrWhiteSpace(part.Text):
+            case PartKind.Text when !contentStripped && string.IsNullOrWhiteSpace(part.Text):
                 throw new ArgumentException($"{path}[{messageIndex}].parts[{partIndex}].text is required");
             case PartKind.Thinking:
                 if (role != MessageRole.Assistant)
@@ -106,7 +110,7 @@ public static class GenerationValidator
                     );
                 }
 
-                if (string.IsNullOrWhiteSpace(part.Thinking))
+                if (!contentStripped && string.IsNullOrWhiteSpace(part.Thinking))
                 {
                     throw new ArgumentException($"{path}[{messageIndex}].parts[{partIndex}].thinking is required");
                 }

--- a/dotnet/src/Grafana.Sigil/Grafana.Sigil.csproj
+++ b/dotnet/src/Grafana.Sigil/Grafana.Sigil.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Grafana.Sigil.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Grpc.Net.Client" />
     <PackageReference Include="Grpc.Tools" PrivateAssets="All" />

--- a/dotnet/src/Grafana.Sigil/Models.cs
+++ b/dotnet/src/Grafana.Sigil/Models.cs
@@ -37,6 +37,32 @@ public enum ConversationRatingValue
     Bad
 }
 
+public enum ContentCaptureMode
+{
+    Default = 0,
+    Full = 1,
+    NoToolContent = 2,
+    MetadataOnly = 3,
+}
+
+public static class ContentCaptureModeExtensions
+{
+    private const string ValueFull = "full";
+    private const string ValueNoToolContent = "no_tool_content";
+    private const string ValueMetadataOnly = "metadata_only";
+
+    public static string ToMetadataValue(this ContentCaptureMode mode)
+    {
+        return mode switch
+        {
+            ContentCaptureMode.Full => ValueFull,
+            ContentCaptureMode.NoToolContent => ValueNoToolContent,
+            ContentCaptureMode.MetadataOnly => ValueMetadataOnly,
+            _ => string.Empty,
+        };
+    }
+}
+
 public sealed class ModelRef
 {
     public string Provider { get; set; } = string.Empty;
@@ -221,6 +247,7 @@ public sealed class GenerationStart
     public Dictionary<string, string> Tags { get; set; } = new(StringComparer.Ordinal);
     public Dictionary<string, object?> Metadata { get; set; } = new(StringComparer.Ordinal);
     public DateTimeOffset? StartedAt { get; set; }
+    public ContentCaptureMode ContentCapture { get; set; } = ContentCaptureMode.Default;
 }
 
 public sealed class EmbeddingStart
@@ -293,7 +320,10 @@ public sealed class ToolExecutionStart
     public string RequestModel { get; set; } = string.Empty;
     /// <summary>The provider that served the model (e.g. "openai").</summary>
     public string RequestProvider { get; set; } = string.Empty;
+    /// <summary>Deprecated: Use ContentCapture instead.</summary>
+    [Obsolete("Use ContentCapture instead. ContentCapture takes precedence when set to Full or MetadataOnly; with NoToolContent (or when unset) IncludeContent still controls whether tool content is captured.")]
     public bool IncludeContent { get; set; }
+    public ContentCaptureMode ContentCapture { get; set; } = ContentCaptureMode.Default;
     public DateTimeOffset? StartedAt { get; set; }
 }
 

--- a/dotnet/src/Grafana.Sigil/SigilClient.cs
+++ b/dotnet/src/Grafana.Sigil/SigilClient.cs
@@ -83,6 +83,7 @@ public sealed partial class SigilClient : IAsyncDisposable
     internal const string SdkName = "sdk-dotnet";
     internal const string MetadataUserIdKey = "sigil.user.id";
     internal const string MetadataLegacyUserIdKey = "user.id";
+    internal const string MetadataKeyContentCaptureMode = "sigil.sdk.content_capture_mode";
 
     internal readonly SigilClientConfig _config;
     private readonly IGenerationExporter _generationExporter;
@@ -239,6 +240,32 @@ public sealed partial class SigilClient : IAsyncDisposable
             ? InternalUtils.Utc(seed.StartedAt.Value)
             : _config.UtcNow!();
 
+        // Resolve content capture before the span starts so MetadataOnly never
+        // attaches sensitive content to live span attributes.
+        var ctxMode = SigilContext.ContentCaptureModeFromContext();
+        var ctxSet = SigilContext.HasContentCaptureModeInContext();
+        var effectiveClientDefault = _config.ContentCapture;
+        if (seed.ContentCapture == ContentCaptureMode.Default && !ctxSet)
+        {
+            var resolverMode = CallContentCaptureResolver(_config.ContentCaptureResolver, null, _log);
+            effectiveClientDefault = ResolveContentCaptureMode(resolverMode, _config.ContentCapture);
+        }
+        var toolMode = ResolveToolContentCaptureMode(seed.ContentCapture, ctxMode, ctxSet, effectiveClientDefault);
+#pragma warning disable CS0618 // IncludeContent is obsolete
+        var includeContent = toolMode switch
+        {
+            ContentCaptureMode.MetadataOnly => false,
+            ContentCaptureMode.Full => true,
+            _ => seed.IncludeContent,
+        };
+#pragma warning restore CS0618
+
+        if (toolMode == ContentCaptureMode.MetadataOnly)
+        {
+            seed.ToolDescription = string.Empty;
+            seed.ConversationTitle = string.Empty;
+        }
+
         var activity = _activitySource.StartActivity(
             ToolSpanName(seed.ToolName),
             ActivityKind.Internal,
@@ -253,7 +280,7 @@ public sealed partial class SigilClient : IAsyncDisposable
             ApplyToolSpanAttributes(activity, seed);
         }
 
-        return new ToolExecutionRecorder(this, seed, seed.StartedAt!.Value, seed.IncludeContent, activity);
+        return new ToolExecutionRecorder(this, seed, seed.StartedAt!.Value, includeContent, toolMode == ContentCaptureMode.MetadataOnly, activity);
     }
 
     public async Task<SubmitConversationRatingResponse> SubmitConversationRatingAsync(
@@ -275,7 +302,18 @@ public sealed partial class SigilClient : IAsyncDisposable
             throw new ValidationException("sigil conversation rating validation failed: conversationId is too long");
         }
 
+        var resolverMode = CallContentCaptureResolver(_config.ContentCaptureResolver, request?.Metadata, _log);
+        var effectiveMode = ResolveContentCaptureMode(resolverMode, ResolveClientContentCaptureMode(_config.ContentCapture));
+
         var normalizedRequest = NormalizeConversationRatingRequest(request);
+
+        // Strip comment when MetadataOnly. Done after clone to avoid mutating
+        // the caller's request object (reference type, unlike Go's value type).
+        if (effectiveMode == ContentCaptureMode.MetadataOnly)
+        {
+            normalizedRequest.Comment = string.Empty;
+        }
+
         var endpoint = BuildConversationRatingEndpoint(
             _config.Api.Endpoint,
             _config.GenerationExport.Insecure,
@@ -418,6 +456,10 @@ public sealed partial class SigilClient : IAsyncDisposable
     {
         EnsureNotShutdown();
 
+        // Capture original metadata before DeepClone, which converts values to
+        // JsonElement via JSON round-trip. The resolver should see the caller's
+        // original types (string, bool, long, etc.).
+        var originalMetadata = start.Metadata;
         var seed = InternalUtils.DeepClone(start);
 
         seed.Mode ??= defaultMode;
@@ -456,6 +498,38 @@ public sealed partial class SigilClient : IAsyncDisposable
             ? InternalUtils.Utc(seed.StartedAt.Value)
             : _config.UtcNow!();
 
+        // Resolve content capture mode before the span starts so MetadataOnly never
+        // attaches sensitive content to live span attributes.
+        var ccMode = seed.ContentCapture;
+        if (ccMode == ContentCaptureMode.Default)
+        {
+            var resolverMode = CallContentCaptureResolver(_config.ContentCaptureResolver, originalMetadata, _log);
+            ccMode = ResolveClientContentCaptureMode(ResolveContentCaptureMode(resolverMode, _config.ContentCapture));
+        }
+        else
+        {
+            ccMode = NormalizeContentCaptureMode(ccMode);
+        }
+
+        var spanGeneration = new Generation
+        {
+            Id = seed.Id,
+            ConversationId = seed.ConversationId,
+            ConversationTitle = ccMode == ContentCaptureMode.MetadataOnly ? string.Empty : seed.ConversationTitle,
+            UserId = seed.UserId,
+            AgentName = seed.AgentName,
+            AgentVersion = seed.AgentVersion,
+            Mode = seed.Mode,
+            OperationName = seed.OperationName,
+            Model = InternalUtils.DeepClone(seed.Model),
+            MaxTokens = seed.MaxTokens,
+            Temperature = seed.Temperature,
+            TopP = seed.TopP,
+            ToolChoice = seed.ToolChoice,
+            ThinkingEnabled = seed.ThinkingEnabled,
+            ParentGenerationIds = [.. seed.ParentGenerationIds],
+        };
+
         var activity = _activitySource.StartActivity(
             GenerationSpanName(seed.OperationName, seed.Model.Name),
             ActivityKind.Client,
@@ -467,27 +541,12 @@ public sealed partial class SigilClient : IAsyncDisposable
 
         if (activity != null)
         {
-            ApplyGenerationSpanAttributes(activity, new Generation
-            {
-                Id = seed.Id,
-                ConversationId = seed.ConversationId,
-                ConversationTitle = seed.ConversationTitle,
-                UserId = seed.UserId,
-                AgentName = seed.AgentName,
-                AgentVersion = seed.AgentVersion,
-                Mode = seed.Mode,
-                OperationName = seed.OperationName,
-                Model = InternalUtils.DeepClone(seed.Model),
-                MaxTokens = seed.MaxTokens,
-                Temperature = seed.Temperature,
-                TopP = seed.TopP,
-                ToolChoice = seed.ToolChoice,
-                ThinkingEnabled = seed.ThinkingEnabled,
-                ParentGenerationIds = [.. seed.ParentGenerationIds],
-            });
+            ApplyGenerationSpanAttributes(activity, spanGeneration);
         }
 
-        return new GenerationRecorder(this, seed, seed.StartedAt!.Value, activity);
+        var recorder = new GenerationRecorder(this, seed, seed.StartedAt!.Value, ccMode, activity);
+        recorder.SetContextScope(SigilContext.PushContentCaptureMode(ccMode));
+        return recorder;
     }
 
     internal void PersistGeneration(Generation generation)
@@ -665,7 +724,7 @@ public sealed partial class SigilClient : IAsyncDisposable
         }
     }
 
-    private static SubmitConversationRatingRequest NormalizeConversationRatingRequest(SubmitConversationRatingRequest request)
+    private static SubmitConversationRatingRequest NormalizeConversationRatingRequest(SubmitConversationRatingRequest? request)
     {
         var input = request ?? new SubmitConversationRatingRequest();
         var normalized = new SubmitConversationRatingRequest
@@ -1791,7 +1850,7 @@ public sealed partial class SigilClient : IAsyncDisposable
 #endif
     }
 
-    internal static void RecordException(Activity activity, Exception error)
+    internal static void RecordException(Activity activity, Exception error, bool redact = false)
     {
         if (activity == null || error == null)
         {
@@ -1799,6 +1858,10 @@ public sealed partial class SigilClient : IAsyncDisposable
         }
 
         activity.SetTag("exception.type", error.GetType().FullName);
+        if (redact)
+        {
+            return;
+        }
         activity.SetTag("exception.message", error.Message);
         activity.SetTag("exception.stacktrace", error.ToString());
     }
@@ -1811,17 +1874,176 @@ public sealed partial class SigilClient : IAsyncDisposable
         return content.ReadAsStringAsync(cancellationToken);
 #endif
     }
+
+    internal static ContentCaptureMode ResolveClientContentCaptureMode(ContentCaptureMode mode)
+    {
+        var normalized = NormalizeContentCaptureMode(mode);
+        return normalized == ContentCaptureMode.Default ? ContentCaptureMode.NoToolContent : normalized;
+    }
+
+    internal static ContentCaptureMode ResolveContentCaptureMode(ContentCaptureMode @override, ContentCaptureMode fallback)
+    {
+        var normalizedOverride = NormalizeContentCaptureMode(@override);
+        return normalizedOverride != ContentCaptureMode.Default ? normalizedOverride : NormalizeContentCaptureMode(fallback);
+    }
+
+    internal static ContentCaptureMode CallContentCaptureResolver(
+        Func<IReadOnlyDictionary<string, object?>?, ContentCaptureMode>? resolver,
+        IDictionary<string, object?>? metadata,
+        Action<string>? logger = null)
+    {
+        if (resolver == null)
+        {
+            return ContentCaptureMode.Default;
+        }
+
+        ContentCaptureMode mode;
+        try
+        {
+            mode = resolver(ToResolverMetadata(metadata));
+        }
+        catch (Exception ex)
+        {
+            logger?.Invoke($"sigil: content capture resolver threw, falling back to MetadataOnly: {ex.Message}");
+            return ContentCaptureMode.MetadataOnly;
+        }
+
+        if (!Enum.IsDefined(typeof(ContentCaptureMode), mode))
+        {
+            logger?.Invoke($"sigil: content capture resolver returned undefined mode {(int)mode}, falling back to MetadataOnly");
+            return ContentCaptureMode.MetadataOnly;
+        }
+
+        return mode;
+    }
+
+    private static ContentCaptureMode NormalizeContentCaptureMode(ContentCaptureMode mode)
+    {
+        return Enum.IsDefined(typeof(ContentCaptureMode), mode) ? mode : ContentCaptureMode.MetadataOnly;
+    }
+
+    private static IReadOnlyDictionary<string, object?>? ToResolverMetadata(IDictionary<string, object?>? metadata)
+    {
+        return metadata == null
+            ? null
+            : new System.Collections.ObjectModel.ReadOnlyDictionary<string, object?>(
+                new Dictionary<string, object?>(metadata, StringComparer.Ordinal));
+    }
+
+    internal static ContentCaptureMode ResolveToolContentCaptureMode(
+        ContentCaptureMode toolMode,
+        ContentCaptureMode ctxMode,
+        bool ctxSet,
+        ContentCaptureMode clientDefault)
+    {
+        var resolved = ResolveClientContentCaptureMode(clientDefault);
+        if (ctxSet)
+        {
+            resolved = NormalizeContentCaptureMode(ctxMode);
+        }
+        if (toolMode != ContentCaptureMode.Default)
+        {
+            resolved = NormalizeContentCaptureMode(toolMode);
+        }
+
+        return resolved;
+    }
+
+    internal static bool ShouldIncludeToolContent(
+        ContentCaptureMode toolMode,
+        ContentCaptureMode ctxMode,
+        bool ctxSet,
+        ContentCaptureMode clientDefault,
+        bool legacyInclude)
+    {
+        return ResolveToolContentCaptureMode(toolMode, ctxMode, ctxSet, clientDefault) switch
+        {
+            ContentCaptureMode.MetadataOnly => false,
+            ContentCaptureMode.Full => true,
+            _ => legacyInclude,
+        };
+    }
+
+    internal static bool IsContentStripped(Generation generation)
+    {
+        if (generation.Metadata == null || !generation.Metadata.TryGetValue(MetadataKeyContentCaptureMode, out var value))
+        {
+            return false;
+        }
+
+        // After DeepClone (JSON round-trip), string values become JsonElement.
+        if (value is string s)
+        {
+            return s == "metadata_only";
+        }
+
+        if (value is JsonElement je && je.ValueKind == JsonValueKind.String)
+        {
+            return je.GetString() == "metadata_only";
+        }
+
+        return false;
+    }
+
+    internal static void StripContent(Generation generation, string errorCategory)
+    {
+        generation.SystemPrompt = string.Empty;
+        generation.Artifacts = [];
+
+        if (!string.IsNullOrEmpty(generation.CallError))
+        {
+            generation.CallError = !string.IsNullOrEmpty(errorCategory) ? errorCategory : "sdk_error";
+        }
+        generation.Metadata.Remove("call_error");
+
+        generation.ConversationTitle = string.Empty;
+        generation.Metadata.Remove(SpanAttrConversationTitle);
+
+        foreach (var message in generation.Input)
+        {
+            StripMessageContent(message);
+        }
+        foreach (var message in generation.Output)
+        {
+            StripMessageContent(message);
+        }
+        foreach (var tool in generation.Tools)
+        {
+            tool.Description = string.Empty;
+            tool.InputSchemaJson = [];
+        }
+    }
+
+    private static void StripMessageContent(Message message)
+    {
+        foreach (var part in message.Parts)
+        {
+            part.Text = string.Empty;
+            part.Thinking = string.Empty;
+            if (part.ToolCall != null)
+            {
+                part.ToolCall.InputJson = [];
+            }
+            if (part.ToolResult != null)
+            {
+                part.ToolResult.Content = string.Empty;
+                part.ToolResult.ContentJson = [];
+            }
+        }
+    }
 }
 
 public sealed class GenerationRecorder
 {
-    internal static readonly GenerationRecorder Noop = new(null, new GenerationStart(), DateTimeOffset.UtcNow, null, true);
+    internal static readonly GenerationRecorder Noop = new(null, new GenerationStart(), DateTimeOffset.UtcNow, ContentCaptureMode.Default, null, true);
 
     private readonly SigilClient? _client;
     private readonly GenerationStart _seed;
     private readonly DateTimeOffset _startedAt;
+    private readonly ContentCaptureMode _contentCaptureMode;
     private readonly Activity? _activity;
     private readonly bool _noop;
+    private IDisposable? _contextScope;
 
 #if NET10_0_OR_GREATER
     private readonly Lock _gate = new();
@@ -1843,6 +2065,7 @@ public sealed class GenerationRecorder
         SigilClient? client,
         GenerationStart seed,
         DateTimeOffset startedAt,
+        ContentCaptureMode contentCaptureMode,
         Activity? activity,
         bool noop = false
     )
@@ -1850,8 +2073,14 @@ public sealed class GenerationRecorder
         _client = client;
         _seed = seed;
         _startedAt = startedAt;
+        _contentCaptureMode = contentCaptureMode;
         _activity = activity;
         _noop = noop;
+    }
+
+    internal void SetContextScope(IDisposable scope)
+    {
+        _contextScope = scope;
     }
 
     public void SetCallError(Exception error)
@@ -1920,8 +2149,31 @@ public sealed class GenerationRecorder
             firstTokenAt = _firstTokenAt;
         }
 
-        var completedAt = _client!._config.UtcNow!();
-        var generation = NormalizeGeneration(result, completedAt, callError);
+        Generation generation;
+        try
+        {
+            var completedAt = _client!._config.UtcNow!();
+            generation = NormalizeGeneration(result, completedAt, callError);
+
+            var modeValue = _contentCaptureMode.ToMetadataValue();
+            if (modeValue.Length > 0)
+            {
+                generation.Metadata[SigilClient.MetadataKeyContentCaptureMode] = modeValue;
+            }
+
+            if (_contentCaptureMode == ContentCaptureMode.MetadataOnly)
+            {
+                var stripErrorCategory = SigilClient.ErrorCategoryFromException(callError, false);
+                SigilClient.StripContent(generation, stripErrorCategory);
+            }
+        }
+        finally
+        {
+            _contextScope?.Dispose();
+            _contextScope = null;
+        }
+
+        var redactErrors = _contentCaptureMode == ContentCaptureMode.MetadataOnly;
 
         if (_activity != null)
         {
@@ -1933,12 +2185,12 @@ public sealed class GenerationRecorder
 
             if (callError != null)
             {
-                SigilClient.RecordException(_activity, callError);
+                SigilClient.RecordException(_activity, callError, redactErrors);
             }
 
             if (mappingError != null)
             {
-                SigilClient.RecordException(_activity, mappingError);
+                SigilClient.RecordException(_activity, mappingError, redactErrors);
             }
         }
 
@@ -1982,14 +2234,17 @@ public sealed class GenerationRecorder
         {
             if (localError != null)
             {
-                SigilClient.RecordException(_activity, localError);
+                SigilClient.RecordException(_activity, localError, redactErrors);
             }
 
             if (errorType.Length > 0)
             {
                 _activity.SetTag(SigilClient.SpanAttrErrorType, errorType);
                 _activity.SetTag(SigilClient.SpanAttrErrorCategory, errorCategory);
-                _activity.SetStatus(ActivityStatusCode.Error, (callError ?? mappingError ?? localError)?.Message);
+                var statusDescription = redactErrors
+                    ? errorCategory
+                    : (callError ?? mappingError ?? localError)?.Message;
+                _activity.SetStatus(ActivityStatusCode.Error, statusDescription);
             }
             else
             {
@@ -2281,12 +2536,13 @@ public sealed class EmbeddingRecorder
 
 public sealed class ToolExecutionRecorder
 {
-    internal static readonly ToolExecutionRecorder Noop = new(null, new ToolExecutionStart(), DateTimeOffset.UtcNow, false, null, true);
+    internal static readonly ToolExecutionRecorder Noop = new(null, new ToolExecutionStart(), DateTimeOffset.UtcNow, false, false, null, true);
 
     private readonly SigilClient? _client;
     private readonly ToolExecutionStart _seed;
     private readonly DateTimeOffset _startedAt;
     private readonly bool _includeContent;
+    private readonly bool _redactErrors;
     private readonly Activity? _activity;
     private readonly bool _noop;
 
@@ -2307,6 +2563,7 @@ public sealed class ToolExecutionRecorder
         ToolExecutionStart seed,
         DateTimeOffset startedAt,
         bool includeContent,
+        bool redactErrors,
         Activity? activity,
         bool noop = false
     )
@@ -2315,6 +2572,7 @@ public sealed class ToolExecutionRecorder
         _seed = seed;
         _startedAt = startedAt;
         _includeContent = includeContent;
+        _redactErrors = redactErrors;
         _activity = activity;
         _noop = noop;
     }
@@ -2401,10 +2659,11 @@ public sealed class ToolExecutionRecorder
 
             if (finalError != null)
             {
-                SigilClient.RecordException(_activity, finalError);
+                SigilClient.RecordException(_activity, finalError, _redactErrors);
+                var errorCategory = SigilClient.ErrorCategoryFromException(finalError, true);
                 _activity.SetTag(SigilClient.SpanAttrErrorType, "tool_execution_error");
-                _activity.SetTag(SigilClient.SpanAttrErrorCategory, SigilClient.ErrorCategoryFromException(finalError, true));
-                _activity.SetStatus(ActivityStatusCode.Error, finalError.Message);
+                _activity.SetTag(SigilClient.SpanAttrErrorCategory, errorCategory);
+                _activity.SetStatus(ActivityStatusCode.Error, _redactErrors ? errorCategory : finalError.Message);
             }
             else
             {

--- a/dotnet/src/Grafana.Sigil/SigilContext.cs
+++ b/dotnet/src/Grafana.Sigil/SigilContext.cs
@@ -9,30 +9,38 @@ public static class SigilContext
     private static readonly AsyncLocal<string?> UserIdSlot = new();
     private static readonly AsyncLocal<string?> AgentNameSlot = new();
     private static readonly AsyncLocal<string?> AgentVersionSlot = new();
+    private static readonly AsyncLocal<ContentCaptureMode?> ContentCaptureModeSlot = new();
+
+    // Stack of active generation recorder capture modes, keyed by recorder ID.
+    // Handles non-LIFO completion when overlapping generations end out-of-order
+    // (matches Python SDK pattern).
+    private static readonly AsyncLocal<CaptureStackEntry[]?> CaptureStack = new();
+    private static readonly AsyncLocal<ContentCaptureMode?> CaptureStackBase = new();
+    private static long _nextRecorderId;
 
     public static IDisposable WithConversationId(string conversationId)
     {
-        return new AsyncLocalScope(ConversationIdSlot, conversationId);
+        return new AsyncLocalScope<string?>(ConversationIdSlot, conversationId);
     }
 
     public static IDisposable WithConversationTitle(string conversationTitle)
     {
-        return new AsyncLocalScope(ConversationTitleSlot, conversationTitle);
+        return new AsyncLocalScope<string?>(ConversationTitleSlot, conversationTitle);
     }
 
     public static IDisposable WithUserId(string userId)
     {
-        return new AsyncLocalScope(UserIdSlot, userId);
+        return new AsyncLocalScope<string?>(UserIdSlot, userId);
     }
 
     public static IDisposable WithAgentName(string agentName)
     {
-        return new AsyncLocalScope(AgentNameSlot, agentName);
+        return new AsyncLocalScope<string?>(AgentNameSlot, agentName);
     }
 
     public static IDisposable WithAgentVersion(string agentVersion)
     {
-        return new AsyncLocalScope(AgentVersionSlot, agentVersion);
+        return new AsyncLocalScope<string?>(AgentVersionSlot, agentVersion);
     }
 
     public static string? ConversationIdFromContext()
@@ -60,16 +68,109 @@ public static class SigilContext
         return AgentVersionSlot.Value;
     }
 
-    private sealed class AsyncLocalScope : IDisposable
+    internal static IDisposable PushContentCaptureMode(ContentCaptureMode mode)
     {
-        private readonly AsyncLocal<string?> _slot;
-        private readonly string? _previousValue;
+        var recorderId = Interlocked.Increment(ref _nextRecorderId);
+        var stack = CaptureStack.Value ?? [];
+        if (stack.Length == 0)
+        {
+            CaptureStackBase.Value = ContentCaptureModeSlot.Value;
+        }
+
+        var newStack = new CaptureStackEntry[stack.Length + 1];
+        Array.Copy(stack, newStack, stack.Length);
+        newStack[stack.Length] = new CaptureStackEntry(recorderId, mode);
+        CaptureStack.Value = newStack;
+        ContentCaptureModeSlot.Value = mode;
+        return new CaptureStackPop(recorderId);
+    }
+
+    internal static ContentCaptureMode ContentCaptureModeFromContext()
+    {
+        return ContentCaptureModeSlot.Value ?? ContentCaptureMode.Default;
+    }
+
+    internal static bool HasContentCaptureModeInContext()
+    {
+        return ContentCaptureModeSlot.Value.HasValue;
+    }
+
+    private static void PopContentCaptureMode(long recorderId)
+    {
+        var stack = CaptureStack.Value;
+        if (stack == null || stack.Length == 0)
+        {
+            return;
+        }
+
+        var count = 0;
+        foreach (var entry in stack)
+        {
+            if (entry.RecorderId != recorderId)
+            {
+                count++;
+            }
+        }
+
+        if (count == stack.Length)
+        {
+            return;
+        }
+
+        var newStack = new CaptureStackEntry[count];
+        var idx = 0;
+        foreach (var entry in stack)
+        {
+            if (entry.RecorderId != recorderId)
+            {
+                newStack[idx++] = entry;
+            }
+        }
+
+        CaptureStack.Value = newStack;
+        ContentCaptureModeSlot.Value = newStack.Length > 0
+            ? newStack[newStack.Length - 1].Mode
+            : CaptureStackBase.Value;
+    }
+
+    private readonly struct CaptureStackEntry
+    {
+        public readonly long RecorderId;
+        public readonly ContentCaptureMode Mode;
+
+        public CaptureStackEntry(long recorderId, ContentCaptureMode mode)
+        {
+            RecorderId = recorderId;
+            Mode = mode;
+        }
+    }
+
+    private sealed class CaptureStackPop(long recorderId) : IDisposable
+    {
         private bool _disposed;
 
-        public AsyncLocalScope(AsyncLocal<string?> slot, string value)
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            PopContentCaptureMode(recorderId);
+        }
+    }
+
+    private sealed class AsyncLocalScope<T> : IDisposable
+    {
+        private readonly AsyncLocal<T> _slot;
+        private readonly T _previousValue;
+        private bool _disposed;
+
+        public AsyncLocalScope(AsyncLocal<T> slot, T value)
         {
             _slot = slot;
-            _previousValue = slot.Value;
+            _previousValue = slot.Value!;
             _slot.Value = value;
         }
 

--- a/dotnet/tests/Grafana.Sigil.Tests/ConformanceTests.cs
+++ b/dotnet/tests/Grafana.Sigil.Tests/ConformanceTests.cs
@@ -319,7 +319,7 @@ public sealed class ConformanceTests
             ToolType = "function",
             RequestProvider = "openai",
             RequestModel = "gpt-5",
-            IncludeContent = true,
+            ContentCapture = ContentCaptureMode.Full,
         });
         recorder.SetResult(new ToolExecutionEnd
         {

--- a/dotnet/tests/Grafana.Sigil.Tests/ContentCaptureModeTests.cs
+++ b/dotnet/tests/Grafana.Sigil.Tests/ContentCaptureModeTests.cs
@@ -1,0 +1,1277 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+using SigilProto = Sigil.V1;
+
+namespace Grafana.Sigil.Tests;
+
+public sealed class ContentCaptureModeTests
+{
+    [Fact]
+    public void ToMetadataValue_ReturnsCorrectStrings()
+    {
+        Assert.Equal("full", ContentCaptureMode.Full.ToMetadataValue());
+        Assert.Equal("no_tool_content", ContentCaptureMode.NoToolContent.ToMetadataValue());
+        Assert.Equal("metadata_only", ContentCaptureMode.MetadataOnly.ToMetadataValue());
+        Assert.Equal(string.Empty, ContentCaptureMode.Default.ToMetadataValue());
+    }
+
+    [Theory]
+    [InlineData(ContentCaptureMode.Full, ContentCaptureMode.Default, ContentCaptureMode.Full)]
+    [InlineData(ContentCaptureMode.Full, ContentCaptureMode.MetadataOnly, ContentCaptureMode.MetadataOnly)]
+    [InlineData(ContentCaptureMode.MetadataOnly, ContentCaptureMode.Default, ContentCaptureMode.MetadataOnly)]
+    [InlineData(ContentCaptureMode.MetadataOnly, ContentCaptureMode.Full, ContentCaptureMode.Full)]
+    public void ResolveContentCaptureMode_Semantics(
+        ContentCaptureMode fallback,
+        ContentCaptureMode @override,
+        ContentCaptureMode expected)
+    {
+        var got = SigilClient.ResolveContentCaptureMode(@override, fallback);
+        Assert.Equal(expected, got);
+    }
+
+    [Fact]
+    public void ResolveContentCaptureMode_InvalidEnumFailsClosed()
+    {
+        Assert.Equal(
+            ContentCaptureMode.MetadataOnly,
+            SigilClient.ResolveContentCaptureMode((ContentCaptureMode)99, ContentCaptureMode.Full));
+        Assert.Equal(
+            ContentCaptureMode.MetadataOnly,
+            SigilClient.ResolveContentCaptureMode(ContentCaptureMode.Default, (ContentCaptureMode)99));
+    }
+
+    [Fact]
+    public void ResolveClientContentCaptureMode_DefaultBecomesNoToolContent()
+    {
+        Assert.Equal(ContentCaptureMode.NoToolContent, SigilClient.ResolveClientContentCaptureMode(ContentCaptureMode.Default));
+        Assert.Equal(ContentCaptureMode.Full, SigilClient.ResolveClientContentCaptureMode(ContentCaptureMode.Full));
+        Assert.Equal(ContentCaptureMode.MetadataOnly, SigilClient.ResolveClientContentCaptureMode(ContentCaptureMode.MetadataOnly));
+    }
+
+    [Fact]
+    public void CallContentCaptureResolver_NilReturnsDefault()
+    {
+        var got = SigilClient.CallContentCaptureResolver(null, null);
+        Assert.Equal(ContentCaptureMode.Default, got);
+    }
+
+    [Fact]
+    public void CallContentCaptureResolver_ReturnsResolverResult()
+    {
+        var got = SigilClient.CallContentCaptureResolver(
+            _ => ContentCaptureMode.MetadataOnly,
+            new Dictionary<string, object?>());
+        Assert.Equal(ContentCaptureMode.MetadataOnly, got);
+    }
+
+    [Fact]
+    public void CallContentCaptureResolver_ReadsMetadata()
+    {
+        var got = SigilClient.CallContentCaptureResolver(
+            metadata =>
+            {
+                if (metadata != null && metadata.TryGetValue("tenant_id", out var val) && val is string s && s == "opted-out")
+                    return ContentCaptureMode.MetadataOnly;
+                return ContentCaptureMode.Full;
+            },
+            new Dictionary<string, object?> { ["tenant_id"] = "opted-out" });
+        Assert.Equal(ContentCaptureMode.MetadataOnly, got);
+    }
+
+    [Fact]
+    public void CallContentCaptureResolver_PassesReadOnlyMetadata()
+    {
+        var metadata = new Dictionary<string, object?> { ["tenant_id"] = "original" };
+        var got = SigilClient.CallContentCaptureResolver(
+            received =>
+            {
+                Assert.NotNull(received);
+                Assert.Throws<NotSupportedException>(() =>
+                    ((IDictionary<string, object?>)received!)["tenant_id"] = "changed");
+                return ContentCaptureMode.Full;
+            },
+            metadata);
+
+        Assert.Equal(ContentCaptureMode.Full, got);
+        Assert.Equal("original", metadata["tenant_id"]);
+    }
+
+    [Fact]
+    public void CallContentCaptureResolver_ExceptionFailsClosed()
+    {
+        var got = SigilClient.CallContentCaptureResolver(
+            _ => throw new InvalidOperationException("resolver bug"),
+            null);
+        Assert.Equal(ContentCaptureMode.MetadataOnly, got);
+    }
+
+    [Fact]
+    public void StripContent_StripsAllSensitiveContent()
+    {
+        var gen = MakeTestGeneration();
+        SigilClient.StripContent(gen, "rate_limit");
+
+        Assert.Equal(string.Empty, gen.SystemPrompt);
+        Assert.Equal(string.Empty, gen.Input[0].Parts[0].Text);
+        Assert.Equal(string.Empty, gen.Output[0].Parts[0].Thinking);
+        Assert.Empty(gen.Output[0].Parts[1].ToolCall!.InputJson);
+        Assert.Equal(string.Empty, gen.Output[0].Parts[2].Text);
+        Assert.Equal(string.Empty, gen.Input[1].Parts[0].ToolResult!.Content);
+        Assert.Empty(gen.Input[1].Parts[0].ToolResult!.ContentJson);
+        Assert.Empty(gen.Tools[0].Description);
+        Assert.Empty(gen.Tools[0].InputSchemaJson);
+        Assert.Empty(gen.Artifacts);
+    }
+
+    [Fact]
+    public void StripContent_StripsConversationTitle()
+    {
+        var gen = MakeTestGeneration();
+        gen.ConversationTitle = "Secret project discussion";
+        gen.Metadata[SigilClient.SpanAttrConversationTitle] = "Secret project discussion";
+        SigilClient.StripContent(gen, "rate_limit");
+
+        Assert.Equal(string.Empty, gen.ConversationTitle);
+        Assert.False(gen.Metadata.ContainsKey(SigilClient.SpanAttrConversationTitle));
+    }
+
+    [Fact]
+    public void StripContent_PreservesMessageStructure()
+    {
+        var gen = MakeTestGeneration();
+        SigilClient.StripContent(gen, "rate_limit");
+
+        Assert.Equal(2, gen.Input.Count);
+        Assert.Single(gen.Output);
+        Assert.Equal(3, gen.Output[0].Parts.Count);
+        Assert.Equal(MessageRole.User, gen.Input[0].Role);
+        Assert.Equal(PartKind.Thinking, gen.Output[0].Parts[0].Kind);
+        Assert.Equal("weather", gen.Output[0].Parts[1].ToolCall!.Name);
+        Assert.Equal("call_1", gen.Output[0].Parts[1].ToolCall!.Id);
+        Assert.Equal("call_1", gen.Input[1].Parts[0].ToolResult!.ToolCallId);
+        Assert.Equal("weather", gen.Input[1].Parts[0].ToolResult!.Name);
+    }
+
+    [Fact]
+    public void StripContent_PreservesOperationalMetadata()
+    {
+        var gen = MakeTestGeneration();
+        SigilClient.StripContent(gen, "rate_limit");
+
+        Assert.Equal("weather", gen.Tools[0].Name);
+        Assert.Equal(120L, gen.Usage.InputTokens);
+        Assert.Equal(42L, gen.Usage.OutputTokens);
+        Assert.Equal("end_turn", gen.StopReason);
+        Assert.Equal("claude-sonnet-4-5", gen.Model.Name);
+        Assert.Equal("sdk-dotnet", gen.Metadata["sigil.sdk.name"]);
+    }
+
+    [Fact]
+    public void StripContent_ReplacesCallErrorWithCategory()
+    {
+        var gen = MakeTestGeneration();
+        SigilClient.StripContent(gen, "rate_limit");
+
+        Assert.Equal("rate_limit", gen.CallError);
+        Assert.False(gen.Metadata.ContainsKey("call_error"));
+    }
+
+    [Fact]
+    public void StripContent_FallsBackToSdkError()
+    {
+        var gen = MakeTestGeneration();
+        SigilClient.StripContent(gen, "");
+
+        Assert.Equal("sdk_error", gen.CallError);
+    }
+
+    [Fact]
+    public async Task DefaultResolution_NoToolContent()
+    {
+        await using var env = new ContentCaptureEnv();
+        var recorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+        });
+        recorder.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("hello") },
+            Output = { Message.AssistantTextMessage("world") },
+            Usage = new TokenUsage { InputTokens = 10, OutputTokens = 5 },
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var gen = env.SingleGeneration();
+        Assert.Equal("no_tool_content", gen.Metadata.Fields[SigilClient.MetadataKeyContentCaptureMode].StringValue);
+        Assert.Equal("hello", gen.Input[0].Parts[0].Text);
+    }
+
+    [Fact]
+    public async Task ClientMetadataOnly_StripsContent()
+    {
+        await using var env = new ContentCaptureEnv(ContentCaptureMode.MetadataOnly);
+        var recorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+        });
+        recorder.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("hello") },
+            Output = { Message.AssistantTextMessage("world") },
+            Usage = new TokenUsage { InputTokens = 10, OutputTokens = 5 },
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var gen = env.SingleGeneration();
+        Assert.Equal("metadata_only", gen.Metadata.Fields[SigilClient.MetadataKeyContentCaptureMode].StringValue);
+        Assert.Equal(string.Empty, gen.Input[0].Parts[0].Text);
+        Assert.Equal(10L, gen.Usage.InputTokens);
+    }
+
+    [Fact]
+    public async Task ClientMetadataOnly_DoesNotAttachConversationTitleToGenerationSpan()
+    {
+        await using var env = new ContentCaptureEnv(ContentCaptureMode.MetadataOnly);
+        var recorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+            ConversationTitle = "Secret project discussion",
+        });
+        recorder.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("hello") },
+            Output = { Message.AssistantTextMessage("world") },
+            Usage = new TokenUsage { InputTokens = 10, OutputTokens = 5 },
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var span = env.Spans.Single(a => a.GetTagItem("gen_ai.operation.name")?.ToString() == "generateText");
+        Assert.Null(span.GetTagItem(SigilClient.SpanAttrConversationTitle));
+    }
+
+    [Fact]
+    public async Task ClientMetadataOnly_RedactsExceptionMessageAndStacktraceOnGenerationSpan()
+    {
+        await using var env = new ContentCaptureEnv(ContentCaptureMode.MetadataOnly);
+        var recorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+        });
+        recorder.SetCallError(new InvalidOperationException("provider rejected: <secret prompt>"));
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var span = env.Spans.Single(a => a.GetTagItem("gen_ai.operation.name")?.ToString() == "generateText");
+        Assert.NotNull(span.GetTagItem("exception.type"));
+        Assert.Null(span.GetTagItem("exception.message"));
+        Assert.Null(span.GetTagItem("exception.stacktrace"));
+        Assert.Equal(ActivityStatusCode.Error, span.Status);
+        Assert.DoesNotContain("secret prompt", span.StatusDescription ?? string.Empty);
+    }
+
+    [Fact]
+    public async Task ClientFull_KeepsExceptionMessageOnGenerationSpan()
+    {
+        await using var env = new ContentCaptureEnv(ContentCaptureMode.Full);
+        var recorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+        });
+        recorder.SetCallError(new InvalidOperationException("provider rejected: <secret prompt>"));
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var span = env.Spans.Single(a => a.GetTagItem("gen_ai.operation.name")?.ToString() == "generateText");
+        Assert.Equal("provider rejected: <secret prompt>", span.GetTagItem("exception.message"));
+        Assert.NotNull(span.GetTagItem("exception.stacktrace"));
+    }
+
+    [Fact]
+    public async Task ToolMetadataOnly_RedactsExceptionMessageOnToolSpan()
+    {
+        await using var env = new ContentCaptureEnv(ContentCaptureMode.MetadataOnly);
+        var recorder = env.Client.StartToolExecution(new ToolExecutionStart
+        {
+            ToolName = "test_tool",
+        });
+        recorder.SetExecutionError(new InvalidOperationException("tool failed: <secret arg>"));
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var span = env.ToolSpan();
+        Assert.NotNull(span.GetTagItem("exception.type"));
+        Assert.Null(span.GetTagItem("exception.message"));
+        Assert.Null(span.GetTagItem("exception.stacktrace"));
+        Assert.DoesNotContain("secret arg", span.StatusDescription ?? string.Empty);
+    }
+
+    [Fact]
+    public async Task ClientFull_PreservesContent()
+    {
+        await using var env = new ContentCaptureEnv(ContentCaptureMode.Full);
+        var recorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+        });
+        recorder.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("hello") },
+            Output = { Message.AssistantTextMessage("world") },
+            Usage = new TokenUsage { InputTokens = 10, OutputTokens = 5 },
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var gen = env.SingleGeneration();
+        Assert.Equal("full", gen.Metadata.Fields[SigilClient.MetadataKeyContentCaptureMode].StringValue);
+        Assert.Equal("hello", gen.Input[0].Parts[0].Text);
+    }
+
+    [Fact]
+    public async Task PerGenerationOverride_MetadataOnlyOverridesClientFull()
+    {
+        await using var env = new ContentCaptureEnv(ContentCaptureMode.Full);
+        var recorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+            ContentCapture = ContentCaptureMode.MetadataOnly,
+        });
+        recorder.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("hello") },
+            Output = { Message.AssistantTextMessage("world") },
+            Usage = new TokenUsage { InputTokens = 10, OutputTokens = 5 },
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var gen = env.SingleGeneration();
+        Assert.Equal("metadata_only", gen.Metadata.Fields[SigilClient.MetadataKeyContentCaptureMode].StringValue);
+        Assert.Equal(string.Empty, gen.Input[0].Parts[0].Text);
+    }
+
+    [Fact]
+    public async Task PerGenerationOverride_FullOverridesClientMetadataOnly()
+    {
+        await using var env = new ContentCaptureEnv(ContentCaptureMode.MetadataOnly);
+        var recorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+            ContentCapture = ContentCaptureMode.Full,
+        });
+        recorder.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("hello") },
+            Output = { Message.AssistantTextMessage("world") },
+            Usage = new TokenUsage { InputTokens = 10, OutputTokens = 5 },
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var gen = env.SingleGeneration();
+        Assert.Equal("full", gen.Metadata.Fields[SigilClient.MetadataKeyContentCaptureMode].StringValue);
+        Assert.Equal("hello", gen.Input[0].Parts[0].Text);
+    }
+
+    [Fact]
+    public async Task Resolver_OverridesClientDefault()
+    {
+        await using var env = new ContentCaptureEnv(
+            ContentCaptureMode.Full,
+            _ => ContentCaptureMode.MetadataOnly);
+        var recorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+        });
+        recorder.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("hello") },
+            Output = { Message.AssistantTextMessage("world") },
+            Usage = new TokenUsage { InputTokens = 10, OutputTokens = 5 },
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var gen = env.SingleGeneration();
+        Assert.Equal("metadata_only", gen.Metadata.Fields[SigilClient.MetadataKeyContentCaptureMode].StringValue);
+        Assert.Equal(string.Empty, gen.Input[0].Parts[0].Text);
+    }
+
+    [Fact]
+    public async Task Resolver_PerGenOverrideTakesPrecedence()
+    {
+        await using var env = new ContentCaptureEnv(
+            ContentCaptureMode.Default,
+            _ => ContentCaptureMode.MetadataOnly);
+        var recorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+            ContentCapture = ContentCaptureMode.Full,
+        });
+        recorder.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("hello") },
+            Output = { Message.AssistantTextMessage("world") },
+            Usage = new TokenUsage { InputTokens = 10, OutputTokens = 5 },
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var gen = env.SingleGeneration();
+        Assert.Equal("full", gen.Metadata.Fields[SigilClient.MetadataKeyContentCaptureMode].StringValue);
+        Assert.Equal("hello", gen.Input[0].Parts[0].Text);
+    }
+
+    [Fact]
+    public async Task Resolver_PerGenOverrideDoesNotInvokeResolver()
+    {
+        var calls = 0;
+        await using var env = new ContentCaptureEnv(
+            ContentCaptureMode.Default,
+            _ =>
+            {
+                calls++;
+                return ContentCaptureMode.MetadataOnly;
+            });
+        var recorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+            ContentCapture = ContentCaptureMode.Full,
+        });
+        recorder.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("hello") },
+            Output = { Message.AssistantTextMessage("world") },
+            Usage = new TokenUsage { InputTokens = 10, OutputTokens = 5 },
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var gen = env.SingleGeneration();
+        Assert.Equal(0, calls);
+        Assert.Equal("full", gen.Metadata.Fields[SigilClient.MetadataKeyContentCaptureMode].StringValue);
+    }
+
+    [Fact]
+    public async Task Resolver_ExceptionFailsClosed()
+    {
+        await using var env = new ContentCaptureEnv(
+            ContentCaptureMode.Full,
+            _ => throw new InvalidOperationException("oops"));
+        var recorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+        });
+        recorder.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("hello") },
+            Output = { Message.AssistantTextMessage("world") },
+            Usage = new TokenUsage { InputTokens = 10, OutputTokens = 5 },
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var gen = env.SingleGeneration();
+        Assert.Equal("metadata_only", gen.Metadata.Fields[SigilClient.MetadataKeyContentCaptureMode].StringValue);
+        Assert.Equal(string.Empty, gen.Input[0].Parts[0].Text);
+    }
+
+    [Fact]
+    public async Task ValidationAcceptsStrippedGeneration()
+    {
+        await using var env = new ContentCaptureEnv(ContentCaptureMode.MetadataOnly);
+        var recorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+        });
+        recorder.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("hello") },
+            Output =
+            {
+                new Message
+                {
+                    Role = MessageRole.Assistant,
+                    Parts =
+                    {
+                        Part.ThinkingPart("deep thoughts"),
+                        Part.TextPart("answer"),
+                    },
+                },
+            },
+            Usage = new TokenUsage { InputTokens = 10, OutputTokens = 5 },
+        });
+        recorder.End();
+
+        Assert.Null(recorder.Error);
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var gen = env.SingleGeneration();
+        Assert.Equal(string.Empty, gen.Input[0].Parts[0].Text);
+        Assert.Equal(string.Empty, gen.Output[0].Parts[0].Thinking);
+        Assert.Equal(string.Empty, gen.Output[0].Parts[1].Text);
+    }
+
+    [Fact]
+    public void ShouldIncludeToolContent_InvalidEnumFailsClosed()
+    {
+        Assert.False(SigilClient.ShouldIncludeToolContent(
+            (ContentCaptureMode)99,
+            ContentCaptureMode.Full,
+            true,
+            ContentCaptureMode.Full,
+            true));
+        Assert.False(SigilClient.ShouldIncludeToolContent(
+            ContentCaptureMode.Default,
+            (ContentCaptureMode)99,
+            true,
+            ContentCaptureMode.Full,
+            true));
+    }
+
+    [Theory]
+    [InlineData(ContentCaptureMode.Default, false, false, false)]
+    [InlineData(ContentCaptureMode.Default, false, true, true)]
+    [InlineData(ContentCaptureMode.Full, false, false, true)]
+    [InlineData(ContentCaptureMode.Full, false, true, true)]
+    [InlineData(ContentCaptureMode.MetadataOnly, false, true, false)]
+    public void ShouldIncludeToolContent_NoContext(
+        ContentCaptureMode clientDefault,
+        bool ctxSet,
+        bool legacyInclude,
+        bool wantContent)
+    {
+        var got = SigilClient.ShouldIncludeToolContent(
+            ContentCaptureMode.Default,
+            ContentCaptureMode.Default,
+            ctxSet,
+            clientDefault,
+            legacyInclude);
+        Assert.Equal(wantContent, got);
+    }
+
+    [Theory]
+    [InlineData(ContentCaptureMode.MetadataOnly, true, true, false)]
+    [InlineData(ContentCaptureMode.Full, true, true, true)]
+    [InlineData(ContentCaptureMode.NoToolContent, true, false, false)]
+    [InlineData(ContentCaptureMode.NoToolContent, true, true, true)]
+    public void ShouldIncludeToolContent_WithContext(
+        ContentCaptureMode ctxMode,
+        bool ctxSet,
+        bool legacyInclude,
+        bool wantContent)
+    {
+        var got = SigilClient.ShouldIncludeToolContent(
+            ContentCaptureMode.Default,
+            ctxMode,
+            ctxSet,
+            ContentCaptureMode.Full,
+            legacyInclude);
+        Assert.Equal(wantContent, got);
+    }
+
+    [Theory]
+    [InlineData(ContentCaptureMode.Full, ContentCaptureMode.MetadataOnly, true, true)]
+    [InlineData(ContentCaptureMode.MetadataOnly, ContentCaptureMode.Full, true, false)]
+    public void ShouldIncludeToolContent_PerToolOverride(
+        ContentCaptureMode toolMode,
+        ContentCaptureMode ctxMode,
+        bool legacyInclude,
+        bool wantContent)
+    {
+        var got = SigilClient.ShouldIncludeToolContent(
+            toolMode,
+            ctxMode,
+            true,
+            ContentCaptureMode.Full,
+            legacyInclude);
+        Assert.Equal(wantContent, got);
+    }
+
+    [Fact]
+    public async Task ToolExecution_ClientDefault_LegacyFalse_Suppressed()
+    {
+        await using var env = new ContentCaptureEnv();
+        var recorder = env.Client.StartToolExecution(new ToolExecutionStart
+        {
+            ToolName = "test_tool",
+        });
+        recorder.SetResult(new ToolExecutionEnd
+        {
+            Arguments = "args",
+            Result = "result",
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var span = env.ToolSpan();
+        Assert.Null(span.GetTagItem(SigilClient.SpanAttrToolCallArguments));
+    }
+
+    [Fact]
+    public async Task ToolExecution_ClientFull_ContentIncluded()
+    {
+        await using var env = new ContentCaptureEnv(ContentCaptureMode.Full);
+        var recorder = env.Client.StartToolExecution(new ToolExecutionStart
+        {
+            ToolName = "test_tool",
+        });
+        recorder.SetResult(new ToolExecutionEnd
+        {
+            Arguments = "args",
+            Result = "result",
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var span = env.ToolSpan();
+        Assert.NotNull(span.GetTagItem(SigilClient.SpanAttrToolCallArguments));
+    }
+
+    [Fact]
+    public async Task ToolExecution_ClientMetadataOnly_LegacyTrue_Suppressed()
+    {
+        await using var env = new ContentCaptureEnv(ContentCaptureMode.MetadataOnly);
+#pragma warning disable CS0618
+        var recorder = env.Client.StartToolExecution(new ToolExecutionStart
+        {
+            ToolName = "test_tool",
+            IncludeContent = true,
+        });
+#pragma warning restore CS0618
+        recorder.SetResult(new ToolExecutionEnd
+        {
+            Arguments = "args",
+            Result = "result",
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var span = env.ToolSpan();
+        Assert.Null(span.GetTagItem(SigilClient.SpanAttrToolCallArguments));
+    }
+
+    [Fact]
+    public async Task ToolExecution_ClientMetadataOnly_DoesNotAttachConversationTitleToSpan()
+    {
+        await using var env = new ContentCaptureEnv(ContentCaptureMode.MetadataOnly);
+#pragma warning disable CS0618
+        var recorder = env.Client.StartToolExecution(new ToolExecutionStart
+        {
+            ToolName = "test_tool",
+            ToolDescription = "Sensitive internal tool prompt",
+            ConversationTitle = "Secret project discussion",
+            IncludeContent = true,
+        });
+#pragma warning restore CS0618
+        recorder.SetResult(new ToolExecutionEnd
+        {
+            Arguments = "args",
+            Result = "result",
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var span = env.ToolSpan();
+        Assert.Null(span.GetTagItem(SigilClient.SpanAttrToolDescription));
+        Assert.Null(span.GetTagItem(SigilClient.SpanAttrConversationTitle));
+        Assert.Null(span.GetTagItem(SigilClient.SpanAttrToolCallArguments));
+    }
+
+    [Fact]
+    public async Task ToolExecution_BackwardCompat_LegacyTrue_Included()
+    {
+        await using var env = new ContentCaptureEnv();
+#pragma warning disable CS0618
+        var recorder = env.Client.StartToolExecution(new ToolExecutionStart
+        {
+            ToolName = "test_tool",
+            IncludeContent = true,
+        });
+#pragma warning restore CS0618
+        recorder.SetResult(new ToolExecutionEnd
+        {
+            Arguments = "args",
+            Result = "result",
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var span = env.ToolSpan();
+        Assert.NotNull(span.GetTagItem(SigilClient.SpanAttrToolCallArguments));
+    }
+
+    [Fact]
+    public async Task ContextPropagation_GenerationSetsContextForToolExecution()
+    {
+        await using var env = new ContentCaptureEnv(ContentCaptureMode.MetadataOnly);
+
+        var genRecorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+        });
+
+        // Tool starts while generation is active — should inherit MetadataOnly from context.
+#pragma warning disable CS0618
+        var toolRecorder = env.Client.StartToolExecution(new ToolExecutionStart
+        {
+            ToolName = "test_tool",
+            IncludeContent = true,
+        });
+#pragma warning restore CS0618
+        toolRecorder.SetResult(new ToolExecutionEnd
+        {
+            Arguments = "args",
+            Result = "result",
+        });
+        toolRecorder.End();
+
+        genRecorder.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("hello") },
+            Output = { Message.AssistantTextMessage("world") },
+            Usage = new TokenUsage { InputTokens = 10, OutputTokens = 5 },
+        });
+        genRecorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var span = env.ToolSpan();
+        Assert.Null(span.GetTagItem(SigilClient.SpanAttrToolCallArguments));
+    }
+
+    [Fact]
+    public async Task ContextPropagation_FullOverridesParentMetadataOnly()
+    {
+        await using var env = new ContentCaptureEnv(ContentCaptureMode.MetadataOnly);
+
+        var genRecorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+            ContentCapture = ContentCaptureMode.Full,
+        });
+
+        // Tool starts under Full generation context.
+#pragma warning disable CS0618
+        var toolRecorder = env.Client.StartToolExecution(new ToolExecutionStart
+        {
+            ToolName = "test_tool",
+            IncludeContent = true,
+        });
+#pragma warning restore CS0618
+        toolRecorder.SetResult(new ToolExecutionEnd
+        {
+            Arguments = "args",
+            Result = "result",
+        });
+        toolRecorder.End();
+
+        genRecorder.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("hello") },
+            Output = { Message.AssistantTextMessage("world") },
+            Usage = new TokenUsage { InputTokens = 10, OutputTokens = 5 },
+        });
+        genRecorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var span = env.ToolSpan();
+        Assert.NotNull(span.GetTagItem(SigilClient.SpanAttrToolCallArguments));
+    }
+
+    [Fact]
+    public void IsContentStripped_DetectsMarker()
+    {
+        var gen = new Generation
+        {
+            Metadata = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                [SigilClient.MetadataKeyContentCaptureMode] = "metadata_only",
+            },
+        };
+        Assert.True(SigilClient.IsContentStripped(gen));
+    }
+
+    [Fact]
+    public void IsContentStripped_FalseWithoutMarker()
+    {
+        Assert.False(SigilClient.IsContentStripped(new Generation()));
+    }
+
+    [Fact]
+    public void IsContentStripped_FalseForOtherModes()
+    {
+        var gen = new Generation
+        {
+            Metadata = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                [SigilClient.MetadataKeyContentCaptureMode] = "full",
+            },
+        };
+        Assert.False(SigilClient.IsContentStripped(gen));
+    }
+
+    [Fact]
+    public async Task ToolExecution_PerToolOverride_Full()
+    {
+        await using var env = new ContentCaptureEnv(ContentCaptureMode.MetadataOnly);
+        var recorder = env.Client.StartToolExecution(new ToolExecutionStart
+        {
+            ToolName = "test_tool",
+            ContentCapture = ContentCaptureMode.Full,
+        });
+        recorder.SetResult(new ToolExecutionEnd
+        {
+            Arguments = "args",
+            Result = "result",
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var span = env.ToolSpan();
+        Assert.NotNull(span.GetTagItem(SigilClient.SpanAttrToolCallArguments));
+    }
+
+    [Fact]
+    public async Task ToolExecution_PerToolOverrideDoesNotInvokeResolver()
+    {
+        var calls = 0;
+        await using var env = new ContentCaptureEnv(
+            ContentCaptureMode.Default,
+            _ =>
+            {
+                calls++;
+                return ContentCaptureMode.MetadataOnly;
+            });
+        var recorder = env.Client.StartToolExecution(new ToolExecutionStart
+        {
+            ToolName = "test_tool",
+            ContentCapture = ContentCaptureMode.Full,
+        });
+        recorder.SetResult(new ToolExecutionEnd
+        {
+            Arguments = "args",
+            Result = "result",
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var span = env.ToolSpan();
+        Assert.Equal(0, calls);
+        Assert.NotNull(span.GetTagItem(SigilClient.SpanAttrToolCallArguments));
+    }
+
+    [Fact]
+    public async Task ToolExecution_ContextDoesNotInvokeResolver()
+    {
+        var calls = 0;
+        await using var env = new ContentCaptureEnv(
+            ContentCaptureMode.Default,
+            _ =>
+            {
+                calls++;
+                return ContentCaptureMode.MetadataOnly;
+            });
+        var genRecorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+            ContentCapture = ContentCaptureMode.Full,
+        });
+
+        var toolRecorder = env.Client.StartToolExecution(new ToolExecutionStart
+        {
+            ToolName = "test_tool",
+        });
+        toolRecorder.SetResult(new ToolExecutionEnd
+        {
+            Arguments = "args",
+            Result = "result",
+        });
+        toolRecorder.End();
+
+        genRecorder.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("hello") },
+            Output = { Message.AssistantTextMessage("world") },
+            Usage = new TokenUsage { InputTokens = 10, OutputTokens = 5 },
+        });
+        genRecorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        var span = env.ToolSpan();
+        Assert.Equal(0, calls);
+        Assert.NotNull(span.GetTagItem(SigilClient.SpanAttrToolCallArguments));
+    }
+
+    [Fact]
+    public void IsContentStripped_DetectsJsonElementMarker()
+    {
+        // After DeepClone (JSON round-trip), string values in metadata become JsonElement.
+        var gen = new Generation
+        {
+            Metadata = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                [SigilClient.MetadataKeyContentCaptureMode] = JsonDocument.Parse("\"metadata_only\"").RootElement,
+            },
+        };
+        Assert.True(SigilClient.IsContentStripped(gen));
+    }
+
+    [Fact]
+    public void IsContentStripped_FalseForNonMetadataOnlyJsonElement()
+    {
+        var gen = new Generation
+        {
+            Metadata = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                [SigilClient.MetadataKeyContentCaptureMode] = JsonDocument.Parse("\"full\"").RootElement,
+            },
+        };
+        Assert.False(SigilClient.IsContentStripped(gen));
+    }
+
+    [Fact]
+    public void CallContentCaptureResolver_PassesNullMetadataThrough()
+    {
+        IReadOnlyDictionary<string, object?>? received = new Dictionary<string, object?>();
+        SigilClient.CallContentCaptureResolver(
+            metadata =>
+            {
+                received = metadata;
+                return ContentCaptureMode.Full;
+            },
+            null);
+        Assert.Null(received);
+    }
+
+    [Fact]
+    public void CallContentCaptureResolver_InvalidEnumFailsClosed()
+    {
+        var got = SigilClient.CallContentCaptureResolver(
+            _ => (ContentCaptureMode)99,
+            null);
+        Assert.Equal(ContentCaptureMode.MetadataOnly, got);
+    }
+
+    [Fact]
+    public void CallContentCaptureResolver_LogsOnException()
+    {
+        List<string> logged = [];
+        SigilClient.CallContentCaptureResolver(
+            _ => throw new InvalidOperationException("resolver bug"),
+            null,
+            msg => logged.Add(msg));
+        Assert.Single(logged);
+        Assert.Contains("resolver bug", logged[0]);
+    }
+
+    [Fact]
+    public void CallContentCaptureResolver_LogsOnInvalidEnum()
+    {
+        List<string> logged = [];
+        SigilClient.CallContentCaptureResolver(
+            _ => (ContentCaptureMode)99,
+            null,
+            msg => logged.Add(msg));
+        Assert.Single(logged);
+        Assert.Contains("undefined mode", logged[0]);
+    }
+
+    [Fact]
+    public async Task OverlappingGenerations_NonLifoCompletion()
+    {
+        // When two generations overlap on the same async flow and the older one
+        // ends first, the newer generation's mode should still be active in context.
+        await using var env = new ContentCaptureEnv(ContentCaptureMode.Full);
+
+        var genA = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+            ContentCapture = ContentCaptureMode.MetadataOnly,
+        });
+
+        var genB = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+            ContentCapture = ContentCaptureMode.Full,
+        });
+
+        // genA ends first (non-LIFO order).
+        genA.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("hello") },
+            Output = { Message.AssistantTextMessage("world") },
+            Usage = new TokenUsage { InputTokens = 10, OutputTokens = 5 },
+        });
+        genA.End();
+
+        // Tool starts after genA ended but while genB is still active.
+        // Should see genB's Full mode, not be wiped by genA's disposal.
+        var toolRecorder = env.Client.StartToolExecution(new ToolExecutionStart
+        {
+            ToolName = "test_tool",
+            ContentCapture = ContentCaptureMode.Default,
+        });
+        toolRecorder.SetResult(new ToolExecutionEnd
+        {
+            Arguments = "args",
+            Result = "result",
+        });
+        toolRecorder.End();
+
+        genB.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("hello") },
+            Output = { Message.AssistantTextMessage("world") },
+            Usage = new TokenUsage { InputTokens = 10, OutputTokens = 5 },
+        });
+        genB.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        // genB was Full, so tool content should have been included.
+        var span = env.ToolSpan();
+        Assert.NotNull(span.GetTagItem(SigilClient.SpanAttrToolCallArguments));
+    }
+
+    [Fact]
+    public async Task Resolver_ReceivesOriginalMetadataTypes()
+    {
+        // The resolver should receive original metadata types (string, bool, long),
+        // not JsonElement values from DeepClone's JSON round-trip.
+        Type? receivedType = null;
+        await using var env = new ContentCaptureEnv(
+            ContentCaptureMode.Default,
+            metadata =>
+            {
+                if (metadata != null && metadata.TryGetValue("tenant_id", out var val))
+                {
+                    receivedType = val?.GetType();
+                }
+                return ContentCaptureMode.Full;
+            });
+
+        var recorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+            Metadata = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["tenant_id"] = "my-tenant",
+            },
+        });
+        recorder.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("hello") },
+            Output = { Message.AssistantTextMessage("world") },
+            Usage = new TokenUsage { InputTokens = 10, OutputTokens = 5 },
+        });
+        recorder.End();
+
+        await env.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(receivedType);
+        Assert.Equal(typeof(string), receivedType);
+    }
+
+    [Fact]
+    public async Task SubmitConversationRating_DoesNotMutateCallerRequest()
+    {
+        await using var env = new ContentCaptureEnv(ContentCaptureMode.MetadataOnly);
+
+        var request = new SubmitConversationRatingRequest
+        {
+            RatingId = "r1",
+            Rating = ConversationRatingValue.Good,
+            Comment = "great answer",
+        };
+
+        try
+        {
+            await env.Client.SubmitConversationRatingAsync("conv-1", request, TestContext.Current.CancellationToken);
+        }
+        catch (RatingTransportException)
+        {
+            // Rating submission may fail (no API endpoint) but the mutation
+            // test is about the request object, not the HTTP call.
+        }
+
+        Assert.Equal("great answer", request.Comment);
+    }
+
+    private static Generation MakeTestGeneration()
+    {
+        return new Generation
+        {
+            Id = "gen-1",
+            ConversationId = "conv-1",
+            AgentName = "test-agent",
+            AgentVersion = "1.0",
+            Mode = GenerationMode.Sync,
+            Model = new ModelRef { Provider = "anthropic", Name = "claude-sonnet-4-5" },
+            SystemPrompt = "You are helpful.",
+            Input =
+            {
+                new Message
+                {
+                    Role = MessageRole.User,
+                    Parts = { Part.TextPart("What is the weather?") },
+                },
+                new Message
+                {
+                    Role = MessageRole.Tool,
+                    Parts =
+                    {
+                        Part.ToolResultPart(new ToolResult
+                        {
+                            ToolCallId = "call_1",
+                            Name = "weather",
+                            Content = "sunny 18C",
+                            ContentJson = Encoding.UTF8.GetBytes("{\"temp\":18}"),
+                        }),
+                    },
+                },
+            },
+            Output =
+            {
+                new Message
+                {
+                    Role = MessageRole.Assistant,
+                    Parts =
+                    {
+                        Part.ThinkingPart("let me think about weather"),
+                        Part.ToolCallPart(new ToolCall
+                        {
+                            Id = "call_1",
+                            Name = "weather",
+                            InputJson = Encoding.UTF8.GetBytes("{\"city\":\"Paris\"}"),
+                        }),
+                        Part.TextPart("It's 18C and sunny in Paris."),
+                    },
+                },
+            },
+            Tools =
+            {
+                new ToolDefinition
+                {
+                    Name = "weather",
+                    Description = "Get weather info",
+                    Type = "function",
+                    InputSchemaJson = Encoding.UTF8.GetBytes("{\"type\":\"object\"}"),
+                },
+            },
+            Usage = new TokenUsage { InputTokens = 120, OutputTokens = 42 },
+            StopReason = "end_turn",
+            CallError = "rate limit exceeded: prompt too long for model",
+            Artifacts =
+            {
+                Artifact.JsonArtifact(ArtifactKind.Request, "request", new { ok = true }),
+            },
+            Metadata = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["sigil.sdk.name"] = "sdk-dotnet",
+                ["call_error"] = "rate limit exceeded: prompt too long for model",
+            },
+        };
+    }
+
+    private sealed class ContentCaptureEnv : IAsyncDisposable
+    {
+        private bool _shutdown;
+        private readonly ActivityListener _activityListener;
+
+        public GrpcIngestServer Ingest { get; }
+        public SigilClient Client { get; }
+        public ConcurrentQueue<Activity> Spans { get; } = new();
+
+        public ContentCaptureEnv(
+            ContentCaptureMode clientMode = ContentCaptureMode.Default,
+            Func<IReadOnlyDictionary<string, object?>?, ContentCaptureMode>? resolver = null)
+        {
+            _activityListener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == SigilClient.InstrumentationName,
+                Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = activity => Spans.Enqueue(activity),
+            };
+            ActivitySource.AddActivityListener(_activityListener);
+
+            Ingest = new GrpcIngestServer();
+            Client = new SigilClient(new SigilClientConfig
+            {
+                ContentCapture = clientMode,
+                ContentCaptureResolver = resolver,
+                GenerationExport = new GenerationExportConfig
+                {
+                    Protocol = GenerationExportProtocol.Grpc,
+                    Endpoint = $"127.0.0.1:{Ingest.Port}",
+                    Insecure = true,
+                    BatchSize = 1,
+                    QueueSize = 10,
+                    FlushInterval = TimeSpan.FromHours(1),
+                    MaxRetries = 1,
+                    InitialBackoff = TimeSpan.FromMilliseconds(1),
+                    MaxBackoff = TimeSpan.FromMilliseconds(2),
+                },
+            });
+        }
+
+        public async Task ShutdownAsync(CancellationToken cancellationToken = default)
+        {
+            if (_shutdown) return;
+            _shutdown = true;
+            await Client.ShutdownAsync(cancellationToken);
+            _activityListener.Dispose();
+            Ingest.Dispose();
+        }
+
+        public SigilProto.Generation SingleGeneration()
+        {
+            Assert.Single(Ingest.Requests);
+            Assert.Single(Ingest.Requests[0].Request.Generations);
+            return Ingest.Requests[0].Request.Generations[0];
+        }
+
+        public Activity ToolSpan()
+        {
+            var span = Spans
+                .Where(a => a.GetTagItem("gen_ai.operation.name")?.ToString() == "execute_tool")
+                .LastOrDefault();
+            Assert.NotNull(span);
+            return span!;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await ShutdownAsync();
+        }
+    }
+}


### PR DESCRIPTION
- Add `ContentCaptureMode` (`Full`, `NoToolContent`, `MetadataOnly`) to control what content leaves the process via generation export and OTel spans
- Config-level defaults, per-recording overrides, resolver callbacks, AsyncLocal context propagation to child tool executions
- `MetadataOnly` strips all sensitive content from payloads: text, thinking, tool I/O, artifacts, conversation titles, raw error messages
- Backward-compatible: `Default` resolves to `NoToolContent`; legacy `IncludeContent` still works via bridging in `ShouldIncludeToolContent`

**Updated PR body — Resolution precedence section**

No code changes needed — the in-code comment at `SigilClient.cs:257` already matches the current behavior. Only the PR body's `Resolution precedence` section needs updating to reflect what the code actually does.

#### Resolution precedence

For tool executions:
1. Per-recording `ContentCapture` on `ToolExecutionStart`
2. AsyncLocal context from parent generation
3. `ContentCaptureResolver` callback
4. `SigilClientConfig.ContentCapture`

For generations (no parent context):
1. Per-recording `ContentCapture` on `GenerationStart`
2. `ContentCaptureResolver` callback
3. `SigilClientConfig.ContentCapture`

Resolver exceptions fail-closed to `MetadataOnly`. Invalid enum values fail-closed to `MetadataOnly`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what data is exported to telemetry/export pipelines and how errors are recorded; mistakes could either leak sensitive content or overly strip useful diagnostics across generation/tool flows.
> 
> **Overview**
> Adds a new `ContentCaptureMode` (client default, per-generation/per-tool overrides, optional metadata-based resolver, and AsyncLocal propagation) to control what content leaves the process via generation export and OTel spans.
> 
> When set to `MetadataOnly`, the SDK now strips prompts/messages/thinking/tool I/O/artifacts/conversation titles from exported `Generation` payloads, marks the mode in `generation.Metadata`, and redacts exception messages/stack traces and span status descriptions to avoid leaking sensitive content. Tool executions bridge the legacy `IncludeContent` flag (now obsolete) through the resolved mode, and generation validation is relaxed to accept structurally-valid but empty text/thinking parts when content has been stripped.
> 
> Also includes `netstandard2.0` `IsExternalInit` polyfill, makes conversation rating normalization null-safe and strips rating comments under `MetadataOnly`, exposes internals to the test assembly, and adds extensive test coverage for mode resolution/precedence, stripping, and redaction behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4624a994cac7ffbaa149a4a9941743371b8fb3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->