### PR TITLE
docs(plugins): add go install path for Linux and Windows

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -52,19 +52,18 @@ The user wants Grafana AI observability to capture sessions from their coding ag
 | [OpenCode](https://opencode.ai) | [`plugins/opencode/`](https://github.com/grafana/sigil-sdk/tree/main/plugins/opencode) | Shared `sigil` Go binary, installs `@grafana/sigil-opencode` |
 | [Pi](https://github.com/badlogic/pi) | [`plugins/pi/`](https://github.com/grafana/sigil-sdk/tree/main/plugins/pi) | Independent npm package `@grafana/sigil-pi` |
 
-## Fast path (Claude Code, Codex, Copilot, Cursor, OpenCode, Pi)
+## Fast path
 
-```sh
-brew install grafana/grafana/sigil
-sigil claude     # Claude Code
-sigil codex      # Codex
-sigil copilot    # Copilot CLI
-sigil cursor     # Cursor
-sigil opencode   # OpenCode
-sigil pi         # Pi
-```
+Install the `sigil` binary:
 
-`sigil <agent>` installs the plugin on first run, prompts for credentials, writes `~/.config/sigil/config.env`, and launches the agent.
+- **macOS:** `brew install grafana/grafana/sigil`
+- **Linux, Windows, or any platform with Go 1.25+:** `go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest`
+
+`go install` puts the binary in `go env GOPATH`/bin (or `GOBIN`); make sure that directory is on your `PATH`.
+
+Then launch your agent with `sigil <agent>`, where `<agent>` is `claude`, `codex`, `copilot`, `opencode`, or `pi`. On first run it installs the plugin, prompts for credentials, writes `~/.config/sigil/config.env`, and launches the agent.
+
+Cursor has no launcher; see [`plugins/cursor/`](https://github.com/grafana/sigil-sdk/tree/main/plugins/cursor) for setup.
 
 To skip the prompt, write the config file by hand:
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -4,18 +4,33 @@ Send conversations from your coding agent to [Grafana AI Observability](https://
 
 > AI Observability is in [public preview](https://grafana.com/docs/release-life-cycle/).
 
-## Fastest start (Claude Code, Codex, Copilot, OpenCode, or pi)
+## Install
+
+On macOS use Homebrew; on Linux and Windows (or any platform with Go 1.25+) use `go install`.
+
+**macOS** — Homebrew:
 
 ```sh
 brew install grafana/grafana/sigil
-sigil claude     # for Claude Code
-sigil codex      # for Codex
-sigil copilot    # for Copilot CLI
-sigil opencode   # for OpenCode
-sigil pi         # for pi
 ```
 
-Use the `sigil <agent>` launcher for setup and daily use. On first run it installs the agent plugin or extension, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches the agent.
+Upgrade later with `brew upgrade grafana/grafana/sigil`.
+
+**Linux and Windows** — `go install` (also works on macOS):
+
+```sh
+go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
+```
+
+This installs `sigil` to `go env GOPATH`/bin (or `GOBIN`); make sure that directory is on your `PATH`. Re-run the same command to upgrade.
+
+Verify the install with `sigil --version`.
+
+## Launch your agent
+
+Launch with `sigil <agent>`, where `<agent>` is `claude`, `codex`, `copilot`, `opencode`, or `pi`. On first run it installs the agent plugin or extension, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches the agent.
+
+Cursor has no launcher; see [`cursor/README.md`](cursor/README.md) for setup.
 
 ## All plugins
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -4,10 +4,21 @@ Sends every Claude Code turn to [Grafana AI Observability](https://grafana.com/d
 
 ## 1. Install and launch
 
+**macOS** (Homebrew):
+
 ```sh
 brew install grafana/grafana/sigil
 sigil claude
 ```
+
+**Linux and Windows** (or any platform with Go 1.25+):
+
+```sh
+go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
+sigil claude
+```
+
+`go install` puts `sigil` in `go env GOPATH`/bin (or `GOBIN`); add that to `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for details.
 
 `sigil claude` registers the `sigil-cc` plugin on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches Claude Code.
 

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -6,10 +6,21 @@ Sends Codex turns to [Grafana AI Observability](https://grafana.com/docs/grafana
 
 ## 1. Install and launch
 
+**macOS** (Homebrew):
+
 ```sh
 brew install grafana/grafana/sigil
 sigil codex
 ```
+
+**Linux and Windows** (or any platform with Go 1.25+):
+
+```sh
+go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
+sigil codex
+```
+
+`go install` puts `sigil` in `go env GOPATH`/bin (or `GOBIN`); add that to `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for details.
 
 `sigil codex` registers `sigil-codex@grafana-sigil` on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches Codex.
 
@@ -117,6 +128,6 @@ If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Ob
 |---|---|
 | `/hooks` is empty | Enable the hook feature flags (`codex features list`), enable `plugins."sigil-codex@grafana-sigil"`, restart Codex. |
 | Hooks listed but inactive | Open `/hooks` and trust each one. |
-| Command not found | Reinstall: `brew install grafana/grafana/sigil`. Check `sigil --version`. |
+| Command not found | Reinstall `sigil` (see step 1). Check `sigil --version` and that its install dir is on `PATH`. |
 | No data appears | Let turns finish (interrupted turns are not exported). Then check the debug log. |
 | Subagent appears as a normal turn | Codex hook payloads don't always carry the parent link. Known limitation. |

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -17,10 +17,21 @@ came from (`hook.surface` = `copilot-cli` or `vscode`).
 
 ## 1. Install and launch
 
+**macOS** (Homebrew):
+
 ```sh
 brew install grafana/grafana/sigil
 sigil copilot -- <copilot args>
 ```
+
+**Linux and Windows** (or any platform with Go 1.25+):
+
+```sh
+go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
+sigil copilot -- <copilot args>
+```
+
+`go install` puts `sigil` in `go env GOPATH`/bin (or `GOBIN`); add that to `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for details.
 
 `sigil copilot` writes the shared hooks file to `~/.copilot/hooks/sigil.json`, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, removes any legacy `sigil-copilot` plugin left by older versions, and then launches Copilot CLI.
 
@@ -191,7 +202,7 @@ field and the `SIGIL_DEBUG` log line (`dispatch: event=… surface=…`).
 |---|---|
 | Hooks file missing at `~/.copilot/hooks/sigil.json` | Re-run `sigil copilot -- <args>` (it writes the file before launching). For VS Code, also add `~/.copilot/hooks` to `chat.hookFilesLocations`. |
 | Turns appear twice in Sigil | A leftover `sigil-copilot` plugin is firing alongside the shared file. Remove it: `copilot plugin uninstall sigil-copilot` (newer `sigil copilot` runs do this automatically). |
-| Command not found | Reinstall: `brew install grafana/grafana/sigil`. Check `sigil --version`. |
+| Command not found | Reinstall `sigil` (see step 1). Check `sigil --version` and that its install dir is on `PATH`. |
 | Hooks run but nothing appears in Sigil | Check `SIGIL_ENDPOINT`, `SIGIL_AUTH_TENANT_ID`, and `SIGIL_AUTH_TOKEN`. Without all three, the plugin discards the completed fragment. |
 | No latency/tool charts in AI Observability | Set `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` so the plugin can emit traces and metrics. |
 | Prompt or tool content is missing | Check `SIGIL_CONTENT_CAPTURE_MODE`. The default is `metadata_only`. |

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -4,9 +4,19 @@ Sends Cursor agent generations to [Grafana AI Observability](https://grafana.com
 
 ## 1. Install the shared binary
 
+**macOS** (Homebrew):
+
 ```sh
 brew install grafana/grafana/sigil
 ```
+
+**Linux and Windows** (or any platform with Go 1.25+):
+
+```sh
+go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
+```
+
+`go install` puts `sigil` in `go env GOPATH`/bin (or `GOBIN`); add that to `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for details.
 
 Cursor does not have a `sigil cursor` launcher. Install the binary, register the Cursor plugin, then use `sigil login` or `~/.config/sigil/config.env` for credentials.
 

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -6,10 +6,21 @@ By default only metadata is sent (token counts, cost, model, tool names, duratio
 
 ## 1. Install and launch
 
+**macOS** (Homebrew):
+
 ```sh
 brew install grafana/grafana/sigil
 sigil opencode
 ```
+
+**Linux and Windows** (or any platform with Go 1.25+):
+
+```sh
+go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
+sigil opencode
+```
+
+`go install` puts `sigil` in `go env GOPATH`/bin (or `GOBIN`); add that to `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for details.
 
 `sigil opencode` installs `@grafana/sigil-opencode` into OpenCode on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches OpenCode. Pass arguments to OpenCode after `--`, e.g. `sigil opencode -- run "say hi"`.
 

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -6,10 +6,21 @@ By default only metadata is sent (token counts, cost, model, tool names, duratio
 
 ## 1. Install and launch
 
+**macOS** (Homebrew):
+
 ```sh
 brew install grafana/grafana/sigil
 sigil pi
 ```
+
+**Linux and Windows** (or any platform with Go 1.25+):
+
+```sh
+go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
+sigil pi
+```
+
+`go install` puts `sigil` in `go env GOPATH`/bin (or `GOBIN`); add that to `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for details.
 
 `sigil pi` installs the `@grafana/sigil-pi` extension on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches pi.
 

--- a/plugins/sigil/README.md
+++ b/plugins/sigil/README.md
@@ -4,9 +4,25 @@ The launcher binary behind the [Claude Code](../claude-code), [Codex](../codex),
 
 ## Install
 
+On macOS use Homebrew; on Linux and Windows (or any platform with Go 1.25+) use `go install`.
+
+**macOS** — Homebrew:
+
 ```sh
 brew install grafana/grafana/sigil
 ```
+
+Upgrade later with `brew upgrade grafana/grafana/sigil`.
+
+**Linux and Windows** — `go install` (also works on macOS):
+
+```sh
+go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
+```
+
+This installs the binary to `go env GOPATH`/bin (or `GOBIN` if set); make sure that directory is on your `PATH`. Re-run the same command to upgrade.
+
+Verify the install with `sigil --version`.
 
 ## Configure
 


### PR DESCRIPTION
Adding `go install` for now, but will also need to work on providing pre-built binaries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only install and troubleshooting updates; no runtime or build behavior changes.
> 
> **Overview**
> Documentation now documents **two install paths** for the shared `sigil` launcher: **Homebrew on macOS** and **`go install`** on Linux, Windows, or any host with Go 1.25+ (`github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest`), including notes on `GOPATH`/`GOBIN`, `PATH`, upgrade, and `sigil --version`.
> 
> The **fast path** in `llms.txt` and `plugins/README.md` is reorganized into separate **Install** and **Launch your agent** sections. Launcher docs no longer imply Homebrew-only setup; **Cursor** is called out as having **no** `sigil cursor` launcher, with a pointer to manual plugin setup.
> 
> Per-agent READMEs (Claude, Codex, Copilot, Cursor, OpenCode, Pi) and `plugins/sigil/README.md` mirror the same macOS vs Linux/Windows blocks. Codex and Copilot troubleshooting **Command not found** rows now point at step 1 reinstall and PATH instead of only `brew install`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a515dcc4c438ee1f321f72d27b363b2ae079358. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->