### PR TITLE
feat(claude-code): send user id

### DIFF
--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -75,6 +75,8 @@ go install github.com/grafana/sigil-sdk/plugins/claude-code/cmd/sigil-cc@latest
 | `SIGIL_PASSWORD` | yes | Basic auth password |
 | `SIGIL_CONTENT_CAPTURE_MODE` | no | Content capture mode: `full`, `metadata_only`, `no_tool_content` (default: `metadata_only`) |
 | `SIGIL_EXTRA_TAGS` | no | Comma-separated `key=value` tags added to every generation (e.g. `account=work,env=dev`). Built-in tags (`git.branch`, `cwd`, `entrypoint`, `subagent`) take precedence on collision. |
+| `SIGIL_USER_ID` | no | Explicit override for the per-generation user id. When set to a non-whitespace value it wins over `~/.claude.json` and ignores `SIGIL_USER_ID_SOURCE`. |
+| `SIGIL_USER_ID_SOURCE` | no | Field to read from `~/.claude.json` when `SIGIL_USER_ID` is unset: `email` (default, uses `oauthAccount.emailAddress`) or `accountUuid` (uses `oauthAccount.accountUuid`). Unknown values fall back to `email`. |
 | `SIGIL_OTEL_ENDPOINT` | no | OTLP HTTP endpoint for metrics + traces (e.g. `https://otlp-gateway.grafana.net/otlp` or `host:4318`) |
 | `SIGIL_OTEL_USER` | no | OTLP auth username (defaults to `SIGIL_USER`) |
 | `SIGIL_OTEL_PASSWORD` | no | OTLP auth password (defaults to `SIGIL_PASSWORD`) |

--- a/plugins/claude-code/cmd/sigil-cc/main.go
+++ b/plugins/claude-code/cmd/sigil-cc/main.go
@@ -67,9 +67,11 @@ func run() {
 
 	contentMode := resolveContentMode()
 	extraTags := parseExtraTags(os.Getenv("SIGIL_EXTRA_TAGS"))
+	userID := resolveUserID()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+	ctx = sigil.WithUserID(ctx, userID)
 
 	// The Go OTLP SDK reads standard OTEL_EXPORTER_OTLP_* env vars automatically,
 	// which Claude Code sets for its own telemetry. Clear them so our SIGIL_OTEL_*

--- a/plugins/claude-code/cmd/sigil-cc/userid.go
+++ b/plugins/claude-code/cmd/sigil-cc/userid.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// resolveUserID returns the user id to attach to every emitted generation.
+// SIGIL_USER_ID wins when set to a non-whitespace value; otherwise we read
+// ~/.claude.json using the field selected by SIGIL_USER_ID_SOURCE (default
+// "email", falling back to "email" on any unrecognized value).
+// Any failure resolves to "" — telemetry is best-effort.
+func resolveUserID() string {
+	if v := strings.TrimSpace(os.Getenv("SIGIL_USER_ID")); v != "" {
+		return v
+	}
+
+	source := strings.TrimSpace(os.Getenv("SIGIL_USER_ID_SOURCE"))
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return loadUserIDFromClaudeJSON(filepath.Join(home, ".claude.json"), source)
+}
+
+// loadUserIDFromClaudeJSON reads ~/.claude.json and returns the selected
+// oauthAccount field. Unknown sources fall back to "email". Returns "" on any
+// error (missing file, malformed JSON, missing field). A malformed file is
+// surfaced to stderr — mirrors state.Load for the same failure class and
+// helps users diagnose why their generations are missing a user id.
+func loadUserIDFromClaudeJSON(path, source string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+
+	var parsed struct {
+		OAuthAccount struct {
+			EmailAddress string `json:"emailAddress"`
+			AccountUUID  string `json:"accountUuid"`
+		} `json:"oauthAccount"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		fmt.Fprintln(os.Stderr, "sigil-cc: malformed ~/.claude.json, cannot resolve user id:", err)
+		return ""
+	}
+
+	switch source {
+	case "accountUuid":
+		return parsed.OAuthAccount.AccountUUID
+	default:
+		return parsed.OAuthAccount.EmailAddress
+	}
+}

--- a/plugins/claude-code/cmd/sigil-cc/userid_test.go
+++ b/plugins/claude-code/cmd/sigil-cc/userid_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const sampleClaudeJSON = `{
+  "oauthAccount": {
+    "emailAddress": "a@b.com",
+    "accountUuid": "uuid-123"
+  }
+}`
+
+func writeClaudeJSON(t *testing.T, dir, contents string) string {
+	t.Helper()
+	path := filepath.Join(dir, ".claude.json")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func TestLoadUserIDFromClaudeJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		writeFix bool
+		source   string
+		want     string
+	}{
+		{name: "email source", contents: sampleClaudeJSON, writeFix: true, source: "email", want: "a@b.com"},
+		{name: "accountUuid source", contents: sampleClaudeJSON, writeFix: true, source: "accountUuid", want: "uuid-123"},
+		{name: "empty source defaults to email", contents: sampleClaudeJSON, writeFix: true, source: "", want: "a@b.com"},
+		{name: "unknown source falls back to email", contents: sampleClaudeJSON, writeFix: true, source: "bogus", want: "a@b.com"},
+		{name: "missing file", writeFix: false, source: "email", want: ""},
+		{name: "malformed JSON", contents: `{"oauthAccount":`, writeFix: true, source: "email", want: ""},
+		{name: "missing oauthAccount", contents: `{"other":"x"}`, writeFix: true, source: "email", want: ""},
+		{name: "empty target field email", contents: `{"oauthAccount":{"accountUuid":"uuid-123"}}`, writeFix: true, source: "email", want: ""},
+		{name: "empty target field accountUuid", contents: `{"oauthAccount":{"emailAddress":"a@b.com"}}`, writeFix: true, source: "accountUuid", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, ".claude.json")
+			if tt.writeFix {
+				writeClaudeJSON(t, dir, tt.contents)
+			}
+
+			got := loadUserIDFromClaudeJSON(path, tt.source)
+			if got != tt.want {
+				t.Errorf("loadUserIDFromClaudeJSON = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveUserID(t *testing.T) {
+	tests := []struct {
+		name       string
+		envUserID  string
+		envSource  string
+		writeFix   bool
+		contents   string
+		want       string
+	}{
+		{
+			name:      "SIGIL_USER_ID wins over file",
+			envUserID: "foo",
+			envSource: "accountUuid",
+			writeFix:  true,
+			contents:  sampleClaudeJSON,
+			want:      "foo",
+		},
+		{
+			name:      "SIGIL_USER_ID wins when no file exists",
+			envUserID: "foo",
+			writeFix:  false,
+			want:      "foo",
+		},
+		{
+			name:      "SIGIL_USER_ID trimmed",
+			envUserID: "  alex@example.com  ",
+			want:      "alex@example.com",
+		},
+		{
+			name:      "whitespace-only SIGIL_USER_ID falls through",
+			envUserID: "   ",
+			writeFix:  true,
+			contents:  sampleClaudeJSON,
+			want:      "a@b.com",
+		},
+		{
+			name:     "default source is email",
+			writeFix: true,
+			contents: sampleClaudeJSON,
+			want:     "a@b.com",
+		},
+		{
+			name:      "accountUuid source",
+			envSource: "accountUuid",
+			writeFix:  true,
+			contents:  sampleClaudeJSON,
+			want:      "uuid-123",
+		},
+		{
+			name:      "unknown source falls back to email",
+			envSource: "bogus",
+			writeFix:  true,
+			contents:  sampleClaudeJSON,
+			want:      "a@b.com",
+		},
+		{
+			name:     "missing file returns empty",
+			writeFix: false,
+			want:     "",
+		},
+		{
+			name:     "malformed file returns empty",
+			writeFix: true,
+			contents: `{broken`,
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("SIGIL_USER_ID", tt.envUserID)
+			t.Setenv("SIGIL_USER_ID_SOURCE", tt.envSource)
+
+			if tt.writeFix {
+				writeClaudeJSON(t, home, tt.contents)
+			}
+
+			got := resolveUserID()
+			if got != tt.want {
+				t.Errorf("resolveUserID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Conversations emitted by sigil-cc shipped with an empty UserID, so Sigil could not attribute them to a specific user. The identity is not in the transcript but is available in ~/.claude.json.

Resolve from SIGIL_USER_ID first (trimmed, non-empty wins), otherwise read ~/.claude.json using the field selected by SIGIL_USER_ID_SOURCE (email by default, accountUuid optional). Resolution is best-effort: any failure leaves UserID empty and telemetry continues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes telemetry attribution and may start exporting a PII-like identifier (e.g., email) depending on configuration; failures are handled best-effort and fall back to an empty user id.
> 
> **Overview**
> `sigil-cc` now attaches a **user identifier** to every exported generation by resolving it from `SIGIL_USER_ID` (explicit override) or from `~/.claude.json` using `SIGIL_USER_ID_SOURCE` (`email` default, `accountUuid` optional).
> 
> The hook injects the resolved value via `sigil.WithUserID(ctx, userID)`, adds best-effort parsing with stderr diagnostics for malformed `~/.claude.json`, includes unit tests for the resolution logic, and documents the new environment variables in the plugin README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34c22ae2bd3f17f6c7b9551fb2af828510a41501. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->