### PR TITLE
ci(npm): switch publishing to trusted publishing

### DIFF
--- a/.github/workflows/js-sdk-publish.yml
+++ b/.github/workflows/js-sdk-publish.yml
@@ -19,6 +19,7 @@ jobs:
   publish:
     if: github.repository == 'grafana/sigil-sdk' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
       contents: read
       id-token: write
@@ -34,7 +35,6 @@ jobs:
           common_secrets: |
             GITHUB_APP_ID=plugins-platform-bot-app:app-id
             GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
-            NPM_TOKEN=sigil-npm:token
           export_env: false
 
       - name: Generate GitHub token
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version-file: js/package.json
+          node-version: '24'
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
@@ -74,9 +74,7 @@ jobs:
 
       - name: Publish
         working-directory: js
-        run: pnpm publish --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).NPM_TOKEN }}
+        run: npm publish --access public
 
       - name: Commit and tag
         run: |

--- a/.github/workflows/plugins-publish.yml
+++ b/.github/workflows/plugins-publish.yml
@@ -131,6 +131,7 @@ jobs:
   publish:
     needs: prepare
     runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
       contents: read
       id-token: write
@@ -140,20 +141,9 @@ jobs:
         plugin: ${{ fromJSON(needs.prepare.outputs.plugins) }}
 
     steps:
-      - name: Get NPM token from Vault
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
-        env:
-          VAULT_INSTANCE: ops
-        with:
-          vault_instance: ${{ env.VAULT_INSTANCE }}
-          common_secrets: |
-            NPM_TOKEN=sigil-npm:token
-          export_env: false
-
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: https://registry.npmjs.org
 
       - name: Download plugin tarballs
@@ -163,6 +153,4 @@ jobs:
           path: tarballs/
 
       - name: Publish ${{ matrix.plugin }} to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).NPM_TOKEN }}
         run: npm publish "tarballs/${{ matrix.plugin }}.tgz" --access public

--- a/js/package.json
+++ b/js/package.json
@@ -1,8 +1,12 @@
 {
   "name": "@grafana/sigil-sdk-js",
   "version": "0.1.0",
-  "private": true,
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/grafana/sigil-sdk.git",
+    "directory": "js"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -2,6 +2,11 @@
   "name": "@grafana/sigil-opencode",
   "version": "0.2.0",
   "description": "OpenCode plugin for Grafana Sigil AI telemetry",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/grafana/sigil-sdk.git",
+    "directory": "plugins/opencode"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/pi/package.json
+++ b/plugins/pi/package.json
@@ -2,6 +2,11 @@
   "name": "@grafana/sigil-pi",
   "version": "0.2.0",
   "description": "Pi agent extension for Grafana Sigil AI telemetry",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/grafana/sigil-sdk.git",
+    "directory": "plugins/pi"
+  },
   "type": "module",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the npm release workflows to rely on GitHub OIDC/trusted publishing instead of Vault-provided `NPM_TOKEN`, which could break releases if npm/GitHub environment configuration is incorrect. Also bumps publish jobs to Node 24, which may affect tooling compatibility in CI.
> 
> **Overview**
> **Npm publishing is migrated to trusted publishing.** Both `js-sdk-publish.yml` and `plugins-publish.yml` now run in the `npm-publish` GitHub environment with `id-token: write` and no longer fetch/use an `NPM_TOKEN` from Vault, publishing directly via `npm publish`.
> 
> **CI publish runtime is updated.** The publish jobs switch to Node `24` (and the JS SDK workflow stops using `node-version-file`), and `js/package.json` plus plugin `package.json`s add `repository` metadata (and the JS SDK is no longer marked `private`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8831335805c911ec872c379293ecefc1fdc4aaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->