### PR TITLE
feat(plugins/copilot): support tool call guards

### DIFF
--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -141,6 +141,9 @@ Redaction happens before export.
 | `SIGIL_TAGS` | — | `key=value,key=value` tags added to every generation. |
 | `SIGIL_USER_ID` | — | Override the user id. |
 | `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
+| `SIGIL_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Copilot `preToolUse` hook is evaluated against Sigil and tool calls denied by guard rules are blocked. |
+| `SIGIL_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |
+| `SIGIL_GUARDS_TIMEOUT_MS` | `1500` | Per-call timeout. Lower = less added latency on every tool call, higher = better tolerance for slow `llm_judge` evaluators. |
 
 If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>`.
 

--- a/plugins/copilot/hooks.json
+++ b/plugins/copilot/hooks.json
@@ -44,7 +44,6 @@
     ],
     "preToolUse": [
       {
-        "matcher": "*",
         "hooks": [
           {
             "type": "command",
@@ -59,7 +58,6 @@
     ],
     "postToolUse": [
       {
-        "matcher": "*",
         "hooks": [
           {
             "type": "command",
@@ -74,7 +72,6 @@
     ],
     "postToolUseFailure": [
       {
-        "matcher": "*",
         "hooks": [
           {
             "type": "command",

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sigil-copilot",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Send GitHub Copilot CLI session telemetry to Grafana Sigil",
   "author": {
     "name": "Grafana Labs"

--- a/plugins/sigil/internal/agents/copilot/config/config.go
+++ b/plugins/sigil/internal/agents/copilot/config/config.go
@@ -15,6 +15,7 @@ import (
 // before this struct is built, so it does not appear here.
 type Config struct {
 	ContentCapture sigil.ContentCaptureMode
+	Guards         envconfig.GuardsConfig
 }
 
 // HasCredentials reports whether the canonical SIGIL_* credentials are
@@ -29,5 +30,6 @@ func HasCredentials() bool {
 func Load(logger *log.Logger) Config {
 	return Config{
 		ContentCapture: envconfig.ResolveContentMode(logger),
+		Guards:         envconfig.ResolveGuards(logger),
 	}
 }

--- a/plugins/sigil/internal/agents/copilot/config/config_test.go
+++ b/plugins/sigil/internal/agents/copilot/config/config_test.go
@@ -23,3 +23,71 @@ func TestLoad_InvalidContentCaptureFailsClosed(t *testing.T) {
 		t.Fatalf("ContentCapture = %v, want metadata_only", cfg.ContentCapture)
 	}
 }
+
+func TestLoad_Guards(t *testing.T) {
+	tests := []struct {
+		name          string
+		env           map[string]string
+		wantEnabled   bool
+		wantFailOpen  bool
+		wantTimeoutMs int
+	}{
+		{
+			name:          "defaults are disabled fail-open 1500ms",
+			env:           map[string]string{},
+			wantEnabled:   false,
+			wantFailOpen:  true,
+			wantTimeoutMs: 1500,
+		},
+		{
+			name: "enabled via env",
+			env: map[string]string{
+				"SIGIL_GUARDS_ENABLED": "true",
+			},
+			wantEnabled:   true,
+			wantFailOpen:  true,
+			wantTimeoutMs: 1500,
+		},
+		{
+			name: "fail-closed via env",
+			env: map[string]string{
+				"SIGIL_GUARDS_ENABLED":   "true",
+				"SIGIL_GUARDS_FAIL_OPEN": "false",
+			},
+			wantEnabled:   true,
+			wantFailOpen:  false,
+			wantTimeoutMs: 1500,
+		},
+		{
+			name: "timeout override",
+			env: map[string]string{
+				"SIGIL_GUARDS_ENABLED":    "true",
+				"SIGIL_GUARDS_TIMEOUT_MS": "750",
+			},
+			wantEnabled:   true,
+			wantFailOpen:  true,
+			wantTimeoutMs: 750,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SIGIL_GUARDS_ENABLED", "")
+			t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "")
+			t.Setenv("SIGIL_GUARDS_TIMEOUT_MS", "")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			cfg := Load(log.New(&bytes.Buffer{}, "", 0))
+			if cfg.Guards.Enabled != tt.wantEnabled {
+				t.Errorf("Guards.Enabled = %t, want %t", cfg.Guards.Enabled, tt.wantEnabled)
+			}
+			if cfg.Guards.FailOpen != tt.wantFailOpen {
+				t.Errorf("Guards.FailOpen = %t, want %t", cfg.Guards.FailOpen, tt.wantFailOpen)
+			}
+			if cfg.Guards.TimeoutMs != tt.wantTimeoutMs {
+				t.Errorf("Guards.TimeoutMs = %d, want %d", cfg.Guards.TimeoutMs, tt.wantTimeoutMs)
+			}
+		})
+	}
+}

--- a/plugins/sigil/internal/agents/copilot/hook.go
+++ b/plugins/sigil/internal/agents/copilot/hook.go
@@ -25,7 +25,7 @@ import (
 // payload omits the event name (the early Copilot CLI did this for several
 // events), SIGIL_COPILOT_HOOK_EVENT is consulted as a fallback — the
 // hooks.json manifest sets it per hook entry.
-func Hook(ctx context.Context, stdin io.Reader, _ io.Writer, logger *log.Logger) error {
+func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Logger) error {
 	raw, err := io.ReadAll(stdin)
 	if err != nil {
 		logger.Printf("dispatch: read stdin: %v", err)
@@ -68,7 +68,7 @@ func Hook(ctx context.Context, stdin io.Reader, _ io.Writer, logger *log.Logger)
 	case "userPromptSubmitted", "UserPromptSubmit", "UserPromptSubmitted":
 		hook.UserPromptSubmit(payload, cfg, logger)
 	case "preToolUse", "PreToolUse":
-		hook.PreToolUse(payload, cfg, logger)
+		hook.PreToolUse(ctx, stdout, payload, cfg, logger)
 	case "postToolUse", "PostToolUse":
 		hook.PostToolUse(payload, cfg, logger, false)
 	case "postToolUseFailure", "PostToolUseFailure":
@@ -84,6 +84,5 @@ func Hook(ctx context.Context, stdin io.Reader, _ io.Writer, logger *log.Logger)
 	default:
 		logger.Printf("dispatch: unknown event %q", eventName)
 	}
-	_ = ctx // handlers manage their own contexts
 	return nil
 }

--- a/plugins/sigil/internal/agents/copilot/hook/handlers.go
+++ b/plugins/sigil/internal/agents/copilot/hook/handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"slices"
@@ -17,6 +18,7 @@ import (
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/copilot/fragment"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/copilot/mapper"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/copilot/transcript"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/guard"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/envconfig"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/otel"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/redact"
@@ -108,11 +110,37 @@ func UserPromptSubmit(p Payload, cfg config.Config, logger *log.Logger) {
 	}
 }
 
-func PreToolUse(p Payload, cfg config.Config, logger *log.Logger) {
+func PreToolUse(ctx context.Context, stdout io.Writer, p Payload, cfg config.Config, logger *log.Logger) {
 	sessionID := p.SessionID()
 	if sessionID == "" {
 		logger.Print("preToolUse: missing session_id")
 		return
+	}
+	toolArgs := p.ToolInput()
+	if cfg.Guards.Enabled {
+		// Best-effort: pull last-known model/provider off the active turn
+		// fragment. Copilot's preToolUse payload doesn't carry model, but
+		// once enrichFromTranscript has run for a prior turn we may have
+		// it cached. The guard helper falls back to "unknown" when blank,
+		// which keeps the request well-formed for Sigil.
+		var provider, modelName string
+		if session := fragment.LoadSessionTolerant(sessionID, logger); session != nil && session.ActiveTurnID != "" {
+			if frag := loadFragment(sessionID, session.ActiveTurnID, logger); frag != nil {
+				provider = frag.Provider
+				modelName = frag.Model
+			}
+		}
+		res := guard.EvaluateToolCall(ctx, cfg.Guards, guard.ToolCallInput{
+			AgentName:     mapper.AgentName,
+			ToolName:      p.ToolName(),
+			ToolInputJSON: toolArgs,
+			ModelProvider: provider,
+			ModelName:     modelName,
+		}, logger)
+		if res.Blocked() {
+			emitCopilotDeny(stdout, res.Reason, logger)
+			return
+		}
 	}
 	turnID, session, err := fragment.EnsureActiveTurn(sessionID, logger, p.ResolvedTimestamp())
 	if err != nil {
@@ -121,7 +149,7 @@ func PreToolUse(p Payload, cfg config.Config, logger *log.Logger) {
 	}
 	if err := updateCommon(sessionID, turnID, session, p, logger, func(f *fragment.Fragment) {
 		f.NextToolIndex++
-		input := p.ToolInput()
+		input := toolArgs
 		if cfg.ContentCapture != sigil.ContentCaptureModeFull {
 			input = nil
 		}
@@ -136,6 +164,29 @@ func PreToolUse(p Payload, cfg config.Config, logger *log.Logger) {
 		})
 	}); err != nil {
 		logger.Printf("preToolUse: update turn: %v", err)
+	}
+}
+
+// copilotDecision matches GitHub's documented preToolUse stdout shape:
+// top-level permissionDecision and permissionDecisionReason. Sigil only
+// emits permissionDecision=deny here; allow paths stay stdout-empty.
+type copilotDecision struct {
+	PermissionDecision       string `json:"permissionDecision"`
+	PermissionDecisionReason string `json:"permissionDecisionReason,omitempty"`
+}
+
+func emitCopilotDeny(stdout io.Writer, reason string, logger *log.Logger) {
+	if stdout == nil {
+		return
+	}
+	if strings.TrimSpace(reason) == "" {
+		reason = "tool call denied by Sigil guard"
+	}
+	if err := json.NewEncoder(stdout).Encode(copilotDecision{
+		PermissionDecision:       "deny",
+		PermissionDecisionReason: reason,
+	}); err != nil && logger != nil {
+		logger.Printf("preToolUse: write deny decision: %v", err)
 	}
 }
 

--- a/plugins/sigil/internal/agents/copilot/hook/handlers_test.go
+++ b/plugins/sigil/internal/agents/copilot/hook/handlers_test.go
@@ -1,6 +1,8 @@
 package hook
 
 import (
+	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -20,6 +22,7 @@ import (
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/copilot/config"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/copilot/fragment"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/copilot/transcript"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/envconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -45,7 +48,7 @@ func TestHookSequenceExportsOnStop(t *testing.T) {
 
 	SessionStart(Payload{HookEventNameJSON: "SessionStart", SessionIDJSON: "sess", Timestamp: []byte(`"2026-05-18T12:00:00Z"`), SourceValue: "new"}, cfg, logger)
 	UserPromptSubmit(Payload{HookEventNameJSON: "UserPromptSubmit", SessionIDJSON: "sess", Timestamp: []byte(`"2026-05-18T12:00:01Z"`), Prompt: "hello glc_abcdefghijklmnopqrstuvwxyz"}, cfg, logger)
-	PreToolUse(Payload{HookEventNameJSON: "PreToolUse", SessionIDJSON: "sess", Timestamp: []byte(`"2026-05-18T12:00:02Z"`), ToolNameJSON: "bash", ToolInputJSON: []byte(`{"cmd":"echo hi"}`)}, cfg, logger)
+	PreToolUse(context.Background(), io.Discard, Payload{HookEventNameJSON: "PreToolUse", SessionIDJSON: "sess", Timestamp: []byte(`"2026-05-18T12:00:02Z"`), ToolNameJSON: "bash", ToolInputJSON: []byte(`{"cmd":"echo hi"}`)}, cfg, logger)
 	PostToolUse(Payload{HookEventNameJSON: "PostToolUse", SessionIDJSON: "sess", Timestamp: []byte(`"2026-05-18T12:00:03Z"`), ToolNameJSON: "bash", ToolResultJSON: []byte(`{"text_result_for_llm":"ok"}`)}, cfg, logger, false)
 	Stop(Payload{HookEventNameJSON: "Stop", SessionIDJSON: "sess", Timestamp: []byte(`"2026-05-18T12:00:04Z"`), StopReasonJSON: "end_turn"}, cfg, logger)
 
@@ -470,6 +473,149 @@ func TestStopWaitsForCurrentCLITranscriptTurnInsteadOfReusingPreviousTurn(t *tes
 	}
 	if strings.Contains(gotBody, `"output_tokens":"621"`) {
 		t.Fatalf("export body reused previous turn output tokens: %s", gotBody)
+	}
+}
+
+func TestPreToolUseGuardBehavior(t *testing.T) {
+	tests := []struct {
+		name string
+		// guards is the GuardsConfig the test passes through cfg.Guards.
+		guards envconfig.GuardsConfig
+		// hookResponse is the JSON the fake Sigil hook server returns.
+		// If empty, an allow is returned.
+		hookResponse string
+		// useClosedServer points cfg.Endpoint at a closed listener so
+		// the request fails at transport.
+		useClosedServer bool
+		// clearCreds blanks SIGIL_ENDPOINT/SIGIL_AUTH_TENANT_ID/SIGIL_AUTH_TOKEN.
+		clearCreds          bool
+		wantServerCalled    bool
+		wantStdoutContains  string
+		wantStdoutEmpty     bool
+		wantToolRecordCount int
+	}{
+		{
+			name:                "disabled stays stdout-empty and records pending tool",
+			guards:              envconfig.GuardsConfig{Enabled: false, TimeoutMs: 1500, FailOpen: true},
+			wantStdoutEmpty:     true,
+			wantToolRecordCount: 1,
+		},
+		{
+			name:                "allow stays stdout-empty and records pending tool",
+			guards:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			hookResponse:        `{"action":"allow"}`,
+			wantServerCalled:    true,
+			wantStdoutEmpty:     true,
+			wantToolRecordCount: 1,
+		},
+		{
+			name:                "deny writes copilot deny JSON and skips record",
+			guards:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			hookResponse:        `{"action":"deny","reason":"blocked tool"}`,
+			wantServerCalled:    true,
+			wantStdoutContains:  `"permissionDecision":"deny"`,
+			wantToolRecordCount: 0,
+		},
+		{
+			name:                "fail-open transport error allows tool and records it",
+			guards:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			useClosedServer:     true,
+			wantStdoutEmpty:     true,
+			wantToolRecordCount: 1,
+		},
+		{
+			name:                "fail-closed transport error denies tool and skips record",
+			guards:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: false},
+			useClosedServer:     true,
+			wantStdoutContains:  `"permissionDecision":"deny"`,
+			wantToolRecordCount: 0,
+		},
+		{
+			name:                "fail-open missing credentials allows tool and records it",
+			guards:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			clearCreds:          true,
+			wantStdoutEmpty:     true,
+			wantToolRecordCount: 1,
+		},
+		{
+			name:                "fail-closed missing credentials denies tool and skips record",
+			guards:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: false},
+			clearCreds:          true,
+			wantStdoutContains:  `"permissionDecision":"deny"`,
+			wantToolRecordCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			logger := log.New(io.Discard, "", 0)
+
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls.Add(1)
+				body := tt.hookResponse
+				if body == "" {
+					body = `{"action":"allow"}`
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(body))
+			}))
+			defer server.Close()
+
+			closed := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			closed.Close()
+
+			endpoint := server.URL
+			if tt.useClosedServer {
+				endpoint = closed.URL
+			}
+			if tt.clearCreds {
+				t.Setenv("SIGIL_ENDPOINT", "")
+				t.Setenv("SIGIL_AUTH_TENANT_ID", "")
+				t.Setenv("SIGIL_AUTH_TOKEN", "")
+			} else {
+				t.Setenv("SIGIL_ENDPOINT", endpoint)
+				t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+				t.Setenv("SIGIL_AUTH_TOKEN", "token")
+			}
+
+			cfg := config.Config{
+				ContentCapture: sigil.ContentCaptureModeFull,
+				Guards:         tt.guards,
+			}
+			UserPromptSubmit(Payload{HookEventNameJSON: "UserPromptSubmit", SessionIDJSON: "sess", Timestamp: []byte(`"2026-05-18T12:00:01Z"`), Prompt: "hello"}, cfg, logger)
+
+			var stdout bytes.Buffer
+			PreToolUse(context.Background(), &stdout, Payload{
+				HookEventNameJSON: "PreToolUse",
+				SessionIDJSON:     "sess",
+				Timestamp:         []byte(`"2026-05-18T12:00:02Z"`),
+				ToolNameJSON:      "bash",
+				ToolInputJSON:     []byte(`{"cmd":"echo hi"}`),
+			}, cfg, logger)
+
+			if tt.wantServerCalled && calls.Load() == 0 {
+				t.Errorf("expected sigil hook server call, got 0")
+			}
+			if !tt.wantServerCalled && !tt.useClosedServer && calls.Load() != 0 {
+				t.Errorf("expected no sigil hook server call, got %d", calls.Load())
+			}
+			if tt.wantStdoutEmpty && stdout.Len() != 0 {
+				t.Errorf("stdout not empty: %q", stdout.String())
+			}
+			if tt.wantStdoutContains != "" && !strings.Contains(stdout.String(), tt.wantStdoutContains) {
+				t.Errorf("stdout = %q, want substring %q", stdout.String(), tt.wantStdoutContains)
+			}
+
+			frag := fragment.LoadTolerant("sess", "turn-000001", logger)
+			if frag == nil {
+				t.Fatalf("expected fragment to exist after UserPromptSubmit")
+			}
+			if len(frag.Tools) != tt.wantToolRecordCount {
+				t.Fatalf("len(frag.Tools) = %d, want %d", len(frag.Tools), tt.wantToolRecordCount)
+			}
+		})
 	}
 }
 

--- a/plugins/sigil/internal/agents/copilot/hook/payload.go
+++ b/plugins/sigil/internal/agents/copilot/hook/payload.go
@@ -27,6 +27,7 @@ type Payload struct {
 
 	ToolInputJSON json.RawMessage `json:"tool_input,omitempty"`
 	ToolInputJS   json.RawMessage `json:"toolInput,omitempty"`
+	ToolArgsJS    json.RawMessage `json:"toolArgs,omitempty"`
 
 	ToolResultJSON json.RawMessage `json:"tool_result,omitempty"`
 	ToolResultJS   json.RawMessage `json:"toolResult,omitempty"`
@@ -101,7 +102,7 @@ func (p Payload) ToolName() string {
 }
 
 func (p Payload) ToolInput() json.RawMessage {
-	return firstNonEmptyRaw(p.ToolInputJSON, p.ToolInputJS)
+	return firstNonEmptyRaw(p.ToolInputJSON, p.ToolInputJS, p.ToolArgsJS)
 }
 
 func (p Payload) ToolResult() json.RawMessage {

--- a/plugins/sigil/internal/agents/copilot/hook/payload_test.go
+++ b/plugins/sigil/internal/agents/copilot/hook/payload_test.go
@@ -1,10 +1,55 @@
 package hook
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestResolvedTimestampParsesStringEncodedEpochMillis(t *testing.T) {
 	got := Payload{Timestamp: []byte(`"1747579200000"`)}.ResolvedTimestamp()
 	if got != "2025-05-18T14:40:00Z" {
 		t.Fatalf("ResolvedTimestamp = %q", got)
+	}
+}
+
+func TestToolInput(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "snake_case tool_input wins",
+			raw:  `{"tool_input":{"a":1},"toolInput":{"b":2},"toolArgs":{"c":3}}`,
+			want: `{"a":1}`,
+		},
+		{
+			name: "legacy camelCase toolInput when no snake_case",
+			raw:  `{"toolInput":{"b":2},"toolArgs":{"c":3}}`,
+			want: `{"b":2}`,
+		},
+		{
+			name: "documented toolArgs when neither input present",
+			raw:  `{"toolArgs":{"c":3}}`,
+			want: `{"c":3}`,
+		},
+		{
+			name: "missing returns nil",
+			raw:  `{}`,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var p Payload
+			if err := json.Unmarshal([]byte(tt.raw), &p); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			got := string(p.ToolInput())
+			if got != tt.want {
+				t.Fatalf("ToolInput() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/plugins/sigil/internal/agents/copilot/hook_test.go
+++ b/plugins/sigil/internal/agents/copilot/hook_test.go
@@ -1,9 +1,12 @@
 package copilot
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -28,6 +31,61 @@ func TestHookUserPromptCreatesTurn(t *testing.T) {
 	got := fragment.LoadTolerant("sess", "turn-000001", logger)
 	if got == nil || got.Prompt != "hello" {
 		t.Fatalf("expected fragment with prompt, got %+v", got)
+	}
+}
+
+func TestHookPreToolUseDeniedPropagatesStdout(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("SIGIL_GUARDS_ENABLED", "true")
+	t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "true")
+	t.Setenv("SIGIL_GUARDS_TIMEOUT_MS", "1500")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"action":"deny","reason":"blocked"}`))
+	}))
+	defer server.Close()
+	t.Setenv("SIGIL_ENDPOINT", server.URL)
+	t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+	t.Setenv("SIGIL_AUTH_TOKEN", "token")
+
+	var stdout bytes.Buffer
+	payload := `{"hook_event_name":"preToolUse","session_id":"sess","tool_name":"bash","toolArgs":{"cmd":"rm -rf /"}}`
+	logger := log.New(io.Discard, "", 0)
+	if err := Hook(context.Background(), strings.NewReader(payload), &stdout, logger); err != nil {
+		t.Fatalf("Hook: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"permissionDecision":"deny"`) {
+		t.Fatalf("stdout = %q, want deny decision", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), `"permissionDecisionReason":"blocked"`) {
+		t.Fatalf("stdout = %q, want deny reason", stdout.String())
+	}
+}
+
+func TestHookPreToolUseAllowKeepsStdoutEmpty(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("SIGIL_GUARDS_ENABLED", "true")
+	t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "true")
+	t.Setenv("SIGIL_GUARDS_TIMEOUT_MS", "1500")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"action":"allow"}`))
+	}))
+	defer server.Close()
+	t.Setenv("SIGIL_ENDPOINT", server.URL)
+	t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+	t.Setenv("SIGIL_AUTH_TOKEN", "token")
+
+	var stdout bytes.Buffer
+	payload := `{"hook_event_name":"preToolUse","session_id":"sess","tool_name":"bash","toolArgs":{"cmd":"echo hi"}}`
+	logger := log.New(io.Discard, "", 0)
+	if err := Hook(context.Background(), strings.NewReader(payload), &stdout, logger); err != nil {
+		t.Fatalf("Hook: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
 	}
 }
 

--- a/plugins/sigil/internal/agents/guard/toolcall.go
+++ b/plugins/sigil/internal/agents/guard/toolcall.go
@@ -1,0 +1,197 @@
+// Package guard evaluates tool calls against Sigil guard policy and
+// returns a host-neutral result; callers translate it into their own
+// stdout response shape.
+package guard
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/grafana/sigil-sdk/go/sigil"
+
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/envconfig"
+)
+
+// ToolCallInput is the host-neutral set of fields needed to evaluate a
+// tool call against Sigil guards.
+type ToolCallInput struct {
+	// AgentName identifies the host agent (e.g. "copilot", "claude-code").
+	AgentName string
+	// AgentVersion is the host agent build version, when known.
+	AgentVersion string
+	// ModelProvider and ModelName describe the upstream model, when known.
+	ModelProvider string
+	ModelName     string
+	// ToolName is required.
+	ToolName string
+	// ToolCallID correlates the tool call with downstream telemetry, when known.
+	ToolCallID string
+	// ToolInputJSON is the raw JSON of the tool arguments, when available.
+	ToolInputJSON json.RawMessage
+}
+
+// Result is the host-neutral outcome of a guard evaluation.
+type Result struct {
+	// Action is allow or deny.
+	Action sigil.HookAction
+	// Reason is the deny reason from Sigil or the host-friendly description
+	// of a fail-closed transport/config error.
+	Reason string
+	// RuleID identifies the rule that produced a deny verdict, when known.
+	RuleID string
+}
+
+// Blocked reports whether the host should refuse to execute the tool call.
+func (r Result) Blocked() bool {
+	return r.Action == sigil.HookActionDeny
+}
+
+// EvaluateToolCall asks Sigil whether the tool call should proceed. It
+// reads SIGIL_ENDPOINT / SIGIL_AUTH_TENANT_ID / SIGIL_AUTH_TOKEN from the
+// process environment and honours envconfig.GuardsConfig for the
+// enabled/timeout/fail-open knobs. Callers are expected to gate this
+// helper behind cfg.Enabled — when disabled it short-circuits to allow.
+//
+// Behaviour:
+//   - guards disabled or tool name empty: returns allow.
+//   - credentials missing and fail-open: returns allow.
+//   - credentials missing and fail-closed: returns deny with a credentials reason.
+//   - Sigil returns allow: returns allow.
+//   - Sigil returns deny: returns deny with the rule reason.
+//   - transport error and fail-open: returns allow (matches SDK behaviour).
+//   - transport error and fail-closed: returns deny with a transport reason.
+func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCallInput, logger *log.Logger) Result {
+	if !cfg.Enabled {
+		return Result{Action: sigil.HookActionAllow}
+	}
+	if strings.TrimSpace(in.ToolName) == "" {
+		return Result{Action: sigil.HookActionAllow}
+	}
+
+	endpoint := strings.TrimSpace(os.Getenv("SIGIL_ENDPOINT"))
+	tenantID := strings.TrimSpace(os.Getenv("SIGIL_AUTH_TENANT_ID"))
+	authToken := strings.TrimSpace(os.Getenv("SIGIL_AUTH_TOKEN"))
+	if endpoint == "" || tenantID == "" || authToken == "" {
+		if cfg.FailOpen {
+			if logger != nil {
+				logger.Printf("guard: missing SIGIL_* credentials; failing open")
+			}
+			return Result{Action: sigil.HookActionAllow}
+		}
+		if logger != nil {
+			logger.Printf("guard: missing SIGIL_* credentials; failing closed")
+		}
+		return Result{
+			Action: sigil.HookActionDeny,
+			Reason: "sigil guard evaluation unavailable: missing SIGIL_ENDPOINT/SIGIL_AUTH_TENANT_ID/SIGIL_AUTH_TOKEN",
+		}
+	}
+
+	failOpen := cfg.FailOpen
+	clientCfg := sigil.Config{
+		API: sigil.APIConfig{
+			Endpoint: endpoint,
+		},
+		Hooks: sigil.HooksConfig{
+			Enabled:  true,
+			Phases:   []sigil.HookPhase{sigil.HookPhasePostflight},
+			Timeout:  time.Duration(cfg.TimeoutMs) * time.Millisecond,
+			FailOpen: &failOpen,
+		},
+		GenerationExport: sigil.GenerationExportConfig{
+			Auth: sigil.AuthConfig{
+				Mode:          sigil.ExportAuthModeBasic,
+				BasicUser:     tenantID,
+				BasicPassword: authToken,
+				TenantID:      tenantID,
+			},
+		},
+	}
+
+	client := sigil.NewClient(clientCfg)
+	defer func() { _ = client.Shutdown(ctx) }()
+
+	provider := strings.TrimSpace(in.ModelProvider)
+	if provider == "" {
+		provider = "unknown"
+	}
+	modelName := strings.TrimSpace(in.ModelName)
+	if modelName == "" {
+		modelName = "unknown"
+	}
+	hookCtx := sigil.HookContext{
+		AgentName:    in.AgentName,
+		AgentVersion: in.AgentVersion,
+		Model: &sigil.HookModel{
+			Provider: provider,
+			Name:     modelName,
+		},
+	}
+
+	req := sigil.HookEvaluateRequest{
+		Phase:   sigil.HookPhasePostflight,
+		Context: hookCtx,
+		Input: sigil.HookInput{
+			Output: []sigil.Message{{
+				Role: sigil.RoleAssistant,
+				Parts: []sigil.Part{{
+					Kind: sigil.PartKindToolCall,
+					ToolCall: &sigil.ToolCall{
+						ID:        strings.TrimSpace(in.ToolCallID),
+						Name:      in.ToolName,
+						InputJSON: in.ToolInputJSON,
+					},
+				}},
+			}},
+		},
+	}
+
+	resp, err := client.EvaluateHook(ctx, req)
+	if err != nil {
+		// The SDK only returns an error when FailOpen=false; the fail-open
+		// path yields an allow response with nil err. So an error here
+		// always means strict mode and we should report deny.
+		if logger != nil {
+			logger.Printf("guard: tool=%q endpoint=%q evaluate err=%v", in.ToolName, endpoint, err)
+		}
+		return Result{
+			Action: sigil.HookActionDeny,
+			Reason: "sigil guard evaluation failed: " + err.Error(),
+		}
+	}
+
+	if resp != nil && logger != nil {
+		logger.Printf(
+			"guard: tool=%q endpoint=%q action=%q rule_id=%q reason=%q",
+			in.ToolName,
+			endpoint,
+			string(resp.Action),
+			resp.RuleID,
+			resp.Reason,
+		)
+	}
+
+	if deniedErr := sigil.HookDeniedFromResponse(resp); deniedErr != nil {
+		reason := "tool call denied by Sigil guard"
+		var denied *sigil.HookDeniedError
+		if errors.As(deniedErr, &denied) && strings.TrimSpace(denied.Reason) != "" {
+			reason = denied.Reason
+		}
+		ruleID := ""
+		if resp != nil {
+			ruleID = resp.RuleID
+		}
+		return Result{
+			Action: sigil.HookActionDeny,
+			Reason: reason,
+			RuleID: ruleID,
+		}
+	}
+
+	return Result{Action: sigil.HookActionAllow}
+}

--- a/plugins/sigil/internal/agents/guard/toolcall_test.go
+++ b/plugins/sigil/internal/agents/guard/toolcall_test.go
@@ -1,0 +1,152 @@
+package guard
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/grafana/sigil-sdk/go/sigil"
+
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/envconfig"
+)
+
+func TestEvaluateToolCall(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            envconfig.GuardsConfig
+		serverResponds string
+		// useClosedServer makes the helper connect to a closed listener so
+		// the request fails at transport.
+		useClosedServer bool
+		// clearCreds blanks the SIGIL_ENDPOINT/SIGIL_AUTH_TENANT_ID/
+		// SIGIL_AUTH_TOKEN env vars before the call.
+		clearCreds       bool
+		toolName         string
+		wantAction       sigil.HookAction
+		wantReasonSub    string
+		wantServerCalled bool
+	}{
+		{
+			name:       "disabled returns allow without contacting sigil",
+			cfg:        envconfig.GuardsConfig{Enabled: false, TimeoutMs: 1500, FailOpen: true},
+			toolName:   "bash",
+			wantAction: sigil.HookActionAllow,
+		},
+		{
+			name:       "empty tool name returns allow",
+			cfg:        envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			toolName:   "",
+			wantAction: sigil.HookActionAllow,
+		},
+		{
+			name:             "allow response from sigil",
+			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:   `{"action":"allow"}`,
+			toolName:         "bash",
+			wantAction:       sigil.HookActionAllow,
+			wantServerCalled: true,
+		},
+		{
+			name:             "deny response from sigil",
+			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:   `{"action":"deny","reason":"blocked tool","rule_id":"r-1"}`,
+			toolName:         "bash",
+			wantAction:       sigil.HookActionDeny,
+			wantReasonSub:    "blocked tool",
+			wantServerCalled: true,
+		},
+		{
+			name:            "transport error fails open",
+			cfg:             envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			useClosedServer: true,
+			toolName:        "bash",
+			wantAction:      sigil.HookActionAllow,
+		},
+		{
+			name:            "transport error fails closed",
+			cfg:             envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: false},
+			useClosedServer: true,
+			toolName:        "bash",
+			wantAction:      sigil.HookActionDeny,
+			wantReasonSub:   "sigil guard evaluation failed",
+		},
+		{
+			name:          "missing credentials fail open",
+			cfg:           envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			clearCreds:    true,
+			toolName:      "bash",
+			wantAction:    sigil.HookActionAllow,
+			wantReasonSub: "",
+		},
+		{
+			name:          "missing credentials fail closed",
+			cfg:           envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: false},
+			clearCreds:    true,
+			toolName:      "bash",
+			wantAction:    sigil.HookActionDeny,
+			wantReasonSub: "missing SIGIL_ENDPOINT",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls.Add(1)
+				body := tt.serverResponds
+				if body == "" {
+					body = `{"action":"allow"}`
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(body))
+			}))
+			defer server.Close()
+
+			closed := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			closed.Close()
+
+			endpoint := server.URL
+			if tt.useClosedServer {
+				endpoint = closed.URL
+			}
+			if tt.clearCreds {
+				t.Setenv("SIGIL_ENDPOINT", "")
+				t.Setenv("SIGIL_AUTH_TENANT_ID", "")
+				t.Setenv("SIGIL_AUTH_TOKEN", "")
+			} else {
+				t.Setenv("SIGIL_ENDPOINT", endpoint)
+				t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+				t.Setenv("SIGIL_AUTH_TOKEN", "token")
+			}
+
+			res := EvaluateToolCall(context.Background(), tt.cfg, ToolCallInput{
+				AgentName:     "copilot",
+				AgentVersion:  "dev",
+				ModelProvider: "openai",
+				ModelName:     "gpt-4",
+				ToolName:      tt.toolName,
+				ToolCallID:    "tu_1",
+				ToolInputJSON: json.RawMessage(`{"cmd":"echo hi"}`),
+			}, log.New(io.Discard, "", 0))
+
+			if res.Action != tt.wantAction {
+				t.Fatalf("Action = %q, want %q", res.Action, tt.wantAction)
+			}
+			if tt.wantReasonSub != "" && !strings.Contains(res.Reason, tt.wantReasonSub) {
+				t.Fatalf("Reason = %q, want substring %q", res.Reason, tt.wantReasonSub)
+			}
+			if tt.wantServerCalled && calls.Load() == 0 {
+				t.Errorf("expected sigil hook server to be called, got 0 calls")
+			}
+			if !tt.wantServerCalled && !tt.useClosedServer && calls.Load() != 0 {
+				t.Errorf("did not expect sigil hook server call, got %d", calls.Load())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add tool call guards support to the GitHub Copilot plugin.

<img width="479" height="153" alt="image" src="https://github.com/user-attachments/assets/58a44b2d-4b82-45db-a6df-6a129160244a" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Guards can block Copilot tool execution on every preToolUse when enabled; default is off with fail-open, but strict mode or misconfiguration could deny legitimate tools or add per-call latency.
> 
> **Overview**
> Adds **optional Sigil tool-call guards** to the GitHub Copilot CLI plugin (v0.2.0). When `SIGIL_GUARDS_ENABLED` is set, each `preToolUse` hook calls Sigil before the tool runs; denials write Copilot’s `permissionDecision: deny` JSON to stdout and **skip** pending tool telemetry.
> 
> A shared `guard.EvaluateToolCall` helper wraps the Sigil hook API with configurable **timeout** and **fail-open vs fail-closed** behavior for missing credentials or network errors. Copilot config loads `SIGIL_GUARDS_*` via existing `envconfig.ResolveGuards`.
> 
> **Payload/hooks:** `toolArgs` is accepted for tool input; wildcard `matcher` entries were removed from `hooks.json`. README documents the new env vars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c00d6cc770e9aeece3266927e2a34f1d62f3df7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->