### PR TITLE
feat(plugins/sigil): add `sigil claude` launcher with plugin bootstrap

### DIFF
--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -1,4 +1,4 @@
-# sigil-cc: Claude Code hooks for Sigil
+# Claude Code plugin for Sigil
 
 A Claude Code plugin that forwards each session's transcript to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/). Backed by the consolidated [`sigil`](../sigil/) binary; this plugin only ships hook manifest + wrapper plumbing.
 
@@ -8,14 +8,28 @@ A Claude Code plugin that forwards each session's transcript to [Grafana AI Obse
 go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
 ```
 
-Then, from inside Claude Code:
+Then pick one of:
+
+### Quick start via `sigil claude`
+
+```sh
+sigil claude
+```
+
+Installs the `sigil-cc` plugin on first run, then launches Claude Code. Subsequent runs just launch it. Forward flags to `claude` after `--`:
+
+```sh
+sigil claude -- --resume <session-id>
+```
+
+### From inside Claude Code
 
 ```
 /plugin marketplace add grafana/sigil-sdk
 /plugin install sigil-cc@grafana-sigil
 ```
 
-The plugin registers the hooks for you; future hook updates ship with the plugin so you don't re-edit `settings.json`.
+Either path registers the hooks for you; future hook updates ship with the plugin so you don't re-edit `settings.json`.
 
 > `go install` drops the binary in `$GOBIN` (usually `~/go/bin`). The hook manifest invokes `sigil claude-code hook` directly, so make sure `$GOBIN` is on `PATH` for the shell that launches Claude Code. Verify with `sigil --version`.
 

--- a/plugins/sigil/README.md
+++ b/plugins/sigil/README.md
@@ -3,9 +3,10 @@
 `sigil` is one Go binary that backs the agent plugins (`plugins/claude-code`, `plugins/codex`, `plugins/cursor`, `plugins/pi`) in this repository. The dispatcher accepts:
 
 ```
-sigil <agent> hook        # process a JSON hook payload on stdin for <agent>
-sigil pi [-- args...]     # bootstrap the @grafana/sigil-pi extension, then exec pi
-sigil --version           # print the build version
+sigil <agent> hook         # process a JSON hook payload on stdin for <agent>
+sigil claude [-- args...]  # bootstrap the sigil-cc plugin, then exec claude
+sigil pi [-- args...]      # bootstrap the @grafana/sigil-pi extension, then exec pi
+sigil --version            # print the build version
 ```
 
 where `<agent>` is `claude-code`, `codex`, or `cursor`.
@@ -55,7 +56,8 @@ When `OTEL_EXPORTER_OTLP_HEADERS` does not contain an `Authorization` entry, the
 
 | Agent | Invocation |
 |-------|------------|
-| `claude-code` | `sigil claude-code hook` (resolved via `PATH`) |
+| `claude-code` (hook) | `sigil claude-code hook` (resolved via `PATH`) |
+| `claude` (launcher) | `sigil claude [-- args...]` (resolved via `PATH`) |
 | `codex` | `sigil codex hook` (resolved via `PATH`) |
 | `cursor` | `plugins/cursor/scripts/run.sh` |
 | `pi` | `sigil pi [-- args...]` (resolved via `PATH`) |

--- a/plugins/sigil/cmd/sigil/main.go
+++ b/plugins/sigil/cmd/sigil/main.go
@@ -2,14 +2,15 @@
 // and pi agent plugins. It accepts:
 //
 //	sigil <agent> hook           — dispatch a JSON hook payload on stdin to <agent>
+//	sigil claude [-- args...]    — exec claude after bootstrapping the sigil-cc plugin
 //	sigil pi [-- args...]        — exec pi after bootstrapping the @grafana/sigil-pi extension
 //	sigil --version              — print the build version
 //
 // Unknown agents and unknown verbs exit with code 2 and a usage message on
 // stderr. For hook agents the binary must never crash the calling agent
 // process; once argv parsing succeeds, all errors are swallowed (and logged
-// when SIGIL_DEBUG=true) and the process exits 0. Launcher agents (currently
-// just `pi`) are invoked by a human, so errors surface on stderr with a
+// when SIGIL_DEBUG=true) and the process exits 0. Launcher agents (`claude`
+// and `pi`) are invoked by a human, so errors surface on stderr with a
 // non-zero exit code.
 package main
 
@@ -27,6 +28,8 @@ import (
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/cli"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/dotenv"
 )
+
+const usageLine = "usage: sigil <agent> hook | sigil claude [-- args...] | sigil pi [-- args...]"
 
 // version is overridden via -ldflags at build time.
 var version = "dev"
@@ -47,11 +50,13 @@ var agents = map[string]agentHook{
 	"cursor":      cursor.Hook,
 }
 
-// launchers maps the argv agent name to its launcher adapter. Launchers are
+// launchers maps the argv name to its launcher adapter. Launchers are
 // invoked directly by a human (no JSON on stdin) and replace the current
-// process with the target CLI.
+// process with the target CLI. The launcher name is the target CLI's own
+// name (`claude`, `pi`), not the hook agent name (`claude-code`).
 var launchers = map[string]agentLauncher{
-	"pi": pi.Launch,
+	"claude": claudecode.Launch,
+	"pi":     pi.Launch,
 }
 
 // exit is a package var so tests can intercept termination.
@@ -68,15 +73,15 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 	}
 
 	if len(args) == 0 {
-		_, _ = fmt.Fprintln(stderr, "usage: sigil <agent> hook | sigil pi [-- args...]")
+		_, _ = fmt.Fprintln(stderr, usageLine)
 		exit(2)
 		return
 	}
 
-	// Launcher dispatch handles `sigil pi [-- args...]` before the hook
-	// branch because pi has no verb (single mode of operation).
+	// Launcher dispatch handles `sigil <launcher> [-- args...]` before the
+	// hook branch because launchers have no verb (single mode of operation).
 	if launcher, ok := launchers[args[0]]; ok {
-		piArgs, ok := parseLauncherArgs(args[0], args[1:], stderr)
+		launcherArgs, ok := parseLauncherArgs(args[0], args[1:], stderr)
 		if !ok {
 			return
 		}
@@ -94,7 +99,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 			}
 		}()
 
-		if err := launcher(context.Background(), piArgs, stdin, stdout, stderr, logger); err != nil {
+		if err := launcher(context.Background(), launcherArgs, stdin, stdout, stderr, logger); err != nil {
 			logger.Printf("launch %s: %v", args[0], err)
 			_, _ = fmt.Fprintf(stderr, "sigil: %v\n", err)
 			exit(1)
@@ -104,7 +109,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 	}
 
 	if len(args) < 2 {
-		_, _ = fmt.Fprintln(stderr, "usage: sigil <agent> hook | sigil pi [-- args...]")
+		_, _ = fmt.Fprintln(stderr, usageLine)
 		exit(2)
 		return
 	}

--- a/plugins/sigil/cmd/sigil/main_test.go
+++ b/plugins/sigil/cmd/sigil/main_test.go
@@ -63,7 +63,7 @@ func TestRun_UnknownAgentExits2(t *testing.T) {
 func TestRun_UnknownVerbExits2(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	gotExit := withExit(t, func() {
-		run([]string{"claude-code", "launch"}, strings.NewReader(""), &stdout, &stderr)
+		run([]string{"codex", "launch"}, strings.NewReader(""), &stdout, &stderr)
 	})
 	if gotExit == nil || *gotExit != 2 {
 		t.Fatalf("exit = %v, want 2", gotExit)
@@ -265,6 +265,115 @@ func TestRun_LauncherErrorExits1(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	gotExit := withExit(t, func() {
 		run([]string{"pi", "--"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	if gotExit == nil || *gotExit != 1 {
+		t.Fatalf("exit = %v, want 1", gotExit)
+	}
+	if !strings.HasPrefix(stderr.String(), "sigil:") {
+		t.Fatalf("stderr does not start with sigil: %q", stderr.String())
+	}
+}
+
+func TestRun_ClaudeLauncherBare(t *testing.T) {
+	var got []string
+	called := 0
+	withStubLauncher(t, "claude", func(_ context.Context, args []string, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		called++
+		got = append([]string{}, args...)
+		return nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"claude"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	if gotExit != nil {
+		t.Fatalf("exit code = %d, want no exit", *gotExit)
+	}
+	if called != 1 {
+		t.Fatalf("launcher called %d times, want 1", called)
+	}
+	if len(got) != 0 {
+		t.Fatalf("launcher args = %v, want empty", got)
+	}
+}
+
+func TestRun_ClaudeLauncherSeparatorOnly(t *testing.T) {
+	var got []string
+	withStubLauncher(t, "claude", func(_ context.Context, args []string, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		got = append([]string{}, args...)
+		return nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	withExit(t, func() {
+		run([]string{"claude", "--"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	if len(got) != 0 {
+		t.Fatalf("launcher args = %v, want empty", got)
+	}
+}
+
+func TestRun_ClaudeLauncherForwardsArgs(t *testing.T) {
+	var got []string
+	withStubLauncher(t, "claude", func(_ context.Context, args []string, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		got = append([]string{}, args...)
+		return nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	withExit(t, func() {
+		run([]string{"claude", "--", "--resume", "abc"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	if !reflect.DeepEqual(got, []string{"--resume", "abc"}) {
+		t.Fatalf("launcher args = %v, want [--resume abc]", got)
+	}
+}
+
+func TestRun_ClaudeLauncherMissingSeparatorExits2(t *testing.T) {
+	withStubLauncher(t, "claude", func(_ context.Context, _ []string, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		t.Fatal("launcher must not be called when separator is missing")
+		return nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"claude", "foo"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	if gotExit == nil || *gotExit != 2 {
+		t.Fatalf("exit = %v, want 2", gotExit)
+	}
+	if !strings.Contains(stderr.String(), "use `sigil claude -- <args>`") {
+		t.Fatalf("stderr missing forward-args hint: %q", stderr.String())
+	}
+}
+
+func TestRun_ClaudeLauncherUnknownOptionsExits2(t *testing.T) {
+	withStubLauncher(t, "claude", func(_ context.Context, _ []string, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		t.Fatal("launcher must not be called when unknown options precede separator")
+		return nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"claude", "--foo", "--", "args"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	if gotExit == nil || *gotExit != 2 {
+		t.Fatalf("exit = %v, want 2", gotExit)
+	}
+	if !strings.Contains(stderr.String(), "unknown options before `--`: [--foo]") {
+		t.Fatalf("stderr missing unknown-options message: %q", stderr.String())
+	}
+}
+
+func TestRun_ClaudeLauncherErrorExits1(t *testing.T) {
+	withStubLauncher(t, "claude", func(_ context.Context, _ []string, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		return errors.New("boom")
+	})
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"claude", "--"}, strings.NewReader(""), &stdout, &stderr)
 	})
 	if gotExit == nil || *gotExit != 1 {
 		t.Fatalf("exit = %v, want 1", gotExit)

--- a/plugins/sigil/internal/agents/claudecode/launch.go
+++ b/plugins/sigil/internal/agents/claudecode/launch.go
@@ -1,0 +1,181 @@
+package claudecode
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+const (
+	// marketplaceRepo is the source argument passed to
+	// `claude plugin marketplace add`.
+	marketplaceRepo = "grafana/sigil-sdk"
+	// marketplaceAlias is the marketplace name declared in
+	// .claude-plugin/marketplace.json.
+	marketplaceAlias = "grafana-sigil"
+	// PluginName is the plugin name declared in
+	// plugins/claude-code/.claude-plugin/plugin.json.
+	PluginName = "sigil-cc"
+)
+
+// Test seams.
+var (
+	lookPath   = exec.LookPath
+	execFn     = syscall.Exec
+	runInstall = defaultRunInstall
+	getwd      = os.Getwd
+)
+
+// Launch resolves the `claude` binary on PATH, ensures the sigil-cc plugin
+// is registered in Claude Code's plugin store (running `claude plugin
+// marketplace add` + `claude plugin install` once if it is not), and then
+// exec's claude with the supplied args.
+func Launch(ctx context.Context, args []string, _ io.Reader, _, stderr io.Writer, logger *log.Logger) error {
+	bin, err := lookPath("claude")
+	if err != nil {
+		return fmt.Errorf("claude CLI not found on PATH: %w", err)
+	}
+
+	installed, err := pluginInstalled()
+	if err != nil {
+		// Treat a broken installed_plugins.json the same as missing: log the
+		// parse failure for SIGIL_DEBUG, then let `claude plugin install`
+		// run. claude's own CLI is the source of truth and will fail loudly
+		// if something is genuinely wrong.
+		logger.Printf("installed_plugins.json probe: %v", err)
+		installed = false
+	}
+	if !installed {
+		_, _ = fmt.Fprintf(stderr, "sigil: registering %s with claude\n", PluginName)
+		if err := runInstall(ctx, bin, stderr); err != nil {
+			// Don't block the user's claude session on a failed install
+			// (offline machine, sandboxed CI, marketplace hiccup, etc.).
+			// Log for SIGIL_DEBUG, point the user at the manual command,
+			// and fall through to exec. claude still runs, just without
+			// the sigil-cc plugin installed.
+			logger.Printf("install %s: %v", PluginName, err)
+			_, _ = fmt.Fprintf(stderr,
+				"sigil: install of %s failed: %v\n"+
+					"sigil: continuing without Sigil capture. To retry manually:\n"+
+					"          claude plugin install %s@%s\n",
+				PluginName, err, PluginName, marketplaceAlias)
+		}
+	}
+
+	argv := append([]string{bin}, args...)
+	if err := execFn(bin, argv, os.Environ()); err != nil {
+		return fmt.Errorf("exec claude: %w", err)
+	}
+	return nil
+}
+
+func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {
+	steps := [][]string{
+		{"plugin", "marketplace", "add", marketplaceRepo},
+		{"plugin", "install", PluginName + "@" + marketplaceAlias},
+	}
+	for _, argv := range steps {
+		cmd := exec.CommandContext(ctx, bin, argv...)
+		cmd.Stdout = w
+		cmd.Stderr = w
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("claude %s: %w", strings.Join(argv, " "), err)
+		}
+	}
+	return nil
+}
+
+// installedPluginsFile is the JSON shape Claude Code writes to
+// $CLAUDE_CONFIG_DIR/plugins/installed_plugins.json. Top-level keys are
+// metadata (`version`) plus a nested `plugins` map whose keys are
+// `<plugin>@<marketplace>` strings and values are arrays of per-scope
+// installation entries.
+type installedPluginsFile struct {
+	Plugins map[string]json.RawMessage `json:"plugins"`
+}
+
+// installedPluginEntry captures the subset of fields we need from each
+// entry in the per-key install array. Claude Code tracks `scope`
+// (`user`, `project`, or `local`) and, for the per-directory scopes,
+// the absolute `projectPath` the install is bound to.
+type installedPluginEntry struct {
+	Scope       string `json:"scope"`
+	ProjectPath string `json:"projectPath"`
+}
+
+// pluginInstalled reports whether the sigil-cc plugin is registered in
+// Claude Code's plugin store *for the current working directory*.
+//
+// Claude Code records per-entry `scope` and `projectPath`: `user` scope
+// is active in every session, while `project` and `local` only apply when
+// the session's cwd matches the recorded `projectPath`. Treating any
+// `sigil-cc@*` key as installed would let a per-directory install for an
+// unrelated project suppress bootstrap here, leaving Sigil hooks inactive.
+// Marketplace alias is intentionally ignored so a foreign alias is not
+// reinstalled on top of.
+func pluginInstalled() (bool, error) {
+	path, err := installedPluginsPath()
+	if err != nil {
+		return false, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+	var f installedPluginsFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		return false, fmt.Errorf("parse %s: %w", path, err)
+	}
+	cwd, err := getwd()
+	if err != nil {
+		return false, fmt.Errorf("resolve cwd: %w", err)
+	}
+	cwdClean := filepath.Clean(cwd)
+	prefix := PluginName + "@"
+	for key, raw := range f.Plugins {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		var entries []installedPluginEntry
+		if err := json.Unmarshal(raw, &entries); err != nil {
+			// Unexpected per-key shape: skip this key but keep scanning.
+			// A user-scope entry under a different alias may still match.
+			continue
+		}
+		for _, e := range entries {
+			if e.Scope == "user" {
+				return true, nil
+			}
+			if e.ProjectPath != "" && filepath.Clean(e.ProjectPath) == cwdClean {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// installedPluginsPath returns the path to Claude Code's
+// installed_plugins.json. It honours $CLAUDE_CONFIG_DIR (set by the user
+// or tests) and falls back to ~/.claude.
+func installedPluginsPath() (string, error) {
+	dir := os.Getenv("CLAUDE_CONFIG_DIR")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home dir for claude config: %w", err)
+		}
+		dir = filepath.Join(home, ".claude")
+	}
+	return filepath.Join(dir, "plugins", "installed_plugins.json"), nil
+}

--- a/plugins/sigil/internal/agents/claudecode/launch_test.go
+++ b/plugins/sigil/internal/agents/claudecode/launch_test.go
@@ -1,0 +1,379 @@
+package claudecode
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestLaunch_MissingClaudeBinary(t *testing.T) {
+	withLookPath(t, func(string) (string, error) { return "", exec.ErrNotFound })
+
+	err := Launch(context.Background(), nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger())
+	if err == nil || !strings.Contains(err.Error(), "claude CLI not found") {
+		t.Fatalf("err = %v, want contains \"claude CLI not found\"", err)
+	}
+}
+
+func TestLaunch_SkipsInstallWhenPluginPresent(t *testing.T) {
+	dir := t.TempDir()
+	writeInstalled(t, dir, `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"user"}]}}`)
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/claude", nil })
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		t.Fatal("runInstall must not be called when plugin is already present")
+		return nil
+	})
+
+	var execArgv []string
+	withExecFn(t, func(_ string, argv []string, _ []string) error {
+		execArgv = append([]string{}, argv...)
+		return nil
+	})
+
+	var stderr bytes.Buffer
+	if err := Launch(context.Background(), []string{"--resume", "abc"}, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+		t.Fatalf("Launch returned err: %v", err)
+	}
+	if !reflect.DeepEqual(execArgv, []string{"/usr/local/bin/claude", "--resume", "abc"}) {
+		t.Fatalf("exec argv = %v", execArgv)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr non-empty: %q", stderr.String())
+	}
+}
+
+// Regression: a per-directory install for another project must not
+// suppress bootstrap in the current directory. Claude Code's plugin
+// store keeps the entry under `sigil-cc@*`, but `scope: project` with
+// a non-matching `projectPath` means the plugin is NOT active here.
+func TestLaunch_RunsInstallWhenOnlyForeignProjectScopeEntry(t *testing.T) {
+	dir := t.TempDir()
+	writeInstalled(t, dir, `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"project","projectPath":"/work/some-other-project"}]}}`)
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	withGetwd(t, func() (string, error) { return "/work/current-project", nil })
+
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/claude", nil })
+
+	installCalls := 0
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		installCalls++
+		return nil
+	})
+	withExecFn(t, func(string, []string, []string) error { return nil })
+
+	if err := Launch(context.Background(), nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger()); err != nil {
+		t.Fatalf("Launch returned err: %v", err)
+	}
+	if installCalls != 1 {
+		t.Fatalf("runInstall calls = %d, want 1 (foreign project-scope entry must not suppress bootstrap)", installCalls)
+	}
+}
+
+func TestLaunch_RunsInstallWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	writeInstalled(t, dir, `{"version":2,"plugins":{"some-other@marketplace":[{"scope":"user"}]}}`)
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/claude", nil })
+
+	installCalls := 0
+	withRunInstall(t, func(_ context.Context, bin string, _ io.Writer) error {
+		installCalls++
+		if bin != "/usr/local/bin/claude" {
+			t.Errorf("install bin = %q, want /usr/local/bin/claude", bin)
+		}
+		return nil
+	})
+
+	execCalled := false
+	withExecFn(t, func(_ string, _ []string, _ []string) error {
+		execCalled = true
+		return nil
+	})
+
+	var stderr bytes.Buffer
+	if err := Launch(context.Background(), nil, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+		t.Fatalf("Launch returned err: %v", err)
+	}
+	if installCalls != 1 {
+		t.Fatalf("runInstall calls = %d, want 1", installCalls)
+	}
+	if !execCalled {
+		t.Fatal("execFn was not called after install")
+	}
+	if !strings.Contains(stderr.String(), "registering "+PluginName+" with claude") {
+		t.Fatalf("stderr missing register message: %q", stderr.String())
+	}
+}
+
+func TestLaunch_RunsInstallWhenFileAbsent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/claude", nil })
+
+	installCalls := 0
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		installCalls++
+		return nil
+	})
+	withExecFn(t, func(string, []string, []string) error { return nil })
+
+	if err := Launch(context.Background(), nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger()); err != nil {
+		t.Fatalf("Launch returned err: %v", err)
+	}
+	if installCalls != 1 {
+		t.Fatalf("runInstall calls = %d, want 1", installCalls)
+	}
+}
+
+func TestLaunch_RunsInstallWhenJSONMalformed(t *testing.T) {
+	dir := t.TempDir()
+	writeInstalled(t, dir, `{"plugins":{`)
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/claude", nil })
+
+	installCalls := 0
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		installCalls++
+		return nil
+	})
+	withExecFn(t, func(string, []string, []string) error { return nil })
+
+	if err := Launch(context.Background(), nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger()); err != nil {
+		t.Fatalf("Launch returned err: %v", err)
+	}
+	if installCalls != 1 {
+		t.Fatalf("runInstall calls = %d, want 1 (malformed JSON should fall through to install)", installCalls)
+	}
+}
+
+// A failed `claude plugin install` must not block the user's claude session.
+// The launcher should print the failure plus a manual-retry hint on stderr,
+// then still exec claude so the workflow keeps moving (just without the
+// sigil-cc plugin installed).
+func TestLaunch_InstallFailureContinuesToExec(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/claude", nil })
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		return errors.New("network down")
+	})
+
+	execCalled := false
+	withExecFn(t, func(_ string, _ []string, _ []string) error {
+		execCalled = true
+		return nil
+	})
+
+	var stderr bytes.Buffer
+	if err := Launch(context.Background(), nil, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+		t.Fatalf("Launch returned err: %v", err)
+	}
+	if !execCalled {
+		t.Fatal("execFn was not called after install failure")
+	}
+	got := stderr.String()
+	if !strings.Contains(got, "install of "+PluginName+" failed") {
+		t.Fatalf("stderr missing failure message: %q", got)
+	}
+	if !strings.Contains(got, "network down") {
+		t.Fatalf("stderr missing underlying error: %q", got)
+	}
+	if !strings.Contains(got, "claude plugin install "+PluginName+"@") {
+		t.Fatalf("stderr missing manual install hint: %q", got)
+	}
+}
+
+func TestPluginInstalled_KeyShapes(t *testing.T) {
+	const cwd = "/work/current-project"
+	const otherDir = "/work/other-project"
+
+	cases := []struct {
+		name     string
+		write    bool
+		contents string
+		want     bool
+		wantErr  bool
+	}{
+		{
+			name:     "user scope matches anywhere",
+			write:    true,
+			contents: `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"user"}]}}`,
+			want:     true,
+		},
+		{
+			name:     "foreign marketplace still matches plugin name",
+			write:    true,
+			contents: `{"version":2,"plugins":{"sigil-cc@other-marketplace":[{"scope":"user"}]}}`,
+			want:     true,
+		},
+		{
+			name:     "project scope matching cwd counts",
+			write:    true,
+			contents: `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"project","projectPath":"` + cwd + `"}]}}`,
+			want:     true,
+		},
+		{
+			name:     "project scope matching cwd via uncleaned path",
+			write:    true,
+			contents: `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"project","projectPath":"/work/current-project/./"}]}}`,
+			want:     true,
+		},
+		{
+			name:     "project scope for another directory does not count",
+			write:    true,
+			contents: `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"project","projectPath":"` + otherDir + `"}]}}`,
+			want:     false,
+		},
+		{
+			name:     "local scope matching cwd counts",
+			write:    true,
+			contents: `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"local","projectPath":"` + cwd + `"}]}}`,
+			want:     true,
+		},
+		{
+			name:     "local scope for another directory does not count",
+			write:    true,
+			contents: `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"local","projectPath":"` + otherDir + `"}]}}`,
+			want:     false,
+		},
+		{
+			name:     "mixed entries: user scope wins over foreign projectPath",
+			write:    true,
+			contents: `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"project","projectPath":"` + otherDir + `"},{"scope":"user"}]}}`,
+			want:     true,
+		},
+		{
+			name:     "only foreign per-directory installs do not count",
+			write:    true,
+			contents: `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"project","projectPath":"` + otherDir + `"},{"scope":"local","projectPath":"/work/yet-another"}]}}`,
+			want:     false,
+		},
+		{
+			name:     "empty top-level object",
+			write:    true,
+			contents: `{}`,
+			want:     false,
+		},
+		{
+			name:     "empty plugins map",
+			write:    true,
+			contents: `{"version":2,"plugins":{}}`,
+			want:     false,
+		},
+		{
+			name:     "empty entry array",
+			write:    true,
+			contents: `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[]}}`,
+			want:     false,
+		},
+		{
+			name:     "unrelated plugins only",
+			write:    true,
+			contents: `{"version":2,"plugins":{"other-plugin@grafana-sigil":[{"scope":"user"}]}}`,
+			want:     false,
+		},
+		{
+			name:     "sigil-cc entry with unexpected shape is skipped, not fatal",
+			write:    true,
+			contents: `{"version":2,"plugins":{"sigil-cc@grafana-sigil":"oops"}}`,
+			want:     false,
+		},
+		{
+			name:  "missing file treated as not installed",
+			write: false,
+			want:  false,
+		},
+		{
+			name:     "malformed json surfaces error",
+			write:    true,
+			contents: `{"plugins":{`,
+			wantErr:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.write {
+				writeInstalled(t, dir, tc.contents)
+			}
+			t.Setenv("CLAUDE_CONFIG_DIR", dir)
+			withGetwd(t, func() (string, error) { return cwd, nil })
+
+			got, err := pluginInstalled()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Fatalf("got = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPluginInstalled_GetwdFailureSurfaces(t *testing.T) {
+	dir := t.TempDir()
+	writeInstalled(t, dir, `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"project","projectPath":"/whatever"}]}}`)
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	withGetwd(t, func() (string, error) { return "", errors.New("no cwd") })
+
+	if _, err := pluginInstalled(); err == nil || !strings.Contains(err.Error(), "resolve cwd") {
+		t.Fatalf("err = %v, want contains \"resolve cwd\"", err)
+	}
+}
+
+func writeInstalled(t *testing.T, dir, contents string) {
+	t.Helper()
+	pluginsDir := filepath.Join(dir, "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginsDir, "installed_plugins.json"), []byte(contents), 0o600); err != nil {
+		t.Fatalf("write installed_plugins.json: %v", err)
+	}
+}
+
+func withLookPath(t *testing.T, fn func(string) (string, error)) {
+	t.Helper()
+	prev := lookPath
+	t.Cleanup(func() { lookPath = prev })
+	lookPath = fn
+}
+
+func withRunInstall(t *testing.T, fn func(context.Context, string, io.Writer) error) {
+	t.Helper()
+	prev := runInstall
+	t.Cleanup(func() { runInstall = prev })
+	runInstall = fn
+}
+
+func withExecFn(t *testing.T, fn func(string, []string, []string) error) {
+	t.Helper()
+	prev := execFn
+	t.Cleanup(func() { execFn = prev })
+	execFn = fn
+}
+
+func withGetwd(t *testing.T, fn func() (string, error)) {
+	t.Helper()
+	prev := getwd
+	t.Cleanup(func() { getwd = prev })
+	getwd = fn
+}
+
+func nopLogger() *log.Logger {
+	return log.New(io.Discard, "", 0)
+}


### PR DESCRIPTION
Adds a `sigil claude [-- args]` subcommand to the `sigil` binary that bootstraps the Claude Code plugin on first run and then exec's `claude`:

```sh
sigil claude                       # first run: bootstrap + launch; later: just launch
sigil claude -- --resume <id>      # forward flags to claude after `--`
```

If install fails, the launcher logs the failure, prints a manual-retry hint, and still exec's `claude` so the user's session is not blocked.

---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new launcher path that shells out to `claude` and performs best-effort plugin installation, which affects user-facing CLI behavior and process execution. Risk is mitigated by extensive tests and by falling back to launching `claude` even when bootstrap fails.
> 
> **Overview**
> Adds a new `sigil claude [-- args...]` *launcher mode* to the consolidated `sigil` binary, including arg-forwarding/usage handling and updated docs.
> 
> Implements `claudecode.Launch` to detect whether `sigil-cc` is installed for the current scope (user/project/local), run `claude plugin marketplace add` + `claude plugin install` when missing, and then `exec` `claude`; install failures are reported but **do not block** launching Claude.
> 
> Extends test coverage for launcher dispatch/arg parsing and for Claude plugin-install detection/bootstrapping edge cases (missing/malformed `installed_plugins.json`, foreign project installs, install failure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 498a90cdfba99fd3d3c53e68d13c495e6552037f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->