### PR TITLE
feat(plugins/sigil): add opencode launcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,12 +37,12 @@ CI runs `mise run check:proto` and fails the build if the committed stubs drift 
 
 | Plugin dir | What it actually is |
 |------------|---------------------|
-| `plugins/sigil/` | The shared Go binary (`brew install grafana/grafana/sigil`). Has subcommands `claude`, `codex`, `copilot`, `cursor`, `pi`, `login`. This is also what consumers use. |
+| `plugins/sigil/` | The shared Go binary (`brew install grafana/grafana/sigil`). Has subcommands `claude`, `codex`, `copilot`, `cursor`, `opencode`, `pi`, `login`. This is also what consumers use. |
 | `plugins/claude-code/`, `plugins/codex/`, `plugins/copilot/`, `plugins/cursor/` | Thin glue: hook scripts and READMEs that wire the host agent to the shared `sigil` binary. No independent code paths. |
-| `plugins/opencode/` | Independent npm package `@grafana/sigil-opencode`. Does *not* use the shared binary. |
-| `plugins/pi/` | Independent npm package `@grafana/sigil-pi`. Does *not* use the shared binary, but `sigil pi` will install it. |
+| `plugins/opencode/` | Independent npm package `@grafana/sigil-opencode`. Runs in-process inside opencode through its TypeScript plugin API; `sigil opencode` installs and launches it. |
+| `plugins/pi/` | Independent npm package `@grafana/sigil-pi`. Runs in-process inside pi; `sigil pi` installs and launches it. |
 
-If you change shared-binary behavior, the four glue plugins all see it. If you change OpenCode or Pi, nothing else moves.
+If you change shared-binary behavior, the four glue plugins all see it. The OpenCode and pi plugins evolve independently, but the shared binary owns their install/launch flow.
 
 ## Cross-language conventions
 

--- a/llms.txt
+++ b/llms.txt
@@ -49,10 +49,10 @@ The user wants Grafana AI observability to capture sessions from their coding ag
 | [Codex](https://developers.openai.com/codex) | [`plugins/codex/`](https://github.com/grafana/sigil-sdk/tree/main/plugins/codex) | Shared `sigil` Go binary via hooks |
 | [Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) | [`plugins/copilot/`](https://github.com/grafana/sigil-sdk/tree/main/plugins/copilot) | Shared `sigil` Go binary via hooks |
 | [Cursor](https://cursor.com) | [`plugins/cursor/`](https://github.com/grafana/sigil-sdk/tree/main/plugins/cursor) | Shared `sigil` Go binary via hooks |
-| [OpenCode](https://opencode.ai) | [`plugins/opencode/`](https://github.com/grafana/sigil-sdk/tree/main/plugins/opencode) | Independent npm package `@grafana/sigil-opencode` |
+| [OpenCode](https://opencode.ai) | [`plugins/opencode/`](https://github.com/grafana/sigil-sdk/tree/main/plugins/opencode) | Shared `sigil` Go binary, installs `@grafana/sigil-opencode` |
 | [Pi](https://github.com/badlogic/pi) | [`plugins/pi/`](https://github.com/grafana/sigil-sdk/tree/main/plugins/pi) | Independent npm package `@grafana/sigil-pi` |
 
-## Fast path (Claude Code, Codex, Copilot, Cursor, Pi)
+## Fast path (Claude Code, Codex, Copilot, Cursor, OpenCode, Pi)
 
 ```sh
 brew install grafana/grafana/sigil
@@ -60,6 +60,7 @@ sigil claude     # Claude Code
 sigil codex      # Codex
 sigil copilot    # Copilot CLI
 sigil cursor     # Cursor
+sigil opencode   # OpenCode
 sigil pi         # Pi
 ```
 
@@ -76,29 +77,9 @@ SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT=<otlp-gateway-url>
 
 To re-enter credentials later, run `sigil login`.
 
-## OpenCode
-
-OpenCode does not use the shared `sigil` binary. It reads its own config file `~/.config/opencode/opencode-sigil.json`:
-
-```json
-{
-  "enabled": true,
-  "endpoint": "<your-sigil-api-url>",
-  "auth": { "mode": "basic", "tenantId": "<your-instance-id>", "token": "glc_..." },
-  "agentName": "opencode",
-  "contentCapture": true
-}
-```
-
-Auth modes: `none` | `bearer` ({ bearerToken }) | `tenant` ({ tenantId }) | `basic` ({ tenantId, token }).
-
 ## Content capture
 
-By default plugins send metadata only (model, tokens, tool names, timing, cost). To send prompt and response bodies as well, set the content capture mode in the plugin config. Valid values across SDKs: `full`, `no_tool_content`, `metadata_only` (default), `full_with_metadata_spans`.
-
-- Shared `sigil` binary: set `SIGIL_CONTENT_CAPTURE_MODE=full` (or one of the other values above) in `config.env`.
-- OpenCode: `"contentCapture": true` (shortcut for `full`).
-- Pi: `contentCapture: "full" | "no_tool_content" | "metadata_only" | "full_with_metadata_spans"`.
+By default plugins send metadata only (model, tokens, tool names, timing, cost). To send prompt and response bodies as well, set `SIGIL_CONTENT_CAPTURE_MODE` in `~/.config/sigil/config.env`. Valid values across SDKs: `full`, `no_tool_content`, `metadata_only` (default), `full_with_metadata_spans`.
 
 Secrets are auto-redacted before send. Treat content capture as opt-in for shared/production machines.
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -4,13 +4,14 @@ Send conversations from your coding agent to [Grafana AI Observability](https://
 
 > AI Observability is in [public preview](https://grafana.com/docs/release-life-cycle/).
 
-## Fastest start (Claude Code, Codex, Copilot, or pi)
+## Fastest start (Claude Code, Codex, Copilot, OpenCode, or pi)
 
 ```sh
 brew install grafana/grafana/sigil
 sigil claude     # for Claude Code
 sigil codex      # for Codex
 sigil copilot    # for Copilot CLI
+sigil opencode   # for OpenCode
 sigil pi         # for pi
 ```
 
@@ -27,4 +28,4 @@ Use the `sigil <agent>` launcher for setup and daily use. On first run it instal
 | [OpenCode](https://opencode.ai) | [`opencode/`](opencode/) | Available |
 | [Pi](https://github.com/badlogic/pi) | [`pi/`](pi/) | Available |
 
-Plugins backed by the `sigil` launcher share one config file at `~/.config/sigil/config.env`. The launcher creates or updates it on first run; `sigil login` re-runs the same prompt later. Cursor has no launcher, so register its plugin in-app and run `sigil login` once for the shared config. OpenCode uses its own JSON config.
+Plugins backed by the `sigil` launcher share one config file at `~/.config/sigil/config.env`. The launcher creates or updates it on first run; `sigil login` re-runs the same prompt later. Cursor has no launcher, so register its plugin in-app and run `sigil login` once for the shared config.

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -8,10 +8,12 @@ By default only metadata is sent (token counts, cost, model, tool names, duratio
 
 ```sh
 brew install grafana/grafana/sigil
-opencode plugin install @grafana/sigil-opencode
+sigil opencode
 ```
 
-The `sigil` CLI is used to prompt for credentials (`sigil login`) and writes them to `~/.config/sigil/config.env`. The OpenCode plugin reads that same file on every session start.
+`sigil opencode` installs `@grafana/sigil-opencode` into OpenCode on first run, prompts for credentials when they're missing, writes them to `~/.config/sigil/config.env`, and then launches OpenCode. Pass arguments to OpenCode after `--`, e.g. `sigil opencode -- run "say hi"`.
+
+To install the plugin manually, run `opencode plugin @grafana/sigil-opencode --global` and then `sigil login` to populate `~/.config/sigil/config.env`. The plugin reads that file on every session start.
 
 ## 2. Credentials
 

--- a/plugins/sigil/README.md
+++ b/plugins/sigil/README.md
@@ -1,6 +1,6 @@
 # sigil
 
-The hook binary behind the [Claude Code](../claude-code), [Codex](../codex), [Copilot](../copilot), and [Cursor](../cursor) plugins for [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/).
+The launcher binary behind the [Claude Code](../claude-code), [Codex](../codex), [Copilot](../copilot), [Cursor](../cursor), [OpenCode](../opencode), and [pi](../pi) plugins for [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/).
 
 ## Install
 
@@ -10,7 +10,7 @@ brew install grafana/grafana/sigil
 
 ## Configure
 
-All four hosts read the same config file at `~/.config/sigil/config.env`. The first run of `sigil claude` or `sigil pi` prompts for your endpoint, tenant ID, token, and OTLP endpoint and writes them there; run `sigil login` to re-enter them later.
+All hosts read the same config file at `~/.config/sigil/config.env`. The first run of `sigil claude`, `sigil opencode`, or `sigil pi` prompts for your endpoint, tenant ID, token, and OTLP endpoint and writes them there; run `sigil login` to re-enter them later.
 
 To preconfigure without the prompt, create the file:
 
@@ -29,11 +29,12 @@ Then follow your agent's quickstart:
 - [Codex](../codex/README.md)
 - [Copilot](../copilot/README.md)
 - [Cursor](../cursor/README.md)
-- [pi](../pi/README.md) (separate JS plugin)
+- [OpenCode](../opencode/README.md)
+- [pi](../pi/README.md)
 
 ## Auto-update
 
-`sigil claude`, `sigil codex`, and `sigil copilot` refresh the installed host plugin automatically. Set `SIGIL_AUTO_UPDATE=false` to opt out.
+`sigil claude`, `sigil codex`, `sigil copilot`, and `sigil opencode` refresh the installed host plugin automatically. Set `SIGIL_AUTO_UPDATE=false` to opt out.
 
 ## Troubleshooting
 

--- a/plugins/sigil/cmd/sigil/main.go
+++ b/plugins/sigil/cmd/sigil/main.go
@@ -1,20 +1,21 @@
 // Command sigil is the single binary used by the Claude Code, Codex,
-// Copilot, Cursor, and pi agent plugins. It accepts:
+// Copilot, Cursor, OpenCode, and pi agent plugins. It accepts:
 //
-//	sigil <agent> hook                    — dispatch a JSON hook payload on stdin to <agent>
-//	sigil claude  [--local] [-- args...]  — exec claude after bootstrapping the sigil-cc plugin
-//	sigil codex   [--local] [-- args...]  — exec codex after bootstrapping the sigil-codex plugin
-//	sigil copilot [--local] [-- args...]  — exec copilot after bootstrapping the sigil-copilot plugin
-//	sigil pi      [--local] [-- args...]  — exec pi after bootstrapping the @grafana/sigil-pi extension
-//	sigil local start|status|stop         — manage the local capture daemon
-//	sigil --version                       — print the build version
+//	sigil <agent> hook                     — dispatch a JSON hook payload on stdin to <agent>
+//	sigil claude   [--local] [-- args...]  — exec claude after bootstrapping the sigil-cc plugin
+//	sigil codex    [--local] [-- args...]  — exec codex after bootstrapping the sigil-codex plugin
+//	sigil copilot  [--local] [-- args...]  — exec copilot after bootstrapping the sigil-copilot plugin
+//	sigil opencode [--local] [-- args...]  — exec opencode after bootstrapping the @grafana/sigil-opencode plugin
+//	sigil pi       [--local] [-- args...]  — exec pi after bootstrapping the @grafana/sigil-pi extension
+//	sigil local start|status|stop          — manage the local capture daemon
+//	sigil --version                        — print the build version
 //
 // Unknown agents and unknown verbs exit with code 2 and a usage message on
 // stderr. For hook agents the binary must never crash the calling agent
 // process; once argv parsing succeeds, all errors are swallowed (and logged
 // when SIGIL_DEBUG=true) and the process exits 0. Launcher agents (`claude`,
-// `codex`, `copilot`, and `pi`) are invoked by a human, so errors surface on
-// stderr with a non-zero exit code.
+// `codex`, `copilot`, `opencode`, and `pi`) are invoked by a human, so
+// errors surface on stderr with a non-zero exit code.
 package main
 
 import (
@@ -35,6 +36,7 @@ import (
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/codex"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/copilot"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/cursor"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/opencode"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/pi"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/cli"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/dotenv"
@@ -68,7 +70,7 @@ func renderLocalBanner(uiURL string) string {
 	return localBannerBox.Render(strings.Join(lines, "\n"))
 }
 
-const usageLine = "usage: sigil login | sigil local start|status|stop | sigil <agent> hook | sigil claude [--local] [-- args...] | sigil codex [--local] [-- args...] | sigil copilot [--local] [-- args...] | sigil pi [--local] [-- args...]"
+const usageLine = "usage: sigil login | sigil local start|status|stop | sigil <agent> hook | sigil claude [--local] [-- args...] | sigil codex [--local] [-- args...] | sigil copilot [--local] [-- args...] | sigil opencode [--local] [-- args...] | sigil pi [--local] [-- args...]"
 
 // version is overridden via -ldflags at build time.
 var version = "dev"
@@ -99,10 +101,11 @@ var agents = map[string]agentHook{
 // process with the target CLI. The launcher name is the target CLI's own
 // name (`claude`, `pi`), not the hook agent name (`claude-code`).
 var launchers = map[string]agentLauncher{
-	"claude":  claudecode.Launch,
-	"codex":   codex.Launch,
-	"copilot": copilot.Launch,
-	"pi":      pi.Launch,
+	"claude":   claudecode.Launch,
+	"codex":    codex.Launch,
+	"copilot":  copilot.Launch,
+	"opencode": opencode.Launch,
+	"pi":       pi.Launch,
 }
 
 // exit is a package var so tests can intercept termination.

--- a/plugins/sigil/cmd/sigil/main_test.go
+++ b/plugins/sigil/cmd/sigil/main_test.go
@@ -216,6 +216,13 @@ func TestRun_LauncherDispatch(t *testing.T) {
 		{name: "claude missing separator exits 2", agent: "claude", argv: []string{"foo"}, wantExit: exitPtr(2), wantStderrContains: "use `sigil claude -- <args>`"},
 		{name: "claude unknown options before separator exits 2", agent: "claude", argv: []string{"--foo", "--", "args"}, wantExit: exitPtr(2), wantStderrContains: "unknown options before `--`: [--foo]"},
 		{name: "claude launcher error exits 1", agent: "claude", argv: []string{"--"}, launcherErr: boom, wantCalled: 1, wantExit: exitPtr(1), wantStderrPrefix: "sigil:"},
+
+		{name: "opencode bare", agent: "opencode", wantCalled: 1},
+		{name: "opencode separator only", agent: "opencode", argv: []string{"--"}, wantCalled: 1},
+		{name: "opencode forwards args after separator", agent: "opencode", argv: []string{"--", "run", "say hi"}, wantCalled: 1, wantArgs: []string{"run", "say hi"}},
+		{name: "opencode missing separator exits 2", agent: "opencode", argv: []string{"run", "hi"}, wantExit: exitPtr(2), wantStderrContains: "use `sigil opencode -- <args>`"},
+		{name: "opencode unknown options before separator exits 2", agent: "opencode", argv: []string{"--debug", "--", "x"}, wantExit: exitPtr(2), wantStderrContains: "unknown options before `--`: [--debug]"},
+		{name: "opencode launcher error exits 1", agent: "opencode", argv: []string{"--"}, launcherErr: boom, wantCalled: 1, wantExit: exitPtr(1), wantStderrPrefix: "sigil:"},
 	}
 
 	for _, tc := range cases {
@@ -670,6 +677,7 @@ func TestRun_LauncherLocalFlagInjectsOpts(t *testing.T) {
 		{name: "claude"},
 		{name: "codex"},
 		{name: "copilot"},
+		{name: "opencode"},
 		{name: "pi"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -766,7 +774,7 @@ func TestRun_LocalLaunchersShareReceiver(t *testing.T) {
 
 	envs := map[string]*local.LaunchEnv{}
 	stubs := map[string]agentLauncher{}
-	for _, name := range []string{"claude", "codex", "copilot", "pi"} {
+	for _, name := range []string{"claude", "codex", "copilot", "opencode", "pi"} {
 		stubs[name] = func(_ context.Context, _ []string, env *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger, _ string) error {
 			envs[name] = env
 			return nil
@@ -775,7 +783,7 @@ func TestRun_LocalLaunchersShareReceiver(t *testing.T) {
 	withStubLaunchers(t, stubs)
 
 	var stdout, stderr bytes.Buffer
-	for _, name := range []string{"pi", "claude", "codex", "copilot"} {
+	for _, name := range []string{"pi", "claude", "codex", "copilot", "opencode"} {
 		stdout.Reset()
 		stderr.Reset()
 		gotExit := withExit(t, func() {
@@ -784,9 +792,9 @@ func TestRun_LocalLaunchersShareReceiver(t *testing.T) {
 		require.Nil(t, gotExit, "launcher=%s stderr=%q", name, stderr.String())
 	}
 
-	require.Len(t, envs, 4)
+	require.Len(t, envs, 5)
 	endpoint := envs["pi"].Endpoint
-	for _, name := range []string{"claude", "codex", "copilot", "pi"} {
+	for _, name := range []string{"claude", "codex", "copilot", "opencode", "pi"} {
 		require.NotNil(t, envs[name], name)
 		assert.Equal(t, endpoint, envs[name].Endpoint, name)
 	}

--- a/plugins/sigil/go.mod
+++ b/plugins/sigil/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/grafana/sigil-sdk/go v0.6.1-0.20260521105622-b9817f5fe521
 	github.com/stretchr/testify v1.11.1
+	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
@@ -15,7 +16,9 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	go.opentelemetry.io/proto/otlp v1.10.0
 	golang.org/x/term v0.43.0
+	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -50,7 +53,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
@@ -58,6 +60,5 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/grpc v1.80.0 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/plugins/sigil/go.sum
+++ b/plugins/sigil/go.sum
@@ -92,6 +92,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd h1:Rf9uhF1+VJ7ZHqxrG8pJ6YacmHvVCmByDmGbAWCc/gA=
+github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd/go.mod h1:EbW0wDK/qEUYI0A5bqq0C2kF8JTQwWONmGDBbzsxxHo=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/plugins/sigil/internal/agents/opencode/launch.go
+++ b/plugins/sigil/internal/agents/opencode/launch.go
@@ -1,0 +1,225 @@
+// Package opencode implements the opencode launcher adapter for the
+// consolidated sigil binary. The dispatcher in cmd/sigil routes
+// `sigil opencode [-- args...]` here.
+//
+// Unlike the hook adapters, this adapter owns the user's terminal: it
+// bootstraps the @grafana/sigil-opencode plugin in opencode's global
+// config on first use, refreshes it periodically, then replaces the
+// current process with the opencode binary via execve so signals, exit
+// codes, and TTY behaviour pass through cleanly. The opencode telemetry
+// plugin itself runs in-process inside opencode through opencode's
+// TypeScript plugin API; the launcher only handles install/refresh and
+// shared env injection.
+package opencode
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/local"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/updatecheck"
+)
+
+const (
+	// PluginSource is the npm spec passed to `opencode plugin <pkg>`.
+	PluginSource = "@grafana/sigil-opencode"
+	// PluginName is the package.json `name` of the plugin. Used to detect
+	// versioned npm specs (e.g. `@grafana/sigil-opencode@0.6.0`) and to
+	// stamp update-check state.
+	PluginName = "@grafana/sigil-opencode"
+
+	updateCheckTTL = 24 * time.Hour
+)
+
+// Test seams.
+var (
+	lookPath     = exec.LookPath
+	execFn       = syscall.Exec
+	runInstall   = defaultRunInstall
+	runUpdate    = defaultRunUpdate
+	configPathFn = defaultConfigPath
+)
+
+// Launch resolves the `opencode` binary on PATH, ensures the
+// @grafana/sigil-opencode plugin is registered in opencode's global
+// config (running `opencode plugin @grafana/sigil-opencode --global`
+// once if it is not), and then exec's opencode with the supplied args.
+// When localEnv is non-nil, the child receives local-mode SIGIL_ENDPOINT,
+// SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT and placeholder auth values so it
+// talks to the in-process receiver instead of Sigil Cloud.
+func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, sigilVersion string) error {
+	bin, err := lookPath("opencode")
+	if err != nil {
+		return fmt.Errorf("opencode CLI not found on PATH: %w", err)
+	}
+
+	installed, err := pluginInstalled()
+	if err != nil {
+		// Surface the probe failure so the user can see why we're falling
+		// through to install on a config file we couldn't read. Treat the
+		// case like a missing plugin — opencode's installer will fail loudly
+		// if the file is genuinely broken.
+		logger.Printf("opencode config probe: %v", err)
+		_, _ = fmt.Fprintf(stderr, "sigil: opencode config probe failed: %v\n", err)
+		installed = false
+	}
+	if !installed {
+		_, _ = fmt.Fprintf(stderr, "sigil: installing %s into opencode\n", PluginSource)
+		if err := runInstall(ctx, bin, stderr); err != nil {
+			// Don't block the user's opencode session on a failed install
+			// (offline machine, npm rate-limit, sandboxed CI, etc.). Log
+			// for SIGIL_DEBUG, point the user at the manual command, and
+			// fall through to exec. opencode still runs, just without
+			// Sigil capture.
+			logger.Printf("install %s: %v", PluginSource, err)
+			_, _ = fmt.Fprintf(stderr,
+				"sigil: install of %s failed: %v\n"+
+					"sigil: continuing without Sigil capture. To retry manually:\n"+
+					"          opencode plugin %s --global\n",
+				PluginSource, err, PluginSource)
+		}
+	} else if updatecheck.ShouldRun(PluginName, updateCheckTTL, sigilVersion) {
+		_, _ = fmt.Fprintf(stderr, "sigil: refreshing %s in opencode\n", PluginSource)
+		if err := runUpdate(ctx, bin, stderr); err != nil {
+			logger.Printf("update %s: %v", PluginSource, err)
+			_, _ = fmt.Fprintf(stderr,
+				"sigil: update of %s failed: %v\n"+
+					"sigil: continuing with the installed version. To retry manually:\n"+
+					"          opencode plugin %s --global --force\n",
+				PluginSource, err, PluginSource)
+		}
+		updatecheck.Record(PluginName, sigilVersion)
+	}
+
+	env := local.Environ(localEnv)
+	argv := append([]string{bin}, args...)
+	if err := execFn(bin, argv, env); err != nil {
+		return fmt.Errorf("exec opencode: %w", err)
+	}
+	return nil
+}
+
+func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {
+	cmd := exec.CommandContext(ctx, bin, "plugin", PluginSource, "--global")
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("opencode plugin %s --global: %w", PluginSource, err)
+	}
+	return nil
+}
+
+func defaultRunUpdate(ctx context.Context, bin string, w io.Writer) error {
+	cmd := exec.CommandContext(ctx, bin, "plugin", PluginSource, "--global", "--force")
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("opencode plugin %s --global --force: %w", PluginSource, err)
+	}
+	return nil
+}
+
+// opencodeConfig is the subset of opencode's global config this launcher
+// inspects. The vendored @opencode-ai/plugin types declare
+// `plugin?: Array<string | [string, PluginOptions]>` — strings name the
+// plugin module, two-element arrays carry plugin-specific options.
+type opencodeConfig struct {
+	Plugin []json.RawMessage `json:"plugin"`
+}
+
+// pluginInstalled reports whether the @grafana/sigil-opencode plugin is
+// already registered in opencode's global config. The config lives at
+// $XDG_CONFIG_HOME/opencode/opencode.json (default
+// $HOME/.config/opencode/opencode.json). A missing file means opencode
+// has never been configured with any plugins — treat as not installed.
+func pluginInstalled() (bool, error) {
+	path, err := configPathFn()
+	if err != nil {
+		return false, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+	var c opencodeConfig
+	if err := json.Unmarshal(data, &c); err != nil {
+		return false, fmt.Errorf("parse %s: %w", path, err)
+	}
+	for _, raw := range c.Plugin {
+		var asString string
+		if err := json.Unmarshal(raw, &asString); err == nil {
+			if sourceMatchesPlugin(asString) {
+				return true, nil
+			}
+			continue
+		}
+		// Tuple form: ["@grafana/sigil-opencode", {...}]
+		var asTuple []json.RawMessage
+		if err := json.Unmarshal(raw, &asTuple); err != nil {
+			continue
+		}
+		if len(asTuple) == 0 {
+			continue
+		}
+		var name string
+		if err := json.Unmarshal(asTuple[0], &name); err != nil {
+			continue
+		}
+		if sourceMatchesPlugin(name) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// sourceMatchesPlugin returns true when a plugin entry identifies the
+// @grafana/sigil-opencode package, accounting for optional `@<version>`
+// suffixes (e.g. `@grafana/sigil-opencode@0.6.0`,
+// `@grafana/sigil-opencode@next`).
+func sourceMatchesPlugin(source string) bool {
+	if source == "" {
+		return false
+	}
+	return stripNpmVersion(source) == PluginName
+}
+
+// stripNpmVersion returns the package name portion of an npm spec,
+// stripping the trailing `@<version>` segment if present. Scoped
+// packages start with `@scope/...`; the leading `@` (index 0) is part of
+// the name, not a version separator, so we look for the LAST `@` after
+// index 0.
+func stripNpmVersion(spec string) string {
+	at := strings.LastIndex(spec, "@")
+	if at <= 0 {
+		return spec
+	}
+	return spec[:at]
+}
+
+// defaultConfigPath returns the path to opencode's global config file,
+// honouring $XDG_CONFIG_HOME (default $HOME/.config). Errors resolving
+// the user's home directory are surfaced so callers don't probe a path
+// silently rooted at CWD.
+func defaultConfigPath() (string, error) {
+	if dir := os.Getenv("XDG_CONFIG_HOME"); filepath.IsAbs(dir) {
+		return filepath.Join(dir, "opencode", "opencode.json"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir for opencode config: %w", err)
+	}
+	return filepath.Join(home, ".config", "opencode", "opencode.json"), nil
+}

--- a/plugins/sigil/internal/agents/opencode/launch.go
+++ b/plugins/sigil/internal/agents/opencode/launch.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/local"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/updatecheck"
+	"github.com/tailscale/hujson"
 )
 
 const (
@@ -43,12 +44,17 @@ const (
 
 // Test seams.
 var (
-	lookPath     = exec.LookPath
-	execFn       = syscall.Exec
-	runInstall   = defaultRunInstall
-	runUpdate    = defaultRunUpdate
-	configPathFn = defaultConfigPath
+	lookPath    = exec.LookPath
+	execFn      = syscall.Exec
+	runInstall  = defaultRunInstall
+	runUpdate   = defaultRunUpdate
+	configDirFn = defaultConfigDir
 )
+
+// configFileNames lists the basenames opencode recognises for its
+// global config, in precedence order. The docs advertise both .json
+// and .jsonc; users may pick either, so we probe both.
+var configFileNames = []string{"opencode.json", "opencode.jsonc"}
 
 // Launch resolves the `opencode` binary on PATH, ensures the
 // @grafana/sigil-opencode plugin is registered in opencode's global
@@ -138,24 +144,46 @@ type opencodeConfig struct {
 }
 
 // pluginInstalled reports whether the @grafana/sigil-opencode plugin is
-// already registered in opencode's global config. The config lives at
-// $XDG_CONFIG_HOME/opencode/opencode.json (default
-// $HOME/.config/opencode/opencode.json). A missing file means opencode
-// has never been configured with any plugins — treat as not installed.
+// already registered in opencode's global config. The config lives in
+// $XDG_CONFIG_HOME/opencode (default $HOME/.config/opencode) as either
+// opencode.json or opencode.jsonc. A missing file means opencode has
+// never been configured with any plugins — treat as not installed.
+//
+// The file contents are parsed as JSONC: opencode's docs explicitly
+// support comments and trailing commas (the very first config example
+// in the docs has a trailing comma), so a strict json.Unmarshal would
+// reject perfectly valid configs and trap us in a reinstall loop.
 func pluginInstalled() (bool, error) {
-	path, err := configPathFn()
+	dir, err := configDirFn()
 	if err != nil {
 		return false, err
 	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return false, nil
+	var (
+		data []byte
+		path string
+	)
+	for _, name := range configFileNames {
+		candidate := filepath.Join(dir, name)
+		b, err := os.ReadFile(candidate)
+		if err == nil {
+			data = b
+			path = candidate
+			break
 		}
-		return false, fmt.Errorf("read %s: %w", path, err)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		return false, fmt.Errorf("read %s: %w", candidate, err)
+	}
+	if data == nil {
+		return false, nil
+	}
+	std, err := hujson.Standardize(data)
+	if err != nil {
+		return false, fmt.Errorf("parse %s: %w", path, err)
 	}
 	var c opencodeConfig
-	if err := json.Unmarshal(data, &c); err != nil {
+	if err := json.Unmarshal(std, &c); err != nil {
 		return false, fmt.Errorf("parse %s: %w", path, err)
 	}
 	for _, raw := range c.Plugin {
@@ -209,17 +237,17 @@ func stripNpmVersion(spec string) string {
 	return spec[:at]
 }
 
-// defaultConfigPath returns the path to opencode's global config file,
-// honouring $XDG_CONFIG_HOME (default $HOME/.config). Errors resolving
-// the user's home directory are surfaced so callers don't probe a path
-// silently rooted at CWD.
-func defaultConfigPath() (string, error) {
+// defaultConfigDir returns the directory holding opencode's global
+// config, honouring $XDG_CONFIG_HOME (default $HOME/.config). Errors
+// resolving the user's home directory are surfaced so callers don't
+// probe a path silently rooted at CWD.
+func defaultConfigDir() (string, error) {
 	if dir := os.Getenv("XDG_CONFIG_HOME"); filepath.IsAbs(dir) {
-		return filepath.Join(dir, "opencode", "opencode.json"), nil
+		return filepath.Join(dir, "opencode"), nil
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve home dir for opencode config: %w", err)
 	}
-	return filepath.Join(home, ".config", "opencode", "opencode.json"), nil
+	return filepath.Join(home, ".config", "opencode"), nil
 }

--- a/plugins/sigil/internal/agents/opencode/launch_test.go
+++ b/plugins/sigil/internal/agents/opencode/launch_test.go
@@ -300,6 +300,24 @@ func TestPluginInstalled_PluginEntryShapes(t *testing.T) {
 			contents: `{"plugin":[[]]}`,
 			want:     false,
 		},
+		{
+			name:     "jsonc trailing comma accepted",
+			write:    true,
+			contents: "{\n  \"plugin\": [\n    \"@grafana/sigil-opencode\",\n  ],\n}\n",
+			want:     true,
+		},
+		{
+			name:     "jsonc line comment accepted",
+			write:    true,
+			contents: "// global opencode config\n{\n  \"plugin\": [\"@grafana/sigil-opencode\"] // sigil capture\n}\n",
+			want:     true,
+		},
+		{
+			name:     "jsonc block comment accepted",
+			write:    true,
+			contents: "{\n  /* installed by sigil */\n  \"plugin\": [\"@grafana/sigil-opencode\"]\n}\n",
+			want:     true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -317,6 +335,27 @@ func TestPluginInstalled_PluginEntryShapes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPluginInstalled_JsoncFilename(t *testing.T) {
+	withConfigFiles(t, map[string]string{
+		"opencode.jsonc": "{\n  // sigil\n  \"plugin\": [\"@grafana/sigil-opencode\"],\n}\n",
+	})
+	got, err := pluginInstalled()
+	require.NoError(t, err)
+	assert.True(t, got, "plugin in opencode.jsonc must be detected")
+}
+
+func TestPluginInstalled_JsonTakesPrecedenceOverJsonc(t *testing.T) {
+	// When both files exist, opencode.json wins. Verify we don't fall
+	// through to opencode.jsonc and report a stale answer.
+	withConfigFiles(t, map[string]string{
+		"opencode.json":  `{"plugin":["other-plugin"]}`,
+		"opencode.jsonc": `{"plugin":["@grafana/sigil-opencode"]}`,
+	})
+	got, err := pluginInstalled()
+	require.NoError(t, err)
+	assert.False(t, got, "opencode.json should take precedence")
 }
 
 func TestLaunch_RefreshesInstalledPluginWhenUpdateDue(t *testing.T) {
@@ -376,34 +415,44 @@ func TestLaunch_SkipsRefreshWhenUpdateDisabled(t *testing.T) {
 	require.NoError(t, Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger(), "dev"))
 }
 
-func TestDefaultConfigPath(t *testing.T) {
+func TestDefaultConfigDir(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "/custom/config")
-	got, err := defaultConfigPath()
+	got, err := defaultConfigDir()
 	require.NoError(t, err)
-	assert.Equal(t, "/custom/config/opencode/opencode.json", got)
+	assert.Equal(t, "/custom/config/opencode", got)
 
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("HOME", "/home/user")
-	got, err = defaultConfigPath()
+	got, err = defaultConfigDir()
 	require.NoError(t, err)
-	assert.Equal(t, "/home/user/.config/opencode/opencode.json", got)
+	assert.Equal(t, "/home/user/.config/opencode", got)
 }
 
-// withConfig points configPathFn at a temp file (creating it with the
-// given contents, or leaving it absent when contents == "") for the
-// duration of one test.
+// withConfig points configDirFn at a temp directory, optionally
+// seeding it with an opencode.json containing the given contents.
+// Pass "" to leave the directory empty.
 func withConfig(t *testing.T, contents string) {
 	t.Helper()
-	dir := t.TempDir()
-	path := filepath.Join(dir, "opencode.json")
+	files := map[string]string{}
 	if contents != "" {
-		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
-			t.Fatalf("write opencode config: %v", err)
+		files["opencode.json"] = contents
+	}
+	withConfigFiles(t, files)
+}
+
+// withConfigFiles points configDirFn at a temp directory and writes the
+// supplied {basename: contents} files into it.
+func withConfigFiles(t *testing.T, files map[string]string) {
+	t.Helper()
+	dir := t.TempDir()
+	for name, contents := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
 		}
 	}
-	prev := configPathFn
-	t.Cleanup(func() { configPathFn = prev })
-	configPathFn = func() (string, error) { return path, nil }
+	prev := configDirFn
+	t.Cleanup(func() { configDirFn = prev })
+	configDirFn = func() (string, error) { return dir, nil }
 }
 
 func withLookPath(t *testing.T, fn func(string) (string, error)) {

--- a/plugins/sigil/internal/agents/opencode/launch_test.go
+++ b/plugins/sigil/internal/agents/opencode/launch_test.go
@@ -1,0 +1,450 @@
+package opencode
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/local"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLaunch(t *testing.T) {
+	const binPath = "/usr/local/bin/opencode"
+	configWithPlugin := `{"plugin":["@grafana/sigil-opencode"]}`
+	configWithOther := `{"plugin":["other-plugin"]}`
+	configMissing := "" // empty string = don't write config file
+
+	cases := []struct {
+		name string
+
+		lookPath   func(string) (string, error)
+		configBody string                                         // "" means don't write
+		runInstall func(context.Context, string, io.Writer) error // nil = success
+		execFn     func(string, []string, []string) error         // nil = success
+		args       []string
+
+		wantErr      string   // substring; "" means no error
+		wantInstall  int      // expected runInstall call count
+		wantExec     bool     // whether execFn must be called
+		wantExecArgv []string // nil = don't assert
+		wantStderr   []string // substrings that must appear in stderr
+		wantLog      []string // substrings that must appear in the logger output
+	}{
+		{
+			name:     "missing opencode binary",
+			lookPath: func(string) (string, error) { return "", exec.ErrNotFound },
+			wantErr:  "opencode CLI not found",
+		},
+		{
+			name:         "skips install when plugin installed and forwards args",
+			lookPath:     func(string) (string, error) { return binPath, nil },
+			configBody:   configWithPlugin,
+			args:         []string{"run", "hi"},
+			wantInstall:  0,
+			wantExec:     true,
+			wantExecArgv: []string{binPath, "run", "hi"},
+		},
+		{
+			name:        "runs install when plugin missing",
+			lookPath:    func(string) (string, error) { return binPath, nil },
+			configBody:  configWithOther,
+			wantInstall: 1,
+			wantExec:    true,
+			wantStderr:  []string{"installing " + PluginSource + " into opencode"},
+		},
+		{
+			name:        "runs install when config file missing",
+			lookPath:    func(string) (string, error) { return binPath, nil },
+			configBody:  configMissing,
+			wantInstall: 1,
+			wantExec:    true,
+		},
+		{
+			name:        "continues when install fails",
+			lookPath:    func(string) (string, error) { return binPath, nil },
+			configBody:  configMissing,
+			runInstall:  func(context.Context, string, io.Writer) error { return errors.New("network down") },
+			wantInstall: 1,
+			wantExec:    true,
+			wantStderr: []string{
+				"install of " + PluginSource + " failed",
+				"network down",
+				"opencode plugin " + PluginSource + " --global",
+			},
+		},
+		{
+			name:       "exec failure surfaces error",
+			lookPath:   func(string) (string, error) { return binPath, nil },
+			configBody: configWithPlugin,
+			execFn:     func(string, []string, []string) error { return errors.New("exec boom") },
+			wantExec:   true,
+			wantErr:    "exec opencode",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SIGIL_AUTO_UPDATE", "false")
+			withConfig(t, tc.configBody)
+			withLookPath(t, tc.lookPath)
+
+			installFn := tc.runInstall
+			if installFn == nil {
+				installFn = func(context.Context, string, io.Writer) error { return nil }
+			}
+			installCalls := 0
+			withRunInstall(t, func(ctx context.Context, bin string, w io.Writer) error {
+				installCalls++
+				if bin != binPath {
+					t.Errorf("install bin = %q, want %q", bin, binPath)
+				}
+				return installFn(ctx, bin, w)
+			})
+
+			execMock := tc.execFn
+			if execMock == nil {
+				execMock = func(string, []string, []string) error { return nil }
+			}
+			var execArgv []string
+			execCalled := false
+			withExecFn(t, func(p string, argv []string, env []string) error {
+				execCalled = true
+				execArgv = append([]string{}, argv...)
+				return execMock(p, argv, env)
+			})
+
+			var stderr bytes.Buffer
+			var logbuf bytes.Buffer
+			logger := log.New(&logbuf, "", 0)
+
+			err := Launch(context.Background(), tc.args, nil, strings.NewReader(""), io.Discard, &stderr, logger, "dev")
+
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantInstall, installCalls)
+			assert.Equal(t, tc.wantExec, execCalled)
+			if tc.wantExecArgv != nil {
+				assert.Equal(t, tc.wantExecArgv, execArgv)
+			}
+			for _, want := range tc.wantStderr {
+				assert.Contains(t, stderr.String(), want)
+			}
+			for _, want := range tc.wantLog {
+				assert.Contains(t, logbuf.String(), want)
+			}
+		})
+	}
+}
+
+func TestLaunch_InvalidConfigProbeFallsThroughToInstall(t *testing.T) {
+	t.Setenv("SIGIL_AUTO_UPDATE", "false")
+	withConfig(t, `{"plugin":[`) // truncated JSON
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/opencode", nil })
+
+	installCalls := 0
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		installCalls++
+		return nil
+	})
+	execCalled := false
+	withExecFn(t, func(string, []string, []string) error {
+		execCalled = true
+		return nil
+	})
+
+	var stderr bytes.Buffer
+	var logbuf bytes.Buffer
+	logger := log.New(&logbuf, "", 0)
+	require.NoError(t, Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, logger, "dev"))
+
+	assert.Equal(t, 1, installCalls, "install must run after probe failure")
+	assert.True(t, execCalled, "exec must be called even after probe failure")
+	assert.Contains(t, stderr.String(), "opencode config probe failed")
+	assert.Contains(t, logbuf.String(), "opencode config probe")
+}
+
+func TestLaunch_LocalEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		presetMode string
+		wantMode   string
+	}{
+		{name: "defaults full capture", wantMode: "full"},
+		{name: "preserves user capture mode", presetMode: "metadata_only", wantMode: "metadata_only"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SIGIL_AUTO_UPDATE", "false")
+			t.Setenv("SIGIL_ENDPOINT", "https://cloud.example.com")
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "")
+			t.Setenv("SIGIL_AUTH_TOKEN", "")
+			t.Setenv("SIGIL_CONTENT_CAPTURE_MODE", tc.presetMode)
+
+			withConfig(t, `{"plugin":["@grafana/sigil-opencode"]}`)
+			withLookPath(t, func(string) (string, error) { return "/usr/local/bin/opencode", nil })
+			withRunInstall(t, func(context.Context, string, io.Writer) error {
+				t.Fatal("runInstall must not be called when plugin is installed")
+				return nil
+			})
+
+			var execEnv []string
+			var execArgv []string
+			withExecFn(t, func(_ string, argv []string, env []string) error {
+				execArgv = append([]string{}, argv...)
+				execEnv = append([]string{}, env...)
+				return nil
+			})
+
+			localEnv := &local.LaunchEnv{Endpoint: "http://127.0.0.1:9000", OTLPEndpoint: "http://127.0.0.1:9000/otlp"}
+			err := Launch(context.Background(), []string{"run", "hi"}, localEnv, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev")
+			require.NoError(t, err)
+			assert.Equal(t, []string{"/usr/local/bin/opencode", "run", "hi"}, execArgv)
+			got := envMap(execEnv)
+			assert.Equal(t, "http://127.0.0.1:9000", got["SIGIL_ENDPOINT"])
+			assert.Equal(t, "http://127.0.0.1:9000/otlp", got["SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT"])
+			assert.Equal(t, "local", got["SIGIL_AUTH_TENANT_ID"])
+			assert.Equal(t, "local", got["SIGIL_AUTH_TOKEN"])
+			assert.Equal(t, tc.wantMode, got["SIGIL_CONTENT_CAPTURE_MODE"])
+		})
+	}
+}
+
+func TestPluginInstalled_PluginEntryShapes(t *testing.T) {
+	cases := []struct {
+		name     string
+		write    bool
+		contents string
+		want     bool
+		wantErr  bool
+	}{
+		{
+			name:     "bare package string matches",
+			write:    true,
+			contents: `{"plugin":["@grafana/sigil-opencode"]}`,
+			want:     true,
+		},
+		{
+			name:     "versioned package string matches",
+			write:    true,
+			contents: `{"plugin":["@grafana/sigil-opencode@0.6.0"]}`,
+			want:     true,
+		},
+		{
+			name:     "dist-tag package string matches",
+			write:    true,
+			contents: `{"plugin":["@grafana/sigil-opencode@next"]}`,
+			want:     true,
+		},
+		{
+			name:     "tuple form matches",
+			write:    true,
+			contents: `{"plugin":[["@grafana/sigil-opencode",{"agentName":"opencode"}]]}`,
+			want:     true,
+		},
+		{
+			name:     "tuple form with versioned name matches",
+			write:    true,
+			contents: `{"plugin":[["@grafana/sigil-opencode@0.6.0",{}]]}`,
+			want:     true,
+		},
+		{
+			name:     "prefix collision does not match",
+			write:    true,
+			contents: `{"plugin":["@grafana/sigil-opencode-extra"]}`,
+			want:     false,
+		},
+		{
+			name:     "unrelated package does not match",
+			write:    true,
+			contents: `{"plugin":["other-plugin",["another",{}]]}`,
+			want:     false,
+		},
+		{
+			name:     "empty plugin list",
+			write:    true,
+			contents: `{"plugin":[]}`,
+			want:     false,
+		},
+		{
+			name:     "config without plugin field",
+			write:    true,
+			contents: `{"theme":"dark"}`,
+			want:     false,
+		},
+		{
+			name:  "missing file treated as not installed",
+			write: false,
+			want:  false,
+		},
+		{
+			name:     "malformed json surfaces error",
+			write:    true,
+			contents: `{"plugin":[`,
+			wantErr:  true,
+		},
+		{
+			name:     "tuple with empty array ignored",
+			write:    true,
+			contents: `{"plugin":[[]]}`,
+			want:     false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.write {
+				withConfig(t, tc.contents)
+			} else {
+				withConfig(t, "")
+			}
+			got, err := pluginInstalled()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Fatalf("got = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLaunch_RefreshesInstalledPluginWhenUpdateDue(t *testing.T) {
+	const binPath = "/usr/local/bin/opencode"
+	state := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", state)
+	t.Setenv("SIGIL_AUTO_UPDATE", "")
+
+	withConfig(t, `{"plugin":["@grafana/sigil-opencode"]}`)
+	withLookPath(t, func(string) (string, error) { return binPath, nil })
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		t.Fatal("runInstall must not be called when plugin is already installed")
+		return nil
+	})
+
+	updateCalls := 0
+	withRunUpdate(t, func(_ context.Context, bin string, _ io.Writer) error {
+		updateCalls++
+		if bin != binPath {
+			t.Errorf("update bin = %q", bin)
+		}
+		return nil
+	})
+	withExecFn(t, func(string, []string, []string) error { return nil })
+
+	var stderr bytes.Buffer
+	require.NoError(t, Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger(), "dev"))
+	if updateCalls != 1 {
+		t.Fatalf("runUpdate calls = %d, want 1", updateCalls)
+	}
+	if !strings.Contains(stderr.String(), "refreshing "+PluginSource+" in opencode") {
+		t.Fatalf("stderr missing refresh message: %q", stderr.String())
+	}
+	stamp := filepath.Join(state, "sigil", "update-checks", PluginName+".stamp")
+	if _, err := os.Stat(stamp); err != nil {
+		t.Fatalf("expected update stamp: %v", err)
+	}
+}
+
+func TestLaunch_SkipsRefreshWhenUpdateDisabled(t *testing.T) {
+	const binPath = "/usr/local/bin/opencode"
+	t.Setenv("SIGIL_AUTO_UPDATE", "false")
+
+	withConfig(t, `{"plugin":["@grafana/sigil-opencode"]}`)
+	withLookPath(t, func(string) (string, error) { return binPath, nil })
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		t.Fatal("runInstall must not be called when plugin is already installed")
+		return nil
+	})
+	withRunUpdate(t, func(context.Context, string, io.Writer) error {
+		t.Fatal("runUpdate must not be called when auto-update is disabled")
+		return nil
+	})
+	withExecFn(t, func(string, []string, []string) error { return nil })
+
+	var stderr bytes.Buffer
+	require.NoError(t, Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger(), "dev"))
+}
+
+func TestDefaultConfigPath(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/custom/config")
+	got, err := defaultConfigPath()
+	require.NoError(t, err)
+	assert.Equal(t, "/custom/config/opencode/opencode.json", got)
+
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "/home/user")
+	got, err = defaultConfigPath()
+	require.NoError(t, err)
+	assert.Equal(t, "/home/user/.config/opencode/opencode.json", got)
+}
+
+// withConfig points configPathFn at a temp file (creating it with the
+// given contents, or leaving it absent when contents == "") for the
+// duration of one test.
+func withConfig(t *testing.T, contents string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "opencode.json")
+	if contents != "" {
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatalf("write opencode config: %v", err)
+		}
+	}
+	prev := configPathFn
+	t.Cleanup(func() { configPathFn = prev })
+	configPathFn = func() (string, error) { return path, nil }
+}
+
+func withLookPath(t *testing.T, fn func(string) (string, error)) {
+	t.Helper()
+	prev := lookPath
+	t.Cleanup(func() { lookPath = prev })
+	lookPath = fn
+}
+
+func withRunInstall(t *testing.T, fn func(context.Context, string, io.Writer) error) {
+	t.Helper()
+	prev := runInstall
+	t.Cleanup(func() { runInstall = prev })
+	runInstall = fn
+}
+
+func withRunUpdate(t *testing.T, fn func(context.Context, string, io.Writer) error) {
+	t.Helper()
+	prev := runUpdate
+	t.Cleanup(func() { runUpdate = prev })
+	runUpdate = fn
+}
+
+func withExecFn(t *testing.T, fn func(string, []string, []string) error) {
+	t.Helper()
+	prev := execFn
+	t.Cleanup(func() { execFn = prev })
+	execFn = fn
+}
+
+func envMap(env []string) map[string]string {
+	out := map[string]string{}
+	for _, kv := range env {
+		key, value, ok := strings.Cut(kv, "=")
+		if ok {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func nopLogger() *log.Logger {
+	return log.New(io.Discard, "", 0)
+}


### PR DESCRIPTION
Support launching opencode with `sigil opencode`. The command automatically installs the plugin and asks for credentials on the first run.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing launcher and plugin install only; failures degrade to running OpenCode without capture rather than breaking auth or data paths.
> 
> **Overview**
> Adds **`sigil opencode`** to the shared Go launcher so OpenCode follows the same first-run flow as Claude/Codex/Pi: optional credential prompt, shared `~/.config/sigil/config.env`, `--local` support, and `sigil opencode -- <args>` forwarding.
> 
> The new **`plugins/sigil/internal/agents/opencode`** adapter finds `opencode` on PATH, detects whether `@grafana/sigil-opencode` is already listed in global `opencode.json` / `opencode.jsonc` (JSONC via **hujson**), runs `opencode plugin … --global` on first use and periodic `--force` refresh when auto-update is enabled, then **exec**s OpenCode. Install/update failures are logged and **do not block** launching OpenCode without capture.
> 
> **Docs** (`AGENTS.md`, `llms.txt`, plugin READMEs) are updated to describe OpenCode as launcher-driven (not a separate JSON-only setup path) and to document content capture via `SIGIL_CONTENT_CAPTURE_MODE` in `config.env`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 891de8759ed01c3d9f17dce9130161622b82f74b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->