### PR TITLE
feat: apply OTel GenAI duration histogram buckets across SDKs

### DIFF
--- a/dotnet/src/Grafana.Sigil/SigilClient.cs
+++ b/dotnet/src/Grafana.Sigil/SigilClient.cs
@@ -73,6 +73,12 @@ public sealed partial class SigilClient : IAsyncDisposable
     internal const string MetricTokenTypeCacheCreation = "cache_creation";
     internal const string MetricTokenTypeReasoning = "reasoning";
 
+    internal static readonly double[] DurationBucketsSeconds =
+    {
+        0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28,
+        2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
+    };
+
 #if NET
     [GeneratedRegex(@"\b([1-5][0-9][0-9])\b", RegexOptions.Compiled)]
     private static partial Regex StatusCodeRegex();
@@ -150,9 +156,15 @@ public sealed partial class SigilClient : IAsyncDisposable
 
         _activitySource = new ActivitySource(InstrumentationName);
         _meter = new Meter(InstrumentationName);
-        _operationDurationHistogram = _meter.CreateHistogram<double>(MetricOperationDuration, "s");
+        _operationDurationHistogram = _meter.CreateHistogram<double>(
+            MetricOperationDuration,
+            unit: "s",
+            advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = DurationBucketsSeconds });
         _tokenUsageHistogram = _meter.CreateHistogram<double>(MetricTokenUsage, "token");
-        _ttftHistogram = _meter.CreateHistogram<double>(MetricTimeToFirstToken, "s");
+        _ttftHistogram = _meter.CreateHistogram<double>(
+            MetricTimeToFirstToken,
+            unit: "s",
+            advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = DurationBucketsSeconds });
         _toolCallsHistogram = _meter.CreateHistogram<double>(MetricToolCallsPerOperation, "count");
 
         _timerTask = Task.Run(RunFlushTimerAsync);

--- a/dotnet/tests/Grafana.Sigil.Tests/HistogramBucketAdviceTests.cs
+++ b/dotnet/tests/Grafana.Sigil.Tests/HistogramBucketAdviceTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Concurrent;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using Xunit;
+
+namespace Grafana.Sigil.Tests;
+
+public sealed class HistogramBucketAdviceTests
+{
+    private static readonly double[] ExpectedDurationBuckets =
+    {
+        0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28,
+        2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
+    };
+
+    [Fact]
+    public async Task DurationHistograms_UseSemconvBucketBoundaries()
+    {
+        var captured = new ConcurrentDictionary<string, double[]>(StringComparer.Ordinal);
+
+        var exporter = new CapturingMetricExporter(captured);
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(SigilClient.InstrumentationName)
+            .AddReader(new BaseExportingMetricReader(exporter))
+            .Build()!;
+
+        var generationExporter = new CapturingGenerationExporter();
+        var config = TestHelpers.TestConfig(generationExporter);
+
+        await using (var client = new SigilClient(config))
+        {
+            var start = TestHelpers.CreateSeedStart("gen-buckets");
+            start.Mode = null;
+            start.OperationName = string.Empty;
+
+            var recorder = client.StartStreamingGeneration(start);
+            recorder.SetFirstTokenAt(start.StartedAt!.Value.AddMilliseconds(50));
+
+            var result = TestHelpers.CreateSeedResult("gen-buckets");
+            result.Mode = GenerationMode.Stream;
+            result.OperationName = "streamText";
+            recorder.SetResult(result);
+            recorder.End();
+
+            await client.ShutdownAsync(TestContext.Current.CancellationToken);
+        }
+
+        meterProvider.ForceFlush();
+
+        Assert.True(
+            captured.TryGetValue("gen_ai.client.operation.duration", out var durationBounds),
+            "expected gen_ai.client.operation.duration data point");
+        Assert.Equal(ExpectedDurationBuckets, durationBounds);
+
+        Assert.True(
+            captured.TryGetValue("gen_ai.client.time_to_first_token", out var ttftBounds),
+            "expected gen_ai.client.time_to_first_token data point");
+        Assert.Equal(ExpectedDurationBuckets, ttftBounds);
+    }
+
+    private sealed class CapturingMetricExporter : BaseExporter<Metric>
+    {
+        private readonly ConcurrentDictionary<string, double[]> _captured;
+
+        public CapturingMetricExporter(ConcurrentDictionary<string, double[]> captured)
+        {
+            _captured = captured;
+        }
+
+        public override ExportResult Export(in Batch<Metric> batch)
+        {
+            foreach (var metric in batch)
+            {
+                if (metric.MetricType != MetricType.Histogram)
+                {
+                    continue;
+                }
+
+                foreach (ref readonly var point in metric.GetMetricPoints())
+                {
+                    var buckets = new List<double>();
+                    foreach (var bucket in point.GetHistogramBuckets())
+                    {
+                        if (!double.IsPositiveInfinity(bucket.ExplicitBound))
+                        {
+                            buckets.Add(bucket.ExplicitBound);
+                        }
+                    }
+                    _captured[metric.Name] = buckets.ToArray();
+                    break;
+                }
+            }
+
+            return ExportResult.Success;
+        }
+    }
+}

--- a/go/sigil/client.go
+++ b/go/sigil/client.go
@@ -171,6 +171,13 @@ const (
 	metricTokenTypeReasoning     = "reasoning"
 )
 
+// durationBucketsSeconds is the OTel GenAI semantic-convention bucket advice
+// applied to gen_ai.client.operation.duration and gen_ai.client.time_to_first_token.
+var durationBucketsSeconds = []float64{
+	0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28,
+	2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
+}
+
 var statusCodePattern = regexp.MustCompile(`\b([1-5][0-9][0-9])\b`)
 
 // Keep unexported aliases for backward-compatible fmt.Errorf wrapping.
@@ -1531,7 +1538,11 @@ func reflectIntField(err error, field string) int {
 func newTelemetryInstruments(meter metric.Meter) (telemetryInstruments, error) {
 	out := telemetryInstruments{}
 	var err error
-	out.operationDuration, err = meter.Float64Histogram(metricOperationDuration, metric.WithUnit("s"))
+	out.operationDuration, err = meter.Float64Histogram(
+		metricOperationDuration,
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(durationBucketsSeconds...),
+	)
 	if err != nil {
 		return telemetryInstruments{}, err
 	}
@@ -1539,7 +1550,11 @@ func newTelemetryInstruments(meter metric.Meter) (telemetryInstruments, error) {
 	if err != nil {
 		return telemetryInstruments{}, err
 	}
-	out.timeToFirstToken, err = meter.Float64Histogram(metricTimeToFirstToken, metric.WithUnit("s"))
+	out.timeToFirstToken, err = meter.Float64Histogram(
+		metricTimeToFirstToken,
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(durationBucketsSeconds...),
+	)
 	if err != nil {
 		return telemetryInstruments{}, err
 	}

--- a/go/sigil/conformance_test.go
+++ b/go/sigil/conformance_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"slices"
 	"testing"
 	"time"
 
@@ -762,6 +763,21 @@ func TestConformance_StreamingMode(t *testing.T) {
 		spanAttrRequestModel: conformanceModel.Name,
 		spanAttrAgentName:    "agent-stream",
 	})
+
+	expectedDurationBuckets := []float64{
+		0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28,
+		2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
+	}
+	duration := findHistogram[float64](t, metrics, metricOperationDuration)
+	if len(duration.DataPoints) == 0 {
+		t.Fatalf("expected %s datapoints", metricOperationDuration)
+	}
+	if got := duration.DataPoints[0].Bounds; !slices.Equal(got, expectedDurationBuckets) {
+		t.Fatalf("%s bucket boundaries mismatch:\nexpected %v\n     got %v", metricOperationDuration, expectedDurationBuckets, got)
+	}
+	if got := ttft.DataPoints[0].Bounds; !slices.Equal(got, expectedDurationBuckets) {
+		t.Fatalf("%s bucket boundaries mismatch:\nexpected %v\n     got %v", metricTimeToFirstToken, expectedDurationBuckets, got)
+	}
 
 	env.Shutdown(t)
 

--- a/java/core/src/main/java/com/grafana/sigil/sdk/SigilClient.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/SigilClient.java
@@ -96,6 +96,10 @@ public final class SigilClient implements AutoCloseable {
     static final String METRIC_TOKEN_TYPE_CACHE_CREATION = "cache_creation";
     static final String METRIC_TOKEN_TYPE_REASONING = "reasoning";
 
+    static final List<Double> DURATION_BUCKETS_SECONDS = List.of(
+            0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28,
+            2.56, 5.12, 10.24, 20.48, 40.96, 81.92);
+
     private static final Pattern STATUS_CODE_PATTERN = Pattern.compile("\\b([1-5][0-9][0-9])\\b");
     private static final String INSTRUMENTATION_NAME = "github.com/grafana/sigil/sdks/java";
     static final String DEFAULT_EMBEDDING_OPERATION_NAME = "embeddings";
@@ -179,12 +183,14 @@ public final class SigilClient implements AutoCloseable {
 
         this.operationDurationHistogram = meter.histogramBuilder(METRIC_OPERATION_DURATION)
                 .setUnit("s")
+                .setExplicitBucketBoundariesAdvice(DURATION_BUCKETS_SECONDS)
                 .build();
         this.tokenUsageHistogram = meter.histogramBuilder(METRIC_TOKEN_USAGE)
                 .setUnit("token")
                 .build();
         this.ttftHistogram = meter.histogramBuilder(METRIC_TTFT)
                 .setUnit("s")
+                .setExplicitBucketBoundariesAdvice(DURATION_BUCKETS_SECONDS)
                 .build();
         this.toolCallsHistogram = meter.histogramBuilder(METRIC_TOOL_CALLS_PER_OPERATION)
                 .setUnit("count")

--- a/java/core/src/test/java/com/grafana/sigil/sdk/SigilClientMetricsTest.java
+++ b/java/core/src/test/java/com/grafana/sigil/sdk/SigilClientMetricsTest.java
@@ -3,10 +3,12 @@ package com.grafana.sigil.sdk;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.HistogramPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -47,7 +49,8 @@ class SigilClientMetricsTest {
             recorder.end();
         }
 
-        List<String> metricNames = metricReader.collectAllMetrics().stream()
+        Collection<MetricData> metrics = metricReader.collectAllMetrics();
+        List<String> metricNames = metrics.stream()
                 .map(MetricData::getName)
                 .toList();
 
@@ -58,8 +61,28 @@ class SigilClientMetricsTest {
                 SigilClient.METRIC_TOOL_CALLS_PER_OPERATION
         );
 
+        List<Double> expectedBuckets = List.of(
+                0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28,
+                2.56, 5.12, 10.24, 20.48, 40.96, 81.92);
+
+        assertThat(durationBucketBoundaries(metrics, SigilClient.METRIC_OPERATION_DURATION))
+                .as("operation duration buckets")
+                .isEqualTo(expectedBuckets);
+        assertThat(durationBucketBoundaries(metrics, SigilClient.METRIC_TTFT))
+                .as("time-to-first-token buckets")
+                .isEqualTo(expectedBuckets);
+
         tracerProvider.shutdown();
         meterProvider.shutdown();
+    }
+
+    private static List<Double> durationBucketBoundaries(Collection<MetricData> metrics, String name) {
+        MetricData metric = metrics.stream()
+                .filter(m -> name.equals(m.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("missing metric " + name));
+        HistogramPointData point = metric.getHistogramData().getPoints().iterator().next();
+        return point.getBoundaries();
     }
 
     @Test

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -142,6 +142,10 @@ const metricTokenTypeCacheRead = 'cache_read';
 const metricTokenTypeCacheWrite = 'cache_write';
 const metricTokenTypeCacheCreation = 'cache_creation';
 const metricTokenTypeReasoning = 'reasoning';
+
+const durationBucketsSeconds: number[] = [
+  0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
+];
 const instrumentationName = 'github.com/grafana/sigil/sdks/js';
 const sdkName = 'sdk-js';
 const defaultEmbeddingOperationName = 'embeddings';
@@ -185,9 +189,15 @@ export class SigilClient {
       this.config.generationExporter ?? createDefaultGenerationExporter(this.config.generationExport);
     this.tracer = this.config.tracer ?? trace.getTracer(instrumentationName);
     this.meter = this.config.meter ?? metrics.getMeter(instrumentationName);
-    this.operationDurationHistogram = this.meter.createHistogram(metricOperationDuration, { unit: 's' });
+    this.operationDurationHistogram = this.meter.createHistogram(metricOperationDuration, {
+      unit: 's',
+      advice: { explicitBucketBoundaries: durationBucketsSeconds },
+    });
     this.tokenUsageHistogram = this.meter.createHistogram(metricTokenUsage, { unit: 'token' });
-    this.ttftHistogram = this.meter.createHistogram(metricTimeToFirstToken, { unit: 's' });
+    this.ttftHistogram = this.meter.createHistogram(metricTimeToFirstToken, {
+      unit: 's',
+      advice: { explicitBucketBoundaries: durationBucketsSeconds },
+    });
     this.toolCallsHistogram = this.meter.createHistogram(metricToolCallsPerOperation, { unit: 'count' });
 
     if (this.config.generationExport.flushIntervalMs > 0) {

--- a/js/test/conformance.test.mjs
+++ b/js/test/conformance.test.mjs
@@ -7,6 +7,7 @@ import * as grpc from '@grpc/grpc-js';
 import * as protoLoader from '@grpc/proto-loader';
 import {
   AggregationTemporality,
+  DataPointType,
   InMemoryMetricExporter,
   MeterProvider,
   PeriodicExportingMetricReader,
@@ -390,6 +391,10 @@ test('conformance streaming telemetry semantics', async () => {
     assert.equal(span.name, 'streamText gpt-5');
     assert.ok(metricNames.includes('gen_ai.client.operation.duration'));
     assert.ok(metricNames.includes('gen_ai.client.time_to_first_token'));
+
+    const expectedBuckets = [0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92];
+    assert.deepEqual(await env.metricBucketBoundaries('gen_ai.client.operation.duration'), expectedBuckets);
+    assert.deepEqual(await env.metricBucketBoundaries('gen_ai.client.time_to_first_token'), expectedBuckets);
   } finally {
     await env.close();
   }
@@ -685,6 +690,17 @@ async function createConformanceEnv(options = {}) {
         .flatMap((resourceMetrics) => resourceMetrics.scopeMetrics)
         .flatMap((scopeMetrics) => scopeMetrics.metrics)
         .map((metric) => metric.descriptor.name);
+    },
+    async metricBucketBoundaries(metricName) {
+      await meterProvider.forceFlush();
+      const metric = metricExporter
+        .getMetrics()
+        .flatMap((resourceMetrics) => resourceMetrics.scopeMetrics)
+        .flatMap((scopeMetrics) => scopeMetrics.metrics)
+        .find((m) => m.descriptor.name === metricName && m.dataPointType === DataPointType.HISTOGRAM);
+      assert.ok(metric, `expected histogram metric ${metricName}`);
+      assert.ok(metric.dataPoints.length > 0, `expected ${metricName} datapoints`);
+      return metric.dataPoints[0].value.buckets.boundaries;
     },
     async close() {
       if (closed) {

--- a/python/sigil_sdk/client.py
+++ b/python/sigil_sdk/client.py
@@ -128,6 +128,23 @@ _metric_token_type_cache_write = "cache_write"
 _metric_token_type_cache_creation = "cache_creation"
 _metric_token_type_reasoning = "reasoning"
 
+_DURATION_BUCKETS_SECONDS: tuple[float, ...] = (
+    0.01,
+    0.02,
+    0.04,
+    0.08,
+    0.16,
+    0.32,
+    0.64,
+    1.28,
+    2.56,
+    5.12,
+    10.24,
+    20.48,
+    40.96,
+    81.92,
+)
+
 _status_code_pattern = re.compile(r"\b([1-5][0-9][0-9])\b")
 _instrumentation_name = "github.com/grafana/sigil/sdks/python"
 _sdk_name = "sdk-python"
@@ -275,10 +292,16 @@ class Client:
         self._meter = self._config.meter if self._config.meter is not None else metrics.get_meter(_instrumentation_name)
 
         self._operation_duration_histogram: Histogram = self._meter.create_histogram(
-            _metric_operation_duration, unit="s"
+            _metric_operation_duration,
+            unit="s",
+            explicit_bucket_boundaries_advisory=_DURATION_BUCKETS_SECONDS,
         )
         self._token_usage_histogram: Histogram = self._meter.create_histogram(_metric_token_usage, unit="token")
-        self._ttft_histogram: Histogram = self._meter.create_histogram(_metric_ttft, unit="s")
+        self._ttft_histogram: Histogram = self._meter.create_histogram(
+            _metric_ttft,
+            unit="s",
+            explicit_bucket_boundaries_advisory=_DURATION_BUCKETS_SECONDS,
+        )
         self._tool_calls_histogram: Histogram = self._meter.create_histogram(
             _metric_tool_calls_per_operation, unit="count"
         )

--- a/python/tests/test_conformance.py
+++ b/python/tests/test_conformance.py
@@ -250,7 +250,11 @@ def test_conformance_sync_roundtrip_semantics() -> None:
                             Part(kind=PartKind.THINKING, thinking="reasoning"),
                             Part(
                                 kind=PartKind.TOOL_CALL,
-                                tool_call=ToolCall(id="call-1", name="weather", input_json=b'{"city":"Paris"}'),
+                                tool_call=ToolCall(
+                                    id="call-1",
+                                    name="weather",
+                                    input_json=b'{"city":"Paris"}',
+                                ),
                             ),
                         ],
                     ),
@@ -346,7 +350,7 @@ def test_conformance_conversation_title_semantics() -> None:
                 start = GenerationStart(
                     model=ModelRef(provider="openai", name="gpt-5"),
                     conversation_title=start_title,
-                    metadata={_metadata_conversation_title: metadata_title} if metadata_title else {},
+                    metadata=({_metadata_conversation_title: metadata_title} if metadata_title else {}),
                 )
                 recorder = env.client.start_generation(start)
                 recorder.set_result(Generation())
@@ -377,7 +381,14 @@ def test_conformance_user_id_semantics() -> None:
         ("whitespace trimmed", "  padded  ", "", "", "", "padded"),
     ]
 
-    for _, start_user_id, context_user_id, canonical_user_id, legacy_user_id, want_user_id in cases:
+    for (
+        _,
+        start_user_id,
+        context_user_id,
+        canonical_user_id,
+        legacy_user_id,
+        want_user_id,
+    ) in cases:
         env = _ConformanceEnv()
         try:
             metadata = {}
@@ -409,8 +420,28 @@ def test_conformance_user_id_semantics() -> None:
 
 def test_conformance_agent_identity_semantics() -> None:
     cases = [
-        ("explicit fields", "agent-explicit", "v1.2.3", "", "", "", "", "agent-explicit", "v1.2.3"),
-        ("context fallback", "", "", "agent-context", "v-context", "", "", "agent-context", "v-context"),
+        (
+            "explicit fields",
+            "agent-explicit",
+            "v1.2.3",
+            "",
+            "",
+            "",
+            "",
+            "agent-explicit",
+            "v1.2.3",
+        ),
+        (
+            "context fallback",
+            "",
+            "",
+            "agent-context",
+            "v-context",
+            "",
+            "",
+            "agent-context",
+            "v-context",
+        ),
         (
             "result-time override",
             "agent-seed",
@@ -504,6 +535,32 @@ def test_conformance_streaming_telemetry_semantics() -> None:
         assert span.name == "streamText gpt-5"
         assert "gen_ai.client.operation.duration" in metrics
         assert "gen_ai.client.time_to_first_token" in metrics
+
+        expected_buckets = (
+            0.01,
+            0.02,
+            0.04,
+            0.08,
+            0.16,
+            0.32,
+            0.64,
+            1.28,
+            2.56,
+            5.12,
+            10.24,
+            20.48,
+            40.96,
+            81.92,
+        )
+        for metric_name in (
+            "gen_ai.client.operation.duration",
+            "gen_ai.client.time_to_first_token",
+        ):
+            data_points = list(metrics[metric_name].data_points)
+            assert data_points, f"expected {metric_name} data points"
+            assert tuple(data_points[0].explicit_bounds) == expected_buckets, (
+                f"{metric_name} bucket boundaries mismatch: {tuple(data_points[0].explicit_bounds)}"
+            )
     finally:
         env.shutdown()
 
@@ -604,7 +661,12 @@ def test_conformance_validation_and_error_semantics() -> None:
                 input=[
                     Message(
                         role=MessageRole.USER,
-                        parts=[Part(kind=PartKind.TOOL_CALL, tool_call=ToolCall(name="weather"))],
+                        parts=[
+                            Part(
+                                kind=PartKind.TOOL_CALL,
+                                tool_call=ToolCall(name="weather"),
+                            )
+                        ],
                     )
                 ]
             )


### PR DESCRIPTION
Apply the OTel GenAI semantic-convention bucket [advice](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiclientoperationduration) (10ms..81.92s) on `gen_ai.client.operation.duration` and `gen_ai.client.time_to_first_token` histograms in Java, Go, Python, .NET, and JS so percentile aggregations are accurate out of the box. View-based overrides remain available for users.

Fixes https://github.com/grafana/sigil-sdk/issues/79

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default bucket boundaries for key latency histograms across all SDKs, which can affect metric cardinality/storage and downstream dashboards/alerts, though it does not change core generation/export behavior.
> 
> **Overview**
> Aligns `gen_ai.client.operation.duration` and `gen_ai.client.time_to_first_token` histograms in **.NET, Go, Java, JS, and Python** to use the OTel GenAI semantic-convention explicit bucket boundaries (10ms–81.92s) instead of relying on default OTLP buckets.
> 
> Adds/updates conformance and metrics tests (including a new .NET `HistogramBucketAdviceTests`) to assert the exported histogram bucket boundaries for these two metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e6d45e088f62f2bf861bcaa30a3ad0b619c6dff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->