### PR TITLE
feat(plugins/copilot): VS Code support, surface tracking, guard deny fix

### DIFF
--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -1,9 +1,12 @@
 # Sigil for GitHub Copilot CLI
 
-Forwards completed GitHub Copilot CLI turns, hook-visible tool calls, error
+Forwards completed GitHub Copilot turns, hook-visible tool calls, error
 metadata, subagent lifecycle metadata, and optional prompt/tool content to
 [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/).
-Ships as a GitHub Copilot CLI plugin powered by the shared `sigil` binary.
+Powered by the shared `sigil` binary and driven by a single hooks file at
+`~/.copilot/hooks/sigil.json`, which is read by **both** the GitHub Copilot CLI
+and Copilot Chat in **VS Code**. Each exported turn is tagged with the host it
+came from (`hook.surface` = `copilot-cli` or `vscode`).
 
 > Experimental. GitHub Copilot CLI plugin support is still evolving, and the
 > current documented hook payloads do not expose final assistant response text,
@@ -16,35 +19,18 @@ Ships as a GitHub Copilot CLI plugin powered by the shared `sigil` binary.
 
 ```sh
 brew install grafana/grafana/sigil
-sigil copilot
+sigil copilot -- <copilot args>
 ```
 
-`sigil copilot` registers `sigil-copilot` on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches Copilot CLI.
+`sigil copilot` writes the shared hooks file to `~/.copilot/hooks/sigil.json`, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, removes any legacy `sigil-copilot` plugin left by older versions, and then launches Copilot CLI.
 
-<details>
-<summary>Manual plugin registration</summary>
+For VS Code, no launch wrapper is needed — once `~/.copilot/hooks/sigil.json` exists, add `~/.copilot/hooks` to the `chat.hookFilesLocations` setting and Copilot Chat picks it up.
 
-The current
-[GitHub Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference)
-documents both local-path and GitHub-subdirectory install forms:
-
-```sh
-copilot plugin install ./plugins/copilot
-```
-
-or:
-
-```sh
-copilot plugin install grafana/sigil-sdk:plugins/copilot
-```
-
-Confirm the install:
-
-```sh
-copilot plugin list
-```
-
-</details>
+> The integration deliberately does **not** register a Copilot CLI plugin. The
+> CLI runs hooks from the plugin store *and* `~/.copilot/hooks`, so a plugin
+> alongside the shared file would fire every hook (and export every turn)
+> twice. The single shared file covers both the CLI and VS Code; the hook
+> dispatcher infers the host at runtime.
 
 ## 2. Credentials
 
@@ -101,7 +87,7 @@ tail -f ~/.local/state/sigil/logs/sigil.log
 
 ## Supported Hook Events
 
-The plugin registers these GitHub Copilot CLI hook triggers:
+The shared hooks file wires these GitHub Copilot hook triggers:
 
 - `sessionStart`
 - `sessionEnd`
@@ -145,7 +131,7 @@ Captured prompt, assistant, and tool content is redacted before export. See [Con
 | `SIGIL_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Copilot `preToolUse` hook is evaluated against Sigil and tool calls denied by guard rules are blocked. |
 | `SIGIL_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |
 | `SIGIL_GUARDS_TIMEOUT_MS` | `1500` | Per-call timeout. Lower = less added latency on every tool call, higher = better tolerance for slow `llm_judge` evaluators. |
-| `SIGIL_AUTO_UPDATE` | `true` | Refresh the `sigil-copilot` plugin automatically. Set `false` to pin the installed version. |
+| `SIGIL_COPILOT_HOOK_SURFACE` | _(auto)_ | Override the detected host surface (`copilot-cli` or `vscode`). Normally inferred at runtime; set explicitly only when driving capture through a custom hooks config. |
 
 If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>`.
 
@@ -166,11 +152,30 @@ When the documented Copilot hook payloads provide it, the plugin exports:
 - subagent lifecycle metadata from `SubagentStart` and `SubagentStop`
 - timestamps and turn duration
 
-The plugin always tags exported generations with:
+Exported generations are always tagged with:
 
 - `entrypoint=copilot`
+- `hook.surface` — `copilot-cli` or `vscode`, inferred at runtime (see below)
 - `cwd` when Copilot includes it
 - `hook.source` when Copilot includes it
+
+### Surface detection (`copilot-cli` vs `vscode`)
+
+The Copilot hook payload carries no host identifier, and one shared
+`~/.copilot/hooks/sigil.json` serves both hosts, so the surface is resolved at
+runtime:
+
+1. An explicit `SIGIL_COPILOT_HOOK_SURFACE` env var wins (the in-repo
+   `plugins/copilot/hooks.json` sets `copilot-cli` for anyone driving capture
+   through a plugin instead of the shared file).
+2. Otherwise, if a `copilot` process is an ancestor of the hook, the surface is
+   `copilot-cli` — this holds even when the CLI runs inside a VS Code
+   integrated terminal.
+3. Otherwise the surface is `vscode` (Copilot Chat's extension host spawns the
+   hook, with no `copilot` ancestor).
+
+The resolved surface is also written to the `copilot.hook_surface` metadata
+field and the `SIGIL_DEBUG` log line (`dispatch: event=… surface=…`).
 
 ## Limitations / Known Gaps
 
@@ -178,13 +183,14 @@ The plugin always tags exported generations with:
 - Current observed Copilot CLI transcripts expose assistant text, model, request ids, message ids, native turn ids, reasoning effort, and output token counts. They do not appear to expose input token counts, cache token counts, or reasoning token counts for completed turns, so usage and cost can still be partial.
 - Copilot does not document a stable native turn ID in these hook payloads. This plugin creates a local monotonic turn ID per session and hashes it into the Sigil generation id.
 - Subagent hooks do not currently expose enough durable identity to synthesize separate child generations safely, so subagent activity is exported as parent-turn metadata only.
-- This package targets Copilot CLI plugin installation. Copilot cloud agent uses repository-level `.github/hooks/*.json` instead, and GitHub documents cloud-agent outbound network access as restricted by the firewall by default.
+- This package targets the local Copilot CLI and Copilot Chat in VS Code via the shared `~/.copilot/hooks/sigil.json`. Copilot cloud agent uses repository-level `.github/hooks/*.json` instead, and GitHub documents cloud-agent outbound network access as restricted by the firewall by default.
 
 ## Troubleshooting
 
 | Symptom | Try |
 |---|---|
-| Plugin does not appear in `copilot plugin list` | Re-run `sigil copilot` or `copilot plugin install grafana/sigil-sdk:plugins/copilot`. Confirm `plugin.json` is at the plugin root. |
+| Hooks file missing at `~/.copilot/hooks/sigil.json` | Re-run `sigil copilot -- <args>` (it writes the file before launching). For VS Code, also add `~/.copilot/hooks` to `chat.hookFilesLocations`. |
+| Turns appear twice in Sigil | A leftover `sigil-copilot` plugin is firing alongside the shared file. Remove it: `copilot plugin uninstall sigil-copilot` (newer `sigil copilot` runs do this automatically). |
 | Command not found | Reinstall: `brew install grafana/grafana/sigil`. Check `sigil --version`. |
 | Hooks run but nothing appears in Sigil | Check `SIGIL_ENDPOINT`, `SIGIL_AUTH_TENANT_ID`, and `SIGIL_AUTH_TOKEN`. Without all three, the plugin discards the completed fragment. |
 | No latency/tool charts in AI Observability | Set `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` so the plugin can emit traces and metrics. |

--- a/plugins/copilot/hooks.json
+++ b/plugins/copilot/hooks.json
@@ -7,6 +7,7 @@
             "type": "command",
             "command": "sigil copilot hook",
             "env": {
+              "SIGIL_COPILOT_HOOK_SURFACE": "copilot-cli",
               "SIGIL_COPILOT_HOOK_EVENT": "sessionStart"
             },
             "timeout": 10
@@ -21,6 +22,7 @@
             "type": "command",
             "command": "sigil copilot hook",
             "env": {
+              "SIGIL_COPILOT_HOOK_SURFACE": "copilot-cli",
               "SIGIL_COPILOT_HOOK_EVENT": "sessionEnd"
             },
             "timeout": 10
@@ -35,6 +37,7 @@
             "type": "command",
             "command": "sigil copilot hook",
             "env": {
+              "SIGIL_COPILOT_HOOK_SURFACE": "copilot-cli",
               "SIGIL_COPILOT_HOOK_EVENT": "userPromptSubmitted"
             },
             "timeout": 10
@@ -49,6 +52,7 @@
             "type": "command",
             "command": "sigil copilot hook",
             "env": {
+              "SIGIL_COPILOT_HOOK_SURFACE": "copilot-cli",
               "SIGIL_COPILOT_HOOK_EVENT": "preToolUse"
             },
             "timeout": 10
@@ -63,6 +67,7 @@
             "type": "command",
             "command": "sigil copilot hook",
             "env": {
+              "SIGIL_COPILOT_HOOK_SURFACE": "copilot-cli",
               "SIGIL_COPILOT_HOOK_EVENT": "postToolUse"
             },
             "timeout": 10
@@ -77,6 +82,7 @@
             "type": "command",
             "command": "sigil copilot hook",
             "env": {
+              "SIGIL_COPILOT_HOOK_SURFACE": "copilot-cli",
               "SIGIL_COPILOT_HOOK_EVENT": "postToolUseFailure"
             },
             "timeout": 10
@@ -91,6 +97,7 @@
             "type": "command",
             "command": "sigil copilot hook",
             "env": {
+              "SIGIL_COPILOT_HOOK_SURFACE": "copilot-cli",
               "SIGIL_COPILOT_HOOK_EVENT": "errorOccurred"
             },
             "timeout": 10
@@ -105,6 +112,7 @@
             "type": "command",
             "command": "sigil copilot hook",
             "env": {
+              "SIGIL_COPILOT_HOOK_SURFACE": "copilot-cli",
               "SIGIL_COPILOT_HOOK_EVENT": "subagentStart"
             },
             "timeout": 10
@@ -119,6 +127,7 @@
             "type": "command",
             "command": "sigil copilot hook",
             "env": {
+              "SIGIL_COPILOT_HOOK_SURFACE": "copilot-cli",
               "SIGIL_COPILOT_HOOK_EVENT": "subagentStop"
             },
             "timeout": 10
@@ -133,6 +142,7 @@
             "type": "command",
             "command": "sigil copilot hook",
             "env": {
+              "SIGIL_COPILOT_HOOK_SURFACE": "copilot-cli",
               "SIGIL_COPILOT_HOOK_EVENT": "agentStop"
             },
             "timeout": 30

--- a/plugins/sigil/cmd/sigil/testdata/golden/copilot-basic/export.golden.json
+++ b/plugins/sigil/cmd/sigil/testdata/golden/copilot-basic/export.golden.json
@@ -34,6 +34,7 @@
           "copilot.agent_version": "1.0.50",
           "copilot.assistant_text_available": true,
           "copilot.error_count": 0,
+          "copilot.hook_surface": "copilot-cli",
           "copilot.interaction_id": "int-1",
           "copilot.message_id": "msg-1",
           "copilot.model_reported": true,
@@ -87,7 +88,8 @@
         "stop_reason": "end_turn",
         "tags": {
           "entrypoint": "copilot",
-          "hook.source": "new"
+          "hook.source": "new",
+          "hook.surface": "copilot-cli"
         },
         "tools": [
           {

--- a/plugins/sigil/cmd/sigil/testdata/golden/copilot-basic/scenario.json
+++ b/plugins/sigil/cmd/sigil/testdata/golden/copilot-basic/scenario.json
@@ -10,34 +10,34 @@
   },
   "events": [
     {
-      "_env": {"SIGIL_COPILOT_HOOK_EVENT": "sessionStart"},
+      "_env": {"SIGIL_COPILOT_HOOK_SURFACE": "copilot-cli", "SIGIL_COPILOT_HOOK_EVENT": "sessionStart"},
       "session_id": "copilot-sess-1",
       "source": "new",
       "transcript_path": "{{transcript:main}}",
       "timestamp": "2026-05-03T12:00:00Z"
     },
     {
-      "_env": {"SIGIL_COPILOT_HOOK_EVENT": "userPromptSubmitted"},
+      "_env": {"SIGIL_COPILOT_HOOK_SURFACE": "copilot-cli", "SIGIL_COPILOT_HOOK_EVENT": "userPromptSubmitted"},
       "session_id": "copilot-sess-1",
       "prompt": "hello glc_abcdefghijklmnopqrstuvwxyz",
       "timestamp": "2026-05-03T12:00:01Z"
     },
     {
-      "_env": {"SIGIL_COPILOT_HOOK_EVENT": "preToolUse"},
+      "_env": {"SIGIL_COPILOT_HOOK_SURFACE": "copilot-cli", "SIGIL_COPILOT_HOOK_EVENT": "preToolUse"},
       "session_id": "copilot-sess-1",
       "tool_name": "bash",
       "tool_input": {"cmd": "echo hi"},
       "timestamp": "2026-05-03T12:00:02Z"
     },
     {
-      "_env": {"SIGIL_COPILOT_HOOK_EVENT": "postToolUse"},
+      "_env": {"SIGIL_COPILOT_HOOK_SURFACE": "copilot-cli", "SIGIL_COPILOT_HOOK_EVENT": "postToolUse"},
       "session_id": "copilot-sess-1",
       "tool_name": "bash",
       "tool_result": {"text_result_for_llm": "ok"},
       "timestamp": "2026-05-03T12:00:03Z"
     },
     {
-      "_env": {"SIGIL_COPILOT_HOOK_EVENT": "agentStop"},
+      "_env": {"SIGIL_COPILOT_HOOK_SURFACE": "copilot-cli", "SIGIL_COPILOT_HOOK_EVENT": "agentStop"},
       "session_id": "copilot-sess-1",
       "stop_reason": "end_turn",
       "transcript_path": "{{transcript:main}}",

--- a/plugins/sigil/internal/agents/copilot/fragment/fragment.go
+++ b/plugins/sigil/internal/agents/copilot/fragment/fragment.go
@@ -60,6 +60,7 @@ type Session struct {
 	SessionID      string `json:"sessionId"`
 	Cwd            string `json:"cwd,omitempty"`
 	Source         string `json:"source,omitempty"`
+	Surface        string `json:"surface,omitempty"`
 	InitialPrompt  string `json:"initialPrompt,omitempty"`
 	TranscriptPath string `json:"transcriptPath,omitempty"`
 	StartedAt      string `json:"startedAt,omitempty"`
@@ -73,6 +74,7 @@ type Fragment struct {
 	TurnID          string           `json:"turnId"`
 	Cwd             string           `json:"cwd,omitempty"`
 	Source          string           `json:"source,omitempty"`
+	Surface         string           `json:"surface,omitempty"`
 	Prompt          string           `json:"prompt,omitempty"`
 	PromptHash      string           `json:"promptHash,omitempty"`
 	InitialPrompt   string           `json:"initialPrompt,omitempty"`

--- a/plugins/sigil/internal/agents/copilot/hook.go
+++ b/plugins/sigil/internal/agents/copilot/hook.go
@@ -48,6 +48,16 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 		logger.Print("dispatch: missing hook_event_name")
 		return nil
 	}
+	// The Copilot payload carries no host identifier and one shared
+	// ~/.copilot/hooks file is read by both the CLI and VS Code, so the
+	// surface (vscode vs copilot-cli) is resolved at runtime: an explicit
+	// SIGIL_COPILOT_HOOK_SURFACE env wins, otherwise it is inferred from the
+	// process tree. Stamp it onto the payload so handlers persist it.
+	payload.SurfaceMarker = surfaceDetect()
+	surfaceLog := payload.SurfaceMarker
+	if surfaceLog == "" {
+		surfaceLog = "unknown"
+	}
 	sessionID := payload.SessionID()
 	defer func() {
 		activeTurnID := ""
@@ -59,7 +69,7 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 		fragment.CleanupStaleExcept(fragment.DefaultStaleAge, time.Now(), logger, sessionID, activeTurnID)
 	}()
 	cfg := config.Load(logger)
-	logger.Printf("dispatch: event=%s", eventName)
+	logger.Printf("dispatch: event=%s surface=%s", eventName, surfaceLog)
 	switch eventName {
 	case "sessionStart", "SessionStart":
 		hook.SessionStart(payload, cfg, logger)

--- a/plugins/sigil/internal/agents/copilot/hook/handlers.go
+++ b/plugins/sigil/internal/agents/copilot/hook/handlers.go
@@ -49,6 +49,9 @@ func SessionStart(p Payload, cfg config.Config, logger *log.Logger) {
 		if src := p.Source(); src != "" {
 			s.Source = src
 		}
+		if surface := p.Surface(); surface != "" {
+			s.Surface = surface
+		}
 		if cfg.ContentCapture != sigil.ContentCaptureModeMetadataOnly {
 			if initialPrompt := p.InitialPrompt(); initialPrompt != "" {
 				s.InitialPrompt = initialPrompt
@@ -139,7 +142,13 @@ func PreToolUse(ctx context.Context, stdout io.Writer, p Payload, cfg config.Con
 			ModelName:     modelName,
 		}, logger)
 		if res.Blocked() {
-			emitCopilotDeny(stdout, res.Reason, logger)
+			// Copilot command hooks (both the CLI and Copilot Chat in VS
+			// Code) read the deny verdict from the nested
+			// hookSpecificOutput.permissionDecision envelope — the same
+			// shape Claude Code and Codex use. A top-level permissionDecision
+			// (the Copilot *SDK* return shape) is silently ignored by VS
+			// Code, so the tool would run anyway. Use the shared writer.
+			guard.WriteHookSpecificOutputDeny(stdout, res.Reason)
 			return
 		}
 	}
@@ -165,29 +174,6 @@ func PreToolUse(ctx context.Context, stdout io.Writer, p Payload, cfg config.Con
 		})
 	}); err != nil {
 		logger.Printf("preToolUse: update turn: %v", err)
-	}
-}
-
-// copilotDecision matches GitHub's documented preToolUse stdout shape:
-// top-level permissionDecision and permissionDecisionReason. Sigil only
-// emits permissionDecision=deny here; allow paths stay stdout-empty.
-type copilotDecision struct {
-	PermissionDecision       string `json:"permissionDecision"`
-	PermissionDecisionReason string `json:"permissionDecisionReason,omitempty"`
-}
-
-func emitCopilotDeny(stdout io.Writer, reason string, logger *log.Logger) {
-	if stdout == nil {
-		return
-	}
-	if strings.TrimSpace(reason) == "" {
-		reason = "tool call denied by Sigil guard"
-	}
-	if err := json.NewEncoder(stdout).Encode(copilotDecision{
-		PermissionDecision:       "deny",
-		PermissionDecisionReason: reason,
-	}); err != nil && logger != nil {
-		logger.Printf("preToolUse: write deny decision: %v", err)
 	}
 }
 
@@ -444,6 +430,9 @@ func updateCommon(sessionID, turnID string, session *fragment.Session, p Payload
 		if src := p.Source(); src != "" {
 			f.Source = src
 		}
+		if surface := p.Surface(); surface != "" {
+			f.Surface = surface
+		}
 		if transcriptPath := p.TranscriptPath(); transcriptPath != "" {
 			f.TranscriptPath = transcriptPath
 		}
@@ -471,6 +460,9 @@ func applySessionDefaults(f *fragment.Fragment, session *fragment.Session) {
 	}
 	if f.Source == "" {
 		f.Source = session.Source
+	}
+	if f.Surface == "" {
+		f.Surface = session.Surface
 	}
 	if f.TranscriptPath == "" {
 		f.TranscriptPath = session.TranscriptPath

--- a/plugins/sigil/internal/agents/copilot/hook/handlers_test.go
+++ b/plugins/sigil/internal/agents/copilot/hook/handlers_test.go
@@ -513,7 +513,7 @@ func TestPreToolUseGuardBehavior(t *testing.T) {
 			guards:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
 			hookResponse:        `{"action":"deny","reason":"blocked tool"}`,
 			wantServerCalled:    true,
-			wantStdoutContains:  []string{`"permissionDecision":"deny"`, `A Grafana AI Observability policy`, `blocked tool`},
+			wantStdoutContains:  []string{`"hookSpecificOutput"`, `"hookEventName":"PreToolUse"`, `"permissionDecision":"deny"`, `A Grafana AI Observability policy`, `blocked tool`},
 			wantToolRecordCount: 0,
 		},
 		{

--- a/plugins/sigil/internal/agents/copilot/hook/payload.go
+++ b/plugins/sigil/internal/agents/copilot/hook/payload.go
@@ -18,6 +18,13 @@ type Payload struct {
 
 	SourceValue string `json:"source,omitempty"`
 
+	// SurfaceMarker identifies which host integration fired the hook
+	// (e.g. "vscode" or "copilot-cli"). It is NOT part of the Copilot hook
+	// wire payload — the dispatcher populates it from the
+	// SIGIL_COPILOT_HOOK_SURFACE env var set per entry in the hooks config,
+	// so each config file (plugin vs ~/.copilot/hooks) self-identifies.
+	SurfaceMarker string `json:"-"`
+
 	InitialPromptJSON string `json:"initial_prompt,omitempty"`
 	InitialPromptJS   string `json:"initialPrompt,omitempty"`
 	Prompt            string `json:"prompt,omitempty"`
@@ -91,6 +98,12 @@ func (p Payload) SessionID() string {
 
 func (p Payload) Source() string {
 	return firstNonEmpty(p.SourceValue)
+}
+
+// Surface returns the host integration that fired the hook, as declared by
+// the hooks config via SIGIL_COPILOT_HOOK_SURFACE. Empty when unknown.
+func (p Payload) Surface() string {
+	return firstNonEmpty(p.SurfaceMarker)
 }
 
 func (p Payload) InitialPrompt() string {

--- a/plugins/sigil/internal/agents/copilot/launch.go
+++ b/plugins/sigil/internal/agents/copilot/launch.go
@@ -3,87 +3,69 @@ package copilot
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"syscall"
-	"time"
 
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/local"
-	"github.com/grafana/sigil-sdk/plugins/sigil/internal/updatecheck"
 )
 
 const (
-	// installSource is the GitHub subdir spec passed to
-	// `copilot plugin install`. Copilot CLI documents
-	// `OWNER/REPO:PATH/TO/PLUGIN` as a first-class install form, so the
-	// launcher uses a single-step install with no separate marketplace step.
-	installSource = "grafana/sigil-sdk:plugins/copilot"
 	// PluginName is the plugin name declared in plugins/copilot/plugin.json.
+	// The launcher no longer registers the plugin (it would double-fire
+	// against the shared user hooks file), but it still probes for and
+	// removes a plugin left over from an older sigil version.
 	PluginName = "sigil-copilot"
 
-	updateCheckTTL = 24 * time.Hour
+	// userHooksFileName is the file the launcher writes into the user-level
+	// Copilot hooks directory. This single file drives capture for both
+	// Copilot Chat in VS Code and the copilot CLI. A dedicated, sigil-owned
+	// filename lets us overwrite it without touching hand-authored hooks.
+	userHooksFileName = "sigil.json"
 )
 
 // Test seams.
 var (
-	lookPath   = exec.LookPath
-	execFn     = syscall.Exec
-	runInstall = defaultRunInstall
-	runUpdate  = defaultRunUpdate
-	pluginList = defaultPluginList
+	lookPath     = exec.LookPath
+	execFn       = syscall.Exec
+	runUninstall = defaultRunUninstall
+	pluginList   = defaultPluginList
 )
 
-// Launch resolves the `copilot` binary on PATH, ensures the sigil-copilot
-// plugin is registered in copilot's plugin store (running
-// `copilot plugin install grafana/sigil-sdk:plugins/copilot` once if it is
-// not), and then exec's copilot with the supplied args. When localEnv is
+// Launch installs the shared user-level Copilot hooks file (read by both
+// Copilot Chat in VS Code and the copilot CLI), resolves the `copilot` binary
+// on PATH, removes any stale sigil-copilot plugin left by an older sigil
+// version, and exec's copilot with the supplied args. When localEnv is
 // non-nil, the child receives local-mode SIGIL_ENDPOINT,
 // SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT and placeholder auth values so it talks
 // to the in-process receiver instead of Sigil Cloud.
-func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, sigilVersion string) error {
+//
+// The launcher deliberately does NOT register the copilot plugin: the CLI
+// loads hooks from the plugin store AND ~/.copilot/hooks and runs both, so a
+// plugin alongside the shared file would fire every hook (and export every
+// turn) twice. The single shared file covers both surfaces; the hook
+// dispatcher infers vscode vs copilot-cli at runtime.
+func Launch(_ context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, _ string) error {
+	// Always ensure the shared hooks file exists, even when copilot is not
+	// on PATH: Copilot Chat in VS Code reads ~/.copilot/hooks regardless of
+	// whether the CLI is installed.
+	installUserHooks(stderr, logger)
+
 	bin, err := lookPath("copilot")
 	if err != nil {
 		return fmt.Errorf("copilot CLI not found on PATH: %w", err)
 	}
 
-	installed, err := pluginInstalled(ctx, bin)
-	if err != nil {
-		// Treat a failed `copilot plugin list` the same as missing: log the
-		// probe failure for SIGIL_DEBUG, then let `copilot plugin install`
-		// run. copilot's own CLI is the source of truth and will fail loudly
-		// if something is genuinely wrong.
-		logger.Printf("copilot plugin list probe: %v", err)
-		installed = false
-	}
-	if !installed {
-		_, _ = fmt.Fprintf(stderr, "sigil: registering %s with copilot\n", PluginName)
-		if err := runInstall(ctx, bin, stderr); err != nil {
-			// Don't block the user's copilot session on a failed install
-			// (offline machine, sandboxed CI, GitHub rate limit, etc.). Log
-			// for SIGIL_DEBUG, point the user at the manual command, and
-			// fall through to exec. copilot still runs, just without Sigil
-			// capture.
-			logger.Printf("install %s: %v", PluginName, err)
-			_, _ = fmt.Fprintf(stderr,
-				"sigil: install of %s failed: %v\n"+
-					"sigil: continuing without Sigil capture. To retry manually:\n"+
-					"          copilot plugin install %s\n",
-				PluginName, err, installSource)
-		}
-	} else if updatecheck.ShouldRun(PluginName, updateCheckTTL, sigilVersion) {
-		_, _ = fmt.Fprintf(stderr, "sigil: refreshing %s in copilot\n", PluginName)
-		if err := runUpdate(ctx, bin, stderr); err != nil {
-			logger.Printf("update %s: %v", PluginName, err)
-			_, _ = fmt.Fprintf(stderr,
-				"sigil: update of %s failed: %v\n"+
-					"sigil: continuing with the installed version. To retry manually:\n"+
-					"          copilot plugin update %s\n",
-				PluginName, err, PluginName)
-		}
-		updatecheck.Record(PluginName, sigilVersion)
-	}
+	// Remove a plugin registered by an older sigil version so the CLI does
+	// not double-fire (plugin + shared user file). Best-effort: a probe or
+	// uninstall failure must not block the user's copilot session.
+	removeStalePlugin(bin, stderr, logger)
 
 	env := local.Environ(localEnv)
 	argv := append([]string{bin}, args...)
@@ -93,22 +75,175 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 	return nil
 }
 
-func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {
-	cmd := exec.CommandContext(ctx, bin, "plugin", "install", installSource)
-	cmd.Stdout = w
-	cmd.Stderr = w
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("copilot plugin install %s: %w", installSource, err)
+// installUserHooks writes the shared user-level Copilot hooks file and reports
+// the outcome. It never returns an error: failing to install the hooks must
+// not block the rest of the launch flow.
+func installUserHooks(stderr io.Writer, logger *log.Logger) {
+	path, wrote, err := writeUserHooks()
+	if err != nil {
+		logger.Printf("write user-level copilot hooks: %v", err)
+		return
 	}
-	return nil
+	if wrote {
+		_, _ = fmt.Fprintf(stderr,
+			"sigil: installed Copilot hooks at %s (used by Copilot in VS Code and by the copilot CLI)\n",
+			path)
+	}
 }
 
-func defaultRunUpdate(ctx context.Context, bin string, w io.Writer) error {
-	cmd := exec.CommandContext(ctx, bin, "plugin", "update", PluginName)
+// removeStalePlugin uninstalls the sigil-copilot plugin if a previous sigil
+// version registered it. It is best-effort: probe and uninstall failures are
+// logged for SIGIL_DEBUG but never block the launch.
+func removeStalePlugin(bin string, stderr io.Writer, logger *log.Logger) {
+	installed, err := pluginInstalled(context.Background(), bin)
+	if err != nil {
+		logger.Printf("copilot plugin list probe: %v", err)
+		return
+	}
+	if !installed {
+		return
+	}
+	_, _ = fmt.Fprintf(stderr,
+		"sigil: removing the legacy %s plugin (capture now runs from ~/.copilot/hooks)\n",
+		PluginName)
+	if err := runUninstall(context.Background(), bin, stderr); err != nil {
+		logger.Printf("uninstall %s: %v", PluginName, err)
+		_, _ = fmt.Fprintf(stderr,
+			"sigil: could not remove the %s plugin: %v\n"+
+				"sigil: to avoid duplicate capture, remove it manually:\n"+
+				"          copilot plugin uninstall %s\n",
+			PluginName, err, PluginName)
+	}
+}
+
+// copilotHooksDir resolves the user-level Copilot hooks directory. It honors
+// COPILOT_HOME (which, per the Copilot config-dir reference, replaces the
+// entire ~/.copilot path) and otherwise falls back to ~/.copilot/hooks.
+func copilotHooksDir() (string, error) {
+	if home := strings.TrimSpace(os.Getenv("COPILOT_HOME")); home != "" {
+		return filepath.Join(home, "hooks"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir for copilot hooks: %w", err)
+	}
+	return filepath.Join(home, ".copilot", "hooks"), nil
+}
+
+// writeUserHooks renders the Sigil hook config and writes it to
+// <copilot-hooks-dir>/sigil.json. The write is atomic (temp file + rename)
+// and idempotent: when the on-disk content already matches, it is left
+// untouched and wrote is false. It returns the target path so callers can
+// report where the hooks landed.
+func writeUserHooks() (path string, wrote bool, err error) {
+	dir, err := copilotHooksDir()
+	if err != nil {
+		return "", false, err
+	}
+	path = filepath.Join(dir, userHooksFileName)
+	content, err := renderUserHooks()
+	if err != nil {
+		return "", false, err
+	}
+	if existing, readErr := os.ReadFile(path); readErr == nil && bytes.Equal(existing, content) {
+		return path, false, nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", false, fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, userHooksFileName+".tmp-*")
+	if err != nil {
+		return "", false, fmt.Errorf("temp file in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return "", false, fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return "", false, fmt.Errorf("chmod temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return "", false, fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return "", false, fmt.Errorf("rename to %s: %w", path, err)
+	}
+	return path, true, nil
+}
+
+// hookCommand mirrors a single command-hook entry in a Copilot hooks file.
+type hookCommand struct {
+	Type    string            `json:"type"`
+	Command string            `json:"command"`
+	Env     map[string]string `json:"env,omitempty"`
+	Timeout int               `json:"timeout,omitempty"`
+}
+
+type hookGroup struct {
+	Hooks []hookCommand `json:"hooks"`
+}
+
+type userHooksFile struct {
+	Version int                    `json:"version"`
+	Hooks   map[string][]hookGroup `json:"hooks"`
+}
+
+// renderUserHooks builds the shared user-level hooks JSON. It mirrors the
+// events and command wiring shipped in plugins/copilot/hooks.json so both
+// drive the exact same `sigil copilot hook` handler. Output is stable
+// (encoding/json sorts map keys) so writeUserHooks can skip no-op rewrites.
+func renderUserHooks() ([]byte, error) {
+	events := []struct {
+		name    string
+		timeout int
+	}{
+		{"sessionStart", 10},
+		{"sessionEnd", 10},
+		{"userPromptSubmitted", 10},
+		{"preToolUse", 10},
+		{"postToolUse", 10},
+		{"postToolUseFailure", 10},
+		{"errorOccurred", 10},
+		{"subagentStart", 10},
+		{"subagentStop", 10},
+		{"agentStop", 30},
+	}
+	f := userHooksFile{Version: 1, Hooks: make(map[string][]hookGroup, len(events))}
+	for _, e := range events {
+		f.Hooks[e.name] = []hookGroup{{
+			Hooks: []hookCommand{{
+				Type:    "command",
+				Command: "sigil copilot hook",
+				// This single file is read by BOTH Copilot Chat in VS Code and
+				// the copilot CLI, so it deliberately does NOT pin
+				// SIGIL_COPILOT_HOOK_SURFACE — the dispatcher infers the
+				// surface (vscode vs copilot-cli) at runtime from the process
+				// tree. Pinning it here would mislabel one of the two hosts.
+				Env:     map[string]string{"SIGIL_COPILOT_HOOK_EVENT": e.name},
+				Timeout: e.timeout,
+			}},
+		}}
+	}
+	b, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("render user-level copilot hooks: %w", err)
+	}
+	return append(b, '\n'), nil
+}
+
+func defaultRunUninstall(ctx context.Context, bin string, w io.Writer) error {
+	cmd := exec.CommandContext(ctx, bin, "plugin", "uninstall", PluginName)
 	cmd.Stdout = w
 	cmd.Stderr = w
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("copilot plugin update %s: %w", PluginName, err)
+		return fmt.Errorf("copilot plugin uninstall %s: %w", PluginName, err)
 	}
 	return nil
 }

--- a/plugins/sigil/internal/agents/copilot/launch.go
+++ b/plugins/sigil/internal/agents/copilot/launch.go
@@ -97,7 +97,16 @@ func installUserHooks(stderr io.Writer, logger *log.Logger) {
 func removeStalePlugin(bin string, stderr io.Writer, logger *log.Logger) {
 	installed, err := pluginInstalled(context.Background(), bin)
 	if err != nil {
+		// The probe failed, so we cannot confirm whether the plugin is
+		// registered. The shared hooks file is already written, so a
+		// lingering plugin would double-fire every turn. Attempt a quiet
+		// best-effort uninstall anyway: when the plugin is absent the CLI
+		// just reports "not installed", which is harmless and stays in the
+		// debug log rather than alarming the user on stderr.
 		logger.Printf("copilot plugin list probe: %v", err)
+		if uninstallErr := runUninstall(context.Background(), bin, io.Discard); uninstallErr != nil {
+			logger.Printf("best-effort uninstall %s after probe failure: %v", PluginName, uninstallErr)
+		}
 		return
 	}
 	if !installed {

--- a/plugins/sigil/internal/agents/copilot/launch_test.go
+++ b/plugins/sigil/internal/agents/copilot/launch_test.go
@@ -3,6 +3,7 @@ package copilot
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"log"
@@ -17,75 +18,88 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestMain redirects user-level Copilot hooks writes to a throwaway COPILOT_HOME
+// so tests exercising the install path never touch the developer's real
+// ~/.copilot. Individual tests override COPILOT_HOME with their own temp dir.
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "sigil-copilot-hooks-test-*")
+	if err != nil {
+		panic(err)
+	}
+	_ = os.Setenv("COPILOT_HOME", tmp)
+	code := m.Run()
+	_ = os.RemoveAll(tmp)
+	os.Exit(code)
+}
+
 func TestLaunch(t *testing.T) {
 	const binPath = "/usr/local/bin/copilot"
-	pluginInstalledOut := []byte("Installed plugins:\n  • sigil-copilot (v0.1.0)\n")
+	pluginInstalledOut := []byte("Installed plugins:\n  • sigil-copilot (v0.2.0)\n")
 	pluginOtherOut := []byte("Installed plugins:\n  • other-plugin (v1.0.0)\n")
-	pluginEmptyOut := []byte("Installed plugins:\n")
 
 	cases := []struct {
 		name string
 
-		lookPath   func(string) (string, error)
-		pluginList func(context.Context, string) ([]byte, error)
-		runInstall func(context.Context, string, io.Writer) error // nil = success
-		execFn     func(string, []string, []string) error         // nil = success
-		args       []string
+		lookPath     func(string) (string, error)
+		pluginList   func(context.Context, string) ([]byte, error)
+		runUninstall func(context.Context, string, io.Writer) error // nil = success
+		execFn       func(string, []string, []string) error         // nil = success
+		args         []string
 
-		wantErr      string   // substring; "" means no error
-		wantInstall  int      // expected runInstall call count
-		wantExec     bool     // whether execFn must be called
-		wantExecArgv []string // nil = don't assert
-		wantStderr   []string // substrings that must appear in stderr
-		wantLog      []string // substrings that must appear in the logger output
+		wantErr       string   // substring; "" means no error
+		wantUninstall int      // expected runUninstall call count
+		wantExec      bool     // whether execFn must be called
+		wantExecArgv  []string // nil = don't assert
+		wantStderr    []string // substrings that must appear in stderr
+		wantLog       []string // substrings that must appear in the logger output
 	}{
 		{
-			name:     "missing copilot binary",
+			name:     "missing copilot binary still surfaces error",
 			lookPath: func(string) (string, error) { return "", exec.ErrNotFound },
 			wantErr:  "copilot CLI not found",
 		},
 		{
-			name:         "skips install when plugin installed and forwards args",
-			lookPath:     func(string) (string, error) { return binPath, nil },
-			pluginList:   func(context.Context, string) ([]byte, error) { return pluginInstalledOut, nil },
-			args:         []string{"exec", "hi"},
-			wantInstall:  0,
-			wantExec:     true,
-			wantExecArgv: []string{binPath, "exec", "hi"},
+			name:          "no plugin installed forwards args without uninstall",
+			lookPath:      func(string) (string, error) { return binPath, nil },
+			pluginList:    func(context.Context, string) ([]byte, error) { return pluginOtherOut, nil },
+			args:          []string{"exec", "hi"},
+			wantUninstall: 0,
+			wantExec:      true,
+			wantExecArgv:  []string{binPath, "exec", "hi"},
 		},
 		{
-			name:        "runs install when plugin missing",
-			lookPath:    func(string) (string, error) { return binPath, nil },
-			pluginList:  func(context.Context, string) ([]byte, error) { return pluginOtherOut, nil },
-			wantInstall: 1,
-			wantExec:    true,
-			wantStderr:  []string{"registering " + PluginName + " with copilot"},
+			name:          "stale plugin is uninstalled then execs",
+			lookPath:      func(string) (string, error) { return binPath, nil },
+			pluginList:    func(context.Context, string) ([]byte, error) { return pluginInstalledOut, nil },
+			wantUninstall: 1,
+			wantExec:      true,
+			wantStderr:    []string{"removing the legacy " + PluginName + " plugin"},
 		},
 		{
-			name:        "runs install when plugin list probe fails",
-			lookPath:    func(string) (string, error) { return binPath, nil },
-			pluginList:  func(context.Context, string) ([]byte, error) { return nil, errors.New("probe boom") },
-			wantInstall: 1,
-			wantExec:    true,
-			wantLog:     []string{"probe boom"},
+			name:          "plugin list probe failure is non-fatal",
+			lookPath:      func(string) (string, error) { return binPath, nil },
+			pluginList:    func(context.Context, string) ([]byte, error) { return nil, errors.New("probe boom") },
+			wantUninstall: 0,
+			wantExec:      true,
+			wantLog:       []string{"probe boom"},
 		},
 		{
-			name:        "continues when install fails",
-			lookPath:    func(string) (string, error) { return binPath, nil },
-			pluginList:  func(context.Context, string) ([]byte, error) { return pluginEmptyOut, nil },
-			runInstall:  func(context.Context, string, io.Writer) error { return errors.New("network down") },
-			wantInstall: 1,
-			wantExec:    true,
+			name:          "continues when uninstall fails",
+			lookPath:      func(string) (string, error) { return binPath, nil },
+			pluginList:    func(context.Context, string) ([]byte, error) { return pluginInstalledOut, nil },
+			runUninstall:  func(context.Context, string, io.Writer) error { return errors.New("network down") },
+			wantUninstall: 1,
+			wantExec:      true,
 			wantStderr: []string{
-				"install of " + PluginName + " failed",
+				"could not remove the " + PluginName + " plugin",
 				"network down",
-				"copilot plugin install grafana/sigil-sdk:plugins/copilot",
+				"copilot plugin uninstall " + PluginName,
 			},
 		},
 		{
 			name:       "exec failure surfaces error",
 			lookPath:   func(string) (string, error) { return binPath, nil },
-			pluginList: func(context.Context, string) ([]byte, error) { return pluginInstalledOut, nil },
+			pluginList: func(context.Context, string) ([]byte, error) { return pluginOtherOut, nil },
 			execFn:     func(string, []string, []string) error { return errors.New("exec boom") },
 			wantExec:   true,
 			wantErr:    "exec copilot",
@@ -94,7 +108,6 @@ func TestLaunch(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SIGIL_AUTO_UPDATE", "false")
 			withLookPath(t, tc.lookPath)
 
 			listFn := tc.pluginList
@@ -106,17 +119,17 @@ func TestLaunch(t *testing.T) {
 			}
 			withPluginList(t, listFn)
 
-			installFn := tc.runInstall
-			if installFn == nil {
-				installFn = func(context.Context, string, io.Writer) error { return nil }
+			uninstallFn := tc.runUninstall
+			if uninstallFn == nil {
+				uninstallFn = func(context.Context, string, io.Writer) error { return nil }
 			}
-			installCalls := 0
-			withRunInstall(t, func(ctx context.Context, bin string, w io.Writer) error {
-				installCalls++
+			uninstallCalls := 0
+			withRunUninstall(t, func(ctx context.Context, bin string, w io.Writer) error {
+				uninstallCalls++
 				if bin != binPath {
-					t.Errorf("install bin = %q, want %q", bin, binPath)
+					t.Errorf("uninstall bin = %q, want %q", bin, binPath)
 				}
-				return installFn(ctx, bin, w)
+				return uninstallFn(ctx, bin, w)
 			})
 
 			execMock := tc.execFn
@@ -143,7 +156,7 @@ func TestLaunch(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			assert.Equal(t, tc.wantInstall, installCalls)
+			assert.Equal(t, tc.wantUninstall, uninstallCalls)
 			assert.Equal(t, tc.wantExec, execCalled)
 			if tc.wantExecArgv != nil {
 				assert.Equal(t, tc.wantExecArgv, execArgv)
@@ -175,11 +188,7 @@ func TestLaunch_LocalEnv(t *testing.T) {
 
 			withLookPath(t, func(string) (string, error) { return "/usr/local/bin/copilot", nil })
 			withPluginList(t, func(context.Context, string) ([]byte, error) {
-				return []byte("Installed plugins:\n  • sigil-copilot (v0.1.0)\n"), nil
-			})
-			withRunInstall(t, func(context.Context, string, io.Writer) error {
-				t.Fatal("runInstall must not be called when plugin is installed")
-				return nil
+				return []byte("Installed plugins:\n  • other-plugin (v1.0.0)\n"), nil
 			})
 
 			var execEnv []string
@@ -274,11 +283,11 @@ func withLookPath(t *testing.T, fn func(string) (string, error)) {
 	lookPath = fn
 }
 
-func withRunInstall(t *testing.T, fn func(context.Context, string, io.Writer) error) {
+func withRunUninstall(t *testing.T, fn func(context.Context, string, io.Writer) error) {
 	t.Helper()
-	prev := runInstall
-	t.Cleanup(func() { runInstall = prev })
-	runInstall = fn
+	prev := runUninstall
+	t.Cleanup(func() { runUninstall = prev })
+	runUninstall = fn
 }
 
 func withExecFn(t *testing.T, fn func(string, []string, []string) error) {
@@ -310,47 +319,106 @@ func nopLogger() *log.Logger {
 	return log.New(io.Discard, "", 0)
 }
 
-func withRunUpdate(t *testing.T, fn func(context.Context, string, io.Writer) error) {
+// userHooksPath returns the sigil.json path under the test's COPILOT_HOME.
+func userHooksPath(t *testing.T) string {
 	t.Helper()
-	prev := runUpdate
-	t.Cleanup(func() { runUpdate = prev })
-	runUpdate = fn
+	return filepath.Join(os.Getenv("COPILOT_HOME"), "hooks", "sigil.json")
 }
 
-func TestLaunch_RefreshesInstalledPlugin(t *testing.T) {
-	const binPath = "/usr/local/bin/copilot"
-	state := t.TempDir()
-	t.Setenv("XDG_STATE_HOME", state)
+// assertValidUserHooks checks the written file is the expected Copilot hooks
+// document: version 1, every wired event, and the shared `sigil copilot hook`
+// command carrying its event env var.
+func assertValidUserHooks(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
 
-	withLookPath(t, func(string) (string, error) { return binPath, nil })
-	withPluginList(t, func(context.Context, string) ([]byte, error) {
-		return []byte("Installed plugins:\n  • sigil-copilot (v0.1.0)\n"), nil
-	})
-	withRunInstall(t, func(context.Context, string, io.Writer) error {
-		t.Fatal("runInstall must not be called when plugin is already installed")
-		return nil
-	})
+	var f struct {
+		Version int `json:"version"`
+		Hooks   map[string][]struct {
+			Hooks []struct {
+				Type    string            `json:"type"`
+				Command string            `json:"command"`
+				Env     map[string]string `json:"env"`
+				Timeout int               `json:"timeout"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	require.NoError(t, json.Unmarshal(data, &f), "written hooks file must be valid JSON")
+	assert.Equal(t, 1, f.Version)
 
-	updateCalls := 0
-	withRunUpdate(t, func(_ context.Context, bin string, _ io.Writer) error {
-		updateCalls++
-		if bin != binPath {
-			t.Errorf("update bin = %q", bin)
-		}
-		return nil
-	})
-	withExecFn(t, func(string, []string, []string) error { return nil })
+	wantEvents := []string{
+		"sessionStart", "sessionEnd", "userPromptSubmitted", "preToolUse",
+		"postToolUse", "postToolUseFailure", "errorOccurred", "subagentStart",
+		"subagentStop", "agentStop",
+	}
+	for _, ev := range wantEvents {
+		groups, ok := f.Hooks[ev]
+		require.Truef(t, ok, "missing event %q", ev)
+		require.Len(t, groups, 1)
+		require.Len(t, groups[0].Hooks, 1)
+		cmd := groups[0].Hooks[0]
+		assert.Equal(t, "command", cmd.Type)
+		assert.Equal(t, "sigil copilot hook", cmd.Command)
+		assert.Equal(t, ev, cmd.Env["SIGIL_COPILOT_HOOK_EVENT"])
+		// The shared user file must NOT pin a surface — runtime detection
+		// distinguishes VS Code from the copilot CLI for this same file.
+		assert.Empty(t, cmd.Env["SIGIL_COPILOT_HOOK_SURFACE"])
+	}
+	assert.Equal(t, 30, f.Hooks["agentStop"][0].Hooks[0].Timeout)
+}
+
+// When the copilot CLI is missing, the launcher cannot start a session, but it
+// must still install the shared user-level hooks (read by Copilot in VS Code)
+// before surfacing the not-found error.
+func TestLaunch_MissingBinaryInstallsUserHooks(t *testing.T) {
+	t.Setenv("COPILOT_HOME", t.TempDir())
+	withLookPath(t, func(string) (string, error) { return "", exec.ErrNotFound })
 
 	var stderr bytes.Buffer
-	require.NoError(t, launchWithLogger(t, nil, &stderr, log.New(io.Discard, "", 0)))
-	if updateCalls != 1 {
-		t.Fatalf("runUpdate calls = %d, want 1", updateCalls)
-	}
-	if !strings.Contains(stderr.String(), "refreshing "+PluginName+" in copilot") {
-		t.Fatalf("stderr missing refresh message: %q", stderr.String())
-	}
-	stamp := filepath.Join(state, "sigil", "update-checks", PluginName+".stamp")
-	if _, err := os.Stat(stamp); err != nil {
-		t.Fatalf("expected update stamp: %v", err)
-	}
+	err := launchWithLogger(t, nil, &stderr, nopLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "copilot CLI not found")
+
+	assertValidUserHooks(t, userHooksPath(t))
+	assert.Contains(t, stderr.String(), "installed Copilot hooks at")
+}
+
+// The shared hooks file must be installed and KEPT even when copilot is present
+// and a stale plugin is uninstalled — VS Code relies on it and the CLI reads
+// the same file, so it is the single source of truth.
+func TestLaunch_InstallsAndKeepsUserHooks(t *testing.T) {
+	t.Setenv("COPILOT_HOME", t.TempDir())
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/copilot", nil })
+	withPluginList(t, func(context.Context, string) ([]byte, error) {
+		return []byte("Installed plugins:\n  • sigil-copilot (v0.2.0)\n"), nil
+	})
+	uninstalled := false
+	withRunUninstall(t, func(context.Context, string, io.Writer) error {
+		uninstalled = true
+		return nil
+	})
+	execCalled := false
+	withExecFn(t, func(string, []string, []string) error {
+		execCalled = true
+		return nil
+	})
+
+	require.NoError(t, launchWithLogger(t, nil, io.Discard, nopLogger()))
+	assert.True(t, execCalled, "should exec copilot")
+	assert.True(t, uninstalled, "stale plugin should be uninstalled")
+	// The shared file must remain after the run.
+	assertValidUserHooks(t, userHooksPath(t))
+}
+
+func TestRenderUserHooks_IsStableAndValid(t *testing.T) {
+	a, err := renderUserHooks()
+	require.NoError(t, err)
+	b, err := renderUserHooks()
+	require.NoError(t, err)
+	assert.Equal(t, a, b, "render must be deterministic for idempotent writes")
+	assert.True(t, json.Valid(a))
+	assert.Contains(t, string(a), "\"sigil copilot hook\"")
+	// The shared file must not pin a surface marker.
+	assert.NotContains(t, string(a), "SIGIL_COPILOT_HOOK_SURFACE")
 }

--- a/plugins/sigil/internal/agents/copilot/launch_test.go
+++ b/plugins/sigil/internal/agents/copilot/launch_test.go
@@ -76,12 +76,26 @@ func TestLaunch(t *testing.T) {
 			wantStderr:    []string{"removing the legacy " + PluginName + " plugin"},
 		},
 		{
-			name:          "plugin list probe failure is non-fatal",
-			lookPath:      func(string) (string, error) { return binPath, nil },
-			pluginList:    func(context.Context, string) ([]byte, error) { return nil, errors.New("probe boom") },
-			wantUninstall: 0,
+			name:       "plugin list probe failure still attempts best-effort uninstall",
+			lookPath:   func(string) (string, error) { return binPath, nil },
+			pluginList: func(context.Context, string) ([]byte, error) { return nil, errors.New("probe boom") },
+			// The probe can't confirm the plugin state, but the shared hooks
+			// file is already written, so we must still try to remove a
+			// possible leftover plugin to avoid double-firing.
+			wantUninstall: 1,
 			wantExec:      true,
 			wantLog:       []string{"probe boom"},
+		},
+		{
+			name:          "probe failure with failing best-effort uninstall stays quiet and non-fatal",
+			lookPath:      func(string) (string, error) { return binPath, nil },
+			pluginList:    func(context.Context, string) ([]byte, error) { return nil, errors.New("probe boom") },
+			runUninstall:  func(context.Context, string, io.Writer) error { return errors.New("not installed") },
+			wantUninstall: 1,
+			wantExec:      true,
+			// Best-effort cleanup must not surface the alarming manual-removal
+			// guidance: when the probe failed the plugin may simply be absent.
+			wantLog: []string{"best-effort uninstall " + PluginName},
 		},
 		{
 			name:          "continues when uninstall fails",

--- a/plugins/sigil/internal/agents/copilot/mapper/mapper.go
+++ b/plugins/sigil/internal/agents/copilot/mapper/mapper.go
@@ -100,6 +100,11 @@ func Map(in Inputs) Mapped {
 	if frag.StopReason != "" {
 		metadata["copilot.stop_reason"] = frag.StopReason
 	}
+	if surface := frag.Surface; surface != "" {
+		metadata["copilot.hook_surface"] = surface
+	} else if in.Session != nil && in.Session.Surface != "" {
+		metadata["copilot.hook_surface"] = in.Session.Surface
+	}
 	if in.Session != nil {
 		if in.Session.Source != "" {
 			metadata["copilot.session_source"] = in.Session.Source
@@ -193,6 +198,11 @@ func buildTags(frag *fragment.Fragment, session *fragment.Session) map[string]st
 		tags["hook.source"] = frag.Source
 	} else if session != nil && session.Source != "" {
 		tags["hook.source"] = session.Source
+	}
+	if frag.Surface != "" {
+		tags["hook.surface"] = frag.Surface
+	} else if session != nil && session.Surface != "" {
+		tags["hook.surface"] = session.Surface
 	}
 	if len(frag.Subagents) > 0 {
 		tags["copilot.subagent_activity"] = "true"

--- a/plugins/sigil/internal/agents/copilot/surface.go
+++ b/plugins/sigil/internal/agents/copilot/surface.go
@@ -1,0 +1,89 @@
+package copilot
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// Test seams.
+var (
+	surfaceDetect = detectSurface
+	// processInfoFn resolves a PID to its command and parent PID. Overridden
+	// in tests to model a synthetic process tree without spawning `ps`.
+	processInfoFn = processInfo
+)
+
+// maxSurfaceAncestry bounds the process-tree walk in detectSurface. The hook
+// is reached within a couple of levels of either host (sh -> copilot, or the
+// VS Code extension host), so a small depth is plenty and keeps the cost of
+// the `ps` probes negligible.
+const maxSurfaceAncestry = 6
+
+// detectSurface determines which host fired the current hook. The Copilot
+// hook payload carries no host identifier and a single ~/.copilot/hooks file
+// is read by BOTH the Copilot CLI and Copilot Chat in VS Code, so the surface
+// must be inferred at runtime. Precedence:
+//
+//  1. SIGIL_COPILOT_HOOK_SURFACE env — an explicit override. The plugin's
+//     hooks.json sets this to "copilot-cli", so anyone driving capture via
+//     the plugin (rather than the shared user file) is labelled precisely.
+//  2. Process ancestry — if a `copilot` binary is an ancestor of this
+//     process, the Copilot CLI invoked us, so the surface is "copilot-cli".
+//     This holds even when the CLI runs inside a VS Code integrated terminal,
+//     because the ancestry there is sh -> copilot, not the VS Code extension
+//     host.
+//  3. Otherwise the only other host that fires these hooks is Copilot Chat in
+//     VS Code, so the surface is "vscode".
+func detectSurface() string {
+	if s := strings.TrimSpace(os.Getenv("SIGIL_COPILOT_HOOK_SURFACE")); s != "" {
+		return s
+	}
+	if hasCopilotAncestor(os.Getppid(), maxSurfaceAncestry) {
+		return "copilot-cli"
+	}
+	return "vscode"
+}
+
+// hasCopilotAncestor walks up to maxDepth ancestors starting at pid and
+// reports whether any of them is a `copilot` process.
+func hasCopilotAncestor(pid, maxDepth int) bool {
+	for i := 0; i < maxDepth && pid > 1; i++ {
+		comm, ppid, ok := processInfoFn(pid)
+		if !ok {
+			return false
+		}
+		if strings.Contains(strings.ToLower(comm), "copilot") {
+			return true
+		}
+		pid = ppid
+	}
+	return false
+}
+
+// processInfo returns the command name and parent PID for pid using `ps`.
+// It returns ok=false on any error or unparseable output so callers degrade
+// gracefully (treating the surface as VS Code, the more common interactive
+// host). Output of `ps -o ppid=,comm= -p <pid>` looks like:
+//
+//	"  1234 /opt/homebrew/bin/copilot"
+//
+// so the first field is the parent PID and the remainder is the command
+// (which may be an absolute path — substring matching on "copilot" handles
+// both bare-name and full-path forms).
+func processInfo(pid int) (comm string, ppid int, ok bool) {
+	out, err := exec.Command("ps", "-o", "ppid=,comm=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return "", 0, false
+	}
+	fields := strings.Fields(strings.TrimSpace(string(out)))
+	if len(fields) < 2 {
+		return "", 0, false
+	}
+	parent, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return "", 0, false
+	}
+	return strings.Join(fields[1:], " "), parent, true
+}

--- a/plugins/sigil/internal/agents/copilot/surface_test.go
+++ b/plugins/sigil/internal/agents/copilot/surface_test.go
@@ -1,0 +1,109 @@
+package copilot
+
+import (
+	"os"
+	"testing"
+)
+
+// fakeProc models a synthetic process tree for hasCopilotAncestor: each pid
+// maps to its command and parent pid.
+type fakeProc struct {
+	comm string
+	ppid int
+}
+
+func withProcessTree(t *testing.T, tree map[int]fakeProc) {
+	t.Helper()
+	prev := processInfoFn
+	t.Cleanup(func() { processInfoFn = prev })
+	processInfoFn = func(pid int) (string, int, bool) {
+		p, ok := tree[pid]
+		if !ok {
+			return "", 0, false
+		}
+		return p.comm, p.ppid, true
+	}
+}
+
+func TestDetectSurface_EnvOverrideWins(t *testing.T) {
+	t.Setenv("SIGIL_COPILOT_HOOK_SURFACE", "copilot-cli")
+	// Even with a non-copilot tree, the explicit env must win.
+	withProcessTree(t, map[int]fakeProc{})
+	if got := detectSurface(); got != "copilot-cli" {
+		t.Fatalf("detectSurface() = %q, want copilot-cli", got)
+	}
+}
+
+func TestHasCopilotAncestor(t *testing.T) {
+	cases := []struct {
+		name string
+		tree map[int]fakeProc
+		want bool
+	}{
+		{
+			name: "copilot is direct parent",
+			// start=10 -> sh(10) parent copilot(20) -> root(1)
+			tree: map[int]fakeProc{
+				10: {comm: "-zsh", ppid: 20},
+				20: {comm: "/opt/homebrew/bin/copilot", ppid: 1},
+			},
+			want: true,
+		},
+		{
+			name: "copilot deeper in chain (CLI in vscode terminal)",
+			tree: map[int]fakeProc{
+				10: {comm: "sh", ppid: 11},
+				11: {comm: "copilot", ppid: 12},
+				12: {comm: "node", ppid: 13},
+				13: {comm: "Code Helper (Plugin)", ppid: 1},
+			},
+			want: true,
+		},
+		{
+			name: "vscode extension host, no copilot ancestor",
+			tree: map[int]fakeProc{
+				10: {comm: "sh", ppid: 11},
+				11: {comm: "Code Helper (Plugin)", ppid: 12},
+				12: {comm: "Electron", ppid: 1},
+			},
+			want: false,
+		},
+		{
+			name: "unknown pid degrades to false",
+			tree: map[int]fakeProc{},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withProcessTree(t, tc.tree)
+			if got := hasCopilotAncestor(10, maxSurfaceAncestry); got != tc.want {
+				t.Fatalf("hasCopilotAncestor() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDetectSurface_ProcessTree(t *testing.T) {
+	t.Setenv("SIGIL_COPILOT_HOOK_SURFACE", "")
+	// detectSurface starts its walk from the real parent PID.
+	start := os.Getppid()
+
+	t.Run("copilot ancestor yields copilot-cli", func(t *testing.T) {
+		withProcessTree(t, map[int]fakeProc{
+			start: {comm: "copilot", ppid: 1},
+		})
+		if got := detectSurface(); got != "copilot-cli" {
+			t.Fatalf("detectSurface() = %q, want copilot-cli", got)
+		}
+	})
+
+	t.Run("no copilot ancestor yields vscode", func(t *testing.T) {
+		withProcessTree(t, map[int]fakeProc{
+			start: {comm: "node", ppid: 1},
+		})
+		if got := detectSurface(); got != "vscode" {
+			t.Fatalf("detectSurface() = %q, want vscode", got)
+		}
+	})
+}

--- a/plugins/sigil/internal/agents/copilot/transcript/transcript.go
+++ b/plugins/sigil/internal/agents/copilot/transcript/transcript.go
@@ -86,15 +86,22 @@ func readTranscriptSnapshot(path string, hint ReadHint) (Snapshot, bool, error) 
 		ok                  bool
 		modelByInteraction  = map[string]string{}
 		promptByInteraction = map[string]string{}
-		lastModel           string
-		lastReasoning       string
-		copilotVersion      string
-		sessionID           string
-		hintPrompt          = strings.TrimSpace(hint.UserPrompt)
-		hintPromptHash      = strings.TrimSpace(hint.UserPromptHash)
-		hintInteractionID   string
-		matched             Snapshot
-		matchedOK           bool
+		// lastUserPrompt tracks the most recent user.message content so an
+		// assistant.message can be associated with its prompt even when the
+		// transcript carries no interactionId. The Copilot CLI emits
+		// interactionId on every message; VS Code's copilot-chat transcript
+		// does not, so without this fallback the prompt-hint match (and thus
+		// assistant-text recovery) fails for VS Code sessions.
+		lastUserPrompt    string
+		lastModel         string
+		lastReasoning     string
+		copilotVersion    string
+		sessionID         string
+		hintPrompt        = strings.TrimSpace(hint.UserPrompt)
+		hintPromptHash    = strings.TrimSpace(hint.UserPromptHash)
+		hintInteractionID string
+		matched           Snapshot
+		matchedOK         bool
 	)
 
 	err := scanJSONLines(path, func(raw []byte) error {
@@ -131,6 +138,7 @@ func readTranscriptSnapshot(path string, hint ReadHint) (Snapshot, bool, error) 
 			if interactionID != "" {
 				promptByInteraction[interactionID] = prompt
 			}
+			lastUserPrompt = prompt
 			if matchesHintUserMessage(hintPrompt, hintPromptHash, prompt) {
 				hintInteractionID = interactionID
 				matched = Snapshot{}
@@ -157,7 +165,7 @@ func readTranscriptSnapshot(path string, hint ReadHint) (Snapshot, bool, error) 
 				AssistantText:   strings.TrimSpace(data.Content),
 				InputTokens:     data.InputTokens,
 				OutputTokens:    data.OutputTokens,
-				UserPrompt:      promptByInteraction[interactionID],
+				UserPrompt:      firstNonEmpty(promptByInteraction[interactionID], lastUserPrompt),
 			}
 			snap = candidate
 			ok = true

--- a/plugins/sigil/internal/agents/copilot/transcript/transcript_test.go
+++ b/plugins/sigil/internal/agents/copilot/transcript/transcript_test.go
@@ -247,3 +247,41 @@ func TestReadAssistantTurnMatchesPromptHash(t *testing.T) {
 		t.Fatalf("RequestID = %q", got.RequestID)
 	}
 }
+
+// TestReadAssistantTurnVSCodeFormatNoInteractionID mirrors the copilot-chat
+// transcript emitted by VS Code, which (unlike the Copilot CLI) omits
+// interactionId. The prompt-hint match must still associate the final
+// assistant.message with the preceding user.message via the lastUserPrompt
+// fallback, otherwise assistant text is silently dropped for VS Code sessions.
+func TestReadAssistantTurnVSCodeFormatNoInteractionID(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	contents := "" +
+		"{\"type\":\"session.start\",\"data\":{\"sessionId\":\"sess-1\",\"copilotVersion\":\"0.50.1\"}}\n" +
+		"{\"type\":\"user.message\",\"data\":{\"content\":\"create an empty test file\"}}\n" +
+		"{\"type\":\"assistant.message\",\"data\":{\"messageId\":\"m1\",\"content\":\"Creating that now.\",\"toolRequests\":[{\"toolCallId\":\"c1\"}]}}\n" +
+		"{\"type\":\"tool.execution_start\",\"data\":{\"toolCallId\":\"c1\",\"toolName\":\"create_file\"}}\n" +
+		"{\"type\":\"tool.execution_complete\",\"data\":{\"toolCallId\":\"c1\",\"success\":true}}\n" +
+		"{\"type\":\"assistant.message\",\"data\":{\"messageId\":\"m2\",\"content\":\"Created an empty file at test.\"}}\n"
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	prompt := "create an empty test file"
+	got, ok, err := ReadAssistantTurn(path, ReadHint{UserPrompt: prompt, UserPromptHash: PromptHash(prompt)})
+	if err != nil {
+		t.Fatalf("ReadAssistantTurn: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected transcript snapshot via lastUserPrompt fallback")
+	}
+	if got.AssistantText != "Created an empty file at test." {
+		t.Fatalf("AssistantText = %q", got.AssistantText)
+	}
+	if got.CopilotVersion != "0.50.1" {
+		t.Fatalf("CopilotVersion = %q", got.CopilotVersion)
+	}
+	if got.UserPrompt != prompt {
+		t.Fatalf("UserPrompt = %q", got.UserPrompt)
+	}
+}


### PR DESCRIPTION
## Summary

Makes the GitHub Copilot integration work for **Copilot Chat in VS Code** alongside the **Copilot CLI**, and fixes the telemetry/guard gaps found while wiring it up. All three hosts now drive the same `sigil copilot hook` handler from one shared `~/.copilot/hooks/sigil.json`.

### Changes
- **Capture VS Code assistant text** (`transcript`): the parser linked user/assistant messages by `interactionId`, which the Copilot CLI emits but VS Code's transcript does not — so assistant text was silently dropped for VS Code turns. Falls back to the most recent `user.message` when `interactionId` is absent. CLI path (interactionId-based) is unchanged.
- **Fix tool-call guard deny in VS Code** (`hook/handlers`): `preToolUse` now emits the nested `hookSpecificOutput.permissionDecision` envelope. The previous top-level shape is the Copilot *SDK* return shape and is silently ignored by VS Code and CLI **command** hooks, so guards weren't actually blocking. Reuses the shared `guard.WriteHookSpecificOutputDeny`.
- **Track host surface** (`surface.go`, dispatcher, mapper): every turn is tagged `hook.surface` (`copilot-cli` | `vscode`) with `copilot.hook_surface` metadata and a `dispatch: … surface=…` debug line. The payload has no host id and one shared file serves both hosts, so the surface is resolved at runtime: `SIGIL_COPILOT_HOOK_SURFACE` override → `copilot` process ancestry → else `vscode`.
- **Single-source launcher** (`launch.go`): writes one shared `~/.copilot/hooks/sigil.json` read by both the CLI and VS Code. Stops registering the plugin (the CLI loads plugin **and** user-file hooks combined, double-firing every turn/export) and **uninstalls any stale `sigil-copilot` plugin**; never deletes the shared file. Removes the now-unused plugin install/update/auto-update paths.

## Why
- VS Code only reads `~/.copilot/hooks/`; the CLI reads that **and** the plugin store and runs all sources. The old launcher deleted the user file when it installed the plugin, which broke VS Code capture and made CLI+VS Code coexistence impossible without duplicate telemetry.

## Test plan
- [x] `go test ./...` and `go vet ./...` pass (module-wide)
- [x] New `transcript` regression test for the VS Code (no-`interactionId`) format
- [x] `handlers_test` asserts the nested `hookSpecificOutput` deny envelope
- [x] New `surface_test` covers env override, copilot ancestry (incl. CLI-in-VS-Code-terminal), and VS-Code-only trees
- [x] Rewritten `launch_test` for the single-source / uninstall-stale-plugin behavior
- [x] Updated `copilot-basic` golden (now includes `hook.surface`/`copilot.hook_surface`; scenario pins surface for determinism)
- [x] Manual: built binary emits nested deny envelope; live `sigil copilot -- --version` rewrites the shared file + uninstalls the plugin; runtime detection logs `surface=vscode` for a shell-parented hook
- [ ] Reviewer: end-to-end smoke in both VS Code Copilot Chat and the Copilot CLI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hook installation, guard blocking semantics, and telemetry tagging across CLI and VS Code; mis-detection or leftover plugins could cause duplicate exports or wrong surface labels, but behavior is heavily tested and legacy plugin cleanup is best-effort.
> 
> **Overview**
> Extends the GitHub Copilot Sigil integration so **Copilot Chat in VS Code** and the **Copilot CLI** share one hook path via `~/.copilot/hooks/sigil.json`, instead of relying on CLI plugin registration.
> 
> **Launcher (`sigil copilot`)** now atomically writes that shared hooks file (even when `copilot` is missing, for VS Code), stops installing/updating the `sigil-copilot` plugin to avoid double-firing hooks, and best-effort uninstalls legacy plugins. Plugin `hooks.json` pins `SIGIL_COPILOT_HOOK_SURFACE=copilot-cli`; the user file leaves surface unset so runtime detection applies.
> 
> **Host surface** is resolved at hook dispatch (`SIGIL_COPILOT_HOOK_SURFACE` → `copilot` process ancestry → `vscode`), persisted on sessions/fragments, and exported as `hook.surface` / `copilot.hook_surface`.
> 
> **VS Code transcript parsing** associates assistant messages with prompts when `interactionId` is absent (CLI behavior unchanged).
> 
> **Tool guards** on `preToolUse` now emit the nested `hookSpecificOutput.permissionDecision` deny envelope (shared with Claude/Codex) so VS Code and CLI command hooks actually block denied tools.
> 
> Docs, golden tests, and launch/surface/transcript tests were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86114d62b2ba956842758a1c78da61fd839fe8c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->