### PR TITLE
docs: document how tags, metadata, and user_id are routed

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Application SDK hooks evaluate Sigil guard rules on your request path before a p
 
 The SDKs default to `no_tool_content`: full generation messages ship to Sigil, but tool-execution arguments and results stay out of spans. The coding-agent plugins default to `metadata_only`. See [Content Capture Modes](docs/concepts/content-capture-modes.md) for the mode matrix, defaults per surface, and the generation, tool-execution, and embedding resolution rules.
 
+To attach custom key/values (team, project, env, request id, end-user id), see [Tags and Metadata](docs/concepts/tags-and-metadata.md). It covers which of client tags, per-generation tags, metadata, and `user_id` reach the generation export vs OTel spans vs metrics, and the cardinality rules for metric labels.
+
 ## Grafana Cloud credentials
 
 All four connection values (API URL, Instance ID, API token, and OTLP endpoint) live on the Connection tab of the AI Observability plugin in your stack:

--- a/docs/concepts/tags-and-metadata.md
+++ b/docs/concepts/tags-and-metadata.md
@@ -1,0 +1,105 @@
+# Tags and Metadata
+
+The SDK lets you attach custom key/value data (team, project, environment, request ID, end-user id) to what you record. Where each piece of data shows up depends on how you attach it. There are three independent mechanisms, and only one of them reaches OTel metrics.
+
+Each SDK README links here for the language-specific config fields.
+
+## The three mechanisms
+
+| Mechanism | Set where | Cardinality | Generation export (Sigil UI) | OTel spans (traces) | OTel metrics |
+| --- | --- | --- | --- | --- | --- |
+| **Client tags** (`SIGIL_TAGS` / config `tags`) | Once, on the client | Keep low | Yes, merged into every generation | Yes, as `sigil.tag.<key>` (Go/JS only) | Yes, as `sigil.tag.<key>` (Go/JS only) |
+| **Per-generation `tags`** | Per `startGeneration` call | Any | Yes | No | No |
+| **`metadata`** (struct/dict) | Per `startGeneration` call | Any | Yes | No | No |
+
+There is also a dedicated **`user_id`** field (`SIGIL_USER_ID` / config / per-call / context). It is recorded on the generation export and on the generation span as the `user.id` attribute (all SDKs), but it is **not** a metric label.
+
+## Cross-SDK parity
+
+`user.id` is emitted on the generation span by all five SDKs (Go, Python, JS, Java, .NET).
+
+Client tags are merged into the generation export by all five SDKs, but only **Go and JS** also emit them as `sigil.tag.<key>` attributes on OTel spans and metrics. In Python, Java, and .NET, client tags are export-only today. If you need a tag as a metric/trace label in those languages, set it on the OTel `Resource` (for example `service.name`, or a custom resource attribute) when you configure the providers.
+
+Client tags become OTel metric attributes on Go/JS, which become Prometheus label values: one time series per distinct value.
+
+## Setting them
+
+### Client tags and default user id (apply to every generation)
+
+Set client tags with the `SIGIL_TAGS` env var (CSV: `key=value,key=value`) and `SIGIL_USER_ID`. The SDK reads them when you construct the client with no explicit values. To set them in code:
+
+**Go**
+
+```go
+cfg := sigil.DefaultConfig()
+cfg.Tags = map[string]string{"team": "checkout", "env": "prod"}
+cfg.UserID = "u-1234" // default; per-call UserID and context still win
+client := sigil.NewClient(cfg)
+```
+
+**Python**
+
+```python
+client = Client(ClientConfig(
+    tags={"team": "checkout", "env": "prod"},
+    user_id="u-1234",
+    generation_export=...,
+))
+```
+
+**TypeScript / JavaScript**
+
+```ts
+const sigil = createSigilClient({
+  tags: { team: "checkout", env: "prod" },
+  userId: "u-1234",
+  generationExport: { /* ... */ },
+});
+```
+
+### Per-generation tags, metadata, and user id
+
+Per-call values win over client-level values on key conflict. Per-call `tags` and `metadata` are export-only; they do not appear on spans or metrics.
+
+**Go**
+
+```go
+ctx, rec := client.StartGeneration(ctx, sigil.GenerationStart{
+    Model:    sigil.ModelRef{Provider: "openai", Name: "gpt-4.1-mini"},
+    UserID:   "u-1234",                                  // -> user.id span attribute + export
+    Tags:     map[string]string{"feature": "summarize"}, // export only
+    Metadata: map[string]any{"prompt_version": "v2"},   // export only
+})
+defer rec.End()
+```
+
+**Python**
+
+```python
+with client.start_generation(GenerationStart(
+    model=ModelRef(provider="openai", name="gpt-4.1-mini"),
+    user_id="u-1234",                  # -> user.id span attribute + export
+    tags={"feature": "summarize"},     # export only
+    metadata={"prompt_version": "v2"} # export only
+)) as rec:
+    ...
+```
+
+**TypeScript / JavaScript**
+
+```ts
+await sigil.startGeneration(
+  {
+    model: { provider: "openai", name: "gpt-4.1-mini" },
+    userId: "u-1234",                  // -> user.id span attribute + export
+    tags: { feature: "summarize" },    // export only
+    metadata: { promptVersion: "v2" }, // export only
+  },
+  (rec) => { /* rec.setResult(...) */ },
+);
+```
+
+## See also
+
+- [Content Capture Modes](content-capture-modes.md) — which content fields ship. Content capture does not strip `tags` or `metadata`; both are always exported.
+- Per-language SDK READMEs for the full config surface and env-var mapping.

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -293,7 +293,7 @@ Resolution precedence for tool executions (highest to lowest):
 3. `SigilClientConfig.ContentCaptureResolver` return value
 4. `SigilClientConfig.ContentCapture` (defaults to `ContentCaptureMode.NoToolContent`)
 
-User-provided `Metadata` and `Tags` are not stripped by any capture mode. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content.
+User-provided `Metadata` and `Tags` are not stripped by any capture mode. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content. See [Tags and Metadata](../docs/concepts/tags-and-metadata.md) for where client tags, per-generation tags, metadata, and `UserId` each show up. .NET merges client tags into the generation export only; it does not emit `sigil.tag.<key>` on spans/metrics.
 
 ## Context defaults
 
@@ -377,7 +377,7 @@ SDK schema defaults fill the rest.
 | `SIGIL_AGENT_NAME` | `SigilClientConfig.AgentName` |
 | `SIGIL_AGENT_VERSION` | `SigilClientConfig.AgentVersion` |
 | `SIGIL_USER_ID` | `SigilClientConfig.UserId` |
-| `SIGIL_TAGS` | `SigilClientConfig.Tags` (CSV; merged into generation export; Go/JS also emit `sigil.tag.<key>` on spans/metrics) |
+| `SIGIL_TAGS` | `SigilClientConfig.Tags` (CSV; merged into generation export only. Only Go/JS emit `sigil.tag.<key>` on spans/metrics; see [Tags and Metadata](../docs/concepts/tags-and-metadata.md)) |
 | `SIGIL_CONTENT_CAPTURE_MODE` | `SigilClientConfig.ContentCapture` |
 | `SIGIL_DEBUG` | `SigilClientConfig.Debug` (tri-state `bool?`) |
 

--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -57,6 +57,10 @@ After running an example, open the AI Observability plugin in your Grafana Cloud
 - The input prompt and assistant response visible in the conversation drilldown.
 - Traces in your Grafana Cloud Traces datasource and metrics in Grafana Cloud Metrics.
 
+## Custom tags and metadata
+
+The Python, TypeScript, and Go single-generation examples set a client-level tag, a per-generation tag, `metadata`, and `user_id` so you can see where each one shows up. Client tags reach the generation plus (on Go/JS) OTel spans/metrics as `sigil.tag.<key>`; per-generation tags and metadata are export-only; `user_id` becomes the `user.id` span attribute. See [Tags and Metadata](../../docs/concepts/tags-and-metadata.md) for the full routing table and cardinality rules.
+
 ## Next steps
 
 - **Provider wrappers** — reduce boilerplate by using pre-built wrappers for [OpenAI](../../go-providers/openai/), [Anthropic](../../python-providers/anthropic/), and [Gemini](../../go-providers/gemini/).

--- a/examples/getting-started/go/main.go
+++ b/examples/getting-started/go/main.go
@@ -57,6 +57,10 @@ func main() {
 		TenantID:      os.Getenv("SIGIL_AUTH_TENANT_ID"),
 		BasicPassword: os.Getenv("SIGIL_AUTH_TOKEN"),
 	}
+	// Client tags attach to every generation. On Go/JS they also become
+	// sigil.tag.<key> attributes on OTel spans and metrics, so keep them
+	// low-cardinality (team, env). See docs/concepts/tags-and-metadata.md.
+	cfg.Tags = map[string]string{"team": "checkout", "env": "dev"}
 	sigilClient := sigil.NewClient(cfg)
 	defer func() { _ = sigilClient.Shutdown(ctx) }()
 
@@ -83,6 +87,13 @@ func main() {
 		AgentName:      "getting-started",
 		AgentVersion:   "1.0.0",
 		Model:          sigil.ModelRef{Provider: "openai", Name: model},
+		// user_id sets the user.id span attribute (all SDKs); use it for
+		// end-user identity instead of a high-cardinality tag.
+		UserID: "demo-user",
+		// Per-generation tags and metadata are export-only: searchable on the
+		// generation in Sigil, never emitted on spans or metrics.
+		Tags:     map[string]string{"feature": "summarize"},
+		Metadata: map[string]any{"prompt_version": "v2"},
 	})
 	defer rec.End()
 	_ = ctx

--- a/examples/getting-started/python/main.py
+++ b/examples/getting-started/python/main.py
@@ -52,6 +52,10 @@ sigil = Client(
                 basic_password=os.environ["SIGIL_AUTH_TOKEN"],
             ),
         ),
+        # Client tags attach to every generation. In Python they are merged
+        # into the generation export only (Go/JS also emit sigil.tag.<key> on
+        # spans/metrics). See docs/concepts/tags-and-metadata.md.
+        tags={"team": "checkout", "env": "dev"},
     )
 )
 
@@ -75,6 +79,13 @@ with sigil.start_generation(
         agent_name="getting-started",
         agent_version="1.0.0",
         model=ModelRef(provider="openai", name=model),
+        # user_id sets the user.id span attribute; use it for end-user
+        # identity instead of a high-cardinality tag.
+        user_id="demo-user",
+        # Per-generation tags and metadata are export-only: searchable on the
+        # generation in Sigil, never emitted on spans or metrics.
+        tags={"feature": "summarize"},
+        metadata={"prompt_version": "v2"},
     )
 ) as rec:
     rec.set_result(

--- a/examples/getting-started/typescript/main.ts
+++ b/examples/getting-started/typescript/main.ts
@@ -44,6 +44,10 @@ const sigil = createSigilClient({
       basicPassword: process.env.SIGIL_AUTH_TOKEN!,
     },
   },
+  // Client tags attach to every generation. On Go/JS they also become
+  // sigil.tag.<key> attributes on OTel spans and metrics, so keep them
+  // low-cardinality (team, env). See docs/concepts/tags-and-metadata.md.
+  tags: { team: "checkout", env: "dev" },
 });
 
 const prompt = "Explain what LLM observability is in two sentences.";
@@ -66,6 +70,13 @@ await sigil.startGeneration(
     agentName: "getting-started",
     agentVersion: "1.0.0",
     model: { provider: "openai", name: model },
+    // userId sets the user.id span attribute (all SDKs); use it for end-user
+    // identity instead of a high-cardinality tag.
+    userId: "demo-user",
+    // Per-generation tags and metadata are export-only: searchable on the
+    // generation in Sigil, never emitted on spans or metrics.
+    tags: { feature: "summarize" },
+    metadata: { promptVersion: "v2" },
   },
   (rec: GenerationRecorder) => {
     rec.setResult({

--- a/go/README.md
+++ b/go/README.md
@@ -334,7 +334,7 @@ Resolution precedence for tool executions (highest to lowest):
 3. `ContentCaptureResolver` return value
 4. `Config.ContentCapture` (defaults to `ContentCaptureModeNoToolContent`)
 
-User-provided `Metadata` and `Tags` are not stripped by any capture mode. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content.
+User-provided `Metadata` and `Tags` are not stripped by any capture mode. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content. See [Tags and Metadata](../docs/concepts/tags-and-metadata.md) for where client tags, per-generation tags, metadata, and `user_id` each show up (export vs spans vs metrics).
 
 ## Pre-Ingest Redaction
 

--- a/java/README.md
+++ b/java/README.md
@@ -196,7 +196,7 @@ Resolution precedence for tool executions (highest to lowest):
 3. `ContentCaptureResolver` return value
 4. `SigilClientConfig.contentCapture` (defaults to `NO_TOOL_CONTENT`)
 
-User-provided `metadata` and `tags` are not stripped by any capture mode. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content.
+User-provided `metadata` and `tags` are not stripped by any capture mode. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content. See [Tags and Metadata](../docs/concepts/tags-and-metadata.md) for where client tags, per-generation tags, metadata, and `userId` each show up. Java merges client tags into the generation export only; it does not emit `sigil.tag.<key>` on spans/metrics.
 
 ## Embedding Observability
 
@@ -367,7 +367,7 @@ SDK schema defaults fill the rest.
 | `SIGIL_AGENT_NAME` | `SigilClientConfig.agentName` |
 | `SIGIL_AGENT_VERSION` | `SigilClientConfig.agentVersion` |
 | `SIGIL_USER_ID` | `SigilClientConfig.userId` |
-| `SIGIL_TAGS` | `SigilClientConfig.tags` (CSV; merged into generation export; Go/JS also emit `sigil.tag.<key>` on spans/metrics) |
+| `SIGIL_TAGS` | `SigilClientConfig.tags` (CSV; merged into generation export only. Only Go/JS emit `sigil.tag.<key>` on spans/metrics; see [Tags and Metadata](../docs/concepts/tags-and-metadata.md)) |
 | `SIGIL_CONTENT_CAPTURE_MODE` | `SigilClientConfig.contentCapture` |
 | `SIGIL_DEBUG` | `SigilClientConfig.debug` (tri-state) |
 

--- a/js/README.md
+++ b/js/README.md
@@ -128,7 +128,7 @@ Resolution precedence (highest to lowest):
 
 Unlike the Go, Python, Java, and .NET SDKs, the JS SDK does not propagate the resolved capture mode through async context, so tool executions started inside a generation block do not automatically inherit the generation's mode. Set `contentCapture` on each `ToolExecutionStart` when you need a tool to follow a non-default policy.
 
-User-provided `metadata` and `tags` are not stripped by any capture mode. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content.
+User-provided `metadata` and `tags` are not stripped by any capture mode. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content. See [Tags and Metadata](../docs/concepts/tags-and-metadata.md) for where client tags, per-generation tags, metadata, and `userId` each show up (export vs spans vs metrics).
 
 ## Pre-Ingest Redaction
 

--- a/llms.txt
+++ b/llms.txt
@@ -109,7 +109,8 @@ SIGIL_PROTOCOL=http
 SIGIL_AUTH_MODE=basic
 SIGIL_AUTH_TENANT_ID=<your-instance-id>
 SIGIL_AUTH_TOKEN=<glc_... token>
-SIGIL_TAGS=project=my-app,env=dev   # optional; also sigil.tag.<key> on OTel spans/metrics
+SIGIL_TAGS=team=checkout,env=prod   # optional client tags; on Go/JS also emitted as sigil.tag.<key> on OTel spans/metrics
+SIGIL_USER_ID=<end-user id>          # optional; sets the user.id span attribute (all SDKs)
 
 # OTel traces and metrics (separate channel; same token)
 OTEL_EXPORTER_OTLP_ENDPOINT=<from stack OpenTelemetry card>
@@ -125,6 +126,16 @@ The core SDK clients default to `no_tool_content`: generation content (prompts, 
 Use the cross-language reference at [`docs/concepts/content-capture-modes.md`](https://github.com/grafana/sigil-sdk/blob/main/docs/concepts/content-capture-modes.md) and the per-language READMEs for examples. Modes supported by the SDKs: `full`, `no_tool_content`, `metadata_only`, `full_with_metadata_spans`. User-provided `metadata` and `tags` are not stripped by capture modes; do not put sensitive content there.
 
 This default differs from coding-agent plugin defaults (Path A), which ship `metadata_only`. Do not mix the two.
+
+### Tags, metadata, and user id
+
+To attach custom key/values, pick the mechanism by where it must show up. See [`docs/concepts/tags-and-metadata.md`](https://github.com/grafana/sigil-sdk/blob/main/docs/concepts/tags-and-metadata.md) for the full table.
+
+- **Client tags** (`SIGIL_TAGS` / config `tags`): merged into every generation export; on **Go/JS** also emitted as `sigil.tag.<key>` on OTel spans and metrics (Python/Java/.NET are export-only). Use for low-cardinality values you want to slice metrics/traces by (team, project, env). Do not put high-cardinality values (user, request id) here, they blow up metric label cardinality.
+- **Per-generation `tags` / `metadata`**: export-only, never on spans/metrics. Use for searchable per-request data.
+- **`user_id`** (`SIGIL_USER_ID` / per-call / context): sets the `user.id` span attribute (all SDKs) plus the export; not a metric label. Use this for end-user identity instead of a tag.
+
+Capture modes do not strip `tags`/`metadata`/`user_id`; do not put secrets there.
 
 ## Mission
 
@@ -436,7 +447,7 @@ In the grafana/sigil-sdk repo:
   - `stop_reason` / `finish_reason`
   - Full token usage including `cache_read_input_tokens`, `cache_write_input_tokens`, and `reasoning_tokens` when the provider returns them
 - Always check `rec.err()` / `Err()` after the generation recorder closes; SDK validation or enqueue errors are otherwise silent.
-- Use `SIGIL_TAGS` (client-level) or `tags` on `GenerationStart` for filtering: export tags on generations; client-level tags also appear as `sigil.tag.<key>` on OTel spans and metrics (e.g. `project=my-app`).
+- Use `SIGIL_TAGS` (client-level) or `tags` on `GenerationStart` for filtering: both export tags on generations. Client-level tags also appear as `sigil.tag.<key>` on OTel spans and metrics on Go/JS only (Python/Java/.NET are export-only); per-generation tags and `metadata` are export-only everywhere. For end-user identity use `user_id` (sets `user.id` span attribute), not a tag. See [`docs/concepts/tags-and-metadata.md`](https://github.com/grafana/sigil-sdk/blob/main/docs/concepts/tags-and-metadata.md).
 
 ## Validation checklist
 

--- a/python/README.md
+++ b/python/README.md
@@ -433,7 +433,7 @@ with with_conversation_id("conv-ctx"), with_agent_name("planner"), with_agent_ve
 
 `FULL_WITH_METADATA_SPANS` is the right mode when the gRPC ingest destination is private but the OTel trace/metric destination is shared and must not receive any content. Tool execution and embedding spans behave like `METADATA_ONLY` under this mode because they have no separate gRPC export.
 
-User-provided `metadata` and `tags` are **not** stripped by any capture mode; callers must avoid putting sensitive content in those dicts when using `METADATA_ONLY` or `FULL_WITH_METADATA_SPANS`. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content.
+User-provided `metadata` and `tags` are **not** stripped by any capture mode; callers must avoid putting sensitive content in those dicts when using `METADATA_ONLY` or `FULL_WITH_METADATA_SPANS`. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content. See [Tags and Metadata](../docs/concepts/tags-and-metadata.md) for where client tags, per-generation tags, metadata, and `user_id` each show up (Python merges client tags into the generation export only, not onto spans/metrics).
 
 ### Client-level default
 


### PR DESCRIPTION
Add a tags-and-metadata concept doc with the routing table, the cross-SDK parity gap, and cardinality guidance, then point the SDK READMEs, llms.txt, and the getting-started examples at it.