### PR TITLE
fix(sigil-sdk-openai): relax openai dependency to >=1.66.0

### DIFF
--- a/python-providers/openai/pyproject.toml
+++ b/python-providers/openai/pyproject.toml
@@ -7,7 +7,7 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
   "sigil-sdk>=0.1.2",
-  "openai>=2.20.0,<3",
+  "openai>=1.66.0,<3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Relaxes the openai dependency from `>=2.20.0,<3` to `>=1.66.0,<3`
- Enables compatibility with OpenLit, which only supports openai v1.x

## Context
The v2.20 constraint was added somewhat arbitrarily when the "strict OpenAI parity" work landed - it was the latest version at the time. The Responses API types that the code uses have been available since v1.66.0 (March 2025).

Related: https://github.com/openlit/openlit/issues/934

## Test plan
- [x] `pytest` passes for sigil-sdk-openai

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency metadata change only; runtime behavior is unchanged but users may now install older `openai` versions, so compatibility relies on APIs available since `openai>=1.66.0`.
> 
> **Overview**
> Lowers `sigil-sdk-openai`'s `openai` dependency constraint from `>=2.20.0,<3` to `>=1.66.0,<3`, allowing installation alongside `openai` v1.x while still permitting v2+.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96621efcbf6c5cf703001a36f262dc9a77d1180d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->