### PR TITLE
feat: auto-append /api/v1/generations:export to HTTP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ import { SigilClient } from "@grafana/sigil-sdk-js";
 const client = new SigilClient({
   generationExport: {
     protocol: "http",
-    endpoint: "http://localhost:8080/api/v1/generations:export",
+    endpoint: "http://localhost:8080",
     auth: { mode: "tenant", tenantId: "dev-tenant" },
   },
 });
@@ -90,7 +90,7 @@ await client.shutdown();
 ```go
 cfg := sigil.DefaultConfig()
 cfg.GenerationExport.Protocol = sigil.GenerationExportProtocolHTTP
-cfg.GenerationExport.Endpoint = "http://localhost:8080/api/v1/generations:export"
+cfg.GenerationExport.Endpoint = "http://localhost:8080"
 cfg.GenerationExport.Auth = sigil.AuthConfig{
 	Mode:     sigil.ExportAuthModeTenant,
 	TenantID: "dev-tenant",
@@ -113,11 +113,14 @@ rec.SetResult(sigil.Generation{
 ### Python
 
 ```python
-from sigil_sdk import Client, ClientConfig, GenerationStart, ModelRef, assistant_text_message
+from sigil_sdk import Client, ClientConfig, GenerationExportConfig, GenerationStart, ModelRef, assistant_text_message
 
 client = Client(
     ClientConfig(
-        generation_export_endpoint="http://localhost:8080/api/v1/generations:export",
+        generation_export=GenerationExportConfig(
+            protocol="http",
+            endpoint="http://localhost:8080",
+        ),
     )
 )
 
@@ -163,13 +166,13 @@ Minimal, self-contained examples that make a real LLM call and record the genera
 
 ### Grafana Cloud credentials
 
-You need three values to connect. All are visible in the **AI Observability plugin → Connection tab** in your Grafana Cloud stack.
+You need three values to connect. The endpoint and instance ID are visible in **AI Observability → Configuration** in your Grafana Cloud stack; see the [Grafana Cloud AI Observability getting started docs](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/) for the full setup flow.
 
 | What | Where to find it |
 |------|-----------------|
-| **Instance ID** — numeric stack ID, used as tenant ID and basic-auth username | Shown under **Instance ID** in the Connection tab. Also in the Cloud Portal under your stack details. |
+| **Instance ID** — numeric stack ID, used as tenant ID and basic-auth username | Shown under **Instance ID** in AI Observability → Configuration. Also in the Cloud Portal under your stack details. |
 | **API token** — starts with `glc_`, used as the basic-auth password | Create one via **Administration → Cloud Access Policies** ([docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/)). Scope it to your stack with write permissions for AI Observability. |
-| **Endpoint URL** — the ingest URL for your region | Shown under **API URL** in the Connection tab. Append `/api/v1/generations:export` to get the full ingest URL. |
+| **Endpoint URL** — the ingest URL for your region | Shown under **API URL** in AI Observability → Configuration. |
 
 ## Plugins
 

--- a/examples/getting-started/go/.env.example
+++ b/examples/getting-started/go/.env.example
@@ -3,16 +3,17 @@
 OPENAI_API_KEY=
 
 # --- Sigil generation export (Grafana Cloud) ---
-# Generation-ingest URL. Find it in your Grafana Cloud stack under
-# AI Observability → SDK connection details.
-SIGIL_ENDPOINT=https://<your-stack>.grafana.net/api/v1/generations:export
+# Sigil API URL. See the Grafana Cloud AI Observability getting started docs:
+# https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/
+# Copy the API URL from Observability → AI Observability → Configuration.
+SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
 
 # Your Grafana Cloud stack / instance ID (numeric).
-# Shown in the stack details page or the SDK connection details panel.
+# Shown under Instance ID in AI Observability → Configuration or in the Cloud Portal stack details.
 GRAFANA_INSTANCE_ID=
 
-# A Grafana Cloud API token with AI Observability write permissions.
-# Create one at https://grafana.com → My Account → API Keys.
+# A Grafana Cloud access policy token with sigil:write.
+# Create one in Security → Access Policies as described in the docs above.
 GRAFANA_CLOUD_TOKEN=
 
 # --- OTel traces + metrics ---

--- a/examples/getting-started/python-multi-agent/.env.example
+++ b/examples/getting-started/python-multi-agent/.env.example
@@ -3,16 +3,17 @@
 OPENAI_API_KEY=
 
 # --- Sigil generation export (Grafana Cloud) ---
-# Generation-ingest URL. Find it in your Grafana Cloud stack under
-# AI Observability → SDK connection details.
-SIGIL_ENDPOINT=https://<your-stack>.grafana.net/api/v1/generations:export
+# Sigil API URL. See the Grafana Cloud AI Observability getting started docs:
+# https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/
+# Copy the API URL from Observability → AI Observability → Configuration.
+SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
 
 # Your Grafana Cloud stack / instance ID (numeric).
-# Shown in the stack details page or the SDK connection details panel.
+# Shown under Instance ID in AI Observability → Configuration or in the Cloud Portal stack details.
 GRAFANA_INSTANCE_ID=
 
-# A Grafana Cloud API token with AI Observability write permissions.
-# Create one at https://grafana.com → My Account → API Keys.
+# A Grafana Cloud access policy token with sigil:write.
+# Create one in Security → Access Policies as described in the docs above.
 GRAFANA_CLOUD_TOKEN=
 
 # --- OTel traces + metrics ---

--- a/examples/getting-started/python-pydantic-ai/.env.example
+++ b/examples/getting-started/python-pydantic-ai/.env.example
@@ -1,8 +1,10 @@
 # Anthropic API key (required). The agent runs against `anthropic:claude-haiku-4-5`.
 ANTHROPIC_API_KEY=sk-ant-...
 
-# Sigil service host. Copy the URL shown in your stack's "SDK connection details" panel.
-SIGIL_ENDPOINT=https://sigil-prod-eu-west-2.grafana.net
+# Sigil API URL. See the Grafana Cloud AI Observability getting started docs:
+# https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/
+# Copy the API URL from Observability → AI Observability → Configuration.
+SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
 
 # Stack / instance ID. Used as the basic-auth user and the X-Scope-OrgID tenant.
 GRAFANA_INSTANCE_ID=

--- a/examples/getting-started/python-pydantic-ai/README.md
+++ b/examples/getting-started/python-pydantic-ai/README.md
@@ -7,7 +7,7 @@ Runs a Pydantic AI agent and records the generation to Grafana Cloud AI Observab
 ```bash
 cd examples/getting-started/python-pydantic-ai
 # Set ANTHROPIC_API_KEY, GRAFANA_INSTANCE_ID, GRAFANA_CLOUD_TOKEN, SIGIL_ENDPOINT
-# See the SDK README for where to find each value.
+# See the SDK README or Grafana Cloud AI Observability getting started docs for where to find each value.
 ```
 
 ```bash

--- a/examples/getting-started/python-strands/.env.example
+++ b/examples/getting-started/python-strands/.env.example
@@ -1,4 +1,6 @@
-# Sigil service host. Copy the URL shown in your stack's "SDK connection details" panel.
+# Sigil API URL. See the Grafana Cloud AI Observability getting started docs:
+# https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/
+# Copy the API URL from Observability → AI Observability → Configuration.
 SIGIL_EXPORT_PROTOCOL=http
 SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
 SIGIL_CONVERSATION_ID=sigil-strands-demo

--- a/examples/getting-started/python-strands/README.md
+++ b/examples/getting-started/python-strands/README.md
@@ -12,7 +12,7 @@ pip install -r requirements.txt
 cp .env.example .env
 ```
 
-Configure Sigil and OTel endpoints from your Grafana Cloud stack:
+Configure Sigil and OTel endpoints from your Grafana Cloud stack. See the [Grafana Cloud AI Observability getting started docs](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/) for where to find the Sigil API URL:
 
 ```bash
 SIGIL_EXPORT_PROTOCOL=http

--- a/examples/getting-started/python/.env.example
+++ b/examples/getting-started/python/.env.example
@@ -3,16 +3,17 @@
 OPENAI_API_KEY=
 
 # --- Sigil generation export (Grafana Cloud) ---
-# Generation-ingest URL. Find it in your Grafana Cloud stack under
-# AI Observability → SDK connection details.
-SIGIL_ENDPOINT=https://<your-stack>.grafana.net/api/v1/generations:export
+# Sigil API URL. See the Grafana Cloud AI Observability getting started docs:
+# https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/
+# Copy the API URL from Observability → AI Observability → Configuration.
+SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
 
 # Your Grafana Cloud stack / instance ID (numeric).
-# Shown in the stack details page or the SDK connection details panel.
+# Shown under Instance ID in AI Observability → Configuration or in the Cloud Portal stack details.
 GRAFANA_INSTANCE_ID=
 
-# A Grafana Cloud API token with AI Observability write permissions.
-# Create one at https://grafana.com → My Account → API Keys.
+# A Grafana Cloud access policy token with sigil:write.
+# Create one in Security → Access Policies as described in the docs above.
 GRAFANA_CLOUD_TOKEN=
 
 # --- OTel traces + metrics ---

--- a/examples/getting-started/typescript-strands/.env.example
+++ b/examples/getting-started/typescript-strands/.env.example
@@ -1,6 +1,8 @@
-# Sigil generation-ingest URL. Copy the URL shown in your stack's "SDK connection details" panel.
+# Sigil API URL. See the Grafana Cloud AI Observability getting started docs:
+# https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/
+# Copy the API URL from Observability → AI Observability → Configuration.
 SIGIL_EXPORT_PROTOCOL=http
-SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net/api/v1/generations:export
+SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
 SIGIL_CONVERSATION_ID=sigil-strands-demo
 
 # Stack / instance ID. Used as the basic-auth user and the X-Scope-OrgID tenant.

--- a/examples/getting-started/typescript-strands/README.md
+++ b/examples/getting-started/typescript-strands/README.md
@@ -10,11 +10,11 @@ npm install
 cp .env.example .env
 ```
 
-Configure Sigil, OpenTelemetry, and OpenAI from your Grafana Cloud stack:
+Configure Sigil, OpenTelemetry, and OpenAI from your Grafana Cloud stack. See the [Grafana Cloud AI Observability getting started docs](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/) for where to find the Sigil API URL:
 
 ```bash
 SIGIL_EXPORT_PROTOCOL=http
-SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net/api/v1/generations:export
+SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
 GRAFANA_INSTANCE_ID=...
 GRAFANA_CLOUD_TOKEN=...
 SIGIL_CONVERSATION_ID=sigil-strands-demo

--- a/examples/getting-started/typescript/.env.example
+++ b/examples/getting-started/typescript/.env.example
@@ -3,16 +3,17 @@
 OPENAI_API_KEY=
 
 # --- Sigil generation export (Grafana Cloud) ---
-# Generation-ingest URL. Find it in your Grafana Cloud stack under
-# AI Observability → SDK connection details.
-SIGIL_ENDPOINT=https://<your-stack>.grafana.net/api/v1/generations:export
+# Sigil API URL. See the Grafana Cloud AI Observability getting started docs:
+# https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/
+# Copy the API URL from Observability → AI Observability → Configuration.
+SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
 
 # Your Grafana Cloud stack / instance ID (numeric).
-# Shown in the stack details page or the SDK connection details panel.
+# Shown under Instance ID in AI Observability → Configuration or in the Cloud Portal stack details.
 GRAFANA_INSTANCE_ID=
 
-# A Grafana Cloud API token with AI Observability write permissions.
-# Create one at https://grafana.com → My Account → API Keys.
+# A Grafana Cloud access policy token with sigil:write.
+# Create one in Security → Access Policies as described in the docs above.
 GRAFANA_CLOUD_TOKEN=
 
 # --- OTel traces + metrics ---

--- a/examples/python-langchain/.env.example
+++ b/examples/python-langchain/.env.example
@@ -2,8 +2,9 @@
 ANTHROPIC_API_KEY=sk-ant-...
 
 # --- Sigil (all required) ---
-# Endpoint of your Sigil instance. For Grafana Cloud this is the URL
-# shown in the "SDK connection details" panel of your stack.
+# Endpoint of your Sigil instance. For Grafana Cloud, see:
+# https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/
+# Copy the API URL from Observability → AI Observability → Configuration.
 SIGIL_API_ENDPOINT=
 SIGIL_GENERATION_EXPORT_ENDPOINT=
 

--- a/go/README.md
+++ b/go/README.md
@@ -78,7 +78,7 @@ cfg := sigil.DefaultConfig()
 
 // Generation export (custom ingest)
 cfg.GenerationExport.Protocol = sigil.GenerationExportProtocolGRPC // default; or sigil.GenerationExportProtocolHTTP / sigil.GenerationExportProtocolNone
-cfg.GenerationExport.Endpoint = "localhost:4317"                  // HTTP parity: "http://localhost:8080/api/v1/generations:export"
+cfg.GenerationExport.Endpoint = "localhost:4317"                  // HTTP parity: "http://localhost:8080" (SDK auto-appends /api/v1/generations:export)
 cfg.GenerationExport.Auth = sigil.AuthConfig{
 	Mode:     sigil.ExportAuthModeTenant,
 	TenantID: "dev-tenant",

--- a/go/sigil/exporter.go
+++ b/go/sigil/exporter.go
@@ -22,8 +22,9 @@ import (
 )
 
 const (
-	tenantHeaderName        = "X-Scope-OrgID"
-	authorizationHeaderName = "Authorization"
+	tenantHeaderName         = "X-Scope-OrgID"
+	authorizationHeaderName  = "Authorization"
+	httpGenerationExportPath = "/api/v1/generations:export"
 )
 
 type queuedGeneration struct {
@@ -134,22 +135,31 @@ type httpGenerationExporter struct {
 }
 
 func newHTTPGenerationExporter(cfg GenerationExportConfig) (generationExporter, error) {
-	endpoint, path, insecureEndpoint, err := splitEndpoint(cfg.Endpoint)
-	if err != nil {
-		return nil, err
+	trimmed := strings.TrimSpace(cfg.Endpoint)
+	if trimmed == "" {
+		return nil, errors.New("endpoint is required")
 	}
 
-	urlString := endpoint
-	if !strings.HasPrefix(urlString, "http://") && !strings.HasPrefix(urlString, "https://") {
+	urlString := trimmed
+	lowerPrefix := strings.ToLower(trimmed)
+	if !strings.HasPrefix(lowerPrefix, "http://") && !strings.HasPrefix(lowerPrefix, "https://") {
 		scheme := "https://"
-		if insecureValue(cfg.Insecure) || insecureEndpoint {
+		if insecureValue(cfg.Insecure) {
 			scheme = "http://"
 		}
-		urlString = scheme + endpoint
+		urlString = scheme + trimmed
 	}
-	if path != "" {
-		urlString = strings.TrimRight(urlString, "/") + path
+	parsed, err := url.Parse(urlString)
+	if err != nil {
+		return nil, fmt.Errorf("parse generation export endpoint %q: %w", cfg.Endpoint, err)
 	}
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("endpoint %q has empty host", cfg.Endpoint)
+	}
+	if parsed.Path == "" || parsed.Path == "/" {
+		parsed.Path = httpGenerationExportPath
+	}
+	urlString = parsed.String()
 
 	return &httpGenerationExporter{
 		endpoint: urlString,

--- a/go/sigil/exporter_test.go
+++ b/go/sigil/exporter_test.go
@@ -253,6 +253,42 @@ func TestNewHTTPGenerationExporterUsesEndpointScheme(t *testing.T) {
 			insecure: true,
 			wantURL:  "http://localhost:8080/api/v1/generations:export",
 		},
+		{
+			name:     "missing path appends default ingest path",
+			endpoint: "http://localhost:8080",
+			insecure: true,
+			wantURL:  "http://localhost:8080/api/v1/generations:export",
+		},
+		{
+			name:     "trailing slash treated as missing path",
+			endpoint: "http://localhost:8080/",
+			insecure: true,
+			wantURL:  "http://localhost:8080/api/v1/generations:export",
+		},
+		{
+			name:     "https with no path appends default ingest path",
+			endpoint: "https://stack.grafana.net",
+			insecure: false,
+			wantURL:  "https://stack.grafana.net/api/v1/generations:export",
+		},
+		{
+			name:     "custom path is preserved",
+			endpoint: "http://localhost:8080/custom/ingest",
+			insecure: true,
+			wantURL:  "http://localhost:8080/custom/ingest",
+		},
+		{
+			name:     "uppercase scheme normalized to lowercase",
+			endpoint: "HTTPS://stack.grafana.net",
+			insecure: false,
+			wantURL:  "https://stack.grafana.net/api/v1/generations:export",
+		},
+		{
+			name:     "query string preserved when path appended",
+			endpoint: "http://localhost:8080?token=abc",
+			insecure: true,
+			wantURL:  "http://localhost:8080/api/v1/generations:export?token=abc",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/java/README.md
+++ b/java/README.md
@@ -54,7 +54,7 @@ SigilClient client = new SigilClient(new SigilClientConfig()
         .setEndpoint("http://localhost:8080"))
     .setGenerationExport(new GenerationExportConfig()
         .setProtocol(GenerationExportProtocol.HTTP)
-        .setEndpoint("http://localhost:8080/api/v1/generations:export")
+        .setEndpoint("http://localhost:8080")
         .setAuth(new AuthConfig().setMode(AuthMode.TENANT).setTenantId("dev-tenant"))));
 
 try {

--- a/java/core/src/main/java/com/grafana/sigil/sdk/GenerationExportConfig.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/GenerationExportConfig.java
@@ -15,10 +15,10 @@ public final class GenerationExportConfig {
     private GenerationExportProtocol protocol;
     /**
      * Export endpoint. Empty string means "not set" — env layer or
-     * {@link SigilClient} resolves it to
-     * {@code http://localhost:8080/api/v1/generations:export}. An explicit
-     * non-empty value is preserved (caller-wins) and not overridden by
-     * {@code SIGIL_ENDPOINT}.
+     * {@link SigilClient} resolves it to {@code http://localhost:8080}.
+     * The HTTP exporter auto-appends {@code /api/v1/generations:export}
+     * when the URL has no path. An explicit non-empty value is preserved
+     * (caller-wins) and not overridden by {@code SIGIL_ENDPOINT}.
      */
     private String endpoint = "";
     private final Map<String, String> headers = new LinkedHashMap<>();

--- a/java/core/src/main/java/com/grafana/sigil/sdk/HttpGenerationExporter.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/HttpGenerationExporter.java
@@ -3,12 +3,14 @@ package com.grafana.sigil.sdk;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.protobuf.util.JsonFormat;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /** HTTP exporter for generation ingest parity endpoint. */
@@ -65,15 +67,49 @@ public final class HttpGenerationExporter implements GenerationExporter {
         return new ExportGenerationsResponse().setResults(results);
     }
 
-    private static String normalizeEndpoint(String endpoint) {
+    private static final String HTTP_GENERATION_EXPORT_PATH = "/api/v1/generations:export";
+
+    static String normalizeEndpoint(String endpoint) {
         String trimmed = endpoint == null ? "" : endpoint.trim();
         if (trimmed.isEmpty()) {
             throw new IllegalArgumentException("generation export endpoint is required");
         }
-        if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
-            return trimmed;
+        boolean hasScheme = trimmed.regionMatches(true, 0, "http://", 0, 7)
+                || trimmed.regionMatches(true, 0, "https://", 0, 8);
+        String withScheme = hasScheme ? trimmed : "http://" + trimmed;
+        URI uri;
+        try {
+            uri = new URI(withScheme);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(
+                    "parse generation export endpoint \"" + endpoint + "\": " + e.getMessage(), e);
         }
-        return "http://" + trimmed;
+        if (uri.getHost() == null || uri.getHost().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "generation export endpoint \"" + endpoint + "\" has empty host");
+        }
+        String path = uri.getRawPath();
+        if (path != null && !path.isEmpty() && !path.equals("/")) {
+            return withLowercaseScheme(uri);
+        }
+
+        StringBuilder builder = new StringBuilder();
+        builder.append(uri.getScheme().toLowerCase(Locale.ROOT))
+                .append("://")
+                .append(uri.getRawAuthority())
+                .append(HTTP_GENERATION_EXPORT_PATH);
+        if (uri.getRawQuery() != null) {
+            builder.append('?').append(uri.getRawQuery());
+        }
+        if (uri.getRawFragment() != null) {
+            builder.append('#').append(uri.getRawFragment());
+        }
+        return builder.toString();
+    }
+
+    private static String withLowercaseScheme(URI uri) {
+        String ascii = uri.toASCIIString();
+        return uri.getScheme().toLowerCase(Locale.ROOT) + ascii.substring(uri.getScheme().length());
     }
 
     private static String firstNonBlank(String... values) {

--- a/java/core/src/main/java/com/grafana/sigil/sdk/SigilEnvConfig.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/SigilEnvConfig.java
@@ -145,7 +145,7 @@ public final class SigilEnvConfig {
             export.setProtocol(GenerationExportProtocol.HTTP);
         }
         if (export.getEndpoint().isEmpty()) {
-            export.setEndpoint("http://localhost:8080/api/v1/generations:export");
+            export.setEndpoint("http://localhost:8080");
         }
         if (auth.getMode() == null) {
             auth.setMode(AuthMode.NONE);

--- a/java/core/src/test/java/com/grafana/sigil/sdk/HttpGenerationExporterTest.java
+++ b/java/core/src/test/java/com/grafana/sigil/sdk/HttpGenerationExporterTest.java
@@ -1,0 +1,85 @@
+package com.grafana.sigil.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Stream;
+
+class HttpGenerationExporterTest {
+
+    static Stream<Arguments> normalizeCases() {
+        return Stream.of(
+                Arguments.of(
+                        "missing path appends default ingest path",
+                        "http://localhost:8080",
+                        "http://localhost:8080/api/v1/generations:export"),
+                Arguments.of(
+                        "trailing slash treated as missing path",
+                        "http://localhost:8080/",
+                        "http://localhost:8080/api/v1/generations:export"),
+                Arguments.of(
+                        "explicit ingest path is preserved",
+                        "http://localhost:8080/api/v1/generations:export",
+                        "http://localhost:8080/api/v1/generations:export"),
+                Arguments.of(
+                        "custom path is preserved",
+                        "http://localhost:8080/custom/ingest",
+                        "http://localhost:8080/custom/ingest"),
+                Arguments.of(
+                        "no scheme defaults to http and appends path",
+                        "localhost:8080",
+                        "http://localhost:8080/api/v1/generations:export"),
+                Arguments.of(
+                        "https with no path appends default ingest path",
+                        "https://stack.grafana.net",
+                        "https://stack.grafana.net/api/v1/generations:export"),
+                Arguments.of(
+                        "uppercase scheme normalized to lowercase",
+                        "HTTPS://stack.grafana.net",
+                        "https://stack.grafana.net/api/v1/generations:export"),
+                Arguments.of(
+                        "query string preserved when path appended",
+                        "http://localhost:8080?token=abc",
+                        "http://localhost:8080/api/v1/generations:export?token=abc"),
+                Arguments.of(
+                        "encoded query string preserved when path appended",
+                        "http://localhost:8080?token=a%26b",
+                        "http://localhost:8080/api/v1/generations:export?token=a%26b"),
+                Arguments.of(
+                        "encoded custom path and query preserved",
+                        "http://localhost:8080/custom%2Fingest?token=a%26b#frag%2Fment",
+                        "http://localhost:8080/custom%2Fingest?token=a%26b#frag%2Fment"),
+                Arguments.of(
+                        "fragment preserved when path appended",
+                        "http://localhost:8080#section",
+                        "http://localhost:8080/api/v1/generations:export#section"),
+                Arguments.of(
+                        "encoded fragment preserved when path appended",
+                        "http://localhost:8080#frag%2Fment",
+                        "http://localhost:8080/api/v1/generations:export#frag%2Fment"));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("normalizeCases")
+    void normalizeEndpoint(String name, String input, String want) {
+        assertThat(HttpGenerationExporter.normalizeEndpoint(input)).isEqualTo(want);
+    }
+
+    @Test
+    void emptyInputThrows() {
+        assertThatThrownBy(() -> HttpGenerationExporter.normalizeEndpoint(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("endpoint is required");
+        assertThatThrownBy(() -> HttpGenerationExporter.normalizeEndpoint("   "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("endpoint is required");
+        assertThatThrownBy(() -> HttpGenerationExporter.normalizeEndpoint(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("endpoint is required");
+    }
+}

--- a/java/core/src/test/java/com/grafana/sigil/sdk/SigilEnvConfigTest.java
+++ b/java/core/src/test/java/com/grafana/sigil/sdk/SigilEnvConfigTest.java
@@ -30,7 +30,7 @@ class SigilEnvConfigTest {
         assertThat(cfg.getDebug()).isNull();
         assertThat(cfg.getGenerationExport().getInsecure()).isNull();
         assertThat(cfg.getGenerationExport().getEndpoint())
-                .isEqualTo("http://localhost:8080/api/v1/generations:export");
+                .isEqualTo("http://localhost:8080");
         assertThat(result.warnings()).isEmpty();
     }
 

--- a/js/README.md
+++ b/js/README.md
@@ -30,7 +30,7 @@ import { SigilClient } from "@grafana/sigil-sdk-js";
 const client = new SigilClient({
   generationExport: {
     protocol: "http",
-    endpoint: "http://localhost:8080/api/v1/generations:export",
+    endpoint: "http://localhost:8080",
     auth: { mode: "tenant", tenantId: "dev-tenant" },
   },
   api: {
@@ -326,7 +326,7 @@ If explicit headers already contain `Authorization` or `X-Scope-OrgID`, explicit
 const client = new SigilClient({
   generationExport: {
     protocol: "http",
-    endpoint: "http://localhost:8080/api/v1/generations:export",
+    endpoint: "http://localhost:8080",
     auth: { mode: "tenant", tenantId: "prod-tenant" },
   },
   api: {
@@ -337,13 +337,13 @@ const client = new SigilClient({
 
 ### Grafana Cloud auth (basic)
 
-For Grafana Cloud, use `basic` auth mode. The username is your Grafana Cloud instance/tenant ID and the password is your Grafana Cloud API key:
+For Grafana Cloud, use `basic` auth mode. The username is your Grafana Cloud instance/tenant ID and the password is your Grafana Cloud API key. See the [Grafana Cloud AI Observability getting started docs](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/) for full setup steps; for this SDK endpoint, copy the **API URL** from **Observability → AI Observability → Configuration**. It looks like `https://sigil-prod-<region>.grafana.net`.
 
 ```ts
 const client = new SigilClient({
   generationExport: {
     protocol: "http",
-    endpoint: "https://<your-stack>.grafana.net/api/v1/generations:export",
+    endpoint: "https://sigil-prod-<region>.grafana.net",
     auth: {
       mode: "basic",
       tenantId: process.env.GRAFANA_CLOUD_INSTANCE_ID,
@@ -374,7 +374,7 @@ const generationBearerToken = (process.env.SIGIL_GEN_BEARER_TOKEN ?? "").trim();
 const client = new SigilClient({
   generationExport: {
     protocol: "http",
-    endpoint: "http://localhost:8080/api/v1/generations:export",
+    endpoint: "http://localhost:8080",
     auth:
       generationBearerToken.length > 0
         ? { mode: "bearer", bearerToken: generationBearerToken }

--- a/js/proto/sigil/v1/generation_ingest.proto
+++ b/js/proto/sigil/v1/generation_ingest.proto
@@ -31,6 +31,7 @@ enum GenerationMode {
   GENERATION_MODE_STREAM = 2;
 }
 
+
 message ModelRef {
   string provider = 1;
   string name = 2;
@@ -143,5 +144,48 @@ message Generation {
   optional string tool_choice = 27;
   optional bool thinking_enabled = 28;
   repeated string parent_generation_ids = 29;
+  // Optional SDK-supplied catalog key. Must match `^sha256:[0-9a-f]{64}$`
+  // when set; ingest rejects any other shape. Sigil falls back to a
+  // server-computed sha256 of (system_prompt + sorted tools) when omitted.
   optional string effective_version = 30;
+}
+
+// --- Workflow Step ingest (separate schema from Generation) ---
+
+service WorkflowStepIngestService {
+  rpc ExportWorkflowSteps(ExportWorkflowStepsRequest) returns (ExportWorkflowStepsResponse);
+}
+
+message ExportWorkflowStepsRequest {
+  repeated WorkflowStep workflow_steps = 1;
+}
+
+message ExportWorkflowStepsResponse {
+  repeated ExportWorkflowStepResult results = 1;
+}
+
+message ExportWorkflowStepResult {
+  string step_id = 1;
+  bool accepted = 2;
+  string error = 3;
+}
+
+message WorkflowStep {
+  string id = 1;
+  string conversation_id = 2;
+  string step_name = 3;
+  string framework = 4;
+  google.protobuf.Timestamp started_at = 5;
+  google.protobuf.Timestamp completed_at = 6;
+  google.protobuf.Struct input_state = 7;
+  google.protobuf.Struct output_state = 8;
+  string error = 9;
+  map<string, string> tags = 10;
+  repeated string linked_generation_ids = 11;
+  repeated string parent_step_ids = 12;
+  string agent_name = 13;
+  string agent_version = 14;
+  string trace_id = 15;
+  string span_id = 16;
+  google.protobuf.Struct metadata = 17;
 }

--- a/js/src/config.ts
+++ b/js/src/config.ts
@@ -21,7 +21,7 @@ const defaultExportAuthConfig: ExportAuthConfig = {
 
 export const defaultGenerationExportConfig: GenerationExportConfig = {
   protocol: 'http',
-  endpoint: 'http://localhost:8080/api/v1/generations:export',
+  endpoint: 'http://localhost:8080',
   auth: defaultExportAuthConfig,
   insecure: false,
   batchSize: 100,

--- a/js/src/exporters/http.ts
+++ b/js/src/exporters/http.ts
@@ -72,16 +72,30 @@ function parseExportGenerationsResponse(
   return { results };
 }
 
-function normalizeHTTPGenerationEndpoint(endpoint: string): string {
+const HTTP_GENERATION_EXPORT_PATH = '/api/v1/generations:export';
+
+/** @internal Exported for tests; not part of the public API. */
+export function normalizeHTTPGenerationEndpoint(endpoint: string): string {
   const trimmed = endpoint.trim();
   if (trimmed.length === 0) {
     throw new Error('generation export endpoint is required');
   }
 
-  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
-    return trimmed;
+  const lowerPrefix = trimmed.slice(0, 8).toLowerCase();
+  const hasScheme = lowerPrefix.startsWith('http://') || lowerPrefix.startsWith('https://');
+  const withScheme = hasScheme ? trimmed : `http://${trimmed}`;
+
+  let url: URL;
+  try {
+    url = new URL(withScheme);
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : String(e);
+    throw new Error(`parse generation export endpoint "${endpoint}": ${detail}`);
   }
-  return `http://${trimmed}`;
+  if (url.pathname === '' || url.pathname === '/') {
+    url.pathname = HTTP_GENERATION_EXPORT_PATH;
+  }
+  return url.toString();
 }
 
 function mapGenerationToProtoJSON(generation: Generation): Record<string, unknown> {

--- a/js/test/exporter.http.test.mjs
+++ b/js/test/exporter.http.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { normalizeHTTPGenerationEndpoint } from '../.test-dist/exporters/http.js';
+
+const cases = [
+  {
+    name: 'missing path appends default ingest path',
+    input: 'http://localhost:8080',
+    want: 'http://localhost:8080/api/v1/generations:export',
+  },
+  {
+    name: 'trailing slash treated as missing path',
+    input: 'http://localhost:8080/',
+    want: 'http://localhost:8080/api/v1/generations:export',
+  },
+  {
+    name: 'explicit ingest path is preserved',
+    input: 'http://localhost:8080/api/v1/generations:export',
+    want: 'http://localhost:8080/api/v1/generations:export',
+  },
+  {
+    name: 'custom path is preserved',
+    input: 'http://localhost:8080/custom/ingest',
+    want: 'http://localhost:8080/custom/ingest',
+  },
+  {
+    name: 'no scheme defaults to http and appends path',
+    input: 'localhost:8080',
+    want: 'http://localhost:8080/api/v1/generations:export',
+  },
+  {
+    name: 'https with no path appends default ingest path',
+    input: 'https://stack.grafana.net',
+    want: 'https://stack.grafana.net/api/v1/generations:export',
+  },
+  {
+    name: 'uppercase scheme normalized to lowercase',
+    input: 'HTTPS://stack.grafana.net',
+    want: 'https://stack.grafana.net/api/v1/generations:export',
+  },
+  {
+    name: 'query string preserved when path appended',
+    input: 'http://localhost:8080?token=abc',
+    want: 'http://localhost:8080/api/v1/generations:export?token=abc',
+  },
+];
+
+for (const tc of cases) {
+  test(`normalizeHTTPGenerationEndpoint: ${tc.name}`, () => {
+    assert.equal(normalizeHTTPGenerationEndpoint(tc.input), tc.want);
+  });
+}
+
+test('normalizeHTTPGenerationEndpoint: empty input throws', () => {
+  assert.throws(() => normalizeHTTPGenerationEndpoint(''), /endpoint is required/);
+  assert.throws(() => normalizeHTTPGenerationEndpoint('   '), /endpoint is required/);
+});

--- a/python/README.md
+++ b/python/README.md
@@ -137,6 +137,7 @@ Full framework examples:
 from sigil_sdk import (
     Client,
     ClientConfig,
+    GenerationExportConfig,
     GenerationStart,
     ModelRef,
     assistant_text_message,
@@ -145,7 +146,10 @@ from sigil_sdk import (
 
 client = Client(
     ClientConfig(
-        generation_export_endpoint="http://localhost:8080/api/v1/generations:export",
+        generation_export=GenerationExportConfig(
+            protocol="http",
+            endpoint="http://localhost:8080",
+        ),
     )
 )
 
@@ -420,7 +424,7 @@ from sigil_sdk import ApiConfig, AuthConfig, ClientConfig, GenerationExportConfi
 cfg = ClientConfig(
     generation_export=GenerationExportConfig(
         protocol="http",
-        endpoint="http://localhost:8080/api/v1/generations:export",
+        endpoint="http://localhost:8080",
         auth=AuthConfig(mode="tenant", tenant_id="dev-tenant"),
     ),
     api=ApiConfig(endpoint="http://localhost:8080"),
@@ -460,7 +464,7 @@ from sigil_sdk import ApiConfig, AuthConfig, ClientConfig, GenerationExportConfi
 cfg = ClientConfig(
     generation_export=GenerationExportConfig(
         protocol="http",
-        endpoint="http://localhost:8080/api/v1/generations:export",
+        endpoint="http://localhost:8080",
         auth=AuthConfig(mode="tenant", tenant_id="prod-tenant"),
     ),
     api=ApiConfig(endpoint="http://localhost:8080"),
@@ -469,7 +473,7 @@ cfg = ClientConfig(
 
 ### Grafana Cloud auth (basic)
 
-For Grafana Cloud, use `basic` auth mode. The username is your Grafana Cloud instance/tenant ID and the password is your Grafana Cloud API key:
+For Grafana Cloud, use `basic` auth mode. The username is your Grafana Cloud instance/tenant ID and the password is your Grafana Cloud API key. See the [Grafana Cloud AI Observability getting started docs](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/) for full setup steps; for this SDK endpoint, copy the **API URL** from **Observability → AI Observability → Configuration**. It looks like `https://sigil-prod-<region>.grafana.net`.
 
 ```python
 import os
@@ -478,7 +482,7 @@ from sigil_sdk import AuthConfig, ClientConfig, GenerationExportConfig
 cfg = ClientConfig(
     generation_export=GenerationExportConfig(
         protocol="http",
-        endpoint="https://<your-stack>.grafana.net/api/v1/generations:export",
+        endpoint="https://sigil-prod-<region>.grafana.net",
         auth=AuthConfig(
             mode="basic",
             tenant_id=os.environ["GRAFANA_CLOUD_INSTANCE_ID"],

--- a/python/sigil_sdk/exporters/http.py
+++ b/python/sigil_sdk/exporters/http.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from urllib import request as urllib_request
+from urllib.parse import urlparse, urlunparse
 
 from ..models import (
     ExportGenerationResult,
@@ -116,11 +117,24 @@ def _normalize_endpoint(endpoint: str, path: str = _EXPORT_PATH) -> str:
     trimmed = endpoint.strip()
     if not trimmed:
         raise ValueError("endpoint is required")
-    if not (trimmed.startswith("http://") or trimmed.startswith("https://")):
-        trimmed = f"http://{trimmed}"
-    base = trimmed.rstrip("/")
-    if base.endswith(_EXPORT_PATH):
-        base = base[: -len(_EXPORT_PATH)]
-    if base.endswith(_WF_EXPORT_PATH):
-        base = base[: -len(_WF_EXPORT_PATH)]
-    return base + path
+
+    lower = trimmed.lower()
+    if lower.startswith("http://") or lower.startswith("https://"):
+        normalized = trimmed
+    else:
+        normalized = f"http://{trimmed}"
+
+    parsed = urlparse(normalized)
+    if not parsed.netloc:
+        raise ValueError("endpoint host is required")
+
+    current_path = parsed.path
+    if not current_path or current_path == "/":
+        return urlunparse(parsed._replace(path=path))
+
+    # A client configured with the canonical generation endpoint should still
+    # export workflow steps to the sibling workflow-step endpoint.
+    if path == _WF_EXPORT_PATH and current_path.rstrip("/") == _EXPORT_PATH:
+        return urlunparse(parsed._replace(path=_WF_EXPORT_PATH))
+
+    return urlunparse(parsed)

--- a/python/tests/test_transport.py
+++ b/python/tests/test_transport.py
@@ -65,8 +65,12 @@ from sigil_sdk.exporters.http import _normalize_endpoint
         ("http://host:8080", "http://host:8080/api/v1/generations:export"),
         ("http://host:8080/", "http://host:8080/api/v1/generations:export"),
         ("https://host:443", "https://host:443/api/v1/generations:export"),
+        ("HTTPS://host:443", "https://host:443/api/v1/generations:export"),
         ("host:8080", "http://host:8080/api/v1/generations:export"),
         ("host:8080/api/v1/generations:export", "http://host:8080/api/v1/generations:export"),
+        ("http://host:8080/custom/ingest", "http://host:8080/custom/ingest"),
+        ("http://host:8080?token=abc", "http://host:8080/api/v1/generations:export?token=abc"),
+        ("http://host:8080/custom/ingest?token=abc", "http://host:8080/custom/ingest?token=abc"),
     ],
 )
 def test_normalize_endpoint(raw: str, expected: str) -> None:

--- a/python/tests/test_workflow_steps.py
+++ b/python/tests/test_workflow_steps.py
@@ -116,13 +116,16 @@ def test_normalize_endpoint_appends_workflow_steps_path() -> None:
         _normalize_endpoint("http://host:8080", "/api/v1/workflow-steps:export")
         == "http://host:8080/api/v1/workflow-steps:export"
     )
-    # base may already carry the generation path; we strip and re-append correctly
     assert (
         _normalize_endpoint(
             "http://host:8080/api/v1/generations:export",
             "/api/v1/workflow-steps:export",
         )
         == "http://host:8080/api/v1/workflow-steps:export"
+    )
+    assert (
+        _normalize_endpoint("http://host:8080/custom/ingest", "/api/v1/workflow-steps:export")
+        == "http://host:8080/custom/ingest"
     )
 
 


### PR DESCRIPTION
The HTTP exporters in Go, JS, and Java didn't normalize the endpoint URL, so users passing a base URL like http://localhost:8080 would silently POST to the host root and get rejected. Python and .NET already handled this case. Aligning Go/JS/Java means all five SDKs accept either form.

With the path now optional, defaults shrink from
http://localhost:8080/api/v1/generations:export to http://localhost:8080 across every SDK. Explicit paths (custom or matching the canonical one) are preserved unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP exporter URL normalization and default `generationExport.endpoint` values across Go/JS/Java, which could affect existing configs that relied on posting to a custom root/path. Risk is moderated by preserving explicit paths and adding expanded unit coverage.
> 
> **Overview**
> Makes HTTP generation export endpoints accept a base URL by **auto-appending** `'/api/v1/generations:export'` when no path is provided (Go `newHTTPGenerationExporter`, JS `normalizeHTTPGenerationEndpoint`, Java `HttpGenerationExporter.normalizeEndpoint`).
> 
> Updates cross-SDK defaults/docs/examples to use the shorter base endpoint (e.g. `http://localhost:8080` / `https://sigil-prod-<region>.grafana.net`) and adds new tests to lock in normalization behavior (path appending, trailing slashes, scheme case, query/fragment preservation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dd89be6f0daa8df16872fb9a2b62c293d20a73a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->