### PR TITLE
feat(plugins/sigil): cache local-mode daemon aggregates per file

### DIFF
--- a/plugins/sigil/internal/local/query.go
+++ b/plugins/sigil/internal/local/query.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -92,14 +93,21 @@ func (s *Storage) ListConversations(limit int) ([]ConversationSummary, error) {
 		if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
 			continue
 		}
-		sum, ok, err := summariseConversationFile(filepath.Join(dir, e.Name()))
+		info, err := e.Info()
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue // file vanished between ReadDir and Info
+			}
+			return nil, err
+		}
+		agg, err := s.fileAggregateFor(filepath.Join(dir, e.Name()), info)
 		if err != nil {
 			return nil, err
 		}
-		if !ok {
+		if !agg.hasSummary {
 			continue // empty or all-invalid file
 		}
-		out = append(out, sum)
+		out = append(out, agg.summary)
 	}
 	sort.Slice(out, func(i, j int) bool {
 		return out[i].LastActivity.After(out[j].LastActivity)
@@ -110,16 +118,41 @@ func (s *Storage) ListConversations(limit int) ([]ConversationSummary, error) {
 	return out, nil
 }
 
-// summariseConversationFile reads one per-conversation JSONL file and
-// returns its aggregated summary. Returns (_, false, nil) when the file
-// has no decodable records.
-func summariseConversationFile(path string) (ConversationSummary, bool, error) {
+// scanFileAggregate reads one per-conversation JSONL file once and
+// computes both its conversation summary and its token-usage points,
+// decoding only the metadata fields they need (see scanGenerationMeta).
+// hasSummary is false when the file has no decodable records, so the
+// caller can cache it as "no summary" and skip re-scanning empty files.
+//
+// The returned aggregate carries the mtime and size of exactly the bytes
+// scanned: it stats the open fd and reads only up to that size, so a
+// concurrent append that lands mid-scan can't make the cache key describe
+// content other than what was actually read. The next poll sees the
+// larger size and re-scans. A missing file yields an empty, no-summary
+// aggregate (zero mtime/size), mirroring the old IsNotExist tolerance.
+func scanFileAggregate(path string) (fileAggregate, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fileAggregate{}, nil
+		}
+		return fileAggregate{}, err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return fileAggregate{}, err
+	}
+
 	agents := map[string]struct{}{}
 	models := map[string]struct{}{}
 	var sum ConversationSummary
 	var hasError, seen bool
+	var points []TokenUsagePoint
 
-	err := scanGenerationRecords(path, func(r generationRecord, gen storedGeneration) {
+	err = scanGenerationMeta(io.LimitReader(f, info.Size()), func(r leanRecord) {
+		gen := r.Generation
 		seen = true
 		if sum.ID == "" {
 			sum.ID = r.ConversationID
@@ -160,12 +193,19 @@ func summariseConversationFile(path string) (ConversationSummary, bool, error) {
 		if gen.CallError != "" {
 			hasError = true
 		}
+
+		if p, ok := tokenUsagePoint(r); ok {
+			points = append(points, p)
+		}
 	})
 	if err != nil {
-		return ConversationSummary{}, false, err
+		return fileAggregate{}, err
 	}
 	if !seen {
-		return ConversationSummary{}, false, nil
+		// File exists but has no decodable records. Cache it with its
+		// real mtime/size so empty files validate and aren't re-scanned
+		// every poll.
+		return fileAggregate{mtime: info.ModTime(), size: info.Size()}, nil
 	}
 	sum.Agents = sortedKeys(agents)
 	sum.Models = sortedKeys(models)
@@ -173,7 +213,13 @@ func summariseConversationFile(path string) (ConversationSummary, bool, error) {
 	if hasError {
 		sum.Status = "err"
 	}
-	return sum, true, nil
+	return fileAggregate{
+		summary:    sum,
+		hasSummary: true,
+		points:     points,
+		mtime:      info.ModTime(),
+		size:       info.Size(),
+	}, nil
 }
 
 // ConversationDetail returns the chronological generation list for one
@@ -277,14 +323,20 @@ func (s *Storage) TokenUsagePoints() ([]TokenUsagePoint, error) {
 		if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
 			continue
 		}
-		err := scanGenerationRecords(filepath.Join(dir, e.Name()), func(r generationRecord, gen storedGeneration) {
-			if p, ok := tokenUsagePoint(r, gen); ok {
-				out = append(out, p)
+		info, err := e.Info()
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue // file vanished between ReadDir and Info
 			}
-		})
+			return nil, err
+		}
+		agg, err := s.fileAggregateFor(filepath.Join(dir, e.Name()), info)
 		if err != nil {
 			return nil, err
 		}
+		// agg.points is owned by the cache; append into our own slice so
+		// the sort below never reorders the cached per-file order.
+		out = append(out, agg.points...)
 	}
 	sort.Slice(out, func(i, j int) bool {
 		return out[i].Timestamp.Before(out[j].Timestamp)
@@ -295,7 +347,8 @@ func (s *Storage) TokenUsagePoints() ([]TokenUsagePoint, error) {
 // tokenUsagePoint builds a TokenUsagePoint from one record. ok is false
 // when the generation recorded no tokens or has no usable timestamp, so
 // the caller can skip it rather than plot a zero-height bar at the epoch.
-func tokenUsagePoint(r generationRecord, gen storedGeneration) (TokenUsagePoint, bool) {
+func tokenUsagePoint(r leanRecord) (TokenUsagePoint, bool) {
+	gen := r.Generation
 	buckets := disjointTokenUsage(gen.Usage.toSDK(), gen.Model.Provider)
 	if buckets == (TokenBuckets{}) {
 		return TokenUsagePoint{}, false
@@ -314,7 +367,7 @@ func tokenUsagePoint(r generationRecord, gen storedGeneration) (TokenUsagePoint,
 
 // generationTime is the wall-clock moment a generation ran, preferring
 // started_at, then completed_at, then the receiver's arrival time.
-func generationTime(gen storedGeneration, r generationRecord) time.Time {
+func generationTime(gen storedGenerationMeta, r leanRecord) time.Time {
 	if !gen.StartedAt.IsZero() {
 		return gen.StartedAt
 	}
@@ -488,6 +541,77 @@ func toolResultMatchesAny(msg sigil.Message, ids map[string]struct{}) bool {
 		}
 	}
 	return false
+}
+
+// storedGenerationMeta is storedGeneration without Input/Output. The
+// JSON decoder skips the (large) input/output values since there are no
+// matching struct fields, so the summary/token scans never allocate the
+// message/part trees they would otherwise decode and discard.
+type storedGenerationMeta struct {
+	ID                string         `json:"id,omitempty"`
+	ConversationID    string         `json:"conversation_id,omitempty"`
+	ConversationTitle string         `json:"conversation_title,omitempty"`
+	AgentName         string         `json:"agent_name,omitempty"`
+	Model             sigil.ModelRef `json:"model,omitzero"`
+	ResponseModel     string         `json:"response_model,omitempty"`
+	Usage             storedUsage    `json:"usage,omitzero"`
+	StartedAt         time.Time      `json:"started_at,omitzero"`
+	CompletedAt       time.Time      `json:"completed_at,omitzero"`
+	Metadata          map[string]any `json:"metadata,omitempty"`
+	CallError         string         `json:"call_error,omitempty"`
+}
+
+// title and modelName duplicate the storedGeneration logic in wire.go;
+// keep them in sync.
+func (g storedGenerationMeta) title() string {
+	if strings.TrimSpace(g.ConversationTitle) != "" {
+		return g.ConversationTitle
+	}
+	if g.Metadata == nil {
+		return ""
+	}
+	if title, ok := g.Metadata[metadataKeyConversationTitle].(string); ok {
+		return title
+	}
+	return ""
+}
+
+func (g storedGenerationMeta) modelName() string {
+	if g.ResponseModel != "" {
+		return g.ResponseModel
+	}
+	return g.Model.Name
+}
+
+// leanRecord decodes one JSONL line: the wrapper scalars plus the nested
+// generation metadata, in a single Unmarshal with no json.RawMessage copy
+// of the full generation.
+type leanRecord struct {
+	ReceivedAt     string               `json:"received_at"`
+	ConversationID string               `json:"conversation_id"`
+	Generation     storedGenerationMeta `json:"generation"`
+}
+
+// scanGenerationMeta walks the JSONL records in r calling visit for every
+// decodable record, decoding only the metadata fields. It mirrors
+// scanGenerationRecords' scanner buffer but does one json.Unmarshal per
+// line instead of two plus a copy. The caller owns the reader (and any
+// size limit); see scanFileAggregate.
+func scanGenerationMeta(r io.Reader, visit func(leanRecord)) error {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 1024*1024), 64*1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var rec leanRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			continue
+		}
+		visit(rec)
+	}
+	return sc.Err()
 }
 
 func scanGenerationRecords(path string, visit func(generationRecord, storedGeneration)) error {

--- a/plugins/sigil/internal/local/query_test.go
+++ b/plugins/sigil/internal/local/query_test.go
@@ -1,7 +1,11 @@
 package local
 
 import (
+	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -685,4 +689,213 @@ func TestTokenUsagePoints_EmptyStore(t *testing.T) {
 	points, err := s.TokenUsagePoints()
 	require.NoError(t, err)
 	assert.Empty(t, points)
+}
+
+// TestAggregateCache_HitsAndInvalidates covers the per-file aggregate
+// cache: identical results on re-call, invalidation when a generation is
+// appended (size+mtime change), a cache hit served without re-reading the
+// file (proved by corrupting content under an unchanged mtime+size), and
+// a TTL-driven re-scan once the entry ages out.
+func TestAggregateCache_HitsAndInvalidates(t *testing.T) {
+	s := newStorage(t)
+	clock := mustParse(t, "2026-05-21T10:00:00Z")
+	s.now = func() time.Time { return clock }
+
+	writeGen(t, s, "conv-A", "g1", sigil.Generation{
+		AgentName:   "pi",
+		Model:       sigil.ModelRef{Provider: "anthropic", Name: "claude-opus-4-7"},
+		StartedAt:   mustParse(t, "2026-05-21T10:00:00Z"),
+		CompletedAt: mustParse(t, "2026-05-21T10:00:03Z"),
+		Usage:       sigil.TokenUsage{InputTokens: 100, OutputTokens: 50},
+	}, "2026-05-21T10:00:03Z")
+
+	list1, err := s.ListConversations(0)
+	require.NoError(t, err)
+	pts1, err := s.TokenUsagePoints()
+	require.NoError(t, err)
+	require.Len(t, list1, 1)
+	require.Equal(t, 1, list1[0].Calls)
+	require.Len(t, pts1, 1)
+
+	// Re-call with no change: identical results, served from cache.
+	list2, err := s.ListConversations(0)
+	require.NoError(t, err)
+	pts2, err := s.TokenUsagePoints()
+	require.NoError(t, err)
+	assert.Equal(t, list1, list2)
+	assert.Equal(t, pts1, pts2)
+
+	// Append a second generation: size grows, so the cache invalidates and
+	// the new generation shows up in both the summary and the points.
+	writeGen(t, s, "conv-A", "g2", sigil.Generation{
+		AgentName:   "pi",
+		Model:       sigil.ModelRef{Provider: "anthropic", Name: "claude-opus-4-7"},
+		StartedAt:   mustParse(t, "2026-05-21T10:00:10Z"),
+		CompletedAt: mustParse(t, "2026-05-21T10:00:13Z"),
+		Usage:       sigil.TokenUsage{InputTokens: 200, OutputTokens: 80},
+	}, "2026-05-21T10:00:13Z")
+
+	list3, err := s.ListConversations(0)
+	require.NoError(t, err)
+	pts3, err := s.TokenUsagePoints()
+	require.NoError(t, err)
+	require.Len(t, list3, 1)
+	assert.Equal(t, 2, list3[0].Calls)
+	assert.Equal(t, int64(300), list3[0].InputTokens)
+	assert.Equal(t, int64(130), list3[0].OutputTokens)
+	assert.Len(t, pts3, 2)
+
+	// Corrupt the file while preserving its size and mtime. A cache hit
+	// must serve the prior aggregate without re-reading the now-garbage
+	// bytes.
+	path := filepath.Join(s.dir, ConversationsDir, "conv-A.jsonl")
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	orig, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, bytes.Repeat([]byte("x"), len(orig)), 0o600))
+	require.NoError(t, os.Chtimes(path, info.ModTime(), info.ModTime()))
+
+	list4, err := s.ListConversations(0)
+	require.NoError(t, err)
+	assert.Equal(t, list3, list4, "unchanged mtime+size must serve the cached summary")
+
+	// Advance past the TTL: the entry ages out and the file is re-scanned.
+	// The garbage has no decodable records, so the conversation drops out.
+	clock = clock.Add(aggregateCacheTTL + time.Minute)
+	list5, err := s.ListConversations(0)
+	require.NoError(t, err)
+	assert.Empty(t, list5, "TTL expiry forces a re-scan of the corrupted file")
+	pts5, err := s.TokenUsagePoints()
+	require.NoError(t, err)
+	assert.Empty(t, pts5)
+}
+
+// TestAggregateCache_ScanUsesFdStatNotCallerInfo pins that the cache key
+// describes the bytes actually scanned, not the caller's pre-scan stat. An
+// append that lands after ListConversations/TokenUsagePoints snapshot the
+// DirEntry info but before the scan runs must not leave the entry keyed by
+// the stale (smaller) size, which would let a later poll at the real size
+// serve content that omits the appended generation.
+func TestAggregateCache_ScanUsesFdStatNotCallerInfo(t *testing.T) {
+	// info picks which os.FileInfo a caller hands to fileAggregateFor,
+	// given the pre-append snapshot and the current on-disk stat. Whatever
+	// it returns, a cold scan must cache the real on-disk content keyed by
+	// the real size from the fd stat — a stale, smaller info must not key
+	// the entry and let a later poll serve a generation-short aggregate.
+	cases := []struct {
+		name string
+		info func(stale, current os.FileInfo) os.FileInfo
+	}{
+		{
+			name: "stale smaller info from before the append",
+			info: func(stale, _ os.FileInfo) os.FileInfo { return stale },
+		},
+		{
+			name: "current info matching disk",
+			info: func(_, current os.FileInfo) os.FileInfo { return current },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newStorage(t)
+			clock := mustParse(t, "2026-05-21T10:00:00Z")
+			s.now = func() time.Time { return clock }
+
+			writeGen(t, s, "conv-A", "g1", sigil.Generation{
+				Model:     sigil.ModelRef{Provider: "anthropic", Name: "claude-opus-4-7"},
+				StartedAt: mustParse(t, "2026-05-21T10:00:00Z"),
+				Usage:     sigil.TokenUsage{InputTokens: 100, OutputTokens: 50},
+			}, "2026-05-21T10:00:00Z")
+
+			path := filepath.Join(s.dir, ConversationsDir, "conv-A.jsonl")
+			stale, err := os.Stat(path)
+			require.NoError(t, err)
+
+			// Append after capturing stale, mimicking a write that lands
+			// between the caller's ReadDir stat and the scan.
+			writeGen(t, s, "conv-A", "g2", sigil.Generation{
+				Model:     sigil.ModelRef{Provider: "anthropic", Name: "claude-opus-4-7"},
+				StartedAt: mustParse(t, "2026-05-21T10:00:10Z"),
+				Usage:     sigil.TokenUsage{InputTokens: 200, OutputTokens: 80},
+			}, "2026-05-21T10:00:10Z")
+
+			current, err := os.Stat(path)
+			require.NoError(t, err)
+			require.Greater(t, current.Size(), stale.Size())
+
+			// The aggregate must reflect both generations on disk, and the
+			// cached entry must carry the real size from the fd stat, not the
+			// info passed in.
+			agg, err := s.fileAggregateFor(path, tc.info(stale, current))
+			require.NoError(t, err)
+			assert.Equal(t, 2, agg.summary.Calls)
+			assert.Equal(t, current.Size(), agg.size)
+			assert.True(t, agg.mtime.Equal(current.ModTime()))
+
+			// The entry is keyed by the real size, so a poll at that size is
+			// a genuine cache hit: overwrite with same-size garbage, keep the
+			// mtime, and confirm the cached summary is served, not the garbage.
+			orig, err := os.ReadFile(path)
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(path, bytes.Repeat([]byte("x"), len(orig)), 0o600))
+			require.NoError(t, os.Chtimes(path, current.ModTime(), current.ModTime()))
+
+			hit, err := s.fileAggregateFor(path, current)
+			require.NoError(t, err)
+			assert.Equal(t, 2, hit.summary.Calls, "real size must hit the cache, not re-scan garbage")
+		})
+	}
+}
+
+// TestAggregates_IgnoreInputOutput is the lean-decode equivalence guard:
+// a generation carrying large input/output message trees must produce the
+// same summary and token points as one with the scalar fields alone, since
+// the aggregate scans never read input/output.
+func TestAggregates_IgnoreInputOutput(t *testing.T) {
+	s := newStorage(t)
+
+	big := strings.Repeat("x", 4096)
+	withContent := sigil.Generation{
+		AgentName:   "pi",
+		Model:       sigil.ModelRef{Provider: "anthropic", Name: "claude-opus-4-7"},
+		StartedAt:   mustParse(t, "2026-05-21T10:00:00Z"),
+		CompletedAt: mustParse(t, "2026-05-21T10:00:03Z"),
+		Usage:       sigil.TokenUsage{InputTokens: 100, OutputTokens: 50, CacheReadInputTokens: 30, CacheWriteInputTokens: 20},
+		Input:       []sigil.Message{{Role: sigil.RoleUser, Parts: []sigil.Part{{Kind: sigil.PartKindText, Text: big}}}},
+		Output:      []sigil.Message{{Role: sigil.RoleAssistant, Parts: []sigil.Part{{Kind: sigil.PartKindText, Text: big}}}},
+	}
+	writeGen(t, s, "conv-A", "g1", withContent, "2026-05-21T10:00:03Z")
+
+	// Same scalars, no message content.
+	noContent := withContent
+	noContent.Input = nil
+	noContent.Output = nil
+	writeGen(t, s, "conv-B", "g2", noContent, "2026-05-21T10:00:03Z")
+
+	list, err := s.ListConversations(0)
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+
+	byID := map[string]ConversationSummary{}
+	for _, c := range list {
+		byID[c.ID] = c
+	}
+	a, b := byID["conv-A"], byID["conv-B"]
+	// Normalise the fields that legitimately differ between the two.
+	a.ID, b.ID = "", ""
+	assert.Equal(t, b, a, "input/output must not change the conversation summary")
+
+	pts, err := s.TokenUsagePoints()
+	require.NoError(t, err)
+	require.Len(t, pts, 2)
+	assert.Equal(t, pts[0].TokenBuckets, pts[1].TokenBuckets, "input/output must not change token points")
+
+	// The full-decode detail path still surfaces the message content.
+	detail, err := s.ConversationDetail("conv-A")
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+	require.Len(t, detail.Generations, 1)
+	assert.NotEmpty(t, detail.Generations[0].Messages, "detail path still decodes input/output")
 }

--- a/plugins/sigil/internal/local/storage.go
+++ b/plugins/sigil/internal/local/storage.go
@@ -12,9 +12,19 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/xdg"
 )
+
+// aggregateCacheTTL bounds how long a cached per-file aggregate is trusted
+// without re-checking the file. mtime+size is the primary validator —
+// conversation files are append-only, so any new generation grows the
+// file and invalidates the entry. The TTL is only a defensive backstop
+// for a same-size+same-mtime overwrite (which append-only capture won't
+// normally produce), and is set well above the viewer's 30s poll so idle
+// conversations stay cached across polls.
+const aggregateCacheTTL = 5 * time.Minute
 
 // File names under the local state root. Kept exported so tests and docs
 // can reference the canonical paths.
@@ -42,6 +52,33 @@ type Storage struct {
 	// need finer locking; this just stops interleaved JSON lines.
 	mu    sync.Mutex
 	locks map[string]*sync.Mutex
+
+	// now is the clock used for aggregate-cache TTL checks; a seam so
+	// tests can advance time without sleeping.
+	now func() time.Time
+
+	// agg caches per-file conversation summaries and token points so the
+	// list/metrics endpoints don't re-parse unchanged files on every poll.
+	// Entries are keyed by path and never evicted: local capture has no
+	// deletion or rotation path, so a stale key can't accumulate in
+	// practice, and a dead entry never surfaces (the endpoints only read
+	// keys for files present in the current ReadDir).
+	aggMu sync.Mutex
+	agg   map[string]fileAggregate
+}
+
+// fileAggregate is one conversation file's cached summary and token
+// points, plus the mtime+size+cachedAt used to decide whether the cache
+// entry is still valid (see fileAggregateFor). hasSummary is false when
+// the file had no decodable records, so empty files are not re-scanned
+// every poll.
+type fileAggregate struct {
+	summary    ConversationSummary
+	hasSummary bool
+	points     []TokenUsagePoint
+	mtime      time.Time
+	size       int64
+	cachedAt   time.Time
 }
 
 // NewStorage returns a Storage rooted at dir. The directory, the
@@ -54,7 +91,47 @@ func NewStorage(dir string) (*Storage, error) {
 	if err := os.MkdirAll(filepath.Join(dir, ConversationsDir), 0o700); err != nil {
 		return nil, fmt.Errorf("local storage: mkdir %s: %w", dir, err)
 	}
-	return &Storage{dir: dir, locks: map[string]*sync.Mutex{}}, nil
+	return &Storage{
+		dir:   dir,
+		locks: map[string]*sync.Mutex{},
+		now:   time.Now,
+		agg:   map[string]fileAggregate{},
+	}, nil
+}
+
+// fileAggregateFor returns the cached aggregate for path when the file's
+// mtime and size still match the cached entry and the entry is younger
+// than aggregateCacheTTL; otherwise it re-scans the file once (computing
+// the summary and token points together), stores the result, and returns
+// it. The scan runs outside the lock, so two concurrent cold callers may
+// scan the same file once each — idempotent, last write wins.
+//
+// info is the caller's current view of the file (from ReadDir) and is used
+// only for the cache-hit check. The stored mtime/size come from
+// scanFileAggregate, which stats the fd it reads, so the cache key always
+// describes the exact bytes scanned even if the file grew between the
+// caller's stat and the scan.
+func (s *Storage) fileAggregateFor(path string, info os.FileInfo) (fileAggregate, error) {
+	s.aggMu.Lock()
+	if e, ok := s.agg[path]; ok &&
+		e.mtime.Equal(info.ModTime()) &&
+		e.size == info.Size() &&
+		s.now().Sub(e.cachedAt) < aggregateCacheTTL {
+		s.aggMu.Unlock()
+		return e, nil
+	}
+	s.aggMu.Unlock()
+
+	agg, err := scanFileAggregate(path)
+	if err != nil {
+		return fileAggregate{}, err
+	}
+	agg.cachedAt = s.now()
+
+	s.aggMu.Lock()
+	s.agg[path] = agg
+	s.aggMu.Unlock()
+	return agg, nil
 }
 
 // Dir returns the storage root directory.

--- a/plugins/sigil/internal/local/wire.go
+++ b/plugins/sigil/internal/local/wire.go
@@ -69,6 +69,10 @@ func (u storedUsage) toSDK() sigil.TokenUsage {
 	}
 }
 
+// storedGeneration is the full on-disk generation. storedGenerationMeta
+// (query.go) is a field-for-field copy minus Input/Output used by the
+// aggregate scans; a field added here that the summary or token points
+// read must also be added there or it will read as zero in the cached path.
 type storedGeneration struct {
 	ID                string          `json:"id,omitempty"`
 	ConversationID    string          `json:"conversation_id,omitempty"`


### PR DESCRIPTION
The --local viewer auto-refreshes every 30s and calls conversations and token-metrics endpoints. Each call re-read and fully parsed every conversations/*.jsonl file, so all data was parsed twice per poll for as long as the tab stayed open, including the heavy input/output message trees the aggregates never look at.

Cache per-file aggregates in the daemon's single Storage instance, keyed by mtime+size with a 5-minute TTL. A single lean decode reads the wrapper scalars and nested meta in one pass and omits input/output, which encoding/json skips.