### PR TITLE
feat(plugins/pi): add PII redaction via SDK secret redaction sanitizer

### DIFF
--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -81,6 +81,32 @@ The `otlp` block exports OTel histograms and trace spans:
 }
 ```
 
+### Redaction (pre-ingest secret scrubbing)
+
+The plugin runs every generation through the SDK's secret redaction sanitizer before it leaves the process. Matched values are replaced with `[REDACTED:<id>]`. The sanitizer covers high-confidence formats including:
+
+- Grafana Cloud tokens (`glc_…`) and service account tokens (`glsa_…`)
+- Cloud provider keys (AWS, GCP), GitHub PATs, OpenAI / Anthropic / Stripe / SendGrid / Twilio / Slack / npm / PyPI tokens
+- PEM-encoded private key blocks
+- Database connection strings (`postgres://user:pass@host`, `mysql://…`, `mongodb://…`, `redis://…`, `amqp://…`)
+- Environment-style `PASSWORD=…` / `SECRET=…` / `TOKEN=…` / `KEY=…` / `CREDENTIAL=…` / `API_KEY=…` / `PRIVATE_KEY=…` / `ACCESS_KEY=…` pairs
+- Bearer tokens
+- Email addresses (optional, on by default)
+
+User input messages are scrubbed by default, flip `redactInputMessages` if you want to leave the user side untouched.
+
+Opt out entirely:
+
+```json
+"redaction": { "enabled": false }
+```
+
+Tweak individual knobs:
+
+```json
+"redaction": { "redactEmailAddresses": false }
+```
+
 ### All options
 
 | Field | Default | Description |
@@ -99,6 +125,9 @@ The `otlp` block exports OTel histograms and trace spans:
 | `otlp.basicUser` / `otlp.basicPassword` | — | OTLP Basic auth |
 | `otlp.bearerToken` | — | OTLP Bearer token |
 | `otlp.headers` | — | Custom OTLP headers |
+| `redaction.enabled` | `true` | Master switch for pre-ingest secret redaction |
+| `redaction.redactInputMessages` | `true` | Also scrub user-role message content (not just assistant/tool output) |
+| `redaction.redactEmailAddresses` | `true` | Scrub generic email addresses |
 
 ### Environment variable overrides
 
@@ -120,6 +149,9 @@ Every config field can be overridden via environment variable:
 | `SIGIL_PI_OTLP_BASIC_USER` | `otlp.basicUser` |
 | `SIGIL_PI_OTLP_BASIC_PASSWORD` | `otlp.basicPassword` |
 | `SIGIL_PI_OTLP_BEARER_TOKEN` | `otlp.bearerToken` |
+| `SIGIL_PI_REDACTION_ENABLED` | `redaction.enabled` (`1`/`true`/`yes`/`on` to enable, `0`/`false`/`no`/`off` to disable) |
+| `SIGIL_PI_REDACT_INPUT_MESSAGES` | `redaction.redactInputMessages` |
+| `SIGIL_PI_REDACT_EMAIL_ADDRESSES` | `redaction.redactEmailAddresses` |
 
 ## What gets sent
 

--- a/plugins/pi/src/client.test.ts
+++ b/plugins/pi/src/client.test.ts
@@ -1,12 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SigilPiConfig } from "./config.js";
 
-const { SigilClientMock } = vi.hoisted(() => ({
-  SigilClientMock: vi.fn(),
-}));
+const { SigilClientMock, createSecretRedactionSanitizerMock, SANITIZER } =
+  vi.hoisted(() => {
+    const sanitizer = Object.assign(() => ({}) as never, {
+      __sentinel: "sanitizer",
+    });
+    return {
+      SigilClientMock: vi.fn(),
+      createSecretRedactionSanitizerMock: vi.fn(() => sanitizer),
+      SANITIZER: sanitizer,
+    };
+  });
 
 vi.mock("@grafana/sigil-sdk-js", () => ({
   SigilClient: SigilClientMock,
+  createSecretRedactionSanitizer: createSecretRedactionSanitizerMock,
 }));
 
 import { createSigilClient } from "./client.js";
@@ -18,6 +27,11 @@ function makeConfig(overrides?: Partial<SigilPiConfig>): SigilPiConfig {
     agentName: "pi",
     contentCapture: "metadata_only",
     debug: false,
+    redaction: {
+      enabled: true,
+      redactInputMessages: true,
+      redactEmailAddresses: true,
+    },
     ...overrides,
   };
 }
@@ -25,6 +39,7 @@ function makeConfig(overrides?: Partial<SigilPiConfig>): SigilPiConfig {
 describe("createSigilClient", () => {
   beforeEach(() => {
     SigilClientMock.mockReset();
+    createSecretRedactionSanitizerMock.mockClear();
     // biome-ignore lint/complexity/useArrowFunction: must be a regular function for `new` to work
     SigilClientMock.mockImplementation(function () {
       return {};
@@ -45,6 +60,7 @@ describe("createSigilClient", () => {
         auth: { mode: "tenant", tenantId: "t-1" },
       },
       contentCapture: "metadata_only",
+      generationSanitizer: SANITIZER,
     });
   });
 
@@ -72,6 +88,7 @@ describe("createSigilClient", () => {
         },
       },
       contentCapture: "metadata_only",
+      generationSanitizer: SANITIZER,
     });
   });
 
@@ -89,5 +106,52 @@ describe("createSigilClient", () => {
 
     const client = createSigilClient(makeConfig());
     expect(client).toBeNull();
+  });
+
+  it("wires generationSanitizer when redaction is enabled", () => {
+    createSigilClient(makeConfig());
+
+    expect(createSecretRedactionSanitizerMock).toHaveBeenCalledTimes(1);
+    expect(createSecretRedactionSanitizerMock).toHaveBeenCalledWith({
+      redactInputMessages: true,
+      redactEmailAddresses: true,
+    });
+    expect(SigilClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({ generationSanitizer: SANITIZER }),
+    );
+  });
+
+  it("forwards redaction sub-flags to the sanitizer factory", () => {
+    createSigilClient(
+      makeConfig({
+        redaction: {
+          enabled: true,
+          redactInputMessages: false,
+          redactEmailAddresses: false,
+        },
+      }),
+    );
+
+    expect(createSecretRedactionSanitizerMock).toHaveBeenCalledWith({
+      redactInputMessages: false,
+      redactEmailAddresses: false,
+    });
+  });
+
+  it("omits generationSanitizer when redaction is disabled", () => {
+    createSigilClient(
+      makeConfig({
+        redaction: {
+          enabled: false,
+          redactInputMessages: true,
+          redactEmailAddresses: true,
+        },
+      }),
+    );
+
+    expect(createSecretRedactionSanitizerMock).not.toHaveBeenCalled();
+    expect(SigilClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({ generationSanitizer: undefined }),
+    );
   });
 });

--- a/plugins/pi/src/client.ts
+++ b/plugins/pi/src/client.ts
@@ -1,5 +1,8 @@
 import type { GenerationExportConfig } from "@grafana/sigil-sdk-js";
-import { SigilClient } from "@grafana/sigil-sdk-js";
+import {
+  createSecretRedactionSanitizer,
+  SigilClient,
+} from "@grafana/sigil-sdk-js";
 import type { Meter, Tracer } from "@opentelemetry/api";
 import type { SigilAuthConfig, SigilPiConfig } from "./config.js";
 
@@ -22,6 +25,12 @@ export function createSigilClient(
       contentCapture: config.contentCapture,
       ...(options?.tracer ? { tracer: options.tracer } : {}),
       ...(options?.meter ? { meter: options.meter } : {}),
+      generationSanitizer: config.redaction.enabled
+        ? createSecretRedactionSanitizer({
+            redactInputMessages: config.redaction.redactInputMessages,
+            redactEmailAddresses: config.redaction.redactEmailAddresses,
+          })
+        : undefined,
     });
   } catch (err) {
     console.warn("[sigil-pi] failed to create SigilClient:", err);

--- a/plugins/pi/src/config.test.ts
+++ b/plugins/pi/src/config.test.ts
@@ -334,6 +334,104 @@ describe("resolveConfig otlp", () => {
   });
 });
 
+describe("resolveConfig redaction", () => {
+  beforeEach(clearEnv);
+  afterEach(clearEnv);
+
+  it("defaults all redaction knobs to true when file omits the block", () => {
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+    });
+    expect(cfg?.redaction).toEqual({
+      enabled: true,
+      redactInputMessages: true,
+      redactEmailAddresses: true,
+    });
+  });
+
+  it("file-level redaction.enabled = false disables it", () => {
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      redaction: { enabled: false },
+    });
+    expect(cfg?.redaction.enabled).toBe(false);
+    // partial override preserves the rest as defaults
+    expect(cfg?.redaction.redactInputMessages).toBe(true);
+    expect(cfg?.redaction.redactEmailAddresses).toBe(true);
+  });
+
+  it("partial file override preserves other defaults", () => {
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      redaction: { redactEmailAddresses: false },
+    });
+    expect(cfg?.redaction).toEqual({
+      enabled: true,
+      redactInputMessages: true,
+      redactEmailAddresses: false,
+    });
+  });
+
+  it("env vars override file values (truthy aliases)", () => {
+    process.env.SIGIL_PI_REDACTION_ENABLED = "1";
+    process.env.SIGIL_PI_REDACT_INPUT_MESSAGES = "true";
+    process.env.SIGIL_PI_REDACT_EMAIL_ADDRESSES = "yes";
+
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      redaction: {
+        enabled: false,
+        redactInputMessages: false,
+        redactEmailAddresses: false,
+      },
+    });
+
+    expect(cfg?.redaction).toEqual({
+      enabled: true,
+      redactInputMessages: true,
+      redactEmailAddresses: true,
+    });
+  });
+
+  it("env vars override file values (falsy aliases)", () => {
+    process.env.SIGIL_PI_REDACTION_ENABLED = "0";
+    process.env.SIGIL_PI_REDACT_INPUT_MESSAGES = "false";
+    process.env.SIGIL_PI_REDACT_EMAIL_ADDRESSES = "off";
+
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      redaction: {
+        enabled: true,
+        redactInputMessages: true,
+        redactEmailAddresses: true,
+      },
+    });
+
+    expect(cfg?.redaction).toEqual({
+      enabled: false,
+      redactInputMessages: false,
+      redactEmailAddresses: false,
+    });
+  });
+
+  it("accepts 'on' as truthy alias", () => {
+    process.env.SIGIL_PI_REDACTION_ENABLED = "on";
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      redaction: { enabled: false },
+    });
+    expect(cfg?.redaction.enabled).toBe(true);
+  });
+
+  it("accepts 'no' as falsy alias", () => {
+    process.env.SIGIL_PI_REDACT_INPUT_MESSAGES = "no";
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+    });
+    expect(cfg?.redaction.redactInputMessages).toBe(false);
+  });
+});
+
 describe("resolveEnvVars", () => {
   beforeEach(clearEnv);
   afterEach(clearEnv);

--- a/plugins/pi/src/config.ts
+++ b/plugins/pi/src/config.ts
@@ -14,6 +14,12 @@ export interface OtlpConfig {
   headers: Record<string, string>;
 }
 
+export interface RedactionConfig {
+  enabled: boolean;
+  redactInputMessages: boolean;
+  redactEmailAddresses: boolean;
+}
+
 export interface SigilPiConfig {
   endpoint: string;
   auth: SigilAuthConfig;
@@ -22,6 +28,7 @@ export interface SigilPiConfig {
   contentCapture: ContentCaptureMode;
   debug: boolean;
   otlp?: OtlpConfig;
+  redaction: RedactionConfig;
 }
 
 const CONFIG_PATH = join(homedir(), ".config", "sigil-pi", "config.json");
@@ -74,6 +81,7 @@ export function resolveConfig(
   const debug = envBool("SIGIL_PI_DEBUG") ?? toBool(file.debug) ?? false;
 
   const otlp = resolveOtlp(file);
+  const redaction = resolveRedaction(file);
 
   return {
     endpoint,
@@ -83,7 +91,29 @@ export function resolveConfig(
     contentCapture,
     debug,
     otlp,
+    redaction,
   };
+}
+
+function resolveRedaction(file: Record<string, unknown>): RedactionConfig {
+  const redactionObj = (file.redaction ?? {}) as Record<string, unknown>;
+
+  const enabled =
+    envBool("SIGIL_PI_REDACTION_ENABLED") ??
+    toBool(redactionObj.enabled) ??
+    true;
+
+  const redactInputMessages =
+    envBool("SIGIL_PI_REDACT_INPUT_MESSAGES") ??
+    toBool(redactionObj.redactInputMessages) ??
+    true;
+
+  const redactEmailAddresses =
+    envBool("SIGIL_PI_REDACT_EMAIL_ADDRESSES") ??
+    toBool(redactionObj.redactEmailAddresses) ??
+    true;
+
+  return { enabled, redactInputMessages, redactEmailAddresses };
 }
 
 function resolveOtlp(file: Record<string, unknown>): OtlpConfig | undefined {


### PR DESCRIPTION
Wire the JS SDK's secret redaction sanitizer into the Pi plugin so generation payloads can be scrubbed of input messages and email addresses before ingest. Redaction is on by default and configurable via config file or SIGIL_PI_REDACTION_* env vars.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches generation export behavior by modifying payload content via redaction; misconfiguration or sanitizer behavior changes could unexpectedly remove data reviewers expect to ingest.
> 
> **Overview**
> **Pi now scrubs secrets/PII before exporting generations** by wiring the Sigil SDK’s `createSecretRedactionSanitizer` into `createSigilClient` as `generationSanitizer` (enabled by default, removable via config).
> 
> Adds a new `redaction` config block with `enabled`, `redactInputMessages`, and `redactEmailAddresses`, supports `SIGIL_PI_REDACTION_*` env overrides, and updates tests and README to cover defaults/overrides and the new knobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 742f82d3354731857d69d5069a70fac76f09eb6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->