### PR TITLE
draft: langgraph node visualization support

### DIFF
--- a/examples/python-langgraph-dag/README.md
+++ b/examples/python-langgraph-dag/README.md
@@ -1,0 +1,40 @@
+# Python LangGraph Dependency DAG POC
+
+This example emits a five-node LangGraph workflow as Sigil generations linked by `parent_generation_ids`.
+
+It uses `FakeListChatModel`, so it exercises the LangGraph callback lifecycle without external model credentials. Replace the fake model with a real in-house LangChain chat model, `ChatOpenAI`, or another provider wrapper for a customer POC.
+
+## Run
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python main.py
+```
+
+By default, the example uses `SIGIL_EXPORT_PROTOCOL=none` so it can run without a local stack. Point it at a local Sigil stack before running if you want the records to appear in Grafana:
+
+```bash
+export SIGIL_EXPORT_PROTOCOL=http
+export SIGIL_EXPORT_ENDPOINT=http://localhost:8080
+python main.py
+```
+
+## What It Proves
+
+Each LangGraph node passes these callback metadata keys into `with_sigil_langgraph_callbacks`:
+
+- `sigil.generation.id`: stable generation ID for the current node.
+- `sigil.generation.parent_generation_ids`: generation IDs for upstream nodes whose output this node consumes.
+- `langgraph_node`: node name shown in Sigil generation metadata.
+- `thread_id`: conversation ID so all node generations land in one conversation.
+
+Sigil's conversation dependency tab can render the resulting workflow because the exported generations form this DAG:
+
+```text
+extract_intent -> retrieve_context -> draft_answer -> critique_answer -> final_answer
+                                      \------------------------------/
+```
+
+This proves the current Sigil data model can represent LangGraph workflow dependencies as a generation DAG. It does not yet provide a native LangGraph state-transition or state-diff UI.

--- a/examples/python-langgraph-dag/main.py
+++ b/examples/python-langgraph-dag/main.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import os
+from typing import Annotated, TypedDict
+from uuid import uuid4
+
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from langchain_core.messages import HumanMessage
+from langgraph.graph import END, START, StateGraph
+from sigil_sdk import Client, ClientConfig, GenerationExportConfig
+from sigil_sdk_langgraph import with_sigil_langgraph_callbacks
+
+
+def merge_generation_ids(left: dict[str, str] | None, right: dict[str, str] | None) -> dict[str, str]:
+    merged = dict(left or {})
+    merged.update(right or {})
+    return merged
+
+
+class GraphState(TypedDict, total=False):
+    question: str
+    intent: str
+    context: str
+    draft: str
+    critique: str
+    answer: str
+    generation_ids: Annotated[dict[str, str], merge_generation_ids]
+
+
+client = Client(
+    ClientConfig(
+        generation_export=GenerationExportConfig(
+            protocol=os.getenv("SIGIL_EXPORT_PROTOCOL", "none"),
+            endpoint=os.getenv("SIGIL_EXPORT_ENDPOINT", "localhost:4317"),
+        )
+    )
+)
+conversation_id = f"rad-ai-langgraph-poc-{uuid4().hex[:8]}"
+
+# FakeListChatModel triggers the LangChain/LangGraph callback lifecycle without
+# requiring external model credentials. Replace this with a real in-house model
+# wrapper or ChatOpenAI/ChatAnthropic in a customer POC.
+llm = FakeListChatModel(
+    responses=[
+        "Intent: explain whether Sigil can visualize LangGraph node dependencies.",
+        "Context: Sigil renders dependency DAGs from parent_generation_ids.",
+        "Draft: emit stable generation IDs per LangGraph node and link parents.",
+        "Critique: call out that this is a generation DAG, not a native LangGraph state diff UI.",
+        "Final: Sigil can POC the workflow DAG today; native state-transition UX is future work.",
+    ]
+)
+
+
+def generation_id(node: str) -> str:
+    return f"{conversation_id}:{node}"
+
+
+def invoke_node(state: GraphState, *, node: str, prompt: str, parents: list[str]) -> tuple[str, str]:
+    current_generation_id = generation_id(node)
+    known_generation_ids = state.get("generation_ids", {})
+    parent_generation_ids = [known_generation_ids[parent] for parent in parents if parent in known_generation_ids]
+
+    config = with_sigil_langgraph_callbacks(
+        {
+            "metadata": {
+                "thread_id": conversation_id,
+                "langgraph_node": node,
+                "sigil.generation.id": current_generation_id,
+                "sigil.generation.parent_generation_ids": parent_generation_ids,
+            },
+            "configurable": {"thread_id": conversation_id},
+        },
+        client=client,
+        provider="custom",
+        agent_name=node,
+        agent_version="poc",
+    )
+    response = llm.invoke([HumanMessage(content=prompt)], config=config)
+    return str(response.content), current_generation_id
+
+
+def extract_intent(state: GraphState) -> GraphState:
+    output, gen_id = invoke_node(
+        state,
+        node="extract_intent",
+        parents=[],
+        prompt=f"Extract the customer's intent from: {state['question']}",
+    )
+    return {"intent": output, "generation_ids": {"extract_intent": gen_id}}
+
+
+def retrieve_context(state: GraphState) -> GraphState:
+    output, gen_id = invoke_node(
+        state,
+        node="retrieve_context",
+        parents=["extract_intent"],
+        prompt=f"Find Sigil context for this intent: {state['intent']}",
+    )
+    return {"context": output, "generation_ids": {"retrieve_context": gen_id}}
+
+
+def draft_answer(state: GraphState) -> GraphState:
+    output, gen_id = invoke_node(
+        state,
+        node="draft_answer",
+        parents=["retrieve_context"],
+        prompt=f"Draft an answer using this context: {state['context']}",
+    )
+    return {"draft": output, "generation_ids": {"draft_answer": gen_id}}
+
+
+def critique_answer(state: GraphState) -> GraphState:
+    output, gen_id = invoke_node(
+        state,
+        node="critique_answer",
+        parents=["draft_answer"],
+        prompt=f"Critique this draft for product accuracy: {state['draft']}",
+    )
+    return {"critique": output, "generation_ids": {"critique_answer": gen_id}}
+
+
+def final_answer(state: GraphState) -> GraphState:
+    output, gen_id = invoke_node(
+        state,
+        node="final_answer",
+        parents=["draft_answer", "critique_answer"],
+        prompt=f"Finalize this draft: {state['draft']}\nCritique: {state['critique']}",
+    )
+    return {"answer": output, "generation_ids": {"final_answer": gen_id}}
+
+
+workflow = StateGraph(GraphState)
+workflow.add_node("extract_intent", extract_intent)
+workflow.add_node("retrieve_context", retrieve_context)
+workflow.add_node("draft_answer", draft_answer)
+workflow.add_node("critique_answer", critique_answer)
+workflow.add_node("final_answer", final_answer)
+workflow.add_edge(START, "extract_intent")
+workflow.add_edge("extract_intent", "retrieve_context")
+workflow.add_edge("retrieve_context", "draft_answer")
+workflow.add_edge("draft_answer", "critique_answer")
+workflow.add_edge("critique_answer", "final_answer")
+workflow.add_edge("final_answer", END)
+graph = workflow.compile()
+
+try:
+    result = graph.invoke(
+        {
+            "question": "Can Sigil visualize a Rad AI LangGraph workflow?",
+            "generation_ids": {},
+        }
+    )
+    client.flush()
+finally:
+    client.shutdown()
+
+print(f"conversation_id={conversation_id}")
+print("generation DAG:")
+for node, gen_id in result["generation_ids"].items():
+    print(f"- {node}: {gen_id}")
+print(f"answer={result['answer']}")

--- a/examples/python-langgraph-dag/requirements.txt
+++ b/examples/python-langgraph-dag/requirements.txt
@@ -1,0 +1,4 @@
+-e ../../python
+-e ../../python-frameworks/langgraph
+langgraph>=0.2.0
+langchain-core>=0.3.0

--- a/python-frameworks/langgraph/README.md
+++ b/python-frameworks/langgraph/README.md
@@ -102,6 +102,33 @@ When `thread_id` is present, the handler records:
 - `metadata["sigil.framework.thread_id"]=<thread id>`
 - generation span attributes `sigil.framework.run_id` and `sigil.framework.thread_id`
 
+## Dependency DAG metadata
+
+Sigil's conversation dependency graph is built from generation IDs, not framework run IDs. For LangGraph workflows where one node consumes another node's output, pass stable generation IDs through callback metadata:
+
+```python
+config = with_sigil_langgraph_callbacks(
+    {
+        "metadata": {
+            "thread_id": "rad-ai-case-42",
+            "langgraph_node": "draft_answer",
+            "sigil.generation.id": "rad-ai-case-42:draft_answer",
+            "sigil.generation.parent_generation_ids": ["rad-ai-case-42:retrieve_context"],
+        },
+        "configurable": {"thread_id": "rad-ai-case-42"},
+    },
+    client=client,
+    provider="custom",
+)
+```
+
+The handler uses:
+
+- `sigil.generation.id` / `generation_id` / `generationId` as the current generation ID.
+- `sigil.generation.parent_generation_ids` / `parent_generation_ids` / `parentGenerationIds` as upstream generation IDs.
+
+See `examples/python-langgraph-dag` for a multi-node POC.
+
 ## Behavior
 
 - Lifecycle mapping:

--- a/python-frameworks/langgraph/tests/test_langgraph_handler.py
+++ b/python-frameworks/langgraph/tests/test_langgraph_handler.py
@@ -118,6 +118,39 @@ def test_langgraph_sync_lifecycle_sets_framework_tags_and_metadata() -> None:
         client.shutdown()
 
 
+def test_langgraph_sync_lifecycle_accepts_explicit_generation_dag_ids() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        run_id = uuid4()
+        handler = SigilLangGraphHandler(client=client, provider="custom")
+
+        handler.on_chat_model_start(
+            {"name": "InHouseChatModel"},
+            [[{"type": "human", "content": "draft answer"}]],
+            run_id=run_id,
+            invocation_params={"model": "rad-ai-internal"},
+            metadata={
+                "thread_id": "rad-ai-case-42",
+                "langgraph_node": "draft_answer",
+                "sigil.generation.id": "gen-draft-answer",
+                "sigil.generation.parent_generation_ids": ["gen-retrieve-context", "", "gen-retrieve-context"],
+            },
+        )
+        handler.on_llm_end(
+            {"generations": [[{"text": "drafted"}]], "llm_output": {"model_name": "rad-ai-internal"}},
+            run_id=run_id,
+        )
+
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        assert generation.id == "gen-draft-answer"
+        assert generation.parent_generation_ids == ["gen-retrieve-context"]
+    finally:
+        client.shutdown()
+
+
 def test_langgraph_stream_lifecycle_uses_stream_mode_and_chunk_fallback() -> None:
     exporter = _CapturingExporter()
     client = _new_client(exporter)

--- a/python/sigil_sdk/framework_handler.py
+++ b/python/sigil_sdk/framework_handler.py
@@ -55,6 +55,8 @@ _default_framework_language = "python"
 _default_framework_instrumentation_name = "github.com/grafana/sigil/sdks/python/frameworks"
 _span_attr_operation_name = "gen_ai.operation.name"
 _span_attr_conversation_id = "gen_ai.conversation.id"
+_span_attr_generation_id = "sigil.generation.id"
+_span_attr_parent_generation_ids = "sigil.generation.parent_generation_ids"
 _span_attr_framework_name = "sigil.framework.name"
 _span_attr_framework_source = "sigil.framework.source"
 _span_attr_framework_language = "sigil.framework.language"
@@ -190,6 +192,8 @@ class SigilFrameworkHandlerBase:
         retry_attempt = _resolve_framework_retry_attempt(callback_kwargs, invocation_params, serialized)
         langgraph_node = _resolve_langgraph_node(callback_kwargs, invocation_params, serialized)
         event_id = _resolve_framework_event_id(callback_kwargs, invocation_params, serialized)
+        generation_id = _resolve_generation_id(callback_kwargs, invocation_params, serialized)
+        parent_generation_ids = _resolve_parent_generation_ids(callback_kwargs, invocation_params, serialized)
 
         metadata: dict[str, Any] = dict(self._extra_metadata)
         metadata[_span_attr_framework_run_id] = run_key
@@ -211,6 +215,7 @@ class SigilFrameworkHandlerBase:
         metadata = _normalize_framework_metadata(metadata)
 
         start = GenerationStart(
+            id=generation_id,
             conversation_id=conversation_id,
             agent_name=self._agent_name,
             agent_version=self._agent_version,
@@ -218,6 +223,7 @@ class SigilFrameworkHandlerBase:
             model=ModelRef(provider=provider_name, name=model_name),
             tags=tags,
             metadata=metadata,
+            parent_generation_ids=parent_generation_ids,
         )
 
         recorder = (
@@ -275,6 +281,8 @@ class SigilFrameworkHandlerBase:
         retry_attempt = _resolve_framework_retry_attempt(callback_kwargs, invocation_params, serialized)
         langgraph_node = _resolve_langgraph_node(callback_kwargs, invocation_params, serialized)
         event_id = _resolve_framework_event_id(callback_kwargs, invocation_params, serialized)
+        generation_id = _resolve_generation_id(callback_kwargs, invocation_params, serialized)
+        parent_generation_ids = _resolve_parent_generation_ids(callback_kwargs, invocation_params, serialized)
 
         metadata: dict[str, Any] = dict(self._extra_metadata)
         metadata[_span_attr_framework_run_id] = run_key
@@ -296,6 +304,7 @@ class SigilFrameworkHandlerBase:
         metadata = _normalize_framework_metadata(metadata)
 
         start = GenerationStart(
+            id=generation_id,
             conversation_id=conversation_id,
             agent_name=self._agent_name,
             agent_version=self._agent_version,
@@ -309,6 +318,7 @@ class SigilFrameworkHandlerBase:
             max_tokens=_as_optional_int(_read(invocation_params, "max_tokens")),
             top_p=_as_optional_float(_read(invocation_params, "top_p")),
             tool_choice=_as_str(_read(invocation_params, "tool_choice")) or None,
+            parent_generation_ids=parent_generation_ids,
         )
 
         recorder = (
@@ -848,6 +858,79 @@ def _langgraph_node_from_payload(payload: Any) -> str:
         if candidate != "":
             return candidate
     return ""
+
+
+def _resolve_generation_id(*payloads: Any) -> str:
+    for payload in payloads:
+        candidate = _generation_id_from_payload(payload)
+        if candidate != "":
+            return candidate
+    return ""
+
+
+def _generation_id_from_payload(payload: Any) -> str:
+    candidates = (
+        _as_str(_read(payload, _span_attr_generation_id)),
+        _as_str(_read(payload, "generation_id")),
+        _as_str(_read(payload, "generationId")),
+        _as_str(_read(_read(payload, "metadata"), _span_attr_generation_id)),
+        _as_str(_read(_read(payload, "metadata"), "generation_id")),
+        _as_str(_read(_read(payload, "metadata"), "generationId")),
+        _as_str(_read(_read(payload, "configurable"), _span_attr_generation_id)),
+        _as_str(_read(_read(payload, "configurable"), "generation_id")),
+        _as_str(_read(_read(payload, "configurable"), "generationId")),
+        _as_str(_read(_read(_read(payload, "config"), "metadata"), _span_attr_generation_id)),
+        _as_str(_read(_read(_read(payload, "config"), "configurable"), _span_attr_generation_id)),
+    )
+    for candidate in candidates:
+        if candidate != "":
+            return candidate
+    return ""
+
+
+def _resolve_parent_generation_ids(*payloads: Any) -> list[str]:
+    output: list[str] = []
+    seen: set[str] = set()
+    for payload in payloads:
+        for raw_value in _parent_generation_id_values_from_payload(payload):
+            for generation_id in _normalize_parent_generation_id_values(raw_value):
+                if generation_id in seen:
+                    continue
+                seen.add(generation_id)
+                output.append(generation_id)
+    return output
+
+
+def _parent_generation_id_values_from_payload(payload: Any) -> tuple[Any, ...]:
+    return (
+        _read(payload, _span_attr_parent_generation_ids),
+        _read(payload, "parent_generation_ids"),
+        _read(payload, "parentGenerationIds"),
+        _read(_read(payload, "metadata"), _span_attr_parent_generation_ids),
+        _read(_read(payload, "metadata"), "parent_generation_ids"),
+        _read(_read(payload, "metadata"), "parentGenerationIds"),
+        _read(_read(payload, "configurable"), _span_attr_parent_generation_ids),
+        _read(_read(payload, "configurable"), "parent_generation_ids"),
+        _read(_read(payload, "configurable"), "parentGenerationIds"),
+        _read(_read(_read(payload, "config"), "metadata"), _span_attr_parent_generation_ids),
+        _read(_read(_read(payload, "config"), "configurable"), _span_attr_parent_generation_ids),
+    )
+
+
+def _normalize_parent_generation_id_values(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        trimmed = value.strip()
+        return [trimmed] if trimmed != "" else []
+    if isinstance(value, (list, tuple, set)):
+        output: list[str] = []
+        for item in value:
+            trimmed = _as_str(item)
+            if trimmed != "":
+                output.append(trimmed)
+        return output
+    return []
 
 
 def _normalize_framework_tags(value: Any) -> list[str]:


### PR DESCRIPTION
# Notes

It would be nice to be able to visualize LangGraph node execution in our DAG viewer, although today since we only support DAG and not a cyclic dependency view, we get something like this:

<img width="3012" height="1514" alt="langgraph" src="https://github.com/user-attachments/assets/9432c8f9-9c7f-4468-b2e1-fbf3281e574f" />

So you can see the nodes, but there are duplicates if a node is revisited in LangGraph. It would be nice to have first class feature support instead of doing just `parent_generation_id` and using the DAG.