### PR TITLE
feat(plugins/claude-code): block tool execution via Sigil guards

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -10,6 +10,30 @@
   "license": "Apache-2.0",
   "keywords": ["telemetry", "observability", "sigil", "grafana"],
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sigil-cc",
+            "timeout": 2000
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sigil-cc",
+            "timeout": 2000
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "",

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -144,12 +144,15 @@ If nothing appears, the most common causes are: `sigil-cc` not on `$PATH`, missi
 
 ## How It Works
 
-1. Claude Code fires the Stop hook after each turn, passing `{session_id, transcript_path}` on stdin
+1. Claude Code fires `SessionStart` and persists the session model (used by tool hooks).
+2. Claude Code fires the Stop hook after each turn, passing `{session_id, transcript_path}` on stdin
 2. `sigil-cc` loads the byte offset from the last run (or 0 for first run)
 3. Reads new JSONL lines from the transcript starting at that offset
 4. Maps assistant messages with token usage to Sigil Generation records
 5. Sends via the sigil-sdk HTTP client
 6. On successful flush, saves the new offset for next invocation
+
+Additionally, the plugin registers a `PreToolUse` hook that evaluates Sigil **postflight** guards against the tool call name. If a guard denies, the hook returns a Claude Code `permissionDecision: "deny"` and the tool call is blocked before execution.
 
 Each assistant API response becomes one Generation with model, tokens, tools, timestamps, tags, and conversation title. The hook always exits 0; telemetry is best-effort.
 

--- a/plugins/claude-code/cmd/sigil-cc/main.go
+++ b/plugins/claude-code/cmd/sigil-cc/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -20,8 +21,24 @@ import (
 )
 
 type hookInput struct {
-	SessionID      string `json:"session_id"`
-	TranscriptPath string `json:"transcript_path"`
+	HookEventName  string          `json:"hook_event_name"`
+	SessionID      string          `json:"session_id"`
+	TranscriptPath string          `json:"transcript_path"`
+	Model          string          `json:"model,omitempty"`
+	ToolName       string          `json:"tool_name,omitempty"`
+	ToolInput      json.RawMessage `json:"tool_input,omitempty"`
+	ToolUseID      string          `json:"tool_use_id,omitempty"`
+}
+
+type hookDecision struct {
+	HookSpecificOutput hookSpecificOutput `json:"hookSpecificOutput"`
+}
+
+type hookSpecificOutput struct {
+	HookEventName              string `json:"hookEventName"`
+	PermissionDecision         string `json:"permissionDecision,omitempty"`
+	PermissionDecisionReason   string `json:"permissionDecisionReason,omitempty"`
+	AdditionalContext          string `json:"additionalContext,omitempty"`
 }
 
 var (
@@ -64,12 +81,12 @@ func main() {
 }
 
 func run() {
-	input, err := parseStdin()
+	input, err := parseHookInput(os.Stdin)
 	if err != nil {
 		logger.Printf("stdin: %v", err)
 		return
 	}
-	logger.Printf("session=%s transcript=%s", input.SessionID, input.TranscriptPath)
+	logger.Printf("event=%s session=%s transcript=%s", input.HookEventName, input.SessionID, input.TranscriptPath)
 
 	// Canonical SIGIL_* schema only — no legacy aliases.
 	sigilEndpoint := os.Getenv("SIGIL_ENDPOINT")
@@ -96,6 +113,26 @@ func run() {
 	defer cancel()
 	ctx = sigil.WithUserID(ctx, userID)
 
+	st := state.Load(input.SessionID)
+
+	switch strings.TrimSpace(input.HookEventName) {
+	case "", "Stop":
+		// Stop hook uses the transcript to export generations.
+	case "SessionStart":
+		st.Model = strings.TrimSpace(input.Model)
+		if err := state.Save(input.SessionID, st); err != nil {
+			logger.Printf("save state: %v", err)
+		}
+		return
+	case "PreToolUse":
+		handlePreToolUse(ctx, input, st, sigilEndpoint, tenantID, authToken)
+		return
+	default:
+		// Ignore unsupported events; hooks are best-effort and should not crash
+		// Claude Code.
+		return
+	}
+
 	// SIGIL_OTEL_* takes precedence over OTEL_*; OTEL_* is the fallback.
 	otelEndpoint := envOr("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
 	otelInsecure := parseBoolEnv(envOr("SIGIL_OTEL_EXPORTER_OTLP_INSECURE", os.Getenv("OTEL_EXPORTER_OTLP_INSECURE")))
@@ -114,8 +151,6 @@ func run() {
 		logger.Printf("otel: endpoint=%s", otelEndpoint)
 	}
 	defer func() { _ = otelProviders.Shutdown(ctx) }()
-
-	st := state.Load(input.SessionID)
 
 	lines, _, err := transcript.Read(input.TranscriptPath, st.Offset)
 	if err != nil {
@@ -227,8 +262,111 @@ func run() {
 	logger.Printf("done: %d generations in %s", len(gens), time.Since(t0))
 }
 
-func parseStdin() (*hookInput, error) {
-	data, err := io.ReadAll(os.Stdin)
+func handlePreToolUse(
+	ctx context.Context,
+	input *hookInput,
+	st state.Session,
+	sigilEndpoint, tenantID, authToken string,
+) {
+	toolName := strings.TrimSpace(input.ToolName)
+	if toolName == "" {
+		return
+	}
+
+	modelName := strings.TrimSpace(st.Model)
+	if modelName == "" {
+		modelName = "unknown"
+	}
+
+	failOpen := true
+	cfg := sigil.Config{
+		API: sigil.APIConfig{
+			Endpoint: sigilEndpoint,
+		},
+		Hooks: sigil.HooksConfig{
+			Enabled:  true,
+			Phases:   []sigil.HookPhase{sigil.HookPhasePostflight},
+			Timeout:  1500 * time.Millisecond,
+			FailOpen: &failOpen,
+		},
+		// Hook evaluation needs auth headers; reuse the export auth inputs.
+		GenerationExport: sigil.GenerationExportConfig{
+			Auth: sigil.AuthConfig{
+				Mode:          sigil.ExportAuthModeBasic,
+				BasicUser:     tenantID,
+				BasicPassword: authToken,
+				TenantID:      tenantID,
+			},
+		},
+	}
+
+	client := sigil.NewClient(cfg)
+	defer func() { _ = client.Shutdown(ctx) }()
+
+	req := sigil.HookEvaluateRequest{
+		Phase: sigil.HookPhasePostflight,
+		Context: sigil.HookContext{
+			AgentName:    "claude-code",
+			AgentVersion: version,
+			Model:        &sigil.HookModel{Provider: "anthropic", Name: modelName},
+		},
+		Input: sigil.HookInput{
+			Output: []sigil.Message{{
+				Role: sigil.RoleAssistant,
+				Parts: []sigil.Part{{
+					Kind: sigil.PartKindToolCall,
+					ToolCall: &sigil.ToolCall{
+						ID:        strings.TrimSpace(input.ToolUseID),
+						Name:      toolName,
+					},
+				}},
+			}},
+		},
+	}
+	if payload, mErr := json.Marshal(req); mErr == nil {
+		logger.Printf("pre_tool_use hook request: %s", string(payload))
+	}
+
+	resp, err := client.EvaluateHook(ctx, req)
+	if err != nil {
+		// Fail-open means tool execution continues.
+		logger.Printf("pre_tool_use hook eval: tool=%q endpoint=%q err=%v", toolName, sigilEndpoint, err)
+		return
+	}
+
+	if resp != nil {
+		logger.Printf(
+			"pre_tool_use hook eval: tool=%q endpoint=%q action=%q rule_id=%q reason=%q",
+			toolName,
+			sigilEndpoint,
+			string(resp.Action),
+			resp.RuleID,
+			resp.Reason,
+		)
+	}
+
+	if deniedErr := sigil.HookDeniedFromResponse(resp); deniedErr != nil {
+		reason := "tool call denied by Sigil guard"
+		var denied *sigil.HookDeniedError
+		if errors.As(deniedErr, &denied) && strings.TrimSpace(denied.Reason) != "" {
+			reason = denied.Reason
+		}
+		if strings.TrimSpace(reason) == "" {
+			reason = "tool call denied by Sigil guard"
+		}
+		out := hookDecision{
+			HookSpecificOutput: hookSpecificOutput{
+				HookEventName:            "PreToolUse",
+				PermissionDecision:       "deny",
+				PermissionDecisionReason: reason,
+			},
+		}
+		_ = json.NewEncoder(os.Stdout).Encode(out)
+	}
+}
+
+func parseHookInput(r io.Reader) (*hookInput, error) {
+	data, err := io.ReadAll(r)
 	if err != nil || len(data) == 0 {
 		return nil, fmt.Errorf("empty stdin")
 	}
@@ -238,6 +376,8 @@ func parseStdin() (*hookInput, error) {
 		return nil, err
 	}
 
+	input.SessionID = strings.TrimSpace(input.SessionID)
+	input.TranscriptPath = strings.TrimSpace(input.TranscriptPath)
 	if input.SessionID == "" || input.TranscriptPath == "" {
 		return nil, fmt.Errorf("missing session_id or transcript_path")
 	}

--- a/plugins/claude-code/cmd/sigil-cc/main_test.go
+++ b/plugins/claude-code/cmd/sigil-cc/main_test.go
@@ -171,6 +171,23 @@ func TestParseExtraTags(t *testing.T) {
 	}
 }
 
+func TestParseStdin_PreToolUse(t *testing.T) {
+	in := `{"hook_event_name":"PreToolUse","session_id":"s1","transcript_path":"/tmp/t.jsonl","tool_name":"Bash","tool_input":{"command":"echo hi"},"tool_use_id":"tu_1"}`
+	got, err := parseHookInput(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("parseStdin: %v", err)
+	}
+	if got.HookEventName != "PreToolUse" {
+		t.Fatalf("HookEventName=%q", got.HookEventName)
+	}
+	if got.ToolName != "Bash" || got.ToolUseID != "tu_1" {
+		t.Fatalf("tool fields = %#v", got)
+	}
+	if len(got.ToolInput) == 0 || !strings.Contains(string(got.ToolInput), "echo hi") {
+		t.Fatalf("ToolInput=%s", string(got.ToolInput))
+	}
+}
+
 func TestBuildToolResultMap(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/plugins/claude-code/internal/state/state.go
+++ b/plugins/claude-code/internal/state/state.go
@@ -12,6 +12,9 @@ import (
 type Session struct {
 	Offset int64  `json:"offset"`
 	Title  string `json:"title,omitempty"`
+	// Model is captured from SessionStart so tool hooks can include model context
+	// when calling Sigil guards (PreToolUse events do not include model fields).
+	Model string `json:"model,omitempty"`
 }
 
 func dir() string {

--- a/plugins/claude-code/internal/state/state_test.go
+++ b/plugins/claude-code/internal/state/state_test.go
@@ -20,7 +20,7 @@ func TestLoad_MissingFile(t *testing.T) {
 func TestSaveLoad_Roundtrip(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 
-	want := Session{Offset: 12345, Title: "Fix the authentication bug"}
+	want := Session{Offset: 12345, Title: "Fix the authentication bug", Model: "claude-sonnet-4-6"}
 	if err := Save("test-session", want); err != nil {
 		t.Fatal(err)
 	}
@@ -31,6 +31,9 @@ func TestSaveLoad_Roundtrip(t *testing.T) {
 	}
 	if got.Title != want.Title {
 		t.Errorf("Title = %q, want %q", got.Title, want.Title)
+	}
+	if got.Model != want.Model {
+		t.Errorf("Model = %q, want %q", got.Model, want.Model)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Register `SessionStart` + `PreToolUse` hooks in the Claude Code plugin.
- On `PreToolUse`, call Sigil `postflight` hooks with a synthesized tool call and deny tool execution when Sigil returns `deny`.
- Persist `model` from `SessionStart` in local state for hook context.

## Why
This lets Sigil guards (tool_filter) stop dangerous tool calls **before** execution in Claude Code.

## Test plan
- `cd plugins/claude-code && go test ./...`
- Manual: create a `postflight` tool_filter guard (e.g. `blocked_names: ["*"]`) and confirm Claude Code tool calls are denied.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `PreToolUse` hook that can deny tool execution based on remote Sigil guard evaluation, which changes runtime behavior and depends on network/auth configuration. Fail-open defaults reduce outage risk, but misconfigured guards or model/state handling could unexpectedly block tools.
> 
> **Overview**
> Registers new Claude Code plugin hooks for `SessionStart` and `PreToolUse` (in addition to `Stop`) and updates docs to describe the new flow and guard-based blocking.
> 
> Extends `sigil-cc` to parse hook-specific stdin, persist the session `model` on `SessionStart`, and on `PreToolUse` call Sigil hook evaluation (postflight phase) with a synthesized tool-call payload; if Sigil returns `deny`, it prints a Claude Code `permissionDecision: "deny"` response to block the tool before execution. Updates state persistence/tests to include the new `Model` field and adds parsing tests for the new hook input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6a37c2d731215a62645ae99432e320a802f5dd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->