### PR TITLE
chore(plugins/claude): bump claude code plugin version

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sigil-cc",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Send Claude Code session telemetry to Grafana Sigil",
   "author": {
     "name": "Grafana Labs"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that only updates the plugin version in `plugin.json` with no behavioral or runtime logic changes.
> 
> **Overview**
> Bumps the Claude Code plugin (`sigil-cc`) version in `plugins/claude-code/.claude-plugin/plugin.json` from `0.1.0` to `0.2.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51b1ba31b9e46d1449ac5cdfb2b3281732a06980. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->