### PR TITLE
feat(plugins/pi): capture user input in Sigil generations

### DIFF
--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -91,7 +91,7 @@ describe("extension lifecycle", () => {
     createSigilClientMock.mockReset();
   });
 
-  it("handles the happy path and exports one generation", async () => {
+  it("handles the happy path and exports one generation with user input", async () => {
     const recorder = {
       setResult: vi.fn(),
       setCallError: vi.fn(),
@@ -114,7 +114,7 @@ describe("extension lifecycle", () => {
       endpoint: "http://localhost:8080/api/v1/generations:export",
       auth: { mode: "none" },
       agentName: "pi",
-      contentCapture: "metadata_only",
+      contentCapture: "full",
     });
     createSigilClientMock.mockReturnValue(sigil);
 
@@ -123,6 +123,9 @@ describe("extension lifecycle", () => {
 
     await pi.emit("session_start");
     await pi.emit("turn_start");
+    await pi.emit("message_end", {
+      message: { role: "user", content: "hey", timestamp: Date.now() },
+    });
     await pi.emit("tool_execution_start", {
       toolCallId: "c1",
       toolName: "read",
@@ -133,6 +136,73 @@ describe("extension lifecycle", () => {
     expect(sigil.startGeneration).toHaveBeenCalledTimes(1);
     expect(recorder.setResult).toHaveBeenCalledTimes(1);
     expect(recorder.setCallError).not.toHaveBeenCalled();
+
+    const result = recorder.setResult.mock.calls[0]![0] as {
+      input?: Array<{
+        role: string;
+        parts?: Array<{ type: string; text?: string }>;
+      }>;
+    };
+    expect(result.input).toBeDefined();
+    expect(result.input).toHaveLength(1);
+    expect(result.input?.[0]?.role).toBe("user");
+    expect(result.input?.[0]?.parts?.[0]).toEqual({
+      type: "text",
+      text: "hey",
+    });
+  });
+
+  it("leaves input empty on a tool-loop continuation with no user message_end", async () => {
+    const recorder = {
+      setResult: vi.fn(),
+      setCallError: vi.fn(),
+    };
+
+    const sigil: SigilLike = {
+      startGeneration: vi.fn(async (_seed, run) => {
+        await run(recorder);
+      }),
+      startToolExecution: vi.fn(() => ({
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        end: vi.fn(),
+        getError: vi.fn(),
+      })),
+      shutdown: vi.fn(async () => {}),
+    };
+
+    loadConfigMock.mockResolvedValue({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      auth: { mode: "none" },
+      agentName: "pi",
+      contentCapture: "full",
+    });
+    createSigilClientMock.mockReturnValue(sigil);
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+
+    await pi.emit("session_start");
+
+    // Turn 1: user types, assistant calls a tool.
+    await pi.emit("turn_start");
+    await pi.emit("message_end", {
+      message: { role: "user", content: "hey", timestamp: Date.now() },
+    });
+    await pi.emit("turn_end", { message: assistantMessage(), toolResults: [] });
+
+    // Turn 2: agent loop continues with no new user input.
+    await pi.emit("turn_start");
+    await pi.emit("turn_end", { message: assistantMessage(), toolResults: [] });
+
+    expect(sigil.startGeneration).toHaveBeenCalledTimes(2);
+    expect(recorder.setResult).toHaveBeenCalledTimes(2);
+
+    const turn1 = recorder.setResult.mock.calls[0]![0] as { input?: unknown[] };
+    const turn2 = recorder.setResult.mock.calls[1]![0] as { input?: unknown[] };
+    expect(turn1.input).toBeDefined();
+    expect(turn1.input).toHaveLength(1);
+    expect(turn2.input).toBeUndefined();
   });
 
   it("clamps startedAt when msg.timestamp precedes turnStartTime", async () => {

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -1,7 +1,11 @@
 import { readFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { ContentCaptureMode, SigilClient } from "@grafana/sigil-sdk-js";
+import type {
+  ContentCaptureMode,
+  Message,
+  SigilClient,
+} from "@grafana/sigil-sdk-js";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { createSigilClient } from "./client.js";
 import type { SigilPiConfig } from "./config.js";
@@ -10,8 +14,10 @@ import {
   mapGenerationResult,
   mapGenerationStart,
   mapToolNames,
+  mapUserMessage,
   type PiAssistantMessage,
   type PiToolResult,
+  type PiUserMessage,
   type ToolTiming,
 } from "./mappers.js";
 import {
@@ -63,6 +69,14 @@ export default function (pi: ExtensionAPI) {
   const toolStarts = new Map<string, { toolName: string; startedAt: number }>();
   const turnToolTimings: ToolTiming[] = [];
 
+  // User messages observed since the previous turn_end. Consumed at the next
+  // turn_end and attached to GenerationResult.input. Filled by the
+  // `message_end` handler (user role only). Per pi's agent loop, `turn_start`
+  // fires BEFORE the user `message_end` for fresh prompts, so this buffer
+  // must NOT be cleared at turn_start — only after consume and on session
+  // boundaries.
+  const pendingInputMessages: Message[] = [];
+
   function resetTurnState() {
     turnStartTime = 0;
     toolStarts.clear();
@@ -81,6 +95,7 @@ export default function (pi: ExtensionAPI) {
       telemetry = null;
     }
     resetTurnState();
+    pendingInputMessages.length = 0;
   }
 
   pi.on("session_start", async (_event, ctx) => {
@@ -135,6 +150,18 @@ export default function (pi: ExtensionAPI) {
     resetTurnState();
     if (!sigil) return;
     turnStartTime = Date.now();
+  });
+
+  pi.on("message_end", async (event, _ctx) => {
+    if (!sigil || !config) return;
+    try {
+      const message = (event as { message?: unknown }).message;
+      if (!isUserMessage(message)) return;
+      const mapped = mapUserMessage(message, config.contentCapture);
+      if (mapped) pendingInputMessages.push(mapped);
+    } catch (err) {
+      console.warn("[sigil-pi] message_end failed:", err);
+    }
   });
 
   pi.on("tool_execution_start", async (event, _ctx) => {
@@ -204,7 +231,14 @@ export default function (pi: ExtensionAPI) {
       );
 
       const toolResults = (event.toolResults ?? []) as PiToolResult[];
-      const result = mapGenerationResult(msg, toolResults, contentCapture);
+      // Snapshot the buffer; the finally below clears it in place and
+      // GenerationResult.input would otherwise alias the cleared array.
+      const result = mapGenerationResult(
+        msg,
+        toolResults,
+        contentCapture,
+        pendingInputMessages.slice(),
+      );
 
       await sigil.startGeneration(seed, async (recorder) => {
         recorder.setResult(result);
@@ -228,6 +262,7 @@ export default function (pi: ExtensionAPI) {
     } finally {
       toolStarts.clear();
       turnToolTimings.length = 0;
+      pendingInputMessages.length = 0;
     }
   });
 
@@ -343,5 +378,16 @@ function isAssistantMessage(message: unknown): message is PiAssistantMessage {
     !!candidate.usage &&
     Array.isArray(candidate.content) &&
     typeof candidate.stopReason === "string"
+  );
+}
+
+function isUserMessage(message: unknown): message is PiUserMessage {
+  if (!message || typeof message !== "object") return false;
+  const candidate = message as Partial<PiUserMessage>;
+  return (
+    candidate.role === "user" &&
+    (typeof candidate.content === "string" ||
+      Array.isArray(candidate.content)) &&
+    typeof candidate.timestamp === "number"
   );
 }

--- a/plugins/pi/src/mappers.test.ts
+++ b/plugins/pi/src/mappers.test.ts
@@ -3,8 +3,10 @@ import {
   mapGenerationResult,
   mapGenerationStart,
   mapToolNames,
+  mapUserMessage,
   type PiAssistantMessage,
   type PiToolResult,
+  type PiUserMessage,
   type ToolTiming,
 } from "./mappers.js";
 
@@ -43,6 +45,15 @@ function makeToolResult(overrides?: Partial<PiToolResult>): PiToolResult {
     content: [{ type: "text", text: "output" }],
     isError: false,
     timestamp: 1700000002000,
+    ...overrides,
+  };
+}
+
+function makeUserMsg(overrides?: Partial<PiUserMessage>): PiUserMessage {
+  return {
+    role: "user",
+    content: "hey",
+    timestamp: 1700000000000,
     ...overrides,
   };
 }
@@ -342,6 +353,107 @@ describe("mapGenerationResult", () => {
       mapGenerationResult(makeMsg({ stopReason: "error" }), [], "metadata_only")
         .stopReason,
     ).toBe("error");
+  });
+});
+
+describe("mapUserMessage", () => {
+  it("maps string content to a single text part in full mode", () => {
+    const msg = makeUserMsg({ content: "hello world" });
+    const out = mapUserMessage(msg, "full");
+    expect(out).toEqual({
+      role: "user",
+      parts: [{ type: "text", text: "hello world" }],
+    });
+  });
+
+  it("maps a TextContent array to a joined text part", () => {
+    const msg = makeUserMsg({
+      content: [
+        { type: "text", text: "first" },
+        { type: "text", text: "second" },
+      ],
+    });
+    const out = mapUserMessage(msg, "full");
+    expect(out?.role).toBe("user");
+    const text = (out?.parts?.[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("first");
+    expect(text).toContain("second");
+  });
+
+  it("filters out image content and keeps text only", () => {
+    const msg = makeUserMsg({
+      content: [
+        { type: "text", text: "look at this" },
+        { type: "image", data: "ZmFrZQ==", mimeType: "image/png" },
+        { type: "text", text: "thanks" },
+      ],
+    });
+    const out = mapUserMessage(msg, "full");
+    expect(out?.parts).toHaveLength(1);
+    const part = out?.parts?.[0] as { type: "text"; text: string };
+    expect(part.type).toBe("text");
+    expect(part.text).toContain("look at this");
+    expect(part.text).toContain("thanks");
+    const partTypes = out?.parts?.map((p) => p.type);
+    expect(partTypes).not.toContain("image");
+  });
+
+  it("returns null for whitespace-only string content", () => {
+    expect(mapUserMessage(makeUserMsg({ content: "   \n\t" }), "full")).toBeNull();
+  });
+
+  it("returns null for empty content array", () => {
+    expect(mapUserMessage(makeUserMsg({ content: [] }), "full")).toBeNull();
+  });
+
+  it("returns null for an image-only array (no text parts)", () => {
+    const msg = makeUserMsg({
+      content: [
+        { type: "image", data: "ZmFrZQ==", mimeType: "image/png" },
+      ],
+    });
+    expect(mapUserMessage(msg, "full")).toBeNull();
+  });
+
+  it("returns null in metadata_only mode regardless of content", () => {
+    expect(mapUserMessage(makeUserMsg({ content: "hey" }), "metadata_only")).toBeNull();
+    expect(
+      mapUserMessage(
+        makeUserMsg({
+          content: [{ type: "text", text: "hey" }],
+        }),
+        "metadata_only",
+      ),
+    ).toBeNull();
+  });
+
+  it("emits text in no_tool_content mode", () => {
+    const out = mapUserMessage(makeUserMsg({ content: "hey" }), "no_tool_content");
+    expect(out).toEqual({
+      role: "user",
+      parts: [{ type: "text", text: "hey" }],
+    });
+  });
+});
+
+describe("mapGenerationResult input wiring", () => {
+  it("sets input when a non-empty list is passed", () => {
+    const msg = makeMsg();
+    const input = [
+      { role: "user", parts: [{ type: "text" as const, text: "hey" }] },
+    ];
+    const result = mapGenerationResult(msg, [], "full", input);
+    expect(result.input).toEqual(input);
+  });
+
+  it("omits input when not passed", () => {
+    const result = mapGenerationResult(makeMsg(), [], "full");
+    expect(result.input).toBeUndefined();
+  });
+
+  it("omits input when an empty array is passed", () => {
+    const result = mapGenerationResult(makeMsg(), [], "full", []);
+    expect(result.input).toBeUndefined();
   });
 });
 

--- a/plugins/pi/src/mappers.test.ts
+++ b/plugins/pi/src/mappers.test.ts
@@ -399,7 +399,9 @@ describe("mapUserMessage", () => {
   });
 
   it("returns null for whitespace-only string content", () => {
-    expect(mapUserMessage(makeUserMsg({ content: "   \n\t" }), "full")).toBeNull();
+    expect(
+      mapUserMessage(makeUserMsg({ content: "   \n\t" }), "full"),
+    ).toBeNull();
   });
 
   it("returns null for empty content array", () => {
@@ -408,15 +410,15 @@ describe("mapUserMessage", () => {
 
   it("returns null for an image-only array (no text parts)", () => {
     const msg = makeUserMsg({
-      content: [
-        { type: "image", data: "ZmFrZQ==", mimeType: "image/png" },
-      ],
+      content: [{ type: "image", data: "ZmFrZQ==", mimeType: "image/png" }],
     });
     expect(mapUserMessage(msg, "full")).toBeNull();
   });
 
   it("returns null in metadata_only mode regardless of content", () => {
-    expect(mapUserMessage(makeUserMsg({ content: "hey" }), "metadata_only")).toBeNull();
+    expect(
+      mapUserMessage(makeUserMsg({ content: "hey" }), "metadata_only"),
+    ).toBeNull();
     expect(
       mapUserMessage(
         makeUserMsg({
@@ -428,7 +430,10 @@ describe("mapUserMessage", () => {
   });
 
   it("emits text in no_tool_content mode", () => {
-    const out = mapUserMessage(makeUserMsg({ content: "hey" }), "no_tool_content");
+    const out = mapUserMessage(
+      makeUserMsg({ content: "hey" }),
+      "no_tool_content",
+    );
     expect(out).toEqual({
       role: "user",
       parts: [{ type: "text", text: "hey" }],

--- a/plugins/pi/src/mappers.ts
+++ b/plugins/pi/src/mappers.ts
@@ -45,6 +45,24 @@ export type PiContentBlock =
       arguments: Record<string, unknown>;
     };
 
+/** Pi's TextContent / ImageContent / UserMessage shapes from @mariozechner/pi-ai. */
+export interface PiTextContent {
+  type: "text";
+  text: string;
+}
+
+export interface PiImageContent {
+  type: "image";
+  data: string;
+  mimeType: string;
+}
+
+export interface PiUserMessage {
+  role: "user";
+  content: string | (PiTextContent | PiImageContent)[];
+  timestamp: number;
+}
+
 export interface PiToolResult {
   role: "toolResult";
   toolCallId: string;
@@ -91,6 +109,7 @@ export function mapGenerationResult(
   msg: PiAssistantMessage,
   toolResults: PiToolResult[],
   contentCapture: ContentCaptureMode,
+  input?: Message[],
 ): GenerationResult {
   const result: GenerationResult = {
     responseId: msg.responseId,
@@ -108,6 +127,10 @@ export function mapGenerationResult(
       msg.usage.cost !== undefined ? { cost_usd: msg.usage.cost.total } : {},
   };
 
+  if (input && input.length > 0) {
+    result.input = input;
+  }
+
   // Always emit structural tool_call / tool_result parts so the SDK can count
   // them for the `gen_ai.client.tool_calls_per_operation` histogram. Body
   // content (assistant text, tool args, tool results) is included per
@@ -121,6 +144,37 @@ export function mapGenerationResult(
   }
 
   return result;
+}
+
+/**
+ * Map a pi user message to a Sigil input Message. Returns null in
+ * `metadata_only` (mirrors how assistant text/thinking is dropped) and for
+ * empty/whitespace-only content. Image parts are skipped because Sigil's
+ * `MessagePart` union has no image type; multiple text parts are joined with
+ * a newline.
+ */
+export function mapUserMessage(
+  msg: PiUserMessage,
+  contentCapture: ContentCaptureMode,
+): Message | null {
+  if (contentCapture === "metadata_only") return null;
+
+  let text: string;
+  if (typeof msg.content === "string") {
+    text = msg.content;
+  } else {
+    text = msg.content
+      .filter((c): c is PiTextContent => c.type === "text")
+      .map((c) => c.text)
+      .join("\n");
+  }
+
+  if (text.trim().length === 0) return null;
+
+  return {
+    role: "user",
+    parts: [{ type: "text", text }],
+  };
 }
 
 /** Map tool names used in this turn to ToolDefinition[]. */


### PR DESCRIPTION
The pi plugin recorded only assistant output, so Sigil conversations showed no user-side messages. Buffer user `message_end` events between turns and attach them to `GenerationResult.input` at `turn_end`, taking into account the configured content capture mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Captures and exports additional user text content, which can affect privacy/compliance expectations depending on `contentCapture` configuration. New buffering across turn boundaries could subtly mis-associate input if event ordering differs from assumptions.
> 
> **Overview**
> Sigil exports from the `pi` plugin now include *user-side input* by buffering `message_end` events (user role) and attaching them to `GenerationResult.input` on `turn_end`, with the buffer cleared only after consumption and on session boundaries.
> 
> Adds `mapUserMessage` and extends `mapGenerationResult` to optionally include `input`, honoring `contentCapture` (drops input in `metadata_only`, filters images, and ignores empty/whitespace content), and updates tests to cover input capture and tool-loop continuations with no new user prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 482e4cda9b8d69d51d84cec91ebeb4ba29e98b05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->