### PR TITLE
feat(plugins): publish pi and opencode to npm under @grafana scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,10 @@ jobs:
         run: mise run lint:ts:plugin-pi
 
       - name: Typecheck pi plugin
-        run: pnpm --filter pi-sigil run typecheck
+        run: pnpm --filter @grafana/sigil-pi run typecheck
 
       - name: Test pi plugin
-        run: pnpm --filter pi-sigil run test
+        run: pnpm --filter @grafana/sigil-pi run test
 
   python-lint:
     name: Python Lint

--- a/.github/workflows/plugins-publish.yml
+++ b/.github/workflows/plugins-publish.yml
@@ -1,0 +1,168 @@
+name: Publish plugins to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      plugin:
+        description: 'Which plugin to publish'
+        required: true
+        type: choice
+        options:
+          - pi
+          - opencode
+          - all
+      version:
+        description: 'Semver bump (applied to each selected plugin from its own current version)'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    if: github.repository == 'grafana/sigil-sdk' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      plugins: ${{ steps.plan.outputs.plugins }}
+
+    steps:
+      - name: Get secrets from Vault
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
+        env:
+          VAULT_INSTANCE: ops
+        with:
+          vault_instance: ${{ env.VAULT_INSTANCE }}
+          common_secrets: |
+            GITHUB_APP_ID=plugins-platform-bot-app:app-id
+            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
+          export_env: false
+
+      - name: Generate GitHub token
+        id: generate-github-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
+          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.generate-github-token.outputs.token }}
+          persist-credentials: true
+
+      - name: Setup Git
+        run: |
+          git config user.name 'grafana-plugins-platform-bot[bot]'
+          git config user.email '144369747+grafana-plugins-platform-bot[bot]@users.noreply.github.com'
+
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: js/package.json
+          cache: pnpm
+
+      - run: pnpm install
+
+      - name: Resolve plugin list
+        id: plan
+        shell: bash
+        run: |
+          case "${{ inputs.plugin }}" in
+            pi)       PLUGINS_JSON='["pi"]' ;;
+            opencode) PLUGINS_JSON='["opencode"]' ;;
+            all)      PLUGINS_JSON='["pi","opencode"]' ;;
+          esac
+          echo "plugins=${PLUGINS_JSON}" >> "$GITHUB_OUTPUT"
+
+      - name: Bump, build, and pack each plugin
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+        run: |
+          # Use the GitHub App token for pushes
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+
+          mkdir -p tarballs
+          PLUGINS=$(echo '${{ steps.plan.outputs.plugins }}' | jq -r '.[]')
+          for p in ${PLUGINS}; do
+            echo "::group::Preparing plugins/${p}"
+            (cd "plugins/${p}" && npm version "${{ inputs.version }}" --no-git-tag-version)
+            NEW=$(node -p "require('./plugins/${p}/package.json').version")
+            NAME=$(node -p "require('./plugins/${p}/package.json').name")
+            echo "Plugin ${p}: ${NAME}@${NEW}"
+
+            pnpm --filter "${NAME}" run build
+            (cd "plugins/${p}" && pnpm pack --pack-destination "../../tarballs")
+
+            # pnpm pack output is e.g. grafana-sigil-pi-0.1.1.tgz; rename to <plugin>.tgz
+            # so the matrix step doesn't need to know the version.
+            TARBALL=$(ls tarballs/ | grep -E "${p}-[0-9]+\.[0-9]+\.[0-9]+\.tgz$" | head -1)
+            mv "tarballs/${TARBALL}" "tarballs/${p}.tgz"
+
+            git add "plugins/${p}/package.json"
+            git commit -m "chore(plugins/${p}): bump version to ${NEW}"
+
+            # Force-replace tag if it already exists (re-run safety)
+            git push origin ":refs/tags/plugins/${p}/v${NEW}" 2>/dev/null || true
+            git tag -f -a "plugins/${p}/v${NEW}" -m "Plugin ${p} ${NEW}"
+            echo "::endgroup::"
+          done
+          git push origin HEAD --tags
+
+      - name: Upload plugin tarballs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: plugin-tarballs
+          path: tarballs/
+          retention-days: 5
+
+  publish:
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        plugin: ${{ fromJSON(needs.prepare.outputs.plugins) }}
+
+    steps:
+      - name: Get NPM token from Vault
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
+        env:
+          VAULT_INSTANCE: ops
+        with:
+          vault_instance: ${{ env.VAULT_INSTANCE }}
+          common_secrets: |
+            NPM_TOKEN=sigil-npm:token
+          export_env: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          registry-url: https://registry.npmjs.org
+
+      - name: Download plugin tarballs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: plugin-tarballs
+          path: tarballs/
+
+      - name: Publish ${{ matrix.plugin }} to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).NPM_TOKEN }}
+        run: npm publish "tarballs/${{ matrix.plugin }}.tgz" --access public

--- a/mise.toml
+++ b/mise.toml
@@ -40,7 +40,7 @@ run = "pnpm --filter @grafana/sigil-sdk-js run lint:fix"
 [tasks."format:ts:plugin-pi"]
 description = "Format Pi plugin code"
 depends = ["deps"]
-run = "pnpm --filter pi-sigil run lint:fix"
+run = "pnpm --filter @grafana/sigil-pi run lint:fix"
 
 [tasks.format]
 description = "Format all code"
@@ -84,7 +84,7 @@ run = "pnpm --filter @grafana/sigil-sdk-js run lint"
 [tasks."lint:ts:plugin-pi"]
 description = "Lint Pi plugin code"
 depends = ["deps"]
-run = "pnpm --filter pi-sigil run lint"
+run = "pnpm --filter @grafana/sigil-pi run lint"
 
 [tasks.lint]
 description = "Run all linting"
@@ -100,7 +100,7 @@ run = "pnpm --filter @grafana/sigil-sdk-js run typecheck"
 [tasks."typecheck:ts:plugin-pi"]
 description = "Type-check Pi plugin code"
 depends = ["deps"]
-run = "pnpm --filter pi-sigil run typecheck"
+run = "pnpm --filter @grafana/sigil-pi run typecheck"
 
 [tasks.typecheck]
 description = "Run all type checks"
@@ -111,7 +111,7 @@ depends = ["typecheck:ts:sdk-js", "typecheck:ts:plugin-pi"]
 [tasks."build:ts:plugin-pi"]
 description = "Build Pi plugin bundle"
 depends = ["deps"]
-run = "pnpm --filter pi-sigil run build"
+run = "pnpm --filter @grafana/sigil-pi run build"
 
 # --- Go SDK tests ---
 
@@ -148,7 +148,7 @@ run = "GOWORK=off go test ./..."
 [tasks."test:ts:plugin-pi"]
 description = "Run Pi plugin tests"
 depends = ["deps"]
-run = "pnpm --filter pi-sigil run test"
+run = "pnpm --filter @grafana/sigil-pi run test"
 
 [tasks."test:go:sdk-conformance"]
 description = "Run the Go SDK core conformance harness"

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -1,4 +1,4 @@
-# opencode-sigil
+# @grafana/sigil-opencode
 
 OpenCode plugin that records LLM generations to Grafana Sigil for AI observability.
 
@@ -34,8 +34,8 @@ Hooks into OpenCode's chat lifecycle to capture assistant messages and send them
 ```bash
 # From the repo root
 pnpm install
-pnpm --filter opencode-sigil build
-pnpm --filter opencode-sigil test
+pnpm --filter @grafana/sigil-opencode build
+pnpm --filter @grafana/sigil-opencode test
 ```
 
 The `@grafana/sigil-sdk-js` dependency resolves via pnpm workspace linking to `sdks/js`.

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "opencode-sigil",
+  "name": "@grafana/sigil-opencode",
   "version": "0.1.0",
   "description": "OpenCode plugin for Grafana Sigil AI telemetry",
   "type": "module",
@@ -12,6 +12,9 @@
     }
   },
   "files": ["dist", "skills"],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "bash scripts/build.sh",
     "typecheck": "tsc --noEmit",

--- a/plugins/opencode/scripts/build.sh
+++ b/plugins/opencode/scripts/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SDK_DIR="$(cd "${SCRIPT_DIR}/../../../sdks/js" && pwd)"
+SDK_DIR="$(cd "${SCRIPT_DIR}/../../../js" && pwd)"
 
 # Build the SDK so workspace-linked types are available
 if [ ! -f "${SDK_DIR}/dist/index.d.ts" ]; then
@@ -21,4 +21,4 @@ npx esbuild src/index.ts \
   --external:@opencode-ai/plugin \
   --external:@opencode-ai/sdk
 
-tsc --emitDeclarationOnly --declaration --declarationMap --outDir dist
+tsc --project tsconfig.build.json --emitDeclarationOnly --declaration --declarationMap --outDir dist

--- a/plugins/opencode/tsconfig.build.json
+++ b/plugins/opencode/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -1,4 +1,4 @@
-# pi-sigil
+# @grafana/sigil-pi
 
 [Pi](https://github.com/badlogic/pi) agent extension that records LLM generations to Grafana AI observability.
 
@@ -7,7 +7,19 @@ By default only metadata is sent (token counts, cost, model, tool names, duratio
 ## Install
 
 ```bash
-pnpm --filter pi-sigil run build
+pi install npm:@grafana/sigil-pi
+```
+
+Pin a specific version:
+
+```bash
+pi install npm:@grafana/sigil-pi@0.1.1
+```
+
+### From source (contributors)
+
+```bash
+pnpm --filter @grafana/sigil-pi run build
 pi install /absolute/path/to/sigil-sdk/plugins/pi
 ```
 

--- a/plugins/pi/package.json
+++ b/plugins/pi/package.json
@@ -1,10 +1,15 @@
 {
-  "name": "pi-sigil",
+  "name": "@grafana/sigil-pi",
   "version": "0.1.0",
   "description": "Pi agent extension for Grafana Sigil AI telemetry",
-  "private": true,
   "type": "module",
   "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "pi-package"
   ],


### PR DESCRIPTION
Rename `pi-sigil` to `@grafana/sigil-pi` and `opencode-sigil` to `@grafana/sigil-opencode` so both plugins can be published to npmjs, and add a `plugins-publish.yml` workflow that bumps, builds, packs, and publishes either or both plugins from a single dispatch (independent versions, per-plugin commits and tags).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces automated version bumping/tagging and npm publishing from CI with GitHub App/Vault credentials; misconfiguration could publish unintended versions or overwrite tags.
> 
> **Overview**
> Updates the Pi and OpenCode plugins to be publishable npm packages under the `@grafana` scope (renaming to `@grafana/sigil-pi` and `@grafana/sigil-opencode`, adding `publishConfig.access=public`, and updating docs/build scripts accordingly).
> 
> Adds a new manually-triggered GitHub Actions workflow `plugins-publish.yml` that can bump each selected plugin’s version, build/pack it, commit and tag the bump (`plugins/<name>/vX.Y.Z`), and then publish the produced tarballs to npm using Vault-provided credentials. CI/mise tasks are adjusted to reference the new scoped Pi package name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77365631235920daa6df323325a016bfe7410f0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->