### PR TITLE
chore(java): remove unused otel proto test dependency

### DIFF
--- a/java/core/build.gradle.kts
+++ b/java/core/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation(libs.assertj.core)
-    testImplementation("io.opentelemetry.proto:opentelemetry-proto:1.9.0-alpha")
     testImplementation(libs.otel.sdk.testing)
 }
 


### PR DESCRIPTION
## Summary
- Remove the unused direct `opentelemetry-proto` test dependency from the Java core module.
- Keep the cleanup scoped to the clearly unused Java test dependency as a follow-up for grafana/sigil#1008.

## Test plan
- [x] `mise run test:java:sdk-core`
- [x] `git diff --check`
- [x] `./gradlew --no-daemon :core:dependencyInsight --dependency opentelemetry-proto --configuration testRuntimeClasspath`

Part of https://github.com/grafana/sigil/issues/1008

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only dependency cleanup with no runtime or test logic changes.
> 
> **Overview**
> Removes the unused direct **`io.opentelemetry.proto:opentelemetry-proto`** `testImplementation` from **`java/core/build.gradle.kts`**. Test dependencies stay on JUnit, AssertJ, and **`libs.otel.sdk.testing`**; no Java code referenced the proto artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a58f0714af9f4d8cff96af623176e75bf67ecf56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->