### PR TITLE
feat(plugins/pi): set a conversation title on exported generations

### DIFF
--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -24,7 +24,9 @@ import {
   type PiToolInfo,
   type PiToolResult,
   type PiUserMessage,
+  resolveConversationTitle,
   type ToolTiming,
+  userMessageText,
 } from "./mappers.js";
 import {
   createTelemetryProviders,
@@ -73,6 +75,12 @@ export default function (pi: ExtensionAPI) {
   // boundaries.
   const pendingInputMessages: Message[] = [];
 
+  // First user prompt text seen in this session, used to derive a
+  // conversation title when pi has no user-set session name. First prompt
+  // wins, so it persists across turns and is only cleared on session
+  // boundaries (never in resetTurnState).
+  let firstUserText: string | undefined;
+
   function resetTurnState() {
     turnStartTime = 0;
     firstTokenTime = 0;
@@ -93,6 +101,7 @@ export default function (pi: ExtensionAPI) {
     }
     resetTurnState();
     pendingInputMessages.length = 0;
+    firstUserText = undefined;
     lastSeenModel = null;
     currentSystemPrompt = undefined;
     currentRequestControls = {};
@@ -224,6 +233,10 @@ export default function (pi: ExtensionAPI) {
         return;
       }
       if (!isUserMessage(message)) return;
+      if (firstUserText === undefined) {
+        const text = userMessageText(message).trim();
+        if (text.length > 0) firstUserText = text;
+      }
       const mapped = mapUserMessage(message, config.contentCapture);
       if (mapped) pendingInputMessages.push(mapped);
     } catch (err) {
@@ -389,8 +402,25 @@ export default function (pi: ExtensionAPI) {
         conversationId,
       );
 
+      // Prefer pi's user-set session name; otherwise derive from the first
+      // prompt (suppressed in metadata_only). Resolved per turn so a name
+      // set mid-session shows up on the next generation.
+      let sessionName: string | undefined;
+      try {
+        sessionName = ctx.sessionManager.getSessionName?.();
+      } catch (err) {
+        logger.debug("getSessionName failed", err);
+      }
+      const conversationTitle = resolveConversationTitle({
+        sessionName,
+        firstUserText,
+        conversationId,
+        contentCapture,
+      });
+
       const seed = mapGenerationStart(msg, {
         conversationId,
+        conversationTitle,
         agentName: config.agentName,
         agentVersion: config.agentVersion,
         startedAt: startedAtMs,
@@ -435,6 +465,7 @@ export default function (pi: ExtensionAPI) {
             turnToolTimings,
             {
               conversationId,
+              conversationTitle,
               agentName: (config as SigilPiConfig).agentName,
               agentVersion: (config as SigilPiConfig).agentVersion,
               contentCapture,
@@ -485,6 +516,7 @@ export function emitToolSpans(
   timings: ToolTiming[],
   opts: {
     conversationId?: string;
+    conversationTitle?: string;
     agentName: string;
     agentVersion?: string;
     contentCapture: ContentCaptureMode;
@@ -521,6 +553,7 @@ export function emitToolSpans(
         toolCallId: timing.toolCallId,
         toolType: "function",
         conversationId: opts.conversationId,
+        conversationTitle: opts.conversationTitle,
         agentName: opts.agentName,
         agentVersion: opts.agentVersion,
         requestModel: msg.model,

--- a/plugins/pi/src/mappers.test.ts
+++ b/plugins/pi/src/mappers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   extractRequestControls,
+  MAX_TITLE_LEN,
   mapGenerationResult,
   mapGenerationStart,
   mapTools,
@@ -9,6 +10,8 @@ import {
   type PiToolInfo,
   type PiToolResult,
   type PiUserMessage,
+  resolveConversationTitle,
+  userMessageText,
 } from "./mappers.js";
 
 function makeMsg(overrides?: Partial<PiAssistantMessage>): PiAssistantMessage {
@@ -88,6 +91,23 @@ describe("mapGenerationStart", () => {
     expect(start.agentName).toBe("pi");
     expect(start.agentVersion).toBe("1.0.0");
     expect(start.startedAt).toEqual(new Date(1700000000000));
+  });
+
+  it("sets conversationTitle when provided and omits it when empty", () => {
+    const withTitle = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      conversationTitle: "summarize the go files",
+      agentName: "pi",
+      startedAt: 0,
+    });
+    expect(withTitle.conversationTitle).toBe("summarize the go files");
+
+    const without = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+    });
+    expect(without.conversationTitle).toBeUndefined();
   });
 
   it("includes tools whenever provided", () => {
@@ -665,6 +685,124 @@ describe("mapUserMessage", () => {
       role: "user",
       parts: [{ type: "text", text: "hey" }],
     });
+  });
+});
+
+describe("resolveConversationTitle", () => {
+  it("prefers a user-set session name over the first prompt", () => {
+    expect(
+      resolveConversationTitle({
+        sessionName: "My named session",
+        firstUserText: "summarize the go files",
+        conversationId: "pi-conv-1",
+        contentCapture: "full",
+      }),
+    ).toBe("My named session");
+  });
+
+  it("derives from the first prompt when no session name is set", () => {
+    expect(
+      resolveConversationTitle({
+        firstUserText: "summarize the go files",
+        conversationId: "pi-conv-1",
+        contentCapture: "full",
+      }),
+    ).toBe("summarize the go files");
+  });
+
+  it("trims whitespace from session name and derived title", () => {
+    expect(
+      resolveConversationTitle({
+        sessionName: "  spaced name  ",
+        contentCapture: "full",
+      }),
+    ).toBe("spaced name");
+    expect(
+      resolveConversationTitle({
+        firstUserText: "  hi there  ",
+        contentCapture: "full",
+      }),
+    ).toBe("hi there");
+  });
+
+  it("ignores a blank session name and falls through to the prompt", () => {
+    expect(
+      resolveConversationTitle({
+        sessionName: "   ",
+        firstUserText: "do the thing",
+        conversationId: "pi-conv-1",
+        contentCapture: "full",
+      }),
+    ).toBe("do the thing");
+  });
+
+  it("suppresses the derived title in metadata_only but keeps the session name", () => {
+    expect(
+      resolveConversationTitle({
+        firstUserText: "summarize the go files",
+        conversationId: "pi-conv-1",
+        contentCapture: "metadata_only",
+      }),
+    ).toBe("pi-conv-1");
+    expect(
+      resolveConversationTitle({
+        sessionName: "My named session",
+        firstUserText: "summarize the go files",
+        conversationId: "pi-conv-1",
+        contentCapture: "metadata_only",
+      }),
+    ).toBe("My named session");
+  });
+
+  it("falls back to the conversation id when nothing else is available", () => {
+    expect(
+      resolveConversationTitle({
+        conversationId: "pi-conv-1",
+        contentCapture: "full",
+      }),
+    ).toBe("pi-conv-1");
+  });
+
+  it("returns undefined when there is no name, prompt, or id", () => {
+    expect(
+      resolveConversationTitle({ contentCapture: "full" }),
+    ).toBeUndefined();
+  });
+
+  it("caps the title at MAX_TITLE_LEN code points without splitting surrogates", () => {
+    const long = "a".repeat(150);
+    expect(
+      resolveConversationTitle({ firstUserText: long, contentCapture: "full" }),
+    ).toHaveLength(MAX_TITLE_LEN);
+
+    // 150 two-code-unit emoji = 150 code points; the cap counts code points,
+    // so it clips to 100 without slicing mid-surrogate into a replacement char.
+    const emoji = "😀".repeat(150);
+    const clipped = resolveConversationTitle({
+      firstUserText: emoji,
+      contentCapture: "full",
+    });
+    expect(Array.from(clipped ?? "")).toHaveLength(MAX_TITLE_LEN);
+    expect(clipped).not.toContain("\uFFFD");
+  });
+});
+
+describe("userMessageText", () => {
+  it("returns string content as-is", () => {
+    expect(userMessageText(makeUserMsg({ content: "hello" }))).toBe("hello");
+  });
+
+  it("joins text parts and drops images", () => {
+    const text = userMessageText(
+      makeUserMsg({
+        content: [
+          { type: "text", text: "first" },
+          { type: "image", data: "ZmFrZQ==", mimeType: "image/png" },
+          { type: "text", text: "second" },
+        ],
+      }),
+    );
+    expect(text).toBe("first\nsecond");
   });
 });
 

--- a/plugins/pi/src/mappers.ts
+++ b/plugins/pi/src/mappers.ts
@@ -118,9 +118,63 @@ export interface ToolTiming {
   isError: boolean;
 }
 
+/**
+ * Cap for the conversation title. Counts code points, not UTF-16 units, so a
+ * trailing surrogate pair (emoji) is never split.
+ */
+export const MAX_TITLE_LEN = 100;
+
+function clipTitle(value: string): string {
+  const trimmed = value.trim();
+  const codepoints = Array.from(trimmed);
+  return codepoints.length > MAX_TITLE_LEN
+    ? codepoints.slice(0, MAX_TITLE_LEN).join("")
+    : trimmed;
+}
+
+/** Inputs for {@link resolveConversationTitle}. */
+export interface ResolveConversationTitleOptions {
+  /** User-defined session name from pi's `SessionManager.getSessionName()`. */
+  sessionName?: string;
+  /** First user prompt text seen in the session (first prompt wins). */
+  firstUserText?: string;
+  /** Session id, used as the last-resort fallback. */
+  conversationId?: string;
+  contentCapture: ContentCaptureMode;
+}
+
+/**
+ * Resolve the conversation title shown in Sigil.
+ *
+ * Pi exposes a real, user-defined session name via `getSessionName()`; prefer
+ * it whenever set. Otherwise derive a title from the first user prompt, the
+ * same approach the Claude Code and Cursor plugins take since neither host
+ * exposes a name. The derived title is suppressed in `metadata_only` because
+ * the prompt body is dropped from the export in that mode; a user-set session
+ * name is metadata rather than content, so it survives. Falls back to the
+ * session id when nothing else is available.
+ *
+ * The returned title is not redacted here: the SDK's generation sanitizer
+ * runs `redactLightweight` over `conversationTitle` on export.
+ */
+export function resolveConversationTitle(
+  opts: ResolveConversationTitleOptions,
+): string | undefined {
+  const name = opts.sessionName?.trim();
+  if (name) return clipTitle(name);
+
+  if (opts.contentCapture !== "metadata_only") {
+    const derived = opts.firstUserText?.trim();
+    if (derived) return clipTitle(derived);
+  }
+
+  return opts.conversationId;
+}
+
 /** Optional context for building a GenerationStart seed. */
 export interface MapGenerationStartOptions {
   conversationId?: string;
+  conversationTitle?: string;
   agentName: string;
   agentVersion?: string;
   startedAt: number;
@@ -148,6 +202,7 @@ export function mapGenerationStart(
 ): GenerationStart {
   const {
     conversationId,
+    conversationTitle,
     agentName,
     agentVersion,
     startedAt,
@@ -162,6 +217,7 @@ export function mapGenerationStart(
   // `{...clientTags, ...seedTags}`), matching claude-code/cursor.
   const start: GenerationStart = {
     conversationId,
+    ...(conversationTitle ? { conversationTitle } : {}),
     agentName,
     agentVersion,
     effectiveVersion: agentVersion,
@@ -272,22 +328,26 @@ export function mapUserMessage(
 ): Message | null {
   if (contentCapture === "metadata_only") return null;
 
-  let text: string;
-  if (typeof msg.content === "string") {
-    text = msg.content;
-  } else {
-    text = msg.content
-      .filter((c): c is PiTextContent => c.type === "text")
-      .map((c) => c.text)
-      .join("\n");
-  }
-
+  const text = userMessageText(msg);
   if (text.trim().length === 0) return null;
 
   return {
     role: "user",
     parts: [{ type: "text", text }],
   };
+}
+
+/**
+ * Flatten a pi user message to plain text. String content passes through;
+ * a content array keeps text parts (joined with a newline) and drops images,
+ * which Sigil's `MessagePart` union cannot represent.
+ */
+export function userMessageText(msg: PiUserMessage): string {
+  if (typeof msg.content === "string") return msg.content;
+  return msg.content
+    .filter((c): c is PiTextContent => c.type === "text")
+    .map((c) => c.text)
+    .join("\n");
 }
 
 /**

--- a/plugins/pi/src/testdata/golden/pi-full-turn.golden.json
+++ b/plugins/pi/src/testdata/golden/pi-full-turn.golden.json
@@ -99,6 +99,7 @@
         },
         "metadata": {
           "cost_usd": 0.003,
+          "sigil.conversation.title": "summarize the go files",
           "sigil.sdk.name": "sdk-js",
           "sigil.sdk.content_capture_mode": "full"
         },


### PR DESCRIPTION
Pi only sent `conversation_id`, so Sigil labeled every conversation with the raw session id (`pi-conv-1`). This PR sends a real title, similar to [Cursor](https://github.com/grafana/sigil-sdk/pull/223) and [Claude](https://github.com/grafana/sigil-sdk/pull/228):

- Prefer pi's user-set session name (`getSessionName()`) when there is one.
- Otherwise fall back to the first user prompt. Capped at 100 characters.

The title is not set in `metadata_only` mode.


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Telemetry/export metadata only; prompt text in titles is gated by content capture (suppressed in metadata_only), with no auth or core runtime behavior changes.
> 
> **Overview**
> The **pi** Sigil plugin now attaches a **conversation title** to exported generations and tool spans so sessions are easier to identify in Sigil.
> 
> Each turn resolves the title via **`resolveConversationTitle`**: prefer pi’s user-set **session name** (`getSessionName()`), otherwise use the **first non-empty user prompt** (capped at 100 Unicode code points). In **`metadata_only`**, prompt-derived titles are skipped and the code falls back to the **conversation id**; a user-set session name is still allowed. The plugin caches **`firstUserText`** from the first user `message_end` (cleared on session boundaries) and re-reads the session name every turn so renames apply on the next export.
> 
> **`conversationTitle`** is passed through **`mapGenerationStart`** and **`emitToolSpans`**. **`userMessageText`** was extracted from **`mapUserMessage`** for shared flattening of user content (text only, images dropped).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69a636a831e1255a4056664b4a8091abb88fc191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->