### PR TITLE
docs: align SDK READMEs and examples to SIGIL_* env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Instrument once with a thin OpenTelemetry-native SDK, then use it to see what yo
 
 ## Quick Examples
 
+The snippets below configure the SDK explicitly. As an alternative, set `SIGIL_*` environment variables and construct the client with no config — refer to the [Grafana Cloud setup guide](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/) for the variable names.
+
 ### TypeScript
 
 ```ts

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -30,7 +30,11 @@ dotnet add package Grafana.Sigil.OpenAI
 # or: Grafana.Sigil.Anthropic / Grafana.Sigil.Gemini
 ```
 
+For a Grafana Cloud setup walkthrough (where to find the endpoint URL, instance ID, and API token), refer to the [Grafana Cloud setup guide](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/).
+
 ## Quickstart (OpenAI Responses wrapper)
+
+The snippet below configures the SDK explicitly. As an alternative, set `SIGIL_*` environment variables and call `new SigilClient()` with no arguments — refer to the [environment variables](#environment-variables) section.
 
 ```csharp
 using Grafana.Sigil;
@@ -41,8 +45,8 @@ var sigil = new SigilClient(new SigilClientConfig
 {
     GenerationExport = new GenerationExportConfig
     {
-        Protocol = GenerationExportProtocol.Grpc,
-        Endpoint = "localhost:4317",
+        Protocol = GenerationExportProtocol.Http,
+        Endpoint = "http://localhost:8080",
         Auth = new AuthConfig
         {
             Mode = ExportAuthMode.Tenant,
@@ -256,8 +260,8 @@ The SDK emits these OTel histograms through your configured OTel meter provider:
 
 ## Environment variables
 
-The SDK reads canonical `SIGIL_*` env vars at client construction. Caller-supplied
-fields on `SigilClientConfig` win; env vars fill anything left at the default;
+The SDK reads `SIGIL_*` environment variables at client construction. Caller-supplied
+fields on `SigilClientConfig` win; environment variables fill anything left at the default;
 SDK schema defaults fill the rest.
 
 | Env var | Field |

--- a/dotnet/src/Grafana.Sigil.Anthropic/README.md
+++ b/dotnet/src/Grafana.Sigil.Anthropic/README.md
@@ -27,7 +27,7 @@ var sigilConfig = new SigilClientConfig
     GenerationExport = new GenerationExportConfig
     {
         Protocol = GenerationExportProtocol.Http,
-        Endpoint = "http://localhost:8080/api/v1/generations:export",
+        Endpoint = "http://localhost:8080",
         Auth = new AuthConfig
         {
             Mode = ExportAuthMode.Tenant,

--- a/dotnet/src/Grafana.Sigil.Gemini/README.md
+++ b/dotnet/src/Grafana.Sigil.Gemini/README.md
@@ -33,7 +33,7 @@ var sigilConfig = new SigilClientConfig
     GenerationExport = new GenerationExportConfig
     {
         Protocol = GenerationExportProtocol.Http,
-        Endpoint = "http://localhost:8080/api/v1/generations:export",
+        Endpoint = "http://localhost:8080",
         Auth = new AuthConfig
         {
             Mode = ExportAuthMode.Tenant,

--- a/dotnet/src/Grafana.Sigil.OpenAI/README.md
+++ b/dotnet/src/Grafana.Sigil.OpenAI/README.md
@@ -45,7 +45,7 @@ var sigilConfig = new SigilClientConfig
     GenerationExport = new GenerationExportConfig
     {
         Protocol = GenerationExportProtocol.Http,
-        Endpoint = "http://localhost:8080/api/v1/generations:export",
+        Endpoint = "http://localhost:8080",
         Auth = new AuthConfig
         {
             Mode = ExportAuthMode.Tenant,

--- a/dotnet/src/Grafana.Sigil/README.md
+++ b/dotnet/src/Grafana.Sigil/README.md
@@ -260,7 +260,7 @@ Per export path, supported auth modes are:
 - `ExportAuthMode.None`
 - `ExportAuthMode.Tenant` (`X-Scope-OrgID`)
 - `ExportAuthMode.Bearer` (`Authorization: Bearer <token>`)
-- `ExportAuthMode.Basic` (requires `BasicPassword` + `BasicUser` or `TenantId`, injects `Authorization: Basic <base64(user:password)>`; also injects `X-Scope-OrgID` when `TenantId` is set — for self-hosted multi-tenancy only, not needed for Grafana Cloud)
+- `ExportAuthMode.Basic` (requires `BasicPassword` + `BasicUser` or `TenantId`, injects `Authorization: Basic <base64(user:password)>`; also injects `X-Scope-OrgID` when `TenantId` is set — for multi-tenant deployments only, not needed for Grafana Cloud)
 
 Explicit transport headers take precedence over auth-derived headers (`Authorization`, `X-Scope-OrgID`, case-insensitive).
 
@@ -272,8 +272,8 @@ For Grafana Cloud, use `Basic` auth mode. The username is your Grafana Cloud ins
 Auth = new AuthConfig
 {
     Mode = ExportAuthMode.Basic,
-    TenantId = Environment.GetEnvironmentVariable("GRAFANA_CLOUD_INSTANCE_ID") ?? "",
-    BasicPassword = Environment.GetEnvironmentVariable("GRAFANA_CLOUD_API_KEY") ?? "",
+    TenantId = Environment.GetEnvironmentVariable("SIGIL_AUTH_TENANT_ID") ?? "",
+    BasicPassword = Environment.GetEnvironmentVariable("SIGIL_AUTH_TOKEN") ?? "",
 },
 ```
 
@@ -283,9 +283,9 @@ If your deployment requires a distinct username, set `BasicUser` explicitly:
 Auth = new AuthConfig
 {
     Mode = ExportAuthMode.Basic,
-    TenantId = Environment.GetEnvironmentVariable("GRAFANA_CLOUD_INSTANCE_ID") ?? "",
-    BasicUser = Environment.GetEnvironmentVariable("GRAFANA_CLOUD_INSTANCE_ID") ?? "",
-    BasicPassword = Environment.GetEnvironmentVariable("GRAFANA_CLOUD_API_KEY") ?? "",
+    TenantId = Environment.GetEnvironmentVariable("SIGIL_AUTH_TENANT_ID") ?? "",
+    BasicUser = Environment.GetEnvironmentVariable("SIGIL_AUTH_TENANT_ID") ?? "",
+    BasicPassword = Environment.GetEnvironmentVariable("SIGIL_AUTH_TOKEN") ?? "",
 },
 ```
 

--- a/examples/getting-started/go/.env.example
+++ b/examples/getting-started/go/.env.example
@@ -7,21 +7,23 @@ OPENAI_API_KEY=
 # https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/
 # Copy the API URL from Observability → AI Observability → Configuration.
 SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
+SIGIL_PROTOCOL=http
+SIGIL_AUTH_MODE=basic
 
 # Your Grafana Cloud stack / instance ID (numeric).
 # Shown under Instance ID in AI Observability → Configuration or in the Cloud Portal stack details.
-GRAFANA_INSTANCE_ID=
+SIGIL_AUTH_TENANT_ID=
 
 # A Grafana Cloud access policy token with sigil:write.
 # Create one in Security → Access Policies as described in the docs above.
-GRAFANA_CLOUD_TOKEN=
+SIGIL_AUTH_TOKEN=
 
 # --- OTel traces + metrics ---
 # Option A — Direct to Grafana Cloud OTLP gateway:
 #   Find the endpoint in your Cloud portal → stack Details → OpenTelemetry.
-#   The header is: Authorization=Basic <base64(instance_id:cloud_api_token)>
+#   The header is: Authorization=Basic <base64(otlp_instance_id:cloud_api_token)>
 OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
-OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instance_id:cloud_api_token)>
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp_instance_id:cloud_api_token)>
 
 # Option B — Via local Alloy / OTel Collector (no auth needed):
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318

--- a/examples/getting-started/go/main.go
+++ b/examples/getting-started/go/main.go
@@ -54,8 +54,8 @@ func main() {
 	cfg.GenerationExport.Endpoint = os.Getenv("SIGIL_ENDPOINT")
 	cfg.GenerationExport.Auth = sigil.AuthConfig{
 		Mode:          sigil.ExportAuthModeBasic,
-		TenantID:      os.Getenv("GRAFANA_INSTANCE_ID"),
-		BasicPassword: os.Getenv("GRAFANA_CLOUD_TOKEN"),
+		TenantID:      os.Getenv("SIGIL_AUTH_TENANT_ID"),
+		BasicPassword: os.Getenv("SIGIL_AUTH_TOKEN"),
 	}
 	sigilClient := sigil.NewClient(cfg)
 	defer func() { _ = sigilClient.Shutdown(ctx) }()

--- a/examples/getting-started/python-pydantic-ai/.env.example
+++ b/examples/getting-started/python-pydantic-ai/.env.example
@@ -6,18 +6,18 @@ ANTHROPIC_API_KEY=sk-ant-...
 # Copy the API URL from Observability → AI Observability → Configuration.
 SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
 
-# Stack / instance ID. Used as the basic-auth user and the X-Scope-OrgID tenant.
-GRAFANA_INSTANCE_ID=
+# Numeric instance ID. Used as the basic-auth user and X-Scope-OrgID tenant.
+SIGIL_AUTH_TENANT_ID=
 
-# Grafana Cloud access policy token (basic-auth password).
-GRAFANA_CLOUD_TOKEN=
+# Cloud Access Policy Token (`glc_…`) with `sigil:write` scope (basic-auth password).
+SIGIL_AUTH_TOKEN=
 
 # --- OTel traces + metrics exporter ---
 # The Sigil SDK emits OTel spans and metrics.
-# Option A — Direct to Cloud (URL + token from Cloud portal -> stack -> OpenTelemetry):
+# Option A — Direct to Cloud (URL + OTLP instance ID from Cloud portal -> stack -> OpenTelemetry):
 #   OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
-#   OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64 of GRAFANA_INSTANCE_ID:GRAFANA_CLOUD_TOKEN>
-#   # e.g.  echo -n "$GRAFANA_INSTANCE_ID:$GRAFANA_CLOUD_TOKEN" | base64
+#   OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64 of OTLP_INSTANCE_ID:SIGIL_AUTH_TOKEN>
+#   # for example: printf '%s' "$OTLP_INSTANCE_ID:$SIGIL_AUTH_TOKEN" | base64 | tr -d '\n'
 # Option B — Via local Alloy/collector:
 #   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 OTEL_EXPORTER_OTLP_ENDPOINT=

--- a/examples/getting-started/python-pydantic-ai/README.md
+++ b/examples/getting-started/python-pydantic-ai/README.md
@@ -6,8 +6,10 @@ Runs a Pydantic AI agent and records the generation to Grafana Cloud AI Observab
 
 ```bash
 cd examples/getting-started/python-pydantic-ai
-# Set ANTHROPIC_API_KEY, GRAFANA_INSTANCE_ID, GRAFANA_CLOUD_TOKEN, SIGIL_ENDPOINT
-# See the SDK README or Grafana Cloud AI Observability getting started docs for where to find each value.
+cp .env.example .env
+# Fill in ANTHROPIC_API_KEY, SIGIL_ENDPOINT, SIGIL_AUTH_TENANT_ID, SIGIL_AUTH_TOKEN.
+# See the Grafana Cloud AI Observability getting started docs for where to find each value:
+# https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/
 ```
 
 ```bash
@@ -20,4 +22,4 @@ pip install -r requirements.txt
 python main.py
 ```
 
-You should see the LLM response printed, followed by `Done`. Open the AI Observability plugin in your Grafana Cloud stack to see the recorded generation, and check your Grafana Cloud Traces and Metrics datasources for SDK-emitted spans and metrics.
+When the LLM response prints, followed by `Done`, open the AI Observability plugin in your Grafana Cloud stack to view the recorded generation, then check your Grafana Cloud Traces and Metrics datasources for SDK-emitted spans and metrics.

--- a/examples/getting-started/python-pydantic-ai/main.py
+++ b/examples/getting-started/python-pydantic-ai/main.py
@@ -54,8 +54,8 @@ sigil = Client(
             endpoint=os.environ["SIGIL_ENDPOINT"],
             auth=AuthConfig(
                 mode="basic",
-                tenant_id=os.environ["GRAFANA_INSTANCE_ID"],
-                basic_password=os.environ["GRAFANA_CLOUD_TOKEN"],
+                tenant_id=os.environ["SIGIL_AUTH_TENANT_ID"],
+                basic_password=os.environ["SIGIL_AUTH_TOKEN"],
             ),
         ),
     )

--- a/examples/getting-started/python-strands/.env.example
+++ b/examples/getting-started/python-strands/.env.example
@@ -1,20 +1,21 @@
 # Sigil API URL. See the Grafana Cloud AI Observability getting started docs:
 # https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/
 # Copy the API URL from Observability → AI Observability → Configuration.
-SIGIL_EXPORT_PROTOCOL=http
+SIGIL_PROTOCOL=http
+SIGIL_AUTH_MODE=basic
 SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
 SIGIL_CONVERSATION_ID=sigil-strands-demo
 
-# Stack / instance ID. Used as the basic-auth user and the X-Scope-OrgID tenant.
-GRAFANA_INSTANCE_ID=
+# Numeric instance ID. Used as the basic-auth user and X-Scope-OrgID tenant.
+SIGIL_AUTH_TENANT_ID=
 
-# Grafana Cloud access policy token (basic-auth password).
-GRAFANA_CLOUD_TOKEN=
+# Cloud Access Policy Token (`glc_…`) with `sigil:write` scope (basic-auth password).
+SIGIL_AUTH_TOKEN=
 
-# OTel metrics export. Use the URL and token from Cloud portal -> stack -> OpenTelemetry.
+# OTel metrics export. Use the URL and OTLP instance ID from Cloud portal -> stack -> OpenTelemetry.
 OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
 OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=
-OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64 of GRAFANA_INSTANCE_ID:GRAFANA_CLOUD_TOKEN>
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64 of OTLP_INSTANCE_ID:SIGIL_AUTH_TOKEN>
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 OTEL_METRIC_EXPORT_INTERVAL_MILLIS=1000
 OTEL_SERVICE_NAME=sigil-strands-example

--- a/examples/getting-started/python-strands/README.md
+++ b/examples/getting-started/python-strands/README.md
@@ -12,17 +12,18 @@ pip install -r requirements.txt
 cp .env.example .env
 ```
 
-Configure Sigil and OTel endpoints from your Grafana Cloud stack. See the [Grafana Cloud AI Observability getting started docs](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/) for where to find the Sigil API URL:
+Configure Sigil and OTel endpoints from your Grafana Cloud stack. See the [Grafana Cloud AI Observability getting started docs](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/) for where to find each value:
 
 ```bash
-SIGIL_EXPORT_PROTOCOL=http
+SIGIL_PROTOCOL=http
+SIGIL_AUTH_MODE=basic
 SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
-GRAFANA_INSTANCE_ID=...
-GRAFANA_CLOUD_TOKEN=...
+SIGIL_AUTH_TENANT_ID=...
+SIGIL_AUTH_TOKEN=...
 SIGIL_CONVERSATION_ID=sigil-strands-demo
 OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
 OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=
-OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64 of GRAFANA_INSTANCE_ID:GRAFANA_CLOUD_TOKEN>"
+OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64 of OTLP_INSTANCE_ID:SIGIL_AUTH_TOKEN>"
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 OTEL_METRIC_EXPORT_INTERVAL_MILLIS=1000
 OTEL_SERVICE_NAME=sigil-strands-example
@@ -44,4 +45,4 @@ Strands itself defaults to Amazon Bedrock when no model is provided. This exampl
 python main.py
 ```
 
-You should see the agent response printed, followed by `Done`. Open Sigil in your Grafana Cloud stack to inspect the recorded generation.
+When the agent response prints, followed by `Done`, open Sigil in your Grafana Cloud stack to inspect the recorded generation.

--- a/examples/getting-started/python-strands/main.py
+++ b/examples/getting-started/python-strands/main.py
@@ -81,17 +81,17 @@ def create_model():
 
 
 meter_provider = setup_metrics()
-grafana_instance_id = required_env("GRAFANA_INSTANCE_ID")
+tenant_id = required_env("SIGIL_AUTH_TENANT_ID")
 sigil = Client(
     ClientConfig(
         generation_export=GenerationExportConfig(
-            protocol=os.getenv("SIGIL_EXPORT_PROTOCOL", "http"),
+            protocol=os.getenv("SIGIL_PROTOCOL", "http"),
             endpoint=required_env("SIGIL_ENDPOINT"),
             auth=AuthConfig(
                 mode="basic",
-                tenant_id=grafana_instance_id,
-                basic_user=grafana_instance_id,
-                basic_password=required_env("GRAFANA_CLOUD_TOKEN"),
+                tenant_id=tenant_id,
+                basic_user=tenant_id,
+                basic_password=required_env("SIGIL_AUTH_TOKEN"),
             ),
         ),
         meter=meter_provider.get_meter("sigil-strands-example"),

--- a/examples/getting-started/python/.env.example
+++ b/examples/getting-started/python/.env.example
@@ -7,21 +7,23 @@ OPENAI_API_KEY=
 # https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/
 # Copy the API URL from Observability → AI Observability → Configuration.
 SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
+SIGIL_PROTOCOL=http
+SIGIL_AUTH_MODE=basic
 
 # Your Grafana Cloud stack / instance ID (numeric).
 # Shown under Instance ID in AI Observability → Configuration or in the Cloud Portal stack details.
-GRAFANA_INSTANCE_ID=
+SIGIL_AUTH_TENANT_ID=
 
 # A Grafana Cloud access policy token with sigil:write.
 # Create one in Security → Access Policies as described in the docs above.
-GRAFANA_CLOUD_TOKEN=
+SIGIL_AUTH_TOKEN=
 
 # --- OTel traces + metrics ---
 # Option A — Direct to Grafana Cloud OTLP gateway:
 #   Find the endpoint in your Cloud portal → stack Details → OpenTelemetry.
-#   The header is: Authorization=Basic <base64(instance_id:cloud_api_token)>
+#   The header is: Authorization=Basic <base64(otlp_instance_id:cloud_api_token)>
 OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
-OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instance_id:cloud_api_token)>
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp_instance_id:cloud_api_token)>
 
 # Option B — Via local Alloy / OTel Collector (no auth needed):
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318

--- a/examples/getting-started/python/main.py
+++ b/examples/getting-started/python/main.py
@@ -48,8 +48,8 @@ sigil = Client(
             endpoint=os.environ["SIGIL_ENDPOINT"],
             auth=AuthConfig(
                 mode="basic",
-                tenant_id=os.environ["GRAFANA_INSTANCE_ID"],
-                basic_password=os.environ["GRAFANA_CLOUD_TOKEN"],
+                tenant_id=os.environ["SIGIL_AUTH_TENANT_ID"],
+                basic_password=os.environ["SIGIL_AUTH_TOKEN"],
             ),
         ),
     )

--- a/examples/getting-started/typescript-strands/.env.example
+++ b/examples/getting-started/typescript-strands/.env.example
@@ -1,19 +1,20 @@
 # Sigil API URL. See the Grafana Cloud AI Observability getting started docs:
 # https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/
 # Copy the API URL from Observability → AI Observability → Configuration.
-SIGIL_EXPORT_PROTOCOL=http
+SIGIL_PROTOCOL=http
+SIGIL_AUTH_MODE=basic
 SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
 SIGIL_CONVERSATION_ID=sigil-strands-demo
 
-# Stack / instance ID. Used as the basic-auth user and the X-Scope-OrgID tenant.
-GRAFANA_INSTANCE_ID=
+# Numeric instance ID. Used as the basic-auth user and X-Scope-OrgID tenant.
+SIGIL_AUTH_TENANT_ID=
 
-# Grafana Cloud access policy token (basic-auth password).
-GRAFANA_CLOUD_TOKEN=
+# Cloud Access Policy Token (`glc_…`) with `sigil:write` scope (basic-auth password).
+SIGIL_AUTH_TOKEN=
 
-# OTel traces and metrics export. Use the URL and token from Cloud portal -> stack -> OpenTelemetry.
+# OTel traces and metrics export. Use the URL and OTLP instance ID from Cloud portal -> stack -> OpenTelemetry.
 OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
-OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64 of GRAFANA_INSTANCE_ID:GRAFANA_CLOUD_TOKEN>
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64 of OTLP_INSTANCE_ID:SIGIL_AUTH_TOKEN>
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 OTEL_METRIC_EXPORT_INTERVAL_MILLIS=1000
 OTEL_SERVICE_NAME=sigil-strands-typescript-example

--- a/examples/getting-started/typescript-strands/README.md
+++ b/examples/getting-started/typescript-strands/README.md
@@ -10,16 +10,17 @@ npm install
 cp .env.example .env
 ```
 
-Configure Sigil, OpenTelemetry, and OpenAI from your Grafana Cloud stack. See the [Grafana Cloud AI Observability getting started docs](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/) for where to find the Sigil API URL:
+Configure Sigil, OpenTelemetry, and OpenAI from your Grafana Cloud stack. See the [Grafana Cloud AI Observability getting started docs](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/) for where to find each value:
 
 ```bash
-SIGIL_EXPORT_PROTOCOL=http
+SIGIL_PROTOCOL=http
+SIGIL_AUTH_MODE=basic
 SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
-GRAFANA_INSTANCE_ID=...
-GRAFANA_CLOUD_TOKEN=...
+SIGIL_AUTH_TENANT_ID=...
+SIGIL_AUTH_TOKEN=...
 SIGIL_CONVERSATION_ID=sigil-strands-demo
 OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
-OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64 of GRAFANA_INSTANCE_ID:GRAFANA_CLOUD_TOKEN>"
+OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64 of OTLP_INSTANCE_ID:SIGIL_AUTH_TOKEN>"
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 OTEL_METRIC_EXPORT_INTERVAL_MILLIS=1000
 OTEL_SERVICE_NAME=sigil-strands-typescript-example
@@ -36,4 +37,4 @@ The example configures OpenTelemetry tracing and metrics. Generations go to
 npm start
 ```
 
-You should see the agent response printed, followed by `Done`. Open Sigil in your Grafana Cloud stack to inspect the recorded generation and tool execution.
+When the agent response prints, followed by `Done`, open Sigil in your Grafana Cloud stack to inspect the recorded generation and tool execution.

--- a/examples/getting-started/typescript-strands/main.ts
+++ b/examples/getting-started/typescript-strands/main.ts
@@ -62,16 +62,16 @@ const addNumbers = tool({
   callback: ({ left, right }) => left + right,
 });
 
-const grafanaInstanceId = requiredEnv('GRAFANA_INSTANCE_ID');
+const tenantId = requiredEnv('SIGIL_AUTH_TENANT_ID');
 const sigil = createSigilClient({
   generationExport: {
-    protocol: env('SIGIL_EXPORT_PROTOCOL', 'http') as 'http' | 'grpc' | 'none',
+    protocol: env('SIGIL_PROTOCOL', 'http') as 'http' | 'grpc' | 'none',
     endpoint: requiredEnv('SIGIL_ENDPOINT'),
     auth: {
       mode: 'basic',
-      tenantId: grafanaInstanceId,
-      basicUser: grafanaInstanceId,
-      basicPassword: requiredEnv('GRAFANA_CLOUD_TOKEN'),
+      tenantId,
+      basicUser: tenantId,
+      basicPassword: requiredEnv('SIGIL_AUTH_TOKEN'),
     },
   },
   meter: meterProvider.getMeter('sigil-strands-typescript-example'),

--- a/examples/getting-started/typescript/.env.example
+++ b/examples/getting-started/typescript/.env.example
@@ -7,21 +7,23 @@ OPENAI_API_KEY=
 # https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/
 # Copy the API URL from Observability → AI Observability → Configuration.
 SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
+SIGIL_PROTOCOL=http
+SIGIL_AUTH_MODE=basic
 
 # Your Grafana Cloud stack / instance ID (numeric).
 # Shown under Instance ID in AI Observability → Configuration or in the Cloud Portal stack details.
-GRAFANA_INSTANCE_ID=
+SIGIL_AUTH_TENANT_ID=
 
 # A Grafana Cloud access policy token with sigil:write.
 # Create one in Security → Access Policies as described in the docs above.
-GRAFANA_CLOUD_TOKEN=
+SIGIL_AUTH_TOKEN=
 
 # --- OTel traces + metrics ---
 # Option A — Direct to Grafana Cloud OTLP gateway:
 #   Find the endpoint in your Cloud portal → stack Details → OpenTelemetry.
-#   The header is: Authorization=Basic <base64(instance_id:cloud_api_token)>
+#   The header is: Authorization=Basic <base64(otlp_instance_id:cloud_api_token)>
 OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
-OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instance_id:cloud_api_token)>
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp_instance_id:cloud_api_token)>
 
 # Option B — Via local Alloy / OTel Collector (no auth needed):
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318

--- a/examples/getting-started/typescript/main.ts
+++ b/examples/getting-started/typescript/main.ts
@@ -40,8 +40,8 @@ const sigil = createSigilClient({
     endpoint: process.env.SIGIL_ENDPOINT!,
     auth: {
       mode: "basic",
-      tenantId: process.env.GRAFANA_INSTANCE_ID!,
-      basicPassword: process.env.GRAFANA_CLOUD_TOKEN!,
+      tenantId: process.env.SIGIL_AUTH_TENANT_ID!,
+      basicPassword: process.env.SIGIL_AUTH_TOKEN!,
     },
   },
 });

--- a/examples/python-langchain/.env.example
+++ b/examples/python-langchain/.env.example
@@ -5,17 +5,20 @@ ANTHROPIC_API_KEY=sk-ant-...
 # Endpoint of your Sigil instance. For Grafana Cloud, see:
 # https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/
 # Copy the API URL from Observability → AI Observability → Configuration.
+SIGIL_ENDPOINT=
+
+# REST API base used by helper endpoints, for example ratings.
+# Same host as SIGIL_ENDPOINT for Grafana Cloud.
 SIGIL_API_ENDPOINT=
-SIGIL_GENERATION_EXPORT_ENDPOINT=
 
-# Tenant / instance ID. Sent as X-Scope-OrgID and used as the basic-auth
-# user when SIGIL_AUTH_TOKEN is set. For Grafana Cloud, this is your
-# stack/instance ID.
-SIGIL_TENANT_ID=
+# Numeric instance ID from AI Observability → Configuration.
+# Sent as X-Scope-OrgID and used as the basic-auth user.
+SIGIL_AUTH_TENANT_ID=
 
-# Access token. Required for Grafana Cloud (basic-auth password).
-# Leave unset when pointing at a self-hosted Sigil that doesn't require
-# auth — the client will fall back to tenant-only mode.
+# Cloud Access Policy Token (`glc_…`) with `sigil:write` scope.
+# Required for Grafana Cloud (basic-auth password).
+# Leave unset when pointing at a Sigil that doesn't require auth —
+# the client falls back to tenant-only mode.
 SIGIL_AUTH_TOKEN=
 
 # --- OTel traces + metrics exporter ---

--- a/examples/python-langchain/README.md
+++ b/examples/python-langchain/README.md
@@ -84,15 +84,16 @@ app/
 See `[.env.example](./.env.example)`.
 
 
-| Variable                           | Purpose                                                                                 |
-| ---------------------------------- | --------------------------------------------------------------------------------------- |
-| `ANTHROPIC_API_KEY`                | Required. Used by both the agent and the classifier.                                    |
-| `SIGIL_GENERATION_EXPORT_ENDPOINT` | HTTP generation-ingest URL. Default `http://localhost:8080/api/v1/generations:export`.  |
-| `SIGIL_API_ENDPOINT`               | Sigil REST API base (ratings, etc.). Default `http://localhost:8080`.                   |
-| `SIGIL_TENANT_ID`                  | Sent as `X-Scope-OrgID`. Any value works when `SIGIL_AUTH_ENABLED=false` on the server. |
-| `OTEL_EXPORTER_OTLP_ENDPOINT`      | OTLP gRPC target for traces + metrics. Default `http://localhost:4317`.                 |
-| `OTEL_EXPORTER_OTLP_INSECURE`      | `true` for plaintext gRPC (local dev).                                                  |
-| `OTEL_SERVICE_NAME`                | Service name tag on spans / metrics.                                                    |
-| `AGENT_MODEL` / `CLASSIFIER_MODEL` | Anthropic model IDs.                                                                    |
+| Variable                           | Purpose                                                                                                                               |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `ANTHROPIC_API_KEY`                | Required. Used by both the agent and the classifier.                                                                                  |
+| `SIGIL_ENDPOINT`                   | API URL from AI Observability → Configuration. Default `http://localhost:8080`.                                                       |
+| `SIGIL_API_ENDPOINT`               | Sigil REST API base used by helper endpoints such as ratings. Default `http://localhost:8080`.                                        |
+| `SIGIL_AUTH_TENANT_ID`             | Numeric instance ID. Sent as `X-Scope-OrgID` and used as basic-auth user.                                                             |
+| `SIGIL_AUTH_TOKEN`                 | Cloud Access Policy Token (`glc_…`) with `sigil:write` scope. Required for Cloud.                                                     |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`      | OTLP gRPC target for traces + metrics. Default `http://localhost:4317`.                                                               |
+| `OTEL_EXPORTER_OTLP_INSECURE`      | `true` for plaintext gRPC (local dev).                                                                                                |
+| `OTEL_SERVICE_NAME`                | Service name tag on spans / metrics.                                                                                                  |
+| `AGENT_MODEL` / `CLASSIFIER_MODEL` | Anthropic model IDs.                                                                                                                  |
 
 

--- a/examples/python-langchain/app/sigil_client.py
+++ b/examples/python-langchain/app/sigil_client.py
@@ -27,9 +27,9 @@ def setup_sigil(
     tracer_provider: TracerProvider,
     meter_provider: MeterProvider,
 ) -> Client:
-    endpoint = _required_env("SIGIL_GENERATION_EXPORT_ENDPOINT")
+    endpoint = _required_env("SIGIL_ENDPOINT")
     api_endpoint = _required_env("SIGIL_API_ENDPOINT")
-    tenant_id = _required_env("SIGIL_TENANT_ID")
+    tenant_id = _required_env("SIGIL_AUTH_TENANT_ID")
     auth_token = os.getenv("SIGIL_AUTH_TOKEN", "").strip()
 
     if auth_token:

--- a/go/README.md
+++ b/go/README.md
@@ -68,6 +68,15 @@ Framework modules:
 
 ## Configuration
 
+The snippet below configures the SDK explicitly. As an alternative, set `SIGIL_*` environment variables and pass an empty `sigil.Config{}` — refer to the [Grafana Cloud setup guide](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/) for the variable names.
+
+```go
+client := sigil.NewClient(sigil.Config{})
+defer func() { _ = client.Shutdown(context.Background()) }()
+```
+
+For explicit configuration with custom auth or batch tuning:
+
 ```go
 cfg := sigil.DefaultConfig()
 
@@ -78,7 +87,7 @@ cfg := sigil.DefaultConfig()
 
 // Generation export (custom ingest)
 cfg.GenerationExport.Protocol = sigil.GenerationExportProtocolGRPC // default; or sigil.GenerationExportProtocolHTTP / sigil.GenerationExportProtocolNone
-cfg.GenerationExport.Endpoint = "localhost:4317"                  // HTTP parity: "http://localhost:8080" (SDK auto-appends /api/v1/generations:export)
+cfg.GenerationExport.Endpoint = "localhost:4317" // HTTP parity: "http://localhost:8080" (SDK auto-appends /api/v1/generations:export)
 cfg.GenerationExport.Auth = sigil.AuthConfig{
 	Mode:     sigil.ExportAuthModeTenant,
 	TenantID: "dev-tenant",
@@ -133,7 +142,7 @@ Auth is configured for generation export.
 - `none`
 - `tenant` (requires `TenantID`, injects `X-Scope-OrgID`)
 - `bearer` (requires `BearerToken`, injects `Authorization: Bearer <token>`)
-- `basic` (requires `BasicPassword` + `BasicUser` or `TenantID`, injects `Authorization: Basic <base64(user:password)>`; also injects `X-Scope-OrgID` when `TenantID` is set — for self-hosted multi-tenancy only, not needed for Grafana Cloud)
+- `basic` (requires `BasicPassword` + `BasicUser` or `TenantID`, injects `Authorization: Basic <base64(user:password)>`; also injects `X-Scope-OrgID` when `TenantID` is set — for multi-tenant deployments only, not needed for Grafana Cloud)
 
 Invalid combinations fail fast during `NewClient(...)`.
 
@@ -153,8 +162,8 @@ For Grafana Cloud, use `basic` auth mode. The username is your Grafana Cloud ins
 ```go
 cfg.GenerationExport.Auth = sigil.AuthConfig{
 	Mode:          sigil.ExportAuthModeBasic,
-	TenantID:      os.Getenv("GRAFANA_CLOUD_INSTANCE_ID"),
-	BasicPassword: os.Getenv("GRAFANA_CLOUD_API_KEY"),
+	TenantID:      os.Getenv("SIGIL_AUTH_TENANT_ID"),
+	BasicPassword: os.Getenv("SIGIL_AUTH_TOKEN"),
 }
 ```
 
@@ -163,9 +172,9 @@ If your deployment requires a distinct username (different from the tenant ID), 
 ```go
 cfg.GenerationExport.Auth = sigil.AuthConfig{
 	Mode:          sigil.ExportAuthModeBasic,
-	TenantID:      os.Getenv("GRAFANA_CLOUD_INSTANCE_ID"),
-	BasicUser:     os.Getenv("GRAFANA_CLOUD_INSTANCE_ID"),
-	BasicPassword: os.Getenv("GRAFANA_CLOUD_API_KEY"),
+	TenantID:      os.Getenv("SIGIL_AUTH_TENANT_ID"),
+	BasicUser:     os.Getenv("SIGIL_AUTH_TENANT_ID"),
+	BasicPassword: os.Getenv("SIGIL_AUTH_TOKEN"),
 }
 ```
 

--- a/java/README.md
+++ b/java/README.md
@@ -9,6 +9,8 @@ The Java SDK records normalized generation payloads, correlates them with traces
 - Java 17+
 - OpenTelemetry SDK already in your app (optional but recommended)
 
+For a Grafana Cloud setup walkthrough (where to find the endpoint URL, instance ID, and API token), refer to the [Grafana Cloud setup guide](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/).
+
 ## Modules
 
 - `:core`: runtime client, models, validation, generation exporters
@@ -47,6 +49,8 @@ The Java SDK records normalized generation payloads, correlates them with traces
 - If caller metadata provides a conflicting value for this key, the SDK overwrites it.
 
 ## Quick Start (sync)
+
+The snippet below configures the SDK explicitly. As an alternative, set `SIGIL_*` environment variables and call `new SigilClient()` with no arguments — refer to the [Grafana Cloud setup guide](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/) for the variable names.
 
 ```java
 SigilClient client = new SigilClient(new SigilClientConfig()
@@ -170,7 +174,7 @@ Auth is configured for generation export:
 - `NONE`
 - `TENANT` (injects `X-Scope-OrgID`)
 - `BEARER` (injects `Authorization: Bearer <token>`)
-- `BASIC` (requires `basicPassword` + `basicUser` or `tenantId`, injects `Authorization: Basic <base64(user:password)>`; also injects `X-Scope-OrgID` when `tenantId` is set — for self-hosted multi-tenancy only, not needed for Grafana Cloud)
+- `BASIC` (requires `basicPassword` + `basicUser` or `tenantId`, injects `Authorization: Basic <base64(user:password)>`; also injects `X-Scope-OrgID` when `tenantId` is set — for multi-tenant deployments only, not needed for Grafana Cloud)
 
 Invalid combinations fail fast at client construction. If explicit headers already contain `Authorization` or `X-Scope-OrgID`, explicit headers win.
 
@@ -181,8 +185,8 @@ For Grafana Cloud, use `BASIC` auth mode. The username is your Grafana Cloud ins
 ```java
 .setAuth(new AuthConfig()
     .setMode(AuthMode.BASIC)
-    .setTenantId(System.getenv("GRAFANA_CLOUD_INSTANCE_ID"))
-    .setBasicPassword(System.getenv("GRAFANA_CLOUD_API_KEY")))
+    .setTenantId(System.getenv("SIGIL_AUTH_TENANT_ID"))
+    .setBasicPassword(System.getenv("SIGIL_AUTH_TOKEN")))
 ```
 
 If your deployment requires a distinct username, set `basicUser` explicitly:
@@ -190,9 +194,9 @@ If your deployment requires a distinct username, set `basicUser` explicitly:
 ```java
 .setAuth(new AuthConfig()
     .setMode(AuthMode.BASIC)
-    .setTenantId(System.getenv("GRAFANA_CLOUD_INSTANCE_ID"))
-    .setBasicUser(System.getenv("GRAFANA_CLOUD_INSTANCE_ID"))
-    .setBasicPassword(System.getenv("GRAFANA_CLOUD_API_KEY")))
+    .setTenantId(System.getenv("SIGIL_AUTH_TENANT_ID"))
+    .setBasicUser(System.getenv("SIGIL_AUTH_TENANT_ID"))
+    .setBasicPassword(System.getenv("SIGIL_AUTH_TOKEN")))
 ```
 
 Generation export transport protocols:
@@ -276,7 +280,7 @@ Framework helpers:
 
 ## Environment variables
 
-The SDK reads canonical `SIGIL_*` env vars at client construction. Caller-supplied
+The SDK reads `SIGIL_*` environment variables at client construction. Caller-supplied
 fields on `SigilClientConfig` win; env vars fill anything left at the default;
 SDK schema defaults fill the rest.
 

--- a/js/README.md
+++ b/js/README.md
@@ -8,6 +8,8 @@ Sigil records normalized LLM generation and tool-execution telemetry using your 
 pnpm add @grafana/sigil-sdk-js
 ```
 
+For a Grafana Cloud setup walkthrough (where to find the endpoint URL, instance ID, and API token), refer to the [Grafana Cloud setup guide](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/).
+
 ## Validation
 
 Run the shared core conformance suite for the JavaScript SDK from the repo root:
@@ -23,6 +25,8 @@ mise run sdk:conformance
 ```
 
 ## Quick Start
+
+The snippet below configures the SDK explicitly. As an alternative, set `SIGIL_*` environment variables and call `new SigilClient()` with no arguments — refer to the [Grafana Cloud setup guide](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/) for the variable names.
 
 ```ts
 import { SigilClient } from "@grafana/sigil-sdk-js";
@@ -316,7 +320,7 @@ Auth is configured for `generationExport`.
 - `mode: "none"`
 - `mode: "tenant"` (requires `tenantId`, injects `X-Scope-OrgID`)
 - `mode: "bearer"` (requires `bearerToken`, injects `Authorization: Bearer <token>`)
-- `mode: "basic"` (requires `basicPassword` + `basicUser` or `tenantId`, injects `Authorization: Basic <base64(user:password)>`; also injects `X-Scope-OrgID` when `tenantId` is set — for self-hosted multi-tenancy only, not needed for Grafana Cloud)
+- `mode: "basic"` (requires `basicPassword` + `basicUser` or `tenantId`, injects `Authorization: Basic <base64(user:password)>`; also injects `X-Scope-OrgID` when `tenantId` is set — for multi-tenant deployments only, not needed for Grafana Cloud)
 
 Invalid mode/field combinations throw during client config resolution.
 
@@ -346,8 +350,8 @@ const client = new SigilClient({
     endpoint: "https://sigil-prod-<region>.grafana.net",
     auth: {
       mode: "basic",
-      tenantId: process.env.GRAFANA_CLOUD_INSTANCE_ID,
-      basicPassword: process.env.GRAFANA_CLOUD_API_KEY,
+      tenantId: process.env.SIGIL_AUTH_TENANT_ID,
+      basicPassword: process.env.SIGIL_AUTH_TOKEN,
     },
   },
 });
@@ -358,9 +362,9 @@ If your deployment requires a distinct username, set `basicUser` explicitly:
 ```ts
 auth: {
   mode: "basic",
-  tenantId: process.env.GRAFANA_CLOUD_INSTANCE_ID,
-  basicUser: process.env.GRAFANA_CLOUD_INSTANCE_ID,
-  basicPassword: process.env.GRAFANA_CLOUD_API_KEY,
+  tenantId: process.env.SIGIL_AUTH_TENANT_ID,
+  basicUser: process.env.SIGIL_AUTH_TENANT_ID,
+  basicPassword: process.env.SIGIL_AUTH_TOKEN,
 },
 ```
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -130,7 +130,7 @@ If nothing appears, the most common causes are: `sigil-cc` not on `$PATH`, missi
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `SIGIL_ENDPOINT` | yes | Sigil API URL from AI Observability → Configuration. The `/api/v1/generations:export` path is appended automatically. |
+| `SIGIL_ENDPOINT` | yes | Sigil API URL from AI Observability → Configuration. |
 | `SIGIL_AUTH_TENANT_ID` | yes | Grafana Cloud stack/instance ID. Sent as Basic-auth username and `X-Scope-OrgID` header. |
 | `SIGIL_AUTH_TOKEN` | yes | `glc_…` access policy token with `sigil:write` (and `metrics:write` / `traces:write` if using OTel). [Access Policies docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/). |
 | `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | yes | OTLP HTTP endpoint for metrics and traces (e.g. `https://otlp-gateway-prod-<region>.grafana.net/otlp`). Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT`. The plugin runs without it, but the AI Observability UI depends on these signals — half the panels are empty. |

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -39,7 +39,7 @@ The Sigil and OTel env-var schemas come from the SDKs, not this plugin:
 
 | Variable | Required | Purpose |
 |---|---|---|
-| `SIGIL_ENDPOINT` | yes | Sigil API URL, e.g. `https://sigil-prod-<region>.grafana.net`. The plugin appends `/api/v1/generations:export`. |
+| `SIGIL_ENDPOINT` | yes | Sigil API URL, for example `https://sigil-prod-<region>.grafana.net`. |
 | `SIGIL_AUTH_TENANT_ID` | yes | Grafana Cloud stack/instance ID. Used as Basic-auth username and the `X-Scope-OrgID` header. |
 | `SIGIL_AUTH_TOKEN` | yes | `glc_…` Cloud access policy token with the `sigil:write` scope. |
 | `SIGIL_TAGS` | no | Comma-separated `k=v` pairs added to every generation. Built-ins (`git.branch`, `cwd`, `subagent`) win on collision. |

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -13,7 +13,7 @@ Hooks into OpenCode's chat lifecycle to capture assistant messages and send them
 ```json
 {
   "enabled": true,
-  "endpoint": "http://localhost:8080/api/v1/generations:export",
+  "endpoint": "http://localhost:8080",
   "auth": { "mode": "none" },
   "agentName": "opencode",
   "contentCapture": true

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -25,7 +25,7 @@ pi install /absolute/path/to/sigil-sdk/plugins/pi
 
 ## Get your credentials from Grafana Cloud
 
-Skip this section if you're connecting to self-hosted Sigil — see [Auth modes](#auth-modes) for `tenant` / `bearer` / `none`.
+Skip this section if you're not connecting to Grafana Cloud — refer to [Auth modes](#auth-modes) for `tenant` / `bearer` / `none`.
 
 You need four values from your Grafana Cloud stack: the Sigil API URL, an OTLP endpoint, an instance ID, and an access policy token.
 
@@ -63,12 +63,12 @@ Create `~/.config/sigil-pi/config.json`:
   "auth": {
     "mode": "basic",
     "user": "123456",
-    "password": "${GRAFANA_CLOUD_TOKEN}"
+    "password": "${SIGIL_AUTH_TOKEN}"
   },
   "otlp": {
     "endpoint": "https://otlp-gateway.grafana.net/otlp",
     "basicUser": "123456",
-    "basicPassword": "${GRAFANA_CLOUD_TOKEN}"
+    "basicPassword": "${SIGIL_AUTH_TOKEN}"
   }
 }
 ```
@@ -79,7 +79,7 @@ Token values support `${ENV_VAR}` interpolation.
 
 **basic** — HTTP Basic auth + X-Scope-OrgID (Grafana Cloud):
 ```json
-{ "mode": "basic", "user": "123456", "password": "${GRAFANA_CLOUD_TOKEN}" }
+{ "mode": "basic", "user": "123456", "password": "${SIGIL_AUTH_TOKEN}" }
 ```
 
 `user` is your Grafana Cloud stack/tenant ID. `password` is a `glc_…` token created in Grafana Cloud -> Access Policies ([docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/)) with the appropriate Sigil scope.
@@ -107,7 +107,7 @@ The `otlp` block exports OTel histograms and trace spans. The AI Observability U
 "otlp": {
   "endpoint": "https://otlp-gateway-prod-<region>.grafana.net/otlp",
   "basicUser": "123456",
-  "basicPassword": "${GRAFANA_CLOUD_TOKEN}"
+  "basicPassword": "${SIGIL_AUTH_TOKEN}"
 }
 ```
 
@@ -141,7 +141,7 @@ Tweak individual knobs:
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `endpoint` | — | Sigil URL (`/api/v1/generations:export` auto-appended) |
+| `endpoint` | — | Sigil URL |
 | `auth.mode` | `"none"` | One of `basic`, `tenant`, `bearer`, `none` |
 | `auth.user` | — | Basic auth user (Grafana Cloud stack ID) |
 | `auth.password` | — | Basic auth password (`glc_…` token) |

--- a/python-frameworks/litellm/README.md
+++ b/python-frameworks/litellm/README.md
@@ -115,8 +115,8 @@ client = Client(ClientConfig(
         endpoint=os.environ["SIGIL_ENDPOINT"],
         auth=AuthConfig(
             mode="basic",
-            tenant_id=os.environ.get("SIGIL_TENANT_ID", ""),
-            basic_password=os.environ.get("SIGIL_API_KEY", ""),
+            tenant_id=os.environ.get("SIGIL_AUTH_TENANT_ID", ""),
+            basic_password=os.environ.get("SIGIL_AUTH_TOKEN", ""),
         ),
     ),
 ))
@@ -147,8 +147,8 @@ docker run -d \
   -v $(pwd)/config.yaml:/app/config.yaml \
   -v $(pwd)/sigil_callback.py:/app/sigil_callback.py \
   -e SIGIL_ENDPOINT=https://your-sigil-endpoint \
-  -e SIGIL_TENANT_ID=your-tenant \
-  -e SIGIL_API_KEY=your-key \
+  -e SIGIL_AUTH_TENANT_ID=your-tenant \
+  -e SIGIL_AUTH_TOKEN=your-key \
   -p 4000:4000 \
   your-litellm-image \
   --config /app/config.yaml

--- a/python-frameworks/litellm/example/README.md
+++ b/python-frameworks/litellm/example/README.md
@@ -13,8 +13,8 @@ Runs a LiteLLM proxy with the Sigil callback handler, exporting generations to G
 ```bash
 cd sdks/python-frameworks/litellm/example
 SIGIL_ENDPOINT=https://your-sigil.grafana.net \
-  SIGIL_TENANT_ID=your-tenant \
-  SIGIL_API_KEY=glc_... \
+  SIGIL_AUTH_TENANT_ID=your-tenant \
+  SIGIL_AUTH_TOKEN=glc_... \
   OPENAI_API_KEY=sk-... \
   docker compose up --build
 ```

--- a/python-frameworks/litellm/example/docker-compose.yaml
+++ b/python-frameworks/litellm/example/docker-compose.yaml
@@ -9,8 +9,8 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       SIGIL_ENDPOINT: ${SIGIL_ENDPOINT}
-      SIGIL_TENANT_ID: ${SIGIL_TENANT_ID}
-      SIGIL_API_KEY: ${SIGIL_API_KEY}
+      SIGIL_AUTH_TENANT_ID: ${SIGIL_AUTH_TENANT_ID}
+      SIGIL_AUTH_TOKEN: ${SIGIL_AUTH_TOKEN}
     volumes:
       - ./config.yaml:/app/config.yaml
       - ./sigil_callback.py:/app/sigil_callback.py

--- a/python-frameworks/litellm/example/sigil_callback.py
+++ b/python-frameworks/litellm/example/sigil_callback.py
@@ -15,8 +15,8 @@ client = Client(
             endpoint=_endpoint,
             auth=AuthConfig(
                 mode="basic",
-                tenant_id=os.environ.get("SIGIL_TENANT_ID", ""),
-                basic_password=os.environ.get("SIGIL_API_KEY", ""),
+                tenant_id=os.environ.get("SIGIL_AUTH_TENANT_ID", ""),
+                basic_password=os.environ.get("SIGIL_AUTH_TOKEN", ""),
             ),
         ),
     )

--- a/python/README.md
+++ b/python/README.md
@@ -14,6 +14,8 @@ Use this package when you want:
 pip install sigil-sdk
 ```
 
+For a Grafana Cloud setup walkthrough (where to find the endpoint URL, instance ID, and API token), refer to the [Grafana Cloud setup guide](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/).
+
 ## Validation
 
 Run the shared core conformance suite for the Python SDK from the repo root:
@@ -133,8 +135,11 @@ Full framework examples:
 
 ## Quick Start (Sync Generation)
 
+The snippet below configures the SDK explicitly. As an alternative, set `SIGIL_*` environment variables and call `Client()` with no arguments — refer to the [Grafana Cloud setup guide](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/) for the variable names.
+
 ```python
 from sigil_sdk import (
+    AuthConfig,
     Client,
     ClientConfig,
     GenerationExportConfig,
@@ -149,6 +154,7 @@ client = Client(
         generation_export=GenerationExportConfig(
             protocol="http",
             endpoint="http://localhost:8080",
+            auth=AuthConfig(mode="tenant", tenant_id="dev-tenant"),
         ),
     )
 )
@@ -452,7 +458,7 @@ Auth is resolved for `generation_export`.
 - `mode="none"`
 - `mode="tenant"` (requires `tenant_id`, injects `X-Scope-OrgID`)
 - `mode="bearer"` (requires `bearer_token`, injects `Authorization: Bearer <token>`)
-- `mode="basic"` (requires `basic_password` + `basic_user` or `tenant_id`, injects `Authorization: Basic <base64(user:password)>`; also injects `X-Scope-OrgID` when `tenant_id` is set — for self-hosted multi-tenancy only, not needed for Grafana Cloud)
+- `mode="basic"` (requires `basic_password` + `basic_user` or `tenant_id`, injects `Authorization: Basic <base64(user:password)>`; also injects `X-Scope-OrgID` when `tenant_id` is set — for multi-tenant deployments only, not needed for Grafana Cloud)
 
 Invalid mode/field combinations fail fast in `resolve_config(...)`.
 
@@ -485,8 +491,8 @@ cfg = ClientConfig(
         endpoint="https://sigil-prod-<region>.grafana.net",
         auth=AuthConfig(
             mode="basic",
-            tenant_id=os.environ["GRAFANA_CLOUD_INSTANCE_ID"],
-            basic_password=os.environ["GRAFANA_CLOUD_API_KEY"],
+            tenant_id=os.environ["SIGIL_AUTH_TENANT_ID"],
+            basic_password=os.environ["SIGIL_AUTH_TOKEN"],
         ),
     ),
 )
@@ -497,9 +503,9 @@ If your deployment requires a distinct username, set `basic_user` explicitly:
 ```python
 auth=AuthConfig(
     mode="basic",
-    tenant_id=os.environ["GRAFANA_CLOUD_INSTANCE_ID"],
-    basic_user=os.environ["GRAFANA_CLOUD_INSTANCE_ID"],
-    basic_password=os.environ["GRAFANA_CLOUD_API_KEY"],
+    tenant_id=os.environ["SIGIL_AUTH_TENANT_ID"],
+    basic_user=os.environ["SIGIL_AUTH_TENANT_ID"],
+    basic_password=os.environ["SIGIL_AUTH_TOKEN"],
 )
 ```
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only updates that standardize environment variable names and example configuration across SDKs; minimal runtime risk aside from potential confusion for users relying on old variable names in docs.
> 
> **Overview**
> **Standardizes documentation and examples to the canonical `SIGIL_*` environment variable schema across languages.** READMEs and getting-started samples for Go, Python, JS/TS, Java, and .NET now consistently use `SIGIL_ENDPOINT`, `SIGIL_PROTOCOL`, `SIGIL_AUTH_MODE`, `SIGIL_AUTH_TENANT_ID`, and `SIGIL_AUTH_TOKEN` (replacing older `GRAFANA_*` and other ad-hoc names), and add links to the Grafana Cloud setup guide.
> 
> **Clarifies endpoint/auth guidance in examples and plugin docs.** Several examples/plugins stop hardcoding the `/api/v1/generations:export` suffix in docs/config snippets (using the base `SIGIL_ENDPOINT` instead), update local HTTP example endpoints, and refine wording around Basic auth being for multi-tenant deployments and OTLP credential expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b1ec6371708c16eaf7cfd6a3b7cb394a0585cc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->