### PR TITLE
test(plugins): remove redundant loop variable copies

### DIFF
--- a/plugins/sigil/cmd/sigil/golden_integration_test.go
+++ b/plugins/sigil/cmd/sigil/golden_integration_test.go
@@ -108,7 +108,6 @@ type goldenExport struct {
 
 func TestGoldenIntegration(t *testing.T) {
 	for _, name := range goldenScenarioNames(t) {
-		name := name
 		t.Run(name, func(t *testing.T) {
 			runGoldenScenario(t, name)
 		})
@@ -367,7 +366,6 @@ func TestSplitEventEnv(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var evt map[string]json.RawMessage
 			if err := json.Unmarshal([]byte(tt.raw), &evt); err != nil {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only cleanup with no production or assertion logic changes.
> 
> **Overview**
> Removes legacy **`name := name`** and **`tt := tt`** shadow copies in `golden_integration_test.go` before `t.Run` subtests in **`TestGoldenIntegration`** and **`TestSplitEventEnv`**.
> 
> Those lines were only needed on Go versions before 1.22, where range loop variables were reused and closures could see the wrong iteration. With the module on **Go 1.25**, each subtest already closes over the correct `name` / `tt` with no behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bdd049f4e1e82aff079aac22d2cf8cacd810544. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->