### PR TITLE
feat(frameworks/litellm): capture reasoning

### DIFF
--- a/python-frameworks/litellm/README.md
+++ b/python-frameworks/litellm/README.md
@@ -171,5 +171,6 @@ The callback file reads connection details from environment variables. Adjust th
 - LiteLLM `request_tags` are forwarded as `litellm.tag.<value>`.
 - Token usage includes detailed breakdowns (cached tokens, reasoning tokens) when the provider returns them.
 - Tool calls and tool results in messages are mapped to Sigil's tool call/result parts.
+- Reasoning/thinking text is captured as `THINKING` parts, ordered before the assistant text. It is read from `thinking_blocks` when present (including redacted blocks), otherwise from the flat `reasoning_content` string.
 
 Call `client.shutdown()` during teardown to flush buffered telemetry.

--- a/python-frameworks/litellm/sigil_sdk_litellm/handler.py
+++ b/python-frameworks/litellm/sigil_sdk_litellm/handler.py
@@ -88,6 +88,9 @@ def _map_messages(messages: list[dict[str, Any]] | None) -> tuple[list[Message],
             )
             continue
 
+        if mapped_role == MessageRole.ASSISTANT:
+            parts.extend(_map_thinking_parts(msg))
+
         if content:
             parts.append(Part(kind=PartKind.TEXT, text=content))
 
@@ -100,6 +103,39 @@ def _map_messages(messages: list[dict[str, Any]] | None) -> tuple[list[Message],
         out.append(Message(role=mapped_role, parts=parts))
 
     return out, "\n\n".join(system_chunks)
+
+
+def _map_thinking_parts(message: dict[str, Any]) -> list[Part]:
+    """Map reasoning/thinking from an OpenAI-format message to THINKING parts.
+
+    Prefers structured ``thinking_blocks`` (Anthropic-style, may include
+    redacted blocks) and falls back to the flat ``reasoning_content`` string.
+    Reading both would double-emit the same text, since ``reasoning_content``
+    is usually the concatenation of the blocks.
+    """
+    if not isinstance(message, dict):
+        return []
+
+    blocks = message.get("thinking_blocks")
+    if isinstance(blocks, list) and blocks:
+        out: list[Part] = []
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            if (block.get("type") or "").lower() == "redacted_thinking":
+                text = block.get("data") or block.get("text") or ""
+            else:
+                text = block.get("thinking") or block.get("text") or ""
+            if text:
+                out.append(Part(kind=PartKind.THINKING, thinking=text))
+        if out:
+            return out
+
+    reasoning = message.get("reasoning_content")
+    if isinstance(reasoning, str) and reasoning:
+        return [Part(kind=PartKind.THINKING, thinking=reasoning)]
+
+    return []
 
 
 def _map_tool_call_parts(tool_calls: list[dict[str, Any]] | None) -> list[Part]:
@@ -173,6 +209,8 @@ def _map_response_output(response: Any) -> list[Message]:
 
         content = response_message.get("content") or ""
         parts: list[Part] = []
+
+        parts.extend(_map_thinking_parts(response_message))
 
         if content:
             parts.append(Part(kind=PartKind.TEXT, text=content))

--- a/python-frameworks/litellm/tests/test_litellm_handler.py
+++ b/python-frameworks/litellm/tests/test_litellm_handler.py
@@ -98,11 +98,17 @@ def _make_slo_response(
     content: str = "Hello!",
     finish_reason: str = "stop",
     tool_calls: list[dict[str, Any]] | None = None,
+    reasoning_content: str | None = None,
+    thinking_blocks: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build an SLO response dict in OpenAI chat completion format."""
     message: dict[str, Any] = {"content": content}
     if tool_calls is not None:
         message["tool_calls"] = tool_calls
+    if reasoning_content is not None:
+        message["reasoning_content"] = reasoning_content
+    if thinking_blocks is not None:
+        message["thinking_blocks"] = thinking_blocks
     return {
         "choices": [
             {
@@ -1404,4 +1410,187 @@ def test_embedding_input_text_honours_litellm_redaction() -> None:
     finally:
         litellm.turn_off_message_logging = prev_redaction
         litellm.callbacks = prev_callbacks
+        client.shutdown()
+
+
+def test_reasoning_content_mapped_to_thinking_output() -> None:
+    """Flat reasoning_content becomes a THINKING part ordered before TEXT."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = SigilLiteLLMLogger(client=client)
+        slo = _base_slo(
+            response=_make_slo_response(
+                content="The answer is 42.",
+                reasoning_content="Let me work through this step by step.",
+            )
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        parts = gen.output[0].parts
+        assert [p.kind for p in parts] == [PartKind.THINKING, PartKind.TEXT]
+        assert parts[0].thinking == "Let me work through this step by step."
+        assert parts[1].text == "The answer is 42."
+    finally:
+        client.shutdown()
+
+
+def test_thinking_blocks_including_redacted() -> None:
+    """thinking_blocks produce a THINKING part per block, reading thinking/data."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = SigilLiteLLMLogger(client=client)
+        slo = _base_slo(
+            response=_make_slo_response(
+                content="Done.",
+                thinking_blocks=[
+                    {"type": "thinking", "thinking": "First I consider X.", "signature": "sig"},
+                    {"type": "redacted_thinking", "data": "encrypted-blob"},
+                ],
+            )
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        parts = gen.output[0].parts
+        assert [p.kind for p in parts] == [PartKind.THINKING, PartKind.THINKING, PartKind.TEXT]
+        assert parts[0].thinking == "First I consider X."
+        assert parts[1].thinking == "encrypted-blob"
+        assert parts[2].text == "Done."
+    finally:
+        client.shutdown()
+
+
+def test_thinking_blocks_preferred_over_reasoning_content() -> None:
+    """When both are present, thinking_blocks win and reasoning_content is not duplicated."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = SigilLiteLLMLogger(client=client)
+        slo = _base_slo(
+            response=_make_slo_response(
+                content="Result.",
+                reasoning_content="Block one. Block two.",
+                thinking_blocks=[
+                    {"type": "thinking", "thinking": "Block one."},
+                    {"type": "thinking", "thinking": "Block two."},
+                ],
+            )
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        thinking_parts = [p for p in gen.output[0].parts if p.kind == PartKind.THINKING]
+        assert [p.thinking for p in thinking_parts] == ["Block one.", "Block two."]
+    finally:
+        client.shutdown()
+
+
+def test_thinking_dropped_when_outputs_disabled() -> None:
+    """capture_outputs=False omits THINKING parts."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = SigilLiteLLMLogger(client=client, capture_outputs=False)
+        slo = _base_slo(
+            response=_make_slo_response(
+                content="Hi",
+                reasoning_content="Secret reasoning.",
+            )
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert len(gen.output) == 0
+    finally:
+        client.shutdown()
+
+
+def test_input_assistant_reasoning_mapped_to_thinking() -> None:
+    """Input assistant message reasoning_content becomes a THINKING part before TEXT."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = SigilLiteLLMLogger(client=client)
+        slo = _base_slo(
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {
+                    "role": "assistant",
+                    "content": "Sure.",
+                    "reasoning_content": "They greeted me.",
+                },
+            ]
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assistant_msg = gen.input[1]
+        assert assistant_msg.role == MessageRole.ASSISTANT
+        assert [p.kind for p in assistant_msg.parts] == [PartKind.THINKING, PartKind.TEXT]
+        assert assistant_msg.parts[0].thinking == "They greeted me."
+        assert assistant_msg.parts[1].text == "Sure."
+    finally:
+        client.shutdown()
+
+
+def test_input_assistant_thinking_dropped_when_inputs_disabled() -> None:
+    """capture_inputs=False omits THINKING parts from input assistant messages."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = SigilLiteLLMLogger(client=client, capture_inputs=False)
+        slo = _base_slo(
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {
+                    "role": "assistant",
+                    "content": "Sure.",
+                    "reasoning_content": "Secret reasoning.",
+                },
+            ]
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert len(gen.input) == 0
+    finally:
         client.shutdown()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Telemetry mapping only in the LiteLLM handler; no auth or export protocol changes, with broad test coverage for ordering and capture flags.
> 
> **Overview**
> The LiteLLM Sigil handler now exports model **reasoning/thinking** text as Sigil `THINKING` message parts, placed **before** assistant `TEXT` and tool-call parts on both **inputs** (assistant history) and **outputs** (SLO response).
> 
> A new `_map_thinking_parts` helper prefers structured `thinking_blocks` (including `redacted_thinking` via `data`/`text`) and only falls back to flat `reasoning_content` when blocks are absent, avoiding duplicate telemetry when both fields are present. Existing `capture_inputs` / `capture_outputs` flags still gate whether thinking is recorded.
> 
> The README documents the behavior, and tests cover flat reasoning, blocks, deduplication, redacted blocks, and capture toggles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b5c0705df0c11ccd4d96c8ec504ed7a0e587db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->