### PR TITLE
refactor(plugins/claude): use shared tool guards functions

### DIFF
--- a/plugins/sigil/internal/agents/claudecode/hook.go
+++ b/plugins/sigil/internal/agents/claudecode/hook.go
@@ -6,7 +6,6 @@ package claudecode
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -19,6 +18,7 @@ import (
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/claudecode/mapper"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/claudecode/state"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/claudecode/transcript"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/guard"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/envconfig"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/otel"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/redact"
@@ -49,17 +49,6 @@ type hookInput struct {
 	ToolUseID      string          `json:"tool_use_id,omitempty"`
 }
 
-type hookDecision struct {
-	HookSpecificOutput hookSpecificOutput `json:"hookSpecificOutput"`
-}
-
-type hookSpecificOutput struct {
-	HookEventName            string `json:"hookEventName"`
-	PermissionDecision       string `json:"permissionDecision,omitempty"`
-	PermissionDecisionReason string `json:"permissionDecisionReason,omitempty"`
-	AdditionalContext        string `json:"additionalContext,omitempty"`
-}
-
 // Hook reads a single Claude Code hook payload from stdin, processes it, and
 // optionally writes a decision response to stdout. Returns an error only on
 // payload-shaped failures the dispatcher should log — runtime telemetry
@@ -71,6 +60,32 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 		return nil
 	}
 	logger.Printf("event=%s session=%s transcript=%s", input.HookEventName, input.SessionID, input.TranscriptPath)
+
+	st := state.Load(input.SessionID)
+
+	// Route lightweight events that do not need real Sigil credentials first.
+	// SessionStart only updates local state; PreToolUse calls into the shared
+	// guard helper which manages its own credentials, timeouts, and
+	// fail-open/closed behaviour. Routing these before the missing-creds
+	// gate below means strict guard mode can still deny when SIGIL_* env
+	// vars are absent.
+	switch strings.TrimSpace(input.HookEventName) {
+	case "SessionStart":
+		st.Model = strings.TrimSpace(input.Model)
+		if err := state.Save(input.SessionID, st); err != nil {
+			logger.Printf("save state: %v", err)
+		}
+		return nil
+	case "PreToolUse":
+		guardCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		handlePreToolUse(guardCtx, stdout, input, st, logger)
+		return nil
+	case "", "Stop", "SessionEnd":
+		// Fall through to transcript export below.
+	default:
+		return nil
+	}
 
 	sigilEndpoint := os.Getenv("SIGIL_ENDPOINT")
 	tenantID := os.Getenv("SIGIL_AUTH_TENANT_ID")
@@ -103,24 +118,6 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 	hookCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	hookCtx = sigil.WithUserID(hookCtx, userID)
-
-	st := state.Load(input.SessionID)
-
-	switch strings.TrimSpace(input.HookEventName) {
-	case "", "Stop", "SessionEnd":
-		// Stop and SessionEnd hooks use the transcript to export generations.
-	case "SessionStart":
-		st.Model = strings.TrimSpace(input.Model)
-		if err := state.Save(input.SessionID, st); err != nil {
-			logger.Printf("save state: %v", err)
-		}
-		return nil
-	case "PreToolUse":
-		handlePreToolUse(hookCtx, stdout, input, st, sigilEndpoint, tenantID, authToken, logger)
-		return nil
-	default:
-		return nil
-	}
 
 	otelProviders, err := otel.Setup(hookCtx, input.SessionID)
 	if err != nil {
@@ -237,123 +234,23 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 	return nil
 }
 
-func handlePreToolUse(
-	ctx context.Context,
-	stdout io.Writer,
-	input *hookInput,
-	st state.Session,
-	sigilEndpoint, tenantID, authToken string,
-	logger *log.Logger,
-) {
-	toolName := strings.TrimSpace(input.ToolName)
-	if toolName == "" {
-		return
-	}
-
-	guards := envconfig.ResolveGuards(logger)
-	if !guards.Enabled {
-		return
-	}
-
-	modelName := strings.TrimSpace(st.Model)
-	if modelName == "" {
-		modelName = "unknown"
-	}
-
-	failOpen := guards.FailOpen
-	cfg := sigil.Config{
-		API: sigil.APIConfig{
-			Endpoint: sigilEndpoint,
-		},
-		Hooks: sigil.HooksConfig{
-			Enabled:  true,
-			Phases:   []sigil.HookPhase{sigil.HookPhasePostflight},
-			Timeout:  time.Duration(guards.TimeoutMs) * time.Millisecond,
-			FailOpen: &failOpen,
-		},
-		GenerationExport: sigil.GenerationExportConfig{
-			Auth: sigil.AuthConfig{
-				Mode:          sigil.ExportAuthModeBasic,
-				BasicUser:     tenantID,
-				BasicPassword: authToken,
-				TenantID:      tenantID,
-			},
-		},
-	}
-
-	client := sigil.NewClient(cfg)
-	defer func() { _ = client.Shutdown(ctx) }()
-
-	req := sigil.HookEvaluateRequest{
-		Phase: sigil.HookPhasePostflight,
-		Context: sigil.HookContext{
-			AgentName:    AgentName,
-			AgentVersion: Version,
-			Model:        &sigil.HookModel{Provider: "anthropic", Name: modelName},
-		},
-		Input: sigil.HookInput{
-			Output: []sigil.Message{{
-				Role: sigil.RoleAssistant,
-				Parts: []sigil.Part{{
-					Kind: sigil.PartKindToolCall,
-					ToolCall: &sigil.ToolCall{
-						ID:        strings.TrimSpace(input.ToolUseID),
-						Name:      toolName,
-						InputJSON: input.ToolInput,
-					},
-				}},
-			}},
-		},
-	}
-	if payload, mErr := json.Marshal(req); mErr == nil {
-		logger.Printf("pre_tool_use hook request: %s", string(payload))
-	}
-
-	resp, err := client.EvaluateHook(ctx, req)
-	if err != nil {
-		// The SDK only surfaces an error when FailOpen=false; the fail-open path
-		// returns an allow response with nil err. So reaching here implies strict
-		// mode and we should always emit the deny.
-		logger.Printf("pre_tool_use hook eval: tool=%q endpoint=%q err=%v", toolName, sigilEndpoint, err)
-		out := hookDecision{
-			HookSpecificOutput: hookSpecificOutput{
-				HookEventName:            "PreToolUse",
-				PermissionDecision:       "deny",
-				PermissionDecisionReason: fmt.Sprintf("sigil guard evaluation failed: %v", err),
-			},
-		}
-		_ = json.NewEncoder(stdout).Encode(out)
-		return
-	}
-
-	if resp != nil {
-		logger.Printf(
-			"pre_tool_use hook eval: tool=%q endpoint=%q action=%q rule_id=%q reason=%q",
-			toolName,
-			sigilEndpoint,
-			string(resp.Action),
-			resp.RuleID,
-			resp.Reason,
-		)
-	}
-
-	if deniedErr := sigil.HookDeniedFromResponse(resp); deniedErr != nil {
-		reason := "tool call denied by Sigil guard"
-		var denied *sigil.HookDeniedError
-		if errors.As(deniedErr, &denied) && strings.TrimSpace(denied.Reason) != "" {
-			reason = denied.Reason
-		}
-		if strings.TrimSpace(reason) == "" {
-			reason = "tool call denied by Sigil guard"
-		}
-		out := hookDecision{
-			HookSpecificOutput: hookSpecificOutput{
-				HookEventName:            "PreToolUse",
-				PermissionDecision:       "deny",
-				PermissionDecisionReason: reason,
-			},
-		}
-		_ = json.NewEncoder(stdout).Encode(out)
+// handlePreToolUse evaluates the tool call against Sigil guards and writes a
+// PreToolUse deny envelope to stdout when the call is blocked. All Sigil
+// transport, credential, fail-open/closed, and local-endpoint placeholder
+// behaviour lives in the shared guard helper so this stays in lockstep with
+// the codex and copilot agents.
+func handlePreToolUse(ctx context.Context, stdout io.Writer, input *hookInput, st state.Session, logger *log.Logger) {
+	res := guard.EvaluateToolCall(ctx, envconfig.ResolveGuards(logger), guard.ToolCallInput{
+		AgentName:     AgentName,
+		AgentVersion:  Version,
+		ModelProvider: "anthropic",
+		ModelName:     strings.TrimSpace(st.Model),
+		ToolName:      strings.TrimSpace(input.ToolName),
+		ToolCallID:    strings.TrimSpace(input.ToolUseID),
+		ToolInputJSON: input.ToolInput,
+	}, logger)
+	if res.Blocked() {
+		guard.WriteHookSpecificOutputDeny(stdout, res.Reason)
 	}
 }
 

--- a/plugins/sigil/internal/agents/claudecode/hook_test.go
+++ b/plugins/sigil/internal/agents/claudecode/hook_test.go
@@ -178,6 +178,13 @@ func TestHookEventRouting(t *testing.T) {
 	}
 }
 
+// TestHandlePreToolUse covers Claude-Code-specific wiring around the shared
+// guard helper: ensuring the helper is consulted only when guards are
+// enabled, that allow verdicts produce empty stdout, and that deny verdicts
+// produce the Claude Code PreToolUse envelope (hookSpecificOutput +
+// hookEventName=PreToolUse). Deep behaviour around fail-open/closed,
+// missing credentials, and transport errors lives in the guard package
+// tests; this test only verifies the integration shape.
 func TestHandlePreToolUse(t *testing.T) {
 	var calls atomic.Int32
 	var responseBody atomic.Value
@@ -193,55 +200,36 @@ func TestHandlePreToolUse(t *testing.T) {
 	}))
 	defer server.Close()
 
-	closed := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	closed.Close()
-
 	tests := []struct {
 		name               string
 		env                map[string]string
-		useClosedEndpoint  bool
 		serverResponds     string
 		expectServerCall   bool
-		wantStdoutContains string
+		wantStdoutContains []string
 		wantStdoutEmpty    bool
 	}{
 		{
-			name:            "disabled_by_default_no_env",
+			name:            "disabled_by_default",
 			wantStdoutEmpty: true,
 		},
 		{
-			name:            "disabled_explicit_false",
-			env:             map[string]string{"SIGIL_GUARDS_ENABLED": "false"},
-			wantStdoutEmpty: true,
-		},
-		{
-			name:             "enabled_allow_response",
+			name:             "enabled_allow",
 			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
 			serverResponds:   `{"action":"allow"}`,
 			expectServerCall: true,
 			wantStdoutEmpty:  true,
 		},
 		{
-			name:               "enabled_deny_response",
-			env:                map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
-			serverResponds:     `{"action":"deny","reason":"blocked tool"}`,
-			expectServerCall:   true,
-			wantStdoutContains: `"permissionDecision":"deny"`,
-		},
-		{
-			name:              "enabled_fail_open_on_transport_error",
-			env:               map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
-			useClosedEndpoint: true,
-			wantStdoutEmpty:   true,
-		},
-		{
-			name: "enabled_fail_closed_on_transport_error",
-			env: map[string]string{
-				"SIGIL_GUARDS_ENABLED":   "true",
-				"SIGIL_GUARDS_FAIL_OPEN": "false",
+			name:             "enabled_deny_writes_claude_envelope",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"deny","reason":"blocked tool"}`,
+			expectServerCall: true,
+			wantStdoutContains: []string{
+				`"hookSpecificOutput"`,
+				`"hookEventName":"PreToolUse"`,
+				`"permissionDecision":"deny"`,
+				`"permissionDecisionReason":"blocked tool"`,
 			},
-			useClosedEndpoint:  true,
-			wantStdoutContains: `"permissionDecision":"deny"`,
 		},
 	}
 
@@ -253,14 +241,12 @@ func TestHandlePreToolUse(t *testing.T) {
 			for k, v := range tt.env {
 				t.Setenv(k, v)
 			}
+			t.Setenv("SIGIL_ENDPOINT", server.URL)
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
 
 			calls.Store(0)
 			responseBody.Store(tt.serverResponds)
-
-			endpoint := server.URL
-			if tt.useClosedEndpoint {
-				endpoint = closed.URL
-			}
 
 			var stdout bytes.Buffer
 			var logs bytes.Buffer
@@ -274,19 +260,21 @@ func TestHandlePreToolUse(t *testing.T) {
 			}
 			st := state.Session{Model: "claude-sonnet-4"}
 
-			handlePreToolUse(context.Background(), &stdout, input, st, endpoint, "tenant", "token", log.New(&logs, "", 0))
+			handlePreToolUse(context.Background(), &stdout, input, st, log.New(&logs, "", 0))
 
 			if tt.expectServerCall && calls.Load() == 0 {
 				t.Errorf("expected server call, got 0")
 			}
-			if !tt.expectServerCall && !tt.useClosedEndpoint && calls.Load() != 0 {
+			if !tt.expectServerCall && calls.Load() != 0 {
 				t.Errorf("expected no server call, got %d", calls.Load())
 			}
 			if tt.wantStdoutEmpty && stdout.Len() != 0 {
 				t.Errorf("stdout not empty: %q", stdout.String())
 			}
-			if tt.wantStdoutContains != "" && !strings.Contains(stdout.String(), tt.wantStdoutContains) {
-				t.Errorf("stdout = %q, want substring %q", stdout.String(), tt.wantStdoutContains)
+			for _, want := range tt.wantStdoutContains {
+				if !strings.Contains(stdout.String(), want) {
+					t.Errorf("stdout missing %q\nfull output: %s", want, stdout.String())
+				}
 			}
 		})
 	}

--- a/plugins/sigil/internal/agents/codex/hook/handlers.go
+++ b/plugins/sigil/internal/agents/codex/hook/handlers.go
@@ -80,24 +80,11 @@ func UserPromptSubmit(p Payload, cfg config.Config, logger *log.Logger) {
 	}
 }
 
-// preToolUseDecision is the JSON shape Codex understands as a deny verdict
-// on PreToolUse. Matches Claude Code's hookDecision so downstream rules
-// stay consistent across agents.
-type preToolUseDecision struct {
-	HookSpecificOutput preToolUseDecisionOutput `json:"hookSpecificOutput"`
-}
-
-type preToolUseDecisionOutput struct {
-	HookEventName            string `json:"hookEventName"`
-	PermissionDecision       string `json:"permissionDecision"`
-	PermissionDecisionReason string `json:"permissionDecisionReason,omitempty"`
-}
-
 // PreToolUse evaluates a Codex tool call against Sigil guard rules. It writes
-// a deny JSON object to stdout when the call must be blocked and stays silent
-// when the call is allowed. Transport setup, credential checks, and
-// fail-open/closed behaviour all live in the shared guard package so this
-// handler stays in lockstep with the copilot and other agents.
+// a PreToolUse deny envelope to stdout when the call must be blocked and
+// stays silent when the call is allowed. Transport setup, credential checks,
+// and fail-open/closed behaviour live in the shared guard package. Claude
+// Code and Codex also share the PreToolUse deny envelope writer.
 func PreToolUse(ctx context.Context, stdout io.Writer, p Payload, cfg config.Config, logger *log.Logger) {
 	res := guard.EvaluateToolCall(ctx, cfg.Guards, guard.ToolCallInput{
 		AgentName:     mapper.AgentName,
@@ -108,7 +95,7 @@ func PreToolUse(ctx context.Context, stdout io.Writer, p Payload, cfg config.Con
 		ModelName:     p.Model,
 	}, logger)
 	if res.Blocked() {
-		writePreToolDeny(stdout, res.Reason)
+		guard.WriteHookSpecificOutputDeny(stdout, res.Reason)
 	}
 }
 
@@ -134,20 +121,6 @@ func isOpenAIOSeriesModel(m string) bool {
 		return false
 	}
 	return m[1] >= '0' && m[1] <= '9'
-}
-
-func writePreToolDeny(stdout io.Writer, reason string) {
-	if strings.TrimSpace(reason) == "" {
-		reason = "tool call denied by Sigil guard"
-	}
-	out := preToolUseDecision{
-		HookSpecificOutput: preToolUseDecisionOutput{
-			HookEventName:            "PreToolUse",
-			PermissionDecision:       "deny",
-			PermissionDecisionReason: reason,
-		},
-	}
-	_ = json.NewEncoder(stdout).Encode(out)
 }
 
 func PostToolUse(p Payload, cfg config.Config, logger *log.Logger) {

--- a/plugins/sigil/internal/agents/guard/toolcall.go
+++ b/plugins/sigil/internal/agents/guard/toolcall.go
@@ -1,12 +1,15 @@
 // Package guard evaluates tool calls against Sigil guard policy and
-// returns a host-neutral result; callers translate it into their own
-// stdout response shape.
+// returns a host-neutral result. Callers translate the result into their
+// own stdout response shape; convenience writers are provided for shapes
+// shared by more than one host agent (e.g. WriteHookSpecificOutputDeny
+// for the Claude Code / Codex PreToolUse envelope).
 package guard
 
 import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -65,6 +68,10 @@ func (r Result) Blocked() bool {
 //   - Sigil returns deny: returns deny with the rule reason.
 //   - transport error and fail-open: returns allow (matches SDK behaviour).
 //   - transport error and fail-closed: returns deny with a transport reason.
+//
+// A local-mode endpoint (http://127.0.0.1, http://localhost, http://[::1])
+// uses stand-in placeholder credentials for the credential check so that
+// running against a local Sigil instance does not require real cloud creds.
 func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCallInput, logger *log.Logger) Result {
 	if !cfg.Enabled {
 		return Result{Action: sigil.HookActionAllow}
@@ -76,6 +83,7 @@ func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCa
 	endpoint := strings.TrimSpace(os.Getenv("SIGIL_ENDPOINT"))
 	tenantID := strings.TrimSpace(os.Getenv("SIGIL_AUTH_TENANT_ID"))
 	authToken := strings.TrimSpace(os.Getenv("SIGIL_AUTH_TOKEN"))
+	tenantID, authToken = envconfig.LocalAuthPlaceholders(endpoint, tenantID, authToken)
 	if endpoint == "" || tenantID == "" || authToken == "" {
 		if cfg.FailOpen {
 			if logger != nil {
@@ -194,4 +202,35 @@ func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCa
 	}
 
 	return Result{Action: sigil.HookActionAllow}
+}
+
+// hookSpecificOutputDeny is the PreToolUse deny envelope shared by Claude
+// Code and Codex. Both hosts read this exact JSON shape on stdout.
+type hookSpecificOutputDeny struct {
+	HookSpecificOutput hookSpecificOutputDenyBody `json:"hookSpecificOutput"`
+}
+
+type hookSpecificOutputDenyBody struct {
+	HookEventName            string `json:"hookEventName"`
+	PermissionDecision       string `json:"permissionDecision"`
+	PermissionDecisionReason string `json:"permissionDecisionReason,omitempty"`
+}
+
+// WriteHookSpecificOutputDeny writes the PreToolUse deny JSON used by Claude
+// Code and Codex. The two hosts share the exact wire format, so they share
+// this writer; reason falls back to a generic message when blank.
+func WriteHookSpecificOutputDeny(stdout io.Writer, reason string) {
+	if stdout == nil {
+		return
+	}
+	if strings.TrimSpace(reason) == "" {
+		reason = "tool call denied by Sigil guard"
+	}
+	_ = json.NewEncoder(stdout).Encode(hookSpecificOutputDeny{
+		HookSpecificOutput: hookSpecificOutputDenyBody{
+			HookEventName:            "PreToolUse",
+			PermissionDecision:       "deny",
+			PermissionDecisionReason: reason,
+		},
+	})
 }

--- a/plugins/sigil/internal/agents/guard/toolcall_test.go
+++ b/plugins/sigil/internal/agents/guard/toolcall_test.go
@@ -1,6 +1,7 @@
 package guard
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -26,11 +27,14 @@ func TestEvaluateToolCall(t *testing.T) {
 		useClosedServer bool
 		// clearCreds blanks the SIGIL_ENDPOINT/SIGIL_AUTH_TENANT_ID/
 		// SIGIL_AUTH_TOKEN env vars before the call.
-		clearCreds       bool
-		toolName         string
-		wantAction       sigil.HookAction
-		wantReasonSub    string
-		wantServerCalled bool
+		clearCreds bool
+		// clearCredsKeepEndpoint clears tenant/token but keeps the (local)
+		// endpoint set, to exercise the LocalAuthPlaceholders path.
+		clearCredsKeepEndpoint bool
+		toolName               string
+		wantAction             sigil.HookAction
+		wantReasonSub          string
+		wantServerCalled       bool
 	}{
 		{
 			name:       "disabled returns allow without contacting sigil",
@@ -92,6 +96,18 @@ func TestEvaluateToolCall(t *testing.T) {
 			wantAction:    sigil.HookActionDeny,
 			wantReasonSub: "missing SIGIL_ENDPOINT",
 		},
+		{
+			// httptest servers bind to a loopback address, which IsLocalEndpoint
+			// classifies as local. With empty creds we expect placeholder auth so
+			// the request proceeds instead of being rejected as missing-creds.
+			name:                   "local endpoint with empty creds applies placeholders",
+			cfg:                    envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: false},
+			clearCredsKeepEndpoint: true,
+			serverResponds:         `{"action":"allow"}`,
+			toolName:               "bash",
+			wantAction:             sigil.HookActionAllow,
+			wantServerCalled:       true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -115,11 +131,16 @@ func TestEvaluateToolCall(t *testing.T) {
 			if tt.useClosedServer {
 				endpoint = closed.URL
 			}
-			if tt.clearCreds {
+			switch {
+			case tt.clearCreds:
 				t.Setenv("SIGIL_ENDPOINT", "")
 				t.Setenv("SIGIL_AUTH_TENANT_ID", "")
 				t.Setenv("SIGIL_AUTH_TOKEN", "")
-			} else {
+			case tt.clearCredsKeepEndpoint:
+				t.Setenv("SIGIL_ENDPOINT", endpoint)
+				t.Setenv("SIGIL_AUTH_TENANT_ID", "")
+				t.Setenv("SIGIL_AUTH_TOKEN", "")
+			default:
 				t.Setenv("SIGIL_ENDPOINT", endpoint)
 				t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
 				t.Setenv("SIGIL_AUTH_TOKEN", "token")
@@ -149,4 +170,43 @@ func TestEvaluateToolCall(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWriteHookSpecificOutputDeny(t *testing.T) {
+	tests := []struct {
+		name    string
+		reason  string
+		wantSub []string
+	}{
+		{
+			name:    "explicit reason",
+			reason:  "blocked by rule r-1",
+			wantSub: []string{`"hookEventName":"PreToolUse"`, `"permissionDecision":"deny"`, `"permissionDecisionReason":"blocked by rule r-1"`},
+		},
+		{
+			name:    "blank reason falls back to generic",
+			reason:  "",
+			wantSub: []string{`"permissionDecisionReason":"tool call denied by Sigil guard"`},
+		},
+		{
+			name:    "whitespace reason falls back to generic",
+			reason:  "   ",
+			wantSub: []string{`"permissionDecisionReason":"tool call denied by Sigil guard"`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			WriteHookSpecificOutputDeny(&buf, tt.reason)
+			got := buf.String()
+			for _, want := range tt.wantSub {
+				if !strings.Contains(got, want) {
+					t.Errorf("output missing %q\nfull output: %s", want, got)
+				}
+			}
+		})
+	}
+
+	// nil writer must not panic.
+	WriteHookSpecificOutputDeny(nil, "x")
 }


### PR DESCRIPTION
Move the Claude Code `PreToolUse` guard logic over to the shared `guard` package that codex and copilot already use. Claude Code now goes through the same code path as the other agents instead of having its own copy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when tool guards run relative to credentials and centralizes deny behavior—security-sensitive hook paths, but behavior is aligned across agents with expanded guard tests.
> 
> **Overview**
> Claude Code **PreToolUse** no longer implements its own Sigil client and deny JSON; it uses the shared **`guard`** package (same path as Codex and Copilot). **`Hook`** now handles **`SessionStart`** and **`PreToolUse`** before the export credential check, so guards can still **deny** tools when `SIGIL_*` env vars are missing (e.g. fail-closed).
> 
> Codex drops its local deny writer in favor of **`guard.WriteHookSpecificOutputDeny`**, which centralizes the shared **`hookSpecificOutput` / PreToolUse** stdout shape for Claude Code and Codex.
> 
> **`EvaluateToolCall`** applies **`LocalAuthPlaceholders`** for loopback endpoints so local Sigil can run without real cloud creds. Tests move fail-open/closed and transport cases into **`guard`**; Claude tests focus on wiring and the deny envelope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69df35a58762c6ae2c58d73677eec841bc4c26e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->