### PR TITLE
feat(plugins/claude-code): emit cost_usd from transcript costUSD field

### DIFF
--- a/plugins/sigil/internal/agents/claudecode/mapper/mapper.go
+++ b/plugins/sigil/internal/agents/claudecode/mapper/mapper.go
@@ -404,6 +404,13 @@ func processAssistantLine(line transcript.Line, uctx *userContext, _ *state.Sess
 	gen.Input = buildInput(uctx, r)
 	gen.Output = buildOutput(msg.Content, r)
 
+	if line.CostUSD > 0 {
+		if gen.Metadata == nil {
+			gen.Metadata = make(map[string]any)
+		}
+		gen.Metadata["cost_usd"] = line.CostUSD
+	}
+
 	return gen, true
 }
 

--- a/plugins/sigil/internal/agents/claudecode/mapper/mapper_test.go
+++ b/plugins/sigil/internal/agents/claudecode/mapper/mapper_test.go
@@ -1084,3 +1084,43 @@ func TestProcess_UserPromptRedaction(t *testing.T) {
 		})
 	}
 }
+
+func TestProcess_CostUSD(t *testing.T) {
+	tests := []struct {
+		name     string
+		costUSD  float64
+		wantCost bool
+	}{
+		{"cost present", 0.0042, true},
+		{"cost zero", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			line := makeAssistantLine("claude-sonnet-4-20250514", 50, []transcript.ContentBlock{
+				{Type: "text", Text: "hello"},
+			}, "end_turn")
+			line.CostUSD = tt.costUSD
+
+			st := &state.Session{}
+			gens := Process([]transcript.Line{line}, st, Options{SessionID: "sess-1"}, nil)
+
+			if len(gens) != 1 {
+				t.Fatalf("got %d generations, want 1", len(gens))
+			}
+			gen := gens[0]
+			if tt.wantCost {
+				if gen.Metadata == nil {
+					t.Fatal("expected metadata to be set")
+				}
+				if gen.Metadata["cost_usd"] != tt.costUSD {
+					t.Errorf("cost_usd = %v, want %v", gen.Metadata["cost_usd"], tt.costUSD)
+				}
+			} else {
+				if gen.Metadata != nil && gen.Metadata["cost_usd"] != nil {
+					t.Errorf("expected no cost_usd in metadata, got %v", gen.Metadata["cost_usd"])
+				}
+			}
+		})
+	}
+}

--- a/plugins/sigil/internal/agents/claudecode/transcript/transcript.go
+++ b/plugins/sigil/internal/agents/claudecode/transcript/transcript.go
@@ -21,6 +21,7 @@ type Line struct {
 	Entrypoint  string          `json:"entrypoint"`
 	RequestID   string          `json:"requestId"`
 	IsSidechain bool            `json:"isSidechain"`
+	CostUSD     float64         `json:"costUSD"`
 	Message     json.RawMessage `json:"message"`
 
 	// EndOffset is the byte position after this line in the transcript file.


### PR DESCRIPTION
## Summary
- Parse the `costUSD` field from Claude Code transcript JSONL lines (previously ignored)
- Emit it as `metadata["cost_usd"]` on each generation, consistent with how the pi plugin reports costs
- Fixes missing cost data in AI Observability dashboards for Claude Code sessions

## Test plan
- [x] Unit test added (`TestProcess_CostUSD`) covering both presence and zero-value cases
- [x] All existing Claude Code tests pass
- [x] Verified end-to-end with local build sending to hosted Grafana — costs now visible


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive observability mapping with unit tests; no auth, billing logic, or breaking API changes.
> 
> **Overview**
> Claude Code transcript lines now carry **`costUSD`** through parsing, and assistant turns with a positive cost set **`metadata["cost_usd"]`** on the mapped generation (aligned with how other Sigil agents report spend).
> 
> **Zero or missing cost** leaves metadata unchanged so generations are not given an empty cost field. **`TestProcess_CostUSD`** covers both positive and zero values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16a2d860527d4493561f6757ebda119d940f8974. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->