### PR TITLE
docs(plugins): switch install instructions to brew and simplify

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,18 +1,27 @@
 # Sigil plugins for coding agents
 
-Plugins that send generations from coding agents to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/). They capture model, tool calls, traces, optionally full conversation content, and tokens/cost where the host agent exposes reliable usage data.
+Send conversations from your coding agent to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/) — model, tokens, tool calls, timing, and optionally the conversation content.
 
-Claude Code, Codex, and Cursor share one Go binary (`sigil`) built from [`sigil/`](sigil/) and invoked as `sigil <host> hook`. Each host directory ships the plugin manifest, hook config, and a wrapper script that locates the shared binary.
+> AI Observability is in [public preview](https://grafana.com/docs/release-life-cycle/).
 
-| Agent | Plugin | Backed by | Status |
-|-------|--------|-----------|--------|
-| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | [`claude-code/`](claude-code/) | [`sigil/`](sigil/) | Available |
-| [Codex](https://developers.openai.com/codex) | [`codex/`](codex/) | [`sigil/`](sigil/) | Experimental |
-| [Cursor](https://cursor.com) | [`cursor/`](cursor/) | [`sigil/`](sigil/) | Available |
-| [OpenCode](https://opencode.ai) | [`opencode/`](opencode/) | TypeScript | Available |
-| [Pi](https://github.com/badlogic/pi) | [`pi/`](pi/) | TypeScript | Available |
+## Fastest start (Claude Code or pi)
 
-Each plugin's README covers install, config, auth, and content-capture options. The shared binary's own [README](sigil/README.md) documents environment variables that apply to all three Go-backed hosts.
+```sh
+brew install grafana/grafana/sigil
+sigil claude     # for Claude Code
+sigil pi         # for pi
+```
 
-Codex support is experimental because Codex hooks and plugin-provided lifecycle
-config remain feature-flagged.
+The launcher installs the plugin on first run. Add your credentials to `~/.config/sigil/config.env` — see any per-agent README for the 3-page Grafana Cloud walkthrough.
+
+## All plugins
+
+| Agent | Plugin | Status |
+|-------|--------|--------|
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | [`claude-code/`](claude-code/) | Available |
+| [Codex](https://developers.openai.com/codex) | [`codex/`](codex/) | Experimental |
+| [Cursor](https://cursor.com) | [`cursor/`](cursor/) | Available |
+| [OpenCode](https://opencode.ai) | [`opencode/`](opencode/) | Available |
+| [Pi](https://github.com/badlogic/pi) | [`pi/`](pi/) | Available |
+
+Claude Code, Codex, and Cursor share the same Go binary (`brew install grafana/grafana/sigil`) and the same config file (`~/.config/sigil/config.env`). All Sigil connection details live at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`.

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -1,208 +1,86 @@
-# Claude Code plugin for Sigil
+# Sigil for Claude Code
 
-A Claude Code plugin that forwards each session's transcript to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/). Backed by the consolidated [`sigil`](../sigil/) binary; this plugin only ships hook manifest + wrapper plumbing.
+Sends every Claude Code turn to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/): model, tokens, tools, timing, and optionally the conversation content.
 
-## Install
+## 1. Install
 
 ```sh
-go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
+brew install grafana/grafana/sigil
 ```
 
-Then pick one of:
+## 2. Register the plugin
 
-### Quick start via `sigil claude`
+Either run:
 
 ```sh
 sigil claude
 ```
 
-Installs the `sigil-cc` plugin on first run, then launches Claude Code. Subsequent runs just launch it. Forward flags to `claude` after `--`:
-
-```sh
-sigil claude -- --resume <session-id>
-```
-
-### From inside Claude Code
+…which installs the `sigil-cc` plugin on first run and launches Claude Code. Or from inside Claude Code:
 
 ```
 /plugin marketplace add grafana/sigil-sdk
 /plugin install sigil-cc@grafana-sigil
 ```
 
-Either path registers the hooks for you; future hook updates ship with the plugin so you don't re-edit `settings.json`.
+## 3. Add your credentials
 
-> `go install` drops the binary in `$GOBIN` (usually `~/go/bin`). The hook manifest invokes `sigil claude-code hook` directly, so make sure `$GOBIN` is on `PATH` for the shell that launches Claude Code. Verify with `sigil --version`.
+All Sigil connection details live at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure AI Observability is enabled on your stack — an administrator opens **Observability → AI Observability** once and accepts the terms.
 
-## Install manually
+You need values from three Grafana Cloud pages:
 
-If you'd rather not use the plugin marketplace, install the binary the same way and wire the hook yourself in `~/.claude/settings.json`:
+1. **AI Observability → Configuration**
+   - **API URL** → `SIGIL_ENDPOINT`
+   - **Instance ID** → `SIGIL_AUTH_TENANT_ID`
 
-```json
-{
-  "hooks": {
-    "Stop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "sigil claude-code hook",
-            "timeout": 10000
-          }
-        ]
-      }
-    ]
-  }
-}
+2. **Administration → Users and access → Cloud access policies**
+   - Create a policy with scopes `sigil:write`, `metrics:write`, `traces:write`.
+   - Add a token. The `glc_…` value is shown once → `SIGIL_AUTH_TOKEN`.
+
+3. **Grafana Cloud Portal → your stack → OpenTelemetry card**
+   - **OTLP endpoint URL** → `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT`
+
+Save them to `~/.config/sigil/config.env` (shared by all three host plugins):
+
+```dotenv
+SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
+SIGIL_AUTH_TENANT_ID=<instance-id>
+SIGIL_AUTH_TOKEN=glc_...
+SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
 ```
 
-## Get your credentials from Grafana Cloud
+To also send the conversation text (with automatic secret redaction), add:
 
-You need four values from your Grafana Cloud stack: the Sigil API URL, an OTLP endpoint, an instance ID, and an access policy token.
+```dotenv
+SIGIL_CONTENT_CAPTURE_MODE=full
+```
 
-### Sigil API URL and Instance ID
+## 4. Verify
 
-In **Observability → AI Observability → Configuration** (`https://<stack>.grafana.net/plugins/grafana-sigil-app`), copy:
+Run any turn in Claude Code, then open **AI Observability → Conversations** in Grafana Cloud. A new generation should appear within a few seconds.
 
-- **API URL** → `SIGIL_ENDPOINT`. Looks like `https://sigil-prod-<region>.grafana.net`.
-- **Instance ID** → `SIGIL_AUTH_TENANT_ID`. Numeric stack ID. Used as Basic-auth username and the `X-Scope-OrgID` header.
-
-### Access policy token
-
-In **Administration → Users and access → Cloud access policies** (`https://<stack>.grafana.net/a/grafana-auth-app`), click **Create access policy**. One token covers both the generations channel and OTel:
-
-- **Scopes**: tick `metrics: Write` and `traces: Write`. Use **Add scope** to add `sigil:write`.
-- Click **Create**, then **Add token** on the new policy. Copy the `glc_…` token once — you can't view it again.
-
-This token → `SIGIL_AUTH_TOKEN`. The same value is reused for OTel auth.
-
-### OTLP endpoint
-
-The AI Observability UI relies on traces and metrics for latency charts, tool call breakdowns, and other panels. Without OTel configured, half the UI is empty — treat this as required.
-
-Open the **Grafana Cloud Portal**, click into your stack, and find the **OpenTelemetry** card. Copy:
-
-- **OTLP Endpoint URL** → `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT`. Looks like `https://otlp-gateway-prod-<region>.grafana.net/otlp`.
-
-## Configure
-
-The binary reads its config from the environment. The hook fires inside Claude Code's process, so anything in Claude Code's environment when it starts works.
-
-### Shell environment (recommended)
-
-Keeps tokens out of any global config file.
+If nothing shows up:
 
 ```sh
-export SIGIL_ENDPOINT=https://sigil-prod-us-central-0.grafana.net
-export SIGIL_AUTH_TENANT_ID=123456
-export SIGIL_AUTH_TOKEN=glc_...
-export SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-us-central-0.grafana.net/otlp
-export SIGIL_CONTENT_CAPTURE_MODE=full
-claude
+SIGIL_DEBUG=true claude  # one turn
+tail -f ~/.local/state/sigil/logs/sigil.log
 ```
 
-OTel auth defaults to `SIGIL_AUTH_TENANT_ID` (Basic-auth user) and `SIGIL_AUTH_TOKEN` (Basic-auth password). Override the password with `SIGIL_OTEL_AUTH_TOKEN` if you want a separate token.
+Common culprits: `sigil --version` doesn't work (binary not on `PATH`), a missing token, or a token without the `sigil:write` scope.
 
-### `~/.claude/settings.json` `env` block
+## All options
 
-Persistent across all Claude Code sessions.
+| Variable | Default | Description |
+|---|---|---|
+| `SIGIL_ENDPOINT` | — | Sigil API URL. Find it at `/plugins/grafana-sigil-app`. |
+| `SIGIL_AUTH_TENANT_ID` | — | Grafana Cloud instance ID. |
+| `SIGIL_AUTH_TOKEN` | — | `glc_…` Cloud Access Policy Token. |
+| `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the AI Observability latency and tool-call panels stay empty. |
+| `SIGIL_OTEL_AUTH_TOKEN` | `SIGIL_AUTH_TOKEN` | Override the OTel password. |
+| `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, or `full`. |
+| `SIGIL_TAGS` | — | `key=value,key=value` tags added to every generation. |
+| `SIGIL_USER_ID` | from `~/.claude.json` | Override the user id. |
+| `SIGIL_USER_ID_SOURCE` | `email` | Which field to read from `~/.claude.json`: `email` or `accountUuid`. |
+| `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
 
-```json
-{
-  "env": {
-    "SIGIL_ENDPOINT": "https://sigil-prod-us-central-0.grafana.net",
-    "SIGIL_AUTH_TENANT_ID": "123456",
-    "SIGIL_AUTH_TOKEN": "glc_...",
-    "SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT": "https://otlp-gateway-prod-us-central-0.grafana.net/otlp",
-    "SIGIL_CONTENT_CAPTURE_MODE": "full"
-  }
-}
-```
-
-### Dotenv fallback
-
-When Claude Code launches `sigil` under a stripped environment, the binary reads `$XDG_CONFIG_HOME/sigil/config.env` (default `~/.config/sigil/config.env`) and applies any unset values. Only `SIGIL_*` and a small set of `OTEL_*` keys are honoured.
-
-## Verify it worked
-
-Run any single turn:
-
-```sh
-claude  # ask it anything, then exit
-```
-
-Then either:
-
-- Check the Sigil UI under **Observability → AI Observability → Conversations**. A new generation should appear within seconds.
-- Or enable debug logging and tail the log:
-
-  ```sh
-  export SIGIL_DEBUG=true
-  claude  # one turn
-  tail -f "${XDG_STATE_HOME:-$HOME/.local/state}/sigil/logs/sigil.log"
-  ```
-
-If nothing appears, the most common causes are: `sigil` not on `$PATH` (run `sigil --version`), missing `SIGIL_ENDPOINT` / `SIGIL_AUTH_TENANT_ID` / `SIGIL_AUTH_TOKEN`, or a token without the `sigil:write` scope.
-
-## Environment variables
-
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `SIGIL_ENDPOINT` | yes | Sigil API URL from AI Observability → Configuration. |
-| `SIGIL_AUTH_TENANT_ID` | yes | Grafana Cloud stack/instance ID. Sent as Basic-auth username and `X-Scope-OrgID` header. |
-| `SIGIL_AUTH_TOKEN` | yes | `glc_…` access policy token with `sigil:write` (and `metrics:write` / `traces:write` if using OTel). [Access Policies docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/). |
-| `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | yes | OTLP HTTP endpoint for metrics and traces. Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT`. The plugin runs without it, but the AI Observability UI depends on these signals — half the panels are empty. |
-| `SIGIL_OTEL_AUTH_TOKEN` | no | OTel Basic-auth password. Defaults to `SIGIL_AUTH_TOKEN`. The OTel Basic-auth username is always `SIGIL_AUTH_TENANT_ID`. |
-| `SIGIL_OTEL_EXPORTER_OTLP_INSECURE` | no | `true` to disable TLS. Falls back to `OTEL_EXPORTER_OTLP_INSECURE`. Default: TLS enabled. |
-| `SIGIL_CONTENT_CAPTURE_MODE` | no | Content capture mode: `full`, `metadata_only`, `no_tool_content` (default: `metadata_only`). |
-| `SIGIL_TAGS` | no | Comma-separated `key=value` tags added to every generation. Built-in tags (`git.branch`, `cwd`, `entrypoint`, `subagent`) take precedence on collision. |
-| `SIGIL_USER_ID` | no | Explicit override for the per-generation user id. When set, it wins over `~/.claude.json` and ignores `SIGIL_USER_ID_SOURCE`. |
-| `SIGIL_USER_ID_SOURCE` | no | Field to read from `~/.claude.json` when `SIGIL_USER_ID` is unset: `email` (default) or `accountUuid`. |
-| `SIGIL_DEBUG` | no | Set to `true` to log to `$XDG_STATE_HOME/sigil/logs/sigil.log`. |
-
-## How It Works
-
-1. Claude Code fires `SessionStart` and persists the session model (used by tool hooks).
-2. Claude Code fires the Stop hook after each turn, passing `{session_id, transcript_path}` on stdin to `sigil claude-code hook`.
-3. The agent adapter loads the byte offset from the last run, reads new JSONL lines, maps assistant messages with token usage to Sigil Generation records, and exports via the sigil-sdk HTTP client.
-4. On successful flush, the new offset is persisted for the next invocation.
-
-The plugin also registers a `PreToolUse` hook that evaluates Sigil **postflight** guards against the tool call name. If a guard denies, the hook returns a Claude Code `permissionDecision: "deny"` and the tool call is blocked before execution.
-
-Each assistant API response becomes one Generation with model, tokens, tools, timestamps, tags, and conversation title. The hook always exits 0; telemetry is best-effort.
-
-## Content Capture
-
-Content capture is controlled by `SIGIL_CONTENT_CAPTURE_MODE` (default: `metadata_only`):
-
-| Mode | What's sent |
-|------|-------------|
-| `metadata_only` | Model, tokens, tool names, timestamps, tags. All text content stripped by the SDK. |
-| `full` | Full conversation content with automatic secret redaction (see below). |
-| `no_tool_content` | Full generation content but tool execution arguments/results excluded from spans. |
-
-When content is included (`full` or `no_tool_content`), automatic redaction is applied:
-
-- User prompts: Tier 1 redaction (known token formats)
-- Assistant text: Tier 1 redaction (known token formats)
-- Tool inputs/outputs: Tier 1 + Tier 2 redaction (tokens + env-file heuristics)
-- Thinking blocks: omitted (noted in metadata)
-
-## Development
-
-The Go code lives in [`../sigil/`](../sigil/). Use the root [`mise`](../../mise.toml) tasks for lint/format/test, or:
-
-```sh
-cd plugins/sigil
-GOWORK=off go test ./internal/agents/claudecode/...
-GOWORK=off go build ./cmd/sigil
-```
-
-Manual test:
-
-```sh
-echo '{"session_id":"test","transcript_path":"/path/to/session.jsonl"}' | \
-  SIGIL_ENDPOINT=https://sigil-prod-us-central-0.grafana.net \
-  SIGIL_AUTH_TENANT_ID=123 SIGIL_AUTH_TOKEN=glc_... \
-  sigil claude-code hook
-```
+If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>` manually instead of relying on the auto-synthesised auth.

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -1,331 +1,100 @@
-# sigil-codex: Codex plugin for Grafana Sigil
+# Sigil for Codex
 
-Forwards completed Codex generations, supported hook-visible tool calls, timing,
-best-effort subagent relationships, and optional content to
-[Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/).
-Backed by the consolidated [`sigil`](../sigil/) binary; this plugin only ships
-the hook manifest.
+Sends Codex turns to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/): model, tokens, tools, timing, and optionally the conversation content.
 
-## Status
+> Experimental. Codex hooks and plugin lifecycle config are still feature-flagged.
 
-This plugin is experimental while Codex hooks and plugin lifecycle config remain
-feature-flagged. The current public
-[Codex hooks documentation](https://developers.openai.com/codex/hooks) names
-the hook flag `codex_hooks`; some local Codex builds expose split `hooks` and
-`plugin_hooks` flags instead. Use `codex features list` to confirm the flag
-names for your installed Codex version.
-
-## Install
+## 1. Install
 
 ```sh
-go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
+brew install grafana/grafana/sigil
 ```
 
-`go install` drops the binary in `$GOBIN` (usually `~/go/bin`). The hook
-manifest invokes `sigil codex hook` directly, so make sure `$GOBIN` is on
-`PATH` for the shell that launches Codex. Verify with:
-
-```sh
-sigil --version
-```
-
-Then add the plugin marketplace:
+## 2. Register the plugin
 
 ```sh
 codex plugin marketplace add grafana/sigil-sdk
 ```
 
-Enable the plugin in `~/.codex/config.toml`:
+Enable it in `~/.codex/config.toml`:
 
 ```toml
 [plugins."sigil-codex@grafana-sigil"]
 enabled = true
-```
 
-If your Codex build exposes a plugin UI, you can enable
-`sigil-codex@grafana-sigil` there instead. The success check is the same:
-restart Codex, open `/hooks`, and confirm the hook source is
-`Plugin - sigil-codex@grafana-sigil`.
-
-The plugin registers Codex lifecycle hooks for you; no manual `~/.codex/hooks.json`
-file is needed.
-
-## Enable Codex plugin hooks
-
-Codex hook flags live in `~/.codex/config.toml`. Current
-[public docs](https://developers.openai.com/codex/hooks) show:
-
-```toml
 [features]
 codex_hooks = true
 ```
 
-Some Codex builds expose the equivalent capability as:
+Older Codex builds use `hooks = true` and `plugin_hooks = true` instead of `codex_hooks`. Run `codex features list` to see which flag names your build accepts.
 
-```toml
-[features]
-hooks = true
-plugin_hooks = true
-```
+Restart Codex, open `/hooks`, and trust the four `sigil-codex@grafana-sigil` hooks (first-run review is expected).
 
-Run `codex features list` and enable the hook/plugin hook flags your build
-reports. If Codex marks a hook feature as under development, you can hide that
-startup warning after intentionally enabling it with this top-level key:
+## 3. Add your credentials
 
-```toml
-suppress_unstable_features_warning = true
-```
+All Sigil connection details live at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure AI Observability is enabled on your stack — an administrator opens **Observability → AI Observability** once and accepts the terms.
 
-Restart Codex after changing `~/.codex/config.toml`.
+You need values from three Grafana Cloud pages:
 
-## Get your credentials from Grafana Cloud
+1. **AI Observability → Configuration**
+   - **API URL** → `SIGIL_ENDPOINT`
+   - **Instance ID** → `SIGIL_AUTH_TENANT_ID`
 
-Generation export needs three values from your Grafana Cloud stack: the Sigil
-API URL, an instance ID, and an access policy token. For the full AI
-Observability UI, also configure the OTLP endpoint so traces, latency charts,
-and tool-call panels populate.
+2. **Administration → Users and access → Cloud access policies**
+   - Create a policy with scopes `sigil:write`, `metrics:write`, `traces:write`.
+   - Add a token. The `glc_…` value is shown once → `SIGIL_AUTH_TOKEN`.
 
-### Sigil API URL and Instance ID
+3. **Grafana Cloud Portal → your stack → OpenTelemetry card**
+   - **OTLP endpoint URL** → `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT`
 
-In **Observability -> AI Observability -> Configuration**
-(`https://<stack>.grafana.net/plugins/grafana-sigil-app`), copy:
+Save them to `~/.config/sigil/config.env` (shared by all three host plugins):
 
-- **API URL** -> `SIGIL_ENDPOINT`. Looks like
-  `https://sigil-prod-<region>.grafana.net`.
-- **Instance ID** -> `SIGIL_AUTH_TENANT_ID`. Numeric stack ID. Used as the
-  Basic-auth username and tenant header.
-
-### Access policy token
-
-In **Administration -> Users and access -> Cloud access policies**
-(`https://<stack>.grafana.net/a/grafana-auth-app`), click **Create access
-policy**. One token can cover both the generations channel and OTel:
-
-- **Scopes**: add `sigil:write` and write scopes for traces, metrics and logs.
-- Click **Create**, then **Add token** on the new policy. Copy the `glc_...`
-  token once; Grafana Cloud will not show it again.
-
-This token -> `SIGIL_AUTH_TOKEN`. The same value is reused for OTel auth unless
-you set `SIGIL_OTEL_AUTH_TOKEN` yourself.
-
-### OTLP endpoint
-
-Generation export works without OTel, but the AI Observability UI relies on
-traces and metrics for latency charts, tool-call breakdowns, and other panels.
-Treat OTel as part of normal setup when you want the complete UI.
-
-Open the **Grafana Cloud Portal**, click into your stack, and find the
-**OpenTelemetry** card. Copy:
-
-- **OTLP Endpoint URL** -> `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT`. Looks like
-  `https://otlp-gateway-prod-<region>.grafana.net/otlp`.
-
-## Configure
-
-Configuration is read from environment variables and from a dotenv file at
-`${XDG_CONFIG_HOME:-$HOME/.config}/sigil/config.env`. OS env wins per-key; the
-file fills in unset keys. Codex hook subprocesses may not inherit your shell
-profile, so the file is the reliable place to put credentials. Keep
-`~/.codex/config.toml` for Codex feature flags and plugin enablement, not for
-Sigil credentials.
-
-The dotenv loader only imports `SIGIL_*` keys and the supported OTel keys
-documented below. It intentionally ignores unrelated process settings such as
-`PATH`.
-
-Create the file:
-
-```sh
-mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/sigil"
-chmod 700 "${XDG_CONFIG_HOME:-$HOME/.config}/sigil"
-cat > "${XDG_CONFIG_HOME:-$HOME/.config}/sigil/config.env" <<'EOF'
+```dotenv
 SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
-SIGIL_AUTH_TENANT_ID=<stack-instance-id>
-SIGIL_AUTH_TOKEN=<grafana-cloud-access-policy-token>
+SIGIL_AUTH_TENANT_ID=<instance-id>
+SIGIL_AUTH_TOKEN=glc_...
 SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
-EOF
-chmod 600 "${XDG_CONFIG_HOME:-$HOME/.config}/sigil/config.env"
 ```
 
-For local debugging or explicit content capture, add these lines to
-`config.env`:
+To also send the conversation text (with automatic secret redaction), add:
 
 ```dotenv
 SIGIL_CONTENT_CAPTURE_MODE=full
-SIGIL_DEBUG=true
 ```
 
-For normal use, omit `SIGIL_CONTENT_CAPTURE_MODE` so the plugin defaults to
-`metadata_only`. Use `full` when you intentionally want prompt, assistant,
-and tool content exported.
+## 4. Verify
 
-OTel auth defaults to `SIGIL_AUTH_TENANT_ID` as the Basic-auth username and
-`SIGIL_AUTH_TOKEN` as the Basic-auth password. Override the password with
-`SIGIL_OTEL_AUTH_TOKEN` if you want a separate token for traces and metrics.
-When `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` is set, the plugin passes that endpoint
-and synthesised Sigil auth directly to the OTel exporters, so inherited
-signal-specific OTel variables such as `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` do
-not override the Sigil destination.
+Run one turn in Codex and let it finish — the plugin only exports completed turns, so `/exit` mid-turn means nothing is sent. Then open **AI Observability → Conversations** in Grafana Cloud.
 
-| Variable | Required | Description |
-| --- | --- | --- |
-| `SIGIL_ENDPOINT` | yes | Sigil API URL. The plugin appends `/api/v1/generations:export`. |
-| `SIGIL_AUTH_TENANT_ID` | yes | Grafana Cloud stack/instance ID. Used as Basic-auth username and tenant header. |
-| `SIGIL_AUTH_TOKEN` | yes | Grafana Cloud token with `sigil:write`; also used to synthesise OTel Basic auth when needed. |
-| `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | for full UI | Base OTLP HTTP endpoint for traces and metrics. The plugin appends `/v1/traces` and `/v1/metrics`. Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT`. |
-| `SIGIL_OTEL_AUTH_TOKEN` | no | OTel Basic-auth password. Defaults to `SIGIL_AUTH_TOKEN`. |
-| `SIGIL_OTEL_EXPORTER_OTLP_INSECURE` | no | `true` to disable TLS. Falls back to `OTEL_EXPORTER_OTLP_INSECURE`. |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | no | Plain OTel endpoint fallback if the Sigil-prefixed endpoint is unset. |
-| `OTEL_EXPORTER_OTLP_HEADERS` | no | Plain OTel headers. If no authorization header is present, the plugin synthesises Basic auth from Sigil credentials. |
-| `OTEL_EXPORTER_OTLP_INSECURE` | no | Plain OTel TLS toggle fallback. |
-| `OTEL_SERVICE_NAME` | no | OTel service name. Defaults to `sigil` when unset. |
-| `SIGIL_CONTENT_CAPTURE_MODE` | no | `metadata_only`, `full`, or `no_tool_content`. Default: `metadata_only`. |
-| `SIGIL_TAGS` | no | Comma-separated `key=value` tags added by the SDK. |
-| `SIGIL_USER_ID` | no | User id override read by the SDK. |
-| `SIGIL_DEBUG` | no | `true` writes logs under `$XDG_STATE_HOME/sigil/logs/sigil.log`. |
-
-Without `SIGIL_ENDPOINT`, `SIGIL_AUTH_TENANT_ID`, or `SIGIL_AUTH_TOKEN`, hooks
-still run and discard the current fragment without emitting telemetry.
-
-## Content Capture
-
-| Mode | User prompt | Assistant text | Tool args/results | Reasoning |
-| --- | --- | --- | --- | --- |
-| `metadata_only` | stripped | stripped | tool names/status only; raw args/results dropped | omitted |
-| `no_tool_content` | included | included | tool names/status only; raw args/results dropped | omitted |
-| `full` | included with redaction | included with redaction | included with redaction | omitted |
-
-In `full` and `no_tool_content`, allowed prompt and assistant text can be stored
-raw in local fragment files until the turn exports or stale cleanup removes the
-fragment. Files are written with `0600` permissions. Redaction happens before
-data is sent to Sigil.
-
-## How It Works
-
-Codex invokes `SessionStart`, `UserPromptSubmit`, `PostToolUse`, and `Stop`
-hooks. The agent adapter stores a lightweight per-turn fragment under
-`$XDG_STATE_HOME/sigil/codex` (default `~/.local/state/sigil/codex`), then
-flushes one generation on `Stop`. Relative `XDG_CONFIG_HOME` and
-`XDG_STATE_HOME` values are ignored; config and state paths are always
-absolute. Session and turn ids are sanitised and hashed before becoming
-filenames so similar ids cannot collide on disk.
-
-When Codex spawns a subagent, current hook payloads do not provide a stable
-parent id. The plugin therefore performs a metadata-only lookup in Codex's
-local transcripts. If the child transcript says it is a subagent and the parent
-transcript contains the matching `spawn_agent` output, Sigil receives the child
-as `agent_name=codex/subagent` with a parent-generation edge. If only the child
-side can be proven, the generation is still labeled `codex/subagent` but
-remains in the child conversation with partial-link metadata. If the transcript
-shape is missing or changes, the plugin exports the turn normally rather than
-failing the Codex session.
-
-`Stop` is the completed-turn boundary. If you exit after a turn finishes, the
-generation should already be exported. If you exit or interrupt while Codex is
-still thinking, Codex may not send `Stop`, and that incomplete turn is not
-exported by this plugin. The exported generation includes a
-`codex.stop_hook_active` tag so reviewers can tell whether the `Stop` hook fired
-while Codex was already continuing from another Stop hook.
-
-Do not combine this plugin with another `Stop` hook that continues the same
-turn with `decision: "block"` or `continue: false` behaviour. Codex launches
-matching command hooks concurrently, so the hook cannot delay export after
-another Stop hook decides to keep the turn going. That setup can create partial
-or duplicate Sigil generations.
-
-Interrupted turns can leave local state under
-`${XDG_STATE_HOME:-$HOME/.local/state}/sigil/codex`. The `turns/` directory can
-contain incomplete turn fragments; in `full` or `no_tool_content` mode, those
-fragments can contain the content allowed by that mode. The `sessions/`
-directory contains session metadata such as cwd, model, source, and transcript
-path. The `subagents/` directory contains metadata-only child-to-parent link
-files. The plugin performs best-effort cleanup of session, turn, and subagent
-link files older than 24 hours on later hook invocations. It does not retry or
-replay interrupted turns.
-
-The hook always exits successfully. Sigil export failures after credentials are
-present keep the current fragment only until stale cleanup; missing credentials
-are treated as local configuration absence and discard the current fragment.
-Stop export is bounded below the Codex hook timeout and uses a reduced retry
-budget so a down Sigil endpoint fails cleanly instead of leaving Codex waiting
-on long SDK backoff.
-
-Codex hook payloads do not place token counts directly in hook stdin, but they
-can include `transcript_path`. On `Stop`, the plugin reads the Codex rollout
-JSONL at that path and looks for `event_msg` records whose payload type is
-`token_count`. It attributes those records by the active `turn_context.turn_id`
-and computes Sigil generation usage from the completed turn's cumulative
-`total_token_usage` delta, not from `last_token_usage`. That avoids
-undercounting turns that make more than one model sampling call before `Stop`.
-If Codex emits a `token_count` immediately after `turn_context` but before any
-assistant model activity, the plugin treats it as the resumed-thread baseline
-rather than usage for the new turn. If the rollout is missing, malformed,
-oversized, or cannot be attributed unambiguously, the generation still exports
-without usage.
-
-When usage is available, the plugin sets Sigil `Generation.Usage` fields for
-input, output, total, cache-read, and reasoning tokens. It stores final
-cumulative totals and context window as generation metadata, not tags, to avoid
-high-cardinality tag values. The plugin does not calculate monetary cost; cost
-should be derived downstream from the provider, model, and token counts when
-pricing metadata is available.
-
-Current documented payloads do not provide a generic tool status or duration
-field [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks).
-Tool status is marked as an error only when Codex provides an explicit
-error/status field or a known response shape such as a non-zero `exit_code`;
-otherwise the status is left unknown. Codex `PostToolUse` currently covers
-supported hook tools such as Bash, `apply_patch`, and MCP calls; it does not
-cover every shell execution path, WebSearch, or other non-shell, non-MCP tools.
-
-## Verify it worked
-
-Start a fresh Codex session after changing plugin or config files:
+If nothing shows up:
 
 ```sh
-codex
+SIGIL_DEBUG=true codex  # one turn
+tail -f ~/.local/state/sigil/logs/sigil.log
 ```
 
-Open `/hooks`. A first install should show four hooks with source:
+## All options
 
-```text
-Plugin - sigil-codex@grafana-sigil
-```
+| Variable | Default | Description |
+|---|---|---|
+| `SIGIL_ENDPOINT` | — | Sigil API URL. Find it at `/plugins/grafana-sigil-app`. |
+| `SIGIL_AUTH_TENANT_ID` | — | Grafana Cloud instance ID. |
+| `SIGIL_AUTH_TOKEN` | — | `glc_…` Cloud Access Policy Token. |
+| `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the AI Observability latency and tool-call panels stay empty. |
+| `SIGIL_OTEL_AUTH_TOKEN` | `SIGIL_AUTH_TOKEN` | Override the OTel password. |
+| `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, or `full`. |
+| `SIGIL_TAGS` | — | `key=value,key=value` tags added to every generation. |
+| `SIGIL_USER_ID` | — | Override the user id. |
+| `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
 
-Review and trust the `SessionStart`, `UserPromptSubmit`, `PostToolUse`, and
-`Stop` hooks. That trust prompt is expected. Hook trust is hash-based, so Codex
-will ask again if the plugin hook manifest changes.
-
-Run one turn that uses a shell command, then let the turn finish normally so
-the `Stop` hook can flush. It is fine to `/exit` after the assistant has
-completed the response. Check **Observability -> AI Observability ->
-Conversations** in Grafana Cloud; a new Codex generation should appear within
-seconds.
-
-To verify subagent linkage, run a prompt that asks Codex to spawn and wait for
-a small subagent. When the parent/child transcript metadata is available, Sigil
-should show a parent `codex` generation and a child `codex/subagent` generation
-connected by a parent-generation edge.
-
-If `SIGIL_DEBUG=true` is set, you can also verify local hook activity with:
-
-```sh
-tail -n 50 "${XDG_STATE_HOME:-$HOME/.local/state}/sigil/logs/sigil.log"
-```
-
-Expected log evidence includes `dispatch: event=UserPromptSubmit`,
-`dispatch: event=PostToolUse`, `dispatch: event=Stop`, and
-`stop: emitted session=...`.
+If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>` manually instead of relying on the auto-synthesised auth.
 
 ## Troubleshooting
 
-| Symptom | Check |
-| --- | --- |
-| `/hooks` is empty | Run `codex features list`, enable the hook/plugin hook flags for your Codex build, enable `plugins."sigil-codex@grafana-sigil"`, then restart Codex. |
-| Hooks are installed but inactive | Open `/hooks`, review each hook, and trust it. First-run review is expected. |
-| Hook command cannot run | Install the binary with `go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest`, and confirm `sigil --version` works in a fresh terminal. |
-| No Sigil data appears | Let a turn finish normally so `Stop` runs, check the debug log, and verify `SIGIL_ENDPOINT`, `SIGIL_AUTH_TENANT_ID`, and `SIGIL_AUTH_TOKEN` are set in `${XDG_CONFIG_HOME:-$HOME/.config}/sigil/config.env` or process env. |
-| Data appears for completed turns but not interrupted ones | This is expected: Codex does not send `Stop` for a turn interrupted before completion. Stale local state is removed after 24 hours by later hook invocations. |
-| A subagent appears as a normal Codex turn | The plugin could not prove the child -> parent relationship from local transcript metadata. The turn still exports; check debug logs for `subagent:` messages if `SIGIL_DEBUG=true`. |
-| A subagent appears as `codex/subagent` but is not connected to the parent | The child transcript proved it was a subagent, but the parent turn or `spawn_agent` output was unavailable. The generation remains visible with partial-link metadata. |
-| Under-development feature warning appears | Set top-level `suppress_unstable_features_warning = true` after intentionally enabling `plugin_hooks`. |
+| Symptom | Try |
+|---|---|
+| `/hooks` is empty | Enable the hook feature flags (`codex features list`), enable `plugins."sigil-codex@grafana-sigil"`, restart Codex. |
+| Hooks listed but inactive | Open `/hooks` and trust each one. |
+| Command not found | Reinstall: `brew install grafana/grafana/sigil`. Check `sigil --version`. |
+| No data appears | Let turns finish (interrupted turns are not exported). Then check the debug log. |
+| Subagent appears as a normal turn | Codex hook payloads don't always carry the parent link. Known limitation. |

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -1,121 +1,76 @@
-# sigil-cursor — Cursor → Grafana Sigil plugin
+# Sigil for Cursor
 
-Forwards Cursor agent generations (prompts, assistant replies, tool calls,
-token usage) to Grafana Sigil for AI observability. Backed by the
-consolidated [`sigil`](../sigil/) binary; this plugin only ships the hook
-manifest and a wrapper script.
+Sends Cursor agent generations to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/): prompts, replies, tool calls, and token usage.
 
-## Install
-
-Cursor's hook runtime does not manage dependencies. Install the binary
-yourself:
+## 1. Install
 
 ```sh
-go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
+brew install grafana/grafana/sigil
 ```
 
-This places `sigil` in `$GOBIN` (default `$HOME/go/bin`). The wrapper at
-[`plugins/cursor/scripts/run.sh`](scripts/run.sh)
-probes `$SIGIL_BIN`, `$HOME/go/bin/sigil`, `/opt/homebrew/bin/sigil`,
-`/usr/local/bin/sigil`, and `$HOME/.local/bin/sigil` to find it under
-Cursor's stripped hook environment.
+## 2. Register the plugin
 
-Then register the plugin in Cursor:
+In Cursor:
 
 ```
 /add-plugin grafana/sigil-sdk
 ```
 
-## Configure
+## 3. Add your credentials
 
-Configuration is read from environment variables and from a dotenv file at
-`${XDG_CONFIG_HOME:-$HOME/.config}/sigil/config.env`. OS env wins
-per-key; the file fills in unset keys. Cursor runs hooks under a clean
-process environment that does not inherit your shell profile, so the file
-is the reliable place to put credentials.
+All Sigil connection details live at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure AI Observability is enabled on your stack — an administrator opens **Observability → AI Observability** once and accepts the terms.
 
-The Sigil and OTel env-var schemas come from the SDKs, not this plugin:
+You need values from three Grafana Cloud pages:
 
-- `SIGIL_*` — read by the Sigil Go SDK
-  ([`go/sigil/env.go`](../../go/sigil/env.go)).
-- `OTEL_EXPORTER_OTLP_*` — read by the OpenTelemetry Go SDK exporters.
+1. **AI Observability → Configuration**
+   - **API URL** → `SIGIL_ENDPOINT`
+   - **Instance ID** → `SIGIL_AUTH_TENANT_ID`
 
-| Variable | Required | Purpose |
-|---|---|---|
-| `SIGIL_ENDPOINT` | yes | Sigil API URL, for example `https://sigil-prod-<region>.grafana.net`. |
-| `SIGIL_AUTH_TENANT_ID` | yes | Grafana Cloud stack/instance ID. Used as Basic-auth username and the `X-Scope-OrgID` header. |
-| `SIGIL_AUTH_TOKEN` | yes | `glc_…` Cloud access policy token with the `sigil:write` scope. |
-| `SIGIL_TAGS` | no | Comma-separated `k=v` pairs added to every generation. Built-ins (`git.branch`, `cwd`, `subagent`) win on collision. |
-| `SIGIL_CONTENT_CAPTURE_MODE` | no | `full`, `no_tool_content`, or `metadata_only` (default). |
-| `SIGIL_USER_ID` | no | Override the per-generation user id (default: `user_email` from Cursor's payload). |
-| `SIGIL_DEBUG` | no | `true` writes a log to `$XDG_STATE_HOME/sigil/logs/sigil.log`. |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | yes | OTLP HTTP endpoint for traces and metrics. The plugin runs without it, but the AI Observability UI depends on these signals; half the panels are empty without them. |
-| `OTEL_EXPORTER_OTLP_HEADERS` | no | Extra OTLP headers (CSV `k=v`). When `Authorization` is missing the plugin synthesises `Authorization=Basic base64(SIGIL_AUTH_TENANT_ID:SIGIL_AUTH_TOKEN)` so the OTel SDK exporter picks it up. |
-| `OTEL_EXPORTER_OTLP_INSECURE` | no | Standard OTel toggle. `true` disables TLS for the OTLP endpoint. |
-| `SIGIL_BIN` | no | Override the binary path used by the wrapper script. |
+2. **Administration → Users and access → Cloud access policies**
+   - Create a policy with scopes `sigil:write`, `metrics:write`, `traces:write`.
+   - Add a token. The `glc_…` value is shown once → `SIGIL_AUTH_TOKEN`.
 
-Without `SIGIL_ENDPOINT` / `SIGIL_AUTH_TENANT_ID` / `SIGIL_AUTH_TOKEN`,
-hooks still run but nothing is emitted to Sigil.
+3. **Grafana Cloud Portal → your stack → OpenTelemetry card**
+   - **OTLP endpoint URL** → `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT`
 
-### Where to find these values
+Save them to `~/.config/sigil/config.env` (shared by all three host plugins):
 
-- `SIGIL_ENDPOINT` — Grafana Cloud → AI Observability → Configuration,
-  **API URL** field.
-- `SIGIL_AUTH_TENANT_ID` — Grafana Cloud → AI Observability →
-  Configuration, **Instance ID** field. Numeric Grafana Cloud stack id.
-- `SIGIL_AUTH_TOKEN` — a Grafana Cloud access policy token (grafana.com →
-  Security → Access Policies), with the realm set to the stack's region.
-  Required scope: `sigil:write`. Add `metrics:write`, `metrics:import`,
-  and `traces:write` when also setting `OTEL_EXPORTER_OTLP_ENDPOINT` —
-  one token can cover both channels.
-- `OTEL_EXPORTER_OTLP_ENDPOINT` — Grafana Cloud → your stack →
-  OpenTelemetry card, **OTLP Endpoint URL**. The OTLP gateway region is
-  tied to the stack's region, which can differ from the Sigil region.
+```dotenv
+SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
+SIGIL_AUTH_TENANT_ID=<instance-id>
+SIGIL_AUTH_TOKEN=glc_...
+SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
+```
 
-## Content capture
+To also send the conversation text (with automatic secret redaction), add:
 
-| Mode | User prompt | Assistant text | Thinking | Tool args / results |
-|---|---|---|---|---|
-| `full` | included | included | presence-only | included |
-| `no_tool_content` | included | included | presence-only | structure kept, content stripped |
-| `metadata_only` (default) | stripped | stripped | presence-only | stripped |
+```dotenv
+SIGIL_CONTENT_CAPTURE_MODE=full
+```
 
-Thinking content is never exported regardless of mode — only
-`thinking_enabled: true` is set on the Generation.
+## 4. Verify
 
-## Built-in tags
+Use Cursor's agent for one turn, then open **AI Observability → Conversations** in Grafana Cloud. A new generation should appear within a few seconds.
 
-The plugin sets these tags automatically; user values from `SIGIL_TAGS`
-lose to built-ins on key collision (the SDK applies `SIGIL_TAGS` as the
-client-level base layer; the plugin sets built-ins per-generation, which
-override on the same key):
-
-- `git.branch` — best-effort branch resolution. Walks up to 6 parent
-  directories from the workspace root looking for a `.git` entry; follows
-  `gitdir: <path>` indirection used by worktrees and submodules; reads
-  HEAD from the resolved git directory. Returns the branch name on a
-  symbolic ref, the first 12 hex chars on detached HEAD, or nothing on
-  failure.
-- `cwd` — first `cwd` observed in `postToolUse`, falling back to the first
-  workspace root.
-- `subagent` — `"true"` for background-agent runs.
-- `entrypoint` — never auto-populated. Set via `SIGIL_TAGS` if you want
-  a value here. Cursor's `composer_mode` is **not** auto-mapped; the
-  equivalence has not been validated.
-
-## How it works
-
-Per-generation state is buffered on disk under
-`$XDG_STATE_HOME/sigil/cursor/<conversation>/gen-<generation>.json` (mode
-`0600`) until the `stop` event flushes it to Sigil. `sessionEnd` removes
-any stranded fragments left by crashed turns.
-
-## Development
-
-The Go code lives in [`../sigil/`](../sigil/). Use the root [`mise`](../../mise.toml) tasks for lint/format/test, or:
+If nothing shows up, add `SIGIL_DEBUG=true` to `~/.config/sigil/config.env` (Cursor launches from the GUI, so a shell env var won't reach the hooks) and tail the log:
 
 ```sh
-cd plugins/sigil
-GOWORK=off go test ./internal/agents/cursor/...
-GOWORK=off go build ./cmd/sigil
+tail -f ~/.local/state/sigil/logs/sigil.log
 ```
+
+## All options
+
+| Variable | Default | Description |
+|---|---|---|
+| `SIGIL_ENDPOINT` | — | Sigil API URL. Find it at `/plugins/grafana-sigil-app`. |
+| `SIGIL_AUTH_TENANT_ID` | — | Grafana Cloud instance ID. |
+| `SIGIL_AUTH_TOKEN` | — | `glc_…` Cloud Access Policy Token. |
+| `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the AI Observability latency and tool-call panels stay empty. |
+| `SIGIL_OTEL_AUTH_TOKEN` | `SIGIL_AUTH_TOKEN` | Override the OTel password. |
+| `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, or `full`. |
+| `SIGIL_TAGS` | — | `key=value,key=value` tags added to every generation. Built-ins (`git.branch`, `cwd`, `subagent`) win on collision. |
+| `SIGIL_USER_ID` | from Cursor | Override the user id. |
+| `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
+| `SIGIL_BIN` | auto | Override the binary path if you installed `sigil` somewhere unusual. |
+
+If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>` manually instead of relying on the auto-synthesised auth.

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -1,33 +1,33 @@
 # @grafana/sigil-opencode
 
-OpenCode plugin that records LLM generations to Grafana Sigil for AI observability.
+OpenCode plugin that sends LLM generations to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/).
 
-## What it does
-
-Hooks into OpenCode's chat lifecycle to capture assistant messages and send them to Sigil as generation telemetry. Tracks conversation context, tool usage, model metadata, and optionally full message content with PII redaction.
+By default only metadata is sent (model, tokens, tool names, timing). Flip `contentCapture` to `true` to also send message content (with automatic secret redaction).
 
 ## Setup
 
 1. Create `~/.config/opencode/opencode-sigil.json`:
 
-```json
-{
-  "enabled": true,
-  "endpoint": "http://localhost:8080",
-  "auth": { "mode": "none" },
-  "agentName": "opencode",
-  "contentCapture": true
-}
-```
+   ```json
+   {
+     "enabled": true,
+     "endpoint": "http://localhost:8080",
+     "auth": { "mode": "none" },
+     "agentName": "opencode",
+     "contentCapture": true
+   }
+   ```
+
+   For Grafana Cloud, set `endpoint` to your Sigil API URL (found at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`) and use `basic` auth — see the modes below.
 
 2. Register the plugin in your OpenCode configuration.
 
 ### Auth modes
 
-- `none` -- no authentication (local dev)
-- `bearer` -- `{ "mode": "bearer", "bearerToken": "..." }`
-- `tenant` -- `{ "mode": "tenant", "tenantId": "..." }`
-- `basic` -- `{ "mode": "basic", "tenantId": "...", "token": "..." }`
+- `none` — no authentication (local dev)
+- `bearer` — `{ "mode": "bearer", "bearerToken": "..." }`
+- `tenant` — `{ "mode": "tenant", "tenantId": "..." }`
+- `basic` — `{ "mode": "basic", "tenantId": "<instance-id>", "token": "glc_..." }`
 
 ## Development
 

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -1,138 +1,114 @@
 # @grafana/sigil-pi
 
-[Pi](https://github.com/badlogic/pi) agent extension that records LLM generations to Grafana AI observability.
+[Pi](https://github.com/badlogic/pi) agent extension that sends LLM generations to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/).
 
-By default only metadata is sent (token counts, cost, model, tool names, durations). Set `contentCapture` to `full` or `no_tool_content` to include message content.
+By default only metadata is sent (token counts, cost, model, tool names, durations). Flip `contentCapture` to `full` or `no_tool_content` to include message content.
 
-## Install
+## 1. Install
 
-**Directly via pi**:
-
-```bash
+```sh
 pi install npm:@grafana/sigil-pi
 ```
 
-**Via the [sigil launcher](../sigil/README.md)** (auto-bootstraps on first run):
+Or use the [sigil launcher](../sigil/README.md) which installs the extension on first run:
 
-```bash
+```sh
+brew install grafana/grafana/sigil
 sigil pi
 ```
 
-The launcher installs Sigil plugin once if the extension isn't registered yet. Subsequent runs skip the install.
+## 2. Add your Grafana Cloud credentials
 
-## Grafana Cloud credentials
+All Sigil connection details live at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Skip this section if you're running against a self-hosted Sigil — see [Auth modes](#auth-modes) below.
 
-Skip this if you're not using Grafana Cloud — see [Auth modes](#auth-modes) for `tenant` / `bearer` / `none`.
+You need values from three Grafana Cloud pages:
 
-The same Instance ID and access token are used for both Sigil and OTLP. OTLP is required for the AI Observability UI's latency, tool-call, and throughput panels.
+1. **AI Observability → Configuration**
+   - **API URL** → `endpoint`
+   - **Instance ID** → `auth.user` and `otlp.basicUser`
 
-1. **API URL and Instance ID** — in **Observability → AI Observability → Configuration**:
-   - **API URL** → `endpoint` (e.g. `https://sigil-prod-<region>.grafana.net`)
-   - **Instance ID** → `auth.user` and `otlp.basicUser` (numeric stack ID)
-2. **Access policy token** — in **Administration → Cloud access policies**, create a policy with scopes `metrics:write`, `traces:write`, and `sigil:write`, then add a token. The `glc_…` value is shown once — goes into `auth.password` and `otlp.basicPassword`.
-3. **OTLP endpoint** — Cloud Portal → your stack → **OpenTelemetry** card. Copy the OTLP endpoint URL → `otlp.endpoint` (e.g. `https://otlp-gateway-prod-<region>.grafana.net/otlp`).
+2. **Administration → Users and access → Cloud access policies**
+   - Create a policy with scopes `sigil:write`, `metrics:write`, `traces:write`.
+   - Add a token. The `glc_…` value is shown once → `auth.password` and `otlp.basicPassword`.
 
-## Configure
+3. **Grafana Cloud Portal → your stack → OpenTelemetry card**
+   - **OTLP endpoint URL** → `otlp.endpoint`
+
+## 3. Configure
 
 Create `~/.config/sigil-pi/config.json`:
 
 ```json
 {
-  "endpoint": "https://sigil.example.com",
+  "endpoint": "https://sigil-prod-<region>.grafana.net",
   "auth": {
     "mode": "basic",
-    "user": "123456",
+    "user": "<instance-id>",
     "password": "${SIGIL_AUTH_TOKEN}"
   },
   "otlp": {
-    "endpoint": "https://otlp-gateway.grafana.net/otlp",
-    "basicUser": "123456",
+    "endpoint": "https://otlp-gateway-prod-<region>.grafana.net/otlp",
+    "basicUser": "<instance-id>",
     "basicPassword": "${SIGIL_AUTH_TOKEN}"
   }
 }
 ```
 
-String values support `${ENV_VAR}` interpolation.
+String values support `${ENV_VAR}` interpolation, so the token stays out of the file.
+
+To include conversation text (with automatic secret redaction), add `"contentCapture": "full"` to the config.
 
 ### Auth modes
 
-- **basic** — HTTP Basic + `X-Scope-OrgID` (Grafana Cloud): `{ "mode": "basic", "user": "<instance-id>", "password": "${SIGIL_AUTH_TOKEN}" }`
-- **tenant** — `X-Scope-OrgID` only: `{ "mode": "tenant", "tenantId": "my-tenant" }`
-- **bearer** — `Authorization: Bearer`: `{ "mode": "bearer", "bearerToken": "${SIGIL_TOKEN}" }`
-- **none** — no auth (default)
+- `basic` — Grafana Cloud: `{ "mode": "basic", "user": "<instance-id>", "password": "${SIGIL_AUTH_TOKEN}" }`
+- `tenant` — `X-Scope-OrgID` only: `{ "mode": "tenant", "tenantId": "my-tenant" }`
+- `bearer` — `{ "mode": "bearer", "bearerToken": "${SIGIL_TOKEN}" }`
+- `none` — no auth (default)
 
-### Redaction
+## Redaction
 
-Generations are scrubbed for secrets before they leave the process; matches become `[REDACTED:<id>]`. The sanitizer covers Grafana Cloud / cloud provider / SaaS tokens, PEM-encoded private keys, database connection strings, `KEY=value` env-style pairs, bearer tokens, and email addresses.
+Before any generation leaves the process, the SDK scrubs known token formats, PEM private keys, database URLs, `KEY=value` pairs, bearer tokens, and email addresses. Matches become `[REDACTED:<id>]`.
 
-User-role messages are scrubbed too — set `redaction.redactInputMessages: false` to leave them alone, or `redaction.enabled: false` to disable redaction entirely.
+User-role messages are scrubbed too. Set `redaction.redactInputMessages: false` to leave them alone, or `redaction.enabled: false` to disable redaction entirely.
 
-### Guards
+## Guards
 
-Guards let you block tool calls before they execute — for example, refusing a `bash` invocation when the command matches a deny rule.
-
-Guards are **disabled by default** and must be turned on explicitly:
+Guards block tool calls before they execute (e.g. refuse a `bash` invocation matching a deny rule). They're off by default:
 
 ```sh
 SIGIL_GUARDS_ENABLED=true pi
 ```
 
-Behavior:
+By default, transport errors and timeouts let the tool through. Set `SIGIL_GUARDS_FAIL_OPEN=false` to block on errors instead.
 
-- Phase is hardcoded to `postflight` (pi's `tool_call` fires after the assistant message but before the tool runs).
-- Fail-open by default — transport errors, timeouts, and unexpected exceptions allow the tool through. Set `SIGIL_GUARDS_FAIL_OPEN=false` to block the tool instead.
-
-### Options
+## All options
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `endpoint` | — | Sigil URL |
+| `endpoint` | — | Sigil URL (find it at `/plugins/grafana-sigil-app`) |
 | `auth.mode` | `"none"` | `basic`, `tenant`, `bearer`, or `none` |
 | `auth.user` / `auth.password` | — | Basic auth credentials |
-| `auth.tenantId` | `auth.user` in basic mode | `X-Scope-OrgID` header (required in `tenant` mode) |
-| `auth.bearerToken` | — | Required in `bearer` mode |
+| `auth.tenantId` | `auth.user` in basic mode | `X-Scope-OrgID` header |
+| `auth.bearerToken` | — | Bearer token |
 | `agentName` | `"pi"` | Agent name reported to Sigil |
-| `agentVersion` | auto-detected | Pi agent version |
 | `contentCapture` | `"metadata_only"` | `full`, `no_tool_content`, or `metadata_only` |
 | `debug` | `false` | Log lifecycle events to stderr |
 | `otlp.endpoint` | — | OTLP HTTP endpoint |
 | `otlp.basicUser` / `otlp.basicPassword` | — | OTLP Basic auth |
 | `otlp.bearerToken` | — | OTLP Bearer token |
-| `otlp.headers` | — | Custom OTLP headers |
 | `redaction.enabled` | `true` | Master switch for redaction |
 | `redaction.redactInputMessages` | `true` | Scrub user-role content too |
-| `redaction.redactEmailAddresses` | `true` | Scrub generic email addresses |
-| `guards.enabled` | `false` | Opt-in to request-path policy checks. When true, every `tool_call` is evaluated by Sigil; a `deny` blocks the tool with the server-provided reason |
-| `guards.timeoutMs` | `1500` | Per-call timeout for the guard request in milliseconds |
-| `guards.failOpen` | `true` | When true, transport errors/timeouts allow the tool through. When false, the tool is blocked with a guard-evaluation-failed reason. |
+| `guards.enabled` | `false` | Evaluate `tool_call` requests against Sigil policy |
+| `guards.timeoutMs` | `1500` | Per-call timeout for guard requests |
+| `guards.failOpen` | `true` | Allow tools through when guard checks fail |
 
-### Environment variables
-
-Any field can be overridden via env var. When launched via `sigil pi`, vars in `~/.config/sigil/config.env` are loaded automatically.
+Every field can be overridden via env var. When launched via `sigil pi`, vars in `~/.config/sigil/config.env` are loaded automatically.
 
 | Variable | Sets |
 |----------|------|
 | `SIGIL_ENDPOINT` | `endpoint` |
-| `SIGIL_AUTH_TENANT_ID` + `SIGIL_AUTH_TOKEN` | Basic auth for Sigil and OTLP (Grafana Cloud pattern) |
-| `SIGIL_AGENT_NAME` / `SIGIL_AGENT_VERSION` | `agentName` / `agentVersion` |
+| `SIGIL_AUTH_TENANT_ID` + `SIGIL_AUTH_TOKEN` | Basic auth for Sigil and OTLP |
 | `SIGIL_CONTENT_CAPTURE_MODE` | `contentCapture` |
 | `SIGIL_DEBUG` | `debug` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `otlp.endpoint` |
-| `SIGIL_OTEL_AUTH_TOKEN` | OTLP basic-auth password (falls back to `SIGIL_AUTH_TOKEN`) |
 | `SIGIL_GUARDS_ENABLED` | `guards.enabled` |
-| `SIGIL_GUARDS_TIMEOUT_MS` | `guards.timeoutMs` (integer milliseconds) |
-| `SIGIL_GUARDS_FAIL_OPEN` | `guards.failOpen` |
-
-Explicit `auth.mode` in the config file always wins over env-derived auth.
-
-## What gets sent
-
-Every generation carries model, token usage (input/output/cache), cost, stop reason, tool names and durations, conversation ID, and turn timing. Message content depends on `contentCapture`:
-
-| Mode | Adds |
-|------|------|
-| `metadata_only` (default) | nothing — content is stripped by the SDK |
-| `no_tool_content` | assistant text and thinking |
-| `full` | assistant text, thinking, tool call arguments, tool results |
-
-When `otlp` is configured, the SDK also exports `gen_ai.client.operation.duration`, `gen_ai.client.token.usage`, and `gen_ai.client.tool_calls_per_operation` histograms (labelled by provider/model/agent) plus one trace span per generation. Resource `service.name` is `sigil-pi`.

--- a/plugins/sigil/README.md
+++ b/plugins/sigil/README.md
@@ -1,95 +1,33 @@
-# sigil — single binary for the Claude Code, Codex, Cursor, and pi agent plugins
+# sigil
 
-`sigil` is one Go binary that backs the agent plugins (`plugins/claude-code`, `plugins/codex`, `plugins/cursor`, `plugins/pi`) in this repository. The dispatcher accepts:
-
-```
-sigil <agent> hook         # process a JSON hook payload on stdin for <agent>
-sigil claude [-- args...]  # bootstrap the sigil-cc plugin, then exec claude
-sigil pi [-- args...]      # bootstrap the @grafana/sigil-pi extension, then exec pi
-sigil --version            # print the build version
-```
-
-where `<agent>` is `claude-code`, `codex`, or `cursor`.
+The hook binary behind the [Claude Code](../claude-code), [Codex](../codex), and [Cursor](../cursor) plugins for [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/).
 
 ## Install
 
 ```sh
-go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
+brew install grafana/grafana/sigil
 ```
 
-The binary lands in `$GOBIN`, or `$(go env GOPATH)/bin` if `GOBIN` is unset — typically `$HOME/go/bin/sigil`. Make sure that directory is on `PATH`; the Claude Code and Codex hook manifests invoke `sigil <agent> hook` directly. The Cursor wrapper at `plugins/cursor/scripts/run.sh` probes common install paths because Cursor's GUI launch strips `PATH` — set `SIGIL_BIN` there to override.
+## Configure
 
-## Configuration
+All three hosts read the same config file. Save this to `~/.config/sigil/config.env`:
 
-The binary reads its configuration from environment variables. When the agent launches hooks under a stripped environment (notably Cursor and Codex headless mode), the binary loads the dotenv file at `$XDG_CONFIG_HOME/sigil/config.env` and applies any keys that are unset in the OS env.
-
-### Required for generation export
-
-```
-SIGIL_ENDPOINT          # e.g. https://sigil.example.com
-SIGIL_AUTH_TENANT_ID    # tenant identifier
-SIGIL_AUTH_TOKEN        # bearer/basic password for export
+```dotenv
+SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
+SIGIL_AUTH_TENANT_ID=<instance-id>
+SIGIL_AUTH_TOKEN=glc_...
+SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
 ```
 
-### Optional
+Find these values in Grafana Cloud at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`.
 
-```
-SIGIL_CONTENT_CAPTURE_MODE   # default metadata_only; set to "full" to include content (with redaction)
-SIGIL_TAGS                   # k=v,k=v applied to every generation
-SIGIL_USER_ID                # override auto-resolved user id
-SIGIL_USER_ID_SOURCE         # claude-code only: "email" (default) or "accountUuid"
-SIGIL_DEBUG                  # true|1|yes — write to $XDG_STATE_HOME/sigil/logs/sigil.log
-```
+Then follow your agent's quickstart:
 
-### OTel trace + metric export
-
-The binary configures OTLP exporters for the SDK's traces and metrics. Set one of:
-
-```
-SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT   # sigil-specific override
-OTEL_EXPORTER_OTLP_ENDPOINT         # standard OTel env var (fallback)
-```
-
-When `OTEL_EXPORTER_OTLP_HEADERS` does not contain an `Authorization` entry, the binary synthesises `Authorization=Basic base64(SIGIL_AUTH_TENANT_ID:SIGIL_AUTH_TOKEN)` so users do not have to hand-encode it. `SIGIL_OTEL_AUTH_TOKEN` overrides the credential token for OTel only.
-
-## How agents launch the binary
-
-| Agent | Invocation |
-|-------|------------|
-| `claude-code` (hook) | `sigil claude-code hook` (resolved via `PATH`) |
-| `claude` (launcher) | `sigil claude [-- args...]` (resolved via `PATH`) |
-| `codex` | `sigil codex hook` (resolved via `PATH`) |
-| `cursor` | `plugins/cursor/scripts/run.sh` |
-| `pi` | `sigil pi [-- args...]` (resolved via `PATH`) |
-
-Claude Code and Codex run hooks under the user's shell environment, so the binary just has to be on `PATH`. Cursor launches hooks under a stripped environment (macOS GUI launches inherit launchd's `/usr/bin:/bin:/usr/sbin:/sbin`), which doesn't include `~/go/bin` or `/opt/homebrew/bin` — the wrapper probes `$SIGIL_BIN`, `~/go/bin/sigil`, `/opt/homebrew/bin/sigil`, `/usr/local/bin/sigil`, and `~/.local/bin/sigil`, then exec's `sigil cursor hook` on the first hit. If no binary is found it emits a permissive JSON response so `beforeSubmitPrompt` is never blocked and exits 0.
-
-## Per-agent details
-
-See the agent-plugin READMEs for agent-specific behaviour:
-
-- [`plugins/claude-code/README.md`](../claude-code/README.md)
-- [`plugins/codex/README.md`](../codex/README.md)
-- [`plugins/cursor/README.md`](../cursor/README.md)
-- [`plugins/pi/README.md`](../pi/README.md)
-
-## Development
-
-```sh
-cd plugins/sigil
-GOWORK=off go test ./...     # full suite, isolated from go.work
-GOWORK=off go build ./...    # compile-check
-make build                   # produces ./sigil
-```
-
-The repo-wide tasks `mise run lint:go` and `mise run format:go` cover this module via `find . -name go.mod`.
+- [Claude Code](../claude-code/README.md)
+- [Codex](../codex/README.md)
+- [Cursor](../cursor/README.md)
+- [pi](../pi/README.md) (separate JS plugin)
 
 ## Troubleshooting
 
-Set `SIGIL_DEBUG=true` to enable logging to `$XDG_STATE_HOME/sigil/logs/sigil.log`. The wrappers always exit 0, so failures only show up in that log; nothing reaches the agent's stderr.
-
-If an agent plugin appears to do nothing:
-
-1. Run `sigil --version` from the user's shell. For Claude Code and Codex the manifest invokes `sigil` directly, so the binary must be on `PATH`. For Cursor the wrapper additionally probes `~/go/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, and `~/.local/bin`.
-2. Confirm credentials are loaded: `cat $XDG_CONFIG_HOME/sigil/config.env`. The dotenv loader only honours `SIGIL_*` keys and a small set of `OTEL_*` keys.
-3. Check the debug log for `not exporting: missing …` lines, which indicate the agent adapter saw incomplete credentials.
+Hooks always exit 0, so problems only show up in the debug log. Set `SIGIL_DEBUG=true` in `~/.config/sigil/config.env` and tail `~/.local/state/sigil/logs/sigil.log`.


### PR DESCRIPTION
- [Updated README.md](https://github.com/grafana/sigil-sdk/blob/979c9cca5961abe91fa9e363550b0e171cee3ac9/plugins/README.md)

Recommend `brew install grafana/grafana/sigil` instead of `go install` since the formula is now published. Consolidate Claude Code, Codex, and Cursor on a single `~/.config/sigil/config.env` file.

Remove internal-architecture sections (hook lifecycle, on-disk fragments, subagent linkage internals, dispatcher invocation maps) from the user quickstarts and align terminology with the docs. Each host README now opens with numbered steps and points at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app` for connection details.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only, primarily simplifying install/setup guidance; the main risk is user confusion if any agent still requires the old `go install` flow or different env var expectations.
> 
> **Overview**
> Updates plugin documentation to prefer `brew install grafana/grafana/sigil` over `go install` and to standardize Claude Code/Codex/Cursor on a shared config file at `~/.config/sigil/config.env`.
> 
> Rewrites the agent READMEs into a short numbered quickstart (install → register → add Grafana Cloud credentials → verify), trims deep implementation/architecture details, and points users to `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app` as the source of connection settings. Also clarifies Codex’s feature-flag differences and adds consistent debug/logging and OTLP instance-id troubleshooting notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 979c9cca5961abe91fa9e363550b0e171cee3ac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->