### PR TITLE
ci(plugins/sigil): publish prebuilt binaries on tag push

### DIFF
--- a/.github/workflows/release-sigil-binaries.yml
+++ b/.github/workflows/release-sigil-binaries.yml
@@ -1,0 +1,146 @@
+name: Release plugins/sigil binaries
+
+on:
+  push:
+    tags:
+      - "plugins/sigil/v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing plugins/sigil/v* tag to (re-)release."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-sigil-binaries-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.repository == 'grafana/sigil-sdk'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to create the GitHub Release and upload assets
+
+    steps:
+      - name: Resolve tag and version
+        id: ver
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          # Manual runs must pass an explicit tag; only tag-triggered
+          # pushes can derive it from GITHUB_REF.
+          if [[ -n "$INPUT_TAG" ]]; then
+            TAG="$INPUT_TAG"
+          elif [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          else
+            echo "::error::Input 'tag' is required when dispatching this workflow manually."
+            exit 1
+          fi
+          case "$TAG" in
+            plugins/sigil/v*) ;;
+            *)
+              echo "::error::Refusing to release '$TAG'; expected a plugins/sigil/v* tag."
+              exit 1
+              ;;
+          esac
+          # VERSION carries the leading `v` (e.g. v0.9.0). GoReleaser strips
+          # that to produce {{ .Version }} = 0.9.0.
+          VERSION="${TAG#plugins/sigil/}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Checkout the tagged commit. workflow_dispatch passes a tag in
+          # `inputs.tag`; the push event already points at the tag ref.
+          ref: ${{ steps.ver.outputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: plugins/sigil/go.mod
+          cache: false
+
+      - name: Extract release notes from CHANGELOG.md
+        run: |
+          set -euo pipefail
+          # Grab the top `## [x.y.z]` section. The awk program prints every
+          # line while inside the first section and exits at the next one.
+          notes=$(awk '/^## \[/{n++} n==1{print} n==2{exit}' plugins/sigil/CHANGELOG.md)
+          if [[ -z "$notes" ]]; then
+            echo "::error::No '## [x.y.z]' section found in plugins/sigil/CHANGELOG.md"
+            exit 1
+          fi
+          delim="$(openssl rand -hex 16)"
+          {
+            echo "RELEASE_NOTES<<${delim}"
+            printf '%s\n' "$notes"
+            echo "${delim}"
+          } >> "$GITHUB_ENV"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean -f plugins/sigil/.goreleaser.yaml
+        env:
+          # `release.disable: true` in the config skips goreleaser's GitHub
+          # Release step; the dedicated step below creates the release.
+          GORELEASER_CURRENT_TAG: ${{ steps.ver.outputs.version }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ steps.ver.outputs.tag }}
+          VERSION: ${{ steps.ver.outputs.version }}
+          NOTES: ${{ env.RELEASE_NOTES }}
+        run: |
+          set -euo pipefail
+          # {{ .Version }} in the goreleaser config drops the leading `v`,
+          # so the archive names use the bare semver.
+          BARE_VERSION="${VERSION#v}"
+          # Windows archives are .zip (format_overrides in the goreleaser
+          # config); everything else is tar.gz.
+          assets=(
+            "dist/sigil_${BARE_VERSION}_linux_amd64.tar.gz"
+            "dist/sigil_${BARE_VERSION}_linux_arm64.tar.gz"
+            "dist/sigil_${BARE_VERSION}_darwin_amd64.tar.gz"
+            "dist/sigil_${BARE_VERSION}_darwin_arm64.tar.gz"
+            "dist/sigil_${BARE_VERSION}_windows_amd64.zip"
+            "dist/sigil_${BARE_VERSION}_windows_arm64.zip"
+            "dist/sigil_${BARE_VERSION}_checksums.txt"
+          )
+          for asset in "${assets[@]}"; do
+            if [[ ! -f "$asset" ]]; then
+              echo "::error::Expected asset is missing: $asset"
+              exit 1
+            fi
+          done
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            # Re-release: refresh notes and overwrite existing assets.
+            gh release edit "$TAG" \
+              --title "$TAG" \
+              --notes "$NOTES"
+            gh release upload "$TAG" --clobber "${assets[@]}"
+          else
+            # --verify-tag makes gh check the tag exists on the remote
+            # before creating the release; the release is automatically
+            # pinned to the commit the tag points at.
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes "$NOTES" \
+              --verify-tag \
+              "${assets[@]}"
+          fi

--- a/plugins/sigil/.goreleaser.yaml
+++ b/plugins/sigil/.goreleaser.yaml
@@ -1,0 +1,46 @@
+version: 2
+
+project_name: sigil
+
+builds:
+  - id: sigil
+    binary: sigil
+    main: ./cmd/sigil
+    dir: plugins/sigil
+    env:
+      - CGO_ENABLED=0
+      - GOWORK=off
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X main.version=v{{ .Version }}
+
+archives:
+  - id: sigil
+    ids: [sigil]
+    formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+  algorithm: sha256
+
+# Release creation is handled by the workflow via `gh release create`,
+# so the published artifacts attach to the real `plugins/sigil/v<ver>` tag
+# rather than GORELEASER_CURRENT_TAG.
+release:
+  disable: true
+
+changelog:
+  disable: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only changes with no runtime or application code; release automation uses scoped tag validation and explicit asset checks before upload.
> 
> **Overview**
> Adds automated **prebuilt `sigil` binary releases** when a `plugins/sigil/v*` tag is pushed (or when the workflow is manually dispatched with that tag).
> 
> A new **GoReleaser** config builds static binaries for linux/darwin/windows on amd64 and arm64, packages them as tar.gz (zip on Windows), and emits SHA256 checksums. GoReleaser’s GitHub release step is **disabled** so artifacts attach to the monorepo tag `plugins/sigil/vX.Y.Z` via a dedicated **`gh release create`** step—not a separate GoReleaser tag.
> 
> The workflow validates the tag prefix, checks out the tagged commit, pulls release notes from the top **`## [x.y.z]`** section in `plugins/sigil/CHANGELOG.md`, verifies all expected assets exist, and supports **re-release** (edit notes + clobber uploads) if the release already exists. Runs are limited to **`grafana/sigil-sdk`** with concurrency per tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 314315145c8ebb320e1f06dd494c9c6fe30decab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->