### PR TITLE
feat(plugins/sigil): use first prompt as conversation title for Claude Code

### DIFF
--- a/plugins/sigil/cmd/sigil/testdata/golden/claude-code-basic/export.golden.json
+++ b/plugins/sigil/cmd/sigil/testdata/golden/claude-code-basic/export.golden.json
@@ -20,7 +20,7 @@
           }
         ],
         "metadata": {
-          "sigil.conversation.title": "cc-sess-1",
+          "sigil.conversation.title": "list go files",
           "sigil.sdk.content_capture_mode": "full",
           "sigil.sdk.name": "sdk-go",
           "sigil.user.id": "test-user"
@@ -86,7 +86,7 @@
           }
         ],
         "metadata": {
-          "sigil.conversation.title": "cc-sess-1",
+          "sigil.conversation.title": "list go files",
           "sigil.sdk.content_capture_mode": "full",
           "sigil.sdk.name": "sdk-go",
           "sigil.user.id": "test-user"

--- a/plugins/sigil/cmd/sigil/testdata/golden/claude-code-subagent/export.golden.json
+++ b/plugins/sigil/cmd/sigil/testdata/golden/claude-code-subagent/export.golden.json
@@ -23,7 +23,7 @@
           }
         ],
         "metadata": {
-          "sigil.conversation.title": "cc-subagent-sess-1",
+          "sigil.conversation.title": "inspect the repository entrypoints",
           "sigil.sdk.content_capture_mode": "full",
           "sigil.sdk.name": "sdk-go",
           "sigil.user.id": "test-user"
@@ -68,7 +68,7 @@
         "effective_version": "\u003cNORMALIZED\u003e",
         "id": "eb85615f-6608-582f-9e24-ab0e555801cb",
         "metadata": {
-          "sigil.conversation.title": "cc-subagent-sess-1",
+          "sigil.conversation.title": "inspect the repository entrypoints",
           "sigil.sdk.content_capture_mode": "full",
           "sigil.sdk.name": "sdk-go",
           "sigil.user.id": "test-user"
@@ -120,7 +120,7 @@
           }
         ],
         "metadata": {
-          "sigil.conversation.title": "cc-subagent-sess-1",
+          "sigil.conversation.title": "inspect the repository entrypoints",
           "sigil.sdk.content_capture_mode": "full",
           "sigil.sdk.name": "sdk-go",
           "sigil.user.id": "test-user"

--- a/plugins/sigil/internal/agents/claudecode/mapper/mapper.go
+++ b/plugins/sigil/internal/agents/claudecode/mapper/mapper.go
@@ -19,6 +19,8 @@ import (
 const (
 	agentName       = "claude-code"
 	maxToolInputLen = 4096
+	// maxTitleLen caps the conversation title derived from the first user prompt.
+	maxTitleLen = 100
 )
 
 // Options controls how transcript lines are mapped to generations.
@@ -185,7 +187,26 @@ func Process(lines []transcript.Line, st *state.Session, opts Options, r *redact
 		}
 	}
 
+	title := conversationTitle(st, opts.SessionID)
+	for i := range gens {
+		gens[i].ConversationTitle = title
+	}
+
 	return gens
+}
+
+// conversationTitle returns a truncated version of the session title derived
+// from the first user prompt. Falls back to the session ID when no title is
+// available (e.g. transcript with no user lines processed yet).
+func conversationTitle(st *state.Session, sessionID string) string {
+	if st == nil || st.Title == "" {
+		return sessionID
+	}
+	t := strings.TrimSpace(st.Title)
+	if len(t) > maxTitleLen {
+		t = t[:maxTitleLen]
+	}
+	return t
 }
 
 // synthesiseSubagentGens creates a generation for each Agent tool result in

--- a/plugins/sigil/internal/agents/claudecode/mapper/mapper.go
+++ b/plugins/sigil/internal/agents/claudecode/mapper/mapper.go
@@ -187,7 +187,7 @@ func Process(lines []transcript.Line, st *state.Session, opts Options, r *redact
 		}
 	}
 
-	title := conversationTitle(st, opts.SessionID)
+	title := conversationTitle(st, opts.SessionID, r)
 	for i := range gens {
 		gens[i].ConversationTitle = title
 	}
@@ -198,13 +198,20 @@ func Process(lines []transcript.Line, st *state.Session, opts Options, r *redact
 // conversationTitle returns a truncated version of the session title derived
 // from the first user prompt. Falls back to the session ID when no title is
 // available (e.g. transcript with no user lines processed yet).
-func conversationTitle(st *state.Session, sessionID string) string {
+func conversationTitle(st *state.Session, sessionID string, r *redact.Redactor) string {
 	if st == nil || st.Title == "" {
 		return sessionID
 	}
 	t := strings.TrimSpace(st.Title)
+	if r != nil {
+		t = r.RedactLightweight(t)
+	}
 	if len(t) > maxTitleLen {
 		t = t[:maxTitleLen]
+		// Truncate to valid UTF-8 boundary
+		for !utf8.ValidString(t) {
+			t = t[:len(t)-1]
+		}
 	}
 	return t
 }

--- a/plugins/sigil/internal/agents/claudecode/mapper/mapper.go
+++ b/plugins/sigil/internal/agents/claudecode/mapper/mapper.go
@@ -206,6 +206,9 @@ func conversationTitle(st *state.Session, sessionID string, r *redact.Redactor) 
 	if r != nil {
 		t = r.RedactLightweight(t)
 	}
+	if t == "" {
+		return sessionID
+	}
 	if len(t) > maxTitleLen {
 		t = t[:maxTitleLen]
 		// Truncate to valid UTF-8 boundary

--- a/plugins/sigil/internal/agents/claudecode/mapper/mapper_test.go
+++ b/plugins/sigil/internal/agents/claudecode/mapper/mapper_test.go
@@ -211,11 +211,12 @@ func TestProcess_ContentModes(t *testing.T) {
 
 func TestProcess_ConversationTitle(t *testing.T) {
 	tests := []struct {
-		name       string
-		state      state.Session
-		lines      []transcript.Line
-		wantTitle  string
-		wantGenCnt int
+		name          string
+		state         state.Session
+		lines         []transcript.Line
+		wantTitle     string
+		wantConvTitle string
+		wantGenCnt    int
 	}{
 		{
 			name:  "title from first prompt",
@@ -230,8 +231,9 @@ func TestProcess_ConversationTitle(t *testing.T) {
 					{Type: "text", Text: "done"},
 				}, "end_turn"),
 			},
-			wantTitle:  "fix the auth bug",
-			wantGenCnt: 2,
+			wantTitle:     "fix the auth bug",
+			wantConvTitle: "fix the auth bug",
+			wantGenCnt:    2,
 		},
 		{
 			name:  "preserves existing title",
@@ -242,8 +244,34 @@ func TestProcess_ConversationTitle(t *testing.T) {
 					{Type: "text", Text: "ok"},
 				}, "end_turn"),
 			},
-			wantTitle:  "old title",
-			wantGenCnt: 1,
+			wantTitle:     "old title",
+			wantConvTitle: "old title",
+			wantGenCnt:    1,
+		},
+		{
+			name:  "falls back to session ID without user lines",
+			state: state.Session{},
+			lines: []transcript.Line{
+				makeAssistantLine("claude-sonnet-4-20250514", 10, []transcript.ContentBlock{
+					{Type: "text", Text: "hi"},
+				}, "end_turn"),
+			},
+			wantTitle:     "",
+			wantConvTitle: "sess-1",
+			wantGenCnt:    1,
+		},
+		{
+			name:  "truncates long prompt to 100 chars",
+			state: state.Session{},
+			lines: []transcript.Line{
+				makeUserLine(strings.Repeat("a", 200)),
+				makeAssistantLine("claude-sonnet-4-20250514", 10, []transcript.ContentBlock{
+					{Type: "text", Text: "ok"},
+				}, "end_turn"),
+			},
+			wantTitle:     strings.Repeat("a", 200),
+			wantConvTitle: strings.Repeat("a", 100),
+			wantGenCnt:    1,
 		},
 	}
 
@@ -258,10 +286,9 @@ func TestProcess_ConversationTitle(t *testing.T) {
 			if len(gens) != tt.wantGenCnt {
 				t.Fatalf("got %d generations, want %d", len(gens), tt.wantGenCnt)
 			}
-			// ConversationTitle always equals SessionID
 			for i, gen := range gens {
-				if gen.ConversationTitle != "sess-1" {
-					t.Errorf("gen[%d].ConversationTitle = %q, want sess-1", i, gen.ConversationTitle)
+				if gen.ConversationTitle != tt.wantConvTitle {
+					t.Errorf("gen[%d].ConversationTitle = %q, want %q", i, gen.ConversationTitle, tt.wantConvTitle)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary
- Claude Code does not expose a conversation name, so we derive one from the first user prompt (truncated to 100 characters) — the same approach as the Cursor plugin (#223).
- Previously `ConversationTitle` was set to the raw session ID (e.g. `cc-sess-1`) which is not human-readable.
- The title is already persisted in `state.Title` by `processUserLine` (first prompt wins); this change wires it into `Generation.ConversationTitle` via a post-processing pass at the end of `Process()`. Falls back to the session ID when no user prompt has been seen.

## Test plan
- [x] Unit tests updated and extended with new cases (fallback to session ID, 100-char truncation).
- [x] Golden integration tests updated (`claude-code-basic`, `claude-code-subagent`).
- [x] `go test ./internal/agents/claudecode/...` passes.
- [x] `TestGoldenIntegration` passes.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mapper-only metadata labeling change with tests; no auth, persistence, or export API contract changes beyond display titles.
> 
> **Overview**
> Claude Code exports now use a **human-readable conversation title** instead of the raw session ID in `sigil.conversation.title` on every generation (including subagent rows).
> 
> After mapping transcript lines, `Process()` sets `ConversationTitle` from the session’s first user prompt (`state.Title`), trimmed and lightly redacted, capped at **100 characters** with safe UTF-8 truncation. If no title exists yet, it still falls back to the session ID. Unit and golden export fixtures were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 923b95974d1d3b950df577d868fbaa82c3b24d5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->