### PR TITLE
fix(ci): use GitHub App token for Python SDK publish push

### DIFF
--- a/.github/workflows/python-sdks-publish.yml
+++ b/.github/workflows/python-sdks-publish.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build:
-    if: github.repository == 'grafana/sigil-sdk' #&& github.ref == 'refs/heads/main'
+    if: github.repository == 'grafana/sigil-sdk' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/python-sdks-publish.yml
+++ b/.github/workflows/python-sdks-publish.yml
@@ -45,6 +45,7 @@ jobs:
           app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
           private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -129,15 +130,29 @@ jobs:
       - name: Commit and push
         shell: bash
         run: |
+          # Configure git to use the GitHub App token
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          
           git add \
             python/pyproject.toml \
             python-providers/*/pyproject.toml \
             python-frameworks/*/pyproject.toml
-          git commit -m "chore(sdk-python): bump version to ${NEW_VERSION}"
-          git tag -a "sdk-python/v${NEW_VERSION}" -m "Python SDK ${NEW_VERSION}"
+          
+          # Check if there are changes to commit
+          if git diff --cached --quiet; then
+            echo "No changes to commit, version may already be bumped"
+          else
+            git commit -m "chore(sdk-python): bump version to ${NEW_VERSION}"
+          fi
+          
+          # Delete existing tag if present (handles re-runs)
+          git push origin :refs/tags/sdk-python/v${NEW_VERSION} 2>/dev/null || true
+          git tag -f -a "sdk-python/v${NEW_VERSION}" -m "Python SDK ${NEW_VERSION}"
+          
           git push origin HEAD --tags
         env:
           NEW_VERSION: ${{ steps.bump.outputs.new-version }}
+          GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}
 
       - name: Upload built distributions
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/python-sdks-publish.yml
+++ b/.github/workflows/python-sdks-publish.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build:
-    if: github.repository == 'grafana/sigil-sdk' && github.ref == 'refs/heads/main'
+    if: github.repository == 'grafana/sigil-sdk' #&& github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/python-frameworks/google-adk/pyproject.toml
+++ b/python-frameworks/google-adk/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "sigil-sdk-google-adk"
-version = "0.1.2"
+version = "0.1.3"
 description = "Google ADK callback handlers for Sigil Python SDK"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
-  "sigil-sdk>=0.1.2",
+  "sigil-sdk>=0.1.3",
   "google-adk>=1.0.0",
 ]
 

--- a/python-frameworks/langchain/pyproject.toml
+++ b/python-frameworks/langchain/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "sigil-sdk-langchain"
-version = "0.1.2"
+version = "0.1.3"
 description = "LangChain callback handlers for Sigil Python SDK"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
-  "sigil-sdk>=0.1.2",
+  "sigil-sdk>=0.1.3",
   "langchain-core>=0.3.0",
 ]
 

--- a/python-frameworks/langgraph/pyproject.toml
+++ b/python-frameworks/langgraph/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "sigil-sdk-langgraph"
-version = "0.1.2"
+version = "0.1.3"
 description = "LangGraph callback handlers for Sigil Python SDK"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
-  "sigil-sdk>=0.1.2",
+  "sigil-sdk>=0.1.3",
   "langchain-core>=0.3.0",
   "langgraph>=0.2.0",
 ]

--- a/python-frameworks/litellm/pyproject.toml
+++ b/python-frameworks/litellm/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "sigil-sdk-litellm"
-version = "0.1.2"
+version = "0.1.3"
 description = "LiteLLM callback handler for Sigil Python SDK"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
-  "sigil-sdk>=0.1.2",
+  "sigil-sdk>=0.1.3",
   "litellm>=1.82.3,!=1.82.7,!=1.82.8",
 ]
 

--- a/python-frameworks/llamaindex/pyproject.toml
+++ b/python-frameworks/llamaindex/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "sigil-sdk-llamaindex"
-version = "0.1.2"
+version = "0.1.3"
 description = "LlamaIndex callback handlers for Sigil Python SDK"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
-  "sigil-sdk>=0.1.2",
+  "sigil-sdk>=0.1.3",
   "llama-index>=0.14.0",
 ]
 

--- a/python-frameworks/openai-agents/pyproject.toml
+++ b/python-frameworks/openai-agents/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "sigil-sdk-openai-agents"
-version = "0.1.2"
+version = "0.1.3"
 description = "OpenAI Agents callback handlers for Sigil Python SDK"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
-  "sigil-sdk>=0.1.2",
+  "sigil-sdk>=0.1.3",
   "openai-agents>=0.9.0",
 ]
 

--- a/python-providers/anthropic/pyproject.toml
+++ b/python-providers/anthropic/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "sigil-sdk-anthropic"
-version = "0.1.2"
+version = "0.1.3"
 description = "Anthropic helper wrappers for Sigil Python SDK"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
-  "sigil-sdk>=0.1.2",
+  "sigil-sdk>=0.1.3",
   "anthropic>=0.79.0,<1",
 ]
 

--- a/python-providers/gemini/pyproject.toml
+++ b/python-providers/gemini/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "sigil-sdk-gemini"
-version = "0.1.2"
+version = "0.1.3"
 description = "Gemini helper wrappers for Sigil Python SDK"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
-  "sigil-sdk>=0.1.2",
+  "sigil-sdk>=0.1.3",
   "google-genai>=1.63.0,<2",
 ]
 

--- a/python-providers/openai/pyproject.toml
+++ b/python-providers/openai/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "sigil-sdk-openai"
-version = "0.1.2"
+version = "0.1.3"
 description = "OpenAI helper wrappers for Sigil Python SDK"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
-  "sigil-sdk>=0.1.2",
+  "sigil-sdk>=0.1.3",
   "openai>=1.66.0,<3",
 ]
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sigil-sdk"
-version = "0.1.2"
+version = "0.1.3"
 description = "Grafana Sigil Python SDK"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- Fixes Python SDK publish workflow failing due to branch protection rules
- Configures git to explicitly use the GitHub App token when pushing version bumps and tags
- Handles workflow re-runs by deleting existing tags before recreating

## Test plan
- [ ] Run the Python SDK publish workflow and verify it can push to main

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release/publish automation (including forced tag recreation), which can affect versioning and tagging behavior if misconfigured, but does not touch runtime application code.
> 
> **Overview**
> Updates the Python SDK publish GitHub Actions workflow to generate a GitHub App token scoped to the current repo, explicitly configure `origin` to use that token for pushes, and avoid failing reruns by skipping empty commits and force-recreating the `sdk-python/v*` tag (deleting any existing remote tag first).
> 
> Bumps `sigil-sdk` and all provider/framework packages from `0.1.2` to `0.1.3`, updating dependent packages’ `sigil-sdk>=...` constraints accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 936180f0d991314d583a4aa7f4d407cd6db389b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->