### PR TITLE
fix(plugins/sigil): scope the headline model count to the time window

### DIFF
--- a/plugins/sigil/internal/local/web/app.jsx
+++ b/plugins/sigil/internal/local/web/app.jsx
@@ -949,6 +949,21 @@
         () => bucketTokenUsage(tokenFiltered, timeRange, now, { window: chartWindow }),
         [tokenFiltered, timeRange, now, chartWindow]
       );
+      // Distinct models that actually produced tokens inside the visible
+      // window. tokenModels spans the whole store (so the dropdown can
+      // still offer every model), but the headline count must agree with
+      // the windowed token total beside it — otherwise a 6h view reports
+      // models that only appear in older conversations.
+      const windowModelCount = useMemo(() => {
+        const seen = new Set();
+        for (const p of points) {
+          if (!p.model) continue;
+          const t = tokenPointTime(p);
+          if (!Number.isFinite(t) || t < chartWindow.start || t > chartWindow.end) continue;
+          seen.add(p.model);
+        }
+        return seen.size;
+      }, [points, chartWindow]);
 
       // Bucket drill-down from a chart bar click: the list narrows to
       // conversations active inside the picked bucket, while the charts
@@ -1018,14 +1033,14 @@
           conversations: filtered.length,
           conversationsSub: query ? "matching filter" : "active in range",
           tokens,
-          models: effectiveModel === "all" ? tokenModels.length : 1,
+          models: effectiveModel === "all" ? windowModelCount : 1,
           cachePct,
           calls,
           avgCalls: filtered.length ? calls / filtered.length : 0,
           errConvs,
           errPct: filtered.length ? Math.round((errConvs / filtered.length) * 100) : 0,
         };
-      }, [filtered, tokenUsage, tokenModels, effectiveModel, query, hiddenSeries]);
+      }, [filtered, tokenUsage, windowModelCount, effectiveModel, query, hiddenSeries]);
 
       return (
         <div style={{ padding: 24, maxWidth: 1600, margin: "0 auto" }}>


### PR DESCRIPTION
Count distinct models among token points inside the chart window, so the count matches the windowed total and the chart.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI calculation change in the local web viewer; no API, auth, or persistence impact.
> 
> **Overview**
> Fixes a mismatch on the Sigil local **Conversations** dashboard where the **Total tokens** KPI subtitle could show more models than the selected time range actually used.
> 
> When **All models** is selected, the model count under **Total tokens** now comes from distinct models on token points inside the same **`chartWindow`** as the token chart and windowed totals, instead of **`tokenModels.length`** across the full store. The model filter dropdown is unchanged and still lists every model ever seen in **`tokenPoints`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 340e42fc19281ede4d6dd3e1656491d644787917. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->