### PR TITLE
chore: publish strands sdk to pypi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
           - { name: google-adk, cmd: "uv run --with './python[dev]' --with './python-frameworks/google-adk[dev]' pytest python-frameworks/google-adk/tests" }
           - { name: litellm, cmd: "uv run --with './python[dev]' --with './python-frameworks/litellm[dev]' pytest python-frameworks/litellm/tests" }
           - { name: pydantic-ai, cmd: "uv run --with './python[dev]' --with './python-frameworks/pydantic-ai[dev]' pytest python-frameworks/pydantic-ai/tests" }
+          - { name: strands, cmd: "uv run --with './python[dev]' --with './python-frameworks/strands[dev]' pytest python-frameworks/strands/tests" }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/python-sdks-publish.yml
+++ b/.github/workflows/python-sdks-publish.yml
@@ -95,6 +95,7 @@ jobs:
             python-frameworks/google-adk
             python-frameworks/litellm
             python-frameworks/pydantic-ai
+            python-frameworks/strands
           )
 
           for dir in "${PACKAGE_DIRS[@]}"; do
@@ -121,6 +122,7 @@ jobs:
             python-frameworks/google-adk
             python-frameworks/litellm
             python-frameworks/pydantic-ai
+            python-frameworks/strands
           )
 
           for dir in "${PACKAGE_DIRS[@]}"; do
@@ -202,6 +204,7 @@ jobs:
           - sigil-sdk-google-adk
           - sigil-sdk-litellm
           - sigil-sdk-pydantic-ai
+          - sigil-sdk-strands
 
     steps:
       - name: Download distributions


### PR DESCRIPTION
Publishing to pypi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just expands existing test/publish matrices to include an additional package.
> 
> **Overview**
> Adds the `python-frameworks/strands` package to the Python CI test matrix so its tests run alongside the other SDK/framework suites.
> 
> Updates the `python-sdks-publish` workflow to version-bump, build, and publish the new `sigil-sdk-strands` distribution to PyPI as part of the existing multi-package release process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8edec32386a617d86f1e029501622c71f6f18cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->