### PR TITLE
fix(plugins/cursor): preserve stdin for sigil binary

### DIFF
--- a/plugins/cursor/scripts/run.sh
+++ b/plugins/cursor/scripts/run.sh
@@ -9,10 +9,14 @@
 # common locations directly. Set SIGIL_BIN to override.
 set -u
 
+# Save the original stdin (the JSON payload from Cursor) before the heredoc
+# below replaces fd 0 with the candidate-path list.
+exec 3<&0
+
 # Iterate over a newline-delimited list so paths with spaces (e.g. macOS
 # user homes) survive word-splitting.
 while IFS= read -r b; do
-  [ -n "$b" ] && [ -x "$b" ] && exec "$b" cursor hook "$@"
+  [ -n "$b" ] && [ -x "$b" ] && exec "$b" cursor hook "$@" <&3
 done <<EOF
 ${SIGIL_BIN:-}
 ${HOME:-}/go/bin/sigil


### PR DESCRIPTION
## Summary
- The heredoc in `run.sh` that resolves the sigil binary path was replacing fd 0, causing the JSON payload from Cursor to be lost before reaching `sigil cursor hook`.
- Fix: save the original stdin to fd 3 before the heredoc and redirect it back when exec-ing the binary.

## Test plan
- [ ] Run `sigil cursor hook` via the Cursor plugin and verify the hook receives the full JSON payload.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small shell launcher change with no auth, data, or API surface impact; only affects how stdin is passed to the hook binary.
> 
> **Overview**
> Fixes the macOS/Linux Cursor plugin launcher so **Cursor’s hook JSON on stdin** still reaches `sigil cursor hook` after the script searches for the binary.
> 
> The path-probe loop uses a heredoc, which **replaces fd 0** with the candidate-path list and was **dropping the original stdin**. The script now **dup’s stdin to fd 3** before the loop and **`exec`s sigil with `<&3`** so the payload is preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acafbd8b55f8f59da19a2a4a889c25fb24d2a4c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->