### PR TITLE
fix(langgraph): unwrap ToolMessage before serialization in on_tool_end

### DIFF
--- a/python-frameworks/langchain/sigil_sdk_langchain/handler.py
+++ b/python-frameworks/langchain/sigil_sdk_langchain/handler.py
@@ -19,23 +19,6 @@ except ModuleNotFoundError:  # pragma: no cover - handled by package dependency 
         """Fallback async base class when langchain-core is unavailable."""
 
 
-def _extract_tool_output(output: Any) -> Any:
-    """Extract serializable content from LangChain tool output.
-
-    LangChain's on_tool_end receives the raw output which may be a
-    ToolMessage or other BaseMessage subclass that isn't directly JSON
-    serializable. Extract the .content string when available.
-    """
-    if output is None:
-        return output
-    if isinstance(output, str):
-        return output
-    # Handle LangChain BaseMessage subclasses (ToolMessage, AIMessage, etc.)
-    if hasattr(output, "content"):
-        return output.content
-    return output
-
-
 _framework_name = "langchain"
 _framework_source = "handler"
 _framework_language = "python"
@@ -167,7 +150,7 @@ class SigilLangChainHandler(_SigilLangChainBase, BaseCallbackHandler):
         )
 
     def on_tool_end(self, output: Any, *, run_id: UUID, **_kwargs: Any) -> None:
-        self._on_tool_end(output=_extract_tool_output(output), run_id=run_id)
+        self._on_tool_end(output=output, run_id=run_id)
 
     def on_tool_error(self, error: BaseException, *, run_id: UUID, **_kwargs: Any) -> None:
         self._on_tool_error(error=error, run_id=run_id)
@@ -302,7 +285,7 @@ class SigilAsyncLangChainHandler(_SigilLangChainBase, AsyncCallbackHandler):
         )
 
     async def on_tool_end(self, output: Any, *, run_id: UUID, **_kwargs: Any) -> None:
-        self._on_tool_end(output=_extract_tool_output(output), run_id=run_id)
+        self._on_tool_end(output=output, run_id=run_id)
 
     async def on_tool_error(self, error: BaseException, *, run_id: UUID, **_kwargs: Any) -> None:
         self._on_tool_error(error=error, run_id=run_id)

--- a/python-frameworks/langchain/tests/test_langchain_handler.py
+++ b/python-frameworks/langchain/tests/test_langchain_handler.py
@@ -18,7 +18,6 @@ from sigil_sdk_langchain import (
     create_sigil_langchain_handler,
     with_sigil_langchain_callbacks,
 )
-from sigil_sdk_langchain.handler import _extract_tool_output
 
 
 class _CapturingExporter:
@@ -335,45 +334,6 @@ def test_langchain_async_handler_records_generation() -> None:
         generation = exporter.requests[0].generations[0]
         assert generation.tags["sigil.framework.name"] == "langchain"
         assert generation.model.provider == "openai"
-    finally:
-        client.shutdown()
-
-
-def test_extract_tool_output_unwraps_message_content_and_preserves_plain_values() -> None:
-    class _FakeToolMessage:
-        def __init__(self, content):
-            self.content = content
-
-    payload = {"temp_c": 18}
-
-    assert _extract_tool_output(_FakeToolMessage("tool result text")) == "tool result text"
-    assert _extract_tool_output("plain string") == "plain string"
-    assert _extract_tool_output(None) is None
-    assert _extract_tool_output(payload) is payload
-
-
-def test_langchain_tool_end_extracts_message_content_before_recording() -> None:
-    exporter = _CapturingExporter()
-    client = _new_client(exporter)
-
-    class _FakeToolMessage:
-        def __init__(self, content):
-            self.content = content
-
-    try:
-        handler = SigilLangChainHandler(client=client)
-        captured: dict[str, object] = {}
-
-        def _capture_tool_end(*, output, run_id) -> None:
-            captured["output"] = output
-            captured["run_id"] = run_id
-
-        handler._on_tool_end = _capture_tool_end  # type: ignore[method-assign]
-
-        run_id = uuid4()
-        handler.on_tool_end(_FakeToolMessage("tool result text"), run_id=run_id)
-
-        assert captured == {"output": "tool result text", "run_id": run_id}
     finally:
         client.shutdown()
 

--- a/python/sigil_sdk/framework_handler.py
+++ b/python/sigil_sdk/framework_handler.py
@@ -29,6 +29,24 @@ from sigil_sdk.usage import map_usage
 
 ProviderResolver = str | Callable[[str, dict[str, Any] | None, dict[str, Any] | None], str]
 
+
+def _extract_tool_output(output: Any) -> Any:
+    """Unwrap BaseMessage subclasses (e.g. ToolMessage) to their ``.content``.
+
+    Callback-based frameworks such as LangChain and LangGraph may deliver a
+    ``BaseMessage`` object to ``on_tool_end``.  These are not JSON-serialisable,
+    so we extract the ``.content`` attribute when present.  Plain strings,
+    ``None``, and other already-serialisable values pass through unchanged.
+    """
+    if output is None:
+        return output
+    if isinstance(output, str):
+        return output
+    if hasattr(output, "content"):
+        return output.content
+    return output
+
+
 _default_framework_source = "handler"
 _default_framework_language = "python"
 _default_framework_instrumentation_name = "github.com/grafana/sigil/sdks/python/frameworks"
@@ -427,7 +445,7 @@ class SigilFrameworkHandlerBase:
             if run_state.arguments is not None:
                 payload["arguments"] = run_state.arguments
             if run_state.capture_outputs:
-                payload["result"] = output
+                payload["result"] = _extract_tool_output(output)
             run_state.recorder.set_result(**payload)
         finally:
             run_state.recorder.end()

--- a/python/tests/test_framework_handler.py
+++ b/python/tests/test_framework_handler.py
@@ -1,0 +1,19 @@
+"""Unit tests for framework_handler utilities."""
+
+from __future__ import annotations
+
+from sigil_sdk.framework_handler import _extract_tool_output
+
+
+class _FakeToolMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+def test_extract_tool_output_unwraps_content_and_preserves_plain_values() -> None:
+    payload = {"temp_c": 18}
+
+    assert _extract_tool_output(_FakeToolMessage("tool result text")) == "tool result text"
+    assert _extract_tool_output("plain string") == "plain string"
+    assert _extract_tool_output(None) is None
+    assert _extract_tool_output(payload) is payload


### PR DESCRIPTION
LangGraph's `on_tool_end` receives ToolMessage objects that aren't JSON serializable, causing `_serialize_tool_content` to error and mark spans with StatusCode.ERROR. The LangChain handler already handled this but the LangGraph handler not.

Add `_extract_tool_output` to unwrap `.content` from message objects at both sync and async `on_tool_end` call sites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to tool result serialization/recording plus test relocation; main risk is subtle behavior differences if callers relied on non-string tool outputs being preserved.
> 
> **Overview**
> Fixes tool execution result recording when callback frameworks return non-JSON-serializable message objects (e.g. LangChain/LangGraph `ToolMessage`).
> 
> Moves `_extract_tool_output` into the shared `SigilFrameworkHandlerBase` path and applies it in `_on_tool_end` so tool results are always unwrapped to `.content` when present; LangChain sync/async handlers now pass raw `output` through and LangChain-specific extractor tests are removed in favor of a new core unit test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c47dbcd4c8a065adef62c395bcf9636b10befe13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->