### PR TITLE
feat(plugins/pi): read config.env on startup

### DIFF
--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -102,7 +102,13 @@ By default, transport errors and timeouts let the tool through. Set `SIGIL_GUARD
 | `guards.timeoutMs` | `1500` | Per-call timeout for guard requests |
 | `guards.failOpen` | `true` | Allow tools through when guard checks fail |
 
-Every field can be overridden via env var. When launched via `sigil pi`, vars in `~/.config/sigil/config.env` are loaded automatically.
+Every field can be overridden via env var.
+
+On startup the extension reads `$XDG_CONFIG_HOME/sigil/config.env` (default `~/.config/sigil/config.env`) and copies the entries into `process.env` for keys whose existing OS value is empty or whitespace-only. This happens on every launch — plain `pi` and `sigil pi` resolve credentials from the same file.
+
+File format: one `KEY=value` per line, `#` line comments, optional `export ` prefix, optional matching single or double quotes around the value. Only the following keys are honoured — anything else (including stray `PATH=…` lines) is ignored: any `SIGIL_*` key plus `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_INSECURE`, and `OTEL_SERVICE_NAME`.
+
+A non-empty OS env value always wins over the file; an empty or whitespace-only OS value is treated as unset and gets filled from `config.env`. Missing files are silent.
 
 | Variable | Sets |
 |----------|------|

--- a/plugins/pi/src/config.test.ts
+++ b/plugins/pi/src/config.test.ts
@@ -1,17 +1,9 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveConfig, resolveEnvVars } from "./config.js";
-
-function clearEnv() {
-  for (const key of Object.keys(process.env)) {
-    if (
-      key.startsWith("SIGIL_PI_") ||
-      key.startsWith("SIGIL_") ||
-      key.startsWith("OTEL_")
-    ) {
-      delete process.env[key];
-    }
-  }
-}
+import { loadConfig, resolveConfig, resolveEnvVars } from "./config.js";
+import { clearSigilEnv as clearEnv } from "./testEnv.js";
 
 describe("resolveConfig", () => {
   beforeEach(clearEnv);
@@ -752,5 +744,54 @@ describe("resolveEnvVars", () => {
 
   it("leaves strings without vars unchanged", () => {
     expect(resolveEnvVars("plain-value")).toBe("plain-value");
+  });
+});
+
+describe("loadConfig reads ~/.config/sigil/config.env", () => {
+  let dir: string;
+  let homeBackup: string | undefined;
+
+  beforeEach(() => {
+    clearEnv();
+    dir = mkdtempSync(join(tmpdir(), "sigil-pi-loadconfig-"));
+    // Redirect both XDG_CONFIG_HOME and HOME at the tmpdir. config.ts resolves
+    // the JSON config path lazily via homedir(), which reads $HOME on POSIX,
+    // so this redirect actually moves the JSON path off the developer's real
+    // home and onto $tmpdir/.config/sigil-pi/config.json (which doesn't
+    // exist). The dotenv loader becomes the only source of credentials.
+    process.env.XDG_CONFIG_HOME = dir;
+    homeBackup = process.env.HOME;
+    process.env.HOME = dir;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    if (homeBackup === undefined) delete process.env.HOME;
+    else process.env.HOME = homeBackup;
+    clearEnv();
+  });
+
+  it("picks up SIGIL_* credentials from config.env when no shell env is set", async () => {
+    const cfgDir = join(dir, "sigil");
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.env"),
+      [
+        "SIGIL_ENDPOINT=https://sigil.example.com",
+        "SIGIL_AUTH_TENANT_ID=tenant-1",
+        "SIGIL_AUTH_TOKEN=glc_token",
+        "",
+      ].join("\n"),
+    );
+
+    const cfg = await loadConfig();
+    expect(cfg).not.toBeNull();
+    expect(cfg?.endpoint).toBe("https://sigil.example.com");
+    expect(cfg?.auth).toEqual({
+      mode: "basic",
+      user: "tenant-1",
+      password: "glc_token",
+      tenantId: "tenant-1",
+    });
   });
 });

--- a/plugins/pi/src/config.ts
+++ b/plugins/pi/src/config.ts
@@ -2,6 +2,8 @@ import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ContentCaptureMode } from "@grafana/sigil-sdk-js";
+import { isMissingFileError } from "./fsErrors.js";
+import { applySigilDotenv } from "./sigilDotenv.js";
 
 export type SigilAuthConfig =
   | { mode: "bearer"; bearerToken: string }
@@ -38,12 +40,23 @@ export interface SigilPiConfig {
   guards: GuardsFeatureConfig;
 }
 
-const CONFIG_PATH = join(homedir(), ".config", "sigil-pi", "config.json");
+// Resolved lazily so tests can redirect $HOME at runtime and the loader
+// follows. Keeping this as a module-level `const` would pin the path to the
+// value at import time and silently bypass test redirection.
+function configPath(): string {
+  return join(homedir(), ".config", "sigil-pi", "config.json");
+}
 
 export async function loadConfig(): Promise<SigilPiConfig | null> {
+  // Read the shared sigil dotenv file before anything else so plain `pi` and
+  // `sigil pi --` resolve credentials from the same place. Values in
+  // process.env always win — applySigilDotenv only fills empty/whitespace
+  // entries — so an explicit shell export still overrides the file.
+  applySigilDotenv();
+
   let fileConfig: Record<string, unknown> = {};
   try {
-    const raw = await readFile(CONFIG_PATH, "utf-8");
+    const raw = await readFile(configPath(), "utf-8");
     fileConfig = parseConfig(raw);
   } catch (err) {
     if (!isMissingFileError(err)) {
@@ -62,8 +75,11 @@ export function resolveConfig(
 ): SigilPiConfig | null {
   // Canonical SIGIL_* env vars (shared with claude-code/codex/cursor) take
   // precedence over the legacy SIGIL_PI_* prefix so a single config.env can
-  // drive every agent. The pi-specific names remain as a fallback so users
-  // who already configured them keep working.
+  // drive every agent. `loadConfig` reads the shared config.env into
+  // process.env via applySigilDotenv() before this resolver runs, with the
+  // OS-env-wins rule: a non-empty shell export beats the file. The
+  // pi-specific names remain as a fallback so users who already configured
+  // them keep working.
   const endpoint = normalizeBaseEndpoint(
     (
       env("SIGIL_ENDPOINT") ??
@@ -495,13 +511,4 @@ function normalizeBaseEndpoint(endpoint: string): string {
       ? trimmed.slice(0, trimmed.length - EXPORT_PATH.length)
       : trimmed;
   }
-}
-
-function isMissingFileError(err: unknown): boolean {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    "code" in err &&
-    (err as { code?: string }).code === "ENOENT"
-  );
 }

--- a/plugins/pi/src/fsErrors.ts
+++ b/plugins/pi/src/fsErrors.ts
@@ -1,0 +1,12 @@
+/**
+ * True when `err` looks like a node:fs ENOENT (missing file/directory).
+ * Used to swallow expected "file not found" cases from optional config reads.
+ */
+export function isMissingFileError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: string }).code === "ENOENT"
+  );
+}

--- a/plugins/pi/src/sigilDotenv.test.ts
+++ b/plugins/pi/src/sigilDotenv.test.ts
@@ -1,0 +1,375 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  applySigilDotenv,
+  loadSigilDotenv,
+  parseSigilDotenv,
+  sigilConfigEnvPath,
+} from "./sigilDotenv.js";
+import { clearSigilEnv } from "./testEnv.js";
+
+describe("parseSigilDotenv", () => {
+  it("parses the full sample from the Go reference test", () => {
+    // Mirrors plugins/sigil/internal/dotenv/dotenv_test.go::TestLoadDotenv
+    const body = `# leading comment
+SIGIL_ENDPOINT=https://sigil.example.com
+export SIGIL_AUTH_TENANT_ID=alice
+SIGIL_AUTH_TOKEN="secret with spaces"
+SIGIL_CONTENT_CAPTURE_MODE='full'
+SIGIL_TAGS=a=1,b=2  # inline comment
+SIGIL_DEBUG=true
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.example.com/otlp
+PATH=/tmp/not-loaded
+no_equals_line
+=missingkey
+EMPTY=
+`;
+    const got = parseSigilDotenv(body);
+    expect(got).toEqual({
+      SIGIL_ENDPOINT: "https://sigil.example.com",
+      SIGIL_AUTH_TENANT_ID: "alice",
+      SIGIL_AUTH_TOKEN: "secret with spaces",
+      SIGIL_CONTENT_CAPTURE_MODE: "full",
+      SIGIL_TAGS: "a=1,b=2",
+      SIGIL_DEBUG: "true",
+      OTEL_EXPORTER_OTLP_ENDPOINT: "https://otlp.example.com/otlp",
+    });
+  });
+
+  it("handles quoted-value edge cases the same way as the Go parser", () => {
+    // Mirrors TestLoadDotenvQuotedValueEdgeCases
+    const body = `SIGIL_DOUBLE="my secret" # comment
+SIGIL_SINGLE='other secret' # comment
+SIGIL_HASH_INSIDE="value # not a comment"
+SIGIL_PLAIN_COMMENT=plain # trailing
+SIGIL_SPACES_INSIDE="  has spaces  "
+SIGIL_UNTERMINATED="oops
+`;
+    const got = parseSigilDotenv(body);
+    expect(got.SIGIL_DOUBLE).toBe("my secret");
+    expect(got.SIGIL_SINGLE).toBe("other secret");
+    expect(got.SIGIL_HASH_INSIDE).toBe("value # not a comment");
+    expect(got.SIGIL_PLAIN_COMMENT).toBe("plain");
+    expect(got.SIGIL_SPACES_INSIDE).toBe("  has spaces  ");
+    // Unterminated quote falls through to the literal value, including
+    // the leading quote. Matches Go parseDotenvValue.
+    expect(got.SIGIL_UNTERMINATED).toBe('"oops');
+  });
+
+  it("skips comments, blank lines, and lines without an equals sign", () => {
+    const body = `
+# top-level comment
+   # indented comment
+
+SIGIL_ENDPOINT=https://ok
+
+no_equals_line
+=missingkey
+EMPTY=
+`;
+    const got = parseSigilDotenv(body);
+    expect(got).toEqual({ SIGIL_ENDPOINT: "https://ok" });
+  });
+
+  it("honors the optional 'export ' prefix", () => {
+    const got = parseSigilDotenv(`export SIGIL_ENDPOINT=https://exported\n`);
+    expect(got).toEqual({ SIGIL_ENDPOINT: "https://exported" });
+  });
+
+  it("ignores keys outside the allow-list", () => {
+    const body = `PATH=/tmp/not-loaded
+HOME=/tmp/not-loaded
+SIGIL_ENDPOINT=https://ok
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic xyz
+OTEL_EXPORTER_OTLP_INSECURE=true
+OTEL_SERVICE_NAME=my-service
+OTEL_RESOURCE_ATTRIBUTES=service.name=other
+`;
+    const got = parseSigilDotenv(body);
+    expect(got).toEqual({
+      SIGIL_ENDPOINT: "https://ok",
+      OTEL_EXPORTER_OTLP_HEADERS: "Authorization=Basic xyz",
+      OTEL_EXPORTER_OTLP_INSECURE: "true",
+      OTEL_SERVICE_NAME: "my-service",
+    });
+    expect(got).not.toHaveProperty("PATH");
+    expect(got).not.toHaveProperty("HOME");
+    expect(got).not.toHaveProperty("OTEL_RESOURCE_ATTRIBUTES");
+  });
+
+  it("accepts both CRLF and LF line endings", () => {
+    const body = "SIGIL_ENDPOINT=https://crlf\r\nSIGIL_DEBUG=true\r\n";
+    expect(parseSigilDotenv(body)).toEqual({
+      SIGIL_ENDPOINT: "https://crlf",
+      SIGIL_DEBUG: "true",
+    });
+  });
+});
+
+describe("sigilConfigEnvPath", () => {
+  beforeEach(clearSigilEnv);
+  afterEach(clearSigilEnv);
+
+  it("honors an absolute XDG_CONFIG_HOME", () => {
+    process.env.XDG_CONFIG_HOME = "/tmp/custom-config";
+    expect(sigilConfigEnvPath()).toBe("/tmp/custom-config/sigil/config.env");
+  });
+
+  it("ignores a relative XDG_CONFIG_HOME and falls back to $HOME/.config", () => {
+    process.env.XDG_CONFIG_HOME = "relative-path";
+    expect(sigilConfigEnvPath()).toBe(
+      join(homedir(), ".config", "sigil", "config.env"),
+    );
+  });
+
+  it("falls back to $HOME/.config/sigil/config.env when XDG_CONFIG_HOME is unset", () => {
+    expect(sigilConfigEnvPath()).toBe(
+      join(homedir(), ".config", "sigil", "config.env"),
+    );
+  });
+
+  it("ignores an XDG_CONFIG_HOME that is whitespace only", () => {
+    process.env.XDG_CONFIG_HOME = "   ";
+    expect(sigilConfigEnvPath()).toBe(
+      join(homedir(), ".config", "sigil", "config.env"),
+    );
+  });
+});
+
+describe("loadSigilDotenv", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    clearSigilEnv();
+    dir = mkdtempSync(join(tmpdir(), "sigil-pi-dotenv-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    clearSigilEnv();
+  });
+
+  it("returns an empty map silently when the file is missing", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const got = loadSigilDotenv(join(dir, "does-not-exist.env"));
+    expect(got).toEqual({});
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("parses an on-disk file", () => {
+    const path = join(dir, "config.env");
+    writeFileSync(
+      path,
+      "SIGIL_ENDPOINT=https://from-file\nSIGIL_AUTH_TOKEN=tok\n",
+    );
+    expect(loadSigilDotenv(path)).toEqual({
+      SIGIL_ENDPOINT: "https://from-file",
+      SIGIL_AUTH_TOKEN: "tok",
+    });
+  });
+
+  it("warns and returns an empty map on non-ENOENT read failures", () => {
+    // A path that points to a directory rather than a file triggers an
+    // EISDIR (or similar) read error, not ENOENT.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const got = loadSigilDotenv(dir);
+    expect(got).toEqual({});
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toMatch(/^\[sigil-pi\]/);
+    warn.mockRestore();
+  });
+});
+
+describe("applySigilDotenv", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    clearSigilEnv();
+    dir = mkdtempSync(join(tmpdir(), "sigil-pi-dotenv-apply-"));
+    process.env.XDG_CONFIG_HOME = dir;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    clearSigilEnv();
+  });
+
+  function configPath(): string {
+    return join(dir, "sigil", "config.env");
+  }
+
+  function writeConfig(body: string): void {
+    const path = configPath();
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, body);
+  }
+
+  it("fills empty OS env values from config.env", () => {
+    writeConfig(
+      "SIGIL_ENDPOINT=https://from-file\nSIGIL_AUTH_TENANT_ID=tenant-1\nSIGIL_AUTH_TOKEN=tok\n",
+    );
+    applySigilDotenv();
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://from-file");
+    expect(process.env.SIGIL_AUTH_TENANT_ID).toBe("tenant-1");
+    expect(process.env.SIGIL_AUTH_TOKEN).toBe("tok");
+  });
+
+  it("keeps non-empty OS env values intact", () => {
+    process.env.SIGIL_ENDPOINT = "https://from-shell";
+    writeConfig("SIGIL_ENDPOINT=https://from-file\n");
+    applySigilDotenv();
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://from-shell");
+  });
+
+  it("treats an empty OS env value as unset", () => {
+    process.env.SIGIL_ENDPOINT = "";
+    writeConfig("SIGIL_ENDPOINT=https://from-file\n");
+    applySigilDotenv();
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://from-file");
+  });
+
+  it("treats a whitespace-only OS env value as unset", () => {
+    process.env.SIGIL_ENDPOINT = "   ";
+    writeConfig("SIGIL_ENDPOINT=https://from-file\n");
+    applySigilDotenv();
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://from-file");
+  });
+
+  it("does nothing silently when config.env is missing", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    applySigilDotenv();
+    expect(process.env.SIGIL_ENDPOINT).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("does not touch keys outside the allow-list", () => {
+    const before = process.env.PATH;
+    writeConfig("PATH=/tmp/not-loaded\nSIGIL_ENDPOINT=https://ok\n");
+    applySigilDotenv();
+    expect(process.env.PATH).toBe(before);
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://ok");
+  });
+
+  it("picks up edits to config.env on a second call", () => {
+    // Owned keys must be refreshed on each call so edits to config.env
+    // propagate across repeated session_start events.
+    writeConfig("SIGIL_ENDPOINT=https://first\n");
+    applySigilDotenv();
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://first");
+
+    writeConfig("SIGIL_ENDPOINT=https://second\n");
+    applySigilDotenv();
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://second");
+  });
+
+  it("clears keys that were removed from config.env on a second call", () => {
+    writeConfig("SIGIL_ENDPOINT=https://from-file\nSIGIL_AUTH_TOKEN=tok\n");
+    applySigilDotenv();
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://from-file");
+    expect(process.env.SIGIL_AUTH_TOKEN).toBe("tok");
+
+    // Drop SIGIL_AUTH_TOKEN. After re-applying, the stale value must be
+    // removed from process.env or downstream auth resolution would silently
+    // keep using credentials the user thought they had deleted.
+    writeConfig("SIGIL_ENDPOINT=https://from-file\n");
+    applySigilDotenv();
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://from-file");
+    expect(process.env.SIGIL_AUTH_TOKEN).toBeUndefined();
+  });
+
+  it("keeps shell-supplied OS env values intact across multiple calls", () => {
+    process.env.SIGIL_ENDPOINT = "https://from-shell";
+    writeConfig("SIGIL_ENDPOINT=https://first\n");
+    applySigilDotenv();
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://from-shell");
+
+    // A later config.env edit must still not clobber the shell export —
+    // "OS env wins per key" is the contract loadConfig advertises.
+    writeConfig("SIGIL_ENDPOINT=https://second\n");
+    applySigilDotenv();
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://from-shell");
+  });
+
+  it("yields to a non-empty OS env value set after a key was copied from config.env", () => {
+    // README/loadConfig promise: "OS env always wins per key". A non-empty
+    // value present in process.env at the time of a call must win, even if
+    // an earlier call had already copied that key from config.env. Without
+    // this, a later session_start in the same Pi process would clobber an
+    // override that another writer (extension, runtime assignment) put in
+    // place between calls.
+    writeConfig("SIGIL_AUTH_TOKEN=from-file\n");
+    applySigilDotenv();
+    expect(process.env.SIGIL_AUTH_TOKEN).toBe("from-file");
+
+    process.env.SIGIL_AUTH_TOKEN = "from-shell";
+    applySigilDotenv();
+    expect(process.env.SIGIL_AUTH_TOKEN).toBe("from-shell");
+
+    // A later edit to config.env must still not clobber the override.
+    writeConfig("SIGIL_AUTH_TOKEN=from-file-2\n");
+    applySigilDotenv();
+    expect(process.env.SIGIL_AUTH_TOKEN).toBe("from-shell");
+  });
+
+  it("does not delete a user-supplied value when the key is removed from config.env", () => {
+    // After ownership has been released by a runtime override, removing
+    // the key from config.env must leave the override in place —
+    // otherwise the dotenv loader would silently delete data it no longer
+    // owns.
+    writeConfig("SIGIL_AUTH_TOKEN=from-file\n");
+    applySigilDotenv();
+
+    process.env.SIGIL_AUTH_TOKEN = "from-shell";
+    writeConfig("");
+    applySigilDotenv();
+    expect(process.env.SIGIL_AUTH_TOKEN).toBe("from-shell");
+  });
+
+  it("re-fills a key from config.env after the runtime override is cleared", () => {
+    // If another writer first overrides our value and then clears it, the
+    // key is no longer owned and the OS-env-wins check sees an empty
+    // value, so the file value is allowed to take effect again on the
+    // next call.
+    writeConfig("SIGIL_AUTH_TOKEN=from-file\n");
+    applySigilDotenv();
+
+    process.env.SIGIL_AUTH_TOKEN = "from-shell";
+    applySigilDotenv();
+    expect(process.env.SIGIL_AUTH_TOKEN).toBe("from-shell");
+
+    delete process.env.SIGIL_AUTH_TOKEN;
+    applySigilDotenv();
+    expect(process.env.SIGIL_AUTH_TOKEN).toBe("from-file");
+  });
+
+  it("keeps owned keys when config.env cannot be read", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    writeConfig("SIGIL_ENDPOINT=https://from-file\nSIGIL_AUTH_TOKEN=tok\n");
+    applySigilDotenv();
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://from-file");
+    expect(process.env.SIGIL_AUTH_TOKEN).toBe("tok");
+
+    rmSync(configPath());
+    mkdirSync(configPath());
+    applySigilDotenv();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://from-file");
+    expect(process.env.SIGIL_AUTH_TOKEN).toBe("tok");
+    warn.mockRestore();
+  });
+
+  it("clears a key when config.env disappears entirely", () => {
+    writeConfig("SIGIL_AUTH_TOKEN=tok\n");
+    applySigilDotenv();
+    expect(process.env.SIGIL_AUTH_TOKEN).toBe("tok");
+
+    rmSync(join(dir, "sigil"), { recursive: true, force: true });
+    applySigilDotenv();
+    expect(process.env.SIGIL_AUTH_TOKEN).toBeUndefined();
+  });
+});

--- a/plugins/pi/src/sigilDotenv.ts
+++ b/plugins/pi/src/sigilDotenv.ts
@@ -1,0 +1,187 @@
+import { readFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { isAbsolute, join } from "node:path";
+import { isMissingFileError } from "./fsErrors.js";
+
+// Mirror plugins/sigil/internal/dotenv/dotenv.go::AllowedDotenvKey so the
+// allow-list stays in sync with the Go launcher. Anything outside the SIGIL_*
+// prefix and this small OTEL_* set is ignored, including innocent-looking
+// vars like PATH that happen to appear in a shared config.env.
+const ALLOWED_OTEL_KEYS = new Set([
+  "OTEL_EXPORTER_OTLP_ENDPOINT",
+  "OTEL_EXPORTER_OTLP_HEADERS",
+  "OTEL_EXPORTER_OTLP_INSECURE",
+  "OTEL_SERVICE_NAME",
+]);
+
+function allowedDotenvKey(key: string): boolean {
+  return key.startsWith("SIGIL_") || ALLOWED_OTEL_KEYS.has(key);
+}
+
+/**
+ * Resolve the path the sigil dotenv loader reads. Mirrors
+ * `plugins/sigil/internal/xdg/xdg.go::ConfigRoot` so plain pi and `sigil pi`
+ * read the same file:
+ *
+ * 1. `$XDG_CONFIG_HOME/sigil/config.env` when XDG_CONFIG_HOME is an absolute path.
+ * 2. `$HOME/.config/sigil/config.env` when the user has a resolvable home.
+ * 3. `<tmpdir>/sigil/config.env` as a last-resort fallback.
+ */
+export function sigilConfigEnvPath(): string {
+  const xdg = (process.env.XDG_CONFIG_HOME ?? "").trim();
+  if (xdg && isAbsolute(xdg)) {
+    return join(xdg, "sigil", "config.env");
+  }
+  const home = homedir();
+  if (home && isAbsolute(home)) {
+    return join(home, ".config", "sigil", "config.env");
+  }
+  return join(tmpdir(), "sigil", "config.env");
+}
+
+/**
+ * Parse a config.env body using the same rules as the Go reference loader
+ * (`plugins/sigil/internal/dotenv/dotenv.go::LoadDotenv` +
+ * `parseDotenvValue`):
+ *
+ * - `KEY=value` one pair per line.
+ * - `#` line comments and blank lines are skipped.
+ * - Optional leading `export ` is stripped.
+ * - Optional matching single- or double-quotes around the value; inner
+ *   whitespace and `#` are preserved as written.
+ * - An unterminated quoted value falls through to the literal value
+ *   (including the leading quote), matching Go.
+ * - Trailing ` # comment` is stripped from unquoted values only.
+ * - Empty values, lines without `=`, and lines with an empty key are dropped.
+ * - Only keys passing `allowedDotenvKey` (SIGIL_* plus four OTEL_*) survive.
+ */
+export function parseSigilDotenv(body: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawLine of body.split(/\r?\n/)) {
+    let line = rawLine.trim();
+    if (line === "" || line.startsWith("#")) continue;
+    if (line.startsWith("export ")) {
+      line = line.slice("export ".length).trim();
+    }
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    if (!key || !allowedDotenvKey(key)) continue;
+    const value = parseDotenvValue(line.slice(eq + 1).trim());
+    if (value !== "") out[key] = value;
+  }
+  return out;
+}
+
+function parseDotenvValue(v: string): string {
+  if (v.length >= 2) {
+    const first = v[0];
+    if (first === '"' || first === "'") {
+      const end = v.indexOf(first, 1);
+      if (end >= 0) return v.slice(1, end);
+    }
+  }
+  const hashIdx = v.indexOf(" #");
+  if (hashIdx >= 0) {
+    return v.slice(0, hashIdx).replace(/[ \t]+$/, "");
+  }
+  return v;
+}
+
+interface SigilDotenvReadResult {
+  env: Record<string, string>;
+  reliable: boolean;
+}
+
+function readSigilDotenv(path: string): SigilDotenvReadResult {
+  let body: string;
+  try {
+    body = readFileSync(path, "utf-8");
+  } catch (err) {
+    if (isMissingFileError(err)) {
+      return { env: {}, reliable: true };
+    }
+    console.warn(`[sigil-pi] failed to read ${path}:`, err);
+    return { env: {}, reliable: false };
+  }
+  return { env: parseSigilDotenv(body), reliable: true };
+}
+
+/**
+ * Read and parse the dotenv file at `path`. Missing files return `{}`
+ * silently — the dotenv config is optional and credentials may come from
+ * other sources (shell env, sigil-pi/config.json). Other read failures emit a
+ * single `[sigil-pi]` warning and also return `{}`.
+ */
+export function loadSigilDotenv(path: string): Record<string, string> {
+  return readSigilDotenv(path).env;
+}
+
+// Maps each key this function has copied from config.env to the exact
+// value it wrote into process.env on the last call. We track the value
+// (not just the key) so a later writer — a shell-style assignment from
+// another loader, an extension, or test setup — can be distinguished from
+// our own previously-written value. Once process.env[key] no longer
+// matches what we wrote, ownership is released and the key is treated as
+// OS-supplied: OS env wins per key, on every call, not just the first.
+const ownedValues = new Map<string, string>();
+
+/**
+ * Read the sigil dotenv file and synchronize its contents with `process.env`.
+ *
+ * Per-call, OS env wins per key: if `process.env[key]` is non-empty and
+ * was not written by an earlier call of this function, it is left alone —
+ * that's the same "shell export beats file" guarantee as the Go launcher's
+ * `dotenv.ApplyEnv`, extended to hold across repeated `session_start`
+ * events in the same Pi process. Keys this function copied from the file
+ * are refreshed (edits propagate) or cleared (removals propagate) on every
+ * call, but only while the value in `process.env` is still the one we
+ * wrote; the moment another writer replaces it, we relinquish ownership.
+ */
+export function applySigilDotenv(): void {
+  const loaded = readSigilDotenv(sigilConfigEnvPath());
+  if (!loaded.reliable) return;
+  const fileEnv = loaded.env;
+
+  // Release ownership for any key whose value in process.env no longer
+  // matches what we wrote. Some other writer (shell-style assignment from
+  // an extension, manual override, etc.) has taken over and the file value
+  // must not stomp on it on this or subsequent calls.
+  for (const [key, ownedValue] of [...ownedValues]) {
+    if (process.env[key] !== ownedValue) {
+      ownedValues.delete(key);
+    }
+  }
+
+  // Drop keys we still own that the file no longer provides, so a deletion
+  // in config.env actually takes effect. Keys whose ownership we just
+  // released above are left alone — the user-supplied value wins.
+  for (const key of [...ownedValues.keys()]) {
+    if (!(key in fileEnv)) {
+      delete process.env[key];
+      ownedValues.delete(key);
+    }
+  }
+
+  for (const [key, value] of Object.entries(fileEnv)) {
+    if (!ownedValues.has(key)) {
+      // We don't own this key — defer to a non-empty OS env value (shell
+      // export, runtime assignment by any other writer) and leave it
+      // untouched. This is the check that enforces "OS env always wins"
+      // even for keys observed for the first time after earlier calls.
+      const current = process.env[key] ?? "";
+      if (current.trim() !== "") continue;
+    }
+    process.env[key] = value;
+    ownedValues.set(key, value);
+  }
+}
+
+/**
+ * Forget which keys `applySigilDotenv` has previously written into
+ * `process.env`. Intended for tests that mutate `process.env` between cases
+ * — production callers don't need to invoke this.
+ */
+export function resetSigilDotenvStateForTests(): void {
+  ownedValues.clear();
+}

--- a/plugins/pi/src/testEnv.ts
+++ b/plugins/pi/src/testEnv.ts
@@ -1,0 +1,24 @@
+import { resetSigilDotenvStateForTests } from "./sigilDotenv.js";
+
+/**
+ * Reset every SIGIL_*, SIGIL_PI_*, OTEL_* env var and XDG_CONFIG_HOME between
+ * test cases so on-disk fixtures (config.env, JSON config) and shell exports
+ * cannot leak across cases. Used by both config.test.ts and sigilDotenv.test.ts.
+ *
+ * Also clears the dotenv loader's per-process "owned keys" tracking so a
+ * test that calls applySigilDotenv doesn't poison the next case's view of
+ * which env values came from the shell vs. config.env.
+ */
+export function clearSigilEnv(): void {
+  for (const key of Object.keys(process.env)) {
+    if (
+      key.startsWith("SIGIL_PI_") ||
+      key.startsWith("SIGIL_") ||
+      key.startsWith("OTEL_")
+    ) {
+      delete process.env[key];
+    }
+  }
+  delete process.env.XDG_CONFIG_HOME;
+  resetSigilDotenvStateForTests();
+}


### PR DESCRIPTION
Same as all other coding agents plugins: read config.env on startup:
1. `$XDG_CONFIG_HOME/sigil/config.env`
2. `$HOME/.config/sigil/config.env` otherwise

**File format**

One `KEY=value` per line. Anything outside this set is ignored`:

- any `SIGIL_*` key
- `OTEL_EXPORTER_OTLP_ENDPOINT`
- `OTEL_EXPORTER_OTLP_HEADERS`
- `OTEL_EXPORTER_OTLP_INSECURE`
- `OTEL_SERVICE_NAME`

**Precedence**

Per key, in order:

1. Non-empty OS env wins. An env variable `SIGIL_*` value wins over the file.
2. Empty or whitespace-only OS env is treated as unset and gets filled from the file.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup config resolution to read and merge `config.env` into `process.env`, which can affect how credentials and OTLP settings are sourced/overridden across runs. Risk is mitigated by an allow-list and explicit per-key precedence rules but could still cause unexpected env precedence if misconfigured.
> 
> **Overview**
> The Pi plugin now **reads the shared Sigil `config.env` on startup** (via new `sigilDotenv.ts`) and merges allowed `SIGIL_*` and select `OTEL_*` keys into `process.env` *only when the existing OS env value is empty/whitespace*, aligning `pi` and `sigil pi` credential resolution.
> 
> This adds a Go-parity dotenv parser (comments, `export` prefix, quoting rules) plus per-process tracking so repeated calls refresh edited keys and clear removed ones without clobbering later shell/runtime overrides. Tests and docs were updated, including new coverage for path resolution (`$XDG_CONFIG_HOME`/`$HOME`) and missing/unreadable file behavior, and `config.json` path resolution was made lazy for testability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8ccbd070c037ede09a06eecfd9c148c95e8e77b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->