### PR TITLE
refactor(plugins/pi): drop SIGIL_PI_* env vars and legacy config file

### DIFF
--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -2,7 +2,7 @@
 
 [Pi](https://github.com/badlogic/pi) agent extension that sends LLM generations to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/).
 
-By default only metadata is sent (token counts, cost, model, tool names, durations). Flip `contentCapture` to `full` or `no_tool_content` to include message content.
+By default only metadata is sent (token counts, cost, model, tool names, durations). Flip `SIGIL_CONTENT_CAPTURE_MODE` to `full` or `no_tool_content` to include message content.
 
 ## 1. Install
 
@@ -19,57 +19,39 @@ sigil pi
 
 ## 2. Add your Grafana Cloud credentials
 
-All Sigil connection details live at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Skip this section if you're running against a self-hosted Sigil — see [Auth modes](#auth-modes) below.
+All Sigil connection details live at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`.
 
 You need values from three Grafana Cloud pages:
 
 1. **AI Observability → Configuration**
-   - **API URL** → `endpoint`
-   - **Instance ID** → `auth.user` and `otlp.basicUser`
+   - **API URL** → `SIGIL_ENDPOINT`
+   - **Instance ID** → `SIGIL_AUTH_TENANT_ID`
 
 2. **Administration → Users and access → Cloud access policies**
    - Create a policy with scopes `sigil:write`, `metrics:write`, `traces:write`.
-   - Add a token. The `glc_…` value is shown once → `auth.password` and `otlp.basicPassword`.
+   - Add a token. The `glc_…` value is shown once → `SIGIL_AUTH_TOKEN`.
 
 3. **Grafana Cloud Portal → your stack → OpenTelemetry card**
-   - **OTLP endpoint URL** → `otlp.endpoint`
+   - **OTLP endpoint URL** → `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT`
 
 ## 3. Configure
 
-Create `~/.config/sigil-pi/config.json`:
+Configuration comes from canonical `SIGIL_*` env vars. The extension also reads `$XDG_CONFIG_HOME/sigil/config.env` (default `~/.config/sigil/config.env`) on startup and copies entries into `process.env` for keys whose existing OS value is empty or whitespace-only. Plain `pi` and `sigil pi` share the same file.
 
-```json
-{
-  "endpoint": "https://sigil-prod-<region>.grafana.net",
-  "auth": {
-    "mode": "basic",
-    "user": "<instance-id>",
-    "password": "${SIGIL_AUTH_TOKEN}"
-  },
-  "otlp": {
-    "endpoint": "https://otlp-gateway-prod-<region>.grafana.net/otlp",
-    "basicUser": "<instance-id>",
-    "basicPassword": "${SIGIL_AUTH_TOKEN}"
-  }
-}
+Minimal `~/.config/sigil/config.env`:
+
+```sh
+SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
+SIGIL_AUTH_TENANT_ID=<instance-id>
+SIGIL_AUTH_TOKEN=glc_...
+SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
 ```
 
-String values support `${ENV_VAR}` interpolation, so the token stays out of the file.
-
-To include conversation text (with automatic secret redaction), add `"contentCapture": "full"` to the config.
-
-### Auth modes
-
-- `basic` — Grafana Cloud: `{ "mode": "basic", "user": "<instance-id>", "password": "${SIGIL_AUTH_TOKEN}" }`
-- `tenant` — `X-Scope-OrgID` only: `{ "mode": "tenant", "tenantId": "my-tenant" }`
-- `bearer` — `{ "mode": "bearer", "bearerToken": "${SIGIL_TOKEN}" }`
-- `none` — no auth (default)
+When `SIGIL_AUTH_TENANT_ID` and `SIGIL_AUTH_TOKEN` are both set, both Sigil generation export and the OTLP endpoint authenticate with the synthesized Basic auth header (`Basic base64(tenant:token)`). With only one of the two set, no auth header is sent.
 
 ## Redaction
 
-Before any generation leaves the process, the SDK scrubs known token formats, PEM private keys, database URLs, `KEY=value` pairs, bearer tokens, and email addresses. Matches become `[REDACTED:<id>]`.
-
-User-role messages are scrubbed too. Set `redaction.redactInputMessages: false` to leave them alone, or `redaction.enabled: false` to disable redaction entirely.
+Before any generation leaves the process, the SDK scrubs known token formats, PEM private keys, database URLs, `KEY=value` pairs, bearer tokens, and email addresses. Matches become `[REDACTED:<id>]`. User input messages are redacted by default; set `SIGIL_REDACT_INPUT_MESSAGES=false` to leave them unchanged.
 
 ## Guards
 
@@ -81,48 +63,28 @@ SIGIL_GUARDS_ENABLED=true pi
 
 By default, transport errors and timeouts let the tool through. Set `SIGIL_GUARDS_FAIL_OPEN=false` to block on errors instead. Raise or lower `SIGIL_GUARDS_TIMEOUT_MS` (default `1500`) to trade latency against tolerance for slow evaluators.
 
-| Variable | Default | Description |
-|---|---|---|
-| `SIGIL_GUARDS_ENABLED` | `false` | Evaluate `tool_call` requests against Sigil policy. |
-| `SIGIL_GUARDS_FAIL_OPEN` | `true` | Allow tools through when the guard call fails. Set `false` for strict mode. |
-| `SIGIL_GUARDS_TIMEOUT_MS` | `1500` | Per-call timeout for guard requests, in milliseconds. |
-
 The same three variables are honored by the [Claude Code plugin](../claude-code/README.md); both plugins read them from `~/.config/sigil/config.env`.
 
 ## All options
 
-| Field | Default | Description |
-|-------|---------|-------------|
-| `endpoint` | — | Sigil URL (find it at `/plugins/grafana-sigil-app`) |
-| `auth.mode` | `"none"` | `basic`, `tenant`, `bearer`, or `none` |
-| `auth.user` / `auth.password` | — | Basic auth credentials |
-| `auth.tenantId` | `auth.user` in basic mode | `X-Scope-OrgID` header |
-| `auth.bearerToken` | — | Bearer token |
-| `agentName` | `"pi"` | Agent name reported to Sigil |
-| `contentCapture` | `"metadata_only"` | `full`, `no_tool_content`, or `metadata_only` |
-| `debug` | `false` | Log lifecycle events to stderr |
-| `otlp.endpoint` | — | OTLP HTTP endpoint |
-| `otlp.basicUser` / `otlp.basicPassword` | — | OTLP Basic auth |
-| `otlp.bearerToken` | — | OTLP Bearer token |
-| `redaction.enabled` | `true` | Master switch for redaction |
-| `redaction.redactInputMessages` | `true` | Scrub user-role content too |
-| `guards.enabled` | `false` | Evaluate `tool_call` requests against Sigil policy |
-| `guards.timeoutMs` | `1500` | Per-call timeout for guard requests |
-| `guards.failOpen` | `true` | Allow tools through when guard checks fail |
+`~/.config/sigil/config.env` is the only configuration file. Every option is set via env var.
 
-Every field can be overridden via env var.
-
-On startup the extension reads `$XDG_CONFIG_HOME/sigil/config.env` (default `~/.config/sigil/config.env`) and copies the entries into `process.env` for keys whose existing OS value is empty or whitespace-only. This happens on every launch — plain `pi` and `sigil pi` resolve credentials from the same file.
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SIGIL_ENDPOINT` | — | Sigil URL (find it at `/plugins/grafana-sigil-app`) |
+| `SIGIL_AUTH_TENANT_ID` | — | Grafana Cloud instance ID. Combined with `SIGIL_AUTH_TOKEN` becomes Basic auth for Sigil and OTLP. |
+| `SIGIL_AUTH_TOKEN` | — | Cloud access policy token (`glc_…`). |
+| `SIGIL_AGENT_NAME` | `pi` | Agent name reported to Sigil. |
+| `SIGIL_AGENT_VERSION` | — | Optional version string reported with the agent. |
+| `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `full`, `no_tool_content`, or `metadata_only`. |
+| `SIGIL_DEBUG` | `false` | Log lifecycle events to stderr. |
+| `SIGIL_REDACT_INPUT_MESSAGES` | `true` | Redact known secret patterns in user input messages before export. |
+| `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP HTTP endpoint. Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT`. |
+| `SIGIL_OTEL_AUTH_TOKEN` | — | OTel-only auth token. Overrides `SIGIL_AUTH_TOKEN` when synthesising OTLP Basic auth. |
+| `SIGIL_GUARDS_ENABLED` | `false` | Evaluate `tool_call` requests against Sigil policy. |
+| `SIGIL_GUARDS_TIMEOUT_MS` | `1500` | Per-call timeout for guard requests, in milliseconds. |
+| `SIGIL_GUARDS_FAIL_OPEN` | `true` | Allow tools through when the guard call fails. Set `false` for strict mode. |
 
 File format: one `KEY=value` per line, `#` line comments, optional `export ` prefix, optional matching single or double quotes around the value. Only the following keys are honoured — anything else (including stray `PATH=…` lines) is ignored: any `SIGIL_*` key plus `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_INSECURE`, and `OTEL_SERVICE_NAME`.
 
 A non-empty OS env value always wins over the file; an empty or whitespace-only OS value is treated as unset and gets filled from `config.env`. Missing files are silent.
-
-| Variable | Sets |
-|----------|------|
-| `SIGIL_ENDPOINT` | `endpoint` |
-| `SIGIL_AUTH_TENANT_ID` + `SIGIL_AUTH_TOKEN` | Basic auth for Sigil and OTLP |
-| `SIGIL_CONTENT_CAPTURE_MODE` | `contentCapture` |
-| `SIGIL_DEBUG` | `debug` |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `otlp.endpoint` |
-| `SIGIL_GUARDS_ENABLED` | `guards.enabled` |

--- a/plugins/pi/src/client.test.ts
+++ b/plugins/pi/src/client.test.ts
@@ -27,11 +27,7 @@ function makeConfig(overrides?: Partial<SigilPiConfig>): SigilPiConfig {
     agentName: "pi",
     contentCapture: "metadata_only",
     debug: false,
-    redaction: {
-      enabled: true,
-      redactInputMessages: true,
-      redactEmailAddresses: true,
-    },
+    redactInputMessages: true,
     guards: {
       enabled: false,
       timeoutMs: 1500,
@@ -51,10 +47,8 @@ describe("createSigilClient", () => {
     });
   });
 
-  it("creates sdk client with tenant auth", () => {
-    const client = createSigilClient(
-      makeConfig({ auth: { mode: "tenant", tenantId: "t-1" } }),
-    );
+  it("creates sdk client with no auth", () => {
+    const client = createSigilClient(makeConfig());
 
     expect(client).toEqual({});
     expect(SigilClientMock).toHaveBeenCalledTimes(1);
@@ -62,7 +56,7 @@ describe("createSigilClient", () => {
       generationExport: {
         protocol: "http",
         endpoint: "http://localhost:8080/api/v1/generations:export",
-        auth: { mode: "tenant", tenantId: "t-1" },
+        auth: { mode: "none" },
       },
       api: { endpoint: "http://localhost:8080" },
       hooks: {
@@ -91,13 +85,13 @@ describe("createSigilClient", () => {
     );
   });
 
-  it("maps basic auth to sdk format with tenantId", () => {
+  it("passes basic auth through with tenantId", () => {
     createSigilClient(
       makeConfig({
         auth: {
           mode: "basic",
-          user: "12345",
-          password: "pass",
+          basicUser: "12345",
+          basicPassword: "pass",
           tenantId: "12345",
         },
       }),
@@ -213,50 +207,15 @@ describe("createSigilClient", () => {
     expect(client).toBeNull();
   });
 
-  it("wires generationSanitizer when redaction is enabled", () => {
-    createSigilClient(makeConfig());
+  it("wires input redaction into the sanitizer", () => {
+    createSigilClient(makeConfig({ redactInputMessages: false }));
 
     expect(createSecretRedactionSanitizerMock).toHaveBeenCalledTimes(1);
     expect(createSecretRedactionSanitizerMock).toHaveBeenCalledWith({
-      redactInputMessages: true,
-      redactEmailAddresses: true,
+      redactInputMessages: false,
     });
     expect(SigilClientMock).toHaveBeenCalledWith(
       expect.objectContaining({ generationSanitizer: SANITIZER }),
-    );
-  });
-
-  it("forwards redaction sub-flags to the sanitizer factory", () => {
-    createSigilClient(
-      makeConfig({
-        redaction: {
-          enabled: true,
-          redactInputMessages: false,
-          redactEmailAddresses: false,
-        },
-      }),
-    );
-
-    expect(createSecretRedactionSanitizerMock).toHaveBeenCalledWith({
-      redactInputMessages: false,
-      redactEmailAddresses: false,
-    });
-  });
-
-  it("omits generationSanitizer when redaction is disabled", () => {
-    createSigilClient(
-      makeConfig({
-        redaction: {
-          enabled: false,
-          redactInputMessages: true,
-          redactEmailAddresses: true,
-        },
-      }),
-    );
-
-    expect(createSecretRedactionSanitizerMock).not.toHaveBeenCalled();
-    expect(SigilClientMock).toHaveBeenCalledWith(
-      expect.objectContaining({ generationSanitizer: undefined }),
     );
   });
 });

--- a/plugins/pi/src/client.ts
+++ b/plugins/pi/src/client.ts
@@ -1,13 +1,10 @@
-import type {
-  GenerationExportConfig,
-  SigilLogger,
-} from "@grafana/sigil-sdk-js";
+import type { SigilLogger } from "@grafana/sigil-sdk-js";
 import {
   createSecretRedactionSanitizer,
   SigilClient,
 } from "@grafana/sigil-sdk-js";
 import type { Meter, Tracer } from "@opentelemetry/api";
-import type { SigilAuthConfig, SigilPiConfig } from "./config.js";
+import type { SigilPiConfig } from "./config.js";
 import { EXPORT_PATH } from "./config.js";
 
 export interface SigilClientOptions {
@@ -51,7 +48,7 @@ export function createSigilClient(
       generationExport: {
         protocol: "http",
         endpoint: appendExportPath(config.endpoint),
-        auth: mapAuth(config.auth),
+        auth: config.auth,
       },
       api: { endpoint: config.endpoint },
       hooks: {
@@ -64,12 +61,9 @@ export function createSigilClient(
       ...(options?.tracer ? { tracer: options.tracer } : {}),
       ...(options?.meter ? { meter: options.meter } : {}),
       logger: createSdkLogger(config.debug),
-      generationSanitizer: config.redaction.enabled
-        ? createSecretRedactionSanitizer({
-            redactInputMessages: config.redaction.redactInputMessages,
-            redactEmailAddresses: config.redaction.redactEmailAddresses,
-          })
-        : undefined,
+      generationSanitizer: createSecretRedactionSanitizer({
+        redactInputMessages: config.redactInputMessages,
+      }),
     });
   } catch (err) {
     console.warn("[sigil-pi] failed to create SigilClient:", err);
@@ -91,19 +85,5 @@ function appendExportPath(endpoint: string): string {
     return url.toString();
   } catch {
     return endpoint.replace(/\/+$/, "") + EXPORT_PATH;
-  }
-}
-
-function mapAuth(auth: SigilAuthConfig): GenerationExportConfig["auth"] {
-  switch (auth.mode) {
-    case "basic":
-      return {
-        mode: "basic",
-        basicUser: auth.user,
-        basicPassword: auth.password,
-        tenantId: auth.tenantId,
-      };
-    default:
-      return auth;
   }
 }

--- a/plugins/pi/src/config.test.ts
+++ b/plugins/pi/src/config.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { loadConfig, resolveConfig, resolveEnvVars } from "./config.js";
+import { loadConfig, resolveConfig } from "./config.js";
 import { clearSigilEnv as clearEnv } from "./testEnv.js";
 
 describe("resolveConfig", () => {
@@ -10,106 +10,86 @@ describe("resolveConfig", () => {
   afterEach(clearEnv);
 
   it("returns null when endpoint is missing", () => {
-    expect(resolveConfig({})).toBeNull();
+    expect(resolveConfig()).toBeNull();
   });
 
   it("returns null when endpoint is whitespace", () => {
-    expect(resolveConfig({ endpoint: "   " })).toBeNull();
-  });
-
-  it("parses full config from file", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080",
-      auth: { mode: "tenant", tenantId: "my-tenant" },
-      agentName: "pi-custom",
-      agentVersion: "1.0.0",
-      contentCapture: true,
-    });
-    expect(cfg).not.toBeNull();
-    expect(cfg?.endpoint).toBe("http://localhost:8080");
-    expect(cfg?.auth).toEqual({ mode: "tenant", tenantId: "my-tenant" });
-    expect(cfg?.agentName).toBe("pi-custom");
-    expect(cfg?.agentVersion).toBe("1.0.0");
-    expect(cfg?.contentCapture).toBe("full");
+    process.env.SIGIL_ENDPOINT = "   ";
+    expect(resolveConfig()).toBeNull();
   });
 
   it("stores the bare base URL when given a clean endpoint", () => {
-    const cfg = resolveConfig({ endpoint: "http://localhost:8080" });
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    const cfg = resolveConfig();
     expect(cfg?.endpoint).toBe("http://localhost:8080");
   });
 
   it("strips a trailing slash", () => {
-    const cfg = resolveConfig({ endpoint: "http://localhost:8080/" });
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080/";
+    const cfg = resolveConfig();
     expect(cfg?.endpoint).toBe("http://localhost:8080");
   });
 
   it("strips an accidentally-pasted export-path suffix", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-    });
+    process.env.SIGIL_ENDPOINT =
+      "http://localhost:8080/api/v1/generations:export";
+    const cfg = resolveConfig();
     expect(cfg?.endpoint).toBe("http://localhost:8080");
   });
 
   it("preserves a prefix path", () => {
-    const cfg = resolveConfig({
-      endpoint: "https://sigil.example.com/sigil",
-    });
+    process.env.SIGIL_ENDPOINT = "https://sigil.example.com/sigil";
+    const cfg = resolveConfig();
     expect(cfg?.endpoint).toBe("https://sigil.example.com/sigil");
   });
 
   it("strips the export-path suffix from a prefix-mounted URL", () => {
-    const cfg = resolveConfig({
-      endpoint: "https://sigil.example.com/sigil/api/v1/generations:export",
-    });
+    process.env.SIGIL_ENDPOINT =
+      "https://sigil.example.com/sigil/api/v1/generations:export";
+    const cfg = resolveConfig();
     expect(cfg?.endpoint).toBe("https://sigil.example.com/sigil");
   });
 
   it("does not falsely match a similar-looking suffix", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export-debug",
-    });
+    process.env.SIGIL_ENDPOINT =
+      "http://localhost:8080/api/v1/generations:export-debug";
+    const cfg = resolveConfig();
     expect(cfg?.endpoint).toBe(
       "http://localhost:8080/api/v1/generations:export-debug",
     );
   });
 
   it("defaults contentCapture to metadata_only", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-    });
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    const cfg = resolveConfig();
     expect(cfg?.contentCapture).toBe("metadata_only");
   });
 
-  it("maps boolean true to full", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      contentCapture: true,
-    });
-    expect(cfg?.contentCapture).toBe("full");
+  it("defaults input message redaction to on", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    const cfg = resolveConfig();
+    expect(cfg?.redactInputMessages).toBe(true);
   });
 
-  it("maps boolean false to metadata_only", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      contentCapture: false,
-    });
-    expect(cfg?.contentCapture).toBe("metadata_only");
+  it("SIGIL_REDACT_INPUT_MESSAGES controls input message redaction", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_REDACT_INPUT_MESSAGES = "false";
+    const cfg = resolveConfig();
+    expect(cfg?.redactInputMessages).toBe(false);
   });
 
   it("accepts mode string no_tool_content", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      contentCapture: "no_tool_content",
-    });
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_CONTENT_CAPTURE_MODE = "no_tool_content";
+    const cfg = resolveConfig();
     expect(cfg?.contentCapture).toBe("no_tool_content");
   });
 
   it("warns and falls back on unknown mode string", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      contentCapture: "yolo",
-    });
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_CONTENT_CAPTURE_MODE = "yolo";
+    const cfg = resolveConfig();
     expect(cfg?.contentCapture).toBe("metadata_only");
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("unsupported contentCapture"),
@@ -118,111 +98,50 @@ describe("resolveConfig", () => {
   });
 
   it("defaults agentName to 'pi'", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      agentName: "   ",
-    });
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_AGENT_NAME = "   ";
+    const cfg = resolveConfig();
     expect(cfg?.agentName).toBe("pi");
   });
 
-  it("env vars override file values", () => {
-    process.env.SIGIL_PI_ENDPOINT = "http://env:9090/api/v1/generations:export";
-    process.env.SIGIL_PI_AGENT_NAME = "pi-env";
-    process.env.SIGIL_PI_CONTENT_CAPTURE = "true";
-    process.env.SIGIL_PI_AUTH_MODE = "bearer";
-    process.env.SIGIL_PI_BEARER_TOKEN = "tok-123";
-
-    const cfg = resolveConfig({
-      endpoint: "http://file:8080",
-      agentName: "pi-file",
-      contentCapture: false,
-      auth: { mode: "none" },
-    });
-
-    expect(cfg?.endpoint).toBe("http://env:9090");
-    expect(cfg?.agentName).toBe("pi-env");
-    expect(cfg?.contentCapture).toBe("full");
-    expect(cfg?.auth).toEqual({ mode: "bearer", bearerToken: "tok-123" });
-  });
-
   it("env bool parsing is case-insensitive", () => {
-    process.env.SIGIL_PI_CONTENT_CAPTURE = "On";
-    process.env.SIGIL_PI_ENDPOINT =
-      "http://localhost:8080/api/v1/generations:export";
-
-    const cfg = resolveConfig({ auth: { mode: "none" } });
-
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_CONTENT_CAPTURE_MODE = "On";
+    const cfg = resolveConfig();
     expect(cfg?.contentCapture).toBe("full");
   });
 
-  it("parses bearer auth from file", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      auth: { mode: "bearer", bearerToken: "my-token" },
-    });
-    expect(cfg?.auth).toEqual({ mode: "bearer", bearerToken: "my-token" });
-  });
-
-  it("returns null on bearer auth with missing token", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      auth: { mode: "bearer", bearerToken: "" },
-    });
-    expect(cfg).toBeNull();
-  });
-
-  it("parses basic auth with tenantId defaulting to user", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      auth: { mode: "basic", user: "12345", password: "pass" },
-    });
+  it("derives basic auth from SIGIL_AUTH_TENANT_ID + SIGIL_AUTH_TOKEN", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_AUTH_TENANT_ID = "tenant-1";
+    process.env.SIGIL_AUTH_TOKEN = "glc_token";
+    const cfg = resolveConfig();
     expect(cfg?.auth).toEqual({
       mode: "basic",
-      user: "12345",
-      password: "pass",
-      tenantId: "12345",
+      basicUser: "tenant-1",
+      basicPassword: "glc_token",
+      tenantId: "tenant-1",
     });
   });
 
-  it("parses basic auth with explicit tenantId", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      auth: {
-        mode: "basic",
-        user: "12345",
-        password: "pass",
-        tenantId: "my-org",
-      },
-    });
-    expect(cfg?.auth).toEqual({
-      mode: "basic",
-      user: "12345",
-      password: "pass",
-      tenantId: "my-org",
-    });
-  });
-
-  it("returns null on basic auth with missing fields", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      auth: { mode: "basic", user: "user", password: "" },
-    });
-    expect(cfg).toBeNull();
-  });
-
-  it("defaults auth to none", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-    });
+  it("falls back to none when only the tenant id is set", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_AUTH_TENANT_ID = "tenant-1";
+    const cfg = resolveConfig();
     expect(cfg?.auth).toEqual({ mode: "none" });
   });
 
-  it("returns null on unsupported auth mode", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      auth: { mode: "berer" },
-    });
-    expect(cfg).toBeNull();
+  it("falls back to none when only the auth token is set", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_AUTH_TOKEN = "glc_token";
+    const cfg = resolveConfig();
+    expect(cfg?.auth).toEqual({ mode: "none" });
+  });
+
+  it("defaults auth to none when no creds are set", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    const cfg = resolveConfig();
+    expect(cfg?.auth).toEqual({ mode: "none" });
   });
 });
 
@@ -232,81 +151,29 @@ describe("resolveConfig canonical SIGIL_* env vars", () => {
 
   it("reads SIGIL_ENDPOINT as the endpoint", () => {
     process.env.SIGIL_ENDPOINT = "http://canonical:8080";
-    const cfg = resolveConfig({});
+    const cfg = resolveConfig();
     expect(cfg?.endpoint).toBe("http://canonical:8080");
-  });
-
-  it("SIGIL_ENDPOINT wins over SIGIL_PI_ENDPOINT", () => {
-    process.env.SIGIL_ENDPOINT = "http://canonical:8080";
-    process.env.SIGIL_PI_ENDPOINT = "http://legacy:9090";
-    const cfg = resolveConfig({});
-    expect(cfg?.endpoint).toBe("http://canonical:8080");
-  });
-
-  it("derives basic auth from SIGIL_AUTH_TENANT_ID + SIGIL_AUTH_TOKEN", () => {
-    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
-    process.env.SIGIL_AUTH_TENANT_ID = "tenant-1";
-    process.env.SIGIL_AUTH_TOKEN = "glc_token";
-    const cfg = resolveConfig({});
-    expect(cfg?.auth).toEqual({
-      mode: "basic",
-      user: "tenant-1",
-      password: "glc_token",
-      tenantId: "tenant-1",
-    });
-  });
-
-  it("does not derive auth from a partial canonical pair", () => {
-    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
-    process.env.SIGIL_AUTH_TENANT_ID = "tenant-1";
-    const cfg = resolveConfig({});
-    expect(cfg?.auth).toEqual({ mode: "none" });
-  });
-
-  it("explicit SIGIL_PI_AUTH_MODE bypasses canonical derivation", () => {
-    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
-    process.env.SIGIL_AUTH_TENANT_ID = "tenant-1";
-    process.env.SIGIL_AUTH_TOKEN = "glc_token";
-    process.env.SIGIL_PI_AUTH_MODE = "bearer";
-    process.env.SIGIL_PI_BEARER_TOKEN = "bearer-tok";
-    const cfg = resolveConfig({});
-    expect(cfg?.auth).toEqual({ mode: "bearer", bearerToken: "bearer-tok" });
-  });
-
-  it("explicit file.auth.mode bypasses canonical derivation", () => {
-    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
-    process.env.SIGIL_AUTH_TENANT_ID = "tenant-1";
-    process.env.SIGIL_AUTH_TOKEN = "glc_token";
-    const cfg = resolveConfig({ auth: { mode: "none" } });
-    expect(cfg?.auth).toEqual({ mode: "none" });
   });
 
   it("SIGIL_DEBUG flips debug on", () => {
     process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.SIGIL_DEBUG = "true";
-    const cfg = resolveConfig({});
-    expect(cfg?.debug).toBe(true);
-  });
-
-  it("SIGIL_PI_DEBUG still wins as legacy override when SIGIL_DEBUG is unset", () => {
-    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
-    process.env.SIGIL_PI_DEBUG = "true";
-    const cfg = resolveConfig({ debug: false });
+    const cfg = resolveConfig();
     expect(cfg?.debug).toBe(true);
   });
 
   it("SIGIL_CONTENT_CAPTURE_MODE sets content capture", () => {
     process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.SIGIL_CONTENT_CAPTURE_MODE = "full";
-    const cfg = resolveConfig({});
+    const cfg = resolveConfig();
     expect(cfg?.contentCapture).toBe("full");
   });
 
-  it("SIGIL_AGENT_NAME and SIGIL_AGENT_VERSION override file values", () => {
+  it("SIGIL_AGENT_NAME and SIGIL_AGENT_VERSION are read from env", () => {
     process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.SIGIL_AGENT_NAME = "pi-canonical";
     process.env.SIGIL_AGENT_VERSION = "9.9.9";
-    const cfg = resolveConfig({ agentName: "file-name", agentVersion: "1.0" });
+    const cfg = resolveConfig();
     expect(cfg?.agentName).toBe("pi-canonical");
     expect(cfg?.agentVersion).toBe("9.9.9");
   });
@@ -320,15 +187,21 @@ describe("resolveConfig canonical OTLP env vars", () => {
     process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT =
       "https://otlp.example.com/otlp";
-    const cfg = resolveConfig({});
+    const cfg = resolveConfig();
     expect(cfg?.otlp?.endpoint).toBe("https://otlp.example.com/otlp");
   });
 
   it("falls back to OTEL_EXPORTER_OTLP_ENDPOINT", () => {
     process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "https://otlp.example.com/otlp";
-    const cfg = resolveConfig({});
+    const cfg = resolveConfig();
     expect(cfg?.otlp?.endpoint).toBe("https://otlp.example.com/otlp");
+  });
+
+  it("returns no otlp when not configured", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    const cfg = resolveConfig();
+    expect(cfg?.otlp).toBeUndefined();
   });
 
   it("synthesises OTLP Basic auth from canonical SIGIL_* creds", () => {
@@ -337,7 +210,7 @@ describe("resolveConfig canonical OTLP env vars", () => {
     process.env.SIGIL_AUTH_TOKEN = "glc_token";
     process.env.SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT =
       "https://otlp.example.com/otlp";
-    const cfg = resolveConfig({});
+    const cfg = resolveConfig();
     expect(cfg?.otlp?.headers.Authorization).toMatch(/^Basic /);
     const decoded = Buffer.from(
       cfg!.otlp!.headers.Authorization!.replace("Basic ", ""),
@@ -353,234 +226,26 @@ describe("resolveConfig canonical OTLP env vars", () => {
     process.env.SIGIL_OTEL_AUTH_TOKEN = "otel-only-token";
     process.env.SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT =
       "https://otlp.example.com/otlp";
-    const cfg = resolveConfig({});
+    const cfg = resolveConfig();
     const decoded = Buffer.from(
       cfg!.otlp!.headers.Authorization!.replace("Basic ", ""),
       "base64",
     ).toString();
     expect(decoded).toBe("tenant-1:otel-only-token");
-    // Generation auth still uses the unscoped token.
     expect(cfg?.auth).toEqual({
       mode: "basic",
-      user: "tenant-1",
-      password: "sigil-only-token",
+      basicUser: "tenant-1",
+      basicPassword: "sigil-only-token",
       tenantId: "tenant-1",
     });
   });
 
-  it("explicit SIGIL_PI_OTLP_* creds win over canonical synthesis", () => {
+  it("env var overrides OTLP endpoint", () => {
     process.env.SIGIL_ENDPOINT = "http://localhost:8080";
-    process.env.SIGIL_AUTH_TENANT_ID = "tenant-1";
-    process.env.SIGIL_AUTH_TOKEN = "sigil-token";
     process.env.SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT =
-      "https://otlp.example.com/otlp";
-    process.env.SIGIL_PI_OTLP_BASIC_USER = "otlp-user";
-    process.env.SIGIL_PI_OTLP_BASIC_PASSWORD = "otlp-pass";
-    const cfg = resolveConfig({});
-    const decoded = Buffer.from(
-      cfg!.otlp!.headers.Authorization!.replace("Basic ", ""),
-      "base64",
-    ).toString();
-    expect(decoded).toBe("otlp-user:otlp-pass");
-  });
-});
-
-describe("resolveConfig otlp", () => {
-  beforeEach(clearEnv);
-  afterEach(clearEnv);
-
-  it("returns no otlp when not configured", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-    });
-    expect(cfg?.otlp).toBeUndefined();
-  });
-
-  it("parses otlp with basic auth", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      otlp: {
-        endpoint: "https://otlp-gw.grafana.net/otlp",
-        basicUser: "123456",
-        basicPassword: "glc_token",
-      },
-    });
-    expect(cfg?.otlp).toBeDefined();
-    expect(cfg?.otlp?.endpoint).toBe("https://otlp-gw.grafana.net/otlp");
-    expect(cfg?.otlp?.headers.Authorization).toMatch(/^Basic /);
-    const decoded = Buffer.from(
-      cfg!.otlp!.headers.Authorization!.replace("Basic ", ""),
-      "base64",
-    ).toString();
-    expect(decoded).toBe("123456:glc_token");
-  });
-
-  it("parses otlp with bearer token", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      otlp: {
-        endpoint: "https://otlp.example.com",
-        bearerToken: "my-token",
-      },
-    });
-    expect(cfg?.otlp?.headers.Authorization).toBe("Bearer my-token");
-  });
-
-  it("parses otlp with custom headers", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      otlp: {
-        endpoint: "https://otlp.example.com",
-        headers: { "X-Custom": "value" },
-      },
-    });
-    expect(cfg?.otlp?.headers["X-Custom"]).toBe("value");
-  });
-
-  it("env vars override otlp config", () => {
-    process.env.SIGIL_PI_OTLP_ENDPOINT = "https://env-otlp.example.com";
-    process.env.SIGIL_PI_OTLP_BASIC_USER = "env-user";
-    process.env.SIGIL_PI_OTLP_BASIC_PASSWORD = "env-pass";
-
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      otlp: {
-        endpoint: "https://file-otlp.example.com",
-        basicUser: "file-user",
-        basicPassword: "file-pass",
-      },
-    });
+      "https://env-otlp.example.com";
+    const cfg = resolveConfig();
     expect(cfg?.otlp?.endpoint).toBe("https://env-otlp.example.com");
-    const decoded = Buffer.from(
-      cfg!.otlp!.headers.Authorization!.replace("Basic ", ""),
-      "base64",
-    ).toString();
-    expect(decoded).toBe("env-user:env-pass");
-  });
-
-  it("basic auth takes precedence over bearer", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      otlp: {
-        endpoint: "https://otlp.example.com",
-        basicUser: "user",
-        basicPassword: "pass",
-        bearerToken: "token",
-      },
-    });
-    expect(cfg?.otlp?.headers.Authorization).toMatch(/^Basic /);
-  });
-
-  it("explicit headers.Authorization wins over basic and bearer shorthand", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      otlp: {
-        endpoint: "https://otlp.example.com",
-        headers: { Authorization: "Bearer custom-token" },
-        basicUser: "user",
-        basicPassword: "pass",
-        bearerToken: "token",
-      },
-    });
-    expect(cfg?.otlp?.headers.Authorization).toBe("Bearer custom-token");
-  });
-});
-
-describe("resolveConfig redaction", () => {
-  beforeEach(clearEnv);
-  afterEach(clearEnv);
-
-  it("defaults all redaction knobs to true when file omits the block", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-    });
-    expect(cfg?.redaction).toEqual({
-      enabled: true,
-      redactInputMessages: true,
-      redactEmailAddresses: true,
-    });
-  });
-
-  it("file-level redaction.enabled = false disables it", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      redaction: { enabled: false },
-    });
-    expect(cfg?.redaction.enabled).toBe(false);
-    // partial override preserves the rest as defaults
-    expect(cfg?.redaction.redactInputMessages).toBe(true);
-    expect(cfg?.redaction.redactEmailAddresses).toBe(true);
-  });
-
-  it("partial file override preserves other defaults", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      redaction: { redactEmailAddresses: false },
-    });
-    expect(cfg?.redaction).toEqual({
-      enabled: true,
-      redactInputMessages: true,
-      redactEmailAddresses: false,
-    });
-  });
-
-  it("env vars override file values (truthy aliases)", () => {
-    process.env.SIGIL_PI_REDACTION_ENABLED = "1";
-    process.env.SIGIL_PI_REDACT_INPUT_MESSAGES = "true";
-    process.env.SIGIL_PI_REDACT_EMAIL_ADDRESSES = "yes";
-
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      redaction: {
-        enabled: false,
-        redactInputMessages: false,
-        redactEmailAddresses: false,
-      },
-    });
-
-    expect(cfg?.redaction).toEqual({
-      enabled: true,
-      redactInputMessages: true,
-      redactEmailAddresses: true,
-    });
-  });
-
-  it("env vars override file values (falsy aliases)", () => {
-    process.env.SIGIL_PI_REDACTION_ENABLED = "0";
-    process.env.SIGIL_PI_REDACT_INPUT_MESSAGES = "false";
-    process.env.SIGIL_PI_REDACT_EMAIL_ADDRESSES = "off";
-
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      redaction: {
-        enabled: true,
-        redactInputMessages: true,
-        redactEmailAddresses: true,
-      },
-    });
-
-    expect(cfg?.redaction).toEqual({
-      enabled: false,
-      redactInputMessages: false,
-      redactEmailAddresses: false,
-    });
-  });
-
-  it("accepts 'on' as truthy alias", () => {
-    process.env.SIGIL_PI_REDACTION_ENABLED = "on";
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      redaction: { enabled: false },
-    });
-    expect(cfg?.redaction.enabled).toBe(true);
-  });
-
-  it("accepts 'no' as falsy alias", () => {
-    process.env.SIGIL_PI_REDACT_INPUT_MESSAGES = "no";
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-    });
-    expect(cfg?.redaction.redactInputMessages).toBe(false);
   });
 });
 
@@ -589,9 +254,8 @@ describe("resolveConfig guards", () => {
   afterEach(clearEnv);
 
   it("defaults to disabled with 1500ms timeout and fail-open=true", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-    });
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    const cfg = resolveConfig();
     expect(cfg?.guards).toEqual({
       enabled: false,
       timeoutMs: 1500,
@@ -599,11 +263,14 @@ describe("resolveConfig guards", () => {
     });
   });
 
-  it("reads file-level guards block", () => {
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      guards: { enabled: true, timeoutMs: 2500, failOpen: false },
-    });
+  it("env values populate the guards block", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_GUARDS_ENABLED = "true";
+    process.env.SIGIL_GUARDS_TIMEOUT_MS = "2500";
+    process.env.SIGIL_GUARDS_FAIL_OPEN = "false";
+
+    const cfg = resolveConfig();
+
     expect(cfg?.guards).toEqual({
       enabled: true,
       timeoutMs: 2500,
@@ -611,45 +278,18 @@ describe("resolveConfig guards", () => {
     });
   });
 
-  it("env overrides file values", () => {
-    process.env.SIGIL_GUARDS_ENABLED = "true";
-    process.env.SIGIL_GUARDS_TIMEOUT_MS = "1500";
-    process.env.SIGIL_GUARDS_FAIL_OPEN = "true";
-
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      guards: { enabled: false, timeoutMs: 2500, failOpen: false },
-    });
-
-    expect(cfg?.guards).toEqual({
-      enabled: true,
-      timeoutMs: 1500,
-      failOpen: true,
-    });
-  });
-
   it("enables guards via canonical env var only", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.SIGIL_GUARDS_ENABLED = "true";
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-    });
+    const cfg = resolveConfig();
     expect(cfg?.guards.enabled).toBe(true);
-  });
-
-  it("does not recognise the pi-prefixed alias", () => {
-    process.env.SIGIL_PI_GUARDS_ENABLED = "true";
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-    });
-    expect(cfg?.guards.enabled).toBe(false);
   });
 
   it("warns and falls back to default when SIGIL_GUARDS_ENABLED is not a boolean", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.SIGIL_GUARDS_ENABLED = "maybe";
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-    });
+    const cfg = resolveConfig();
     expect(cfg).not.toBeNull();
     expect(cfg?.guards.enabled).toBe(false);
     expect(warn).toHaveBeenCalledWith(
@@ -660,10 +300,9 @@ describe("resolveConfig guards", () => {
 
   it("warns and falls back to default when SIGIL_GUARDS_TIMEOUT_MS is not numeric", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.SIGIL_GUARDS_TIMEOUT_MS = "fast";
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-    });
+    const cfg = resolveConfig();
     expect(cfg).not.toBeNull();
     expect(cfg?.guards.timeoutMs).toBe(1500);
     expect(warn).toHaveBeenCalledWith(
@@ -676,10 +315,9 @@ describe("resolveConfig guards", () => {
 
   it("rejects SIGIL_GUARDS_TIMEOUT_MS=0 so the SDK does not fall back to its 15s default", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.SIGIL_GUARDS_TIMEOUT_MS = "0";
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-    });
+    const cfg = resolveConfig();
     expect(cfg?.guards.timeoutMs).toBe(1500);
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -689,25 +327,11 @@ describe("resolveConfig guards", () => {
     warn.mockRestore();
   });
 
-  it("rejects guards.timeoutMs=0 from the file config", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      guards: { timeoutMs: 0 },
-    });
-    expect(cfg?.guards.timeoutMs).toBe(1500);
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("invalid integer value for guards.* file entry"),
-    );
-    warn.mockRestore();
-  });
-
   it("warns and falls back to default when SIGIL_GUARDS_FAIL_OPEN is not a boolean", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.SIGIL_GUARDS_FAIL_OPEN = "sometimes";
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-    });
+    const cfg = resolveConfig();
     expect(cfg).not.toBeNull();
     expect(cfg?.guards.failOpen).toBe(true);
     expect(warn).toHaveBeenCalledWith(
@@ -719,31 +343,12 @@ describe("resolveConfig guards", () => {
   });
 
   it("supports truthy aliases (on, yes, 1) for env vars", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.SIGIL_GUARDS_ENABLED = "on";
     process.env.SIGIL_GUARDS_FAIL_OPEN = "no";
-    const cfg = resolveConfig({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-    });
+    const cfg = resolveConfig();
     expect(cfg?.guards.enabled).toBe(true);
     expect(cfg?.guards.failOpen).toBe(false);
-  });
-});
-
-describe("resolveEnvVars", () => {
-  beforeEach(clearEnv);
-  afterEach(clearEnv);
-
-  it("replaces ${VAR} with env value", () => {
-    process.env.MY_TOKEN = "secret-123";
-    expect(resolveEnvVars("Bearer ${MY_TOKEN}")).toBe("Bearer secret-123");
-  });
-
-  it("replaces missing vars with empty string", () => {
-    expect(resolveEnvVars("${NONEXISTENT}")).toBe("");
-  });
-
-  it("leaves strings without vars unchanged", () => {
-    expect(resolveEnvVars("plain-value")).toBe("plain-value");
   });
 });
 
@@ -754,11 +359,9 @@ describe("loadConfig reads ~/.config/sigil/config.env", () => {
   beforeEach(() => {
     clearEnv();
     dir = mkdtempSync(join(tmpdir(), "sigil-pi-loadconfig-"));
-    // Redirect both XDG_CONFIG_HOME and HOME at the tmpdir. config.ts resolves
-    // the JSON config path lazily via homedir(), which reads $HOME on POSIX,
-    // so this redirect actually moves the JSON path off the developer's real
-    // home and onto $tmpdir/.config/sigil-pi/config.json (which doesn't
-    // exist). The dotenv loader becomes the only source of credentials.
+    // Redirect both XDG_CONFIG_HOME and HOME at the tmpdir so the dotenv
+    // loader's lazy homedir() lookup follows. The dotenv file becomes the
+    // only source of credentials.
     process.env.XDG_CONFIG_HOME = dir;
     homeBackup = process.env.HOME;
     process.env.HOME = dir;
@@ -789,9 +392,21 @@ describe("loadConfig reads ~/.config/sigil/config.env", () => {
     expect(cfg?.endpoint).toBe("https://sigil.example.com");
     expect(cfg?.auth).toEqual({
       mode: "basic",
-      user: "tenant-1",
-      password: "glc_token",
+      basicUser: "tenant-1",
+      basicPassword: "glc_token",
       tenantId: "tenant-1",
     });
+  });
+
+  it("ignores a stray ~/.config/sigil-pi/config.json on disk", async () => {
+    const legacyDir = join(dir, "sigil-pi");
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(
+      join(legacyDir, "config.json"),
+      JSON.stringify({ endpoint: "http://legacy:9090" }),
+    );
+
+    const cfg = await loadConfig();
+    expect(cfg).toBeNull();
   });
 });

--- a/plugins/pi/src/config.ts
+++ b/plugins/pi/src/config.ts
@@ -1,25 +1,18 @@
-import { readFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import type { ContentCaptureMode } from "@grafana/sigil-sdk-js";
-import { isMissingFileError } from "./fsErrors.js";
 import { applySigilDotenv } from "./sigilDotenv.js";
 
 export type SigilAuthConfig =
-  | { mode: "bearer"; bearerToken: string }
-  | { mode: "tenant"; tenantId: string }
-  | { mode: "basic"; user: string; password: string; tenantId: string }
+  | {
+      mode: "basic";
+      basicUser: string;
+      basicPassword: string;
+      tenantId: string;
+    }
   | { mode: "none" };
 
 export interface OtlpConfig {
   endpoint: string;
   headers: Record<string, string>;
-}
-
-export interface RedactionConfig {
-  enabled: boolean;
-  redactInputMessages: boolean;
-  redactEmailAddresses: boolean;
 }
 
 export interface GuardsFeatureConfig {
@@ -35,282 +28,96 @@ export interface SigilPiConfig {
   agentVersion?: string;
   contentCapture: ContentCaptureMode;
   debug: boolean;
+  redactInputMessages: boolean;
   otlp?: OtlpConfig;
-  redaction: RedactionConfig;
   guards: GuardsFeatureConfig;
 }
 
-// Resolved lazily so tests can redirect $HOME at runtime and the loader
-// follows. Keeping this as a module-level `const` would pin the path to the
-// value at import time and silently bypass test redirection.
-function configPath(): string {
-  return join(homedir(), ".config", "sigil-pi", "config.json");
-}
-
 export async function loadConfig(): Promise<SigilPiConfig | null> {
-  // Read the shared sigil dotenv file before anything else so plain `pi` and
-  // `sigil pi --` resolve credentials from the same place. Values in
-  // process.env always win — applySigilDotenv only fills empty/whitespace
-  // entries — so an explicit shell export still overrides the file.
+  // Read the shared sigil dotenv file so plain `pi` and `sigil pi --` resolve
+  // credentials from the same place. Values in process.env always win —
+  // applySigilDotenv only fills empty/whitespace entries.
   applySigilDotenv();
-
-  let fileConfig: Record<string, unknown> = {};
-  try {
-    const raw = await readFile(configPath(), "utf-8");
-    fileConfig = parseConfig(raw);
-  } catch (err) {
-    if (!isMissingFileError(err)) {
-      console.warn(
-        "[sigil-pi] failed to read config file, falling back to env vars:",
-        err,
-      );
-    }
-  }
-
-  return resolveConfig(fileConfig);
+  return resolveConfig();
 }
 
-export function resolveConfig(
-  file: Record<string, unknown>,
-): SigilPiConfig | null {
-  // Canonical SIGIL_* env vars (shared with claude-code/codex/cursor) take
-  // precedence over the legacy SIGIL_PI_* prefix so a single config.env can
-  // drive every agent. `loadConfig` reads the shared config.env into
-  // process.env via applySigilDotenv() before this resolver runs, with the
-  // OS-env-wins rule: a non-empty shell export beats the file. The
-  // pi-specific names remain as a fallback so users who already configured
-  // them keep working.
-  const endpoint = normalizeBaseEndpoint(
-    (
-      env("SIGIL_ENDPOINT") ??
-      env("SIGIL_PI_ENDPOINT") ??
-      asString(file.endpoint) ??
-      ""
-    ).trim(),
-  );
+export function resolveConfig(): SigilPiConfig | null {
+  const endpoint = normalizeBaseEndpoint((env("SIGIL_ENDPOINT") ?? "").trim());
   if (!endpoint) return null;
 
-  const auth = resolveAuth(file);
-  if (!auth) return null;
-
-  const configuredAgentName = (
-    env("SIGIL_AGENT_NAME") ??
-    env("SIGIL_PI_AGENT_NAME") ??
-    asString(file.agentName) ??
-    "pi"
-  ).trim();
+  const configuredAgentName = (env("SIGIL_AGENT_NAME") ?? "pi").trim();
   const agentName = configuredAgentName.length > 0 ? configuredAgentName : "pi";
 
-  const configuredAgentVersion = (
-    env("SIGIL_AGENT_VERSION") ??
-    env("SIGIL_PI_AGENT_VERSION") ??
-    asString(file.agentVersion) ??
-    ""
-  ).trim();
+  const configuredAgentVersion = (env("SIGIL_AGENT_VERSION") ?? "").trim();
   const agentVersion =
     configuredAgentVersion.length > 0 ? configuredAgentVersion : undefined;
 
-  const contentCapture = resolveContentCapture(file);
-
-  const debug =
-    envBool("SIGIL_DEBUG") ??
-    envBool("SIGIL_PI_DEBUG") ??
-    toBool(file.debug) ??
-    false;
-
-  const otlp = resolveOtlp(file);
-  const redaction = resolveRedaction(file);
-  const guards = resolveGuards(file);
+  const contentCapture = resolveContentCapture();
+  const debug = envBool("SIGIL_DEBUG") ?? false;
+  const redactInputMessages = envBoolOr("SIGIL_REDACT_INPUT_MESSAGES", true);
 
   return {
     endpoint,
-    auth,
+    auth: resolveAuth(),
     agentName,
     agentVersion,
     contentCapture,
     debug,
-    otlp,
-    redaction,
-    guards,
+    redactInputMessages,
+    otlp: resolveOtlp(),
+    guards: resolveGuards(),
   };
 }
 
-function resolveGuards(file: Record<string, unknown>): GuardsFeatureConfig {
-  const guardsObj = (file.guards ?? {}) as Record<string, unknown>;
-
-  const enabled = resolveGuardsBool(
-    "SIGIL_GUARDS_ENABLED",
-    guardsObj.enabled,
-    false,
-  );
-  const timeoutMs = resolveGuardsInt(
-    "SIGIL_GUARDS_TIMEOUT_MS",
-    guardsObj.timeoutMs,
-    1500,
-  );
-  const failOpen = resolveGuardsBool(
-    "SIGIL_GUARDS_FAIL_OPEN",
-    guardsObj.failOpen,
-    true,
-  );
-
-  return { enabled, timeoutMs, failOpen };
+function resolveAuth(): SigilAuthConfig {
+  const tenant = (env("SIGIL_AUTH_TENANT_ID") ?? "").trim();
+  const token = (env("SIGIL_AUTH_TOKEN") ?? "").trim();
+  if (tenant && token) {
+    return {
+      mode: "basic",
+      basicUser: tenant,
+      basicPassword: token,
+      tenantId: tenant,
+    };
+  }
+  return { mode: "none" };
 }
 
-function resolveGuardsBool(
-  envKey: string,
-  fileValue: unknown,
-  defaultValue: boolean,
-): boolean {
-  const rawEnv = env(envKey);
-  if (rawEnv !== undefined) {
-    const parsed = toBool(rawEnv);
-    if (parsed === undefined) {
-      console.warn(
-        `[sigil-pi] invalid boolean value for ${envKey}: "${rawEnv}" — using default ${defaultValue}`,
-      );
-      return defaultValue;
-    }
-    return parsed;
-  }
-  if (fileValue !== undefined) {
-    const parsed = toBool(fileValue);
-    if (parsed === undefined) {
-      console.warn(
-        `[sigil-pi] invalid boolean value for guards.* file entry — using default ${defaultValue}`,
-      );
-      return defaultValue;
-    }
-    return parsed;
-  }
-  return defaultValue;
-}
-
-function resolveGuardsInt(
-  envKey: string,
-  fileValue: unknown,
-  defaultValue: number,
-): number {
-  // 0 is rejected: the SDK interprets timeoutMs <= 0 as "use built-in default
-  // (15000ms)", which would silently override the plugin's documented 1500ms.
-  const rawEnv = env(envKey);
-  if (rawEnv !== undefined) {
-    const n = Number(rawEnv);
-    if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
-      console.warn(
-        `[sigil-pi] invalid integer value for ${envKey}: "${rawEnv}" — using default ${defaultValue}`,
-      );
-      return defaultValue;
-    }
-    return n;
-  }
-  if (fileValue !== undefined) {
-    if (
-      typeof fileValue !== "number" ||
-      !Number.isInteger(fileValue) ||
-      fileValue <= 0
-    ) {
-      console.warn(
-        `[sigil-pi] invalid integer value for guards.* file entry — using default ${defaultValue}`,
-      );
-      return defaultValue;
-    }
-    return fileValue;
-  }
-  return defaultValue;
-}
-
-function resolveRedaction(file: Record<string, unknown>): RedactionConfig {
-  const redactionObj = (file.redaction ?? {}) as Record<string, unknown>;
-
-  const enabled =
-    envBool("SIGIL_PI_REDACTION_ENABLED") ??
-    toBool(redactionObj.enabled) ??
-    true;
-
-  const redactInputMessages =
-    envBool("SIGIL_PI_REDACT_INPUT_MESSAGES") ??
-    toBool(redactionObj.redactInputMessages) ??
-    true;
-
-  const redactEmailAddresses =
-    envBool("SIGIL_PI_REDACT_EMAIL_ADDRESSES") ??
-    toBool(redactionObj.redactEmailAddresses) ??
-    true;
-
-  return { enabled, redactInputMessages, redactEmailAddresses };
-}
-
-function resolveOtlp(file: Record<string, unknown>): OtlpConfig | undefined {
-  const otlpObj = (file.otlp ?? {}) as Record<string, unknown>;
-
-  // Endpoint precedence: canonical sigil override > standard OTel env var >
-  // legacy SIGIL_PI_OTLP_ENDPOINT > file config.
+function resolveOtlp(): OtlpConfig | undefined {
   const endpoint = (
     env("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT") ??
     env("OTEL_EXPORTER_OTLP_ENDPOINT") ??
-    env("SIGIL_PI_OTLP_ENDPOINT") ??
-    asString(otlpObj.endpoint) ??
     ""
   ).trim();
   if (!endpoint) return undefined;
 
   const headers: Record<string, string> = {};
-
-  // Support explicit headers object
-  if (otlpObj.headers && typeof otlpObj.headers === "object") {
-    for (const [k, v] of Object.entries(
-      otlpObj.headers as Record<string, unknown>,
-    )) {
-      if (typeof v === "string") {
-        headers[k] = resolveEnvVars(v);
-      }
-    }
-  }
-
-  // Support basic auth shorthand (Grafana Cloud pattern)
-  const basicUser = resolveEnvVars(
-    env("SIGIL_PI_OTLP_BASIC_USER") ?? asString(otlpObj.basicUser) ?? "",
+  const tenant = (env("SIGIL_AUTH_TENANT_ID") ?? "").trim();
+  const token = (
+    env("SIGIL_OTEL_AUTH_TOKEN") ??
+    env("SIGIL_AUTH_TOKEN") ??
+    ""
   ).trim();
-  const basicPassword = resolveEnvVars(
-    env("SIGIL_PI_OTLP_BASIC_PASSWORD") ??
-      asString(otlpObj.basicPassword) ??
-      "",
-  ).trim();
-
-  if (basicUser && basicPassword && !headers.Authorization) {
-    const encoded = Buffer.from(`${basicUser}:${basicPassword}`).toString(
-      "base64",
-    );
-    headers.Authorization = `Basic ${encoded}`;
+  if (tenant && token) {
+    headers.Authorization = `Basic ${Buffer.from(`${tenant}:${token}`).toString("base64")}`;
   }
-
-  const bearerToken = resolveEnvVars(
-    env("SIGIL_PI_OTLP_BEARER_TOKEN") ?? asString(otlpObj.bearerToken) ?? "",
-  ).trim();
-  if (bearerToken && !headers.Authorization) {
-    headers.Authorization = `Bearer ${bearerToken}`;
-  }
-
-  // Final fallback: synthesise Basic auth from the canonical SIGIL_* creds,
-  // matching the consolidated sigil binary's behaviour. SIGIL_OTEL_AUTH_TOKEN
-  // overrides the auth token for OTel only (parity with sigil README).
-  if (!headers.Authorization) {
-    const canonicalTenant = (env("SIGIL_AUTH_TENANT_ID") ?? "").trim();
-    const canonicalToken = (
-      env("SIGIL_OTEL_AUTH_TOKEN") ??
-      env("SIGIL_AUTH_TOKEN") ??
-      ""
-    ).trim();
-    if (canonicalTenant && canonicalToken) {
-      const encoded = Buffer.from(
-        `${canonicalTenant}:${canonicalToken}`,
-      ).toString("base64");
-      headers.Authorization = `Basic ${encoded}`;
-    }
-  }
-
   return { endpoint, headers };
+}
+
+function resolveContentCapture(): ContentCaptureMode {
+  const envVal = env("SIGIL_CONTENT_CAPTURE_MODE");
+  if (envVal !== undefined) {
+    return parseContentCaptureMode(envVal);
+  }
+  return "metadata_only";
+}
+
+function resolveGuards(): GuardsFeatureConfig {
+  return {
+    enabled: envBoolOr("SIGIL_GUARDS_ENABLED", false),
+    timeoutMs: envPositiveIntOr("SIGIL_GUARDS_TIMEOUT_MS", 1500),
+    failOpen: envBoolOr("SIGIL_GUARDS_FAIL_OPEN", true),
+  };
 }
 
 const VALID_CAPTURE_MODES: ContentCaptureMode[] = [
@@ -318,27 +125,6 @@ const VALID_CAPTURE_MODES: ContentCaptureMode[] = [
   "no_tool_content",
   "metadata_only",
 ];
-
-function resolveContentCapture(
-  file: Record<string, unknown>,
-): ContentCaptureMode {
-  // Canonical name (shared with other sigil adapters) wins over the legacy
-  // pi-specific one.
-  const envVal =
-    env("SIGIL_CONTENT_CAPTURE_MODE") ?? env("SIGIL_PI_CONTENT_CAPTURE");
-  if (envVal !== undefined) {
-    return parseContentCaptureMode(envVal);
-  }
-  if (file.contentCapture !== undefined) {
-    if (typeof file.contentCapture === "boolean") {
-      return file.contentCapture ? "full" : "metadata_only";
-    }
-    if (typeof file.contentCapture === "string") {
-      return parseContentCaptureMode(file.contentCapture);
-    }
-  }
-  return "metadata_only";
-}
 
 function parseContentCaptureMode(value: string): ContentCaptureMode {
   const normalized = value.trim().toLowerCase();
@@ -353,104 +139,6 @@ function parseContentCaptureMode(value: string): ContentCaptureMode {
   return "metadata_only";
 }
 
-function resolveAuth(file: Record<string, unknown>): SigilAuthConfig | null {
-  const explicitMode =
-    env("SIGIL_PI_AUTH_MODE") ??
-    asString((file.auth as Record<string, unknown> | undefined)?.mode);
-
-  // Canonical SIGIL_AUTH_TENANT_ID + SIGIL_AUTH_TOKEN pattern: when neither
-  // the env nor the file picks an explicit auth mode, treat the canonical
-  // pair as Grafana Cloud basic auth (tenant as user, token as password).
-  // This matches the implicit contract used by claude-code/codex/cursor.
-  if (explicitMode === undefined) {
-    const canonicalTenant = (env("SIGIL_AUTH_TENANT_ID") ?? "").trim();
-    const canonicalToken = (env("SIGIL_AUTH_TOKEN") ?? "").trim();
-    if (canonicalTenant && canonicalToken) {
-      return {
-        mode: "basic",
-        user: canonicalTenant,
-        password: canonicalToken,
-        tenantId: canonicalTenant,
-      };
-    }
-  }
-
-  const mode = (explicitMode ?? "none").trim().toLowerCase();
-
-  const authObj = (file.auth ?? {}) as Record<string, unknown>;
-
-  switch (mode) {
-    case "bearer": {
-      const token = resolveEnvVars(
-        env("SIGIL_PI_BEARER_TOKEN") ?? asString(authObj.bearerToken) ?? "",
-      ).trim();
-      if (!token) {
-        console.warn(
-          "[sigil-pi] auth mode bearer requires bearerToken — disabling",
-        );
-        return null;
-      }
-      return { mode: "bearer", bearerToken: token };
-    }
-    case "tenant": {
-      const tenantId = resolveEnvVars(
-        env("SIGIL_PI_TENANT_ID") ?? asString(authObj.tenantId) ?? "",
-      ).trim();
-      if (!tenantId) {
-        console.warn(
-          "[sigil-pi] auth mode tenant requires tenantId — disabling",
-        );
-        return null;
-      }
-      return { mode: "tenant", tenantId };
-    }
-    case "basic": {
-      const user = resolveEnvVars(
-        env("SIGIL_PI_BASIC_USER") ?? asString(authObj.user) ?? "",
-      ).trim();
-      const password = resolveEnvVars(
-        env("SIGIL_PI_BASIC_PASSWORD") ?? asString(authObj.password) ?? "",
-      ).trim();
-
-      if (!user || !password) {
-        console.warn(
-          "[sigil-pi] auth mode basic requires user and password — disabling",
-        );
-        return null;
-      }
-
-      const tenantId =
-        resolveEnvVars(
-          env("SIGIL_PI_TENANT_ID") ?? asString(authObj.tenantId) ?? "",
-        ).trim() || user;
-
-      return {
-        mode: "basic",
-        user,
-        password,
-        tenantId,
-      };
-    }
-    case "none":
-      return { mode: "none" };
-    default:
-      console.warn(`[sigil-pi] unsupported auth mode "${mode}" — disabling`);
-      return null;
-  }
-}
-
-export function resolveEnvVars(value: string): string {
-  return value.replace(/\$\{(\w+)\}/g, (_match, name) => {
-    const resolved = process.env[name as string];
-    if (resolved === undefined) {
-      console.warn(
-        `[sigil-pi] env var \${${name}} is not set, resolving to empty string`,
-      );
-    }
-    return resolved ?? "";
-  });
-}
-
 function env(key: string): string | undefined {
   const v = process.env[key];
   return v !== undefined && v !== "" ? v : undefined;
@@ -461,8 +149,32 @@ function envBool(key: string): boolean | undefined {
   return v !== undefined ? toBool(v) : undefined;
 }
 
-function asString(v: unknown): string | undefined {
-  return typeof v === "string" ? v : undefined;
+function envBoolOr(envKey: string, defaultValue: boolean): boolean {
+  const raw = env(envKey);
+  if (raw === undefined) return defaultValue;
+  const parsed = toBool(raw);
+  if (parsed === undefined) {
+    console.warn(
+      `[sigil-pi] invalid boolean value for ${envKey}: "${raw}" — using default ${defaultValue}`,
+    );
+    return defaultValue;
+  }
+  return parsed;
+}
+
+function envPositiveIntOr(envKey: string, defaultValue: number): number {
+  // 0 is rejected: the SDK interprets timeoutMs <= 0 as "use built-in default
+  // (15000ms)", which would silently override the plugin's documented 1500ms.
+  const raw = env(envKey);
+  if (raw === undefined) return defaultValue;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
+    console.warn(
+      `[sigil-pi] invalid integer value for ${envKey}: "${raw}" — using default ${defaultValue}`,
+    );
+    return defaultValue;
+  }
+  return n;
 }
 
 function toBool(v: unknown): boolean | undefined {
@@ -474,14 +186,6 @@ function toBool(v: unknown): boolean | undefined {
   if (["0", "false", "no", "off"].includes(normalized)) return false;
 
   return undefined;
-}
-
-function parseConfig(raw: string): Record<string, unknown> {
-  const parsed: unknown = JSON.parse(raw);
-  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error("config must be a JSON object");
-  }
-  return parsed as Record<string, unknown>;
 }
 
 export const EXPORT_PATH = "/api/v1/generations:export";
@@ -502,8 +206,6 @@ function normalizeBaseEndpoint(endpoint: string): string {
       pathname = pathname.slice(0, pathname.length - EXPORT_PATH.length);
     }
     url.pathname = pathname;
-    // URL preserves a trailing "/" when pathname is empty; strip it for a
-    // tidy stored value ("http://host" rather than "http://host/").
     return url.toString().replace(/\/+$/, "");
   } catch {
     const trimmed = endpoint.replace(/\/+$/, "");

--- a/plugins/pi/src/sigilDotenv.ts
+++ b/plugins/pi/src/sigilDotenv.ts
@@ -110,8 +110,8 @@ function readSigilDotenv(path: string): SigilDotenvReadResult {
 /**
  * Read and parse the dotenv file at `path`. Missing files return `{}`
  * silently — the dotenv config is optional and credentials may come from
- * other sources (shell env, sigil-pi/config.json). Other read failures emit a
- * single `[sigil-pi]` warning and also return `{}`.
+ * other sources (shell env). Other read failures emit a single `[sigil-pi]`
+ * warning and also return `{}`.
  */
 export function loadSigilDotenv(path: string): Record<string, string> {
   return readSigilDotenv(path).env;

--- a/plugins/pi/src/testEnv.ts
+++ b/plugins/pi/src/testEnv.ts
@@ -1,9 +1,9 @@
 import { resetSigilDotenvStateForTests } from "./sigilDotenv.js";
 
 /**
- * Reset every SIGIL_*, SIGIL_PI_*, OTEL_* env var and XDG_CONFIG_HOME between
- * test cases so on-disk fixtures (config.env, JSON config) and shell exports
- * cannot leak across cases. Used by both config.test.ts and sigilDotenv.test.ts.
+ * Reset every SIGIL_* and OTEL_* env var and XDG_CONFIG_HOME between test
+ * cases so on-disk fixtures (config.env) and shell exports cannot leak across
+ * cases. Used by both config.test.ts and sigilDotenv.test.ts.
  *
  * Also clears the dotenv loader's per-process "owned keys" tracking so a
  * test that calls applySigilDotenv doesn't poison the next case's view of
@@ -11,11 +11,7 @@ import { resetSigilDotenvStateForTests } from "./sigilDotenv.js";
  */
 export function clearSigilEnv(): void {
   for (const key of Object.keys(process.env)) {
-    if (
-      key.startsWith("SIGIL_PI_") ||
-      key.startsWith("SIGIL_") ||
-      key.startsWith("OTEL_")
-    ) {
+    if (key.startsWith("SIGIL_") || key.startsWith("OTEL_")) {
       delete process.env[key];
     }
   }


### PR DESCRIPTION
Remove `SIGIL_PI_*` and the old config file (`~/.config/sigil-pi`). These env vars and files were used before SDKs started to support the same `SIGIL_*` variables and the centralized config file at `~/.config/sigil/`.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Breaking change for anyone still on `sigil-pi/config.json`, `SIGIL_PI_*`, or bearer/tenant auth modes; misconfigured partial credentials now export with no auth instead of failing loudly in some cases.
> 
> **Overview**
> The Pi plugin **drops `~/.config/sigil-pi/config.json` and all `SIGIL_PI_*` overrides**, so configuration is only **`SIGIL_*` / `OTEL_*` env vars** plus the shared **`~/.config/sigil/config.env`** loader (aligned with other Sigil agents).
> 
> **Auth and export wiring are simplified:** credentials come from **`SIGIL_AUTH_TENANT_ID` + `SIGIL_AUTH_TOKEN`** (both required for Basic auth; otherwise `none`). Bearer/tenant modes and JSON `${ENV}` interpolation are removed. The SDK gets **`basicUser` / `basicPassword`** directly (no `mapAuth`). OTLP uses canonical endpoints and synthesizes Basic auth from the same tenant/token pair, with **`SIGIL_OTEL_AUTH_TOKEN`** overriding the token for OTLP only.
> 
> **Redaction** is no longer a nested `redaction.enabled` block: secret sanitization always runs, with **`SIGIL_REDACT_INPUT_MESSAGES`** (default on) controlling user-message scrubbing. Docs and tests are updated accordingly, including a test that legacy **`config.json` is ignored**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 318760b83c84eb420b11332694311219253ce674. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->