### PR TITLE
feat(plugins/pi): capture systemPrompt and tool schemas

### DIFF
--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -92,6 +92,8 @@ function assistantMessageUpdate(
 
 class FakePi {
   handlers = new Map<string, (event: any, ctx: any) => Promise<void> | void>();
+  getAllTools?: () => unknown;
+  getActiveTools?: () => string[];
 
   on(event: string, handler: (event: any, ctx: any) => Promise<void> | void) {
     this.handlers.set(event, handler);
@@ -1483,6 +1485,702 @@ describe("extension lifecycle", () => {
 
     expect(resolveGitBranchMock).toHaveBeenCalledTimes(1);
     expect(capturedSeed!.tags).toBeUndefined();
+  });
+
+  describe("systemPrompt capture", () => {
+    function setupClient() {
+      const seeds: Array<{ systemPrompt?: string }> = [];
+      const recorder = {
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        setFirstTokenAt: vi.fn(),
+      };
+      const sigil: SigilLike = {
+        startStreamingGeneration: vi.fn(async (seed, run) => {
+          seeds.push(seed as { systemPrompt?: string });
+          await run(recorder);
+        }),
+        startToolExecution: vi.fn(() => ({
+          setResult: vi.fn(),
+          setCallError: vi.fn(),
+          end: vi.fn(),
+          getError: vi.fn(),
+        })),
+        shutdown: vi.fn(async () => {}),
+      };
+      return { sigil, seeds, recorder };
+    }
+
+    it("attaches systemPrompt to every turn_end during the agent loop under full mode", async () => {
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "full",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("before_agent_start", {
+        systemPrompt: "You are a helpful agent.",
+      });
+      // Turn 1
+      await pi.emit("turn_start");
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+      // Turn 2 (tool-loop continuation)
+      await pi.emit("turn_start");
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      expect(seeds).toHaveLength(2);
+      expect(seeds[0]!.systemPrompt).toBe("You are a helpful agent.");
+      expect(seeds[1]!.systemPrompt).toBe("You are a helpful agent.");
+    });
+
+    it("caches the prompt under no_tool_content but strips it under metadata_only", async () => {
+      for (const mode of ["no_tool_content", "metadata_only"] as const) {
+        const { sigil, seeds } = setupClient();
+        loadConfigMock.mockResolvedValue({
+          endpoint: "http://localhost:8080/api/v1/generations:export",
+          auth: { mode: "none" },
+          agentName: "pi",
+          contentCapture: mode,
+        });
+        createSigilClientMock.mockReturnValue(sigil);
+
+        const pi = new FakePi();
+        registerExtension(pi as any);
+
+        await pi.emit("session_start");
+        await pi.emit("before_agent_start", {
+          systemPrompt: "You are a helpful agent.",
+        });
+        await pi.emit("turn_start");
+        await pi.emit("turn_end", {
+          message: assistantMessage(),
+          toolResults: [],
+        });
+
+        if (mode === "no_tool_content") {
+          expect(seeds[0]!.systemPrompt, `mode=${mode}`).toBe(
+            "You are a helpful agent.",
+          );
+        } else {
+          expect(seeds[0]!.systemPrompt, `mode=${mode}`).toBeUndefined();
+        }
+      }
+    });
+
+    it("clears the cached prompt on agent_end so the next loop starts empty", async () => {
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "full",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("before_agent_start", { systemPrompt: "first prompt" });
+      await pi.emit("turn_start");
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+      await pi.emit("agent_end", { messages: [] });
+
+      // No new before_agent_start — second loop must not reuse the prior prompt.
+      await pi.emit("turn_start");
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      expect(seeds).toHaveLength(2);
+      expect(seeds[0]!.systemPrompt).toBe("first prompt");
+      expect(seeds[1]!.systemPrompt).toBeUndefined();
+    });
+
+    it("clears the cached prompt on session_shutdown", async () => {
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "full",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("before_agent_start", { systemPrompt: "first prompt" });
+      await pi.emit("session_shutdown");
+
+      // Fresh session, no new before_agent_start.
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      expect(seeds[0]!.systemPrompt).toBeUndefined();
+    });
+  });
+
+  describe("tool catalog capture", () => {
+    function setupClient() {
+      const seeds: Array<{ tools?: unknown[] }> = [];
+      const recorder = {
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        setFirstTokenAt: vi.fn(),
+      };
+      const sigil: SigilLike = {
+        startStreamingGeneration: vi.fn(async (seed, run) => {
+          seeds.push(seed as { tools?: unknown[] });
+          await run(recorder);
+        }),
+        startToolExecution: vi.fn(() => ({
+          setResult: vi.fn(),
+          setCallError: vi.fn(),
+          end: vi.fn(),
+          getError: vi.fn(),
+        })),
+        shutdown: vi.fn(async () => {}),
+      };
+      return { sigil, seeds };
+    }
+
+    const bashTool = {
+      name: "bash",
+      description: "Run a shell command",
+      parameters: {
+        type: "object",
+        properties: { command: { type: "string" } },
+      },
+    };
+    const readTool = {
+      name: "read",
+      description: "Read a file",
+      parameters: {
+        type: "object",
+        properties: { path: { type: "string" } },
+      },
+    };
+
+    it("emits description and inputSchemaJSON for active tools under full mode", async () => {
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "full",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      pi.getAllTools = () => [bashTool, readTool];
+      pi.getActiveTools = () => ["bash", "read"];
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      const tools = seeds[0]!.tools as Array<{
+        name: string;
+        description?: string;
+        inputSchemaJSON?: string;
+      }>;
+      expect(tools).toHaveLength(2);
+      expect(tools[0]).toEqual({
+        name: "bash",
+        description: "Run a shell command",
+        inputSchemaJSON: JSON.stringify(bashTool.parameters),
+      });
+      expect(tools[1]?.inputSchemaJSON).toBe(
+        JSON.stringify(readTool.parameters),
+      );
+    });
+
+    it("strips description and inputSchemaJSON under metadata_only and no_tool_content", async () => {
+      for (const mode of ["metadata_only", "no_tool_content"] as const) {
+        const { sigil, seeds } = setupClient();
+        loadConfigMock.mockResolvedValue({
+          endpoint: "http://localhost:8080/api/v1/generations:export",
+          auth: { mode: "none" },
+          agentName: "pi",
+          contentCapture: mode,
+        });
+        createSigilClientMock.mockReturnValue(sigil);
+
+        const pi = new FakePi();
+        pi.getAllTools = () => [bashTool, readTool];
+        pi.getActiveTools = () => ["bash", "read"];
+        registerExtension(pi as any);
+
+        await pi.emit("session_start");
+        await pi.emit("turn_start");
+        await pi.emit("turn_end", {
+          message: assistantMessage(),
+          toolResults: [],
+        });
+
+        const tools = seeds[0]!.tools as Array<{
+          name: string;
+          description?: string;
+          inputSchemaJSON?: string;
+        }>;
+        expect(tools, `mode=${mode}`).toEqual([
+          { name: "bash" },
+          { name: "read" },
+        ]);
+      }
+    });
+
+    it("emits the offered (active) catalog even when no tool is called this turn", async () => {
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      pi.getAllTools = () => [bashTool, readTool];
+      pi.getActiveTools = () => ["bash", "read"];
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
+      // No tool_execution_* events — model offered tools but didn't call any.
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      const tools = seeds[0]!.tools as Array<{ name: string }>;
+      expect(tools.map((t) => t.name)).toEqual(["bash", "read"]);
+    });
+
+    it("degrades to empty tools without crashing when getAllTools throws", async () => {
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "full",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      pi.getAllTools = () => {
+        throw new Error("registry unavailable");
+      };
+      pi.getActiveTools = () => [];
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      expect(seeds).toHaveLength(1);
+      expect(seeds[0]!.tools).toBeUndefined();
+    });
+
+    it("synthesizes name-only tools from getActiveTools when getAllTools throws", async () => {
+      // Registry lookup fails (signature drift, transient error) but the
+      // active-set API still reports the names pi offered the model.
+      // Without the fallback, mapTools would filter an empty catalog and
+      // the seed would silently omit the tool list.
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "full",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      pi.getAllTools = () => {
+        throw new Error("registry unavailable");
+      };
+      pi.getActiveTools = () => ["bash", "read"];
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      expect(seeds).toHaveLength(1);
+      const tools = seeds[0]!.tools as Array<{
+        name: string;
+        description?: string;
+        inputSchemaJSON?: string;
+      }>;
+      expect(tools.map((t) => t.name).sort()).toEqual(["bash", "read"]);
+      // Catalog was unavailable, so we have no description/schema to emit.
+      for (const t of tools) {
+        expect(t.description).toBeUndefined();
+        expect(t.inputSchemaJSON).toBeUndefined();
+      }
+    });
+
+    it("falls back to called tool names when getActiveTools is unavailable", async () => {
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      // Neither hook present — emulates older pi versions.
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
+      await pi.emit("tool_execution_start", {
+        toolCallId: "c1",
+        toolName: "bash",
+      });
+      await pi.emit("tool_execution_end", { toolCallId: "c1", isError: false });
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      const tools = seeds[0]!.tools as Array<{ name: string }>;
+      expect(tools).toEqual([{ name: "bash" }]);
+    });
+
+    it("emits no tools when getActiveTools explicitly returns []", async () => {
+      // The registry is populated but the user disabled every tool via
+      // setActiveTools([]); the seed must NOT report the full registry.
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      pi.getAllTools = () => [bashTool, readTool];
+      pi.getActiveTools = () => [];
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      expect(seeds[0]!.tools).toBeUndefined();
+    });
+  });
+
+  describe("request controls capture", () => {
+    function setupClient() {
+      const seeds: Array<Record<string, unknown>> = [];
+      const recorder = {
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        setFirstTokenAt: vi.fn(),
+      };
+      const sigil: SigilLike = {
+        startStreamingGeneration: vi.fn(async (seed, run) => {
+          seeds.push(seed as Record<string, unknown>);
+          await run(recorder);
+        }),
+        startToolExecution: vi.fn(() => ({
+          setResult: vi.fn(),
+          setCallError: vi.fn(),
+          end: vi.fn(),
+          getError: vi.fn(),
+        })),
+        shutdown: vi.fn(async () => {}),
+      };
+      return { sigil, seeds };
+    }
+
+    it("populates the seed for the matching turn_end", async () => {
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
+      await pi.emit("before_provider_request", {
+        payload: {
+          max_tokens: 4096,
+          temperature: 0.2,
+          top_p: 0.9,
+          tool_choice: { type: "auto" },
+          thinking: { type: "enabled", budget_tokens: 2048 },
+        },
+      });
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      const seed = seeds[0]!;
+      expect(seed.maxTokens).toBe(4096);
+      expect(seed.temperature).toBe(0.2);
+      expect(seed.topP).toBe(0.9);
+      expect(seed.toolChoice).toBe("auto");
+      expect(seed.metadata).toEqual({
+        "sigil.gen_ai.request.thinking.budget_tokens": 2048,
+      });
+    });
+
+    it("clears between turns so an empty turn 2 does not inherit turn 1's values", async () => {
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
+      await pi.emit("before_provider_request", {
+        payload: { max_tokens: 1024, temperature: 0.5 },
+      });
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      // Turn 2: no before_provider_request fires — values must clear.
+      await pi.emit("turn_start");
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      expect(seeds[0]!.maxTokens).toBe(1024);
+      expect(seeds[0]!.temperature).toBe(0.5);
+      expect(seeds[1]!.maxTokens).toBeUndefined();
+      expect(seeds[1]!.temperature).toBeUndefined();
+    });
+
+    it("clears on agent_end so the next agent loop does not inherit controls", async () => {
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("before_agent_start", { systemPrompt: "sp" });
+      await pi.emit("turn_start");
+      await pi.emit("before_provider_request", {
+        payload: { max_tokens: 1024, temperature: 0.5 },
+      });
+      // Agent loop ends without a matching turn_end — turn_end's finally
+      // never runs, so agent_end is the last line of defense against stale
+      // request controls leaking into the next agent loop.
+      await pi.emit("agent_end", { messages: [] });
+
+      // Next agent loop: no before_provider_request fires before turn_end.
+      await pi.emit("turn_start");
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      expect(seeds).toHaveLength(1);
+      expect(seeds[0]!.maxTokens).toBeUndefined();
+      expect(seeds[0]!.temperature).toBeUndefined();
+    });
+
+    it("refreshes per turn when consecutive before_provider_request events fire", async () => {
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
+      await pi.emit("before_provider_request", {
+        payload: { max_tokens: 1024, temperature: 0.5, top_p: 0.8 },
+      });
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      // Tool-loop continuation: a new request payload with fewer fields.
+      await pi.emit("turn_start");
+      await pi.emit("before_provider_request", {
+        payload: { max_tokens: 2048 },
+      });
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      expect(seeds[0]!.maxTokens).toBe(1024);
+      expect(seeds[0]!.topP).toBe(0.8);
+      expect(seeds[1]!.maxTokens).toBe(2048);
+      expect(seeds[1]!.temperature).toBeUndefined();
+      expect(seeds[1]!.topP).toBeUndefined();
+    });
+
+    it("emits controls under metadata_only too", async () => {
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
+      await pi.emit("before_provider_request", {
+        payload: { temperature: 0.1, max_tokens: 256 },
+      });
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      expect(seeds[0]!.temperature).toBe(0.1);
+      expect(seeds[0]!.maxTokens).toBe(256);
+    });
+
+    it("extracts controls from Gemini-shaped payloads", async () => {
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
+      await pi.emit("before_provider_request", {
+        payload: {
+          model: "gemini-2.0-flash",
+          contents: [],
+          config: {
+            temperature: 0.4,
+            topP: 0.95,
+            maxOutputTokens: 8192,
+            toolConfig: { functionCallingConfig: { mode: "ANY" } },
+            thinkingConfig: { thinkingBudget: 2048 },
+          },
+        },
+      });
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      expect(seeds[0]!.maxTokens).toBe(8192);
+      expect(seeds[0]!.temperature).toBe(0.4);
+      expect(seeds[0]!.topP).toBe(0.95);
+      expect(seeds[0]!.toolChoice).toBe("ANY");
+      expect(seeds[0]!.metadata).toEqual({
+        "sigil.gen_ai.request.thinking.budget_tokens": 2048,
+      });
+    });
+
+    it("preserves the forced tool name in Anthropic tool_choice", async () => {
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
+      await pi.emit("before_provider_request", {
+        payload: { tool_choice: { type: "tool", name: "search" } },
+      });
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      expect(seeds[0]!.toolChoice).toBe("tool:search");
+    });
   });
 });
 

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -14,11 +14,14 @@ import { loadConfig } from "./config.js";
 import { resolveGitBranch } from "./git.js";
 import { runToolCallGuard } from "./guard.js";
 import {
+  type CachedRequestControls,
+  extractRequestControls,
   mapGenerationResult,
   mapGenerationStart,
-  mapToolNames,
+  mapTools,
   mapUserMessage,
   type PiAssistantMessage,
+  type PiToolInfo,
   type PiToolResult,
   type PiUserMessage,
   type ToolTiming,
@@ -76,6 +79,15 @@ export default function (pi: ExtensionAPI) {
   // same turn, so this is the actual completion time of the model call.
   // 0 means: no assistant message_end seen yet for this turn.
   let assistantMessageEndTime = 0;
+  // Cached from the most recent `before_agent_start`. Outlives a single
+  // turn so multi-turn tool loops reuse the same prompt; cleared on
+  // agent_end and session_shutdown.
+  let currentSystemPrompt: string | undefined;
+  // Refreshed for every `before_provider_request` and consumed by the
+  // matching `turn_end`. Cleared in the per-turn finally so a stale value
+  // from turn N never leaks into turn N+1, and also on `agent_end` /
+  // session shutdown in case a turn ends without a matching `turn_end`.
+  let currentRequestControls: CachedRequestControls = {};
 
   function debugLog(msg: string, ...args: unknown[]) {
     if (config?.debug) console.error(`[sigil-pi] ${msg}`, ...args);
@@ -114,6 +126,8 @@ export default function (pi: ExtensionAPI) {
     resetTurnState();
     pendingInputMessages.length = 0;
     lastSeenModel = null;
+    currentSystemPrompt = undefined;
+    currentRequestControls = {};
   }
 
   function cacheAssistantModel(message: PiAssistantMessage) {
@@ -181,6 +195,45 @@ export default function (pi: ExtensionAPI) {
     resetTurnState();
     if (!sigil) return;
     turnStartTime = Date.now();
+  });
+
+  pi.on("before_agent_start", async (event, _ctx) => {
+    if (!sigil || !config) return;
+    try {
+      // System prompts encode project conventions (CLAUDE.md, skill text,
+      // etc.). Gate on contentCapture the same way `git.branch` is gated.
+      if (config.contentCapture === "metadata_only") return;
+      const prompt = (event as { systemPrompt?: unknown }).systemPrompt;
+      if (typeof prompt === "string" && prompt.length > 0) {
+        currentSystemPrompt = prompt;
+      }
+    } catch (err) {
+      console.warn("[sigil-pi] before_agent_start failed:", err);
+    }
+  });
+
+  pi.on("agent_end", async (_event, _ctx) => {
+    // Clear both caches at the agent boundary. `currentRequestControls` is
+    // normally cleared in turn_end's finally, but if an agent loop ends
+    // without a matching turn_end, those provider settings could otherwise
+    // attach to the next agent loop's first exported generation.
+    currentSystemPrompt = undefined;
+    currentRequestControls = {};
+  });
+
+  // Refresh request controls before every provider call. The payload is
+  // provider-specific (Anthropic/OpenAI/Gemini), so extraction is purely
+  // structural — see `extractRequestControls`. This handler MUST NOT return
+  // a value: pi treats a returned value as a payload replacement.
+  pi.on("before_provider_request", async (event, _ctx) => {
+    if (!sigil) return;
+    try {
+      const payload = (event as { payload?: unknown }).payload;
+      currentRequestControls = extractRequestControls(payload);
+    } catch (err) {
+      console.warn("[sigil-pi] before_provider_request failed:", err);
+      currentRequestControls = {};
+    }
   });
 
   pi.on("message_end", async (event, _ctx) => {
@@ -282,7 +335,45 @@ export default function (pi: ExtensionAPI) {
 
       const msg = event.message;
       const contentCapture = config.contentCapture;
-      const toolDefs = mapToolNames(turnToolTimings);
+
+      // Build the active tool catalog from pi's registry. Prefer the active
+      // set (what the model was offered this turn) so evaluators can
+      // compute precision/recall. `null` means the active-set API is
+      // unavailable (older pi versions); an empty Set means it returned
+      // explicitly no tools — those are different cases and `mapTools`
+      // treats them differently.
+      let toolCatalog: PiToolInfo[] = [];
+      try {
+        toolCatalog = pi.getAllTools?.() ?? [];
+      } catch (err) {
+        debugLog("getAllTools failed", err);
+        toolCatalog = [];
+      }
+      let activeNames: Set<string> | null = null;
+      try {
+        const active = pi.getActiveTools?.();
+        if (Array.isArray(active)) activeNames = new Set(active);
+      } catch (err) {
+        debugLog("getActiveTools failed", err);
+      }
+      if (
+        toolCatalog.length === 0 &&
+        activeNames !== null &&
+        activeNames.size > 0
+      ) {
+        // getAllTools threw or returned [] but getActiveTools still gave us
+        // names — synthesize name-only defs so the seed records the tools
+        // pi actually offered the model. Without this, `mapTools` would
+        // filter an empty catalog and drop the tool list entirely.
+        toolCatalog = Array.from(activeNames).map((name) => ({ name }));
+      } else if (activeNames === null && toolCatalog.length === 0) {
+        // Neither catalog nor active-set API — fall back to the called-tools
+        // subset so older pi versions still emit something useful.
+        const calledNames = new Set(turnToolTimings.map((t) => t.toolName));
+        toolCatalog = Array.from(calledNames).map((name) => ({ name }));
+        activeNames = calledNames;
+      }
+      const toolDefs = mapTools(toolCatalog, activeNames, contentCapture);
 
       // Read the current sessionId every turn. SessionManager reassigns
       // sessionId on fork/branch, and extensions that spawn child sessions
@@ -316,15 +407,16 @@ export default function (pi: ExtensionAPI) {
           : undefined;
       const builtinTags = gitBranch ? { "git.branch": gitBranch } : undefined;
 
-      const seed = mapGenerationStart(
-        msg,
+      const seed = mapGenerationStart(msg, {
         conversationId,
-        config.agentName,
-        config.agentVersion,
-        startedAtMs,
-        toolDefs.length > 0 ? toolDefs : undefined,
-        builtinTags,
-      );
+        agentName: config.agentName,
+        agentVersion: config.agentVersion,
+        startedAt: startedAtMs,
+        tools: toolDefs.length > 0 ? toolDefs : undefined,
+        tags: builtinTags,
+        systemPrompt: currentSystemPrompt,
+        requestControls: currentRequestControls,
+      });
 
       const toolResults = (event.toolResults ?? []) as PiToolResult[];
       // Snapshot the buffer; the finally below clears it in place and
@@ -382,6 +474,7 @@ export default function (pi: ExtensionAPI) {
       toolStarts.clear();
       turnToolTimings.length = 0;
       pendingInputMessages.length = 0;
+      currentRequestControls = {};
     }
   });
 

--- a/plugins/pi/src/mappers.test.ts
+++ b/plugins/pi/src/mappers.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
+  extractRequestControls,
   mapGenerationResult,
   mapGenerationStart,
-  mapToolNames,
+  mapTools,
   mapUserMessage,
   type PiAssistantMessage,
+  type PiToolInfo,
   type PiToolResult,
   type PiUserMessage,
-  type ToolTiming,
 } from "./mappers.js";
 
 function makeMsg(overrides?: Partial<PiAssistantMessage>): PiAssistantMessage {
@@ -58,28 +59,27 @@ function makeUserMsg(overrides?: Partial<PiUserMessage>): PiUserMessage {
   };
 }
 
-function makeTiming(overrides?: Partial<ToolTiming>): ToolTiming {
+function makeToolInfo(overrides?: Partial<PiToolInfo>): PiToolInfo {
   return {
-    toolCallId: "call-1",
-    toolName: "bash",
-    startedAt: 1700000000500,
-    completedAt: 1700000001500,
-    isError: false,
+    name: "bash",
+    description: "Run a shell command",
+    parameters: {
+      type: "object",
+      properties: { command: { type: "string" } },
+      required: ["command"],
+    },
     ...overrides,
   };
 }
 
 describe("mapGenerationStart", () => {
   it("maps model, conversation, agent info", () => {
-    const msg = makeMsg();
-    const start = mapGenerationStart(
-      msg,
-      "session-abc",
-      "pi",
-      "1.0.0",
-      1700000000000,
-      undefined,
-    );
+    const start = mapGenerationStart(makeMsg(), {
+      conversationId: "session-abc",
+      agentName: "pi",
+      agentVersion: "1.0.0",
+      startedAt: 1700000000000,
+    });
     expect(start.model).toEqual({
       provider: "anthropic",
       name: "claude-sonnet-4-20250514",
@@ -91,10 +91,13 @@ describe("mapGenerationStart", () => {
   });
 
   it("includes tools whenever provided", () => {
-    const msg = makeMsg();
     const tools = [{ name: "bash" }, { name: "read" }];
-
-    const result = mapGenerationStart(msg, "s", "pi", undefined, 0, tools);
+    const result = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+      tools,
+    });
     expect(result.tools).toEqual(tools);
   });
 
@@ -105,80 +108,134 @@ describe("mapGenerationStart", () => {
         { type: "text", text: "answer" },
       ],
     });
-    const start = mapGenerationStart(
-      msg,
-      undefined,
-      "pi",
-      undefined,
-      0,
-      undefined,
-    );
+    const start = mapGenerationStart(msg, { agentName: "pi", startedAt: 0 });
     expect(start.thinkingEnabled).toBe(true);
   });
 
   it("omits thinkingEnabled when no thinking blocks present", () => {
-    const start = mapGenerationStart(
-      makeMsg(),
-      undefined,
-      "pi",
-      undefined,
-      0,
-      undefined,
-    );
+    const start = mapGenerationStart(makeMsg(), {
+      agentName: "pi",
+      startedAt: 0,
+    });
     expect(start.thinkingEnabled).toBeUndefined();
   });
 
   it("propagates agentVersion into effectiveVersion", () => {
     const msg = makeMsg();
-    const a = mapGenerationStart(msg, "s", "pi", "1.4.7", 0, [
-      { name: "bash" },
-    ]);
-    const b = mapGenerationStart(msg, "s", "pi", "1.4.7", 0, [
-      { name: "read" },
-    ]);
+    const a = mapGenerationStart(msg, {
+      conversationId: "s",
+      agentName: "pi",
+      agentVersion: "1.4.7",
+      startedAt: 0,
+      tools: [{ name: "bash" }],
+    });
+    const b = mapGenerationStart(msg, {
+      conversationId: "s",
+      agentName: "pi",
+      agentVersion: "1.4.7",
+      startedAt: 0,
+      tools: [{ name: "read" }],
+    });
     expect(a.effectiveVersion).toBe("1.4.7");
     expect(a.effectiveVersion).toBe(b.effectiveVersion);
     expect(a.effectiveVersion).toBe(a.agentVersion);
   });
 
   it("leaves effectiveVersion unset when agentVersion is missing", () => {
-    const start = mapGenerationStart(
-      makeMsg(),
-      "s",
-      "pi",
-      undefined,
-      0,
-      undefined,
-    );
+    const start = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+    });
     expect(start.effectiveVersion).toBeUndefined();
   });
 
   it("attaches tags when provided", () => {
-    const start = mapGenerationStart(
-      makeMsg(),
-      "s",
-      "pi",
-      undefined,
-      0,
-      undefined,
-      { "git.branch": "main" },
-    );
+    const start = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+      tags: { "git.branch": "main" },
+    });
     expect(start.tags).toEqual({ "git.branch": "main" });
   });
 
   it("omits tags when empty or undefined", () => {
-    const a = mapGenerationStart(
-      makeMsg(),
-      "s",
-      "pi",
-      undefined,
-      0,
-      undefined,
-      {},
-    );
-    const b = mapGenerationStart(makeMsg(), "s", "pi", undefined, 0, undefined);
+    const a = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+      tags: {},
+    });
+    const b = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+    });
     expect(a.tags).toBeUndefined();
     expect(b.tags).toBeUndefined();
+  });
+
+  it("sets systemPrompt when provided and non-empty", () => {
+    const start = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+      systemPrompt: "You are a helpful agent.",
+    });
+    expect(start.systemPrompt).toBe("You are a helpful agent.");
+  });
+
+  it("omits systemPrompt when undefined or empty", () => {
+    const a = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+    });
+    const b = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+      systemPrompt: "",
+    });
+    expect(a.systemPrompt).toBeUndefined();
+    expect(b.systemPrompt).toBeUndefined();
+  });
+
+  it("sets request controls when provided", () => {
+    const start = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+      requestControls: {
+        maxTokens: 1024,
+        temperature: 0.2,
+        topP: 0.9,
+        toolChoice: "auto",
+        thinkingBudgetTokens: 4096,
+      },
+    });
+    expect(start.maxTokens).toBe(1024);
+    expect(start.temperature).toBe(0.2);
+    expect(start.topP).toBe(0.9);
+    expect(start.toolChoice).toBe("auto");
+    expect(start.metadata).toEqual({
+      "sigil.gen_ai.request.thinking.budget_tokens": 4096,
+    });
+  });
+
+  it("leaves request controls unset when fields are missing", () => {
+    const start = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+      requestControls: {},
+    });
+    expect(start.maxTokens).toBeUndefined();
+    expect(start.temperature).toBeUndefined();
+    expect(start.topP).toBeUndefined();
+    expect(start.toolChoice).toBeUndefined();
+    expect(start.metadata).toBeUndefined();
   });
 });
 
@@ -515,18 +572,232 @@ describe("mapGenerationResult input wiring", () => {
   });
 });
 
-describe("mapToolNames", () => {
-  it("deduplicates tool names", () => {
-    const timings = [
-      makeTiming({ toolName: "bash" }),
-      makeTiming({ toolName: "read" }),
-      makeTiming({ toolName: "bash" }),
+describe("mapTools", () => {
+  it("returns name-only under metadata_only", () => {
+    const catalog = [
+      makeToolInfo({ name: "bash" }),
+      makeToolInfo({ name: "read", description: "Read a file" }),
     ];
-    const defs = mapToolNames(timings);
+    const defs = mapTools(catalog, new Set(["bash", "read"]), "metadata_only");
     expect(defs).toEqual([{ name: "bash" }, { name: "read" }]);
   });
 
-  it("returns empty for no timings", () => {
-    expect(mapToolNames([])).toEqual([]);
+  it("returns name-only under no_tool_content", () => {
+    const catalog = [makeToolInfo({ name: "bash" })];
+    const defs = mapTools(catalog, new Set(["bash"]), "no_tool_content");
+    expect(defs).toEqual([{ name: "bash" }]);
+  });
+
+  it("returns name+description+inputSchemaJSON under full", () => {
+    const catalog = [
+      makeToolInfo({
+        name: "bash",
+        description: "Run a shell command",
+        parameters: { type: "object", properties: { cmd: { type: "string" } } },
+      }),
+    ];
+    const defs = mapTools(catalog, new Set(["bash"]), "full");
+    expect(defs).toHaveLength(1);
+    expect(defs[0]).toEqual({
+      name: "bash",
+      description: "Run a shell command",
+      inputSchemaJSON:
+        '{"type":"object","properties":{"cmd":{"type":"string"}}}',
+    });
+  });
+
+  it("filters by activeNames when set is non-empty", () => {
+    const catalog = [
+      makeToolInfo({ name: "bash" }),
+      makeToolInfo({ name: "read" }),
+      makeToolInfo({ name: "write" }),
+    ];
+    const defs = mapTools(catalog, new Set(["bash", "write"]), "metadata_only");
+    expect(defs.map((d) => d.name)).toEqual(["bash", "write"]);
+  });
+
+  it("emits the full catalog when activeNames is null (no filter)", () => {
+    // null means the active-set API is unavailable (older pi versions);
+    // emit the registry so something useful still ships.
+    const catalog = [
+      makeToolInfo({ name: "bash" }),
+      makeToolInfo({ name: "read" }),
+    ];
+    const defs = mapTools(catalog, null, "metadata_only");
+    expect(defs.map((d) => d.name)).toEqual(["bash", "read"]);
+  });
+
+  it("emits no tools when activeNames is an empty Set", () => {
+    // An empty Set means "no tools offered this turn" — different from null.
+    const catalog = [
+      makeToolInfo({ name: "bash" }),
+      makeToolInfo({ name: "read" }),
+    ];
+    expect(mapTools(catalog, new Set(), "metadata_only")).toEqual([]);
+  });
+
+  it("handles an empty catalog", () => {
+    expect(mapTools([], new Set(["bash"]), "full")).toEqual([]);
+  });
+
+  it("deduplicates by tool name", () => {
+    const catalog = [
+      makeToolInfo({ name: "bash" }),
+      makeToolInfo({ name: "bash" }),
+      makeToolInfo({ name: "read" }),
+    ];
+    const defs = mapTools(catalog, new Set(["bash", "read"]), "metadata_only");
+    expect(defs.map((d) => d.name)).toEqual(["bash", "read"]);
+  });
+
+  it("skips description under full when value is empty", () => {
+    const catalog = [makeToolInfo({ name: "bash", description: "" })];
+    const defs = mapTools(catalog, new Set(["bash"]), "full");
+    expect(defs[0]?.description).toBeUndefined();
+  });
+});
+
+describe("extractRequestControls", () => {
+  it("extracts Anthropic-shaped payload with thinking", () => {
+    const ctrls = extractRequestControls({
+      max_tokens: 4096,
+      temperature: 0.2,
+      top_p: 0.9,
+      tool_choice: { type: "auto" },
+      thinking: { type: "enabled", budget_tokens: 2048 },
+    });
+    expect(ctrls).toEqual({
+      maxTokens: 4096,
+      temperature: 0.2,
+      topP: 0.9,
+      toolChoice: "auto",
+      thinkingBudgetTokens: 2048,
+    });
+  });
+
+  it("preserves the forced tool name in Anthropic tool_choice", () => {
+    const ctrls = extractRequestControls({
+      tool_choice: { type: "tool", name: "search" },
+    });
+    expect(ctrls.toolChoice).toBe("tool:search");
+  });
+
+  it("falls back to type when forced-tool name is missing", () => {
+    const ctrls = extractRequestControls({
+      tool_choice: { type: "tool" },
+    });
+    expect(ctrls.toolChoice).toBe("tool");
+  });
+
+  it("accepts OpenAI Chat max_tokens", () => {
+    const ctrls = extractRequestControls({ max_tokens: 512 });
+    expect(ctrls.maxTokens).toBe(512);
+  });
+
+  it("accepts OpenAI Chat max_completion_tokens", () => {
+    const ctrls = extractRequestControls({ max_completion_tokens: 1024 });
+    expect(ctrls.maxTokens).toBe(1024);
+  });
+
+  it("accepts OpenAI Responses max_output_tokens", () => {
+    const ctrls = extractRequestControls({ max_output_tokens: 2000 });
+    expect(ctrls.maxTokens).toBe(2000);
+  });
+
+  it("reads Gemini config wrapper (pi's @google/genai SDK shape)", () => {
+    // Matches the payload pi's google.js builds: temperature/maxOutputTokens
+    // spread into `config`, plus toolConfig and thinkingConfig nests.
+    const ctrls = extractRequestControls({
+      model: "gemini-2.0-flash",
+      contents: [],
+      config: {
+        temperature: 0.7,
+        topP: 0.95,
+        maxOutputTokens: 8192,
+        toolConfig: { functionCallingConfig: { mode: "AUTO" } },
+        thinkingConfig: { thinkingBudget: 1024 },
+      },
+    });
+    expect(ctrls).toEqual({
+      maxTokens: 8192,
+      temperature: 0.7,
+      topP: 0.95,
+      toolChoice: "AUTO",
+      thinkingBudgetTokens: 1024,
+    });
+  });
+
+  it("reads the legacy generationConfig nest too", () => {
+    const ctrls = extractRequestControls({
+      generationConfig: {
+        temperature: 0.7,
+        topP: 0.95,
+        maxOutputTokens: 8192,
+      },
+    });
+    expect(ctrls).toEqual({
+      maxTokens: 8192,
+      temperature: 0.7,
+      topP: 0.95,
+    });
+  });
+
+  it("prefers top-level fields over Gemini config wrapper", () => {
+    // If both shapes appear (shouldn't happen in practice), top-level wins.
+    const ctrls = extractRequestControls({
+      max_tokens: 256,
+      config: { maxOutputTokens: 8192 },
+    });
+    expect(ctrls.maxTokens).toBe(256);
+  });
+
+  it("accepts string tool_choice", () => {
+    expect(extractRequestControls({ tool_choice: "required" }).toolChoice).toBe(
+      "required",
+    );
+  });
+
+  it("accepts camelCase toolChoice and topP", () => {
+    const ctrls = extractRequestControls({
+      toolChoice: "none",
+      topP: 0.5,
+    });
+    expect(ctrls.toolChoice).toBe("none");
+    expect(ctrls.topP).toBe(0.5);
+  });
+
+  it("returns {} for null", () => {
+    expect(extractRequestControls(null)).toEqual({});
+  });
+
+  it("returns {} for undefined", () => {
+    expect(extractRequestControls(undefined)).toEqual({});
+  });
+
+  it("returns {} for a string", () => {
+    expect(extractRequestControls("hello")).toEqual({});
+  });
+
+  it("returns {} for a number", () => {
+    expect(extractRequestControls(42)).toEqual({});
+  });
+
+  it("returns {} for an array", () => {
+    expect(extractRequestControls([1, 2])).toEqual({});
+  });
+
+  it("ignores non-finite numbers", () => {
+    const ctrls = extractRequestControls({
+      max_tokens: Number.NaN,
+      temperature: Number.POSITIVE_INFINITY,
+    });
+    expect(ctrls).toEqual({});
+  });
+
+  it("skips thinking budget when not numeric", () => {
+    const ctrls = extractRequestControls({
+      thinking: { type: "enabled", budget_tokens: "lots" },
+    });
+    expect(ctrls.thinkingBudgetTokens).toBeUndefined();
   });
 });

--- a/plugins/pi/src/mappers.ts
+++ b/plugins/pi/src/mappers.ts
@@ -7,6 +7,30 @@ import type {
 } from "@grafana/sigil-sdk-js";
 
 /**
+ * Pi's ToolInfo shape from @mariozechner/pi-coding-agent.
+ * Declared here to avoid a hard import of pi types (treated as external at
+ * runtime); the structural fields match `ToolInfo` in pi's `ExtensionAPI`.
+ */
+export interface PiToolInfo {
+  name: string;
+  description?: string;
+  parameters?: unknown;
+}
+
+/**
+ * Request controls extracted from a `before_provider_request` payload.
+ * Defensive shape: every field is optional because providers differ in
+ * which controls they accept and what names they use.
+ */
+export interface CachedRequestControls {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  toolChoice?: string;
+  thinkingBudgetTokens?: number;
+}
+
+/**
  * Pi's AssistantMessage shape from @mariozechner/pi-ai.
  * Declared here to avoid hard import (pi types are external at runtime).
  */
@@ -81,16 +105,33 @@ export interface ToolTiming {
   isError: boolean;
 }
 
+/** Optional context for building a GenerationStart seed. */
+export interface MapGenerationStartOptions {
+  conversationId?: string;
+  agentName: string;
+  agentVersion?: string;
+  startedAt: number;
+  tools?: ToolDefinition[];
+  tags?: Record<string, string>;
+  systemPrompt?: string;
+  requestControls?: CachedRequestControls;
+}
+
 /** Build the GenerationStart seed from an assistant message and context. */
 export function mapGenerationStart(
   msg: PiAssistantMessage,
-  conversationId: string | undefined,
-  agentName: string,
-  agentVersion: string | undefined,
-  turnStartTime: number,
-  tools: ToolDefinition[] | undefined,
-  tags?: Record<string, string>,
+  opts: MapGenerationStartOptions,
 ): GenerationStart {
+  const {
+    conversationId,
+    agentName,
+    agentVersion,
+    startedAt,
+    tools,
+    tags,
+    systemPrompt,
+    requestControls,
+  } = opts;
   // Tags on the seed override client-level SIGIL_TAGS (the SDK merges
   // `{...clientTags, ...seedTags}`), matching claude-code/cursor.
   const start: GenerationStart = {
@@ -99,12 +140,37 @@ export function mapGenerationStart(
     agentVersion,
     effectiveVersion: agentVersion,
     model: { provider: msg.provider, name: msg.model },
-    startedAt: new Date(turnStartTime),
+    startedAt: new Date(startedAt),
     ...(tools && tools.length > 0 ? { tools } : {}),
     ...(tags && Object.keys(tags).length > 0 ? { tags } : {}),
   };
   if (msg.content.some((b) => b.type === "thinking")) {
     start.thinkingEnabled = true;
+  }
+  if (systemPrompt && systemPrompt.length > 0) {
+    start.systemPrompt = systemPrompt;
+  }
+  if (requestControls) {
+    if (typeof requestControls.maxTokens === "number") {
+      start.maxTokens = requestControls.maxTokens;
+    }
+    if (typeof requestControls.temperature === "number") {
+      start.temperature = requestControls.temperature;
+    }
+    if (typeof requestControls.topP === "number") {
+      start.topP = requestControls.topP;
+    }
+    if (typeof requestControls.toolChoice === "string") {
+      start.toolChoice = requestControls.toolChoice;
+    }
+    if (typeof requestControls.thinkingBudgetTokens === "number") {
+      // The SDK reads `sigil.gen_ai.request.thinking.budget_tokens` from
+      // generation metadata and surfaces it as the matching span attribute.
+      start.metadata = {
+        "sigil.gen_ai.request.thinking.budget_tokens":
+          requestControls.thinkingBudgetTokens,
+      };
+    }
   }
   return start;
 }
@@ -192,17 +258,136 @@ export function mapUserMessage(
   };
 }
 
-/** Map tool names used in this turn to ToolDefinition[]. */
-export function mapToolNames(toolTimings: ToolTiming[]): ToolDefinition[] {
-  const seen = new Set<string>();
+/**
+ * Map the active tool catalog to ToolDefinition[]. Filters `toolCatalog` by
+ * `activeNames` so the seed reflects what was offered to the model, not the
+ * full registry. `activeNames === null` means "no filter" (the active-set
+ * API is unavailable); an empty Set means "no tools offered this turn" and
+ * produces an empty result. `description` and `inputSchemaJSON` are body
+ * content and are only emitted under `contentCapture === "full"`; otherwise
+ * the definitions are name-only, matching how `git.branch` is gated.
+ */
+export function mapTools(
+  toolCatalog: PiToolInfo[],
+  activeNames: Set<string> | null,
+  contentCapture: ContentCaptureMode,
+): ToolDefinition[] {
   const defs: ToolDefinition[] = [];
-  for (const t of toolTimings) {
-    if (!seen.has(t.toolName)) {
-      seen.add(t.toolName);
-      defs.push({ name: t.toolName });
+  const seen = new Set<string>();
+  const includeBody = contentCapture === "full";
+
+  for (const tool of toolCatalog) {
+    if (!tool || typeof tool.name !== "string") continue;
+    if (activeNames !== null && !activeNames.has(tool.name)) continue;
+    if (seen.has(tool.name)) continue;
+    seen.add(tool.name);
+
+    const def: ToolDefinition = { name: tool.name };
+    if (includeBody) {
+      if (typeof tool.description === "string" && tool.description.length > 0) {
+        def.description = tool.description;
+      }
+      if (tool.parameters !== undefined) {
+        try {
+          def.inputSchemaJSON = JSON.stringify(tool.parameters);
+        } catch {
+          // Non-serializable schema (cycles, BigInt, etc.) — skip silently.
+        }
+      }
     }
+    defs.push(def);
   }
   return defs;
+}
+
+/**
+ * Read provider-specific request controls from a `before_provider_request`
+ * payload. Pi emits provider-shaped payloads:
+ *   - Anthropic / OpenAI Chat / OpenAI Responses: fields at the top level
+ *     (`max_tokens`, `temperature`, `top_p`, `tool_choice`, `thinking`).
+ *   - Gemini (`@google/genai` SDK): wrapped in `config` (`config.temperature`,
+ *     `config.maxOutputTokens`, `config.toolConfig.functionCallingConfig.mode`,
+ *     `config.thinkingConfig.thinkingBudget`).
+ * Unknown shapes degrade to `{}`.
+ */
+export function extractRequestControls(
+  payload: unknown,
+): CachedRequestControls {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return {};
+  }
+  const obj = payload as Record<string, unknown>;
+  const out: CachedRequestControls = {};
+
+  const asObject = (v: unknown): Record<string, unknown> | undefined =>
+    v && typeof v === "object" && !Array.isArray(v)
+      ? (v as Record<string, unknown>)
+      : undefined;
+
+  // Gemini wraps controls in `config`. The legacy REST shape used
+  // `generationConfig`; accept both so older pi versions or compat layers
+  // still work.
+  const geminiConfig = asObject(obj.config) ?? asObject(obj.generationConfig);
+
+  const readNumber = (...candidates: unknown[]): number | undefined => {
+    for (const c of candidates) {
+      if (typeof c === "number" && Number.isFinite(c)) return c;
+    }
+    return undefined;
+  };
+
+  const maxTokens = readNumber(
+    obj.max_tokens,
+    obj.max_completion_tokens,
+    obj.max_output_tokens,
+    geminiConfig?.maxOutputTokens,
+  );
+  if (maxTokens !== undefined) out.maxTokens = maxTokens;
+
+  const temperature = readNumber(obj.temperature, geminiConfig?.temperature);
+  if (temperature !== undefined) out.temperature = temperature;
+
+  const topP = readNumber(obj.top_p, obj.topP, geminiConfig?.topP);
+  if (topP !== undefined) out.topP = topP;
+
+  // `tool_choice` is a string for some providers and an object for others.
+  // Anthropic forced-tool uses `{type: "tool", name: "<tool>"}` — encode as
+  // `"tool:<name>"` so the forced tool isn't lost.
+  // Gemini uses `config.toolConfig.functionCallingConfig.mode`.
+  const tc = obj.tool_choice ?? obj.toolChoice;
+  if (typeof tc === "string") {
+    out.toolChoice = tc;
+  } else {
+    const tcObj = asObject(tc);
+    if (tcObj) {
+      const t = tcObj.type;
+      const name = tcObj.name;
+      if (typeof t === "string") {
+        out.toolChoice =
+          t === "tool" && typeof name === "string" && name.length > 0
+            ? `tool:${name}`
+            : t;
+      }
+    }
+  }
+  if (out.toolChoice === undefined && geminiConfig) {
+    const fc = asObject(geminiConfig.toolConfig)?.functionCallingConfig;
+    const mode = asObject(fc)?.mode;
+    if (typeof mode === "string") out.toolChoice = mode;
+  }
+
+  const thinking = asObject(obj.thinking);
+  if (thinking && typeof thinking.budget_tokens === "number") {
+    out.thinkingBudgetTokens = thinking.budget_tokens;
+  }
+  if (out.thinkingBudgetTokens === undefined && geminiConfig) {
+    const thinkingConfig = asObject(geminiConfig.thinkingConfig);
+    if (thinkingConfig && typeof thinkingConfig.thinkingBudget === "number") {
+      out.thinkingBudgetTokens = thinkingConfig.thinkingBudget;
+    }
+  }
+
+  return out;
 }
 
 /**


### PR DESCRIPTION
Subscribe to `before_agent_start` to cache the system prompt, and to `before_provider_request` to extract `max_tokens`, `temperature`, `top_p`, `tool_choice`, and `thinking.budget_tokens` from the provider payload. Build the tool catalog from `getAllTools`/`getActiveTools` so the seed reflects the tools offered to the model rather than only the ones called.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes what metadata/content is exported (system prompts, tool schemas, and provider settings) and adds new per-turn caching/clearing logic that could affect telemetry correctness or data sensitivity if misconfigured.
> 
> **Overview**
> **Exports richer generation context from the pi plugin.** The extension now caches the `systemPrompt` from `before_agent_start` (gated by `contentCapture`) and attaches it to each exported turn, clearing it on `agent_end`/`session_shutdown`.
> 
> **Improves tool and request metadata capture.** Turn exports now include an *offered tool catalog* derived from `getAllTools`/`getActiveTools` (with fallbacks to name-only when APIs fail or are unavailable), emitting `description`/`inputSchemaJSON` only in `full` mode. It also captures per-provider request controls (e.g., `max_tokens`, `temperature`, `top_p`, `tool_choice`, thinking budget; including Gemini shapes) via `before_provider_request`, ensuring values are reset between turns and across agent/session boundaries.
> 
> **Refactors and tests.** `mapGenerationStart` now takes an options object and supports the new fields; `mapToolNames` is replaced by `mapTools`, and extensive unit/integration tests were added for prompt/tool catalog/request control behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 678862845d220ef897887fe821c20efe3edfd886. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->