### PR TITLE
fix(plugins/pi): record LLM turns as streaming generations

### DIFF
--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -34,6 +34,7 @@ import type {
 interface RecorderLike {
   setResult: (value: unknown) => void;
   setCallError: (error: Error) => void;
+  setFirstTokenAt?: (firstTokenAt: Date) => void;
 }
 
 interface ToolRecorderLike {
@@ -44,12 +45,40 @@ interface ToolRecorderLike {
 }
 
 interface SigilLike {
-  startGeneration: (
+  startStreamingGeneration: (
     seed: unknown,
     run: (recorder: RecorderLike) => Promise<void>,
   ) => Promise<void>;
   startToolExecution: ReturnType<typeof vi.fn>;
   shutdown: () => Promise<void>;
+}
+
+function assistantMessageUpdate(
+  overrides?: Partial<{ type: string; delta: string }>,
+) {
+  return {
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: "h" }],
+      provider: "anthropic",
+      model: "claude-sonnet-4",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    },
+    assistantMessageEvent: {
+      type: overrides?.type ?? "text_delta",
+      contentIndex: 0,
+      delta: overrides?.delta ?? "h",
+      partial: {},
+    },
+  };
 }
 
 class FakePi {
@@ -119,6 +148,304 @@ describe("extension lifecycle", () => {
     createTelemetryProvidersMock.mockReset();
   });
 
+  it("uses assistant message_end timestamp as completedAt, not msg.timestamp", async () => {
+    // `msg.timestamp` is set by pi providers when constructing the
+    // AssistantMessage object — i.e. before the HTTP request — so it sits
+    // near turn_start, not at stream completion. The plugin must instead
+    // pick up Date.now() from the assistant `message_end` event, which
+    // fires immediately after the provider stream's done/error event.
+    let capturedSeed: { startedAt: Date } | undefined;
+    const recorder = {
+      setResult: vi.fn(),
+      setCallError: vi.fn(),
+      setFirstTokenAt: vi.fn(),
+    };
+
+    const sigil: SigilLike = {
+      startStreamingGeneration: vi.fn(async (seed, run) => {
+        capturedSeed = seed as { startedAt: Date };
+        await run(recorder);
+      }),
+      startToolExecution: vi.fn(() => ({
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        end: vi.fn(),
+        getError: vi.fn(),
+      })),
+      shutdown: vi.fn(async () => {}),
+    };
+
+    loadConfigMock.mockResolvedValue({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      auth: { mode: "none" },
+      agentName: "pi",
+      contentCapture: "metadata_only",
+    });
+    createSigilClientMock.mockReturnValue(sigil);
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+
+    const msg = assistantMessage();
+    // Deliberately ancient timestamp; if the plugin still uses
+    // msg.timestamp, the assertion below will catch it.
+    msg.timestamp = 1700000000000;
+
+    await pi.emit("session_start");
+    await pi.emit("turn_start");
+
+    const beforeMessageEnd = Date.now();
+    await pi.emit("message_end", { message: { role: "assistant" } });
+    const afterMessageEnd = Date.now();
+
+    await pi.emit("turn_end", { message: msg, toolResults: [] });
+
+    expect(recorder.setResult).toHaveBeenCalledTimes(1);
+    const result = recorder.setResult.mock.calls[0]![0] as {
+      completedAt: Date;
+    };
+    const completedAt = result.completedAt.getTime();
+    expect(completedAt).toBeGreaterThanOrEqual(beforeMessageEnd);
+    expect(completedAt).toBeLessThanOrEqual(afterMessageEnd);
+    expect(completedAt).not.toBe(msg.timestamp);
+
+    // Sanity: startedAt is from turn_start and predates completedAt, so
+    // duration is positive (not the ~0 we got from msg.timestamp before).
+    expect(capturedSeed!.startedAt.getTime()).toBeLessThanOrEqual(completedAt);
+  });
+
+  it("falls back to msg.timestamp when no assistant message_end is observed", async () => {
+    const recorder = {
+      setResult: vi.fn(),
+      setCallError: vi.fn(),
+      setFirstTokenAt: vi.fn(),
+    };
+
+    const sigil: SigilLike = {
+      startStreamingGeneration: vi.fn(async (_seed, run) => {
+        await run(recorder);
+      }),
+      startToolExecution: vi.fn(() => ({
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        end: vi.fn(),
+        getError: vi.fn(),
+      })),
+      shutdown: vi.fn(async () => {}),
+    };
+
+    loadConfigMock.mockResolvedValue({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      auth: { mode: "none" },
+      agentName: "pi",
+      contentCapture: "metadata_only",
+    });
+    createSigilClientMock.mockReturnValue(sigil);
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+
+    const msg = assistantMessage();
+    msg.timestamp = 1700000005000;
+
+    await pi.emit("session_start");
+    await pi.emit("turn_start");
+    // No assistant message_end — simulates extension-stripped events or
+    // older pi versions. Plugin should fall back to msg.timestamp.
+    await pi.emit("turn_end", { message: msg, toolResults: [] });
+
+    const result = recorder.setResult.mock.calls[0]![0] as {
+      completedAt: Date;
+    };
+    expect(result.completedAt.getTime()).toBe(msg.timestamp);
+  });
+
+  it("keeps firstTokenAt within [startedAt, completedAt] when streaming", async () => {
+    // Smoke check that the TTFT, startedAt and completedAt timestamps are
+    // mutually consistent: with streaming + assistant message_end, TTFT
+    // must not exceed the generation duration.
+    let capturedSeed: { startedAt: Date } | undefined;
+    const recorder = {
+      setResult: vi.fn(),
+      setCallError: vi.fn(),
+      setFirstTokenAt: vi.fn(),
+    };
+
+    const sigil: SigilLike = {
+      startStreamingGeneration: vi.fn(async (seed, run) => {
+        capturedSeed = seed as { startedAt: Date };
+        await run(recorder);
+      }),
+      startToolExecution: vi.fn(() => ({
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        end: vi.fn(),
+        getError: vi.fn(),
+      })),
+      shutdown: vi.fn(async () => {}),
+    };
+
+    loadConfigMock.mockResolvedValue({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      auth: { mode: "none" },
+      agentName: "pi",
+      contentCapture: "metadata_only",
+    });
+    createSigilClientMock.mockReturnValue(sigil);
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+
+    await pi.emit("session_start");
+    await pi.emit("turn_start");
+    await pi.emit("message_update", assistantMessageUpdate());
+    await pi.emit("message_end", { message: { role: "assistant" } });
+    await pi.emit("turn_end", { message: assistantMessage(), toolResults: [] });
+
+    expect(recorder.setFirstTokenAt).toHaveBeenCalledTimes(1);
+    const firstTokenAt = (
+      recorder.setFirstTokenAt.mock.calls[0]![0] as Date
+    ).getTime();
+    const startedAt = capturedSeed!.startedAt.getTime();
+    const completedAt = (
+      recorder.setResult.mock.calls[0]![0] as { completedAt: Date }
+    ).completedAt.getTime();
+
+    expect(startedAt).toBeLessThanOrEqual(firstTokenAt);
+    expect(firstTokenAt).toBeLessThanOrEqual(completedAt);
+  });
+
+  it("records streaming generations and first-token time from message_update", async () => {
+    const recorder = {
+      setResult: vi.fn(),
+      setCallError: vi.fn(),
+      setFirstTokenAt: vi.fn(),
+    };
+
+    const sigil = {
+      startGeneration: vi.fn(),
+      startStreamingGeneration: vi.fn(async (_seed, run) => {
+        await run(recorder);
+      }),
+      startToolExecution: vi.fn(() => ({
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        end: vi.fn(),
+        getError: vi.fn(),
+      })),
+      shutdown: vi.fn(async () => {}),
+    };
+
+    loadConfigMock.mockResolvedValue({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      auth: { mode: "none" },
+      agentName: "pi",
+      contentCapture: "metadata_only",
+    });
+    createSigilClientMock.mockReturnValue(sigil);
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+
+    await pi.emit("session_start");
+    await pi.emit("turn_start");
+    // Pi emits message_update events for each streamed chunk; only the first
+    // one should be captured as the time-to-first-token.
+    await pi.emit("message_update", assistantMessageUpdate({ delta: "he" }));
+    await pi.emit("message_update", assistantMessageUpdate({ delta: "llo" }));
+    await pi.emit("turn_end", { message: assistantMessage(), toolResults: [] });
+
+    expect(sigil.startStreamingGeneration).toHaveBeenCalledTimes(1);
+    expect(sigil.startGeneration).not.toHaveBeenCalled();
+    expect(recorder.setFirstTokenAt).toHaveBeenCalledTimes(1);
+    const firstTokenAt = recorder.setFirstTokenAt.mock.calls[0]![0] as Date;
+    expect(firstTokenAt).toBeInstanceOf(Date);
+    expect(Number.isNaN(firstTokenAt.getTime())).toBe(false);
+  });
+
+  it("does not call setFirstTokenAt when no message_update fires", async () => {
+    const recorder = {
+      setResult: vi.fn(),
+      setCallError: vi.fn(),
+      setFirstTokenAt: vi.fn(),
+    };
+
+    const sigil: SigilLike = {
+      startStreamingGeneration: vi.fn(async (_seed, run) => {
+        await run(recorder);
+      }),
+      startToolExecution: vi.fn(() => ({
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        end: vi.fn(),
+        getError: vi.fn(),
+      })),
+      shutdown: vi.fn(async () => {}),
+    };
+
+    loadConfigMock.mockResolvedValue({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      auth: { mode: "none" },
+      agentName: "pi",
+      contentCapture: "metadata_only",
+    });
+    createSigilClientMock.mockReturnValue(sigil);
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+
+    await pi.emit("session_start");
+    await pi.emit("turn_start");
+    await pi.emit("turn_end", { message: assistantMessage(), toolResults: [] });
+
+    expect(sigil.startStreamingGeneration).toHaveBeenCalledTimes(1);
+    expect(recorder.setFirstTokenAt).not.toHaveBeenCalled();
+  });
+
+  it("ignores message_update for non-assistant roles", async () => {
+    const recorder = {
+      setResult: vi.fn(),
+      setCallError: vi.fn(),
+      setFirstTokenAt: vi.fn(),
+    };
+
+    const sigil: SigilLike = {
+      startStreamingGeneration: vi.fn(async (_seed, run) => {
+        await run(recorder);
+      }),
+      startToolExecution: vi.fn(() => ({
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        end: vi.fn(),
+        getError: vi.fn(),
+      })),
+      shutdown: vi.fn(async () => {}),
+    };
+
+    loadConfigMock.mockResolvedValue({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      auth: { mode: "none" },
+      agentName: "pi",
+      contentCapture: "metadata_only",
+    });
+    createSigilClientMock.mockReturnValue(sigil);
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+
+    await pi.emit("session_start");
+    await pi.emit("turn_start");
+    // Defensive: pi only emits message_update for assistant streaming, but
+    // ignore any other roles regardless to avoid mis-attributing TTFT.
+    await pi.emit("message_update", {
+      message: { role: "user", content: "hey", timestamp: Date.now() },
+      assistantMessageEvent: { type: "text_delta", delta: "x" },
+    });
+    await pi.emit("turn_end", { message: assistantMessage(), toolResults: [] });
+
+    expect(recorder.setFirstTokenAt).not.toHaveBeenCalled();
+  });
+
   it("handles the happy path and exports one generation with user input", async () => {
     const recorder = {
       setResult: vi.fn(),
@@ -126,7 +453,7 @@ describe("extension lifecycle", () => {
     };
 
     const sigil: SigilLike = {
-      startGeneration: vi.fn(async (_seed, run) => {
+      startStreamingGeneration: vi.fn(async (_seed, run) => {
         await run(recorder);
       }),
       startToolExecution: vi.fn(() => ({
@@ -161,7 +488,7 @@ describe("extension lifecycle", () => {
     await pi.emit("tool_execution_end", { toolCallId: "c1", isError: false });
     await pi.emit("turn_end", { message: assistantMessage(), toolResults: [] });
 
-    expect(sigil.startGeneration).toHaveBeenCalledTimes(1);
+    expect(sigil.startStreamingGeneration).toHaveBeenCalledTimes(1);
     expect(recorder.setResult).toHaveBeenCalledTimes(1);
     expect(recorder.setCallError).not.toHaveBeenCalled();
 
@@ -187,7 +514,7 @@ describe("extension lifecycle", () => {
     };
 
     const sigil: SigilLike = {
-      startGeneration: vi.fn(async (_seed, run) => {
+      startStreamingGeneration: vi.fn(async (_seed, run) => {
         await run(recorder);
       }),
       startToolExecution: vi.fn(() => ({
@@ -243,7 +570,7 @@ describe("extension lifecycle", () => {
     };
 
     const sigil: SigilLike = {
-      startGeneration: vi.fn(async (_seed, run) => {
+      startStreamingGeneration: vi.fn(async (_seed, run) => {
         await run(recorder);
       }),
       startToolExecution: vi.fn(() => ({
@@ -304,7 +631,7 @@ describe("extension lifecycle", () => {
     };
 
     const sigil: SigilLike = {
-      startGeneration: vi.fn(async (_seed, run) => {
+      startStreamingGeneration: vi.fn(async (_seed, run) => {
         await run(recorder);
       }),
       startToolExecution: vi.fn(() => ({
@@ -340,7 +667,7 @@ describe("extension lifecycle", () => {
     await pi.emit("turn_start");
     await pi.emit("turn_end", { message: assistantMessage(), toolResults: [] });
 
-    expect(sigil.startGeneration).toHaveBeenCalledTimes(2);
+    expect(sigil.startStreamingGeneration).toHaveBeenCalledTimes(2);
     expect(recorder.setResult).toHaveBeenCalledTimes(2);
 
     const turn1 = recorder.setResult.mock.calls[0]![0] as { input?: unknown[] };
@@ -358,7 +685,7 @@ describe("extension lifecycle", () => {
     };
 
     const sigil: SigilLike = {
-      startGeneration: vi.fn(async (seed, run) => {
+      startStreamingGeneration: vi.fn(async (seed, run) => {
         capturedSeed = seed;
         await run(recorder);
       }),
@@ -392,7 +719,7 @@ describe("extension lifecycle", () => {
 
     await pi.emit("turn_end", { message: msg, toolResults: [] });
 
-    expect(sigil.startGeneration).toHaveBeenCalledTimes(1);
+    expect(sigil.startStreamingGeneration).toHaveBeenCalledTimes(1);
     // startedAt must be <= completedAt
     const startedAt = capturedSeed.startedAt.getTime();
     const completedAt = msg.timestamp;
@@ -407,7 +734,7 @@ describe("extension lifecycle", () => {
     };
 
     const sigil: SigilLike = {
-      startGeneration: vi.fn(async (_seed, run) => {
+      startStreamingGeneration: vi.fn(async (_seed, run) => {
         await run(recorder);
       }),
       startToolExecution: vi.fn(() => {
@@ -469,7 +796,7 @@ describe("extension lifecycle", () => {
 
   it("swallows sigil failures instead of throwing or printing by default", async () => {
     const sigil = {
-      startGeneration: vi.fn(async () => {
+      startStreamingGeneration: vi.fn(async () => {
         throw new Error("transport down");
       }),
       shutdown: vi.fn(async () => {}),
@@ -507,7 +834,7 @@ describe("extension lifecycle", () => {
 
   it("prints sigil failures in debug mode", async () => {
     const sigil = {
-      startGeneration: vi.fn(async () => {
+      startStreamingGeneration: vi.fn(async () => {
         throw new Error("transport down");
       }),
       shutdown: vi.fn(async () => {}),
@@ -552,7 +879,7 @@ describe("extension lifecycle", () => {
       setCallError: vi.fn(),
     };
     const sigil: SigilLike = {
-      startGeneration: vi.fn(async (_seed, run) => {
+      startStreamingGeneration: vi.fn(async (_seed, run) => {
         await run(recorder);
       }),
       startToolExecution: vi.fn(),
@@ -579,7 +906,7 @@ describe("extension lifecycle", () => {
       toolResults: [],
     });
 
-    expect(sigil.startGeneration).not.toHaveBeenCalled();
+    expect(sigil.startStreamingGeneration).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("did not validate"),
     );
@@ -593,7 +920,7 @@ describe("extension lifecycle", () => {
     const seeds: Array<{ conversationId?: string }> = [];
     const recorder = { setResult: vi.fn(), setCallError: vi.fn() };
     const sigil: SigilLike = {
-      startGeneration: vi.fn(async (seed, run) => {
+      startStreamingGeneration: vi.fn(async (seed, run) => {
         seeds.push(seed as { conversationId?: string });
         await run(recorder);
       }),
@@ -667,7 +994,7 @@ describe("extension lifecycle", () => {
     const seeds: Array<{ conversationId?: string }> = [];
     const recorder = { setResult: vi.fn(), setCallError: vi.fn() };
     const sigil: SigilLike = {
-      startGeneration: vi.fn(async (seed, run) => {
+      startStreamingGeneration: vi.fn(async (seed, run) => {
         seeds.push(seed as { conversationId?: string });
         await run(recorder);
       }),
@@ -733,7 +1060,7 @@ describe("extension lifecycle", () => {
     let capturedSeed: { conversationId?: string } | undefined;
     const recorder = { setResult: vi.fn(), setCallError: vi.fn() };
     const sigil: SigilLike = {
-      startGeneration: vi.fn(async (seed, run) => {
+      startStreamingGeneration: vi.fn(async (seed, run) => {
         capturedSeed = seed as { conversationId?: string };
         await run(recorder);
       }),

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -59,6 +59,17 @@ export default function (pi: ExtensionAPI) {
   let telemetry: TelemetryProviders | null = null;
 
   let turnStartTime = 0;
+  // Earliest `message_update` event observed in the current turn. Pi emits
+  // `message_update` for streaming text/thinking/toolcall blocks coming back
+  // from the provider, so the first one is a faithful TTFT signal.
+  // 0 means: no streamed chunk seen yet for this turn.
+  let firstTokenTime = 0;
+  // Time the assistant `message_end` fired for this turn. Pi's agent loop
+  // emits message_end (assistant) immediately after the provider stream's
+  // `done`/`error` event, *before* any subsequent tool execution in the
+  // same turn, so this is the actual completion time of the model call.
+  // 0 means: no assistant message_end seen yet for this turn.
+  let assistantMessageEndTime = 0;
 
   function debugLog(msg: string, ...args: unknown[]) {
     if (config?.debug) console.error(`[sigil-pi] ${msg}`, ...args);
@@ -78,6 +89,8 @@ export default function (pi: ExtensionAPI) {
 
   function resetTurnState() {
     turnStartTime = 0;
+    firstTokenTime = 0;
+    assistantMessageEndTime = 0;
     toolStarts.clear();
     turnToolTimings.length = 0;
   }
@@ -157,12 +170,35 @@ export default function (pi: ExtensionAPI) {
     if (!sigil || !config) return;
     try {
       const message = (event as { message?: unknown }).message;
+      const role = (message as { role?: string } | null | undefined)?.role;
+      if (role === "assistant") {
+        // First write wins: pi emits exactly one assistant message_end per
+        // turn, but guard against stray duplicates from extensions so a
+        // later (post-tool) timestamp can't displace the real one.
+        if (assistantMessageEndTime === 0) {
+          assistantMessageEndTime = Date.now();
+        }
+        return;
+      }
       if (!isUserMessage(message)) return;
       const mapped = mapUserMessage(message, config.contentCapture);
       if (mapped) pendingInputMessages.push(mapped);
     } catch (err) {
       console.warn("[sigil-pi] message_end failed:", err);
     }
+  });
+
+  // Record the first streamed chunk of an assistant message as the TTFT
+  // signal. Pi only emits `message_update` for streamed assistant blocks
+  // (text/thinking/toolcall *_start, *_delta, *_end events from
+  // AssistantMessageEventStream), so any first occurrence reflects the
+  // moment the provider began producing output for this turn.
+  pi.on("message_update", async (event, _ctx) => {
+    if (!sigil) return;
+    if (firstTokenTime !== 0) return;
+    const role = (event as { message?: { role?: string } }).message?.role;
+    if (role !== "assistant") return;
+    firstTokenTime = Date.now();
   });
 
   pi.on("tool_execution_start", async (event, _ctx) => {
@@ -221,10 +257,15 @@ export default function (pi: ExtensionAPI) {
       // (session-manager.d.ts: ReadonlySessionManager).
       const conversationId = ctx.sessionManager.getSessionId() || undefined;
 
-      // Ensure startedAt <= completedAt (msg.timestamp). The provider sets
-      // msg.timestamp via Date.now() when creating the message object, which
-      // is normally after turn_start, but clock adjustments can invert them.
-      const completedAtMs = msg.timestamp;
+      // Prefer the assistant `message_end` timestamp captured above (fires
+      // right after the provider stream ends, before tools execute). Fall
+      // back to `msg.timestamp` only when no assistant message_end was
+      // observed — pi providers set `msg.timestamp` when constructing the
+      // assistant message object (before the HTTP request), so it sits near
+      // turnStartTime, not at stream completion. The Math.min clamp guards
+      // against clock adjustments inverting startedAt and completedAt.
+      const completedAtMs =
+        assistantMessageEndTime > 0 ? assistantMessageEndTime : msg.timestamp;
       const startedAtMs = Math.min(
         turnStartTime || completedAtMs,
         completedAtMs,
@@ -247,10 +288,18 @@ export default function (pi: ExtensionAPI) {
         toolResults,
         contentCapture,
         pendingInputMessages.slice(),
+        completedAtMs,
       );
 
       try {
-        await sigil.startGeneration(seed, async (recorder) => {
+        // Pi streams provider responses (see message_update handler above),
+        // so generations are exported with mode=STREAM. The SDK only records
+        // the gen_ai.client.time_to_first_token histogram when the operation
+        // is `streamText`, which `startStreamingGeneration` sets by default.
+        await sigil.startStreamingGeneration(seed, async (recorder) => {
+          if (firstTokenTime > 0) {
+            recorder.setFirstTokenAt(new Date(firstTokenTime));
+          }
           recorder.setResult(result);
           if (msg.errorMessage) {
             recorder.setCallError(new Error(msg.errorMessage));

--- a/plugins/pi/src/mappers.ts
+++ b/plugins/pi/src/mappers.ts
@@ -105,12 +105,22 @@ export function mapGenerationStart(
   return start;
 }
 
-/** Build the GenerationResult from an assistant message. */
+/**
+ * Build the GenerationResult from an assistant message.
+ *
+ * `completedAtMs` should be the time the provider stream finished
+ * (assistant `message_end`). `msg.timestamp` is unreliable as a completion
+ * marker: pi providers set it via `Date.now()` when constructing the
+ * assistant message object — i.e. *before* the API request is sent — so
+ * it is closer to a start timestamp than an end timestamp. Falls back to
+ * `msg.timestamp` only when no end timestamp was observed.
+ */
 export function mapGenerationResult(
   msg: PiAssistantMessage,
   toolResults: PiToolResult[],
   contentCapture: ContentCaptureMode,
   input?: Message[],
+  completedAtMs?: number,
 ): GenerationResult {
   const result: GenerationResult = {
     responseId: msg.responseId,
@@ -123,7 +133,7 @@ export function mapGenerationResult(
       cacheCreationInputTokens: msg.usage.cacheWrite,
     },
     stopReason: mapStopReason(msg.stopReason),
-    completedAt: new Date(msg.timestamp),
+    completedAt: new Date(completedAtMs ?? msg.timestamp),
     metadata:
       msg.usage.cost !== undefined ? { cost_usd: msg.usage.cost.total } : {},
   };


### PR DESCRIPTION
Pi streams provider responses, but the plugin opened generations with `startGeneration()` (SYNC mode). The SDK only records TTFT for `streamText`, so `gen_ai.client.time_to_first_token` was always empty. Switch to `startStreamingGeneration()` and forward the first per-turn `message_update` as the first-token timestamp.

Also fix `completedAt`: `msg.timestamp` is set by pi providers when constructing the assistant message — before the HTTP request — so it landed near turn start and made generation duration ≈ 0. Use the assistant `message_end` time (emitted after the stream's done/error, before tool execution) instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes generation export mode and timestamp attribution, which impacts telemetry/metrics (TTFT, duration) and could affect downstream analytics if event ordering differs from assumptions.
> 
> **Overview**
> Exports Pi assistant turns as **streaming** generations by switching to `startStreamingGeneration` and capturing time-to-first-token from the first assistant `message_update` event.
> 
> Fixes generation end timing by using the assistant `message_end` time for `completedAt` (with fallback to `msg.timestamp` when missing), and threads this through `mapGenerationResult`. Updates and expands tests to cover TTFT capture, role filtering, and timestamp fallback/consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d31c6f968d0f0140fa47d1dd75a3f1a108d2496d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->