### PR TITLE
fix(plugins/pi) fix bundle loading in ESM contexts

### DIFF
--- a/plugins/pi/package.json
+++ b/plugins/pi/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "prebuild": "bash scripts/ensure-sdk.sh",
-    "build": "tsc --noEmit && esbuild src/index.ts --bundle --format=esm --platform=node --target=es2022 --outfile=dist/index.js --external:@mariozechner/pi-coding-agent --external:@mariozechner/pi-ai --external:@sinclair/typebox --external:@grpc/grpc-js --external:@grpc/proto-loader",
+    "build": "node scripts/build.mjs",
     "lint": "biome check .",
     "lint:fix": "biome check --fix .",
     "pretypecheck": "bash scripts/ensure-sdk.sh",

--- a/plugins/pi/scripts/build.mjs
+++ b/plugins/pi/scripts/build.mjs
@@ -1,0 +1,40 @@
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const tsc = process.platform === "win32" ? "tsc.cmd" : "tsc";
+
+const typecheck = spawnSync(tsc, ["--noEmit"], {
+  cwd: packageDir,
+  stdio: "inherit",
+});
+if (typecheck.error) {
+  console.error(typecheck.error);
+  process.exit(1);
+}
+if (typecheck.status !== 0) {
+  process.exit(typecheck.status ?? 1);
+}
+
+await build({
+  absWorkingDir: packageDir,
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  target: "es2022",
+  banner: {
+    js: "import { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);",
+  },
+  outfile: "dist/index.js",
+  external: [
+    "@mariozechner/pi-coding-agent",
+    "@mariozechner/pi-ai",
+    "@sinclair/typebox",
+    "@grpc/grpc-js",
+    "@grpc/proto-loader",
+  ],
+  logLevel: "info",
+});

--- a/plugins/pi/src/bundle.test.ts
+++ b/plugins/pi/src/bundle.test.ts
@@ -1,0 +1,31 @@
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("bundle", () => {
+  it("loads from an ESM-only context", () => {
+    const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+    const build = spawnSync(pnpm, ["run", "build"], {
+      cwd: packageDir,
+      encoding: "utf-8",
+    });
+    const buildOutput = build.error?.message || build.stderr || build.stdout;
+    expect(build.status, buildOutput).toBe(0);
+
+    const result = spawnSync(
+      process.execPath,
+      ["--input-type=module", "-e", "await import('./dist/index.js');"],
+      {
+        cwd: packageDir,
+        encoding: "utf-8",
+      },
+    );
+
+    const resultOutput =
+      result.error?.message || result.stderr || result.stdout;
+    expect(result.status, resultOutput).toBe(0);
+  });
+});


### PR DESCRIPTION
The ESM bundle can include CommonJS dependencies that still call Node's require at runtime. Importing the package from a real ESM context then fails before the extension can load.

Move the build into a small script so the esbuild banner can define a local createRequire shim, and add a smoke test for the ESM import path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the plugin’s build pipeline and bundled runtime prelude, which can affect how dependencies resolve at runtime and how the package is published/consumed. Risk is limited to the `plugins/pi` package but could break consumers if bundling behavior regresses.
> 
> **Overview**
> Fixes `plugins/pi` bundle import failures in *ESM-only* environments by moving the build into `scripts/build.mjs` and injecting an esbuild `banner` that defines a local `require` via `createRequire`.
> 
> Updates `package.json` to run the new build script (including a `tsc --noEmit` typecheck step) and adds a Vitest smoke test (`src/bundle.test.ts`) that builds the package and verifies `dist/index.js` can be `import()`ed under `--input-type=module`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b85ed028c9c244482c77da22139cd752c6048fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->