### PR TITLE
ci(plugins/sigil): fix binary release

### DIFF
--- a/.github/workflows/release-sigil-binaries.yml
+++ b/.github/workflows/release-sigil-binaries.yml
@@ -92,10 +92,18 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean -f plugins/sigil/.goreleaser.yaml
+          # `--skip=validate` is required because GORELEASER_CURRENT_TAG
+          # overrides the tag with the prefix-stripped version (e.g.
+          # v0.11.0), which is not a real git tag. Without it goreleaser's
+          # git-state check fails with "git tag v0.11.0 was not made against
+          # commit ...". The monorepo block that would handle the real
+          # plugins/sigil/v* tag natively is goreleaser Pro only.
+          args: release --clean --skip=validate -f plugins/sigil/.goreleaser.yaml
         env:
-          # `release.disable: true` in the config skips goreleaser's GitHub
-          # Release step; the dedicated step below creates the release.
+          # GORELEASER_CURRENT_TAG feeds {{ .Version }} (prefix and leading
+          # `v` stripped). `release.disable: true` in the config skips
+          # goreleaser's GitHub Release step; the dedicated step below
+          # creates the release.
           GORELEASER_CURRENT_TAG: ${{ steps.ver.outputs.version }}
 
       - name: Create GitHub Release


### PR DESCRIPTION
The release job [failed](https://github.com/grafana/sigil-sdk/actions/runs/27052697688) because `GORELEASER_CURRENT_TAG` is set to the prefix-stripped version (e.g. `v0.11.0`), which is not a real tag. GoReleaser's git-state check then aborts with `git tag v0.11.0 was not made against commit ...`. Pass `--skip=validate` so it builds against the overridden version; the real `plugins/sigil/v*` tag is what the gh release step works with.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that skips GoReleaser’s git tag validation; binaries still build from the tagged checkout and releases still use the real `plugins/sigil/v*` tag via `gh`.
> 
> **Overview**
> Fixes failed **plugins/sigil** binary releases by passing **`--skip=validate`** to GoReleaser in `release-sigil-binaries.yml`.
> 
> The workflow sets **`GORELEASER_CURRENT_TAG`** to the semver derived from the monorepo tag (e.g. `v0.11.0`), not the real **`plugins/sigil/v*`** ref. GoReleaser’s default git-state validation then errors because that synthetic tag is not on the checked-out commit. Skipping validate lets the build use the overridden version for **`{{ .Version }}`** while the separate **`gh release`** step still publishes under the actual tag.
> 
> Inline comments were expanded to document why validate is skipped and how **`GORELEASER_CURRENT_TAG`** relates to the disabled GoReleaser release step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd5cb1e020b62d0bf9c03a4a744b8c8ac26b3ca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->