### PR TITLE
fix: Gemini langchain SDK tool calling properly recorded

### DIFF
--- a/python-frameworks/langchain/tests/test_langchain_handler.py
+++ b/python-frameworks/langchain/tests/test_langchain_handler.py
@@ -168,6 +168,140 @@ def test_langchain_sync_lifecycle_extracts_anthropic_style_usage_and_stop_reason
         client.shutdown()
 
 
+def test_langchain_gemini_tool_calls_map_from_message_fields() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        run_id = uuid4()
+        handler = SigilLangChainHandler(
+            client=client,
+            agent_name="agent-langchain",
+            provider_resolver="auto",
+        )
+
+        handler.on_chat_model_start(
+            {"name": "ChatGoogleGenerativeAI"},
+            [
+                [
+                    {"type": "human", "content": "Use the weather tool."},
+                    {
+                        "type": "ai",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "name": "get_weather",
+                                "args": {"city": "Paris"},
+                                "id": "call-weather",
+                                "type": "tool_call",
+                            }
+                        ],
+                    },
+                    {
+                        "type": "tool",
+                        "content": "Paris: 72F and sunny",
+                        "tool_call_id": "call-weather",
+                        "name": "get_weather",
+                    },
+                ]
+            ],
+            run_id=run_id,
+            invocation_params={
+                "model": "gemini-2.5-flash",
+                "tool_choice": "get_weather",
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "description": "Get current weather for a city.",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                                "required": ["city"],
+                            },
+                        },
+                    }
+                ],
+            },
+        )
+        handler.on_llm_end(
+            {
+                "generations": [
+                    [
+                        {
+                            "message": {
+                                "type": "ai",
+                                "content": "",
+                                "tool_calls": [
+                                    {
+                                        "name": "get_weather",
+                                        "args": {"city": "Paris"},
+                                        "id": "call-weather",
+                                        "type": "tool_call",
+                                    }
+                                ],
+                                "usage_metadata": {
+                                    "input_tokens": 49,
+                                    "output_tokens": 51,
+                                    "total_tokens": 100,
+                                    "input_token_details": {"cache_read": 7},
+                                    "output_token_details": {"reasoning": 36},
+                                },
+                                "response_metadata": {
+                                    "finish_reason": "STOP",
+                                    "model_name": "gemini-2.5-flash",
+                                    "model_provider": "google_genai",
+                                },
+                            }
+                        }
+                    ]
+                ],
+                "llm_output": {},
+            },
+            run_id=run_id,
+        )
+
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        assert generation.model.provider == "gemini"
+        assert generation.model.name == "gemini-2.5-flash"
+        assert generation.response_model == "gemini-2.5-flash"
+        assert generation.stop_reason == "STOP"
+        assert generation.tool_choice == "get_weather"
+        assert [(tool.name, tool.type) for tool in generation.tools] == [("get_weather", "function")]
+        assert b'"city"' in generation.tools[0].input_schema_json
+
+        assert generation.input[1].role.value == "assistant"
+        input_tool_call = generation.input[1].parts[0].tool_call
+        assert input_tool_call is not None
+        assert input_tool_call.id == "call-weather"
+        assert input_tool_call.name == "get_weather"
+        assert b'"Paris"' in input_tool_call.input_json
+
+        assert generation.input[2].role.value == "tool"
+        input_tool_result = generation.input[2].parts[0].tool_result
+        assert input_tool_result is not None
+        assert input_tool_result.tool_call_id == "call-weather"
+        assert input_tool_result.name == "get_weather"
+        assert input_tool_result.content == "Paris: 72F and sunny"
+
+        assert generation.output[0].role.value == "assistant"
+        output_tool_call = generation.output[0].parts[0].tool_call
+        assert output_tool_call is not None
+        assert output_tool_call.id == "call-weather"
+        assert output_tool_call.name == "get_weather"
+        assert b'"Paris"' in output_tool_call.input_json
+
+        assert generation.usage.input_tokens == 49
+        assert generation.usage.output_tokens == 51
+        assert generation.usage.total_tokens == 100
+        assert generation.usage.cache_read_input_tokens == 7
+        assert generation.usage.reasoning_tokens == 36
+    finally:
+        client.shutdown()
+
+
 def test_langchain_stream_lifecycle_uses_stream_mode_and_chunk_fallback() -> None:
     exporter = _CapturingExporter()
     client = _new_client(exporter)

--- a/python-frameworks/langchain/tests/test_langchain_handler.py
+++ b/python-frameworks/langchain/tests/test_langchain_handler.py
@@ -182,29 +182,7 @@ def test_langchain_gemini_tool_calls_map_from_message_fields() -> None:
 
         handler.on_chat_model_start(
             {"name": "ChatGoogleGenerativeAI"},
-            [
-                [
-                    {"type": "human", "content": "Use the weather tool."},
-                    {
-                        "type": "ai",
-                        "content": "",
-                        "tool_calls": [
-                            {
-                                "name": "get_weather",
-                                "args": {"city": "Paris"},
-                                "id": "call-weather",
-                                "type": "tool_call",
-                            }
-                        ],
-                    },
-                    {
-                        "type": "tool",
-                        "content": "Paris: 72F and sunny",
-                        "tool_call_id": "call-weather",
-                        "name": "get_weather",
-                    },
-                ]
-            ],
+            [[{"type": "human", "content": "Use the weather tool."}]],
             run_id=run_id,
             invocation_params={
                 "model": "gemini-2.5-flash",
@@ -271,20 +249,6 @@ def test_langchain_gemini_tool_calls_map_from_message_fields() -> None:
         assert generation.tool_choice == "get_weather"
         assert [(tool.name, tool.type) for tool in generation.tools] == [("get_weather", "function")]
         assert b'"city"' in generation.tools[0].input_schema_json
-
-        assert generation.input[1].role.value == "assistant"
-        input_tool_call = generation.input[1].parts[0].tool_call
-        assert input_tool_call is not None
-        assert input_tool_call.id == "call-weather"
-        assert input_tool_call.name == "get_weather"
-        assert b'"Paris"' in input_tool_call.input_json
-
-        assert generation.input[2].role.value == "tool"
-        input_tool_result = generation.input[2].parts[0].tool_result
-        assert input_tool_result is not None
-        assert input_tool_result.tool_call_id == "call-weather"
-        assert input_tool_result.name == "get_weather"
-        assert input_tool_result.content == "Paris: 72F and sunny"
 
         assert generation.output[0].role.value == "assistant"
         output_tool_call = generation.output[0].parts[0].tool_call

--- a/python/sigil_sdk/framework_handler.py
+++ b/python/sigil_sdk/framework_handler.py
@@ -26,7 +26,6 @@ from sigil_sdk import (
     ToolCall,
     ToolDefinition,
     ToolExecutionStart,
-    ToolResult,
     user_text_message,
 )
 from sigil_sdk.usage import map_usage
@@ -1009,10 +1008,15 @@ def _map_chat_inputs(messages: list[list[Any]]) -> list[Message]:
     output: list[Message] = []
     for batch in messages:
         for message in batch:
-            mapped = _map_framework_message(message)
-            if mapped is None:
+            text = _extract_message_text(message)
+            if text == "":
                 continue
-            output.append(mapped)
+            output.append(
+                Message(
+                    role=_normalize_role(_extract_message_role(message)),
+                    parts=[Part(kind=PartKind.TEXT, text=text)],
+                )
+            )
     return output
 
 
@@ -1047,118 +1051,23 @@ def _map_output_messages(response: Any) -> list[Message]:
     return output
 
 
-def _extract_generation_text(candidate: Any) -> str:
-    text = _as_str(_read(candidate, "text"))
-    if text != "":
-        return text
-
-    message = _read(candidate, "message")
-    text = _extract_message_text(message)
-    if text != "":
-        return text
-
-    return ""
-
-
 def _map_generation_candidate_message(candidate: Any) -> Message | None:
     message = _read(candidate, "message")
-    mapped = _map_framework_message(message)
-    if mapped is not None:
-        return mapped
-
-    return None
-
-
-def _map_framework_message(message: Any) -> Message | None:
-    role = _normalize_role(_extract_message_role(message))
-    content = _read(message, "content")
     parts: list[Part] = []
-    contains_tool_result = False
 
-    if isinstance(content, str):
-        text = content.strip()
-        if text != "":
-            parts.append(Part(kind=PartKind.TEXT, text=text))
-    elif isinstance(content, list):
-        for item in content:
-            if isinstance(item, str):
-                trimmed = item.strip()
-                if trimmed != "":
-                    parts.append(Part(kind=PartKind.TEXT, text=trimmed))
-                continue
-
-            text = _as_str(_read(item, "text"))
-            if text != "":
-                parts.append(Part(kind=PartKind.TEXT, text=text))
-                continue
-
-            tool_use_part = _map_tool_use_part(_read(item, "toolUse"))
-            if tool_use_part is not None:
-                parts.append(tool_use_part)
-                continue
-
-            tool_result_part = _map_tool_result_part(_read(item, "toolResult"))
-            if tool_result_part is not None:
-                contains_tool_result = True
-                parts.append(tool_result_part)
-    elif isinstance(content, dict):
-        text = _as_str(_read(content, "text"))
-        if text != "":
-            parts.append(Part(kind=PartKind.TEXT, text=text))
+    text = _extract_message_text(message)
+    if text != "":
+        parts.append(Part(kind=PartKind.TEXT, text=text))
 
     for tool_call in _as_list(_read(message, "tool_calls")):
         tool_call_part = _map_langchain_tool_call_part(tool_call)
         if tool_call_part is not None:
             parts.append(tool_call_part)
 
-    if role == MessageRole.TOOL:
-        tool_result_part = _map_langchain_tool_message_part(message)
-        if tool_result_part is not None:
-            contains_tool_result = True
-            parts.append(tool_result_part)
-
     if not parts:
         return None
 
-    if contains_tool_result:
-        role = MessageRole.TOOL
-        parts = [part for part in parts if part.kind == PartKind.TOOL_RESULT]
-
-    return Message(role=role, parts=parts)
-
-
-def _map_tool_use_part(tool_use: Any) -> Part | None:
-    if tool_use is None:
-        return None
-    name = _as_str(_read(tool_use, "name"))
-    if name == "":
-        return None
-    return Part(
-        kind=PartKind.TOOL_CALL,
-        tool_call=ToolCall(
-            id=_as_str(_read(tool_use, "toolUseId")),
-            name=name,
-            input_json=_json_bytes(_read(tool_use, "input")),
-        ),
-    )
-
-
-def _map_tool_result_part(tool_result: Any) -> Part | None:
-    if tool_result is None:
-        return None
-    tool_call_id = _as_str(_read(tool_result, "toolUseId"))
-    content = _tool_result_text(_read(tool_result, "content"))
-    content_json = _json_bytes(_read(tool_result, "content"))
-    is_error = _as_str(_read(tool_result, "status")).lower() == "error"
-    return Part(
-        kind=PartKind.TOOL_RESULT,
-        tool_result=ToolResult(
-            tool_call_id=tool_call_id,
-            content=content,
-            content_json=content_json,
-            is_error=is_error,
-        ),
-    )
+    return Message(role=_normalize_role(_extract_message_role(message)), parts=parts)
 
 
 def _map_langchain_tool_call_part(tool_call: Any) -> Part | None:
@@ -1178,42 +1087,6 @@ def _map_langchain_tool_call_part(tool_call: Any) -> Part | None:
             input_json=_json_bytes(args),
         ),
     )
-
-
-def _map_langchain_tool_message_part(message: Any) -> Part | None:
-    tool_call_id = _as_str(_read(message, "tool_call_id"))
-    name = _as_str(_read(message, "name"))
-    content = _read(message, "content")
-    content_text = _tool_result_text(content)
-    if content_text == "" and isinstance(content, str):
-        content_text = content.strip()
-
-    if tool_call_id == "" and name == "" and content_text == "":
-        return None
-
-    return Part(
-        kind=PartKind.TOOL_RESULT,
-        tool_result=ToolResult(
-            tool_call_id=tool_call_id,
-            name=name,
-            content=content_text,
-            content_json=_json_bytes(content),
-            is_error=_as_str(_read(message, "status")).lower() == "error",
-        ),
-    )
-
-
-def _tool_result_text(content: Any) -> str:
-    if isinstance(content, str):
-        return content.strip()
-    if not isinstance(content, list):
-        return ""
-    parts: list[str] = []
-    for item in content:
-        text = _as_str(_read(item, "text"))
-        if text != "":
-            parts.append(text)
-    return " ".join(parts).strip()
 
 
 def _extract_message_text(message: Any) -> str:

--- a/python/sigil_sdk/framework_handler.py
+++ b/python/sigil_sdk/framework_handler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import math
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -22,8 +23,10 @@ from sigil_sdk import (
     ModelRef,
     Part,
     PartKind,
+    ToolCall,
     ToolDefinition,
     ToolExecutionStart,
+    ToolResult,
     user_text_message,
 )
 from sigil_sdk.usage import map_usage
@@ -342,10 +345,21 @@ class SigilFrameworkHandlerBase:
 
         try:
             llm_output = _read(response, "llm_output")
-            raw_usage = _read(llm_output, "token_usage") or _read(llm_output, "usage")
-            usage = map_usage(raw_usage)
-            response_model = _as_str(_read(llm_output, "model_name"))
-            stop_reason = _as_str(_read(llm_output, "finish_reason") or _read(llm_output, "stop_reason"))
+            response_message = _first_generation_message(response)
+            response_metadata = _read(response_message, "response_metadata")
+            raw_usage = (
+                _read(llm_output, "token_usage")
+                or _read(llm_output, "usage")
+                or _read(response_message, "usage_metadata")
+            )
+            usage = _map_framework_usage(raw_usage)
+            response_model = _as_str(_read(llm_output, "model_name")) or _as_str(_read(response_metadata, "model_name"))
+            stop_reason = _as_str(
+                _read(llm_output, "finish_reason")
+                or _read(llm_output, "stop_reason")
+                or _read(response_metadata, "finish_reason")
+                or _read(response_metadata, "stop_reason")
+            )
 
             output_messages: list[Message] = []
             if run_state.capture_outputs:
@@ -995,40 +1009,42 @@ def _map_chat_inputs(messages: list[list[Any]]) -> list[Message]:
     output: list[Message] = []
     for batch in messages:
         for message in batch:
-            text = _extract_message_text(message)
-            if text == "":
+            mapped = _map_framework_message(message)
+            if mapped is None:
                 continue
-            output.append(
-                Message(
-                    role=_normalize_role(_extract_message_role(message)),
-                    parts=[Part(kind=PartKind.TEXT, text=text)],
-                )
-            )
+            output.append(mapped)
     return output
 
 
 def _map_output_messages(response: Any) -> list[Message]:
-    texts: list[str] = []
+    output: list[Message] = []
+    text_chunks: list[str] = []
     for candidates in _as_list(_read(response, "generations")):
         for candidate in _as_list(candidates):
-            text = _extract_generation_text(candidate)
+            mapped = _map_generation_candidate_message(candidate)
+            text = _as_str(_read(candidate, "text"))
             if text != "":
-                texts.append(text)
+                if mapped is None:
+                    text_chunks.append(text)
+                else:
+                    output.append(mapped)
+                continue
 
-    if not texts:
+            if mapped is not None:
+                output.append(mapped)
+
+    if text_chunks:
+        output.insert(
+            0,
+            Message(role=MessageRole.ASSISTANT, parts=[Part(kind=PartKind.TEXT, text="\n".join(text_chunks))]),
+        )
+
+    if not output:
         fallback_text = _as_str(_read(response, "text"))
         if fallback_text != "":
-            texts.append(fallback_text)
+            output.append(Message(role=MessageRole.ASSISTANT, parts=[Part(kind=PartKind.TEXT, text=fallback_text)]))
 
-    if not texts:
-        return []
-
-    return [
-        Message(
-            role=MessageRole.ASSISTANT,
-            parts=[Part(kind=PartKind.TEXT, text="\n".join(texts))],
-        )
-    ]
+    return output
 
 
 def _extract_generation_text(candidate: Any) -> str:
@@ -1042,6 +1058,162 @@ def _extract_generation_text(candidate: Any) -> str:
         return text
 
     return ""
+
+
+def _map_generation_candidate_message(candidate: Any) -> Message | None:
+    message = _read(candidate, "message")
+    mapped = _map_framework_message(message)
+    if mapped is not None:
+        return mapped
+
+    return None
+
+
+def _map_framework_message(message: Any) -> Message | None:
+    role = _normalize_role(_extract_message_role(message))
+    content = _read(message, "content")
+    parts: list[Part] = []
+    contains_tool_result = False
+
+    if isinstance(content, str):
+        text = content.strip()
+        if text != "":
+            parts.append(Part(kind=PartKind.TEXT, text=text))
+    elif isinstance(content, list):
+        for item in content:
+            if isinstance(item, str):
+                trimmed = item.strip()
+                if trimmed != "":
+                    parts.append(Part(kind=PartKind.TEXT, text=trimmed))
+                continue
+
+            text = _as_str(_read(item, "text"))
+            if text != "":
+                parts.append(Part(kind=PartKind.TEXT, text=text))
+                continue
+
+            tool_use_part = _map_tool_use_part(_read(item, "toolUse"))
+            if tool_use_part is not None:
+                parts.append(tool_use_part)
+                continue
+
+            tool_result_part = _map_tool_result_part(_read(item, "toolResult"))
+            if tool_result_part is not None:
+                contains_tool_result = True
+                parts.append(tool_result_part)
+    elif isinstance(content, dict):
+        text = _as_str(_read(content, "text"))
+        if text != "":
+            parts.append(Part(kind=PartKind.TEXT, text=text))
+
+    for tool_call in _as_list(_read(message, "tool_calls")):
+        tool_call_part = _map_langchain_tool_call_part(tool_call)
+        if tool_call_part is not None:
+            parts.append(tool_call_part)
+
+    if role == MessageRole.TOOL:
+        tool_result_part = _map_langchain_tool_message_part(message)
+        if tool_result_part is not None:
+            contains_tool_result = True
+            parts.append(tool_result_part)
+
+    if not parts:
+        return None
+
+    if contains_tool_result:
+        role = MessageRole.TOOL
+        parts = [part for part in parts if part.kind == PartKind.TOOL_RESULT]
+
+    return Message(role=role, parts=parts)
+
+
+def _map_tool_use_part(tool_use: Any) -> Part | None:
+    if tool_use is None:
+        return None
+    name = _as_str(_read(tool_use, "name"))
+    if name == "":
+        return None
+    return Part(
+        kind=PartKind.TOOL_CALL,
+        tool_call=ToolCall(
+            id=_as_str(_read(tool_use, "toolUseId")),
+            name=name,
+            input_json=_json_bytes(_read(tool_use, "input")),
+        ),
+    )
+
+
+def _map_tool_result_part(tool_result: Any) -> Part | None:
+    if tool_result is None:
+        return None
+    tool_call_id = _as_str(_read(tool_result, "toolUseId"))
+    content = _tool_result_text(_read(tool_result, "content"))
+    content_json = _json_bytes(_read(tool_result, "content"))
+    is_error = _as_str(_read(tool_result, "status")).lower() == "error"
+    return Part(
+        kind=PartKind.TOOL_RESULT,
+        tool_result=ToolResult(
+            tool_call_id=tool_call_id,
+            content=content,
+            content_json=content_json,
+            is_error=is_error,
+        ),
+    )
+
+
+def _map_langchain_tool_call_part(tool_call: Any) -> Part | None:
+    name = _as_str(_read(tool_call, "name"))
+    if name == "":
+        return None
+
+    args = _read(tool_call, "args")
+    if args is None:
+        args = _read(tool_call, "arguments")
+
+    return Part(
+        kind=PartKind.TOOL_CALL,
+        tool_call=ToolCall(
+            id=_as_str(_read(tool_call, "id")),
+            name=name,
+            input_json=_json_bytes(args),
+        ),
+    )
+
+
+def _map_langchain_tool_message_part(message: Any) -> Part | None:
+    tool_call_id = _as_str(_read(message, "tool_call_id"))
+    name = _as_str(_read(message, "name"))
+    content = _read(message, "content")
+    content_text = _tool_result_text(content)
+    if content_text == "" and isinstance(content, str):
+        content_text = content.strip()
+
+    if tool_call_id == "" and name == "" and content_text == "":
+        return None
+
+    return Part(
+        kind=PartKind.TOOL_RESULT,
+        tool_result=ToolResult(
+            tool_call_id=tool_call_id,
+            name=name,
+            content=content_text,
+            content_json=_json_bytes(content),
+            is_error=_as_str(_read(message, "status")).lower() == "error",
+        ),
+    )
+
+
+def _tool_result_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content.strip()
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for item in content:
+        text = _as_str(_read(item, "text"))
+        if text != "":
+            parts.append(text)
+    return " ".join(parts).strip()
 
 
 def _extract_message_text(message: Any) -> str:
@@ -1082,6 +1254,31 @@ def _extract_message_role(message: Any) -> str:
     return "user"
 
 
+def _first_generation_message(response: Any) -> Any:
+    for candidates in _as_list(_read(response, "generations")):
+        for candidate in _as_list(candidates):
+            message = _read(candidate, "message")
+            if message is not None:
+                return message
+    return None
+
+
+def _map_framework_usage(raw_usage: Any):
+    usage = map_usage(raw_usage)
+    input_token_details = _read(raw_usage, "input_token_details")
+    output_token_details = _read(raw_usage, "output_token_details")
+
+    cache_read = _as_int(_read(input_token_details, "cache_read"))
+    if cache_read > 0 and usage.cache_read_input_tokens == 0:
+        usage.cache_read_input_tokens = cache_read
+
+    reasoning = _as_int(_read(output_token_details, "reasoning"))
+    if reasoning > 0 and usage.reasoning_tokens == 0:
+        usage.reasoning_tokens = reasoning
+
+    return usage
+
+
 def _normalize_role(role: str) -> MessageRole:
     normalized = role.strip().lower()
     if normalized in {"assistant", "ai"}:
@@ -1109,6 +1306,15 @@ def _as_str(value: Any) -> str:
     if isinstance(value, str):
         return value.strip()
     return ""
+
+
+def _json_bytes(value: Any) -> bytes:
+    if value is None:
+        return b""
+    try:
+        return json.dumps(value, default=str, sort_keys=True).encode("utf-8")
+    except Exception:
+        return b""
 
 
 def _id_path(value: Any) -> str:
@@ -1187,6 +1393,26 @@ def _resolve_tool_definitions(invocation_params: dict[str, Any] | None) -> list[
     for item in raw:
         if isinstance(item, ToolDefinition):
             result.append(item)
+            continue
+
+        tool_type = _as_str(_read(item, "type"))
+        function = _read(item, "function") if tool_type == "function" else item
+        name = _as_str(_read(function, "name"))
+        if name == "":
+            continue
+
+        schema = _read(function, "parameters")
+        if schema is None:
+            schema = _read(function, "parameters_json_schema")
+
+        result.append(
+            ToolDefinition(
+                name=name,
+                description=_as_str(_read(function, "description")),
+                type=tool_type or "function",
+                input_schema_json=_json_bytes(schema),
+            )
+        )
     return result
 
 


### PR DESCRIPTION
## Notes

Fixes missing tool-call recording for Python LangChain generations, specifically the  
`langchain-google-genai` / Gemini shape where the assistant response has empty text but  
includes `AIMessage.tool_calls`.

The handler now records:

- assistant tool calls from `message.tool_calls`
- OpenAI-style LangChain tool definitions from `invocation_params["tools"]`
- Gemini response model / stop reason from `response_metadata`
- Gemini token usage from `usage_metadata`

## Testing

- Verified against local Sigil with a real Gemini + LangChain tool-call run:
  - Model: `gemini-2.5-flash`
  - Tool: `get_weather`
  - Conversation: `codex-gemini-langchain-targeted-1777479746`

Sigil recorded:
- `output_tool_call.name = get_weather`
- tool definition `get_weather`
- `response_model = gemini-2.5-flash`
- `stop_reason = STOP`
- token usage

Before:
<img width="2195" height="630" alt="gemin-before" src="https://github.com/user-attachments/assets/3dbba235-339e-44a9-bb22-a2b2c4abf43a" />

After:
<img width="2081" height="725" alt="gemini-after" src="https://github.com/user-attachments/assets/32383256-ed01-4212-810a-aa4a73f37999" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how generation outputs and token usage are parsed/mapped across LangChain providers, which could affect recorded traces/analytics for existing integrations.
> 
> **Overview**
> Improves the Python framework handler’s LangChain `on_llm_end` mapping to support Gemini/`langchain-google-genai` response shapes by reading `response_metadata` (model + stop reason) and `usage_metadata` (including cache-read and reasoning token details).
> 
> Updates output mapping to build assistant messages from `message.content` **and** `message.tool_calls`, emitting `TOOL_CALL` parts with JSON-encoded inputs, and expands tool definition parsing to handle OpenAI-style `invocation_params["tools"]` entries with `function` schemas.
> 
> Adds a targeted LangChain test covering Gemini tool-call-only assistant responses and asserting tool choice/definitions, tool call output parts, and detailed usage fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7886509903a7ec1db0e58c2b25af460b4cdc2afa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->