### PR TITLE
feat(plugins/codex): add sigil codex command

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -4,11 +4,12 @@ Send conversations from your coding agent to [Grafana AI Observability](https://
 
 > AI Observability is in [public preview](https://grafana.com/docs/release-life-cycle/).
 
-## Fastest start (Claude Code or pi)
+## Fastest start (Claude Code, Codex, or pi)
 
 ```sh
 brew install grafana/grafana/sigil
 sigil claude     # for Claude Code
+sigil codex      # for Codex
 sigil pi         # for pi
 ```
 

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -13,10 +13,21 @@ brew install grafana/grafana/sigil
 ## 2. Register the plugin
 
 ```sh
-codex plugin marketplace add grafana/sigil-sdk
+sigil codex
 ```
 
-Enable it in `~/.codex/config.toml`:
+The launcher resolves `codex` on `PATH`, registers `sigil-codex@grafana-sigil` with codex on first run, then execs codex. On first launch only, open `/hooks` inside codex and trust each `sigil-codex@grafana-sigil` hook — codex requires manual review on install.
+
+### Manual setup
+
+If you'd rather drive codex's plugin store yourself (or are on an older build where the launcher's auto-install does not work), the same flow with codex's verbs:
+
+```sh
+codex plugin marketplace add grafana/sigil-sdk
+codex plugin add sigil-codex@grafana-sigil
+```
+
+On current codex builds the `hooks` and `plugin_hooks` features are stable by default (`codex features list` confirms this), so no config.toml edits are needed. Older builds gated this on feature flags — if `/hooks` is empty after install, add the following to `~/.codex/config.toml`:
 
 ```toml
 [plugins."sigil-codex@grafana-sigil"]

--- a/plugins/sigil/cmd/sigil/main.go
+++ b/plugins/sigil/cmd/sigil/main.go
@@ -3,15 +3,16 @@
 //
 //	sigil <agent> hook           — dispatch a JSON hook payload on stdin to <agent>
 //	sigil claude [-- args...]    — exec claude after bootstrapping the sigil-cc plugin
-//	sigil pi [-- args...]        — exec pi after bootstrapping the @grafana/sigil-pi extension
+//	sigil codex  [-- args...]    — exec codex after bootstrapping the sigil-codex plugin
+//	sigil pi     [-- args...]    — exec pi after bootstrapping the @grafana/sigil-pi extension
 //	sigil --version              — print the build version
 //
 // Unknown agents and unknown verbs exit with code 2 and a usage message on
 // stderr. For hook agents the binary must never crash the calling agent
 // process; once argv parsing succeeds, all errors are swallowed (and logged
-// when SIGIL_DEBUG=true) and the process exits 0. Launcher agents (`claude`
-// and `pi`) are invoked by a human, so errors surface on stderr with a
-// non-zero exit code.
+// when SIGIL_DEBUG=true) and the process exits 0. Launcher agents (`claude`,
+// `codex`, and `pi`) are invoked by a human, so errors surface on stderr
+// with a non-zero exit code.
 package main
 
 import (
@@ -32,7 +33,7 @@ import (
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/login"
 )
 
-const usageLine = "usage: sigil login | sigil <agent> hook | sigil claude [-- args...] | sigil pi [-- args...]"
+const usageLine = "usage: sigil login | sigil <agent> hook | sigil claude [-- args...] | sigil codex [-- args...] | sigil pi [-- args...]"
 
 // version is overridden via -ldflags at build time.
 var version = "dev"
@@ -59,6 +60,7 @@ var agents = map[string]agentHook{
 // name (`claude`, `pi`), not the hook agent name (`claude-code`).
 var launchers = map[string]agentLauncher{
 	"claude": claudecode.Launch,
+	"codex":  codex.Launch,
 	"pi":     pi.Launch,
 }
 
@@ -95,7 +97,15 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 
 	// Launcher dispatch handles `sigil <launcher> [-- args...]` before the
 	// hook branch because launchers have no verb (single mode of operation).
-	if launcher, ok := launchers[args[0]]; ok {
+	//
+	// One exception: when a name appears in both maps (today: `codex`, which
+	// is both a launcher and a hook agent), the literal verb `hook` always
+	// means hook dispatch. Without this guard `sigil codex hook` would hit
+	// the launcher branch, fail parseLauncherArgs because there is no `--`,
+	// and exit 2 — breaking every hook fired by plugins/codex/hooks/hooks.json.
+	_, isHookAgent := agents[args[0]]
+	isHookCall := len(args) >= 2 && args[1] == "hook" && isHookAgent
+	if launcher, ok := launchers[args[0]]; ok && !isHookCall {
 		launcherArgs, ok := parseLauncherArgs(args[0], args[1:], stderr)
 		if !ok {
 			return

--- a/plugins/sigil/cmd/sigil/main_test.go
+++ b/plugins/sigil/cmd/sigil/main_test.go
@@ -74,7 +74,7 @@ func TestRun_UnknownAgentExits2(t *testing.T) {
 func TestRun_UnknownVerbExits2(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	gotExit := withExit(t, func() {
-		run([]string{"codex", "launch"}, strings.NewReader(""), &stdout, &stderr)
+		run([]string{"claude-code", "launch"}, strings.NewReader(""), &stdout, &stderr)
 	})
 	if gotExit == nil || *gotExit != 2 {
 		t.Fatalf("exit = %v, want 2", gotExit)
@@ -385,6 +385,115 @@ func TestRun_ClaudeLauncherErrorExits1(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	gotExit := withExit(t, func() {
 		run([]string{"claude", "--"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	if gotExit == nil || *gotExit != 1 {
+		t.Fatalf("exit = %v, want 1", gotExit)
+	}
+	if !strings.HasPrefix(stderr.String(), "sigil:") {
+		t.Fatalf("stderr does not start with sigil: %q", stderr.String())
+	}
+}
+
+// `codex` is registered in both `agents` and `launchers`. The dispatcher
+// must prefer the hook branch when the second arg is the literal verb
+// `hook` so plugins/codex/hooks/hooks.json (which invokes `sigil codex hook`)
+// keeps working after the launcher was added.
+func TestRun_CodexHookDispatchesEvenWithLauncher(t *testing.T) {
+	hookCalls := 0
+	prevAgents := agents
+	t.Cleanup(func() { agents = prevAgents })
+	agents = map[string]agentHook{
+		"codex": func(_ context.Context, _ io.Reader, _ io.Writer, _ *log.Logger) error {
+			hookCalls++
+			return nil
+		},
+	}
+	withStubLauncher(t, "codex", func(_ context.Context, _ []string, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		t.Fatal("launcher must not be called for `sigil codex hook`")
+		return nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"codex", "hook"}, strings.NewReader(`{}`), &stdout, &stderr)
+	})
+	if gotExit != nil {
+		t.Fatalf("exit = %v, want no exit", gotExit)
+	}
+	if hookCalls != 1 {
+		t.Fatalf("hook called %d times, want 1", hookCalls)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr non-empty: %q", stderr.String())
+	}
+}
+
+func TestRun_CodexLauncherBare(t *testing.T) {
+	var got []string
+	called := 0
+	withStubLauncher(t, "codex", func(_ context.Context, args []string, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		called++
+		got = append([]string{}, args...)
+		return nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"codex"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	if gotExit != nil {
+		t.Fatalf("exit code = %d, want no exit", *gotExit)
+	}
+	if called != 1 {
+		t.Fatalf("launcher called %d times, want 1", called)
+	}
+	if len(got) != 0 {
+		t.Fatalf("launcher args = %v, want empty", got)
+	}
+}
+
+func TestRun_CodexLauncherForwardsArgs(t *testing.T) {
+	var got []string
+	withStubLauncher(t, "codex", func(_ context.Context, args []string, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		got = append([]string{}, args...)
+		return nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	withExit(t, func() {
+		run([]string{"codex", "--", "exec", "prompt"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	if !reflect.DeepEqual(got, []string{"exec", "prompt"}) {
+		t.Fatalf("launcher args = %v, want [exec prompt]", got)
+	}
+}
+
+func TestRun_CodexLauncherMissingSeparatorExits2(t *testing.T) {
+	withStubLauncher(t, "codex", func(_ context.Context, _ []string, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		t.Fatal("launcher must not be called when separator is missing")
+		return nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"codex", "foo"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	if gotExit == nil || *gotExit != 2 {
+		t.Fatalf("exit = %v, want 2", gotExit)
+	}
+	if !strings.Contains(stderr.String(), "use `sigil codex -- <args>`") {
+		t.Fatalf("stderr missing forward-args hint: %q", stderr.String())
+	}
+}
+
+func TestRun_CodexLauncherErrorExits1(t *testing.T) {
+	withStubLauncher(t, "codex", func(_ context.Context, _ []string, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		return errors.New("boom")
+	})
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"codex", "--"}, strings.NewReader(""), &stdout, &stderr)
 	})
 	if gotExit == nil || *gotExit != 1 {
 		t.Fatalf("exit = %v, want 1", gotExit)

--- a/plugins/sigil/internal/agents/codex/launch.go
+++ b/plugins/sigil/internal/agents/codex/launch.go
@@ -1,0 +1,150 @@
+package codex
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+const (
+	// marketplaceRepo is the source argument passed to
+	// `codex plugin marketplace add`.
+	marketplaceRepo = "grafana/sigil-sdk"
+	// marketplaceAlias is the marketplace name declared in
+	// .claude-plugin/marketplace.json (shared between Claude Code and Codex
+	// host plugins).
+	marketplaceAlias = "grafana-sigil"
+	// PluginName is the codex plugin name declared in
+	// plugins/codex/.codex-plugin/plugin.json.
+	PluginName = "sigil-codex"
+)
+
+// Test seams.
+var (
+	lookPath   = exec.LookPath
+	execFn     = syscall.Exec
+	runInstall = defaultRunInstall
+	pluginList = defaultPluginList
+)
+
+// Launch resolves the `codex` binary on PATH, ensures the sigil-codex plugin
+// is registered and enabled in codex's plugin store (running
+// `codex plugin marketplace add` + `codex plugin add` once if it is not),
+// and then exec's codex with the supplied args.
+func Launch(ctx context.Context, args []string, _ io.Reader, _, stderr io.Writer, logger *log.Logger) error {
+	bin, err := lookPath("codex")
+	if err != nil {
+		return fmt.Errorf("codex CLI not found on PATH: %w", err)
+	}
+
+	installed, err := pluginInstalled(ctx, bin)
+	if err != nil {
+		// Treat a failed `codex plugin list` the same as missing: log the
+		// probe failure for SIGIL_DEBUG, then let `codex plugin add` run.
+		// codex's own CLI is the source of truth and will fail loudly if
+		// something is genuinely wrong.
+		logger.Printf("codex plugin list probe: %v", err)
+		installed = false
+	}
+	if !installed {
+		_, _ = fmt.Fprintf(stderr, "sigil: registering %s with codex\n", PluginName)
+		if err := runInstall(ctx, bin, stderr); err != nil {
+			// Don't block the user's codex session on a failed install
+			// (offline machine, sandboxed CI, marketplace hiccup, etc.).
+			// Log for SIGIL_DEBUG, point the user at the manual command,
+			// and fall through to exec. codex still runs, just without
+			// Sigil capture.
+			logger.Printf("install %s: %v", PluginName, err)
+			_, _ = fmt.Fprintf(stderr,
+				"sigil: install of %s failed: %v\n"+
+					"sigil: continuing without Sigil capture. To retry manually:\n"+
+					"          codex plugin marketplace add %s\n"+
+					"          codex plugin add %s@%s\n",
+				PluginName, err, marketplaceRepo, PluginName, marketplaceAlias)
+		} else {
+			// One-time trust step the launcher cannot automate: codex
+			// requires the user to open /hooks inside the TUI and accept
+			// each sigil-codex hook on first run.
+			_, _ = fmt.Fprintf(stderr,
+				"sigil: first run only — open /hooks inside codex and trust the\n"+
+					"       %s hooks to start exporting turns.\n", PluginName)
+		}
+	}
+
+	argv := append([]string{bin}, args...)
+	if err := execFn(bin, argv, os.Environ()); err != nil {
+		return fmt.Errorf("exec codex: %w", err)
+	}
+	return nil
+}
+
+func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {
+	steps := [][]string{
+		{"plugin", "marketplace", "add", marketplaceRepo},
+		{"plugin", "add", PluginName + "@" + marketplaceAlias},
+	}
+	for _, argv := range steps {
+		cmd := exec.CommandContext(ctx, bin, argv...)
+		cmd.Stdout = w
+		cmd.Stderr = w
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("codex %s: %w", strings.Join(argv, " "), err)
+		}
+	}
+	return nil
+}
+
+// defaultPluginList shells out to `codex plugin list` and returns the raw
+// output. Output is human-formatted but stable: each plugin line looks like
+// `  <plugin>@<marketplace> (<state>)`.
+func defaultPluginList(ctx context.Context, bin string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, bin, "plugin", "list")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		// `%v` on *exec.ExitError renders only "exit status N" and drops the
+		// captured stderr, so attach codex's diagnostic explicitly.
+		if msg := bytes.TrimSpace(stderr.Bytes()); len(msg) > 0 {
+			return nil, fmt.Errorf("%w: %s", err, msg)
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+// pluginInstalled reports whether `sigil-codex@grafana-sigil` is registered
+// and enabled in codex's plugin store.
+//
+// We shell out to `codex plugin list` because it's the source of truth and
+// doesn't depend on the user's $XDG_CONFIG_HOME layout. Anything other than
+// an `(installed, enabled)` marker is treated as not installed —
+// `(installed, disabled)` shouldn't be silently re-enabled in the user's
+// face but re-running install on codex's side is idempotent and surfaces
+// the disabled state to the user.
+func pluginInstalled(ctx context.Context, bin string) (bool, error) {
+	out, err := pluginList(ctx, bin)
+	if err != nil {
+		return false, err
+	}
+	needle := []byte(PluginName + "@" + marketplaceAlias)
+	for _, line := range bytes.Split(out, []byte{'\n'}) {
+		// Anchor on the first whitespace-delimited token so suffix collisions
+		// like `my-sigil-codex@grafana-sigil` or
+		// `sigil-codex@grafana-sigil-staging` don't satisfy the check.
+		fields := bytes.Fields(line)
+		if len(fields) == 0 || !bytes.Equal(fields[0], needle) {
+			continue
+		}
+		if bytes.Contains(line, []byte("installed, enabled")) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/plugins/sigil/internal/agents/codex/launch_test.go
+++ b/plugins/sigil/internal/agents/codex/launch_test.go
@@ -1,0 +1,331 @@
+package codex
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestLaunch_MissingCodexBinary(t *testing.T) {
+	withLookPath(t, func(string) (string, error) { return "", exec.ErrNotFound })
+
+	err := Launch(context.Background(), nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger())
+	if err == nil || !strings.Contains(err.Error(), "codex CLI not found") {
+		t.Fatalf("err = %v, want contains \"codex CLI not found\"", err)
+	}
+}
+
+func TestLaunch_SkipsInstallWhenPluginInstalledAndEnabled(t *testing.T) {
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/codex", nil })
+	withPluginList(t, func(context.Context, string) ([]byte, error) {
+		return []byte("  sigil-codex@grafana-sigil (installed, enabled)\n"), nil
+	})
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		t.Fatal("runInstall must not be called when plugin is installed and enabled")
+		return nil
+	})
+
+	var execArgv []string
+	withExecFn(t, func(_ string, argv []string, _ []string) error {
+		execArgv = append([]string{}, argv...)
+		return nil
+	})
+
+	var stderr bytes.Buffer
+	if err := Launch(context.Background(), []string{"exec", "hi"}, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+		t.Fatalf("Launch returned err: %v", err)
+	}
+	if !reflect.DeepEqual(execArgv, []string{"/usr/local/bin/codex", "exec", "hi"}) {
+		t.Fatalf("exec argv = %v", execArgv)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr non-empty: %q", stderr.String())
+	}
+}
+
+func TestLaunch_RunsInstallWhenPluginMissing(t *testing.T) {
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/codex", nil })
+	withPluginList(t, func(context.Context, string) ([]byte, error) {
+		return []byte("  other-plugin@elsewhere (installed, enabled)\n"), nil
+	})
+
+	installCalls := 0
+	withRunInstall(t, func(_ context.Context, bin string, _ io.Writer) error {
+		installCalls++
+		if bin != "/usr/local/bin/codex" {
+			t.Errorf("install bin = %q, want /usr/local/bin/codex", bin)
+		}
+		return nil
+	})
+
+	execCalled := false
+	withExecFn(t, func(_ string, _ []string, _ []string) error {
+		execCalled = true
+		return nil
+	})
+
+	var stderr bytes.Buffer
+	if err := Launch(context.Background(), nil, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+		t.Fatalf("Launch returned err: %v", err)
+	}
+	if installCalls != 1 {
+		t.Fatalf("runInstall calls = %d, want 1", installCalls)
+	}
+	if !execCalled {
+		t.Fatal("execFn was not called after install")
+	}
+	got := stderr.String()
+	if !strings.Contains(got, "registering "+PluginName+" with codex") {
+		t.Fatalf("stderr missing install message: %q", got)
+	}
+	if !strings.Contains(got, "/hooks") {
+		t.Fatalf("stderr missing /hooks trust hint: %q", got)
+	}
+}
+
+func TestLaunch_RunsInstallWhenPluginInstalledButDisabled(t *testing.T) {
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/codex", nil })
+	withPluginList(t, func(context.Context, string) ([]byte, error) {
+		return []byte("  sigil-codex@grafana-sigil (installed, disabled)\n"), nil
+	})
+
+	installCalls := 0
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		installCalls++
+		return nil
+	})
+
+	execCalled := false
+	withExecFn(t, func(_ string, _ []string, _ []string) error {
+		execCalled = true
+		return nil
+	})
+
+	if err := Launch(context.Background(), nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger()); err != nil {
+		t.Fatalf("Launch returned err: %v", err)
+	}
+	if installCalls != 1 {
+		t.Fatalf("runInstall calls = %d, want 1 (disabled plugin should trigger install)", installCalls)
+	}
+	if !execCalled {
+		t.Fatal("execFn was not called")
+	}
+}
+
+// A failed install must not block the user. The launcher must print the
+// failure and a manual-retry hint listing the correct codex verbs on stderr,
+// then still exec codex so the workflow keeps moving.
+func TestLaunch_InstallFailureContinuesToExec(t *testing.T) {
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/codex", nil })
+	withPluginList(t, func(context.Context, string) ([]byte, error) {
+		return []byte(""), nil
+	})
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		return errors.New("network down")
+	})
+
+	execCalled := false
+	withExecFn(t, func(_ string, _ []string, _ []string) error {
+		execCalled = true
+		return nil
+	})
+
+	var stderr bytes.Buffer
+	if err := Launch(context.Background(), nil, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+		t.Fatalf("Launch returned err: %v", err)
+	}
+	if !execCalled {
+		t.Fatal("execFn was not called after install failure")
+	}
+	got := stderr.String()
+	if !strings.Contains(got, "install of "+PluginName+" failed") {
+		t.Fatalf("stderr missing failure message: %q", got)
+	}
+	if !strings.Contains(got, "network down") {
+		t.Fatalf("stderr missing underlying error: %q", got)
+	}
+	if !strings.Contains(got, "codex plugin marketplace add grafana/sigil-sdk") {
+		t.Fatalf("stderr missing marketplace add hint: %q", got)
+	}
+	if !strings.Contains(got, "codex plugin add sigil-codex@grafana-sigil") {
+		t.Fatalf("stderr missing plugin add hint: %q", got)
+	}
+	// The /hooks trust hint should NOT appear when install failed.
+	if strings.Contains(got, "/hooks") {
+		t.Fatalf("stderr unexpectedly contains /hooks hint on failure: %q", got)
+	}
+}
+
+func TestLaunch_PluginListProbeFailureFallsThroughToInstall(t *testing.T) {
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/codex", nil })
+	withPluginList(t, func(context.Context, string) ([]byte, error) {
+		return nil, errors.New("probe boom")
+	})
+
+	installCalls := 0
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		installCalls++
+		return nil
+	})
+
+	execCalled := false
+	withExecFn(t, func(_ string, _ []string, _ []string) error {
+		execCalled = true
+		return nil
+	})
+
+	var logbuf bytes.Buffer
+	logger := log.New(&logbuf, "", 0)
+	if err := Launch(context.Background(), nil, strings.NewReader(""), io.Discard, io.Discard, logger); err != nil {
+		t.Fatalf("Launch returned err: %v", err)
+	}
+	if installCalls != 1 {
+		t.Fatalf("runInstall calls = %d, want 1 (probe failure should trigger install)", installCalls)
+	}
+	if !execCalled {
+		t.Fatal("execFn was not called")
+	}
+	if !strings.Contains(logbuf.String(), "probe boom") {
+		t.Fatalf("logger missing probe failure: %q", logbuf.String())
+	}
+}
+
+func TestLaunch_ExecFailureSurfacesError(t *testing.T) {
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/codex", nil })
+	withPluginList(t, func(context.Context, string) ([]byte, error) {
+		return []byte("  sigil-codex@grafana-sigil (installed, enabled)\n"), nil
+	})
+	withRunInstall(t, func(context.Context, string, io.Writer) error { return nil })
+	withExecFn(t, func(string, []string, []string) error {
+		return errors.New("exec boom")
+	})
+
+	err := Launch(context.Background(), nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger())
+	if err == nil || !strings.Contains(err.Error(), "exec codex") {
+		t.Fatalf("err = %v, want contains \"exec codex\"", err)
+	}
+}
+
+func TestLaunch_ForwardsArgvUnchanged(t *testing.T) {
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/codex", nil })
+	withPluginList(t, func(context.Context, string) ([]byte, error) {
+		return []byte("  sigil-codex@grafana-sigil (installed, enabled)\n"), nil
+	})
+	withRunInstall(t, func(context.Context, string, io.Writer) error { return nil })
+
+	var execArgv []string
+	withExecFn(t, func(_ string, argv []string, _ []string) error {
+		execArgv = append([]string{}, argv...)
+		return nil
+	})
+
+	args := []string{"exec", "--model", "gpt-5", "hi"}
+	if err := Launch(context.Background(), args, strings.NewReader(""), io.Discard, io.Discard, nopLogger()); err != nil {
+		t.Fatalf("Launch returned err: %v", err)
+	}
+	want := append([]string{"/usr/local/bin/codex"}, args...)
+	if !reflect.DeepEqual(execArgv, want) {
+		t.Fatalf("exec argv = %v, want %v", execArgv, want)
+	}
+}
+
+func TestPluginInstalled_ParsesPluginListOutput(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want bool
+	}{
+		{
+			name: "installed enabled",
+			out:  "  sigil-codex@grafana-sigil (installed, enabled)\n",
+			want: true,
+		},
+		{
+			name: "installed disabled",
+			out:  "  sigil-codex@grafana-sigil (installed, disabled)\n",
+			want: false,
+		},
+		{
+			name: "not installed",
+			out:  "  sigil-codex@grafana-sigil (not installed)\n",
+			want: false,
+		},
+		{
+			name: "empty",
+			out:  "",
+			want: false,
+		},
+		{
+			name: "other plugins only",
+			out:  "  other@somewhere (installed, enabled)\n",
+			want: false,
+		},
+		{
+			name: "mixed lines",
+			out:  "  other@somewhere (installed, disabled)\n  sigil-codex@grafana-sigil (installed, enabled)\n",
+			want: true,
+		},
+		{
+			name: "name prefix collision",
+			out:  "  my-sigil-codex@grafana-sigil (installed, enabled)\n",
+			want: false,
+		},
+		{
+			name: "alias suffix collision",
+			out:  "  sigil-codex@grafana-sigil-staging (installed, enabled)\n",
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withPluginList(t, func(context.Context, string) ([]byte, error) {
+				return []byte(tc.out), nil
+			})
+			got, err := pluginInstalled(context.Background(), "/usr/local/bin/codex")
+			if err != nil {
+				t.Fatalf("err = %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func withLookPath(t *testing.T, fn func(string) (string, error)) {
+	t.Helper()
+	prev := lookPath
+	t.Cleanup(func() { lookPath = prev })
+	lookPath = fn
+}
+
+func withRunInstall(t *testing.T, fn func(context.Context, string, io.Writer) error) {
+	t.Helper()
+	prev := runInstall
+	t.Cleanup(func() { runInstall = prev })
+	runInstall = fn
+}
+
+func withExecFn(t *testing.T, fn func(string, []string, []string) error) {
+	t.Helper()
+	prev := execFn
+	t.Cleanup(func() { execFn = prev })
+	execFn = fn
+}
+
+func withPluginList(t *testing.T, fn func(context.Context, string) ([]byte, error)) {
+	t.Helper()
+	prev := pluginList
+	t.Cleanup(func() { pluginList = prev })
+	pluginList = fn
+}
+
+func nopLogger() *log.Logger {
+	return log.New(io.Discard, "", 0)
+}


### PR DESCRIPTION
`sigil codex` resolves codex on PATH, registers sigil-codex@grafana-sigil via `codex plugin marketplace add` + `plugin add` on first run, then execs codex. Mirrors the `sigil claude` and `sigil pi` launcher flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `codex` launcher path that shells out to manage Codex plugins and then `exec`s the Codex CLI, plus adjusts dispatch logic to disambiguate `codex` as both a launcher and a hook agent. Risk is moderate due to changes in CLI argument routing and external process execution, though behavior is covered by new unit tests.
> 
> **Overview**
> Adds first-class support for running Codex via `sigil codex`, including **auto-registering** the `sigil-codex@grafana-sigil` plugin (via `codex plugin marketplace add` + `codex plugin add`) and then `exec`-ing the `codex` CLI; install failures now **degrade gracefully** and continue without capture.
> 
> Updates `sigil` command dispatch to avoid ambiguity when `codex` is both a launcher and a hook agent (ensuring `sigil codex hook` still routes to hooks), and expands unit test coverage for the new launcher, argument forwarding, and the hook/launcher precedence. Documentation is updated to include Codex in the quickstart and to describe launcher vs manual plugin setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1e02d2ae6cf6e8e788b7258d7d915fb8c5ddc73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->