### PR TITLE
docs: document agent_version performance requirement

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -143,6 +143,7 @@ Return:
   - non-stream: `SYNC`
   - stream: `STREAM`
 - Raw provider artifacts are default OFF and only enabled for explicit debug opt-in.
+- Set stable `agent_name` and `agent_version` on generations and framework handlers. `agent_version` is optional for generation ingest, but it is required for version-level Performance charts because Sigil joins Prometheus metrics by the SDK-emitted `gen_ai.agent.version` label.
 
 ## OTel setup (required)
 
@@ -253,7 +254,7 @@ On generation and tool spans, capture or preserve these when available:
   - `sigil.generation.id`
   - `gen_ai.conversation.id`
   - `gen_ai.agent.name`
-  - `gen_ai.agent.version`
+  - `gen_ai.agent.version` — required for per-version Performance charts; set SDK `agent_version`
   - `sigil.generation.parent_generation_ids`
   - `sigil.sdk.name`
 - model:
@@ -364,6 +365,7 @@ from sigil_sdk_langgraph import SigilLangGraphHandler
 handler = SigilLangGraphHandler(
     client=client,
     agent_name="my-pipeline",
+    agent_version="1.0.0",
     conversation_title="Incident Response Pipeline",
     capture_workflow_steps=True,
 )


### PR DESCRIPTION
## Summary
- Document that `agent_version` is optional for ingest but required for version-level Performance charts.
- Mark `gen_ai.agent.version` as the SDK field that enables per-version Performance views.
- Add `agent_version="1.0.0"` to the LangGraph instrumentation example.

## Test plan
- [x] `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to llms.txt with no runtime or API behavior changes.
> 
> **Overview**
> Documentation in **`llms.txt`** clarifies how **`agent_version`** relates to Grafana AI observability Performance views.
> 
> The ingest architecture section now states that **`agent_version`** is optional for generation ingest but **required for version-level Performance charts**, because Sigil joins Prometheus metrics on the SDK **`gen_ai.agent.version`** label. The telemetry field list calls out the same requirement and points readers to SDK **`agent_version`**. The LangGraph **`SigilLangGraphHandler`** example adds **`agent_version="1.0.0"`** so the sample matches that guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fa8af20413bc081cc9aa72259bee319b249c5b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->