### PR TITLE
feat(plugins/copilot): add sigil copilot launcher

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -4,12 +4,13 @@ Send conversations from your coding agent to [Grafana AI Observability](https://
 
 > AI Observability is in [public preview](https://grafana.com/docs/release-life-cycle/).
 
-## Fastest start (Claude Code, Codex, or pi)
+## Fastest start (Claude Code, Codex, Copilot, or pi)
 
 ```sh
 brew install grafana/grafana/sigil
 sigil claude     # for Claude Code
 sigil codex      # for Codex
+sigil copilot    # for Copilot CLI
 sigil pi         # for pi
 ```
 

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -26,6 +26,15 @@ which sigil
 
 ## 2. Register the plugin
 
+```sh
+sigil copilot
+```
+
+The launcher resolves `copilot` on `PATH`, registers `sigil-copilot` with copilot on first run, then execs copilot.
+
+<details>
+<summary>Manual install</summary>
+
 The current
 [GitHub Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference)
 documents both local-path and GitHub-subdirectory install forms:
@@ -45,6 +54,8 @@ Confirm the install:
 ```sh
 copilot plugin list
 ```
+
+</details>
 
 ## 3. Add your credentials
 
@@ -172,7 +183,7 @@ The plugin always tags exported generations with:
 
 | Symptom | Try |
 |---|---|
-| Plugin does not appear in `copilot plugin list` | Re-run `copilot plugin install ./plugins/copilot` or the GitHub subdir install form. Confirm `plugin.json` is at the plugin root. |
+| Plugin does not appear in `copilot plugin list` | Re-run `sigil copilot` or `copilot plugin install grafana/sigil-sdk:plugins/copilot`. Confirm `plugin.json` is at the plugin root. |
 | Command not found | Reinstall: `brew install grafana/grafana/sigil`. Check `sigil --version`. |
 | Hooks run but nothing appears in Sigil | Check `SIGIL_ENDPOINT`, `SIGIL_AUTH_TENANT_ID`, and `SIGIL_AUTH_TOKEN`. Without all three, the plugin discards the completed fragment. |
 | No latency/tool charts in AI Observability | Set `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` so the plugin can emit traces and metrics. |

--- a/plugins/sigil/cmd/sigil/main.go
+++ b/plugins/sigil/cmd/sigil/main.go
@@ -1,18 +1,19 @@
 // Command sigil is the single binary used by the Claude Code, Codex,
 // Copilot, Cursor, and pi agent plugins. It accepts:
 //
-//	sigil <agent> hook           — dispatch a JSON hook payload on stdin to <agent>
-//	sigil claude [-- args...]    — exec claude after bootstrapping the sigil-cc plugin
-//	sigil codex  [-- args...]    — exec codex after bootstrapping the sigil-codex plugin
-//	sigil pi     [-- args...]    — exec pi after bootstrapping the @grafana/sigil-pi extension
-//	sigil --version              — print the build version
+//	sigil <agent> hook            — dispatch a JSON hook payload on stdin to <agent>
+//	sigil claude  [-- args...]    — exec claude after bootstrapping the sigil-cc plugin
+//	sigil codex   [-- args...]    — exec codex after bootstrapping the sigil-codex plugin
+//	sigil copilot [-- args...]    — exec copilot after bootstrapping the sigil-copilot plugin
+//	sigil pi      [-- args...]    — exec pi after bootstrapping the @grafana/sigil-pi extension
+//	sigil --version               — print the build version
 //
 // Unknown agents and unknown verbs exit with code 2 and a usage message on
 // stderr. For hook agents the binary must never crash the calling agent
 // process; once argv parsing succeeds, all errors are swallowed (and logged
 // when SIGIL_DEBUG=true) and the process exits 0. Launcher agents (`claude`,
-// `codex`, and `pi`) are invoked by a human, so errors surface on stderr
-// with a non-zero exit code.
+// `codex`, `copilot`, and `pi`) are invoked by a human, so errors surface on
+// stderr with a non-zero exit code.
 package main
 
 import (
@@ -34,7 +35,7 @@ import (
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/login"
 )
 
-const usageLine = "usage: sigil login | sigil <agent> hook | sigil claude [-- args...] | sigil codex [-- args...] | sigil pi [-- args...]"
+const usageLine = "usage: sigil login | sigil <agent> hook | sigil claude [-- args...] | sigil codex [-- args...] | sigil copilot [-- args...] | sigil pi [-- args...]"
 
 // version is overridden via -ldflags at build time.
 var version = "dev"
@@ -61,9 +62,10 @@ var agents = map[string]agentHook{
 // process with the target CLI. The launcher name is the target CLI's own
 // name (`claude`, `pi`), not the hook agent name (`claude-code`).
 var launchers = map[string]agentLauncher{
-	"claude": claudecode.Launch,
-	"codex":  codex.Launch,
-	"pi":     pi.Launch,
+	"claude":  claudecode.Launch,
+	"codex":   codex.Launch,
+	"copilot": copilot.Launch,
+	"pi":      pi.Launch,
 }
 
 // exit is a package var so tests can intercept termination.

--- a/plugins/sigil/internal/agents/copilot/launch.go
+++ b/plugins/sigil/internal/agents/copilot/launch.go
@@ -1,0 +1,125 @@
+package copilot
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+const (
+	// installSource is the GitHub subdir spec passed to
+	// `copilot plugin install`. Copilot CLI documents
+	// `OWNER/REPO:PATH/TO/PLUGIN` as a first-class install form, so the
+	// launcher uses a single-step install with no separate marketplace step.
+	installSource = "grafana/sigil-sdk:plugins/copilot"
+	// PluginName is the plugin name declared in plugins/copilot/plugin.json.
+	PluginName = "sigil-copilot"
+)
+
+// Test seams.
+var (
+	lookPath   = exec.LookPath
+	execFn     = syscall.Exec
+	runInstall = defaultRunInstall
+	pluginList = defaultPluginList
+)
+
+// Launch resolves the `copilot` binary on PATH, ensures the sigil-copilot
+// plugin is registered in copilot's plugin store (running
+// `copilot plugin install grafana/sigil-sdk:plugins/copilot` once if it is
+// not), and then exec's copilot with the supplied args.
+func Launch(ctx context.Context, args []string, _ io.Reader, _, stderr io.Writer, logger *log.Logger) error {
+	bin, err := lookPath("copilot")
+	if err != nil {
+		return fmt.Errorf("copilot CLI not found on PATH: %w", err)
+	}
+
+	installed, err := pluginInstalled(ctx, bin)
+	if err != nil {
+		// Treat a failed `copilot plugin list` the same as missing: log the
+		// probe failure for SIGIL_DEBUG, then let `copilot plugin install`
+		// run. copilot's own CLI is the source of truth and will fail loudly
+		// if something is genuinely wrong.
+		logger.Printf("copilot plugin list probe: %v", err)
+		installed = false
+	}
+	if !installed {
+		_, _ = fmt.Fprintf(stderr, "sigil: registering %s with copilot\n", PluginName)
+		if err := runInstall(ctx, bin, stderr); err != nil {
+			// Don't block the user's copilot session on a failed install
+			// (offline machine, sandboxed CI, GitHub rate limit, etc.). Log
+			// for SIGIL_DEBUG, point the user at the manual command, and
+			// fall through to exec. copilot still runs, just without Sigil
+			// capture.
+			logger.Printf("install %s: %v", PluginName, err)
+			_, _ = fmt.Fprintf(stderr,
+				"sigil: install of %s failed: %v\n"+
+					"sigil: continuing without Sigil capture. To retry manually:\n"+
+					"          copilot plugin install %s\n",
+				PluginName, err, installSource)
+		}
+	}
+
+	argv := append([]string{bin}, args...)
+	if err := execFn(bin, argv, os.Environ()); err != nil {
+		return fmt.Errorf("exec copilot: %w", err)
+	}
+	return nil
+}
+
+func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {
+	cmd := exec.CommandContext(ctx, bin, "plugin", "install", installSource)
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("copilot plugin install %s: %w", installSource, err)
+	}
+	return nil
+}
+
+// defaultPluginList shells out to `copilot plugin list` and returns the raw
+// output. Output is human-formatted but stable for direct installs: a
+// `Installed plugins:` header followed by one `  • <plugin> (v<ver>)` line
+// per plugin.
+func defaultPluginList(ctx context.Context, bin string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, bin, "plugin", "list")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		if msg := bytes.TrimSpace(stderr.Bytes()); len(msg) > 0 {
+			return nil, fmt.Errorf("%w: %s", err, msg)
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+// pluginInstalled reports whether `sigil-copilot` is registered in copilot's
+// plugin store. Disabled-state detection is deferred until we confirm
+// copilot's `plugin list` output for a disabled plugin — for now, presence
+// counts as installed.
+func pluginInstalled(ctx context.Context, bin string) (bool, error) {
+	out, err := pluginList(ctx, bin)
+	if err != nil {
+		return false, err
+	}
+	needle := []byte(PluginName)
+	// Lines look like `  • sigil-copilot (v0.1.0)`. Strip leading whitespace
+	// and the bullet glyph, then exact-match the first remaining token. This
+	// rejects the `Installed plugins:` header, a bare bullet line, and
+	// suffix collisions like `my-sigil-copilot`.
+	for _, line := range bytes.Split(out, []byte{'\n'}) {
+		trimmed := bytes.TrimLeft(bytes.TrimSpace(line), "•*-+ \t")
+		fields := bytes.Fields(trimmed)
+		if len(fields) > 0 && bytes.Equal(fields[0], needle) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/plugins/sigil/internal/agents/copilot/launch_test.go
+++ b/plugins/sigil/internal/agents/copilot/launch_test.go
@@ -1,0 +1,253 @@
+package copilot
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestLaunch(t *testing.T) {
+	const binPath = "/usr/local/bin/copilot"
+	pluginInstalledOut := []byte("Installed plugins:\n  • sigil-copilot (v0.1.0)\n")
+	pluginOtherOut := []byte("Installed plugins:\n  • other-plugin (v1.0.0)\n")
+	pluginEmptyOut := []byte("Installed plugins:\n")
+
+	cases := []struct {
+		name string
+
+		lookPath   func(string) (string, error)
+		pluginList func(context.Context, string) ([]byte, error)
+		runInstall func(context.Context, string, io.Writer) error // nil = success
+		execFn     func(string, []string, []string) error         // nil = success
+		args       []string
+
+		wantErr      string   // substring; "" means no error
+		wantInstall  int      // expected runInstall call count
+		wantExec     bool     // whether execFn must be called
+		wantExecArgv []string // nil = don't assert
+		wantStderr   []string // substrings that must appear in stderr
+		wantLog      []string // substrings that must appear in the logger output
+	}{
+		{
+			name:     "missing copilot binary",
+			lookPath: func(string) (string, error) { return "", exec.ErrNotFound },
+			wantErr:  "copilot CLI not found",
+		},
+		{
+			name:         "skips install when plugin installed and forwards args",
+			lookPath:     func(string) (string, error) { return binPath, nil },
+			pluginList:   func(context.Context, string) ([]byte, error) { return pluginInstalledOut, nil },
+			args:         []string{"exec", "hi"},
+			wantInstall:  0,
+			wantExec:     true,
+			wantExecArgv: []string{binPath, "exec", "hi"},
+		},
+		{
+			name:        "runs install when plugin missing",
+			lookPath:    func(string) (string, error) { return binPath, nil },
+			pluginList:  func(context.Context, string) ([]byte, error) { return pluginOtherOut, nil },
+			wantInstall: 1,
+			wantExec:    true,
+			wantStderr:  []string{"registering " + PluginName + " with copilot"},
+		},
+		{
+			name:        "runs install when plugin list probe fails",
+			lookPath:    func(string) (string, error) { return binPath, nil },
+			pluginList:  func(context.Context, string) ([]byte, error) { return nil, errors.New("probe boom") },
+			wantInstall: 1,
+			wantExec:    true,
+			wantLog:     []string{"probe boom"},
+		},
+		{
+			name:        "continues when install fails",
+			lookPath:    func(string) (string, error) { return binPath, nil },
+			pluginList:  func(context.Context, string) ([]byte, error) { return pluginEmptyOut, nil },
+			runInstall:  func(context.Context, string, io.Writer) error { return errors.New("network down") },
+			wantInstall: 1,
+			wantExec:    true,
+			wantStderr: []string{
+				"install of " + PluginName + " failed",
+				"network down",
+				"copilot plugin install grafana/sigil-sdk:plugins/copilot",
+			},
+		},
+		{
+			name:       "exec failure surfaces error",
+			lookPath:   func(string) (string, error) { return binPath, nil },
+			pluginList: func(context.Context, string) ([]byte, error) { return pluginInstalledOut, nil },
+			execFn:     func(string, []string, []string) error { return errors.New("exec boom") },
+			wantExec:   true,
+			wantErr:    "exec copilot",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withLookPath(t, tc.lookPath)
+
+			listFn := tc.pluginList
+			if listFn == nil {
+				listFn = func(context.Context, string) ([]byte, error) {
+					t.Fatal("pluginList must not be called")
+					return nil, nil
+				}
+			}
+			withPluginList(t, listFn)
+
+			installFn := tc.runInstall
+			if installFn == nil {
+				installFn = func(context.Context, string, io.Writer) error { return nil }
+			}
+			installCalls := 0
+			withRunInstall(t, func(ctx context.Context, bin string, w io.Writer) error {
+				installCalls++
+				if bin != binPath {
+					t.Errorf("install bin = %q, want %q", bin, binPath)
+				}
+				return installFn(ctx, bin, w)
+			})
+
+			execMock := tc.execFn
+			if execMock == nil {
+				execMock = func(string, []string, []string) error { return nil }
+			}
+			var execArgv []string
+			execCalled := false
+			withExecFn(t, func(p string, argv []string, env []string) error {
+				execCalled = true
+				execArgv = append([]string{}, argv...)
+				return execMock(p, argv, env)
+			})
+
+			var stderr bytes.Buffer
+			var logbuf bytes.Buffer
+			logger := log.New(&logbuf, "", 0)
+
+			err := Launch(context.Background(), tc.args, strings.NewReader(""), io.Discard, &stderr, logger)
+
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want contains %q", err, tc.wantErr)
+				}
+			} else if err != nil {
+				t.Fatalf("Launch returned err: %v", err)
+			}
+			if installCalls != tc.wantInstall {
+				t.Errorf("runInstall calls = %d, want %d", installCalls, tc.wantInstall)
+			}
+			if execCalled != tc.wantExec {
+				t.Errorf("execFn called = %v, want %v", execCalled, tc.wantExec)
+			}
+			if tc.wantExecArgv != nil && !reflect.DeepEqual(execArgv, tc.wantExecArgv) {
+				t.Errorf("exec argv = %v, want %v", execArgv, tc.wantExecArgv)
+			}
+			for _, want := range tc.wantStderr {
+				if !strings.Contains(stderr.String(), want) {
+					t.Errorf("stderr missing %q: %q", want, stderr.String())
+				}
+			}
+			for _, want := range tc.wantLog {
+				if !strings.Contains(logbuf.String(), want) {
+					t.Errorf("log missing %q: %q", want, logbuf.String())
+				}
+			}
+		})
+	}
+}
+
+func TestPluginInstalled_ParsesPluginListOutput(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want bool
+	}{
+		{
+			name: "real direct-install output",
+			out:  "Installed plugins:\n  • sigil-copilot (v0.1.0)\n",
+			want: true,
+		},
+		{
+			name: "header line only",
+			out:  "Installed plugins:\n",
+			want: false,
+		},
+		{
+			name: "empty",
+			out:  "",
+			want: false,
+		},
+		{
+			name: "other plugin",
+			out:  "Installed plugins:\n  • other-plugin (v1.0.0)\n",
+			want: false,
+		},
+		{
+			name: "prefix collision",
+			out:  "Installed plugins:\n  • my-sigil-copilot (v0.1.0)\n",
+			want: false,
+		},
+		{
+			name: "suffix collision",
+			out:  "Installed plugins:\n  • sigil-copilot-staging (v0.1.0)\n",
+			want: false,
+		},
+		{
+			name: "bare bullet line",
+			out:  "Installed plugins:\n  •\n",
+			want: false,
+		},
+		{
+			name: "sigil-copilot among other plugins",
+			out:  "Installed plugins:\n  • other (v1.0.0)\n  • sigil-copilot (v0.1.0)\n",
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withPluginList(t, func(context.Context, string) ([]byte, error) {
+				return []byte(tc.out), nil
+			})
+			got, err := pluginInstalled(context.Background(), "/usr/local/bin/copilot")
+			if err != nil {
+				t.Fatalf("err = %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func withLookPath(t *testing.T, fn func(string) (string, error)) {
+	t.Helper()
+	prev := lookPath
+	t.Cleanup(func() { lookPath = prev })
+	lookPath = fn
+}
+
+func withRunInstall(t *testing.T, fn func(context.Context, string, io.Writer) error) {
+	t.Helper()
+	prev := runInstall
+	t.Cleanup(func() { runInstall = prev })
+	runInstall = fn
+}
+
+func withExecFn(t *testing.T, fn func(string, []string, []string) error) {
+	t.Helper()
+	prev := execFn
+	t.Cleanup(func() { execFn = prev })
+	execFn = fn
+}
+
+func withPluginList(t *testing.T, fn func(context.Context, string) ([]byte, error)) {
+	t.Helper()
+	prev := pluginList
+	t.Cleanup(func() { pluginList = prev })
+	pluginList = fn
+}


### PR DESCRIPTION
Add a `sigil copilot` subcommand so users can run Copilot CLI in one step, matching `sigil claude`, `sigil pi`, and others.

On first run the launcher installs the plugin via `copilot plugin install grafana/sigil-sdk:plugins/copilot` and then execs copilot. Plugin presence is checked via `copilot plugin list`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: introduces new launcher/exec path and plugin auto-install behavior that shells out to `copilot` and changes `sigil` CLI dispatch/usage strings; failures could affect how users start Copilot via Sigil.
> 
> **Overview**
> Adds first-class `sigil copilot` support: the `sigil` binary can now launch Copilot CLI, detect whether `sigil-copilot` is registered via `copilot plugin list`, and run a one-time `copilot plugin install grafana/sigil-sdk:plugins/copilot` when missing (non-blocking if install fails).
> 
> Updates Copilot plugin docs and the top-level plugins README to advertise the new one-step launcher flow, and adds unit tests covering install detection, error handling, and argument forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbdb67bb646399424ecab14cd88e21761e31ef5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->