### PR TITLE
feat(plugins/pi): apply transform/redact guards

### DIFF
--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -78,15 +78,28 @@ Before any generation leaves the process, the SDK scrubs known token formats, PE
 
 ## Guards
 
-Guards block tool calls before they execute (e.g. refuse a `bash` invocation matching a deny rule). They're off by default:
+Guards do two things when enabled: block tool calls that match a deny rule, and apply Transform rules to redact sensitive content. They're off by default:
 
 ```sh
 SIGIL_GUARDS_ENABLED=true sigil pi
 ```
 
-By default, transport errors and timeouts let the tool through. Set `SIGIL_GUARDS_FAIL_OPEN=false` to block on errors instead. Raise or lower `SIGIL_GUARDS_TIMEOUT_MS` (default `1500`) to trade latency against tolerance for slow evaluators.
+By default, transport errors and timeouts let the request through. Set `SIGIL_GUARDS_FAIL_OPEN=false` to block tool calls on errors instead. Raise or lower `SIGIL_GUARDS_TIMEOUT_MS` (default `1500`) to trade latency against tolerance for slow evaluators.
 
 The same three variables are honored by the [Claude Code plugin](../claude-code/README.md); both plugins read them from `~/.config/sigil/config.env`.
+
+### Transform guards (redaction)
+
+When guards are enabled, pi also applies [Transform guards](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/guides/guards/) — regex redaction rules you configure in Grafana — in two places:
+
+- **Preflight (message redaction).** Before each model call, the outgoing conversation is sent to Sigil; redacted text replaces the original, so the placeholder (e.g. `[REDACTED]`) reaches the model instead of the secret.
+- **Postflight (tool-argument redaction).** Before a tool runs, its arguments are sent to Sigil; if a Transform rule matches, the redacted arguments replace what the tool receives.
+
+Limits:
+
+- Each guarded model call adds one synchronous hook round-trip (`SIGIL_GUARDS_TIMEOUT_MS`, default `1500`). Transform redaction always fails open: on a transport error or timeout the original messages or tool arguments pass through unchanged.
+- A preflight deny verdict cannot stop the model call, only the transform output is applied. Enforced blocking happens at the tool-call (postflight) level.
+- Redaction rewrites text content only. `thinking` blocks on assistant messages are left unchanged so multi-turn continuity is preserved.
 
 ## All options
 

--- a/plugins/pi/src/client.ts
+++ b/plugins/pi/src/client.ts
@@ -56,6 +56,12 @@ export function createSigilClient(
       api: { endpoint: config.endpoint },
       hooks: {
         enabled: config.guards.enabled,
+        // The pi plugin's default hook evaluations are postflight (tool-arg
+        // redaction and deny). The preflight `context` path passes its own
+        // `phases: ["preflight"]` override to `evaluateHook`, which fully
+        // replaces this list for that call (see `SigilClient.evaluateHook`
+        // — `{ ...this.config.hooks, ...override }`), so preflight does not
+        // need to be listed here.
         phases: ["postflight"],
         timeoutMs: config.guards.timeoutMs,
         failOpen: config.guards.failOpen,

--- a/plugins/pi/src/golden.test.ts
+++ b/plugins/pi/src/golden.test.ts
@@ -22,7 +22,7 @@ import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import registerExtension from "./index.js";
-import { resetSigilDotenvStateForTests } from "./sigilDotenv.js";
+import { restoreEnv, snapshotAndClearTestEnv } from "./testEnv.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const GOLDEN_PATH = join(
@@ -114,50 +114,6 @@ function closeServer(server: Server): Promise<void> {
   return new Promise((resolve, reject) => {
     server.close((err) => (err ? reject(err) : resolve()));
   });
-}
-
-function snapshotAndClearTestEnv(): Record<string, string | undefined> {
-  const keys = new Set<string>(["HOME", "USERPROFILE", "XDG_CONFIG_HOME"]);
-  for (const key of Object.keys(process.env)) {
-    if (
-      key.startsWith("SIGIL_") ||
-      key.startsWith("SIGIL_PI_") ||
-      key.startsWith("OTEL_")
-    ) {
-      keys.add(key);
-    }
-  }
-
-  const saved: Record<string, string | undefined> = {};
-  for (const key of keys) {
-    saved[key] = process.env[key];
-    delete process.env[key];
-  }
-  resetSigilDotenvStateForTests();
-  return saved;
-}
-
-function restoreEnv(saved: Record<string, string | undefined>): void {
-  for (const key of Object.keys(process.env)) {
-    if (
-      key === "HOME" ||
-      key === "USERPROFILE" ||
-      key === "XDG_CONFIG_HOME" ||
-      key.startsWith("SIGIL_") ||
-      key.startsWith("SIGIL_PI_") ||
-      key.startsWith("OTEL_")
-    ) {
-      delete process.env[key];
-    }
-  }
-  for (const [key, value] of Object.entries(saved)) {
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
-  }
-  resetSigilDotenvStateForTests();
 }
 
 // piTurnFixture returns the message payloads used by the golden test:

--- a/plugins/pi/src/guard.test.ts
+++ b/plugins/pi/src/guard.test.ts
@@ -1,10 +1,36 @@
 import type {
   HookEvaluateRequest,
   HookEvaluateResponse,
+  HookInput,
+  Message,
   SigilClient,
 } from "@grafana/sigil-sdk-js";
 import { describe, expect, it, vi } from "vitest";
-import { type GuardArgs, runToolCallGuard } from "./guard.js";
+import {
+  type GuardArgs,
+  type GuardBlockResult,
+  type GuardResult,
+  type GuardTransformResult,
+  type PreflightTransformArgs,
+  runPreflightTransform,
+  runToolCallGuard,
+} from "./guard.js";
+
+function expectBlock(result: GuardResult): asserts result is GuardBlockResult {
+  if (!result || !("block" in result)) {
+    throw new Error(`expected a block result, got ${JSON.stringify(result)}`);
+  }
+}
+
+function expectTransform(
+  result: GuardResult,
+): asserts result is GuardTransformResult {
+  if (!result || !("transform" in result)) {
+    throw new Error(
+      `expected a transform result, got ${JSON.stringify(result)}`,
+    );
+  }
+}
 
 function makeClient(
   evaluateHook: (
@@ -60,11 +86,12 @@ describe("runToolCallGuard", () => {
     }));
 
     const result = await runToolCallGuard(makeArgs({ client }));
-    expect(result?.block).toBe(true);
-    expect(result?.reason).toContain("blocked rm -rf");
-    expect(result?.reason).toContain("A Grafana AI Observability policy");
-    expect(result?.reason).toContain('"bash"');
-    expect(result?.reason).toContain("Stop and tell the user");
+    expectBlock(result);
+    expect(result.block).toBe(true);
+    expect(result.reason).toContain("blocked rm -rf");
+    expect(result.reason).toContain("A Grafana AI Observability policy");
+    expect(result.reason).toContain('"bash"');
+    expect(result.reason).toContain("Stop and tell the user");
   });
 
   it("omits the Reason clause when the deny reason is empty", async () => {
@@ -75,11 +102,12 @@ describe("runToolCallGuard", () => {
     }));
 
     const result = await runToolCallGuard(makeArgs({ client }));
-    expect(result?.block).toBe(true);
-    expect(result?.reason).toContain("A Grafana AI Observability policy");
-    expect(result?.reason).toContain('"bash"');
-    expect(result?.reason).not.toContain("Reason:");
-    expect(result?.reason).toContain("Stop and tell the user");
+    expectBlock(result);
+    expect(result.block).toBe(true);
+    expect(result.reason).toContain("A Grafana AI Observability policy");
+    expect(result.reason).toContain('"bash"');
+    expect(result.reason).not.toContain("Reason:");
+    expect(result.reason).toContain("Stop and tell the user");
   });
 
   it("returns undefined and logs a warning on transport errors when failOpen", async () => {
@@ -123,12 +151,13 @@ describe("runToolCallGuard", () => {
     const result = await runToolCallGuard(
       makeArgs({ client, failOpen: false, logger: { warn } }),
     );
-    expect(result?.block).toBe(true);
-    expect(result?.reason).toContain("could not evaluate");
-    expect(result?.reason).toContain("safety measure");
-    expect(result?.reason).toContain('"bash"');
-    expect(result?.reason).toContain("network down");
-    expect(result?.reason).not.toContain(
+    expectBlock(result);
+    expect(result.block).toBe(true);
+    expect(result.reason).toContain("could not evaluate");
+    expect(result.reason).toContain("safety measure");
+    expect(result.reason).toContain('"bash"');
+    expect(result.reason).toContain("network down");
+    expect(result.reason).not.toContain(
       "A Grafana AI Observability policy blocked",
     );
     expect(warn).toHaveBeenCalledWith(
@@ -172,5 +201,250 @@ describe("runToolCallGuard", () => {
       inputJSON: '{"command":"ls"}',
     });
     expect(override).toEqual({ enabled: true });
+  });
+
+  it("returns a transform result when the server emits redacted tool_call args", async () => {
+    const { client } = makeClient(async () => ({
+      action: "allow",
+      evaluations: [],
+      transformedInput: {
+        output: [
+          {
+            role: "assistant",
+            parts: [
+              {
+                type: "tool_call",
+                toolCall: {
+                  id: "c1",
+                  name: "bash",
+                  inputJSON: '{"command":"echo [REDACTED_KEY]"}',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    }));
+
+    const result = await runToolCallGuard(
+      makeArgs({
+        client,
+        toolCallId: "c1",
+        toolName: "bash",
+        input: { command: "echo sk-real-secret" },
+      }),
+    );
+    expectTransform(result);
+    expect(result.transform).toEqual({
+      command: "echo [REDACTED_KEY]",
+    });
+  });
+
+  it("ignores transformed_input that targets a different toolCallId", async () => {
+    const { client } = makeClient(async () => ({
+      action: "allow",
+      evaluations: [],
+      transformedInput: {
+        output: [
+          {
+            role: "assistant",
+            parts: [
+              {
+                type: "tool_call",
+                toolCall: {
+                  id: "different-call-id",
+                  name: "bash",
+                  inputJSON: '{"command":"echo X"}',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    }));
+
+    // No matching tool_call id means there is simply no redaction for this
+    // call, so it must stay silent (no warning).
+    const warn = vi.fn();
+    const result = await runToolCallGuard(
+      makeArgs({
+        client,
+        toolCallId: "c1",
+        toolName: "bash",
+        logger: { warn },
+      }),
+    );
+    expect(result).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("logs and drops a transform whose inputJSON cannot be parsed", async () => {
+    const { client } = makeClient(async () => ({
+      action: "allow",
+      evaluations: [],
+      transformedInput: {
+        output: [
+          {
+            role: "assistant",
+            parts: [
+              {
+                type: "tool_call",
+                toolCall: {
+                  id: "c1",
+                  name: "bash",
+                  inputJSON: "not valid json",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    }));
+
+    const warn = vi.fn();
+    const result = await runToolCallGuard(
+      makeArgs({
+        client,
+        toolCallId: "c1",
+        toolName: "bash",
+        logger: { warn },
+      }),
+    );
+    expect(result).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("invalid JSON arguments"),
+    );
+  });
+
+  it("prefers deny over transform when both are present", async () => {
+    const { client } = makeClient(async () => ({
+      action: "deny",
+      reason: "blocked",
+      evaluations: [],
+      transformedInput: {
+        output: [
+          {
+            role: "assistant",
+            parts: [
+              {
+                type: "tool_call",
+                toolCall: {
+                  id: "c1",
+                  name: "bash",
+                  inputJSON: '{"command":"echo redacted"}',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    }));
+
+    const result = await runToolCallGuard(
+      makeArgs({ client, toolCallId: "c1", toolName: "bash" }),
+    );
+    expectBlock(result);
+  });
+});
+
+function makePreflightArgs(
+  overrides?: Partial<PreflightTransformArgs>,
+): PreflightTransformArgs {
+  return {
+    client: {} as SigilClient,
+    agentName: "pi",
+    agentVersion: "1.0.0",
+    model: { provider: "anthropic", name: "claude-sonnet-4" },
+    messages: [{ role: "user", parts: [{ type: "text", text: "hi" }] }],
+    ...overrides,
+  };
+}
+
+describe("runPreflightTransform", () => {
+  it("sends a preflight request with phases override", async () => {
+    const { client, calls } = makeClient(async () => ({
+      action: "allow",
+      evaluations: [],
+    }));
+
+    await runPreflightTransform(makePreflightArgs({ client }));
+
+    expect(calls).toHaveLength(1);
+    const { req, override } = calls[0]!;
+    expect(req.phase).toBe("preflight");
+    expect(req.context).toEqual({
+      agentName: "pi",
+      agentVersion: "1.0.0",
+      model: { provider: "anthropic", name: "claude-sonnet-4" },
+    });
+    expect((req.input as HookInput).messages).toEqual([
+      { role: "user", parts: [{ type: "text", text: "hi" }] },
+    ]);
+    expect(override).toEqual({ enabled: true, phases: ["preflight"] });
+  });
+
+  it("returns the redacted messages from transformedInput", async () => {
+    const redacted: Message[] = [
+      { role: "user", parts: [{ type: "text", text: "hi [REDACTED]" }] },
+    ];
+    const { client } = makeClient(async () => ({
+      action: "allow",
+      evaluations: [],
+      transformedInput: { messages: redacted },
+    }));
+
+    const result = await runPreflightTransform(makePreflightArgs({ client }));
+    expect(result).toEqual({ messages: redacted });
+  });
+
+  it("returns undefined when the server does not emit transformedInput", async () => {
+    const { client } = makeClient(async () => ({
+      action: "allow",
+      evaluations: [],
+    }));
+
+    const result = await runPreflightTransform(makePreflightArgs({ client }));
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when the server returns an empty messages list", async () => {
+    const { client } = makeClient(async () => ({
+      action: "allow",
+      evaluations: [],
+      transformedInput: { messages: [] },
+    }));
+
+    const result = await runPreflightTransform(makePreflightArgs({ client }));
+    expect(result).toBeUndefined();
+  });
+
+  it("fails open on transport errors, logging a warning", async () => {
+    const { client } = makeClient(async () => {
+      throw new Error("network down");
+    });
+    const warn = vi.fn();
+
+    const result = await runPreflightTransform(
+      makePreflightArgs({ client, logger: { warn } }),
+    );
+    expect(result).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("preflight transform eval failed"),
+    );
+  });
+
+  it("surfaces a preflight deny without a transform as no-op (cannot block via context)", async () => {
+    // The pi `context` event has no `block` field, so a preflight deny
+    // verdict cannot be enforced at this seam. Without transformedInput
+    // there is nothing to apply, so we surface no transform and let the
+    // original messages flow through.
+    const { client } = makeClient(async () => ({
+      action: "deny",
+      reason: "preflight deny",
+      evaluations: [],
+    }));
+
+    const result = await runPreflightTransform(makePreflightArgs({ client }));
+    expect(result).toBeUndefined();
   });
 });

--- a/plugins/pi/src/guard.ts
+++ b/plugins/pi/src/guard.ts
@@ -1,4 +1,8 @@
-import type { HookEvaluateRequest, SigilClient } from "@grafana/sigil-sdk-js";
+import type {
+  HookEvaluateRequest,
+  Message,
+  SigilClient,
+} from "@grafana/sigil-sdk-js";
 
 export interface GuardArgs {
   client: SigilClient;
@@ -13,6 +17,10 @@ export interface GuardArgs {
 }
 
 export type GuardBlockResult = { block: true; reason: string };
+
+export type GuardTransformResult = { transform: Record<string, unknown> };
+
+export type GuardResult = GuardBlockResult | GuardTransformResult | undefined;
 
 /**
  * Instructs the model how to react to a guard deny verdict, so the reason is
@@ -63,6 +71,59 @@ function formatEvalFailure(
   return `${msg}\n\n${GUARD_BEHAVIOR_HINT}`;
 }
 
+export interface PreflightTransformArgs {
+  client: SigilClient;
+  agentName: string;
+  agentVersion?: string;
+  model: { provider: string; name: string };
+  messages: Message[];
+  logger?: { warn: (msg: string) => void };
+}
+
+export type PreflightTransformResult = { messages: Message[] } | undefined;
+
+/**
+ * Evaluates the Sigil preflight hook against the outgoing conversation and
+ * returns the redacted messages from `transformedInput.messages`, or
+ * `undefined` when no usable transform was applied or evaluation failed.
+ *
+ * Always fails open: pi's `ContextEventResult` has no `block` field, so a
+ * preflight deny cannot be enforced at this seam, and any eval error or
+ * timeout forwards the original messages. `SIGIL_GUARDS_FAIL_OPEN` only
+ * governs the postflight tool-call block decision, so it has no effect here.
+ */
+export async function runPreflightTransform(
+  args: PreflightTransformArgs,
+): Promise<PreflightTransformResult> {
+  try {
+    const req: HookEvaluateRequest = {
+      phase: "preflight",
+      context: {
+        agentName: args.agentName,
+        agentVersion: args.agentVersion,
+        model: args.model,
+      },
+      input: {
+        messages: args.messages,
+      },
+    };
+
+    const resp = await args.client.evaluateHook(req, {
+      enabled: true,
+      phases: ["preflight"],
+    });
+
+    const transformed = resp.transformedInput?.messages;
+    if (!transformed || transformed.length === 0) {
+      return undefined;
+    }
+    return { messages: transformed };
+  } catch (err) {
+    args.logger?.warn(`preflight transform eval failed: ${err}`);
+    return undefined;
+  }
+}
+
 /**
  * Evaluates the Sigil postflight hook for a tool call. Returns a block result
  * when the server denies the call. On transport/timeout/serialization errors,
@@ -73,9 +134,7 @@ function formatEvalFailure(
  * here and translate it into one of the two outcomes above instead of letting
  * it propagate.
  */
-export async function runToolCallGuard(
-  args: GuardArgs,
-): Promise<GuardBlockResult | undefined> {
+export async function runToolCallGuard(args: GuardArgs): Promise<GuardResult> {
   try {
     const req: HookEvaluateRequest = {
       phase: "postflight",
@@ -110,6 +169,14 @@ export async function runToolCallGuard(
         reason: formatPolicyDeny(args.toolName, resp.reason),
       };
     }
+    const transform = extractToolCallTransform(
+      resp.transformedInput?.output,
+      args.toolCallId,
+      args.logger,
+    );
+    if (transform) {
+      return { transform };
+    }
     return undefined;
   } catch (err) {
     args.logger?.warn(`guard eval failed: ${err}`);
@@ -121,4 +188,52 @@ export async function runToolCallGuard(
     }
     return undefined;
   }
+}
+
+/**
+ * Walks the server-returned `transformed_input.output` for the tool_call
+ * part matching `toolCallId` and parses its `inputJSON` into an object.
+ * Returns `undefined` on any mismatch or parse failure so the caller can
+ * fall through to the original tool input unchanged.
+ */
+function extractToolCallTransform(
+  output: Message[] | undefined,
+  toolCallId: string,
+  logger?: { warn: (msg: string) => void },
+): Record<string, unknown> | undefined {
+  if (!output || output.length === 0) return undefined;
+  for (const msg of output) {
+    if (!msg.parts) continue;
+    for (const part of msg.parts) {
+      if (part.type !== "tool_call") continue;
+      const tc = part.toolCall;
+      if (!tc || tc.id !== toolCallId) continue;
+      // A matching tool_call whose args we cannot parse means the server sent
+      // a transform we cannot apply; log it. The no-match case stays silent,
+      // since that just means there is no redaction for this call.
+      const raw = tc.inputJSON;
+      if (typeof raw !== "string" || raw.length === 0) {
+        logger?.warn(
+          `tool-call transform for ${toolCallId} dropped: empty arguments`,
+        );
+        return undefined;
+      }
+      try {
+        const parsed = JSON.parse(raw) as unknown;
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          return parsed as Record<string, unknown>;
+        }
+        logger?.warn(
+          `tool-call transform for ${toolCallId} dropped: arguments were not a JSON object`,
+        );
+        return undefined;
+      } catch {
+        logger?.warn(
+          `tool-call transform for ${toolCallId} dropped: invalid JSON arguments`,
+        );
+        return undefined;
+      }
+    }
+  }
+  return undefined;
 }

--- a/plugins/pi/src/guards.e2e.test.ts
+++ b/plugins/pi/src/guards.e2e.test.ts
@@ -1,0 +1,504 @@
+// Pi guards: real-SDK-over-HTTP integration tests.
+//
+// Drives the @grafana/sigil-pi extension through a faked pi host, but unlike
+// the handler-wiring unit tests (index.test.ts) the Sigil client here is the
+// real JS SDK pointed at a local HTTP server. Each test exercises the full
+// preflight (`context`) or postflight (`tool_call`) path end to end: real
+// SigilClient.evaluateHook -> HTTP hooks:evaluate round-trip -> wire parse ->
+// in-place write-back into pi's messages / tool input.
+//
+// The unit suites already prove the mapper/guard branches; this suite adds the
+// transport + wire-decode dimension and asserts both what the plugin sent and
+// what it applied.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import registerExtension from "./index.js";
+import type {
+  PiAgentMessage,
+  PiAssistantMessage,
+  PiToolResult,
+  PiUserMessage,
+} from "./mappers.js";
+import { restoreEnv, snapshotAndClearTestEnv } from "./testEnv.js";
+import {
+  closeServer,
+  type HookResponse,
+  type SigilTestServer,
+  startSigilTestServer,
+} from "./testHttp.js";
+
+// Minimal pi host: registerExtension subscribes handlers; tests invoke a
+// handler directly (via the map) so they can capture its return value, which
+// pi's emit path would otherwise swallow.
+class FakePi {
+  handlers = new Map<string, (event: any, ctx: any) => Promise<any> | any>();
+  on(event: string, handler: (event: any, ctx: any) => Promise<any> | any) {
+    this.handlers.set(event, handler);
+  }
+  async emit(event: string, payload: any, ctx: any) {
+    const handler = this.handlers.get(event);
+    if (!handler) return undefined;
+    return handler(payload, ctx);
+  }
+}
+
+const ctx = {
+  sessionManager: {
+    getSessionFile: () => "guards-session.jsonl",
+    getSessionId: () => "guards-conv-1",
+  },
+};
+
+function assistantFixture(
+  content: PiAssistantMessage["content"] = [{ type: "text", text: "ok" }],
+): PiAssistantMessage {
+  return {
+    role: "assistant",
+    content,
+    provider: "anthropic",
+    model: "claude-sonnet-4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+    },
+    stopReason: "stop",
+    timestamp: 1,
+  };
+}
+
+function userMsg(content: PiUserMessage["content"]): PiUserMessage {
+  return { role: "user", content, timestamp: 1 };
+}
+
+function toolResultMsg(text: string): PiToolResult {
+  return {
+    role: "toolResult",
+    toolCallId: "tc-1",
+    toolName: "bash",
+    content: [{ type: "text", text }],
+    isError: false,
+    timestamp: 1,
+  };
+}
+
+// Wire-shaped (snake_case) hook response bodies, matching what the Sigil API
+// emits and what js/src/hooks.ts parses.
+function preflightTransform(messages: unknown[]): HookResponse {
+  return {
+    json: { action: "allow", evaluations: [], transformed_input: { messages } },
+  };
+}
+function postflightTransform(output: unknown[]): HookResponse {
+  return {
+    json: { action: "allow", evaluations: [], transformed_input: { output } },
+  };
+}
+function deny(reason: string): HookResponse {
+  return { json: { action: "deny", reason, evaluations: [] } };
+}
+const ALLOW: HookResponse = { json: { action: "allow", evaluations: [] } };
+
+interface GuardEnv {
+  enabled?: boolean;
+  failOpen?: boolean;
+  timeoutMs?: number;
+}
+
+function setGuardEnv(env: GuardEnv): void {
+  process.env.SIGIL_GUARDS_ENABLED = String(env.enabled ?? true);
+  process.env.SIGIL_GUARDS_FAIL_OPEN = String(env.failOpen ?? true);
+  process.env.SIGIL_GUARDS_TIMEOUT_MS = String(env.timeoutMs ?? 1500);
+}
+
+describe("pi guards: real-SDK over HTTP", () => {
+  let server: SigilTestServer;
+  let savedEnv: Record<string, string | undefined> = {};
+  // Set per-test before setup() runs the session_start that builds the client.
+  let nextHook: (call: { phase: string }) => HookResponse = () => ALLOW;
+
+  beforeEach(async () => {
+    server = await startSigilTestServer({ hook: (call) => nextHook(call) });
+    nextHook = () => ALLOW;
+    savedEnv = snapshotAndClearTestEnv();
+
+    process.env.HOME = "/nonexistent-guards-home";
+    process.env.USERPROFILE = process.env.HOME;
+    process.env.XDG_CONFIG_HOME = "/nonexistent-guards-home/.config";
+    process.env.SIGIL_ENDPOINT = server.baseUrl;
+    process.env.SIGIL_AUTH_TENANT_ID = "tenant";
+    process.env.SIGIL_AUTH_TOKEN = "token";
+    process.env.SIGIL_AGENT_NAME = "pi";
+    process.env.SIGIL_AGENT_VERSION = "test-version";
+    process.env.SIGIL_CONTENT_CAPTURE_MODE = "full";
+    process.env.SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT = "";
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "";
+    process.env.SIGIL_DEBUG = "";
+    setGuardEnv({});
+  });
+
+  afterEach(async () => {
+    await closeServer(server.server);
+    restoreEnv(savedEnv);
+    savedEnv = {};
+  });
+
+  // Boot a session and cache an assistant model so preflight forwards a real
+  // model rather than the unknown fallback.
+  async function setup(): Promise<FakePi> {
+    const pi = new FakePi();
+    registerExtension(pi as any);
+    await pi.emit("session_start", {}, ctx);
+    await pi.emit("turn_start", {}, ctx);
+    await pi.emit("message_end", { message: assistantFixture() }, ctx);
+    return pi;
+  }
+
+  async function runContext(
+    pi: FakePi,
+    messages: PiAgentMessage[],
+  ): Promise<{ result: unknown; event: { messages: PiAgentMessage[] } }> {
+    const event = { messages };
+    const result = await pi.handlers.get("context")!(event, ctx);
+    return { result, event };
+  }
+
+  async function runToolCall(
+    pi: FakePi,
+    input: Record<string, unknown>,
+  ): Promise<{ result: unknown; event: { input: Record<string, unknown> } }> {
+    const event = { toolCallId: "tc-1", toolName: "bash", input };
+    const result = await pi.handlers.get("tool_call")!(event, ctx);
+    return { result, event };
+  }
+
+  describe("preflight (context)", () => {
+    interface PreflightCase {
+      name: string;
+      env?: GuardEnv;
+      hook?: HookResponse;
+      messages: () => PiAgentMessage[];
+      assert: (args: {
+        result: unknown;
+        event: { messages: PiAgentMessage[] };
+        server: SigilTestServer;
+      }) => void;
+    }
+
+    const cases: PreflightCase[] = [
+      {
+        name: "redacts user text and forwards the original",
+        hook: preflightTransform([
+          { role: "user", parts: [{ type: "text", text: "email [REDACTED]" }] },
+        ]),
+        messages: () => [userMsg("email leak@example.com")],
+        assert: ({ result, event, server }) => {
+          expect((event.messages[0] as PiUserMessage).content).toBe(
+            "email [REDACTED]",
+          );
+          expect(result).toEqual({ messages: event.messages });
+          expect(server.hookCalls).toHaveLength(1);
+          const call = server.hookCalls[0]!;
+          expect(call.phase).toBe("preflight");
+          // The forwarded body carried the unredacted original.
+          const sent = call.body.input?.messages as
+            | Array<{ parts: Array<{ text: string }> }>
+            | undefined;
+          expect(sent?.[0]?.parts[0]?.text).toBe("email leak@example.com");
+        },
+      },
+      {
+        name: "redacts tool-result content via the tool_result part",
+        hook: preflightTransform([
+          {
+            role: "tool",
+            parts: [
+              {
+                type: "tool_result",
+                toolResult: {
+                  tool_call_id: "tc-1",
+                  name: "bash",
+                  content: "out [REDACTED_API_KEY]",
+                },
+              },
+            ],
+          },
+        ]),
+        messages: () => [toolResultMsg("out sk-deadbeef")],
+        assert: ({ event }) => {
+          expect((event.messages[0] as PiToolResult).content[0]).toMatchObject({
+            type: "text",
+            text: "out [REDACTED_API_KEY]",
+          });
+        },
+      },
+      {
+        name: "keeps assistant thinking parts untouched while redacting text",
+        hook: preflightTransform([
+          { role: "user", parts: [{ type: "text", text: "hi [REDACTED]" }] },
+          { role: "assistant", parts: [{ type: "text", text: "answer red" }] },
+        ]),
+        messages: () => [
+          userMsg("hi secret@example.com"),
+          assistantFixture([
+            { type: "thinking", thinking: "opaque-sig" },
+            { type: "text", text: "answer original" },
+          ]),
+        ],
+        assert: ({ event }) => {
+          const asst = event.messages[1] as PiAssistantMessage;
+          expect(asst.content[0]).toEqual({
+            type: "thinking",
+            thinking: "opaque-sig",
+          });
+          expect(asst.content[1]).toMatchObject({
+            type: "text",
+            text: "answer red",
+          });
+        },
+      },
+      {
+        name: "applies Go/proto-encoded wire messages (role+Payload shape)",
+        hook: {
+          json: {
+            action: "allow",
+            evaluations: [],
+            transformed_input: {
+              messages: [{ role: 1, parts: [{ Payload: { Text: "hi [R]" } }] }],
+            },
+          },
+        },
+        messages: () => [userMsg("hi secret@example.com")],
+        assert: ({ event }) => {
+          expect((event.messages[0] as PiUserMessage).content).toBe("hi [R]");
+        },
+      },
+      {
+        name: "leaves messages unchanged when the server applies no transform",
+        hook: ALLOW,
+        messages: () => [userMsg("nothing to redact")],
+        assert: ({ result, event, server }) => {
+          expect(result).toBeUndefined();
+          expect((event.messages[0] as PiUserMessage).content).toBe(
+            "nothing to redact",
+          );
+          expect(server.hookCalls).toHaveLength(1);
+        },
+      },
+      {
+        name: "fails open when the redacted message count diverges",
+        hook: preflightTransform([
+          { role: "user", parts: [{ type: "text", text: "a" }] },
+          { role: "user", parts: [{ type: "text", text: "b" }] },
+        ]),
+        messages: () => [userMsg("original")],
+        assert: ({ result, event }) => {
+          expect(result).toBeUndefined();
+          expect((event.messages[0] as PiUserMessage).content).toBe("original");
+        },
+      },
+      {
+        name: "ignores a preflight deny (context cannot block)",
+        hook: deny("preflight deny"),
+        messages: () => [userMsg("still here")],
+        assert: ({ result, event }) => {
+          expect(result).toBeUndefined();
+          expect((event.messages[0] as PiUserMessage).content).toBe(
+            "still here",
+          );
+        },
+      },
+      {
+        name: "fails open on a 5xx hook error (failOpen=true)",
+        hook: { status: 500, json: { error: "boom" } },
+        messages: () => [userMsg("kept on error")],
+        assert: ({ result, event, server }) => {
+          expect(result).toBeUndefined();
+          expect((event.messages[0] as PiUserMessage).content).toBe(
+            "kept on error",
+          );
+          expect(server.hookCalls).toHaveLength(1);
+        },
+      },
+      {
+        name: "fails open on a hook timeout",
+        env: { timeoutMs: 50 },
+        hook: {
+          delayMs: 250,
+          ...preflightTransform([
+            { role: "user", parts: [{ type: "text", text: "too late" }] },
+          ]),
+        },
+        messages: () => [userMsg("kept on timeout")],
+        assert: ({ result, event }) => {
+          expect(result).toBeUndefined();
+          expect((event.messages[0] as PiUserMessage).content).toBe(
+            "kept on timeout",
+          );
+        },
+      },
+      {
+        name: "does not call the hook when guards are disabled",
+        env: { enabled: false },
+        hook: preflightTransform([
+          { role: "user", parts: [{ type: "text", text: "[REDACTED]" }] },
+        ]),
+        messages: () => [userMsg("untouched")],
+        assert: ({ result, event, server }) => {
+          expect(result).toBeUndefined();
+          expect((event.messages[0] as PiUserMessage).content).toBe(
+            "untouched",
+          );
+          expect(server.hookCalls).toHaveLength(0);
+        },
+      },
+    ];
+
+    it.each(cases)("$name", async ({ env, hook, messages, assert }) => {
+      if (env) setGuardEnv(env);
+      nextHook = () => hook ?? ALLOW;
+      const pi = await setup();
+      const { result, event } = await runContext(pi, messages());
+      assert({ result, event, server });
+      expect(server.errors).toEqual([]);
+    });
+  });
+
+  describe("postflight (tool_call)", () => {
+    interface PostflightCase {
+      name: string;
+      env?: GuardEnv;
+      hook?: HookResponse;
+      input?: Record<string, unknown>;
+      assert: (args: {
+        result: unknown;
+        event: { input: Record<string, unknown> };
+        server: SigilTestServer;
+      }) => void;
+    }
+
+    const redactedToolCall = (id: string, inputJson: string) =>
+      postflightTransform([
+        {
+          role: "assistant",
+          parts: [
+            {
+              type: "tool_call",
+              toolCall: { id, name: "bash", input_json: inputJson },
+            },
+          ],
+        },
+      ]);
+
+    const cases: PostflightCase[] = [
+      {
+        name: "redacts tool arguments in place",
+        hook: redactedToolCall("tc-1", '{"command":"echo [REDACTED]"}'),
+        assert: ({ result, event, server }) => {
+          expect(result).toBeUndefined();
+          expect(event.input).toEqual({ command: "echo [REDACTED]" });
+          expect(server.hookCalls[0]!.phase).toBe("postflight");
+        },
+      },
+      {
+        name: "drops keys the server omits from the redacted args",
+        hook: redactedToolCall("tc-1", '{"command":"echo [REDACTED]"}'),
+        input: { command: "echo sk-real-secret", token: "sk-leak" },
+        assert: ({ result, event }) => {
+          expect(result).toBeUndefined();
+          // `token` was not in the server's redacted set, so it must not
+          // survive on the merged input with its original value.
+          expect(event.input).toEqual({ command: "echo [REDACTED]" });
+        },
+      },
+      {
+        name: "fails open (no block) when the tool input cannot be mutated",
+        hook: redactedToolCall("tc-1", '{"command":"echo [REDACTED]"}'),
+        input: Object.freeze({ command: "echo sk-real-secret" }),
+        assert: ({ result, event }) => {
+          expect(result).toBeUndefined();
+          expect(event.input).toEqual({ command: "echo sk-real-secret" });
+        },
+      },
+      {
+        name: "blocks on a deny verdict with policy wording",
+        hook: deny("blocked rm -rf"),
+        assert: ({ result }) => {
+          expect(result).toMatchObject({ block: true });
+          const reason = (result as { reason: string }).reason;
+          expect(reason).toContain("blocked rm -rf");
+          expect(reason).toContain("A Grafana AI Observability policy");
+          expect(reason).toContain("Stop and tell the user");
+        },
+      },
+      {
+        name: "leaves input unchanged on a plain allow",
+        hook: ALLOW,
+        assert: ({ result, event }) => {
+          expect(result).toBeUndefined();
+          expect(event.input).toEqual({ command: "echo sk-real-secret" });
+        },
+      },
+      {
+        name: "ignores a transform aimed at a different toolCallId",
+        hook: redactedToolCall("other-id", '{"command":"echo X"}'),
+        assert: ({ result, event }) => {
+          expect(result).toBeUndefined();
+          expect(event.input).toEqual({ command: "echo sk-real-secret" });
+        },
+      },
+      {
+        name: "ignores an unparseable transform input_json",
+        hook: redactedToolCall("tc-1", "not json"),
+        assert: ({ result, event }) => {
+          expect(result).toBeUndefined();
+          expect(event.input).toEqual({ command: "echo sk-real-secret" });
+        },
+      },
+      {
+        name: "blocks fail-closed on a 5xx hook error (failOpen=false)",
+        env: { failOpen: false },
+        hook: { status: 500, json: { error: "boom" } },
+        assert: ({ result }) => {
+          expect(result).toMatchObject({ block: true });
+          const reason = (result as { reason: string }).reason;
+          expect(reason).toContain("could not evaluate");
+          expect(reason).toContain("safety measure");
+        },
+      },
+      {
+        name: "fails open on a 5xx hook error (failOpen=true)",
+        hook: { status: 500, json: { error: "boom" } },
+        assert: ({ result, event }) => {
+          expect(result).toBeUndefined();
+          expect(event.input).toEqual({ command: "echo sk-real-secret" });
+        },
+      },
+      {
+        name: "does not call the hook when guards are disabled",
+        env: { enabled: false },
+        hook: redactedToolCall("tc-1", '{"command":"echo [REDACTED]"}'),
+        assert: ({ result, event, server }) => {
+          expect(result).toBeUndefined();
+          expect(event.input).toEqual({ command: "echo sk-real-secret" });
+          expect(server.hookCalls).toHaveLength(0);
+        },
+      },
+    ];
+
+    it.each(cases)("$name", async ({ env, hook, input, assert }) => {
+      if (env) setGuardEnv(env);
+      nextHook = () => hook ?? ALLOW;
+      const pi = await setup();
+      const { result, event } = await runToolCall(
+        pi,
+        input ?? { command: "echo sk-real-secret" },
+      );
+      assert({ result, event, server });
+      expect(server.errors).toEqual([]);
+    });
+  });
+});

--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -1358,6 +1358,386 @@ describe("extension lifecycle", () => {
         name: "unknown",
       });
     });
+
+    it("applies transformedInput tool args to event.input via in-place mutation", async () => {
+      const evaluateHook = vi.fn().mockResolvedValue({
+        action: "allow",
+        evaluations: [],
+        transformedInput: {
+          output: [
+            {
+              role: "assistant",
+              parts: [
+                {
+                  type: "tool_call",
+                  toolCall: {
+                    id: "c1",
+                    name: "bash",
+                    inputJSON: '{"command":"echo [REDACTED]"}',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      });
+      const sigil = makeSigilLike(evaluateHook);
+
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+        guards: { enabled: true, timeoutMs: 1500, failOpen: true },
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const fakePi = new FakePi();
+      registerExtension(fakePi as any);
+
+      await fakePi.emit("session_start");
+      await fakePi.emit("turn_start");
+      const handler = fakePi.handlers.get("tool_call")!;
+      const event = {
+        toolCallId: "c1",
+        toolName: "bash",
+        input: { command: "echo sk-real-secret" },
+      };
+      const result = await handler(event, defaultCtx);
+
+      // Allow the call (no block) but mutate input in place.
+      expect(result).toBeUndefined();
+      expect(event.input).toEqual({ command: "echo [REDACTED]" });
+    });
+  });
+
+  describe("guards (context wiring — preflight transform)", () => {
+    function makeRecorder() {
+      return {
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        setFirstTokenAt: vi.fn(),
+      };
+    }
+
+    function makeSigilLike(
+      evaluateHook?: ReturnType<typeof vi.fn>,
+    ): SigilLike & { evaluateHook?: ReturnType<typeof vi.fn> } {
+      const recorder = makeRecorder();
+      return {
+        startStreamingGeneration: vi.fn(async (_seed, run) => {
+          await run(recorder);
+        }),
+        startToolExecution: vi.fn(() => ({
+          setResult: vi.fn(),
+          setCallError: vi.fn(),
+          end: vi.fn(),
+          getError: vi.fn(),
+        })),
+        shutdown: vi.fn(async () => {}),
+        ...(evaluateHook ? { evaluateHook } : {}),
+      } as SigilLike & { evaluateHook?: ReturnType<typeof vi.fn> };
+    }
+
+    function preflightConfig() {
+      return {
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" as const },
+        agentName: "pi",
+        contentCapture: "metadata_only" as const,
+        guards: { enabled: true, timeoutMs: 1500, failOpen: true },
+      };
+    }
+
+    it("does not call evaluateHook when guards are disabled", async () => {
+      const evaluateHook = vi.fn();
+      const sigil = makeSigilLike(evaluateHook);
+      loadConfigMock.mockResolvedValue({
+        ...preflightConfig(),
+        guards: { enabled: false, timeoutMs: 1500, failOpen: true },
+      });
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const fakePi = new FakePi();
+      registerExtension(fakePi as any);
+
+      await fakePi.emit("session_start");
+      const handler = fakePi.handlers.get("context")!;
+      const result = await handler(
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 1 }],
+        },
+        defaultCtx,
+      );
+
+      expect(evaluateHook).not.toHaveBeenCalled();
+      expect(result).toBeUndefined();
+    });
+
+    it("replaces outgoing messages with redacted text from transformedInput", async () => {
+      const evaluateHook = vi.fn().mockResolvedValue({
+        action: "allow",
+        evaluations: [],
+        transformedInput: {
+          messages: [
+            {
+              role: "user",
+              parts: [
+                {
+                  type: "text",
+                  text: "my email is [REDACTED_EMAIL]",
+                },
+              ],
+            },
+          ],
+        },
+      });
+      const sigil = makeSigilLike(evaluateHook);
+      loadConfigMock.mockResolvedValue(preflightConfig());
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const fakePi = new FakePi();
+      registerExtension(fakePi as any);
+
+      await fakePi.emit("session_start");
+      const handler = fakePi.handlers.get("context")!;
+      const piMessages = [
+        {
+          role: "user",
+          content: "my email is leak@example.com",
+          timestamp: 1,
+        },
+      ];
+      const result = await handler({ messages: piMessages }, defaultCtx);
+
+      expect(evaluateHook).toHaveBeenCalledTimes(1);
+      const [_req, override] = evaluateHook.mock.calls[0]!;
+      expect(override).toEqual({
+        enabled: true,
+        phases: ["preflight"],
+      });
+      expect(result).toEqual({ messages: piMessages });
+      expect(piMessages[0]!.content).toBe("my email is [REDACTED_EMAIL]");
+    });
+
+    it("returns undefined when the server emits no transformedInput", async () => {
+      const evaluateHook = vi
+        .fn()
+        .mockResolvedValue({ action: "allow", evaluations: [] });
+      const sigil = makeSigilLike(evaluateHook);
+      loadConfigMock.mockResolvedValue(preflightConfig());
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const fakePi = new FakePi();
+      registerExtension(fakePi as any);
+
+      await fakePi.emit("session_start");
+      const handler = fakePi.handlers.get("context")!;
+      const piMessages = [{ role: "user", content: "hello", timestamp: 1 }];
+      const result = await handler({ messages: piMessages }, defaultCtx);
+      expect(result).toBeUndefined();
+      expect(piMessages[0]!.content).toBe("hello");
+    });
+
+    it("fails open (no transform) when evaluateHook throws", async () => {
+      const evaluateHook = vi.fn().mockRejectedValue(new Error("timeout"));
+      const sigil = makeSigilLike(evaluateHook);
+      loadConfigMock.mockResolvedValue(preflightConfig());
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const fakePi = new FakePi();
+      registerExtension(fakePi as any);
+
+      await fakePi.emit("session_start");
+      const handler = fakePi.handlers.get("context")!;
+      const piMessages = [
+        { role: "user", content: "hello secret@example.com", timestamp: 1 },
+      ];
+      const result = await handler({ messages: piMessages }, defaultCtx);
+      expect(result).toBeUndefined();
+      expect(piMessages[0]!.content).toBe("hello secret@example.com");
+    });
+
+    it("passes through unchanged when redacted message count diverges", async () => {
+      // Only one outgoing message but the server returned two. Pi keeps
+      // the originals: we refuse to apply a misaligned redaction.
+      loggerMock.debug.mockReset();
+      const evaluateHook = vi.fn().mockResolvedValue({
+        action: "allow",
+        evaluations: [],
+        transformedInput: {
+          messages: [
+            { role: "user", parts: [{ type: "text", text: "a" }] },
+            { role: "user", parts: [{ type: "text", text: "b" }] },
+          ],
+        },
+      });
+      const sigil = makeSigilLike(evaluateHook);
+      loadConfigMock.mockResolvedValue(preflightConfig());
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const fakePi = new FakePi();
+      registerExtension(fakePi as any);
+
+      await fakePi.emit("session_start");
+      const handler = fakePi.handlers.get("context")!;
+      const piMessages = [{ role: "user", content: "original", timestamp: 1 }];
+      const result = await handler({ messages: piMessages }, defaultCtx);
+      expect(result).toBeUndefined();
+      expect(piMessages[0]!.content).toBe("original");
+      expect(loggerMock.debug).toHaveBeenCalledWith(
+        expect.stringContaining("preflight transform dropped"),
+      );
+    });
+
+    it("keeps thinking parts on assistant messages untouched during redaction", async () => {
+      const evaluateHook = vi.fn().mockResolvedValue({
+        action: "allow",
+        evaluations: [],
+        transformedInput: {
+          messages: [
+            { role: "user", parts: [{ type: "text", text: "hi [REDACTED]" }] },
+            {
+              role: "assistant",
+              parts: [{ type: "text", text: "answer" }],
+            },
+          ],
+        },
+      });
+      const sigil = makeSigilLike(evaluateHook);
+      loadConfigMock.mockResolvedValue(preflightConfig());
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const fakePi = new FakePi();
+      registerExtension(fakePi as any);
+
+      await fakePi.emit("session_start");
+      const handler = fakePi.handlers.get("context")!;
+      const piMessages = [
+        { role: "user", content: "hi secret@example.com", timestamp: 1 },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "opaque-sig" },
+            { type: "text", text: "original" },
+          ],
+          provider: "anthropic",
+          model: "claude-sonnet-4",
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+          },
+          stopReason: "stop",
+          timestamp: 2,
+        },
+      ];
+      await handler({ messages: piMessages }, defaultCtx);
+
+      // User text overwritten.
+      expect(piMessages[0]!.content).toBe("hi [REDACTED]");
+      // Thinking part preserved unchanged on the assistant message.
+      const asst = piMessages[1] as unknown as {
+        content: Array<{ type: string; text?: string; thinking?: string }>;
+      };
+      expect(asst.content[0]).toEqual({
+        type: "thinking",
+        thinking: "opaque-sig",
+      });
+      expect(asst.content[1]).toMatchObject({
+        type: "text",
+        text: "answer",
+      });
+    });
+
+    it("sends provider/name = unknown on the first preflight (no assistant turn yet)", async () => {
+      const evaluateHook = vi
+        .fn()
+        .mockResolvedValue({ action: "allow", evaluations: [] });
+      const sigil = makeSigilLike(evaluateHook);
+      loadConfigMock.mockResolvedValue(preflightConfig());
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const fakePi = new FakePi();
+      registerExtension(fakePi as any);
+
+      await fakePi.emit("session_start");
+      const handler = fakePi.handlers.get("context")!;
+      await handler(
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 1 }],
+        },
+        defaultCtx,
+      );
+      const req = evaluateHook.mock.calls[0]![0] as {
+        context: { model: { provider: string; name: string } };
+      };
+      expect(req.context.model).toEqual({
+        provider: "unknown",
+        name: "unknown",
+      });
+    });
+
+    it("applies redacted tool-result content from the server's tool_result part", async () => {
+      // Regression for the bug where the plugin only walked text parts and
+      // silently dropped the server's redacted `tool_result.content`. The
+      // server transforms ToolResult.Content in place and returns it on the
+      // same tool_result part, not as a synthetic text part.
+      const evaluateHook = vi.fn().mockResolvedValue({
+        action: "allow",
+        evaluations: [],
+        transformedInput: {
+          messages: [
+            { role: "user", parts: [{ type: "text", text: "run it" }] },
+            {
+              role: "tool",
+              parts: [
+                {
+                  type: "tool_result",
+                  toolResult: {
+                    toolCallId: "c1",
+                    name: "bash",
+                    content: "token=[REDACTED_API_KEY]",
+                    isError: false,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      });
+      const sigil = makeSigilLike(evaluateHook);
+      loadConfigMock.mockResolvedValue(preflightConfig());
+      createSigilClientMock.mockReturnValue(sigil);
+
+      const fakePi = new FakePi();
+      registerExtension(fakePi as any);
+
+      await fakePi.emit("session_start");
+      const handler = fakePi.handlers.get("context")!;
+      const piMessages = [
+        { role: "user", content: "run it", timestamp: 1 },
+        {
+          role: "toolResult",
+          toolCallId: "c1",
+          toolName: "bash",
+          content: [{ type: "text", text: "token=sk-LEAKED" }],
+          isError: false,
+          timestamp: 2,
+        },
+      ];
+      const result = await handler({ messages: piMessages }, defaultCtx);
+      expect(result).toEqual({ messages: piMessages });
+      const tr = piMessages[1] as unknown as {
+        content: Array<{ type: string; text?: string }>;
+      };
+      expect(tr.content[0]).toMatchObject({
+        type: "text",
+        text: "token=[REDACTED_API_KEY]",
+      });
+    });
   });
 
   it("emits git.branch tag when contentCapture=full", async () => {

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -10,12 +10,14 @@ import type { SigilPiConfig } from "./config.js";
 import { loadConfig } from "./config.js";
 import { detectPiVersion } from "./detectPiVersion.js";
 import { resolveGitBranch } from "./git.js";
-import { runToolCallGuard } from "./guard.js";
+import { runPreflightTransform, runToolCallGuard } from "./guard.js";
 import { resolvePiGenerationLineage } from "./lineage.js";
 import { logger } from "./logger.js";
 import {
+  applyRedactedText,
   type CachedRequestControls,
   extractRequestControls,
+  mapAgentMessagesForHook,
   mapGenerationResult,
   mapGenerationStart,
   mapTools,
@@ -26,6 +28,7 @@ import {
   type PiUserMessage,
   resolveConversationTitle,
   type ToolTiming,
+  toolResultText,
   userMessageText,
 } from "./mappers.js";
 import {
@@ -257,9 +260,58 @@ export default function (pi: ExtensionAPI) {
     firstTokenTime = Date.now();
   });
 
+  pi.on("context", async (event, _ctx) => {
+    if (!sigil || !config?.guards.enabled) return;
+    try {
+      const piMessages = event.messages;
+      if (!Array.isArray(piMessages) || piMessages.length === 0) return;
+
+      const forward = mapAgentMessagesForHook(piMessages);
+      if (forward.length === 0) return;
+
+      const result = await runPreflightTransform({
+        client: sigil,
+        agentName: config.agentName,
+        agentVersion: config.agentVersion,
+        model: lastSeenModel ?? { provider: "unknown", name: "unknown" },
+        messages: forward,
+        logger: { warn: (msg: string) => logger.warn(msg) },
+      });
+      if (!result) return;
+
+      // The server returns one redacted message per forwarded message. If the
+      // counts diverge we cannot align the redaction by index, so drop it and
+      // forward the originals unchanged.
+      if (result.messages.length !== forward.length) {
+        logger.debug(
+          `preflight transform dropped: got ${result.messages.length} messages, expected ${forward.length}`,
+        );
+        return;
+      }
+
+      const applied = applyRedactedText(piMessages, result.messages);
+      if (!applied) {
+        logger.debug(
+          "preflight transform dropped: could not align redacted messages with the outgoing conversation",
+        );
+        return;
+      }
+
+      // applyRedactedText mutated piMessages (pi's own AgentMessage[]) in
+      // place; returning it hands the redacted conversation back to pi.
+      return { messages: piMessages };
+    } catch (err) {
+      // Pi runs `context` handlers serially; any error here would otherwise
+      // surface as a turn failure. Drop the transform and let the original
+      // messages flow through.
+      logger.warn(`context handler failed: ${err}`);
+      return;
+    }
+  });
+
   pi.on("tool_call", async (event, _ctx) => {
     if (!sigil || !config?.guards.enabled) return;
-    return runToolCallGuard({
+    const res = await runToolCallGuard({
       client: sigil,
       agentName: config.agentName,
       agentVersion: config.agentVersion,
@@ -270,6 +322,30 @@ export default function (pi: ExtensionAPI) {
       failOpen: config.guards.failOpen,
       logger: { warn: (msg: string) => logger.warn(msg) },
     });
+    if (!res) return;
+    if ("block" in res) return { block: true, reason: res.reason };
+    // Postflight transform: the server returns the complete redacted argument
+    // set, so replace the tool input wholesale. A plain Object.assign would
+    // merge instead, leaving any key the server dropped (an unredacted
+    // original) in place. Pi sees the patched arguments at execution time; no
+    // re-validation runs after the mutation, so it is the server's
+    // responsibility to keep the schema intact.
+    //
+    // Redaction fails open: if the patch cannot be applied (e.g. event.input
+    // is null or frozen), log it and let the original arguments through rather
+    // than throwing, which pi would treat as a block.
+    try {
+      const input = event.input as Record<string, unknown>;
+      for (const key of Object.keys(input)) {
+        if (!Object.hasOwn(res.transform, key)) {
+          delete input[key];
+        }
+      }
+      Object.assign(input, res.transform);
+    } catch (err) {
+      logger.warn(`tool_call transform apply failed: ${err}`);
+    }
+    return;
   });
 
   pi.on("tool_execution_start", async (event, _ctx) => {
@@ -535,14 +611,7 @@ export function emitToolSpans(
       }
     }
     for (const tr of toolResults) {
-      const text = tr.content
-        .filter(
-          (c): c is { type: "text"; text: string } =>
-            c.type === "text" && !!c.text,
-        )
-        .map((c) => c.text)
-        .join("\n");
-      resultMap.set(tr.toolCallId, text);
+      resultMap.set(tr.toolCallId, toolResultText(tr.content));
     }
   }
 

--- a/plugins/pi/src/mappers.test.ts
+++ b/plugins/pi/src/mappers.test.ts
@@ -1,11 +1,15 @@
+import type { Message } from "@grafana/sigil-sdk-js";
 import { describe, expect, it } from "vitest";
 import {
+  applyRedactedText,
   extractRequestControls,
   MAX_TITLE_LEN,
+  mapAgentMessagesForHook,
   mapGenerationResult,
   mapGenerationStart,
   mapTools,
   mapUserMessage,
+  type PiAgentMessage,
   type PiAssistantMessage,
   type PiToolInfo,
   type PiToolResult,
@@ -1054,5 +1058,351 @@ describe("extractRequestControls", () => {
       thinking: { type: "enabled", budget_tokens: "lots" },
     });
     expect(ctrls.thinkingBudgetTokens).toBeUndefined();
+  });
+});
+
+describe("mapAgentMessagesForHook", () => {
+  it("maps user, assistant, and tool result messages 1:1 regardless of contentCapture", () => {
+    const messages: PiAgentMessage[] = [
+      { role: "user", content: "hello secret@example.com", timestamp: 1 },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "hi" },
+          {
+            type: "toolCall",
+            id: "c1",
+            name: "bash",
+            arguments: { cmd: "ls" },
+          },
+        ],
+        provider: "anthropic",
+        model: "claude-sonnet-4",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+        },
+        stopReason: "toolUse",
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "c1",
+        toolName: "bash",
+        content: [{ type: "text", text: "output" }],
+        isError: false,
+        timestamp: 3,
+      },
+    ];
+    const out = mapAgentMessagesForHook(messages);
+    expect(out).toHaveLength(3);
+    expect(out[0]).toEqual({
+      role: "user",
+      parts: [{ type: "text", text: "hello secret@example.com" }],
+    });
+    expect(out[1]).toMatchObject({
+      role: "assistant",
+      parts: [{ type: "text", text: "hi" }],
+    });
+    expect(out[2]?.role).toBe("tool");
+  });
+
+  it("drops thinking parts from the forward payload but keeps the message slot", () => {
+    const messages: PiAgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "reasoning" },
+          { type: "text", text: "answer" },
+        ],
+        provider: "anthropic",
+        model: "claude-sonnet-4",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+        },
+        stopReason: "stop",
+        timestamp: 1,
+      },
+    ];
+    const out = mapAgentMessagesForHook(messages);
+    expect(out).toHaveLength(1);
+    const parts = out[0]?.parts ?? [];
+    expect(parts.some((p) => p.type === "thinking")).toBe(false);
+    expect(parts).toEqual([{ type: "text", text: "answer" }]);
+  });
+
+  it("emits a placeholder for unknown/custom agent message subtypes", () => {
+    const messages: PiAgentMessage[] = [
+      { role: "user", content: "hi", timestamp: 1 },
+      // Simulated custom AgentMessage (e.g. a UI-only notification).
+      { role: "bash_execution" } as PiAgentMessage,
+    ];
+    const out = mapAgentMessagesForHook(messages);
+    // Alignment must be preserved — unknown roles must not be dropped
+    // because that would break index-aligned write-back.
+    expect(out).toHaveLength(2);
+    expect(out[1]?.role).toBe("bash_execution");
+    expect(out[1]?.parts).toEqual([]);
+  });
+
+  it("emits a placeholder for null/non-object slots so alignment is preserved", () => {
+    const messages = [
+      { role: "user", content: "hi", timestamp: 1 },
+      null,
+      { role: "user", content: "bye", timestamp: 2 },
+    ] as unknown as PiAgentMessage[];
+    const out = mapAgentMessagesForHook(messages);
+    // The null slot must not be dropped, otherwise forward shrinks below
+    // piMessages and the whole transform is discarded on write-back.
+    expect(out).toHaveLength(3);
+    expect(out[1]).toEqual({ role: "unknown", parts: [] });
+  });
+
+  it("emits a user message with an empty parts array when content is image-only", () => {
+    const messages: PiAgentMessage[] = [
+      {
+        role: "user",
+        content: [{ type: "image", data: "x", mimeType: "image/png" }],
+        timestamp: 1,
+      },
+    ];
+    const out = mapAgentMessagesForHook(messages);
+    expect(out[0]).toEqual({ role: "user", parts: [] });
+  });
+});
+
+describe("applyRedactedText", () => {
+  it("overwrites string user content with the redacted text", () => {
+    const pi: PiAgentMessage[] = [
+      {
+        role: "user",
+        content: "my email is leak@example.com",
+        timestamp: 1,
+      },
+    ];
+    const redacted: Message[] = [
+      {
+        role: "user",
+        parts: [{ type: "text", text: "my email is [REDACTED_EMAIL]" }],
+      },
+    ];
+    const ok = applyRedactedText(pi, redacted);
+    expect(ok).toBe(true);
+    expect((pi[0] as PiUserMessage).content).toBe(
+      "my email is [REDACTED_EMAIL]",
+    );
+  });
+
+  it("overwrites the first text block of array-shaped user content and clears the rest", () => {
+    const pi: PiAgentMessage[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "hi leak@example.com" },
+          { type: "image", data: "x", mimeType: "image/png" },
+          { type: "text", text: "bye" },
+        ],
+        timestamp: 1,
+      },
+    ];
+    const redacted: Message[] = [
+      {
+        role: "user",
+        parts: [{ type: "text", text: "hi [REDACTED_EMAIL]\nbye" }],
+      },
+    ];
+    applyRedactedText(pi, redacted);
+    const content = (pi[0] as PiUserMessage).content as Array<{
+      type: string;
+      text?: string;
+    }>;
+    expect(content[0]?.text).toBe("hi [REDACTED_EMAIL]\nbye");
+    // Image must not be touched.
+    expect(content[1]).toEqual({
+      type: "image",
+      data: "x",
+      mimeType: "image/png",
+    });
+    // Trailing text part cleared so the rendered message equals the
+    // redacted payload exactly.
+    expect(content[2]?.text).toBe("");
+  });
+
+  it("leaves provider-signed thinking parts on assistant messages untouched", () => {
+    const pi: PiAgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "opaque-sig" },
+          { type: "text", text: "original secret" },
+          {
+            type: "toolCall",
+            id: "c1",
+            name: "bash",
+            arguments: { cmd: "ls" },
+          },
+        ],
+        provider: "anthropic",
+        model: "claude-sonnet-4",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+        },
+        stopReason: "toolUse",
+        timestamp: 1,
+      },
+    ];
+    const redacted: Message[] = [
+      {
+        role: "assistant",
+        parts: [{ type: "text", text: "original [REDACTED]" }],
+      },
+    ];
+    applyRedactedText(pi, redacted);
+    const content = (pi[0] as PiAssistantMessage).content;
+    expect(content[0]).toEqual({ type: "thinking", thinking: "opaque-sig" });
+    expect(content[1]).toMatchObject({
+      type: "text",
+      text: "original [REDACTED]",
+    });
+    expect(content[2]).toMatchObject({
+      type: "toolCall",
+      id: "c1",
+      name: "bash",
+      arguments: { cmd: "ls" },
+    });
+  });
+
+  it("returns false when message counts diverge", () => {
+    const pi: PiAgentMessage[] = [
+      { role: "user", content: "a", timestamp: 1 },
+      { role: "user", content: "b", timestamp: 2 },
+    ];
+    const redacted: Message[] = [
+      { role: "user", parts: [{ type: "text", text: "a" }] },
+    ];
+    expect(applyRedactedText(pi, redacted)).toBe(false);
+    // pi unchanged.
+    expect((pi[0] as PiUserMessage).content).toBe("a");
+    expect((pi[1] as PiUserMessage).content).toBe("b");
+  });
+
+  it("skips a null/non-object pi slot and still redacts the rest of the turn", () => {
+    const pi = [
+      { role: "user", content: "leak@example.com", timestamp: 1 },
+      null,
+      { role: "user", content: "also leak@example.com", timestamp: 2 },
+    ] as unknown as PiAgentMessage[];
+    const redacted: Message[] = [
+      { role: "user", parts: [{ type: "text", text: "[REDACTED_EMAIL]" }] },
+      { role: "unknown", parts: [] },
+      {
+        role: "user",
+        parts: [{ type: "text", text: "also [REDACTED_EMAIL]" }],
+      },
+    ];
+    const ok = applyRedactedText(pi, redacted);
+    expect(ok).toBe(true);
+    expect((pi[0] as PiUserMessage).content).toBe("[REDACTED_EMAIL]");
+    expect(pi[1]).toBeNull();
+    expect((pi[2] as PiUserMessage).content).toBe("also [REDACTED_EMAIL]");
+  });
+
+  it("no-ops when redacted message has no extractable text", () => {
+    const pi: PiAgentMessage[] = [
+      {
+        role: "user",
+        content: "hi",
+        timestamp: 1,
+      },
+    ];
+    const redacted: Message[] = [{ role: "user", parts: [] }];
+    const ok = applyRedactedText(pi, redacted);
+    expect(ok).toBe(true);
+    expect((pi[0] as PiUserMessage).content).toBe("hi");
+  });
+
+  it("tolerates the legacy `content` shorthand on the redacted side", () => {
+    const pi: PiAgentMessage[] = [
+      { role: "user", content: "hi leak@example.com", timestamp: 1 },
+    ];
+    const redacted: Message[] = [
+      { role: "user", content: "hi [REDACTED_EMAIL]" },
+    ];
+    applyRedactedText(pi, redacted);
+    expect((pi[0] as PiUserMessage).content).toBe("hi [REDACTED_EMAIL]");
+  });
+
+  it("overwrites tool-result text in place from the redacted tool_result part", () => {
+    // The server keeps the `tool_result` part shape and redacts its
+    // `content` field in place (grafana/sigil
+    // `internal/eval/hooks/transform.go`). The plugin must read the redaction
+    // off the tool_result part, not from a synthetic text part that the
+    // server never emits.
+    const pi: PiAgentMessage[] = [
+      {
+        role: "toolResult",
+        toolCallId: "c1",
+        toolName: "bash",
+        content: [{ type: "text", text: "secret-output sk-XXXX" }],
+        isError: false,
+        timestamp: 1,
+      },
+    ];
+    const redacted: Message[] = [
+      {
+        role: "tool",
+        parts: [
+          {
+            type: "tool_result",
+            toolResult: {
+              toolCallId: "c1",
+              name: "bash",
+              content: "secret-output [REDACTED_API_KEY]",
+              isError: false,
+            },
+          },
+        ],
+      },
+    ];
+    const ok = applyRedactedText(pi, redacted);
+    expect(ok).toBe(true);
+    expect((pi[0] as PiToolResult).content[0]).toMatchObject({
+      type: "text",
+      text: "secret-output [REDACTED_API_KEY]",
+    });
+  });
+
+  it("no-ops a tool-result message when the redacted tool_result part is absent", () => {
+    // Defensive: if the server returns the tool role with no tool_result
+    // part (e.g. a transformed payload that dropped it), leave pi untouched
+    // rather than guessing from any other parts.
+    const pi: PiAgentMessage[] = [
+      {
+        role: "toolResult",
+        toolCallId: "c1",
+        toolName: "bash",
+        content: [{ type: "text", text: "original" }],
+        isError: false,
+        timestamp: 1,
+      },
+    ];
+    const redacted: Message[] = [{ role: "tool", parts: [] }];
+    const ok = applyRedactedText(pi, redacted);
+    expect(ok).toBe(true);
+    expect((pi[0] as PiToolResult).content[0]).toMatchObject({
+      type: "text",
+      text: "original",
+    });
   });
 });

--- a/plugins/pi/src/mappers.ts
+++ b/plugins/pi/src/mappers.ts
@@ -316,6 +316,291 @@ export function mapGenerationResult(
 }
 
 /**
+ * Pi's AgentMessage union as exposed in the `context` event. Declared
+ * structurally to avoid hard-importing pi-ai/pi-agent-core types at runtime.
+ * Matches `UserMessage | AssistantMessage | ToolResultMessage` from
+ * @mariozechner/pi-ai, plus any custom AgentMessage extensions, which we
+ * pass through without touching.
+ */
+export type PiAgentMessage =
+  | PiUserMessage
+  | PiAssistantMessage
+  | PiToolResult
+  | { role?: string };
+
+/**
+ * Map pi's `ContextEvent.messages` (the full conversation pi is about to
+ * send to the model) to Sigil `Message[]` for a preflight hook evaluation.
+ *
+ * Differences from `mapUserMessage`/`mapAssistantOutput`:
+ * - All roles (user, assistant, tool) are mapped 1:1 so the redacted
+ *   round-trip can be aligned by index. Returning fewer messages would
+ *   break that alignment.
+ * - `contentCapture` is intentionally NOT applied. The hook server only
+ *   sees these messages in memory and never persists them; redacting them
+ *   here would defeat the point of running transforms (Vercel adapter
+ *   takes the same approach for the same reason).
+ * - Provider-signed `thinking` parts are dropped from the forward payload:
+ *   they carry an opaque provider signature, are not transformable, and
+ *   would needlessly inflate the hook request. The original pi message is
+ *   kept by the caller, so the `thinking` block survives untouched on the
+ *   write-back side.
+ * - Image content is skipped (Sigil's `MessagePart` union has no image
+ *   type), mirroring `mapUserMessage`.
+ */
+export function mapAgentMessagesForHook(messages: PiAgentMessage[]): Message[] {
+  return messages.map(mapAgentMessageForHook);
+}
+
+function mapAgentMessageForHook(msg: PiAgentMessage): Message {
+  // Null / non-object slot. Emit a placeholder so the 1:1 index alignment
+  // between forward and write-back arrays is preserved; dropping it here
+  // would shrink `forward` below `piMessages` and force the whole transform
+  // to be discarded on write-back. The write-back side skips slots it cannot
+  // touch.
+  if (!msg || typeof msg !== "object") {
+    return { role: "unknown", parts: [] };
+  }
+  const role = (msg as { role?: unknown }).role;
+
+  if (role === "user") {
+    return mapUserMessageForHook(msg as PiUserMessage);
+  }
+  if (role === "assistant") {
+    return mapAssistantMessageForHook(msg as PiAssistantMessage);
+  }
+  if (role === "toolResult") {
+    return mapToolResultForHook(msg as PiToolResult);
+  }
+  // Unknown / custom AgentMessage subtype. Emit a placeholder so the
+  // index alignment between forward and write-back arrays is preserved.
+  return { role: String(role ?? "unknown"), parts: [] };
+}
+
+function mapUserMessageForHook(msg: PiUserMessage): Message {
+  const text = userMessageText(msg);
+  return {
+    role: "user",
+    parts: text.length > 0 ? [{ type: "text", text }] : [],
+  };
+}
+
+function mapAssistantMessageForHook(msg: PiAssistantMessage): Message {
+  // Concatenate all assistant text parts into a single text part. `thinking`
+  // blocks carry an opaque provider signature that must round-trip unchanged,
+  // so they are dropped from the forward payload. `toolCall` blocks are
+  // dropped here too: postflight tool-arg redaction has its own path through
+  // `runToolCallGuard`, and forwarding the call here would duplicate it.
+  const textParts: string[] = [];
+  const partList: NonNullable<Message["parts"]> = [];
+  for (const block of msg.content) {
+    if (block.type === "text" && block.text.length > 0) {
+      textParts.push(block.text);
+    }
+  }
+  if (textParts.length > 0) {
+    partList.push({ type: "text", text: textParts.join("\n") });
+  }
+  return { role: "assistant", parts: partList };
+}
+
+/**
+ * Join a pi tool result's text content into a single string, dropping
+ * non-text parts (e.g. images). Shared by the hook mappers and the tool-span
+ * emitter so tool output is flattened the same way everywhere.
+ */
+export function toolResultText(
+  content: Array<{ type: string; text?: string }>,
+): string {
+  return content
+    .filter(
+      (c): c is { type: "text"; text: string } => c.type === "text" && !!c.text,
+    )
+    .map((c) => c.text)
+    .join("\n");
+}
+
+function mapToolResultForHook(tr: PiToolResult): Message {
+  const text = toolResultText(tr.content);
+  return {
+    role: "tool",
+    parts: [
+      {
+        type: "tool_result",
+        toolResult: {
+          toolCallId: tr.toolCallId,
+          name: tr.toolName,
+          content: text,
+          isError: tr.isError,
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * Write redacted text from a Sigil-side preflight transform back into the
+ * original pi messages, in place. Returns true on a clean apply, false when
+ * any safety check fails (counts diverge, role mismatch, no text part where
+ * one is expected). On a false return, callers must NOT replace pi's
+ * outgoing `messages` — the transform is dropped and the original text
+ * flows through unchanged.
+ *
+ * `thinking` parts on assistant messages are never touched: their opaque
+ * provider signature must round-trip unchanged. Only the assistant text
+ * blocks are overwritten, and only when the redacted message exposes a
+ * single text part covering them all.
+ */
+export function applyRedactedText(
+  piMessages: PiAgentMessage[],
+  redactedSigilMessages: Message[],
+): boolean {
+  if (piMessages.length !== redactedSigilMessages.length) {
+    return false;
+  }
+  for (let i = 0; i < piMessages.length; i++) {
+    const pi = piMessages[i];
+    const sig = redactedSigilMessages[i];
+    if (!sig) return false;
+    // Null / non-object pi slot: nothing writable here. The mapper emitted a
+    // placeholder to keep alignment, so skip it rather than dropping the
+    // redaction for every other message in the turn.
+    if (typeof pi !== "object" || pi === null) continue;
+    const ok = applyRedactedToMessage(pi, sig);
+    if (!ok) return false;
+  }
+  return true;
+}
+
+function applyRedactedToMessage(pi: PiAgentMessage, sig: Message): boolean {
+  const role = (pi as { role?: unknown }).role;
+  if (role === "user") {
+    return applyRedactedToUser(pi as PiUserMessage, sig);
+  }
+  if (role === "assistant") {
+    return applyRedactedToAssistant(pi as PiAssistantMessage, sig);
+  }
+  if (role === "toolResult") {
+    return applyRedactedToToolResult(pi as PiToolResult, sig);
+  }
+  // Unknown role: leave untouched, but accept (alignment preserved).
+  return true;
+}
+
+function extractTextFromSigilMessage(sig: Message): string | null {
+  // Accept both shapes: legacy `content` shorthand and the typed `parts`
+  // array. The Sigil server emits typed parts on the transformed payload,
+  // but tolerate either to keep round-tripping robust to wire changes.
+  if (typeof sig.content === "string") return sig.content;
+  if (!sig.parts) return null;
+  let acc = "";
+  let seenText = false;
+  for (const p of sig.parts) {
+    if (p.type === "text") {
+      if (seenText) acc += "\n";
+      acc += p.text;
+      seenText = true;
+    }
+  }
+  return seenText ? acc : null;
+}
+
+function applyRedactedToUser(pi: PiUserMessage, sig: Message): boolean {
+  const redacted = extractTextFromSigilMessage(sig);
+  if (redacted === null) {
+    // Server stripped the message to nothing (e.g. image-only original).
+    // Leave pi untouched — there is nothing meaningful to write back.
+    return true;
+  }
+  if (typeof pi.content === "string") {
+    pi.content = redacted;
+    return true;
+  }
+  // Array-shaped content: collapse all text parts into the first text
+  // slot and empty the rest. We do not attempt to split the redacted text
+  // back across multiple slots because the regex transform may have
+  // changed or added newlines, and a misaligned split would silently
+  // misrepresent message structure. Image parts are left untouched.
+  return collapseTextParts(
+    pi.content as Array<PiTextContent | PiImageContent>,
+    redacted,
+  );
+}
+
+function applyRedactedToAssistant(
+  pi: PiAssistantMessage,
+  sig: Message,
+): boolean {
+  const redacted = extractTextFromSigilMessage(sig);
+  if (redacted === null) {
+    // No text in the redacted payload (e.g. assistant turn had only tool
+    // calls / thinking originally). Leave pi untouched.
+    return true;
+  }
+  // Collapse text blocks but never touch `thinking` or `toolCall` blocks:
+  // their provider signatures must round-trip unchanged.
+  return collapseTextParts(
+    pi.content as Array<{ type: string; text?: string }>,
+    redacted,
+  );
+}
+
+function applyRedactedToToolResult(pi: PiToolResult, sig: Message): boolean {
+  // For tool-result messages the server keeps the `tool_result` part shape
+  // and redacts `toolResult.content` in place (grafana/sigil
+  // `internal/eval/hooks/transform.go`). The text part path is intentionally
+  // ignored here: the SDK does not synthesize a standalone text part for
+  // redacted tool results, so falling back to `extractTextFromSigilMessage`
+  // would silently miss the redaction.
+  const redacted = extractToolResultContent(sig);
+  if (redacted === null) return true;
+  return collapseTextParts(
+    pi.content as Array<{ type: string; text?: string }>,
+    redacted,
+  );
+}
+
+function extractToolResultContent(sig: Message): string | null {
+  if (!sig.parts) return null;
+  for (const p of sig.parts) {
+    if (p.type !== "tool_result") continue;
+    const c = p.toolResult?.content;
+    if (typeof c === "string") return c;
+  }
+  return null;
+}
+
+/**
+ * Walk a content array, replace the first `text` block's text with
+ * `redacted`, and clear text on any other `text` blocks. Non-text blocks
+ * (`thinking`, `toolCall`, `image`) are left untouched. Returns true if at
+ * least one text block was found and updated, or if there were no text
+ * blocks at all (nothing to redact). Mutates `parts` in place.
+ */
+function collapseTextParts(
+  parts: Array<{ type: string; text?: string }>,
+  redacted: string,
+): boolean {
+  let firstText: { type: string; text?: string } | undefined;
+  let firstTextIndex = -1;
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part?.type === "text") {
+      firstText = part;
+      firstTextIndex = i;
+      break;
+    }
+  }
+  if (!firstText) return true;
+  firstText.text = redacted;
+  for (let i = firstTextIndex + 1; i < parts.length; i++) {
+    const part = parts[i];
+    if (part?.type === "text") part.text = "";
+  }
+  return true;
+}
+
+/**
  * Map a pi user message to a Sigil input Message. Returns null in
  * `metadata_only` (mirrors how assistant text/thinking is dropped) and for
  * empty/whitespace-only content. Image parts are skipped because Sigil's
@@ -557,13 +842,7 @@ function mapToolResultsOutput(
   for (const tr of toolResults) {
     let content = "";
     if (includeBody) {
-      content = tr.content
-        .filter(
-          (c): c is { type: "text"; text: string } =>
-            c.type === "text" && !!c.text,
-        )
-        .map((c) => c.text)
-        .join("\n");
+      content = toolResultText(tr.content);
     }
 
     messages.push({

--- a/plugins/pi/src/testEnv.ts
+++ b/plugins/pi/src/testEnv.ts
@@ -18,3 +18,65 @@ export function clearSigilEnv(): void {
   delete process.env.XDG_CONFIG_HOME;
   resetSigilDotenvStateForTests();
 }
+
+// Keys that the real-SDK suites (golden, guards e2e) snapshot and clear so
+// neither on-disk config.env nor shell exports leak across cases. HOME and the
+// XDG/USERPROFILE pointers are included because loadConfig resolves the dotenv
+// path from them.
+const REALSDK_PRESERVED_KEYS = [
+  "HOME",
+  "USERPROFILE",
+  "XDG_CONFIG_HOME",
+] as const;
+
+function isManagedRealSdkKey(key: string): boolean {
+  return (
+    key.startsWith("SIGIL_") ||
+    key.startsWith("SIGIL_PI_") ||
+    key.startsWith("OTEL_")
+  );
+}
+
+/**
+ * Snapshot then delete the env vars a real-SDK test must control: HOME and the
+ * XDG/USERPROFILE pointers plus every key matched by {@link isManagedRealSdkKey}
+ * (the SIGIL, SIGIL_PI, and OTEL prefixes). Returns the prior values so
+ * {@link restoreEnv} can put them back in afterEach. Also resets the dotenv
+ * loader's owned-keys tracking.
+ */
+export function snapshotAndClearTestEnv(): Record<string, string | undefined> {
+  const keys = new Set<string>(REALSDK_PRESERVED_KEYS);
+  for (const key of Object.keys(process.env)) {
+    if (isManagedRealSdkKey(key)) {
+      keys.add(key);
+    }
+  }
+
+  const saved: Record<string, string | undefined> = {};
+  for (const key of keys) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  resetSigilDotenvStateForTests();
+  return saved;
+}
+
+/** Restore the env captured by {@link snapshotAndClearTestEnv}. */
+export function restoreEnv(saved: Record<string, string | undefined>): void {
+  for (const key of Object.keys(process.env)) {
+    if (
+      (REALSDK_PRESERVED_KEYS as readonly string[]).includes(key) ||
+      isManagedRealSdkKey(key)
+    ) {
+      delete process.env[key];
+    }
+  }
+  for (const [key, value] of Object.entries(saved)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  resetSigilDotenvStateForTests();
+}

--- a/plugins/pi/src/testHttp.ts
+++ b/plugins/pi/src/testHttp.ts
@@ -1,0 +1,184 @@
+// Local HTTP harness for the pi real-SDK guard tests.
+//
+// Stands up one server that routes the two endpoints the real Sigil JS SDK
+// talks to when guards are enabled: `/api/v1/hooks:evaluate` (preflight /
+// postflight evaluation) and `/api/v1/generations:export` (turn export). Hook
+// responses are supplied per request via a caller-provided responder so a
+// single test can model allow / deny / transform / transport-failure / timeout
+// without standing up its own server.
+
+import { createServer, type Server } from "node:http";
+
+const HOOKS_PATH = "/api/v1/hooks:evaluate";
+const EXPORT_PATH = "/api/v1/generations:export";
+
+/** One captured `hooks:evaluate` request: the phase plus the parsed body. */
+export interface HookCall {
+  phase: string;
+  body: HookRequestBody;
+}
+
+/** Shape of the serialized hook request body the plugin sends (snake_case). */
+export interface HookRequestBody {
+  phase?: string;
+  context?: {
+    model?: { provider?: string; name?: string };
+    agent_name?: string;
+    agent_version?: string;
+  };
+  input?: {
+    messages?: unknown[];
+    output?: unknown[];
+  };
+}
+
+/**
+ * What the responder returns for a `hooks:evaluate` request. `json` is the
+ * response body (defaults to a bare allow). `status` overrides the HTTP status
+ * for the transport-failure path. `delayMs` holds the response open so a test
+ * can force a client-side abort/timeout.
+ */
+export interface HookResponse {
+  status?: number;
+  json?: unknown;
+  delayMs?: number;
+}
+
+export interface SigilTestServer {
+  server: Server;
+  baseUrl: string;
+  hookCalls: HookCall[];
+  /** Number of accepted `generations:export` requests. */
+  exportCount: number;
+  /** Non-empty when the server saw an unexpected path or invalid JSON. */
+  errors: string[];
+}
+
+/**
+ * Start a server on 127.0.0.1 that captures `hooks:evaluate` requests and acks
+ * `generations:export`. `hook()` is called once per hook request to produce the
+ * response, so a test can vary behavior across the preflight and postflight
+ * calls of a single turn by returning different values on successive calls.
+ */
+export function startSigilTestServer(opts: {
+  hook: (call: HookCall) => HookResponse;
+}): Promise<SigilTestServer> {
+  const state: SigilTestServer = {
+    server: undefined as unknown as Server,
+    baseUrl: "",
+    hookCalls: [],
+    exportCount: 0,
+    errors: [],
+  };
+
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      let raw = "";
+      req.on("data", (chunk) => {
+        raw += chunk;
+      });
+      req.on("end", () => {
+        const url = req.url ?? "";
+
+        if (url === EXPORT_PATH) {
+          handleExport(raw, res, state);
+          return;
+        }
+        if (url === HOOKS_PATH) {
+          handleHook(raw, res, state, opts.hook);
+          return;
+        }
+
+        state.errors.push(`unexpected path: ${url}`);
+        res.statusCode = 404;
+        res.end(JSON.stringify({ error: "unexpected path" }));
+      });
+    });
+
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        throw new Error("expected AddressInfo from server.address()");
+      }
+      state.server = server;
+      state.baseUrl = `http://127.0.0.1:${addr.port}`;
+      resolve(state);
+    });
+  });
+}
+
+function handleExport(
+  raw: string,
+  res: import("node:http").ServerResponse,
+  state: SigilTestServer,
+): void {
+  let parsed: { generations?: Array<{ id?: string }> };
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    state.errors.push(`invalid export JSON: ${String(err)}`);
+    res.statusCode = 400;
+    res.end(JSON.stringify({ error: "invalid export JSON" }));
+    return;
+  }
+  state.exportCount += 1;
+  const results = (parsed.generations ?? []).map((g) => ({
+    generation_id: g?.id ?? "",
+    accepted: true,
+  }));
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify({ results }));
+}
+
+function handleHook(
+  raw: string,
+  res: import("node:http").ServerResponse,
+  state: SigilTestServer,
+  hook: (call: HookCall) => HookResponse,
+): void {
+  let body: HookRequestBody;
+  try {
+    body = JSON.parse(raw);
+  } catch (err) {
+    state.errors.push(`invalid hook JSON: ${String(err)}`);
+    res.statusCode = 400;
+    res.end(JSON.stringify({ error: "invalid hook JSON" }));
+    return;
+  }
+
+  const call: HookCall = { phase: body.phase ?? "", body };
+  state.hookCalls.push(call);
+  const response = hook(call);
+
+  // The client aborts on timeout, so a delayed response may write to a closed
+  // socket. Swallow those errors instead of crashing the server callback.
+  res.on("error", () => {});
+  const send = () => {
+    try {
+      res.statusCode = response.status ?? 200;
+      res.setHeader("Content-Type", "application/json");
+      res.end(
+        JSON.stringify(response.json ?? { action: "allow", evaluations: [] }),
+      );
+    } catch {
+      /* response already torn down by the aborting client */
+    }
+  };
+
+  if (response.delayMs && response.delayMs > 0) {
+    setTimeout(send, response.delayMs).unref();
+    return;
+  }
+  send();
+}
+
+export function closeServer(server: Server): Promise<void> {
+  // Drop any sockets still held open by a delayed/aborted response so close()
+  // resolves promptly instead of waiting on the timeout responder.
+  (
+    server as Server & { closeAllConnections?: () => void }
+  ).closeAllConnections?.();
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}


### PR DESCRIPTION
Add support for two guard types, both behind `SIGIL_GUARDS_ENABLED`:

  - Preflight: runs the preflight hook with the outgoing messages and writes the redacted text back into pi's AgentMessage list in place, keeping thinking parts and tool_call parts unchanged.
  - Postflight: runToolCallGuard now also returns a transform result; the tool_call handler mutates event.input in place with the redacted arguments before the tool runs.

Both are fail open: if the hook errors, times out, or returns a shape we cannot align 1:1 with the outgoing messages, the original input is passed through. Preflight can't block in Pi, so a deny verdict on the preflight call is currently ignored.

I created two guards (preflight and postflight) to test this:

<img width="714" height="267" alt="image" src="https://github.com/user-attachments/assets/5729c773-5b68-4a5f-bb97-7d9d8073db47" />

And ran a test Pi session:

<img width="386" height="320" alt="image" src="https://github.com/user-attachments/assets/bdfd5ed8-7741-46ab-871d-8ab781101110" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the guard path that mutates conversation text and tool arguments before the model and tools run; incorrect alignment or apply logic could leak secrets or break turns, though the design fails open on errors and mismatches.
> 
> **Overview**
> When **`SIGIL_GUARDS_ENABLED`** is on, the pi plugin now applies Grafana **Transform** guard rules in addition to existing deny blocking.
> 
> **Preflight (`context` event):** Before each model call, outgoing conversation messages are sent to Sigil’s preflight hook; redacted text is written back in place via new **`mapAgentMessagesForHook`** / **`applyRedactedText`**. Assistant **`thinking`** blocks and tool-call structure are preserved; misaligned or failed transforms fail open (original text kept). Preflight **deny** cannot block the turn—only redaction applies.
> 
> **Postflight (`tool_call` event):** **`runToolCallGuard`** can return a **`transform`** as well as **block**; the handler replaces **`event.input`** wholesale (drops keys omitted by the server, then assigns redacted fields) so secrets are not left behind via merge. Deny still blocks; transport errors respect **`SIGIL_GUARDS_FAIL_OPEN`**.
> 
> Docs in **`plugins/pi/README.md`** describe transform behavior and limits. **`client.ts`** documents that preflight uses a separate **`phases: ["preflight"]`** override on **`evaluateHook`**. Test helpers **`testEnv`**, **`testHttp`**, plus unit/e2e coverage for wiring and HTTP round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aaf0df158e6735b12d2dad35e1b02e8a6f3d90a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->