### PR TITLE
feat(plugins): auto-update sigil plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "sigil-cc",
       "source": "./plugins/claude-code",
       "description": "Send Claude Code session telemetry to Grafana Sigil",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "Grafana Labs"
       }

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -87,6 +87,7 @@ Common culprits: `sigil --version` doesn't work (binary not on `PATH`), a missin
 | `SIGIL_USER_ID` | from `~/.claude.json` | Override the user id. |
 | `SIGIL_USER_ID_SOURCE` | `email` | Which field to read from `~/.claude.json`: `email` or `accountUuid`. |
 | `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
+| `SIGIL_AUTO_UPDATE` | `true` | Refresh the `sigil-cc` plugin automatically. Set `false` to pin the installed version. |
 | `SIGIL_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Claude Code `PreToolUse` hook calls Sigil's `/api/v1/hooks:evaluate` and blocks tool calls denied by guard rules. |
 | `SIGIL_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |
 | `SIGIL_GUARDS_TIMEOUT_MS` | `1500` | Per-call timeout. Lower = less added latency on every tool call, higher = better tolerance for slow `llm_judge` evaluators. |

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -105,6 +105,7 @@ tail -f ~/.local/state/sigil/logs/sigil.log
 | `SIGIL_GUARDS_ENABLED` | `false` | Enable Codex `PreToolUse` guards against Sigil rules. |
 | `SIGIL_GUARDS_FAIL_OPEN` | `true` | Allow the tool call when the guard request fails (set `false` for fail-closed). |
 | `SIGIL_GUARDS_TIMEOUT_MS` | `1500` | Per-call guard timeout. |
+| `SIGIL_AUTO_UPDATE` | `true` | Refresh the `sigil-codex` plugin automatically. Set `false` to pin the installed version. |
 
 Guards only intercept tool calls that Codex routes through `PreToolUse` — Bash, the `apply_patch` variants, and MCP tools. See the [Codex hooks docs](https://developers.openai.com/codex/hooks) for the supported set.
 

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -144,6 +144,7 @@ Redaction happens before export.
 | `SIGIL_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Copilot `preToolUse` hook is evaluated against Sigil and tool calls denied by guard rules are blocked. |
 | `SIGIL_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |
 | `SIGIL_GUARDS_TIMEOUT_MS` | `1500` | Per-call timeout. Lower = less added latency on every tool call, higher = better tolerance for slow `llm_judge` evaluators. |
+| `SIGIL_AUTO_UPDATE` | `true` | Refresh the `sigil-copilot` plugin automatically. Set `false` to pin the installed version. |
 
 If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>`.
 

--- a/plugins/sigil/README.md
+++ b/plugins/sigil/README.md
@@ -31,6 +31,10 @@ Then follow your agent's quickstart:
 - [Cursor](../cursor/README.md)
 - [pi](../pi/README.md) (separate JS plugin)
 
+## Auto-update
+
+`sigil claude`, `sigil codex`, and `sigil copilot` refresh the installed host plugin automatically. Set `SIGIL_AUTO_UPDATE=false` to opt out.
+
 ## Troubleshooting
 
 Hooks always exit 0, so problems only show up in the debug log. Set `SIGIL_DEBUG=true` in `~/.config/sigil/config.env` and tail `~/.local/state/sigil/logs/sigil.log`.

--- a/plugins/sigil/cmd/sigil/main.go
+++ b/plugins/sigil/cmd/sigil/main.go
@@ -81,7 +81,9 @@ type agentHook func(ctx context.Context, stdin io.Reader, stdout io.Writer, log 
 // unchanged to the underlying CLI via process replacement. localEnv is
 // non-nil when the caller requested `--local`, in which case the agent's
 // child inherits local-mode SIGIL_* env vars from local.LaunchEnv.Apply.
-type agentLauncher func(ctx context.Context, args []string, localEnv *local.LaunchEnv, stdin io.Reader, stdout, stderr io.Writer, log *log.Logger) error
+// sigilVersion is the build version forwarded so launchers can stamp
+// update-check state with the version that performed the refresh.
+type agentLauncher func(ctx context.Context, args []string, localEnv *local.LaunchEnv, stdin io.Reader, stdout, stderr io.Writer, log *log.Logger, sigilVersion string) error
 
 // agents maps the argv agent name to its adapter Hook. The map is a package
 // var so tests can substitute mock hooks.
@@ -201,7 +203,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 			}
 		}()
 
-		if err := launcher(context.Background(), launcherArgs, localEnv, stdin, stdout, stderr, logger); err != nil {
+		if err := launcher(context.Background(), launcherArgs, localEnv, stdin, stdout, stderr, logger, version); err != nil {
 			logger.Printf("launch %s: %v", args[0], err)
 			_, _ = fmt.Fprintf(stderr, "sigil: %v\n", err)
 			exit(1)

--- a/plugins/sigil/cmd/sigil/main_test.go
+++ b/plugins/sigil/cmd/sigil/main_test.go
@@ -222,7 +222,7 @@ func TestRun_LauncherDispatch(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var gotArgs []string
 			called := 0
-			withStubLauncher(t, tc.agent, func(_ context.Context, args []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+			withStubLauncher(t, tc.agent, func(_ context.Context, args []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger, _ string) error {
 				called++
 				gotArgs = append([]string{}, args...)
 				return tc.launcherErr
@@ -275,7 +275,7 @@ func TestRun_CodexHookDispatchesEvenWithLauncher(t *testing.T) {
 			return nil
 		},
 	}
-	withStubLauncher(t, "codex", func(_ context.Context, _ []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+	withStubLauncher(t, "codex", func(_ context.Context, _ []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger, _ string) error {
 		t.Fatal("launcher must not be called for `sigil codex hook`")
 		return nil
 	})
@@ -298,7 +298,7 @@ func TestRun_CodexHookDispatchesEvenWithLauncher(t *testing.T) {
 func TestRun_CodexLauncherBare(t *testing.T) {
 	var got []string
 	called := 0
-	withStubLauncher(t, "codex", func(_ context.Context, args []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+	withStubLauncher(t, "codex", func(_ context.Context, args []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger, _ string) error {
 		called++
 		got = append([]string{}, args...)
 		return nil
@@ -321,7 +321,7 @@ func TestRun_CodexLauncherBare(t *testing.T) {
 
 func TestRun_CodexLauncherForwardsArgs(t *testing.T) {
 	var got []string
-	withStubLauncher(t, "codex", func(_ context.Context, args []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+	withStubLauncher(t, "codex", func(_ context.Context, args []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger, _ string) error {
 		got = append([]string{}, args...)
 		return nil
 	})
@@ -336,7 +336,7 @@ func TestRun_CodexLauncherForwardsArgs(t *testing.T) {
 }
 
 func TestRun_CodexLauncherMissingSeparatorExits2(t *testing.T) {
-	withStubLauncher(t, "codex", func(_ context.Context, _ []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+	withStubLauncher(t, "codex", func(_ context.Context, _ []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger, _ string) error {
 		t.Fatal("launcher must not be called when separator is missing")
 		return nil
 	})
@@ -354,7 +354,7 @@ func TestRun_CodexLauncherMissingSeparatorExits2(t *testing.T) {
 }
 
 func TestRun_CodexLauncherErrorExits1(t *testing.T) {
-	withStubLauncher(t, "codex", func(_ context.Context, _ []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+	withStubLauncher(t, "codex", func(_ context.Context, _ []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger, _ string) error {
 		return errors.New("boom")
 	})
 
@@ -494,7 +494,7 @@ func TestRun_LauncherAutoPromptsWhenCredsMissing(t *testing.T) {
 	})
 
 	launcherCalled := 0
-	withStubLauncher(t, "pi", func(context.Context, []string, *local.LaunchEnv, io.Reader, io.Writer, io.Writer, *log.Logger) error {
+	withStubLauncher(t, "pi", func(context.Context, []string, *local.LaunchEnv, io.Reader, io.Writer, io.Writer, *log.Logger, string) error {
 		launcherCalled++
 		if os.Getenv("SIGIL_ENDPOINT") != "https://sigil.example.com" {
 			t.Errorf("launcher saw SIGIL_ENDPOINT = %q, want set by login", os.Getenv("SIGIL_ENDPOINT"))
@@ -529,7 +529,7 @@ func TestRun_LauncherSkipsAutoPromptWhenCredsPresent(t *testing.T) {
 	})
 
 	launcherCalled := 0
-	withStubLauncher(t, "pi", func(context.Context, []string, *local.LaunchEnv, io.Reader, io.Writer, io.Writer, *log.Logger) error {
+	withStubLauncher(t, "pi", func(context.Context, []string, *local.LaunchEnv, io.Reader, io.Writer, io.Writer, *log.Logger, string) error {
 		launcherCalled++
 		return nil
 	})
@@ -557,7 +557,7 @@ func TestRun_LauncherContinuesWhenLoginAborted(t *testing.T) {
 	})
 
 	launcherCalled := 0
-	withStubLauncher(t, "pi", func(context.Context, []string, *local.LaunchEnv, io.Reader, io.Writer, io.Writer, *log.Logger) error {
+	withStubLauncher(t, "pi", func(context.Context, []string, *local.LaunchEnv, io.Reader, io.Writer, io.Writer, *log.Logger, string) error {
 		launcherCalled++
 		return nil
 	})
@@ -680,7 +680,7 @@ func TestRun_LauncherLocalFlagInjectsOpts(t *testing.T) {
 			_, daemonURL := inProcessDaemon(t)
 
 			var gotEnv *local.LaunchEnv
-			withStubLauncher(t, tc.name, func(_ context.Context, _ []string, env *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+			withStubLauncher(t, tc.name, func(_ context.Context, _ []string, env *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger, _ string) error {
 				gotEnv = env
 				return nil
 			})
@@ -716,7 +716,7 @@ func TestRun_LauncherLocalFlagInvalidArgsDoNotStartDaemon(t *testing.T) {
 				return &local.Status{PID: os.Getpid(), Port: 8765, Endpoint: "http://127.0.0.1:8765", StartedAt: time.Now().UTC().Format(time.RFC3339Nano)}, nil
 			})
 			t.Cleanup(restore)
-			withStubLauncher(t, tc.agent, func(_ context.Context, _ []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+			withStubLauncher(t, tc.agent, func(_ context.Context, _ []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger, _ string) error {
 				t.Fatal("launcher must not be called for invalid sigil-side args")
 				return nil
 			})
@@ -742,7 +742,7 @@ func TestRun_LauncherLocalFlagWithForwardedArgs(t *testing.T) {
 	inProcessDaemon(t)
 
 	var gotArgs []string
-	withStubLauncher(t, "claude", func(_ context.Context, args []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+	withStubLauncher(t, "claude", func(_ context.Context, args []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger, _ string) error {
 		gotArgs = append([]string{}, args...)
 		return nil
 	})
@@ -767,7 +767,7 @@ func TestRun_LocalLaunchersShareReceiver(t *testing.T) {
 	envs := map[string]*local.LaunchEnv{}
 	stubs := map[string]agentLauncher{}
 	for _, name := range []string{"claude", "codex", "copilot", "pi"} {
-		stubs[name] = func(_ context.Context, _ []string, env *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger) error {
+		stubs[name] = func(_ context.Context, _ []string, env *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger, _ string) error {
 			envs[name] = env
 			return nil
 		}

--- a/plugins/sigil/internal/agents/claudecode/launch.go
+++ b/plugins/sigil/internal/agents/claudecode/launch.go
@@ -12,8 +12,10 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/local"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/updatecheck"
 )
 
 const (
@@ -26,6 +28,8 @@ const (
 	// PluginName is the plugin name declared in
 	// plugins/claude-code/.claude-plugin/plugin.json.
 	PluginName = "sigil-cc"
+
+	updateCheckTTL = 24 * time.Hour
 )
 
 // Test seams.
@@ -33,6 +37,7 @@ var (
 	lookPath   = exec.LookPath
 	execFn     = syscall.Exec
 	runInstall = defaultRunInstall
+	runUpdate  = defaultRunUpdate
 	getwd      = os.Getwd
 )
 
@@ -43,7 +48,7 @@ var (
 // child receives local-mode SIGIL_ENDPOINT, SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT
 // and placeholder auth values so it talks to the in-process receiver
 // instead of Sigil Cloud.
-func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger) error {
+func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, sigilVersion string) error {
 	bin, err := lookPath("claude")
 	if err != nil {
 		return fmt.Errorf("claude CLI not found on PATH: %w", err)
@@ -73,6 +78,18 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 					"          claude plugin install %s@%s\n",
 				PluginName, err, PluginName, marketplaceAlias)
 		}
+	} else if updatecheck.ShouldRun(PluginName, updateCheckTTL, sigilVersion) {
+		_, _ = fmt.Fprintf(stderr, "sigil: refreshing %s in claude\n", PluginName)
+		if err := runUpdate(ctx, bin, stderr); err != nil {
+			logger.Printf("update %s: %v", PluginName, err)
+			_, _ = fmt.Fprintf(stderr,
+				"sigil: update of %s failed: %v\n"+
+					"sigil: continuing with the installed version. To retry manually:\n"+
+					"          claude plugin marketplace update %s\n"+
+					"          claude plugin update %s@%s\n",
+				PluginName, err, marketplaceAlias, PluginName, marketplaceAlias)
+		}
+		updatecheck.Record(PluginName, sigilVersion)
 	}
 
 	env := local.Environ(localEnv)
@@ -84,10 +101,20 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 }
 
 func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {
-	steps := [][]string{
+	return runSteps(ctx, bin, w, [][]string{
 		{"plugin", "marketplace", "add", marketplaceRepo},
 		{"plugin", "install", PluginName + "@" + marketplaceAlias},
-	}
+	})
+}
+
+func defaultRunUpdate(ctx context.Context, bin string, w io.Writer) error {
+	return runSteps(ctx, bin, w, [][]string{
+		{"plugin", "marketplace", "update", marketplaceAlias},
+		{"plugin", "update", PluginName + "@" + marketplaceAlias},
+	})
+}
+
+func runSteps(ctx context.Context, bin string, w io.Writer, steps [][]string) error {
 	for _, argv := range steps {
 		cmd := exec.CommandContext(ctx, bin, argv...)
 		cmd.Stdout = w

--- a/plugins/sigil/internal/agents/claudecode/launch_test.go
+++ b/plugins/sigil/internal/agents/claudecode/launch_test.go
@@ -14,18 +14,21 @@ import (
 	"testing"
 
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/local"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLaunch_MissingClaudeBinary(t *testing.T) {
 	withLookPath(t, func(string) (string, error) { return "", exec.ErrNotFound })
 
-	err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger())
+	err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev")
 	if err == nil || !strings.Contains(err.Error(), "claude CLI not found") {
 		t.Fatalf("err = %v, want contains \"claude CLI not found\"", err)
 	}
 }
 
 func TestLaunch_SkipsInstallWhenPluginPresent(t *testing.T) {
+	t.Setenv("SIGIL_AUTO_UPDATE", "false")
+
 	dir := t.TempDir()
 	writeInstalled(t, dir, `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"user"}]}}`)
 	t.Setenv("CLAUDE_CONFIG_DIR", dir)
@@ -43,7 +46,7 @@ func TestLaunch_SkipsInstallWhenPluginPresent(t *testing.T) {
 	})
 
 	var stderr bytes.Buffer
-	if err := Launch(context.Background(), []string{"--resume", "abc"}, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+	if err := Launch(context.Background(), []string{"--resume", "abc"}, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	if !reflect.DeepEqual(execArgv, []string{"/usr/local/bin/claude", "--resume", "abc"}) {
@@ -73,7 +76,7 @@ func TestLaunch_RunsInstallWhenOnlyForeignProjectScopeEntry(t *testing.T) {
 	})
 	withExecFn(t, func(string, []string, []string) error { return nil })
 
-	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger()); err != nil {
+	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	if installCalls != 1 {
@@ -104,7 +107,7 @@ func TestLaunch_RunsInstallWhenMissing(t *testing.T) {
 	})
 
 	var stderr bytes.Buffer
-	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	if installCalls != 1 {
@@ -131,7 +134,7 @@ func TestLaunch_RunsInstallWhenFileAbsent(t *testing.T) {
 	})
 	withExecFn(t, func(string, []string, []string) error { return nil })
 
-	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger()); err != nil {
+	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	if installCalls != 1 {
@@ -153,7 +156,7 @@ func TestLaunch_RunsInstallWhenJSONMalformed(t *testing.T) {
 	})
 	withExecFn(t, func(string, []string, []string) error { return nil })
 
-	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger()); err != nil {
+	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	if installCalls != 1 {
@@ -181,7 +184,7 @@ func TestLaunch_InstallFailureContinuesToExec(t *testing.T) {
 	})
 
 	var stderr bytes.Buffer
-	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	if !execCalled {
@@ -225,7 +228,7 @@ func TestLaunch_LocalInjectsEnvAndForwardsArgs(t *testing.T) {
 		Endpoint:     "http://127.0.0.1:9000",
 		OTLPEndpoint: "http://127.0.0.1:9000/otlp",
 	}
-	if err := Launch(context.Background(), []string{"--resume", "abc"}, localEnv, strings.NewReader(""), io.Discard, io.Discard, nopLogger()); err != nil {
+	if err := Launch(context.Background(), []string{"--resume", "abc"}, localEnv, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	if !reflect.DeepEqual(execArgv, []string{"/usr/local/bin/claude", "--resume", "abc"}) {
@@ -262,7 +265,7 @@ func TestLaunch_NormalModeDoesNotInjectLocalEnv(t *testing.T) {
 		return nil
 	})
 
-	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger()); err != nil {
+	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	got := envToMap(execEnv)
@@ -463,6 +466,61 @@ func withGetwd(t *testing.T, fn func() (string, error)) {
 	getwd = fn
 }
 
+func withRunUpdate(t *testing.T, fn func(context.Context, string, io.Writer) error) {
+	t.Helper()
+	prev := runUpdate
+	t.Cleanup(func() { runUpdate = prev })
+	runUpdate = fn
+}
+
+func launch(t *testing.T, args []string, stdout, stderr io.Writer) error {
+	t.Helper()
+	return Launch(context.Background(), args, nil, strings.NewReader(""), stdout, stderr, nopLogger(), "dev")
+}
+
+func launchOK(t *testing.T, args []string, stdout, stderr io.Writer) {
+	t.Helper()
+	require.NoError(t, launch(t, args, stdout, stderr))
+}
+
 func nopLogger() *log.Logger {
 	return log.New(io.Discard, "", 0)
+}
+
+func TestLaunch_RefreshesInstalledPlugin(t *testing.T) {
+	state := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", state)
+
+	dir := t.TempDir()
+	writeInstalled(t, dir, `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"user"}]}}`)
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/claude", nil })
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		t.Fatal("runInstall must not be called when plugin is already present")
+		return nil
+	})
+
+	updateCalls := 0
+	withRunUpdate(t, func(_ context.Context, bin string, _ io.Writer) error {
+		updateCalls++
+		if bin != "/usr/local/bin/claude" {
+			t.Errorf("update bin = %q", bin)
+		}
+		return nil
+	})
+	withExecFn(t, func(string, []string, []string) error { return nil })
+
+	var stderr bytes.Buffer
+	launchOK(t, nil, io.Discard, &stderr)
+	if updateCalls != 1 {
+		t.Fatalf("runUpdate calls = %d, want 1", updateCalls)
+	}
+	if !strings.Contains(stderr.String(), "refreshing "+PluginName+" in claude") {
+		t.Fatalf("stderr missing refresh message: %q", stderr.String())
+	}
+	stamp := filepath.Join(state, "sigil", "update-checks", PluginName+".stamp")
+	if _, err := os.Stat(stamp); err != nil {
+		t.Fatalf("expected update stamp: %v", err)
+	}
 }

--- a/plugins/sigil/internal/agents/codex/launch.go
+++ b/plugins/sigil/internal/agents/codex/launch.go
@@ -9,8 +9,10 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/local"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/updatecheck"
 )
 
 const (
@@ -24,6 +26,8 @@ const (
 	// PluginName is the codex plugin name declared in
 	// plugins/codex/.codex-plugin/plugin.json.
 	PluginName = "sigil-codex"
+
+	updateCheckTTL = 24 * time.Hour
 )
 
 // Test seams.
@@ -31,6 +35,7 @@ var (
 	lookPath   = exec.LookPath
 	execFn     = syscall.Exec
 	runInstall = defaultRunInstall
+	runUpdate  = defaultRunUpdate
 	pluginList = defaultPluginList
 )
 
@@ -41,7 +46,7 @@ var (
 // the child receives local-mode SIGIL_ENDPOINT,
 // SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT and placeholder auth values so it talks
 // to the in-process receiver instead of Sigil Cloud.
-func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger) error {
+func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, sigilVersion string) error {
 	bin, err := lookPath("codex")
 	if err != nil {
 		return fmt.Errorf("codex CLI not found on PATH: %w", err)
@@ -79,6 +84,18 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 				"sigil: first run only — open /hooks inside codex and trust the\n"+
 					"       %s hooks to start exporting turns.\n", PluginName)
 		}
+	} else if updatecheck.ShouldRun(PluginName, updateCheckTTL, sigilVersion) {
+		_, _ = fmt.Fprintf(stderr, "sigil: refreshing %s in codex\n", PluginName)
+		if err := runUpdate(ctx, bin, stderr); err != nil {
+			logger.Printf("update %s: %v", PluginName, err)
+			_, _ = fmt.Fprintf(stderr,
+				"sigil: update of %s failed: %v\n"+
+					"sigil: continuing with the installed version. To retry manually:\n"+
+					"          codex plugin marketplace upgrade\n"+
+					"          codex plugin add %s@%s\n",
+				PluginName, err, PluginName, marketplaceAlias)
+		}
+		updatecheck.Record(PluginName, sigilVersion)
 	}
 
 	env := local.Environ(localEnv)
@@ -90,10 +107,20 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 }
 
 func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {
-	steps := [][]string{
+	return runSteps(ctx, bin, w, [][]string{
 		{"plugin", "marketplace", "add", marketplaceRepo},
 		{"plugin", "add", PluginName + "@" + marketplaceAlias},
-	}
+	})
+}
+
+func defaultRunUpdate(ctx context.Context, bin string, w io.Writer) error {
+	return runSteps(ctx, bin, w, [][]string{
+		{"plugin", "marketplace", "upgrade"},
+		{"plugin", "add", PluginName + "@" + marketplaceAlias},
+	})
+}
+
+func runSteps(ctx context.Context, bin string, w io.Writer, steps [][]string) error {
 	for _, argv := range steps {
 		cmd := exec.CommandContext(ctx, bin, argv...)
 		cmd.Stdout = w

--- a/plugins/sigil/internal/agents/codex/launch_test.go
+++ b/plugins/sigil/internal/agents/codex/launch_test.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"io"
 	"log"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -19,13 +21,14 @@ import (
 func TestLaunch_MissingCodexBinary(t *testing.T) {
 	withLookPath(t, func(string) (string, error) { return "", exec.ErrNotFound })
 
-	err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger())
+	err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev")
 	if err == nil || !strings.Contains(err.Error(), "codex CLI not found") {
 		t.Fatalf("err = %v, want contains \"codex CLI not found\"", err)
 	}
 }
 
 func TestLaunch_SkipsInstallWhenPluginInstalledAndEnabled(t *testing.T) {
+	t.Setenv("SIGIL_AUTO_UPDATE", "false")
 	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/codex", nil })
 	withPluginList(t, func(context.Context, string) ([]byte, error) {
 		return []byte("  sigil-codex@grafana-sigil (installed, enabled)\n"), nil
@@ -42,7 +45,7 @@ func TestLaunch_SkipsInstallWhenPluginInstalledAndEnabled(t *testing.T) {
 	})
 
 	var stderr bytes.Buffer
-	if err := Launch(context.Background(), []string{"exec", "hi"}, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+	if err := Launch(context.Background(), []string{"exec", "hi"}, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	if !reflect.DeepEqual(execArgv, []string{"/usr/local/bin/codex", "exec", "hi"}) {
@@ -75,7 +78,7 @@ func TestLaunch_RunsInstallWhenPluginMissing(t *testing.T) {
 	})
 
 	var stderr bytes.Buffer
-	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	if installCalls != 1 {
@@ -111,7 +114,7 @@ func TestLaunch_RunsInstallWhenPluginInstalledButDisabled(t *testing.T) {
 		return nil
 	})
 
-	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger()); err != nil {
+	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	if installCalls != 1 {
@@ -141,7 +144,7 @@ func TestLaunch_InstallFailureContinuesToExec(t *testing.T) {
 	})
 
 	var stderr bytes.Buffer
-	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	if !execCalled {
@@ -186,7 +189,7 @@ func TestLaunch_PluginListProbeFailureFallsThroughToInstall(t *testing.T) {
 
 	var logbuf bytes.Buffer
 	logger := log.New(&logbuf, "", 0)
-	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, logger); err != nil {
+	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, logger, "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	if installCalls != 1 {
@@ -201,6 +204,7 @@ func TestLaunch_PluginListProbeFailureFallsThroughToInstall(t *testing.T) {
 }
 
 func TestLaunch_ExecFailureSurfacesError(t *testing.T) {
+	t.Setenv("SIGIL_AUTO_UPDATE", "false")
 	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/codex", nil })
 	withPluginList(t, func(context.Context, string) ([]byte, error) {
 		return []byte("  sigil-codex@grafana-sigil (installed, enabled)\n"), nil
@@ -210,7 +214,7 @@ func TestLaunch_ExecFailureSurfacesError(t *testing.T) {
 		return errors.New("exec boom")
 	})
 
-	err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger())
+	err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev")
 	if err == nil || !strings.Contains(err.Error(), "exec codex") {
 		t.Fatalf("err = %v, want contains \"exec codex\"", err)
 	}
@@ -247,7 +251,7 @@ func TestLaunch_LocalEnv(t *testing.T) {
 			})
 
 			localEnv := &local.LaunchEnv{Endpoint: "http://127.0.0.1:9000", OTLPEndpoint: "http://127.0.0.1:9000/otlp"}
-			err := Launch(context.Background(), []string{"exec", "hi"}, localEnv, strings.NewReader(""), io.Discard, io.Discard, nopLogger())
+			err := Launch(context.Background(), []string{"exec", "hi"}, localEnv, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev")
 			require.NoError(t, err)
 			got := envMap(execEnv)
 			assert.Equal(t, "http://127.0.0.1:9000", got["SIGIL_ENDPOINT"])
@@ -260,6 +264,7 @@ func TestLaunch_LocalEnv(t *testing.T) {
 }
 
 func TestLaunch_ForwardsArgvUnchanged(t *testing.T) {
+	t.Setenv("SIGIL_AUTO_UPDATE", "false")
 	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/codex", nil })
 	withPluginList(t, func(context.Context, string) ([]byte, error) {
 		return []byte("  sigil-codex@grafana-sigil (installed, enabled)\n"), nil
@@ -273,7 +278,7 @@ func TestLaunch_ForwardsArgvUnchanged(t *testing.T) {
 	})
 
 	args := []string{"exec", "--model", "gpt-5", "hi"}
-	if err := Launch(context.Background(), args, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger()); err != nil {
+	if err := Launch(context.Background(), args, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	want := append([]string{"/usr/local/bin/codex"}, args...)
@@ -384,6 +389,65 @@ func envMap(env []string) map[string]string {
 	return out
 }
 
+func withRunUpdate(t *testing.T, fn func(context.Context, string, io.Writer) error) {
+	t.Helper()
+	prev := runUpdate
+	t.Cleanup(func() { runUpdate = prev })
+	runUpdate = fn
+}
+
+func launch(t *testing.T, args []string, stdout, stderr io.Writer) error {
+	t.Helper()
+	return launchWithLogger(t, args, stdout, stderr, nopLogger())
+}
+
+func launchWithLogger(t *testing.T, args []string, stdout, stderr io.Writer, logger *log.Logger) error {
+	t.Helper()
+	return Launch(context.Background(), args, nil, strings.NewReader(""), stdout, stderr, logger, "dev")
+}
+
+func launchOK(t *testing.T, args []string, stdout, stderr io.Writer) {
+	t.Helper()
+	require.NoError(t, launch(t, args, stdout, stderr))
+}
+
 func nopLogger() *log.Logger {
 	return log.New(io.Discard, "", 0)
+}
+
+func TestLaunch_RefreshesInstalledPlugin(t *testing.T) {
+	state := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", state)
+
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/codex", nil })
+	withPluginList(t, func(context.Context, string) ([]byte, error) {
+		return []byte("  sigil-codex@grafana-sigil (installed, enabled)\n"), nil
+	})
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		t.Fatal("runInstall must not be called when plugin is already installed")
+		return nil
+	})
+
+	updateCalls := 0
+	withRunUpdate(t, func(_ context.Context, bin string, _ io.Writer) error {
+		updateCalls++
+		if bin != "/usr/local/bin/codex" {
+			t.Errorf("update bin = %q", bin)
+		}
+		return nil
+	})
+	withExecFn(t, func(string, []string, []string) error { return nil })
+
+	var stderr bytes.Buffer
+	launchOK(t, nil, io.Discard, &stderr)
+	if updateCalls != 1 {
+		t.Fatalf("runUpdate calls = %d, want 1", updateCalls)
+	}
+	if !strings.Contains(stderr.String(), "refreshing "+PluginName+" in codex") {
+		t.Fatalf("stderr missing refresh message: %q", stderr.String())
+	}
+	stamp := filepath.Join(state, "sigil", "update-checks", PluginName+".stamp")
+	if _, err := os.Stat(stamp); err != nil {
+		t.Fatalf("expected update stamp: %v", err)
+	}
 }

--- a/plugins/sigil/internal/agents/copilot/launch.go
+++ b/plugins/sigil/internal/agents/copilot/launch.go
@@ -8,8 +8,10 @@ import (
 	"log"
 	"os/exec"
 	"syscall"
+	"time"
 
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/local"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/updatecheck"
 )
 
 const (
@@ -20,6 +22,8 @@ const (
 	installSource = "grafana/sigil-sdk:plugins/copilot"
 	// PluginName is the plugin name declared in plugins/copilot/plugin.json.
 	PluginName = "sigil-copilot"
+
+	updateCheckTTL = 24 * time.Hour
 )
 
 // Test seams.
@@ -27,6 +31,7 @@ var (
 	lookPath   = exec.LookPath
 	execFn     = syscall.Exec
 	runInstall = defaultRunInstall
+	runUpdate  = defaultRunUpdate
 	pluginList = defaultPluginList
 )
 
@@ -37,7 +42,7 @@ var (
 // non-nil, the child receives local-mode SIGIL_ENDPOINT,
 // SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT and placeholder auth values so it talks
 // to the in-process receiver instead of Sigil Cloud.
-func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger) error {
+func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, sigilVersion string) error {
 	bin, err := lookPath("copilot")
 	if err != nil {
 		return fmt.Errorf("copilot CLI not found on PATH: %w", err)
@@ -67,6 +72,17 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 					"          copilot plugin install %s\n",
 				PluginName, err, installSource)
 		}
+	} else if updatecheck.ShouldRun(PluginName, updateCheckTTL, sigilVersion) {
+		_, _ = fmt.Fprintf(stderr, "sigil: refreshing %s in copilot\n", PluginName)
+		if err := runUpdate(ctx, bin, stderr); err != nil {
+			logger.Printf("update %s: %v", PluginName, err)
+			_, _ = fmt.Fprintf(stderr,
+				"sigil: update of %s failed: %v\n"+
+					"sigil: continuing with the installed version. To retry manually:\n"+
+					"          copilot plugin update %s\n",
+				PluginName, err, PluginName)
+		}
+		updatecheck.Record(PluginName, sigilVersion)
 	}
 
 	env := local.Environ(localEnv)
@@ -83,6 +99,16 @@ func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {
 	cmd.Stderr = w
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("copilot plugin install %s: %w", installSource, err)
+	}
+	return nil
+}
+
+func defaultRunUpdate(ctx context.Context, bin string, w io.Writer) error {
+	cmd := exec.CommandContext(ctx, bin, "plugin", "update", PluginName)
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("copilot plugin update %s: %w", PluginName, err)
 	}
 	return nil
 }

--- a/plugins/sigil/internal/agents/copilot/launch_test.go
+++ b/plugins/sigil/internal/agents/copilot/launch_test.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"io"
 	"log"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -92,6 +94,7 @@ func TestLaunch(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SIGIL_AUTO_UPDATE", "false")
 			withLookPath(t, tc.lookPath)
 
 			listFn := tc.pluginList
@@ -132,7 +135,7 @@ func TestLaunch(t *testing.T) {
 			var logbuf bytes.Buffer
 			logger := log.New(&logbuf, "", 0)
 
-			err := Launch(context.Background(), tc.args, nil, strings.NewReader(""), io.Discard, &stderr, logger)
+			err := Launch(context.Background(), tc.args, nil, strings.NewReader(""), io.Discard, &stderr, logger, "dev")
 
 			if tc.wantErr != "" {
 				require.Error(t, err)
@@ -186,7 +189,7 @@ func TestLaunch_LocalEnv(t *testing.T) {
 			})
 
 			localEnv := &local.LaunchEnv{Endpoint: "http://127.0.0.1:9000", OTLPEndpoint: "http://127.0.0.1:9000/otlp"}
-			err := Launch(context.Background(), []string{"exec", "hi"}, localEnv, strings.NewReader(""), io.Discard, io.Discard, nopLogger())
+			err := Launch(context.Background(), []string{"exec", "hi"}, localEnv, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev")
 			require.NoError(t, err)
 			got := envMap(execEnv)
 			assert.Equal(t, "http://127.0.0.1:9000", got["SIGIL_ENDPOINT"])
@@ -251,14 +254,17 @@ func TestPluginInstalled_ParsesPluginListOutput(t *testing.T) {
 				return []byte(tc.out), nil
 			})
 			got, err := pluginInstalled(context.Background(), "/usr/local/bin/copilot")
-			if err != nil {
-				t.Fatalf("err = %v", err)
-			}
+			require.NoError(t, err)
 			if got != tc.want {
 				t.Fatalf("got = %v, want %v", got, tc.want)
 			}
 		})
 	}
+}
+
+func launchWithLogger(t *testing.T, args []string, stderr io.Writer, logger *log.Logger) error {
+	t.Helper()
+	return Launch(context.Background(), args, nil, strings.NewReader(""), io.Discard, stderr, logger, "dev")
 }
 
 func withLookPath(t *testing.T, fn func(string) (string, error)) {
@@ -302,4 +308,49 @@ func envMap(env []string) map[string]string {
 
 func nopLogger() *log.Logger {
 	return log.New(io.Discard, "", 0)
+}
+
+func withRunUpdate(t *testing.T, fn func(context.Context, string, io.Writer) error) {
+	t.Helper()
+	prev := runUpdate
+	t.Cleanup(func() { runUpdate = prev })
+	runUpdate = fn
+}
+
+func TestLaunch_RefreshesInstalledPlugin(t *testing.T) {
+	const binPath = "/usr/local/bin/copilot"
+	state := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", state)
+
+	withLookPath(t, func(string) (string, error) { return binPath, nil })
+	withPluginList(t, func(context.Context, string) ([]byte, error) {
+		return []byte("Installed plugins:\n  • sigil-copilot (v0.1.0)\n"), nil
+	})
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		t.Fatal("runInstall must not be called when plugin is already installed")
+		return nil
+	})
+
+	updateCalls := 0
+	withRunUpdate(t, func(_ context.Context, bin string, _ io.Writer) error {
+		updateCalls++
+		if bin != binPath {
+			t.Errorf("update bin = %q", bin)
+		}
+		return nil
+	})
+	withExecFn(t, func(string, []string, []string) error { return nil })
+
+	var stderr bytes.Buffer
+	require.NoError(t, launchWithLogger(t, nil, &stderr, log.New(io.Discard, "", 0)))
+	if updateCalls != 1 {
+		t.Fatalf("runUpdate calls = %d, want 1", updateCalls)
+	}
+	if !strings.Contains(stderr.String(), "refreshing "+PluginName+" in copilot") {
+		t.Fatalf("stderr missing refresh message: %q", stderr.String())
+	}
+	stamp := filepath.Join(state, "sigil", "update-checks", PluginName+".stamp")
+	if _, err := os.Stat(stamp); err != nil {
+		t.Fatalf("expected update stamp: %v", err)
+	}
 }

--- a/plugins/sigil/internal/agents/pi/launch.go
+++ b/plugins/sigil/internal/agents/pi/launch.go
@@ -49,8 +49,11 @@ var (
 // once if it is not), and then exec's pi with the supplied args. When
 // localEnv is non-nil, the child receives local-mode SIGIL_ENDPOINT,
 // SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT and placeholder auth values so it
-// talks to the in-process receiver instead of Sigil Cloud.
-func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger) error {
+// talks to the in-process receiver instead of Sigil Cloud. The trailing
+// string arg is the sigil build version; the pi adapter does not run
+// auto-update checks (pi's own installer handles upgrades) so it is
+// accepted to satisfy the launcher signature and ignored.
+func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, _ string) error {
 	bin, err := lookPath("pi")
 	if err != nil {
 		return fmt.Errorf("pi CLI not found on PATH: %w", err)

--- a/plugins/sigil/internal/agents/pi/launch_test.go
+++ b/plugins/sigil/internal/agents/pi/launch_test.go
@@ -19,7 +19,7 @@ import (
 func TestLaunch_MissingPiBinary(t *testing.T) {
 	withLookPath(t, func(string) (string, error) { return "", exec.ErrNotFound })
 
-	err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger())
+	err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev")
 	if err == nil || !strings.Contains(err.Error(), "pi CLI not found") {
 		t.Fatalf("err = %v, want contains \"pi CLI not found\"", err)
 	}
@@ -43,7 +43,7 @@ func TestLaunch_SkipsInstallWhenPackagePresent(t *testing.T) {
 	})
 
 	var stderr bytes.Buffer
-	if err := Launch(context.Background(), []string{"--print", "hi"}, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+	if err := Launch(context.Background(), []string{"--print", "hi"}, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	if !reflect.DeepEqual(execArgv, []string{"/usr/local/bin/pi", "--print", "hi"}) {
@@ -77,7 +77,7 @@ func TestLaunch_RunsInstallWhenPackageMissing(t *testing.T) {
 	})
 
 	var stderr bytes.Buffer
-	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	if installCalls != 1 {
@@ -111,7 +111,7 @@ func TestLaunch_InstallFailureContinuesToExec(t *testing.T) {
 	})
 
 	var stderr bytes.Buffer
-	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger()); err != nil {
+	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	if !execCalled {
@@ -159,7 +159,7 @@ func TestLaunch_LocalInjectsEnvAndForwardsArgs(t *testing.T) {
 		Endpoint:     "http://127.0.0.1:9000",
 		OTLPEndpoint: "http://127.0.0.1:9000/otlp",
 	}
-	if err := Launch(context.Background(), []string{"--print", "hi"}, localEnv, strings.NewReader(""), io.Discard, io.Discard, nopLogger()); err != nil {
+	if err := Launch(context.Background(), []string{"--print", "hi"}, localEnv, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	if !reflect.DeepEqual(execArgv, []string{"/usr/local/bin/pi", "--print", "hi"}) {
@@ -199,7 +199,7 @@ func TestLaunch_LocalDefaultsFullContentWhenUnset(t *testing.T) {
 		Endpoint:     "http://127.0.0.1:9000",
 		OTLPEndpoint: "http://127.0.0.1:9000/otlp",
 	}
-	if err := Launch(context.Background(), nil, localEnv, strings.NewReader(""), io.Discard, io.Discard, nopLogger()); err != nil {
+	if err := Launch(context.Background(), nil, localEnv, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	got := envToMap(execEnv)
@@ -224,7 +224,7 @@ func TestLaunch_NormalModeDoesNotInjectLocalEnv(t *testing.T) {
 		return nil
 	})
 
-	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger()); err != nil {
+	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev"); err != nil {
 		t.Fatalf("Launch returned err: %v", err)
 	}
 	got := envToMap(execEnv)

--- a/plugins/sigil/internal/updatecheck/check.go
+++ b/plugins/sigil/internal/updatecheck/check.go
@@ -1,0 +1,76 @@
+// Package updatecheck rate-limits launcher plugin refreshes.
+package updatecheck
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/xdg"
+)
+
+const appName = "sigil"
+
+var (
+	stateRoot = func() string { return xdg.StateRoot(appName) }
+	now       = time.Now
+)
+
+// ShouldRun reports whether agent's refresh should run.
+func ShouldRun(agent string, ttl time.Duration, sigilVersion string) bool {
+	if Disabled() {
+		return false
+	}
+	if ttl <= 0 {
+		return true
+	}
+	path := stampPath(agent)
+	info, err := os.Stat(path)
+	if err != nil {
+		return true
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return true
+	}
+	if strings.TrimSpace(string(data)) != normalizeVersion(sigilVersion) {
+		return true
+	}
+	return now().Sub(info.ModTime()) >= ttl
+}
+
+// Record marks agent's refresh as attempted. Errors are ignored so update
+// bookkeeping cannot block launching the wrapped CLI.
+func Record(agent, sigilVersion string) {
+	path := stampPath(agent)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	if err := os.WriteFile(path, []byte(normalizeVersion(sigilVersion)), 0o600); err != nil {
+		return
+	}
+	t := now()
+	_ = os.Chtimes(path, t, t)
+}
+
+// Disabled reports whether SIGIL_AUTO_UPDATE opts out of periodic refreshes.
+func Disabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("SIGIL_AUTO_UPDATE"))) {
+	case "0", "false", "no", "off":
+		return true
+	default:
+		return false
+	}
+}
+
+func stampPath(agent string) string {
+	return filepath.Join(stateRoot(), "update-checks", agent+".stamp")
+}
+
+func normalizeVersion(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return "dev"
+	}
+	return v
+}

--- a/plugins/sigil/internal/updatecheck/check_test.go
+++ b/plugins/sigil/internal/updatecheck/check_test.go
@@ -1,0 +1,59 @@
+package updatecheck
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestShouldRun(t *testing.T) {
+	root := t.TempDir()
+	withStateRoot(t, root)
+
+	if !ShouldRun("sigil-cc", time.Hour, "1.0.0") {
+		t.Fatal("missing stamp should run")
+	}
+
+	Record("sigil-cc", "1.0.0")
+	if ShouldRun("sigil-cc", time.Hour, "1.0.0") {
+		t.Fatal("fresh stamp should skip")
+	}
+
+	if !ShouldRun("sigil-cc", time.Hour, "1.0.1") {
+		t.Fatal("version mismatch should run")
+	}
+
+	Record("sigil-cc", "1.0.1")
+	stale := time.Now().Add(-2 * time.Hour)
+	path := filepath.Join(root, "update-checks", "sigil-cc.stamp")
+	if err := os.Chtimes(path, stale, stale); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	if !ShouldRun("sigil-cc", time.Hour, "1.0.1") {
+		t.Fatal("stale stamp should run")
+	}
+}
+
+func TestDisabled(t *testing.T) {
+	for _, v := range []string{"0", "false", "False", "no", "off"} {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv("SIGIL_AUTO_UPDATE", v)
+			if !Disabled() {
+				t.Fatalf("Disabled() = false for %q", v)
+			}
+		})
+	}
+
+	t.Setenv("SIGIL_AUTO_UPDATE", "true")
+	if Disabled() {
+		t.Fatal("true should keep auto-update enabled")
+	}
+}
+
+func withStateRoot(t *testing.T, root string) {
+	t.Helper()
+	prev := stateRoot
+	t.Cleanup(func() { stateRoot = prev })
+	stateRoot = func() string { return root }
+}


### PR DESCRIPTION
Installed agent plugins can get stale after users upgrade `sigil`. The launcher now keeps the plugins in sync. It also rate-limits refresh attempts, and forcefully refreshes when the `sigil` binary version changes.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to optional launcher-side plugin CLI refresh with fail-open behavior; no auth or telemetry pipeline changes.
> 
> **Overview**
> **`sigil claude`**, **`sigil codex`**, and **`sigil copilot`** now refresh their host plugins when the extension is already installed, so upgrading the **`sigil`** binary does not leave stale **`sigil-cc`** / **`sigil-codex`** / **`sigil-copilot`** copies behind. First-time install behavior is unchanged.
> 
> A new **`updatecheck`** helper rate-limits refreshes to about once per 24 hours per agent (stamp files under XDG state) and forces a refresh when the stamp’s stored **`sigil`** build version no longer matches the running binary. Launchers pass the build **`version`** from **`main`** into each adapter for that bookkeeping. Failed updates are logged and surfaced on stderr with manual retry hints; the underlying CLI still starts.
> 
> **`SIGIL_AUTO_UPDATE`** (default **`true`**) opts out when set to **`false`** / **`off`**, etc. **`sigil pi`** only accepts the extra launcher argument for signature compatibility and does not run this path. Docs and **`sigil-cc`** marketplace version bump to **0.2.0** document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed65b47be629fd16b7879d6c1f3771485fb3349e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->