### PR TITLE
fix(sdk-py): wire ToolDefinition.deferred through hooks and generation export

### DIFF
--- a/python/sigil_sdk/models.py
+++ b/python/sigil_sdk/models.py
@@ -80,6 +80,7 @@ class ToolDefinition:
     description: str = ""
     type: str = ""
     input_schema_json: bytes = b""
+    deferred: bool = False
 
 
 @dataclass(slots=True)

--- a/python/sigil_sdk/proto_mapping.py
+++ b/python/sigil_sdk/proto_mapping.py
@@ -224,6 +224,7 @@ def _map_tool(tool: object) -> sigil_pb2.ToolDefinition:
         description=tool.description,
         type=tool.type,
         input_schema_json=bytes(tool.input_schema_json),
+        deferred=bool(tool.deferred),
     )
 
 

--- a/python/tests/test_hooks_transport.py
+++ b/python/tests/test_hooks_transport.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import threading
+from collections.abc import Iterator
 from datetime import timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
 
 import pytest
 from opentelemetry import trace
@@ -24,6 +27,7 @@ from sigil_sdk import (
     HooksConfig,
     HookTransportError,
     MessageRole,
+    ToolDefinition,
     hook_denied_from_response,
     user_text_message,
 )
@@ -321,6 +325,62 @@ def test_evaluate_hook_skips_mismatched_phase() -> None:
         assert response.action == "allow"
     finally:
         client.shutdown()
+        server.shutdown()
+        server.server_close()
+
+
+def test_evaluate_hook_serializes_tool_definitions_including_deferred() -> None:
+    with _capturing_hook_server({"action": "allow", "evaluations": []}) as (captured, base_url):
+        client = _new_client(base_url, hooks=HooksConfig(enabled=True, phases=["preflight"]))
+        try:
+            response = client.evaluate_hook(
+                HookEvaluateRequest(
+                    phase=HookPhase.PREFLIGHT.value,
+                    context=HookContext(model=HookModel(provider="openai", name="gpt-4o")),
+                    input=HookInput(
+                        tools=[
+                            ToolDefinition(name="search", description="search the web", type="function"),
+                            ToolDefinition(name="approve_refund", type="function", deferred=True),
+                        ],
+                    ),
+                )
+            )
+        finally:
+            client.shutdown()
+
+    assert response.action == "allow"
+    tools = captured["payload"]["input"]["tools"]
+    assert [t["name"] for t in tools] == ["search", "approve_refund"]
+    assert "deferred" not in tools[0]
+    assert tools[1]["deferred"] is True
+
+
+@contextlib.contextmanager
+def _capturing_hook_server(response: dict[str, Any]) -> Iterator[tuple[dict[str, Any], str]]:
+    """Run a stub hooks:evaluate server that captures one request and returns `response`."""
+    captured: dict[str, Any] = {}
+    body = json.dumps(response).encode("utf-8")
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0"))
+            captured["path"] = self.path
+            captured["headers"] = {k.lower(): v for k, v in self.headers.items()}
+            captured["payload"] = json.loads(self.rfile.read(length).decode("utf-8"))
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format, *_args):  # noqa: A003
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield captured, f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
         server.shutdown()
         server.server_close()
 

--- a/python/tests/test_transport.py
+++ b/python/tests/test_transport.py
@@ -443,6 +443,7 @@ def _assert_generation_json_payload(generation: dict[str, Any]) -> None:
     assert tools[0]["description"] == "Get weather"
     assert tools[0]["type"] == "function"
     assert _decode_proto_json_bytes(tools[0]["input_schema_json"]) == b'{"type":"object"}'
+    assert tools[0]["deferred"] is True
 
     usage = generation["usage"]
     assert _proto_json_int(usage["input_tokens"]) == 120
@@ -531,6 +532,7 @@ def _assert_generation_proto_payload(generation: sigil_pb2.Generation) -> None:
     assert generation.tools[0].description == "Get weather"
     assert generation.tools[0].type == "function"
     assert generation.tools[0].input_schema_json == b'{"type":"object"}'
+    assert generation.tools[0].deferred is True
 
     assert generation.usage.input_tokens == 120
     assert generation.usage.output_tokens == 42
@@ -618,6 +620,7 @@ def _payload_fixture() -> tuple[GenerationStart, Generation]:
                 description="Get weather",
                 type="function",
                 input_schema_json=b'{"type":"object"}',
+                deferred=True,
             )
         ],
         tags={"env": "test"},


### PR DESCRIPTION
Fixes #138

The hook serializer in `hooks.py` tried to read `tool.deferred`, but `ToolDefinition` did not define that field. As a result, any `evaluate_hook` call with tools raised an `AttributeError`.

The generation export path had a related issue. `_map_tool` in `proto_mapping` created `sigil_pb2.ToolDefinition` values without copying `deferred`, so the field was silently dropped during export.

This change adds `deferred` to the `ToolDefinition` dataclass with a default of `False`, then forwards it through the proto mapper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, additive model/serialization change with targeted tests; main risk is minor wire-format differences when tools are exported or sent to hooks.
> 
> **Overview**
> Fixes tool serialization by adding `deferred: bool` to `ToolDefinition` and wiring it through both the hooks request serializer and generation export proto mapping so the flag is no longer dropped or raises `AttributeError`.
> 
> Updates transport tests to assert `deferred` is emitted in generation export payloads, and adds a hooks transport test that verifies `deferred` is only included when true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a66f60a5720a6a40e774a483c0a0937a4f6875f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->