### PR TITLE
feat(plugins/codex): support tool call guards

### DIFF
--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sigil-codex",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Send Codex session telemetry to Grafana Sigil",
   "author": {
     "name": "Grafana Labs"

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -35,7 +35,7 @@ codex_hooks = true
 
 Older Codex builds use `hooks = true` and `plugin_hooks = true` instead of `codex_hooks`. Run `codex features list` to see which flag names your build accepts.
 
-Restart Codex, open `/hooks`, and trust the four `sigil-codex@grafana-sigil` hooks (first-run review is expected).
+Restart Codex, open `/hooks`, and trust the five `sigil-codex@grafana-sigil` hooks (first-run review is expected).
 
 </details>
 
@@ -102,6 +102,11 @@ tail -f ~/.local/state/sigil/logs/sigil.log
 | `SIGIL_TAGS` | — | `key=value,key=value` tags added to every generation. |
 | `SIGIL_USER_ID` | — | Override the user id. |
 | `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
+| `SIGIL_GUARDS_ENABLED` | `false` | Enable Codex `PreToolUse` guards against Sigil rules. |
+| `SIGIL_GUARDS_FAIL_OPEN` | `true` | Allow the tool call when the guard request fails (set `false` for fail-closed). |
+| `SIGIL_GUARDS_TIMEOUT_MS` | `1500` | Per-call guard timeout. |
+
+Guards only intercept tool calls that Codex routes through `PreToolUse` — Bash, the `apply_patch` variants, and MCP tools. See the [Codex hooks docs](https://developers.openai.com/codex/hooks) for the supported set.
 
 If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>`.
 

--- a/plugins/codex/hooks/hooks.json
+++ b/plugins/codex/hooks/hooks.json
@@ -24,6 +24,19 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sigil codex hook",
+            "timeout": 10,
+            "statusMessage": "Checking Sigil guard"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "*",

--- a/plugins/sigil/internal/agents/codex/config/config.go
+++ b/plugins/sigil/internal/agents/codex/config/config.go
@@ -15,6 +15,7 @@ import (
 type Config struct {
 	ContentCapture sigil.ContentCaptureMode
 	Debug          bool
+	Guards         envconfig.GuardsConfig
 }
 
 // HasCredentials reports whether the canonical SIGIL_* credentials are
@@ -51,5 +52,6 @@ func Load(logger *log.Logger) Config {
 	return Config{
 		ContentCapture: envconfig.ResolveContentMode(logger),
 		Debug:          envconfig.ParseBool(os.Getenv("SIGIL_DEBUG")),
+		Guards:         envconfig.ResolveGuards(logger),
 	}
 }

--- a/plugins/sigil/internal/agents/codex/config/config_test.go
+++ b/plugins/sigil/internal/agents/codex/config/config_test.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"bytes"
+	"log"
+	"testing"
+)
+
+// TestLoad_Guards pins the env-var contract and defaults for codex against
+// the shared envconfig resolver, mirroring the copilot config test so the
+// two agents stay byte-identical on the guard knobs that ship in
+// ~/.config/sigil/config.env.
+func TestLoad_Guards(t *testing.T) {
+	tests := []struct {
+		name          string
+		env           map[string]string
+		wantEnabled   bool
+		wantFailOpen  bool
+		wantTimeoutMs int
+	}{
+		{
+			name:          "defaults are disabled fail-open 1500ms",
+			env:           map[string]string{},
+			wantEnabled:   false,
+			wantFailOpen:  true,
+			wantTimeoutMs: 1500,
+		},
+		{
+			name: "enabled via env",
+			env: map[string]string{
+				"SIGIL_GUARDS_ENABLED": "true",
+			},
+			wantEnabled:   true,
+			wantFailOpen:  true,
+			wantTimeoutMs: 1500,
+		},
+		{
+			name: "fail-closed via env",
+			env: map[string]string{
+				"SIGIL_GUARDS_ENABLED":   "true",
+				"SIGIL_GUARDS_FAIL_OPEN": "false",
+			},
+			wantEnabled:   true,
+			wantFailOpen:  false,
+			wantTimeoutMs: 1500,
+		},
+		{
+			name: "timeout override",
+			env: map[string]string{
+				"SIGIL_GUARDS_ENABLED":    "true",
+				"SIGIL_GUARDS_TIMEOUT_MS": "750",
+			},
+			wantEnabled:   true,
+			wantFailOpen:  true,
+			wantTimeoutMs: 750,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SIGIL_GUARDS_ENABLED", "")
+			t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "")
+			t.Setenv("SIGIL_GUARDS_TIMEOUT_MS", "")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			cfg := Load(log.New(&bytes.Buffer{}, "", 0))
+			if cfg.Guards.Enabled != tt.wantEnabled {
+				t.Errorf("Guards.Enabled = %t, want %t", cfg.Guards.Enabled, tt.wantEnabled)
+			}
+			if cfg.Guards.FailOpen != tt.wantFailOpen {
+				t.Errorf("Guards.FailOpen = %t, want %t", cfg.Guards.FailOpen, tt.wantFailOpen)
+			}
+			if cfg.Guards.TimeoutMs != tt.wantTimeoutMs {
+				t.Errorf("Guards.TimeoutMs = %d, want %d", cfg.Guards.TimeoutMs, tt.wantTimeoutMs)
+			}
+		})
+	}
+}

--- a/plugins/sigil/internal/agents/codex/hook.go
+++ b/plugins/sigil/internal/agents/codex/hook.go
@@ -18,7 +18,7 @@ import (
 // Hook reads a Codex hook JSON payload from stdin and dispatches it to the
 // matching handler. Telemetry errors are logged; the function returns nil
 // in almost every case because hooks must never crash the agent.
-func Hook(ctx context.Context, stdin io.Reader, _ io.Writer, logger *log.Logger) error {
+func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Logger) error {
 	raw, err := io.ReadAll(stdin)
 	if err != nil {
 		logger.Printf("dispatch: read stdin: %v", err)
@@ -47,6 +47,8 @@ func Hook(ctx context.Context, stdin io.Reader, _ io.Writer, logger *log.Logger)
 		hook.SessionStart(payload, cfg, logger)
 	case "UserPromptSubmit":
 		hook.UserPromptSubmit(payload, cfg, logger)
+	case "PreToolUse":
+		hook.PreToolUse(ctx, stdout, payload, cfg, logger)
 	case "PostToolUse":
 		hook.PostToolUse(payload, cfg, logger)
 	case "Stop":
@@ -54,6 +56,5 @@ func Hook(ctx context.Context, stdin io.Reader, _ io.Writer, logger *log.Logger)
 	default:
 		logger.Printf("dispatch: unknown event %q", payload.HookEventName)
 	}
-	_ = ctx // hook handlers manage their own contexts
 	return nil
 }

--- a/plugins/sigil/internal/agents/codex/hook/handlers.go
+++ b/plugins/sigil/internal/agents/codex/hook/handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/codex/config"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/codex/fragment"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/codex/mapper"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/guard"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/envconfig"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/otel"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/redact"
@@ -76,6 +78,76 @@ func UserPromptSubmit(p Payload, cfg config.Config, logger *log.Logger) {
 	}); err != nil {
 		logger.Printf("userPromptSubmit: %v", err)
 	}
+}
+
+// preToolUseDecision is the JSON shape Codex understands as a deny verdict
+// on PreToolUse. Matches Claude Code's hookDecision so downstream rules
+// stay consistent across agents.
+type preToolUseDecision struct {
+	HookSpecificOutput preToolUseDecisionOutput `json:"hookSpecificOutput"`
+}
+
+type preToolUseDecisionOutput struct {
+	HookEventName            string `json:"hookEventName"`
+	PermissionDecision       string `json:"permissionDecision"`
+	PermissionDecisionReason string `json:"permissionDecisionReason,omitempty"`
+}
+
+// PreToolUse evaluates a Codex tool call against Sigil guard rules. It writes
+// a deny JSON object to stdout when the call must be blocked and stays silent
+// when the call is allowed. Transport setup, credential checks, and
+// fail-open/closed behaviour all live in the shared guard package so this
+// handler stays in lockstep with the copilot and other agents.
+func PreToolUse(ctx context.Context, stdout io.Writer, p Payload, cfg config.Config, logger *log.Logger) {
+	res := guard.EvaluateToolCall(ctx, cfg.Guards, guard.ToolCallInput{
+		AgentName:     mapper.AgentName,
+		ToolName:      p.ToolName,
+		ToolCallID:    p.ToolUseID,
+		ToolInputJSON: p.ToolInput,
+		ModelProvider: guardProviderFromModel(p.Model),
+		ModelName:     p.Model,
+	}, logger)
+	if res.Blocked() {
+		writePreToolDeny(stdout, res.Reason)
+	}
+}
+
+func guardProviderFromModel(model string) string {
+	m := strings.ToLower(model)
+	switch {
+	case strings.Contains(m, "claude"):
+		return "anthropic"
+	case strings.HasPrefix(m, "gpt"), isOpenAIOSeriesModel(m):
+		return "openai"
+	case strings.Contains(m, "gemini"):
+		return "google"
+	}
+	return ""
+}
+
+// isOpenAIOSeriesModel reports whether m starts with the OpenAI "o-series"
+// prefix `o` immediately followed by a digit (o1, o3, o4, o5, …). Matching
+// the family rather than a fixed list keeps future releases attributed to
+// OpenAI without code changes.
+func isOpenAIOSeriesModel(m string) bool {
+	if len(m) < 2 || m[0] != 'o' {
+		return false
+	}
+	return m[1] >= '0' && m[1] <= '9'
+}
+
+func writePreToolDeny(stdout io.Writer, reason string) {
+	if strings.TrimSpace(reason) == "" {
+		reason = "tool call denied by Sigil guard"
+	}
+	out := preToolUseDecision{
+		HookSpecificOutput: preToolUseDecisionOutput{
+			HookEventName:            "PreToolUse",
+			PermissionDecision:       "deny",
+			PermissionDecisionReason: reason,
+		},
+	}
+	_ = json.NewEncoder(stdout).Encode(out)
 }
 
 func PostToolUse(p Payload, cfg config.Config, logger *log.Logger) {

--- a/plugins/sigil/internal/agents/codex/hook/handlers_test.go
+++ b/plugins/sigil/internal/agents/codex/hook/handlers_test.go
@@ -2,6 +2,7 @@ package hook
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -720,6 +721,236 @@ func TestStopRetrySweepPreservesSubagentLinkAndTokenUsage(t *testing.T) {
 	}
 	if retried.Metadata["codex.token_usage.source"] != "turn_context_delta" {
 		t.Errorf("retry token-usage metadata missing or wrong: %+v", retried.Metadata)
+	}
+}
+
+func TestPreToolUseGuard(t *testing.T) {
+	var calls atomic.Int32
+	var responseBody atomic.Value
+	responseBody.Store("")
+	server := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		body, _ := responseBody.Load().(string)
+		if body == "" {
+			body = `{"action":"allow"}`
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	closed := newTestServer(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	closed.Close()
+
+	tests := []struct {
+		name               string
+		env                map[string]string
+		useClosedEndpoint  bool
+		clearCreds         bool
+		serverResponds     string
+		expectServerCall   bool
+		wantStdoutContains []string
+		wantStdoutEmpty    bool
+	}{
+		{
+			name:            "disabled_by_default_no_env",
+			wantStdoutEmpty: true,
+		},
+		{
+			name:            "disabled_explicit_false",
+			env:             map[string]string{"SIGIL_GUARDS_ENABLED": "false"},
+			wantStdoutEmpty: true,
+		},
+		{
+			name:             "enabled_allow_response",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow"}`,
+			expectServerCall: true,
+			wantStdoutEmpty:  true,
+		},
+		{
+			name:               "enabled_deny_response",
+			env:                map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:     `{"action":"deny","reason":"blocked tool"}`,
+			expectServerCall:   true,
+			wantStdoutContains: []string{`"permissionDecision":"deny"`, "blocked tool"},
+		},
+		{
+			name:               "enabled_deny_empty_reason_fallback",
+			env:                map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:     `{"action":"deny"}`,
+			expectServerCall:   true,
+			wantStdoutContains: []string{`"permissionDecision":"deny"`, "tool call denied by Sigil guard"},
+		},
+		{
+			name:              "enabled_fail_open_on_transport_error",
+			env:               map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			useClosedEndpoint: true,
+			wantStdoutEmpty:   true,
+		},
+		{
+			name: "enabled_fail_closed_on_transport_error",
+			env: map[string]string{
+				"SIGIL_GUARDS_ENABLED":   "true",
+				"SIGIL_GUARDS_FAIL_OPEN": "false",
+			},
+			useClosedEndpoint:  true,
+			wantStdoutContains: []string{`"permissionDecision":"deny"`, "sigil guard evaluation failed"},
+		},
+		{
+			name:            "enabled_fail_open_missing_credentials",
+			env:             map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			clearCreds:      true,
+			wantStdoutEmpty: true,
+		},
+		{
+			name: "enabled_fail_closed_missing_credentials",
+			env: map[string]string{
+				"SIGIL_GUARDS_ENABLED":   "true",
+				"SIGIL_GUARDS_FAIL_OPEN": "false",
+			},
+			clearCreds:         true,
+			wantStdoutContains: []string{`"permissionDecision":"deny"`, "missing SIGIL_ENDPOINT/SIGIL_AUTH_TENANT_ID/SIGIL_AUTH_TOKEN"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SIGIL_GUARDS_ENABLED", "")
+			t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "")
+			t.Setenv("SIGIL_GUARDS_TIMEOUT_MS", "")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			endpoint := server.URL
+			if tt.useClosedEndpoint {
+				endpoint = closed.URL
+			}
+			if tt.clearCreds {
+				t.Setenv("SIGIL_ENDPOINT", "")
+				t.Setenv("SIGIL_AUTH_TENANT_ID", "")
+				t.Setenv("SIGIL_AUTH_TOKEN", "")
+			} else {
+				t.Setenv("SIGIL_ENDPOINT", endpoint)
+				t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+				t.Setenv("SIGIL_AUTH_TOKEN", "token")
+			}
+
+			calls.Store(0)
+			responseBody.Store(tt.serverResponds)
+
+			cfg := config.Load(log.New(io.Discard, "", 0))
+			var stdout bytes.Buffer
+			var logs bytes.Buffer
+			payload := Payload{
+				HookEventName: "PreToolUse",
+				SessionID:     "sess",
+				ToolName:      "Bash",
+				ToolUseID:     "tu_1",
+				ToolInput:     json.RawMessage(`{"command":"echo hi"}`),
+				Model:         "gpt-5",
+			}
+
+			PreToolUse(context.Background(), &stdout, payload, cfg, log.New(&logs, "", 0))
+
+			if tt.expectServerCall && calls.Load() == 0 {
+				t.Errorf("expected server call, got 0")
+			}
+			if !tt.expectServerCall && !tt.useClosedEndpoint && !tt.clearCreds && calls.Load() != 0 {
+				t.Errorf("expected no server call, got %d", calls.Load())
+			}
+			if tt.wantStdoutEmpty && stdout.Len() != 0 {
+				t.Errorf("stdout not empty: %q", stdout.String())
+			}
+			for _, want := range tt.wantStdoutContains {
+				if !strings.Contains(stdout.String(), want) {
+					t.Errorf("stdout = %q, want substring %q", stdout.String(), want)
+				}
+			}
+		})
+	}
+}
+
+func TestPreToolUseGuardSendsExpectedRequest(t *testing.T) {
+	var capturedPath atomic.Value
+	var capturedBody atomic.Value
+	server := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath.Store(r.URL.Path)
+		body, _ := io.ReadAll(r.Body)
+		capturedBody.Store(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"action":"allow"}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("SIGIL_GUARDS_ENABLED", "true")
+	t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "")
+	t.Setenv("SIGIL_GUARDS_TIMEOUT_MS", "")
+	t.Setenv("SIGIL_ENDPOINT", server.URL)
+	t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+	t.Setenv("SIGIL_AUTH_TOKEN", "token")
+
+	cfg := config.Load(log.New(io.Discard, "", 0))
+	var stdout bytes.Buffer
+	payload := Payload{
+		HookEventName: "PreToolUse",
+		SessionID:     "sess",
+		ToolName:      "Bash",
+		ToolUseID:     "tu_1",
+		ToolInput:     json.RawMessage(`{"command":"rm -rf /"}`),
+		Model:         "gpt-5",
+	}
+	PreToolUse(context.Background(), &stdout, payload, cfg, log.New(io.Discard, "", 0))
+
+	path, _ := capturedPath.Load().(string)
+	if path != "/api/v1/hooks:evaluate" {
+		t.Errorf("path = %q, want /api/v1/hooks:evaluate", path)
+	}
+	rawBody, _ := capturedBody.Load().([]byte)
+	if len(rawBody) == 0 {
+		t.Fatal("captured body is empty")
+	}
+	var req struct {
+		Phase   string `json:"phase"`
+		Context struct {
+			AgentName string `json:"agent_name"`
+		} `json:"context"`
+		Input struct {
+			Output []struct {
+				Role  string `json:"role"`
+				Parts []struct {
+					Kind     string `json:"kind"`
+					ToolCall *struct {
+						ID    string          `json:"id"`
+						Name  string          `json:"name"`
+						Input json.RawMessage `json:"input_json"`
+					} `json:"tool_call"`
+				} `json:"parts"`
+			} `json:"output"`
+		} `json:"input"`
+	}
+	if err := json.Unmarshal(rawBody, &req); err != nil {
+		t.Fatalf("decode request body: %v\nbody: %s", err, string(rawBody))
+	}
+	if req.Phase != "postflight" {
+		t.Errorf("phase = %q, want postflight", req.Phase)
+	}
+	if req.Context.AgentName != mapper.AgentName {
+		t.Errorf("agent_name = %q, want %q", req.Context.AgentName, mapper.AgentName)
+	}
+	if len(req.Input.Output) != 1 || len(req.Input.Output[0].Parts) != 1 {
+		t.Fatalf("unexpected output shape: %+v", req.Input.Output)
+	}
+	tc := req.Input.Output[0].Parts[0].ToolCall
+	if tc == nil {
+		t.Fatal("missing tool_call part")
+	}
+	if tc.Name != "Bash" || tc.ID != "tu_1" {
+		t.Errorf("tool_call name/id = %q/%q, want Bash/tu_1", tc.Name, tc.ID)
+	}
+	if !strings.Contains(string(tc.Input), "rm -rf /") {
+		t.Errorf("tool_call input = %s, want substring %q", string(tc.Input), "rm -rf /")
 	}
 }
 

--- a/plugins/sigil/internal/agents/codex/hook_test.go
+++ b/plugins/sigil/internal/agents/codex/hook_test.go
@@ -1,0 +1,85 @@
+package codex
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestHookRoutesPreToolUse(t *testing.T) {
+	var responseBody atomic.Value
+	responseBody.Store("")
+	server := newDispatcherTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := responseBody.Load().(string)
+		if body == "" {
+			body = `{"action":"allow"}`
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name               string
+		serverResponds     string
+		wantStdoutEmpty    bool
+		wantStdoutContains string
+	}{
+		{
+			name:            "allow_response_produces_empty_stdout",
+			serverResponds:  `{"action":"allow"}`,
+			wantStdoutEmpty: true,
+		},
+		{
+			name:               "deny_response_emits_codex_deny_json",
+			serverResponds:     `{"action":"deny","reason":"blocked"}`,
+			wantStdoutContains: `"permissionDecision":"deny"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			t.Setenv("SIGIL_GUARDS_ENABLED", "true")
+			t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "")
+			t.Setenv("SIGIL_GUARDS_TIMEOUT_MS", "")
+			t.Setenv("SIGIL_ENDPOINT", server.URL)
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
+
+			responseBody.Store(tt.serverResponds)
+
+			stdin := strings.NewReader(`{"hook_event_name":"PreToolUse","session_id":"sess","tool_name":"Bash","tool_use_id":"tu_1","tool_input":{"command":"rm -rf /"},"model":"gpt-5"}`)
+			var stdout bytes.Buffer
+			if err := Hook(context.Background(), stdin, &stdout, log.New(io.Discard, "", 0)); err != nil {
+				t.Fatalf("Hook: %v", err)
+			}
+
+			if tt.wantStdoutEmpty && stdout.Len() != 0 {
+				t.Errorf("stdout not empty: %q", stdout.String())
+			}
+			if tt.wantStdoutContains != "" && !strings.Contains(stdout.String(), tt.wantStdoutContains) {
+				t.Errorf("stdout = %q, want substring %q", stdout.String(), tt.wantStdoutContains)
+			}
+		})
+	}
+}
+
+func newDispatcherTestServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("loopback listen unavailable in this sandbox: %v", err)
+	}
+	server := httptest.NewUnstartedServer(handler)
+	server.Listener = listener
+	server.Start()
+	return server
+}


### PR DESCRIPTION

<img width="432" height="179" alt="image" src="https://github.com/user-attachments/assets/fbbfe21a-38ce-4591-a82f-aae69b035d43" />


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Guards can block tool execution when enabled and fail-closed; default is off with fail-open, but misconfiguration could disrupt agent workflows.
> 
> **Overview**
> Adds **optional Sigil tool-call guards** for Codex by wiring a new **`PreToolUse`** hook (plugin **0.2.0**, five hooks to trust) that runs `sigil codex hook` before tools execute.
> 
> When **`SIGIL_GUARDS_ENABLED`** is set, each tool call is evaluated via the shared **`guard`** package against **`/api/v1/hooks:evaluate`**; denies are written to **stdout** as Codex **`permissionDecision: deny`** JSON (aligned with other agents). **`SIGIL_GUARDS_FAIL_OPEN`** and **`SIGIL_GUARDS_TIMEOUT_MS`** control outage and missing-credential behavior; README documents scope (Bash, apply_patch, MCP).
> 
> The Codex adapter now loads **`Guards`** from env, routes **`PreToolUse`** through the dispatcher with real **stdout**, and includes handler plus config/dispatcher tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0337d50e8858a8e60f96806aa3383f2f0db0d45c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->