### PR TITLE
feat: add pii redaction gitleaks shared util for python sdks

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -64,6 +64,10 @@ llamaindex_config = with_sigil_llamaindex_callbacks(None, client=client, provide
 google_adk_agent_config = with_sigil_google_adk_callbacks(None, client=client, provider_resolver="auto")
 ```
 
+Framework handlers use the `Client` instance you pass in. If that client is configured with
+`generation_sanitizer`, the same redaction policy applies automatically to generations recorded
+through LangChain, LangGraph, OpenAI Agents, LlamaIndex, and Google ADK integrations.
+
 Framework handlers inject framework tags/metadata on recorded generations:
 
 - `sigil.framework.name` (`langchain`, `langgraph`, `openai-agents`, `llamaindex`, or `google-adk`)
@@ -143,6 +147,50 @@ with client.start_generation(
         raise rec.err()
 
 client.shutdown()
+```
+
+## Pre-Ingest Redaction
+
+Use `generation_sanitizer` when you want to redact substrings from normalized generations before
+validation, span sync, and export.
+
+```python
+from sigil_sdk import (
+    Client,
+    ClientConfig,
+    SecretRedactionOptions,
+    create_secret_redaction_sanitizer,
+)
+
+client = Client(
+    ClientConfig(
+        generation_sanitizer=create_secret_redaction_sanitizer(
+            SecretRedactionOptions(
+                redact_input_messages=False,
+                redact_email_addresses=True,
+            )
+        )
+    )
+)
+```
+
+The built-in sanitizer:
+
+- redacts high-confidence secret formats in assistant text and thinking
+- redacts secret formats plus env-style secret values in tool call inputs and tool results
+- redacts email addresses by default
+- leaves user input unchanged unless `redact_input_messages=True` is set
+
+To preserve email addresses, opt out explicitly:
+
+```python
+client = Client(
+    ClientConfig(
+        generation_sanitizer=create_secret_redaction_sanitizer(
+            SecretRedactionOptions(redact_email_addresses=False)
+        )
+    )
+)
 ```
 
 Configure OTEL exporters (traces/metrics) in your application OTEL SDK setup. You can optionally pass `tracer` and `meter` via `ClientConfig`.

--- a/python/sigil_sdk/__init__.py
+++ b/python/sigil_sdk/__init__.py
@@ -1,7 +1,15 @@
 """Public exports for the Sigil Python SDK."""
 
 from .client import Client
-from .config import ApiConfig, AuthConfig, ClientConfig, EmbeddingCaptureConfig, GenerationExportConfig, default_config
+from .config import (
+    ApiConfig,
+    AuthConfig,
+    ClientConfig,
+    EmbeddingCaptureConfig,
+    GenerationExportConfig,
+    GenerationSanitizer,
+    default_config,
+)
 from .context import (
     agent_name_from_context,
     agent_version_from_context,
@@ -60,6 +68,7 @@ from .models import (
     tool_result_part,
     user_text_message,
 )
+from .redaction import SecretRedactionOptions, create_secret_redaction_sanitizer
 from .validation import validate_embedding_result, validate_embedding_start, validate_generation
 
 __all__ = [
@@ -81,6 +90,7 @@ __all__ = [
     "EnqueueError",
     "Generation",
     "GenerationExportConfig",
+    "GenerationSanitizer",
     "GenerationMode",
     "GenerationStart",
     "MappingError",
@@ -94,6 +104,7 @@ __all__ = [
     "RatingConflictError",
     "RatingTransportError",
     "SigilError",
+    "SecretRedactionOptions",
     "SubmitConversationRatingResponse",
     "TokenUsage",
     "ToolCall",
@@ -106,6 +117,7 @@ __all__ = [
     "agent_version_from_context",
     "assistant_text_message",
     "content_capture_mode_from_context",
+    "create_secret_redaction_sanitizer",
     "conversation_id_from_context",
     "conversation_title_from_context",
     "text_part",

--- a/python/sigil_sdk/client.py
+++ b/python/sigil_sdk/client.py
@@ -898,8 +898,8 @@ class GenerationRecorder:
             _apply_trace_context_from_span(self.span, generation)
 
             effective_content_capture_mode = self._content_capture_mode
-            validation_target = copy.deepcopy(generation)
             _stamp_content_capture_metadata(generation, self._content_capture_mode)
+            validation_target = copy.deepcopy(generation)
             if self._content_capture_mode == ContentCaptureMode.METADATA_ONLY:
                 error_cat = _error_category_from_exception(call_error, fallback_sdk=True) if call_error else ""
                 _strip_content(generation, error_cat)

--- a/python/sigil_sdk/client.py
+++ b/python/sigil_sdk/client.py
@@ -623,6 +623,18 @@ class Client:
         except Exception as exc:  # noqa: BLE001
             self._log_warn("sigil generation export failed", exc)
 
+    def _has_generation_sanitizer(self) -> bool:
+        return self._config.generation_sanitizer is not None
+
+    def _sanitize_generation(self, generation: Generation) -> Generation:
+        sanitizer = self._config.generation_sanitizer
+        if sanitizer is None:
+            return generation
+        sanitized = sanitizer(copy.deepcopy(generation))
+        if sanitized is None:
+            raise ValueError("generation sanitizer must return a generation")
+        return copy.deepcopy(sanitized)
+
     def _flush_internal(self) -> None:
         with self._flush_lock:
             while True:
@@ -885,17 +897,38 @@ class GenerationRecorder:
             generation = self._normalize_generation(result, completed_at, call_error)
             _apply_trace_context_from_span(self.span, generation)
 
+            effective_content_capture_mode = self._content_capture_mode
+            validation_target = copy.deepcopy(generation)
             _stamp_content_capture_metadata(generation, self._content_capture_mode)
             if self._content_capture_mode == ContentCaptureMode.METADATA_ONLY:
                 error_cat = _error_category_from_exception(call_error, fallback_sdk=True) if call_error else ""
                 _strip_content(generation, error_cat)
+            elif self.client._has_generation_sanitizer():
+                try:
+                    generation = self.client._sanitize_generation(generation)
+                    validation_target = copy.deepcopy(generation)
+                except Exception:  # noqa: BLE001
+                    effective_content_capture_mode = ContentCaptureMode.METADATA_ONLY
+                    error_cat = _error_category_from_exception(call_error, fallback_sdk=True) if call_error else ""
+                    _strip_content(generation, error_cat)
+                    _stamp_content_capture_metadata(generation, effective_content_capture_mode)
+                    if self.client._config.logger is not None:
+                        self.client._config.logger.warning(
+                            "sigil: generation sanitization failed, falling back to metadata_only",
+                            exc_info=True,
+                        )
 
             self.span.update_name(_generation_span_name(generation.operation_name, generation.model.name))
             _set_generation_span_attributes(self.span, generation)
+            if (
+                effective_content_capture_mode == ContentCaptureMode.METADATA_ONLY
+                and self._content_capture_mode != ContentCaptureMode.METADATA_ONLY
+            ):
+                self.span.set_attribute(_span_attr_conversation_title, "")
 
             local_error: Exception | None = None
             try:
-                validate_generation(generation)
+                validate_generation(validation_target)
             except Exception as exc:  # noqa: BLE001
                 local_error = ValidationError(f"sigil: generation validation failed: {exc}")
 
@@ -909,7 +942,7 @@ class GenerationRecorder:
                 except Exception as exc:  # noqa: BLE001
                     local_error = EnqueueError(f"sigil: generation enqueue failed: {exc}")
 
-            is_metadata_only = self._content_capture_mode == ContentCaptureMode.METADATA_ONLY
+            is_metadata_only = effective_content_capture_mode == ContentCaptureMode.METADATA_ONLY
 
             if not is_metadata_only:
                 if call_error is not None:

--- a/python/sigil_sdk/config.py
+++ b/python/sigil_sdk/config.py
@@ -14,10 +14,11 @@ from opentelemetry.metrics import Meter
 from opentelemetry.trace import Tracer
 
 from .exporters.base import GenerationExporter
-from .models import ContentCaptureMode, utc_now
+from .models import ContentCaptureMode, Generation, utc_now
 
 TENANT_HEADER = "X-Scope-OrgID"
 AUTHORIZATION_HEADER = "Authorization"
+GenerationSanitizer = Callable[[Generation], Generation]
 
 
 @dataclass(slots=True)
@@ -74,6 +75,7 @@ class ClientConfig:
     embedding_capture: EmbeddingCaptureConfig = field(default_factory=EmbeddingCaptureConfig)
     content_capture: ContentCaptureMode = ContentCaptureMode.DEFAULT
     content_capture_resolver: Callable[[dict[str, Any]], ContentCaptureMode] | None = None
+    generation_sanitizer: GenerationSanitizer | None = None
     tracer: Tracer | None = None
     meter: Meter | None = None
     logger: logging.Logger | None = None

--- a/python/sigil_sdk/redaction.py
+++ b/python/sigil_sdk/redaction.py
@@ -1,0 +1,186 @@
+"""
+Secret redaction engine for Sigil content capture.
+
+~20 high-confidence patterns hand-curated from Gitleaks
+(https://github.com/gitleaks/gitleaks). Two tiers:
+  - Tier 1: definite secret formats and optional email addresses
+    used by both redact() and redact_lightweight()
+  - Tier 2: heuristic env patterns
+    used only by redact()
+
+Add more patterns when concrete unredacted secrets are observed.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+from dataclasses import dataclass
+
+from .config import GenerationSanitizer
+from .models import Generation, Message, MessageRole, Part, PartKind
+
+
+@dataclass(frozen=True, slots=True)
+class _SecretPattern:
+    id: str
+    regex: re.Pattern[str]
+
+
+@dataclass(frozen=True, slots=True)
+class SecretRedactionOptions:
+    """
+    Options for the built-in secret redaction sanitizer.
+
+    `redact_input_messages` defaults to False to match the current opencode
+    plugin behavior.
+
+    `redact_email_addresses` defaults to True. Callers can opt out when email
+    addresses should be preserved.
+    """
+
+    redact_input_messages: bool = False
+    redact_email_addresses: bool = True
+
+
+# --- Tier 1: High-confidence patterns (definite secret formats) ---
+_TIER1_PATTERNS: tuple[_SecretPattern, ...] = (
+    _SecretPattern("grafana-cloud-token", re.compile(r"\bglc_[A-Za-z0-9_-]{20,}")),
+    _SecretPattern("grafana-service-account-token", re.compile(r"\bglsa_[A-Za-z0-9_-]{20,}")),
+    _SecretPattern("aws-access-token", re.compile(r"\b(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z2-7]{16}\b")),
+    _SecretPattern("github-pat", re.compile(r"\bghp_[A-Za-z0-9_]{36,}")),
+    _SecretPattern("github-oauth", re.compile(r"\bgho_[A-Za-z0-9_]{36,}")),
+    _SecretPattern("github-app-token", re.compile(r"\bghs_[A-Za-z0-9_]{36,}")),
+    _SecretPattern("github-fine-grained-pat", re.compile(r"\bgithub_pat_[A-Za-z0-9_]{82}")),
+    _SecretPattern("anthropic-api-key", re.compile(r"\bsk-ant-api03-[a-zA-Z0-9_-]{93}AA")),
+    _SecretPattern("anthropic-admin-key", re.compile(r"\bsk-ant-admin01-[a-zA-Z0-9_-]{93}AA")),
+    _SecretPattern("openai-api-key", re.compile(r"\bsk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20}")),
+    _SecretPattern("openai-project-key", re.compile(r"\bsk-proj-[a-zA-Z0-9_-]{40,}")),
+    _SecretPattern("openai-svcacct-key", re.compile(r"\bsk-svcacct-[a-zA-Z0-9_-]{40,}")),
+    _SecretPattern("gcp-api-key", re.compile(r"\bAIza[A-Za-z0-9_-]{35}")),
+    _SecretPattern(
+        "private-key",
+        re.compile(r"-----BEGIN[A-Z ]*PRIVATE KEY-----[\s\S]*?-----END[A-Z ]*PRIVATE KEY-----"),
+    ),
+    _SecretPattern("connection-string", re.compile(r"(?:postgres|mysql|mongodb|redis|amqp):\/\/[^\s'\"]+@[^\s'\"]+")),
+    _SecretPattern("bearer-token", re.compile(r"[Bb]earer\s+[A-Za-z0-9_.\-~+/]{20,}={0,3}")),
+    _SecretPattern("slack-token", re.compile(r"\bxox[bporas]-[A-Za-z0-9-]{10,}")),
+    _SecretPattern("stripe-key", re.compile(r"\b[sr]k_(?:live|test)_[A-Za-z0-9]{20,}")),
+    _SecretPattern("sendgrid-api-key", re.compile(r"\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}")),
+    _SecretPattern("twilio-api-key", re.compile(r"\bSK[a-f0-9]{32}")),
+    _SecretPattern("npm-token", re.compile(r"\bnpm_[A-Za-z0-9]{36}")),
+    _SecretPattern("pypi-token", re.compile(r"\bpypi-[A-Za-z0-9_-]{50,}")),
+)
+
+_EMAIL_PATTERN = _SecretPattern("email", re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE))
+
+# --- Tier 2: Heuristic patterns (env file values) ---
+_TIER2_PATTERNS: tuple[_SecretPattern, ...] = (
+    _SecretPattern(
+        "env-secret-value",
+        re.compile(
+            r"((?:PASSWORD|SECRET|TOKEN|KEY|CREDENTIAL|API_KEY|PRIVATE_KEY|ACCESS_KEY)\s*[=:]\s*)(\S+)",
+            re.IGNORECASE,
+        ),
+    ),
+)
+
+
+class _SecretRedactor:
+    """Regex-based redactor with full and lightweight modes."""
+
+    def __init__(self, include_email_addresses: bool) -> None:
+        self._include_email_addresses = include_email_addresses
+
+    # Full redaction: tier 1 + tier 2. Use for tool call args and tool results.
+    def redact(self, text: str) -> str:
+        result = _apply_patterns(text, _TIER1_PATTERNS)
+        if self._include_email_addresses:
+            result = _apply_pattern(result, _EMAIL_PATTERN)
+        return _apply_tier2_patterns(result)
+
+    # Lightweight redaction: tier 1 only. Use for assistant text and reasoning.
+    def redact_lightweight(self, text: str) -> str:
+        result = _apply_patterns(text, _TIER1_PATTERNS)
+        if self._include_email_addresses:
+            result = _apply_pattern(result, _EMAIL_PATTERN)
+        return result
+
+
+def create_secret_redaction_sanitizer(
+    options: SecretRedactionOptions | None = None,
+) -> GenerationSanitizer:
+    """Returns a reusable generation sanitizer that redacts known secret formats."""
+
+    resolved = options or SecretRedactionOptions()
+    redactor = _SecretRedactor(include_email_addresses=resolved.redact_email_addresses)
+
+    def _sanitize(generation: Generation) -> Generation:
+        sanitized = copy.deepcopy(generation)
+
+        for message in sanitized.input:
+            mode = "full" if message.role == MessageRole.USER and resolved.redact_input_messages else "none"
+            _sanitize_message(message, redactor, mode)
+
+        for message in sanitized.output:
+            if message.role == MessageRole.ASSISTANT:
+                mode = "light"
+            elif message.role == MessageRole.TOOL:
+                mode = "full"
+            else:
+                mode = "none"
+            _sanitize_message(message, redactor, mode)
+
+        return sanitized
+
+    return _sanitize
+
+
+def _sanitize_message(message: Message, redactor: _SecretRedactor, default_text_mode: str) -> None:
+    for part in message.parts:
+        _sanitize_part(part, redactor, default_text_mode)
+
+
+def _sanitize_part(part: Part, redactor: _SecretRedactor, default_text_mode: str) -> None:
+    if part.kind == PartKind.TEXT:
+        part.text = _redact_string(part.text, redactor, default_text_mode)
+        return
+    if part.kind == PartKind.THINKING:
+        part.thinking = redactor.redact_lightweight(part.thinking)
+        return
+    if part.kind == PartKind.TOOL_CALL and part.tool_call is not None:
+        if len(part.tool_call.input_json) > 0:
+            part.tool_call.input_json = redactor.redact(part.tool_call.input_json.decode("utf-8")).encode("utf-8")
+        return
+    if part.kind == PartKind.TOOL_RESULT and part.tool_result is not None:
+        part.tool_result.content = redactor.redact(part.tool_result.content)
+        if len(part.tool_result.content_json) > 0:
+            part.tool_result.content_json = redactor.redact(part.tool_result.content_json.decode("utf-8")).encode(
+                "utf-8"
+            )
+
+
+def _redact_string(value: str, redactor: _SecretRedactor, mode: str) -> str:
+    if mode == "full":
+        return redactor.redact(value)
+    if mode == "light":
+        return redactor.redact_lightweight(value)
+    return value
+
+
+def _apply_patterns(text: str, patterns: tuple[_SecretPattern, ...]) -> str:
+    result = text
+    for pattern in patterns:
+        result = _apply_pattern(result, pattern)
+    return result
+
+
+def _apply_pattern(text: str, pattern: _SecretPattern) -> str:
+    return pattern.regex.sub(f"[REDACTED:{pattern.id}]", text)
+
+
+def _apply_tier2_patterns(text: str) -> str:
+    result = text
+    for pattern in _TIER2_PATTERNS:
+        result = pattern.regex.sub(rf"\1[REDACTED:{pattern.id}]", result)
+    return result

--- a/python/sigil_sdk/redaction.py
+++ b/python/sigil_sdk/redaction.py
@@ -79,7 +79,7 @@ _TIER2_PATTERNS: tuple[_SecretPattern, ...] = (
     _SecretPattern(
         "env-secret-value",
         re.compile(
-            r"((?:PASSWORD|SECRET|TOKEN|KEY|CREDENTIAL|API_KEY|PRIVATE_KEY|ACCESS_KEY)\s*[=:]\s*)(\S+)",
+            r"((?:PASSWORD|SECRET|TOKEN|KEY|CREDENTIAL|API_KEY|PRIVATE_KEY|ACCESS_KEY)\s*[=:]\s*)([^\s\"{}\[\],]+)",
             re.IGNORECASE,
         ),
     ),

--- a/python/sigil_sdk/redaction.py
+++ b/python/sigil_sdk/redaction.py
@@ -13,7 +13,6 @@ Add more patterns when concrete unredacted secrets are observed.
 
 from __future__ import annotations
 
-import copy
 import re
 from dataclasses import dataclass
 

--- a/python/sigil_sdk/redaction.py
+++ b/python/sigil_sdk/redaction.py
@@ -116,13 +116,11 @@ def create_secret_redaction_sanitizer(
     redactor = _SecretRedactor(include_email_addresses=resolved.redact_email_addresses)
 
     def _sanitize(generation: Generation) -> Generation:
-        sanitized = copy.deepcopy(generation)
-
-        for message in sanitized.input:
+        for message in generation.input:
             mode = "full" if message.role == MessageRole.USER and resolved.redact_input_messages else "none"
             _sanitize_message(message, redactor, mode)
 
-        for message in sanitized.output:
+        for message in generation.output:
             if message.role == MessageRole.ASSISTANT:
                 mode = "light"
             elif message.role == MessageRole.TOOL:
@@ -131,7 +129,7 @@ def create_secret_redaction_sanitizer(
                 mode = "none"
             _sanitize_message(message, redactor, mode)
 
-        return sanitized
+        return generation
 
     return _sanitize
 
@@ -142,6 +140,8 @@ def _sanitize_message(message: Message, redactor: _SecretRedactor, default_text_
 
 
 def _sanitize_part(part: Part, redactor: _SecretRedactor, default_text_mode: str) -> None:
+    if default_text_mode == "none":
+        return
     if part.kind == PartKind.TEXT:
         part.text = _redact_string(part.text, redactor, default_text_mode)
         return

--- a/python/sigil_sdk/redaction.py
+++ b/python/sigil_sdk/redaction.py
@@ -115,6 +115,9 @@ def create_secret_redaction_sanitizer(
     redactor = _SecretRedactor(include_email_addresses=resolved.redact_email_addresses)
 
     def _sanitize(generation: Generation) -> Generation:
+        if generation.system_prompt:
+            generation.system_prompt = redactor.redact(generation.system_prompt)
+
         for message in generation.input:
             mode = "full" if message.role == MessageRole.USER and resolved.redact_input_messages else "none"
             _sanitize_message(message, redactor, mode)

--- a/python/sigil_sdk/redaction.py
+++ b/python/sigil_sdk/redaction.py
@@ -119,7 +119,17 @@ def create_secret_redaction_sanitizer(
             generation.system_prompt = redactor.redact(generation.system_prompt)
 
         for message in generation.input:
-            mode = "full" if message.role == MessageRole.USER and resolved.redact_input_messages else "none"
+            if resolved.redact_input_messages:
+                if message.role == MessageRole.USER:
+                    mode = "full"
+                elif message.role == MessageRole.ASSISTANT:
+                    mode = "light"
+                elif message.role == MessageRole.TOOL:
+                    mode = "full"
+                else:
+                    mode = "none"
+            else:
+                mode = "none"
             _sanitize_message(message, redactor, mode)
 
         for message in generation.output:

--- a/python/tests/test_redaction.py
+++ b/python/tests/test_redaction.py
@@ -191,6 +191,67 @@ def test_secret_redaction_sanitizer_can_redact_user_input() -> None:
     assert "[REDACTED:openai-project-key]" in sanitized.input[0].parts[0].text
 
 
+def test_secret_redaction_sanitizer_redacts_tool_and_assistant_input_when_opted_in() -> None:
+    sanitizer = create_secret_redaction_sanitizer(SecretRedactionOptions(redact_input_messages=True))
+    secret_token = "glc_abcdefghijklmnopqrstuvwxyz1234"
+    env_secret = "DATABASE_PASSWORD=hunter2secret123"
+    bearer_token = "a" * 30
+
+    sanitized = sanitizer(
+        Generation(
+            id="gen-1",
+            mode=GenerationMode.SYNC,
+            operation_name="generateText",
+            model=ModelRef(provider="openai", name="gpt-5"),
+            input=[
+                Message(
+                    role=MessageRole.USER,
+                    parts=[Part(kind=PartKind.TEXT, text=f"user pasted {secret_token}")],
+                ),
+                Message(
+                    role=MessageRole.ASSISTANT,
+                    parts=[
+                        Part(kind=PartKind.TEXT, text=f"assistant response with {secret_token}"),
+                        Part(
+                            kind=PartKind.TOOL_CALL,
+                            tool_call=ToolCall(
+                                name="bash",
+                                id="call-1",
+                                input_json=f'{{"header":"Bearer {bearer_token}"}}'.encode(),
+                            ),
+                        ),
+                    ],
+                ),
+                Message(
+                    role=MessageRole.TOOL,
+                    parts=[
+                        Part(
+                            kind=PartKind.TOOL_RESULT,
+                            tool_result=ToolResult(
+                                tool_call_id="call-1",
+                                name="bash",
+                                content=f"output {env_secret}",
+                            ),
+                        )
+                    ],
+                ),
+            ],
+        )
+    )
+
+    assert "glc_" not in sanitized.input[0].parts[0].text
+    assert "[REDACTED:grafana-cloud-token]" in sanitized.input[0].parts[0].text
+
+    assert "glc_" not in sanitized.input[1].parts[0].text
+    assert "[REDACTED:grafana-cloud-token]" in sanitized.input[1].parts[0].text
+
+    assert "Bearer " not in sanitized.input[1].parts[1].tool_call.input_json.decode("utf-8")
+    assert "[REDACTED:bearer-token]" in sanitized.input[1].parts[1].tool_call.input_json.decode("utf-8")
+
+    assert "hunter2secret123" not in sanitized.input[2].parts[0].tool_result.content
+    assert "[REDACTED:env-secret-value]" in sanitized.input[2].parts[0].tool_result.content
+
+
 def test_generation_sanitizer_failure_falls_back_to_metadata_only(caplog) -> None:
     exporter = CapturingGenerationExporter()
     logger = logging.getLogger("sigil_sdk.test_redaction")

--- a/python/tests/test_redaction.py
+++ b/python/tests/test_redaction.py
@@ -1,0 +1,233 @@
+"""Tests for generation sanitization and built-in secret redaction."""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from conftest import CapturingGenerationExporter
+from sigil_sdk import (
+    Client,
+    ClientConfig,
+    ContentCaptureMode,
+    Generation,
+    GenerationExportConfig,
+    GenerationMode,
+    GenerationStart,
+    Message,
+    MessageRole,
+    ModelRef,
+    Part,
+    PartKind,
+    SecretRedactionOptions,
+    ToolCall,
+    ToolResult,
+    TokenUsage,
+    create_secret_redaction_sanitizer,
+)
+
+
+def _new_client(
+    exporter: CapturingGenerationExporter,
+    *,
+    generation_sanitizer=None,
+    logger: logging.Logger | None = None,
+) -> Client:
+    return Client(
+        ClientConfig(
+            generation_export=GenerationExportConfig(
+                batch_size=10,
+                flush_interval=timedelta(seconds=60),
+                queue_size=10,
+                max_retries=1,
+                initial_backoff=timedelta(milliseconds=1),
+                max_backoff=timedelta(milliseconds=1),
+            ),
+            generation_exporter=exporter,
+            content_capture=ContentCaptureMode.DEFAULT,
+            generation_sanitizer=generation_sanitizer,
+            logger=logger,
+        )
+    )
+
+
+def test_secret_redaction_sanitizer_redacts_assistant_and_tool_content_by_default() -> None:
+    exporter = CapturingGenerationExporter()
+    client = _new_client(exporter, generation_sanitizer=create_secret_redaction_sanitizer())
+
+    try:
+        secret_token = "glc_abcdefghijklmnopqrstuvwxyz1234"
+        env_secret = "DATABASE_PASSWORD=hunter2secret123"
+        bearer_token = "a" * 30
+
+        rec = client.start_generation(
+            GenerationStart(
+                model=ModelRef(provider="openai", name="gpt-5"),
+            )
+        )
+        rec.set_result(
+            Generation(
+                input=[
+                    Message(
+                        role=MessageRole.USER,
+                        parts=[Part(kind=PartKind.TEXT, text=f"user pasted {secret_token}")],
+                    )
+                ],
+                output=[
+                    Message(
+                        role=MessageRole.ASSISTANT,
+                        parts=[
+                            Part(kind=PartKind.TEXT, text=f"assistant saw {secret_token}"),
+                            Part(kind=PartKind.THINKING, thinking=f"thinking about {secret_token}"),
+                            Part(
+                                kind=PartKind.TOOL_CALL,
+                                tool_call=ToolCall(
+                                    name="bash",
+                                    id="call-1",
+                                    input_json=f'{{"header":"Bearer {bearer_token}","env":"{env_secret}"}}'.encode(
+                                        "utf-8"
+                                    ),
+                                ),
+                            ),
+                        ],
+                    ),
+                    Message(
+                        role=MessageRole.TOOL,
+                        parts=[
+                            Part(
+                                kind=PartKind.TOOL_RESULT,
+                                tool_result=ToolResult(
+                                    tool_call_id="call-1",
+                                    name="bash",
+                                    content=f"output {env_secret}",
+                                ),
+                            )
+                        ],
+                    ),
+                ],
+                usage=TokenUsage(input_tokens=1, output_tokens=1),
+            )
+        )
+        rec.end()
+
+        assert rec.err() is None
+        generation = rec.last_generation
+        assert generation is not None
+        assert "glc_" in generation.input[0].parts[0].text
+        assert "glc_" not in generation.output[0].parts[0].text
+        assert "[REDACTED:grafana-cloud-token]" in generation.output[0].parts[0].text
+        assert "glc_" not in generation.output[0].parts[1].thinking
+        assert "hunter2secret123" not in generation.output[0].parts[2].tool_call.input_json.decode("utf-8")
+        assert "Bearer " not in generation.output[0].parts[2].tool_call.input_json.decode("utf-8")
+        assert "[REDACTED:" in generation.output[0].parts[2].tool_call.input_json.decode("utf-8")
+        assert "hunter2secret123" not in generation.output[1].parts[0].tool_result.content
+        assert "[REDACTED:env-secret-value]" in generation.output[1].parts[0].tool_result.content
+    finally:
+        client.shutdown()
+
+
+def test_secret_redaction_sanitizer_redacts_email_addresses_by_default() -> None:
+    sanitizer = create_secret_redaction_sanitizer()
+    sanitized = sanitizer(
+        Generation(
+            id="gen-1",
+            mode=GenerationMode.SYNC,
+            operation_name="generateText",
+            model=ModelRef(provider="openai", name="gpt-5"),
+            output=[
+                Message(
+                    role=MessageRole.ASSISTANT,
+                    parts=[Part(kind=PartKind.TEXT, text="Send me an email to example@example.com")],
+                )
+            ],
+        )
+    )
+
+    assert "example@example.com" not in sanitized.output[0].parts[0].text
+    assert "[REDACTED:email]" in sanitized.output[0].parts[0].text
+
+
+def test_secret_redaction_sanitizer_can_leave_email_addresses_enabled_off() -> None:
+    sanitizer = create_secret_redaction_sanitizer(SecretRedactionOptions(redact_email_addresses=False))
+    sanitized = sanitizer(
+        Generation(
+            id="gen-1",
+            mode=GenerationMode.SYNC,
+            operation_name="generateText",
+            model=ModelRef(provider="openai", name="gpt-5"),
+            output=[
+                Message(
+                    role=MessageRole.ASSISTANT,
+                    parts=[Part(kind=PartKind.TEXT, text="Send me an email to example@example.com")],
+                )
+            ],
+        )
+    )
+
+    assert sanitized.output[0].parts[0].text == "Send me an email to example@example.com"
+
+
+def test_secret_redaction_sanitizer_can_redact_user_input() -> None:
+    sanitizer = create_secret_redaction_sanitizer(SecretRedactionOptions(redact_input_messages=True))
+    sanitized = sanitizer(
+        Generation(
+            id="gen-1",
+            mode=GenerationMode.SYNC,
+            operation_name="generateText",
+            model=ModelRef(provider="openai", name="gpt-5"),
+            input=[
+                Message(
+                    role=MessageRole.USER,
+                    parts=[
+                        Part(
+                            kind=PartKind.TEXT,
+                            text="key sk-proj-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        )
+                    ],
+                )
+            ],
+        )
+    )
+
+    assert "sk-proj-" not in sanitized.input[0].parts[0].text
+    assert "[REDACTED:openai-project-key]" in sanitized.input[0].parts[0].text
+
+
+def test_generation_sanitizer_failure_falls_back_to_metadata_only(caplog) -> None:
+    exporter = CapturingGenerationExporter()
+    logger = logging.getLogger("sigil_sdk.test_redaction")
+    client = _new_client(
+        exporter,
+        generation_sanitizer=lambda _generation: (_ for _ in ()).throw(RuntimeError("boom")),
+        logger=logger,
+    )
+
+    try:
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            rec = client.start_generation(
+                GenerationStart(
+                    model=ModelRef(provider="openai", name="gpt-5"),
+                    conversation_title="Top secret title",
+                    system_prompt="system secret",
+                )
+            )
+            rec.set_result(
+                Generation(
+                    input=[Message(role=MessageRole.USER, parts=[Part(kind=PartKind.TEXT, text="hello")])],
+                    output=[Message(role=MessageRole.ASSISTANT, parts=[Part(kind=PartKind.TEXT, text="world")])],
+                    usage=TokenUsage(input_tokens=1, output_tokens=1),
+                )
+            )
+            rec.end()
+
+        assert rec.err() is None
+        generation = rec.last_generation
+        assert generation is not None
+        assert generation.metadata["sigil.sdk.content_capture_mode"] == "metadata_only"
+        assert generation.conversation_title == ""
+        assert generation.system_prompt == ""
+        assert generation.input[0].parts[0].text == ""
+        assert generation.output[0].parts[0].text == ""
+        assert "sigil: generation sanitization failed, falling back to metadata_only" in caplog.text
+    finally:
+        client.shutdown()

--- a/python/tests/test_redaction.py
+++ b/python/tests/test_redaction.py
@@ -20,9 +20,9 @@ from sigil_sdk import (
     Part,
     PartKind,
     SecretRedactionOptions,
+    TokenUsage,
     ToolCall,
     ToolResult,
-    TokenUsage,
     create_secret_redaction_sanitizer,
 )
 
@@ -84,9 +84,7 @@ def test_secret_redaction_sanitizer_redacts_assistant_and_tool_content_by_defaul
                                 tool_call=ToolCall(
                                     name="bash",
                                     id="call-1",
-                                    input_json=f'{{"header":"Bearer {bearer_token}","env":"{env_secret}"}}'.encode(
-                                        "utf-8"
-                                    ),
+                                    input_json=f'{{"header":"Bearer {bearer_token}","env":"{env_secret}"}}'.encode(),
                                 ),
                             ),
                         ],


### PR DESCRIPTION
## Summary

Adds reusable generation sanitization to the Python core SDK via a new `generation_sanitizer` hook on `ClientConfig`.

Introduces a built-in `create_secret_redaction_sanitizer()` helper that ports the opencode plugin’s secret-redaction behavior into core, based on the existing plugin implementation in [`plugins/opencode/src/redact.ts`](https://github.com/grafana/sigil-sdk/blob/main/plugins/opencode/src/redact.ts) and the high-confidence secret-pattern approach used by [Gitleaks](https://github.com/gitleaks/gitleaks).

- Lightweight tier-1 redaction for assistant text and thinking  
- Full tier-1 + tier-2 redaction for tool call inputs and tool results  
- Email-address redaction enabled by default, with opt-out via `SecretRedactionOptions(redact_email_addresses=False)`  
- Optional user-input redaction via `SecretRedactionOptions(redact_input_messages=True)`

Wires sanitization into the normalized generation finalization path before span sync, validation, and export. If sanitization throws, the SDK now fails closed by falling back to metadata-only stripping and logs a warning.

Exports the new sanitizer helper from the Python package and adds targeted tests for redaction behavior, email redaction configuration, and fail-closed fallback.

## Tests

New unit tests that can be run with:

```
./.venv/bin/python -m pytest -q tests/test_redaction.py tests/test_content_capture.py
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core generation finalization/export path and can change recorded/exported content (including fail-closed fallback to `metadata_only`) when a sanitizer is configured or misbehaves.
> 
> **Overview**
> Adds a `ClientConfig.generation_sanitizer` hook to pre-process normalized generations *before* validation/span sync/export, including safe handling when sanitization fails (logs a warning and strips content by falling back to `ContentCaptureMode.METADATA_ONLY`).
> 
> Introduces a built-in `create_secret_redaction_sanitizer()` with configurable `SecretRedactionOptions` to redact common secret/token formats (and email addresses by default) across assistant text/thinking and tool call inputs/results, exposes the new API exports, documents usage in the Python README, and adds targeted unit tests for redaction behavior and fail-closed fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb8f28d335caf43a95d35dafffcec738ae24503f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->