### PR TITLE
fix(sdk-go): resolve auth headers in EvaluateHook

### DIFF
--- a/go/sigil/hooks.go
+++ b/go/sigil/hooks.go
@@ -209,7 +209,11 @@ func (c *Client) EvaluateHook(ctx context.Context, req HookEvaluateRequest) (*Ho
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set(hookTimeoutHeader, strconv.FormatInt(timeout.Milliseconds(), 10))
-	for key, value := range c.config.GenerationExport.Headers {
+	resolvedHeaders, err := resolveHeadersWithAuth(c.config.GenerationExport.Headers, c.config.GenerationExport.Auth)
+	if err != nil {
+		return failOpenOrError(failOpen, fmt.Errorf("%w: resolve auth headers: %v", ErrHookTransportFailed, err))
+	}
+	for key, value := range resolvedHeaders {
 		httpReq.Header.Set(key, value)
 	}
 


### PR DESCRIPTION
## Summary

- Fix missing X-Scope-OrgID header in hook evaluation requests
- Use resolveHeadersWithAuth to properly resolve auth configuration

## Details

The `EvaluateHook` function was only copying raw `Headers` from the config but not resolving the `AuthConfig` to set the `X-Scope-OrgID` header. This caused hook requests to be sent without the tenant ID, making server-side rule matching fail (rules are tenant-scoped).

This change uses `resolveHeadersWithAuth` to properly resolve auth configuration, matching the behavior of the generation export code path.

## Test plan

- [x] Manual testing with assistant preflight hooks
- [ ] Unit test for header resolution in EvaluateHook

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes how hook evaluation HTTP headers are constructed, aligning them with existing auth/header resolution logic; potential impact is limited to hook request authentication/tenant routing.
> 
> **Overview**
> Hook evaluation requests (`Client.EvaluateHook`) now resolve configured headers via `resolveHeadersWithAuth(...)` instead of sending raw `GenerationExport.Headers`, ensuring auth-derived headers (e.g., tenant/`X-Scope-OrgID` and `Authorization`) are included.
> 
> If header/auth resolution fails, the request now follows the existing hook *fail-open vs. error* behavior by returning allow or surfacing `ErrHookTransportFailed` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0954731380d135d2bb20f607aa32b64c4a87f8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->