### PR TITLE
feat(java): add secrets redaction sanitizer

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -198,6 +198,26 @@ Resolution precedence for tool executions (highest to lowest):
 
 User-provided `metadata` and `tags` are not stripped by any capture mode. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content.
 
+## Local Secret Redaction
+
+The Java SDK can redact high-confidence secret patterns before generation data is exported. The built-in redactor uses the same hand-curated gitleaks-derived patterns as the other Sigil SDKs and replaces matches with `[REDACTED:<category>]`.
+
+```java
+SigilClient client = new SigilClient(new SigilClientConfig()
+    .setGenerationSanitizer(SecretRedaction.createSecretRedactionSanitizer()));
+```
+
+By default, user-role input messages are left untouched. To also redact user input messages, opt in explicitly:
+
+```java
+SigilClient client = new SigilClient(new SigilClientConfig()
+    .setGenerationSanitizer(SecretRedaction.createSecretRedactionSanitizer(
+        new SecretRedactionOptions()
+            .setRedactInputMessages(true))));
+```
+
+`SecretRedaction.createSecretRedactionSanitizer()` reads `SIGIL_REDACT_INPUT_MESSAGES` (accepts `1/0`, `true/false`, `yes/no`, `on/off`) when `redactInputMessages` is left unset. Explicit options take precedence over the environment variable. Email address redaction is on by default and can be disabled with `setRedactEmailAddresses(false)`.
+
 ## Embedding Observability
 
 Use `startEmbedding(...)` / `withEmbedding(...)` for embedding API calls. Embedding recording emits OTel spans and SDK metrics only, and does not enqueue generation exports.

--- a/java/core/src/main/java/com/grafana/sigil/sdk/GenerationRecorder.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/GenerationRecorder.java
@@ -117,15 +117,31 @@ public class GenerationRecorder implements AutoCloseable {
         try {
             generation = normalize(snapshotResult, completedAt, snapshotCallError, snapshotExtra);
 
-            SigilClient.stampContentCaptureMetadata(generation, contentCaptureMode);
-            if (contentCaptureMode == ContentCaptureMode.METADATA_ONLY) {
-                String errorCategory = SigilClient.errorCategoryFromThrowable(snapshotCallError, false);
-                SigilClient.stripContent(generation, errorCategory);
-            }
-
             if (span.getSpanContext().isValid()) {
                 generation.setTraceId(span.getSpanContext().getTraceId());
                 generation.setSpanId(span.getSpanContext().getSpanId());
+            }
+
+            ContentCaptureMode effectiveContentCaptureMode = contentCaptureMode;
+            boolean sanitizerRan = false;
+            GenerationSanitizer sanitizer = client.getGenerationSanitizer();
+            if (sanitizer != null && effectiveContentCaptureMode != ContentCaptureMode.METADATA_ONLY) {
+                sanitizerRan = true;
+                try {
+                    Generation sanitized = sanitizer.sanitize(generation.copy());
+                    generation = sanitized == null ? new Generation() : sanitized;
+                } catch (Throwable throwable) {
+                    effectiveContentCaptureMode = ContentCaptureMode.METADATA_ONLY;
+                    client.logGenerationSanitizerFailure(throwable);
+                }
+            }
+
+            syncCanonicalMetadataMirrors(generation);
+
+            SigilClient.stampContentCaptureMetadata(generation, effectiveContentCaptureMode);
+            if (effectiveContentCaptureMode == ContentCaptureMode.METADATA_ONLY) {
+                String errorCategory = SigilClient.errorCategoryFromThrowable(snapshotCallError, false);
+                SigilClient.stripContent(generation, errorCategory);
             }
 
             span.updateName(SigilClient.generationSpanName(generation.getOperationName(), generation.getModel().getName()));
@@ -133,7 +149,7 @@ public class GenerationRecorder implements AutoCloseable {
             // span path must drop sigil.conversation.title. `generation` is
             // a local snapshot here, so save the title, zero it for the span
             // attribute call, and restore — no deep copy needed.
-            if (contentCaptureMode == ContentCaptureMode.FULL_WITH_METADATA_SPANS) {
+            if (effectiveContentCaptureMode == ContentCaptureMode.FULL_WITH_METADATA_SPANS) {
                 String savedTitle = generation.getConversationTitle();
                 generation.setConversationTitle("");
                 try {
@@ -143,6 +159,9 @@ public class GenerationRecorder implements AutoCloseable {
                 }
             } else {
                 SigilClient.setGenerationSpanAttributes(span, generation);
+            }
+            if (sanitizerRan && effectiveContentCaptureMode != ContentCaptureMode.FULL_WITH_METADATA_SPANS) {
+                span.setAttribute(SigilClient.SPAN_ATTR_CONVERSATION_TITLE, generation.getConversationTitle());
             }
 
             try {
@@ -163,8 +182,8 @@ public class GenerationRecorder implements AutoCloseable {
             // export under FULL_WITH_METADATA_SPANS still gets the raw
             // generation.callError; only the OTel span path is redacted.
             boolean redactSpanErrors =
-                    contentCaptureMode == ContentCaptureMode.METADATA_ONLY
-                            || contentCaptureMode == ContentCaptureMode.FULL_WITH_METADATA_SPANS;
+                    effectiveContentCaptureMode == ContentCaptureMode.METADATA_ONLY
+                            || effectiveContentCaptureMode == ContentCaptureMode.FULL_WITH_METADATA_SPANS;
             if (snapshotCallError != null && !redactSpanErrors) {
                 span.recordException(snapshotCallError);
             }
@@ -347,5 +366,18 @@ public class GenerationRecorder implements AutoCloseable {
 
     private static String normalizeResolvedString(String value) {
         return value == null ? "" : value.trim();
+    }
+
+    private static void syncCanonicalMetadataMirrors(Generation generation) {
+        if (generation.getConversationTitle().isEmpty()) {
+            generation.getMetadata().remove(SigilClient.SPAN_ATTR_CONVERSATION_TITLE);
+        } else {
+            generation.getMetadata().put(SigilClient.SPAN_ATTR_CONVERSATION_TITLE, generation.getConversationTitle());
+        }
+        if (generation.getCallError().isEmpty()) {
+            generation.getMetadata().remove("call_error");
+        } else {
+            generation.getMetadata().put("call_error", generation.getCallError());
+        }
     }
 }

--- a/java/core/src/main/java/com/grafana/sigil/sdk/GenerationRecorder.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/GenerationRecorder.java
@@ -129,7 +129,10 @@ public class GenerationRecorder implements AutoCloseable {
                 sanitizerRan = true;
                 try {
                     Generation sanitized = sanitizer.sanitize(generation.copy());
-                    generation = sanitized == null ? new Generation() : sanitized;
+                    if (sanitized == null) {
+                        throw new IllegalStateException("generation sanitizer must return a generation");
+                    }
+                    generation = sanitized;
                 } catch (Throwable throwable) {
                     effectiveContentCaptureMode = ContentCaptureMode.METADATA_ONLY;
                     client.logGenerationSanitizerFailure(throwable);
@@ -160,7 +163,7 @@ public class GenerationRecorder implements AutoCloseable {
             } else {
                 SigilClient.setGenerationSpanAttributes(span, generation);
             }
-            if (sanitizerRan && effectiveContentCaptureMode != ContentCaptureMode.FULL_WITH_METADATA_SPANS) {
+            if (sanitizerRan && contentCaptureMode != ContentCaptureMode.FULL_WITH_METADATA_SPANS) {
                 span.setAttribute(SigilClient.SPAN_ATTR_CONVERSATION_TITLE, generation.getConversationTitle());
             }
 

--- a/java/core/src/main/java/com/grafana/sigil/sdk/GenerationSanitizer.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/GenerationSanitizer.java
@@ -1,0 +1,13 @@
+package com.grafana.sigil.sdk;
+
+/** Mutates or replaces a normalized generation before export. */
+@FunctionalInterface
+public interface GenerationSanitizer {
+    /**
+     * Sanitizes a normalized generation payload.
+     *
+     * <p>Implementations may mutate string and byte payloads, but should
+     * preserve message and part structure.</p>
+     */
+    Generation sanitize(Generation generation);
+}

--- a/java/core/src/main/java/com/grafana/sigil/sdk/SecretRedaction.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/SecretRedaction.java
@@ -1,0 +1,237 @@
+package com.grafana.sigil.sdk;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Built-in local secret redaction for generation exports. */
+public final class SecretRedaction {
+    static final String ENV_REDACT_INPUT_MESSAGES = "SIGIL_REDACT_INPUT_MESSAGES";
+
+    private static final List<SecretPattern> TIER1_PATTERNS = List.of(
+            new SecretPattern("grafana-cloud-token", Pattern.compile("\\bglc_[A-Za-z0-9_-]{20,}")),
+            new SecretPattern("grafana-service-account-token", Pattern.compile("\\bglsa_[A-Za-z0-9_-]{20,}")),
+            new SecretPattern("aws-access-token", Pattern.compile("\\b(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z2-7]{16}\\b")),
+            new SecretPattern("github-pat", Pattern.compile("\\bghp_[A-Za-z0-9_]{36,}")),
+            new SecretPattern("github-oauth", Pattern.compile("\\bgho_[A-Za-z0-9_]{36,}")),
+            new SecretPattern("github-app-token", Pattern.compile("\\bghs_[A-Za-z0-9_]{36,}")),
+            new SecretPattern("github-fine-grained-pat", Pattern.compile("\\bgithub_pat_[A-Za-z0-9_]{82}")),
+            new SecretPattern("anthropic-api-key", Pattern.compile("\\bsk-ant-api03-[a-zA-Z0-9_-]{93}AA")),
+            new SecretPattern("anthropic-admin-key", Pattern.compile("\\bsk-ant-admin01-[a-zA-Z0-9_-]{93}AA")),
+            new SecretPattern("openai-api-key", Pattern.compile("\\bsk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20}")),
+            new SecretPattern("openai-project-key", Pattern.compile("\\bsk-proj-[a-zA-Z0-9_-]{40,}")),
+            new SecretPattern("openai-svcacct-key", Pattern.compile("\\bsk-svcacct-[a-zA-Z0-9_-]{40,}")),
+            new SecretPattern("gcp-api-key", Pattern.compile("\\bAIza[A-Za-z0-9_-]{35}")),
+            new SecretPattern("private-key", Pattern.compile("-----BEGIN[A-Z ]*PRIVATE KEY-----[\\s\\S]*?-----END[A-Z ]*PRIVATE KEY-----")),
+            new SecretPattern("connection-string", Pattern.compile("(?:postgres|mysql|mongodb|redis|amqp)://[^\\s'\"]+@[^\\s'\"]+")),
+            new SecretPattern("bearer-token", Pattern.compile("[Bb]earer\\s+[A-Za-z0-9_.\\-~+/]{20,}={0,3}")),
+            new SecretPattern("slack-token", Pattern.compile("\\bxox[bporas]-[A-Za-z0-9-]{10,}")),
+            new SecretPattern("stripe-key", Pattern.compile("\\b[sr]k_(?:live|test)_[A-Za-z0-9]{20,}")),
+            new SecretPattern("sendgrid-api-key", Pattern.compile("\\bSG\\.[A-Za-z0-9_-]{22}\\.[A-Za-z0-9_-]{43}")),
+            new SecretPattern("twilio-api-key", Pattern.compile("\\bSK[a-f0-9]{32}")),
+            new SecretPattern("npm-token", Pattern.compile("\\bnpm_[A-Za-z0-9]{36}")),
+            new SecretPattern("pypi-token", Pattern.compile("\\bpypi-[A-Za-z0-9_-]{50,}")));
+
+    private static final SecretPattern EMAIL_PATTERN = new SecretPattern(
+            "email",
+            Pattern.compile("\\b[A-Z0-9._%+\\-]+@[A-Z0-9.\\-]+\\.[A-Z]{2,}\\b", Pattern.CASE_INSENSITIVE));
+    private static final SecretPattern ENV_SECRET_PATTERN = new SecretPattern(
+            "env-secret-value",
+            Pattern.compile("((?:PASSWORD|SECRET|TOKEN|KEY|CREDENTIAL|API_KEY|PRIVATE_KEY|ACCESS_KEY)\\s*[=:]\\s*)([^\\s\"{}\\[\\],]+)", Pattern.CASE_INSENSITIVE));
+
+    private SecretRedaction() {
+    }
+
+    /** Returns a sanitizer that redacts known secret formats before generation export. */
+    public static GenerationSanitizer createSecretRedactionSanitizer() {
+        return createSecretRedactionSanitizer(new SecretRedactionOptions());
+    }
+
+    /** Returns a sanitizer that redacts known secret formats before generation export. */
+    public static GenerationSanitizer createSecretRedactionSanitizer(SecretRedactionOptions options) {
+        return createSecretRedactionSanitizer(options, System::getenv, Logger.getLogger("com.grafana.sigil.sdk"));
+    }
+
+    static GenerationSanitizer createSecretRedactionSanitizer(
+            SecretRedactionOptions options, Function<String, String> lookup, Logger logger) {
+        SecretRedactionOptions opts = options == null ? new SecretRedactionOptions() : options;
+        boolean includeEmail = opts.getRedactEmailAddresses() == null || opts.getRedactEmailAddresses();
+        boolean redactInputMessages = resolveRedactInputMessages(opts.getRedactInputMessages(), lookup, logger);
+        SecretRedactor redactor = new SecretRedactor(includeEmail);
+
+        return generation -> {
+            Generation sanitized = generation == null ? new Generation() : generation.copy();
+            if (!sanitized.getSystemPrompt().isEmpty()) {
+                sanitized.setSystemPrompt(redactor.redactFull(sanitized.getSystemPrompt()));
+            }
+            if (!sanitized.getConversationTitle().isEmpty()) {
+                sanitized.setConversationTitle(redactor.redactLight(sanitized.getConversationTitle()));
+            }
+            if (!sanitized.getCallError().isEmpty()) {
+                sanitized.setCallError(redactor.redactLight(sanitized.getCallError()));
+            }
+
+            for (Message message : sanitized.getInput()) {
+                sanitizeMessage(message, inputTextMode(message.getRole(), redactInputMessages), redactor);
+            }
+            for (Message message : sanitized.getOutput()) {
+                sanitizeMessage(message, outputTextMode(message.getRole()), redactor);
+            }
+            return sanitized;
+        };
+    }
+
+    static boolean resolveRedactInputMessages(Boolean explicit, Function<String, String> lookup, Logger logger) {
+        if (explicit != null) {
+            return explicit;
+        }
+        Function<String, String> source = lookup == null ? System::getenv : lookup;
+        String raw;
+        try {
+            raw = source.apply(ENV_REDACT_INPUT_MESSAGES);
+        } catch (SecurityException ex) {
+            return false;
+        }
+        if (raw == null || raw.trim().isEmpty()) {
+            return false;
+        }
+        Boolean parsed = parseStrictBool(raw);
+        if (parsed != null) {
+            return parsed;
+        }
+        if (logger != null) {
+            logger.log(Level.WARNING, "sigil: ignoring invalid " + ENV_REDACT_INPUT_MESSAGES + " " + raw.trim());
+        }
+        return false;
+    }
+
+    private static Boolean parseStrictBool(String raw) {
+        String token = raw.trim().toLowerCase(Locale.ROOT);
+        return switch (token) {
+            case "1", "true", "yes", "on" -> true;
+            case "0", "false", "no", "off" -> false;
+            default -> null;
+        };
+    }
+
+    private static TextMode inputTextMode(MessageRole role, boolean redactInputMessages) {
+        return switch (role) {
+            case USER -> redactInputMessages ? TextMode.FULL : TextMode.SKIP;
+            case TOOL -> TextMode.FULL;
+            case ASSISTANT -> TextMode.LIGHT;
+            default -> TextMode.SKIP;
+        };
+    }
+
+    private static TextMode outputTextMode(MessageRole role) {
+        return switch (role) {
+            case ASSISTANT -> TextMode.LIGHT;
+            case TOOL -> TextMode.FULL;
+            default -> TextMode.SKIP;
+        };
+    }
+
+    private static void sanitizeMessage(Message message, TextMode mode, SecretRedactor redactor) {
+        if (message == null || mode == TextMode.SKIP) {
+            return;
+        }
+        for (MessagePart part : message.getParts()) {
+            sanitizePart(part, mode, redactor);
+        }
+    }
+
+    private static void sanitizePart(MessagePart part, TextMode mode, SecretRedactor redactor) {
+        if (part == null) {
+            return;
+        }
+        switch (part.getKind()) {
+            case TEXT -> part.setText(redactString(part.getText(), mode, redactor));
+            case THINKING -> part.setThinking(redactor.redactLight(part.getThinking()));
+            case TOOL_CALL -> {
+                ToolCall toolCall = part.getToolCall();
+                if (toolCall != null && toolCall.getInputJson().length > 0) {
+                    toolCall.setInputJson(redactor.redactFullBytes(toolCall.getInputJson()));
+                }
+            }
+            case TOOL_RESULT -> {
+                ToolResultPart toolResult = part.getToolResult();
+                if (toolResult != null) {
+                    if (!toolResult.getContent().isEmpty()) {
+                        toolResult.setContent(redactor.redactFull(toolResult.getContent()));
+                    }
+                    if (toolResult.getContentJson().length > 0) {
+                        toolResult.setContentJson(redactor.redactFullBytes(toolResult.getContentJson()));
+                    }
+                }
+            }
+        }
+    }
+
+    private static String redactString(String value, TextMode mode, SecretRedactor redactor) {
+        return switch (mode) {
+            case FULL -> redactor.redactFull(value);
+            case LIGHT -> redactor.redactLight(value);
+            case SKIP -> value;
+        };
+    }
+
+    private record SecretPattern(String id, Pattern regex) {
+    }
+
+    private enum TextMode {
+        SKIP,
+        LIGHT,
+        FULL
+    }
+
+    private static final class SecretRedactor {
+        private final boolean includeEmail;
+
+        private SecretRedactor(boolean includeEmail) {
+            this.includeEmail = includeEmail;
+        }
+
+        String redactFull(String value) {
+            String result = redactTier1(value);
+            if (includeEmail) {
+                result = applyPattern(result, EMAIL_PATTERN);
+            }
+            return applyEnvSecretPattern(result);
+        }
+
+        String redactLight(String value) {
+            String result = redactTier1(value);
+            if (includeEmail) {
+                result = applyPattern(result, EMAIL_PATTERN);
+            }
+            return result;
+        }
+
+        byte[] redactFullBytes(byte[] value) {
+            return redactFull(new String(value, StandardCharsets.UTF_8)).getBytes(StandardCharsets.UTF_8);
+        }
+
+        private String redactTier1(String value) {
+            String result = value == null ? "" : value;
+            for (SecretPattern pattern : TIER1_PATTERNS) {
+                result = applyPattern(result, pattern);
+            }
+            return result;
+        }
+
+        private static String applyPattern(String value, SecretPattern pattern) {
+            return pattern.regex().matcher(value).replaceAll(Matcher.quoteReplacement("[REDACTED:" + pattern.id() + "]"));
+        }
+
+        private static String applyEnvSecretPattern(String value) {
+            return ENV_SECRET_PATTERN.regex()
+                    .matcher(value)
+                    .replaceAll("$1" + Matcher.quoteReplacement("[REDACTED:" + ENV_SECRET_PATTERN.id() + "]"));
+        }
+    }
+}

--- a/java/core/src/main/java/com/grafana/sigil/sdk/SecretRedactionOptions.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/SecretRedactionOptions.java
@@ -1,0 +1,37 @@
+package com.grafana.sigil.sdk;
+
+/** Options for {@link SecretRedaction#createSecretRedactionSanitizer(SecretRedactionOptions)}. */
+public final class SecretRedactionOptions {
+    private Boolean redactInputMessages;
+    private Boolean redactEmailAddresses;
+
+    /**
+     * Whether user-role input messages should be redacted.
+     *
+     * <p>{@code null} falls back to {@code SIGIL_REDACT_INPUT_MESSAGES} and
+     * then to {@code false}. Assistant and tool messages are redacted
+     * regardless because they share the same secret surface as outputs.</p>
+     */
+    public Boolean getRedactInputMessages() {
+        return redactInputMessages;
+    }
+
+    public SecretRedactionOptions setRedactInputMessages(Boolean redactInputMessages) {
+        this.redactInputMessages = redactInputMessages;
+        return this;
+    }
+
+    /**
+     * Whether generic email addresses should be redacted.
+     *
+     * <p>{@code null} defaults to {@code true}.</p>
+     */
+    public Boolean getRedactEmailAddresses() {
+        return redactEmailAddresses;
+    }
+
+    public SecretRedactionOptions setRedactEmailAddresses(Boolean redactEmailAddresses) {
+        this.redactEmailAddresses = redactEmailAddresses;
+        return this;
+    }
+}

--- a/java/core/src/main/java/com/grafana/sigil/sdk/SigilClient.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/SigilClient.java
@@ -613,6 +613,14 @@ public final class SigilClient implements AutoCloseable {
         return embeddingCaptureConfig;
     }
 
+    GenerationSanitizer getGenerationSanitizer() {
+        return config.getGenerationSanitizer();
+    }
+
+    void logGenerationSanitizerFailure(Throwable throwable) {
+        logWarn("sigil: generation sanitization failed, falling back to metadata_only", throwable);
+    }
+
     void enqueueGeneration(Generation generation) {
         if (shuttingDown || closed) {
             throw new ClientShutdownException("sigil: client is shutting down");

--- a/java/core/src/main/java/com/grafana/sigil/sdk/SigilClientConfig.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/SigilClientConfig.java
@@ -15,6 +15,7 @@ public final class SigilClientConfig {
     private EmbeddingCaptureConfig embeddingCapture = new EmbeddingCaptureConfig();
     private ContentCaptureMode contentCapture = ContentCaptureMode.DEFAULT;
     private ContentCaptureResolver contentCaptureResolver;
+    private GenerationSanitizer generationSanitizer;
     private GenerationExporter generationExporter;
     private Tracer tracer;
     private Meter meter;
@@ -90,6 +91,24 @@ public final class SigilClientConfig {
      */
     public SigilClientConfig setContentCaptureResolver(ContentCaptureResolver contentCaptureResolver) {
         this.contentCaptureResolver = contentCaptureResolver;
+        return this;
+    }
+
+    public GenerationSanitizer getGenerationSanitizer() {
+        return generationSanitizer;
+    }
+
+    /**
+     * Sets a sanitizer invoked on each normalized generation before export.
+     *
+     * <p>The sanitizer runs after generation normalization, but before
+     * content-capture stripping and metadata stamping. It is skipped when the
+     * resolved content-capture mode is {@link ContentCaptureMode#METADATA_ONLY}.
+     * If it throws, the SDK logs a warning and falls back to
+     * {@link ContentCaptureMode#METADATA_ONLY} for that generation.</p>
+     */
+    public SigilClientConfig setGenerationSanitizer(GenerationSanitizer generationSanitizer) {
+        this.generationSanitizer = generationSanitizer;
         return this;
     }
 
@@ -216,6 +235,7 @@ public final class SigilClientConfig {
                 .setEmbeddingCapture(embeddingCapture.copy())
                 .setContentCapture(contentCapture)
                 .setContentCaptureResolver(contentCaptureResolver)
+                .setGenerationSanitizer(generationSanitizer)
                 .setGenerationExporter(generationExporter)
                 .setTracer(tracer)
                 .setMeter(meter)

--- a/java/core/src/test/java/com/grafana/sigil/sdk/SecretRedactionTest.java
+++ b/java/core/src/test/java/com/grafana/sigil/sdk/SecretRedactionTest.java
@@ -1,0 +1,161 @@
+package com.grafana.sigil.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.Test;
+
+class SecretRedactionTest {
+    @Test
+    void secretRedactionSanitizerRedactsExportedGeneration() throws Exception {
+        TestFixtures.CapturingExporter exporter = new TestFixtures.CapturingExporter();
+        SigilClientConfig config = new SigilClientConfig()
+                .setTracer(GlobalOpenTelemetry.getTracer("test"))
+                .setGenerationExporter(exporter)
+                .setGenerationSanitizer(SecretRedaction.createSecretRedactionSanitizer())
+                .setGenerationExport(new GenerationExportConfig()
+                        .setBatchSize(1)
+                        .setQueueSize(100)
+                        .setFlushInterval(Duration.ofMinutes(10))
+                        .setMaxRetries(0));
+
+        try (SigilClient client = new SigilClient(config)) {
+            GenerationStart start = TestFixtures.startFixture()
+                    .setSystemPrompt("Use TOKEN=system-secret")
+                    .setConversationTitle("Ask support@example.com");
+
+            GenerationResult result = TestFixtures.resultFixture()
+                    .setSystemPrompt("Use TOKEN=system-secret")
+                    .setInput(List.of(new Message()
+                            .setRole(MessageRole.USER)
+                            .setParts(List.of(MessagePart.text("raw input AKIAIOSFODNN7EXAMPLE")))))
+                    .setOutput(List.of(
+                            new Message()
+                                    .setRole(MessageRole.ASSISTANT)
+                                    .setParts(List.of(
+                                            MessagePart.text("email support@example.com "
+                                                    + "key sk-proj-" + "a".repeat(40)),
+                                            MessagePart.thinking("seen " + githubPat()),
+                                            MessagePart.toolCall(new ToolCall()
+                                                    .setId("tool-call-1")
+                                                    .setName("search")
+                                                    .setInputJson(("{\"auth\":\"Bearer " + "a".repeat(24) + "\"}")
+                                                            .getBytes(StandardCharsets.UTF_8))))),
+                            new Message()
+                                    .setRole(MessageRole.TOOL)
+                                    .setParts(List.of(MessagePart.toolResult(new ToolResultPart()
+                                            .setToolCallId("tool-call-1")
+                                            .setName("search")
+                                            .setContent("PASSWORD=tool-secret")
+                                            .setContentJson("{\"token\":\"ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}"
+                                                    .getBytes(StandardCharsets.UTF_8)))))));
+
+            GenerationRecorder recorder = client.startGeneration(start);
+            recorder.setResult(result);
+            recorder.end();
+        }
+
+        TestFixtures.waitFor(() -> !exporter.getRequests().isEmpty(), Duration.ofSeconds(2));
+        Generation generation = exporter.getRequests().get(0).get(0);
+
+        assertThat(generation.getSystemPrompt()).contains("TOKEN=[REDACTED:env-secret-value]");
+        assertThat(generation.getConversationTitle()).isEqualTo("Ask [REDACTED:email]");
+        assertThat(generation.getMetadata()).containsEntry(SigilClient.SPAN_ATTR_CONVERSATION_TITLE, "Ask [REDACTED:email]");
+        assertThat(generation.getInput().get(0).getParts().get(0).getText()).contains("AKIAIOSFODNN7EXAMPLE");
+        assertThat(generation.getOutput().get(0).getParts().get(0).getText())
+                .contains("[REDACTED:email]")
+                .contains("[REDACTED:openai-project-key]");
+        assertThat(generation.getOutput().get(0).getParts().get(1).getThinking())
+                .contains("[REDACTED:github-pat]");
+        assertThat(new String(
+                generation.getOutput().get(0).getParts().get(2).getToolCall().getInputJson(),
+                StandardCharsets.UTF_8)).contains("[REDACTED:bearer-token]");
+        assertThat(generation.getOutput().get(1).getParts().get(0).getToolResult().getContent())
+                .contains("PASSWORD=[REDACTED:env-secret-value]");
+        assertThat(new String(
+                generation.getOutput().get(1).getParts().get(0).getToolResult().getContentJson(),
+                StandardCharsets.UTF_8)).contains("[REDACTED:github-pat]");
+    }
+
+    @Test
+    void secretRedactionSanitizerCanRedactUserInputMessages() {
+        GenerationSanitizer sanitizer = SecretRedaction.createSecretRedactionSanitizer(
+                new SecretRedactionOptions().setRedactInputMessages(true));
+
+        Generation generation = new Generation();
+        generation.setInput(List.of(new Message()
+                .setRole(MessageRole.USER)
+                .setParts(List.of(MessagePart.text("aws AKIAIOSFODNN7EXAMPLE")))));
+
+        Generation sanitized = sanitizer.sanitize(generation);
+
+        assertThat(sanitized.getInput().get(0).getParts().get(0).getText())
+                .contains("[REDACTED:aws-access-token]");
+        assertThat(generation.getInput().get(0).getParts().get(0).getText())
+                .contains("AKIAIOSFODNN7EXAMPLE");
+    }
+
+    @Test
+    void secretRedactionSanitizerSupportsGitleaksPatternSet() {
+        GenerationSanitizer sanitizer = SecretRedaction.createSecretRedactionSanitizer(
+                new SecretRedactionOptions().setRedactInputMessages(true));
+
+        for (Map.Entry<String, String> fixture : fixtures().entrySet()) {
+            Generation generation = new Generation();
+            generation.setOutput(List.of(new Message()
+                    .setRole(MessageRole.ASSISTANT)
+                    .setParts(List.of(MessagePart.text(fixture.getValue())))));
+            Generation sanitized = sanitizer.sanitize(generation);
+
+            assertThat(sanitized.getOutput().get(0).getParts().get(0).getText())
+                    .as(fixture.getKey())
+                    .contains("[REDACTED:" + fixture.getKey() + "]");
+        }
+    }
+
+    @Test
+    void redactInputMessagesResolvesExplicitThenEnvThenFalse() {
+        Logger logger = Logger.getLogger("com.grafana.sigil.sdk.test");
+
+        assertThat(SecretRedaction.resolveRedactInputMessages(true, key -> "false", logger)).isTrue();
+        assertThat(SecretRedaction.resolveRedactInputMessages(null, key -> "yes", logger)).isTrue();
+        assertThat(SecretRedaction.resolveRedactInputMessages(null, key -> "0", logger)).isFalse();
+        assertThat(SecretRedaction.resolveRedactInputMessages(null, key -> "maybe", logger)).isFalse();
+        assertThat(SecretRedaction.resolveRedactInputMessages(null, key -> null, logger)).isFalse();
+    }
+
+    private static Map<String, String> fixtures() {
+        return Map.ofEntries(
+                Map.entry("grafana-cloud-token", "glc_" + "a".repeat(20)),
+                Map.entry("grafana-service-account-token", "glsa_" + "b".repeat(20)),
+                Map.entry("aws-access-token", "AKIAIOSFODNN7EXAMPLE"),
+                Map.entry("github-pat", githubPat()),
+                Map.entry("github-oauth", "gho_" + "c".repeat(36)),
+                Map.entry("github-app-token", "ghs_" + "d".repeat(36)),
+                Map.entry("github-fine-grained-pat", "github_pat_" + "e".repeat(82)),
+                Map.entry("anthropic-api-key", "sk-ant-api03-" + "f".repeat(93) + "AA"),
+                Map.entry("anthropic-admin-key", "sk-ant-admin01-" + "g".repeat(93) + "AA"),
+                Map.entry("openai-api-key", "sk-" + "h".repeat(20) + "T3BlbkFJ" + "i".repeat(20)),
+                Map.entry("openai-project-key", "sk-proj-" + "j".repeat(40)),
+                Map.entry("openai-svcacct-key", "sk-svcacct-" + "k".repeat(40)),
+                Map.entry("gcp-api-key", "AIza" + "l".repeat(35)),
+                Map.entry("private-key", "-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----"),
+                Map.entry("connection-string", "postgres://user:pass@example.com/db"),
+                Map.entry("bearer-token", "Bearer " + "m".repeat(24)),
+                Map.entry("slack-token", "xoxb-" + "n".repeat(10)),
+                Map.entry("stripe-key", "sk_live_" + "o".repeat(20)),
+                Map.entry("sendgrid-api-key", "SG." + "p".repeat(22) + "." + "q".repeat(43)),
+                Map.entry("twilio-api-key", "SK" + "a".repeat(32)),
+                Map.entry("npm-token", "npm_" + "r".repeat(36)),
+                Map.entry("pypi-token", "pypi-" + "s".repeat(50)));
+    }
+
+    private static String githubPat() {
+        return "ghp_" + "a".repeat(36);
+    }
+}


### PR DESCRIPTION
## Notes

Targeting feature parity with other SDKs using the same secret redaction logic from gitleaks.

Adds the Java generation sanitizer hook and built-in gitleaks-derived secrets redactor so credentials are redacted before generation export. Includes regression coverage for pattern parity, input opt-in, metadata-only behavior, and sanitizer failure fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what leaves the app in exported generations and spans; sanitizer bugs.*config or regex edge cases could over-redact or miss secrets, though failures fall back to metadata-only export.
> 
> **Overview**
> Adds a **`GenerationSanitizer`** hook on **`SigilClientConfig`** and runs it in **`GenerationRecorder.end()`** after normalization and before content-capture stripping. Sanitizers are skipped when capture is already **`METADATA_ONLY`**; on failure the SDK logs a warning and **fail-closes** to **`METADATA_ONLY`** for that generation. After sanitization, **`syncCanonicalMetadataMirrors`** keeps **`call_error`** and **`sigil.conversation.title`** metadata aligned with redacted fields, and span attributes can pick up a sanitized conversation title when appropriate.
> 
> Ships **`SecretRedaction.createSecretRedactionSanitizer()`** with gitleaks-aligned patterns (API keys, tokens, private keys, connection strings, etc.), replacing matches with **`[REDACTED:<category>]`**. By default user input is not redacted; **`SecretRedactionOptions`** and **`SIGIL_REDACT_INPUT_MESSAGES`** opt in. Email redaction defaults on. README documents setup; **`SecretRedactionTest`** covers export integration, input opt-in, pattern parity, and env resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9341c85043c0dee2402d3b6602cf8c6606ff407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->