### PR TITLE
fix(plugins/pi): silence telemetry flush failures

### DIFF
--- a/plugins/pi/src/client.test.ts
+++ b/plugins/pi/src/client.test.ts
@@ -60,6 +60,7 @@ describe("createSigilClient", () => {
         auth: { mode: "tenant", tenantId: "t-1" },
       },
       contentCapture: "metadata_only",
+      logger: expect.any(Object),
       generationSanitizer: SANITIZER,
     });
   });
@@ -88,6 +89,7 @@ describe("createSigilClient", () => {
         },
       },
       contentCapture: "metadata_only",
+      logger: expect.any(Object),
       generationSanitizer: SANITIZER,
     });
   });
@@ -97,6 +99,52 @@ describe("createSigilClient", () => {
     expect(SigilClientMock).toHaveBeenCalledWith(
       expect.objectContaining({ contentCapture: "full" }),
     );
+  });
+
+  it("uses warn as the default sdk log level", () => {
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      createSigilClient(makeConfig());
+      const [{ logger }] = SigilClientMock.mock.calls[0]!;
+      logger.debug("debug");
+      logger.warn("warn");
+      logger.error("error");
+
+      expect(debug).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith("[sigil-pi] warn");
+      expect(error).toHaveBeenCalledWith("[sigil-pi] error");
+    } finally {
+      debug.mockRestore();
+      warn.mockRestore();
+      error.mockRestore();
+    }
+  });
+
+  it("downgrades best-effort export sdk logs to debug", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      createSigilClient(makeConfig());
+      const [{ logger: defaultLogger }] = SigilClientMock.mock.calls[0]!;
+      defaultLogger.warn("sigil generation export failed: transport down");
+      defaultLogger.warn("sigil generation rejected id=g-1: invalid");
+
+      expect(warn).not.toHaveBeenCalled();
+      expect(error).not.toHaveBeenCalled();
+
+      createSigilClient(makeConfig({ debug: true }));
+      const [{ logger: debugLogger }] = SigilClientMock.mock.calls[1]!;
+      debugLogger.warn("sigil generation export failed: transport down");
+
+      expect(error).toHaveBeenCalledWith(
+        "[sigil-pi] sigil generation export failed: transport down",
+      );
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
   });
 
   it("returns null when sdk constructor throws", () => {

--- a/plugins/pi/src/client.ts
+++ b/plugins/pi/src/client.ts
@@ -1,4 +1,7 @@
-import type { GenerationExportConfig } from "@grafana/sigil-sdk-js";
+import type {
+  GenerationExportConfig,
+  SigilLogger,
+} from "@grafana/sigil-sdk-js";
 import {
   createSecretRedactionSanitizer,
   SigilClient,
@@ -9,6 +12,33 @@ import type { SigilAuthConfig, SigilPiConfig } from "./config.js";
 export interface SigilClientOptions {
   tracer?: Tracer;
   meter?: Meter;
+}
+
+function createSdkLogger(debug: boolean): SigilLogger {
+  const debugLog = (message: string, ...args: unknown[]) => {
+    if (debug) console.error(`[sigil-pi] ${message}`, ...args);
+  };
+
+  return {
+    debug: debugLog,
+    warn: (message: string, ...args: unknown[]) => {
+      if (isBestEffortExportLog(message)) {
+        debugLog(message, ...args);
+        return;
+      }
+      console.warn(`[sigil-pi] ${message}`, ...args);
+    },
+    error: (message: string, ...args: unknown[]) => {
+      console.error(`[sigil-pi] ${message}`, ...args);
+    },
+  };
+}
+
+function isBestEffortExportLog(message: string): boolean {
+  return (
+    message.startsWith("sigil generation export failed") ||
+    message.startsWith("sigil generation rejected")
+  );
 }
 
 export function createSigilClient(
@@ -25,6 +55,7 @@ export function createSigilClient(
       contentCapture: config.contentCapture,
       ...(options?.tracer ? { tracer: options.tracer } : {}),
       ...(options?.meter ? { meter: options.meter } : {}),
+      logger: createSdkLogger(config.debug),
       generationSanitizer: config.redaction.enabled
         ? createSecretRedactionSanitizer({
             redactInputMessages: config.redaction.redactInputMessages,

--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -236,6 +236,67 @@ describe("extension lifecycle", () => {
     expect(telemetry.forceFlush).toHaveBeenCalledTimes(1);
   });
 
+  it("does not print telemetry flush failures", async () => {
+    const recorder = {
+      setResult: vi.fn(),
+      setCallError: vi.fn(),
+    };
+
+    const sigil: SigilLike = {
+      startGeneration: vi.fn(async (_seed, run) => {
+        await run(recorder);
+      }),
+      startToolExecution: vi.fn(() => ({
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        end: vi.fn(),
+        getError: vi.fn(),
+      })),
+      shutdown: vi.fn(async () => {}),
+    };
+    const telemetry = {
+      tracer: { tracer: true },
+      meter: { meter: true },
+      forceFlush: vi.fn(async () => {
+        throw new Error("flush timeout");
+      }),
+      shutdown: vi.fn(async () => {}),
+    };
+
+    loadConfigMock.mockResolvedValue({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      auth: { mode: "none" },
+      agentName: "pi",
+      contentCapture: "metadata_only",
+      debug: false,
+      otlp: { endpoint: "http://localhost:4318", headers: {} },
+    });
+    createTelemetryProvidersMock.mockReturnValue(telemetry);
+    createSigilClientMock.mockReturnValue(sigil);
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const pi = new FakePi();
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+      await Promise.resolve();
+
+      expect(telemetry.forceFlush).toHaveBeenCalledTimes(1);
+      expect(warn).not.toHaveBeenCalled();
+      expect(error).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
+  });
+
   it("leaves input empty on a tool-loop continuation with no user message_end", async () => {
     const recorder = {
       setResult: vi.fn(),
@@ -406,7 +467,7 @@ describe("extension lifecycle", () => {
     expect(toolRecorders[1]!.setCallError).toHaveBeenCalled();
   });
 
-  it("swallows sigil failures instead of throwing", async () => {
+  it("swallows sigil failures instead of throwing or printing by default", async () => {
     const sigil = {
       startGeneration: vi.fn(async () => {
         throw new Error("transport down");
@@ -419,18 +480,70 @@ describe("extension lifecycle", () => {
       auth: { mode: "none" },
       agentName: "pi",
       contentCapture: "metadata_only",
+      debug: false,
     });
     createSigilClientMock.mockReturnValue(sigil);
 
-    const pi = new FakePi();
-    registerExtension(pi as any);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const pi = new FakePi();
+      registerExtension(pi as any);
 
-    await pi.emit("session_start");
-    await pi.emit("turn_start");
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
 
-    await expect(
-      pi.emit("turn_end", { message: assistantMessage(), toolResults: [] }),
-    ).resolves.toBeUndefined();
+      await expect(
+        pi.emit("turn_end", { message: assistantMessage(), toolResults: [] }),
+      ).resolves.toBeUndefined();
+
+      expect(warn).not.toHaveBeenCalled();
+      expect(error).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
+  });
+
+  it("prints sigil failures in debug mode", async () => {
+    const sigil = {
+      startGeneration: vi.fn(async () => {
+        throw new Error("transport down");
+      }),
+      shutdown: vi.fn(async () => {}),
+    };
+
+    loadConfigMock.mockResolvedValue({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      auth: { mode: "none" },
+      agentName: "pi",
+      contentCapture: "metadata_only",
+      debug: true,
+    });
+    createSigilClientMock.mockReturnValue(sigil);
+
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const pi = new FakePi();
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      expect(error).toHaveBeenCalledWith(
+        "[sigil-pi] generation export failed",
+        expect.any(Error),
+      );
+      expect(error.mock.calls.map(([message]) => message)).not.toEqual(
+        expect.arrayContaining([expect.stringContaining("generation queued")]),
+      );
+    } finally {
+      error.mockRestore();
+    }
   });
 
   it("warns and skips when assistant message shape is invalid", async () => {

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -60,8 +60,8 @@ export default function (pi: ExtensionAPI) {
 
   let turnStartTime = 0;
 
-  function debugLog(msg: string) {
-    if (config?.debug) console.error(`[sigil-pi] ${msg}`);
+  function debugLog(msg: string, ...args: unknown[]) {
+    if (config?.debug) console.error(`[sigil-pi] ${msg}`, ...args);
   }
 
   // Tool execution timing: toolCallId → start timestamp
@@ -249,29 +249,38 @@ export default function (pi: ExtensionAPI) {
         pendingInputMessages.slice(),
       );
 
-      await sigil.startGeneration(seed, async (recorder) => {
-        recorder.setResult(result);
-        if (msg.errorMessage) {
-          recorder.setCallError(new Error(msg.errorMessage));
-        }
+      try {
+        await sigil.startGeneration(seed, async (recorder) => {
+          recorder.setResult(result);
+          if (msg.errorMessage) {
+            recorder.setCallError(new Error(msg.errorMessage));
+          }
 
-        // sigil and config are guaranteed non-null by the guard at the top of this handler.
-        emitToolSpans(sigil as SigilClient, msg, toolResults, turnToolTimings, {
-          conversationId,
-          agentName: (config as SigilPiConfig).agentName,
-          agentVersion: (config as SigilPiConfig).agentVersion,
-          contentCapture,
+          // sigil and config are guaranteed non-null by the guard at the top of this handler.
+          emitToolSpans(
+            sigil as SigilClient,
+            msg,
+            toolResults,
+            turnToolTimings,
+            {
+              conversationId,
+              agentName: (config as SigilPiConfig).agentName,
+              agentVersion: (config as SigilPiConfig).agentVersion,
+              contentCapture,
+            },
+          );
         });
-      });
+        debugLog(
+          `generation queued, model=${msg.model} tokens=${msg.usage.totalTokens}`,
+        );
+      } catch (err) {
+        debugLog("generation export failed", err);
+      }
       if (telemetry) {
         void telemetry.forceFlush().catch((err) => {
-          console.warn("[sigil-pi] telemetry flush failed:", err);
+          debugLog("telemetry flush failed", err);
         });
       }
-
-      debugLog(
-        `generation queued, model=${msg.model} tokens=${msg.usage.totalTokens}`,
-      );
     } catch (err) {
       console.warn("[sigil-pi] turn_end failed:", err);
     } finally {


### PR DESCRIPTION
Pi surfaces extension stderr in the TUI, and it creates noisy output that looks like it breaks the agent:

<img width="782" height="319" alt="image" src="https://github.com/user-attachments/assets/9758bfdf-b67f-4830-8b0b-c77c85ff372c" />

This keeps the plugin logger at warn by default, and changes export/flush failures to debug-only output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to logging/observability behavior (log levels and error swallowing) without altering exported payloads or auth/redaction behavior.
> 
> **Overview**
> Reduces noisy stderr output from the `pi` plugin by **making Sigil/telemetry failures debug-only by default**.
> 
> Adds a custom SDK `logger` in `createSigilClient` that defaults to warn/error, but downgrades best-effort export warnings (e.g. generation export/rejection) to debug unless `config.debug` is enabled.
> 
> Wraps `sigil.startGeneration` and telemetry `forceFlush()` so export/flush failures are swallowed and only logged via `debugLog` when `debug` is true; tests are updated/added to assert the new logging behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c77fa2d697d43b05522584369a51cc1d733b7d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->