### PR TITLE
fix(plugins/sigil): stop local daemons started with go run

### DIFF
--- a/plugins/sigil/internal/local/manager.go
+++ b/plugins/sigil/internal/local/manager.go
@@ -294,7 +294,12 @@ func processLooksLikeDaemon(pid int) (bool, error) {
 	if exe == "" {
 		return false, nil
 	}
-	return strings.HasPrefix(filepath.Base(exe), "sigil"), nil
+	base := filepath.Base(exe)
+	// Release builds and `go build` name the binary "sigil"; `go run`
+	// compiles it to "main" in the build cache. Accept both, otherwise a
+	// daemon started from a dev build fails this check, Stop deletes the
+	// status file, and the daemon is orphaned on its port.
+	return strings.HasPrefix(base, "sigil") || base == "main", nil
 }
 
 // endpointAlive returns true when GET <endpoint>/healthz responds within

--- a/plugins/sigil/internal/local/manager_test.go
+++ b/plugins/sigil/internal/local/manager_test.go
@@ -49,7 +49,10 @@ func TestStop_EndpointDeadButProcessAlive(t *testing.T) {
 	}{
 		{name: "signals daemon-looking process", cmdline: "/usr/local/bin/sigil local serve", wantStop: true},
 		{name: "signals daemon-looking process with spaces in path", cmdline: "/tmp/Sigil Dev/sigil local serve", wantStop: true},
+		{name: "signals go run dev daemon", cmdline: "/Users/x/Library/Caches/go-build/ab/cd-d/main local serve", wantStop: true},
 		{name: "does not signal unrelated live pid", cmdline: "sleep 60", wantAlive: true},
+		{name: "does not signal main without local serve suffix", cmdline: "/tmp/main serve", wantAlive: true},
+		{name: "does not signal non-sigil binary with local serve suffix", cmdline: "/tmp/python local serve", wantAlive: true},
 		{name: "does not signal unrelated live pid with healthy endpoint", cmdline: "sleep 60", liveEndpoint: true, wantAlive: true},
 		{name: "keeps status when pid identity cannot be checked", cmdlineError: errors.New("ps failed"), wantAlive: true, wantErr: "identify recorded daemon", wantStatus: true},
 	} {


### PR DESCRIPTION
A `go run` dev build compiles to a binary named `main`, so its executable basename is `main` and not `sigil`. `processLooksLikeDaemon` only accepted a `sigil` prefix, so `Stop` failed the identity check, removed the status file, and left the daemon working with no way for the CLI to reach it again.