### PR TITLE
fix(plugin): capture opencode system prompt and dedupe duplicate exports

### DIFF
--- a/plugins/opencode/src/hooks.test.ts
+++ b/plugins/opencode/src/hooks.test.ts
@@ -1,0 +1,181 @@
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AssistantMessage, Part, UserMessage } from "@opencode-ai/sdk";
+import { createSigilHooks } from "./hooks.js";
+import type { SigilConfig } from "./config.js";
+
+const mocks = vi.hoisted(() => {
+  const records: { seed: any; recorder: any }[] = [];
+  return {
+    records,
+    sigil: {
+      startGeneration: vi.fn(async (seed: any, callback: (recorder: any) => Promise<void>) => {
+        const recorder = {
+          setResult: vi.fn(),
+          setCallError: vi.fn(),
+        };
+        records.push({ seed, recorder });
+        await callback(recorder);
+      }),
+      flush: vi.fn(),
+      shutdown: vi.fn(),
+    },
+  };
+});
+
+vi.mock("./client.js", () => ({
+  createSigilClient: vi.fn(() => mocks.sigil),
+}));
+
+const config: SigilConfig = {
+  enabled: true,
+  endpoint: "http://localhost:8080/api/v1/generations:export",
+  auth: { mode: "none" },
+  agentName: "opencode",
+  contentCapture: true,
+};
+
+function makeClient() {
+  return {
+    session: {
+      message: vi.fn(async () => ({
+        data: {
+          parts: [
+            { id: "part-assistant", sessionID: "ses-1", messageID: "assistant", type: "text", text: "done" },
+          ],
+        },
+      })),
+    },
+  } as any;
+}
+
+function makeUserMessage(id: string, sessionID: string, system?: string): UserMessage {
+  return {
+    id,
+    sessionID,
+    role: "user",
+    time: { created: 1 },
+    agent: "build",
+    model: { providerID: "openai", modelID: "gpt-5.4" },
+    ...(system && { system }),
+    tools: { bash: true },
+  } as UserMessage;
+}
+
+function makeAssistantMessage(
+  id: string,
+  sessionID: string,
+  parentID: string,
+  finish: string,
+): AssistantMessage {
+  return {
+    id,
+    sessionID,
+    role: "assistant",
+    parentID,
+    modelID: "gpt-5.4",
+    providerID: "openai",
+    mode: "build",
+    path: { cwd: "/tmp", root: "/tmp" },
+    cost: 0.01,
+    tokens: { input: 100, output: 50, reasoning: 0, cache: { read: 0, write: 0 } },
+    time: { created: 10, completed: 20 },
+    finish,
+  } as AssistantMessage;
+}
+
+describe("createSigilHooks", () => {
+  let testDedupDir: string;
+
+  beforeEach(async () => {
+    testDedupDir = await mkdtemp(join(tmpdir(), "sigil-opencode-test-"));
+    process.env.SIGIL_OPENCODE_DEDUP_DIR = testDedupDir;
+    mocks.records.length = 0;
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    delete process.env.SIGIL_OPENCODE_DEDUP_DIR;
+    await rm(testDedupDir, { recursive: true, force: true });
+  });
+
+  it("records the effective system prompt from opencode system transform output", async () => {
+    const hooks = await createSigilHooks(config, makeClient());
+    if (!hooks) throw new Error("expected hooks");
+
+    const parts = [
+      { id: "part-user", sessionID: "ses-1", messageID: "user-1", type: "text", text: "hello" },
+    ] as Part[];
+    hooks.chatMessage({ sessionID: "ses-1" }, { message: makeUserMessage("user-1", "ses-1"), parts });
+    hooks.systemTransform(
+      { sessionID: "ses-1" },
+      { system: ["base opencode prompt", "agent-specific instructions"] },
+    );
+
+    await hooks.event({
+      event: {
+        type: "message.updated",
+        properties: { info: makeAssistantMessage("assistant-1", "ses-1", "user-1", "stop") },
+      },
+    });
+
+    expect(mocks.records[0].seed.systemPrompt).toBe(
+      "base opencode prompt\n\nagent-specific instructions",
+    );
+  });
+
+  it("keeps pending prompt context across intermediate tool-call assistant messages", async () => {
+    const hooks = await createSigilHooks(config, makeClient());
+    if (!hooks) throw new Error("expected hooks");
+
+    hooks.chatMessage({
+      sessionID: "ses-2",
+    }, {
+      message: makeUserMessage("user-2", "ses-2", "message system prompt"),
+      parts: [],
+    });
+
+    await hooks.event({
+      event: {
+        type: "message.updated",
+        properties: { info: makeAssistantMessage("assistant-2a", "ses-2", "user-2", "tool-calls") },
+      },
+    });
+    await hooks.event({
+      event: {
+        type: "message.updated",
+        properties: { info: makeAssistantMessage("assistant-2b", "ses-2", "user-2", "stop") },
+      },
+    });
+
+    expect(mocks.records).toHaveLength(2);
+    expect(mocks.records[0].seed.systemPrompt).toBe("message system prompt");
+    expect(mocks.records[1].seed.systemPrompt).toBe("message system prompt");
+  });
+
+  it("deduplicates repeated terminal events for the same assistant message", async () => {
+    const hooks = await createSigilHooks(config, makeClient());
+    if (!hooks) throw new Error("expected hooks");
+
+    hooks.chatMessage({
+      sessionID: "ses-3",
+    }, {
+      message: makeUserMessage("user-3", "ses-3", "message system prompt"),
+      parts: [],
+    });
+
+    const event = {
+      event: {
+        type: "message.updated",
+        properties: { info: makeAssistantMessage("assistant-3", "ses-3", "user-3", "stop") },
+      },
+    };
+    await hooks.event(event);
+    await hooks.event(event);
+
+    expect(mocks.records).toHaveLength(1);
+    expect(mocks.records[0].seed.id).toBe("assistant-3");
+  });
+});

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -1,3 +1,6 @@
+import { mkdir, open, unlink } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
 import type { SigilClient } from "@grafana/sigil-sdk-js";
 import type { AssistantMessage, UserMessage, Part } from "@opencode-ai/sdk";
 import type { PluginInput } from "@opencode-ai/plugin";
@@ -18,10 +21,59 @@ type PendingGeneration = {
   tools: Record<string, boolean> | undefined;
 };
 const pendingGenerations = new Map<string, PendingGeneration>();
+const sessionPendingMessages = new Map<string, Set<string>>();
+const latestSystemPrompts = new Map<string, string>();
+
+function dedupDir(): string {
+  return process.env.SIGIL_OPENCODE_DEDUP_DIR ??
+    join(homedir(), ".cache", "opencode", "sigil-recorded");
+}
 
 function buildAgentName(prefix: string | undefined, mode: string | undefined): string {
   const base = prefix || "opencode";
   return mode ? `${base}:${mode}` : base;
+}
+
+function safePathPart(value: string): string {
+  return value.replace(/[^A-Za-z0-9_.-]/g, "_");
+}
+
+function dedupMarkerPath(sessionID: string, messageID: string): string {
+  return join(dedupDir(), `${safePathPart(sessionID)}-${safePathPart(messageID)}.lock`);
+}
+
+async function claimRecordedMessage(sessionID: string, messageID: string): Promise<boolean> {
+  const sessionSet = recordedMessages.get(sessionID) ?? new Set<string>();
+  if (sessionSet.has(messageID)) return false;
+
+  try {
+    await mkdir(dedupDir(), { recursive: true });
+    const marker = await open(dedupMarkerPath(sessionID, messageID), "wx");
+    await marker.close();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      return false;
+    }
+    // If filesystem dedup is unavailable, keep the existing in-process guard.
+  }
+
+  sessionSet.add(messageID);
+  recordedMessages.set(sessionID, sessionSet);
+  return true;
+}
+
+async function releaseRecordedMessage(sessionID: string, messageID: string): Promise<void> {
+  recordedMessages.get(sessionID)?.delete(messageID);
+  try {
+    await unlink(dedupMarkerPath(sessionID, messageID));
+  } catch {
+    // Best effort cleanup; a stale marker is preferable to duplicate exports.
+  }
+}
+
+function joinSystemPrompt(system: string[] | undefined): string | undefined {
+  const prompt = system?.filter((part) => part.trim().length > 0).join("\n\n");
+  return prompt && prompt.length > 0 ? prompt : undefined;
 }
 
 /**
@@ -32,11 +84,48 @@ function handleChatMessage(
   input: { sessionID: string },
   output: { message: UserMessage; parts: Part[] },
 ): void {
-  pendingGenerations.set(input.sessionID, {
-    systemPrompt: output.message.system,
+  const messageID = output.message.id;
+  pendingGenerations.set(messageID, {
+    systemPrompt: output.message.system ?? latestSystemPrompts.get(input.sessionID),
     userParts: output.parts,
     tools: output.message.tools,
   });
+  const sessionSet = sessionPendingMessages.get(input.sessionID) ?? new Set<string>();
+  sessionSet.add(messageID);
+  sessionPendingMessages.set(input.sessionID, sessionSet);
+}
+
+function handleSystemTransform(
+  input: { sessionID?: string },
+  output: { system: string[] },
+): void {
+  if (!input.sessionID) return;
+  const systemPrompt = joinSystemPrompt(output.system);
+  if (!systemPrompt) return;
+
+  latestSystemPrompts.set(input.sessionID, systemPrompt);
+  for (const messageID of sessionPendingMessages.get(input.sessionID) ?? []) {
+    const pending = pendingGenerations.get(messageID);
+    if (pending) {
+      pending.systemPrompt = systemPrompt;
+    }
+  }
+}
+
+function shouldClearPendingGeneration(msg: AssistantMessage): boolean {
+  if (msg.error) return true;
+  return msg.finish !== "tool-calls";
+}
+
+function clearPendingGeneration(sessionID: string, messageID: string | undefined): void {
+  if (!messageID) return;
+  pendingGenerations.delete(messageID);
+  const sessionSet = sessionPendingMessages.get(sessionID);
+  if (!sessionSet) return;
+  sessionSet.delete(messageID);
+  if (sessionSet.size === 0) {
+    sessionPendingMessages.delete(sessionID);
+  }
 }
 
 async function handleEvent(
@@ -58,14 +147,11 @@ async function handleEvent(
   const isTerminal = assistantMsg.finish || assistantMsg.error || assistantMsg.time.completed;
   if (!isTerminal) return;
 
-  // Dedup
-  const sessionSet = recordedMessages.get(assistantMsg.sessionID) ?? new Set<string>();
-  if (sessionSet.has(assistantMsg.id)) return;
-  sessionSet.add(assistantMsg.id);
-  recordedMessages.set(assistantMsg.sessionID, sessionSet);
+  // Dedup across repeated events and multiple live opencode processes.
+  if (!(await claimRecordedMessage(assistantMsg.sessionID, assistantMsg.id))) return;
 
   // Look up pending generation (user-side data)
-  const pending = pendingGenerations.get(assistantMsg.sessionID);
+  const pending = pendingGenerations.get(assistantMsg.parentID);
 
   // Fetch assistant parts via REST
   let assistantParts: Part[] = [];
@@ -81,6 +167,7 @@ async function handleEvent(
   const contentCapture = config.contentCapture ?? true;
 
   const seed = {
+    id: assistantMsg.id,
     conversationId: assistantMsg.sessionID,
     agentName: buildAgentName(config.agentName, assistantMsg.mode),
     agentVersion: config.agentVersion,
@@ -110,11 +197,14 @@ async function handleEvent(
       });
     }
   } catch {
+    await releaseRecordedMessage(assistantMsg.sessionID, assistantMsg.id);
     // Sigil recording failure should never break the plugin
   }
 
-  // Clean up pending generation
-  pendingGenerations.delete(assistantMsg.sessionID);
+  // Keep user-side context through intermediate tool-call assistant messages.
+  if (shouldClearPendingGeneration(assistantMsg)) {
+    clearPendingGeneration(assistantMsg.sessionID, assistantMsg.parentID);
+  }
 }
 
 async function handleLifecycle(
@@ -136,7 +226,11 @@ async function handleLifecycle(
     const sessionId = properties?.info?.id;
     if (sessionId) {
       recordedMessages.delete(sessionId);
-      pendingGenerations.delete(sessionId);
+      for (const messageID of sessionPendingMessages.get(sessionId) ?? []) {
+        pendingGenerations.delete(messageID);
+      }
+      sessionPendingMessages.delete(sessionId);
+      latestSystemPrompts.delete(sessionId);
     }
   }
 
@@ -154,6 +248,10 @@ export type SigilHooks = {
   chatMessage: (
     input: { sessionID: string },
     output: { message: UserMessage; parts: Part[] },
+  ) => void;
+  systemTransform: (
+    input: { sessionID?: string },
+    output: { system: string[] },
   ) => void;
 };
 
@@ -184,6 +282,9 @@ export async function createSigilHooks(
     },
     chatMessage: (input, output) => {
       handleChatMessage(input, output);
+    },
+    systemTransform: (input, output) => {
+      handleSystemTransform(input, output);
     },
   };
 }

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -13,6 +13,9 @@ export const SigilPlugin: Plugin = async ({ client }) => {
     "chat.message": async (input, output) => {
       hooks.chatMessage(input, output);
     },
+    "experimental.chat.system.transform": async (input, output) => {
+      hooks.systemTransform(input, output);
+    },
     event: async ({ event }) => {
       await hooks.event({
         event: event as { type: string; properties: unknown },


### PR DESCRIPTION
## Notes

This PR fixes the OpenCode plugin which was not capturing system prompt correctly and sometimes duplicating messages if you had multiple Opencode windows open at the same time.

## Testing

Installed the local fix to my local OpenCode and verified system prompt was captured correctly and messages were deduped (see screenshot)

<img width="882" height="463" alt="image" src="https://github.com/user-attachments/assets/31a51315-9977-45e9-9a26-f2875e458650" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes message export bookkeeping and introduces filesystem-based dedup markers, which can affect export completeness and behavior across sessions/processes. Risk is moderate due to new state management and disk I/O, but scoped to the Sigil export plugin.
> 
> **Overview**
> Fixes Sigil export seeding to **capture the effective system prompt** by wiring the `experimental.chat.system.transform` hook and propagating the transformed/combined prompt into pending generations.
> 
> Reworks pending-generation tracking to key off the *user message id* (`assistant.parentID`) and to **persist context across intermediate `tool-calls` assistant messages**, clearing only when the assistant reaches a non-tool-call terminal state or errors.
> 
> Adds **cross-process deduplication** of exported assistant messages via per-message filesystem lock markers (configurable with `SIGIL_OPENCODE_DEDUP_DIR`) plus best-effort cleanup on failure, and includes a new `hooks.test.ts` covering system prompt capture, tool-call continuity, and dedup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbe0d61b4644f0d636f539258b2c104d682fe5c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->