### PR TITLE
feat(sdk): add SIGIL_REDACT_INPUT_MESSAGES env support

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -342,9 +342,10 @@ Use `GenerationSanitizer` when you want to redact substrings from normalized gen
 
 ```go
 redactEmails := true
+redactInputs := false
 cfg := sigil.DefaultConfig()
 cfg.GenerationSanitizer = sigil.NewSecretRedactionSanitizer(sigil.SecretRedactionOptions{
-    RedactInputMessages:  false,         // also redact user messages in Generation.Input
+    RedactInputMessages:  &redactInputs, // nil falls back to SIGIL_REDACT_INPUT_MESSAGES, then false
     RedactEmailAddresses: &redactEmails, // nil defaults to true; point to false to preserve
 })
 
@@ -357,7 +358,7 @@ The built-in sanitizer:
 - redacts secret formats plus env-style secret values in tool call inputs and tool results
 - redacts email addresses by default
 - redacts historic assistant turns and tool messages in `Generation.Input`
-- leaves user messages in `Generation.Input` unchanged unless `RedactInputMessages: true` is set
+- leaves user messages in `Generation.Input` unchanged unless input redaction is enabled
 
 To preserve email addresses, opt out explicitly:
 
@@ -369,6 +370,15 @@ cfg.GenerationSanitizer = sigil.NewSecretRedactionSanitizer(sigil.SecretRedactio
 ```
 
 If a sanitizer panics during `Recorder.End`, the SDK falls back to `ContentCaptureModeMetadataOnly` for that generation and logs a warning via `Config.Logger`, so a partially redacted payload is never shipped.
+
+### Configuring redaction via environment variables
+
+`NewSecretRedactionSanitizer` reads `SIGIL_REDACT_INPUT_MESSAGES` (accepts `1/0`, `true/false`, `yes/no`, `on/off`) when `RedactInputMessages` is left nil. Precedence is explicit option > env var > `false`. An unrecognised env value is logged via the standard logger and ignored, so a typo falls back to the next layer instead of silently flipping redaction.
+
+```go
+// Leave RedactInputMessages nil so SIGIL_REDACT_INPUT_MESSAGES decides.
+cfg.GenerationSanitizer = sigil.NewSecretRedactionSanitizer(sigil.SecretRedactionOptions{})
+```
 
 ## Conversation Ratings
 

--- a/go/sigil/env.go
+++ b/go/sigil/env.go
@@ -9,19 +9,20 @@ import (
 
 // canonical SIGIL_* env-var names.
 const (
-	envEndpoint           = "SIGIL_ENDPOINT"
-	envProtocol           = "SIGIL_PROTOCOL"
-	envInsecure           = "SIGIL_INSECURE"
-	envHeaders            = "SIGIL_HEADERS"
-	envAuthMode           = "SIGIL_AUTH_MODE"
-	envAuthTenantID       = "SIGIL_AUTH_TENANT_ID"
-	envAuthToken          = "SIGIL_AUTH_TOKEN"
-	envAgentName          = "SIGIL_AGENT_NAME"
-	envAgentVersion       = "SIGIL_AGENT_VERSION"
-	envUserID             = "SIGIL_USER_ID"
-	envTags               = "SIGIL_TAGS"
-	envContentCaptureMode = "SIGIL_CONTENT_CAPTURE_MODE"
-	envDebug              = "SIGIL_DEBUG"
+	envEndpoint            = "SIGIL_ENDPOINT"
+	envProtocol            = "SIGIL_PROTOCOL"
+	envInsecure            = "SIGIL_INSECURE"
+	envHeaders             = "SIGIL_HEADERS"
+	envAuthMode            = "SIGIL_AUTH_MODE"
+	envAuthTenantID        = "SIGIL_AUTH_TENANT_ID"
+	envAuthToken           = "SIGIL_AUTH_TOKEN"
+	envAgentName           = "SIGIL_AGENT_NAME"
+	envAgentVersion        = "SIGIL_AGENT_VERSION"
+	envUserID              = "SIGIL_USER_ID"
+	envTags                = "SIGIL_TAGS"
+	envContentCaptureMode  = "SIGIL_CONTENT_CAPTURE_MODE"
+	envDebug               = "SIGIL_DEBUG"
+	envRedactInputMessages = "SIGIL_REDACT_INPUT_MESSAGES"
 )
 
 // envLookup resolves canonical SIGIL_* env vars from os.Environ unless a
@@ -139,6 +140,19 @@ func parseBool(raw string) bool {
 		return true
 	}
 	return false
+}
+
+// parseStrictBool accepts the same true tokens as parseBool plus the matching
+// false tokens, and reports whether the input was recognised. Use this when an
+// invalid value must not silently fall through to false.
+func parseStrictBool(raw string) (bool, bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "1", "true", "yes", "on":
+		return true, true
+	case "0", "false", "no", "off":
+		return false, true
+	}
+	return false, false
 }
 
 func parseCSVKV(raw string) map[string]string {

--- a/go/sigil/redaction.go
+++ b/go/sigil/redaction.go
@@ -1,6 +1,7 @@
 package sigil
 
 import (
+	"log"
 	"regexp"
 	"strings"
 )
@@ -16,11 +17,13 @@ type GenerationSanitizer func(Generation) Generation
 
 // SecretRedactionOptions configures the built-in secret-redaction sanitizer.
 type SecretRedactionOptions struct {
-	// RedactInputMessages, when true, also sanitizes user messages in
-	// Generation.Input. Assistant and tool messages in Input are sanitized
-	// regardless because they typically replay tool results and prior model
-	// output that share the same secret surface as Generation.Output.
-	RedactInputMessages bool
+	// RedactInputMessages, when non-nil, sets whether user messages in
+	// Generation.Input are sanitized too. Nil falls back to
+	// SIGIL_REDACT_INPUT_MESSAGES and then to false (leave user input as-is).
+	// Assistant and tool messages in Input are sanitized regardless because
+	// they typically replay tool results and prior model output that share the
+	// same secret surface as Generation.Output.
+	RedactInputMessages *bool
 	// RedactEmailAddresses, when non-nil, sets whether email addresses are
 	// redacted. Nil defaults to true (redact). Set to a pointer to false to
 	// preserve email addresses verbatim.
@@ -163,6 +166,24 @@ func redactTier1Bytes(src []byte) []byte {
 	return out
 }
 
+// resolveRedactInputMessages applies precedence explicit > env > false.
+// An unrecognised SIGIL_REDACT_INPUT_MESSAGES value is logged and ignored.
+func resolveRedactInputMessages(lookup envLookup, explicit *bool) bool {
+	if explicit != nil {
+		return *explicit
+	}
+	if lookup == nil {
+		lookup = defaultLookup
+	}
+	if v, ok := envTrimmed(lookup, envRedactInputMessages); ok {
+		if parsed, valid := parseStrictBool(v); valid {
+			return parsed
+		}
+		log.Default().Printf("sigil: ignoring invalid %s %q", envRedactInputMessages, v)
+	}
+	return false
+}
+
 // NewSecretRedactionSanitizer returns a GenerationSanitizer that redacts
 // known secret formats from generation content. The returned sanitizer is
 // safe for concurrent use.
@@ -170,11 +191,17 @@ func redactTier1Bytes(src []byte) []byte {
 // By default it redacts Generation.Output (assistant + tool), Generation.SystemPrompt,
 // Generation.ConversationTitle, Generation.CallError, and the assistant /
 // tool messages in Generation.Input. User messages in Generation.Input are
-// only redacted when RedactInputMessages is set. Email redaction is on unless
+// only redacted when input redaction is enabled, resolved as:
+// explicit RedactInputMessages > SIGIL_REDACT_INPUT_MESSAGES > false.
+// An invalid env value is logged and ignored. Email redaction is on unless
 // RedactEmailAddresses points to false.
 func NewSecretRedactionSanitizer(opts SecretRedactionOptions) GenerationSanitizer {
+	return newSecretRedactionSanitizer(defaultLookup, opts)
+}
+
+func newSecretRedactionSanitizer(lookup envLookup, opts SecretRedactionOptions) GenerationSanitizer {
 	includeEmail := opts.RedactEmailAddresses == nil || *opts.RedactEmailAddresses
-	redactInputs := opts.RedactInputMessages
+	redactInputs := resolveRedactInputMessages(lookup, opts.RedactInputMessages)
 
 	return func(g Generation) Generation {
 		if g.SystemPrompt != "" {

--- a/go/sigil/redaction_test.go
+++ b/go/sigil/redaction_test.go
@@ -185,15 +185,18 @@ func TestSecretRedactionSanitizerInputRedactionByRole(t *testing.T) {
 	cases := []struct {
 		name             string
 		opts             SecretRedactionOptions
+		env              map[string]string
 		wantUserRedacted bool
 	}{
 		{name: "default preserves user only", opts: SecretRedactionOptions{}, wantUserRedacted: false},
-		{name: "opt-in redacts user too", opts: SecretRedactionOptions{RedactInputMessages: true}, wantUserRedacted: true},
+		{name: "opt-in redacts user too", opts: SecretRedactionOptions{RedactInputMessages: boolPtr(true)}, wantUserRedacted: true},
+		{name: "env enables when option nil", env: map[string]string{"SIGIL_REDACT_INPUT_MESSAGES": "true"}, wantUserRedacted: true},
+		{name: "explicit false beats env true", opts: SecretRedactionOptions{RedactInputMessages: boolPtr(false)}, env: map[string]string{"SIGIL_REDACT_INPUT_MESSAGES": "true"}, wantUserRedacted: false},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			sanitized := NewSecretRedactionSanitizer(tc.opts)(build())
+			sanitized := newSecretRedactionSanitizer(mapLookup(tc.env), tc.opts)(build())
 
 			userText := sanitized.Input[0].Parts[0].Text
 			if tc.wantUserRedacted {
@@ -545,4 +548,34 @@ func TestGenerationSanitizerSkippedInMetadataOnlyMode(t *testing.T) {
 func metaString(g Generation, key string) string {
 	v, _ := g.Metadata[key].(string)
 	return v
+}
+
+func TestResolveRedactInputMessages(t *testing.T) {
+	cases := []struct {
+		name     string
+		explicit *bool
+		env      map[string]string
+		want     bool
+	}{
+		{name: "nil and unset defaults to false", want: false},
+		{name: "explicit true wins over unset env", explicit: boolPtr(true), want: true},
+		{name: "explicit false wins over env true", explicit: boolPtr(false), env: map[string]string{"SIGIL_REDACT_INPUT_MESSAGES": "true"}, want: false},
+		{name: "explicit true wins over env false", explicit: boolPtr(true), env: map[string]string{"SIGIL_REDACT_INPUT_MESSAGES": "false"}, want: true},
+		{name: "env true when option nil", env: map[string]string{"SIGIL_REDACT_INPUT_MESSAGES": "true"}, want: true},
+		{name: "env false when option nil", env: map[string]string{"SIGIL_REDACT_INPUT_MESSAGES": "false"}, want: false},
+		{name: "env 1 parses true", env: map[string]string{"SIGIL_REDACT_INPUT_MESSAGES": "1"}, want: true},
+		{name: "env ON case-insensitive", env: map[string]string{"SIGIL_REDACT_INPUT_MESSAGES": "ON"}, want: true},
+		{name: "env yes parses true", env: map[string]string{"SIGIL_REDACT_INPUT_MESSAGES": "yes"}, want: true},
+		{name: "env off parses false", env: map[string]string{"SIGIL_REDACT_INPUT_MESSAGES": "off"}, want: false},
+		{name: "blank env falls back to false", env: map[string]string{"SIGIL_REDACT_INPUT_MESSAGES": "   "}, want: false},
+		{name: "invalid env falls back to false", env: map[string]string{"SIGIL_REDACT_INPUT_MESSAGES": "maybe"}, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveRedactInputMessages(mapLookup(tc.env), tc.explicit); got != tc.want {
+				t.Errorf("resolveRedactInputMessages = %v, want %v", got, tc.want)
+			}
+		})
+	}
 }

--- a/js/README.md
+++ b/js/README.md
@@ -143,7 +143,7 @@ import {
 
 const client = new SigilClient({
   generationSanitizer: createSecretRedactionSanitizer({
-    redactInputMessages: false,
+    redactInputMessages: false, // omit to fall back to SIGIL_REDACT_INPUT_MESSAGES, then false
     redactEmailAddresses: true,
   }),
 });
@@ -154,7 +154,7 @@ The built-in sanitizer:
 - redacts high-confidence secret formats in assistant text and thinking
 - redacts secret formats plus env-style secret values in tool call inputs and tool results
 - redacts email addresses by default
-- leaves user input unchanged unless `redactInputMessages: true` is set
+- leaves user input unchanged unless input redaction is enabled
 
 To preserve email addresses, opt out explicitly:
 
@@ -163,6 +163,26 @@ const client = new SigilClient({
   generationSanitizer: createSecretRedactionSanitizer({
     redactEmailAddresses: false,
   }),
+});
+```
+
+### Configuring redaction via environment variables
+
+`createSecretRedactionSanitizer()` reads `SIGIL_REDACT_INPUT_MESSAGES` (accepts
+`1/0`, `true/false`, `yes/no`, `on/off`) when `redactInputMessages` is omitted.
+Precedence is explicit option > env var > `false`. An unrecognised env value is
+warned and falls back to the next layer, so a typo cannot silently flip
+redaction.
+
+```ts
+import {
+  createSecretRedactionSanitizer,
+  SigilClient,
+} from "@grafana/sigil-sdk-js";
+
+// Omit redactInputMessages so SIGIL_REDACT_INPUT_MESSAGES decides.
+const client = new SigilClient({
+  generationSanitizer: createSecretRedactionSanitizer(),
 });
 ```
 

--- a/js/src/redaction.ts
+++ b/js/src/redaction.ts
@@ -1,4 +1,4 @@
-import type { GenerationSanitizer, Message, MessagePart } from './types.js';
+import type { GenerationSanitizer, Message, MessagePart, SigilLogger } from './types.js';
 import { cloneGeneration } from './utils.js';
 
 /**
@@ -96,9 +96,22 @@ class SecretRedactor {
   }
 }
 
-export function createSecretRedactionSanitizer(options: SecretRedactionOptions = {}): GenerationSanitizer {
+/**
+ * Build a generation sanitizer that redacts known secret formats.
+ *
+ * `redactInputMessages` resolves as: explicit option > `SIGIL_REDACT_INPUT_MESSAGES`
+ * (accepts `1/0`, `true/false`, `yes/no`, `on/off`, case-insensitive) > `false`.
+ * An unrecognised env value is warned through `logger` and falls back to
+ * `false`, so a typo cannot silently flip redaction.
+ */
+export function createSecretRedactionSanitizer(
+  options: SecretRedactionOptions = {},
+  env: Record<string, string | undefined> = readProcessEnv(),
+  logger: SigilLogger = consoleLogger,
+): GenerationSanitizer {
   const redactor = new SecretRedactor(options.redactEmailAddresses ?? true);
-  const redactInputMessages = options.redactInputMessages ?? false;
+  const redactInputMessages =
+    options.redactInputMessages ?? parseEnvBool(env, 'SIGIL_REDACT_INPUT_MESSAGES', logger) ?? false;
 
   return (generation) => {
     const sanitized = cloneGeneration(generation);
@@ -209,3 +222,31 @@ function applyTier2Patterns(text: string, patterns: SecretPattern[]): string {
   }
   return result;
 }
+
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const FALSE_VALUES = new Set(['0', 'false', 'no', 'off']);
+
+function parseEnvBool(env: Record<string, string | undefined>, key: string, logger: SigilLogger): boolean | undefined {
+  const raw = env[key];
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const normalized = trimmed.toLowerCase();
+  if (TRUE_VALUES.has(normalized)) return true;
+  if (FALSE_VALUES.has(normalized)) return false;
+  logger.warn?.(`sigil: ignoring invalid ${key}: ${raw}`);
+  return undefined;
+}
+
+function readProcessEnv(): Record<string, string | undefined> {
+  if (typeof process !== 'undefined' && process.env !== undefined) {
+    return process.env;
+  }
+  return {};
+}
+
+const consoleLogger: SigilLogger = {
+  warn(message: string, ...args: unknown[]) {
+    console.warn(message, ...args);
+  },
+};

--- a/js/test/client.redaction.test.mjs
+++ b/js/test/client.redaction.test.mjs
@@ -274,3 +274,64 @@ test('secret redaction sanitizer redacts assistant and tool messages in input', 
   assert.match(sanitized.input[1].parts[0].toolResult.content, /\[REDACTED:grafana-cloud-token\]/);
   assert.match(sanitized.input[1].parts[0].toolResult.content, /\[REDACTED:env-secret-value\]/);
 });
+
+function buildUserSecretGeneration() {
+  return {
+    id: 'gen-env-1',
+    mode: 'SYNC',
+    operationName: 'generateText',
+    model: { provider: 'openai', name: 'gpt-5' },
+    startedAt: new Date('2026-01-01T00:00:00Z'),
+    completedAt: new Date('2026-01-01T00:00:01Z'),
+    input: [
+      {
+        role: 'user',
+        parts: [{ type: 'text', text: 'key sk-proj-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }],
+      },
+    ],
+  };
+}
+
+test('createSecretRedactionSanitizer: SIGIL_REDACT_INPUT_MESSAGES truthy aliases enable user input redaction', () => {
+  for (const value of ['1', 'true', 'TRUE', 'yes', 'on']) {
+    const sanitizer = createSecretRedactionSanitizer({}, { SIGIL_REDACT_INPUT_MESSAGES: value });
+    const sanitized = sanitizer(buildUserSecretGeneration());
+    assert.match(sanitized.input[0].parts[0].text, /\[REDACTED:openai-project-key\]/, `value=${value}`);
+  }
+});
+
+test('createSecretRedactionSanitizer: SIGIL_REDACT_INPUT_MESSAGES falsy aliases leave user input untouched', () => {
+  for (const value of ['0', 'false', 'FALSE', 'no', 'off']) {
+    const sanitizer = createSecretRedactionSanitizer({}, { SIGIL_REDACT_INPUT_MESSAGES: value });
+    const sanitized = sanitizer(buildUserSecretGeneration());
+    assert.match(sanitized.input[0].parts[0].text, /sk-proj-/, `value=${value}`);
+  }
+});
+
+test('createSecretRedactionSanitizer: explicit redactInputMessages wins over env', () => {
+  const sanitizer = createSecretRedactionSanitizer(
+    { redactInputMessages: false },
+    { SIGIL_REDACT_INPUT_MESSAGES: 'true' },
+  );
+  const sanitized = sanitizer(buildUserSecretGeneration());
+  assert.match(sanitized.input[0].parts[0].text, /sk-proj-/);
+});
+
+test('createSecretRedactionSanitizer: invalid env value warns and falls back to false', () => {
+  const warnings = [];
+  const logger = { warn: (message) => warnings.push(message) };
+  const sanitizer = createSecretRedactionSanitizer({}, { SIGIL_REDACT_INPUT_MESSAGES: 'maybe' }, logger);
+  const sanitized = sanitizer(buildUserSecretGeneration());
+  assert.match(sanitized.input[0].parts[0].text, /sk-proj-/);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /SIGIL_REDACT_INPUT_MESSAGES.*maybe/);
+});
+
+test('createSecretRedactionSanitizer: blank env value is treated as unset (no warning)', () => {
+  const warnings = [];
+  const logger = { warn: (message) => warnings.push(message) };
+  const sanitizer = createSecretRedactionSanitizer({}, { SIGIL_REDACT_INPUT_MESSAGES: '   ' }, logger);
+  const sanitized = sanitizer(buildUserSecretGeneration());
+  assert.match(sanitized.input[0].parts[0].text, /sk-proj-/);
+  assert.equal(warnings.length, 0);
+});

--- a/python/README.md
+++ b/python/README.md
@@ -202,7 +202,7 @@ client = Client(
     ClientConfig(
         generation_sanitizer=create_secret_redaction_sanitizer(
             SecretRedactionOptions(
-                redact_input_messages=False,
+                redact_input_messages=False,  # None falls back to SIGIL_REDACT_INPUT_MESSAGES, then False
                 redact_email_addresses=True,
             )
         )
@@ -215,7 +215,7 @@ The built-in sanitizer:
 - redacts high-confidence secret formats in assistant text and thinking
 - redacts secret formats plus env-style secret values in tool call inputs and tool results
 - redacts email addresses by default
-- leaves user input unchanged unless `redact_input_messages=True` is set
+- leaves user input unchanged unless input redaction is enabled
 
 To preserve email addresses, opt out explicitly:
 
@@ -225,6 +225,25 @@ client = Client(
         generation_sanitizer=create_secret_redaction_sanitizer(
             SecretRedactionOptions(redact_email_addresses=False)
         )
+    )
+)
+```
+
+### Configuring redaction via environment variables
+
+`create_secret_redaction_sanitizer()` reads `SIGIL_REDACT_INPUT_MESSAGES` (accepts `1/0`, `true/false`, `yes/no`, `on/off`) when `redact_input_messages` is left `None`. Precedence is explicit option > env var > `False`. An unrecognised env value logs a warning through the `sigil_sdk` logger and falls back to the next layer, so a typo cannot silently flip redaction.
+
+```python
+from sigil_sdk import (
+    Client,
+    ClientConfig,
+    create_secret_redaction_sanitizer,
+)
+
+# Leave redact_input_messages unset so SIGIL_REDACT_INPUT_MESSAGES decides.
+client = Client(
+    ClientConfig(
+        generation_sanitizer=create_secret_redaction_sanitizer(),
     )
 )
 ```

--- a/python/sigil_sdk/__init__.py
+++ b/python/sigil_sdk/__init__.py
@@ -90,7 +90,10 @@ from .models import (
     tool_result_part,
     user_text_message,
 )
-from .redaction import SecretRedactionOptions, create_secret_redaction_sanitizer
+from .redaction import (
+    SecretRedactionOptions,
+    create_secret_redaction_sanitizer,
+)
 from .validation import validate_embedding_result, validate_embedding_start, validate_generation
 
 __all__ = [

--- a/python/sigil_sdk/redaction.py
+++ b/python/sigil_sdk/redaction.py
@@ -13,11 +13,19 @@ Add more patterns when concrete unredacted secrets are observed.
 
 from __future__ import annotations
 
+import logging
+import os
 import re
 from dataclasses import dataclass
 
 from .config import GenerationSanitizer
 from .models import Generation, Message, MessageRole, Part, PartKind
+
+_logger = logging.getLogger("sigil_sdk")
+
+_ENV_REDACT_INPUT_MESSAGES = "SIGIL_REDACT_INPUT_MESSAGES"
+_TRUE_TOKENS = frozenset({"1", "true", "yes", "on"})
+_FALSE_TOKENS = frozenset({"0", "false", "no", "off"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,14 +39,15 @@ class SecretRedactionOptions:
     """
     Options for the built-in secret redaction sanitizer.
 
-    `redact_input_messages` defaults to False to match the current opencode
-    plugin behavior.
+    `redact_input_messages` is None by default, which falls back to
+    SIGIL_REDACT_INPUT_MESSAGES and then to False (the current opencode plugin
+    behavior). Set it explicitly to override the env var.
 
     `redact_email_addresses` defaults to True. Callers can opt out when email
     addresses should be preserved.
     """
 
-    redact_input_messages: bool = False
+    redact_input_messages: bool | None = None
     redact_email_addresses: bool = True
 
 
@@ -106,6 +115,49 @@ class _SecretRedactor:
         return result
 
 
+def _resolve_redact_input_messages(
+    explicit: bool | None,
+    env: dict[str, str] | None = None,
+) -> bool:
+    """Resolve input-message redaction: explicit > env > ``False``.
+
+    ``SIGIL_REDACT_INPUT_MESSAGES`` accepts ``1/0``, ``true/false``,
+    ``yes/no``, ``on/off`` (case-insensitive) and is consulted only when
+    ``explicit`` is ``None``. An unrecognised env value logs a warning through
+    the ``sigil_sdk`` logger and falls back to ``False``, so a typo cannot
+    silently flip redaction.
+    """
+
+    if explicit is not None:
+        return explicit
+    raw = _env_lookup(env, _ENV_REDACT_INPUT_MESSAGES)
+    if raw is None:
+        return False
+    parsed = _parse_strict_bool(raw)
+    if parsed is None:
+        _logger.warning("sigil: ignoring invalid %s: %s", _ENV_REDACT_INPUT_MESSAGES, raw)
+        return False
+    return parsed
+
+
+def _env_lookup(env: dict[str, str] | None, key: str) -> str | None:
+    src = env if env is not None else os.environ
+    raw = src.get(key)
+    if raw is None:
+        return None
+    val = raw.strip()
+    return val or None
+
+
+def _parse_strict_bool(raw: str) -> bool | None:
+    token = raw.strip().lower()
+    if token in _TRUE_TOKENS:
+        return True
+    if token in _FALSE_TOKENS:
+        return False
+    return None
+
+
 def create_secret_redaction_sanitizer(
     options: SecretRedactionOptions | None = None,
 ) -> GenerationSanitizer:
@@ -113,13 +165,14 @@ def create_secret_redaction_sanitizer(
 
     resolved = options or SecretRedactionOptions()
     redactor = _SecretRedactor(include_email_addresses=resolved.redact_email_addresses)
+    redact_inputs = _resolve_redact_input_messages(resolved.redact_input_messages)
 
     def _sanitize(generation: Generation) -> Generation:
         if generation.system_prompt:
             generation.system_prompt = redactor.redact(generation.system_prompt)
 
         for message in generation.input:
-            if resolved.redact_input_messages:
+            if redact_inputs:
                 if message.role == MessageRole.USER:
                     mode = "full"
                 elif message.role == MessageRole.ASSISTANT:

--- a/python/tests/test_redaction.py
+++ b/python/tests/test_redaction.py
@@ -25,6 +25,7 @@ from sigil_sdk import (
     ToolResult,
     create_secret_redaction_sanitizer,
 )
+from sigil_sdk.redaction import _resolve_redact_input_messages
 
 
 def _new_client(
@@ -290,3 +291,58 @@ def test_generation_sanitizer_failure_falls_back_to_metadata_only(caplog) -> Non
         assert "sigil: generation sanitization failed, falling back to metadata_only" in caplog.text
     finally:
         client.shutdown()
+
+
+def test_resolve_redact_input_messages_defaults_to_false() -> None:
+    assert _resolve_redact_input_messages(None, env={}) is False
+
+
+def test_resolve_redact_input_messages_explicit_wins_over_env() -> None:
+    assert _resolve_redact_input_messages(False, env={"SIGIL_REDACT_INPUT_MESSAGES": "true"}) is False
+    assert _resolve_redact_input_messages(True, env={"SIGIL_REDACT_INPUT_MESSAGES": "false"}) is True
+
+
+def test_resolve_redact_input_messages_truthy_tokens() -> None:
+    for token in ("1", "true", "TRUE", "yes", "on"):
+        got = _resolve_redact_input_messages(None, env={"SIGIL_REDACT_INPUT_MESSAGES": token})
+        assert got is True, f"token={token!r}"
+
+
+def test_resolve_redact_input_messages_falsy_tokens() -> None:
+    for token in ("0", "false", "FALSE", "no", "off"):
+        got = _resolve_redact_input_messages(None, env={"SIGIL_REDACT_INPUT_MESSAGES": token})
+        assert got is False, f"token={token!r}"
+
+
+def test_resolve_redact_input_messages_blank_falls_back_to_false() -> None:
+    assert _resolve_redact_input_messages(None, env={"SIGIL_REDACT_INPUT_MESSAGES": "   "}) is False
+
+
+def test_resolve_redact_input_messages_invalid_warns_and_falls_back(caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger="sigil_sdk"):
+        got = _resolve_redact_input_messages(None, env={"SIGIL_REDACT_INPUT_MESSAGES": "maybe"})
+    assert got is False
+    assert any(
+        "SIGIL_REDACT_INPUT_MESSAGES" in record.getMessage() and "maybe" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_create_secret_redaction_sanitizer_reads_env(monkeypatch) -> None:
+    monkeypatch.setenv("SIGIL_REDACT_INPUT_MESSAGES", "true")
+    sanitizer = create_secret_redaction_sanitizer()
+    generation = Generation(
+        id="gen-env",
+        mode=GenerationMode.SYNC,
+        operation_name="generateText",
+        model=ModelRef(provider="openai", name="gpt-5"),
+        input=[
+            Message(
+                role=MessageRole.USER,
+                parts=[Part(kind=PartKind.TEXT, text="token glc_abcdefghijklmnopqrstuvwxyz0123")],
+            )
+        ],
+    )
+    sanitized = sanitizer(generation)
+    assert "glc_" not in sanitized.input[0].parts[0].text
+    assert "[REDACTED:grafana-cloud-token]" in sanitized.input[0].parts[0].text

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -477,7 +477,7 @@ wheels = [
 
 [[package]]
 name = "sigil-sdk"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes pre-ingest redaction of user prompts (PII/secrets) across three SDKs; default remains off, but misconfiguration or env typos only warn and fall back rather than silently enabling redaction.
> 
> **Overview**
> Adds **`SIGIL_REDACT_INPUT_MESSAGES`** so Go, JavaScript, and Python can turn on secret redaction for **user** messages in `Generation.Input` without code changes.
> 
> **`RedactInputMessages` / `redactInputMessages` / `redact_input_messages`** are now optional (`*bool` / omitted / `None`). Resolution is **explicit option → env → `false`**. The env accepts `1/0`, `true/false`, `yes/no`, `on/off` (case-insensitive). Invalid or blank values **warn and fall back** instead of being treated as false silently or enabling redaction by mistake.
> 
> Go adds `parseStrictBool` and `resolveRedactInputMessages`; JS injects optional `env` and `logger` into `createSecretRedactionSanitizer`. READMEs document the env for all three SDKs. Tests cover precedence, aliases, and invalid env handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc3bf62b6a5cd90d9addd46a329c7f18ac7e4a68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->