### PR TITLE
chore(deps): bump OpenTelemetry to 1.15.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,8 +143,11 @@ jobs:
         with:
           global-json-file: dotnet/global.json
 
+      - name: Restore
+        run: dotnet restore dotnet/Sigil.DotNet.slnx
+
       - name: Format check
-        run: dotnet format dotnet/Sigil.DotNet.slnx --verify-no-changes
+        run: dotnet format dotnet/Sigil.DotNet.slnx --verify-no-changes --no-restore
 
       - name: Test
         run: dotnet test dotnet/Sigil.DotNet.slnx -c Release

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -7,8 +7,8 @@
     <PackageVersion Include="Grpc.Net.Client" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.78.0" PrivateAssets="All" />
     <PackageVersion Include="OpenAI" Version="2.9.1" />
-    <PackageVersion Include="OpenTelemetry" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
   <!-- Test dependencies -->


### PR DESCRIPTION
The CI was failing, and the actual error was hidden by the `dotnet format dotnet/Sigil.DotNet.slnx --verify-no-changes` step. Split it in two (`dotnet restore` then `dotnet format --no-restore`), so that the errors are visible in the logs.

Also bump OpenTelemetry to 1.15.3 to actually fix the CI [errors](https://github.com/grafana/sigil-sdk/actions/runs/24996822799/job/73195874410):

```
error NU1902: Warning As Error: Package 'OpenTelemetry.Api' 1.15.2 
has a known moderate severity vulnerability, https://github.com/advisories/GHSA-g94r-2vxg-569j
...
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI workflow tweak and a patch-level dependency update; potential impact is limited to .NET build/format behavior and runtime telemetry package compatibility.
> 
> **Overview**
> Improves the .NET CI job by running `dotnet restore` as an explicit step and switching `dotnet format` to `--no-restore`, making restore failures surface clearly in logs.
> 
> Bumps `OpenTelemetry` and `OpenTelemetry.Exporter.OpenTelemetryProtocol` from `1.15.2` to `1.15.3` in `dotnet/Directory.Packages.props` to resolve the vulnerability-related NuGet failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01bd2e588415697309763fff32e3c7c2b275d433. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->