### PR TITLE
feat(plugins/claude): apply transform/redact guards

### DIFF
--- a/plugins/sigil/internal/agents/claudecode/hook.go
+++ b/plugins/sigil/internal/agents/claudecode/hook.go
@@ -246,10 +246,12 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 }
 
 // handlePreToolUse evaluates the tool call against Sigil guards and writes a
-// PreToolUse deny envelope to stdout when the call is blocked. All Sigil
-// transport, credential, fail-open/closed, and local-endpoint placeholder
-// behaviour lives in the shared guard helper so this stays in lockstep with
-// the codex and copilot agents.
+// PreToolUse deny envelope to stdout when the call is blocked, or an
+// allow+updatedInput envelope when a Transform rule redacted the tool
+// arguments. A plain allow stays silent on stdout. All Sigil transport,
+// credential, fail-open/closed, and local-endpoint placeholder behaviour
+// lives in the shared guard helper so this stays in lockstep with the codex
+// and copilot agents.
 func handlePreToolUse(ctx context.Context, stdout io.Writer, input *hookInput, st state.Session, logger *log.Logger) {
 	res := guard.EvaluateToolCall(ctx, envconfig.ResolveGuards(logger), guard.ToolCallInput{
 		AgentName:     AgentName,
@@ -262,6 +264,10 @@ func handlePreToolUse(ctx context.Context, stdout io.Writer, input *hookInput, s
 	}, logger)
 	if res.Blocked() {
 		guard.WriteHookSpecificOutputDeny(stdout, res.Reason)
+		return
+	}
+	if len(res.UpdatedInputJSON) > 0 {
+		guard.WriteHookSpecificOutputUpdatedInput(stdout, res.UpdatedInputJSON)
 	}
 }
 

--- a/plugins/sigil/internal/agents/claudecode/hook_test.go
+++ b/plugins/sigil/internal/agents/claudecode/hook_test.go
@@ -188,11 +188,12 @@ func TestHookEventRouting(t *testing.T) {
 
 // TestHandlePreToolUse covers Claude-Code-specific wiring around the shared
 // guard helper: ensuring the helper is consulted only when guards are
-// enabled, that allow verdicts produce empty stdout, and that deny verdicts
+// enabled, that allow verdicts produce empty stdout, that deny verdicts
 // produce the Claude Code PreToolUse envelope (hookSpecificOutput +
-// hookEventName=PreToolUse). Deep behaviour around fail-open/closed,
-// missing credentials, and transport errors lives in the guard package
-// tests; this test only verifies the integration shape.
+// hookEventName=PreToolUse), and that Transform verdicts produce the
+// allow+updatedInput envelope. Deep behaviour around fail-open/closed,
+// missing credentials, transport errors, and transform extraction lives in
+// the guard package tests; this test only verifies the integration shape.
 func TestHandlePreToolUse(t *testing.T) {
 	var calls atomic.Int32
 	var responseBody atomic.Value
@@ -239,6 +240,25 @@ func TestHandlePreToolUse(t *testing.T) {
 				`A Grafana AI Observability policy`,
 				`blocked tool`,
 			},
+		},
+		{
+			name:             "enabled_allow_transform_writes_updated_input",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_1","name":"Bash","input_json":{"command":"echo [REDACTED]"}}}]}]}}`,
+			expectServerCall: true,
+			wantStdoutContains: []string{
+				`"hookSpecificOutput"`,
+				`"hookEventName":"PreToolUse"`,
+				`"permissionDecision":"allow"`,
+				`"updatedInput":{"command":"echo [REDACTED]"}`,
+			},
+		},
+		{
+			name:             "enabled_allow_unusable_transform_stays_silent",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_other","name":"Bash","input_json":{"command":"echo X"}}}]}]}}`,
+			expectServerCall: true,
+			wantStdoutEmpty:  true,
 		},
 	}
 

--- a/plugins/sigil/internal/agents/guard/toolcall.go
+++ b/plugins/sigil/internal/agents/guard/toolcall.go
@@ -7,6 +7,7 @@ package guard
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -76,6 +77,10 @@ type Result struct {
 	Reason string
 	// RuleID identifies the rule that produced a deny verdict, when known.
 	RuleID string
+	// UpdatedInputJSON carries the transformed (redacted) tool arguments
+	// when Sigil returned a usable Transform verdict for this tool call.
+	// Nil when no transform applies; always nil on deny.
+	UpdatedInputJSON json.RawMessage
 }
 
 // Blocked reports whether the host should refuse to execute the tool call.
@@ -93,7 +98,9 @@ func (r Result) Blocked() bool {
 //   - guards disabled or tool name empty: returns allow.
 //   - credentials missing and fail-open: returns allow.
 //   - credentials missing and fail-closed: returns deny with a credentials reason.
-//   - Sigil returns allow: returns allow.
+//   - Sigil returns allow: returns allow. When the response carries a
+//     transformed_input with redacted arguments for this tool call,
+//     UpdatedInputJSON is set so the host can rewrite the tool input.
 //   - Sigil returns deny: returns deny with the rule reason.
 //   - transport error and fail-open: returns allow (matches SDK behaviour).
 //   - transport error and fail-closed: returns deny with a transport reason.
@@ -230,7 +237,75 @@ func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCa
 		}
 	}
 
-	return Result{Action: sigil.HookActionAllow}
+	return Result{
+		Action:           sigil.HookActionAllow,
+		UpdatedInputJSON: extractToolCallTransform(resp, strings.TrimSpace(in.ToolCallID), logger),
+	}
+}
+
+// extractToolCallTransform walks the server-returned transformed_input for
+// the tool_call part matching toolCallID and returns its arguments as raw
+// JSON. Returns nil on any mismatch or parse failure so the caller falls
+// through to the original tool input unchanged. Mirrors pi guard.ts
+// extractToolCallTransform; keep the two in sync.
+func extractToolCallTransform(resp *sigil.HookEvaluateResponse, toolCallID string, logger *log.Logger) json.RawMessage {
+	if resp == nil || resp.TransformedInput == nil {
+		return nil
+	}
+	for _, msg := range resp.TransformedInput.Output {
+		for _, part := range msg.Parts {
+			if part.Kind != sigil.PartKindToolCall || part.ToolCall == nil || part.ToolCall.ID != toolCallID {
+				continue
+			}
+			// A matching tool_call whose args we cannot parse means the
+			// server sent a transform we cannot apply; log it. The no-match
+			// case stays silent, since that just means there is no redaction
+			// for this call.
+			raw := part.ToolCall.InputJSON
+			if len(raw) > 0 {
+				raw = unwrapProtoJSONBytes(raw)
+			}
+			if len(raw) == 0 {
+				if logger != nil {
+					logger.Printf("guard: tool-call transform for %s dropped: empty arguments", toolCallID)
+				}
+				return nil
+			}
+			if !json.Valid(raw) {
+				if logger != nil {
+					logger.Printf("guard: tool-call transform for %s dropped: invalid JSON arguments", toolCallID)
+				}
+				return nil
+			}
+			var obj map[string]any
+			if err := json.Unmarshal(raw, &obj); err != nil || obj == nil {
+				if logger != nil {
+					logger.Printf("guard: tool-call transform for %s dropped: arguments were not a JSON object", toolCallID)
+				}
+				return nil
+			}
+			return raw
+		}
+	}
+	return nil
+}
+
+// unwrapProtoJSONBytes unwraps transform arguments that arrived as a JSON
+// string. The Sigil server marshals the proto `bytes input_json` field with
+// encoding/json, which base64-encodes it; other emitters may put plain JSON
+// text in the string. Values that are not JSON strings pass through
+// unchanged. Same purpose as the JS SDK's maybeDecodeGoProtoJSONBytes, but
+// stricter: decoded bytes are used only when they are valid JSON; otherwise
+// the raw string contents are returned.
+func unwrapProtoJSONBytes(raw json.RawMessage) json.RawMessage {
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return raw
+	}
+	if decoded, err := base64.StdEncoding.DecodeString(s); err == nil && json.Valid(decoded) {
+		return decoded
+	}
+	return json.RawMessage(s)
 }
 
 // hookSpecificOutputDeny is the PreToolUse deny envelope shared by Claude
@@ -260,6 +335,36 @@ func WriteHookSpecificOutputDeny(stdout io.Writer, reason string) {
 			HookEventName:            "PreToolUse",
 			PermissionDecision:       "deny",
 			PermissionDecisionReason: reason,
+		},
+	})
+}
+
+// hookSpecificOutputUpdatedInput is the PreToolUse allow+updatedInput
+// envelope shared by Claude Code and Codex. Both hosts replace the tool
+// arguments with updatedInput when permissionDecision is allow.
+type hookSpecificOutputUpdatedInput struct {
+	HookSpecificOutput hookSpecificOutputUpdatedInputBody `json:"hookSpecificOutput"`
+}
+
+type hookSpecificOutputUpdatedInputBody struct {
+	HookEventName      string          `json:"hookEventName"`
+	PermissionDecision string          `json:"permissionDecision"`
+	UpdatedInput       json.RawMessage `json:"updatedInput"`
+}
+
+// WriteHookSpecificOutputUpdatedInput writes the PreToolUse allow JSON that
+// replaces the tool arguments with updatedInput. Claude Code and Codex share
+// the exact wire format, so they share this writer; it writes nothing when
+// updatedInput is empty.
+func WriteHookSpecificOutputUpdatedInput(stdout io.Writer, updatedInput json.RawMessage) {
+	if stdout == nil || len(updatedInput) == 0 {
+		return
+	}
+	_ = json.NewEncoder(stdout).Encode(hookSpecificOutputUpdatedInput{
+		HookSpecificOutput: hookSpecificOutputUpdatedInputBody{
+			HookEventName:      "PreToolUse",
+			PermissionDecision: "allow",
+			UpdatedInput:       updatedInput,
 		},
 	})
 }

--- a/plugins/sigil/internal/agents/guard/toolcall_test.go
+++ b/plugins/sigil/internal/agents/guard/toolcall_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -34,6 +33,8 @@ func TestEvaluateToolCall(t *testing.T) {
 		toolName               string
 		wantAction             sigil.HookAction
 		wantReasonSub          string
+		wantUpdatedInput       string
+		wantLogSub             string
 		wantServerCalled       bool
 	}{
 		{
@@ -97,6 +98,70 @@ func TestEvaluateToolCall(t *testing.T) {
 			wantReasonSub: "missing SIGIL_ENDPOINT",
 		},
 		{
+			name:             "allow with transform returns redacted args",
+			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_1","name":"bash","input_json":{"cmd":"echo [REDACTED]"}}}]}]}}`,
+			toolName:         "bash",
+			wantAction:       sigil.HookActionAllow,
+			wantUpdatedInput: `{"cmd":"echo [REDACTED]"}`,
+			wantServerCalled: true,
+		},
+		{
+			// The Sigil server marshals the proto bytes input_json field with
+			// encoding/json, so the real wire value is a base64 JSON string.
+			name:             "allow with base64 string transform decodes server wire format",
+			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_1","name":"bash","input_json":"eyJjb21tYW5kIjoiZWNobyBbUkVEQUNURURdIn0="}}]}]}}`,
+			toolName:         "bash",
+			wantAction:       sigil.HookActionAllow,
+			wantUpdatedInput: `{"command":"echo [REDACTED]"}`,
+			wantServerCalled: true,
+		},
+		{
+			name:             "transform for different tool call id is ignored",
+			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_other","name":"bash","input_json":{"cmd":"echo X"}}}]}]}}`,
+			toolName:         "bash",
+			wantAction:       sigil.HookActionAllow,
+			wantServerCalled: true,
+		},
+		{
+			name:             "invalid transform JSON is dropped",
+			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_1","name":"bash","input_json":"not json"}}]}]}}`,
+			toolName:         "bash",
+			wantAction:       sigil.HookActionAllow,
+			wantLogSub:       "tool-call transform for tu_1 dropped: invalid JSON arguments",
+			wantServerCalled: true,
+		},
+		{
+			name:             "non-object transform arguments are dropped",
+			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_1","name":"bash","input_json":[1,2]}}]}]}}`,
+			toolName:         "bash",
+			wantAction:       sigil.HookActionAllow,
+			wantLogSub:       "tool-call transform for tu_1 dropped: arguments were not a JSON object",
+			wantServerCalled: true,
+		},
+		{
+			name:             "empty transform arguments are dropped",
+			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_1","name":"bash","input_json":""}}]}]}}`,
+			toolName:         "bash",
+			wantAction:       sigil.HookActionAllow,
+			wantLogSub:       "tool-call transform for tu_1 dropped: empty arguments",
+			wantServerCalled: true,
+		},
+		{
+			name:             "deny with transform stays deny without transform",
+			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:   `{"action":"deny","reason":"blocked tool","rule_id":"r-1","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_1","name":"bash","input_json":{"cmd":"echo [REDACTED]"}}}]}]}}`,
+			toolName:         "bash",
+			wantAction:       sigil.HookActionDeny,
+			wantReasonSub:    "blocked tool",
+			wantServerCalled: true,
+		},
+		{
 			// httptest servers bind to a loopback address, which IsLocalEndpoint
 			// classifies as local. With empty creds we expect placeholder auth so
 			// the request proceeds instead of being rejected as missing-creds.
@@ -146,6 +211,7 @@ func TestEvaluateToolCall(t *testing.T) {
 				t.Setenv("SIGIL_AUTH_TOKEN", "token")
 			}
 
+			var logBuf bytes.Buffer
 			res := EvaluateToolCall(context.Background(), tt.cfg, ToolCallInput{
 				AgentName:     "copilot",
 				AgentVersion:  "dev",
@@ -154,13 +220,19 @@ func TestEvaluateToolCall(t *testing.T) {
 				ToolName:      tt.toolName,
 				ToolCallID:    "tu_1",
 				ToolInputJSON: json.RawMessage(`{"cmd":"echo hi"}`),
-			}, log.New(io.Discard, "", 0))
+			}, log.New(&logBuf, "", 0))
 
 			if res.Action != tt.wantAction {
 				t.Fatalf("Action = %q, want %q", res.Action, tt.wantAction)
 			}
 			if tt.wantReasonSub != "" && !strings.Contains(res.Reason, tt.wantReasonSub) {
 				t.Fatalf("Reason = %q, want substring %q", res.Reason, tt.wantReasonSub)
+			}
+			if string(res.UpdatedInputJSON) != tt.wantUpdatedInput {
+				t.Errorf("UpdatedInputJSON = %q, want %q", res.UpdatedInputJSON, tt.wantUpdatedInput)
+			}
+			if tt.wantLogSub != "" && !strings.Contains(logBuf.String(), tt.wantLogSub) {
+				t.Errorf("logs missing %q:\n%s", tt.wantLogSub, logBuf.String())
 			}
 			if tt.wantServerCalled && calls.Load() == 0 {
 				t.Errorf("expected sigil hook server to be called, got 0 calls")
@@ -209,4 +281,35 @@ func TestWriteHookSpecificOutputDeny(t *testing.T) {
 
 	// nil writer must not panic.
 	WriteHookSpecificOutputDeny(nil, "x")
+}
+
+func TestWriteHookSpecificOutputUpdatedInput(t *testing.T) {
+	tests := []struct {
+		name         string
+		updatedInput json.RawMessage
+		want         string
+	}{
+		{
+			name:         "object arguments",
+			updatedInput: json.RawMessage(`{"command":"echo [REDACTED]"}`),
+			want:         `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","updatedInput":{"command":"echo [REDACTED]"}}}` + "\n",
+		},
+		{
+			name:         "empty input writes nothing",
+			updatedInput: nil,
+			want:         "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			WriteHookSpecificOutputUpdatedInput(&buf, tt.updatedInput)
+			if got := buf.String(); got != tt.want {
+				t.Errorf("output = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	// nil writer must not panic.
+	WriteHookSpecificOutputUpdatedInput(nil, json.RawMessage(`{}`))
 }


### PR DESCRIPTION

<img width="215" height="83" alt="image" src="https://github.com/user-attachments/assets/1fd4ab3f-431f-4dfc-82ea-79b86b533760" />


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes PreToolUse guard behavior and tool argument rewriting; invalid transforms fail open to original input, but wrong extraction could alter what tools execute.
> 
> **Overview**
> Adds **Sigil guard transform (redact) support** so allowed tool calls can run with policy-scrubbed arguments instead of only allow/deny.
> 
> The shared **`guard`** package now surfaces **`UpdatedInputJSON`** from hook **`transformed_input`**, including extraction by tool call ID, base64 proto **`input_json`** decoding, and safe fallbacks when the transform is missing or invalid (original args unchanged). A new **`WriteHookSpecificOutputUpdatedInput`** writer emits the Claude Code / Codex **PreToolUse** allow envelope with **`updatedInput`**.
> 
> The **Claude Code** **`PreToolUse`** handler writes that envelope when a usable transform is present; plain allows stay silent and denies still use the deny envelope only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8516607d56f8af59b9473f7ae80d9d3c48641eb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->