### PR TITLE
fix(plugins): accept all ContentCaptureMode values in opencode and pi

### DIFF
--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -2,7 +2,7 @@
 
 [OpenCode](https://opencode.ai) plugin that sends LLM generations to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/).
 
-By default only metadata is sent (token counts, cost, model, tool names, durations). Set `SIGIL_CONTENT_CAPTURE_MODE=full` or `no_tool_content` to include message content.
+By default only metadata is sent (token counts, cost, model, tool names, durations). Set `SIGIL_CONTENT_CAPTURE_MODE` to `full`, `no_tool_content`, `metadata_only`, or `full_with_metadata_spans` to control what is sent. `default` is accepted as an alias for `metadata_only`.
 
 ## 1. Install and launch
 
@@ -83,7 +83,7 @@ If nothing shows up, set `SIGIL_DEBUG=true` in `~/.config/sigil/config.env`, run
 | `SIGIL_AUTH_TOKEN` | — | `glc_…` Cloud Access Policy Token. |
 | `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the AI Observability latency and tool-call panels stay empty. Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT`. |
 | `SIGIL_OTEL_AUTH_TOKEN` | `SIGIL_AUTH_TOKEN` | Override the OTLP password. |
-| `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, or `full`. |
+| `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | One of `full`, `no_tool_content`, `metadata_only`, or `full_with_metadata_spans`. `default` is accepted as an alias for `metadata_only`. |
 | `SIGIL_AGENT_NAME` | `opencode` | Agent name reported to Sigil. The plugin appends `:<mode>` for OpenCode's UI mode, such as `build` or `plan`. |
 | `SIGIL_AGENT_VERSION` | — | Optional version string reported with the agent. |
 | `SIGIL_DEBUG` | `false` | Log lifecycle events to stderr. |

--- a/plugins/opencode/src/config.test.ts
+++ b/plugins/opencode/src/config.test.ts
@@ -73,6 +73,23 @@ describe("resolveConfig", () => {
     expect(cfg?.contentCapture).toBe("metadata_only");
   });
 
+  it("accepts SIGIL_CONTENT_CAPTURE_MODE=full_with_metadata_spans", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_CONTENT_CAPTURE_MODE = "full_with_metadata_spans";
+    const cfg = resolveConfig();
+    expect(cfg?.contentCapture).toBe("full_with_metadata_spans");
+  });
+
+  it("maps SIGIL_CONTENT_CAPTURE_MODE=default to metadata_only without warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_CONTENT_CAPTURE_MODE = "default";
+    const cfg = resolveConfig();
+    expect(cfg?.contentCapture).toBe("metadata_only");
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it("warns and falls back to metadata_only on unknown content-capture value", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     process.env.SIGIL_ENDPOINT = "http://localhost:8080";

--- a/plugins/opencode/src/config.ts
+++ b/plugins/opencode/src/config.ts
@@ -129,16 +129,26 @@ function resolveContentCapture(): ContentCaptureMode {
   return "metadata_only";
 }
 
+// Modes the parser passes through to the SDK verbatim. "default" is
+// intentionally absent: it is collapsed to "metadata_only" in
+// parseContentCaptureMode before the includes check, matching the canonical
+// Go envconfig.ResolveContentMode. If "default" were listed here, removing
+// the early-return would silently let the literal reach the SDK, which would
+// then resolve it to "no_tool_content" via its client-level default.
 const VALID_CAPTURE_MODES: ContentCaptureMode[] = [
   "full",
   "no_tool_content",
   "metadata_only",
+  "full_with_metadata_spans",
 ];
 
 function parseContentCaptureMode(value: string): ContentCaptureMode {
   const normalized = value.trim().toLowerCase();
   if (["1", "true", "yes", "on"].includes(normalized)) return "full";
   if (["0", "false", "no", "off"].includes(normalized)) return "metadata_only";
+  // Resolve "default" inside the plugin: the SDK's client-level default would
+  // otherwise map it to "no_tool_content", which differs from the Go binary.
+  if (normalized === "default") return "metadata_only";
   if (VALID_CAPTURE_MODES.includes(normalized as ContentCaptureMode)) {
     return normalized as ContentCaptureMode;
   }

--- a/plugins/opencode/src/golden.test.ts
+++ b/plugins/opencode/src/golden.test.ts
@@ -335,6 +335,7 @@ describe("opencode plugin: real-SDK golden export", () => {
     "full",
     "no_tool_content",
     "metadata_only",
+    "full_with_metadata_spans",
   ] as const)("propagates content capture mode %s to the SDK export", async (contentCapture) => {
     const { turn, messageFetches } = await runCompleteAssistantTurn({
       contentCapture,
@@ -350,6 +351,17 @@ describe("opencode plugin: real-SDK golden export", () => {
         "Bash",
         "Read",
       ]);
+    }
+    // full_with_metadata_spans must keep tool bodies in the proto export
+    // (the SDK splits content only on the OTel span side); see
+    // go/sigil/content_capture.go on ContentCaptureModeFullWithMetadataSpans.
+    if (contentCapture === "full_with_metadata_spans") {
+      expect(findOutputPart(turn, "tool_call").tool_call.input_json).not.toBe(
+        "",
+      );
+      expect(findOutputPart(turn, "tool_result").tool_result.content).not.toBe(
+        "",
+      );
     }
   });
 

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -2,7 +2,7 @@
 
 [Pi](https://github.com/badlogic/pi) agent extension that sends LLM generations to [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/).
 
-By default only metadata is sent (token counts, cost, model, tool names, durations). Set `SIGIL_CONTENT_CAPTURE_MODE=full` or `no_tool_content` to include message content.
+By default only metadata is sent (token counts, cost, model, tool names, durations). Set `SIGIL_CONTENT_CAPTURE_MODE` to `full`, `no_tool_content`, `metadata_only`, or `full_with_metadata_spans` to control what is sent. `default` is accepted as an alias for `metadata_only`.
 
 ## 1. Install and launch
 
@@ -99,7 +99,7 @@ The same three variables are honored by the [Claude Code plugin](../claude-code/
 | `SIGIL_AUTH_TOKEN` | — | Cloud access policy token (`glc_…`). |
 | `SIGIL_AGENT_NAME` | `pi` | Agent name reported to Sigil. |
 | `SIGIL_AGENT_VERSION` | — | Optional version string reported with the agent. |
-| `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `full`, `no_tool_content`, or `metadata_only`. |
+| `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | One of `full`, `no_tool_content`, `metadata_only`, or `full_with_metadata_spans`. `default` is accepted as an alias for `metadata_only`. |
 | `SIGIL_DEBUG` | `false` | Log lifecycle events to stderr. |
 | `SIGIL_REDACT_INPUT_MESSAGES` | `true` | Redact known secret patterns in user input messages before export. |
 | `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP HTTP endpoint. Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT`. |

--- a/plugins/pi/src/config.test.ts
+++ b/plugins/pi/src/config.test.ts
@@ -85,6 +85,23 @@ describe("resolveConfig", () => {
     expect(cfg?.contentCapture).toBe("no_tool_content");
   });
 
+  it("accepts SIGIL_CONTENT_CAPTURE_MODE=full_with_metadata_spans", () => {
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_CONTENT_CAPTURE_MODE = "full_with_metadata_spans";
+    const cfg = resolveConfig();
+    expect(cfg?.contentCapture).toBe("full_with_metadata_spans");
+  });
+
+  it("maps SIGIL_CONTENT_CAPTURE_MODE=default to metadata_only without warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    process.env.SIGIL_CONTENT_CAPTURE_MODE = "default";
+    const cfg = resolveConfig();
+    expect(cfg?.contentCapture).toBe("metadata_only");
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it("warns and falls back on unknown mode string", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     process.env.SIGIL_ENDPOINT = "http://localhost:8080";

--- a/plugins/pi/src/config.ts
+++ b/plugins/pi/src/config.ts
@@ -138,16 +138,26 @@ function resolveGuards(): GuardsFeatureConfig {
   };
 }
 
+// Modes the parser passes through to the SDK verbatim. "default" is
+// intentionally absent: it is collapsed to "metadata_only" in
+// parseContentCaptureMode before the includes check, matching the canonical
+// Go envconfig.ResolveContentMode. If "default" were listed here, removing
+// the early-return would silently let the literal reach the SDK, which would
+// then resolve it to "no_tool_content" via its client-level default.
 const VALID_CAPTURE_MODES: ContentCaptureMode[] = [
   "full",
   "no_tool_content",
   "metadata_only",
+  "full_with_metadata_spans",
 ];
 
 function parseContentCaptureMode(value: string): ContentCaptureMode {
   const normalized = value.trim().toLowerCase();
   if (["1", "true", "yes", "on"].includes(normalized)) return "full";
   if (["0", "false", "no", "off"].includes(normalized)) return "metadata_only";
+  // Resolve "default" inside the plugin: the SDK's client-level default would
+  // otherwise map it to "no_tool_content", which differs from the Go binary.
+  if (normalized === "default") return "metadata_only";
   if (VALID_CAPTURE_MODES.includes(normalized as ContentCaptureMode)) {
     return normalized as ContentCaptureMode;
   }

--- a/plugins/pi/src/golden.test.ts
+++ b/plugins/pi/src/golden.test.ts
@@ -245,7 +245,14 @@ describe("pi plugin: real-SDK golden export", () => {
     savedEnv = {};
   });
 
-  it("matches the recorded golden export for a full assistant turn", async () => {
+  // runFullTurn drives the FakePi event stream through one assistant turn and
+  // returns the normalized export plus the turn generation. Tests that want a
+  // non-default content capture mode set
+  // process.env.SIGIL_CONTENT_CAPTURE_MODE before calling this helper.
+  async function runFullTurn(): Promise<{
+    exports: { path: string; generations: unknown[] }[];
+    turn: any;
+  }> {
     const pi = new FakePi();
     registerExtension(pi as any);
 
@@ -303,7 +310,6 @@ describe("pi plugin: real-SDK golden export", () => {
       );
     }
 
-    // Invariant assertions in addition to the golden diff.
     for (const exp of exports) {
       expect(exp.path).toBe("/api/v1/generations:export");
     }
@@ -311,6 +317,25 @@ describe("pi plugin: real-SDK golden export", () => {
     expect(allGen.length).toBeGreaterThan(0);
     const turn = allGen.find((g) => g.agent_name === "pi");
     expect(turn, "expected a generation with agent_name=pi").toBeDefined();
+
+    return { exports, turn };
+  }
+
+  // The proto export uses a oneof for `parts`, so a part is identified by
+  // which field is populated (`tool_call`, `tool_result`, `text`, ...), not
+  // by a `type` discriminator. Matches the helper in opencode's golden test.
+  function findOutputPart(turn: any, key: string): any {
+    for (const msg of turn.output ?? []) {
+      for (const part of msg.parts ?? []) {
+        if (part[key] !== undefined) return part;
+      }
+    }
+    throw new Error(`missing output part ${key}`);
+  }
+
+  it("matches the recorded golden export for a full assistant turn", async () => {
+    const { exports, turn } = await runFullTurn();
+
     expect(turn.conversation_id).toBe("pi-conv-1");
     expect(turn.model.name).toBe("claude-sonnet-4-pi");
     expect(turn.model.provider).toBe("anthropic");
@@ -319,6 +344,38 @@ describe("pi plugin: real-SDK golden export", () => {
     expect(String(turn.usage.output_tokens)).toBe("30");
 
     assertGoldenJSON(GOLDEN_PATH, exports);
+  });
+
+  it.each([
+    "full",
+    "no_tool_content",
+    "metadata_only",
+    "full_with_metadata_spans",
+  ] as const)("propagates content capture mode %s to the SDK export", async (contentCapture) => {
+    process.env.SIGIL_CONTENT_CAPTURE_MODE = contentCapture;
+
+    const { turn } = await runFullTurn();
+
+    expect(turn.metadata["sigil.sdk.content_capture_mode"]).toBe(
+      contentCapture,
+    );
+
+    // full and full_with_metadata_spans must keep tool bodies in the proto
+    // export (the SDK splits content only on the OTel span side); see
+    // go/sigil/content_capture.go on ContentCaptureModeFullWithMetadataSpans.
+    const expectsToolBodies =
+      contentCapture === "full" ||
+      contentCapture === "full_with_metadata_spans";
+
+    const toolCall = findOutputPart(turn, "tool_call");
+    const toolResult = findOutputPart(turn, "tool_result");
+    if (expectsToolBodies) {
+      expect(toolCall.tool_call.input_json).not.toBe("");
+      expect(toolResult.tool_result.content).not.toBe("");
+    } else {
+      expect(toolCall.tool_call.input_json).toBe("");
+      expect(toolResult.tool_result.content).toBe("");
+    }
   });
 });
 

--- a/plugins/pi/src/mappers.test.ts
+++ b/plugins/pi/src/mappers.test.ts
@@ -416,6 +416,71 @@ describe("mapGenerationResult", () => {
     expect(roles).toContain("tool");
   });
 
+  it("full_with_metadata_spans matches full for proto-export tool bodies", () => {
+    // Per the SDK contract (ContentCaptureModeFullWithMetadataSpans in
+    // go/sigil/content_capture.go), the proto export gets full generation
+    // content under this mode; only the OTel span side is reduced.
+    const msg = makeMsg({
+      content: [
+        { type: "text", text: "I'll run that command" },
+        {
+          type: "toolCall",
+          id: "c1",
+          name: "bash",
+          arguments: { command: "ls" },
+        },
+      ],
+    });
+    const toolResults = [
+      makeToolResult({
+        toolCallId: "c1",
+        content: [{ type: "text", text: "file.txt" }],
+      }),
+    ];
+    const result = mapGenerationResult(
+      msg,
+      toolResults,
+      "full_with_metadata_spans",
+    );
+
+    const toolCallPart = result.output
+      ?.flatMap((m) => m.parts ?? [])
+      .find((p) => p.type === "tool_call");
+    expect(
+      (toolCallPart as { toolCall: { inputJSON: string } }).toolCall.inputJSON,
+    ).toBe(JSON.stringify({ command: "ls" }));
+
+    const toolResultPart = result.output
+      ?.flatMap((m) => m.parts ?? [])
+      .find((p) => p.type === "tool_result");
+    expect(
+      (toolResultPart as { toolResult: { content: string } }).toolResult
+        .content,
+    ).toBe("file.txt");
+  });
+
+  it("mapTools emits descriptions and schemas under full_with_metadata_spans", () => {
+    const catalog: PiToolInfo[] = [
+      {
+        name: "bash",
+        description: "Run a shell command",
+        parameters: { type: "object" },
+      },
+    ];
+    const defs = mapTools(
+      catalog,
+      new Set(["bash"]),
+      "full_with_metadata_spans",
+    );
+    expect(defs).toEqual([
+      {
+        name: "bash",
+        description: "Run a shell command",
+        inputSchemaJSON: JSON.stringify({ type: "object" }),
+      },
+    ]);
+  });
+
   it("skips redacted thinking blocks", () => {
     const msg = makeMsg({
       content: [

--- a/plugins/pi/src/mappers.ts
+++ b/plugins/pi/src/mappers.ts
@@ -6,6 +6,19 @@ import type {
   ToolDefinition,
 } from "@grafana/sigil-sdk-js";
 
+// includesToolBodies decides whether tool argument JSON, tool result content,
+// and tool description/schema are included in the proto export.
+//
+// Both `full` and `full_with_metadata_spans` ship full content in the proto
+// export per the SDK contract (see go/sigil/content_capture.go on
+// ContentCaptureModeFullWithMetadataSpans). The two modes only differ on the
+// OTel span side, which is handled inside the SDK, not in this mapper.
+function includesToolBodies(contentCapture: ContentCaptureMode): boolean {
+  return (
+    contentCapture === "full" || contentCapture === "full_with_metadata_spans"
+  );
+}
+
 /**
  * Pi's ToolInfo shape from @mariozechner/pi-coding-agent.
  * Declared here to avoid a hard import of pi types (treated as external at
@@ -264,8 +277,9 @@ export function mapUserMessage(
  * full registry. `activeNames === null` means "no filter" (the active-set
  * API is unavailable); an empty Set means "no tools offered this turn" and
  * produces an empty result. `description` and `inputSchemaJSON` are body
- * content and are only emitted under `contentCapture === "full"`; otherwise
- * the definitions are name-only, matching how `git.branch` is gated.
+ * content and are only emitted when the mode includes tool bodies (`full` or
+ * `full_with_metadata_spans`); otherwise the definitions are name-only,
+ * matching how `git.branch` is gated.
  */
 export function mapTools(
   toolCatalog: PiToolInfo[],
@@ -274,7 +288,7 @@ export function mapTools(
 ): ToolDefinition[] {
   const defs: ToolDefinition[] = [];
   const seen = new Set<string>();
-  const includeBody = contentCapture === "full";
+  const includeBody = includesToolBodies(contentCapture);
 
   for (const tool of toolCatalog) {
     if (!tool || typeof tool.name !== "string") continue;
@@ -394,7 +408,8 @@ export function extractRequestControls(
  * Map assistant message content blocks to Sigil output messages.
  * - text/thinking parts: only when contentCapture allows body content.
  * - tool_call parts: always emitted (structure needed for the SDK's
- *   tool_calls_per_operation metric); inputJSON is only filled in `full` mode.
+ *   tool_calls_per_operation metric); inputJSON is only filled when the mode
+ *   includes tool bodies (`full` or `full_with_metadata_spans`).
  */
 function mapAssistantOutput(
   msg: PiAssistantMessage,
@@ -433,10 +448,9 @@ function mapAssistantOutput(
               toolCall: {
                 id: block.id,
                 name: block.name,
-                inputJSON:
-                  contentCapture === "full"
-                    ? JSON.stringify(block.arguments)
-                    : "",
+                inputJSON: includesToolBodies(contentCapture)
+                  ? JSON.stringify(block.arguments)
+                  : "",
               },
             },
           ],
@@ -451,14 +465,15 @@ function mapAssistantOutput(
 
 /**
  * Map pi tool results to Sigil tool result messages. Always emits the
- * structural part; body content is included only in `full` mode.
+ * structural part; body content is included only when the mode includes tool
+ * bodies (`full` or `full_with_metadata_spans`).
  */
 function mapToolResultsOutput(
   toolResults: PiToolResult[],
   contentCapture: ContentCaptureMode,
 ): Message[] {
   const messages: Message[] = [];
-  const includeBody = contentCapture === "full";
+  const includeBody = includesToolBodies(contentCapture);
 
   for (const tr of toolResults) {
     let content = "";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are env parsing, documentation, and export gating for observability content modes; no auth or critical runtime paths.
> 
> **Overview**
> **OpenCode** and **Pi** now accept the full `SIGIL_CONTENT_CAPTURE_MODE` surface: `full_with_metadata_spans` is a valid value, and `default` is normalized to `metadata_only` inside each plugin (with tests) so behavior matches the Go `envconfig` resolver instead of the JS SDK’s client default (`no_tool_content`).
> 
> README tables and intro text for both plugins list all four modes and document the `default` alias.
> 
> **Pi** additionally treats `full_with_metadata_spans` like `full` for proto export—tool call input, tool results, and tool definitions keep bodies via `includesToolBodies`; only OTel span shaping stays in the SDK. Golden and mapper tests lock that in. **OpenCode** gains golden coverage that the new mode propagates to the SDK and retains tool bodies in exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71417a8b319ce4937553538b9042d3b2818c6cca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->