### PR TITLE
fix(js): bump package.json version to 0.3.1

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/sigil-sdk-js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bumps `js/package.json` version from `0.3.0` to `0.3.1` to match what was published to npm.
- CI published the release but the source version was not updated.

## Notes
- `js/package-lock.json` was already out of sync (at `0.1.0`) and has pre-existing peer dependency conflicts — left unchanged to keep this PR minimal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that updates the published package version with no runtime or dependency modifications.
> 
> **Overview**
> Updates `js/package.json` to bump `@grafana/sigil-sdk-js` from `0.3.0` to `0.3.1` to align the source version with the npm release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01ee5238daea4297d2dfa633311657d59de791c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->