### PR TITLE
feat(plugins/sigil): add install script for prebuilt binaries

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -56,10 +56,11 @@ The user wants Grafana AI observability to capture sessions from their coding ag
 
 Install the `sigil` binary:
 
-- **macOS:** `brew install grafana/grafana/sigil`
-- **Linux, Windows, or any platform with Go 1.25+:** `go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest`
+- **Quick install (Linux/macOS):** `curl -fsSL https://raw.githubusercontent.com/grafana/sigil-sdk/main/plugins/sigil/scripts/install.sh | sh` (downloads the latest release, verifies the checksum, installs to `~/.local/bin`)
+- **Homebrew (macOS):** `brew install grafana/grafana/sigil`
+- **Go install (Windows, or any platform with Go 1.25+):** `go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest`
 
-`go install` puts the binary in `go env GOPATH`/bin (or `GOBIN`); make sure that directory is on your `PATH`.
+The script installs to `~/.local/bin`; `go install` puts the binary in `go env GOPATH`/bin (or `GOBIN`). Make sure that directory is on your `PATH`.
 
 Then launch your agent with `sigil <agent>`, where `<agent>` is `claude`, `codex`, `copilot`, `opencode`, or `pi`. On first run it installs the plugin, prompts for credentials, writes `~/.config/sigil/config.env`, and launches the agent.
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -4,21 +4,28 @@ Sends every Claude Code turn to [Grafana AI Observability](https://grafana.com/d
 
 ## 1. Install and launch
 
-**macOS** (Homebrew):
+**Quick install (Linux/macOS):**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/grafana/sigil-sdk/main/plugins/sigil/scripts/install.sh | sh
+sigil claude
+```
+
+**Homebrew (macOS):**
 
 ```sh
 brew install grafana/grafana/sigil
 sigil claude
 ```
 
-**Linux and Windows** (or any platform with Go 1.25+):
+**Go install (Windows, or any platform with Go 1.25+):**
 
 ```sh
 go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
 sigil claude
 ```
 
-`go install` puts `sigil` in `go env GOPATH`/bin (or `GOBIN`); add that to `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for details.
+The script installs `sigil` to `~/.local/bin`; `go install` uses `go env GOPATH`/bin (or `GOBIN`). Make sure that directory is on your `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for all install options.
 
 `sigil claude` registers the `sigil-cc` plugin on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches Claude Code.
 

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -6,21 +6,28 @@ Sends Codex turns to [Grafana AI Observability](https://grafana.com/docs/grafana
 
 ## 1. Install and launch
 
-**macOS** (Homebrew):
+**Quick install (Linux/macOS):**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/grafana/sigil-sdk/main/plugins/sigil/scripts/install.sh | sh
+sigil codex
+```
+
+**Homebrew (macOS):**
 
 ```sh
 brew install grafana/grafana/sigil
 sigil codex
 ```
 
-**Linux and Windows** (or any platform with Go 1.25+):
+**Go install (Windows, or any platform with Go 1.25+):**
 
 ```sh
 go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
 sigil codex
 ```
 
-`go install` puts `sigil` in `go env GOPATH`/bin (or `GOBIN`); add that to `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for details.
+The script installs `sigil` to `~/.local/bin`; `go install` uses `go env GOPATH`/bin (or `GOBIN`). Make sure that directory is on your `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for all install options.
 
 `sigil codex` registers `sigil-codex@grafana-sigil` on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches Codex.
 

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -17,21 +17,28 @@ came from (`hook.surface` = `copilot-cli` or `vscode`).
 
 ## 1. Install and launch
 
-**macOS** (Homebrew):
+**Quick install (Linux/macOS):**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/grafana/sigil-sdk/main/plugins/sigil/scripts/install.sh | sh
+sigil copilot -- <copilot args>
+```
+
+**Homebrew (macOS):**
 
 ```sh
 brew install grafana/grafana/sigil
 sigil copilot -- <copilot args>
 ```
 
-**Linux and Windows** (or any platform with Go 1.25+):
+**Go install (Windows, or any platform with Go 1.25+):**
 
 ```sh
 go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
 sigil copilot -- <copilot args>
 ```
 
-`go install` puts `sigil` in `go env GOPATH`/bin (or `GOBIN`); add that to `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for details.
+The script installs `sigil` to `~/.local/bin`; `go install` uses `go env GOPATH`/bin (or `GOBIN`). Make sure that directory is on your `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for all install options.
 
 `sigil copilot` writes the shared hooks file to `~/.copilot/hooks/sigil.json`, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, removes any legacy `sigil-copilot` plugin left by older versions, and then launches Copilot CLI.
 

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -4,19 +4,25 @@ Sends Cursor agent generations to [Grafana AI Observability](https://grafana.com
 
 ## 1. Install the shared binary
 
-**macOS** (Homebrew):
+**Quick install (Linux/macOS):**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/grafana/sigil-sdk/main/plugins/sigil/scripts/install.sh | sh
+```
+
+**Homebrew (macOS):**
 
 ```sh
 brew install grafana/grafana/sigil
 ```
 
-**Linux and Windows** (or any platform with Go 1.25+):
+**Go install (Windows, or any platform with Go 1.25+):**
 
 ```sh
 go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
 ```
 
-`go install` puts `sigil` in `go env GOPATH`/bin (or `GOBIN`); add that to `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for details.
+The script installs `sigil` to `~/.local/bin`; `go install` uses `go env GOPATH`/bin (or `GOBIN`). Make sure that directory is on your `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for all install options.
 
 Cursor does not have a `sigil cursor` launcher. Install the binary, register the Cursor plugin, then use `sigil login` or `~/.config/sigil/config.env` for credentials.
 

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -6,21 +6,28 @@ By default only metadata is sent (token counts, cost, model, tool names, duratio
 
 ## 1. Install and launch
 
-**macOS** (Homebrew):
+**Quick install (Linux/macOS):**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/grafana/sigil-sdk/main/plugins/sigil/scripts/install.sh | sh
+sigil opencode
+```
+
+**Homebrew (macOS):**
 
 ```sh
 brew install grafana/grafana/sigil
 sigil opencode
 ```
 
-**Linux and Windows** (or any platform with Go 1.25+):
+**Go install (Windows, or any platform with Go 1.25+):**
 
 ```sh
 go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
 sigil opencode
 ```
 
-`go install` puts `sigil` in `go env GOPATH`/bin (or `GOBIN`); add that to `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for details.
+The script installs `sigil` to `~/.local/bin`; `go install` uses `go env GOPATH`/bin (or `GOBIN`). Make sure that directory is on your `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for all install options.
 
 `sigil opencode` installs `@grafana/sigil-opencode` into OpenCode on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches OpenCode. Pass arguments to OpenCode after `--`, e.g. `sigil opencode -- run "say hi"`.
 

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -6,21 +6,28 @@ By default only metadata is sent (token counts, cost, model, tool names, duratio
 
 ## 1. Install and launch
 
-**macOS** (Homebrew):
+**Quick install (Linux/macOS):**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/grafana/sigil-sdk/main/plugins/sigil/scripts/install.sh | sh
+sigil pi
+```
+
+**Homebrew (macOS):**
 
 ```sh
 brew install grafana/grafana/sigil
 sigil pi
 ```
 
-**Linux and Windows** (or any platform with Go 1.25+):
+**Go install (Windows, or any platform with Go 1.25+):**
 
 ```sh
 go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
 sigil pi
 ```
 
-`go install` puts `sigil` in `go env GOPATH`/bin (or `GOBIN`); add that to `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for details.
+The script installs `sigil` to `~/.local/bin`; `go install` uses `go env GOPATH`/bin (or `GOBIN`). Make sure that directory is on your `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for all install options.
 
 `sigil pi` installs the `@grafana/sigil-pi` extension on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches pi.
 

--- a/plugins/sigil/README.md
+++ b/plugins/sigil/README.md
@@ -4,9 +4,19 @@ The launcher binary behind the [Claude Code](../claude-code), [Codex](../codex),
 
 ## Install
 
-On macOS use Homebrew; on Linux and Windows (or any platform with Go 1.25+) use `go install`.
+**Quick install (Linux/macOS):**
 
-**macOS** — Homebrew:
+```sh
+curl -fsSL https://raw.githubusercontent.com/grafana/sigil-sdk/main/plugins/sigil/scripts/install.sh | sh
+```
+
+The script downloads the latest [release](https://github.com/grafana/sigil-sdk/releases) for your OS and architecture, verifies its SHA-256 checksum, and installs the binary to `~/.local/bin`. Re-run it to upgrade. Set `INSTALL_DIR` to change the directory and `VERSION` to pin a release:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/grafana/sigil-sdk/main/plugins/sigil/scripts/install.sh | INSTALL_DIR=/usr/local/bin sh
+```
+
+**Homebrew (macOS):**
 
 ```sh
 brew install grafana/grafana/sigil
@@ -14,7 +24,9 @@ brew install grafana/grafana/sigil
 
 Upgrade later with `brew upgrade grafana/grafana/sigil`.
 
-**Linux and Windows** — `go install` (also works on macOS):
+**Prebuilt binary (Windows):** download the `windows_amd64` or `windows_arm64` zip from the [releases page](https://github.com/grafana/sigil-sdk/releases), extract `sigil.exe`, and put it on your `PATH`.
+
+**Go install (any platform with Go 1.25+):**
 
 ```sh
 go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest

--- a/plugins/sigil/scripts/install.sh
+++ b/plugins/sigil/scripts/install.sh
@@ -1,0 +1,232 @@
+#!/bin/sh
+# install.sh - Download and install the latest sigil binary.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/grafana/sigil-sdk/main/plugins/sigil/scripts/install.sh | sh
+#
+# Environment variables:
+#   INSTALL_DIR    Directory to install into (default: $HOME/.local/bin)
+#   VERSION        Specific version to install, without v prefix (default: latest)
+#   GITHUB_TOKEN   GitHub token for API requests (avoids rate limits)
+
+set -eu
+
+GITHUB_REPO="grafana/sigil-sdk"
+BINARY_NAME="sigil"
+# Binary releases are tagged plugins/sigil/v<ver> in the monorepo.
+TAG_PREFIX="plugins/sigil/v"
+DEFAULT_INSTALL_DIR="${HOME}/.local/bin"
+
+info() {
+    printf '  %s\n' "$@"
+}
+
+warn() {
+    printf '  WARNING: %s\n' "$@" >&2
+}
+
+err() {
+    printf '  ERROR: %s\n' "$@" >&2
+    exit 1
+}
+
+need_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        err "Required command '$1' not found. Please install it and try again."
+    fi
+}
+
+detect_os() {
+    os="$(uname -s)"
+    case "$os" in
+        Linux)  echo "linux" ;;
+        Darwin) echo "darwin" ;;
+        *)      err "Unsupported OS: $os. This installer supports Linux and macOS." \
+                    "On Windows, download the zip from https://github.com/${GITHUB_REPO}/releases" ;;
+    esac
+}
+
+detect_arch() {
+    arch="$(uname -m)"
+    case "$arch" in
+        x86_64|amd64)   echo "amd64" ;;
+        aarch64|arm64)  echo "arm64" ;;
+        *)              err "Unsupported architecture: $arch" ;;
+    esac
+}
+
+detect_user_shell() {
+    if [ -n "${SHELL:-}" ]; then
+        printf '%s\n' "${SHELL##*/}"
+    else
+        printf '%s\n' "sh"
+    fi
+}
+
+print_path_instructions() {
+    install_dir="$1"
+    shell_name=$(detect_user_shell)
+
+    echo ""
+    case "$shell_name" in
+        bash)
+            info "${install_dir} is not in your PATH. Add it with:"
+            echo ""
+            info "  echo 'export PATH=\"${install_dir}:\$PATH\"' >> ~/.bashrc"
+            info "  . ~/.bashrc"
+            ;;
+        zsh)
+            info "${install_dir} is not in your PATH. Add it with:"
+            echo ""
+            info "  echo 'export PATH=\"${install_dir}:\$PATH\"' >> ~/.zshrc"
+            info "  source ~/.zshrc"
+            ;;
+        fish)
+            info "${install_dir} is not in your PATH. Add it with:"
+            echo ""
+            info "  mkdir -p ~/.config/fish"
+            info "  echo 'fish_add_path ${install_dir}' >> ~/.config/fish/config.fish"
+            info "  source ~/.config/fish/config.fish"
+            ;;
+        *)
+            info "${install_dir} is not in your PATH. Add it to your shell startup file:"
+            echo ""
+            info "  export PATH=\"${install_dir}:\$PATH\""
+            ;;
+    esac
+}
+
+get_latest_version() {
+    # The monorepo hosts releases for more than the sigil binary, so
+    # releases/latest is not guaranteed to be one of ours, and the newest
+    # plugins/sigil/v* release can fall past the first page once other
+    # components publish enough releases. Page through (newest first) and
+    # take the first plugins/sigil/v* tag we hit.
+    auth_header=""
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        auth_header="Authorization: Bearer ${GITHUB_TOKEN}"
+    fi
+
+    page=1
+    while [ "$page" -le 10 ]; do
+        url="https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=100&page=${page}"
+        if [ -n "$auth_header" ]; then
+            response=$(curl -fsSL -H "$auth_header" "$url") || err "Failed to fetch releases from GitHub API."
+        else
+            response=$(curl -fsSL "$url") || err "Failed to fetch releases from GitHub API. If rate-limited, set GITHUB_TOKEN or VERSION."
+        fi
+
+        tag=$(printf '%s' "$response" |
+            grep -o "\"tag_name\": *\"${TAG_PREFIX}[^\"]*\"" |
+            sed 's/.*: *"//;s/"$//' |
+            head -1)
+        if [ -n "$tag" ]; then
+            # Strip the tag prefix; archive filenames use bare version numbers.
+            printf '%s' "${tag#"${TAG_PREFIX}"}"
+            return 0
+        fi
+
+        # Stop once a page comes back with no releases at all.
+        if ! printf '%s' "$response" | grep -q '"tag_name"'; then
+            break
+        fi
+
+        page=$((page + 1))
+    done
+
+    err "Could not find a ${TAG_PREFIX}* release."
+}
+
+verify_checksum() {
+    archive_path="$1"
+    expected="$2"
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual=$(sha256sum "$archive_path" | cut -d' ' -f1)
+    elif command -v shasum >/dev/null 2>&1; then
+        actual=$(shasum -a 256 "$archive_path" | cut -d' ' -f1)
+    else
+        warn "Neither sha256sum nor shasum found. Skipping checksum verification."
+        return 0
+    fi
+
+    if [ "$actual" != "$expected" ]; then
+        err "Checksum mismatch! Expected: ${expected}, got: ${actual}"
+    fi
+    info "Checksum verified."
+}
+
+main() {
+    need_cmd curl
+    need_cmd tar
+
+    os=$(detect_os)
+    arch=$(detect_arch)
+
+    if [ -n "${VERSION:-}" ]; then
+        version="${VERSION#v}"
+    else
+        info "Fetching latest release..."
+        version=$(get_latest_version)
+    fi
+
+    install_dir="${INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
+    archive="${BINARY_NAME}_${version}_${os}_${arch}.tar.gz"
+    base_url="https://github.com/${GITHUB_REPO}/releases/download/${TAG_PREFIX}${version}"
+
+    info "Installing ${BINARY_NAME} ${version} (${os}/${arch})"
+
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    # Download archive and checksums.
+    info "Downloading ${archive}..."
+    curl -fsSL "${base_url}/${archive}" -o "${tmpdir}/${archive}" ||
+        err "Failed to download ${base_url}/${archive}"
+
+    checksums_file="${BINARY_NAME}_${version}_checksums.txt"
+    curl -fsSL "${base_url}/${checksums_file}" -o "${tmpdir}/${checksums_file}" ||
+        err "Failed to download checksums file."
+
+    # Verify checksum.
+    expected=$(grep "${archive}" "${tmpdir}/${checksums_file}" | cut -d' ' -f1)
+    if [ -z "$expected" ]; then
+        err "Archive ${archive} not found in checksums file."
+    fi
+    verify_checksum "${tmpdir}/${archive}" "$expected"
+
+    # Extract binary.
+    tar xzf "${tmpdir}/${archive}" -C "${tmpdir}" "${BINARY_NAME}" ||
+        err "Failed to extract ${BINARY_NAME} from archive."
+
+    # Install binary.
+    mkdir -p "$install_dir"
+    mv "${tmpdir}/${BINARY_NAME}" "${install_dir}/${BINARY_NAME}"
+    chmod +x "${install_dir}/${BINARY_NAME}"
+
+    # Remove macOS quarantine attribute if present.
+    if [ "$os" = "darwin" ] && command -v xattr >/dev/null 2>&1; then
+        xattr -d com.apple.quarantine "${install_dir}/${BINARY_NAME}" 2>/dev/null || true
+    fi
+
+    # Verify installation.
+    if "${install_dir}/${BINARY_NAME}" --version >/dev/null 2>&1; then
+        installed_version=$("${install_dir}/${BINARY_NAME}" --version 2>&1 | head -1)
+        info "Installed: ${installed_version}"
+    else
+        info "Installed ${BINARY_NAME} to ${install_dir}/${BINARY_NAME}"
+    fi
+
+    # Check if install dir is in PATH.
+    case ":${PATH}:" in
+        *":${install_dir}:"*) ;;
+        *)
+            print_path_instructions "$install_dir"
+            ;;
+    esac
+
+    echo ""
+    info "To uninstall: rm ${install_dir}/${BINARY_NAME}"
+}
+
+main "$@"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to a new install script and documentation; no runtime or ingest behavior is modified.
> 
> **Overview**
> Adds a **curl \| sh** installer at `plugins/sigil/scripts/install.sh` so Linux and macOS users can install the `sigil` launcher from GitHub release tarballs (default `~/.local/bin`) with SHA-256 verification, optional `VERSION` / `INSTALL_DIR` / `GITHUB_TOKEN`, monorepo-aware release discovery for `plugins/sigil/v*` tags, and shell-specific PATH hints when needed.
> 
> Documentation is updated so **quick install** is the primary path: `llms.txt`, `plugins/sigil/README.md` (plus Windows zip and clearer install ordering), and every agent plugin README (Claude, Codex, Copilot, Cursor, OpenCode, Pi) now lead with the script and clarify PATH for `~/.local/bin` vs `go install`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f49daebd2db4ac556b86c1c9d8ca8b5826dbe3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->