### PR TITLE
fix(ci): remove skip ci for plugins bump PRs

### DIFF
--- a/.github/workflows/plugins-publish.yml
+++ b/.github/workflows/plugins-publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       plugin:
-        description: 'Which plugin to publish'
+        description: "Which plugin to publish"
         required: true
         type: choice
         options:
@@ -12,7 +12,7 @@ on:
           - opencode
           - all
       version:
-        description: 'Semver bump (applied to each selected plugin from its own current version)'
+        description: "Semver bump (applied to each selected plugin from its own current version)"
         required: true
         type: choice
         options:
@@ -123,7 +123,7 @@ jobs:
           TIMESTAMP=$(date +%Y%m%d%H%M%S)
           BRANCH="release/plugins-${TIMESTAMP}"
           git checkout -b "${BRANCH}"
-          git commit -m "chore(plugins): bump versions (${{ inputs.version }}) [skip ci]"
+          git commit -m "chore(plugins): bump versions (${{ inputs.version }})"
 
           # Push branch and tags
           for p in ${PLUGINS}; do
@@ -167,7 +167,7 @@ jobs:
     steps:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24'
+          node-version: "24"
           registry-url: https://registry.npmjs.org
 
       - name: Download plugin tarballs


### PR DESCRIPTION
Can't merge it otherwise: https://github.com/grafana/sigil-sdk/pull/111 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the plugin publish GitHub Actions workflow commit message and YAML quoting; the main impact is that automated version-bump PRs will now trigger CI, which could affect release automation timing and merge behavior.
> 
> **Overview**
> Ensures the plugin publish workflow’s auto-generated version-bump commit no longer includes ` [skip ci]`, allowing the resulting PR to run required checks and be mergeable.
> 
> Also normalizes a few YAML strings in `.github/workflows/plugins-publish.yml` (switching to double quotes, including the `node-version` value) with no functional workflow logic changes beyond CI triggering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f4e2a7b7738ff0e193f6160a8341f1ef881db8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->