### PR TITLE
feat(litellm): record embeddings as OTel spans

### DIFF
--- a/python-frameworks/litellm/README.md
+++ b/python-frameworks/litellm/README.md
@@ -161,7 +161,9 @@ The callback file reads connection details from environment variables. Adjust th
 - Mode mapping: non-stream calls -> `SYNC`, stream calls -> `STREAM` with first-token timestamp.
 - Provider detection: uses `custom_llm_provider` from LiteLLM's standard logging object.
 - Failed calls are recorded with the error attached via `set_call_error`.
-- Only chat completion call types (`completion`, `acompletion`) are recorded; embeddings and other call types are skipped.
+- Chat completion call types (`completion`, `acompletion`, `text_completion`, `atext_completion`) are recorded as generations.
+- Embedding call types (`embedding`, `aembedding`) are recorded as OTel embedding spans (no generation export). The span carries input/token counts and dimensions; the input text is attached only when the handler's `capture_inputs` is set and the SDK's `EmbeddingCaptureConfig.capture_input=True`. Embedding spans require a configured OTel tracer.
+- Image, audio, and transcription call types are skipped.
 - Framework tags are always set:
   - `sigil.framework.name=litellm`
   - `sigil.framework.source=handler`

--- a/python-frameworks/litellm/sigil_sdk_litellm/handler.py
+++ b/python-frameworks/litellm/sigil_sdk_litellm/handler.py
@@ -10,6 +10,8 @@ from typing import Any
 from litellm.integrations.custom_logger import CustomLogger
 from sigil_sdk import Client
 from sigil_sdk.models import (
+    EmbeddingResult,
+    EmbeddingStart,
     Generation,
     GenerationMode,
     GenerationStart,
@@ -35,6 +37,8 @@ _CHAT_CALL_TYPES = frozenset(
         "atext_completion",
     }
 )
+
+_EMBEDDING_CALL_TYPES = frozenset({"embedding", "aembedding"})
 
 
 def _make_tool_call_part(*, call_id: str, name: str, arguments: str) -> Part:
@@ -271,6 +275,55 @@ def _safe_cast(params: dict[str, Any], key: str, cast: type) -> Any:
         return None
 
 
+def _normalize_embedding_inputs(inputs: Any) -> list[str]:
+    """Extract embedding input text, dropping token-id inputs that aren't text.
+
+    LiteLLM clears the input to an empty string when message logging is off, so
+    an empty string is dropped to stay consistent with ``_embedding_input_count``.
+    """
+    if isinstance(inputs, str):
+        return [inputs] if inputs else []
+    if isinstance(inputs, list):
+        return [item for item in inputs if isinstance(item, str)]
+    return []
+
+
+def _embedding_input_count(inputs: Any) -> int:
+    """Count distinct embedding inputs.
+
+    A single pre-tokenized input (``list[int]``) counts as one; a batch of
+    token-id lists (``list[list[int]]``) counts each entry. LiteLLM clears the
+    input to an empty string when message logging is off, so an empty string is
+    treated as no input rather than a single one.
+    """
+    if inputs is None:
+        return 0
+    if isinstance(inputs, str):
+        return 1 if inputs else 0
+    if isinstance(inputs, list):
+        if inputs and all(isinstance(item, int) for item in inputs):
+            return 1
+        return len(inputs)
+    return 0
+
+
+def _embedding_dimensions_from_response(response_obj: Any) -> int | None:
+    """Read the embedding vector length from the first response item."""
+    data = getattr(response_obj, "data", None)
+    if not data:
+        return None
+    first = data[0]
+    embedding = first.get("embedding") if isinstance(first, dict) else getattr(first, "embedding", None)
+    if not isinstance(embedding, (list, tuple)):
+        return None
+    return len(embedding)
+
+
+def _response_model(response_obj: Any) -> str:
+    """Extract the response model name, tolerating a missing attribute."""
+    return getattr(response_obj, "model", "") or ""
+
+
 def _extract_detailed_usage(response_obj: Any, slo: dict[str, Any]) -> TokenUsage:
     """Build TokenUsage with detailed breakdowns from response_obj, basic counts from SLO."""
     usage = TokenUsage(
@@ -353,10 +406,14 @@ class SigilLiteLLMLogger(CustomLogger):
         if slo is None:
             return
 
+        call_type = slo.get("call_type") or ""
         try:
-            self._record_generation(kwargs, response_obj, slo, start_time, end_time, is_failure=is_failure)
+            if call_type in _EMBEDDING_CALL_TYPES:
+                self._record_embedding(kwargs, response_obj, slo, start_time, end_time, is_failure=is_failure)
+            else:
+                self._record_generation(kwargs, response_obj, slo, start_time, end_time, is_failure=is_failure)
         except Exception:
-            logger.exception("sigil: failed to record LiteLLM generation")
+            logger.exception("sigil: failed to record LiteLLM event")
 
     def _resolve_agent_name(self, kwargs: dict[str, Any]) -> str:
         """Resolve agent_name from per-request metadata, falling back to static."""
@@ -505,3 +562,72 @@ class SigilLiteLLMLogger(CustomLogger):
             err = recorder.err()
             if err is not None:
                 logger.warning("sigil: recorder error: %s", err)
+
+    def _record_embedding(
+        self,
+        kwargs: dict[str, Any],
+        response_obj: Any,
+        slo: dict[str, Any],
+        start_time: datetime,
+        end_time: datetime,
+        *,
+        is_failure: bool,
+    ) -> None:
+        model_name = slo.get("model") or ""
+        if not model_name:
+            return
+
+        provider = (slo.get("custom_llm_provider") or "").lower()
+        optional_params = kwargs.get("optional_params") or {}
+        dimensions = _safe_cast(optional_params, "dimensions", int)
+        encoding_format = optional_params.get("encoding_format") or ""
+
+        tags: dict[str, str] = {
+            "sigil.framework.name": "litellm",
+            "sigil.framework.source": "handler",
+            "sigil.framework.language": "python",
+        }
+        for tag_value in slo.get("request_tags") or []:
+            tag_str = str(tag_value)
+            tags[f"litellm.tag.{tag_str}"] = tag_str
+        tags.update(self._extra_tags)
+
+        recorder = self._client.start_embedding(
+            EmbeddingStart(
+                model=ModelRef(provider=provider, name=model_name),
+                agent_name=self._resolve_agent_name(kwargs),
+                agent_version=self._resolve_agent_version(kwargs),
+                dimensions=dimensions,
+                encoding_format=encoding_format,
+                tags=tags,
+                metadata=dict(self._extra_metadata),
+                started_at=_datetime_to_utc(start_time),
+            )
+        )
+
+        try:
+            if is_failure:
+                error_str = slo.get("error_str") or ""
+                if error_str:
+                    recorder.set_call_error(RuntimeError(error_str))
+
+            # Embedding input lives in kwargs["input"], not the SLO. LiteLLM clears
+            # it (sets it to "") before invoking callbacks when message logging is
+            # turned off, so reading it here honours LiteLLM redaction settings.
+            inputs = kwargs.get("input")
+            input_texts = _normalize_embedding_inputs(inputs) if self._capture_inputs else []
+
+            recorder.set_result(
+                EmbeddingResult(
+                    input_count=_embedding_input_count(inputs),
+                    input_tokens=slo.get("prompt_tokens") or 0,
+                    input_texts=input_texts,
+                    response_model=_response_model(response_obj) or model_name,
+                    dimensions=dimensions or _embedding_dimensions_from_response(response_obj),
+                )
+            )
+        finally:
+            recorder.end()
+            err = recorder.err()
+            if err is not None:
+                logger.warning("sigil: embedding recorder error: %s", err)

--- a/python-frameworks/litellm/tests/test_litellm_handler.py
+++ b/python-frameworks/litellm/tests/test_litellm_handler.py
@@ -6,7 +6,10 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any
 
-from sigil_sdk import Client, ClientConfig, GenerationExportConfig
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from sigil_sdk import Client, ClientConfig, EmbeddingCaptureConfig, GenerationExportConfig
 from sigil_sdk.models import (
     ExportGenerationResult,
     ExportGenerationsResponse,
@@ -40,6 +43,54 @@ def _new_client(exporter: _CapturingExporter) -> Client:
             ),
             generation_exporter=exporter,
         )
+    )
+
+
+def _new_span_client(
+    exporter: _CapturingExporter,
+    span_exporter: InMemorySpanExporter,
+    *,
+    embedding_capture: EmbeddingCaptureConfig | None = None,
+) -> Client:
+    """Client wired to an in-memory span exporter for span-only output."""
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    return Client(
+        ClientConfig(
+            tracer=provider.get_tracer("sigil-litellm-test"),
+            generation_export=GenerationExportConfig(
+                batch_size=10,
+                flush_interval=timedelta(seconds=60),
+            ),
+            generation_exporter=exporter,
+            embedding_capture=embedding_capture or EmbeddingCaptureConfig(),
+        )
+    )
+
+
+def _base_embedding_slo(**overrides: Any) -> dict[str, Any]:
+    slo: dict[str, Any] = {
+        "id": "embd-abc123",
+        "call_type": "embedding",
+        "stream": False,
+        "custom_llm_provider": "openai",
+        "model": "text-embedding-3-small",
+        "prompt_tokens": 8,
+        "total_tokens": 8,
+        "error_str": None,
+        "request_tags": [],
+        "end_user": None,
+    }
+    slo.update(overrides)
+    return slo
+
+
+def _embedding_response_obj(dimensions: int = 3) -> SimpleNamespace:
+    """Build an EmbeddingResponse-like object with one vector."""
+    return SimpleNamespace(
+        model="text-embedding-3-small",
+        data=[{"embedding": [0.0] * dimensions}],
+        usage=SimpleNamespace(prompt_tokens=8, total_tokens=8),
     )
 
 
@@ -573,12 +624,12 @@ def test_create_sigil_litellm_logger_factory() -> None:
 
 
 def test_non_chat_call_type_skipped() -> None:
-    """Embedding, image_generation etc. call types are silently skipped."""
+    """image_generation/transcription call types produce no generation export."""
     exporter = _CapturingExporter()
     client = _new_client(exporter)
     try:
         handler = SigilLiteLLMLogger(client=client)
-        for call_type in ("embedding", "aembedding", "image_generation", "transcription"):
+        for call_type in ("image_generation", "transcription"):
             slo = _base_slo(call_type=call_type)
             handler.log_success_event(
                 kwargs=_make_kwargs(slo),
@@ -1068,4 +1119,289 @@ def test_multi_choice_response_all_mapped() -> None:
         # stop_reason comes from first choice
         assert gen.stop_reason == "stop"
     finally:
+        client.shutdown()
+
+
+def test_embedding_produces_span() -> None:
+    """Embedding call emits a span with provider, model, counts, and dimensions."""
+    exporter = _CapturingExporter()
+    span_exporter = InMemorySpanExporter()
+    client = _new_span_client(exporter, span_exporter)
+    try:
+        handler = SigilLiteLLMLogger(client=client)
+        slo = _base_embedding_slo()
+        kwargs = _make_kwargs(slo)
+        kwargs["input"] = "hello world"
+        handler.log_success_event(
+            kwargs=kwargs,
+            response_obj=_embedding_response_obj(dimensions=3),
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        assert len(exporter.requests) == 0
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "embeddings text-embedding-3-small"
+        assert span.attributes.get("gen_ai.provider.name") == "openai"
+        assert span.attributes.get("gen_ai.request.model") == "text-embedding-3-small"
+        assert span.attributes.get("gen_ai.embeddings.input_count") == 1
+        assert span.attributes.get("gen_ai.usage.input_tokens") == 8
+        assert span.attributes.get("gen_ai.embeddings.dimension.count") == 3
+    finally:
+        client.shutdown()
+
+
+def test_embedding_input_texts_suppressed_by_default() -> None:
+    """input_texts is absent unless both capture flags are enabled."""
+    exporter = _CapturingExporter()
+    span_exporter = InMemorySpanExporter()
+    client = _new_span_client(exporter, span_exporter)
+    try:
+        handler = SigilLiteLLMLogger(client=client, capture_inputs=True)
+        slo = _base_embedding_slo()
+        kwargs = _make_kwargs(slo)
+        kwargs["input"] = "secret text"
+        handler.log_success_event(
+            kwargs=kwargs,
+            response_obj=_embedding_response_obj(),
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        span = span_exporter.get_finished_spans()[0]
+        assert "gen_ai.embeddings.input_texts" not in span.attributes
+        assert span.attributes.get("gen_ai.embeddings.input_count") == 1
+        assert span.attributes.get("gen_ai.usage.input_tokens") == 8
+    finally:
+        client.shutdown()
+
+
+def test_embedding_input_texts_captured_when_both_flags_enabled() -> None:
+    """input_texts is attached only when capture_inputs and capture_input are both true."""
+    exporter = _CapturingExporter()
+    span_exporter = InMemorySpanExporter()
+    client = _new_span_client(
+        exporter,
+        span_exporter,
+        embedding_capture=EmbeddingCaptureConfig(capture_input=True),
+    )
+    try:
+        handler = SigilLiteLLMLogger(client=client, capture_inputs=True)
+        slo = _base_embedding_slo()
+        kwargs = _make_kwargs(slo)
+        kwargs["input"] = ["first", "second"]
+        handler.log_success_event(
+            kwargs=kwargs,
+            response_obj=_embedding_response_obj(),
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        span = span_exporter.get_finished_spans()[0]
+        assert span.attributes.get("gen_ai.embeddings.input_texts") == ("first", "second")
+        assert span.attributes.get("gen_ai.embeddings.input_count") == 2
+    finally:
+        client.shutdown()
+
+
+def test_embedding_empty_input_sets_no_input_texts() -> None:
+    """A redacted empty-string input counts as 0 and leaves input_texts unset."""
+    exporter = _CapturingExporter()
+    span_exporter = InMemorySpanExporter()
+    client = _new_span_client(
+        exporter,
+        span_exporter,
+        embedding_capture=EmbeddingCaptureConfig(capture_input=True),
+    )
+    try:
+        handler = SigilLiteLLMLogger(client=client, capture_inputs=True)
+        slo = _base_embedding_slo()
+        kwargs = _make_kwargs(slo)
+        kwargs["input"] = ""
+        handler.log_success_event(
+            kwargs=kwargs,
+            response_obj=_embedding_response_obj(),
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        span = span_exporter.get_finished_spans()[0]
+        assert "gen_ai.embeddings.input_texts" not in span.attributes
+        assert span.attributes.get("gen_ai.embeddings.input_count") == 0
+    finally:
+        client.shutdown()
+
+
+def test_embedding_input_text_gated_by_handler_capture_inputs() -> None:
+    """SDK capture_input alone is not enough; handler capture_inputs must also be true."""
+    exporter = _CapturingExporter()
+    span_exporter = InMemorySpanExporter()
+    client = _new_span_client(
+        exporter,
+        span_exporter,
+        embedding_capture=EmbeddingCaptureConfig(capture_input=True),
+    )
+    try:
+        handler = SigilLiteLLMLogger(client=client, capture_inputs=False)
+        slo = _base_embedding_slo()
+        kwargs = _make_kwargs(slo)
+        kwargs["input"] = "secret text"
+        handler.log_success_event(
+            kwargs=kwargs,
+            response_obj=_embedding_response_obj(),
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        span = span_exporter.get_finished_spans()[0]
+        assert "gen_ai.embeddings.input_texts" not in span.attributes
+    finally:
+        client.shutdown()
+
+
+def test_aembedding_recorded() -> None:
+    """Async embedding call_type produces a span."""
+    exporter = _CapturingExporter()
+    span_exporter = InMemorySpanExporter()
+    client = _new_span_client(exporter, span_exporter)
+    try:
+        handler = SigilLiteLLMLogger(client=client)
+        slo = _base_embedding_slo(call_type="aembedding")
+        kwargs = _make_kwargs(slo)
+        kwargs["input"] = "hello"
+        handler.log_success_event(
+            kwargs=kwargs,
+            response_obj=_embedding_response_obj(),
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "embeddings text-embedding-3-small"
+    finally:
+        client.shutdown()
+
+
+def test_embedding_failure_sets_error_status() -> None:
+    """A failed embedding call produces an error-status span."""
+    from opentelemetry.trace import StatusCode
+
+    exporter = _CapturingExporter()
+    span_exporter = InMemorySpanExporter()
+    client = _new_span_client(exporter, span_exporter)
+    try:
+        handler = SigilLiteLLMLogger(client=client)
+        slo = _base_embedding_slo(error_str="rate limit exceeded")
+        kwargs = _make_kwargs(slo)
+        kwargs["input"] = "hello"
+        handler.log_failure_event(
+            kwargs=kwargs,
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        span = span_exporter.get_finished_spans()[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.attributes.get("error.type") == "provider_call_error"
+    finally:
+        client.shutdown()
+
+
+def test_embedding_input_count_string_vs_list() -> None:
+    """String counts as 1, a list of N strings as N, and a redacted empty string as 0."""
+    exporter = _CapturingExporter()
+    span_exporter = InMemorySpanExporter()
+    client = _new_span_client(exporter, span_exporter)
+    cases = [
+        ("just one", 1),
+        (["a", "b", "c"], 3),
+        ("", 0),
+    ]
+    try:
+        handler = SigilLiteLLMLogger(client=client)
+        for inputs, _ in cases:
+            slo = _base_embedding_slo()
+            kwargs = _make_kwargs(slo)
+            kwargs["input"] = inputs
+            handler.log_success_event(
+                kwargs=kwargs,
+                response_obj=_embedding_response_obj(),
+                start_time=_START,
+                end_time=_END,
+            )
+
+        client.flush()
+        spans = span_exporter.get_finished_spans()
+        for span, (_, expected) in zip(spans, cases, strict=True):
+            assert span.attributes.get("gen_ai.embeddings.input_count") == expected
+    finally:
+        client.shutdown()
+
+
+def test_embedding_dimensions_fall_back_to_response() -> None:
+    """When optional_params lacks dimensions, the response vector length is used."""
+    exporter = _CapturingExporter()
+    span_exporter = InMemorySpanExporter()
+    client = _new_span_client(exporter, span_exporter)
+    try:
+        handler = SigilLiteLLMLogger(client=client)
+        slo = _base_embedding_slo()
+        kwargs = _make_kwargs(slo)
+        kwargs["input"] = "hello"
+        handler.log_success_event(
+            kwargs=kwargs,
+            response_obj=_embedding_response_obj(dimensions=5),
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        span = span_exporter.get_finished_spans()[0]
+        assert span.attributes.get("gen_ai.embeddings.dimension.count") == 5
+    finally:
+        client.shutdown()
+
+
+def test_embedding_input_text_honours_litellm_redaction() -> None:
+    """With message logging off, LiteLLM clears kwargs['input'] before the callback,
+    so no real input text reaches the span even with both capture flags enabled."""
+    import litellm
+
+    exporter = _CapturingExporter()
+    span_exporter = InMemorySpanExporter()
+    client = _new_span_client(
+        exporter,
+        span_exporter,
+        embedding_capture=EmbeddingCaptureConfig(capture_input=True),
+    )
+    prev_redaction = litellm.turn_off_message_logging
+    prev_callbacks = litellm.callbacks
+    try:
+        handler = SigilLiteLLMLogger(client=client, capture_inputs=True)
+        litellm.turn_off_message_logging = True
+        litellm.callbacks = [handler]
+        litellm.embedding(
+            model="openai/text-embedding-3-small",
+            input=["secret one", "secret two"],
+            mock_response=[0.1, 0.2, 0.3],
+        )
+        client.flush()
+
+        span = span_exporter.get_finished_spans()[0]
+        texts = span.attributes.get("gen_ai.embeddings.input_texts")
+        assert texts is None or all(not text for text in texts)
+    finally:
+        litellm.turn_off_message_logging = prev_redaction
+        litellm.callbacks = prev_callbacks
         client.shutdown()


### PR DESCRIPTION
LiteLLM now records embedding calls as OpenTelemetry spans

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only path for embedding call types with explicit input capture gates; no changes to chat generation export behavior beyond routing by call_type.
> 
> **Overview**
> The LiteLLM Sigil handler now **routes `embedding` / `aembedding` calls** through a dedicated `_record_embedding` path that uses the SDK’s **`start_embedding` recorder** (OpenTelemetry embedding spans) instead of being skipped or exported as chat generations.
> 
> Spans include provider/model, **input count**, **prompt tokens**, and **dimensions** (from request params or the first response vector). **Raw input text** is only attached when both the handler’s `capture_inputs` and the SDK’s `EmbeddingCaptureConfig.capture_input` are enabled; counts treat LiteLLM-redacted empty `kwargs["input"]` as zero. Failures set call errors on the recorder like generations. **Image/transcription** (and similar) remain non-exported; chat types are unchanged.
> 
> README behavior is updated, and tests assert span attributes, capture gating, async embedding, failures, and redaction with `turn_off_message_logging`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a00eef0d5c167ffefed87caebaa899a68d68f388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->