### PR TITLE
feat(sdk): record metrics while span is active for exemplar support

### DIFF
--- a/dotnet/src/Grafana.Sigil/SigilClient.cs
+++ b/dotnet/src/Grafana.Sigil/SigilClient.cs
@@ -2325,11 +2325,10 @@ public sealed class GenerationRecorder
             {
                 _activity.SetStatus(ActivityStatusCode.Ok);
             }
-
-            _activity.Stop();
         }
 
         _client.RecordGenerationMetrics(generation, errorType, errorCategory, firstTokenAt);
+        _activity?.Stop();
 
         LastGeneration = InternalUtils.DeepClone(generation);
         Error = localError;
@@ -2604,12 +2603,12 @@ public sealed class EmbeddingRecorder
             {
                 _activity.SetStatus(ActivityStatusCode.Ok);
             }
-
-            _activity.SetEndTime(completedAt.UtcDateTime);
-            _activity.Stop();
         }
 
         _client.RecordEmbeddingMetrics(_seed, result, _startedAt, completedAt, errorType, errorCategory);
+        _activity?.SetEndTime(completedAt.UtcDateTime);
+        _activity?.Stop();
+
         Error = localError;
     }
 }
@@ -2749,12 +2748,12 @@ public sealed class ToolExecutionRecorder
             {
                 _activity.SetStatus(ActivityStatusCode.Ok);
             }
-
-            _activity.SetEndTime(completedAt.UtcDateTime);
-            _activity.Stop();
         }
 
         _client!.RecordToolExecutionMetrics(_seed, _startedAt, completedAt, finalError);
+        _activity?.SetEndTime(completedAt.UtcDateTime);
+        _activity?.Stop();
+
         Error = finalError;
     }
 }

--- a/dotnet/tests/Grafana.Sigil.Tests/MetricExemplarTests.cs
+++ b/dotnet/tests/Grafana.Sigil.Tests/MetricExemplarTests.cs
@@ -1,0 +1,91 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Xunit;
+
+namespace Grafana.Sigil.Tests;
+
+public sealed class MetricExemplarTests
+{
+    [Fact]
+    public async Task GenerationMetrics_RecordedWhileActivityIsCurrent()
+    {
+        using var harness = new ExemplarHarness();
+        await using var client = harness.NewClient();
+
+        var recorder = client.StartGeneration(TestHelpers.CreateSeedStart());
+        recorder.SetResult(TestHelpers.CreateSeedResult());
+        recorder.End();
+
+        Assert.NotNull(harness.CapturedActivityId);
+    }
+
+    [Fact]
+    public async Task EmbeddingMetrics_RecordedWhileActivityIsCurrent()
+    {
+        using var harness = new ExemplarHarness();
+        await using var client = harness.NewClient();
+
+        var recorder = client.StartEmbedding(new EmbeddingStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "text-embedding-3-small" },
+            AgentName = "test-agent",
+        });
+        recorder.SetResult(new EmbeddingResult { InputTokens = 42, InputCount = 1 });
+        recorder.End();
+
+        Assert.NotNull(harness.CapturedActivityId);
+    }
+
+    [Fact]
+    public async Task ToolExecutionMetrics_RecordedWhileActivityIsCurrent()
+    {
+        using var harness = new ExemplarHarness();
+        await using var client = harness.NewClient();
+
+        var recorder = client.StartToolExecution(new ToolExecutionStart
+        {
+            ToolName = "weather",
+            AgentName = "test-agent",
+        });
+        recorder.SetResult(new ToolExecutionResult { Result = "sunny" });
+        recorder.End();
+
+        Assert.NotNull(harness.CapturedActivityId);
+    }
+
+    private sealed class ExemplarHarness : IDisposable
+    {
+        private readonly MeterListener _listener;
+
+        public string? CapturedActivityId { get; private set; }
+
+        public ExemplarHarness()
+        {
+            _listener = new MeterListener();
+            _listener.InstrumentPublished += (instrument, meterListener) =>
+            {
+                if (instrument.Name == "gen_ai.client.operation.duration")
+                {
+                    meterListener.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<double>((instrument, _, _, _) =>
+            {
+                CapturedActivityId = Activity.Current?.Id;
+            });
+            _listener.Start();
+        }
+
+        public SigilClient NewClient()
+        {
+            var exporter = new CapturingGenerationExporter();
+            var config = TestHelpers.TestConfig(exporter);
+            return new SigilClient(config);
+        }
+
+        public void Dispose()
+        {
+            _listener.Dispose();
+        }
+    }
+}

--- a/dotnet/tests/Grafana.Sigil.Tests/MetricExemplarTests.cs
+++ b/dotnet/tests/Grafana.Sigil.Tests/MetricExemplarTests.cs
@@ -55,25 +55,33 @@ public sealed class MetricExemplarTests
 
     private sealed class ExemplarHarness : IDisposable
     {
-        private readonly MeterListener _listener;
+        private readonly MeterListener _meterListener;
+        private readonly ActivityListener _activityListener;
 
         public string? CapturedActivityId { get; private set; }
 
         public ExemplarHarness()
         {
-            _listener = new MeterListener();
-            _listener.InstrumentPublished += (instrument, meterListener) =>
+            _activityListener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == SigilClient.InstrumentationName,
+                Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            };
+            ActivitySource.AddActivityListener(_activityListener);
+
+            _meterListener = new MeterListener();
+            _meterListener.InstrumentPublished += (instrument, meterListener) =>
             {
                 if (instrument.Name == "gen_ai.client.operation.duration")
                 {
                     meterListener.EnableMeasurementEvents(instrument);
                 }
             };
-            _listener.SetMeasurementEventCallback<double>((instrument, _, _, _) =>
+            _meterListener.SetMeasurementEventCallback<double>((instrument, _, _, _) =>
             {
                 CapturedActivityId = Activity.Current?.Id;
             });
-            _listener.Start();
+            _meterListener.Start();
         }
 
         public SigilClient NewClient()
@@ -85,7 +93,8 @@ public sealed class MetricExemplarTests
 
         public void Dispose()
         {
-            _listener.Dispose();
+            _meterListener.Dispose();
+            _activityListener.Dispose();
         }
     }
 }

--- a/dotnet/tests/Grafana.Sigil.Tests/MetricExemplarTests.cs
+++ b/dotnet/tests/Grafana.Sigil.Tests/MetricExemplarTests.cs
@@ -47,7 +47,7 @@ public sealed class MetricExemplarTests
             ToolName = "weather",
             AgentName = "test-agent",
         });
-        recorder.SetResult(new ToolExecutionResult { Result = "sunny" });
+        recorder.SetResult(new ToolExecutionEnd { Result = "sunny" });
         recorder.End();
 
         Assert.NotNull(harness.CapturedActivityId);

--- a/go/sigil/client.go
+++ b/go/sigil/client.go
@@ -198,16 +198,16 @@ const (
 	spanAttrToolCallArguments      = "gen_ai.tool.call.arguments"
 	spanAttrToolCallResult         = "gen_ai.tool.call.result"
 
-	metricOperationDuration      = "gen_ai.client.operation.duration"
-	metricTokenUsage             = "gen_ai.client.token.usage"
-	metricTimeToFirstToken       = "gen_ai.client.time_to_first_token"
-	metricToolCallsPerOperation  = "gen_ai.client.tool_calls_per_operation"
-	metricAttrTokenType          = "gen_ai.token.type"
-	metricTokenTypeInput         = "input"
-	metricTokenTypeOutput        = "output"
-	metricTokenTypeCacheRead     = "cache_read"
-	metricTokenTypeCacheWrite    = "cache_write"
-	metricTokenTypeReasoning     = "reasoning"
+	metricOperationDuration     = "gen_ai.client.operation.duration"
+	metricTokenUsage            = "gen_ai.client.token.usage"
+	metricTimeToFirstToken      = "gen_ai.client.time_to_first_token"
+	metricToolCallsPerOperation = "gen_ai.client.tool_calls_per_operation"
+	metricAttrTokenType         = "gen_ai.token.type"
+	metricTokenTypeInput        = "input"
+	metricTokenTypeOutput       = "output"
+	metricTokenTypeCacheRead    = "cache_read"
+	metricTokenTypeCacheWrite   = "cache_write"
+	metricTokenTypeReasoning    = "reasoning"
 )
 
 // durationBucketsSeconds is the OTel GenAI semantic-convention bucket advice
@@ -892,7 +892,7 @@ func (r *GenerationRecorder) End() {
 	default:
 		r.span.SetStatus(codes.Ok, "")
 	}
-	r.client.recordGenerationMetrics(normalized, errorType, errorCategory, firstTokenAt)
+	r.client.recordGenerationMetrics(r.ctx, normalized, errorType, errorCategory, firstTokenAt)
 	r.span.End(trace.WithTimestamp(normalized.CompletedAt))
 
 	// rec.Err reports local validation/enqueue failures only.
@@ -1034,7 +1034,7 @@ func (r *EmbeddingRecorder) End() {
 		r.span.SetAttributes(attribute.String(spanAttrErrorCategory, errorCategory))
 	}
 
-	r.client.recordEmbeddingMetrics(r.seed, normalized, r.startedAt, completedAt, errorType, errorCategory)
+	r.client.recordEmbeddingMetrics(r.ctx, r.seed, normalized, r.startedAt, completedAt, errorType, errorCategory)
 	r.span.End(trace.WithTimestamp(completedAt))
 
 	r.mu.Lock()
@@ -1148,7 +1148,7 @@ func (r *ToolExecutionRecorder) End() {
 	} else {
 		r.span.SetStatus(codes.Ok, "")
 	}
-	r.client.recordToolExecutionMetrics(r.seed, r.startedAt, completedAt, finalErr)
+	r.client.recordToolExecutionMetrics(r.ctx, r.seed, r.startedAt, completedAt, finalErr)
 	r.span.End(trace.WithTimestamp(completedAt))
 
 	r.mu.Lock()
@@ -1749,7 +1749,7 @@ func newTelemetryInstruments(meter metric.Meter) (telemetryInstruments, error) {
 	return out, nil
 }
 
-func (c *Client) recordGenerationMetrics(generation Generation, errorType string, errorCategory string, firstTokenAt time.Time) {
+func (c *Client) recordGenerationMetrics(ctx context.Context, generation Generation, errorType string, errorCategory string, firstTokenAt time.Time) {
 	if c == nil {
 		return
 	}
@@ -1773,14 +1773,14 @@ func (c *Client) recordGenerationMetrics(generation Generation, errorType string
 		attribute.String(spanAttrErrorType, errorType),
 		attribute.String(spanAttrErrorCategory, errorCategory),
 	)
-	c.instruments.operationDuration.Record(context.Background(), duration, durationAttrs)
+	c.instruments.operationDuration.Record(ctx, duration, durationAttrs)
 
 	recordToken := func(tokenType string, value int64) {
 		if value == 0 {
 			return
 		}
 		c.instruments.tokenUsage.Record(
-			context.Background(),
+			ctx,
 			value,
 			metric.WithAttributes(
 				attribute.String(spanAttrOperationName, operationName(generation)),
@@ -1800,7 +1800,7 @@ func (c *Client) recordGenerationMetrics(generation Generation, errorType string
 
 	toolCalls := countToolCalls(generation.Output)
 	c.instruments.toolCallsPerOperation.Record(
-		context.Background(),
+		ctx,
 		int64(toolCalls),
 		metric.WithAttributes(
 			attribute.String(spanAttrProviderName, strings.TrimSpace(generation.Model.Provider)),
@@ -1813,7 +1813,7 @@ func (c *Client) recordGenerationMetrics(generation Generation, errorType string
 		ttft := firstTokenAt.Sub(generation.StartedAt).Seconds()
 		if ttft >= 0 {
 			c.instruments.timeToFirstToken.Record(
-				context.Background(),
+				ctx,
 				ttft,
 				metric.WithAttributes(
 					attribute.String(spanAttrProviderName, strings.TrimSpace(generation.Model.Provider)),
@@ -1826,6 +1826,7 @@ func (c *Client) recordGenerationMetrics(generation Generation, errorType string
 }
 
 func (c *Client) recordEmbeddingMetrics(
+	ctx context.Context,
 	seed EmbeddingStart,
 	result EmbeddingResult,
 	startedAt time.Time,
@@ -1852,7 +1853,7 @@ func (c *Client) recordEmbeddingMetrics(
 	model := strings.TrimSpace(seed.Model.Name)
 	agentName := strings.TrimSpace(seed.AgentName)
 	c.instruments.operationDuration.Record(
-		context.Background(),
+		ctx,
 		duration,
 		metric.WithAttributes(
 			attribute.String(spanAttrOperationName, defaultEmbeddingOperationName),
@@ -1866,7 +1867,7 @@ func (c *Client) recordEmbeddingMetrics(
 
 	if result.InputTokens != 0 {
 		c.instruments.tokenUsage.Record(
-			context.Background(),
+			ctx,
 			result.InputTokens,
 			metric.WithAttributes(
 				attribute.String(spanAttrOperationName, defaultEmbeddingOperationName),
@@ -1879,7 +1880,7 @@ func (c *Client) recordEmbeddingMetrics(
 	}
 }
 
-func (c *Client) recordToolExecutionMetrics(seed ToolExecutionStart, startedAt time.Time, completedAt time.Time, finalErr error) {
+func (c *Client) recordToolExecutionMetrics(ctx context.Context, seed ToolExecutionStart, startedAt time.Time, completedAt time.Time, finalErr error) {
 	if c == nil {
 		return
 	}
@@ -1900,7 +1901,7 @@ func (c *Client) recordToolExecutionMetrics(seed ToolExecutionStart, startedAt t
 		errorCategory = toolErrorCategory(finalErr)
 	}
 	c.instruments.operationDuration.Record(
-		context.Background(),
+		ctx,
 		duration,
 		metric.WithAttributes(
 			attribute.String(spanAttrOperationName, "execute_tool"),

--- a/go/sigil/exporter_auth_test.go
+++ b/go/sigil/exporter_auth_test.go
@@ -103,11 +103,11 @@ func TestResolveHeadersWithAuth(t *testing.T) {
 // any real bug.
 func TestResolveHeadersWithAuthRejectsMissingRequiredField(t *testing.T) {
 	testCases := []AuthConfig{
-		{Mode: ExportAuthModeTenant},                              // tenant requires tenant_id
-		{Mode: ExportAuthModeBearer},                              // bearer requires bearer_token
-		{Mode: ExportAuthModeBasic},                               // basic requires password
-		{Mode: ExportAuthModeBasic, BasicPassword: "secret"},      // basic also requires user/tenant
-		{Mode: ExportAuthMode("unknown"), TenantID: "tenant-a"},   // unknown mode
+		{Mode: ExportAuthModeTenant},                            // tenant requires tenant_id
+		{Mode: ExportAuthModeBearer},                            // bearer requires bearer_token
+		{Mode: ExportAuthModeBasic},                             // basic requires password
+		{Mode: ExportAuthModeBasic, BasicPassword: "secret"},    // basic also requires user/tenant
+		{Mode: ExportAuthMode("unknown"), TenantID: "tenant-a"}, // unknown mode
 	}
 
 	for _, testCase := range testCases {

--- a/go/sigil/generation.go
+++ b/go/sigil/generation.go
@@ -50,29 +50,29 @@ type Generation struct {
 	OperationName string `json:"operation_name,omitempty"`
 	// TraceID and SpanID identify the OTel span created by StartGeneration or
 	// StartStreamingGeneration.
-	TraceID             string           `json:"trace_id,omitempty"`
-	SpanID              string           `json:"span_id,omitempty"`
-	Model               ModelRef         `json:"model"`
-	ResponseID          string           `json:"response_id,omitempty"`
-	ResponseModel       string           `json:"response_model,omitempty"`
-	SystemPrompt        string           `json:"system_prompt,omitempty"`
-	Input               []Message        `json:"input,omitempty"`
-	Output              []Message        `json:"output,omitempty"`
-	Tools               []ToolDefinition `json:"tools,omitempty"`
-	MaxTokens           *int64           `json:"max_tokens,omitempty"`
-	Temperature         *float64         `json:"temperature,omitempty"`
-	TopP                *float64         `json:"top_p,omitempty"`
-	ToolChoice          *string          `json:"tool_choice,omitempty"`
-	ThinkingEnabled     *bool            `json:"thinking_enabled,omitempty"`
-	ParentGenerationIDs []string         `json:"parent_generation_ids,omitempty"`
-	EffectiveVersion    string           `json:"effective_version,omitempty"`
-	Usage            TokenUsage        `json:"usage,omitempty"`
-	StopReason       string            `json:"stop_reason,omitempty"`
-	StartedAt        time.Time         `json:"started_at,omitempty"`
-	CompletedAt      time.Time         `json:"completed_at,omitempty"`
-	Tags             map[string]string `json:"tags,omitempty"`
-	Metadata         map[string]any    `json:"metadata,omitempty"`
-	Artifacts        []Artifact        `json:"artifacts,omitempty"`
+	TraceID             string            `json:"trace_id,omitempty"`
+	SpanID              string            `json:"span_id,omitempty"`
+	Model               ModelRef          `json:"model"`
+	ResponseID          string            `json:"response_id,omitempty"`
+	ResponseModel       string            `json:"response_model,omitempty"`
+	SystemPrompt        string            `json:"system_prompt,omitempty"`
+	Input               []Message         `json:"input,omitempty"`
+	Output              []Message         `json:"output,omitempty"`
+	Tools               []ToolDefinition  `json:"tools,omitempty"`
+	MaxTokens           *int64            `json:"max_tokens,omitempty"`
+	Temperature         *float64          `json:"temperature,omitempty"`
+	TopP                *float64          `json:"top_p,omitempty"`
+	ToolChoice          *string           `json:"tool_choice,omitempty"`
+	ThinkingEnabled     *bool             `json:"thinking_enabled,omitempty"`
+	ParentGenerationIDs []string          `json:"parent_generation_ids,omitempty"`
+	EffectiveVersion    string            `json:"effective_version,omitempty"`
+	Usage               TokenUsage        `json:"usage,omitempty"`
+	StopReason          string            `json:"stop_reason,omitempty"`
+	StartedAt           time.Time         `json:"started_at,omitempty"`
+	CompletedAt         time.Time         `json:"completed_at,omitempty"`
+	Tags                map[string]string `json:"tags,omitempty"`
+	Metadata            map[string]any    `json:"metadata,omitempty"`
+	Artifacts           []Artifact        `json:"artifacts,omitempty"`
 	// CallError captures upstream call failure text when End receives callErr.
 	CallError string `json:"call_error,omitempty"`
 }
@@ -99,8 +99,8 @@ type GenerationStart struct {
 	ParentGenerationIDs []string
 	EffectiveVersion    string
 	Tags                map[string]string
-	Metadata         map[string]any
-	StartedAt        time.Time
+	Metadata            map[string]any
+	StartedAt           time.Time
 	// ContentCapture overrides the client-level ContentCaptureMode for this
 	// generation. Default (zero value) inherits from Config.
 	ContentCapture ContentCaptureMode

--- a/go/sigil/hooks.go
+++ b/go/sigil/hooks.go
@@ -146,11 +146,11 @@ type HookEvaluation struct {
 
 // HookEvaluateResponse is the parsed server response.
 type HookEvaluateResponse struct {
-	Action            HookAction       `json:"action"`
-	RuleID            string           `json:"rule_id,omitempty"`
-	Reason            string           `json:"reason,omitempty"`
-	TransformedInput  *HookInput       `json:"transformed_input,omitempty"`
-	Evaluations       []HookEvaluation `json:"evaluations"`
+	Action           HookAction       `json:"action"`
+	RuleID           string           `json:"rule_id,omitempty"`
+	Reason           string           `json:"reason,omitempty"`
+	TransformedInput *HookInput       `json:"transformed_input,omitempty"`
+	Evaluations      []HookEvaluation `json:"evaluations"`
 }
 
 // EvaluateHook calls POST /api/v1/hooks:evaluate to run synchronous hook

--- a/go/sigil/hooks_test.go
+++ b/go/sigil/hooks_test.go
@@ -60,7 +60,7 @@ func TestEvaluateHookSendsRequestAndParsesAllow(t *testing.T) {
 	defer server.Close()
 
 	client := newHookTestClient(t, hookTestClientOptions{
-		apiEndpoint: server.URL,
+		apiEndpoint:  server.URL,
 		hooksEnabled: true,
 	})
 	t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
@@ -155,7 +155,7 @@ func TestEvaluateHookReturnsDeny(t *testing.T) {
 	defer server.Close()
 
 	client := newHookTestClient(t, hookTestClientOptions{
-		apiEndpoint: server.URL,
+		apiEndpoint:  server.URL,
 		hooksEnabled: true,
 	})
 	t.Cleanup(func() { _ = client.Shutdown(context.Background()) })

--- a/go/sigil/metric_exemplar_test.go
+++ b/go/sigil/metric_exemplar_test.go
@@ -1,0 +1,169 @@
+package sigil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/exemplar"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestGenerationMetricsCarryTraceExemplar(t *testing.T) {
+	spanRecorder, tp, metricReader, mp := newExemplarTestHarness(t)
+
+	client := NewClient(Config{
+		Tracer:                 tp.Tracer("sigil-test"),
+		Meter:                  mp.Meter("sigil-test"),
+		Now:                    time.Now,
+		testGenerationExporter: &capturingGenerationExporter{},
+	})
+	t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
+
+	_, rec := client.StartGeneration(context.Background(), GenerationStart{
+		Model:     ModelRef{Provider: "openai", Name: "gpt-5"},
+		AgentName: "test-agent",
+	})
+	rec.SetResult(Generation{
+		Output: []Message{{Role: "assistant", Parts: []Part{{Kind: PartKindText, Text: "hello"}}}},
+		Usage:  TokenUsage{InputTokens: 10, OutputTokens: 5},
+	}, nil)
+	rec.End()
+	if err := rec.Err(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	spans := spanRecorder.Ended()
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span")
+	}
+	wantTraceID := spans[0].SpanContext().TraceID()
+
+	assertExemplarTraceID(t, metricReader, metricOperationDuration, wantTraceID)
+}
+
+func TestEmbeddingMetricsCarryTraceExemplar(t *testing.T) {
+	spanRecorder, tp, metricReader, mp := newExemplarTestHarness(t)
+
+	client := NewClient(Config{
+		Tracer:                 tp.Tracer("sigil-test"),
+		Meter:                  mp.Meter("sigil-test"),
+		Now:                    time.Now,
+		testGenerationExporter: &capturingGenerationExporter{},
+	})
+	t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
+
+	_, rec := client.StartEmbedding(context.Background(), EmbeddingStart{
+		Model:     ModelRef{Provider: "openai", Name: "text-embedding-3-small"},
+		AgentName: "test-agent",
+	})
+	rec.SetResult(EmbeddingResult{InputTokens: 42, InputCount: 1})
+	rec.End()
+	if err := rec.Err(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	spans := spanRecorder.Ended()
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span")
+	}
+	wantTraceID := spans[0].SpanContext().TraceID()
+
+	assertExemplarTraceID(t, metricReader, metricOperationDuration, wantTraceID)
+}
+
+func TestToolExecutionMetricsCarryTraceExemplar(t *testing.T) {
+	spanRecorder, tp, metricReader, mp := newExemplarTestHarness(t)
+
+	client := NewClient(Config{
+		Tracer:                 tp.Tracer("sigil-test"),
+		Meter:                  mp.Meter("sigil-test"),
+		Now:                    time.Now,
+		testGenerationExporter: &capturingGenerationExporter{},
+	})
+	t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
+
+	_, rec := client.StartToolExecution(context.Background(), ToolExecutionStart{
+		ToolName:  "weather",
+		AgentName: "test-agent",
+	})
+	rec.SetResult(ToolExecutionEnd{
+		Result: "sunny",
+	})
+	rec.End()
+	if err := rec.Err(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	spans := spanRecorder.Ended()
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span")
+	}
+	wantTraceID := spans[0].SpanContext().TraceID()
+
+	assertExemplarTraceID(t, metricReader, metricOperationDuration, wantTraceID)
+}
+
+func newExemplarTestHarness(t *testing.T) (*tracetest.SpanRecorder, *sdktrace.TracerProvider, *sdkmetric.ManualReader, *sdkmetric.MeterProvider) {
+	t.Helper()
+
+	spanRecorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	metricReader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(metricReader),
+		sdkmetric.WithExemplarFilter(exemplar.AlwaysOnFilter),
+	)
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	return spanRecorder, tp, metricReader, mp
+}
+
+func assertExemplarTraceID(t *testing.T, metricReader *sdkmetric.ManualReader, metricName string, wantTraceID trace.TraceID) {
+	t.Helper()
+
+	var collected metricdata.ResourceMetrics
+	if err := metricReader.Collect(context.Background(), &collected); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+
+	found := false
+	for _, scopeMetrics := range collected.ScopeMetrics {
+		for _, m := range scopeMetrics.Metrics {
+			if m.Name != metricName {
+				continue
+			}
+			histogram, ok := m.Data.(metricdata.Histogram[float64])
+			if !ok {
+				continue
+			}
+			for _, dp := range histogram.DataPoints {
+				for _, ex := range dp.Exemplars {
+					found = true
+					var gotTraceID trace.TraceID
+					copy(gotTraceID[:], ex.TraceID)
+					if wantTraceID.IsValid() && gotTraceID != wantTraceID {
+						t.Errorf("exemplar trace_id = %s, want %s", gotTraceID, wantTraceID)
+					}
+					if !gotTraceID.IsValid() {
+						t.Error("exemplar trace_id is zero (no span context propagated)")
+					}
+					var gotSpanID trace.SpanID
+					copy(gotSpanID[:], ex.SpanID)
+					if !gotSpanID.IsValid() {
+						t.Error("exemplar span_id is zero (no span context propagated)")
+					}
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no exemplars found on %s histogram", metricName)
+	}
+}

--- a/go/sigil/redaction_test.go
+++ b/go/sigil/redaction_test.go
@@ -485,4 +485,3 @@ func metaString(g Generation, key string) string {
 	v, _ := g.Metadata[key].(string)
 	return v
 }
-

--- a/java/core/src/main/java/com/grafana/sigil/sdk/EmbeddingRecorder.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/EmbeddingRecorder.java
@@ -2,6 +2,7 @@ package com.grafana.sigil.sdk;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Scope;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -110,7 +111,9 @@ public final class EmbeddingRecorder implements AutoCloseable {
         }
 
         Instant completedAt = client.now();
-        client.recordEmbeddingMetrics(seed, snapshotResult, startedAt, completedAt, errorType, errorCategory);
+        try (Scope metricsScope = span.makeCurrent()) {
+            client.recordEmbeddingMetrics(seed, snapshotResult, startedAt, completedAt, errorType, errorCategory);
+        }
         span.end(completedAt.toEpochMilli(), TimeUnit.MILLISECONDS);
 
         synchronized (lock) {

--- a/java/core/src/main/java/com/grafana/sigil/sdk/GenerationRecorder.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/GenerationRecorder.java
@@ -145,7 +145,9 @@ public class GenerationRecorder implements AutoCloseable {
                 span.setStatus(StatusCode.OK);
             }
 
-            client.recordGenerationMetrics(generation, errorType, errorCategory, snapshotFirstTokenAt);
+            try (Scope metricsScope = span.makeCurrent()) {
+                client.recordGenerationMetrics(generation, errorType, errorCategory, snapshotFirstTokenAt);
+            }
             span.end(completedAt.toEpochMilli(), TimeUnit.MILLISECONDS);
             client.recordGeneration(generation);
         } finally {

--- a/java/core/src/main/java/com/grafana/sigil/sdk/ToolExecutionRecorder.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/ToolExecutionRecorder.java
@@ -2,6 +2,7 @@ package com.grafana.sigil.sdk;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Scope;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -120,7 +121,9 @@ public class ToolExecutionRecorder implements AutoCloseable {
             span.setStatus(StatusCode.OK);
         }
 
-        client.recordToolExecutionMetrics(seed, startedAt, completedAt, snapshotCallError);
+        try (Scope metricsScope = span.makeCurrent()) {
+            client.recordToolExecutionMetrics(seed, startedAt, completedAt, snapshotCallError);
+        }
         span.end(completedAt.toEpochMilli(), TimeUnit.MILLISECONDS);
         client.recordToolExecution(execution);
 

--- a/java/core/src/test/java/com/grafana/sigil/sdk/SigilClientMetricExemplarTest.java
+++ b/java/core/src/test/java/com/grafana/sigil/sdk/SigilClientMetricExemplarTest.java
@@ -1,0 +1,154 @@
+package com.grafana.sigil.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.HistogramPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SigilClientMetricExemplarTest {
+    private static final AttributeKey<String> OPERATION_NAME_KEY =
+            AttributeKey.stringKey(SigilClient.SPAN_ATTR_OPERATION_NAME);
+
+    @Test
+    void generationMetricsCarryTraceExemplar() {
+        ExemplarHarness h = newHarness();
+        try (SigilClient client = h.newClient()) {
+            GenerationRecorder recorder = client.startGeneration(
+                    new GenerationStart()
+                            .setModel(new ModelRef().setProvider("openai").setName("gpt-5"))
+                            .setAgentName("test-agent"));
+            recorder.setResult(TestFixtures.resultFixture());
+            recorder.end();
+            assertThat(recorder.error()).isEmpty();
+        }
+
+        SpanData span = h.findSpan(op -> !"execute_tool".equals(op));
+        assertExemplarTraceId(h.metricReader, SigilClient.METRIC_OPERATION_DURATION, span.getTraceId());
+        h.shutdown();
+    }
+
+    @Test
+    void embeddingMetricsCarryTraceExemplar() {
+        ExemplarHarness h = newHarness();
+        try (SigilClient client = h.newClient()) {
+            EmbeddingRecorder recorder = client.startEmbedding(
+                    new EmbeddingStart()
+                            .setModel(new ModelRef().setProvider("openai").setName("text-embedding-3-small"))
+                            .setAgentName("test-agent"));
+            recorder.setResult(new EmbeddingResult().setInputTokens(42).setInputCount(1));
+            recorder.end();
+            assertThat(recorder.error()).isEmpty();
+        }
+
+        SpanData span = h.findSpan(op -> "embeddings".equals(op));
+        assertExemplarTraceId(h.metricReader, SigilClient.METRIC_OPERATION_DURATION, span.getTraceId());
+        h.shutdown();
+    }
+
+    @Test
+    void toolExecutionMetricsCarryTraceExemplar() {
+        ExemplarHarness h = newHarness();
+        try (SigilClient client = h.newClient()) {
+            ToolExecutionRecorder recorder = client.startToolExecution(
+                    new ToolExecutionStart()
+                            .setToolName("weather")
+                            .setAgentName("test-agent"));
+            recorder.setResult(new ToolExecutionResult().setResult("sunny"));
+            recorder.end();
+            assertThat(recorder.error()).isEmpty();
+        }
+
+        SpanData span = h.findSpan(op -> "execute_tool".equals(op));
+        assertExemplarTraceId(h.metricReader, SigilClient.METRIC_OPERATION_DURATION, span.getTraceId());
+        h.shutdown();
+    }
+
+    // -----------------------------------------------------------------------
+    // Harness
+    // -----------------------------------------------------------------------
+
+    private static final class ExemplarHarness {
+        final InMemorySpanExporter spanExporter;
+        final SdkTracerProvider tracerProvider;
+        final InMemoryMetricReader metricReader;
+        final SdkMeterProvider meterProvider;
+
+        ExemplarHarness(
+                InMemorySpanExporter spanExporter,
+                SdkTracerProvider tracerProvider,
+                InMemoryMetricReader metricReader,
+                SdkMeterProvider meterProvider) {
+            this.spanExporter = spanExporter;
+            this.tracerProvider = tracerProvider;
+            this.metricReader = metricReader;
+            this.meterProvider = meterProvider;
+        }
+
+        SigilClient newClient() {
+            SigilClientConfig config = new SigilClientConfig()
+                    .setTracer(tracerProvider.get("test"))
+                    .setMeter(meterProvider.get("test"))
+                    .setGenerationExporter(new TestFixtures.CapturingExporter())
+                    .setGenerationExport(new GenerationExportConfig()
+                            .setBatchSize(100)
+                            .setQueueSize(100)
+                            .setFlushInterval(Duration.ofMinutes(10))
+                            .setMaxRetries(0));
+            return new SigilClient(config);
+        }
+
+        SpanData findSpan(java.util.function.Predicate<String> operationFilter) {
+            return spanExporter.getFinishedSpanItems().stream()
+                    .filter(s -> operationFilter.test(s.getAttributes().get(OPERATION_NAME_KEY)))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("no span matching filter"));
+        }
+
+        void shutdown() {
+            tracerProvider.shutdown();
+            meterProvider.shutdown();
+        }
+    }
+
+    private static ExemplarHarness newHarness() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+                .build();
+        InMemoryMetricReader metricReader = InMemoryMetricReader.create();
+        SdkMeterProvider meterProvider = SdkMeterProvider.builder()
+                .registerMetricReader(metricReader)
+                .build();
+        return new ExemplarHarness(spanExporter, tracerProvider, metricReader, meterProvider);
+    }
+
+    private static void assertExemplarTraceId(InMemoryMetricReader metricReader, String metricName, String wantTraceId) {
+        Collection<MetricData> allMetrics = metricReader.collectAllMetrics();
+        MetricData durationMetric = allMetrics.stream()
+                .filter(m -> m.getName().equals(metricName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("metric " + metricName + " not found"));
+
+        List<ExemplarData> exemplars = durationMetric.getHistogramData().getPoints().stream()
+                .map(HistogramPointData::getExemplars)
+                .flatMap(List::stream)
+                .toList();
+
+        assertThat(exemplars).as("exemplars on %s", metricName).isNotEmpty();
+        assertThat(exemplars.get(0).getSpanContext().getTraceId())
+                .as("exemplar trace_id")
+                .isEqualTo(wantTraceId);
+    }
+}

--- a/java/core/src/test/java/com/grafana/sigil/sdk/SigilClientMetricExemplarTest.java
+++ b/java/core/src/test/java/com/grafana/sigil/sdk/SigilClientMetricExemplarTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
-import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.HistogramPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
@@ -141,7 +141,7 @@ class SigilClientMetricExemplarTest {
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("metric " + metricName + " not found"));
 
-        List<ExemplarData> exemplars = durationMetric.getHistogramData().getPoints().stream()
+        List<DoubleExemplarData> exemplars = durationMetric.getHistogramData().getPoints().stream()
                 .map(HistogramPointData::getExemplars)
                 .flatMap(List::stream)
                 .toList();

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1,4 +1,5 @@
 import {
+  context,
   type Histogram,
   type Meter,
   metrics,
@@ -788,7 +789,10 @@ export class SigilClient {
       span.setStatus({ code: SpanStatusCode.OK });
     }
 
-    this.recordGenerationMetrics(generation, errorType, errorCategory, firstTokenAt);
+    const spanCtx = trace.setSpan(context.active(), span);
+    context.with(spanCtx, () => {
+      this.recordGenerationMetrics(generation, errorType, errorCategory, firstTokenAt);
+    });
 
     span.end(generation.completedAt);
   }
@@ -832,7 +836,10 @@ export class SigilClient {
       span.setAttribute(spanAttrErrorCategory, errorCategory);
     }
 
-    this.recordEmbeddingMetrics(seed, result, startedAt, completedAt, errorType, errorCategory);
+    const spanCtx = trace.setSpan(context.active(), span);
+    context.with(spanCtx, () => {
+      this.recordEmbeddingMetrics(seed, result, startedAt, completedAt, errorType, errorCategory);
+    });
 
     span.end(completedAt);
   }
@@ -874,10 +881,13 @@ export class SigilClient {
       span.setStatus({ code: SpanStatusCode.OK });
     }
 
-    this.recordToolExecutionMetrics(
-      toolExecution,
-      localError ?? (toolExecution.callError !== undefined ? new Error(toolExecution.callError) : undefined),
-    );
+    const spanCtx = trace.setSpan(context.active(), span);
+    context.with(spanCtx, () => {
+      this.recordToolExecutionMetrics(
+        toolExecution,
+        localError ?? (toolExecution.callError !== undefined ? new Error(toolExecution.callError) : undefined),
+      );
+    });
 
     span.end(toolExecution.completedAt);
     return localError;

--- a/js/test/client.metric-exemplar.test.mjs
+++ b/js/test/client.metric-exemplar.test.mjs
@@ -6,7 +6,16 @@ import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '
 import { defaultConfig, SigilClient } from '../.test-dist/index.js';
 
 const contextManager = new AsyncLocalStorageContextManager();
-context.setGlobalContextManager(contextManager);
+
+test.before(() => {
+  contextManager.enable();
+  context.setGlobalContextManager(contextManager);
+});
+
+test.after(() => {
+  context.disable();
+  contextManager.disable();
+});
 
 class CapturingExporter {
   requests = [];

--- a/js/test/client.metric-exemplar.test.mjs
+++ b/js/test/client.metric-exemplar.test.mjs
@@ -1,0 +1,229 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { context, metrics as metricsApi, trace } from '@opentelemetry/api';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { defaultConfig, SigilClient } from '../.test-dist/index.js';
+
+const contextManager = new AsyncLocalStorageContextManager();
+context.setGlobalContextManager(contextManager);
+
+class CapturingExporter {
+  requests = [];
+
+  async exportGenerations(request) {
+    this.requests.push(structuredClone(request));
+    return {
+      results: request.generations.map((generation) => ({
+        generationId: generation.id,
+        accepted: true,
+      })),
+    };
+  }
+}
+
+class SpanCapturingMeter {
+  capturedTraceIds = [];
+
+  constructor(inner) {
+    this._inner = inner;
+    this._capturedTraceIds = this.capturedTraceIds;
+  }
+
+  createHistogram(name, options) {
+    const inner = this._inner.createHistogram(name, options);
+    const capturedTraceIds = this._capturedTraceIds;
+    return {
+      record(value, attributes) {
+        const activeSpan = trace.getSpan(context.active());
+        if (activeSpan?.spanContext) {
+          const sc = activeSpan.spanContext();
+          if (sc.traceId && sc.traceId !== '00000000000000000000000000000000') {
+            capturedTraceIds.push(sc.traceId);
+          }
+        }
+        return inner.record(value, attributes);
+      },
+    };
+  }
+
+  createCounter(name, options) {
+    return this._inner.createCounter(name, options);
+  }
+
+  createUpDownCounter(name, options) {
+    return this._inner.createUpDownCounter(name, options);
+  }
+
+  createObservableGauge(name, options) {
+    return this._inner.createObservableGauge(name, options);
+  }
+
+  createObservableCounter(name, options) {
+    return this._inner.createObservableCounter(name, options);
+  }
+
+  createObservableUpDownCounter(name, options) {
+    return this._inner.createObservableUpDownCounter(name, options);
+  }
+
+  createGauge(name, options) {
+    return this._inner.createGauge(name, options);
+  }
+}
+
+test('generation metric recording has active span context', async () => {
+  const harness = newHarness();
+
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'openai', name: 'gpt-5' },
+    });
+    recorder.setResult({
+      input: [{ role: 'user', content: 'hi' }],
+      output: [{ role: 'assistant', content: 'hello' }],
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+
+    const span = singleGenerationSpan(harness.spanExporter);
+    assert.ok(
+      harness.capturingMeter.capturedTraceIds.length > 0,
+      'histogram.record should have been called with active span',
+    );
+    assert.ok(
+      harness.capturingMeter.capturedTraceIds.includes(span.spanContext().traceId),
+      'metric should carry generation span trace_id',
+    );
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('embedding metric recording has active span context', async () => {
+  const harness = newHarness();
+
+  try {
+    const recorder = harness.client.startEmbedding({
+      model: { provider: 'openai', name: 'text-embedding-3-small' },
+    });
+    recorder.setResult({ inputTokens: 42 });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+
+    const span = singleEmbeddingSpan(harness.spanExporter);
+    assert.ok(
+      harness.capturingMeter.capturedTraceIds.length > 0,
+      'histogram.record should have been called with active span',
+    );
+    assert.ok(
+      harness.capturingMeter.capturedTraceIds.includes(span.spanContext().traceId),
+      'metric should carry embedding span trace_id',
+    );
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('tool execution metric recording has active span context', async () => {
+  const harness = newHarness();
+
+  try {
+    const recorder = harness.client.startToolExecution({
+      toolName: 'weather',
+    });
+    recorder.setResult({ result: 'sunny' });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+
+    const span = singleToolSpan(harness.spanExporter);
+    assert.ok(
+      harness.capturingMeter.capturedTraceIds.length > 0,
+      'histogram.record should have been called with active span',
+    );
+    assert.ok(
+      harness.capturingMeter.capturedTraceIds.includes(span.spanContext().traceId),
+      'metric should carry tool span trace_id',
+    );
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function newHarness(overrides = {}) {
+  const spanExporter = new InMemorySpanExporter();
+  const traceProvider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(spanExporter)],
+  });
+  const tracer = traceProvider.getTracer('sigil-sdk-js-test');
+  const generationExporter = new CapturingExporter();
+  const defaults = defaultConfig();
+
+  const capturingMeter = new SpanCapturingMeter(metricsApi.getMeter('sigil-test-exemplar'));
+
+  const client = new SigilClient({
+    tracer,
+    meter: capturingMeter,
+    generationExport: {
+      ...defaults.generationExport,
+      batchSize: 100,
+      flushIntervalMs: 60_000,
+      maxRetries: 1,
+      initialBackoffMs: 1,
+      maxBackoffMs: 1,
+    },
+    generationExporter,
+    ...overrides,
+  });
+
+  return {
+    client,
+    spanExporter,
+    traceProvider,
+    generationExporter,
+    capturingMeter,
+  };
+}
+
+async function shutdownHarness(harness) {
+  await harness.client.shutdown();
+  await harness.traceProvider.shutdown();
+}
+
+function generationSpans(spanExporter) {
+  return spanExporter.getFinishedSpans().filter((span) => {
+    const operation = span.attributes['gen_ai.operation.name'];
+    return operation !== 'execute_tool' && operation !== 'embeddings';
+  });
+}
+
+function embeddingSpans(spanExporter) {
+  return spanExporter.getFinishedSpans().filter((span) => span.attributes['gen_ai.operation.name'] === 'embeddings');
+}
+
+function toolSpans(spanExporter) {
+  return spanExporter.getFinishedSpans().filter((span) => span.attributes['gen_ai.operation.name'] === 'execute_tool');
+}
+
+function singleGenerationSpan(spanExporter) {
+  const spans = generationSpans(spanExporter);
+  assert.equal(spans.length, 1);
+  return spans[0];
+}
+
+function singleEmbeddingSpan(spanExporter) {
+  const spans = embeddingSpans(spanExporter);
+  assert.equal(spans.length, 1);
+  return spans[0];
+}
+
+function singleToolSpan(spanExporter) {
+  const spans = toolSpans(spanExporter);
+  assert.equal(spans.length, 1);
+  return spans[0];
+}

--- a/plugins/claude-code/cmd/sigil-cc/main.go
+++ b/plugins/claude-code/cmd/sigil-cc/main.go
@@ -35,10 +35,10 @@ type hookDecision struct {
 }
 
 type hookSpecificOutput struct {
-	HookEventName              string `json:"hookEventName"`
-	PermissionDecision         string `json:"permissionDecision,omitempty"`
-	PermissionDecisionReason   string `json:"permissionDecisionReason,omitempty"`
-	AdditionalContext          string `json:"additionalContext,omitempty"`
+	HookEventName            string `json:"hookEventName"`
+	PermissionDecision       string `json:"permissionDecision,omitempty"`
+	PermissionDecisionReason string `json:"permissionDecisionReason,omitempty"`
+	AdditionalContext        string `json:"additionalContext,omitempty"`
 }
 
 var (
@@ -94,9 +94,9 @@ func run() {
 	authToken := os.Getenv("SIGIL_AUTH_TOKEN")
 
 	missing := missingEnvVars(map[string]string{
-		"SIGIL_ENDPOINT":        sigilEndpoint,
-		"SIGIL_AUTH_TENANT_ID":  tenantID,
-		"SIGIL_AUTH_TOKEN":      authToken,
+		"SIGIL_ENDPOINT":       sigilEndpoint,
+		"SIGIL_AUTH_TENANT_ID": tenantID,
+		"SIGIL_AUTH_TOKEN":     authToken,
 	})
 	if len(missing) > 0 {
 		// Stderr regardless of SIGIL_DEBUG; the debug-gated logger would swallow this.

--- a/plugins/claude-code/cmd/sigil-cc/userid_test.go
+++ b/plugins/claude-code/cmd/sigil-cc/userid_test.go
@@ -59,12 +59,12 @@ func TestLoadUserIDFromClaudeJSON(t *testing.T) {
 
 func TestResolveUserID(t *testing.T) {
 	tests := []struct {
-		name       string
-		envUserID  string
-		envSource  string
-		writeFix   bool
-		contents   string
-		want       string
+		name      string
+		envUserID string
+		envSource string
+		writeFix  bool
+		contents  string
+		want      string
 	}{
 		{
 			name:      "SIGIL_USER_ID wins over file",

--- a/plugins/claude-code/internal/transcript/transcript_test.go
+++ b/plugins/claude-code/internal/transcript/transcript_test.go
@@ -195,9 +195,9 @@ func TestParseUserContent(t *testing.T) {
 
 func TestUserContentBlock_Content(t *testing.T) {
 	tests := []struct {
-		name    string
-		raw     string
-		want    string
+		name string
+		raw  string
+		want string
 	}{
 		{
 			name: "string content",

--- a/plugins/cursor/internal/config/config_test.go
+++ b/plugins/cursor/internal/config/config_test.go
@@ -179,11 +179,11 @@ func TestApplyEnv(t *testing.T) {
 
 func TestHasCredentials(t *testing.T) {
 	cases := []struct {
-		name      string
-		endpoint  string
-		tenant    string
-		token     string
-		want      bool
+		name     string
+		endpoint string
+		tenant   string
+		token    string
+		want     bool
 	}{
 		{"all set", "https://e", "t", "k", true},
 		{"missing endpoint", "", "t", "k", false},
@@ -202,4 +202,3 @@ func TestHasCredentials(t *testing.T) {
 		})
 	}
 }
-

--- a/plugins/cursor/internal/hook/emit_test.go
+++ b/plugins/cursor/internal/hook/emit_test.go
@@ -12,10 +12,10 @@ func TestToolSpanWindow(t *testing.T) {
 	dur := func(ms float64) *float64 { return &ms }
 
 	cases := []struct {
-		name              string
-		rec               fragment.ToolRecord
-		wantStarted       time.Time
-		wantCompleted     time.Time
+		name          string
+		rec           fragment.ToolRecord
+		wantStarted   time.Time
+		wantCompleted time.Time
 	}{
 		{
 			name: "uses tool's own completedAt and subtracts duration",

--- a/python/sigil_sdk/client.py
+++ b/python/sigil_sdk/client.py
@@ -18,7 +18,7 @@ from urllib import request as urllib_request
 
 from opentelemetry import metrics, trace
 from opentelemetry.metrics import Histogram
-from opentelemetry.trace import Span, SpanKind, Status, StatusCode
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode, use_span
 
 from .config import ClientConfig, resolve_config
 from .context import (
@@ -1253,7 +1253,8 @@ class GenerationRecorder:
             else:
                 self.span.set_status(Status(StatusCode.OK))
 
-            self.client._record_generation_metrics(generation, error_type, error_category, first_token_at)
+            with use_span(self.span, end_on_exit=False):
+                self.client._record_generation_metrics(generation, error_type, error_category, first_token_at)
 
             self.span.end(end_time=_datetime_to_ns(generation.completed_at or completed_at))
 
@@ -1464,14 +1465,15 @@ class EmbeddingRecorder:
             self.span.set_attribute(_span_attr_error_type, error_type)
             self.span.set_attribute(_span_attr_error_category, error_category)
 
-        self.client._record_embedding_metrics(
-            self.seed,
-            result,
-            self.started_at,
-            completed_at,
-            error_type,
-            error_category,
-        )
+        with use_span(self.span, end_on_exit=False):
+            self.client._record_embedding_metrics(
+                self.seed,
+                result,
+                self.started_at,
+                completed_at,
+                error_type,
+                error_category,
+            )
         self.span.end(end_time=_datetime_to_ns(completed_at))
 
         with self._lock:
@@ -1576,7 +1578,8 @@ class ToolExecutionRecorder:
         else:
             self.span.set_status(Status(StatusCode.OK))
 
-        self.client._record_tool_execution_metrics(self.seed, self.started_at, completed_at, final_error)
+        with use_span(self.span, end_on_exit=False):
+            self.client._record_tool_execution_metrics(self.seed, self.started_at, completed_at, final_error)
 
         self.span.end(end_time=_datetime_to_ns(completed_at))
 

--- a/python/tests/test_metric_exemplar.py
+++ b/python/tests/test_metric_exemplar.py
@@ -1,0 +1,128 @@
+"""Tests that metric recordings carry span context for exemplars."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from conftest import CapturingGenerationExporter
+from opentelemetry import trace
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from sigil_sdk import (
+    Client,
+    ClientConfig,
+    EmbeddingResult,
+    EmbeddingStart,
+    GenerationExportConfig,
+    GenerationStart,
+    ModelRef,
+    ToolExecutionStart,
+)
+
+_OPENAI = ModelRef(provider="openai", name="gpt-5")
+_EMBEDDING_MODEL = ModelRef(provider="openai", name="text-embedding-3-small")
+
+
+class _ExemplarHarness:
+    """Shared OTel + Sigil plumbing for exemplar tests."""
+
+    def __init__(self) -> None:
+        self.span_exporter = InMemorySpanExporter()
+        self.tracer_provider = TracerProvider()
+        self.tracer_provider.add_span_processor(SimpleSpanProcessor(self.span_exporter))
+
+        self.metric_reader = InMemoryMetricReader()
+        self.meter_provider = MeterProvider(metric_readers=[self.metric_reader])
+
+        gen_export = GenerationExportConfig(
+            batch_size=10,
+            flush_interval=timedelta(seconds=60),
+            queue_size=10,
+            max_retries=1,
+            initial_backoff=timedelta(milliseconds=1),
+            max_backoff=timedelta(milliseconds=1),
+        )
+        exporter = CapturingGenerationExporter()
+        self.client = Client(
+            ClientConfig(
+                tracer=self.tracer_provider.get_tracer("sigil-test"),
+                meter=self.meter_provider.get_meter("sigil-test"),
+                generation_export=gen_export,
+                generation_exporter=exporter,
+            )
+        )
+
+        self.captured_trace_ids: list[str] = []
+        self._original_record = self.client._operation_duration_histogram.record
+
+    def capturing_record(self, value, attributes=None, context=None):
+        span = trace.get_current_span()
+        sc = span.get_span_context()
+        if sc and sc.trace_id != 0:
+            self.captured_trace_ids.append(format(sc.trace_id, "032x"))
+        return self._original_record(value, attributes=attributes, context=context)
+
+    def shutdown(self) -> None:
+        self.client.shutdown()
+        self.tracer_provider.shutdown()
+        self.meter_provider.shutdown()
+
+    def assert_metric_carries_trace_id(self, operation_filter: str | None, *, label: str) -> None:
+        spans = self.span_exporter.get_finished_spans()
+        if operation_filter is None:
+            filtered = [
+                s for s in spans if s.attributes.get("gen_ai.operation.name") not in ("execute_tool", "embeddings")
+            ]
+        else:
+            filtered = [s for s in spans if s.attributes.get("gen_ai.operation.name") == operation_filter]
+
+        assert len(filtered) == 1, f"expected 1 {label} span, got {len(filtered)}"
+        want_trace_id = format(filtered[0].context.trace_id, "032x")
+
+        assert len(self.captured_trace_ids) > 0, "histogram.record should have been called"
+        assert self.captured_trace_ids[0] == want_trace_id, (
+            f"metric should carry {label} span trace_id: got {self.captured_trace_ids[0]}, want {want_trace_id}"
+        )
+
+
+def test_generation_metrics_carry_span_context():
+    h = _ExemplarHarness()
+    try:
+        with patch.object(h.client._operation_duration_histogram, "record", side_effect=h.capturing_record):
+            rec = h.client.start_generation(GenerationStart(model=_OPENAI))
+            rec.set_result(output_messages=[], usage_input_tokens=10, usage_output_tokens=5)
+            rec.end()
+            assert rec.err() is None
+        h.assert_metric_carries_trace_id(None, label="generation")
+    finally:
+        h.shutdown()
+
+
+def test_embedding_metrics_carry_span_context():
+    h = _ExemplarHarness()
+    try:
+        with patch.object(h.client._operation_duration_histogram, "record", side_effect=h.capturing_record):
+            rec = h.client.start_embedding(EmbeddingStart(model=_EMBEDDING_MODEL))
+            rec.set_result(EmbeddingResult(input_tokens=42))
+            rec.end()
+            assert rec.err() is None
+        h.assert_metric_carries_trace_id("embeddings", label="embedding")
+    finally:
+        h.shutdown()
+
+
+def test_tool_execution_metrics_carry_span_context():
+    h = _ExemplarHarness()
+    try:
+        with patch.object(h.client._operation_duration_histogram, "record", side_effect=h.capturing_record):
+            rec = h.client.start_tool_execution(ToolExecutionStart(tool_name="weather"))
+            rec.set_result(result="sunny")
+            rec.end()
+            assert rec.err() is None
+        h.assert_metric_carries_trace_id("execute_tool", label="tool")
+    finally:
+        h.shutdown()

--- a/python/tests/test_metric_exemplar.py
+++ b/python/tests/test_metric_exemplar.py
@@ -20,6 +20,7 @@ from sigil_sdk import (
     GenerationExportConfig,
     GenerationStart,
     ModelRef,
+    TokenUsage,
     ToolExecutionStart,
 )
 
@@ -94,7 +95,7 @@ def test_generation_metrics_carry_span_context():
     try:
         with patch.object(h.client._operation_duration_histogram, "record", side_effect=h.capturing_record):
             rec = h.client.start_generation(GenerationStart(model=_OPENAI))
-            rec.set_result(output_messages=[], usage_input_tokens=10, usage_output_tokens=5)
+            rec.set_result(output=[], usage=TokenUsage(input_tokens=10, output_tokens=5))
             rec.end()
             assert rec.err() is None
         h.assert_metric_carries_trace_id(None, label="generation")


### PR DESCRIPTION
## Summary

- Ensure OTel metrics (`gen_ai.client.operation.duration`, `token.usage`, `time_to_first_token`, `tool_calls_per_operation`) are recorded while the corresponding span/activity is still active, so `TraceBasedFilter` can attach trace-context exemplars to metric data points.
- Applies the correct context-propagation pattern for each language: Go passes `context.Context`, JS uses `context.with(trace.setSpan(...))`, Python uses `use_span()`, Java uses `span.makeCurrent()`, and .NET reorders to record before `Activity.Stop()`.
- Adds exemplar tests for all five SDKs (Go, JS/TS, Python, Java, .NET) that verify the span's trace ID is propagated during metric recording.

## Language details

| SDK | Mechanism | Key change |
|-----|-----------|------------|
| Go | Pass `r.ctx` instead of `context.Background()` | `recordGenerationMetrics` et al. gain a `ctx` parameter |
| JS/TS | `context.with(trace.setSpan(context.active(), span), fn)` | Wraps metric recording in active-span callback |
| Python | `with use_span(self.span, end_on_exit=False):` | Context-manager activates span during metrics |
| Java | `try (Scope s = span.makeCurrent()) { ... }` | Auto-closeable scope wraps metric recording |
| .NET | Move `RecordXxxMetrics()` before `_activity.Stop()` | Metrics recorded while Activity is still Current |

## Test plan

- [x] Go: `go test -run TestGenerationMetricsCarryTraceExemplar -v ./go/sigil/` — passes
- [x] JS: `node --test test/client.metric-exemplar.test.mjs` — passes
- [ ] Python: `test_metric_exemplar.py` (needs `uv`/`pytest` environment)
- [ ] Java: `SigilClientMetricExemplarTest.java` (needs Maven/Gradle build)
- [ ] .NET: `MetricExemplarTests.cs` (needs `dotnet` SDK)

#### Exemplars for Assistant are propagated with this PR (no Assistant repo change needed)

<img width="1533" height="923" alt="image" src="https://github.com/user-attachments/assets/42b64fec-8511-4e3c-81d8-bceb33edec00" />


#### Not propagated using current version of SDK
<img width="1614" height="890" alt="image" src="https://github.com/user-attachments/assets/73a3f07c-8e6b-4dfd-aa1b-59afed0bd552" />


Made with [Cursor](https://cursor.com)