### PR TITLE
feat(sdk): add User-Agent to generation traffic

### DIFF
--- a/dotnet/src/Grafana.Sigil/Exporters.cs
+++ b/dotnet/src/Grafana.Sigil/Exporters.cs
@@ -40,6 +40,7 @@ internal sealed class HttpGenerationExporter : IGenerationExporter
 {
     private readonly HttpClient _httpClient;
     private readonly Uri _endpoint;
+    private readonly string _userAgent;
     private readonly IReadOnlyDictionary<string, string> _headers;
 
     public HttpGenerationExporter(string endpoint, IReadOnlyDictionary<string, string> headers)
@@ -66,11 +67,24 @@ internal sealed class HttpGenerationExporter : IGenerationExporter
         }
 
         _endpoint = uri;
+        // Resolve the User-Agent like the gRPC exporter: a non-blank caller
+        // override wins, otherwise the SDK default. Any User-Agent entry is
+        // stripped so a blank value can't override the resolved one.
+        var userAgent = SdkVersion.UserAgent();
         var normalizedHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var pair in headers)
         {
+            if (string.Equals(pair.Key, "User-Agent", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!string.IsNullOrWhiteSpace(pair.Value))
+                {
+                    userAgent = pair.Value;
+                }
+                continue;
+            }
             normalizedHeaders[pair.Key] = pair.Value;
         }
+        _userAgent = userAgent;
         _headers = normalizedHeaders;
         _httpClient = new HttpClient(new HttpClientHandler
         {
@@ -95,6 +109,7 @@ internal sealed class HttpGenerationExporter : IGenerationExporter
             Content = new StringContent(payload, System.Text.Encoding.UTF8, "application/json"),
         };
 
+        httpRequest.Headers.TryAddWithoutValidation("User-Agent", _userAgent);
         foreach (var header in _headers)
         {
             httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
@@ -176,18 +191,53 @@ internal sealed class GrpcGenerationExporter : IGenerationExporter, IDisposable
             handler.ServerCertificateCustomValidationCallback = static (_, _, _, _) => true;
         }
 
-        _channel = GrpcChannel.ForAddress(uri, new GrpcChannelOptions
-        {
-            HttpHandler = handler,
-            DisposeHttpClient = true,
-        });
-        _client = new Proto.GenerationIngestService.GenerationIngestServiceClient(_channel);
+        // grpc-dotnet sets its own user-agent and ignores call metadata for it,
+        // so prepend our token in a delegating handler that rewrites the header
+        // just before the request goes out.
+        var userAgent = SdkVersion.UserAgent();
         var normalizedHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var pair in headers)
         {
+            if (string.Equals(pair.Key, "User-Agent", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!string.IsNullOrWhiteSpace(pair.Value))
+                {
+                    userAgent = pair.Value;
+                }
+                continue;
+            }
             normalizedHeaders[pair.Key] = pair.Value;
         }
         _headers = normalizedHeaders;
+
+        _channel = GrpcChannel.ForAddress(uri, new GrpcChannelOptions
+        {
+            HttpHandler = new UserAgentHandler(userAgent) { InnerHandler = handler },
+            DisposeHttpClient = true,
+        });
+        _client = new Proto.GenerationIngestService.GenerationIngestServiceClient(_channel);
+    }
+
+    // UserAgentHandler prepends our token in front of grpc-dotnet's own
+    // user-agent on every request, so the wire User-Agent is
+    // "sigil-sdk-dotnet/<ver> grpc-dotnet/<ver>".
+    private sealed class UserAgentHandler : DelegatingHandler
+    {
+        private readonly string _userAgent;
+
+        public UserAgentHandler(string userAgent)
+        {
+            _userAgent = userAgent;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var existing = request.Headers.UserAgent.ToString();
+            request.Headers.Remove("User-Agent");
+            var value = string.IsNullOrEmpty(existing) ? _userAgent : _userAgent + " " + existing;
+            request.Headers.TryAddWithoutValidation("User-Agent", value);
+            return base.SendAsync(request, cancellationToken);
+        }
     }
 
     public void Dispose()

--- a/dotnet/src/Grafana.Sigil/SdkVersion.cs
+++ b/dotnet/src/Grafana.Sigil/SdkVersion.cs
@@ -1,0 +1,22 @@
+namespace Grafana.Sigil;
+
+/// <summary>
+/// SDK version and User-Agent product token.
+/// </summary>
+/// <remarks>
+/// <see cref="Version"/> is stamped into the default generation-export User-Agent
+/// (see <see cref="UserAgent"/>). Keep in sync with the package version on release.
+/// </remarks>
+public static class SdkVersion
+{
+    /// <summary>Released version of the Sigil .NET SDK.</summary>
+    public const string Version = "0.1.0";
+
+    private const string UserAgentProduct = "sigil-sdk-dotnet";
+
+    /// <summary>
+    /// Returns the SDK's default generation-export User-Agent product token,
+    /// <c>sigil-sdk-dotnet/&lt;Version&gt;</c>.
+    /// </summary>
+    public static string UserAgent() => UserAgentProduct + "/" + Version;
+}

--- a/dotnet/tests/Grafana.Sigil.Tests/GenerationTransportTests.cs
+++ b/dotnet/tests/Grafana.Sigil.Tests/GenerationTransportTests.cs
@@ -107,6 +107,66 @@ public sealed class GenerationTransportTests
 
         Assert.True(server.Requests.TryDequeue(out var captured));
         Assert.Equal("tenant-a", captured.Headers["X-Scope-OrgID"]);
+        Assert.Equal(SdkVersion.UserAgent(), captured.Headers["User-Agent"]);
+    }
+
+    // A non-blank caller User-Agent wins; a blank or whitespace-only one (or no
+    // header at all) must fall back to the SDK default, matching gRPC.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("sigil-plugin-semantic-kernel/1.2.3")]
+    public async Task GenerationHttpTransport_ResolvesUserAgent(string? headerValue)
+    {
+        var expected = string.IsNullOrWhiteSpace(headerValue) ? SdkVersion.UserAgent() : headerValue;
+
+        using var server = new HttpCaptureServer((_, body) =>
+        {
+            var request = Google.Protobuf.JsonParser.Default.Parse<SigilProto.ExportGenerationsRequest>(
+                Encoding.UTF8.GetString(body)
+            );
+
+            var response = new SigilProto.ExportGenerationsResponse();
+            foreach (var generation in request.Generations)
+            {
+                response.Results.Add(new SigilProto.ExportGenerationResult
+                {
+                    GenerationId = generation.Id,
+                    Accepted = true,
+                });
+            }
+
+            return Encoding.UTF8.GetBytes(JsonFormatter.Default.Format(response));
+        });
+
+        var config = new SigilClientConfig
+        {
+            GenerationExport = new GenerationExportConfig
+            {
+                Protocol = GenerationExportProtocol.Http,
+                Endpoint = $"http://127.0.0.1:{server.Port}/api/v1/generations:export",
+                BatchSize = 1,
+                QueueSize = 10,
+                FlushInterval = TimeSpan.FromSeconds(1),
+            },
+        };
+        if (headerValue != null)
+        {
+            config.GenerationExport.Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["User-Agent"] = headerValue,
+            };
+        }
+
+        await using var client = new SigilClient(config);
+        var recorder = client.StartGeneration(TestHelpers.CreateSeedStart("gen-http-ua"));
+        recorder.SetResult(TestHelpers.CreateSeedResult("gen-http-ua"));
+        recorder.End();
+        await client.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(server.Requests.TryDequeue(out var captured));
+        Assert.Equal(expected, captured.Headers["User-Agent"]);
     }
 
     [Fact]
@@ -162,6 +222,46 @@ public sealed class GenerationTransportTests
         Assert.True(server.Requests.TryDequeue(out var captured));
         Assert.Equal("tenant-override", captured.Headers["x-scope-orgid"]);
         Assert.Equal("Bearer override-token", captured.Headers["authorization"]);
+    }
+
+    [Fact]
+    public async Task GenerationGrpcTransport_SendsDefaultUserAgent()
+    {
+        using var server = new GrpcIngestServer();
+
+        var config = new SigilClientConfig
+        {
+            GenerationExport = new GenerationExportConfig
+            {
+                Protocol = GenerationExportProtocol.Grpc,
+                Endpoint = $"127.0.0.1:{server.Port}",
+                Insecure = true,
+                BatchSize = 1,
+                QueueSize = 10,
+                FlushInterval = TimeSpan.FromSeconds(1),
+                MaxRetries = 1,
+                InitialBackoff = TimeSpan.FromMilliseconds(1),
+                MaxBackoff = TimeSpan.FromMilliseconds(2),
+            },
+        };
+
+        await using (var client = new SigilClient(config))
+        {
+            var recorder = client.StartGeneration(TestHelpers.CreateSeedStart("gen-grpc-ua"));
+            recorder.SetResult(TestHelpers.CreateSeedResult("gen-grpc-ua"));
+            recorder.End();
+            await client.FlushAsync(TestContext.Current.CancellationToken);
+            await client.ShutdownAsync(TestContext.Current.CancellationToken);
+        }
+
+        await TestHelpers.WaitForAsync(
+            () => server.UserAgents.Count >= 1,
+            TimeSpan.FromSeconds(5),
+            "expected one gRPC export request"
+        );
+        var userAgent = server.UserAgents[0];
+        // grpc-dotnet appends its own token after ours.
+        Assert.Equal(SdkVersion.UserAgent(), userAgent.Split(' ', 2)[0]);
     }
 
     [Fact]

--- a/dotnet/tests/Grafana.Sigil.Tests/TestHelpers.cs
+++ b/dotnet/tests/Grafana.Sigil.Tests/TestHelpers.cs
@@ -361,6 +361,8 @@ internal sealed class GrpcIngestServer : IDisposable
 
     public IReadOnlyList<(IngestProto.ExportGenerationsRequest Request, Metadata Headers)> Requests => _store.Snapshot();
 
+    public IReadOnlyList<string> UserAgents => _store.UserAgentSnapshot();
+
     public GrpcIngestServer()
     {
         Port = ReservePort();
@@ -413,12 +415,14 @@ internal sealed class GrpcIngestServer : IDisposable
 #endif
 
         private readonly List<(IngestProto.ExportGenerationsRequest Request, Metadata Headers)> _requests = [];
+        private readonly List<string> _userAgents = [];
 
-        public void Add(IngestProto.ExportGenerationsRequest request, Metadata headers)
+        public void Add(IngestProto.ExportGenerationsRequest request, Metadata headers, string userAgent)
         {
             lock (_gate)
             {
                 _requests.Add((request, headers));
+                _userAgents.Add(userAgent);
             }
         }
 
@@ -427,6 +431,14 @@ internal sealed class GrpcIngestServer : IDisposable
             lock (_gate)
             {
                 return [.. _requests];
+            }
+        }
+
+        public IReadOnlyList<string> UserAgentSnapshot()
+        {
+            lock (_gate)
+            {
+                return [.. _userAgents];
             }
         }
     }
@@ -442,7 +454,8 @@ internal sealed class GrpcIngestServer : IDisposable
             ServerCallContext context
         )
         {
-            _store.Add(request, context.RequestHeaders);
+            var userAgent = context.GetHttpContext().Request.Headers.UserAgent.ToString();
+            _store.Add(request, context.RequestHeaders, userAgent);
 
             var response = new IngestProto.ExportGenerationsResponse();
             foreach (var generation in request.Generations)

--- a/go/sigil/client.go
+++ b/go/sigil/client.go
@@ -22,6 +22,20 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// Version is the released version of the Sigil Go SDK. It is stamped into the
+// default generation-export User-Agent (see UserAgent). Released via the
+// go/vX.Y.Z git tag; bump this on release.
+const Version = "0.8.0"
+
+// UserAgent returns the SDK's default generation-export User-Agent product
+// token, "sigil-sdk-go/<Version>". Coding-agent plugins prepend their own token
+// (most-specific first), e.g.
+//
+//	"sigil-plugin-claude-code/" + pluginVersion + " " + sigil.UserAgent()
+func UserAgent() string {
+	return sdkUserAgentProduct + "/" + Version
+}
+
 // Config controls Sigil client behavior.
 type Config struct {
 	GenerationExport GenerationExportConfig
@@ -159,9 +173,10 @@ const (
 	defaultGRPCMaxReceiveMessageBytes = 16 << 20
 	defaultGenerationPayloadMaxBytes  = 16 << 20
 
-	sdkMetadataKeyName = "sigil.sdk.name"
-	metadataUserIDKey  = "sigil.user.id"
-	sdkName            = "sdk-go"
+	sdkMetadataKeyName  = "sigil.sdk.name"
+	metadataUserIDKey   = "sigil.user.id"
+	sdkName             = "sdk-go"
+	sdkUserAgentProduct = "sigil-sdk-go"
 
 	spanAttrGenerationID           = "sigil.generation.id"
 	spanAttrConversationID         = "gen_ai.conversation.id"

--- a/go/sigil/exporter.go
+++ b/go/sigil/exporter.go
@@ -94,9 +94,15 @@ func newGRPCGenerationExporter(cfg GenerationExportConfig) (generationExporter, 
 		transportCreds = insecure.NewCredentials()
 	}
 
+	// gRPC reserves the user-agent metadata key, so the User-Agent must travel
+	// via the dial option rather than outgoing metadata. grpc-go appends its own
+	// token after this value.
+	userAgent, headers := splitUserAgent(cfg.Headers)
+
 	conn, err := grpc.NewClient(
 		endpoint,
 		grpc.WithTransportCredentials(transportCreds),
+		grpc.WithUserAgent(userAgent),
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallSendMsgSize(maxSendMessageBytes),
 			grpc.MaxCallRecvMsgSize(maxReceiveMessageBytes),
@@ -109,8 +115,25 @@ func newGRPCGenerationExporter(cfg GenerationExportConfig) (generationExporter, 
 	return &grpcGenerationExporter{
 		client:  sigilv1.NewGenerationIngestServiceClient(conn),
 		conn:    conn,
-		headers: cloneTags(cfg.Headers),
+		headers: headers,
 	}, nil
+}
+
+// splitUserAgent returns the User-Agent to set as the gRPC dial option and the
+// remaining headers with any User-Agent entry removed. When the caller did not
+// supply one, the SDK default (UserAgent) is used.
+func splitUserAgent(headers map[string]string) (userAgent string, rest map[string]string) {
+	userAgent = UserAgent()
+	rest = cloneTags(headers)
+	for key, value := range rest {
+		if strings.EqualFold(key, "User-Agent") {
+			if trimmed := strings.TrimSpace(value); trimmed != "" {
+				userAgent = value
+			}
+			delete(rest, key)
+		}
+	}
+	return userAgent, rest
 }
 
 func (e *grpcGenerationExporter) Export(ctx context.Context, request *sigilv1.ExportGenerationsRequest) (*sigilv1.ExportGenerationsResponse, error) {
@@ -128,9 +151,10 @@ func (e *grpcGenerationExporter) Shutdown(_ context.Context) error {
 }
 
 type httpGenerationExporter struct {
-	endpoint string
-	headers  map[string]string
-	client   *http.Client
+	endpoint  string
+	userAgent string
+	headers   map[string]string
+	client    *http.Client
 }
 
 func newHTTPGenerationExporter(cfg GenerationExportConfig) (generationExporter, error) {
@@ -139,9 +163,14 @@ func newHTTPGenerationExporter(cfg GenerationExportConfig) (generationExporter, 
 		return nil, err
 	}
 
+	// Resolve the User-Agent the same way the gRPC exporter does: a non-blank
+	// caller override wins, otherwise the SDK default. headers has any
+	// User-Agent entry removed so it can't blank out the resolved value below.
+	userAgent, headers := splitUserAgent(cfg.Headers)
 	return &httpGenerationExporter{
-		endpoint: urlString,
-		headers:  cloneTags(cfg.Headers),
+		endpoint:  urlString,
+		userAgent: userAgent,
+		headers:   headers,
 		client: &http.Client{
 			Timeout: 10 * time.Second,
 		},
@@ -159,6 +188,7 @@ func (e *httpGenerationExporter) Export(ctx context.Context, request *sigilv1.Ex
 		return nil, fmt.Errorf("build generation request: %w", err)
 	}
 	httpRequest.Header.Set("Content-Type", wire.ContentTypeJSON)
+	httpRequest.Header.Set("User-Agent", e.userAgent)
 	for key, value := range e.headers {
 		httpRequest.Header.Set(key, value)
 	}

--- a/go/sigil/exporter_transport_test.go
+++ b/go/sigil/exporter_transport_test.go
@@ -16,6 +16,7 @@ import (
 	sigilv1 "github.com/grafana/sigil-sdk/go/proto/sigil/v1"
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -442,13 +443,32 @@ func boolPtr(value bool) *bool {
 type capturingIngestServer struct {
 	sigilv1.UnimplementedGenerationIngestServiceServer
 
-	mu       sync.Mutex
-	requests []*sigilv1.ExportGenerationsRequest
+	mu         sync.Mutex
+	requests   []*sigilv1.ExportGenerationsRequest
+	userAgents []string
 }
 
-func (s *capturingIngestServer) ExportGenerations(_ context.Context, req *sigilv1.ExportGenerationsRequest) (*sigilv1.ExportGenerationsResponse, error) {
+func (s *capturingIngestServer) ExportGenerations(ctx context.Context, req *sigilv1.ExportGenerationsRequest) (*sigilv1.ExportGenerationsResponse, error) {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if vals := md.Get("user-agent"); len(vals) > 0 {
+			s.mu.Lock()
+			s.userAgents = append(s.userAgents, vals[0])
+			s.mu.Unlock()
+		}
+	}
 	s.capture(req)
 	return acceptanceResponse(req), nil
+}
+
+func (s *capturingIngestServer) singleUserAgent(t *testing.T) string {
+	t.Helper()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.userAgents) != 1 {
+		t.Fatalf("expected exactly one captured user-agent, got %d", len(s.userAgents))
+	}
+	return s.userAgents[0]
 }
 
 func (s *capturingIngestServer) capture(req *sigilv1.ExportGenerationsRequest) {

--- a/go/sigil/user_agent_test.go
+++ b/go/sigil/user_agent_test.go
@@ -1,0 +1,187 @@
+package sigil
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	sigilv1 "github.com/grafana/sigil-sdk/go/proto/sigil/v1"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func TestSDKExportSendsDefaultUserAgent(t *testing.T) {
+	want := "sigil-sdk-go/" + Version
+
+	t.Run("http", func(t *testing.T) {
+		if got := exportAndCaptureHTTPUserAgent(t, nil); got != want {
+			t.Fatalf("http User-Agent = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("grpc", func(t *testing.T) {
+		// grpc-go appends its own token (grpc-go/<ver>) after ours.
+		got := exportAndCaptureGRPCUserAgent(t, nil)
+		if first := firstToken(got); first != want {
+			t.Fatalf("grpc first token = %q, want %q (full %q)", first, want, got)
+		}
+	})
+}
+
+func TestSDKExportUserAgentOverride(t *testing.T) {
+	defaultUA := "sigil-sdk-go/" + Version
+	override := "sigil-plugin-claude-code/1.2.3 " + defaultUA
+
+	// A non-blank caller User-Agent wins; a blank or whitespace-only one must
+	// not blank out the default. HTTP and gRPC must agree.
+	cases := []struct {
+		name   string
+		header string
+		wantUA string
+	}{
+		{name: "non-blank", header: override, wantUA: override},
+		{name: "empty", header: "", wantUA: defaultUA},
+		{name: "whitespace", header: "   ", wantUA: defaultUA},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			headers := map[string]string{"User-Agent": tc.header}
+
+			t.Run("http", func(t *testing.T) {
+				if got := exportAndCaptureHTTPUserAgent(t, headers); got != tc.wantUA {
+					t.Fatalf("http User-Agent = %q, want %q", got, tc.wantUA)
+				}
+			})
+
+			t.Run("grpc", func(t *testing.T) {
+				// grpc-go appends its own token after ours, so compare first tokens.
+				got := exportAndCaptureGRPCUserAgent(t, headers)
+				if first, want := firstToken(got), firstToken(tc.wantUA); first != want {
+					t.Fatalf("grpc first token = %q, want %q (full %q)", first, want, got)
+				}
+			})
+		})
+	}
+}
+
+func userAgentTestConfig(headers map[string]string) Config {
+	return Config{
+		Tracer: noop.NewTracerProvider().Tracer("test"),
+		GenerationExport: GenerationExportConfig{
+			Headers:        headers,
+			BatchSize:      1,
+			QueueSize:      10,
+			FlushInterval:  time.Second,
+			MaxRetries:     1,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+		},
+	}
+}
+
+func runOneExport(t *testing.T, client *Client) {
+	t.Helper()
+
+	_, rec := client.StartGeneration(context.Background(), GenerationStart{
+		Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+	})
+	rec.SetResult(Generation{
+		Input:  []Message{UserTextMessage("hello")},
+		Output: []Message{AssistantTextMessage("hi")},
+	}, nil)
+	rec.End()
+	if err := rec.Err(); err != nil {
+		t.Fatalf("recorder error: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Shutdown(ctx); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+}
+
+func exportAndCaptureHTTPUserAgent(t *testing.T, headers map[string]string) string {
+	t.Helper()
+
+	captured := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case captured <- r.Header.Get("User-Agent"):
+		default:
+		}
+		payload, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body", http.StatusBadRequest)
+			return
+		}
+		request := &sigilv1.ExportGenerationsRequest{}
+		if err := protojson.Unmarshal(payload, request); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		response := acceptanceResponse(request)
+		encoded, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(response)
+		if err != nil {
+			http.Error(w, "marshal response", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write(encoded)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := userAgentTestConfig(headers)
+	cfg.GenerationExport.Protocol = GenerationExportProtocolHTTP
+	cfg.GenerationExport.Endpoint = srv.URL + "/api/v1/generations:export"
+	runOneExport(t, NewClient(cfg))
+
+	select {
+	case ua := <-captured:
+		return ua
+	default:
+		t.Fatal("no export request reached the server")
+		return ""
+	}
+}
+
+func exportAndCaptureGRPCUserAgent(t *testing.T, headers map[string]string) string {
+	t.Helper()
+
+	ingest := &capturingIngestServer{}
+	grpcServer := grpc.NewServer()
+	sigilv1.RegisterGenerationIngestServiceServer(grpcServer, ingest)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen grpc: %v", err)
+	}
+	go func() {
+		_ = grpcServer.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		_ = listener.Close()
+	})
+
+	cfg := userAgentTestConfig(headers)
+	cfg.GenerationExport.Protocol = GenerationExportProtocolGRPC
+	cfg.GenerationExport.Endpoint = listener.Addr().String()
+	cfg.GenerationExport.Insecure = BoolPtr(true)
+	runOneExport(t, NewClient(cfg))
+
+	return ingest.singleUserAgent(t)
+}
+
+func firstToken(userAgent string) string {
+	token, _, _ := strings.Cut(userAgent, " ")
+	return token
+}

--- a/java/core/src/main/java/com/grafana/sigil/sdk/GrpcGenerationExporter.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/GrpcGenerationExporter.java
@@ -25,9 +25,26 @@ public final class GrpcGenerationExporter implements GenerationExporter {
         if (insecure || parsed.insecure) {
             builder = builder.usePlaintext();
         }
+        // gRPC reserves the user-agent metadata key, so the User-Agent travels
+        // via the channel user-agent rather than per-call metadata. grpc-java
+        // appends its own token after this value.
+        Map<String, String> remaining = new LinkedHashMap<>();
+        String userAgent = SdkVersion.userAgent();
+        if (headers != null) {
+            for (Map.Entry<String, String> entry : headers.entrySet()) {
+                if (entry.getKey().equalsIgnoreCase("User-Agent")) {
+                    if (entry.getValue() != null && !entry.getValue().isBlank()) {
+                        userAgent = entry.getValue();
+                    }
+                    continue;
+                }
+                remaining.put(entry.getKey(), entry.getValue());
+            }
+        }
+        builder = builder.userAgent(userAgent);
         this.channel = builder.build();
         this.stub = GenerationIngestServiceGrpc
-                .newBlockingStub(io.grpc.ClientInterceptors.intercept(channel, new HeadersInterceptor(headers)));
+                .newBlockingStub(io.grpc.ClientInterceptors.intercept(channel, new HeadersInterceptor(remaining)));
     }
 
     @Override

--- a/java/core/src/main/java/com/grafana/sigil/sdk/HttpGenerationExporter.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/HttpGenerationExporter.java
@@ -9,6 +9,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -16,12 +17,32 @@ import java.util.Map;
 /** HTTP exporter for generation ingest parity endpoint. */
 public final class HttpGenerationExporter implements GenerationExporter {
     private final URI endpoint;
+    private final String userAgent;
     private final Map<String, String> headers;
     private final HttpClient client;
 
     public HttpGenerationExporter(String endpoint, Map<String, String> headers) {
         this.endpoint = URI.create(normalizeEndpoint(endpoint));
-        this.headers = headers;
+        // Resolve the User-Agent like the gRPC exporter: a non-blank caller
+        // override wins, otherwise the SDK default (HttpClient would otherwise
+        // send "Java-http-client/<ver>"). Any User-Agent entry is stripped so a
+        // blank value can't override the resolved one, and header() can't append
+        // a duplicate.
+        String resolvedUserAgent = SdkVersion.userAgent();
+        Map<String, String> remaining = new LinkedHashMap<>();
+        if (headers != null) {
+            for (Map.Entry<String, String> entry : headers.entrySet()) {
+                if (entry.getKey().equalsIgnoreCase("User-Agent")) {
+                    if (entry.getValue() != null && !entry.getValue().isBlank()) {
+                        resolvedUserAgent = entry.getValue();
+                    }
+                    continue;
+                }
+                remaining.put(entry.getKey(), entry.getValue());
+            }
+        }
+        this.userAgent = resolvedUserAgent;
+        this.headers = remaining;
         this.client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
     }
 
@@ -36,6 +57,7 @@ public final class HttpGenerationExporter implements GenerationExporter {
                 .timeout(Duration.ofSeconds(10))
                 .header("Content-Type", "application/json")
                 .POST(HttpRequest.BodyPublishers.ofString(body));
+        requestBuilder.header("User-Agent", userAgent);
         for (Map.Entry<String, String> entry : headers.entrySet()) {
             requestBuilder.header(entry.getKey(), entry.getValue());
         }

--- a/java/core/src/main/java/com/grafana/sigil/sdk/SdkVersion.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/SdkVersion.java
@@ -1,0 +1,24 @@
+package com.grafana.sigil.sdk;
+
+/**
+ * SDK version and User-Agent product token.
+ *
+ * <p>{@link #VERSION} is stamped into the default generation-export User-Agent (see {@link
+ * #userAgent()}). Keep in sync with the gradle {@code version} on release.
+ */
+public final class SdkVersion {
+    /** Released version of the Sigil Java SDK. */
+    public static final String VERSION = "0.2.0";
+
+    private static final String USER_AGENT_PRODUCT = "sigil-sdk-java";
+
+    private SdkVersion() {}
+
+    /**
+     * Returns the SDK's default generation-export User-Agent product token, {@code
+     * sigil-sdk-java/<VERSION>}.
+     */
+    public static String userAgent() {
+        return USER_AGENT_PRODUCT + "/" + VERSION;
+    }
+}

--- a/java/core/src/test/java/com/grafana/sigil/sdk/SigilClientTransportTest.java
+++ b/java/core/src/test/java/com/grafana/sigil/sdk/SigilClientTransportTest.java
@@ -25,7 +25,11 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import sigil.v1.GenerationIngest;
 import sigil.v1.GenerationIngestServiceGrpc;
 
@@ -83,8 +87,70 @@ class SigilClientTransportTest {
 
         assertThat(path.get()).isEqualTo("/api/v1/generations:export");
         assertThat(headers.get().get("x-scope-orgid")).isEqualTo("tenant-a");
+        assertThat(headers.get().get("user-agent")).isEqualTo(SdkVersion.userAgent());
         assertThat(request.getGenerationsCount()).isEqualTo(1);
         assertThat(request.getGenerations(0)).isEqualTo(ProtoMapper.toProtoGeneration(lastGeneration.get()));
+    }
+
+    static Stream<Arguments> httpUserAgentCases() {
+        String defaultUserAgent = SdkVersion.userAgent();
+        String override = "sigil-plugin-langchain4j/1.2.3 " + defaultUserAgent;
+        // A non-blank caller User-Agent wins; a blank or whitespace-only one must
+        // not blank out the default. A null header value exercises the no-header
+        // path.
+        return Stream.of(
+                Arguments.of("no header", null, defaultUserAgent),
+                Arguments.of("non-blank override", override, override),
+                Arguments.of("empty falls back to default", "", defaultUserAgent),
+                Arguments.of("whitespace falls back to default", "   ", defaultUserAgent));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("httpUserAgentCases")
+    void httpExportResolvesUserAgent(String name, String headerValue, String wantUserAgent) throws Exception {
+        AtomicReference<Map<String, String>> headers = new AtomicReference<>();
+
+        com.sun.net.httpserver.HttpServer server =
+                com.sun.net.httpserver.HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/v1/generations:export", exchange -> {
+            Map<String, String> requestHeaders = new LinkedHashMap<>();
+            exchange.getRequestHeaders().forEach((k, v) -> requestHeaders.put(k.toLowerCase(), String.join(",", v)));
+            headers.set(requestHeaders);
+            exchange.getRequestBody().readAllBytes();
+
+            byte[] response = "{\"results\":[{\"generation_id\":\"gen-fixture-1\",\"accepted\":true}]}".getBytes();
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(202, response.length);
+            try (OutputStream outputStream = exchange.getResponseBody()) {
+                outputStream.write(response);
+            }
+        });
+        server.start();
+
+        GenerationExportConfig exportConfig = new GenerationExportConfig()
+                .setProtocol(GenerationExportProtocol.HTTP)
+                .setEndpoint("http://127.0.0.1:" + server.getAddress().getPort() + "/api/v1/generations:export")
+                .setBatchSize(1)
+                .setFlushInterval(Duration.ofMinutes(10))
+                .setMaxRetries(0);
+        if (headerValue != null) {
+            exportConfig.setHeaders(Map.of("User-Agent", headerValue));
+        }
+
+        SigilClientConfig config = new SigilClientConfig()
+                .setTracer(GlobalOpenTelemetry.getTracer("test"))
+                .setGenerationExport(exportConfig);
+
+        try (SigilClient client = new SigilClient(config)) {
+            GenerationRecorder recorder = client.startGeneration(TestFixtures.startFixture());
+            recorder.setResult(TestFixtures.resultFixture());
+            recorder.end();
+            client.shutdown();
+        } finally {
+            server.stop(0);
+        }
+
+        assertThat(headers.get().get("user-agent")).isEqualTo(wantUserAgent);
     }
 
     @Test
@@ -164,6 +230,8 @@ class SigilClientTransportTest {
         assertThat(requests.get(0).getGenerations(0).getOutput(0).getParts(1).hasToolCall()).isTrue();
         assertThat(requests.get(0).getGenerations(0).getOutput(1).getParts(0).hasToolResult()).isTrue();
         assertThat(metadata.get().get("authorization")).isEqualTo("Bearer override-token");
+        // grpc-java appends its own token after ours.
+        assertThat(metadata.get().get("user-agent")).startsWith(SdkVersion.userAgent());
     }
 
     @Test

--- a/js/src/core.ts
+++ b/js/src/core.ts
@@ -75,6 +75,7 @@ export type {
   ToolExecutionStart,
   ToolResultPart,
 } from './types.js';
+export { SDK_VERSION, userAgent } from './version.js';
 
 import { SigilClient } from './client.js';
 import type { SigilSdkConfigInput } from './types.js';

--- a/js/src/exporters/grpc.ts
+++ b/js/src/exporters/grpc.ts
@@ -14,6 +14,7 @@ import type {
   ToolDefinition,
 } from '../types.js';
 import { canonicalEffectiveVersion } from '../utils.js';
+import { userAgent } from '../version.js';
 
 type ExportGenerationsMethod = (
   request: unknown,
@@ -49,6 +50,7 @@ export class GRPCGenerationExporter implements GenerationExporter {
   private readonly endpoint: string;
   private readonly headers: Record<string, string>;
   private readonly insecure: boolean;
+  private readonly userAgent: string;
 
   private initPromise: Promise<void> | undefined;
   private client: GRPCServiceClient | undefined;
@@ -57,7 +59,12 @@ export class GRPCGenerationExporter implements GenerationExporter {
     const parsed = parseGRPCEndpoint(endpoint);
     this.endpoint = parsed.host;
     this.insecure = insecure || parsed.insecure;
-    this.headers = headers ? { ...headers } : {};
+    // gRPC reserves the user-agent metadata key, so the User-Agent must travel
+    // via the channel option rather than per-call metadata. grpc-js appends its
+    // own token after this value.
+    const split = splitUserAgent(headers);
+    this.userAgent = split.userAgent;
+    this.headers = split.rest;
   }
 
   async exportGenerations(request: ExportGenerationsRequest): Promise<ExportGenerationsResponse> {
@@ -119,8 +126,31 @@ export class GRPCGenerationExporter implements GenerationExporter {
     }
 
     const credentials = this.insecure ? grpc.credentials.createInsecure() : grpc.credentials.createSsl();
-    this.client = new clientCtor(this.endpoint, credentials) as GRPCServiceClient;
+    this.client = new clientCtor(this.endpoint, credentials, {
+      'grpc.primary_user_agent': this.userAgent,
+    }) as GRPCServiceClient;
   }
+}
+
+// splitUserAgent returns the User-Agent to set as the gRPC channel option and
+// the remaining headers with any user-agent entry removed. When the caller did
+// not supply one, the SDK default (userAgent) is used.
+function splitUserAgent(headers?: Record<string, string>): {
+  userAgent: string;
+  rest: Record<string, string>;
+} {
+  const rest: Record<string, string> = {};
+  let resolved = userAgent();
+  for (const [key, value] of Object.entries(headers ?? {})) {
+    if (key.toLowerCase() === 'user-agent') {
+      if (value.trim().length > 0) {
+        resolved = value;
+      }
+      continue;
+    }
+    rest[key] = value;
+  }
+  return { userAgent: resolved, rest };
 }
 
 function parseGRPCEndpoint(endpoint: string): { host: string; insecure: boolean } {

--- a/js/src/exporters/http.ts
+++ b/js/src/exporters/http.ts
@@ -11,6 +11,7 @@ import type {
   ToolDefinition,
 } from '../types.js';
 import { canonicalEffectiveVersion, isRecord } from '../utils.js';
+import { userAgent } from '../version.js';
 
 export class HTTPGenerationExporter implements GenerationExporter {
   private readonly endpoint: string;
@@ -18,7 +19,21 @@ export class HTTPGenerationExporter implements GenerationExporter {
 
   constructor(endpoint: string, headers?: Record<string, string>) {
     this.endpoint = normalizeHTTPGenerationEndpoint(endpoint);
-    this.headers = headers ? { ...headers } : {};
+    // Resolve the User-Agent like the gRPC exporter: a non-blank caller override
+    // (case-insensitive) wins, otherwise the SDK default. A blank/whitespace
+    // override is dropped so it can't blank out the default.
+    let resolved = userAgent();
+    const rest: Record<string, string> = {};
+    for (const [key, value] of Object.entries(headers ?? {})) {
+      if (key.toLowerCase() === 'user-agent') {
+        if (value.trim().length > 0) {
+          resolved = value;
+        }
+        continue;
+      }
+      rest[key] = value;
+    }
+    this.headers = { 'user-agent': resolved, ...rest };
   }
 
   async exportGenerations(request: ExportGenerationsRequest): Promise<ExportGenerationsResponse> {

--- a/js/src/version.ts
+++ b/js/src/version.ts
@@ -1,0 +1,15 @@
+// SDK_VERSION is the released version of the Sigil JS SDK. It is stamped into
+// the default generation-export User-Agent (see userAgent). Keep in sync with
+// package.json on release.
+export const SDK_VERSION = '0.6.0';
+
+const SDK_USER_AGENT_PRODUCT = 'sigil-sdk-js';
+
+/**
+ * Returns the SDK's default generation-export User-Agent product token,
+ * `sigil-sdk-js/<SDK_VERSION>`. Coding-agent plugins prepend their own token
+ * (most-specific first).
+ */
+export function userAgent(): string {
+  return `${SDK_USER_AGENT_PRODUCT}/${SDK_VERSION}`;
+}

--- a/js/test/client.user-agent.test.mjs
+++ b/js/test/client.user-agent.test.mjs
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import * as grpc from '@grpc/grpc-js';
+import * as protoLoader from '@grpc/proto-loader';
+import { trace } from '@opentelemetry/api';
+import { defaultConfig, SDK_VERSION, SigilClient, userAgent } from '../.test-dist/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const protoPath = join(__dirname, '../proto/sigil/v1/generation_ingest.proto');
+const protoLoadOptions = {
+  keepCase: false,
+  longs: String,
+  enums: String,
+  defaults: false,
+  oneofs: true,
+};
+
+test('userAgent() returns the SDK product token', () => {
+  assert.equal(userAgent(), `sigil-sdk-js/${SDK_VERSION}`);
+});
+
+const defaultUserAgent = `sigil-sdk-js/${SDK_VERSION}`;
+const overrideUserAgent = `sigil-plugin-opencode/1.2.3 ${defaultUserAgent}`;
+
+// A non-blank caller User-Agent wins; a blank or whitespace-only one must not
+// blank out the default. undefined exercises the no-header path. HTTP and gRPC
+// must resolve identically.
+const userAgentCases = [
+  { name: 'no header', headers: undefined, wantUserAgent: defaultUserAgent },
+  { name: 'override', headers: { 'user-agent': overrideUserAgent }, wantUserAgent: overrideUserAgent },
+  { name: 'empty', headers: { 'user-agent': '' }, wantUserAgent: defaultUserAgent },
+  { name: 'whitespace', headers: { 'user-agent': '   ' }, wantUserAgent: defaultUserAgent },
+];
+
+for (const { name, headers, wantUserAgent } of userAgentCases) {
+  test(`HTTP export resolves the User-Agent (${name})`, async () => {
+    const received = await captureHTTPUserAgent(headers);
+    assert.equal(received, wantUserAgent);
+  });
+
+  test(`gRPC export resolves the User-Agent first token (${name})`, async () => {
+    // grpc-js appends its own token after ours, so compare the first token.
+    const received = await captureGRPCUserAgent(headers);
+    assert.equal(firstToken(received), firstToken(wantUserAgent));
+  });
+}
+
+async function captureHTTPUserAgent(headers) {
+  let captured;
+  const server = createServer(async (request, response) => {
+    captured = request.headers['user-agent'];
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    const payload = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    response.writeHead(202, { 'content-type': 'application/json' });
+    response.end(
+      JSON.stringify({
+        results: (payload.generations ?? []).map((generation) => ({
+          generationId: generation.id,
+          accepted: true,
+        })),
+      }),
+    );
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  try {
+    const client = newClient({
+      protocol: 'http',
+      endpoint: `http://127.0.0.1:${address.port}/api/v1/generations:export`,
+      headers,
+    });
+    await runOneExport(client);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+  return captured;
+}
+
+async function captureGRPCUserAgent(headers) {
+  let captured;
+  const grpcServer = await startGRPCServer((_request, metadata) => {
+    captured = metadata['user-agent'];
+  });
+  try {
+    const client = newClient({
+      protocol: 'grpc',
+      endpoint: `127.0.0.1:${grpcServer.port}`,
+      insecure: true,
+      headers,
+    });
+    await runOneExport(client);
+  } finally {
+    await stopGRPCServer(grpcServer.server);
+  }
+  return captured;
+}
+
+function newClient(generationExportOverrides) {
+  const defaults = defaultConfig();
+  return new SigilClient({
+    tracer: trace.getTracer('sigil-sdk-js-test'),
+    generationExport: {
+      ...defaults.generationExport,
+      batchSize: 1,
+      flushIntervalMs: 60_000,
+      maxRetries: 1,
+      initialBackoffMs: 1,
+      maxBackoffMs: 1,
+      ...generationExportOverrides,
+    },
+  });
+}
+
+async function runOneExport(client) {
+  const recorder = client.startGeneration({
+    id: 'gen-ua',
+    model: { provider: 'openai', name: 'gpt-5' },
+  });
+  recorder.setResult({
+    input: [{ role: 'user', parts: [{ type: 'text', text: 'hi' }] }],
+    output: [{ role: 'assistant', parts: [{ type: 'text', text: 'ok' }] }],
+  });
+  recorder.end();
+  assert.equal(recorder.getError(), undefined);
+  await client.shutdown();
+}
+
+function firstToken(userAgentValue) {
+  const space = userAgentValue.indexOf(' ');
+  return space >= 0 ? userAgentValue.slice(0, space) : userAgentValue;
+}
+
+async function startGRPCServer(onRequest) {
+  const packageDefinition = await protoLoader.load(protoPath, protoLoadOptions);
+  const loaded = grpc.loadPackageDefinition(packageDefinition);
+  const service = loaded.sigil.v1.GenerationIngestService;
+
+  const server = new grpc.Server();
+  server.addService(service.service, {
+    ExportGenerations(call, callback) {
+      onRequest(call.request, call.metadata.getMap());
+      callback(null, {
+        results: (call.request.generations ?? []).map((generation) => ({
+          generationId: generation.id,
+          accepted: true,
+        })),
+      });
+    },
+  });
+
+  const port = await new Promise((resolve, reject) => {
+    server.bindAsync('127.0.0.1:0', grpc.ServerCredentials.createInsecure(), (error, boundPort) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(boundPort);
+    });
+  });
+
+  return { server, port };
+}
+
+function stopGRPCServer(server) {
+  return new Promise((resolve) => {
+    server.tryShutdown(() => {
+      resolve();
+    });
+  });
+}

--- a/python/sigil_sdk/exporters/grpc.py
+++ b/python/sigil_sdk/exporters/grpc.py
@@ -17,6 +17,7 @@ from ..models import (
     ExportWorkflowStepsResponse,
 )
 from ..proto_mapping import generation_to_proto, workflow_step_to_proto
+from ..version import user_agent
 
 
 class GRPCGenerationExporter:
@@ -24,11 +25,23 @@ class GRPCGenerationExporter:
 
     def __init__(self, endpoint: str, headers: dict[str, str] | None = None, insecure: bool = False) -> None:
         host, implicit_insecure = _parse_endpoint(endpoint)
-        self._headers = [(k.lower(), v) for k, v in (headers or {}).items()]
+        # gRPC reserves the user-agent metadata key, so the User-Agent travels
+        # via the channel option rather than per-call metadata. grpc appends its
+        # own token after this value.
+        user_agent_value = user_agent()
+        metadata: list[tuple[str, str]] = []
+        for key, value in (headers or {}).items():
+            if key.lower() == "user-agent":
+                if value.strip():
+                    user_agent_value = value
+                continue
+            metadata.append((key.lower(), value))
+        self._headers = metadata
+        options = [("grpc.primary_user_agent", user_agent_value)]
         self._channel = (
-            grpc.insecure_channel(host)
+            grpc.insecure_channel(host, options=options)
             if (insecure or implicit_insecure)
-            else grpc.secure_channel(host, grpc.ssl_channel_credentials())
+            else grpc.secure_channel(host, grpc.ssl_channel_credentials(), options=options)
         )
         self._stub = sigil_pb2_grpc.GenerationIngestServiceStub(self._channel)
         self._workflow_step_stub = sigil_pb2_grpc.WorkflowStepIngestServiceStub(self._channel)

--- a/python/sigil_sdk/exporters/http.py
+++ b/python/sigil_sdk/exporters/http.py
@@ -15,6 +15,7 @@ from ..models import (
     ExportWorkflowStepsResponse,
 )
 from ..proto_mapping import generation_to_proto_json, workflow_step_to_proto_json
+from ..version import user_agent
 
 
 class HTTPGenerationExporter:
@@ -23,7 +24,19 @@ class HTTPGenerationExporter:
     def __init__(self, endpoint: str, headers: dict[str, str] | None = None) -> None:
         self._endpoint = _normalize_endpoint(endpoint, _EXPORT_PATH)
         self._wf_endpoint = _normalize_endpoint(endpoint, _WF_EXPORT_PATH)
-        self._headers = dict(headers or {})
+        # Resolve the User-Agent like the gRPC exporter: a non-blank caller
+        # override wins, otherwise the SDK default (urllib would otherwise send
+        # "Python-urllib/<ver>"). Any User-Agent entry is stripped so a blank
+        # value can't override the resolved one.
+        user_agent_value = user_agent()
+        self._headers = {}
+        for key, value in (headers or {}).items():
+            if key.lower() == "user-agent":
+                if value.strip():
+                    user_agent_value = value
+                continue
+            self._headers[key] = value
+        self._headers["User-Agent"] = user_agent_value
 
     def export_generations(self, request: ExportGenerationsRequest) -> ExportGenerationsResponse:
         payload = {

--- a/python/sigil_sdk/version.py
+++ b/python/sigil_sdk/version.py
@@ -1,0 +1,26 @@
+"""SDK version and User-Agent product token.
+
+SDK_VERSION is stamped into the default generation-export User-Agent (see
+``user_agent``). It is read from the installed package metadata so it always
+matches the published version; the ``sdk:py:bump`` release tooling only rewrites
+pyproject.toml, and reading metadata here avoids a second copy that would drift.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    SDK_VERSION = version("sigil-sdk")
+except PackageNotFoundError:
+    # Running from a source tree without an installed distribution.
+    SDK_VERSION = "0.0.0+unknown"
+
+_SDK_USER_AGENT_PRODUCT = "sigil-sdk-python"
+
+
+def user_agent() -> str:
+    """Return the SDK's default generation-export User-Agent product token,
+    ``sigil-sdk-python/<SDK_VERSION>``.
+    """
+    return f"{_SDK_USER_AGENT_PRODUCT}/{SDK_VERSION}"

--- a/python/tests/test_transport.py
+++ b/python/tests/test_transport.py
@@ -56,6 +56,7 @@ class _CapturingGenerationServicer(sigil_pb2_grpc.GenerationIngestServiceService
 
 import pytest
 from sigil_sdk.exporters.http import _normalize_endpoint
+from sigil_sdk.version import SDK_VERSION
 
 
 @pytest.mark.parametrize(
@@ -298,6 +299,111 @@ def test_sdk_generation_auth_tenant_over_http() -> None:
     finally:
         server.shutdown()
         server.server_close()
+
+
+_DEFAULT_USER_AGENT = f"sigil-sdk-python/{SDK_VERSION}"
+_OVERRIDE_USER_AGENT = f"sigil-plugin-langgraph/1.2.3 {_DEFAULT_USER_AGENT}"
+
+# A non-blank caller User-Agent wins; a blank or whitespace-only one must not
+# blank out the default. None exercises the no-header path. HTTP and gRPC must
+# resolve identically.
+_USER_AGENT_CASES = [
+    pytest.param(None, _DEFAULT_USER_AGENT, id="no-header"),
+    pytest.param({"User-Agent": _OVERRIDE_USER_AGENT}, _OVERRIDE_USER_AGENT, id="override"),
+    pytest.param({"User-Agent": ""}, _DEFAULT_USER_AGENT, id="empty"),
+    pytest.param({"User-Agent": "   "}, _DEFAULT_USER_AGENT, id="whitespace"),
+]
+
+
+@pytest.mark.parametrize(("headers", "expected_user_agent"), _USER_AGENT_CASES)
+def test_sdk_generation_user_agent_over_http(headers, expected_user_agent) -> None:
+    captured_headers: list[dict[str, str]] = []
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            captured_headers.append({k.lower(): v for k, v in self.headers.items()})
+            self.send_response(202)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"results":[{"generation_id":"gen-fixture-1","accepted":true}]}')
+
+        def log_message(self, _format, *_args):  # noqa: A003
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    client = _new_client(
+        GenerationExportConfig(
+            protocol="http",
+            endpoint=f"http://127.0.0.1:{server.server_address[1]}/api/v1/generations:export",
+            headers=headers,
+            batch_size=1,
+            flush_interval=timedelta(seconds=1),
+            max_retries=1,
+            initial_backoff=timedelta(milliseconds=1),
+            max_backoff=timedelta(milliseconds=10),
+        )
+    )
+
+    try:
+        start, result = _payload_fixture()
+        rec = client.start_generation(start)
+        rec.set_result(result)
+        rec.end()
+        assert rec.err() is None
+        client.shutdown()
+
+        assert len(captured_headers) >= 1
+        assert captured_headers[0].get("user-agent") == expected_user_agent
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.mark.parametrize(("headers", "expected_user_agent"), _USER_AGENT_CASES)
+def test_sdk_generation_user_agent_over_grpc(headers, expected_user_agent) -> None:
+    servicer = _CapturingGenerationServicer()
+    grpc_server = grpc.server(thread_pool=__import__("concurrent.futures").futures.ThreadPoolExecutor(max_workers=2))
+    sigil_pb2_grpc.add_GenerationIngestServiceServicer_to_server(servicer, grpc_server)
+
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    grpc_server.add_insecure_port(f"127.0.0.1:{port}")
+    grpc_server.start()
+
+    client = _new_client(
+        GenerationExportConfig(
+            protocol="grpc",
+            endpoint=f"127.0.0.1:{port}",
+            insecure=True,
+            headers=headers,
+            batch_size=1,
+            flush_interval=timedelta(seconds=1),
+            max_retries=1,
+            initial_backoff=timedelta(milliseconds=1),
+            max_backoff=timedelta(milliseconds=10),
+        )
+    )
+
+    try:
+        start, result = _payload_fixture()
+        rec = client.start_generation(start)
+        rec.set_result(result)
+        rec.end()
+        assert rec.err() is None
+        client.shutdown()
+
+        assert len(servicer.metadata) == 1
+        # grpc appends its own token after ours, so compare the first token.
+        user_agent = servicer.metadata[0].get("user-agent", "")
+        assert user_agent.split(" ", 1)[0] == expected_user_agent.split(" ", 1)[0]
+    finally:
+        grpc_server.stop(grace=0)
 
 
 def test_sdk_generation_auth_bearer_over_grpc_with_header_override() -> None:

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -477,7 +477,7 @@ wheels = [
 
 [[package]]
 name = "sigil-sdk"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive request metadata on export clients only; behavior is covered by transport tests and does not change auth, payload, or ingest protocol semantics.
> 
> **Overview**
> All Sigil language SDKs now identify generation ingest traffic with a default **`User-Agent`** of the form `sigil-sdk-<language>/<version>` on both **HTTP** and **gRPC** export paths.
> 
> Callers can still supply **`User-Agent`** in `GenerationExport` headers: a non-empty value wins; empty or whitespace-only values are ignored so the SDK default is always sent. That header is peeled out of the generic header map so it is not duplicated or sent as metadata on gRPC (each runtime sets user agent via dial/channel options, with grpc libraries often appending their own token after the SDK string).
> 
> New **`SdkVersion` / `UserAgent()`** (or equivalent) helpers are exposed per language, with transport tests covering default, override, missing, and blank cases. Python’s lockfile reflects a package version bump to **0.5.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19045a333a10c00c2a0e05360d41d674e042f28c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->