### PR TITLE
feat(plugins): log when a guard redaction transform is applied

### DIFF
--- a/plugins/pi/src/guard.test.ts
+++ b/plugins/pi/src/guard.test.ts
@@ -226,18 +226,23 @@ describe("runToolCallGuard", () => {
       },
     }));
 
+    const warn = vi.fn();
     const result = await runToolCallGuard(
       makeArgs({
         client,
         toolCallId: "c1",
         toolName: "bash",
         input: { command: "echo sk-real-secret" },
+        logger: { warn },
       }),
     );
     expectTransform(result);
     expect(result.transform).toEqual({
       command: "echo [REDACTED_KEY]",
     });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("transform for c1 applied"),
+    );
   });
 
   it("ignores transformed_input that targets a different toolCallId", async () => {
@@ -263,8 +268,9 @@ describe("runToolCallGuard", () => {
       },
     }));
 
-    // No matching tool_call id means there is simply no redaction for this
-    // call, so it must stay silent (no warning).
+    // A transform was present but none of its parts matched this call, so the
+    // original input is left unchanged. Log it so a no-op transform is
+    // distinguishable from a plain allow in the debug log.
     const warn = vi.fn();
     const result = await runToolCallGuard(
       makeArgs({
@@ -275,7 +281,9 @@ describe("runToolCallGuard", () => {
       }),
     );
     expect(result).toBeUndefined();
-    expect(warn).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("no part matched c1"),
+    );
   });
 
   it("logs and drops a transform whose inputJSON cannot be parsed", async () => {

--- a/plugins/pi/src/guard.ts
+++ b/plugins/pi/src/guard.ts
@@ -209,8 +209,7 @@ function extractToolCallTransform(
       const tc = part.toolCall;
       if (!tc || tc.id !== toolCallId) continue;
       // A matching tool_call whose args we cannot parse means the server sent
-      // a transform we cannot apply; log it. The no-match case stays silent,
-      // since that just means there is no redaction for this call.
+      // a transform we cannot apply; log it.
       const raw = tc.inputJSON;
       if (typeof raw !== "string" || raw.length === 0) {
         logger?.warn(
@@ -221,6 +220,7 @@ function extractToolCallTransform(
       try {
         const parsed = JSON.parse(raw) as unknown;
         if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          logger?.warn(`tool-call transform for ${toolCallId} applied`);
           return parsed as Record<string, unknown>;
         }
         logger?.warn(
@@ -235,5 +235,9 @@ function extractToolCallTransform(
       }
     }
   }
+  // A transform was present in the response but none of its tool_call parts
+  // matched this call's id, so the original input is left unchanged. Worth a
+  // line because it is otherwise indistinguishable from a plain allow.
+  logger?.warn(`tool-call transform present but no part matched ${toolCallId}`);
   return undefined;
 }

--- a/plugins/sigil/internal/agents/guard/toolcall.go
+++ b/plugins/sigil/internal/agents/guard/toolcall.go
@@ -209,18 +209,29 @@ func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCa
 		}
 	}
 
+	deniedErr := sigil.HookDeniedFromResponse(resp)
+
+	// Resolve any redaction transform before logging so the decision line can
+	// report whether the tool input was rewritten. A deny never carries a
+	// usable transform, so only the allow path looks for one.
+	var updatedInput json.RawMessage
+	if deniedErr == nil {
+		updatedInput = extractToolCallTransform(resp, strings.TrimSpace(in.ToolCallID), logger)
+	}
+
 	if resp != nil && logger != nil {
 		logger.Printf(
-			"guard: tool=%q endpoint=%q action=%q rule_id=%q reason=%q",
+			"guard: tool=%q endpoint=%q action=%q rule_id=%q reason=%q transform_applied=%t",
 			in.ToolName,
 			endpoint,
 			string(resp.Action),
 			resp.RuleID,
 			resp.Reason,
+			len(updatedInput) > 0,
 		)
 	}
 
-	if deniedErr := sigil.HookDeniedFromResponse(resp); deniedErr != nil {
+	if deniedErr != nil {
 		var ruleReason string
 		var denied *sigil.HookDeniedError
 		if errors.As(deniedErr, &denied) {
@@ -239,7 +250,7 @@ func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCa
 
 	return Result{
 		Action:           sigil.HookActionAllow,
-		UpdatedInputJSON: extractToolCallTransform(resp, strings.TrimSpace(in.ToolCallID), logger),
+		UpdatedInputJSON: updatedInput,
 	}
 }
 
@@ -249,7 +260,11 @@ func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCa
 // through to the original tool input unchanged. Mirrors pi guard.ts
 // extractToolCallTransform; keep the two in sync.
 func extractToolCallTransform(resp *sigil.HookEvaluateResponse, toolCallID string, logger *log.Logger) json.RawMessage {
-	if resp == nil || resp.TransformedInput == nil {
+	// Treat an absent or empty output the same way: there is no transform to
+	// apply, so stay silent. This mirrors pi guard.ts, whose early return also
+	// covers the empty-output case; the no-match line below is reserved for a
+	// transform that carried parts but none for this tool call.
+	if resp == nil || resp.TransformedInput == nil || len(resp.TransformedInput.Output) == 0 {
 		return nil
 	}
 	for _, msg := range resp.TransformedInput.Output {
@@ -284,8 +299,17 @@ func extractToolCallTransform(resp *sigil.HookEvaluateResponse, toolCallID strin
 				}
 				return nil
 			}
+			if logger != nil {
+				logger.Printf("guard: tool-call transform for %s applied", toolCallID)
+			}
 			return raw
 		}
+	}
+	// A transform was present in the response but none of its tool_call parts
+	// matched this call's ID, so the original input is left unchanged. Worth a
+	// line because it is otherwise indistinguishable from a plain allow.
+	if logger != nil {
+		logger.Printf("guard: tool-call transform present but no part matched %s", toolCallID)
 	}
 	return nil
 }

--- a/plugins/sigil/internal/agents/guard/toolcall_test.go
+++ b/plugins/sigil/internal/agents/guard/toolcall_test.go
@@ -35,6 +35,7 @@ func TestEvaluateToolCall(t *testing.T) {
 		wantReasonSub          string
 		wantUpdatedInput       string
 		wantLogSub             string
+		wantNoLogSub           string
 		wantServerCalled       bool
 	}{
 		{
@@ -55,6 +56,18 @@ func TestEvaluateToolCall(t *testing.T) {
 			serverResponds:   `{"action":"allow"}`,
 			toolName:         "bash",
 			wantAction:       sigil.HookActionAllow,
+			wantLogSub:       "transform_applied=false",
+			wantServerCalled: true,
+		},
+		{
+			// An empty output is treated the same as no transform at all, so it
+			// must stay silent rather than emit the no-match line. Mirrors pi.
+			name:             "empty transform output is ignored",
+			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:   `{"action":"allow","transformed_input":{"output":[]}}`,
+			toolName:         "bash",
+			wantAction:       sigil.HookActionAllow,
+			wantNoLogSub:     "tool-call transform present but no part matched",
 			wantServerCalled: true,
 		},
 		{
@@ -104,6 +117,7 @@ func TestEvaluateToolCall(t *testing.T) {
 			toolName:         "bash",
 			wantAction:       sigil.HookActionAllow,
 			wantUpdatedInput: `{"cmd":"echo [REDACTED]"}`,
+			wantLogSub:       "transform_applied=true",
 			wantServerCalled: true,
 		},
 		{
@@ -123,6 +137,7 @@ func TestEvaluateToolCall(t *testing.T) {
 			serverResponds:   `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"tu_other","name":"bash","input_json":{"cmd":"echo X"}}}]}]}}`,
 			toolName:         "bash",
 			wantAction:       sigil.HookActionAllow,
+			wantLogSub:       "tool-call transform present but no part matched tu_1",
 			wantServerCalled: true,
 		},
 		{
@@ -233,6 +248,9 @@ func TestEvaluateToolCall(t *testing.T) {
 			}
 			if tt.wantLogSub != "" && !strings.Contains(logBuf.String(), tt.wantLogSub) {
 				t.Errorf("logs missing %q:\n%s", tt.wantLogSub, logBuf.String())
+			}
+			if tt.wantNoLogSub != "" && strings.Contains(logBuf.String(), tt.wantNoLogSub) {
+				t.Errorf("logs contain %q but should not:\n%s", tt.wantNoLogSub, logBuf.String())
 			}
 			if tt.wantServerCalled && calls.Load() == 0 {
 				t.Errorf("expected sigil hook server to be called, got 0 calls")


### PR DESCRIPTION
Improve logging for transform guards:
- Add `transform_applied` to the debug log line that
- A line for the present-but-unmatched case

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are logging and test assertions only; allow/deny and redaction application logic are unchanged aside from new diagnostic messages.
> 
> **Overview**
> **Guard tool-call transform logging** is expanded in the **pi** plugin and the **Sigil** Go guard so debug output distinguishes plain allows from redaction outcomes.
> 
> When a matching redaction transform is applied, both paths now emit a **“transform applied”** warning. When `transformed_input` includes tool-call parts but none match the current call ID, they log **“present but no part matched”** instead of staying silent—while **empty** transform output still produces no extra line (aligned between pi and Go).
> 
> On the Go side, **`transform_applied`** is added to the main guard decision log line, with transform resolution moved **before** that log so the flag reflects whether input was actually rewritten; deny paths skip transform extraction as before. Tests cover the new log expectations, including the empty-output silent case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c09ec3ed60008ff4b084679271c4f66694fec7ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->