### PR TITLE
feat(java): add Maven Central publishing via Central Portal

### DIFF
--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -46,6 +46,7 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ fromJSON(steps.get-secrets.outputs.secrets).CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ fromJSON(steps.get-secrets.outputs.secrets).GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ fromJSON(steps.get-secrets.outputs.secrets).GPG_PASSPHRASE }}
+          PKG_VERSION: ${{ inputs.version }}
         run: |
           ./gradlew --no-daemon publishAllPublicationsToMavenCentralRepository \
-            -Pversion="${{ inputs.version }}"
+            -Pversion="${PKG_VERSION}"

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -23,16 +23,12 @@ jobs:
       - name: Get secrets from Vault
         id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
-        env:
-          VAULT_INSTANCE: ops
         with:
-          vault_instance: ${{ env.VAULT_INSTANCE }}
-          common_secrets: |
-            MAVEN_USERNAME=sigil-maven:username
-            MAVEN_PASSWORD=sigil-maven:password
-            GPG_PRIVATE_KEY=sigil-maven:gpg-private-key
-            GPG_PASSPHRASE=sigil-maven:gpg-passphrase
-          export_env: false
+          repo_secrets: |
+            CENTRAL_USERNAME=secrets:username
+            CENTRAL_PASSWORD=secrets:password
+            GPG_PRIVATE_KEY=gpg:private-key
+            GPG_PASSPHRASE=gpg:passphrase
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -43,18 +39,13 @@ jobs:
           distribution: temurin
           java-version: '21'
 
-      - name: Publish
+      - name: Publish to Maven Central
         working-directory: java
         env:
-          PKG_VERSION: ${{ inputs.version }}
-          OSSRH_USERNAME: ${{ fromJSON(steps.get-secrets.outputs.secrets).MAVEN_USERNAME }}
-          OSSRH_PASSWORD: ${{ fromJSON(steps.get-secrets.outputs.secrets).MAVEN_PASSWORD }}
-          SIGNING_KEY: ${{ fromJSON(steps.get-secrets.outputs.secrets).GPG_PRIVATE_KEY }}
-          SIGNING_PASSWORD: ${{ fromJSON(steps.get-secrets.outputs.secrets).GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ fromJSON(steps.get-secrets.outputs.secrets).CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ fromJSON(steps.get-secrets.outputs.secrets).CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ fromJSON(steps.get-secrets.outputs.secrets).GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ fromJSON(steps.get-secrets.outputs.secrets).GPG_PASSPHRASE }}
         run: |
-          ./gradlew --no-daemon publish \
-            -Pversion="${PKG_VERSION}" \
-            -PossrhUsername="${OSSRH_USERNAME}" \
-            -PossrhPassword="${OSSRH_PASSWORD}" \
-            -Psigning.key="${SIGNING_KEY}" \
-            -Psigning.password="${SIGNING_PASSWORD}"
+          ./gradlew --no-daemon publishAllPublicationsToMavenCentralRepository \
+            -Pversion="${{ inputs.version }}"

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -1,11 +1,12 @@
 plugins {
     alias(libs.plugins.jmh) apply false
     alias(libs.plugins.protobuf) apply false
+    alias(libs.plugins.maven.publish) apply false
 }
 
 allprojects {
     group = "com.grafana.sigil"
-    version = "0.1.0"
+    version = findProperty("version")?.toString() ?: "0.1.0-SNAPSHOT"
 }
 
 subprojects {
@@ -18,6 +19,42 @@ subprojects {
 
         tasks.withType<Test>().configureEach {
             useJUnitPlatform()
+        }
+    }
+
+    plugins.withId("com.vanniktech.maven.publish") {
+        extensions.configure<com.vanniktech.maven.publish.MavenPublishBaseExtension> {
+            publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL)
+            signAllPublications()
+
+            pom {
+                name.set(project.name)
+                description.set("Sigil SDK for Java - ${project.name}")
+                url.set("https://github.com/grafana/sigil-sdk")
+                inceptionYear.set("2025")
+
+                licenses {
+                    license {
+                        name.set("Apache License, Version 2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                        distribution.set("repo")
+                    }
+                }
+
+                developers {
+                    developer {
+                        id.set("grafana")
+                        name.set("Grafana Labs")
+                        url.set("https://grafana.com")
+                    }
+                }
+
+                scm {
+                    url.set("https://github.com/grafana/sigil-sdk")
+                    connection.set("scm:git:git://github.com/grafana/sigil-sdk.git")
+                    developerConnection.set("scm:git:ssh://git@github.com/grafana/sigil-sdk.git")
+                }
+            }
         }
     }
 }

--- a/java/core/build.gradle.kts
+++ b/java/core/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
     `java-library`
     alias(libs.plugins.protobuf)
+    alias(libs.plugins.maven.publish)
 }
 
-java {
-    withJavadocJar()
-    withSourcesJar()
+mavenPublishing {
+    coordinates(artifactId = "sigil-sdk-core")
 }
 
 val protoRoot = rootProject.projectDir.resolve("../proto")

--- a/java/frameworks/google-adk/build.gradle.kts
+++ b/java/frameworks/google-adk/build.gradle.kts
@@ -1,5 +1,15 @@
 plugins {
     `java-library`
+    alias(libs.plugins.maven.publish)
+}
+
+mavenPublishing {
+    coordinates(artifactId = "sigil-sdk-google-adk")
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
 dependencies {

--- a/java/frameworks/google-adk/build.gradle.kts
+++ b/java/frameworks/google-adk/build.gradle.kts
@@ -7,11 +7,6 @@ mavenPublishing {
     coordinates(artifactId = "sigil-sdk-google-adk")
 }
 
-java {
-    withJavadocJar()
-    withSourcesJar()
-}
-
 dependencies {
     api(project(":core"))
 

--- a/java/gradle/libs.versions.toml
+++ b/java/gradle/libs.versions.toml
@@ -48,3 +48,4 @@ google-genai = { module = "com.google.genai:google-genai", version = "1.44.0" }
 [plugins]
 protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
 jmh = { id = "me.champeau.jmh", version.ref = "jmh" }
+maven-publish = { id = "com.vanniktech.maven.publish", version = "0.30.0" }

--- a/java/providers/anthropic/build.gradle.kts
+++ b/java/providers/anthropic/build.gradle.kts
@@ -7,11 +7,6 @@ mavenPublishing {
     coordinates(artifactId = "sigil-sdk-anthropic")
 }
 
-java {
-    withJavadocJar()
-    withSourcesJar()
-}
-
 dependencies {
     api(project(":core"))
     compileOnly(libs.anthropic.java)

--- a/java/providers/anthropic/build.gradle.kts
+++ b/java/providers/anthropic/build.gradle.kts
@@ -1,5 +1,15 @@
 plugins {
     `java-library`
+    alias(libs.plugins.maven.publish)
+}
+
+mavenPublishing {
+    coordinates(artifactId = "sigil-sdk-anthropic")
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
 dependencies {

--- a/java/providers/gemini/build.gradle.kts
+++ b/java/providers/gemini/build.gradle.kts
@@ -1,5 +1,15 @@
 plugins {
     `java-library`
+    alias(libs.plugins.maven.publish)
+}
+
+mavenPublishing {
+    coordinates(artifactId = "sigil-sdk-gemini")
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
 dependencies {

--- a/java/providers/gemini/build.gradle.kts
+++ b/java/providers/gemini/build.gradle.kts
@@ -7,11 +7,6 @@ mavenPublishing {
     coordinates(artifactId = "sigil-sdk-gemini")
 }
 
-java {
-    withJavadocJar()
-    withSourcesJar()
-}
-
 dependencies {
     api(project(":core"))
     compileOnly(libs.google.genai)

--- a/java/providers/openai/build.gradle.kts
+++ b/java/providers/openai/build.gradle.kts
@@ -7,11 +7,6 @@ mavenPublishing {
     coordinates(artifactId = "sigil-sdk-openai")
 }
 
-java {
-    withJavadocJar()
-    withSourcesJar()
-}
-
 dependencies {
     api(project(":core"))
     compileOnly(libs.openai.java)

--- a/java/providers/openai/build.gradle.kts
+++ b/java/providers/openai/build.gradle.kts
@@ -1,5 +1,15 @@
 plugins {
     `java-library`
+    alias(libs.plugins.maven.publish)
+}
+
+mavenPublishing {
+    coordinates(artifactId = "sigil-sdk-openai")
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
 dependencies {

--- a/java/settings.gradle.kts
+++ b/java/settings.gradle.kts
@@ -20,6 +20,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
## Summary
- Add vanniktech maven-publish plugin for Central Portal support
- Configure publishing for core, providers (openai, anthropic, gemini), and google-adk modules
- Update workflow to use repo_secrets for Vault credentials
- Add GPG signing and POM metadata configuration

## Artifacts published
- `com.grafana.sigil:sigil-sdk-core`
- `com.grafana.sigil:sigil-sdk-openai`
- `com.grafana.sigil:sigil-sdk-anthropic`
- `com.grafana.sigil:sigil-sdk-gemini`
- `com.grafana.sigil:sigil-sdk-google-adk`

## Vault secrets required
The following secrets need to be configured at `ci/repo/github/grafana/sigil-sdk/`:

| Path | Key | Description |
|------|-----|-------------|
| `secrets` | `username` | Central Portal token username |
| `secrets` | `password` | Central Portal token password |
| `gpg` | `private-key` | ASCII-armored GPG private key |
| `gpg` | `passphrase` | GPG key passphrase |

## Test plan
- [ ] Verify Gradle build succeeds: `cd java && ./gradlew build`
- [ ] Verify publishing tasks exist: `./gradlew tasks --group=publishing`
- [ ] After merge, trigger workflow manually with a test version

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release/publishing pipeline and signing/credentials handling; misconfiguration could break releases or publish incorrect artifacts.
> 
> **Overview**
> Enables publishing Java artifacts to Maven Central via the **Sonatype Central Portal** using the `com.vanniktech.maven.publish` plugin, including shared POM metadata and GPG signing configuration across subprojects.
> 
> Updates the release workflow to fetch Central Portal/GPG secrets from Vault as `repo_secrets`, pass them via `ORG_GRADLE_PROJECT_*` env vars, and publish using `publishAllPublicationsToMavenCentralRepository` with a version supplied via `-Pversion`. Also changes default project versioning to be property-driven (`0.1.0-SNAPSHOT` fallback) and adds per-module Maven coordinates for `core`, provider modules, and `google-adk`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49e04d4e20f85d848d09ec9383d635cd4c469e80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->