### PR TITLE
docs: clarify tool call vs tool execution concepts

### DIFF
--- a/docs/concepts/tool-call-vs-tool-execution.md
+++ b/docs/concepts/tool-call-vs-tool-execution.md
@@ -1,0 +1,124 @@
+# Tool Calls vs Tool Executions
+
+Sigil distinguishes between two related but distinct concepts when instrumenting tool usage in AI agents. Understanding this distinction helps you choose the right instrumentation approach.
+
+## Overview
+
+| Concept | What It Represents | Where It Appears | SDK Method |
+|---------|-------------------|------------------|------------|
+| **Tool Call** | The LLM's request to invoke a tool | Part of generation output messages | `MessagePart.toolCall(...)` |
+| **Tool Execution** | Your code actually running the tool | Separate OTel span | `startToolExecution(...)` |
+
+## Tool Call (Message Part)
+
+A **tool call** is what the LLM outputs when it decides it wants to use a tool. It's part of the generation's message content—the model's **request** to invoke a tool.
+
+```java
+// Tool call appears in the generation output
+Message output = new Message()
+    .setRole(MessageRole.ASSISTANT)
+    .setParts(List.of(
+        MessagePart.toolCall(new ToolCall()
+            .setId("call_abc123")
+            .setName("weather")
+            .setInputJson("{\"city\":\"Paris\"}".getBytes()))
+    ));
+```
+
+In the Sigil UI:
+- Shows as **"Call weather"** in the conversation view
+- Input/output content is visible because it's stored in the generation payload
+- **Not** listed in the Tools tab (it's embedded in the generation)
+
+## Tool Execution (Span)
+
+A **tool execution** is when your application code actually runs the tool. It creates a separate OTel span that tracks timing, errors, and optionally captures arguments/results.
+
+```java
+// Tool execution is your code running
+try (ToolExecutionRecorder rec = client.startToolExecution(
+        new ToolExecutionStart()
+            .setToolName("weather")
+            .setToolCallId("call_abc123"))) {
+    
+    String result = weatherService.getWeather("Paris");
+    rec.setResult(result);
+}
+```
+
+In the Sigil UI:
+- Shows as **"Tool execute_tool weather"** in the flow view
+- Listed in the Tools tab with timing metrics
+- Attributes visible in span details
+
+## When to Use Each
+
+### Use Tool Calls When...
+
+You're recording what the LLM requested as part of its generation output. Provider wrappers (OpenAI, Anthropic, etc.) handle this automatically when the model returns tool_use/function_call in its response.
+
+### Use Tool Executions When...
+
+You're instrumenting **your code** that runs in response to a tool call, or any tool-like operation that isn't an LLM-requested tool. Examples:
+
+- **Agent tool handlers** — wrap your tool implementation code
+- **RAG retrieval steps** — document lookups before generating a response
+- **External service calls** — database queries, API calls made by the agent
+- **Custom agent actions** — any function your agent framework executes
+
+```java
+// RAG retrieval example: your code, not an LLM-requested tool
+try (ToolExecutionRecorder rec = client.startToolExecution(
+        new ToolExecutionStart()
+            .setToolName("document_retriever")
+            .setToolDescription("Retrieves relevant documents for context"))) {
+    
+    List<Document> docs = vectorStore.similaritySearch(query, 5);
+    rec.setResult(Map.of(
+        "count", docs.size(),
+        "source", "knowledge_base"
+    ));
+}
+```
+
+## Linking Tool Calls to Executions
+
+When your tool execution corresponds to a specific LLM tool call, set `toolCallId` to correlate them:
+
+```java
+// LLM outputs a tool call with id "call_abc123"
+// Your code executes it:
+try (ToolExecutionRecorder rec = client.startToolExecution(
+        new ToolExecutionStart()
+            .setToolName("weather")
+            .setToolCallId("call_abc123"))) {  // Links to the tool call
+    // ...
+}
+```
+
+This allows Sigil to correlate the model's request with your execution timing.
+
+## Capturing Arguments and Results
+
+By default, tool execution spans capture timing but not content. To capture arguments and results, enable content capture:
+
+```java
+try (ToolExecutionRecorder rec = client.startToolExecution(
+        new ToolExecutionStart()
+            .setToolName("document_retriever")
+            .setContentCapture(ContentCaptureMode.FULL_CONTENT))) {
+    
+    rec.setArguments(Map.of("query", searchQuery, "limit", 5));
+    List<Document> docs = vectorStore.similaritySearch(searchQuery, 5);
+    rec.setResult(Map.of("count", docs.size(), "ids", docs.stream().map(Document::getId).toList()));
+}
+```
+
+With content capture enabled, arguments appear as `gen_ai.tool.call.arguments` and results as `gen_ai.tool.call.result` in span attributes.
+
+## Summary
+
+- **Tool Call**: Model's intent, part of generation messages, shows input/output in conversation view
+- **Tool Execution**: Your code's runtime, separate span, shows in Tools tab with timing metrics
+
+For most agent instrumentation, you'll use both: provider wrappers capture tool calls automatically, and you add tool executions around your handler code that processes those calls.

--- a/java/README.md
+++ b/java/README.md
@@ -35,7 +35,7 @@ The Java SDK records normalized generation payloads, correlates them with traces
 - `startStreamingGeneration(start)`
 - `withGeneration(start, fn)`
 - `withStreamingGeneration(start, fn)`
-- `startToolExecution(start)`
+- `startToolExecution(start)` — see [Tool Calls vs Tool Executions](../docs/concepts/tool-call-vs-tool-execution.md)
 - `withToolExecution(start, fn)`
 - `flush()` and `shutdown()`
 
@@ -88,6 +88,40 @@ AutoConfiguredOpenTelemetrySdk.initialize();
 ## Streaming Pattern
 
 Use `startStreamingGeneration(...)` or `withStreamingGeneration(...)`. The SDK sets mode to `STREAM` and keeps operation naming consistent.
+
+## Tool Execution Observability
+
+Use `startToolExecution(...)` / `withToolExecution(...)` to instrument your tool handler code. This is distinct from **tool calls** (what the LLM requests) which are captured automatically by provider wrappers as part of generation output.
+
+```java
+// Instrument your tool handler
+try (ToolExecutionRecorder rec = client.startToolExecution(
+        new ToolExecutionStart()
+            .setToolName("weather")
+            .setToolCallId("call_abc123"))) {  // Optional: links to LLM's tool_call
+    
+    String result = weatherService.getWeather("Paris");
+    rec.setResult(result);
+}
+```
+
+Tool executions create OTel spans (`execute_tool <name>`) and appear in the Sigil Tools tab with timing metrics.
+
+For RAG retrieval or other preprocessing steps, use tool execution even though there's no corresponding LLM tool call:
+
+```java
+try (ToolExecutionRecorder rec = client.startToolExecution(
+        new ToolExecutionStart()
+            .setToolName("document_retriever")
+            .setContentCapture(ContentCaptureMode.FULL_CONTENT))) {
+    
+    rec.setArguments(Map.of("query", searchQuery, "limit", 5));
+    List<Document> docs = vectorStore.similaritySearch(searchQuery, 5);
+    rec.setResult(Map.of("count", docs.size()));
+}
+```
+
+See [Tool Calls vs Tool Executions](../docs/concepts/tool-call-vs-tool-execution.md) for the full conceptual guide.
 
 ## Embedding Observability
 


### PR DESCRIPTION
## Summary

- Add documentation explaining the distinction between tool calls (LLM's request, message part) and tool executions (your code running, separate span)
- Update Java README with tool execution section and practical examples

## Context

Users were confused about when to use `startToolExecution` vs recording `tool_call` message parts, and why they appear differently in the Sigil UI:

- **Tool calls** show in conversation view with input/output content visible
- **Tool executions** show in Tools tab with timing metrics

The new concepts doc clarifies:
- When to use each approach
- How to link them via `toolCallId`
- How to enable content capture for tool executions
- Practical examples like sentinel classifiers and preprocessing steps

## Test plan

- [x] Documentation renders correctly in GitHub
- [x] Links between docs are valid

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (new doc and README updates) with no runtime or API behavior impact.
> 
> **Overview**
> Adds a new concepts guide, `docs/concepts/tool-call-vs-tool-execution.md`, explaining the difference between **tool calls** (LLM-requested `MessagePart.toolCall(...)` captured in generation output) and **tool executions** (your code’s `startToolExecution(...)` spans), including UI expectations, linking via `toolCallId`, and optional argument/result content capture.
> 
> Updates `java/README.md` to reference the new guide from the Recording API list and adds a dedicated **Tool Execution Observability** section with practical examples (handler instrumentation and RAG retrieval) to reduce confusion about when each mechanism applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d695a1185eb7462460a3f949f9647149a6f0a972. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->