### PR TITLE
ci(plugins/sigil): add release workflow

### DIFF
--- a/.github/scripts/changelog-for-plugin.sh
+++ b/.github/scripts/changelog-for-plugin.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Generate a markdown changelog section for a plugin release.
+#
+# Usage:
+#   changelog-for-plugin.sh <plugin-path> <new-version>
+#
+# Example:
+#   .github/scripts/changelog-for-plugin.sh plugins/sigil 0.7.0
+#
+# Walks `git log <last-tag>..HEAD -- <plugin-path>/` and groups commits
+# by their conventional-commit type. Squash-merge subjects already carry
+# the `(#PR)` suffix, so the output is link-ready on GitHub.
+#
+# Prints the section (one ## heading + body) to stdout. Does not touch
+# any files. Caller is responsible for prepending the output to
+# CHANGELOG.md.
+
+set -euo pipefail
+
+PLUGIN="${1:-}"
+NEW="${2:-}"
+
+if [[ -z "$PLUGIN" || -z "$NEW" ]]; then
+  echo "usage: $0 <plugin-path> <new-version>" >&2
+  exit 64
+fi
+
+# Find the previous tag for this plugin. If none, walk full history.
+PREV=$(git tag -l "${PLUGIN}/v*" | sort -V | tail -1 || true)
+if [[ -n "$PREV" ]]; then
+  RANGE="${PREV}..HEAD"
+else
+  RANGE="HEAD"
+fi
+
+# Only commits that actually touched files under the plugin path.
+COMMITS=$(git log --no-merges --pretty=format:'%s' "$RANGE" -- "${PLUGIN}/" || true)
+
+emit_section() {
+  local title="$1" pattern="$2" matched
+  matched=$(grep -E "$pattern" <<<"$COMMITS" || true)
+  [[ -z "$matched" ]] && return
+  printf '### %s\n\n' "$title"
+  # Drop the leading `type` but keep the scope as a bold prefix when present,
+  # so `feat(plugins/copilot): foo` -> `- **plugins/copilot**: foo` and a
+  # bare `feat: foo` -> `- foo`.
+  printf '%s\n' "$matched" \
+    | sed -E 's/^[a-z]+\(([^)]+)\)!?: /- **\1**: /' \
+    | sed -E 's/^[a-z]+!?: /- /'
+  printf '\n'
+}
+
+printf '## [%s] - %s\n\n' "$NEW" "$(date +%Y-%m-%d)"
+
+# Breaking changes first (any type with `!:` suffix). Keep them out of
+# type-specific sections so each commit appears once.
+emit_section 'Breaking Changes' '^[a-z]+(\([^)]+\))?!: '
+emit_section 'Features'         '^feat(\([^)]+\))?: '
+emit_section 'Bug Fixes'        '^fix(\([^)]+\))?: '
+emit_section 'Performance'      '^perf(\([^)]+\))?: '
+emit_section 'Documentation'    '^docs(\([^)]+\))?: '
+
+if ! grep -qE '^([a-z]+(\([^)]+\))?!: |(feat|fix|perf|docs)(\([^)]+\))?: )' <<<"$COMMITS"; then
+  printf '_No user-facing changes._\n\n'
+fi

--- a/.github/scripts/changelog-for-plugin.test.sh
+++ b/.github/scripts/changelog-for-plugin.test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Tests for changelog-for-plugin.sh. Exits non-zero on any failure.
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+CHANGELOG="${DIR}/changelog-for-plugin.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+fail=0
+pass=0
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if grep -Fq -- "$needle" <<<"$haystack"; then
+    pass=$((pass + 1))
+  else
+    echo "FAIL ${desc}: missing '${needle}'"
+    echo "--- output ---"
+    printf '%s\n' "$haystack"
+    echo "--------------"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if grep -Fq -- "$needle" <<<"$haystack"; then
+    echo "FAIL ${desc}: unexpected '${needle}'"
+    echo "--- output ---"
+    printf '%s\n' "$haystack"
+    echo "--------------"
+    fail=$((fail + 1))
+  else
+    pass=$((pass + 1))
+  fi
+}
+
+assert_count() {
+  local desc="$1" needle="$2" want="$3" haystack="$4" got
+  got=$(grep -F -c -- "$needle" <<<"$haystack")
+  if [[ "$got" == "$want" ]]; then
+    pass=$((pass + 1))
+  else
+    echo "FAIL ${desc}: '${needle}' appeared ${got} times, want ${want}"
+    echo "--- output ---"
+    printf '%s\n' "$haystack"
+    echo "--------------"
+    fail=$((fail + 1))
+  fi
+}
+
+commit_plugin() {
+  local msg="$1"
+  printf '%s\n' "$msg" >> plugins/sigil/file.txt
+  git add plugins/sigil/file.txt
+  git commit -q -m "$msg"
+}
+
+cd "$TMP" || exit 1
+git init -q
+git config user.name 'Test User'
+git config user.email 'test@example.com'
+
+mkdir -p plugins/sigil plugins/pi
+printf 'seed\n' > plugins/sigil/file.txt
+git add plugins/sigil/file.txt
+git commit -q -m 'feat(plugins/sigil): initial release'
+git tag plugins/sigil/v0.1.0
+
+commit_plugin 'feat!: rename config key'
+commit_plugin 'chore!: drop old flag'
+commit_plugin 'fix(plugins/sigil): repair login'
+commit_plugin 'docs: update sigil docs'
+printf 'pi\n' > plugins/pi/file.txt
+git add plugins/pi/file.txt
+git commit -q -m 'feat(plugins/pi): unrelated plugin change'
+
+out=$("$CHANGELOG" plugins/sigil 0.2.0)
+assert_contains 'breaking section exists' '### Breaking Changes' "$out"
+assert_contains 'breaking feat listed' '- rename config key' "$out"
+assert_contains 'breaking chore listed' '- drop old flag' "$out"
+assert_count 'breaking feat is not duplicated' '- rename config key' 1 "$out"
+assert_count 'breaking chore is not contradicted by fallback' '- drop old flag' 1 "$out"
+assert_not_contains 'breaking feat excluded from feature section' '### Features' "$out"
+assert_not_contains 'breaking changes count as user-facing' '_No user-facing changes._' "$out"
+assert_contains 'scoped fix keeps scope' '- **plugins/sigil**: repair login' "$out"
+assert_contains 'docs section exists' '### Documentation' "$out"
+assert_contains 'docs entry listed' '- update sigil docs' "$out"
+assert_not_contains 'other plugin path excluded' 'unrelated plugin change' "$out"
+
+git tag plugins/sigil/v0.2.0
+commit_plugin 'chore: internal cleanup'
+
+out=$("$CHANGELOG" plugins/sigil 0.3.0)
+assert_contains 'non-user-facing fallback' '_No user-facing changes._' "$out"
+assert_not_contains 'non-breaking chore omitted' 'internal cleanup' "$out"
+
+echo "passed: ${pass}, failed: ${fail}"
+[[ $fail -eq 0 ]]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Test bump-version.sh
         run: ./.github/scripts/bump-version.test.sh
 
+      - name: Test changelog-for-plugin.sh
+        run: ./.github/scripts/changelog-for-plugin.test.sh
+
   proto:
     name: Protobuf drift
     runs-on: ubuntu-latest

--- a/.github/workflows/release-sigil.yml
+++ b/.github/workflows/release-sigil.yml
@@ -1,0 +1,146 @@
+name: Release plugins/sigil
+
+# Opens a release PR that bumps the changelog. The tag is created by
+# tag-sigil-on-merge.yml when this PR merges into main, so the tag always
+# points at a real commit on main (which Homebrew, `go install`, and humans
+# pulling main all expect).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Semver bump (applied to the latest plugins/sigil/v* tag)'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      dry-run:
+        description: 'Preview only, do not open the release PR'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    if: github.repository == 'grafana/sigil-sdk' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Generate GitHub token
+        id: generate-github-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
+        with:
+          github_app: grafana-plugins-platform-bot
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.generate-github-token.outputs.token }}
+          persist-credentials: true
+          fetch-depth: 0  # changelog script needs full git history
+
+      - name: Setup Git
+        run: |
+          git config user.name 'grafana-plugins-platform-bot[bot]'
+          git config user.email '144369747+grafana-plugins-platform-bot[bot]@users.noreply.github.com'
+
+      - name: Compute next version
+        id: ver
+        env:
+          BUMP: ${{ inputs.version }}
+        run: |
+          CURRENT=$(git tag -l 'plugins/sigil/v*' | sed 's|plugins/sigil/v||' | sort -V | tail -1)
+          CURRENT=${CURRENT:-0.0.0}
+
+          # Fail if the changelog is already ahead of the latest tag, so we
+          # don't re-emit a duplicate section after a previous tag step failed.
+          TOP=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' plugins/sigil/CHANGELOG.md 2>/dev/null | tr -d '#[] ' || true)
+          if [[ -n "$TOP" && "$(printf '%s\n%s\n' "$TOP" "$CURRENT" | sort -V | tail -1)" == "$TOP" && "$TOP" != "$CURRENT" ]]; then
+            echo "::error::CHANGELOG top v${TOP} is ahead of tag plugins/sigil/v${CURRENT}; create the missing tag and retry."
+            exit 1
+          fi
+
+          NEW=$(./.github/scripts/bump-version.sh "$BUMP" "$CURRENT")
+          echo "current=${CURRENT}" >> "$GITHUB_OUTPUT"
+          echo "new=${NEW}" >> "$GITHUB_OUTPUT"
+
+      - name: Update CHANGELOG.md
+        id: cl
+        env:
+          BUMP: ${{ inputs.version }}
+          CURRENT: ${{ steps.ver.outputs.current }}
+          DRY_RUN: ${{ inputs.dry-run }}
+          NEW: ${{ steps.ver.outputs.new }}
+        run: |
+          NEW_SECTION=$(./.github/scripts/changelog-for-plugin.sh plugins/sigil "$NEW")
+
+          # Prepend the new section, then the existing body (minus its old
+          # top-level header so we don't duplicate it).
+          {
+            printf '# Changelog\n\n'
+            printf '%s\n' "$NEW_SECTION"
+            if [[ -f plugins/sigil/CHANGELOG.md ]]; then
+              awk 'NR==1 && /^# /{next} {print}' plugins/sigil/CHANGELOG.md
+            fi
+          } > /tmp/CHANGELOG.md
+          mv /tmp/CHANGELOG.md plugins/sigil/CHANGELOG.md
+
+          # Stash the section for the PR body and the run summary.
+          {
+            echo 'section<<EOF'
+            printf '%s\n' "$NEW_SECTION"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo '## Release plan'
+            echo ''
+            echo "- bump: \`${BUMP}\`"
+            echo "- current: \`v${CURRENT}\`"
+            echo "- new: \`v${NEW}\`"
+            echo "- dry-run: \`${DRY_RUN}\`"
+            echo ''
+            echo '### Changelog section'
+            echo ''
+            printf '%s\n' "$NEW_SECTION"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open release PR
+        if: ${{ !inputs.dry-run }}
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+          GH_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+          NEW: ${{ steps.ver.outputs.new }}
+          SECTION: ${{ steps.cl.outputs.section }}
+          REPO: ${{ github.repository }}
+        run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git"
+
+          BRANCH="release/plugins-sigil-v${NEW}"
+          git checkout -b "$BRANCH"
+          git add plugins/sigil/CHANGELOG.md
+          git commit -m "chore(plugins/sigil): release v${NEW}"
+          git push origin "$BRANCH"
+
+          {
+            printf "Releases \`plugins/sigil/v%s\`.\n\n" "$NEW"
+            printf '%s\n\n' "$SECTION"
+            printf '---\n\n'
+            printf "The tag \`plugins/sigil/v%s\` will be created automatically by \`tag-sigil-on-merge.yml\` when this PR merges into main.\n\n" "$NEW"
+            printf "Generated by \`.github/workflows/release-sigil.yml\`.\n"
+          } > /tmp/pr-body.md
+
+          gh pr create \
+            --title "chore(plugins/sigil): release v${NEW}" \
+            --body-file /tmp/pr-body.md \
+            --base main \
+            --head "$BRANCH"

--- a/.github/workflows/tag-sigil-on-merge.yml
+++ b/.github/workflows/tag-sigil-on-merge.yml
@@ -1,0 +1,75 @@
+name: Tag plugins/sigil on merge
+
+# Pairs with release-sigil.yml. When that workflow's release PR merges,
+# plugins/sigil/CHANGELOG.md changes on main; this workflow reads the
+# top version heading and creates `plugins/sigil/v<version>` at the
+# merge commit.
+#
+# Idempotent: if the tag already exists it does nothing, so manual
+# edits to the changelog won't re-tag.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'plugins/sigil/CHANGELOG.md'
+
+permissions:
+  contents: read
+
+jobs:
+  tag:
+    if: github.repository == 'grafana/sigil-sdk'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Generate GitHub token
+        id: generate-github-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
+        with:
+          github_app: grafana-plugins-platform-bot
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.generate-github-token.outputs.token }}
+          persist-credentials: true
+          fetch-depth: 0
+
+      - name: Setup Git
+        run: |
+          git config user.name 'grafana-plugins-platform-bot[bot]'
+          git config user.email '144369747+grafana-plugins-platform-bot[bot]@users.noreply.github.com'
+
+      - name: Read top version from CHANGELOG.md
+        id: ver
+        run: |
+          # First `## [X.Y.Z]` heading in the file is the just-released version.
+          VERSION=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' plugins/sigil/CHANGELOG.md || true)
+          VERSION=${VERSION#'## ['}
+          VERSION=${VERSION%']'}
+          if [[ -z "$VERSION" ]]; then
+            echo "No \`## [X.Y.Z]\` heading found; nothing to tag."
+            exit 0
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag if missing
+        if: steps.ver.outputs.version != ''
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          TAG="plugins/sigil/v${VERSION}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists; nothing to do."
+            exit 0
+          fi
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git"
+          git tag -a "$TAG" -m "plugins/sigil ${VERSION}"
+          git push origin "$TAG"
+          echo "Created and pushed ${TAG}" >> "$GITHUB_STEP_SUMMARY"

--- a/plugins/sigil/CHANGELOG.md
+++ b/plugins/sigil/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+## [0.6.0] - 2026-05-26
+
+### Features
+
+- **plugins/sigil**: add local capture mode (#186)
+
+### Bug Fixes
+
+- pin transitive dependencies (#208)
+- **plugins/claude**: advance offset only after assistant response (#187)
+
+## [0.5.0] - 2026-05-21
+
+### Features
+
+- **plugins/copilot**: add sigil copilot launcher (#181)
+- **plugins/claude**: support SIGIL_GUARDS_* env vars in Claude Code plugin (#178)
+- **plugins/copilot**: move copilot plugin into sigil single binary (#176)
+- **plugins/codex**: add sigil codex command (#177)
+
+## [0.4.0] - 2026-05-20
+
+### Features
+
+- **plugins/claude**: preserve Claude Code offsets on empty batches (#175)
+- **plugins**: add interactive login flow for sigil (#172)
+- **plugins**: add copilot plugin (#164)
+
+### Bug Fixes
+
+- **sdk/go**: surface async export failures through Flush() (#171)
+
+### Documentation
+
+- **plugins**: switch install instructions to brew and simplify (#174)
+
+## [0.3.0] - 2026-05-20
+
+### Features
+
+- **plugins/sigil**: add `sigil claude` launcher with plugin bootstrap (#167)
+- **plugins/sigil**: add pi launcher subcommand (#166)
+
+## [0.2.0] - 2026-05-19
+
+### Features
+
+- **plugins**: consolidate claude-code, codex, cursor plugin helpers into single binary (#163)


### PR DESCRIPTION
Adds a PR-based release flow for `plugins/sigil`.

The release workflow:

- computes the next `plugins/sigil` version from the latest `plugins/sigil/v*` tag
- generates a changelog section
- opens a PR
- tags the merge commit after the release PR is merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are release automation, shell scripts, and documentation only; no runtime product code paths.
> 
> **Overview**
> Adds a **PR-based release pipeline** for `plugins/sigil`: a dispatch workflow computes the next semver from `plugins/sigil/v*` tags, builds a changelog section from commits since the last tag (via new `changelog-for-plugin.sh`), prepends it to `plugins/sigil/CHANGELOG.md`, and optionally opens a release PR (dry-run by default). A separate push workflow on `plugins/sigil/CHANGELOG.md` creates the annotated tag at the merge commit if it does not already exist.
> 
> Also adds **shell tests** for the changelog script in CI and seeds **`plugins/sigil/CHANGELOG.md`** with historical release notes. The release job guards against a changelog version ahead of the latest tag to avoid duplicate sections after a failed tag step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 887092136d629cfe95651d32b261859dd597f707. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->