### PR TITLE
fix(plugins/claude): capture final assistant turn lost to transcript flush race

### DIFF
--- a/plugins/sigil/internal/agents/claudecode/hook.go
+++ b/plugins/sigil/internal/agents/claudecode/hook.go
@@ -275,12 +275,12 @@ func handlePreToolUse(ctx context.Context, stdout io.Writer, input *hookInput, s
 // Because export happens solely on Stop/SessionEnd, no later event re-reads the
 // turn once it lands, so the final message is lost forever.
 //
-// To close the race we re-read until the transcript's tail is itself the last
-// complete assistant turn — i.e. the safe offset reaches the end of the last
-// meaningful line, meaning nothing is still landing — or transcriptSettleWindow
-// elapses. The common case (the turn is already fully flushed when Stop fires)
-// settles on the first read and adds no latency; only a detected trailing
-// fragment triggers the bounded wait.
+// To close the race we re-read until the tail no longer looks like an
+// assistant turn that is still landing (see tailNeedsSettle) or
+// transcriptSettleWindow elapses. The common case (the turn is already fully
+// flushed when Stop fires) settles on the first read and adds no latency; only
+// a trailing tool_result, a partial assistant line, or a lone prompt awaiting
+// its first assistant reply triggers the bounded wait.
 //
 // Returns the coalesced lines, the safe offset, and the raw line count so the
 // caller can distinguish "nothing to read" from "read but nothing complete".
@@ -295,15 +295,10 @@ func readTranscriptSettled(ctx context.Context, path string, offset int64, logge
 
 		coalesced, safeOffset := mapper.Coalesce(raw)
 
-		// Settle when there is nothing left to wait for: either the read is
-		// empty (a redundant Stop/SessionEnd after a prior export — the user
-		// prompt that begins any real turn lands well before Stop fires, so an
-		// empty read means "nothing new", not "mid-flush"), or the tail is
-		// already the last complete assistant turn. Only a trailing tool_result
-		// or partial turn that Claude Code is still flushing warrants the wait.
-		// A trailing user prompt (text only, no tool_result) is context for the
-		// next turn and doesn't indicate mid-flush state; treat as settled.
-		settled := len(raw) == 0 || raw[len(raw)-1].EndOffset == safeOffset || isUserTextPrompt(raw[len(raw)-1])
+		// Settle unless the tail is an assistant turn Claude Code is still
+		// flushing. An empty read (redundant Stop/SessionEnd after a prior
+		// export) has nothing to wait for, and tailNeedsSettle decides the rest.
+		settled := len(raw) == 0 || !tailNeedsSettle(raw[len(raw)-1], safeOffset)
 		if settled || !time.Now().Before(deadline) {
 			return coalesced, safeOffset, len(raw)
 		}
@@ -318,31 +313,45 @@ func readTranscriptSettled(ctx context.Context, path string, offset int64, logge
 	}
 }
 
-// isUserTextPrompt returns true if line is a user message containing only a
-// text prompt (no tool_result blocks). Such lines are context for the next
-// turn, not evidence that Claude Code is mid-flush, so they should not trigger
-// the settle wait.
-func isUserTextPrompt(line transcript.Line) bool {
-	if line.Type != "user" {
+// tailNeedsSettle reports whether the last raw transcript line indicates an
+// assistant turn that Claude Code is still flushing, so re-reading may recover
+// it. safeOffset is the end of the last complete assistant turn (from Coalesce).
+//
+//   - Tail is the last complete assistant turn (EndOffset == safeOffset): fully
+//     landed, nothing to wait for.
+//   - Tail is an assistant line that did not coalesce (no terminal stop_reason):
+//     a partial/streaming turn still landing — wait.
+//   - Tail is a tool_result: the assistant called a tool and will emit a follow
+//     -up turn that has not landed yet — wait (this is the diagnosed bug).
+//   - Tail is a plain user prompt: the start of a turn. Wait only when no
+//     completed assistant turn has landed in this batch (safeOffset == 0) — that
+//     is the symmetric race for a tool-free final turn whose assistant reply is
+//     still flushing. When a completed turn precedes the prompt (safeOffset > 0)
+//     the prompt belongs to a *future* turn, so the current event already has
+//     all it needs and must not block on it.
+func tailNeedsSettle(last transcript.Line, safeOffset int64) bool {
+	if last.EndOffset == safeOffset {
 		return false
 	}
-	var msg transcript.UserMessage
-	if err := json.Unmarshal(line.Message, &msg); err != nil {
-		return false
-	}
-	text, blocks, err := transcript.ParseUserContent(msg.Content)
-	if err != nil {
-		return false
-	}
-	if text != "" {
+	if last.Type == "assistant" {
 		return true
 	}
-	for _, b := range blocks {
-		if b.Type == "tool_result" {
-			return false
+
+	var msg transcript.UserMessage
+	if err := json.Unmarshal(last.Message, &msg); err != nil {
+		// Unknown shape: be conservative and wait rather than risk dropping
+		// an assistant turn that is mid-flush behind it.
+		return true
+	}
+	_, blocks, err := transcript.ParseUserContent(msg.Content)
+	if err == nil {
+		for _, b := range blocks {
+			if b.Type == "tool_result" {
+				return true
+			}
 		}
 	}
-	return true
+	return safeOffset == 0
 }
 
 func parseHookInput(r io.Reader) (*hookInput, error) {

--- a/plugins/sigil/internal/agents/claudecode/hook.go
+++ b/plugins/sigil/internal/agents/claudecode/hook.go
@@ -295,7 +295,13 @@ func readTranscriptSettled(ctx context.Context, path string, offset int64, logge
 
 		coalesced, safeOffset := mapper.Coalesce(raw)
 
-		settled := len(raw) > 0 && raw[len(raw)-1].EndOffset == safeOffset
+		// Settle when there is nothing left to wait for: either the read is
+		// empty (a redundant Stop/SessionEnd after a prior export — the user
+		// prompt that begins any real turn lands well before Stop fires, so an
+		// empty read means "nothing new", not "mid-flush"), or the tail is
+		// already the last complete assistant turn. Only a trailing tool_result
+		// or partial turn that Claude Code is still flushing warrants the wait.
+		settled := len(raw) == 0 || raw[len(raw)-1].EndOffset == safeOffset
 		if settled || !time.Now().Before(deadline) {
 			return coalesced, safeOffset, len(raw)
 		}

--- a/plugins/sigil/internal/agents/claudecode/hook.go
+++ b/plugins/sigil/internal/agents/claudecode/hook.go
@@ -301,7 +301,9 @@ func readTranscriptSettled(ctx context.Context, path string, offset int64, logge
 		// empty read means "nothing new", not "mid-flush"), or the tail is
 		// already the last complete assistant turn. Only a trailing tool_result
 		// or partial turn that Claude Code is still flushing warrants the wait.
-		settled := len(raw) == 0 || raw[len(raw)-1].EndOffset == safeOffset
+		// A trailing user prompt (text only, no tool_result) is context for the
+		// next turn and doesn't indicate mid-flush state; treat as settled.
+		settled := len(raw) == 0 || raw[len(raw)-1].EndOffset == safeOffset || isUserTextPrompt(raw[len(raw)-1])
 		if settled || !time.Now().Before(deadline) {
 			return coalesced, safeOffset, len(raw)
 		}
@@ -314,6 +316,33 @@ func readTranscriptSettled(ctx context.Context, path string, offset int64, logge
 		case <-timer.C:
 		}
 	}
+}
+
+// isUserTextPrompt returns true if line is a user message containing only a
+// text prompt (no tool_result blocks). Such lines are context for the next
+// turn, not evidence that Claude Code is mid-flush, so they should not trigger
+// the settle wait.
+func isUserTextPrompt(line transcript.Line) bool {
+	if line.Type != "user" {
+		return false
+	}
+	var msg transcript.UserMessage
+	if err := json.Unmarshal(line.Message, &msg); err != nil {
+		return false
+	}
+	text, blocks, err := transcript.ParseUserContent(msg.Content)
+	if err != nil {
+		return false
+	}
+	if text != "" {
+		return true
+	}
+	for _, b := range blocks {
+		if b.Type == "tool_result" {
+			return false
+		}
+	}
+	return true
 }
 
 func parseHookInput(r io.Reader) (*hookInput, error) {

--- a/plugins/sigil/internal/agents/claudecode/hook.go
+++ b/plugins/sigil/internal/agents/claudecode/hook.go
@@ -54,6 +54,16 @@ func exportConfig(endpoint, tenantID, authToken string) sigil.GenerationExportCo
 // previously filtered on "sigil-cc" need to update to "sigil.claude-code".
 const otelInstrumentationName = "sigil.claude-code"
 
+// transcriptSettleInterval is the poll spacing used while waiting for Claude
+// Code to finish flushing a turn to the transcript (see readTranscriptSettled).
+const transcriptSettleInterval = 100 * time.Millisecond
+
+// transcriptSettleWindow bounds how long readTranscriptSettled re-reads the
+// transcript waiting for the final assistant turn to land on disk. It is a var
+// so tests can zero it out and skip the wait. See readTranscriptSettled for why
+// the wait exists.
+var transcriptSettleWindow = 2 * time.Second
+
 type hookInput struct {
 	HookEventName  string          `json:"hook_event_name"`
 	SessionID      string          `json:"session_id"`
@@ -143,17 +153,12 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 	}
 	defer func() { _ = otelProviders.Shutdown(hookCtx) }()
 
-	lines, _, err := transcript.Read(input.TranscriptPath, st.Offset)
-	if err != nil {
-		logger.Printf("read transcript: %v", err)
+	lines, safeOffset, rawCount := readTranscriptSettled(hookCtx, input.TranscriptPath, st.Offset, logger)
+	if rawCount == 0 {
 		return nil
 	}
-	if len(lines) == 0 {
-		return nil
-	}
-	logger.Printf("read %d raw lines", len(lines))
+	logger.Printf("read %d raw lines", rawCount)
 
-	lines, safeOffset := mapper.Coalesce(lines)
 	if safeOffset == 0 {
 		logger.Printf("no completed assistant turn yet; keeping offset=%d", st.Offset)
 		return nil
@@ -257,6 +262,51 @@ func handlePreToolUse(ctx context.Context, stdout io.Writer, input *hookInput, s
 	}, logger)
 	if res.Blocked() {
 		guard.WriteHookSpecificOutputDeny(stdout, res.Reason)
+	}
+}
+
+// readTranscriptSettled reads transcript lines from offset and coalesces them
+// into complete assistant turns, briefly re-reading to dodge a flush race.
+//
+// Claude Code fires the Stop hook before the closing assistant turn (and its
+// preceding tool_result) is reliably flushed to the JSONL transcript. A single
+// read therefore often misses the last turn of a session: the hook coalesces
+// only through the prior tool-use turn, advances the offset there, and exits.
+// Because export happens solely on Stop/SessionEnd, no later event re-reads the
+// turn once it lands, so the final message is lost forever.
+//
+// To close the race we re-read until the transcript's tail is itself the last
+// complete assistant turn — i.e. the safe offset reaches the end of the last
+// meaningful line, meaning nothing is still landing — or transcriptSettleWindow
+// elapses. The common case (the turn is already fully flushed when Stop fires)
+// settles on the first read and adds no latency; only a detected trailing
+// fragment triggers the bounded wait.
+//
+// Returns the coalesced lines, the safe offset, and the raw line count so the
+// caller can distinguish "nothing to read" from "read but nothing complete".
+func readTranscriptSettled(ctx context.Context, path string, offset int64, logger *log.Logger) ([]transcript.Line, int64, int) {
+	deadline := time.Now().Add(transcriptSettleWindow)
+	for {
+		raw, _, err := transcript.Read(path, offset)
+		if err != nil {
+			logger.Printf("read transcript: %v", err)
+			return nil, 0, 0
+		}
+
+		coalesced, safeOffset := mapper.Coalesce(raw)
+
+		settled := len(raw) > 0 && raw[len(raw)-1].EndOffset == safeOffset
+		if settled || !time.Now().Before(deadline) {
+			return coalesced, safeOffset, len(raw)
+		}
+
+		timer := time.NewTimer(transcriptSettleInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return coalesced, safeOffset, len(raw)
+		case <-timer.C:
+		}
 	}
 }
 

--- a/plugins/sigil/internal/agents/claudecode/hook_test.go
+++ b/plugins/sigil/internal/agents/claudecode/hook_test.go
@@ -473,6 +473,83 @@ func TestReadTranscriptSettled_EmptyReadReturnsImmediately(t *testing.T) {
 	}
 }
 
+// TestReadTranscriptSettled_TrailingPromptAfterCompleteTurn guards against
+// blocking the settle window on a Stop whose tail is an already-flushed next
+// user prompt sitting after a complete assistant turn. The completed turn is
+// what the event reports; the prompt belongs to a future turn, so the read must
+// settle at once (returning the complete turn, leaving the prompt for later).
+func TestReadTranscriptSettled_TrailingPromptAfterCompleteTurn(t *testing.T) {
+	prev := transcriptSettleWindow
+	transcriptSettleWindow = 5 * time.Second
+	t.Cleanup(func() { transcriptSettleWindow = prev })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	sessionID := "trailing-prompt"
+	complete := buildHookAssistantJSONL(sessionID, "req_a", "end_turn", "done", 5) + "\n"
+	content := complete + buildHookUserJSONL(sessionID, "next question") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	lines, safeOffset, rawCount := readTranscriptSettled(context.Background(), path, 0, log.New(io.Discard, "", 0))
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("trailing-prompt read took %s; expected immediate return (completed turn already present)", elapsed)
+	}
+	if rawCount != 2 {
+		t.Fatalf("rawCount = %d, want 2 (assistant turn + trailing prompt)", rawCount)
+	}
+	// safeOffset must stop at the end of the completed assistant turn, leaving
+	// the trailing prompt to be consumed by a later event.
+	wantSafe := int64(len(complete))
+	if safeOffset != wantSafe {
+		t.Fatalf("safeOffset = %d, want %d (end of completed assistant turn)", safeOffset, wantSafe)
+	}
+	if lines[len(lines)-1].RequestID != "req_a" {
+		t.Fatalf("last coalesced line = %q, want req_a", lines[len(lines)-1].RequestID)
+	}
+}
+
+// TestReadTranscriptSettled_LonePromptWaitsForReply confirms the symmetric race
+// is still covered: a tool-free final turn whose only flushed line is the user
+// prompt (no completed assistant turn yet) must still poll so the assistant
+// reply is captured when it lands.
+func TestReadTranscriptSettled_LonePromptWaitsForReply(t *testing.T) {
+	prev := transcriptSettleWindow
+	transcriptSettleWindow = 2 * time.Second
+	t.Cleanup(func() { transcriptSettleWindow = prev })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	sessionID := "lone-prompt"
+	if err := os.WriteFile(path, []byte(buildHookUserJSONL(sessionID, "hi there")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			return
+		}
+		defer func() { _ = f.Close() }()
+		_, _ = f.WriteString(buildHookAssistantJSONL(sessionID, "req_a", "end_turn", "hello", 4) + "\n")
+	}()
+
+	lines, safeOffset, rawCount := readTranscriptSettled(context.Background(), path, 0, log.New(io.Discard, "", 0))
+	if rawCount != 2 {
+		t.Fatalf("rawCount = %d, want 2 (prompt + late assistant reply)", rawCount)
+	}
+	last := lines[len(lines)-1]
+	if last.RequestID != "req_a" {
+		t.Fatalf("last coalesced line = %q, want req_a (the late reply)", last.RequestID)
+	}
+	if safeOffset != last.EndOffset {
+		t.Fatalf("safeOffset = %d, want %d (end of late reply)", safeOffset, last.EndOffset)
+	}
+}
+
 func TestBuildToolResultMap(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/plugins/sigil/internal/agents/claudecode/hook_test.go
+++ b/plugins/sigil/internal/agents/claudecode/hook_test.go
@@ -444,6 +444,35 @@ func TestReadTranscriptSettled_ReturnsImmediatelyWhenTerminal(t *testing.T) {
 	}
 }
 
+// TestReadTranscriptSettled_EmptyReadReturnsImmediately guards against blocking
+// the hook for the full settle window on a redundant Stop/SessionEnd: when the
+// read at the saved offset yields nothing (EOF / already exported), there is no
+// pending fragment to wait for, so the function must return at once.
+func TestReadTranscriptSettled_EmptyReadReturnsImmediately(t *testing.T) {
+	prev := transcriptSettleWindow
+	transcriptSettleWindow = 5 * time.Second
+	t.Cleanup(func() { transcriptSettleWindow = prev })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	sessionID := "already-exported"
+	content := buildHookAssistantJSONL(sessionID, "req_a", "end_turn", "done", 5) + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read from end-of-file: a prior export already consumed everything.
+	eof := int64(len(content))
+	start := time.Now()
+	lines, safeOffset, rawCount := readTranscriptSettled(context.Background(), path, eof, log.New(io.Discard, "", 0))
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("empty read took %s; expected immediate return without waiting out the settle window", elapsed)
+	}
+	if rawCount != 0 || len(lines) != 0 || safeOffset != 0 {
+		t.Fatalf("rawCount=%d len(lines)=%d safeOffset=%d, want 0/0/0", rawCount, len(lines), safeOffset)
+	}
+}
+
 func TestBuildToolResultMap(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/plugins/sigil/internal/agents/claudecode/hook_test.go
+++ b/plugins/sigil/internal/agents/claudecode/hook_test.go
@@ -23,6 +23,14 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
+func TestMain(m *testing.M) {
+	// The transcript flush-race wait is unnecessary against the synthetic,
+	// fully-written transcripts these tests use; zero it so incomplete
+	// fixtures return immediately instead of blocking the settle window.
+	transcriptSettleWindow = 0
+	os.Exit(m.Run())
+}
+
 func TestParseHookInput_PreToolUse(t *testing.T) {
 	in := `{"hook_event_name":"PreToolUse","session_id":"s1","transcript_path":"/tmp/t.jsonl","tool_name":"Bash","tool_input":{"command":"echo hi"},"tool_use_id":"tu_1"}`
 	got, err := parseHookInput(strings.NewReader(in))
@@ -320,6 +328,120 @@ func buildHookUserJSONL(sessionID, text string) string {
 	}
 	data, _ := json.Marshal(line)
 	return string(data)
+}
+
+func buildHookAssistantJSONL(sessionID, requestID, stopReason, text string, outputTokens int64) string {
+	line := map[string]any{
+		"type":      "assistant",
+		"sessionId": sessionID,
+		"timestamp": "2025-06-01T12:00:00Z",
+		"version":   "1.0.0",
+		"requestId": requestID,
+		"message": map[string]any{
+			"model":       "claude-opus-4",
+			"stop_reason": stopReason,
+			"usage":       map[string]any{"input_tokens": 3, "output_tokens": outputTokens},
+			"content":     []any{map[string]any{"type": "text", "text": text}},
+		},
+	}
+	data, _ := json.Marshal(line)
+	return string(data)
+}
+
+func buildHookToolResultJSONL(sessionID, toolUseID, content string) string {
+	line := map[string]any{
+		"type":      "user",
+		"sessionId": sessionID,
+		"timestamp": "2025-06-01T12:00:00Z",
+		"version":   "1.0.0",
+		"message": map[string]any{
+			"role": "user",
+			"content": []any{map[string]any{
+				"type":        "tool_result",
+				"tool_use_id": toolUseID,
+				"content":     content,
+			}},
+		},
+	}
+	data, _ := json.Marshal(line)
+	return string(data)
+}
+
+// TestReadTranscriptSettled_CapturesLateFinalTurn reproduces the Claude Code
+// flush race: the Stop hook reads a transcript whose tail is still a dangling
+// tool_result, then the closing assistant turn lands on disk a moment later.
+// Without the settle wait the final turn would be dropped (and never recovered,
+// since export only happens on Stop/SessionEnd).
+func TestReadTranscriptSettled_CapturesLateFinalTurn(t *testing.T) {
+	prev := transcriptSettleWindow
+	transcriptSettleWindow = 2 * time.Second
+	t.Cleanup(func() { transcriptSettleWindow = prev })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	sessionID := "late-final-turn"
+
+	// Initial on-disk state at Stop time: the tool-use turn is complete, its
+	// result has landed, but the closing assistant turn has not been flushed.
+	initial := buildHookAssistantJSONL(sessionID, "req_a", "tool_use", "calling tool", 10) + "\n" +
+		buildHookToolResultJSONL(sessionID, "tu_1", "tool ok") + "\n"
+	if err := os.WriteFile(path, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Append the closing assistant turn shortly after the first read.
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			return
+		}
+		defer func() { _ = f.Close() }()
+		_, _ = f.WriteString(buildHookAssistantJSONL(sessionID, "req_b", "end_turn", "all done", 5) + "\n")
+	}()
+
+	logs := log.New(io.Discard, "", 0)
+	lines, safeOffset, rawCount := readTranscriptSettled(context.Background(), path, 0, logs)
+
+	if rawCount != 3 {
+		t.Fatalf("rawCount = %d, want 3 (tool-use turn, tool_result, final turn)", rawCount)
+	}
+	last := lines[len(lines)-1]
+	if last.RequestID != "req_b" {
+		t.Fatalf("last coalesced line RequestID = %q, want req_b (the late final turn)", last.RequestID)
+	}
+	if safeOffset != last.EndOffset {
+		t.Fatalf("safeOffset = %d, want %d (end of final turn)", safeOffset, last.EndOffset)
+	}
+}
+
+// TestReadTranscriptSettled_ReturnsImmediatelyWhenTerminal confirms the common
+// case adds no latency: when the tail is already a complete assistant turn the
+// function returns on the first read without waiting out the settle window.
+func TestReadTranscriptSettled_ReturnsImmediatelyWhenTerminal(t *testing.T) {
+	prev := transcriptSettleWindow
+	transcriptSettleWindow = 5 * time.Second
+	t.Cleanup(func() { transcriptSettleWindow = prev })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	sessionID := "terminal-tail"
+	content := buildHookAssistantJSONL(sessionID, "req_a", "end_turn", "done", 5) + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	lines, safeOffset, rawCount := readTranscriptSettled(context.Background(), path, 0, log.New(io.Discard, "", 0))
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("settled read took %s; expected near-immediate return", elapsed)
+	}
+	if rawCount != 1 || len(lines) != 1 {
+		t.Fatalf("rawCount=%d len(lines)=%d, want 1/1", rawCount, len(lines))
+	}
+	if safeOffset != lines[0].EndOffset {
+		t.Fatalf("safeOffset = %d, want %d", safeOffset, lines[0].EndOffset)
+	}
 }
 
 func TestBuildToolResultMap(t *testing.T) {


### PR DESCRIPTION
## Summary

The Claude Code launcher was dropping the **final assistant turn** of a session. Diagnosed from a real transcript: the closing `end_turn` message existed on disk (bytes 88385–89669) but the hook's saved offset was stuck at 87527 (the end of the prior tool-use turn), and re-running the production pipeline over the complete file produced 16 generations vs. the 15 exported.

**Root cause — a transcript flush race.** Export only happens on `Stop`/`SessionEnd`, and `Coalesce` deliberately advances the offset only to the last *complete* assistant turn. Claude Code fires the `Stop` hook before the closing assistant turn (and its preceding `tool_result`) is reliably flushed to the JSONL transcript, so the hook reads only through the previous tool-use turn, advances the offset, exports, and exits. Since nothing re-reads after the last `Stop`/`SessionEnd`, the final message is lost permanently.

## Changes

- Add `readTranscriptSettled` in `claudecode/hook.go`: on terminal events it briefly re-reads the transcript (100ms poll, bounded by `transcriptSettleWindow = 2s`) until the tail is itself the last complete assistant turn (no unflushed trailing fragment).
  - **Common case** (turn already flushed when `Stop` fires): settles on the first read, **zero added latency**.
  - **Race case** (trailing `tool_result`/partial turn detected): waits briefly for the closing turn to land, then exports it and advances the offset correctly.
  - Respects the hook's context deadline; on timeout it falls back to prior behavior (export what's complete, leave the rest for the next event).
- This mirrors the retry loop Copilot already uses in `enrichFromTranscript` (1.5s/100ms), which is prior art for the same class of race. Codex (final message from the `Stop` payload) and Cursor (push-based payloads) are not affected.

## Test plan

- [x] `go test ./plugins/sigil/internal/agents/claudecode/...` passes
- [x] `go vet ./plugins/sigil/internal/agents/claudecode/...` clean
- New tests in `hook_test.go`:
  - `TestReadTranscriptSettled_CapturesLateFinalTurn` — reproduces the race (final turn appended 150ms after the first read) and asserts it's captured.
  - `TestReadTranscriptSettled_ReturnsImmediatelyWhenTerminal` — asserts no wait when the tail is already a terminal turn.
  - `TestMain` zeroes the settle window so existing incomplete-transcript fixtures don't incur the wait.

Note: this prevents future data loss; already-recorded traces won't backfill.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only Stop/SessionEnd export timing and offset advancement; bounded wait can add up to ~2s on race paths but falls back on timeout/context cancel.
> 
> **Overview**
> Fixes **permanent loss of the last assistant turn** on Claude Code `Stop`/`SessionEnd` export when the hook runs before the closing turn (or its trailing `tool_result`) is flushed to the JSONL transcript.
> 
> **Stop/SessionEnd** transcript handling now goes through **`readTranscriptSettled`**, which coalesces on each read and **polls re-reads** (100ms, up to 2s, bounded by hook context) until **`tailNeedsSettle`** says the tail is not a still-landing fragment—e.g. dangling `tool_result`, partial assistant line, or a lone user prompt with no completed turn yet. It **does not wait** on empty reads or a **next user prompt after an already-complete turn**. When the transcript is already complete, behavior stays **single-read / no extra latency**.
> 
> Tests add **`TestMain`** to zero the settle window for existing fixtures, plus targeted cases for the late final turn, immediate terminal tail, empty offset, trailing prompt, and lone-prompt reply races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 806641c7b01ca10a3bbc5238eafd31df037764cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->