### PR TITLE
fix(plugins/sigil): fix compilation on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,18 @@ jobs:
       - name: Test
         run: cd ${{ matrix.module }} && GOWORK=off go test ./...
 
+      - name: Build Sigil CLI
+        if: matrix.module == 'plugins/sigil'
+        env:
+          GOWORK: "off"
+        run: |
+          cd ${{ matrix.module }}
+          for target in windows/amd64 windows/arm64 darwin/amd64 darwin/arm64; do
+            echo "::group::build $target"
+            GOOS="${target%/*}" GOARCH="${target#*/}" go build ./...
+            echo "::endgroup::"
+          done
+
   go:
     name: Go SDK
     runs-on: ubuntu-latest

--- a/plugins/sigil/internal/local/daemon_unix.go
+++ b/plugins/sigil/internal/local/daemon_unix.go
@@ -1,0 +1,131 @@
+//go:build !windows
+
+package local
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type daemonLock struct {
+	f *os.File
+}
+
+func acquireDaemonLock(dir string) (*daemonLock, error) {
+	path := filepath.Join(dir, LockFile)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open lockfile: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("flock: %w", err)
+	}
+	return &daemonLock{f: f}, nil
+}
+
+func (l *daemonLock) release() {
+	_ = syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+	_ = l.f.Close()
+}
+
+// startDaemon launches `sigil local serve` as a detached child process.
+// The parent waits for the child to write its status file, then returns
+// the recorded endpoint. The child detaches by setting its own session
+// (SysProcAttr.Setsid) so it survives the parent exiting.
+func startDaemon(ctx context.Context, dir string, logger *log.Logger) (*Status, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("mkdir: %w", err)
+	}
+	bin, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("resolve sigil binary: %w", err)
+	}
+
+	logPath := filepath.Join(dir, "server.log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open log: %w", err)
+	}
+
+	cmd := exec.Command(bin, "local", "serve")
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	// Inherit env so SIGIL_DEBUG and XDG_* flow through.
+	cmd.Env = os.Environ()
+	if err := cmd.Start(); err != nil {
+		_ = logFile.Close()
+		return nil, fmt.Errorf("start daemon: %w", err)
+	}
+	// Close the log handle in this process; the child has its own copy.
+	_ = logFile.Close()
+
+	// Wait up to ~5s for the child to write its status file.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			_ = cmd.Process.Kill()
+			return nil, ctx.Err()
+		}
+		if s, err := IsRunning(dir); err == nil && s != nil {
+			if logger != nil {
+				logger.Printf("local: daemon started pid=%d port=%d", s.PID, s.Port)
+			}
+			return s, nil
+		}
+		// Check the child exited prematurely so we don't block forever.
+		var ws syscall.WaitStatus
+		pid, _ := syscall.Wait4(cmd.Process.Pid, &ws, syscall.WNOHANG, nil)
+		if pid == cmd.Process.Pid {
+			body, _ := os.ReadFile(logPath)
+			return nil, fmt.Errorf("daemon exited prematurely: %s", strings.TrimSpace(string(body)))
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	_ = cmd.Process.Kill()
+	return nil, fmt.Errorf("daemon did not become ready within 5s")
+}
+
+// pidAlive reports whether a process with the given PID exists by
+// sending signal 0 (no-op probe).
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(syscall.Signal(0))
+	return err == nil
+}
+
+// terminateProcess sends SIGTERM to pid for a graceful shutdown.
+func terminateProcess(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return proc.Signal(syscall.SIGTERM)
+}
+
+func processCommandLine(pid int) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ps", "-p", strconv.Itoa(pid), "-o", "command=")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/plugins/sigil/internal/local/daemon_windows.go
+++ b/plugins/sigil/internal/local/daemon_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package local
+
+import (
+	"context"
+	"errors"
+	"log"
+)
+
+// errLocalUnsupported is returned by every daemon entry point on Windows.
+// The local receiver relies on Unix process semantics (flock, Setsid,
+// signal-based liveness and termination) that have no portable equivalent
+// here, so `--local` capture mode is unavailable. Default Cloud mode never
+// touches this code path.
+var errLocalUnsupported = errors.New("sigil local receiver is not supported on Windows")
+
+type daemonLock struct{}
+
+func acquireDaemonLock(dir string) (*daemonLock, error) { return nil, errLocalUnsupported }
+
+func (l *daemonLock) release() {}
+
+func startDaemon(ctx context.Context, dir string, logger *log.Logger) (*Status, error) {
+	return nil, errLocalUnsupported
+}
+
+func pidAlive(pid int) bool { return false }
+
+func terminateProcess(pid int) error { return errLocalUnsupported }
+
+func processCommandLine(pid int) (string, error) { return "", errLocalUnsupported }

--- a/plugins/sigil/internal/local/manager.go
+++ b/plugins/sigil/internal/local/manager.go
@@ -10,9 +10,7 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -162,28 +160,6 @@ func EnsureRunning(ctx context.Context, dir string, logger *log.Logger) (*Status
 	return startDaemonFn(ctx, dir, logger)
 }
 
-type daemonLock struct {
-	f *os.File
-}
-
-func acquireDaemonLock(dir string) (*daemonLock, error) {
-	path := filepath.Join(dir, LockFile)
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
-	if err != nil {
-		return nil, fmt.Errorf("open lockfile: %w", err)
-	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
-		_ = f.Close()
-		return nil, fmt.Errorf("flock: %w", err)
-	}
-	return &daemonLock{f: f}, nil
-}
-
-func (l *daemonLock) release() {
-	_ = syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
-	_ = l.f.Close()
-}
-
 // startDaemonFn is a test seam — production points at startDaemon,
 // tests can swap in an in-process server.
 var startDaemonFn = startDaemon
@@ -229,11 +205,7 @@ func Stop(dir string) (bool, error) {
 		_ = RemoveStatus(dir)
 		return false, nil
 	}
-	proc, err := os.FindProcess(s.PID)
-	if err != nil {
-		return false, err
-	}
-	if err := proc.Signal(syscall.SIGTERM); err != nil {
+	if err := terminateProcess(s.PID); err != nil {
 		return false, err
 	}
 	// Poll for the daemon to exit. We don't own the child, so we cannot
@@ -308,78 +280,6 @@ func Serve(ctx context.Context, dir string, port int, logger *log.Logger) error 
 	}
 }
 
-// startDaemon launches `sigil local serve` as a detached child process.
-// The parent waits for the child to write its status file, then returns
-// the recorded endpoint. The child detaches by setting its own session
-// (SysProcAttr.Setsid) so it survives the parent exiting.
-func startDaemon(ctx context.Context, dir string, logger *log.Logger) (*Status, error) {
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return nil, fmt.Errorf("mkdir: %w", err)
-	}
-	bin, err := os.Executable()
-	if err != nil {
-		return nil, fmt.Errorf("resolve sigil binary: %w", err)
-	}
-
-	logPath := filepath.Join(dir, "server.log")
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
-	if err != nil {
-		return nil, fmt.Errorf("open log: %w", err)
-	}
-
-	cmd := exec.Command(bin, "local", "serve")
-	cmd.Stdout = logFile
-	cmd.Stderr = logFile
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-	// Inherit env so SIGIL_DEBUG and XDG_* flow through.
-	cmd.Env = os.Environ()
-	if err := cmd.Start(); err != nil {
-		_ = logFile.Close()
-		return nil, fmt.Errorf("start daemon: %w", err)
-	}
-	// Close the log handle in this process; the child has its own copy.
-	_ = logFile.Close()
-
-	// Wait up to ~5s for the child to write its status file.
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if ctx.Err() != nil {
-			_ = cmd.Process.Kill()
-			return nil, ctx.Err()
-		}
-		if s, err := IsRunning(dir); err == nil && s != nil {
-			if logger != nil {
-				logger.Printf("local: daemon started pid=%d port=%d", s.PID, s.Port)
-			}
-			return s, nil
-		}
-		// Check the child exited prematurely so we don't block forever.
-		var ws syscall.WaitStatus
-		pid, _ := syscall.Wait4(cmd.Process.Pid, &ws, syscall.WNOHANG, nil)
-		if pid == cmd.Process.Pid {
-			body, _ := os.ReadFile(logPath)
-			return nil, fmt.Errorf("daemon exited prematurely: %s", strings.TrimSpace(string(body)))
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	_ = cmd.Process.Kill()
-	return nil, fmt.Errorf("daemon did not become ready within 5s")
-}
-
-// pidAlive reports whether a process with the given PID exists by
-// sending signal 0 (no-op probe).
-func pidAlive(pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	err = proc.Signal(syscall.Signal(0))
-	return err == nil
-}
-
 func processLooksLikeDaemon(pid int) (bool, error) {
 	cmdline, err := processCommandLineFn(pid)
 	if err != nil {
@@ -395,18 +295,6 @@ func processLooksLikeDaemon(pid int) (bool, error) {
 		return false, nil
 	}
 	return strings.HasPrefix(filepath.Base(exe), "sigil"), nil
-}
-
-func processCommandLine(pid int) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "ps", "-p", strconv.Itoa(pid), "-o", "command=")
-	out, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
 }
 
 // endpointAlive returns true when GET <endpoint>/healthz responds within

--- a/plugins/sigil/internal/local/manager_test.go
+++ b/plugins/sigil/internal/local/manager_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package local
 
 import (


### PR DESCRIPTION
The local receiver depends on Unix process semantics (flock, Setsid, signal-based liveness/termination, ps) that have no portable Windows equivalent, so plugins/sigil failed to cross-compile for Windows.

Split the daemon internals behind build tags: daemon_unix.go keeps the real implementation unchanged, daemon_windows.go stubs every entry point to return a "not supported on Windows".

Also added a github workflow step to test builds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor plus explicit Windows unsupported path; Unix local receiver behavior is preserved and CI adds cross-compile coverage without touching auth or cloud capture.
> 
> **Overview**
> **Fixes `plugins/sigil` failing to build on Windows** by moving Unix-only local daemon logic out of `manager.go` into build-tagged files, while keeping shared manager behavior unchanged on Unix.
> 
> **Platform split:** `daemon_unix.go` (`!windows`) holds the existing flock/SetSid/`ps`-based start, lock, liveness, and shutdown helpers. `daemon_windows.go` stubs those entry points with a clear **“local receiver not supported on Windows”** error so `--local` fails predictably instead of breaking compilation. `Stop` now goes through `terminateProcess` instead of inlining Unix signals.
> 
> **CI:** The Go module job for `plugins/sigil` **cross-builds** `windows/amd64`, `windows/arm64`, `darwin/amd64`, and `darwin/arm64`. Local manager tests are gated with `//go:build !windows`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b2b739521e12f891f51beeda08bd2f9ad181782. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->