### PR TITLE
feat(plugins/pi): tag generations with git.branch

### DIFF
--- a/plugins/pi/src/git.test.ts
+++ b/plugins/pi/src/git.test.ts
@@ -1,0 +1,61 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveGitBranch } from "./git.js";
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  }).trim();
+}
+
+function initRepo(cwd: string, branch = "main"): void {
+  // Use a fixed initial branch so the test doesn't depend on the host's
+  // init.defaultBranch (which differs between machines and CI images).
+  git(cwd, ["init", "-q", "-b", branch]);
+  // user.* config is required for `git commit` to succeed in CI sandboxes.
+  git(cwd, ["config", "user.email", "test@example.com"]);
+  git(cwd, ["config", "user.name", "test"]);
+  git(cwd, ["commit", "-q", "--allow-empty", "-m", "init"]);
+}
+
+describe("resolveGitBranch", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sigil-pi-git-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns the branch name on a normal checkout", () => {
+    initRepo(dir, "feature-x");
+    expect(resolveGitBranch(dir)).toBe("feature-x");
+  });
+
+  it("returns a short sha on detached HEAD", () => {
+    initRepo(dir, "main");
+    const sha = git(dir, ["rev-parse", "HEAD"]);
+    git(dir, ["checkout", "-q", "--detach", sha]);
+
+    const out = resolveGitBranch(dir);
+    expect(out).toBeDefined();
+    expect(out).not.toBe("HEAD");
+    expect(out).toBe(sha.slice(0, 12));
+  });
+
+  it("returns undefined outside a git repo", () => {
+    // mkdtemp roots have no `.git` ancestor on macOS/Linux.
+    expect(resolveGitBranch(dir)).toBeUndefined();
+  });
+
+  it("returns undefined for empty cwd", () => {
+    expect(resolveGitBranch("")).toBeUndefined();
+  });
+});

--- a/plugins/pi/src/git.ts
+++ b/plugins/pi/src/git.ts
@@ -1,0 +1,31 @@
+import { execFileSync } from "node:child_process";
+
+/**
+ * Resolve the current git branch via `git rev-parse`.
+ *
+ * Returns the branch name on a normal checkout, a 12-char short sha on
+ * detached HEAD (matching plugins/cursor), or undefined when git is
+ * unavailable or `cwd` is not in a repo.
+ */
+export function resolveGitBranch(cwd: string): string | undefined {
+  if (!cwd) return undefined;
+  const branch = runGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+  if (!branch) return undefined;
+  if (branch !== "HEAD") return branch;
+  // Detached HEAD: fall back to a short sha.
+  return runGit(["rev-parse", "--short=12", "HEAD"], cwd);
+}
+
+function runGit(args: string[], cwd: string): string | undefined {
+  try {
+    const out = execFileSync("git", args, {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf-8",
+      timeout: 1000,
+    }).trim();
+    return out.length > 0 ? out : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -1,11 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { loadConfigMock, createSigilClientMock, createTelemetryProvidersMock } =
-  vi.hoisted(() => ({
-    loadConfigMock: vi.fn(),
-    createSigilClientMock: vi.fn(),
-    createTelemetryProvidersMock: vi.fn(),
-  }));
+const {
+  loadConfigMock,
+  createSigilClientMock,
+  createTelemetryProvidersMock,
+  resolveGitBranchMock,
+} = vi.hoisted(() => ({
+  loadConfigMock: vi.fn(),
+  createSigilClientMock: vi.fn(),
+  createTelemetryProvidersMock: vi.fn(),
+  resolveGitBranchMock: vi.fn(),
+}));
 
 vi.mock("./config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./config.js")>();
@@ -21,6 +26,10 @@ vi.mock("./client.js", () => ({
 
 vi.mock("./telemetry.js", () => ({
   createTelemetryProviders: createTelemetryProvidersMock,
+}));
+
+vi.mock("./git.js", () => ({
+  resolveGitBranch: resolveGitBranchMock,
 }));
 
 import type { SigilClient } from "@grafana/sigil-sdk-js";
@@ -146,6 +155,9 @@ describe("extension lifecycle", () => {
     loadConfigMock.mockReset();
     createSigilClientMock.mockReset();
     createTelemetryProvidersMock.mockReset();
+    // Default: no git repo. Individual tests opt into a branch by overriding.
+    resolveGitBranchMock.mockReset();
+    resolveGitBranchMock.mockReturnValue(undefined);
   });
 
   it("uses assistant message_end timestamp as completedAt, not msg.timestamp", async () => {
@@ -1102,6 +1114,145 @@ describe("extension lifecycle", () => {
 
     expect(capturedSeed).toBeDefined();
     expect(capturedSeed!.conversationId).toBeUndefined();
+  });
+
+  it("emits git.branch tag when contentCapture=full", async () => {
+    resolveGitBranchMock.mockReturnValue("feature-x");
+
+    let capturedSeed: { tags?: Record<string, string> } | undefined;
+    const recorder = {
+      setResult: vi.fn(),
+      setCallError: vi.fn(),
+      setFirstTokenAt: vi.fn(),
+    };
+    const sigil: SigilLike = {
+      startStreamingGeneration: vi.fn(async (seed, run) => {
+        capturedSeed = seed as { tags?: Record<string, string> };
+        await run(recorder);
+      }),
+      startToolExecution: vi.fn(() => ({
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        end: vi.fn(),
+        getError: vi.fn(),
+      })),
+      shutdown: vi.fn(async () => {}),
+    };
+
+    loadConfigMock.mockResolvedValue({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      auth: { mode: "none" },
+      agentName: "pi",
+      contentCapture: "full",
+    });
+    createSigilClientMock.mockReturnValue(sigil);
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+
+    await pi.emit("session_start");
+    await pi.emit("turn_start");
+    await pi.emit("turn_end", {
+      message: assistantMessage(),
+      toolResults: [],
+    });
+
+    expect(resolveGitBranchMock).toHaveBeenCalledTimes(1);
+    expect(capturedSeed!.tags).toEqual({ "git.branch": "feature-x" });
+  });
+
+  it("omits git.branch tag (and skips the subprocess) when contentCapture is not full", async () => {
+    resolveGitBranchMock.mockReturnValue("feature-x");
+
+    for (const mode of ["metadata_only", "no_tool_content"] as const) {
+      resolveGitBranchMock.mockClear();
+
+      let capturedSeed: { tags?: Record<string, string> } | undefined;
+      const recorder = {
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        setFirstTokenAt: vi.fn(),
+      };
+      const sigil: SigilLike = {
+        startStreamingGeneration: vi.fn(async (seed, run) => {
+          capturedSeed = seed as { tags?: Record<string, string> };
+          await run(recorder);
+        }),
+        startToolExecution: vi.fn(() => ({
+          setResult: vi.fn(),
+          setCallError: vi.fn(),
+          end: vi.fn(),
+          getError: vi.fn(),
+        })),
+        shutdown: vi.fn(async () => {}),
+      };
+
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: mode,
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      expect(resolveGitBranchMock, `mode=${mode}`).not.toHaveBeenCalled();
+      expect(capturedSeed!.tags, `mode=${mode}`).toBeUndefined();
+    }
+  });
+
+  it("omits git.branch tag when not in a git repo even with contentCapture=full", async () => {
+    resolveGitBranchMock.mockReturnValue(undefined);
+
+    let capturedSeed: { tags?: Record<string, string> } | undefined;
+    const recorder = {
+      setResult: vi.fn(),
+      setCallError: vi.fn(),
+      setFirstTokenAt: vi.fn(),
+    };
+    const sigil: SigilLike = {
+      startStreamingGeneration: vi.fn(async (seed, run) => {
+        capturedSeed = seed as { tags?: Record<string, string> };
+        await run(recorder);
+      }),
+      startToolExecution: vi.fn(() => ({
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        end: vi.fn(),
+        getError: vi.fn(),
+      })),
+      shutdown: vi.fn(async () => {}),
+    };
+
+    loadConfigMock.mockResolvedValue({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      auth: { mode: "none" },
+      agentName: "pi",
+      contentCapture: "full",
+    });
+    createSigilClientMock.mockReturnValue(sigil);
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+
+    await pi.emit("session_start");
+    await pi.emit("turn_start");
+    await pi.emit("turn_end", {
+      message: assistantMessage(),
+      toolResults: [],
+    });
+
+    expect(resolveGitBranchMock).toHaveBeenCalledTimes(1);
+    expect(capturedSeed!.tags).toBeUndefined();
   });
 });
 

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -11,6 +11,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { createSigilClient } from "./client.js";
 import type { SigilPiConfig } from "./config.js";
 import { loadConfig } from "./config.js";
+import { resolveGitBranch } from "./git.js";
 import {
   mapGenerationResult,
   mapGenerationStart,
@@ -275,6 +276,16 @@ export default function (pi: ExtensionAPI) {
         completedAtMs,
       );
 
+      // Resolved per turn so mid-session checkouts land on the next
+      // generation. Gated on contentCapture=full because branch names
+      // can leak project context (diverges from claude-code/cursor,
+      // which always send it).
+      const gitBranch =
+        config.contentCapture === "full"
+          ? resolveGitBranch(process.cwd())
+          : undefined;
+      const builtinTags = gitBranch ? { "git.branch": gitBranch } : undefined;
+
       const seed = mapGenerationStart(
         msg,
         conversationId,
@@ -282,6 +293,7 @@ export default function (pi: ExtensionAPI) {
         config.agentVersion,
         startedAtMs,
         toolDefs.length > 0 ? toolDefs : undefined,
+        builtinTags,
       );
 
       const toolResults = (event.toolResults ?? []) as PiToolResult[];

--- a/plugins/pi/src/mappers.test.ts
+++ b/plugins/pi/src/mappers.test.ts
@@ -152,6 +152,34 @@ describe("mapGenerationStart", () => {
     );
     expect(start.effectiveVersion).toBeUndefined();
   });
+
+  it("attaches tags when provided", () => {
+    const start = mapGenerationStart(
+      makeMsg(),
+      "s",
+      "pi",
+      undefined,
+      0,
+      undefined,
+      { "git.branch": "main" },
+    );
+    expect(start.tags).toEqual({ "git.branch": "main" });
+  });
+
+  it("omits tags when empty or undefined", () => {
+    const a = mapGenerationStart(
+      makeMsg(),
+      "s",
+      "pi",
+      undefined,
+      0,
+      undefined,
+      {},
+    );
+    const b = mapGenerationStart(makeMsg(), "s", "pi", undefined, 0, undefined);
+    expect(a.tags).toBeUndefined();
+    expect(b.tags).toBeUndefined();
+  });
 });
 
 describe("mapGenerationResult", () => {

--- a/plugins/pi/src/mappers.ts
+++ b/plugins/pi/src/mappers.ts
@@ -89,7 +89,10 @@ export function mapGenerationStart(
   agentVersion: string | undefined,
   turnStartTime: number,
   tools: ToolDefinition[] | undefined,
+  tags?: Record<string, string>,
 ): GenerationStart {
+  // Tags on the seed override client-level SIGIL_TAGS (the SDK merges
+  // `{...clientTags, ...seedTags}`), matching claude-code/cursor.
   const start: GenerationStart = {
     conversationId,
     agentName,
@@ -98,6 +101,7 @@ export function mapGenerationStart(
     model: { provider: msg.provider, name: msg.model },
     startedAt: new Date(turnStartTime),
     ...(tools && tools.length > 0 ? { tools } : {}),
+    ...(tags && Object.keys(tags).length > 0 ? { tags } : {}),
   };
   if (msg.content.some((b) => b.type === "thinking")) {
     start.thinkingEnabled = true;


### PR DESCRIPTION
Add `git.branch` tag to generations, the same as Claude Code plugin does.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a per-turn `git` subprocess to annotate exported generations with a `git.branch` tag when `contentCapture=full`, which could affect performance or leak repo context if misconfigured. Changes are otherwise additive and guarded with timeouts and feature gating.
> 
> **Overview**
> When `plugins/pi` exports a generation, it now *optionally* attaches a `git.branch` tag to the `GenerationStart` seed.
> 
> A new `resolveGitBranch()` helper shells out to `git rev-parse` and returns either the current branch or a short SHA for detached HEAD; it is only invoked when `contentCapture` is `full`, and the tag is omitted when not in a repo or git is unavailable.
> 
> `mapGenerationStart` now accepts optional `tags` (omitting empty objects), and new unit tests cover git resolution plus the content-capture gating and tag wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7f84b6fde5537501c4b98dba07442a8e0274daa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->