### PR TITLE
feat(plugins/sigil): add --tag flag to set SIGIL_TAGS on launchers

### DIFF
--- a/plugins/sigil/README.md
+++ b/plugins/sigil/README.md
@@ -32,6 +32,18 @@ Then follow your agent's quickstart:
 - [OpenCode](../opencode/README.md)
 - [pi](../pi/README.md)
 
+## Tagging sessions
+
+Add `--tag key=value` (repeatable) before any `--` to attach tags to every generation the launched session produces. This is shorthand for setting `SIGIL_TAGS`; flag tags merge onto (and override) any `SIGIL_TAGS` already in the environment.
+
+```sh
+sigil claude --tag project=hackathon --tag team=ai
+# forward args to the underlying CLI after `--`
+sigil claude --tag project=hackathon -- --resume
+```
+
+The same flag works for every launcher (`claude`, `codex`, `copilot`, `opencode`, `pi`) and combines with `--local`.
+
 ## Content capture
 
 The shared `sigil` binary defaults to `metadata_only`: only model, tokens, tool names, timing, and cost ship to Grafana AI Observability. Prompts, responses, and tool I/O stay on the local machine. To opt into sending content, set `SIGIL_CONTENT_CAPTURE_MODE` in `~/.config/sigil/config.env`. The shared binary parser accepts every mode the SDKs support:

--- a/plugins/sigil/cmd/sigil/main.go
+++ b/plugins/sigil/cmd/sigil/main.go
@@ -442,7 +442,7 @@ func mergeTags(existing string, flagTags []string) string {
 		}
 		vals[k] = v
 	}
-	for _, part := range strings.Split(existing, ",") {
+	for part := range strings.SplitSeq(existing, ",") {
 		part = strings.TrimSpace(part)
 		if part == "" {
 			continue

--- a/plugins/sigil/cmd/sigil/main.go
+++ b/plugins/sigil/cmd/sigil/main.go
@@ -415,16 +415,15 @@ func parseLauncherArgs(name string, rest []string, stderr io.Writer) ([]string, 
 // (matching the SDK's SIGIL_TAGS parser, which keeps empty values). ok is
 // false when the token has no `=` or an empty key.
 func normalizeTag(raw string) (string, bool) {
-	idx := strings.IndexByte(raw, '=')
-	if idx < 0 {
+	rawKey, rawValue, ok := strings.Cut(raw, "=")
+	if !ok {
 		return "", false
 	}
-	key := strings.TrimSpace(raw[:idx])
+	key := strings.TrimSpace(rawKey)
 	if key == "" {
 		return "", false
 	}
-	value := strings.TrimSpace(raw[idx+1:])
-	return key + "=" + value, true
+	return key + "=" + strings.TrimSpace(rawValue), true
 }
 
 // mergeTags layers flag-supplied `key=value` tags onto an existing
@@ -447,15 +446,19 @@ func mergeTags(existing string, flagTags []string) string {
 		if part == "" {
 			continue
 		}
-		idx := strings.IndexByte(part, '=')
-		if idx <= 0 {
+		rawKey, rawValue, ok := strings.Cut(part, "=")
+		if !ok {
 			continue
 		}
-		add(strings.TrimSpace(part[:idx]), strings.TrimSpace(part[idx+1:]))
+		key := strings.TrimSpace(rawKey)
+		if key == "" {
+			continue
+		}
+		add(key, strings.TrimSpace(rawValue))
 	}
 	for _, t := range flagTags {
-		idx := strings.IndexByte(t, '=')
-		add(t[:idx], t[idx+1:])
+		key, value, _ := strings.Cut(t, "=")
+		add(key, value)
 	}
 	parts := make([]string, 0, len(order))
 	for _, k := range order {

--- a/plugins/sigil/cmd/sigil/main.go
+++ b/plugins/sigil/cmd/sigil/main.go
@@ -1,14 +1,17 @@
 // Command sigil is the single binary used by the Claude Code, Codex,
 // Copilot, Cursor, OpenCode, and pi agent plugins. It accepts:
 //
-//	sigil <agent> hook                     — dispatch a JSON hook payload on stdin to <agent>
-//	sigil claude   [--local] [-- args...]  — exec claude after bootstrapping the sigil-cc plugin
-//	sigil codex    [--local] [-- args...]  — exec codex after bootstrapping the sigil-codex plugin
-//	sigil copilot  [--local] [-- args...]  — exec copilot after bootstrapping the sigil-copilot plugin
-//	sigil opencode [--local] [-- args...]  — exec opencode after bootstrapping the @grafana/sigil-opencode plugin
-//	sigil pi       [--local] [-- args...]  — exec pi after bootstrapping the @grafana/sigil-pi extension
-//	sigil local start|status|stop          — manage the local capture daemon
-//	sigil --version                        — print the build version
+//	sigil <agent> hook                                — dispatch a JSON hook payload on stdin to <agent>
+//	sigil claude   [--local] [--tag k=v] [-- args...] — exec claude after bootstrapping the sigil-cc plugin
+//	sigil codex    [--local] [--tag k=v] [-- args...] — exec codex after bootstrapping the sigil-codex plugin
+//	sigil copilot  [--local] [--tag k=v] [-- args...] — exec copilot after bootstrapping the sigil-copilot plugin
+//	sigil opencode [--local] [--tag k=v] [-- args...] — exec opencode after bootstrapping the @grafana/sigil-opencode plugin
+//	sigil pi       [--local] [--tag k=v] [-- args...] — exec pi after bootstrapping the @grafana/sigil-pi extension
+//	sigil local start|status|stop                     — manage the local capture daemon
+//	sigil --version                                   — print the build version
+//
+// --tag is repeatable and adds key=value pairs to SIGIL_TAGS so they land
+// on every generation the launched session produces.
 //
 // Unknown agents and unknown verbs exit with code 2 and a usage message on
 // stderr. For hook agents the binary must never crash the calling agent
@@ -71,7 +74,7 @@ func renderLocalBanner(uiURL string) string {
 	return localBannerBox.Render(strings.Join(lines, "\n"))
 }
 
-const usageLine = "usage: sigil login | sigil local start|status|stop | sigil <agent> hook | sigil claude [--local] [-- args...] | sigil codex [--local] [-- args...] | sigil copilot [--local] [-- args...] | sigil opencode [--local] [-- args...] | sigil pi [--local] [-- args...]"
+const usageLine = "usage: sigil login | sigil local start|status|stop | sigil <agent> hook | sigil <claude|codex|copilot|opencode|pi> [--local] [--tag key=value]... [-- args...]"
 
 // version is overridden via -ldflags at build time.
 var version = "dev"
@@ -308,12 +311,19 @@ func runLoginCommand(args []string, stderr io.Writer) {
 }
 
 // parseLauncherArgs splits sigil-side tokens from forwarded args at the
-// first `--`. The only recognised sigil-side flag is `--local`, which
-// redirects the launched agent at the local receiver. Any other token
-// before `--` is an error.
+// first `--`. Recognised sigil-side flags are:
+//   - `--local`, which redirects the launched agent at the local receiver.
+//   - `--tag key=value` (repeatable; also `--tag=key=value`), which adds
+//     a tag to SIGIL_TAGS so it lands on every generation the session
+//     produces. Flag tags merge onto (and override) any SIGIL_TAGS already
+//     in the environment.
+//
+// Any other token before `--` is an error.
 //
 // Returns the forwarded args plus a non-nil *local.LaunchEnv when --local
-// was set; the env values point at the local daemon.
+// was set; the env values point at the local daemon. When --tag is used,
+// SIGIL_TAGS is updated in the current process environment so the exec'd
+// child (which inherits os.Environ via local.Environ) sees it.
 //
 // Diagnostics distinguish two cases:
 //   - No `--` and there are unrecognised tokens: the user probably
@@ -339,11 +349,36 @@ func parseLauncherArgs(name string, rest []string, stderr io.Writer) ([]string, 
 	}
 
 	localRequested := false
+	var flagTags []string
 	var unknown []string
-	for _, tok := range sigilSide {
-		switch tok {
-		case "--local":
+	for i := 0; i < len(sigilSide); i++ {
+		tok := sigilSide[i]
+		switch {
+		case tok == "--local":
 			localRequested = true
+		case tok == "--tag":
+			if i+1 >= len(sigilSide) {
+				_, _ = fmt.Fprintln(stderr, "sigil: --tag requires a key=value argument")
+				exit(2)
+				return nil, nil, false
+			}
+			i++
+			kv, ok := normalizeTag(sigilSide[i])
+			if !ok {
+				_, _ = fmt.Fprintf(stderr, "sigil: invalid --tag %q (want key=value)\n", sigilSide[i])
+				exit(2)
+				return nil, nil, false
+			}
+			flagTags = append(flagTags, kv)
+		case strings.HasPrefix(tok, "--tag="):
+			raw := strings.TrimPrefix(tok, "--tag=")
+			kv, ok := normalizeTag(raw)
+			if !ok {
+				_, _ = fmt.Fprintf(stderr, "sigil: invalid --tag %q (want key=value)\n", raw)
+				exit(2)
+				return nil, nil, false
+			}
+			flagTags = append(flagTags, kv)
 		default:
 			unknown = append(unknown, tok)
 		}
@@ -359,6 +394,10 @@ func parseLauncherArgs(name string, rest []string, stderr io.Writer) ([]string, 
 		return nil, nil, false
 	}
 
+	if len(flagTags) > 0 {
+		_ = os.Setenv("SIGIL_TAGS", mergeTags(os.Getenv("SIGIL_TAGS"), flagTags))
+	}
+
 	var localEnv *local.LaunchEnv
 	if localRequested {
 		endpoint, otlp, err := setupLocalLaunch(stderr)
@@ -369,6 +408,60 @@ func parseLauncherArgs(name string, rest []string, stderr io.Writer) ([]string, 
 		localEnv = &local.LaunchEnv{Endpoint: endpoint, OTLPEndpoint: otlp}
 	}
 	return forwarded, localEnv, true
+}
+
+// normalizeTag validates a `--tag` value and returns it as a trimmed
+// `key=value` pair. The key must be non-empty; the value may be empty
+// (matching the SDK's SIGIL_TAGS parser, which keeps empty values). ok is
+// false when the token has no `=` or an empty key.
+func normalizeTag(raw string) (string, bool) {
+	idx := strings.IndexByte(raw, '=')
+	if idx < 0 {
+		return "", false
+	}
+	key := strings.TrimSpace(raw[:idx])
+	if key == "" {
+		return "", false
+	}
+	value := strings.TrimSpace(raw[idx+1:])
+	return key + "=" + value, true
+}
+
+// mergeTags layers flag-supplied `key=value` tags onto an existing
+// SIGIL_TAGS CSV value and returns the merged CSV. Existing keys keep their
+// position but take the flag's value (flags win); new keys are appended in
+// flag order. Malformed existing entries (no `=`, empty key) are dropped,
+// matching the SDK's parseCSVKV. flagTags entries are assumed already
+// normalised by normalizeTag.
+func mergeTags(existing string, flagTags []string) string {
+	var order []string
+	vals := map[string]string{}
+	add := func(k, v string) {
+		if _, seen := vals[k]; !seen {
+			order = append(order, k)
+		}
+		vals[k] = v
+	}
+	for _, part := range strings.Split(existing, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		idx := strings.IndexByte(part, '=')
+		if idx <= 0 {
+			continue
+		}
+		add(strings.TrimSpace(part[:idx]), strings.TrimSpace(part[idx+1:]))
+	}
+	for _, t := range flagTags {
+		idx := strings.IndexByte(t, '=')
+		add(t[:idx], t[idx+1:])
+	}
+	parts := make([]string, 0, len(order))
+	for _, k := range order {
+		parts = append(parts, k+"="+vals[k])
+	}
+	return strings.Join(parts, ",")
 }
 
 // setupLocalLaunch starts the local receiver if needed and returns the

--- a/plugins/sigil/cmd/sigil/main_test.go
+++ b/plugins/sigil/cmd/sigil/main_test.go
@@ -799,3 +799,126 @@ func TestRun_LocalLaunchersShareReceiver(t *testing.T) {
 		assert.Equal(t, endpoint, envs[name].Endpoint, name)
 	}
 }
+
+func TestNormalizeTag(t *testing.T) {
+	for _, tc := range []struct {
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{in: "project=hackathon", want: "project=hackathon", wantOK: true},
+		{in: "  project = hackathon  ", want: "project=hackathon", wantOK: true},
+		{in: "empty=", want: "empty=", wantOK: true},
+		{in: "value=has=equals", want: "value=has=equals", wantOK: true},
+		{in: "noequals", wantOK: false},
+		{in: "=novalue", wantOK: false},
+		{in: "  =trimmed", wantOK: false},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			got, ok := normalizeTag(tc.in)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestMergeTags(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		existing string
+		flags    []string
+		want     string
+	}{
+		{name: "no existing", existing: "", flags: []string{"project=hackathon"}, want: "project=hackathon"},
+		{name: "append to existing", existing: "env=prod", flags: []string{"project=hackathon"}, want: "env=prod,project=hackathon"},
+		{name: "flag overrides existing in place", existing: "project=old,env=prod", flags: []string{"project=new"}, want: "project=new,env=prod"},
+		{name: "multiple flags", existing: "", flags: []string{"project=hackathon", "team=ai"}, want: "project=hackathon,team=ai"},
+		{name: "drops malformed existing entries", existing: "bogus, =bad ,env=prod", flags: []string{"project=x"}, want: "env=prod,project=x"},
+		{name: "last flag wins for duplicate key", existing: "", flags: []string{"k=1", "k=2"}, want: "k=2"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, mergeTags(tc.existing, tc.flags))
+		})
+	}
+}
+
+// TestRun_LauncherTagFlagSetsSigilTags checks that --tag tokens before `--`
+// merge into SIGIL_TAGS for the exec'd child while args after `--` are
+// forwarded untouched.
+func TestRun_LauncherTagFlagSetsSigilTags(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		existingTag string
+		argv        []string
+		wantTags    string
+		wantArgs    []string
+	}{
+		{name: "single tag no separator", argv: []string{"--tag", "project=hackathon"}, wantTags: "project=hackathon", wantArgs: nil},
+		{name: "equals form", argv: []string{"--tag=project=hackathon"}, wantTags: "project=hackathon", wantArgs: nil},
+		{name: "repeated with forwarded args", argv: []string{"--tag", "project=hackathon", "--tag", "team=ai", "--", "--resume"}, wantTags: "project=hackathon,team=ai", wantArgs: []string{"--resume"}},
+		{name: "merges onto existing env", existingTag: "env=prod", argv: []string{"--tag", "project=hackathon"}, wantTags: "env=prod,project=hackathon", wantArgs: nil},
+		{name: "overrides existing key", existingTag: "project=old", argv: []string{"--tag", "project=new"}, wantTags: "project=new", wantArgs: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateDotenvHome(t)
+			t.Setenv("SIGIL_ENDPOINT", "https://cloud.example.com")
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
+			// Register SIGIL_TAGS for cleanup so os.Setenv inside run does
+			// not leak into other tests.
+			t.Setenv("SIGIL_TAGS", tc.existingTag)
+
+			var gotTags string
+			var gotArgs []string
+			withStubLauncher(t, "claude", func(_ context.Context, args []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger, _ string) error {
+				gotTags = os.Getenv("SIGIL_TAGS")
+				gotArgs = args
+				return nil
+			})
+
+			var stdout, stderr bytes.Buffer
+			gotExit := withExit(t, func() {
+				run(append([]string{"claude"}, tc.argv...), strings.NewReader(""), &stdout, &stderr)
+			})
+			require.Nil(t, gotExit, "stderr=%q", stderr.String())
+			assert.Equal(t, tc.wantTags, gotTags)
+			assert.Equal(t, tc.wantArgs, gotArgs)
+		})
+	}
+}
+
+func TestRun_LauncherTagFlagInvalid(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		argv              []string
+		wantStderrContain string
+	}{
+		{name: "missing argument", argv: []string{"--tag"}, wantStderrContain: "--tag requires a key=value argument"},
+		{name: "missing argument before separator", argv: []string{"--tag", "--", "x"}, wantStderrContain: "--tag requires a key=value argument"},
+		{name: "greedily consumes next token", argv: []string{"--tag", "--local"}, wantStderrContain: "invalid --tag \"--local\""},
+		{name: "no equals", argv: []string{"--tag", "bogus"}, wantStderrContain: "invalid --tag \"bogus\""},
+		{name: "empty key", argv: []string{"--tag", "=novalue"}, wantStderrContain: "invalid --tag \"=novalue\""},
+		{name: "equals form no value separator", argv: []string{"--tag=bogus"}, wantStderrContain: "invalid --tag \"bogus\""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateDotenvHome(t)
+			t.Setenv("SIGIL_ENDPOINT", "https://cloud.example.com")
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
+			withStubLauncher(t, "claude", func(_ context.Context, _ []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger, _ string) error {
+				t.Fatal("launcher must not be called for invalid --tag")
+				return nil
+			})
+
+			var stdout, stderr bytes.Buffer
+			gotExit := withExit(t, func() {
+				run(append([]string{"claude"}, tc.argv...), strings.NewReader(""), &stdout, &stderr)
+			})
+			require.NotNil(t, gotExit)
+			assert.Equal(t, 2, *gotExit)
+			assert.Contains(t, stderr.String(), tc.wantStderrContain)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a repeatable `--tag key=value` flag to the `sigil` launchers (`claude`, `codex`, `copilot`, `opencode`, `pi`) so users can attach tags to every generation a session produces, without exporting `SIGIL_TAGS` by hand.
- Flag tags are merged into `SIGIL_TAGS` in the launcher process before exec — existing keys keep their position but take the flag's value, new keys append. Since every launcher builds its child env from `os.Environ()` via `local.Environ`, no launcher signature changes were needed.
- Composes with `--local` and forwards everything after `--` to the underlying CLI unchanged. Invalid usage (`--tag` with no arg, or a value without `=`/empty key) exits 2 without starting the local daemon or exec'ing the agent.

```sh
sigil claude --tag project=hackathon
sigil claude --tag project=hackathon --tag team=ai -- --resume
```

The output format matches the SDK's existing `SIGIL_TAGS` CSV parser (`parseCSVKV` in `go/sigil/env.go`).

## Test plan

- [x] `mise exec -- go test ./cmd/... ./internal/agents/...` passes
- [x] New unit tests for `normalizeTag` and `mergeTags`
- [x] New end-to-end tests through `run`: no-separator, `--tag=` form, repeated tags with forwarded args, env merge/override, and invalid-input paths
- [x] `go build ./...` + `go vet ./cmd/sigil/` clean

## Notes

- Chose the unambiguous, repeatable `--tag key=value` form over a generic `--key=value` passthrough, which would collide with the existing "you forgot `--`" guard (any unknown `--foo` before `--` errors).
- The AI Observability onboarding wizard copy of the consumer prompt was intentionally not touched; if it documents launcher invocation it may want the same mention.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only change to launcher argv parsing and env merging; no auth or export pipeline changes, with solid unit and integration tests.
> 
> **Overview**
> Adds a repeatable **`--tag key=value`** (or **`--tag=key=value`**) launcher flag so sessions can carry observability tags without manually exporting **`SIGIL_TAGS`**. Tags are parsed in **`parseLauncherArgs`** alongside **`--local`**, must appear before **`--`**, and invalid values exit **2** without starting the agent or local daemon.
> 
> Flag tags are merged into the process environment via **`mergeTags`** (existing keys keep order but flag values win; malformed CSV entries are dropped to match the SDK’s **`parseCSVKV`** behavior) before the child inherits **`os.Environ`**. Usage text and the sigil README document the new “Tagging sessions” workflow for all launchers (**`claude`**, **`codex`**, **`copilot`**, **`opencode`**, **`pi`**).
> 
> Tests cover **`normalizeTag`**, **`mergeTags`**, end-to-end **`run`** paths (merge/override, forwarding after **`--`**), and invalid **`--tag`** handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3ddb000403a20aefd80d7ba28f473fa88e6e90a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->