### PR TITLE
fix(plugins/claude-code): include tool arguments in guard hook request

### DIFF
--- a/plugins/claude-code/cmd/sigil-cc/main.go
+++ b/plugins/claude-code/cmd/sigil-cc/main.go
@@ -318,6 +318,7 @@ func handlePreToolUse(
 					ToolCall: &sigil.ToolCall{
 						ID:        strings.TrimSpace(input.ToolUseID),
 						Name:      toolName,
+						InputJSON: input.ToolInput,
 					},
 				}},
 			}},


### PR DESCRIPTION
## Summary

- Wire `input.ToolInput` into the `ToolCall.InputJSON` field in the pre_tool_use hook request so guard evaluations can see tool arguments, not just the tool name.
- Previously, a `Bash(echo hi)` call sent `{"name":"Bash"}` with no `input_json`; now it sends `{"name":"Bash","input_json":{"command":"echo hi"}}`.

## Context

This is the SDK-side counterpart to grafana/sigil#TBD which adds argument-level matching in tool filter guards. Without this fix, the server never receives tool arguments for Claude Code hook evaluations.

## Test plan

- [x] `go build` passes
- [ ] Manual test: configure a guard with `Bash(*rm*)` and verify it blocks `rm` commands from Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the data sent to hook/guard evaluation for `PreToolUse`, which can affect allow/deny decisions; small, targeted change but touches security/guard behavior.
> 
> **Overview**
> `PreToolUse` hook evaluations now include the tool’s argument payload by wiring `input.ToolInput` into `sigil.ToolCall.InputJSON` in the hook request.
> 
> This lets guard rules match on tool parameters (not just the tool name) when deciding whether to allow or deny a tool call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29846c7713e0e407953e7068604e1040f758170a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->