### PR TITLE
feat: apply OTel GenAI token usage histogram buckets across SDKs

### DIFF
--- a/dotnet/src/Grafana.Sigil/SigilClient.cs
+++ b/dotnet/src/Grafana.Sigil/SigilClient.cs
@@ -79,6 +79,12 @@ public sealed partial class SigilClient : IAsyncDisposable
         2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
     };
 
+    internal static readonly double[] TokenUsageBuckets =
+    {
+        1, 4, 16, 64, 256, 1024, 4096, 16384,
+        65536, 262144, 1048576, 4194304, 16777216, 67108864,
+    };
+
 #if NET
     [GeneratedRegex(@"\b([1-5][0-9][0-9])\b", RegexOptions.Compiled)]
     private static partial Regex StatusCodeRegex();
@@ -160,7 +166,10 @@ public sealed partial class SigilClient : IAsyncDisposable
             MetricOperationDuration,
             unit: "s",
             advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = DurationBucketsSeconds });
-        _tokenUsageHistogram = _meter.CreateHistogram<double>(MetricTokenUsage, "token");
+        _tokenUsageHistogram = _meter.CreateHistogram<double>(
+            MetricTokenUsage,
+            unit: "token",
+            advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = TokenUsageBuckets });
         _ttftHistogram = _meter.CreateHistogram<double>(
             MetricTimeToFirstToken,
             unit: "s",

--- a/dotnet/tests/Grafana.Sigil.Tests/HistogramBucketAdviceTests.cs
+++ b/dotnet/tests/Grafana.Sigil.Tests/HistogramBucketAdviceTests.cs
@@ -13,8 +13,14 @@ public sealed class HistogramBucketAdviceTests
         2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
     };
 
+    private static readonly double[] ExpectedTokenUsageBuckets =
+    {
+        1, 4, 16, 64, 256, 1024, 4096, 16384,
+        65536, 262144, 1048576, 4194304, 16777216, 67108864,
+    };
+
     [Fact]
-    public async Task DurationHistograms_UseSemconvBucketBoundaries()
+    public async Task Histograms_UseSemconvBucketBoundaries()
     {
         var captured = new ConcurrentDictionary<string, double[]>(StringComparer.Ordinal);
 
@@ -56,6 +62,11 @@ public sealed class HistogramBucketAdviceTests
             captured.TryGetValue("gen_ai.client.time_to_first_token", out var ttftBounds),
             "expected gen_ai.client.time_to_first_token data point");
         Assert.Equal(ExpectedDurationBuckets, ttftBounds);
+
+        Assert.True(
+            captured.TryGetValue("gen_ai.client.token.usage", out var tokenUsageBounds),
+            "expected gen_ai.client.token.usage data point");
+        Assert.Equal(ExpectedTokenUsageBuckets, tokenUsageBounds);
     }
 
     private sealed class CapturingMetricExporter : BaseExporter<Metric>

--- a/go/sigil/client.go
+++ b/go/sigil/client.go
@@ -178,6 +178,13 @@ var durationBucketsSeconds = []float64{
 	2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
 }
 
+// tokenUsageBuckets is the OTel GenAI semantic-convention bucket advice
+// applied to gen_ai.client.token.usage (powers of 4 from 1 to ~67M tokens).
+var tokenUsageBuckets = []float64{
+	1, 4, 16, 64, 256, 1024, 4096, 16384,
+	65536, 262144, 1048576, 4194304, 16777216, 67108864,
+}
+
 var statusCodePattern = regexp.MustCompile(`\b([1-5][0-9][0-9])\b`)
 
 // Keep unexported aliases for backward-compatible fmt.Errorf wrapping.
@@ -1546,7 +1553,11 @@ func newTelemetryInstruments(meter metric.Meter) (telemetryInstruments, error) {
 	if err != nil {
 		return telemetryInstruments{}, err
 	}
-	out.tokenUsage, err = meter.Int64Histogram(metricTokenUsage, metric.WithUnit("token"))
+	out.tokenUsage, err = meter.Int64Histogram(
+		metricTokenUsage,
+		metric.WithUnit("token"),
+		metric.WithExplicitBucketBoundaries(tokenUsageBuckets...),
+	)
 	if err != nil {
 		return telemetryInstruments{}, err
 	}

--- a/go/sigil/conformance_test.go
+++ b/go/sigil/conformance_test.go
@@ -744,8 +744,13 @@ func TestConformance_StreamingMode(t *testing.T) {
 	})
 	recorder.SetFirstTokenAt(streamStartedAt.Add(250 * time.Millisecond))
 	recorder.SetResult(sigil.Generation{
-		Input:       []sigil.Message{sigil.UserTextMessage("say hello")},
-		Output:      []sigil.Message{sigil.AssistantTextMessage("Hello world")},
+		Input:  []sigil.Message{sigil.UserTextMessage("say hello")},
+		Output: []sigil.Message{sigil.AssistantTextMessage("Hello world")},
+		Usage: sigil.TokenUsage{
+			InputTokens:  3,
+			OutputTokens: 2,
+			TotalTokens:  5,
+		},
 		CompletedAt: streamStartedAt.Add(1500 * time.Millisecond),
 	}, nil)
 	recorder.End()
@@ -768,6 +773,10 @@ func TestConformance_StreamingMode(t *testing.T) {
 		0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28,
 		2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
 	}
+	expectedTokenUsageBuckets := []float64{
+		1, 4, 16, 64, 256, 1024, 4096, 16384,
+		65536, 262144, 1048576, 4194304, 16777216, 67108864,
+	}
 	duration := findHistogram[float64](t, metrics, metricOperationDuration)
 	if len(duration.DataPoints) == 0 {
 		t.Fatalf("expected %s datapoints", metricOperationDuration)
@@ -777,6 +786,13 @@ func TestConformance_StreamingMode(t *testing.T) {
 	}
 	if got := ttft.DataPoints[0].Bounds; !slices.Equal(got, expectedDurationBuckets) {
 		t.Fatalf("%s bucket boundaries mismatch:\nexpected %v\n     got %v", metricTimeToFirstToken, expectedDurationBuckets, got)
+	}
+	tokenUsage := findHistogram[int64](t, metrics, metricTokenUsage)
+	if len(tokenUsage.DataPoints) == 0 {
+		t.Fatalf("expected %s datapoints", metricTokenUsage)
+	}
+	if got := tokenUsage.DataPoints[0].Bounds; !slices.Equal(got, expectedTokenUsageBuckets) {
+		t.Fatalf("%s bucket boundaries mismatch:\nexpected %v\n     got %v", metricTokenUsage, expectedTokenUsageBuckets, got)
 	}
 
 	env.Shutdown(t)

--- a/java/core/src/main/java/com/grafana/sigil/sdk/SigilClient.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/SigilClient.java
@@ -100,6 +100,10 @@ public final class SigilClient implements AutoCloseable {
             0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28,
             2.56, 5.12, 10.24, 20.48, 40.96, 81.92);
 
+    static final List<Double> TOKEN_USAGE_BUCKETS = List.of(
+            1.0, 4.0, 16.0, 64.0, 256.0, 1024.0, 4096.0, 16384.0,
+            65536.0, 262144.0, 1048576.0, 4194304.0, 16777216.0, 67108864.0);
+
     private static final Pattern STATUS_CODE_PATTERN = Pattern.compile("\\b([1-5][0-9][0-9])\\b");
     private static final String INSTRUMENTATION_NAME = "github.com/grafana/sigil/sdks/java";
     static final String DEFAULT_EMBEDDING_OPERATION_NAME = "embeddings";
@@ -187,6 +191,7 @@ public final class SigilClient implements AutoCloseable {
                 .build();
         this.tokenUsageHistogram = meter.histogramBuilder(METRIC_TOKEN_USAGE)
                 .setUnit("token")
+                .setExplicitBucketBoundariesAdvice(TOKEN_USAGE_BUCKETS)
                 .build();
         this.ttftHistogram = meter.histogramBuilder(METRIC_TTFT)
                 .setUnit("s")

--- a/java/core/src/test/java/com/grafana/sigil/sdk/SigilClientMetricsTest.java
+++ b/java/core/src/test/java/com/grafana/sigil/sdk/SigilClientMetricsTest.java
@@ -65,18 +65,25 @@ class SigilClientMetricsTest {
                 0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28,
                 2.56, 5.12, 10.24, 20.48, 40.96, 81.92);
 
-        assertThat(durationBucketBoundaries(metrics, SigilClient.METRIC_OPERATION_DURATION))
+        assertThat(histogramBucketBoundaries(metrics, SigilClient.METRIC_OPERATION_DURATION))
                 .as("operation duration buckets")
                 .isEqualTo(expectedBuckets);
-        assertThat(durationBucketBoundaries(metrics, SigilClient.METRIC_TTFT))
+        assertThat(histogramBucketBoundaries(metrics, SigilClient.METRIC_TTFT))
                 .as("time-to-first-token buckets")
                 .isEqualTo(expectedBuckets);
+
+        List<Double> expectedTokenUsageBuckets = List.of(
+                1.0, 4.0, 16.0, 64.0, 256.0, 1024.0, 4096.0, 16384.0,
+                65536.0, 262144.0, 1048576.0, 4194304.0, 16777216.0, 67108864.0);
+        assertThat(histogramBucketBoundaries(metrics, SigilClient.METRIC_TOKEN_USAGE))
+                .as("token usage buckets")
+                .isEqualTo(expectedTokenUsageBuckets);
 
         tracerProvider.shutdown();
         meterProvider.shutdown();
     }
 
-    private static List<Double> durationBucketBoundaries(Collection<MetricData> metrics, String name) {
+    private static List<Double> histogramBucketBoundaries(Collection<MetricData> metrics, String name) {
         MetricData metric = metrics.stream()
                 .filter(m -> name.equals(m.getName()))
                 .findFirst()

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -146,6 +146,9 @@ const metricTokenTypeReasoning = 'reasoning';
 const durationBucketsSeconds: number[] = [
   0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
 ];
+const tokenUsageBuckets: number[] = [
+  1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864,
+];
 const instrumentationName = 'github.com/grafana/sigil/sdks/js';
 const sdkName = 'sdk-js';
 const defaultEmbeddingOperationName = 'embeddings';
@@ -193,7 +196,10 @@ export class SigilClient {
       unit: 's',
       advice: { explicitBucketBoundaries: durationBucketsSeconds },
     });
-    this.tokenUsageHistogram = this.meter.createHistogram(metricTokenUsage, { unit: 'token' });
+    this.tokenUsageHistogram = this.meter.createHistogram(metricTokenUsage, {
+      unit: 'token',
+      advice: { explicitBucketBoundaries: tokenUsageBuckets },
+    });
     this.ttftHistogram = this.meter.createHistogram(metricTimeToFirstToken, {
       unit: 's',
       advice: { explicitBucketBoundaries: durationBucketsSeconds },

--- a/js/test/client.redaction.test.mjs
+++ b/js/test/client.redaction.test.mjs
@@ -202,7 +202,7 @@ test('generation sanitizer failure falls back to metadata_only stripping', async
 
 test('secret redaction sanitizer redacts systemPrompt, conversationTitle, and callError', async () => {
   const sanitizer = createSecretRedactionSanitizer();
-  const apiKey = 'sk-proj-' + 'a'.repeat(48);
+  const apiKey = `sk-proj-${'a'.repeat(48)}`;
   const sanitized = sanitizer({
     id: 'gen-4',
     mode: 'SYNC',

--- a/js/test/conformance.test.mjs
+++ b/js/test/conformance.test.mjs
@@ -395,6 +395,11 @@ test('conformance streaming telemetry semantics', async () => {
     const expectedBuckets = [0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92];
     assert.deepEqual(await env.metricBucketBoundaries('gen_ai.client.operation.duration'), expectedBuckets);
     assert.deepEqual(await env.metricBucketBoundaries('gen_ai.client.time_to_first_token'), expectedBuckets);
+
+    const expectedTokenUsageBuckets = [
+      1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864,
+    ];
+    assert.deepEqual(await env.metricBucketBoundaries('gen_ai.client.token.usage'), expectedTokenUsageBuckets);
   } finally {
     await env.close();
   }

--- a/python/sigil_sdk/client.py
+++ b/python/sigil_sdk/client.py
@@ -145,6 +145,23 @@ _DURATION_BUCKETS_SECONDS: tuple[float, ...] = (
     81.92,
 )
 
+_TOKEN_USAGE_BUCKETS: tuple[float, ...] = (
+    1,
+    4,
+    16,
+    64,
+    256,
+    1024,
+    4096,
+    16384,
+    65536,
+    262144,
+    1048576,
+    4194304,
+    16777216,
+    67108864,
+)
+
 _status_code_pattern = re.compile(r"\b([1-5][0-9][0-9])\b")
 _instrumentation_name = "github.com/grafana/sigil/sdks/python"
 _sdk_name = "sdk-python"
@@ -296,7 +313,11 @@ class Client:
             unit="s",
             explicit_bucket_boundaries_advisory=_DURATION_BUCKETS_SECONDS,
         )
-        self._token_usage_histogram: Histogram = self._meter.create_histogram(_metric_token_usage, unit="token")
+        self._token_usage_histogram: Histogram = self._meter.create_histogram(
+            _metric_token_usage,
+            unit="token",
+            explicit_bucket_boundaries_advisory=_TOKEN_USAGE_BUCKETS,
+        )
         self._ttft_histogram: Histogram = self._meter.create_histogram(
             _metric_ttft,
             unit="s",

--- a/python/tests/test_conformance.py
+++ b/python/tests/test_conformance.py
@@ -561,6 +561,28 @@ def test_conformance_streaming_telemetry_semantics() -> None:
             assert tuple(data_points[0].explicit_bounds) == expected_buckets, (
                 f"{metric_name} bucket boundaries mismatch: {tuple(data_points[0].explicit_bounds)}"
             )
+
+        expected_token_usage_buckets = (
+            1,
+            4,
+            16,
+            64,
+            256,
+            1024,
+            4096,
+            16384,
+            65536,
+            262144,
+            1048576,
+            4194304,
+            16777216,
+            67108864,
+        )
+        token_usage_points = list(metrics["gen_ai.client.token.usage"].data_points)
+        assert token_usage_points, "expected gen_ai.client.token.usage data points"
+        assert tuple(token_usage_points[0].explicit_bounds) == expected_token_usage_buckets, (
+            f"gen_ai.client.token.usage bucket boundaries mismatch: {tuple(token_usage_points[0].explicit_bounds)}"
+        )
     finally:
         env.shutdown()
 


### PR DESCRIPTION
Configure gen_ai.client.token.usage with the semconv-recommended bucket [advice](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiclienttokenusage) (powers of 4 from 1 to ~67M tokens) in the Go, Python, JS, Java, and .NET SDKs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metrics-only change that adjusts histogram bucket configuration and test expectations; low likelihood of functional impact outside telemetry shape/aggregation.
> 
> **Overview**
> Aligns `gen_ai.client.token.usage` histograms with the OpenTelemetry GenAI semantic conventions by adding explicit bucket boundary advice (powers of 4 from 1 to ~67M) in the Go, Python, JS, Java, and .NET SDKs.
> 
> Updates conformance/unit tests in each language to validate the new `token.usage` histogram boundaries (and renames the .NET duration-only test to cover all relevant histograms). Also includes minor test-only cleanup in JS (template literal for an API key string).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f91fff4b80564dd7e678d53083c12b2b59bd5b6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->