### PR TITLE
feat(sdk-go): built-in secret redaction sanitizer

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -190,6 +190,40 @@ Common topology:
 - Traces/metrics via OTEL Collector/Alloy: configure exporters in your app OTEL SDK setup.
 - Enterprise proxy: generation `bearer` mode to proxy; proxy authenticates and forwards tenant header upstream.
 
+## Pre-Ingest Redaction
+
+Use `GenerationSanitizer` when you want to redact substrings from normalized generations before validation, span sync, and export.
+
+```go
+redactEmails := true
+cfg := sigil.DefaultConfig()
+cfg.GenerationSanitizer = sigil.NewSecretRedactionSanitizer(sigil.SecretRedactionOptions{
+    RedactInputMessages:  false,         // also redact user messages in Generation.Input
+    RedactEmailAddresses: &redactEmails, // nil defaults to true; point to false to preserve
+})
+
+client := sigil.NewClient(cfg)
+```
+
+The built-in sanitizer:
+
+- redacts high-confidence secret formats in assistant text and thinking
+- redacts secret formats plus env-style secret values in tool call inputs and tool results
+- redacts email addresses by default
+- redacts historic assistant turns and tool messages in `Generation.Input`
+- leaves user messages in `Generation.Input` unchanged unless `RedactInputMessages: true` is set
+
+To preserve email addresses, opt out explicitly:
+
+```go
+preserveEmails := false
+cfg.GenerationSanitizer = sigil.NewSecretRedactionSanitizer(sigil.SecretRedactionOptions{
+    RedactEmailAddresses: &preserveEmails,
+})
+```
+
+If a sanitizer panics during `Recorder.End`, the SDK falls back to `ContentCaptureModeMetadataOnly` for that generation and logs a warning via `Config.Logger`, so a partially redacted payload is never shipped.
+
 ## Conversation Ratings
 
 Use the SDK helper to submit user-facing ratings:

--- a/go/sigil/client.go
+++ b/go/sigil/client.go
@@ -48,6 +48,18 @@ type Config struct {
 	// Panics are recovered and treated as ContentCaptureModeMetadataOnly
 	// (fail-closed).
 	ContentCaptureResolver func(ctx context.Context, metadata map[string]any) ContentCaptureMode
+	// GenerationSanitizer, when set, is invoked on each generation in
+	// GenerationRecorder.End after normalization and trace-context application,
+	// but before content-capture stripping and metadata stamping. The sanitizer
+	// may mutate strings or payloads (e.g. redact secrets) but must preserve
+	// message and part structure.
+	//
+	// If the sanitizer panics the SDK downgrades the generation's content
+	// capture mode to ContentCaptureModeMetadataOnly so that no partially
+	// redacted payload is shipped, and logs a warning via Config.Logger.
+	//
+	// Use NewSecretRedactionSanitizer for the built-in regex-based redactor.
+	GenerationSanitizer GenerationSanitizer
 	// Tracer is optional and mainly used for tests. If nil, the client uses the global OpenTelemetry tracer.
 	Tracer trace.Tracer
 	// Meter is optional and mainly used for tests. If nil, the client uses the global OpenTelemetry meter.
@@ -810,6 +822,22 @@ func (r *GenerationRecorder) End() {
 	normalized := r.normalizeGeneration(generation, completedAt, callErr)
 	applyTraceContextFromSpan(r.span, &normalized)
 
+	sanitizerRan := false
+	if r.client.config.GenerationSanitizer != nil && r.contentCaptureMode != ContentCaptureModeMetadataOnly {
+		sanitizerRan = true
+		sanitized, panicked := r.applyGenerationSanitizer(normalized)
+		if panicked {
+			r.contentCaptureMode = ContentCaptureModeMetadataOnly
+		} else {
+			normalized = sanitized
+		}
+	}
+
+	// Mirror the (possibly redacted) canonical fields back into the metadata
+	// keys that downstream readers and the span attribute layer consume, so a
+	// successful sanitizer pass cannot leak via Metadata.
+	syncCanonicalMetadataMirrors(&normalized)
+
 	stampContentCaptureMetadata(&normalized, r.contentCaptureMode)
 	if r.contentCaptureMode == ContentCaptureModeMetadataOnly {
 		stripContent(&normalized, classifyErrorCategory(callErr, false))
@@ -817,6 +845,12 @@ func (r *GenerationRecorder) End() {
 
 	r.span.SetName(generationSpanName(normalized))
 	r.span.SetAttributes(generationSpanAttributes(normalized)...)
+	if sanitizerRan {
+		// The start span published the raw seed title; overwrite with the
+		// post-sanitizer/strip value so a sanitizer that empties or rewrites
+		// the title doesn't leave the raw value on the span.
+		r.span.SetAttributes(attribute.String(spanAttrConversationTitle, normalized.ConversationTitle))
+	}
 
 	r.mu.Lock()
 	r.lastGeneration = cloneGeneration(normalized)
@@ -824,9 +858,15 @@ func (r *GenerationRecorder) End() {
 
 	enqueueErr := r.client.persistGeneration(normalized)
 
-	// Record errors on span.
+	// Record errors on span. Use normalized.CallError (post-sanitization, post-
+	// strip) for the provider call error so secrets the sanitizer redacted, or
+	// strip replaced with a category, don't leak via exception events.
 	if callErr != nil {
-		r.span.RecordError(callErr)
+		spanErr := callErr
+		if normalized.CallError != callErr.Error() {
+			spanErr = errors.New(normalized.CallError)
+		}
+		r.span.RecordError(spanErr)
 	}
 	if mapErr != nil {
 		r.span.RecordError(mapErr)
@@ -846,7 +886,7 @@ func (r *GenerationRecorder) End() {
 
 	switch {
 	case callErr != nil:
-		r.span.SetStatus(codes.Error, callErr.Error())
+		r.span.SetStatus(codes.Error, normalized.CallError)
 	case mapErr != nil:
 		r.span.SetStatus(codes.Error, mapErr.Error())
 	case enqueueErr != nil:
@@ -872,6 +912,41 @@ func (r *GenerationRecorder) Err() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.finalErr
+}
+
+// applyGenerationSanitizer invokes Config.GenerationSanitizer with panic
+// recovery. On panic it logs a warning and returns panicked=true so the caller
+// can downgrade content capture mode.
+func (r *GenerationRecorder) applyGenerationSanitizer(g Generation) (sanitized Generation, panicked bool) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			panicked = true
+			if r.client.config.Logger != nil {
+				r.client.config.Logger.Printf("sigil: generation sanitization failed, falling back to metadata_only: %v", rec)
+			}
+		}
+	}()
+	return r.client.config.GenerationSanitizer(g), false
+}
+
+// syncCanonicalMetadataMirrors propagates the canonical ConversationTitle and
+// CallError values into the metadata keys that span attribute extraction and
+// downstream readers consume. Run after the sanitizer so redactions on the
+// canonical fields are reflected in the mirrors before export.
+func syncCanonicalMetadataMirrors(g *Generation) {
+	if g.Metadata == nil {
+		return
+	}
+	if g.ConversationTitle != "" {
+		g.Metadata[spanAttrConversationTitle] = g.ConversationTitle
+	} else {
+		delete(g.Metadata, spanAttrConversationTitle)
+	}
+	if g.CallError != "" {
+		g.Metadata["call_error"] = g.CallError
+	} else {
+		delete(g.Metadata, "call_error")
+	}
 }
 
 // SetCallError records a provider/network call error.

--- a/go/sigil/redaction.go
+++ b/go/sigil/redaction.go
@@ -1,0 +1,275 @@
+package sigil
+
+import (
+	"regexp"
+	"strings"
+)
+
+// GenerationSanitizer mutates a generation before export. Sanitizers receive
+// the fully normalized Generation and return the version to ship. Implementations
+// may mutate strings/payloads (e.g. redact secrets) but must preserve message
+// and part structure.
+//
+// If a sanitizer panics during Recorder.End the SDK downgrades the generation's
+// content capture mode to ContentCaptureModeMetadataOnly and logs a warning.
+type GenerationSanitizer func(Generation) Generation
+
+// SecretRedactionOptions configures the built-in secret-redaction sanitizer.
+type SecretRedactionOptions struct {
+	// RedactInputMessages, when true, also sanitizes user messages in
+	// Generation.Input. Assistant and tool messages in Input are sanitized
+	// regardless because they typically replay tool results and prior model
+	// output that share the same secret surface as Generation.Output.
+	RedactInputMessages bool
+	// RedactEmailAddresses, when non-nil, sets whether email addresses are
+	// redacted. Nil defaults to true (redact). Set to a pointer to false to
+	// preserve email addresses verbatim.
+	RedactEmailAddresses *bool
+}
+
+type secretPattern struct {
+	id string
+	re *regexp.Regexp
+}
+
+// tier1Patterns covers high-confidence secret formats. Applied by both the
+// full and lightweight redactors.
+var tier1Patterns = []secretPattern{
+	{"grafana-cloud-token", regexp.MustCompile(`\bglc_[A-Za-z0-9_-]{20,}`)},
+	{"grafana-service-account-token", regexp.MustCompile(`\bglsa_[A-Za-z0-9_-]{20,}`)},
+	{"aws-access-token", regexp.MustCompile(`\b(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z2-7]{16}\b`)},
+	{"github-pat", regexp.MustCompile(`\bghp_[A-Za-z0-9_]{36,}`)},
+	{"github-oauth", regexp.MustCompile(`\bgho_[A-Za-z0-9_]{36,}`)},
+	{"github-app-token", regexp.MustCompile(`\bghs_[A-Za-z0-9_]{36,}`)},
+	{"github-fine-grained-pat", regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{82}`)},
+	{"anthropic-api-key", regexp.MustCompile(`\bsk-ant-api03-[a-zA-Z0-9_-]{93}AA`)},
+	{"anthropic-admin-key", regexp.MustCompile(`\bsk-ant-admin01-[a-zA-Z0-9_-]{93}AA`)},
+	{"openai-api-key", regexp.MustCompile(`\bsk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20}`)},
+	{"openai-project-key", regexp.MustCompile(`\bsk-proj-[a-zA-Z0-9_-]{40,}`)},
+	{"openai-svcacct-key", regexp.MustCompile(`\bsk-svcacct-[a-zA-Z0-9_-]{40,}`)},
+	{"gcp-api-key", regexp.MustCompile(`\bAIza[A-Za-z0-9_-]{35}`)},
+	{"private-key", regexp.MustCompile(`-----BEGIN[A-Z ]*PRIVATE KEY-----[\s\S]*?-----END[A-Z ]*PRIVATE KEY-----`)},
+	{"connection-string", regexp.MustCompile(`(?:postgres|mysql|mongodb|redis|amqp)://[^\s'"]+@[^\s'"]+`)},
+	{"bearer-token", regexp.MustCompile(`[Bb]earer\s+[A-Za-z0-9_.\-~+/]{20,}={0,3}`)},
+	{"slack-token", regexp.MustCompile(`\bxox[bporas]-[A-Za-z0-9-]{10,}`)},
+	{"stripe-key", regexp.MustCompile(`\b[sr]k_(?:live|test)_[A-Za-z0-9]{20,}`)},
+	{"sendgrid-api-key", regexp.MustCompile(`\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}`)},
+	{"twilio-api-key", regexp.MustCompile(`\bSK[a-f0-9]{32}`)},
+	{"npm-token", regexp.MustCompile(`\bnpm_[A-Za-z0-9]{36}`)},
+	{"pypi-token", regexp.MustCompile(`\bpypi-[A-Za-z0-9_-]{50,}`)},
+}
+
+// tier1Combined alternates all tier1Patterns into a single regex so each input
+// is scanned once instead of once per pattern. Each pattern is wrapped in a
+// capturing group; the matched group index identifies which pattern fired.
+var tier1Combined = func() *regexp.Regexp {
+	parts := make([]string, len(tier1Patterns))
+	for i, p := range tier1Patterns {
+		parts[i] = "(" + p.re.String() + ")"
+	}
+	return regexp.MustCompile(strings.Join(parts, "|"))
+}()
+
+// emailPattern is toggleable via SecretRedactionOptions.RedactEmailAddresses.
+var emailPattern = secretPattern{
+	id: "email",
+	re: regexp.MustCompile(`(?i)\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b`),
+}
+
+// envSecretPattern covers heuristic env-style key/value assignments. Applied
+// only by the full redactor (skipped for assistant text/thinking in
+// lightweight mode) to avoid mangling natural-language strings.
+var envSecretPattern = secretPattern{
+	id: "env-secret-value",
+	re: regexp.MustCompile(`(?i)((?:PASSWORD|SECRET|TOKEN|KEY|CREDENTIAL|API_KEY|PRIVATE_KEY|ACCESS_KEY)\s*[=:]\s*)([^\s"{}\[\],]+)`),
+}
+
+// redactFull applies tier 1, optional email, and env-style patterns. Use for
+// tool-call args, tool-result content, system prompts, and any field where
+// arbitrary content can be expected (env dumps, shell output).
+func redactFull(s string, includeEmail bool) string {
+	s = redactTier1String(s)
+	if includeEmail {
+		s = emailPattern.re.ReplaceAllString(s, "[REDACTED:"+emailPattern.id+"]")
+	}
+	return envSecretPattern.re.ReplaceAllString(s, "${1}[REDACTED:"+envSecretPattern.id+"]")
+}
+
+// redactLight applies tier 1 and optional email patterns only. Use for
+// assistant text and reasoning, where env-style heuristics would cause too many
+// false positives, and for short metadata strings (titles, error messages).
+func redactLight(s string, includeEmail bool) string {
+	s = redactTier1String(s)
+	if includeEmail {
+		s = emailPattern.re.ReplaceAllString(s, "[REDACTED:"+emailPattern.id+"]")
+	}
+	return s
+}
+
+// redactFullBytes is the []byte form of redactFull; it operates on the source
+// slice directly so JSON payloads avoid a string round-trip.
+func redactFullBytes(src []byte, includeEmail bool) []byte {
+	src = redactTier1Bytes(src)
+	if includeEmail {
+		src = emailPattern.re.ReplaceAll(src, []byte("[REDACTED:"+emailPattern.id+"]"))
+	}
+	return envSecretPattern.re.ReplaceAll(src, []byte("${1}[REDACTED:"+envSecretPattern.id+"]"))
+}
+
+func redactTier1String(s string) string {
+	matches := tier1Combined.FindAllStringSubmatchIndex(s, -1)
+	if len(matches) == 0 {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	last := 0
+	for _, m := range matches {
+		b.WriteString(s[last:m[0]])
+		for g := 1; g <= len(tier1Patterns); g++ {
+			if m[2*g] >= 0 {
+				b.WriteString("[REDACTED:")
+				b.WriteString(tier1Patterns[g-1].id)
+				b.WriteByte(']')
+				break
+			}
+		}
+		last = m[1]
+	}
+	b.WriteString(s[last:])
+	return b.String()
+}
+
+func redactTier1Bytes(src []byte) []byte {
+	matches := tier1Combined.FindAllSubmatchIndex(src, -1)
+	if len(matches) == 0 {
+		return src
+	}
+	out := make([]byte, 0, len(src))
+	last := 0
+	for _, m := range matches {
+		out = append(out, src[last:m[0]]...)
+		for g := 1; g <= len(tier1Patterns); g++ {
+			if m[2*g] >= 0 {
+				out = append(out, "[REDACTED:"...)
+				out = append(out, tier1Patterns[g-1].id...)
+				out = append(out, ']')
+				break
+			}
+		}
+		last = m[1]
+	}
+	out = append(out, src[last:]...)
+	return out
+}
+
+// NewSecretRedactionSanitizer returns a GenerationSanitizer that redacts
+// known secret formats from generation content. The returned sanitizer is
+// safe for concurrent use.
+//
+// By default it redacts Generation.Output (assistant + tool), Generation.SystemPrompt,
+// Generation.ConversationTitle, Generation.CallError, and the assistant /
+// tool messages in Generation.Input. User messages in Generation.Input are
+// only redacted when RedactInputMessages is set. Email redaction is on unless
+// RedactEmailAddresses points to false.
+func NewSecretRedactionSanitizer(opts SecretRedactionOptions) GenerationSanitizer {
+	includeEmail := opts.RedactEmailAddresses == nil || *opts.RedactEmailAddresses
+	redactInputs := opts.RedactInputMessages
+
+	return func(g Generation) Generation {
+		if g.SystemPrompt != "" {
+			g.SystemPrompt = redactFull(g.SystemPrompt, includeEmail)
+		}
+		// ConversationTitle and CallError are short natural-language strings;
+		// lightweight redaction (tier 1 + email) avoids mangling them with the
+		// env-style heuristic.
+		if g.ConversationTitle != "" {
+			g.ConversationTitle = redactLight(g.ConversationTitle, includeEmail)
+		}
+		if g.CallError != "" {
+			g.CallError = redactLight(g.CallError, includeEmail)
+		}
+
+		for i := range g.Input {
+			sanitizeMessage(&g.Input[i], inputTextMode(g.Input[i].Role, redactInputs), includeEmail)
+		}
+
+		for i := range g.Output {
+			sanitizeMessage(&g.Output[i], outputTextMode(g.Output[i].Role), includeEmail)
+		}
+
+		return g
+	}
+}
+
+// textMode is which tier to apply to PartKindText for a given role; thinking,
+// tool-call, and tool-result parts use a fixed tier regardless.
+type textMode int
+
+const (
+	textModeSkip textMode = iota
+	textModeLight
+	textModeFull
+)
+
+// inputTextMode picks the tier for an Input message's text part. Historic
+// assistant turns and tool results in Input always get role-aware redaction;
+// user text is only redacted when the caller opts in.
+func inputTextMode(role Role, redactUserInput bool) textMode {
+	switch role {
+	case RoleUser:
+		if redactUserInput {
+			return textModeFull
+		}
+		return textModeSkip
+	case RoleTool:
+		return textModeFull
+	case RoleAssistant:
+		return textModeLight
+	default:
+		return textModeSkip
+	}
+}
+
+func outputTextMode(role Role) textMode {
+	switch role {
+	case RoleAssistant:
+		return textModeLight
+	case RoleTool:
+		return textModeFull
+	default:
+		return textModeSkip
+	}
+}
+
+func sanitizeMessage(m *Message, mode textMode, includeEmail bool) {
+	if mode == textModeSkip {
+		return
+	}
+	for i := range m.Parts {
+		p := &m.Parts[i]
+		switch p.Kind {
+		case PartKindText:
+			if mode == textModeFull {
+				p.Text = redactFull(p.Text, includeEmail)
+			} else {
+				p.Text = redactLight(p.Text, includeEmail)
+			}
+		case PartKindThinking:
+			p.Thinking = redactLight(p.Thinking, includeEmail)
+		case PartKindToolCall:
+			if p.ToolCall != nil && len(p.ToolCall.InputJSON) > 0 {
+				p.ToolCall.InputJSON = redactFullBytes(p.ToolCall.InputJSON, includeEmail)
+			}
+		case PartKindToolResult:
+			if p.ToolResult != nil {
+				if p.ToolResult.Content != "" {
+					p.ToolResult.Content = redactFull(p.ToolResult.Content, includeEmail)
+				}
+				if len(p.ToolResult.ContentJSON) > 0 {
+					p.ToolResult.ContentJSON = redactFullBytes(p.ToolResult.ContentJSON, includeEmail)
+				}
+			}
+		}
+	}
+}

--- a/go/sigil/redaction_test.go
+++ b/go/sigil/redaction_test.go
@@ -1,0 +1,488 @@
+package sigil
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"strings"
+	"testing"
+)
+
+func TestSecretRedactionSanitizerRedactsAssistantAndToolOutputByDefault(t *testing.T) {
+	client, _, _ := newTestClient(t, Config{
+		GenerationSanitizer: NewSecretRedactionSanitizer(SecretRedactionOptions{}),
+	})
+
+	secretToken := "glc_abcdefghijklmnopqrstuvwxyz1234"
+	envSecret := "DATABASE_PASSWORD=hunter2secret123"
+	bearerToken := strings.Repeat("a", 30)
+	historicBearer := strings.Repeat("h", 30)
+	historicEnv := "API_TOKEN=historicvalue9876"
+
+	_, rec := client.StartGeneration(context.Background(), GenerationStart{
+		Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+	})
+	rec.SetResult(Generation{
+		Input: []Message{
+			{Role: RoleUser, Parts: []Part{{Kind: PartKindText, Text: "user pasted " + secretToken}}},
+			{Role: RoleAssistant, Parts: []Part{
+				{Kind: PartKindText, Text: "previous turn mentioned " + secretToken},
+				{Kind: PartKindToolCall, ToolCall: &ToolCall{
+					ID:        "prev-call",
+					Name:      "bash",
+					InputJSON: json.RawMessage(`{"header":"Bearer ` + historicBearer + `"}`),
+				}},
+			}},
+			{Role: RoleTool, Parts: []Part{
+				{Kind: PartKindToolResult, ToolResult: &ToolResult{
+					ToolCallID: "prev-call",
+					Name:       "bash",
+					Content:    "previous output " + historicEnv,
+				}},
+			}},
+		},
+		Output: []Message{
+			{Role: RoleAssistant, Parts: []Part{
+				{Kind: PartKindText, Text: "assistant saw " + secretToken},
+				{Kind: PartKindThinking, Thinking: "thinking about " + secretToken},
+				{Kind: PartKindToolCall, ToolCall: &ToolCall{
+					ID:        "call-1",
+					Name:      "bash",
+					InputJSON: json.RawMessage(`{"header":"Bearer ` + bearerToken + `","env":"` + envSecret + `"}`),
+				}},
+			}},
+			{Role: RoleTool, Parts: []Part{
+				{Kind: PartKindToolResult, ToolResult: &ToolResult{
+					ToolCallID: "call-1",
+					Name:       "bash",
+					Content:    "output " + envSecret,
+				}},
+			}},
+		},
+		Usage: TokenUsage{InputTokens: 1, OutputTokens: 1},
+	}, nil)
+	rec.End()
+
+	if err := rec.Err(); err != nil {
+		t.Fatalf("recorder error: %v", err)
+	}
+
+	gen := rec.lastGeneration
+	if !strings.Contains(gen.Input[0].Parts[0].Text, "glc_") {
+		t.Errorf("user input was redacted; expected unchanged. got %q", gen.Input[0].Parts[0].Text)
+	}
+	if strings.Contains(gen.Input[1].Parts[0].Text, "glc_") {
+		t.Errorf("historic assistant text not redacted: %q", gen.Input[1].Parts[0].Text)
+	}
+	historicToolCall := string(gen.Input[1].Parts[1].ToolCall.InputJSON)
+	if strings.Contains(historicToolCall, "Bearer "+historicBearer) {
+		t.Errorf("historic tool-call bearer not redacted: %q", historicToolCall)
+	}
+	historicToolResult := gen.Input[2].Parts[0].ToolResult.Content
+	if strings.Contains(historicToolResult, "historicvalue9876") {
+		t.Errorf("historic tool-result env secret not redacted: %q", historicToolResult)
+	}
+	if strings.Contains(gen.Output[0].Parts[0].Text, "glc_") {
+		t.Errorf("assistant text not redacted: %q", gen.Output[0].Parts[0].Text)
+	}
+	if !strings.Contains(gen.Output[0].Parts[0].Text, "[REDACTED:grafana-cloud-token]") {
+		t.Errorf("assistant text missing redaction marker: %q", gen.Output[0].Parts[0].Text)
+	}
+	if strings.Contains(gen.Output[0].Parts[1].Thinking, "glc_") {
+		t.Errorf("thinking not redacted: %q", gen.Output[0].Parts[1].Thinking)
+	}
+	toolCallInput := string(gen.Output[0].Parts[2].ToolCall.InputJSON)
+	if strings.Contains(toolCallInput, "hunter2secret123") {
+		t.Errorf("tool-call env secret not redacted: %q", toolCallInput)
+	}
+	if strings.Contains(toolCallInput, "Bearer "+bearerToken) {
+		t.Errorf("tool-call bearer not redacted: %q", toolCallInput)
+	}
+	if !strings.Contains(toolCallInput, "[REDACTED:") {
+		t.Errorf("tool-call missing redaction marker: %q", toolCallInput)
+	}
+	toolResult := gen.Output[1].Parts[0].ToolResult.Content
+	if strings.Contains(toolResult, "hunter2secret123") {
+		t.Errorf("tool-result env secret not redacted: %q", toolResult)
+	}
+	if !strings.Contains(toolResult, "[REDACTED:env-secret-value]") {
+		t.Errorf("tool-result missing env-secret-value marker: %q", toolResult)
+	}
+}
+
+func TestSecretRedactionSanitizerEmailToggle(t *testing.T) {
+	const text = "Send me an email to example@example.com"
+
+	cases := []struct {
+		name         string
+		opts         SecretRedactionOptions
+		wantMarker   bool
+		wantPreserve bool
+	}{
+		{name: "default redacts email", opts: SecretRedactionOptions{}, wantMarker: true},
+		{name: "disable preserves email", opts: SecretRedactionOptions{RedactEmailAddresses: boolPtr(false)}, wantPreserve: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sanitizer := NewSecretRedactionSanitizer(tc.opts)
+			got := sanitizer(Generation{
+				Output: []Message{{
+					Role:  RoleAssistant,
+					Parts: []Part{{Kind: PartKindText, Text: text}},
+				}},
+			}).Output[0].Parts[0].Text
+
+			if tc.wantPreserve {
+				if got != text {
+					t.Errorf("email should be preserved, got %q", got)
+				}
+				return
+			}
+			if strings.Contains(got, "example@example.com") {
+				t.Errorf("email not redacted: %q", got)
+			}
+			if tc.wantMarker && !strings.Contains(got, "[REDACTED:email]") {
+				t.Errorf("email marker missing: %q", got)
+			}
+		})
+	}
+}
+
+func TestSecretRedactionSanitizerInputRedactionByRole(t *testing.T) {
+	secretToken := "glc_abcdefghijklmnopqrstuvwxyz1234"
+	envSecret := "DATABASE_PASSWORD=hunter2secret123"
+	bearerToken := strings.Repeat("a", 30)
+
+	build := func() Generation {
+		return Generation{
+			ID:    "gen-1",
+			Mode:  GenerationModeSync,
+			Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+			Input: []Message{
+				{Role: RoleUser, Parts: []Part{{Kind: PartKindText, Text: "user pasted " + secretToken}}},
+				{Role: RoleAssistant, Parts: []Part{
+					{Kind: PartKindText, Text: "assistant response with " + secretToken},
+					{Kind: PartKindToolCall, ToolCall: &ToolCall{
+						ID:        "call-1",
+						Name:      "bash",
+						InputJSON: json.RawMessage(`{"header":"Bearer ` + bearerToken + `"}`),
+					}},
+				}},
+				{Role: RoleTool, Parts: []Part{
+					{Kind: PartKindToolResult, ToolResult: &ToolResult{
+						ToolCallID: "call-1",
+						Name:       "bash",
+						Content:    "output " + envSecret,
+					}},
+				}},
+			},
+		}
+	}
+
+	cases := []struct {
+		name             string
+		opts             SecretRedactionOptions
+		wantUserRedacted bool
+	}{
+		{name: "default preserves user only", opts: SecretRedactionOptions{}, wantUserRedacted: false},
+		{name: "opt-in redacts user too", opts: SecretRedactionOptions{RedactInputMessages: true}, wantUserRedacted: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sanitized := NewSecretRedactionSanitizer(tc.opts)(build())
+
+			userText := sanitized.Input[0].Parts[0].Text
+			if tc.wantUserRedacted {
+				if strings.Contains(userText, secretToken) {
+					t.Errorf("user input not redacted: %q", userText)
+				}
+				if !strings.Contains(userText, "[REDACTED:grafana-cloud-token]") {
+					t.Errorf("user input missing marker: %q", userText)
+				}
+			} else if !strings.Contains(userText, secretToken) {
+				t.Errorf("user input should be unchanged, got %q", userText)
+			}
+
+			assistantText := sanitized.Input[1].Parts[0].Text
+			if strings.Contains(assistantText, secretToken) {
+				t.Errorf("assistant text not redacted: %q", assistantText)
+			}
+			toolCall := string(sanitized.Input[1].Parts[1].ToolCall.InputJSON)
+			if strings.Contains(toolCall, "Bearer "+bearerToken) {
+				t.Errorf("assistant tool-call bearer not redacted: %q", toolCall)
+			}
+			toolResult := sanitized.Input[2].Parts[0].ToolResult.Content
+			if strings.Contains(toolResult, "hunter2secret123") {
+				t.Errorf("tool result env secret not redacted: %q", toolResult)
+			}
+		})
+	}
+}
+
+func TestSecretRedactionPatterns(t *testing.T) {
+	sanitizer := NewSecretRedactionSanitizer(SecretRedactionOptions{})
+
+	cases := []struct {
+		id    string
+		value string
+	}{
+		{"grafana-cloud-token", "glc_abcdefghijklmnopqrstuvwxyz1234"},
+		{"grafana-service-account-token", "glsa_abcdefghijklmnopqrstuvwxyz1234"},
+		{"aws-access-token", "AKIAIOSFODNN7EXAMPLE"},
+		{"github-pat", "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		{"github-oauth", "gho_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		{"github-app-token", "ghs_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		{"github-fine-grained-pat", "github_pat_" + strings.Repeat("a", 82)},
+		{"anthropic-api-key", "sk-ant-api03-" + strings.Repeat("a", 93) + "AA"},
+		{"anthropic-admin-key", "sk-ant-admin01-" + strings.Repeat("a", 93) + "AA"},
+		{"openai-api-key", "sk-" + strings.Repeat("a", 20) + "T3BlbkFJ" + strings.Repeat("b", 20)},
+		{"openai-project-key", "sk-proj-" + strings.Repeat("a", 40)},
+		{"openai-svcacct-key", "sk-svcacct-" + strings.Repeat("a", 40)},
+		{"gcp-api-key", "AIza" + strings.Repeat("a", 35)},
+		{"private-key", "-----BEGIN RSA PRIVATE KEY-----\nfake-test-body\n-----END RSA PRIVATE KEY-----"},
+		{"connection-string", "postgres://user:password@db.example.com:5432/app"},
+		{"bearer-token", "Bearer " + strings.Repeat("a", 30)},
+		{"slack-token", "xoxb-" + strings.Repeat("a", 20)},
+		{"stripe-key", "sk_live_" + strings.Repeat("a", 24)},
+		{"sendgrid-api-key", "SG." + strings.Repeat("a", 22) + "." + strings.Repeat("b", 43)},
+		{"twilio-api-key", "SK" + strings.Repeat("a", 32)},
+		{"npm-token", "npm_" + strings.Repeat("a", 36)},
+		{"pypi-token", "pypi-" + strings.Repeat("a", 50)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			input := "prefix " + tc.value + " suffix"
+			gen := sanitizer(Generation{
+				ID:    "gen-1",
+				Mode:  GenerationModeSync,
+				Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+				Output: []Message{{
+					Role:  RoleTool,
+					Parts: []Part{{Kind: PartKindToolResult, ToolResult: &ToolResult{Content: input}}},
+				}},
+			})
+
+			got := gen.Output[0].Parts[0].ToolResult.Content
+			marker := "[REDACTED:" + tc.id + "]"
+			if !strings.Contains(got, marker) {
+				t.Errorf("missing marker %q in %q", marker, got)
+			}
+			if strings.Contains(got, tc.value) {
+				t.Errorf("raw value %q still present in %q", tc.value, got)
+			}
+		})
+	}
+}
+
+func TestGenerationSanitizerPanic(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+
+	titleSecret := "glc_abcdefghijklmnopqrstuvwxyz1234"
+
+	client, recorder, _ := newTestClient(t, Config{
+		Logger: logger,
+		GenerationSanitizer: func(_ Generation) Generation {
+			panic("boom")
+		},
+	})
+
+	_, rec := client.StartGeneration(context.Background(), GenerationStart{
+		Model:             ModelRef{Provider: "openai", Name: "gpt-5"},
+		ConversationTitle: "title with " + titleSecret,
+		SystemPrompt:      "system secret",
+	})
+	rec.SetResult(Generation{
+		Input:  []Message{{Role: RoleUser, Parts: []Part{{Kind: PartKindText, Text: "hello"}}}},
+		Output: []Message{{Role: RoleAssistant, Parts: []Part{{Kind: PartKindText, Text: "world"}}}},
+		Usage:  TokenUsage{InputTokens: 1, OutputTokens: 1},
+	}, nil)
+	rec.End()
+
+	if err := rec.Err(); err != nil {
+		t.Fatalf("recorder error: %v", err)
+	}
+	gen := rec.lastGeneration
+	span := onlyGenerationSpan(t, recorder.Ended())
+	spanAttrs := spanAttributeMap(span)
+
+	stripped := []struct {
+		name  string
+		value string
+	}{
+		{"SystemPrompt", gen.SystemPrompt},
+		{"ConversationTitle", gen.ConversationTitle},
+		{"Input text", gen.Input[0].Parts[0].Text},
+		{"Output text", gen.Output[0].Parts[0].Text},
+	}
+	for _, tc := range stripped {
+		t.Run("stripped "+tc.name, func(t *testing.T) {
+			if tc.value != "" {
+				t.Errorf("%s should be stripped, got %q", tc.name, tc.value)
+			}
+		})
+	}
+
+	t.Run("content capture mode flagged metadata_only", func(t *testing.T) {
+		if v, _ := gen.Metadata[metadataKeyContentCaptureMode].(string); v != contentCaptureModeValueMetaOnly {
+			t.Errorf("got %q", v)
+		}
+	})
+	t.Run("logger captures fallback warning", func(t *testing.T) {
+		if !strings.Contains(buf.String(), "sigil: generation sanitization failed, falling back to metadata_only") {
+			t.Errorf("missing warning: %q", buf.String())
+		}
+	})
+	t.Run("span conversation title does not leak", func(t *testing.T) {
+		if title := spanAttrs[spanAttrConversationTitle].AsString(); strings.Contains(title, titleSecret) {
+			t.Errorf("title attr leaks secret: %q", title)
+		}
+	})
+}
+
+func TestSecretRedactionSanitizerRedactsTitleAndCallErrorAcrossSinks(t *testing.T) {
+	secret := "glc_abcdefghijklmnopqrstuvwxyz1234"
+	client, recorder, _ := newTestClient(t, Config{
+		GenerationSanitizer: NewSecretRedactionSanitizer(SecretRedactionOptions{}),
+	})
+
+	_, rec := client.StartGeneration(context.Background(), GenerationStart{
+		Model:             ModelRef{Provider: "openai", Name: "gpt-5"},
+		ConversationTitle: "title with " + secret,
+	})
+	rec.SetCallError(errors.New("api failure: " + secret))
+	rec.End()
+
+	if err := rec.Err(); err != nil {
+		t.Fatalf("recorder error: %v", err)
+	}
+	gen := rec.lastGeneration
+	span := onlyGenerationSpan(t, recorder.Ended())
+	spanAttrs := spanAttributeMap(span)
+
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"canonical ConversationTitle", gen.ConversationTitle},
+		{"canonical CallError", gen.CallError},
+		{"metadata " + spanAttrConversationTitle, metaString(gen, spanAttrConversationTitle)},
+		{"metadata call_error", metaString(gen, "call_error")},
+		{"span attr " + spanAttrConversationTitle, spanAttrs[spanAttrConversationTitle].AsString()},
+		{"span status description", span.Status().Description},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if strings.Contains(tc.value, secret) {
+				t.Errorf("sink leaks secret: %q", tc.value)
+			}
+		})
+	}
+
+	t.Run("span events", func(t *testing.T) {
+		for _, ev := range span.Events() {
+			for _, attr := range ev.Attributes {
+				if strings.Contains(attr.Value.Emit(), secret) {
+					t.Errorf("event %q attr %s leaks secret: %q", ev.Name, attr.Key, attr.Value.Emit())
+				}
+			}
+		}
+	})
+
+	t.Run("mirrors match canonical", func(t *testing.T) {
+		if got := metaString(gen, spanAttrConversationTitle); got != gen.ConversationTitle {
+			t.Errorf("title mirror %q != canonical %q", got, gen.ConversationTitle)
+		}
+		if got := metaString(gen, "call_error"); got != gen.CallError {
+			t.Errorf("call_error mirror %q != canonical %q", got, gen.CallError)
+		}
+	})
+}
+
+func TestGenerationSanitizerClearingCallErrorDoesNotLeak(t *testing.T) {
+	secret := "glc_abcdefghijklmnopqrstuvwxyz1234"
+	client, recorder, _ := newTestClient(t, Config{
+		GenerationSanitizer: func(g Generation) Generation {
+			g.CallError = ""
+			return g
+		},
+	})
+
+	_, rec := client.StartGeneration(context.Background(), GenerationStart{
+		Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+	})
+	rec.SetCallError(errors.New("api failure: " + secret))
+	rec.End()
+
+	span := onlyGenerationSpan(t, recorder.Ended())
+	if got := span.Status().Description; strings.Contains(got, secret) {
+		t.Errorf("span status description leaks secret: %q", got)
+	}
+	for _, ev := range span.Events() {
+		for _, attr := range ev.Attributes {
+			if strings.Contains(attr.Value.Emit(), secret) {
+				t.Errorf("event %q attr %s leaks secret: %q", ev.Name, attr.Key, attr.Value.Emit())
+			}
+		}
+	}
+}
+
+func TestGenerationSanitizerClearingTitleDoesNotLeak(t *testing.T) {
+	secret := "glc_abcdefghijklmnopqrstuvwxyz1234"
+	client, recorder, _ := newTestClient(t, Config{
+		GenerationSanitizer: func(g Generation) Generation {
+			g.ConversationTitle = ""
+			return g
+		},
+	})
+
+	_, rec := client.StartGeneration(context.Background(), GenerationStart{
+		Model:             ModelRef{Provider: "openai", Name: "gpt-5"},
+		ConversationTitle: "title with " + secret,
+	})
+	rec.SetResult(Generation{
+		Output: []Message{{Role: RoleAssistant, Parts: []Part{{Kind: PartKindText, Text: "ok"}}}},
+		Usage:  TokenUsage{InputTokens: 1, OutputTokens: 1},
+	}, nil)
+	rec.End()
+
+	span := onlyGenerationSpan(t, recorder.Ended())
+	if got := spanAttributeMap(span)[spanAttrConversationTitle].AsString(); strings.Contains(got, secret) {
+		t.Errorf("title span attr leaks secret: %q", got)
+	}
+}
+
+func TestGenerationSanitizerSkippedInMetadataOnlyMode(t *testing.T) {
+	var calls int
+	client, _, _ := newTestClient(t, Config{
+		ContentCapture: ContentCaptureModeMetadataOnly,
+		GenerationSanitizer: func(g Generation) Generation {
+			calls++
+			return g
+		},
+	})
+
+	_, rec := client.StartGeneration(context.Background(), GenerationStart{
+		Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+	})
+	rec.SetResult(Generation{
+		Output: []Message{{Role: RoleAssistant, Parts: []Part{{Kind: PartKindText, Text: "ok"}}}},
+		Usage:  TokenUsage{InputTokens: 1, OutputTokens: 1},
+	}, nil)
+	rec.End()
+
+	if calls != 0 {
+		t.Errorf("sanitizer should be skipped in metadata-only mode; got %d calls", calls)
+	}
+}
+
+func metaString(g Generation, key string) string {
+	v, _ := g.Metadata[key].(string)
+	return v
+}
+


### PR DESCRIPTION
Adds a built-in secret-redaction sanitizer to the Go SDK, matching the existing [Python](https://github.com/grafana/sigil-sdk/pull/49) and [JS](https://github.com/grafana/sigil-sdk/pull/47) implementations.

- new `GenerationSanitizer` hook on `Config`, invoked in `GenerationRecorder.End` between normalization and content-capture stripping
- `NewSecretRedactionSanitizer` ships the same tier-1 + tier-2 + email pattern set as the Python/JS SDKs.
- A failing sanitizer downgrades the generation to metadata-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches generation finalization and span/error emission paths; incorrect ordering or regex behavior could affect exported payloads or accidentally strip/retain sensitive data.
> 
> **Overview**
> Adds a new `Config.GenerationSanitizer` hook that runs during `GenerationRecorder.End` after normalization but before content-capture stripping/export, with panic recovery that fail-closes by downgrading the generation to `ContentCaptureModeMetadataOnly` and logging a warning.
> 
> Introduces a built-in `NewSecretRedactionSanitizer` that redacts common secret formats (plus optional email and env-style key/value secrets) across generation fields and message parts, and ensures redactions propagate to metadata mirrors and span sinks (span attributes, status, and exception events) to prevent leaks.
> 
> Updates the Go SDK README with usage guidance and adds comprehensive tests covering default behavior, role-based input handling, email toggle, pattern coverage, panic fallback, and cross-sink non-leak guarantees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7e9d7d42c14a93915ac6ab5ea4020fe40e0336a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->