### PR TITLE
feat(plugins/sigil): chart token usage in the local viewer

### DIFF
--- a/plugins/sigil/internal/local/query.go
+++ b/plugins/sigil/internal/local/query.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -25,8 +26,11 @@ type ConversationSummary struct {
 	InputTokens  int64     `json:"input_tokens"`
 	OutputTokens int64     `json:"output_tokens"`
 	TotalTokens  int64     `json:"total_tokens"`
-	Agents       []string  `json:"agents"`
-	Models       []string  `json:"models"`
+	// TokenBuckets sums the disjoint per-generation buckets across the
+	// conversation, for the list's token breakdown tooltip.
+	TokenBuckets TokenBuckets `json:"token_buckets"`
+	Agents       []string     `json:"agents"`
+	Models       []string     `json:"models"`
 	// Status is "ok" or "err". "err" means at least one generation in
 	// the conversation recorded a call_error.
 	Status string `json:"status"`
@@ -40,23 +44,26 @@ type ConversationSummary struct {
 // metadata_only mode, in which case the viewer should fall back to the
 // token counts and tool preview.
 type GenerationView struct {
-	GenerationID    string          `json:"generation_id"`
-	AgentName       string          `json:"agent_name,omitempty"`
-	Model           string          `json:"model,omitempty"`
-	Provider        string          `json:"provider,omitempty"`
-	StartedAt       time.Time       `json:"started_at"`
-	CompletedAt     time.Time       `json:"completed_at"`
-	DurationSeconds float64         `json:"duration_seconds"`
-	InputTokens     int64           `json:"input_tokens"`
-	OutputTokens    int64           `json:"output_tokens"`
-	TotalTokens     int64           `json:"total_tokens"`
-	Messages        []sigil.Message `json:"messages,omitempty"`
-	Input           []sigil.Message `json:"input,omitempty"`
-	Output          []sigil.Message `json:"output,omitempty"`
-	Tools           []string        `json:"tools,omitempty"`
-	ToolPreview     string          `json:"tool_preview,omitempty"`
-	StopReason      string          `json:"stop_reason,omitempty"`
-	CallError       string          `json:"call_error,omitempty"`
+	GenerationID    string    `json:"generation_id"`
+	AgentName       string    `json:"agent_name,omitempty"`
+	Model           string    `json:"model,omitempty"`
+	Provider        string    `json:"provider,omitempty"`
+	StartedAt       time.Time `json:"started_at"`
+	CompletedAt     time.Time `json:"completed_at"`
+	DurationSeconds float64   `json:"duration_seconds"`
+	InputTokens     int64     `json:"input_tokens"`
+	OutputTokens    int64     `json:"output_tokens"`
+	TotalTokens     int64     `json:"total_tokens"`
+	// TokenBuckets is this step's disjoint usage split, so the viewer
+	// can show where the step's tokens went (cache hit vs fresh input).
+	TokenBuckets TokenBuckets    `json:"token_buckets"`
+	Messages     []sigil.Message `json:"messages,omitempty"`
+	Input        []sigil.Message `json:"input,omitempty"`
+	Output       []sigil.Message `json:"output,omitempty"`
+	Tools        []string        `json:"tools,omitempty"`
+	ToolPreview  string          `json:"tool_preview,omitempty"`
+	StopReason   string          `json:"stop_reason,omitempty"`
+	CallError    string          `json:"call_error,omitempty"`
 }
 
 // ConversationDetail is the payload for the detail screen — the
@@ -122,6 +129,7 @@ func summariseConversationFile(path string) (ConversationSummary, bool, error) {
 		sum.InputTokens += usage.InputTokens
 		sum.OutputTokens += usage.OutputTokens
 		sum.TotalTokens += usage.Normalize().TotalTokens
+		sum.TokenBuckets = sum.TokenBuckets.plus(disjointTokenUsage(usage, gen.Model.Provider))
 
 		if !gen.StartedAt.IsZero() && (sum.StartedAt.IsZero() || gen.StartedAt.Before(sum.StartedAt)) {
 			sum.StartedAt = gen.StartedAt
@@ -194,6 +202,7 @@ func (s *Storage) ConversationDetail(id string) (*ConversationDetail, error) {
 			InputTokens:  usage.InputTokens,
 			OutputTokens: usage.OutputTokens,
 			TotalTokens:  usage.Normalize().TotalTokens,
+			TokenBuckets: disjointTokenUsage(usage, gen.Model.Provider),
 			Messages:     threadMessages(input, output),
 			Input:        input,
 			Output:       output,
@@ -216,6 +225,187 @@ func (s *Storage) ConversationDetail(id string) (*ConversationDetail, error) {
 		return out.Generations[i].StartedAt.Before(out.Generations[j].StartedAt)
 	})
 	return out, nil
+}
+
+// TokenBuckets is token usage split into five non-overlapping buckets
+// (see disjointTokenUsage). Because they are disjoint, the viewer can
+// stack or sum them without double-counting; the chart points, the
+// conversation summaries, and the per-step views all share this shape.
+type TokenBuckets struct {
+	FreshInput int64 `json:"fresh_input"`
+	CacheRead  int64 `json:"cache_read"`
+	CacheWrite int64 `json:"cache_write"`
+	Output     int64 `json:"output"`
+	Reasoning  int64 `json:"reasoning"`
+}
+
+func (b TokenBuckets) plus(o TokenBuckets) TokenBuckets {
+	return TokenBuckets{
+		FreshInput: b.FreshInput + o.FreshInput,
+		CacheRead:  b.CacheRead + o.CacheRead,
+		CacheWrite: b.CacheWrite + o.CacheWrite,
+		Output:     b.Output + o.Output,
+		Reasoning:  b.Reasoning + o.Reasoning,
+	}
+}
+
+// TokenUsagePoint is one generation's disjoint token buckets tagged
+// with the model/provider that produced them and the time it ran. The
+// viewer re-buckets these by time to draw the token-usage chart. The
+// embedded TokenBuckets fields flatten into the JSON object.
+type TokenUsagePoint struct {
+	Timestamp time.Time `json:"t"`
+	Model     string    `json:"model,omitempty"`
+	Provider  string    `json:"provider,omitempty"`
+	TokenBuckets
+}
+
+// TokenUsagePoints walks every conversation file and returns one point
+// per generation that recorded any token usage, sorted oldest-first.
+// A missing conversations dir yields no points (first-launch case).
+func (s *Storage) TokenUsagePoints() ([]TokenUsagePoint, error) {
+	dir := filepath.Join(s.dir, ConversationsDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []TokenUsagePoint
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
+			continue
+		}
+		err := scanGenerationRecords(filepath.Join(dir, e.Name()), func(r generationRecord, gen storedGeneration) {
+			if p, ok := tokenUsagePoint(r, gen); ok {
+				out = append(out, p)
+			}
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Timestamp.Before(out[j].Timestamp)
+	})
+	return out, nil
+}
+
+// tokenUsagePoint builds a TokenUsagePoint from one record. ok is false
+// when the generation recorded no tokens or has no usable timestamp, so
+// the caller can skip it rather than plot a zero-height bar at the epoch.
+func tokenUsagePoint(r generationRecord, gen storedGeneration) (TokenUsagePoint, bool) {
+	buckets := disjointTokenUsage(gen.Usage.toSDK(), gen.Model.Provider)
+	if buckets == (TokenBuckets{}) {
+		return TokenUsagePoint{}, false
+	}
+	when := generationTime(gen, r)
+	if when.IsZero() {
+		return TokenUsagePoint{}, false
+	}
+	return TokenUsagePoint{
+		Timestamp:    when,
+		Model:        gen.modelName(),
+		Provider:     gen.Model.Provider,
+		TokenBuckets: buckets,
+	}, true
+}
+
+// generationTime is the wall-clock moment a generation ran, preferring
+// started_at, then completed_at, then the receiver's arrival time.
+func generationTime(gen storedGeneration, r generationRecord) time.Time {
+	if !gen.StartedAt.IsZero() {
+		return gen.StartedAt
+	}
+	if !gen.CompletedAt.IsZero() {
+		return gen.CompletedAt
+	}
+	when, _ := time.Parse(time.RFC3339Nano, r.ReceivedAt)
+	return when
+}
+
+// disjointTokenUsage splits a generation's usage into five buckets that
+// don't overlap, so the viewer can stack them without double-counting.
+//
+// Providers disagree on how cache and reasoning tokens relate to the
+// input/output totals, so both carve-outs are provider-aware:
+//
+//   - cache_read: Anthropic reports input_tokens as the non-cached input,
+//     so cache_read/cache_write are extra on top. OpenAI, Gemini, and
+//     codex fold cached tokens into input_tokens, so cache_read is a
+//     subset that must be carved back out (see cacheReadInsideInput).
+//   - reasoning: OpenAI and codex nest reasoning inside output
+//     (completion) tokens, so it's carved out. Gemini reports thoughts as
+//     additive (output is just the candidate tokens) and Anthropic
+//     doesn't populate it, so for those reasoning stands alone (see
+//     reasoningInsideOutput).
+//
+// cache_write is never folded into input by any provider we map, so it
+// always stands alone.
+//
+// For well-formed usage the buckets sum back to what the provider
+// reported: Anthropic input + cache_read + cache_write + output; OpenAI
+// input + output; Gemini input + output + reasoning (its total also
+// counts tool-use prompt tokens, which the SDK's TokenUsage has no field
+// for). When a subset field exceeds its total, the nonNeg clamps keep
+// the subset and zero the remainder, so the sum can exceed what was
+// reported.
+func disjointTokenUsage(u sigil.TokenUsage, provider string) TokenBuckets {
+	b := TokenBuckets{
+		FreshInput: nonNeg(u.InputTokens),
+		CacheRead:  nonNeg(u.CacheReadInputTokens),
+		CacheWrite: nonNeg(u.CacheWriteInputTokens),
+		Output:     nonNeg(u.OutputTokens),
+		Reasoning:  nonNeg(u.ReasoningTokens),
+	}
+	if cacheReadInsideInput(provider) {
+		b.FreshInput = nonNeg(b.FreshInput - b.CacheRead)
+	}
+	if reasoningInsideOutput(provider) {
+		b.Output = nonNeg(b.Output - b.Reasoning)
+	}
+	return b
+}
+
+// cacheReadInsideInput reports whether the provider counts cache_read
+// tokens within input_tokens (subset semantics). Anthropic keeps them
+// separate; OpenAI and Gemini fold them in, and so does codex, the codex
+// agent's fallback provider for model names it can't attribute (its
+// usage comes from the Responses API). Unknown providers default to
+// "separate" so we never subtract tokens we can't account for and end up
+// hiding real input.
+func cacheReadInsideInput(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "openai", "azure", "azure-openai", "azureopenai", "codex",
+		"gemini", "google", "googleai", "google-genai", "vertex", "vertexai", "google-vertex":
+		return true
+	default:
+		return false
+	}
+}
+
+// reasoningInsideOutput reports whether the provider counts reasoning
+// tokens within output_tokens (subset semantics). OpenAI and codex nest
+// reasoning inside completion tokens; Gemini reports thoughts as a
+// separate additive count and Anthropic doesn't populate reasoning, so
+// both keep it standalone. Unknown providers default to "separate" so we
+// never subtract reasoning we can't account for and end up hiding real
+// output.
+func reasoningInsideOutput(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "openai", "azure", "azure-openai", "azureopenai", "codex":
+		return true
+	default:
+		return false
+	}
+}
+
+func nonNeg(n int64) int64 {
+	if n < 0 {
+		return 0
+	}
+	return n
 }
 
 // scanGenerationRecords walks one per-conversation JSONL file calling visit

--- a/plugins/sigil/internal/local/query_test.go
+++ b/plugins/sigil/internal/local/query_test.go
@@ -134,6 +134,9 @@ func TestListConversations_Aggregates(t *testing.T) {
 		if a.InputTokens != 300 || a.OutputTokens != 130 || a.TotalTokens != 430 {
 			t.Errorf("conv-A tokens = in=%d out=%d total=%d, want 300/130/430", a.InputTokens, a.OutputTokens, a.TotalTokens)
 		}
+		if a.TokenBuckets != (TokenBuckets{FreshInput: 300, Output: 130}) {
+			t.Errorf("conv-A token_buckets = %+v, want fresh=300 output=130", a.TokenBuckets)
+		}
 		if len(a.Agents) != 1 || a.Agents[0] != "pi" {
 			t.Errorf("conv-A agents = %v, want [pi]", a.Agents)
 		}
@@ -263,6 +266,9 @@ func TestConversationDetail(t *testing.T) {
 	}
 	if first.TotalTokens != 15 {
 		t.Errorf("first.total_tokens = %d, want 15 (input+output via Normalize)", first.TotalTokens)
+	}
+	if first.TokenBuckets != (TokenBuckets{FreshInput: 10, Output: 5}) {
+		t.Errorf("first.token_buckets = %+v, want fresh=10 output=5", first.TokenBuckets)
 	}
 	// Dedup keeps a single "bash" tool; preview unwraps `command`.
 	if len(first.Tools) != 1 || first.Tools[0] != "bash" {
@@ -501,4 +507,182 @@ func TestConversationDetail_InputOutputPassThrough(t *testing.T) {
 			tc.check(t, got.Generations[0])
 		})
 	}
+}
+
+// TestDisjointTokenUsage covers the provider-aware split into
+// non-overlapping buckets. Anthropic keeps cache tokens separate from
+// input; OpenAI, Gemini, and codex fold cache_read into input; OpenAI
+// and codex also nest reasoning in output while Gemini keeps thoughts
+// additive; unknown providers default to "separate" on both axes.
+func TestDisjointTokenUsage(t *testing.T) {
+	cases := []struct {
+		name                                                 string
+		provider                                             string
+		usage                                                sigil.TokenUsage
+		freshInput, cacheRead, cacheWrite, output, reasoning int64
+	}{
+		{
+			name:       "anthropic keeps cache additive",
+			provider:   "anthropic",
+			usage:      sigil.TokenUsage{InputTokens: 100, OutputTokens: 50, CacheReadInputTokens: 30, CacheWriteInputTokens: 20},
+			freshInput: 100, cacheRead: 30, cacheWrite: 20, output: 50, reasoning: 0,
+		},
+		{
+			name:       "openai carves cache_read out of input and reasoning out of output",
+			provider:   "openai",
+			usage:      sigil.TokenUsage{InputTokens: 100, OutputTokens: 50, CacheReadInputTokens: 30, ReasoningTokens: 10},
+			freshInput: 70, cacheRead: 30, cacheWrite: 0, output: 40, reasoning: 10,
+		},
+		{
+			name:       "gemini fully cached prompt leaves zero fresh input",
+			provider:   "gemini",
+			usage:      sigil.TokenUsage{InputTokens: 80, OutputTokens: 20, CacheReadInputTokens: 80},
+			freshInput: 0, cacheRead: 80, cacheWrite: 0, output: 20, reasoning: 0,
+		},
+		{
+			// Gemini carves cache_read out of input but keeps thoughts
+			// additive: output stays at the candidate count.
+			name:       "gemini keeps reasoning additive to output",
+			provider:   "gemini",
+			usage:      sigil.TokenUsage{InputTokens: 80, OutputTokens: 40, CacheReadInputTokens: 20, ReasoningTokens: 10},
+			freshInput: 60, cacheRead: 20, cacheWrite: 0, output: 40, reasoning: 10,
+		},
+		{
+			// Azure OpenAI shares OpenAI's subset semantics on both axes.
+			name:       "azure carves cache_read and reasoning out",
+			provider:   "azure",
+			usage:      sigil.TokenUsage{InputTokens: 100, OutputTokens: 50, CacheReadInputTokens: 30, ReasoningTokens: 10},
+			freshInput: 70, cacheRead: 30, cacheWrite: 0, output: 40, reasoning: 10,
+		},
+		{
+			// The codex agent falls back to provider "codex" for model
+			// names it can't attribute; its usage comes from the
+			// Responses API, so OpenAI subset semantics apply.
+			name:       "codex shares openai subset semantics",
+			provider:   "codex",
+			usage:      sigil.TokenUsage{InputTokens: 100, OutputTokens: 50, CacheReadInputTokens: 30, ReasoningTokens: 10},
+			freshInput: 70, cacheRead: 30, cacheWrite: 0, output: 40, reasoning: 10,
+		},
+		{
+			// Unknown provider keeps reasoning additive (never hide output).
+			name:       "unknown provider keeps reasoning additive",
+			provider:   "openrouter",
+			usage:      sigil.TokenUsage{InputTokens: 100, OutputTokens: 50, ReasoningTokens: 10},
+			freshInput: 100, cacheRead: 0, cacheWrite: 0, output: 50, reasoning: 10,
+		},
+		{
+			name:       "unknown provider defaults to separate (no subtraction)",
+			provider:   "mystery-llm",
+			usage:      sigil.TokenUsage{InputTokens: 100, OutputTokens: 50, CacheReadInputTokens: 30},
+			freshInput: 100, cacheRead: 30, cacheWrite: 0, output: 50, reasoning: 0,
+		},
+		{
+			name:       "empty provider defaults to separate",
+			provider:   "",
+			usage:      sigil.TokenUsage{InputTokens: 100, CacheReadInputTokens: 30},
+			freshInput: 100, cacheRead: 30, cacheWrite: 0, output: 0, reasoning: 0,
+		},
+		{
+			name:       "subset cache_read larger than input clamps fresh input to zero",
+			provider:   "openai",
+			usage:      sigil.TokenUsage{InputTokens: 10, OutputTokens: 5, CacheReadInputTokens: 30},
+			freshInput: 0, cacheRead: 30, cacheWrite: 0, output: 5, reasoning: 0,
+		},
+		{
+			name:       "reasoning larger than output clamps output to zero",
+			provider:   "openai",
+			usage:      sigil.TokenUsage{InputTokens: 20, OutputTokens: 5, ReasoningTokens: 10},
+			freshInput: 20, cacheRead: 0, cacheWrite: 0, output: 0, reasoning: 10,
+		},
+		{
+			name:       "negative values clamp to zero",
+			provider:   "anthropic",
+			usage:      sigil.TokenUsage{InputTokens: -5, OutputTokens: -1, CacheReadInputTokens: -3},
+			freshInput: 0, cacheRead: 0, cacheWrite: 0, output: 0, reasoning: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := disjointTokenUsage(tc.usage, tc.provider)
+			assert.Equal(t, TokenBuckets{
+				FreshInput: tc.freshInput,
+				CacheRead:  tc.cacheRead,
+				CacheWrite: tc.cacheWrite,
+				Output:     tc.output,
+				Reasoning:  tc.reasoning,
+			}, b)
+		})
+	}
+}
+
+// TestTokenUsagePoints seeds generations across conversations and checks
+// the flattened, time-sorted points: provider-aware buckets, model and
+// provider tagging, the received_at timestamp fallback, and that
+// zero-token generations are dropped.
+func TestTokenUsagePoints(t *testing.T) {
+	s := newStorage(t)
+
+	writeGen(t, s, "conv-A", "g1", sigil.Generation{
+		Model:       sigil.ModelRef{Provider: "anthropic", Name: "claude-sonnet-4"},
+		StartedAt:   mustParse(t, "2026-05-21T10:00:10Z"),
+		CompletedAt: mustParse(t, "2026-05-21T10:00:12Z"),
+		Usage:       sigil.TokenUsage{InputTokens: 100, OutputTokens: 50, CacheReadInputTokens: 30, CacheWriteInputTokens: 20},
+	}, "2026-05-21T10:00:12Z")
+
+	// Earlier than g1 so it must sort first; OpenAI subset semantics.
+	writeGen(t, s, "conv-B", "g2", sigil.Generation{
+		Model:       sigil.ModelRef{Provider: "openai", Name: "gpt-5-omni"},
+		StartedAt:   mustParse(t, "2026-05-21T09:00:00Z"),
+		CompletedAt: mustParse(t, "2026-05-21T09:00:01Z"),
+		Usage:       sigil.TokenUsage{InputTokens: 100, OutputTokens: 50, CacheReadInputTokens: 30, ReasoningTokens: 10},
+	}, "2026-05-21T09:00:01Z")
+
+	// No started/completed: timestamp must fall back to received_at.
+	writeGen(t, s, "conv-C", "g3", sigil.Generation{
+		Model: sigil.ModelRef{Provider: "anthropic", Name: "claude-opus-4-7"},
+		Usage: sigil.TokenUsage{InputTokens: 5, OutputTokens: 3},
+	}, "2026-05-21T12:00:00Z")
+
+	// Zero tokens: must be dropped entirely.
+	writeGen(t, s, "conv-D", "g4", sigil.Generation{
+		Model:     sigil.ModelRef{Provider: "anthropic", Name: "claude-opus-4-7"},
+		StartedAt: mustParse(t, "2026-05-21T08:00:00Z"),
+	}, "2026-05-21T08:00:00Z")
+
+	points, err := s.TokenUsagePoints()
+	require.NoError(t, err)
+	require.Len(t, points, 3, "zero-token generation should be dropped")
+
+	// Sorted oldest-first: g2 (09:00) → g1 (10:00) → g3 (12:00 received_at).
+	assert.Equal(t, "gpt-5-omni", points[0].Model)
+	assert.Equal(t, "claude-sonnet-4", points[1].Model)
+	assert.Equal(t, "claude-opus-4-7", points[2].Model)
+
+	// g2 OpenAI: cache_read carved out of input, reasoning out of output.
+	assert.Equal(t, TokenUsagePoint{
+		Timestamp:    mustParse(t, "2026-05-21T09:00:00Z"),
+		Model:        "gpt-5-omni",
+		Provider:     "openai",
+		TokenBuckets: TokenBuckets{FreshInput: 70, CacheRead: 30, Output: 40, Reasoning: 10},
+	}, points[0])
+
+	// g1 Anthropic: cache stays additive.
+	assert.Equal(t, TokenUsagePoint{
+		Timestamp:    mustParse(t, "2026-05-21T10:00:10Z"),
+		Model:        "claude-sonnet-4",
+		Provider:     "anthropic",
+		TokenBuckets: TokenBuckets{FreshInput: 100, CacheRead: 30, CacheWrite: 20, Output: 50},
+	}, points[1])
+
+	// g3 timestamp falls back to received_at.
+	assert.Equal(t, mustParse(t, "2026-05-21T12:00:00Z"), points[2].Timestamp)
+}
+
+// TestTokenUsagePoints_EmptyStore checks that TokenUsagePoints returns
+// no points and no error before any conversations exist.
+func TestTokenUsagePoints_EmptyStore(t *testing.T) {
+	s := newStorage(t)
+	points, err := s.TokenUsagePoints()
+	require.NoError(t, err)
+	assert.Empty(t, points)
 }

--- a/plugins/sigil/internal/local/server.go
+++ b/plugins/sigil/internal/local/server.go
@@ -51,6 +51,7 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /assets/app.jsx", s.handleAppJSX)
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
 	mux.HandleFunc("GET /api/v1/conversations", s.handleListConversations)
+	mux.HandleFunc("GET /api/v1/metrics/tokens", s.handleTokenMetrics)
 	mux.HandleFunc("GET /api/v1/conversations/{id}", func(w http.ResponseWriter, r *http.Request) {
 		s.handleConversationDetail(w, r, r.PathValue("id"))
 	})
@@ -234,6 +235,22 @@ func (s *Server) handleListConversations(w http.ResponseWriter, r *http.Request)
 		convs = []ConversationSummary{}
 	}
 	s.writeJSON(w, http.StatusOK, map[string]any{"conversations": convs})
+}
+
+// handleTokenMetrics returns one token-usage point per recorded
+// generation as JSON. The viewer buckets these by time to draw the
+// token-usage chart; an empty store returns an empty array, never null.
+func (s *Server) handleTokenMetrics(w http.ResponseWriter, _ *http.Request) {
+	points, err := s.storage.TokenUsagePoints()
+	if err != nil {
+		s.logger.Printf("local: token metrics: %v", err)
+		http.Error(w, "token metrics: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if points == nil {
+		points = []TokenUsagePoint{}
+	}
+	s.writeJSON(w, http.StatusOK, map[string]any{"points": points})
 }
 
 // handleConversationDetail returns the per-conversation generation

--- a/plugins/sigil/internal/local/server_test.go
+++ b/plugins/sigil/internal/local/server_test.go
@@ -438,3 +438,59 @@ func decodeJSON(t *testing.T, body interface {
 		t.Fatalf("decode: %v", err)
 	}
 }
+
+// TestServer_APITokenMetrics checks the token-usage endpoint the viewer
+// charts: a seeded store returns points with provider-aware disjoint
+// buckets, and a wrong method is rejected. Bucket math and sorting are
+// covered in query_test; this asserts the wire shape.
+func TestServer_APITokenMetrics(t *testing.T) {
+	srv, dir := newTestServer(t)
+	storage, err := NewStorage(dir)
+	require.NoError(t, err)
+
+	writeGen(t, storage, "conv-A", "g1", sigil.Generation{
+		Model:       sigil.ModelRef{Provider: "anthropic", Name: "claude-sonnet-4"},
+		StartedAt:   mustParse(t, "2026-05-21T10:00:00Z"),
+		CompletedAt: mustParse(t, "2026-05-21T10:00:02Z"),
+		Usage:       sigil.TokenUsage{InputTokens: 100, OutputTokens: 50, CacheReadInputTokens: 30, CacheWriteInputTokens: 20},
+	}, "2026-05-21T10:00:02Z")
+
+	t.Run("seeded store returns disjoint points", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/metrics/tokens", nil)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+
+		var body struct {
+			Points []TokenUsagePoint `json:"points"`
+		}
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+		require.Len(t, body.Points, 1)
+		// The embedded TokenBuckets must flatten into the point object;
+		// the viewer reads these keys at the top level.
+		assert.Contains(t, rr.Body.String(), `"fresh_input":100`)
+		assert.Contains(t, rr.Body.String(), `"cache_read":30`)
+		assert.Equal(t, TokenUsagePoint{
+			Timestamp:    mustParse(t, "2026-05-21T10:00:00Z"),
+			Model:        "claude-sonnet-4",
+			Provider:     "anthropic",
+			TokenBuckets: TokenBuckets{FreshInput: 100, CacheRead: 30, CacheWrite: 20, Output: 50},
+		}, body.Points[0])
+	})
+
+	t.Run("wrong method rejected", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/metrics/tokens", strings.NewReader("{}"))
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+	})
+}
+
+func TestServer_APITokenMetrics_EmptyStorage(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/metrics/tokens", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, `{"points":[]}`, strings.TrimSpace(rr.Body.String()))
+}

--- a/plugins/sigil/internal/local/web/app.jsx
+++ b/plugins/sigil/internal/local/web/app.jsx
@@ -59,6 +59,8 @@
     }
 
     const TIME_RANGES = [
+      { value: "5m", label: "Last 5 minutes", ms: 5 * 60 * 1000 },
+      { value: "15m", label: "Last 15 minutes", ms: 15 * 60 * 1000 },
       { value: "1h", label: "Last 1 hour", ms: 60 * 60 * 1000 },
       { value: "6h", label: "Last 6 hours", ms: 6 * 60 * 60 * 1000 },
       { value: "24h", label: "Last 24 hours", ms: 24 * 60 * 60 * 1000 },
@@ -67,7 +69,7 @@
     ];
 
     function timeRangeOption(value) {
-      return TIME_RANGES.find(r => r.value === value) || TIME_RANGES[1];
+      return TIME_RANGES.find(r => r.value === value) || TIME_RANGES.find(r => r.value === "6h");
     }
 
     function conversationTime(c) {
@@ -77,6 +79,7 @@
 
     function formatBucketSize(ms) {
       if (!Number.isFinite(ms) || ms <= 0) return "buckets";
+      if (ms < 60000) return `${Math.round(ms / 1000)}-sec buckets`;
       const mins = Math.round(ms / 60000);
       if (mins < 60) return `${mins}-min buckets`;
       const hours = Math.round(mins / 60);
@@ -90,7 +93,23 @@
       if (bucketMs >= 24 * 60 * 60 * 1000) {
         return d.toLocaleDateString([], { month: "short", day: "numeric" });
       }
-      return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
+      const time = d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
+      // 2h+ buckets mean the chart spans more than a day, so a bare
+      // time is ambiguous — prefix the date.
+      if (bucketMs >= 2 * 60 * 60 * 1000) {
+        return d.toLocaleDateString([], { month: "short", day: "numeric" }) + " " + time;
+      }
+      // Sub-minute buckets need seconds or adjacent labels collide.
+      if (bucketMs < 60 * 1000) {
+        return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false });
+      }
+      return time;
+    }
+
+    // chartTooltipLeft centers the hover tooltip on its bar but keeps it
+    // clear of the card edges so the first and last buckets don't clip.
+    function chartTooltipLeft(i, n) {
+      return `${Math.min(88, Math.max(12, ((i + 0.5) / n) * 100))}%`;
     }
 
     // Per-model dot colour. New models fall back to a neutral grey
@@ -107,34 +126,109 @@
       return MODEL_COLORS[name] || "#808080";
     }
 
-    function bucketActivity(conversations, rangeValue, now, { count = 12 } = {}) {
+    // Token-usage chart series. The server splits each generation into
+    // these five non-overlapping buckets (provider-aware, see
+    // disjointTokenUsage in query.go), so stacking them never
+    // double-counts. Order is bottom-to-top in the stack.
+    const TOKEN_SERIES = [
+      { key: "fresh_input", label: "Input",       color: "var(--viz-blue)" },
+      { key: "cache_read",  label: "Cache read",  color: "var(--viz-green)" },
+      { key: "cache_write", label: "Cache write", color: "var(--viz-purple)" },
+      { key: "output",      label: "Output",      color: "var(--viz-orange)" },
+      { key: "reasoning",   label: "Reasoning",   color: "var(--viz-yellow)" },
+    ];
+
+    // tokenBreakdownTitle renders disjoint token buckets as a multi-line
+    // native tooltip for the list's Tokens cell.
+    function tokenBreakdownTitle(buckets) {
+      if (!buckets) return undefined;
+      const lines = TOKEN_SERIES.filter(s => buckets[s.key] > 0)
+        .map(s => `${s.label}: ${formatTokens(buckets[s.key])}`);
+      return lines.length ? lines.join("\n") : undefined;
+    }
+
+    // timeWindow computes a chart's [start, end] for a range selection.
+    // For "All", min/max accumulate in a loop instead of spreading into
+    // Math.min/Math.max: with one entry per generation the times array
+    // can be large enough that spread overflows the argument stack
+    // (RangeError).
+    function timeWindow(times, rangeValue, now) {
       const range = timeRangeOption(rangeValue);
-      const times = conversations.map(conversationTime).filter(t => t != null);
-      const end = range.ms == null
-        ? Math.max(now, ...times)
-        : now;
-      const start = range.ms == null
-        ? (times.length ? Math.min(...times) : end - 60 * 60 * 1000)
-        : end - range.ms;
+      if (range.ms != null) return { start: now - range.ms, end: now };
+      let minT = Infinity, maxT = -Infinity, n = 0;
+      for (const t of times) {
+        if (!Number.isFinite(t)) continue;
+        n++;
+        if (t < minT) minT = t;
+        if (t > maxT) maxT = t;
+      }
+      const end = n ? Math.max(now, maxT) : now;
+      const start = n ? minT : end - 60 * 60 * 1000;
+      return { start, end };
+    }
+
+    // bucketByTime lays out `count` equal buckets across the selected
+    // range and folds every in-window item into its bucket: init seeds a
+    // bucket's counters, add(bucket, item) accumulates one item. Pass
+    // `window` to share one [start, end] between charts.
+    function bucketByTime(items, getTime, rangeValue, now, { count = 12, init, add, window: win }) {
+      const times = items.map(getTime);
+      const { start, end } = win || timeWindow(times, rangeValue, now);
       const span = Math.max(end - start, 60 * 1000);
       const bucketMs = span / count;
       const buckets = [];
       for (let i = 0; i < count; i++) {
         const bucketStart = start + i * bucketMs;
+        // The last bucket absorbs the end instant, mirroring the clamped
+        // index below, so [start, end) tests against bucket bounds agree
+        // with where points were counted.
         const bucketEnd = i === count - 1 ? end + 1 : bucketStart + bucketMs;
-        buckets.push({
-          t: formatBucketLabel(bucketStart, bucketMs),
-          start: bucketStart,
-          end: bucketEnd,
-          c: 0,
-        });
+        buckets.push({ t: formatBucketLabel(bucketStart, bucketMs), start: bucketStart, end: bucketEnd, ...init() });
       }
-      for (const t of times) {
-        if (t < start || t > end) continue;
-        const idx = Math.min(count - 1, Math.max(0, Math.floor((t - start) / bucketMs)));
-        buckets[idx].c++;
-      }
+      items.forEach((item, i) => {
+        const t = times[i];
+        if (!Number.isFinite(t) || t < start || t > end) return;
+        add(buckets[Math.min(count - 1, Math.max(0, Math.floor((t - start) / bucketMs)))], item);
+      });
       return { buckets, bucketLabel: formatBucketSize(bucketMs) };
+    }
+
+    function tokenPointTime(p) {
+      return new Date(p.t).getTime();
+    }
+
+    // bucketTokenUsage sums each disjoint token series per bucket. points
+    // carry an RFC3339 `t` plus the five token fields.
+    function bucketTokenUsage(points, rangeValue, now, opts = {}) {
+      let grandTotal = 0;
+      const totals = {};
+      for (const s of TOKEN_SERIES) totals[s.key] = 0;
+      const result = bucketByTime(points, tokenPointTime, rangeValue, now, {
+        ...opts,
+        init: () => {
+          const b = { total: 0 };
+          for (const s of TOKEN_SERIES) b[s.key] = 0;
+          return b;
+        },
+        add: (b, p) => {
+          for (const s of TOKEN_SERIES) {
+            const v = p[s.key] || 0;
+            b[s.key] += v;
+            b.total += v;
+            totals[s.key] += v;
+            grandTotal += v;
+          }
+        },
+      });
+      return { ...result, grandTotal, totals };
+    }
+
+    function bucketActivity(conversations, rangeValue, now, opts = {}) {
+      return bucketByTime(conversations, conversationTime, rangeValue, now, {
+        ...opts,
+        init: () => ({ c: 0 }),
+        add: b => { b.c += 1; },
+      });
     }
 
     // ============================================================
@@ -353,7 +447,32 @@
     // Screen 1 — Conversations list
     // ============================================================
 
-    function ActivityChart({ data, bucketLabel, accent = "var(--brand-orange)" }) {
+    // ChartSwitch picks which metric the single chart slot shows. It
+    // doubles as the chart's title: the active segment names the data.
+    function ChartSwitch({ value, onChange }) {
+      const opts = [
+        { value: "tokens", label: "Tokens" },
+        { value: "activity", label: "Conversations" },
+      ];
+      return (
+        <div style={{ display: "inline-flex", border: "1px solid var(--border-medium)", borderRadius: 2, overflow: "hidden" }}>
+          {opts.map(o => {
+            const active = o.value === value;
+            return (
+              <button key={o.value} onClick={() => onChange(o.value)} style={{
+                padding: "4px 10px",
+                background: active ? "rgba(204,204,220,0.08)" : "transparent",
+                color: active ? "var(--fg-max)" : "var(--fg2)",
+                border: "none", cursor: active ? "default" : "pointer",
+                fontSize: 11, fontFamily: "var(--fontFamilyMonospace)",
+              }}>{o.label}</button>
+            );
+          })}
+        </div>
+      );
+    }
+
+    function ActivityChart({ data, bucketLabel, switcher, selection, onBucketClick, accent = "var(--brand-orange)" }) {
       const W = 100, H = 32;
       const max = Math.max(1, ...data.map(d => d.c));
       const barW = (W / Math.max(1, data.length)) * 0.7;
@@ -363,7 +482,7 @@
       return (
         <div style={{ position: "relative", padding: "16px 20px 12px", background: "var(--bg-primary)", border: "1px solid var(--border-weak)", borderRadius: 2 }}>
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
-            <div style={{ fontSize: 13, color: "var(--fg1)", fontWeight: 500 }}>Conversation activity</div>
+            {switcher}
             <div style={{ display: "flex", alignItems: "center", gap: 12, fontSize: 11, color: "var(--fg3)", fontFamily: "var(--fontFamilyMonospace)" }}>
               <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
                 <span style={{ width: 10, height: 10, background: accent, borderRadius: 1 }}/> count
@@ -381,10 +500,17 @@
                 const x = i * (W / data.length) + gap/2;
                 const y = H - h;
                 const isHover = hover === i;
+                // Midpoint containment, not overlap: the window shifts a
+                // little every render (now moves), so an overlap test can
+                // light up two adjacent bars.
+                const isSel = selection && (d.start + d.end) / 2 >= selection.start && (d.start + d.end) / 2 < selection.end;
+                const dim = selection && !isSel;
                 return (
-                  <g key={i} onMouseEnter={() => setHover(i)} onMouseLeave={() => setHover(null)}>
+                  <g key={i} onMouseEnter={() => setHover(i)} onMouseLeave={() => setHover(null)}
+                    onClick={onBucketClick ? () => onBucketClick(d) : undefined}
+                    style={{ cursor: onBucketClick ? "pointer" : "default" }}>
                     <rect x={x - 0.4} y={0} width={barW + 0.8} height={H} fill="transparent"/>
-                    <rect x={x} y={y} width={barW} height={Math.max(h, 0.4)} fill={isHover ? "var(--brand-orange-text)" : accent} opacity={isHover ? 1 : 0.85}/>
+                    <rect x={x} y={y} width={barW} height={Math.max(h, 0.4)} fill={isHover ? "var(--brand-orange-text)" : accent} opacity={isHover || isSel ? 1 : dim ? 0.3 : 0.85}/>
                   </g>
                 );
               })}
@@ -395,7 +521,7 @@
             {hover !== null && (
               <div style={{
                 position: "absolute",
-                left: `${((hover + 0.5) / data.length) * 100}%`,
+                left: chartTooltipLeft(hover, data.length),
                 transform: "translate(-50%, -100%)",
                 top: -4,
                 background: "var(--bg-secondary)",
@@ -410,6 +536,166 @@
                 boxShadow: "var(--shadow-z2)",
               }}>
                 <span style={{ color: "var(--fg3)" }}>{data[hover].t}</span> · {data[hover].c} {data[hover].c === 1 ? "conversation" : "conversations"}
+              </div>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    // Stacked token-usage-over-time chart. Mirrors ActivityChart's frame
+    // but stacks the five disjoint token series per bucket, with a
+    // per-model filter and a click-to-toggle legend. data comes from
+    // bucketTokenUsage.
+    function TokenChart({ data, bucketLabel, grandTotal, totals, models, model, onModelChange, switcher, selection, onBucketClick }) {
+      const W = 100, H = 32;
+      const barW = (W / Math.max(1, data.length)) * 0.7;
+      const gap  = (W / Math.max(1, data.length)) * 0.3;
+      const [hover, setHover] = useState(null);
+      const [hidden, setHidden] = useState(() => new Set());
+      const toggleSeries = key => setHidden(prev => {
+        const next = new Set(prev);
+        next.has(key) ? next.delete(key) : next.add(key);
+        return next;
+      });
+      // Only show legend entries for series that actually appear, so a
+      // pure-Anthropic store doesn't carry an always-zero "Reasoning"
+      // swatch. Fall back to the full set when there's no data at all.
+      const present = TOKEN_SERIES.filter(s => data.some(d => d[s.key] > 0));
+      const legend = present.length ? present : TOKEN_SERIES;
+      // Hidden series drop out of the bars, the tooltip, and the y scale,
+      // so toggling a dominant series (usually cache reads) rescales the
+      // chart to show what's left.
+      const visible = TOKEN_SERIES.filter(s => !hidden.has(s.key));
+      const visibleTotal = d => visible.reduce((acc, s) => acc + (d[s.key] || 0), 0);
+      const max = Math.max(1, ...data.map(visibleTotal));
+      const empty = grandTotal === 0;
+      // The header total tracks the visible series so it always matches
+      // the stacked bars and the tooltip; hiding a series excludes it
+      // here too. The cache stat only renders while both of its inputs
+      // are visible — with cache read hidden it would claim "0% cached".
+      const shownTotal = totals ? visible.reduce((acc, s) => acc + (totals[s.key] || 0), 0) : grandTotal;
+      const cacheVisible = !hidden.has("fresh_input") && !hidden.has("cache_read");
+      const cacheDenom = totals ? (totals.fresh_input || 0) + (totals.cache_read || 0) : 0;
+      const cachePct = cacheVisible && cacheDenom > 0 ? Math.round(((totals.cache_read || 0) / cacheDenom) * 100) : null;
+      const yLabel = {
+        position: "absolute", left: 0, transform: "translateY(-50%)",
+        fontSize: 10, lineHeight: "10px", color: "var(--fg3)",
+        fontFamily: "var(--fontFamilyMonospace)",
+        background: "var(--bg-primary)", padding: "1px 4px 1px 0",
+        pointerEvents: "none",
+      };
+
+      return (
+        <div style={{ position: "relative", padding: "16px 20px 12px", background: "var(--bg-primary)", border: "1px solid var(--border-weak)", borderRadius: 2 }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10, gap: 12, flexWrap: "wrap" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              {switcher}
+              <span style={{ color: "var(--fg3)", fontFamily: "var(--fontFamilyMonospace)", fontSize: 11 }}>
+                {formatTokens(shownTotal)} tok
+                {cachePct != null && (
+                  <span title="Share of input tokens served from the prompt cache: cache read / (fresh input + cache read)"> · {cachePct}% cached</span>
+                )}
+              </span>
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 12, fontSize: 11, color: "var(--fg3)", fontFamily: "var(--fontFamilyMonospace)", flexWrap: "wrap" }}>
+              {legend.map(s => {
+                const off = hidden.has(s.key);
+                return (
+                  <button key={s.key} onClick={() => toggleSeries(s.key)}
+                    title={off ? `Show ${s.label}` : `Hide ${s.label}`}
+                    style={{
+                      display: "inline-flex", alignItems: "center", gap: 6,
+                      background: "transparent", border: "none", padding: 0,
+                      cursor: "pointer", font: "inherit",
+                      color: off ? "var(--fg3)" : "inherit",
+                      opacity: off ? 0.6 : 1,
+                      textDecoration: off ? "line-through" : "none",
+                    }}>
+                    <span style={{ width: 10, height: 10, boxSizing: "border-box", background: off ? "transparent" : s.color, border: `1px solid ${off ? "var(--border-medium)" : s.color}`, borderRadius: 1 }}/> {s.label}
+                  </button>
+                );
+              })}
+              {models.length > 0 && (
+                <select value={model} onChange={e => onModelChange(e.target.value)} title="Filter by model"
+                  style={{ height: 24, padding: "0 6px", border: "1px solid var(--border-medium)", borderRadius: 2, background: "var(--bg-primary)", color: "var(--fg1)", fontSize: 11, fontFamily: "var(--fontFamilyMonospace)" }}>
+                  <option value="all">All models</option>
+                  {models.map(m => <option key={m} value={m}>{m}</option>)}
+                </select>
+              )}
+              <span>{bucketLabel}</span>
+            </div>
+          </div>
+          <div style={{ position: "relative" }}>
+            <svg viewBox={`0 0 ${W} ${H + 8}`} preserveAspectRatio="none" style={{ width: "100%", height: 130, display: "block" }}>
+              {[0, 1, 2, 3, 4].map(g => (
+                <line key={g} x1={0} x2={W} y1={(H * g)/4} y2={(H * g)/4} stroke="rgba(204,204,220,0.06)" strokeWidth="0.2"/>
+              ))}
+              {data.map((d, i) => {
+                const x = i * (W / data.length) + gap/2;
+                const isHover = hover === i;
+                // Midpoint containment, not overlap — see ActivityChart.
+                const isSel = selection && (d.start + d.end) / 2 >= selection.start && (d.start + d.end) / 2 < selection.end;
+                const dim = selection && !isSel;
+                const barOpacity = isHover || isSel ? 1 : dim ? 0.3 : 0.85;
+                let yTop = H;
+                const segs = [];
+                for (const s of visible) {
+                  const v = d[s.key] || 0;
+                  if (v <= 0) continue;
+                  const h = (v / max) * H;
+                  yTop -= h;
+                  segs.push(<rect key={s.key} x={x} y={yTop} width={barW} height={Math.max(h, 0.2)} fill={s.color} opacity={barOpacity}/>);
+                }
+                return (
+                  <g key={i} onMouseEnter={() => setHover(i)} onMouseLeave={() => setHover(null)}
+                    onClick={onBucketClick ? () => onBucketClick(d) : undefined}
+                    style={{ cursor: onBucketClick ? "pointer" : "default" }}>
+                    <rect x={x - 0.4} y={0} width={barW + 0.8} height={H} fill="transparent"/>
+                    {segs}
+                  </g>
+                );
+              })}
+            </svg>
+            {/* The svg stretches its viewBox, so the y-scale labels are
+                HTML overlays pinned to the top and middle gridlines (0px
+                and 52px of the 130px-tall plot). */}
+            {!empty && visible.length > 0 && <div style={{ ...yLabel, top: 0 }}>{formatTokens(max)}</div>}
+            {!empty && visible.length > 0 && <div style={{ ...yLabel, top: 52 }}>{formatTokens(Math.round(max / 2))}</div>}
+            {empty && (
+              <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: 130, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 11, color: "var(--fg3)", fontFamily: "var(--fontFamilyMonospace)", pointerEvents: "none" }}>
+                No token usage {model !== "all" ? `for ${model} ` : ""}in this range
+              </div>
+            )}
+            <div style={{ display: "flex", justifyContent: "space-between", marginTop: 4, fontSize: 10, color: "var(--fg3)", fontFamily: "var(--fontFamilyMonospace)" }}>
+              {data.map((d, i) => <span key={i} style={{ flex: 1, textAlign: "left" }}>{d.t}</span>)}
+            </div>
+            {hover !== null && visibleTotal(data[hover]) > 0 && (
+              <div style={{
+                position: "absolute",
+                left: chartTooltipLeft(hover, data.length),
+                transform: "translate(-50%, -100%)",
+                top: -4,
+                background: "var(--bg-secondary)",
+                border: "1px solid var(--border-medium)",
+                borderRadius: 2,
+                padding: "6px 8px",
+                fontFamily: "var(--fontFamilyMonospace)",
+                fontSize: 11,
+                color: "var(--fg1)",
+                whiteSpace: "nowrap",
+                pointerEvents: "none",
+                boxShadow: "var(--shadow-z2)",
+                zIndex: 1,
+              }}>
+                <div style={{ color: "var(--fg3)", marginBottom: 4 }}>{data[hover].t} · {formatTokens(visibleTotal(data[hover]))} tok</div>
+                {visible.filter(s => data[hover][s.key] > 0).map(s => (
+                  <div key={s.key} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                    <span style={{ width: 8, height: 8, background: s.color, borderRadius: 1 }}/>
+                    <span style={{ color: "var(--fg2)" }}>{s.label}</span>
+                    <span style={{ marginLeft: "auto", color: "var(--fg1)" }}>{formatTokens(data[hover][s.key])}</span>
+                  </div>
+                ))}
               </div>
             )}
           </div>
@@ -508,7 +794,7 @@
             <span style={{ color: "var(--fg3)", padding: "0 6px" }}>·</span>
             <span style={{ color: "var(--fg1)" }}>{c.calls} {c.calls === 1 ? "call" : "calls"}</span>
           </span>
-          <span style={{ color: "var(--fg1)" }}>{formatTokens(c.total_tokens)}</span>
+          <span style={{ color: "var(--fg1)" }} title={tokenBreakdownTitle(c.token_buckets)}>{formatTokens(c.total_tokens)}</span>
           <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
             {(c.agents || []).map(a => <AgentPill key={a} name={a} size="sm"/>)}
           </div>
@@ -519,7 +805,25 @@
       );
     }
 
-    function ConversationsView({ conversations, loading, error, query, setQuery, timeRange, setTimeRange, onOpen, onRefresh, refreshing }) {
+    // SortHeader is a clickable list-header cell: click sorts by the
+    // column, clicking again flips the direction.
+    function SortHeader({ label, sortKey, sort, onSort }) {
+      const active = sort.key === sortKey;
+      return (
+        <button onClick={() => onSort(sortKey)} title={`Sort by ${label.toLowerCase()}`}
+          style={{
+            display: "inline-flex", alignItems: "center", gap: 4,
+            background: "transparent", border: "none", padding: 0,
+            cursor: "pointer", font: "inherit", textAlign: "left",
+            textTransform: "uppercase", letterSpacing: "0.08em", fontWeight: 500,
+            color: active ? "var(--fg1)" : "inherit",
+          }}>
+          {label}{active && <span style={{ fontSize: 8 }}>{sort.dir === "asc" ? "▲" : "▼"}</span>}
+        </button>
+      );
+    }
+
+    function ConversationsView({ conversations, tokenPoints, loading, error, query, setQuery, timeRange, setTimeRange, tokenModel, setTokenModel, chartMetric, setChartMetric, bucketSel, setBucketSel, listSort, setListSort, onOpen, onRefresh, refreshing }) {
       const now = Date.now();
       const range = timeRangeOption(timeRange);
       const rangeFiltered = useMemo(() => {
@@ -541,12 +845,93 @@
         );
       }, [rangeFiltered, query]);
 
-      const activity = useMemo(() => bucketActivity(filtered, timeRange, now), [filtered, timeRange, now]);
+      // Token chart has its own model filter and is driven only by the
+      // time range, not the text query (token points carry model, not the
+      // searchable conversation fields). The selection lives in App so it
+      // survives navigating into a conversation and back; a model that
+      // disappears from the store falls back to "all" by derivation.
+      const points = tokenPoints || [];
+      const tokenModels = useMemo(
+        () => Array.from(new Set(points.map(p => p.model).filter(Boolean))).sort(),
+        [points]
+      );
+      const effectiveModel = tokenModels.includes(tokenModel) ? tokenModel : "all";
+      const tokenFiltered = useMemo(
+        () => effectiveModel === "all" ? points : points.filter(p => p.model === effectiveModel),
+        [points, effectiveModel]
+      );
+      // Both metrics share one window so switching the chart between
+      // them doesn't shift the time axis; with per-metric windows the
+      // "All" range drifts when the datasets' extents differ.
+      const chartWindow = useMemo(() => {
+        const times = filtered.map(conversationTime).concat(tokenFiltered.map(tokenPointTime));
+        return timeWindow(times, timeRange, now);
+      }, [filtered, tokenFiltered, timeRange, now]);
+      const activity = useMemo(
+        () => bucketActivity(filtered, timeRange, now, { window: chartWindow }),
+        [filtered, timeRange, now, chartWindow]
+      );
+      const tokenUsage = useMemo(
+        () => bucketTokenUsage(tokenFiltered, timeRange, now, { window: chartWindow }),
+        [tokenFiltered, timeRange, now, chartWindow]
+      );
+
+      // Bucket drill-down from a chart bar click: the list narrows to
+      // conversations active inside the picked bucket, while the charts
+      // keep the full window and just highlight the selection.
+      const onBucketClick = useCallback(b => {
+        setBucketSel(sel => sel && sel.start === b.start && sel.end === b.end ? null : { start: b.start, end: b.end });
+      }, [setBucketSel]);
+      const listFiltered = useMemo(() => {
+        if (!bucketSel) return filtered;
+        return filtered.filter(c => {
+          const endT = conversationTime(c);
+          if (endT == null) return false;
+          const startT = new Date(c.started_at).getTime();
+          const s = Number.isFinite(startT) ? startT : endT;
+          return s < bucketSel.end && endT >= bucketSel.start;
+        });
+      }, [filtered, bucketSel]);
+
+      const handleSort = useCallback(key => {
+        setListSort(s => s.key === key ? { key, dir: s.dir === "desc" ? "asc" : "desc" } : { key, dir: "desc" });
+      }, [setListSort]);
+      const sorted = useMemo(() => {
+        const dir = listSort.dir === "asc" ? 1 : -1;
+        const val = c => {
+          if (listSort.key === "duration") {
+            const d = durationBetweenSeconds(c.started_at, c.last_activity);
+            return d == null ? -1 : d;
+          }
+          if (listSort.key === "tokens") return c.total_tokens || 0;
+          const t = conversationTime(c);
+          return t == null ? 0 : t;
+        };
+        return [...listFiltered].sort((a, b) => (val(a) - val(b)) * dir);
+      }, [listFiltered, listSort]);
 
       return (
         <div style={{ padding: 24, maxWidth: 1600, margin: "0 auto" }}>
           <FilterBar query={query} onQueryChange={setQuery} timeRange={timeRange} onTimeRangeChange={setTimeRange} onRefresh={onRefresh} refreshing={refreshing}/>
-          <ActivityChart data={activity.buckets} bucketLabel={activity.bucketLabel}/>
+          {chartMetric === "activity"
+            ? <ActivityChart data={activity.buckets} bucketLabel={activity.bucketLabel}
+                selection={bucketSel} onBucketClick={onBucketClick}
+                switcher={<ChartSwitch value={chartMetric} onChange={setChartMetric}/>}/>
+            : <TokenChart data={tokenUsage.buckets} bucketLabel={tokenUsage.bucketLabel} grandTotal={tokenUsage.grandTotal} totals={tokenUsage.totals} models={tokenModels} model={effectiveModel} onModelChange={setTokenModel}
+                selection={bucketSel} onBucketClick={onBucketClick}
+                switcher={<ChartSwitch value={chartMetric} onChange={setChartMetric}/>}/>}
+
+          {bucketSel && (
+            <div style={{ marginTop: 10, display: "flex", alignItems: "center", gap: 10, fontSize: 11, fontFamily: "var(--fontFamilyMonospace)", color: "var(--fg2)" }}>
+              <span>
+                Showing {formatBucketLabel(bucketSel.start, bucketSel.end - bucketSel.start)} – {formatBucketLabel(bucketSel.end, bucketSel.end - bucketSel.start)}
+              </span>
+              <button onClick={() => setBucketSel(null)}
+                style={{ background: "transparent", border: "1px solid var(--border-medium)", borderRadius: 2, color: "var(--fg2)", cursor: "pointer", fontSize: 11, fontFamily: "var(--fontFamilyMonospace)", padding: "1px 8px" }}>
+                ✕ clear
+              </button>
+            </div>
+          )}
 
           <div style={{
             marginTop: 18,
@@ -564,7 +949,11 @@
               background: "var(--bg-secondary)",
               fontSize: 11, color: "var(--fg3)", textTransform: "uppercase", letterSpacing: "0.08em", fontWeight: 500,
             }}>
-              <span>Last activity</span><span>Conversation</span><span>Duration</span><span>Tokens</span><span>Agents</span><span>Models</span>
+              <SortHeader label="Last activity" sortKey="last_activity" sort={listSort} onSort={handleSort}/>
+              <span>Conversation</span>
+              <SortHeader label="Duration" sortKey="duration" sort={listSort} onSort={handleSort}/>
+              <SortHeader label="Tokens" sortKey="tokens" sort={listSort} onSort={handleSort}/>
+              <span>Agents</span><span>Models</span>
             </div>
 
             {error && (
@@ -592,7 +981,12 @@
                 No matches for <code style={{ color: "var(--fg1)" }}>{query}</code>.
               </div>
             )}
-            {filtered.map(c => <ConvRow key={c.id} c={c} now={now} onOpen={onOpen}/>)}
+            {!error && bucketSel && listFiltered.length === 0 && filtered.length > 0 && (
+              <div style={{ padding: "16px 18px", color: "var(--fg2)", fontSize: 12 }}>
+                No conversations in the selected bucket.
+              </div>
+            )}
+            {sorted.map(c => <ConvRow key={c.id} c={c} now={now} onOpen={onOpen}/>)}
           </div>
 
           <div style={{
@@ -600,7 +994,7 @@
             fontSize: 11, color: "var(--fg3)",
             fontFamily: "var(--fontFamilyMonospace)",
           }}>
-            {filtered.length} of {conversations.length} {conversations.length === 1 ? "conversation" : "conversations"}
+            {sorted.length} of {conversations.length} {conversations.length === 1 ? "conversation" : "conversations"}
           </div>
         </div>
       );
@@ -736,6 +1130,31 @@
       );
     }
 
+    // StepTokenBar shows one step's disjoint token buckets: a thin
+    // proportional stacked bar plus labeled counts in the chart's series
+    // colors. Answers "did this step hit the prompt cache?" at a glance.
+    function StepTokenBar({ buckets }) {
+      if (!buckets) return null;
+      const parts = TOKEN_SERIES.map(s => ({ ...s, v: buckets[s.key] || 0 })).filter(p => p.v > 0);
+      const total = parts.reduce((acc, p) => acc + p.v, 0);
+      if (total === 0) return null;
+      return (
+        <div style={{ marginBottom: 10 }}>
+          <div style={{ display: "flex", height: 4, borderRadius: 1, overflow: "hidden", marginBottom: 6 }}>
+            {parts.map(p => <span key={p.key} style={{ width: `${(p.v / total) * 100}%`, background: p.color }}/>)}
+          </div>
+          <div style={{ display: "flex", gap: 12, flexWrap: "wrap", fontSize: 11, fontFamily: "var(--fontFamilyMonospace)", color: "var(--fg2)" }}>
+            {parts.map(p => (
+              <span key={p.key} style={{ display: "inline-flex", alignItems: "center", gap: 5 }}>
+                <span style={{ width: 8, height: 8, background: p.color, borderRadius: 1 }}/>
+                {p.label} <span style={{ color: "var(--fg1)" }}>{formatTokens(p.v)}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      );
+    }
+
     function StepCard({ step, n, expanded, onToggle }) {
       const hasError = !!step.call_error;
       const dotColor = hasError ? "var(--error-text)" : "#73BF69";
@@ -789,6 +1208,8 @@
                   <span style={{ color: "var(--fg3)", fontFamily: "var(--fontFamilyMonospace)" }}>provider · {step.provider}</span>
                 )}
               </div>
+
+              <StepTokenBar buckets={step.token_buckets}/>
 
               {hasError && (
                 <div style={{ marginBottom: 10 }}>
@@ -981,13 +1402,43 @@
       };
     }
 
+    // usePersistedState is useState mirrored into localStorage (string
+    // values only, plain values — no updater functions) so viewer
+    // preferences survive reloads. accept guards against stale or
+    // foreign stored values; storage errors (private mode, disabled)
+    // fall back to in-memory state.
+    function usePersistedState(key, initial, accept) {
+      const [value, setValue] = useState(() => {
+        try {
+          const raw = window.localStorage.getItem(key);
+          return raw != null && accept(raw) ? raw : initial;
+        } catch (_) {
+          return initial;
+        }
+      });
+      const set = useCallback(v => {
+        setValue(v);
+        try {
+          window.localStorage.setItem(key, v);
+        } catch (_) {}
+      }, [key]);
+      return [value, set];
+    }
+
     function App() {
       const [selectedID, setSelectedID] = useState(conversationIDFromPath);
       const [conversations, setConversations] = useState([]);
+      const [tokenPoints, setTokenPoints] = useState([]);
       const [loadingList, setLoadingList] = useState(true);
       const [errList, setErrList] = useState(null);
       const [query, setQuery] = useState("");
-      const [timeRange, setTimeRange] = useState("6h");
+      const [timeRange, setTimeRange] = usePersistedState("sigil.local.timeRange", "6h",
+        v => TIME_RANGES.some(r => r.value === v));
+      const [tokenModel, setTokenModel] = useState("all");
+      const [chartMetric, setChartMetric] = usePersistedState("sigil.local.chartMetric", "tokens",
+        v => v === "tokens" || v === "activity");
+      const [bucketSel, setBucketSel] = useState(null);
+      const [listSort, setListSort] = useState({ key: "last_activity", dir: "desc" });
 
       const [detail, setDetail] = useState(null);
       const [loadingDetail, setLoadingDetail] = useState(false);
@@ -997,6 +1448,18 @@
       const selected = selectedID
         ? conversations.find(c => c.id === selectedID) || summaryFromDetail(detail, selectedID)
         : null;
+
+      // Changing the time range invalidates a bucket drill-down: the
+      // bucket boundaries belong to the old window.
+      const changeTimeRange = useCallback(v => {
+        setBucketSel(null);
+        setTimeRange(v);
+      }, [setTimeRange]);
+
+      const pageTitle = view === "conversation" && selected
+        ? `${selected.title || selected.id} — sigil local`
+        : "sigil — local";
+      useEffect(() => { document.title = pageTitle; }, [pageTitle]);
 
       const fetchList = useCallback(() => {
         setLoadingList(true);
@@ -1009,6 +1472,21 @@
           .catch(e => setErrList(String(e.message || e)))
           .finally(() => setLoadingList(false));
       }, []);
+
+      // Token points back the usage chart. Failures are swallowed: the
+      // chart is supplementary, so a hiccup here shouldn't surface an
+      // error banner over the conversation list.
+      const fetchTokens = useCallback(() => {
+        return fetch("/api/v1/metrics/tokens")
+          .then(r => r.ok ? r.json() : null)
+          .then(body => { if (body) setTokenPoints(body.points || []); })
+          .catch(() => {});
+      }, []);
+
+      const refreshAll = useCallback(() => {
+        fetchList();
+        fetchTokens();
+      }, [fetchList, fetchTokens]);
 
       const fetchDetail = useCallback((id) => {
         setLoadingDetail(true);
@@ -1025,7 +1503,7 @@
           .finally(() => setLoadingDetail(false));
       }, []);
 
-      useEffect(() => { fetchList(); }, [fetchList]);
+      useEffect(() => { refreshAll(); }, [refreshAll]);
 
       useEffect(() => {
         const onPopState = () => setSelectedID(conversationIDFromPath());
@@ -1049,9 +1527,9 @@
       // user.
       useEffect(() => {
         if (view !== "conversations") return;
-        const id = setInterval(fetchList, 30_000);
+        const id = setInterval(refreshAll, 30_000);
         return () => clearInterval(id);
-      }, [view, fetchList]);
+      }, [view, refreshAll]);
 
       const openConv = (c) => {
         window.history.pushState({}, "", conversationPath(c.id));
@@ -1078,14 +1556,23 @@
             {view === "conversations" && (
               <ConversationsView
                 conversations={conversations}
+                tokenPoints={tokenPoints}
                 loading={loadingList}
                 error={errList}
                 query={query}
                 setQuery={setQuery}
                 timeRange={timeRange}
-                setTimeRange={setTimeRange}
+                setTimeRange={changeTimeRange}
+                tokenModel={tokenModel}
+                setTokenModel={setTokenModel}
+                chartMetric={chartMetric}
+                setChartMetric={setChartMetric}
+                bucketSel={bucketSel}
+                setBucketSel={setBucketSel}
+                listSort={listSort}
+                setListSort={setListSort}
                 onOpen={openConv}
-                onRefresh={fetchList}
+                onRefresh={refreshAll}
                 refreshing={loadingList}
               />
             )}


### PR DESCRIPTION
Add a `GET /api/v1/metrics/tokens` endpoint that returns data per generation, plus a "Token usage" chart in the viewer with a per-model filter:

```
SIGIL_CONTENT_CAPTURE_MODE=full go run ./plugins/sigil/cmd/sigil/main.go pi --local
```

<img width="1302" height="470" alt="image" src="https://github.com/user-attachments/assets/8b34faea-a402-4495-bdf2-970b28f3d3b0" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Token bucket math depends on provider heuristics; mistakes would skew charts/tooltips but not affect generation storage or auth. Large viewer changes are covered by new Go tests for bucket logic and the metrics endpoint.
> 
> **Overview**
> Adds **provider-aware disjoint token buckets** (fresh input, cache read/write, output, reasoning) so stacked charts and tooltips do not double-count when providers fold cache or reasoning into input/output totals. Conversation list, detail steps, and a new **`GET /api/v1/metrics/tokens`** endpoint all expose **`token_buckets`** / time-series **points** per generation.
> 
> The local viewer gains a **Tokens vs Conversations** chart switch, a **stacked token-usage chart** (model filter, toggleable series, cache-hit %), **token breakdown tooltips** on the list and **per-step bars** in detail, plus **sortable columns**, **5m/15m ranges**, **persisted chart/time prefs**, and **click-a-bar bucket drill-down** that narrows the conversation list while keeping the full chart window (shared **`timeWindow`** also fixes **RangeError** on “All” with many generations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c678a98fd816d431db70783d0ba8f3f88c27950. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->