### PR TITLE
fix(js/ts): cloudflare workers runtime compatibility

### DIFF
--- a/js/src/config.ts
+++ b/js/src/config.ts
@@ -118,6 +118,8 @@ export function mergeConfig(
 }
 
 function defaultEnv(): Record<string, string | undefined> {
+  // Edge runtimes (for example Cloudflare Workers) may not define `process`.
+  // Fall back to an empty env object so default config resolution stays safe.
   if (typeof process !== 'undefined' && process.env !== undefined) {
     return process.env;
   }

--- a/js/src/config.ts
+++ b/js/src/config.ts
@@ -80,13 +80,13 @@ export function defaultConfig(): SigilSdkConfig {
  * Most callers should use `new SigilClient()` (env reading is automatic).
  * Use `configFromEnv()` for tests, debugging, or advanced layering.
  */
-export function configFromEnv(env: Record<string, string | undefined> = process.env): SigilSdkConfig {
+export function configFromEnv(env: Record<string, string | undefined> = defaultEnv()): SigilSdkConfig {
   return mergeConfig({}, env);
 }
 
 export function mergeConfig(
   config: SigilSdkConfigInput,
-  env: Record<string, string | undefined> = process.env,
+  env: Record<string, string | undefined> = defaultEnv(),
 ): SigilSdkConfig {
   // Layer env values under user-provided fields. The user-provided field wins
   // when defined; env fills in undefined fields; defaults fill the rest.
@@ -115,6 +115,13 @@ export function mergeConfig(
     tags: overlaid.tags ? { ...overlaid.tags } : undefined,
     debug: overlaid.debug,
   };
+}
+
+function defaultEnv(): Record<string, string | undefined> {
+  if (typeof process !== 'undefined' && process.env !== undefined) {
+    return process.env;
+  }
+  return {};
 }
 
 function envOverrides(env: Record<string, string | undefined>, logger: SigilLogger): SigilSdkConfigInput {

--- a/js/src/exporters/default.ts
+++ b/js/src/exporters/default.ts
@@ -40,6 +40,12 @@ class UnavailableGenerationExporter implements GenerationExporter {
   }
 }
 
+/**
+ * Lazily loads the Node/gRPC exporter only when protocol=grpc is used.
+ *
+ * This keeps edge runtimes (for example Cloudflare Workers) on the HTTP/none
+ * path from evaluating Node-only gRPC modules during startup.
+ */
 class LazyGRPCGenerationExporter implements GenerationExporter {
   private initPromise: Promise<GenerationExporter> | undefined;
   private exporter: GenerationExporter | undefined;

--- a/js/src/exporters/default.ts
+++ b/js/src/exporters/default.ts
@@ -4,7 +4,6 @@ import type {
   GenerationExportConfig,
   GenerationExporter,
 } from '../types.js';
-import { GRPCGenerationExporter } from './grpc.js';
 import { HTTPGenerationExporter } from './http.js';
 
 export function createDefaultGenerationExporter(config: GenerationExportConfig): GenerationExporter {
@@ -12,7 +11,7 @@ export function createDefaultGenerationExporter(config: GenerationExportConfig):
     case 'http':
       return new HTTPGenerationExporter(config.endpoint, config.headers);
     case 'grpc':
-      return new GRPCGenerationExporter(config.endpoint, config.headers, config.insecure);
+      return new LazyGRPCGenerationExporter(config.endpoint, config.headers, config.insecure);
     case 'none':
       return new NoopGenerationExporter();
     default:
@@ -38,5 +37,46 @@ class UnavailableGenerationExporter implements GenerationExporter {
 
   async exportGenerations(): Promise<never> {
     throw this.reason;
+  }
+}
+
+class LazyGRPCGenerationExporter implements GenerationExporter {
+  private initPromise: Promise<GenerationExporter> | undefined;
+  private exporter: GenerationExporter | undefined;
+
+  constructor(
+    private readonly endpoint: string,
+    private readonly headers: Record<string, string> | undefined,
+    private readonly insecure: boolean,
+  ) {}
+
+  async exportGenerations(request: ExportGenerationsRequest): Promise<ExportGenerationsResponse> {
+    const exporter = await this.getExporter();
+    return exporter.exportGenerations(request);
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.initPromise === undefined && this.exporter === undefined) {
+      return;
+    }
+    const exporter = await this.getExporter();
+    await exporter.shutdown?.();
+  }
+
+  private async getExporter(): Promise<GenerationExporter> {
+    if (this.exporter !== undefined) {
+      return this.exporter;
+    }
+    if (this.initPromise !== undefined) {
+      return this.initPromise;
+    }
+    this.initPromise = this.initializeExporter();
+    this.exporter = await this.initPromise;
+    return this.exporter;
+  }
+
+  private async initializeExporter(): Promise<GenerationExporter> {
+    const grpc = await import('./grpc.js');
+    return new grpc.GRPCGenerationExporter(this.endpoint, this.headers, this.insecure);
   }
 }


### PR DESCRIPTION
Sigil wasn't compatible with [cloudflare worker](https://workers.cloudflare.com) runtime. Cf workers do not handle gRPC, so even selecting the http option tried to load gRPC causing issues (worker will crash during the start because `import.meta.url` at [js/src/exporters/grpc.ts](https://github.com/grafana/sigil-sdk/blob/2be18edfcb1fb4064631c741c8a648e6ac757d86/js/src/exporters/grpc.ts#L35) is undefined in the worker runtime).

Env vars rely on process.env not available in some environments like cloudflare workers.

## Summary

- lazy-load the gRPC exporter so HTTP/none paths do not evaluate Node gRPC modules at startup
- guard SDK env defaults for edge runtimes where `process` may be unavailable
- keep existing Node behavior for gRPC users

## Changes
- `js/src/exporters/default.ts`
  - replaced eager gRPC import with lazy dynamic import via `LazyGRPCGenerationExporter`
- `js/src/config.ts`
  - switched default env resolution from direct `process.env` references to a safe `defaultEnv()` helper

## Validation
- `pnpm run test:ci` (js package): pass ✅
- `pnpm run test:build && node --test test/conformance.test.mjs` (js package): pass ✅
- I created a cf worker agent demo using the cloudflare starter `npx create-cloudflare@latest --template cloudflare/agents-starter`, see it here: https://github.com/Lp-Francois/cf-agents-starter-with-sigil and I instrumented it with Sigil SDK
  - to test my changes, I updated sigil SDK on a branch in this repo, then built it and packaged it as `./js/grafana-sigil-sdk-js-0.3.0.tgz`. Then from my test project, I loaded it up. I didn't run into any issues :) and managed to see o11y in the sigil view on grafana cloud.

<img width="735" height="648" alt="Screenshot 2026-05-07 at 12 42 31" src="https://github.com/user-attachments/assets/12edb2d2-6376-46de-98eb-8d93cc606ac9" />

Then I made sure it shows up in Grafana:

<img width="1892" height="837" alt="Screenshot 2026-05-07 at 12 41 39" src="https://github.com/user-attachments/assets/556eb6f2-ee7a-4ca2-8855-dd8e5b36d2b3" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes default configuration resolution and the gRPC exporter instantiation path; behavior should be unchanged for Node users but could affect environments relying on implicit `process.env` or gRPC initialization timing.
> 
> **Overview**
> Improves JS/TS SDK compatibility with edge runtimes (e.g., Cloudflare Workers) by avoiding eager evaluation of Node-only code paths.
> 
> `configFromEnv()`/`mergeConfig()` now default to a guarded `defaultEnv()` helper instead of directly referencing `process.env`, falling back to `{}` when `process` is unavailable.
> 
> The default generation exporter no longer eagerly imports the gRPC implementation; when `protocol=grpc`, it now uses a `LazyGRPCGenerationExporter` that dynamically imports `./grpc.js` only on first use (and supports `shutdown()`), keeping HTTP/none startup paths safe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d07ead63d69c2e60baa3718c7b81bb8e55fab1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->