### PR TITLE
feat(plugins/claude): preserve Claude Code offsets on empty batches

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -45,6 +45,18 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sigil claude-code hook",
+            "timeout": 10000
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/sigil/internal/agents/claudecode/hook.go
+++ b/plugins/sigil/internal/agents/claudecode/hook.go
@@ -16,10 +16,10 @@ import (
 
 	"github.com/grafana/sigil-sdk/go/sigil"
 
-	"github.com/grafana/sigil-sdk/plugins/sigil/internal/envconfig"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/claudecode/mapper"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/claudecode/state"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/claudecode/transcript"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/envconfig"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/otel"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/redact"
 )
@@ -101,8 +101,8 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 	st := state.Load(input.SessionID)
 
 	switch strings.TrimSpace(input.HookEventName) {
-	case "", "Stop":
-		// Stop hook uses the transcript to export generations.
+	case "", "Stop", "SessionEnd":
+		// Stop and SessionEnd hooks use the transcript to export generations.
 	case "SessionStart":
 		st.Model = strings.TrimSpace(input.Model)
 		if err := state.Save(input.SessionID, st); err != nil {
@@ -153,8 +153,7 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 	}, r)
 
 	if len(gens) == 0 {
-		st.Offset = safeOffset
-		_ = state.Save(input.SessionID, st)
+		logger.Printf("no generations produced; keeping offset=%d for next event", st.Offset)
 		return nil
 	}
 	logger.Printf("produced %d generations", len(gens))

--- a/plugins/sigil/internal/agents/claudecode/hook_test.go
+++ b/plugins/sigil/internal/agents/claudecode/hook_test.go
@@ -1,13 +1,19 @@
 package claudecode
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/grafana/sigil-sdk/go/sigil"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/claudecode/state"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
@@ -37,6 +43,176 @@ func TestParseHookInput_RejectsEmpty(t *testing.T) {
 	if _, err := parseHookInput(strings.NewReader(`{}`)); err == nil {
 		t.Fatal("expected error on missing fields")
 	}
+}
+
+func TestHookEventRouting(t *testing.T) {
+	tests := []struct {
+		name            string
+		setup           func(t *testing.T, dir string) hookInput
+		wantLogs        []string
+		wantMissingLogs []string
+		assertState     func(t *testing.T)
+	}{
+		{
+			name: "Stop keeps offset when no generations are produced",
+			setup: func(t *testing.T, dir string) hookInput {
+				t.Helper()
+				sessionID := "zero-generation-session"
+				transcriptPath := filepath.Join(dir, "transcript.jsonl")
+				processedPart := buildHookUserJSONL(sessionID, "already processed") + "\n"
+				userPart := buildHookUserJSONL(sessionID, "hey") + "\n"
+				if err := os.WriteFile(transcriptPath, []byte(processedPart+userPart), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				startOffset := int64(len([]byte(processedPart)))
+				if err := state.Save(sessionID, state.Session{Offset: startOffset, Title: "existing title", Model: "claude-sonnet-4"}); err != nil {
+					t.Fatal(err)
+				}
+				return hookInput{
+					HookEventName:  "Stop",
+					SessionID:      sessionID,
+					TranscriptPath: transcriptPath,
+				}
+			},
+			wantLogs: []string{"no generations produced; keeping offset="},
+			assertState: func(t *testing.T) {
+				t.Helper()
+				sessionID := "zero-generation-session"
+				wantOffset := int64(len([]byte(buildHookUserJSONL(sessionID, "already processed") + "\n")))
+				st := state.Load(sessionID)
+				if st.Offset != wantOffset {
+					t.Fatalf("Offset = %d, want %d", st.Offset, wantOffset)
+				}
+				if st.Title != "existing title" {
+					t.Fatalf("Title = %q, want existing title", st.Title)
+				}
+			},
+		},
+		{
+			name: "SessionEnd processes transcript",
+			setup: func(t *testing.T, dir string) hookInput {
+				t.Helper()
+				sessionID := "sessionend-route"
+				transcriptPath := filepath.Join(dir, "transcript.jsonl")
+				userLine := buildHookUserJSONL(sessionID, "hey")
+				if err := os.WriteFile(transcriptPath, []byte(userLine+"\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return hookInput{
+					HookEventName:  "SessionEnd",
+					SessionID:      sessionID,
+					TranscriptPath: transcriptPath,
+				}
+			},
+			wantLogs: []string{
+				"read 1 raw lines",
+				"no generations produced; keeping offset=0 for next event",
+			},
+		},
+		{
+			name: "SessionStart does not process transcript",
+			setup: func(t *testing.T, dir string) hookInput {
+				t.Helper()
+				return hookInput{
+					HookEventName:  "SessionStart",
+					SessionID:      "sessionstart-route",
+					TranscriptPath: filepath.Join(dir, "missing.jsonl"),
+					Model:          "claude-opus-4-20250514",
+				}
+			},
+			wantMissingLogs: []string{"read transcript:", "raw lines"},
+			assertState: func(t *testing.T) {
+				t.Helper()
+				st := state.Load("sessionstart-route")
+				if st.Model != "claude-opus-4-20250514" {
+					t.Fatalf("Model = %q, want claude-opus-4-20250514", st.Model)
+				}
+			},
+		},
+		{
+			name: "unknown event does not process transcript",
+			setup: func(t *testing.T, dir string) hookInput {
+				t.Helper()
+				return hookInput{
+					HookEventName:  "UnknownEvent",
+					SessionID:      "unknown-route",
+					TranscriptPath: filepath.Join(dir, "missing.jsonl"),
+				}
+			},
+			wantMissingLogs: []string{"read transcript:", "raw lines"},
+			assertState: func(t *testing.T) {
+				t.Helper()
+				st := state.Load("unknown-route")
+				if st != (state.Session{}) {
+					t.Fatalf("state = %#v, want zero value", st)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("XDG_STATE_HOME", filepath.Join(dir, "state"))
+			setHookExportEnv(t, "http://example.invalid")
+
+			logs := runHookForTest(t, tt.setup(t, dir))
+			for _, want := range tt.wantLogs {
+				if !strings.Contains(logs, want) {
+					t.Fatalf("logs do not contain %q:\n%s", want, logs)
+				}
+			}
+			for _, missing := range tt.wantMissingLogs {
+				if strings.Contains(logs, missing) {
+					t.Fatalf("logs contain unexpected %q:\n%s", missing, logs)
+				}
+			}
+			if tt.assertState != nil {
+				tt.assertState(t)
+			}
+		})
+	}
+}
+
+func setHookExportEnv(t *testing.T, endpoint string) {
+	t.Helper()
+	t.Setenv("SIGIL_ENDPOINT", endpoint)
+	t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+	t.Setenv("SIGIL_AUTH_TOKEN", "token")
+	t.Setenv("SIGIL_AUTH_MODE", "basic")
+	t.Setenv("SIGIL_PROTOCOL", "http")
+	t.Setenv("SIGIL_USER_ID", "test-user")
+	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+}
+
+func runHookForTest(t *testing.T, input hookInput) string {
+	t.Helper()
+	payload, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var logs bytes.Buffer
+	if err := Hook(context.Background(), bytes.NewReader(payload), io.Discard, log.New(&logs, "", 0)); err != nil {
+		t.Fatalf("Hook: %v", err)
+	}
+	return logs.String()
+}
+
+func buildHookUserJSONL(sessionID, text string) string {
+	line := map[string]any{
+		"type":      "user",
+		"sessionId": sessionID,
+		"timestamp": "2025-06-01T12:00:00Z",
+		"version":   "1.0.0",
+		"message": map[string]any{
+			"role":    "user",
+			"content": text,
+		},
+	}
+	data, _ := json.Marshal(line)
+	return string(data)
 }
 
 func TestBuildToolResultMap(t *testing.T) {

--- a/plugins/sigil/internal/agents/claudecode/mapper/hook_integration_test.go
+++ b/plugins/sigil/internal/agents/claudecode/mapper/hook_integration_test.go
@@ -1,0 +1,205 @@
+package mapper_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	claudecode "github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/claudecode"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/claudecode/state"
+)
+
+func TestHookSessionEndProcessesAssistantFlushedAfterStop(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", filepath.Join(dir, "state"))
+
+	capture := &exportCapture{}
+	server := httptest.NewServer(http.HandlerFunc(capture.handle))
+	defer server.Close()
+	setHookExportEnv(t, server.URL)
+
+	sessionID := "delayed-flush-session"
+	transcriptPath := filepath.Join(dir, "transcript.jsonl")
+	userPart := buildUserJSONL(sessionID, "hey") + "\n"
+	assistantPart := buildAssistantJSONL(sessionID, "req-1", "claude-sonnet-4-20250514", 25, "hello") + "\n"
+	if err := os.WriteFile(transcriptPath, []byte(userPart), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stopLogs := runClaudeHook(t, hookPayload{
+		HookEventName:  "Stop",
+		SessionID:      sessionID,
+		TranscriptPath: transcriptPath,
+	})
+	if !strings.Contains(stopLogs, "no generations produced; keeping offset=0 for next event") {
+		t.Fatalf("Stop did not preserve offset after user-only transcript:\n%s", stopLogs)
+	}
+	if st := state.Load(sessionID); st.Offset != 0 {
+		t.Fatalf("Offset after Stop = %d, want 0", st.Offset)
+	}
+	capture.assert(t, nil)
+
+	f, err := os.OpenFile(transcriptPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(assistantPart); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionEndLogs := runClaudeHook(t, hookPayload{
+		HookEventName:  "SessionEnd",
+		SessionID:      sessionID,
+		TranscriptPath: transcriptPath,
+	})
+	if !strings.Contains(sessionEndLogs, "produced 1 generations") {
+		t.Fatalf("SessionEnd did not produce one generation:\n%s", sessionEndLogs)
+	}
+
+	capture.assert(t, []int{1})
+	st := state.Load(sessionID)
+	wantOffset := int64(len([]byte(userPart + assistantPart)))
+	if st.Offset != wantOffset {
+		t.Fatalf("Offset after SessionEnd = %d, want %d", st.Offset, wantOffset)
+	}
+}
+
+type hookPayload struct {
+	HookEventName  string `json:"hook_event_name"`
+	SessionID      string `json:"session_id"`
+	TranscriptPath string `json:"transcript_path"`
+	Model          string `json:"model,omitempty"`
+}
+
+type exportCapture struct {
+	mu               sync.Mutex
+	paths            []string
+	generationCounts []int
+	readErrs         []string
+	decodeErrs       []string
+}
+
+func (c *exportCapture) handle(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	var req struct {
+		Generations []json.RawMessage `json:"generations"`
+	}
+	decodeErr := json.Unmarshal(body, &req)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.paths = append(c.paths, r.URL.Path)
+	c.generationCounts = append(c.generationCounts, len(req.Generations))
+	if err != nil {
+		c.readErrs = append(c.readErrs, err.Error())
+	}
+	if decodeErr != nil {
+		c.decodeErrs = append(c.decodeErrs, decodeErr.Error())
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"results":[]}`))
+}
+
+func (c *exportCapture) assert(t *testing.T, wantCounts []int) {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if len(c.readErrs) > 0 {
+		t.Fatalf("read export body errors: %v", c.readErrs)
+	}
+	if len(c.decodeErrs) > 0 {
+		t.Fatalf("decode export body errors: %v", c.decodeErrs)
+	}
+	if len(c.generationCounts) != len(wantCounts) {
+		t.Fatalf("export request count = %d, want %d (counts=%v)", len(c.generationCounts), len(wantCounts), c.generationCounts)
+	}
+	for i, want := range wantCounts {
+		if c.paths[i] != "/api/v1/generations:export" {
+			t.Fatalf("export path[%d] = %q, want /api/v1/generations:export", i, c.paths[i])
+		}
+		if c.generationCounts[i] != want {
+			t.Fatalf("export generations[%d] = %d, want %d", i, c.generationCounts[i], want)
+		}
+	}
+}
+
+func setHookExportEnv(t *testing.T, endpoint string) {
+	t.Helper()
+	t.Setenv("SIGIL_ENDPOINT", endpoint)
+	t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+	t.Setenv("SIGIL_AUTH_TOKEN", "token")
+	t.Setenv("SIGIL_AUTH_MODE", "basic")
+	t.Setenv("SIGIL_PROTOCOL", "http")
+	t.Setenv("SIGIL_USER_ID", "test-user")
+	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+}
+
+func runClaudeHook(t *testing.T, input hookPayload) string {
+	t.Helper()
+	payload, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var logs bytes.Buffer
+	if err := claudecode.Hook(context.Background(), bytes.NewReader(payload), io.Discard, log.New(&logs, "", 0)); err != nil {
+		t.Fatalf("Hook: %v", err)
+	}
+	return logs.String()
+}
+
+func buildUserJSONL(sessionID, text string) string {
+	line := map[string]any{
+		"type":      "user",
+		"sessionId": sessionID,
+		"timestamp": "2025-06-01T12:00:00Z",
+		"version":   "1.0.0",
+		"message": map[string]any{
+			"role":    "user",
+			"content": text,
+		},
+	}
+	data, _ := json.Marshal(line)
+	return string(data)
+}
+
+func buildAssistantJSONL(sessionID, requestID, model string, outputTokens int, text string) string {
+	line := map[string]any{
+		"type":      "assistant",
+		"sessionId": sessionID,
+		"timestamp": "2025-06-01T12:01:00Z",
+		"version":   "1.0.0",
+		"gitBranch": "main",
+		"cwd":       "/projects/test",
+		"requestId": requestID,
+		"message": map[string]any{
+			"model": model,
+			"content": []map[string]any{
+				{"type": "text", "text": text},
+			},
+			"stop_reason": "end_turn",
+			"usage": map[string]any{
+				"input_tokens":  50,
+				"output_tokens": outputTokens,
+			},
+		},
+	}
+	data, _ := json.Marshal(line)
+	return string(data)
+}


### PR DESCRIPTION
`Stop` can run before Claude has flushed the assistant line. If the hook advances the saved offset in that state, the later `SessionEnd` event cannot recover the skipped user prompt.

Keep the prior offset when no generations are produced, and run the transcript processing path on `SessionEnd` so short sessions can export after the transcript settles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Claude Code hook routing and state offset persistence, which can affect what transcript data gets exported (or missed) across events. Covered by new unit/integration tests, but regressions could still impact telemetry completeness for short or delayed-flush sessions.
> 
> **Overview**
> **Improves Claude Code transcript export reliability across hook events.** The hook now routes `SessionEnd` through the same transcript-processing path as `Stop`, enabling exports after the transcript finishes flushing.
> 
> When transcript processing yields **zero generations**, the hook no longer advances/persists the saved offset (it logs and keeps the prior offset), preventing later events from skipping unexported lines. Adds new unit and integration tests to validate event routing and the delayed-assistant-flush scenario, and updates the Claude Code plugin config to register the new `SessionEnd` hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49dd899267a240613ff604e5dfe8a52474ec2655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->