### PR TITLE
[codex] fix python google adk compatibility

### DIFF
--- a/python-frameworks/google-adk/pyproject.toml
+++ b/python-frameworks/google-adk/pyproject.toml
@@ -7,7 +7,7 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
   "sigil-sdk>=0.8.0",
-  "google-adk>=1.0.0",
+  "google-adk>=1.31.0",
 ]
 
 [project.optional-dependencies]

--- a/python-frameworks/google-adk/sigil_sdk_google_adk/__init__.py
+++ b/python-frameworks/google-adk/sigil_sdk_google_adk/__init__.py
@@ -7,7 +7,7 @@ import json
 from typing import Any
 from uuid import UUID, uuid4
 
-from sigil_sdk import Client
+from sigil_sdk import Client, ToolDefinition
 
 from .handler import SigilAsyncGoogleAdkHandler, SigilGoogleAdkHandler
 
@@ -28,6 +28,14 @@ except Exception:  # pragma: no cover - lightweight fallback for local unit test
 
         async def after_run_callback(self, *, invocation_context: Any) -> None:
             del invocation_context
+            return None
+
+        async def before_agent_callback(self, *, agent: Any, callback_context: Any) -> Any:
+            del agent, callback_context
+            return None
+
+        async def after_agent_callback(self, *, agent: Any, callback_context: Any) -> Any:
+            del agent, callback_context
             return None
 
         async def before_model_callback(self, *, callback_context: Any, llm_request: Any) -> Any:
@@ -96,13 +104,8 @@ class SigilGoogleAdkCallbacks:
         run_id = uuid4()
         self._llm_run_stacks.setdefault(invocation_key, []).append(run_id)
 
-        model_name = _first_non_empty(
-            _as_string(_read(llm_request, "model")),
-            _as_string(_read(_read(llm_request, "config"), "model")),
-        )
-        invocation_params: dict[str, Any] = {}
-        if model_name != "":
-            invocation_params["model"] = model_name
+        invocation_params = _adk_invocation_params(llm_request)
+        model_name = _as_string(invocation_params.get("model"))
 
         messages = _adk_messages(_read(llm_request, "contents"))
         await _invoke_handler(
@@ -289,7 +292,7 @@ class SigilGoogleAdkPlugin(BasePlugin):
         await _invoke_handler(self._sigil_handler, "on_chain_end", {"status": "completed"}, run_id=run_id)
         return None
 
-    async def before_agent_callback(self, *, callback_context: Any) -> None:
+    async def before_agent_callback(self, *, callback_context: Any, agent: Any | None = None) -> None:
         invocation_context = _adk_invocation_context(callback_context)
         invocation_key = _invocation_key(invocation_context)
         run_id = uuid4()
@@ -297,7 +300,7 @@ class SigilGoogleAdkPlugin(BasePlugin):
         parent_run_id = stack[-1] if stack else self._run_ids.get(invocation_key)
         stack.append(run_id)
 
-        run_name = _agent_name(callback_context)
+        run_name = _agent_name(callback_context, agent)
         await _invoke_handler(
             self._sigil_handler,
             "on_chain_start",
@@ -311,7 +314,8 @@ class SigilGoogleAdkPlugin(BasePlugin):
         )
         return None
 
-    async def after_agent_callback(self, *, callback_context: Any) -> None:
+    async def after_agent_callback(self, *, callback_context: Any, agent: Any | None = None) -> None:
+        del agent
         invocation_key = _invocation_key(_adk_invocation_context(callback_context))
         stack = self._agent_run_stacks.get(invocation_key, [])
         run_id = stack.pop() if stack else None
@@ -527,18 +531,189 @@ def _serialized_llm_payload(callback_context: Any, model_name: str) -> dict[str,
     return serialized
 
 
+def _adk_invocation_params(llm_request: Any) -> dict[str, Any]:
+    config = _read(llm_request, "config")
+    invocation_params: dict[str, Any] = {}
+
+    model_name = _first_non_empty(
+        _as_string(_read(llm_request, "model")),
+        _as_string(_read(config, "model")),
+    )
+    if model_name != "":
+        invocation_params["model"] = model_name
+
+    system_prompt = _adk_content_text(_read(config, "system_instruction"))
+    if system_prompt != "":
+        invocation_params["system_prompt"] = system_prompt
+
+    tools = _adk_tool_definitions(_read(config, "tools"), _read(llm_request, "tools_dict"))
+    if tools:
+        invocation_params["tools"] = tools
+
+    max_tokens = _read(config, "max_output_tokens")
+    if max_tokens is not None:
+        invocation_params["max_tokens"] = max_tokens
+
+    temperature = _read(config, "temperature")
+    if temperature is not None:
+        invocation_params["temperature"] = temperature
+
+    top_p = _read(config, "top_p")
+    if top_p is not None:
+        invocation_params["top_p"] = top_p
+
+    tool_choice = _adk_tool_choice(_read(config, "tool_config"))
+    if tool_choice != "":
+        invocation_params["tool_choice"] = tool_choice
+
+    thinking_config = _read(config, "thinking_config")
+    thinking_enabled = _bool_or_none(
+        _first_non_none(
+            _read(thinking_config, "include_thoughts"),
+            _read(thinking_config, "includeThoughts"),
+        )
+    )
+    if thinking_enabled is not None:
+        invocation_params["thinking_enabled"] = thinking_enabled
+
+    thinking_budget = _int_or_none(
+        _first_non_none(
+            _read(thinking_config, "thinking_budget"),
+            _read(thinking_config, "thinkingBudget"),
+        )
+    )
+    if thinking_budget is not None:
+        invocation_params["thinking_budget"] = thinking_budget
+
+    thinking_level = _adk_thinking_level(
+        _first_non_none(
+            _read(thinking_config, "thinking_level"),
+            _read(thinking_config, "thinkingLevel"),
+        )
+    )
+    if thinking_level != "":
+        invocation_params["thinking_level"] = thinking_level
+
+    return invocation_params
+
+
+def _adk_tool_definitions(config_tools: Any, tools_dict: Any) -> list[ToolDefinition]:
+    definitions: list[ToolDefinition] = []
+    seen: set[tuple[str, str]] = set()
+
+    def add(definition: ToolDefinition) -> None:
+        key = (definition.type, definition.name)
+        if definition.name == "" or key in seen:
+            return
+        seen.add(key)
+        definitions.append(definition)
+
+    for tool in _as_sequence(config_tools):
+        for declaration in _as_sequence(_read(tool, "function_declarations")):
+            name = _as_string(_read(declaration, "name"))
+            if name == "":
+                continue
+            schema = _first_non_none(
+                _read(declaration, "parameters_json_schema"),
+                _read(declaration, "parameters"),
+            )
+            add(
+                ToolDefinition(
+                    name=name,
+                    description=_as_string(_read(declaration, "description")),
+                    type="function",
+                    input_schema_json=_json_bytes(schema),
+                )
+            )
+
+        for builtin_name in (
+            "google_search",
+            "google_search_retrieval",
+            "code_execution",
+            "url_context",
+            "retrieval",
+            "enterprise_web_search",
+            "google_maps",
+            "computer_use",
+            "file_search",
+        ):
+            if _read(tool, builtin_name) is not None:
+                add(ToolDefinition(name=builtin_name, type=builtin_name))
+
+    if isinstance(tools_dict, dict):
+        for key, tool in tools_dict.items():
+            name = _first_non_empty(_as_string(_read(tool, "name")), _as_string(key))
+            if name == "":
+                continue
+            add(
+                ToolDefinition(
+                    name=name,
+                    description=_as_string(_read(tool, "description")),
+                    type="function",
+                )
+            )
+
+    return definitions
+
+
+def _adk_tool_choice(tool_config: Any) -> str:
+    function_calling_config = _read(tool_config, "function_calling_config")
+    mode = _as_string(_jsonable(_read(function_calling_config, "mode"))).lower()
+    allowed_names = _as_sequence(_read(function_calling_config, "allowed_function_names"))
+    if len(allowed_names) == 1:
+        return _as_string(allowed_names[0])
+    return mode
+
+
+def _adk_thinking_level(value: Any) -> str:
+    normalized = _as_string(_jsonable(value)).lower()
+    if normalized in {"", "thinking_level_unspecified"}:
+        return ""
+    if normalized in {"thinking_level_low", "low"}:
+        return "low"
+    if normalized in {"thinking_level_medium", "medium"}:
+        return "medium"
+    if normalized in {"thinking_level_high", "high"}:
+        return "high"
+    if normalized in {"thinking_level_minimal", "minimal"}:
+        return "minimal"
+    return normalized
+
+
 def _adk_messages(contents: Any) -> list[dict[str, Any]]:
     if not isinstance(contents, list):
         return []
     messages: list[dict[str, Any]] = []
     for content in contents:
-        role = _first_non_empty(_as_string(_read(content, "role")), "user")
-        parts = _read(content, "parts")
-        text = _content_parts_text(parts)
-        if text == "":
+        message = _adk_content_message(content, default_role="user")
+        if message is None:
             continue
-        messages.append({"role": role, "content": text})
+        messages.append(message)
     return messages
+
+
+def _adk_content_message(content: Any, *, default_role: str) -> dict[str, Any] | None:
+    parts = _read(content, "parts")
+    text = _content_parts_text(parts)
+    tool_calls = _adk_function_calls(parts)
+    tool_results = _adk_function_responses(parts)
+    if text == "" and not tool_calls and not tool_results:
+        return None
+
+    role = _adk_role(_first_non_empty(_as_string(_read(content, "role")), default_role))
+    if tool_results:
+        role = "tool"
+
+    message: dict[str, Any] = {
+        "role": role,
+    }
+    if text != "":
+        message["content"] = text
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    if tool_results:
+        message["tool_results"] = tool_results
+    return message
 
 
 def _content_parts_text(parts: Any) -> str:
@@ -556,6 +731,53 @@ def _content_parts_text(parts: Any) -> str:
     return " ".join(text_parts).strip()
 
 
+def _adk_function_calls(parts: Any) -> list[dict[str, Any]]:
+    if not isinstance(parts, list):
+        return []
+
+    calls: list[dict[str, Any]] = []
+    for part in parts:
+        function_call = _read(part, "function_call")
+        if function_call is None:
+            continue
+
+        name = _as_string(_read(function_call, "name"))
+        if name == "":
+            continue
+
+        call: dict[str, Any] = {
+            "id": _as_string(_read(function_call, "id")),
+            "name": name,
+        }
+        args = _read(function_call, "args")
+        if args is not None:
+            call["args"] = _jsonable(args)
+        calls.append(call)
+    return calls
+
+
+def _adk_function_responses(parts: Any) -> list[dict[str, Any]]:
+    if not isinstance(parts, list):
+        return []
+
+    results: list[dict[str, Any]] = []
+    for part in parts:
+        function_response = _read(part, "function_response")
+        if function_response is None:
+            continue
+
+        response = _jsonable(_read(function_response, "response"))
+        result: dict[str, Any] = {
+            "tool_call_id": _as_string(_read(function_response, "id")),
+            "name": _as_string(_read(function_response, "name")),
+            "response": response,
+        }
+        if isinstance(response, dict) and "error" in response:
+            result["is_error"] = True
+        results.append(result)
+    return results
+
+
 def _adk_llm_end_payload(llm_response: Any) -> dict[str, Any]:
     llm_output: dict[str, Any] = {}
     model_name = _first_non_empty(
@@ -570,28 +792,33 @@ def _adk_llm_end_payload(llm_response: Any) -> dict[str, Any]:
         llm_output["finish_reason"] = finish_reason
 
     usage_metadata = _read(llm_response, "usage_metadata")
-    token_usage = _adk_token_usage(usage_metadata)
-    if token_usage:
-        llm_output["token_usage"] = token_usage
+    usage = _adk_usage_metadata(usage_metadata)
+    if usage:
+        llm_output["usage"] = usage
 
-    text = _content_parts_text(_read(_read(llm_response, "content"), "parts"))
     payload: dict[str, Any] = {"llm_output": llm_output}
-    if text != "":
-        payload["generations"] = [[{"text": text}]]
+    message = _adk_content_message(_read(llm_response, "content"), default_role="assistant")
+    if message is not None:
+        payload["generations"] = [[{"message": message}]]
     return payload
 
 
-def _adk_token_usage(usage_metadata: Any) -> dict[str, int]:
-    prompt_tokens = _int_or_none(_read(usage_metadata, "prompt_token_count"))
-    completion_tokens = _int_or_none(_read(usage_metadata, "candidates_token_count"))
-    total_tokens = _int_or_none(_read(usage_metadata, "total_token_count"))
+def _adk_usage_metadata(usage_metadata: Any) -> dict[str, int]:
+    fields = (
+        "prompt_token_count",
+        "candidates_token_count",
+        "total_token_count",
+        "cached_content_token_count",
+        "cache_write_input_token_count",
+        "cache_creation_input_token_count",
+        "thoughts_token_count",
+        "tool_use_prompt_token_count",
+    )
     token_usage: dict[str, int] = {}
-    if prompt_tokens is not None:
-        token_usage["prompt_tokens"] = prompt_tokens
-    if completion_tokens is not None:
-        token_usage["completion_tokens"] = completion_tokens
-    if total_tokens is not None:
-        token_usage["total_tokens"] = total_tokens
+    for field_name in fields:
+        value = _int_or_none(_read(usage_metadata, field_name))
+        if value is not None:
+            token_usage[field_name] = value
     return token_usage
 
 
@@ -628,12 +855,13 @@ def _adk_context_metadata(callback_context: Any) -> dict[str, Any]:
     return metadata
 
 
-def _agent_name(callback_context: Any) -> str:
+def _agent_name(callback_context: Any, agent: Any | None = None) -> str:
     invocation_context = _adk_invocation_context(callback_context)
     return _first_non_empty(
         _as_string(_read(callback_context, "agent_name")),
         _as_string(_read(callback_context, "agentName")),
         _as_string(_read(_read(callback_context, "agent"), "name")),
+        _as_string(_read(agent, "name")),
         _as_string(_read(invocation_context, "agent_name")),
         _as_string(_read(invocation_context, "agentName")),
         _as_string(_read(_read(invocation_context, "agent"), "name")),
@@ -661,10 +889,23 @@ def _adk_event_text(event: Any) -> str:
 def _adk_content_text(content: Any) -> str:
     if isinstance(content, str):
         return content.strip()
+    if isinstance(content, list):
+        return " ".join(text for text in (_adk_content_text(item) for item in content) if text != "").strip()
     parts_text = _content_parts_text(_read(content, "parts"))
     if parts_text != "":
         return parts_text
     return _as_string(_read(content, "text"))
+
+
+def _adk_role(role: str) -> str:
+    normalized = role.strip().lower()
+    if normalized == "model":
+        return "assistant"
+    if normalized in {"function", "tool"}:
+        return "tool"
+    if normalized != "":
+        return normalized
+    return "user"
 
 
 def _json_string(value: Any) -> str:
@@ -672,6 +913,34 @@ def _json_string(value: Any) -> str:
         return json.dumps(value, default=str, sort_keys=True)
     except Exception:
         return str(value)
+
+
+def _json_bytes(value: Any) -> bytes:
+    if value is None:
+        return b""
+    try:
+        return json.dumps(_jsonable(value), default=str, sort_keys=True).encode("utf-8")
+    except Exception:
+        return b""
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    enum_value = getattr(value, "value", None)
+    if enum_value is not None and not callable(enum_value):
+        return enum_value
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return model_dump(by_alias=True, exclude_none=True, mode="json")
+        except TypeError:
+            return model_dump()
+    return value
 
 
 def _read(value: Any, key: str) -> Any:
@@ -694,6 +963,26 @@ def _int_or_none(value: Any) -> int | None:
     if isinstance(value, int):
         return value
     return None
+
+
+def _bool_or_none(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return None
+
+
+def _as_sequence(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return []
 
 
 def _is_true(value: Any) -> bool:

--- a/python-frameworks/google-adk/tests/test_sigil_sdk_google_adk.py
+++ b/python-frameworks/google-adk/tests/test_sigil_sdk_google_adk.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from uuid import UUID, uuid4
 
 from google.adk.plugins import BasePlugin
+from google.genai import types as genai_types
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -492,6 +493,163 @@ def test_sigil_sdk_google_adk_plugin_helpers_attach_plugin_list() -> None:
         generation = exporter.requests[0].generations[0]
         assert generation.conversation_id == "adk-plugin-session-42"
         assert generation.tags["sigil.framework.name"] == "google-adk"
+    finally:
+        client.shutdown()
+
+
+def test_sigil_sdk_google_adk_plugin_maps_current_request_config_tools_and_usage() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    class _Session:
+        id = "adk-current-session-42"
+        state: dict[str, str] = {}
+
+    class _InvocationContext:
+        invocation_id = "adk-current-invocation-42"
+        session = _Session()
+        agent_name = "adk-current-agent"
+
+    class _CallbackContext:
+        invocation_context = _InvocationContext()
+
+    class _LlmRequest:
+        model = "gemini-2.5-pro"
+        contents = [
+            genai_types.Content(role="user", parts=[genai_types.Part(text="weather in Paris?")]),
+            genai_types.Content(
+                role="model",
+                parts=[
+                    genai_types.Part(
+                        function_call=genai_types.FunctionCall(
+                            id="call-weather-0",
+                            name="get_weather",
+                            args={"city": "Paris"},
+                        )
+                    )
+                ],
+            ),
+            genai_types.Content(
+                role="user",
+                parts=[
+                    genai_types.Part(
+                        function_response=genai_types.FunctionResponse(
+                            id="call-weather-0",
+                            name="get_weather",
+                            response={"forecast": "sunny"},
+                        )
+                    )
+                ],
+            ),
+        ]
+        config = genai_types.GenerateContentConfig(
+            system_instruction=genai_types.Content(role="system", parts=[genai_types.Part(text="Be concise.")]),
+            temperature=0.2,
+            max_output_tokens=256,
+            top_p=0.95,
+            tool_config=genai_types.ToolConfig(
+                function_calling_config=genai_types.FunctionCallingConfig(
+                    mode=genai_types.FunctionCallingConfigMode.ANY,
+                    allowed_function_names=["get_weather"],
+                )
+            ),
+            thinking_config=genai_types.ThinkingConfig(include_thoughts=True, thinking_budget=1536),
+            tools=[
+                genai_types.Tool(
+                    function_declarations=[
+                        genai_types.FunctionDeclaration(
+                            name="get_weather",
+                            description="Gets the weather for a city.",
+                            parameters_json_schema={
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                                "required": ["city"],
+                            },
+                        )
+                    ]
+                )
+            ],
+        )
+        tools_dict = {}
+
+    class _LlmResponse:
+        content = genai_types.Content(
+            role="model",
+            parts=[
+                genai_types.Part(
+                    function_call=genai_types.FunctionCall(
+                        id="call-weather-1",
+                        name="get_weather",
+                        args={"city": "Paris"},
+                    )
+                )
+            ],
+        )
+        model_version = "gemini-2.5-pro-001"
+        usage_metadata = genai_types.GenerateContentResponseUsageMetadata(
+            prompt_token_count=10,
+            candidates_token_count=5,
+            cached_content_token_count=3,
+            thoughts_token_count=2,
+            tool_use_prompt_token_count=4,
+            total_token_count=21,
+        )
+        finish_reason = "STOP"
+
+    try:
+        plugin = create_sigil_google_adk_plugin(client=client)
+
+        async def _run() -> None:
+            invocation_context = _InvocationContext()
+            callback_context = _CallbackContext()
+            await plugin.before_run_callback(invocation_context=invocation_context)
+            await plugin.before_agent_callback(agent=object(), callback_context=callback_context)
+            await plugin.before_model_callback(callback_context=callback_context, llm_request=_LlmRequest())
+            await plugin.after_model_callback(callback_context=callback_context, llm_response=_LlmResponse())
+            await plugin.after_agent_callback(agent=object(), callback_context=callback_context)
+            await plugin.after_run_callback(invocation_context=invocation_context)
+
+        asyncio.run(_run())
+        client.flush()
+
+        generation = exporter.requests[0].generations[0]
+        assert generation.system_prompt == "Be concise."
+        assert generation.max_tokens == 256
+        assert generation.temperature == 0.2
+        assert generation.top_p == 0.95
+        assert generation.tool_choice == "get_weather"
+        assert generation.thinking_enabled is True
+        assert generation.metadata["sigil.gen_ai.request.thinking.budget_tokens"] == 1536
+        assert len(generation.tools) == 1
+        assert generation.tools[0].name == "get_weather"
+        assert generation.tools[0].description == "Gets the weather for a city."
+        assert b'"city"' in generation.tools[0].input_schema_json
+
+        assert generation.input[1].role.value == "assistant"
+        history_tool_call = generation.input[1].parts[0].tool_call
+        assert history_tool_call is not None
+        assert history_tool_call.id == "call-weather-0"
+        assert history_tool_call.name == "get_weather"
+
+        assert generation.input[2].role.value == "tool"
+        history_tool_result = generation.input[2].parts[0].tool_result
+        assert history_tool_result is not None
+        assert history_tool_result.tool_call_id == "call-weather-0"
+        assert history_tool_result.name == "get_weather"
+        assert b'"forecast"' in history_tool_result.content_json
+
+        assert generation.output[0].role.value == "assistant"
+        tool_call = generation.output[0].parts[0].tool_call
+        assert tool_call is not None
+        assert tool_call.id == "call-weather-1"
+        assert tool_call.name == "get_weather"
+        assert b'"Paris"' in tool_call.input_json
+
+        assert generation.usage.input_tokens == 14
+        assert generation.usage.output_tokens == 7
+        assert generation.usage.cache_read_input_tokens == 3
+        assert generation.usage.reasoning_tokens == 2
+        assert generation.usage.total_tokens == 21
     finally:
         client.shutdown()
 

--- a/python/sigil_sdk/framework_handler.py
+++ b/python/sigil_sdk/framework_handler.py
@@ -28,6 +28,7 @@ from sigil_sdk import (
     ToolCall,
     ToolDefinition,
     ToolExecutionStart,
+    ToolResult,
     WorkflowStep,
     user_text_message,
 )
@@ -74,6 +75,8 @@ _span_attr_framework_langgraph_node = "sigil.framework.langgraph.node"
 _span_attr_framework_event_id = "sigil.framework.event_id"
 _span_attr_error_type = "error.type"
 _span_attr_error_category = "error.category"
+_metadata_thinking_budget_tokens = "sigil.gen_ai.request.thinking.budget_tokens"
+_metadata_thinking_level = "sigil.gen_ai.request.thinking.level"
 _max_framework_metadata_depth = 5
 _metadata_drop = object()
 
@@ -344,6 +347,7 @@ class SigilFrameworkHandlerBase:
             metadata[_span_attr_framework_langgraph_node] = langgraph_node
         if event_id != "":
             metadata[_span_attr_framework_event_id] = event_id
+        _add_invocation_control_metadata(metadata, invocation_params)
         metadata = _normalize_framework_metadata(metadata)
 
         if parent_run_id is not None:
@@ -447,6 +451,7 @@ class SigilFrameworkHandlerBase:
             metadata[_span_attr_framework_langgraph_node] = langgraph_node
         if event_id != "":
             metadata[_span_attr_framework_event_id] = event_id
+        _add_invocation_control_metadata(metadata, invocation_params)
         metadata = _normalize_framework_metadata(metadata)
 
         if parent_run_id is not None:
@@ -474,6 +479,7 @@ class SigilFrameworkHandlerBase:
             max_tokens=_as_optional_int(_read(invocation_params, "max_tokens")),
             top_p=_as_optional_float(_read(invocation_params, "top_p")),
             tool_choice=_as_str(_read(invocation_params, "tool_choice")) or None,
+            thinking_enabled=_as_optional_bool(_read(invocation_params, "thinking_enabled")),
             parent_generation_ids=parent_generation_ids,
         )
         if start.id == "":
@@ -1297,6 +1303,16 @@ def _resolve_framework_event_id(*payloads: Any) -> str:
     return ""
 
 
+def _add_invocation_control_metadata(metadata: dict[str, Any], invocation_params: dict[str, Any] | None) -> None:
+    thinking_budget = _as_optional_int(_read(invocation_params, "thinking_budget"))
+    if thinking_budget is not None:
+        metadata.setdefault(_metadata_thinking_budget_tokens, thinking_budget)
+
+    thinking_level = _as_str(_read(invocation_params, "thinking_level"))
+    if thinking_level != "":
+        metadata.setdefault(_metadata_thinking_level, thinking_level)
+
+
 def _retry_attempt_from_payload(payload: Any) -> int | None:
     candidates = (
         _as_optional_int(_read(payload, "retry_attempt")),
@@ -1349,16 +1365,33 @@ def _map_chat_inputs(messages: list[list[Any]]) -> list[Message]:
     output: list[Message] = []
     for batch in messages:
         for message in batch:
-            text = _extract_message_text(message)
-            if text == "":
-                continue
-            output.append(
-                Message(
-                    role=_normalize_role(_extract_message_role(message)),
-                    parts=[Part(kind=PartKind.TEXT, text=text)],
-                )
-            )
+            mapped = _map_chat_input_message(message)
+            if mapped is not None:
+                output.append(mapped)
     return output
+
+
+def _map_chat_input_message(message: Any) -> Message | None:
+    parts: list[Part] = []
+
+    text = _extract_message_text(message)
+    if text != "":
+        parts.append(Part(kind=PartKind.TEXT, text=text))
+
+    for tool_call in _as_list(_read(message, "tool_calls")):
+        tool_call_part = _map_langchain_tool_call_part(tool_call)
+        if tool_call_part is not None:
+            parts.append(tool_call_part)
+
+    for tool_result in _as_list(_read(message, "tool_results")):
+        tool_result_part = _map_framework_tool_result_part(tool_result)
+        if tool_result_part is not None:
+            parts.append(tool_result_part)
+
+    if not parts:
+        return None
+
+    return Message(role=_normalize_message_role(message, parts), parts=parts)
 
 
 def _map_output_messages(response: Any) -> list[Message]:
@@ -1405,10 +1438,15 @@ def _map_generation_candidate_message(candidate: Any) -> Message | None:
         if tool_call_part is not None:
             parts.append(tool_call_part)
 
+    for tool_result in _as_list(_read(message, "tool_results")):
+        tool_result_part = _map_framework_tool_result_part(tool_result)
+        if tool_result_part is not None:
+            parts.append(tool_result_part)
+
     if not parts:
         return None
 
-    return Message(role=_normalize_role(_extract_message_role(message)), parts=parts)
+    return Message(role=_normalize_message_role(message, parts), parts=parts)
 
 
 def _map_langchain_tool_call_part(tool_call: Any) -> Part | None:
@@ -1426,6 +1464,39 @@ def _map_langchain_tool_call_part(tool_call: Any) -> Part | None:
             id=_as_str(_read(tool_call, "id")),
             name=name,
             input_json=_json_bytes(args),
+        ),
+    )
+
+
+def _map_framework_tool_result_part(tool_result: Any) -> Part | None:
+    response = _read(tool_result, "response")
+    content = _read(tool_result, "content")
+    if content is None and isinstance(response, str):
+        content = response
+
+    content_json = _first_present(
+        _read(tool_result, "content_json"),
+        _read(tool_result, "contentJson"),
+    )
+    if content_json is None and response is not None and not isinstance(response, str):
+        content_json = response
+
+    if content is None and content_json is None:
+        return None
+
+    return Part(
+        kind=PartKind.TOOL_RESULT,
+        tool_result=ToolResult(
+            tool_call_id=_first_non_empty_str(
+                _read(tool_result, "tool_call_id"),
+                _read(tool_result, "toolCallId"),
+                _read(tool_result, "call_id"),
+                _read(tool_result, "id"),
+            ),
+            name=_as_str(_read(tool_result, "name")),
+            content=_as_str(content),
+            content_json=content_json if isinstance(content_json, bytes) else _json_bytes(content_json),
+            is_error=_as_bool(_read(tool_result, "is_error")),
         ),
     )
 
@@ -1495,11 +1566,17 @@ def _map_framework_usage(raw_usage: Any):
 
 def _normalize_role(role: str) -> MessageRole:
     normalized = role.strip().lower()
-    if normalized in {"assistant", "ai"}:
+    if normalized in {"assistant", "ai", "model"}:
         return MessageRole.ASSISTANT
     if normalized == "tool":
         return MessageRole.TOOL
     return MessageRole.USER
+
+
+def _normalize_message_role(message: Any, parts: list[Part]) -> MessageRole:
+    if any(part.kind == PartKind.TOOL_RESULT for part in parts):
+        return MessageRole.TOOL
+    return _normalize_role(_extract_message_role(message))
 
 
 def _read(value: Any, key: str) -> Any:
@@ -1514,6 +1591,21 @@ def _as_list(value: Any) -> list[Any]:
     if isinstance(value, list):
         return value
     return []
+
+
+def _first_present(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _first_non_empty_str(*values: Any) -> str:
+    for value in values:
+        text = _as_str(value)
+        if text != "":
+            return text
+    return ""
 
 
 def _as_str(value: Any) -> str:
@@ -1613,6 +1705,22 @@ def _as_optional_float(value: Any) -> float | None:
             return float(stripped)
         except ValueError:
             return None
+    return None
+
+
+def _as_optional_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    if isinstance(value, int):
+        return value != 0
     return None
 
 

--- a/python/sigil_sdk/usage.py
+++ b/python/sigil_sdk/usage.py
@@ -71,14 +71,16 @@ def from_gemini(raw: Any) -> TokenUsage:
     if raw is None:
         return TokenUsage()
 
-    input_tokens = _as_int(_read(raw, "prompt_token_count"))
-    output_tokens = _as_int(_read(raw, "candidates_token_count"))
+    prompt_tokens = _as_int(_read(raw, "prompt_token_count"))
+    candidate_tokens = _as_int(_read(raw, "candidates_token_count"))
     total_tokens = _as_int(_read(raw, "total_token_count"))
     tool_use_prompt_tokens = _as_int(_read(raw, "tool_use_prompt_token_count"))
     reasoning_tokens = _as_int(_read(raw, "thoughts_token_count"))
+    input_tokens = prompt_tokens + tool_use_prompt_tokens
+    output_tokens = candidate_tokens + reasoning_tokens
 
     if total_tokens == 0:
-        total_tokens = input_tokens + output_tokens + tool_use_prompt_tokens + reasoning_tokens
+        total_tokens = input_tokens + output_tokens
 
     cache_write_raw = _read(raw, "cache_write_input_token_count")
     cache_write = (

--- a/python/tests/test_usage.py
+++ b/python/tests/test_usage.py
@@ -205,8 +205,8 @@ class TestFromGemini:
             "tool_use_prompt_token_count": 15,
         }
         usage = from_gemini(raw)
-        assert usage.input_tokens == 500
-        assert usage.output_tokens == 250
+        assert usage.input_tokens == 515
+        assert usage.output_tokens == 285
         assert usage.total_tokens == 800
         assert usage.cache_read_input_tokens == 60
         # When both upstream fields are present, prefer cache_write_input_token_count.
@@ -222,6 +222,8 @@ class TestFromGemini:
             "tool_use_prompt_token_count": 10,
         }
         usage = from_gemini(raw)
+        assert usage.input_tokens == 110
+        assert usage.output_tokens == 70
         assert usage.total_tokens == 180  # 100 + 50 + 10 + 20
 
     def test_partial(self):


### PR DESCRIPTION
## Summary

This updates the Python Google ADK integration for current ADK request and callback behavior, with explicit coverage for Google ADK 1.31 compatibility. The customer-visible symptoms were that tools and prompt details could disappear from Sigil captures, and Gemini/ADK token accounting could look wrong for tool-heavy or thinking-enabled calls.

## Root Cause

The adapter was still treating Google ADK model callbacks as mostly text-only payloads. Current ADK carries important data on `LlmRequest.config`, including system instructions, `GenerateContentConfig.tools`, `tool_config`, and `thinking_config`. Model content and history also use GenAI `Content` parts such as `function_call` and `function_response`, not just text.

That meant Sigil could miss tool definitions, assistant tool calls, prior tool results in prompt history, and ADK control fields. Separately, Gemini usage metadata includes `tool_use_prompt_token_count` and `thoughts_token_count`; those were preserved but not reflected in the input/output buckets used for pricing-style views.

## Changes

- Raises the Python Google ADK package dependency floor to `google-adk>=1.31.0`.
- Updates the Google ADK plugin bridge for current `BasePlugin` agent callback signatures that pass `agent=`.
- Maps current ADK request config into Sigil generation controls: system prompt, tools, tool choice, max tokens, temperature, top-p, and thinking config.
- Maps GenAI function declarations, built-in ADK tools, assistant function calls, and ADK `function_response` history into Sigil tool definitions, tool calls, and tool results.
- Preserves Gemini/ADK usage metadata fields and adjusts Gemini usage bucketing so tool-use prompt tokens count as input and thoughts count as output/reasoning.
- Adds regression coverage using real `google.genai.types` request/response objects.

## Validation

- `uv run --python 3.13 --reinstall-package sigil-sdk-google-adk --reinstall-package sigil-sdk --with './python[dev]' --with './python-frameworks/google-adk[dev]' --with 'google-adk==1.31.0' pytest python-frameworks/google-adk/tests python/tests/test_usage.py`
- `uv run --python 3.13 --reinstall-package sigil-sdk-google-adk --reinstall-package sigil-sdk --with './python[dev]' --with './python-frameworks/google-adk[dev]' pytest python-frameworks/google-adk/tests`
- `mise run test:py:sdk-google-adk`
- `mise run test:py:sdk-gemini`
- `mise run test:py:sdk-langchain`
- `mise run test:py:sdk-langgraph`
- `mise run test:py:sdk-core`
- `mise run lint:py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes generation export shape and Gemini token bucketing for all Gemini usage paths, not only ADK; behavior is intentional but could shift reported input/output totals for existing customers.
> 
> **Overview**
> Aligns the Python **Google ADK** integration with current ADK/GenAI callbacks so Sigil exports match what ADK actually sends on the wire.
> 
> The adapter now reads **`GenerateContentConfig`** (system instruction, tools, tool choice, sampling limits, thinking config) into generation start fields, maps **function_call** / **function_response** parts in history and outputs (not just text), and accepts **`agent=`** on agent plugin callbacks. Dependency floor is **`google-adk>=1.31.0`**.
> 
> Shared **`framework_handler`** changes propagate ADK-shaped messages: chat input/output mapping includes **tool_calls** and **tool_results**, **thinking_enabled** and thinking budget/level metadata, and **`model`** roles normalize to assistant.
> 
> **Gemini `from_gemini` usage** now rolls **tool_use_prompt_token_count** into input and **thoughts_token_count** into output/reasoning so pricing-style totals match tool-heavy and thinking-enabled calls; tests cover the new ADK plugin path with real **`google.genai.types`** objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14e116a3b9d103cdcf3aea2447360e05ba164c6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->