### PR TITLE
feat(dotnet): add secrets redaction sanitizer

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -127,6 +127,40 @@ Generation export transport protocols:
 - `GenerationExportProtocol.Http`
 - `GenerationExportProtocol.None` (instrumentation-only; no generation transport)
 
+## Secrets redaction
+
+Use the built-in secrets sanitizer to redact high-confidence secret formats
+before generation data is exported. It uses the same gitleaks-derived pattern
+set as the other Sigil SDKs and replaces matches with
+`[REDACTED:<category>]` placeholders.
+
+```csharp
+using Grafana.Sigil;
+
+var sigil = new SigilClient(new SigilClientConfig
+{
+    GenerationSanitizer = SecretRedactionSanitizer.Create(),
+});
+```
+
+By default, the sanitizer redacts assistant output, thinking blocks, tool call
+arguments, tool results, system prompts, conversation titles, provider call
+errors, and email addresses. User input messages are left unchanged unless you
+opt in:
+
+```csharp
+var sigil = new SigilClient(new SigilClientConfig
+{
+    GenerationSanitizer = SecretRedactionSanitizer.Create(new SecretRedactionOptions
+    {
+        RedactInputMessages = true,
+    }),
+});
+```
+
+You can also set `SIGIL_REDACT_INPUT_MESSAGES=true`. An explicit
+`RedactInputMessages` value takes precedence over the environment variable.
+
 ## Embedding observability
 
 Use `StartEmbedding(...)` for manual embedding instrumentation. Embedding recording emits OTel spans and SDK metrics only, and does not enqueue generation export payloads.

--- a/dotnet/src/Grafana.Sigil/Config.cs
+++ b/dotnet/src/Grafana.Sigil/Config.cs
@@ -80,6 +80,12 @@ public sealed class SigilClientConfig
     public EmbeddingCaptureConfig EmbeddingCapture { get; set; } = new();
     public ContentCaptureMode ContentCapture { get; set; } = ContentCaptureMode.Default;
     public Func<IReadOnlyDictionary<string, object?>?, ContentCaptureMode>? ContentCaptureResolver { get; set; }
+    /// <summary>
+    /// Optional hook invoked for each generation after normalization and before
+    /// content-capture stripping/export. Use <see cref="SecretRedactionSanitizer"/>
+    /// to create the built-in regex-based secrets redactor.
+    /// </summary>
+    public GenerationSanitizer? GenerationSanitizer { get; set; }
     public Action<string>? Logger { get; set; }
     public Func<DateTimeOffset>? UtcNow { get; set; }
     public Func<TimeSpan, CancellationToken, Task>? SleepAsync { get; set; }

--- a/dotnet/src/Grafana.Sigil/README.md
+++ b/dotnet/src/Grafana.Sigil/README.md
@@ -78,6 +78,33 @@ var client = new SigilClient(new SigilClientConfig
 });
 ```
 
+## Secrets redaction
+
+Use the built-in sanitizer to redact high-confidence secret formats before
+generation data is exported:
+
+```csharp
+var client = new SigilClient(new SigilClientConfig
+{
+    GenerationSanitizer = SecretRedactionSanitizer.Create(),
+});
+```
+
+User input messages are not redacted by default. To opt in:
+
+```csharp
+var client = new SigilClient(new SigilClientConfig
+{
+    GenerationSanitizer = SecretRedactionSanitizer.Create(new SecretRedactionOptions
+    {
+        RedactInputMessages = true,
+    }),
+});
+```
+
+You can also set `SIGIL_REDACT_INPUT_MESSAGES=true`. Explicit options take
+precedence over the environment variable.
+
 ## Manual generation instrumentation (sync)
 
 Use this API for unsupported providers or custom pipelines.

--- a/dotnet/src/Grafana.Sigil/Redaction.cs
+++ b/dotnet/src/Grafana.Sigil/Redaction.cs
@@ -1,0 +1,280 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Grafana.Sigil;
+
+/// <summary>
+/// Mutates a normalized generation before export. Sanitizers may redact strings
+/// and byte payloads, but should preserve message and part structure.
+/// </summary>
+public delegate Generation GenerationSanitizer(Generation generation);
+
+/// <summary>Options for the built-in secret redaction sanitizer.</summary>
+public sealed class SecretRedactionOptions
+{
+    /// <summary>
+    /// Redact user messages in <see cref="Generation.Input"/>. <c>null</c>
+    /// falls back to <c>SIGIL_REDACT_INPUT_MESSAGES</c>, then <c>false</c>.
+    /// Assistant and tool messages in input are always sanitized.
+    /// </summary>
+    public bool? RedactInputMessages { get; set; }
+
+    /// <summary>
+    /// Redact generic email addresses. Defaults to <c>true</c>.
+    /// </summary>
+    public bool RedactEmailAddresses { get; set; } = true;
+}
+
+/// <summary>Factory for the built-in regex-based secrets redactor.</summary>
+public static class SecretRedactionSanitizer
+{
+    private const string EnvRedactInputMessages = "SIGIL_REDACT_INPUT_MESSAGES";
+    private static readonly HashSet<string> TrueTokens = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "1", "true", "yes", "on",
+    };
+    private static readonly HashSet<string> FalseTokens = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "0", "false", "no", "off",
+    };
+
+    private sealed record SecretPattern(string Id, Regex Regex);
+
+    private static readonly SecretPattern[] Tier1Patterns =
+    [
+        new("grafana-cloud-token", new Regex(@"\bglc_[A-Za-z0-9_-]{20,}", RegexOptions.Compiled)),
+        new("grafana-service-account-token", new Regex(@"\bglsa_[A-Za-z0-9_-]{20,}", RegexOptions.Compiled)),
+        new("aws-access-token", new Regex(@"\b(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z2-7]{16}\b", RegexOptions.Compiled)),
+        new("github-pat", new Regex(@"\bghp_[A-Za-z0-9_]{36,}", RegexOptions.Compiled)),
+        new("github-oauth", new Regex(@"\bgho_[A-Za-z0-9_]{36,}", RegexOptions.Compiled)),
+        new("github-app-token", new Regex(@"\bghs_[A-Za-z0-9_]{36,}", RegexOptions.Compiled)),
+        new("github-fine-grained-pat", new Regex(@"\bgithub_pat_[A-Za-z0-9_]{82}", RegexOptions.Compiled)),
+        new("anthropic-api-key", new Regex(@"\bsk-ant-api03-[a-zA-Z0-9_-]{93}AA", RegexOptions.Compiled)),
+        new("anthropic-admin-key", new Regex(@"\bsk-ant-admin01-[a-zA-Z0-9_-]{93}AA", RegexOptions.Compiled)),
+        new("openai-api-key", new Regex(@"\bsk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20}", RegexOptions.Compiled)),
+        new("openai-project-key", new Regex(@"\bsk-proj-[a-zA-Z0-9_-]{40,}", RegexOptions.Compiled)),
+        new("openai-svcacct-key", new Regex(@"\bsk-svcacct-[a-zA-Z0-9_-]{40,}", RegexOptions.Compiled)),
+        new("gcp-api-key", new Regex(@"\bAIza[A-Za-z0-9_-]{35}", RegexOptions.Compiled)),
+        new("private-key", new Regex(@"-----BEGIN[A-Z ]*PRIVATE KEY-----[\s\S]*?-----END[A-Z ]*PRIVATE KEY-----", RegexOptions.Compiled)),
+        new("connection-string", new Regex(@"(?:postgres|mysql|mongodb|redis|amqp)://[^\s'""]+@[^\s'""]+", RegexOptions.Compiled)),
+        new("bearer-token", new Regex(@"[Bb]earer\s+[A-Za-z0-9_.\-~+/]{20,}={0,3}", RegexOptions.Compiled)),
+        new("slack-token", new Regex(@"\bxox[bporas]-[A-Za-z0-9-]{10,}", RegexOptions.Compiled)),
+        new("stripe-key", new Regex(@"\b[sr]k_(?:live|test)_[A-Za-z0-9]{20,}", RegexOptions.Compiled)),
+        new("sendgrid-api-key", new Regex(@"\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}", RegexOptions.Compiled)),
+        new("twilio-api-key", new Regex(@"\bSK[a-f0-9]{32}", RegexOptions.Compiled)),
+        new("npm-token", new Regex(@"\bnpm_[A-Za-z0-9]{36}", RegexOptions.Compiled)),
+        new("pypi-token", new Regex(@"\bpypi-[A-Za-z0-9_-]{50,}", RegexOptions.Compiled)),
+    ];
+
+    private static readonly SecretPattern EmailPattern = new(
+        "email",
+        new Regex(@"\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b", RegexOptions.Compiled | RegexOptions.IgnoreCase)
+    );
+
+    private static readonly SecretPattern EnvSecretPattern = new(
+        "env-secret-value",
+        new Regex(
+            @"((?:PASSWORD|SECRET|TOKEN|KEY|CREDENTIAL|API_KEY|PRIVATE_KEY|ACCESS_KEY)\s*[=:]\s*)([^\s""{}\[\],]+)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase
+        )
+    );
+
+    /// <summary>
+    /// Returns a reusable generation sanitizer that redacts known secret formats.
+    /// </summary>
+    public static GenerationSanitizer Create(SecretRedactionOptions? options = null)
+    {
+        return Create(options, Environment.GetEnvironmentVariable, null);
+    }
+
+    internal static GenerationSanitizer Create(
+        SecretRedactionOptions? options,
+        Func<string, string?> envLookup,
+        Action<string>? logger
+    )
+    {
+        var resolved = options ?? new SecretRedactionOptions();
+        var redactInputs = ResolveRedactInputMessages(resolved.RedactInputMessages, envLookup, logger);
+        var includeEmail = resolved.RedactEmailAddresses;
+
+        return generation =>
+        {
+            if (!string.IsNullOrEmpty(generation.SystemPrompt))
+            {
+                generation.SystemPrompt = RedactFull(generation.SystemPrompt, includeEmail);
+            }
+
+            if (!string.IsNullOrEmpty(generation.ConversationTitle))
+            {
+                generation.ConversationTitle = RedactLight(generation.ConversationTitle, includeEmail);
+            }
+
+            if (!string.IsNullOrEmpty(generation.CallError))
+            {
+                generation.CallError = RedactLight(generation.CallError, includeEmail);
+            }
+
+            foreach (var message in generation.Input)
+            {
+                SanitizeMessage(message, InputTextMode(message.Role, redactInputs), includeEmail);
+            }
+
+            foreach (var message in generation.Output)
+            {
+                SanitizeMessage(message, OutputTextMode(message.Role), includeEmail);
+            }
+
+            return generation;
+        };
+    }
+
+    internal static string RedactFull(string value, bool includeEmail)
+    {
+        var result = RedactTier1(value);
+        if (includeEmail)
+        {
+            result = ApplyPattern(result, EmailPattern);
+        }
+
+        return EnvSecretPattern.Regex.Replace(result, $"$1[REDACTED:{EnvSecretPattern.Id}]");
+    }
+
+    internal static string RedactLight(string value, bool includeEmail)
+    {
+        var result = RedactTier1(value);
+        if (includeEmail)
+        {
+            result = ApplyPattern(result, EmailPattern);
+        }
+
+        return result;
+    }
+
+    private static byte[] RedactFullBytes(byte[] value, bool includeEmail)
+    {
+        if (value.Length == 0)
+        {
+            return value;
+        }
+
+        return Encoding.UTF8.GetBytes(RedactFull(Encoding.UTF8.GetString(value), includeEmail));
+    }
+
+    private static string RedactTier1(string value)
+    {
+        var result = value;
+        foreach (var pattern in Tier1Patterns)
+        {
+            result = ApplyPattern(result, pattern);
+        }
+
+        return result;
+    }
+
+    private static string ApplyPattern(string value, SecretPattern pattern)
+    {
+        return pattern.Regex.Replace(value, $"[REDACTED:{pattern.Id}]");
+    }
+
+    private static void SanitizeMessage(Message message, TextMode mode, bool includeEmail)
+    {
+        if (mode == TextMode.Skip)
+        {
+            return;
+        }
+
+        foreach (var part in message.Parts)
+        {
+            switch (part.Kind)
+            {
+                case PartKind.Text:
+                    part.Text = mode == TextMode.Full
+                        ? RedactFull(part.Text, includeEmail)
+                        : RedactLight(part.Text, includeEmail);
+                    break;
+                case PartKind.Thinking:
+                    part.Thinking = RedactLight(part.Thinking, includeEmail);
+                    break;
+                case PartKind.ToolCall:
+                    if (part.ToolCall?.InputJson is { Length: > 0 })
+                    {
+                        part.ToolCall.InputJson = RedactFullBytes(part.ToolCall.InputJson, includeEmail);
+                    }
+                    break;
+                case PartKind.ToolResult:
+                    if (part.ToolResult != null)
+                    {
+                        if (!string.IsNullOrEmpty(part.ToolResult.Content))
+                        {
+                            part.ToolResult.Content = RedactFull(part.ToolResult.Content, includeEmail);
+                        }
+                        if (part.ToolResult.ContentJson.Length > 0)
+                        {
+                            part.ToolResult.ContentJson = RedactFullBytes(part.ToolResult.ContentJson, includeEmail);
+                        }
+                    }
+                    break;
+            }
+        }
+    }
+
+    private static TextMode InputTextMode(MessageRole role, bool redactUserInput)
+    {
+        return role switch
+        {
+            MessageRole.User => redactUserInput ? TextMode.Full : TextMode.Skip,
+            MessageRole.Assistant => TextMode.Light,
+            MessageRole.Tool => TextMode.Full,
+            _ => TextMode.Skip,
+        };
+    }
+
+    private static TextMode OutputTextMode(MessageRole role)
+    {
+        return role switch
+        {
+            MessageRole.Assistant => TextMode.Light,
+            MessageRole.Tool => TextMode.Full,
+            _ => TextMode.Skip,
+        };
+    }
+
+    private static bool ResolveRedactInputMessages(
+        bool? explicitValue,
+        Func<string, string?> envLookup,
+        Action<string>? logger
+    )
+    {
+        if (explicitValue.HasValue)
+        {
+            return explicitValue.Value;
+        }
+
+        var raw = envLookup(EnvRedactInputMessages)?.Trim();
+        if (string.IsNullOrEmpty(raw))
+        {
+            return false;
+        }
+        var value = raw!;
+
+        if (TrueTokens.Contains(value))
+        {
+            return true;
+        }
+
+        if (FalseTokens.Contains(value))
+        {
+            return false;
+        }
+
+        logger?.Invoke($"sigil: ignoring invalid {EnvRedactInputMessages}: {value}");
+        return false;
+    }
+
+    private enum TextMode
+    {
+        Skip,
+        Light,
+        Full,
+    }
+}

--- a/dotnet/src/Grafana.Sigil/SigilClient.cs
+++ b/dotnet/src/Grafana.Sigil/SigilClient.cs
@@ -2318,35 +2318,56 @@ public sealed class GenerationRecorder
         }
 
         Generation generation;
+        var initialContentCaptureMode = _contentCaptureMode;
+        var effectiveContentCaptureMode = _contentCaptureMode;
+        var sanitizerRan = false;
+        var spanCallError = string.Empty;
+        var redactErrors = false;
         try
         {
             var completedAt = _client!._config.UtcNow!();
             generation = NormalizeGeneration(result, completedAt, callError, snapshotExtra);
 
-            var modeValue = _contentCaptureMode.ToMetadataValue();
+            if (_client!._config.GenerationSanitizer != null && effectiveContentCaptureMode != ContentCaptureMode.MetadataOnly)
+            {
+                sanitizerRan = true;
+                try
+                {
+                    generation = _client._config.GenerationSanitizer(generation);
+                }
+                catch (Exception ex)
+                {
+                    _client._config.Logger?.Invoke(
+                        $"sigil: generation sanitization failed, falling back to metadata_only: {ex.Message}"
+                    );
+                    effectiveContentCaptureMode = ContentCaptureMode.MetadataOnly;
+                }
+            }
+
+            SyncCanonicalMetadataMirrors(generation);
+
+            var modeValue = effectiveContentCaptureMode.ToMetadataValue();
             if (modeValue.Length > 0)
             {
                 generation.Metadata[SigilClient.MetadataKeyContentCaptureMode] = modeValue;
             }
 
-            if (_contentCaptureMode == ContentCaptureMode.MetadataOnly)
+            if (effectiveContentCaptureMode == ContentCaptureMode.MetadataOnly)
             {
                 var stripErrorCategory = SigilClient.ErrorCategoryFromException(callError, false);
                 SigilClient.StripContent(generation, stripErrorCategory);
             }
+
+            redactErrors =
+                effectiveContentCaptureMode == ContentCaptureMode.MetadataOnly
+                || effectiveContentCaptureMode == ContentCaptureMode.FullWithMetadataSpans;
+            spanCallError = generation.CallError;
         }
         finally
         {
             _contextScope?.Dispose();
             _contextScope = null;
         }
-
-        // Redact span-side error text under both stripped modes. Proto export
-        // under FullWithMetadataSpans still gets the raw generation.CallError
-        // (set during normalization); only the OTel span path is redacted.
-        var redactErrors =
-            _contentCaptureMode == ContentCaptureMode.MetadataOnly
-            || _contentCaptureMode == ContentCaptureMode.FullWithMetadataSpans;
 
         if (_activity != null)
         {
@@ -2358,7 +2379,7 @@ public sealed class GenerationRecorder
             // must drop sigil.conversation.title. `generation` is a local
             // snapshot here, so save the title, zero it for the span call,
             // and restore — no deep clone needed.
-            if (_contentCaptureMode == ContentCaptureMode.FullWithMetadataSpans)
+            if (effectiveContentCaptureMode == ContentCaptureMode.FullWithMetadataSpans)
             {
                 var savedTitle = generation.ConversationTitle;
                 generation.ConversationTitle = string.Empty;
@@ -2376,9 +2397,17 @@ public sealed class GenerationRecorder
                 SigilClient.ApplyGenerationSpanAttributes(_activity, generation);
             }
 
+            if (sanitizerRan && initialContentCaptureMode != ContentCaptureMode.FullWithMetadataSpans)
+            {
+                _activity.SetTag(SigilClient.SpanAttrConversationTitle, generation.ConversationTitle);
+            }
+
             if (callError != null)
             {
-                SigilClient.RecordException(_activity, callError, redactErrors);
+                var spanError = redactErrors || spanCallError == callError.Message
+                    ? callError
+                    : new Exception(spanCallError);
+                SigilClient.RecordException(_activity, spanError, redactErrors);
             }
 
             if (mappingError != null)
@@ -2436,7 +2465,9 @@ public sealed class GenerationRecorder
                 _activity.SetTag(SigilClient.SpanAttrErrorCategory, errorCategory);
                 var statusDescription = redactErrors
                     ? errorCategory
-                    : (callError ?? mappingError ?? localError)?.Message;
+                    : callError != null
+                        ? spanCallError
+                        : (mappingError ?? localError)?.Message;
                 _activity.SetStatus(ActivityStatusCode.Error, statusDescription);
             }
             else
@@ -2572,6 +2603,27 @@ public sealed class GenerationRecorder
 
         var text = value.ToString()?.Trim() ?? string.Empty;
         return text;
+    }
+
+    private static void SyncCanonicalMetadataMirrors(Generation generation)
+    {
+        if (!string.IsNullOrWhiteSpace(generation.ConversationTitle))
+        {
+            generation.Metadata[SigilClient.SpanAttrConversationTitle] = generation.ConversationTitle;
+        }
+        else
+        {
+            generation.Metadata.Remove(SigilClient.SpanAttrConversationTitle);
+        }
+
+        if (!string.IsNullOrWhiteSpace(generation.CallError))
+        {
+            generation.Metadata["call_error"] = generation.CallError;
+        }
+        else
+        {
+            generation.Metadata.Remove("call_error");
+        }
     }
 
     private static string NormalizeResolvedString(string value)

--- a/dotnet/tests/Grafana.Sigil.Tests/RedactionTests.cs
+++ b/dotnet/tests/Grafana.Sigil.Tests/RedactionTests.cs
@@ -1,0 +1,304 @@
+using System.Text;
+using Xunit;
+
+namespace Grafana.Sigil.Tests;
+
+public sealed class RedactionTests
+{
+    [Fact]
+    public void SecretRedactionSanitizer_RedactsAssistantAndToolContentByDefault()
+    {
+        var sanitizer = SecretRedactionSanitizer.Create();
+        var secretToken = "glc_abcdefghijklmnopqrstuvwxyz1234";
+        var envSecret = "DATABASE_PASSWORD=hunter2secret123";
+        var bearerToken = new string('a', 30);
+        var historicBearer = new string('h', 30);
+        var historicEnv = "API_TOKEN=historicvalue9876";
+
+        var generation = sanitizer(new Generation
+        {
+            Input =
+            {
+                Message.UserTextMessage("user pasted " + secretToken),
+                new Message
+                {
+                    Role = MessageRole.Assistant,
+                    Parts =
+                    {
+                        Part.TextPart("previous turn mentioned " + secretToken),
+                        Part.ToolCallPart(new ToolCall
+                        {
+                            Id = "prev-call",
+                            Name = "bash",
+                            InputJson = Encoding.UTF8.GetBytes("{\"header\":\"Bearer " + historicBearer + "\"}"),
+                        }),
+                    },
+                },
+                new Message
+                {
+                    Role = MessageRole.Tool,
+                    Parts =
+                    {
+                        Part.ToolResultPart(new ToolResult
+                        {
+                            ToolCallId = "prev-call",
+                            Name = "bash",
+                            Content = "previous output " + historicEnv,
+                        }),
+                    },
+                },
+            },
+            Output =
+            {
+                new Message
+                {
+                    Role = MessageRole.Assistant,
+                    Parts =
+                    {
+                        Part.TextPart("assistant saw " + secretToken),
+                        Part.ThinkingPart("thinking about " + secretToken),
+                        Part.ToolCallPart(new ToolCall
+                        {
+                            Id = "call-1",
+                            Name = "bash",
+                            InputJson = Encoding.UTF8.GetBytes("{\"header\":\"Bearer " + bearerToken + "\",\"env\":\"" + envSecret + "\"}"),
+                        }),
+                    },
+                },
+                new Message
+                {
+                    Role = MessageRole.Tool,
+                    Parts =
+                    {
+                        Part.ToolResultPart(new ToolResult
+                        {
+                            ToolCallId = "call-1",
+                            Name = "bash",
+                            Content = "output " + envSecret,
+                        }),
+                    },
+                },
+            },
+        });
+
+        Assert.Contains(secretToken, generation.Input[0].Parts[0].Text);
+        Assert.DoesNotContain(secretToken, generation.Input[1].Parts[0].Text);
+        Assert.DoesNotContain("Bearer " + historicBearer, Encoding.UTF8.GetString(generation.Input[1].Parts[1].ToolCall!.InputJson));
+        Assert.DoesNotContain("historicvalue9876", generation.Input[2].Parts[0].ToolResult!.Content);
+        Assert.Contains("[REDACTED:grafana-cloud-token]", generation.Output[0].Parts[0].Text);
+        Assert.DoesNotContain(secretToken, generation.Output[0].Parts[1].Thinking);
+        Assert.DoesNotContain("hunter2secret123", Encoding.UTF8.GetString(generation.Output[0].Parts[2].ToolCall!.InputJson));
+        Assert.DoesNotContain("Bearer " + bearerToken, Encoding.UTF8.GetString(generation.Output[0].Parts[2].ToolCall!.InputJson));
+        Assert.Contains("[REDACTED:env-secret-value]", generation.Output[1].Parts[0].ToolResult!.Content);
+    }
+
+    [Fact]
+    public void SecretRedactionSanitizer_InputRedactionRespectsOptionAndEnv()
+    {
+        var secretToken = "glc_abcdefghijklmnopqrstuvwxyz1234";
+
+        var defaultSanitized = SecretRedactionSanitizer.Create()(GenerationWithUserInput(secretToken));
+        Assert.Contains(secretToken, defaultSanitized.Input[0].Parts[0].Text);
+
+        var optionSanitized = SecretRedactionSanitizer.Create(new SecretRedactionOptions
+        {
+            RedactInputMessages = true,
+        })(GenerationWithUserInput(secretToken));
+        Assert.DoesNotContain(secretToken, optionSanitized.Input[0].Parts[0].Text);
+
+        var envSanitized = SecretRedactionSanitizer.Create(
+            null,
+            key => key == "SIGIL_REDACT_INPUT_MESSAGES" ? "true" : null,
+            null
+        )(GenerationWithUserInput(secretToken));
+        Assert.DoesNotContain(secretToken, envSanitized.Input[0].Parts[0].Text);
+
+        var explicitFalse = SecretRedactionSanitizer.Create(
+            new SecretRedactionOptions { RedactInputMessages = false },
+            key => key == "SIGIL_REDACT_INPUT_MESSAGES" ? "true" : null,
+            null
+        )(GenerationWithUserInput(secretToken));
+        Assert.Contains(secretToken, explicitFalse.Input[0].Parts[0].Text);
+    }
+
+    [Fact]
+    public void SecretRedactionSanitizer_EmailToggle()
+    {
+        const string text = "send mail to example@example.com";
+
+        var defaultSanitized = SecretRedactionSanitizer.Create()(new Generation
+        {
+            Output = { Message.AssistantTextMessage(text) },
+        });
+        Assert.Contains("[REDACTED:email]", defaultSanitized.Output[0].Parts[0].Text);
+        Assert.DoesNotContain("example@example.com", defaultSanitized.Output[0].Parts[0].Text);
+
+        var disabled = SecretRedactionSanitizer.Create(new SecretRedactionOptions
+        {
+            RedactEmailAddresses = false,
+        })(new Generation
+        {
+            Output = { Message.AssistantTextMessage(text) },
+        });
+        Assert.Equal(text, disabled.Output[0].Parts[0].Text);
+    }
+
+    [Fact]
+    public void SecretRedactionSanitizer_RedactsTier1Patterns()
+    {
+        var sanitizer = SecretRedactionSanitizer.Create();
+        var cases = new (string Id, string Value)[]
+        {
+            ("grafana-cloud-token", "glc_abcdefghijklmnopqrstuvwxyz1234"),
+            ("grafana-service-account-token", "glsa_abcdefghijklmnopqrstuvwxyz1234"),
+            ("aws-access-token", "AKIAIOSFODNN7EXAMPLE"),
+            ("github-pat", "ghp_" + new string('a', 36)),
+            ("github-oauth", "gho_" + new string('a', 36)),
+            ("github-app-token", "ghs_" + new string('a', 36)),
+            ("github-fine-grained-pat", "github_pat_" + new string('a', 82)),
+            ("anthropic-api-key", "sk-ant-api03-" + new string('a', 93) + "AA"),
+            ("anthropic-admin-key", "sk-ant-admin01-" + new string('a', 93) + "AA"),
+            ("openai-api-key", "sk-" + new string('a', 20) + "T3BlbkFJ" + new string('b', 20)),
+            ("openai-project-key", "sk-proj-" + new string('a', 40)),
+            ("openai-svcacct-key", "sk-svcacct-" + new string('a', 40)),
+            ("gcp-api-key", "AIza" + new string('a', 35)),
+            ("private-key", "-----BEGIN RSA PRIVATE KEY-----\nfake-test-body\n-----END RSA PRIVATE KEY-----"),
+            ("connection-string", "postgres://user:password@db.example.com:5432/app"),
+            ("bearer-token", "Bearer " + new string('a', 30)),
+            ("slack-token", "xoxb-" + new string('a', 20)),
+            ("stripe-key", "sk_live_" + new string('a', 24)),
+            ("sendgrid-api-key", "SG." + new string('a', 22) + "." + new string('b', 43)),
+            ("twilio-api-key", "SK" + new string('a', 32)),
+            ("npm-token", "npm_" + new string('a', 36)),
+            ("pypi-token", "pypi-" + new string('a', 50)),
+        };
+
+        foreach (var (id, value) in cases)
+        {
+            var generation = sanitizer(new Generation
+            {
+                Output =
+                {
+                    new Message
+                    {
+                        Role = MessageRole.Tool,
+                        Parts =
+                        {
+                            Part.ToolResultPart(new ToolResult { Content = "prefix " + value + " suffix" }),
+                        },
+                    },
+                },
+            });
+
+            var got = generation.Output[0].Parts[0].ToolResult!.Content;
+            Assert.Contains("[REDACTED:" + id + "]", got);
+            Assert.DoesNotContain(value, got);
+        }
+    }
+
+    [Fact]
+    public async Task GenerationRecorder_AppliesSanitizerBeforeExport()
+    {
+        var secret = "glc_abcdefghijklmnopqrstuvwxyz1234";
+        var exporter = new CapturingGenerationExporter();
+        var config = TestHelpers.TestConfig(exporter);
+        config.GenerationSanitizer = SecretRedactionSanitizer.Create();
+
+        await using var client = new SigilClient(config);
+        var recorder = client.StartGeneration(new GenerationStart
+        {
+            Id = "gen-redact",
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+            ConversationTitle = "title " + secret,
+            SystemPrompt = "SYSTEM_TOKEN=" + secret,
+        });
+        recorder.SetCallError(new InvalidOperationException("provider failed with " + secret));
+        recorder.SetResult(new Generation
+        {
+            Output = { Message.AssistantTextMessage("assistant saw " + secret) },
+            Usage = new TokenUsage { InputTokens = 1, OutputTokens = 1 },
+        });
+        recorder.End();
+
+        var generation = recorder.LastGeneration!;
+        Assert.DoesNotContain(secret, generation.ConversationTitle);
+        Assert.DoesNotContain(secret, generation.SystemPrompt);
+        Assert.DoesNotContain(secret, generation.CallError);
+        Assert.DoesNotContain(secret, generation.Output[0].Parts[0].Text);
+        Assert.Equal(generation.ConversationTitle, generation.Metadata[SigilClient.SpanAttrConversationTitle]?.ToString());
+        Assert.Equal(generation.CallError, generation.Metadata["call_error"]?.ToString());
+    }
+
+    [Fact]
+    public async Task GenerationRecorder_SanitizerExceptionDowngradesToMetadataOnly()
+    {
+        var logs = new List<string>();
+        var exporter = new CapturingGenerationExporter();
+        var config = TestHelpers.TestConfig(exporter);
+        config.ContentCapture = ContentCaptureMode.Full;
+        config.Logger = logs.Add;
+        config.GenerationSanitizer = _ => throw new InvalidOperationException("boom");
+
+        await using var client = new SigilClient(config);
+        var recorder = client.StartGeneration(new GenerationStart
+        {
+            Id = "gen-sanitizer-fail",
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+            ConversationTitle = "sensitive title",
+            SystemPrompt = "sensitive system prompt",
+        });
+        recorder.SetResult(new Generation
+        {
+            Input = { Message.UserTextMessage("sensitive input") },
+            Output = { Message.AssistantTextMessage("sensitive output") },
+            Usage = new TokenUsage { InputTokens = 1, OutputTokens = 1 },
+        });
+        recorder.End();
+
+        var generation = recorder.LastGeneration!;
+        Assert.Null(recorder.Error);
+        Assert.Equal("metadata_only", generation.Metadata[SigilClient.MetadataKeyContentCaptureMode]?.ToString());
+        Assert.Equal(string.Empty, generation.ConversationTitle);
+        Assert.Equal(string.Empty, generation.SystemPrompt);
+        Assert.Equal(string.Empty, generation.Input[0].Parts[0].Text);
+        Assert.Equal(string.Empty, generation.Output[0].Parts[0].Text);
+        Assert.Contains(logs, entry => entry.Contains("sigil: generation sanitization failed, falling back to metadata_only"));
+    }
+
+    [Fact]
+    public async Task GenerationRecorder_SkipsSanitizerInMetadataOnlyMode()
+    {
+        var calls = 0;
+        var exporter = new CapturingGenerationExporter();
+        var config = TestHelpers.TestConfig(exporter);
+        config.ContentCapture = ContentCaptureMode.MetadataOnly;
+        config.GenerationSanitizer = generation =>
+        {
+            calls++;
+            return generation;
+        };
+
+        await using var client = new SigilClient(config);
+        var recorder = client.StartGeneration(new GenerationStart
+        {
+            Id = "gen-metadata-only",
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+        });
+        recorder.SetResult(new Generation
+        {
+            Output = { Message.AssistantTextMessage("ok") },
+            Usage = new TokenUsage { InputTokens = 1, OutputTokens = 1 },
+        });
+        recorder.End();
+
+        Assert.Equal(0, calls);
+    }
+
+    private static Generation GenerationWithUserInput(string secret)
+    {
+        return new Generation
+        {
+            Input = { Message.UserTextMessage("user pasted " + secret) },
+        };
+    }
+}


### PR DESCRIPTION
## Notes

Parity with other SDKs on secret redaction.

Adds the .NET generation sanitizer hook and built-in gitleaks-derived secrets redactor so credentials are redacted before generation export. Includes regression coverage for pattern parity, input opt-in, metadata-only behavior, and sanitizer failure fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what leaves the SDK on the export and tracing path; misconfiguration or regex gaps could leak secrets or over-redact, though sanitizer failures fail closed to metadata_only.
> 
> **Overview**
> Adds a **`GenerationSanitizer`** hook on `SigilClientConfig` and wires it into **`GenerationRecorder.End()`** after normalization and before content-capture stripping and export, aligning .NET with other Sigil SDKs.
> 
> The built-in **`SecretRedactionSanitizer`** applies gitleaks-style regex rules across generation fields (system prompt, titles, call errors, assistant/thinking/tool content, etc.), replacing matches with `[REDACTED:<category>]`. User **input** text stays untouched unless **`RedactInputMessages`** is set or **`SIGIL_REDACT_INPUT_MESSAGES=true`** (explicit option wins). Optional email redaction is on by default.
> 
> **Failure handling:** sanitizer exceptions log and downgrade the generation to **`metadata_only`** instead of exporting raw content. The sanitizer is **skipped** when capture mode is already **`metadata_only`**. After redaction, **`SyncCanonicalMetadataMirrors`** keeps span/export metadata in sync with sanitized title and **`call_error`**, and OTel span errors use the sanitized call error text where appropriate.
> 
> Documentation and **`RedactionTests`** cover pattern parity, opt-in input redaction, recorder integration, and fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dea2beb160f43e081e1d4da0839be5df398e035. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->