### PR TITLE
feat(sdk): canonical SIGIL_* env-var schema in Java and .NET clients

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -254,6 +254,42 @@ The SDK emits these OTel histograms through your configured OTel meter provider:
 - `gen_ai.client.time_to_first_token`
 - `gen_ai.client.tool_calls_per_operation`
 
+## Environment variables
+
+The SDK reads canonical `SIGIL_*` env vars at client construction. Caller-supplied
+fields on `SigilClientConfig` win; env vars fill anything left at the default;
+SDK schema defaults fill the rest.
+
+| Env var | Field |
+| --- | --- |
+| `SIGIL_ENDPOINT` | `GenerationExportConfig.Endpoint` |
+| `SIGIL_PROTOCOL` | `GenerationExportConfig.Protocol` (`http`/`grpc`/`none`) |
+| `SIGIL_INSECURE` | `GenerationExportConfig.Insecure` (tri-state `bool?`) |
+| `SIGIL_HEADERS` | `GenerationExportConfig.Headers` (CSV: `K=V,...`) |
+| `SIGIL_AUTH_MODE` | `AuthConfig.Mode` (`none`/`tenant`/`bearer`/`basic`) |
+| `SIGIL_AUTH_TENANT_ID` | `AuthConfig.TenantId` |
+| `SIGIL_AUTH_TOKEN` | `AuthConfig.BearerToken` and/or `BasicPassword` (filled when empty) |
+| `SIGIL_AGENT_NAME` | `SigilClientConfig.AgentName` |
+| `SIGIL_AGENT_VERSION` | `SigilClientConfig.AgentVersion` |
+| `SIGIL_USER_ID` | `SigilClientConfig.UserId` |
+| `SIGIL_TAGS` | `SigilClientConfig.Tags` (CSV merged under per-call tags) |
+| `SIGIL_CONTENT_CAPTURE_MODE` | `SigilClientConfig.ContentCapture` |
+| `SIGIL_DEBUG` | `SigilClientConfig.Debug` (tri-state `bool?`) |
+
+Use `EnvConfig.FromEnv()` to inspect the resolved config without constructing a
+client. Invalid values (bad auth mode, etc.) are skipped with a warning so a
+single typo does not discard the rest of the env layer.
+
+## Breaking changes (unreleased)
+
+- `GenerationExportConfig.Insecure` is now `bool?` instead of `bool`. The
+  default flips from `true` to `false` (TLS on) when neither caller nor
+  `SIGIL_INSECURE` provides a value. Code that reads the property as a plain
+  `bool` needs to coalesce (e.g. `cfg.Insecure ?? false`).
+- `ConfigResolver.ResolveHeadersWithAuth` no longer rejects mode-irrelevant
+  fields (e.g. `TenantId` set under `Mode = Bearer`). This matches Go/JS/Python
+  and lets env layering populate any field independently of mode.
+
 ## Local tasks
 
 Run from repository root:

--- a/dotnet/src/Grafana.Sigil/Config.cs
+++ b/dotnet/src/Grafana.Sigil/Config.cs
@@ -17,7 +17,13 @@ public enum ExportAuthMode
 
 public sealed class AuthConfig
 {
-    public ExportAuthMode Mode { get; set; } = ExportAuthMode.None;
+    /// <summary>
+    /// Auth mode. <c>null</c> means "not set" — the env layer or
+    /// <c>ConfigResolver</c> resolves it to <see cref="ExportAuthMode.None"/>.
+    /// Explicit <c>Mode = ExportAuthMode.None</c> is preserved (caller-wins)
+    /// and not overridden by <c>SIGIL_AUTH_MODE</c>.
+    /// </summary>
+    public ExportAuthMode? Mode { get; set; }
     public string TenantId { get; set; } = string.Empty;
     public string BearerToken { get; set; } = string.Empty;
     /// <summary>Username for basic auth. When empty, TenantId is used.</summary>
@@ -28,11 +34,31 @@ public sealed class AuthConfig
 
 public sealed class GenerationExportConfig
 {
-    public GenerationExportProtocol Protocol { get; set; } = GenerationExportProtocol.Grpc;
-    public string Endpoint { get; set; } = "localhost:4317";
+    /// <summary>
+    /// Export protocol. <c>null</c> means "not set" — the env layer or
+    /// <c>ConfigResolver</c> resolves it to
+    /// <see cref="GenerationExportProtocol.Grpc"/>. An explicit
+    /// <c>Protocol = ...</c> assignment is preserved (caller-wins) and not
+    /// overridden by <c>SIGIL_PROTOCOL</c>.
+    /// </summary>
+    public GenerationExportProtocol? Protocol { get; set; }
+    /// <summary>
+    /// Export endpoint. Empty string means "not set" — env layer or
+    /// <c>ConfigResolver</c> resolves it to <c>localhost:4317</c>. An explicit
+    /// non-empty value is preserved (caller-wins) and not overridden by
+    /// <c>SIGIL_ENDPOINT</c>.
+    /// </summary>
+    public string Endpoint { get; set; } = "";
     public Dictionary<string, string> Headers { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     public AuthConfig Auth { get; set; } = new();
-    public bool Insecure { get; set; } = true;
+
+    /// <summary>
+    /// Tri-state insecure flag. <c>null</c> means "not set" — the resolved
+    /// value is <c>false</c> (TLS on) unless <c>SIGIL_INSECURE</c> provides a
+    /// value or the caller explicitly sets one. Matches Go's <c>*bool</c>
+    /// semantics so explicit <c>false</c> overrides <c>SIGIL_INSECURE=true</c>.
+    /// </summary>
+    public bool? Insecure { get; set; }
     public int BatchSize { get; set; } = 100;
     public TimeSpan FlushInterval { get; set; } = TimeSpan.FromSeconds(1);
     public int QueueSize { get; set; } = 2000;
@@ -58,6 +84,48 @@ public sealed class SigilClientConfig
     public Func<DateTimeOffset>? UtcNow { get; set; }
     public Func<TimeSpan, CancellationToken, Task>? SleepAsync { get; set; }
     public IGenerationExporter? GenerationExporter { get; set; }
+
+    /// <summary>
+    /// Default <c>gen_ai.agent.name</c> for generations that don't supply one
+    /// per-call. Filled from <c>SIGIL_AGENT_NAME</c> when the caller leaves
+    /// this empty.
+    /// </summary>
+    public string AgentName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Default <c>gen_ai.agent.version</c>. Filled from <c>SIGIL_AGENT_VERSION</c>.
+    /// </summary>
+    public string AgentVersion { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Default <c>user.id</c>. Filled from <c>SIGIL_USER_ID</c>.
+    /// </summary>
+    public string UserId { get; set; } = string.Empty;
+
+    private Dictionary<string, string> _tags = new();
+
+    /// <summary>
+    /// Tags merged into every <see cref="GenerationStart"/>'s tags. Per-call
+    /// tags win on key collision. Filled from <c>SIGIL_TAGS</c>.
+    /// </summary>
+    /// <remarks>
+    /// The setter takes a defensive copy so caller-side mutations after
+    /// assignment cannot reach the SDK. The getter returns the live
+    /// internal map so the env resolver and client code can populate it.
+    /// </remarks>
+    public Dictionary<string, string> Tags
+    {
+        get => _tags;
+        set => _tags = value == null ? new Dictionary<string, string>() : new Dictionary<string, string>(value);
+    }
+
+    /// <summary>
+    /// Tri-state debug flag mirroring Go's <c>*bool</c>. <c>null</c> means
+    /// "not set" — filled from <c>SIGIL_DEBUG</c> when the caller hasn't
+    /// supplied a value. Explicit <c>false</c> overrides
+    /// <c>SIGIL_DEBUG=true</c>.
+    /// </summary>
+    public bool? Debug { get; set; }
 }
 
 public sealed class EmbeddingCaptureConfig
@@ -74,9 +142,20 @@ internal static class ConfigResolver
 
     public static SigilClientConfig Resolve(SigilClientConfig? config)
     {
-        var resolved = config ?? new SigilClientConfig();
+        return Resolve(config, Environment.GetEnvironmentVariable);
+    }
 
+    internal static SigilClientConfig Resolve(SigilClientConfig? config, Func<string, string?> envLookup)
+    {
+        var (resolved, warnings) = EnvConfig.ResolveFromEnv(envLookup, config ?? new SigilClientConfig());
+
+        var callerLogger = resolved.Logger;
         resolved.Logger ??= _ => { };
+        // Always surface env-resolve warnings to stderr so a typo in
+        // SIGIL_AUTH_MODE / SIGIL_PROTOCOL / SIGIL_CONTENT_CAPTURE_MODE has
+        // operator-visible signal even when the caller didn't supply a Logger.
+        // When the caller provided a Logger, route warnings through it as well.
+        EnvConfig.LogWarnings(callerLogger ?? Console.Error.WriteLine, warnings);
 
 #if NET8_0_OR_GREATER
         resolved.UtcNow ??= TimeProvider.System.GetUtcNow;
@@ -85,6 +164,9 @@ internal static class ConfigResolver
 #endif
 
         resolved.SleepAsync ??= static (delay, ct) => Task.Delay(delay, ct);
+
+        // After env layering, null Insecure resolves to false (TLS on).
+        resolved.GenerationExport.Insecure ??= false;
 
         resolved.GenerationExport.Headers = ResolveHeadersWithAuth(
             resolved.GenerationExport.Headers,
@@ -140,6 +222,14 @@ internal static class ConfigResolver
         return resolved;
     }
 
+    /// <summary>
+    /// Builds the auth-related headers for <paramref name="auth"/>.Mode.
+    /// Mode-irrelevant fields (e.g. <c>TenantId</c> on a bearer-mode config)
+    /// are silently ignored — env layering can populate any field independently
+    /// of mode, and rejecting cross-mode mixes only forced extra cleanup
+    /// upstream. Callers who want strict validation should check their
+    /// <see cref="AuthConfig"/> before constructing the client.
+    /// </summary>
     public static Dictionary<string, string> ResolveHeadersWithAuth(
         Dictionary<string, string> headers,
         AuthConfig auth,
@@ -151,25 +241,16 @@ internal static class ConfigResolver
         var tenantId = auth.TenantId?.Trim() ?? string.Empty;
         var bearerToken = auth.BearerToken?.Trim() ?? string.Empty;
 
-        switch (auth.Mode)
+        // Default null Mode to None so direct callers (without ConfigResolver)
+        // get the same fallback behavior as env-resolved configs.
+        switch (auth.Mode ?? ExportAuthMode.None)
         {
             case ExportAuthMode.None:
-                var noneBasicUser = auth.BasicUser?.Trim() ?? string.Empty;
-                var noneBasicPassword = auth.BasicPassword?.Trim() ?? string.Empty;
-                if (tenantId.Length > 0 || bearerToken.Length > 0 || noneBasicUser.Length > 0 || noneBasicPassword.Length > 0)
-                {
-                    throw new ArgumentException($"{label} auth mode 'none' does not allow credentials");
-                }
                 return resolved;
             case ExportAuthMode.Tenant:
                 if (tenantId.Length == 0)
                 {
                     throw new ArgumentException($"{label} auth mode 'tenant' requires tenant_id");
-                }
-
-                if (bearerToken.Length > 0)
-                {
-                    throw new ArgumentException($"{label} auth mode 'tenant' does not allow bearer_token");
                 }
 
                 if (!resolved.ContainsKey(TenantHeaderName))
@@ -182,11 +263,6 @@ internal static class ConfigResolver
                 if (bearerToken.Length == 0)
                 {
                     throw new ArgumentException($"{label} auth mode 'bearer' requires bearer_token");
-                }
-
-                if (tenantId.Length > 0)
-                {
-                    throw new ArgumentException($"{label} auth mode 'bearer' does not allow tenant_id");
                 }
 
                 if (!resolved.ContainsKey(AuthorizationHeaderName))

--- a/dotnet/src/Grafana.Sigil/EnvConfig.cs
+++ b/dotnet/src/Grafana.Sigil/EnvConfig.cs
@@ -1,0 +1,351 @@
+namespace Grafana.Sigil;
+
+/// <summary>
+/// Reads canonical <c>SIGIL_*</c> environment variables and layers them under
+/// caller-supplied <see cref="SigilClientConfig"/> values.
+/// </summary>
+/// <remarks>
+/// <para>Resolution order (highest precedence first):</para>
+/// <list type="number">
+///   <item><description>Caller-supplied <see cref="SigilClientConfig"/> field
+///       (when not at its default/unset state).</description></item>
+///   <item><description>Canonical <c>SIGIL_*</c> env var.</description></item>
+///   <item><description>SDK schema default.</description></item>
+/// </list>
+/// <para>Mirrors the Go reference implementation in
+/// <c>go/sigil/env.go</c>. Invalid env values are skipped with a warning so
+/// a single typo does not discard the rest of the env layer.</para>
+/// </remarks>
+public static class EnvConfig
+{
+    public const string EnvEndpoint = "SIGIL_ENDPOINT";
+    public const string EnvProtocol = "SIGIL_PROTOCOL";
+    public const string EnvInsecure = "SIGIL_INSECURE";
+    public const string EnvHeaders = "SIGIL_HEADERS";
+    public const string EnvAuthMode = "SIGIL_AUTH_MODE";
+    public const string EnvAuthTenantId = "SIGIL_AUTH_TENANT_ID";
+    public const string EnvAuthToken = "SIGIL_AUTH_TOKEN";
+    public const string EnvAgentName = "SIGIL_AGENT_NAME";
+    public const string EnvAgentVersion = "SIGIL_AGENT_VERSION";
+    public const string EnvUserId = "SIGIL_USER_ID";
+    public const string EnvTags = "SIGIL_TAGS";
+    public const string EnvContentCaptureMode = "SIGIL_CONTENT_CAPTURE_MODE";
+    public const string EnvDebug = "SIGIL_DEBUG";
+
+    internal const string DefaultEndpoint = "localhost:4317";
+
+    /// <summary>
+    /// Returns a config built from process env vars layered onto a fresh
+    /// <see cref="SigilClientConfig"/>. Convenience helper; most callers should
+    /// let <see cref="SigilClient"/> construction perform the same resolution
+    /// internally. Warnings for invalid env values are written to stderr.
+    /// </summary>
+    public static SigilClientConfig FromEnv()
+    {
+        var (cfg, warnings) = ResolveFromEnv(Environment.GetEnvironmentVariable, new SigilClientConfig());
+        LogWarnings(Console.Error.WriteLine, warnings);
+        return cfg;
+    }
+
+    /// <summary>
+    /// Applies canonical <c>SIGIL_*</c> env values onto <paramref name="base"/>,
+    /// preserving caller-supplied fields. Mutates <paramref name="base"/> in
+    /// place to match the existing <c>ConfigResolver.Resolve</c> semantics so
+    /// callers can read back resolved auth headers and other normalised fields
+    /// from the config object they supplied.
+    /// </summary>
+    /// <returns>
+    /// Tuple of the resolved config (same reference as <paramref name="base"/>)
+    /// and a list of warnings emitted for invalid env values (e.g. unknown
+    /// <c>SIGIL_AUTH_MODE</c>).
+    /// </returns>
+    internal static (SigilClientConfig config, IReadOnlyList<string> warnings) ResolveFromEnv(
+        Func<string, string?> lookup,
+        SigilClientConfig @base
+    )
+    {
+        var src = lookup ?? Environment.GetEnvironmentVariable;
+        var cfg = @base ?? new SigilClientConfig();
+        EnsureNonNullNested(cfg);
+        var warnings = new List<string>();
+
+        var export = cfg.GenerationExport;
+
+        var endpoint = EnvTrimmed(src, EnvEndpoint);
+        if (endpoint != null && string.IsNullOrEmpty(export.Endpoint))
+        {
+            export.Endpoint = endpoint;
+        }
+
+        var protocol = EnvTrimmed(src, EnvProtocol);
+        if (protocol != null && export.Protocol == null)
+        {
+            var parsed = ParseProtocol(protocol);
+            if (parsed.HasValue)
+            {
+                export.Protocol = parsed.Value;
+            }
+            else
+            {
+                warnings.Add($"sigil: ignoring invalid {EnvProtocol} {protocol}");
+            }
+        }
+
+        var insecureRaw = EnvTrimmed(src, EnvInsecure);
+        if (insecureRaw != null && export.Insecure == null)
+        {
+            export.Insecure = ParseBool(insecureRaw);
+        }
+
+        var headersRaw = EnvTrimmed(src, EnvHeaders);
+        if (headersRaw != null && (export.Headers == null || export.Headers.Count == 0))
+        {
+            // Headers are HTTP-style and case-insensitive at the consumer; the
+            // env-derived map mirrors that. Built element-by-element so case-mixed
+            // duplicates (x-a=1,X-A=2) collapse to last-wins instead of throwing.
+            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kv in ParseCsvKv(headersRaw))
+            {
+                headers[kv.Key] = kv.Value;
+            }
+            export.Headers = headers;
+        }
+
+        var auth = export.Auth ??= new AuthConfig();
+        var authModeRaw = EnvTrimmed(src, EnvAuthMode);
+        if (authModeRaw != null && auth.Mode == null)
+        {
+            var parsed = ParseAuthMode(authModeRaw);
+            if (parsed.HasValue)
+            {
+                auth.Mode = parsed.Value;
+            }
+            else
+            {
+                warnings.Add($"sigil: ignoring invalid {EnvAuthMode} {authModeRaw}");
+            }
+        }
+
+        var tenantId = EnvTrimmed(src, EnvAuthTenantId);
+        if (tenantId != null && string.IsNullOrEmpty(auth.TenantId))
+        {
+            auth.TenantId = tenantId;
+        }
+
+        var token = EnvTrimmed(src, EnvAuthToken);
+        if (token != null)
+        {
+            // Set both fields when empty; ResolveHeadersWithAuth uses only the
+            // one matching the final mode. Lets env's token populate a
+            // caller-set mode without env declaring SIGIL_AUTH_MODE.
+            if (string.IsNullOrEmpty(auth.BearerToken))
+            {
+                auth.BearerToken = token;
+            }
+            if (string.IsNullOrEmpty(auth.BasicPassword))
+            {
+                auth.BasicPassword = token;
+            }
+        }
+        if (auth.Mode == ExportAuthMode.Basic
+            && string.IsNullOrEmpty(auth.BasicUser)
+            && !string.IsNullOrEmpty(auth.TenantId))
+        {
+            auth.BasicUser = auth.TenantId;
+        }
+
+        // Finalize tri-state defaults after env layering: null/empty means
+        // "no caller value and no env value", so apply the schema default.
+        export.Protocol ??= GenerationExportProtocol.Grpc;
+        if (string.IsNullOrEmpty(export.Endpoint))
+        {
+            export.Endpoint = DefaultEndpoint;
+        }
+        auth.Mode ??= ExportAuthMode.None;
+
+        var agentName = EnvTrimmed(src, EnvAgentName);
+        if (agentName != null && string.IsNullOrEmpty(cfg.AgentName))
+        {
+            cfg.AgentName = agentName;
+        }
+        var agentVersion = EnvTrimmed(src, EnvAgentVersion);
+        if (agentVersion != null && string.IsNullOrEmpty(cfg.AgentVersion))
+        {
+            cfg.AgentVersion = agentVersion;
+        }
+        var userId = EnvTrimmed(src, EnvUserId);
+        if (userId != null && string.IsNullOrEmpty(cfg.UserId))
+        {
+            cfg.UserId = userId;
+        }
+
+        var tagsRaw = EnvTrimmed(src, EnvTags);
+        if (tagsRaw != null)
+        {
+            var envTags = ParseCsvKv(tagsRaw);
+            // Env tags act as a base layer; caller tags win on collision.
+            var merged = new Dictionary<string, string>(envTags);
+            if (cfg.Tags != null)
+            {
+                foreach (var kv in cfg.Tags)
+                {
+                    merged[kv.Key] = kv.Value;
+                }
+            }
+            cfg.Tags = merged;
+        }
+
+        var ccmRaw = EnvTrimmed(src, EnvContentCaptureMode);
+        if (ccmRaw != null && cfg.ContentCapture == ContentCaptureMode.Default)
+        {
+            var parsed = ParseContentCaptureMode(ccmRaw);
+            if (parsed.HasValue)
+            {
+                cfg.ContentCapture = parsed.Value;
+            }
+            else
+            {
+                warnings.Add($"sigil: ignoring invalid {EnvContentCaptureMode} {ccmRaw}");
+            }
+        }
+
+        var debugRaw = EnvTrimmed(src, EnvDebug);
+        if (debugRaw != null && cfg.Debug == null)
+        {
+            cfg.Debug = ParseBool(debugRaw);
+        }
+
+        return (cfg, warnings);
+    }
+
+    private static void EnsureNonNullNested(SigilClientConfig cfg)
+    {
+        cfg.Api ??= new ApiConfig();
+        cfg.GenerationExport ??= new GenerationExportConfig();
+        cfg.GenerationExport.Auth ??= new AuthConfig();
+        cfg.GenerationExport.Headers ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        cfg.Tags ??= new Dictionary<string, string>();
+    }
+
+    internal static string? EnvTrimmed(Func<string, string?> lookup, string key)
+    {
+        string? raw;
+        try
+        {
+            raw = lookup(key);
+        }
+        catch (System.Security.SecurityException)
+        {
+            return null;
+        }
+        if (raw == null)
+        {
+            return null;
+        }
+        var v = raw.Trim();
+        return v.Length == 0 ? null : v;
+    }
+
+    internal static bool ParseBool(string? raw)
+    {
+        if (raw == null)
+        {
+            return false;
+        }
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "1" or "true" or "yes" or "on" => true,
+            _ => false,
+        };
+    }
+
+    internal static Dictionary<string, string> ParseCsvKv(string? raw)
+    {
+        // Case-sensitive to match Go/Java: SIGIL_TAGS=env=prod,Env=staging
+        // yields two distinct keys. Headers consumers wrap the result in an
+        // OrdinalIgnoreCase dictionary at the use site.
+        var out_ = new Dictionary<string, string>();
+        if (raw == null)
+        {
+            return out_;
+        }
+        foreach (var part in raw.Split(','))
+        {
+            var trimmed = part.Trim();
+            if (trimmed.Length == 0)
+            {
+                continue;
+            }
+            var idx = trimmed.IndexOf('=');
+            if (idx <= 0)
+            {
+                continue;
+            }
+            var key = trimmed.Substring(0, idx).Trim();
+            var value = trimmed.Substring(idx + 1).Trim();
+            if (key.Length > 0)
+            {
+                out_[key] = value;
+            }
+        }
+        return out_;
+    }
+
+    internal static ContentCaptureMode? ParseContentCaptureMode(string? raw)
+    {
+        if (raw == null)
+        {
+            return null;
+        }
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "full" => ContentCaptureMode.Full,
+            "no_tool_content" => ContentCaptureMode.NoToolContent,
+            "metadata_only" => ContentCaptureMode.MetadataOnly,
+            _ => null,
+        };
+    }
+
+    internal static ExportAuthMode? ParseAuthMode(string? raw)
+    {
+        if (raw == null)
+        {
+            return null;
+        }
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "none" => ExportAuthMode.None,
+            "tenant" => ExportAuthMode.Tenant,
+            "bearer" => ExportAuthMode.Bearer,
+            "basic" => ExportAuthMode.Basic,
+            _ => null,
+        };
+    }
+
+    internal static GenerationExportProtocol? ParseProtocol(string? raw)
+    {
+        if (raw == null)
+        {
+            return null;
+        }
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "grpc" => GenerationExportProtocol.Grpc,
+            "http" => GenerationExportProtocol.Http,
+            "none" => GenerationExportProtocol.None,
+            _ => null,
+        };
+    }
+
+    internal static void LogWarnings(Action<string>? log, IReadOnlyList<string> warnings)
+    {
+        if (log == null || warnings == null)
+        {
+            return;
+        }
+        foreach (var w in warnings)
+        {
+            log(w);
+        }
+    }
+}

--- a/dotnet/src/Grafana.Sigil/SigilClient.cs
+++ b/dotnet/src/Grafana.Sigil/SigilClient.cs
@@ -143,7 +143,7 @@ public sealed partial class SigilClient : IAsyncDisposable
         _embeddingCapture = InternalUtils.DeepClone(_config.EmbeddingCapture);
 
         _generationExporter = _config.GenerationExporter
-            ?? _config.GenerationExport.Protocol switch
+            ?? _config.GenerationExport.Protocol!.Value switch
             {
                 GenerationExportProtocol.Http => new HttpGenerationExporter(
                     _config.GenerationExport.Endpoint,
@@ -151,7 +151,7 @@ public sealed partial class SigilClient : IAsyncDisposable
                 ),
                 GenerationExportProtocol.Grpc => new GrpcGenerationExporter(
                     _config.GenerationExport.Endpoint,
-                    _config.GenerationExport.Insecure,
+                    _config.GenerationExport.Insecure!.Value,
                     _config.GenerationExport.Headers
                 ),
                 GenerationExportProtocol.None => new NoopGenerationExporter(),
@@ -199,10 +199,18 @@ public sealed partial class SigilClient : IAsyncDisposable
         {
             seed.AgentName = SigilContext.AgentNameFromContext() ?? string.Empty;
         }
+        if (string.IsNullOrWhiteSpace(seed.AgentName))
+        {
+            seed.AgentName = _config.AgentName ?? string.Empty;
+        }
 
         if (string.IsNullOrWhiteSpace(seed.AgentVersion))
         {
             seed.AgentVersion = SigilContext.AgentVersionFromContext() ?? string.Empty;
+        }
+        if (string.IsNullOrWhiteSpace(seed.AgentVersion))
+        {
+            seed.AgentVersion = _config.AgentVersion ?? string.Empty;
         }
 
         seed.StartedAt = seed.StartedAt.HasValue
@@ -251,10 +259,18 @@ public sealed partial class SigilClient : IAsyncDisposable
         {
             seed.AgentName = SigilContext.AgentNameFromContext() ?? string.Empty;
         }
+        if (string.IsNullOrWhiteSpace(seed.AgentName))
+        {
+            seed.AgentName = _config.AgentName ?? string.Empty;
+        }
 
         if (string.IsNullOrWhiteSpace(seed.AgentVersion))
         {
             seed.AgentVersion = SigilContext.AgentVersionFromContext() ?? string.Empty;
+        }
+        if (string.IsNullOrWhiteSpace(seed.AgentVersion))
+        {
+            seed.AgentVersion = _config.AgentVersion ?? string.Empty;
         }
 
         seed.StartedAt = seed.StartedAt.HasValue
@@ -337,7 +353,7 @@ public sealed partial class SigilClient : IAsyncDisposable
 
         var endpoint = BuildConversationRatingEndpoint(
             _config.Api.Endpoint,
-            _config.GenerationExport.Insecure,
+            _config.GenerationExport.Insecure!.Value,
             normalizedConversationId
         );
 
@@ -504,15 +520,33 @@ public sealed partial class SigilClient : IAsyncDisposable
         {
             seed.UserId = SigilContext.UserIdFromContext() ?? string.Empty;
         }
+        if (string.IsNullOrWhiteSpace(seed.UserId))
+        {
+            seed.UserId = _config.UserId ?? string.Empty;
+        }
 
         if (string.IsNullOrWhiteSpace(seed.AgentName))
         {
             seed.AgentName = SigilContext.AgentNameFromContext() ?? string.Empty;
         }
+        if (string.IsNullOrWhiteSpace(seed.AgentName))
+        {
+            seed.AgentName = _config.AgentName ?? string.Empty;
+        }
 
         if (string.IsNullOrWhiteSpace(seed.AgentVersion))
         {
             seed.AgentVersion = SigilContext.AgentVersionFromContext() ?? string.Empty;
+        }
+        if (string.IsNullOrWhiteSpace(seed.AgentVersion))
+        {
+            seed.AgentVersion = _config.AgentVersion ?? string.Empty;
+        }
+
+        // Merge config-default tags as a base layer; per-call seed tags win.
+        if (_config.Tags != null && _config.Tags.Count > 0)
+        {
+            seed.Tags = MergeTagsConfigUnderSeed(_config.Tags, seed.Tags);
         }
 
         seed.StartedAt = seed.StartedAt.HasValue
@@ -2051,6 +2085,33 @@ public sealed partial class SigilClient : IAsyncDisposable
                 part.ToolResult.ContentJson = [];
             }
         }
+    }
+
+    /// <summary>
+    /// Merges config-default tags under per-call seed tags. Seed entries win
+    /// on key collision so per-call generation tags always take precedence
+    /// over env-derived defaults (matches Go's <c>client.go:71-73</c> contract).
+    /// Returns a fresh dictionary so later mutations do not reach the client
+    /// config.
+    /// </summary>
+    internal static Dictionary<string, string> MergeTagsConfigUnderSeed(
+        IReadOnlyDictionary<string, string> configTags,
+        IReadOnlyDictionary<string, string>? seedTags
+    )
+    {
+        var merged = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var pair in configTags)
+        {
+            merged[pair.Key] = pair.Value;
+        }
+        if (seedTags != null)
+        {
+            foreach (var pair in seedTags)
+            {
+                merged[pair.Key] = pair.Value;
+            }
+        }
+        return merged;
     }
 }
 

--- a/dotnet/tests/Grafana.Sigil.Anthropic.Tests/AssemblyInfo.cs
+++ b/dotnet/tests/Grafana.Sigil.Anthropic.Tests/AssemblyInfo.cs
@@ -1,7 +1,4 @@
 using System.Runtime.CompilerServices;
-using Xunit;
-
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
 
 internal static class TestEnvCleanup
 {
@@ -9,9 +6,7 @@ internal static class TestEnvCleanup
     internal static void ClearSigilEnvVars()
     {
         // Clear canonical SIGIL_* env vars so individual tests don't pick up
-        // developer-machine config when they construct a SigilClient. Tests
-        // that exercise env layering should pass an explicit lookup to
-        // EnvConfig.ResolveFromEnv.
+        // developer-machine config when they construct a SigilClient.
         string[] keys =
         {
             "SIGIL_ENDPOINT",

--- a/dotnet/tests/Grafana.Sigil.Gemini.Tests/AssemblyInfo.cs
+++ b/dotnet/tests/Grafana.Sigil.Gemini.Tests/AssemblyInfo.cs
@@ -1,7 +1,4 @@
 using System.Runtime.CompilerServices;
-using Xunit;
-
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
 
 internal static class TestEnvCleanup
 {
@@ -9,9 +6,7 @@ internal static class TestEnvCleanup
     internal static void ClearSigilEnvVars()
     {
         // Clear canonical SIGIL_* env vars so individual tests don't pick up
-        // developer-machine config when they construct a SigilClient. Tests
-        // that exercise env layering should pass an explicit lookup to
-        // EnvConfig.ResolveFromEnv.
+        // developer-machine config when they construct a SigilClient.
         string[] keys =
         {
             "SIGIL_ENDPOINT",

--- a/dotnet/tests/Grafana.Sigil.OpenAI.Tests/AssemblyInfo.cs
+++ b/dotnet/tests/Grafana.Sigil.OpenAI.Tests/AssemblyInfo.cs
@@ -1,7 +1,4 @@
 using System.Runtime.CompilerServices;
-using Xunit;
-
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
 
 internal static class TestEnvCleanup
 {
@@ -9,9 +6,7 @@ internal static class TestEnvCleanup
     internal static void ClearSigilEnvVars()
     {
         // Clear canonical SIGIL_* env vars so individual tests don't pick up
-        // developer-machine config when they construct a SigilClient. Tests
-        // that exercise env layering should pass an explicit lookup to
-        // EnvConfig.ResolveFromEnv.
+        // developer-machine config when they construct a SigilClient.
         string[] keys =
         {
             "SIGIL_ENDPOINT",

--- a/dotnet/tests/Grafana.Sigil.Tests/AuthConfigTests.cs
+++ b/dotnet/tests/Grafana.Sigil.Tests/AuthConfigTests.cs
@@ -25,51 +25,9 @@ public sealed class AuthConfigTests
             {
                 new AuthConfig
                 {
-                    Mode = ExportAuthMode.None,
-                    TenantId = "tenant-a",
-                },
-                "generation auth mode 'none' does not allow credentials"
-            },
-            {
-                new AuthConfig
-                {
-                    Mode = ExportAuthMode.Tenant,
-                    TenantId = "tenant-a",
-                    BearerToken = "token",
-                },
-                "generation auth mode 'tenant' does not allow bearer_token"
-            },
-            {
-                new AuthConfig
-                {
-                    Mode = ExportAuthMode.Bearer,
-                    TenantId = "tenant-a",
-                    BearerToken = "token",
-                },
-                "generation auth mode 'bearer' does not allow tenant_id"
-            },
-            {
-                new AuthConfig
-                {
                     Mode = (ExportAuthMode)99,
                 },
                 "unsupported generation auth mode"
-            },
-            {
-                new AuthConfig
-                {
-                    Mode = ExportAuthMode.None,
-                    BasicUser = "user",
-                },
-                "generation auth mode 'none' does not allow credentials"
-            },
-            {
-                new AuthConfig
-                {
-                    Mode = ExportAuthMode.None,
-                    BasicPassword = "secret",
-                },
-                "generation auth mode 'none' does not allow credentials"
             },
             {
                 new AuthConfig
@@ -87,6 +45,44 @@ public sealed class AuthConfigTests
                 "generation auth mode 'basic' requires basic_user or tenant_id"
             },
         };
+
+    [Fact]
+    public void ModeNoneIgnoresIrrelevantCredentialFields()
+    {
+        // env layering can populate cross-mode fields without explicit SIGIL_AUTH_MODE.
+        var auth = new AuthConfig
+        {
+            Mode = ExportAuthMode.None,
+            TenantId = "42",
+            BearerToken = "tok",
+            BasicUser = "user",
+            BasicPassword = "pass",
+        };
+        var headers = ConfigResolver.ResolveHeadersWithAuth(
+            new Dictionary<string, string>(),
+            auth,
+            "generation"
+        );
+        Assert.Empty(headers);
+    }
+
+    [Fact]
+    public void ModeBearerIgnoresIrrelevantTenantField()
+    {
+        var auth = new AuthConfig
+        {
+            Mode = ExportAuthMode.Bearer,
+            BearerToken = "tok",
+            TenantId = "42",
+        };
+        var headers = ConfigResolver.ResolveHeadersWithAuth(
+            new Dictionary<string, string>(),
+            auth,
+            "generation"
+        );
+        Assert.Equal("Bearer tok", headers["Authorization"]);
+        Assert.False(headers.ContainsKey("X-Scope-OrgID"));
+    }
 
     [Theory]
 #pragma warning disable xUnit1044 // Avoid using TheoryData type arguments that are not serializable

--- a/dotnet/tests/Grafana.Sigil.Tests/EnvConfigTests.cs
+++ b/dotnet/tests/Grafana.Sigil.Tests/EnvConfigTests.cs
@@ -1,0 +1,334 @@
+using Xunit;
+
+namespace Grafana.Sigil.Tests;
+
+public sealed class EnvConfigTests
+{
+    private static Func<string, string?> MapLookup(IDictionary<string, string?> env)
+    {
+        return key => env.TryGetValue(key, out var value) ? value : null;
+    }
+
+    private static Func<string, string?> EmptyLookup => _ => null;
+
+    [Fact]
+    public void NoEnvKeepsBaseDefaults()
+    {
+        var (cfg, warnings) = EnvConfig.ResolveFromEnv(EmptyLookup, new SigilClientConfig());
+
+        Assert.Equal(string.Empty, cfg.AgentName);
+        Assert.Equal(string.Empty, cfg.AgentVersion);
+        Assert.Equal(string.Empty, cfg.UserId);
+        Assert.Empty(cfg.Tags);
+        Assert.Null(cfg.Debug);
+        Assert.Null(cfg.GenerationExport.Insecure);
+        Assert.Equal("localhost:4317", cfg.GenerationExport.Endpoint);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void TransportFromEnv()
+    {
+        var env = new Dictionary<string, string?>
+        {
+            ["SIGIL_ENDPOINT"] = "https://env:4318",
+            ["SIGIL_PROTOCOL"] = "http",
+            ["SIGIL_INSECURE"] = "true",
+            ["SIGIL_HEADERS"] = "X-A=1,X-B=two",
+        };
+
+        var (cfg, _) = EnvConfig.ResolveFromEnv(MapLookup(env), new SigilClientConfig());
+
+        Assert.Equal("https://env:4318", cfg.GenerationExport.Endpoint);
+        Assert.Equal(GenerationExportProtocol.Http, cfg.GenerationExport.Protocol);
+        Assert.True(cfg.GenerationExport.Insecure);
+        Assert.Equal("1", cfg.GenerationExport.Headers["X-A"]);
+        Assert.Equal("two", cfg.GenerationExport.Headers["X-B"]);
+    }
+
+    [Fact]
+    public void BasicAuthFromEnv()
+    {
+        var env = new Dictionary<string, string?>
+        {
+            ["SIGIL_AUTH_MODE"] = "basic",
+            ["SIGIL_AUTH_TENANT_ID"] = "42",
+            ["SIGIL_AUTH_TOKEN"] = "glc_xxx",
+        };
+
+        var (cfg, _) = EnvConfig.ResolveFromEnv(MapLookup(env), new SigilClientConfig());
+        var auth = cfg.GenerationExport.Auth;
+
+        Assert.Equal(ExportAuthMode.Basic, auth.Mode);
+        Assert.Equal("42", auth.TenantId);
+        Assert.Equal("glc_xxx", auth.BasicPassword);
+        Assert.Equal("42", auth.BasicUser);
+    }
+
+    [Fact]
+    public void BearerAuthFromEnv()
+    {
+        var env = new Dictionary<string, string?>
+        {
+            ["SIGIL_AUTH_MODE"] = "bearer",
+            ["SIGIL_AUTH_TOKEN"] = "tok",
+        };
+
+        var (cfg, _) = EnvConfig.ResolveFromEnv(MapLookup(env), new SigilClientConfig());
+        var auth = cfg.GenerationExport.Auth;
+
+        Assert.Equal(ExportAuthMode.Bearer, auth.Mode);
+        Assert.Equal("tok", auth.BearerToken);
+    }
+
+    [Fact]
+    public void InvalidAuthModeWarnsAndPreservesOtherEnv()
+    {
+        var env = new Dictionary<string, string?>
+        {
+            ["SIGIL_AUTH_MODE"] = "Bearrer",
+            ["SIGIL_ENDPOINT"] = "valid.example:4318",
+            ["SIGIL_AGENT_NAME"] = "valid-agent",
+            ["SIGIL_USER_ID"] = "alice",
+        };
+
+        var (cfg, warnings) = EnvConfig.ResolveFromEnv(MapLookup(env), new SigilClientConfig());
+
+        Assert.Equal("valid.example:4318", cfg.GenerationExport.Endpoint);
+        Assert.Equal("valid-agent", cfg.AgentName);
+        Assert.Equal("alice", cfg.UserId);
+        Assert.Equal(ExportAuthMode.None, cfg.GenerationExport.Auth.Mode);
+        Assert.Contains(warnings, w => w.Contains("SIGIL_AUTH_MODE"));
+    }
+
+    [Fact]
+    public void InvalidContentCaptureModeWarnsAndPreservesOtherEnv()
+    {
+        var env = new Dictionary<string, string?>
+        {
+            ["SIGIL_CONTENT_CAPTURE_MODE"] = "bogus",
+            ["SIGIL_ENDPOINT"] = "valid.example:4318",
+        };
+
+        var (cfg, warnings) = EnvConfig.ResolveFromEnv(MapLookup(env), new SigilClientConfig());
+
+        Assert.Equal(ContentCaptureMode.Default, cfg.ContentCapture);
+        Assert.Equal("valid.example:4318", cfg.GenerationExport.Endpoint);
+        Assert.Contains(warnings, w => w.Contains("SIGIL_CONTENT_CAPTURE_MODE"));
+    }
+
+    [Fact]
+    public void InvalidContentCaptureModeKeepsCallerBaseValue()
+    {
+        var baseConfig = new SigilClientConfig { ContentCapture = ContentCaptureMode.MetadataOnly };
+        var env = new Dictionary<string, string?> { ["SIGIL_CONTENT_CAPTURE_MODE"] = "bogus" };
+
+        var (cfg, _) = EnvConfig.ResolveFromEnv(MapLookup(env), baseConfig);
+
+        Assert.Equal(ContentCaptureMode.MetadataOnly, cfg.ContentCapture);
+    }
+
+    [Fact]
+    public void ContentCaptureModeFromEnv()
+    {
+        var env = new Dictionary<string, string?> { ["SIGIL_CONTENT_CAPTURE_MODE"] = "metadata_only" };
+        var (cfg, _) = EnvConfig.ResolveFromEnv(MapLookup(env), new SigilClientConfig());
+        Assert.Equal(ContentCaptureMode.MetadataOnly, cfg.ContentCapture);
+    }
+
+    [Fact]
+    public void AgentUserTagsDebugFromEnv()
+    {
+        var env = new Dictionary<string, string?>
+        {
+            ["SIGIL_AGENT_NAME"] = "planner",
+            ["SIGIL_AGENT_VERSION"] = "1.2.3",
+            ["SIGIL_USER_ID"] = "alice@example.com",
+            ["SIGIL_TAGS"] = "service=orchestrator,env=prod",
+            ["SIGIL_DEBUG"] = "true",
+        };
+
+        var (cfg, _) = EnvConfig.ResolveFromEnv(MapLookup(env), new SigilClientConfig());
+
+        Assert.Equal("planner", cfg.AgentName);
+        Assert.Equal("1.2.3", cfg.AgentVersion);
+        Assert.Equal("alice@example.com", cfg.UserId);
+        Assert.Equal("orchestrator", cfg.Tags["service"]);
+        Assert.Equal("prod", cfg.Tags["env"]);
+        Assert.True(cfg.Debug);
+    }
+
+    [Fact]
+    public void WhitespaceOnlyValuesAreIgnored()
+    {
+        var env = new Dictionary<string, string?>
+        {
+            ["SIGIL_TAGS"] = "   ",
+            ["SIGIL_AGENT_NAME"] = "",
+            ["SIGIL_USER_ID"] = "\t \n",
+        };
+
+        var (cfg, _) = EnvConfig.ResolveFromEnv(MapLookup(env), new SigilClientConfig());
+
+        Assert.Empty(cfg.Tags);
+        Assert.Equal(string.Empty, cfg.AgentName);
+        Assert.Equal(string.Empty, cfg.UserId);
+    }
+
+    [Fact]
+    public void CallerEndpointWinsOverEnv()
+    {
+        var baseConfig = new SigilClientConfig();
+        baseConfig.GenerationExport.Endpoint = "https://caller-host";
+        var env = new Dictionary<string, string?> { ["SIGIL_ENDPOINT"] = "https://env-host" };
+
+        var (cfg, _) = EnvConfig.ResolveFromEnv(MapLookup(env), baseConfig);
+
+        Assert.Equal("https://caller-host", cfg.GenerationExport.Endpoint);
+    }
+
+    [Fact]
+    public void CallerInsecureFalseBeatsEnvTrue()
+    {
+        var baseConfig = new SigilClientConfig();
+        baseConfig.GenerationExport.Insecure = false;
+        var env = new Dictionary<string, string?> { ["SIGIL_INSECURE"] = "true" };
+
+        var (cfg, _) = EnvConfig.ResolveFromEnv(MapLookup(env), baseConfig);
+
+        Assert.False(cfg.GenerationExport.Insecure);
+    }
+
+    [Fact]
+    public void EnvInsecureTrueLayersUnderUnsetCaller()
+    {
+        var env = new Dictionary<string, string?> { ["SIGIL_INSECURE"] = "true" };
+        var (cfg, _) = EnvConfig.ResolveFromEnv(MapLookup(env), new SigilClientConfig());
+        Assert.True(cfg.GenerationExport.Insecure);
+    }
+
+    [Fact]
+    public void UnsetInsecureRemainsNull()
+    {
+        var (cfg, _) = EnvConfig.ResolveFromEnv(EmptyLookup, new SigilClientConfig());
+        Assert.Null(cfg.GenerationExport.Insecure);
+    }
+
+    [Fact]
+    public void AuthTokenFillsBothBearerAndBasicWhenEmpty()
+    {
+        var env = new Dictionary<string, string?> { ["SIGIL_AUTH_TOKEN"] = "secret" };
+        var (cfg, _) = EnvConfig.ResolveFromEnv(MapLookup(env), new SigilClientConfig());
+        var auth = cfg.GenerationExport.Auth;
+        Assert.Equal("secret", auth.BearerToken);
+        Assert.Equal("secret", auth.BasicPassword);
+    }
+
+    [Fact]
+    public void AuthTokenSkipsAlreadyFilledFields()
+    {
+        var baseConfig = new SigilClientConfig();
+        baseConfig.GenerationExport.Auth.BearerToken = "caller-bearer";
+        var env = new Dictionary<string, string?> { ["SIGIL_AUTH_TOKEN"] = "env-token" };
+
+        var (cfg, _) = EnvConfig.ResolveFromEnv(MapLookup(env), baseConfig);
+        var auth = cfg.GenerationExport.Auth;
+
+        Assert.Equal("caller-bearer", auth.BearerToken);
+        Assert.Equal("env-token", auth.BasicPassword);
+    }
+
+    [Fact]
+    public void BasicModeUsesTenantAsBasicUserFallback()
+    {
+        var env = new Dictionary<string, string?>
+        {
+            ["SIGIL_AUTH_MODE"] = "basic",
+            ["SIGIL_AUTH_TENANT_ID"] = "tenant-a",
+            ["SIGIL_AUTH_TOKEN"] = "secret",
+        };
+
+        var (cfg, _) = EnvConfig.ResolveFromEnv(MapLookup(env), new SigilClientConfig());
+        var auth = cfg.GenerationExport.Auth;
+
+        Assert.Equal(ExportAuthMode.Basic, auth.Mode);
+        Assert.Equal("tenant-a", auth.BasicUser);
+        Assert.Equal("secret", auth.BasicPassword);
+    }
+
+    [Fact]
+    public void StrayTenantIdKeepsModeNone()
+    {
+        var env = new Dictionary<string, string?> { ["SIGIL_AUTH_TENANT_ID"] = "42" };
+        var (cfg, _) = EnvConfig.ResolveFromEnv(MapLookup(env), new SigilClientConfig());
+        Assert.Equal(ExportAuthMode.None, cfg.GenerationExport.Auth.Mode);
+        Assert.Equal("42", cfg.GenerationExport.Auth.TenantId);
+    }
+
+    [Fact]
+    public void ParseCsvKvHandlesEdgeCases()
+    {
+        var result = EnvConfig.ParseCsvKv("a=1, b = two ,, =skip,c=");
+        Assert.Equal("1", result["a"]);
+        Assert.Equal("two", result["b"]);
+        Assert.Equal(string.Empty, result["c"]);
+        Assert.False(result.ContainsKey(""));
+        Assert.Equal(3, result.Count);
+    }
+
+    [Fact]
+    public void EnvTagsMergeUnderCallerTags()
+    {
+        var baseConfig = new SigilClientConfig
+        {
+            Tags = new Dictionary<string, string>
+            {
+                ["team"] = "ai",
+                ["env"] = "staging",
+            },
+        };
+        var env = new Dictionary<string, string?> { ["SIGIL_TAGS"] = "service=orch,env=prod" };
+
+        var (cfg, _) = EnvConfig.ResolveFromEnv(MapLookup(env), baseConfig);
+
+        Assert.Equal("orch", cfg.Tags["service"]);   // env-only fills
+        Assert.Equal("ai", cfg.Tags["team"]);        // caller-only preserved
+        Assert.Equal("staging", cfg.Tags["env"]);    // caller wins on collision
+    }
+
+    [Fact]
+    public void ParseBoolAcceptsCanonicalTrue()
+    {
+        Assert.True(EnvConfig.ParseBool("1"));
+        Assert.True(EnvConfig.ParseBool("true"));
+        Assert.True(EnvConfig.ParseBool("YES"));
+        Assert.True(EnvConfig.ParseBool("On"));
+        Assert.False(EnvConfig.ParseBool("0"));
+        Assert.False(EnvConfig.ParseBool("false"));
+        Assert.False(EnvConfig.ParseBool("garbage"));
+    }
+
+    [Fact]
+    public void FromEnvUsesProcessEnv()
+    {
+        // Smoke: just verify it doesn't throw and returns a config.
+        var cfg = EnvConfig.FromEnv();
+        Assert.NotNull(cfg);
+    }
+
+    [Fact]
+    public void ResolveMutatesBaseInPlace()
+    {
+        // .NET's ConfigResolver mutates in-place to preserve the existing
+        // contract where callers can read back the resolved Headers from the
+        // config object they supplied.
+        var baseConfig = new SigilClientConfig { AgentName = "base-agent" };
+        var env = new Dictionary<string, string?> { ["SIGIL_USER_ID"] = "alice" };
+
+        var (resolved, _) = EnvConfig.ResolveFromEnv(MapLookup(env), baseConfig);
+
+        Assert.Same(baseConfig, resolved);
+        Assert.Equal("alice", baseConfig.UserId);
+        Assert.Equal("base-agent", baseConfig.AgentName);
+    }
+}

--- a/dotnet/tests/Grafana.Sigil.Tests/EnvIntegrationTests.cs
+++ b/dotnet/tests/Grafana.Sigil.Tests/EnvIntegrationTests.cs
@@ -1,0 +1,163 @@
+using Xunit;
+
+namespace Grafana.Sigil.Tests;
+
+public sealed class EnvIntegrationTests
+{
+    private static GenerationStart MinimalStart()
+    {
+        return new GenerationStart
+        {
+            Id = "gen-1",
+            ConversationId = "conv-1",
+            Mode = GenerationMode.Sync,
+            OperationName = "chat",
+            Model = new ModelRef { Provider = "openai", Name = "gpt-4o" },
+        };
+    }
+
+    private static Generation BareResult()
+    {
+        return new Generation
+        {
+            Usage = new TokenUsage { InputTokens = 1, OutputTokens = 1 },
+            StopReason = "stop",
+        };
+    }
+
+    [Fact]
+    public void ResolveFromEnvFillsConfigDefaults()
+    {
+        var caller = new SigilClientConfig();
+        var env = new Dictionary<string, string?>
+        {
+            ["SIGIL_AGENT_NAME"] = "env-agent",
+            ["SIGIL_AGENT_VERSION"] = "1.2.3",
+            ["SIGIL_USER_ID"] = "user-1",
+            ["SIGIL_TAGS"] = "service=demo,team=ai",
+        };
+
+        var (resolved, _) = EnvConfig.ResolveFromEnv(k => env.TryGetValue(k, out var v) ? v : null, caller);
+
+        Assert.Equal("env-agent", resolved.AgentName);
+        Assert.Equal("1.2.3", resolved.AgentVersion);
+        Assert.Equal("user-1", resolved.UserId);
+        Assert.Equal("demo", resolved.Tags["service"]);
+        Assert.Equal("ai", resolved.Tags["team"]);
+    }
+
+    [Fact]
+    public void CallerConfigOverridesEnv()
+    {
+        var caller = new SigilClientConfig { AgentName = "caller-agent" };
+        var env = new Dictionary<string, string?> { ["SIGIL_AGENT_NAME"] = "env-agent" };
+
+        var (resolved, _) = EnvConfig.ResolveFromEnv(k => env.TryGetValue(k, out var v) ? v : null, caller);
+
+        Assert.Equal("caller-agent", resolved.AgentName);
+    }
+
+    [Fact]
+    public async Task PerCallSeedTagWinsOverConfigTag()
+    {
+        var exporter = new CapturingGenerationExporter();
+        var config = TestHelpers.TestConfig(exporter);
+        config.Tags["service"] = "demo";
+        config.Tags["team"] = "ai";
+
+        await using (var client = new SigilClient(config))
+        {
+            var start = MinimalStart();
+            start.Tags["team"] = "obs";
+            var rec = client.StartGeneration(start);
+            rec.SetResult(BareResult());
+            rec.End();
+            Assert.Null(rec.Error);
+            await client.FlushAsync(TestContext.Current.CancellationToken);
+        }
+
+        Assert.NotEmpty(exporter.Requests);
+        var captured = exporter.Requests[0].Generations[0];
+        Assert.Equal("demo", captured.Tags["service"]);
+        Assert.Equal("obs", captured.Tags["team"]);
+    }
+
+    [Fact]
+    public async Task ConfigIdentityFallsThroughToGenerationStart()
+    {
+        var exporter = new CapturingGenerationExporter();
+        var config = TestHelpers.TestConfig(exporter);
+        config.AgentName = "env-agent";
+        config.AgentVersion = "1.2.3";
+        config.UserId = "user-1";
+
+        await using (var client = new SigilClient(config))
+        {
+            var rec = client.StartGeneration(MinimalStart());
+            rec.SetResult(BareResult());
+            rec.End();
+            Assert.Null(rec.Error);
+            await client.FlushAsync(TestContext.Current.CancellationToken);
+        }
+
+        var captured = exporter.Requests[0].Generations[0];
+        Assert.Equal("env-agent", captured.AgentName);
+        Assert.Equal("1.2.3", captured.AgentVersion);
+        Assert.Equal("user-1", captured.UserId);
+    }
+
+    [Fact]
+    public async Task PerCallSeedIdentityOverridesConfigDefault()
+    {
+        var exporter = new CapturingGenerationExporter();
+        var config = TestHelpers.TestConfig(exporter);
+        config.AgentName = "env-agent";
+        config.UserId = "env-user";
+
+        await using (var client = new SigilClient(config))
+        {
+            var start = MinimalStart();
+            start.AgentName = "call-agent";
+            start.UserId = "call-user";
+            var rec = client.StartGeneration(start);
+            rec.SetResult(BareResult());
+            rec.End();
+            Assert.Null(rec.Error);
+            await client.FlushAsync(TestContext.Current.CancellationToken);
+        }
+
+        var captured = exporter.Requests[0].Generations[0];
+        Assert.Equal("call-agent", captured.AgentName);
+        Assert.Equal("call-user", captured.UserId);
+    }
+
+    [Fact]
+    public void ExplicitInsecureFalseBeatsEnvTrue()
+    {
+        var caller = new SigilClientConfig();
+        caller.GenerationExport.Insecure = false;
+        var env = new Dictionary<string, string?> { ["SIGIL_INSECURE"] = "true" };
+
+        var (resolved, _) = EnvConfig.ResolveFromEnv(k => env.TryGetValue(k, out var v) ? v : null, caller);
+
+        Assert.False(resolved.GenerationExport.Insecure);
+    }
+
+    [Fact]
+    public void NoEnvNoCallerInsecureResolvesToFalseAfterConfigResolver()
+    {
+        var caller = new SigilClientConfig();
+        var resolved = ConfigResolverTestHook.Resolve(caller, _ => null);
+        Assert.NotNull(resolved.GenerationExport.Insecure);
+        Assert.False(resolved.GenerationExport.Insecure!.Value);
+    }
+}
+
+internal static class ConfigResolverTestHook
+{
+    public static SigilClientConfig Resolve(SigilClientConfig? config, Func<string, string?> envLookup)
+    {
+        // Wrapper that goes through ConfigResolver.Resolve via internal access.
+        return ConfigResolver.Resolve(config, envLookup);
+    }
+}

--- a/java/README.md
+++ b/java/README.md
@@ -274,6 +274,45 @@ Framework helpers:
 
 - Google ADK: `frameworks/google-adk/README.md`
 
+## Environment variables
+
+The SDK reads canonical `SIGIL_*` env vars at client construction. Caller-supplied
+fields on `SigilClientConfig` win; env vars fill anything left at the default;
+SDK schema defaults fill the rest.
+
+| Env var | Field |
+| --- | --- |
+| `SIGIL_ENDPOINT` | `GenerationExportConfig.endpoint` |
+| `SIGIL_PROTOCOL` | `GenerationExportConfig.protocol` (`http`/`grpc`/`none`) |
+| `SIGIL_INSECURE` | `GenerationExportConfig.insecure` (tri-state) |
+| `SIGIL_HEADERS` | `GenerationExportConfig.headers` (CSV: `K=V,...`) |
+| `SIGIL_AUTH_MODE` | `AuthConfig.mode` (`none`/`tenant`/`bearer`/`basic`) |
+| `SIGIL_AUTH_TENANT_ID` | `AuthConfig.tenantId` |
+| `SIGIL_AUTH_TOKEN` | `AuthConfig.bearerToken` and/or `basicPassword` (filled when empty) |
+| `SIGIL_AGENT_NAME` | `SigilClientConfig.agentName` |
+| `SIGIL_AGENT_VERSION` | `SigilClientConfig.agentVersion` |
+| `SIGIL_USER_ID` | `SigilClientConfig.userId` |
+| `SIGIL_TAGS` | `SigilClientConfig.tags` (CSV merged under per-call tags) |
+| `SIGIL_CONTENT_CAPTURE_MODE` | `SigilClientConfig.contentCapture` |
+| `SIGIL_DEBUG` | `SigilClientConfig.debug` (tri-state) |
+
+Use `SigilEnvConfig.fromEnv()` to inspect the resolved config without
+constructing a client. Invalid values (bad auth mode, etc.) are skipped with a
+warning so a single typo does not discard the rest of the env layer.
+
+## Breaking changes (unreleased)
+
+- `GenerationExportConfig.insecure` is now tri-state (`Boolean` instead of
+  `boolean`). The default flips from `true` to `false` (TLS on) when neither
+  caller nor `SIGIL_INSECURE` provides a value. Existing callers that call
+  `setInsecure(true)` keep working through autoboxing. The previous
+  `isInsecure()` boolean accessor was replaced by `getInsecure()`
+  (returns `Boolean`) and `isInsecureResolved()` (returns `boolean`,
+  treats null as TLS on).
+- `AuthHeaders.resolve` no longer rejects mode-irrelevant fields (e.g.
+  `tenantId` set under `mode=BEARER`). This matches Go/JS/Python and lets env
+  layering populate any field independently of mode.
+
 ## Best Practices
 
 - Keep raw artifacts disabled in production unless actively debugging.

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -19,6 +19,23 @@ subprojects {
 
         tasks.withType<Test>().configureEach {
             useJUnitPlatform()
+            // Clear canonical SIGIL_* env vars so individual tests don't pick
+            // up developer-machine config when they construct a SigilClient.
+            // Tests that exercise env layering should pass an explicit lookup
+            // to SigilEnvConfig.resolveFromEnv.
+            environment("SIGIL_ENDPOINT", "")
+            environment("SIGIL_PROTOCOL", "")
+            environment("SIGIL_INSECURE", "")
+            environment("SIGIL_HEADERS", "")
+            environment("SIGIL_AUTH_MODE", "")
+            environment("SIGIL_AUTH_TENANT_ID", "")
+            environment("SIGIL_AUTH_TOKEN", "")
+            environment("SIGIL_AGENT_NAME", "")
+            environment("SIGIL_AGENT_VERSION", "")
+            environment("SIGIL_USER_ID", "")
+            environment("SIGIL_TAGS", "")
+            environment("SIGIL_CONTENT_CAPTURE_MODE", "")
+            environment("SIGIL_DEBUG", "")
         }
     }
 

--- a/java/core/src/main/java/com/grafana/sigil/sdk/AuthConfig.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/AuthConfig.java
@@ -2,7 +2,13 @@ package com.grafana.sigil.sdk;
 
 /** Per-export authentication settings. */
 public final class AuthConfig {
-    private AuthMode mode = AuthMode.NONE;
+    /**
+     * Auth mode. {@code null} means "not set" — the env layer or
+     * {@link AuthHeaders} resolves it to {@link AuthMode#NONE}. Explicit
+     * {@code setMode(AuthMode.NONE)} is preserved (caller-wins) and not
+     * overridden by {@code SIGIL_AUTH_MODE}.
+     */
+    private AuthMode mode;
     private String tenantId = "";
     private String bearerToken = "";
     private String basicUser = "";
@@ -13,7 +19,7 @@ public final class AuthConfig {
     }
 
     public AuthConfig setMode(AuthMode mode) {
-        this.mode = mode == null ? AuthMode.NONE : mode;
+        this.mode = mode;
         return this;
     }
 

--- a/java/core/src/main/java/com/grafana/sigil/sdk/AuthHeaders.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/AuthHeaders.java
@@ -12,6 +12,12 @@ final class AuthHeaders {
     private AuthHeaders() {
     }
 
+    /**
+     * Builds the auth-related headers for {@code auth.mode}. Mode-irrelevant
+     * fields (e.g. {@code tenantId} on a bearer-mode config) are silently
+     * ignored — env layering can populate any field independently of mode,
+     * and rejecting cross-mode mixes only forced extra cleanup upstream.
+     */
     static Map<String, String> resolve(Map<String, String> headers, AuthConfig auth, String label) {
         Map<String, String> out = new LinkedHashMap<>();
         if (headers != null) {
@@ -23,20 +29,12 @@ final class AuthHeaders {
         String bearer = auth == null ? "" : auth.getBearerToken().trim();
 
         if (mode == AuthMode.NONE) {
-            String basicUser = auth == null ? "" : auth.getBasicUser().trim();
-            String basicPassword = auth == null ? "" : auth.getBasicPassword().trim();
-            if (!tenantId.isEmpty() || !bearer.isEmpty() || !basicUser.isEmpty() || !basicPassword.isEmpty()) {
-                throw new IllegalArgumentException(label + " auth mode 'none' does not allow credentials");
-            }
             return out;
         }
 
         if (mode == AuthMode.TENANT) {
             if (tenantId.isEmpty()) {
                 throw new IllegalArgumentException(label + " auth mode 'tenant' requires tenantId");
-            }
-            if (!bearer.isEmpty()) {
-                throw new IllegalArgumentException(label + " auth mode 'tenant' does not allow bearerToken");
             }
             if (!hasHeader(out, TENANT_HEADER)) {
                 out.put(TENANT_HEADER, tenantId);
@@ -47,9 +45,6 @@ final class AuthHeaders {
         if (mode == AuthMode.BEARER) {
             if (bearer.isEmpty()) {
                 throw new IllegalArgumentException(label + " auth mode 'bearer' requires bearerToken");
-            }
-            if (!tenantId.isEmpty()) {
-                throw new IllegalArgumentException(label + " auth mode 'bearer' does not allow tenantId");
             }
             if (!hasHeader(out, AUTHORIZATION_HEADER)) {
                 out.put(AUTHORIZATION_HEADER, formatBearer(bearer));

--- a/java/core/src/main/java/com/grafana/sigil/sdk/GenerationExportConfig.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/GenerationExportConfig.java
@@ -6,11 +6,24 @@ import java.util.Map;
 
 /** Generation ingest export settings. */
 public final class GenerationExportConfig {
-    private GenerationExportProtocol protocol = GenerationExportProtocol.HTTP;
-    private String endpoint = "http://localhost:8080/api/v1/generations:export";
+    /**
+     * Export protocol. {@code null} means "not set" — env layer or
+     * {@link SigilClient} resolves it to {@link GenerationExportProtocol#HTTP}.
+     * An explicit {@code setProtocol(...)} call is preserved (caller-wins) and
+     * not overridden by {@code SIGIL_PROTOCOL}.
+     */
+    private GenerationExportProtocol protocol;
+    /**
+     * Export endpoint. Empty string means "not set" — env layer or
+     * {@link SigilClient} resolves it to
+     * {@code http://localhost:8080/api/v1/generations:export}. An explicit
+     * non-empty value is preserved (caller-wins) and not overridden by
+     * {@code SIGIL_ENDPOINT}.
+     */
+    private String endpoint = "";
     private final Map<String, String> headers = new LinkedHashMap<>();
     private AuthConfig auth = new AuthConfig();
-    private boolean insecure = true;
+    private Boolean insecure;
 
     private int batchSize = 100;
     private Duration flushInterval = Duration.ofSeconds(1);
@@ -25,7 +38,7 @@ public final class GenerationExportConfig {
     }
 
     public GenerationExportConfig setProtocol(GenerationExportProtocol protocol) {
-        this.protocol = protocol == null ? GenerationExportProtocol.HTTP : protocol;
+        this.protocol = protocol;
         return this;
     }
 
@@ -59,13 +72,30 @@ public final class GenerationExportConfig {
         return this;
     }
 
-    public boolean isInsecure() {
+    /**
+     * Returns the tri-state insecure flag. {@code null} means "not set" — the
+     * resolved value is {@code false} (TLS on) unless {@code SIGIL_INSECURE}
+     * provides a value or the caller explicitly sets one.
+     *
+     * <p>Use {@link #isInsecureResolved()} to read the boolean for transport
+     * decisions.</p>
+     */
+    public Boolean getInsecure() {
         return insecure;
     }
 
-    public GenerationExportConfig setInsecure(boolean insecure) {
+    public GenerationExportConfig setInsecure(Boolean insecure) {
         this.insecure = insecure;
         return this;
+    }
+
+    /**
+     * Returns the resolved boolean value with {@code null} treated as
+     * {@code false} (TLS on by default — matches Go/JS/Python SDKs after
+     * PR #103).
+     */
+    public boolean isInsecureResolved() {
+        return Boolean.TRUE.equals(insecure);
     }
 
     public int getBatchSize() {

--- a/java/core/src/main/java/com/grafana/sigil/sdk/SigilClient.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/SigilClient.java
@@ -163,9 +163,11 @@ public final class SigilClient implements AutoCloseable {
      * fail fast at this point.</p>
      */
     public SigilClient(SigilClientConfig inputConfig) {
-        this.config = inputConfig == null ? new SigilClientConfig() : inputConfig.copy();
+        SigilEnvConfig.EnvResolveResult envResult = SigilEnvConfig.resolveFromEnv(System::getenv, inputConfig);
+        this.config = envResult.config();
         this.logger = config.getLogger();
         this.clock = config.getClock();
+        SigilEnvConfig.logWarnings(this.logger, envResult.warnings());
         this.embeddingCaptureConfig = normalizeEmbeddingCaptureConfig(config.getEmbeddingCapture());
 
         GenerationExportConfig exportConfig = config.getGenerationExport();
@@ -225,8 +227,14 @@ public final class SigilClient implements AutoCloseable {
         if (seed.getAgentName().isBlank()) {
             seed.setAgentName(SigilContext.agentNameFromContext());
         }
+        if (seed.getAgentName().isBlank()) {
+            seed.setAgentName(config.getAgentName());
+        }
         if (seed.getAgentVersion().isBlank()) {
             seed.setAgentVersion(SigilContext.agentVersionFromContext());
+        }
+        if (seed.getAgentVersion().isBlank()) {
+            seed.setAgentVersion(config.getAgentVersion());
         }
 
         Instant startedAt = seed.getStartedAt() == null ? now() : seed.getStartedAt();
@@ -324,8 +332,14 @@ public final class SigilClient implements AutoCloseable {
         if (seed.getAgentName().isBlank()) {
             seed.setAgentName(SigilContext.agentNameFromContext());
         }
+        if (seed.getAgentName().isBlank()) {
+            seed.setAgentName(config.getAgentName());
+        }
         if (seed.getAgentVersion().isBlank()) {
             seed.setAgentVersion(SigilContext.agentVersionFromContext());
+        }
+        if (seed.getAgentVersion().isBlank()) {
+            seed.setAgentVersion(config.getAgentVersion());
         }
 
         Instant startedAt = seed.getStartedAt() == null ? now() : seed.getStartedAt();
@@ -583,11 +597,24 @@ public final class SigilClient implements AutoCloseable {
         if (seed.getUserId().isBlank()) {
             seed.setUserId(SigilContext.userIdFromContext());
         }
+        if (seed.getUserId().isBlank()) {
+            seed.setUserId(config.getUserId());
+        }
         if (seed.getAgentName().isBlank()) {
             seed.setAgentName(SigilContext.agentNameFromContext());
         }
+        if (seed.getAgentName().isBlank()) {
+            seed.setAgentName(config.getAgentName());
+        }
         if (seed.getAgentVersion().isBlank()) {
             seed.setAgentVersion(SigilContext.agentVersionFromContext());
+        }
+        if (seed.getAgentVersion().isBlank()) {
+            seed.setAgentVersion(config.getAgentVersion());
+        }
+        // Merge config-default tags as a base layer; per-call seed tags win.
+        if (!config.getTags().isEmpty()) {
+            seed.setTags(mergeTags(config.getTags(), seed.getTags()));
         }
 
         Instant startedAt = seed.getStartedAt() == null ? now() : seed.getStartedAt();
@@ -702,7 +729,7 @@ public final class SigilClient implements AutoCloseable {
 
     private GenerationExporter createGenerationExporter(GenerationExportConfig exportConfig) {
         return switch (exportConfig.getProtocol()) {
-            case GRPC -> new GrpcGenerationExporter(exportConfig.getEndpoint(), exportConfig.getHeaders(), exportConfig.isInsecure());
+            case GRPC -> new GrpcGenerationExporter(exportConfig.getEndpoint(), exportConfig.getHeaders(), exportConfig.isInsecureResolved());
             case HTTP -> new HttpGenerationExporter(exportConfig.getEndpoint(), exportConfig.getHeaders());
             case NONE -> new NoopGenerationExporter();
         };
@@ -769,7 +796,7 @@ public final class SigilClient implements AutoCloseable {
     }
 
     private String conversationRatingEndpoint(ApiConfig apiConfig, GenerationExportConfig exportConfig, String conversationId) {
-        String baseUrl = baseUrlFromEndpoint(apiConfig.getEndpoint(), exportConfig.isInsecure());
+        String baseUrl = baseUrlFromEndpoint(apiConfig.getEndpoint(), exportConfig.isInsecureResolved());
         return baseUrl + "/api/v1/conversations/" + encodePathSegment(conversationId) + "/ratings";
     }
 
@@ -871,6 +898,22 @@ public final class SigilClient implements AutoCloseable {
         }
 
         return summary;
+    }
+
+    /**
+     * Merges {@code base} and {@code override} into a fresh map. Override values
+     * win on key collision. Used to layer config-default tags under per-call
+     * generation tags (matches Go {@code mergeTags} in client.go:1962).
+     */
+    static Map<String, String> mergeTags(Map<String, String> base, Map<String, String> override) {
+        Map<String, String> out = new LinkedHashMap<>();
+        if (base != null) {
+            out.putAll(base);
+        }
+        if (override != null) {
+            out.putAll(override);
+        }
+        return out;
     }
 
     private static String requiredString(JsonNode node, String key) {

--- a/java/core/src/main/java/com/grafana/sigil/sdk/SigilClientConfig.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/SigilClientConfig.java
@@ -3,6 +3,9 @@ package com.grafana.sigil.sdk;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
 import java.time.Clock;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.logging.Logger;
 
 /** Top-level runtime configuration for {@link SigilClient}. */
@@ -17,6 +20,12 @@ public final class SigilClientConfig {
     private Meter meter;
     private Logger logger = Logger.getLogger("com.grafana.sigil.sdk");
     private Clock clock = Clock.systemUTC();
+
+    private String agentName = "";
+    private String agentVersion = "";
+    private String userId = "";
+    private Map<String, String> tags = new LinkedHashMap<>();
+    private Boolean debug;
 
     public GenerationExportConfig getGenerationExport() {
         return generationExport;
@@ -129,6 +138,77 @@ public final class SigilClientConfig {
         return this;
     }
 
+    /**
+     * Default {@code gen_ai.agent.name} for generations that don't supply one
+     * per-call. Filled from {@code SIGIL_AGENT_NAME} when the caller leaves
+     * this empty.
+     */
+    public String getAgentName() {
+        return agentName;
+    }
+
+    public SigilClientConfig setAgentName(String agentName) {
+        this.agentName = agentName == null ? "" : agentName;
+        return this;
+    }
+
+    /**
+     * Default {@code gen_ai.agent.version} for generations that don't supply
+     * one per-call. Filled from {@code SIGIL_AGENT_VERSION}.
+     */
+    public String getAgentVersion() {
+        return agentVersion;
+    }
+
+    public SigilClientConfig setAgentVersion(String agentVersion) {
+        this.agentVersion = agentVersion == null ? "" : agentVersion;
+        return this;
+    }
+
+    /**
+     * Default {@code user.id} for generations that don't supply one per-call.
+     * Filled from {@code SIGIL_USER_ID}.
+     */
+    public String getUserId() {
+        return userId;
+    }
+
+    public SigilClientConfig setUserId(String userId) {
+        this.userId = userId == null ? "" : userId;
+        return this;
+    }
+
+    /**
+     * Tags merged into every {@link GenerationStart#getTags()}. Per-call tags
+     * win on key collision. Filled from {@code SIGIL_TAGS}.
+     *
+     * <p>The returned map is unmodifiable; use {@link #setTags(Map)} to
+     * replace it.</p>
+     */
+    public Map<String, String> getTags() {
+        return Collections.unmodifiableMap(tags);
+    }
+
+    public SigilClientConfig setTags(Map<String, String> tags) {
+        this.tags = tags == null ? new LinkedHashMap<>() : new LinkedHashMap<>(tags);
+        return this;
+    }
+
+    /**
+     * Tri-state debug flag mirroring Go's {@code *bool}. {@code null} means
+     * "not set" — filled from {@code SIGIL_DEBUG} when the caller hasn't
+     * supplied a value. Explicit {@code Boolean.FALSE} overrides
+     * {@code SIGIL_DEBUG=true}.
+     */
+    public Boolean getDebug() {
+        return debug;
+    }
+
+    public SigilClientConfig setDebug(Boolean debug) {
+        this.debug = debug;
+        return this;
+    }
+
     public SigilClientConfig copy() {
         return new SigilClientConfig()
                 .setGenerationExport(generationExport.copy())
@@ -140,6 +220,11 @@ public final class SigilClientConfig {
                 .setTracer(tracer)
                 .setMeter(meter)
                 .setLogger(logger)
-                .setClock(clock);
+                .setClock(clock)
+                .setAgentName(agentName)
+                .setAgentVersion(agentVersion)
+                .setUserId(userId)
+                .setTags(tags)
+                .setDebug(debug);
     }
 }

--- a/java/core/src/main/java/com/grafana/sigil/sdk/SigilEnvConfig.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/SigilEnvConfig.java
@@ -1,0 +1,306 @@
+package com.grafana.sigil.sdk;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Reads canonical {@code SIGIL_*} environment variables and layers them under
+ * caller-supplied {@link SigilClientConfig} values.
+ *
+ * <p>Resolution order (highest precedence first):
+ *
+ * <ol>
+ *   <li>Caller-supplied {@code SigilClientConfig} field (when not at its
+ *       default/unset state).</li>
+ *   <li>Canonical {@code SIGIL_*} env var.</li>
+ *   <li>SDK schema default (the field initializer on
+ *       {@link SigilClientConfig} / {@link GenerationExportConfig} /
+ *       {@link AuthConfig}).</li>
+ * </ol>
+ *
+ * <p>Mirrors the Go reference implementation in {@code go/sigil/env.go}.
+ * Invalid env values are skipped with a warning so a single typo does not
+ * discard the rest of the env layer.</p>
+ */
+public final class SigilEnvConfig {
+    public static final String ENV_ENDPOINT = "SIGIL_ENDPOINT";
+    public static final String ENV_PROTOCOL = "SIGIL_PROTOCOL";
+    public static final String ENV_INSECURE = "SIGIL_INSECURE";
+    public static final String ENV_HEADERS = "SIGIL_HEADERS";
+    public static final String ENV_AUTH_MODE = "SIGIL_AUTH_MODE";
+    public static final String ENV_AUTH_TENANT_ID = "SIGIL_AUTH_TENANT_ID";
+    public static final String ENV_AUTH_TOKEN = "SIGIL_AUTH_TOKEN";
+    public static final String ENV_AGENT_NAME = "SIGIL_AGENT_NAME";
+    public static final String ENV_AGENT_VERSION = "SIGIL_AGENT_VERSION";
+    public static final String ENV_USER_ID = "SIGIL_USER_ID";
+    public static final String ENV_TAGS = "SIGIL_TAGS";
+    public static final String ENV_CONTENT_CAPTURE_MODE = "SIGIL_CONTENT_CAPTURE_MODE";
+    public static final String ENV_DEBUG = "SIGIL_DEBUG";
+
+    private SigilEnvConfig() {
+    }
+
+    /** Result of {@link #resolveFromEnv} — resolved config plus any non-fatal warnings. */
+    public record EnvResolveResult(SigilClientConfig config, List<String> warnings) {
+        public EnvResolveResult {
+            warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        }
+    }
+
+    /**
+     * Returns a config built from process env vars layered onto a fresh
+     * {@link SigilClientConfig}. Convenience helper; most callers should let
+     * {@link SigilClient} construction perform the same resolution internally.
+     * Warnings for invalid env values are logged to {@code com.grafana.sigil.sdk}.
+     */
+    public static SigilClientConfig fromEnv() {
+        EnvResolveResult result = resolveFromEnv(System::getenv, new SigilClientConfig());
+        logWarnings(Logger.getLogger("com.grafana.sigil.sdk"), result.warnings());
+        return result.config();
+    }
+
+    /**
+     * Applies canonical {@code SIGIL_*} env values onto {@code base},
+     * preserving caller-supplied fields. The returned config is a fresh copy;
+     * {@code base} is not mutated.
+     *
+     * <p>Invalid {@code SIGIL_AUTH_MODE}, {@code SIGIL_PROTOCOL}, or
+     * {@code SIGIL_CONTENT_CAPTURE_MODE} values are skipped — the base value
+     * is kept and the warning is appended to the result so other valid env
+     * vars still apply.</p>
+     */
+    public static EnvResolveResult resolveFromEnv(Function<String, String> lookup, SigilClientConfig base) {
+        Function<String, String> source = lookup == null ? System::getenv : lookup;
+        SigilClientConfig cfg = base == null ? new SigilClientConfig() : base.copy();
+        List<String> warnings = new ArrayList<>();
+
+        GenerationExportConfig export = cfg.getGenerationExport();
+
+        String endpoint = envTrimmed(source, ENV_ENDPOINT);
+        if (endpoint != null && export.getEndpoint().isEmpty()) {
+            export.setEndpoint(endpoint);
+        }
+
+        String protocol = envTrimmed(source, ENV_PROTOCOL);
+        if (protocol != null && export.getProtocol() == null) {
+            GenerationExportProtocol parsed = parseProtocol(protocol);
+            if (parsed != null) {
+                export.setProtocol(parsed);
+            } else {
+                warnings.add("sigil: ignoring invalid " + ENV_PROTOCOL + " " + protocol);
+            }
+        }
+
+        String insecureRaw = envTrimmed(source, ENV_INSECURE);
+        if (insecureRaw != null && export.getInsecure() == null) {
+            export.setInsecure(parseBool(insecureRaw));
+        }
+
+        String headersRaw = envTrimmed(source, ENV_HEADERS);
+        if (headersRaw != null && export.getHeaders().isEmpty()) {
+            export.setHeaders(parseCsvKv(headersRaw));
+        }
+
+        AuthConfig auth = export.getAuth();
+        String authModeRaw = envTrimmed(source, ENV_AUTH_MODE);
+        if (authModeRaw != null && auth.getMode() == null) {
+            AuthMode parsed = parseAuthMode(authModeRaw);
+            if (parsed != null) {
+                auth.setMode(parsed);
+            } else {
+                warnings.add("sigil: ignoring invalid " + ENV_AUTH_MODE + " " + authModeRaw);
+            }
+        }
+
+        String tenantId = envTrimmed(source, ENV_AUTH_TENANT_ID);
+        if (tenantId != null && auth.getTenantId().isEmpty()) {
+            auth.setTenantId(tenantId);
+        }
+
+        String token = envTrimmed(source, ENV_AUTH_TOKEN);
+        if (token != null) {
+            // Set both fields when empty; AuthHeaders.resolve uses only the one
+            // matching the final mode. Lets env's token populate a caller-set
+            // mode without env declaring SIGIL_AUTH_MODE.
+            if (auth.getBearerToken().isEmpty()) {
+                auth.setBearerToken(token);
+            }
+            if (auth.getBasicPassword().isEmpty()) {
+                auth.setBasicPassword(token);
+            }
+        }
+        if (auth.getMode() == AuthMode.BASIC && auth.getBasicUser().isEmpty() && !auth.getTenantId().isEmpty()) {
+            auth.setBasicUser(auth.getTenantId());
+        }
+
+        // Finalize tri-state defaults after env layering: null/empty means
+        // "no caller value and no env value", so apply the schema default.
+        if (export.getProtocol() == null) {
+            export.setProtocol(GenerationExportProtocol.HTTP);
+        }
+        if (export.getEndpoint().isEmpty()) {
+            export.setEndpoint("http://localhost:8080/api/v1/generations:export");
+        }
+        if (auth.getMode() == null) {
+            auth.setMode(AuthMode.NONE);
+        }
+
+        String agentName = envTrimmed(source, ENV_AGENT_NAME);
+        if (agentName != null && cfg.getAgentName().isEmpty()) {
+            cfg.setAgentName(agentName);
+        }
+        String agentVersion = envTrimmed(source, ENV_AGENT_VERSION);
+        if (agentVersion != null && cfg.getAgentVersion().isEmpty()) {
+            cfg.setAgentVersion(agentVersion);
+        }
+        String userId = envTrimmed(source, ENV_USER_ID);
+        if (userId != null && cfg.getUserId().isEmpty()) {
+            cfg.setUserId(userId);
+        }
+
+        String tagsRaw = envTrimmed(source, ENV_TAGS);
+        if (tagsRaw != null) {
+            Map<String, String> envTags = parseCsvKv(tagsRaw);
+            // Env tags act as a base layer; caller tags win on collision.
+            Map<String, String> merged = new LinkedHashMap<>(envTags);
+            merged.putAll(cfg.getTags());
+            cfg.setTags(merged);
+        }
+
+        String ccmRaw = envTrimmed(source, ENV_CONTENT_CAPTURE_MODE);
+        if (ccmRaw != null && cfg.getContentCapture() == ContentCaptureMode.DEFAULT) {
+            ContentCaptureMode parsed = parseContentCaptureMode(ccmRaw);
+            if (parsed != null) {
+                cfg.setContentCapture(parsed);
+            } else {
+                warnings.add("sigil: ignoring invalid " + ENV_CONTENT_CAPTURE_MODE + " " + ccmRaw);
+            }
+        }
+
+        String debugRaw = envTrimmed(source, ENV_DEBUG);
+        if (debugRaw != null && cfg.getDebug() == null) {
+            cfg.setDebug(parseBool(debugRaw));
+        }
+
+        return new EnvResolveResult(cfg, warnings);
+    }
+
+    /** Logs each warning at WARNING level on {@code logger} (no-op when null). */
+    public static void logWarnings(Logger logger, List<String> warnings) {
+        if (logger == null || warnings == null) {
+            return;
+        }
+        for (String w : warnings) {
+            logger.log(Level.WARNING, w);
+        }
+    }
+
+    private static String envTrimmed(Function<String, String> lookup, String key) {
+        String raw;
+        try {
+            raw = lookup.apply(key);
+        } catch (SecurityException ex) {
+            return null;
+        }
+        if (raw == null) {
+            return null;
+        }
+        String v = raw.trim();
+        return v.isEmpty() ? null : v;
+    }
+
+    static boolean parseBool(String raw) {
+        if (raw == null) {
+            return false;
+        }
+        switch (raw.trim().toLowerCase(Locale.ROOT)) {
+            case "1":
+            case "true":
+            case "yes":
+            case "on":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    static Map<String, String> parseCsvKv(String raw) {
+        Map<String, String> out = new LinkedHashMap<>();
+        if (raw == null) {
+            return out;
+        }
+        for (String part : raw.split(",", -1)) {
+            String trimmed = part.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            int idx = trimmed.indexOf('=');
+            if (idx <= 0) {
+                continue;
+            }
+            String key = trimmed.substring(0, idx).trim();
+            String value = trimmed.substring(idx + 1).trim();
+            if (!key.isEmpty()) {
+                out.put(key, value);
+            }
+        }
+        return out;
+    }
+
+    static ContentCaptureMode parseContentCaptureMode(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        switch (raw.trim().toLowerCase(Locale.ROOT)) {
+            case "full":
+                return ContentCaptureMode.FULL;
+            case "no_tool_content":
+                return ContentCaptureMode.NO_TOOL_CONTENT;
+            case "metadata_only":
+                return ContentCaptureMode.METADATA_ONLY;
+            default:
+                return null;
+        }
+    }
+
+    static AuthMode parseAuthMode(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        switch (raw.trim().toLowerCase(Locale.ROOT)) {
+            case "none":
+                return AuthMode.NONE;
+            case "tenant":
+                return AuthMode.TENANT;
+            case "bearer":
+                return AuthMode.BEARER;
+            case "basic":
+                return AuthMode.BASIC;
+            default:
+                return null;
+        }
+    }
+
+    static GenerationExportProtocol parseProtocol(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        switch (raw.trim().toLowerCase(Locale.ROOT)) {
+            case "grpc":
+                return GenerationExportProtocol.GRPC;
+            case "http":
+                return GenerationExportProtocol.HTTP;
+            case "none":
+                return GenerationExportProtocol.NONE;
+            default:
+                return null;
+        }
+    }
+
+}

--- a/java/core/src/test/java/com/grafana/sigil/sdk/SigilAuthConfigTest.java
+++ b/java/core/src/test/java/com/grafana/sigil/sdk/SigilAuthConfigTest.java
@@ -11,19 +11,7 @@ import org.junit.jupiter.api.Test;
 
 class SigilAuthConfigTest {
     @Test
-    void validatesAuthModeShape() {
-        assertThatThrownBy(() -> AuthHeaders.resolve(Map.of(), new AuthConfig().setMode(AuthMode.NONE).setTenantId("x"), "trace"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("mode 'none'");
-
-        assertThatThrownBy(() -> AuthHeaders.resolve(Map.of(), new AuthConfig().setMode(AuthMode.NONE).setBasicUser("user"), "trace"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("mode 'none'");
-
-        assertThatThrownBy(() -> AuthHeaders.resolve(Map.of(), new AuthConfig().setMode(AuthMode.NONE).setBasicPassword("secret"), "trace"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("mode 'none'");
-
+    void requiresModeSpecificCredentials() {
         assertThatThrownBy(() -> AuthHeaders.resolve(Map.of(), new AuthConfig().setMode(AuthMode.TENANT), "generation export"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("requires tenantId");
@@ -31,6 +19,31 @@ class SigilAuthConfigTest {
         assertThatThrownBy(() -> AuthHeaders.resolve(Map.of(), new AuthConfig().setMode(AuthMode.BEARER), "generation export"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("requires bearerToken");
+    }
+
+    @Test
+    void modeNoneIgnoresIrrelevantCredentialFields() {
+        // env layering can populate cross-mode fields without explicit SIGIL_AUTH_MODE.
+        Map<String, String> headers = AuthHeaders.resolve(
+                Map.of(),
+                new AuthConfig()
+                        .setMode(AuthMode.NONE)
+                        .setTenantId("42")
+                        .setBearerToken("tok")
+                        .setBasicUser("user")
+                        .setBasicPassword("pass"),
+                "trace");
+        assertThat(headers).isEmpty();
+    }
+
+    @Test
+    void modeBearerIgnoresIrrelevantTenantField() {
+        Map<String, String> headers = AuthHeaders.resolve(
+                Map.of(),
+                new AuthConfig().setMode(AuthMode.BEARER).setBearerToken("tok").setTenantId("42"),
+                "generation export");
+        assertThat(headers).containsEntry("Authorization", "Bearer tok");
+        assertThat(headers).doesNotContainKey("X-Scope-OrgID");
     }
 
     @Test

--- a/java/core/src/test/java/com/grafana/sigil/sdk/SigilClientEnvIntegrationTest.java
+++ b/java/core/src/test/java/com/grafana/sigil/sdk/SigilClientEnvIntegrationTest.java
@@ -1,0 +1,172 @@
+package com.grafana.sigil.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SigilClientEnvIntegrationTest {
+
+    private static SigilClientConfig baseConfig(TestFixtures.CapturingExporter exporter) {
+        return new SigilClientConfig()
+                .setTracer(GlobalOpenTelemetry.getTracer("test"))
+                .setGenerationExporter(exporter)
+                .setGenerationExport(new GenerationExportConfig()
+                        .setProtocol(GenerationExportProtocol.HTTP)
+                        .setBatchSize(1)
+                        .setQueueSize(100)
+                        .setFlushInterval(Duration.ofMinutes(10))
+                        .setMaxRetries(0));
+    }
+
+    private static GenerationStart minimalStart() {
+        return new GenerationStart()
+                .setId("gen-1")
+                .setConversationId("conv-1")
+                .setMode(GenerationMode.SYNC)
+                .setOperationName("chat")
+                .setModel(new ModelRef().setProvider("openai").setName("gpt-4o"));
+    }
+
+    @Test
+    void resolveFromEnvFillsConfigDefaults() {
+        SigilClientConfig caller = new SigilClientConfig();
+        Map<String, String> env = Map.of(
+                "SIGIL_AGENT_NAME", "env-agent",
+                "SIGIL_AGENT_VERSION", "1.2.3",
+                "SIGIL_USER_ID", "user-1",
+                "SIGIL_TAGS", "service=demo,team=ai");
+
+        SigilClientConfig resolved = SigilEnvConfig.resolveFromEnv(env::get, caller).config();
+
+        assertThat(resolved.getAgentName()).isEqualTo("env-agent");
+        assertThat(resolved.getAgentVersion()).isEqualTo("1.2.3");
+        assertThat(resolved.getUserId()).isEqualTo("user-1");
+        assertThat(resolved.getTags())
+                .containsEntry("service", "demo")
+                .containsEntry("team", "ai");
+    }
+
+    @Test
+    void callerConfigOverridesEnv() {
+        SigilClientConfig caller = new SigilClientConfig().setAgentName("caller-agent");
+        SigilClientConfig resolved = SigilEnvConfig.resolveFromEnv(
+                Map.of("SIGIL_AGENT_NAME", "env-agent")::get, caller).config();
+        assertThat(resolved.getAgentName()).isEqualTo("caller-agent");
+    }
+
+    @Test
+    void perCallSeedTagWinsOverConfigTag() throws Exception {
+        TestFixtures.CapturingExporter exporter = new TestFixtures.CapturingExporter();
+        SigilClientConfig config = baseConfig(exporter);
+        config.setTags(Map.of("service", "demo", "team", "ai"));
+
+        try (SigilClient client = new SigilClient(config)) {
+            GenerationStart start = minimalStart();
+            start.getTags().put("team", "obs");
+            GenerationRecorder rec = client.startGeneration(start);
+            rec.setResult(TestFixtures.resultFixture());
+            rec.close();
+            assertThat(rec.error()).isEmpty();
+            client.flush();
+            TestFixtures.waitFor(() -> !exporter.getRequests().isEmpty(), Duration.ofSeconds(2));
+        }
+
+        Generation captured = exporter.getRequests().get(0).get(0);
+        assertThat(captured.getTags()).containsEntry("service", "demo");
+        assertThat(captured.getTags()).containsEntry("team", "obs");
+    }
+
+    private static GenerationResult bareResult() {
+        // Avoid TestFixtures.resultFixture() which sets identity fields the
+        // recorder would prefer over the seed when finalizing the generation.
+        return new GenerationResult()
+                .setUsage(new TokenUsage().setInputTokens(1).setOutputTokens(1))
+                .setStopReason("stop");
+    }
+
+    @Test
+    void configIdentityFallsThroughToGenerationStart() throws Exception {
+        TestFixtures.CapturingExporter exporter = new TestFixtures.CapturingExporter();
+        SigilClientConfig config = baseConfig(exporter)
+                .setAgentName("env-agent")
+                .setAgentVersion("1.2.3")
+                .setUserId("user-1");
+
+        try (SigilClient client = new SigilClient(config)) {
+            GenerationStart start = minimalStart();
+            GenerationRecorder rec = client.startGeneration(start);
+            rec.setResult(bareResult());
+            rec.close();
+            assertThat(rec.error()).isEmpty();
+            client.flush();
+            TestFixtures.waitFor(() -> !exporter.getRequests().isEmpty(), Duration.ofSeconds(2));
+        }
+
+        Generation captured = exporter.getRequests().get(0).get(0);
+        assertThat(captured.getAgentName()).isEqualTo("env-agent");
+        assertThat(captured.getAgentVersion()).isEqualTo("1.2.3");
+        assertThat(captured.getUserId()).isEqualTo("user-1");
+    }
+
+    @Test
+    void perCallSeedIdentityOverridesConfigDefault() throws Exception {
+        TestFixtures.CapturingExporter exporter = new TestFixtures.CapturingExporter();
+        SigilClientConfig config = baseConfig(exporter)
+                .setAgentName("env-agent")
+                .setUserId("env-user");
+
+        try (SigilClient client = new SigilClient(config)) {
+            GenerationStart start = minimalStart()
+                    .setAgentName("call-agent")
+                    .setUserId("call-user");
+            GenerationRecorder rec = client.startGeneration(start);
+            rec.setResult(bareResult());
+            rec.close();
+            assertThat(rec.error()).isEmpty();
+            client.flush();
+            TestFixtures.waitFor(() -> !exporter.getRequests().isEmpty(), Duration.ofSeconds(2));
+        }
+
+        Generation captured = exporter.getRequests().get(0).get(0);
+        assertThat(captured.getAgentName()).isEqualTo("call-agent");
+        assertThat(captured.getUserId()).isEqualTo("call-user");
+    }
+
+    @Test
+    void mergeTagsHelperPutsOverrideOnTop() {
+        Map<String, String> base = new LinkedHashMap<>();
+        base.put("service", "demo");
+        base.put("team", "ai");
+        Map<String, String> override = new LinkedHashMap<>();
+        override.put("team", "obs");
+
+        Map<String, String> merged = SigilClient.mergeTags(base, override);
+
+        assertThat(merged).containsEntry("service", "demo");
+        assertThat(merged).containsEntry("team", "obs");
+        // The helper returns a fresh map.
+        merged.put("late", "edit");
+        assertThat(base).doesNotContainKey("late");
+        assertThat(override).doesNotContainKey("late");
+    }
+
+    @Test
+    void explicitInsecureFalseBeatsEnvTrue() {
+        SigilClientConfig caller = new SigilClientConfig();
+        caller.getGenerationExport().setInsecure(Boolean.FALSE);
+        SigilClientConfig resolved = SigilEnvConfig.resolveFromEnv(
+                Map.of("SIGIL_INSECURE", "true")::get, caller).config();
+        assertThat(resolved.getGenerationExport().getInsecure()).isFalse();
+    }
+
+    @Test
+    void noEnvNoCallerInsecureResolvesToFalse() {
+        SigilClientConfig resolved = SigilEnvConfig.resolveFromEnv(
+                Map.<String, String>of()::get, new SigilClientConfig()).config();
+        assertThat(resolved.getGenerationExport().isInsecureResolved()).isFalse();
+    }
+}

--- a/java/core/src/test/java/com/grafana/sigil/sdk/SigilEnvConfigTest.java
+++ b/java/core/src/test/java/com/grafana/sigil/sdk/SigilEnvConfigTest.java
@@ -1,0 +1,296 @@
+package com.grafana.sigil.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.grafana.sigil.sdk.SigilEnvConfig.EnvResolveResult;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+class SigilEnvConfigTest {
+
+    private static Function<String, String> mapLookup(Map<String, String> env) {
+        return env::get;
+    }
+
+    private static EnvResolveResult resolve(Map<String, String> env) {
+        return SigilEnvConfig.resolveFromEnv(mapLookup(env), new SigilClientConfig());
+    }
+
+    @Test
+    void noEnvKeepsBaseDefaults() {
+        EnvResolveResult result = resolve(Map.of());
+        SigilClientConfig cfg = result.config();
+        assertThat(cfg.getAgentName()).isEmpty();
+        assertThat(cfg.getAgentVersion()).isEmpty();
+        assertThat(cfg.getUserId()).isEmpty();
+        assertThat(cfg.getTags()).isEmpty();
+        assertThat(cfg.getDebug()).isNull();
+        assertThat(cfg.getGenerationExport().getInsecure()).isNull();
+        assertThat(cfg.getGenerationExport().getEndpoint())
+                .isEqualTo("http://localhost:8080/api/v1/generations:export");
+        assertThat(result.warnings()).isEmpty();
+    }
+
+    @Test
+    void transportFromEnv() {
+        Map<String, String> env = Map.of(
+                "SIGIL_ENDPOINT", "https://env:4318",
+                "SIGIL_PROTOCOL", "http",
+                "SIGIL_INSECURE", "true",
+                "SIGIL_HEADERS", "X-A=1,X-B=two");
+        SigilClientConfig cfg = resolve(env).config();
+        assertThat(cfg.getGenerationExport().getEndpoint()).isEqualTo("https://env:4318");
+        assertThat(cfg.getGenerationExport().getProtocol()).isEqualTo(GenerationExportProtocol.HTTP);
+        assertThat(cfg.getGenerationExport().getInsecure()).isTrue();
+        assertThat(cfg.getGenerationExport().getHeaders())
+                .containsEntry("X-A", "1")
+                .containsEntry("X-B", "two");
+    }
+
+    @Test
+    void grpcProtocolFromEnv() {
+        SigilClientConfig cfg = resolve(Map.of("SIGIL_PROTOCOL", "grpc")).config();
+        assertThat(cfg.getGenerationExport().getProtocol()).isEqualTo(GenerationExportProtocol.GRPC);
+    }
+
+    @Test
+    void basicAuthFromEnv() {
+        Map<String, String> env = Map.of(
+                "SIGIL_AUTH_MODE", "basic",
+                "SIGIL_AUTH_TENANT_ID", "42",
+                "SIGIL_AUTH_TOKEN", "glc_xxx");
+        AuthConfig auth = resolve(env).config().getGenerationExport().getAuth();
+        assertThat(auth.getMode()).isEqualTo(AuthMode.BASIC);
+        assertThat(auth.getTenantId()).isEqualTo("42");
+        assertThat(auth.getBasicPassword()).isEqualTo("glc_xxx");
+        assertThat(auth.getBasicUser()).isEqualTo("42");
+    }
+
+    @Test
+    void bearerAuthFromEnv() {
+        Map<String, String> env = Map.of(
+                "SIGIL_AUTH_MODE", "bearer",
+                "SIGIL_AUTH_TOKEN", "tok");
+        AuthConfig auth = resolve(env).config().getGenerationExport().getAuth();
+        assertThat(auth.getMode()).isEqualTo(AuthMode.BEARER);
+        assertThat(auth.getBearerToken()).isEqualTo("tok");
+    }
+
+    @Test
+    void invalidAuthModeWarnsAndPreservesOtherEnv() {
+        Map<String, String> env = new HashMap<>();
+        env.put("SIGIL_AUTH_MODE", "Bearrer");
+        env.put("SIGIL_ENDPOINT", "valid.example:4318");
+        env.put("SIGIL_AGENT_NAME", "valid-agent");
+        env.put("SIGIL_USER_ID", "alice");
+        EnvResolveResult result = SigilEnvConfig.resolveFromEnv(env::get, new SigilClientConfig());
+
+        SigilClientConfig cfg = result.config();
+        assertThat(cfg.getGenerationExport().getEndpoint()).isEqualTo("valid.example:4318");
+        assertThat(cfg.getAgentName()).isEqualTo("valid-agent");
+        assertThat(cfg.getUserId()).isEqualTo("alice");
+        assertThat(cfg.getGenerationExport().getAuth().getMode()).isEqualTo(AuthMode.NONE);
+        assertThat(result.warnings()).anySatisfy(w -> assertThat(w).contains("SIGIL_AUTH_MODE"));
+    }
+
+    @Test
+    void invalidContentCaptureModeWarnsAndPreservesOtherEnv() {
+        Map<String, String> env = new HashMap<>();
+        env.put("SIGIL_CONTENT_CAPTURE_MODE", "bogus");
+        env.put("SIGIL_ENDPOINT", "valid.example:4318");
+        EnvResolveResult result = SigilEnvConfig.resolveFromEnv(env::get, new SigilClientConfig());
+
+        SigilClientConfig cfg = result.config();
+        assertThat(cfg.getContentCapture()).isEqualTo(ContentCaptureMode.DEFAULT);
+        assertThat(cfg.getGenerationExport().getEndpoint()).isEqualTo("valid.example:4318");
+        assertThat(result.warnings()).anySatisfy(w -> assertThat(w).contains("SIGIL_CONTENT_CAPTURE_MODE"));
+    }
+
+    @Test
+    void invalidContentCaptureModeKeepsCallerBaseValue() {
+        SigilClientConfig base = new SigilClientConfig().setContentCapture(ContentCaptureMode.METADATA_ONLY);
+        EnvResolveResult result = SigilEnvConfig.resolveFromEnv(
+                Map.of("SIGIL_CONTENT_CAPTURE_MODE", "bogus")::get, base);
+        // Base value should remain because it isn't DEFAULT (caller-set).
+        assertThat(result.config().getContentCapture()).isEqualTo(ContentCaptureMode.METADATA_ONLY);
+    }
+
+    @Test
+    void contentCaptureModeFromEnv() {
+        SigilClientConfig cfg = resolve(Map.of("SIGIL_CONTENT_CAPTURE_MODE", "metadata_only")).config();
+        assertThat(cfg.getContentCapture()).isEqualTo(ContentCaptureMode.METADATA_ONLY);
+    }
+
+    @Test
+    void agentUserTagsDebugFromEnv() {
+        Map<String, String> env = Map.of(
+                "SIGIL_AGENT_NAME", "planner",
+                "SIGIL_AGENT_VERSION", "1.2.3",
+                "SIGIL_USER_ID", "alice@example.com",
+                "SIGIL_TAGS", "service=orchestrator,env=prod",
+                "SIGIL_DEBUG", "true");
+        SigilClientConfig cfg = resolve(env).config();
+        assertThat(cfg.getAgentName()).isEqualTo("planner");
+        assertThat(cfg.getAgentVersion()).isEqualTo("1.2.3");
+        assertThat(cfg.getUserId()).isEqualTo("alice@example.com");
+        assertThat(cfg.getTags()).containsEntry("service", "orchestrator").containsEntry("env", "prod");
+        assertThat(cfg.getDebug()).isTrue();
+    }
+
+    @Test
+    void whitespaceOnlyValuesAreIgnored() {
+        Map<String, String> env = new HashMap<>();
+        env.put("SIGIL_TAGS", "   ");
+        env.put("SIGIL_AGENT_NAME", "");
+        env.put("SIGIL_USER_ID", "\t \n");
+        SigilClientConfig cfg = SigilEnvConfig.resolveFromEnv(env::get, new SigilClientConfig()).config();
+        assertThat(cfg.getTags()).isEmpty();
+        assertThat(cfg.getAgentName()).isEmpty();
+        assertThat(cfg.getUserId()).isEmpty();
+    }
+
+    @Test
+    void callerEndpointWinsOverEnv() {
+        SigilClientConfig base = new SigilClientConfig();
+        base.getGenerationExport().setEndpoint("https://caller-host");
+        SigilClientConfig cfg = SigilEnvConfig.resolveFromEnv(
+                Map.of("SIGIL_ENDPOINT", "https://env-host")::get, base).config();
+        assertThat(cfg.getGenerationExport().getEndpoint()).isEqualTo("https://caller-host");
+    }
+
+    @Test
+    void callerInsecureFalseBeatsEnvTrue() {
+        SigilClientConfig base = new SigilClientConfig();
+        base.getGenerationExport().setInsecure(Boolean.FALSE);
+        SigilClientConfig cfg = SigilEnvConfig.resolveFromEnv(
+                Map.of("SIGIL_INSECURE", "true")::get, base).config();
+        assertThat(cfg.getGenerationExport().getInsecure()).isFalse();
+        assertThat(cfg.getGenerationExport().isInsecureResolved()).isFalse();
+    }
+
+    @Test
+    void envInsecureTrueLayersUnderUnsetCaller() {
+        SigilClientConfig cfg = SigilEnvConfig.resolveFromEnv(
+                Map.of("SIGIL_INSECURE", "true")::get, new SigilClientConfig()).config();
+        assertThat(cfg.getGenerationExport().getInsecure()).isTrue();
+        assertThat(cfg.getGenerationExport().isInsecureResolved()).isTrue();
+    }
+
+    @Test
+    void unsetInsecureResolvesToFalse() {
+        // SIGIL_INSECURE unset and caller didn't set → resolved boolean is false (TLS on).
+        SigilClientConfig cfg = SigilEnvConfig.resolveFromEnv(Map.<String, String>of()::get, new SigilClientConfig())
+                .config();
+        assertThat(cfg.getGenerationExport().getInsecure()).isNull();
+        assertThat(cfg.getGenerationExport().isInsecureResolved()).isFalse();
+    }
+
+    @Test
+    void authTokenFillsBothBearerAndBasicWhenEmpty() {
+        SigilClientConfig cfg = SigilEnvConfig.resolveFromEnv(
+                Map.of("SIGIL_AUTH_TOKEN", "secret")::get, new SigilClientConfig()).config();
+        AuthConfig auth = cfg.getGenerationExport().getAuth();
+        assertThat(auth.getBearerToken()).isEqualTo("secret");
+        assertThat(auth.getBasicPassword()).isEqualTo("secret");
+    }
+
+    @Test
+    void authTokenSkipsAlreadyFilledFields() {
+        SigilClientConfig base = new SigilClientConfig();
+        base.getGenerationExport().getAuth().setBearerToken("caller-bearer");
+        SigilClientConfig cfg = SigilEnvConfig.resolveFromEnv(
+                Map.of("SIGIL_AUTH_TOKEN", "env-token")::get, base).config();
+        AuthConfig auth = cfg.getGenerationExport().getAuth();
+        assertThat(auth.getBearerToken()).isEqualTo("caller-bearer");
+        assertThat(auth.getBasicPassword()).isEqualTo("env-token");
+    }
+
+    @Test
+    void basicModeUsesTenantAsBasicUserFallback() {
+        Map<String, String> env = Map.of(
+                "SIGIL_AUTH_MODE", "basic",
+                "SIGIL_AUTH_TENANT_ID", "tenant-a",
+                "SIGIL_AUTH_TOKEN", "secret");
+        AuthConfig auth = resolve(env).config().getGenerationExport().getAuth();
+        assertThat(auth.getMode()).isEqualTo(AuthMode.BASIC);
+        assertThat(auth.getBasicUser()).isEqualTo("tenant-a");
+        assertThat(auth.getBasicPassword()).isEqualTo("secret");
+    }
+
+    @Test
+    void strayTenantIdKeepsModeNone() {
+        AuthConfig auth = resolve(Map.of("SIGIL_AUTH_TENANT_ID", "42"))
+                .config().getGenerationExport().getAuth();
+        assertThat(auth.getMode()).isEqualTo(AuthMode.NONE);
+        assertThat(auth.getTenantId()).isEqualTo("42");
+    }
+
+    @Test
+    void parseCsvKvHandlesEdgeCases() {
+        Map<String, String> result = SigilEnvConfig.parseCsvKv("a=1, b = two ,, =skip,c=");
+        assertThat(result).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "a", "1",
+                "b", "two",
+                "c", ""));
+    }
+
+    @Test
+    void envTagsMergeUnderCallerTags() {
+        SigilClientConfig base = new SigilClientConfig();
+        base.setTags(Map.of("team", "ai", "env", "staging"));
+        SigilClientConfig cfg = SigilEnvConfig.resolveFromEnv(
+                Map.of("SIGIL_TAGS", "service=orch,env=prod")::get, base).config();
+        Map<String, String> tags = cfg.getTags();
+        assertThat(tags).containsEntry("service", "orch");      // env-only fills
+        assertThat(tags).containsEntry("team", "ai");           // caller-only preserved
+        assertThat(tags).containsEntry("env", "staging");       // caller wins on collision
+    }
+
+    @Test
+    void parseBoolAcceptsCanonicalTrue() {
+        assertThat(SigilEnvConfig.parseBool("1")).isTrue();
+        assertThat(SigilEnvConfig.parseBool("true")).isTrue();
+        assertThat(SigilEnvConfig.parseBool("YES")).isTrue();
+        assertThat(SigilEnvConfig.parseBool("On")).isTrue();
+        assertThat(SigilEnvConfig.parseBool("0")).isFalse();
+        assertThat(SigilEnvConfig.parseBool("false")).isFalse();
+        assertThat(SigilEnvConfig.parseBool("garbage")).isFalse();
+    }
+
+    @Test
+    void fromEnvUsesProcessEnv() {
+        // Smoke: just verify it doesn't throw and returns a config.
+        SigilClientConfig cfg = SigilEnvConfig.fromEnv();
+        assertThat(cfg).isNotNull();
+    }
+
+    @Test
+    void resolveDoesNotMutateBase() {
+        SigilClientConfig base = new SigilClientConfig().setAgentName("base-agent");
+        SigilClientConfig resolved = SigilEnvConfig.resolveFromEnv(
+                Map.of("SIGIL_USER_ID", "alice")::get, base).config();
+        assertThat(base.getUserId()).isEmpty();
+        assertThat(resolved.getUserId()).isEqualTo("alice");
+        assertThat(resolved.getAgentName()).isEqualTo("base-agent");
+    }
+
+    @Test
+    void parseAuthModeNormalizesCase() {
+        assertThat(SigilEnvConfig.parseAuthMode("BASIC")).isEqualTo(AuthMode.BASIC);
+        assertThat(SigilEnvConfig.parseAuthMode("Bearer")).isEqualTo(AuthMode.BEARER);
+        assertThat(SigilEnvConfig.parseAuthMode("none")).isEqualTo(AuthMode.NONE);
+        assertThat(SigilEnvConfig.parseAuthMode("garbage")).isNull();
+    }
+
+    @Test
+    void fluentSetTagsCopiesInput() {
+        Map<String, String> source = new LinkedHashMap<>();
+        source.put("k", "v");
+        SigilClientConfig cfg = new SigilClientConfig().setTags(source);
+        source.put("late", "edit");
+        assertThat(cfg.getTags()).containsExactly(Map.entry("k", "v"));
+    }
+}


### PR DESCRIPTION
Follow-up for https://github.com/grafana/sigil-sdk/pull/103, but for Java and .NET SDK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client construction/config resolution in both Java and .NET, including a breaking default for `insecure` (now tri-state with TLS-on by default) and relaxed auth-field validation, which could alter runtime export/auth behavior if callers relied on previous defaults.
> 
> **Overview**
> Adds canonical `SIGIL_*` environment-variable configuration layering for **.NET** (`EnvConfig`, wired into `ConfigResolver`) and **Java** (`SigilEnvConfig`, wired into `SigilClient`), with warnings for invalid values rather than failing the whole env layer.
> 
> Updates both SDKs to support env-driven defaults for agent/user identity, tags, content-capture mode, and debug, and merges config/env default tags under per-call generation tags.
> 
> Introduces a **breaking change** to make `GenerationExportConfig.insecure`/`Insecure` tri-state and changes the default to TLS-on when unset, and relaxes auth header resolution to ignore mode-irrelevant credential fields; docs and extensive unit/integration tests were added, including test harness env-var cleanup to avoid developer-machine leakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ead84f07ecf74391d166af8c45ba1f0cc6570d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->