### PR TITLE
docs: add OTel setup guidance, Cloud OTLP options, and telemetry to examples

### DIFF
--- a/.cursor/rules/sigil-instrumentation.mdc
+++ b/.cursor/rules/sigil-instrumentation.mdc
@@ -60,9 +60,34 @@ The Sigil SDK internally emits OTel spans and metrics (`gen_ai.client.operation.
 
 The SDK does NOT create OTel providers — that is the application's responsibility. Always ensure the app configures providers BEFORE creating the Sigil client, and shuts them down AFTER `sigil.shutdown()`.
 
-The endpoint, protocol (HTTP vs gRPC), and port depend on the user's collector/Alloy configuration. Use an env var like `OTEL_EXPORTER_OTLP_ENDPOINT` so the app doesn't hardcode assumptions. Common collector ports: 4318 (OTLP/HTTP), 4317 (OTLP/gRPC). The snippets below use HTTP — switch to gRPC equivalents if the target collector only accepts gRPC.
+Traces and metrics can be sent to Grafana Cloud in two ways. Always use env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`) so the app doesn't hardcode assumptions.
 
-### Python (HTTP)
+### Option A — Direct to Grafana Cloud (no collector needed)
+
+Send OTLP straight to the Grafana Cloud OTLP gateway. The exact URL is stack-specific — get it from the **Grafana Cloud portal → stack Details page** ([docs](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp)). Authentication uses Basic auth with instance ID and a Cloud API token.
+
+Env vars:
+```
+OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>   # from Cloud portal
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instance_id:cloud_api_token)>
+```
+
+The OTel SDK exporters read these env vars automatically — no extra code needed beyond the provider setup below.
+
+### Option B — Via Alloy / OTel Collector (optional)
+
+Run a local Alloy or OTel Collector that receives unauthenticated OTLP and forwards to Cloud with credentials. Useful for centralized token management, retries, relabeling, and metadata enrichment. Common local ports: 4318 (OTLP/HTTP), 4317 (OTLP/gRPC).
+
+Env vars:
+```
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+```
+
+### Provider setup (required for both options)
+
+The snippets below configure TracerProvider and MeterProvider using OTLP/HTTP exporters that honour the env vars above.
+
+#### Python
 ```python
 from opentelemetry import trace, metrics
 from opentelemetry.sdk.trace import TracerProvider
@@ -74,20 +99,19 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 
 resource = Resource.create({"service.name": "my-app"})
-endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
 
 tp = TracerProvider(resource=resource)
-tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{endpoint}/v1/traces")))
+tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
 trace.set_tracer_provider(tp)
 
 mp = MeterProvider(resource=resource, metric_readers=[
-    PeriodicExportingMetricReader(OTLPMetricExporter(endpoint=f"{endpoint}/v1/metrics"))
+    PeriodicExportingMetricReader(OTLPMetricExporter())
 ])
 metrics.set_meter_provider(mp)
 # Deps: opentelemetry-sdk, opentelemetry-exporter-otlp-proto-http
 ```
 
-### Go
+#### Go
 ```go
 traceExp, _ := otlptracehttp.New(ctx)
 tp := sdktrace.NewTracerProvider(sdktrace.WithBatcher(traceExp), sdktrace.WithResource(res))
@@ -100,7 +124,7 @@ otel.SetMeterProvider(mp)
 defer mp.Shutdown(ctx)
 ```
 
-### JS/TS
+#### JS/TS
 ```typescript
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';

--- a/.cursor/rules/sigil-instrumentation.mdc
+++ b/.cursor/rules/sigil-instrumentation.mdc
@@ -54,6 +54,70 @@ Return:
   - stream: `STREAM`
 - Raw provider artifacts are default OFF and only enabled for explicit debug opt-in.
 
+## OTel setup (required)
+
+The Sigil SDK internally emits OTel spans and metrics (`gen_ai.client.operation.duration`, `gen_ai.client.token.usage`, `gen_ai.client.time_to_first_token`, `gen_ai.client.tool_calls_per_operation`). **Without a configured TracerProvider and MeterProvider these go to the default no-op and are silently lost.**
+
+The SDK does NOT create OTel providers — that is the application's responsibility. Always ensure the app configures providers BEFORE creating the Sigil client, and shuts them down AFTER `sigil.shutdown()`.
+
+The endpoint, protocol (HTTP vs gRPC), and port depend on the user's collector/Alloy configuration. Use an env var like `OTEL_EXPORTER_OTLP_ENDPOINT` so the app doesn't hardcode assumptions. Common collector ports: 4318 (OTLP/HTTP), 4317 (OTLP/gRPC). The snippets below use HTTP — switch to gRPC equivalents if the target collector only accepts gRPC.
+
+### Python (HTTP)
+```python
+from opentelemetry import trace, metrics
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+
+resource = Resource.create({"service.name": "my-app"})
+endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+
+tp = TracerProvider(resource=resource)
+tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{endpoint}/v1/traces")))
+trace.set_tracer_provider(tp)
+
+mp = MeterProvider(resource=resource, metric_readers=[
+    PeriodicExportingMetricReader(OTLPMetricExporter(endpoint=f"{endpoint}/v1/metrics"))
+])
+metrics.set_meter_provider(mp)
+# Deps: opentelemetry-sdk, opentelemetry-exporter-otlp-proto-http
+```
+
+### Go
+```go
+traceExp, _ := otlptracehttp.New(ctx)
+tp := sdktrace.NewTracerProvider(sdktrace.WithBatcher(traceExp), sdktrace.WithResource(res))
+otel.SetTracerProvider(tp)
+defer tp.Shutdown(ctx)
+
+metricExp, _ := otlpmetrichttp.New(ctx)
+mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricExp)), sdkmetric.WithResource(res))
+otel.SetMeterProvider(mp)
+defer mp.Shutdown(ctx)
+```
+
+### JS/TS
+```typescript
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { MeterProvider, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
+
+const tp = new NodeTracerProvider({ resource });
+tp.addSpanProcessor(new BatchSpanProcessor(new OTLPTraceExporter()));
+tp.register();
+
+const mp = new MeterProvider({
+  resource,
+  readers: [new PeriodicExportingMetricReader({ exporter: new OTLPMetricExporter() })],
+});
+```
+
 ## Telemetry fields to prioritize
 
 On generation and tool spans, capture or preserve these when available:
@@ -142,6 +206,13 @@ In the sigil-sdk repo:
 - Keep raw artifacts disabled unless explicitly asked.
 - Ensure non-stream wrappers set `SYNC`, stream wrappers set `STREAM`.
 - Ensure lifecycle flush/shutdown semantics are preserved.
+- When calling `set_result` / `SetResult`, always include all available fields:
+  - `response_id` (provider correlation, maps to `gen_ai.response.id`)
+  - `response_model` (actual model used)
+  - `stop_reason` / `finish_reason`
+  - Full token usage including `cache_read_input_tokens`, `cache_creation_input_tokens`, and `reasoning_tokens` when the provider returns them
+- Always check `rec.err()` / `Err()` after the generation recorder closes — SDK validation or enqueue errors are otherwise silent.
+- Use `tags` on `GenerationStart` for filtering in the Sigil UI (e.g. pipeline name, layer, agent role).
 
 ## Validation checklist
 

--- a/.cursor/rules/sigil-instrumentation.mdc
+++ b/.cursor/rules/sigil-instrumentation.mdc
@@ -126,6 +126,7 @@ defer mp.Shutdown(ctx)
 
 #### JS/TS
 ```typescript
+import { metrics } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
@@ -140,6 +141,7 @@ const mp = new MeterProvider({
   resource,
   readers: [new PeriodicExportingMetricReader({ exporter: new OTLPMetricExporter() })],
 });
+metrics.setGlobalMeterProvider(mp);
 ```
 
 ## Telemetry fields to prioritize

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,34 @@ The Sigil SDK internally emits OTel spans and metrics (`gen_ai.client.operation.
 
 The SDK does NOT create OTel providers — that is the application's responsibility. Always ensure the app configures providers BEFORE creating the Sigil client, and shuts them down AFTER `sigil.shutdown()`.
 
-The endpoint, protocol (HTTP vs gRPC), and port depend on the user's collector/Alloy configuration. Use an env var like `OTEL_EXPORTER_OTLP_ENDPOINT` so the app doesn't hardcode assumptions. Common collector ports: 4318 (OTLP/HTTP), 4317 (OTLP/gRPC). The snippets below use HTTP — switch to gRPC equivalents if the target collector only accepts gRPC.
+Traces and metrics can be sent to Grafana Cloud in two ways. Always use env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`) so the app doesn't hardcode assumptions.
 
-### Python (HTTP)
+### Option A — Direct to Grafana Cloud (no collector needed)
+
+Send OTLP straight to the Grafana Cloud OTLP gateway. The exact URL is stack-specific — get it from the **Grafana Cloud portal → stack Details page** ([docs](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp)). Authentication uses Basic auth with instance ID and a Cloud API token.
+
+Env vars:
+```
+OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>   # from Cloud portal
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instance_id:cloud_api_token)>
+```
+
+The OTel SDK exporters read these env vars automatically — no extra code needed beyond the provider setup below.
+
+### Option B — Via Alloy / OTel Collector (optional)
+
+Run a local Alloy or OTel Collector that receives unauthenticated OTLP and forwards to Cloud with credentials. Useful for centralized token management, retries, relabeling, and metadata enrichment. Common local ports: 4318 (OTLP/HTTP), 4317 (OTLP/gRPC).
+
+Env vars:
+```
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+```
+
+### Provider setup (required for both options)
+
+The snippets below configure TracerProvider and MeterProvider using OTLP/HTTP exporters that honour the env vars above.
+
+#### Python
 ```python
 from opentelemetry import trace, metrics
 from opentelemetry.sdk.trace import TracerProvider
@@ -59,20 +84,19 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 
 resource = Resource.create({"service.name": "my-app"})
-endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
 
 tp = TracerProvider(resource=resource)
-tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{endpoint}/v1/traces")))
+tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
 trace.set_tracer_provider(tp)
 
 mp = MeterProvider(resource=resource, metric_readers=[
-    PeriodicExportingMetricReader(OTLPMetricExporter(endpoint=f"{endpoint}/v1/metrics"))
+    PeriodicExportingMetricReader(OTLPMetricExporter())
 ])
 metrics.set_meter_provider(mp)
 # Deps: opentelemetry-sdk, opentelemetry-exporter-otlp-proto-http
 ```
 
-### Go
+#### Go
 ```go
 traceExp, _ := otlptracehttp.New(ctx)
 tp := sdktrace.NewTracerProvider(sdktrace.WithBatcher(traceExp), sdktrace.WithResource(res))
@@ -85,7 +109,7 @@ otel.SetMeterProvider(mp)
 defer mp.Shutdown(ctx)
 ```
 
-### JS/TS
+#### JS/TS
 ```typescript
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ defer mp.Shutdown(ctx)
 
 #### JS/TS
 ```typescript
+import { metrics } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
@@ -125,6 +126,7 @@ const mp = new MeterProvider({
   resource,
   readers: [new PeriodicExportingMetricReader({ exporter: new OTLPMetricExporter() })],
 });
+metrics.setGlobalMeterProvider(mp);
 ```
 
 ## Telemetry fields to prioritize

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,70 @@ Return:
   - stream: `STREAM`
 - Raw provider artifacts are default OFF and only enabled for explicit debug opt-in.
 
+## OTel setup (required)
+
+The Sigil SDK internally emits OTel spans and metrics (`gen_ai.client.operation.duration`, `gen_ai.client.token.usage`, `gen_ai.client.time_to_first_token`, `gen_ai.client.tool_calls_per_operation`). **Without a configured TracerProvider and MeterProvider these go to the default no-op and are silently lost.**
+
+The SDK does NOT create OTel providers — that is the application's responsibility. Always ensure the app configures providers BEFORE creating the Sigil client, and shuts them down AFTER `sigil.shutdown()`.
+
+The endpoint, protocol (HTTP vs gRPC), and port depend on the user's collector/Alloy configuration. Use an env var like `OTEL_EXPORTER_OTLP_ENDPOINT` so the app doesn't hardcode assumptions. Common collector ports: 4318 (OTLP/HTTP), 4317 (OTLP/gRPC). The snippets below use HTTP — switch to gRPC equivalents if the target collector only accepts gRPC.
+
+### Python (HTTP)
+```python
+from opentelemetry import trace, metrics
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+
+resource = Resource.create({"service.name": "my-app"})
+endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+
+tp = TracerProvider(resource=resource)
+tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{endpoint}/v1/traces")))
+trace.set_tracer_provider(tp)
+
+mp = MeterProvider(resource=resource, metric_readers=[
+    PeriodicExportingMetricReader(OTLPMetricExporter(endpoint=f"{endpoint}/v1/metrics"))
+])
+metrics.set_meter_provider(mp)
+# Deps: opentelemetry-sdk, opentelemetry-exporter-otlp-proto-http
+```
+
+### Go
+```go
+traceExp, _ := otlptracehttp.New(ctx)
+tp := sdktrace.NewTracerProvider(sdktrace.WithBatcher(traceExp), sdktrace.WithResource(res))
+otel.SetTracerProvider(tp)
+defer tp.Shutdown(ctx)
+
+metricExp, _ := otlpmetrichttp.New(ctx)
+mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricExp)), sdkmetric.WithResource(res))
+otel.SetMeterProvider(mp)
+defer mp.Shutdown(ctx)
+```
+
+### JS/TS
+```typescript
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { MeterProvider, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
+
+const tp = new NodeTracerProvider({ resource });
+tp.addSpanProcessor(new BatchSpanProcessor(new OTLPTraceExporter()));
+tp.register();
+
+const mp = new MeterProvider({
+  resource,
+  readers: [new PeriodicExportingMetricReader({ exporter: new OTLPMetricExporter() })],
+});
+```
+
 ## Telemetry fields to prioritize
 
 On generation and tool spans, capture or preserve these when available:
@@ -127,6 +191,13 @@ In the sigil-sdk repo:
 - Keep raw artifacts disabled unless explicitly asked.
 - Ensure non-stream wrappers set `SYNC`, stream wrappers set `STREAM`.
 - Ensure lifecycle flush/shutdown semantics are preserved.
+- When calling `set_result` / `SetResult`, always include all available fields:
+  - `response_id` (provider correlation, maps to `gen_ai.response.id`)
+  - `response_model` (actual model used)
+  - `stop_reason` / `finish_reason`
+  - Full token usage including `cache_read_input_tokens`, `cache_creation_input_tokens`, and `reasoning_tokens` when the provider returns them
+- Always check `rec.err()` / `Err()` after the generation recorder closes — SDK validation or enqueue errors are otherwise silent.
+- Use `tags` on `GenerationStart` for filtering in the Sigil UI (e.g. pipeline name, layer, agent role).
 
 ## Validation checklist
 

--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -10,10 +10,11 @@ Minimal, self-contained examples that make a real LLM call and record the genera
 
 Each example:
 
-1. Creates an OpenAI client and sends a chat completion request.
-2. Creates an SDK client authenticated against Grafana Cloud.
-3. Records the generation (input, output, token usage, model metadata).
-4. Shuts down cleanly.
+1. Configures OpenTelemetry (TracerProvider + MeterProvider) so SDK-emitted spans and metrics are exported.
+2. Creates an OpenAI client and sends a chat completion request.
+3. Creates an SDK client authenticated against Grafana Cloud.
+4. Records the generation (input, output, token usage, model metadata).
+5. Shuts down cleanly (Sigil client first, then OTel providers).
 
 ## Credentials
 
@@ -21,7 +22,14 @@ Each example needs an **OpenAI API key** ([platform.openai.com/api-keys](https:/
 
 See the [credentials section in the SDK README](../../README.md#grafana-cloud-credentials) for where to find each value in your Grafana Cloud stack.
 
-Set them as environment variables before running an example.
+### OTel endpoint for traces and metrics
+
+The SDK emits OpenTelemetry spans and metrics (`gen_ai.client.operation.duration`, `gen_ai.client.token.usage`, etc.). These need an OTLP endpoint:
+
+- **Direct to Cloud** — set `OTEL_EXPORTER_OTLP_ENDPOINT` to your Cloud OTLP gateway URL (find it in the Grafana Cloud portal → stack Details page, [docs](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp)) and `OTEL_EXPORTER_OTLP_HEADERS` with Basic auth credentials.
+- **Via Alloy** — set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318` if you have a local Alloy/collector forwarding to Cloud.
+
+Set all values as environment variables before running an example.
 
 ## What to look for
 
@@ -30,6 +38,7 @@ After running an example, open the AI Observability plugin in your Grafana Cloud
 - A new generation under the conversation ID used in the example.
 - Model name, provider, token usage, and latency filled in.
 - The input prompt and assistant response visible in the conversation drilldown.
+- Traces in your Grafana Cloud Traces datasource and metrics in Grafana Cloud Metrics.
 
 ## Next steps
 

--- a/examples/getting-started/go/.env.example
+++ b/examples/getting-started/go/.env.example
@@ -1,14 +1,26 @@
-# LLM provider
+# --- LLM provider ---
+# This example uses OpenAI. Replace with your provider's key if different.
 OPENAI_API_KEY=
 
-# Sigil generation export (Grafana Cloud)
+# --- Sigil generation export (Grafana Cloud) ---
+# Generation-ingest URL. Find it in your Grafana Cloud stack under
+# AI Observability → SDK connection details.
 SIGIL_ENDPOINT=https://<your-stack>.grafana.net/api/v1/generations:export
+
+# Your Grafana Cloud stack / instance ID (numeric).
+# Shown in the stack details page or the SDK connection details panel.
 GRAFANA_INSTANCE_ID=
+
+# A Grafana Cloud API token with AI Observability write permissions.
+# Create one at https://grafana.com → My Account → API Keys.
 GRAFANA_CLOUD_TOKEN=
 
-# OTel traces + metrics
-# Option A — Direct to Cloud (get URL from Cloud portal → stack Details):
+# --- OTel traces + metrics ---
+# Option A — Direct to Grafana Cloud OTLP gateway:
+#   Find the endpoint in your Cloud portal → stack Details → OpenTelemetry.
+#   The header is: Authorization=Basic <base64(instance_id:cloud_api_token)>
 OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
 OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instance_id:cloud_api_token)>
-# Option B — Via local Alloy/collector:
+
+# Option B — Via local Alloy / OTel Collector (no auth needed):
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318

--- a/examples/getting-started/go/.env.example
+++ b/examples/getting-started/go/.env.example
@@ -1,0 +1,14 @@
+# LLM provider
+OPENAI_API_KEY=
+
+# Sigil generation export (Grafana Cloud)
+SIGIL_ENDPOINT=https://<your-stack>.grafana.net/api/v1/generations:export
+GRAFANA_INSTANCE_ID=
+GRAFANA_CLOUD_TOKEN=
+
+# OTel traces + metrics
+# Option A — Direct to Cloud (get URL from Cloud portal → stack Details):
+OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instance_id:cloud_api_token)>
+# Option B — Via local Alloy/collector:
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318

--- a/examples/getting-started/go/README.md
+++ b/examples/getting-started/go/README.md
@@ -6,15 +6,8 @@ Makes an OpenAI chat completion and records the generation to Grafana Cloud AI O
 
 ```bash
 cd examples/getting-started/go
-# Set OPENAI_API_KEY, GRAFANA_INSTANCE_ID, GRAFANA_CLOUD_TOKEN, SIGIL_ENDPOINT
-# See the SDK README for where to find each value.
-#
-# For traces and metrics, set the OTLP endpoint.
-# Option A — Direct to Cloud (get URL from Cloud portal → stack Details):
-#   OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
-#   OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64(instance_id:cloud_api_token)>"
-# Option B — Via local Alloy/collector:
-#   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+cp .env.example .env
+# Fill in your credentials in .env — see the SDK README for where to find each value.
 go mod tidy
 ```
 

--- a/examples/getting-started/go/README.md
+++ b/examples/getting-started/go/README.md
@@ -8,6 +8,13 @@ Makes an OpenAI chat completion and records the generation to Grafana Cloud AI O
 cd examples/getting-started/go
 # Set OPENAI_API_KEY, GRAFANA_INSTANCE_ID, GRAFANA_CLOUD_TOKEN, SIGIL_ENDPOINT
 # See the SDK README for where to find each value.
+#
+# For traces and metrics, set the OTLP endpoint.
+# Option A — Direct to Cloud (get URL from Cloud portal → stack Details):
+#   OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
+#   OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64(instance_id:cloud_api_token)>"
+# Option B — Via local Alloy/collector:
+#   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 go mod tidy
 ```
 
@@ -17,4 +24,4 @@ go mod tidy
 go run .
 ```
 
-You should see the LLM response printed, followed by `Done`. Open the AI Observability plugin in your Grafana Cloud stack to see the recorded generation.
+You should see the LLM response printed, followed by `Done`. Open the AI Observability plugin in your Grafana Cloud stack to see the recorded generation, and check your Grafana Cloud Traces and Metrics datasources for SDK-emitted spans and metrics.

--- a/examples/getting-started/go/go.mod
+++ b/examples/getting-started/go/go.mod
@@ -5,6 +5,11 @@ go 1.23
 require (
 	github.com/grafana/sigil-sdk/go v0.0.0
 	github.com/openai/openai-go/v3 v3.29.0
+	go.opentelemetry.io/contrib/exporters/autoexport v0.60.0
+	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	go.opentelemetry.io/otel/semconv v1.26.0
 )
 
 replace github.com/grafana/sigil-sdk/go => ../../../go

--- a/examples/getting-started/go/go.mod
+++ b/examples/getting-started/go/go.mod
@@ -4,6 +4,7 @@ go 1.23
 
 require (
 	github.com/grafana/sigil-sdk/go v0.0.0
+	github.com/joho/godotenv v1.5.1
 	github.com/openai/openai-go/v3 v3.29.0
 	go.opentelemetry.io/contrib/exporters/autoexport v0.60.0
 	go.opentelemetry.io/otel v1.43.0

--- a/examples/getting-started/go/main.go
+++ b/examples/getting-started/go/main.go
@@ -11,11 +11,40 @@ import (
 	openai "github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/shared"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/contrib/exporters/autoexport"
 )
 
 func main() {
 	ctx := context.Background()
 	model := "gpt-4.1-mini"
+
+	res, err := resource.New(ctx, resource.WithAttributes(
+		semconv.ServiceName("getting-started-go"),
+	))
+	if err != nil {
+		log.Fatalf("resource: %v", err)
+	}
+
+	traceExp, err := autoexport.NewSpanExporter(ctx)
+	if err != nil {
+		log.Fatalf("trace exporter: %v", err)
+	}
+	tp := sdktrace.NewTracerProvider(sdktrace.WithBatcher(traceExp), sdktrace.WithResource(res))
+	otel.SetTracerProvider(tp)
+	defer func() { _ = tp.Shutdown(ctx) }()
+
+	metricExp, err := autoexport.NewMetricReader(ctx)
+	if err != nil {
+		log.Fatalf("metric reader: %v", err)
+	}
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(metricExp), sdkmetric.WithResource(res))
+	otel.SetMeterProvider(mp)
+	defer func() { _ = mp.Shutdown(ctx) }()
 
 	cfg := sigil.DefaultConfig()
 	cfg.GenerationExport.Protocol = sigil.GenerationExportProtocolHTTP

--- a/examples/getting-started/go/main.go
+++ b/examples/getting-started/go/main.go
@@ -8,18 +8,21 @@ import (
 	"os"
 
 	"github.com/grafana/sigil-sdk/go/sigil"
+	"github.com/joho/godotenv"
 	openai "github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/shared"
+	"go.opentelemetry.io/contrib/exporters/autoexport"
 	"go.opentelemetry.io/otel"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
-	"go.opentelemetry.io/contrib/exporters/autoexport"
 )
 
 func main() {
+	_ = godotenv.Load()
+
 	ctx := context.Background()
 	model := "gpt-4.1-mini"
 

--- a/examples/getting-started/python/.env.example
+++ b/examples/getting-started/python/.env.example
@@ -1,14 +1,26 @@
-# LLM provider
+# --- LLM provider ---
+# This example uses OpenAI. Replace with your provider's key if different.
 OPENAI_API_KEY=
 
-# Sigil generation export (Grafana Cloud)
+# --- Sigil generation export (Grafana Cloud) ---
+# Generation-ingest URL. Find it in your Grafana Cloud stack under
+# AI Observability → SDK connection details.
 SIGIL_ENDPOINT=https://<your-stack>.grafana.net/api/v1/generations:export
+
+# Your Grafana Cloud stack / instance ID (numeric).
+# Shown in the stack details page or the SDK connection details panel.
 GRAFANA_INSTANCE_ID=
+
+# A Grafana Cloud API token with AI Observability write permissions.
+# Create one at https://grafana.com → My Account → API Keys.
 GRAFANA_CLOUD_TOKEN=
 
-# OTel traces + metrics
-# Option A — Direct to Cloud (get URL from Cloud portal → stack Details):
+# --- OTel traces + metrics ---
+# Option A — Direct to Grafana Cloud OTLP gateway:
+#   Find the endpoint in your Cloud portal → stack Details → OpenTelemetry.
+#   The header is: Authorization=Basic <base64(instance_id:cloud_api_token)>
 OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
 OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instance_id:cloud_api_token)>
-# Option B — Via local Alloy/collector:
+
+# Option B — Via local Alloy / OTel Collector (no auth needed):
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318

--- a/examples/getting-started/python/.env.example
+++ b/examples/getting-started/python/.env.example
@@ -1,0 +1,14 @@
+# LLM provider
+OPENAI_API_KEY=
+
+# Sigil generation export (Grafana Cloud)
+SIGIL_ENDPOINT=https://<your-stack>.grafana.net/api/v1/generations:export
+GRAFANA_INSTANCE_ID=
+GRAFANA_CLOUD_TOKEN=
+
+# OTel traces + metrics
+# Option A — Direct to Cloud (get URL from Cloud portal → stack Details):
+OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instance_id:cloud_api_token)>
+# Option B — Via local Alloy/collector:
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318

--- a/examples/getting-started/python/README.md
+++ b/examples/getting-started/python/README.md
@@ -6,15 +6,8 @@ Makes an OpenAI chat completion and records the generation to Grafana Cloud AI O
 
 ```bash
 cd examples/getting-started/python
-# Set OPENAI_API_KEY, GRAFANA_INSTANCE_ID, GRAFANA_CLOUD_TOKEN, SIGIL_ENDPOINT
-# See the SDK README for where to find each value.
-#
-# For traces and metrics, set the OTLP endpoint.
-# Option A — Direct to Cloud (get URL from Cloud portal → stack Details):
-#   OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
-#   OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64(instance_id:cloud_api_token)>"
-# Option B — Via local Alloy/collector:
-#   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+cp .env.example .env
+# Fill in your credentials in .env — see the SDK README for where to find each value.
 ```
 
 ```bash

--- a/examples/getting-started/python/README.md
+++ b/examples/getting-started/python/README.md
@@ -8,6 +8,13 @@ Makes an OpenAI chat completion and records the generation to Grafana Cloud AI O
 cd examples/getting-started/python
 # Set OPENAI_API_KEY, GRAFANA_INSTANCE_ID, GRAFANA_CLOUD_TOKEN, SIGIL_ENDPOINT
 # See the SDK README for where to find each value.
+#
+# For traces and metrics, set the OTLP endpoint.
+# Option A — Direct to Cloud (get URL from Cloud portal → stack Details):
+#   OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
+#   OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64(instance_id:cloud_api_token)>"
+# Option B — Via local Alloy/collector:
+#   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 ```
 
 ```bash
@@ -20,4 +27,4 @@ pip install -r requirements.txt
 python main.py
 ```
 
-You should see the LLM response printed, followed by `Done`. Open the AI Observability plugin in your Grafana Cloud stack to see the recorded generation.
+You should see the LLM response printed, followed by `Done`. Open the AI Observability plugin in your Grafana Cloud stack to see the recorded generation, and check your Grafana Cloud Traces and Metrics datasources for SDK-emitted spans and metrics.

--- a/examples/getting-started/python/main.py
+++ b/examples/getting-started/python/main.py
@@ -4,6 +4,14 @@ import os
 
 from dotenv import load_dotenv
 from openai import OpenAI
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from sigil_sdk import (
     AuthConfig,
     Client,
@@ -17,6 +25,18 @@ from sigil_sdk import (
 )
 
 load_dotenv()
+
+resource = Resource.create({"service.name": "getting-started-python"})
+
+tp = TracerProvider(resource=resource)
+tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+trace.set_tracer_provider(tp)
+
+mp = MeterProvider(
+    resource=resource,
+    metric_readers=[PeriodicExportingMetricReader(OTLPMetricExporter())],
+)
+metrics.set_meter_provider(mp)
 
 openai_client = OpenAI()
 model = "gpt-4.1-mini"
@@ -72,4 +92,6 @@ with sigil.start_generation(
         print("SDK error:", rec.err())
 
 sigil.shutdown()
+tp.shutdown()
+mp.shutdown()
 print("Done — check the AI Observability plugin in your Grafana Cloud stack.")

--- a/examples/getting-started/python/requirements.txt
+++ b/examples/getting-started/python/requirements.txt
@@ -1,3 +1,5 @@
 openai
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-http
 python-dotenv
 sigil-sdk

--- a/examples/getting-started/typescript/.env.example
+++ b/examples/getting-started/typescript/.env.example
@@ -1,14 +1,26 @@
-# LLM provider
+# --- LLM provider ---
+# This example uses OpenAI. Replace with your provider's key if different.
 OPENAI_API_KEY=
 
-# Sigil generation export (Grafana Cloud)
+# --- Sigil generation export (Grafana Cloud) ---
+# Generation-ingest URL. Find it in your Grafana Cloud stack under
+# AI Observability → SDK connection details.
 SIGIL_ENDPOINT=https://<your-stack>.grafana.net/api/v1/generations:export
+
+# Your Grafana Cloud stack / instance ID (numeric).
+# Shown in the stack details page or the SDK connection details panel.
 GRAFANA_INSTANCE_ID=
+
+# A Grafana Cloud API token with AI Observability write permissions.
+# Create one at https://grafana.com → My Account → API Keys.
 GRAFANA_CLOUD_TOKEN=
 
-# OTel traces + metrics
-# Option A — Direct to Cloud (get URL from Cloud portal → stack Details):
+# --- OTel traces + metrics ---
+# Option A — Direct to Grafana Cloud OTLP gateway:
+#   Find the endpoint in your Cloud portal → stack Details → OpenTelemetry.
+#   The header is: Authorization=Basic <base64(instance_id:cloud_api_token)>
 OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
 OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instance_id:cloud_api_token)>
-# Option B — Via local Alloy/collector:
+
+# Option B — Via local Alloy / OTel Collector (no auth needed):
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318

--- a/examples/getting-started/typescript/.env.example
+++ b/examples/getting-started/typescript/.env.example
@@ -1,0 +1,14 @@
+# LLM provider
+OPENAI_API_KEY=
+
+# Sigil generation export (Grafana Cloud)
+SIGIL_ENDPOINT=https://<your-stack>.grafana.net/api/v1/generations:export
+GRAFANA_INSTANCE_ID=
+GRAFANA_CLOUD_TOKEN=
+
+# OTel traces + metrics
+# Option A — Direct to Cloud (get URL from Cloud portal → stack Details):
+OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instance_id:cloud_api_token)>
+# Option B — Via local Alloy/collector:
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318

--- a/examples/getting-started/typescript/README.md
+++ b/examples/getting-started/typescript/README.md
@@ -8,6 +8,13 @@ Makes an OpenAI chat completion and records the generation to Grafana Cloud AI O
 cd examples/getting-started/typescript
 # Set OPENAI_API_KEY, GRAFANA_INSTANCE_ID, GRAFANA_CLOUD_TOKEN, SIGIL_ENDPOINT
 # See the SDK README for where to find each value.
+#
+# For traces and metrics, set the OTLP endpoint.
+# Option A — Direct to Cloud (get URL from Cloud portal → stack Details):
+#   OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
+#   OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64(instance_id:cloud_api_token)>"
+# Option B — Via local Alloy/collector:
+#   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 ```
 
 ```bash
@@ -22,4 +29,4 @@ npm install
 npx tsx main.ts
 ```
 
-You should see the LLM response printed, followed by `Done`. Open the AI Observability plugin in your Grafana Cloud stack to see the recorded generation.
+You should see the LLM response printed, followed by `Done`. Open the AI Observability plugin in your Grafana Cloud stack to see the recorded generation, and check your Grafana Cloud Traces and Metrics datasources for SDK-emitted spans and metrics.

--- a/examples/getting-started/typescript/README.md
+++ b/examples/getting-started/typescript/README.md
@@ -6,15 +6,8 @@ Makes an OpenAI chat completion and records the generation to Grafana Cloud AI O
 
 ```bash
 cd examples/getting-started/typescript
-# Set OPENAI_API_KEY, GRAFANA_INSTANCE_ID, GRAFANA_CLOUD_TOKEN, SIGIL_ENDPOINT
-# See the SDK README for where to find each value.
-#
-# For traces and metrics, set the OTLP endpoint.
-# Option A — Direct to Cloud (get URL from Cloud portal → stack Details):
-#   OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
-#   OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64(instance_id:cloud_api_token)>"
-# Option B — Via local Alloy/collector:
-#   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+cp .env.example .env
+# Fill in your credentials in .env — see the SDK README for where to find each value.
 ```
 
 ```bash

--- a/examples/getting-started/typescript/main.ts
+++ b/examples/getting-started/typescript/main.ts
@@ -4,8 +4,30 @@
 
 import "dotenv/config";
 import OpenAI from "openai";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import {
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from "@opentelemetry/sdk-metrics";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
+import { Resource } from "@opentelemetry/resources";
 import { createSigilClient } from "@grafana/sigil-sdk-js";
 import type { GenerationRecorder } from "@grafana/sigil-sdk-js";
+
+const resource = new Resource({ "service.name": "getting-started-typescript" });
+
+const tp = new NodeTracerProvider({ resource });
+tp.addSpanProcessor(new BatchSpanProcessor(new OTLPTraceExporter()));
+tp.register();
+
+const mp = new MeterProvider({
+  resource,
+  readers: [
+    new PeriodicExportingMetricReader({ exporter: new OTLPMetricExporter() }),
+  ],
+});
 
 const openai = new OpenAI();
 const model = "gpt-4.1-mini";
@@ -59,6 +81,8 @@ await sigil.startGeneration(
 );
 
 await sigil.shutdown();
+await tp.shutdown();
+await mp.shutdown();
 console.log(
   "Done — check the AI Observability plugin in your Grafana Cloud stack.",
 );

--- a/examples/getting-started/typescript/main.ts
+++ b/examples/getting-started/typescript/main.ts
@@ -4,6 +4,7 @@
 
 import "dotenv/config";
 import OpenAI from "openai";
+import { metrics } from "@opentelemetry/api";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
@@ -28,6 +29,7 @@ const mp = new MeterProvider({
     new PeriodicExportingMetricReader({ exporter: new OTLPMetricExporter() }),
   ],
 });
+metrics.setGlobalMeterProvider(mp);
 
 const openai = new OpenAI();
 const model = "gpt-4.1-mini";

--- a/examples/getting-started/typescript/package.json
+++ b/examples/getting-started/typescript/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@grafana/sigil-sdk-js": "file:../../../js",
+    "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.57.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
     "@opentelemetry/resources": "^1.30.0",

--- a/examples/getting-started/typescript/package.json
+++ b/examples/getting-started/typescript/package.json
@@ -8,6 +8,12 @@
   },
   "dependencies": {
     "@grafana/sigil-sdk-js": "file:../../../js",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.57.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
+    "@opentelemetry/resources": "^1.30.0",
+    "@opentelemetry/sdk-metrics": "^1.30.0",
+    "@opentelemetry/sdk-trace-base": "^1.30.0",
+    "@opentelemetry/sdk-trace-node": "^1.30.0",
     "dotenv": "^16.0.0",
     "openai": "^4.0.0",
     "tsx": "^4.0.0",

--- a/examples/python-langchain/.env.example
+++ b/examples/python-langchain/.env.example
@@ -21,9 +21,10 @@ SIGIL_AUTH_TOKEN=
 # Option A — Direct to Cloud (get URL from Cloud portal → stack Details):
 #   OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
 #   OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instance_id:cloud_api_token)>
-# Option B — Via local Alloy/collector:
-#   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
-OTEL_EXPORTER_OTLP_ENDPOINT=
+# Option B — Via local Alloy/collector (default for docker-compose):
+#   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+# Leave unset to use the exporter's built-in default (localhost:4317 for gRPC).
+# OTEL_EXPORTER_OTLP_ENDPOINT=
 OTEL_SERVICE_NAME=sigil-langchain-weather-example
 
 # --- Model selection (override to whatever you have access to) ---

--- a/examples/python-langchain/.env.example
+++ b/examples/python-langchain/.env.example
@@ -18,8 +18,12 @@ SIGIL_TENANT_ID=
 SIGIL_AUTH_TOKEN=
 
 # --- OTel traces + metrics exporter ---
+# Option A — Direct to Cloud (get URL from Cloud portal → stack Details):
+#   OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
+#   OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instance_id:cloud_api_token)>
+# Option B — Via local Alloy/collector:
+#   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 OTEL_EXPORTER_OTLP_ENDPOINT=
-OTEL_EXPORTER_OTLP_INSECURE=true
 OTEL_SERVICE_NAME=sigil-langchain-weather-example
 
 # --- Model selection (override to whatever you have access to) ---

--- a/examples/python-langchain/app/telemetry.py
+++ b/examples/python-langchain/app/telemetry.py
@@ -1,6 +1,6 @@
 """OpenTelemetry bootstrap.
 
-Sets up a TracerProvider + MeterProvider using OTLP/HTTP exporters and
+Sets up a TracerProvider + MeterProvider using OTLP/gRPC exporters and
 registers them globally. The exporters read standard OTel env vars
 (OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_HEADERS, etc.)
 automatically, so no endpoint/auth is hardcoded here.
@@ -9,7 +9,7 @@ Send traces and metrics to Grafana Cloud either:
   A) Direct — set OTEL_EXPORTER_OTLP_ENDPOINT to your Cloud OTLP gateway
      URL (from Cloud portal → stack Details) and OTEL_EXPORTER_OTLP_HEADERS
      with Basic auth.
-  B) Via Alloy — set OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+  B) Via Alloy — set OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
      and let Alloy handle Cloud auth.
 """
 
@@ -19,8 +19,8 @@ import os
 from dataclasses import dataclass
 
 from opentelemetry import metrics, trace
-from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource

--- a/examples/python-langchain/app/telemetry.py
+++ b/examples/python-langchain/app/telemetry.py
@@ -1,8 +1,16 @@
 """OpenTelemetry bootstrap.
 
-Sets up a TracerProvider + MeterProvider that export to an OTLP gRPC
-target (Sigil's OTLP ingest on :4317 by default) and registers them
-globally. Standard OTel — nothing Sigil-specific lives here.
+Sets up a TracerProvider + MeterProvider using OTLP/HTTP exporters and
+registers them globally. The exporters read standard OTel env vars
+(OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_HEADERS, etc.)
+automatically, so no endpoint/auth is hardcoded here.
+
+Send traces and metrics to Grafana Cloud either:
+  A) Direct — set OTEL_EXPORTER_OTLP_ENDPOINT to your Cloud OTLP gateway
+     URL (from Cloud portal → stack Details) and OTEL_EXPORTER_OTLP_HEADERS
+     with Basic auth.
+  B) Via Alloy — set OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+     and let Alloy handle Cloud auth.
 """
 
 from __future__ import annotations
@@ -11,8 +19,8 @@ import os
 from dataclasses import dataclass
 
 from opentelemetry import metrics, trace
-from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
@@ -30,33 +38,18 @@ class OpenTelemetry:
         self.meter_provider.shutdown()
 
 
-def _env(name: str, default: str) -> str:
-    value = os.getenv(name, default).strip()
-    return value or default
-
-
 def setup_opentelemetry() -> OpenTelemetry:
-    service_name = _env("OTEL_SERVICE_NAME", "sigil-langchain-weather-example")
-    otlp_endpoint = _env("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
-    otlp_insecure = _env("OTEL_EXPORTER_OTLP_INSECURE", "true").lower() == "true"
+    service_name = os.getenv("OTEL_SERVICE_NAME", "sigil-langchain-weather-example")
 
     resource = Resource.create({"service.name": service_name})
 
     tracer_provider = TracerProvider(resource=resource)
-    tracer_provider.add_span_processor(
-        BatchSpanProcessor(
-            OTLPSpanExporter(endpoint=otlp_endpoint, insecure=otlp_insecure)
-        )
-    )
+    tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
     trace.set_tracer_provider(tracer_provider)
 
     meter_provider = MeterProvider(
         resource=resource,
-        metric_readers=[
-            PeriodicExportingMetricReader(
-                OTLPMetricExporter(endpoint=otlp_endpoint, insecure=otlp_insecure)
-            )
-        ],
+        metric_readers=[PeriodicExportingMetricReader(OTLPMetricExporter())],
     )
     metrics.set_meter_provider(meter_provider)
 

--- a/examples/python-langchain/pyproject.toml
+++ b/examples/python-langchain/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 
     "opentelemetry-api>=1.27",
     "opentelemetry-sdk>=1.27",
-    "opentelemetry-exporter-otlp-proto-http>=1.27",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.27",
     "opentelemetry-instrumentation-fastapi>=0.48b0",
 
     "sigil-sdk>=0.1.2",

--- a/examples/python-langchain/pyproject.toml
+++ b/examples/python-langchain/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 
     "opentelemetry-api>=1.27",
     "opentelemetry-sdk>=1.27",
-    "opentelemetry-exporter-otlp-proto-grpc>=1.27",
+    "opentelemetry-exporter-otlp-proto-http>=1.27",
     "opentelemetry-instrumentation-fastapi>=0.48b0",
 
     "sigil-sdk>=0.1.2",

--- a/plugins/opencode/skills/sigil/SKILL.md
+++ b/plugins/opencode/skills/sigil/SKILL.md
@@ -46,6 +46,70 @@ Authoritative references in this repo:
 - `docs/references/generation-ingest-contract.md`
 - `docs/references/semantic-conventions.md`
 
+## OTel setup (required)
+
+The Sigil SDK internally emits OTel spans and metrics (`gen_ai.client.operation.duration`, `gen_ai.client.token.usage`, `gen_ai.client.time_to_first_token`, `gen_ai.client.tool_calls_per_operation`). **Without a configured TracerProvider and MeterProvider these go to the default no-op and are silently lost.**
+
+The SDK does NOT create OTel providers — that is the application's responsibility. Always ensure the app configures providers BEFORE creating the Sigil client, and shuts them down AFTER `sigil.shutdown()`.
+
+The endpoint, protocol (HTTP vs gRPC), and port depend on the user's collector/Alloy configuration. Use an env var like `OTEL_EXPORTER_OTLP_ENDPOINT` so the app doesn't hardcode assumptions. Common collector ports: 4318 (OTLP/HTTP), 4317 (OTLP/gRPC). The snippets below use HTTP — switch to gRPC equivalents if the target collector only accepts gRPC.
+
+### Python (HTTP)
+```python
+from opentelemetry import trace, metrics
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+
+resource = Resource.create({"service.name": "my-app"})
+endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+
+tp = TracerProvider(resource=resource)
+tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{endpoint}/v1/traces")))
+trace.set_tracer_provider(tp)
+
+mp = MeterProvider(resource=resource, metric_readers=[
+    PeriodicExportingMetricReader(OTLPMetricExporter(endpoint=f"{endpoint}/v1/metrics"))
+])
+metrics.set_meter_provider(mp)
+# Deps: opentelemetry-sdk, opentelemetry-exporter-otlp-proto-http
+```
+
+### Go
+```go
+traceExp, _ := otlptracehttp.New(ctx)
+tp := sdktrace.NewTracerProvider(sdktrace.WithBatcher(traceExp), sdktrace.WithResource(res))
+otel.SetTracerProvider(tp)
+defer tp.Shutdown(ctx)
+
+metricExp, _ := otlpmetrichttp.New(ctx)
+mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricExp)), sdkmetric.WithResource(res))
+otel.SetMeterProvider(mp)
+defer mp.Shutdown(ctx)
+```
+
+### JS/TS
+```typescript
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { MeterProvider, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
+
+const tp = new NodeTracerProvider({ resource });
+tp.addSpanProcessor(new BatchSpanProcessor(new OTLPTraceExporter()));
+tp.register();
+
+const mp = new MeterProvider({
+  resource,
+  readers: [new PeriodicExportingMetricReader({ exporter: new OTLPMetricExporter() })],
+});
+```
+
 ## Telemetry fields to prioritize
 
 On generation and tool spans, capture or preserve these when available:
@@ -143,6 +207,13 @@ Provider wrappers and framework adapters already exist; reuse them where possibl
 - Keep raw artifacts disabled unless explicitly asked.
 - Ensure non-stream wrappers set `SYNC`, stream wrappers set `STREAM`.
 - Ensure lifecycle flush/shutdown semantics are preserved.
+- When calling `set_result` / `SetResult`, always include all available fields:
+  - `response_id` (provider correlation, maps to `gen_ai.response.id`)
+  - `response_model` (actual model used)
+  - `stop_reason` / `finish_reason`
+  - Full token usage including `cache_read_input_tokens`, `cache_creation_input_tokens`, and `reasoning_tokens` when the provider returns them
+- Always check `rec.err()` / `Err()` after the generation recorder closes — SDK validation or enqueue errors are otherwise silent.
+- Use `tags` on `GenerationStart` for filtering in the Sigil UI (e.g. pipeline name, layer, agent role).
 
 ## Validation checklist
 

--- a/plugins/opencode/skills/sigil/SKILL.md
+++ b/plugins/opencode/skills/sigil/SKILL.md
@@ -52,9 +52,34 @@ The Sigil SDK internally emits OTel spans and metrics (`gen_ai.client.operation.
 
 The SDK does NOT create OTel providers — that is the application's responsibility. Always ensure the app configures providers BEFORE creating the Sigil client, and shuts them down AFTER `sigil.shutdown()`.
 
-The endpoint, protocol (HTTP vs gRPC), and port depend on the user's collector/Alloy configuration. Use an env var like `OTEL_EXPORTER_OTLP_ENDPOINT` so the app doesn't hardcode assumptions. Common collector ports: 4318 (OTLP/HTTP), 4317 (OTLP/gRPC). The snippets below use HTTP — switch to gRPC equivalents if the target collector only accepts gRPC.
+Traces and metrics can be sent to Grafana Cloud in two ways. Always use env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`) so the app doesn't hardcode assumptions.
 
-### Python (HTTP)
+### Option A — Direct to Grafana Cloud (no collector needed)
+
+Send OTLP straight to the Grafana Cloud OTLP gateway. The exact URL is stack-specific — get it from the **Grafana Cloud portal → stack Details page** ([docs](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp)). Authentication uses Basic auth with instance ID and a Cloud API token.
+
+Env vars:
+```
+OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>   # from Cloud portal
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instance_id:cloud_api_token)>
+```
+
+The OTel SDK exporters read these env vars automatically — no extra code needed beyond the provider setup below.
+
+### Option B — Via Alloy / OTel Collector (optional)
+
+Run a local Alloy or OTel Collector that receives unauthenticated OTLP and forwards to Cloud with credentials. Useful for centralized token management, retries, relabeling, and metadata enrichment. Common local ports: 4318 (OTLP/HTTP), 4317 (OTLP/gRPC).
+
+Env vars:
+```
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+```
+
+### Provider setup (required for both options)
+
+The snippets below configure TracerProvider and MeterProvider using OTLP/HTTP exporters that honour the env vars above.
+
+#### Python
 ```python
 from opentelemetry import trace, metrics
 from opentelemetry.sdk.trace import TracerProvider
@@ -66,20 +91,19 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 
 resource = Resource.create({"service.name": "my-app"})
-endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
 
 tp = TracerProvider(resource=resource)
-tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{endpoint}/v1/traces")))
+tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
 trace.set_tracer_provider(tp)
 
 mp = MeterProvider(resource=resource, metric_readers=[
-    PeriodicExportingMetricReader(OTLPMetricExporter(endpoint=f"{endpoint}/v1/metrics"))
+    PeriodicExportingMetricReader(OTLPMetricExporter())
 ])
 metrics.set_meter_provider(mp)
 # Deps: opentelemetry-sdk, opentelemetry-exporter-otlp-proto-http
 ```
 
-### Go
+#### Go
 ```go
 traceExp, _ := otlptracehttp.New(ctx)
 tp := sdktrace.NewTracerProvider(sdktrace.WithBatcher(traceExp), sdktrace.WithResource(res))
@@ -92,7 +116,7 @@ otel.SetMeterProvider(mp)
 defer mp.Shutdown(ctx)
 ```
 
-### JS/TS
+#### JS/TS
 ```typescript
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';

--- a/plugins/opencode/skills/sigil/SKILL.md
+++ b/plugins/opencode/skills/sigil/SKILL.md
@@ -118,6 +118,7 @@ defer mp.Shutdown(ctx)
 
 #### JS/TS
 ```typescript
+import { metrics } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
@@ -132,6 +133,7 @@ const mp = new MeterProvider({
   resource,
   readers: [new PeriodicExportingMetricReader({ exporter: new OTLPMetricExporter() })],
 });
+metrics.setGlobalMeterProvider(mp);
 ```
 
 ## Telemetry fields to prioritize


### PR DESCRIPTION
## Summary

- **Instrumentation prompts** (Cursor `.mdc`, `CLAUDE.md`, Opencode `SKILL.md`): Add required OTel `TracerProvider`/`MeterProvider` setup with two options — direct to Grafana Cloud OTLP gateway (no collector needed) or via Alloy (optional). Include `set_result` best practices (`response_id`, full `TokenUsage`, `rec.err()`, `tags`).
- **Getting-started examples** (Python, TypeScript, Go): Add OTel provider setup so SDK-emitted spans and metrics are actually exported instead of silently lost. Add OTel deps and document OTLP env vars in READMEs.
- **python-langchain example**: Simplify `telemetry.py` to use env var auto-discovery instead of manual endpoint parsing. Update `.env.example` with Cloud direct and Alloy options. Keep gRPC exporters (matches bundled docker-compose Alloy on port 4317).

## Context

The Sigil SDK emits OTel spans and metrics internally but relies on the app to configure providers. Without this setup all telemetry goes to the default no-op and is silently lost. This was discovered when demo pipelines had correct generation ingest but zero traces/metrics.

The prompts previously assumed a local Alloy collector was always required. Users can send OTLP directly to the Grafana Cloud OTLP gateway — this PR documents both options.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-only changes; main risk is minor breakage if OTel dependency versions or env var expectations differ in user environments.
> 
> **Overview**
> Adds explicit OpenTelemetry setup guidance (TracerProvider + MeterProvider) to the instrumentation prompts (`.cursor` rules, `CLAUDE.md`, Opencode `SKILL.md`), including Cloud-direct vs Alloy/collector OTLP configuration and additional recording best practices (`set_result` fields, `rec.err()`/`Err()` checks, and `tags`).
> 
> Updates the getting-started Go/Python/TypeScript examples to actually initialize OTel providers, add required OTel dependencies, and provide `.env.example` files plus README updates so SDK-emitted spans/metrics are exported and shutdown ordering is clear.
> 
> Simplifies the `examples/python-langchain` telemetry bootstrap to rely on standard OTel env var auto-discovery (no manual endpoint/insecure parsing) and refreshes its `.env.example` with Cloud-direct and Alloy options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dde76ce92c24141bab9abb9fcbb8c02d911b5a6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->