### PR TITLE
feat(plugin): adding opencode guard support

### DIFF
--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -84,6 +84,9 @@ If nothing shows up, set `SIGIL_DEBUG=true` in `~/.config/sigil/config.env`, run
 | `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the AI Observability latency and tool-call panels stay empty. Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT`. |
 | `SIGIL_OTEL_AUTH_TOKEN` | `SIGIL_AUTH_TOKEN` | Override the OTLP password. |
 | `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | One of `full`, `no_tool_content`, `metadata_only`, or `full_with_metadata_spans`. `default` is accepted as an alias for `metadata_only`. |
+| `SIGIL_GUARDS_ENABLED` | `false` | Evaluate OpenCode tool calls against Sigil guards before execution. |
+| `SIGIL_GUARDS_TIMEOUT_MS` | `1500` | Per-evaluation guard timeout in milliseconds. |
+| `SIGIL_GUARDS_FAIL_OPEN` | `true` | Allow tool calls if guard evaluation fails. Set to `false` to fail closed. |
 | `SIGIL_AGENT_NAME` | `opencode` | Agent name reported to Sigil. The plugin appends `:<mode>` for OpenCode's UI mode, such as `build` or `plan`. |
 | `SIGIL_AGENT_VERSION` | — | Optional version string reported with the agent. |
 | `SIGIL_DEBUG` | `false` | Log lifecycle events to stderr. |

--- a/plugins/opencode/src/client.test.ts
+++ b/plugins/opencode/src/client.test.ts
@@ -52,8 +52,34 @@ describe("createSigilClient", () => {
         endpoint: "http://localhost:8080/api/v1/generations:export",
         auth: { mode: "none" },
       },
+      api: { endpoint: "http://localhost:8080" },
+      hooks: {
+        enabled: false,
+        phases: ["postflight"],
+        timeoutMs: 1500,
+        failOpen: true,
+      },
       contentCapture: "metadata_only",
     });
+  });
+
+  it("passes guard config to the SDK client", () => {
+    createSigilClient(
+      makeConfig({
+        guards: { enabled: true, timeoutMs: 2500, failOpen: false },
+      }),
+    );
+
+    expect(SigilClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hooks: {
+          enabled: true,
+          phases: ["postflight"],
+          timeoutMs: 2500,
+          failOpen: false,
+        },
+      }),
+    );
   });
 
   it("appends the export path for a prefix-mounted endpoint", () => {

--- a/plugins/opencode/src/client.ts
+++ b/plugins/opencode/src/client.ts
@@ -12,11 +12,23 @@ export function createSigilClient(
   options?: SigilClientOptions,
 ): SigilClient | null {
   try {
+    const guards = config.guards ?? {
+      enabled: false,
+      timeoutMs: 1500,
+      failOpen: true,
+    };
     return new SigilClient({
       generationExport: {
         protocol: "http",
         endpoint: appendExportPath(config.endpoint),
         auth: config.auth,
+      },
+      api: { endpoint: config.endpoint },
+      hooks: {
+        enabled: guards.enabled,
+        phases: ["postflight"],
+        timeoutMs: guards.timeoutMs,
+        failOpen: guards.failOpen,
       },
       contentCapture: config.contentCapture,
       ...(options?.tracer ? { tracer: options.tracer } : {}),

--- a/plugins/opencode/src/config.test.ts
+++ b/plugins/opencode/src/config.test.ts
@@ -115,6 +115,42 @@ describe("resolveConfig", () => {
     expect(cfg?.debug).toBe(false);
   });
 
+  it("defaults guards off, fail-open, with 1500ms timeout", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    const cfg = resolveConfig();
+    expect(cfg?.guards).toEqual({
+      enabled: false,
+      timeoutMs: 1500,
+      failOpen: true,
+    });
+  });
+
+  it("reads guard settings from canonical env vars", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_GUARDS_ENABLED = "on";
+    process.env.SIGIL_GUARDS_TIMEOUT_MS = "2400";
+    process.env.SIGIL_GUARDS_FAIL_OPEN = "no";
+
+    const cfg = resolveConfig();
+    expect(cfg?.guards).toEqual({
+      enabled: true,
+      timeoutMs: 2400,
+      failOpen: false,
+    });
+  });
+
+  it("falls back to the default guard timeout for invalid values", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_GUARDS_TIMEOUT_MS = "nope";
+    const cfg = resolveConfig();
+    expect(cfg?.guards?.timeoutMs).toBe(1500);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("invalid integer value"),
+    );
+    warn.mockRestore();
+  });
+
   it("derives basic auth from SIGIL_AUTH_TENANT_ID + SIGIL_AUTH_TOKEN", () => {
     process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.SIGIL_AUTH_TENANT_ID = "tenant-1";

--- a/plugins/opencode/src/config.ts
+++ b/plugins/opencode/src/config.ts
@@ -16,6 +16,12 @@ export interface OtlpConfig {
   headers: Record<string, string>;
 }
 
+export interface GuardsFeatureConfig {
+  enabled: boolean;
+  timeoutMs: number;
+  failOpen: boolean;
+}
+
 export interface SigilOpencodeConfig {
   endpoint: string;
   auth: SigilAuthConfig;
@@ -23,6 +29,7 @@ export interface SigilOpencodeConfig {
   agentVersion?: string;
   contentCapture: ContentCaptureMode;
   debug: boolean;
+  guards?: GuardsFeatureConfig;
   otlp?: OtlpConfig;
 }
 
@@ -56,6 +63,7 @@ export function resolveConfig(): SigilOpencodeConfig | null {
     agentVersion,
     contentCapture,
     debug,
+    guards: resolveGuards(),
     otlp: resolveOtlp(),
   };
 }
@@ -166,6 +174,25 @@ function env(key: string): string | undefined {
 function envBool(key: string): boolean | undefined {
   const v = env(key);
   return v !== undefined ? toBool(v) : undefined;
+}
+
+export function resolveGuards(): GuardsFeatureConfig {
+  return {
+    enabled: envBool("SIGIL_GUARDS_ENABLED") ?? false,
+    timeoutMs: envPositiveInt("SIGIL_GUARDS_TIMEOUT_MS") ?? 1500,
+    failOpen: envBool("SIGIL_GUARDS_FAIL_OPEN") ?? true,
+  };
+}
+
+function envPositiveInt(key: string): number | undefined {
+  const raw = env(key);
+  if (raw === undefined || raw.trim() === "") return undefined;
+  const n = Number(raw);
+  if (Number.isInteger(n) && n > 0) return n;
+  console.warn(
+    `[sigil-opencode] invalid integer value for ${key}: "${raw}" - using default`,
+  );
+  return undefined;
 }
 
 function toBool(v: unknown): boolean | undefined {

--- a/plugins/opencode/src/guard.test.ts
+++ b/plugins/opencode/src/guard.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { denyResult, runToolCallGuard } from "./guard.js";
+
+describe("runToolCallGuard", () => {
+  it("returns undefined when Sigil allows the tool call", async () => {
+    const calls: unknown[] = [];
+    const client = {
+      evaluateHook: async (req: unknown) => {
+        calls.push(req);
+        return { action: "allow", evaluations: [] };
+      },
+    };
+
+    const res = await runToolCallGuard({
+      client: client as any,
+      agentName: "opencode",
+      model: { provider: "anthropic", name: "claude" },
+      toolCallId: "c1",
+      toolName: "bash",
+      input: { command: "ls" },
+      failOpen: true,
+    });
+
+    expect(res).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect((calls[0] as any).phase).toBe("postflight");
+    expect((calls[0] as any).input.output[0].parts[0].toolCall.inputJSON).toBe(
+      JSON.stringify({ command: "ls" }),
+    );
+  });
+
+  it("returns a block result when Sigil denies the tool call", async () => {
+    const client = {
+      evaluateHook: async () => ({
+        action: "deny",
+        reason: "blocked by rule",
+        evaluations: [],
+      }),
+    };
+
+    const res = await runToolCallGuard({
+      client: client as any,
+      agentName: "opencode",
+      model: { provider: "anthropic", name: "claude" },
+      toolCallId: "c1",
+      toolName: "bash",
+      input: { command: "rm -rf /" },
+      failOpen: true,
+    });
+
+    expect(res).toEqual({ block: true, reason: "blocked by rule" });
+  });
+
+  it("denies when the SDK throws (fail-closed mode)", async () => {
+    const client = {
+      evaluateHook: async () => {
+        throw new Error("network down");
+      },
+    };
+
+    const res = await runToolCallGuard({
+      client: client as any,
+      agentName: "opencode",
+      model: { provider: "anthropic", name: "claude" },
+      toolCallId: "c1",
+      toolName: "bash",
+      input: {},
+      failOpen: false,
+    });
+
+    expect(res?.block).toBe(true);
+    expect(res?.reason).toContain("sigil guard evaluation failed");
+  });
+
+  it("allows when the SDK throws (fail-open mode)", async () => {
+    const client = {
+      evaluateHook: async () => {
+        throw new Error("network down");
+      },
+    };
+
+    const res = await runToolCallGuard({
+      client: client as any,
+      agentName: "opencode",
+      model: { provider: "anthropic", name: "claude" },
+      toolCallId: "c1",
+      toolName: "bash",
+      input: {},
+      failOpen: true,
+    });
+
+    expect(res).toBeUndefined();
+  });
+
+  it("allows when JSON.stringify throws (fail-open mode)", async () => {
+    const client = {
+      evaluateHook: async () => {
+        return { action: "allow", evaluations: [] };
+      },
+    };
+
+    const circular: any = {};
+    circular.self = circular;
+
+    const res = await runToolCallGuard({
+      client: client as any,
+      agentName: "opencode",
+      model: { provider: "anthropic", name: "claude" },
+      toolCallId: "c1",
+      toolName: "bash",
+      input: circular,
+      failOpen: true,
+    });
+
+    expect(res).toBeUndefined();
+  });
+
+  it("uses the default deny reason when Sigil omits one", () => {
+    expect(denyResult(undefined)).toEqual({
+      block: true,
+      reason: "tool call denied by Sigil guard",
+    });
+  });
+});

--- a/plugins/opencode/src/guard.ts
+++ b/plugins/opencode/src/guard.ts
@@ -1,0 +1,75 @@
+import type { HookEvaluateRequest, SigilClient } from "@grafana/sigil-sdk-js";
+
+export interface GuardArgs {
+  client: SigilClient;
+  agentName: string;
+  agentVersion?: string;
+  model: { provider: string; name: string };
+  toolCallId?: string;
+  toolName: string;
+  input: unknown;
+  failOpen: boolean;
+}
+
+export type GuardBlockResult = { block: true; reason: string };
+
+/**
+ * Evaluates the Sigil postflight hook for a tool call. Returns a block result
+ * when the server denies the call. On transport/timeout/serialization errors,
+ * returns `undefined` (allow) when `failOpen` is true and a block result when
+ * `failOpen` is false.
+ */
+export async function runToolCallGuard(
+  args: GuardArgs,
+): Promise<GuardBlockResult | undefined> {
+  try {
+    const req: HookEvaluateRequest = {
+      phase: "postflight",
+      context: {
+        agentName: args.agentName,
+        agentVersion: args.agentVersion,
+        model: {
+          provider: args.model.provider || "unknown",
+          name: args.model.name || "unknown",
+        },
+      },
+      input: {
+        output: [
+          {
+            role: "assistant",
+            parts: [
+              {
+                type: "tool_call",
+                toolCall: {
+                  id: args.toolCallId,
+                  name: args.toolName,
+                  inputJSON: JSON.stringify(args.input ?? {}),
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const resp = await args.client.evaluateHook(req, { enabled: true });
+    if (resp.action === "deny") return denyResult(resp.reason);
+    return undefined;
+  } catch (err) {
+    if (!args.failOpen) {
+      return denyResult(`sigil guard evaluation failed: ${String(err)}`);
+    }
+    return undefined;
+  }
+}
+
+export function denyResult(reason: string | undefined): GuardBlockResult {
+  const trimmed = reason?.trim();
+  return {
+    block: true,
+    reason:
+      trimmed && trimmed.length > 0
+        ? trimmed
+        : "tool call denied by Sigil guard",
+  };
+}

--- a/plugins/opencode/src/hooks.guard.test.ts
+++ b/plugins/opencode/src/hooks.guard.test.ts
@@ -1,0 +1,186 @@
+import { createServer, type Server } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import type { SigilOpencodeConfig } from "./config.js";
+import { createSigilHooks } from "./hooks.js";
+
+type HookServer = {
+  server: Server;
+  baseUrl: string;
+  captures: Array<Record<string, any>>;
+};
+
+function startHookServer(
+  response: Record<string, unknown>,
+): Promise<HookServer> {
+  const captures: Array<Record<string, any>> = [];
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        captures.push(JSON.parse(body));
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify(response));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        throw new Error("expected AddressInfo from server.address()");
+      }
+      resolve({
+        server,
+        baseUrl: `http://127.0.0.1:${addr.port}`,
+        captures,
+      });
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function config(endpoint: string): SigilOpencodeConfig {
+  return {
+    endpoint,
+    auth: { mode: "none" },
+    agentName: "opencode",
+    agentVersion: "test-version",
+    contentCapture: "full",
+    debug: false,
+    guards: { enabled: true, timeoutMs: 1500, failOpen: true },
+  };
+}
+
+describe("opencode guards", () => {
+  const servers: Server[] = [];
+
+  afterEach(async () => {
+    await Promise.all(servers.splice(0).map(closeServer));
+  });
+
+  it("blocks denied tool.execute.before calls", async () => {
+    const hookServer = await startHookServer({
+      action: "deny",
+      reason: "blocked demo tool",
+      evaluations: [],
+    });
+    servers.push(hookServer.server);
+
+    const hooks = await createSigilHooks(config(hookServer.baseUrl), {
+      session: { message: async () => ({ data: { parts: [] } }) },
+    } as any);
+    if (!hooks) throw new Error("expected hooks");
+
+    hooks.chatMessage(
+      {
+        sessionID: "sess-1",
+        agent: "build",
+        model: { providerID: "anthropic", modelID: "claude-sonnet-4" },
+      },
+      {
+        message: {
+          id: "msg-user",
+          sessionID: "sess-1",
+          role: "user",
+          system: "",
+          tools: {},
+        } as any,
+        parts: [],
+      },
+    );
+
+    await expect(
+      hooks.toolExecuteBefore(
+        {
+          sessionID: "sess-1",
+          callID: "call-1",
+          tool: "third-party-test-mcp_third_party_test_mcp_leak_fake_credential",
+        },
+        { args: { demo: true } },
+      ),
+    ).rejects.toThrow("blocked demo tool");
+
+    expect(hookServer.captures).toHaveLength(1);
+    expect(hookServer.captures[0]).toMatchObject({
+      phase: "postflight",
+      context: {
+        agent_name: "opencode:build",
+        agent_version: "test-version",
+        model: { provider: "anthropic", name: "claude-sonnet-4" },
+      },
+      input: {
+        output: [
+          {
+            role: "assistant",
+            parts: [
+              {
+                type: "tool_call",
+                toolCall: {
+                  id: "call-1",
+                  name: "third-party-test-mcp_third_party_test_mcp_leak_fake_credential",
+                  inputJSON: JSON.stringify({ demo: true }),
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+  });
+
+  it("sets permission.ask output to deny when Sigil denies", async () => {
+    const hookServer = await startHookServer({
+      action: "deny",
+      reason: "blocked permission",
+      evaluations: [],
+    });
+    servers.push(hookServer.server);
+
+    const hooks = await createSigilHooks(config(hookServer.baseUrl), {
+      session: { message: async () => ({ data: { parts: [] } }) },
+    } as any);
+    if (!hooks) throw new Error("expected hooks");
+
+    const output: { status: "ask" | "deny" | "allow" } = { status: "ask" };
+    await hooks.permissionAsk(
+      {
+        id: "perm-1",
+        sessionID: "sess-1",
+        messageID: "msg-1",
+        callID: "call-1",
+        type: "bash",
+        pattern: "rm *",
+        title: "Run shell command",
+        metadata: { command: "rm -rf /tmp/demo" },
+        time: { created: Date.now() },
+      },
+      output,
+    );
+
+    expect(output.status).toBe("deny");
+    expect(
+      hookServer.captures[0]?.input?.output?.[0]?.parts?.[0],
+    ).toMatchObject({
+      type: "tool_call",
+      toolCall: {
+        id: "call-1",
+        name: "bash",
+        inputJSON: JSON.stringify({
+          pattern: "rm *",
+          title: "Run shell command",
+          metadata: { command: "rm -rf /tmp/demo" },
+        }),
+      },
+    });
+
+    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+  });
+});

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -1,9 +1,15 @@
 import { randomUUID } from "node:crypto";
 import type { SigilClient } from "@grafana/sigil-sdk-js";
 import type { PluginInput } from "@opencode-ai/plugin";
-import type { AssistantMessage, Part, UserMessage } from "@opencode-ai/sdk";
+import type {
+  AssistantMessage,
+  Part,
+  Permission,
+  UserMessage,
+} from "@opencode-ai/sdk";
 import { createSigilClient } from "./client.js";
 import type { SigilOpencodeConfig } from "./config.js";
+import { runToolCallGuard } from "./guard.js";
 import { mapError, mapGeneration, mapToolDefinitions } from "./mappers.js";
 import { Redactor } from "./redact.js";
 import {
@@ -24,6 +30,17 @@ type PendingGeneration = {
 };
 const pendingGenerations = new Map<string, PendingGeneration>();
 
+type SessionContext = {
+  agent: string | undefined;
+  model: { provider: string; name: string } | undefined;
+};
+const sessionContexts = new Map<string, SessionContext>();
+
+type MessageUpdatedInfo = Partial<AssistantMessage> & {
+  id?: string;
+  sessionID?: string;
+};
+
 function buildAgentName(
   prefix: string | undefined,
   mode: string | undefined,
@@ -37,13 +54,21 @@ function buildAgentName(
  * when the assistant message completes.
  */
 function handleChatMessage(
-  input: { sessionID: string },
+  input: {
+    sessionID: string;
+    agent?: string;
+    model?: { providerID: string; modelID: string };
+  },
   output: { message: UserMessage; parts: Part[] },
 ): void {
   pendingGenerations.set(input.sessionID, {
     systemPrompt: output.message.system,
     userParts: output.parts,
     tools: output.message.tools,
+  });
+  sessionContexts.set(input.sessionID, {
+    agent: input.agent ?? stringField(output.message, "agent"),
+    model: resolveModel(input.model, output.message),
   });
 }
 
@@ -52,17 +77,112 @@ async function handleEvent(
   config: SigilOpencodeConfig,
   client: OpencodeClient,
   redactor: Redactor,
+  debugLog: (msg: string, ...args: unknown[]) => void,
   event: { type: string; properties: unknown },
 ): Promise<void> {
+  if (event.type === "message.part.updated") {
+    await handleMessagePartUpdated(
+      sigil,
+      config,
+      client,
+      redactor,
+      debugLog,
+      event.properties,
+    );
+    return;
+  }
   if (event.type !== "message.updated") return;
 
   const properties = event.properties as
-    | { info?: { role?: string } }
+    | { info?: MessageUpdatedInfo }
     | undefined;
   const msg = properties?.info;
-  if (!msg || msg.role !== "assistant") return;
+  if (!msg) return;
 
-  const assistantMsg = msg as AssistantMessage;
+  let assistantMsg: AssistantMessage | undefined =
+    msg.role === "assistant" ? (msg as AssistantMessage) : undefined;
+  let fetchedParts: Part[] | undefined;
+  if (
+    !assistantMsg &&
+    isTerminalMessageUpdate(msg) &&
+    msg.sessionID &&
+    msg.id
+  ) {
+    try {
+      const response = await client.session.message({
+        path: { id: msg.sessionID, messageID: msg.id },
+      });
+      if (response.data?.info?.role === "assistant") {
+        assistantMsg = response.data.info as AssistantMessage;
+        fetchedParts = response.data.parts ?? [];
+      }
+    } catch (err) {
+      debugLog("failed to hydrate partial assistant message", err);
+      return;
+    }
+  }
+  if (!assistantMsg) return;
+
+  await recordAssistantMessage(
+    sigil,
+    config,
+    client,
+    redactor,
+    debugLog,
+    assistantMsg,
+    fetchedParts,
+  );
+}
+
+async function handleMessagePartUpdated(
+  sigil: SigilClient,
+  config: SigilOpencodeConfig,
+  client: OpencodeClient,
+  redactor: Redactor,
+  debugLog: (msg: string, ...args: unknown[]) => void,
+  properties: unknown,
+): Promise<void> {
+  const part = recordField(properties, "part");
+  if (stringField(part, "type") !== "step-finish") return;
+  const sessionID = stringField(part, "sessionID");
+  const messageID = stringField(part, "messageID");
+  if (!sessionID || !messageID) return;
+
+  try {
+    const response = await client.session.message({
+      path: { id: sessionID, messageID },
+    });
+    if (response.data?.info?.role !== "assistant") return;
+    await recordAssistantMessage(
+      sigil,
+      config,
+      client,
+      redactor,
+      debugLog,
+      response.data.info as AssistantMessage,
+      response.data.parts ?? [],
+    );
+  } catch (err) {
+    debugLog("failed to export terminal message part", err);
+  }
+}
+
+async function recordAssistantMessage(
+  sigil: SigilClient,
+  config: SigilOpencodeConfig,
+  client: OpencodeClient,
+  redactor: Redactor,
+  debugLog: (msg: string, ...args: unknown[]) => void,
+  assistantMsg: AssistantMessage,
+  fetchedParts?: Part[],
+): Promise<void> {
+  sessionContexts.set(assistantMsg.sessionID, {
+    agent: assistantMsg.mode,
+    model: {
+      provider: assistantMsg.providerID,
+      name: assistantMsg.modelID,
+    },
+  });
 
   // Only record terminal messages
   const isTerminal =
@@ -84,13 +204,18 @@ async function handleEvent(
   // Fetch assistant parts only when the selected mode can export message bodies.
   let assistantParts: Part[] = [];
   if (includeMessageBodies) {
-    try {
-      const response = await client.session.message({
-        path: { id: assistantMsg.sessionID, messageID: assistantMsg.id },
-      });
-      assistantParts = response.data?.parts ?? [];
-    } catch {
-      // REST fetch failed — fall back to metadata-only output content.
+    if (fetchedParts !== undefined) {
+      assistantParts = fetchedParts;
+    } else {
+      try {
+        const response = await client.session.message({
+          path: { id: assistantMsg.sessionID, messageID: assistantMsg.id },
+        });
+        assistantParts = response.data?.parts ?? [];
+      } catch (err) {
+        debugLog("failed to fetch assistant message parts", err);
+        // REST fetch failed — fall back to metadata-only output content.
+      }
     }
   }
 
@@ -127,7 +252,8 @@ async function handleEvent(
         recorder.setResult(result);
       });
     }
-  } catch {
+  } catch (err) {
+    debugLog("sigil generation export failed", err);
     // Sigil recording failure should never break the plugin
   }
 
@@ -135,8 +261,44 @@ async function handleEvent(
   pendingGenerations.delete(assistantMsg.sessionID);
 }
 
+async function sweepTerminalAssistantMessages(
+  sigil: SigilClient,
+  config: SigilOpencodeConfig,
+  client: OpencodeClient,
+  redactor: Redactor,
+  debugLog: (msg: string, ...args: unknown[]) => void,
+  sessionID: string,
+): Promise<void> {
+  try {
+    const response = await client.session.messages({
+      path: { id: sessionID },
+    });
+    for (const message of response.data ?? []) {
+      if (message.info.role !== "assistant") continue;
+      await recordAssistantMessage(
+        sigil,
+        config,
+        client,
+        redactor,
+        debugLog,
+        message.info as AssistantMessage,
+        message.parts ?? [],
+      );
+    }
+  } catch (err) {
+    debugLog("failed to sweep terminal assistant messages", err);
+  }
+}
+
+function isTerminalMessageUpdate(msg: MessageUpdatedInfo): boolean {
+  return Boolean(msg.finish || msg.error || msg.time?.completed);
+}
+
 async function handleLifecycle(
   sigil: SigilClient,
+  config: SigilOpencodeConfig,
+  client: OpencodeClient,
+  redactor: Redactor,
   telemetry: TelemetryProviders | null,
   debugLog: (msg: string, ...args: unknown[]) => void,
   event: { type: string; properties: unknown },
@@ -144,6 +306,22 @@ async function handleLifecycle(
   const type = event.type as string;
 
   if (type === "session.idle") {
+    const properties = event.properties as
+      | { info?: { id?: string } }
+      | undefined;
+    const sessionIds = properties?.info?.id
+      ? [properties.info.id]
+      : Array.from(pendingGenerations.keys());
+    for (const sessionId of sessionIds) {
+      await sweepTerminalAssistantMessages(
+        sigil,
+        config,
+        client,
+        redactor,
+        debugLog,
+        sessionId,
+      );
+    }
     // Fire-and-forget: a stuck OTLP endpoint must not block session.idle for
     // up to ~30s (BatchSpanProcessor default) per turn.
     void sigil.flush().catch((err) => debugLog("sigil flush failed", err));
@@ -162,6 +340,7 @@ async function handleLifecycle(
     if (sessionId) {
       recordedMessages.delete(sessionId);
       pendingGenerations.delete(sessionId);
+      sessionContexts.delete(sessionId);
     }
   }
 
@@ -181,14 +360,135 @@ async function handleLifecycle(
   }
 }
 
+async function handleToolExecuteBefore(
+  sigil: SigilClient,
+  config: SigilOpencodeConfig,
+  input: { tool: string; sessionID: string; callID: string },
+  output: { args: unknown },
+): Promise<void> {
+  const guards = config.guards;
+  if (guards?.enabled !== true) return;
+  const res = await runToolCallGuard({
+    client: sigil,
+    agentName: agentNameForSession(config, input.sessionID),
+    agentVersion: config.agentVersion,
+    model: modelForSession(input.sessionID),
+    toolCallId: input.callID,
+    toolName: input.tool,
+    input: output.args ?? {},
+    failOpen: guards.failOpen,
+  });
+  if (res?.block) {
+    throw new Error(res.reason);
+  }
+}
+
+async function handlePermissionAsk(
+  sigil: SigilClient,
+  config: SigilOpencodeConfig,
+  input: Permission,
+  output: { status: "ask" | "deny" | "allow" },
+): Promise<void> {
+  const guards = config.guards;
+  if (guards?.enabled !== true) return;
+  const res = await runToolCallGuard({
+    client: sigil,
+    agentName: agentNameForSession(config, input.sessionID),
+    agentVersion: config.agentVersion,
+    model: modelForSession(input.sessionID),
+    toolCallId: input.callID,
+    toolName: input.type,
+    input: {
+      pattern: input.pattern,
+      title: input.title,
+      metadata: input.metadata,
+    },
+    failOpen: guards.failOpen,
+  });
+  if (res?.block) {
+    output.status = "deny";
+  }
+}
+
+function agentNameForSession(
+  config: SigilOpencodeConfig,
+  sessionID: string,
+): string {
+  return buildAgentName(
+    config.agentName,
+    sessionContexts.get(sessionID)?.agent,
+  );
+}
+
+function modelForSession(sessionID: string): {
+  provider: string;
+  name: string;
+} {
+  return (
+    sessionContexts.get(sessionID)?.model ?? {
+      provider: "unknown",
+      name: "unknown",
+    }
+  );
+}
+
+function resolveModel(
+  inputModel: { providerID: string; modelID: string } | undefined,
+  message: UserMessage,
+): { provider: string; name: string } | undefined {
+  if (inputModel) {
+    return { provider: inputModel.providerID, name: inputModel.modelID };
+  }
+  const rawModel = recordField(message, "model");
+  if (!rawModel) return undefined;
+  const provider = stringField(rawModel, "providerID");
+  const name = stringField(rawModel, "modelID");
+  if (!provider && !name) return undefined;
+  return {
+    provider: provider || "unknown",
+    name: name || "unknown",
+  };
+}
+
+function recordField(
+  value: unknown,
+  key: string,
+): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const field = (value as Record<string, unknown>)[key];
+  return field && typeof field === "object"
+    ? (field as Record<string, unknown>)
+    : undefined;
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const field = (value as Record<string, unknown>)[key];
+  return typeof field === "string" && field.trim().length > 0
+    ? field
+    : undefined;
+}
+
 export type SigilHooks = {
   event: (input: {
     event: { type: string; properties: unknown };
   }) => Promise<void>;
   chatMessage: (
-    input: { sessionID: string },
+    input: {
+      sessionID: string;
+      agent?: string;
+      model?: { providerID: string; modelID: string };
+    },
     output: { message: UserMessage; parts: Part[] },
   ) => void;
+  toolExecuteBefore: (
+    input: { tool: string; sessionID: string; callID: string },
+    output: { args: unknown },
+  ) => Promise<void>;
+  permissionAsk: (
+    input: Permission,
+    output: { status: "ask" | "deny" | "allow" },
+  ) => Promise<void>;
 };
 
 export async function createSigilHooks(
@@ -236,11 +536,25 @@ export async function createSigilHooks(
 
   return {
     event: async (input) => {
-      await handleEvent(sigil, config, client, redactor, input.event);
-      await handleLifecycle(sigil, telemetry, debugLog, input.event);
+      await handleEvent(sigil, config, client, redactor, debugLog, input.event);
+      await handleLifecycle(
+        sigil,
+        config,
+        client,
+        redactor,
+        telemetry,
+        debugLog,
+        input.event,
+      );
     },
     chatMessage: (input, output) => {
       handleChatMessage(input, output);
+    },
+    toolExecuteBefore: async (input, output) => {
+      await handleToolExecuteBefore(sigil, config, input, output);
+    },
+    permissionAsk: async (input, output) => {
+      await handlePermissionAsk(sigil, config, input, output);
     },
   };
 }

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -18,5 +18,11 @@ export const SigilPlugin: Plugin = async ({ client }) => {
         event: event as { type: string; properties: unknown },
       });
     },
+    "tool.execute.before": async (input, output) => {
+      await hooks.toolExecuteBefore(input, output);
+    },
+    "permission.ask": async (input, output) => {
+      await hooks.permissionAsk(input, output);
+    },
   };
 };


### PR DESCRIPTION
## Notes

Follows the same pattern as the other agent plugins for tool call guard support

<img width="736" height="388" alt="Screenshot 2026-05-26 at 10 02 31 PM" src="https://github.com/user-attachments/assets/437d7928-965e-4353-b573-f85c01d98195" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Guards can block tool execution and permissions when enabled; defaults are off and fail-open, but misconfiguration or Sigil outages affect agent behavior at runtime.
> 
> **Overview**
> Adds **Sigil guard** support to the OpenCode plugin so tool calls can be evaluated against server-side rules before they run, aligned with other Sigil agent plugins.
> 
> When `SIGIL_GUARDS_ENABLED` is on, the plugin wires the JS SDK with API/hook settings (`SIGIL_GUARDS_TIMEOUT_MS`, `SIGIL_GUARDS_FAIL_OPEN`) and runs **postflight** `evaluateHook` checks via new `runToolCallGuard`. Denials block **`tool.execute.before`** (thrown error) and set **`permission.ask`** to `deny`. Session agent/model context is tracked for guard payloads.
> 
> Generation export is also hardened: terminal assistant messages can be hydrated from partial `message.updated` events, `message.part.updated` (`step-finish`), and a **`session.idle`** sweep so observability is less likely to miss completed turns.
> 
> README and tests cover guard env parsing, SDK client options, unit guard behavior, and integration against a mock hook server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 664eab8c6ecff001c33e488e99c4d30389c030f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->