### PR TITLE
ci(python): publish sigil-sdk-pydantic-ai to PyPI

### DIFF
--- a/.github/workflows/python-sdks-publish.yml
+++ b/.github/workflows/python-sdks-publish.yml
@@ -93,6 +93,7 @@ jobs:
             python-frameworks/llamaindex
             python-frameworks/google-adk
             python-frameworks/litellm
+            python-frameworks/pydantic-ai
           )
 
           for dir in "${PACKAGE_DIRS[@]}"; do
@@ -118,6 +119,7 @@ jobs:
             python-frameworks/llamaindex
             python-frameworks/google-adk
             python-frameworks/litellm
+            python-frameworks/pydantic-ai
           )
 
           for dir in "${PACKAGE_DIRS[@]}"; do
@@ -184,6 +186,7 @@ jobs:
           - sigil-sdk-llamaindex
           - sigil-sdk-google-adk
           - sigil-sdk-litellm
+          - sigil-sdk-pydantic-ai
 
     steps:
       - name: Download distributions


### PR DESCRIPTION
Wire the new pydantic-ai framework package into the version-bump, build, and publish-dependents matrix so it ships alongside the other Python framework packages.

Part of https://github.com/grafana/sigil-sdk/issues/67

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release/publishing GitHub Actions workflow; a misconfiguration could break version bumps/builds or accidentally omit/fail a package publish.
> 
> **Overview**
> Wires the new `python-frameworks/pydantic-ai` package into the `python-sdks-publish.yml` workflow so it is included in the automated version bump, build artifact generation, and PyPI publish matrix.
> 
> This extends the dependent-package publish job to also upload `sigil-sdk-pydantic-ai` from the built distributions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 695851d8e79628a05a5aa010fb7b63a00a8a5e42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->