### PR TITLE
feat(plugins/cursor): add tool-call guards (block + transform)

### DIFF
--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -113,6 +113,9 @@ tail -f ~/.local/state/sigil/logs/sigil.log
 | `SIGIL_TAGS` | — | `key=value,key=value` tags on every generation and as `sigil.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). Built-ins (`git.branch`, `cwd`, `subagent`) win on generation-export tag collision. |
 | `SIGIL_USER_ID` | from Cursor | Override the user id. |
 | `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
+| `SIGIL_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Cursor `preToolUse` hook is evaluated against Sigil: tool calls denied by guard rules are blocked, and Transform rules rewrite the tool arguments before execution. |
+| `SIGIL_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |
+| `SIGIL_GUARDS_TIMEOUT_MS` | `1500` | Per-call timeout. Lower = less added latency on every tool call, higher = better tolerance for slow `llm_judge` evaluators. |
 | `SIGIL_BIN` | auto | Override the binary path if you installed `sigil` somewhere unusual. |
 
 If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your AI Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>`.

--- a/plugins/cursor/hooks/hooks.json
+++ b/plugins/cursor/hooks/hooks.json
@@ -3,6 +3,7 @@
   "hooks": {
     "sessionStart":       [{ "command": "${CURSOR_PLUGIN_ROOT}/scripts/run.sh" }],
     "beforeSubmitPrompt": [{ "command": "${CURSOR_PLUGIN_ROOT}/scripts/run.sh" }],
+    "preToolUse":         [{ "command": "${CURSOR_PLUGIN_ROOT}/scripts/run.sh" }],
     "afterAgentResponse": [{ "command": "${CURSOR_PLUGIN_ROOT}/scripts/run.sh" }],
     "afterAgentThought":  [{ "command": "${CURSOR_PLUGIN_ROOT}/scripts/run.sh" }],
     "postToolUse":        [{ "command": "${CURSOR_PLUGIN_ROOT}/scripts/run.sh" }],

--- a/plugins/sigil/internal/agents/cursor/hook.go
+++ b/plugins/sigil/internal/agents/cursor/hook.go
@@ -1,10 +1,11 @@
 // Package cursor implements the Cursor agent adapter for the consolidated
 // sigil binary. The dispatcher in cmd/sigil routes `sigil cursor hook` here.
 //
-// Cursor expects a permissive JSON response on `before*` events when the
+// Cursor expects a permissive JSON response on pre-execution events when the
 // plugin wants to allow the action — a missing or non-JSON stdout on those
 // events is treated as a block. We always emit the permissive response on
-// beforeSubmitPrompt regardless of how dispatch terminates.
+// beforeSubmitPrompt regardless of how dispatch terminates, and on preToolUse
+// whenever the guard handler did not get a chance to answer itself.
 package cursor
 
 import (
@@ -22,16 +23,39 @@ import (
 
 const permissiveResponse = `{"continue":true,"permission":"allow"}` + "\n"
 
-var beforeSubmitMarker = []byte(`"hook_event_name":"beforeSubmitPrompt"`)
+var (
+	beforeSubmitMarker = []byte(`"hook_event_name":"beforeSubmitPrompt"`)
+	preToolUseMarker   = []byte(`"hook_event_name":"preToolUse"`)
+)
 
 // Hook reads a Cursor hook JSON payload from stdin and dispatches it to the
 // matching handler. On beforeSubmitPrompt the permissive response is
 // always emitted to stdout, even on parse failure, so Cursor never blocks
-// the user's input on telemetry trouble.
+// the user's input on telemetry trouble. preToolUse gets the same treatment
+// when dispatch bails before the guard handler runs; the handler itself
+// always writes a response on every evaluation outcome.
 func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Logger) error {
 	var raw []byte
+	var event string
+	parsed := false
+	preToolUseHandled := false
 	defer func() {
-		if bytes.Contains(raw, beforeSubmitMarker) {
+		// Before the payload parses we can only guess the event from the raw
+		// bytes, and beforeSubmitPrompt wins so a nested preToolUse marker can't
+		// trigger a second permissive line. Once parsed, the real event name
+		// drives the fallback and substring collisions stop mattering.
+		if !parsed {
+			switch {
+			case bytes.Contains(raw, beforeSubmitMarker):
+				event = "beforeSubmitPrompt"
+			case bytes.Contains(raw, preToolUseMarker):
+				event = "preToolUse"
+			}
+		}
+		if event == "beforeSubmitPrompt" {
+			_, _ = fmt.Fprint(stdout, permissiveResponse)
+		}
+		if event == "preToolUse" && !preToolUseHandled {
 			_, _ = fmt.Fprint(stdout, permissiveResponse)
 		}
 	}()
@@ -52,7 +76,8 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 		logger.Printf("dispatch: invalid JSON: %v", err)
 		return nil
 	}
-	event := payload.HookEventName
+	parsed = true
+	event = payload.HookEventName
 	if event == "" {
 		logger.Print("dispatch: missing hook_event_name")
 		return nil
@@ -66,6 +91,9 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 		hook.SessionStart(payload, logger)
 	case "beforeSubmitPrompt":
 		hook.BeforeSubmit(payload, cfg, logger)
+	case "preToolUse":
+		hook.PreToolUse(ctx, payload, stdout, logger)
+		preToolUseHandled = true
 	case "afterAgentResponse":
 		hook.AfterAgentResponse(payload, cfg, logger)
 	case "afterAgentThought":
@@ -81,6 +109,5 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 	default:
 		logger.Printf("dispatch: unknown event %q", event)
 	}
-	_ = ctx
 	return nil
 }

--- a/plugins/sigil/internal/agents/cursor/hook/pretooluse.go
+++ b/plugins/sigil/internal/agents/cursor/hook/pretooluse.go
@@ -1,0 +1,68 @@
+package hook
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"strings"
+
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/cursor/mapper"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/guard"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/envconfig"
+)
+
+// preToolUseResponse is the flat JSON Cursor reads from preToolUse stdout.
+// `permission` is required on every response; `updated_input` replaces the
+// tool arguments in full when present; `agent_message` carries the deny
+// reason to the model.
+type preToolUseResponse struct {
+	Permission   string          `json:"permission"`
+	AgentMessage string          `json:"agent_message,omitempty"`
+	UpdatedInput json.RawMessage `json:"updated_input,omitempty"`
+}
+
+// PreToolUse evaluates the tool call against Sigil guards and writes exactly
+// one preToolUse response to stdout: deny with the policy reason when
+// blocked, allow with updated_input when a Transform rule redacted the
+// arguments, plain allow otherwise (including guards disabled). All Sigil
+// transport, credential, fail-open/closed, and transform-extraction
+// behaviour lives in the shared guard helper so this stays in lockstep with
+// the other agents.
+func PreToolUse(ctx context.Context, p Payload, stdout io.Writer, logger *log.Logger) {
+	res := guard.EvaluateToolCall(ctx, envconfig.ResolveGuards(logger), guard.ToolCallInput{
+		AgentName:     mapper.AgentName,
+		AgentVersion:  strings.TrimSpace(p.CursorVersion),
+		ModelProvider: strings.TrimSpace(p.Provider),
+		ModelName:     strings.TrimSpace(p.Model),
+		ToolName:      strings.TrimSpace(p.ToolName),
+		ToolCallID:    strings.TrimSpace(p.ToolUseID),
+		ToolInputJSON: p.ToolInput,
+	}, logger)
+
+	resp := preToolUseResponse{Permission: "allow"}
+	switch {
+	case res.Blocked():
+		resp = preToolUseResponse{Permission: "deny", AgentMessage: res.Reason}
+	case len(res.UpdatedInputJSON) > 0:
+		// Cursor rejects Shell-style updated_input without a string command
+		// field, which would error the tool call instead of running it. A
+		// transform that strips command therefore fails open: keep the
+		// original arguments.
+		if hasStringCommand(p.ToolInput) && !hasStringCommand(res.UpdatedInputJSON) {
+			logger.Printf("guard: tool-call transform for %s dropped: transformed arguments missing string command field", p.ToolUseID)
+			break
+		}
+		resp.UpdatedInput = res.UpdatedInputJSON
+	}
+	_ = json.NewEncoder(stdout).Encode(resp)
+}
+
+func hasStringCommand(raw json.RawMessage) bool {
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return false
+	}
+	_, ok := obj["command"].(string)
+	return ok
+}

--- a/plugins/sigil/internal/agents/cursor/hook/pretooluse_test.go
+++ b/plugins/sigil/internal/agents/cursor/hook/pretooluse_test.go
@@ -1,0 +1,166 @@
+package hook
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// TestPreToolUse covers the Cursor-specific wiring around the shared guard
+// helper: the handler always writes exactly one flat preToolUse response —
+// permissive on disabled/allow/unusable-transform/fail-open, deny with the
+// policy reason in agent_message, allow+updated_input on a usable Transform.
+// Deep behaviour around fail-open/closed, missing credentials, transport
+// errors, and transform extraction lives in the guard package tests; this
+// test only verifies the integration shape.
+func TestPreToolUse(t *testing.T) {
+	const permissive = `{"permission":"allow"}` + "\n"
+
+	tests := []struct {
+		name string
+		env  map[string]string
+		// serverResponds is the JSON the fake Sigil hook server returns;
+		// empty means allow.
+		serverResponds string
+		// useClosedServer points SIGIL_ENDPOINT at a closed listener so the
+		// evaluation fails at transport.
+		useClosedServer    bool
+		expectServerCall   bool
+		wantStdout         string
+		wantStdoutContains []string
+	}{
+		{
+			name:       "disabled_by_default_responds_permissive",
+			wantStdout: permissive,
+		},
+		{
+			name:             "enabled_allow_responds_permissive",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow"}`,
+			expectServerCall: true,
+			wantStdout:       permissive,
+		},
+		{
+			name:             "enabled_deny_writes_deny_with_agent_message",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"deny","reason":"blocked tool"}`,
+			expectServerCall: true,
+			wantStdoutContains: []string{
+				`"permission":"deny"`,
+				`"agent_message"`,
+				`A Grafana AI Observability policy`,
+				`blocked tool`,
+			},
+		},
+		{
+			name:             "enabled_allow_transform_writes_updated_input",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_1","name":"Shell","input_json":{"command":"echo [REDACTED]"}}}]}]}}`,
+			expectServerCall: true,
+			wantStdout:       `{"permission":"allow","updated_input":{"command":"echo [REDACTED]"}}` + "\n",
+		},
+		{
+			name:             "enabled_allow_transform_dropping_command_keeps_original_input",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_1","name":"Shell","input_json":{"args":"echo [REDACTED]"}}}]}]}}`,
+			expectServerCall: true,
+			wantStdout:       permissive,
+		},
+		{
+			name:             "enabled_allow_transform_with_null_command_keeps_original_input",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_1","name":"Shell","input_json":{"command":null}}}]}]}}`,
+			expectServerCall: true,
+			wantStdout:       permissive,
+		},
+		{
+			name:             "enabled_allow_unusable_transform_keeps_original_input",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_other","name":"Shell","input_json":{"command":"echo X"}}}]}]}}`,
+			expectServerCall: true,
+			wantStdout:       permissive,
+		},
+		{
+			name:            "transport_error_fail_open_responds_permissive",
+			env:             map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			useClosedServer: true,
+			wantStdout:      permissive,
+		},
+		{
+			name:            "transport_error_fail_closed_denies",
+			env:             map[string]string{"SIGIL_GUARDS_ENABLED": "true", "SIGIL_GUARDS_FAIL_OPEN": "false"},
+			useClosedServer: true,
+			wantStdoutContains: []string{
+				`"permission":"deny"`,
+				`"agent_message"`,
+				`could not evaluate`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls.Add(1)
+				body := tt.serverResponds
+				if body == "" {
+					body = `{"action":"allow"}`
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(body))
+			}))
+			defer server.Close()
+
+			closed := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			closed.Close()
+
+			endpoint := server.URL
+			if tt.useClosedServer {
+				endpoint = closed.URL
+			}
+
+			t.Setenv("SIGIL_GUARDS_ENABLED", "")
+			t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "")
+			t.Setenv("SIGIL_GUARDS_TIMEOUT_MS", "")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			t.Setenv("SIGIL_ENDPOINT", endpoint)
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
+
+			var stdout bytes.Buffer
+			PreToolUse(context.Background(), Payload{
+				HookEventName:  "preToolUse",
+				ConversationID: "conv",
+				GenerationID:   "gen",
+				CursorVersion:  "1.2.3",
+				Model:          "claude-sonnet-4",
+				ToolName:       "Shell",
+				ToolUseID:      "tu_1",
+				ToolInput:      []byte(`{"command":"echo hi"}`),
+			}, &stdout, log.New(&bytes.Buffer{}, "", 0))
+
+			if tt.expectServerCall && calls.Load() == 0 {
+				t.Errorf("expected sigil hook server call, got 0")
+			}
+			if !tt.expectServerCall && !tt.useClosedServer && calls.Load() != 0 {
+				t.Errorf("expected no sigil hook server call, got %d", calls.Load())
+			}
+			if tt.wantStdout != "" && stdout.String() != tt.wantStdout {
+				t.Errorf("stdout = %q, want %q", stdout.String(), tt.wantStdout)
+			}
+			for _, want := range tt.wantStdoutContains {
+				if !strings.Contains(stdout.String(), want) {
+					t.Errorf("stdout missing %q\nfull output: %s", want, stdout.String())
+				}
+			}
+		})
+	}
+}

--- a/plugins/sigil/internal/agents/cursor/hook_test.go
+++ b/plugins/sigil/internal/agents/cursor/hook_test.go
@@ -1,0 +1,89 @@
+package cursor
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHookDispatch verifies the dispatcher-level response contract: the event
+// reaches the right handler, every terminating path writes exactly one JSON
+// response, and the permissive defer fallback never stacks a second line on
+// top of a handler-written verdict or a real beforeSubmitPrompt response.
+func TestHookDispatch(t *testing.T) {
+	denyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"action":"deny","reason":"blocked tool"}`))
+	}))
+	defer denyServer.Close()
+
+	tests := []struct {
+		name               string
+		env                map[string]string
+		stdin              string
+		wantStdout         string
+		wantStdoutContains []string
+	}{
+		{
+			name:       "routed_event_guards_disabled_responds_permissive",
+			stdin:      `{"hook_event_name":"preToolUse","conversation_id":"conv","generation_id":"gen","tool_name":"Shell","tool_use_id":"tu_1","tool_input":{"command":"echo hi"}}`,
+			wantStdout: `{"permission":"allow"}` + "\n",
+		},
+		{
+			name:       "malformed_payload_falls_back_permissive",
+			stdin:      `{"hook_event_name":"preToolUse","tool_name":`,
+			wantStdout: `{"continue":true,"permission":"allow"}` + "\n",
+		},
+		{
+			// A beforeSubmitPrompt payload that embeds the literal preToolUse
+			// marker (here in a nested object) must not make the defer fallback
+			// write a second permissive line.
+			name:       "before_submit_prompt_nested_pretooluse_marker_single_line",
+			stdin:      `{"hook_event_name":"beforeSubmitPrompt","prompt":"describe hooks","extra":{"hook_event_name":"preToolUse"}}`,
+			wantStdout: permissiveResponse,
+		},
+		{
+			name: "deny_verdict_not_overridden_by_fallback",
+			env:  map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			stdin: `{"hook_event_name":"preToolUse","conversation_id":"conv","generation_id":"gen",` +
+				`"tool_name":"Shell","tool_use_id":"tu_1","tool_input":{"command":"echo hi"}}`,
+			wantStdoutContains: []string{`"permission":"deny"`, `blocked tool`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SIGIL_GUARDS_ENABLED", "")
+			t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "")
+			t.Setenv("SIGIL_GUARDS_TIMEOUT_MS", "")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			t.Setenv("SIGIL_ENDPOINT", denyServer.URL)
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
+
+			var stdout bytes.Buffer
+			err := Hook(context.Background(), strings.NewReader(tt.stdin), &stdout, log.New(&bytes.Buffer{}, "", 0))
+			if err != nil {
+				t.Fatalf("Hook returned error: %v", err)
+			}
+
+			if tt.wantStdout != "" && stdout.String() != tt.wantStdout {
+				t.Errorf("stdout = %q, want %q", stdout.String(), tt.wantStdout)
+			}
+			for _, want := range tt.wantStdoutContains {
+				if !strings.Contains(stdout.String(), want) {
+					t.Errorf("stdout missing %q\nfull output: %s", want, stdout.String())
+				}
+			}
+			if got := strings.Count(stdout.String(), "\n"); got != 1 {
+				t.Errorf("expected exactly one response line, got %d: %q", got, stdout.String())
+			}
+		})
+	}
+}

--- a/plugins/sigil/internal/agents/cursor/install/install.go
+++ b/plugins/sigil/internal/agents/cursor/install/install.go
@@ -31,10 +31,11 @@ import (
 // cursorEvents are the hook events Sigil wires, matching the set shipped in
 // plugins/cursor/hooks/hooks.json. The Cursor dispatcher infers the event
 // from hook_event_name in the payload, so the same `sigil cursor hook`
-// command serves all eight.
+// command serves all nine.
 var cursorEvents = []string{
 	"sessionStart",
 	"beforeSubmitPrompt",
+	"preToolUse",
 	"afterAgentResponse",
 	"afterAgentThought",
 	"postToolUse",


### PR DESCRIPTION
Add block and tool args transform guards support to cursor:

<img width="806" height="433" alt="image" src="https://github.com/user-attachments/assets/25b53a58-0ab2-4b4b-8b19-db80268a9f6c" />


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Intercepts every tool call when guards are enabled, so misconfiguration or strict fail-closed mode can block agent work; default off and fail-open limit blast radius.
> 
> **Overview**
> Adds **Sigil tool-call guards** to the Cursor plugin by wiring a **`preToolUse`** hook so each agent tool invocation can be **denied**, **allowed**, or **argument-rewritten** before it runs (guards off by default via `SIGIL_GUARDS_ENABLED`).
> 
> The new **`PreToolUse`** handler calls the shared **`guard.EvaluateToolCall`** helper and emits Cursor’s flat JSON (`permission`, optional `updated_input`, `agent_message` on deny). **Transform** rules apply `updated_input` when safe; if a Shell-style call originally had a string **`command`** and the transform drops it, the handler **keeps the original args** so Cursor doesn’t error the tool. **`hook.go`** routes `preToolUse`, avoids **double stdout** (defer permissive fallback only when the handler didn’t run), and documents the same “always respond” contract as **`beforeSubmitPrompt`**. **`sigil cursor install`** and bundled **`hooks.json`** now register **`preToolUse`**; README documents **`SIGIL_GUARDS_*`** (fail-open, timeout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6e1f1ca3161ae5380393e21a41d87a7a331b1a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->