### PR TITLE
feat(plugins/claude-code): use subagent_type as subagent name

### DIFF
--- a/plugins/claude-code/internal/mapper/mapper.go
+++ b/plugins/claude-code/internal/mapper/mapper.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"maps"
 	"slices"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -112,8 +113,9 @@ func mergeAssistantGroup(lines []transcript.Line) transcript.Line {
 
 // agentCall holds the metadata captured from an Agent tool_use block.
 type agentCall struct {
-	parentGenID string           // generation that spawned this call
-	parentGen   sigil.Generation // copy for inheriting fields
+	parentGenID  string           // generation that spawned this call
+	parentGen    sigil.Generation // copy for inheriting fields
+	subagentType string           // lowercased subagent_type from tool input; empty falls back to "subagent"
 }
 
 // Process walks transcript lines and produces Generation records.
@@ -146,9 +148,14 @@ func Process(lines []transcript.Line, st *state.Session, opts Options, r *redact
 				for _, msg := range gen.Output {
 					for _, part := range msg.Parts {
 						if part.ToolCall != nil && part.ToolCall.Name == "Agent" {
+							var parsed struct {
+								SubagentType string `json:"subagent_type"`
+							}
+							_ = json.Unmarshal(part.ToolCall.InputJSON, &parsed)
 							agentCalls[part.ToolCall.ID] = agentCall{
-								parentGenID: gen.ID,
-								parentGen:   gen,
+								parentGenID:  gen.ID,
+								parentGen:    gen,
+								subagentType: strings.ToLower(parsed.SubagentType),
 							}
 						}
 					}
@@ -178,12 +185,17 @@ func synthesiseSubagentGens(line transcript.Line, uctx *userContext, calls map[s
 
 			completedAt, _ := time.Parse(time.RFC3339Nano, line.Timestamp)
 
+			suffix := ac.subagentType
+			if suffix == "" {
+				suffix = "subagent"
+			}
+
 			gen := sigil.Generation{
 				ID:                  subagentGenID(opts.SessionID, part.ToolResult.ToolCallID),
 				ConversationID:      opts.SessionID,
 				ConversationTitle:   opts.SessionID,
 				ParentGenerationIDs: []string{ac.parentGenID},
-				AgentName:           agentName + "/subagent",
+				AgentName:           agentName + "/" + suffix,
 				AgentVersion:        ac.parentGen.AgentVersion,
 				EffectiveVersion:    ac.parentGen.EffectiveVersion,
 				Mode:                sigil.GenerationModeSync,

--- a/plugins/claude-code/internal/mapper/mapper_test.go
+++ b/plugins/claude-code/internal/mapper/mapper_test.go
@@ -741,6 +741,90 @@ func TestProcess_ParentGenerationIDs(t *testing.T) {
 			wantGenCount: 2,
 			wantParents:  nil,
 		},
+		{
+			name: "subagent_type lowercase",
+			lines: []transcript.Line{
+				makeUserLine("explore"),
+				makeAssistantLine("claude-sonnet-4-20250514", 30, []transcript.ContentBlock{
+					{Type: "tool_use", ID: "agent_gp", Name: "Agent", Input: json.RawMessage(`{"subagent_type":"general-purpose","description":"test"}`)},
+				}, "tool_use"),
+				makeToolResultLine("agent_gp", "result"),
+				makeAssistantLine("claude-sonnet-4-20250514", 40, []transcript.ContentBlock{
+					{Type: "text", Text: "done"},
+				}, "end_turn"),
+			},
+			wantGenCount:   3,
+			wantParents:    map[int][]int{1: {0}},
+			wantAgentNames: map[int]string{1: "claude-code/general-purpose"},
+		},
+		{
+			name: "subagent_type PascalCase lowercased",
+			lines: []transcript.Line{
+				makeUserLine("explore"),
+				makeAssistantLine("claude-sonnet-4-20250514", 30, []transcript.ContentBlock{
+					{Type: "tool_use", ID: "agent_ex", Name: "Agent", Input: json.RawMessage(`{"subagent_type":"Explore","description":"…"}`)},
+				}, "tool_use"),
+				makeToolResultLine("agent_ex", "result"),
+				makeAssistantLine("claude-sonnet-4-20250514", 40, []transcript.ContentBlock{
+					{Type: "text", Text: "done"},
+				}, "end_turn"),
+			},
+			wantGenCount:   3,
+			wantParents:    map[int][]int{1: {0}},
+			wantAgentNames: map[int]string{1: "claude-code/explore"},
+		},
+		{
+			name: "plugin-namespaced subagent_type preserved verbatim",
+			lines: []transcript.Line{
+				makeUserLine("create agent"),
+				makeAssistantLine("claude-sonnet-4-20250514", 30, []transcript.ContentBlock{
+					{Type: "tool_use", ID: "agent_plug", Name: "Agent", Input: json.RawMessage(`{"subagent_type":"plugin-dev:agent-creator","description":"…"}`)},
+				}, "tool_use"),
+				makeToolResultLine("agent_plug", "result"),
+				makeAssistantLine("claude-sonnet-4-20250514", 40, []transcript.ContentBlock{
+					{Type: "text", Text: "done"},
+				}, "end_turn"),
+			},
+			wantGenCount:   3,
+			wantParents:    map[int][]int{1: {0}},
+			wantAgentNames: map[int]string{1: "claude-code/plugin-dev:agent-creator"},
+		},
+		{
+			name: "empty subagent_type falls back",
+			lines: []transcript.Line{
+				makeUserLine("call agent"),
+				makeAssistantLine("claude-sonnet-4-20250514", 30, []transcript.ContentBlock{
+					{Type: "tool_use", ID: "agent_empty", Name: "Agent", Input: json.RawMessage(`{"subagent_type":"","description":"test"}`)},
+				}, "tool_use"),
+				makeToolResultLine("agent_empty", "result"),
+				makeAssistantLine("claude-sonnet-4-20250514", 40, []transcript.ContentBlock{
+					{Type: "text", Text: "done"},
+				}, "end_turn"),
+			},
+			wantGenCount:   3,
+			wantParents:    map[int][]int{1: {0}},
+			wantAgentNames: map[int]string{1: "claude-code/subagent"},
+		},
+		{
+			// json.Marshal validates RawMessage syntactically, so genuinely
+			// malformed bytes can't survive the assistant-message round-trip.
+			// Use a valid-JSON-but-wrong-shape input (array) to exercise the
+			// json.Unmarshal error fallback in mapper.go.
+			name: "unparseable subagent_type input falls back",
+			lines: []transcript.Line{
+				makeUserLine("call agent"),
+				makeAssistantLine("claude-sonnet-4-20250514", 30, []transcript.ContentBlock{
+					{Type: "tool_use", ID: "agent_bad", Name: "Agent", Input: json.RawMessage(`[]`)},
+				}, "tool_use"),
+				makeToolResultLine("agent_bad", "result"),
+				makeAssistantLine("claude-sonnet-4-20250514", 40, []transcript.ContentBlock{
+					{Type: "text", Text: "done"},
+				}, "end_turn"),
+			},
+			wantGenCount:   3,
+			wantParents:    map[int][]int{1: {0}},
+			wantAgentNames: map[int]string{1: "claude-code/subagent"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Subagent generations all shared the `claude-code/subagent` name. This PR parses `subagent_type` from the Agent `tool_use` input and use the lowercased value as the suffix (`claude-code/<subagent_type>`, for example `claude-code/explore` or `claude-code/plan`), falling back to `claude-code/subagent` when the field is missing or empty:

<img width="292" height="179" alt="image" src="https://github.com/user-attachments/assets/adbc3e4f-8b3f-4032-8085-727129cf0e64" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only how synthetic subagent generations are labeled (via `AgentName`), with fallback behavior and expanded tests; no changes to core parsing, redaction, or persistence logic.
> 
> **Overview**
> **Subagent generations are now named using the Agent call’s `subagent_type`.** The mapper parses `subagent_type` from `Agent` `tool_use` input, lowercases it, and uses it as the `AgentName` suffix (e.g., `claude-code/explore`), falling back to `claude-code/subagent` when missing/empty or unparseable.
> 
> **Tests are expanded** to cover lowercase/PascalCase inputs, plugin-namespaced types, empty values, and invalid JSON shapes to ensure the fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fce49f12cbcef66a5eadd2606e0755712e3456b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->