### PR TITLE
feat(plugins/pi): add Sigil guards support

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1905,7 +1905,10 @@ function baseURLFromAPIEndpoint(endpoint: string, insecure: boolean): string {
 
   if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
     const parsed = new URL(trimmed);
-    return `${parsed.protocol}//${parsed.host}`;
+    // Preserve a path prefix so prefix-mounted Sigil deployments
+    // (https://host/sigil) route /api/v1/conversations/... under the prefix.
+    const path = parsed.pathname.replace(/\/+$/, '');
+    return `${parsed.protocol}//${parsed.host}${path}`;
   }
 
   const withoutScheme = trimmed.startsWith('grpc://') ? trimmed.slice('grpc://'.length) : trimmed;

--- a/js/src/hooks.ts
+++ b/js/src/hooks.ts
@@ -148,7 +148,10 @@ function baseURLFromAPIEndpoint(endpoint: string, insecure: boolean): string {
 
   if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
     const parsed = new URL(trimmed);
-    return `${parsed.protocol}//${parsed.host}`;
+    // Preserve a path prefix so prefix-mounted Sigil deployments
+    // (https://host/sigil) route /api/v1/hooks:evaluate under the prefix.
+    const path = parsed.pathname.replace(/\/+$/, '');
+    return `${parsed.protocol}//${parsed.host}${path}`;
   }
 
   const withoutScheme = trimmed.startsWith('grpc://') ? trimmed.slice('grpc://'.length) : trimmed;

--- a/js/test/client.hooks.test.mjs
+++ b/js/test/client.hooks.test.mjs
@@ -116,6 +116,69 @@ test('evaluateHook posts JSON to /api/v1/hooks:evaluate and parses allow respons
   }
 });
 
+test('evaluateHook routes hooks:evaluate under a path prefix when api.endpoint has one', async () => {
+  let receivedPath = '';
+  const server = createServer(async (request, response) => {
+    receivedPath = request.url ?? '';
+    for await (const _ of request) {
+      // drain
+    }
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ action: 'allow', evaluations: [] }));
+  });
+  await listen(server);
+  const address = server.address();
+
+  const client = newClient({
+    apiEndpoint: `http://127.0.0.1:${address.port}/sigil`,
+    hooksEnabled: true,
+  });
+
+  try {
+    const response = await client.evaluateHook({
+      phase: 'preflight',
+      context: { model: { provider: 'openai', name: 'gpt-4o' } },
+      input: {},
+    });
+    assert.equal(receivedPath, '/sigil/api/v1/hooks:evaluate');
+    assert.equal(response.action, 'allow');
+  } finally {
+    await client.shutdown();
+    await close(server);
+  }
+});
+
+test('evaluateHook handles api.endpoint with a trailing slash', async () => {
+  let receivedPath = '';
+  const server = createServer(async (request, response) => {
+    receivedPath = request.url ?? '';
+    for await (const _ of request) {
+      // drain
+    }
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ action: 'allow', evaluations: [] }));
+  });
+  await listen(server);
+  const address = server.address();
+
+  const client = newClient({
+    apiEndpoint: `http://127.0.0.1:${address.port}/sigil/`,
+    hooksEnabled: true,
+  });
+
+  try {
+    await client.evaluateHook({
+      phase: 'preflight',
+      context: { model: { provider: 'openai', name: 'gpt-4o' } },
+      input: {},
+    });
+    assert.equal(receivedPath, '/sigil/api/v1/hooks:evaluate');
+  } finally {
+    await client.shutdown();
+    await close(server);
+  }
+});
+
 test('evaluateHook parses transformed_input from allow response', async () => {
   const server = createServer((_request, response) => {
     response.writeHead(200, { 'content-type': 'application/json' });

--- a/js/test/client.rating.test.mjs
+++ b/js/test/client.rating.test.mjs
@@ -81,6 +81,58 @@ test('submitConversationRating sends HTTP request and maps response', async () =
   }
 });
 
+test('submitConversationRating routes under a path prefix when api.endpoint has one', async () => {
+  let receivedPath = '';
+  const server = createServer(async (request, response) => {
+    receivedPath = request.url ?? '';
+    for await (const _ of request) {
+      // drain
+    }
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(
+      JSON.stringify({
+        rating: {
+          rating_id: 'rat-1',
+          conversation_id: 'conv-1',
+          rating: 'CONVERSATION_RATING_VALUE_GOOD',
+          created_at: '2026-02-13T12:00:00Z',
+        },
+        summary: {
+          total_count: 1,
+          good_count: 1,
+          bad_count: 0,
+          latest_rating: 'CONVERSATION_RATING_VALUE_GOOD',
+          latest_rated_at: '2026-02-13T12:00:00Z',
+          has_bad_rating: false,
+        },
+      }),
+    );
+  });
+  await listen(server);
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('failed to resolve rating prefix server address');
+  }
+
+  const client = newClient({
+    generationEndpoint: 'localhost:4317',
+    generationProtocol: 'grpc',
+    apiEndpoint: `http://127.0.0.1:${address.port}/sigil`,
+    auth: { mode: 'tenant', tenantId: 'tenant-a' },
+  });
+
+  try {
+    await client.submitConversationRating('conv-1', {
+      ratingId: 'rat-1',
+      rating: 'CONVERSATION_RATING_VALUE_GOOD',
+    });
+    assert.equal(receivedPath, '/sigil/api/v1/conversations/conv-1/ratings');
+  } finally {
+    await client.shutdown();
+    await close(server);
+  }
+});
+
 test('submitConversationRating maps 409 to conflict error', async () => {
   const server = createServer((_request, response) => {
     response.writeHead(409, { 'content-type': 'text/plain' });

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -67,6 +67,21 @@ Generations are scrubbed for secrets before they leave the process; matches beco
 
 User-role messages are scrubbed too — set `redaction.redactInputMessages: false` to leave them alone, or `redaction.enabled: false` to disable redaction entirely.
 
+### Guards
+
+Guards let you block tool calls before they execute — for example, refusing a `bash` invocation when the command matches a deny rule.
+
+Guards are **disabled by default** and must be turned on explicitly:
+
+```sh
+SIGIL_GUARDS_ENABLED=true pi
+```
+
+Behavior:
+
+- Phase is hardcoded to `postflight` (pi's `tool_call` fires after the assistant message but before the tool runs).
+- Fail-open by default — transport errors, timeouts, and unexpected exceptions allow the tool through. Set `SIGIL_GUARDS_FAIL_OPEN=false` to block the tool instead.
+
 ### Options
 
 | Field | Default | Description |
@@ -87,6 +102,9 @@ User-role messages are scrubbed too — set `redaction.redactInputMessages: fals
 | `redaction.enabled` | `true` | Master switch for redaction |
 | `redaction.redactInputMessages` | `true` | Scrub user-role content too |
 | `redaction.redactEmailAddresses` | `true` | Scrub generic email addresses |
+| `guards.enabled` | `false` | Opt-in to request-path policy checks. When true, every `tool_call` is evaluated by Sigil; a `deny` blocks the tool with the server-provided reason |
+| `guards.timeoutMs` | `1500` | Per-call timeout for the guard request in milliseconds |
+| `guards.failOpen` | `true` | When true, transport errors/timeouts allow the tool through. When false, the tool is blocked with a guard-evaluation-failed reason. |
 
 ### Environment variables
 
@@ -101,6 +119,9 @@ Any field can be overridden via env var. When launched via `sigil pi`, vars in `
 | `SIGIL_DEBUG` | `debug` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `otlp.endpoint` |
 | `SIGIL_OTEL_AUTH_TOKEN` | OTLP basic-auth password (falls back to `SIGIL_AUTH_TOKEN`) |
+| `SIGIL_GUARDS_ENABLED` | `guards.enabled` |
+| `SIGIL_GUARDS_TIMEOUT_MS` | `guards.timeoutMs` (integer milliseconds) |
+| `SIGIL_GUARDS_FAIL_OPEN` | `guards.failOpen` |
 
 Explicit `auth.mode` in the config file always wins over env-derived auth.
 

--- a/plugins/pi/src/client.test.ts
+++ b/plugins/pi/src/client.test.ts
@@ -22,7 +22,7 @@ import { createSigilClient } from "./client.js";
 
 function makeConfig(overrides?: Partial<SigilPiConfig>): SigilPiConfig {
   return {
-    endpoint: "http://localhost:8080/api/v1/generations:export",
+    endpoint: "http://localhost:8080",
     auth: { mode: "none" },
     agentName: "pi",
     contentCapture: "metadata_only",
@@ -31,6 +31,11 @@ function makeConfig(overrides?: Partial<SigilPiConfig>): SigilPiConfig {
       enabled: true,
       redactInputMessages: true,
       redactEmailAddresses: true,
+    },
+    guards: {
+      enabled: false,
+      timeoutMs: 1500,
+      failOpen: true,
     },
     ...overrides,
   };
@@ -59,10 +64,31 @@ describe("createSigilClient", () => {
         endpoint: "http://localhost:8080/api/v1/generations:export",
         auth: { mode: "tenant", tenantId: "t-1" },
       },
+      api: { endpoint: "http://localhost:8080" },
+      hooks: {
+        enabled: false,
+        phases: ["postflight"],
+        timeoutMs: 1500,
+        failOpen: true,
+      },
       contentCapture: "metadata_only",
       logger: expect.any(Object),
       generationSanitizer: SANITIZER,
     });
+  });
+
+  it("appends the export path for a prefix-mounted endpoint", () => {
+    createSigilClient(
+      makeConfig({ endpoint: "https://sigil.example.com/sigil" }),
+    );
+    expect(SigilClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generationExport: expect.objectContaining({
+          endpoint: "https://sigil.example.com/sigil/api/v1/generations:export",
+        }),
+        api: { endpoint: "https://sigil.example.com/sigil" },
+      }),
+    );
   });
 
   it("maps basic auth to sdk format with tenantId", () => {
@@ -88,10 +114,41 @@ describe("createSigilClient", () => {
           tenantId: "12345",
         },
       },
+      api: { endpoint: "http://localhost:8080" },
+      hooks: {
+        enabled: false,
+        phases: ["postflight"],
+        timeoutMs: 1500,
+        failOpen: true,
+      },
       contentCapture: "metadata_only",
       logger: expect.any(Object),
       generationSanitizer: SANITIZER,
     });
+  });
+
+  it("forwards guards config to the SDK hooks block", () => {
+    createSigilClient(
+      makeConfig({
+        endpoint: "https://sigil.example.com",
+        guards: { enabled: true, timeoutMs: 2500, failOpen: false },
+      }),
+    );
+
+    expect(SigilClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        api: { endpoint: "https://sigil.example.com" },
+        generationExport: expect.objectContaining({
+          endpoint: "https://sigil.example.com/api/v1/generations:export",
+        }),
+        hooks: {
+          enabled: true,
+          phases: ["postflight"],
+          timeoutMs: 2500,
+          failOpen: false,
+        },
+      }),
+    );
   });
 
   it("passes contentCapture to SigilClient", () => {

--- a/plugins/pi/src/client.ts
+++ b/plugins/pi/src/client.ts
@@ -8,6 +8,7 @@ import {
 } from "@grafana/sigil-sdk-js";
 import type { Meter, Tracer } from "@opentelemetry/api";
 import type { SigilAuthConfig, SigilPiConfig } from "./config.js";
+import { EXPORT_PATH } from "./config.js";
 
 export interface SigilClientOptions {
   tracer?: Tracer;
@@ -49,8 +50,15 @@ export function createSigilClient(
     return new SigilClient({
       generationExport: {
         protocol: "http",
-        endpoint: config.endpoint,
+        endpoint: appendExportPath(config.endpoint),
         auth: mapAuth(config.auth),
+      },
+      api: { endpoint: config.endpoint },
+      hooks: {
+        enabled: config.guards.enabled,
+        phases: ["postflight"],
+        timeoutMs: config.guards.timeoutMs,
+        failOpen: config.guards.failOpen,
       },
       contentCapture: config.contentCapture,
       ...(options?.tracer ? { tracer: options.tracer } : {}),
@@ -66,6 +74,23 @@ export function createSigilClient(
   } catch (err) {
     console.warn("[sigil-pi] failed to create SigilClient:", err);
     return null;
+  }
+}
+
+/**
+ * Append `/api/v1/generations:export` to a bare Sigil base URL. The SDK's
+ * own normalizer only appends when the URL has no path, which breaks
+ * prefix-mounted Sigil deployments (`https://host/prefix`) — so we do it
+ * here unconditionally.
+ */
+function appendExportPath(endpoint: string): string {
+  if (!endpoint) return "";
+  try {
+    const url = new URL(endpoint);
+    url.pathname = url.pathname.replace(/\/+$/, "") + EXPORT_PATH;
+    return url.toString();
+  } catch {
+    return endpoint.replace(/\/+$/, "") + EXPORT_PATH;
   }
 }
 

--- a/plugins/pi/src/config.test.ts
+++ b/plugins/pi/src/config.test.ts
@@ -27,52 +27,49 @@ describe("resolveConfig", () => {
 
   it("parses full config from file", () => {
     const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
+      endpoint: "http://localhost:8080",
       auth: { mode: "tenant", tenantId: "my-tenant" },
       agentName: "pi-custom",
       agentVersion: "1.0.0",
       contentCapture: true,
     });
     expect(cfg).not.toBeNull();
-    expect(cfg?.endpoint).toBe(
-      "http://localhost:8080/api/v1/generations:export",
-    );
+    expect(cfg?.endpoint).toBe("http://localhost:8080");
     expect(cfg?.auth).toEqual({ mode: "tenant", tenantId: "my-tenant" });
     expect(cfg?.agentName).toBe("pi-custom");
     expect(cfg?.agentVersion).toBe("1.0.0");
     expect(cfg?.contentCapture).toBe("full");
   });
 
-  it("auto-appends export path to endpoint", () => {
+  it("stores the bare base URL when given a clean endpoint", () => {
     const cfg = resolveConfig({ endpoint: "http://localhost:8080" });
-    expect(cfg?.endpoint).toBe(
-      "http://localhost:8080/api/v1/generations:export",
-    );
+    expect(cfg?.endpoint).toBe("http://localhost:8080");
   });
 
-  it("auto-appends export path and strips trailing slash", () => {
+  it("strips a trailing slash", () => {
     const cfg = resolveConfig({ endpoint: "http://localhost:8080/" });
-    expect(cfg?.endpoint).toBe(
-      "http://localhost:8080/api/v1/generations:export",
-    );
+    expect(cfg?.endpoint).toBe("http://localhost:8080");
   });
 
-  it("does not double-append export path", () => {
+  it("strips an accidentally-pasted export-path suffix", () => {
     const cfg = resolveConfig({
       endpoint: "http://localhost:8080/api/v1/generations:export",
     });
-    expect(cfg?.endpoint).toBe(
-      "http://localhost:8080/api/v1/generations:export",
-    );
+    expect(cfg?.endpoint).toBe("http://localhost:8080");
   });
 
-  it("preserves an export path with a query string", () => {
+  it("preserves a prefix path", () => {
     const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export?debug=1",
+      endpoint: "https://sigil.example.com/sigil",
     });
-    expect(cfg?.endpoint).toBe(
-      "http://localhost:8080/api/v1/generations:export?debug=1",
-    );
+    expect(cfg?.endpoint).toBe("https://sigil.example.com/sigil");
+  });
+
+  it("strips the export-path suffix from a prefix-mounted URL", () => {
+    const cfg = resolveConfig({
+      endpoint: "https://sigil.example.com/sigil/api/v1/generations:export",
+    });
+    expect(cfg?.endpoint).toBe("https://sigil.example.com/sigil");
   });
 
   it("does not falsely match a similar-looking suffix", () => {
@@ -80,7 +77,7 @@ describe("resolveConfig", () => {
       endpoint: "http://localhost:8080/api/v1/generations:export-debug",
     });
     expect(cfg?.endpoint).toBe(
-      "http://localhost:8080/api/v1/generations:export-debug/api/v1/generations:export",
+      "http://localhost:8080/api/v1/generations:export-debug",
     );
   });
 
@@ -150,7 +147,7 @@ describe("resolveConfig", () => {
       auth: { mode: "none" },
     });
 
-    expect(cfg?.endpoint).toBe("http://env:9090/api/v1/generations:export");
+    expect(cfg?.endpoint).toBe("http://env:9090");
     expect(cfg?.agentName).toBe("pi-env");
     expect(cfg?.contentCapture).toBe("full");
     expect(cfg?.auth).toEqual({ mode: "bearer", bearerToken: "tok-123" });
@@ -244,18 +241,14 @@ describe("resolveConfig canonical SIGIL_* env vars", () => {
   it("reads SIGIL_ENDPOINT as the endpoint", () => {
     process.env.SIGIL_ENDPOINT = "http://canonical:8080";
     const cfg = resolveConfig({});
-    expect(cfg?.endpoint).toBe(
-      "http://canonical:8080/api/v1/generations:export",
-    );
+    expect(cfg?.endpoint).toBe("http://canonical:8080");
   });
 
   it("SIGIL_ENDPOINT wins over SIGIL_PI_ENDPOINT", () => {
     process.env.SIGIL_ENDPOINT = "http://canonical:8080";
     process.env.SIGIL_PI_ENDPOINT = "http://legacy:9090";
     const cfg = resolveConfig({});
-    expect(cfg?.endpoint).toBe(
-      "http://canonical:8080/api/v1/generations:export",
-    );
+    expect(cfg?.endpoint).toBe("http://canonical:8080");
   });
 
   it("derives basic auth from SIGIL_AUTH_TENANT_ID + SIGIL_AUTH_TOKEN", () => {
@@ -596,6 +589,151 @@ describe("resolveConfig redaction", () => {
       endpoint: "http://localhost:8080/api/v1/generations:export",
     });
     expect(cfg?.redaction.redactInputMessages).toBe(false);
+  });
+});
+
+describe("resolveConfig guards", () => {
+  beforeEach(clearEnv);
+  afterEach(clearEnv);
+
+  it("defaults to disabled with 1500ms timeout and fail-open=true", () => {
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+    });
+    expect(cfg?.guards).toEqual({
+      enabled: false,
+      timeoutMs: 1500,
+      failOpen: true,
+    });
+  });
+
+  it("reads file-level guards block", () => {
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      guards: { enabled: true, timeoutMs: 2500, failOpen: false },
+    });
+    expect(cfg?.guards).toEqual({
+      enabled: true,
+      timeoutMs: 2500,
+      failOpen: false,
+    });
+  });
+
+  it("env overrides file values", () => {
+    process.env.SIGIL_GUARDS_ENABLED = "true";
+    process.env.SIGIL_GUARDS_TIMEOUT_MS = "1500";
+    process.env.SIGIL_GUARDS_FAIL_OPEN = "true";
+
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      guards: { enabled: false, timeoutMs: 2500, failOpen: false },
+    });
+
+    expect(cfg?.guards).toEqual({
+      enabled: true,
+      timeoutMs: 1500,
+      failOpen: true,
+    });
+  });
+
+  it("enables guards via canonical env var only", () => {
+    process.env.SIGIL_GUARDS_ENABLED = "true";
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+    });
+    expect(cfg?.guards.enabled).toBe(true);
+  });
+
+  it("does not recognise the pi-prefixed alias", () => {
+    process.env.SIGIL_PI_GUARDS_ENABLED = "true";
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+    });
+    expect(cfg?.guards.enabled).toBe(false);
+  });
+
+  it("warns and falls back to default when SIGIL_GUARDS_ENABLED is not a boolean", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.SIGIL_GUARDS_ENABLED = "maybe";
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+    });
+    expect(cfg).not.toBeNull();
+    expect(cfg?.guards.enabled).toBe(false);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("invalid boolean value for SIGIL_GUARDS_ENABLED"),
+    );
+    warn.mockRestore();
+  });
+
+  it("warns and falls back to default when SIGIL_GUARDS_TIMEOUT_MS is not numeric", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.SIGIL_GUARDS_TIMEOUT_MS = "fast";
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+    });
+    expect(cfg).not.toBeNull();
+    expect(cfg?.guards.timeoutMs).toBe(1500);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "invalid integer value for SIGIL_GUARDS_TIMEOUT_MS",
+      ),
+    );
+    warn.mockRestore();
+  });
+
+  it("rejects SIGIL_GUARDS_TIMEOUT_MS=0 so the SDK does not fall back to its 15s default", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.SIGIL_GUARDS_TIMEOUT_MS = "0";
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+    });
+    expect(cfg?.guards.timeoutMs).toBe(1500);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "invalid integer value for SIGIL_GUARDS_TIMEOUT_MS",
+      ),
+    );
+    warn.mockRestore();
+  });
+
+  it("rejects guards.timeoutMs=0 from the file config", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+      guards: { timeoutMs: 0 },
+    });
+    expect(cfg?.guards.timeoutMs).toBe(1500);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("invalid integer value for guards.* file entry"),
+    );
+    warn.mockRestore();
+  });
+
+  it("warns and falls back to default when SIGIL_GUARDS_FAIL_OPEN is not a boolean", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.SIGIL_GUARDS_FAIL_OPEN = "sometimes";
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+    });
+    expect(cfg).not.toBeNull();
+    expect(cfg?.guards.failOpen).toBe(true);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "invalid boolean value for SIGIL_GUARDS_FAIL_OPEN",
+      ),
+    );
+    warn.mockRestore();
+  });
+
+  it("supports truthy aliases (on, yes, 1) for env vars", () => {
+    process.env.SIGIL_GUARDS_ENABLED = "on";
+    process.env.SIGIL_GUARDS_FAIL_OPEN = "no";
+    const cfg = resolveConfig({
+      endpoint: "http://localhost:8080/api/v1/generations:export",
+    });
+    expect(cfg?.guards.enabled).toBe(true);
+    expect(cfg?.guards.failOpen).toBe(false);
   });
 });
 

--- a/plugins/pi/src/config.ts
+++ b/plugins/pi/src/config.ts
@@ -20,6 +20,12 @@ export interface RedactionConfig {
   redactEmailAddresses: boolean;
 }
 
+export interface GuardsFeatureConfig {
+  enabled: boolean;
+  timeoutMs: number;
+  failOpen: boolean;
+}
+
 export interface SigilPiConfig {
   endpoint: string;
   auth: SigilAuthConfig;
@@ -29,6 +35,7 @@ export interface SigilPiConfig {
   debug: boolean;
   otlp?: OtlpConfig;
   redaction: RedactionConfig;
+  guards: GuardsFeatureConfig;
 }
 
 const CONFIG_PATH = join(homedir(), ".config", "sigil-pi", "config.json");
@@ -57,7 +64,7 @@ export function resolveConfig(
   // precedence over the legacy SIGIL_PI_* prefix so a single config.env can
   // drive every agent. The pi-specific names remain as a fallback so users
   // who already configured them keep working.
-  const endpoint = ensureExportPath(
+  const endpoint = normalizeBaseEndpoint(
     (
       env("SIGIL_ENDPOINT") ??
       env("SIGIL_PI_ENDPOINT") ??
@@ -97,6 +104,7 @@ export function resolveConfig(
 
   const otlp = resolveOtlp(file);
   const redaction = resolveRedaction(file);
+  const guards = resolveGuards(file);
 
   return {
     endpoint,
@@ -107,7 +115,93 @@ export function resolveConfig(
     debug,
     otlp,
     redaction,
+    guards,
   };
+}
+
+function resolveGuards(file: Record<string, unknown>): GuardsFeatureConfig {
+  const guardsObj = (file.guards ?? {}) as Record<string, unknown>;
+
+  const enabled = resolveGuardsBool(
+    "SIGIL_GUARDS_ENABLED",
+    guardsObj.enabled,
+    false,
+  );
+  const timeoutMs = resolveGuardsInt(
+    "SIGIL_GUARDS_TIMEOUT_MS",
+    guardsObj.timeoutMs,
+    1500,
+  );
+  const failOpen = resolveGuardsBool(
+    "SIGIL_GUARDS_FAIL_OPEN",
+    guardsObj.failOpen,
+    true,
+  );
+
+  return { enabled, timeoutMs, failOpen };
+}
+
+function resolveGuardsBool(
+  envKey: string,
+  fileValue: unknown,
+  defaultValue: boolean,
+): boolean {
+  const rawEnv = env(envKey);
+  if (rawEnv !== undefined) {
+    const parsed = toBool(rawEnv);
+    if (parsed === undefined) {
+      console.warn(
+        `[sigil-pi] invalid boolean value for ${envKey}: "${rawEnv}" — using default ${defaultValue}`,
+      );
+      return defaultValue;
+    }
+    return parsed;
+  }
+  if (fileValue !== undefined) {
+    const parsed = toBool(fileValue);
+    if (parsed === undefined) {
+      console.warn(
+        `[sigil-pi] invalid boolean value for guards.* file entry — using default ${defaultValue}`,
+      );
+      return defaultValue;
+    }
+    return parsed;
+  }
+  return defaultValue;
+}
+
+function resolveGuardsInt(
+  envKey: string,
+  fileValue: unknown,
+  defaultValue: number,
+): number {
+  // 0 is rejected: the SDK interprets timeoutMs <= 0 as "use built-in default
+  // (15000ms)", which would silently override the plugin's documented 1500ms.
+  const rawEnv = env(envKey);
+  if (rawEnv !== undefined) {
+    const n = Number(rawEnv);
+    if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
+      console.warn(
+        `[sigil-pi] invalid integer value for ${envKey}: "${rawEnv}" — using default ${defaultValue}`,
+      );
+      return defaultValue;
+    }
+    return n;
+  }
+  if (fileValue !== undefined) {
+    if (
+      typeof fileValue !== "number" ||
+      !Number.isInteger(fileValue) ||
+      fileValue <= 0
+    ) {
+      console.warn(
+        `[sigil-pi] invalid integer value for guards.* file entry — using default ${defaultValue}`,
+      );
+      return defaultValue;
+    }
+    return fileValue;
+  }
+  return defaultValue;
 }
 
 function resolveRedaction(file: Record<string, unknown>): RedactionConfig {
@@ -374,26 +468,33 @@ function parseConfig(raw: string): Record<string, unknown> {
   return parsed as Record<string, unknown>;
 }
 
-const EXPORT_PATH = "/api/v1/generations:export";
+export const EXPORT_PATH = "/api/v1/generations:export";
 
 /**
- * Normalize a Sigil endpoint by appending `/api/v1/generations:export` unless
- * the path already ends with it. URL parsing handles trailing slashes and
- * query strings; non-URL inputs fall through and let the SDK surface the
- * failure later.
+ * Normalize a Sigil endpoint to the bare API base URL. Accepts either the
+ * base URL (`https://host` or `https://host/prefix`) or a full generations
+ * export URL (`https://host/api/v1/generations:export`) — the latter is a
+ * common copy-paste mistake. Trailing slashes are stripped. The export path
+ * is reapplied in `client.ts` when constructing the generationExport URL.
  */
-function ensureExportPath(endpoint: string): string {
+function normalizeBaseEndpoint(endpoint: string): string {
   if (!endpoint) return "";
-  let url: URL;
   try {
-    url = new URL(endpoint);
+    const url = new URL(endpoint);
+    let pathname = url.pathname.replace(/\/+$/, "");
+    if (pathname.endsWith(EXPORT_PATH)) {
+      pathname = pathname.slice(0, pathname.length - EXPORT_PATH.length);
+    }
+    url.pathname = pathname;
+    // URL preserves a trailing "/" when pathname is empty; strip it for a
+    // tidy stored value ("http://host" rather than "http://host/").
+    return url.toString().replace(/\/+$/, "");
   } catch {
-    return endpoint.replace(/\/+$/, "") + EXPORT_PATH;
+    const trimmed = endpoint.replace(/\/+$/, "");
+    return trimmed.endsWith(EXPORT_PATH)
+      ? trimmed.slice(0, trimmed.length - EXPORT_PATH.length)
+      : trimmed;
   }
-  const cleanPath = url.pathname.replace(/\/+$/, "");
-  if (cleanPath.endsWith(EXPORT_PATH)) return endpoint;
-  url.pathname = cleanPath + EXPORT_PATH;
-  return url.toString();
 }
 
 function isMissingFileError(err: unknown): boolean {

--- a/plugins/pi/src/guard.test.ts
+++ b/plugins/pi/src/guard.test.ts
@@ -1,0 +1,167 @@
+import type {
+  HookEvaluateRequest,
+  HookEvaluateResponse,
+  SigilClient,
+} from "@grafana/sigil-sdk-js";
+import { describe, expect, it, vi } from "vitest";
+import { type GuardArgs, runToolCallGuard } from "./guard.js";
+
+function makeClient(
+  evaluateHook: (
+    req: HookEvaluateRequest,
+    override?: unknown,
+  ) => Promise<HookEvaluateResponse>,
+): {
+  client: SigilClient;
+  calls: Array<{ req: HookEvaluateRequest; override: unknown }>;
+} {
+  const calls: Array<{ req: HookEvaluateRequest; override: unknown }> = [];
+  const client = {
+    evaluateHook: vi.fn(
+      async (req: HookEvaluateRequest, override?: unknown) => {
+        calls.push({ req, override });
+        return evaluateHook(req, override);
+      },
+    ),
+  } as unknown as SigilClient;
+  return { client, calls };
+}
+
+function makeArgs(overrides?: Partial<GuardArgs>): GuardArgs {
+  return {
+    client: {} as SigilClient,
+    agentName: "pi",
+    agentVersion: "1.0.0",
+    model: { provider: "anthropic", name: "claude-sonnet-4" },
+    toolCallId: "c1",
+    toolName: "bash",
+    input: { command: "ls" },
+    failOpen: true,
+    ...overrides,
+  };
+}
+
+describe("runToolCallGuard", () => {
+  it("returns undefined when the server allows", async () => {
+    const { client } = makeClient(async () => ({
+      action: "allow",
+      evaluations: [],
+    }));
+
+    const result = await runToolCallGuard(makeArgs({ client }));
+    expect(result).toBeUndefined();
+  });
+
+  it("returns block + reason when the server denies", async () => {
+    const { client } = makeClient(async () => ({
+      action: "deny",
+      reason: "blocked rm -rf",
+      evaluations: [],
+    }));
+
+    const result = await runToolCallGuard(makeArgs({ client }));
+    expect(result).toEqual({ block: true, reason: "blocked rm -rf" });
+  });
+
+  it("falls back to a generic reason when the deny reason is empty", async () => {
+    const { client } = makeClient(async () => ({
+      action: "deny",
+      reason: "   ",
+      evaluations: [],
+    }));
+
+    const result = await runToolCallGuard(makeArgs({ client }));
+    expect(result).toEqual({
+      block: true,
+      reason: "tool call denied by Sigil guard",
+    });
+  });
+
+  it("returns undefined and logs a warning on transport errors when failOpen", async () => {
+    const { client } = makeClient(async () => {
+      throw new Error("network down");
+    });
+    const warn = vi.fn();
+
+    const result = await runToolCallGuard(
+      makeArgs({ client, logger: { warn } }),
+    );
+    expect(result).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("guard eval failed"),
+    );
+  });
+
+  it("fails open when tool input cannot be serialized", async () => {
+    const { client, calls } = makeClient(async () => {
+      throw new Error("should not call evaluateHook");
+    });
+    const warn = vi.fn();
+
+    const result = await runToolCallGuard(
+      makeArgs({ client, input: { value: 1n }, logger: { warn } }),
+    );
+
+    expect(result).toBeUndefined();
+    expect(calls).toHaveLength(0);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("guard eval failed"),
+    );
+  });
+
+  it("returns block on transport errors when failOpen=false", async () => {
+    const { client } = makeClient(async () => {
+      throw new Error("network down");
+    });
+    const warn = vi.fn();
+
+    const result = await runToolCallGuard(
+      makeArgs({ client, failOpen: false, logger: { warn } }),
+    );
+    expect(result).toEqual({
+      block: true,
+      reason: expect.stringContaining("guard evaluation failed"),
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("guard eval failed"),
+    );
+  });
+
+  it("builds a postflight request with the expected shape", async () => {
+    const { client, calls } = makeClient(async () => ({
+      action: "allow",
+      evaluations: [],
+    }));
+
+    await runToolCallGuard(
+      makeArgs({
+        client,
+        toolCallId: "c1",
+        toolName: "bash",
+        input: { command: "ls" },
+      }),
+    );
+
+    expect(calls).toHaveLength(1);
+    const { req, override } = calls[0]!;
+    expect(req.phase).toBe("postflight");
+    expect(req.context.agentName).toBe("pi");
+    expect(req.context.agentVersion).toBe("1.0.0");
+    expect(req.context.model).toEqual({
+      provider: "anthropic",
+      name: "claude-sonnet-4",
+    });
+    expect(req.input.output).toHaveLength(1);
+    const msg = req.input.output![0]!;
+    expect(msg.role).toBe("assistant");
+    expect(msg.parts).toHaveLength(1);
+    const part = msg.parts![0]!;
+    expect(part.type).toBe("tool_call");
+    expect(part.type === "tool_call" && part.toolCall).toEqual({
+      id: "c1",
+      name: "bash",
+      inputJSON: '{"command":"ls"}',
+    });
+    expect(override).toEqual({ enabled: true });
+  });
+});

--- a/plugins/pi/src/guard.ts
+++ b/plugins/pi/src/guard.ts
@@ -1,0 +1,80 @@
+import type { HookEvaluateRequest, SigilClient } from "@grafana/sigil-sdk-js";
+
+export interface GuardArgs {
+  client: SigilClient;
+  agentName: string;
+  agentVersion?: string;
+  model: { provider: string; name: string };
+  toolCallId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  failOpen: boolean;
+  logger?: { warn: (msg: string) => void };
+}
+
+export type GuardBlockResult = { block: true; reason: string };
+
+/**
+ * Evaluates the Sigil postflight hook for a tool call. Returns a block result
+ * when the server denies the call. On transport/timeout/serialization errors,
+ * returns `undefined` (allow) when `failOpen` is true and a block result when
+ * `failOpen` is false.
+ *
+ * Pi treats handler exceptions as blocks (fail-safe), so we catch every error
+ * here and translate it into one of the two outcomes above instead of letting
+ * it propagate.
+ */
+export async function runToolCallGuard(
+  args: GuardArgs,
+): Promise<GuardBlockResult | undefined> {
+  try {
+    const req: HookEvaluateRequest = {
+      phase: "postflight",
+      context: {
+        agentName: args.agentName,
+        agentVersion: args.agentVersion,
+        model: args.model,
+      },
+      input: {
+        output: [
+          {
+            role: "assistant",
+            parts: [
+              {
+                type: "tool_call",
+                toolCall: {
+                  id: args.toolCallId,
+                  name: args.toolName,
+                  inputJSON: JSON.stringify(args.input),
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const resp = await args.client.evaluateHook(req, { enabled: true });
+    if (resp.action === "deny") {
+      return denyResult(resp.reason);
+    }
+    return undefined;
+  } catch (err) {
+    args.logger?.warn(`[sigil-pi] guard eval failed: ${err}`);
+    if (!args.failOpen) {
+      return denyResult(`guard evaluation failed: ${err}`);
+    }
+    return undefined;
+  }
+}
+
+function denyResult(reason: string | undefined): GuardBlockResult {
+  const trimmed = reason?.trim();
+  return {
+    block: true,
+    reason:
+      trimmed && trimmed.length > 0
+        ? trimmed
+        : "tool call denied by Sigil guard",
+  };
+}

--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -1116,6 +1116,236 @@ describe("extension lifecycle", () => {
     expect(capturedSeed!.conversationId).toBeUndefined();
   });
 
+  describe("guards (tool_call wiring)", () => {
+    function makeRecorder() {
+      return {
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        setFirstTokenAt: vi.fn(),
+      };
+    }
+
+    function makeSigilLike(
+      evaluateHook?: ReturnType<typeof vi.fn>,
+    ): SigilLike & { evaluateHook?: ReturnType<typeof vi.fn> } {
+      const recorder = makeRecorder();
+      return {
+        startStreamingGeneration: vi.fn(async (_seed, run) => {
+          await run(recorder);
+        }),
+        startToolExecution: vi.fn(() => ({
+          setResult: vi.fn(),
+          setCallError: vi.fn(),
+          end: vi.fn(),
+          getError: vi.fn(),
+        })),
+        shutdown: vi.fn(async () => {}),
+        ...(evaluateHook ? { evaluateHook } : {}),
+      } as SigilLike & { evaluateHook?: ReturnType<typeof vi.fn> };
+    }
+
+    it("does not call evaluateHook when guards are disabled", async () => {
+      const evaluateHook = vi.fn();
+      const sigil = makeSigilLike(evaluateHook);
+
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+        guards: { enabled: false, timeoutMs: 1500, failOpen: true },
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const fakePi = new FakePi();
+      registerExtension(fakePi as any);
+
+      await fakePi.emit("session_start");
+      await fakePi.emit("turn_start");
+      const handler = fakePi.handlers.get("tool_call")!;
+      const result = await handler(
+        { toolCallId: "c1", toolName: "bash", input: { command: "ls" } },
+        defaultCtx,
+      );
+
+      expect(evaluateHook).not.toHaveBeenCalled();
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined (allow) when guards allow the tool call", async () => {
+      const evaluateHook = vi
+        .fn()
+        .mockResolvedValue({ action: "allow", evaluations: [] });
+      const sigil = makeSigilLike(evaluateHook);
+
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+        guards: { enabled: true, timeoutMs: 1500, failOpen: true },
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const fakePi = new FakePi();
+      registerExtension(fakePi as any);
+
+      await fakePi.emit("session_start");
+      await fakePi.emit("turn_start");
+      const handler = fakePi.handlers.get("tool_call")!;
+      const result = await handler(
+        { toolCallId: "c1", toolName: "bash", input: { command: "ls" } },
+        defaultCtx,
+      );
+
+      expect(evaluateHook).toHaveBeenCalledTimes(1);
+      expect(result).toBeUndefined();
+    });
+
+    it("returns { block, reason } when guards deny the tool call", async () => {
+      const evaluateHook = vi.fn().mockResolvedValue({
+        action: "deny",
+        reason: "blocked rm -rf",
+        evaluations: [],
+      });
+      const sigil = makeSigilLike(evaluateHook);
+
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+        guards: { enabled: true, timeoutMs: 1500, failOpen: true },
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const fakePi = new FakePi();
+      registerExtension(fakePi as any);
+
+      await fakePi.emit("session_start");
+      await fakePi.emit("turn_start");
+      const handler = fakePi.handlers.get("tool_call")!;
+      const result = await handler(
+        { toolCallId: "c1", toolName: "bash", input: { command: "rm -rf /" } },
+        defaultCtx,
+      );
+
+      expect(result).toEqual({ block: true, reason: "blocked rm -rf" });
+    });
+
+    it("forwards the model cached from the current assistant message_end", async () => {
+      const evaluateHook = vi
+        .fn()
+        .mockResolvedValue({ action: "allow", evaluations: [] });
+      const sigil = makeSigilLike(evaluateHook);
+
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+        guards: { enabled: true, timeoutMs: 1500, failOpen: true },
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const fakePi = new FakePi();
+      registerExtension(fakePi as any);
+
+      await fakePi.emit("session_start");
+      await fakePi.emit("turn_start");
+      await fakePi.emit("message_end", { message: assistantMessage() });
+      const handler = fakePi.handlers.get("tool_call")!;
+      await handler(
+        { toolCallId: "c1", toolName: "bash", input: { command: "ls" } },
+        defaultCtx,
+      );
+
+      const req = evaluateHook.mock.calls[0]![0] as {
+        context: { model: { provider: string; name: string } };
+      };
+      expect(req.context.model).toEqual({
+        provider: "anthropic",
+        name: "claude-sonnet-4",
+      });
+    });
+
+    it("falls back to unknown model when no assistant message has ended yet", async () => {
+      const evaluateHook = vi
+        .fn()
+        .mockResolvedValue({ action: "allow", evaluations: [] });
+      const sigil = makeSigilLike(evaluateHook);
+
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+        guards: { enabled: true, timeoutMs: 1500, failOpen: true },
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const fakePi = new FakePi();
+      registerExtension(fakePi as any);
+
+      await fakePi.emit("session_start");
+      await fakePi.emit("turn_start");
+      const handler = fakePi.handlers.get("tool_call")!;
+      await handler(
+        { toolCallId: "c1", toolName: "bash", input: { command: "ls" } },
+        defaultCtx,
+      );
+
+      const req = evaluateHook.mock.calls[0]![0] as {
+        context: { model: { provider: string; name: string } };
+      };
+      expect(req.context.model).toEqual({
+        provider: "unknown",
+        name: "unknown",
+      });
+    });
+
+    it("clears the cached model on session_shutdown", async () => {
+      const evaluateHook = vi
+        .fn()
+        .mockResolvedValue({ action: "allow", evaluations: [] });
+      const sigil = makeSigilLike(evaluateHook);
+
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+        guards: { enabled: true, timeoutMs: 1500, failOpen: true },
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const fakePi = new FakePi();
+      registerExtension(fakePi as any);
+
+      await fakePi.emit("session_start");
+      await fakePi.emit("turn_start");
+      await fakePi.emit("message_end", { message: assistantMessage() });
+      await fakePi.emit("session_shutdown");
+
+      // Re-init session and immediately try a tool_call (no assistant message yet).
+      await fakePi.emit("session_start");
+      await fakePi.emit("turn_start");
+      const handler = fakePi.handlers.get("tool_call")!;
+      await handler(
+        { toolCallId: "c1", toolName: "bash", input: { command: "ls" } },
+        defaultCtx,
+      );
+
+      const req = evaluateHook.mock.calls[0]![0] as {
+        context: { model: { provider: string; name: string } };
+      };
+      expect(req.context.model).toEqual({
+        provider: "unknown",
+        name: "unknown",
+      });
+    });
+  });
+
   it("emits git.branch tag when contentCapture=full", async () => {
     resolveGitBranchMock.mockReturnValue("feature-x");
 

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -12,6 +12,7 @@ import { createSigilClient } from "./client.js";
 import type { SigilPiConfig } from "./config.js";
 import { loadConfig } from "./config.js";
 import { resolveGitBranch } from "./git.js";
+import { runToolCallGuard } from "./guard.js";
 import {
   mapGenerationResult,
   mapGenerationStart,
@@ -59,6 +60,9 @@ export default function (pi: ExtensionAPI) {
   let sigil: SigilClient | null = null;
   let config: SigilPiConfig | null = null;
   let telemetry: TelemetryProviders | null = null;
+  // Cached from the latest assistant message. `tool_call` events carry no model
+  // metadata, so guards read it from `message_end` before the tool runs.
+  let lastSeenModel: { provider: string; name: string } | null = null;
 
   let turnStartTime = 0;
   // Earliest `message_update` event observed in the current turn. Pi emits
@@ -109,6 +113,14 @@ export default function (pi: ExtensionAPI) {
     }
     resetTurnState();
     pendingInputMessages.length = 0;
+    lastSeenModel = null;
+  }
+
+  function cacheAssistantModel(message: PiAssistantMessage) {
+    lastSeenModel = {
+      provider: message.provider,
+      name: message.model,
+    };
   }
 
   pi.on("session_start", async (_event, ctx) => {
@@ -183,6 +195,9 @@ export default function (pi: ExtensionAPI) {
         if (assistantMessageEndTime === 0) {
           assistantMessageEndTime = Date.now();
         }
+        if (isAssistantMessage(message)) {
+          cacheAssistantModel(message);
+        }
         return;
       }
       if (!isUserMessage(message)) return;
@@ -204,6 +219,21 @@ export default function (pi: ExtensionAPI) {
     const role = (event as { message?: { role?: string } }).message?.role;
     if (role !== "assistant") return;
     firstTokenTime = Date.now();
+  });
+
+  pi.on("tool_call", async (event, _ctx) => {
+    if (!sigil || !config?.guards.enabled) return;
+    return runToolCallGuard({
+      client: sigil,
+      agentName: config.agentName,
+      agentVersion: config.agentVersion,
+      model: lastSeenModel ?? { provider: "unknown", name: "unknown" },
+      toolCallId: event.toolCallId,
+      toolName: event.toolName,
+      input: event.input as Record<string, unknown>,
+      failOpen: config.guards.failOpen,
+      logger: { warn: (msg: string) => console.warn(msg) },
+    });
   });
 
   pi.on("tool_execution_start", async (event, _ctx) => {
@@ -365,6 +395,7 @@ export default function (pi: ExtensionAPI) {
     }
 
     sigil = null;
+    lastSeenModel = null;
     await resetSessionState();
   });
 }


### PR DESCRIPTION
Adds Guards support, so that tool executions can be blocked. Mirrors the same `PreToolUse → EvaluateHook(postflight)` flow the claude-code plugin already implements.

**What it does**

When guards are enabled, every tool call pi is about to run is sent to Sigil's `/api/v1/hooks:evaluate` endpoint with `phase: "postflight"`. If the server returns `action: "deny"`, pi blocks the tool and surfaces the reason to the model. Otherwise the tool runs normally.

Default behavior:

- Disabled. The plugin's existing generation export is unchanged unless you opt in.
- Fail-open: transport errors, timeouts, and unexpected exceptions allow the tool through. Flip `SIGIL_GUARDS_FAIL_OPEN=false` to block instead.

**Configure**

Minimum to turn it on:

```sh
SIGIL_GUARDS_ENABLED=true pi
```

Full config block in `~/.config/sigil-pi/config.json`:

```json
{
  "guards": {
    "enabled": true,
    "timeoutMs": 1500,
    "failOpen": true
  }
}
```

Env vars:

| Variable | Default | Purpose |
|---|---|---|
| `SIGIL_GUARDS_ENABLED` | `false` | Turn guards on. |
| `SIGIL_GUARDS_TIMEOUT_MS` | `1500` | Per-call timeout. `0` is rejected because the SDK would silently fall back to 15 s. |
| `SIGIL_GUARDS_FAIL_OPEN` | `true` | When `false`, transport errors block the tool with a `guard evaluation failed` reason. |

Env vars override the file. Invalid values warn and fall back to defaults. They don't disable the rest of the plugin.

The Sigil guard rules themselves are configured server-side in the Grafana AI Observability UI.

**Not implemented**

- Argument-level filtering via `transformedInput` (would mutate `event.input` in place instead of blocking the call).



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new pre-execution decision point that can block `tool_call`s based on remote hook evaluation, so misconfiguration or server issues could change tool execution behavior. Also changes endpoint normalization to preserve path prefixes, which may affect how some deployments construct API URLs.
> 
> **Overview**
> Adds **optional Sigil “guards”** to the `pi` plugin: when enabled, each `tool_call` is evaluated via Sigil hooks (`postflight`), and a server `deny` blocks the tool with the returned reason (with configurable *fail-open vs fail-closed* behavior).
> 
> Refactors endpoint handling in `sigil-pi` to store a **bare base URL** (stripping accidentally pasted `/api/v1/generations:export` and trailing slashes) and to **append the export path at client construction time**, including support for prefix-mounted deployments.
> 
> Updates the JS SDK URL normalizers for hooks evaluation and conversation ratings to **preserve any path prefix** in `api.endpoint`, and extends tests/docs to cover prefix/trailing-slash routing plus the new guards config/env vars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a70fe3635b8bd123906828fa3965e4f83dbc4fb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->