### PR TITLE
docs: sync top-level READMEs with actual SDK, framework, and plugin layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,18 @@ Instrument once with a thin OpenTelemetry-native SDK, then use it to see what yo
 |----------|-----------|------|
 | Go | Anthropic, OpenAI, Gemini | [`go-providers/`](go-providers/) |
 | Python | Anthropic, OpenAI, Gemini | [`python-providers/`](python-providers/) |
+| Java | Anthropic, OpenAI, Gemini | [`java/providers/`](java/providers/) |
+| .NET | Anthropic, OpenAI, Gemini | [`dotnet/src/`](dotnet/src/) |
+| TypeScript/JavaScript | Anthropic, OpenAI, Gemini | [`js/docs/providers/`](js/docs/providers/) |
 
 ## Framework Integrations
 
 | Language | Frameworks | Path |
 |----------|------------|------|
 | Go | Google ADK | [`go-frameworks/`](go-frameworks/) |
-| Python | LangChain, LangGraph, OpenAI Agents, LlamaIndex, Google ADK, Strands Agents | [`python-frameworks/`](python-frameworks/) |
+| Python | LangChain, LangGraph, OpenAI Agents, LlamaIndex, Google ADK, Strands Agents, LiteLLM, Pydantic AI | [`python-frameworks/`](python-frameworks/) |
+| Java | Google ADK | [`java/frameworks/`](java/frameworks/) |
+| TypeScript/JavaScript | LangChain, LangGraph, OpenAI Agents, LlamaIndex, Google ADK, Strands, Vercel AI SDK | [`js/docs/frameworks/`](js/docs/frameworks/) |
 
 ## Quick Examples
 
@@ -150,7 +155,10 @@ Minimal, self-contained examples that make a real LLM call and record the genera
 | Language | Example |
 |----------|---------|
 | Python | [`examples/getting-started/python/`](examples/getting-started/python/) |
+| Python + Pydantic AI | [`examples/getting-started/python-pydantic-ai/`](examples/getting-started/python-pydantic-ai/) |
+| Python + Strands | [`examples/getting-started/python-strands/`](examples/getting-started/python-strands/) |
 | TypeScript | [`examples/getting-started/typescript/`](examples/getting-started/typescript/) |
+| TypeScript + Strands | [`examples/getting-started/typescript-strands/`](examples/getting-started/typescript-strands/) |
 | Go | [`examples/getting-started/go/`](examples/getting-started/go/) |
 
 ### Grafana Cloud credentials
@@ -165,7 +173,11 @@ You need three values to connect. All are visible in the **AI Observability plug
 
 ## Plugins
 
-- [OpenCode](plugins/opencode/) — AI Observability integration for OpenCode
+Drop-in integrations for coding agents. See [`plugins/`](plugins/) for details.
+
+- [Claude Code](plugins/claude-code/)
+- [OpenCode](plugins/opencode/)
+- [Pi](plugins/pi/)
 
 ## Proto
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,11 @@
+# Sigil plugins for coding agents
+
+Plugins that send generations from coding agents to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/). They capture model, tokens, cost, tool calls, traces, and optionally full conversation content.
+
+| Agent | Plugin | Status |
+|-------|--------|--------|
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | [`claude-code/`](claude-code/) | Available |
+| [OpenCode](https://opencode.ai) | [`opencode/`](opencode/) | Available |
+| [Pi](https://github.com/badlogic/pi) | [`pi/`](pi/) | Available |
+
+Each plugin's README covers install, config, auth, and content-capture options.

--- a/python/README.md
+++ b/python/README.md
@@ -45,6 +45,8 @@ pip install sigil-sdk-openai-agents
 pip install sigil-sdk-llamaindex
 pip install sigil-sdk-google-adk
 pip install sigil-sdk-strands
+pip install sigil-sdk-litellm
+pip install sigil-sdk-pydantic-ai
 ```
 
 Framework handler usage:
@@ -57,6 +59,7 @@ from sigil_sdk_openai_agents import with_sigil_openai_agents_hooks
 from sigil_sdk_llamaindex import with_sigil_llamaindex_callbacks
 from sigil_sdk_google_adk import with_sigil_google_adk_callbacks
 from sigil_sdk_strands import with_sigil_strands_hooks
+from sigil_sdk_pydantic_ai import with_sigil_pydantic_ai_capability
 
 client = Client()
 chain_config = with_sigil_langchain_callbacks(None, client=client, provider_resolver="auto")
@@ -65,15 +68,27 @@ openai_agents_run_options = with_sigil_openai_agents_hooks(None, client=client, 
 llamaindex_config = with_sigil_llamaindex_callbacks(None, client=client, provider_resolver="auto")
 google_adk_agent_config = with_sigil_google_adk_callbacks(None, client=client, provider_resolver="auto")
 strands_agent_config = with_sigil_strands_hooks(None, client=client, provider_resolver="auto")
+pydantic_ai_capabilities = with_sigil_pydantic_ai_capability(None, client=client, provider_resolver="auto")
+```
+
+LiteLLM uses a callback class instead of a `with_sigil_*` helper:
+
+```python
+import litellm
+from sigil_sdk import Client
+from sigil_sdk_litellm import SigilLiteLLMLogger
+
+client = Client()
+litellm.callbacks = [SigilLiteLLMLogger(client=client)]
 ```
 
 Framework handlers use the `Client` instance you pass in. If that client is configured with
 `generation_sanitizer`, the same redaction policy applies automatically to generations recorded
-through LangChain, LangGraph, OpenAI Agents, LlamaIndex, and Google ADK integrations.
+through LangChain, LangGraph, OpenAI Agents, LlamaIndex, Google ADK, Strands, LiteLLM, and Pydantic AI integrations.
 
 Framework handlers inject framework tags/metadata on recorded generations:
 
-- `sigil.framework.name` (`langchain`, `langgraph`, `openai-agents`, `llamaindex`, `google-adk`, or `strands`)
+- `sigil.framework.name` (`langchain`, `langgraph`, `openai-agents`, `llamaindex`, `google-adk`, `strands`, `litellm`, or `pydantic-ai`)
 - `sigil.framework.source=handler` (or `hooks` for Strands Agents)
 - `sigil.framework.language=python`
 - `metadata["sigil.framework.run_id"]`
@@ -113,6 +128,8 @@ Full framework examples:
 - LlamaIndex: `../python-frameworks/llamaindex/README.md`
 - Google ADK: `../python-frameworks/google-adk/README.md`
 - Strands Agents: `../python-frameworks/strands/README.md`
+- LiteLLM: `../python-frameworks/litellm/README.md`
+- Pydantic AI: `../python-frameworks/pydantic-ai/README.md`
 
 ## Quick Start (Sync Generation)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only updates that adjust referenced packages/paths and add usage snippets; low risk aside from potential broken links or confusing guidance if paths drift.
> 
> **Overview**
> Updates the top-level `README.md` to reflect the current repo layout: adds Java/.NET/JS provider adapter entries, expands the listed framework integrations (including new Python and JS frameworks), adds additional getting-started example links, and refreshes the plugins section.
> 
> Adds a new `plugins/README.md` to document available coding-agent plugins, and updates `python/README.md` to document new optional framework modules (`sigil-sdk-litellm`, `sigil-sdk-pydantic-ai`) with corresponding usage guidance and updated framework metadata/docs links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4020d5a3a8e2e5232c9d6b06e9da7132601ba0ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->