### PR TITLE
feat(plugins/claude): support SIGIL_GUARDS_* env vars in Claude Code plugin

### DIFF
--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -82,5 +82,8 @@ Common culprits: `sigil --version` doesn't work (binary not on `PATH`), a missin
 | `SIGIL_USER_ID` | from `~/.claude.json` | Override the user id. |
 | `SIGIL_USER_ID_SOURCE` | `email` | Which field to read from `~/.claude.json`: `email` or `accountUuid`. |
 | `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
+| `SIGIL_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Claude Code `PreToolUse` hook calls Sigil's `/api/v1/hooks:evaluate` and blocks tool calls denied by guard rules. |
+| `SIGIL_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |
+| `SIGIL_GUARDS_TIMEOUT_MS` | `1500` | Per-call timeout. Lower = less added latency on every tool call, higher = better tolerance for slow `llm_judge` evaluators. |
 
 If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>` manually instead of relying on the auto-synthesised auth.

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -79,7 +79,15 @@ Guards block tool calls before they execute (e.g. refuse a `bash` invocation mat
 SIGIL_GUARDS_ENABLED=true pi
 ```
 
-By default, transport errors and timeouts let the tool through. Set `SIGIL_GUARDS_FAIL_OPEN=false` to block on errors instead.
+By default, transport errors and timeouts let the tool through. Set `SIGIL_GUARDS_FAIL_OPEN=false` to block on errors instead. Raise or lower `SIGIL_GUARDS_TIMEOUT_MS` (default `1500`) to trade latency against tolerance for slow evaluators.
+
+| Variable | Default | Description |
+|---|---|---|
+| `SIGIL_GUARDS_ENABLED` | `false` | Evaluate `tool_call` requests against Sigil policy. |
+| `SIGIL_GUARDS_FAIL_OPEN` | `true` | Allow tools through when the guard call fails. Set `false` for strict mode. |
+| `SIGIL_GUARDS_TIMEOUT_MS` | `1500` | Per-call timeout for guard requests, in milliseconds. |
+
+The same three variables are honored by the [Claude Code plugin](../claude-code/README.md); both plugins read them from `~/.config/sigil/config.env`.
 
 ## All options
 

--- a/plugins/sigil/internal/agents/claudecode/hook.go
+++ b/plugins/sigil/internal/agents/claudecode/hook.go
@@ -243,12 +243,17 @@ func handlePreToolUse(
 		return
 	}
 
+	guards := envconfig.ResolveGuards(logger)
+	if !guards.Enabled {
+		return
+	}
+
 	modelName := strings.TrimSpace(st.Model)
 	if modelName == "" {
 		modelName = "unknown"
 	}
 
-	failOpen := true
+	failOpen := guards.FailOpen
 	cfg := sigil.Config{
 		API: sigil.APIConfig{
 			Endpoint: sigilEndpoint,
@@ -256,7 +261,7 @@ func handlePreToolUse(
 		Hooks: sigil.HooksConfig{
 			Enabled:  true,
 			Phases:   []sigil.HookPhase{sigil.HookPhasePostflight},
-			Timeout:  1500 * time.Millisecond,
+			Timeout:  time.Duration(guards.TimeoutMs) * time.Millisecond,
 			FailOpen: &failOpen,
 		},
 		GenerationExport: sigil.GenerationExportConfig{
@@ -299,7 +304,18 @@ func handlePreToolUse(
 
 	resp, err := client.EvaluateHook(ctx, req)
 	if err != nil {
+		// The SDK only surfaces an error when FailOpen=false; the fail-open path
+		// returns an allow response with nil err. So reaching here implies strict
+		// mode and we should always emit the deny.
 		logger.Printf("pre_tool_use hook eval: tool=%q endpoint=%q err=%v", toolName, sigilEndpoint, err)
+		out := hookDecision{
+			HookSpecificOutput: hookSpecificOutput{
+				HookEventName:            "PreToolUse",
+				PermissionDecision:       "deny",
+				PermissionDecisionReason: fmt.Sprintf("sigil guard evaluation failed: %v", err),
+			},
+		}
+		_ = json.NewEncoder(stdout).Encode(out)
 		return
 	}
 

--- a/plugins/sigil/internal/agents/claudecode/hook_test.go
+++ b/plugins/sigil/internal/agents/claudecode/hook_test.go
@@ -6,9 +6,12 @@ import (
 	"encoding/json"
 	"io"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -169,6 +172,120 @@ func TestHookEventRouting(t *testing.T) {
 			}
 			if tt.assertState != nil {
 				tt.assertState(t)
+			}
+		})
+	}
+}
+
+func TestHandlePreToolUse(t *testing.T) {
+	var calls atomic.Int32
+	var responseBody atomic.Value
+	responseBody.Store("")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		body, _ := responseBody.Load().(string)
+		if body == "" {
+			body = `{"action":"allow"}`
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	closed := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	closed.Close()
+
+	tests := []struct {
+		name               string
+		env                map[string]string
+		useClosedEndpoint  bool
+		serverResponds     string
+		expectServerCall   bool
+		wantStdoutContains string
+		wantStdoutEmpty    bool
+	}{
+		{
+			name:            "disabled_by_default_no_env",
+			wantStdoutEmpty: true,
+		},
+		{
+			name:            "disabled_explicit_false",
+			env:             map[string]string{"SIGIL_GUARDS_ENABLED": "false"},
+			wantStdoutEmpty: true,
+		},
+		{
+			name:             "enabled_allow_response",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow"}`,
+			expectServerCall: true,
+			wantStdoutEmpty:  true,
+		},
+		{
+			name:               "enabled_deny_response",
+			env:                map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:     `{"action":"deny","reason":"blocked tool"}`,
+			expectServerCall:   true,
+			wantStdoutContains: `"permissionDecision":"deny"`,
+		},
+		{
+			name:              "enabled_fail_open_on_transport_error",
+			env:               map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			useClosedEndpoint: true,
+			wantStdoutEmpty:   true,
+		},
+		{
+			name: "enabled_fail_closed_on_transport_error",
+			env: map[string]string{
+				"SIGIL_GUARDS_ENABLED":   "true",
+				"SIGIL_GUARDS_FAIL_OPEN": "false",
+			},
+			useClosedEndpoint:  true,
+			wantStdoutContains: `"permissionDecision":"deny"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SIGIL_GUARDS_ENABLED", "")
+			t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "")
+			t.Setenv("SIGIL_GUARDS_TIMEOUT_MS", "")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			calls.Store(0)
+			responseBody.Store(tt.serverResponds)
+
+			endpoint := server.URL
+			if tt.useClosedEndpoint {
+				endpoint = closed.URL
+			}
+
+			var stdout bytes.Buffer
+			var logs bytes.Buffer
+			input := &hookInput{
+				HookEventName:  "PreToolUse",
+				SessionID:      "s1",
+				TranscriptPath: "/tmp/t.jsonl",
+				ToolName:       "Bash",
+				ToolInput:      json.RawMessage(`{"command":"echo hi"}`),
+				ToolUseID:      "tu_1",
+			}
+			st := state.Session{Model: "claude-sonnet-4"}
+
+			handlePreToolUse(context.Background(), &stdout, input, st, endpoint, "tenant", "token", log.New(&logs, "", 0))
+
+			if tt.expectServerCall && calls.Load() == 0 {
+				t.Errorf("expected server call, got 0")
+			}
+			if !tt.expectServerCall && !tt.useClosedEndpoint && calls.Load() != 0 {
+				t.Errorf("expected no server call, got %d", calls.Load())
+			}
+			if tt.wantStdoutEmpty && stdout.Len() != 0 {
+				t.Errorf("stdout not empty: %q", stdout.String())
+			}
+			if tt.wantStdoutContains != "" && !strings.Contains(stdout.String(), tt.wantStdoutContains) {
+				t.Errorf("stdout = %q, want substring %q", stdout.String(), tt.wantStdoutContains)
 			}
 		})
 	}

--- a/plugins/sigil/internal/envconfig/envconfig.go
+++ b/plugins/sigil/internal/envconfig/envconfig.go
@@ -5,6 +5,7 @@ package envconfig
 import (
 	"log"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/grafana/sigil-sdk/go/sigil"
@@ -93,4 +94,63 @@ func ResolveContentMode(logger *log.Logger) sigil.ContentCaptureMode {
 		return sigil.ContentCaptureModeMetadataOnly
 	}
 	return mode
+}
+
+// GuardsConfig is the resolved guard feature flags for a hook handler.
+// Mirrors plugins/pi/src/config.ts::GuardsFeatureConfig so a single
+// ~/.config/sigil/config.env drives both plugins.
+type GuardsConfig struct {
+	Enabled   bool
+	TimeoutMs int
+	FailOpen  bool
+}
+
+const (
+	defaultGuardsEnabled   = false
+	defaultGuardsTimeoutMs = 1500
+	defaultGuardsFailOpen  = true
+)
+
+// ResolveGuards reads SIGIL_GUARDS_ENABLED / _TIMEOUT_MS / _FAIL_OPEN and
+// returns the effective guard configuration. Unset or empty values fall back
+// to the defaults (off / 1500ms / fail-open). Unrecognised boolean values and
+// non-numeric, zero, or negative timeout values are reported via logger when
+// non-nil and fall back to the default — matching pi's resolveGuards behaviour
+// so the shared config.env produces identical results across plugins. Hooks
+// must not write to stderr, so callers pass their adapter logger here.
+func ResolveGuards(logger *log.Logger) GuardsConfig {
+	cfg := GuardsConfig{
+		Enabled:   resolveGuardsBool(logger, "SIGIL_GUARDS_ENABLED", defaultGuardsEnabled),
+		TimeoutMs: defaultGuardsTimeoutMs,
+		FailOpen:  resolveGuardsBool(logger, "SIGIL_GUARDS_FAIL_OPEN", defaultGuardsFailOpen),
+	}
+	if v := strings.TrimSpace(os.Getenv("SIGIL_GUARDS_TIMEOUT_MS")); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			if logger != nil {
+				logger.Printf("config: invalid SIGIL_GUARDS_TIMEOUT_MS=%q; using %d", v, defaultGuardsTimeoutMs)
+			}
+		} else {
+			cfg.TimeoutMs = n
+		}
+	}
+	return cfg
+}
+
+func resolveGuardsBool(logger *log.Logger, key string, def bool) bool {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return def
+	}
+	switch strings.ToLower(raw) {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		if logger != nil {
+			logger.Printf("config: invalid %s=%q; using %v", key, raw, def)
+		}
+		return def
+	}
 }

--- a/plugins/sigil/internal/envconfig/envconfig_test.go
+++ b/plugins/sigil/internal/envconfig/envconfig_test.go
@@ -1,7 +1,10 @@
 package envconfig
 
 import (
+	"bytes"
+	"log"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -71,5 +74,128 @@ func TestParseExtraTags(t *testing.T) {
 		if !reflect.DeepEqual(got, tc.want) {
 			t.Errorf("ParseExtraTags(%q) = %v, want %v", tc.in, got, tc.want)
 		}
+	}
+}
+
+func TestResolveGuards(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     map[string]string
+		want    GuardsConfig
+		wantLog string
+	}{
+		{
+			name: "defaults_no_env",
+			env:  nil,
+			want: GuardsConfig{Enabled: false, TimeoutMs: 1500, FailOpen: true},
+		},
+		{
+			name: "explicit_enable_true",
+			env:  map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			want: GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+		},
+		{
+			name: "explicit_enable_yes",
+			env:  map[string]string{"SIGIL_GUARDS_ENABLED": "yes"},
+			want: GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+		},
+		{
+			name: "explicit_enable_1",
+			env:  map[string]string{"SIGIL_GUARDS_ENABLED": "1"},
+			want: GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+		},
+		{
+			name: "explicit_disable_false",
+			env:  map[string]string{"SIGIL_GUARDS_ENABLED": "false"},
+			want: GuardsConfig{Enabled: false, TimeoutMs: 1500, FailOpen: true},
+		},
+		{
+			name: "explicit_disable_0",
+			env:  map[string]string{"SIGIL_GUARDS_ENABLED": "0"},
+			want: GuardsConfig{Enabled: false, TimeoutMs: 1500, FailOpen: true},
+		},
+		{
+			name: "explicit_disable_no",
+			env:  map[string]string{"SIGIL_GUARDS_ENABLED": "no"},
+			want: GuardsConfig{Enabled: false, TimeoutMs: 1500, FailOpen: true},
+		},
+		{
+			name: "whitespace_enabled",
+			env:  map[string]string{"SIGIL_GUARDS_ENABLED": " true "},
+			want: GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+		},
+		{
+			name: "fail_open_disabled",
+			env:  map[string]string{"SIGIL_GUARDS_FAIL_OPEN": "false"},
+			want: GuardsConfig{Enabled: false, TimeoutMs: 1500, FailOpen: false},
+		},
+		{
+			name: "custom_timeout",
+			env:  map[string]string{"SIGIL_GUARDS_TIMEOUT_MS": "500"},
+			want: GuardsConfig{Enabled: false, TimeoutMs: 500, FailOpen: true},
+		},
+		{
+			name:    "invalid_timeout_string",
+			env:     map[string]string{"SIGIL_GUARDS_TIMEOUT_MS": "abc"},
+			want:    GuardsConfig{Enabled: false, TimeoutMs: 1500, FailOpen: true},
+			wantLog: `invalid SIGIL_GUARDS_TIMEOUT_MS="abc"`,
+		},
+		{
+			name:    "zero_timeout",
+			env:     map[string]string{"SIGIL_GUARDS_TIMEOUT_MS": "0"},
+			want:    GuardsConfig{Enabled: false, TimeoutMs: 1500, FailOpen: true},
+			wantLog: `invalid SIGIL_GUARDS_TIMEOUT_MS="0"`,
+		},
+		{
+			name:    "negative_timeout",
+			env:     map[string]string{"SIGIL_GUARDS_TIMEOUT_MS": "-1"},
+			want:    GuardsConfig{Enabled: false, TimeoutMs: 1500, FailOpen: true},
+			wantLog: `invalid SIGIL_GUARDS_TIMEOUT_MS="-1"`,
+		},
+		{
+			name: "all_three_set",
+			env: map[string]string{
+				"SIGIL_GUARDS_ENABLED":    "true",
+				"SIGIL_GUARDS_FAIL_OPEN":  "false",
+				"SIGIL_GUARDS_TIMEOUT_MS": "2000",
+			},
+			want: GuardsConfig{Enabled: true, TimeoutMs: 2000, FailOpen: false},
+		},
+		{
+			name:    "invalid_enabled_typo_uses_default",
+			env:     map[string]string{"SIGIL_GUARDS_ENABLED": "ture"},
+			want:    GuardsConfig{Enabled: false, TimeoutMs: 1500, FailOpen: true},
+			wantLog: `invalid SIGIL_GUARDS_ENABLED="ture"`,
+		},
+		{
+			name:    "invalid_fail_open_typo_uses_default",
+			env:     map[string]string{"SIGIL_GUARDS_FAIL_OPEN": "fals"},
+			want:    GuardsConfig{Enabled: false, TimeoutMs: 1500, FailOpen: true},
+			wantLog: `invalid SIGIL_GUARDS_FAIL_OPEN="fals"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SIGIL_GUARDS_ENABLED", "")
+			t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "")
+			t.Setenv("SIGIL_GUARDS_TIMEOUT_MS", "")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			var buf bytes.Buffer
+			logger := log.New(&buf, "", 0)
+			got := ResolveGuards(logger)
+			if got != tt.want {
+				t.Errorf("ResolveGuards() = %+v, want %+v", got, tt.want)
+			}
+			if tt.wantLog != "" && !strings.Contains(buf.String(), tt.wantLog) {
+				t.Errorf("log output = %q, want substring %q", buf.String(), tt.wantLog)
+			}
+			if tt.wantLog == "" && buf.Len() != 0 {
+				t.Errorf("unexpected log output: %q", buf.String())
+			}
+		})
 	}
 }


### PR DESCRIPTION
Claude Code's `PreToolUse` handler hardcoded guards as enabled with a fixed 1500ms timeout and fail-open behaviour, so the shared `~/.config/sigil/config.env` that already work for Pi agent had no effect on Claude Code.

Resolve `SIGIL_GUARDS_ENABLED` / `_TIMEOUT_MS` / `_FAIL_OPEN` mirroring Pi's parsing so a single `config.env` produces identical behaviour across plugins. Guards are off by default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Claude Code `PreToolUse` guard behavior to be driven by environment flags, which can affect whether tool calls are evaluated/blocked and how failures are handled. Risk is moderated by guards defaulting to disabled and added test coverage for allow/deny and fail-open vs fail-closed paths.
> 
> **Overview**
> Claude Code’s `PreToolUse` hook now **conditionally runs Sigil guard evaluation** based on `SIGIL_GUARDS_ENABLED`, with `SIGIL_GUARDS_TIMEOUT_MS` and `SIGIL_GUARDS_FAIL_OPEN` controlling timeout and fail-open/strict behavior (matching Pi’s semantics).
> 
> Adds shared guard env parsing via `envconfig.ResolveGuards`, updates error handling to emit an explicit deny decision in strict mode when guard evaluation fails, and expands unit tests/docs in both `claude-code` and `pi` READMEs to cover the new variables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25c4c4fe1c5bd84a830a2d7b1b007b5a430a9424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->