### PR TITLE
fix(plugins/opencode): record error spans for tools that never complete

### DIFF
--- a/plugins/opencode/src/hooks.otlp.test.ts
+++ b/plugins/opencode/src/hooks.otlp.test.ts
@@ -1,7 +1,7 @@
 import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { SigilOpencodeConfig } from "./config.js";
-import { createSigilHooks } from "./hooks.js";
+import { _resetHookState, createSigilHooks } from "./hooks.js";
 
 const SIGIL_OPENCODE_SCOPE = "sigil-opencode";
 const SIGIL_OPERATION_DURATION_METRIC = "gen_ai.client.operation.duration";
@@ -186,6 +186,7 @@ describe("createSigilHooks OTLP wiring", () => {
   let savedEnv: Record<string, string | undefined> = {};
 
   beforeEach(async () => {
+    _resetHookState();
     for (const k of ENV_KEYS) {
       savedEnv[k] = process.env[k];
       delete process.env[k];
@@ -202,6 +203,7 @@ describe("createSigilHooks OTLP wiring", () => {
       else process.env[k] = v;
     }
     savedEnv = {};
+    _resetHookState();
   });
 
   async function runOneTurn(otlpEnabled: boolean) {
@@ -372,5 +374,122 @@ describe("createSigilHooks OTLP wiring", () => {
   it("does not contact the OTLP endpoint when config.otlp is absent", async () => {
     await runOneTurn(false);
     expect(otlp.requests).toEqual([]);
+  });
+
+  // A tool that fires tool.execute.before but never tool.execute.after
+  // (errored or denied upstream). In metadata_only the terminal parts are not
+  // fetched, so the only source for a span is the drained active entry.
+  async function runNeverCompletedTurn() {
+    const sessionID = "otlp-sess-fail";
+    const userMessage = {
+      id: "user-fail-1",
+      sessionID,
+      role: "user",
+      time: { created: 1_700_000_000_000 },
+      system: "you are a helpful assistant",
+      tools: { bash: true },
+    };
+    const assistantMessage = {
+      id: "otlp-msg-fail",
+      sessionID,
+      role: "assistant",
+      time: { created: 1_700_000_001_000, completed: 1_700_000_002_500 },
+      parentID: "user-fail-1",
+      modelID: "claude-sonnet-4-opencode",
+      providerID: "anthropic",
+      mode: "build",
+      tokens: {
+        input: 10,
+        output: 5,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+      finish: "end_turn",
+    };
+
+    const config: SigilOpencodeConfig = {
+      endpoint: sigil.baseUrl,
+      auth: { mode: "none" },
+      agentName: "opencode",
+      agentVersion: "test-version",
+      contentCapture: "metadata_only",
+      debug: false,
+      otlp: {
+        endpoint: otlp.endpoint,
+        headers: { "X-Test-Header": "present" },
+      },
+    };
+
+    const fakeClient = {
+      session: { message: async () => ({ data: { parts: [] } }) },
+    } as any;
+
+    const hooks = await createSigilHooks(config, fakeClient);
+    if (!hooks) throw new Error("expected createSigilHooks to return hooks");
+
+    hooks.chatMessage(
+      { sessionID },
+      { message: userMessage as any, parts: [] as any },
+    );
+    await hooks.toolExecuteBefore(
+      { sessionID, callID: "tc-fail-1", tool: "bash" },
+      { args: { command: "false" } },
+    );
+    // No toolExecuteAfter.
+    await hooks.event({
+      event: {
+        type: "message.updated",
+        properties: { info: assistantMessage as any },
+      },
+    });
+    await hooks.event({
+      event: {
+        type: "session.idle",
+        properties: { info: { id: sessionID } },
+      },
+    });
+    await hooks.event({
+      event: { type: "global.disposed", properties: {} },
+    });
+  }
+
+  it("exports an error execute_tool span for a tool that never completes in metadata_only", async () => {
+    await runNeverCompletedTurn();
+
+    const traceReqs = otlp.requests.filter((r) => r.url === "/otlp/v1/traces");
+    expect(traceReqs.length).toBeGreaterThan(0);
+
+    type AttributeKV = { key?: string; value?: { stringValue?: string } };
+    type Span = { name?: string; attributes?: AttributeKV[] };
+    const spans: Span[] = [];
+    for (const req of traceReqs) {
+      const payload = JSON.parse(req.body) as {
+        resourceSpans?: Array<{
+          scopeSpans?: Array<{ spans?: Span[] }>;
+        }>;
+      };
+      for (const rs of payload.resourceSpans ?? []) {
+        for (const ss of rs.scopeSpans ?? []) {
+          for (const sp of ss.spans ?? []) spans.push(sp);
+        }
+      }
+    }
+
+    const toolSpans = spans.filter((sp) =>
+      sp.attributes?.some(
+        (a) =>
+          a.key === "gen_ai.operation.name" &&
+          a.value?.stringValue === "execute_tool",
+      ),
+    );
+    expect(toolSpans).toHaveLength(1);
+
+    const toolSpan = toolSpans[0]!;
+    const callId = toolSpan.attributes?.find(
+      (a) => a.key === "gen_ai.tool.call.id",
+    );
+    expect(callId?.value?.stringValue).toBe("tc-fail-1");
+    const errorType = toolSpan.attributes?.find((a) => a.key === "error.type");
+    expect(errorType?.value?.stringValue).toBe("tool_execution_error");
   });
 });

--- a/plugins/opencode/src/hooks.toolSpans.test.ts
+++ b/plugins/opencode/src/hooks.toolSpans.test.ts
@@ -5,8 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SigilOpencodeConfig } from "./config.js";
 import {
   _peekToolExecutionState,
+  _resetHookState,
   _resetToolExecutionState,
   createSigilHooks,
+  drainActiveToolExecutions,
   emitToolSpans,
   mergeToolSpanRecords,
   type ToolExecutionRecord,
@@ -303,6 +305,164 @@ describe("mergeToolSpanRecords", () => {
     const merged = mergeToolSpanRecords(term, hook);
     expect(merged).toHaveLength(2);
   });
+
+  it("keeps a term error record over a drained record with the same key", () => {
+    const term = [
+      makeRecord({
+        toolCallId: "c1",
+        startedAt: 1,
+        completedAt: 2,
+        isError: true,
+        error: "ENOENT",
+      }),
+    ];
+    const drained = [
+      makeRecord({
+        toolCallId: "c1",
+        startedAt: 100,
+        completedAt: 200,
+        isError: true,
+        error: "tool did not complete (errored, denied, or interrupted)",
+      }),
+    ];
+
+    const merged = mergeToolSpanRecords(term, drained);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      toolCallId: "c1",
+      startedAt: 1,
+      completedAt: 2,
+      error: "ENOENT",
+    });
+  });
+
+  it("keeps a drained record whose key is not covered by term records", () => {
+    const term = [makeRecord({ toolCallId: "c1" })];
+    const drained = [
+      makeRecord({
+        toolCallId: "c2",
+        startedAt: 100,
+        completedAt: 200,
+        isError: true,
+        error: "tool did not complete (errored, denied, or interrupted)",
+      }),
+    ];
+
+    const merged = mergeToolSpanRecords(term, drained);
+    expect(merged).toHaveLength(2);
+    expect(merged[1]).toMatchObject({ toolCallId: "c2", isError: true });
+  });
+});
+
+function metadataOnlyConfig(): SigilOpencodeConfig {
+  return {
+    endpoint: "http://127.0.0.1:1",
+    auth: { mode: "none" },
+    agentName: "opencode",
+    agentVersion: "test-version",
+    contentCapture: "metadata_only",
+    debug: false,
+  };
+}
+
+async function makeHooks(config: SigilOpencodeConfig) {
+  const hooks = await createSigilHooks(config, {
+    session: { message: async () => ({ data: { parts: [] } }) },
+  } as never);
+  if (!hooks) throw new Error("expected hooks");
+  return hooks;
+}
+
+describe("drainActiveToolExecutions", () => {
+  beforeEach(() => _resetToolExecutionState());
+  afterEach(() => _resetToolExecutionState());
+
+  it("turns active entries into error records, removes them, scoped by session", async () => {
+    const hooks = await makeHooks(metadataOnlyConfig());
+
+    await hooks.toolExecuteBefore(
+      { sessionID: "s1", callID: "c1", tool: "bash" },
+      { args: { command: "false" } },
+    );
+    await hooks.toolExecuteBefore(
+      { sessionID: "s1", callID: "c2", tool: "read" },
+      { args: { path: "/x" } },
+    );
+    await hooks.toolExecuteBefore(
+      { sessionID: "s2", callID: "c3", tool: "grep" },
+      { args: { pattern: "x" } },
+    );
+
+    const drained = drainActiveToolExecutions("s1");
+
+    expect(drained).toHaveLength(2);
+    for (const rec of drained) {
+      expect(rec.isError).toBe(true);
+      expect(rec.error).toBeTruthy();
+      expect(rec.completedAt).toBeGreaterThan(0);
+    }
+    expect(drained.map((r) => r.toolCallId).sort()).toEqual(["c1", "c2"]);
+
+    // Only s1 is drained; the unrelated session keeps its active entry.
+    const active = _peekToolExecutionState().active;
+    expect(active).toHaveLength(1);
+    expect(active[0]).toMatchObject({ sessionID: "s2", toolCallId: "c3" });
+  });
+
+  it("returns nothing and mutates nothing when the session has no active entries", async () => {
+    const hooks = await makeHooks(metadataOnlyConfig());
+    await hooks.toolExecuteBefore(
+      { sessionID: "s2", callID: "c3", tool: "grep" },
+      { args: {} },
+    );
+
+    expect(drainActiveToolExecutions("s1")).toEqual([]);
+    expect(_peekToolExecutionState().active).toHaveLength(1);
+  });
+});
+
+describe("synthesized error spans for never-completed tools", () => {
+  beforeEach(() => _resetToolExecutionState());
+  afterEach(() => {
+    _resetToolExecutionState();
+    vi.useRealTimers();
+  });
+
+  it("emits exactly one error span with real startedAt in metadata_only", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+
+    const hooks = await makeHooks(metadataOnlyConfig());
+    await hooks.toolExecuteBefore(
+      { sessionID: "s1", callID: "c1", tool: "bash" },
+      { args: { command: "false" } },
+    );
+    // The tool errored or was denied upstream: tool.execute.after never fires.
+    vi.setSystemTime(5000);
+
+    // Reproduce recordAssistantMessage's span assembly in metadata_only: parts
+    // are not fetched, so termRecords is empty and the drained record is the
+    // only source.
+    const termRecords = toolSpansFromParts("s1", []);
+    const drained = drainActiveToolExecutions("s1");
+    const merged = mergeToolSpanRecords(termRecords, drained);
+
+    const { client, recorders } = mockSigilClient();
+    emitToolSpans(client, merged, {
+      ...defaultOpts(),
+      conversationId: "s1",
+      contentCapture: "metadata_only",
+    });
+
+    expect(recorders).toHaveLength(1);
+    expect(recorders[0]!.start).toMatchObject({
+      toolName: "bash",
+      toolCallId: "c1",
+      startedAt: new Date(1000),
+    });
+    expect(recorders[0]!.callError).toBeInstanceOf(Error);
+    expect(_peekToolExecutionState().active).toHaveLength(0);
+  });
 });
 
 function startResponseServer(
@@ -333,12 +493,12 @@ describe("hook lifecycle records and guard denial", () => {
   const servers: Server[] = [];
 
   beforeEach(() => {
-    _resetToolExecutionState();
+    _resetHookState();
   });
 
   afterEach(async () => {
     await Promise.all(servers.splice(0).map(closeServer));
-    _resetToolExecutionState();
+    _resetHookState();
   });
 
   it("toolExecuteBefore/After move an active record into completed", async () => {
@@ -431,6 +591,173 @@ describe("hook lifecycle records and guard denial", () => {
       { title: "ls", output: "ignored", metadata: {} },
     );
     expect(_peekToolExecutionState().completed).toHaveLength(0);
+
+    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+  });
+
+  it("drains an incomplete tool execution when the assistant message records (metadata_only)", async () => {
+    const sigilSrv = await startResponseServer({ results: [] });
+    servers.push(sigilSrv.server);
+
+    const config: SigilOpencodeConfig = {
+      endpoint: sigilSrv.baseUrl,
+      auth: { mode: "none" },
+      agentName: "opencode",
+      agentVersion: "test-version",
+      contentCapture: "metadata_only",
+      debug: false,
+    };
+
+    const hooks = await createSigilHooks(config, {
+      session: { message: async () => ({ data: { parts: [] } }) },
+    } as never);
+    if (!hooks) throw new Error("expected hooks");
+
+    const sessionID = "sess-1";
+    hooks.chatMessage(
+      { sessionID },
+      {
+        message: {
+          id: "user-1",
+          sessionID,
+          role: "user",
+          time: { created: 1_700_000_000_000 },
+          system: "sys",
+          tools: { bash: true },
+        } as never,
+        parts: [] as never,
+      },
+    );
+
+    // Tool starts but never completes (errored or denied upstream): opencode
+    // skips tool.execute.after, so no after hook fires.
+    await hooks.toolExecuteBefore(
+      { sessionID, callID: "call-1", tool: "bash" },
+      { args: { command: "false" } },
+    );
+    expect(_peekToolExecutionState().active).toHaveLength(1);
+
+    await hooks.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg-1",
+            sessionID,
+            role: "assistant",
+            time: {
+              created: 1_700_000_001_000,
+              completed: 1_700_000_002_000,
+            },
+            modelID: "claude-sonnet-4-opencode",
+            providerID: "anthropic",
+            mode: "build",
+            tokens: {
+              input: 10,
+              output: 5,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+            finish: "end_turn",
+          },
+        },
+      },
+    });
+
+    expect(_peekToolExecutionState().active).toHaveLength(0);
+
+    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+  });
+
+  it("removes the stranded active entry in full mode when the error part is present", async () => {
+    const sigilSrv = await startResponseServer({ results: [] });
+    servers.push(sigilSrv.server);
+
+    const sessionID = "sess-full";
+    const messageID = "msg-full";
+    const errorPart = {
+      id: "p-err",
+      sessionID,
+      messageID,
+      type: "tool",
+      callID: "call-1",
+      tool: "bash",
+      state: {
+        status: "error",
+        input: { command: "false" },
+        error: "exit status 1",
+        time: { start: 1_700_000_001_200, end: 1_700_000_001_400 },
+      },
+    };
+
+    const config: SigilOpencodeConfig = {
+      endpoint: sigilSrv.baseUrl,
+      auth: { mode: "none" },
+      agentName: "opencode",
+      agentVersion: "test-version",
+      contentCapture: "full",
+      debug: false,
+    };
+
+    const hooks = await createSigilHooks(config, {
+      session: { message: async () => ({ data: { parts: [errorPart] } }) },
+    } as never);
+    if (!hooks) throw new Error("expected hooks");
+
+    hooks.chatMessage(
+      { sessionID },
+      {
+        message: {
+          id: "user-full",
+          sessionID,
+          role: "user",
+          time: { created: 1_700_000_000_000 },
+          system: "sys",
+          tools: { bash: true },
+        } as never,
+        parts: [] as never,
+      },
+    );
+
+    // Native tool errored: tool.execute.after never fires, leaving an active
+    // entry, but the error is captured in the fetched parts.
+    await hooks.toolExecuteBefore(
+      { sessionID, callID: "call-1", tool: "bash" },
+      { args: { command: "false" } },
+    );
+    expect(_peekToolExecutionState().active).toHaveLength(1);
+
+    await hooks.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: messageID,
+            sessionID,
+            role: "assistant",
+            time: {
+              created: 1_700_000_001_000,
+              completed: 1_700_000_002_000,
+            },
+            modelID: "claude-sonnet-4-opencode",
+            providerID: "anthropic",
+            mode: "build",
+            tokens: {
+              input: 10,
+              output: 5,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+            finish: "end_turn",
+          },
+        },
+      },
+    });
+
+    // Drained in full mode too, so the entry never leaks. The merge keeps the
+    // accurate terminal record over the synthesized drained one; that
+    // precedence is pinned by the mergeToolSpanRecords cases above.
+    expect(_peekToolExecutionState().active).toHaveLength(0);
 
     await hooks.event({ event: { type: "global.disposed", properties: {} } });
   });

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -83,6 +83,25 @@ export function _resetToolExecutionState(): void {
   completedToolExecutions.clear();
 }
 
+/**
+ * Resets every module-level map: the dedup/generation tracking plus the
+ * tool-execution maps. Integration tests that drive the full record path
+ * (`chat.message` -> `message.updated`) need this between cases. Without it, a
+ * reused session/message id hits the dedup early-return in
+ * `recordAssistantMessage`, silently skips recording, and produces a
+ * misleading green.
+ *
+ * @internal Exported for testing.
+ */
+export function _resetHookState(): void {
+  recordedMessages.clear();
+  lastGenerationIdBySession.clear();
+  firstPartAtByMessage.clear();
+  pendingGenerations.clear();
+  sessionContexts.clear();
+  _resetToolExecutionState();
+}
+
 /** @internal Exported for testing. */
 export function _peekToolExecutionState(): {
   active: ToolExecutionRecord[];
@@ -353,7 +372,16 @@ async function recordAssistantMessage(
     assistantParts,
   );
   const hookRecords = completedToolExecutions.get(assistantMsg.sessionID) ?? [];
-  const spanRecords = mergeToolSpanRecords(termRecords, hookRecords);
+  // Tools that started but never fired `tool.execute.after` (errored, denied,
+  // or interrupted) become error records here, so they surface as spans even
+  // in metadata_only and stop leaking from activeToolExecutions. termRecords
+  // win on key collision, so a native tool with an error part keeps the
+  // accurate terminal record while the active entry is still deleted.
+  const drainedRecords = drainActiveToolExecutions(assistantMsg.sessionID);
+  const spanRecords = mergeToolSpanRecords(termRecords, [
+    ...hookRecords,
+    ...drainedRecords,
+  ]);
   const spanOpts = {
     conversationId: assistantMsg.sessionID,
     agentName: buildAgentName(config.agentName, assistantMsg.mode),
@@ -658,6 +686,39 @@ export function toolSpansFromParts(
     }
   }
   return records;
+}
+
+/**
+ * Convert tool executions that started but never completed for this session
+ * into error records, removing them from the active map. opencode skips
+ * `tool.execute.after` when a tool throws or a permission deny aborts it, so
+ * an entry still active when the assistant message goes terminal is a failed,
+ * denied, or interrupted call. Without this it produces no span (in
+ * `metadata_only`, where terminal parts aren't fetched) and leaks from
+ * `activeToolExecutions` until `session.deleted`.
+ *
+ * `startedAt` is the real value from the before hook; `completedAt` is
+ * approximate (we have no real end time) and the reason is generic because the
+ * hook can't tell an error from a deny from an interrupt.
+ *
+ * @internal Exported for testing.
+ */
+export function drainActiveToolExecutions(
+  sessionID: string,
+): ToolExecutionRecord[] {
+  const drained: ToolExecutionRecord[] = [];
+  const now = Date.now();
+  for (const [key, record] of activeToolExecutions) {
+    if (record.sessionID !== sessionID) continue;
+    activeToolExecutions.delete(key);
+    drained.push({
+      ...record,
+      completedAt: now,
+      isError: true,
+      error: "tool did not complete (errored, denied, or interrupted)",
+    });
+  }
+  return drained;
 }
 
 /**


### PR DESCRIPTION
opencode skips `tool.execute.after` when a tool's execute throws or a permission deny aborts it, so a failed or denied tool left its activeToolExecutions entry stranded until session.deleted and produced no span at all.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only fix in the opencode plugin’s tool span path; no auth or data-model changes, with broad test coverage for merge precedence and OTLP export.
> 
> **Overview**
> When opencode never fires **`tool.execute.after`** (failed execute, permission deny, interrupt), tool calls could stay in **`activeToolExecutions`** with **no telemetry span**, especially in **`metadata_only`** where assistant tool parts are not fetched.
> 
> **`drainActiveToolExecutions`** runs when an assistant message is recorded: it turns any still-active tools for that session into **error records**, removes them from the active map, and merges them into span export with hook and terminal-part records. Terminal **`ToolPart`** error timing still **wins on duplicate call IDs**, so **`full`** mode keeps accurate errors while the stray active entry is cleared.
> 
> Tests add **`_resetHookState`** for full hook integration isolation, unit coverage for drain/merge, lifecycle cases for **`metadata_only`** and **`full`**, and an OTLP assertion for **`execute_tool`** with **`error.type: tool_execution_error`** when a tool never completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ff8759ff574d21c1dda35a3f90d5f0d4918175d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->