### PR TITLE
feat(plugins/opencode): read shared ~/.config/sigil/config.env

### DIFF
--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -1,41 +1,85 @@
 # @grafana/sigil-opencode
 
-OpenCode plugin that sends LLM generations to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/).
+[OpenCode](https://opencode.ai) plugin that sends LLM generations to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/).
 
-By default only metadata is sent (model, tokens, tool names, timing). Flip `contentCapture` to `true` to also send message content (with automatic secret redaction).
+By default only metadata is sent (token counts, cost, model, tool names, durations). Set `SIGIL_CONTENT_CAPTURE_MODE=full` or `no_tool_content` to include message content.
 
-## Setup
+## 1. Install
 
-1. Create `~/.config/opencode/opencode-sigil.json`:
+```sh
+brew install grafana/grafana/sigil
+opencode plugin install @grafana/sigil-opencode
+```
 
-   ```json
-   {
-     "enabled": true,
-     "endpoint": "http://localhost:8080",
-     "auth": { "mode": "none" },
-     "agentName": "opencode",
-     "contentCapture": true
-   }
-   ```
+The `sigil` CLI is used to prompt for credentials (`sigil login`) and writes them to `~/.config/sigil/config.env`. The OpenCode plugin reads that same file on every session start.
 
-   For Grafana Cloud, set `endpoint` to your Sigil API URL (found at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`) and use `basic` auth — see the modes below.
+## 2. Credentials
 
-2. Register the plugin in your OpenCode configuration.
+Run `sigil login` and copy values from `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure AI Observability is enabled on your stack — an administrator opens **Observability → AI Observability** once and accepts the terms.
 
-### Auth modes
+You need values from two Grafana Cloud pages:
 
-- `none` — no authentication (local dev)
-- `bearer` — `{ "mode": "bearer", "bearerToken": "..." }`
-- `tenant` — `{ "mode": "tenant", "tenantId": "..." }`
-- `basic` — `{ "mode": "basic", "tenantId": "<instance-id>", "token": "glc_..." }`
+1. **AI Observability → Configuration**
+   - **API URL** → `SIGIL_ENDPOINT`
+   - **Instance ID** → `SIGIL_AUTH_TENANT_ID`
+
+2. **Administration → Users and access → Cloud access policies**
+   - Create a policy with scope `sigil:write`.
+   - Add a token. The `glc_…` value is shown once → `SIGIL_AUTH_TOKEN`.
+
+Run `sigil login` later to update saved credentials.
+
+<details>
+<summary>Non-interactive config.env</summary>
+
+Create or update `~/.config/sigil/config.env`:
+
+```dotenv
+SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
+SIGIL_AUTH_TENANT_ID=<instance-id>
+SIGIL_AUTH_TOKEN=glc_...
+```
+
+</details>
+
+When `SIGIL_AUTH_TENANT_ID` and `SIGIL_AUTH_TOKEN` are both set, Sigil generation export authenticates with the synthesized Basic auth header (`Basic base64(tenant:token)`). With only `SIGIL_AUTH_TENANT_ID` set, the `X-Scope-OrgID` header is sent on its own (tenant mode). Without either, no auth header is sent.
+
+To include conversation text (with automatic secret redaction), add this to `~/.config/sigil/config.env`:
+
+```dotenv
+SIGIL_CONTENT_CAPTURE_MODE=full
+```
+
+## 3. Verify
+
+Run one OpenCode turn, then open **AI Observability → Conversations** in Grafana Cloud. A new generation should appear within a few seconds.
+
+If nothing shows up, set `SIGIL_DEBUG=true` in `~/.config/sigil/config.env`, run another turn, and check OpenCode stderr plus any Sigil logs.
+
+## All options
+
+`~/.config/sigil/config.env` is the only configuration file. Every option is set via env var.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SIGIL_ENDPOINT` | — | Sigil URL (find it at `/plugins/grafana-sigil-app`). Empty value disables the plugin. |
+| `SIGIL_AUTH_TENANT_ID` | — | Grafana Cloud instance ID. Combined with `SIGIL_AUTH_TOKEN` becomes Basic auth. |
+| `SIGIL_AUTH_TOKEN` | — | Cloud access policy token (`glc_…`). |
+| `SIGIL_AGENT_NAME` | `opencode` | Agent name reported to Sigil. The plugin appends `:<mode>` (OpenCode's UI mode, e.g. `build`, `plan`) to this. |
+| `SIGIL_AGENT_VERSION` | — | Optional version string reported with the agent. |
+| `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `full`, `no_tool_content`, or `metadata_only`. |
+| `SIGIL_DEBUG` | `false` | Log lifecycle events to stderr. |
+
+File format: one `KEY=value` per line, `#` line comments, optional `export ` prefix, optional matching single or double quotes around the value. Only `SIGIL_*` keys plus `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_INSECURE`, and `OTEL_SERVICE_NAME` are honored — anything else (including stray `PATH=…` lines) is ignored.
+
+A non-empty OS env value always wins over the file; an empty or whitespace-only OS value is treated as unset and gets filled from `config.env`. Missing files are silent.
 
 ## Development
 
 ```bash
-# From the repo root
 pnpm install
 pnpm --filter @grafana/sigil-opencode build
 pnpm --filter @grafana/sigil-opencode test
 ```
 
-The `@grafana/sigil-sdk-js` dependency resolves via pnpm workspace linking to `sdks/js`.
+The `@grafana/sigil-sdk-js` dependency resolves via pnpm workspace linking to `js/`.

--- a/plugins/opencode/src/client.test.ts
+++ b/plugins/opencode/src/client.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SigilOpencodeConfig } from "./config.js";
+
+const { SigilClientMock } = vi.hoisted(() => ({
+  SigilClientMock: vi.fn(),
+}));
+
+vi.mock("@grafana/sigil-sdk-js", () => ({
+  SigilClient: SigilClientMock,
+}));
+
+import { createSigilClient } from "./client.js";
+
+function makeConfig(
+  overrides?: Partial<SigilOpencodeConfig>,
+): SigilOpencodeConfig {
+  return {
+    endpoint: "http://localhost:8080",
+    auth: { mode: "none" },
+    agentName: "opencode",
+    contentCapture: "metadata_only",
+    debug: false,
+    ...overrides,
+  };
+}
+
+describe("createSigilClient", () => {
+  beforeEach(() => {
+    SigilClientMock.mockReset();
+    // biome-ignore lint/complexity/useArrowFunction: must be a regular function for `new` to work
+    SigilClientMock.mockImplementation(function () {
+      return {};
+    });
+  });
+
+  it("passes contentCapture to the SDK client", () => {
+    createSigilClient(makeConfig({ contentCapture: "full" }));
+
+    expect(SigilClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({ contentCapture: "full" }),
+    );
+  });
+
+  it("creates SDK client with export config", () => {
+    const client = createSigilClient(makeConfig());
+
+    expect(client).toEqual({});
+    expect(SigilClientMock).toHaveBeenCalledTimes(1);
+    expect(SigilClientMock).toHaveBeenCalledWith({
+      generationExport: {
+        protocol: "http",
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+      },
+      contentCapture: "metadata_only",
+    });
+  });
+
+  it("appends the export path for a prefix-mounted endpoint", () => {
+    createSigilClient(
+      makeConfig({ endpoint: "https://sigil.example.com/sigil" }),
+    );
+
+    expect(SigilClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generationExport: expect.objectContaining({
+          endpoint: "https://sigil.example.com/sigil/api/v1/generations:export",
+        }),
+      }),
+    );
+  });
+
+  it("returns null when SDK constructor throws", () => {
+    SigilClientMock.mockImplementationOnce(() => {
+      throw new Error("boom");
+    });
+
+    const client = createSigilClient(makeConfig());
+
+    expect(client).toBeNull();
+  });
+});

--- a/plugins/opencode/src/client.ts
+++ b/plugins/opencode/src/client.ts
@@ -1,71 +1,37 @@
 import { SigilClient } from "@grafana/sigil-sdk-js";
-import type { SigilAuthConfig, SigilConfig } from "./config.js";
+import { EXPORT_PATH, type SigilOpencodeConfig } from "./config.js";
 
-// Matches ExportAuthConfig from @grafana/sigil-sdk-js (not re-exported from package index)
-type ResolvedAuth = {
-  mode: "none" | "tenant" | "bearer";
-  tenantId?: string;
-  bearerToken?: string;
-};
-
-export function resolveEnvVars(value: string): string {
-  return value.replace(/\$\{(\w+)\}/g, (_match, name) => {
-    return process.env[name] ?? "";
-  });
-}
-
-type ResolvedTransport = {
-  auth: ResolvedAuth;
-  headers?: Record<string, string>;
-};
-
-function resolveAuth(auth: SigilAuthConfig): ResolvedTransport {
-  switch (auth.mode) {
-    case "bearer":
-      return {
-        auth: { mode: "bearer", bearerToken: resolveEnvVars(auth.bearerToken) },
-      };
-    case "tenant":
-      return {
-        auth: { mode: "tenant", tenantId: resolveEnvVars(auth.tenantId) },
-      };
-    case "basic": {
-      // JS SDK doesn't support Basic auth natively — use
-      // mode "none" and inject the Authorization header manually.
-      const user = resolveEnvVars(auth.tenantId);
-      const pass = resolveEnvVars(auth.token);
-      const encoded = Buffer.from(`${user}:${pass}`).toString("base64");
-      return {
-        auth: { mode: "none" },
-        headers: { Authorization: `Basic ${encoded}` },
-      };
-    }
-    case "none":
-      return { auth: { mode: "none" } };
-  }
-}
-
-const GENERATION_EXPORT_PATH = "/api/v1/generations:export";
-
-export function createSigilClient(config: SigilConfig): SigilClient | null {
+export function createSigilClient(
+  config: SigilOpencodeConfig,
+): SigilClient | null {
   try {
-    if (!config.endpoint.includes(GENERATION_EXPORT_PATH)) {
-      console.warn(
-        `[sigil] endpoint "${config.endpoint}" does not include "${GENERATION_EXPORT_PATH}" -- ` +
-          `the JS SDK requires the full export URL (e.g. "http://localhost:8080${GENERATION_EXPORT_PATH}")`,
-      );
-    }
-    const transport = resolveAuth(config.auth);
     return new SigilClient({
       generationExport: {
         protocol: "http",
-        endpoint: config.endpoint,
-        auth: transport.auth,
-        ...(transport.headers && { headers: transport.headers }),
+        endpoint: appendExportPath(config.endpoint),
+        auth: config.auth,
       },
+      contentCapture: config.contentCapture,
     });
-  } catch {
-    console.warn("[sigil] failed to create SigilClient");
+  } catch (err) {
+    console.warn("[sigil-opencode] failed to create SigilClient:", err);
     return null;
+  }
+}
+
+/**
+ * Append `/api/v1/generations:export` to a bare Sigil base URL. The SDK's
+ * own normalizer only appends when the URL has no path, which breaks
+ * prefix-mounted Sigil deployments (`https://host/prefix`) — so we do it
+ * here unconditionally.
+ */
+function appendExportPath(endpoint: string): string {
+  if (!endpoint) return "";
+  try {
+    const url = new URL(endpoint);
+    url.pathname = url.pathname.replace(/\/+$/, "") + EXPORT_PATH;
+    return url.toString();
+  } catch {
+    return endpoint.replace(/\/+$/, "") + EXPORT_PATH;
   }
 }

--- a/plugins/opencode/src/config.test.ts
+++ b/plugins/opencode/src/config.test.ts
@@ -1,0 +1,268 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadConfig, normalizeBaseEndpoint, resolveConfig } from "./config.js";
+import { clearSigilEnv } from "./testEnv.js";
+
+describe("resolveConfig", () => {
+  beforeEach(clearSigilEnv);
+  afterEach(clearSigilEnv);
+
+  it("returns null when endpoint is missing", () => {
+    expect(resolveConfig()).toBeNull();
+  });
+
+  it("returns null when endpoint is whitespace", () => {
+    process.env.SIGIL_ENDPOINT = "   ";
+    expect(resolveConfig()).toBeNull();
+  });
+
+  it("stores the bare base URL when given a clean endpoint", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    const cfg = resolveConfig();
+    expect(cfg?.endpoint).toBe("http://localhost:8080");
+  });
+
+  it("defaults agentName to 'opencode'", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    const cfg = resolveConfig();
+    expect(cfg?.agentName).toBe("opencode");
+  });
+
+  it("falls back to 'opencode' when SIGIL_AGENT_NAME is whitespace", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_AGENT_NAME = "   ";
+    const cfg = resolveConfig();
+    expect(cfg?.agentName).toBe("opencode");
+  });
+
+  it("reads SIGIL_AGENT_NAME and SIGIL_AGENT_VERSION", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_AGENT_NAME = "opencode-custom";
+    process.env.SIGIL_AGENT_VERSION = "9.9.9";
+    const cfg = resolveConfig();
+    expect(cfg?.agentName).toBe("opencode-custom");
+    expect(cfg?.agentVersion).toBe("9.9.9");
+  });
+
+  it("defaults contentCapture to metadata_only", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    const cfg = resolveConfig();
+    expect(cfg?.contentCapture).toBe("metadata_only");
+  });
+
+  it("accepts SIGIL_CONTENT_CAPTURE_MODE=full", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_CONTENT_CAPTURE_MODE = "full";
+    const cfg = resolveConfig();
+    expect(cfg?.contentCapture).toBe("full");
+  });
+
+  it("accepts SIGIL_CONTENT_CAPTURE_MODE=no_tool_content", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_CONTENT_CAPTURE_MODE = "no_tool_content";
+    const cfg = resolveConfig();
+    expect(cfg?.contentCapture).toBe("no_tool_content");
+  });
+
+  it("accepts SIGIL_CONTENT_CAPTURE_MODE=metadata_only", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_CONTENT_CAPTURE_MODE = "metadata_only";
+    const cfg = resolveConfig();
+    expect(cfg?.contentCapture).toBe("metadata_only");
+  });
+
+  it("warns and falls back to metadata_only on unknown content-capture value", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_CONTENT_CAPTURE_MODE = "yolo";
+    const cfg = resolveConfig();
+    expect(cfg?.contentCapture).toBe("metadata_only");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("unsupported contentCapture"),
+    );
+    warn.mockRestore();
+  });
+
+  it("SIGIL_DEBUG flips debug on", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_DEBUG = "true";
+    const cfg = resolveConfig();
+    expect(cfg?.debug).toBe(true);
+  });
+
+  it("debug defaults to false", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    const cfg = resolveConfig();
+    expect(cfg?.debug).toBe(false);
+  });
+
+  it("derives basic auth from SIGIL_AUTH_TENANT_ID + SIGIL_AUTH_TOKEN", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_AUTH_TENANT_ID = "tenant-1";
+    process.env.SIGIL_AUTH_TOKEN = "glc_token";
+    const cfg = resolveConfig();
+    expect(cfg?.auth).toEqual({
+      mode: "basic",
+      basicUser: "tenant-1",
+      basicPassword: "glc_token",
+      tenantId: "tenant-1",
+    });
+  });
+
+  it("falls back to tenant mode when only the tenant id is set", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_AUTH_TENANT_ID = "tenant-1";
+    const cfg = resolveConfig();
+    expect(cfg?.auth).toEqual({ mode: "tenant", tenantId: "tenant-1" });
+  });
+
+  it("warns and falls back to none when only the auth token is set", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_AUTH_TOKEN = "glc_token";
+    const cfg = resolveConfig();
+    expect(cfg?.auth).toEqual({ mode: "none" });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("SIGIL_AUTH_TENANT_ID is missing"),
+    );
+    warn.mockRestore();
+  });
+
+  it("defaults auth to none when no creds are set", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    const cfg = resolveConfig();
+    expect(cfg?.auth).toEqual({ mode: "none" });
+  });
+});
+
+describe("normalizeBaseEndpoint", () => {
+  it("returns empty string for empty input", () => {
+    expect(normalizeBaseEndpoint("")).toBe("");
+  });
+
+  it("preserves a clean base URL", () => {
+    expect(normalizeBaseEndpoint("http://localhost:8080")).toBe(
+      "http://localhost:8080",
+    );
+  });
+
+  it("strips a trailing slash", () => {
+    expect(normalizeBaseEndpoint("http://localhost:8080/")).toBe(
+      "http://localhost:8080",
+    );
+  });
+
+  it("strips an accidentally-pasted export-path suffix", () => {
+    expect(
+      normalizeBaseEndpoint("http://localhost:8080/api/v1/generations:export"),
+    ).toBe("http://localhost:8080");
+  });
+
+  it("preserves a prefix path", () => {
+    expect(normalizeBaseEndpoint("https://sigil.example.com/sigil")).toBe(
+      "https://sigil.example.com/sigil",
+    );
+  });
+
+  it("strips the export-path suffix from a prefix-mounted URL", () => {
+    expect(
+      normalizeBaseEndpoint(
+        "https://sigil.example.com/sigil/api/v1/generations:export",
+      ),
+    ).toBe("https://sigil.example.com/sigil");
+  });
+
+  it("does not falsely match a similar-looking suffix", () => {
+    expect(
+      normalizeBaseEndpoint(
+        "http://localhost:8080/api/v1/generations:export-debug",
+      ),
+    ).toBe("http://localhost:8080/api/v1/generations:export-debug");
+  });
+});
+
+describe("loadConfig reads ~/.config/sigil/config.env", () => {
+  let dir: string;
+  let homeBackup: string | undefined;
+
+  beforeEach(() => {
+    clearSigilEnv();
+    dir = mkdtempSync(join(tmpdir(), "sigil-opencode-loadconfig-"));
+    process.env.XDG_CONFIG_HOME = dir;
+    homeBackup = process.env.HOME;
+    process.env.HOME = dir;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    if (homeBackup === undefined) delete process.env.HOME;
+    else process.env.HOME = homeBackup;
+    clearSigilEnv();
+  });
+
+  it("returns null when config.env is missing and no shell env is set", async () => {
+    const cfg = await loadConfig();
+    expect(cfg).toBeNull();
+  });
+
+  it("picks up SIGIL_* credentials from config.env when no shell env is set", async () => {
+    const cfgDir = join(dir, "sigil");
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.env"),
+      [
+        "SIGIL_ENDPOINT=https://sigil.example.com",
+        "SIGIL_AUTH_TENANT_ID=tenant-1",
+        "SIGIL_AUTH_TOKEN=glc_token",
+        "",
+      ].join("\n"),
+    );
+
+    const cfg = await loadConfig();
+    expect(cfg).not.toBeNull();
+    expect(cfg?.endpoint).toBe("https://sigil.example.com");
+    expect(cfg?.auth).toEqual({
+      mode: "basic",
+      basicUser: "tenant-1",
+      basicPassword: "glc_token",
+      tenantId: "tenant-1",
+    });
+  });
+
+  it("ignores a stray ~/.config/opencode/opencode-sigil.json on disk", async () => {
+    const legacyDir = join(dir, ".config", "opencode");
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(
+      join(legacyDir, "opencode-sigil.json"),
+      JSON.stringify({
+        enabled: true,
+        endpoint: "http://legacy:9090",
+        auth: { mode: "none" },
+      }),
+    );
+
+    const cfg = await loadConfig();
+    expect(cfg).toBeNull();
+  });
+
+  it("shell env overrides config.env values per key", async () => {
+    const cfgDir = join(dir, "sigil");
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.env"),
+      [
+        "SIGIL_ENDPOINT=https://shared.example",
+        "SIGIL_AGENT_NAME=opencode",
+        "",
+      ].join("\n"),
+    );
+
+    process.env.SIGIL_ENDPOINT = "https://shell.example";
+
+    const cfg = await loadConfig();
+    expect(cfg?.endpoint).toBe("https://shell.example");
+    expect(cfg?.agentName).toBe("opencode");
+  });
+});

--- a/plugins/opencode/src/config.ts
+++ b/plugins/opencode/src/config.ts
@@ -1,56 +1,151 @@
-import { readFile } from "fs/promises";
-import { homedir } from "os";
-import { join } from "path";
+import type { ContentCaptureMode } from "@grafana/sigil-sdk-js";
+import { applySigilDotenv } from "./sigilDotenv.js";
 
 export type SigilAuthConfig =
-  | { mode: "bearer"; bearerToken: string }
+  | {
+      mode: "basic";
+      basicUser: string;
+      basicPassword: string;
+      tenantId: string;
+    }
   | { mode: "tenant"; tenantId: string }
-  | { mode: "basic"; tenantId: string; token: string }
   | { mode: "none" };
 
-export type SigilConfig = {
-  enabled: boolean;
+export interface SigilOpencodeConfig {
   endpoint: string;
   auth: SigilAuthConfig;
-  agentName?: string;
+  agentName: string;
   agentVersion?: string;
-  contentCapture?: boolean;
-};
-
-const CONFIG_PATH = join(
-  homedir(),
-  ".config",
-  "opencode",
-  "opencode-sigil.json",
-);
-
-const DISABLED: SigilConfig = {
-  enabled: false,
-  endpoint: "",
-  auth: { mode: "none" },
-};
-
-export async function loadSigilConfig(): Promise<SigilConfig> {
-  try {
-    const raw = await readFile(CONFIG_PATH, "utf-8");
-    const parsed = JSON.parse(raw);
-    return parseSigilConfig(parsed) ?? DISABLED;
-  } catch {
-    return DISABLED;
-  }
+  contentCapture: ContentCaptureMode;
+  debug: boolean;
 }
 
-export function parseSigilConfig(raw: unknown): SigilConfig | undefined {
-  if (!raw || typeof raw !== "object") return undefined;
-  const obj = raw as Record<string, unknown>;
-  if (obj.enabled !== true) return undefined;
-  if (typeof obj.endpoint !== "string" || !obj.endpoint) {
-    console.warn("[sigil] enabled but endpoint is missing -- disabling");
-    return undefined;
+export async function loadConfig(): Promise<SigilOpencodeConfig | null> {
+  // Read the shared sigil dotenv file so the OpenCode plugin and every other
+  // Sigil agent resolve credentials from the same place. Values in process.env
+  // always win — applySigilDotenv only fills empty/whitespace entries.
+  applySigilDotenv();
+  return resolveConfig();
+}
+
+export function resolveConfig(): SigilOpencodeConfig | null {
+  const endpoint = normalizeBaseEndpoint((env("SIGIL_ENDPOINT") ?? "").trim());
+  if (!endpoint) return null;
+
+  const configuredAgentName = (env("SIGIL_AGENT_NAME") ?? "opencode").trim();
+  const agentName =
+    configuredAgentName.length > 0 ? configuredAgentName : "opencode";
+
+  const configuredAgentVersion = (env("SIGIL_AGENT_VERSION") ?? "").trim();
+  const agentVersion =
+    configuredAgentVersion.length > 0 ? configuredAgentVersion : undefined;
+
+  const contentCapture = resolveContentCapture();
+  const debug = envBool("SIGIL_DEBUG") ?? false;
+
+  return {
+    endpoint,
+    auth: resolveAuth(),
+    agentName,
+    agentVersion,
+    contentCapture,
+    debug,
+  };
+}
+
+function resolveAuth(): SigilAuthConfig {
+  const tenant = (env("SIGIL_AUTH_TENANT_ID") ?? "").trim();
+  const token = (env("SIGIL_AUTH_TOKEN") ?? "").trim();
+  if (tenant && token) {
+    return {
+      mode: "basic",
+      basicUser: tenant,
+      basicPassword: token,
+      tenantId: tenant,
+    };
   }
-  if (!obj.auth || typeof obj.auth !== "object") {
-    console.warn("[sigil] enabled but auth config is missing -- disabling");
-    return undefined;
+  if (tenant) {
+    return { mode: "tenant", tenantId: tenant };
   }
-  return raw as SigilConfig;
+  if (token) {
+    console.warn(
+      "[sigil-opencode] SIGIL_AUTH_TOKEN is set but SIGIL_AUTH_TENANT_ID is missing — auth disabled",
+    );
+  }
+  return { mode: "none" };
+}
+
+function resolveContentCapture(): ContentCaptureMode {
+  const envVal = env("SIGIL_CONTENT_CAPTURE_MODE");
+  if (envVal !== undefined) {
+    return parseContentCaptureMode(envVal);
+  }
+  return "metadata_only";
+}
+
+const VALID_CAPTURE_MODES: ContentCaptureMode[] = [
+  "full",
+  "no_tool_content",
+  "metadata_only",
+];
+
+function parseContentCaptureMode(value: string): ContentCaptureMode {
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return "full";
+  if (["0", "false", "no", "off"].includes(normalized)) return "metadata_only";
+  if (VALID_CAPTURE_MODES.includes(normalized as ContentCaptureMode)) {
+    return normalized as ContentCaptureMode;
+  }
+  console.warn(
+    `[sigil-opencode] unsupported contentCapture value "${value}", defaulting to metadata_only`,
+  );
+  return "metadata_only";
+}
+
+function env(key: string): string | undefined {
+  const v = process.env[key];
+  return v !== undefined && v !== "" ? v : undefined;
+}
+
+function envBool(key: string): boolean | undefined {
+  const v = env(key);
+  return v !== undefined ? toBool(v) : undefined;
+}
+
+function toBool(v: unknown): boolean | undefined {
+  if (typeof v === "boolean") return v;
+  if (typeof v !== "string") return undefined;
+
+  const normalized = v.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+
+  return undefined;
+}
+
+export const EXPORT_PATH = "/api/v1/generations:export";
+
+/**
+ * Normalize a Sigil endpoint to the bare API base URL. Accepts either the
+ * base URL (`https://host` or `https://host/prefix`) or a full generations
+ * export URL (`https://host/api/v1/generations:export`) — the latter is a
+ * common copy-paste mistake. Trailing slashes are stripped. The export path
+ * is reapplied in `client.ts` when constructing the generationExport URL.
+ */
+export function normalizeBaseEndpoint(endpoint: string): string {
+  if (!endpoint) return "";
+  try {
+    const url = new URL(endpoint);
+    let pathname = url.pathname.replace(/\/+$/, "");
+    if (pathname.endsWith(EXPORT_PATH)) {
+      pathname = pathname.slice(0, pathname.length - EXPORT_PATH.length);
+    }
+    url.pathname = pathname;
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    const trimmed = endpoint.replace(/\/+$/, "");
+    return trimmed.endsWith(EXPORT_PATH)
+      ? trimmed.slice(0, trimmed.length - EXPORT_PATH.length)
+      : trimmed;
+  }
 }

--- a/plugins/opencode/src/fsErrors.ts
+++ b/plugins/opencode/src/fsErrors.ts
@@ -1,0 +1,12 @@
+/**
+ * True when `err` looks like a node:fs ENOENT (missing file/directory).
+ * Used to swallow expected "file not found" cases from optional config reads.
+ */
+export function isMissingFileError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: string }).code === "ENOENT"
+  );
+}

--- a/plugins/opencode/src/golden.test.ts
+++ b/plugins/opencode/src/golden.test.ts
@@ -17,7 +17,7 @@ import { createServer, type Server } from "node:http";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { SigilConfig } from "./config.js";
+import type { SigilOpencodeConfig } from "./config.js";
 import { createSigilHooks } from "./hooks.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -78,7 +78,7 @@ function startExportCaptureServer(): Promise<{
       }
       resolve({
         server,
-        baseUrl: `http://127.0.0.1:${addr.port}/api/v1/generations:export`,
+        baseUrl: `http://127.0.0.1:${addr.port}`,
         captures,
         errors,
       });
@@ -215,7 +215,7 @@ describe("opencode plugin: real-SDK golden export", () => {
   });
 
   async function runCompleteAssistantTurn(
-    configOverrides: Partial<SigilConfig> = {},
+    configOverrides: Partial<SigilOpencodeConfig> = {},
   ) {
     const {
       sessionID,
@@ -225,13 +225,13 @@ describe("opencode plugin: real-SDK golden export", () => {
       assistantParts,
     } = opencodeMessageFixture();
 
-    const config: SigilConfig = {
-      enabled: true,
+    const config: SigilOpencodeConfig = {
       endpoint: serverEnv.baseUrl,
       auth: { mode: "none" },
       agentName: "opencode",
       agentVersion: "test-version",
-      contentCapture: true,
+      contentCapture: "full",
+      debug: false,
       ...configOverrides,
     };
 
@@ -330,7 +330,51 @@ describe("opencode plugin: real-SDK golden export", () => {
 
     assertGoldenJSON(GOLDEN_PATH, exports);
   });
+
+  it.each([
+    "full",
+    "no_tool_content",
+    "metadata_only",
+  ] as const)("propagates content capture mode %s to the SDK export", async (contentCapture) => {
+    const { turn, messageFetches } = await runCompleteAssistantTurn({
+      contentCapture,
+    });
+
+    expectCommonTurnFields(turn);
+    expect(turn.metadata["sigil.sdk.content_capture_mode"]).toBe(
+      contentCapture,
+    );
+    expect(messageFetches).toBe(contentCapture === "metadata_only" ? 0 : 1);
+    if (contentCapture === "metadata_only") {
+      expect(turn.tools.map((tool: any) => tool.name)).toEqual([
+        "Bash",
+        "Read",
+      ]);
+    }
+  });
+
+  it("keeps text but omits tool bodies in no_tool_content exports", async () => {
+    const { turn } = await runCompleteAssistantTurn({
+      contentCapture: "no_tool_content",
+    });
+
+    expect(turn.input[0].parts[0].text).toBe("list go files in this repo");
+    expect(findOutputPart(turn, "text").text).toBe(
+      "I will list the go files for you.",
+    );
+    expect(findOutputPart(turn, "tool_call").tool_call.input_json).toBe("");
+    expect(findOutputPart(turn, "tool_result").tool_result.content).toBe("");
+  });
 });
+
+function findOutputPart(turn: any, key: string): any {
+  for (const message of turn.output ?? []) {
+    for (const part of message.parts ?? []) {
+      if (part[key] !== undefined) return part;
+    }
+  }
+  throw new Error(`missing output part ${key}`);
+}
 
 const normalizeFields: Record<string, string> = {
   started_at: "<NORMALIZED>",

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -2,7 +2,7 @@ import type { SigilClient } from "@grafana/sigil-sdk-js";
 import type { PluginInput } from "@opencode-ai/plugin";
 import type { AssistantMessage, Part, UserMessage } from "@opencode-ai/sdk";
 import { createSigilClient } from "./client.js";
-import type { SigilConfig } from "./config.js";
+import type { SigilOpencodeConfig } from "./config.js";
 import { mapError, mapGeneration, mapToolDefinitions } from "./mappers.js";
 import { Redactor } from "./redact.js";
 
@@ -44,7 +44,7 @@ function handleChatMessage(
 
 async function handleEvent(
   sigil: SigilClient,
-  config: SigilConfig,
+  config: SigilOpencodeConfig,
   client: OpencodeClient,
   redactor: Redactor,
   event: { type: string; properties: unknown },
@@ -74,19 +74,22 @@ async function handleEvent(
   // Look up pending generation (user-side data)
   const pending = pendingGenerations.get(assistantMsg.sessionID);
 
-  // Fetch assistant parts via REST
+  const includeMessageBodies = config.contentCapture !== "metadata_only";
+
+  // Fetch assistant parts only when the selected mode can export message bodies.
   let assistantParts: Part[] = [];
-  try {
-    const response = await client.session.message({
-      path: { id: assistantMsg.sessionID, messageID: assistantMsg.id },
-    });
-    assistantParts = response.data?.parts ?? [];
-  } catch {
-    // REST fetch failed — fall back to metadata-only
+  if (includeMessageBodies) {
+    try {
+      const response = await client.session.message({
+        path: { id: assistantMsg.sessionID, messageID: assistantMsg.id },
+      });
+      assistantParts = response.data?.parts ?? [];
+    } catch {
+      // REST fetch failed — fall back to metadata-only output content.
+    }
   }
 
-  const contentCapture = config.contentCapture ?? true;
-
+  const tools = mapToolDefinitions(pending?.tools);
   const seed = {
     conversationId: assistantMsg.sessionID,
     agentName: buildAgentName(config.agentName, assistantMsg.mode),
@@ -94,22 +97,18 @@ async function handleEvent(
     effectiveVersion: config.agentVersion,
     model: { provider: assistantMsg.providerID, name: assistantMsg.modelID },
     startedAt: new Date(assistantMsg.time.created),
-    ...(contentCapture && {
-      systemPrompt: pending?.systemPrompt,
-      tools: mapToolDefinitions(pending?.tools),
-    }),
+    contentCapture: config.contentCapture,
+    ...(tools.length > 0 && { tools }),
+    ...(includeMessageBodies && { systemPrompt: pending?.systemPrompt }),
   };
 
-  // When contentCapture is enabled, map full content with redaction;
-  // otherwise fall back to metadata-only result (no message content).
-  const result = contentCapture
-    ? mapGeneration(
-        assistantMsg,
-        pending?.userParts ?? [],
-        assistantParts,
-        redactor,
-      )
-    : mapGeneration(assistantMsg, [], [], redactor);
+  const result = mapGeneration(
+    assistantMsg,
+    includeMessageBodies ? (pending?.userParts ?? []) : [],
+    assistantParts,
+    redactor,
+    config.contentCapture,
+  );
 
   try {
     if (assistantMsg.error) {
@@ -176,18 +175,9 @@ export type SigilHooks = {
 };
 
 export async function createSigilHooks(
-  config: SigilConfig,
+  config: SigilOpencodeConfig,
   client: OpencodeClient,
 ): Promise<SigilHooks | null> {
-  if (!config.enabled) return null;
-
-  if (!config.endpoint) {
-    console.warn(
-      "[sigil] endpoint is required when enabled -- skipping Sigil initialization",
-    );
-    return null;
-  }
-
   const sigil = createSigilClient(config);
   if (!sigil) return null;
 

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -1,10 +1,10 @@
 import type { Plugin } from "@opencode-ai/plugin";
-import { loadSigilConfig } from "./config.js";
+import { loadConfig } from "./config.js";
 import { createSigilHooks } from "./hooks.js";
 
 export const SigilPlugin: Plugin = async ({ client }) => {
-  const config = await loadSigilConfig();
-  if (!config.enabled) return {};
+  const config = await loadConfig();
+  if (!config) return {};
 
   const hooks = await createSigilHooks(config, client);
   if (!hooks) return {};

--- a/plugins/opencode/src/mappers.test.ts
+++ b/plugins/opencode/src/mappers.test.ts
@@ -101,6 +101,20 @@ describe("mapInputMessages", () => {
     expect(result).toHaveLength(1);
     expect(result[0].parts?.[0]).toEqual({ type: "text", text: "hello" });
   });
+
+  it("omits input bodies in metadata_only mode", () => {
+    const parts = [
+      {
+        id: "p1",
+        sessionID: "s1",
+        messageID: "m1",
+        type: "text" as const,
+        text: "hello world",
+      },
+    ] as Part[];
+
+    expect(mapInputMessages(parts, "metadata_only")).toEqual([]);
+  });
 });
 
 describe("mapOutputMessages", () => {
@@ -165,8 +179,83 @@ describe("mapOutputMessages", () => {
     expect(result).toHaveLength(2);
     expect(result[0].role).toBe("assistant");
     expect(result[0].parts?.[0].type).toBe("tool_call");
+    const toolCall = (result[0].parts?.[0] as any).toolCall;
+    expect(toolCall.inputJSON).toBe('{"command":"echo test"}');
     expect(result[1].role).toBe("tool");
     expect(result[1].parts?.[0].type).toBe("tool_result");
+    const toolResult = (result[1].parts?.[0] as any).toolResult;
+    expect(toolResult.content).toBe("test output");
+  });
+
+  it("keeps message text but omits tool bodies in no_tool_content mode", () => {
+    const parts = [
+      {
+        id: "p1",
+        sessionID: "s1",
+        messageID: "m1",
+        type: "text" as const,
+        text: "assistant reply",
+      },
+      {
+        id: "p2",
+        sessionID: "s1",
+        messageID: "m1",
+        type: "tool" as const,
+        callID: "call-1",
+        tool: "bash",
+        state: {
+          status: "completed" as const,
+          input: { command: "echo test" },
+          output: "test output",
+          title: "Run bash",
+          metadata: {},
+          time: { start: 1000, end: 2000 },
+        },
+      },
+    ] as Part[];
+
+    const result = mapOutputMessages(parts, redactor, "no_tool_content");
+
+    expect(result[0].parts?.[0]).toEqual({
+      type: "text",
+      text: "assistant reply",
+    });
+    expect((result[1].parts?.[0] as any).toolCall.inputJSON).toBe("");
+    expect((result[2].parts?.[0] as any).toolResult.content).toBe("");
+  });
+
+  it("omits text and tool bodies in metadata_only mode", () => {
+    const parts = [
+      {
+        id: "p1",
+        sessionID: "s1",
+        messageID: "m1",
+        type: "text" as const,
+        text: "assistant reply",
+      },
+      {
+        id: "p2",
+        sessionID: "s1",
+        messageID: "m1",
+        type: "tool" as const,
+        callID: "call-1",
+        tool: "bash",
+        state: {
+          status: "completed" as const,
+          input: { command: "echo test" },
+          output: "test output",
+          title: "Run bash",
+          metadata: {},
+          time: { start: 1000, end: 2000 },
+        },
+      },
+    ] as Part[];
+
+    const result = mapOutputMessages(parts, redactor, "metadata_only");
+
+    expect(result).toHaveLength(2);
+    expect((result[0].parts?.[0] as any).toolCall.inputJSON).toBe("");
+    expect((result[1].parts?.[0] as any).toolResult.content).toBe("");
   });
 
   it("skips text parts with empty or whitespace-only text", () => {

--- a/plugins/opencode/src/mappers.ts
+++ b/plugins/opencode/src/mappers.ts
@@ -1,4 +1,5 @@
 import type {
+  ContentCaptureMode,
   GenerationResult,
   Message,
   ToolDefinition,
@@ -8,13 +9,26 @@ import type { Redactor } from "./redact.js";
 
 export type { GenerationResult };
 
+function includesMessageBodies(contentCapture: ContentCaptureMode): boolean {
+  return contentCapture !== "metadata_only";
+}
+
+function includesToolBodies(contentCapture: ContentCaptureMode): boolean {
+  return (
+    contentCapture === "full" || contentCapture === "full_with_metadata_spans"
+  );
+}
+
 /**
  * Map user-side parts to Sigil input messages. No redaction applied — user text is the
- * user's own data and Sigil needs it verbatim for prompt analysis. Tier 1 patterns in
- * user text (e.g., pasted connection strings) are a known accepted gap; apply redaction
- * here if this becomes a problem.
+ * user's own data and Sigil needs it for prompt analysis when content capture allows it.
  */
-export function mapInputMessages(parts: Part[]): Message[] {
+export function mapInputMessages(
+  parts: Part[],
+  contentCapture: ContentCaptureMode = "full",
+): Message[] {
+  if (!includesMessageBodies(contentCapture)) return [];
+
   const messages: Message[] = [];
   for (const part of parts) {
     if (part.type === "text" && part.text.trim().length > 0) {
@@ -31,27 +45,35 @@ export function mapInputMessages(parts: Part[]): Message[] {
 export function mapOutputMessages(
   parts: Part[],
   redactor: Redactor,
+  contentCapture: ContentCaptureMode = "full",
 ): Message[] {
   const messages: Message[] = [];
+  const includeBodies = includesMessageBodies(contentCapture);
+  const includeToolBodies = includesToolBodies(contentCapture);
+
   for (const part of parts) {
     switch (part.type) {
       case "text": {
-        const text = redactor.redactLightweight(part.text);
-        if (text.trim().length > 0) {
-          messages.push({
-            role: "assistant",
-            parts: [{ type: "text", text }],
-          });
+        if (includeBodies) {
+          const text = redactor.redactLightweight(part.text);
+          if (text.trim().length > 0) {
+            messages.push({
+              role: "assistant",
+              parts: [{ type: "text", text }],
+            });
+          }
         }
         break;
       }
       case "reasoning": {
-        const thinking = redactor.redactLightweight(part.text);
-        if (thinking.trim().length > 0) {
-          messages.push({
-            role: "assistant",
-            parts: [{ type: "thinking", thinking }],
-          });
+        if (includeBodies) {
+          const thinking = redactor.redactLightweight(part.text);
+          if (thinking.trim().length > 0) {
+            messages.push({
+              role: "assistant",
+              parts: [{ type: "thinking", thinking }],
+            });
+          }
         }
         break;
       }
@@ -66,7 +88,9 @@ export function mapOutputMessages(
                 toolCall: {
                   id: part.callID,
                   name: part.tool,
-                  inputJSON: redactor.redact(JSON.stringify(state.input ?? {})),
+                  inputJSON: includeToolBodies
+                    ? redactor.redact(JSON.stringify(state.input ?? {}))
+                    : "",
                 },
               },
             ],
@@ -79,7 +103,9 @@ export function mapOutputMessages(
                 toolResult: {
                   toolCallId: part.callID,
                   name: part.tool,
-                  content: redactor.redact(state.output ?? ""),
+                  content: includeToolBodies
+                    ? redactor.redact(state.output ?? "")
+                    : "",
                 },
               },
             ],
@@ -93,7 +119,9 @@ export function mapOutputMessages(
                 toolCall: {
                   id: part.callID,
                   name: part.tool,
-                  inputJSON: redactor.redact(JSON.stringify(state.input ?? {})),
+                  inputJSON: includeToolBodies
+                    ? redactor.redact(JSON.stringify(state.input ?? {}))
+                    : "",
                 },
               },
             ],
@@ -106,7 +134,9 @@ export function mapOutputMessages(
                 toolResult: {
                   toolCallId: part.callID,
                   name: part.tool,
-                  content: redactor.redact(state.error ?? "unknown error"),
+                  content: includeToolBodies
+                    ? redactor.redact(state.error ?? "unknown error")
+                    : "",
                   isError: true,
                 },
               },
@@ -136,10 +166,11 @@ export function mapGeneration(
   userParts: Part[],
   assistantParts: Part[],
   redactor: Redactor,
+  contentCapture: ContentCaptureMode = "full",
 ): GenerationResult {
   return {
-    input: mapInputMessages(userParts),
-    output: mapOutputMessages(assistantParts, redactor),
+    input: mapInputMessages(userParts, contentCapture),
+    output: mapOutputMessages(assistantParts, redactor, contentCapture),
     usage: {
       inputTokens: msg.tokens.input,
       outputTokens: msg.tokens.output,

--- a/plugins/opencode/src/sigilDotenv.test.ts
+++ b/plugins/opencode/src/sigilDotenv.test.ts
@@ -1,0 +1,205 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  applySigilDotenv,
+  loadSigilDotenv,
+  parseSigilDotenv,
+  sigilConfigEnvPath,
+} from "./sigilDotenv.js";
+import { clearSigilEnv } from "./testEnv.js";
+
+describe("parseSigilDotenv", () => {
+  it("parses the full sample from the Go reference test", () => {
+    const body = `# leading comment
+SIGIL_ENDPOINT=https://sigil.example.com
+export SIGIL_AUTH_TENANT_ID=alice
+SIGIL_AUTH_TOKEN="secret with spaces"
+SIGIL_CONTENT_CAPTURE_MODE='full'
+SIGIL_TAGS=a=1,b=2  # inline comment
+SIGIL_DEBUG=true
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.example.com/otlp
+PATH=/tmp/not-loaded
+no_equals_line
+=missingkey
+EMPTY=
+`;
+    const got = parseSigilDotenv(body);
+    expect(got).toEqual({
+      SIGIL_ENDPOINT: "https://sigil.example.com",
+      SIGIL_AUTH_TENANT_ID: "alice",
+      SIGIL_AUTH_TOKEN: "secret with spaces",
+      SIGIL_CONTENT_CAPTURE_MODE: "full",
+      SIGIL_TAGS: "a=1,b=2",
+      SIGIL_DEBUG: "true",
+      OTEL_EXPORTER_OTLP_ENDPOINT: "https://otlp.example.com/otlp",
+    });
+  });
+
+  it("skips comments, blank lines, and lines without an equals sign", () => {
+    const body = `
+# top-level comment
+   # indented comment
+
+SIGIL_ENDPOINT=https://ok
+
+no_equals_line
+=missingkey
+EMPTY=
+`;
+    const got = parseSigilDotenv(body);
+    expect(got).toEqual({ SIGIL_ENDPOINT: "https://ok" });
+  });
+
+  it("honors the optional 'export ' prefix", () => {
+    const got = parseSigilDotenv(`export SIGIL_ENDPOINT=https://exported\n`);
+    expect(got).toEqual({ SIGIL_ENDPOINT: "https://exported" });
+  });
+
+  it("ignores keys outside the allow-list", () => {
+    const body = `PATH=/tmp/not-loaded
+HOME=/tmp/not-loaded
+SIGIL_ENDPOINT=https://ok
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic xyz
+OTEL_EXPORTER_OTLP_INSECURE=true
+OTEL_SERVICE_NAME=my-service
+OTEL_RESOURCE_ATTRIBUTES=service.name=other
+`;
+    const got = parseSigilDotenv(body);
+    expect(got).toEqual({
+      SIGIL_ENDPOINT: "https://ok",
+      OTEL_EXPORTER_OTLP_HEADERS: "Authorization=Basic xyz",
+      OTEL_EXPORTER_OTLP_INSECURE: "true",
+      OTEL_SERVICE_NAME: "my-service",
+    });
+    expect(got).not.toHaveProperty("PATH");
+    expect(got).not.toHaveProperty("HOME");
+    expect(got).not.toHaveProperty("OTEL_RESOURCE_ATTRIBUTES");
+  });
+
+  it("accepts both CRLF and LF line endings", () => {
+    const body = "SIGIL_ENDPOINT=https://crlf\r\nSIGIL_DEBUG=true\r\n";
+    expect(parseSigilDotenv(body)).toEqual({
+      SIGIL_ENDPOINT: "https://crlf",
+      SIGIL_DEBUG: "true",
+    });
+  });
+});
+
+describe("sigilConfigEnvPath", () => {
+  beforeEach(clearSigilEnv);
+  afterEach(clearSigilEnv);
+
+  it("honors an absolute XDG_CONFIG_HOME", () => {
+    process.env.XDG_CONFIG_HOME = "/tmp/custom-config";
+    expect(sigilConfigEnvPath()).toBe("/tmp/custom-config/sigil/config.env");
+  });
+
+  it("falls back to $HOME/.config/sigil/config.env when XDG_CONFIG_HOME is unset", () => {
+    expect(sigilConfigEnvPath()).toBe(
+      join(homedir(), ".config", "sigil", "config.env"),
+    );
+  });
+});
+
+describe("loadSigilDotenv", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    clearSigilEnv();
+    dir = mkdtempSync(join(tmpdir(), "sigil-opencode-dotenv-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    clearSigilEnv();
+  });
+
+  it("returns an empty map silently when the file is missing", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const got = loadSigilDotenv(join(dir, "does-not-exist.env"));
+    expect(got).toEqual({});
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("parses an on-disk file", () => {
+    const path = join(dir, "config.env");
+    writeFileSync(
+      path,
+      "SIGIL_ENDPOINT=https://from-file\nSIGIL_AUTH_TOKEN=tok\n",
+    );
+    expect(loadSigilDotenv(path)).toEqual({
+      SIGIL_ENDPOINT: "https://from-file",
+      SIGIL_AUTH_TOKEN: "tok",
+    });
+  });
+
+  it("warns with the opencode prefix on non-ENOENT read failures", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const got = loadSigilDotenv(dir);
+    expect(got).toEqual({});
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toMatch(/^\[sigil-opencode\]/);
+    warn.mockRestore();
+  });
+});
+
+describe("applySigilDotenv", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    clearSigilEnv();
+    dir = mkdtempSync(join(tmpdir(), "sigil-opencode-dotenv-apply-"));
+    process.env.XDG_CONFIG_HOME = dir;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    clearSigilEnv();
+  });
+
+  function configPath(): string {
+    return join(dir, "sigil", "config.env");
+  }
+
+  function writeConfig(body: string): void {
+    const path = configPath();
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, body);
+  }
+
+  it("fills empty OS env values from config.env", () => {
+    writeConfig(
+      "SIGIL_ENDPOINT=https://from-file\nSIGIL_AUTH_TENANT_ID=tenant-1\nSIGIL_AUTH_TOKEN=tok\n",
+    );
+    applySigilDotenv();
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://from-file");
+    expect(process.env.SIGIL_AUTH_TENANT_ID).toBe("tenant-1");
+    expect(process.env.SIGIL_AUTH_TOKEN).toBe("tok");
+  });
+
+  it("keeps non-empty OS env values intact", () => {
+    process.env.SIGIL_ENDPOINT = "https://from-shell";
+    writeConfig("SIGIL_ENDPOINT=https://from-file\n");
+    applySigilDotenv();
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://from-shell");
+  });
+
+  it("does nothing silently when config.env is missing", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    applySigilDotenv();
+    expect(process.env.SIGIL_ENDPOINT).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("does not touch keys outside the allow-list", () => {
+    const before = process.env.PATH;
+    writeConfig("PATH=/tmp/not-loaded\nSIGIL_ENDPOINT=https://ok\n");
+    applySigilDotenv();
+    expect(process.env.PATH).toBe(before);
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://ok");
+  });
+});

--- a/plugins/opencode/src/sigilDotenv.ts
+++ b/plugins/opencode/src/sigilDotenv.ts
@@ -1,0 +1,133 @@
+import { readFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { isAbsolute, join } from "node:path";
+import { isMissingFileError } from "./fsErrors.js";
+
+// Mirror plugins/sigil/internal/dotenv/dotenv.go::AllowedDotenvKey so the
+// allow-list stays in sync with the Go launcher. Anything outside the SIGIL_*
+// prefix and this small OTEL_* set is ignored, including innocent-looking
+// vars like PATH that happen to appear in a shared config.env.
+const ALLOWED_OTEL_KEYS = new Set([
+  "OTEL_EXPORTER_OTLP_ENDPOINT",
+  "OTEL_EXPORTER_OTLP_HEADERS",
+  "OTEL_EXPORTER_OTLP_INSECURE",
+  "OTEL_SERVICE_NAME",
+]);
+
+function allowedDotenvKey(key: string): boolean {
+  return key.startsWith("SIGIL_") || ALLOWED_OTEL_KEYS.has(key);
+}
+
+/**
+ * Resolve the path the sigil dotenv loader reads. Mirrors
+ * `plugins/sigil/internal/xdg/xdg.go::ConfigRoot` so every Sigil agent reads
+ * the same file:
+ *
+ * 1. `$XDG_CONFIG_HOME/sigil/config.env` when XDG_CONFIG_HOME is an absolute path.
+ * 2. `$HOME/.config/sigil/config.env` when the user has a resolvable home.
+ * 3. `<tmpdir>/sigil/config.env` as a last-resort fallback.
+ */
+export function sigilConfigEnvPath(): string {
+  const xdg = (process.env.XDG_CONFIG_HOME ?? "").trim();
+  if (xdg && isAbsolute(xdg)) {
+    return join(xdg, "sigil", "config.env");
+  }
+  const home = homedir();
+  if (home && isAbsolute(home)) {
+    return join(home, ".config", "sigil", "config.env");
+  }
+  return join(tmpdir(), "sigil", "config.env");
+}
+
+/**
+ * Parse a config.env body using the same rules as the Go reference loader
+ * (`plugins/sigil/internal/dotenv/dotenv.go::LoadDotenv` +
+ * `parseDotenvValue`):
+ *
+ * - `KEY=value` one pair per line.
+ * - `#` line comments and blank lines are skipped.
+ * - Optional leading `export ` is stripped.
+ * - Optional matching single- or double-quotes around the value; inner
+ *   whitespace and `#` are preserved as written.
+ * - An unterminated quoted value falls through to the literal value
+ *   (including the leading quote), matching Go.
+ * - Trailing ` # comment` is stripped from unquoted values only.
+ * - Empty values, lines without `=`, and lines with an empty key are dropped.
+ * - Only keys passing `allowedDotenvKey` (SIGIL_* plus four OTEL_*) survive.
+ */
+export function parseSigilDotenv(body: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawLine of body.split(/\r?\n/)) {
+    let line = rawLine.trim();
+    if (line === "" || line.startsWith("#")) continue;
+    if (line.startsWith("export ")) {
+      line = line.slice("export ".length).trim();
+    }
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    if (!key || !allowedDotenvKey(key)) continue;
+    const value = parseDotenvValue(line.slice(eq + 1).trim());
+    if (value !== "") out[key] = value;
+  }
+  return out;
+}
+
+function parseDotenvValue(v: string): string {
+  if (v.length >= 2) {
+    const first = v[0];
+    if (first === '"' || first === "'") {
+      const end = v.indexOf(first, 1);
+      if (end >= 0) return v.slice(1, end);
+    }
+  }
+  const hashIdx = v.indexOf(" #");
+  if (hashIdx >= 0) {
+    return v.slice(0, hashIdx).replace(/[ \t]+$/, "");
+  }
+  return v;
+}
+
+interface SigilDotenvReadResult {
+  env: Record<string, string>;
+  reliable: boolean;
+}
+
+function readSigilDotenv(path: string): SigilDotenvReadResult {
+  let body: string;
+  try {
+    body = readFileSync(path, "utf-8");
+  } catch (err) {
+    if (isMissingFileError(err)) {
+      return { env: {}, reliable: true };
+    }
+    console.warn(`[sigil-opencode] failed to read ${path}:`, err);
+    return { env: {}, reliable: false };
+  }
+  return { env: parseSigilDotenv(body), reliable: true };
+}
+
+/**
+ * Read and parse the dotenv file at `path`. Missing files return `{}`
+ * silently — the dotenv config is optional and credentials may come from
+ * other sources (shell env). Other read failures emit a single
+ * `[sigil-opencode]` warning and also return `{}`.
+ */
+export function loadSigilDotenv(path: string): Record<string, string> {
+  return readSigilDotenv(path).env;
+}
+
+/**
+ * Read the sigil dotenv file and fill any empty entries in `process.env`.
+ * Mirrors the Go launcher's `dotenv.ApplyEnv`: OS env wins per key, the
+ * file value is only written when the OS value is empty or whitespace.
+ */
+export function applySigilDotenv(): void {
+  const loaded = readSigilDotenv(sigilConfigEnvPath());
+  if (!loaded.reliable) return;
+  for (const [key, value] of Object.entries(loaded.env)) {
+    const current = (process.env[key] ?? "").trim();
+    if (current !== "") continue;
+    process.env[key] = value;
+  }
+}

--- a/plugins/opencode/src/testEnv.ts
+++ b/plugins/opencode/src/testEnv.ts
@@ -1,0 +1,13 @@
+/**
+ * Reset every SIGIL_* and OTEL_* env var and XDG_CONFIG_HOME between test
+ * cases so on-disk fixtures (config.env) and shell exports cannot leak across
+ * cases. Used by both config.test.ts and sigilDotenv.test.ts.
+ */
+export function clearSigilEnv(): void {
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith("SIGIL_") || key.startsWith("OTEL_")) {
+      delete process.env[key];
+    }
+  }
+  delete process.env.XDG_CONFIG_HOME;
+}

--- a/plugins/opencode/src/testdata/golden/opencode-full-message.golden.json
+++ b/plugins/opencode/src/testdata/golden/opencode-full-message.golden.json
@@ -95,7 +95,7 @@
         "metadata": {
           "cost": 0.005,
           "sigil.sdk.name": "sdk-js",
-          "sigil.sdk.content_capture_mode": "no_tool_content"
+          "sigil.sdk.content_capture_mode": "full"
         },
         "raw_artifacts": [],
         "call_error": "",


### PR DESCRIPTION
Opencode did not use `~/.config/sigil/config.env` as all other agents, making a breaking change to use the same config.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Breaking config migration (JSON → env) and changes what conversation/tool data is exported by default; auth and endpoint handling are reworked but covered by new tests.
> 
> **Overview**
> The OpenCode Sigil plugin **drops** `~/.config/opencode/opencode-sigil.json` and loads settings from the shared **`~/.config/sigil/config.env`** (same path and parsing rules as the Go `sigil` CLI). On startup it applies that dotenv file into `process.env` only for empty keys; shell env still wins per variable. The plugin is **off** when `SIGIL_ENDPOINT` is unset or blank.
> 
> Configuration is now **`SIGIL_*` env vars**: endpoint normalization (strips a pasted `/api/v1/generations:export` suffix), auth from tenant id + token (Basic via the JS SDK), optional tenant-only mode, agent name/version, and **`SIGIL_CONTENT_CAPTURE_MODE`** (`metadata_only` default, `full`, `no_tool_content`). **`SIGIL_DEBUG`** enables stderr logging.
> 
> The HTTP client always **appends** the generations export path (including prefix-mounted bases) and passes **`contentCapture`** into `@grafana/sigil-sdk-js` instead of hand-building Basic auth headers.
> 
> Export behavior follows the capture mode: **`metadata_only`** skips fetching assistant message bodies and omits text/tool payloads; **`no_tool_content`** keeps message text but blanks tool I/O; **`full`** keeps redacted content. README is rewritten for `sigil login`, brew install, and the env-only option table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccefbd9cbfafc5a56551b25f0724d7c477451dce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->