### PR TITLE
fix(java-sdk): set gen_ai.operation.name on tool-execution spans

### DIFF
--- a/java/core/src/main/java/com/grafana/sigil/sdk/SigilClient.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/SigilClient.java
@@ -99,6 +99,7 @@ public final class SigilClient implements AutoCloseable {
     private static final Pattern STATUS_CODE_PATTERN = Pattern.compile("\\b([1-5][0-9][0-9])\\b");
     private static final String INSTRUMENTATION_NAME = "github.com/grafana/sigil/sdks/java";
     static final String DEFAULT_EMBEDDING_OPERATION_NAME = "embeddings";
+    static final String TOOL_EXECUTION_OPERATION_NAME = "execute_tool";
     static final String SDK_NAME = "sdk-java";
     static final String METADATA_USER_ID_KEY = "sigil.user.id";
     static final String METADATA_LEGACY_USER_ID_KEY = "user.id";
@@ -1033,6 +1034,7 @@ public final class SigilClient implements AutoCloseable {
 
     static void setToolSpanAttributes(Span span, ToolExecutionStart seed) {
         span.setAttribute(SPAN_ATTR_SDK_NAME, SDK_NAME);
+        span.setAttribute(SPAN_ATTR_OPERATION_NAME, TOOL_EXECUTION_OPERATION_NAME);
         if (!seed.getConversationId().isBlank()) {
             span.setAttribute(SPAN_ATTR_CONVERSATION_ID, seed.getConversationId());
         }
@@ -1190,7 +1192,7 @@ public final class SigilClient implements AutoCloseable {
         operationDurationHistogram.record(
                 durationSeconds,
                 Attributes.builder()
-                        .put(SPAN_ATTR_OPERATION_NAME, "execute_tool")
+                        .put(SPAN_ATTR_OPERATION_NAME, TOOL_EXECUTION_OPERATION_NAME)
                         .put(SPAN_ATTR_PROVIDER_NAME, seed.getRequestProvider().trim())
                         .put(SPAN_ATTR_REQUEST_MODEL, seed.getRequestModel().trim())
                         .put(SPAN_ATTR_TOOL_NAME, seed.getToolName().trim())

--- a/java/core/src/test/java/com/grafana/sigil/sdk/SigilClientSpansTest.java
+++ b/java/core/src/test/java/com/grafana/sigil/sdk/SigilClientSpansTest.java
@@ -97,6 +97,8 @@ class SigilClientSpansTest {
         SpanData span = spans.get(0);
         assertThat(span.getName()).isEqualTo("execute_tool weather");
         assertThat(span.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_SDK_NAME))).isEqualTo("sdk-java");
+        assertThat(span.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_OPERATION_NAME)))
+                .isEqualTo(SigilClient.TOOL_EXECUTION_OPERATION_NAME);
         assertThat(span.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_TOOL_NAME))).isEqualTo("weather");
         assertThat(span.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_TOOL_CALL_ID))).isEqualTo("call-1");
         assertThat(span.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_PROVIDER_NAME))).isEqualTo("openai");


### PR DESCRIPTION
## Summary

The Java SDK's `setToolSpanAttributes` does not set the `gen_ai.operation.name` attribute on tool-execution spans, while the Go SDK does (`toolSpanAttributes` in `go/sigil/client.go`).

Sigil's plugin "Recent conversations" panel for a tool queries Tempo with the predicate

```
span.gen_ai.tool.name = "<tool>" && span.gen_ai.operation.name = "execute_tool"
```

so spans emitted by the Java SDK never satisfy the second clause, and the panel always reads "No conversations matched this tool in the selected time range" for any Java SDK consumer — even though the Tools dashboard's metric tiles still work because `recordToolExecutionMetrics` already sets the attribute on the histogram's `Attributes` builder.

## Reproduction

1. Use the Java SDK to wrap a tool execution via `client.startToolExecution(...)`.
2. Trigger the tool. Tools dashboard top tiles populate (executions count, latency).
3. Scroll to "Recent conversations" — empty.
4. Verify directly via Tempo:
   ```bash
   # Returns the spans:
   curl -s -H 'X-Scope-OrgID: fake' --get http://localhost:3200/api/search \
     --data-urlencode 'q={ span.gen_ai.tool.name = "<tool>" }'

   # Returns nothing (the predicate the dashboard uses):
   curl -s -H 'X-Scope-OrgID: fake' --get http://localhost:3200/api/search \
     --data-urlencode 'q={ span.gen_ai.tool.name = "<tool>" \
                            && span.gen_ai.operation.name = "execute_tool" }'
   ```
5. Inspect any single trace via `GET /api/traces/<id>` — the tool span has `gen_ai.tool.name`, `gen_ai.conversation.id`, `gen_ai.agent.name`, etc., but no `gen_ai.operation.name` key.

## Fix

- Add `span.setAttribute(SPAN_ATTR_OPERATION_NAME, "execute_tool")` to `setToolSpanAttributes`, mirroring the Go SDK.
- Lift the literal `"execute_tool"` to a static constant `TOOL_EXECUTION_OPERATION_NAME` (alongside the existing `DEFAULT_EMBEDDING_OPERATION_NAME`) and reuse it from both `setToolSpanAttributes` and `recordToolExecutionMetrics` so the span and metric attribute values can't drift.
- Extend `SigilClientSpansTest.toolSpanHasRequiredAttributes()` to assert the operation-name attribute is present on tool spans (it already asserts the other tool-span attributes).

## Test plan

- [x] `./gradlew :core:test` green
- [x] Existing `SigilClientSpansTest.toolSpanHasRequiredAttributes()` extended with the new assertion
- [x] No API change; strictly additive at the span-attribute level

## Risk

Strictly additive. No API change, no migration concern. Consumers' dashboards already expect the attribute — they'll just start receiving traces that match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive telemetry attribute + small refactor to reuse a constant; no API or behavior changes beyond extra span metadata.
> 
> **Overview**
> Tool-execution spans emitted by the Java SDK now include `gen_ai.operation.name` set to `execute_tool`, aligning span attributes with existing tool-execution metrics and enabling dashboards/queries that filter on operation name.
> 
> The literal operation name is centralized as `TOOL_EXECUTION_OPERATION_NAME` and reused in both span attribute setting and `recordToolExecutionMetrics`, and `SigilClientSpansTest` is extended to assert the attribute is present on tool spans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13e9020228beff6d712a232a001aec0d4ab93bfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->