### PR TITLE
fix(plugins/pi): write diagnostics to the debug log file, not the terminal

### DIFF
--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -70,7 +70,7 @@ SIGIL_CONTENT_CAPTURE_MODE=full
 
 Run one pi turn, then open **AI Observability → Conversations** in Grafana Cloud. A new generation should appear within a few seconds.
 
-If nothing shows up, set `SIGIL_DEBUG=true` in `~/.config/sigil/config.env`, run another turn, and check pi stderr plus any Sigil logs.
+If nothing shows up, set `SIGIL_DEBUG=true` in `~/.config/sigil/config.env`, run another turn, and check the debug log at `~/.local/state/sigil/logs/sigil.log` (honors `XDG_STATE_HOME`).
 
 ## Redaction
 
@@ -100,7 +100,7 @@ The same three variables are honored by the [Claude Code plugin](../claude-code/
 | `SIGIL_AGENT_NAME` | `pi` | Agent name reported to Sigil. |
 | `SIGIL_AGENT_VERSION` | — | Optional version string reported with the agent. |
 | `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | One of `full`, `no_tool_content`, `metadata_only`, or `full_with_metadata_spans`. `default` is accepted as an alias for `metadata_only`. |
-| `SIGIL_DEBUG` | `false` | Log lifecycle events to stderr. |
+| `SIGIL_DEBUG` | `false` | Write lifecycle events to `~/.local/state/sigil/logs/sigil.log` (honors `XDG_STATE_HOME`). Never written to the terminal, to avoid corrupting pi's TUI. |
 | `SIGIL_REDACT_INPUT_MESSAGES` | `true` | Redact known secret patterns in user input messages before export. |
 | `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP HTTP endpoint. Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT`. |
 | `SIGIL_OTEL_AUTH_TOKEN` | `SIGIL_AUTH_TOKEN` | Override the OTLP password. |

--- a/plugins/pi/src/client.test.ts
+++ b/plugins/pi/src/client.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SigilPiConfig } from "./config.js";
 
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("./logger.js", () => ({ logger: loggerMock }));
+
 const { SigilClientMock, createSecretRedactionSanitizerMock, SANITIZER } =
   vi.hoisted(() => {
     const sanitizer = Object.assign(() => ({}) as never, {
@@ -26,7 +32,6 @@ function makeConfig(overrides?: Partial<SigilPiConfig>): SigilPiConfig {
     auth: { mode: "none" },
     agentName: "pi",
     contentCapture: "metadata_only",
-    debug: false,
     redactInputMessages: true,
     guards: {
       enabled: false,
@@ -41,6 +46,9 @@ describe("createSigilClient", () => {
   beforeEach(() => {
     SigilClientMock.mockReset();
     createSecretRedactionSanitizerMock.mockClear();
+    loggerMock.debug.mockReset();
+    loggerMock.warn.mockReset();
+    loggerMock.error.mockReset();
     // biome-ignore lint/complexity/useArrowFunction: must be a regular function for `new` to work
     SigilClientMock.mockImplementation(function () {
       return {};
@@ -152,50 +160,32 @@ describe("createSigilClient", () => {
     );
   });
 
-  it("uses warn as the default sdk log level", () => {
-    const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const error = vi.spyOn(console, "error").mockImplementation(() => {});
-    try {
-      createSigilClient(makeConfig());
-      const [{ logger }] = SigilClientMock.mock.calls[0]!;
-      logger.debug("debug");
-      logger.warn("warn");
-      logger.error("error");
+  it("routes sdk logs through the file logger by level", () => {
+    createSigilClient(makeConfig());
+    const [{ logger }] = SigilClientMock.mock.calls[0]!;
+    logger.debug("debug");
+    logger.warn("warn");
+    logger.error("error");
 
-      expect(debug).not.toHaveBeenCalled();
-      expect(warn).toHaveBeenCalledWith("[sigil-pi] warn");
-      expect(error).toHaveBeenCalledWith("[sigil-pi] error");
-    } finally {
-      debug.mockRestore();
-      warn.mockRestore();
-      error.mockRestore();
-    }
+    expect(loggerMock.debug).toHaveBeenCalledWith("debug");
+    expect(loggerMock.warn).toHaveBeenCalledWith("warn");
+    expect(loggerMock.error).toHaveBeenCalledWith("error");
   });
 
   it("downgrades best-effort export sdk logs to debug", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const error = vi.spyOn(console, "error").mockImplementation(() => {});
-    try {
-      createSigilClient(makeConfig());
-      const [{ logger: defaultLogger }] = SigilClientMock.mock.calls[0]!;
-      defaultLogger.warn("sigil generation export failed: transport down");
-      defaultLogger.warn("sigil generation rejected id=g-1: invalid");
+    createSigilClient(makeConfig());
+    const [{ logger }] = SigilClientMock.mock.calls[0]!;
+    logger.warn("sigil generation export failed: transport down");
+    logger.warn("sigil generation rejected id=g-1: invalid");
 
-      expect(warn).not.toHaveBeenCalled();
-      expect(error).not.toHaveBeenCalled();
-
-      createSigilClient(makeConfig({ debug: true }));
-      const [{ logger: debugLogger }] = SigilClientMock.mock.calls[1]!;
-      debugLogger.warn("sigil generation export failed: transport down");
-
-      expect(error).toHaveBeenCalledWith(
-        "[sigil-pi] sigil generation export failed: transport down",
-      );
-    } finally {
-      warn.mockRestore();
-      error.mockRestore();
-    }
+    // Best-effort export failures are demoted to debug, never warn.
+    expect(loggerMock.warn).not.toHaveBeenCalled();
+    expect(loggerMock.debug).toHaveBeenCalledWith(
+      "sigil generation export failed: transport down",
+    );
+    expect(loggerMock.debug).toHaveBeenCalledWith(
+      "sigil generation rejected id=g-1: invalid",
+    );
   });
 
   it("returns null when sdk constructor throws", () => {

--- a/plugins/pi/src/client.ts
+++ b/plugins/pi/src/client.ts
@@ -6,28 +6,29 @@ import {
 import type { Meter, Tracer } from "@opentelemetry/api";
 import type { SigilPiConfig } from "./config.js";
 import { EXPORT_PATH } from "./config.js";
+import { logger } from "./logger.js";
 
 export interface SigilClientOptions {
   tracer?: Tracer;
   meter?: Meter;
 }
 
-function createSdkLogger(debug: boolean): SigilLogger {
-  const debugLog = (message: string, ...args: unknown[]) => {
-    if (debug) console.error(`[sigil-pi] ${message}`, ...args);
-  };
-
+function createSdkLogger(): SigilLogger {
   return {
-    debug: debugLog,
+    debug: (message: string, ...args: unknown[]) => {
+      logger.debug(message, ...args);
+    },
     warn: (message: string, ...args: unknown[]) => {
+      // Best-effort export failures are expected when the endpoint is
+      // unreachable; keep them at debug level so they don't read as warnings.
       if (isBestEffortExportLog(message)) {
-        debugLog(message, ...args);
+        logger.debug(message, ...args);
         return;
       }
-      console.warn(`[sigil-pi] ${message}`, ...args);
+      logger.warn(message, ...args);
     },
     error: (message: string, ...args: unknown[]) => {
-      console.error(`[sigil-pi] ${message}`, ...args);
+      logger.error(message, ...args);
     },
   };
 }
@@ -60,13 +61,13 @@ export function createSigilClient(
       contentCapture: config.contentCapture,
       ...(options?.tracer ? { tracer: options.tracer } : {}),
       ...(options?.meter ? { meter: options.meter } : {}),
-      logger: createSdkLogger(config.debug),
+      logger: createSdkLogger(),
       generationSanitizer: createSecretRedactionSanitizer({
         redactInputMessages: config.redactInputMessages,
       }),
     });
   } catch (err) {
-    console.warn("[sigil-pi] failed to create SigilClient:", err);
+    logger.error("failed to create SigilClient", err);
     return null;
   }
 }

--- a/plugins/pi/src/config.test.ts
+++ b/plugins/pi/src/config.test.ts
@@ -2,8 +2,15 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { loadConfig, resolveConfig } from "./config.js";
 import { clearSigilEnv as clearEnv } from "./testEnv.js";
+
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("./logger.js", () => ({ logger: loggerMock }));
+
+import { loadConfig, resolveConfig } from "./config.js";
 
 describe("resolveConfig", () => {
   beforeEach(clearEnv);
@@ -93,7 +100,8 @@ describe("resolveConfig", () => {
   });
 
   it("maps SIGIL_CONTENT_CAPTURE_MODE=default to metadata_only without warning", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = loggerMock.warn;
+    warn.mockClear();
     process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.SIGIL_CONTENT_CAPTURE_MODE = "default";
     const cfg = resolveConfig();
@@ -103,7 +111,8 @@ describe("resolveConfig", () => {
   });
 
   it("warns and falls back on unknown mode string", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = loggerMock.warn;
+    warn.mockClear();
     process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.SIGIL_CONTENT_CAPTURE_MODE = "yolo";
     const cfg = resolveConfig();
@@ -170,13 +179,6 @@ describe("resolveConfig canonical SIGIL_* env vars", () => {
     process.env.SIGIL_ENDPOINT = "http://canonical:8080";
     const cfg = resolveConfig();
     expect(cfg?.endpoint).toBe("http://canonical:8080");
-  });
-
-  it("SIGIL_DEBUG flips debug on", () => {
-    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
-    process.env.SIGIL_DEBUG = "true";
-    const cfg = resolveConfig();
-    expect(cfg?.debug).toBe(true);
   });
 
   it("SIGIL_CONTENT_CAPTURE_MODE sets content capture", () => {
@@ -316,7 +318,8 @@ describe("resolveConfig guards", () => {
   });
 
   it("warns and falls back to default when SIGIL_GUARDS_ENABLED is not a boolean", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = loggerMock.warn;
+    warn.mockClear();
     process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.SIGIL_GUARDS_ENABLED = "maybe";
     const cfg = resolveConfig();
@@ -329,7 +332,8 @@ describe("resolveConfig guards", () => {
   });
 
   it("warns and falls back to default when SIGIL_GUARDS_TIMEOUT_MS is not numeric", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = loggerMock.warn;
+    warn.mockClear();
     process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.SIGIL_GUARDS_TIMEOUT_MS = "fast";
     const cfg = resolveConfig();
@@ -344,7 +348,8 @@ describe("resolveConfig guards", () => {
   });
 
   it("rejects SIGIL_GUARDS_TIMEOUT_MS=0 so the SDK does not fall back to its 15s default", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = loggerMock.warn;
+    warn.mockClear();
     process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.SIGIL_GUARDS_TIMEOUT_MS = "0";
     const cfg = resolveConfig();
@@ -358,7 +363,8 @@ describe("resolveConfig guards", () => {
   });
 
   it("warns and falls back to default when SIGIL_GUARDS_FAIL_OPEN is not a boolean", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = loggerMock.warn;
+    warn.mockClear();
     process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     process.env.SIGIL_GUARDS_FAIL_OPEN = "sometimes";
     const cfg = resolveConfig();

--- a/plugins/pi/src/config.ts
+++ b/plugins/pi/src/config.ts
@@ -1,4 +1,5 @@
 import type { ContentCaptureMode } from "@grafana/sigil-sdk-js";
+import { logger } from "./logger.js";
 import { applySigilDotenv } from "./sigilDotenv.js";
 
 export type SigilAuthConfig =
@@ -27,7 +28,6 @@ export interface SigilPiConfig {
   agentName: string;
   agentVersion?: string;
   contentCapture: ContentCaptureMode;
-  debug: boolean;
   redactInputMessages: boolean;
   otlp?: OtlpConfig;
   guards: GuardsFeatureConfig;
@@ -53,7 +53,6 @@ export function resolveConfig(): SigilPiConfig | null {
     configuredAgentVersion.length > 0 ? configuredAgentVersion : undefined;
 
   const contentCapture = resolveContentCapture();
-  const debug = envBool("SIGIL_DEBUG") ?? false;
   const redactInputMessages = envBoolOr("SIGIL_REDACT_INPUT_MESSAGES", true);
 
   return {
@@ -62,7 +61,6 @@ export function resolveConfig(): SigilPiConfig | null {
     agentName,
     agentVersion,
     contentCapture,
-    debug,
     redactInputMessages,
     otlp: resolveOtlp(),
     guards: resolveGuards(),
@@ -161,8 +159,8 @@ function parseContentCaptureMode(value: string): ContentCaptureMode {
   if (VALID_CAPTURE_MODES.includes(normalized as ContentCaptureMode)) {
     return normalized as ContentCaptureMode;
   }
-  console.warn(
-    `[sigil-pi] unsupported contentCapture value "${value}", defaulting to metadata_only`,
+  logger.warn(
+    `unsupported contentCapture value "${value}", defaulting to metadata_only`,
   );
   return "metadata_only";
 }
@@ -172,18 +170,13 @@ function env(key: string): string | undefined {
   return v !== undefined && v !== "" ? v : undefined;
 }
 
-function envBool(key: string): boolean | undefined {
-  const v = env(key);
-  return v !== undefined ? toBool(v) : undefined;
-}
-
 function envBoolOr(envKey: string, defaultValue: boolean): boolean {
   const raw = env(envKey);
   if (raw === undefined) return defaultValue;
   const parsed = toBool(raw);
   if (parsed === undefined) {
-    console.warn(
-      `[sigil-pi] invalid boolean value for ${envKey}: "${raw}" — using default ${defaultValue}`,
+    logger.warn(
+      `invalid boolean value for ${envKey}: "${raw}" — using default ${defaultValue}`,
     );
     return defaultValue;
   }
@@ -197,8 +190,8 @@ function envPositiveIntOr(envKey: string, defaultValue: number): number {
   if (raw === undefined) return defaultValue;
   const n = Number(raw);
   if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
-    console.warn(
-      `[sigil-pi] invalid integer value for ${envKey}: "${raw}" — using default ${defaultValue}`,
+    logger.warn(
+      `invalid integer value for ${envKey}: "${raw}" — using default ${defaultValue}`,
     );
     return defaultValue;
   }

--- a/plugins/pi/src/guard.ts
+++ b/plugins/pi/src/guard.ts
@@ -60,7 +60,7 @@ export async function runToolCallGuard(
     }
     return undefined;
   } catch (err) {
-    args.logger?.warn(`[sigil-pi] guard eval failed: ${err}`);
+    args.logger?.warn(`guard eval failed: ${err}`);
     if (!args.failOpen) {
       return denyResult(`guard evaluation failed: ${err}`);
     }

--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -5,12 +5,16 @@ const {
   createSigilClientMock,
   createTelemetryProvidersMock,
   resolveGitBranchMock,
+  loggerMock,
 } = vi.hoisted(() => ({
   loadConfigMock: vi.fn(),
   createSigilClientMock: vi.fn(),
   createTelemetryProvidersMock: vi.fn(),
   resolveGitBranchMock: vi.fn(),
+  loggerMock: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
+
+vi.mock("./logger.js", () => ({ logger: loggerMock }));
 
 vi.mock("./config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./config.js")>();
@@ -160,6 +164,9 @@ describe("extension lifecycle", () => {
     // Default: no git repo. Individual tests opt into a branch by overriding.
     resolveGitBranchMock.mockReset();
     resolveGitBranchMock.mockReturnValue(undefined);
+    loggerMock.debug.mockReset();
+    loggerMock.warn.mockReset();
+    loggerMock.error.mockReset();
   });
 
   it("uses assistant message_end timestamp as completedAt, not msg.timestamp", async () => {
@@ -612,7 +619,6 @@ describe("extension lifecycle", () => {
       auth: { mode: "none" },
       agentName: "pi",
       contentCapture: "metadata_only",
-      debug: false,
       otlp: { endpoint: "http://localhost:4318", headers: {} },
     });
     createTelemetryProvidersMock.mockReturnValue(telemetry);
@@ -811,7 +817,7 @@ describe("extension lifecycle", () => {
     expect(toolRecorders[1]!.setCallError).toHaveBeenCalled();
   });
 
-  it("swallows sigil failures instead of throwing or printing by default", async () => {
+  it("swallows sigil failures instead of throwing", async () => {
     const sigil = {
       startStreamingGeneration: vi.fn(async () => {
         throw new Error("transport down");
@@ -824,7 +830,6 @@ describe("extension lifecycle", () => {
       auth: { mode: "none" },
       agentName: "pi",
       contentCapture: "metadata_only",
-      debug: false,
     });
     createSigilClientMock.mockReturnValue(sigil);
 
@@ -841,6 +846,7 @@ describe("extension lifecycle", () => {
         pi.emit("turn_end", { message: assistantMessage(), toolResults: [] }),
       ).resolves.toBeUndefined();
 
+      // Never touch the terminal: it would corrupt pi's TUI frame.
       expect(warn).not.toHaveBeenCalled();
       expect(error).not.toHaveBeenCalled();
     } finally {
@@ -849,7 +855,7 @@ describe("extension lifecycle", () => {
     }
   });
 
-  it("prints sigil failures in debug mode", async () => {
+  it("logs export failures to the debug log, not the terminal", async () => {
     const sigil = {
       startStreamingGeneration: vi.fn(async () => {
         throw new Error("transport down");
@@ -862,7 +868,6 @@ describe("extension lifecycle", () => {
       auth: { mode: "none" },
       agentName: "pi",
       contentCapture: "metadata_only",
-      debug: true,
     });
     createSigilClientMock.mockReturnValue(sigil);
 
@@ -878,13 +883,17 @@ describe("extension lifecycle", () => {
         toolResults: [],
       });
 
-      expect(error).toHaveBeenCalledWith(
-        "[sigil-pi] generation export failed",
+      expect(loggerMock.debug).toHaveBeenCalledWith(
+        "generation export failed",
         expect.any(Error),
       );
-      expect(error.mock.calls.map(([message]) => message)).not.toEqual(
+      expect(
+        loggerMock.debug.mock.calls.map(([message]) => message),
+      ).not.toEqual(
         expect.arrayContaining([expect.stringContaining("generation queued")]),
       );
+      // The export failure must never reach the terminal.
+      expect(error).not.toHaveBeenCalled();
     } finally {
       error.mockRestore();
     }
@@ -911,7 +920,6 @@ describe("extension lifecycle", () => {
     });
     createSigilClientMock.mockReturnValue(sigil);
 
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const pi = new FakePi();
     registerExtension(pi as any);
 
@@ -924,10 +932,9 @@ describe("extension lifecycle", () => {
     });
 
     expect(sigil.startStreamingGeneration).not.toHaveBeenCalled();
-    expect(warn).toHaveBeenCalledWith(
+    expect(loggerMock.warn).toHaveBeenCalledWith(
       expect.stringContaining("did not validate"),
     );
-    warn.mockRestore();
   });
 
   it("uses sessionId, not file basename, as conversationId", async () => {

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -12,6 +12,7 @@ import { detectPiVersion } from "./detectPiVersion.js";
 import { resolveGitBranch } from "./git.js";
 import { runToolCallGuard } from "./guard.js";
 import { resolvePiGenerationLineage } from "./lineage.js";
+import { logger } from "./logger.js";
 import {
   type CachedRequestControls,
   extractRequestControls,
@@ -60,10 +61,6 @@ export default function (pi: ExtensionAPI) {
   // session shutdown in case a turn ends without a matching `turn_end`.
   let currentRequestControls: CachedRequestControls = {};
 
-  function debugLog(msg: string, ...args: unknown[]) {
-    if (config?.debug) console.error(`[sigil-pi] ${msg}`, ...args);
-  }
-
   // Tool execution timing: toolCallId → start timestamp
   const toolStarts = new Map<string, { toolName: string; startedAt: number }>();
   const turnToolTimings: ToolTiming[] = [];
@@ -90,7 +87,7 @@ export default function (pi: ExtensionAPI) {
       try {
         await telemetry.shutdown();
       } catch (err) {
-        console.warn("[sigil-pi] telemetry shutdown failed:", err);
+        logger.error("telemetry shutdown failed", err);
       }
       telemetry = null;
     }
@@ -114,7 +111,7 @@ export default function (pi: ExtensionAPI) {
         try {
           await sigil.shutdown();
         } catch (err) {
-          console.warn("[sigil-pi] stale client shutdown failed:", err);
+          logger.error("stale client shutdown failed", err);
         }
       }
 
@@ -141,7 +138,7 @@ export default function (pi: ExtensionAPI) {
           const instanceId = ctx.sessionManager.getSessionId() || randomUUID();
           telemetry = createTelemetryProviders(config.otlp, instanceId);
         } catch (err) {
-          console.warn("[sigil-pi] failed to create OTel providers:", err);
+          logger.error("failed to create OTel providers", err);
         }
       }
 
@@ -154,9 +151,11 @@ export default function (pi: ExtensionAPI) {
         return;
       }
 
-      debugLog(`enabled, endpoint=${config.endpoint} auth=${config.auth.mode}`);
+      logger.debug(
+        `enabled, endpoint=${config.endpoint} auth=${config.auth.mode}`,
+      );
     } catch (err) {
-      console.warn("[sigil-pi] session_start failed:", err);
+      logger.error("session_start failed", err);
       sigil = null;
       await resetSessionState();
     }
@@ -179,7 +178,7 @@ export default function (pi: ExtensionAPI) {
         currentSystemPrompt = prompt;
       }
     } catch (err) {
-      console.warn("[sigil-pi] before_agent_start failed:", err);
+      logger.error("before_agent_start failed", err);
     }
   });
 
@@ -202,7 +201,7 @@ export default function (pi: ExtensionAPI) {
       const payload = (event as { payload?: unknown }).payload;
       currentRequestControls = extractRequestControls(payload);
     } catch (err) {
-      console.warn("[sigil-pi] before_provider_request failed:", err);
+      logger.error("before_provider_request failed", err);
       currentRequestControls = {};
     }
   });
@@ -228,7 +227,7 @@ export default function (pi: ExtensionAPI) {
       const mapped = mapUserMessage(message, config.contentCapture);
       if (mapped) pendingInputMessages.push(mapped);
     } catch (err) {
-      console.warn("[sigil-pi] message_end failed:", err);
+      logger.error("message_end failed", err);
     }
   });
 
@@ -256,7 +255,7 @@ export default function (pi: ExtensionAPI) {
       toolName: event.toolName,
       input: event.input as Record<string, unknown>,
       failOpen: config.guards.failOpen,
-      logger: { warn: (msg: string) => console.warn(msg) },
+      logger: { warn: (msg: string) => logger.warn(msg) },
     });
   });
 
@@ -269,7 +268,7 @@ export default function (pi: ExtensionAPI) {
         startedAt: Date.now(),
       });
     } catch (err) {
-      console.warn("[sigil-pi] tool_execution_start failed:", err);
+      logger.error("tool_execution_start failed", err);
     }
   });
 
@@ -289,7 +288,7 @@ export default function (pi: ExtensionAPI) {
         isError: event.isError,
       });
     } catch (err) {
-      console.warn("[sigil-pi] tool_execution_end failed:", err);
+      logger.error("tool_execution_end failed", err);
     }
   });
 
@@ -298,8 +297,8 @@ export default function (pi: ExtensionAPI) {
 
     try {
       if (!isAssistantMessage(event.message)) {
-        console.warn(
-          "[sigil-pi] turn_end: assistant message shape did not validate, skipping",
+        logger.warn(
+          "turn_end: assistant message shape did not validate, skipping",
         );
         return;
       }
@@ -317,7 +316,7 @@ export default function (pi: ExtensionAPI) {
       try {
         toolCatalog = pi.getAllTools?.() ?? [];
       } catch (err) {
-        debugLog("getAllTools failed", err);
+        logger.debug("getAllTools failed", err);
         toolCatalog = [];
       }
       let activeNames: Set<string> | null = null;
@@ -325,7 +324,7 @@ export default function (pi: ExtensionAPI) {
         const active = pi.getActiveTools?.();
         if (Array.isArray(active)) activeNames = new Set(active);
       } catch (err) {
-        debugLog("getActiveTools failed", err);
+        logger.debug("getActiveTools failed", err);
       }
       if (
         toolCatalog.length === 0 &&
@@ -442,19 +441,19 @@ export default function (pi: ExtensionAPI) {
             },
           );
         });
-        debugLog(
+        logger.debug(
           `generation queued, model=${msg.model} tokens=${msg.usage.totalTokens}`,
         );
       } catch (err) {
-        debugLog("generation export failed", err);
+        logger.debug("generation export failed", err);
       }
       if (telemetry) {
         void telemetry.forceFlush().catch((err) => {
-          debugLog("telemetry flush failed", err);
+          logger.debug("telemetry flush failed", err);
         });
       }
     } catch (err) {
-      console.warn("[sigil-pi] turn_end failed:", err);
+      logger.error("turn_end failed", err);
     } finally {
       toolStarts.clear();
       turnToolTimings.length = 0;
@@ -468,7 +467,7 @@ export default function (pi: ExtensionAPI) {
       try {
         await sigil.shutdown();
       } catch (err) {
-        console.warn("[sigil-pi] session shutdown failed:", err);
+        logger.error("session shutdown failed", err);
       }
     }
 
@@ -556,10 +555,7 @@ export function emitToolSpans(
       toolRec.setResult(end);
       toolRec.end();
     } catch (err) {
-      console.warn(
-        `[sigil-pi] failed to emit tool span for ${timing.toolName}:`,
-        err,
-      );
+      logger.error(`failed to emit tool span for ${timing.toolName}`, err);
     }
   }
 }

--- a/plugins/pi/src/logger.test.ts
+++ b/plugins/pi/src/logger.test.ts
@@ -1,0 +1,91 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  logFilePath,
+  logger,
+  resetLoggerForTests,
+  stateRoot,
+} from "./logger.js";
+
+describe("logFilePath", () => {
+  const saved = {
+    xdg: process.env.XDG_STATE_HOME,
+    home: process.env.HOME,
+  };
+
+  afterEach(() => {
+    process.env.XDG_STATE_HOME = saved.xdg;
+    process.env.HOME = saved.home;
+  });
+
+  it("honors an absolute XDG_STATE_HOME", () => {
+    process.env.XDG_STATE_HOME = "/var/state";
+    expect(stateRoot()).toBe("/var/state/sigil");
+    expect(logFilePath()).toBe("/var/state/sigil/logs/sigil.log");
+  });
+
+  it("ignores a relative XDG_STATE_HOME and falls back to HOME", () => {
+    process.env.XDG_STATE_HOME = "relative/path";
+    process.env.HOME = "/home/alex";
+    expect(logFilePath()).toBe("/home/alex/.local/state/sigil/logs/sigil.log");
+  });
+});
+
+describe("logger", () => {
+  let dir: string;
+  const saved = process.env.SIGIL_DEBUG;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sigil-pi-log-"));
+    process.env.XDG_STATE_HOME = dir;
+    resetLoggerForTests();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    if (saved === undefined) delete process.env.SIGIL_DEBUG;
+    else process.env.SIGIL_DEBUG = saved;
+    resetLoggerForTests();
+  });
+
+  function readLog(): string {
+    return readFileSync(join(dir, "sigil", "logs", "sigil.log"), "utf-8");
+  }
+
+  it("writes nothing when SIGIL_DEBUG is off", () => {
+    delete process.env.SIGIL_DEBUG;
+    logger.debug("hidden");
+    logger.warn("hidden");
+    logger.error("hidden");
+    expect(() => readLog()).toThrow();
+  });
+
+  it("appends formatted lines to the debug log when SIGIL_DEBUG is on", () => {
+    process.env.SIGIL_DEBUG = "true";
+    logger.debug("queued model=%s", "claude");
+    logger.warn("heads up");
+    logger.error("boom", new Error("nope"));
+
+    const body = readLog();
+    expect(body).toContain("sigil[pi]:");
+    expect(body).toContain("debug queued model=claude");
+    expect(body).toContain("warn heads up");
+    expect(body).toContain("error boom");
+    expect(body).toContain("nope");
+    // One line per call plus the Error's multi-line stack trace.
+    expect(body.split("sigil[pi]:")).toHaveLength(4);
+  });
+
+  it("re-reads SIGIL_DEBUG per call so dotenv-applied values take effect", () => {
+    delete process.env.SIGIL_DEBUG;
+    logger.warn("before");
+    process.env.SIGIL_DEBUG = "1";
+    logger.warn("after");
+
+    const body = readLog();
+    expect(body).toContain("after");
+    expect(body).not.toContain("before");
+  });
+});

--- a/plugins/pi/src/logger.ts
+++ b/plugins/pi/src/logger.ts
@@ -1,0 +1,80 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, isAbsolute, join } from "node:path";
+import { format } from "node:util";
+
+// The pi plugin runs in-process inside pi's TUI. Anything written to the
+// terminal via console.* corrupts the live TUI frame (pi does not take over
+// stdout in interactive mode — see core/output-guard.ts). So all diagnostics
+// go to a file instead, matching the shared sigil binary, which writes its
+// SIGIL_DEBUG log to $XDG_STATE_HOME/sigil/logs/sigil.log (see
+// plugins/sigil/internal/xdg and internal/cli InitLogger). Logging is silent
+// unless SIGIL_DEBUG is truthy.
+const APP_NAME = "sigil";
+
+/** Mirrors plugins/sigil/internal/xdg.StateRoot for app "sigil". */
+export function stateRoot(appName = APP_NAME): string {
+  const xdg = (process.env.XDG_STATE_HOME ?? "").trim();
+  if (xdg && isAbsolute(xdg)) return join(xdg, appName);
+  const home = homedir();
+  if (home && isAbsolute(home)) return join(home, ".local", "state", appName);
+  return join(tmpdir(), appName);
+}
+
+/** Mirrors plugins/sigil/internal/xdg.LogFilePath for app "sigil". */
+export function logFilePath(appName = APP_NAME): string {
+  return join(stateRoot(appName), "logs", `${appName}.log`);
+}
+
+export interface SigilPiLogger {
+  debug(message: string, ...args: unknown[]): void;
+  warn(message: string, ...args: unknown[]): void;
+  error(message: string, ...args: unknown[]): void;
+}
+
+function debugEnabled(): boolean {
+  const v = (process.env.SIGIL_DEBUG ?? "").trim().toLowerCase();
+  return ["1", "true", "yes", "on"].includes(v);
+}
+
+// Cache the last directory we successfully created so we don't mkdir on every
+// line. Keyed on the resolved dir so a changed XDG_STATE_HOME (e.g. in tests)
+// re-creates it.
+let ensuredDir: string | undefined;
+
+function ensureLogDir(path: string): boolean {
+  const dir = dirname(path);
+  if (ensuredDir === dir) return true;
+  try {
+    mkdirSync(dir, { recursive: true, mode: 0o755 });
+    ensuredDir = dir;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function emit(level: string, message: string, args: unknown[]): void {
+  // Re-read the env per write: loadConfig() applies the sigil dotenv file,
+  // which may set SIGIL_DEBUG after the module first loads.
+  if (!debugEnabled()) return;
+  const path = logFilePath();
+  if (!ensureLogDir(path)) return;
+  const line = `sigil[pi]: ${new Date().toISOString()} ${level} ${format(message, ...args)}\n`;
+  try {
+    appendFileSync(path, line, { mode: 0o600 });
+  } catch {
+    // Best effort. A logging failure must never surface into the TUI.
+  }
+}
+
+export const logger: SigilPiLogger = {
+  debug: (message, ...args) => emit("debug", message, args),
+  warn: (message, ...args) => emit("warn", message, args),
+  error: (message, ...args) => emit("error", message, args),
+};
+
+/** @internal Reset cached state so tests can re-evaluate the log directory. */
+export function resetLoggerForTests(): void {
+  ensuredDir = undefined;
+}

--- a/plugins/pi/src/sigilDotenv.test.ts
+++ b/plugins/pi/src/sigilDotenv.test.ts
@@ -2,6 +2,13 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("./logger.js", () => ({ logger: loggerMock }));
+
 import {
   applySigilDotenv,
   loadSigilDotenv,
@@ -152,7 +159,8 @@ describe("loadSigilDotenv", () => {
   });
 
   it("returns an empty map silently when the file is missing", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = loggerMock.warn;
+    warn.mockClear();
     const got = loadSigilDotenv(join(dir, "does-not-exist.env"));
     expect(got).toEqual({});
     expect(warn).not.toHaveBeenCalled();
@@ -174,11 +182,12 @@ describe("loadSigilDotenv", () => {
   it("warns and returns an empty map on non-ENOENT read failures", () => {
     // A path that points to a directory rather than a file triggers an
     // EISDIR (or similar) read error, not ENOENT.
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = loggerMock.warn;
+    warn.mockClear();
     const got = loadSigilDotenv(dir);
     expect(got).toEqual({});
     expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn.mock.calls[0]?.[0]).toMatch(/^\[sigil-pi\]/);
+    expect(warn.mock.calls[0]?.[0]).toMatch(/^failed to read/);
     warn.mockRestore();
   });
 });
@@ -239,7 +248,8 @@ describe("applySigilDotenv", () => {
   });
 
   it("does nothing silently when config.env is missing", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = loggerMock.warn;
+    warn.mockClear();
     applySigilDotenv();
     expect(process.env.SIGIL_ENDPOINT).toBeUndefined();
     expect(warn).not.toHaveBeenCalled();
@@ -347,7 +357,8 @@ describe("applySigilDotenv", () => {
   });
 
   it("keeps owned keys when config.env cannot be read", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = loggerMock.warn;
+    warn.mockClear();
     writeConfig("SIGIL_ENDPOINT=https://from-file\nSIGIL_AUTH_TOKEN=tok\n");
     applySigilDotenv();
     expect(process.env.SIGIL_ENDPOINT).toBe("https://from-file");

--- a/plugins/pi/src/sigilDotenv.ts
+++ b/plugins/pi/src/sigilDotenv.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import { isMissingFileError } from "./fsErrors.js";
+import { logger } from "./logger.js";
 
 // Mirror plugins/sigil/internal/dotenv/dotenv.go::AllowedDotenvKey so the
 // allow-list stays in sync with the Go launcher. Anything outside the SIGIL_*
@@ -101,7 +102,7 @@ function readSigilDotenv(path: string): SigilDotenvReadResult {
     if (isMissingFileError(err)) {
       return { env: {}, reliable: true };
     }
-    console.warn(`[sigil-pi] failed to read ${path}:`, err);
+    logger.warn(`failed to read ${path}`, err);
     return { env: {}, reliable: false };
   }
   return { env: parseSigilDotenv(body), reliable: true };
@@ -110,8 +111,8 @@ function readSigilDotenv(path: string): SigilDotenvReadResult {
 /**
  * Read and parse the dotenv file at `path`. Missing files return `{}`
  * silently — the dotenv config is optional and credentials may come from
- * other sources (shell env). Other read failures emit a single `[sigil-pi]`
- * warning and also return `{}`.
+ * other sources (shell env). Other read failures emit a single warning to
+ * the sigil debug log and also return `{}`.
  */
 export function loadSigilDotenv(path: string): Record<string, string> {
   return readSigilDotenv(path).env;


### PR DESCRIPTION
The plugin logged through console.warn/error, so the debug output
clobbered the UI.

Now it logs to the same file sigil binary uses for its debug log,

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change: no export, auth, or guard behavior changes beyond where messages are written.
> 
> **Overview**
> The **pi** plugin no longer writes diagnostics to **stderr/stdout** via `console.*`, which was corrupting pi’s interactive TUI. It now routes all plugin and SDK logging through a new **file logger** that appends to the same path as the sigil binary: `~/.local/state/sigil/logs/sigil.log` (honors **`XDG_STATE_HOME`**), only when **`SIGIL_DEBUG`** is truthy.
> 
> **`SigilPiConfig.debug`** is removed; debug gating lives entirely in the logger (re-reads **`SIGIL_DEBUG`** on each write so values from **`config.env`** apply after dotenv load). Extension lifecycle, config validation, dotenv read errors, and **`createSigilClient`** use **`logger.debug` / `warn` / `error`** instead of the terminal. Expected export failures stay at **debug** (including SDK “best-effort” export messages). README documents the log file for troubleshooting.
> 
> Tests mock **`./logger.js`** and add **`logger.test.ts`** for path resolution and file append behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98f7fd0e2451bde5a2903acb1a547f02401be7f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->