### PR TITLE
feat(plugins/sigil): add sigil cursor install command

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -147,6 +147,7 @@ golang.org/x/mod v0.32.0/go.mod h1:SgipZ/3h2Ci89DlEtEXWUk/HteuRin+HHhN+WbNhguU=
 golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
 golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
+golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 golang.org/x/net v0.48.0/go.mod h1:+ndRgGjkh8FGtu1w1FGbEC31if4VrNVMuKTgcAAnQRY=
 golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
 golang.org/x/oauth2 v0.34.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
@@ -168,6 +169,7 @@ golang.org/x/tools v0.41.0/go.mod h1:XSY6eDqxVNiYgezAVqqCeihT4j1U2CCsqvH3WhQpnlg
 golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=
 golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=
 golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=
+golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
 gonum.org/v1/plot v0.15.2/go.mod h1:DX+x+DWso3LTha+AdkJEv5Txvi+Tql3KAGkehP0/Ubg=
 gonum.org/v1/tools v0.0.0-20200318103217-c168b003ce8c/go.mod h1:fy6Otjqbk477ELp8IXTpw1cObQtLbRCBVonY+bTTfcM=
 google.golang.org/api v0.264.0 h1:+Fo3DQXBK8gLdf8rFZ3uLu39JpOnhvzJrLMQSoSYZJM=

--- a/llms.txt
+++ b/llms.txt
@@ -64,7 +64,7 @@ The script installs to `~/.local/bin`; `go install` puts the binary in `go env G
 
 Then launch your agent with `sigil <agent>`, where `<agent>` is `claude`, `codex`, `copilot`, `opencode`, or `pi`. On first run it installs the plugin, prompts for credentials, writes `~/.config/sigil/config.env`, and launches the agent.
 
-Cursor has no launcher; see [`plugins/cursor/`](https://github.com/grafana/sigil-sdk/tree/main/plugins/cursor) for setup.
+Cursor has no launcher (it is a GUI app). After installing the binary, wire its hooks once with `sigil cursor install` (it merges into `~/.cursor/hooks.json` and prompts for credentials on first run); `sigil cursor uninstall` removes them. See [`plugins/cursor/`](https://github.com/grafana/sigil-sdk/tree/main/plugins/cursor) for details.
 
 To skip the prompt, write the config file by hand:
 

--- a/plugins/cursor/.cursor-plugin/plugin.json
+++ b/plugins/cursor/.cursor-plugin/plugin.json
@@ -1,9 +1,17 @@
 {
   "name": "grafana-ai-observability",
-  "version": "0.2.0",
-  "description": "Send Cursor agent telemetry to Grafana Sigil",
-  "author": { "name": "Grafana Labs" },
+  "displayName": "Grafana AI Observability",
+  "version": "0.3.0",
+  "description": "Send Cursor agent prompts, replies, tool calls, and token usage to Grafana AI Observability.",
+  "author": {
+    "name": "Grafana Labs",
+    "email": "machine-learning@grafana.com"
+  },
+  "homepage": "https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/",
+  "repository": "https://github.com/grafana/sigil-sdk",
   "license": "Apache-2.0",
-  "keywords": ["telemetry", "observability", "sigil", "grafana", "cursor"],
-  "hooks": "hooks/hooks.json"
+  "keywords": ["telemetry", "observability", "sigil", "grafana", "cursor", "ai", "llm"],
+  "category": "developer-tools",
+  "tags": ["ai-observability", "telemetry", "monitoring", "llm"],
+  "hooks": "./hooks/hooks.json"
 }

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -24,19 +24,36 @@ go install github.com/grafana/sigil-sdk/plugins/sigil/cmd/sigil@latest
 
 The script installs `sigil` to `~/.local/bin`; `go install` uses `go env GOPATH`/bin (or `GOBIN`). Make sure that directory is on your `PATH`. See the [`sigil` binary README](../sigil/README.md#install) for all install options.
 
-Cursor does not have a `sigil cursor` launcher. Install the binary, register the Cursor plugin, then use `sigil login` or `~/.config/sigil/config.env` for credentials.
+Cursor is a GUI app with no `sigil cursor` launcher, so after installing the binary you wire the hooks once with `sigil cursor install` (next step), then add credentials.
 
-## 2. Register the plugin
+## 2. Wire the hooks
 
-In Cursor:
+Run this once from a terminal:
+
+```sh
+sigil cursor install
+```
+
+It registers `sigil cursor hook` for the Cursor events Sigil captures in `~/.cursor/hooks.json`, merging with any hooks other tools already added. Re-running is safe: it updates Sigil's entry in place instead of adding a duplicate. On first run it also prompts for credentials (the same prompt as `sigil login`).
+
+To undo the wiring later, run `sigil cursor uninstall` — it removes only Sigil's entries and leaves other tools' hooks alone.
+
+<details>
+<summary>Alternative: register the plugin inside Cursor</summary>
+
+Instead of `sigil cursor install`, you can register the plugin from Cursor's command palette:
 
 ```
 /add-plugin grafana/sigil-sdk
 ```
 
+Do not use both. `/add-plugin` and `sigil cursor install` write to the same `~/.cursor/hooks.json`, so running both captures every turn twice. Pick one.
+
+</details>
+
 ## 3. Add your credentials
 
-Run `sigil login` from a terminal. The prompt asks for values from `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure AI Observability is enabled on your stack — an administrator opens **Observability → AI Observability** once and accepts the terms.
+`sigil cursor install` already prompts for these on first run; run `sigil login` from a terminal to enter or change them later. The prompt asks for values from `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure AI Observability is enabled on your stack — an administrator opens **Observability → AI Observability** once and accepts the terms.
 
 You need values from three Grafana Cloud pages:
 

--- a/plugins/sigil/README.md
+++ b/plugins/sigil/README.md
@@ -38,7 +38,7 @@ Verify the install with `sigil --version`.
 
 ## Configure
 
-All hosts read the same config file at `~/.config/sigil/config.env`. The first run of `sigil claude`, `sigil opencode`, or `sigil pi` prompts for your endpoint, tenant ID, token, and OTLP endpoint and writes them there; run `sigil login` to re-enter them later.
+All hosts read the same config file at `~/.config/sigil/config.env`. The first run of `sigil claude`, `sigil opencode`, or `sigil pi` prompts for your endpoint, tenant ID, token, and OTLP endpoint and writes them there; run `sigil login` to re-enter them later. Cursor has no launcher, so wire it once with `sigil cursor install` (which also prompts on first run) and remove it with `sigil cursor uninstall`.
 
 To preconfigure without the prompt, create the file:
 

--- a/plugins/sigil/cmd/sigil/main.go
+++ b/plugins/sigil/cmd/sigil/main.go
@@ -8,6 +8,7 @@
 //	sigil opencode [--local] [--tag k=v] [-- args...] — exec opencode after bootstrapping the @grafana/sigil-opencode plugin
 //	sigil pi       [--local] [--tag k=v] [-- args...] — exec pi after bootstrapping the @grafana/sigil-pi extension
 //	sigil vibe     [--local] [--tag k=v] [-- args...] — exec vibe after installing the sigil hook in vibe's hooks.toml
+//	sigil cursor   install|uninstall                  — wire (or remove) the Cursor hook in ~/.cursor/hooks.json
 //	sigil local start|status|stop                     — manage the local capture daemon
 //	sigil --version                                   — print the build version
 //
@@ -40,6 +41,7 @@ import (
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/codex"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/copilot"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/cursor"
+	cursorinstall "github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/cursor/install"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/opencode"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/pi"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/vibe"
@@ -76,7 +78,7 @@ func renderLocalBanner(uiURL string) string {
 	return localBannerBox.Render(strings.Join(lines, "\n"))
 }
 
-const usageLine = "usage: sigil login | sigil local start|status|stop | sigil <agent> hook | sigil <claude|codex|copilot|opencode|pi|vibe> [--local] [--tag key=value]... [-- args...]"
+const usageLine = "usage: sigil login | sigil local start|status|stop | sigil cursor install|uninstall | sigil <agent> hook | sigil <claude|codex|copilot|opencode|pi|vibe> [--local] [--tag key=value]... [-- args...]"
 
 // version is overridden via -ldflags at build time.
 var version = "dev"
@@ -122,6 +124,13 @@ var exit = os.Exit
 // loginRun is a package var so tests can stub the interactive login flow
 // without driving the huh TTY. Production code points at login.Run.
 var loginRun = login.Run
+
+// cursorInstall and cursorUninstall are package vars so tests can stub the
+// filesystem-touching `sigil cursor install`/`uninstall` flow.
+var (
+	cursorInstall   = cursorinstall.Run
+	cursorUninstall = cursorinstall.Uninstall
+)
 
 func main() {
 	run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr)
@@ -236,6 +245,16 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 		exit(2)
 		return
 	}
+
+	// Cursor has no launcher (it is a GUI app), so `sigil cursor install`
+	// wires its hooks directly. This branch sits before the generic
+	// non-`hook` verb rejection below so `install`/`uninstall` reach the
+	// installer while `sigil cursor hook` still falls through to dispatch.
+	if agent == "cursor" && (verb == "install" || verb == "uninstall") {
+		runCursorInstall(verb, stdout, stderr)
+		return
+	}
+
 	if verb != "hook" {
 		_, _ = fmt.Fprintf(stderr, "sigil: unknown verb %q (only \"hook\" supported)\n", verb)
 		exit(2)
@@ -311,6 +330,55 @@ func runLoginCommand(args []string, stderr io.Writer) {
 		_, _ = fmt.Fprintf(stderr, "sigil: login failed: %v\n", err)
 		exit(1)
 		return
+	}
+}
+
+// runCursorInstall handles `sigil cursor install` and `sigil cursor
+// uninstall`. install wires Sigil's hook into ~/.cursor/hooks.json and, when
+// no credentials are configured yet, chains the interactive login prompt the
+// same way the launchers do; uninstall removes the hook entries.
+func runCursorInstall(verb string, stdout, stderr io.Writer) {
+	// dotenv must run before InitLogger so SIGIL_DEBUG=true set only in
+	// $XDG_CONFIG_HOME/sigil/config.env still enables file logging, and
+	// before HasCredentials so dotenv-supplied credentials are visible.
+	dotenv.ApplyEnv("sigil", nil)
+	logger := cli.InitLogger("sigil", "cursor", "SIGIL_DEBUG")
+
+	if verb == "uninstall" {
+		if err := cursorUninstall(stdout, stderr, logger); err != nil {
+			logger.Printf("cursor uninstall: %v", err)
+			_, _ = fmt.Fprintf(stderr, "sigil: %v\n", err)
+			exit(1)
+		}
+		return
+	}
+
+	if err := cursorInstall(stdout, stderr, logger); err != nil {
+		logger.Printf("cursor install: %v", err)
+		_, _ = fmt.Fprintf(stderr, "sigil: %v\n", err)
+		exit(1)
+		return
+	}
+
+	// Wiring the hook does nothing without credentials, so chain the login
+	// prompt on first install, mirroring the launcher auto-prompt. login.Run
+	// returns ErrNotInteractive when stdin is not a TTY (CI, piped input), in
+	// which case we skip silently and leave `sigil login` for later. A failed
+	// or aborted login never fails the install: the hook is already wired.
+	if !dotenv.HasCredentials() {
+		err := loginRun(context.Background(), login.RunOpts{
+			Stderr: stderr,
+			Logger: logger,
+		})
+		switch {
+		case err == nil, errors.Is(err, login.ErrNotInteractive):
+			// either succeeded or no TTY; nothing to report.
+		case errors.Is(err, login.ErrAborted):
+			_, _ = fmt.Fprintln(stderr, "sigil: setup aborted; run `sigil login` when ready")
+		default:
+			logger.Printf("auto-login: %v", err)
+			_, _ = fmt.Fprintf(stderr, "sigil: setup failed (%v); run `sigil login` when ready\n", err)
+		}
 	}
 }
 

--- a/plugins/sigil/cmd/sigil/main_test.go
+++ b/plugins/sigil/cmd/sigil/main_test.go
@@ -377,6 +377,136 @@ func TestRun_CodexLauncherErrorExits1(t *testing.T) {
 	}
 }
 
+// `sigil cursor install`/`uninstall` must dispatch to the installer before
+// the generic non-`hook` verb rejection, while `sigil cursor hook` still
+// reaches the hook handler and an unknown cursor verb still exits 2. Each
+// row stubs all three seams with counters so the want* fields pin both the
+// branch that fired and the ones that must stay untouched.
+func TestRun_CursorInstallDispatch(t *testing.T) {
+	exitPtr := func(c int) *int { return &c }
+
+	cases := []struct {
+		name               string
+		verb               string
+		installErr         error
+		wantInstall        int
+		wantUninstall      int
+		wantHook           int
+		wantExit           *int // nil → run must not call exit
+		wantStderrContains string
+	}{
+		{name: "install dispatches to seam", verb: "install", wantInstall: 1},
+		{name: "uninstall dispatches to seam", verb: "uninstall", wantUninstall: 1},
+		{name: "hook verb still dispatches to handler", verb: "hook", wantHook: 1},
+		{name: "unknown cursor verb exits 2", verb: "bogus", wantExit: exitPtr(2), wantStderrContains: `unknown verb "bogus"`},
+		{name: "install error exits 1", verb: "install", installErr: errors.New("boom"), wantInstall: 1, wantExit: exitPtr(1), wantStderrContains: "sigil: boom"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateDotenvHome(t)
+			// Credentials present so install does not chain the login prompt.
+			t.Setenv("SIGIL_ENDPOINT", "https://cloud.example.com")
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
+
+			install, uninstall, hook := 0, 0, 0
+			withStubCursorInstall(t, func(_, _ io.Writer, _ *log.Logger) error {
+				install++
+				return tc.installErr
+			})
+			withStubCursorUninstall(t, func(io.Writer, io.Writer, *log.Logger) error {
+				uninstall++
+				return nil
+			})
+			prev := agents
+			t.Cleanup(func() { agents = prev })
+			agents = map[string]agentHook{
+				"cursor": func(context.Context, io.Reader, io.Writer, *log.Logger) error {
+					hook++
+					return nil
+				},
+			}
+
+			var stdout, stderr bytes.Buffer
+			gotExit := withExit(t, func() {
+				run([]string{"cursor", tc.verb}, strings.NewReader(`{}`), &stdout, &stderr)
+			})
+
+			switch {
+			case tc.wantExit == nil && gotExit != nil:
+				t.Fatalf("exit = %d, want no exit (stderr=%q)", *gotExit, stderr.String())
+			case tc.wantExit != nil && (gotExit == nil || *gotExit != *tc.wantExit):
+				t.Fatalf("exit = %v, want %d (stderr=%q)", gotExit, *tc.wantExit, stderr.String())
+			}
+			assert.Equal(t, tc.wantInstall, install, "install calls")
+			assert.Equal(t, tc.wantUninstall, uninstall, "uninstall calls")
+			assert.Equal(t, tc.wantHook, hook, "hook calls")
+			if tc.wantStderrContains != "" {
+				assert.Contains(t, stderr.String(), tc.wantStderrContains)
+			}
+		})
+	}
+}
+
+// On first install (no credentials yet) the login prompt is chained, mirroring
+// the launcher auto-prompt; when credentials are present it is skipped.
+func TestRun_CursorInstallLoginChain(t *testing.T) {
+	cases := []struct {
+		name           string
+		creds          bool
+		wantLoginCalls int
+	}{
+		{name: "chains login when credentials missing", creds: false, wantLoginCalls: 1},
+		{name: "skips login when credentials present", creds: true, wantLoginCalls: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateDotenvHome(t)
+			if tc.creds {
+				t.Setenv("SIGIL_ENDPOINT", "https://cloud.example.com")
+				t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+				t.Setenv("SIGIL_AUTH_TOKEN", "token")
+			} else {
+				t.Setenv("SIGIL_ENDPOINT", "")
+				t.Setenv("SIGIL_AUTH_TENANT_ID", "")
+				t.Setenv("SIGIL_AUTH_TOKEN", "")
+			}
+
+			withStubCursorInstall(t, func(io.Writer, io.Writer, *log.Logger) error { return nil })
+			loginCalls := 0
+			withStubLoginRun(t, func(context.Context, login.RunOpts) error {
+				loginCalls++
+				return login.ErrNotInteractive
+			})
+
+			var stdout, stderr bytes.Buffer
+			gotExit := withExit(t, func() {
+				run([]string{"cursor", "install"}, strings.NewReader(""), &stdout, &stderr)
+			})
+			require.Nil(t, gotExit, "stderr=%q", stderr.String())
+			assert.Equal(t, tc.wantLoginCalls, loginCalls)
+		})
+	}
+}
+
+// withStubCursorInstall / withStubCursorUninstall replace the cursor install
+// seams so dispatch can be asserted without touching ~/.cursor/hooks.json.
+func withStubCursorInstall(t *testing.T, fn func(io.Writer, io.Writer, *log.Logger) error) {
+	t.Helper()
+	prev := cursorInstall
+	t.Cleanup(func() { cursorInstall = prev })
+	cursorInstall = fn
+}
+
+func withStubCursorUninstall(t *testing.T, fn func(io.Writer, io.Writer, *log.Logger) error) {
+	t.Helper()
+	prev := cursorUninstall
+	t.Cleanup(func() { cursorUninstall = prev })
+	cursorUninstall = fn
+}
+
 // withStubLauncher replaces the launchers map with a single entry for the
 // duration of the test.
 func withStubLauncher(t *testing.T, name string, fn agentLauncher) {

--- a/plugins/sigil/internal/agents/cursor/install/install.go
+++ b/plugins/sigil/internal/agents/cursor/install/install.go
@@ -1,0 +1,394 @@
+// Package install wires Sigil's Cursor hook into the user-level
+// ~/.cursor/hooks.json from the command line.
+//
+// Cursor is a GUI app with no exec launch point, so unlike the other agents
+// there is no `sigil cursor` launcher to bootstrap capture on first run.
+// `sigil cursor install` writes the hook entry directly, the same way
+// `sigil copilot` writes Copilot's hooks file.
+//
+// hooks.json is shared with other tools (the live file holds superconductor
+// and superset entries alongside Sigil's), so install MERGES into it rather
+// than overwriting: it keeps unknown top-level keys and every event entry it
+// does not own, and replaces its own entry in place so re-runs do not
+// double-fire. The legacy /add-plugin run.sh entry is recognised on a
+// best-effort basis (see isSigilHook), so users should not run direct install
+// and /add-plugin together.
+package install
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// cursorEvents are the hook events Sigil wires, matching the set shipped in
+// plugins/cursor/hooks/hooks.json. The Cursor dispatcher infers the event
+// from hook_event_name in the payload, so the same `sigil cursor hook`
+// command serves all eight.
+var cursorEvents = []string{
+	"sessionStart",
+	"beforeSubmitPrompt",
+	"afterAgentResponse",
+	"afterAgentThought",
+	"postToolUse",
+	"postToolUseFailure",
+	"stop",
+	"sessionEnd",
+}
+
+// Test seams.
+var (
+	userHomeDir = os.UserHomeDir
+	executable  = os.Executable
+)
+
+// hookEntry is a single Cursor hook command entry. Cursor entries may carry
+// other fields, but Sigil only ever writes the command; extra fields on other
+// tools' entries are preserved as raw JSON, not through this type.
+type hookEntry struct {
+	Command string `json:"command"`
+}
+
+// Run wires `sigil cursor hook` into ~/.cursor/hooks.json for all eight
+// Cursor hook events, creating the file and parent directory when absent. It
+// merges into an existing file: unknown top-level keys and other tools'
+// entries are preserved, and a recognised pre-existing Sigil entry (a previous
+// install, or a legacy run.sh entry when detectable) is replaced in place to
+// avoid double-firing capture. The write is atomic and idempotent — when the
+// result already matches what is on disk, the file is left untouched.
+func Run(stdout, _ io.Writer, logger *log.Logger) error {
+	path, err := cursorHooksPath()
+	if err != nil {
+		return err
+	}
+	cmd, err := sigilCommand()
+	if err != nil {
+		return err
+	}
+	logger.Printf("cursor install: hooks=%s command=%q", path, cmd)
+
+	doc, err := loadHooks(path)
+	if err != nil {
+		return err
+	}
+
+	entry, err := json.Marshal(hookEntry{Command: cmd})
+	if err != nil {
+		return fmt.Errorf("encode cursor hook entry: %w", err)
+	}
+	for _, event := range cursorEvents {
+		doc.hooks[event] = upsertSigil(doc.hooks[event], entry)
+	}
+
+	wrote, err := writeHooks(path, doc)
+	if err != nil {
+		return err
+	}
+	if wrote {
+		_, _ = fmt.Fprintf(stdout, "sigil: wired Cursor hooks at %s\n", path)
+	} else {
+		_, _ = fmt.Fprintf(stdout, "sigil: Cursor hooks already up to date at %s\n", path)
+	}
+	return nil
+}
+
+// Uninstall removes Sigil's hook entries from ~/.cursor/hooks.json, leaving
+// other tools' entries and unknown keys intact. Event arrays left empty are
+// dropped. The write is atomic and idempotent — a file with no Sigil entries
+// is left untouched, and a missing file is a no-op (no file is created).
+func Uninstall(stdout, _ io.Writer, logger *log.Logger) error {
+	path, err := cursorHooksPath()
+	if err != nil {
+		return err
+	}
+	logger.Printf("cursor uninstall: hooks=%s", path)
+
+	if _, statErr := os.Stat(path); errors.Is(statErr, os.ErrNotExist) {
+		_, _ = fmt.Fprintf(stdout, "sigil: no Cursor hooks to remove at %s\n", path)
+		return nil
+	}
+
+	doc, err := loadHooks(path)
+	if err != nil {
+		return err
+	}
+	for event, entries := range doc.hooks {
+		kept := removeSigil(entries)
+		if len(kept) == 0 {
+			delete(doc.hooks, event)
+			continue
+		}
+		doc.hooks[event] = kept
+	}
+
+	wrote, err := writeHooks(path, doc)
+	if err != nil {
+		return err
+	}
+	if wrote {
+		_, _ = fmt.Fprintf(stdout, "sigil: removed Cursor hooks from %s\n", path)
+	} else {
+		_, _ = fmt.Fprintf(stdout, "sigil: no Cursor hooks to remove at %s\n", path)
+	}
+	return nil
+}
+
+// cursorHooksPath returns the user-level Cursor hooks file path.
+//
+// Cursor reads ~/.cursor/hooks.json for user-global hooks. No config-dir
+// override env var is documented (no CURSOR_* knob exists in Cursor's hook
+// docs), so this is fixed to ~/.cursor for now.
+//
+// TODO: honor a Cursor config-dir override env var once one is confirmed.
+func cursorHooksPath() (string, error) {
+	home, err := userHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir for cursor hooks: %w", err)
+	}
+	return filepath.Join(home, ".cursor", "hooks.json"), nil
+}
+
+// sigilCommand returns the hook command Cursor should run:
+// `<sigil-binary> cursor hook`. The binary path comes from os.Executable
+// WITHOUT resolving symlinks, so the stable ~/.local/bin/sigil or
+// /opt/homebrew/bin/sigil symlink is recorded rather than a versioned brew
+// Cellar path that changes on upgrade.
+//
+// Cursor parses the command through a shell, so a path containing spaces or
+// shell metacharacters is single-quoted.
+func sigilCommand() (string, error) {
+	bin, err := executable()
+	if err != nil {
+		return "", fmt.Errorf("resolve sigil binary path: %w", err)
+	}
+	return shellQuote(bin) + " cursor hook", nil
+}
+
+// legacyRunShLiteral is the hook command the bundled /add-plugin wiring
+// registers (plugins/cursor/hooks/hooks.json). Cursor usually expands
+// CURSOR_PLUGIN_ROOT when it copies the entry into the user-level hooks.json,
+// leaving the repo's plugins/cursor/scripts/run.sh tail in the path, but it may
+// also keep the literal, so isSigilHook checks for both.
+const legacyRunShLiteral = "${CURSOR_PLUGIN_ROOT}/scripts/run.sh"
+
+// isSigilHook reports whether an existing entry's command is one of ours, so
+// re-runs and the legacy /add-plugin run.sh wiring update in place instead of
+// double-firing. It matches any command of the form `<path-to-sigil> cursor
+// hook`, plus the legacy run.sh entry in both its bundled
+// "${CURSOR_PLUGIN_ROOT}/scripts/run.sh" form and the expanded form Cursor
+// writes once it resolves CURSOR_PLUGIN_ROOT. Legacy detection is best-effort:
+// an expanded path that no longer carries the plugins/cursor segment is not
+// recognised.
+func isSigilHook(cmd string) bool {
+	c := strings.TrimSpace(cmd)
+	if strings.Contains(c, legacyRunShLiteral) ||
+		strings.Contains(c, filepath.Join("plugins", "cursor", "scripts", "run.sh")) {
+		return true
+	}
+	bin, ok := strings.CutSuffix(c, " cursor hook")
+	if !ok {
+		return false
+	}
+	bin = unquote(strings.TrimSpace(bin))
+	return bin != "" && strings.TrimSuffix(filepath.Base(bin), ".exe") == "sigil"
+}
+
+// upsertSigil replaces the first Sigil-owned entry in entries with cmd (in
+// place, so other tools' entries keep their order) and drops any further
+// Sigil entries; when none is present it appends cmd.
+func upsertSigil(entries []json.RawMessage, cmd json.RawMessage) []json.RawMessage {
+	out := make([]json.RawMessage, 0, len(entries)+1)
+	inserted := false
+	for _, raw := range entries {
+		if isSigilHook(commandOf(raw)) {
+			if !inserted {
+				out = append(out, cmd)
+				inserted = true
+			}
+			continue
+		}
+		out = append(out, raw)
+	}
+	if !inserted {
+		out = append(out, cmd)
+	}
+	return out
+}
+
+// removeSigil returns entries with every Sigil-owned entry dropped.
+func removeSigil(entries []json.RawMessage) []json.RawMessage {
+	out := make([]json.RawMessage, 0, len(entries))
+	for _, raw := range entries {
+		if isSigilHook(commandOf(raw)) {
+			continue
+		}
+		out = append(out, raw)
+	}
+	return out
+}
+
+// commandOf extracts the "command" string from a hook entry, returning ""
+// when the entry is not an object or has no command (such entries are never
+// treated as Sigil's).
+func commandOf(raw json.RawMessage) string {
+	var e hookEntry
+	if err := json.Unmarshal(raw, &e); err != nil {
+		return ""
+	}
+	return e.Command
+}
+
+// hooksDoc is the parsed hooks.json. Top-level keys are preserved as raw JSON
+// (so `version` and any unknown keys survive a round-trip) with the `hooks`
+// object pulled out into a per-event entry list we can edit.
+type hooksDoc struct {
+	top   map[string]json.RawMessage
+	hooks map[string][]json.RawMessage
+}
+
+// loadHooks reads and parses path. A missing or empty file yields an empty
+// document so callers can treat fresh installs and merges uniformly.
+func loadHooks(path string) (*hooksDoc, error) {
+	doc := &hooksDoc{
+		top:   map[string]json.RawMessage{},
+		hooks: map[string][]json.RawMessage{},
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return doc, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return doc, nil
+	}
+	if err := json.Unmarshal(data, &doc.top); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if rawHooks, ok := doc.top["hooks"]; ok {
+		if err := json.Unmarshal(rawHooks, &doc.hooks); err != nil {
+			return nil, fmt.Errorf("parse hooks in %s: %w", path, err)
+		}
+		// A literal `"hooks": null` unmarshals to a nil map; reset it so Run
+		// can assign event entries without panicking.
+		if doc.hooks == nil {
+			doc.hooks = map[string][]json.RawMessage{}
+		}
+	}
+	// hooks is reattached from doc.hooks at render time.
+	delete(doc.top, "hooks")
+	return doc, nil
+}
+
+// renderHooks serialises doc back to indented JSON. The hooks map is
+// reattached under the "hooks" key and version defaults to 1 when absent.
+// Output is stable (encoding/json sorts map keys) so writeHooks can skip
+// no-op rewrites.
+func renderHooks(doc *hooksDoc) ([]byte, error) {
+	top := make(map[string]json.RawMessage, len(doc.top)+2)
+	maps.Copy(top, doc.top)
+	if _, ok := top["version"]; !ok {
+		top["version"] = json.RawMessage("1")
+	}
+	hooks, err := json.Marshal(doc.hooks)
+	if err != nil {
+		return nil, fmt.Errorf("encode cursor hooks: %w", err)
+	}
+	top["hooks"] = hooks
+
+	out, err := json.MarshalIndent(top, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode cursor hooks file: %w", err)
+	}
+	return append(out, '\n'), nil
+}
+
+// writeHooks renders doc and atomically writes it to path (temp file +
+// rename). It returns wrote=false and leaves the file untouched when the
+// rendered bytes already match what is on disk.
+func writeHooks(path string, doc *hooksDoc) (bool, error) {
+	content, err := renderHooks(doc)
+	if err != nil {
+		return false, err
+	}
+	if existing, readErr := os.ReadFile(path); readErr == nil && bytes.Equal(existing, content) {
+		return false, nil
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return false, fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, "hooks.json.tmp-*")
+	if err != nil {
+		return false, fmt.Errorf("temp file in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return false, fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return false, fmt.Errorf("chmod temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return false, fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return false, fmt.Errorf("rename to %s: %w", path, err)
+	}
+	return true, nil
+}
+
+// shellQuote single-quotes s for POSIX shells when it contains characters a
+// shell would interpret, and returns it unchanged otherwise.
+func shellQuote(s string) string {
+	if !needsShellQuote(s) {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// needsShellQuote reports whether s contains anything outside the set of
+// characters a shell leaves untouched in an unquoted word.
+func needsShellQuote(s string) bool {
+	if s == "" {
+		return true
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case strings.ContainsRune("@%+=:,./-_", r):
+		default:
+			return true
+		}
+	}
+	return false
+}
+
+// unquote strips a single matching pair of surrounding single or double
+// quotes from s. It is a best-effort helper for recognising our own
+// shell-quoted binary path and does not interpret escapes.
+func unquote(s string) string {
+	if len(s) >= 2 {
+		first := s[0]
+		if (first == '\'' || first == '"') && s[len(s)-1] == first {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}

--- a/plugins/sigil/internal/agents/cursor/install/install_test.go
+++ b/plugins/sigil/internal/agents/cursor/install/install_test.go
@@ -1,0 +1,490 @@
+package install
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testBin = "/opt/homebrew/bin/sigil"
+
+func TestRun(t *testing.T) {
+	const (
+		superconductor = "/Users/me/.superconductor/hooks/cursor-notify.sh"
+		supersetStart  = "/Users/me/.superset/hooks/cursor-hook.sh Start"
+		supersetStop   = "/Users/me/.superset/hooks/cursor-hook.sh Stop"
+		legacyRunSh    = "/Users/me/projects/sigil-sdk/plugins/cursor/scripts/run.sh"
+		stalePath      = "/old/bin/sigil cursor hook"
+	)
+	wantCmd := testBin + " cursor hook"
+
+	cases := []struct {
+		name string
+		// seed is the hooks.json written before Run; "" means no file.
+		seed string
+		// preserved commands that must survive untouched in their event.
+		preserved map[string][]string
+		// nonSigilEvents are events whose entries Run must not touch at all.
+		nonSigilEvents map[string][]string
+	}{
+		{
+			name: "fresh file create",
+			seed: "",
+		},
+		{
+			name: "null hooks treated as empty",
+			seed: `{"version": 1, "hooks": null}`,
+		},
+		{
+			name: "merge preserves other tools entries",
+			seed: `{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {"command": "` + legacyRunSh + `"},
+      {"command": "` + superconductor + `"}
+    ],
+    "beforeSubmitPrompt": [
+      {"command": "` + supersetStart + `"},
+      {"command": "` + legacyRunSh + `"},
+      {"command": "` + superconductor + `"}
+    ],
+    "stop": [
+      {"command": "` + supersetStop + `"},
+      {"command": "` + legacyRunSh + `"}
+    ],
+    "beforeShellExecution": [
+      {"command": "` + superconductor + `"}
+    ]
+  }
+}`,
+			preserved: map[string][]string{
+				"sessionStart":       {superconductor},
+				"beforeSubmitPrompt": {supersetStart, superconductor},
+				"stop":               {supersetStop},
+			},
+			nonSigilEvents: map[string][]string{
+				"beforeShellExecution": {superconductor},
+			},
+		},
+		{
+			name: "stale sigil path replaced in place",
+			seed: `{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {"command": "` + superconductor + `"},
+      {"command": "` + stalePath + `"}
+    ]
+  }
+}`,
+			preserved: map[string][]string{
+				"sessionStart": {superconductor},
+			},
+		},
+		{
+			name: "legacy run.sh replaced without a second entry",
+			seed: `{
+  "version": 1,
+  "hooks": {
+    "afterAgentResponse": [
+      {"command": "` + legacyRunSh + `"}
+    ]
+  }
+}`,
+		},
+		{
+			name: "legacy env-var run.sh replaced without a second entry",
+			seed: `{
+  "version": 1,
+  "hooks": {
+    "afterAgentResponse": [
+      {"command": "${CURSOR_PLUGIN_ROOT}/scripts/run.sh"}
+    ]
+  }
+}`,
+		},
+		{
+			name: "duplicate sigil entries collapse to one",
+			seed: `{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {"command": "` + legacyRunSh + `"},
+      {"command": "` + stalePath + `"},
+      {"command": "` + superconductor + `"}
+    ]
+  }
+}`,
+			preserved: map[string][]string{
+				"sessionStart": {superconductor},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			withHome(t, home)
+			withExecutable(t, testBin)
+			if tc.seed != "" {
+				seedHooks(t, home, tc.seed)
+			}
+
+			var stdout bytes.Buffer
+			require.NoError(t, Run(&stdout, io.Discard, nopLogger()))
+			assert.Contains(t, stdout.String(), "wired Cursor hooks at")
+
+			got := readEntries(t, hooksPath(home))
+
+			// Every wired event has exactly one Sigil entry, set to wantCmd.
+			for _, ev := range cursorEvents {
+				cmds := got[ev]
+				require.NotEmpty(t, cmds, "event %q missing", ev)
+				sigil := sigilCommands(cmds)
+				require.Len(t, sigil, 1, "event %q must have one Sigil entry, got %v", ev, cmds)
+				assert.Equal(t, wantCmd, sigil[0], "event %q", ev)
+			}
+
+			for ev, want := range tc.preserved {
+				assert.Equal(t, want, nonSigilCommands(got[ev]), "preserved entries for %q", ev)
+			}
+			for ev, want := range tc.nonSigilEvents {
+				assert.Equal(t, want, got[ev], "untouched event %q", ev)
+			}
+		})
+	}
+}
+
+// Fresh install records the running binary's path verbatim (no symlink
+// resolution) and defaults version to 1.
+func TestRun_FreshFileShape(t *testing.T) {
+	home := t.TempDir()
+	withHome(t, home)
+	withExecutable(t, testBin)
+
+	require.NoError(t, Run(io.Discard, io.Discard, nopLogger()))
+
+	data, err := os.ReadFile(hooksPath(home))
+	require.NoError(t, err)
+	var doc struct {
+		Version int                         `json:"version"`
+		Hooks   map[string][]map[string]any `json:"hooks"`
+	}
+	require.NoError(t, json.Unmarshal(data, &doc))
+	assert.Equal(t, 1, doc.Version)
+	require.Len(t, doc.Hooks, len(cursorEvents))
+	for _, ev := range cursorEvents {
+		require.Len(t, doc.Hooks[ev], 1, "event %q", ev)
+		assert.Equal(t, testBin+" cursor hook", doc.Hooks[ev][0]["command"])
+	}
+}
+
+// version and unknown top-level keys survive a merge round-trip.
+func TestRun_PreservesUnknownTopLevelKeys(t *testing.T) {
+	home := t.TempDir()
+	withHome(t, home)
+	withExecutable(t, testBin)
+	seedHooks(t, home, `{
+  "version": 2,
+  "extras": {"keep": ["me"]},
+  "hooks": {"sessionStart": [{"command": "/Users/me/.superset/hooks/x.sh"}]}
+}`)
+
+	require.NoError(t, Run(io.Discard, io.Discard, nopLogger()))
+
+	data, err := os.ReadFile(hooksPath(home))
+	require.NoError(t, err)
+	var doc struct {
+		Version int             `json:"version"`
+		Extras  json.RawMessage `json:"extras"`
+	}
+	require.NoError(t, json.Unmarshal(data, &doc))
+	assert.Equal(t, 2, doc.Version, "existing version must not be reset")
+	assert.JSONEq(t, `{"keep": ["me"]}`, string(doc.Extras))
+}
+
+func TestRun_Idempotent(t *testing.T) {
+	home := t.TempDir()
+	withHome(t, home)
+	withExecutable(t, testBin)
+	seedHooks(t, home, `{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {"command": "/Users/me/.superconductor/hooks/cursor-notify.sh"},
+      {"command": "/Users/me/projects/sigil-sdk/plugins/cursor/scripts/run.sh"}
+    ]
+  }
+}`)
+
+	require.NoError(t, Run(io.Discard, io.Discard, nopLogger()))
+	first, err := os.ReadFile(hooksPath(home))
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	require.NoError(t, Run(&stdout, io.Discard, nopLogger()))
+	second, err := os.ReadFile(hooksPath(home))
+	require.NoError(t, err)
+
+	assert.Equal(t, string(first), string(second), "second run must not change the file")
+	assert.Contains(t, stdout.String(), "already up to date")
+}
+
+// A corrupt hooks.json must abort with an error and leave the file byte-for-byte
+// untouched, so a file shared with other tools is never lost to a partial
+// rewrite.
+func TestCorruptHooksFileAborts(t *testing.T) {
+	const corrupt = `{"version": 1, "hooks": {`
+	cases := []struct {
+		name string
+		run  func(io.Writer, io.Writer, *log.Logger) error
+	}{
+		{"install", Run},
+		{"uninstall", Uninstall},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			withHome(t, home)
+			withExecutable(t, testBin)
+			dir := filepath.Join(home, ".cursor")
+			require.NoError(t, os.MkdirAll(dir, 0o755))
+			path := hooksPath(home)
+			require.NoError(t, os.WriteFile(path, []byte(corrupt), 0o644))
+
+			require.Error(t, tc.run(io.Discard, io.Discard, nopLogger()))
+
+			data, err := os.ReadFile(path)
+			require.NoError(t, err)
+			assert.Equal(t, corrupt, string(data), "file must be left untouched on parse error")
+		})
+	}
+}
+
+func TestUninstall(t *testing.T) {
+	const (
+		superconductor = "/Users/me/.superconductor/hooks/cursor-notify.sh"
+		supersetStart  = "/Users/me/.superset/hooks/cursor-hook.sh Start"
+		legacyRunSh    = "/Users/me/projects/sigil-sdk/plugins/cursor/scripts/run.sh"
+	)
+
+	t.Run("removes only sigil entries", func(t *testing.T) {
+		home := t.TempDir()
+		withHome(t, home)
+		seedHooks(t, home, `{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {"command": "`+legacyRunSh+`"},
+      {"command": "`+superconductor+`"}
+    ],
+    "beforeSubmitPrompt": [
+      {"command": "`+supersetStart+`"},
+      {"command": "`+legacyRunSh+`"}
+    ]
+  }
+}`)
+
+		var stdout bytes.Buffer
+		require.NoError(t, Uninstall(&stdout, io.Discard, nopLogger()))
+		assert.Contains(t, stdout.String(), "removed Cursor hooks from")
+
+		got := readEntries(t, hooksPath(home))
+		assert.Equal(t, []string{superconductor}, got["sessionStart"])
+		assert.Equal(t, []string{supersetStart}, got["beforeSubmitPrompt"])
+	})
+
+	t.Run("drops events left empty", func(t *testing.T) {
+		home := t.TempDir()
+		withHome(t, home)
+		seedHooks(t, home, `{
+  "version": 1,
+  "hooks": {"stop": [{"command": "`+legacyRunSh+`"}]}
+}`)
+
+		require.NoError(t, Uninstall(io.Discard, io.Discard, nopLogger()))
+		_, ok := readEntries(t, hooksPath(home))["stop"]
+		assert.False(t, ok, "empty event array must be dropped")
+	})
+
+	t.Run("idempotent on already-clean file", func(t *testing.T) {
+		home := t.TempDir()
+		withHome(t, home)
+		seedHooks(t, home, `{
+  "version": 1,
+  "hooks": {"sessionStart": [{"command": "`+superconductor+`"}]}
+}`)
+
+		require.NoError(t, Uninstall(io.Discard, io.Discard, nopLogger()))
+		first, err := os.ReadFile(hooksPath(home))
+		require.NoError(t, err)
+
+		var stdout bytes.Buffer
+		require.NoError(t, Uninstall(&stdout, io.Discard, nopLogger()))
+		second, err := os.ReadFile(hooksPath(home))
+		require.NoError(t, err)
+
+		assert.Equal(t, string(first), string(second))
+		assert.Contains(t, stdout.String(), "no Cursor hooks to remove")
+		assert.Equal(t, []string{superconductor}, readEntries(t, hooksPath(home))["sessionStart"])
+	})
+
+	t.Run("missing file is a no-op", func(t *testing.T) {
+		home := t.TempDir()
+		withHome(t, home)
+
+		var stdout bytes.Buffer
+		require.NoError(t, Uninstall(&stdout, io.Discard, nopLogger()))
+		assert.Contains(t, stdout.String(), "no Cursor hooks to remove")
+		_, err := os.Stat(hooksPath(home))
+		assert.True(t, os.IsNotExist(err), "uninstall must not create the file")
+	})
+}
+
+func TestInstallThenUninstallRoundTrip(t *testing.T) {
+	const superconductor = "/Users/me/.superconductor/hooks/cursor-notify.sh"
+	home := t.TempDir()
+	withHome(t, home)
+	withExecutable(t, testBin)
+	seedHooks(t, home, `{
+  "version": 1,
+  "hooks": {"sessionStart": [{"command": "`+superconductor+`"}]}
+}`)
+
+	require.NoError(t, Run(io.Discard, io.Discard, nopLogger()))
+	require.NoError(t, Uninstall(io.Discard, io.Discard, nopLogger()))
+
+	got := readEntries(t, hooksPath(home))
+	assert.Equal(t, []string{superconductor}, got["sessionStart"])
+	for _, ev := range cursorEvents {
+		assert.Empty(t, sigilCommands(got[ev]), "event %q still has a Sigil entry", ev)
+	}
+}
+
+func TestIsSigilHook(t *testing.T) {
+	cases := []struct {
+		cmd  string
+		want bool
+	}{
+		{"/opt/homebrew/bin/sigil cursor hook", true},
+		{"sigil cursor hook", true},
+		{"/Users/me/.local/bin/sigil cursor hook", true},
+		{"'/Users/me/with space/bin/sigil' cursor hook", true},
+		{"/Users/me/projects/sigil-sdk/plugins/cursor/scripts/run.sh", true},
+		{"${CURSOR_PLUGIN_ROOT}/scripts/run.sh", true},
+		{"/opt/homebrew/bin/sigil.exe cursor hook", true},
+		{"  /opt/homebrew/bin/sigil cursor hook  ", true},
+		{"/usr/bin/notsigil cursor hook", false},
+		{"/opt/homebrew/bin/sigil claude hook", false},
+		{"/Users/me/.superconductor/hooks/cursor-notify.sh", false},
+		{"/Users/me/.superset/hooks/cursor-hook.sh Start", false},
+		{"", false},
+		{"cursor hook", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.cmd, func(t *testing.T) {
+			assert.Equal(t, tc.want, isSigilHook(tc.cmd))
+		})
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"/opt/homebrew/bin/sigil", "/opt/homebrew/bin/sigil"},
+		{"/Users/me/.local/bin/sigil", "/Users/me/.local/bin/sigil"},
+		{"/Users/me/my apps/sigil", "'/Users/me/my apps/sigil'"},
+		{"/has/dollar$ign/sigil", "'/has/dollar$ign/sigil'"},
+		{"/quote'd/sigil", `'/quote'\''d/sigil'`},
+		{"", "''"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.want, shellQuote(tc.in))
+		})
+	}
+}
+
+// --- helpers ---
+
+func withHome(t *testing.T, home string) {
+	t.Helper()
+	prev := userHomeDir
+	t.Cleanup(func() { userHomeDir = prev })
+	userHomeDir = func() (string, error) { return home, nil }
+}
+
+func withExecutable(t *testing.T, path string) {
+	t.Helper()
+	prev := executable
+	t.Cleanup(func() { executable = prev })
+	executable = func() (string, error) { return path, nil }
+}
+
+func hooksPath(home string) string {
+	return filepath.Join(home, ".cursor", "hooks.json")
+}
+
+func seedHooks(t *testing.T, home, content string) {
+	t.Helper()
+	require.True(t, json.Valid([]byte(content)), "seed must be valid JSON")
+	dir := filepath.Join(home, ".cursor")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "hooks.json"), []byte(content), 0o644))
+}
+
+// readEntries parses the hooks file into event -> ordered command strings.
+func readEntries(t *testing.T, path string) map[string][]string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var doc struct {
+		Hooks map[string][]struct {
+			Command string `json:"command"`
+		} `json:"hooks"`
+	}
+	require.NoError(t, json.Unmarshal(data, &doc))
+	out := map[string][]string{}
+	for ev, entries := range doc.Hooks {
+		cmds := make([]string, 0, len(entries))
+		for _, e := range entries {
+			cmds = append(cmds, e.Command)
+		}
+		out[ev] = cmds
+	}
+	return out
+}
+
+func sigilCommands(cmds []string) []string {
+	var out []string
+	for _, c := range cmds {
+		if isSigilHook(c) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func nonSigilCommands(cmds []string) []string {
+	var out []string
+	for _, c := range cmds {
+		if !isSigilHook(c) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func nopLogger() *log.Logger {
+	return log.New(io.Discard, "", 0)
+}


### PR DESCRIPTION
Add `sigil cursor install` / `sigil cursor uninstall` commands.

- `install` registers `sigil cursor hook` for Cursor events in `~/.cursor/hooks.json`, merging with hooks other tools already wrote. Re-runs replace Sigil's entry.
- `uninstall` Sigil's entries.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Install/uninstall rewrite a shared user config file (~/.cursor/hooks.json); merge and atomic-write logic reduce double-capture and corruption risk, but a bad hooks.json still blocks install until fixed manually.
> 
> **Overview**
> Adds **`sigil cursor install`** and **`sigil cursor uninstall`** so Cursor users can wire Sigil without a GUI launcher. Install registers **`sigil cursor hook`** for all eight Cursor events in **`~/.cursor/hooks.json`**, using merge/upsert logic that keeps other tools’ hooks, replaces legacy **`/add-plugin`** / **`run.sh`** entries, and skips writes when already up to date (atomic temp+rename).
> 
> The **`sigil`** CLI routes **`cursor install|uninstall`** before the generic “hook-only” verb check; **`sigil cursor hook`** is unchanged. Successful install optionally chains **`sigil login`** when credentials are missing (install still succeeds if login is skipped or fails).
> 
> Docs (**`llms.txt`**, Cursor and sigil READMEs) now describe the install/uninstall flow and warn against mixing install with **`/add-plugin`**. **`go.work.sum`** picks up minor golang.org/x module checksum entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da43714cd3e12350286e80105b6d1c1f2c512ca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->