### PR TITLE
docs(plugins): lead with sigil launcher, hide manual install

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -14,7 +14,7 @@ sigil copilot    # for Copilot CLI
 sigil pi         # for pi
 ```
 
-The launcher installs the plugin on first run. Add your credentials to `~/.config/sigil/config.env` — see any per-agent README for the 3-page Grafana Cloud walkthrough.
+Use the `sigil <agent>` launcher for setup and daily use. On first run it installs the agent plugin or extension, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches the agent.
 
 ## All plugins
 
@@ -27,4 +27,4 @@ The launcher installs the plugin on first run. Add your credentials to `~/.confi
 | [OpenCode](https://opencode.ai) | [`opencode/`](opencode/) | Available |
 | [Pi](https://github.com/badlogic/pi) | [`pi/`](pi/) | Available |
 
-Claude Code, Codex, Copilot, and Cursor share the same Go binary (`brew install grafana/grafana/sigil`) and the same config file (`~/.config/sigil/config.env`). All Sigil connection details live at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`.
+Plugins backed by the `sigil` launcher share one config file at `~/.config/sigil/config.env`. The launcher creates or updates it on first run; `sigil login` re-runs the same prompt later. Cursor has no launcher, so register its plugin in-app and run `sigil login` once for the shared config. OpenCode uses its own JSON config.

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -2,30 +2,28 @@
 
 Sends every Claude Code turn to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/): model, tokens, tools, timing, and optionally the conversation content.
 
-## 1. Install
+## 1. Install and launch
 
 ```sh
 brew install grafana/grafana/sigil
-```
-
-## 2. Register the plugin
-
-Either run:
-
-```sh
 sigil claude
 ```
 
-…which installs the `sigil-cc` plugin on first run and launches Claude Code. Or from inside Claude Code:
+`sigil claude` registers the `sigil-cc` plugin on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches Claude Code.
+
+<details>
+<summary>Manual plugin registration</summary>
 
 ```
 /plugin marketplace add grafana/sigil-sdk
 /plugin install sigil-cc@grafana-sigil
 ```
 
-## 3. Add your credentials
+</details>
 
-All Sigil connection details live at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure AI Observability is enabled on your stack — an administrator opens **Observability → AI Observability** once and accepts the terms.
+## 2. Credentials
+
+When `sigil claude` prompts, copy values from `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure AI Observability is enabled on your stack — an administrator opens **Observability → AI Observability** once and accepts the terms.
 
 You need values from three Grafana Cloud pages:
 
@@ -40,7 +38,12 @@ You need values from three Grafana Cloud pages:
 3. **Grafana Cloud Portal → your stack → OpenTelemetry card**
    - **OTLP endpoint URL** → `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT`
 
-Save them to `~/.config/sigil/config.env` (shared by all three host plugins):
+Run `sigil login` later to update saved credentials.
+
+<details>
+<summary>Non-interactive config.env</summary>
+
+Create or update `~/.config/sigil/config.env`:
 
 ```dotenv
 SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
@@ -49,20 +52,22 @@ SIGIL_AUTH_TOKEN=glc_...
 SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
 ```
 
-To also send the conversation text (with automatic secret redaction), add:
+</details>
+
+To also send the conversation text (with automatic secret redaction), add this to `~/.config/sigil/config.env`:
 
 ```dotenv
 SIGIL_CONTENT_CAPTURE_MODE=full
 ```
 
-## 4. Verify
+## 3. Verify
 
 Run any turn in Claude Code, then open **AI Observability → Conversations** in Grafana Cloud. A new generation should appear within a few seconds.
 
 If nothing shows up:
 
 ```sh
-SIGIL_DEBUG=true claude  # one turn
+SIGIL_DEBUG=true sigil claude  # one turn
 tail -f ~/.local/state/sigil/logs/sigil.log
 ```
 
@@ -86,4 +91,4 @@ Common culprits: `sigil --version` doesn't work (binary not on `PATH`), a missin
 | `SIGIL_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |
 | `SIGIL_GUARDS_TIMEOUT_MS` | `1500` | Per-call timeout. Lower = less added latency on every tool call, higher = better tolerance for slow `llm_judge` evaluators. |
 
-If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>` manually instead of relying on the auto-synthesised auth.
+If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>`.

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -4,30 +4,26 @@ Sends Codex turns to [Grafana AI Observability](https://grafana.com/docs/grafana
 
 > Experimental. Codex hooks and plugin lifecycle config are still feature-flagged.
 
-## 1. Install
+## 1. Install and launch
 
 ```sh
 brew install grafana/grafana/sigil
-```
-
-## 2. Register the plugin
-
-```sh
 sigil codex
 ```
 
-The launcher resolves `codex` on `PATH`, registers `sigil-codex@grafana-sigil` with codex on first run, then execs codex. On first launch only, open `/hooks` inside codex and trust each `sigil-codex@grafana-sigil` hook — codex requires manual review on install.
+`sigil codex` registers `sigil-codex@grafana-sigil` on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches Codex.
 
-### Manual setup
+On first launch only, open `/hooks` inside Codex and trust each `sigil-codex@grafana-sigil` hook. Codex requires this manual review after plugin install.
 
-If you'd rather drive codex's plugin store yourself (or are on an older build where the launcher's auto-install does not work), the same flow with codex's verbs:
+<details>
+<summary>Manual plugin registration</summary>
 
 ```sh
 codex plugin marketplace add grafana/sigil-sdk
 codex plugin add sigil-codex@grafana-sigil
 ```
 
-On current codex builds the `hooks` and `plugin_hooks` features are stable by default (`codex features list` confirms this), so no config.toml edits are needed. Older builds gated this on feature flags — if `/hooks` is empty after install, add the following to `~/.codex/config.toml`:
+On current Codex builds the `hooks` and `plugin_hooks` features are stable by default (`codex features list` confirms this), so no `config.toml` edits are needed. Older builds gated this on feature flags — if `/hooks` is empty after install, add the following to `~/.codex/config.toml`:
 
 ```toml
 [plugins."sigil-codex@grafana-sigil"]
@@ -41,9 +37,11 @@ Older Codex builds use `hooks = true` and `plugin_hooks = true` instead of `code
 
 Restart Codex, open `/hooks`, and trust the four `sigil-codex@grafana-sigil` hooks (first-run review is expected).
 
-## 3. Add your credentials
+</details>
 
-All Sigil connection details live at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure AI Observability is enabled on your stack — an administrator opens **Observability → AI Observability** once and accepts the terms.
+## 2. Credentials
+
+When `sigil codex` prompts, copy values from `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure AI Observability is enabled on your stack — an administrator opens **Observability → AI Observability** once and accepts the terms.
 
 You need values from three Grafana Cloud pages:
 
@@ -58,7 +56,12 @@ You need values from three Grafana Cloud pages:
 3. **Grafana Cloud Portal → your stack → OpenTelemetry card**
    - **OTLP endpoint URL** → `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT`
 
-Save them to `~/.config/sigil/config.env` (shared by all three host plugins):
+Run `sigil login` later to update saved credentials.
+
+<details>
+<summary>Non-interactive config.env</summary>
+
+Create or update `~/.config/sigil/config.env`:
 
 ```dotenv
 SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
@@ -67,20 +70,22 @@ SIGIL_AUTH_TOKEN=glc_...
 SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
 ```
 
-To also send the conversation text (with automatic secret redaction), add:
+</details>
+
+To also send the conversation text (with automatic secret redaction), add this to `~/.config/sigil/config.env`:
 
 ```dotenv
 SIGIL_CONTENT_CAPTURE_MODE=full
 ```
 
-## 4. Verify
+## 3. Verify
 
 Run one turn in Codex and let it finish — the plugin only exports completed turns, so `/exit` mid-turn means nothing is sent. Then open **AI Observability → Conversations** in Grafana Cloud.
 
 If nothing shows up:
 
 ```sh
-SIGIL_DEBUG=true codex  # one turn
+SIGIL_DEBUG=true sigil codex  # one turn
 tail -f ~/.local/state/sigil/logs/sigil.log
 ```
 
@@ -98,7 +103,7 @@ tail -f ~/.local/state/sigil/logs/sigil.log
 | `SIGIL_USER_ID` | — | Override the user id. |
 | `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
 
-If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>` manually instead of relying on the auto-synthesised auth.
+If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>`.
 
 ## Troubleshooting
 

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -12,28 +12,17 @@ Ships as a GitHub Copilot CLI plugin powered by the shared `sigil` binary.
 > synthetic turn ID at the hook layer, then enriches the completed turn from
 > Copilot CLI's local `events.jsonl` transcript when that artifact is present.
 
-## 1. Install
+## 1. Install and launch
 
 ```sh
 brew install grafana/grafana/sigil
-```
-
-Verify the binary is on the `PATH` visible to Copilot hook subprocesses:
-
-```sh
-which sigil
-```
-
-## 2. Register the plugin
-
-```sh
 sigil copilot
 ```
 
-The launcher resolves `copilot` on `PATH`, registers `sigil-copilot` with copilot on first run, then execs copilot.
+`sigil copilot` registers `sigil-copilot` on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches Copilot CLI.
 
 <details>
-<summary>Manual install</summary>
+<summary>Manual plugin registration</summary>
 
 The current
 [GitHub Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference)
@@ -57,9 +46,9 @@ copilot plugin list
 
 </details>
 
-## 3. Add your credentials
+## 2. Credentials
 
-All Sigil connection details live at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure AI Observability is enabled on your stack — an administrator opens **Observability → AI Observability** once and accepts the terms.
+When `sigil copilot` prompts, copy values from `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure AI Observability is enabled on your stack — an administrator opens **Observability → AI Observability** once and accepts the terms.
 
 You need values from three Grafana Cloud pages:
 
@@ -74,7 +63,12 @@ You need values from three Grafana Cloud pages:
 3. **Grafana Cloud Portal → your stack → OpenTelemetry card**
    - **OTLP endpoint URL** → `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT`
 
-Save them to `~/.config/sigil/config.env` (shared by all host plugins):
+Run `sigil login` later to update saved credentials.
+
+<details>
+<summary>Non-interactive config.env</summary>
+
+Create or update `~/.config/sigil/config.env`:
 
 ```dotenv
 SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
@@ -83,13 +77,15 @@ SIGIL_AUTH_TOKEN=glc_...
 SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
 ```
 
-To also send the conversation text (with automatic secret redaction), add:
+</details>
+
+To also send the conversation text (with automatic secret redaction), add this to `~/.config/sigil/config.env`:
 
 ```dotenv
 SIGIL_CONTENT_CAPTURE_MODE=full
 ```
 
-## 4. Verify
+## 3. Verify
 
 Start a Copilot CLI session in a repository and give it a prompt that triggers
 at least one tool call. The plugin only exports completed turns at `agentStop`.
@@ -99,7 +95,7 @@ generations with `agent_name=copilot`.
 If nothing shows up:
 
 ```sh
-SIGIL_DEBUG=true copilot   # one turn
+SIGIL_DEBUG=true sigil copilot   # one turn
 tail -f ~/.local/state/sigil/logs/sigil.log
 ```
 
@@ -146,7 +142,7 @@ Redaction happens before export.
 | `SIGIL_USER_ID` | — | Override the user id. |
 | `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
 
-If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>` manually instead of relying on the auto-synthesised auth.
+If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>`.
 
 ## What Gets Exported
 

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -2,11 +2,13 @@
 
 Sends Cursor agent generations to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/): prompts, replies, tool calls, and token usage.
 
-## 1. Install
+## 1. Install the shared binary
 
 ```sh
 brew install grafana/grafana/sigil
 ```
+
+Cursor does not have a `sigil cursor` launcher. Install the binary, register the Cursor plugin, then use `sigil login` or `~/.config/sigil/config.env` for credentials.
 
 ## 2. Register the plugin
 
@@ -18,7 +20,7 @@ In Cursor:
 
 ## 3. Add your credentials
 
-All Sigil connection details live at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure AI Observability is enabled on your stack — an administrator opens **Observability → AI Observability** once and accepts the terms.
+Run `sigil login` from a terminal. The prompt asks for values from `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure AI Observability is enabled on your stack — an administrator opens **Observability → AI Observability** once and accepts the terms.
 
 You need values from three Grafana Cloud pages:
 
@@ -33,7 +35,10 @@ You need values from three Grafana Cloud pages:
 3. **Grafana Cloud Portal → your stack → OpenTelemetry card**
    - **OTLP endpoint URL** → `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT`
 
-Save them to `~/.config/sigil/config.env` (shared by all three host plugins):
+<details>
+<summary>Non-interactive config.env</summary>
+
+Create or update `~/.config/sigil/config.env`:
 
 ```dotenv
 SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
@@ -42,7 +47,9 @@ SIGIL_AUTH_TOKEN=glc_...
 SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
 ```
 
-To also send the conversation text (with automatic secret redaction), add:
+</details>
+
+To also send the conversation text (with automatic secret redaction), add this to `~/.config/sigil/config.env`:
 
 ```dotenv
 SIGIL_CONTENT_CAPTURE_MODE=full
@@ -73,4 +80,4 @@ tail -f ~/.local/state/sigil/logs/sigil.log
 | `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
 | `SIGIL_BIN` | auto | Override the binary path if you installed `sigil` somewhere unusual. |
 
-If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>` manually instead of relying on the auto-synthesised auth.
+If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>`.

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -2,24 +2,32 @@
 
 [Pi](https://github.com/badlogic/pi) agent extension that sends LLM generations to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/).
 
-By default only metadata is sent (token counts, cost, model, tool names, durations). Flip `SIGIL_CONTENT_CAPTURE_MODE` to `full` or `no_tool_content` to include message content.
+By default only metadata is sent (token counts, cost, model, tool names, durations). Set `SIGIL_CONTENT_CAPTURE_MODE=full` or `no_tool_content` to include message content.
 
-## 1. Install
-
-```sh
-pi install npm:@grafana/sigil-pi
-```
-
-Or use the [sigil launcher](../sigil/README.md) which installs the extension on first run:
+## 1. Install and launch
 
 ```sh
 brew install grafana/grafana/sigil
 sigil pi
 ```
 
-## 2. Add your Grafana Cloud credentials
+`sigil pi` installs the `@grafana/sigil-pi` extension on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches pi.
 
-All Sigil connection details live at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`.
+<details>
+<summary>Manual extension registration</summary>
+
+```sh
+pi install npm:@grafana/sigil-pi
+sigil login
+```
+
+The extension reads the same `~/.config/sigil/config.env` file whether you start pi with `sigil pi` or plain `pi`.
+
+</details>
+
+## 2. Credentials
+
+When `sigil pi` or `sigil login` prompts, copy values from `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure AI Observability is enabled on your stack — an administrator opens **Observability → AI Observability** once and accepts the terms.
 
 You need values from three Grafana Cloud pages:
 
@@ -34,20 +42,35 @@ You need values from three Grafana Cloud pages:
 3. **Grafana Cloud Portal → your stack → OpenTelemetry card**
    - **OTLP endpoint URL** → `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT`
 
-## 3. Configure
+Run `sigil login` later to update saved credentials.
 
-Configuration comes from canonical `SIGIL_*` env vars. The extension also reads `$XDG_CONFIG_HOME/sigil/config.env` (default `~/.config/sigil/config.env`) on startup and copies entries into `process.env` for keys whose existing OS value is empty or whitespace-only. Plain `pi` and `sigil pi` share the same file.
+<details>
+<summary>Non-interactive config.env</summary>
 
-Minimal `~/.config/sigil/config.env`:
+Create or update `~/.config/sigil/config.env`:
 
-```sh
+```dotenv
 SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
 SIGIL_AUTH_TENANT_ID=<instance-id>
 SIGIL_AUTH_TOKEN=glc_...
 SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
 ```
 
+</details>
+
 When `SIGIL_AUTH_TENANT_ID` and `SIGIL_AUTH_TOKEN` are both set, both Sigil generation export and the OTLP endpoint authenticate with the synthesized Basic auth header (`Basic base64(tenant:token)`). With only one of the two set, no auth header is sent.
+
+To include conversation text (with automatic secret redaction), add this to `~/.config/sigil/config.env`:
+
+```dotenv
+SIGIL_CONTENT_CAPTURE_MODE=full
+```
+
+## 3. Verify
+
+Run one pi turn, then open **AI Observability → Conversations** in Grafana Cloud. A new generation should appear within a few seconds.
+
+If nothing shows up, set `SIGIL_DEBUG=true` in `~/.config/sigil/config.env`, run another turn, and check pi stderr plus any Sigil logs.
 
 ## Redaction
 
@@ -58,7 +81,7 @@ Before any generation leaves the process, the SDK scrubs known token formats, PE
 Guards block tool calls before they execute (e.g. refuse a `bash` invocation matching a deny rule). They're off by default:
 
 ```sh
-SIGIL_GUARDS_ENABLED=true pi
+SIGIL_GUARDS_ENABLED=true sigil pi
 ```
 
 By default, transport errors and timeouts let the tool through. Set `SIGIL_GUARDS_FAIL_OPEN=false` to block on errors instead. Raise or lower `SIGIL_GUARDS_TIMEOUT_MS` (default `1500`) to trade latency against tolerance for slow evaluators.

--- a/plugins/sigil/README.md
+++ b/plugins/sigil/README.md
@@ -12,7 +12,7 @@ brew install grafana/grafana/sigil
 
 All four hosts read the same config file at `~/.config/sigil/config.env`. The first run of `sigil claude` or `sigil pi` prompts for your endpoint, tenant ID, token, and OTLP endpoint and writes them there; run `sigil login` to re-enter them later.
 
-To skip the prompt, create the file by hand:
+To preconfigure without the prompt, create the file:
 
 ```dotenv
 SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Markdown-only documentation changes with no runtime or configuration code touched.
> 
> **Overview**
> Plugin setup docs now treat **`sigil <agent>`** as the primary path: first-run plugin/extension install, interactive credentials, writing **`~/.config/sigil/config.env`**, then launching the agent.
> 
> The top-level **`plugins/README.md`** explains launcher behavior and how shared config, **`sigil login`**, Cursor (no launcher), and OpenCode (separate JSON config) differ. Per-agent READMEs (Claude, Codex, Copilot, pi, Cursor, **`plugins/sigil`**) use a shorter flow—**Install and launch** → **Credentials** → **Verify**—with manual marketplace/plugin steps and hand-edited **`config.env`** moved into **`<details>`** blocks. Debug examples now use **`SIGIL_DEBUG=true sigil <agent>`** where the launcher applies; OTLP header notes drop “auto-synthesised” wording without changing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b14774f1783a003f0175cddaef91819eefca0697. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->