### PR TITLE
fix(plugins/pi): fix sending OTel telemetry

### DIFF
--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -163,4 +163,4 @@ Every generation always carries model, token usage (input/output/cache), cost, s
 | `no_tool_content` | assistant text and thinking |
 | `full` | assistant text, thinking, tool call arguments, tool results |
 
-When `otlp` is configured, the SDK additionally exports `gen_ai.client.operation.duration`, `gen_ai.client.token.usage`, and `gen_ai.client.tool_calls_per_operation` histograms (provider/model/agent labels) plus one trace span per generation.
+When `otlp` is configured, the SDK additionally exports `gen_ai.client.operation.duration`, `gen_ai.client.token.usage`, and `gen_ai.client.tool_calls_per_operation` histograms (provider/model/agent labels) plus one trace span per generation. The plugin sets the OTel resource `service.name` to `sigil-pi` for both metrics and traces.

--- a/plugins/pi/package.json
+++ b/plugins/pi/package.json
@@ -50,6 +50,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.214.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
+    "@opentelemetry/resources": "^2.6.1",
     "@opentelemetry/sdk-metrics": "^2.1.0",
     "@opentelemetry/sdk-trace-base": "^2.5.0",
     "@types/node": "^25.6.0",

--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { loadConfigMock, createSigilClientMock } = vi.hoisted(() => ({
-  loadConfigMock: vi.fn(),
-  createSigilClientMock: vi.fn(),
-}));
+const { loadConfigMock, createSigilClientMock, createTelemetryProvidersMock } =
+  vi.hoisted(() => ({
+    loadConfigMock: vi.fn(),
+    createSigilClientMock: vi.fn(),
+    createTelemetryProvidersMock: vi.fn(),
+  }));
 
 vi.mock("./config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./config.js")>();
@@ -15,6 +17,10 @@ vi.mock("./config.js", async (importOriginal) => {
 
 vi.mock("./client.js", () => ({
   createSigilClient: createSigilClientMock,
+}));
+
+vi.mock("./telemetry.js", () => ({
+  createTelemetryProviders: createTelemetryProvidersMock,
 }));
 
 import type { SigilClient } from "@grafana/sigil-sdk-js";
@@ -110,6 +116,7 @@ describe("extension lifecycle", () => {
   beforeEach(() => {
     loadConfigMock.mockReset();
     createSigilClientMock.mockReset();
+    createTelemetryProvidersMock.mockReset();
   });
 
   it("handles the happy path and exports one generation with user input", async () => {
@@ -171,6 +178,62 @@ describe("extension lifecycle", () => {
       type: "text",
       text: "hey",
     });
+  });
+
+  it("force flushes telemetry after exporting a turn", async () => {
+    const recorder = {
+      setResult: vi.fn(),
+      setCallError: vi.fn(),
+    };
+
+    const sigil: SigilLike = {
+      startGeneration: vi.fn(async (_seed, run) => {
+        await run(recorder);
+      }),
+      startToolExecution: vi.fn(() => ({
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        end: vi.fn(),
+        getError: vi.fn(),
+      })),
+      shutdown: vi.fn(async () => {}),
+    };
+    const telemetry = {
+      tracer: { tracer: true },
+      meter: { meter: true },
+      forceFlush: vi.fn(async () => {}),
+      shutdown: vi.fn(async () => {}),
+    };
+
+    loadConfigMock.mockResolvedValue({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      auth: { mode: "none" },
+      agentName: "pi",
+      contentCapture: "metadata_only",
+      otlp: { endpoint: "http://localhost:4318", headers: {} },
+    });
+    createTelemetryProvidersMock.mockReturnValue(telemetry);
+    createSigilClientMock.mockReturnValue(sigil);
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+
+    await pi.emit("session_start");
+    await pi.emit("turn_start");
+    await pi.emit("turn_end", { message: assistantMessage(), toolResults: [] });
+
+    expect(createTelemetryProvidersMock).toHaveBeenCalledWith({
+      endpoint: "http://localhost:4318",
+      headers: {},
+    });
+    expect(createSigilClientMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        tracer: telemetry.tracer,
+        meter: telemetry.meter,
+      }),
+    );
+    expect(telemetry.forceFlush).toHaveBeenCalledTimes(1);
   });
 
   it("leaves input empty on a tool-loop continuation with no user message_end", async () => {

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -263,6 +263,12 @@ export default function (pi: ExtensionAPI) {
           contentCapture,
         });
       });
+      if (telemetry) {
+        void telemetry.forceFlush().catch((err) => {
+          console.warn("[sigil-pi] telemetry flush failed:", err);
+        });
+      }
+
       debugLog(
         `generation queued, model=${msg.model} tokens=${msg.usage.totalTokens}`,
       );

--- a/plugins/pi/src/telemetry.test.ts
+++ b/plugins/pi/src/telemetry.test.ts
@@ -1,0 +1,117 @@
+import { createServer, type IncomingHttpHeaders } from "node:http";
+import { describe, expect, it } from "vitest";
+import { createTelemetryProviders } from "./telemetry.js";
+
+const OTLP_AGGREGATION_TEMPORALITY_CUMULATIVE = 2;
+
+interface CapturedRequest {
+  url: string | undefined;
+  headers: IncomingHttpHeaders;
+  body: string;
+}
+
+async function startOtlpServer() {
+  const requests: CapturedRequest[] = [];
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      requests.push({
+        url: req.url,
+        headers: req.headers,
+        body: Buffer.concat(chunks).toString("utf-8"),
+      });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end("{}");
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("server did not bind to a TCP port");
+  }
+
+  return {
+    endpoint: `http://127.0.0.1:${address.port}/otlp`,
+    requests,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+function parseMetricPayload(requests: CapturedRequest[], metricName: string) {
+  for (const request of requests.filter((r) => r.url === "/otlp/v1/metrics")) {
+    const payload = JSON.parse(request.body) as {
+      resourceMetrics?: Array<{
+        resource?: {
+          attributes?: Array<{
+            key: string;
+            value: { stringValue?: string };
+          }>;
+        };
+        scopeMetrics?: Array<{
+          metrics?: Array<{
+            name: string;
+            histogram?: { aggregationTemporality?: number };
+          }>;
+        }>;
+      }>;
+    };
+
+    for (const resourceMetric of payload.resourceMetrics ?? []) {
+      for (const scopeMetric of resourceMetric.scopeMetrics ?? []) {
+        const metric = scopeMetric.metrics?.find((m) => m.name === metricName);
+        if (metric) return { request, resourceMetric, metric };
+      }
+    }
+  }
+
+  throw new Error(`metric ${metricName} was not exported`);
+}
+
+describe("createTelemetryProviders", () => {
+  it("exports metrics with sigil-pi resource and cumulative temporality", async () => {
+    const server = await startOtlpServer();
+    try {
+      const providers = createTelemetryProviders({
+        endpoint: server.endpoint,
+        headers: { "X-Test-Header": "present" },
+      });
+
+      providers.meter
+        .createHistogram("sigil_pi.test.duration", { unit: "s" })
+        .record(0.5, { test: "true" });
+
+      await providers.forceFlush();
+      await providers.shutdown();
+
+      const { request, resourceMetric, metric } = parseMetricPayload(
+        server.requests,
+        "sigil_pi.test.duration",
+      );
+
+      expect(request.headers["x-test-header"]).toBe("present");
+
+      const resourceAttributes = Object.fromEntries(
+        (resourceMetric.resource?.attributes ?? []).map((attr) => [
+          attr.key,
+          attr.value.stringValue,
+        ]),
+      );
+      expect(resourceAttributes["service.name"]).toBe("sigil-pi");
+      expect(resourceAttributes["telemetry.sdk.language"]).toBe("nodejs");
+
+      expect(metric.histogram?.aggregationTemporality).toBe(
+        OTLP_AGGREGATION_TEMPORALITY_CUMULATIVE,
+      );
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/plugins/pi/src/telemetry.ts
+++ b/plugins/pi/src/telemetry.ts
@@ -5,11 +5,12 @@
  */
 
 import type { Meter, Tracer } from "@opentelemetry/api";
-import {
-  AggregationTemporalityPreference,
-  OTLPMetricExporter,
-} from "@opentelemetry/exporter-metrics-otlp-http";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import {
+  defaultResource,
+  resourceFromAttributes,
+} from "@opentelemetry/resources";
 import {
   MeterProvider,
   PeriodicExportingMetricReader,
@@ -21,26 +22,32 @@ import {
 import type { OtlpConfig } from "./config.js";
 
 const INSTRUMENTATION_SCOPE = "sigil-pi";
+const SERVICE_NAME = "sigil-pi";
 
 export interface TelemetryProviders {
   tracer: Tracer;
   meter: Meter;
+  forceFlush: () => Promise<void>;
   shutdown: () => Promise<void>;
 }
 
 export function createTelemetryProviders(otlp: OtlpConfig): TelemetryProviders {
   const base = otlp.endpoint.replace(/\/+$/, "");
+  const resource = defaultResource().merge(
+    resourceFromAttributes({ "service.name": SERVICE_NAME }),
+  );
 
   const metricExporter = new OTLPMetricExporter({
     url: `${base}/v1/metrics`,
     headers: otlp.headers,
-    temporalityPreference: AggregationTemporalityPreference.DELTA,
   });
   const metricReader = new PeriodicExportingMetricReader({
     exporter: metricExporter,
-    exportIntervalMillis: 15_000,
+    exportIntervalMillis: 5_000,
+    exportTimeoutMillis: 5_000,
   });
   const meterProvider = new MeterProvider({
+    resource,
     readers: [metricReader],
   });
 
@@ -49,25 +56,36 @@ export function createTelemetryProviders(otlp: OtlpConfig): TelemetryProviders {
     headers: otlp.headers,
   });
   const tracerProvider = new BasicTracerProvider({
+    resource,
     spanProcessors: [new BatchSpanProcessor(traceExporter)],
   });
 
   return {
     tracer: tracerProvider.getTracer(INSTRUMENTATION_SCOPE),
     meter: meterProvider.getMeter(INSTRUMENTATION_SCOPE),
+    forceFlush: async () => {
+      await settleOrThrow(
+        [meterProvider.forceFlush(), tracerProvider.forceFlush()],
+        "telemetry force flush failed",
+      );
+    },
     shutdown: async () => {
-      // Both providers must attempt shutdown even if one fails, so we use
-      // allSettled and aggregate errors afterwards rather than short-circuiting.
-      const results = await Promise.allSettled([
-        meterProvider.shutdown(),
-        tracerProvider.shutdown(),
-      ]);
-      const reasons = results
-        .filter((r): r is PromiseRejectedResult => r.status === "rejected")
-        .map((r) => r.reason);
-      if (reasons.length > 0) {
-        throw new AggregateError(reasons, "telemetry shutdown failed");
-      }
+      await settleOrThrow(
+        [meterProvider.shutdown(), tracerProvider.shutdown()],
+        "telemetry shutdown failed",
+      );
     },
   };
+}
+
+async function settleOrThrow(promises: Promise<void>[], message: string) {
+  // Both providers must attempt the operation even if one fails, so we use
+  // allSettled and aggregate errors afterwards rather than short-circuiting.
+  const results = await Promise.allSettled(promises);
+  const reasons = results
+    .filter((r): r is PromiseRejectedResult => r.status === "rejected")
+    .map((r) => r.reason);
+  if (reasons.length > 0) {
+    throw new AggregateError(reasons, message);
+  }
 }

--- a/plugins/pi/src/telemetry.ts
+++ b/plugins/pi/src/telemetry.ts
@@ -8,16 +8,16 @@ import type { Meter, Tracer } from "@opentelemetry/api";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import {
-  defaultResource,
-  resourceFromAttributes,
+    defaultResource,
+    resourceFromAttributes,
 } from "@opentelemetry/resources";
 import {
-  MeterProvider,
-  PeriodicExportingMetricReader,
+    MeterProvider,
+    PeriodicExportingMetricReader,
 } from "@opentelemetry/sdk-metrics";
 import {
-  BasicTracerProvider,
-  BatchSpanProcessor,
+    BasicTracerProvider,
+    BatchSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
 import type { OtlpConfig } from "./config.js";
 
@@ -25,67 +25,67 @@ const INSTRUMENTATION_SCOPE = "sigil-pi";
 const SERVICE_NAME = "sigil-pi";
 
 export interface TelemetryProviders {
-  tracer: Tracer;
-  meter: Meter;
-  forceFlush: () => Promise<void>;
-  shutdown: () => Promise<void>;
+    tracer: Tracer;
+    meter: Meter;
+    forceFlush: () => Promise<void>;
+    shutdown: () => Promise<void>;
 }
 
 export function createTelemetryProviders(otlp: OtlpConfig): TelemetryProviders {
-  const base = otlp.endpoint.replace(/\/+$/, "");
-  const resource = defaultResource().merge(
-    resourceFromAttributes({ "service.name": SERVICE_NAME }),
-  );
+    const base = otlp.endpoint.replace(/\/+$/, "");
+    const resource = defaultResource().merge(
+        resourceFromAttributes({ "service.name": SERVICE_NAME }),
+    );
 
-  const metricExporter = new OTLPMetricExporter({
-    url: `${base}/v1/metrics`,
-    headers: otlp.headers,
-  });
-  const metricReader = new PeriodicExportingMetricReader({
-    exporter: metricExporter,
-    exportIntervalMillis: 5_000,
-    exportTimeoutMillis: 5_000,
-  });
-  const meterProvider = new MeterProvider({
-    resource,
-    readers: [metricReader],
-  });
+    const metricExporter = new OTLPMetricExporter({
+        url: `${base}/v1/metrics`,
+        headers: otlp.headers,
+    });
+    const metricReader = new PeriodicExportingMetricReader({
+        exporter: metricExporter,
+        exportIntervalMillis: 15_000,
+        exportTimeoutMillis: 15_000,
+    });
+    const meterProvider = new MeterProvider({
+        resource,
+        readers: [metricReader],
+    });
 
-  const traceExporter = new OTLPTraceExporter({
-    url: `${base}/v1/traces`,
-    headers: otlp.headers,
-  });
-  const tracerProvider = new BasicTracerProvider({
-    resource,
-    spanProcessors: [new BatchSpanProcessor(traceExporter)],
-  });
+    const traceExporter = new OTLPTraceExporter({
+        url: `${base}/v1/traces`,
+        headers: otlp.headers,
+    });
+    const tracerProvider = new BasicTracerProvider({
+        resource,
+        spanProcessors: [new BatchSpanProcessor(traceExporter)],
+    });
 
-  return {
-    tracer: tracerProvider.getTracer(INSTRUMENTATION_SCOPE),
-    meter: meterProvider.getMeter(INSTRUMENTATION_SCOPE),
-    forceFlush: async () => {
-      await settleOrThrow(
-        [meterProvider.forceFlush(), tracerProvider.forceFlush()],
-        "telemetry force flush failed",
-      );
-    },
-    shutdown: async () => {
-      await settleOrThrow(
-        [meterProvider.shutdown(), tracerProvider.shutdown()],
-        "telemetry shutdown failed",
-      );
-    },
-  };
+    return {
+        tracer: tracerProvider.getTracer(INSTRUMENTATION_SCOPE),
+        meter: meterProvider.getMeter(INSTRUMENTATION_SCOPE),
+        forceFlush: async () => {
+            await settleOrThrow(
+                [meterProvider.forceFlush(), tracerProvider.forceFlush()],
+                "telemetry force flush failed",
+            );
+        },
+        shutdown: async () => {
+            await settleOrThrow(
+                [meterProvider.shutdown(), tracerProvider.shutdown()],
+                "telemetry shutdown failed",
+            );
+        },
+    };
 }
 
 async function settleOrThrow(promises: Promise<void>[], message: string) {
-  // Both providers must attempt the operation even if one fails, so we use
-  // allSettled and aggregate errors afterwards rather than short-circuiting.
-  const results = await Promise.allSettled(promises);
-  const reasons = results
-    .filter((r): r is PromiseRejectedResult => r.status === "rejected")
-    .map((r) => r.reason);
-  if (reasons.length > 0) {
-    throw new AggregateError(reasons, message);
-  }
+    // Both providers must attempt the operation even if one fails, so we use
+    // allSettled and aggregate errors afterwards rather than short-circuiting.
+    const results = await Promise.allSettled(promises);
+    const reasons = results
+        .filter((r): r is PromiseRejectedResult => r.status === "rejected")
+        .map((r) => r.reason);
+    if (reasons.length > 0) {
+        throw new AggregateError(reasons, message);
+    }
 }

--- a/plugins/pi/src/telemetry.ts
+++ b/plugins/pi/src/telemetry.ts
@@ -8,16 +8,16 @@ import type { Meter, Tracer } from "@opentelemetry/api";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import {
-    defaultResource,
-    resourceFromAttributes,
+  defaultResource,
+  resourceFromAttributes,
 } from "@opentelemetry/resources";
 import {
-    MeterProvider,
-    PeriodicExportingMetricReader,
+  MeterProvider,
+  PeriodicExportingMetricReader,
 } from "@opentelemetry/sdk-metrics";
 import {
-    BasicTracerProvider,
-    BatchSpanProcessor,
+  BasicTracerProvider,
+  BatchSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
 import type { OtlpConfig } from "./config.js";
 
@@ -25,67 +25,67 @@ const INSTRUMENTATION_SCOPE = "sigil-pi";
 const SERVICE_NAME = "sigil-pi";
 
 export interface TelemetryProviders {
-    tracer: Tracer;
-    meter: Meter;
-    forceFlush: () => Promise<void>;
-    shutdown: () => Promise<void>;
+  tracer: Tracer;
+  meter: Meter;
+  forceFlush: () => Promise<void>;
+  shutdown: () => Promise<void>;
 }
 
 export function createTelemetryProviders(otlp: OtlpConfig): TelemetryProviders {
-    const base = otlp.endpoint.replace(/\/+$/, "");
-    const resource = defaultResource().merge(
-        resourceFromAttributes({ "service.name": SERVICE_NAME }),
-    );
+  const base = otlp.endpoint.replace(/\/+$/, "");
+  const resource = defaultResource().merge(
+    resourceFromAttributes({ "service.name": SERVICE_NAME }),
+  );
 
-    const metricExporter = new OTLPMetricExporter({
-        url: `${base}/v1/metrics`,
-        headers: otlp.headers,
-    });
-    const metricReader = new PeriodicExportingMetricReader({
-        exporter: metricExporter,
-        exportIntervalMillis: 15_000,
-        exportTimeoutMillis: 15_000,
-    });
-    const meterProvider = new MeterProvider({
-        resource,
-        readers: [metricReader],
-    });
+  const metricExporter = new OTLPMetricExporter({
+    url: `${base}/v1/metrics`,
+    headers: otlp.headers,
+  });
+  const metricReader = new PeriodicExportingMetricReader({
+    exporter: metricExporter,
+    exportIntervalMillis: 15_000,
+    exportTimeoutMillis: 15_000,
+  });
+  const meterProvider = new MeterProvider({
+    resource,
+    readers: [metricReader],
+  });
 
-    const traceExporter = new OTLPTraceExporter({
-        url: `${base}/v1/traces`,
-        headers: otlp.headers,
-    });
-    const tracerProvider = new BasicTracerProvider({
-        resource,
-        spanProcessors: [new BatchSpanProcessor(traceExporter)],
-    });
+  const traceExporter = new OTLPTraceExporter({
+    url: `${base}/v1/traces`,
+    headers: otlp.headers,
+  });
+  const tracerProvider = new BasicTracerProvider({
+    resource,
+    spanProcessors: [new BatchSpanProcessor(traceExporter)],
+  });
 
-    return {
-        tracer: tracerProvider.getTracer(INSTRUMENTATION_SCOPE),
-        meter: meterProvider.getMeter(INSTRUMENTATION_SCOPE),
-        forceFlush: async () => {
-            await settleOrThrow(
-                [meterProvider.forceFlush(), tracerProvider.forceFlush()],
-                "telemetry force flush failed",
-            );
-        },
-        shutdown: async () => {
-            await settleOrThrow(
-                [meterProvider.shutdown(), tracerProvider.shutdown()],
-                "telemetry shutdown failed",
-            );
-        },
-    };
+  return {
+    tracer: tracerProvider.getTracer(INSTRUMENTATION_SCOPE),
+    meter: meterProvider.getMeter(INSTRUMENTATION_SCOPE),
+    forceFlush: async () => {
+      await settleOrThrow(
+        [meterProvider.forceFlush(), tracerProvider.forceFlush()],
+        "telemetry force flush failed",
+      );
+    },
+    shutdown: async () => {
+      await settleOrThrow(
+        [meterProvider.shutdown(), tracerProvider.shutdown()],
+        "telemetry shutdown failed",
+      );
+    },
+  };
 }
 
 async function settleOrThrow(promises: Promise<void>[], message: string) {
-    // Both providers must attempt the operation even if one fails, so we use
-    // allSettled and aggregate errors afterwards rather than short-circuiting.
-    const results = await Promise.allSettled(promises);
-    const reasons = results
-        .filter((r): r is PromiseRejectedResult => r.status === "rejected")
-        .map((r) => r.reason);
-    if (reasons.length > 0) {
-        throw new AggregateError(reasons, message);
-    }
+  // Both providers must attempt the operation even if one fails, so we use
+  // allSettled and aggregate errors afterwards rather than short-circuiting.
+  const results = await Promise.allSettled(promises);
+  const reasons = results
+    .filter((r): r is PromiseRejectedResult => r.status === "rejected")
+    .map((r) => r.reason);
+  if (reasons.length > 0) {
+    throw new AggregateError(reasons, message);
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.214.0
         version: 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^2.6.1
+        version: 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics':
         specifier: ^2.1.0
         version: 2.6.1(@opentelemetry/api@1.9.1)


### PR DESCRIPTION
- Set service.name (so metrics do not show up as unknown_service)
- Remove delta temporality override
- force flush after each turn end.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes OpenTelemetry export semantics (resource attributes, temporality behavior, and flush timing), which could affect downstream dashboards and add per-turn overhead.
> 
> **Overview**
> Improves `@grafana/sigil-pi` OTLP telemetry reliability by setting an explicit OTel resource `service.name` (`sigil-pi`) for both metrics and traces and by removing the custom delta-temporality override so exports use the SDK defaults.
> 
> After each `turn_end` export, the plugin now triggers a best-effort `telemetry.forceFlush()` to reduce missing/late metrics/spans; telemetry helpers were refactored to share error-aggregating logic, and new tests validate OTLP headers/resource attributes/temporality plus the per-turn flush behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46e0e98995b7bed69aa84b3e152adfe8095a17db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->