### PR TITLE
feat(python): Add Pydantic AI framework integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
           - { name: llamaindex, cmd: "uv run --with './python[dev]' --with './python-frameworks/llamaindex[dev]' pytest python-frameworks/llamaindex/tests" }
           - { name: google-adk, cmd: "uv run --with './python[dev]' --with './python-frameworks/google-adk[dev]' pytest python-frameworks/google-adk/tests" }
           - { name: litellm, cmd: "uv run --with './python[dev]' --with './python-frameworks/litellm[dev]' pytest python-frameworks/litellm/tests" }
+          - { name: pydantic-ai, cmd: "uv run --with './python[dev]' --with './python-frameworks/pydantic-ai[dev]' pytest python-frameworks/pydantic-ai/tests" }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ __pycache__/
 *.egg-info/
 .pytest_cache/
 .mypy_cache/
+python-frameworks/pydantic-ai/build
 
 # e2e outputs
 /test-results/
@@ -67,3 +68,5 @@ __pycache__/
 .eslintcache
 .turbo/
 scripts/mysql-port-forward.sh
+
+examples/getting-started/python-pydantic-ai/.env

--- a/examples/getting-started/python-pydantic-ai/.env.example
+++ b/examples/getting-started/python-pydantic-ai/.env.example
@@ -1,0 +1,23 @@
+# Anthropic API key (required). The agent runs against `anthropic:claude-haiku-4-5`.
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Sigil service host. Copy the URL shown in your stack's "SDK connection details" panel.
+SIGIL_ENDPOINT=https://sigil-prod-eu-west-2.grafana.net
+
+# Stack / instance ID. Used as the basic-auth user and the X-Scope-OrgID tenant.
+GRAFANA_INSTANCE_ID=
+
+# Grafana Cloud access policy token (basic-auth password).
+GRAFANA_CLOUD_TOKEN=
+
+# --- OTel traces + metrics exporter ---
+# The Sigil SDK emits OTel spans and metrics.
+# Option A — Direct to Cloud (URL + token from Cloud portal -> stack -> OpenTelemetry):
+#   OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
+#   OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64 of GRAFANA_INSTANCE_ID:GRAFANA_CLOUD_TOKEN>
+#   # e.g.  echo -n "$GRAFANA_INSTANCE_ID:$GRAFANA_CLOUD_TOKEN" | base64
+# Option B — Via local Alloy/collector:
+#   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+OTEL_EXPORTER_OTLP_ENDPOINT=
+OTEL_EXPORTER_OTLP_HEADERS=
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf

--- a/examples/getting-started/python-pydantic-ai/README.md
+++ b/examples/getting-started/python-pydantic-ai/README.md
@@ -1,0 +1,23 @@
+# Getting Started — Python + Pydantic AI
+
+Runs a Pydantic AI agent and records the generation to Grafana Cloud AI Observability via the `sigil-sdk-pydantic-ai` capability.
+
+## Setup
+
+```bash
+cd examples/getting-started/python-pydantic-ai
+# Set ANTHROPIC_API_KEY, GRAFANA_INSTANCE_ID, GRAFANA_CLOUD_TOKEN, SIGIL_ENDPOINT
+# See the SDK README for where to find each value.
+```
+
+```bash
+pip install -r requirements.txt
+```
+
+## Run
+
+```bash
+python main.py
+```
+
+You should see the LLM response printed, followed by `Done`. Open the AI Observability plugin in your Grafana Cloud stack to see the recorded generation, and check your Grafana Cloud Traces and Metrics datasources for SDK-emitted spans and metrics.

--- a/examples/getting-started/python-pydantic-ai/main.py
+++ b/examples/getting-started/python-pydantic-ai/main.py
@@ -1,0 +1,96 @@
+"""Minimal AI Observability getting-started example — Python + Pydantic AI."""
+
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from dotenv import load_dotenv
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from pydantic_ai import Agent, RunContext
+from sigil_sdk import (
+    AuthConfig,
+    Client,
+    ClientConfig,
+    GenerationExportConfig,
+    with_conversation_title,
+)
+from sigil_sdk_pydantic_ai import with_sigil_pydantic_ai_capability
+
+load_dotenv()
+
+
+@dataclass
+class Deps:
+    conversation_id: str
+
+
+# Register OTel providers so SDK-emitted traces and metrics are exported.
+# OTLPSpanExporter / OTLPMetricExporter pick up OTEL_EXPORTER_OTLP_ENDPOINT and
+# OTEL_EXPORTER_OTLP_HEADERS automatically.
+resource = Resource.create({"service.name": "getting-started-python-pydantic-ai"})
+
+tp = TracerProvider(resource=resource)
+tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+trace.set_tracer_provider(tp)
+
+mp = MeterProvider(
+    resource=resource,
+    metric_readers=[PeriodicExportingMetricReader(OTLPMetricExporter())],
+)
+metrics.set_meter_provider(mp)
+
+sigil = Client(
+    ClientConfig(
+        generation_export=GenerationExportConfig(
+            protocol="http",
+            endpoint=os.environ["SIGIL_ENDPOINT"],
+            auth=AuthConfig(
+                mode="basic",
+                tenant_id=os.environ["GRAFANA_INSTANCE_ID"],
+                basic_password=os.environ["GRAFANA_CLOUD_TOKEN"],
+            ),
+        ),
+    )
+)
+
+agent = Agent(
+    "anthropic:claude-haiku-4-5",
+    deps_type=Deps,
+    capabilities=with_sigil_pydantic_ai_capability(None, client=sigil),
+)
+
+
+@agent.tool
+def get_current_time(ctx: RunContext[Deps]) -> str:
+    """Return the current UTC time in ISO 8601 format."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+deps = Deps(
+    conversation_id=f"getting-started-python-pydantic-ai-{uuid.uuid4().hex[:12]}"
+)
+
+with with_conversation_title("getting-started-python-pydantic-ai"):
+    first = agent.run_sync("What is the current UTC time?", deps=deps)
+    print(f"Reply 1: {first.output}\n")
+
+    second = agent.run_sync(
+        "Now explain what LLM observability is in one sentence.",
+        deps=deps,
+        message_history=first.all_messages(),
+    )
+    print(f"Reply 2: {second.output}\n")
+
+# Shut down Sigil first so in-flight generations finish exporting before OTel stops.
+sigil.shutdown()
+tp.shutdown()
+mp.shutdown()
+print("Done — check the AI Observability plugin in your Grafana Cloud stack.")

--- a/examples/getting-started/python-pydantic-ai/requirements.txt
+++ b/examples/getting-started/python-pydantic-ai/requirements.txt
@@ -1,0 +1,6 @@
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-http
+pydantic-ai
+python-dotenv
+sigil-sdk
+sigil-sdk-pydantic-ai

--- a/python-frameworks/pydantic-ai/LICENSE
+++ b/python-frameworks/pydantic-ai/LICENSE
@@ -1,0 +1,3 @@
+SPDX-License-Identifier: Apache-2.0
+
+See /LICENSE at repository root for full license text.

--- a/python-frameworks/pydantic-ai/README.md
+++ b/python-frameworks/pydantic-ai/README.md
@@ -1,0 +1,85 @@
+# Grafana AI Observability Python Framework Module: Pydantic AI
+
+`sigil-sdk-pydantic-ai` provides an `AbstractCapability` implementation that maps Pydantic AI lifecycle hooks into Sigil generation recorder lifecycles.
+
+## Installation
+
+```bash
+pip install sigil-sdk sigil-sdk-pydantic-ai
+pip install pydantic-ai
+```
+
+## Quickstart
+
+```python
+from pydantic_ai import Agent
+from sigil_sdk import Client
+from sigil_sdk_pydantic_ai import create_sigil_pydantic_ai_capability
+
+client = Client()
+capability = create_sigil_pydantic_ai_capability(client=client, provider_resolver="auto")
+
+agent = Agent("openai:gpt-4o", capabilities=[capability])
+result = agent.run_sync("What is the weather?")
+print(result.output)
+
+client.shutdown()
+```
+
+## End-to-end example (run + run_stream)
+
+```python
+from pydantic_ai import Agent
+from sigil_sdk import Client
+from sigil_sdk_pydantic_ai import with_sigil_pydantic_ai_capability
+
+client = Client()
+capabilities = with_sigil_pydantic_ai_capability(
+    None,
+    client=client,
+    provider_resolver="auto",
+    agent_name="pydantic-ai-example",
+    agent_version="1.0.0",
+)
+
+agent = Agent("openai:gpt-4o-mini", capabilities=capabilities)
+
+# Non-stream call -> SYNC generation mode.
+result = agent.run_sync("Summarize why retry budgets matter.")
+print(result.output)
+
+# Stream call -> STREAM generation mode + TTFT tracking.
+async def stream_example() -> None:
+    async with agent.run_stream("Give me three short reliability tips.") as stream:
+        async for chunk in stream.stream_text():
+            print(chunk, end="", flush=True)
+        print()
+
+import asyncio
+asyncio.run(stream_example())
+
+client.shutdown()
+```
+
+## Conversation mapping
+
+Primary mapping is Pydantic AI run identity:
+
+1. `conversation_id` / `session_id` from `ctx.deps` or `ctx.metadata`
+2. `thread_id` from `ctx.deps` or `ctx.metadata`
+3. fallback `sigil:framework:pydantic-ai:<run_id>`
+
+## Metadata and lineage
+
+- Required: `sigil.framework.run_type`
+- Optional: `sigil.framework.run_id`, `sigil.framework.parent_run_id`, `sigil.framework.thread_id`, `sigil.framework.event_id`, `sigil.framework.component_name`, `sigil.framework.retry_attempt`
+
+## Provider resolver
+
+Resolver order: explicit provider option -> callback payload -> model prefix inference -> `custom`.
+
+## Troubleshooting
+
+- Provide stable `conversation_id` via `ctx.deps` or `ctx.metadata` to avoid fragmented conversations.
+- If model aliases are custom, set explicit `provider` on the handler.
+- Always call `client.shutdown()` during teardown to flush buffered telemetry.

--- a/python-frameworks/pydantic-ai/pyproject.toml
+++ b/python-frameworks/pydantic-ai/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "sigil-sdk-pydantic-ai"
+version = "0.1.2"
+description = "Pydantic AI capability for Sigil Python SDK"
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.10"
+dependencies = [
+  "sigil-sdk>=0.1.2",
+  "pydantic-ai>=1.86.0,<2.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.2.0",
+]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["sigil_sdk_pydantic_ai*"]
+
+[tool.setuptools.package-data]
+sigil_sdk_pydantic_ai = ["py.typed"]

--- a/python-frameworks/pydantic-ai/sigil_sdk_pydantic_ai/__init__.py
+++ b/python-frameworks/pydantic-ai/sigil_sdk_pydantic_ai/__init__.py
@@ -1,0 +1,15 @@
+from .capability import (
+    SigilPydanticAICapability,
+    create_sigil_pydantic_ai_capability,
+    create_sigil_pydantic_ai_handler,
+    with_sigil_pydantic_ai_capability,
+)
+from .handler import SigilPydanticAIHandler
+
+__all__ = [
+    "SigilPydanticAICapability",
+    "SigilPydanticAIHandler",
+    "create_sigil_pydantic_ai_capability",
+    "create_sigil_pydantic_ai_handler",
+    "with_sigil_pydantic_ai_capability",
+]

--- a/python-frameworks/pydantic-ai/sigil_sdk_pydantic_ai/capability.py
+++ b/python-frameworks/pydantic-ai/sigil_sdk_pydantic_ai/capability.py
@@ -15,7 +15,7 @@ from pydantic_ai.exceptions import (
     SkipToolValidation,
     ToolRetryError,
 )
-from sigil_sdk import Client, ToolDefinition
+from sigil_sdk import Client, TokenUsage, ToolDefinition
 
 from .handler import SigilPydanticAIHandler
 
@@ -401,9 +401,8 @@ def _map_pydantic_response(response: Any, fallback_model_name: str) -> dict[str,
     if finish_reason != "":
         llm_output["finish_reason"] = finish_reason
 
-    usage = _read(response, "usage")
-    token_usage = _map_pydantic_usage(usage)
-    if token_usage:
+    token_usage = _map_pydantic_usage(_read(response, "usage"))
+    if token_usage is not None:
         llm_output["token_usage"] = token_usage
 
     text = _extract_response_text(response)
@@ -417,27 +416,21 @@ def _map_pydantic_response(response: Any, fallback_model_name: str) -> dict[str,
     return payload
 
 
-_USAGE_FIELD_MAP: dict[str, str] = {
-    "input_tokens": "prompt_tokens",
-    "output_tokens": "completion_tokens",
-    "cache_read_tokens": "cache_read_input_tokens",
-    "cache_write_tokens": "cache_creation_input_tokens",
-}
-
-
-def _map_pydantic_usage(usage: Any) -> dict[str, int]:
+def _map_pydantic_usage(usage: Any) -> TokenUsage | None:
     if usage is None:
-        return {}
-    token_usage: dict[str, int] = {}
-    for src, dst in _USAGE_FIELD_MAP.items():
-        val = _int_or_none(_read(usage, src))
-        if val is not None:
-            token_usage[dst] = val
-    prompt = token_usage.get("prompt_tokens", 0)
-    completion = token_usage.get("completion_tokens", 0)
-    if prompt or completion:
-        token_usage["total_tokens"] = prompt + completion
-    return token_usage
+        return None
+    input_tokens = _int_or_none(_read(usage, "input_tokens"))
+    output_tokens = _int_or_none(_read(usage, "output_tokens"))
+    cache_read = _int_or_none(_read(usage, "cache_read_tokens"))
+    cache_write = _int_or_none(_read(usage, "cache_write_tokens"))
+    if input_tokens is None and output_tokens is None and cache_read is None and cache_write is None:
+        return None
+    return TokenUsage(
+        input_tokens=input_tokens or 0,
+        output_tokens=output_tokens or 0,
+        cache_read_input_tokens=cache_read or 0,
+        cache_creation_input_tokens=cache_write or 0,
+    ).normalize()
 
 
 def _extract_response_text(response: Any) -> str:

--- a/python-frameworks/pydantic-ai/sigil_sdk_pydantic_ai/capability.py
+++ b/python-frameworks/pydantic-ai/sigil_sdk_pydantic_ai/capability.py
@@ -1,0 +1,534 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+from uuid import UUID, uuid4
+
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.exceptions import (
+    ApprovalRequired,
+    CallDeferred,
+    ModelRetry,
+    SkipModelRequest,
+    SkipToolExecution,
+    SkipToolValidation,
+    ToolRetryError,
+)
+from sigil_sdk import Client, ToolDefinition
+
+from .handler import SigilPydanticAIHandler
+
+logger = logging.getLogger(__name__)
+
+# Pydantic AI control-flow exceptions that must propagate without error recording.
+_PYDANTIC_CONTROL_FLOW: tuple[type[BaseException], ...] = (
+    ModelRetry,
+    SkipModelRequest,
+    SkipToolValidation,
+    SkipToolExecution,
+    CallDeferred,
+    ApprovalRequired,
+    ToolRetryError,
+)
+
+
+def create_sigil_pydantic_ai_handler(*, client: Client, **handler_kwargs: Any) -> SigilPydanticAIHandler:
+    """Create a Pydantic AI Sigil handler."""
+    return SigilPydanticAIHandler(client=client, **handler_kwargs)
+
+
+class SigilPydanticAICapability(AbstractCapability):
+    """Pydantic AI capability bridge that maps lifecycle hooks to Sigil handlers."""
+
+    def __init__(self, sigil_handler: SigilPydanticAIHandler) -> None:
+        self._sigil_handler = sigil_handler
+        self._run_stack: list[UUID] = []
+        self._llm_run_ids: list[UUID] = []
+
+    async def for_run(self, ctx: Any) -> SigilPydanticAICapability:
+        """Per-run isolated state — each agent run gets its own stacks."""
+        return SigilPydanticAICapability(self._sigil_handler)
+
+    async def wrap_run(self, ctx: Any, *, handler: Any) -> Any:
+        run_id = uuid4()
+        self._run_stack.append(run_id)
+
+        run_name = _agent_name(ctx)
+        metadata = _run_context_metadata(ctx)
+        try:
+            self._sigil_handler.on_chain_start(
+                {"name": run_name},
+                {},
+                run_id=run_id,
+                parent_run_id=None,
+                metadata=metadata,
+                run_type="agent",
+                run_name=run_name,
+            )
+        except BaseException:
+            _remove(self._run_stack, run_id)
+            raise
+
+        try:
+            result = await handler()
+        except BaseException as exc:
+            _remove(self._run_stack, run_id)
+            if isinstance(exc, _PYDANTIC_CONTROL_FLOW):
+                self._sigil_handler._discard_chain_run(run_id=run_id)
+            else:
+                try:
+                    self._sigil_handler.on_chain_error(exc, run_id=run_id)
+                except Exception:
+                    logger.debug("sigil: failed to record chain error", exc_info=True)
+            raise
+
+        _remove(self._run_stack, run_id)
+        try:
+            self._sigil_handler.on_chain_end({"status": "completed"}, run_id=run_id)
+        except Exception:
+            logger.debug("sigil: failed to record chain end", exc_info=True)
+        return result
+
+    async def wrap_model_request(self, ctx: Any, *, request_context: Any, handler: Any) -> Any:
+        run_id = uuid4()
+        self._llm_run_ids.append(run_id)
+
+        parent_run_id = self._run_stack[-1] if self._run_stack else None
+
+        model_name = _resolve_pydantic_model_name(request_context)
+        invocation_params = _build_invocation_params(model_name, request_context, handler)
+
+        messages = _map_pydantic_messages(request_context)
+        serialized: dict[str, Any] = {"name": _agent_name(ctx)}
+        if model_name != "":
+            serialized["kwargs"] = {"model": model_name}
+
+        metadata = _run_context_metadata(ctx)
+        try:
+            self._sigil_handler.on_chat_model_start(
+                serialized,
+                [messages],
+                run_id=run_id,
+                parent_run_id=parent_run_id,
+                invocation_params=invocation_params,
+                metadata=metadata,
+                run_name=_agent_name(ctx),
+            )
+        except BaseException:
+            _remove(self._llm_run_ids, run_id)
+            raise
+
+        try:
+            response = await handler(request_context)
+        except BaseException as exc:
+            _remove(self._llm_run_ids, run_id)
+            if isinstance(exc, _PYDANTIC_CONTROL_FLOW):
+                self._sigil_handler._discard_llm_run(run_id=run_id)
+            else:
+                try:
+                    self._sigil_handler.on_llm_error(exc, run_id=run_id)
+                except Exception:
+                    logger.debug("sigil: failed to record LLM error", exc_info=True)
+            raise
+
+        _remove(self._llm_run_ids, run_id)
+        try:
+            self._sigil_handler.on_llm_end(_map_pydantic_response(response, model_name), run_id=run_id)
+        except Exception:
+            logger.debug("sigil: failed to record LLM end", exc_info=True)
+        return response
+
+    async def on_model_request_error(self, ctx: Any, *, request_context: Any, error: Any) -> Any:
+        # wrap_model_request already handles cleanup and error reporting;
+        # this hook fires after the wrapper re-raises, so just propagate.
+        raise error
+
+    async def wrap_tool_execute(self, ctx: Any, *, call: Any, tool_def: Any, args: Any, handler: Any) -> Any:
+        run_id = uuid4()
+
+        # Pydantic AI runs tools in CallToolsNode after ModelRequestNode
+        # completes, so _llm_run_ids is always empty here. Use the agent run.
+        parent_run_id = self._run_stack[-1] if self._run_stack else None
+
+        tool_name = _tool_name(call, tool_def)
+        metadata = _run_context_metadata(ctx)
+        self._sigil_handler.on_tool_start(
+            {"name": tool_name, "description": _as_string(_read(tool_def, "description"))},
+            "",
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+            metadata=metadata,
+            run_name=tool_name,
+            inputs=args,
+        )
+
+        try:
+            result = await handler(args)
+        except BaseException as exc:
+            if isinstance(exc, _PYDANTIC_CONTROL_FLOW):
+                self._sigil_handler._discard_tool_run(run_id=run_id)
+            else:
+                try:
+                    self._sigil_handler.on_tool_error(exc, run_id=run_id)
+                except Exception:
+                    logger.debug("sigil: failed to record tool error", exc_info=True)
+            raise
+
+        try:
+            self._sigil_handler.on_tool_end(result, run_id=run_id)
+        except Exception:
+            logger.debug("sigil: failed to record tool end", exc_info=True)
+        return result
+
+    async def on_tool_execute_error(self, ctx: Any, *, call: Any, tool_def: Any, args: Any, error: Any) -> Any:
+        # wrap_tool_execute already handles cleanup and error reporting;
+        # this hook fires after the wrapper re-raises, so just propagate.
+        raise error
+
+    async def wrap_run_event_stream(self, ctx: Any, *, stream: Any) -> Any:
+        async for event in stream:
+            token = _extract_stream_token(event)
+            if token != "" and self._llm_run_ids:
+                try:
+                    self._sigil_handler.on_llm_new_token(token, run_id=self._llm_run_ids[-1])
+                except Exception:
+                    logger.debug("sigil: failed to record stream token", exc_info=True)
+            yield event
+
+
+def create_sigil_pydantic_ai_capability(*, client: Client, **handler_kwargs: Any) -> SigilPydanticAICapability:
+    """Create a Pydantic AI capability wired to Sigil instrumentation."""
+    return SigilPydanticAICapability(create_sigil_pydantic_ai_handler(client=client, **handler_kwargs))
+
+
+def with_sigil_pydantic_ai_capability(
+    capabilities: list[Any] | None,
+    *,
+    client: Client,
+    **handler_kwargs: Any,
+) -> list[Any]:
+    """Add a Sigil capability to a list, with double-injection guard."""
+    result = list(capabilities or [])
+    if any(isinstance(cap, SigilPydanticAICapability) for cap in result):
+        return result
+    result.append(create_sigil_pydantic_ai_capability(client=client, **handler_kwargs))
+    return result
+
+
+def _remove(stack: list[UUID], run_id: UUID) -> None:
+    try:
+        stack.remove(run_id)
+    except ValueError:
+        pass
+
+
+def _agent_name(ctx: Any) -> str:
+    for candidate in (
+        _as_string(_read(_read(ctx, "agent"), "name")),
+        _as_string(_read(_read(ctx, "model"), "name")),
+        _as_string(_read(_read(ctx, "model"), "model_name")),
+    ):
+        if candidate != "":
+            return candidate
+    return "pydantic_ai_agent"
+
+
+def _build_invocation_params(model_name: str, request_context: Any, handler: Any) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+    if model_name != "":
+        params["model"] = model_name
+
+    settings = _read(request_context, "model_settings")
+    for key in ("temperature", "max_tokens", "top_p", "tool_choice", "seed", "presence_penalty", "frequency_penalty"):
+        value = _read(settings, key)
+        if value is not None:
+            params[key] = value
+
+    request_params = _read(request_context, "model_request_parameters")
+    tools = _map_pydantic_tools(request_params)
+    if tools:
+        params["tools"] = tools
+
+    system_prompt = _join_instruction_parts(request_params)
+    if system_prompt != "":
+        params["system_prompt"] = system_prompt
+
+    # Pydantic AI streams via a dedicated handler closure named `_streaming_handler`
+    # in `pydantic_ai._agent_graph`. wrap_run_event_stream fires *after* on_chat_model_start,
+    # so this is the only signal we have at this point.
+    if getattr(handler, "__name__", "") == "_streaming_handler":
+        params["stream"] = True
+
+    return params
+
+
+def _map_pydantic_tools(request_params: Any) -> list[ToolDefinition]:
+    tool_defs = _read(request_params, "function_tools")
+    if not isinstance(tool_defs, (list, tuple)):
+        return []
+    result: list[ToolDefinition] = []
+    for tool_def in tool_defs:
+        name = _as_string(_read(tool_def, "name"))
+        if name == "":
+            continue
+        result.append(
+            ToolDefinition(
+                name=name,
+                description=_as_string(_read(tool_def, "description")),
+                type="function",
+                input_schema_json=_schema_to_bytes(_read(tool_def, "parameters_json_schema")),
+            )
+        )
+    return result
+
+
+def _join_instruction_parts(request_params: Any) -> str:
+    parts = _read(request_params, "instruction_parts")
+    if not isinstance(parts, (list, tuple)):
+        return ""
+    contents = [_as_string(_read(part, "content")) for part in parts]
+    return "\n\n".join(c for c in contents if c != "")
+
+
+def _schema_to_bytes(schema: Any) -> bytes:
+    if schema is None:
+        return b""
+    try:
+        return json.dumps(schema, default=str, sort_keys=True).encode("utf-8")
+    except Exception:
+        return b""
+
+
+def _resolve_pydantic_model_name(request_context: Any) -> str:
+    model = _read(request_context, "model")
+    for candidate in (
+        model if isinstance(model, str) else "",
+        _as_string(_read(model, "model_name")),
+        _as_string(_read(model, "name")),
+        _as_string(_read(model, "model")),
+    ):
+        if candidate != "":
+            return candidate
+    return ""
+
+
+def _run_context_metadata(ctx: Any) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+
+    deps = _read(ctx, "deps")
+    if deps is not None:
+        for snake, camel in (
+            ("conversation_id", "conversationId"),
+            ("session_id", "sessionId"),
+            ("thread_id", "threadId"),
+        ):
+            value = _as_string(_read(deps, snake)) or _as_string(_read(deps, camel))
+            if value != "":
+                metadata[snake] = value
+
+    ctx_metadata = _read(ctx, "metadata")
+    if isinstance(ctx_metadata, dict):
+        for key in ("conversation_id", "session_id", "thread_id", "event_id"):
+            value = _as_string(ctx_metadata.get(key))
+            if value != "" and key not in metadata:
+                metadata[key] = value
+
+    # Synthetic fallback when no user-provided IDs were found. Uses pydantic-ai's
+    # ctx.run_id so spans for a single agent run share a stable conversation_id.
+    if not any(k in metadata for k in ("conversation_id", "session_id", "thread_id")):
+        run_id = _as_string(_read(ctx, "run_id"))
+        if run_id != "":
+            metadata["conversation_id"] = f"sigil:framework:pydantic-ai:{run_id}"
+
+    return metadata
+
+
+_REQUEST_PART_ROLES: dict[str, str] = {
+    "system-prompt": "system",
+    "user-prompt": "user",
+    "tool-return": "tool",
+    "retry-prompt": "user",
+}
+
+
+def _map_pydantic_messages(request_context: Any) -> list[dict[str, Any]]:
+    messages_list = _read(request_context, "messages")
+    if not isinstance(messages_list, list):
+        return []
+    result: list[dict[str, Any]] = []
+    for message in messages_list:
+        parts = _read(message, "parts")
+        if not isinstance(parts, (list, tuple)):
+            continue
+        kind = _as_string(_read(message, "kind"))
+        if kind == "request":
+            for part in parts:
+                role = _REQUEST_PART_ROLES.get(_as_string(_read(part, "part_kind")))
+                if role:
+                    text = _as_string(_read(part, "content"))
+                    if text != "":
+                        result.append({"role": role, "content": text})
+        elif kind == "response":
+            texts: list[str] = []
+            tool_calls: list[dict[str, Any]] = []
+            for part in parts:
+                part_kind = _as_string(_read(part, "part_kind"))
+                if part_kind == "text":
+                    text = _as_string(_read(part, "content"))
+                    if text != "":
+                        texts.append(text)
+                elif part_kind == "tool-call":
+                    tool_calls.append(_tool_call_dict_from_part(part))
+            if texts or tool_calls:
+                msg: dict[str, Any] = {
+                    "role": "assistant",
+                    "content": " ".join(texts) if texts else "",
+                }
+                if tool_calls:
+                    msg["tool_calls"] = tool_calls
+                result.append(msg)
+    return result
+
+
+def _map_pydantic_response(response: Any, fallback_model_name: str) -> dict[str, Any]:
+    llm_output: dict[str, Any] = {}
+    model_name = _as_string(_read(response, "model_name")) or fallback_model_name
+    if model_name != "":
+        llm_output["model_name"] = model_name
+
+    finish_reason = _as_string(_read(response, "finish_reason"))
+    if finish_reason != "":
+        llm_output["finish_reason"] = finish_reason
+
+    usage = _read(response, "usage")
+    token_usage = _map_pydantic_usage(usage)
+    if token_usage:
+        llm_output["token_usage"] = token_usage
+
+    text = _extract_response_text(response)
+    tool_calls = _extract_response_tool_calls(response)
+    payload: dict[str, Any] = {"llm_output": llm_output}
+    if text != "" or tool_calls:
+        generation: dict[str, Any] = {"text": text}
+        if tool_calls:
+            generation["message"] = {"additional_kwargs": {"tool_calls": tool_calls}}
+        payload["generations"] = [[generation]]
+    return payload
+
+
+_USAGE_FIELD_MAP: dict[str, str] = {
+    "input_tokens": "prompt_tokens",
+    "output_tokens": "completion_tokens",
+    "cache_read_tokens": "cache_read_input_tokens",
+    "cache_write_tokens": "cache_creation_input_tokens",
+}
+
+
+def _map_pydantic_usage(usage: Any) -> dict[str, int]:
+    if usage is None:
+        return {}
+    token_usage: dict[str, int] = {}
+    for src, dst in _USAGE_FIELD_MAP.items():
+        val = _int_or_none(_read(usage, src))
+        if val is not None:
+            token_usage[dst] = val
+    prompt = token_usage.get("prompt_tokens", 0)
+    completion = token_usage.get("completion_tokens", 0)
+    if prompt or completion:
+        token_usage["total_tokens"] = prompt + completion
+    return token_usage
+
+
+def _extract_response_text(response: Any) -> str:
+    parts = _read(response, "parts")
+    if not isinstance(parts, (list, tuple)):
+        return ""
+    texts: list[str] = []
+    for part in parts:
+        part_kind = _as_string(_read(part, "part_kind"))
+        if part_kind == "text":
+            text = _as_string(_read(part, "content"))
+            if text != "":
+                texts.append(text)
+    return " ".join(texts).strip()
+
+
+def _extract_response_tool_calls(response: Any) -> list[dict[str, Any]]:
+    parts = _read(response, "parts")
+    if not isinstance(parts, (list, tuple)):
+        return []
+    return [_tool_call_dict_from_part(part) for part in parts if _as_string(_read(part, "part_kind")) == "tool-call"]
+
+
+def _tool_call_dict_from_part(part: Any) -> dict[str, Any]:
+    call_info: dict[str, Any] = {
+        "function": {
+            "name": _as_string(_read(part, "tool_name")),
+            "arguments": _json_string(_read(part, "args")),
+        },
+    }
+    call_id = _as_string(_read(part, "tool_call_id"))
+    if call_id != "":
+        call_info["id"] = call_id
+    return call_info
+
+
+def _extract_stream_token(event: Any) -> str:
+    event_kind = _as_string(_read(event, "event_kind"))
+    if event_kind == "part_delta":
+        delta = _read(event, "delta")
+        return _as_string(_read(delta, "content_delta"))
+    return ""
+
+
+def _tool_name(call: Any, tool_def: Any) -> str:
+    for candidate in (
+        _as_string(_read(call, "tool_name")),
+        _as_string(_read(tool_def, "name")),
+    ):
+        if candidate != "":
+            return candidate
+    return "framework_tool"
+
+
+def _json_string(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, default=str, sort_keys=True)
+    except Exception:
+        return str(value)
+
+
+def _read(value: Any, key: str) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value.get(key)
+    return getattr(value, key, None)
+
+
+def _as_string(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    return "" if value is None else str(value).strip()
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        integer = int(value)
+        return integer if float(integer) == value else None
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped == "":
+            return None
+        try:
+            return int(stripped)
+        except ValueError:
+            return None
+    return None

--- a/python-frameworks/pydantic-ai/sigil_sdk_pydantic_ai/handler.py
+++ b/python-frameworks/pydantic-ai/sigil_sdk_pydantic_ai/handler.py
@@ -1,0 +1,199 @@
+"""Sigil framework handler for the Pydantic AI integration."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from opentelemetry.trace import Status, StatusCode
+from sigil_sdk import Client
+from sigil_sdk.framework_handler import ProviderResolver, SigilFrameworkHandlerBase, merge_framework_callback_kwargs
+
+try:
+    from sigil_sdk.context import _pop_capture_mode
+except ImportError:
+
+    def _pop_capture_mode(recorder_id: int) -> None:
+        return
+
+
+_framework_name = "pydantic-ai"
+_framework_source = "handler"
+_framework_language = "python"
+_framework_instrumentation_name = "github.com/grafana/sigil/sdks/python-frameworks/pydantic-ai"
+
+
+def _discard_recorder(recorder: Any, *, pop_capture_mode: bool = False) -> None:
+    lock = getattr(recorder, "_lock", None)
+    if lock is not None:
+        with lock:
+            if getattr(recorder, "_ended", False):
+                return
+            recorder._ended = True
+    elif getattr(recorder, "_ended", False):
+        return
+    else:
+        recorder._ended = True
+
+    try:
+        span = getattr(recorder, "span", None)
+        if span is not None:
+            span.set_status(Status(StatusCode.OK))
+            span.end()
+    finally:
+        if pop_capture_mode:
+            _pop_capture_mode(id(recorder))
+
+
+class SigilPydanticAIHandler(SigilFrameworkHandlerBase):
+    """Sigil framework handler for the Pydantic AI integration."""
+
+    def __init__(
+        self,
+        *,
+        client: Client,
+        agent_name: str = "",
+        agent_version: str = "",
+        provider_resolver: ProviderResolver = "auto",
+        provider: str = "",
+        capture_inputs: bool = True,
+        capture_outputs: bool = True,
+        extra_tags: dict[str, str] | None = None,
+        extra_metadata: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(
+            client=client,
+            framework_name=_framework_name,
+            framework_source=_framework_source,
+            framework_language=_framework_language,
+            framework_instrumentation_name=_framework_instrumentation_name,
+            agent_name=agent_name,
+            agent_version=agent_version,
+            provider_resolver=provider_resolver,
+            provider=provider,
+            capture_inputs=capture_inputs,
+            capture_outputs=capture_outputs,
+            extra_tags=extra_tags,
+            extra_metadata=extra_metadata,
+        )
+
+    def on_llm_start(
+        self,
+        serialized: dict[str, Any] | None,
+        prompts: list[str],
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        invocation_params: dict[str, Any] | None = None,
+        run_name: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self._on_llm_start(
+            serialized=serialized,
+            prompts=prompts,
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+            invocation_params=invocation_params,
+            callback_kwargs=merge_framework_callback_kwargs(kwargs, tags=tags, metadata=metadata, run_name=run_name),
+        )
+
+    def on_chat_model_start(
+        self,
+        serialized: dict[str, Any] | None,
+        messages: list[list[Any]],
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        invocation_params: dict[str, Any] | None = None,
+        run_name: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self._on_chat_model_start(
+            serialized=serialized,
+            messages=messages,
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+            invocation_params=invocation_params,
+            callback_kwargs=merge_framework_callback_kwargs(kwargs, tags=tags, metadata=metadata, run_name=run_name),
+        )
+
+    def on_llm_new_token(self, token: str, *, run_id: UUID, **_kwargs: Any) -> None:
+        self._on_llm_new_token(token=token, run_id=run_id)
+
+    def on_llm_end(self, response: Any, *, run_id: UUID, **_kwargs: Any) -> None:
+        self._on_llm_end(response=response, run_id=run_id)
+
+    def on_llm_error(self, error: BaseException, *, run_id: UUID, **_kwargs: Any) -> None:
+        self._on_llm_error(error=error, run_id=run_id)
+
+    def on_tool_start(
+        self,
+        serialized: dict[str, Any] | None,
+        input_str: str,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        run_name: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self._on_tool_start(
+            serialized=serialized,
+            input_str=input_str,
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+            callback_kwargs=merge_framework_callback_kwargs(kwargs, tags=tags, metadata=metadata, run_name=run_name),
+        )
+
+    def on_tool_end(self, output: Any, *, run_id: UUID, **_kwargs: Any) -> None:
+        self._on_tool_end(output=output, run_id=run_id)
+
+    def on_tool_error(self, error: BaseException, *, run_id: UUID, **_kwargs: Any) -> None:
+        self._on_tool_error(error=error, run_id=run_id)
+
+    def on_chain_start(
+        self,
+        serialized: dict[str, Any] | None,
+        _inputs: dict[str, Any] | None,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        run_type: str | None = None,
+        run_name: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self._on_chain_start(
+            serialized=serialized,
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+            run_type=run_type or "chain",
+            callback_kwargs=merge_framework_callback_kwargs(kwargs, tags=tags, metadata=metadata, run_name=run_name),
+        )
+
+    def on_chain_end(self, _outputs: dict[str, Any] | None, *, run_id: UUID, **_kwargs: Any) -> None:
+        self._on_chain_end(run_id=run_id)
+
+    def on_chain_error(self, error: BaseException, *, run_id: UUID, **_kwargs: Any) -> None:
+        self._on_chain_error(error=error, run_id=run_id)
+
+    def _discard_llm_run(self, *, run_id: UUID) -> None:
+        run_state = self._runs.pop(str(run_id), None)
+        if run_state is None:
+            return
+        _discard_recorder(run_state.recorder, pop_capture_mode=True)
+
+    def _discard_tool_run(self, *, run_id: UUID) -> None:
+        run_state = self._tool_runs.pop(str(run_id), None)
+        if run_state is None:
+            return
+        _discard_recorder(run_state.recorder)
+
+    def _discard_chain_run(self, *, run_id: UUID) -> None:
+        self._end_framework_span(self._chain_spans, run_id=run_id, error=None)

--- a/python-frameworks/pydantic-ai/tests/test_sigil_sdk_pydantic_ai.py
+++ b/python-frameworks/pydantic-ai/tests/test_sigil_sdk_pydantic_ai.py
@@ -1,0 +1,896 @@
+"""pydantic-ai handler lifecycle and conversation-mapping tests."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from sigil_sdk import Client, ClientConfig, GenerationExportConfig
+from sigil_sdk.models import ExportGenerationResult, ExportGenerationsResponse
+from sigil_sdk_pydantic_ai import (
+    SigilPydanticAICapability,
+    SigilPydanticAIHandler,
+    create_sigil_pydantic_ai_capability,
+    create_sigil_pydantic_ai_handler,
+    with_sigil_pydantic_ai_capability,
+)
+
+
+class _CapturingExporter:
+    def __init__(self) -> None:
+        self.requests = []
+
+    def export_generations(self, request):
+        self.requests.append(request)
+        return ExportGenerationsResponse(
+            results=[
+                ExportGenerationResult(generation_id=generation.id, accepted=True) for generation in request.generations
+            ]
+        )
+
+    def shutdown(self) -> None:
+        return
+
+
+def _new_client(exporter: _CapturingExporter, tracer=None) -> Client:
+    return Client(
+        ClientConfig(
+            tracer=tracer,
+            generation_export=GenerationExportConfig(batch_size=10, flush_interval=timedelta(seconds=60)),
+            generation_exporter=exporter,
+        )
+    )
+
+
+def test_sigil_sdk_pydantic_ai_sync_lifecycle_sets_framework_metadata() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        run_id = uuid4()
+        parent_run_id = uuid4()
+        handler = SigilPydanticAIHandler(client=client, provider_resolver="auto")
+
+        handler.on_chat_model_start(
+            {"name": "ChatModel"},
+            [[{"type": "human", "content": "hello"}]],
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+            tags=["prod"],
+            invocation_params={"model": "gpt-5", "retry_attempt": 2, "session_id": "session-invocation"},
+            metadata={
+                "conversation_id": "framework-conversation-42",
+                "thread_id": "framework-thread-42",
+                "event_id": "framework-event-42",
+            },
+        )
+        handler.on_llm_end(
+            {
+                "generations": [[{"text": "world"}]],
+                "llm_output": {
+                    "model_name": "gpt-5",
+                    "finish_reason": "stop",
+                },
+            },
+            run_id=run_id,
+        )
+
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        assert generation.tags["sigil.framework.name"] == "pydantic-ai"
+        assert generation.tags["sigil.framework.source"] == "handler"
+        assert generation.tags["sigil.framework.language"] == "python"
+        assert generation.conversation_id == "framework-conversation-42"
+        assert generation.metadata["sigil.framework.run_id"] == str(run_id)
+        assert generation.metadata["sigil.framework.parent_run_id"] == str(parent_run_id)
+        assert generation.metadata["sigil.framework.thread_id"] == "framework-thread-42"
+        assert generation.metadata["sigil.framework.event_id"] == "framework-event-42"
+        assert generation.metadata["sigil.framework.run_type"] == "chat"
+        assert generation.metadata["sigil.framework.retry_attempt"] == 2
+        assert generation.output[0].parts[0].text == "world"
+    finally:
+        client.shutdown()
+
+
+def test_sigil_sdk_pydantic_ai_keeps_thread_metadata_when_ids_are_split_across_payloads() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        run_id = uuid4()
+        handler = SigilPydanticAIHandler(client=client, provider_resolver="auto")
+
+        handler.on_chat_model_start(
+            {"name": "ChatModel"},
+            [[{"type": "human", "content": "hello"}]],
+            run_id=run_id,
+            invocation_params={"model": "gpt-5"},
+            metadata={
+                "conversation_id": "framework-conversation-split-42",
+                "event_id": "framework-event-split-42",
+            },
+            thread_id="framework-thread-split-42",
+        )
+        handler.on_llm_end(
+            {
+                "generations": [[{"text": "world"}]],
+                "llm_output": {"model_name": "gpt-5"},
+            },
+            run_id=run_id,
+        )
+
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        assert generation.conversation_id == "framework-conversation-split-42"
+        assert generation.metadata["sigil.framework.thread_id"] == "framework-thread-split-42"
+        assert generation.metadata["sigil.framework.event_id"] == "framework-event-split-42"
+    finally:
+        client.shutdown()
+
+
+def test_sigil_sdk_pydantic_ai_fallback_conversation_is_deterministic() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        run_id = uuid4()
+        handler = SigilPydanticAIHandler(client=client)
+
+        handler.on_llm_start(
+            {"kwargs": {"model": "gpt-5"}},
+            ["hello"],
+            run_id=run_id,
+            invocation_params={"model": "gpt-5"},
+        )
+        handler.on_llm_end({"generations": [[{"text": "ok"}]], "llm_output": {"model_name": "gpt-5"}}, run_id=run_id)
+
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        assert generation.conversation_id == f"sigil:framework:pydantic-ai:{run_id}"
+    finally:
+        client.shutdown()
+
+
+def test_sigil_sdk_pydantic_ai_stream_mode_uses_chunks_when_output_missing() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        run_id = uuid4()
+        handler = SigilPydanticAIHandler(client=client)
+
+        handler.on_llm_start(
+            {"kwargs": {"model": "claude-sonnet-4-5"}},
+            ["stream this"],
+            run_id=run_id,
+            invocation_params={"stream": True, "model": "claude-sonnet-4-5"},
+        )
+        handler.on_llm_new_token("hello", run_id=run_id)
+        handler.on_llm_new_token(" world", run_id=run_id)
+        handler.on_llm_end({"llm_output": {"model_name": "claude-sonnet-4-5"}}, run_id=run_id)
+
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        assert generation.mode.value == "STREAM"
+        assert generation.model.provider == "anthropic"
+        assert generation.output[0].parts[0].text == "hello world"
+    finally:
+        client.shutdown()
+
+
+def test_sigil_sdk_pydantic_ai_generation_span_tracks_active_parent_span_and_export_lineage() -> None:
+    exporter = _CapturingExporter()
+    span_exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    tracer = provider.get_tracer("sigil-framework-test")
+    client = _new_client(exporter, tracer=tracer)
+
+    try:
+        run_id = uuid4()
+        with tracer.start_as_current_span("framework.request"):
+            handler = SigilPydanticAIHandler(client=client, provider_resolver="auto")
+            handler.on_chat_model_start(
+                {"name": "ChatModel"},
+                [[{"type": "human", "content": "hello"}]],
+                run_id=run_id,
+                parent_run_id=uuid4(),
+                invocation_params={"model": "gpt-5"},
+                metadata={
+                    "conversation_id": "framework-conversation-lineage-42",
+                    "thread_id": "framework-thread-lineage-42",
+                },
+            )
+            handler.on_llm_end(
+                {"generations": [[{"text": "world"}]], "llm_output": {"model_name": "gpt-5", "finish_reason": "stop"}},
+                run_id=run_id,
+            )
+
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        spans = span_exporter.get_finished_spans()
+        parent_span = next(span for span in spans if span.name == "framework.request")
+        generation_span = next(span for span in spans if span.attributes.get("gen_ai.operation.name") == "generateText")
+
+        assert generation_span.parent is not None
+        assert generation_span.parent.span_id == parent_span.context.span_id
+        assert generation_span.context.trace_id == parent_span.context.trace_id
+        assert generation.trace_id == generation_span.context.trace_id.to_bytes(16, "big").hex()
+        assert generation.span_id == generation_span.context.span_id.to_bytes(8, "big").hex()
+    finally:
+        client.shutdown()
+        provider.shutdown()
+
+
+def test_sigil_sdk_pydantic_ai_handler_records_generation_from_async_context() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    async def _run() -> None:
+        run_id = uuid4()
+        handler = SigilPydanticAIHandler(client=client)
+        handler.on_llm_start({}, ["hello"], run_id=run_id, invocation_params={"model": "gpt-5"})
+        handler.on_llm_end({"generations": [[{"text": "world"}]]}, run_id=run_id)
+
+    try:
+        asyncio.run(_run())
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        assert generation.tags["sigil.framework.name"] == "pydantic-ai"
+        assert generation.model.provider == "openai"
+    finally:
+        client.shutdown()
+
+
+def test_sigil_sdk_pydantic_ai_capability_wrap_model_request() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    class _RunContext:
+        run_id = "pydantic-run-42"
+        deps = None
+        metadata = None
+        model = None
+
+    class _Usage:
+        input_tokens = 10
+        output_tokens = 5
+        cache_read_tokens = 0
+        cache_write_tokens = 0
+
+    class _TextPart:
+        part_kind = "text"
+        content = "world"
+
+    class _ModelResponse:
+        parts = [_TextPart()]
+        model_name = "gpt-5"
+        finish_reason = "stop"
+        usage = _Usage()
+
+    class _UserPart:
+        part_kind = "user-prompt"
+        content = "hello"
+
+    class _ModelRequest:
+        kind = "request"
+        parts = [_UserPart()]
+
+    class _RequestContext:
+        model = "gpt-5"
+        messages = [_ModelRequest()]
+
+    try:
+        capability = create_sigil_pydantic_ai_capability(client=client, provider_resolver="auto")
+
+        async def _run() -> None:
+            ctx = _RunContext()
+            request_context = _RequestContext()
+
+            async def handler(rc: Any) -> Any:
+                return _ModelResponse()
+
+            await capability.wrap_model_request(ctx, request_context=request_context, handler=handler)
+
+        asyncio.run(_run())
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        assert generation.tags["sigil.framework.name"] == "pydantic-ai"
+        assert generation.model.name == "gpt-5"
+        assert generation.model.provider == "openai"
+        assert generation.conversation_id == "sigil:framework:pydantic-ai:pydantic-run-42"
+        assert generation.output[0].parts[0].text == "world"
+    finally:
+        client.shutdown()
+
+
+def test_sigil_sdk_pydantic_ai_capability_wrap_model_request_propagates_settings_and_tools() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    class _RunContext:
+        run_id = "pydantic-settings-42"
+        deps = None
+        metadata = None
+        model = None
+        agent = None
+
+    class _ModelResponse:
+        parts: list[Any] = []
+        model_name = "gpt-5"
+        finish_reason = "stop"
+        usage = None
+
+    class _ToolDef:
+        name = "lookup_city"
+        description = "Lookup a city"
+        parameters_json_schema = {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        }
+
+    class _RequestParams:
+        function_tools = [_ToolDef()]
+        instruction_parts = [
+            type("_IP", (), {"content": "You are a concise weather assistant."})(),
+            type("_IP", (), {"content": "Always answer in English."})(),
+        ]
+
+    class _RequestContext:
+        model = "gpt-5"
+        messages: list[Any] = []
+        model_settings = {"temperature": 0.2, "max_tokens": 256, "top_p": 0.9}
+        model_request_parameters = _RequestParams()
+
+    try:
+        capability = create_sigil_pydantic_ai_capability(client=client, provider_resolver="auto")
+
+        async def _run() -> None:
+            async def handler(rc: Any) -> Any:
+                return _ModelResponse()
+
+            await capability.wrap_model_request(_RunContext(), request_context=_RequestContext(), handler=handler)
+
+        asyncio.run(_run())
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        assert generation.temperature == 0.2
+        assert generation.max_tokens == 256
+        assert generation.top_p == 0.9
+        assert generation.system_prompt == "You are a concise weather assistant.\n\nAlways answer in English."
+        assert len(generation.tools) == 1
+        assert generation.tools[0].name == "lookup_city"
+        assert generation.tools[0].description == "Lookup a city"
+        assert generation.tools[0].type == "function"
+        assert b'"city"' in generation.tools[0].input_schema_json
+    finally:
+        client.shutdown()
+
+
+def test_sigil_sdk_pydantic_ai_capability_wrap_model_request_marks_streaming_handler() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    class _RunContext:
+        run_id = "pydantic-stream-42"
+        deps = None
+        metadata = None
+        model = None
+        agent = None
+
+    class _ModelResponse:
+        parts: list[Any] = []
+        model_name = "gpt-5"
+        finish_reason = "stop"
+        usage = None
+
+    class _RequestContext:
+        model = "gpt-5"
+        messages: list[Any] = []
+        model_settings = None
+        model_request_parameters = None
+
+    async def _streaming_handler(rc: Any) -> Any:
+        return _ModelResponse()
+
+    try:
+        capability = create_sigil_pydantic_ai_capability(client=client, provider_resolver="auto")
+
+        async def _run() -> None:
+            await capability.wrap_model_request(
+                _RunContext(), request_context=_RequestContext(), handler=_streaming_handler
+            )
+
+        asyncio.run(_run())
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        assert generation.mode.value == "STREAM"
+    finally:
+        client.shutdown()
+
+
+def test_sigil_sdk_pydantic_ai_capability_wrap_tool_execute() -> None:
+    class _CapturingHandler:
+        def __init__(self) -> None:
+            self.started: list[UUID] = []
+            self.ended: list[UUID] = []
+
+        def on_tool_start(self, *args, **kwargs) -> None:
+            del args
+            run_id = kwargs.get("run_id")
+            if isinstance(run_id, UUID):
+                self.started.append(run_id)
+
+        def on_tool_end(self, *args, **kwargs) -> None:
+            del args
+            run_id = kwargs.get("run_id")
+            if isinstance(run_id, UUID):
+                self.ended.append(run_id)
+
+    class _RunContext:
+        run_id = "pydantic-tool-run-42"
+        deps = None
+        metadata = None
+        model = None
+
+    class _ToolCall:
+        tool_name = "weather_tool"
+
+    class _ToolDef:
+        name = "weather_tool"
+        description = "Get weather info"
+
+    capture = _CapturingHandler()
+    capability = SigilPydanticAICapability(capture)  # type: ignore[arg-type]
+
+    async def _run() -> None:
+        ctx = _RunContext()
+
+        async def handler(args: Any) -> Any:
+            return {"temperature": 22}
+
+        await capability.wrap_tool_execute(
+            ctx,
+            call=_ToolCall(),
+            tool_def=_ToolDef(),
+            args={"city": "Paris"},
+            handler=handler,
+        )
+
+    asyncio.run(_run())
+
+    assert len(capture.started) == 1
+    assert len(capture.ended) == 1
+    assert capture.started[0] == capture.ended[0]
+
+
+def test_sigil_sdk_pydantic_ai_capability_wrap_tool_execute_records_arguments() -> None:
+    exporter = _CapturingExporter()
+    span_exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    tracer = provider.get_tracer("sigil-pydantic-ai-tool-args")
+    client = _new_client(exporter, tracer=tracer)
+
+    class _RunContext:
+        run_id = "pydantic-tool-args-42"
+        deps = None
+        metadata = None
+        model = None
+        agent = None
+
+    class _ToolCall:
+        tool_name = "weather_tool"
+
+    class _ToolDef:
+        name = "weather_tool"
+        description = "Get weather info"
+
+    try:
+        capability = create_sigil_pydantic_ai_capability(client=client)
+
+        async def _run() -> None:
+            async def handler(args: Any) -> Any:
+                return {"temperature": 22}
+
+            await capability.wrap_tool_execute(
+                ctx=_RunContext(),
+                call=_ToolCall(),
+                tool_def=_ToolDef(),
+                args={"city": "Paris"},
+                handler=handler,
+            )
+
+        asyncio.run(_run())
+        client.flush()
+
+        spans = span_exporter.get_finished_spans()
+        tool_span = next(span for span in spans if span.attributes.get("gen_ai.operation.name") == "execute_tool")
+        assert tool_span.attributes.get("gen_ai.tool.name") == "weather_tool"
+        arguments = tool_span.attributes.get("gen_ai.tool.call.arguments")
+        assert isinstance(arguments, str)
+        assert "Paris" in arguments
+        assert "city" in arguments
+    finally:
+        client.shutdown()
+        provider.shutdown()
+
+
+def test_sigil_sdk_pydantic_ai_capability_wrap_run_chain_spans() -> None:
+    class _CapturingHandler:
+        def __init__(self) -> None:
+            self.starts: list[dict[str, object]] = []
+            self.ends: list[dict[str, object]] = []
+
+        def on_chain_start(self, *args, **kwargs) -> None:
+            self.starts.append({"args": args, "kwargs": kwargs})
+
+        def on_chain_end(self, *args, **kwargs) -> None:
+            self.ends.append({"args": args, "kwargs": kwargs})
+
+    class _RunContext:
+        run_id = "pydantic-chain-run-42"
+        deps = None
+        metadata = None
+        model = None
+
+    class _Result:
+        data = "ok"
+
+    capture = _CapturingHandler()
+    capability = SigilPydanticAICapability(capture)  # type: ignore[arg-type]
+
+    async def _run() -> None:
+        ctx = _RunContext()
+
+        async def handler() -> Any:
+            return _Result()
+
+        await capability.wrap_run(ctx, handler=handler)
+
+    asyncio.run(_run())
+
+    assert len(capture.starts) == 1
+    assert len(capture.ends) == 1
+    start_kwargs = capture.starts[0]["kwargs"]
+    assert start_kwargs["run_type"] == "agent"
+    assert start_kwargs["run_name"] == "pydantic_ai_agent"
+
+
+def test_sigil_sdk_pydantic_ai_factory_function_return_types() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        handler = create_sigil_pydantic_ai_handler(client=client)
+        assert isinstance(handler, SigilPydanticAIHandler)
+
+        capability = create_sigil_pydantic_ai_capability(client=client)
+        assert isinstance(capability, SigilPydanticAICapability)
+    finally:
+        client.shutdown()
+
+
+def test_sigil_sdk_pydantic_ai_double_injection_guard() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        caps = with_sigil_pydantic_ai_capability(None, client=client)
+        assert len(caps) == 1
+        assert isinstance(caps[0], SigilPydanticAICapability)
+
+        caps2 = with_sigil_pydantic_ai_capability(caps, client=client)
+        assert len(caps2) == 1
+        assert caps2[0] is caps[0]
+    finally:
+        client.shutdown()
+
+
+def test_sigil_sdk_pydantic_ai_capability_for_run_returns_isolated_capability() -> None:
+    class _CapturingHandler:
+        pass
+
+    capability = SigilPydanticAICapability(_CapturingHandler())  # type: ignore[arg-type]
+
+    async def _run() -> SigilPydanticAICapability:
+        return await capability.for_run(object())
+
+    run_capability = asyncio.run(_run())
+
+    assert isinstance(run_capability, SigilPydanticAICapability)
+    assert run_capability is not capability
+    assert run_capability._sigil_handler is capability._sigil_handler
+
+
+def test_sigil_sdk_pydantic_ai_capability_control_flow_exceptions_do_not_record_errors() -> None:
+    from pydantic_ai.exceptions import ModelRetry, SkipModelRequest, SkipToolExecution
+
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    class _RunContext:
+        run_id = "pydantic-control-flow-42"
+        deps = None
+        metadata = None
+        model = None
+        agent = None
+
+    class _RequestContext:
+        model = "gpt-5"
+        messages = []
+
+    class _ToolCall:
+        tool_name = "cached_tool"
+
+    class _ToolDef:
+        name = "cached_tool"
+        description = "Can be skipped"
+
+    try:
+        handler = SigilPydanticAIHandler(client=client)
+        capability = SigilPydanticAICapability(handler)
+
+        async def _run() -> None:
+            ctx = _RunContext()
+
+            async def run_handler() -> Any:
+                raise ModelRetry("retry the agent")
+
+            with pytest.raises(ModelRetry):
+                await capability.wrap_run(ctx, handler=run_handler)
+
+            async def model_handler(rc: Any) -> Any:
+                raise SkipModelRequest(object())
+
+            with pytest.raises(SkipModelRequest):
+                await capability.wrap_model_request(ctx, request_context=_RequestContext(), handler=model_handler)
+
+            async def tool_handler(args: Any) -> Any:
+                raise SkipToolExecution("cached")
+
+            with pytest.raises(SkipToolExecution):
+                await capability.wrap_tool_execute(
+                    ctx,
+                    call=_ToolCall(),
+                    tool_def=_ToolDef(),
+                    args={},
+                    handler=tool_handler,
+                )
+
+        asyncio.run(_run())
+        client.flush()
+
+        assert handler._chain_spans == {}
+        assert handler._runs == {}
+        assert handler._tool_runs == {}
+        assert exporter.requests == []
+    finally:
+        client.shutdown()
+
+
+def test_sigil_sdk_pydantic_ai_capability_wrap_model_request_error_records_llm_error() -> None:
+    class _CapturingHandler:
+        def __init__(self) -> None:
+            self.started: list[UUID] = []
+            self.errors: list[tuple[UUID, BaseException]] = []
+            self.ended: list[UUID] = []
+
+        def on_chat_model_start(self, *args, **kwargs) -> None:
+            run_id = kwargs.get("run_id")
+            if isinstance(run_id, UUID):
+                self.started.append(run_id)
+
+        def on_llm_end(self, *args, **kwargs) -> None:
+            run_id = kwargs.get("run_id")
+            if isinstance(run_id, UUID):
+                self.ended.append(run_id)
+
+        def on_llm_error(self, error, *args, **kwargs) -> None:
+            run_id = kwargs.get("run_id")
+            if isinstance(run_id, UUID):
+                self.errors.append((run_id, error))
+
+    class _RunContext:
+        run_id = "pydantic-error-run-42"
+        deps = None
+        metadata = None
+        model = None
+        agent = None
+
+    class _RequestContext:
+        model = "gpt-5"
+        messages = []
+
+    capture = _CapturingHandler()
+    capability = SigilPydanticAICapability(capture)  # type: ignore[arg-type]
+
+    async def _run() -> None:
+        ctx = _RunContext()
+        request_context = _RequestContext()
+
+        async def handler(rc: Any) -> Any:
+            raise ValueError("model failed")
+
+        with pytest.raises(ValueError, match="model failed"):
+            await capability.wrap_model_request(ctx, request_context=request_context, handler=handler)
+
+    asyncio.run(_run())
+
+    assert len(capture.started) == 1
+    assert len(capture.errors) == 1
+    assert len(capture.ended) == 0
+    assert capture.started[0] == capture.errors[0][0]
+    assert str(capture.errors[0][1]) == "model failed"
+
+
+def test_sigil_sdk_pydantic_ai_capability_wrap_tool_execute_error_records_tool_error() -> None:
+    class _CapturingHandler:
+        def __init__(self) -> None:
+            self.started: list[UUID] = []
+            self.errors: list[tuple[UUID, BaseException]] = []
+            self.ended: list[UUID] = []
+
+        def on_tool_start(self, *args, **kwargs) -> None:
+            run_id = kwargs.get("run_id")
+            if isinstance(run_id, UUID):
+                self.started.append(run_id)
+
+        def on_tool_end(self, *args, **kwargs) -> None:
+            run_id = kwargs.get("run_id")
+            if isinstance(run_id, UUID):
+                self.ended.append(run_id)
+
+        def on_tool_error(self, error, *args, **kwargs) -> None:
+            run_id = kwargs.get("run_id")
+            if isinstance(run_id, UUID):
+                self.errors.append((run_id, error))
+
+    class _RunContext:
+        run_id = "pydantic-tool-error-42"
+        deps = None
+        metadata = None
+        model = None
+        agent = None
+
+    class _ToolCall:
+        tool_name = "broken_tool"
+
+    class _ToolDef:
+        name = "broken_tool"
+        description = "A tool that fails"
+
+    capture = _CapturingHandler()
+    capability = SigilPydanticAICapability(capture)  # type: ignore[arg-type]
+
+    async def _run() -> None:
+        ctx = _RunContext()
+
+        async def handler(args: Any) -> Any:
+            raise RuntimeError("tool exploded")
+
+        with pytest.raises(RuntimeError, match="tool exploded"):
+            await capability.wrap_tool_execute(
+                ctx,
+                call=_ToolCall(),
+                tool_def=_ToolDef(),
+                args={"x": 1},
+                handler=handler,
+            )
+
+    asyncio.run(_run())
+
+    assert len(capture.started) == 1
+    assert len(capture.errors) == 1
+    assert len(capture.ended) == 0
+    assert capture.started[0] == capture.errors[0][0]
+    assert str(capture.errors[0][1]) == "tool exploded"
+
+
+def test_sigil_sdk_pydantic_ai_capability_wrap_run_error_records_chain_error() -> None:
+    class _CapturingHandler:
+        def __init__(self) -> None:
+            self.starts: list[UUID] = []
+            self.errors: list[tuple[UUID, BaseException]] = []
+            self.ends: list[UUID] = []
+
+        def on_chain_start(self, *args, **kwargs) -> None:
+            run_id = kwargs.get("run_id")
+            if isinstance(run_id, UUID):
+                self.starts.append(run_id)
+
+        def on_chain_end(self, *args, **kwargs) -> None:
+            run_id = kwargs.get("run_id")
+            if isinstance(run_id, UUID):
+                self.ends.append(run_id)
+
+        def on_chain_error(self, error, *args, **kwargs) -> None:
+            run_id = kwargs.get("run_id")
+            if isinstance(run_id, UUID):
+                self.errors.append((run_id, error))
+
+    class _RunContext:
+        run_id = "pydantic-chain-error-42"
+        deps = None
+        metadata = None
+        model = None
+        agent = None
+
+    capture = _CapturingHandler()
+    capability = SigilPydanticAICapability(capture)  # type: ignore[arg-type]
+
+    async def _run() -> None:
+        ctx = _RunContext()
+
+        async def handler() -> Any:
+            raise RuntimeError("agent crashed")
+
+        with pytest.raises(RuntimeError, match="agent crashed"):
+            await capability.wrap_run(ctx, handler=handler)
+
+    asyncio.run(_run())
+
+    assert len(capture.starts) == 1
+    assert len(capture.errors) == 1
+    assert len(capture.ends) == 0
+    assert capture.starts[0] == capture.errors[0][0]
+    assert str(capture.errors[0][1]) == "agent crashed"
+
+
+def test_sigil_sdk_pydantic_ai_capability_agent_name_from_agent_attribute() -> None:
+    class _Agent:
+        name = "my_custom_agent"
+
+    class _RunContext:
+        run_id = "pydantic-agent-name-42"
+        deps = None
+        metadata = None
+        model = None
+        agent = _Agent()
+
+    class _CapturingHandler:
+        def __init__(self) -> None:
+            self.run_names: list[str] = []
+
+        def on_chain_start(self, *args, **kwargs) -> None:
+            run_name = kwargs.get("run_name")
+            if run_name:
+                self.run_names.append(run_name)
+
+        def on_chain_end(self, *args, **kwargs) -> None:
+            pass
+
+    capture = _CapturingHandler()
+    capability = SigilPydanticAICapability(capture)  # type: ignore[arg-type]
+
+    async def _run() -> None:
+        ctx = _RunContext()
+
+        async def handler() -> Any:
+            return "ok"
+
+        await capability.wrap_run(ctx, handler=handler)
+
+    asyncio.run(_run())
+
+    assert len(capture.run_names) == 1
+    assert capture.run_names[0] == "my_custom_agent"
+
+
+def test_sigil_sdk_pydantic_ai_handler_explicitly_has_no_embedding_lifecycle() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = SigilPydanticAIHandler(client=client)
+        assert not hasattr(handler, "on_embedding_start")
+        assert not hasattr(handler, "on_embedding_end")
+        assert not hasattr(handler, "on_embedding_error")
+    finally:
+        client.shutdown()

--- a/python-frameworks/pydantic-ai/tests/test_sigil_sdk_pydantic_ai.py
+++ b/python-frameworks/pydantic-ai/tests/test_sigil_sdk_pydantic_ai.py
@@ -261,8 +261,8 @@ def test_sigil_sdk_pydantic_ai_capability_wrap_model_request() -> None:
     class _Usage:
         input_tokens = 10
         output_tokens = 5
-        cache_read_tokens = 0
-        cache_write_tokens = 0
+        cache_read_tokens = 3
+        cache_write_tokens = 2
 
     class _TextPart:
         part_kind = "text"
@@ -306,6 +306,11 @@ def test_sigil_sdk_pydantic_ai_capability_wrap_model_request() -> None:
         assert generation.model.provider == "openai"
         assert generation.conversation_id == "sigil:framework:pydantic-ai:pydantic-run-42"
         assert generation.output[0].parts[0].text == "world"
+        assert generation.usage.input_tokens == 10
+        assert generation.usage.output_tokens == 5
+        assert generation.usage.cache_read_input_tokens == 3
+        assert generation.usage.cache_creation_input_tokens == 2
+        assert generation.usage.total_tokens == 15
     finally:
         client.shutdown()
 

--- a/python/sigil_sdk/framework_handler.py
+++ b/python/sigil_sdk/framework_handler.py
@@ -22,6 +22,7 @@ from sigil_sdk import (
     ModelRef,
     Part,
     PartKind,
+    ToolDefinition,
     ToolExecutionStart,
     user_text_message,
 )
@@ -300,6 +301,12 @@ class SigilFrameworkHandlerBase:
             model=ModelRef(provider=provider_name, name=model_name),
             tags=tags,
             metadata=metadata,
+            system_prompt=_as_str(_read(invocation_params, "system_prompt")),
+            tools=_resolve_tool_definitions(invocation_params),
+            temperature=_as_optional_float(_read(invocation_params, "temperature")),
+            max_tokens=_as_optional_int(_read(invocation_params, "max_tokens")),
+            top_p=_as_optional_float(_read(invocation_params, "top_p")),
+            tool_choice=_as_str(_read(invocation_params, "tool_choice")) or None,
         )
 
         recorder = (
@@ -1154,6 +1161,33 @@ def _as_optional_int(value: Any) -> int | None:
         except ValueError:
             return None
     return None
+
+
+def _as_optional_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped == "":
+            return None
+        try:
+            return float(stripped)
+        except ValueError:
+            return None
+    return None
+
+
+def _resolve_tool_definitions(invocation_params: dict[str, Any] | None) -> list[ToolDefinition]:
+    raw = _read(invocation_params, "tools")
+    if not isinstance(raw, (list, tuple)):
+        return []
+    result: list[ToolDefinition] = []
+    for item in raw:
+        if isinstance(item, ToolDefinition):
+            result.append(item)
+    return result
 
 
 def _as_bool(value: Any) -> bool:


### PR DESCRIPTION
Add [Pydantic AI](https://pydantic.dev/docs/ai/overview/) integration. No publishing step to pypi yet.

Part of https://github.com/grafana/sigil-sdk/issues/67


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new integration package and expands generation payload fields in the shared Python framework handler, which could affect telemetry emitted by existing framework integrations if invocation params collide or are malformed.
> 
> **Overview**
> Adds a new Python framework module `sigil-sdk-pydantic-ai` that bridges Pydantic AI lifecycle hooks (agent run, model request, tool execution, and streaming tokens) into Sigil generation/tool/span recording, including conversation-id mapping and control-flow exception handling that avoids emitting error telemetry.
> 
> Extends `SigilFrameworkHandlerBase` to populate `GenerationStart` with additional invocation metadata (e.g., `system_prompt`, tool definitions, and sampling params like `temperature`/`top_p`/`max_tokens`), and adds helper parsing for optional floats and tool lists.
> 
> Includes a getting-started example (`examples/getting-started/python-pydantic-ai`) plus extensive unit tests for lifecycle, streaming, lineage, and metadata behavior; updates `.gitignore` for the new build output and example `.env`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c36011aec2f656b259f6f94ca5a67de4329d59b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->