### PR TITLE
feat(sdk): promote SIGIL_TAGS onto OTel spans and metrics

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -343,7 +343,7 @@ SDK schema defaults fill the rest.
 | `SIGIL_AGENT_NAME` | `SigilClientConfig.AgentName` |
 | `SIGIL_AGENT_VERSION` | `SigilClientConfig.AgentVersion` |
 | `SIGIL_USER_ID` | `SigilClientConfig.UserId` |
-| `SIGIL_TAGS` | `SigilClientConfig.Tags` (CSV merged under per-call tags) |
+| `SIGIL_TAGS` | `SigilClientConfig.Tags` (CSV; merged into generation export; Go/JS also emit `sigil.tag.<key>` on spans/metrics) |
 | `SIGIL_CONTENT_CAPTURE_MODE` | `SigilClientConfig.ContentCapture` |
 | `SIGIL_DEBUG` | `SigilClientConfig.Debug` (tri-state `bool?`) |
 

--- a/go/sigil/client.go
+++ b/go/sigil/client.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -95,8 +96,9 @@ type Config struct {
 	// empty and no user_id has been threaded through the request context.
 	// Read from SIGIL_USER_ID by ConfigFromEnv.
 	UserID string
-	// Tags are merged into every GenerationStart.Tags. Per-call tags win on
-	// key conflict. Read from SIGIL_TAGS (CSV) by ConfigFromEnv.
+	// Tags are merged into every GenerationStart.Tags (per-call tags win on
+	// key conflict) and emitted on OTel spans/metrics as sigil.tag.<key>.
+	// Read from SIGIL_TAGS (CSV) by ConfigFromEnv.
 	Tags map[string]string
 	// Debug, when set, signals downstream consumers (plugins, telemetry) that
 	// the SDK is running in verbose mode. Read from SIGIL_DEBUG by ConfigFromEnv.
@@ -213,6 +215,7 @@ const (
 	spanAttrToolDescription        = "gen_ai.tool.description"
 	spanAttrToolCallArguments      = "gen_ai.tool.call.arguments"
 	spanAttrToolCallResult         = "gen_ai.tool.call.result"
+	spanAttrTagPrefix              = "sigil.tag."
 
 	metricOperationDuration     = "gen_ai.client.operation.duration"
 	metricTokenUsage            = "gen_ai.client.token.usage"
@@ -605,6 +608,7 @@ func (c *Client) startGeneration(ctx context.Context, start GenerationStart, def
 
 	callCtx, span := c.startSpan(ctx, spanGeneration, trace.SpanKindClient, startedAt)
 	span.SetAttributes(generationSpanAttributes(spanGeneration)...)
+	setSpanTagAttributes(span, c.config.Tags)
 
 	callCtx = withContentCaptureMode(callCtx, ccMode)
 
@@ -673,6 +677,7 @@ func (c *Client) StartEmbedding(ctx context.Context, start EmbeddingStart) (cont
 		trace.WithTimestamp(startedAt),
 	)
 	span.SetAttributes(embeddingSpanStartAttributes(seed)...)
+	setSpanTagAttributes(span, c.config.Tags)
 
 	return callCtx, &EmbeddingRecorder{
 		client:             c,
@@ -769,6 +774,7 @@ func (c *Client) StartToolExecution(ctx context.Context, start ToolExecutionStar
 		trace.WithTimestamp(startedAt),
 	)
 	span.SetAttributes(toolSpanAttributes(seed)...)
+	setSpanTagAttributes(span, c.config.Tags)
 
 	return callCtx, &ToolExecutionRecorder{
 		client:             c,
@@ -1894,10 +1900,12 @@ func (c *Client) recordGenerationMetrics(ctx context.Context, generation Generat
 		generation.AgentName,
 		generation.AgentVersion,
 	)
+	tagAttrs := c.clientTagMetricAttributes()
 	durationAttrs := append(
 		[]attribute.KeyValue{attribute.String(spanAttrOperationName, operationName(generation))},
 		identityAttrs...,
 	)
+	durationAttrs = append(durationAttrs, tagAttrs...)
 	durationAttrs = append(durationAttrs,
 		attribute.String(spanAttrErrorType, errorType),
 		attribute.String(spanAttrErrorCategory, errorCategory),
@@ -1912,6 +1920,7 @@ func (c *Client) recordGenerationMetrics(ctx context.Context, generation Generat
 			[]attribute.KeyValue{attribute.String(spanAttrOperationName, operationName(generation))},
 			identityAttrs...,
 		)
+		tokenAttrs = append(tokenAttrs, tagAttrs...)
 		tokenAttrs = append(tokenAttrs, attribute.String(metricAttrTokenType, tokenType))
 		c.instruments.tokenUsage.Record(ctx, value, metric.WithAttributes(tokenAttrs...))
 	}
@@ -1923,19 +1932,21 @@ func (c *Client) recordGenerationMetrics(ctx context.Context, generation Generat
 	recordToken(metricTokenTypeReasoning, generation.Usage.ReasoningTokens)
 
 	toolCalls := countToolCalls(generation.Output)
+	toolCallAttrs := append(append([]attribute.KeyValue(nil), identityAttrs...), tagAttrs...)
 	c.instruments.toolCallsPerOperation.Record(
 		ctx,
 		int64(toolCalls),
-		metric.WithAttributes(identityAttrs...),
+		metric.WithAttributes(toolCallAttrs...),
 	)
 
 	if operationName(generation) == defaultOperationNameStream && !firstTokenAt.IsZero() {
 		ttft := firstTokenAt.Sub(generation.StartedAt).Seconds()
 		if ttft >= 0 {
+			ttftAttrs := append(append([]attribute.KeyValue(nil), identityAttrs...), tagAttrs...)
 			c.instruments.timeToFirstToken.Record(
 				ctx,
 				ttft,
-				metric.WithAttributes(identityAttrs...),
+				metric.WithAttributes(ttftAttrs...),
 			)
 		}
 	}
@@ -1969,10 +1980,12 @@ func (c *Client) recordEmbeddingMetrics(
 	model := strings.TrimSpace(seed.Model.Name)
 	agentName := strings.TrimSpace(seed.AgentName)
 	identityAttrs := metricIdentityAttributes(provider, model, agentName, seed.AgentVersion)
+	tagAttrs := c.clientTagMetricAttributes()
 	durationAttrs := append(
 		[]attribute.KeyValue{attribute.String(spanAttrOperationName, defaultEmbeddingOperationName)},
 		identityAttrs...,
 	)
+	durationAttrs = append(durationAttrs, tagAttrs...)
 	durationAttrs = append(durationAttrs,
 		attribute.String(spanAttrErrorType, errorType),
 		attribute.String(spanAttrErrorCategory, errorCategory),
@@ -1988,6 +2001,7 @@ func (c *Client) recordEmbeddingMetrics(
 			[]attribute.KeyValue{attribute.String(spanAttrOperationName, defaultEmbeddingOperationName)},
 			identityAttrs...,
 		)
+		tokenAttrs = append(tokenAttrs, tagAttrs...)
 		tokenAttrs = append(tokenAttrs, attribute.String(metricAttrTokenType, metricTokenTypeInput))
 		c.instruments.tokenUsage.Record(
 			ctx,
@@ -2022,6 +2036,7 @@ func (c *Client) recordToolExecutionMetrics(ctx context.Context, seed ToolExecut
 		attribute.String(spanAttrOperationName, "execute_tool"),
 		attribute.String(spanAttrToolName, strings.TrimSpace(seed.ToolName)),
 	}, attrs...)
+	attrs = append(attrs, c.clientTagMetricAttributes()...)
 	attrs = append(attrs,
 		attribute.String(spanAttrErrorType, errorType),
 		attribute.String(spanAttrErrorCategory, errorCategory),
@@ -2031,6 +2046,51 @@ func (c *Client) recordToolExecutionMetrics(ctx context.Context, seed ToolExecut
 		duration,
 		metric.WithAttributes(attrs...),
 	)
+}
+
+func tagAttributes(tags map[string]string) []attribute.KeyValue {
+	if len(tags) == 0 {
+		return nil
+	}
+	type tagPair struct {
+		key   string
+		value string
+	}
+	pairs := make([]tagPair, 0, len(tags))
+	for k, v := range tags {
+		key := strings.TrimSpace(k)
+		if key == "" {
+			continue
+		}
+		pairs = append(pairs, tagPair{key: key, value: strings.TrimSpace(v)})
+	}
+	if len(pairs) == 0 {
+		return nil
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].key < pairs[j].key })
+	attrs := make([]attribute.KeyValue, 0, len(pairs))
+	for _, p := range pairs {
+		attrs = append(attrs, attribute.String(spanAttrTagPrefix+p.key, p.value))
+	}
+	return attrs
+}
+
+func setSpanTagAttributes(span trace.Span, tags map[string]string) {
+	if span == nil {
+		return
+	}
+	attrs := tagAttributes(tags)
+	if len(attrs) == 0 {
+		return
+	}
+	span.SetAttributes(attrs...)
+}
+
+func (c *Client) clientTagMetricAttributes() []attribute.KeyValue {
+	if c == nil {
+		return nil
+	}
+	return tagAttributes(c.config.Tags)
 }
 
 func metricIdentityAttributes(provider, model, agentName, agentVersion string) []attribute.KeyValue {

--- a/go/sigil/client_tags_test.go
+++ b/go/sigil/client_tags_test.go
@@ -1,0 +1,171 @@
+package sigil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+const clientTagProjectKey = spanAttrTagPrefix + "project"
+
+func TestClientTagsOnGenerationSpanAndMetrics(t *testing.T) {
+	metricReader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(metricReader))
+	t.Cleanup(func() {
+		_ = meterProvider.Shutdown(context.Background())
+	})
+
+	client, recorder, _ := newTestClient(t, Config{
+		Tags:  map[string]string{"project": "checkout-svc"},
+		Meter: meterProvider.Meter("sigil-test"),
+		Now: func() time.Time {
+			return time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+		},
+	})
+
+	_, genRec := client.StartGeneration(context.Background(), GenerationStart{
+		ConversationID: "conv-tags",
+		Model:          ModelRef{Provider: "openai", Name: "gpt-5"},
+	})
+	genRec.SetResult(Generation{
+		Usage: TokenUsage{InputTokens: 10, OutputTokens: 5},
+	}, nil)
+	genRec.End()
+
+	span := onlyGenerationSpan(t, recorder.Ended())
+	attrs := spanAttributeMap(span)
+	if got := attrs[clientTagProjectKey].AsString(); got != "checkout-svc" {
+		t.Fatalf("expected %s=checkout-svc on generation span, got %q", clientTagProjectKey, got)
+	}
+
+	collected := collectMetrics(t, metricReader)
+	_ = findHistogramPointForTags(t, findHistogram(t, collected, metricOperationDuration), map[string]string{
+		clientTagProjectKey: "checkout-svc",
+	})
+}
+
+func TestClientTagsOnEmbeddingAndToolSpans(t *testing.T) {
+	client, recorder, _ := newTestClient(t, Config{
+		Tags: map[string]string{"project": "embed-tools"},
+	})
+
+	_, embedRec := client.StartEmbedding(context.Background(), EmbeddingStart{
+		Model: ModelRef{Provider: "openai", Name: "text-embedding-3-small"},
+	})
+	embedRec.SetResult(EmbeddingResult{InputTokens: 1})
+	embedRec.End()
+
+	embedSpan := onlyEmbeddingSpan(t, recorder.Ended())
+	if got := spanAttributeMap(embedSpan)[clientTagProjectKey].AsString(); got != "embed-tools" {
+		t.Fatalf("expected %s on embedding span, got %q", clientTagProjectKey, got)
+	}
+
+	_, toolRec := client.StartToolExecution(context.Background(), ToolExecutionStart{
+		ToolName: "weather",
+	})
+	toolRec.SetResult(ToolExecutionEnd{Result: map[string]any{"temp": 72}})
+	toolRec.End()
+
+	toolSpan := onlyToolSpan(t, recorder.Ended())
+	if got := spanAttributeMap(toolSpan)[clientTagProjectKey].AsString(); got != "embed-tools" {
+		t.Fatalf("expected %s on tool span, got %q", clientTagProjectKey, got)
+	}
+}
+
+func TestClientTagsEmptyIsNoOpOnSpan(t *testing.T) {
+	client, recorder, _ := newTestClient(t, Config{})
+
+	_, genRec := client.StartGeneration(context.Background(), GenerationStart{
+		Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+	})
+	genRec.SetResult(Generation{}, nil)
+	genRec.End()
+
+	span := onlyGenerationSpan(t, recorder.Ended())
+	attrs := spanAttributeMap(span)
+	if _, ok := attrs[clientTagProjectKey]; ok {
+		t.Fatalf("did not expect %s when client tags are unset", clientTagProjectKey)
+	}
+}
+
+func TestPerCallGenerationTagsStayExportOnly(t *testing.T) {
+	exporter := &capturingGenerationExporter{}
+	client, recorder, _ := newTestClient(t, Config{
+		testGenerationExporter: exporter,
+	})
+
+	_, genRec := client.StartGeneration(context.Background(), GenerationStart{
+		Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+		Tags:  map[string]string{"call_only": "yes"},
+	})
+	genRec.SetResult(Generation{}, nil)
+	genRec.End()
+
+	span := onlyGenerationSpan(t, recorder.Ended())
+	if _, ok := spanAttributeMap(span)[spanAttrTagPrefix+"call_only"]; ok {
+		t.Fatalf("per-call tag must not appear on span without client-level SIGIL_TAGS")
+	}
+
+	if err := client.Flush(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	if len(exporter.requests) != 1 || len(exporter.requests[0].Generations) != 1 {
+		t.Fatalf("expected one exported generation, got %#v", exporter.requests)
+	}
+	if got := exporter.requests[0].Generations[0].GetTags()["call_only"]; got != "yes" {
+		t.Fatalf("expected call_only=yes on export tags, got %#v", exporter.requests[0].Generations[0].GetTags())
+	}
+}
+
+func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+	var collected metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &collected); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	return collected
+}
+
+func findHistogramPointForTags(t *testing.T, histogram metricdata.Histogram[float64], want map[string]string) metricdata.HistogramDataPoint[float64] {
+	t.Helper()
+	for _, point := range histogram.DataPoints {
+		if histogramPointMatchesForTags(point.Attributes, want) {
+			return point
+		}
+	}
+	t.Fatalf("expected histogram point with attrs %v", want)
+	return metricdata.HistogramDataPoint[float64]{}
+}
+
+func histogramPointMatchesForTags(attrs attribute.Set, want map[string]string) bool {
+	for key, expected := range want {
+		value, ok := (&attrs).Value(attribute.Key(key))
+		if !ok || value.AsString() != expected {
+			return false
+		}
+	}
+	return true
+}
+
+func findHistogram(t *testing.T, collected metricdata.ResourceMetrics, metricName string) metricdata.Histogram[float64] {
+	t.Helper()
+	for _, scopeMetrics := range collected.ScopeMetrics {
+		for _, metric := range scopeMetrics.Metrics {
+			if metric.Name != metricName {
+				continue
+			}
+			histogram, ok := metric.Data.(metricdata.Histogram[float64])
+			if !ok {
+				t.Fatalf("metric %q is not a float64 histogram", metricName)
+			}
+			return histogram
+		}
+	}
+	t.Fatalf("metric %q not found", metricName)
+	return metricdata.Histogram[float64]{}
+}

--- a/go/sigil/env.go
+++ b/go/sigil/env.go
@@ -9,16 +9,18 @@ import (
 
 // canonical SIGIL_* env-var names.
 const (
-	envEndpoint            = "SIGIL_ENDPOINT"
-	envProtocol            = "SIGIL_PROTOCOL"
-	envInsecure            = "SIGIL_INSECURE"
-	envHeaders             = "SIGIL_HEADERS"
-	envAuthMode            = "SIGIL_AUTH_MODE"
-	envAuthTenantID        = "SIGIL_AUTH_TENANT_ID"
-	envAuthToken           = "SIGIL_AUTH_TOKEN"
-	envAgentName           = "SIGIL_AGENT_NAME"
-	envAgentVersion        = "SIGIL_AGENT_VERSION"
-	envUserID              = "SIGIL_USER_ID"
+	envEndpoint     = "SIGIL_ENDPOINT"
+	envProtocol     = "SIGIL_PROTOCOL"
+	envInsecure     = "SIGIL_INSECURE"
+	envHeaders      = "SIGIL_HEADERS"
+	envAuthMode     = "SIGIL_AUTH_MODE"
+	envAuthTenantID = "SIGIL_AUTH_TENANT_ID"
+	envAuthToken    = "SIGIL_AUTH_TOKEN"
+	envAgentName    = "SIGIL_AGENT_NAME"
+	envAgentVersion = "SIGIL_AGENT_VERSION"
+	envUserID       = "SIGIL_USER_ID"
+	// envTags: comma-separated key=value pairs merged into generation export tags
+	// and emitted on OTel spans/metrics as sigil.tag.<key>.
 	envTags                = "SIGIL_TAGS"
 	envContentCaptureMode  = "SIGIL_CONTENT_CAPTURE_MODE"
 	envDebug               = "SIGIL_DEBUG"

--- a/java/README.md
+++ b/java/README.md
@@ -367,7 +367,7 @@ SDK schema defaults fill the rest.
 | `SIGIL_AGENT_NAME` | `SigilClientConfig.agentName` |
 | `SIGIL_AGENT_VERSION` | `SigilClientConfig.agentVersion` |
 | `SIGIL_USER_ID` | `SigilClientConfig.userId` |
-| `SIGIL_TAGS` | `SigilClientConfig.tags` (CSV merged under per-call tags) |
+| `SIGIL_TAGS` | `SigilClientConfig.tags` (CSV; merged into generation export; Go/JS also emit `sigil.tag.<key>` on spans/metrics) |
 | `SIGIL_CONTENT_CAPTURE_MODE` | `SigilClientConfig.contentCapture` |
 | `SIGIL_DEBUG` | `SigilClientConfig.debug` (tri-state) |
 

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -133,6 +133,7 @@ const spanAttrToolType = 'gen_ai.tool.type';
 const spanAttrToolDescription = 'gen_ai.tool.description';
 const spanAttrToolCallArguments = 'gen_ai.tool.call.arguments';
 const spanAttrToolCallResult = 'gen_ai.tool.call.result';
+const spanAttrTagPrefix = 'sigil.tag.';
 const maxRatingConversationIdLen = 255;
 const maxRatingIdLen = 128;
 const maxRatingGenerationIdLen = 255;
@@ -727,6 +728,7 @@ export class SigilClient {
       thinkingEnabled: seed.thinkingEnabled,
       metadata: seed.metadata,
     });
+    setTagSpanAttributes(span, this.config.tags);
 
     return span;
   }
@@ -737,6 +739,7 @@ export class SigilClient {
       startTime: startedAt,
     });
     setEmbeddingStartSpanAttributes(span, seed);
+    setTagSpanAttributes(span, this.config.tags);
     return span;
   }
 
@@ -747,6 +750,7 @@ export class SigilClient {
     });
 
     setToolSpanAttributes(span, seed);
+    setTagSpanAttributes(span, this.config.tags);
     return span;
   }
 
@@ -964,9 +968,11 @@ export class SigilClient {
       generation.agentName,
       generation.agentVersion,
     );
+    const tagAttributes = tagMetricAttributes(this.config.tags);
     this.operationDurationHistogram.record(durationSeconds, {
       [spanAttrOperationName]: generation.operationName,
       ...identityAttributes,
+      ...tagAttributes,
       [spanAttrErrorType]: errorType,
       [spanAttrErrorCategory]: errorCategory,
     });
@@ -982,6 +988,7 @@ export class SigilClient {
 
     this.toolCallsHistogram.record(countToolCallParts(generation.output ?? []), {
       ...identityAttributes,
+      ...tagAttributes,
     });
 
     if (generation.operationName === 'streamText' && firstTokenAt !== undefined) {
@@ -989,6 +996,7 @@ export class SigilClient {
       if (ttftSeconds >= 0) {
         this.ttftHistogram.record(ttftSeconds, {
           ...identityAttributes,
+          ...tagAttributes,
         });
       }
     }
@@ -1009,9 +1017,11 @@ export class SigilClient {
       seed.agentName,
       seed.agentVersion,
     );
+    const tagAttributes = tagMetricAttributes(this.config.tags);
     this.operationDurationHistogram.record(durationSeconds, {
       [spanAttrOperationName]: defaultEmbeddingOperationName,
       ...identityAttributes,
+      ...tagAttributes,
       [spanAttrErrorType]: errorType,
       [spanAttrErrorCategory]: errorCategory,
     });
@@ -1020,6 +1030,7 @@ export class SigilClient {
       this.tokenUsageHistogram.record(result.inputTokens, {
         [spanAttrOperationName]: defaultEmbeddingOperationName,
         ...identityAttributes,
+        ...tagAttributes,
         [metricAttrTokenType]: metricTokenTypeInput,
       });
     }
@@ -1037,6 +1048,7 @@ export class SigilClient {
         generation.agentName,
         generation.agentVersion,
       ),
+      ...tagMetricAttributes(this.config.tags),
       [metricAttrTokenType]: tokenType,
     });
   }
@@ -1056,6 +1068,7 @@ export class SigilClient {
         toolExecution.agentName,
         toolExecution.agentVersion,
       ),
+      ...tagMetricAttributes(this.config.tags),
       [spanAttrErrorType]: errorType,
       [spanAttrErrorCategory]: errorCategory,
     });
@@ -1683,6 +1696,33 @@ function toolSpanName(toolName: string): string {
     return 'execute_tool unknown';
   }
   return `execute_tool ${normalized}`;
+}
+
+function tagMetricAttributes(tags: Record<string, string> | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (tags === undefined) {
+    return out;
+  }
+  const pairs: { key: string; value: string }[] = [];
+  for (const [k, v] of Object.entries(tags)) {
+    const key = k.trim();
+    if (key.length === 0) {
+      continue;
+    }
+    pairs.push({ key, value: (v ?? '').trim() });
+  }
+  pairs.sort((a, b) => a.key.localeCompare(b.key));
+  for (const { key, value } of pairs) {
+    out[`${spanAttrTagPrefix}${key}`] = value;
+  }
+  return out;
+}
+
+function setTagSpanAttributes(span: Span, tags: Record<string, string> | undefined): void {
+  const attrs = tagMetricAttributes(tags);
+  for (const [key, value] of Object.entries(attrs)) {
+    span.setAttribute(key, value);
+  }
 }
 
 function metricIdentityAttributes(

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -222,7 +222,10 @@ export interface SigilSdkConfig {
   agentVersion?: string;
   /** Default user identifier. Read from `SIGIL_USER_ID`. */
   userId?: string;
-  /** Default tags merged into every generation; per-call tags win. Read from `SIGIL_TAGS` (CSV). */
+  /**
+   * Default tags merged into every generation (per-call tags win) and emitted on
+   * OTel spans/metrics as `sigil.tag.<key>`. Read from `SIGIL_TAGS` (CSV).
+   */
   tags?: Record<string, string>;
   /**
    * When true, signals to downstream consumers (plugins, telemetry) that the

--- a/js/test/client.tags.test.mjs
+++ b/js/test/client.tags.test.mjs
@@ -1,0 +1,204 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  AggregationTemporality,
+  DataPointType,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
+import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { defaultConfig, SigilClient } from '../.test-dist/index.js';
+
+const clientTagProjectKey = 'sigil.tag.project';
+
+class CapturingExporter {
+  requests = [];
+
+  async exportGenerations(request) {
+    this.requests.push(structuredClone(request));
+    return {
+      results: request.generations.map((generation) => ({
+        generationId: generation.id,
+        accepted: true,
+      })),
+    };
+  }
+}
+
+test('client SIGIL_TAGS appear on generation span and metrics', async () => {
+  const harness = newHarness({ tags: { project: 'checkout-svc' } });
+
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'openai', name: 'gpt-5' },
+    });
+    recorder.setResult({
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+    recorder.end();
+
+    const span = singleGenerationSpan(harness.spanExporter);
+    assert.equal(span.attributes[clientTagProjectKey], 'checkout-svc');
+
+    const metricAttrs = await harness.metricDataPointAttributes('gen_ai.client.operation.duration');
+    assert.ok(
+      metricAttrs.some((attrs) => attrs[clientTagProjectKey] === 'checkout-svc'),
+      'expected sigil.tag.project on operation.duration metric',
+    );
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('client tags on embedding and tool spans', async () => {
+  const harness = newHarness({ tags: { project: 'embed-tools' } });
+
+  try {
+    const embed = harness.client.startEmbedding({
+      model: { provider: 'openai', name: 'text-embedding-3-small' },
+    });
+    embed.setResult({ inputTokens: 1 });
+    embed.end();
+
+    const embedSpan = singleEmbeddingSpan(harness.spanExporter);
+    assert.equal(embedSpan.attributes[clientTagProjectKey], 'embed-tools');
+
+    const tool = harness.client.startToolExecution({ toolName: 'weather' });
+    tool.setResult({ result: 'sunny' });
+    tool.end();
+
+    const toolSpan = singleToolSpan(harness.spanExporter);
+    assert.equal(toolSpan.attributes[clientTagProjectKey], 'embed-tools');
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('empty client tags are omitted from spans', async () => {
+  const harness = newHarness();
+
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'openai', name: 'gpt-5' },
+    });
+    recorder.end();
+
+    const span = singleGenerationSpan(harness.spanExporter);
+    assert.equal(span.attributes[clientTagProjectKey], undefined);
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
+test('per-call generation tags stay export-only', async () => {
+  const harness = newHarness();
+
+  try {
+    const recorder = harness.client.startGeneration({
+      model: { provider: 'openai', name: 'gpt-5' },
+      tags: { call_only: 'yes' },
+    });
+    recorder.end();
+
+    const span = singleGenerationSpan(harness.spanExporter);
+    assert.equal(span.attributes['sigil.tag.call_only'], undefined);
+
+    await harness.client.shutdown();
+    const generation = harness.generationExporter.requests[0]?.generations?.[0];
+    assert.equal(generation?.tags?.call_only, 'yes');
+  } finally {
+    await harness.traceProvider.shutdown();
+  }
+});
+
+function newHarness(overrides = {}) {
+  const spanExporter = new InMemorySpanExporter();
+  const traceProvider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(spanExporter)],
+  });
+  const tracer = traceProvider.getTracer('sigil-sdk-js-test');
+  const generationExporter = new CapturingExporter();
+  const defaults = defaultConfig();
+
+  const metricExporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
+  const metricReader = new PeriodicExportingMetricReader({
+    exporter: metricExporter,
+    exportIntervalMillis: 60_000,
+  });
+  const meterProvider = new MeterProvider({ readers: [metricReader] });
+
+  const client = new SigilClient({
+    tracer,
+    meter: meterProvider.getMeter('sigil-test'),
+    generationExport: {
+      ...defaults.generationExport,
+      batchSize: 100,
+      flushIntervalMs: 60_000,
+      maxRetries: 1,
+      initialBackoffMs: 1,
+      maxBackoffMs: 1,
+    },
+    generationExporter,
+    ...overrides,
+  });
+
+  return {
+    client,
+    spanExporter,
+    traceProvider,
+    generationExporter,
+    metricExporter,
+    meterProvider,
+    metricReader,
+    async metricDataPointAttributes(metricName) {
+      await metricReader.forceFlush();
+      const metric = metricExporter
+        .getMetrics()
+        .flatMap((resourceMetrics) => resourceMetrics.scopeMetrics)
+        .flatMap((scopeMetrics) => scopeMetrics.metrics)
+        .find((m) => m.descriptor.name === metricName && m.dataPointType === DataPointType.HISTOGRAM);
+      assert.ok(metric, `expected histogram metric ${metricName}`);
+      return metric.dataPoints.map((point) => point.attributes);
+    },
+  };
+}
+
+async function shutdownHarness(harness) {
+  await harness.client.shutdown();
+  await harness.meterProvider.shutdown();
+  await harness.traceProvider.shutdown();
+}
+
+function generationSpans(spanExporter) {
+  return spanExporter.getFinishedSpans().filter((span) => {
+    const operation = span.attributes['gen_ai.operation.name'];
+    return operation !== 'execute_tool' && operation !== 'embeddings';
+  });
+}
+
+function embeddingSpans(spanExporter) {
+  return spanExporter.getFinishedSpans().filter((span) => span.attributes['gen_ai.operation.name'] === 'embeddings');
+}
+
+function toolSpans(spanExporter) {
+  return spanExporter.getFinishedSpans().filter((span) => span.attributes['gen_ai.operation.name'] === 'execute_tool');
+}
+
+function singleGenerationSpan(spanExporter) {
+  const spans = generationSpans(spanExporter);
+  assert.equal(spans.length, 1);
+  return spans[0];
+}
+
+function singleEmbeddingSpan(spanExporter) {
+  const spans = embeddingSpans(spanExporter);
+  assert.equal(spans.length, 1);
+  return spans[0];
+}
+
+function singleToolSpan(spanExporter) {
+  const spans = toolSpans(spanExporter);
+  assert.equal(spans.length, 1);
+  return spans[0];
+}

--- a/llms.txt
+++ b/llms.txt
@@ -109,6 +109,7 @@ SIGIL_PROTOCOL=http
 SIGIL_AUTH_MODE=basic
 SIGIL_AUTH_TENANT_ID=<your-instance-id>
 SIGIL_AUTH_TOKEN=<glc_... token>
+SIGIL_TAGS=project=my-app,env=dev   # optional; also sigil.tag.<key> on OTel spans/metrics
 
 # OTel traces and metrics (separate channel; same token)
 OTEL_EXPORTER_OTLP_ENDPOINT=<from stack OpenTelemetry card>
@@ -435,7 +436,7 @@ In the grafana/sigil-sdk repo:
   - `stop_reason` / `finish_reason`
   - Full token usage including `cache_read_input_tokens`, `cache_write_input_tokens`, and `reasoning_tokens` when the provider returns them
 - Always check `rec.err()` / `Err()` after the generation recorder closes; SDK validation or enqueue errors are otherwise silent.
-- Use `tags` on `GenerationStart` for filtering in the Sigil UI (e.g. pipeline name, layer, agent role).
+- Use `SIGIL_TAGS` (client-level) or `tags` on `GenerationStart` for filtering: export tags on generations; client-level tags also appear as `sigil.tag.<key>` on OTel spans and metrics (e.g. `project=my-app`).
 
 ## Validation checklist
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -83,7 +83,7 @@ Common culprits: `sigil --version` doesn't work (binary not on `PATH`), a missin
 | `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the AI Observability latency and tool-call panels stay empty. |
 | `SIGIL_OTEL_AUTH_TOKEN` | `SIGIL_AUTH_TOKEN` | Override the OTel password. |
 | `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md). |
-| `SIGIL_TAGS` | — | `key=value,key=value` tags added to every generation. |
+| `SIGIL_TAGS` | — | `key=value,key=value` tags on every generation and as `sigil.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). |
 | `SIGIL_USER_ID` | from `~/.claude.json` | Override the user id. |
 | `SIGIL_USER_ID_SOURCE` | `email` | Which field to read from `~/.claude.json`: `email` or `accountUuid`. |
 | `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -99,7 +99,7 @@ tail -f ~/.local/state/sigil/logs/sigil.log
 | `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the AI Observability latency and tool-call panels stay empty. |
 | `SIGIL_OTEL_AUTH_TOKEN` | `SIGIL_AUTH_TOKEN` | Override the OTel password. |
 | `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md). |
-| `SIGIL_TAGS` | — | `key=value,key=value` tags added to every generation. |
+| `SIGIL_TAGS` | — | `key=value,key=value` tags on every generation and as `sigil.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). |
 | `SIGIL_USER_ID` | — | Override the user id. |
 | `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
 | `SIGIL_GUARDS_ENABLED` | `false` | Enable Codex `PreToolUse` guards against Sigil rules. |

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -125,7 +125,7 @@ Captured prompt, assistant, and tool content is redacted before export. See [Con
 | `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the AI Observability latency and tool-call panels stay empty. |
 | `SIGIL_OTEL_AUTH_TOKEN` | `SIGIL_AUTH_TOKEN` | Override the OTel password. |
 | `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. |
-| `SIGIL_TAGS` | — | `key=value,key=value` tags added to every generation. |
+| `SIGIL_TAGS` | — | `key=value,key=value` tags on every generation and as `sigil.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). |
 | `SIGIL_USER_ID` | — | Override the user id. |
 | `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
 | `SIGIL_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Copilot `preToolUse` hook is evaluated against Sigil and tool calls denied by guard rules are blocked. |

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -77,7 +77,7 @@ tail -f ~/.local/state/sigil/logs/sigil.log
 | `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the AI Observability latency and tool-call panels stay empty. |
 | `SIGIL_OTEL_AUTH_TOKEN` | `SIGIL_AUTH_TOKEN` | Override the OTel password. |
 | `SIGIL_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md). |
-| `SIGIL_TAGS` | — | `key=value,key=value` tags added to every generation. Built-ins (`git.branch`, `cwd`, `subagent`) win on collision. |
+| `SIGIL_TAGS` | — | `key=value,key=value` tags on every generation and as `sigil.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). Built-ins (`git.branch`, `cwd`, `subagent`) win on generation-export tag collision. |
 | `SIGIL_USER_ID` | from Cursor | Override the user id. |
 | `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
 | `SIGIL_BIN` | auto | Override the binary path if you installed `sigil` somewhere unusual. |


### PR DESCRIPTION
## Summary

- Client-level tags (resolved from `SIGIL_TAGS`) are now emitted as `sigil.tag.<key>` **OTel span attributes** on generation, embedding, and tool-execution spans, and as **labels** on the `gen_ai.client.*` metrics — in addition to the existing generation-export tags.
- This lets users define a "project" (e.g. `SIGIL_TAGS=project=checkout-svc`) and group/filter traces (`span.sigil.tag.project`) and metric series (typically `sigil_tag_project`) by it.
- Implemented in the **Go** and **JS** SDKs, which back all six coding-agent plugins, so **no plugin changes** are required — tags already flow `SIGIL_TAGS` → `config.Tags` via `NewClient` / `new SigilClient`.

## Design notes

- Source is **client-level** `config.Tags` only; per-call `GenerationStart.tags` stay export-only (no surprise per-request metric cardinality).
- Keys are prefixed `sigil.tag.` to avoid colliding with reserved `gen_ai.*` / `service.*` attributes.
- Attributes are set once at span start; emission is sorted for deterministic output and is a no-op when no tags are set.
- Adds one label dimension per tag key to `gen_ai.client.*` histograms (intended).

## Scope

- Go + JS SDKs, docs (`llms.txt`, plugin READMEs, Java/.NET env tables). Python/Java/.NET SDKs unchanged; conformance stays green because it asserts named span attrs and subset metric labels.

## Files

- `go/sigil/client.go`, `go/sigil/env.go` (+ `go/sigil/client_tags_test.go`)
- `js/src/client.ts`, `js/src/types.ts` (+ `js/test/client.tags.test.mjs`)
- Docs: `llms.txt`, `plugins/{claude-code,codex,copilot,cursor}/README.md`, `java/README.md`, `dotnet/README.md`

## Test plan

- [x] `go test ./sigil` (full package) passes; gofmt clean
- [x] New Go tests: tags on generation/embedding/tool spans + metric points, empty-tags no-op, per-call tag stays export-only
- [x] JS biome + tsc typecheck clean
- [x] New JS tests (`client.tags.test.mjs`) pass: spans, metrics, empty no-op, per-call export-only
- [ ] CI conformance (Go/JS/Python/Java/.NET) green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive telemetry and docs only; no auth or export contract changes. Extra metric label dimensions from client tags are intentional but increase cardinality if many tag keys are configured.
> 
> **Overview**
> **Client-level tags** (`SIGIL_TAGS` / `config.Tags`) now show up on OpenTelemetry as **`sigil.tag.<key>`** on generation, embedding, and tool spans, and as extra labels on **`gen_ai.client.*`** histograms—while still merging into generation export as before.
> 
> Only **Go** and **JS** implement this; **per-call** `GenerationStart.tags` stay **export-only** so OTel cardinality stays tied to env/client config. Docs (plugin READMEs, `llms.txt`, Java/.NET env tables) note the new behavior; Python/Java/.NET SDKs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa80929ac93f673b51d592b477e63993996f0057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->