### PR TITLE
feat(plugins/opencode): emit tool execution spans

### DIFF
--- a/plugins/opencode/src/hooks.otlp.test.ts
+++ b/plugins/opencode/src/hooks.otlp.test.ts
@@ -140,6 +140,22 @@ function opencodeMessageFixture() {
       type: "text",
       text: "hi",
     },
+    {
+      id: "assist-tool-1",
+      sessionID,
+      messageID,
+      type: "tool",
+      callID: "tc-otlp-1",
+      tool: "Bash",
+      state: {
+        status: "completed",
+        input: { command: "ls" },
+        output: "main.go",
+        title: "ls",
+        metadata: {},
+        time: { start: 1_700_000_001_500, end: 1_700_000_002_000 },
+      },
+    },
   ];
   return {
     sessionID,
@@ -225,6 +241,19 @@ describe("createSigilHooks OTLP wiring", () => {
       { sessionID },
       { message: userMessage as any, parts: userParts as any },
     );
+    await hooks.toolExecuteBefore(
+      { sessionID, callID: "tc-otlp-1", tool: "Bash" },
+      { args: { command: "ls" } },
+    );
+    hooks.toolExecuteAfter(
+      {
+        sessionID,
+        callID: "tc-otlp-1",
+        tool: "Bash",
+        args: { command: "ls" },
+      },
+      { title: "ls", output: "main.go", metadata: {} },
+    );
     await hooks.event({
       event: {
         type: "message.updated",
@@ -259,42 +288,85 @@ describe("createSigilHooks OTLP wiring", () => {
     }
 
     const traceScopes = new Set<string>();
+    type AttributeKV = {
+      key?: string;
+      value?: {
+        stringValue?: string;
+        intValue?: string | number;
+        doubleValue?: number;
+        boolValue?: boolean;
+      };
+    };
+    type Span = {
+      name?: string;
+      attributes?: AttributeKV[];
+    };
+    const spans: Span[] = [];
     for (const req of traceReqs) {
       const payload = JSON.parse(req.body) as {
         resourceSpans?: Array<{
-          scopeSpans?: Array<{ scope?: { name?: string } }>;
+          scopeSpans?: Array<{
+            scope?: { name?: string };
+            spans?: Span[];
+          }>;
         }>;
       };
       for (const rs of payload.resourceSpans ?? []) {
         for (const ss of rs.scopeSpans ?? []) {
           if (ss.scope?.name) traceScopes.add(ss.scope.name);
+          for (const sp of ss.spans ?? []) spans.push(sp);
         }
       }
     }
     expect(traceScopes.has(SIGIL_OPENCODE_SCOPE)).toBe(true);
 
+    const hasExecuteToolSpan = spans.some((sp) =>
+      sp.attributes?.some(
+        (a) =>
+          a.key === "gen_ai.operation.name" &&
+          a.value?.stringValue === "execute_tool",
+      ),
+    );
+    expect(hasExecuteToolSpan).toBe(true);
+
     let sawDurationMetric = false;
+    let sawExecuteToolDuration = false;
     for (const req of metricReqs) {
       const payload = JSON.parse(req.body) as {
         resourceMetrics?: Array<{
           scopeMetrics?: Array<{
             scope?: { name?: string };
-            metrics?: Array<{ name: string }>;
+            metrics?: Array<{
+              name: string;
+              histogram?: {
+                dataPoints?: Array<{
+                  attributes?: AttributeKV[];
+                }>;
+              };
+            }>;
           }>;
         }>;
       };
       for (const rm of payload.resourceMetrics ?? []) {
         for (const sm of rm.scopeMetrics ?? []) {
           if (sm.scope?.name !== SIGIL_OPENCODE_SCOPE) continue;
-          if (
-            sm.metrics?.some((m) => m.name === SIGIL_OPERATION_DURATION_METRIC)
-          ) {
+          for (const m of sm.metrics ?? []) {
+            if (m.name !== SIGIL_OPERATION_DURATION_METRIC) continue;
             sawDurationMetric = true;
+            for (const dp of m.histogram?.dataPoints ?? []) {
+              const op = dp.attributes?.find(
+                (a) => a.key === "gen_ai.operation.name",
+              );
+              if (op?.value?.stringValue === "execute_tool") {
+                sawExecuteToolDuration = true;
+              }
+            }
           }
         }
       }
     }
     expect(sawDurationMetric).toBe(true);
+    expect(sawExecuteToolDuration).toBe(true);
   });
 
   it("does not contact the OTLP endpoint when config.otlp is absent", async () => {

--- a/plugins/opencode/src/hooks.toolSpans.test.ts
+++ b/plugins/opencode/src/hooks.toolSpans.test.ts
@@ -1,0 +1,496 @@
+import { createServer, type Server } from "node:http";
+import type { SigilClient } from "@grafana/sigil-sdk-js";
+import type { Part } from "@opencode-ai/sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SigilOpencodeConfig } from "./config.js";
+import {
+  _peekToolExecutionState,
+  _resetToolExecutionState,
+  createSigilHooks,
+  emitToolSpans,
+  mergeToolSpanRecords,
+  type ToolExecutionRecord,
+  toolSpansFromParts,
+} from "./hooks.js";
+import { Redactor } from "./redact.js";
+
+function mockSigilClient() {
+  const recorders: Array<{
+    start: Record<string, unknown>;
+    result: Record<string, unknown> | undefined;
+    callError: unknown;
+    ended: boolean;
+  }> = [];
+
+  const client = {
+    startToolExecution: vi.fn((start: Record<string, unknown>) => {
+      const rec = {
+        start,
+        result: undefined as Record<string, unknown> | undefined,
+        callError: undefined as unknown,
+        ended: false,
+      };
+      recorders.push(rec);
+      return {
+        setResult: vi.fn((r: Record<string, unknown>) => {
+          rec.result = r;
+        }),
+        setCallError: vi.fn((e: unknown) => {
+          rec.callError = e;
+        }),
+        end: vi.fn(() => {
+          rec.ended = true;
+        }),
+        getError: vi.fn(() => undefined),
+      };
+    }),
+  } as unknown as SigilClient;
+
+  return { client, recorders };
+}
+
+function makeRecord(
+  overrides?: Partial<ToolExecutionRecord>,
+): ToolExecutionRecord {
+  return {
+    sessionID: "sess-1",
+    toolName: "Bash",
+    toolCallId: "call-1",
+    startedAt: 1_700_000_001_000,
+    completedAt: 1_700_000_002_000,
+    input: { command: "ls" },
+    output: "ok",
+    ...overrides,
+  };
+}
+
+const defaultOpts = () => ({
+  conversationId: "sess-1",
+  agentName: "opencode:build",
+  agentVersion: "test-version",
+  requestProvider: "anthropic",
+  requestModel: "claude-sonnet-4-opencode",
+  redactor: new Redactor(),
+  debugLog: () => {},
+});
+
+describe("emitToolSpans", () => {
+  it("does nothing when no records", () => {
+    const { client, recorders } = mockSigilClient();
+    emitToolSpans(client, [], {
+      ...defaultOpts(),
+      contentCapture: "metadata_only",
+    });
+    expect(recorders).toHaveLength(0);
+  });
+
+  it("creates a span per completed record with full context", () => {
+    const { client, recorders } = mockSigilClient();
+    emitToolSpans(
+      client,
+      [
+        makeRecord({ toolCallId: "c1", toolName: "Bash" }),
+        makeRecord({ toolCallId: "c2", toolName: "Read" }),
+      ],
+      { ...defaultOpts(), contentCapture: "metadata_only" },
+    );
+
+    expect(recorders).toHaveLength(2);
+    expect(recorders[0]!.start).toMatchObject({
+      toolName: "Bash",
+      toolCallId: "c1",
+      toolType: "function",
+      conversationId: "sess-1",
+      agentName: "opencode:build",
+      agentVersion: "test-version",
+      requestProvider: "anthropic",
+      requestModel: "claude-sonnet-4-opencode",
+    });
+    expect(recorders[1]!.start).toMatchObject({
+      toolName: "Read",
+      toolCallId: "c2",
+    });
+    expect(recorders.every((r) => r.ended)).toBe(true);
+  });
+
+  it("uses real start/end times", () => {
+    const { client, recorders } = mockSigilClient();
+    emitToolSpans(
+      client,
+      [makeRecord({ startedAt: 1000, completedAt: 5000 })],
+      { ...defaultOpts(), contentCapture: "metadata_only" },
+    );
+
+    expect(recorders[0]!.start).toMatchObject({ startedAt: new Date(1000) });
+    expect(recorders[0]!.result?.completedAt).toEqual(new Date(5000));
+  });
+
+  it("omits arguments and result in metadata_only", () => {
+    const { client, recorders } = mockSigilClient();
+    emitToolSpans(client, [makeRecord()], {
+      ...defaultOpts(),
+      contentCapture: "metadata_only",
+    });
+
+    expect(recorders[0]!.result?.arguments).toBeUndefined();
+    expect(recorders[0]!.result?.result).toBeUndefined();
+  });
+
+  it("omits arguments and result in no_tool_content", () => {
+    const { client, recorders } = mockSigilClient();
+    emitToolSpans(client, [makeRecord()], {
+      ...defaultOpts(),
+      contentCapture: "no_tool_content",
+    });
+
+    expect(recorders[0]!.result?.arguments).toBeUndefined();
+    expect(recorders[0]!.result?.result).toBeUndefined();
+  });
+
+  it("includes redacted arguments and result in full", () => {
+    const { client, recorders } = mockSigilClient();
+    emitToolSpans(
+      client,
+      [
+        makeRecord({
+          input: { command: "echo glc_abcdefghijklmnopqrstuv" },
+          output: "leaked glc_abcdefghijklmnopqrstuv done",
+        }),
+      ],
+      { ...defaultOpts(), contentCapture: "full" },
+    );
+
+    expect(recorders[0]!.result?.arguments).toBe(
+      '{"command":"echo [REDACTED:grafana-cloud-token]"}',
+    );
+    expect(recorders[0]!.result?.result).toBe(
+      "leaked [REDACTED:grafana-cloud-token] done",
+    );
+  });
+
+  it("marks error records with setCallError", () => {
+    const { client, recorders } = mockSigilClient();
+    emitToolSpans(client, [makeRecord({ isError: true, error: "boom" })], {
+      ...defaultOpts(),
+      contentCapture: "metadata_only",
+    });
+
+    expect(recorders[0]!.callError).toBeInstanceOf(Error);
+    expect((recorders[0]!.callError as Error).message).toBe("boom");
+  });
+
+  it("swallows SDK errors so a span failure does not break the plugin", () => {
+    const failing = {
+      startToolExecution: () => {
+        throw new Error("nope");
+      },
+    } as unknown as SigilClient;
+    expect(() =>
+      emitToolSpans(failing, [makeRecord()], {
+        ...defaultOpts(),
+        contentCapture: "metadata_only",
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("toolSpansFromParts", () => {
+  it("returns completed and error records with terminal timing", () => {
+    const parts: Part[] = [
+      {
+        id: "p1",
+        sessionID: "sess-1",
+        messageID: "m1",
+        type: "tool",
+        callID: "c1",
+        tool: "Bash",
+        state: {
+          status: "completed",
+          input: { command: "ls" },
+          output: "main.go",
+          title: "ls",
+          metadata: {},
+          time: { start: 100, end: 200 },
+        },
+      } as Part,
+      {
+        id: "p2",
+        sessionID: "sess-1",
+        messageID: "m1",
+        type: "tool",
+        callID: "c2",
+        tool: "Read",
+        state: {
+          status: "error",
+          input: { path: "/missing" },
+          error: "ENOENT",
+          time: { start: 300, end: 400 },
+        },
+      } as Part,
+      {
+        id: "p3",
+        sessionID: "sess-1",
+        messageID: "m1",
+        type: "tool",
+        callID: "c3",
+        tool: "Pending",
+        state: { status: "pending", input: {}, raw: "" },
+      } as Part,
+      {
+        id: "p4",
+        sessionID: "sess-1",
+        messageID: "m1",
+        type: "text",
+        text: "hello",
+      } as Part,
+    ];
+
+    const records = toolSpansFromParts("sess-1", parts);
+    expect(records).toEqual([
+      {
+        sessionID: "sess-1",
+        toolName: "Bash",
+        toolCallId: "c1",
+        startedAt: 100,
+        completedAt: 200,
+        input: { command: "ls" },
+        output: "main.go",
+      },
+      {
+        sessionID: "sess-1",
+        toolName: "Read",
+        toolCallId: "c2",
+        startedAt: 300,
+        completedAt: 400,
+        input: { path: "/missing" },
+        isError: true,
+        error: "ENOENT",
+      },
+    ]);
+  });
+});
+
+describe("mergeToolSpanRecords", () => {
+  it("prefers terminal records, keeps unique hook records", () => {
+    const term = [
+      makeRecord({ toolCallId: "c1", startedAt: 1, completedAt: 2 }),
+    ];
+    const hook = [
+      makeRecord({ toolCallId: "c1", startedAt: 10, completedAt: 20 }),
+      makeRecord({ toolCallId: "c2", startedAt: 30, completedAt: 40 }),
+    ];
+
+    const merged = mergeToolSpanRecords(term, hook);
+    expect(merged).toHaveLength(2);
+    expect(merged[0]).toMatchObject({
+      toolCallId: "c1",
+      startedAt: 1,
+      completedAt: 2,
+    });
+    expect(merged[1]).toMatchObject({
+      toolCallId: "c2",
+      startedAt: 30,
+      completedAt: 40,
+    });
+  });
+
+  it("scopes the dedup key by session", () => {
+    const term = [makeRecord({ sessionID: "sess-a", toolCallId: "shared" })];
+    const hook = [
+      makeRecord({ sessionID: "sess-b", toolCallId: "shared", startedAt: 99 }),
+    ];
+
+    const merged = mergeToolSpanRecords(term, hook);
+    expect(merged).toHaveLength(2);
+  });
+});
+
+function startResponseServer(
+  response: Record<string, unknown>,
+): Promise<{ server: Server; baseUrl: string }> {
+  return new Promise((resolve) => {
+    const server = createServer((_req, res) => {
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify(response));
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        throw new Error("expected AddressInfo from server.address()");
+      }
+      resolve({ server, baseUrl: `http://127.0.0.1:${addr.port}` });
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+describe("hook lifecycle records and guard denial", () => {
+  const servers: Server[] = [];
+
+  beforeEach(() => {
+    _resetToolExecutionState();
+  });
+
+  afterEach(async () => {
+    await Promise.all(servers.splice(0).map(closeServer));
+    _resetToolExecutionState();
+  });
+
+  it("toolExecuteBefore/After move an active record into completed", async () => {
+    const config: SigilOpencodeConfig = {
+      endpoint: "http://127.0.0.1:1",
+      auth: { mode: "none" },
+      agentName: "opencode",
+      agentVersion: "test-version",
+      contentCapture: "full",
+      debug: false,
+      // guards disabled, so the before hook just records timing.
+    };
+
+    const hooks = await createSigilHooks(config, {
+      session: { message: async () => ({ data: { parts: [] } }) },
+    } as never);
+    if (!hooks) throw new Error("expected hooks");
+
+    await hooks.toolExecuteBefore(
+      { sessionID: "sess-1", callID: "call-1", tool: "Bash" },
+      { args: { command: "ls" } },
+    );
+
+    expect(_peekToolExecutionState().active).toHaveLength(1);
+
+    hooks.toolExecuteAfter(
+      {
+        sessionID: "sess-1",
+        callID: "call-1",
+        tool: "Bash",
+        args: { command: "ls" },
+      },
+      { title: "ls", output: "main.go", metadata: {} },
+    );
+
+    const peeked = _peekToolExecutionState();
+    expect(peeked.active).toHaveLength(0);
+    expect(peeked.completed).toHaveLength(1);
+    expect(peeked.completed[0]).toMatchObject({
+      sessionID: "sess-1",
+      toolCallId: "call-1",
+      toolName: "Bash",
+      input: { command: "ls" },
+      output: "main.go",
+    });
+    expect(peeked.completed[0]!.completedAt).toBeGreaterThan(0);
+  });
+
+  it("clears the active record when the guard denies the tool", async () => {
+    const guardSrv = await startResponseServer({
+      action: "deny",
+      reason: "blocked",
+      evaluations: [],
+    });
+    servers.push(guardSrv.server);
+
+    const config: SigilOpencodeConfig = {
+      endpoint: guardSrv.baseUrl,
+      auth: { mode: "none" },
+      agentName: "opencode",
+      agentVersion: "test-version",
+      contentCapture: "full",
+      debug: false,
+      guards: { enabled: true, timeoutMs: 1500, failOpen: false },
+    };
+
+    const hooks = await createSigilHooks(config, {
+      session: { message: async () => ({ data: { parts: [] } }) },
+    } as never);
+    if (!hooks) throw new Error("expected hooks");
+
+    await expect(
+      hooks.toolExecuteBefore(
+        { sessionID: "sess-1", callID: "call-1", tool: "Bash" },
+        { args: { command: "ls" } },
+      ),
+    ).rejects.toThrow("blocked");
+
+    expect(_peekToolExecutionState().active).toHaveLength(0);
+
+    // The after hook for a denied call should be a no-op since the active
+    // record was already cleared.
+    hooks.toolExecuteAfter(
+      {
+        sessionID: "sess-1",
+        callID: "call-1",
+        tool: "Bash",
+        args: { command: "ls" },
+      },
+      { title: "ls", output: "ignored", metadata: {} },
+    );
+    expect(_peekToolExecutionState().completed).toHaveLength(0);
+
+    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+  });
+
+  it("clears active and completed records on session.deleted", async () => {
+    const config: SigilOpencodeConfig = {
+      endpoint: "http://127.0.0.1:1",
+      auth: { mode: "none" },
+      agentName: "opencode",
+      agentVersion: "test-version",
+      contentCapture: "full",
+      debug: false,
+    };
+
+    const hooks = await createSigilHooks(config, {
+      session: { message: async () => ({ data: { parts: [] } }) },
+    } as never);
+    if (!hooks) throw new Error("expected hooks");
+
+    // Active record for sess-1.
+    await hooks.toolExecuteBefore(
+      { sessionID: "sess-1", callID: "call-1", tool: "Bash" },
+      { args: { command: "ls" } },
+    );
+    // Completed record for sess-1.
+    await hooks.toolExecuteBefore(
+      { sessionID: "sess-1", callID: "call-2", tool: "Read" },
+      { args: { path: "/x" } },
+    );
+    hooks.toolExecuteAfter(
+      {
+        sessionID: "sess-1",
+        callID: "call-2",
+        tool: "Read",
+        args: { path: "/x" },
+      },
+      { title: "/x", output: "ok", metadata: {} },
+    );
+    // Active record for an unrelated session that must survive cleanup.
+    await hooks.toolExecuteBefore(
+      { sessionID: "sess-2", callID: "call-3", tool: "Bash" },
+      { args: { command: "pwd" } },
+    );
+
+    expect(_peekToolExecutionState().active).toHaveLength(2);
+    expect(_peekToolExecutionState().completed).toHaveLength(1);
+
+    await hooks.event({
+      event: {
+        type: "session.deleted",
+        properties: { info: { id: "sess-1" } },
+      },
+    });
+
+    const peeked = _peekToolExecutionState();
+    expect(peeked.completed).toHaveLength(0);
+    expect(peeked.active).toHaveLength(1);
+    expect(peeked.active[0]).toMatchObject({
+      sessionID: "sess-2",
+      toolCallId: "call-3",
+    });
+  });
+});

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { SigilClient } from "@grafana/sigil-sdk-js";
+import type { ContentCaptureMode, SigilClient } from "@grafana/sigil-sdk-js";
 import type { PluginInput } from "@opencode-ai/plugin";
 import type {
   AssistantMessage,
@@ -35,6 +35,46 @@ type SessionContext = {
   model: { provider: string; name: string } | undefined;
 };
 const sessionContexts = new Map<string, SessionContext>();
+
+export type ToolExecutionRecord = {
+  sessionID: string;
+  toolName: string;
+  toolCallId: string;
+  startedAt: number;
+  completedAt: number;
+  input?: unknown;
+  output?: unknown;
+  isError?: boolean;
+  error?: string;
+};
+
+const activeToolExecutions = new Map<string, ToolExecutionRecord>();
+const completedToolExecutions = new Map<string, ToolExecutionRecord[]>();
+
+function toolExecutionKey(sessionID: string, callID: string): string {
+  return `${sessionID}\x00${callID}`;
+}
+
+/** @internal Exported for testing. */
+export function _resetToolExecutionState(): void {
+  activeToolExecutions.clear();
+  completedToolExecutions.clear();
+}
+
+/** @internal Exported for testing. */
+export function _peekToolExecutionState(): {
+  active: ToolExecutionRecord[];
+  completed: ToolExecutionRecord[];
+} {
+  const completed: ToolExecutionRecord[] = [];
+  for (const list of completedToolExecutions.values()) {
+    completed.push(...list);
+  }
+  return {
+    active: Array.from(activeToolExecutions.values()),
+    completed,
+  };
+}
 
 type MessageUpdatedInfo = Partial<AssistantMessage> & {
   id?: string;
@@ -240,16 +280,39 @@ async function recordAssistantMessage(
     config.contentCapture,
   );
 
+  // Span records prefer terminal `ToolPart.state.time` when assistant parts
+  // are already available. `assistantParts` is empty in `metadata_only` (we
+  // intentionally skip the REST fetch there), so hook records take over and
+  // give us per-tool spans without forcing a body fetch.
+  const termRecords = toolSpansFromParts(
+    assistantMsg.sessionID,
+    assistantParts,
+  );
+  const hookRecords = completedToolExecutions.get(assistantMsg.sessionID) ?? [];
+  const spanRecords = mergeToolSpanRecords(termRecords, hookRecords);
+  const spanOpts = {
+    conversationId: assistantMsg.sessionID,
+    agentName: buildAgentName(config.agentName, assistantMsg.mode),
+    agentVersion: config.agentVersion,
+    requestProvider: assistantMsg.providerID,
+    requestModel: assistantMsg.modelID,
+    contentCapture: config.contentCapture,
+    redactor,
+    debugLog,
+  };
+
   try {
     if (assistantMsg.error) {
       const error = assistantMsg.error;
       await sigil.startGeneration(seed, async (recorder) => {
         recorder.setResult(result);
         recorder.setCallError(mapError(error));
+        emitToolSpans(sigil, spanRecords, spanOpts);
       });
     } else {
       await sigil.startGeneration(seed, async (recorder) => {
         recorder.setResult(result);
+        emitToolSpans(sigil, spanRecords, spanOpts);
       });
     }
   } catch (err) {
@@ -257,8 +320,11 @@ async function recordAssistantMessage(
     // Sigil recording failure should never break the plugin
   }
 
-  // Clean up pending generation
+  // Clean up pending generation and per-turn tool records. The completed
+  // records were consumed above; clearing them prevents duplicate spans if
+  // another export path fires for the same session.
   pendingGenerations.delete(assistantMsg.sessionID);
+  completedToolExecutions.delete(assistantMsg.sessionID);
 }
 
 async function sweepTerminalAssistantMessages(
@@ -341,10 +407,18 @@ async function handleLifecycle(
       recordedMessages.delete(sessionId);
       pendingGenerations.delete(sessionId);
       sessionContexts.delete(sessionId);
+      completedToolExecutions.delete(sessionId);
+      for (const key of activeToolExecutions.keys()) {
+        if (key.startsWith(`${sessionId}\x00`)) {
+          activeToolExecutions.delete(key);
+        }
+      }
     }
   }
 
   if (type === "global.disposed") {
+    activeToolExecutions.clear();
+    completedToolExecutions.clear();
     try {
       await sigil.shutdown();
     } catch {
@@ -366,6 +440,16 @@ async function handleToolExecuteBefore(
   input: { tool: string; sessionID: string; callID: string },
   output: { args: unknown },
 ): Promise<void> {
+  const key = toolExecutionKey(input.sessionID, input.callID);
+  activeToolExecutions.set(key, {
+    sessionID: input.sessionID,
+    toolName: input.tool,
+    toolCallId: input.callID,
+    startedAt: Date.now(),
+    completedAt: 0,
+    input: output.args,
+  });
+
   const guards = config.guards;
   if (guards?.enabled !== true) return;
   const res = await runToolCallGuard({
@@ -379,8 +463,28 @@ async function handleToolExecuteBefore(
     failOpen: guards.failOpen,
   });
   if (res?.block) {
+    activeToolExecutions.delete(key);
     throw new Error(res.reason);
   }
+}
+
+function handleToolExecuteAfter(
+  input: { tool: string; sessionID: string; callID: string; args: unknown },
+  output: { title: string; output: string; metadata: unknown },
+): void {
+  const key = toolExecutionKey(input.sessionID, input.callID);
+  const active = activeToolExecutions.get(key);
+  if (!active) return;
+  activeToolExecutions.delete(key);
+
+  const completed: ToolExecutionRecord = {
+    ...active,
+    completedAt: Date.now(),
+    output: output.output,
+  };
+  const list = completedToolExecutions.get(input.sessionID) ?? [];
+  list.push(completed);
+  completedToolExecutions.set(input.sessionID, list);
 }
 
 async function handlePermissionAsk(
@@ -469,6 +573,138 @@ function stringField(value: unknown, key: string): string | undefined {
     : undefined;
 }
 
+/**
+ * Extract completed/error tool execution records from already-fetched
+ * terminal assistant parts. Persisted `ToolPart.state.time.start/end` is
+ * more accurate than hook wall-clock timing, so prefer this when parts are
+ * available.
+ *
+ * @internal Exported for testing.
+ */
+export function toolSpansFromParts(
+  sessionID: string,
+  parts: Part[],
+): ToolExecutionRecord[] {
+  const records: ToolExecutionRecord[] = [];
+  for (const part of parts) {
+    if (part.type !== "tool") continue;
+    const { state } = part;
+    if (state.status === "completed") {
+      records.push({
+        sessionID,
+        toolName: part.tool,
+        toolCallId: part.callID,
+        startedAt: state.time.start,
+        completedAt: state.time.end,
+        input: state.input,
+        output: state.output,
+      });
+    } else if (state.status === "error") {
+      records.push({
+        sessionID,
+        toolName: part.tool,
+        toolCallId: part.callID,
+        startedAt: state.time.start,
+        completedAt: state.time.end,
+        input: state.input,
+        isError: true,
+        error: state.error,
+      });
+    }
+  }
+  return records;
+}
+
+/**
+ * Merge tool execution records from terminal `ToolPart` values with
+ * hook-recorded records, preferring terminal-part timing and state. Hook
+ * records survive only when the terminal parts don't already cover them.
+ *
+ * @internal Exported for testing.
+ */
+export function mergeToolSpanRecords(
+  termRecords: ToolExecutionRecord[],
+  hookRecords: ToolExecutionRecord[],
+): ToolExecutionRecord[] {
+  const merged: ToolExecutionRecord[] = [...termRecords];
+  const seen = new Set(
+    termRecords.map((r) => toolExecutionKey(r.sessionID, r.toolCallId)),
+  );
+  for (const rec of hookRecords) {
+    const key = toolExecutionKey(rec.sessionID, rec.toolCallId);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(rec);
+  }
+  return merged;
+}
+
+/**
+ * Emit Sigil tool execution spans for a set of completed tool records.
+ * Errors thrown by the SDK are swallowed so a span failure cannot break
+ * the plugin.
+ *
+ * @internal Exported for testing.
+ */
+export function emitToolSpans(
+  client: SigilClient,
+  records: ToolExecutionRecord[],
+  opts: {
+    conversationId: string;
+    agentName: string;
+    agentVersion?: string;
+    requestProvider: string;
+    requestModel: string;
+    contentCapture: ContentCaptureMode;
+    redactor: Redactor;
+    debugLog: (msg: string, ...args: unknown[]) => void;
+  },
+): void {
+  if (records.length === 0) return;
+  const includeContent = opts.contentCapture === "full";
+
+  for (const record of records) {
+    try {
+      const rec = client.startToolExecution({
+        toolName: record.toolName,
+        toolCallId: record.toolCallId,
+        toolType: "function",
+        conversationId: opts.conversationId,
+        agentName: opts.agentName,
+        agentVersion: opts.agentVersion,
+        requestProvider: opts.requestProvider,
+        requestModel: opts.requestModel,
+        startedAt: new Date(record.startedAt),
+        contentCapture: opts.contentCapture,
+      });
+
+      if (record.isError) {
+        rec.setCallError(new Error(record.error || "tool returned error"));
+      }
+
+      const end: {
+        arguments?: unknown;
+        result?: unknown;
+        completedAt: Date;
+      } = {
+        completedAt: new Date(record.completedAt),
+      };
+
+      if (includeContent && record.input !== undefined) {
+        end.arguments = opts.redactor.redact(JSON.stringify(record.input));
+      }
+      if (includeContent && record.output !== undefined) {
+        end.result = opts.redactor.redact(String(record.output));
+      }
+
+      rec.setResult(end);
+      rec.end();
+    } catch (err) {
+      opts.debugLog(`tool span export failed for ${record.toolName}`, err);
+    }
+  }
+}
+
 export type SigilHooks = {
   event: (input: {
     event: { type: string; properties: unknown };
@@ -485,6 +721,10 @@ export type SigilHooks = {
     input: { tool: string; sessionID: string; callID: string },
     output: { args: unknown },
   ) => Promise<void>;
+  toolExecuteAfter: (
+    input: { tool: string; sessionID: string; callID: string; args: unknown },
+    output: { title: string; output: string; metadata: unknown },
+  ) => void;
   permissionAsk: (
     input: Permission,
     output: { status: "ask" | "deny" | "allow" },
@@ -552,6 +792,9 @@ export async function createSigilHooks(
     },
     toolExecuteBefore: async (input, output) => {
       await handleToolExecuteBefore(sigil, config, input, output);
+    },
+    toolExecuteAfter: (input, output) => {
+      handleToolExecuteAfter(input, output);
     },
     permissionAsk: async (input, output) => {
       await handlePermissionAsk(sigil, config, input, output);

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -21,6 +21,9 @@ export const SigilPlugin: Plugin = async ({ client }) => {
     "tool.execute.before": async (input, output) => {
       await hooks.toolExecuteBefore(input, output);
     },
+    "tool.execute.after": async (input, output) => {
+      hooks.toolExecuteAfter(input, output);
+    },
     "permission.ask": async (input, output) => {
       await hooks.permissionAsk(input, output);
     },


### PR DESCRIPTION
Track tool calls through `tool.execute.before`/`tool.execute.after` hooks and emit one `execute_tool` span per completed or errored call alongside the existing generation span. When terminal `ToolPart.state.time` is available the persisted timing wins over the hook wall clock.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches observability and in-memory session state around tool hooks and generation export; failures are isolated but timing/content behavior depends on content capture mode and guard outcomes.
> 
> **Overview**
> Adds **per-tool `execute_tool` telemetry** to the OpenCode Sigil plugin by wiring **`tool.execute.after`**, tracking in-flight calls in **`tool.execute.before`**, and emitting spans when a terminal assistant message is exported.
> 
> Hook timing is stored per session and merged with completed/errored **`ToolPart`** records (persisted **`state.time`** wins on dedup) so spans still appear in **`metadata_only`** without fetching message bodies. **`emitToolSpans`** respects **`contentCapture`** (metadata vs redacted full I/O), marks tool errors, and swallows SDK failures so observability cannot break the plugin. Session delete / guard deny / global dispose clear state to avoid leaks or duplicate spans.
> 
> Tests cover span emission, merge/dedup, hook lifecycle, guard denial, OTLP **`execute_tool`** traces and duration metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff864af03187c488dad3ebc81c4af08beaf52879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->