### PR TITLE
ci: harden SDK publish/tag workflow permissions and artifact provenance

### DIFF
--- a/.github/workflows/go-sdk-tag.yml
+++ b/.github/workflows/go-sdk-tag.yml
@@ -17,14 +17,15 @@ on:
         type: boolean
         default: true
 
-permissions:
-  contents: write
-  id-token: write
+permissions: {}
 
 jobs:
   tag:
     if: github.repository == 'grafana/sigil-sdk' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - name: Generate GitHub token

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -76,7 +76,6 @@ jobs:
     if: ${{ !inputs.dry-run }}
     needs: build
     runs-on: ubuntu-latest
-    environment: maven-central
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -76,6 +76,9 @@ jobs:
     if: ${{ !inputs.dry-run }}
     needs: build
     runs-on: ubuntu-latest
+    environment:
+      name: maven-central
+      url: https://central.sonatype.com/namespace/com.grafana
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -76,9 +76,7 @@ jobs:
     if: ${{ !inputs.dry-run }}
     needs: build
     runs-on: ubuntu-latest
-    environment:
-      name: maven-central
-      url: https://central.sonatype.com/namespace/com.grafana
+    environment: maven-central
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/js-sdk-publish.yml
+++ b/.github/workflows/js-sdk-publish.yml
@@ -24,6 +24,8 @@ jobs:
   build:
     if: github.repository == 'grafana/sigil-sdk' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       new-version: ${{ steps.bump.outputs.new-version }}
       tag: ${{ steps.bump.outputs.tag }}
@@ -116,14 +118,15 @@ jobs:
         run: |
           # Preflight both tarballs first so a registry/auth error on the new
           # core package is caught before the full SDK version is burned.
-          npm publish ./tarballs/sdk-js-core.tgz --access public --ignore-scripts --dry-run
-          npm publish ./tarballs/sdk-js.tgz --access public --ignore-scripts --dry-run
+          # --provenance attaches SLSA build provenance via OIDC (id-token: write).
+          npm publish ./tarballs/sdk-js-core.tgz --access public --ignore-scripts --provenance --dry-run
+          npm publish ./tarballs/sdk-js.tgz --access public --ignore-scripts --provenance --dry-run
 
           # Publish the new (less-proven) package first. If it fails the run
           # can be retried without leaving an orphan @grafana/sigil-sdk-js
           # release on npm.
-          npm publish ./tarballs/sdk-js-core.tgz --access public --ignore-scripts
-          npm publish ./tarballs/sdk-js.tgz --access public --ignore-scripts
+          npm publish ./tarballs/sdk-js-core.tgz --access public --ignore-scripts --provenance
+          npm publish ./tarballs/sdk-js.tgz --access public --ignore-scripts --provenance
 
   tag:
     if: ${{ !inputs.dry-run }}

--- a/.github/workflows/plugins-publish.yml
+++ b/.github/workflows/plugins-publish.yml
@@ -202,4 +202,5 @@ jobs:
       - name: Publish ${{ matrix.plugin }} to npm
         env:
           PLUGIN: ${{ matrix.plugin }}
-        run: npm publish "./tarballs/${PLUGIN}.tgz" --access public --ignore-scripts
+        # --provenance attaches SLSA build provenance via OIDC (id-token: write).
+        run: npm publish "./tarballs/${PLUGIN}.tgz" --access public --ignore-scripts --provenance

--- a/.github/workflows/python-sdks-publish.yml
+++ b/.github/workflows/python-sdks-publish.yml
@@ -187,6 +187,11 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: dist/sigil-sdk/
+          # PEP 740 attestations via OIDC (id-token: write). Default since
+          # v1.11.0; pin it explicitly so future action upgrades that flip the
+          # default would surface as a workflow change instead of a silent
+          # regression.
+          attestations: true
 
   publish-dependents:
     if: ${{ !inputs.dry-run }}
@@ -222,3 +227,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: dist/${{ matrix.package }}/
+          attestations: true


### PR DESCRIPTION
## Summary
This PR is focused, workflow-only changes that improve supply-chain signal and tighten least-privilege without changing publish behavior.

### npm publish — SLSA provenance
- `js-sdk-publish.yml`, `plugins-publish.yml`: pass `--provenance` to every `npm publish` invocation so the published tarballs carry SLSA build provenance attestations on the npm registry. OIDC trusted publishing was already configured (`id-token: write`, npm@^11.5.1, environment-gated jobs); only the flag was missing.
  - Covers `@grafana/sigil-sdk-js`, `@grafana/sigil-sdk-js-core`, `@grafana/sigil-pi`, `@grafana/sigil-opencode`.

### PyPI publish — PEP 740 attestations
- `python-sdks-publish.yml`: set `attestations: true` explicitly on `pypa/gh-action-pypi-publish`. It is the default since v1.11.0; pinning it keeps PEP 740 attestations from silently regressing if a future upgrade flips the default. Applies to `sigil-sdk` and all 11 provider/framework packages.

### Least-privilege tightening
- `go-sdk-tag.yml`: move `contents: write` / `id-token: write` from the top-level `permissions:` block down to the `tag` job. Top-level is now `{}` so any future job added to this workflow starts with zero permissions and must opt in explicitly.
- `js-sdk-publish.yml`: set explicit `permissions: contents: read` on the `build` job for parity with the other publish workflows.

### What this PR does **not** do
- Does not change credentials, environments' protection rules, or which secrets are mounted where.
- Does not touch tag-creation, version-bump, or PR-opening logic.
- Does not add an environment gate to the Java Maven Central publish job. That job authenticates to Vault via OIDC, and GitHub environments change the OIDC `sub` claim, so environment protection should be handled only alongside the corresponding Vault role update.
- Does not add attestations for .NET (NuGet) or Java (Maven) artifacts via `actions/attest-build-provenance` — those registries don't accept attestations yet, so it would be GH-only provenance. Worth a follow-up.

## Test plan
- [ ] CI green (workflow files are still valid YAML; nothing else touched).
- [ ] Dry-run the JS publish workflow on `workflow_dispatch` with `dry-run: true`; confirm the `npm publish --dry-run --provenance` step succeeds and reports the provenance generation lines.
- [ ] Dry-run the plugins publish workflow with `dry-run: true`.
- [ ] Dry-run the Python publish workflow with `dry-run: true` (the `publish-*` jobs are skipped on dry-run, so the `attestations: true` change is a no-op until the next real publish).
- [ ] Dry-run `go-sdk-tag.yml` with `dry-run: true`; confirm the `tag` job still mints the GitHub App token and runs.

Refs: grafana/sigil#1012, grafana/sigil#1002

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes; publish behavior and secrets are unchanged aside from enabling registry attestations that rely on existing OIDC setup.
> 
> **Overview**
> This PR tightens **GitHub Actions** supply-chain and permission posture for SDK/plugin publish workflows without changing release ordering or credentials.
> 
> **npm:** `js-sdk-publish.yml` and `plugins-publish.yml` now pass **`--provenance`** on all `npm publish` steps (including dry-run preflights), attaching **SLSA** build provenance via existing **OIDC** (`id-token: write`).
> 
> **PyPI:** `python-sdks-publish.yml` sets **`attestations: true`** explicitly on `pypa/gh-action-pypi-publish` for the core and dependent packages so **PEP 740** attestations stay on if the action default changes.
> 
> **Least privilege:** `go-sdk-tag.yml` clears workflow-level permissions (`permissions: {}`) and grants **`contents: write`** / **`id-token: write`** only on the **`tag`** job. `js-sdk-publish.yml` adds explicit **`contents: read`** on the **`build`** job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 479fbec75c02459f31e248316be71925b30e46c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->