### PR TITLE
feat(examples): add python + langchain example

### DIFF
--- a/examples/python-langchain/.env.example
+++ b/examples/python-langchain/.env.example
@@ -1,0 +1,27 @@
+# Anthropic API key (required).
+ANTHROPIC_API_KEY=sk-ant-...
+
+# --- Sigil (all required) ---
+# Endpoint of your Sigil instance. For Grafana Cloud this is the URL
+# shown in the "SDK connection details" panel of your stack.
+SIGIL_API_ENDPOINT=
+SIGIL_GENERATION_EXPORT_ENDPOINT=
+
+# Tenant / instance ID. Sent as X-Scope-OrgID and used as the basic-auth
+# user when SIGIL_AUTH_TOKEN is set. For Grafana Cloud, this is your
+# stack/instance ID.
+SIGIL_TENANT_ID=
+
+# Access token. Required for Grafana Cloud (basic-auth password).
+# Leave unset when pointing at a self-hosted Sigil that doesn't require
+# auth — the client will fall back to tenant-only mode.
+SIGIL_AUTH_TOKEN=
+
+# --- OTel traces + metrics exporter ---
+OTEL_EXPORTER_OTLP_ENDPOINT=
+OTEL_EXPORTER_OTLP_INSECURE=true
+OTEL_SERVICE_NAME=sigil-langchain-weather-example
+
+# --- Model selection (override to whatever you have access to) ---
+AGENT_MODEL=claude-sonnet-4-6
+CLASSIFIER_MODEL=claude-haiku-4-5

--- a/examples/python-langchain/.gitignore
+++ b/examples/python-langchain/.gitignore
@@ -1,0 +1,11 @@
+.env
+.venv/
+__pycache__/
+*.pyc
+.uv/
+uv.lock
+.mypy_cache/
+.ruff_cache/
+*.egg-info/
+build/
+dist/

--- a/examples/python-langchain/README.md
+++ b/examples/python-langchain/README.md
@@ -1,0 +1,103 @@
+# Sigil + LangChain weather example
+
+A deliberately small FastAPI service that demonstrates **two ways to instrument LLM calls with Sigil from the same app**:
+
+
+| Path                        | How it's instrumented                                        | Where to look                              |
+| --------------------------- | ------------------------------------------------------------ | ------------------------------------------ |
+| LangChain weather agent     | `with_sigil_langchain_callbacks(...)` on the runnable config | `[app/agent.py](./app/agent.py)`           |
+| Direct Anthropic classifier | `sigil.start_generation(...)` + `rec.set_result(...)`        | `[app/classifier.py](./app/classifier.py)` |
+
+
+Both LLM calls run under the same `conversation_id`, so they land grouped together in the Sigil UI. That makes it easy to compare how each path shows up, and to see that framework callbacks and raw SDK recording produce the same canonical generation shape.
+
+## What the demo teaches
+
+1. **Setting up OpenTelemetry for a FastAPI app.** `[app/telemetry.py](./app/telemetry.py)` wires a `TracerProvider` and `MeterProvider` with OTLP gRPC exporters.
+2. **Creating a Sigil client.** `[app/sigil_client.py](./app/sigil_client.py)` builds a `sigil_sdk.Client` that reuses those OTel providers, so `gen_ai.`* spans and metrics flow through the same pipeline as the rest of the app.
+3. **Instrumenting a LangChain agent.** One line in `[app/agent.py](./app/agent.py)` — `with_sigil_langchain_callbacks(config, client=sigil, ...)` — attaches the Sigil callback handler to the agent's config.
+4. **Instrumenting arbitrary LLM code.** `[app/classifier.py](./app/classifier.py)` shows the raw SDK pattern for any provider call, regardless of framework.
+5. **Grouping related generations.** Passing a common `conversation_id` ties both calls together in the Sigil UI.
+
+## Prerequisites
+
+- Python 3.11+
+- `[uv](https://docs.astral.sh/uv/)`
+- An `ANTHROPIC_API_KEY`
+- A local Sigil stack reachable at:
+  - `http://localhost:8080` — HTTP generation ingest + REST API
+  - `localhost:4317` — OTLP gRPC (traces, metrics)
+
+If you're running the Sigil dev compose from this repo, both ports are already exposed and auth is disabled.
+
+## Setup
+
+```bash
+cd examples/python-langchain
+cp .env.example .env
+uv sync
+```
+
+By default `pyproject.toml` pins `sigil-sdk` and `sigil-sdk-langchain` to the local packages in this monorepo via `[tool.uv.sources]`. Remove that block to consume the published PyPI releases instead.
+
+## Run
+
+```bash
+uv run uvicorn app.main:app --reload --port 8000
+```
+
+## Try it
+
+```bash
+# On-topic: agent uses the tool, classifier returns ON_TOPIC
+curl -s localhost:8000/chat \
+  -H 'content-type: application/json' \
+  -d '{"message": "Whats the weather in Paris on 2026-04-18?"}' | jq
+
+# Off-topic: agent declines, classifier returns OFF_TOPIC
+curl -s localhost:8000/chat \
+  -H 'content-type: application/json' \
+  -d '{"message": "Write me a limerick about kubernetes."}' | jq
+```
+
+FastAPI also serves interactive docs at [http://localhost:8000/docs](http://localhost:8000/docs).
+
+## What to look for in Sigil
+
+Open the Sigil UI. For each request you should see:
+
+- A **conversation** identified by the `conv-…` id returned in the response.
+- Two generations under it:
+  - `weather-agent` — emitted by the LangChain callback handler, with a child `execute_tool` span for `get_weather` when invoked.
+  - `topic-classifier` — emitted by the manual SDK instrumentation.
+- In Tempo: a `chat.request` parent span containing `gen_ai.`* child spans from both paths, plus LangChain chain/tool spans.
+
+## Project layout
+
+```
+app/
+  telemetry.py      # OTel TracerProvider / MeterProvider bootstrap
+  sigil_client.py   # Sigil SDK client, wired to the OTel providers
+  agent.py          # LangChain agent + get_weather tool
+  classifier.py     # Direct Anthropic call, manually recorded to Sigil
+  weather.py        # Stubbed April 2026 weather data
+  main.py           # FastAPI app (POST /chat, GET /healthz)
+```
+
+## Environment variables
+
+See `[.env.example](./.env.example)`.
+
+
+| Variable                           | Purpose                                                                                 |
+| ---------------------------------- | --------------------------------------------------------------------------------------- |
+| `ANTHROPIC_API_KEY`                | Required. Used by both the agent and the classifier.                                    |
+| `SIGIL_GENERATION_EXPORT_ENDPOINT` | HTTP generation-ingest URL. Default `http://localhost:8080/api/v1/generations:export`.  |
+| `SIGIL_API_ENDPOINT`               | Sigil REST API base (ratings, etc.). Default `http://localhost:8080`.                   |
+| `SIGIL_TENANT_ID`                  | Sent as `X-Scope-OrgID`. Any value works when `SIGIL_AUTH_ENABLED=false` on the server. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`      | OTLP gRPC target for traces + metrics. Default `http://localhost:4317`.                 |
+| `OTEL_EXPORTER_OTLP_INSECURE`      | `true` for plaintext gRPC (local dev).                                                  |
+| `OTEL_SERVICE_NAME`                | Service name tag on spans / metrics.                                                    |
+| `AGENT_MODEL` / `CLASSIFIER_MODEL` | Anthropic model IDs.                                                                    |
+
+

--- a/examples/python-langchain/README.md
+++ b/examples/python-langchain/README.md
@@ -22,13 +22,8 @@ Both LLM calls run under the same `conversation_id`, so they land grouped togeth
 ## Prerequisites
 
 - Python 3.11+
-- `[uv](https://docs.astral.sh/uv/)`
+- [uv](https://docs.astral.sh/uv/)
 - An `ANTHROPIC_API_KEY`
-- A local Sigil stack reachable at:
-  - `http://localhost:8080` — HTTP generation ingest + REST API
-  - `localhost:4317` — OTLP gRPC (traces, metrics)
-
-If you're running the Sigil dev compose from this repo, both ports are already exposed and auth is disabled.
 
 ## Setup
 

--- a/examples/python-langchain/app/agent.py
+++ b/examples/python-langchain/app/agent.py
@@ -1,0 +1,112 @@
+"""LangChain agent instrumented via Sigil's callback handler.
+
+The entire Sigil integration is one line: wrap the runnable config with
+`with_sigil_langchain_callbacks(...)`. LLM calls, tool invocations, and
+chain spans are all recorded automatically — no manual `start_generation`
+needed. Compare with `classifier.py` for the raw-SDK pattern.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date
+from typing import Any
+
+from langchain.agents import create_agent
+from langchain_anthropic import ChatAnthropic
+from langchain_core.tools import tool
+
+from sigil_sdk import Client
+from sigil_sdk_langchain import with_sigil_langchain_callbacks
+
+from .weather import known_cities, lookup_forecast
+
+
+SYSTEM_PROMPT_TEMPLATE = (
+    "You are a concise weather assistant. Only answer weather questions. "
+    "When the user asks about weather, always call the `get_weather` tool. "
+    "Today's date is {today}; resolve relative dates like 'today' or "
+    "'tomorrow' against it."
+)
+
+
+@tool
+def get_weather(city: str, date: str) -> str:
+    """Get the weather forecast for a city on a specific date.
+
+    Args:
+        city: City name, e.g. "London" or "San Francisco".
+        date: ISO date (YYYY-MM-DD). Only April 17-19 2026 are supported.
+    """
+    forecast = lookup_forecast(city, date)
+    if forecast is None:
+        return (
+            f"No forecast available for {city!r} on {date!r}. "
+            f"Known cities: {', '.join(known_cities())}. "
+            f"Dates available: 2026-04-17, 2026-04-18, 2026-04-19."
+        )
+    return (
+        f"{forecast.city} on {forecast.date}: {forecast.condition}. "
+        f"High {forecast.high_c}°C / low {forecast.low_c}°C, "
+        f"precipitation {forecast.precipitation_mm} mm."
+    )
+
+
+def build_agent(model_name: str) -> Any:
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        raise RuntimeError("ANTHROPIC_API_KEY must be set before building the agent.")
+
+    llm = ChatAnthropic(
+        model_name=model_name,
+        temperature=0,
+        timeout=None,
+        stop=None,
+    )
+    return create_agent(
+        model=llm,
+        tools=[get_weather],
+        system_prompt=SYSTEM_PROMPT_TEMPLATE.format(today=date.today().isoformat()),
+    )
+
+
+def run_agent(
+    *,
+    agent: Any,
+    sigil: Client,
+    user_message: str,
+    conversation_id: str,
+) -> str:
+    """Invoke the agent with Sigil callbacks attached, return the final reply."""
+    config = with_sigil_langchain_callbacks(
+        {"metadata": {"conversation_id": conversation_id}},
+        client=sigil,
+        provider_resolver="auto",
+        agent_name="weather-agent",
+        agent_version="1.0.0",
+    )
+
+    result = agent.invoke(
+        {"messages": [{"role": "user", "content": user_message}]},
+        config=config,
+    )
+
+    return _final_text(result)
+
+
+def _final_text(result: Any) -> str:
+    """Extract the assistant's final text reply from a LangChain agent result."""
+    messages = result.get("messages", []) if isinstance(result, dict) else []
+    for msg in reversed(messages):
+        content = getattr(msg, "content", None)
+        if isinstance(content, str) and content.strip():
+            return content
+        if isinstance(content, list):
+            parts = [
+                part.get("text", "")
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "text"
+            ]
+            joined = "".join(parts).strip()
+            if joined:
+                return joined
+    return ""

--- a/examples/python-langchain/app/classifier.py
+++ b/examples/python-langchain/app/classifier.py
@@ -1,0 +1,110 @@
+"""Direct Anthropic call, instrumented with the raw Sigil SDK.
+
+Counterpoint to `agent.py`. When you're not using a framework Sigil
+has a callback for, the pattern is:
+
+    with sigil.start_generation(GenerationStart(...)) as rec:
+        response = provider_call(...)
+        rec.set_result(input=..., output=..., usage=...)
+
+The classifier decides whether the message is a weather question so the
+caller can skip the agent on OFF_TOPIC. Both calls share a
+`conversation_id` so they group together in the Sigil UI.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Literal
+
+from anthropic import Anthropic
+from anthropic.types import TextBlock
+
+from sigil_sdk import (
+    Client,
+    GenerationStart,
+    ModelRef,
+    TokenUsage,
+    assistant_text_message,
+    user_text_message,
+)
+
+
+Label = Literal["ON_TOPIC", "OFF_TOPIC", "UNKNOWN"]
+
+
+@dataclass(frozen=True)
+class Classification:
+    label: Label
+    raw: str
+
+
+_PROMPT_TEMPLATE = """\
+You are a strict classifier. Decide whether the user's message is asking about WEATHER.
+Output exactly one token: ON_TOPIC if it's a weather/forecast question, OFF_TOPIC otherwise.
+Do not explain.
+
+User message:
+{user_message}
+
+Label:"""
+
+
+def _parse_label(raw: str) -> Label:
+    head = raw.strip().upper()
+    if head.startswith("ON_TOPIC"):
+        return "ON_TOPIC"
+    if head.startswith("OFF_TOPIC"):
+        return "OFF_TOPIC"
+    return "UNKNOWN"
+
+
+def classify_message(
+    *,
+    sigil: Client,
+    conversation_id: str,
+    user_message: str,
+    model_name: str,
+) -> Classification:
+    anthropic = Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+    prompt = _PROMPT_TEMPLATE.format(user_message=user_message)
+
+    raw_text = ""
+    with sigil.start_generation(
+        GenerationStart(
+            conversation_id=conversation_id,
+            agent_name="topic-classifier",
+            agent_version="1.0.0",
+            model=ModelRef(provider="anthropic", name=model_name),
+            max_tokens=8,
+            temperature=0,
+        )
+    ) as rec:
+        try:
+            response = anthropic.messages.create(
+                model=model_name,
+                max_tokens=8,
+                temperature=0,
+                messages=[{"role": "user", "content": prompt}],
+            )
+        except Exception as exc:
+            rec.set_call_error(exc)
+            raise
+
+        raw_text = "".join(
+            block.text for block in response.content if isinstance(block, TextBlock)
+        ).strip()
+
+        rec.set_result(
+            input=[user_text_message(prompt)],
+            output=[assistant_text_message(raw_text)],
+            usage=TokenUsage(
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+            ),
+            response_id=response.id,
+            response_model=response.model,
+        )
+
+    return Classification(label=_parse_label(raw_text), raw=raw_text)

--- a/examples/python-langchain/app/handlers.py
+++ b/examples/python-langchain/app/handlers.py
@@ -1,0 +1,73 @@
+"""HTTP route handlers.
+
+`POST /chat` runs the classifier first, then the agent (unless the
+message is off-topic). Both calls share a `conversation_id` so they
+group together in Sigil.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from .agent import run_agent
+from .classifier import classify_message
+
+
+OFF_TOPIC_REPLY = (
+    "I'm a weather assistant, so I can only help with weather and "
+    "forecast questions. Ask me about the weather in a city and I'll "
+    "look it up for you."
+)
+
+
+class ChatRequest(BaseModel):
+    message: str
+    conversation_id: str | None = None
+
+
+class ChatResponse(BaseModel):
+    conversation_id: str
+    reply: str
+    classification: str
+    classifier_raw: str
+
+
+router = APIRouter()
+
+
+@router.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@router.post("/chat", response_model=ChatResponse)
+def chat(req: ChatRequest, request: Request) -> ChatResponse:
+    state = request.app.state
+    conversation_id = req.conversation_id or f"conv-{uuid.uuid4().hex[:12]}"
+
+    classification = classify_message(
+        sigil=state.sigil,
+        conversation_id=conversation_id,
+        user_message=req.message,
+        model_name=state.classifier_model,
+    )
+
+    if classification.label == "OFF_TOPIC":
+        reply = OFF_TOPIC_REPLY
+    else:
+        reply = run_agent(
+            agent=state.agent,
+            sigil=state.sigil,
+            user_message=req.message,
+            conversation_id=conversation_id,
+        )
+
+    return ChatResponse(
+        conversation_id=conversation_id,
+        reply=reply,
+        classification=classification.label,
+        classifier_raw=classification.raw,
+    )

--- a/examples/python-langchain/app/main.py
+++ b/examples/python-langchain/app/main.py
@@ -1,0 +1,50 @@
+"""FastAPI entry point.
+
+Bootstraps OpenTelemetry and the Sigil client on startup, exposes them
+on `app.state` for handlers, and mounts the routes from `handlers.py`.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import asynccontextmanager
+
+from dotenv import load_dotenv
+from fastapi import FastAPI
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+from .agent import build_agent
+from .handlers import router
+from .sigil_client import setup_sigil
+from .telemetry import setup_opentelemetry
+
+
+load_dotenv()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    otel = setup_opentelemetry()
+    sigil = setup_sigil(
+        tracer_provider=otel.tracer_provider,
+        meter_provider=otel.meter_provider,
+    )
+
+    app.state.otel = otel
+    app.state.sigil = sigil
+    app.state.agent = build_agent(os.getenv("AGENT_MODEL", "claude-sonnet-4-5"))
+    app.state.classifier_model = os.getenv("CLASSIFIER_MODEL", "claude-haiku-4-5")
+
+    FastAPIInstrumentor.instrument_app(app, tracer_provider=otel.tracer_provider)
+
+    try:
+        yield
+    finally:
+        # Shut down Sigil first so in-flight generations finish exporting
+        # before OTel tears down the gRPC channels underneath.
+        sigil.shutdown()
+        otel.shutdown()
+
+
+app = FastAPI(title="Sigil + LangChain weather example", lifespan=lifespan)
+app.include_router(router)

--- a/examples/python-langchain/app/sigil_client.py
+++ b/examples/python-langchain/app/sigil_client.py
@@ -1,0 +1,58 @@
+"""Sigil client bootstrap.
+
+Builds a `sigil_sdk.Client` that reuses the app's OTel providers, so the
+`gen_ai.*` spans and metrics it emits flow through the same pipeline as
+everything else. Config comes from environment variables (see `.env.example`).
+"""
+
+from __future__ import annotations
+
+import os
+
+from opentelemetry.metrics import MeterProvider
+from opentelemetry.trace import TracerProvider
+
+from sigil_sdk import ApiConfig, AuthConfig, Client, ClientConfig, GenerationExportConfig
+
+
+def _required_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise RuntimeError(f"{name} must be set (see .env.example).")
+    return value
+
+
+def setup_sigil(
+    *,
+    tracer_provider: TracerProvider,
+    meter_provider: MeterProvider,
+) -> Client:
+    endpoint = _required_env("SIGIL_GENERATION_EXPORT_ENDPOINT")
+    api_endpoint = _required_env("SIGIL_API_ENDPOINT")
+    tenant_id = _required_env("SIGIL_TENANT_ID")
+    auth_token = os.getenv("SIGIL_AUTH_TOKEN", "").strip()
+
+    if auth_token:
+        # Grafana Cloud: basic auth (user = instance ID, password = access token).
+        auth = AuthConfig(
+            mode="basic",
+            tenant_id=tenant_id,
+            basic_user=tenant_id,
+            basic_password=auth_token,
+        )
+    else:
+        # Self-hosted / local dev: just X-Scope-OrgID, no credentials.
+        auth = AuthConfig(mode="tenant", tenant_id=tenant_id)
+
+    return Client(
+        ClientConfig(
+            generation_export=GenerationExportConfig(
+                protocol="http",
+                endpoint=endpoint,
+                auth=auth,
+            ),
+            api=ApiConfig(endpoint=api_endpoint),
+            tracer=tracer_provider.get_tracer("sigil-sdk"),
+            meter=meter_provider.get_meter("sigil-sdk"),
+        )
+    )

--- a/examples/python-langchain/app/telemetry.py
+++ b/examples/python-langchain/app/telemetry.py
@@ -1,0 +1,66 @@
+"""OpenTelemetry bootstrap.
+
+Sets up a TracerProvider + MeterProvider that export to an OTLP gRPC
+target (Sigil's OTLP ingest on :4317 by default) and registers them
+globally. Standard OTel — nothing Sigil-specific lives here.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+
+@dataclass
+class OpenTelemetry:
+    tracer_provider: TracerProvider
+    meter_provider: MeterProvider
+
+    def shutdown(self) -> None:
+        self.tracer_provider.shutdown()
+        self.meter_provider.shutdown()
+
+
+def _env(name: str, default: str) -> str:
+    value = os.getenv(name, default).strip()
+    return value or default
+
+
+def setup_opentelemetry() -> OpenTelemetry:
+    service_name = _env("OTEL_SERVICE_NAME", "sigil-langchain-weather-example")
+    otlp_endpoint = _env("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    otlp_insecure = _env("OTEL_EXPORTER_OTLP_INSECURE", "true").lower() == "true"
+
+    resource = Resource.create({"service.name": service_name})
+
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(
+        BatchSpanProcessor(
+            OTLPSpanExporter(endpoint=otlp_endpoint, insecure=otlp_insecure)
+        )
+    )
+    trace.set_tracer_provider(tracer_provider)
+
+    meter_provider = MeterProvider(
+        resource=resource,
+        metric_readers=[
+            PeriodicExportingMetricReader(
+                OTLPMetricExporter(endpoint=otlp_endpoint, insecure=otlp_insecure)
+            )
+        ],
+    )
+    metrics.set_meter_provider(meter_provider)
+
+    return OpenTelemetry(
+        tracer_provider=tracer_provider,
+        meter_provider=meter_provider,
+    )

--- a/examples/python-langchain/app/weather.py
+++ b/examples/python-langchain/app/weather.py
@@ -1,0 +1,46 @@
+"""Stubbed weather data for April 2026.
+
+The agent's `get_weather` tool reads from this table, so the demo is
+deterministic and needs no external weather API. Values are fictional.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Forecast:
+    city: str
+    date: str
+    condition: str
+    high_c: int
+    low_c: int
+    precipitation_mm: float
+
+
+_FORECASTS: dict[tuple[str, str], Forecast] = {
+    ("london", "2026-04-17"): Forecast("London", "2026-04-17", "Overcast with light drizzle", 14, 8, 2.1),
+    ("london", "2026-04-18"): Forecast("London", "2026-04-18", "Partly cloudy", 16, 9, 0.0),
+    ("london", "2026-04-19"): Forecast("London", "2026-04-19", "Sunny intervals", 18, 10, 0.0),
+    ("paris", "2026-04-17"): Forecast("Paris", "2026-04-17", "Sunny", 21, 11, 0.0),
+    ("paris", "2026-04-18"): Forecast("Paris", "2026-04-18", "Sunny", 22, 12, 0.0),
+    ("paris", "2026-04-19"): Forecast("Paris", "2026-04-19", "Thunderstorms in the evening", 20, 13, 8.4),
+    ("new york", "2026-04-17"): Forecast("New York", "2026-04-17", "Rain", 12, 7, 11.5),
+    ("new york", "2026-04-18"): Forecast("New York", "2026-04-18", "Clearing, breezy", 15, 6, 0.2),
+    ("new york", "2026-04-19"): Forecast("New York", "2026-04-19", "Sunny and cool", 17, 8, 0.0),
+    ("tokyo", "2026-04-17"): Forecast("Tokyo", "2026-04-17", "Clear, cherry blossom season winding down", 19, 12, 0.0),
+    ("tokyo", "2026-04-18"): Forecast("Tokyo", "2026-04-18", "Clear", 21, 13, 0.0),
+    ("tokyo", "2026-04-19"): Forecast("Tokyo", "2026-04-19", "Light rain", 18, 14, 3.6),
+    ("san francisco", "2026-04-17"): Forecast("San Francisco", "2026-04-17", "Morning fog, sunny afternoon", 17, 11, 0.0),
+    ("san francisco", "2026-04-18"): Forecast("San Francisco", "2026-04-18", "Sunny", 19, 12, 0.0),
+    ("san francisco", "2026-04-19"): Forecast("San Francisco", "2026-04-19", "Windy, partly cloudy", 16, 10, 0.0),
+}
+
+
+def lookup_forecast(city: str, date: str) -> Forecast | None:
+    return _FORECASTS.get((city.strip().lower(), date.strip()))
+
+
+def known_cities() -> list[str]:
+    return sorted({f.city for f in _FORECASTS.values()})

--- a/examples/python-langchain/mise.toml
+++ b/examples/python-langchain/mise.toml
@@ -1,0 +1,11 @@
+[env]
+PYTHONPATH = ""
+PYTHONHOME = ""
+
+[tasks.dev]
+description = "Run the FastAPI app with autoreload"
+run = "uv run uvicorn app.main:app --reload --port 8000"
+
+[tasks.sync]
+description = "Install deps into the local venv"
+run = "uv sync"

--- a/examples/python-langchain/pyproject.toml
+++ b/examples/python-langchain/pyproject.toml
@@ -1,0 +1,46 @@
+[project]
+name = "sigil-langchain-weather-example"
+version = "0.1.0"
+description = "Minimal FastAPI + LangChain weather agent instrumented with Sigil and OpenTelemetry."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.32",
+    "python-dotenv>=1.0",
+    "pydantic>=2.8",
+
+    "langchain>=1.2.15",
+    "langchain-core>=1.3.0",
+    "langchain-anthropic>=1.4.1",
+
+    "anthropic>=0.96",
+
+    "opentelemetry-api>=1.27",
+    "opentelemetry-sdk>=1.27",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.27",
+    "opentelemetry-instrumentation-fastapi>=0.48b0",
+
+    "sigil-sdk>=0.1.2",
+    "sigil-sdk-langchain>=0.1.2",
+]
+
+[tool.uv.sources]
+# Point at the local packages in this monorepo so the example runs against
+# the code in this checkout. Remove these two entries to consume the
+# published PyPI releases instead.
+sigil-sdk = { path = "../../python", editable = true }
+sigil-sdk-langchain = { path = "../../python-frameworks/langchain", editable = true }
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["app*"]
+
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+extraPaths = ["../../python", "../../python-frameworks/langchain"]


### PR DESCRIPTION
Adds a small FastAPI example under `examples/python-langchain/` that demonstrates two ways to instrument LLM calls with Sigil from the same app:

- A LangChain agent wired up with `with_sigil_langchain_callbacks(...)`.
- A direct Anthropic call recorded manually with `sigil.start_generation(...)` / `rec.set_result(...)`.

Both calls share a `conversation_id` so they group together in the Sigil UI. OTel traces and metrics flow through an OTLP gRPC exporter, and the Sigil client reuses the same providers.

See `examples/python-langchain/README.md` for setup and example requests.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new standalone example app and does not modify existing library/runtime code; risk is mainly around keeping dependencies and environment configuration for the demo accurate.
> 
> **Overview**
> Adds a new `examples/python-langchain` FastAPI "weather" service that demonstrates **two Sigil instrumentation paths in one app**: LangChain agent tracing via `with_sigil_langchain_callbacks(...)` and a direct Anthropic call recorded manually with `sigil.start_generation(...)`/`rec.set_result(...)`, both grouped under a shared `conversation_id`.
> 
> Includes OpenTelemetry bootstrap + FastAPI instrumentation, a Sigil client wired to the app’s OTel providers, stubbed deterministic weather data/tools, and example project scaffolding (`pyproject.toml`, `mise.toml`, `.env.example`, `.gitignore`, and README with run instructions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69a74c3867d6385fdb972dd26726c636c30e2603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->