### PR TITLE
feat(plugins): add git.branch and cwd built-in tags to pi, opencode, codex, copilot

### DIFF
--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -92,6 +92,25 @@ Run one OpenCode turn, then open **AI Observability → Conversations** in Grafa
 
 If nothing shows up, set `SIGIL_DEBUG=true` in `~/.config/sigil/config.env`, run another turn, and check OpenCode stderr.
 
+## Tagging sessions
+
+Launch with `--tag key=value` (repeatable) to attach tags to every generation the plugin exports:
+
+```sh
+sigil opencode --tag project=hackathon --tag team=ai
+# forward args to opencode after `--`
+sigil opencode --tag team=ai -- run "say hi"
+```
+
+`--tag` is shorthand for `SIGIL_TAGS`; flag tags merge onto (and override) any `SIGIL_TAGS` already in the environment or `~/.config/sigil/config.env`. The merge happens in the SDK, so user tags reach every generation without the plugin reparsing them.
+
+The plugin always attaches two built-in tags to every generation:
+
+- `git.branch` — current branch from the opencode project directory, or a 12-char short SHA on detached HEAD. Omitted when not inside a git checkout.
+- `cwd` — the opencode project directory (from `PluginInput.directory`).
+
+Built-in tags win collisions with user tags, matching the claude-code and cursor launchers.
+
 ## All options
 
 `~/.config/sigil/config.env` is the only configuration file. Every option is set via env var.

--- a/plugins/opencode/src/git.ts
+++ b/plugins/opencode/src/git.ts
@@ -1,0 +1,31 @@
+import { execFileSync } from "node:child_process";
+
+/**
+ * Resolve the current git branch via `git rev-parse`.
+ *
+ * Returns the branch name on a normal checkout, a 12-char short sha on
+ * detached HEAD (matching plugins/cursor), or undefined when git is
+ * unavailable or `cwd` is not in a repo.
+ */
+export function resolveGitBranch(cwd: string): string | undefined {
+  if (!cwd) return undefined;
+  const branch = runGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+  if (!branch) return undefined;
+  if (branch !== "HEAD") return branch;
+  // Detached HEAD: fall back to a short sha.
+  return runGit(["rev-parse", "--short=12", "HEAD"], cwd);
+}
+
+function runGit(args: string[], cwd: string): string | undefined {
+  try {
+    const out = execFileSync("git", args, {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf-8",
+      timeout: 1000,
+    }).trim();
+    return out.length > 0 ? out : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/plugins/opencode/src/golden.test.ts
+++ b/plugins/opencode/src/golden.test.ts
@@ -399,6 +399,12 @@ const normalizeFields: Record<string, string> = {
   "sigil.sdk.commit": "<NORMALIZED>",
   // sha256 derived from agent_version; see Pi golden test for the rationale.
   effective_version: "<NORMALIZED>",
+  // The plugin resolves git.branch and cwd from the opencode plugin
+  // directory (PluginInput.directory, falling back to process.cwd() in
+  // tests), which varies per developer checkout. Normalize so the golden
+  // is stable in CI.
+  "git.branch": "<NORMALIZED>",
+  cwd: "<NORMALIZED>",
 };
 
 const normalizeKeySuffixes = [".started_at", ".completed_at", ".timestamp"];

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -9,10 +9,12 @@ import type {
 } from "@opencode-ai/sdk";
 import { createSigilClient } from "./client.js";
 import type { SigilOpencodeConfig } from "./config.js";
+import { resolveGitBranch } from "./git.js";
 import { runToolCallGuard } from "./guard.js";
 import { stableOpencodeGenerationId } from "./lineage.js";
 import { mapError, mapGeneration, mapToolDefinitions } from "./mappers.js";
 import { Redactor } from "./redact.js";
+import { buildBuiltinTags } from "./tags.js";
 import {
   createTelemetryProviders,
   type TelemetryProviders,
@@ -159,6 +161,7 @@ async function handleEvent(
   client: OpencodeClient,
   redactor: Redactor,
   debugLog: (msg: string, ...args: unknown[]) => void,
+  projectDir: string,
   event: { type: string; properties: unknown },
 ): Promise<void> {
   if (event.type === "message.part.updated") {
@@ -168,6 +171,7 @@ async function handleEvent(
       client,
       redactor,
       debugLog,
+      projectDir,
       event.properties,
     );
     return;
@@ -210,6 +214,7 @@ async function handleEvent(
     client,
     redactor,
     debugLog,
+    projectDir,
     assistantMsg,
     fetchedParts,
   );
@@ -221,6 +226,7 @@ async function handleMessagePartUpdated(
   client: OpencodeClient,
   redactor: Redactor,
   debugLog: (msg: string, ...args: unknown[]) => void,
+  projectDir: string,
   properties: unknown,
 ): Promise<void> {
   const part = recordField(properties, "part");
@@ -241,6 +247,7 @@ async function handleMessagePartUpdated(
       client,
       redactor,
       debugLog,
+      projectDir,
       response.data.info as AssistantMessage,
       response.data.parts ?? [],
     );
@@ -283,6 +290,7 @@ async function recordAssistantMessage(
   client: OpencodeClient,
   redactor: Redactor,
   debugLog: (msg: string, ...args: unknown[]) => void,
+  projectDir: string,
   assistantMsg: AssistantMessage,
   fetchedParts?: Part[],
 ): Promise<void> {
@@ -341,6 +349,14 @@ async function recordAssistantMessage(
   }
 
   const tools = mapToolDefinitions(pending?.tools);
+  // Resolved per turn so a mid-session checkout lands on the next
+  // generation. Always sent regardless of content capture mode:
+  // `git.branch` and `cwd` are low-cardinality session metadata, not
+  // message content, matching claude-code/cursor.
+  const builtinTags = buildBuiltinTags({
+    cwd: projectDir,
+    gitBranch: resolveGitBranch(projectDir),
+  });
   const seed = {
     id: genId,
     conversationId: assistantMsg.sessionID,
@@ -353,6 +369,7 @@ async function recordAssistantMessage(
     ...(parent && { parentGenerationIds: [parent] }),
     ...(tools.length > 0 && { tools }),
     ...(includeMessageBodies && { systemPrompt: pending?.systemPrompt }),
+    ...(builtinTags && { tags: builtinTags }),
   };
 
   const result = mapGeneration(
@@ -840,7 +857,12 @@ export type SigilHooks = {
 export async function createSigilHooks(
   config: SigilOpencodeConfig,
   client: OpencodeClient,
+  options: { projectDir?: string } = {},
 ): Promise<SigilHooks | null> {
+  // Prefer the opencode plugin's project directory (PluginInput.directory)
+  // because the opencode server can run from a directory different from the
+  // project root. Fall back to `process.cwd()` for older callers and tests.
+  const projectDir = options.projectDir || process.cwd();
   function debugLog(msg: string, ...args: unknown[]) {
     if (config.debug) console.error(`[sigil-opencode] ${msg}`, ...args);
   }
@@ -882,7 +904,15 @@ export async function createSigilHooks(
 
   return {
     event: async (input) => {
-      await handleEvent(sigil, config, client, redactor, debugLog, input.event);
+      await handleEvent(
+        sigil,
+        config,
+        client,
+        redactor,
+        debugLog,
+        projectDir,
+        input.event,
+      );
       await handleLifecycle(sigil, telemetry, debugLog, input.event);
     },
     chatMessage: (input, output) => {

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -2,11 +2,13 @@ import type { Plugin } from "@opencode-ai/plugin";
 import { loadConfig } from "./config.js";
 import { createSigilHooks } from "./hooks.js";
 
-export const SigilPlugin: Plugin = async ({ client }) => {
+export const SigilPlugin: Plugin = async ({ client, directory }) => {
   const config = await loadConfig();
   if (!config) return {};
 
-  const hooks = await createSigilHooks(config, client);
+  const hooks = await createSigilHooks(config, client, {
+    projectDir: directory,
+  });
   if (!hooks) return {};
 
   return {

--- a/plugins/opencode/src/tags.test.ts
+++ b/plugins/opencode/src/tags.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { buildBuiltinTags } from "./tags.js";
+
+describe("buildBuiltinTags", () => {
+  const cases: {
+    name: string;
+    in: Parameters<typeof buildBuiltinTags>[0];
+    want: ReturnType<typeof buildBuiltinTags>;
+  }[] = [
+    {
+      name: "both keys populated",
+      in: { cwd: "/repo", gitBranch: "main" },
+      want: { "git.branch": "main", cwd: "/repo" },
+    },
+    {
+      name: "branch only",
+      in: { gitBranch: "main" },
+      want: { "git.branch": "main" },
+    },
+    {
+      name: "cwd only",
+      in: { cwd: "/repo" },
+      want: { cwd: "/repo" },
+    },
+    {
+      name: "empty inputs return undefined",
+      in: {},
+      want: undefined,
+    },
+    {
+      name: "empty-string inputs return undefined",
+      in: { cwd: "", gitBranch: "" },
+      want: undefined,
+    },
+  ];
+
+  it.each(cases)("$name", ({ in: input, want }) => {
+    expect(buildBuiltinTags(input)).toEqual(want);
+  });
+});

--- a/plugins/opencode/src/tags.ts
+++ b/plugins/opencode/src/tags.ts
@@ -1,0 +1,29 @@
+// Build per-generation built-in tags for the opencode plugin.
+//
+// Mirrors the Go side in plugins/sigil/internal/agents/cursor/tags/tags.go
+// `Build`: only emits keys whose values are non-empty, returns `undefined`
+// when no inputs are populated. User-supplied `SIGIL_TAGS` is layered in by
+// the SDK at the client level; the seed/built-in tags merged here take
+// precedence on collisions because the SDK merges per-generation Tags atop
+// client-level Tags.
+
+export interface BuiltinTagInputs {
+  cwd?: string;
+  gitBranch?: string;
+}
+
+export function buildBuiltinTags(
+  in_: BuiltinTagInputs,
+): Record<string, string> | undefined {
+  const out: Record<string, string> = {};
+  if (in_.gitBranch) {
+    out["git.branch"] = in_.gitBranch;
+  }
+  if (in_.cwd) {
+    out.cwd = in_.cwd;
+  }
+  if (Object.keys(out).length === 0) {
+    return undefined;
+  }
+  return out;
+}

--- a/plugins/opencode/src/testdata/golden/opencode-full-message.golden.json
+++ b/plugins/opencode/src/testdata/golden/opencode-full-message.golden.json
@@ -91,7 +91,10 @@
         "stop_reason": "end_turn",
         "started_at": "<NORMALIZED>",
         "completed_at": "<NORMALIZED>",
-        "tags": {},
+        "tags": {
+          "git.branch": "<NORMALIZED>",
+          "cwd": "<NORMALIZED>"
+        },
         "metadata": {
           "cost": 0.005,
           "sigil.sdk.name": "sdk-js",

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -90,6 +90,25 @@ Run one pi turn, then open **AI Observability → Conversations** in Grafana Clo
 
 If nothing shows up, set `SIGIL_DEBUG=true` in `~/.config/sigil/config.env`, run another turn, and check the debug log at `~/.local/state/sigil/logs/sigil.log` (honors `XDG_STATE_HOME`).
 
+## Tagging sessions
+
+Launch with `--tag key=value` (repeatable) to attach tags to every generation pi exports:
+
+```sh
+sigil pi --tag project=hackathon --tag team=ai
+# forward args to pi after `--`
+sigil pi --tag team=ai -- --resume
+```
+
+`--tag` is shorthand for `SIGIL_TAGS`; flag tags merge onto (and override) any `SIGIL_TAGS` already in the environment or `~/.config/sigil/config.env`. The merge happens in the SDK, so user tags reach every generation without the plugin reparsing them.
+
+The plugin always attaches two built-in tags to every generation:
+
+- `git.branch` — current branch from the working directory, or a 12-char short SHA on detached HEAD. Omitted when not inside a git checkout.
+- `cwd` — the process working directory.
+
+Built-in tags win collisions with user tags, matching the claude-code and cursor launchers.
+
 ## Redaction
 
 Before any generation leaves the process, the SDK scrubs known token formats, PEM private keys, database URLs, `KEY=value` pairs, bearer tokens, and email addresses. Matches become `[REDACTED:<id>]`. User input messages are redacted by default; set `SIGIL_REDACT_INPUT_MESSAGES=false` to leave them unchanged.

--- a/plugins/pi/src/golden.test.ts
+++ b/plugins/pi/src/golden.test.ts
@@ -319,6 +319,27 @@ describe("pi plugin: real-SDK golden export", () => {
     assertGoldenJSON(GOLDEN_PATH, exports);
   });
 
+  it("keeps user SIGIL_TAGS and lets built-in git.branch win collisions", async () => {
+    // Drive the user-tag merge path: SIGIL_TAGS becomes a client-level
+    // tag (js/src/config.ts) that the SDK merges under the per-generation
+    // (seed) tags, so the built-in git.branch must win over the
+    // user-supplied one. team=ai must survive because it does not collide.
+    process.env.SIGIL_TAGS = "team=ai,git.branch=should-lose";
+
+    await runFullTurn();
+
+    // Inspect the raw export capture (pre-normalization) so we can assert
+    // on the actual git.branch value. The normalizeFields rule rewrites
+    // git.branch to "<NORMALIZED>" by key, which would hide a regression
+    // where the user value won.
+    const allRawGen = serverEnv.captures.flatMap((c) => c.generations);
+    const rawTurn = allRawGen.find((g: any) => g?.agent_name === "pi") as any;
+    expect(rawTurn).toBeDefined();
+    expect(rawTurn.tags.team).toBe("ai");
+    expect(rawTurn.tags["git.branch"]).toBeDefined();
+    expect(rawTurn.tags["git.branch"]).not.toBe("should-lose");
+  });
+
   it.each([
     "full",
     "no_tool_content",
@@ -368,11 +389,13 @@ const normalizeFields: Record<string, string> = {
   // effective_version is a sha256 derived from agent_version. Normalize so
   // a future agent_version bump does not silently change the golden hash.
   effective_version: "<NORMALIZED>",
-  // The plugin resolves git.branch from process.cwd(), which varies per
-  // developer checkout. Normalize so the golden is stable in CI. The Go
-  // harness does not need the same rule because Go fixtures pass cwd /
-  // git.branch in via transcript or event data, not from process.cwd().
+  // The plugin resolves git.branch and cwd from process.cwd(), which
+  // varies per developer checkout. Normalize so the golden is stable in
+  // CI. The Go harness does not need the same rule because Go fixtures
+  // pass cwd / git.branch in via transcript or event data, not from
+  // process.cwd().
   "git.branch": "<NORMALIZED>",
+  cwd: "<NORMALIZED>",
 };
 
 const normalizeKeySuffixes = [".started_at", ".completed_at", ".timestamp"];

--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -1740,55 +1740,18 @@ describe("extension lifecycle", () => {
     });
   });
 
-  it("emits git.branch tag when contentCapture=full", async () => {
+  it("emits git.branch and cwd tags regardless of content capture mode", async () => {
+    // git.branch + cwd are low-cardinality session metadata, not message
+    // content; they ship in every content-capture mode (matches
+    // claude-code/cursor).
     resolveGitBranchMock.mockReturnValue("feature-x");
 
-    let capturedSeed: { tags?: Record<string, string> } | undefined;
-    const recorder = {
-      setResult: vi.fn(),
-      setCallError: vi.fn(),
-      setFirstTokenAt: vi.fn(),
-    };
-    const sigil: SigilLike = {
-      startStreamingGeneration: vi.fn(async (seed, run) => {
-        capturedSeed = seed as { tags?: Record<string, string> };
-        await run(recorder);
-      }),
-      startToolExecution: vi.fn(() => ({
-        setResult: vi.fn(),
-        setCallError: vi.fn(),
-        end: vi.fn(),
-        getError: vi.fn(),
-      })),
-      shutdown: vi.fn(async () => {}),
-    };
-
-    loadConfigMock.mockResolvedValue({
-      endpoint: "http://localhost:8080/api/v1/generations:export",
-      auth: { mode: "none" },
-      agentName: "pi",
-      contentCapture: "full",
-    });
-    createSigilClientMock.mockReturnValue(sigil);
-
-    const pi = new FakePi();
-    registerExtension(pi as any);
-
-    await pi.emit("session_start");
-    await pi.emit("turn_start");
-    await pi.emit("turn_end", {
-      message: assistantMessage(),
-      toolResults: [],
-    });
-
-    expect(resolveGitBranchMock).toHaveBeenCalledTimes(1);
-    expect(capturedSeed!.tags).toEqual({ "git.branch": "feature-x" });
-  });
-
-  it("omits git.branch tag (and skips the subprocess) when contentCapture is not full", async () => {
-    resolveGitBranchMock.mockReturnValue("feature-x");
-
-    for (const mode of ["metadata_only", "no_tool_content"] as const) {
+    for (const mode of [
+      "full",
+      "metadata_only",
+      "no_tool_content",
+      "full_with_metadata_spans",
+    ] as const) {
       resolveGitBranchMock.mockClear();
 
       let capturedSeed: { tags?: Record<string, string> } | undefined;
@@ -1829,12 +1792,15 @@ describe("extension lifecycle", () => {
         toolResults: [],
       });
 
-      expect(resolveGitBranchMock, `mode=${mode}`).not.toHaveBeenCalled();
-      expect(capturedSeed!.tags, `mode=${mode}`).toBeUndefined();
+      expect(resolveGitBranchMock, `mode=${mode}`).toHaveBeenCalledTimes(1);
+      expect(capturedSeed!.tags, `mode=${mode}`).toEqual({
+        "git.branch": "feature-x",
+        cwd: process.cwd(),
+      });
     }
   });
 
-  it("omits git.branch tag when not in a git repo even with contentCapture=full", async () => {
+  it("emits cwd tag without git.branch when not in a git repo", async () => {
     resolveGitBranchMock.mockReturnValue(undefined);
 
     let capturedSeed: { tags?: Record<string, string> } | undefined;
@@ -1876,7 +1842,7 @@ describe("extension lifecycle", () => {
     });
 
     expect(resolveGitBranchMock).toHaveBeenCalledTimes(1);
-    expect(capturedSeed!.tags).toBeUndefined();
+    expect(capturedSeed!.tags).toEqual({ cwd: process.cwd() });
   });
 
   describe("systemPrompt capture", () => {

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -31,6 +31,7 @@ import {
   toolResultText,
   userMessageText,
 } from "./mappers.js";
+import { buildBuiltinTags } from "./tags.js";
 import {
   createTelemetryProviders,
   type TelemetryProviders,
@@ -457,14 +458,14 @@ export default function (pi: ExtensionAPI) {
       );
 
       // Resolved per turn so mid-session checkouts land on the next
-      // generation. Gated on contentCapture=full because branch names
-      // can leak project context (diverges from claude-code/cursor,
-      // which always send it).
-      const gitBranch =
-        config.contentCapture === "full"
-          ? resolveGitBranch(process.cwd())
-          : undefined;
-      const builtinTags = gitBranch ? { "git.branch": gitBranch } : undefined;
+      // generation. Always sent, regardless of content capture mode:
+      // `git.branch` and `cwd` are low-cardinality session metadata,
+      // not message content, matching claude-code/cursor.
+      const turnCwd = process.cwd();
+      const builtinTags = buildBuiltinTags({
+        cwd: turnCwd,
+        gitBranch: resolveGitBranch(turnCwd),
+      });
 
       // Resolve lineage at `turn_end`, not `message_end`: pi awaits
       // extension `message_end` callbacks *before* calling

--- a/plugins/pi/src/tags.test.ts
+++ b/plugins/pi/src/tags.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { buildBuiltinTags } from "./tags.js";
+
+describe("buildBuiltinTags", () => {
+  const cases: {
+    name: string;
+    in: Parameters<typeof buildBuiltinTags>[0];
+    want: ReturnType<typeof buildBuiltinTags>;
+  }[] = [
+    {
+      name: "both keys populated",
+      in: { cwd: "/repo", gitBranch: "main" },
+      want: { "git.branch": "main", cwd: "/repo" },
+    },
+    {
+      name: "branch only",
+      in: { gitBranch: "main" },
+      want: { "git.branch": "main" },
+    },
+    {
+      name: "cwd only",
+      in: { cwd: "/repo" },
+      want: { cwd: "/repo" },
+    },
+    {
+      name: "empty inputs return undefined",
+      in: {},
+      want: undefined,
+    },
+    {
+      name: "empty-string inputs return undefined",
+      in: { cwd: "", gitBranch: "" },
+      want: undefined,
+    },
+  ];
+
+  it.each(cases)("$name", ({ in: input, want }) => {
+    expect(buildBuiltinTags(input)).toEqual(want);
+  });
+});

--- a/plugins/pi/src/tags.ts
+++ b/plugins/pi/src/tags.ts
@@ -1,0 +1,29 @@
+// Build per-generation built-in tags for the pi plugin.
+//
+// Mirrors the Go side in plugins/sigil/internal/agents/cursor/tags/tags.go
+// `Build`: only emits keys whose values are non-empty, returns `undefined`
+// when no inputs are populated. User-supplied `SIGIL_TAGS` is layered in by
+// the SDK at the client level; the seed/built-in tags merged here take
+// precedence on collisions because the SDK merges per-generation Tags atop
+// client-level Tags.
+
+export interface BuiltinTagInputs {
+  cwd?: string;
+  gitBranch?: string;
+}
+
+export function buildBuiltinTags(
+  in_: BuiltinTagInputs,
+): Record<string, string> | undefined {
+  const out: Record<string, string> = {};
+  if (in_.gitBranch) {
+    out["git.branch"] = in_.gitBranch;
+  }
+  if (in_.cwd) {
+    out.cwd = in_.cwd;
+  }
+  if (Object.keys(out).length === 0) {
+    return undefined;
+  }
+  return out;
+}

--- a/plugins/pi/src/testdata/golden/pi-full-turn.golden.json
+++ b/plugins/pi/src/testdata/golden/pi-full-turn.golden.json
@@ -95,7 +95,8 @@
         "started_at": "<NORMALIZED>",
         "completed_at": "<NORMALIZED>",
         "tags": {
-          "git.branch": "<NORMALIZED>"
+          "git.branch": "<NORMALIZED>",
+          "cwd": "<NORMALIZED>"
         },
         "metadata": {
           "cost_usd": 0.003,

--- a/plugins/sigil/internal/agents/codex/mapper/mapper.go
+++ b/plugins/sigil/internal/agents/codex/mapper/mapper.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/codex/codexlog"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/codex/fragment"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/gitbranch"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/redact"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/timeutil"
 )
@@ -61,6 +62,9 @@ func Map(in Inputs) Mapped {
 	tags := map[string]string{"entrypoint": "codex"}
 	if frag.Cwd != "" {
 		tags["cwd"] = frag.Cwd
+	}
+	if branch := gitbranch.Resolve(frag.Cwd); branch != "" {
+		tags["git.branch"] = branch
 	}
 	if frag.Source != "" {
 		tags["hook.source"] = frag.Source

--- a/plugins/sigil/internal/agents/codex/mapper/mapper_test.go
+++ b/plugins/sigil/internal/agents/codex/mapper/mapper_test.go
@@ -2,6 +2,8 @@ package mapper
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -127,6 +129,62 @@ func TestMapFullRedactsSensitiveJSONKeys(t *testing.T) {
 	}
 	if !json.Valid([]byte(toolResult)) {
 		t.Fatalf("redacted JSON must remain valid: %s", toolResult)
+	}
+}
+
+func TestMapResolvesGitBranchFromCwd(t *testing.T) {
+	// Fragment cwd points at a temp dir containing a `.git/HEAD` symbolic
+	// ref, so the gitbranch resolver finds the branch without shelling
+	// out. Mirrors the cursor tags-package fixture.
+	cases := []struct {
+		name    string
+		headRaw string
+		want    string
+	}{
+		{name: "regular branch", headRaw: "ref: refs/heads/feature/codex\n", want: "feature/codex"},
+		{name: "detached HEAD", headRaw: "abcdef0123456789abcdef0123456789abcdef01\n", want: "abcdef012345"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			gitHead := filepath.Join(root, ".git", "HEAD")
+			if err := os.MkdirAll(filepath.Dir(gitHead), 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.WriteFile(gitHead, []byte(tc.headRaw), 0o644); err != nil {
+				t.Fatalf("write head: %v", err)
+			}
+			f := &fragment.Fragment{
+				SessionID: "sess",
+				TurnID:    "turn",
+				Model:     "gpt-5.5",
+				Cwd:       root,
+			}
+			got := Map(Inputs{Fragment: f, ContentCapture: sigil.ContentCaptureModeMetadataOnly, Now: time.Unix(1, 0)})
+			if got.Generation.Tags["git.branch"] != tc.want {
+				t.Fatalf("git.branch = %q, want %q", got.Generation.Tags["git.branch"], tc.want)
+			}
+			if got.Generation.Tags["cwd"] != root {
+				t.Fatalf("cwd = %q, want %q", got.Generation.Tags["cwd"], root)
+			}
+		})
+	}
+}
+
+func TestMapOmitsGitBranchWhenNoCheckout(t *testing.T) {
+	root := t.TempDir()
+	f := &fragment.Fragment{
+		SessionID: "sess",
+		TurnID:    "turn",
+		Model:     "gpt-5.5",
+		Cwd:       root,
+	}
+	got := Map(Inputs{Fragment: f, ContentCapture: sigil.ContentCaptureModeMetadataOnly, Now: time.Unix(1, 0)})
+	if _, ok := got.Generation.Tags["git.branch"]; ok {
+		t.Fatalf("git.branch should be absent when no .git found; got tags=%+v", got.Generation.Tags)
+	}
+	if got.Generation.Tags["cwd"] != root {
+		t.Fatalf("cwd should still be present; got %q", got.Generation.Tags["cwd"])
 	}
 }
 

--- a/plugins/sigil/internal/agents/copilot/mapper/mapper.go
+++ b/plugins/sigil/internal/agents/copilot/mapper/mapper.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/sigil-sdk/go/sigil"
 
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/copilot/fragment"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/gitbranch"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/redact"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/timeutil"
 )
@@ -189,10 +190,15 @@ func buildTags(frag *fragment.Fragment, session *fragment.Session) map[string]st
 	tags := map[string]string{
 		"entrypoint": "copilot",
 	}
-	if frag.Cwd != "" {
-		tags["cwd"] = frag.Cwd
-	} else if session != nil && session.Cwd != "" {
-		tags["cwd"] = session.Cwd
+	cwd := frag.Cwd
+	if cwd == "" && session != nil {
+		cwd = session.Cwd
+	}
+	if cwd != "" {
+		tags["cwd"] = cwd
+	}
+	if branch := gitbranch.Resolve(cwd); branch != "" {
+		tags["git.branch"] = branch
 	}
 	if frag.Source != "" {
 		tags["hook.source"] = frag.Source

--- a/plugins/sigil/internal/agents/copilot/mapper/mapper_test.go
+++ b/plugins/sigil/internal/agents/copilot/mapper/mapper_test.go
@@ -2,6 +2,8 @@ package mapper
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -130,6 +132,75 @@ func TestMapUsesHookStopReasonWhenSuccessful(t *testing.T) {
 	})
 	if got.Generation.StopReason != "end_turn" {
 		t.Fatalf("StopReason = %q", got.Generation.StopReason)
+	}
+}
+
+func TestMapResolvesGitBranchFromCwd(t *testing.T) {
+	// Fragment cwd points at a temp dir containing a `.git/HEAD` symbolic
+	// ref, so the gitbranch resolver finds the branch without shelling
+	// out. The second case verifies the session.Cwd fallback when the
+	// fragment cwd is empty (copilot's normal resolution).
+	cases := []struct {
+		name               string
+		headRaw            string
+		useSessionFallback bool // place root in Session.Cwd instead of Fragment.Cwd
+		wantBr             string
+	}{
+		{name: "frag.Cwd direct", headRaw: "ref: refs/heads/feature/copilot\n", wantBr: "feature/copilot"},
+		{name: "session.Cwd fallback", headRaw: "ref: refs/heads/sess-branch\n", useSessionFallback: true, wantBr: "sess-branch"},
+		{name: "detached HEAD", headRaw: "abcdef0123456789abcdef0123456789abcdef01\n", wantBr: "abcdef012345"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			gitHead := filepath.Join(root, ".git", "HEAD")
+			if err := os.MkdirAll(filepath.Dir(gitHead), 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.WriteFile(gitHead, []byte(tc.headRaw), 0o644); err != nil {
+				t.Fatalf("write head: %v", err)
+			}
+
+			frag := basicFragment()
+			frag.Model = "gpt-5.4"
+			var session *fragment.Session
+			if tc.useSessionFallback {
+				frag.Cwd = ""
+				session = &fragment.Session{Cwd: root}
+			} else {
+				frag.Cwd = root
+			}
+			got := Map(Inputs{
+				Fragment:       frag,
+				Session:        session,
+				ContentCapture: sigil.ContentCaptureModeMetadataOnly,
+				Now:            fixedTime,
+			})
+			if got.Generation.Tags["git.branch"] != tc.wantBr {
+				t.Fatalf("git.branch = %q, want %q (tags=%+v)", got.Generation.Tags["git.branch"], tc.wantBr, got.Generation.Tags)
+			}
+			if got.Generation.Tags["cwd"] != root {
+				t.Fatalf("cwd = %q, want %q", got.Generation.Tags["cwd"], root)
+			}
+		})
+	}
+}
+
+func TestMapOmitsGitBranchWhenNoCheckout(t *testing.T) {
+	root := t.TempDir()
+	frag := basicFragment()
+	frag.Cwd = root
+	frag.Model = "gpt-5.4"
+	got := Map(Inputs{
+		Fragment:       frag,
+		ContentCapture: sigil.ContentCaptureModeMetadataOnly,
+		Now:            fixedTime,
+	})
+	if _, ok := got.Generation.Tags["git.branch"]; ok {
+		t.Fatalf("git.branch should be absent when no .git found; got %+v", got.Generation.Tags)
+	}
+	if got.Generation.Tags["cwd"] != root {
+		t.Fatalf("cwd should still be present; got %q", got.Generation.Tags["cwd"])
 	}
 }
 

--- a/plugins/sigil/internal/agents/cursor/mapper/mapper.go
+++ b/plugins/sigil/internal/agents/cursor/mapper/mapper.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/cursor/fragment"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/cursor/tags"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/gitbranch"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/timeutil"
 )
 
@@ -105,7 +106,7 @@ func MapFragment(in Inputs) Mapped {
 	tagMap := tags.Build(tags.BuiltinInputs{
 		WorkspaceRoot:     workspaceRoot,
 		Cwd:               firstToolCwd(frag.Tools),
-		GitBranch:         tags.ResolveGitBranch(workspaceRoot),
+		GitBranch:         gitbranch.Resolve(workspaceRoot),
 		IsBackgroundAgent: isBackgroundAgent,
 	})
 

--- a/plugins/sigil/internal/agents/cursor/tags/tags.go
+++ b/plugins/sigil/internal/agents/cursor/tags/tags.go
@@ -1,13 +1,10 @@
 package tags
 
-import (
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
-)
-
 // BuiltinInputs carries the values used to populate built-in tag keys.
+//
+// `git.branch` resolution lives in the shared package
+// plugins/sigil/internal/gitbranch so codex/copilot can reuse it without
+// importing this cursor-scoped package.
 type BuiltinInputs struct {
 	WorkspaceRoot     string
 	Cwd               string
@@ -42,85 +39,4 @@ func Build(in BuiltinInputs) map[string]string {
 		return nil
 	}
 	return out
-}
-
-var (
-	gitDirIndirection = regexp.MustCompile(`(?m)^gitdir:\s*(.+)$`)
-	headRefRegex      = regexp.MustCompile(`^ref:\s*refs/heads/(.+)$`)
-	shaRegex          = regexp.MustCompile(`^[0-9a-fA-F]{7,}$`)
-)
-
-// ResolveGitBranch walks up to 6 parent directories from workspaceRoot looking
-// for a `.git` entry, follows `gitdir:` indirection used by worktrees and
-// submodules, and reads HEAD from the resolved git directory.
-//
-// Returns the branch name on a symbolic ref, the first 12 hex chars on a
-// detached HEAD, or "" on any failure (no `.git` found, unreadable file,
-// unrecognized HEAD content).
-func ResolveGitBranch(workspaceRoot string) string {
-	if workspaceRoot == "" {
-		return ""
-	}
-	current := workspaceRoot
-	for range 6 {
-		gitPath := filepath.Join(current, ".git")
-		if gitDir := resolveGitDir(gitPath); gitDir != "" {
-			return readHeadBranch(gitDir)
-		}
-		parent := filepath.Dir(current)
-		if parent == current {
-			break
-		}
-		current = parent
-	}
-	return ""
-}
-
-// resolveGitDir maps `<workspace>/.git` to the actual git directory. Returns
-// the path when `.git` is a directory, follows `gitdir: <path>` when it's a
-// file (worktrees, submodules), or "" when missing.
-func resolveGitDir(gitPath string) string {
-	info, err := os.Stat(gitPath)
-	if err != nil {
-		return ""
-	}
-	if info.IsDir() {
-		return gitPath
-	}
-	if !info.Mode().IsRegular() {
-		return ""
-	}
-	raw, err := os.ReadFile(gitPath)
-	if err != nil {
-		return ""
-	}
-	m := gitDirIndirection.FindStringSubmatch(strings.TrimSpace(string(raw)))
-	if len(m) < 2 {
-		return ""
-	}
-	target := strings.TrimSpace(m[1])
-	if filepath.IsAbs(target) {
-		return target
-	}
-	return filepath.Clean(filepath.Join(filepath.Dir(gitPath), target))
-}
-
-func readHeadBranch(gitDir string) string {
-	raw, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
-	if err != nil {
-		return ""
-	}
-	content := strings.TrimSpace(string(raw))
-	if m := headRefRegex.FindStringSubmatch(content); len(m) >= 2 {
-		return m[1]
-	}
-	if shaRegex.MatchString(content) {
-		// Detached HEAD: keep the first 12 hex chars to match
-		// `git rev-parse --short=12 HEAD`.
-		if len(content) > 12 {
-			return content[:12]
-		}
-		return content
-	}
-	return ""
 }

--- a/plugins/sigil/internal/agents/cursor/tags/tags_test.go
+++ b/plugins/sigil/internal/agents/cursor/tags/tags_test.go
@@ -1,10 +1,6 @@
 package tags
 
-import (
-	"os"
-	"path/filepath"
-	"testing"
-)
+import "testing"
 
 func TestBuild(t *testing.T) {
 	cases := []struct {
@@ -68,91 +64,6 @@ func TestBuild(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.check(t, Build(tc.in))
-		})
-	}
-}
-
-// writeFile creates a file with the given content under root, ensuring parent
-// dirs exist. Test helper so HEAD/.git fixtures are easy to set up inline.
-func writeFile(t *testing.T, path, content string) {
-	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-}
-
-func TestResolveGitBranch(t *testing.T) {
-	cases := []struct {
-		name  string
-		setup func(t *testing.T) (workspaceRoot string)
-		want  string
-	}{
-		{
-			name: "regular repo",
-			setup: func(t *testing.T) string {
-				root := t.TempDir()
-				writeFile(t, filepath.Join(root, ".git/HEAD"), "ref: refs/heads/feature/fancy\n")
-				return root
-			},
-			want: "feature/fancy",
-		},
-		{
-			name: "detached HEAD returns 12-char prefix",
-			setup: func(t *testing.T) string {
-				root := t.TempDir()
-				writeFile(t, filepath.Join(root, ".git/HEAD"), "abcdef0123456789abcdef0123456789abcdef01\n")
-				return root
-			},
-			want: "abcdef012345",
-		},
-		{
-			name: "gitdir indirection (worktree)",
-			setup: func(t *testing.T) string {
-				root := t.TempDir()
-				actualGitDir := filepath.Join(root, "actual-git")
-				writeFile(t, filepath.Join(root, "wt/.git"), "gitdir: ../actual-git\n")
-				writeFile(t, filepath.Join(actualGitDir, "HEAD"), "ref: refs/heads/wt-branch\n")
-				return filepath.Join(root, "wt")
-			},
-			want: "wt-branch",
-		},
-		{
-			name: "walks up parent directories",
-			setup: func(t *testing.T) string {
-				root := t.TempDir()
-				writeFile(t, filepath.Join(root, ".git/HEAD"), "ref: refs/heads/main\n")
-				deep := filepath.Join(root, "a", "b", "c")
-				if err := os.MkdirAll(deep, 0o755); err != nil {
-					t.Fatalf("mkdir: %v", err)
-				}
-				return deep
-			},
-			want: "main",
-		},
-		{
-			name: "no .git found",
-			setup: func(t *testing.T) string {
-				return t.TempDir()
-			},
-			want: "",
-		},
-		{
-			name: "empty workspace root",
-			setup: func(t *testing.T) string {
-				return ""
-			},
-			want: "",
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			root := tc.setup(t)
-			if got := ResolveGitBranch(root); got != tc.want {
-				t.Errorf("got %q want %q", got, tc.want)
-			}
 		})
 	}
 }

--- a/plugins/sigil/internal/gitbranch/gitbranch.go
+++ b/plugins/sigil/internal/gitbranch/gitbranch.go
@@ -1,0 +1,92 @@
+// Package gitbranch resolves the current git branch for a workspace root
+// without shelling out to `git`. Shared across the codex, copilot, and
+// cursor mappers so non-cursor agents don't import a cursor-scoped package.
+package gitbranch
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var (
+	gitDirIndirection = regexp.MustCompile(`(?m)^gitdir:\s*(.+)$`)
+	headRefRegex      = regexp.MustCompile(`^ref:\s*refs/heads/(.+)$`)
+	shaRegex          = regexp.MustCompile(`^[0-9a-fA-F]{7,}$`)
+)
+
+// Resolve walks up to 6 parent directories from workspaceRoot looking for a
+// `.git` entry, follows `gitdir:` indirection used by worktrees and
+// submodules, and reads HEAD from the resolved git directory.
+//
+// Returns the branch name on a symbolic ref, the first 12 hex chars on a
+// detached HEAD, or "" on any failure (no `.git` found, unreadable file,
+// unrecognized HEAD content).
+func Resolve(workspaceRoot string) string {
+	if workspaceRoot == "" {
+		return ""
+	}
+	current := workspaceRoot
+	for range 6 {
+		gitPath := filepath.Join(current, ".git")
+		if gitDir := resolveGitDir(gitPath); gitDir != "" {
+			return readHeadBranch(gitDir)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+	return ""
+}
+
+// resolveGitDir maps `<workspace>/.git` to the actual git directory. Returns
+// the path when `.git` is a directory, follows `gitdir: <path>` when it's a
+// file (worktrees, submodules), or "" when missing.
+func resolveGitDir(gitPath string) string {
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return ""
+	}
+	if info.IsDir() {
+		return gitPath
+	}
+	if !info.Mode().IsRegular() {
+		return ""
+	}
+	raw, err := os.ReadFile(gitPath)
+	if err != nil {
+		return ""
+	}
+	m := gitDirIndirection.FindStringSubmatch(strings.TrimSpace(string(raw)))
+	if len(m) < 2 {
+		return ""
+	}
+	target := strings.TrimSpace(m[1])
+	if filepath.IsAbs(target) {
+		return target
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(gitPath), target))
+}
+
+func readHeadBranch(gitDir string) string {
+	raw, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
+	if err != nil {
+		return ""
+	}
+	content := strings.TrimSpace(string(raw))
+	if m := headRefRegex.FindStringSubmatch(content); len(m) >= 2 {
+		return m[1]
+	}
+	if shaRegex.MatchString(content) {
+		// Detached HEAD: keep the first 12 hex chars to match
+		// `git rev-parse --short=12 HEAD`.
+		if len(content) > 12 {
+			return content[:12]
+		}
+		return content
+	}
+	return ""
+}

--- a/plugins/sigil/internal/gitbranch/gitbranch_test.go
+++ b/plugins/sigil/internal/gitbranch/gitbranch_test.go
@@ -1,0 +1,92 @@
+package gitbranch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeFile creates a file with the given content under root, ensuring parent
+// dirs exist. Test helper so HEAD/.git fixtures are easy to set up inline.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestResolve(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(t *testing.T) (workspaceRoot string)
+		want  string
+	}{
+		{
+			name: "regular repo",
+			setup: func(t *testing.T) string {
+				root := t.TempDir()
+				writeFile(t, filepath.Join(root, ".git/HEAD"), "ref: refs/heads/feature/fancy\n")
+				return root
+			},
+			want: "feature/fancy",
+		},
+		{
+			name: "detached HEAD returns 12-char prefix",
+			setup: func(t *testing.T) string {
+				root := t.TempDir()
+				writeFile(t, filepath.Join(root, ".git/HEAD"), "abcdef0123456789abcdef0123456789abcdef01\n")
+				return root
+			},
+			want: "abcdef012345",
+		},
+		{
+			name: "gitdir indirection (worktree)",
+			setup: func(t *testing.T) string {
+				root := t.TempDir()
+				actualGitDir := filepath.Join(root, "actual-git")
+				writeFile(t, filepath.Join(root, "wt/.git"), "gitdir: ../actual-git\n")
+				writeFile(t, filepath.Join(actualGitDir, "HEAD"), "ref: refs/heads/wt-branch\n")
+				return filepath.Join(root, "wt")
+			},
+			want: "wt-branch",
+		},
+		{
+			name: "walks up parent directories",
+			setup: func(t *testing.T) string {
+				root := t.TempDir()
+				writeFile(t, filepath.Join(root, ".git/HEAD"), "ref: refs/heads/main\n")
+				deep := filepath.Join(root, "a", "b", "c")
+				if err := os.MkdirAll(deep, 0o755); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				return deep
+			},
+			want: "main",
+		},
+		{
+			name: "no .git found",
+			setup: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			want: "",
+		},
+		{
+			name: "empty workspace root",
+			setup: func(t *testing.T) string {
+				return ""
+			},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := tc.setup(t)
+			if got := Resolve(root); got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
claude-code and cursor already attach `git.branch` and `cwd` to every generation. The other four plugins were inconsistent: codex and copilot sent `cwd` but no `git.branch`, pi sent `git.branch` only and gated it behind `contentCapture=full`, and opencode sent no built-in tags at all.

Bring them up to the same baseline. For Go, the git-branch resolver moves out of the cursor-scoped tags package into the `plugins/sigil/internal/gitbranch` package so codex and copilot can call it without depending on cursor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only export tagging and a refactor of existing git HEAD parsing; no auth, payment, or message-body handling changes.
> 
> **Overview**
> **Standardizes session metadata tags** across plugins so observability can filter by branch and working directory the same way for every agent.
> 
> **Pi** now emits **`git.branch`** and **`cwd`** on every turn (all content-capture modes), via shared **`buildBuiltinTags`**, instead of gating branch on `full` capture only. **OpenCode** adds the same built-in tags per generation, resolves git from a new **`git.ts`** helper, and uses **`PluginInput.directory`** as **`projectDir`** (not **`process.cwd()`**) for **`cwd`** / branch. **Codex** and **Copilot** mappers add **`git.branch`** from fragment/session **`cwd`**; **Cursor** switches to the shared resolver.
> 
> On the Go side, **`ResolveGitBranch`** moves from the cursor-only tags package into **`plugins/sigil/internal/gitbranch`**, with tests relocated. Pi/opencode READMEs gain a **Tagging sessions** section (`--tag`, **`SIGIL_TAGS`**, built-ins overriding user tags on collision).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 383a9ff6e22bd8956d2e914bf6c37e9c34fa7ab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->