### PR TITLE
fix(ci): prefix tarball path with ./ so npm publish treats it as a local file

### DIFF
--- a/.github/workflows/plugins-publish.yml
+++ b/.github/workflows/plugins-publish.yml
@@ -153,4 +153,4 @@ jobs:
           path: tarballs/
 
       - name: Publish ${{ matrix.plugin }} to npm
-        run: npm publish "tarballs/${{ matrix.plugin }}.tgz" --access public
+        run: npm publish "./tarballs/${{ matrix.plugin }}.tgz" --access public


### PR DESCRIPTION
Without the leading `./`, npm parsed `tarballs/opencode.tgz` as a GitHub short-spec (`<owner>/<repo>`) and tried to git-clone it failing with permission denied.

tested with dry-run: https://github.com/grafana/sigil-sdk/actions/runs/25123123865

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI workflow change that only affects how `npm publish` resolves the tarball path during releases.
> 
> **Overview**
> Updates the `plugins-publish` GitHub Actions workflow to publish plugin tarballs using an explicit local path (`./tarballs/<plugin>.tgz`) so `npm publish` doesn’t misinterpret `tarballs/...` as a GitHub short-spec and attempt a git clone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce828629ece1c123ae97b85f0fac56becefa9295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->