### PR TITLE
fix(plugins/pi): tag OTel resource with per-session service.instance.id

### DIFF
--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -549,10 +549,13 @@ describe("extension lifecycle", () => {
     await pi.emit("turn_start");
     await pi.emit("turn_end", { message: assistantMessage(), toolResults: [] });
 
-    expect(createTelemetryProvidersMock).toHaveBeenCalledWith({
-      endpoint: "http://localhost:4318",
-      headers: {},
-    });
+    expect(createTelemetryProvidersMock).toHaveBeenCalledWith(
+      {
+        endpoint: "http://localhost:4318",
+        headers: {},
+      },
+      "sess-default-id",
+    );
     expect(createSigilClientMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -109,7 +110,7 @@ export default function (pi: ExtensionAPI) {
     pendingInputMessages.length = 0;
   }
 
-  pi.on("session_start", async (_event, _ctx) => {
+  pi.on("session_start", async (_event, ctx) => {
     try {
       if (sigil) {
         try {
@@ -134,10 +135,13 @@ export default function (pi: ExtensionAPI) {
       // (session-manager.js:927,961) are reflected without restarting
       // the plugin. We intentionally do NOT cache it here.
 
-      // Set up OTel providers if OTLP is configured
+      // Set up OTel providers if OTLP is configured.
+      // Pass the pi session id as service.instance.id so concurrent pi
+      // sessions on the same machine emit distinct OTel metric series.
       if (config.otlp) {
         try {
-          telemetry = createTelemetryProviders(config.otlp);
+          const instanceId = ctx.sessionManager.getSessionId() || randomUUID();
+          telemetry = createTelemetryProviders(config.otlp, instanceId);
         } catch (err) {
           console.warn("[sigil-pi] failed to create OTel providers:", err);
         }

--- a/plugins/pi/src/telemetry.test.ts
+++ b/plugins/pi/src/telemetry.test.ts
@@ -79,10 +79,13 @@ describe("createTelemetryProviders", () => {
   it("exports metrics with sigil-pi resource and cumulative temporality", async () => {
     const server = await startOtlpServer();
     try {
-      const providers = createTelemetryProviders({
-        endpoint: server.endpoint,
-        headers: { "X-Test-Header": "present" },
-      });
+      const providers = createTelemetryProviders(
+        {
+          endpoint: server.endpoint,
+          headers: { "X-Test-Header": "present" },
+        },
+        "session-abc",
+      );
 
       providers.meter
         .createHistogram("sigil_pi.test.duration", { unit: "s" })
@@ -105,11 +108,66 @@ describe("createTelemetryProviders", () => {
         ]),
       );
       expect(resourceAttributes["service.name"]).toBe("sigil-pi");
+      expect(resourceAttributes["service.instance.id"]).toBe("session-abc");
       expect(resourceAttributes["telemetry.sdk.language"]).toBe("nodejs");
 
       expect(metric.histogram?.aggregationTemporality).toBe(
         OTLP_AGGREGATION_TEMPORALITY_CUMULATIVE,
       );
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("tags each session's metrics with a distinct service.instance.id", async () => {
+    const server = await startOtlpServer();
+    try {
+      const a = createTelemetryProviders(
+        { endpoint: server.endpoint, headers: {} },
+        "session-a",
+      );
+      const b = createTelemetryProviders(
+        { endpoint: server.endpoint, headers: {} },
+        "session-b",
+      );
+
+      a.meter
+        .createHistogram("sigil_pi.test.duration", { unit: "s" })
+        .record(0.5);
+      b.meter
+        .createHistogram("sigil_pi.test.duration", { unit: "s" })
+        .record(0.5);
+
+      await a.forceFlush();
+      await b.forceFlush();
+      await a.shutdown();
+      await b.shutdown();
+
+      const instanceIds = new Set<string | undefined>();
+      for (const request of server.requests.filter(
+        (r) => r.url === "/otlp/v1/metrics",
+      )) {
+        const payload = JSON.parse(request.body) as {
+          resourceMetrics?: Array<{
+            resource?: {
+              attributes?: Array<{
+                key: string;
+                value: { stringValue?: string };
+              }>;
+            };
+          }>;
+        };
+        for (const rm of payload.resourceMetrics ?? []) {
+          for (const attr of rm.resource?.attributes ?? []) {
+            if (attr.key === "service.instance.id") {
+              instanceIds.add(attr.value.stringValue);
+            }
+          }
+        }
+      }
+
+      expect(instanceIds.has("session-a")).toBe(true);
+      expect(instanceIds.has("session-b")).toBe(true);
     } finally {
       await server.close();
     }

--- a/plugins/pi/src/telemetry.ts
+++ b/plugins/pi/src/telemetry.ts
@@ -31,10 +31,17 @@ export interface TelemetryProviders {
   shutdown: () => Promise<void>;
 }
 
-export function createTelemetryProviders(otlp: OtlpConfig): TelemetryProviders {
+export function createTelemetryProviders(
+  otlp: OtlpConfig,
+  instanceId: string,
+): TelemetryProviders {
   const base = otlp.endpoint.replace(/\/+$/, "");
+  // service.instance.id MUST disambiguate concurrent pi sessions on the same host.
   const resource = defaultResource().merge(
-    resourceFromAttributes({ "service.name": SERVICE_NAME }),
+    resourceFromAttributes({
+      "service.name": SERVICE_NAME,
+      "service.instance.id": instanceId,
+    }),
   );
 
   const metricExporter = new OTLPMetricExporter({


### PR DESCRIPTION
The resource only carried `service.name=sigil-pi`, so concurrent pi sessions on the same host emitted SDK metrics under one identity.

Wire `ctx.sessionManager.getSessionId()` into `service.instance.id` so each session becomes its own metric series.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to OpenTelemetry resource metadata and related wiring/tests, affecting metric/trace labeling but not core generation/export logic.
> 
> **Overview**
> Ensures concurrent `pi` sessions emit distinct OTel metric/trace series by passing `ctx.sessionManager.getSessionId()` (with a `randomUUID()` fallback) into `createTelemetryProviders` and attaching it as `service.instance.id` on the OTel `Resource`.
> 
> Updates unit tests to assert the new `createTelemetryProviders(otlp, instanceId)` signature and verifies metrics are exported with the expected per-session `service.instance.id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b2931e1d15ad3e5d1ed97a1ee495767ab2e5689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->