### PR TITLE
feat(sdk-js): capture Output.object schema into Generation.tools

### DIFF
--- a/js/src/frameworks/vercel-ai-sdk/hooks.ts
+++ b/js/src/frameworks/vercel-ai-sdk/hooks.ts
@@ -5,11 +5,13 @@ import type {
   GenerationRecorder,
   HookEvaluateResponse,
   Message,
+  ToolDefinition,
   ToolExecutionRecorder,
 } from '../../types.js';
 import {
   buildFrameworkMetadata,
   buildFrameworkTags,
+  extractOutputSchemaTool,
   extractStepNumber,
   isTextChunk,
   mapInputMessages,
@@ -44,6 +46,9 @@ interface StepState {
   stepStartEvent: StepStartEvent;
   toolCallIds: Set<string>;
   hasToolCalls: boolean;
+  outputSchemaPromise?: Promise<ToolDefinition | undefined>;
+  outputSchemaTool?: ToolDefinition;
+  outputSchemaResolved: boolean;
 }
 
 interface ToolState {
@@ -219,12 +224,33 @@ export class SigilVercelAiSdkInstrumentation {
         stepStartEvent: params.stepStartEvent,
         toolCallIds: new Set<string>(),
         hasToolCalls: false,
+        outputSchemaResolved: false,
       };
       state.stepStates.set(params.stepNumber, stepState);
       if (mode === 'STREAM') {
         hasCreatedStreamStepState = true;
       }
+      kickOffOutputSchemaExtraction(stepState);
       return stepState;
+    };
+    const kickOffOutputSchemaExtraction = (stepState: StepState): void => {
+      const outputRef = stepState.stepStartEvent.output;
+      if (outputRef === undefined || outputRef === null) {
+        stepState.outputSchemaResolved = true;
+        return;
+      }
+      const promise = extractOutputSchemaTool(outputRef).then(
+        (tool) => {
+          stepState.outputSchemaTool = tool;
+          stepState.outputSchemaResolved = true;
+          return tool;
+        },
+        () => {
+          stepState.outputSchemaResolved = true;
+          return undefined;
+        },
+      );
+      stepState.outputSchemaPromise = promise;
     };
     const resolveOrCreateStepStateForFinish = (params: {
       eventStepNumber: unknown;
@@ -573,49 +599,66 @@ export class SigilVercelAiSdkInstrumentation {
         const usage = mapUsageFromStepFinish(event);
         const isError = shouldTreatStepAsError(event);
 
-        try {
-          recorder.setResult({
-            conversationId: conversation.conversationId,
-            agentName: callAgentName,
-            agentVersion: this.agentVersion,
-            operationName,
-            input: this.captureInputs ? stepState.inputMessages : undefined,
-            output: this.captureOutputs ? outputMapping.output : undefined,
-            usage,
-            stopReason: response.finishReason,
-            responseId: response.responseId,
-            responseModel: response.responseModel,
-            tags,
-            metadata,
-            completedAt: new Date(),
-          });
-          if (isError) {
-            recorder.setCallError(event.error ?? new Error('step finished with error'));
+        const completeFinish = (schemaTool: ToolDefinition | undefined): void => {
+          const tools = schemaTool !== undefined ? [schemaTool] : undefined;
+          try {
+            recorder.setResult({
+              conversationId: conversation.conversationId,
+              agentName: callAgentName,
+              agentVersion: this.agentVersion,
+              operationName,
+              input: this.captureInputs ? stepState.inputMessages : undefined,
+              output: this.captureOutputs ? outputMapping.output : undefined,
+              usage,
+              stopReason: response.finishReason,
+              responseId: response.responseId,
+              responseModel: response.responseModel,
+              tags,
+              metadata,
+              tools,
+              completedAt: new Date(),
+            });
+            if (isError) {
+              recorder.setCallError(event.error ?? new Error('step finished with error'));
+            }
+          } finally {
+            recorder.end();
           }
-        } finally {
-          recorder.end();
-        }
 
-        const recorderError = recorder.getError();
-        const fallbackToolRecorderError = recordToolExecutionFromStepFinish({
-          stepNumber,
-          stepState,
-          conversationId: conversation.conversationId,
-          output: outputMapping.output,
-        });
-        state.stepStates.delete(stepNumber);
-        if (stepState.toolCallIds.size > 0) {
-          const closeError = isError
-            ? (event.error ?? new Error('parent step failed'))
-            : new Error('tool call did not finish before step completion');
-          closeStepTools(state, stepState, closeError);
+          const recorderError = recorder.getError();
+          const fallbackToolRecorderError = recordToolExecutionFromStepFinish({
+            stepNumber,
+            stepState,
+            conversationId: conversation.conversationId,
+            output: outputMapping.output,
+          });
+          state.stepStates.delete(stepNumber);
+          if (stepState.toolCallIds.size > 0) {
+            const closeError = isError
+              ? (event.error ?? new Error('parent step failed'))
+              : new Error('tool call did not finish before step completion');
+            closeStepTools(state, stepState, closeError);
+          }
+          if (recorderError !== undefined) {
+            throw recorderError;
+          }
+          if (fallbackToolRecorderError !== undefined) {
+            throw fallbackToolRecorderError;
+          }
+        };
+
+        if (stepState.outputSchemaResolved || stepState.outputSchemaPromise === undefined) {
+          completeFinish(stepState.outputSchemaTool);
+          return;
         }
-        if (recorderError !== undefined) {
-          throw recorderError;
-        }
-        if (fallbackToolRecorderError !== undefined) {
-          throw fallbackToolRecorderError;
-        }
+        return stepState.outputSchemaPromise.then(
+          (tool) => {
+            completeFinish(tool);
+          },
+          () => {
+            completeFinish(undefined);
+          },
+        );
       },
       experimental_onToolCallStart: (event: ToolCallStartEvent) => {
         const parsed = parseToolCallStart(event);

--- a/js/src/frameworks/vercel-ai-sdk/index.ts
+++ b/js/src/frameworks/vercel-ai-sdk/index.ts
@@ -6,6 +6,7 @@ export { SigilVercelAiSdkInstrumentation } from './hooks.js';
 export {
   buildFrameworkMetadata,
   buildFrameworkTags,
+  extractOutputSchemaTool,
   fallbackConversationId,
   frameworkIdentity,
   isTextChunk,

--- a/js/src/frameworks/vercel-ai-sdk/mapping.ts
+++ b/js/src/frameworks/vercel-ai-sdk/mapping.ts
@@ -1,4 +1,4 @@
-import type { Message, MessagePart, TokenUsage } from '../../types.js';
+import type { Message, MessagePart, TokenUsage, ToolDefinition } from '../../types.js';
 import type {
   ConversationResolution,
   ParsedToolCall,
@@ -91,6 +91,61 @@ export function extractStepNumber(event: { stepNumber?: unknown }, fallback: num
     return stepNumber;
   }
   return fallback;
+}
+
+/**
+ * Best-effort extraction of an output-schema tool from the AI SDK step-start
+ * `output` reference (set via `generateText({ output: Output.object({ schema }) })`).
+ *
+ * Fail-open: any shape mismatch, schema resolution failure, or serialization
+ * error resolves to `undefined` so schema capture never breaks the generation.
+ */
+export async function extractOutputSchemaTool(output: unknown): Promise<ToolDefinition | undefined> {
+  try {
+    if (!isRecord(output)) {
+      return undefined;
+    }
+    const responseFormatRef = (output as { responseFormat?: unknown }).responseFormat;
+    if (responseFormatRef === undefined || responseFormatRef === null) {
+      return undefined;
+    }
+    const responseFormat = await Promise.resolve(responseFormatRef as unknown);
+    if (!isRecord(responseFormat)) {
+      return undefined;
+    }
+    const formatType = asString((responseFormat as { type?: unknown }).type);
+    if (formatType !== 'json') {
+      return undefined;
+    }
+    const schema = (responseFormat as { schema?: unknown }).schema;
+    if (schema === undefined || schema === null) {
+      return undefined;
+    }
+    let inputSchemaJSON: string;
+    try {
+      const encoded = JSON.stringify(schema);
+      if (encoded === undefined || encoded === 'null') {
+        return undefined;
+      }
+      inputSchemaJSON = encoded;
+    } catch {
+      return undefined;
+    }
+    const formatName = asString((responseFormat as { name?: unknown }).name);
+    const outputName = asString((output as { name?: unknown }).name);
+    const description = asString((responseFormat as { description?: unknown }).description);
+    const tool: ToolDefinition = {
+      name: formatName.length > 0 ? formatName : outputName.length > 0 ? outputName : 'output',
+      type: 'output_schema',
+      inputSchemaJSON,
+    };
+    if (description.length > 0) {
+      tool.description = description;
+    }
+    return tool;
+  } catch {
+    return undefined;
+  }
 }
 
 export function mapModelFromStepStart(event: StepStartEvent): { provider: string; modelName: string } {

--- a/js/src/frameworks/vercel-ai-sdk/types.ts
+++ b/js/src/frameworks/vercel-ai-sdk/types.ts
@@ -13,6 +13,12 @@ export interface StepStartEvent {
   stepNumber?: unknown;
   messages?: unknown;
   model?: StepStartModelRef;
+  /**
+   * Output configuration the AI SDK passes through (e.g. `Output.object(...)`).
+   * Not declared on the public AI SDK type — surfaced at runtime on the step-start
+   * event so adapters can capture the response-format schema.
+   */
+  output?: unknown;
 }
 
 export interface StepFinishResponseRef {

--- a/js/test/frameworks.vercel-ai-sdk.mapping.test.mjs
+++ b/js/test/frameworks.vercel-ai-sdk.mapping.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   buildFrameworkMetadata,
   buildFrameworkTags,
+  extractOutputSchemaTool,
   isTextChunk,
   mapInputMessages,
   mapModelFromStepStart,
@@ -221,6 +222,62 @@ test('vercel ai sdk mapping parses tool lifecycle events', () => {
   assert.equal(finish.toolCallId, 'call-1');
   assert.equal(finish.success, true);
   assert.equal(finish.durationMs, 120);
+});
+
+test('extractOutputSchemaTool returns ToolDefinition for Output.object-style responseFormat', async () => {
+  const schema = {
+    type: 'object',
+    properties: { question: { type: 'string' }, skills: { type: 'array', items: { type: 'string' } } },
+    required: ['question', 'skills'],
+  };
+  const output = {
+    name: 'object',
+    responseFormat: Promise.resolve({ type: 'json', schema, name: 'person', description: 'A person record' }),
+  };
+
+  const tool = await extractOutputSchemaTool(output);
+  assert.ok(tool);
+  assert.equal(tool.name, 'person');
+  assert.equal(tool.type, 'output_schema');
+  assert.equal(tool.description, 'A person record');
+  assert.deepEqual(JSON.parse(tool.inputSchemaJSON), schema);
+});
+
+test('extractOutputSchemaTool falls back to Output.name when responseFormat omits name', async () => {
+  const schema = { type: 'object', properties: { value: { type: 'number' } } };
+  const tool = await extractOutputSchemaTool({
+    name: 'object',
+    responseFormat: { type: 'json', schema },
+  });
+  assert.ok(tool);
+  assert.equal(tool.name, 'object');
+  assert.equal(tool.type, 'output_schema');
+  assert.equal(tool.description, undefined);
+  assert.deepEqual(JSON.parse(tool.inputSchemaJSON), schema);
+});
+
+test('extractOutputSchemaTool returns undefined for missing or non-json output', async () => {
+  assert.equal(await extractOutputSchemaTool(undefined), undefined);
+  assert.equal(await extractOutputSchemaTool(null), undefined);
+  assert.equal(await extractOutputSchemaTool({}), undefined);
+  assert.equal(await extractOutputSchemaTool({ responseFormat: { type: 'text' } }), undefined);
+  assert.equal(await extractOutputSchemaTool({ responseFormat: { type: 'json' } }), undefined);
+});
+
+test('extractOutputSchemaTool fails open when responseFormat promise rejects', async () => {
+  const tool = await extractOutputSchemaTool({
+    responseFormat: Promise.reject(new Error('schema unavailable')),
+  });
+  assert.equal(tool, undefined);
+});
+
+test('extractOutputSchemaTool fails open when schema cannot be serialized', async () => {
+  const circular = { type: 'object' };
+  circular.self = circular;
+  const tool = await extractOutputSchemaTool({
+    responseFormat: { type: 'json', schema: circular },
+  });
+  assert.equal(tool, undefined);
 });
 
 test('vercel ai sdk mapping includes canonical framework identity in tags and metadata', () => {

--- a/js/test/frameworks.vercel-ai-sdk.test.mjs
+++ b/js/test/frameworks.vercel-ai-sdk.test.mjs
@@ -1134,6 +1134,98 @@ test('vercel ai sdk isolates step state across concurrent calls', async () => {
   assert.equal(generationB.output[0].content, 'out-b');
 });
 
+test('vercel ai sdk captures Output.object schema into Generation.tools', async () => {
+  const schema = {
+    type: 'object',
+    properties: {
+      question: { type: 'string' },
+      skills: { type: 'array', items: { type: 'string' } },
+    },
+    required: ['question', 'skills'],
+  };
+  const { generations } = await captureSession(async (client) => {
+    const sigil = createSigilVercelAiSdk(client, { agentName: 'structured-agent' });
+    const hooks = sigil.generateTextHooks({ conversationId: 'conv-output-schema' });
+    hooks.experimental_onStepStart?.({
+      stepNumber: 0,
+      model: { provider: 'openai', modelId: 'gpt-5' },
+      messages: [{ role: 'user', content: 'generate a question' }],
+      output: {
+        name: 'object',
+        responseFormat: Promise.resolve({
+          type: 'json',
+          schema,
+          name: 'question_skills',
+          description: 'Question with associated skills',
+        }),
+      },
+    });
+    await hooks.onStepFinish?.({
+      stepNumber: 0,
+      finishReason: 'stop',
+      text: '{"question":"q?","skills":["s1"]}',
+      response: { id: 'resp-schema', modelId: 'gpt-5' },
+    });
+  });
+
+  assert.equal(generations.length, 1);
+  const [generation] = generations;
+  assert.ok(generation.tools);
+  assert.equal(generation.tools.length, 1);
+  const [tool] = generation.tools;
+  assert.equal(tool.name, 'question_skills');
+  assert.equal(tool.type, 'output_schema');
+  assert.equal(tool.description, 'Question with associated skills');
+  assert.deepEqual(JSON.parse(tool.inputSchemaJSON), schema);
+});
+
+test('vercel ai sdk omits tools entry when no output schema is configured', async () => {
+  const { generations } = await captureSession(async (client) => {
+    const sigil = createSigilVercelAiSdk(client);
+    const hooks = sigil.generateTextHooks({ conversationId: 'conv-no-schema' });
+    hooks.experimental_onStepStart?.({
+      stepNumber: 0,
+      model: { provider: 'openai', modelId: 'gpt-5' },
+      messages: [{ role: 'user', content: 'hello' }],
+    });
+    hooks.onStepFinish?.({
+      stepNumber: 0,
+      finishReason: 'stop',
+      text: 'hi',
+      response: { id: 'resp-no-schema', modelId: 'gpt-5' },
+    });
+  });
+
+  assert.equal(generations.length, 1);
+  assert.equal(generations[0].tools, undefined);
+});
+
+test('vercel ai sdk recovers without tools when output schema extraction fails', async () => {
+  const { generations } = await captureSession(async (client) => {
+    const sigil = createSigilVercelAiSdk(client);
+    const hooks = sigil.generateTextHooks({ conversationId: 'conv-schema-fail' });
+    hooks.experimental_onStepStart?.({
+      stepNumber: 0,
+      model: { provider: 'openai', modelId: 'gpt-5' },
+      messages: [{ role: 'user', content: 'hello' }],
+      output: {
+        name: 'object',
+        responseFormat: Promise.reject(new Error('schema resolution failed')),
+      },
+    });
+    await hooks.onStepFinish?.({
+      stepNumber: 0,
+      finishReason: 'stop',
+      text: 'recovered',
+      response: { id: 'resp-fail', modelId: 'gpt-5' },
+    });
+  });
+
+  assert.equal(generations.length, 1);
+  assert.equal(generations[0].tools, undefined);
+  assert.equal(generations[0].output[0].content, 'recovered');
+});
+
 async function captureSingleGeneration(run) {
   const { generations } = await captureSession(run);
   assert.equal(generations.length, 1);


### PR DESCRIPTION
Vercel AI SDK calls using `generateText({ output: Output.object({ schema }) })` were arriving in Sigil with `Generation.tools` empty — the adapter only mapped tool-call schemas surfaced via step output, not the response-format schema attached through `experimental_output`. Users had no way to see which structured shape the model was constrained to without inspecting source.

The AI SDK runtime sets the user's `output` reference on the step-start event (not declared on the public type, but present on the event object passed to `experimental_onStepStart`). Read it there, await `responseFormat`, and inject a `ToolDefinition` (`name = format.name || output.name || 'output'`, `type = 'output_schema'`, `inputSchemaJSON = JSON.stringify(schema)`) into `setResult.tools` for the generation. No new `CallOptions` surface — common case stays automatic and apps do not duplicate schemas.

Extraction is fail-open at every layer (try/catch around schema resolution, serialization, and the promise chain). If the response format is not JSON, the schema is missing, the promise rejects, or the schema can't be serialized, the tool is dropped and the generation records normally without tools. Stream-failure paths leave `tools` unset.

Closes #169

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes generation finalization flow to optionally await async schema extraction before recording results; a bug here could delay or omit generation exports, though the logic is explicitly fail-open.
> 
> **Overview**
> Adds **best-effort capture of Vercel AI SDK structured output schemas** (from step-start `output.responseFormat`) and records them as a `ToolDefinition` (`type: 'output_schema'`) on `Generation.tools`.
> 
> Instrumentation now kicks off schema extraction on `experimental_onStepStart` and, on `onStepFinish`, waits for the extraction (when available) before calling `recorder.setResult`; failures/rejections/serialization issues intentionally resolve to *no tools* so generation recording continues normally. Includes updated public exports (`extractOutputSchemaTool`), extends `StepStartEvent` with `output?: unknown`, and adds tests covering success, fallbacks, and fail-open behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 775d0e780d9b0c65930b6ac2af4013196a76e589. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->