### PR TITLE
fix(ci): install mise so plugin builds find it

### DIFF
--- a/.github/workflows/plugins-publish.yml
+++ b/.github/workflows/plugins-publish.yml
@@ -64,6 +64,12 @@ jobs:
           node-version: "24"
           cache: pnpm
 
+      - name: Setup mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          install: true
+          cache: true
+
       - run: pnpm install --frozen-lockfile
 
       - name: Resolve plugin list


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change mirroring an existing setup step; no runtime or application code affected.
> 
> **Overview**
> The **plugin publish** workflow’s `prepare` job now installs **mise** (same `jdx/mise-action` step as main CI) before `pnpm install` and the bump/build/pack loop.
> 
> That aligns publish with how plugin packages are built locally and in CI: their `prebuild` / `pretypecheck` / `pretest` scripts invoke `mise run build:ts:sdk-js`, which was missing on the publish runner and could break `pnpm … run build` during release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd95de251380aa4b7618a67bc123a3c52805be45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->