### PR TITLE
ci: pin protoc toolchain and check generated protobuf stubs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,39 @@ jobs:
       - name: Test bump-version.sh
         run: ./.github/scripts/bump-version.test.sh
 
+  proto:
+    name: Protobuf drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Setup mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          install: true
+          cache: true
+
+      - name: Install JS deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Check protobuf stubs are in sync
+        run: mise run check:proto
+
   go:
     name: Go SDK
     runs-on: ubuntu-latest

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,17 +20,45 @@ This runs three subtasks:
 
 Java and .NET compile the proto on build (gradle protobuf plugin and `Grpc.Tools` respectively), so they pick up changes automatically once the canonical `.proto` is updated.
 
-### Go tooling
+### Pinned tool versions
 
-If `protoc-gen-go` or `protoc-gen-go-grpc` are missing, install them:
+All codegen tools are pinned in [`mise.toml`](../mise.toml) so regenerated stubs are byte-identical across machines and CI:
+
+| Tool | Version | Where it's pinned |
+| --- | --- | --- |
+| `protoc` | `34.1` | `[tools]` |
+| `protoc-gen-go` | `v1.36.11` | `[tools]` (go install) |
+| `protoc-gen-go-grpc` | `v1.6.1` | `[tools]` (go install) |
+| `grpcio-tools` (Python) | `1.80.0` | `SIGIL_GRPCIO_TOOLS_VERSION` env |
+| `protobuf` (Python) | `6.31.1` | `SIGIL_PROTOBUF_VERSION` env |
+
+Install everything with:
 
 ```bash
-go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+mise install
 ```
 
-`protoc` itself comes from your package manager (`brew install protobuf`, `apt install protobuf-compiler`, etc.).
+Go and Python pins match the runtime deps in `go/go.mod` and `python/pyproject.toml`. Bumping a generator version means regenerating the stubs and committing the diff.
 
-### Python tooling
+### Drift check
 
-The script prefers an existing Python that has `grpcio-tools` installed (`PYTHON_BIN`, defaults to `python3`); if that's unavailable it falls back to `uv run --with grpcio-tools`. Install [uv](https://docs.astral.sh/uv/) and you don't need to install `grpcio-tools` globally.
+`mise run check:proto` regenerates the Go, Python, and JS stubs into a temporary directory and diffs them against the committed tree. It runs in CI as the `Protobuf drift` job and fails the build if anyone edits the proto without running `mise run generate:proto`, or if the local tool versions don't match the pins above.
+
+### Manual installs (no mise)
+
+If you prefer not to use `mise`:
+
+```bash
+# Go tools
+go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.1
+
+# protoc — install 34.1 via your package manager:
+#   brew install protobuf            # macOS
+#   apt install protobuf-compiler    # Debian/Ubuntu (version varies)
+
+# Python tools
+python3 -m pip install grpcio-tools==1.80.0 protobuf==6.31.1
+```
+
+The Python script prefers an existing Python that already has `grpcio-tools` installed (`PYTHON_BIN`, defaults to `python3`); otherwise it falls back to `uv run --with grpcio-tools==<pinned> --with protobuf==<pinned>`. Install [uv](https://docs.astral.sh/uv/) and you don't need to install the Python tools globally.

--- a/go/scripts/generate_proto.sh
+++ b/go/scripts/generate_proto.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-OUT_DIR="${ROOT_DIR}/go/sigil/internal/gen"
+OUT_DIR="${1:-${ROOT_DIR}/go/sigil/internal/gen}"
 GO_PKG="github.com/grafana/sigil-sdk/go/sigil/internal/gen/sigil/v1"
 
 GOPATH_BIN="$(go env GOPATH 2>/dev/null || echo "${HOME}/go")/bin"
@@ -16,10 +16,14 @@ done
 if [[ ${#missing[@]} -gt 0 ]]; then
   cat >&2 <<EOF
 Missing required tools: ${missing[*]}
-Install:
-  protoc:             https://protobuf.dev/installation/
-  protoc-gen-go:      go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-  protoc-gen-go-grpc: go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+
+The pinned versions live in mise.toml. Install them with:
+  mise install
+
+Or install manually:
+  protoc:             https://protobuf.dev/installation/  (pinned to 34.1)
+  protoc-gen-go:      go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
+  protoc-gen-go-grpc: go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.1
 EOF
   exit 1
 fi

--- a/js/scripts/sync-proto.mjs
+++ b/js/scripts/sync-proto.mjs
@@ -1,12 +1,22 @@
 #!/usr/bin/env node
 import { copyFile, mkdir, readdir } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '..', '..');
 const src = join(repoRoot, 'proto', 'sigil', 'v1');
-const dst = join(__dirname, '..', 'proto', 'sigil', 'v1');
+
+// Optional first argument: alternate destination root. When set, files are
+// written to `${arg}/sigil/v1/*.proto` so callers (like `mise run check:proto`)
+// can compare against the committed `js/proto/sigil/` tree.
+const destArg = process.argv[2];
+const destRoot = destArg
+  ? isAbsolute(destArg)
+    ? destArg
+    : resolve(process.cwd(), destArg)
+  : join(__dirname, '..', 'proto');
+const dst = join(destRoot, 'sigil', 'v1');
 
 await mkdir(dst, { recursive: true });
 const entries = await readdir(src);

--- a/mise.toml
+++ b/mise.toml
@@ -1,9 +1,18 @@
 [tools]
 biome = "2.4.11"
 ruff = "0.15.12"
+go = "1.25.6"
+protoc = "34.1"
+"go:google.golang.org/protobuf/cmd/protoc-gen-go" = "v1.36.11"
+"go:google.golang.org/grpc/cmd/protoc-gen-go-grpc" = "v1.6.1"
 
 [env]
 PYTHON_BIN = "python3"
+# Pin the Python protobuf toolchain so generated stubs are reproducible across
+# machines and CI. Bumping these requires regenerating stubs via
+# `mise run generate:proto:python`.
+SIGIL_GRPCIO_TOOLS_VERSION = "1.80.0"
+SIGIL_PROTOBUF_VERSION = "6.31.1"
 
 # --- Dependencies ---
 
@@ -486,6 +495,51 @@ run = "pnpm --filter @grafana/sigil-sdk-js run sync-proto"
 description = "Regenerate protobuf stubs for all SDKs"
 depends = ["generate:proto:go", "generate:proto:python", "generate:proto:js"]
 
+[tasks."check:proto"]
+description = "Fail if generated protobuf stubs drift from proto/sigil/v1/*.proto"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail=0
+
+echo "==> check:proto go"
+bash go/scripts/generate_proto.sh "$tmp/go"
+if ! diff -ruN go/sigil/internal/gen "$tmp/go"; then
+  echo >&2 "::error::Go protobuf stubs are out of sync with proto/sigil/v1/*.proto"
+  fail=1
+fi
+
+echo "==> check:proto python"
+bash python/scripts/generate_proto.sh "$tmp/python"
+if ! diff -ruN python/sigil_sdk/internal/gen "$tmp/python"; then
+  echo >&2 "::error::Python protobuf stubs are out of sync with proto/sigil/v1/*.proto"
+  fail=1
+fi
+
+echo "==> check:proto js"
+mkdir -p "$tmp/js"
+node js/scripts/sync-proto.mjs "$tmp/js"
+if ! diff -ruN js/proto/sigil "$tmp/js/sigil"; then
+  echo >&2 "::error::JS proto copy in js/proto/sigil is out of sync with proto/sigil/v1/*.proto"
+  fail=1
+fi
+
+if [[ $fail -ne 0 ]]; then
+  cat >&2 <<'EOF'
+
+Generated protobuf code drifted from proto/sigil/v1/*.proto.
+Run `mise run generate:proto` and commit the regenerated files.
+EOF
+  exit 1
+fi
+
+echo "==> check:proto: stubs in sync"
+"""
+
 # --- Mock generation (stubs) ---
 
 [tasks."generate:mocks:sdk-go"]
@@ -521,5 +575,5 @@ depends = ["generate:mocks:sdk-go", "generate:mocks:sdk-go-providers", "generate
 
 [tasks.check]
 description = "Run lint + typecheck + tests"
-depends = ["lint", "typecheck"]
+depends = ["lint", "typecheck", "check:proto"]
 run = "mise run test:sdk:all"

--- a/python/scripts/generate_proto.sh
+++ b/python/scripts/generate_proto.sh
@@ -2,25 +2,35 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-SDK_DIR="${ROOT_DIR}/python"
-OUT_DIR="${SDK_DIR}/sigil_sdk/internal/gen"
+OUT_DIR="${1:-${ROOT_DIR}/python/sigil_sdk/internal/gen}"
 PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+# Pinned via mise.toml; bump both versions together and regenerate stubs.
+GRPCIO_TOOLS_VERSION="${SIGIL_GRPCIO_TOOLS_VERSION:-1.80.0}"
+PROTOBUF_VERSION="${SIGIL_PROTOBUF_VERSION:-6.31.1}"
 
 if "${PYTHON_BIN}" -c "import grpc_tools" >/dev/null 2>&1; then
   PYTHON=("${PYTHON_BIN}")
 elif command -v uv >/dev/null 2>&1; then
-  PYTHON=(uv run --quiet --directory "${SDK_DIR}" --with grpcio-tools python)
+  # --no-project so uv resolves a standalone ephemeral env and does not
+  # touch python/uv.lock during codegen.
+  PYTHON=(uv run --quiet --no-project \
+    --with "grpcio-tools==${GRPCIO_TOOLS_VERSION}" \
+    --with "protobuf==${PROTOBUF_VERSION}" \
+    python)
 else
-  cat >&2 <<'EOF'
+  cat >&2 <<EOF
 grpcio-tools is required to regenerate protobuf stubs.
 Either install uv (preferred — https://docs.astral.sh/uv/) and re-run,
-or install grpcio-tools into your Python:
-  python3 -m pip install grpcio-tools
+or install the pinned tools into your Python:
+  python3 -m pip install grpcio-tools==${GRPCIO_TOOLS_VERSION} protobuf==${PROTOBUF_VERSION}
 EOF
   exit 1
 fi
 
 PROTO_INCLUDE="$("${PYTHON[@]}" -c 'import pathlib, grpc_tools; print(pathlib.Path(grpc_tools.__file__).parent / "_proto")')"
+
+mkdir -p "${OUT_DIR}"
 
 "${PYTHON[@]}" -m grpc_tools.protoc \
   -I"${ROOT_DIR}/proto" \
@@ -34,3 +44,15 @@ TMP_FILE="$(mktemp)"
 sed 's|from sigil.v1 import generation_ingest_pb2 as|from . import generation_ingest_pb2 as|' \
   "${OUT_DIR}/sigil/v1/generation_ingest_pb2_grpc.py" > "${TMP_FILE}"
 mv "${TMP_FILE}" "${OUT_DIR}/sigil/v1/generation_ingest_pb2_grpc.py"
+
+# protoc does not emit package __init__.py files; recreate them so the drift
+# check and a fresh regenerate both produce the full committed tree.
+cat > "${OUT_DIR}/__init__.py" <<'EOF'
+"""Generated protobuf modules."""
+EOF
+cat > "${OUT_DIR}/sigil/__init__.py" <<'EOF'
+"""Generated sigil protobuf namespace."""
+EOF
+cat > "${OUT_DIR}/sigil/v1/__init__.py" <<'EOF'
+"""Generated sigil.v1 protobuf namespace."""
+EOF


### PR DESCRIPTION
The protobuf codegen tools weren't pinned, so the checked-in stubs in `go/sigil/internal/gen`, `python/sigil_sdk/internal/gen` and `js/proto` could drift silently when contributors had different local versions, and a proto edit without a follow-up regen would only surface at runtime.

Pin `protoc`, `protoc-gen-go`, `protoc-gen-go-grpc`, `grpcio-tools` and `protobuf` via `mise` to the versions already stamped in the committed stubs, add a `check:proto` task that regenerates into a temp dir and diffs against the tree, and run it from a Protobuf drift CI job.