### PR TITLE
feat(plugins/sigil): add pi launcher subcommand

### DIFF
--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -2,56 +2,35 @@
 
 [Pi](https://github.com/badlogic/pi) agent extension that records LLM generations to Grafana AI observability.
 
-By default only metadata is sent (token counts, cost, model, tool names, durations). Message content is included only when `contentCapture` is set to `full` or `no_tool_content`.
+By default only metadata is sent (token counts, cost, model, tool names, durations). Set `contentCapture` to `full` or `no_tool_content` to include message content.
 
 ## Install
+
+**Directly via pi**:
 
 ```bash
 pi install npm:@grafana/sigil-pi
 ```
 
-Pin a specific version:
+**Via the [sigil launcher](../sigil/README.md)** (auto-bootstraps on first run):
 
 ```bash
-pi install npm:@grafana/sigil-pi@0.1.1
+sigil pi
 ```
 
-### From source (contributors)
+The launcher installs Sigil plugin once if the extension isn't registered yet. Subsequent runs skip the install.
 
-```bash
-pnpm --filter @grafana/sigil-pi run build
-pi install /absolute/path/to/sigil-sdk/plugins/pi
-```
+## Grafana Cloud credentials
 
-## Get your credentials from Grafana Cloud
+Skip this if you're not using Grafana Cloud — see [Auth modes](#auth-modes) for `tenant` / `bearer` / `none`.
 
-Skip this section if you're not connecting to Grafana Cloud — refer to [Auth modes](#auth-modes) for `tenant` / `bearer` / `none`.
+The same Instance ID and access token are used for both Sigil and OTLP. OTLP is required for the AI Observability UI's latency, tool-call, and throughput panels.
 
-You need four values from your Grafana Cloud stack: the Sigil API URL, an OTLP endpoint, an instance ID, and an access policy token.
-
-### Sigil API URL and Instance ID
-
-In **Observability → AI Observability → Configuration** (`https://<stack>.grafana.net/plugins/grafana-sigil-app`), copy:
-
-- **API URL** → `endpoint`. Looks like `https://sigil-prod-<region>.grafana.net`.
-- **Instance ID** → `auth.user` (and `otlp.basicUser`). Numeric stack ID.
-
-### Access policy token
-
-In **Administration → Users and access → Cloud access policies** (`https://<stack>.grafana.net/a/grafana-auth-app`), click **Create access policy**. One token covers both the generations channel and OTel:
-
-- **Scopes**: tick `metrics: Write` and `traces: Write`. Use **Add scope** to add `sigil:write`.
-- Click **Create**, then **Add token** on the new policy. Copy the `glc_…` token once — you can't view it again.
-
-This token goes into both `auth.password` and `otlp.basicPassword`.
-
-### OTLP endpoint
-
-The AI Observability UI relies on traces and metrics for latency charts, tool call breakdowns, and other panels. Without OTel configured, half the UI is empty — treat this as required.
-
-Open the **Grafana Cloud Portal**, click into your stack, and find the **OpenTelemetry** card. Copy:
-
-- **OTLP Endpoint URL** → `otlp.endpoint`. Looks like `https://otlp-gateway-prod-<region>.grafana.net/otlp`.
+1. **API URL and Instance ID** — in **Observability → AI Observability → Configuration**:
+   - **API URL** → `endpoint` (e.g. `https://sigil-prod-<region>.grafana.net`)
+   - **Instance ID** → `auth.user` and `otlp.basicUser` (numeric stack ID)
+2. **Access policy token** — in **Administration → Cloud access policies**, create a policy with scopes `metrics:write`, `traces:write`, and `sigil:write`, then add a token. The `glc_…` value is shown once — goes into `auth.password` and `otlp.basicPassword`.
+3. **OTLP endpoint** — Cloud Portal → your stack → **OpenTelemetry** card. Copy the OTLP endpoint URL → `otlp.endpoint` (e.g. `https://otlp-gateway-prod-<region>.grafana.net/otlp`).
 
 ## Configure
 
@@ -73,119 +52,61 @@ Create `~/.config/sigil-pi/config.json`:
 }
 ```
 
-Token values support `${ENV_VAR}` interpolation.
+String values support `${ENV_VAR}` interpolation.
 
 ### Auth modes
 
-**basic** — HTTP Basic auth + X-Scope-OrgID (Grafana Cloud):
-```json
-{ "mode": "basic", "user": "123456", "password": "${SIGIL_AUTH_TOKEN}" }
-```
+- **basic** — HTTP Basic + `X-Scope-OrgID` (Grafana Cloud): `{ "mode": "basic", "user": "<instance-id>", "password": "${SIGIL_AUTH_TOKEN}" }`
+- **tenant** — `X-Scope-OrgID` only: `{ "mode": "tenant", "tenantId": "my-tenant" }`
+- **bearer** — `Authorization: Bearer`: `{ "mode": "bearer", "bearerToken": "${SIGIL_TOKEN}" }`
+- **none** — no auth (default)
 
-`user` is your Grafana Cloud stack/tenant ID. `password` is a `glc_…` token created in Grafana Cloud -> Access Policies ([docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/)) with the appropriate Sigil scope.
+### Redaction
 
-**tenant** — X-Scope-OrgID header only:
-```json
-{ "mode": "tenant", "tenantId": "my-tenant" }
-```
+Generations are scrubbed for secrets before they leave the process; matches become `[REDACTED:<id>]`. The sanitizer covers Grafana Cloud / cloud provider / SaaS tokens, PEM-encoded private keys, database connection strings, `KEY=value` env-style pairs, bearer tokens, and email addresses.
 
-**bearer** — Authorization: Bearer header:
-```json
-{ "mode": "bearer", "bearerToken": "${SIGIL_TOKEN}" }
-```
+User-role messages are scrubbed too — set `redaction.redactInputMessages: false` to leave them alone, or `redaction.enabled: false` to disable redaction entirely.
 
-**none** — no auth (default):
-```json
-{ "mode": "none" }
-```
-
-### OTLP (metrics & traces)
-
-The `otlp` block exports OTel histograms and trace spans. The AI Observability UI relies on these for latency, tool-call, and throughput panels — leaving it unconfigured leaves half the UI empty.
-
-```json
-"otlp": {
-  "endpoint": "https://otlp-gateway-prod-<region>.grafana.net/otlp",
-  "basicUser": "123456",
-  "basicPassword": "${SIGIL_AUTH_TOKEN}"
-}
-```
-
-### Redaction (pre-ingest secret scrubbing)
-
-The plugin runs every generation through the SDK's secret redaction sanitizer before it leaves the process. Matched values are replaced with `[REDACTED:<id>]`. The sanitizer covers high-confidence formats including:
-
-- Grafana Cloud tokens (`glc_…`) and service account tokens (`glsa_…`)
-- Cloud provider keys (AWS, GCP), GitHub PATs, OpenAI / Anthropic / Stripe / SendGrid / Twilio / Slack / npm / PyPI tokens
-- PEM-encoded private key blocks
-- Database connection strings (`postgres://user:pass@host`, `mysql://…`, `mongodb://…`, `redis://…`, `amqp://…`)
-- Environment-style `PASSWORD=…` / `SECRET=…` / `TOKEN=…` / `KEY=…` / `CREDENTIAL=…` / `API_KEY=…` / `PRIVATE_KEY=…` / `ACCESS_KEY=…` pairs
-- Bearer tokens
-- Email addresses (optional, on by default)
-
-User input messages are scrubbed by default, flip `redactInputMessages` if you want to leave the user side untouched.
-
-Opt out entirely:
-
-```json
-"redaction": { "enabled": false }
-```
-
-Tweak individual knobs:
-
-```json
-"redaction": { "redactEmailAddresses": false }
-```
-
-### All options
+### Options
 
 | Field | Default | Description |
 |-------|---------|-------------|
 | `endpoint` | — | Sigil URL |
-| `auth.mode` | `"none"` | One of `basic`, `tenant`, `bearer`, `none` |
-| `auth.user` | — | Basic auth user (Grafana Cloud stack ID) |
-| `auth.password` | — | Basic auth password (`glc_…` token) |
+| `auth.mode` | `"none"` | `basic`, `tenant`, `bearer`, or `none` |
+| `auth.user` / `auth.password` | — | Basic auth credentials |
 | `auth.tenantId` | `auth.user` in basic mode | `X-Scope-OrgID` header (required in `tenant` mode) |
-| `auth.bearerToken` | — | Bearer token (required in `bearer` mode) |
+| `auth.bearerToken` | — | Required in `bearer` mode |
 | `agentName` | `"pi"` | Agent name reported to Sigil |
 | `agentVersion` | auto-detected | Pi agent version |
 | `contentCapture` | `"metadata_only"` | `full`, `no_tool_content`, or `metadata_only` |
 | `debug` | `false` | Log lifecycle events to stderr |
-| `otlp.endpoint` | — | OTLP HTTP endpoint (e.g. `https://otlp-gateway-prod-<region>.grafana.net/otlp`). Required for the AI Observability UI to populate latency/tool-call panels. |
+| `otlp.endpoint` | — | OTLP HTTP endpoint |
 | `otlp.basicUser` / `otlp.basicPassword` | — | OTLP Basic auth |
 | `otlp.bearerToken` | — | OTLP Bearer token |
 | `otlp.headers` | — | Custom OTLP headers |
-| `redaction.enabled` | `true` | Master switch for pre-ingest secret redaction |
-| `redaction.redactInputMessages` | `true` | Also scrub user-role message content (not just assistant/tool output) |
+| `redaction.enabled` | `true` | Master switch for redaction |
+| `redaction.redactInputMessages` | `true` | Scrub user-role content too |
 | `redaction.redactEmailAddresses` | `true` | Scrub generic email addresses |
 
-### Environment variable overrides
+### Environment variables
 
-Every config field can be overridden via environment variable:
+Any field can be overridden via env var. When launched via `sigil pi`, vars in `~/.config/sigil/config.env` are loaded automatically.
 
-| Variable | Overrides |
-|----------|-----------|
-| `SIGIL_PI_ENDPOINT` | `endpoint` |
-| `SIGIL_PI_AUTH_MODE` | `auth.mode` |
-| `SIGIL_PI_TENANT_ID` | `auth.tenantId` |
-| `SIGIL_PI_BEARER_TOKEN` | `auth.bearerToken` |
-| `SIGIL_PI_BASIC_USER` | `auth.user` |
-| `SIGIL_PI_BASIC_PASSWORD` | `auth.password` |
-| `SIGIL_PI_AGENT_NAME` | `agentName` |
-| `SIGIL_PI_AGENT_VERSION` | `agentVersion` |
-| `SIGIL_PI_CONTENT_CAPTURE` | `contentCapture` |
-| `SIGIL_PI_DEBUG` | `debug` (`1`/`true` to enable) |
-| `SIGIL_PI_OTLP_ENDPOINT` | `otlp.endpoint` |
-| `SIGIL_PI_OTLP_BASIC_USER` | `otlp.basicUser` |
-| `SIGIL_PI_OTLP_BASIC_PASSWORD` | `otlp.basicPassword` |
-| `SIGIL_PI_OTLP_BEARER_TOKEN` | `otlp.bearerToken` |
-| `SIGIL_PI_REDACTION_ENABLED` | `redaction.enabled` (`1`/`true`/`yes`/`on` to enable, `0`/`false`/`no`/`off` to disable) |
-| `SIGIL_PI_REDACT_INPUT_MESSAGES` | `redaction.redactInputMessages` |
-| `SIGIL_PI_REDACT_EMAIL_ADDRESSES` | `redaction.redactEmailAddresses` |
+| Variable | Sets |
+|----------|------|
+| `SIGIL_ENDPOINT` | `endpoint` |
+| `SIGIL_AUTH_TENANT_ID` + `SIGIL_AUTH_TOKEN` | Basic auth for Sigil and OTLP (Grafana Cloud pattern) |
+| `SIGIL_AGENT_NAME` / `SIGIL_AGENT_VERSION` | `agentName` / `agentVersion` |
+| `SIGIL_CONTENT_CAPTURE_MODE` | `contentCapture` |
+| `SIGIL_DEBUG` | `debug` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `otlp.endpoint` |
+| `SIGIL_OTEL_AUTH_TOKEN` | OTLP basic-auth password (falls back to `SIGIL_AUTH_TOKEN`) |
+
+Explicit `auth.mode` in the config file always wins over env-derived auth.
 
 ## What gets sent
 
-Every generation always carries model, token usage (input/output/cache), cost, stop reason, tool names and durations, conversation ID, and turn timing. Message content depends on `contentCapture`:
+Every generation carries model, token usage (input/output/cache), cost, stop reason, tool names and durations, conversation ID, and turn timing. Message content depends on `contentCapture`:
 
 | Mode | Adds |
 |------|------|
@@ -193,4 +114,4 @@ Every generation always carries model, token usage (input/output/cache), cost, s
 | `no_tool_content` | assistant text and thinking |
 | `full` | assistant text, thinking, tool call arguments, tool results |
 
-When `otlp` is configured, the SDK additionally exports `gen_ai.client.operation.duration`, `gen_ai.client.token.usage`, and `gen_ai.client.tool_calls_per_operation` histograms (provider/model/agent labels) plus one trace span per generation. The plugin sets the OTel resource `service.name` to `sigil-pi` for both metrics and traces.
+When `otlp` is configured, the SDK also exports `gen_ai.client.operation.duration`, `gen_ai.client.token.usage`, and `gen_ai.client.tool_calls_per_operation` histograms (labelled by provider/model/agent) plus one trace span per generation. Resource `service.name` is `sigil-pi`.

--- a/plugins/pi/src/config.test.ts
+++ b/plugins/pi/src/config.test.ts
@@ -3,7 +3,11 @@ import { resolveConfig, resolveEnvVars } from "./config.js";
 
 function clearEnv() {
   for (const key of Object.keys(process.env)) {
-    if (key.startsWith("SIGIL_PI_")) {
+    if (
+      key.startsWith("SIGIL_PI_") ||
+      key.startsWith("SIGIL_") ||
+      key.startsWith("OTEL_")
+    ) {
       delete process.env[key];
     }
   }
@@ -230,6 +234,169 @@ describe("resolveConfig", () => {
       auth: { mode: "berer" },
     });
     expect(cfg).toBeNull();
+  });
+});
+
+describe("resolveConfig canonical SIGIL_* env vars", () => {
+  beforeEach(clearEnv);
+  afterEach(clearEnv);
+
+  it("reads SIGIL_ENDPOINT as the endpoint", () => {
+    process.env.SIGIL_ENDPOINT = "http://canonical:8080";
+    const cfg = resolveConfig({});
+    expect(cfg?.endpoint).toBe(
+      "http://canonical:8080/api/v1/generations:export",
+    );
+  });
+
+  it("SIGIL_ENDPOINT wins over SIGIL_PI_ENDPOINT", () => {
+    process.env.SIGIL_ENDPOINT = "http://canonical:8080";
+    process.env.SIGIL_PI_ENDPOINT = "http://legacy:9090";
+    const cfg = resolveConfig({});
+    expect(cfg?.endpoint).toBe(
+      "http://canonical:8080/api/v1/generations:export",
+    );
+  });
+
+  it("derives basic auth from SIGIL_AUTH_TENANT_ID + SIGIL_AUTH_TOKEN", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_AUTH_TENANT_ID = "tenant-1";
+    process.env.SIGIL_AUTH_TOKEN = "glc_token";
+    const cfg = resolveConfig({});
+    expect(cfg?.auth).toEqual({
+      mode: "basic",
+      user: "tenant-1",
+      password: "glc_token",
+      tenantId: "tenant-1",
+    });
+  });
+
+  it("does not derive auth from a partial canonical pair", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_AUTH_TENANT_ID = "tenant-1";
+    const cfg = resolveConfig({});
+    expect(cfg?.auth).toEqual({ mode: "none" });
+  });
+
+  it("explicit SIGIL_PI_AUTH_MODE bypasses canonical derivation", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_AUTH_TENANT_ID = "tenant-1";
+    process.env.SIGIL_AUTH_TOKEN = "glc_token";
+    process.env.SIGIL_PI_AUTH_MODE = "bearer";
+    process.env.SIGIL_PI_BEARER_TOKEN = "bearer-tok";
+    const cfg = resolveConfig({});
+    expect(cfg?.auth).toEqual({ mode: "bearer", bearerToken: "bearer-tok" });
+  });
+
+  it("explicit file.auth.mode bypasses canonical derivation", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_AUTH_TENANT_ID = "tenant-1";
+    process.env.SIGIL_AUTH_TOKEN = "glc_token";
+    const cfg = resolveConfig({ auth: { mode: "none" } });
+    expect(cfg?.auth).toEqual({ mode: "none" });
+  });
+
+  it("SIGIL_DEBUG flips debug on", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_DEBUG = "true";
+    const cfg = resolveConfig({});
+    expect(cfg?.debug).toBe(true);
+  });
+
+  it("SIGIL_PI_DEBUG still wins as legacy override when SIGIL_DEBUG is unset", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_PI_DEBUG = "true";
+    const cfg = resolveConfig({ debug: false });
+    expect(cfg?.debug).toBe(true);
+  });
+
+  it("SIGIL_CONTENT_CAPTURE_MODE sets content capture", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_CONTENT_CAPTURE_MODE = "full";
+    const cfg = resolveConfig({});
+    expect(cfg?.contentCapture).toBe("full");
+  });
+
+  it("SIGIL_AGENT_NAME and SIGIL_AGENT_VERSION override file values", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_AGENT_NAME = "pi-canonical";
+    process.env.SIGIL_AGENT_VERSION = "9.9.9";
+    const cfg = resolveConfig({ agentName: "file-name", agentVersion: "1.0" });
+    expect(cfg?.agentName).toBe("pi-canonical");
+    expect(cfg?.agentVersion).toBe("9.9.9");
+  });
+});
+
+describe("resolveConfig canonical OTLP env vars", () => {
+  beforeEach(clearEnv);
+  afterEach(clearEnv);
+
+  it("reads SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT =
+      "https://otlp.example.com/otlp";
+    const cfg = resolveConfig({});
+    expect(cfg?.otlp?.endpoint).toBe("https://otlp.example.com/otlp");
+  });
+
+  it("falls back to OTEL_EXPORTER_OTLP_ENDPOINT", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "https://otlp.example.com/otlp";
+    const cfg = resolveConfig({});
+    expect(cfg?.otlp?.endpoint).toBe("https://otlp.example.com/otlp");
+  });
+
+  it("synthesises OTLP Basic auth from canonical SIGIL_* creds", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_AUTH_TENANT_ID = "tenant-1";
+    process.env.SIGIL_AUTH_TOKEN = "glc_token";
+    process.env.SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT =
+      "https://otlp.example.com/otlp";
+    const cfg = resolveConfig({});
+    expect(cfg?.otlp?.headers.Authorization).toMatch(/^Basic /);
+    const decoded = Buffer.from(
+      cfg!.otlp!.headers.Authorization!.replace("Basic ", ""),
+      "base64",
+    ).toString();
+    expect(decoded).toBe("tenant-1:glc_token");
+  });
+
+  it("SIGIL_OTEL_AUTH_TOKEN overrides SIGIL_AUTH_TOKEN for OTel only", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_AUTH_TENANT_ID = "tenant-1";
+    process.env.SIGIL_AUTH_TOKEN = "sigil-only-token";
+    process.env.SIGIL_OTEL_AUTH_TOKEN = "otel-only-token";
+    process.env.SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT =
+      "https://otlp.example.com/otlp";
+    const cfg = resolveConfig({});
+    const decoded = Buffer.from(
+      cfg!.otlp!.headers.Authorization!.replace("Basic ", ""),
+      "base64",
+    ).toString();
+    expect(decoded).toBe("tenant-1:otel-only-token");
+    // Generation auth still uses the unscoped token.
+    expect(cfg?.auth).toEqual({
+      mode: "basic",
+      user: "tenant-1",
+      password: "sigil-only-token",
+      tenantId: "tenant-1",
+    });
+  });
+
+  it("explicit SIGIL_PI_OTLP_* creds win over canonical synthesis", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_AUTH_TENANT_ID = "tenant-1";
+    process.env.SIGIL_AUTH_TOKEN = "sigil-token";
+    process.env.SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT =
+      "https://otlp.example.com/otlp";
+    process.env.SIGIL_PI_OTLP_BASIC_USER = "otlp-user";
+    process.env.SIGIL_PI_OTLP_BASIC_PASSWORD = "otlp-pass";
+    const cfg = resolveConfig({});
+    const decoded = Buffer.from(
+      cfg!.otlp!.headers.Authorization!.replace("Basic ", ""),
+      "base64",
+    ).toString();
+    expect(decoded).toBe("otlp-user:otlp-pass");
   });
 });
 

--- a/plugins/pi/src/config.ts
+++ b/plugins/pi/src/config.ts
@@ -53,8 +53,17 @@ export async function loadConfig(): Promise<SigilPiConfig | null> {
 export function resolveConfig(
   file: Record<string, unknown>,
 ): SigilPiConfig | null {
+  // Canonical SIGIL_* env vars (shared with claude-code/codex/cursor) take
+  // precedence over the legacy SIGIL_PI_* prefix so a single config.env can
+  // drive every agent. The pi-specific names remain as a fallback so users
+  // who already configured them keep working.
   const endpoint = ensureExportPath(
-    (env("SIGIL_PI_ENDPOINT") ?? asString(file.endpoint) ?? "").trim(),
+    (
+      env("SIGIL_ENDPOINT") ??
+      env("SIGIL_PI_ENDPOINT") ??
+      asString(file.endpoint) ??
+      ""
+    ).trim(),
   );
   if (!endpoint) return null;
 
@@ -62,6 +71,7 @@ export function resolveConfig(
   if (!auth) return null;
 
   const configuredAgentName = (
+    env("SIGIL_AGENT_NAME") ??
     env("SIGIL_PI_AGENT_NAME") ??
     asString(file.agentName) ??
     "pi"
@@ -69,6 +79,7 @@ export function resolveConfig(
   const agentName = configuredAgentName.length > 0 ? configuredAgentName : "pi";
 
   const configuredAgentVersion = (
+    env("SIGIL_AGENT_VERSION") ??
     env("SIGIL_PI_AGENT_VERSION") ??
     asString(file.agentVersion) ??
     ""
@@ -78,7 +89,11 @@ export function resolveConfig(
 
   const contentCapture = resolveContentCapture(file);
 
-  const debug = envBool("SIGIL_PI_DEBUG") ?? toBool(file.debug) ?? false;
+  const debug =
+    envBool("SIGIL_DEBUG") ??
+    envBool("SIGIL_PI_DEBUG") ??
+    toBool(file.debug) ??
+    false;
 
   const otlp = resolveOtlp(file);
   const redaction = resolveRedaction(file);
@@ -119,7 +134,11 @@ function resolveRedaction(file: Record<string, unknown>): RedactionConfig {
 function resolveOtlp(file: Record<string, unknown>): OtlpConfig | undefined {
   const otlpObj = (file.otlp ?? {}) as Record<string, unknown>;
 
+  // Endpoint precedence: canonical sigil override > standard OTel env var >
+  // legacy SIGIL_PI_OTLP_ENDPOINT > file config.
   const endpoint = (
+    env("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT") ??
+    env("OTEL_EXPORTER_OTLP_ENDPOINT") ??
     env("SIGIL_PI_OTLP_ENDPOINT") ??
     asString(otlpObj.endpoint) ??
     ""
@@ -163,6 +182,24 @@ function resolveOtlp(file: Record<string, unknown>): OtlpConfig | undefined {
     headers.Authorization = `Bearer ${bearerToken}`;
   }
 
+  // Final fallback: synthesise Basic auth from the canonical SIGIL_* creds,
+  // matching the consolidated sigil binary's behaviour. SIGIL_OTEL_AUTH_TOKEN
+  // overrides the auth token for OTel only (parity with sigil README).
+  if (!headers.Authorization) {
+    const canonicalTenant = (env("SIGIL_AUTH_TENANT_ID") ?? "").trim();
+    const canonicalToken = (
+      env("SIGIL_OTEL_AUTH_TOKEN") ??
+      env("SIGIL_AUTH_TOKEN") ??
+      ""
+    ).trim();
+    if (canonicalTenant && canonicalToken) {
+      const encoded = Buffer.from(
+        `${canonicalTenant}:${canonicalToken}`,
+      ).toString("base64");
+      headers.Authorization = `Basic ${encoded}`;
+    }
+  }
+
   return { endpoint, headers };
 }
 
@@ -175,7 +212,10 @@ const VALID_CAPTURE_MODES: ContentCaptureMode[] = [
 function resolveContentCapture(
   file: Record<string, unknown>,
 ): ContentCaptureMode {
-  const envVal = env("SIGIL_PI_CONTENT_CAPTURE");
+  // Canonical name (shared with other sigil adapters) wins over the legacy
+  // pi-specific one.
+  const envVal =
+    env("SIGIL_CONTENT_CAPTURE_MODE") ?? env("SIGIL_PI_CONTENT_CAPTURE");
   if (envVal !== undefined) {
     return parseContentCaptureMode(envVal);
   }
@@ -204,13 +244,28 @@ function parseContentCaptureMode(value: string): ContentCaptureMode {
 }
 
 function resolveAuth(file: Record<string, unknown>): SigilAuthConfig | null {
-  const mode = (
+  const explicitMode =
     env("SIGIL_PI_AUTH_MODE") ??
-    asString((file.auth as Record<string, unknown> | undefined)?.mode) ??
-    "none"
-  )
-    .trim()
-    .toLowerCase();
+    asString((file.auth as Record<string, unknown> | undefined)?.mode);
+
+  // Canonical SIGIL_AUTH_TENANT_ID + SIGIL_AUTH_TOKEN pattern: when neither
+  // the env nor the file picks an explicit auth mode, treat the canonical
+  // pair as Grafana Cloud basic auth (tenant as user, token as password).
+  // This matches the implicit contract used by claude-code/codex/cursor.
+  if (explicitMode === undefined) {
+    const canonicalTenant = (env("SIGIL_AUTH_TENANT_ID") ?? "").trim();
+    const canonicalToken = (env("SIGIL_AUTH_TOKEN") ?? "").trim();
+    if (canonicalTenant && canonicalToken) {
+      return {
+        mode: "basic",
+        user: canonicalTenant,
+        password: canonicalToken,
+        tenantId: canonicalTenant,
+      };
+    }
+  }
+
+  const mode = (explicitMode ?? "none").trim().toLowerCase();
 
   const authObj = (file.auth ?? {}) as Record<string, unknown>;
 

--- a/plugins/sigil/README.md
+++ b/plugins/sigil/README.md
@@ -1,9 +1,10 @@
-# sigil — single binary for the Claude Code, Codex, and Cursor agent plugins
+# sigil — single binary for the Claude Code, Codex, Cursor, and pi agent plugins
 
-`sigil` is one Go binary that backs all three agent plugins (`plugins/claude-code`, `plugins/codex`, `plugins/cursor`) in this repository. The dispatcher accepts:
+`sigil` is one Go binary that backs the agent plugins (`plugins/claude-code`, `plugins/codex`, `plugins/cursor`, `plugins/pi`) in this repository. The dispatcher accepts:
 
 ```
 sigil <agent> hook        # process a JSON hook payload on stdin for <agent>
+sigil pi [-- args...]     # bootstrap the @grafana/sigil-pi extension, then exec pi
 sigil --version           # print the build version
 ```
 
@@ -57,16 +58,18 @@ When `OTEL_EXPORTER_OTLP_HEADERS` does not contain an `Authorization` entry, the
 | `claude-code` | `sigil claude-code hook` (resolved via `PATH`) |
 | `codex` | `sigil codex hook` (resolved via `PATH`) |
 | `cursor` | `plugins/cursor/scripts/run.sh` |
+| `pi` | `sigil pi [-- args...]` (resolved via `PATH`) |
 
 Claude Code and Codex run hooks under the user's shell environment, so the binary just has to be on `PATH`. Cursor launches hooks under a stripped environment (macOS GUI launches inherit launchd's `/usr/bin:/bin:/usr/sbin:/sbin`), which doesn't include `~/go/bin` or `/opt/homebrew/bin` — the wrapper probes `$SIGIL_BIN`, `~/go/bin/sigil`, `/opt/homebrew/bin/sigil`, `/usr/local/bin/sigil`, and `~/.local/bin/sigil`, then exec's `sigil cursor hook` on the first hit. If no binary is found it emits a permissive JSON response so `beforeSubmitPrompt` is never blocked and exits 0.
 
-## Per-agent quirks
+## Per-agent details
 
 See the agent-plugin READMEs for agent-specific behaviour:
 
 - [`plugins/claude-code/README.md`](../claude-code/README.md)
 - [`plugins/codex/README.md`](../codex/README.md)
 - [`plugins/cursor/README.md`](../cursor/README.md)
+- [`plugins/pi/README.md`](../pi/README.md)
 
 ## Development
 

--- a/plugins/sigil/cmd/sigil/main.go
+++ b/plugins/sigil/cmd/sigil/main.go
@@ -1,13 +1,16 @@
-// Command sigil is the single binary used by the Claude Code, Codex, and
-// Cursor agent plugins. It accepts:
+// Command sigil is the single binary used by the Claude Code, Codex, Cursor,
+// and pi agent plugins. It accepts:
 //
-//	sigil <agent> hook   — dispatch a JSON hook payload on stdin to <agent>
-//	sigil --version      — print the build version
+//	sigil <agent> hook           — dispatch a JSON hook payload on stdin to <agent>
+//	sigil pi [-- args...]        — exec pi after bootstrapping the @grafana/sigil-pi extension
+//	sigil --version              — print the build version
 //
 // Unknown agents and unknown verbs exit with code 2 and a usage message on
-// stderr. The binary must never crash the calling agent process; once argv
-// parsing succeeds, all errors are swallowed (and logged when
-// SIGIL_DEBUG=true) and the process exits 0.
+// stderr. For hook agents the binary must never crash the calling agent
+// process; once argv parsing succeeds, all errors are swallowed (and logged
+// when SIGIL_DEBUG=true) and the process exits 0. Launcher agents (currently
+// just `pi`) are invoked by a human, so errors surface on stderr with a
+// non-zero exit code.
 package main
 
 import (
@@ -17,18 +20,24 @@ import (
 	"log"
 	"os"
 
-	"github.com/grafana/sigil-sdk/plugins/sigil/internal/cli"
-	"github.com/grafana/sigil-sdk/plugins/sigil/internal/dotenv"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/claudecode"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/codex"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/cursor"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/pi"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/cli"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/dotenv"
 )
 
 // version is overridden via -ldflags at build time.
 var version = "dev"
 
-// agentHook is the entrypoint each agent adapter exposes.
+// agentHook is the entrypoint each hook agent adapter exposes.
 type agentHook func(ctx context.Context, stdin io.Reader, stdout io.Writer, log *log.Logger) error
+
+// agentLauncher is the entrypoint each launcher agent adapter exposes. It
+// owns the user's terminal — args after the `--` separator are forwarded
+// unchanged to the underlying CLI via process replacement.
+type agentLauncher func(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer, log *log.Logger) error
 
 // agents maps the argv agent name to its adapter Hook. The map is a package
 // var so tests can substitute mock hooks.
@@ -36,6 +45,13 @@ var agents = map[string]agentHook{
 	"claude-code": claudecode.Hook,
 	"codex":       codex.Hook,
 	"cursor":      cursor.Hook,
+}
+
+// launchers maps the argv agent name to its launcher adapter. Launchers are
+// invoked directly by a human (no JSON on stdin) and replace the current
+// process with the target CLI.
+var launchers = map[string]agentLauncher{
+	"pi": pi.Launch,
 }
 
 // exit is a package var so tests can intercept termination.
@@ -51,8 +67,44 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 		return
 	}
 
+	if len(args) == 0 {
+		_, _ = fmt.Fprintln(stderr, "usage: sigil <agent> hook | sigil pi [-- args...]")
+		exit(2)
+		return
+	}
+
+	// Launcher dispatch handles `sigil pi [-- args...]` before the hook
+	// branch because pi has no verb (single mode of operation).
+	if launcher, ok := launchers[args[0]]; ok {
+		piArgs, ok := parseLauncherArgs(args[0], args[1:], stderr)
+		if !ok {
+			return
+		}
+
+		dotenv.ApplyEnv("sigil", nil)
+		logger := cli.InitLogger("sigil", args[0], "SIGIL_DEBUG")
+		// Launcher panics must surface to the user (non-zero exit, message on
+		// stderr) — log to the debug file, then re-panic so the Go runtime
+		// reports it. cli.RecoverAndLog would silently swallow the panic and
+		// exit 0, which is the hook-agent contract, not the launcher one.
+		defer func() {
+			if r := recover(); r != nil {
+				logger.Printf("launch %s: panic: %v", args[0], r)
+				panic(r)
+			}
+		}()
+
+		if err := launcher(context.Background(), piArgs, stdin, stdout, stderr, logger); err != nil {
+			logger.Printf("launch %s: %v", args[0], err)
+			_, _ = fmt.Fprintf(stderr, "sigil: %v\n", err)
+			exit(1)
+			return
+		}
+		return
+	}
+
 	if len(args) < 2 {
-		_, _ = fmt.Fprintln(stderr, "usage: sigil <agent> hook")
+		_, _ = fmt.Fprintln(stderr, "usage: sigil <agent> hook | sigil pi [-- args...]")
 		exit(2)
 		return
 	}
@@ -85,5 +137,33 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 
 	if err := hook(context.Background(), stdin, stdout, logger); err != nil {
 		logger.Printf("hook: %v", err)
+	}
+}
+
+// parseLauncherArgs splits sigil-side tokens from forwarded args at the first
+// `--`. There are no sigil-side flags yet, so any token before `--` is an
+// error.
+func parseLauncherArgs(name string, rest []string, stderr io.Writer) ([]string, bool) {
+	sep := -1
+	for i, a := range rest {
+		if a == "--" {
+			sep = i
+			break
+		}
+	}
+	switch {
+	case sep < 0 && len(rest) == 0:
+		return nil, true
+	case sep < 0:
+		_, _ = fmt.Fprintf(stderr, "sigil: use `sigil %s -- <args>` to forward args to %[1]s\n", name)
+		exit(2)
+		return nil, false
+	default:
+		if sep > 0 {
+			_, _ = fmt.Fprintf(stderr, "sigil: unknown options before `--`: %v\n", rest[:sep])
+			exit(2)
+			return nil, false
+		}
+		return rest[sep+1:], true
 	}
 }

--- a/plugins/sigil/cmd/sigil/main_test.go
+++ b/plugins/sigil/cmd/sigil/main_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -162,6 +163,124 @@ func TestRun_HookErrorIsSwallowedAfterDispatch(t *testing.T) {
 	if gotExit != nil {
 		t.Fatalf("exit code = %d, want no exit", *gotExit)
 	}
+}
+
+func TestRun_LauncherBareLaunch(t *testing.T) {
+	var got []string
+	called := 0
+	withStubLauncher(t, "pi", func(_ context.Context, args []string, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		called++
+		got = append([]string{}, args...)
+		return nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"pi"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	if gotExit != nil {
+		t.Fatalf("exit code = %d, want no exit", *gotExit)
+	}
+	if called != 1 {
+		t.Fatalf("launcher called %d times, want 1", called)
+	}
+	if len(got) != 0 {
+		t.Fatalf("launcher args = %v, want empty", got)
+	}
+}
+
+func TestRun_LauncherSeparatorOnly(t *testing.T) {
+	var got []string
+	withStubLauncher(t, "pi", func(_ context.Context, args []string, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		got = append([]string{}, args...)
+		return nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	withExit(t, func() {
+		run([]string{"pi", "--"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	if len(got) != 0 {
+		t.Fatalf("launcher args = %v, want empty", got)
+	}
+}
+
+func TestRun_LauncherForwardsArgsAfterSeparator(t *testing.T) {
+	var got []string
+	withStubLauncher(t, "pi", func(_ context.Context, args []string, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		got = append([]string{}, args...)
+		return nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	withExit(t, func() {
+		run([]string{"pi", "--", "--print", "hi"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	if !reflect.DeepEqual(got, []string{"--print", "hi"}) {
+		t.Fatalf("launcher args = %v, want [--print hi]", got)
+	}
+}
+
+func TestRun_LauncherMissingSeparatorExits2(t *testing.T) {
+	withStubLauncher(t, "pi", func(_ context.Context, _ []string, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		t.Fatal("launcher must not be called when separator is missing")
+		return nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"pi", "--print", "hi"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	if gotExit == nil || *gotExit != 2 {
+		t.Fatalf("exit = %v, want 2", gotExit)
+	}
+	if !strings.Contains(stderr.String(), "use `sigil pi -- <args>`") {
+		t.Fatalf("stderr missing forward-args hint: %q", stderr.String())
+	}
+}
+
+func TestRun_LauncherUnknownFlagsBeforeSeparatorExit2(t *testing.T) {
+	withStubLauncher(t, "pi", func(_ context.Context, _ []string, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		t.Fatal("launcher must not be called when unknown options precede separator")
+		return nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"pi", "--debug", "--", "x"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	if gotExit == nil || *gotExit != 2 {
+		t.Fatalf("exit = %v, want 2", gotExit)
+	}
+	if !strings.Contains(stderr.String(), "unknown options before `--`") {
+		t.Fatalf("stderr missing unknown-options message: %q", stderr.String())
+	}
+}
+
+func TestRun_LauncherErrorExits1(t *testing.T) {
+	withStubLauncher(t, "pi", func(_ context.Context, _ []string, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		return errors.New("boom")
+	})
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"pi", "--"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	if gotExit == nil || *gotExit != 1 {
+		t.Fatalf("exit = %v, want 1", gotExit)
+	}
+	if !strings.HasPrefix(stderr.String(), "sigil:") {
+		t.Fatalf("stderr does not start with sigil: %q", stderr.String())
+	}
+}
+
+// withStubLauncher replaces the launchers map with a single entry for the
+// duration of the test.
+func withStubLauncher(t *testing.T, name string, fn agentLauncher) {
+	t.Helper()
+	prev := launchers
+	t.Cleanup(func() { launchers = prev })
+	launchers = map[string]agentLauncher{name: fn}
 }
 
 // withExit replaces the package's exit function with a recorder, runs f, and

--- a/plugins/sigil/internal/agents/pi/launch.go
+++ b/plugins/sigil/internal/agents/pi/launch.go
@@ -1,0 +1,252 @@
+// Package pi implements the pi launcher adapter for the consolidated sigil
+// binary. The dispatcher in cmd/sigil routes `sigil pi [-- args...]` here.
+//
+// Unlike the hook adapters, this adapter owns the user's terminal: it
+// bootstraps the @grafana/sigil-pi extension in pi's settings file on first
+// use, then replaces the current process with the pi binary via execve so
+// signals, exit codes, and TTY behaviour pass through cleanly.
+package pi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+const (
+	// PluginSource is the canonical npm spec used for fresh installs.
+	PluginSource = "npm:@grafana/sigil-pi"
+	// pluginName is the package.json `name` of the extension. Used to detect
+	// versioned npm specs (e.g. `npm:@grafana/sigil-pi@0.1.1`) and local-path
+	// installs that point at a checkout of this package.
+	pluginName = "@grafana/sigil-pi"
+	npmPrefix  = "npm:"
+	// projectConfigDirName is pi's default project config directory. Pi
+	// allows overriding this via package.json `piConfig.configDir`, but the
+	// default `.pi` covers every shipped install.
+	projectConfigDirName = ".pi"
+)
+
+// Test seams.
+var (
+	lookPath   = exec.LookPath
+	execFn     = syscall.Exec
+	runInstall = defaultRunInstall
+)
+
+// Launch resolves the `pi` binary on PATH, ensures the @grafana/sigil-pi
+// extension is registered in the user's pi settings (running `pi install`
+// once if it is not), and then exec's pi with the supplied args.
+func Launch(ctx context.Context, args []string, _ io.Reader, _, stderr io.Writer, logger *log.Logger) error {
+	bin, err := lookPath("pi")
+	if err != nil {
+		return fmt.Errorf("pi CLI not found on PATH: %w", err)
+	}
+
+	installed, err := pluginInstalled()
+	if err != nil {
+		logger.Printf("settings probe: %v", err)
+		// Surface the probe failure so the user can see why we're falling
+		// through to install on a settings file we couldn't read. Treat the
+		// case like a missing extension — pi's installer will fail loudly if
+		// the file is genuinely broken.
+		_, _ = fmt.Fprintf(stderr, "sigil: pi settings probe failed: %v\n", err)
+		installed = false
+	}
+	if !installed {
+		_, _ = fmt.Fprintf(stderr, "sigil: installing %s into pi\n", PluginSource)
+		if err := runInstall(ctx, bin, stderr); err != nil {
+			// Don't block the user's pi session on a failed install (offline
+			// machine, npm rate-limit, sandboxed CI, etc.). Log the failure for
+			// SIGIL_DEBUG, point the user at the manual command, and fall
+			// through to exec. pi still runs, just without Sigil capture.
+			logger.Printf("install %s: %v", PluginSource, err)
+			_, _ = fmt.Fprintf(stderr,
+				"sigil: install of %s failed: %v\n"+
+					"sigil: continuing without Sigil capture. To retry manually:\n"+
+					"          pi install %s\n",
+				PluginSource, err, PluginSource)
+		}
+	}
+
+	argv := append([]string{bin}, args...)
+	if err := execFn(bin, argv, os.Environ()); err != nil {
+		return fmt.Errorf("exec pi: %w", err)
+	}
+	return nil
+}
+
+func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {
+	cmd := exec.CommandContext(ctx, bin, "install", PluginSource)
+	cmd.Stdout = w
+	cmd.Stderr = w
+	return cmd.Run()
+}
+
+// piSettings is the subset of pi's settings.json this launcher inspects.
+type piSettings struct {
+	Packages []json.RawMessage `json:"packages"`
+}
+
+// pluginInstalled reports whether the @grafana/sigil-pi extension is
+// already registered in pi's settings. Pi reads two settings files: the
+// global one under PI_CODING_AGENT_DIR (default ~/.pi/agent) and the
+// project one at <cwd>/.pi/settings.json (used when the user runs
+// `pi install -l` from a project directory). Either is enough — pi will
+// load the extension at startup if it appears in either file.
+//
+// Settings entries may be plain strings or objects with a `source` field,
+// and the source itself may be a bare npm spec (`npm:@grafana/sigil-pi`),
+// a versioned npm spec (`npm:@grafana/sigil-pi@0.1.1`), or a local path.
+// A missing settings file means that scope is unused — treat as not
+// installed in that scope and move on.
+func pluginInstalled() (bool, error) {
+	globalPath, err := settingsPath()
+	if err != nil {
+		return false, err
+	}
+	if found, err := readSettingsAndCheck(globalPath); err != nil {
+		return false, err
+	} else if found {
+		return true, nil
+	}
+
+	// Project-scoped install (`pi install -l`) writes to <cwd>/.pi/settings.json.
+	// Pi only consults the literal cwd, no parent walking, so we mirror that.
+	// A failure to resolve cwd is exceptionally rare; treat it as "no project
+	// settings available" rather than blocking the launch.
+	projectPath, err := projectSettingsPath()
+	if err != nil {
+		return false, nil
+	}
+	return readSettingsAndCheck(projectPath)
+}
+
+// readSettingsAndCheck loads one pi settings file and returns whether the
+// @grafana/sigil-pi extension is registered in it. A missing file is not
+// an error — that scope is just unused.
+func readSettingsAndCheck(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+	var s piSettings
+	if err := json.Unmarshal(data, &s); err != nil {
+		return false, fmt.Errorf("parse %s: %w", path, err)
+	}
+	settingsDir := filepath.Dir(path)
+	for _, raw := range s.Packages {
+		var source string
+		if err := json.Unmarshal(raw, &source); err != nil {
+			var asObj struct {
+				Source string `json:"source"`
+			}
+			if err := json.Unmarshal(raw, &asObj); err != nil {
+				continue
+			}
+			source = asObj.Source
+		}
+		if sourceMatchesPlugin(source, settingsDir) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// sourceMatchesPlugin returns true when a pi settings source identifies the
+// @grafana/sigil-pi extension. It handles three shapes:
+//   - bare npm specs: `npm:@grafana/sigil-pi`
+//   - versioned npm specs: `npm:@grafana/sigil-pi@<version-or-tag>`
+//   - local paths (absolute or relative to settingsDir) that point at a
+//     directory whose package.json declares `name: "@grafana/sigil-pi"`
+//
+// git: / https: / ssh: sources are never matched — we don't publish there.
+func sourceMatchesPlugin(source, settingsDir string) bool {
+	if source == "" {
+		return false
+	}
+	if strings.HasPrefix(source, npmPrefix) {
+		return stripNpmVersion(strings.TrimPrefix(source, npmPrefix)) == pluginName
+	}
+	if filepath.IsAbs(source) || strings.HasPrefix(source, "./") || strings.HasPrefix(source, "../") {
+		path := source
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(settingsDir, path)
+		}
+		return localPathIsPlugin(path)
+	}
+	return false
+}
+
+// stripNpmVersion returns the package name portion of an npm spec, stripping
+// the trailing `@<version>` segment if present. Scoped packages start with
+// `@scope/...`; the leading `@` (index 0) is part of the name, not a version
+// separator, so we look for the LAST `@` after index 0.
+func stripNpmVersion(spec string) string {
+	at := strings.LastIndex(spec, "@")
+	if at <= 0 {
+		return spec
+	}
+	return spec[:at]
+}
+
+// localPathIsPlugin returns true when path is a directory containing a
+// package.json with name == pluginName. Any IO/parse failure means we can't
+// confirm the match — treat as a non-match rather than an error, since the
+// settings file may legitimately reference other local packages we don't
+// own.
+func localPathIsPlugin(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	data, err := os.ReadFile(filepath.Join(path, "package.json"))
+	if err != nil {
+		return false
+	}
+	var pkg struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return false
+	}
+	return pkg.Name == pluginName
+}
+
+// settingsPath returns the path to pi's global settings.json, honouring
+// PI_CODING_AGENT_DIR (default $HOME/.pi/agent) per `pi --help`. Errors
+// resolving the user's home directory are surfaced so callers don't probe a
+// path silently rooted at CWD.
+func settingsPath() (string, error) {
+	dir := os.Getenv("PI_CODING_AGENT_DIR")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home dir for pi settings: %w", err)
+		}
+		dir = filepath.Join(home, ".pi", "agent")
+	}
+	return filepath.Join(dir, "settings.json"), nil
+}
+
+// projectSettingsPath returns the path to pi's project-scoped settings.json
+// (<cwd>/.pi/settings.json). Pi only consults the literal cwd — it does not
+// walk up parent directories — so we don't either.
+func projectSettingsPath() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("resolve cwd for pi project settings: %w", err)
+	}
+	return filepath.Join(cwd, projectConfigDirName, "settings.json"), nil
+}

--- a/plugins/sigil/internal/agents/pi/launch_test.go
+++ b/plugins/sigil/internal/agents/pi/launch_test.go
@@ -1,0 +1,458 @@
+package pi
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestLaunch_MissingPiBinary(t *testing.T) {
+	withLookPath(t, func(string) (string, error) { return "", exec.ErrNotFound })
+
+	err := Launch(context.Background(), nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger())
+	if err == nil || !strings.Contains(err.Error(), "pi CLI not found") {
+		t.Fatalf("err = %v, want contains \"pi CLI not found\"", err)
+	}
+}
+
+func TestLaunch_SkipsInstallWhenPackagePresent(t *testing.T) {
+	dir := t.TempDir()
+	writeSettings(t, dir, `{"packages":["npm:@grafana/sigil-pi"]}`)
+	t.Setenv("PI_CODING_AGENT_DIR", dir)
+
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/pi", nil })
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		t.Fatal("runInstall must not be called when package is already present")
+		return nil
+	})
+
+	var execArgv []string
+	withExecFn(t, func(_ string, argv []string, _ []string) error {
+		execArgv = append([]string{}, argv...)
+		return nil
+	})
+
+	var stderr bytes.Buffer
+	if err := Launch(context.Background(), []string{"--print", "hi"}, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+		t.Fatalf("Launch returned err: %v", err)
+	}
+	if !reflect.DeepEqual(execArgv, []string{"/usr/local/bin/pi", "--print", "hi"}) {
+		t.Fatalf("exec argv = %v", execArgv)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr non-empty: %q", stderr.String())
+	}
+}
+
+func TestLaunch_RunsInstallWhenPackageMissing(t *testing.T) {
+	dir := t.TempDir()
+	writeSettings(t, dir, `{"packages":[]}`)
+	t.Setenv("PI_CODING_AGENT_DIR", dir)
+
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/pi", nil })
+
+	installCalls := 0
+	withRunInstall(t, func(_ context.Context, bin string, _ io.Writer) error {
+		installCalls++
+		if bin != "/usr/local/bin/pi" {
+			t.Errorf("install bin = %q, want /usr/local/bin/pi", bin)
+		}
+		return nil
+	})
+
+	execCalled := false
+	withExecFn(t, func(_ string, _ []string, _ []string) error {
+		execCalled = true
+		return nil
+	})
+
+	var stderr bytes.Buffer
+	if err := Launch(context.Background(), nil, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+		t.Fatalf("Launch returned err: %v", err)
+	}
+	if installCalls != 1 {
+		t.Fatalf("runInstall calls = %d, want 1", installCalls)
+	}
+	if !execCalled {
+		t.Fatal("execFn was not called after install")
+	}
+	if !strings.Contains(stderr.String(), "installing "+PluginSource) {
+		t.Fatalf("stderr missing install message: %q", stderr.String())
+	}
+}
+
+// A failed `pi install` should not block the user's session. The launcher
+// must print the failure and a manual-retry hint on stderr, then still exec
+// pi so the workflow keeps moving (just without Sigil capture).
+func TestLaunch_InstallFailureContinuesToExec(t *testing.T) {
+	dir := t.TempDir()
+	writeSettings(t, dir, `{"packages":[]}`)
+	t.Setenv("PI_CODING_AGENT_DIR", dir)
+
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/pi", nil })
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		return errors.New("network down")
+	})
+
+	execCalled := false
+	withExecFn(t, func(_ string, _ []string, _ []string) error {
+		execCalled = true
+		return nil
+	})
+
+	var stderr bytes.Buffer
+	if err := Launch(context.Background(), nil, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+		t.Fatalf("Launch returned err: %v", err)
+	}
+	if !execCalled {
+		t.Fatal("execFn was not called after install failure")
+	}
+	got := stderr.String()
+	if !strings.Contains(got, "install of "+PluginSource+" failed") {
+		t.Fatalf("stderr missing failure message: %q", got)
+	}
+	if !strings.Contains(got, "network down") {
+		t.Fatalf("stderr missing underlying error: %q", got)
+	}
+	if !strings.Contains(got, "pi install "+PluginSource) {
+		t.Fatalf("stderr missing manual install hint: %q", got)
+	}
+}
+
+func TestPluginInstalled_RecognisesBothShapes(t *testing.T) {
+	// localPluginDir is a sibling directory referenced by relative-path test
+	// cases. It is materialised below before each subtest runs.
+	const localPluginDir = "local-plugin"
+
+	cases := []struct {
+		name     string
+		write    bool
+		contents string
+		// localPkg, when non-empty, is written to <tmpdir>/local-plugin/package.json
+		// so relative/absolute path entries in `contents` resolve to a real package.
+		localPkg string
+		want     bool
+		wantErr  bool
+	}{
+		{
+			name:     "string entry matches",
+			write:    true,
+			contents: `{"packages":["npm:@grafana/sigil-pi"]}`,
+			want:     true,
+		},
+		{
+			name:     "object entry matches",
+			write:    true,
+			contents: `{"packages":[{"source":"npm:@grafana/sigil-pi","alias":"sigil"}]}`,
+			want:     true,
+		},
+		{
+			name:     "versioned npm string matches",
+			write:    true,
+			contents: `{"packages":["npm:@grafana/sigil-pi@0.1.1"]}`,
+			want:     true,
+		},
+		{
+			name:     "versioned npm object matches",
+			write:    true,
+			contents: `{"packages":[{"source":"npm:@grafana/sigil-pi@1.0.0-rc.3"}]}`,
+			want:     true,
+		},
+		{
+			name:     "npm dist-tag matches",
+			write:    true,
+			contents: `{"packages":["npm:@grafana/sigil-pi@next"]}`,
+			want:     true,
+		},
+		{
+			name:     "similar npm name does not match",
+			write:    true,
+			contents: `{"packages":["npm:@grafana/sigil-pi-extra","npm:@grafana/sigil-pi-extra@1.0.0"]}`,
+			want:     false,
+		},
+		{
+			name:     "relative local path matches",
+			write:    true,
+			contents: `{"packages":["./local-plugin"]}`,
+			localPkg: `{"name":"@grafana/sigil-pi"}`,
+			want:     true,
+		},
+		{
+			name:     "relative local path with wrong name does not match",
+			write:    true,
+			contents: `{"packages":["./local-plugin"]}`,
+			localPkg: `{"name":"@grafana/other"}`,
+			want:     false,
+		},
+		{
+			name:     "missing local path does not match and does not error",
+			write:    true,
+			contents: `{"packages":["/does/not/exist","./also-missing"]}`,
+			want:     false,
+		},
+		{
+			name:     "git source does not match",
+			write:    true,
+			contents: `{"packages":["git:github.com/grafana/sigil-sdk"]}`,
+			want:     false,
+		},
+		{
+			name:     "unrelated entries do not match",
+			write:    true,
+			contents: `{"packages":["npm:other-pkg",{"source":"npm:another"}]}`,
+			want:     false,
+		},
+		{
+			name:     "empty packages list",
+			write:    true,
+			contents: `{"packages":[]}`,
+			want:     false,
+		},
+		{
+			name:  "missing file treated as not installed",
+			write: false,
+			want:  false,
+		},
+		{
+			name:     "malformed json surfaces error",
+			write:    true,
+			contents: `{"packages":[`,
+			wantErr:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.write {
+				writeSettings(t, dir, tc.contents)
+			}
+			if tc.localPkg != "" {
+				pkgDir := filepath.Join(dir, localPluginDir)
+				if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+					t.Fatalf("mkdir local plugin: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(tc.localPkg), 0o600); err != nil {
+					t.Fatalf("write local package.json: %v", err)
+				}
+			}
+			t.Setenv("PI_CODING_AGENT_DIR", dir)
+
+			got, err := pluginInstalled()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Fatalf("got = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPluginInstalled_ProjectScope(t *testing.T) {
+	// Project-scoped installs (`pi install -l`) land in <cwd>/.pi/settings.json
+	// rather than the global file. The launcher must consider those installed
+	// too — otherwise it re-runs `pi install` on every invocation, writing
+	// to the global file the user explicitly chose to avoid.
+	cases := []struct {
+		name    string
+		global  string // contents of global settings.json ("" = don't create)
+		project string // contents of <cwd>/.pi/settings.json ("" = don't create)
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "project-only install matches",
+			global:  `{"packages":[]}`,
+			project: `{"packages":["npm:@grafana/sigil-pi"]}`,
+			want:    true,
+		},
+		{
+			name:    "project-only versioned install matches",
+			global:  `{"packages":[]}`,
+			project: `{"packages":["npm:@grafana/sigil-pi@0.1.1"]}`,
+			want:    true,
+		},
+		{
+			name:    "global wins without consulting project",
+			global:  `{"packages":["npm:@grafana/sigil-pi"]}`,
+			project: `{"packages":[]}`,
+			want:    true,
+		},
+		{
+			name:    "both scopes have it",
+			global:  `{"packages":["npm:@grafana/sigil-pi"]}`,
+			project: `{"packages":["npm:@grafana/sigil-pi@0.2.0"]}`,
+			want:    true,
+		},
+		{
+			name:    "neither scope has it",
+			global:  `{"packages":["npm:other"]}`,
+			project: `{"packages":["npm:another"]}`,
+			want:    false,
+		},
+		{
+			name:    "project file absent falls back to global only",
+			global:  `{"packages":["npm:@grafana/sigil-pi"]}`,
+			project: "",
+			want:    true,
+		},
+		{
+			name:    "project file absent and global lacks plugin",
+			global:  `{"packages":[]}`,
+			project: "",
+			want:    false,
+		},
+		{
+			name:    "malformed project settings surfaces error",
+			global:  `{"packages":[]}`,
+			project: `{"packages":[`,
+			wantErr: true,
+		},
+		{
+			name:    "global file absent, project has plugin",
+			global:  "",
+			project: `{"packages":["npm:@grafana/sigil-pi"]}`,
+			want:    true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			globalDir := t.TempDir()
+			projectRoot := t.TempDir()
+			if tc.global != "" {
+				writeSettings(t, globalDir, tc.global)
+			}
+			if tc.project != "" {
+				projectPiDir := filepath.Join(projectRoot, ".pi")
+				if err := os.MkdirAll(projectPiDir, 0o755); err != nil {
+					t.Fatalf("mkdir project .pi: %v", err)
+				}
+				writeSettings(t, projectPiDir, tc.project)
+			}
+			t.Setenv("PI_CODING_AGENT_DIR", globalDir)
+			t.Chdir(projectRoot)
+
+			got, err := pluginInstalled()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Fatalf("got = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPluginInstalled_ProjectScopeLocalPath(t *testing.T) {
+	// Relative paths in project settings resolve against the project .pi dir,
+	// not the global one. Make sure that resolution works end to end.
+	globalDir := t.TempDir()
+	projectRoot := t.TempDir()
+
+	projectPiDir := filepath.Join(projectRoot, ".pi")
+	if err := os.MkdirAll(projectPiDir, 0o755); err != nil {
+		t.Fatalf("mkdir project .pi: %v", err)
+	}
+	// Local plugin sits at <projectRoot>/.pi/local-plugin/, referenced as
+	// "./local-plugin" from <projectRoot>/.pi/settings.json.
+	pkgDir := filepath.Join(projectPiDir, "local-plugin")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatalf("mkdir local plugin: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(`{"name":"@grafana/sigil-pi"}`), 0o600); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+	writeSettings(t, projectPiDir, `{"packages":["./local-plugin"]}`)
+
+	t.Setenv("PI_CODING_AGENT_DIR", globalDir)
+	t.Chdir(projectRoot)
+
+	got, err := pluginInstalled()
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !got {
+		t.Fatal("relative local path in project settings should match")
+	}
+}
+
+func TestPluginInstalled_AbsoluteLocalPath(t *testing.T) {
+	// Absolute paths are resolved as-is, independent of settingsDir.
+	dir := t.TempDir()
+	pkgDir := filepath.Join(t.TempDir(), "sigil-pi-checkout")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(`{"name":"@grafana/sigil-pi"}`), 0o600); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+	contents := `{"packages":["` + pkgDir + `"]}`
+	writeSettings(t, dir, contents)
+	t.Setenv("PI_CODING_AGENT_DIR", dir)
+
+	got, err := pluginInstalled()
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !got {
+		t.Fatal("absolute local path should match")
+	}
+}
+
+func TestStripNpmVersion(t *testing.T) {
+	cases := map[string]string{
+		"@grafana/sigil-pi":       "@grafana/sigil-pi",
+		"@grafana/sigil-pi@0.1.1": "@grafana/sigil-pi",
+		"@grafana/sigil-pi@next":  "@grafana/sigil-pi",
+		"pkg":                     "pkg",
+		"pkg@1.0.0":               "pkg",
+		"@grafana/sigil-pi-extra": "@grafana/sigil-pi-extra",
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			if got := stripNpmVersion(in); got != want {
+				t.Fatalf("stripNpmVersion(%q) = %q, want %q", in, got, want)
+			}
+		})
+	}
+}
+
+func writeSettings(t *testing.T, dir, contents string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(contents), 0o600); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+}
+
+func withLookPath(t *testing.T, fn func(string) (string, error)) {
+	t.Helper()
+	prev := lookPath
+	t.Cleanup(func() { lookPath = prev })
+	lookPath = fn
+}
+
+func withRunInstall(t *testing.T, fn func(context.Context, string, io.Writer) error) {
+	t.Helper()
+	prev := runInstall
+	t.Cleanup(func() { runInstall = prev })
+	runInstall = fn
+}
+
+func withExecFn(t *testing.T, fn func(string, []string, []string) error) {
+	t.Helper()
+	prev := execFn
+	t.Cleanup(func() { execFn = prev })
+	execFn = fn
+}
+
+func nopLogger() *log.Logger {
+	return log.New(io.Discard, "", 0)
+}


### PR DESCRIPTION
Adds `sigil pi [-- args...]` command that launches Pi agent and installs the plugin if needed and then exec's `pi`:

```sh
sigil pi                       # first run: bootstrap + launch; later: just launch
sigil pi -- --continue         # forward flags to pi after `--`
```

If install fails, the launcher logs the failure, prints a manual-retry hint, and still exec's `pi` so the user's session is not blocked.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new CLI dispatch/exec behavior and changes env-var precedence/implicit auth derivation, which could alter how existing pi deployments resolve credentials and OTLP settings.
> 
> **Overview**
> Adds a new `sigil pi [-- args...]` launcher path in the consolidated `sigil` binary that auto-installs `npm:@grafana/sigil-pi` into pi (if not already registered in global or project `.pi/settings.json`) and then `exec`s `pi`, with safe arg-forwarding via `--` and non-blocking behavior on install failures.
> 
> Updates the pi extension config resolver to prefer canonical cross-agent env vars (`SIGIL_ENDPOINT`, `SIGIL_AUTH_TENANT_ID`/`SIGIL_AUTH_TOKEN`, `SIGIL_CONTENT_CAPTURE_MODE`, `SIGIL_DEBUG`, `OTEL_EXPORTER_OTLP_ENDPOINT`) over legacy `SIGIL_PI_*`, including implicit basic-auth/OTLP auth synthesis from the canonical creds, and refreshes docs/tests to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 539c84b8ff05449e9a5b8910ab3be2c329295cdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->