### PR TITLE
fix(sdk): add agent version metric labels

### DIFF
--- a/dotnet/src/Grafana.Sigil/SigilClient.cs
+++ b/dotnet/src/Grafana.Sigil/SigilClient.cs
@@ -1454,14 +1454,14 @@ public sealed partial class SigilClient : IAsyncDisposable
 
         _operationDurationHistogram.Record(
             durationSeconds,
-            [
+            WithAgentVersionTag(generation.AgentVersion, [
                 new(SpanAttrOperationName, OperationName(generation)),
                 new(SpanAttrProviderName, generation.Model.Provider ?? string.Empty),
                 new(SpanAttrRequestModel, generation.Model.Name ?? string.Empty),
                 new(SpanAttrAgentName, generation.AgentName ?? string.Empty),
                 new(SpanAttrErrorType, errorType ?? string.Empty),
                 new(SpanAttrErrorCategory, errorCategory ?? string.Empty),
-            ]);
+            ]));
 
         RecordTokenUsage(generation, MetricTokenTypeInput, generation.Usage.InputTokens);
         RecordTokenUsage(generation, MetricTokenTypeOutput, generation.Usage.OutputTokens);
@@ -1471,11 +1471,11 @@ public sealed partial class SigilClient : IAsyncDisposable
 
         _toolCallsHistogram.Record(
             CountToolCallParts(generation.Output),
-            [
+            WithAgentVersionTag(generation.AgentVersion, [
                 new(SpanAttrProviderName, generation.Model.Provider ?? string.Empty),
                 new(SpanAttrRequestModel, generation.Model.Name ?? string.Empty),
                 new(SpanAttrAgentName, generation.AgentName ?? string.Empty),
-            ]);
+            ]));
 
         if (string.Equals(OperationName(generation), DefaultOperationNameStream, StringComparison.Ordinal)
             && firstTokenAt.HasValue)
@@ -1485,11 +1485,11 @@ public sealed partial class SigilClient : IAsyncDisposable
             {
                 _ttftHistogram.Record(
                     ttftSeconds,
-                    [
+                    WithAgentVersionTag(generation.AgentVersion, [
                         new(SpanAttrProviderName, generation.Model.Provider ?? string.Empty),
                         new(SpanAttrRequestModel, generation.Model.Name ?? string.Empty),
                         new(SpanAttrAgentName, generation.AgentName ?? string.Empty),
-                    ]);
+                    ]));
             }
         }
     }
@@ -1506,26 +1506,26 @@ public sealed partial class SigilClient : IAsyncDisposable
         var durationSeconds = Math.Max(0d, (completedAt - startedAt).TotalSeconds);
         _operationDurationHistogram.Record(
             durationSeconds,
-            [
+            WithAgentVersionTag(seed.AgentVersion, [
                 new(SpanAttrOperationName, DefaultOperationNameEmbedding),
                 new(SpanAttrProviderName, seed.Model.Provider ?? string.Empty),
                 new(SpanAttrRequestModel, seed.Model.Name ?? string.Empty),
                 new(SpanAttrAgentName, seed.AgentName ?? string.Empty),
                 new(SpanAttrErrorType, errorType ?? string.Empty),
                 new(SpanAttrErrorCategory, errorCategory ?? string.Empty),
-            ]);
+            ]));
 
         if (result.InputTokens != 0L)
         {
             _tokenUsageHistogram.Record(
                 result.InputTokens,
-                [
+                WithAgentVersionTag(seed.AgentVersion, [
                     new(SpanAttrOperationName, DefaultOperationNameEmbedding),
                     new(SpanAttrProviderName, seed.Model.Provider ?? string.Empty),
                     new(SpanAttrRequestModel, seed.Model.Name ?? string.Empty),
                     new(SpanAttrAgentName, seed.AgentName ?? string.Empty),
                     new(MetricAttrTokenType, MetricTokenTypeInput),
-                ]);
+                ]));
         }
     }
 
@@ -1542,7 +1542,7 @@ public sealed partial class SigilClient : IAsyncDisposable
 
         _operationDurationHistogram.Record(
             durationSeconds,
-            [
+            WithAgentVersionTag(seed.AgentVersion, [
                 new(SpanAttrOperationName, "execute_tool"),
                 new(SpanAttrProviderName, (seed.RequestProvider ?? string.Empty).Trim()),
                 new(SpanAttrRequestModel, (seed.RequestModel ?? string.Empty).Trim()),
@@ -1550,7 +1550,7 @@ public sealed partial class SigilClient : IAsyncDisposable
                 new(SpanAttrAgentName, seed.AgentName ?? string.Empty),
                 new(SpanAttrErrorType, errorType),
                 new(SpanAttrErrorCategory, errorCategory),
-            ]);
+            ]));
     }
 
     internal static string ErrorCategoryFromException(Exception? error, bool fallbackSdk)
@@ -1610,13 +1610,30 @@ public sealed partial class SigilClient : IAsyncDisposable
 
         _tokenUsageHistogram.Record(
             value,
-            [
+            WithAgentVersionTag(generation.AgentVersion, [
                 new(SpanAttrOperationName, OperationName(generation)),
                 new(SpanAttrProviderName, generation.Model.Provider ?? string.Empty),
                 new(SpanAttrRequestModel, generation.Model.Name ?? string.Empty),
                 new(SpanAttrAgentName, generation.AgentName ?? string.Empty),
                 new(MetricAttrTokenType, tokenType),
-            ]);
+            ]));
+    }
+
+    private static KeyValuePair<string, object?>[] WithAgentVersionTag(
+        string? agentVersion,
+        KeyValuePair<string, object?>[] tags
+    )
+    {
+        var version = (agentVersion ?? string.Empty).Trim();
+        if (version.Length == 0)
+        {
+            return tags;
+        }
+
+        var outTags = new KeyValuePair<string, object?>[tags.Length + 1];
+        Array.Copy(tags, outTags, tags.Length);
+        outTags[^1] = new KeyValuePair<string, object?>(SpanAttrAgentVersion, version);
+        return outTags;
     }
 
     private static long CountToolCallParts(IReadOnlyList<Message> messages)

--- a/dotnet/src/Grafana.Sigil/SigilClient.cs
+++ b/dotnet/src/Grafana.Sigil/SigilClient.cs
@@ -1632,7 +1632,7 @@ public sealed partial class SigilClient : IAsyncDisposable
 
         var outTags = new KeyValuePair<string, object?>[tags.Length + 1];
         Array.Copy(tags, outTags, tags.Length);
-        outTags[^1] = new KeyValuePair<string, object?>(SpanAttrAgentVersion, version);
+        outTags[tags.Length] = new KeyValuePair<string, object?>(SpanAttrAgentVersion, version);
         return outTags;
     }
 

--- a/dotnet/tests/Grafana.Sigil.Tests/ConformanceTests.cs
+++ b/dotnet/tests/Grafana.Sigil.Tests/ConformanceTests.cs
@@ -150,6 +150,10 @@ public sealed class ConformanceTests
         Assert.Contains("gen_ai.client.operation.duration", env.MetricNames);
         Assert.Contains("gen_ai.client.token.usage", env.MetricNames);
         Assert.DoesNotContain("gen_ai.client.time_to_first_token", env.MetricNames);
+        Assert.True(
+            env.HasMetricTag("gen_ai.client.token.usage", "gen_ai.agent.version", "v-roundtrip"),
+            "token usage metrics should include the agent version tag"
+        );
     }
 
     [Theory]
@@ -637,6 +641,7 @@ public sealed class ConformanceTests
         public SigilClient Client { get; }
         public ConcurrentQueue<Activity> Spans { get; } = new();
         public ConcurrentDictionary<string, byte> MetricNames { get; } = new(StringComparer.Ordinal);
+        public ConcurrentQueue<MetricMeasurement> MetricMeasurements { get; } = new();
 
         public ConformanceEnv(int batchSize = 1)
         {
@@ -659,9 +664,15 @@ public sealed class ConformanceTests
                     listener.EnableMeasurementEvents(instrument);
                 }
             };
-            _meterListener.SetMeasurementEventCallback<double>((instrument, _, _, _) =>
+            _meterListener.SetMeasurementEventCallback<double>((instrument, _, tags, _) =>
             {
                 MetricNames[instrument.Name] = 0;
+                var tagSnapshot = new Dictionary<string, object?>(StringComparer.Ordinal);
+                foreach (var tag in tags)
+                {
+                    tagSnapshot[tag.Key] = tag.Value;
+                }
+                MetricMeasurements.Enqueue(new MetricMeasurement(instrument.Name, tagSnapshot));
             });
             _meterListener.Start();
 
@@ -745,6 +756,23 @@ public sealed class ConformanceTests
             return OperationSpan([operationName]);
         }
 
+        public bool HasMetricTag(string metricName, string key, string value)
+        {
+            foreach (var measurement in MetricMeasurements)
+            {
+                if (!string.Equals(measurement.Name, metricName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                if (measurement.Tags.TryGetValue(key, out var got) && string.Equals(got?.ToString(), value, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private Activity OperationSpan(string[] operationNames)
         {
             var span = Spans
@@ -758,6 +786,8 @@ public sealed class ConformanceTests
             await ShutdownAsync();
         }
     }
+
+    private sealed record MetricMeasurement(string Name, IReadOnlyDictionary<string, object?> Tags);
 
     private sealed class NullScope : IDisposable
     {

--- a/go/sigil/client.go
+++ b/go/sigil/client.go
@@ -1769,31 +1769,32 @@ func (c *Client) recordGenerationMetrics(ctx context.Context, generation Generat
 		duration = 0
 	}
 
-	durationAttrs := metric.WithAttributes(
-		attribute.String(spanAttrOperationName, operationName(generation)),
-		attribute.String(spanAttrProviderName, strings.TrimSpace(generation.Model.Provider)),
-		attribute.String(spanAttrRequestModel, strings.TrimSpace(generation.Model.Name)),
-		attribute.String(spanAttrAgentName, strings.TrimSpace(generation.AgentName)),
+	identityAttrs := metricIdentityAttributes(
+		generation.Model.Provider,
+		generation.Model.Name,
+		generation.AgentName,
+		generation.AgentVersion,
+	)
+	durationAttrs := append(
+		[]attribute.KeyValue{attribute.String(spanAttrOperationName, operationName(generation))},
+		identityAttrs...,
+	)
+	durationAttrs = append(durationAttrs,
 		attribute.String(spanAttrErrorType, errorType),
 		attribute.String(spanAttrErrorCategory, errorCategory),
 	)
-	c.instruments.operationDuration.Record(ctx, duration, durationAttrs)
+	c.instruments.operationDuration.Record(ctx, duration, metric.WithAttributes(durationAttrs...))
 
 	recordToken := func(tokenType string, value int64) {
 		if value == 0 {
 			return
 		}
-		c.instruments.tokenUsage.Record(
-			ctx,
-			value,
-			metric.WithAttributes(
-				attribute.String(spanAttrOperationName, operationName(generation)),
-				attribute.String(spanAttrProviderName, strings.TrimSpace(generation.Model.Provider)),
-				attribute.String(spanAttrRequestModel, strings.TrimSpace(generation.Model.Name)),
-				attribute.String(spanAttrAgentName, strings.TrimSpace(generation.AgentName)),
-				attribute.String(metricAttrTokenType, tokenType),
-			),
+		tokenAttrs := append(
+			[]attribute.KeyValue{attribute.String(spanAttrOperationName, operationName(generation))},
+			identityAttrs...,
 		)
+		tokenAttrs = append(tokenAttrs, attribute.String(metricAttrTokenType, tokenType))
+		c.instruments.tokenUsage.Record(ctx, value, metric.WithAttributes(tokenAttrs...))
 	}
 
 	recordToken(metricTokenTypeInput, generation.Usage.InputTokens)
@@ -1806,11 +1807,7 @@ func (c *Client) recordGenerationMetrics(ctx context.Context, generation Generat
 	c.instruments.toolCallsPerOperation.Record(
 		ctx,
 		int64(toolCalls),
-		metric.WithAttributes(
-			attribute.String(spanAttrProviderName, strings.TrimSpace(generation.Model.Provider)),
-			attribute.String(spanAttrRequestModel, strings.TrimSpace(generation.Model.Name)),
-			attribute.String(spanAttrAgentName, strings.TrimSpace(generation.AgentName)),
-		),
+		metric.WithAttributes(identityAttrs...),
 	)
 
 	if operationName(generation) == defaultOperationNameStream && !firstTokenAt.IsZero() {
@@ -1819,11 +1816,7 @@ func (c *Client) recordGenerationMetrics(ctx context.Context, generation Generat
 			c.instruments.timeToFirstToken.Record(
 				ctx,
 				ttft,
-				metric.WithAttributes(
-					attribute.String(spanAttrProviderName, strings.TrimSpace(generation.Model.Provider)),
-					attribute.String(spanAttrRequestModel, strings.TrimSpace(generation.Model.Name)),
-					attribute.String(spanAttrAgentName, strings.TrimSpace(generation.AgentName)),
-				),
+				metric.WithAttributes(identityAttrs...),
 			)
 		}
 	}
@@ -1856,30 +1849,31 @@ func (c *Client) recordEmbeddingMetrics(
 	provider := strings.TrimSpace(seed.Model.Provider)
 	model := strings.TrimSpace(seed.Model.Name)
 	agentName := strings.TrimSpace(seed.AgentName)
+	identityAttrs := metricIdentityAttributes(provider, model, agentName, seed.AgentVersion)
+	durationAttrs := append(
+		[]attribute.KeyValue{attribute.String(spanAttrOperationName, defaultEmbeddingOperationName)},
+		identityAttrs...,
+	)
+	durationAttrs = append(durationAttrs,
+		attribute.String(spanAttrErrorType, errorType),
+		attribute.String(spanAttrErrorCategory, errorCategory),
+	)
 	c.instruments.operationDuration.Record(
 		ctx,
 		duration,
-		metric.WithAttributes(
-			attribute.String(spanAttrOperationName, defaultEmbeddingOperationName),
-			attribute.String(spanAttrProviderName, provider),
-			attribute.String(spanAttrRequestModel, model),
-			attribute.String(spanAttrAgentName, agentName),
-			attribute.String(spanAttrErrorType, errorType),
-			attribute.String(spanAttrErrorCategory, errorCategory),
-		),
+		metric.WithAttributes(durationAttrs...),
 	)
 
 	if result.InputTokens != 0 {
+		tokenAttrs := append(
+			[]attribute.KeyValue{attribute.String(spanAttrOperationName, defaultEmbeddingOperationName)},
+			identityAttrs...,
+		)
+		tokenAttrs = append(tokenAttrs, attribute.String(metricAttrTokenType, metricTokenTypeInput))
 		c.instruments.tokenUsage.Record(
 			ctx,
 			result.InputTokens,
-			metric.WithAttributes(
-				attribute.String(spanAttrOperationName, defaultEmbeddingOperationName),
-				attribute.String(spanAttrProviderName, provider),
-				attribute.String(spanAttrRequestModel, model),
-				attribute.String(spanAttrAgentName, agentName),
-				attribute.String(metricAttrTokenType, metricTokenTypeInput),
-			),
+			metric.WithAttributes(tokenAttrs...),
 		)
 	}
 }
@@ -1904,19 +1898,32 @@ func (c *Client) recordToolExecutionMetrics(ctx context.Context, seed ToolExecut
 		errorType = "tool_execution_error"
 		errorCategory = toolErrorCategory(finalErr)
 	}
+	attrs := metricIdentityAttributes(seed.RequestProvider, seed.RequestModel, seed.AgentName, seed.AgentVersion)
+	attrs = append([]attribute.KeyValue{
+		attribute.String(spanAttrOperationName, "execute_tool"),
+		attribute.String(spanAttrToolName, strings.TrimSpace(seed.ToolName)),
+	}, attrs...)
+	attrs = append(attrs,
+		attribute.String(spanAttrErrorType, errorType),
+		attribute.String(spanAttrErrorCategory, errorCategory),
+	)
 	c.instruments.operationDuration.Record(
 		ctx,
 		duration,
-		metric.WithAttributes(
-			attribute.String(spanAttrOperationName, "execute_tool"),
-			attribute.String(spanAttrProviderName, strings.TrimSpace(seed.RequestProvider)),
-			attribute.String(spanAttrRequestModel, strings.TrimSpace(seed.RequestModel)),
-			attribute.String(spanAttrToolName, strings.TrimSpace(seed.ToolName)),
-			attribute.String(spanAttrAgentName, strings.TrimSpace(seed.AgentName)),
-			attribute.String(spanAttrErrorType, errorType),
-			attribute.String(spanAttrErrorCategory, errorCategory),
-		),
+		metric.WithAttributes(attrs...),
 	)
+}
+
+func metricIdentityAttributes(provider, model, agentName, agentVersion string) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.String(spanAttrProviderName, strings.TrimSpace(provider)),
+		attribute.String(spanAttrRequestModel, strings.TrimSpace(model)),
+		attribute.String(spanAttrAgentName, strings.TrimSpace(agentName)),
+	}
+	if version := strings.TrimSpace(agentVersion); version != "" {
+		attrs = append(attrs, attribute.String(spanAttrAgentVersion, version))
+	}
+	return attrs
 }
 
 func countToolCalls(messages []Message) int {

--- a/go/sigil/conformance_test.go
+++ b/go/sigil/conformance_test.go
@@ -210,6 +210,7 @@ func TestConformance_FullGenerationRoundtrip(t *testing.T) {
 		spanAttrProviderName:  "anthropic",
 		spanAttrRequestModel:  "claude-sonnet-4-5",
 		spanAttrAgentName:     "assistant-anthropic",
+		spanAttrAgentVersion:  "1.0.0",
 		spanAttrErrorType:     "",
 		spanAttrErrorCategory: "",
 	})
@@ -233,6 +234,7 @@ func TestConformance_FullGenerationRoundtrip(t *testing.T) {
 			spanAttrProviderName:  "anthropic",
 			spanAttrRequestModel:  "claude-sonnet-4-5",
 			spanAttrAgentName:     "assistant-anthropic",
+			spanAttrAgentVersion:  "1.0.0",
 			metricAttrTokenType:   tokenType,
 		})
 		if point.Count != 1 {
@@ -248,6 +250,7 @@ func TestConformance_FullGenerationRoundtrip(t *testing.T) {
 		spanAttrProviderName: "anthropic",
 		spanAttrRequestModel: "claude-sonnet-4-5",
 		spanAttrAgentName:    "assistant-anthropic",
+		spanAttrAgentVersion: "1.0.0",
 	})
 	if toolPoint.Count != 1 {
 		t.Fatalf("unexpected %s count: got %d want %d", metricToolCallsPerOperation, toolPoint.Count, 1)

--- a/java/core/src/main/java/com/grafana/sigil/sdk/SigilClient.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/SigilClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Span;
@@ -1216,6 +1217,17 @@ public final class SigilClient implements AutoCloseable {
         }
     }
 
+    private static AttributesBuilder metricIdentityAttributes(String provider, String model, String agentName, String agentVersion) {
+        AttributesBuilder builder = Attributes.builder()
+                .put(SPAN_ATTR_PROVIDER_NAME, provider == null ? "" : provider.trim())
+                .put(SPAN_ATTR_REQUEST_MODEL, model == null ? "" : model.trim())
+                .put(SPAN_ATTR_AGENT_NAME, agentName == null ? "" : agentName.trim());
+        if (agentVersion != null && !agentVersion.trim().isEmpty()) {
+            builder.put(SPAN_ATTR_AGENT_VERSION, agentVersion.trim());
+        }
+        return builder;
+    }
+
     void recordGenerationMetrics(Generation generation, String errorType, String errorCategory, Instant firstTokenAt) {
         if (generation == null) {
             return;
@@ -1225,13 +1237,16 @@ public final class SigilClient implements AutoCloseable {
         }
 
         double durationSeconds = Math.max(0d, Duration.between(generation.getStartedAt(), generation.getCompletedAt()).toNanos() / 1_000_000_000d);
+        Attributes identityAttributes = metricIdentityAttributes(
+                generation.getModel() == null ? "" : generation.getModel().getProvider(),
+                generation.getModel() == null ? "" : generation.getModel().getName(),
+                generation.getAgentName(),
+                generation.getAgentVersion()
+        ).build();
         operationDurationHistogram.record(
                 durationSeconds,
-                Attributes.builder()
+                identityAttributes.toBuilder()
                         .put(SPAN_ATTR_OPERATION_NAME, operationName(generation))
-                        .put(SPAN_ATTR_PROVIDER_NAME, generation.getModel() == null ? "" : generation.getModel().getProvider())
-                        .put(SPAN_ATTR_REQUEST_MODEL, generation.getModel() == null ? "" : generation.getModel().getName())
-                        .put(SPAN_ATTR_AGENT_NAME, generation.getAgentName())
                         .put(SPAN_ATTR_ERROR_TYPE, errorType == null ? "" : errorType)
                         .put(SPAN_ATTR_ERROR_CATEGORY, errorCategory == null ? "" : errorCategory)
                         .build()
@@ -1248,11 +1263,7 @@ public final class SigilClient implements AutoCloseable {
 
         toolCallsHistogram.record(
                 (double) countToolCalls(generation.getOutput()),
-                Attributes.builder()
-                        .put(SPAN_ATTR_PROVIDER_NAME, generation.getModel() == null ? "" : generation.getModel().getProvider())
-                        .put(SPAN_ATTR_REQUEST_MODEL, generation.getModel() == null ? "" : generation.getModel().getName())
-                        .put(SPAN_ATTR_AGENT_NAME, generation.getAgentName())
-                        .build()
+                identityAttributes
         );
 
         if (defaultOperationName(GenerationMode.STREAM).equals(operationName(generation)) && firstTokenAt != null) {
@@ -1260,11 +1271,7 @@ public final class SigilClient implements AutoCloseable {
             if (ttftSeconds >= 0d) {
                 ttftHistogram.record(
                         ttftSeconds,
-                        Attributes.builder()
-                                .put(SPAN_ATTR_PROVIDER_NAME, generation.getModel() == null ? "" : generation.getModel().getProvider())
-                                .put(SPAN_ATTR_REQUEST_MODEL, generation.getModel() == null ? "" : generation.getModel().getName())
-                                .put(SPAN_ATTR_AGENT_NAME, generation.getAgentName())
-                                .build()
+                        identityAttributes
                 );
             }
         }
@@ -1282,13 +1289,16 @@ public final class SigilClient implements AutoCloseable {
         }
 
         double durationSeconds = Math.max(0d, Duration.between(startedAt, completedAt).toNanos() / 1_000_000_000d);
+        Attributes identityAttributes = metricIdentityAttributes(
+                seed.getModel() == null ? "" : seed.getModel().getProvider(),
+                seed.getModel() == null ? "" : seed.getModel().getName(),
+                seed.getAgentName(),
+                seed.getAgentVersion()
+        ).build();
         operationDurationHistogram.record(
                 durationSeconds,
-                Attributes.builder()
+                identityAttributes.toBuilder()
                         .put(SPAN_ATTR_OPERATION_NAME, DEFAULT_EMBEDDING_OPERATION_NAME)
-                        .put(SPAN_ATTR_PROVIDER_NAME, seed.getModel() == null ? "" : seed.getModel().getProvider())
-                        .put(SPAN_ATTR_REQUEST_MODEL, seed.getModel() == null ? "" : seed.getModel().getName())
-                        .put(SPAN_ATTR_AGENT_NAME, seed.getAgentName())
                         .put(SPAN_ATTR_ERROR_TYPE, errorType == null ? "" : errorType)
                         .put(SPAN_ATTR_ERROR_CATEGORY, errorCategory == null ? "" : errorCategory)
                         .build()
@@ -1297,11 +1307,8 @@ public final class SigilClient implements AutoCloseable {
         if (result.getInputTokens() != 0L) {
             tokenUsageHistogram.record(
                     (double) result.getInputTokens(),
-                    Attributes.builder()
+                    identityAttributes.toBuilder()
                             .put(SPAN_ATTR_OPERATION_NAME, DEFAULT_EMBEDDING_OPERATION_NAME)
-                            .put(SPAN_ATTR_PROVIDER_NAME, seed.getModel() == null ? "" : seed.getModel().getProvider())
-                            .put(SPAN_ATTR_REQUEST_MODEL, seed.getModel() == null ? "" : seed.getModel().getName())
-                            .put(SPAN_ATTR_AGENT_NAME, seed.getAgentName())
                             .put(METRIC_ATTR_TOKEN_TYPE, METRIC_TOKEN_TYPE_INPUT)
                             .build()
             );
@@ -1314,11 +1321,13 @@ public final class SigilClient implements AutoCloseable {
         }
         tokenUsageHistogram.record(
                 (double) value,
-                Attributes.builder()
+                metricIdentityAttributes(
+                        generation.getModel() == null ? "" : generation.getModel().getProvider(),
+                        generation.getModel() == null ? "" : generation.getModel().getName(),
+                        generation.getAgentName(),
+                        generation.getAgentVersion()
+                )
                         .put(SPAN_ATTR_OPERATION_NAME, operationName(generation))
-                        .put(SPAN_ATTR_PROVIDER_NAME, generation.getModel() == null ? "" : generation.getModel().getProvider())
-                        .put(SPAN_ATTR_REQUEST_MODEL, generation.getModel() == null ? "" : generation.getModel().getName())
-                        .put(SPAN_ATTR_AGENT_NAME, generation.getAgentName())
                         .put(METRIC_ATTR_TOKEN_TYPE, tokenType)
                         .build()
         );
@@ -1339,12 +1348,9 @@ public final class SigilClient implements AutoCloseable {
 
         operationDurationHistogram.record(
                 durationSeconds,
-                Attributes.builder()
+                metricIdentityAttributes(seed.getRequestProvider(), seed.getRequestModel(), seed.getAgentName(), seed.getAgentVersion())
                         .put(SPAN_ATTR_OPERATION_NAME, TOOL_EXECUTION_OPERATION_NAME)
-                        .put(SPAN_ATTR_PROVIDER_NAME, seed.getRequestProvider().trim())
-                        .put(SPAN_ATTR_REQUEST_MODEL, seed.getRequestModel().trim())
                         .put(SPAN_ATTR_TOOL_NAME, seed.getToolName().trim())
-                        .put(SPAN_ATTR_AGENT_NAME, seed.getAgentName())
                         .put(SPAN_ATTR_ERROR_TYPE, errorType)
                         .put(SPAN_ATTR_ERROR_CATEGORY, errorCategory)
                         .build()

--- a/java/core/src/test/java/com/grafana/sigil/sdk/ConformanceTest.java
+++ b/java/core/src/test/java/com/grafana/sigil/sdk/ConformanceTest.java
@@ -148,6 +148,13 @@ class ConformanceTest {
                     .isEqualTo("user-roundtrip");
             assertThat(metricNames).contains(SigilClient.METRIC_OPERATION_DURATION, SigilClient.METRIC_TOKEN_USAGE);
             assertThat(metricNames).doesNotContain(SigilClient.METRIC_TTFT);
+            assertThat(env.metricData(SigilClient.METRIC_TOKEN_USAGE).getHistogramData().getPoints())
+                    .anySatisfy(point -> {
+                        assertThat(point.getAttributes().get(AttributeKey.stringKey(SigilClient.SPAN_ATTR_AGENT_VERSION)))
+                                .isEqualTo("v-roundtrip");
+                        assertThat(point.getAttributes().get(AttributeKey.stringKey(SigilClient.METRIC_ATTR_TOKEN_TYPE)))
+                                .isEqualTo("input");
+                    });
         }
     }
 
@@ -702,6 +709,13 @@ class ConformanceTest {
             return metricReader.collectAllMetrics().stream()
                     .map(MetricData::getName)
                     .toList();
+        }
+
+        MetricData metricData(String name) {
+            return metricReader.collectAllMetrics().stream()
+                    .filter(metric -> metric.getName().equals(name))
+                    .findFirst()
+                    .orElseThrow();
         }
 
         @Override

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -907,11 +907,15 @@ export class SigilClient {
     const startedMs = generation.startedAt.getTime();
     const completedMs = generation.completedAt.getTime();
     const durationSeconds = Math.max(0, (completedMs - startedMs) / 1_000);
+    const identityAttributes = metricIdentityAttributes(
+      generation.model.provider,
+      generation.model.name,
+      generation.agentName,
+      generation.agentVersion,
+    );
     this.operationDurationHistogram.record(durationSeconds, {
       [spanAttrOperationName]: generation.operationName,
-      [spanAttrProviderName]: generation.model.provider,
-      [spanAttrRequestModel]: generation.model.name,
-      [spanAttrAgentName]: generation.agentName ?? '',
+      ...identityAttributes,
       [spanAttrErrorType]: errorType,
       [spanAttrErrorCategory]: errorCategory,
     });
@@ -926,18 +930,14 @@ export class SigilClient {
     }
 
     this.toolCallsHistogram.record(countToolCallParts(generation.output ?? []), {
-      [spanAttrProviderName]: generation.model.provider,
-      [spanAttrRequestModel]: generation.model.name,
-      [spanAttrAgentName]: generation.agentName ?? '',
+      ...identityAttributes,
     });
 
     if (generation.operationName === 'streamText' && firstTokenAt !== undefined) {
       const ttftSeconds = (firstTokenAt.getTime() - startedMs) / 1_000;
       if (ttftSeconds >= 0) {
         this.ttftHistogram.record(ttftSeconds, {
-          [spanAttrProviderName]: generation.model.provider,
-          [spanAttrRequestModel]: generation.model.name,
-          [spanAttrAgentName]: generation.agentName ?? '',
+          ...identityAttributes,
         });
       }
     }
@@ -952,11 +952,15 @@ export class SigilClient {
     errorCategory: string,
   ): void {
     const durationSeconds = Math.max(0, (completedAt.getTime() - startedAt.getTime()) / 1_000);
+    const identityAttributes = metricIdentityAttributes(
+      seed.model.provider,
+      seed.model.name,
+      seed.agentName,
+      seed.agentVersion,
+    );
     this.operationDurationHistogram.record(durationSeconds, {
       [spanAttrOperationName]: defaultEmbeddingOperationName,
-      [spanAttrProviderName]: seed.model.provider,
-      [spanAttrRequestModel]: seed.model.name,
-      [spanAttrAgentName]: seed.agentName ?? '',
+      ...identityAttributes,
       [spanAttrErrorType]: errorType,
       [spanAttrErrorCategory]: errorCategory,
     });
@@ -964,9 +968,7 @@ export class SigilClient {
     if (result.inputTokens !== undefined && result.inputTokens !== 0) {
       this.tokenUsageHistogram.record(result.inputTokens, {
         [spanAttrOperationName]: defaultEmbeddingOperationName,
-        [spanAttrProviderName]: seed.model.provider,
-        [spanAttrRequestModel]: seed.model.name,
-        [spanAttrAgentName]: seed.agentName ?? '',
+        ...identityAttributes,
         [metricAttrTokenType]: metricTokenTypeInput,
       });
     }
@@ -978,9 +980,12 @@ export class SigilClient {
     }
     this.tokenUsageHistogram.record(value, {
       [spanAttrOperationName]: generation.operationName,
-      [spanAttrProviderName]: generation.model.provider,
-      [spanAttrRequestModel]: generation.model.name,
-      [spanAttrAgentName]: generation.agentName ?? '',
+      ...metricIdentityAttributes(
+        generation.model.provider,
+        generation.model.name,
+        generation.agentName,
+        generation.agentVersion,
+      ),
       [metricAttrTokenType]: tokenType,
     });
   }
@@ -993,10 +998,13 @@ export class SigilClient {
     const errorCategory = finalError === undefined ? '' : errorCategoryFromError(finalError, true);
     this.operationDurationHistogram.record(durationSeconds, {
       [spanAttrOperationName]: 'execute_tool',
-      [spanAttrProviderName]: (toolExecution.requestProvider ?? '').trim(),
-      [spanAttrRequestModel]: (toolExecution.requestModel ?? '').trim(),
       [spanAttrToolName]: toolExecution.toolName.trim(),
-      [spanAttrAgentName]: toolExecution.agentName ?? '',
+      ...metricIdentityAttributes(
+        toolExecution.requestProvider ?? '',
+        toolExecution.requestModel ?? '',
+        toolExecution.agentName,
+        toolExecution.agentVersion,
+      ),
       [spanAttrErrorType]: errorType,
       [spanAttrErrorCategory]: errorCategory,
     });
@@ -1577,6 +1585,23 @@ function toolSpanName(toolName: string): string {
     return 'execute_tool unknown';
   }
   return `execute_tool ${normalized}`;
+}
+
+function metricIdentityAttributes(
+  provider: string,
+  model: string,
+  agentName: string | undefined,
+  agentVersion: string | undefined,
+): Record<string, string> {
+  const attributes: Record<string, string> = {
+    [spanAttrProviderName]: provider.trim(),
+    [spanAttrRequestModel]: model.trim(),
+    [spanAttrAgentName]: agentName?.trim() ?? '',
+  };
+  if (notEmpty(agentVersion)) {
+    attributes[spanAttrAgentVersion] = agentVersion.trim();
+  }
+  return attributes;
 }
 
 function setGenerationSpanAttributes(

--- a/js/test/conformance.test.mjs
+++ b/js/test/conformance.test.mjs
@@ -111,6 +111,7 @@ test('conformance sync roundtrip semantics', async () => {
     const generation = env.singleGeneration();
     const span = env.latestGenerationSpan();
     const metricNames = await env.metricNames();
+    const tokenUsageAttributes = await env.metricDataPointAttributes('gen_ai.client.token.usage');
 
     assert.equal(generation.mode, 'GENERATION_MODE_SYNC');
     assert.equal(generation.operationName, 'generateText');
@@ -147,6 +148,13 @@ test('conformance sync roundtrip semantics', async () => {
     assert.ok(metricNames.includes('gen_ai.client.operation.duration'));
     assert.ok(metricNames.includes('gen_ai.client.token.usage'));
     assert.ok(!metricNames.includes('gen_ai.client.time_to_first_token'));
+    assert.ok(
+      tokenUsageAttributes.some(
+        (attributes) =>
+          attributes['gen_ai.agent.version'] === 'v-roundtrip' && attributes['gen_ai.token.type'] === 'input',
+      ),
+      'token usage metrics should include the agent version attribute',
+    );
   } finally {
     await env.close();
   }
@@ -789,6 +797,16 @@ async function createConformanceEnv(options = {}) {
       assert.ok(metric, `expected histogram metric ${metricName}`);
       assert.ok(metric.dataPoints.length > 0, `expected ${metricName} datapoints`);
       return metric.dataPoints[0].value.buckets.boundaries;
+    },
+    async metricDataPointAttributes(metricName) {
+      await meterProvider.forceFlush();
+      const metric = metricExporter
+        .getMetrics()
+        .flatMap((resourceMetrics) => resourceMetrics.scopeMetrics)
+        .flatMap((scopeMetrics) => scopeMetrics.metrics)
+        .find((m) => m.descriptor.name === metricName && m.dataPointType === DataPointType.HISTOGRAM);
+      assert.ok(metric, `expected histogram metric ${metricName}`);
+      return metric.dataPoints.map((point) => point.attributes);
     },
     async close() {
       if (closed) {

--- a/python/sigil_sdk/client.py
+++ b/python/sigil_sdk/client.py
@@ -985,13 +985,17 @@ class Client:
             return
 
         duration_seconds = max((completed_at - started_at).total_seconds(), 0.0)
+        identity_attributes = _metric_identity_attributes(
+            generation.model.provider,
+            generation.model.name,
+            generation.agent_name,
+            generation.agent_version,
+        )
         self._operation_duration_histogram.record(
             duration_seconds,
             attributes={
                 _span_attr_operation_name: generation.operation_name,
-                _span_attr_provider_name: generation.model.provider,
-                _span_attr_request_model: generation.model.name,
-                _span_attr_agent_name: generation.agent_name,
+                **identity_attributes,
                 _span_attr_error_type: error_type,
                 _span_attr_error_category: error_category,
             },
@@ -1007,9 +1011,7 @@ class Client:
         self._tool_calls_histogram.record(
             _count_tool_call_parts(generation.output),
             attributes={
-                _span_attr_provider_name: generation.model.provider,
-                _span_attr_request_model: generation.model.name,
-                _span_attr_agent_name: generation.agent_name,
+                **identity_attributes,
             },
         )
 
@@ -1019,9 +1021,7 @@ class Client:
                 self._ttft_histogram.record(
                     ttft_seconds,
                     attributes={
-                        _span_attr_provider_name: generation.model.provider,
-                        _span_attr_request_model: generation.model.name,
-                        _span_attr_agent_name: generation.agent_name,
+                        **identity_attributes,
                     },
                 )
 
@@ -1035,13 +1035,17 @@ class Client:
         error_category: str,
     ) -> None:
         duration_seconds = max((completed_at - started_at).total_seconds(), 0.0)
+        identity_attributes = _metric_identity_attributes(
+            seed.model.provider,
+            seed.model.name,
+            seed.agent_name,
+            seed.agent_version,
+        )
         self._operation_duration_histogram.record(
             duration_seconds,
             attributes={
                 _span_attr_operation_name: _default_embedding_operation_name,
-                _span_attr_provider_name: seed.model.provider,
-                _span_attr_request_model: seed.model.name,
-                _span_attr_agent_name: seed.agent_name,
+                **identity_attributes,
                 _span_attr_error_type: error_type,
                 _span_attr_error_category: error_category,
             },
@@ -1052,9 +1056,7 @@ class Client:
                 result.input_tokens,
                 attributes={
                     _span_attr_operation_name: _default_embedding_operation_name,
-                    _span_attr_provider_name: seed.model.provider,
-                    _span_attr_request_model: seed.model.name,
-                    _span_attr_agent_name: seed.agent_name,
+                    **identity_attributes,
                     _metric_attr_token_type: _metric_token_type_input,
                 },
             )
@@ -1066,9 +1068,12 @@ class Client:
             value,
             attributes={
                 _span_attr_operation_name: generation.operation_name,
-                _span_attr_provider_name: generation.model.provider,
-                _span_attr_request_model: generation.model.name,
-                _span_attr_agent_name: generation.agent_name,
+                **_metric_identity_attributes(
+                    generation.model.provider,
+                    generation.model.name,
+                    generation.agent_name,
+                    generation.agent_version,
+                ),
                 _metric_attr_token_type: token_type,
             },
         )
@@ -1091,10 +1096,13 @@ class Client:
             duration_seconds,
             attributes={
                 _span_attr_operation_name: "execute_tool",
-                _span_attr_provider_name: seed.request_provider.strip() if seed.request_provider else "",
-                _span_attr_request_model: seed.request_model.strip() if seed.request_model else "",
                 _span_attr_tool_name: seed.tool_name.strip(),
-                _span_attr_agent_name: seed.agent_name,
+                **_metric_identity_attributes(
+                    seed.request_provider,
+                    seed.request_model,
+                    seed.agent_name,
+                    seed.agent_version,
+                ),
                 _span_attr_error_type: error_type,
                 _span_attr_error_category: error_category,
             },
@@ -1910,6 +1918,22 @@ def _default_operation_name(mode: GenerationMode | None) -> str:
     if mode == GenerationMode.STREAM:
         return "streamText"
     return "generateText"
+
+
+def _metric_identity_attributes(
+    provider: str | None,
+    model: str | None,
+    agent_name: str | None,
+    agent_version: str | None,
+) -> dict[str, str]:
+    attrs = {
+        _span_attr_provider_name: provider.strip() if provider else "",
+        _span_attr_request_model: model.strip() if model else "",
+        _span_attr_agent_name: agent_name.strip() if agent_name else "",
+    }
+    if agent_version and agent_version.strip():
+        attrs[_span_attr_agent_version] = agent_version.strip()
+    return attrs
 
 
 def _new_random_id(prefix: str) -> str:

--- a/python/tests/test_conformance.py
+++ b/python/tests/test_conformance.py
@@ -327,6 +327,11 @@ def test_conformance_sync_roundtrip_semantics() -> None:
         assert "gen_ai.client.operation.duration" in metrics
         assert "gen_ai.client.token.usage" in metrics
         assert "gen_ai.client.time_to_first_token" not in metrics
+        assert any(
+            point.attributes.get("gen_ai.agent.version") == "v-roundtrip"
+            and point.attributes.get("gen_ai.token.type") == "input"
+            for point in metrics["gen_ai.client.token.usage"].data_points
+        )
     finally:
         env.shutdown()
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -478,7 +478,7 @@ wheels = [
 
 [[package]]
 name = "sigil-sdk"
-version = "0.2.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
## Summary
- Add `gen_ai.agent.version` to GenAI metric attributes across Go, JS/TS, Python, Java, and .NET SDK runtimes when an agent version is available.
- Cover token usage metrics with conformance assertions so Prometheus-backed agent performance views can group by version.
- Sync the Python lockfile package version generated by the focused Python conformance run.

## Test plan
- `mise run test:go:sdk-conformance`
- `mise run test:ts:sdk-conformance`
- `mise run test:py:sdk-conformance`
- `mise run test:java:sdk-conformance`
- `.NET conformance not run locally: dotnet is not installed in this environment`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes OpenTelemetry metric attribute sets across all SDKs, which can impact metric cardinality and downstream dashboards/alerting if label expectations change.
> 
> **Overview**
> Adds `gen_ai.agent.version` as an optional attribute on GenAI client metrics (operation duration, token usage, tool calls, and TTFT where applicable) across the Go, .NET, Java, JS/TS, and Python SDKs, typically via a shared “identity attributes” helper that trims values and omits empty versions.
> 
> Updates conformance tests in each runtime to assert the agent version attribute is present on token-usage (and related) metric points, and adjusts .NET test metric capture to retain per-measurement tag snapshots. Also bumps the Python `uv.lock` editable package version to `0.4.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f151a3680e39f72aa3554bd27ae82953a954db9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->