### PR TITLE
chore: enforce golangci-lint config across all Go modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,19 @@ jobs:
       - name: Check protobuf stubs are in sync
         run: mise run check:proto
 
-  go:
-    name: Go SDK
+  go-module:
+    name: Go module
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - go
+          - go-providers/anthropic
+          - go-providers/openai
+          - go-providers/gemini
+          - go-frameworks/google-adk
+          - plugins/sigil
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -63,31 +73,33 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: go/go.mod
+          go-version-file: ${{ matrix.module }}/go.mod
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        env:
+          # Force each module to lint with GOWORK=off so it resolves its own
+          # go.mod, matching the local `mise run lint:go` behavior.
+          GOWORK: "off"
         with:
           args: --timeout=5m
-          working-directory: go
+          working-directory: ${{ matrix.module }}
 
-      - name: Test core
-        run: cd go && GOWORK=off go test ./...
+      - name: Test
+        run: cd ${{ matrix.module }} && GOWORK=off go test ./...
 
-      - name: Test anthropic provider
-        run: cd go-providers/anthropic && GOWORK=off go test ./...
-
-      - name: Test openai provider
-        run: cd go-providers/openai && GOWORK=off go test ./...
-
-      - name: Test gemini provider
-        run: cd go-providers/gemini && GOWORK=off go test ./...
-
-      - name: Test google-adk framework
-        run: cd go-frameworks/google-adk && GOWORK=off go test ./...
-
-      - name: Test sigil plugin
-        run: cd plugins/sigil && GOWORK=off go test ./...
+  go:
+    name: Go SDK
+    runs-on: ubuntu-latest
+    needs: [go-module]
+    if: always()
+    steps:
+      - name: Verify all Go module jobs succeeded
+        run: |
+          if [[ "${{ needs.go-module.result }}" != "success" ]]; then
+            echo "Go module matrix did not succeed: ${{ needs.go-module.result }}"
+            exit 1
+          fi
 
   typescript:
     name: TypeScript SDK

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,114 @@
+version: "2"
+
+linters:
+  enable:
+    - asciicheck
+    - bodyclose
+    - dogsled
+    - errcheck
+    - errorlint
+    - exhaustive
+    - forbidigo
+    - gocyclo
+    - goprintffuncname
+    - gosec
+    - govet
+    - ineffassign
+    - loggercheck
+    - misspell
+    - modernize
+    - nakedret
+    - prealloc
+    - revive
+    - staticcheck
+    - unconvert
+    - unused
+  settings:
+    errcheck:
+      exclude-functions:
+        - io.Copy
+        - io/ioutil.ReadFile
+        - io/ioutil.WriteFile
+    exhaustive:
+      # A default clause is treated as covering all unlisted enum members.
+      default-signifies-exhaustive: true
+    errorlint:
+      # Do not check whether fmt.Errorf uses the %w verb for formatting errors.
+      errorf: false
+      # Do not check for plain type assertions and type switches.
+      asserts: false
+      # Check for plain error comparisons.
+      comparison: true
+    gocyclo:
+      # Provider mappers and metadata normalizers are inherently branchy.
+      # Raise the default 30 to accommodate them; test files are excluded below.
+      min-complexity: 50
+    revive:
+      rules:
+        # Allow `*testing.T` and friends to precede context.Context in test
+        # helpers, which is the standard Go testing convention.
+        - name: context-as-argument
+          arguments:
+            - allowTypesBefore: "*testing.T,*testing.B,*testing.TB,testing.TB"
+    gosec:
+      includes:
+        - G104
+        - G108
+        - G109
+        - G112
+        - G114
+    staticcheck:
+      checks:
+        - "-QF1008" # Disable the "could remove embedded field" check.
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - revive
+        text: if-return
+      - linters:
+          - revive
+        text: consider calling this Factory
+      - linters:
+          - revive
+        text: by other packages, and that stutters
+      - linters:
+          - revive
+        text: "var-naming: don't use an underscore in package name"
+      - linters:
+          - revive
+        text: "var-naming: avoid meaningless package names"
+      - linters:
+          - revive
+        text: "var-naming: avoid package names that conflict with"
+      - linters:
+          - revive
+          - staticcheck
+        text: should have name of the form ErrFoo
+      - linters:
+          - staticcheck
+        text: should not use underscores in package names
+      # Table-driven tests are intentionally large; complexity checks don't add value there.
+      - path: _test\.go
+        linters:
+          - gocyclo
+          - prealloc
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/go-frameworks/google-adk/.golangci.yml
+++ b/go-frameworks/google-adk/.golangci.yml
@@ -1,4 +1,0 @@
-version: "2"
-
-run:
-  tests: false

--- a/go-frameworks/google-adk/adapter.go
+++ b/go-frameworks/google-adk/adapter.go
@@ -3,6 +3,7 @@ package googleadk
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math"
 	"reflect"
 	"strings"
@@ -237,9 +238,7 @@ func (a *Adapter) OnRunStart(ctx context.Context, event RunStartEvent) error {
 	})
 
 	tags := make(map[string]string, len(a.opts.ExtraTags)+3)
-	for key, value := range a.opts.ExtraTags {
-		tags[key] = value
-	}
+	maps.Copy(tags, a.opts.ExtraTags)
 	tags["sigil.framework.name"] = frameworkName
 	tags["sigil.framework.source"] = frameworkSource
 	tags["sigil.framework.language"] = frameworkLanguage

--- a/go-frameworks/google-adk/adapter_test.go
+++ b/go-frameworks/google-adk/adapter_test.go
@@ -585,9 +585,9 @@ func TestOnRunStartDeduplicatesConcurrentStarts(t *testing.T) {
 	})
 
 	adapter := NewSigilAdapter(client, Options{})
-	var startCalls int32
+	var startCalls atomic.Int32
 	adapter.startRun = func(ctx context.Context, start sigil.GenerationStart, stream bool) *sigil.GenerationRecorder {
-		atomic.AddInt32(&startCalls, 1)
+		startCalls.Add(1)
 		if stream {
 			_, rec := client.StartStreamingGeneration(ctx, start)
 			return rec
@@ -606,7 +606,7 @@ func TestOnRunStartDeduplicatesConcurrentStarts(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(2)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		go func() {
 			defer wg.Done()
 			_ = adapter.OnRunStart(context.Background(), startEvent)
@@ -614,7 +614,7 @@ func TestOnRunStartDeduplicatesConcurrentStarts(t *testing.T) {
 	}
 	wg.Wait()
 
-	if got := atomic.LoadInt32(&startCalls); got != 1 {
+	if got := startCalls.Load(); got != 1 {
 		t.Fatalf("expected one generation start call, got %d", got)
 	}
 
@@ -632,9 +632,9 @@ func TestOnToolStartDeduplicatesConcurrentStarts(t *testing.T) {
 	})
 
 	adapter := NewSigilAdapter(client, Options{})
-	var startCalls int32
+	var startCalls atomic.Int32
 	adapter.startTool = func(ctx context.Context, start sigil.ToolExecutionStart) *sigil.ToolExecutionRecorder {
-		atomic.AddInt32(&startCalls, 1)
+		startCalls.Add(1)
 		_, rec := client.StartToolExecution(ctx, start)
 		return rec
 	}
@@ -649,7 +649,7 @@ func TestOnToolStartDeduplicatesConcurrentStarts(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(2)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		go func() {
 			defer wg.Done()
 			_ = adapter.OnToolStart(context.Background(), startEvent)
@@ -657,7 +657,7 @@ func TestOnToolStartDeduplicatesConcurrentStarts(t *testing.T) {
 	}
 	wg.Wait()
 
-	if got := atomic.LoadInt32(&startCalls); got != 1 {
+	if got := startCalls.Load(); got != 1 {
 		t.Fatalf("expected one tool start call, got %d", got)
 	}
 

--- a/go-providers/anthropic/conformance_test.go
+++ b/go-providers/anthropic/conformance_test.go
@@ -45,7 +45,7 @@ func TestConformance_AnthropicSyncMapping(t *testing.T) {
 		ConversationTitle: "Anthropic sync",
 		AgentName:         "agent-anthropic",
 		AgentVersion:      "v-anthropic",
-		Model:             sigil.ModelRef{Provider: "anthropic", Name: string(req.Model)},
+		Model:             sigil.ModelRef{Provider: "anthropic", Name: req.Model},
 	}
 
 	generation, err := FromRequestResponse(
@@ -156,7 +156,7 @@ func TestConformance_AnthropicStreamMapping(t *testing.T) {
 		ConversationID: "conv-anthropic-stream",
 		AgentName:      "agent-anthropic-stream",
 		AgentVersion:   "v-anthropic-stream",
-		Model:          sigil.ModelRef{Provider: "anthropic", Name: string(req.Model)},
+		Model:          sigil.ModelRef{Provider: "anthropic", Name: req.Model},
 	}
 
 	generation, err := FromStream(

--- a/go-providers/anthropic/mapper.go
+++ b/go-providers/anthropic/mapper.go
@@ -3,6 +3,7 @@ package anthropic
 import (
 	"encoding/json"
 	"errors"
+	"maps"
 	"strconv"
 	"strings"
 
@@ -53,8 +54,8 @@ func FromRequestResponse(req asdk.BetaMessageNewParams, resp *asdk.BetaMessage, 
 		artifacts = append(artifacts, artifact)
 	}
 
-	requestModel := string(req.Model)
-	responseModel := string(resp.Model)
+	requestModel := req.Model
+	responseModel := resp.Model
 	if responseModel == "" {
 		responseModel = requestModel
 	}
@@ -669,9 +670,7 @@ func cloneStringMap(in map[string]string) map[string]string {
 	}
 
 	out := make(map[string]string, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
+	maps.Copy(out, in)
 
 	return out
 }
@@ -682,9 +681,7 @@ func cloneAnyMap(in map[string]any) map[string]any {
 	}
 
 	out := make(map[string]any, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
+	maps.Copy(out, in)
 
 	return out
 }

--- a/go-providers/anthropic/options.go
+++ b/go-providers/anthropic/options.go
@@ -1,5 +1,7 @@
 package anthropic
 
+import "maps"
+
 // Option configures Anthropic mapper behavior.
 type Option func(*mapperOptions)
 
@@ -76,9 +78,7 @@ func WithTags(tags map[string]string) Option {
 		if options.tags == nil {
 			options.tags = make(map[string]string, len(tags))
 		}
-		for key, value := range tags {
-			options.tags[key] = value
-		}
+		maps.Copy(options.tags, tags)
 	}
 }
 
@@ -101,9 +101,7 @@ func WithMetadata(metadata map[string]any) Option {
 		if options.metadata == nil {
 			options.metadata = make(map[string]any, len(metadata))
 		}
-		for key, value := range metadata {
-			options.metadata[key] = value
-		}
+		maps.Copy(options.metadata, metadata)
 	}
 }
 

--- a/go-providers/anthropic/record.go
+++ b/go-providers/anthropic/record.go
@@ -38,7 +38,7 @@ func message(
 		ConversationTitle: options.conversationTitle,
 		AgentName:         options.agentName,
 		AgentVersion:      options.agentVersion,
-		Model:             sigil.ModelRef{Provider: options.providerName, Name: string(req.Model)},
+		Model:             sigil.ModelRef{Provider: options.providerName, Name: req.Model},
 	})
 	defer rec.End()
 
@@ -70,7 +70,7 @@ func MessageStream(
 		ConversationTitle: options.conversationTitle,
 		AgentName:         options.agentName,
 		AgentVersion:      options.agentVersion,
-		Model:             sigil.ModelRef{Provider: options.providerName, Name: string(req.Model)},
+		Model:             sigil.ModelRef{Provider: options.providerName, Name: req.Model},
 	})
 	defer rec.End()
 

--- a/go-providers/anthropic/sdk_example_test.go
+++ b/go-providers/anthropic/sdk_example_test.go
@@ -55,7 +55,7 @@ func Example_withSigilDefer() {
 		ConversationID: "conv-anthropic-2",
 		AgentName:      "assistant-anthropic",
 		AgentVersion:   "1.0.0",
-		Model:          sigil.ModelRef{Provider: "anthropic", Name: string(req.Model)},
+		Model:          sigil.ModelRef{Provider: "anthropic", Name: req.Model},
 	})
 	defer rec.End()
 
@@ -117,7 +117,7 @@ func Example_withSigilStreamingDefer() {
 		ConversationID: "conv-anthropic-4",
 		AgentName:      "assistant-anthropic",
 		AgentVersion:   "1.0.0",
-		Model:          sigil.ModelRef{Provider: "anthropic", Name: string(req.Model)},
+		Model:          sigil.ModelRef{Provider: "anthropic", Name: req.Model},
 	})
 	defer rec.End()
 

--- a/go-providers/anthropic/stream_mapper.go
+++ b/go-providers/anthropic/stream_mapper.go
@@ -36,7 +36,7 @@ func FromStream(req asdk.BetaMessageNewParams, summary StreamSummary, opts ...Op
 
 	usage := sigil.TokenUsage{}
 	stopReason := ""
-	modelName := string(req.Model)
+	modelName := req.Model
 	responseID := ""
 	serverToolUsage := asdk.BetaServerToolUsage{}
 
@@ -49,7 +49,7 @@ func FromStream(req asdk.BetaMessageNewParams, summary StreamSummary, opts ...Op
 				responseID = event.Message.ID
 			}
 			if event.Message.Model != "" {
-				modelName = string(event.Message.Model)
+				modelName = event.Message.Model
 			}
 		case "content_block_start":
 			blocks.startBlock(int(event.Index), event.ContentBlock)
@@ -111,7 +111,7 @@ func FromStream(req asdk.BetaMessageNewParams, summary StreamSummary, opts ...Op
 		ConversationTitle: options.conversationTitle,
 		AgentName:         options.agentName,
 		AgentVersion:      options.agentVersion,
-		Model:             sigil.ModelRef{Provider: options.providerName, Name: string(req.Model)},
+		Model:             sigil.ModelRef{Provider: options.providerName, Name: req.Model},
 		ResponseID:        responseID,
 		ResponseModel:     modelName,
 		SystemPrompt:      mapSystemPrompt(req.System),

--- a/go-providers/gemini/mapper.go
+++ b/go-providers/gemini/mapper.go
@@ -3,6 +3,7 @@ package gemini
 import (
 	"encoding/json"
 	"errors"
+	"maps"
 	"strings"
 
 	"google.golang.org/genai"
@@ -434,9 +435,7 @@ func cloneStringMap(in map[string]string) map[string]string {
 	}
 
 	out := make(map[string]string, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
+	maps.Copy(out, in)
 	return out
 }
 
@@ -446,9 +445,7 @@ func cloneAnyMap(in map[string]any) map[string]any {
 	}
 
 	out := make(map[string]any, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
+	maps.Copy(out, in)
 	return out
 }
 

--- a/go-providers/gemini/options.go
+++ b/go-providers/gemini/options.go
@@ -1,5 +1,7 @@
 package gemini
 
+import "maps"
+
 // Option configures Gemini mapper behavior.
 type Option func(*mapperOptions)
 
@@ -76,9 +78,7 @@ func WithTags(tags map[string]string) Option {
 		if options.tags == nil {
 			options.tags = make(map[string]string, len(tags))
 		}
-		for key, value := range tags {
-			options.tags[key] = value
-		}
+		maps.Copy(options.tags, tags)
 	}
 }
 
@@ -101,9 +101,7 @@ func WithMetadata(metadata map[string]any) Option {
 		if options.metadata == nil {
 			options.metadata = make(map[string]any, len(metadata))
 		}
-		for key, value := range metadata {
-			options.metadata[key] = value
-		}
+		maps.Copy(options.metadata, metadata)
 	}
 }
 

--- a/go-providers/openai/conformance_test.go
+++ b/go-providers/openai/conformance_test.go
@@ -32,7 +32,7 @@ func TestConformance_OpenAIResponsesSyncMapping(t *testing.T) {
 		ConversationTitle: "OpenAI responses sync",
 		AgentName:         "agent-openai",
 		AgentVersion:      "v-openai",
-		Model:             sigil.ModelRef{Provider: "openai", Name: string(req.Model)},
+		Model:             sigil.ModelRef{Provider: "openai", Name: req.Model},
 	}
 
 	generation, err := ResponsesFromRequestResponse(
@@ -105,7 +105,7 @@ func TestConformance_OpenAIResponsesStreamMapping(t *testing.T) {
 		ConversationID: "conv-openai-stream",
 		AgentName:      "agent-openai-stream",
 		AgentVersion:   "v-openai-stream",
-		Model:          sigil.ModelRef{Provider: "openai", Name: string(req.Model)},
+		Model:          sigil.ModelRef{Provider: "openai", Name: req.Model},
 	}
 
 	generation, err := ResponsesFromStream(
@@ -200,7 +200,7 @@ func TestConformance_OpenAIEmbeddingMapping(t *testing.T) {
 	}
 	dimensions := int64(3)
 	sigiltest.RecordEmbedding(t, env, sigil.EmbeddingStart{
-		Model:        sigil.ModelRef{Provider: "openai", Name: string(req.Model)},
+		Model:        sigil.ModelRef{Provider: "openai", Name: req.Model},
 		AgentName:    "agent-openai-embed",
 		AgentVersion: "v-openai-embed",
 		Dimensions:   &dimensions,

--- a/go-providers/openai/mapper.go
+++ b/go-providers/openai/mapper.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"encoding/json"
 	"errors"
+	"maps"
 	"strconv"
 	"strings"
 
@@ -47,7 +48,7 @@ func ChatCompletionsFromRequestResponse(req osdk.ChatCompletionNewParams, resp *
 		artifacts = append(artifacts, artifact)
 	}
 
-	requestModel := string(req.Model)
+	requestModel := req.Model
 	responseModel := resp.Model
 	if responseModel == "" {
 		responseModel = requestModel
@@ -585,9 +586,7 @@ func cloneStringMap(in map[string]string) map[string]string {
 	}
 
 	out := make(map[string]string, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
+	maps.Copy(out, in)
 
 	return out
 }
@@ -598,9 +597,7 @@ func cloneAnyMap(in map[string]any) map[string]any {
 	}
 
 	out := make(map[string]any, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
+	maps.Copy(out, in)
 
 	return out
 }

--- a/go-providers/openai/options.go
+++ b/go-providers/openai/options.go
@@ -1,5 +1,7 @@
 package openai
 
+import "maps"
+
 // Option configures OpenAI mapper behavior.
 type Option func(*mapperOptions)
 
@@ -76,9 +78,7 @@ func WithTags(tags map[string]string) Option {
 		if options.tags == nil {
 			options.tags = make(map[string]string, len(tags))
 		}
-		for key, value := range tags {
-			options.tags[key] = value
-		}
+		maps.Copy(options.tags, tags)
 	}
 }
 
@@ -101,9 +101,7 @@ func WithMetadata(metadata map[string]any) Option {
 		if options.metadata == nil {
 			options.metadata = make(map[string]any, len(metadata))
 		}
-		for key, value := range metadata {
-			options.metadata[key] = value
-		}
+		maps.Copy(options.metadata, metadata)
 	}
 }
 

--- a/go-providers/openai/record.go
+++ b/go-providers/openai/record.go
@@ -39,7 +39,7 @@ func chatCompletionsNew(
 		ConversationTitle: options.conversationTitle,
 		AgentName:         options.agentName,
 		AgentVersion:      options.agentVersion,
-		Model:             sigil.ModelRef{Provider: options.providerName, Name: string(req.Model)},
+		Model:             sigil.ModelRef{Provider: options.providerName, Name: req.Model},
 	})
 	defer rec.End()
 
@@ -71,7 +71,7 @@ func ChatCompletionsNewStreaming(
 		ConversationTitle: options.conversationTitle,
 		AgentName:         options.agentName,
 		AgentVersion:      options.agentVersion,
-		Model:             sigil.ModelRef{Provider: options.providerName, Name: string(req.Model)},
+		Model:             sigil.ModelRef{Provider: options.providerName, Name: req.Model},
 	})
 	defer rec.End()
 
@@ -133,7 +133,7 @@ func responsesNew(
 		ConversationTitle: options.conversationTitle,
 		AgentName:         options.agentName,
 		AgentVersion:      options.agentVersion,
-		Model:             sigil.ModelRef{Provider: options.providerName, Name: string(req.Model)},
+		Model:             sigil.ModelRef{Provider: options.providerName, Name: req.Model},
 	})
 	defer rec.End()
 
@@ -173,7 +173,7 @@ func embeddingsNew(
 	start := sigil.EmbeddingStart{
 		AgentName:    options.agentName,
 		AgentVersion: options.agentVersion,
-		Model:        sigil.ModelRef{Provider: options.providerName, Name: string(req.Model)},
+		Model:        sigil.ModelRef{Provider: options.providerName, Name: req.Model},
 	}
 	if req.Dimensions.Valid() {
 		start.Dimensions = &req.Dimensions.Value
@@ -212,7 +212,7 @@ func ResponsesNewStreaming(
 		ConversationTitle: options.conversationTitle,
 		AgentName:         options.agentName,
 		AgentVersion:      options.agentVersion,
-		Model:             sigil.ModelRef{Provider: options.providerName, Name: string(req.Model)},
+		Model:             sigil.ModelRef{Provider: options.providerName, Name: req.Model},
 	})
 	defer rec.End()
 

--- a/go-providers/openai/responses_mapper.go
+++ b/go-providers/openai/responses_mapper.go
@@ -33,8 +33,8 @@ func ResponsesFromRequestResponse(req responses.ResponseNewParams, resp *respons
 	tools := mapResponsesTools(requestPayload["tools"])
 	maxTokens, temperature, topP, toolChoice, thinkingEnabled, thinkingBudget := mapResponsesRequestControls(requestPayload)
 
-	requestModel := string(req.Model)
-	responseModel := string(resp.Model)
+	requestModel := req.Model
+	responseModel := resp.Model
 	if responseModel == "" {
 		responseModel = requestModel
 	}
@@ -114,7 +114,7 @@ func ResponsesFromStream(req responses.ResponseNewParams, summary ResponsesStrea
 	options := applyOptions(opts)
 
 	responseID := ""
-	responseModel := string(req.Model)
+	responseModel := req.Model
 	usage := sigil.TokenUsage{}
 	stopReason := ""
 	text := strings.Builder{}
@@ -127,7 +127,7 @@ func ResponsesFromStream(req responses.ResponseNewParams, summary ResponsesStrea
 
 		if event.Response.ID != "" {
 			responseID = event.Response.ID
-			if model := string(event.Response.Model); model != "" {
+			if model := event.Response.Model; model != "" {
 				responseModel = model
 			}
 			usage = mapResponsesUsage(event.Response.Usage)
@@ -236,7 +236,7 @@ func ResponsesFromStream(req responses.ResponseNewParams, summary ResponsesStrea
 		ConversationTitle: options.conversationTitle,
 		AgentName:         options.agentName,
 		AgentVersion:      options.agentVersion,
-		Model:             sigil.ModelRef{Provider: options.providerName, Name: string(req.Model)},
+		Model:             sigil.ModelRef{Provider: options.providerName, Name: req.Model},
 		ResponseID:        responseID,
 		ResponseModel:     responseModel,
 		SystemPrompt:      systemPrompt,

--- a/go-providers/openai/sdk_example_test.go
+++ b/go-providers/openai/sdk_example_test.go
@@ -56,7 +56,7 @@ func Example_withSigilDefer() {
 		ConversationID: "conv-openai-2",
 		AgentName:      "assistant-openai",
 		AgentVersion:   "1.0.0",
-		Model:          sigil.ModelRef{Provider: "openai", Name: string(req.Model)},
+		Model:          sigil.ModelRef{Provider: "openai", Name: req.Model},
 	})
 	defer rec.End()
 
@@ -118,7 +118,7 @@ func Example_withSigilStreamingDefer() {
 		ConversationID: "conv-openai-4",
 		AgentName:      "assistant-openai",
 		AgentVersion:   "1.0.0",
-		Model:          sigil.ModelRef{Provider: "openai", Name: string(req.Model)},
+		Model:          sigil.ModelRef{Provider: "openai", Name: req.Model},
 	})
 	defer rec.End()
 

--- a/go-providers/openai/stream_mapper.go
+++ b/go-providers/openai/stream_mapper.go
@@ -42,7 +42,7 @@ func ChatCompletionsFromStream(req osdk.ChatCompletionNewParams, summary ChatCom
 	output := make([]sigil.Message, 0, 1)
 	maxTokens, temperature, topP, toolChoice, thinkingEnabled, thinkingBudget := mapRequestControls(req)
 
-	modelName := string(req.Model)
+	modelName := req.Model
 	responseID := ""
 	usage := sigil.TokenUsage{}
 	stopReason := ""
@@ -145,7 +145,7 @@ func ChatCompletionsFromStream(req osdk.ChatCompletionNewParams, summary ChatCom
 		ConversationTitle: options.conversationTitle,
 		AgentName:         options.agentName,
 		AgentVersion:      options.agentVersion,
-		Model:             sigil.ModelRef{Provider: options.providerName, Name: string(req.Model)},
+		Model:             sigil.ModelRef{Provider: options.providerName, Name: req.Model},
 		ResponseID:        responseID,
 		ResponseModel:     modelName,
 		SystemPrompt:      systemPrompt,

--- a/go/sigil/cache_diagnostics_test.go
+++ b/go/sigil/cache_diagnostics_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestSetCacheDiagnostics_NilRecorder(t *testing.T) {
+func TestSetCacheDiagnostics_NilRecorder(_ *testing.T) {
 	SetCacheDiagnostics(nil, "system_changed")
 }
 

--- a/go/sigil/client.go
+++ b/go/sigil/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"maps"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -543,9 +544,7 @@ func (c *Client) startGeneration(ctx context.Context, start GenerationStart, def
 	}
 	if len(c.config.Tags) > 0 {
 		merged := cloneTags(c.config.Tags)
-		for k, v := range seed.Tags {
-			merged[k] = v
-		}
+		maps.Copy(merged, seed.Tags)
 		seed.Tags = merged
 	}
 
@@ -559,7 +558,7 @@ func (c *Client) startGeneration(ctx context.Context, start GenerationStart, def
 
 	// Resolve content capture mode before the span starts so MetadataOnly never
 	// attaches sensitive content to live span attributes.
-	resolverMode := callContentCaptureResolver(c.config.ContentCaptureResolver, ctx, seed.Metadata)
+	resolverMode := callContentCaptureResolver(ctx, c.config.ContentCaptureResolver, seed.Metadata)
 	clientMode := resolveClientContentCaptureMode(resolveContentCaptureMode(resolverMode, c.config.ContentCapture))
 	ccMode := resolveContentCaptureMode(seed.ContentCapture, clientMode)
 
@@ -635,7 +634,7 @@ func (c *Client) StartEmbedding(ctx context.Context, start EmbeddingStart) (cont
 	}
 	seed.StartedAt = startedAt
 
-	resolverMode := callContentCaptureResolver(c.config.ContentCaptureResolver, ctx, seed.Metadata)
+	resolverMode := callContentCaptureResolver(ctx, c.config.ContentCaptureResolver, seed.Metadata)
 	effectiveMode := resolveClientContentCaptureMode(resolveContentCaptureMode(resolverMode, c.config.ContentCapture))
 
 	tracer := c.tracer
@@ -714,7 +713,7 @@ func (c *Client) StartToolExecution(ctx context.Context, start ToolExecutionStar
 
 	// Resolve content capture before the span starts so MetadataOnly never
 	// attaches sensitive content to live span attributes.
-	resolverMode := callContentCaptureResolver(c.config.ContentCaptureResolver, ctx, nil)
+	resolverMode := callContentCaptureResolver(ctx, c.config.ContentCaptureResolver, nil)
 	effectiveClientDefault := resolveContentCaptureMode(resolverMode, c.config.ContentCapture)
 	ctxMode, ctxSet := contentCaptureModeFromContext(ctx)
 	toolMode := resolveToolContentCaptureMode(seed.ContentCapture, ctxMode, ctxSet, effectiveClientDefault)
@@ -1656,7 +1655,7 @@ func coerceInt64(value any) (int64, bool) {
 	case uint32:
 		return int64(typed), true
 	case uint64:
-		if typed > uint64(^uint64(0)>>1) {
+		if typed > ^uint64(0)>>1 {
 			return 0, false
 		}
 		return int64(typed), true
@@ -2147,9 +2146,7 @@ func mergeTags(base, override map[string]string) map[string]string {
 	if out == nil {
 		out = map[string]string{}
 	}
-	for key, value := range override {
-		out[key] = value
-	}
+	maps.Copy(out, override)
 	return out
 }
 
@@ -2162,9 +2159,7 @@ func mergeMetadata(base, override map[string]any) map[string]any {
 	if out == nil {
 		out = map[string]any{}
 	}
-	for key, value := range override {
-		out[key] = value
-	}
+	maps.Copy(out, override)
 	return out
 }
 

--- a/go/sigil/client_test.go
+++ b/go/sigil/client_test.go
@@ -3,6 +3,7 @@ package sigil
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -1130,9 +1131,9 @@ func TestToolExecutionRecorderContentCapture(t *testing.T) {
 			t.Fatalf("tool execution error: %v", err)
 		}
 		spans := recorder.Ended()
-		for i := len(spans) - 1; i >= 0; i-- {
-			if isToolSpan(spans[i]) {
-				return spans[i]
+		for _, v := range slices.Backward(spans) {
+			if isToolSpan(v) {
+				return v
 			}
 		}
 		t.Fatal("tool span not found")

--- a/go/sigil/conformance_test.go
+++ b/go/sigil/conformance_test.go
@@ -517,7 +517,7 @@ func TestConformance_ConversationTitleSemantics(t *testing.T) {
 				}
 			}
 
-			recordGeneration(t, env, ctx, start, sigil.Generation{})
+			recordGeneration(t, ctx, env, start, sigil.Generation{})
 
 			span := findSpan(t, env.Spans.Ended(), conformanceOperationName)
 			attrs := spanAttrs(span)
@@ -608,7 +608,7 @@ func TestConformance_UserIDSemantics(t *testing.T) {
 				}
 			}
 
-			recordGeneration(t, env, ctx, start, sigil.Generation{})
+			recordGeneration(t, ctx, env, start, sigil.Generation{})
 
 			span := findSpan(t, env.Spans.Ended(), conformanceOperationName)
 			attrs := spanAttrs(span)
@@ -685,7 +685,7 @@ func TestConformance_AgentIdentitySemantics(t *testing.T) {
 				AgentVersion: tc.resultVersion,
 			}
 
-			recordGeneration(t, env, ctx, start, result)
+			recordGeneration(t, ctx, env, start, result)
 
 			span := findSpan(t, env.Spans.Ended(), conformanceOperationName)
 			attrs := spanAttrs(span)
@@ -759,7 +759,7 @@ func TestConformance_EffectiveVersionSemantics(t *testing.T) {
 				Model:            conformanceModel,
 				EffectiveVersion: tc.effectiveVersion,
 			}
-			recordGeneration(t, env, context.Background(), start, sigil.Generation{})
+			recordGeneration(t, context.Background(), env, start, sigil.Generation{})
 
 			env.Shutdown(t)
 			generation := env.Ingest.SingleGeneration(t)
@@ -815,7 +815,7 @@ func TestConformance_EffectiveVersionResultOverridesStart(t *testing.T) {
 				EffectiveVersion: tc.startValue,
 			}
 			result := sigil.Generation{EffectiveVersion: tc.resultValue}
-			recordGeneration(t, env, context.Background(), start, result)
+			recordGeneration(t, context.Background(), env, start, result)
 
 			env.Shutdown(t)
 			generation := env.Ingest.SingleGeneration(t)
@@ -830,7 +830,7 @@ func TestConformance_EffectiveVersionResultOverridesStart(t *testing.T) {
 func TestConformance_StreamingMode(t *testing.T) {
 	env := newConformanceEnv(t)
 
-	recordGeneration(t, env, context.Background(), sigil.GenerationStart{
+	recordGeneration(t, context.Background(), env, sigil.GenerationStart{
 		ConversationID: "conv-sync",
 		Model:          conformanceModel,
 		StartedAt:      time.Date(2026, 3, 12, 14, 0, 0, 0, time.UTC),
@@ -1581,7 +1581,7 @@ func TestConformance_ShutdownFlushesPendingGeneration(t *testing.T) {
 		cfg.GenerationExport.BatchSize = 10
 	}))
 
-	recordGeneration(t, env, context.Background(), sigil.GenerationStart{
+	recordGeneration(t, context.Background(), env, sigil.GenerationStart{
 		ConversationID: "conv-shutdown",
 		Model:          conformanceModel,
 		StartedAt:      time.Date(2026, 3, 12, 14, 6, 0, 0, time.UTC),
@@ -1606,7 +1606,7 @@ func TestConformance_ShutdownFlushesPendingGeneration(t *testing.T) {
 	}
 }
 
-func recordGeneration(t *testing.T, env *conformanceEnv, ctx context.Context, start sigil.GenerationStart, result sigil.Generation) {
+func recordGeneration(t *testing.T, ctx context.Context, env *conformanceEnv, start sigil.GenerationStart, result sigil.Generation) {
 	t.Helper()
 
 	_, recorder := env.Client.StartGeneration(ctx, start)

--- a/go/sigil/content_capture.go
+++ b/go/sigil/content_capture.go
@@ -76,7 +76,7 @@ func resolveContentCaptureMode(override, fallback ContentCaptureMode) ContentCap
 // callContentCaptureResolver invokes the resolver callback safely, recovering
 // from panics. Returns ContentCaptureModeDefault when the resolver is nil.
 // Panics are treated as ContentCaptureModeMetadataOnly (fail-closed).
-func callContentCaptureResolver(resolver func(ctx context.Context, metadata map[string]any) ContentCaptureMode, ctx context.Context, metadata map[string]any) (mode ContentCaptureMode) {
+func callContentCaptureResolver(ctx context.Context, resolver func(ctx context.Context, metadata map[string]any) ContentCaptureMode, metadata map[string]any) (mode ContentCaptureMode) {
 	if resolver == nil {
 		return ContentCaptureModeDefault
 	}

--- a/go/sigil/content_capture_test.go
+++ b/go/sigil/content_capture_test.go
@@ -562,7 +562,7 @@ func TestCallContentCaptureResolver(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := callContentCaptureResolver(tc.resolver, context.Background(), tc.metadata)
+			got := callContentCaptureResolver(context.Background(), tc.resolver, tc.metadata)
 			if got != tc.want {
 				t.Fatalf("got %v, want %v", got, tc.want)
 			}

--- a/go/sigil/env.go
+++ b/go/sigil/env.go
@@ -143,7 +143,7 @@ func parseBool(raw string) bool {
 
 func parseCSVKV(raw string) map[string]string {
 	out := map[string]string{}
-	for _, part := range strings.Split(raw, ",") {
+	for part := range strings.SplitSeq(raw, ",") {
 		part = strings.TrimSpace(part)
 		if part == "" {
 			continue

--- a/go/sigil/exporter.go
+++ b/go/sigil/exporter.go
@@ -559,7 +559,7 @@ func (c *Client) exportWithRetry(request *sigilv1.ExportGenerationsRequest) erro
 	}
 
 	var lastErr error
-	for attempt := 0; attempt < attempts; attempt++ {
+	for attempt := range attempts {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		response, err := c.exporter.Export(timeoutCtx, request)
 		cancel()

--- a/go/sigil/exporter_test.go
+++ b/go/sigil/exporter_test.go
@@ -71,7 +71,7 @@ func TestGenerationExporterFlushesByBatchSize(t *testing.T) {
 		_ = client.Shutdown(context.Background())
 	})
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		_, rec := client.StartGeneration(context.Background(), GenerationStart{Model: ModelRef{Provider: "openai", Name: "gpt-5"}})
 		rec.SetResult(Generation{
 			Input:  []Message{UserTextMessage("hello")},
@@ -278,7 +278,7 @@ func TestFlushDrainsQueuedGenerations(t *testing.T) {
 	})
 
 	const n = 50
-	for i := 0; i < n; i++ {
+	for i := range n {
 		_, rec := client.StartGeneration(context.Background(), GenerationStart{Model: ModelRef{Provider: "openai", Name: "gpt-5"}})
 		rec.SetResult(Generation{
 			Input:  []Message{UserTextMessage("hello")},

--- a/go/sigil/generation.go
+++ b/go/sigil/generation.go
@@ -2,6 +2,7 @@ package sigil
 
 import (
 	"encoding/json"
+	"maps"
 	"time"
 )
 
@@ -50,29 +51,32 @@ type Generation struct {
 	OperationName string `json:"operation_name,omitempty"`
 	// TraceID and SpanID identify the OTel span created by StartGeneration or
 	// StartStreamingGeneration.
-	TraceID             string            `json:"trace_id,omitempty"`
-	SpanID              string            `json:"span_id,omitempty"`
-	Model               ModelRef          `json:"model"`
-	ResponseID          string            `json:"response_id,omitempty"`
-	ResponseModel       string            `json:"response_model,omitempty"`
-	SystemPrompt        string            `json:"system_prompt,omitempty"`
-	Input               []Message         `json:"input,omitempty"`
-	Output              []Message         `json:"output,omitempty"`
-	Tools               []ToolDefinition  `json:"tools,omitempty"`
-	MaxTokens           *int64            `json:"max_tokens,omitempty"`
-	Temperature         *float64          `json:"temperature,omitempty"`
-	TopP                *float64          `json:"top_p,omitempty"`
-	ToolChoice          *string           `json:"tool_choice,omitempty"`
-	ThinkingEnabled     *bool             `json:"thinking_enabled,omitempty"`
-	ParentGenerationIDs []string          `json:"parent_generation_ids,omitempty"`
-	EffectiveVersion    string            `json:"effective_version,omitempty"`
-	Usage               TokenUsage        `json:"usage,omitempty"`
-	StopReason          string            `json:"stop_reason,omitempty"`
-	StartedAt           time.Time         `json:"started_at,omitempty"`
-	CompletedAt         time.Time         `json:"completed_at,omitempty"`
-	Tags                map[string]string `json:"tags,omitempty"`
-	Metadata            map[string]any    `json:"metadata,omitempty"`
-	Artifacts           []Artifact        `json:"artifacts,omitempty"`
+	TraceID             string           `json:"trace_id,omitempty"`
+	SpanID              string           `json:"span_id,omitempty"`
+	Model               ModelRef         `json:"model"`
+	ResponseID          string           `json:"response_id,omitempty"`
+	ResponseModel       string           `json:"response_model,omitempty"`
+	SystemPrompt        string           `json:"system_prompt,omitempty"`
+	Input               []Message        `json:"input,omitempty"`
+	Output              []Message        `json:"output,omitempty"`
+	Tools               []ToolDefinition `json:"tools,omitempty"`
+	MaxTokens           *int64           `json:"max_tokens,omitempty"`
+	Temperature         *float64         `json:"temperature,omitempty"`
+	TopP                *float64         `json:"top_p,omitempty"`
+	ToolChoice          *string          `json:"tool_choice,omitempty"`
+	ThinkingEnabled     *bool            `json:"thinking_enabled,omitempty"`
+	ParentGenerationIDs []string         `json:"parent_generation_ids,omitempty"`
+	EffectiveVersion    string           `json:"effective_version,omitempty"`
+	// Usage/StartedAt/CompletedAt are value-type structs where `omitempty` has
+	// no effect (gostructs are never "empty" in encoding/json's sense). The tag
+	// is intentionally omitted so the JSON shape matches the actual behavior.
+	Usage       TokenUsage        `json:"usage"`
+	StopReason  string            `json:"stop_reason,omitempty"`
+	StartedAt   time.Time         `json:"started_at"`
+	CompletedAt time.Time         `json:"completed_at"`
+	Tags        map[string]string `json:"tags,omitempty"`
+	Metadata    map[string]any    `json:"metadata,omitempty"`
+	Artifacts   []Artifact        `json:"artifacts,omitempty"`
 	// CallError captures upstream call failure text when End receives callErr.
 	CallError string `json:"call_error,omitempty"`
 }
@@ -296,9 +300,7 @@ func cloneTags(in map[string]string) map[string]string {
 	}
 
 	out := make(map[string]string, len(in))
-	for k, v := range in {
-		out[k] = v
-	}
+	maps.Copy(out, in)
 
 	return out
 }
@@ -309,9 +311,7 @@ func cloneMetadata(in map[string]any) map[string]any {
 	}
 
 	out := make(map[string]any, len(in))
-	for k, v := range in {
-		out[k] = v
-	}
+	maps.Copy(out, in)
 
 	return out
 }

--- a/go/sigil/hooks.go
+++ b/go/sigil/hooks.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -282,10 +283,5 @@ func phaseEnabled(phases []HookPhase, phase HookPhase) bool {
 	if len(phases) == 0 {
 		return true
 	}
-	for _, candidate := range phases {
-		if candidate == phase {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(phases, phase)
 }

--- a/go/sigil/message.go
+++ b/go/sigil/message.go
@@ -28,12 +28,14 @@ type Message struct {
 }
 
 type Part struct {
-	Kind       PartKind     `json:"kind"`
-	Text       string       `json:"text,omitempty"`
-	Thinking   string       `json:"thinking,omitempty"`
-	ToolCall   *ToolCall    `json:"tool_call,omitempty"`
-	ToolResult *ToolResult  `json:"tool_result,omitempty"`
-	Metadata   PartMetadata `json:"metadata,omitempty"`
+	Kind       PartKind    `json:"kind"`
+	Text       string      `json:"text,omitempty"`
+	Thinking   string      `json:"thinking,omitempty"`
+	ToolCall   *ToolCall   `json:"tool_call,omitempty"`
+	ToolResult *ToolResult `json:"tool_result,omitempty"`
+	// Metadata is a value-type struct where `omitempty` has no effect; the
+	// field is always emitted in JSON form.
+	Metadata PartMetadata `json:"metadata"`
 }
 
 // PartMetadata carries provider-specific details while keeping the core shape typed.

--- a/go/sigil/rating.go
+++ b/go/sigil/rating.go
@@ -57,7 +57,7 @@ type ConversationRatingSummary struct {
 	BadCount      int       `json:"bad_count"`
 	LatestRating  string    `json:"latest_rating,omitempty"`
 	LatestRatedAt time.Time `json:"latest_rated_at"`
-	LatestBadAt   time.Time `json:"latest_bad_at,omitempty"`
+	LatestBadAt   time.Time `json:"latest_bad_at"`
 	HasBadRating  bool      `json:"has_bad_rating"`
 }
 
@@ -80,7 +80,7 @@ func (c *Client) SubmitConversationRating(ctx context.Context, conversationID st
 	}
 
 	// Check content capture resolver — strip comment when MetadataOnly.
-	resolverMode := callContentCaptureResolver(c.config.ContentCaptureResolver, ctx, input.Metadata)
+	resolverMode := callContentCaptureResolver(ctx, c.config.ContentCaptureResolver, input.Metadata)
 	effectiveMode := resolveContentCaptureMode(resolverMode, resolveClientContentCaptureMode(c.config.ContentCapture))
 	if effectiveMode == ContentCaptureModeMetadataOnly {
 		input.Comment = ""

--- a/plugins/sigil/internal/agents/claudecode/mapper/live_transcripts_test.go
+++ b/plugins/sigil/internal/agents/claudecode/mapper/live_transcripts_test.go
@@ -37,7 +37,7 @@ func TestLiveTranscripts(t *testing.T) {
 		totalErrors              int
 	)
 
-	for _, path := range strings.Split(raw, ",") {
+	for path := range strings.SplitSeq(raw, ",") {
 		path = strings.TrimSpace(path)
 		if path == "" {
 			continue

--- a/plugins/sigil/internal/agents/claudecode/mapper/mapper.go
+++ b/plugins/sigil/internal/agents/claudecode/mapper/mapper.go
@@ -381,9 +381,7 @@ func buildTags(line transcript.Line, subagent bool, extras map[string]string) ma
 	tags := make(map[string]string, 4+len(extras))
 	// Extras go in first; built-ins written below overwrite any collisions
 	// so user-supplied keys can never shadow git.branch/cwd/entrypoint/subagent.
-	for k, v := range extras {
-		tags[k] = v
-	}
+	maps.Copy(tags, extras)
 	if line.GitBranch != "" {
 		tags["git.branch"] = line.GitBranch
 	}

--- a/plugins/sigil/internal/agents/codex/launch.go
+++ b/plugins/sigil/internal/agents/codex/launch.go
@@ -134,7 +134,7 @@ func pluginInstalled(ctx context.Context, bin string) (bool, error) {
 		return false, err
 	}
 	needle := []byte(PluginName + "@" + marketplaceAlias)
-	for _, line := range bytes.Split(out, []byte{'\n'}) {
+	for line := range bytes.SplitSeq(out, []byte{'\n'}) {
 		// Anchor on the first whitespace-delimited token so suffix collisions
 		// like `my-sigil-codex@grafana-sigil` or
 		// `sigil-codex@grafana-sigil-staging` don't satisfy the check.

--- a/plugins/sigil/internal/agents/codex/mapper/mapper.go
+++ b/plugins/sigil/internal/agents/codex/mapper/mapper.go
@@ -3,6 +3,7 @@ package mapper
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"maps"
 	"sort"
 	"strconv"
 	"strings"
@@ -196,9 +197,7 @@ func cloneStringMap(in map[string]string) map[string]string {
 		return nil
 	}
 	out := make(map[string]string, len(in))
-	for k, v := range in {
-		out[k] = v
-	}
+	maps.Copy(out, in)
 	return out
 }
 
@@ -207,9 +206,7 @@ func cloneAnyMap(in map[string]any) map[string]any {
 		return nil
 	}
 	out := make(map[string]any, len(in))
-	for k, v := range in {
-		out[k] = v
-	}
+	maps.Copy(out, in)
 	return out
 }
 

--- a/plugins/sigil/internal/agents/copilot/fragment/fragment.go
+++ b/plugins/sigil/internal/agents/copilot/fragment/fragment.go
@@ -91,7 +91,7 @@ type Fragment struct {
 	Tools           []ToolRecord     `json:"tools,omitempty"`
 	Errors          []ErrorRecord    `json:"errors,omitempty"`
 	Subagents       []SubagentRecord `json:"subagents,omitempty"`
-	TokenUsage      TokenUsage       `json:"tokenUsage,omitempty"`
+	TokenUsage      TokenUsage       `json:"tokenUsage"`
 	StartedAt       string           `json:"startedAt,omitempty"`
 	CompletedAt     string           `json:"completedAt,omitempty"`
 	LastEventAt     string           `json:"lastEventAt,omitempty"`

--- a/plugins/sigil/internal/agents/copilot/hook/handlers.go
+++ b/plugins/sigil/internal/agents/copilot/hook/handlers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -688,8 +689,8 @@ func toolErrorOr(msg string) error {
 var errToolError = errors.New("tool returned error")
 
 func findPendingToolIndex(tools []fragment.ToolRecord, toolName string) int {
-	for i := len(tools) - 1; i >= 0; i-- {
-		if tools[i].ToolName == toolName && tools[i].CompletedAt == "" {
+	for i, v := range slices.Backward(tools) {
+		if v.ToolName == toolName && v.CompletedAt == "" {
 			return i
 		}
 	}
@@ -697,11 +698,11 @@ func findPendingToolIndex(tools []fragment.ToolRecord, toolName string) int {
 }
 
 func findPendingSubagentIndex(items []fragment.SubagentRecord, agentName, displayName string) int {
-	for i := len(items) - 1; i >= 0; i-- {
-		if items[i].CompletedAt != "" {
+	for i, v := range slices.Backward(items) {
+		if v.CompletedAt != "" {
 			continue
 		}
-		if items[i].AgentName == agentName || items[i].AgentDisplayName == displayName {
+		if v.AgentName == agentName || v.AgentDisplayName == displayName {
 			return i
 		}
 	}

--- a/plugins/sigil/internal/agents/copilot/launch.go
+++ b/plugins/sigil/internal/agents/copilot/launch.go
@@ -114,7 +114,7 @@ func pluginInstalled(ctx context.Context, bin string) (bool, error) {
 	// and the bullet glyph, then exact-match the first remaining token. This
 	// rejects the `Installed plugins:` header, a bare bullet line, and
 	// suffix collisions like `my-sigil-copilot`.
-	for _, line := range bytes.Split(out, []byte{'\n'}) {
+	for line := range bytes.SplitSeq(out, []byte{'\n'}) {
 		trimmed := bytes.TrimLeft(bytes.TrimSpace(line), "•*-+ \t")
 		fields := bytes.Fields(trimmed)
 		if len(fields) > 0 && bytes.Equal(fields[0], needle) {

--- a/plugins/sigil/internal/agents/copilot/mapper/mapper.go
+++ b/plugins/sigil/internal/agents/copilot/mapper/mapper.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"maps"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -227,8 +229,8 @@ func buildSubagentMetadata(subagents []fragment.SubagentRecord) []map[string]any
 }
 
 func mapCallError(records []fragment.ErrorRecord) (*fragment.ErrorRecord, error) {
-	for i := len(records) - 1; i >= 0; i-- {
-		item := records[i]
+	for _, v := range slices.Backward(records) {
+		item := v
 		if item.Recoverable || item.Context == "tool_execution" {
 			continue
 		}
@@ -328,9 +330,7 @@ func cloneStringMap(in map[string]string) map[string]string {
 		return nil
 	}
 	out := make(map[string]string, len(in))
-	for k, v := range in {
-		out[k] = v
-	}
+	maps.Copy(out, in)
 	return out
 }
 
@@ -339,9 +339,7 @@ func cloneAnyMap(in map[string]any) map[string]any {
 		return nil
 	}
 	out := make(map[string]any, len(in))
-	for k, v := range in {
-		out[k] = v
-	}
+	maps.Copy(out, in)
 	return out
 }
 

--- a/plugins/sigil/internal/agents/cursor/mapper/mapper.go
+++ b/plugins/sigil/internal/agents/cursor/mapper/mapper.go
@@ -279,11 +279,18 @@ func buildToolDefinitions(tools []fragment.ToolRecord) []sigil.ToolDefinition {
 
 func buildMessages(frag *fragment.Fragment, mode sigil.ContentCaptureMode) (input, output []sigil.Message) {
 	// Normalize so the rest of this function only deals with the three real
-	// modes. envconfig.ResolveContentMode also maps Default → MetadataOnly,
-	// but doing it again here keeps the three content-gating checks below
-	// internally consistent regardless of caller.
-	if mode == sigil.ContentCaptureModeDefault {
+	// content-gating modes. envconfig.ResolveContentMode also maps Default →
+	// MetadataOnly, but doing it again here keeps the gating below internally
+	// consistent regardless of caller. FullWithMetadataSpans differs from
+	// Full only in what the OTel span exposes; the gRPC payload that
+	// buildMessages produces carries the same full content in both modes.
+	switch mode {
+	case sigil.ContentCaptureModeDefault:
 		mode = sigil.ContentCaptureModeMetadataOnly
+	case sigil.ContentCaptureModeFullWithMetadataSpans:
+		mode = sigil.ContentCaptureModeFull
+	default:
+		// Full, NoToolContent, MetadataOnly pass through unchanged.
 	}
 
 	// User prompt → user input message. Dropped in metadata-only mode.
@@ -358,6 +365,8 @@ func buildMessages(frag *fragment.Fragment, mode sigil.ContentCaptureMode) (inpu
 			})
 		case sigil.ContentCaptureModeMetadataOnly:
 			// Drop the tool_result entirely.
+		default:
+			// Default and FullWithMetadataSpans are normalized away above.
 		}
 	}
 

--- a/plugins/sigil/internal/agents/cursor/mapper/mapper_test.go
+++ b/plugins/sigil/internal/agents/cursor/mapper/mapper_test.go
@@ -29,7 +29,9 @@ func basicFragment(t *testing.T) *fragment.Fragment {
 	}
 }
 
-func TestMapFragment_FullMode_IncludesContent(t *testing.T) {
+// TestMapFragment_BasicFields covers the non-content-capture-dependent
+// fields that MapFragment populates from a fragment.
+func TestMapFragment_BasicFields(t *testing.T) {
 	got := MapFragment(Inputs{
 		Fragment:       basicFragment(t),
 		ContentCapture: sigil.ContentCaptureModeFull,
@@ -42,147 +44,93 @@ func TestMapFragment_FullMode_IncludesContent(t *testing.T) {
 	if got.Generation.Model.Provider != "anthropic" || got.Generation.Model.Name != "claude-sonnet-4-6" {
 		t.Errorf("Model = %+v; want anthropic/claude-sonnet-4-6", got.Generation.Model)
 	}
-
-	// User prompt should appear in input.
-	foundUserPrompt := false
-	for _, msg := range got.Generation.Input {
-		if msg.Role == sigil.RoleUser {
-			for _, p := range msg.Parts {
-				if p.Text == "hello" {
-					foundUserPrompt = true
-				}
-			}
-		}
-	}
-	if !foundUserPrompt {
-		t.Errorf("user prompt 'hello' missing from input; got %+v", got.Generation.Input)
-	}
-
-	// Assistant text should appear in output.
-	foundAssistantText := false
-	for _, msg := range got.Generation.Output {
-		if msg.Role == sigil.RoleAssistant {
-			for _, p := range msg.Parts {
-				if p.Text == "hi there" {
-					foundAssistantText = true
-				}
-			}
-		}
-	}
-	if !foundAssistantText {
-		t.Errorf("assistant text 'hi there' missing from output; got %+v", got.Generation.Output)
-	}
-
-	// Tool input bytes should be present in full mode.
-	foundToolInput := false
-	for _, msg := range got.Generation.Output {
-		for _, p := range msg.Parts {
-			if p.ToolCall != nil && len(p.ToolCall.InputJSON) > 0 {
-				foundToolInput = true
-			}
-		}
-	}
-	if !foundToolInput {
-		t.Errorf("tool input bytes missing in full mode")
-	}
-
 	if got.Generation.ThinkingEnabled == nil || !*got.Generation.ThinkingEnabled {
 		t.Errorf("ThinkingEnabled = %v; want true", got.Generation.ThinkingEnabled)
 	}
 }
 
-func TestMapFragment_MetadataOnly_StripsContent(t *testing.T) {
-	got := MapFragment(Inputs{
-		Fragment:       basicFragment(t),
-		ContentCapture: sigil.ContentCaptureModeMetadataOnly,
-		Now:            fixedTime,
-	})
-
-	// User prompt must be absent.
-	for _, msg := range got.Generation.Input {
-		for _, p := range msg.Parts {
-			if p.Text == "hello" {
-				t.Errorf("user prompt leaked into metadata_only output")
-			}
-		}
+// TestMapFragment_ContentCaptureModes covers what every supported
+// ContentCaptureMode includes or strips in the gRPC payload that
+// buildMessages produces.
+//
+//   - Full and FullWithMetadataSpans carry full content; they only diverge
+//     in what the OTel span exposes, which is decided elsewhere.
+//   - NoToolContent keeps the tool_call/tool_result skeleton but strips
+//     argument and result bytes.
+//   - MetadataOnly drops user prompts, assistant text, and the tool_result
+//     message entirely.
+//   - Default is the zero-value enum. envconfig.ResolveContentMode maps it
+//     to MetadataOnly, but a caller that bypasses the config layer (or
+//     constructs Inputs directly in tests) might pass it through, so
+//     buildMessages re-applies the same mapping defensively.
+func TestMapFragment_ContentCaptureModes(t *testing.T) {
+	cases := []struct {
+		name            string
+		mode            sigil.ContentCaptureMode
+		wantUserPrompt  bool
+		wantAssistant   bool
+		wantToolInput   bool
+		wantToolResult  bool // tool_result message present in input
+		wantToolContent bool // tool_result carries ContentJSON or Content
+	}{
+		{"full", sigil.ContentCaptureModeFull, true, true, true, true, true},
+		{"full_with_metadata_spans", sigil.ContentCaptureModeFullWithMetadataSpans, true, true, true, true, true},
+		{"no_tool_content", sigil.ContentCaptureModeNoToolContent, true, true, false, true, false},
+		{"metadata_only", sigil.ContentCaptureModeMetadataOnly, false, false, false, false, false},
+		{"default", sigil.ContentCaptureModeDefault, false, false, false, false, false},
 	}
-	// Assistant text must be absent.
-	for _, msg := range got.Generation.Output {
-		for _, p := range msg.Parts {
-			if p.Text == "hi there" {
-				t.Errorf("assistant text leaked into metadata_only output")
-			}
-		}
-	}
-	// Tool calls keep structure, but tool result messages should be dropped.
-	for _, msg := range got.Generation.Input {
-		if msg.Role == sigil.RoleTool {
-			t.Errorf("tool result message leaked in metadata_only; got %+v", msg)
-		}
-	}
-}
 
-// envconfig.ResolveContentMode maps the Default zero-value enum to
-// MetadataOnly, but a caller that bypasses the config layer (or constructs
-// Inputs directly in tests) might pass Default through. buildMessages must
-// treat the two consistently across user prompt, tool results, and
-// assistant text — otherwise prompts could leak while tool results drop.
-func TestMapFragment_DefaultModeBehavesAsMetadataOnly(t *testing.T) {
-	got := MapFragment(Inputs{
-		Fragment:       basicFragment(t),
-		ContentCapture: sigil.ContentCaptureModeDefault,
-		Now:            fixedTime,
-	})
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MapFragment(Inputs{
+				Fragment:       basicFragment(t),
+				ContentCapture: tc.mode,
+				Now:            fixedTime,
+			})
 
-	for _, msg := range got.Generation.Input {
-		for _, p := range msg.Parts {
-			if p.Text == "hello" {
-				t.Errorf("user prompt leaked under Default mode")
-			}
-		}
-		if msg.Role == sigil.RoleTool {
-			t.Errorf("tool result leaked under Default mode; got %+v", msg)
-		}
-	}
-	for _, msg := range got.Generation.Output {
-		for _, p := range msg.Parts {
-			if p.Text == "hi there" {
-				t.Errorf("assistant text leaked under Default mode")
-			}
-		}
-	}
-}
-
-func TestMapFragment_NoToolContent_KeepsStructureStripsBytes(t *testing.T) {
-	got := MapFragment(Inputs{
-		Fragment:       basicFragment(t),
-		ContentCapture: sigil.ContentCaptureModeNoToolContent,
-		Now:            fixedTime,
-	})
-
-	// Tool result message present, but content stripped.
-	foundToolResult := false
-	for _, msg := range got.Generation.Input {
-		if msg.Role == sigil.RoleTool {
-			foundToolResult = true
-			for _, p := range msg.Parts {
-				if p.ToolResult != nil && (p.ToolResult.Content != "" || len(p.ToolResult.ContentJSON) > 0) {
-					t.Errorf("tool result content leaked in no_tool_content mode; got %+v", p.ToolResult)
+			var gotPrompt, gotAssistant, gotToolInput, gotToolResult, gotToolContent bool
+			for _, msg := range got.Generation.Input {
+				for _, p := range msg.Parts {
+					if p.Text == "hello" {
+						gotPrompt = true
+					}
+				}
+				if msg.Role == sigil.RoleTool {
+					gotToolResult = true
+					for _, p := range msg.Parts {
+						if p.ToolResult != nil && (p.ToolResult.Content != "" || len(p.ToolResult.ContentJSON) > 0) {
+							gotToolContent = true
+						}
+					}
 				}
 			}
-		}
-	}
-	if !foundToolResult {
-		t.Errorf("tool_result skeleton missing in no_tool_content mode")
-	}
-
-	// Tool call inputJSON should be absent.
-	for _, msg := range got.Generation.Output {
-		for _, p := range msg.Parts {
-			if p.ToolCall != nil && len(p.ToolCall.InputJSON) > 0 {
-				t.Errorf("tool call inputJSON leaked in no_tool_content mode")
+			for _, msg := range got.Generation.Output {
+				for _, p := range msg.Parts {
+					if p.Text == "hi there" {
+						gotAssistant = true
+					}
+					if p.ToolCall != nil && len(p.ToolCall.InputJSON) > 0 {
+						gotToolInput = true
+					}
+				}
 			}
-		}
+
+			if gotPrompt != tc.wantUserPrompt {
+				t.Errorf("user prompt present = %v; want %v", gotPrompt, tc.wantUserPrompt)
+			}
+			if gotAssistant != tc.wantAssistant {
+				t.Errorf("assistant text present = %v; want %v", gotAssistant, tc.wantAssistant)
+			}
+			if gotToolInput != tc.wantToolInput {
+				t.Errorf("tool_call InputJSON present = %v; want %v", gotToolInput, tc.wantToolInput)
+			}
+			if gotToolResult != tc.wantToolResult {
+				t.Errorf("tool_result message present = %v; want %v", gotToolResult, tc.wantToolResult)
+			}
+			if gotToolContent != tc.wantToolContent {
+				t.Errorf("tool_result content present = %v; want %v", gotToolContent, tc.wantToolContent)
+			}
+		})
 	}
 }
 

--- a/plugins/sigil/internal/agents/cursor/tags/tags.go
+++ b/plugins/sigil/internal/agents/cursor/tags/tags.go
@@ -62,7 +62,7 @@ func ResolveGitBranch(workspaceRoot string) string {
 		return ""
 	}
 	current := workspaceRoot
-	for i := 0; i < 6; i++ {
+	for range 6 {
 		gitPath := filepath.Join(current, ".git")
 		if gitDir := resolveGitDir(gitPath); gitDir != "" {
 			return readHeadBranch(gitDir)

--- a/plugins/sigil/internal/agents/pi/launch.go
+++ b/plugins/sigil/internal/agents/pi/launch.go
@@ -176,8 +176,8 @@ func sourceMatchesPlugin(source, settingsDir string) bool {
 	if source == "" {
 		return false
 	}
-	if strings.HasPrefix(source, npmPrefix) {
-		return stripNpmVersion(strings.TrimPrefix(source, npmPrefix)) == pluginName
+	if after, ok := strings.CutPrefix(source, npmPrefix); ok {
+		return stripNpmVersion(after) == pluginName
 	}
 	if filepath.IsAbs(source) || strings.HasPrefix(source, "./") || strings.HasPrefix(source, "../") {
 		path := source

--- a/plugins/sigil/internal/envconfig/envconfig.go
+++ b/plugins/sigil/internal/envconfig/envconfig.go
@@ -50,7 +50,7 @@ func ParseExtraTags(s string) map[string]string {
 		return nil
 	}
 	out := make(map[string]string)
-	for _, pair := range strings.Split(s, ",") {
+	for pair := range strings.SplitSeq(s, ",") {
 		k, v, ok := strings.Cut(pair, "=")
 		if !ok {
 			continue

--- a/plugins/sigil/internal/login/login.go
+++ b/plugins/sigil/internal/login/login.go
@@ -55,7 +55,6 @@ var (
 	bannerSubtitle = lipgloss.NewStyle().Faint(true)
 	bannerLabel    = lipgloss.NewStyle().Faint(true)
 	bannerURL      = lipgloss.NewStyle().Underline(true)
-	inlineAccent   = lipgloss.NewStyle().Bold(true).Foreground(grafanaOrange)
 )
 
 // grafanaTheme returns a huh theme tinted with Grafana orange for the

--- a/plugins/sigil/internal/otel/otel.go
+++ b/plugins/sigil/internal/otel/otel.go
@@ -208,13 +208,13 @@ func envOr(key, fallback string) string {
 
 func parseHeaders(raw string) map[string]string {
 	out := map[string]string{}
-	for _, pair := range strings.Split(raw, ",") {
-		eq := strings.IndexByte(pair, '=')
-		if eq < 0 {
+	for pair := range strings.SplitSeq(raw, ",") {
+		before, after, ok := strings.Cut(pair, "=")
+		if !ok {
 			continue
 		}
-		key := strings.TrimSpace(pair[:eq])
-		value := strings.TrimSpace(pair[eq+1:])
+		key := strings.TrimSpace(before)
+		value := strings.TrimSpace(after)
 		if key != "" && value != "" {
 			out[key] = value
 		}
@@ -230,4 +230,3 @@ func hasAuthorizationHeader(headers map[string]string) bool {
 	}
 	return false
 }
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly CI and lint-driven refactors; behavior changes are small (e.g. content-capture resolver arg order, JSON field tags) and covered by existing tests.
> 
> **Overview**
> Introduces a **repo-wide `.golangci.yml`** (revive, staticcheck, gosec, modernize, etc.) and removes the old per-module override under `go-frameworks/google-adk`.
> 
> **CI** splits Go work into a **`go-module` matrix** (`go`, providers, `google-adk`, `plugins/sigil`) that runs `golangci-lint` and `go test` per module with **`GOWORK=off`**, matching local `mise run lint:go`. The **`Go SDK` job** is now a gate that fails if any matrix job did not succeed.
> 
> **Lint-driven code fixes** span the core SDK, providers, frameworks, and plugins: `maps.Copy` instead of manual map loops, `atomic.Int32` / `for range` / `slices` / `strings.SplitSeq` idioms, **`callContentCaptureResolver(ctx, …)`** argument order, dropping redundant `string()` on typed model fields, JSON tag cleanup on struct fields where `omitempty` was misleading, and consolidated **Cursor mapper content-capture tests**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc765000033011be6a416db1ddbcb9f9196ad385. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->