### PR TITLE
feat(plugins): wrap guard deny messages with source, tool, and behavior hint

### DIFF
--- a/plugins/opencode/src/guard.test.ts
+++ b/plugins/opencode/src/guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { denyResult, runToolCallGuard } from "./guard.js";
+import { runToolCallGuard } from "./guard.js";
 
 describe("runToolCallGuard", () => {
   it("returns undefined when Sigil allows the tool call", async () => {
@@ -29,7 +29,7 @@ describe("runToolCallGuard", () => {
     );
   });
 
-  it("returns a block result when Sigil denies the tool call", async () => {
+  it("returns a wrapped policy-deny result when Sigil denies the tool call", async () => {
     const client = {
       evaluateHook: async () => ({
         action: "deny",
@@ -48,10 +48,40 @@ describe("runToolCallGuard", () => {
       failOpen: true,
     });
 
-    expect(res).toEqual({ block: true, reason: "blocked by rule" });
+    expect(res?.block).toBe(true);
+    expect(res?.reason).toContain("A Grafana AI Observability policy");
+    expect(res?.reason).toContain('"bash"');
+    expect(res?.reason).toContain("Reason: blocked by rule");
+    expect(res?.reason).toContain("Stop and tell the user");
   });
 
-  it("denies when the SDK throws (fail-closed mode)", async () => {
+  it("omits the Reason clause when Sigil denies without a reason", async () => {
+    const client = {
+      evaluateHook: async () => ({
+        action: "deny",
+        reason: "   ",
+        evaluations: [],
+      }),
+    };
+
+    const res = await runToolCallGuard({
+      client: client as any,
+      agentName: "opencode",
+      model: { provider: "anthropic", name: "claude" },
+      toolCallId: "c1",
+      toolName: "bash",
+      input: { command: "ls" },
+      failOpen: true,
+    });
+
+    expect(res?.block).toBe(true);
+    expect(res?.reason).toContain("A Grafana AI Observability policy");
+    expect(res?.reason).toContain('"bash"');
+    expect(res?.reason).not.toContain("Reason:");
+    expect(res?.reason).toContain("Stop and tell the user");
+  });
+
+  it("returns a wrapped fail-closed message when the SDK throws (fail-closed mode)", async () => {
     const client = {
       evaluateHook: async () => {
         throw new Error("network down");
@@ -69,7 +99,13 @@ describe("runToolCallGuard", () => {
     });
 
     expect(res?.block).toBe(true);
-    expect(res?.reason).toContain("sigil guard evaluation failed");
+    expect(res?.reason).toContain("could not evaluate");
+    expect(res?.reason).toContain("safety measure");
+    expect(res?.reason).toContain('"bash"');
+    expect(res?.reason).toContain("network down");
+    expect(res?.reason).not.toContain(
+      "A Grafana AI Observability policy blocked",
+    );
   });
 
   it("allows when the SDK throws (fail-open mode)", async () => {
@@ -113,12 +149,5 @@ describe("runToolCallGuard", () => {
     });
 
     expect(res).toBeUndefined();
-  });
-
-  it("uses the default deny reason when Sigil omits one", () => {
-    expect(denyResult(undefined)).toEqual({
-      block: true,
-      reason: "tool call denied by Sigil guard",
-    });
   });
 });

--- a/plugins/opencode/src/guard.ts
+++ b/plugins/opencode/src/guard.ts
@@ -14,6 +14,54 @@ export interface GuardArgs {
 export type GuardBlockResult = { block: true; reason: string };
 
 /**
+ * Instructs the model how to react to a guard deny verdict, so the reason is
+ * not mistaken for a generic tool failure to retry or work around. Appended
+ * by both the policy-deny and fail-closed formatters.
+ *
+ * Mirrors `guardBehaviorHint` in `plugins/sigil/internal/agents/guard/toolcall.go`.
+ * Keep the two in sync.
+ */
+const GUARD_BEHAVIOR_HINT =
+  "Stop and tell the user this tool call was blocked, then wait for their direction before taking any other action.";
+
+/**
+ * Wraps a rule-authored reason (which may be empty) into a self-explanatory
+ * message naming the Grafana AI Observability source, the blocked tool, and
+ * the expected agent behavior.
+ *
+ * Mirrors `formatPolicyDeny` in the Go guard helper. Keep the wording aligned.
+ */
+function formatPolicyDeny(
+  toolName: string,
+  reason: string | undefined,
+): string {
+  let msg = `A Grafana AI Observability policy blocked the "${toolName}" tool call, so it was not run.`;
+  const trimmed = reason?.trim();
+  if (trimmed) {
+    msg += ` Reason: ${trimmed}`;
+  }
+  return `${msg}\n\n${GUARD_BEHAVIOR_HINT}`;
+}
+
+/**
+ * Fail-closed message used when the guard evaluation request fails. Explicitly
+ * distinguishes the infrastructure failure from a policy decision.
+ *
+ * Mirrors `formatEvalFailure` in the Go guard helper. Keep the wording aligned.
+ */
+function formatEvalFailure(
+  toolName: string,
+  detail: string | undefined,
+): string {
+  let msg = `Sigil could not evaluate the Grafana AI Observability guard for the "${toolName}" tool call, so it was blocked as a safety measure.`;
+  const trimmed = detail?.trim();
+  if (trimmed) {
+    msg += ` Details: ${trimmed}`;
+  }
+  return `${msg}\n\n${GUARD_BEHAVIOR_HINT}`;
+}
+
+/**
  * Evaluates the Sigil postflight hook for a tool call. Returns a block result
  * when the server denies the call. On transport/timeout/serialization errors,
  * returns `undefined` (allow) when `failOpen` is true and a block result when
@@ -53,23 +101,20 @@ export async function runToolCallGuard(
     };
 
     const resp = await args.client.evaluateHook(req, { enabled: true });
-    if (resp.action === "deny") return denyResult(resp.reason);
+    if (resp.action === "deny") {
+      return {
+        block: true,
+        reason: formatPolicyDeny(args.toolName, resp.reason),
+      };
+    }
     return undefined;
   } catch (err) {
     if (!args.failOpen) {
-      return denyResult(`sigil guard evaluation failed: ${String(err)}`);
+      return {
+        block: true,
+        reason: formatEvalFailure(args.toolName, String(err)),
+      };
     }
     return undefined;
   }
-}
-
-export function denyResult(reason: string | undefined): GuardBlockResult {
-  const trimmed = reason?.trim();
-  return {
-    block: true,
-    reason:
-      trimmed && trimmed.length > 0
-        ? trimmed
-        : "tool call denied by Sigil guard",
-  };
 }

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -490,6 +490,7 @@ function handleToolExecuteAfter(
 async function handlePermissionAsk(
   sigil: SigilClient,
   config: SigilOpencodeConfig,
+  debugLog: (msg: string, ...args: unknown[]) => void,
   input: Permission,
   output: { status: "ask" | "deny" | "allow" },
 ): Promise<void> {
@@ -511,6 +512,12 @@ async function handlePermissionAsk(
   });
   if (res?.block) {
     output.status = "deny";
+    // Log the reason so it's recoverable from the debug log; opencode's
+    // permission.ask output API has no field to surface it to the model or
+    // the user.
+    debugLog(
+      `guard denied permission.ask for tool=${input.type} (reason dropped, API has no field): ${res.reason}`,
+    );
   }
 }
 
@@ -797,7 +804,7 @@ export async function createSigilHooks(
       handleToolExecuteAfter(input, output);
     },
     permissionAsk: async (input, output) => {
-      await handlePermissionAsk(sigil, config, input, output);
+      await handlePermissionAsk(sigil, config, debugLog, input, output);
     },
   };
 }

--- a/plugins/pi/src/guard.test.ts
+++ b/plugins/pi/src/guard.test.ts
@@ -52,7 +52,7 @@ describe("runToolCallGuard", () => {
     expect(result).toBeUndefined();
   });
 
-  it("returns block + reason when the server denies", async () => {
+  it("returns block with wrapped policy-deny reason when the server denies", async () => {
     const { client } = makeClient(async () => ({
       action: "deny",
       reason: "blocked rm -rf",
@@ -60,10 +60,14 @@ describe("runToolCallGuard", () => {
     }));
 
     const result = await runToolCallGuard(makeArgs({ client }));
-    expect(result).toEqual({ block: true, reason: "blocked rm -rf" });
+    expect(result?.block).toBe(true);
+    expect(result?.reason).toContain("blocked rm -rf");
+    expect(result?.reason).toContain("A Grafana AI Observability policy");
+    expect(result?.reason).toContain('"bash"');
+    expect(result?.reason).toContain("Stop and tell the user");
   });
 
-  it("falls back to a generic reason when the deny reason is empty", async () => {
+  it("omits the Reason clause when the deny reason is empty", async () => {
     const { client } = makeClient(async () => ({
       action: "deny",
       reason: "   ",
@@ -71,10 +75,11 @@ describe("runToolCallGuard", () => {
     }));
 
     const result = await runToolCallGuard(makeArgs({ client }));
-    expect(result).toEqual({
-      block: true,
-      reason: "tool call denied by Sigil guard",
-    });
+    expect(result?.block).toBe(true);
+    expect(result?.reason).toContain("A Grafana AI Observability policy");
+    expect(result?.reason).toContain('"bash"');
+    expect(result?.reason).not.toContain("Reason:");
+    expect(result?.reason).toContain("Stop and tell the user");
   });
 
   it("returns undefined and logs a warning on transport errors when failOpen", async () => {
@@ -109,7 +114,7 @@ describe("runToolCallGuard", () => {
     );
   });
 
-  it("returns block on transport errors when failOpen=false", async () => {
+  it("returns block with fail-closed message on transport errors when failOpen=false", async () => {
     const { client } = makeClient(async () => {
       throw new Error("network down");
     });
@@ -118,10 +123,14 @@ describe("runToolCallGuard", () => {
     const result = await runToolCallGuard(
       makeArgs({ client, failOpen: false, logger: { warn } }),
     );
-    expect(result).toEqual({
-      block: true,
-      reason: expect.stringContaining("guard evaluation failed"),
-    });
+    expect(result?.block).toBe(true);
+    expect(result?.reason).toContain("could not evaluate");
+    expect(result?.reason).toContain("safety measure");
+    expect(result?.reason).toContain('"bash"');
+    expect(result?.reason).toContain("network down");
+    expect(result?.reason).not.toContain(
+      "A Grafana AI Observability policy blocked",
+    );
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("guard eval failed"),
     );

--- a/plugins/pi/src/guard.ts
+++ b/plugins/pi/src/guard.ts
@@ -15,6 +15,55 @@ export interface GuardArgs {
 export type GuardBlockResult = { block: true; reason: string };
 
 /**
+ * Instructs the model how to react to a guard deny verdict, so the reason is
+ * not mistaken for a generic tool failure to retry or work around. Appended
+ * by both the policy-deny and fail-closed formatters.
+ *
+ * Mirrors `guardBehaviorHint` in `plugins/sigil/internal/agents/guard/toolcall.go`.
+ * Keep the two in sync.
+ */
+const GUARD_BEHAVIOR_HINT =
+  "Stop and tell the user this tool call was blocked, then wait for their direction before taking any other action.";
+
+/**
+ * Wraps a rule-authored reason (which may be empty) into a self-explanatory
+ * message naming the Grafana AI Observability source, the blocked tool, and
+ * the expected agent behavior.
+ *
+ * Mirrors `formatPolicyDeny` in the Go guard helper. Keep the wording aligned.
+ */
+function formatPolicyDeny(
+  toolName: string,
+  reason: string | undefined,
+): string {
+  let msg = `A Grafana AI Observability policy blocked the "${toolName}" tool call, so it was not run.`;
+  const trimmed = reason?.trim();
+  if (trimmed) {
+    msg += ` Reason: ${trimmed}`;
+  }
+  return `${msg}\n\n${GUARD_BEHAVIOR_HINT}`;
+}
+
+/**
+ * Fail-closed message used when the guard could not be evaluated (transport
+ * failure or, on the Go side, missing credentials). Explicitly distinguishes
+ * the infrastructure failure from a policy decision.
+ *
+ * Mirrors `formatEvalFailure` in the Go guard helper. Keep the wording aligned.
+ */
+function formatEvalFailure(
+  toolName: string,
+  detail: string | undefined,
+): string {
+  let msg = `Sigil could not evaluate the Grafana AI Observability guard for the "${toolName}" tool call, so it was blocked as a safety measure.`;
+  const trimmed = detail?.trim();
+  if (trimmed) {
+    msg += ` Details: ${trimmed}`;
+  }
+  return `${msg}\n\n${GUARD_BEHAVIOR_HINT}`;
+}
+
+/**
  * Evaluates the Sigil postflight hook for a tool call. Returns a block result
  * when the server denies the call. On transport/timeout/serialization errors,
  * returns `undefined` (allow) when `failOpen` is true and a block result when
@@ -56,25 +105,20 @@ export async function runToolCallGuard(
 
     const resp = await args.client.evaluateHook(req, { enabled: true });
     if (resp.action === "deny") {
-      return denyResult(resp.reason);
+      return {
+        block: true,
+        reason: formatPolicyDeny(args.toolName, resp.reason),
+      };
     }
     return undefined;
   } catch (err) {
     args.logger?.warn(`guard eval failed: ${err}`);
     if (!args.failOpen) {
-      return denyResult(`guard evaluation failed: ${err}`);
+      return {
+        block: true,
+        reason: formatEvalFailure(args.toolName, String(err)),
+      };
     }
     return undefined;
   }
-}
-
-function denyResult(reason: string | undefined): GuardBlockResult {
-  const trimmed = reason?.trim();
-  return {
-    block: true,
-    reason:
-      trimmed && trimmed.length > 0
-        ? trimmed
-        : "tool call denied by Sigil guard",
-  };
 }

--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -1239,7 +1239,12 @@ describe("extension lifecycle", () => {
         defaultCtx,
       );
 
-      expect(result).toEqual({ block: true, reason: "blocked rm -rf" });
+      expect(result).toMatchObject({ block: true });
+      const reason = (result as unknown as { reason: string }).reason;
+      expect(reason).toContain("blocked rm -rf");
+      expect(reason).toContain("A Grafana AI Observability policy");
+      expect(reason).toContain('"bash"');
+      expect(reason).toContain("Stop and tell the user");
     });
 
     it("forwards the model cached from the current assistant message_end", async () => {

--- a/plugins/sigil/internal/agents/claudecode/hook_test.go
+++ b/plugins/sigil/internal/agents/claudecode/hook_test.go
@@ -228,7 +228,8 @@ func TestHandlePreToolUse(t *testing.T) {
 				`"hookSpecificOutput"`,
 				`"hookEventName":"PreToolUse"`,
 				`"permissionDecision":"deny"`,
-				`"permissionDecisionReason":"blocked tool"`,
+				`A Grafana AI Observability policy`,
+				`blocked tool`,
 			},
 		},
 	}

--- a/plugins/sigil/internal/agents/codex/hook/handlers_test.go
+++ b/plugins/sigil/internal/agents/codex/hook/handlers_test.go
@@ -773,14 +773,14 @@ func TestPreToolUseGuard(t *testing.T) {
 			env:                map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
 			serverResponds:     `{"action":"deny","reason":"blocked tool"}`,
 			expectServerCall:   true,
-			wantStdoutContains: []string{`"permissionDecision":"deny"`, "blocked tool"},
+			wantStdoutContains: []string{`"permissionDecision":"deny"`, "blocked tool", "A Grafana AI Observability policy"},
 		},
 		{
 			name:               "enabled_deny_empty_reason_fallback",
 			env:                map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
 			serverResponds:     `{"action":"deny"}`,
 			expectServerCall:   true,
-			wantStdoutContains: []string{`"permissionDecision":"deny"`, "tool call denied by Sigil guard"},
+			wantStdoutContains: []string{`"permissionDecision":"deny"`, "A Grafana AI Observability policy blocked"},
 		},
 		{
 			name:              "enabled_fail_open_on_transport_error",
@@ -795,7 +795,7 @@ func TestPreToolUseGuard(t *testing.T) {
 				"SIGIL_GUARDS_FAIL_OPEN": "false",
 			},
 			useClosedEndpoint:  true,
-			wantStdoutContains: []string{`"permissionDecision":"deny"`, "sigil guard evaluation failed"},
+			wantStdoutContains: []string{`"permissionDecision":"deny"`, "could not evaluate"},
 		},
 		{
 			name:            "enabled_fail_open_missing_credentials",

--- a/plugins/sigil/internal/agents/copilot/hook/handlers_test.go
+++ b/plugins/sigil/internal/agents/copilot/hook/handlers_test.go
@@ -490,7 +490,7 @@ func TestPreToolUseGuardBehavior(t *testing.T) {
 		// clearCreds blanks SIGIL_ENDPOINT/SIGIL_AUTH_TENANT_ID/SIGIL_AUTH_TOKEN.
 		clearCreds          bool
 		wantServerCalled    bool
-		wantStdoutContains  string
+		wantStdoutContains  []string
 		wantStdoutEmpty     bool
 		wantToolRecordCount int
 	}{
@@ -513,7 +513,7 @@ func TestPreToolUseGuardBehavior(t *testing.T) {
 			guards:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
 			hookResponse:        `{"action":"deny","reason":"blocked tool"}`,
 			wantServerCalled:    true,
-			wantStdoutContains:  `"permissionDecision":"deny"`,
+			wantStdoutContains:  []string{`"permissionDecision":"deny"`, `A Grafana AI Observability policy`, `blocked tool`},
 			wantToolRecordCount: 0,
 		},
 		{
@@ -527,7 +527,7 @@ func TestPreToolUseGuardBehavior(t *testing.T) {
 			name:                "fail-closed transport error denies tool and skips record",
 			guards:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: false},
 			useClosedServer:     true,
-			wantStdoutContains:  `"permissionDecision":"deny"`,
+			wantStdoutContains:  []string{`"permissionDecision":"deny"`, `could not evaluate`},
 			wantToolRecordCount: 0,
 		},
 		{
@@ -541,7 +541,7 @@ func TestPreToolUseGuardBehavior(t *testing.T) {
 			name:                "fail-closed missing credentials denies tool and skips record",
 			guards:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: false},
 			clearCreds:          true,
-			wantStdoutContains:  `"permissionDecision":"deny"`,
+			wantStdoutContains:  []string{`"permissionDecision":"deny"`, `could not evaluate`, `missing SIGIL_ENDPOINT`},
 			wantToolRecordCount: 0,
 		},
 	}
@@ -604,8 +604,10 @@ func TestPreToolUseGuardBehavior(t *testing.T) {
 			if tt.wantStdoutEmpty && stdout.Len() != 0 {
 				t.Errorf("stdout not empty: %q", stdout.String())
 			}
-			if tt.wantStdoutContains != "" && !strings.Contains(stdout.String(), tt.wantStdoutContains) {
-				t.Errorf("stdout = %q, want substring %q", stdout.String(), tt.wantStdoutContains)
+			for _, want := range tt.wantStdoutContains {
+				if !strings.Contains(stdout.String(), want) {
+					t.Errorf("stdout = %q, want substring %q", stdout.String(), want)
+				}
 			}
 
 			frag := fragment.LoadTolerant("sess", "turn-000001", logger)

--- a/plugins/sigil/internal/agents/copilot/hook_test.go
+++ b/plugins/sigil/internal/agents/copilot/hook_test.go
@@ -58,8 +58,9 @@ func TestHookPreToolUseDeniedPropagatesStdout(t *testing.T) {
 	if !strings.Contains(stdout.String(), `"permissionDecision":"deny"`) {
 		t.Fatalf("stdout = %q, want deny decision", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), `"permissionDecisionReason":"blocked"`) {
-		t.Fatalf("stdout = %q, want deny reason", stdout.String())
+	if !strings.Contains(stdout.String(), `A Grafana AI Observability policy`) ||
+		!strings.Contains(stdout.String(), `Reason: blocked`) {
+		t.Fatalf("stdout = %q, want wrapped deny reason", stdout.String())
 	}
 }
 

--- a/plugins/sigil/internal/agents/guard/toolcall.go
+++ b/plugins/sigil/internal/agents/guard/toolcall.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -19,6 +20,34 @@ import (
 
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/envconfig"
 )
+
+// guardBehaviorHint instructs the model on how to react to a deny verdict so
+// the surfaced reason is not mistaken for a generic tool failure to retry or
+// work around. It is appended by both the policy-deny and fail-closed
+// formatters.
+const guardBehaviorHint = "Stop and tell the user this tool call was blocked, then wait for their direction before taking any other action."
+
+// formatPolicyDeny wraps a rule-authored reason (which may be empty) into a
+// self-explanatory message naming the Grafana AI Observability source, the
+// blocked tool, and the expected agent behavior.
+func formatPolicyDeny(toolName, reason string) string {
+	msg := fmt.Sprintf("A Grafana AI Observability policy blocked the %q tool call, so it was not run.", toolName)
+	if r := strings.TrimSpace(reason); r != "" {
+		msg += " Reason: " + r
+	}
+	return msg + "\n\n" + guardBehaviorHint
+}
+
+// formatEvalFailure is the fail-closed message used when the guard could not
+// be evaluated (missing credentials or transport failure). It explicitly
+// distinguishes the infrastructure failure from a policy decision.
+func formatEvalFailure(toolName, detail string) string {
+	msg := fmt.Sprintf("Sigil could not evaluate the Grafana AI Observability guard for the %q tool call, so it was blocked as a safety measure.", toolName)
+	if d := strings.TrimSpace(detail); d != "" {
+		msg += " Details: " + d
+	}
+	return msg + "\n\n" + guardBehaviorHint
+}
 
 // ToolCallInput is the host-neutral set of fields needed to evaluate a
 // tool call against Sigil guards.
@@ -96,7 +125,7 @@ func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCa
 		}
 		return Result{
 			Action: sigil.HookActionDeny,
-			Reason: "sigil guard evaluation unavailable: missing SIGIL_ENDPOINT/SIGIL_AUTH_TENANT_ID/SIGIL_AUTH_TOKEN",
+			Reason: formatEvalFailure(in.ToolName, "missing SIGIL_ENDPOINT/SIGIL_AUTH_TENANT_ID/SIGIL_AUTH_TOKEN"),
 		}
 	}
 
@@ -169,7 +198,7 @@ func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCa
 		}
 		return Result{
 			Action: sigil.HookActionDeny,
-			Reason: "sigil guard evaluation failed: " + err.Error(),
+			Reason: formatEvalFailure(in.ToolName, err.Error()),
 		}
 	}
 
@@ -185,10 +214,10 @@ func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCa
 	}
 
 	if deniedErr := sigil.HookDeniedFromResponse(resp); deniedErr != nil {
-		reason := "tool call denied by Sigil guard"
+		var ruleReason string
 		var denied *sigil.HookDeniedError
-		if errors.As(deniedErr, &denied) && strings.TrimSpace(denied.Reason) != "" {
-			reason = denied.Reason
+		if errors.As(deniedErr, &denied) {
+			ruleReason = denied.Reason
 		}
 		ruleID := ""
 		if resp != nil {
@@ -196,7 +225,7 @@ func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCa
 		}
 		return Result{
 			Action: sigil.HookActionDeny,
-			Reason: reason,
+			Reason: formatPolicyDeny(in.ToolName, ruleReason),
 			RuleID: ruleID,
 		}
 	}

--- a/plugins/sigil/internal/agents/guard/toolcall_test.go
+++ b/plugins/sigil/internal/agents/guard/toolcall_test.go
@@ -78,7 +78,7 @@ func TestEvaluateToolCall(t *testing.T) {
 			useClosedServer: true,
 			toolName:        "bash",
 			wantAction:      sigil.HookActionDeny,
-			wantReasonSub:   "sigil guard evaluation failed",
+			wantReasonSub:   "could not evaluate",
 		},
 		{
 			name:          "missing credentials fail open",


### PR DESCRIPTION
The deny reason surfaced to the agent was the bare rule string, and the agents sometimes read it as a generic tool failure and retried or worked around it. 

Now it returns a clearer message instead:

> A Grafana AI Observability policy blocked the %q tool call, so it was not run.
> Stop and tell the user this tool call was blocked, then wait for their direction before taking any other action.

Or in case of a failure:

> Sigil could not evaluate the Grafana AI Observability guard for the %q tool call, so it was blocked as a safety measure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user- and model-visible guard messaging and fail-closed copy across multiple agent integrations; behavior is safer but wording must stay aligned between Go and TS.
> 
> **Overview**
> Guard **deny** and **fail-closed** reasons are no longer bare rule or SDK strings. Shared formatters in the Go `guard` helper and the **opencode** / **pi** TypeScript guards now build messages that name **Grafana AI Observability**, the blocked **tool**, an optional **Reason** / **Details** line, and a fixed **behavior hint** telling the model to stop, inform the user, and wait—so denials are not treated like retriable tool errors.
> 
> **Policy deny** uses the “policy blocked … tool call” wording; **evaluation failures** (transport, missing credentials, fail-closed SDK errors) use “could not evaluate … safety measure” wording instead of the policy template. The old `denyResult` export was removed in favor of inline formatting.
> 
> Tests across Claude Code, Codex, Copilot, opencode, and pi were updated for the new strings. **Opencode** also **debug-logs** the full deny reason on `permission.ask` when the API only allows `status: deny` and cannot surface the message to the model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 713e12558f58bb669c841bfa4ec7f4f4f3a63e63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->