### PR TITLE
feat(hooks): support transformed_input from hooks:evaluate

### DIFF
--- a/go/sigil/hooks.go
+++ b/go/sigil/hooks.go
@@ -146,10 +146,11 @@ type HookEvaluation struct {
 
 // HookEvaluateResponse is the parsed server response.
 type HookEvaluateResponse struct {
-	Action      HookAction       `json:"action"`
-	RuleID      string           `json:"rule_id,omitempty"`
-	Reason      string           `json:"reason,omitempty"`
-	Evaluations []HookEvaluation `json:"evaluations"`
+	Action            HookAction       `json:"action"`
+	RuleID            string           `json:"rule_id,omitempty"`
+	Reason            string           `json:"reason,omitempty"`
+	TransformedInput  *HookInput       `json:"transformed_input,omitempty"`
+	Evaluations       []HookEvaluation `json:"evaluations"`
 }
 
 // EvaluateHook calls POST /api/v1/hooks:evaluate to run synchronous hook

--- a/go/sigil/hooks_test.go
+++ b/go/sigil/hooks_test.go
@@ -111,6 +111,35 @@ func TestEvaluateHookSendsRequestAndParsesAllow(t *testing.T) {
 	}
 }
 
+func TestEvaluateHookParsesTransformedInput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"action":"allow",
+			"transformed_input":{"conversation_preview":"[REDACTED]"},
+			"evaluations":[]
+		}`))
+	}))
+	defer server.Close()
+
+	client := newHookTestClient(t, hookTestClientOptions{
+		apiEndpoint:  server.URL,
+		hooksEnabled: true,
+	})
+	t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
+
+	resp, err := client.EvaluateHook(context.Background(), HookEvaluateRequest{
+		Phase:   HookPhasePreflight,
+		Context: HookContext{Model: &HookModel{Provider: "openai", Name: "gpt-4o"}},
+	})
+	if err != nil {
+		t.Fatalf("evaluate hook: %v", err)
+	}
+	if resp.TransformedInput == nil || resp.TransformedInput.ConversationPreview != "[REDACTED]" {
+		t.Fatalf("unexpected transformed input: %#v", resp.TransformedInput)
+	}
+}
+
 func TestEvaluateHookReturnsDeny(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/js/src/frameworks/vercel-ai-sdk/hooks.ts
+++ b/js/src/frameworks/vercel-ai-sdk/hooks.ts
@@ -464,7 +464,7 @@ export class SigilVercelAiSdkInstrumentation {
       return firstError;
     };
 
-    const runPreflight = async (event: StepStartEvent, inputMessages: Message[]): Promise<void> => {
+    const runPreflight = async (event: StepStartEvent, inputMessages: Message[]): Promise<Message[]> => {
       const model = mapModelFromStepStart(event);
       // evaluateHook honors fail-open internally; an exception here means
       // fail_open=false and the LLM call should be aborted.
@@ -492,6 +492,11 @@ export class SigilVercelAiSdkInstrumentation {
           response.evaluations,
         );
       }
+      const ti = response.transformedInput?.messages;
+      if (ti !== undefined && ti.length > 0) {
+        return ti;
+      }
+      return inputMessages;
     };
 
     const hooks: StreamTextHooks = {
@@ -508,17 +513,17 @@ export class SigilVercelAiSdkInstrumentation {
         }
 
         const inputMessages = mapInputMessages(event.messages);
-        const finalize = (): void => {
+        const finalize = (resolvedMessages: Message[]): void => {
           createStepState({
             stepNumber,
             stepStartEvent: event,
             startedAt: new Date(),
-            inputMessages: this.captureInputs ? inputMessages : [],
+            inputMessages: this.captureInputs ? resolvedMessages : [],
           });
         };
 
         if (!this.preflightEnabled()) {
-          finalize();
+          finalize(inputMessages);
           return;
         }
 

--- a/js/src/hooks.ts
+++ b/js/src/hooks.ts
@@ -1,4 +1,10 @@
-import type { HookEvaluateRequest, HookEvaluateResponse, HookEvaluation, HooksConfig } from './types.js';
+import type {
+  HookEvaluateRequest,
+  HookEvaluateResponse,
+  HookEvaluation,
+  HookInput,
+  HooksConfig,
+} from './types.js';
 import { asError } from './utils.js';
 
 const hooksEvaluatePath = '/api/v1/hooks:evaluate';
@@ -218,7 +224,45 @@ function parseEvaluateResponse(payload: unknown): HookEvaluateResponse {
     });
   }
 
-  return { action, ruleId, reason, evaluations };
+  const transformedInput = parseTransformedInputPayload(payload);
+
+  return { action, ruleId, reason, transformedInput, evaluations };
+}
+
+function parseTransformedInputPayload(payload: Record<string, unknown>): HookInput | undefined {
+  const raw = payload.transformed_input;
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  if (!isRecord(raw)) {
+    return undefined;
+  }
+  const out: HookInput = {};
+  if (Array.isArray(raw.messages) && raw.messages.length > 0) {
+    out.messages = raw.messages as HookInput['messages'];
+  }
+  if (Array.isArray(raw.tools) && raw.tools.length > 0) {
+    out.tools = raw.tools as HookInput['tools'];
+  }
+  if (typeof raw.system_prompt === 'string' && raw.system_prompt.length > 0) {
+    out.systemPrompt = raw.system_prompt;
+  }
+  if (Array.isArray(raw.output) && raw.output.length > 0) {
+    out.output = raw.output as HookInput['output'];
+  }
+  if (typeof raw.conversation_preview === 'string' && raw.conversation_preview.length > 0) {
+    out.conversationPreview = raw.conversation_preview;
+  }
+  if (
+    out.messages === undefined &&
+    out.tools === undefined &&
+    out.systemPrompt === undefined &&
+    out.output === undefined &&
+    out.conversationPreview === undefined
+  ) {
+    return undefined;
+  }
+  return out;
 }
 
 function stringField(value: unknown): string {

--- a/js/src/hooks.ts
+++ b/js/src/hooks.ts
@@ -1,10 +1,4 @@
-import type {
-  HookEvaluateRequest,
-  HookEvaluateResponse,
-  HookEvaluation,
-  HookInput,
-  HooksConfig,
-} from './types.js';
+import type { HookEvaluateRequest, HookEvaluateResponse, HookEvaluation, HookInput, HooksConfig } from './types.js';
 import { asError } from './utils.js';
 
 const hooksEvaluatePath = '/api/v1/hooks:evaluate';

--- a/js/src/hooks.ts
+++ b/js/src/hooks.ts
@@ -1,4 +1,15 @@
-import type { HookEvaluateRequest, HookEvaluateResponse, HookEvaluation, HookInput, HooksConfig } from './types.js';
+import type {
+  HookEvaluateRequest,
+  HookEvaluateResponse,
+  HookEvaluation,
+  HookInput,
+  HooksConfig,
+  Message,
+  MessagePart,
+  ToolCallPart,
+  ToolDefinition,
+  ToolResultPart,
+} from './types.js';
 import { asError } from './utils.js';
 
 const hooksEvaluatePath = '/api/v1/hooks:evaluate';
@@ -231,21 +242,31 @@ function parseTransformedInputPayload(payload: Record<string, unknown>): HookInp
   if (!isRecord(raw)) {
     return undefined;
   }
+  return parseHookInputWire(raw);
+}
+
+/** Parses `transformed_input` from the Sigil API (SDK-shaped JSON and Go/proto JSON encodings). */
+function parseHookInputWire(raw: Record<string, unknown>): HookInput | undefined {
   const out: HookInput = {};
-  if (Array.isArray(raw.messages) && raw.messages.length > 0) {
-    out.messages = raw.messages as HookInput['messages'];
+  const msgs = parseWireMessages(raw.messages);
+  if (msgs !== undefined && msgs.length > 0) {
+    out.messages = msgs;
   }
-  if (Array.isArray(raw.tools) && raw.tools.length > 0) {
-    out.tools = raw.tools as HookInput['tools'];
+  const tools = parseWireTools(raw.tools);
+  if (tools !== undefined && tools.length > 0) {
+    out.tools = tools;
   }
-  if (typeof raw.system_prompt === 'string' && raw.system_prompt.length > 0) {
-    out.systemPrompt = raw.system_prompt;
+  const output = parseWireMessages(raw.output);
+  if (output !== undefined && output.length > 0) {
+    out.output = output;
   }
-  if (Array.isArray(raw.output) && raw.output.length > 0) {
-    out.output = raw.output as HookInput['output'];
+  const sp = raw.system_prompt ?? raw.systemPrompt;
+  if (typeof sp === 'string' && sp.length > 0) {
+    out.systemPrompt = sp;
   }
-  if (typeof raw.conversation_preview === 'string' && raw.conversation_preview.length > 0) {
-    out.conversationPreview = raw.conversation_preview;
+  const cp = raw.conversation_preview ?? raw.conversationPreview;
+  if (typeof cp === 'string' && cp.length > 0) {
+    out.conversationPreview = cp;
   }
   if (
     out.messages === undefined &&
@@ -253,6 +274,227 @@ function parseTransformedInputPayload(payload: Record<string, unknown>): HookInp
     out.systemPrompt === undefined &&
     out.output === undefined &&
     out.conversationPreview === undefined
+  ) {
+    return undefined;
+  }
+  return out;
+}
+
+function parseWireTools(raw: unknown): ToolDefinition[] | undefined {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return undefined;
+  }
+  const out: ToolDefinition[] = [];
+  for (const item of raw) {
+    if (!isRecord(item)) {
+      continue;
+    }
+    const td = parseWireToolDefinition(item);
+    if (td !== undefined) {
+      out.push(td);
+    }
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function parseWireToolDefinition(rec: Record<string, unknown>): ToolDefinition | undefined {
+  const name = typeof rec.name === 'string' ? rec.name : '';
+  if (name.length === 0) {
+    return undefined;
+  }
+  const out: ToolDefinition = { name };
+  if (typeof rec.description === 'string') {
+    out.description = rec.description;
+  }
+  if (typeof rec.type === 'string') {
+    out.type = rec.type;
+  }
+  const schemaKey = rec.input_schema_json ?? rec.inputSchemaJson ?? rec.inputSchemaJSON;
+  if (typeof schemaKey === 'string' && schemaKey.length > 0) {
+    out.inputSchemaJSON = maybeDecodeGoProtoJSONBytes(schemaKey);
+  }
+  return out;
+}
+
+function maybeDecodeGoProtoJSONBytes(value: string): string {
+  if (!/^[A-Za-z0-9+/]+=*$/.test(value) || value.length < 4) {
+    return value;
+  }
+  try {
+    const g = globalThis as typeof globalThis & {
+      Buffer?: { from(data: string, enc: string): { toString(enc: string): string } };
+    };
+    if (g.Buffer !== undefined) {
+      const text = g.Buffer.from(value, 'base64').toString('utf8');
+      if (text.length > 0) {
+        return text;
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  return value;
+}
+
+function parseWireMessages(raw: unknown): Message[] | undefined {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return undefined;
+  }
+  const out: Message[] = [];
+  for (const item of raw) {
+    if (!isRecord(item)) {
+      continue;
+    }
+    const m = parseWireMessage(item);
+    if (m !== undefined) {
+      out.push(m);
+    }
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function parseWireMessage(rec: Record<string, unknown>): Message | undefined {
+  const role = wireRoleToSdk(rec.role);
+  const partsRaw = rec.parts;
+  const parts: MessagePart[] = [];
+  if (Array.isArray(partsRaw)) {
+    for (const p of partsRaw) {
+      if (!isRecord(p)) {
+        continue;
+      }
+      const part = parseWireMessagePart(p);
+      if (part !== undefined) {
+        parts.push(part);
+      }
+    }
+  }
+  const name = typeof rec.name === 'string' ? rec.name : undefined;
+  const content = typeof rec.content === 'string' ? rec.content : undefined;
+  return {
+    role,
+    ...(name !== undefined ? { name } : {}),
+    ...(content !== undefined ? { content } : {}),
+    ...(parts.length > 0 ? { parts } : {}),
+  };
+}
+
+function wireRoleToSdk(role: unknown): string {
+  if (typeof role === 'string') {
+    return role.toLowerCase();
+  }
+  if (role === 1) {
+    return 'user';
+  }
+  if (role === 2) {
+    return 'assistant';
+  }
+  if (role === 3) {
+    return 'tool';
+  }
+  return 'user';
+}
+
+function parseWireMessagePart(rec: Record<string, unknown>): MessagePart | undefined {
+  const typ = rec.type;
+  if (typ === 'text' && typeof rec.text === 'string') {
+    return { type: 'text', text: rec.text };
+  }
+  if (typ === 'thinking' && typeof rec.thinking === 'string') {
+    return { type: 'thinking', thinking: rec.thinking };
+  }
+  if (typ === 'tool_call' && isRecord(rec.toolCall)) {
+    const tc = parseWireToolCallPart(rec.toolCall);
+    return tc !== undefined ? { type: 'tool_call', toolCall: tc } : undefined;
+  }
+  if (typ === 'tool_result' && isRecord(rec.toolResult)) {
+    const tr = parseWireToolResultPart(rec.toolResult);
+    return tr !== undefined ? { type: 'tool_result', toolResult: tr } : undefined;
+  }
+
+  const payload = rec.Payload ?? rec.payload;
+  if (isRecord(payload)) {
+    if (typeof payload.Text === 'string') {
+      return { type: 'text', text: payload.Text };
+    }
+    if (typeof payload.Thinking === 'string') {
+      return { type: 'thinking', thinking: payload.Thinking };
+    }
+    if (isRecord(payload.ToolCall)) {
+      const tc = parseWireToolCallPart(payload.ToolCall);
+      return tc !== undefined ? { type: 'tool_call', toolCall: tc } : undefined;
+    }
+    if (isRecord(payload.ToolResult)) {
+      const tr = parseWireToolResultPart(payload.ToolResult);
+      return tr !== undefined ? { type: 'tool_result', toolResult: tr } : undefined;
+    }
+  }
+
+  const kind = typeof rec.kind === 'string' ? rec.kind : '';
+  if (kind === 'text' && typeof rec.text === 'string') {
+    return { type: 'text', text: rec.text };
+  }
+  if (kind === 'thinking' && typeof rec.thinking === 'string') {
+    return { type: 'thinking', thinking: rec.thinking };
+  }
+  if (kind === 'tool_call') {
+    const rawTc = rec.tool_call ?? rec.toolCall;
+    if (isRecord(rawTc)) {
+      const tc = parseWireToolCallPart(rawTc);
+      return tc !== undefined ? { type: 'tool_call', toolCall: tc } : undefined;
+    }
+  }
+  if (kind === 'tool_result') {
+    const rawTr = rec.tool_result ?? rec.toolResult;
+    if (isRecord(rawTr)) {
+      const tr = parseWireToolResultPart(rawTr);
+      return tr !== undefined ? { type: 'tool_result', toolResult: tr } : undefined;
+    }
+  }
+  return undefined;
+}
+
+function parseWireToolCallPart(rec: Record<string, unknown>): ToolCallPart | undefined {
+  const name = typeof rec.name === 'string' ? rec.name : '';
+  if (name.length === 0) {
+    return undefined;
+  }
+  const out: ToolCallPart = { name };
+  if (typeof rec.id === 'string') {
+    out.id = rec.id;
+  }
+  const rawInput = rec.input_json ?? rec.inputJson ?? rec.inputJSON;
+  if (typeof rawInput === 'string' && rawInput.length > 0) {
+    out.inputJSON = maybeDecodeGoProtoJSONBytes(rawInput);
+  }
+  return out;
+}
+
+function parseWireToolResultPart(rec: Record<string, unknown>): ToolResultPart | undefined {
+  const out: ToolResultPart = {};
+  if (typeof rec.tool_call_id === 'string') {
+    out.toolCallId = rec.tool_call_id;
+  } else if (typeof rec.toolCallId === 'string') {
+    out.toolCallId = rec.toolCallId;
+  }
+  if (typeof rec.name === 'string') {
+    out.name = rec.name;
+  }
+  if (typeof rec.content === 'string') {
+    out.content = rec.content;
+  }
+  const rawCj = rec.content_json ?? rec.contentJson ?? rec.contentJSON;
+  if (typeof rawCj === 'string' && rawCj.length > 0) {
+    out.contentJSON = maybeDecodeGoProtoJSONBytes(rawCj);
+  }
+  if (rec.is_error === true || rec.isError === true) {
+    out.isError = true;
+  }
+  if (
+    out.toolCallId === undefined &&
+    out.name === undefined &&
+    out.content === undefined &&
+    out.contentJSON === undefined &&
+    out.isError === undefined
   ) {
     return undefined;
   }

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -598,5 +598,10 @@ export interface HookEvaluateResponse {
   action: HookAction;
   ruleId?: string;
   reason?: string;
+  /**
+   * When the server applied hook transform rules, the redacted/sanitized
+   * payload to use instead of the original request input.
+   */
+  transformedInput?: HookInput;
   evaluations: HookEvaluation[];
 }

--- a/js/test/client.hooks.test.mjs
+++ b/js/test/client.hooks.test.mjs
@@ -149,6 +149,49 @@ test('evaluateHook parses transformed_input from allow response', async () => {
   }
 });
 
+test('evaluateHook normalizes Go/json-encoded proto transformed_input messages', async () => {
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(
+      JSON.stringify({
+        action: 'allow',
+        transformed_input: {
+          messages: [
+            {
+              role: 1,
+              parts: [{ Payload: { Text: 'hello' } }],
+            },
+          ],
+        },
+        evaluations: [],
+      }),
+    );
+  });
+  await listen(server);
+  const address = server.address();
+
+  const client = newClient({
+    apiEndpoint: `http://127.0.0.1:${address.port}`,
+    hooksEnabled: true,
+  });
+
+  try {
+    const response = await client.evaluateHook({
+      phase: 'preflight',
+      context: { model: { provider: 'openai', name: 'gpt-4o' } },
+      input: {},
+    });
+    assert.equal(response.action, 'allow');
+    const msg = response.transformedInput?.messages?.[0];
+    assert.equal(msg?.role, 'user');
+    assert.equal(msg?.parts?.[0]?.type, 'text');
+    assert.equal(msg?.parts?.[0]?.type === 'text' ? msg.parts[0].text : '', 'hello');
+  } finally {
+    await client.shutdown();
+    await close(server);
+  }
+});
+
 test('evaluateHook returns deny payload as-is', async () => {
   const server = createServer((_request, response) => {
     response.writeHead(200, { 'content-type': 'application/json' });

--- a/js/test/client.hooks.test.mjs
+++ b/js/test/client.hooks.test.mjs
@@ -116,6 +116,39 @@ test('evaluateHook posts JSON to /api/v1/hooks:evaluate and parses allow respons
   }
 });
 
+test('evaluateHook parses transformed_input from allow response', async () => {
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(
+      JSON.stringify({
+        action: 'allow',
+        transformed_input: { conversation_preview: '[REDACTED]' },
+        evaluations: [],
+      }),
+    );
+  });
+  await listen(server);
+  const address = server.address();
+
+  const client = newClient({
+    apiEndpoint: `http://127.0.0.1:${address.port}`,
+    hooksEnabled: true,
+  });
+
+  try {
+    const response = await client.evaluateHook({
+      phase: 'preflight',
+      context: { model: { provider: 'openai', name: 'gpt-4o' } },
+      input: {},
+    });
+    assert.equal(response.action, 'allow');
+    assert.equal(response.transformedInput?.conversationPreview, '[REDACTED]');
+  } finally {
+    await client.shutdown();
+    await close(server);
+  }
+});
+
 test('evaluateHook returns deny payload as-is', async () => {
   const server = createServer((_request, response) => {
     response.writeHead(200, { 'content-type': 'application/json' });

--- a/python/sigil_sdk/hooks.py
+++ b/python/sigil_sdk/hooks.py
@@ -13,7 +13,7 @@ from urllib import request as urllib_request
 
 from .config import HooksConfig
 from .errors import HookDeniedError, HookTransportError
-from .models import Message, PartKind, ToolDefinition
+from .models import Message, MessageRole, Part, PartKind, ToolDefinition
 
 HOOKS_EVALUATE_PATH = "/api/v1/hooks:evaluate"
 HOOK_TIMEOUT_HEADER = "X-Sigil-Hook-Timeout-Ms"
@@ -93,6 +93,7 @@ class HookEvaluateResponse:
     action: str
     rule_id: str = ""
     reason: str = ""
+    transformed_input: HookInput | None = None
     evaluations: list[HookEvaluation] = field(default_factory=list)
 
     @property
@@ -325,12 +326,70 @@ def _parse_response(payload: Any) -> HookEvaluateResponse:
                     reason=_string_field(entry.get("reason")),
                 )
             )
+    raw_ti = payload.get("transformed_input")
+    transformed_input = _parse_hook_input_wire(raw_ti)
+
     return HookEvaluateResponse(
         action=action,
         rule_id=rule_id,
         reason=reason,
+        transformed_input=transformed_input,
         evaluations=evaluations,
     )
+
+
+def _parse_hook_input_wire(data: Any) -> HookInput | None:
+    """Parses server transformed_input (snake_case JSON) into HookInput."""
+
+    if not isinstance(data, dict):
+        return None
+    out = HookInput()
+    cp = data.get("conversation_preview")
+    if isinstance(cp, str) and cp != "":
+        out.conversation_preview = cp
+    sp = data.get("system_prompt")
+    if isinstance(sp, str) and sp != "":
+        out.system_prompt = sp
+    raw_msgs = data.get("messages")
+    if isinstance(raw_msgs, list):
+        msgs: list[Message] = []
+        for item in raw_msgs:
+            m = _parse_wire_message_dict(item)
+            if m is not None:
+                msgs.append(m)
+        if msgs:
+            out.messages = msgs
+    if out.messages or out.conversation_preview or out.system_prompt:
+        return out
+    return None
+
+
+def _parse_wire_message_dict(item: Any) -> Message | None:
+    if not isinstance(item, dict):
+        return None
+    role_raw = str(item.get("role", "user")).lower()
+    role = MessageRole.USER
+    if role_raw == "assistant":
+        role = MessageRole.ASSISTANT
+    elif role_raw == "tool":
+        role = MessageRole.TOOL
+    parts_raw = item.get("parts")
+    if not isinstance(parts_raw, list):
+        return Message(role=role, parts=[])
+    parts: list[Part] = []
+    for pr in parts_raw:
+        if not isinstance(pr, dict):
+            continue
+        txt = pr.get("text")
+        if isinstance(txt, str) and txt != "":
+            parts.append(Part(kind=PartKind.TEXT, text=txt))
+            continue
+        think = pr.get("thinking")
+        if isinstance(think, str) and think != "":
+            parts.append(Part(kind=PartKind.THINKING, thinking=think))
+    name = item.get("name")
+    n = str(name) if isinstance(name, str) else ""
+    return Message(role=role, parts=parts, name=n)
 
 
 def _string_field(value: Any) -> str:

--- a/python/sigil_sdk/hooks.py
+++ b/python/sigil_sdk/hooks.py
@@ -367,12 +367,19 @@ def _parse_hook_input_wire(data: Any) -> HookInput | None:
 def _parse_wire_message_dict(item: Any) -> Message | None:
     if not isinstance(item, dict):
         return None
-    role_raw = str(item.get("role", "user")).lower()
+    role_val = item.get("role", "user")
     role = MessageRole.USER
-    if role_raw == "assistant":
-        role = MessageRole.ASSISTANT
-    elif role_raw == "tool":
-        role = MessageRole.TOOL
+    if isinstance(role_val, int):
+        if role_val == 2:
+            role = MessageRole.ASSISTANT
+        elif role_val == 3:
+            role = MessageRole.TOOL
+    else:
+        role_raw = str(role_val).lower()
+        if role_raw == "assistant":
+            role = MessageRole.ASSISTANT
+        elif role_raw == "tool":
+            role = MessageRole.TOOL
     parts_raw = item.get("parts")
     if not isinstance(parts_raw, list):
         return Message(role=role, parts=[])

--- a/python/tests/test_hooks_transport.py
+++ b/python/tests/test_hooks_transport.py
@@ -23,6 +23,7 @@ from sigil_sdk import (
     HookPhase,
     HooksConfig,
     HookTransportError,
+    MessageRole,
     hook_denied_from_response,
     user_text_message,
 )
@@ -41,6 +42,25 @@ def test_parse_hook_response_includes_transformed_input() -> None:
     assert parsed.action == "allow"
     assert parsed.transformed_input is not None
     assert parsed.transformed_input.conversation_preview == "[REDACTED]"
+
+
+def test_parse_hook_response_transformed_messages_numeric_proto_role() -> None:
+    from sigil_sdk.hooks import _parse_response
+
+    parsed = _parse_response(
+        {
+            "action": "allow",
+            "transformed_input": {
+                "messages": [
+                    {"role": 2, "parts": [{"text": "hello"}]},
+                ],
+            },
+            "evaluations": [],
+        }
+    )
+    assert parsed.transformed_input is not None
+    assert len(parsed.transformed_input.messages) == 1
+    assert parsed.transformed_input.messages[0].role == MessageRole.ASSISTANT
 
 
 def test_evaluate_hook_disabled_short_circuits() -> None:

--- a/python/tests/test_hooks_transport.py
+++ b/python/tests/test_hooks_transport.py
@@ -28,6 +28,21 @@ from sigil_sdk import (
 )
 
 
+def test_parse_hook_response_includes_transformed_input() -> None:
+    from sigil_sdk.hooks import _parse_response
+
+    parsed = _parse_response(
+        {
+            "action": "allow",
+            "transformed_input": {"conversation_preview": "[REDACTED]"},
+            "evaluations": [],
+        }
+    )
+    assert parsed.action == "allow"
+    assert parsed.transformed_input is not None
+    assert parsed.transformed_input.conversation_preview == "[REDACTED]"
+
+
 def test_evaluate_hook_disabled_short_circuits() -> None:
     class _Handler(BaseHTTPRequestHandler):
         def do_POST(self):  # noqa: N802


### PR DESCRIPTION
## Summary
- Add `transformed_input` to hook evaluation responses (Go, JavaScript, Python).
- Vercel AI SDK: use `transformedInput.messages` for step state when the server returns them.

## Server dependency
- Requires Sigil server changes: https://github.com/grafana/sigil/pull/870

## Testing
- `go test ./go/sigil/...`
- `pnpm run test` (js)
- `pytest python/tests/test_hooks_transport.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds cross-SDK parsing/normalization of an optional `transformed_input` payload and changes Vercel AI step-state recording to use server-transformed messages when present; mistakes could alter captured/recorded prompts or tool schemas but the field is optional and defaults preserve existing behavior.
> 
> **Overview**
> Adds support for an optional `transformed_input` field on `hooks:evaluate` responses across Go, JS, and Python SDKs, exposing sanitized/redacted inputs back to callers.
> 
> In the JS SDK, `evaluateHook` now parses and *normalizes* `transformed_input` (including Go/proto-style JSON encodings and base64-encoded JSON fields for tools/tool parts), and the Vercel AI SDK instrumentation updates preflight handling to prefer `response.transformedInput.messages` when creating step state.
> 
> Includes new/updated unit tests in Go, JS, and Python covering transformed input parsing and message-role normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbb39d53e8f397a7c88d2aa1a5a3eba91a4cd4e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->