### PR TITLE
feat(plugins/pi): emit deterministic generation IDs and parent links

### DIFF
--- a/plugins/pi/src/golden.test.ts
+++ b/plugins/pi/src/golden.test.ts
@@ -256,14 +256,31 @@ describe("pi plugin: real-SDK golden export", () => {
     const pi = new FakePi();
     registerExtension(pi as any);
 
+    const { userMsg, assistantMsg, toolResult } = piTurnFixture();
+
+    // Static session branch matching the fixture: user u1 -> assistant a1.
+    // Lineage resolution hashes (conversationId, entry id) so the
+    // generation id in the golden stays stable across runs.
     const ctx = {
       sessionManager: {
         getSessionFile: () => "pi-session.jsonl",
         getSessionId: () => "pi-conv-1",
+        getBranch: () => [
+          {
+            type: "message",
+            id: "u1",
+            parentId: null,
+            message: userMsg,
+          },
+          {
+            type: "message",
+            id: "a1",
+            parentId: "u1",
+            message: assistantMsg,
+          },
+        ],
       },
     };
-
-    const { userMsg, assistantMsg, toolResult } = piTurnFixture();
 
     await pi.emit("session_start", {}, ctx);
     await pi.emit("turn_start", {}, ctx);
@@ -404,8 +421,11 @@ const normalizeFields: Record<string, string> = {
 
 const normalizeKeySuffixes = [".started_at", ".completed_at", ".timestamp"];
 
-// generated-ID prefixes whose values look like `gen-<random>` and need
-// scrubbing. Pi's generation IDs are issued by the JS SDK at enqueue time.
+// Generated-ID prefixes whose values look like `<prefix>-<random>` and need
+// scrubbing. The SDK assigns `gen-*` when a producer-supplied id is absent
+// and `span-*`/`trace-*` from the OTel SDK. Pi's deterministic `pi-*` ids
+// are intentionally NOT scrubbed: they are stable per conversationId +
+// session entry id, so they should remain visible in the golden fixture.
 const idPrefixes = ["gen-", "span-", "trace-"];
 
 function normalizeAny(value: unknown): unknown {
@@ -429,7 +449,9 @@ function normalizeAny(value: unknown): unknown {
       }
       if (matched) continue;
       // The SDK assigns a generation `id` if the producer didn't set one.
-      // Pi does not pass an explicit ID, so the field is dynamic.
+      // Pi sets a deterministic `pi-*` id from the session branch when
+      // available; only random-prefixed ids (gen-/span-/trace-) are
+      // scrubbed so the pi-* id stays visible in the golden.
       if (
         k === "id" &&
         typeof v === "string" &&

--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -2182,6 +2182,266 @@ describe("extension lifecycle", () => {
       expect(seeds[0]!.toolChoice).toBe("tool:search");
     });
   });
+
+  describe("generation lineage", () => {
+    function setupClient() {
+      const seeds: Array<{
+        id?: string;
+        parentGenerationIds?: string[];
+      }> = [];
+      const recorder = {
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        setFirstTokenAt: vi.fn(),
+      };
+      const sigil: SigilLike = {
+        startStreamingGeneration: vi.fn(async (seed, run) => {
+          seeds.push(seed as { id?: string; parentGenerationIds?: string[] });
+          await run(recorder);
+        }),
+        startToolExecution: vi.fn(() => ({
+          setResult: vi.fn(),
+          setCallError: vi.fn(),
+          end: vi.fn(),
+          getError: vi.fn(),
+        })),
+        shutdown: vi.fn(async () => {}),
+      };
+      return { sigil, seeds };
+    }
+
+    // ctxWithBranch is a fake ReadonlySessionManager that returns a static
+    // session branch. We track which assistant entry each turn_end should
+    // hit by swapping a shared `currentMessage` reference between turns,
+    // mirroring how the real pi runtime appends entries to the tree.
+    function ctxWithBranch(
+      sessionId: string,
+      branch: Array<{
+        type: string;
+        id: string;
+        parentId: string | null;
+        message?: { role: string } | null;
+      }>,
+    ) {
+      return {
+        sessionManager: {
+          getSessionFile: () => "pi-session.jsonl",
+          getSessionId: () => sessionId,
+          getBranch: () => branch,
+        },
+      };
+    }
+
+    it("emits deterministic pi-* generation id when branch data is available", async () => {
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const msg = assistantMessage();
+      const ctx = ctxWithBranch("pi-conv-1", [
+        {
+          type: "message",
+          id: "u1",
+          parentId: null,
+          message: { role: "user" },
+        },
+        {
+          type: "message",
+          id: "a1",
+          parentId: "u1",
+          message: msg,
+        },
+      ]);
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: msg, toolResults: [] }, ctx);
+
+      expect(seeds).toHaveLength(1);
+      expect(seeds[0]!.id).toMatch(/^pi-[a-f0-9]{24}$/);
+      // First assistant turn — no parent.
+      expect(seeds[0]!.parentGenerationIds).toBeUndefined();
+    });
+
+    it("is stable across re-exports of the same conversationId + session entry", async () => {
+      // Re-running the export pipeline against the same session state
+      // (same conversationId, same assistant entry id) must produce the
+      // same generation id. This is what makes the dependency graph robust
+      // to retries.
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const msg = assistantMessage();
+      const branch = [
+        {
+          type: "message",
+          id: "u1",
+          parentId: null,
+          message: { role: "user" },
+        },
+        {
+          type: "message",
+          id: "a1",
+          parentId: "u1",
+          message: msg,
+        },
+      ];
+
+      const piA = new FakePi();
+      registerExtension(piA as any);
+      const ctxA = ctxWithBranch("pi-conv-1", branch);
+      await piA.emit("session_start", {}, ctxA);
+      await piA.emit("turn_start", {}, ctxA);
+      await piA.emit("turn_end", { message: msg, toolResults: [] }, ctxA);
+
+      const piB = new FakePi();
+      registerExtension(piB as any);
+      const ctxB = ctxWithBranch("pi-conv-1", branch);
+      await piB.emit("session_start", {}, ctxB);
+      await piB.emit("turn_start", {}, ctxB);
+      await piB.emit("turn_end", { message: msg, toolResults: [] }, ctxB);
+
+      expect(seeds).toHaveLength(2);
+      expect(seeds[0]!.id).toBe(seeds[1]!.id);
+    });
+
+    it("links a second assistant turn to the first one on the same branch", async () => {
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const msg1 = assistantMessage();
+      const msg2 = assistantMessage();
+      // Branch grows as turns proceed: turn 1 sees only [u1, a1]; turn 2
+      // sees [u1, a1, u2, a2]. Encode this with a closure-backed branch.
+      let branch: Array<{
+        type: string;
+        id: string;
+        parentId: string | null;
+        message?: { role: string } | null;
+      }> = [
+        {
+          type: "message",
+          id: "u1",
+          parentId: null,
+          message: { role: "user" },
+        },
+        { type: "message", id: "a1", parentId: "u1", message: msg1 },
+      ];
+      const ctx = {
+        sessionManager: {
+          getSessionFile: () => "pi-session.jsonl",
+          getSessionId: () => "pi-conv-2",
+          getBranch: () => branch,
+        },
+      };
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: msg1, toolResults: [] }, ctx);
+
+      // Pi appends the user message and assistant response to the tree as
+      // turn 2 progresses.
+      branch = [
+        ...branch,
+        {
+          type: "message",
+          id: "u2",
+          parentId: "a1",
+          message: { role: "user" },
+        },
+        { type: "message", id: "a2", parentId: "u2", message: msg2 },
+      ];
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: msg2, toolResults: [] }, ctx);
+
+      expect(seeds).toHaveLength(2);
+      expect(seeds[0]!.id).toMatch(/^pi-[a-f0-9]{24}$/);
+      expect(seeds[1]!.id).toMatch(/^pi-[a-f0-9]{24}$/);
+      expect(seeds[0]!.id).not.toBe(seeds[1]!.id);
+
+      // Turn 1 is the first assistant on the branch — no parent.
+      expect(seeds[0]!.parentGenerationIds).toBeUndefined();
+      // Turn 2 points back to turn 1.
+      expect(seeds[1]!.parentGenerationIds).toEqual([seeds[0]!.id]);
+    });
+
+    it("omits lineage fields when getBranch is unavailable (older pi)", async () => {
+      // Older pi runtimes do not expose getBranch on ReadonlySessionManager;
+      // the plugin must not set id or parentGenerationIds so the SDK keeps
+      // its random `gen-*` fallback behavior.
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      // defaultCtx has no getBranch.
+      await pi.emit("session_start");
+      await pi.emit("turn_start");
+      await pi.emit("turn_end", {
+        message: assistantMessage(),
+        toolResults: [],
+      });
+
+      expect(seeds).toHaveLength(1);
+      expect(seeds[0]!.id).toBeUndefined();
+      expect(seeds[0]!.parentGenerationIds).toBeUndefined();
+    });
+
+    it("omits lineage when conversationId is empty", async () => {
+      // No conversationId (no-session mode): we cannot hash a stable id.
+      const { sigil, seeds } = setupClient();
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const msg = assistantMessage();
+      const ctx = ctxWithBranch("", [
+        { type: "message", id: "a1", parentId: null, message: msg },
+      ]);
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: msg, toolResults: [] }, ctx);
+
+      expect(seeds[0]!.id).toBeUndefined();
+      expect(seeds[0]!.parentGenerationIds).toBeUndefined();
+    });
+  });
 });
 
 // --- Unit tests for emitToolSpans ---

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -11,6 +11,7 @@ import { loadConfig } from "./config.js";
 import { detectPiVersion } from "./detectPiVersion.js";
 import { resolveGitBranch } from "./git.js";
 import { runToolCallGuard } from "./guard.js";
+import { resolvePiGenerationLineage } from "./lineage.js";
 import {
   type CachedRequestControls,
   extractRequestControls,
@@ -377,6 +378,18 @@ export default function (pi: ExtensionAPI) {
           : undefined;
       const builtinTags = gitBranch ? { "git.branch": gitBranch } : undefined;
 
+      // Resolve lineage at `turn_end`, not `message_end`: pi awaits
+      // extension `message_end` callbacks *before* calling
+      // `sessionManager.appendMessage` (see agent-session.js `_publish`),
+      // so the assistant entry is not yet in the tree at that point. By
+      // `turn_end` it has been appended and any subsequent extension
+      // mutations have settled.
+      const lineage = resolvePiGenerationLineage(
+        ctx.sessionManager,
+        msg,
+        conversationId,
+      );
+
       const seed = mapGenerationStart(msg, {
         conversationId,
         agentName: config.agentName,
@@ -386,6 +399,8 @@ export default function (pi: ExtensionAPI) {
         tags: builtinTags,
         systemPrompt: currentSystemPrompt,
         requestControls: currentRequestControls,
+        generationId: lineage.generationId,
+        parentGenerationIds: lineage.parentGenerationIds,
       });
 
       const toolResults = (event.toolResults ?? []) as PiToolResult[];

--- a/plugins/pi/src/lineage.test.ts
+++ b/plugins/pi/src/lineage.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolvePiGenerationLineage,
+  type SessionEntryLike,
+  stablePiGenerationId,
+} from "./lineage.js";
+
+function assistantEntry(
+  id: string,
+  parentId: string | null,
+  message: unknown = { role: "assistant" },
+): SessionEntryLike {
+  return {
+    type: "message",
+    id,
+    parentId,
+    message: message as { role?: string },
+  };
+}
+
+function userEntry(id: string, parentId: string | null): SessionEntryLike {
+  return {
+    type: "message",
+    id,
+    parentId,
+    message: { role: "user" },
+  };
+}
+
+function nonMessageEntry(
+  id: string,
+  parentId: string | null,
+): SessionEntryLike {
+  // e.g. thinking_level_change, model_change, compaction. Lineage must
+  // ignore these and follow the parent chain through them.
+  return { type: "model_change", id, parentId };
+}
+
+describe("stablePiGenerationId", () => {
+  it("produces a pi-prefixed 24-char hex suffix", () => {
+    const id = stablePiGenerationId("pi-conv-1", "entry-a");
+    expect(id).toMatch(/^pi-[a-f0-9]{24}$/);
+  });
+
+  it("is stable for the same inputs", () => {
+    const a = stablePiGenerationId("pi-conv-1", "entry-a");
+    const b = stablePiGenerationId("pi-conv-1", "entry-a");
+    expect(a).toBe(b);
+  });
+
+  it("differs when conversationId differs", () => {
+    expect(stablePiGenerationId("pi-conv-1", "entry-a")).not.toBe(
+      stablePiGenerationId("pi-conv-2", "entry-a"),
+    );
+  });
+
+  it("differs when entryId differs", () => {
+    expect(stablePiGenerationId("pi-conv-1", "entry-a")).not.toBe(
+      stablePiGenerationId("pi-conv-1", "entry-b"),
+    );
+  });
+
+  it("treats conversationId\\0entryId as distinct from entryId\\0conversationId", () => {
+    // Sanity: the NUL-separated hash is order-sensitive so we don't end up
+    // colliding when ids and conversation ids share a value space.
+    expect(stablePiGenerationId("a", "b")).not.toBe(
+      stablePiGenerationId("b", "a"),
+    );
+  });
+});
+
+describe("resolvePiGenerationLineage", () => {
+  it("returns empty when conversationId is missing", () => {
+    const sm = {
+      getBranch: () => [assistantEntry("a", null)],
+    };
+    expect(
+      resolvePiGenerationLineage(sm, sm.getBranch()[0]!.message, undefined),
+    ).toEqual({});
+  });
+
+  it("returns empty when sessionManager is missing", () => {
+    expect(
+      resolvePiGenerationLineage(undefined, { role: "assistant" }, "conv"),
+    ).toEqual({});
+    expect(
+      resolvePiGenerationLineage(null, { role: "assistant" }, "conv"),
+    ).toEqual({});
+  });
+
+  it("returns empty when getBranch is not a function (older runtimes)", () => {
+    const sm = { getSessionId: () => "x" } as Record<string, unknown>;
+    expect(
+      resolvePiGenerationLineage(
+        sm as unknown as Parameters<typeof resolvePiGenerationLineage>[0],
+        { role: "assistant" },
+        "conv",
+      ),
+    ).toEqual({});
+  });
+
+  it("returns empty when getBranch throws", () => {
+    const sm = {
+      getBranch: () => {
+        throw new Error("not a real session");
+      },
+    };
+    expect(
+      resolvePiGenerationLineage(sm, { role: "assistant" }, "conv"),
+    ).toEqual({});
+  });
+
+  it("returns empty when getBranch returns []", () => {
+    const sm = { getBranch: () => [] };
+    expect(
+      resolvePiGenerationLineage(sm, { role: "assistant" }, "conv"),
+    ).toEqual({});
+  });
+
+  it("returns empty when no assistant entry exists on the branch", () => {
+    // First turn during turn_end may briefly precede the assistant
+    // entry's persistence; degrade gracefully.
+    const sm = { getBranch: () => [userEntry("u1", null)] };
+    expect(
+      resolvePiGenerationLineage(sm, { role: "assistant" }, "conv"),
+    ).toEqual({});
+  });
+
+  it("matches the current assistant entry by object identity", () => {
+    const assistantMsg = { role: "assistant" };
+    const otherAssistantMsg = { role: "assistant" };
+    const branch: SessionEntryLike[] = [
+      userEntry("u1", null),
+      assistantEntry("a1", "u1", otherAssistantMsg),
+      userEntry("u2", "a1"),
+      assistantEntry("a2", "u2", assistantMsg),
+    ];
+    const sm = { getBranch: () => branch };
+    const lineage = resolvePiGenerationLineage(sm, assistantMsg, "conv");
+    expect(lineage.generationId).toBe(stablePiGenerationId("conv", "a2"));
+    expect(lineage.parentGenerationIds).toEqual([
+      stablePiGenerationId("conv", "a1"),
+    ]);
+  });
+
+  it("falls back to latest assistant entry when message identity does not match", () => {
+    // Defensive: an event payload with a different `Message` object should
+    // still produce a deterministic ID for the latest assistant entry.
+    const branch: SessionEntryLike[] = [
+      userEntry("u1", null),
+      assistantEntry("a1", "u1", { role: "assistant" }),
+    ];
+    const sm = { getBranch: () => branch };
+    const lineage = resolvePiGenerationLineage(
+      sm,
+      { role: "assistant" }, // distinct object reference
+      "conv",
+    );
+    expect(lineage.generationId).toBe(stablePiGenerationId("conv", "a1"));
+    expect(lineage.parentGenerationIds).toBeUndefined();
+  });
+
+  it("omits parentGenerationIds for the first assistant turn", () => {
+    const assistantMsg = { role: "assistant" };
+    const branch: SessionEntryLike[] = [
+      userEntry("u1", null),
+      assistantEntry("a1", "u1", assistantMsg),
+    ];
+    const sm = { getBranch: () => branch };
+    const lineage = resolvePiGenerationLineage(sm, assistantMsg, "conv");
+    expect(lineage.generationId).toBe(stablePiGenerationId("conv", "a1"));
+    expect(lineage.parentGenerationIds).toBeUndefined();
+  });
+
+  it("links a linear second assistant turn to the first one", () => {
+    const second = { role: "assistant" };
+    const branch: SessionEntryLike[] = [
+      userEntry("u1", null),
+      assistantEntry("a1", "u1", { role: "assistant" }),
+      userEntry("u2", "a1"),
+      assistantEntry("a2", "u2", second),
+    ];
+    const sm = { getBranch: () => branch };
+    const lineage = resolvePiGenerationLineage(sm, second, "conv");
+    expect(lineage.generationId).toBe(stablePiGenerationId("conv", "a2"));
+    expect(lineage.parentGenerationIds).toEqual([
+      stablePiGenerationId("conv", "a1"),
+    ]);
+  });
+
+  it("walks through non-message entries when finding the parent assistant", () => {
+    // Pi inserts thinking_level_change / model_change entries in the
+    // tree; lineage must skip them and follow parentId.
+    const assistantMsg = { role: "assistant" };
+    const branch: SessionEntryLike[] = [
+      userEntry("u1", null),
+      assistantEntry("a1", "u1", { role: "assistant" }),
+      nonMessageEntry("mc1", "a1"),
+      userEntry("u2", "mc1"),
+      assistantEntry("a2", "u2", assistantMsg),
+    ];
+    const sm = { getBranch: () => branch };
+    const lineage = resolvePiGenerationLineage(sm, assistantMsg, "conv");
+    expect(lineage.parentGenerationIds).toEqual([
+      stablePiGenerationId("conv", "a1"),
+    ]);
+  });
+
+  it("walks through user entries to the previous assistant on the branch", () => {
+    // Multiple user messages between two assistant turns must not become
+    // the parent — only the nearest previous assistant entry counts.
+    const assistantMsg = { role: "assistant" };
+    const branch: SessionEntryLike[] = [
+      userEntry("u1", null),
+      assistantEntry("a1", "u1", { role: "assistant" }),
+      userEntry("u2", "a1"),
+      userEntry("u3", "u2"),
+      assistantEntry("a2", "u3", assistantMsg),
+    ];
+    const sm = { getBranch: () => branch };
+    const lineage = resolvePiGenerationLineage(sm, assistantMsg, "conv");
+    expect(lineage.parentGenerationIds).toEqual([
+      stablePiGenerationId("conv", "a1"),
+    ]);
+  });
+
+  it("picks the assistant entry on the active branch, not the most recent chronological one", () => {
+    // Branch scenario: branch from a1 to a new path a1 -> a3, even though
+    // the underlying session also contains a2 (an abandoned branch). After
+    // navigating, getBranch() only returns the active path (u1 -> a1 -> u3 -> a3).
+    const assistantMsg = { role: "assistant" };
+    const branch: SessionEntryLike[] = [
+      userEntry("u1", null),
+      assistantEntry("a1", "u1", { role: "assistant" }),
+      // Note: a2 belongs to a sibling branch (parent u2 -> a1), it is NOT
+      // included in getBranch() for the active path.
+      userEntry("u3", "a1"),
+      assistantEntry("a3", "u3", assistantMsg),
+    ];
+    const sm = { getBranch: () => branch };
+    const lineage = resolvePiGenerationLineage(sm, assistantMsg, "conv");
+    expect(lineage.generationId).toBe(stablePiGenerationId("conv", "a3"));
+    expect(lineage.parentGenerationIds).toEqual([
+      stablePiGenerationId("conv", "a1"),
+    ]);
+    // Should not link to the abandoned sibling assistant entry.
+    expect(lineage.parentGenerationIds).not.toContain(
+      stablePiGenerationId("conv", "a2"),
+    );
+  });
+});

--- a/plugins/pi/src/lineage.ts
+++ b/plugins/pi/src/lineage.ts
@@ -1,0 +1,184 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Lineage helpers for deterministic, branch-aware Pi generation IDs.
+ *
+ * Pi persists conversation history as an append-only entry tree
+ * (`SessionManager`), where each `SessionEntry` carries a stable `id` and a
+ * `parentId`. The active branch is the path from the current leaf back to
+ * the root, returned by `getBranch()`. We hash `conversationId + entryId`
+ * for the assistant message entry of the turn being exported, and look up
+ * the nearest previous assistant entry on the same branch as the parent.
+ *
+ * The Pi runtime types are referenced structurally so this plugin keeps
+ * working against minor changes in `@mariozechner/pi-coding-agent`. Unknown
+ * shapes degrade to an empty result, which lets the SDK fall back to its
+ * usual `gen-*` ID behavior.
+ */
+
+/**
+ * Subset of the Pi session manager shape consumed by the lineage helper.
+ * Mirrors `ReadonlySessionManager` in pi-coding-agent, but only the methods
+ * we actually use, so the helper stays usable with future signature drift.
+ */
+export interface SessionManagerLike {
+  getBranch?: (fromId?: string) => SessionEntryLike[];
+}
+
+/**
+ * Minimal `SessionEntry` shape: just the fields we read. `getBranch()`
+ * returns mixed entry types (message, thinking_level_change, model_change,
+ * compaction, …); we only treat `type === "message"` entries with an
+ * assistant message as relevant.
+ */
+export interface SessionEntryLike {
+  type?: string;
+  id?: string;
+  parentId?: string | null;
+  message?: { role?: string } | null;
+}
+
+/** What `resolvePiGenerationLineage` returns. Empty when no lineage. */
+export interface PiGenerationLineage {
+  generationId?: string;
+  parentGenerationIds?: string[];
+}
+
+/**
+ * Deterministic Pi generation ID: SHA-256 of `${conversationId}\0${entryId}`
+ * truncated to 24 hex chars and prefixed with `pi-`. Matches the convention
+ * in `plugins/sigil/internal/agents/{codex,copilot}/mapper/mapper.go`, but
+ * uses a Pi-specific prefix so generation IDs identify the producer plugin.
+ */
+export function stablePiGenerationId(
+  conversationId: string,
+  entryId: string,
+): string {
+  const hex = createHash("sha256")
+    .update(`${conversationId}\0${entryId}`)
+    .digest("hex");
+  return `pi-${hex.slice(0, 24)}`;
+}
+
+/**
+ * Resolve `{ generationId, parentGenerationIds }` for the assistant turn
+ * currently being exported.
+ *
+ * Strategy:
+ *  1. Read the active branch via `sessionManager.getBranch()`. Bail with an
+ *     empty result if the runtime does not expose it.
+ *  2. Locate the assistant message entry that corresponds to `assistantMessage`.
+ *     Prefer object identity (the same `Message` instance pi handed us in
+ *     `turn_end`), and fall back to the latest assistant entry on the branch.
+ *  3. Hash it as `generationId`. Then walk earlier along the branch for the
+ *     nearest other assistant message entry and hash that as the parent.
+ *
+ * The first assistant turn on a branch produces no parent. When the branch
+ * is unavailable (older runtimes) or no assistant entry can be found, the
+ * helper returns `{}` so the SDK keeps its existing fallback behavior.
+ */
+export function resolvePiGenerationLineage(
+  sessionManager: SessionManagerLike | undefined | null,
+  assistantMessage: unknown,
+  conversationId: string | undefined,
+): PiGenerationLineage {
+  if (!conversationId) return {};
+  if (!sessionManager || typeof sessionManager.getBranch !== "function") {
+    return {};
+  }
+
+  let branch: SessionEntryLike[];
+  try {
+    branch = sessionManager.getBranch();
+  } catch {
+    return {};
+  }
+  if (!Array.isArray(branch) || branch.length === 0) return {};
+
+  // `getBranch()` returns the path from the root down to the leaf (see
+  // SessionManager.getBranch, which `unshift`s while walking parentId
+  // upward). We still resolve the parent via the parentId chain rather
+  // than positional order to stay robust against future changes and to
+  // make the intent obvious on branched trees.
+  const assistantEntries = branch.filter(isAssistantMessageEntry);
+  if (assistantEntries.length === 0) return {};
+
+  // Object-identity match: pi appends the assistant message into the session
+  // tree right before `turn_end` fires (session-manager appendMessage),
+  // and the event payload carries the same `Message` reference. Identity is
+  // therefore the most precise way to pin down which branch entry to use.
+  let currentIndex = assistantEntries.findIndex(
+    (entry) => entry.message === assistantMessage,
+  );
+  if (currentIndex === -1) {
+    // Fallback when the event payload's message is not the same object
+    // reference as the one persisted in the session tree (e.g. extensions
+    // that clone messages). Pick the last assistant entry in `branch` order,
+    // which in practice points at the just-appended turn under the current
+    // pi runtime.
+    currentIndex = assistantEntries.length - 1;
+  }
+
+  const currentEntry = assistantEntries[currentIndex];
+  if (!currentEntry || typeof currentEntry.id !== "string") return {};
+
+  const generationId = stablePiGenerationId(conversationId, currentEntry.id);
+
+  // Walk the parentId chain upward through the branch to find the nearest
+  // ancestor assistant entry. On linear branches this is the previous
+  // assistant turn; on branched trees it is the assistant turn at the
+  // branch point, not the most recent chronological assistant entry from
+  // a sibling branch.
+  const parentId = findParentAssistantEntryId(
+    currentEntry,
+    branch,
+    assistantEntries,
+  );
+  if (!parentId) return { generationId };
+
+  return {
+    generationId,
+    parentGenerationIds: [stablePiGenerationId(conversationId, parentId)],
+  };
+}
+
+/**
+ * Walk the parentId chain from `entry` toward the root and return the id of
+ * the nearest ancestor that is an assistant message entry. Returns
+ * `undefined` for the first assistant turn on the branch.
+ *
+ * `branch` is used to look up entries by id; `assistantEntries` is the
+ * pre-filtered list, used to detect when an ancestor is itself an
+ * assistant entry.
+ */
+function findParentAssistantEntryId(
+  entry: SessionEntryLike,
+  branch: SessionEntryLike[],
+  assistantEntries: SessionEntryLike[],
+): string | undefined {
+  const byId = new Map<string, SessionEntryLike>();
+  for (const e of branch) {
+    if (typeof e.id === "string") byId.set(e.id, e);
+  }
+  const assistantIds = new Set<string>();
+  for (const e of assistantEntries) {
+    if (typeof e.id === "string") assistantIds.add(e.id);
+  }
+
+  let cursor = entry.parentId;
+  const seen = new Set<string>();
+  while (typeof cursor === "string" && !seen.has(cursor)) {
+    seen.add(cursor);
+    const parent = byId.get(cursor);
+    if (!parent) return undefined;
+    if (assistantIds.has(cursor)) return cursor;
+    cursor = parent.parentId ?? null;
+  }
+  return undefined;
+}
+
+function isAssistantMessageEntry(entry: SessionEntryLike): boolean {
+  if (!entry || entry.type !== "message") return false;
+  const role = entry.message?.role;
+  return role === "assistant";
+}

--- a/plugins/pi/src/mappers.test.ts
+++ b/plugins/pi/src/mappers.test.ts
@@ -237,6 +237,58 @@ describe("mapGenerationStart", () => {
     expect(start.toolChoice).toBeUndefined();
     expect(start.metadata).toBeUndefined();
   });
+
+  it("copies generationId to start.id when set", () => {
+    const start = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+      generationId: "pi-abcdef0123456789abcdef01",
+    });
+    expect(start.id).toBe("pi-abcdef0123456789abcdef01");
+  });
+
+  it("omits start.id when generationId is missing or empty", () => {
+    const a = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+    });
+    const b = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+      generationId: "",
+    });
+    expect(a.id).toBeUndefined();
+    expect(b.id).toBeUndefined();
+  });
+
+  it("copies parentGenerationIds when set", () => {
+    const start = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+      parentGenerationIds: ["pi-deadbeefcafebabe00010203"],
+    });
+    expect(start.parentGenerationIds).toEqual(["pi-deadbeefcafebabe00010203"]);
+  });
+
+  it("omits parentGenerationIds when empty or undefined", () => {
+    const a = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+    });
+    const b = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+      parentGenerationIds: [],
+    });
+    expect(a.parentGenerationIds).toBeUndefined();
+    expect(b.parentGenerationIds).toBeUndefined();
+  });
 });
 
 describe("mapGenerationResult", () => {

--- a/plugins/pi/src/mappers.ts
+++ b/plugins/pi/src/mappers.ts
@@ -128,6 +128,17 @@ export interface MapGenerationStartOptions {
   tags?: Record<string, string>;
   systemPrompt?: string;
   requestControls?: CachedRequestControls;
+  /**
+   * Deterministic generation ID. When set, overrides the SDK's random
+   * `gen-*` ID so Sigil can link this generation in the dependency graph.
+   * Resolved from the active Pi session branch in `index.ts`.
+   */
+  generationId?: string;
+  /**
+   * Producer-supplied parent generation IDs. Pi uses this to point at the
+   * previous assistant turn on the same branch.
+   */
+  parentGenerationIds?: string[];
 }
 
 /** Build the GenerationStart seed from an assistant message and context. */
@@ -144,6 +155,8 @@ export function mapGenerationStart(
     tags,
     systemPrompt,
     requestControls,
+    generationId,
+    parentGenerationIds,
   } = opts;
   // Tags on the seed override client-level SIGIL_TAGS (the SDK merges
   // `{...clientTags, ...seedTags}`), matching claude-code/cursor.
@@ -157,6 +170,12 @@ export function mapGenerationStart(
     ...(tools && tools.length > 0 ? { tools } : {}),
     ...(tags && Object.keys(tags).length > 0 ? { tags } : {}),
   };
+  if (generationId) {
+    start.id = generationId;
+  }
+  if (parentGenerationIds && parentGenerationIds.length > 0) {
+    start.parentGenerationIds = parentGenerationIds;
+  }
   if (msg.content.some((b) => b.type === "thinking")) {
     start.thinkingEnabled = true;
   }

--- a/plugins/pi/src/testdata/golden/pi-full-turn.golden.json
+++ b/plugins/pi/src/testdata/golden/pi-full-turn.golden.json
@@ -3,7 +3,7 @@
     "path": "/api/v1/generations:export",
     "generations": [
       {
-        "id": "<NORMALIZED-ID>",
+        "id": "pi-7d0cc91aec6a3962f720b126",
         "conversation_id": "pi-conv-1",
         "operation_name": "streamText",
         "mode": "GENERATION_MODE_STREAM",


### PR DESCRIPTION
Add parent links, so that session can be viewed properly in the dependencies tab:

<img width="1186" height="361" alt="image" src="https://github.com/user-attachments/assets/5c5a9c74-f36f-4f06-b3b5-f2a140326b3f" />

This screenshot shows a single session that was forked into two branches.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how exported generation IDs are produced and linked; incorrect lineage could miswire the dependency graph, though missing branch data safely falls back to SDK random IDs.
> 
> **Overview**
> The Pi Sigil plugin now assigns **stable `pi-*` generation IDs** and **parent links** on export so Sigil can build a retry-safe dependency graph across assistant turns.
> 
> At **`turn_end`**, it reads the active session branch via `getBranch()`, hashes `conversationId` + assistant session entry id into `pi-<24 hex>`, and walks `parentId` to the previous assistant entry on that branch (skipping users and non-message nodes like `model_change`). Those values flow through `mapGenerationStart` as `id` and `parentGenerationIds`, replacing the SDK’s random `gen-*` IDs when lineage is available. Lineage is resolved at turn end (not `message_end`) because Pi appends the assistant message to the tree only after extension `message_end` handlers run.
> 
> When `getBranch`, `conversationId`, or a matching assistant entry is missing, the plugin omits lineage fields so the SDK keeps its existing fallback. Golden normalization was updated to **keep `pi-*` ids visible** while still scrubbing `gen-` / `span-` / `trace-` prefixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f9317467f9bfa97ec3148e7872c2cb5beccbe39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->