### PR TITLE
fix(plugins/opencode): stop re-exporting session history as new generations

### DIFF
--- a/plugins/opencode/src/hooks.lineage.test.ts
+++ b/plugins/opencode/src/hooks.lineage.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createSigilClientMock, createTelemetryProvidersMock } = vi.hoisted(
+  () => ({
+    createSigilClientMock: vi.fn(),
+    createTelemetryProvidersMock: vi.fn(),
+  }),
+);
+
+vi.mock("./client.js", () => ({ createSigilClient: createSigilClientMock }));
+vi.mock("./telemetry.js", () => ({
+  createTelemetryProviders: createTelemetryProvidersMock,
+}));
+
+import type { SigilOpencodeConfig } from "./config.js";
+import { createSigilHooks } from "./hooks.js";
+import { stableOpencodeGenerationId } from "./lineage.js";
+
+type CapturedGeneration = {
+  seed: any;
+  firstTokenAt: Date | undefined;
+  result: unknown;
+  callError: unknown;
+};
+
+function makeSigilMock() {
+  const generations: CapturedGeneration[] = [];
+  const startStreamingGeneration = vi.fn(async (seed: any, run: any) => {
+    const entry: CapturedGeneration = {
+      seed,
+      firstTokenAt: undefined,
+      result: undefined,
+      callError: undefined,
+    };
+    generations.push(entry);
+    await run({
+      setResult: (r: unknown) => {
+        entry.result = r;
+      },
+      setCallError: (e: unknown) => {
+        entry.callError = e;
+      },
+      setFirstTokenAt: (d: Date) => {
+        entry.firstTokenAt = d;
+      },
+      setCacheDiagnostics: vi.fn(),
+      end: vi.fn(),
+      getError: () => undefined,
+    });
+  });
+  const startGeneration = vi.fn();
+  const sigil = {
+    startStreamingGeneration,
+    startGeneration,
+    startToolExecution: vi.fn(() => ({
+      setResult: vi.fn(),
+      setCallError: vi.fn(),
+      end: vi.fn(),
+      getError: vi.fn(),
+    })),
+    flush: vi.fn(async () => {}),
+    shutdown: vi.fn(async () => {}),
+  };
+  return { sigil, generations, startStreamingGeneration, startGeneration };
+}
+
+function makeOpencodeClient(parts: any[] = []) {
+  return {
+    session: { message: vi.fn(async () => ({ data: { parts } })) },
+  } as any;
+}
+
+function baseConfig(
+  overrides: Partial<SigilOpencodeConfig> = {},
+): SigilOpencodeConfig {
+  return {
+    endpoint: "http://127.0.0.1:1/api/v1/generations:export",
+    auth: { mode: "none" },
+    agentName: "opencode",
+    agentVersion: "test-version",
+    contentCapture: "full",
+    debug: false,
+    ...overrides,
+  };
+}
+
+function assistantMessage(sessionID: string, messageID: string) {
+  return {
+    id: messageID,
+    sessionID,
+    role: "assistant",
+    time: { created: 1_700_000_001_000, completed: 1_700_000_002_500 },
+    parentID: "user-1",
+    modelID: "claude-sonnet-4",
+    providerID: "anthropic",
+    mode: "build",
+    path: { cwd: "/repo", root: "/repo" },
+    cost: 0.001,
+    tokens: {
+      input: 10,
+      output: 5,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+    finish: "end_turn",
+  } as const;
+}
+
+function textPart(
+  sessionID: string,
+  messageID: string,
+  start: number,
+): unknown {
+  return {
+    id: "p-1",
+    sessionID,
+    messageID,
+    type: "text",
+    text: "hello",
+    time: { start },
+  };
+}
+
+async function emitMessageUpdated(
+  hooks: NonNullable<Awaited<ReturnType<typeof createSigilHooks>>>,
+  msg: unknown,
+): Promise<void> {
+  await hooks.event({
+    event: { type: "message.updated", properties: { info: msg } },
+  });
+}
+
+async function emitPartUpdated(
+  hooks: NonNullable<Awaited<ReturnType<typeof createSigilHooks>>>,
+  part: unknown,
+): Promise<void> {
+  await hooks.event({
+    event: { type: "message.part.updated", properties: { part } },
+  });
+}
+
+async function emitSessionDeleted(
+  hooks: NonNullable<Awaited<ReturnType<typeof createSigilHooks>>>,
+  sessionID: string,
+): Promise<void> {
+  await hooks.event({
+    event: { type: "session.deleted", properties: { info: { id: sessionID } } },
+  });
+}
+
+describe("opencode generation lineage and streaming", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("assigns a deterministic opencode- generation id from session and message id", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await createSigilHooks(baseConfig(), makeOpencodeClient());
+    if (!hooks) throw new Error("expected hooks");
+
+    await emitMessageUpdated(hooks, assistantMessage("sess-det", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.id).toBe(
+      stableOpencodeGenerationId("sess-det", "msg-1"),
+    );
+  });
+
+  it("exports through startStreamingGeneration, not startGeneration", async () => {
+    const { sigil, startStreamingGeneration, startGeneration } =
+      makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await createSigilHooks(baseConfig(), makeOpencodeClient());
+    if (!hooks) throw new Error("expected hooks");
+
+    await emitMessageUpdated(hooks, assistantMessage("sess-stream", "msg-1"));
+
+    expect(startStreamingGeneration).toHaveBeenCalledTimes(1);
+    expect(startGeneration).not.toHaveBeenCalled();
+  });
+
+  it("chains two sequential assistant generations via parentGenerationIds", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await createSigilHooks(baseConfig(), makeOpencodeClient());
+    if (!hooks) throw new Error("expected hooks");
+
+    await emitMessageUpdated(hooks, assistantMessage("sess-chain", "msg-1"));
+    await emitMessageUpdated(hooks, assistantMessage("sess-chain", "msg-2"));
+
+    const idA = stableOpencodeGenerationId("sess-chain", "msg-1");
+    const idB = stableOpencodeGenerationId("sess-chain", "msg-2");
+    expect(generations).toHaveLength(2);
+    expect(generations[0]!.seed.id).toBe(idA);
+    expect(generations[0]!.seed.parentGenerationIds).toBeUndefined();
+    expect(generations[1]!.seed.id).toBe(idB);
+    expect(generations[1]!.seed.parentGenerationIds).toEqual([idA]);
+  });
+
+  it("re-exporting the same message after a restart keeps the same id and no parent", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await createSigilHooks(baseConfig(), makeOpencodeClient());
+    if (!hooks) throw new Error("expected hooks");
+
+    await emitMessageUpdated(hooks, assistantMessage("sess-restart", "msg-1"));
+    // session.deleted clears the in-process dedup and parent chain, the same
+    // way a process restart would, so the next record is a "first" turn.
+    await emitSessionDeleted(hooks, "sess-restart");
+    await emitMessageUpdated(hooks, assistantMessage("sess-restart", "msg-1"));
+
+    const id = stableOpencodeGenerationId("sess-restart", "msg-1");
+    expect(generations).toHaveLength(2);
+    expect(generations[0]!.seed.id).toBe(id);
+    expect(generations[1]!.seed.id).toBe(id);
+    expect(generations[1]!.seed.parentGenerationIds).toBeUndefined();
+  });
+
+  it("records first-token time from the first streamed part", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await createSigilHooks(baseConfig(), makeOpencodeClient());
+    if (!hooks) throw new Error("expected hooks");
+
+    await emitPartUpdated(
+      hooks,
+      textPart("sess-ttft", "msg-1", 1_700_000_001_200),
+    );
+    // A later part for the same message must not overwrite the first.
+    await emitPartUpdated(
+      hooks,
+      textPart("sess-ttft", "msg-1", 1_700_000_001_900),
+    );
+    await emitMessageUpdated(hooks, assistantMessage("sess-ttft", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.firstTokenAt).toEqual(new Date(1_700_000_001_200));
+  });
+
+  it("records TTFT in metadata_only without fetching the message body", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const client = makeOpencodeClient();
+    const hooks = await createSigilHooks(
+      baseConfig({ contentCapture: "metadata_only" }),
+      client,
+    );
+    if (!hooks) throw new Error("expected hooks");
+
+    await emitPartUpdated(
+      hooks,
+      textPart("sess-ttft-meta", "msg-1", 1_700_000_001_200),
+    );
+    await emitMessageUpdated(
+      hooks,
+      assistantMessage("sess-ttft-meta", "msg-1"),
+    );
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.firstTokenAt).toEqual(new Date(1_700_000_001_200));
+    expect(client.session.message).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -10,6 +10,7 @@ import type {
 import { createSigilClient } from "./client.js";
 import type { SigilOpencodeConfig } from "./config.js";
 import { runToolCallGuard } from "./guard.js";
+import { stableOpencodeGenerationId } from "./lineage.js";
 import { mapError, mapGeneration, mapToolDefinitions } from "./mappers.js";
 import { Redactor } from "./redact.js";
 import {
@@ -21,6 +22,27 @@ type OpencodeClient = PluginInput["client"];
 
 // Track recorded messages per session for dedup and cleanup
 const recordedMessages = new Map<string, Set<string>>();
+
+// Last assistant generation id recorded per session, used as the parent for
+// the next assistant generation. opencode assistant messages all share a
+// `parentID` pointing at the user message, so they cannot express
+// assistant-to-assistant lineage themselves. Message ids are monotonic and
+// recording is sequential, so the previous recorded generation is the
+// correct parent. The chain is in-memory and resets per process: the first
+// turn after a restart loses its parent edge, but its deterministic id still
+// dedups.
+const lastGenerationIdBySession = new Map<string, string>();
+
+// First streamed assistant part time per message, keyed by
+// `${sessionID}\x00${messageID}`. Captured from `message.part.updated`
+// before the message completes so it survives `metadata_only` (where we
+// never fetch the message body). Consumed and cleared when the message is
+// recorded.
+const firstPartAtByMessage = new Map<string, number>();
+
+function messageKey(sessionID: string, messageID: string): string {
+  return `${sessionID}\x00${messageID}`;
+}
 
 // Pending generation store: user-side data captured before assistant responds
 type PendingGeneration = {
@@ -183,6 +205,7 @@ async function handleMessagePartUpdated(
   properties: unknown,
 ): Promise<void> {
   const part = recordField(properties, "part");
+  recordFirstPartTime(part);
   if (stringField(part, "type") !== "step-finish") return;
   const sessionID = stringField(part, "sessionID");
   const messageID = stringField(part, "messageID");
@@ -205,6 +228,34 @@ async function handleMessagePartUpdated(
   } catch (err) {
     debugLog("failed to export terminal message part", err);
   }
+}
+
+/**
+ * Record the time of the first streamed text/reasoning/tool part for a
+ * message. This is the time-to-first-token signal: opencode emits
+ * `message.part.updated` as the provider streams output, so the first such
+ * part marks when the model began producing the response. Keyed by message
+ * id, so a user message's parts never displace the assistant turn we read
+ * back in `recordAssistantMessage`.
+ *
+ * Prefer the part's own `time.start`; fall back to `Date.now()` so tool
+ * parts (whose timestamp lives under `state.time`) and any part lacking a
+ * `time` field still yield a signal. First write wins.
+ */
+function recordFirstPartTime(part: Record<string, unknown> | undefined): void {
+  if (!part) return;
+  const type = stringField(part, "type");
+  if (type !== "text" && type !== "reasoning" && type !== "tool") return;
+  const sessionID = stringField(part, "sessionID");
+  const messageID = stringField(part, "messageID");
+  if (!sessionID || !messageID) return;
+  const key = messageKey(sessionID, messageID);
+  if (firstPartAtByMessage.has(key)) return;
+  const rawStart = recordField(part, "time")?.start;
+  firstPartAtByMessage.set(
+    key,
+    typeof rawStart === "number" ? rawStart : Date.now(),
+  );
 }
 
 async function recordAssistantMessage(
@@ -236,6 +287,17 @@ async function recordAssistantMessage(
   sessionSet.add(assistantMsg.id);
   recordedMessages.set(assistantMsg.sessionID, sessionSet);
 
+  // Deterministic id + parent link. The id makes re-exporting this message a
+  // backend no-op; the parent is the previous assistant generation recorded
+  // for this session in this process. Update the chain before exporting so a
+  // failed export still parents the next turn correctly.
+  const genId = stableOpencodeGenerationId(
+    assistantMsg.sessionID,
+    assistantMsg.id,
+  );
+  const parent = lastGenerationIdBySession.get(assistantMsg.sessionID);
+  lastGenerationIdBySession.set(assistantMsg.sessionID, genId);
+
   // Look up pending generation (user-side data)
   const pending = pendingGenerations.get(assistantMsg.sessionID);
 
@@ -261,6 +323,7 @@ async function recordAssistantMessage(
 
   const tools = mapToolDefinitions(pending?.tools);
   const seed = {
+    id: genId,
     conversationId: assistantMsg.sessionID,
     agentName: buildAgentName(config.agentName, assistantMsg.mode),
     agentVersion: config.agentVersion,
@@ -268,6 +331,7 @@ async function recordAssistantMessage(
     model: { provider: assistantMsg.providerID, name: assistantMsg.modelID },
     startedAt: new Date(assistantMsg.time.created),
     contentCapture: config.contentCapture,
+    ...(parent && { parentGenerationIds: [parent] }),
     ...(tools.length > 0 && { tools }),
     ...(includeMessageBodies && { systemPrompt: pending?.systemPrompt }),
   };
@@ -301,16 +365,25 @@ async function recordAssistantMessage(
     debugLog,
   };
 
+  // opencode streams provider responses, so generations are exported with
+  // mode=STREAM. The SDK only records the gen_ai.client.time_to_first_token
+  // histogram for streaming generations.
+  const firstAt = firstPartAtByMessage.get(
+    messageKey(assistantMsg.sessionID, assistantMsg.id),
+  );
+
   try {
     if (assistantMsg.error) {
       const error = assistantMsg.error;
-      await sigil.startGeneration(seed, async (recorder) => {
+      await sigil.startStreamingGeneration(seed, async (recorder) => {
+        if (firstAt !== undefined) recorder.setFirstTokenAt(new Date(firstAt));
         recorder.setResult(result);
         recorder.setCallError(mapError(error));
         emitToolSpans(sigil, spanRecords, spanOpts);
       });
     } else {
-      await sigil.startGeneration(seed, async (recorder) => {
+      await sigil.startStreamingGeneration(seed, async (recorder) => {
+        if (firstAt !== undefined) recorder.setFirstTokenAt(new Date(firstAt));
         recorder.setResult(result);
         emitToolSpans(sigil, spanRecords, spanOpts);
       });
@@ -325,35 +398,9 @@ async function recordAssistantMessage(
   // another export path fires for the same session.
   pendingGenerations.delete(assistantMsg.sessionID);
   completedToolExecutions.delete(assistantMsg.sessionID);
-}
-
-async function sweepTerminalAssistantMessages(
-  sigil: SigilClient,
-  config: SigilOpencodeConfig,
-  client: OpencodeClient,
-  redactor: Redactor,
-  debugLog: (msg: string, ...args: unknown[]) => void,
-  sessionID: string,
-): Promise<void> {
-  try {
-    const response = await client.session.messages({
-      path: { id: sessionID },
-    });
-    for (const message of response.data ?? []) {
-      if (message.info.role !== "assistant") continue;
-      await recordAssistantMessage(
-        sigil,
-        config,
-        client,
-        redactor,
-        debugLog,
-        message.info as AssistantMessage,
-        message.parts ?? [],
-      );
-    }
-  } catch (err) {
-    debugLog("failed to sweep terminal assistant messages", err);
-  }
+  firstPartAtByMessage.delete(
+    messageKey(assistantMsg.sessionID, assistantMsg.id),
+  );
 }
 
 function isTerminalMessageUpdate(msg: MessageUpdatedInfo): boolean {
@@ -362,9 +409,6 @@ function isTerminalMessageUpdate(msg: MessageUpdatedInfo): boolean {
 
 async function handleLifecycle(
   sigil: SigilClient,
-  config: SigilOpencodeConfig,
-  client: OpencodeClient,
-  redactor: Redactor,
   telemetry: TelemetryProviders | null,
   debugLog: (msg: string, ...args: unknown[]) => void,
   event: { type: string; properties: unknown },
@@ -372,22 +416,10 @@ async function handleLifecycle(
   const type = event.type as string;
 
   if (type === "session.idle") {
-    const properties = event.properties as
-      | { info?: { id?: string } }
-      | undefined;
-    const sessionIds = properties?.info?.id
-      ? [properties.info.id]
-      : Array.from(pendingGenerations.keys());
-    for (const sessionId of sessionIds) {
-      await sweepTerminalAssistantMessages(
-        sigil,
-        config,
-        client,
-        redactor,
-        debugLog,
-        sessionId,
-      );
-    }
+    // Recording happens live on `message.updated` and `message.part.updated`
+    // (step-finish). Idle only flushes already-recorded events; it does not
+    // refetch session history.
+    //
     // Fire-and-forget: a stuck OTLP endpoint must not block session.idle for
     // up to ~30s (BatchSpanProcessor default) per turn.
     void sigil.flush().catch((err) => debugLog("sigil flush failed", err));
@@ -405,12 +437,18 @@ async function handleLifecycle(
     const sessionId = properties?.info?.id;
     if (sessionId) {
       recordedMessages.delete(sessionId);
+      lastGenerationIdBySession.delete(sessionId);
       pendingGenerations.delete(sessionId);
       sessionContexts.delete(sessionId);
       completedToolExecutions.delete(sessionId);
       for (const key of activeToolExecutions.keys()) {
         if (key.startsWith(`${sessionId}\x00`)) {
           activeToolExecutions.delete(key);
+        }
+      }
+      for (const key of firstPartAtByMessage.keys()) {
+        if (key.startsWith(`${sessionId}\x00`)) {
+          firstPartAtByMessage.delete(key);
         }
       }
     }
@@ -784,15 +822,7 @@ export async function createSigilHooks(
   return {
     event: async (input) => {
       await handleEvent(sigil, config, client, redactor, debugLog, input.event);
-      await handleLifecycle(
-        sigil,
-        config,
-        client,
-        redactor,
-        telemetry,
-        debugLog,
-        input.event,
-      );
+      await handleLifecycle(sigil, telemetry, debugLog, input.event);
     },
     chatMessage: (input, output) => {
       handleChatMessage(input, output);

--- a/plugins/opencode/src/lineage.test.ts
+++ b/plugins/opencode/src/lineage.test.ts
@@ -1,0 +1,36 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { stableOpencodeGenerationId } from "./lineage.js";
+
+describe("stableOpencodeGenerationId", () => {
+  it("is deterministic for identical inputs", () => {
+    expect(stableOpencodeGenerationId("sess-1", "msg-1")).toBe(
+      stableOpencodeGenerationId("sess-1", "msg-1"),
+    );
+  });
+
+  it("differs for a different message id", () => {
+    expect(stableOpencodeGenerationId("sess-1", "msg-1")).not.toBe(
+      stableOpencodeGenerationId("sess-1", "msg-2"),
+    );
+  });
+
+  it("differs for a different session id", () => {
+    expect(stableOpencodeGenerationId("sess-1", "msg-1")).not.toBe(
+      stableOpencodeGenerationId("sess-2", "msg-1"),
+    );
+  });
+
+  it("uses the opencode- prefix and a 24-hex-char digest", () => {
+    const id = stableOpencodeGenerationId("sess-1", "msg-1");
+    expect(id).toMatch(/^opencode-[0-9a-f]{24}$/);
+  });
+
+  it("matches the documented sha256(sessionID\\0messageID)[:24] shape", () => {
+    const expected = `opencode-${createHash("sha256")
+      .update("sess-1\0msg-1")
+      .digest("hex")
+      .slice(0, 24)}`;
+    expect(stableOpencodeGenerationId("sess-1", "msg-1")).toBe(expected);
+  });
+});

--- a/plugins/opencode/src/lineage.ts
+++ b/plugins/opencode/src/lineage.ts
@@ -1,0 +1,24 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Deterministic OpenCode generation ID: SHA-256 of
+ * `${sessionID}\0${messageID}` truncated to 24 hex chars and prefixed with
+ * `opencode-`. Matches the convention in
+ * `plugins/sigil/internal/agents/{codex,copilot}/mapper/mapper.go` and
+ * `plugins/pi/src/lineage.ts` (`stablePiGenerationId`), but uses an
+ * opencode-specific prefix so generation IDs identify the producer plugin.
+ *
+ * The same assistant message therefore always maps to the same generation
+ * id. Re-exporting it (on resume, restart, or a double-firing event) hits
+ * the backend's first-write-wins dedup and is rejected as a no-op instead
+ * of inflating token and cost totals.
+ */
+export function stableOpencodeGenerationId(
+  sessionID: string,
+  messageID: string,
+): string {
+  const hex = createHash("sha256")
+    .update(`${sessionID}\0${messageID}`)
+    .digest("hex");
+  return `opencode-${hex.slice(0, 24)}`;
+}

--- a/plugins/opencode/src/testdata/golden/opencode-full-message.golden.json
+++ b/plugins/opencode/src/testdata/golden/opencode-full-message.golden.json
@@ -3,10 +3,10 @@
     "path": "/api/v1/generations:export",
     "generations": [
       {
-        "id": "<NORMALIZED-ID>",
+        "id": "opencode-d0c11673ecf0262346ca8e82",
         "conversation_id": "opencode-sess-1",
-        "operation_name": "generateText",
-        "mode": "GENERATION_MODE_SYNC",
+        "operation_name": "streamText",
+        "mode": "GENERATION_MODE_STREAM",
         "trace_id": "<NORMALIZED>",
         "span_id": "<NORMALIZED>",
         "model": {


### PR DESCRIPTION
On `session.idle` the plugin refetched every message and recorded each one, deduplicated only by an in-memory map that resets per process. After a resume, restart, or switching to a session from an earlier run, the first idle re-exported the whole history with fresh random generation IDs, so the backend stored them as distinct generations and inflated token and cost totals.

Give each assistant generation a deterministic ID derived from the session and message IDs, matching the pi and codex/copilot, so a re-export hits the backend's first-write-wins dedup and becomes a no-op. Link each generation to the previous one recorded for the session so assistant turns form a chain. Drop the idle sweep entirely, recording already happens on `message.updated` and `message.part.updated`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes generation export identity, lineage, and when history is recorded—directly affecting backend dedup and usage metrics, though the intent is to fix double-counting rather than introduce new failure modes.
> 
> **Overview**
> Fixes inflated token and cost totals when the OpenCode plugin re-recorded whole sessions after resume or restart.
> 
> **Deterministic generation IDs and lineage:** Assistant exports now use `stableOpencodeGenerationId` (`opencode-` + SHA-256 of session and message id) so backend first-write-wins dedup treats repeats as no-ops. Sequential turns in-process get `parentGenerationIds` from the last recorded assistant generation; the chain resets on process restart or `session.deleted`.
> 
> **Live recording only:** The `session.idle` history sweep (`sweepTerminalAssistantMessages`) is removed—recording stays on `message.updated` and `message.part.updated` (step-finish). Idle only flushes Sigil/OTLP.
> 
> **Streaming export + TTFT:** Exports use `startStreamingGeneration` (golden expects `streamText` / `GENERATION_MODE_STREAM`). First text/reasoning/tool part time from `message.part.updated` is stored and passed as `setFirstTokenAt`, including in `metadata_only` without fetching message bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65cc022b6d22bc4f4345691d86b50503aa3ef81e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->