### PR TITLE
fix(plugins/pi): use sessionId as conversation id

### DIFF
--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -63,8 +63,29 @@ class FakePi {
 const defaultCtx = {
   sessionManager: {
     getSessionFile: () => "session-1",
+    getSessionId: () => "sess-default-id",
   },
 };
+
+function makeCtx({
+  sessionFile,
+  sessionId,
+}: {
+  sessionFile?: string | (() => string | undefined);
+  sessionId: string | (() => string);
+}) {
+  const fileFn =
+    typeof sessionFile === "function"
+      ? sessionFile
+      : () => sessionFile ?? "session-1";
+  const idFn = typeof sessionId === "function" ? sessionId : () => sessionId;
+  return {
+    sessionManager: {
+      getSessionFile: fileFn,
+      getSessionId: idFn,
+    },
+  };
+}
 
 function assistantMessage() {
   return {
@@ -387,6 +408,194 @@ describe("extension lifecycle", () => {
       expect.stringContaining("did not validate"),
     );
     warn.mockRestore();
+  });
+
+  it("uses sessionId, not file basename, as conversationId", async () => {
+    // Two distinct pi sessions whose session files share a basename
+    // (e.g. extensions that spawn child sessions under <root>/run-N/session.jsonl)
+    // must emit distinct conversationIds.
+    const seeds: Array<{ conversationId?: string }> = [];
+    const recorder = { setResult: vi.fn(), setCallError: vi.fn() };
+    const sigil: SigilLike = {
+      startGeneration: vi.fn(async (seed, run) => {
+        seeds.push(seed as { conversationId?: string });
+        await run(recorder);
+      }),
+      startToolExecution: vi.fn(() => ({
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        end: vi.fn(),
+        getError: vi.fn(),
+      })),
+      shutdown: vi.fn(async () => {}),
+    };
+
+    loadConfigMock.mockResolvedValue({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      auth: { mode: "none" },
+      agentName: "pi",
+      contentCapture: "metadata_only",
+    });
+    createSigilClientMock.mockReturnValue(sigil);
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+
+    // Session 1: filename basename === "session.jsonl", uuid AAA
+    const ctxA = makeCtx({
+      sessionFile: "/tmp/runs/run-0/session.jsonl",
+      sessionId: "019dd89e-ffad-76ae-9f80-454acd646039",
+    });
+    await pi.emit("session_start", {}, ctxA);
+    await pi.emit("turn_start", {}, ctxA);
+    await pi.emit(
+      "turn_end",
+      {
+        message: assistantMessage(),
+        toolResults: [],
+      },
+      ctxA,
+    );
+    await pi.emit("session_shutdown", {}, ctxA);
+
+    // Session 2: same basename, different uuid BBB
+    const ctxB = makeCtx({
+      sessionFile: "/tmp/runs/run-1/session.jsonl",
+      sessionId: "019de579-98b4-7619-9157-8a6a4f61d487",
+    });
+    await pi.emit("session_start", {}, ctxB);
+    await pi.emit("turn_start", {}, ctxB);
+    await pi.emit(
+      "turn_end",
+      {
+        message: assistantMessage(),
+        toolResults: [],
+      },
+      ctxB,
+    );
+
+    expect(seeds).toHaveLength(2);
+    expect(seeds[0]!.conversationId).toBe(
+      "019dd89e-ffad-76ae-9f80-454acd646039",
+    );
+    expect(seeds[1]!.conversationId).toBe(
+      "019de579-98b4-7619-9157-8a6a4f61d487",
+    );
+    expect(seeds[0]!.conversationId).not.toBe(seeds[1]!.conversationId);
+  });
+
+  it("refreshes conversationId per turn when sessionId changes mid-life", async () => {
+    // SessionManager reassigns this.sessionId on fork/branch
+    // (session-manager.js:927,961). The plugin must observe the current
+    // sessionId at every turn_end, not just at session_start.
+    const seeds: Array<{ conversationId?: string }> = [];
+    const recorder = { setResult: vi.fn(), setCallError: vi.fn() };
+    const sigil: SigilLike = {
+      startGeneration: vi.fn(async (seed, run) => {
+        seeds.push(seed as { conversationId?: string });
+        await run(recorder);
+      }),
+      startToolExecution: vi.fn(() => ({
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        end: vi.fn(),
+        getError: vi.fn(),
+      })),
+      shutdown: vi.fn(async () => {}),
+    };
+
+    loadConfigMock.mockResolvedValue({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      auth: { mode: "none" },
+      agentName: "pi",
+      contentCapture: "metadata_only",
+    });
+    createSigilClientMock.mockReturnValue(sigil);
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+
+    let currentId = "id-before-fork";
+    const ctx = makeCtx({
+      sessionFile: "/tmp/sess/session.jsonl",
+      sessionId: () => currentId,
+    });
+
+    await pi.emit("session_start", {}, ctx);
+    await pi.emit("turn_start", {}, ctx);
+    await pi.emit(
+      "turn_end",
+      {
+        message: assistantMessage(),
+        toolResults: [],
+      },
+      ctx,
+    );
+
+    // Simulate fork/branch: sessionManager swaps sessionId.
+    currentId = "id-after-fork";
+
+    await pi.emit("turn_start", {}, ctx);
+    await pi.emit(
+      "turn_end",
+      {
+        message: assistantMessage(),
+        toolResults: [],
+      },
+      ctx,
+    );
+
+    expect(seeds).toHaveLength(2);
+    expect(seeds[0]!.conversationId).toBe("id-before-fork");
+    expect(seeds[1]!.conversationId).toBe("id-after-fork");
+  });
+
+  it("yields undefined conversationId when sessionId is empty (no-session mode)", async () => {
+    // session-manager.js:430 initializes sessionId to "" before newSession()
+    // runs, and --no-session never assigns one. We must not emit a literal
+    // empty string as the conversationId.
+    let capturedSeed: { conversationId?: string } | undefined;
+    const recorder = { setResult: vi.fn(), setCallError: vi.fn() };
+    const sigil: SigilLike = {
+      startGeneration: vi.fn(async (seed, run) => {
+        capturedSeed = seed as { conversationId?: string };
+        await run(recorder);
+      }),
+      startToolExecution: vi.fn(() => ({
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        end: vi.fn(),
+        getError: vi.fn(),
+      })),
+      shutdown: vi.fn(async () => {}),
+    };
+
+    loadConfigMock.mockResolvedValue({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      auth: { mode: "none" },
+      agentName: "pi",
+      contentCapture: "metadata_only",
+    });
+    createSigilClientMock.mockReturnValue(sigil);
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+
+    const ctx = makeCtx({ sessionFile: undefined, sessionId: "" });
+
+    await pi.emit("session_start", {}, ctx);
+    await pi.emit("turn_start", {}, ctx);
+    await pi.emit(
+      "turn_end",
+      {
+        message: assistantMessage(),
+        toolResults: [],
+      },
+      ctx,
+    );
+
+    expect(capturedSeed).toBeDefined();
+    expect(capturedSeed!.conversationId).toBeUndefined();
   });
 });
 

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { basename, dirname, join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type {
   ContentCaptureMode,
@@ -59,7 +59,6 @@ export default function (pi: ExtensionAPI) {
   let telemetry: TelemetryProviders | null = null;
 
   let turnStartTime = 0;
-  let conversationId: string | undefined;
 
   function debugLog(msg: string) {
     if (config?.debug) console.error(`[sigil-pi] ${msg}`);
@@ -85,7 +84,6 @@ export default function (pi: ExtensionAPI) {
 
   async function resetSessionState() {
     config = null;
-    conversationId = undefined;
     if (telemetry) {
       try {
         await telemetry.shutdown();
@@ -98,7 +96,7 @@ export default function (pi: ExtensionAPI) {
     pendingInputMessages.length = 0;
   }
 
-  pi.on("session_start", async (_event, ctx) => {
+  pi.on("session_start", async (_event, _ctx) => {
     try {
       if (sigil) {
         try {
@@ -117,8 +115,11 @@ export default function (pi: ExtensionAPI) {
       if (!config.agentVersion) {
         config = { ...config, agentVersion: detectPiVersion() };
       }
-      const sessionFile = ctx.sessionManager.getSessionFile();
-      conversationId = sessionFile ? basename(sessionFile) : undefined;
+
+      // Note: conversationId is read fresh per turn from
+      // ctx.sessionManager.getSessionId() so fork/branch reassignments
+      // (session-manager.js:927,961) are reflected without restarting
+      // the plugin. We intentionally do NOT cache it here.
 
       // Set up OTel providers if OTLP is configured
       if (config.otlp) {
@@ -197,7 +198,7 @@ export default function (pi: ExtensionAPI) {
     }
   });
 
-  pi.on("turn_end", async (event, _ctx) => {
+  pi.on("turn_end", async (event, ctx) => {
     if (!sigil || !config) return;
 
     try {
@@ -211,6 +212,14 @@ export default function (pi: ExtensionAPI) {
       const msg = event.message;
       const contentCapture = config.contentCapture;
       const toolDefs = mapToolNames(turnToolTimings);
+
+      // Read the current sessionId every turn. SessionManager reassigns
+      // sessionId on fork/branch, and extensions that spawn child sessions
+      // can share a literal filename (e.g. "session.jsonl") across runs —
+      // so file-path-derived ids collapse multiple sessions into one.
+      // getSessionId() is the stable unique identifier
+      // (session-manager.d.ts: ReadonlySessionManager).
+      const conversationId = ctx.sessionManager.getSessionId() || undefined;
 
       // Ensure startedAt <= completedAt (msg.timestamp). The provider sets
       // msg.timestamp via Date.now() when creating the message object, which


### PR DESCRIPTION
The plugin was deriving conversationId from basename(sessionFile), which is not unique: any caller that hands pi a session file with the same filename (different directories) collapses every session into one Sigil conversation. The result is a single big conversation that aggregates calls and tokens across unrelated runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `conversationId` is computed for Sigil exports, which affects conversation aggregation and telemetry grouping across sessions (including forks). Scoped to the pi Sigil plugin and covered by new unit tests, but wrong IDs could impact downstream observability/data attribution.
> 
> **Overview**
> Fixes Sigil export seeding to use `ctx.sessionManager.getSessionId()` (read *each* `turn_end`) as `conversationId` instead of deriving it from the session file basename, avoiding collisions across runs and reflecting fork/branch sessionId changes.
> 
> Adds targeted lifecycle tests to ensure distinct sessionIds yield distinct conversationIds, mid-session sessionId changes are picked up per turn, and empty sessionIds result in `conversationId` being omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93b84dd9e1520f94dce5b863b394b1d02f56451c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->