### PR TITLE
feat: datasets from conversation collections prompt only

### DIFF
--- a/python/sigil_sdk/__init__.py
+++ b/python/sigil_sdk/__init__.py
@@ -49,6 +49,7 @@ from .errors import (
 )
 from .experiment import (
     DatasetItem,
+    DatasetMode,
     DatasetScorer,
     DatasetTarget,
     ExperimentResult,
@@ -57,7 +58,9 @@ from .experiment import (
     ScoreOutput,
     TargetResult,
     UploadMode,
+    dataset_from_collection,
     experiment,
+    initial_user_prompt,
     stable_id,
 )
 from .hooks import (
@@ -145,6 +148,7 @@ __all__ = [
     "ConversationRatingValue",
     "CreateExperimentRequest",
     "DatasetItem",
+    "DatasetMode",
     "DatasetScorer",
     "DatasetTarget",
     "EmbeddingCaptureConfig",
@@ -216,7 +220,9 @@ __all__ = [
     "assistant_text_message",
     "content_capture_mode_from_context",
     "create_secret_redaction_sanitizer",
+    "dataset_from_collection",
     "experiment",
+    "initial_user_prompt",
     "set_cache_diagnostics",
     "conversation_id_from_context",
     "conversation_title_from_context",

--- a/python/sigil_sdk/client.py
+++ b/python/sigil_sdk/client.py
@@ -21,6 +21,7 @@ from opentelemetry import metrics, trace
 from opentelemetry.metrics import Histogram
 from opentelemetry.trace import Span, SpanKind, Status, StatusCode, use_span
 
+from . import conversations as _conversations
 from . import experiments as _experiments
 from .config import ClientConfig, resolve_config
 from .context import (
@@ -826,6 +827,37 @@ class Client:
         return _experiments.get_experiment_report(
             **self._eval_args(),
             run_id=run_id,
+            retry=self._experiment_retry_policy(),
+        )
+
+    def list_collection_members(self, collection_id: str) -> list[dict[str, Any]]:
+        """Lists the saved conversations belonging to an eval collection.
+
+        Uses the protected eval control plane (see :meth:`_eval_args`). Returns
+        raw member dicts (``saved_id``, ``conversation_id``, ``name``, ...).
+        Pair with :func:`sigil_sdk.dataset_from_collection` to turn a collection
+        into experiment dataset items.
+        """
+
+        self._assert_open()
+        return _conversations.list_collection_members(
+            **self._eval_args(),
+            collection_id=collection_id,
+            retry=self._experiment_retry_policy(),
+        )
+
+    def get_conversation(self, conversation_id: str) -> dict[str, Any]:
+        """Fetches a single conversation (with its generations) by id.
+
+        Uses the protected eval control plane (see :meth:`_eval_args`). Returns
+        the raw conversation dict; use :func:`sigil_sdk.initial_user_prompt` to
+        recover the prompt that started it.
+        """
+
+        self._assert_open()
+        return _conversations.get_conversation(
+            **self._eval_args(),
+            conversation_id=conversation_id,
             retry=self._experiment_retry_policy(),
         )
 

--- a/python/sigil_sdk/conversations.py
+++ b/python/sigil_sdk/conversations.py
@@ -1,0 +1,106 @@
+"""Read-only access to Sigil conversations and eval collections.
+
+This module backs the experiment *dataset* builder in
+:mod:`sigil_sdk.experiment`: a Sigil collection groups "saved conversations"
+(bookmarks of live conversations), and each conversation carries the
+generations — with their input/output messages — that produced it. Turning a
+collection into a dataset means listing its members, then fetching each
+conversation to recover the initial user prompt.
+
+Endpoints share the same eval connection args as experiments (``/api/v1`` for
+self-hosted Sigil; the Grafana plugin resource proxy on Grafana Cloud, e.g.
+``/api/plugins/grafana-sigil-app/resources``):
+
+  GET {prefix}/eval/collections/{collection_id}/members  saved conversations in a collection
+  GET {prefix}/query/conversations/{conversation_id}     one conversation with generations
+
+The functions here are thin; :class:`sigil_sdk.client.Client` wraps them with a
+resolved endpoint, insecure flag, auth headers, and path prefix (see
+``Client._eval_args``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib import parse as urllib_parse
+
+from .errors import ExperimentTransportError, ValidationError
+from .experiments import RetryPolicy, _base_url, _request_json
+
+_DEFAULT_PATH_PREFIX = "/api/v1"
+
+
+def list_collection_members(
+    *,
+    api_endpoint: str,
+    insecure: bool,
+    headers: dict[str, str],
+    collection_id: str,
+    path_prefix: str = _DEFAULT_PATH_PREFIX,
+    retry: RetryPolicy | None = None,
+) -> list[dict[str, Any]]:
+    """Lists the saved conversations belonging to a collection.
+
+    Returns the raw member dicts (``saved_id``, ``conversation_id``, ``name``,
+    ...) as decoded JSON for this first iteration.
+    """
+
+    cid = (collection_id or "").strip()
+    if cid == "":
+        raise ValidationError("sigil collection validation failed: collection_id is required")
+    url = _collection_members_url(api_endpoint, insecure, cid, path_prefix)
+    body = _request_json("GET", url, headers, None, retry, ExperimentTransportError, "collection members list")
+    return _as_member_list(body)
+
+
+def get_conversation(
+    *,
+    api_endpoint: str,
+    insecure: bool,
+    headers: dict[str, str],
+    conversation_id: str,
+    path_prefix: str = _DEFAULT_PATH_PREFIX,
+    retry: RetryPolicy | None = None,
+) -> dict[str, Any]:
+    """Fetches a single conversation with all of its generations.
+
+    Returns the raw conversation dict as decoded JSON for this first iteration.
+    """
+
+    cid = (conversation_id or "").strip()
+    if cid == "":
+        raise ValidationError("sigil conversation validation failed: conversation_id is required")
+    url = _conversation_url(api_endpoint, insecure, cid, path_prefix)
+    body = _request_json("GET", url, headers, None, retry, ExperimentTransportError, "conversation get")
+    return body if isinstance(body, dict) else {}
+
+
+# --------------------------------------------------------------------------- #
+# URL + parsing helpers
+# --------------------------------------------------------------------------- #
+
+
+def _as_member_list(body: Any) -> list[dict[str, Any]]:
+    """Normalizes the members response (a bare array or an items/members wrapper)."""
+
+    if isinstance(body, list):
+        raw = body
+    elif isinstance(body, dict):
+        raw = body.get("members") or body.get("items") or []
+    else:
+        raw = []
+    return [m for m in raw if isinstance(m, dict)]
+
+
+def _prefix(path_prefix: str) -> str:
+    return "/" + (path_prefix or _DEFAULT_PATH_PREFIX).strip().strip("/")
+
+
+def _collection_members_url(endpoint: str, insecure: bool, collection_id: str, path_prefix: str) -> str:
+    quoted = urllib_parse.quote(collection_id, safe="")
+    return f"{_base_url(endpoint, insecure)}{_prefix(path_prefix)}/eval/collections/{quoted}/members"
+
+
+def _conversation_url(endpoint: str, insecure: bool, conversation_id: str, path_prefix: str) -> str:
+    quoted = urllib_parse.quote(conversation_id, safe="")
+    return f"{_base_url(endpoint, insecure)}{_prefix(path_prefix)}/query/conversations/{quoted}"

--- a/python/sigil_sdk/experiment.py
+++ b/python/sigil_sdk/experiment.py
@@ -65,6 +65,21 @@ RESERVED_METADATA_KEYS = (
 
 UploadMode = Literal["continuous", "bulk", "manual"]
 
+# How to turn a saved conversation into a dataset item. ``user_prompt`` re-runs
+# the agent from the conversation's initial user prompt (implemented). ``golden``
+# will additionally keep the original answer as a reference for LLM-judge
+# scoring (reserved; not implemented yet).
+DatasetMode = Literal["user_prompt", "golden"]
+
+# Message roles as recorded on conversation generations (proto enum names plus
+# their lowercase forms, to be liberal in what we accept).
+_USER_ROLES = frozenset({"MESSAGE_ROLE_USER", "user", "USER"})
+_SYSTEM_ROLES = frozenset({"MESSAGE_ROLE_SYSTEM", "system", "SYSTEM"})
+
+# Tag prefix linking an experiment run back to the collection its dataset came
+# from. The plugin UI and `gcx` filter runs on this.
+COLLECTION_ID_TAG_PREFIX = "collectionId:"
+
 
 @dataclass(slots=True)
 class DatasetItem:
@@ -128,6 +143,141 @@ def stable_id(prefix: str, *parts: Any) -> str:
 # Target and scorer callable signatures (documented as type aliases).
 DatasetTarget = Callable[[DatasetItem, "ExperimentRun"], "TargetResult | None"]
 DatasetScorer = Callable[[DatasetItem, TargetResult], "Sequence[ScoreOutput] | None"]
+
+
+# --------------------------------------------------------------------------- #
+# Building a dataset from an existing Sigil collection
+# --------------------------------------------------------------------------- #
+
+
+def _message_text(message: dict[str, Any]) -> str:
+    """Concatenates the text parts of one conversation message."""
+
+    parts = message.get("parts")
+    if not isinstance(parts, list):
+        return ""
+    texts = [p.get("text", "") for p in parts if isinstance(p, dict) and isinstance(p.get("text"), str)]
+    return "".join(texts).strip()
+
+
+def _generation_sort_key(generation: dict[str, Any]) -> str:
+    """Sort key picking the chronologically earliest generation (ISO-8601 sorts lexically)."""
+
+    return str(generation.get("started_at") or generation.get("created_at") or "")
+
+
+def initial_user_prompt(conversation: dict[str, Any]) -> str:
+    """Returns the initial user prompt from a fetched conversation.
+
+    Looks at the chronologically earliest generation and returns the text of its
+    last user-role input message — i.e. the user turn that kicked the
+    conversation off, skipping any leading system prompt (some agents record the
+    system prompt as a user-role message, so we keep the *last* user message).
+    Falls back to the first non-system message, then to ``""`` when nothing
+    usable is present.
+    """
+
+    generations = conversation.get("generations")
+    if not isinstance(generations, list) or not generations:
+        return ""
+    earliest = min(generations, key=_generation_sort_key)
+    messages = earliest.get("input")
+    if not isinstance(messages, list):
+        return ""
+
+    user_texts = [
+        text
+        for m in messages
+        if isinstance(m, dict) and str(m.get("role") or "") in _USER_ROLES
+        for text in (_message_text(m),)
+        if text
+    ]
+    if user_texts:
+        return user_texts[-1]
+
+    for m in messages:
+        if isinstance(m, dict) and str(m.get("role") or "") not in _SYSTEM_ROLES:
+            text = _message_text(m)
+            if text:
+                return text
+    return ""
+
+
+def dataset_from_collection(
+    client: Client,
+    collection_id: str,
+    *,
+    mode: DatasetMode = "user_prompt",
+    limit: int | None = None,
+    skip_empty: bool = True,
+) -> list[DatasetItem]:
+    """Builds experiment :class:`DatasetItem`s from a Sigil collection.
+
+    Lists the collection's saved conversations, fetches each one, and turns it
+    into a dataset item keyed by its initial user prompt:
+
+    - ``mode="user_prompt"`` (default, implemented): ``input`` is the
+      conversation's initial user prompt, so the experiment target can re-run
+      the agent from scratch on that prompt and you score the fresh answer.
+      ``expected`` is left ``None``.
+    - ``mode="golden"`` (reserved, not yet implemented): will additionally
+      capture the original assistant answer as ``expected`` so it can be used as
+      a reference in an LLM-as-judge scorer. Raises :class:`NotImplementedError`
+      for now.
+
+    Each item carries ``collection_id``, ``conversation_id``, ``saved_id`` and a
+    ``task_id`` (defaulting to the saved/conversation id) in ``metadata`` so the
+    Sigil report groups scores cleanly. ``limit`` caps how many members are
+    pulled; ``skip_empty`` drops conversations with no recoverable user prompt.
+
+    Pair the result with :class:`ExperimentRunner` (passing the same
+    ``collection_id`` so the run links back to the collection)::
+
+        ds = dataset_from_collection(client, collection_id)
+        runner = ExperimentRunner(client=client, run_id=..., name=...,
+                                  collection_id=collection_id)
+        runner.run(ds, target, [scorer])
+    """
+
+    if mode == "golden":
+        raise NotImplementedError(
+            "sigil dataset: mode='golden' is not implemented yet; use mode='user_prompt' "
+            "(the original answer will later be exposed as DatasetItem.expected)"
+        )
+    if mode != "user_prompt":
+        raise ValueError(f"sigil dataset: unknown mode {mode!r}; expected 'user_prompt' or 'golden'")
+
+    cid = (collection_id or "").strip()
+    if cid == "":
+        raise ValueError("sigil dataset: collection_id is required")
+
+    members = client.list_collection_members(cid)
+    if limit is not None:
+        members = members[: max(limit, 0)]
+
+    items: list[DatasetItem] = []
+    for member in members:
+        conversation_id = str(member.get("conversation_id") or "").strip()
+        if conversation_id == "":
+            continue
+        saved_id = str(member.get("saved_id") or "").strip()
+        conversation = client.get_conversation(conversation_id)
+        prompt = initial_user_prompt(conversation)
+        if skip_empty and prompt == "":
+            continue
+        item_id = saved_id or conversation_id
+        metadata: dict[str, Any] = {
+            "collection_id": cid,
+            "conversation_id": conversation_id,
+            "saved_id": saved_id,
+            "task_id": item_id,
+            "source": "collection",
+        }
+        name = str(member.get("name") or "").strip()
+        if name:
+            metadata["saved_name"] = name
+        items.append(DatasetItem(id=item_id, input=prompt, metadata=metadata))
+    return items
 
 
 class ExperimentRun:
@@ -439,6 +589,7 @@ def experiment(
     agent_version: str = "",
     extra_tags: dict[str, str] | None = None,
     extra_metadata: dict[str, Any] | None = None,
+    collection_id: str = "",
 ) -> Iterator[ExperimentRun]:
     """Opens an external experiment run and finalizes it on exit.
 
@@ -450,16 +601,33 @@ def experiment(
 
     ``agent_name``/``agent_version`` and ``extra_tags``/``extra_metadata`` are
     applied to every generation recorded via :meth:`ExperimentRun.start_generation`.
+
+    When ``collection_id`` is set (e.g. the collection a
+    :func:`dataset_from_collection` dataset came from), the run is linked to that
+    collection and a ``collectionId:<id>`` tag is added so it can be filtered in
+    the Sigil UI / ``gcx``.
     """
 
+    cid = (collection_id or "").strip()
+    run_tags = list(tags or [])
+    if cid:
+        collection_tag = f"{COLLECTION_ID_TAG_PREFIX}{cid}"
+        if collection_tag not in run_tags:
+            run_tags.append(collection_tag)
     create_metadata = _run_metadata(metadata, dataset, candidate)
+    # Also stamp the collection id into metadata. The dedicated collection_id
+    # field and the collectionId tag are sent too, but some backends don't yet
+    # persist those columns — metadata is durable, so the link survives there.
+    if cid:
+        create_metadata.setdefault("collection_id", cid)
     client.create_experiment(
         CreateExperimentRequest(
             run_id=run_id,
             name=name,
             source="external",
             description=description,
-            tags=list(tags or []),
+            tags=run_tags,
+            collection_id=cid,
             metadata=create_metadata,
         )
     )
@@ -524,6 +692,7 @@ class ExperimentRunner:
         agent_version: str = "",
         extra_tags: dict[str, str] | None = None,
         extra_metadata: dict[str, Any] | None = None,
+        collection_id: str = "",
     ) -> None:
         self._client = client
         self._run_id = run_id
@@ -540,6 +709,7 @@ class ExperimentRunner:
         self._agent_version = agent_version
         self._extra_tags = dict(extra_tags or {})
         self._extra_metadata = dict(extra_metadata or {})
+        self._collection_id = collection_id
 
     def run(
         self,
@@ -564,6 +734,7 @@ class ExperimentRunner:
             agent_version=self._agent_version,
             extra_tags=self._extra_tags,
             extra_metadata=self._extra_metadata,
+            collection_id=self._collection_id,
         ) as run:
             for item in items:
                 # Assign one stable conversation id per item before running the

--- a/python/sigil_sdk/experiment.py
+++ b/python/sigil_sdk/experiment.py
@@ -163,7 +163,7 @@ def _message_text(message: dict[str, Any]) -> str:
 def _generation_sort_key(generation: dict[str, Any]) -> str:
     """Sort key picking the chronologically earliest generation (ISO-8601 sorts lexically)."""
 
-    return str(generation.get("started_at") or generation.get("created_at") or "")
+    return str(generation.get("started_at") or generation.get("created_at") or "~")
 
 
 def initial_user_prompt(conversation: dict[str, Any]) -> str:

--- a/python/skills/sigil-experiments/SKILL.md
+++ b/python/skills/sigil-experiments/SKILL.md
@@ -210,6 +210,40 @@ finally:
     client.shutdown()
 ```
 
+## Pattern 4 — Build a dataset from a Sigil collection
+
+Instead of hand-writing a dataset, pull one from an existing **collection** of
+saved conversations and re-run the agent from each conversation's *initial user
+prompt* (the "user-prompt kickoff"). `dataset_from_collection` lists the
+collection's members, fetches each conversation, and returns `DatasetItem`s
+keyed by the recovered prompt:
+
+```python
+from sigil_sdk import ExperimentRunner, dataset_from_collection
+
+collection_id = "0324f4c9-..."           # from `gcx aio11y collections list`
+dataset = dataset_from_collection(client, collection_id)  # -> list[DatasetItem]
+# item.input = initial user prompt; item.metadata has collection_id / conversation_id
+
+runner = ExperimentRunner(
+    client=client, run_id=run_id, name="collection replay",
+    collection_id=collection_id,         # links the run + adds a `collectionId:<id>` tag
+)
+runner.run(dataset, target, [my_scorer]) # target re-runs the agent on item.input
+```
+
+Notes:
+- `mode="user_prompt"` (default) sets `input` to the initial prompt and leaves
+  `expected=None`. `mode="golden"` (capture the original answer as a reference
+  for an LLM-judge) is reserved and raises `NotImplementedError` for now.
+- Passing `collection_id` to `ExperimentRunner`/`experiment(...)` sets the run's
+  `collection_id`, adds a `collectionId:<id>` tag, and stamps `collection_id`
+  into the run metadata (durable even where the tag/field columns aren't yet
+  persisted), so the run is discoverable from the collection.
+- Reading collections/conversations uses the protected eval control plane (same
+  `SIGIL_EVAL_*` config as experiments). `limit=` caps how many members are
+  pulled; `skip_empty=False` keeps conversations with no recoverable prompt.
+
 ## Rules / gotchas
 
 - Always record the agent's call through `run.start_generation(...)` (or call

--- a/python/tests/test_dataset_collection.py
+++ b/python/tests/test_dataset_collection.py
@@ -1,0 +1,223 @@
+"""Tests for building experiment datasets from Sigil collections."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from sigil_sdk import (
+    DatasetItem,
+    ExperimentRunner,
+    ExportScoresResponse,
+    TargetResult,
+    dataset_from_collection,
+    initial_user_prompt,
+)
+
+
+def _gen(role_texts: list[tuple[str, str]], *, started_at: str = "") -> dict[str, Any]:
+    """Builds a generation dict with the given (role, text) input messages."""
+
+    return {
+        "started_at": started_at,
+        "input": [{"role": role, "parts": [{"text": text}]} for role, text in role_texts],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# initial_user_prompt
+# --------------------------------------------------------------------------- #
+
+
+def test_initial_user_prompt_skips_system_recorded_as_user() -> None:
+    # The Sir Alex agent records its system prompt as a second USER message; the
+    # real prompt is the last user-role message.
+    conversation = {
+        "generations": [
+            _gen(
+                [
+                    ("MESSAGE_ROLE_USER", "You are Sir Alex, an FPL assistant..."),
+                    ("MESSAGE_ROLE_USER", "Who should I captain this week?"),
+                ]
+            )
+        ]
+    }
+    assert initial_user_prompt(conversation) == "Who should I captain this week?"
+
+
+def test_initial_user_prompt_handles_system_role() -> None:
+    conversation = {
+        "generations": [
+            _gen(
+                [
+                    ("MESSAGE_ROLE_SYSTEM", "system prompt"),
+                    ("MESSAGE_ROLE_USER", "Compare Salah and Palmer."),
+                ]
+            )
+        ]
+    }
+    assert initial_user_prompt(conversation) == "Compare Salah and Palmer."
+
+
+def test_initial_user_prompt_picks_earliest_generation() -> None:
+    conversation = {
+        "generations": [
+            _gen([("MESSAGE_ROLE_USER", "second turn")], started_at="2026-06-03T18:00:00Z"),
+            _gen([("MESSAGE_ROLE_USER", "first turn")], started_at="2026-06-03T17:00:00Z"),
+        ]
+    }
+    assert initial_user_prompt(conversation) == "first turn"
+
+
+def test_initial_user_prompt_empty_when_no_user_message() -> None:
+    assert initial_user_prompt({"generations": []}) == ""
+    assert initial_user_prompt({}) == ""
+    assert initial_user_prompt({"generations": [_gen([("MESSAGE_ROLE_SYSTEM", "only system")])]}) == ""
+
+
+# --------------------------------------------------------------------------- #
+# dataset_from_collection
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class _FakeReadClient:
+    """Serves canned collection members and conversations."""
+
+    members: list[dict[str, Any]] = field(default_factory=list)
+    conversations: dict[str, dict[str, Any]] = field(default_factory=dict)
+    member_calls: list[str] = field(default_factory=list)
+    conversation_calls: list[str] = field(default_factory=list)
+
+    def list_collection_members(self, collection_id: str) -> list[dict[str, Any]]:
+        self.member_calls.append(collection_id)
+        return list(self.members)
+
+    def get_conversation(self, conversation_id: str) -> dict[str, Any]:
+        self.conversation_calls.append(conversation_id)
+        return self.conversations.get(conversation_id, {})
+
+    # Unused control-plane surface for the runner test below.
+    created: list[Any] = field(default_factory=list)
+
+    def create_experiment(self, request):
+        self.created.append(request)
+        return request
+
+    def flush(self):
+        return
+
+    def export_scores(self, scores):
+        return ExportScoresResponse(results=[])
+
+    def complete_experiment(self, run_id, status, *, score_count=None, error=None, metadata=None):
+        return
+
+    def cancel_experiment(self, run_id):
+        return
+
+    def experiment_url(self, run_id):
+        return f"https://sigil.example/exp/{run_id}"
+
+
+def test_dataset_from_collection_builds_items() -> None:
+    client = _FakeReadClient(
+        members=[
+            {"saved_id": "saved-conv-1", "conversation_id": "conv-1", "name": "captain"},
+            {"saved_id": "saved-conv-2", "conversation_id": "conv-2", "name": "compare"},
+        ],
+        conversations={
+            "conv-1": {"generations": [_gen([("MESSAGE_ROLE_USER", "Captain pick?")])]},
+            "conv-2": {"generations": [_gen([("MESSAGE_ROLE_USER", "Salah or Palmer?")])]},
+        },
+    )
+
+    items = dataset_from_collection(client, "coll-123")
+
+    assert [i.id for i in items] == ["saved-conv-1", "saved-conv-2"]
+    assert [i.input for i in items] == ["Captain pick?", "Salah or Palmer?"]
+    assert items[0].expected is None
+    assert items[0].metadata == {
+        "collection_id": "coll-123",
+        "conversation_id": "conv-1",
+        "saved_id": "saved-conv-1",
+        "task_id": "saved-conv-1",
+        "source": "collection",
+        "saved_name": "captain",
+    }
+    assert client.member_calls == ["coll-123"]
+    assert client.conversation_calls == ["conv-1", "conv-2"]
+
+
+def test_dataset_from_collection_skips_empty_prompts() -> None:
+    client = _FakeReadClient(
+        members=[
+            {"saved_id": "s1", "conversation_id": "conv-1"},
+            {"saved_id": "s2", "conversation_id": "conv-2"},
+        ],
+        conversations={
+            "conv-1": {"generations": [_gen([("MESSAGE_ROLE_SYSTEM", "no user msg")])]},
+            "conv-2": {"generations": [_gen([("MESSAGE_ROLE_USER", "real prompt")])]},
+        },
+    )
+
+    items = dataset_from_collection(client, "coll-123")
+    assert [i.id for i in items] == ["s2"]
+
+    # skip_empty=False keeps the empty-prompt item.
+    items_all = dataset_from_collection(client, "coll-123", skip_empty=False)
+    assert [i.id for i in items_all] == ["s1", "s2"]
+
+
+def test_dataset_from_collection_respects_limit() -> None:
+    client = _FakeReadClient(
+        members=[{"saved_id": f"s{i}", "conversation_id": f"conv-{i}"} for i in range(5)],
+        conversations={f"conv-{i}": {"generations": [_gen([("MESSAGE_ROLE_USER", f"q{i}")])]} for i in range(5)},
+    )
+    items = dataset_from_collection(client, "coll-123", limit=2)
+    assert [i.id for i in items] == ["s0", "s1"]
+    # Only fetched the conversations we kept.
+    assert client.conversation_calls == ["conv-0", "conv-1"]
+
+
+def test_dataset_from_collection_golden_not_implemented() -> None:
+    client = _FakeReadClient()
+    with pytest.raises(NotImplementedError):
+        dataset_from_collection(client, "coll-123", mode="golden")
+
+
+def test_dataset_from_collection_requires_collection_id() -> None:
+    with pytest.raises(ValueError):
+        dataset_from_collection(_FakeReadClient(), "  ")
+
+
+# --------------------------------------------------------------------------- #
+# ExperimentRunner collection linkage
+# --------------------------------------------------------------------------- #
+
+
+def test_runner_adds_collection_id_tag_and_links_run() -> None:
+    client = _FakeReadClient()
+    runner = ExperimentRunner(
+        client=client,
+        run_id="run-1",
+        name="collection run",
+        tags=["ci"],
+        collection_id="coll-123",
+        fetch_report=False,
+        print_url=False,
+    )
+
+    def target(item: DatasetItem, run) -> TargetResult:
+        return TargetResult(output="ok")
+
+    runner.run([DatasetItem(id="s1", input="hi")], target, [])
+
+    assert len(client.created) == 1
+    request = client.created[0]
+    assert request.collection_id == "coll-123"
+    assert "collectionId:coll-123" in request.tags
+    assert "ci" in request.tags
+    # Durable fallback for backends that don't persist the tag/collection_id columns.
+    assert request.metadata.get("collection_id") == "coll-123"


### PR DESCRIPTION
## Notes

Added an SDK helper for using a `Collection` as a source of input prompts for running an Experiment. The flow goes as follows:
  1. Pull a dataset straight from a Sigil collection of saved conversations
     (``dataset_from_collection``). Each item's ``input`` is the *initial user
     prompt* of that conversation.
  2. Re-run the agent from scratch on that prompt (the "user-prompt kickoff").
  3. Grade the fresh answer with a pure numeric LLM-judge score and publish.

More updates to come with adding ground truth annotations to be used in grading. For now, this just allows initial kick off prompts to be generated from a collection.

## Testing
https://github.com/jgordley/sir-alex-fpl-agent/blob/main/experiment_from_collection.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK APIs and helpers with unit tests; no changes to generation ingest or auth beyond existing eval control-plane usage.
> 
> **Overview**
> Adds **collection-backed experiment datasets** so saved conversations can drive offline eval without hand-authored `DatasetItem` lists.
> 
> New read APIs on `Client` (`list_collection_members`, `get_conversation`) call the eval control plane via a thin `conversations` module. **`dataset_from_collection`** walks a collection, fetches each conversation, and sets **`item.input`** to the recovered **initial user prompt** (`initial_user_prompt`, with heuristics for system-as-user and earliest generation). Default **`mode="user_prompt"`** leaves `expected` unset; **`mode="golden"`** is reserved and raises `NotImplementedError`.
> 
> **`experiment`** / **`ExperimentRunner`** accept optional **`collection_id`**, which sets the run’s `collection_id`, adds a **`collectionId:<id>`** tag, and stamps metadata for UI/`gcx` discovery. Public exports and the sigil-experiments skill document Pattern 4; tests cover prompt extraction, dataset building, and collection linkage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a2585b3e9f54d03dfb6db35e36f48edeb5839fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->