### PR TITLE
chore(plugins/claude-code): bump version to 0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "sigil-cc",
       "source": "./plugins/claude-code",
       "description": "Send Claude Code session telemetry to Grafana Sigil",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "Grafana Labs"
       }

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sigil-cc",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Send Claude Code session telemetry to Grafana Sigil",
   "author": {
     "name": "Grafana Labs"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only version string updates with no runtime or configuration changes beyond the version field.
> 
> **Overview**
> Bumps the **sigil-cc** Claude Code plugin from **0.2.0** to **0.3.0** in both the marketplace listing (`.claude-plugin/marketplace.json`) and the plugin manifest (`plugins/claude-code/.claude-plugin/plugin.json`). No hook commands, timeouts, or other plugin behavior is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 206586cb889814bf86a28703814eba2210c218e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->