### PR TITLE
feat(plugins/sigil): add doctor diagnostic command

### DIFF
--- a/plugins/sigil/README.md
+++ b/plugins/sigil/README.md
@@ -91,4 +91,29 @@ A plugin can only export fields the host agent passes through to it, so individu
 
 ## Troubleshooting
 
-Hooks always exit 0, so problems only show up in the debug log. Set `SIGIL_DEBUG=true` in `~/.config/sigil/config.env` and tail `~/.local/state/sigil/logs/sigil.log`.
+Run `sigil doctor` first. It's a read-only diagnostic that reports both export pipelines, config, and installed host-agent plugins in one place:
+
+```sh
+sigil doctor
+```
+
+The two pipelines are independent and fail independently:
+
+- **Conversations** (the chat transcripts) export over `SIGIL_ENDPOINT` + `SIGIL_AUTH_TENANT_ID` + `SIGIL_AUTH_TOKEN`. The token needs the `sigil:write` scope.
+- **Analytics** (the AI Observability metrics and traces) export over `SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT` (or `OTEL_EXPORTER_OTLP_ENDPOINT`). The token needs `metrics:write` and `traces:write`.
+
+The common failure is conversations showing up while the analytics page stays empty: the OTLP endpoint is unset, or the token lacks the metrics/traces scopes. `sigil doctor` flags that case explicitly and exits non-zero when a pipeline is broken.
+
+Add `--probe` to send a lightweight request to each endpoint and report the HTTP status (a 401/403 on the OTLP path means the token is missing `metrics:write`/`traces:write`):
+
+```sh
+sigil doctor --probe
+```
+
+For support, capture the machine-readable report — it never includes the auth token value:
+
+```sh
+sigil doctor --json
+```
+
+If you need lower-level detail, hooks always exit 0, so problems only show up in the debug log. Set `SIGIL_DEBUG=true` in `~/.config/sigil/config.env` and tail `~/.local/state/sigil/logs/sigil.log`.

--- a/plugins/sigil/cmd/sigil/main.go
+++ b/plugins/sigil/cmd/sigil/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/pi"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/vibe"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/cli"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/doctor"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/dotenv"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/local"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/login"
@@ -78,7 +79,7 @@ func renderLocalBanner(uiURL string) string {
 	return localBannerBox.Render(strings.Join(lines, "\n"))
 }
 
-const usageLine = "usage: sigil login | sigil local start|status|stop | sigil cursor install|uninstall | sigil <agent> hook | sigil <claude|codex|copilot|opencode|pi|vibe> [--local] [--tag key=value]... [-- args...]"
+const usageLine = "usage: sigil login | sigil doctor [--json] [--probe] | sigil local start|status|stop | sigil cursor install|uninstall | sigil <agent> hook | sigil <claude|codex|copilot|opencode|pi|vibe> [--local] [--tag key=value]... [-- args...]"
 
 // version is overridden via -ldflags at build time.
 var version = "dev"
@@ -158,6 +159,13 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 
 	if args[0] == "local" {
 		runLocalCommand(args[1:], stdout, stderr)
+		return
+	}
+
+	// `sigil doctor` is a read-only diagnostic, dispatched before launcher
+	// dispatch like `local`. It owns its own flag parsing.
+	if args[0] == "doctor" {
+		runDoctorCommand(args[1:], stdout, stderr)
 		return
 	}
 
@@ -379,6 +387,23 @@ func runCursorInstall(verb string, stdout, stderr io.Writer) {
 			logger.Printf("auto-login: %v", err)
 			_, _ = fmt.Fprintf(stderr, "sigil: setup failed (%v); run `sigil login` when ready\n", err)
 		}
+	}
+}
+
+// runDoctorCommand handles `sigil doctor`. doctor is strictly read-only and
+// owns its own flag parsing. The OS environment is snapshotted before dotenv
+// is applied so doctor can attribute each value to the OS env vs config.env.
+func runDoctorCommand(args []string, stdout, stderr io.Writer) {
+	osEnv := doctor.SnapshotEnv()
+	dotenv.ApplyEnv("sigil", nil)
+	code := doctor.Run(context.Background(), args, doctor.Params{
+		Version: version,
+		OSEnv:   osEnv,
+		Stdout:  stdout,
+		Stderr:  stderr,
+	})
+	if code != 0 {
+		exit(code)
 	}
 }
 

--- a/plugins/sigil/cmd/sigil/main_test.go
+++ b/plugins/sigil/cmd/sigil/main_test.go
@@ -756,6 +756,56 @@ func TestRun_LocalSubcommand(t *testing.T) {
 	}
 }
 
+func TestRun_DoctorSubcommand(t *testing.T) {
+	cases := []struct {
+		name          string
+		argv          []string
+		env           map[string]string
+		wantExit      *int // nil = no exit
+		wantStdoutHas string
+	}{
+		{name: "unconfigured is healthy and exits 0", argv: []string{"doctor"}, wantStdoutHas: "sigil doctor"},
+		{name: "json mode emits sections", argv: []string{"doctor", "--json"}, wantStdoutHas: `"conversations"`},
+		{
+			name:     "conversations set but no OTLP exits 1",
+			argv:     []string{"doctor"},
+			env:      map[string]string{"SIGIL_ENDPOINT": "https://x", "SIGIL_AUTH_TENANT_ID": "1", "SIGIL_AUTH_TOKEN": "glc_t"},
+			wantExit: intPtr(1),
+		},
+		{name: "bad flag exits 2", argv: []string{"doctor", "--nope"}, wantExit: intPtr(2)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateDotenvHome(t)
+			// Empty PATH so no host-agent binaries are found: the agent sweep
+			// then never shells out, keeping the test hermetic and fast.
+			t.Setenv("PATH", t.TempDir())
+			for _, k := range []string{
+				"SIGIL_ENDPOINT", "SIGIL_AUTH_TENANT_ID", "SIGIL_AUTH_TOKEN",
+				"SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_ENDPOINT",
+			} {
+				t.Setenv(k, "")
+			}
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			var stdout, stderr bytes.Buffer
+			gotExit := withExit(t, func() {
+				run(tc.argv, strings.NewReader(""), &stdout, &stderr)
+			})
+			switch {
+			case tc.wantExit == nil && gotExit != nil:
+				t.Fatalf("exit = %d, want no exit (stderr=%q)", *gotExit, stderr.String())
+			case tc.wantExit != nil && (gotExit == nil || *gotExit != *tc.wantExit):
+				t.Fatalf("exit = %v, want %d", gotExit, *tc.wantExit)
+			}
+			if tc.wantStdoutHas != "" && !strings.Contains(stdout.String(), tc.wantStdoutHas) {
+				t.Fatalf("stdout missing %q: %q", tc.wantStdoutHas, stdout.String())
+			}
+		})
+	}
+}
+
 func intPtr(c int) *int { return &c }
 
 // inProcessDaemon swaps the local daemon for an httptest.Server so the

--- a/plugins/sigil/internal/agents/claudecode/launch.go
+++ b/plugins/sigil/internal/agents/claudecode/launch.go
@@ -100,6 +100,16 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 	return nil
 }
 
+// Status reports whether the sigil-cc plugin is installed for the current
+// working directory. It reuses the read-only pluginInstalled probe and never
+// installs, updates, or writes update-check state — `sigil doctor` relies on
+// this. installed_plugins.json carries no version, so version is always empty
+// (best-effort).
+func Status(_ context.Context) (installed bool, version string, err error) {
+	installed, err = pluginInstalled()
+	return installed, "", err
+}
+
 func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {
 	return runSteps(ctx, bin, w, [][]string{
 		{"plugin", "marketplace", "add", marketplaceRepo},

--- a/plugins/sigil/internal/agents/claudecode/launch_test.go
+++ b/plugins/sigil/internal/agents/claudecode/launch_test.go
@@ -524,3 +524,28 @@ func TestLaunch_RefreshesInstalledPlugin(t *testing.T) {
 		t.Fatalf("expected update stamp: %v", err)
 	}
 }
+
+func TestStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		installed     string // installed_plugins.json content; empty means not written
+		wantInstalled bool
+	}{
+		{name: "installed", installed: `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"user"}]}}`, wantInstalled: true},
+		{name: "not installed", wantInstalled: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.installed != "" {
+				writeInstalled(t, dir, tc.installed)
+			}
+			t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+			installed, version, err := Status(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, tc.wantInstalled, installed)
+			require.Empty(t, version) // installed_plugins.json carries no version
+		})
+	}
+}

--- a/plugins/sigil/internal/agents/codex/launch.go
+++ b/plugins/sigil/internal/agents/codex/launch.go
@@ -106,6 +106,19 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 	return nil
 }
 
+// Status reports whether the sigil-codex plugin is installed and enabled. It
+// reuses the read-only `codex plugin list` probe and never installs, updates,
+// or writes update-check state — `sigil doctor` relies on this. codex's plugin
+// list does not expose a version, so version is always empty (best-effort).
+func Status(ctx context.Context) (installed bool, version string, err error) {
+	bin, err := lookPath("codex")
+	if err != nil {
+		return false, "", err
+	}
+	installed, err = pluginInstalled(ctx, bin)
+	return installed, "", err
+}
+
 func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {
 	return runSteps(ctx, bin, w, [][]string{
 		{"plugin", "marketplace", "add", marketplaceRepo},

--- a/plugins/sigil/internal/agents/codex/launch_test.go
+++ b/plugins/sigil/internal/agents/codex/launch_test.go
@@ -451,3 +451,44 @@ func TestLaunch_RefreshesInstalledPlugin(t *testing.T) {
 		t.Fatalf("expected update stamp: %v", err)
 	}
 }
+
+func TestStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		lookPath      func(string) (string, error)
+		pluginList    func(context.Context, string) ([]byte, error)
+		wantInstalled bool
+		wantErr       bool
+	}{
+		{
+			name:     "installed",
+			lookPath: func(string) (string, error) { return "/usr/local/bin/codex", nil },
+			pluginList: func(context.Context, string) ([]byte, error) {
+				return []byte("  sigil-codex@grafana-sigil (installed, enabled)\n"), nil
+			},
+			wantInstalled: true,
+		},
+		{
+			name:     "not on path",
+			lookPath: func(string) (string, error) { return "", errors.New("not found") },
+			wantErr:  true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withLookPath(t, tc.lookPath)
+			if tc.pluginList != nil {
+				withPluginList(t, tc.pluginList)
+			}
+
+			installed, version, err := Status(context.Background())
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.wantInstalled, installed)
+			require.Empty(t, version) // codex plugin list does not expose a version
+		})
+	}
+}

--- a/plugins/sigil/internal/agents/copilot/launch.go
+++ b/plugins/sigil/internal/agents/copilot/launch.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -275,6 +276,35 @@ func defaultPluginList(ctx context.Context, bin string) ([]byte, error) {
 	return out, nil
 }
 
+// Status reports whether Sigil capture is configured for Copilot. Capture is
+// driven by the shared user-level hooks file the launcher writes (see
+// writeUserHooks), NOT by a plugin — the launcher deliberately avoids
+// registering a plugin and removes any legacy one — so doctor must check for
+// that file. The hooks file has no version, so version is always empty. It
+// never installs, updates, or removes anything — `sigil doctor` relies on this.
+func Status(_ context.Context) (installed bool, version string, err error) {
+	installed, err = HooksInstalled()
+	return installed, "", err
+}
+
+// HooksInstalled reports whether the shared user-level Copilot hooks file that
+// drives capture is present. Read-only, and reuses copilotHooksDir so it
+// honors COPILOT_HOME exactly like the launcher's write path. The CLI need not
+// be on PATH: Copilot Chat in VS Code reads this file without it.
+func HooksInstalled() (bool, error) {
+	dir, err := copilotHooksDir()
+	if err != nil {
+		return false, err
+	}
+	if _, err := os.Stat(filepath.Join(dir, userHooksFileName)); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 // pluginInstalled reports whether `sigil-copilot` is registered in copilot's
 // plugin store. Disabled-state detection is deferred until we confirm
 // copilot's `plugin list` output for a disabled plugin — for now, presence
@@ -284,17 +314,42 @@ func pluginInstalled(ctx context.Context, bin string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	installed, _ := parsePluginListStatus(out)
+	return installed, nil
+}
+
+// parsePluginListStatus scans `copilot plugin list` output for the sigil
+// plugin line and returns whether it's present plus the version from the
+// trailing `(vX.Y.Z)`, if any.
+//
+// Lines look like `  • sigil-copilot (v0.1.0)`. Leading whitespace and the
+// bullet glyph are stripped, then the first remaining token is exact-matched.
+// This rejects the `Installed plugins:` header, a bare bullet line, and suffix
+// collisions like `my-sigil-copilot`.
+func parsePluginListStatus(out []byte) (installed bool, version string) {
 	needle := []byte(PluginName)
-	// Lines look like `  • sigil-copilot (v0.1.0)`. Strip leading whitespace
-	// and the bullet glyph, then exact-match the first remaining token. This
-	// rejects the `Installed plugins:` header, a bare bullet line, and
-	// suffix collisions like `my-sigil-copilot`.
 	for line := range bytes.SplitSeq(out, []byte{'\n'}) {
 		trimmed := bytes.TrimLeft(bytes.TrimSpace(line), "•*-+ \t")
 		fields := bytes.Fields(trimmed)
-		if len(fields) > 0 && bytes.Equal(fields[0], needle) {
-			return true, nil
+		if len(fields) == 0 || !bytes.Equal(fields[0], needle) {
+			continue
 		}
+		return true, parseParenVersion(line)
 	}
-	return false, nil
+	return false, ""
+}
+
+// parseParenVersion extracts the version from a trailing `(vX.Y.Z)` on a
+// plugin list line, returning the version without the leading `v`. Returns ""
+// when no parenthesised version is present.
+func parseParenVersion(line []byte) string {
+	_, afterOpen, ok := bytes.Cut(line, []byte("("))
+	if !ok {
+		return ""
+	}
+	inner, _, ok := bytes.Cut(afterOpen, []byte(")"))
+	if !ok {
+		return ""
+	}
+	return strings.TrimPrefix(strings.TrimSpace(string(inner)), "v")
 }

--- a/plugins/sigil/internal/agents/copilot/launch_test.go
+++ b/plugins/sigil/internal/agents/copilot/launch_test.go
@@ -436,3 +436,52 @@ func TestRenderUserHooks_IsStableAndValid(t *testing.T) {
 	// The shared file must not pin a surface marker.
 	assert.NotContains(t, string(a), "SIGIL_COPILOT_HOOK_SURFACE")
 }
+
+func TestParsePluginListStatus_Version(t *testing.T) {
+	cases := []struct {
+		name          string
+		out           string
+		wantInstalled bool
+		wantVersion   string
+	}{
+		{name: "with version", out: "Installed plugins:\n  • sigil-copilot (v0.1.0)\n", wantInstalled: true, wantVersion: "0.1.0"},
+		{name: "no parenthesised version", out: "Installed plugins:\n  • sigil-copilot\n", wantInstalled: true, wantVersion: ""},
+		{name: "absent", out: "Installed plugins:\n", wantInstalled: false, wantVersion: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			installed, version := parsePluginListStatus([]byte(tc.out))
+			require.Equal(t, tc.wantInstalled, installed)
+			require.Equal(t, tc.wantVersion, version)
+		})
+	}
+}
+
+// Status detects the shared hooks file (capture is hook-based, not plugin
+// based), so it never consults `plugin list` or PATH.
+func TestStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		writeHooks    bool
+		wantInstalled bool
+	}{
+		{name: "hooks file present", writeHooks: true, wantInstalled: true},
+		{name: "hooks file absent", writeHooks: false, wantInstalled: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("COPILOT_HOME", home)
+			if tc.writeHooks {
+				dir := filepath.Join(home, "hooks")
+				require.NoError(t, os.MkdirAll(dir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "sigil.json"), []byte("{}"), 0o644))
+			}
+
+			installed, version, err := Status(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, tc.wantInstalled, installed)
+			require.Empty(t, version, "hooks file carries no version")
+		})
+	}
+}

--- a/plugins/sigil/internal/agents/opencode/launch.go
+++ b/plugins/sigil/internal/agents/opencode/launch.go
@@ -154,9 +154,36 @@ type opencodeConfig struct {
 // in the docs has a trailing comma), so a strict json.Unmarshal would
 // reject perfectly valid configs and trap us in a reinstall loop.
 func pluginInstalled() (bool, error) {
+	_, found, err := installedPluginSource()
+	return found, err
+}
+
+// Status reports whether the @grafana/sigil-opencode plugin is registered in
+// opencode's global config. It reuses the read-only config probe and never
+// installs or updates — `sigil doctor` relies on this. When the registered
+// spec pins a version (`@grafana/sigil-opencode@1.2.3`) that version is
+// reported; an unpinned spec yields an empty (unknown) version.
+func Status(_ context.Context) (installed bool, version string, err error) {
+	source, found, err := installedPluginSource()
+	if err != nil {
+		return false, "", err
+	}
+	if !found {
+		return false, "", nil
+	}
+	return true, versionFromNpmSpec(source), nil
+}
+
+// installedPluginSource reads opencode's global config and returns the plugin
+// entry source string that matches @grafana/sigil-opencode, if any. The config
+// lives in $XDG_CONFIG_HOME/opencode (default $HOME/.config/opencode) as either
+// opencode.json or opencode.jsonc; a missing file means no plugins are
+// configured. The file is parsed as JSONC because opencode's docs allow
+// comments and trailing commas.
+func installedPluginSource() (source string, found bool, err error) {
 	dir, err := configDirFn()
 	if err != nil {
-		return false, err
+		return "", false, err
 	}
 	var (
 		data []byte
@@ -173,24 +200,24 @@ func pluginInstalled() (bool, error) {
 		if errors.Is(err, os.ErrNotExist) {
 			continue
 		}
-		return false, fmt.Errorf("read %s: %w", candidate, err)
+		return "", false, fmt.Errorf("read %s: %w", candidate, err)
 	}
 	if data == nil {
-		return false, nil
+		return "", false, nil
 	}
 	std, err := hujson.Standardize(data)
 	if err != nil {
-		return false, fmt.Errorf("parse %s: %w", path, err)
+		return "", false, fmt.Errorf("parse %s: %w", path, err)
 	}
 	var c opencodeConfig
 	if err := json.Unmarshal(std, &c); err != nil {
-		return false, fmt.Errorf("parse %s: %w", path, err)
+		return "", false, fmt.Errorf("parse %s: %w", path, err)
 	}
 	for _, raw := range c.Plugin {
 		var asString string
 		if err := json.Unmarshal(raw, &asString); err == nil {
 			if sourceMatchesPlugin(asString) {
-				return true, nil
+				return asString, true, nil
 			}
 			continue
 		}
@@ -207,10 +234,22 @@ func pluginInstalled() (bool, error) {
 			continue
 		}
 		if sourceMatchesPlugin(name) {
-			return true, nil
+			return name, true, nil
 		}
 	}
-	return false, nil
+	return "", false, nil
+}
+
+// versionFromNpmSpec returns the pinned version of a scoped npm spec, e.g.
+// "1.2.3" from "@grafana/sigil-opencode@1.2.3". The leading `@` of a scoped
+// package is part of the name, so only a later `@` separates the version.
+// Returns "" for an unpinned spec.
+func versionFromNpmSpec(spec string) string {
+	at := strings.LastIndex(spec, "@")
+	if at <= 0 {
+		return ""
+	}
+	return spec[at+1:]
 }
 
 // sourceMatchesPlugin returns true when a plugin entry identifies the

--- a/plugins/sigil/internal/agents/opencode/launch_test.go
+++ b/plugins/sigil/internal/agents/opencode/launch_test.go
@@ -497,3 +497,41 @@ func envMap(env []string) map[string]string {
 func nopLogger() *log.Logger {
 	return log.New(io.Discard, "", 0)
 }
+
+func TestVersionFromNpmSpec(t *testing.T) {
+	cases := []struct {
+		spec string
+		want string
+	}{
+		{spec: "@grafana/sigil-opencode", want: ""},
+		{spec: "@grafana/sigil-opencode@0.6.0", want: "0.6.0"},
+		{spec: "@grafana/sigil-opencode@next", want: "next"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.spec, func(t *testing.T) {
+			require.Equal(t, tc.want, versionFromNpmSpec(tc.spec))
+		})
+	}
+}
+
+func TestStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        string
+		wantInstalled bool
+		wantVersion   string
+	}{
+		{name: "installed", config: `{"plugin":["@grafana/sigil-opencode@0.6.0"]}`, wantInstalled: true, wantVersion: "0.6.0"},
+		{name: "not installed", config: `{"plugin":["other-plugin"]}`, wantInstalled: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withConfig(t, tc.config)
+
+			installed, version, err := Status(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, tc.wantInstalled, installed)
+			require.Equal(t, tc.wantVersion, version)
+		})
+	}
+}

--- a/plugins/sigil/internal/agents/pi/launch.go
+++ b/plugins/sigil/internal/agents/pi/launch.go
@@ -118,59 +118,97 @@ type piSettings struct {
 // A missing settings file means that scope is unused — treat as not
 // installed in that scope and move on.
 func pluginInstalled() (bool, error) {
+	_, found, err := installedPluginSource()
+	return found, err
+}
+
+// Status reports whether the @grafana/sigil-pi extension is registered in pi's
+// settings. It reuses the read-only settings probe and never installs — `sigil
+// doctor` relies on this. When the registered source is a pinned npm spec
+// (`npm:@grafana/sigil-pi@0.1.1`) that version is reported; bare specs and
+// local-path installs yield an empty (unknown) version.
+func Status(_ context.Context) (installed bool, version string, err error) {
+	source, found, err := installedPluginSource()
+	if err != nil {
+		return false, "", err
+	}
+	if !found {
+		return false, "", nil
+	}
+	return true, versionFromPiSource(source), nil
+}
+
+// installedPluginSource returns the settings source string registering the
+// @grafana/sigil-pi extension, checking the global settings first and then the
+// project-scoped settings (<cwd>/.pi/settings.json, written by `pi install -l`).
+func installedPluginSource() (source string, found bool, err error) {
 	globalPath, err := settingsPath()
 	if err != nil {
-		return false, err
+		return "", false, err
 	}
-	if found, err := readSettingsAndCheck(globalPath); err != nil {
-		return false, err
+	if src, found, err := readSettingsAndCheck(globalPath); err != nil {
+		return "", false, err
 	} else if found {
-		return true, nil
+		return src, true, nil
 	}
 
-	// Project-scoped install (`pi install -l`) writes to <cwd>/.pi/settings.json.
 	// Pi only consults the literal cwd, no parent walking, so we mirror that.
 	// A failure to resolve cwd is exceptionally rare; treat it as "no project
 	// settings available" rather than blocking the launch.
 	projectPath, err := projectSettingsPath()
 	if err != nil {
-		return false, nil
+		return "", false, nil
 	}
 	return readSettingsAndCheck(projectPath)
 }
 
-// readSettingsAndCheck loads one pi settings file and returns whether the
-// @grafana/sigil-pi extension is registered in it. A missing file is not
-// an error — that scope is just unused.
-func readSettingsAndCheck(path string) (bool, error) {
+// readSettingsAndCheck loads one pi settings file and returns the source
+// string registering the @grafana/sigil-pi extension, if any. A missing file
+// is not an error — that scope is just unused.
+func readSettingsAndCheck(path string) (source string, found bool, err error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return false, nil
+			return "", false, nil
 		}
-		return false, fmt.Errorf("read %s: %w", path, err)
+		return "", false, fmt.Errorf("read %s: %w", path, err)
 	}
 	var s piSettings
 	if err := json.Unmarshal(data, &s); err != nil {
-		return false, fmt.Errorf("parse %s: %w", path, err)
+		return "", false, fmt.Errorf("parse %s: %w", path, err)
 	}
 	settingsDir := filepath.Dir(path)
 	for _, raw := range s.Packages {
-		var source string
-		if err := json.Unmarshal(raw, &source); err != nil {
+		var src string
+		if err := json.Unmarshal(raw, &src); err != nil {
 			var asObj struct {
 				Source string `json:"source"`
 			}
 			if err := json.Unmarshal(raw, &asObj); err != nil {
 				continue
 			}
-			source = asObj.Source
+			src = asObj.Source
 		}
-		if sourceMatchesPlugin(source, settingsDir) {
-			return true, nil
+		if sourceMatchesPlugin(src, settingsDir) {
+			return src, true, nil
 		}
 	}
-	return false, nil
+	return "", false, nil
+}
+
+// versionFromPiSource returns the pinned version of an npm-spec source, e.g.
+// "0.1.1" from "npm:@grafana/sigil-pi@0.1.1". Bare specs and local-path
+// sources yield "".
+func versionFromPiSource(source string) string {
+	after, ok := strings.CutPrefix(source, npmPrefix)
+	if !ok {
+		return ""
+	}
+	at := strings.LastIndex(after, "@")
+	if at <= 0 {
+		return ""
+	}
+	return after[at+1:]
 }
 
 // sourceMatchesPlugin returns true when a pi settings source identifies the

--- a/plugins/sigil/internal/agents/pi/launch_test.go
+++ b/plugins/sigil/internal/agents/pi/launch_test.go
@@ -577,3 +577,54 @@ func withExecFn(t *testing.T, fn func(string, []string, []string) error) {
 func nopLogger() *log.Logger {
 	return log.New(io.Discard, "", 0)
 }
+
+func TestVersionFromPiSource(t *testing.T) {
+	cases := []struct {
+		source string
+		want   string
+	}{
+		{source: "npm:@grafana/sigil-pi", want: ""},
+		{source: "npm:@grafana/sigil-pi@0.1.1", want: "0.1.1"},
+		{source: "npm:@grafana/sigil-pi@1.0.0-rc.3", want: "1.0.0-rc.3"},
+		{source: "npm:@grafana/sigil-pi@next", want: "next"},
+		{source: "./local-plugin", want: ""},
+		{source: "/abs/path", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.source, func(t *testing.T) {
+			if got := versionFromPiSource(tc.source); got != tc.want {
+				t.Fatalf("versionFromPiSource(%q) = %q, want %q", tc.source, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		settings      string
+		wantInstalled bool
+		wantVersion   string
+	}{
+		{name: "installed reports version", settings: `{"packages":["npm:@grafana/sigil-pi@0.1.1"]}`, wantInstalled: true, wantVersion: "0.1.1"},
+		{name: "not installed", settings: `{"packages":[]}`, wantInstalled: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("PI_CODING_AGENT_DIR", dir)
+			writeSettings(t, dir, tc.settings)
+
+			installed, version, err := Status(context.Background())
+			if err != nil {
+				t.Fatalf("Status err: %v", err)
+			}
+			if installed != tc.wantInstalled {
+				t.Fatalf("installed = %v, want %v", installed, tc.wantInstalled)
+			}
+			if version != tc.wantVersion {
+				t.Fatalf("version = %q, want %q", version, tc.wantVersion)
+			}
+		})
+	}
+}

--- a/plugins/sigil/internal/doctor/agents.go
+++ b/plugins/sigil/internal/doctor/agents.go
@@ -1,0 +1,114 @@
+package doctor
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/claudecode"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/codex"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/copilot"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/opencode"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/agents/pi"
+)
+
+// statusFn is the non-mutating per-agent probe each launcher package exposes.
+// It returns install state and a best-effort version, and must not install,
+// update, or write any state.
+type statusFn func(ctx context.Context) (installed bool, version string, err error)
+
+// agentProbe describes how doctor detects and probes one host agent.
+type agentProbe struct {
+	// name is the CLI/host name shown in the report.
+	name string
+	// bin is the executable looked up on PATH.
+	bin string
+	// status is the package's read-only install probe, or nil for hook-only
+	// agents (cursor) that the sigil binary never installs.
+	status statusFn
+	// configBased is true when status reads install state from files and needs
+	// no binary on PATH (claude, opencode, pi, copilot). For these, doctor
+	// reports install state even when the CLI is absent. CLI-dependent probes
+	// (codex) shell out to the binary, so they're skipped when it's missing.
+	configBased bool
+	// notInstalledLabel overrides the default "plugin not installed" wording
+	// for agents whose capture isn't plugin-based (copilot uses hooks).
+	notInstalledLabel string
+	// note annotates the agent in the report.
+	note string
+}
+
+// Test seam.
+var lookPath = exec.LookPath
+
+// agentProbes is the detection/probe table. cursor is hook-only (no launcher),
+// so it has no install probe: its capture is wired into Cursor's own hook
+// settings, and its effective version is the sigil binary's.
+var agentProbes = []agentProbe{
+	{name: "claude", bin: "claude", status: claudecode.Status, configBased: true},
+	{name: "codex", bin: "codex", status: codex.Status},
+	{name: "copilot", bin: "copilot", status: copilot.Status, configBased: true, notInstalledLabel: "not configured", note: "hook-based"},
+	{name: "opencode", bin: "opencode", status: opencode.Status, configBased: true},
+	{name: "pi", bin: "pi", status: pi.Status, configBased: true},
+	{name: "cursor", bin: "cursor", status: nil, note: "hook-based; configured in Cursor settings"},
+}
+
+// defaultCollectAgents runs the PATH sweep and per-agent read-only status
+// probe. sigilVersion is reported as cursor's version (its hooks call the
+// sigil binary, so they move together).
+func defaultCollectAgents(ctx context.Context, sigilVersion string) []AgentStatus {
+	out := make([]AgentStatus, 0, len(agentProbes))
+	for _, probe := range agentProbes {
+		out = append(out, probeAgent(ctx, probe, sigilVersion))
+	}
+	return out
+}
+
+func probeAgent(ctx context.Context, probe agentProbe, sigilVersion string) AgentStatus {
+	a := AgentStatus{Name: probe.name, Note: probe.note, notInstalledLabel: probe.notInstalledLabel}
+	_, lookErr := lookPath(probe.bin)
+	a.OnPath = lookErr == nil
+
+	// Hook-only agent (cursor): no install probe, detection is PATH presence.
+	// Capture is configured in the host's own settings, which the sigil binary
+	// doesn't manage, so report it as present with the sigil binary version.
+	if probe.status == nil {
+		if !a.OnPath {
+			a.Health = HealthSkipped
+			return a
+		}
+		a.HookBased = true
+		a.Version = sigilVersion
+		a.Health = HealthOK
+		return a
+	}
+
+	// A CLI-dependent probe (codex, copilot) shells out to the binary to read
+	// install state, so skip it when the binary is absent. Config-based probes
+	// (claude, opencode, pi) read state from files and run regardless of PATH.
+	if !a.OnPath && !probe.configBased {
+		a.Health = HealthSkipped
+		return a
+	}
+
+	installed, version, err := probe.status(ctx)
+	if err != nil {
+		a.Health = HealthWarn
+		a.Note = appendNote(a.Note, "install state unknown: "+err.Error())
+		return a
+	}
+	a.Installed = installed
+	a.Version = version
+	if installed {
+		a.Health = HealthOK
+	} else {
+		a.Health = HealthWarn
+	}
+	return a
+}
+
+func appendNote(existing, extra string) string {
+	if existing == "" {
+		return extra
+	}
+	return existing + "; " + extra
+}

--- a/plugins/sigil/internal/doctor/agents_test.go
+++ b/plugins/sigil/internal/doctor/agents_test.go
@@ -1,0 +1,60 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestDefaultCollectAgents(t *testing.T) {
+	prevLook, prevProbes := lookPath, agentProbes
+	t.Cleanup(func() { lookPath, agentProbes = prevLook, prevProbes })
+
+	onPath := map[string]bool{"claude": true, "errcli": true, "cursor": true}
+	lookPath = func(name string) (string, error) {
+		if onPath[name] {
+			return "/usr/local/bin/" + name, nil
+		}
+		return "", errors.New("not found on PATH")
+	}
+
+	agentProbes = []agentProbe{
+		{name: "claude", bin: "claude", status: func(context.Context) (bool, string, error) { return true, "0.3.0", nil }},
+		{name: "codex", bin: "codex", status: func(context.Context) (bool, string, error) {
+			t.Error("a CLI-dependent status must not run for an agent that isn't on PATH")
+			return false, "", nil
+		}},
+		// A config-based agent reads install state from files, so its probe
+		// runs even when the binary is absent from PATH. notInstalledLabel must
+		// propagate from the probe table into the status.
+		{name: "cfgcli", bin: "cfgcli", configBased: true, notInstalledLabel: "not configured", status: func(context.Context) (bool, string, error) { return true, "2.0.0", nil }},
+		{name: "errcli", bin: "errcli", status: func(context.Context) (bool, string, error) { return false, "", errors.New("probe boom") }},
+		{name: "cursor", bin: "cursor", status: nil, note: "hook-based"},
+	}
+
+	got := defaultCollectAgents(context.Background(), "9.9.9")
+	byName := map[string]AgentStatus{}
+	for _, a := range got {
+		byName[a.Name] = a
+	}
+
+	if a := byName["claude"]; !a.OnPath || !a.Installed || a.Version != "0.3.0" || a.Health != HealthOK {
+		t.Fatalf("claude = %+v", a)
+	}
+	if a := byName["codex"]; a.OnPath || a.Health != HealthSkipped {
+		t.Fatalf("codex = %+v, want not-on-path/skipped", a)
+	}
+	if a := byName["cfgcli"]; a.OnPath || !a.Installed || a.Version != "2.0.0" || a.Health != HealthOK {
+		t.Fatalf("cfgcli = %+v, want not-on-path but installed/ok via config probe", a)
+	} else if a.notInstalledLabel != "not configured" {
+		t.Fatalf("cfgcli notInstalledLabel = %q, want propagated from probe", a.notInstalledLabel)
+	}
+	if a := byName["errcli"]; !a.OnPath || a.Health != HealthWarn || a.Installed {
+		t.Fatalf("errcli = %+v, want on-path/warn/not-installed", a)
+	} else if a.Note == "" {
+		t.Fatalf("errcli note should record the probe error")
+	}
+	if a := byName["cursor"]; !a.OnPath || !a.HookBased || a.Version != "9.9.9" || a.Health != HealthOK {
+		t.Fatalf("cursor = %+v, want on-path/hook-based/sigil-version/ok", a)
+	}
+}

--- a/plugins/sigil/internal/doctor/doctor.go
+++ b/plugins/sigil/internal/doctor/doctor.go
@@ -1,0 +1,591 @@
+// Package doctor implements `sigil doctor`: a read-only diagnostic that
+// reports the health of the two export pipelines (conversations and
+// analytics), config validity, and installed host-agent plugins in one place.
+//
+// The command never installs, updates, or otherwise mutates host-agent
+// plugin state, and never writes update-check stamps. It only reads.
+//
+// The conversations pipeline (generation export) and the analytics pipeline
+// (OTLP metrics + traces) are independent: they use different endpoints and
+// different token scopes. A user can have conversations working while
+// analytics is silently dead because the OTLP endpoint is unset or the token
+// lacks metrics:write/traces:write. Doctor surfaces both pipelines separately
+// so that split is visible.
+package doctor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/dotenv"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/envconfig"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/updatecheck"
+)
+
+// Health is the per-section verdict. error is the only level that drives a
+// non-zero exit code; warning is advisory (e.g. a host agent isn't installed)
+// and ok/skipped are informational.
+type Health string
+
+const (
+	HealthOK      Health = "ok"
+	HealthWarn    Health = "warning"
+	HealthError   Health = "error"
+	HealthSkipped Health = "skipped"
+)
+
+// Value sources for a resolved env var.
+const (
+	sourceEnv    = "env"
+	sourceConfig = "config.env"
+)
+
+// trackedKeys are the env vars doctor attributes to a source (OS env vs
+// config.env). SnapshotEnv records their OS-env values before dotenv merge so
+// Collect can tell where each effective value came from.
+var trackedKeys = []string{
+	"SIGIL_ENDPOINT",
+	"SIGIL_INSECURE",
+	"SIGIL_AUTH_TENANT_ID",
+	"SIGIL_AUTH_TOKEN",
+	"SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_HEADERS",
+	"SIGIL_OTEL_AUTH_TOKEN",
+	"SIGIL_CONTENT_CAPTURE_MODE",
+	"SIGIL_TAGS",
+	"SIGIL_AUTO_UPDATE",
+}
+
+// Options are the parsed doctor flags.
+type Options struct {
+	JSON    bool
+	Probe   bool
+	NoColor bool
+}
+
+// Params carry the per-invocation inputs Run needs. OSEnv is the OS
+// environment snapshot taken before dotenv was applied (see SnapshotEnv).
+type Params struct {
+	Version string
+	OSEnv   map[string]string
+	Stdout  io.Writer
+	Stderr  io.Writer
+}
+
+// Report is the full diagnostic. Field names and the `status` strings are the
+// stable contract for `--json` / support tooling.
+type Report struct {
+	Sigil              SigilSection         `json:"sigil"`
+	Config             ConfigSection        `json:"config"`
+	Conversations      ConversationsSection `json:"conversations"`
+	Analytics          AnalyticsSection     `json:"analytics"`
+	Agents             []AgentStatus        `json:"agents"`
+	AutoUpdateDisabled bool                 `json:"auto_update_disabled"`
+}
+
+// SigilSection reports the binary's build version.
+type SigilSection struct {
+	Version string `json:"version"`
+}
+
+// envValue is a non-secret resolved env var: endpoints and tenant IDs are safe
+// to print, so Value is populated.
+type envValue struct {
+	Set    bool   `json:"set"`
+	Value  string `json:"value,omitempty"`
+	Source string `json:"source,omitempty"`
+}
+
+// tokenValue is a resolved secret. The value is never recorded; only presence
+// and an optional non-sensitive scheme prefix (e.g. "glc_") are.
+type tokenValue struct {
+	Set    bool   `json:"set"`
+	Prefix string `json:"prefix,omitempty"`
+	Source string `json:"source,omitempty"`
+}
+
+// ConfigSection reports config.env validity and the resolved feature settings
+// that every agent hook reads (content capture, guards, tags).
+type ConfigSection struct {
+	Path                string            `json:"path"`
+	Exists              bool              `json:"exists"`
+	DisallowedKeys      []string          `json:"disallowed_keys,omitempty"`
+	ContentCaptureMode  string            `json:"content_capture_mode"`
+	ContentModeFellBack bool              `json:"content_mode_fell_back"`
+	GuardsEnabled       bool              `json:"guards_enabled"`
+	GuardsTimeoutMs     int               `json:"guards_timeout_ms"`
+	GuardsFailOpen      bool              `json:"guards_fail_open"`
+	GuardsFellBack      bool              `json:"guards_fell_back,omitempty"`
+	Tags                map[string]string `json:"tags,omitempty"`
+	TagsSource          string            `json:"tags_source,omitempty"`
+	Health              Health            `json:"status"`
+	Messages            []string          `json:"messages,omitempty"`
+}
+
+// ConversationsSection reports the generation-export pipeline.
+type ConversationsSection struct {
+	Endpoint envValue     `json:"endpoint"`
+	TenantID envValue     `json:"tenant_id"`
+	Token    tokenValue   `json:"token"`
+	Health   Health       `json:"status"`
+	Messages []string     `json:"messages,omitempty"`
+	Probe    *ProbeResult `json:"probe,omitempty"`
+}
+
+func (s ConversationsSection) configured() bool {
+	return s.Endpoint.Set && s.TenantID.Set && s.Token.Set
+}
+
+// AnalyticsSection reports the OTLP metrics + traces pipeline.
+type AnalyticsSection struct {
+	Endpoint    envValue        `json:"endpoint"`
+	EndpointVar string          `json:"endpoint_var,omitempty"`
+	Health      Health          `json:"status"`
+	Messages    []string        `json:"messages,omitempty"`
+	Probe       *AnalyticsProbe `json:"probe,omitempty"`
+}
+
+// AgentStatus reports one host agent's detection + install state. HookBased is
+// set for agents the sigil binary never installs (cursor): their capture is
+// wired into the host's own hook settings, so install state isn't something
+// doctor can read.
+type AgentStatus struct {
+	Name      string `json:"name"`
+	OnPath    bool   `json:"on_path"`
+	Installed bool   `json:"installed"`
+	HookBased bool   `json:"hook_based,omitempty"`
+	Version   string `json:"version,omitempty"`
+	Note      string `json:"note,omitempty"`
+	Health    Health `json:"status"`
+
+	// notInstalledLabel overrides the human "plugin not installed" wording for
+	// non-plugin agents (copilot). Human-only; not part of the JSON contract.
+	notInstalledLabel string
+}
+
+// ProbeResult is one HTTP probe outcome.
+type ProbeResult struct {
+	URL        string `json:"url,omitempty"`
+	StatusCode int    `json:"status_code,omitempty"`
+	OK         bool   `json:"ok"`
+	Message    string `json:"message,omitempty"`
+}
+
+func (p *ProbeResult) authFailure() bool {
+	return p != nil && (p.StatusCode == 401 || p.StatusCode == 403)
+}
+
+// unreachable reports a probe outcome that means a configured pipeline can't
+// deliver: a transport error (no HTTP response, e.g. DNS failure, connection
+// refused, or timeout) or a 5xx server error. 401/403 are handled separately
+// as a scope problem (authFailure). Other 4xx are not treated as broken because
+// the minimal probe body ({}) can draw a benign 400/415 from an endpoint that
+// validates the body before auth.
+func (p *ProbeResult) unreachable() bool {
+	return p != nil && (p.StatusCode == 0 || p.StatusCode >= 500)
+}
+
+// AnalyticsProbe holds the per-signal OTLP probe results.
+type AnalyticsProbe struct {
+	Metrics *ProbeResult `json:"metrics,omitempty"`
+	Traces  *ProbeResult `json:"traces,omitempty"`
+}
+
+// Test seams. Production points at the default implementations; tests swap
+// these to avoid shelling out or hitting the network.
+var (
+	collectAgents        = defaultCollectAgents
+	probeConversationsFn = defaultProbeConversations
+	probeOTLPFn          = defaultProbeOTLP
+)
+
+// SnapshotEnv records the OS-env values of the tracked keys. Call it before
+// dotenv.ApplyEnv so Collect can attribute each effective value to the OS
+// environment vs config.env.
+func SnapshotEnv() map[string]string {
+	m := make(map[string]string, len(trackedKeys))
+	for _, k := range trackedKeys {
+		if v, ok := os.LookupEnv(k); ok && strings.TrimSpace(v) != "" {
+			m[k] = v
+		}
+	}
+	return m
+}
+
+// Run parses flags, collects the report, renders it, and returns the exit
+// code: 0 healthy, 1 when any section is broken, 2 on a flag error.
+func Run(ctx context.Context, args []string, p Params) int {
+	opts, err := parseFlags(args, p.Stderr)
+	if err != nil {
+		return 2
+	}
+	report := Collect(ctx, opts, p)
+	if opts.JSON {
+		if err := renderJSON(p.Stdout, report); err != nil {
+			_, _ = fmt.Fprintf(p.Stderr, "sigil: doctor: %v\n", err)
+			return 2
+		}
+	} else {
+		renderHuman(p.Stdout, report, !opts.NoColor, opts.Probe)
+	}
+	return report.exitCode()
+}
+
+func parseFlags(args []string, stderr io.Writer) (Options, error) {
+	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		_, _ = fmt.Fprintln(stderr, "usage: sigil doctor [--json] [--probe] [--no-color]")
+		_, _ = fmt.Fprintln(stderr)
+		_, _ = fmt.Fprintln(stderr, "Report the health of the conversations and analytics export pipelines,")
+		_, _ = fmt.Fprintln(stderr, "config validity, and installed host-agent plugins.")
+		_, _ = fmt.Fprintln(stderr)
+		_, _ = fmt.Fprintln(stderr, "  --json       emit a stable JSON report (for support tooling)")
+		_, _ = fmt.Fprintln(stderr, "  --probe      send live requests to the endpoints and report HTTP status")
+		_, _ = fmt.Fprintln(stderr, "  --no-color   disable ANSI colors")
+	}
+	var opts Options
+	var online bool
+	fs.BoolVar(&opts.JSON, "json", false, "emit a JSON report")
+	fs.BoolVar(&opts.Probe, "probe", false, "send live requests to the endpoints")
+	fs.BoolVar(&online, "online", false, "alias for --probe")
+	fs.BoolVar(&opts.NoColor, "no-color", false, "disable ANSI colors")
+	if err := fs.Parse(args); err != nil {
+		return Options{}, err
+	}
+	if fs.NArg() > 0 {
+		fs.Usage()
+		return Options{}, fmt.Errorf("unexpected arguments: %v", fs.Args())
+	}
+	opts.Probe = opts.Probe || online
+	return opts, nil
+}
+
+// Collect builds the report. It reads config.env and the env snapshot but
+// performs no mutations. Network probes run only when opts.Probe is set.
+func Collect(ctx context.Context, opts Options, p Params) *Report {
+	fileEnv := dotenv.LoadDotenv(dotenv.FilePath("sigil"), nil)
+	osEnv := p.OSEnv
+	if osEnv == nil {
+		osEnv = map[string]string{}
+	}
+
+	r := &Report{}
+	r.Sigil = SigilSection{Version: normalizeVersion(p.Version)}
+	r.Conversations = collectConversations(osEnv, fileEnv)
+	r.Analytics = collectAnalytics(osEnv, fileEnv, r.Conversations.configured())
+	r.Config = collectConfig(osEnv, fileEnv)
+	r.Agents = collectAgents(ctx, r.Sigil.Version)
+	r.AutoUpdateDisabled = updatecheck.Disabled()
+
+	if opts.Probe {
+		runProbes(ctx, r, osEnv, fileEnv)
+	}
+	return r
+}
+
+// exitCode is 1 when any pipeline or config section is broken, else 0. The
+// agent section is informational and never fails the command.
+func (r *Report) exitCode() int {
+	healths := []Health{r.Conversations.Health, r.Analytics.Health, r.Config.Health}
+	if slices.Contains(healths, HealthError) {
+		return 1
+	}
+	return 0
+}
+
+func collectConversations(osEnv, fileEnv map[string]string) ConversationsSection {
+	endpoint := resolveEnv("SIGIL_ENDPOINT", osEnv, fileEnv)
+	tenant := resolveEnv("SIGIL_AUTH_TENANT_ID", osEnv, fileEnv)
+	token := resolveEnv("SIGIL_AUTH_TOKEN", osEnv, fileEnv)
+
+	sec := ConversationsSection{
+		Endpoint: endpoint.envValue(),
+		TenantID: tenant.envValue(),
+		Token:    token.tokenValue(),
+	}
+	switch boolToInt(endpoint.set) + boolToInt(tenant.set) + boolToInt(token.set) {
+	case 3:
+		sec.Health = HealthOK
+	case 0:
+		sec.Health = HealthWarn
+		sec.Messages = append(sec.Messages,
+			"not configured — run `sigil login` or set SIGIL_ENDPOINT, SIGIL_AUTH_TENANT_ID and SIGIL_AUTH_TOKEN")
+	default:
+		sec.Health = HealthError
+		var missing []string
+		if !endpoint.set {
+			missing = append(missing, "SIGIL_ENDPOINT")
+		}
+		if !tenant.set {
+			missing = append(missing, "SIGIL_AUTH_TENANT_ID")
+		}
+		if !token.set {
+			missing = append(missing, "SIGIL_AUTH_TOKEN")
+		}
+		sec.Messages = append(sec.Messages, "incomplete credentials; missing "+strings.Join(missing, ", "))
+	}
+	return sec
+}
+
+func collectAnalytics(osEnv, fileEnv map[string]string, conversationsConfigured bool) AnalyticsSection {
+	sigilOTLP := resolveEnv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", osEnv, fileEnv)
+	stdOTLP := resolveEnv("OTEL_EXPORTER_OTLP_ENDPOINT", osEnv, fileEnv)
+
+	sec := AnalyticsSection{}
+	switch {
+	case sigilOTLP.set:
+		sec.Endpoint = sigilOTLP.envValue()
+		sec.EndpointVar = "SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT"
+	case stdOTLP.set:
+		sec.Endpoint = stdOTLP.envValue()
+		sec.EndpointVar = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	case conversationsConfigured:
+		// The headline failure: conversations export fine, but analytics
+		// (the AI Observability page) stays empty because no OTLP endpoint
+		// is configured. dotenv.HasCredentials passes here, so nothing else
+		// the binary does today would flag this.
+		sec.Health = HealthError
+		sec.Messages = append(sec.Messages,
+			"no OTLP endpoint set — metrics and traces will not be exported even though conversations are configured. "+
+				"Set SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT (e.g. https://otlp-gateway-prod-<region>.grafana.net/otlp).")
+		return sec
+	default:
+		sec.Health = HealthWarn
+		sec.Messages = append(sec.Messages, "no OTLP endpoint set; analytics export is disabled")
+		return sec
+	}
+
+	// The endpoint is set, but OTLP export still needs auth (unless the
+	// collector is open). Mirror internal/otel: auth is an explicit
+	// Authorization entry in OTEL_EXPORTER_OTLP_HEADERS, or synthesized from
+	// SIGIL_AUTH_TENANT_ID + (SIGIL_OTEL_AUTH_TOKEN or SIGIL_AUTH_TOKEN). Don't
+	// report ok when none of those resolve, otherwise doctor shows a healthy
+	// analytics pipeline that exports nothing.
+	if analyticsAuthResolvable(osEnv, fileEnv) {
+		sec.Health = HealthOK
+	} else {
+		sec.Health = HealthWarn
+		sec.Messages = append(sec.Messages,
+			"OTLP endpoint set but no auth resolved — set SIGIL_AUTH_TENANT_ID and SIGIL_OTEL_AUTH_TOKEN "+
+				"(or SIGIL_AUTH_TOKEN), or an Authorization entry in OTEL_EXPORTER_OTLP_HEADERS. "+
+				"Export will be unauthenticated unless the collector is open.")
+	}
+	return sec
+}
+
+// analyticsAuthResolvable reports whether the OTLP exporter would have a
+// credential: an explicit Authorization header, or a tenant + token pair that
+// internal/otel turns into Basic auth. It does not validate the credential —
+// `--probe` does that against the live endpoint.
+func analyticsAuthResolvable(osEnv, fileEnv map[string]string) bool {
+	if headersHaveAuthorization(resolveEnv("OTEL_EXPORTER_OTLP_HEADERS", osEnv, fileEnv).value) {
+		return true
+	}
+	tenant := resolveEnv("SIGIL_AUTH_TENANT_ID", osEnv, fileEnv)
+	token := resolveEnv("SIGIL_OTEL_AUTH_TOKEN", osEnv, fileEnv)
+	if !token.set {
+		token = resolveEnv("SIGIL_AUTH_TOKEN", osEnv, fileEnv)
+	}
+	return tenant.set && token.set
+}
+
+// headersHaveAuthorization parses the OTEL_EXPORTER_OTLP_HEADERS value
+// (comma-separated key=value pairs) and reports whether it carries an
+// Authorization entry with a non-empty value, matching how internal/otel
+// parses headers: it drops pairs whose key or value is empty after trimming,
+// so an Authorization with no value exports unauthenticated.
+func headersHaveAuthorization(raw string) bool {
+	for pair := range strings.SplitSeq(raw, ",") {
+		key, value, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(key), "Authorization") && strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
+	path := dotenv.FilePath("sigil")
+	sec := ConfigSection{Path: path, Health: HealthOK}
+	if _, err := os.Stat(path); err == nil {
+		sec.Exists = true
+	}
+	sec.DisallowedKeys = disallowedKeys(path)
+
+	// ResolveContentMode logs a line when it falls back from an invalid value,
+	// so a capturing logger doubles as the fell-back signal.
+	var buf bytes.Buffer
+	mode := envconfig.ResolveContentMode(log.New(&buf, "", 0))
+	sec.ContentCaptureMode = mode.String()
+	sec.ContentModeFellBack = buf.Len() > 0
+
+	// Guards are the shared pre-tool-call enforcement flags every agent hook
+	// reads via envconfig.ResolveGuards. They default off, so surface the
+	// effective values to confirm whether guards actually run and with what
+	// timeout / fail mode. ResolveGuards logs on an invalid value, so a
+	// capturing logger doubles as the fell-back signal, same as content mode.
+	var guardBuf bytes.Buffer
+	guards := envconfig.ResolveGuards(log.New(&guardBuf, "", 0))
+	sec.GuardsEnabled = guards.Enabled
+	sec.GuardsTimeoutMs = guards.TimeoutMs
+	sec.GuardsFailOpen = guards.FailOpen
+	sec.GuardsFellBack = guardBuf.Len() > 0
+
+	// SIGIL_TAGS attaches key=value tags to every generation. They aren't
+	// secret, so surface the resolved set (and where it came from) to make a
+	// mis-set or forgotten tag visible.
+	if tags := resolveEnv("SIGIL_TAGS", osEnv, fileEnv); tags.set {
+		if parsed := envconfig.ParseExtraTags(tags.value); len(parsed) > 0 {
+			sec.Tags = parsed
+			sec.TagsSource = tags.source
+		}
+	}
+
+	if len(sec.DisallowedKeys) > 0 {
+		sec.Health = HealthWarn
+		sec.Messages = append(sec.Messages,
+			"config.env has keys sigil ignores: "+strings.Join(sec.DisallowedKeys, ", "))
+	}
+	if sec.ContentModeFellBack {
+		sec.Health = HealthWarn
+		sec.Messages = append(sec.Messages,
+			fmt.Sprintf("SIGIL_CONTENT_CAPTURE_MODE is invalid; using %s", mode))
+	}
+	if sec.GuardsFellBack {
+		sec.Health = HealthWarn
+		sec.Messages = append(sec.Messages,
+			"a SIGIL_GUARDS_* value is invalid; falling back to defaults")
+	}
+	return sec
+}
+
+func runProbes(ctx context.Context, r *Report, osEnv, fileEnv map[string]string) {
+	if r.Conversations.configured() {
+		token := resolveEnv("SIGIL_AUTH_TOKEN", osEnv, fileEnv).value
+		insecure := envconfig.ParseBool(resolveEnv("SIGIL_INSECURE", osEnv, fileEnv).value)
+		res := probeConversationsFn(ctx, r.Conversations.Endpoint.Value, r.Conversations.TenantID.Value, token, insecure)
+		r.Conversations.Probe = res
+		switch {
+		case res.authFailure():
+			r.Conversations.Health = HealthError
+			r.Conversations.Messages = append(r.Conversations.Messages, res.Message)
+		case res.unreachable():
+			r.Conversations.Health = HealthError
+			r.Conversations.Messages = append(r.Conversations.Messages,
+				"could not reach the conversations endpoint: "+describeProbe(res))
+		}
+	}
+	if r.Analytics.Endpoint.Set {
+		probe := probeOTLPFn(ctx)
+		r.Analytics.Probe = probe
+		if probe != nil {
+			switch {
+			case probe.Metrics.authFailure() || probe.Traces.authFailure():
+				r.Analytics.Health = HealthError
+				r.Analytics.Messages = append(r.Analytics.Messages,
+					"OTLP endpoint rejected auth (401/403) — the token is likely missing metrics:write/traces:write scope")
+			case probe.Metrics.unreachable() || probe.Traces.unreachable():
+				r.Analytics.Health = HealthError
+				r.Analytics.Messages = append(r.Analytics.Messages,
+					"could not reach the OTLP endpoint — metrics and traces will not be exported")
+			}
+		}
+	}
+}
+
+// resolved is the effective value of an env var plus where it came from.
+type resolved struct {
+	set    bool
+	value  string
+	source string
+}
+
+func (r resolved) envValue() envValue {
+	return envValue{Set: r.set, Value: r.value, Source: r.source}
+}
+
+func (r resolved) tokenValue() tokenValue {
+	return tokenValue{Set: r.set, Prefix: tokenPrefix(r.value), Source: r.source}
+}
+
+// resolveEnv mirrors dotenv.ApplyEnv precedence: a non-empty OS-env value wins
+// over config.env. The OS-env snapshot must predate the dotenv merge.
+func resolveEnv(key string, osEnv, fileEnv map[string]string) resolved {
+	if v, ok := osEnv[key]; ok && strings.TrimSpace(v) != "" {
+		return resolved{set: true, value: strings.TrimSpace(v), source: sourceEnv}
+	}
+	if v, ok := fileEnv[key]; ok && strings.TrimSpace(v) != "" {
+		return resolved{set: true, value: strings.TrimSpace(v), source: sourceConfig}
+	}
+	return resolved{}
+}
+
+// tokenPrefix returns the non-sensitive scheme marker of a token (everything
+// up to and including the first underscore, e.g. "glc_"), or "" when there is
+// none. It never returns the secret part.
+func tokenPrefix(token string) string {
+	token = strings.TrimSpace(token)
+	if i := strings.IndexByte(token, '_'); i > 0 && i <= 8 {
+		return token[:i+1]
+	}
+	return ""
+}
+
+// disallowedKeys lists keys in config.env that sigil's dotenv loader ignores.
+// It mirrors dotenv.LoadDotenv's line handling so the same lines are parsed,
+// but reports the rejected keys the loader silently drops.
+func disallowedKeys(path string) []string {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = f.Close() }()
+
+	var bad []string
+	seen := map[string]bool{}
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if after, ok := strings.CutPrefix(line, "export "); ok {
+			line = strings.TrimSpace(after)
+		}
+		key, _, ok := strings.Cut(line, "=")
+		key = strings.TrimSpace(key)
+		if !ok || key == "" || dotenv.AllowedDotenvKey(key) || seen[key] {
+			continue
+		}
+		seen[key] = true
+		bad = append(bad, key)
+	}
+	return bad
+}
+
+func normalizeVersion(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return "dev"
+	}
+	return v
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/plugins/sigil/internal/doctor/doctor_test.go
+++ b/plugins/sigil/internal/doctor/doctor_test.go
@@ -1,0 +1,567 @@
+package doctor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// isolateEnv points the dotenv/state roots at a fresh tempdir and clears the
+// tracked env vars so a test never reads the developer's real config.
+func isolateEnv(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(dir, "state"))
+	for _, k := range trackedKeys {
+		t.Setenv(k, "")
+	}
+	return dir
+}
+
+// stubSeams replaces the network/agent seams with cheap fakes so Collect
+// tests stay hermetic.
+func stubSeams(t *testing.T) {
+	t.Helper()
+	prevAgents, prevConv, prevOTLP := collectAgents, probeConversationsFn, probeOTLPFn
+	t.Cleanup(func() {
+		collectAgents, probeConversationsFn, probeOTLPFn = prevAgents, prevConv, prevOTLP
+	})
+	collectAgents = func(context.Context, string) []AgentStatus { return nil }
+	probeConversationsFn = func(context.Context, string, string, string, bool) *ProbeResult {
+		return &ProbeResult{StatusCode: 200, OK: true}
+	}
+	probeOTLPFn = func(context.Context) *AnalyticsProbe { return nil }
+}
+
+func writeConfig(t *testing.T, content string) {
+	t.Helper()
+	path := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "sigil", "config.env")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseFlags(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantJSON  bool
+		wantProbe bool
+		wantColor bool // NoColor
+		wantErr   bool
+	}{
+		{name: "no flags"},
+		{name: "json", args: []string{"--json"}, wantJSON: true},
+		{name: "probe", args: []string{"--probe"}, wantProbe: true},
+		{name: "online alias", args: []string{"--online"}, wantProbe: true},
+		{name: "no-color", args: []string{"--no-color"}, wantColor: true},
+		{name: "combined", args: []string{"--json", "--probe", "--no-color"}, wantJSON: true, wantProbe: true, wantColor: true},
+		{name: "unknown flag", args: []string{"--nope"}, wantErr: true},
+		{name: "positional arg", args: []string{"extra"}, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, err := parseFlags(tc.args, &bytes.Buffer{})
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %v", tc.args)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if opts.JSON != tc.wantJSON || opts.Probe != tc.wantProbe || opts.NoColor != tc.wantColor {
+				t.Fatalf("opts = %+v", opts)
+			}
+		})
+	}
+}
+
+func TestReportExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		conv Health
+		anal Health
+		conf Health
+		want int
+	}{
+		{name: "all ok", conv: HealthOK, anal: HealthOK, conf: HealthOK, want: 0},
+		{name: "warnings only", conv: HealthWarn, anal: HealthWarn, conf: HealthWarn, want: 0},
+		{name: "analytics broken", conv: HealthOK, anal: HealthError, conf: HealthOK, want: 1},
+		{name: "conversations broken", conv: HealthError, anal: HealthOK, conf: HealthOK, want: 1},
+		{name: "config broken", conv: HealthOK, anal: HealthOK, conf: HealthError, want: 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Report{
+				Conversations: ConversationsSection{Health: tc.conv},
+				Analytics:     AnalyticsSection{Health: tc.anal},
+				Config:        ConfigSection{Health: tc.conf},
+			}
+			if got := r.exitCode(); got != tc.want {
+				t.Fatalf("exitCode = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCollectConversations(t *testing.T) {
+	tests := []struct {
+		name       string
+		osEnv      map[string]string
+		wantHealth Health
+		wantMsg    string
+	}{
+		{
+			name:       "all set",
+			osEnv:      map[string]string{"SIGIL_ENDPOINT": "https://x", "SIGIL_AUTH_TENANT_ID": "1", "SIGIL_AUTH_TOKEN": "glc_t"},
+			wantHealth: HealthOK,
+		},
+		{
+			name:       "none set",
+			osEnv:      map[string]string{},
+			wantHealth: HealthWarn,
+			wantMsg:    "not configured",
+		},
+		{
+			name:       "missing token",
+			osEnv:      map[string]string{"SIGIL_ENDPOINT": "https://x", "SIGIL_AUTH_TENANT_ID": "1"},
+			wantHealth: HealthError,
+			wantMsg:    "SIGIL_AUTH_TOKEN",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sec := collectConversations(tc.osEnv, nil)
+			if sec.Health != tc.wantHealth {
+				t.Fatalf("health = %q, want %q", sec.Health, tc.wantHealth)
+			}
+			if tc.wantMsg != "" && !strings.Contains(strings.Join(sec.Messages, " "), tc.wantMsg) {
+				t.Fatalf("messages %v missing %q", sec.Messages, tc.wantMsg)
+			}
+		})
+	}
+}
+
+func TestCollectAnalytics(t *testing.T) {
+	tests := []struct {
+		name         string
+		osEnv        map[string]string
+		convConfig   bool
+		wantHealth   Health
+		wantEndpoint string
+		wantVar      string
+	}{
+		{
+			name: "sigil otlp set with auth",
+			osEnv: map[string]string{
+				"SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT": "https://otlp",
+				"SIGIL_AUTH_TENANT_ID":              "12345",
+				"SIGIL_OTEL_AUTH_TOKEN":             "glc_tok",
+			},
+			wantHealth:   HealthOK,
+			wantEndpoint: "https://otlp",
+			wantVar:      "SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT",
+		},
+		{
+			name: "standard otel fallback with auth via SIGIL_AUTH_TOKEN",
+			osEnv: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT": "https://otlp2",
+				"SIGIL_AUTH_TENANT_ID":        "12345",
+				"SIGIL_AUTH_TOKEN":            "glc_tok",
+			},
+			wantHealth:   HealthOK,
+			wantEndpoint: "https://otlp2",
+			wantVar:      "OTEL_EXPORTER_OTLP_ENDPOINT",
+		},
+		{
+			name: "auth via OTEL_EXPORTER_OTLP_HEADERS authorization entry",
+			osEnv: map[string]string{
+				"SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT": "https://otlp",
+				"OTEL_EXPORTER_OTLP_HEADERS":        "authorization=Basic abc,x-extra=1",
+			},
+			wantHealth:   HealthOK,
+			wantEndpoint: "https://otlp",
+			wantVar:      "SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT",
+		},
+		{
+			name: "empty authorization header value is not auth",
+			osEnv: map[string]string{
+				"SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT": "https://otlp",
+				"OTEL_EXPORTER_OTLP_HEADERS":        "authorization=  ,x-extra=1",
+			},
+			wantHealth:   HealthWarn,
+			wantEndpoint: "https://otlp",
+			wantVar:      "SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT",
+		},
+		{
+			name:         "endpoint set but no auth resolvable is a warning",
+			osEnv:        map[string]string{"SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT": "https://otlp"},
+			wantHealth:   HealthWarn,
+			wantEndpoint: "https://otlp",
+			wantVar:      "SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT",
+		},
+		{
+			name:       "missing but conversations configured is the headline error",
+			osEnv:      map[string]string{},
+			convConfig: true,
+			wantHealth: HealthError,
+		},
+		{
+			name:       "missing and nothing configured is just a warning",
+			osEnv:      map[string]string{},
+			convConfig: false,
+			wantHealth: HealthWarn,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sec := collectAnalytics(tc.osEnv, nil, tc.convConfig)
+			if sec.Health != tc.wantHealth {
+				t.Fatalf("health = %q, want %q", sec.Health, tc.wantHealth)
+			}
+			if tc.wantEndpoint != "" && sec.Endpoint.Value != tc.wantEndpoint {
+				t.Fatalf("endpoint = %q, want %q", sec.Endpoint.Value, tc.wantEndpoint)
+			}
+			if tc.wantVar != "" && sec.EndpointVar != tc.wantVar {
+				t.Fatalf("endpoint var = %q, want %q", sec.EndpointVar, tc.wantVar)
+			}
+		})
+	}
+}
+
+func TestRunProbes(t *testing.T) {
+	tests := []struct {
+		name          string
+		conv          *ProbeResult
+		otlp          *AnalyticsProbe
+		wantConv      Health
+		wantAnalytics Health
+	}{
+		{
+			name:          "all reachable",
+			conv:          &ProbeResult{StatusCode: 200, OK: true},
+			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 200, OK: true}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			wantConv:      HealthOK,
+			wantAnalytics: HealthOK,
+		},
+		{
+			name:          "auth failure escalates",
+			conv:          &ProbeResult{StatusCode: 403, Message: "missing sigil:write"},
+			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 401}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			wantConv:      HealthError,
+			wantAnalytics: HealthError,
+		},
+		{
+			name:          "transport error escalates",
+			conv:          &ProbeResult{StatusCode: 0, Message: "connection refused"},
+			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 0, Message: "timeout"}, Traces: &ProbeResult{StatusCode: 0, Message: "timeout"}},
+			wantConv:      HealthError,
+			wantAnalytics: HealthError,
+		},
+		{
+			name:          "5xx escalates",
+			conv:          &ProbeResult{StatusCode: 503},
+			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 500}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			wantConv:      HealthError,
+			wantAnalytics: HealthError,
+		},
+		{
+			name:          "benign 4xx stays healthy",
+			conv:          &ProbeResult{StatusCode: 400},
+			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 415}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			wantConv:      HealthOK,
+			wantAnalytics: HealthOK,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prevConv, prevOTLP := probeConversationsFn, probeOTLPFn
+			t.Cleanup(func() { probeConversationsFn, probeOTLPFn = prevConv, prevOTLP })
+			probeConversationsFn = func(context.Context, string, string, string, bool) *ProbeResult { return tc.conv }
+			probeOTLPFn = func(context.Context) *AnalyticsProbe { return tc.otlp }
+
+			r := &Report{
+				Conversations: ConversationsSection{
+					Endpoint: envValue{Set: true, Value: "https://sigil.example.net"},
+					TenantID: envValue{Set: true, Value: "t"},
+					Token:    tokenValue{Set: true},
+					Health:   HealthOK,
+				},
+				Analytics: AnalyticsSection{
+					Endpoint: envValue{Set: true, Value: "https://otlp.example.net"},
+					Health:   HealthOK,
+				},
+			}
+			runProbes(context.Background(), r, map[string]string{}, nil)
+			if r.Conversations.Health != tc.wantConv {
+				t.Fatalf("conversations health = %q, want %q", r.Conversations.Health, tc.wantConv)
+			}
+			if r.Analytics.Health != tc.wantAnalytics {
+				t.Fatalf("analytics health = %q, want %q", r.Analytics.Health, tc.wantAnalytics)
+			}
+		})
+	}
+}
+
+func TestResolveEnv(t *testing.T) {
+	tests := []struct {
+		name       string
+		osEnv      map[string]string
+		fileEnv    map[string]string
+		wantSet    bool
+		wantValue  string
+		wantSource string
+	}{
+		{name: "os env wins", osEnv: map[string]string{"K": "fromenv"}, fileEnv: map[string]string{"K": "fromfile"}, wantSet: true, wantValue: "fromenv", wantSource: sourceEnv},
+		{name: "config fallback", osEnv: map[string]string{}, fileEnv: map[string]string{"K": "fromfile"}, wantSet: true, wantValue: "fromfile", wantSource: sourceConfig},
+		{name: "unset", osEnv: map[string]string{}, fileEnv: map[string]string{}, wantSet: false},
+		{name: "blank os falls through to file", osEnv: map[string]string{"K": "  "}, fileEnv: map[string]string{"K": "fromfile"}, wantSet: true, wantValue: "fromfile", wantSource: sourceConfig},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveEnv("K", tc.osEnv, tc.fileEnv)
+			if got.set != tc.wantSet || got.value != tc.wantValue {
+				t.Fatalf("got %+v", got)
+			}
+			if tc.wantSet && got.source != tc.wantSource {
+				t.Fatalf("source = %q, want %q", got.source, tc.wantSource)
+			}
+		})
+	}
+}
+
+func TestTokenPrefix(t *testing.T) {
+	tests := []struct {
+		token string
+		want  string
+	}{
+		{token: "glc_abcdef", want: "glc_"},
+		{token: "glsa_xyz", want: "glsa_"},
+		{token: "nounderscore", want: ""},
+		{token: "", want: ""},
+		{token: "_leading", want: ""},
+		{token: "averyverylongprefix_x", want: ""}, // prefix too long to be a scheme marker
+	}
+	for _, tc := range tests {
+		t.Run(tc.token, func(t *testing.T) {
+			if got := tokenPrefix(tc.token); got != tc.want {
+				t.Fatalf("tokenPrefix(%q) = %q, want %q", tc.token, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDisallowedKeys(t *testing.T) {
+	isolateEnv(t)
+	writeConfig(t, strings.Join([]string{
+		"SIGIL_ENDPOINT=https://x",
+		"export OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp",
+		"# comment",
+		"RANDOM_KEY=nope",
+		"AWS_SECRET=leak",
+		"RANDOM_KEY=dup", // duplicate reported once
+	}, "\n"))
+
+	got := disallowedKeys(filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "sigil", "config.env"))
+	want := []string{"RANDOM_KEY", "AWS_SECRET"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("disallowedKeys = %v, want %v", got, want)
+	}
+}
+
+func TestCollectConfig_ContentMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		mode         string
+		wantMode     string
+		wantFellBack bool
+		wantHealth   Health // "" = don't assert
+	}{
+		{name: "invalid mode falls back", mode: "bogus", wantMode: "metadata_only", wantFellBack: true, wantHealth: HealthWarn},
+		{name: "valid mode no fallback", mode: "full", wantMode: "full", wantFellBack: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateEnv(t)
+			t.Setenv("SIGIL_CONTENT_CAPTURE_MODE", tc.mode)
+
+			sec := collectConfig(nil, nil)
+			if sec.ContentModeFellBack != tc.wantFellBack {
+				t.Fatalf("ContentModeFellBack = %v, want %v", sec.ContentModeFellBack, tc.wantFellBack)
+			}
+			if sec.ContentCaptureMode != tc.wantMode {
+				t.Fatalf("mode = %q, want %q", sec.ContentCaptureMode, tc.wantMode)
+			}
+			if tc.wantHealth != "" && sec.Health != tc.wantHealth {
+				t.Fatalf("health = %q, want %q", sec.Health, tc.wantHealth)
+			}
+		})
+	}
+}
+
+func TestCollectConfig_Guards(t *testing.T) {
+	tests := []struct {
+		name          string
+		enabled       string
+		timeout       string
+		failOpen      string
+		wantEnabled   bool
+		wantTimeoutMs int
+		wantFailOpen  bool
+		wantFellBack  bool
+		wantHealth    Health // "" = don't assert
+	}{
+		{name: "unset uses defaults", wantEnabled: false, wantTimeoutMs: 1500, wantFailOpen: true},
+		{name: "enabled fail-open", enabled: "true", wantEnabled: true, wantTimeoutMs: 1500, wantFailOpen: true},
+		{name: "enabled fail-closed with timeout", enabled: "1", timeout: "500", failOpen: "false", wantEnabled: true, wantTimeoutMs: 500, wantFailOpen: false},
+		{name: "invalid enabled falls back", enabled: "maybe", wantEnabled: false, wantTimeoutMs: 1500, wantFailOpen: true, wantFellBack: true, wantHealth: HealthWarn},
+		{name: "invalid timeout falls back", enabled: "true", timeout: "-1", wantEnabled: true, wantTimeoutMs: 1500, wantFailOpen: true, wantFellBack: true, wantHealth: HealthWarn},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateEnv(t)
+			// ResolveGuards reads the process env directly, so clear the guard
+			// vars first to keep the baseline independent of the host shell.
+			t.Setenv("SIGIL_GUARDS_ENABLED", tc.enabled)
+			t.Setenv("SIGIL_GUARDS_TIMEOUT_MS", tc.timeout)
+			t.Setenv("SIGIL_GUARDS_FAIL_OPEN", tc.failOpen)
+
+			sec := collectConfig(nil, nil)
+			if sec.GuardsEnabled != tc.wantEnabled {
+				t.Fatalf("GuardsEnabled = %v, want %v", sec.GuardsEnabled, tc.wantEnabled)
+			}
+			if sec.GuardsTimeoutMs != tc.wantTimeoutMs {
+				t.Fatalf("GuardsTimeoutMs = %d, want %d", sec.GuardsTimeoutMs, tc.wantTimeoutMs)
+			}
+			if sec.GuardsFailOpen != tc.wantFailOpen {
+				t.Fatalf("GuardsFailOpen = %v, want %v", sec.GuardsFailOpen, tc.wantFailOpen)
+			}
+			if sec.GuardsFellBack != tc.wantFellBack {
+				t.Fatalf("GuardsFellBack = %v, want %v", sec.GuardsFellBack, tc.wantFellBack)
+			}
+			if tc.wantHealth != "" && sec.Health != tc.wantHealth {
+				t.Fatalf("health = %q, want %q", sec.Health, tc.wantHealth)
+			}
+		})
+	}
+}
+
+func TestCollectConfig_Tags(t *testing.T) {
+	tests := []struct {
+		name       string
+		osEnv      map[string]string
+		fileEnv    map[string]string
+		wantTags   map[string]string
+		wantSource string
+	}{
+		{name: "no tags", wantTags: nil},
+		{
+			name:       "from env",
+			osEnv:      map[string]string{"SIGIL_TAGS": "team=assistant,env=prod"},
+			wantTags:   map[string]string{"team": "assistant", "env": "prod"},
+			wantSource: sourceEnv,
+		},
+		{
+			name:       "from config.env when env unset",
+			fileEnv:    map[string]string{"SIGIL_TAGS": "team=alerting"},
+			wantTags:   map[string]string{"team": "alerting"},
+			wantSource: sourceConfig,
+		},
+		{
+			name:     "all entries malformed yields no tags",
+			osEnv:    map[string]string{"SIGIL_TAGS": "novalue,=noKey"},
+			wantTags: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateEnv(t)
+			sec := collectConfig(tc.osEnv, tc.fileEnv)
+			if len(sec.Tags) != len(tc.wantTags) {
+				t.Fatalf("tags = %v, want %v", sec.Tags, tc.wantTags)
+			}
+			for k, v := range tc.wantTags {
+				if sec.Tags[k] != v {
+					t.Fatalf("tags[%q] = %q, want %q", k, sec.Tags[k], v)
+				}
+			}
+			if sec.TagsSource != tc.wantSource {
+				t.Fatalf("tags source = %q, want %q", sec.TagsSource, tc.wantSource)
+			}
+		})
+	}
+}
+
+func TestRun(t *testing.T) {
+	convOnly := map[string]string{
+		"SIGIL_ENDPOINT":       "https://sigil.example.net",
+		"SIGIL_AUTH_TENANT_ID": "12345",
+		"SIGIL_AUTH_TOKEN":     "glc_supersecretvalue",
+	}
+	healthy := map[string]string{
+		"SIGIL_ENDPOINT":                    "https://sigil.example.net",
+		"SIGIL_AUTH_TENANT_ID":              "12345",
+		"SIGIL_AUTH_TOKEN":                  "glc_t",
+		"SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT": "https://otlp.example.net/otlp",
+	}
+	tests := []struct {
+		name     string
+		args     []string
+		osEnv    map[string]string
+		stub     bool // swap the network/agent seams for fakes
+		wantCode int
+		check    func(t *testing.T, stdout string)
+	}{
+		{
+			// conversations set but analytics unset → exit 1.
+			name:     "json redacts token and flags the analytics gap",
+			args:     []string{"--json"},
+			osEnv:    convOnly,
+			stub:     true,
+			wantCode: 1,
+			check: func(t *testing.T, stdout string) {
+				if strings.Contains(stdout, "supersecret") {
+					t.Fatalf("token value leaked into JSON output:\n%s", stdout)
+				}
+				var report map[string]any
+				if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+					t.Fatalf("invalid JSON: %v", err)
+				}
+				for _, key := range []string{"sigil", "config", "conversations", "analytics", "agents"} {
+					if _, ok := report[key]; !ok {
+						t.Fatalf("JSON missing section %q", key)
+					}
+				}
+			},
+		},
+		{name: "fully configured exits 0", osEnv: healthy, stub: true, wantCode: 0},
+		{name: "bad flag exits 2", args: []string{"--bogus"}, wantCode: 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateEnv(t)
+			if tc.stub {
+				stubSeams(t)
+			}
+			var stdout, stderr bytes.Buffer
+			code := Run(context.Background(), tc.args, Params{Version: "1.2.3", OSEnv: tc.osEnv, Stdout: &stdout, Stderr: &stderr})
+			if code != tc.wantCode {
+				t.Fatalf("exit code = %d, want %d (stdout=%s stderr=%s)", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if tc.check != nil {
+				tc.check(t, stdout.String())
+			}
+		})
+	}
+}

--- a/plugins/sigil/internal/doctor/probe.go
+++ b/plugins/sigil/internal/doctor/probe.go
@@ -1,0 +1,114 @@
+package doctor
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/grafana/sigil-sdk/go/proto/sigil/wire"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/otel"
+)
+
+// probeTimeout bounds each network probe so `--probe` stays responsive even
+// against a black-holed endpoint. A var so tests can shrink it.
+var probeTimeout = 3 * time.Second
+
+// probeClient is the shared client for probes. Per-request contexts carry the
+// real deadline; the client timeout is a backstop.
+var probeClient = &http.Client{Timeout: probeTimeout}
+
+// defaultProbeConversations checks the generation-export endpoint with the
+// same headers a real export sends: HTTP Basic auth (base64(tenant:token))
+// plus the X-Scope-OrgID tenant header, matching the SDK exporter's
+// ExportAuthModeBasic that every agent plugin uses. Using Bearer here would
+// draw a spurious 401 from Grafana Cloud's gateway even with a valid token. It
+// POSTs an empty body so the edge auth layer is exercised (401/403 surface
+// before the empty body is rejected) without creating a real generation.
+// Connectivity and auth failures are returned as results, never as errors that
+// abort the report. insecure mirrors SIGIL_INSECURE so a scheme-less endpoint
+// resolves to http here just as the SDK exporter does; otherwise the probe
+// would hit https and report a cleartext setup as unreachable.
+func defaultProbeConversations(ctx context.Context, endpoint, tenant, token string, insecure bool) *ProbeResult {
+	target, err := wire.NormalizeGenerationExportURL(endpoint, insecure)
+	if err != nil {
+		return &ProbeResult{Message: "invalid endpoint: " + err.Error()}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, strings.NewReader("{}"))
+	if err != nil {
+		return &ProbeResult{URL: target, Message: err.Error()}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if tenant != "" {
+		req.Header.Set("X-Scope-OrgID", tenant)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(tenant+":"+token)))
+	}
+
+	res := doProbe(target, req)
+	if res.authFailure() {
+		res.Message = "endpoint rejected auth — token likely missing sigil:write scope"
+	}
+	return res
+}
+
+// defaultProbeOTLP checks the OTLP metrics and traces endpoints, reusing the
+// resolved signal URLs and synthesized auth headers from internal/otel. Each
+// signal is POSTed an empty JSON body so the edge auth layer is exercised
+// without pushing data; 401/403 indicate the token is missing
+// metrics:write/traces:write. The real exporter sends protobuf, so an endpoint
+// that validates content-type before auth could answer 400/415 here; against
+// Grafana's OTLP gateway auth precedes parsing, so 200/401/403 is what's seen.
+func defaultProbeOTLP(ctx context.Context) *AnalyticsProbe {
+	metrics, traces, ok := otel.ProbeConfig()
+	if !ok {
+		return nil
+	}
+	return &AnalyticsProbe{
+		Metrics: probeOTLPSignal(ctx, metrics),
+		Traces:  probeOTLPSignal(ctx, traces),
+	}
+}
+
+func probeOTLPSignal(ctx context.Context, target otel.ProbeTarget) *ProbeResult {
+	ctx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target.URL, strings.NewReader("{}"))
+	if err != nil {
+		return &ProbeResult{URL: target.URL, Message: err.Error()}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range target.Headers {
+		req.Header.Set(k, v)
+	}
+
+	res := doProbe(target.URL, req)
+	if res.authFailure() {
+		res.Message = "missing metrics:write/traces:write scope"
+	}
+	return res
+}
+
+// doProbe sends req and maps the outcome to a ProbeResult. A transport error
+// is reported as no response; any HTTP status below 400 (and 405, since a
+// method-restricted route still proves reach + auth) counts as reachable.
+func doProbe(target string, req *http.Request) *ProbeResult {
+	resp, err := probeClient.Do(req)
+	if err != nil {
+		return &ProbeResult{URL: target, Message: err.Error()}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	return &ProbeResult{
+		URL:        target,
+		StatusCode: resp.StatusCode,
+		OK:         resp.StatusCode < 400 || resp.StatusCode == http.StatusMethodNotAllowed,
+	}
+}

--- a/plugins/sigil/internal/doctor/probe_test.go
+++ b/plugins/sigil/internal/doctor/probe_test.go
@@ -1,0 +1,159 @@
+package doctor
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/sigil-sdk/go/proto/sigil/wire"
+)
+
+func TestProbeConversations(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      int
+		badURL      bool // probe an unparseable endpoint instead of the test server
+		wantOK      bool
+		wantAuthMsg bool
+		wantErr     bool // transport error: status 0 with a message, server never hit
+	}{
+		{name: "200 ok", status: 200, wantOK: true},
+		{name: "401 unauthorized", status: 401, wantAuthMsg: true},
+		{name: "403 forbidden", status: 403, wantAuthMsg: true},
+		{name: "400 reachable", status: 400, wantOK: false},
+		{name: "invalid endpoint", badURL: true, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath, gotTenant, gotAuth string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotTenant = r.Header.Get("X-Scope-OrgID")
+				gotAuth = r.Header.Get("Authorization")
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+
+			url := srv.URL
+			if tc.badURL {
+				url = "://bad"
+			}
+			res := defaultProbeConversations(context.Background(), url, "tenant-1", "glc_tok", false)
+
+			if tc.wantErr {
+				if res.StatusCode != 0 || res.Message == "" {
+					t.Fatalf("expected a transport error result, got %+v", res)
+				}
+				return
+			}
+			if res.StatusCode != tc.status {
+				t.Fatalf("status = %d, want %d", res.StatusCode, tc.status)
+			}
+			if res.OK != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", res.OK, tc.wantOK)
+			}
+			if tc.wantAuthMsg && !strings.Contains(res.Message, "sigil:write") {
+				t.Fatalf("expected auth message, got %q", res.Message)
+			}
+			if gotPath != wire.GenerationExportHTTPPath {
+				t.Fatalf("probe hit %q, want %q", gotPath, wire.GenerationExportHTTPPath)
+			}
+			wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("tenant-1:glc_tok"))
+			if gotTenant != "tenant-1" || gotAuth != wantAuth {
+				t.Fatalf("missing auth headers: tenant=%q auth=%q want auth=%q", gotTenant, gotAuth, wantAuth)
+			}
+		})
+	}
+}
+
+func TestProbeConversations_Timeout(t *testing.T) {
+	prev := probeTimeout
+	t.Cleanup(func() { probeTimeout = prev })
+	probeTimeout = 50 * time.Millisecond
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(300 * time.Millisecond)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	res := defaultProbeConversations(context.Background(), srv.URL, "t", "tok", false)
+	if res.StatusCode != 0 || res.Message == "" {
+		t.Fatalf("expected timeout error, got %+v", res)
+	}
+}
+
+// A scheme-less endpoint with SIGIL_INSECURE resolves to http, matching the
+// SDK exporter; without it the probe would hit https and miss a cleartext
+// collector that real export reaches.
+func TestProbeConversations_InsecureScheme(t *testing.T) {
+	secure, err := wire.NormalizeGenerationExportURL("collector.local:4317", false)
+	if err != nil {
+		t.Fatalf("normalize secure: %v", err)
+	}
+	if !strings.HasPrefix(secure, "https://") {
+		t.Fatalf("secure target = %q, want https scheme", secure)
+	}
+
+	var gotScheme string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotScheme = "http"
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	// srv.Listener.Addr() is a scheme-less host:port; with insecure the probe
+	// must reach it over http.
+	res := defaultProbeConversations(context.Background(), srv.Listener.Addr().String(), "t", "tok", true)
+	if !res.OK || gotScheme != "http" {
+		t.Fatalf("insecure probe = %+v, server scheme %q, want http reach", res, gotScheme)
+	}
+}
+
+func TestProbeOTLP(t *testing.T) {
+	var hitMetrics, hitTraces bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/metrics":
+			hitMetrics = true
+		case "/v1/traces":
+			hitTraces = true
+		}
+		if r.Header.Get("Authorization") == "" {
+			t.Errorf("OTLP probe sent no auth header")
+		}
+		w.WriteHeader(403)
+	}))
+	defer srv.Close()
+
+	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", srv.URL)
+	t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant-1")
+	t.Setenv("SIGIL_AUTH_TOKEN", "glc_tok")
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "")
+
+	probe := defaultProbeOTLP(context.Background())
+	if probe == nil {
+		t.Fatal("expected a probe result")
+	}
+	if !hitMetrics || !hitTraces {
+		t.Fatalf("both signals must be probed: metrics=%v traces=%v", hitMetrics, hitTraces)
+	}
+	if probe.Metrics.StatusCode != 403 || !probe.Metrics.authFailure() {
+		t.Fatalf("metrics probe = %+v", probe.Metrics)
+	}
+	if !strings.Contains(probe.Metrics.Message, "metrics:write/traces:write") {
+		t.Fatalf("metrics message = %q", probe.Metrics.Message)
+	}
+}
+
+func TestProbeOTLP_NoEndpoint(t *testing.T) {
+	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	if got := defaultProbeOTLP(context.Background()); got != nil {
+		t.Fatalf("expected nil probe when no endpoint configured, got %+v", got)
+	}
+}

--- a/plugins/sigil/internal/doctor/render.go
+++ b/plugins/sigil/internal/doctor/render.go
@@ -1,0 +1,316 @@
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// renderJSON writes the stable machine-readable report. encoding/json never
+// emits color codes, and the token value is absent from the Report type, so
+// this output is safe to hand to support tooling.
+func renderJSON(w io.Writer, r *Report) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}
+
+// palette renders styled text when color is on, plain text otherwise. When
+// color is on it uses lipgloss, which itself drops color codes on a non-TTY
+// writer, so captured/redirected output is plain regardless.
+type palette struct {
+	color bool
+}
+
+var (
+	orangeStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FF671D"))
+	okStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#73BF69"))
+	warnStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF9830"))
+	errStyle    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#F2495C"))
+	faintStyle  = lipgloss.NewStyle().Faint(true)
+)
+
+func (p palette) heading(s string) string { return p.apply(orangeStyle, s) }
+func (p palette) faint(s string) string   { return p.apply(faintStyle, s) }
+
+// sectionTitle colors a section header by its health: green when passing, red
+// when failing, orange for warnings.
+func (p palette) sectionTitle(s string, h Health) string {
+	switch h {
+	case HealthOK:
+		return p.apply(okStyle, s)
+	case HealthWarn:
+		return p.apply(warnStyle, s)
+	case HealthError:
+		return p.apply(errStyle, s)
+	default:
+		return p.heading(s)
+	}
+}
+
+func (p palette) apply(style lipgloss.Style, s string) string {
+	if !p.color {
+		return s
+	}
+	return style.Render(s)
+}
+
+// glyph returns the status marker for a health level.
+func (p palette) glyph(h Health) string {
+	switch h {
+	case HealthOK:
+		return p.apply(okStyle, "✓")
+	case HealthWarn:
+		return p.apply(warnStyle, "!")
+	case HealthError:
+		return p.apply(errStyle, "✗")
+	default:
+		return p.faint("·")
+	}
+}
+
+// renderHuman writes the colored (or plain) report. probed reports whether
+// live probes ran; when they didn't, a hint nudges the user toward --probe
+// since the section verdicts are config-only and don't test credentials.
+func renderHuman(w io.Writer, r *Report, color, probed bool) {
+	p := palette{color: color}
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "%s %s\n\n", p.heading("sigil doctor"), p.faint("v"+r.Sigil.Version))
+
+	// Conversations pipeline.
+	writeSection(&b, p, "Conversations (generation export)", r.Conversations.Health)
+	writeKV(&b, p, "endpoint", describeEnv(r.Conversations.Endpoint))
+	writeKV(&b, p, "tenant id", describeEnv(r.Conversations.TenantID))
+	writeKV(&b, p, "auth token", describeToken(r.Conversations.Token))
+	if r.Conversations.Probe != nil {
+		writeKV(&b, p, "probe", describeProbe(r.Conversations.Probe))
+	}
+	writeMessages(&b, p, r.Conversations.Messages)
+	b.WriteString("\n")
+
+	// Analytics pipeline.
+	writeSection(&b, p, "Analytics (OTLP metrics & traces)", r.Analytics.Health)
+	if r.Analytics.Endpoint.Set {
+		writeKV(&b, p, "endpoint", fmt.Sprintf("%s %s", r.Analytics.Endpoint.Value, p.faint("("+r.Analytics.EndpointVar+", "+r.Analytics.Endpoint.Source+")")))
+	} else {
+		writeKV(&b, p, "endpoint", p.faint("not set"))
+	}
+	if r.Analytics.Probe != nil {
+		if r.Analytics.Probe.Metrics != nil {
+			writeKV(&b, p, "metrics probe", describeProbe(r.Analytics.Probe.Metrics))
+		}
+		if r.Analytics.Probe.Traces != nil {
+			writeKV(&b, p, "traces probe", describeProbe(r.Analytics.Probe.Traces))
+		}
+	}
+	writeMessages(&b, p, r.Analytics.Messages)
+	b.WriteString("\n")
+
+	// Config.
+	writeSection(&b, p, "Config", r.Config.Health)
+	exists := "missing"
+	if r.Config.Exists {
+		exists = "present"
+	}
+	writeKV(&b, p, "file", fmt.Sprintf("%s %s", r.Config.Path, p.faint("("+exists+")")))
+	mode := r.Config.ContentCaptureMode
+	if r.Config.ContentModeFellBack {
+		mode += " " + p.faint("(invalid value, fell back)")
+	}
+	writeKV(&b, p, "content capture", mode)
+	writeKV(&b, p, "guards", describeGuards(p, r.Config))
+	if len(r.Config.Tags) > 0 {
+		writeKV(&b, p, "tags", fmt.Sprintf("%s %s", formatTags(r.Config.Tags), p.faint("("+r.Config.TagsSource+")")))
+	}
+	writeMessages(&b, p, r.Config.Messages)
+	b.WriteString("\n")
+
+	// Agents.
+	fmt.Fprintf(&b, "%s\n", p.sectionTitle("Coding agents", HealthOK))
+	for _, a := range r.Agents {
+		writeKV(&b, p, a.Name, describeAgent(p, a))
+	}
+	if r.AutoUpdateDisabled {
+		writeKV(&b, p, "auto-update", p.faint("disabled (SIGIL_AUTO_UPDATE)"))
+	}
+	b.WriteString("\n")
+
+	// Summary.
+	writeSummary(&b, p, r)
+	if !probed {
+		writeProbeHint(&b, p, r)
+	}
+
+	_, _ = io.WriteString(w, b.String())
+}
+
+// writeProbeHint nudges toward --probe when the report is config-only and
+// there is something to probe. Without it, the section verdicts reflect only
+// that credentials are present, not that they work.
+func writeProbeHint(b *strings.Builder, p palette, r *Report) {
+	if !r.Conversations.configured() && !r.Analytics.Endpoint.Set {
+		return
+	}
+	fmt.Fprintf(b, "\n%s\n", p.faint("Verdicts above check configuration only. Run `sigil doctor --probe` to test credentials against the endpoints."))
+}
+
+func writeSection(b *strings.Builder, p palette, title string, h Health) {
+	fmt.Fprintf(b, "%s %s\n", p.glyph(h), p.sectionTitle(title, h))
+}
+
+func writeKV(b *strings.Builder, p palette, key, value string) {
+	fmt.Fprintf(b, "  %s %s\n", p.faint(padRight(key+":", 16)), value)
+}
+
+func writeMessages(b *strings.Builder, p palette, messages []string) {
+	for _, m := range messages {
+		fmt.Fprintf(b, "  %s %s\n", p.glyph(HealthWarn), m)
+	}
+}
+
+func writeSummary(b *strings.Builder, p palette, r *Report) {
+	var broken []string
+	if r.Conversations.Health == HealthError {
+		broken = append(broken, "conversations")
+	}
+	if r.Analytics.Health == HealthError {
+		broken = append(broken, "analytics")
+	}
+	if r.Config.Health == HealthError {
+		broken = append(broken, "config")
+	}
+	if len(broken) == 0 {
+		fmt.Fprintf(b, "%s %s\n", p.glyph(HealthOK), "no problems detected")
+		return
+	}
+	fmt.Fprintf(b, "%s %s\n", p.glyph(HealthError),
+		fmt.Sprintf("%d problem(s): %s misconfigured", len(broken), strings.Join(broken, ", ")))
+}
+
+func describeEnv(v envValue) string {
+	if !v.Set {
+		return "not set"
+	}
+	return fmt.Sprintf("%s (%s)", v.Value, v.Source)
+}
+
+func describeToken(t tokenValue) string {
+	if !t.Set {
+		return "not set"
+	}
+	if t.Prefix != "" {
+		return fmt.Sprintf("set (%s…, %s)", t.Prefix, t.Source)
+	}
+	return fmt.Sprintf("set (%s)", t.Source)
+}
+
+// describeGuards renders the resolved guard feature flags. Guards default off,
+// so a plain "disabled" is the common line; when on, the timeout and fail mode
+// matter (fail-closed blocks the tool call when a guard errors or times out).
+func describeGuards(p palette, c ConfigSection) string {
+	var out string
+	if c.GuardsEnabled {
+		failMode := "fail-open"
+		if !c.GuardsFailOpen {
+			failMode = "fail-closed"
+		}
+		out = "enabled " + p.faint(fmt.Sprintf("(timeout %dms, %s)", c.GuardsTimeoutMs, failMode))
+	} else {
+		out = p.faint("disabled")
+	}
+	if c.GuardsFellBack {
+		out += " " + p.faint("(invalid value, fell back)")
+	}
+	return out
+}
+
+func describeProbe(p *ProbeResult) string {
+	if p == nil {
+		return "skipped"
+	}
+	status := "no response"
+	if p.StatusCode != 0 {
+		status = fmt.Sprintf("HTTP %d", p.StatusCode)
+	}
+	if p.Message != "" {
+		return fmt.Sprintf("%s — %s", status, p.Message)
+	}
+	return status
+}
+
+func describeAgent(p palette, a AgentStatus) string {
+	// Hook-only agents (cursor) are detected purely by PATH presence.
+	if a.HookBased {
+		return agentNote(p, joinAgent("detected", a.Version), a.Note)
+	}
+	// The install probe never ran: a CLI-dependent agent whose binary is
+	// absent, or a hook-only agent off PATH.
+	if a.Health == HealthSkipped {
+		return agentNote(p, p.faint("not found on PATH"), a.Note)
+	}
+	// Hook-file based agent (copilot): capture doesn't depend on the CLI being
+	// on PATH, so report install state with its own wording and no PATH
+	// qualifiers.
+	if a.notInstalledLabel != "" {
+		state := a.notInstalledLabel
+		if a.Installed {
+			state = "installed"
+		}
+		return agentNote(p, joinAgent(state, a.Version), a.Note)
+	}
+	// The probe ran. Report install state, only claiming "on PATH" when true so
+	// config-based agents installed without the CLI present aren't mislabeled.
+	var state string
+	switch {
+	case a.Installed && a.OnPath:
+		state = "installed"
+	case a.Installed:
+		state = "installed " + p.faint("(CLI not on PATH)")
+	case a.OnPath:
+		state = "on PATH, plugin not installed"
+	default:
+		state = "plugin not installed"
+	}
+	return agentNote(p, joinAgent(state, a.Version), a.Note)
+}
+
+func joinAgent(state, version string) string {
+	if version != "" {
+		return state + " v" + version
+	}
+	return state
+}
+
+func agentNote(p palette, body, note string) string {
+	if note == "" {
+		return body
+	}
+	return body + " " + p.faint("("+note+")")
+}
+
+// formatTags renders a tag map as "k=v, k=v" with keys sorted so the line is
+// deterministic across runs.
+func formatTags(tags map[string]string) string {
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+tags[k])
+	}
+	return strings.Join(parts, ", ")
+}
+
+func padRight(s string, n int) string {
+	if len(s) >= n {
+		return s
+	}
+	return s + strings.Repeat(" ", n-len(s))
+}

--- a/plugins/sigil/internal/doctor/render_test.go
+++ b/plugins/sigil/internal/doctor/render_test.go
@@ -1,0 +1,242 @@
+package doctor
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func sampleReport() *Report {
+	return &Report{
+		Sigil: SigilSection{Version: "1.2.3"},
+		Config: ConfigSection{
+			Path: "/tmp/sigil/config.env", Exists: true,
+			ContentCaptureMode: "metadata_only", Health: HealthOK,
+		},
+		Conversations: ConversationsSection{
+			Endpoint: envValue{Set: true, Value: "https://sigil.example", Source: sourceEnv},
+			TenantID: envValue{Set: true, Value: "12345", Source: sourceEnv},
+			Token:    tokenValue{Set: true, Prefix: "glc_", Source: sourceEnv},
+			Health:   HealthOK,
+		},
+		Analytics: AnalyticsSection{
+			Health:   HealthError,
+			Messages: []string{"no OTLP endpoint set"},
+		},
+		Agents: []AgentStatus{
+			{Name: "claude", OnPath: true, Installed: true, Version: "0.3.0", Health: HealthOK},
+			{Name: "cursor", OnPath: true, HookBased: true, Version: "1.2.3", Note: "hook-based", Health: HealthOK},
+		},
+	}
+}
+
+func TestRenderJSON_ValidAndNoToken(t *testing.T) {
+	r := sampleReport()
+	var buf bytes.Buffer
+	if err := renderJSON(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+	var decoded Report
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	// The token value never appears in the JSON contract — only presence and
+	// the non-secret prefix.
+	if !strings.Contains(buf.String(), `"prefix": "glc_"`) {
+		t.Fatalf("expected redacted token prefix in output:\n%s", buf.String())
+	}
+}
+
+func TestRenderHuman_NoColorIsPlain(t *testing.T) {
+	r := sampleReport()
+	var buf bytes.Buffer
+	renderHuman(&buf, r, false, false)
+	out := buf.String()
+
+	if strings.Contains(out, "\x1b[") {
+		t.Fatalf("--no-color output contains ANSI escapes:\n%q", out)
+	}
+	for _, want := range []string{
+		"Conversations (generation export)",
+		"Analytics (OTLP metrics & traces)",
+		"https://sigil.example (env)",
+		"set (glc_…, env)",
+		"1 problem(s)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("human output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderHuman_ProbeHint(t *testing.T) {
+	const hint = "sigil doctor --probe"
+	nothingProbeable := func() *Report {
+		r := sampleReport()
+		r.Conversations = ConversationsSection{Health: HealthWarn}
+		r.Analytics = AnalyticsSection{Health: HealthWarn}
+		return r
+	}
+	tests := []struct {
+		name     string
+		report   func() *Report
+		probed   bool
+		wantHint bool
+	}{
+		{name: "shown when configured and not probed", report: sampleReport, probed: false, wantHint: true},
+		{name: "hidden when probed", report: sampleReport, probed: true, wantHint: false},
+		{name: "hidden when nothing is probeable", report: nothingProbeable, probed: false, wantHint: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			renderHuman(&buf, tc.report(), false, tc.probed)
+			if got := strings.Contains(buf.String(), hint); got != tc.wantHint {
+				t.Fatalf("probe hint present = %v, want %v:\n%s", got, tc.wantHint, buf.String())
+			}
+		})
+	}
+}
+
+func TestDescribeAgent(t *testing.T) {
+	p := palette{color: false}
+	tests := []struct {
+		name  string
+		agent AgentStatus
+		want  string
+	}{
+		{name: "hook-based", agent: AgentStatus{HookBased: true, OnPath: true, Version: "1.2.3", Note: "hook-based", Health: HealthOK}, want: "detected v1.2.3 (hook-based)"},
+		{name: "skipped not on path", agent: AgentStatus{OnPath: false, Health: HealthSkipped}, want: "not found on PATH"},
+		{name: "installed on path", agent: AgentStatus{OnPath: true, Installed: true, Version: "0.3.0", Health: HealthOK}, want: "installed v0.3.0"},
+		{name: "config-based installed without cli", agent: AgentStatus{OnPath: false, Installed: true, Version: "2.0.0", Health: HealthOK}, want: "installed (CLI not on PATH) v2.0.0"},
+		{name: "on path not installed", agent: AgentStatus{OnPath: true, Installed: false, Health: HealthWarn}, want: "on PATH, plugin not installed"},
+		{name: "config-based not installed without cli", agent: AgentStatus{OnPath: false, Installed: false, Health: HealthWarn}, want: "plugin not installed"},
+		{name: "hook-file based installed (copilot)", agent: AgentStatus{OnPath: false, Installed: true, notInstalledLabel: "not configured", Note: "hook-based", Health: HealthOK}, want: "installed (hook-based)"},
+		{name: "hook-file based not configured ignores PATH (copilot)", agent: AgentStatus{OnPath: true, Installed: false, notInstalledLabel: "not configured", Note: "hook-based", Health: HealthWarn}, want: "not configured (hook-based)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := describeAgent(p, tc.agent); got != tc.want {
+				t.Fatalf("describeAgent = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatTags(t *testing.T) {
+	tests := []struct {
+		name string
+		tags map[string]string
+		want string
+	}{
+		// Keys are sorted so the rendered line is stable regardless of map order.
+		{name: "sorted by key", tags: map[string]string{"team": "assistant", "env": "prod", "az": "1"}, want: "az=1, env=prod, team=assistant"},
+		{name: "single", tags: map[string]string{"team": "assistant"}, want: "team=assistant"},
+		{name: "empty", tags: map[string]string{}, want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatTags(tc.tags); got != tc.want {
+				t.Fatalf("formatTags = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRenderHuman_TagsLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     map[string]string
+		source   string
+		wantLine string // "" = expect no tags line at all
+	}{
+		{name: "tags shown with source", tags: map[string]string{"team": "assistant", "env": "prod"}, source: sourceConfig, wantLine: "env=prod, team=assistant (config.env)"},
+		{name: "no tags omits line", tags: nil, wantLine: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := sampleReport()
+			r.Config.Tags = tc.tags
+			r.Config.TagsSource = tc.source
+			var buf bytes.Buffer
+			renderHuman(&buf, r, false, false)
+			out := buf.String()
+			if tc.wantLine == "" {
+				if strings.Contains(out, "tags:") {
+					t.Fatalf("expected no tags line:\n%s", out)
+				}
+				return
+			}
+			if !strings.Contains(out, "tags:") || !strings.Contains(out, tc.wantLine) {
+				t.Fatalf("expected tags line %q:\n%s", tc.wantLine, out)
+			}
+		})
+	}
+}
+
+func TestDescribeGuards(t *testing.T) {
+	p := palette{color: false}
+	tests := []struct {
+		name   string
+		config ConfigSection
+		want   string
+	}{
+		{name: "disabled", config: ConfigSection{GuardsEnabled: false}, want: "disabled"},
+		{name: "enabled fail-open", config: ConfigSection{GuardsEnabled: true, GuardsTimeoutMs: 1500, GuardsFailOpen: true}, want: "enabled (timeout 1500ms, fail-open)"},
+		{name: "enabled fail-closed", config: ConfigSection{GuardsEnabled: true, GuardsTimeoutMs: 500, GuardsFailOpen: false}, want: "enabled (timeout 500ms, fail-closed)"},
+		{name: "disabled after fallback", config: ConfigSection{GuardsEnabled: false, GuardsFellBack: true}, want: "disabled (invalid value, fell back)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := describeGuards(p, tc.config); got != tc.want {
+				t.Fatalf("describeGuards = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRenderHuman_GuardsLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   ConfigSection
+		wantLine string
+	}{
+		{name: "disabled", config: ConfigSection{GuardsEnabled: false}, wantLine: "disabled"},
+		{name: "enabled fail-open", config: ConfigSection{GuardsEnabled: true, GuardsTimeoutMs: 1500, GuardsFailOpen: true}, wantLine: "enabled (timeout 1500ms, fail-open)"},
+		{name: "enabled fail-closed", config: ConfigSection{GuardsEnabled: true, GuardsTimeoutMs: 500, GuardsFailOpen: false}, wantLine: "enabled (timeout 500ms, fail-closed)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := sampleReport()
+			r.Config.GuardsEnabled = tc.config.GuardsEnabled
+			r.Config.GuardsTimeoutMs = tc.config.GuardsTimeoutMs
+			r.Config.GuardsFailOpen = tc.config.GuardsFailOpen
+			var buf bytes.Buffer
+			renderHuman(&buf, r, false, false)
+			out := buf.String()
+			if !strings.Contains(out, "guards:") || !strings.Contains(out, tc.wantLine) {
+				t.Fatalf("expected guards line %q:\n%s", tc.wantLine, out)
+			}
+		})
+	}
+}
+
+func TestDescribeToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		token tokenValue
+		want  string
+	}{
+		{name: "unset", token: tokenValue{}, want: "not set"},
+		{name: "with prefix", token: tokenValue{Set: true, Prefix: "glc_", Source: sourceEnv}, want: "set (glc_…, env)"},
+		{name: "no prefix", token: tokenValue{Set: true, Source: sourceConfig}, want: "set (config.env)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := describeToken(tc.token); got != tc.want {
+				t.Fatalf("describeToken = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/plugins/sigil/internal/otel/otel.go
+++ b/plugins/sigil/internal/otel/otel.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 	"time"
@@ -172,6 +173,51 @@ func Setup(ctx context.Context, instanceID string) (*Providers, error) {
 // SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT over OTEL_EXPORTER_OTLP_ENDPOINT.
 func EndpointFromEnv() string {
 	return envOr("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+}
+
+// ProbeTarget is one OTLP signal's resolved probe destination: the full
+// signal URL plus the auth headers a real export would carry.
+type ProbeTarget struct {
+	URL     string
+	Headers map[string]string
+}
+
+// ProbeConfig resolves the OTLP endpoint and returns the per-signal probe
+// targets for metrics and traces, reusing the same endpoint resolution,
+// signal-URL construction, and auth-header synthesis as Setup. ok is false
+// when no OTLP endpoint is configured. Used by `sigil doctor --probe` to send
+// a lightweight request to each signal and report the HTTP status without
+// standing up the full exporter pipeline.
+func ProbeConfig() (metrics, traces ProbeTarget, ok bool) {
+	endpoint := EndpointFromEnv()
+	if endpoint == "" {
+		return ProbeTarget{}, ProbeTarget{}, false
+	}
+	cfg := exporterConfigFromEnv(endpoint)
+	return ProbeTarget{URL: probeSignalURL(cfg, "metrics"), Headers: cloneHeaders(cfg.headers)},
+		ProbeTarget{URL: probeSignalURL(cfg, "traces"), Headers: cloneHeaders(cfg.headers)},
+		true
+}
+
+// probeSignalURL is signalEndpointURL adjusted for the insecure setting. When
+// the exporter is configured insecure, the SDK's WithInsecure() forces
+// cleartext to the same host:port regardless of the endpoint scheme, so a
+// probe over https would exercise a different transport than real export. Drop
+// to http here to match what export actually does.
+func probeSignalURL(cfg exporterConfig, signal string) string {
+	u := signalEndpointURL(cfg.endpoint, signal)
+	if cfg.insecure {
+		if rest, ok := strings.CutPrefix(u, "https://"); ok {
+			return "http://" + rest
+		}
+	}
+	return u
+}
+
+func cloneHeaders(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	maps.Copy(out, in)
+	return out
 }
 
 func exporterConfigFromEnv(endpoint string) exporterConfig {

--- a/plugins/sigil/internal/otel/otel_test.go
+++ b/plugins/sigil/internal/otel/otel_test.go
@@ -84,6 +84,63 @@ func TestExporterConfigKeepsExplicitAuthorization(t *testing.T) {
 	}
 }
 
+func TestProbeConfig(t *testing.T) {
+	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "https://otlp.example/otlp")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+	t.Setenv("SIGIL_AUTH_TOKEN", "token")
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "")
+
+	metrics, traces, ok := ProbeConfig()
+	if !ok {
+		t.Fatal("expected ok=true when an OTLP endpoint is configured")
+	}
+	if metrics.URL != "https://otlp.example/otlp/v1/metrics" {
+		t.Fatalf("metrics URL = %q", metrics.URL)
+	}
+	if traces.URL != "https://otlp.example/otlp/v1/traces" {
+		t.Fatalf("traces URL = %q", traces.URL)
+	}
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("tenant:token"))
+	if metrics.Headers["Authorization"] != want {
+		t.Fatalf("metrics auth = %q, want %q", metrics.Headers["Authorization"], want)
+	}
+	// Headers must be independent copies so a probe mutating one signal's
+	// headers cannot corrupt the other's.
+	metrics.Headers["Authorization"] = "tampered"
+	if traces.Headers["Authorization"] != want {
+		t.Fatalf("traces headers aliased metrics headers")
+	}
+}
+
+func TestProbeConfigInsecureDropsToHTTP(t *testing.T) {
+	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "https://otlp.example/otlp")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_INSECURE", "true")
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "")
+
+	metrics, traces, ok := ProbeConfig()
+	if !ok {
+		t.Fatal("expected ok=true when an OTLP endpoint is configured")
+	}
+	// Real export ships cleartext when insecure is set, so the probe must hit
+	// http to test the same transport.
+	if metrics.URL != "http://otlp.example/otlp/v1/metrics" {
+		t.Fatalf("metrics URL = %q", metrics.URL)
+	}
+	if traces.URL != "http://otlp.example/otlp/v1/traces" {
+		t.Fatalf("traces URL = %q", traces.URL)
+	}
+}
+
+func TestProbeConfigNoEndpoint(t *testing.T) {
+	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	if _, _, ok := ProbeConfig(); ok {
+		t.Fatal("expected ok=false when no OTLP endpoint is configured")
+	}
+}
+
 func TestSignalEndpointURLAppendsOTLPHTTPPaths(t *testing.T) {
 	if got := signalEndpointURL("https://otlp.example/otlp", "traces"); got != "https://otlp.example/otlp/v1/traces" {
 		t.Fatalf("trace endpoint = %q", got)


### PR DESCRIPTION

<img width="846" height="381" alt="image" src="https://github.com/user-attachments/assets/b9e63181-49b5-4a30-9458-0f0ac25676b1" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only diagnostics and tests; optional network probes only with `--probe`. No changes to export or install paths at runtime.
> 
> **Overview**
> Adds **`sigil doctor`**, a read-only CLI that reports **conversations** (generation export) and **analytics** (OTLP) pipelines separately, **`config.env`** validity (capture mode, guards, tags, disallowed keys), and per-agent install state. Supports **`--json`** (token-safe for support) and **`--probe`** / **`--online`** for live HTTP checks with scope-aware 401/403 hints. Exits **1** when conversations, analytics, or config is in **error** (notably conversations configured but no OTLP endpoint).
> 
> Each launcher agent gains a non-mutating **`Status`** probe (Copilot checks hooks file, not plugin list; OpenCode/Pi can report pinned npm versions). **`internal/otel.ProbeConfig`** aligns OTLP probe URLs/auth with real export.
> 
> README troubleshooting now leads with **`sigil doctor`** instead of debug logs only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27e777e1b897761de0132ce18807218309a3a9cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->