### PR TITLE
docs: clarify content capture modes across SDKs and plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Minimal, self-contained examples that make a real LLM call and record the genera
 | TypeScript + Strands | [`examples/getting-started/typescript-strands/`](examples/getting-started/typescript-strands/) |
 | Go | [`examples/getting-started/go/`](examples/getting-started/go/) |
 
+## Content capture and privacy
+
+The SDKs default to `no_tool_content`: full generation messages ship to Sigil, but tool-execution arguments and results stay out of spans. The coding-agent plugins default to `metadata_only`. See [Content Capture Modes](docs/concepts/content-capture-modes.md) for the mode matrix, defaults per surface, and the generation, tool-execution, and embedding resolution rules.
+
 ## Grafana Cloud credentials
 
 All four connection values (API URL, Instance ID, API token, and OTLP endpoint) live on the Connection tab of the AI Observability plugin in your stack:

--- a/docs/concepts/content-capture-modes.md
+++ b/docs/concepts/content-capture-modes.md
@@ -1,0 +1,86 @@
+# Content Capture Modes
+
+Content capture decides which fields the Sigil SDK includes in exported generations and OTel span attributes. Use it to keep prompts, tool I/O, and model responses inside the process when the destination (Grafana stack, OTel collector, shared infrastructure) should not receive them.
+
+Each SDK README links here for language-specific examples.
+
+## Modes
+
+| Mode | Meaning |
+| --- | --- |
+| `default` | Inherit from the next layer in the resolution chain. At the client level this resolves to `no_tool_content`. |
+| `full` | Export all content: generation messages, thinking, system prompts, tool arguments and results, embedding input texts. |
+| `no_tool_content` | Export full generation content but omit tool-execution arguments and results from span attributes. Matches the pre-`ContentCaptureMode` SDK default. |
+| `metadata_only` | Preserve structure (message roles, part kinds, tool names, model, token usage, timing, IDs) and strip text, tool arguments, tool results, thinking, system prompts, conversation titles, raw artifacts, tool descriptions, tool input schemas, and detailed error messages. |
+| `full_with_metadata_spans` | Send full content over the gRPC/HTTP generation ingest, but omit content fields from OTel spans. Useful when ingest is private but traces and metrics are shared. |
+
+`default` is never written into telemetry. It is the placeholder for "inherit"; the SDK resolves it to one of the four concrete modes before exporting anything.
+
+## Behavior matrix
+
+| Mode | Generation export (gRPC/HTTP) | Generation span | Tool execution span | Embedding span |
+| --- | --- | --- | --- | --- |
+| `full` | Full content. | Content attributes included. | Arguments and results included. | Input texts included when `EmbeddingCapture.CaptureInput` is on. |
+| `no_tool_content` | Full content. | Content attributes included. | Arguments and results omitted. | Input texts included when `EmbeddingCapture.CaptureInput` is on. |
+| `metadata_only` | Structure only. Messages, tool args/results, thinking, system prompts, conversation titles, artifacts, error text removed. | Content attributes omitted. | Arguments and results omitted. | Input texts omitted. |
+| `full_with_metadata_spans` | Full content. | Content attributes omitted (`sigil.conversation.title` and related fields). | Arguments and results omitted. Equivalent to `metadata_only` for tool spans because there is no separate gRPC export for tool executions. | Input texts omitted. Equivalent to `metadata_only` for embedding spans for the same reason. |
+
+Embedding input text capture is gated by both the effective capture mode and `EmbeddingCapture.CaptureInput` / `embeddingCapture.captureInput`. Setting the flag does not bypass `metadata_only` or `full_with_metadata_spans`.
+
+## Caveats
+
+No capture mode strips user-provided `metadata` or `tags` on a generation or tool execution. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content. Keep sensitive content out of `metadata` and `tags` when using `metadata_only` or `full_with_metadata_spans`.
+
+Capture modes decide *which fields ship*, not what's inside them. To sanitize the fields that do ship (e.g. strip secrets out of assistant text under `full`), use the pre-ingest redactor: `GenerationSanitizer` in Go, `generationSanitizer` in JS/TS, the equivalent in Python.
+
+`full_with_metadata_spans` only protects spans. Generation content still flows through the SDK's generation export channel. Use `metadata_only` if you also want the ingest channel to receive no content.
+
+## Defaults
+
+The default differs between SDK clients and coding-agent plugins.
+
+| Surface | Default mode |
+| --- | --- |
+| Core SDK client (Go, Python, JS/TS, Java, .NET) | `no_tool_content`. Generation content is captured; tool-execution arguments and results stay out of spans. |
+| Coding-agent plugins (shared `sigil` binary, `@grafana/sigil-pi`, `@grafana/sigil-opencode`) | `metadata_only`. Coding-agent sessions usually run on shared machines, so the plugins ship metadata-only by default. |
+
+`default` at the client level resolves to `no_tool_content`. To get full content on a core SDK client, set `contentCapture: 'full'` (or the language equivalent) explicitly.
+
+## Resolution precedence
+
+The SDK resolves capture mode differently by recording type and language.
+
+Generation starts:
+
+- Go, JS/TS, Java, and .NET: per-generation `ContentCapture` / `contentCapture` > `ContentCaptureResolver` / `contentCaptureResolver` return value > client-level setting.
+- Python: per-generation `content_capture` > `with_content_capture_mode(...)` when set > `content_capture_resolver` return value > client-level setting.
+
+Tool executions:
+
+- Go, Python, Java, and .NET: per-tool `ContentCapture` / `content_capture` > parent generation's resolved mode (or Python's public capture-mode scope) > resolver return value > client-level setting.
+- JS/TS: per-tool `contentCapture` > resolver return value > client-level setting. The JS SDK does not propagate capture mode through async context.
+
+Embeddings:
+
+- All SDKs: resolver return value > client-level setting, then the embedding input-capture flag gates whether input texts can be attached to spans.
+
+A resolver return value of `default` defers to the next layer. Resolver exceptions are caught and treated as `metadata_only` (fail-closed).
+
+## Configuring capture
+
+Per-language READMEs include code examples:
+
+- Go: [`go/README.md`](../../go/README.md)
+- Python: [`python/README.md`](../../python/README.md)
+- JS/TS: [`js/README.md`](../../js/README.md)
+- Java: [`java/README.md`](../../java/README.md)
+- .NET: [`dotnet/README.md`](../../dotnet/README.md)
+
+For coding-agent plugins, the relevant env var is `SIGIL_CONTENT_CAPTURE_MODE`. All plugins (the shared `sigil` binary used by Claude Code, Codex, Copilot, and Cursor; Pi via `@grafana/sigil-pi`; OpenCode via `@grafana/sigil-opencode`) accept `full`, `no_tool_content`, `metadata_only`, and `full_with_metadata_spans`. `default` is accepted as an alias for `metadata_only` so plugins match the Go envconfig resolver rather than the JS SDK's client-level default of `no_tool_content`.
+
+Unknown values fall back to `metadata_only` with a warning in the plugin log. A plugin can still export less than the SDK allows. For example, an adapter may drop a field if the host agent does not pass it through.
+
+## Related
+
+- [Tool Calls vs Tool Executions](./tool-call-vs-tool-execution.md): explains why tool-execution spans have their own content-capture story.
+- SDK `GenerationSanitizer` / `generationSanitizer`: pre-ingest redaction; runs alongside capture modes, not as a replacement.

--- a/docs/concepts/tool-call-vs-tool-execution.md
+++ b/docs/concepts/tool-call-vs-tool-execution.md
@@ -100,13 +100,13 @@ This allows Sigil to correlate the model's request with your execution timing.
 
 ## Capturing Arguments and Results
 
-By default, tool execution spans capture timing but not content. To capture arguments and results, enable content capture:
+By default, tool execution spans capture timing but not content. The core SDK client default is `NO_TOOL_CONTENT`, which keeps generation content but excludes tool arguments and results from spans. To include them, raise the mode to `FULL` for the tool execution:
 
 ```java
 try (ToolExecutionRecorder rec = client.startToolExecution(
         new ToolExecutionStart()
             .setToolName("document_retriever")
-            .setContentCapture(ContentCaptureMode.FULL_CONTENT))) {
+            .setContentCapture(ContentCaptureMode.FULL))) {
     
     rec.setArguments(Map.of("query", searchQuery, "limit", 5));
     List<Document> docs = vectorStore.similaritySearch(searchQuery, 5);
@@ -115,6 +115,8 @@ try (ToolExecutionRecorder rec = client.startToolExecution(
 ```
 
 With content capture enabled, arguments appear as `gen_ai.tool.call.arguments` and results as `gen_ai.tool.call.result` in span attributes.
+
+See [Content Capture Modes](./content-capture-modes.md) for the full mode matrix, defaults, and resolution precedence.
 
 ## Summary
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -193,6 +193,74 @@ TraceQL examples:
 - `traces{gen_ai.operation.name="embeddings" && gen_ai.request.model="text-embedding-3-small"}`
 - `traces{gen_ai.operation.name="embeddings" && error.type!=""}`
 
+## Content capture
+
+`ContentCaptureMode` controls what content the SDK includes in exported generation payloads and OTel span attributes. See [Content Capture Modes](../docs/concepts/content-capture-modes.md) for the canonical mode matrix and defaults; the snippets below show how to wire it up in C#.
+
+Client-level default:
+
+```csharp
+var sigil = new SigilClient(new SigilClientConfig
+{
+    ContentCapture = ContentCaptureMode.MetadataOnly,
+});
+```
+
+The core SDK client treats `ContentCaptureMode.Default` as `ContentCaptureMode.NoToolContent`: generation content is captured but tool-execution arguments and results stay out of spans.
+
+Per-generation override:
+
+```csharp
+var recorder = client.StartGeneration(new GenerationStart
+{
+    Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+    ContentCapture = ContentCaptureMode.Full,
+});
+```
+
+Per-tool-execution override (here `Full` opts into capturing tool arguments and results in the span):
+
+```csharp
+var tool = client.StartToolExecution(new ToolExecutionStart
+{
+    ToolName = "search",
+    ContentCapture = ContentCaptureMode.Full,
+});
+```
+
+Dynamic resolution via `ContentCaptureResolver`:
+
+```csharp
+var sigil = new SigilClient(new SigilClientConfig
+{
+    ContentCaptureResolver = metadata =>
+    {
+        if (metadata != null && metadata.TryGetValue("sigil.tenant", out var tenant) && (string?)tenant == "healthcare")
+        {
+            return ContentCaptureMode.MetadataOnly;
+        }
+        return ContentCaptureMode.Default; // defer to ContentCapture
+    },
+});
+```
+
+Exception-throwing resolvers are caught and treated as `ContentCaptureMode.MetadataOnly` (fail-closed).
+
+Resolution precedence for generations (highest to lowest):
+
+1. Per-generation `GenerationStart.ContentCapture`
+2. `SigilClientConfig.ContentCaptureResolver` return value
+3. `SigilClientConfig.ContentCapture` (defaults to `ContentCaptureMode.NoToolContent`)
+
+Resolution precedence for tool executions (highest to lowest):
+
+1. Per-tool `ToolExecutionStart.ContentCapture`
+2. Parent generation's resolved mode
+3. `SigilClientConfig.ContentCaptureResolver` return value
+4. `SigilClientConfig.ContentCapture` (defaults to `ContentCaptureMode.NoToolContent`)
+
+User-provided `Metadata` and `Tags` are not stripped by any capture mode. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content.
+
 ## Context defaults
 
 `SigilContext` uses async-local scopes:

--- a/go/README.md
+++ b/go/README.md
@@ -226,6 +226,72 @@ Common topology:
 - Traces/metrics via OTEL Collector/Alloy: configure exporters in your app OTEL SDK setup.
 - Enterprise proxy: generation `bearer` mode to proxy; proxy authenticates and forwards tenant header upstream.
 
+## Content Capture Mode
+
+`ContentCaptureMode` controls what content the SDK includes in exported generation payloads and OTel span attributes. See [Content Capture Modes](../docs/concepts/content-capture-modes.md) for the canonical mode matrix and defaults; the snippets below show how to wire it up in Go.
+
+Client-level default:
+
+```go
+cfg := sigil.DefaultConfig()
+cfg.ContentCapture = sigil.ContentCaptureModeMetadataOnly
+
+client := sigil.NewClient(cfg)
+defer func() { _ = client.Shutdown(context.Background()) }()
+```
+
+The core SDK client treats `ContentCaptureModeDefault` as `ContentCaptureModeNoToolContent`: generation content is captured but tool-execution arguments and results stay out of spans.
+
+Per-generation override:
+
+```go
+ctx, rec := client.StartGeneration(ctx, sigil.GenerationStart{
+    Model:          sigil.ModelRef{Provider: "openai", Name: "gpt-5"},
+    ContentCapture: sigil.ContentCaptureModeFull,
+})
+defer rec.End()
+```
+
+Per-tool-execution override (here `Full` opts into capturing tool arguments and results in the span):
+
+```go
+ctx, tool := client.StartToolExecution(ctx, sigil.ToolExecutionStart{
+    ToolName:       "search",
+    ContentCapture: sigil.ContentCaptureModeFull,
+})
+defer tool.End()
+```
+
+Tool executions also inherit the parent generation's resolved mode via context, so explicit overrides are rarely needed inside an instrumented generation block.
+
+Dynamic resolution via `ContentCaptureResolver`:
+
+```go
+cfg.ContentCaptureResolver = func(ctx context.Context, metadata map[string]any) sigil.ContentCaptureMode {
+    if metadata["sigil.tenant"] == "healthcare" {
+        return sigil.ContentCaptureModeMetadataOnly
+    }
+    return sigil.ContentCaptureModeDefault // defer to Config.ContentCapture
+}
+```
+
+Resolver panics are recovered and treated as `ContentCaptureModeMetadataOnly` (fail-closed).
+
+Resolution precedence for generations (highest to lowest):
+
+1. Per-generation `ContentCapture`
+2. `ContentCaptureResolver` return value
+3. `Config.ContentCapture` (defaults to `ContentCaptureModeNoToolContent`)
+
+Resolution precedence for tool executions (highest to lowest):
+
+1. Per-tool `ContentCapture`
+2. Parent generation's resolved mode, propagated through `context.Context`
+3. `ContentCaptureResolver` return value
+4. `Config.ContentCapture` (defaults to `ContentCaptureModeNoToolContent`)
+
+User-provided `Metadata` and `Tags` are not stripped by any capture mode. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content.
+
 ## Pre-Ingest Redaction
 
 Use `GenerationSanitizer` when you want to redact substrings from normalized generations before validation, span sync, and export.

--- a/go/sigil/client.go
+++ b/go/sigil/client.go
@@ -35,10 +35,10 @@ type Config struct {
 	// generations and tool executions. Per-recording overrides take precedence.
 	ContentCapture ContentCaptureMode
 	// ContentCaptureResolver, when set, is called before each generation,
-	// tool execution, and rating submission to dynamically resolve the content
-	// capture mode. It receives the request context and the recording's
-	// metadata (nil when the recording type has no metadata, e.g. tool
-	// executions).
+	// embedding, tool execution, and rating submission to dynamically resolve
+	// the content capture mode. It receives the request context and the
+	// recording's metadata (nil when the recording type has no metadata, e.g.
+	// tool executions).
 	//
 	// Resolution precedence (highest → lowest):
 	//   1. Per-recording ContentCapture field (explicit override)

--- a/go/sigil/doc.go
+++ b/go/sigil/doc.go
@@ -22,29 +22,60 @@
 //
 // # Content Capture
 //
-// Config.ContentCapture sets the default ContentCaptureMode (Full or MetadataOnly).
-// MetadataOnly strips prompts, messages, tool arguments, and tool results before
-// export while preserving usage, timing, model info, and message structure.
+// Config.ContentCapture sets the default ContentCaptureMode. The SDK supports
+// four concrete modes plus the Default placeholder:
+//
+//   - ContentCaptureModeDefault: inherit from the next layer. At the client
+//     level this resolves to ContentCaptureModeNoToolContent.
+//   - ContentCaptureModeFull: export all content.
+//   - ContentCaptureModeNoToolContent: full generation content, but tool
+//     execution arguments and results are excluded from span attributes.
+//     This is the effective client default and matches pre-ContentCaptureMode
+//     SDK behavior.
+//   - ContentCaptureModeMetadataOnly: preserve structure, tool names, usage,
+//     timing, and IDs; strip text, tool arguments, tool results, thinking,
+//     system prompts, conversation titles, raw artifacts, tool descriptions,
+//     tool input schemas, and detailed error text.
+//   - ContentCaptureModeFullWithMetadataSpans: keep full content on the
+//     generation export (gRPC/HTTP) but omit content fields from OTel spans.
+//     Use this when the gRPC ingest destination is private but the OTel
+//     traces/metrics destination is shared. Tool execution and embedding
+//     spans behave like MetadataOnly under this mode because they have no
+//     separate gRPC export.
+//
 // Per-generation and per-tool-execution overrides are available via the
 // ContentCapture field on GenerationStart and ToolExecutionStart.
-// Tool executions inherit the parent generation's mode via context.
+// Tool executions inherit the parent generation's resolved mode via context.
 //
 // Config.ContentCaptureResolver enables dynamic per-request resolution. When set,
-// the resolver is called before each generation start and rating submission with
-// the request context and recording metadata. This is the recommended integration
-// point for multi-tenant services that need to resolve content capture mode based
-// on tenant-level policies (e.g., data-sharing opt-out).
+// the resolver is called before each generation start, embedding start, tool
+// execution, and rating submission with the request context and recording
+// metadata (nil for tool executions, which carry no metadata). This is the
+// recommended integration point for multi-tenant services that need to resolve
+// content capture mode based on tenant-level policies (e.g., data-sharing
+// opt-out).
 //
-// Resolution precedence (highest to lowest):
-//   - Per-recording ContentCapture field (explicit override)
+// Generation resolution precedence (highest to lowest):
+//   - GenerationStart.ContentCapture (explicit override)
 //   - ContentCaptureResolver return value
-//   - Config.ContentCapture (static default)
+//   - Config.ContentCapture (static default; ContentCaptureModeDefault here
+//     resolves to ContentCaptureModeNoToolContent)
+//
+// Tool execution resolution precedence (highest to lowest):
+//   - ToolExecutionStart.ContentCapture (explicit override)
+//   - Parent generation's resolved mode (via context)
+//   - ContentCaptureResolver return value
+//   - Config.ContentCapture (static default; ContentCaptureModeDefault here
+//     resolves to ContentCaptureModeNoToolContent)
 //
 // Resolver panics are recovered and treated as MetadataOnly (fail-closed).
 //
-// MetadataOnly does not filter user-provided Metadata or Tags maps.
+// Capture modes do not filter user-provided Metadata or Tags maps.
 // Callers are responsible for not including sensitive content in those fields
-// when using MetadataOnly mode.
+// when using MetadataOnly or FullWithMetadataSpans mode.
+//
+// See docs/concepts/content-capture-modes.md in the repository for the full
+// per-surface behavior matrix shared across SDKs.
 //
 // # Linking
 //

--- a/java/README.md
+++ b/java/README.md
@@ -117,7 +117,7 @@ For RAG retrieval or other preprocessing steps, use tool execution even though t
 try (ToolExecutionRecorder rec = client.startToolExecution(
         new ToolExecutionStart()
             .setToolName("document_retriever")
-            .setContentCapture(ContentCaptureMode.FULL_CONTENT))) {
+            .setContentCapture(ContentCaptureMode.FULL))) {
     
     rec.setArguments(Map.of("query", searchQuery, "limit", 5));
     List<Document> docs = vectorStore.similaritySearch(searchQuery, 5);
@@ -125,7 +125,78 @@ try (ToolExecutionRecorder rec = client.startToolExecution(
 }
 ```
 
-See [Tool Calls vs Tool Executions](../docs/concepts/tool-call-vs-tool-execution.md) for the full conceptual guide.
+See [Tool Calls vs Tool Executions](../docs/concepts/tool-call-vs-tool-execution.md) for the full conceptual guide, and [Content Capture Modes](../docs/concepts/content-capture-modes.md) for the modes and defaults.
+
+## Content Capture
+
+`ContentCaptureMode` controls what content the SDK includes in exported generation payloads and OTel span attributes. See [Content Capture Modes](../docs/concepts/content-capture-modes.md) for the canonical mode matrix; the snippets below show how to wire it up in Java.
+
+Client-level default:
+
+```java
+SigilClient client = new SigilClient(new SigilClientConfig()
+    .setContentCapture(ContentCaptureMode.METADATA_ONLY));
+```
+
+The core SDK client treats `ContentCaptureMode.DEFAULT` as `NO_TOOL_CONTENT`.
+
+Per-generation override:
+
+```java
+client.withGeneration(
+    new GenerationStart()
+        .setModel(new ModelRef().setProvider("openai").setName("gpt-5"))
+        .setContentCapture(ContentCaptureMode.FULL),
+    recorder -> {
+        recorder.setResult(new GenerationResult()
+            .setOutput(java.util.List.of(
+                new Message().setRole(MessageRole.ASSISTANT)
+                    .setParts(java.util.List.of(MessagePart.text("hello"))))));
+        return null;
+    }
+);
+```
+
+Per-tool-execution override (here `FULL` opts into capturing arguments and results in the span):
+
+```java
+try (ToolExecutionRecorder rec = client.startToolExecution(
+        new ToolExecutionStart()
+            .setToolName("search")
+            .setContentCapture(ContentCaptureMode.FULL))) {
+    rec.setArguments(Map.of("q", "weather"));
+    rec.setResult(Map.of("temp_c", 18));
+}
+```
+
+Dynamic resolution via `ContentCaptureResolver`:
+
+```java
+SigilClient client = new SigilClient(new SigilClientConfig()
+    .setContentCaptureResolver(metadata -> {
+        if (metadata != null && "healthcare".equals(metadata.get("sigil.tenant"))) {
+            return ContentCaptureMode.METADATA_ONLY;
+        }
+        return ContentCaptureMode.DEFAULT;
+    }));
+```
+
+Resolver exceptions are caught and treated as `METADATA_ONLY` (fail-closed).
+
+Resolution precedence for generations (highest to lowest):
+
+1. Per-generation `ContentCapture`
+2. `ContentCaptureResolver` return value
+3. `SigilClientConfig.contentCapture` (defaults to `NO_TOOL_CONTENT`)
+
+Resolution precedence for tool executions (highest to lowest):
+
+1. Per-tool `ContentCapture`
+2. Parent generation's resolved mode
+3. `ContentCaptureResolver` return value
+4. `SigilClientConfig.contentCapture` (defaults to `NO_TOOL_CONTENT`)
+
+User-provided `metadata` and `tags` are not stripped by any capture mode. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content.
 
 ## Embedding Observability
 

--- a/js/README.md
+++ b/js/README.md
@@ -58,6 +58,72 @@ await client.startGeneration(
 await client.shutdown();
 ```
 
+## Content Capture
+
+`contentCapture` controls what content the SDK includes in exported generation payloads and OTel span attributes. See [Content Capture Modes](../docs/concepts/content-capture-modes.md) for the canonical mode matrix and defaults; the snippets below show how to wire it up in TypeScript.
+
+Client-level default:
+
+```ts
+import { SigilClient } from "@grafana/sigil-sdk-js";
+
+const client = new SigilClient({
+  contentCapture: "metadata_only",
+});
+```
+
+The core SDK client treats `"default"` as `"no_tool_content"`: generation content is captured but tool-execution arguments and results stay out of spans.
+
+Per-generation override:
+
+```ts
+await client.startGeneration(
+  {
+    model: { provider: "openai", name: "gpt-5" },
+    contentCapture: "full",
+  },
+  async (recorder) => {
+    recorder.setResult({ output: [{ role: "assistant", content: "hi" }] });
+  }
+);
+```
+
+Per-tool-execution override (here `"full"` opts into capturing tool arguments and results in the span):
+
+```ts
+await client.startToolExecution(
+  { toolName: "search", contentCapture: "full" },
+  async (recorder) => {
+    recorder.setResult({ arguments: { q: "weather" }, result: { tempC: 18 } });
+  }
+);
+```
+
+Dynamic resolution via `contentCaptureResolver`:
+
+```ts
+const client = new SigilClient({
+  contentCaptureResolver: (metadata) => {
+    if (metadata?.["sigil.tenant"] === "healthcare") {
+      return "metadata_only";
+    }
+    return "default"; // defer to `contentCapture`
+  },
+});
+```
+
+The resolver receives the recording's metadata (or `undefined` for recording types that have no metadata, like tool executions). Thrown errors are caught and treated as `"metadata_only"` (fail-closed).
+
+Resolution precedence (highest to lowest):
+
+1. Per-recording `contentCapture` on `GenerationStart` / `ToolExecutionStart`
+2. `contentCaptureResolver` return value
+3. Client-level `contentCapture` (defaults to `"no_tool_content"`)
+
+Unlike the Go, Python, Java, and .NET SDKs, the JS SDK does not propagate the resolved capture mode through async context, so tool executions started inside a generation block do not automatically inherit the generation's mode. Set `contentCapture` on each `ToolExecutionStart` when you need a tool to follow a non-default policy.
+
+User-provided `metadata` and `tags` are not stripped by any capture mode. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content.
+
 ## Pre-Ingest Redaction
 
 Use `generationSanitizer` when you want to redact substrings from normalized generations before

--- a/llms.txt
+++ b/llms.txt
@@ -79,9 +79,13 @@ To re-enter credentials later, run `sigil login`.
 
 ## Content capture
 
-By default plugins send metadata only (model, tokens, tool names, timing, cost). To send prompt and response bodies as well, set `SIGIL_CONTENT_CAPTURE_MODE` in `~/.config/sigil/config.env`. Valid values across SDKs: `full`, `no_tool_content`, `metadata_only` (default), `full_with_metadata_spans`.
+Coding-agent plugins default to `metadata_only`: only model, tokens, tool names, timing, and cost are sent. Prompts, responses, and tool I/O stay on the local machine. To opt into sending content, set `SIGIL_CONTENT_CAPTURE_MODE` in `~/.config/sigil/config.env`.
 
-Secrets are auto-redacted before send. Treat content capture as opt-in for shared/production machines.
+Accepted values depend on the plugin surface:
+
+- Claude Code, Codex, Copilot, Cursor (shared `sigil` binary), OpenCode (`@grafana/sigil-opencode`), and Pi (`@grafana/sigil-pi`): `full`, `no_tool_content`, `metadata_only`, `full_with_metadata_spans`. `default` is accepted as an alias for `metadata_only`.
+
+Unknown values fall back to `metadata_only` with a warning. Secret redaction is plugin-specific. Capture modes choose which fields ship, not whether the shipped fields are scrubbed. Treat content capture as opt-in for shared/production machines.
 
 ## Verifying the install
 
@@ -112,6 +116,14 @@ OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64 of "<otlp-instance-id>:<g
 ```
 
 Construct the client with no config when the env vars are present; the SDK reads them. Only use explicit `ClientConfig(...)` when the app needs values that aren't in env (e.g. test endpoints).
+
+### Content capture
+
+The core SDK clients default to `no_tool_content`: generation content (prompts, responses, thinking, system prompts) is exported, but tool-execution arguments and results stay out of spans. Setting `contentCapture: 'default'` (or the language equivalent) resolves to `no_tool_content` at the client level.
+
+Use the cross-language reference at [`docs/concepts/content-capture-modes.md`](https://github.com/grafana/sigil-sdk/blob/main/docs/concepts/content-capture-modes.md) and the per-language READMEs for examples. Modes supported by the SDKs: `full`, `no_tool_content`, `metadata_only`, `full_with_metadata_spans`. User-provided `metadata` and `tags` are not stripped by capture modes; do not put sensitive content there.
+
+This default differs from coding-agent plugin defaults (Path A), which ship `metadata_only`. Do not mix the two.
 
 ## Mission
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -82,7 +82,7 @@ Common culprits: `sigil --version` doesn't work (binary not on `PATH`), a missin
 | `SIGIL_AUTH_TOKEN` | — | `glc_…` Cloud Access Policy Token. |
 | `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the AI Observability latency and tool-call panels stay empty. |
 | `SIGIL_OTEL_AUTH_TOKEN` | `SIGIL_AUTH_TOKEN` | Override the OTel password. |
-| `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, or `full`. |
+| `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md). |
 | `SIGIL_TAGS` | — | `key=value,key=value` tags added to every generation. |
 | `SIGIL_USER_ID` | from `~/.claude.json` | Override the user id. |
 | `SIGIL_USER_ID_SOURCE` | `email` | Which field to read from `~/.claude.json`: `email` or `accountUuid`. |

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -98,7 +98,7 @@ tail -f ~/.local/state/sigil/logs/sigil.log
 | `SIGIL_AUTH_TOKEN` | — | `glc_…` Cloud Access Policy Token. |
 | `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the AI Observability latency and tool-call panels stay empty. |
 | `SIGIL_OTEL_AUTH_TOKEN` | `SIGIL_AUTH_TOKEN` | Override the OTel password. |
-| `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, or `full`. |
+| `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md). |
 | `SIGIL_TAGS` | — | `key=value,key=value` tags added to every generation. |
 | `SIGIL_USER_ID` | — | Override the user id. |
 | `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -125,8 +125,9 @@ shapes.
 | `metadata_only` | stripped | stripped | tool names/status only | stripped |
 | `no_tool_content` | included with redaction | included with redaction | tool names/status only | stripped |
 | `full` | included with redaction | included with redaction | included with redaction | included with redaction |
+| `full_with_metadata_spans` | included on generation export with redaction; stripped on OTel spans | included on generation export with redaction; stripped on OTel spans | tool names/status only | stripped |
 
-Redaction happens before export.
+Captured prompt, assistant, and tool content is redacted before export. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md) for the cross-SDK reference.
 
 ## All options
 
@@ -137,7 +138,7 @@ Redaction happens before export.
 | `SIGIL_AUTH_TOKEN` | — | `glc_…` Cloud Access Policy Token. |
 | `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the AI Observability latency and tool-call panels stay empty. |
 | `SIGIL_OTEL_AUTH_TOKEN` | `SIGIL_AUTH_TOKEN` | Override the OTel password. |
-| `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, or `full`. |
+| `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. |
 | `SIGIL_TAGS` | — | `key=value,key=value` tags added to every generation. |
 | `SIGIL_USER_ID` | — | Override the user id. |
 | `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -49,11 +49,13 @@ SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net
 
 </details>
 
-To also send the conversation text (with automatic secret redaction), add this to `~/.config/sigil/config.env`:
+To also send the conversation text, add this to `~/.config/sigil/config.env`:
 
 ```dotenv
 SIGIL_CONTENT_CAPTURE_MODE=full
 ```
+
+Cursor content is not passed through the shared redactor before export. Avoid `full` when prompts, replies, or tool output may contain secrets.
 
 ## 4. Verify
 
@@ -74,7 +76,7 @@ tail -f ~/.local/state/sigil/logs/sigil.log
 | `SIGIL_AUTH_TOKEN` | — | `glc_…` Cloud Access Policy Token. |
 | `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the AI Observability latency and tool-call panels stay empty. |
 | `SIGIL_OTEL_AUTH_TOKEN` | `SIGIL_AUTH_TOKEN` | Override the OTel password. |
-| `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, or `full`. |
+| `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md). |
 | `SIGIL_TAGS` | — | `key=value,key=value` tags added to every generation. Built-ins (`git.branch`, `cwd`, `subagent`) win on collision. |
 | `SIGIL_USER_ID` | from Cursor | Override the user id. |
 | `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -2,7 +2,7 @@
 
 [OpenCode](https://opencode.ai) plugin that sends LLM generations to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/).
 
-By default only metadata is sent (token counts, cost, model, tool names, durations). Set `SIGIL_CONTENT_CAPTURE_MODE` to `full`, `no_tool_content`, `metadata_only`, or `full_with_metadata_spans` to control what is sent. `default` is accepted as an alias for `metadata_only`.
+By default only metadata is sent (token counts, cost, model, tool names, durations). Set `SIGIL_CONTENT_CAPTURE_MODE` to `full`, `no_tool_content`, `metadata_only`, or `full_with_metadata_spans` to control what is sent. `default` is accepted as an alias for `metadata_only`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md) for the full reference.
 
 ## 1. Install and launch
 
@@ -60,11 +60,13 @@ SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net
 
 When `SIGIL_AUTH_TENANT_ID` and `SIGIL_AUTH_TOKEN` are set, the plugin uses them for Sigil and OTLP auth. If the OpenTelemetry card shows a different Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>`.
 
-To include conversation text (with automatic secret redaction), add this to `~/.config/sigil/config.env`:
+To include conversation text, add this to `~/.config/sigil/config.env`:
 
 ```dotenv
 SIGIL_CONTENT_CAPTURE_MODE=full
 ```
+
+OpenCode redacts assistant and tool content before export. User prompt text is sent as-is when content capture allows it.
 
 ## 3. Verify
 

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -2,7 +2,7 @@
 
 [Pi](https://github.com/badlogic/pi) agent extension that sends LLM generations to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/).
 
-By default only metadata is sent (token counts, cost, model, tool names, durations). Set `SIGIL_CONTENT_CAPTURE_MODE` to `full`, `no_tool_content`, `metadata_only`, or `full_with_metadata_spans` to control what is sent. `default` is accepted as an alias for `metadata_only`.
+By default only metadata is sent (token counts, cost, model, tool names, durations). Set `SIGIL_CONTENT_CAPTURE_MODE` to `full`, `no_tool_content`, `metadata_only`, or `full_with_metadata_spans` to control what is sent. `default` is accepted as an alias for `metadata_only`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md) for the full reference.
 
 ## 1. Install and launch
 

--- a/plugins/sigil/README.md
+++ b/plugins/sigil/README.md
@@ -32,6 +32,19 @@ Then follow your agent's quickstart:
 - [OpenCode](../opencode/README.md)
 - [pi](../pi/README.md)
 
+## Content capture
+
+The shared `sigil` binary defaults to `metadata_only`: only model, tokens, tool names, timing, and cost ship to Grafana AI Observability. Prompts, responses, and tool I/O stay on the local machine. To opt into sending content, set `SIGIL_CONTENT_CAPTURE_MODE` in `~/.config/sigil/config.env`. The shared binary parser accepts every mode the SDKs support:
+
+```dotenv
+# valid values: full | no_tool_content | metadata_only | full_with_metadata_spans
+SIGIL_CONTENT_CAPTURE_MODE=full
+```
+
+Unknown values fall back to `metadata_only` with a warning. `default` is accepted as an alias for `metadata_only` so the shared binary matches the Go envconfig resolver rather than the JS SDK's client-level default of `no_tool_content`. The Pi (`@grafana/sigil-pi`) and OpenCode (`@grafana/sigil-opencode`) plugins ship their own parsers but accept the same set of values.
+
+A plugin can only export fields the host agent passes through to it, so individual plugins may capture less than the SDK matrix shows. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md) for the SDK-level behavior matrix and plugin defaults.
+
 ## Auto-update
 
 `sigil claude`, `sigil codex`, `sigil copilot`, and `sigil opencode` refresh the installed host plugin automatically. Set `SIGIL_AUTO_UPDATE=false` to opt out.

--- a/python/README.md
+++ b/python/README.md
@@ -346,17 +346,20 @@ with with_conversation_id("conv-ctx"), with_agent_name("planner"), with_agent_ve
 
 ## Content Capture Mode
 
-`ContentCaptureMode` controls what content is included in exported generation payloads and OTel span attributes. Use it to prevent sensitive text (prompts, tool I/O, model responses) from leaving the process.
+`ContentCaptureMode` controls what content is included in exported generation payloads and OTel span attributes. Use it to prevent sensitive text (prompts, tool I/O, model responses) from leaving the process. See [Content Capture Modes](../docs/concepts/content-capture-modes.md) for the cross-SDK reference, including the per-surface behavior matrix.
 
+| Mode                            | Generation export                            | Generation span             | Tool spans                              | Embedding span                          |
+| ------------------------------- | -------------------------------------------- | --------------------------- | --------------------------------------- | --------------------------------------- |
+| `FULL`                          | Full content                                 | Content attributes included | Arguments and results included          | Input texts included when capture is on |
+| `NO_TOOL_CONTENT` (SDK default) | Full content                                 | Content attributes included | Arguments and results excluded          | Input texts included when capture is on |
+| `METADATA_ONLY`                 | Structure only; text and tool I/O stripped   | Content attributes omitted  | Arguments and results excluded          | Input texts omitted                     |
+| `FULL_WITH_METADATA_SPANS`      | Full content                                 | Content attributes omitted  | Arguments and results excluded          | Input texts omitted                     |
 
-| Mode                            | Generations                            | Tool spans                               |
-| ------------------------------- | -------------------------------------- | ---------------------------------------- |
-| `FULL`                          | All content exported                   | Arguments and results in span attributes |
-| `NO_TOOL_CONTENT` (SDK default) | All content exported                   | Arguments and results excluded           |
-| `METADATA_ONLY`                 | Structure preserved, all text stripped | Arguments and results excluded           |
+`DEFAULT` is a placeholder for "inherit from the next layer"; at the client level it resolves to `NO_TOOL_CONTENT`. The SDK default is `NO_TOOL_CONTENT`, which matches the SDK's behavior before this feature was added.
 
+`FULL_WITH_METADATA_SPANS` is the right mode when the gRPC ingest destination is private but the OTel trace/metric destination is shared and must not receive any content. Tool execution and embedding spans behave like `METADATA_ONLY` under this mode because they have no separate gRPC export.
 
-The default is `NO_TOOL_CONTENT`, which matches the SDK's behavior before this feature was added.
+User-provided `metadata` and `tags` are **not** stripped by any capture mode; callers must avoid putting sensitive content in those dicts when using `METADATA_ONLY` or `FULL_WITH_METADATA_SPANS`. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content.
 
 ### Client-level default
 
@@ -416,12 +419,21 @@ client = Client(ClientConfig(
 ))
 ```
 
-### Resolution precedence (highest to lowest)
+### Resolution precedence
 
-1. Per-recording `content_capture` field (`GenerationStart` / `ToolExecutionStart`)
-2. `content_capture_resolver` return value
-3. `ContextVar` from `with_content_capture_mode()`
-4. `ClientConfig.content_capture` (defaults to `NO_TOOL_CONTENT`)
+For generations, highest to lowest:
+
+1. `GenerationStart.content_capture`
+2. `with_content_capture_mode(...)` when set
+3. `content_capture_resolver` return value
+4. `ClientConfig.content_capture` (defaults to `NO_TOOL_CONTENT`; `DEFAULT` at the client level resolves to `NO_TOOL_CONTENT`)
+
+For tool executions, highest to lowest:
+
+1. `ToolExecutionStart.content_capture`
+2. Parent generation's resolved mode, or `with_content_capture_mode(...)` when set
+3. `content_capture_resolver` return value
+4. `ClientConfig.content_capture` (defaults to `NO_TOOL_CONTENT`; `DEFAULT` at the client level resolves to `NO_TOOL_CONTENT`)
 
 Exceptions in the resolver are caught and treated as `METADATA_ONLY` (fail-closed).
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior modifications.
> 
> **Overview**
> Adds a canonical **[Content Capture Modes](docs/concepts/content-capture-modes.md)** guide (mode definitions, ingest vs OTel span matrix, SDK vs coding-agent defaults, resolution precedence, caveats about `metadata`/`tags` and redaction).
> 
> **Cross-links and alignment:** root `README`, `llms.txt`, Go package `doc.go`, and per-language SDK READMEs (Go, Python, JS, Java, .NET) now point at that doc and document how to set overrides/resolvers. Python’s capture section is expanded (span/export matrix, separate generation vs tool precedence). **Tool Calls vs Tool Executions** uses `FULL` instead of `FULL_CONTENT` and states the `NO_TOOL_CONTENT` default.
> 
> **Plugins:** READMEs for the shared `sigil` binary and agent plugins document `SIGIL_CONTENT_CAPTURE_MODE` (including `full_with_metadata_spans` where the Go parser supports it), link the concept doc, and call out Pi/OpenCode parser limits, Cursor’s lack of pre-export redaction, and Copilot’s mode table row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3094f5f44a04b8b44e835e0c51421aef46c8c8b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->