### PR TITLE
fix(plugins/pi): report host pi version, not stale peer copy

### DIFF
--- a/plugins/pi/src/detectPiVersion.test.ts
+++ b/plugins/pi/src/detectPiVersion.test.ts
@@ -1,0 +1,139 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { detectPiVersion } from "./detectPiVersion.js";
+
+const originalArgv = process.argv;
+
+function stageHostPi(
+  root: string,
+  packageName: string,
+  version: string,
+): string {
+  const pkgDir = join(root, "lib", "node_modules", ...packageName.split("/"));
+  const distDir = join(pkgDir, "dist");
+  mkdirSync(distDir, { recursive: true });
+  writeFileSync(
+    join(pkgDir, "package.json"),
+    JSON.stringify({ name: packageName, version }),
+  );
+  const cli = join(distDir, "cli.js");
+  writeFileSync(cli, "#!/usr/bin/env node\n");
+  return cli;
+}
+
+function setArgv(entry: string): void {
+  process.argv = [originalArgv[0] ?? "node", entry];
+}
+
+describe("detectPiVersion", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sigil-pi-detect-"));
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reads version from @earendil-works host package", () => {
+    const cli = stageHostPi(dir, "@earendil-works/pi-coding-agent", "0.75.4");
+    setArgv(cli);
+    expect(detectPiVersion()).toBe("0.75.4");
+  });
+
+  it("reads version from @mariozechner host package", () => {
+    const cli = stageHostPi(dir, "@mariozechner/pi-coding-agent", "0.73.1");
+    setArgv(cli);
+    expect(detectPiVersion()).toBe("0.73.1");
+  });
+
+  it("follows a symlinked entry script via realpath", () => {
+    const cli = stageHostPi(dir, "@earendil-works/pi-coding-agent", "0.75.4");
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const symlink = join(binDir, "pi");
+    symlinkSync(cli, symlink);
+    setArgv(symlink);
+    expect(detectPiVersion()).toBe("0.75.4");
+  });
+
+  it("ignores a stale peer copy bundled next to the extension", () => {
+    const cli = stageHostPi(dir, "@earendil-works/pi-coding-agent", "0.75.4");
+    const staleDir = join(
+      dir,
+      "lib",
+      "node_modules",
+      "@grafana",
+      "sigil-pi",
+      "node_modules",
+      "@mariozechner",
+      "pi-coding-agent",
+    );
+    mkdirSync(staleDir, { recursive: true });
+    writeFileSync(
+      join(staleDir, "package.json"),
+      JSON.stringify({
+        name: "@mariozechner/pi-coding-agent",
+        version: "0.70.5",
+      }),
+    );
+    setArgv(cli);
+    const detected = detectPiVersion();
+    expect(detected).toBe("0.75.4");
+    expect(detected).not.toBe("0.70.5");
+  });
+
+  it("returns undefined when argv[1] is missing", () => {
+    process.argv = [originalArgv[0] ?? "node"];
+    expect(detectPiVersion()).toBeUndefined();
+  });
+
+  it("returns undefined when no matching package.json is found", () => {
+    const scriptDir = join(dir, "some", "unrelated", "tree");
+    mkdirSync(scriptDir, { recursive: true });
+    const script = join(scriptDir, "script.js");
+    writeFileSync(script, "");
+    setArgv(script);
+    expect(detectPiVersion()).toBeUndefined();
+  });
+
+  it("returns undefined and does not throw when realpath fails", () => {
+    setArgv(join(dir, "does-not-exist", "cli.js"));
+    expect(() => detectPiVersion()).not.toThrow();
+    expect(detectPiVersion()).toBeUndefined();
+  });
+
+  it("walks up until it finds the host package", () => {
+    const deepDir = join(
+      dir,
+      "lib",
+      "node_modules",
+      "@earendil-works",
+      "pi-coding-agent",
+    );
+    mkdirSync(deepDir, { recursive: true });
+    writeFileSync(
+      join(deepDir, "package.json"),
+      JSON.stringify({
+        name: "@earendil-works/pi-coding-agent",
+        version: "0.75.4",
+      }),
+    );
+    const nestedDir = join(deepDir, "a", "b", "c", "d", "e", "f", "g");
+    mkdirSync(nestedDir, { recursive: true });
+    const cli = join(nestedDir, "cli.js");
+    writeFileSync(cli, "");
+    setArgv(cli);
+    expect(detectPiVersion()).toBe("0.75.4");
+  });
+});

--- a/plugins/pi/src/detectPiVersion.ts
+++ b/plugins/pi/src/detectPiVersion.ts
@@ -1,0 +1,37 @@
+import { readFileSync, realpathSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+// Pi ships under two package names; both are valid host installs.
+const SUPPORTED_PACKAGE_NAMES = new Set([
+  "@mariozechner/pi-coding-agent",
+  "@earendil-works/pi-coding-agent",
+]);
+
+/**
+ * Returns the host pi package version, or `undefined` when no matching
+ * package is found or any filesystem operation fails.
+ */
+export function detectPiVersion(): string | undefined {
+  try {
+    const entry = process.argv[1];
+    if (!entry) return undefined;
+    let dir = dirname(realpathSync(entry));
+    while (true) {
+      try {
+        const pkg = JSON.parse(
+          readFileSync(join(dir, "package.json"), "utf-8"),
+        ) as { name?: string; version?: string };
+        if (pkg.name && SUPPORTED_PACKAGE_NAMES.has(pkg.name)) {
+          return pkg.version;
+        }
+      } catch {
+        // No package.json at this level (or unreadable); keep walking.
+      }
+      const parent = dirname(dir);
+      if (parent === dir) return undefined;
+      dir = parent;
+    }
+  } catch {
+    return undefined;
+  }
+}

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -1,7 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import type {
   ContentCaptureMode,
   Message,
@@ -11,6 +8,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { createSigilClient } from "./client.js";
 import type { SigilPiConfig } from "./config.js";
 import { loadConfig } from "./config.js";
+import { detectPiVersion } from "./detectPiVersion.js";
 import { resolveGitBranch } from "./git.js";
 import { runToolCallGuard } from "./guard.js";
 import {
@@ -27,34 +25,6 @@ import {
   createTelemetryProviders,
   type TelemetryProviders,
 } from "./telemetry.js";
-
-function detectPiVersion(): string | undefined {
-  try {
-    // Resolve an exported subpath via ESM resolution, then walk up to package.json.
-    // createRequire won't work here: pi's package.json uses "import"-only exports.
-    const resolved = import.meta.resolve("@mariozechner/pi-coding-agent/hooks");
-    // import.meta.resolve is sync on Node ≥20.6; older versions return a
-    // Promise. Bail out in that case rather than passing a Promise downstream.
-    if (typeof resolved !== "string") return undefined;
-    let dir = dirname(fileURLToPath(resolved));
-    for (let i = 0; i < 5; i++) {
-      try {
-        const pkgPath = join(dir, "package.json");
-        const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
-          name?: string;
-          version?: string;
-        };
-        if (pkg.name === "@mariozechner/pi-coding-agent") return pkg.version;
-      } catch {
-        // no package.json at this level, keep walking
-      }
-      dir = dirname(dir);
-    }
-    return undefined;
-  } catch {
-    return undefined;
-  }
-}
 
 export default function (pi: ExtensionAPI) {
   let sigil: SigilClient | null = null;


### PR DESCRIPTION
Detect the version from the running pi entrypoint instead of resolving the package from the plugin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only how the plugin discovers the Pi host package version for telemetry/config, with defensive fallbacks to `undefined` on failures.
> 
> **Overview**
> Updates the Pi plugin to **detect the host Pi agent version from the running entry script path** (via `process.argv[1]` + `realpath` + upward `package.json` search) instead of resolving the package from within the plugin, avoiding accidentally reporting a bundled/stale peer copy.
> 
> Adds a focused `vitest` suite covering both supported package names, symlinked entrypoints, ignoring stale adjacent installs, deep directory walking, and failure cases (missing argv, missing package.json, broken realpath).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52f2e8256e1a7d5c758e2b6afe7f530f2cba4c62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->