### PR TITLE
feat(plugins/copilot): apply transform/redact guards

### DIFF
--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -133,6 +133,26 @@ shapes.
 
 Captured prompt, assistant, and tool content is redacted before export. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md) for the cross-SDK reference.
 
+## Guards
+
+Guards do two things when enabled: block tool calls that match a deny rule, and apply Transform rules to redact sensitive tool arguments. They're off by default:
+
+```sh
+SIGIL_GUARDS_ENABLED=true sigil copilot
+```
+
+By default, transport errors and timeouts let the tool call through. Set `SIGIL_GUARDS_FAIL_OPEN=false` to block tool calls on errors instead. Raise or lower `SIGIL_GUARDS_TIMEOUT_MS` (default `1500`) to trade latency against tolerance for slow evaluators.
+
+### Transform guards (redaction)
+
+When guards are enabled and a [Transform rule](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/guides/guards/) matches a tool call, the redacted arguments replace what the tool receives.
+
+Limits:
+
+- Transforms apply in `copilot-cli`. Copilot Chat in VS Code expects a different hook response shape for argument rewrites that has not been verified end to end, so no rewrite is sent there and VS Code tool calls run with their original arguments. Deny rules work on both surfaces.
+- Each guarded tool call adds one synchronous hook round-trip (`SIGIL_GUARDS_TIMEOUT_MS`). Transform redaction fails open: when the transform cannot be applied, the original arguments pass through unchanged. Transport errors follow `SIGIL_GUARDS_FAIL_OPEN`.
+- When arguments are redacted, the exported tool record carries the redacted arguments the tool actually ran with.
+
 ## All options
 
 | Variable | Default | Description |
@@ -146,7 +166,7 @@ Captured prompt, assistant, and tool content is redacted before export. See [Con
 | `SIGIL_TAGS` | — | `key=value,key=value` tags on every generation and as `sigil.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). |
 | `SIGIL_USER_ID` | — | Override the user id. |
 | `SIGIL_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
-| `SIGIL_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Copilot `preToolUse` hook is evaluated against Sigil and tool calls denied by guard rules are blocked. |
+| `SIGIL_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Copilot `preToolUse` hook is evaluated against Sigil: tool calls denied by guard rules are blocked, and Transform rules redact tool arguments in `copilot-cli`. |
 | `SIGIL_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |
 | `SIGIL_GUARDS_TIMEOUT_MS` | `1500` | Per-call timeout. Lower = less added latency on every tool call, higher = better tolerance for slow `llm_judge` evaluators. |
 | `SIGIL_COPILOT_HOOK_SURFACE` | _(auto)_ | Override the detected host surface (`copilot-cli` or `vscode`). Normally inferred at runtime; set explicitly only when driving capture through a custom hooks config. |

--- a/plugins/sigil/internal/agents/copilot/hook/handlers.go
+++ b/plugins/sigil/internal/agents/copilot/hook/handlers.go
@@ -135,21 +135,44 @@ func PreToolUse(ctx context.Context, stdout io.Writer, p Payload, cfg config.Con
 			}
 		}
 		res := guard.EvaluateToolCall(ctx, cfg.Guards, guard.ToolCallInput{
-			AgentName:     mapper.AgentName,
-			ToolName:      p.ToolName(),
-			ToolInputJSON: toolArgs,
+			AgentName: mapper.AgentName,
+			ToolName:  p.ToolName(),
+			// Copilot delivers tool args as a JSON-encoded string; the Sigil
+			// server only transforms tool-call input that is a JSON object, so
+			// decode the wrapper before evaluating or redaction never happens.
+			ToolInputJSON: decodeStringEncodedToolInput(toolArgs),
 			ModelProvider: provider,
 			ModelName:     modelName,
 		}, logger)
 		if res.Blocked() {
-			// Copilot command hooks (both the CLI and Copilot Chat in VS
-			// Code) read the deny verdict from the nested
-			// hookSpecificOutput.permissionDecision envelope — the same
-			// shape Claude Code and Codex use. A top-level permissionDecision
-			// (the Copilot *SDK* return shape) is silently ignored by VS
-			// Code, so the tool would run anyway. Use the shared writer.
-			guard.WriteHookSpecificOutputDeny(stdout, res.Reason)
+			// The two Copilot surfaces read opposite response shapes: the
+			// CLI honors only the flat top-level permissionDecision
+			// (verified against CLI 1.0.54, which silently ignores the
+			// nested envelope), while Copilot Chat in VS Code honors only
+			// the nested hookSpecificOutput envelope and ignores the flat
+			// fields. Each host skips the shape it does not know, so one
+			// combined object blocks on both.
+			writeDeny(stdout, res.Reason)
 			return
+		}
+		if len(res.UpdatedInputJSON) > 0 {
+			// Transform (redaction) verdicts are applied on the copilot-cli
+			// surface only. The CLI substitutes tool arguments from the flat
+			// {"modifiedArgs": <object>} response (verified against CLI
+			// 1.0.54, which ignores the nested hookSpecificOutput envelope
+			// for argument rewrites). Copilot Chat in VS Code parses only
+			// hookSpecificOutput.updatedInput, and that path is unverified
+			// live, so nothing is written there. A transform the host
+			// silently drops would report redaction that never happened.
+			if p.Surface() == surfaceCopilotCLI {
+				writeModifiedArgs(stdout, res.UpdatedInputJSON)
+				// Record the redacted arguments: they are what the tool
+				// actually runs with, and the originals may hold the very
+				// content the Transform rule strips.
+				toolArgs = res.UpdatedInputJSON
+			} else {
+				logger.Printf("preToolUse: dropping guard transform for tool %q: surface %q is not verified to apply modified arguments", p.ToolName(), p.Surface())
+			}
 		}
 	}
 	turnID, session, err := fragment.EnsureActiveTurn(sessionID, logger, p.ResolvedTimestamp())
@@ -175,6 +198,91 @@ func PreToolUse(ctx context.Context, stdout io.Writer, p Payload, cfg config.Con
 	}); err != nil {
 		logger.Printf("preToolUse: update turn: %v", err)
 	}
+}
+
+// surfaceCopilotCLI is the surface the dispatcher stamps onto the payload
+// when the Copilot CLI (rather than Copilot Chat in VS Code) fired the hook;
+// see copilot/surface.go.
+const surfaceCopilotCLI = "copilot-cli"
+
+// decodeStringEncodedToolInput unwraps tool arguments that the Copilot CLI
+// delivers as a JSON-encoded string (e.g. `"{\"command\":\"…\"}"`) into the
+// underlying JSON object. The Sigil server only applies Transform rules to
+// tool-call input that is a JSON object: given a JSON string it returns no
+// transform at all, so Copilot's arguments are never redacted without this.
+// Returns raw unchanged when it is already an object, or a string that does
+// not wrap a JSON object.
+func decodeStringEncodedToolInput(raw json.RawMessage) json.RawMessage {
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return raw
+	}
+	inner := json.RawMessage(s)
+	var obj map[string]any
+	if err := json.Unmarshal(inner, &obj); err != nil || obj == nil {
+		return raw
+	}
+	return inner
+}
+
+// preToolUseModifiedArgs is the flat preToolUse response the Copilot CLI
+// reads to substitute tool arguments. It is unrelated to the nested
+// hookSpecificOutput envelope used for deny verdicts.
+type preToolUseModifiedArgs struct {
+	ModifiedArgs json.RawMessage `json:"modifiedArgs"`
+}
+
+// preToolUseDeny carries the deny verdict in both Copilot response shapes:
+// the flat fields for the CLI and the nested envelope for Copilot Chat in
+// VS Code.
+type preToolUseDeny struct {
+	PermissionDecision       string                 `json:"permissionDecision"`
+	PermissionDecisionReason string                 `json:"permissionDecisionReason"`
+	HookSpecificOutput       preToolUseDenyEnvelope `json:"hookSpecificOutput"`
+}
+
+type preToolUseDenyEnvelope struct {
+	HookEventName            string `json:"hookEventName"`
+	PermissionDecision       string `json:"permissionDecision"`
+	PermissionDecisionReason string `json:"permissionDecisionReason"`
+}
+
+// writeDeny writes the combined PreToolUse deny JSON. The Copilot CLI reads
+// the flat permissionDecision fields and ignores the nested envelope
+// (verified against CLI 1.0.54); Copilot Chat in VS Code reads the nested
+// hookSpecificOutput envelope and ignores the flat fields. The hookEventName
+// must be the PascalCase "PreToolUse"; VS Code drops the envelope on an
+// exact-match failure.
+func writeDeny(stdout io.Writer, reason string) {
+	if stdout == nil {
+		return
+	}
+	if strings.TrimSpace(reason) == "" {
+		reason = "tool call denied by Sigil guard"
+	}
+	_ = json.NewEncoder(stdout).Encode(preToolUseDeny{
+		PermissionDecision:       "deny",
+		PermissionDecisionReason: reason,
+		HookSpecificOutput: preToolUseDenyEnvelope{
+			HookEventName:            "PreToolUse",
+			PermissionDecision:       "deny",
+			PermissionDecisionReason: reason,
+		},
+	})
+}
+
+// writeModifiedArgs writes the flat modifiedArgs JSON that makes the Copilot
+// CLI run the tool with the substituted arguments. modifiedArgs must be a
+// JSON object, which guard.EvaluateToolCall already guarantees for
+// UpdatedInputJSON; the CLI ignores a JSON-encoded string even though it
+// sends toolArgs in that form. No permissionDecision is included: the CLI applies
+// modifiedArgs without one, and adding "allow" would also skip the user's
+// permission prompt for the tool call.
+func writeModifiedArgs(stdout io.Writer, modifiedArgs json.RawMessage) {
+	if stdout == nil || len(modifiedArgs) == 0 {
+		return
+	}
+	_ = json.NewEncoder(stdout).Encode(preToolUseModifiedArgs{ModifiedArgs: modifiedArgs})
 }
 
 func PostToolUse(p Payload, cfg config.Config, logger *log.Logger, failed bool) {

--- a/plugins/sigil/internal/agents/copilot/hook/handlers_test.go
+++ b/plugins/sigil/internal/agents/copilot/hook/handlers_test.go
@@ -488,11 +488,23 @@ func TestPreToolUseGuardBehavior(t *testing.T) {
 		// the request fails at transport.
 		useClosedServer bool
 		// clearCreds blanks SIGIL_ENDPOINT/SIGIL_AUTH_TENANT_ID/SIGIL_AUTH_TOKEN.
-		clearCreds          bool
-		wantServerCalled    bool
-		wantStdoutContains  []string
-		wantStdoutEmpty     bool
-		wantToolRecordCount int
+		clearCreds bool
+		// surface is stamped onto the payload the way the dispatcher would.
+		surface string
+		// toolInput overrides the payload tool arguments; empty uses a bare
+		// object. The Copilot CLI delivers args as a JSON-encoded string, so
+		// transform cases use that real wire shape.
+		toolInput string
+		// wantSentArgsContains asserts a substring of the guard request body,
+		// to verify the handler decodes string-encoded args to a JSON object.
+		wantSentArgsContains  string
+		wantServerCalled      bool
+		wantStdoutContains    []string
+		wantStdoutNotContains []string
+		wantStdoutEmpty       bool
+		wantToolRecordCount   int
+		// wantToolInput asserts the recorded tool input when non-empty.
+		wantToolInput string
 	}{
 		{
 			name:                "disabled stays stdout-empty and records pending tool",
@@ -509,12 +521,65 @@ func TestPreToolUseGuardBehavior(t *testing.T) {
 			wantToolRecordCount: 1,
 		},
 		{
-			name:                "deny writes copilot deny JSON and skips record",
-			guards:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
-			hookResponse:        `{"action":"deny","reason":"blocked tool"}`,
+			name:         "deny writes combined flat and nested deny JSON and skips record",
+			guards:       envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			hookResponse: `{"action":"deny","reason":"blocked tool"}`,
+			// The flat fields are what the Copilot CLI reads; the nested
+			// envelope is what Copilot Chat in VS Code reads. The leading
+			// `{"permissionDecision"` matches only the flat copy.
 			wantServerCalled:    true,
-			wantStdoutContains:  []string{`"hookSpecificOutput"`, `"hookEventName":"PreToolUse"`, `"permissionDecision":"deny"`, `A Grafana AI Observability policy`, `blocked tool`},
+			wantStdoutContains:  []string{`{"permissionDecision":"deny"`, `"hookSpecificOutput"`, `"hookEventName":"PreToolUse"`, `A Grafana AI Observability policy`, `blocked tool`},
 			wantToolRecordCount: 0,
+		},
+		{
+			// Reproduces the live Copilot CLI flow: args arrive as a
+			// JSON-encoded string. The handler decodes them to an object before
+			// the guard call (the server only transforms objects), and the
+			// server returns base64 of the redacted object.
+			name:                  "allow with transform on copilot-cli writes flat modifiedArgs and records redacted args",
+			guards:                envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			toolInput:             `"{\"cmd\":\"echo SK-TEST-123\"}"`,
+			hookResponse:          `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"","name":"bash","input_json":"eyJjbWQiOiJlY2hvIFtSRURBQ1RFRF0ifQ=="}}]}]}}`,
+			surface:               "copilot-cli",
+			wantServerCalled:      true,
+			wantSentArgsContains:  `"input_json":{"cmd":"echo SK-TEST-123"}`,
+			wantStdoutContains:    []string{`{"modifiedArgs":{"cmd":"echo [REDACTED]"}}`},
+			wantStdoutNotContains: []string{`hookSpecificOutput`, `permissionDecision`},
+			wantToolRecordCount:   1,
+			wantToolInput:         `{"cmd":"echo [REDACTED]"}`,
+		},
+		{
+			name:                 "allow with transform on vscode stays stdout-empty and keeps original args",
+			guards:               envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			toolInput:            `"{\"cmd\":\"echo SK-TEST-123\"}"`,
+			hookResponse:         `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"","name":"bash","input_json":"eyJjbWQiOiJlY2hvIFtSRURBQ1RFRF0ifQ=="}}]}]}}`,
+			surface:              "vscode",
+			wantServerCalled:     true,
+			wantSentArgsContains: `"input_json":{"cmd":"echo SK-TEST-123"}`,
+			wantStdoutEmpty:      true,
+			wantToolRecordCount:  1,
+			wantToolInput:        `"{\"cmd\":\"echo SK-TEST-123\"}"`,
+		},
+		{
+			name:                 "allow with transform on unknown surface stays stdout-empty and keeps original args",
+			guards:               envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			toolInput:            `"{\"cmd\":\"echo SK-TEST-123\"}"`,
+			hookResponse:         `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"","name":"bash","input_json":"eyJjbWQiOiJlY2hvIFtSRURBQ1RFRF0ifQ=="}}]}]}}`,
+			wantServerCalled:     true,
+			wantSentArgsContains: `"input_json":{"cmd":"echo SK-TEST-123"}`,
+			wantStdoutEmpty:      true,
+			wantToolRecordCount:  1,
+			wantToolInput:        `"{\"cmd\":\"echo SK-TEST-123\"}"`,
+		},
+		{
+			name:                  "deny with transform writes deny envelope without modifiedArgs",
+			guards:                envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			hookResponse:          `{"action":"deny","reason":"blocked tool","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"","name":"bash","input_json":{"cmd":"echo [REDACTED]"}}}]}]}}`,
+			surface:               "copilot-cli",
+			wantServerCalled:      true,
+			wantStdoutContains:    []string{`{"permissionDecision":"deny"`, `"hookSpecificOutput"`, `blocked tool`},
+			wantStdoutNotContains: []string{`modifiedArgs`},
+			wantToolRecordCount:   0,
 		},
 		{
 			name:                "fail-open transport error allows tool and records it",
@@ -527,7 +592,7 @@ func TestPreToolUseGuardBehavior(t *testing.T) {
 			name:                "fail-closed transport error denies tool and skips record",
 			guards:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: false},
 			useClosedServer:     true,
-			wantStdoutContains:  []string{`"permissionDecision":"deny"`, `could not evaluate`},
+			wantStdoutContains:  []string{`{"permissionDecision":"deny"`, `"hookSpecificOutput"`, `could not evaluate`},
 			wantToolRecordCount: 0,
 		},
 		{
@@ -541,7 +606,7 @@ func TestPreToolUseGuardBehavior(t *testing.T) {
 			name:                "fail-closed missing credentials denies tool and skips record",
 			guards:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: false},
 			clearCreds:          true,
-			wantStdoutContains:  []string{`"permissionDecision":"deny"`, `could not evaluate`, `missing SIGIL_ENDPOINT`},
+			wantStdoutContains:  []string{`{"permissionDecision":"deny"`, `"hookSpecificOutput"`, `could not evaluate`, `missing SIGIL_ENDPOINT`},
 			wantToolRecordCount: 0,
 		},
 	}
@@ -552,8 +617,10 @@ func TestPreToolUseGuardBehavior(t *testing.T) {
 			logger := log.New(io.Discard, "", 0)
 
 			var calls atomic.Int32
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			var sentBody []byte
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				calls.Add(1)
+				sentBody, _ = io.ReadAll(r.Body)
 				body := tt.hookResponse
 				if body == "" {
 					body = `{"action":"allow"}`
@@ -586,13 +653,18 @@ func TestPreToolUseGuardBehavior(t *testing.T) {
 			}
 			UserPromptSubmit(Payload{HookEventNameJSON: "UserPromptSubmit", SessionIDJSON: "sess", Timestamp: []byte(`"2026-05-18T12:00:01Z"`), Prompt: "hello"}, cfg, logger)
 
+			toolInput := tt.toolInput
+			if toolInput == "" {
+				toolInput = `{"cmd":"echo hi"}`
+			}
 			var stdout bytes.Buffer
 			PreToolUse(context.Background(), &stdout, Payload{
 				HookEventNameJSON: "PreToolUse",
 				SessionIDJSON:     "sess",
 				Timestamp:         []byte(`"2026-05-18T12:00:02Z"`),
 				ToolNameJSON:      "bash",
-				ToolInputJSON:     []byte(`{"cmd":"echo hi"}`),
+				ToolInputJSON:     []byte(toolInput),
+				SurfaceMarker:     tt.surface,
 			}, cfg, logger)
 
 			if tt.wantServerCalled && calls.Load() == 0 {
@@ -600,6 +672,9 @@ func TestPreToolUseGuardBehavior(t *testing.T) {
 			}
 			if !tt.wantServerCalled && !tt.useClosedServer && calls.Load() != 0 {
 				t.Errorf("expected no sigil hook server call, got %d", calls.Load())
+			}
+			if tt.wantSentArgsContains != "" && !strings.Contains(string(sentBody), tt.wantSentArgsContains) {
+				t.Errorf("guard request body = %q, want substring %q", sentBody, tt.wantSentArgsContains)
 			}
 			if tt.wantStdoutEmpty && stdout.Len() != 0 {
 				t.Errorf("stdout not empty: %q", stdout.String())
@@ -609,6 +684,11 @@ func TestPreToolUseGuardBehavior(t *testing.T) {
 					t.Errorf("stdout = %q, want substring %q", stdout.String(), want)
 				}
 			}
+			for _, notWant := range tt.wantStdoutNotContains {
+				if strings.Contains(stdout.String(), notWant) {
+					t.Errorf("stdout = %q, must not contain %q", stdout.String(), notWant)
+				}
+			}
 
 			frag := fragment.LoadTolerant("sess", "turn-000001", logger)
 			if frag == nil {
@@ -616,6 +696,9 @@ func TestPreToolUseGuardBehavior(t *testing.T) {
 			}
 			if len(frag.Tools) != tt.wantToolRecordCount {
 				t.Fatalf("len(frag.Tools) = %d, want %d", len(frag.Tools), tt.wantToolRecordCount)
+			}
+			if tt.wantToolInput != "" && string(frag.Tools[0].ToolInput) != tt.wantToolInput {
+				t.Errorf("recorded tool input = %q, want %q", frag.Tools[0].ToolInput, tt.wantToolInput)
 			}
 		})
 	}


### PR DESCRIPTION

<img width="1121" height="433" alt="image" src="https://github.com/user-attachments/assets/b49cb089-fcca-4d90-9894-cb7eb939f474" />


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes sit on the security-sensitive preToolUse path and alter what arguments tools receive on copilot-cli, though VS Code intentionally skips transforms and existing fail-open/fail-closed guard behavior is preserved.
> 
> **Overview**
> Copilot **preToolUse** guards now apply **Transform** rules (redacted tool arguments) in addition to deny blocking, and document the behavior in the Copilot plugin README.
> 
> **Deny responses** no longer use the shared nested-only writer. They emit a **single combined JSON object** with flat `permissionDecision` fields for the Copilot CLI and nested `hookSpecificOutput` for Copilot Chat in VS Code, so both surfaces block reliably.
> 
> When Sigil returns transformed input, **`copilot-cli`** gets flat `{"modifiedArgs": …}` on stdout (no `permissionDecision`, so permission prompts still run). The pending tool record stores the **redacted arguments** that actually execute. **`vscode`** and other surfaces skip the rewrite (unverified VS Code path) and keep original args, with a debug log.
> 
> Tests cover combined deny JSON, CLI transform stdout, VS Code/unknown surface no-op, deny-over-transform precedence, and recorded tool input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91f639ed9cdb84d0a264cff3ec52342d0a9771c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->