### PR TITLE
feat(plugins/codex): apply transform/redact guards

### DIFF
--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sigil-codex",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Send Codex session telemetry to Grafana Sigil",
   "author": {
     "name": "Grafana Labs"

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -118,7 +118,7 @@ tail -f ~/.local/state/sigil/logs/sigil.log
 | `SIGIL_GUARDS_TIMEOUT_MS` | `1500` | Per-call guard timeout. |
 | `SIGIL_AUTO_UPDATE` | `true` | Refresh the `sigil-codex` plugin automatically. Set `false` to pin the installed version. |
 
-Guards only intercept tool calls that Codex routes through `PreToolUse` — Bash, the `apply_patch` variants, and MCP tools. See the [Codex hooks docs](https://developers.openai.com/codex/hooks) for the supported set.
+Guard rules can block a tool call or rewrite its arguments (Transform rules, e.g. redacting a secret before the tool runs). Guards only intercept tool calls that Codex routes through `PreToolUse` — Bash, the `apply_patch` variants, and MCP tools. See the [Codex hooks docs](https://developers.openai.com/codex/hooks) for the supported set.
 
 If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>`.
 

--- a/plugins/sigil/internal/agents/codex/hook/handlers.go
+++ b/plugins/sigil/internal/agents/codex/hook/handlers.go
@@ -82,10 +82,11 @@ func UserPromptSubmit(p Payload, cfg config.Config, logger *log.Logger) {
 }
 
 // PreToolUse evaluates a Codex tool call against Sigil guard rules. It writes
-// a PreToolUse deny envelope to stdout when the call must be blocked and
-// stays silent when the call is allowed. Transport setup, credential checks,
-// and fail-open/closed behaviour live in the shared guard package. Claude
-// Code and Codex also share the PreToolUse deny envelope writer.
+// a PreToolUse deny envelope to stdout when the call must be blocked, an
+// allow+updatedInput envelope when a Transform rule redacted the tool
+// arguments, and stays silent on a plain allow. Transport setup, credential
+// checks, and fail-open/closed behaviour live in the shared guard package.
+// Claude Code and Codex also share both PreToolUse envelope writers.
 func PreToolUse(ctx context.Context, stdout io.Writer, p Payload, cfg config.Config, logger *log.Logger) {
 	res := guard.EvaluateToolCall(ctx, cfg.Guards, guard.ToolCallInput{
 		AgentName:     mapper.AgentName,
@@ -97,7 +98,29 @@ func PreToolUse(ctx context.Context, stdout io.Writer, p Payload, cfg config.Con
 	}, logger)
 	if res.Blocked() {
 		guard.WriteHookSpecificOutputDeny(stdout, res.Reason)
+		return
 	}
+	if len(res.UpdatedInputJSON) == 0 {
+		return
+	}
+	// Codex rejects Bash and apply_patch updatedInput without a string
+	// command field, which would error the tool call instead of running it.
+	// A transform that strips command therefore fails open: keep the
+	// original arguments.
+	if hasStringCommand(p.ToolInput) && !hasStringCommand(res.UpdatedInputJSON) {
+		logger.Printf("guard: tool-call transform for %s dropped: transformed arguments missing string command field", p.ToolUseID)
+		return
+	}
+	guard.WriteHookSpecificOutputUpdatedInput(stdout, res.UpdatedInputJSON)
+}
+
+func hasStringCommand(raw json.RawMessage) bool {
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return false
+	}
+	_, ok := obj["command"].(string)
+	return ok
 }
 
 func guardProviderFromModel(model string) string {

--- a/plugins/sigil/internal/agents/codex/hook/handlers_test.go
+++ b/plugins/sigil/internal/agents/codex/hook/handlers_test.go
@@ -748,9 +748,12 @@ func TestPreToolUseGuard(t *testing.T) {
 		useClosedEndpoint  bool
 		clearCreds         bool
 		serverResponds     string
+		toolInput          string
 		expectServerCall   bool
 		wantStdoutContains []string
+		wantStdoutExcludes []string
 		wantStdoutEmpty    bool
+		wantLogContains    string
 	}{
 		{
 			name:            "disabled_by_default_no_env",
@@ -812,6 +815,60 @@ func TestPreToolUseGuard(t *testing.T) {
 			clearCreds:         true,
 			wantStdoutContains: []string{`"permissionDecision":"deny"`, "missing SIGIL_ENDPOINT/SIGIL_AUTH_TENANT_ID/SIGIL_AUTH_TOKEN"},
 		},
+		{
+			name:             "enabled_allow_transform_writes_updated_input",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_1","name":"Bash","input_json":{"command":"echo [REDACTED]"}}}]}]}}`,
+			expectServerCall: true,
+			wantStdoutContains: []string{
+				`"hookSpecificOutput"`,
+				`"hookEventName":"PreToolUse"`,
+				`"permissionDecision":"allow"`,
+				`"updatedInput":{"command":"echo [REDACTED]"}`,
+			},
+		},
+		{
+			name:             "enabled_allow_transform_for_mcp_tool_without_command",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_1","name":"mcp__vault__read","input_json":{"token":"REDACTED"}}}]}]}}`,
+			toolInput:        `{"token":"secret"}`,
+			expectServerCall: true,
+			wantStdoutContains: []string{
+				`"permissionDecision":"allow"`,
+				`"updatedInput":{"token":"REDACTED"}`,
+			},
+		},
+		{
+			name:             "enabled_allow_transform_dropping_command_is_dropped",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_1","name":"Bash","input_json":{"args":"echo [REDACTED]"}}}]}]}}`,
+			expectServerCall: true,
+			wantStdoutEmpty:  true,
+			wantLogContains:  "tool-call transform for tu_1 dropped",
+		},
+		{
+			name:             "enabled_allow_transform_with_null_command_is_dropped",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_1","name":"Bash","input_json":{"command":null}}}]}]}}`,
+			expectServerCall: true,
+			wantStdoutEmpty:  true,
+			wantLogContains:  "tool-call transform for tu_1 dropped",
+		},
+		{
+			name:               "enabled_deny_with_transform_stays_deny_only",
+			env:                map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:     `{"action":"deny","reason":"blocked tool","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_1","name":"Bash","input_json":{"command":"echo [REDACTED]"}}}]}]}}`,
+			expectServerCall:   true,
+			wantStdoutContains: []string{`"permissionDecision":"deny"`, "blocked tool"},
+			wantStdoutExcludes: []string{"updatedInput"},
+		},
+		{
+			name:             "enabled_allow_unusable_transform_stays_silent",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_other","name":"Bash","input_json":{"command":"echo X"}}}]}]}}`,
+			expectServerCall: true,
+			wantStdoutEmpty:  true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -843,12 +900,16 @@ func TestPreToolUseGuard(t *testing.T) {
 			cfg := config.Load(log.New(io.Discard, "", 0))
 			var stdout bytes.Buffer
 			var logs bytes.Buffer
+			toolInput := tt.toolInput
+			if toolInput == "" {
+				toolInput = `{"command":"echo hi"}`
+			}
 			payload := Payload{
 				HookEventName: "PreToolUse",
 				SessionID:     "sess",
 				ToolName:      "Bash",
 				ToolUseID:     "tu_1",
-				ToolInput:     json.RawMessage(`{"command":"echo hi"}`),
+				ToolInput:     json.RawMessage(toolInput),
 				Model:         "gpt-5",
 			}
 
@@ -867,6 +928,14 @@ func TestPreToolUseGuard(t *testing.T) {
 				if !strings.Contains(stdout.String(), want) {
 					t.Errorf("stdout = %q, want substring %q", stdout.String(), want)
 				}
+			}
+			for _, exclude := range tt.wantStdoutExcludes {
+				if strings.Contains(stdout.String(), exclude) {
+					t.Errorf("stdout = %q, must not contain %q", stdout.String(), exclude)
+				}
+			}
+			if tt.wantLogContains != "" && !strings.Contains(logs.String(), tt.wantLogContains) {
+				t.Errorf("logs missing %q:\n%s", tt.wantLogContains, logs.String())
 			}
 		})
 	}

--- a/plugins/sigil/internal/agents/codex/hook_test.go
+++ b/plugins/sigil/internal/agents/codex/hook_test.go
@@ -30,7 +30,7 @@ func TestHookRoutesPreToolUse(t *testing.T) {
 		name               string
 		serverResponds     string
 		wantStdoutEmpty    bool
-		wantStdoutContains string
+		wantStdoutContains []string
 	}{
 		{
 			name:            "allow_response_produces_empty_stdout",
@@ -40,7 +40,17 @@ func TestHookRoutesPreToolUse(t *testing.T) {
 		{
 			name:               "deny_response_emits_codex_deny_json",
 			serverResponds:     `{"action":"deny","reason":"blocked"}`,
-			wantStdoutContains: `"permissionDecision":"deny"`,
+			wantStdoutContains: []string{`"permissionDecision":"deny"`},
+		},
+		{
+			name:           "transform_response_emits_allow_updated_input_json",
+			serverResponds: `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_1","name":"Bash","input_json":{"command":"echo [REDACTED]"}}}]}]}}`,
+			wantStdoutContains: []string{
+				`"hookSpecificOutput"`,
+				`"hookEventName":"PreToolUse"`,
+				`"permissionDecision":"allow"`,
+				`"updatedInput":{"command":"echo [REDACTED]"}`,
+			},
 		},
 	}
 
@@ -65,8 +75,10 @@ func TestHookRoutesPreToolUse(t *testing.T) {
 			if tt.wantStdoutEmpty && stdout.Len() != 0 {
 				t.Errorf("stdout not empty: %q", stdout.String())
 			}
-			if tt.wantStdoutContains != "" && !strings.Contains(stdout.String(), tt.wantStdoutContains) {
-				t.Errorf("stdout = %q, want substring %q", stdout.String(), tt.wantStdoutContains)
+			for _, want := range tt.wantStdoutContains {
+				if !strings.Contains(stdout.String(), want) {
+					t.Errorf("stdout = %q, want substring %q", stdout.String(), want)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Add transform tool arguments guard support:

<img width="991" height="414" alt="image" src="https://github.com/user-attachments/assets/d9f089fc-1b71-4809-8c40-b14066203031" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes run on every guarded tool call and can alter arguments before execution; fail-open on bad transforms limits breakage but incorrect transforms could still affect MCP or other tools.
> 
> **Overview**
> **Codex `PreToolUse` guards** now support **Transform** rules (e.g. redact secrets in tool args), not just deny. When Sigil returns allow with transformed input, the hook writes the shared **allow + `updatedInput`** envelope to stdout; plain allow and deny behavior is unchanged, and deny responses never include `updatedInput`.
> 
> For **Bash / apply_patch** tools, if the original input had a string **`command`** but the transform removes or invalidates it, the transform is **dropped** and the call proceeds with the original args (fail-open) so Codex does not error on malformed `updatedInput`. MCP-style tools without `command` can still be rewritten.
> 
> Docs note Transform guard behavior; **`sigil-codex`** version is **0.3.0**. Tests cover transform, deny-only, dropped transforms, and end-to-end hook routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e64bbfe66e5b14ee52b3df989b4aababe1e419e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->