### PR TITLE
feat(plugins/sigil): add Settings tab to the local viewer

### DIFF
--- a/plugins/sigil/cmd/sigil/main_test.go
+++ b/plugins/sigil/cmd/sigil/main_test.go
@@ -822,7 +822,7 @@ func inProcessDaemon(t *testing.T) (dir string, baseURL string) {
 	if err != nil {
 		t.Fatalf("storage: %v", err)
 	}
-	ts := httptest.NewServer(local.NewServer(storage, nil))
+	ts := httptest.NewServer(local.NewServer(storage, nil, filepath.Join(dir, "config.env")))
 	t.Cleanup(ts.Close)
 
 	// Pin the daemon launcher to return the running test server's

--- a/plugins/sigil/internal/agents/codex/launch_test.go
+++ b/plugins/sigil/internal/agents/codex/launch_test.go
@@ -227,7 +227,7 @@ func TestLaunch_LocalEnv(t *testing.T) {
 		wantMode   string
 	}{
 		{name: "defaults full capture", wantMode: "full"},
-		{name: "preserves user capture mode", presetMode: "metadata_only", wantMode: "metadata_only"},
+		{name: "forces full even when a capture mode is set", presetMode: "metadata_only", wantMode: "full"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("SIGIL_ENDPOINT", "https://cloud.example.com")

--- a/plugins/sigil/internal/agents/copilot/launch_test.go
+++ b/plugins/sigil/internal/agents/copilot/launch_test.go
@@ -192,7 +192,7 @@ func TestLaunch_LocalEnv(t *testing.T) {
 		wantMode   string
 	}{
 		{name: "defaults full capture", wantMode: "full"},
-		{name: "preserves user capture mode", presetMode: "metadata_only", wantMode: "metadata_only"},
+		{name: "forces full even when a capture mode is set", presetMode: "metadata_only", wantMode: "full"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("SIGIL_ENDPOINT", "https://cloud.example.com")

--- a/plugins/sigil/internal/agents/opencode/launch_test.go
+++ b/plugins/sigil/internal/agents/opencode/launch_test.go
@@ -183,7 +183,7 @@ func TestLaunch_LocalEnv(t *testing.T) {
 		wantMode   string
 	}{
 		{name: "defaults full capture", wantMode: "full"},
-		{name: "preserves user capture mode", presetMode: "metadata_only", wantMode: "metadata_only"},
+		{name: "forces full even when a capture mode is set", presetMode: "metadata_only", wantMode: "full"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("SIGIL_AUTO_UPDATE", "false")

--- a/plugins/sigil/internal/agents/pi/launch_test.go
+++ b/plugins/sigil/internal/agents/pi/launch_test.go
@@ -144,7 +144,8 @@ func TestLaunch_LocalInjectsEnvAndForwardsArgs(t *testing.T) {
 	// covered in TestLaunch_NormalModeDoesNotInjectLocalEnv.
 	t.Setenv("SIGIL_AUTH_TENANT_ID", "")
 	t.Setenv("SIGIL_AUTH_TOKEN", "")
-	// Ensure the user's existing capture-mode preference flows through.
+	// Local forces full content on this machine regardless of the configured
+	// Cloud capture mode, so a preset value here must be overridden to full.
 	t.Setenv("SIGIL_CONTENT_CAPTURE_MODE", "no_tool_content")
 
 	var execEnv []string
@@ -175,9 +176,10 @@ func TestLaunch_LocalInjectsEnvAndForwardsArgs(t *testing.T) {
 	if got["SIGIL_AUTH_TENANT_ID"] != "local" || got["SIGIL_AUTH_TOKEN"] != "local" {
 		t.Errorf("placeholder auth missing: tenant=%q token=%q", got["SIGIL_AUTH_TENANT_ID"], got["SIGIL_AUTH_TOKEN"])
 	}
-	// User pre-set capture mode must not be overwritten.
-	if got["SIGIL_CONTENT_CAPTURE_MODE"] != "no_tool_content" {
-		t.Errorf("SIGIL_CONTENT_CAPTURE_MODE = %q, want preserved no_tool_content", got["SIGIL_CONTENT_CAPTURE_MODE"])
+	// Local always captures full content; the configured Cloud capture mode is
+	// overridden for the local session.
+	if got["SIGIL_CONTENT_CAPTURE_MODE"] != "full" {
+		t.Errorf("SIGIL_CONTENT_CAPTURE_MODE = %q, want full (local forces full content)", got["SIGIL_CONTENT_CAPTURE_MODE"])
 	}
 }
 

--- a/plugins/sigil/internal/dotenv/write.go
+++ b/plugins/sigil/internal/dotenv/write.go
@@ -38,21 +38,9 @@ func WriteDotenv(path string, updates map[string]string, logger *log.Logger) err
 		merged[k] = v
 	}
 
-	keys := make([]string, 0, len(merged))
-	for k := range merged {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	var b strings.Builder
-	b.WriteString("# Managed by `sigil login`. Hand-edits to known keys persist\n")
-	b.WriteString("# across re-runs; comments and ordering do not.\n")
-	for _, k := range keys {
-		quoted, err := quoteDotenvValue(merged[k])
-		if err != nil {
-			return fmt.Errorf("dotenv: cannot serialise %s: %w", k, err)
-		}
-		fmt.Fprintf(&b, "%s=%s\n", k, quoted)
+	rendered, err := renderDotenv(merged)
+	if err != nil {
+		return err
 	}
 
 	dir := filepath.Dir(path)
@@ -66,7 +54,7 @@ func WriteDotenv(path string, updates map[string]string, logger *log.Logger) err
 	}
 	tmpPath := tmp.Name()
 	cleanup := func() { _ = os.Remove(tmpPath) }
-	if _, err := tmp.WriteString(b.String()); err != nil {
+	if _, err := tmp.Write(rendered); err != nil {
 		_ = tmp.Close()
 		cleanup()
 		return fmt.Errorf("dotenv: write temp: %w", err)
@@ -85,6 +73,49 @@ func WriteDotenv(path string, updates map[string]string, logger *log.Logger) err
 		return fmt.Errorf("dotenv: rename to %s: %w", path, err)
 	}
 	return nil
+}
+
+// RenderManaged renders updates as managed dotenv file content without
+// touching disk. The output is what WriteDotenv would produce for a file that
+// contained only these keys: the managed header followed by KEY=value lines
+// sorted alphabetically. Empty values are dropped because they represent
+// deletions, and only keys accepted by AllowedDotenvKey may appear. Callers
+// use this to preview the file a form will persist without exposing any other
+// keys already on disk.
+func RenderManaged(updates map[string]string) ([]byte, error) {
+	for k := range updates {
+		if !AllowedDotenvKey(k) {
+			return nil, fmt.Errorf("dotenv: refusing to render disallowed key %q", k)
+		}
+	}
+	return renderDotenv(updates)
+}
+
+// renderDotenv serialises m into the managed dotenv format: the two-line
+// managed header, then KEY=value lines sorted alphabetically, each value
+// quoted by quoteDotenvValue. Keys whose value is empty (after trimming) are
+// skipped so the rendered bytes match the on-disk result of deleting them.
+func renderDotenv(m map[string]string) ([]byte, error) {
+	keys := make([]string, 0, len(m))
+	for k, v := range m {
+		if strings.TrimSpace(v) == "" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	b.WriteString("# Managed by `sigil login`. Hand-edits to known keys persist\n")
+	b.WriteString("# across re-runs; comments and ordering do not.\n")
+	for _, k := range keys {
+		quoted, err := quoteDotenvValue(m[k])
+		if err != nil {
+			return nil, fmt.Errorf("dotenv: cannot serialise %s: %w", k, err)
+		}
+		fmt.Fprintf(&b, "%s=%s\n", k, quoted)
+	}
+	return []byte(b.String()), nil
 }
 
 // quoteDotenvValue returns v in a form the dotenv parser can round-trip.

--- a/plugins/sigil/internal/dotenv/write_test.go
+++ b/plugins/sigil/internal/dotenv/write_test.go
@@ -129,3 +129,32 @@ func TestWriteDotenv_RejectsDisallowedKeys(t *testing.T) {
 		t.Errorf("error = %v, want mention of disallowed key", err)
 	}
 }
+
+func TestRenderManaged(t *testing.T) {
+	t.Run("sorts keys, prepends header, drops empties", func(t *testing.T) {
+		out, err := RenderManaged(map[string]string{
+			"SIGIL_USER_ID":              "alice",
+			"SIGIL_CONTENT_CAPTURE_MODE": "full",
+			"SIGIL_DEBUG":                "", // deletion: must not appear
+			"SIGIL_TAGS":                 "team=ai",
+		})
+		if err != nil {
+			t.Fatalf("RenderManaged: %v", err)
+		}
+		got := string(out)
+		want := "# Managed by `sigil login`. Hand-edits to known keys persist\n" +
+			"# across re-runs; comments and ordering do not.\n" +
+			"SIGIL_CONTENT_CAPTURE_MODE=full\n" +
+			"SIGIL_TAGS=team=ai\n" +
+			"SIGIL_USER_ID=alice\n"
+		if got != want {
+			t.Errorf("RenderManaged mismatch:\n got: %q\nwant: %q", got, want)
+		}
+	})
+
+	t.Run("rejects disallowed keys", func(t *testing.T) {
+		if _, err := RenderManaged(map[string]string{"PATH": "/usr/bin"}); err == nil {
+			t.Fatal("expected error for disallowed key, got nil")
+		}
+	})
+}

--- a/plugins/sigil/internal/envconfig/envconfig.go
+++ b/plugins/sigil/internal/envconfig/envconfig.go
@@ -22,6 +22,21 @@ func ParseBool(raw string) bool {
 	}
 }
 
+// ParseBoolDefault parses a boolean config value, returning def when the value
+// is empty or unrecognised. It honours the same 1/true/yes/on and
+// 0/false/no/off whitelist as resolveGuardsBool, so callers that read SIGIL_*
+// booleans from a dotenv map (rather than os.Getenv) get identical semantics.
+func ParseBoolDefault(raw string, def bool) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return def
+	}
+}
+
 // EnvOr returns the value of key if non-empty (after trimming), else fallback.
 func EnvOr(key, fallback string) string {
 	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
@@ -156,10 +171,15 @@ type GuardsConfig struct {
 	FailOpen  bool
 }
 
+// DefaultGuardsTimeoutMs is the guard check timeout applied when
+// SIGIL_GUARDS_TIMEOUT_MS is unset, non-numeric, or non-positive. Exported so
+// callers writing config.env (sigil login, the local Settings page) can treat
+// this value as "use the default" and omit the key.
+const DefaultGuardsTimeoutMs = 1500
+
 const (
-	defaultGuardsEnabled   = false
-	defaultGuardsTimeoutMs = 1500
-	defaultGuardsFailOpen  = true
+	defaultGuardsEnabled  = false
+	defaultGuardsFailOpen = true
 )
 
 // ResolveGuards reads SIGIL_GUARDS_ENABLED / _TIMEOUT_MS / _FAIL_OPEN and
@@ -172,14 +192,14 @@ const (
 func ResolveGuards(logger *log.Logger) GuardsConfig {
 	cfg := GuardsConfig{
 		Enabled:   resolveGuardsBool(logger, "SIGIL_GUARDS_ENABLED", defaultGuardsEnabled),
-		TimeoutMs: defaultGuardsTimeoutMs,
+		TimeoutMs: DefaultGuardsTimeoutMs,
 		FailOpen:  resolveGuardsBool(logger, "SIGIL_GUARDS_FAIL_OPEN", defaultGuardsFailOpen),
 	}
 	if v := strings.TrimSpace(os.Getenv("SIGIL_GUARDS_TIMEOUT_MS")); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n <= 0 {
 			if logger != nil {
-				logger.Printf("config: invalid SIGIL_GUARDS_TIMEOUT_MS=%q; using %d", v, defaultGuardsTimeoutMs)
+				logger.Printf("config: invalid SIGIL_GUARDS_TIMEOUT_MS=%q; using %d", v, DefaultGuardsTimeoutMs)
 			}
 		} else {
 			cfg.TimeoutMs = n

--- a/plugins/sigil/internal/local/env.go
+++ b/plugins/sigil/internal/local/env.go
@@ -25,13 +25,15 @@ func Environ(e *LaunchEnv) []string {
 	return e.Apply(env)
 }
 
-// Apply returns env with local-mode overrides applied. SIGIL_ENDPOINT
-// and SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT are always overridden so the
-// agent points at the local receiver. SIGIL_AUTH_TENANT_ID /
-// SIGIL_AUTH_TOKEN / SIGIL_CONTENT_CAPTURE_MODE are only set when the
-// user hasn't already configured them — a user with Cloud credentials
-// in their shell shouldn't get them clobbered by `sigil <agent>
-// --local`.
+// Apply returns env with local-mode overrides applied. SIGIL_ENDPOINT,
+// SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT, and SIGIL_CONTENT_CAPTURE_MODE are
+// always overridden: the agent points at the local receiver and always
+// captures full content on this machine. The configured capture mode is a
+// Cloud-forwarding setting that applies to non-local sessions, so any value
+// in config.env is kept on disk but never downgrades local capture.
+// SIGIL_AUTH_TENANT_ID and SIGIL_AUTH_TOKEN are only set when the user hasn't
+// already configured them, so a user with Cloud credentials in their shell
+// doesn't get them clobbered by `sigil <agent> --local`.
 //
 // Placeholder auth values are injected so existing hook code (which
 // short-circuits when SIGIL_AUTH_TENANT_ID / SIGIL_AUTH_TOKEN are
@@ -41,11 +43,11 @@ func (e LaunchEnv) Apply(env []string) []string {
 	overrides := map[string]string{
 		"SIGIL_ENDPOINT":                    e.Endpoint,
 		"SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT": e.OTLPEndpoint,
+		"SIGIL_CONTENT_CAPTURE_MODE":        "full",
 	}
 	defaults := map[string]string{
-		"SIGIL_AUTH_TENANT_ID":       "local",
-		"SIGIL_AUTH_TOKEN":           "local",
-		"SIGIL_CONTENT_CAPTURE_MODE": "full",
+		"SIGIL_AUTH_TENANT_ID": "local",
+		"SIGIL_AUTH_TOKEN":     "local",
 	}
 	keptDefaults := map[string]bool{}
 	out := make([]string, 0, len(env)+len(overrides)+len(defaults))

--- a/plugins/sigil/internal/local/manager.go
+++ b/plugins/sigil/internal/local/manager.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/dotenv"
 )
 
 // Status describes the running local receiver daemon.
@@ -237,7 +239,7 @@ func Serve(ctx context.Context, dir string, port int, logger *log.Logger) error 
 		return fmt.Errorf("listen: %w", err)
 	}
 	actualPort := listener.Addr().(*net.TCPAddr).Port
-	srv := NewServer(storage, logger)
+	srv := NewServer(storage, logger, dotenv.FilePath("sigil"))
 	httpSrv := &http.Server{
 		Handler:           srv,
 		ReadHeaderTimeout: 5 * time.Second,

--- a/plugins/sigil/internal/local/server.go
+++ b/plugins/sigil/internal/local/server.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/dotenv"
 )
 
 // Maximum body sizes accepted by the receiver. These guard against
@@ -21,22 +23,27 @@ const (
 // Server is the in-process HTTP handler that records generations from
 // local agent sessions and serves the local viewer API.
 type Server struct {
-	storage *Storage
-	logger  *log.Logger
-	now     func() time.Time
-	mux     *http.ServeMux
+	storage    *Storage
+	logger     *log.Logger
+	now        func() time.Time
+	configPath string
+	mux        *http.ServeMux
 }
 
 // NewServer builds a Server backed by the given storage. logger may be
-// nil — the server logs only diagnostic information.
-func NewServer(storage *Storage, logger *log.Logger) *Server {
+// nil — the server logs only diagnostic information. configPath is the
+// dotenv file the Settings API reads and writes; an empty path disables
+// persistence (reads return defaults, writes fail) but keeps the rest of
+// the server usable for tests.
+func NewServer(storage *Storage, logger *log.Logger, configPath string) *Server {
 	if logger == nil {
 		logger = log.New(io.Discard, "", 0)
 	}
 	s := &Server{
-		storage: storage,
-		logger:  logger,
-		now:     func() time.Time { return time.Now().UTC() },
+		storage:    storage,
+		logger:     logger,
+		configPath: configPath,
+		now:        func() time.Time { return time.Now().UTC() },
 	}
 	s.mux = s.routes()
 	return s
@@ -47,11 +54,16 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /{$}", s.handleIndex)
 	mux.HandleFunc("GET /conversations/{id}", s.handleIndex)
 	mux.HandleFunc("GET /conversations/{id}/{$}", s.handleIndex)
+	mux.HandleFunc("GET /settings", s.handleIndex)
+	mux.HandleFunc("GET /settings/{$}", s.handleIndex)
 	mux.HandleFunc("GET /assets/app.css", s.handleAppCSS)
 	mux.HandleFunc("GET /assets/app.jsx", s.handleAppJSX)
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
 	mux.HandleFunc("GET /api/v1/conversations", s.handleListConversations)
 	mux.HandleFunc("GET /api/v1/metrics/tokens", s.handleTokenMetrics)
+	mux.HandleFunc("GET /api/v1/config", s.handleGetConfig)
+	mux.HandleFunc("POST /api/v1/config:preview", s.handlePreviewConfig)
+	mux.HandleFunc("PUT /api/v1/config", s.handleSaveConfig)
 	mux.HandleFunc("GET /api/v1/conversations/{id}", func(w http.ResponseWriter, r *http.Request) {
 		s.handleConversationDetail(w, r, r.PathValue("id"))
 	})
@@ -211,6 +223,101 @@ func (s *Server) handleHookEvaluate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.writeJSON(w, http.StatusOK, hookResponse{Action: "allow", Evaluations: []any{}})
+}
+
+// configResponse is the GET /api/v1/config and PUT /api/v1/config payload:
+// the page-managed settings, the rendered config.env preview, and a display
+// path for the file. It never includes the endpoint, tenant id, or auth
+// token — those keys are not part of Settings and are never read back into
+// the response.
+type configResponse struct {
+	Settings Settings `json:"settings"`
+	Preview  string   `json:"preview"`
+	Path     string   `json:"path"`
+}
+
+// configRequest is the POST :preview / PUT body: the form state the viewer
+// edits.
+type configRequest struct {
+	Settings Settings `json:"settings"`
+}
+
+// handleGetConfig hydrates Settings from the current config.env and returns
+// them with a rendered preview. Only the page-managed keys are exposed.
+func (s *Server) handleGetConfig(w http.ResponseWriter, _ *http.Request) {
+	settings := ParseSettings(dotenv.LoadDotenv(s.configPath, s.logger))
+	s.writeConfigResponse(w, settings)
+}
+
+// handlePreviewConfig renders the config.env the given form state would
+// produce, without writing. It backs the viewer's live preview panel.
+func (s *Server) handlePreviewConfig(w http.ResponseWriter, r *http.Request) {
+	settings, ok := s.decodeConfigRequest(w, r)
+	if !ok {
+		return
+	}
+	preview, err := dotenv.RenderManaged(settings.previewUpdates())
+	if err != nil {
+		http.Error(w, "render config: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.writeJSON(w, http.StatusOK, map[string]any{"preview": string(preview)})
+}
+
+// handleSaveConfig persists the given form state to config.env (merging with
+// and preserving any keys the page does not manage) and returns the re-read
+// settings plus preview so the client gets a clean saved snapshot.
+func (s *Server) handleSaveConfig(w http.ResponseWriter, r *http.Request) {
+	if s.configPath == "" {
+		http.Error(w, "config persistence disabled", http.StatusServiceUnavailable)
+		return
+	}
+	settings, ok := s.decodeConfigRequest(w, r)
+	if !ok {
+		return
+	}
+	if err := dotenv.WriteDotenv(s.configPath, settings.Updates(), s.logger); err != nil {
+		s.logger.Printf("local: write config: %v", err)
+		http.Error(w, "write config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// Re-read so the response reflects the normalised on-disk state (dropped
+	// defaults, deleted keys), which the client adopts as its saved snapshot.
+	settings = ParseSettings(dotenv.LoadDotenv(s.configPath, s.logger))
+	s.writeConfigResponse(w, settings)
+}
+
+func (s *Server) writeConfigResponse(w http.ResponseWriter, settings Settings) {
+	preview, err := dotenv.RenderManaged(settings.previewUpdates())
+	if err != nil {
+		http.Error(w, "render config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.writeJSON(w, http.StatusOK, configResponse{
+		Settings: settings,
+		Preview:  string(preview),
+		Path:     displayConfigPath(s.configPath),
+	})
+}
+
+// decodeConfigRequest reads and decodes a configRequest body, writing the
+// appropriate HTTP error and returning ok=false on failure.
+func (s *Server) decodeConfigRequest(w http.ResponseWriter, r *http.Request) (Settings, bool) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxHookBodyBytes+1))
+	if err != nil {
+		http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
+		return Settings{}, false
+	}
+	if len(body) > maxHookBodyBytes {
+		http.Error(w, "body too large", http.StatusRequestEntityTooLarge)
+		return Settings{}, false
+	}
+	var req configRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, "decode body: "+err.Error(), http.StatusBadRequest)
+		return Settings{}, false
+	}
+	return req.Settings, true
 }
 
 // handleListConversations returns the aggregated conversation list as

--- a/plugins/sigil/internal/local/server_test.go
+++ b/plugins/sigil/internal/local/server_test.go
@@ -3,6 +3,7 @@ package local
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/grafana/sigil-sdk/go/sigil"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/dotenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -147,6 +149,8 @@ func TestServer_Routing(t *testing.T) {
 	}{
 		{name: "root serves viewer HTML", method: http.MethodGet, path: "/", want: http.StatusOK, wantContentType: "text/html", wantBodyHas: `<script type="text/babel" src="/assets/app.jsx">`},
 		{name: "conversation path serves viewer HTML", method: http.MethodGet, path: "/conversations/conv-123", want: http.StatusOK, wantContentType: "text/html", wantBodyHas: `<script type="text/babel" src="/assets/app.jsx">`},
+		{name: "settings path serves viewer HTML", method: http.MethodGet, path: "/settings", want: http.StatusOK, wantContentType: "text/html", wantBodyHas: `<script type="text/babel" src="/assets/app.jsx">`},
+		{name: "settings trailing slash serves viewer HTML", method: http.MethodGet, path: "/settings/", want: http.StatusOK, wantContentType: "text/html", wantBodyHas: `<script type="text/babel" src="/assets/app.jsx">`},
 		{name: "CSS asset", method: http.MethodGet, path: "/assets/app.css", want: http.StatusOK, wantContentType: "text/css", wantBodyHas: ":root"},
 		{name: "JSX asset", method: http.MethodGet, path: "/assets/app.jsx", want: http.StatusOK, wantContentType: "text/babel", wantBodyHas: "function App()"},
 		{name: "healthz serves JSON", method: http.MethodGet, path: "/healthz", want: http.StatusOK, wantContentType: "application/json", wantBodyHas: `"status":"ok"`},
@@ -401,7 +405,7 @@ func newTestServer(t *testing.T) (*Server, string) {
 	if err != nil {
 		t.Fatalf("NewStorage: %v", err)
 	}
-	return NewServer(storage, nil), dir
+	return NewServer(storage, nil, filepath.Join(dir, "config.env")), dir
 }
 
 func post(t *testing.T, s *Server, path, contentType, body string) *http.Response {
@@ -493,4 +497,165 @@ func TestServer_APITokenMetrics_EmptyStorage(t *testing.T) {
 	srv.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, `{"points":[]}`, strings.TrimSpace(rr.Body.String()))
+}
+
+// configPathFor returns the dotenv path newTestServer wired into the server,
+// so config-endpoint tests can inspect what was written to disk.
+func configPathFor(dir string) string { return filepath.Join(dir, "config.env") }
+
+func putConfig(t *testing.T, s *Server, settings Settings) *http.Response {
+	t.Helper()
+	body, err := json.Marshal(configRequest{Settings: settings})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/config", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.ServeHTTP(rr, req)
+	return rr.Result()
+}
+
+// TestServer_Config_RoundTrip saves settings and reads them back, asserting
+// the GET reflects the normalised on-disk state and the file is written.
+func TestServer_Config_RoundTrip(t *testing.T) {
+	srv, dir := newTestServer(t)
+
+	// GET on an absent file returns the local defaults.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/config", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	var got configResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+	assert.Empty(t, got.Settings.Capture) // unset until the user picks a mode
+	assert.True(t, got.Settings.AutoUpdate)
+	assert.Equal(t, guardsOff, got.Settings.Guards)
+
+	// Save a non-default configuration.
+	resp := putConfig(t, srv, Settings{
+		Capture:      "metadata_only",
+		Tags:         []Tag{{Key: "team", Value: "ai"}},
+		Guards:       guardsFailClosed,
+		GuardTimeout: "2000",
+		Debug:        true,
+		AutoUpdate:   false,
+		UserID:       "alice",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var saved configResponse
+	decodeJSON(t, resp.Body, &saved)
+	assert.Equal(t, "metadata_only", saved.Settings.Capture)
+	assert.Equal(t, guardsFailClosed, saved.Settings.Guards)
+	assert.Equal(t, "2000", saved.Settings.GuardTimeout)
+	assert.True(t, saved.Settings.Debug)
+	assert.False(t, saved.Settings.AutoUpdate)
+	assert.Equal(t, "alice", saved.Settings.UserID)
+
+	// Preview and on-disk file agree, sorted with the managed header.
+	onDisk, err := os.ReadFile(configPathFor(dir))
+	require.NoError(t, err)
+	assert.Contains(t, string(onDisk), "SIGIL_CONTENT_CAPTURE_MODE=metadata_only")
+	assert.Contains(t, string(onDisk), "SIGIL_GUARDS_TIMEOUT_MS=2000")
+	assert.Contains(t, saved.Preview, "SIGIL_USER_ID=alice")
+	assert.True(t, strings.HasPrefix(saved.Preview, "# Managed by `sigil login`."))
+
+	// A fresh GET returns the same saved snapshot.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/config", nil)
+	rr2 := httptest.NewRecorder()
+	srv.ServeHTTP(rr2, req2)
+	require.Equal(t, http.StatusOK, rr2.Code)
+	var reread configResponse
+	require.NoError(t, json.Unmarshal(rr2.Body.Bytes(), &reread))
+	assert.Equal(t, saved.Settings, reread.Settings)
+}
+
+// TestServer_Config_Preview renders without writing to disk.
+func TestServer_Config_Preview(t *testing.T) {
+	srv, dir := newTestServer(t)
+	body, err := json.Marshal(configRequest{Settings: Settings{
+		Capture: "full", Guards: guardsFailOpen, GuardTimeout: "2500", AutoUpdate: true,
+	}})
+	require.NoError(t, err)
+	resp := post(t, srv, "/api/v1/config:preview", "application/json", string(body))
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var got struct {
+		Preview string `json:"preview"`
+	}
+	decodeJSON(t, resp.Body, &got)
+	assert.Contains(t, got.Preview, "SIGIL_GUARDS_FAIL_OPEN=true")
+	assert.Contains(t, got.Preview, "SIGIL_GUARDS_TIMEOUT_MS=2500")
+	// Opt-out/opt-in keys at their defaults must not appear.
+	assert.NotContains(t, got.Preview, "SIGIL_AUTO_UPDATE")
+	assert.NotContains(t, got.Preview, "SIGIL_DEBUG")
+	// Preview is read-only: no file should have been created.
+	_, statErr := os.Stat(configPathFor(dir))
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+// TestServer_Config_DoesNotLeakSecrets confirms the auth token never crosses
+// to the client (endpoint and tenant id may, they are not secrets), that a
+// blank token is kept, and that an explicit reset removes it.
+func TestServer_Config_DoesNotLeakSecrets(t *testing.T) {
+	srv, dir := newTestServer(t)
+	path := configPathFor(dir)
+	require.NoError(t, dotenv.WriteDotenv(path, map[string]string{
+		"SIGIL_ENDPOINT":       "https://sigil.example.net",
+		"SIGIL_AUTH_TENANT_ID": "12345",
+		"SIGIL_AUTH_TOKEN":     "glc_supersecret",
+		"SIGIL_USER_ID_SOURCE": "accountUuid",
+	}, nil))
+
+	// GET surfaces endpoint/tenant and reports the token is set, but never
+	// returns the token value; the preview shows it masked.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/config", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.NotContains(t, rr.Body.String(), "glc_supersecret")
+	var got configResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+	assert.Equal(t, "https://sigil.example.net", got.Settings.Endpoint)
+	assert.Equal(t, "12345", got.Settings.TenantID)
+	assert.True(t, got.Settings.TokenSet)
+	assert.Empty(t, got.Settings.Token)
+	assert.Contains(t, got.Preview, "SIGIL_AUTH_TOKEN=<set>")
+
+	// Saving with a blank token keeps it; endpoint/tenant round-trip; unmanaged
+	// keys survive the merge.
+	resp := putConfig(t, srv, Settings{
+		Endpoint: "https://sigil.example.net", TenantID: "12345", TokenSet: true,
+		Capture: "full", Guards: guardsOff, AutoUpdate: true, UserID: "alice",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "glc_supersecret")
+
+	onDisk, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(onDisk), "SIGIL_AUTH_TOKEN=glc_supersecret")
+	assert.Contains(t, string(onDisk), "SIGIL_USER_ID_SOURCE=accountUuid")
+	assert.Contains(t, string(onDisk), "SIGIL_USER_ID=alice")
+
+	// Resetting the token removes it from disk.
+	resp2 := putConfig(t, srv, Settings{
+		Endpoint: "https://sigil.example.net", TenantID: "12345",
+		TokenSet: true, TokenCleared: true,
+		Capture: "full", Guards: guardsOff, AutoUpdate: true,
+	})
+	defer resp2.Body.Close()
+	require.Equal(t, http.StatusOK, resp2.StatusCode)
+	onDisk2, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(onDisk2), "SIGIL_AUTH_TOKEN")
+}
+
+// TestServer_Config_RejectsBadBody covers malformed input handling.
+func TestServer_Config_RejectsBadBody(t *testing.T) {
+	srv, _ := newTestServer(t)
+	resp := post(t, srv, "/api/v1/config:preview", "application/json", "{not json")
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	resp.Body.Close()
 }

--- a/plugins/sigil/internal/local/settings.go
+++ b/plugins/sigil/internal/local/settings.go
@@ -1,0 +1,269 @@
+package local
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/sigil-sdk/go/sigil"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/envconfig"
+)
+
+// Guard selector values exposed to the viewer. One control encodes both the
+// enabled flag and the fail mode, mapping onto the three SIGIL_GUARDS_* keys.
+// These are the API/UI values defined by the Settings design; they differ from
+// the labels sigil login uses internally.
+const (
+	guardsOff        = "off"
+	guardsFailOpen   = "failopen"
+	guardsFailClosed = "failclosed"
+)
+
+// tokenMask stands in for SIGIL_AUTH_TOKEN in the live preview. The stored
+// token is never sent to the browser, so the preview shows this marker to
+// signal a token is present without leaking the value.
+const tokenMask = "<set>"
+
+// Tag is one session-tag key=value pair as edited in the UI.
+type Tag struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// Settings is the subset of config.env the local viewer's Settings page
+// edits. It is hydrated from the dotenv file by ParseSettings and mapped back
+// to SIGIL_* keys by Updates.
+//
+// The auth token is write-only: Token is never populated on read (the daemon
+// never sends the stored token to the browser). TokenSet reports whether a
+// token exists on disk so the UI can show "set" state and the preview can
+// render a masked marker. The token is tri-state on write: a new Token value
+// replaces it, TokenCleared removes it, and otherwise the stored token is left
+// untouched.
+type Settings struct {
+	Endpoint     string `json:"endpoint"`
+	TenantID     string `json:"tenantId"`
+	OtlpEndpoint string `json:"otlpEndpoint"`
+	TokenSet     bool   `json:"tokenSet"`
+	Token        string `json:"token"`
+	TokenCleared bool   `json:"tokenCleared"`
+	Capture      string `json:"capture"`
+	Tags         []Tag  `json:"tags"`
+	Guards       string `json:"guards"`
+	GuardTimeout string `json:"guardTimeout"`
+	Debug        bool   `json:"debug"`
+	AutoUpdate   bool   `json:"autoUpdate"`
+	UserID       string `json:"userId"`
+}
+
+// ParseSettings hydrates Settings from a dotenv map (as returned by
+// dotenv.LoadDotenv). Unset or unrecognised values fall back to the same
+// effective defaults the plugins apply at runtime, so a config.env with none
+// of these keys yields the default configuration. Boolean parsing reuses
+// envconfig so the viewer and the hook runtime agree on what counts as
+// enabled.
+func ParseSettings(env map[string]string) Settings {
+	return Settings{
+		Endpoint:     strings.TrimSpace(env["SIGIL_ENDPOINT"]),
+		TenantID:     strings.TrimSpace(env["SIGIL_AUTH_TENANT_ID"]),
+		OtlpEndpoint: strings.TrimSpace(env["SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT"]),
+		TokenSet:     strings.TrimSpace(env["SIGIL_AUTH_TOKEN"]) != "",
+		// Token is intentionally left empty: the stored token is never read back.
+		Capture:      parseCaptureMode(env["SIGIL_CONTENT_CAPTURE_MODE"]),
+		Tags:         parseTags(env["SIGIL_TAGS"]),
+		Guards:       seedGuards(env["SIGIL_GUARDS_ENABLED"], env["SIGIL_GUARDS_FAIL_OPEN"]),
+		GuardTimeout: strings.TrimSpace(env["SIGIL_GUARDS_TIMEOUT_MS"]),
+		Debug:        envconfig.ParseBoolDefault(env["SIGIL_DEBUG"], false),
+		// SIGIL_AUTO_UPDATE is opt-out: unset means enabled. This matches
+		// updatecheck.Disabled (only explicit falsey values disable updates).
+		AutoUpdate: envconfig.ParseBoolDefault(env["SIGIL_AUTO_UPDATE"], true),
+		UserID:     strings.TrimSpace(env["SIGIL_USER_ID"]),
+	}
+}
+
+// Updates maps Settings onto the SIGIL_* keys WriteDotenv persists. An empty
+// value signals a deletion: WriteDotenv removes that key and dotenv.RenderManaged
+// drops it from the preview. The returned map therefore covers the complete
+// set of decisions for the page-managed keys (write a value, or delete it);
+// any key not listed here is left untouched on disk.
+func (s Settings) Updates() map[string]string {
+	u := map[string]string{
+		"SIGIL_TAGS":                        renderTags(s.Tags),
+		"SIGIL_ENDPOINT":                    strings.TrimSpace(s.Endpoint),
+		"SIGIL_AUTH_TENANT_ID":              strings.TrimSpace(s.TenantID),
+		"SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT": strings.TrimSpace(s.OtlpEndpoint),
+	}
+
+	// Capture mode is written only when explicitly set. Leaving it unset keeps
+	// the runtime defaults intact (metadata_only for Cloud, full for --local via
+	// env.go), so saving unrelated settings never silently forces a capture mode
+	// onto config.env.
+	if c := parseCaptureMode(s.Capture); c != "" {
+		u["SIGIL_CONTENT_CAPTURE_MODE"] = c
+	}
+
+	// The token is write-only and tri-state: an explicit reset deletes it, a
+	// freshly entered value replaces it, and otherwise the key is omitted so
+	// WriteDotenv preserves whatever is already on disk.
+	switch {
+	case s.TokenCleared:
+		u["SIGIL_AUTH_TOKEN"] = ""
+	case strings.TrimSpace(s.Token) != "":
+		u["SIGIL_AUTH_TOKEN"] = strings.TrimSpace(s.Token)
+	}
+
+	switch s.Guards {
+	case guardsFailOpen, guardsFailClosed:
+		u["SIGIL_GUARDS_ENABLED"] = "true"
+		if s.Guards == guardsFailOpen {
+			u["SIGIL_GUARDS_FAIL_OPEN"] = "true"
+		} else {
+			u["SIGIL_GUARDS_FAIL_OPEN"] = "false"
+		}
+		u["SIGIL_GUARDS_TIMEOUT_MS"] = guardTimeoutValue(s.GuardTimeout)
+	default:
+		// Disabled: clear the enabled flag and remove the fail mode and
+		// timeout so a later re-enable starts from the documented defaults
+		// rather than a stale value.
+		u["SIGIL_GUARDS_ENABLED"] = "false"
+		u["SIGIL_GUARDS_FAIL_OPEN"] = ""
+		u["SIGIL_GUARDS_TIMEOUT_MS"] = ""
+	}
+
+	// SIGIL_DEBUG is opt-in: write it only when on, delete otherwise.
+	if s.Debug {
+		u["SIGIL_DEBUG"] = "true"
+	} else {
+		u["SIGIL_DEBUG"] = ""
+	}
+
+	// SIGIL_AUTO_UPDATE is opt-out: unset means enabled, so write false only
+	// when disabled and delete the key otherwise.
+	if s.AutoUpdate {
+		u["SIGIL_AUTO_UPDATE"] = ""
+	} else {
+		u["SIGIL_AUTO_UPDATE"] = "false"
+	}
+
+	u["SIGIL_USER_ID"] = strings.TrimSpace(s.UserID)
+
+	return u
+}
+
+// previewUpdates returns the keys to render in the live config.env preview. It
+// mirrors Updates but never exposes the auth token: a stored or freshly
+// entered token is shown masked so the panel signals the key is present
+// without leaking the value.
+func (s Settings) previewUpdates() map[string]string {
+	u := s.Updates()
+	if !s.TokenCleared && (strings.TrimSpace(s.Token) != "" || s.TokenSet) {
+		u["SIGIL_AUTH_TOKEN"] = tokenMask
+	} else {
+		delete(u, "SIGIL_AUTH_TOKEN")
+	}
+	return u
+}
+
+// parseCaptureMode maps a raw value onto one of the SDK's canonical capture
+// mode strings using sigil.ContentCaptureMode as the single source of truth,
+// or "" when the mode is unset, the "default" alias, or unrecognised.
+//
+// Returning "" for an unset mode is deliberate: Updates omits the key in that
+// case so the runtime defaults stand (metadata_only for Cloud,
+// full for --local via env.go). Forcing a value here would let an unrelated
+// save silently enable full content capture for Cloud sessions.
+func parseCaptureMode(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	var m sigil.ContentCaptureMode
+	if err := m.UnmarshalText([]byte(raw)); err != nil || m == sigil.ContentCaptureModeDefault {
+		return ""
+	}
+	return m.String()
+}
+
+// parseTags splits the SIGIL_TAGS CSV into ordered key=value pairs, dropping
+// malformed entries (no '=', empty key, or empty value) so the parsed set
+// matches what envconfig.ParseExtraTags applies at runtime. Order is preserved
+// so reloading the page does not shuffle the user's tags. Always returns a
+// non-nil slice so the JSON encoding is [] rather than null.
+func parseTags(raw string) []Tag {
+	raw = strings.TrimSpace(raw)
+	tags := []Tag{}
+	if raw == "" {
+		return tags
+	}
+	for part := range strings.SplitSeq(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(part, "=")
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if !ok || k == "" || v == "" {
+			continue
+		}
+		tags = append(tags, Tag{Key: k, Value: v})
+	}
+	return tags
+}
+
+// renderTags serialises tags as the CSV key=value form SIGIL_TAGS expects,
+// dropping pairs with an empty key or value (envconfig.ParseExtraTags would
+// drop them at read time anyway). Returns "" when nothing remains so the key
+// is deleted rather than written empty.
+func renderTags(tags []Tag) string {
+	parts := make([]string, 0, len(tags))
+	for _, t := range tags {
+		k := strings.TrimSpace(t.Key)
+		v := strings.TrimSpace(t.Value)
+		if k == "" || v == "" {
+			continue
+		}
+		parts = append(parts, k+"="+v)
+	}
+	return strings.Join(parts, ",")
+}
+
+// guardTimeoutValue returns the SIGIL_GUARDS_TIMEOUT_MS value to persist: the
+// trimmed input when it is a positive integer other than the default, else ""
+// so the key is dropped and the runtime default applies. A non-numeric,
+// non-positive, or default value is treated as "use default".
+func guardTimeoutValue(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 || n == envconfig.DefaultGuardsTimeoutMs {
+		return ""
+	}
+	return raw
+}
+
+// seedGuards derives the guard selector value from the persisted enabled and
+// fail-open keys. Fail-open defaults to true (matching the plugins), so an
+// enabled-but-unspecified config seeds the fail-open option.
+func seedGuards(enabledRaw, failOpenRaw string) string {
+	if !envconfig.ParseBoolDefault(enabledRaw, false) {
+		return guardsOff
+	}
+	if envconfig.ParseBoolDefault(failOpenRaw, true) {
+		return guardsFailOpen
+	}
+	return guardsFailClosed
+}
+
+// displayConfigPath collapses the user's home prefix to ~ for display so the
+// viewer shows ~/.config/sigil/config.env rather than an absolute path.
+func displayConfigPath(path string) string {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if rel, ok := strings.CutPrefix(path, home+string(os.PathSeparator)); ok {
+			return "~" + string(os.PathSeparator) + rel
+		}
+	}
+	return path
+}

--- a/plugins/sigil/internal/local/settings_test.go
+++ b/plugins/sigil/internal/local/settings_test.go
@@ -1,0 +1,258 @@
+package local
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseSettings(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want Settings
+	}{
+		{
+			name: "empty config leaves capture unset",
+			env:  map[string]string{},
+			want: Settings{
+				Capture:    "", // unset: not written, so runtime defaults stand
+				Tags:       []Tag{},
+				Guards:     guardsOff,
+				AutoUpdate: true,
+			},
+		},
+		{
+			name: "full config round-trips every field",
+			env: map[string]string{
+				"SIGIL_CONTENT_CAPTURE_MODE": "metadata_only",
+				"SIGIL_TAGS":                 "team=ai,project=demo",
+				"SIGIL_GUARDS_ENABLED":       "true",
+				"SIGIL_GUARDS_FAIL_OPEN":     "false",
+				"SIGIL_GUARDS_TIMEOUT_MS":    "2000",
+				"SIGIL_DEBUG":                "true",
+				"SIGIL_AUTO_UPDATE":          "false",
+				"SIGIL_USER_ID":              "alice",
+			},
+			want: Settings{
+				Capture:      "metadata_only",
+				Tags:         []Tag{{Key: "team", Value: "ai"}, {Key: "project", Value: "demo"}},
+				Guards:       guardsFailClosed,
+				GuardTimeout: "2000",
+				Debug:        true,
+				AutoUpdate:   false,
+				UserID:       "alice",
+			},
+		},
+		{
+			name: "advanced capture mode is preserved",
+			env:  map[string]string{"SIGIL_CONTENT_CAPTURE_MODE": "no_tool_content"},
+			want: Settings{Capture: "no_tool_content", Tags: []Tag{}, Guards: guardsOff, AutoUpdate: true},
+		},
+		{
+			name: "unknown capture mode is treated as unset",
+			env:  map[string]string{"SIGIL_CONTENT_CAPTURE_MODE": "bogus"},
+			want: Settings{Capture: "", Tags: []Tag{}, Guards: guardsOff, AutoUpdate: true},
+		},
+		{
+			name: "default alias is treated as unset",
+			env:  map[string]string{"SIGIL_CONTENT_CAPTURE_MODE": "default"},
+			want: Settings{Capture: "", Tags: []Tag{}, Guards: guardsOff, AutoUpdate: true},
+		},
+		{
+			name: "guards enabled without fail-open seeds fail-open",
+			env:  map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			want: Settings{Capture: "", Tags: []Tag{}, Guards: guardsFailOpen, AutoUpdate: true},
+		},
+		{
+			name: "auto-update only disabled by explicit falsey value",
+			env:  map[string]string{"SIGIL_AUTO_UPDATE": "off"},
+			want: Settings{Capture: "", Tags: []Tag{}, Guards: guardsOff, AutoUpdate: false},
+		},
+		{
+			name: "malformed tag pairs are dropped",
+			env:  map[string]string{"SIGIL_TAGS": "team=ai,,bad,empty="},
+			want: Settings{Capture: "", Tags: []Tag{{Key: "team", Value: "ai"}}, Guards: guardsOff, AutoUpdate: true},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ParseSettings(tc.env))
+		})
+	}
+}
+
+func TestSettingsUpdates(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Settings
+		want map[string]string
+	}{
+		{
+			name: "unset capture is not written",
+			in:   Settings{Capture: "", Guards: guardsOff, AutoUpdate: true},
+			want: map[string]string{
+				"SIGIL_TAGS":              "",
+				"SIGIL_GUARDS_ENABLED":    "false",
+				"SIGIL_GUARDS_FAIL_OPEN":  "",
+				"SIGIL_GUARDS_TIMEOUT_MS": "",
+				"SIGIL_DEBUG":             "",
+				"SIGIL_AUTO_UPDATE":       "",
+				"SIGIL_USER_ID":           "",
+			},
+		},
+		{
+			name: "defaults delete opt-in/opt-out keys",
+			in:   Settings{Capture: "full", Guards: guardsOff, AutoUpdate: true},
+			want: map[string]string{
+				"SIGIL_CONTENT_CAPTURE_MODE": "full",
+				"SIGIL_TAGS":                 "",
+				"SIGIL_GUARDS_ENABLED":       "false",
+				"SIGIL_GUARDS_FAIL_OPEN":     "",
+				"SIGIL_GUARDS_TIMEOUT_MS":    "",
+				"SIGIL_DEBUG":                "",
+				"SIGIL_AUTO_UPDATE":          "",
+				"SIGIL_USER_ID":              "",
+			},
+		},
+		{
+			name: "fail-open with non-default timeout writes timeout",
+			in:   Settings{Capture: "full", Guards: guardsFailOpen, GuardTimeout: "2000", AutoUpdate: true},
+			want: map[string]string{
+				"SIGIL_CONTENT_CAPTURE_MODE": "full",
+				"SIGIL_TAGS":                 "",
+				"SIGIL_GUARDS_ENABLED":       "true",
+				"SIGIL_GUARDS_FAIL_OPEN":     "true",
+				"SIGIL_GUARDS_TIMEOUT_MS":    "2000",
+				"SIGIL_DEBUG":                "",
+				"SIGIL_AUTO_UPDATE":          "",
+				"SIGIL_USER_ID":              "",
+			},
+		},
+		{
+			name: "default timeout value is dropped",
+			in:   Settings{Capture: "full", Guards: guardsFailClosed, GuardTimeout: "1500", AutoUpdate: true},
+			want: map[string]string{
+				"SIGIL_CONTENT_CAPTURE_MODE": "full",
+				"SIGIL_TAGS":                 "",
+				"SIGIL_GUARDS_ENABLED":       "true",
+				"SIGIL_GUARDS_FAIL_OPEN":     "false",
+				"SIGIL_GUARDS_TIMEOUT_MS":    "",
+				"SIGIL_DEBUG":                "",
+				"SIGIL_AUTO_UPDATE":          "",
+				"SIGIL_USER_ID":              "",
+			},
+		},
+		{
+			name: "debug on, auto-update off, tags and user id set",
+			in: Settings{
+				Capture:    "metadata_only",
+				Tags:       []Tag{{Key: "team", Value: "ai"}, {Key: "drop", Value: ""}},
+				Guards:     guardsOff,
+				Debug:      true,
+				AutoUpdate: false,
+				UserID:     "  alice  ",
+			},
+			want: map[string]string{
+				"SIGIL_CONTENT_CAPTURE_MODE": "metadata_only",
+				"SIGIL_TAGS":                 "team=ai",
+				"SIGIL_GUARDS_ENABLED":       "false",
+				"SIGIL_GUARDS_FAIL_OPEN":     "",
+				"SIGIL_GUARDS_TIMEOUT_MS":    "",
+				"SIGIL_DEBUG":                "true",
+				"SIGIL_AUTO_UPDATE":          "false",
+				"SIGIL_USER_ID":              "alice",
+			},
+		},
+		{
+			name: "non-numeric timeout is treated as default",
+			in:   Settings{Capture: "full", Guards: guardsFailOpen, GuardTimeout: "abc", AutoUpdate: true},
+			want: map[string]string{
+				"SIGIL_CONTENT_CAPTURE_MODE": "full",
+				"SIGIL_TAGS":                 "",
+				"SIGIL_GUARDS_ENABLED":       "true",
+				"SIGIL_GUARDS_FAIL_OPEN":     "true",
+				"SIGIL_GUARDS_TIMEOUT_MS":    "",
+				"SIGIL_DEBUG":                "",
+				"SIGIL_AUTO_UPDATE":          "",
+				"SIGIL_USER_ID":              "",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// None of these cases set connection fields, so Updates always emits
+			// empty (delete) markers for them and no token key.
+			want := tc.want
+			want["SIGIL_ENDPOINT"] = ""
+			want["SIGIL_AUTH_TENANT_ID"] = ""
+			want["SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT"] = ""
+			assert.Equal(t, want, tc.in.Updates())
+		})
+	}
+}
+
+// TestSettingsConnection covers the connection fields and the write-only,
+// tri-state auth token (keep / replace / remove).
+func TestSettingsConnection(t *testing.T) {
+	t.Run("parse never reads the token back but reports it is set", func(t *testing.T) {
+		got := ParseSettings(map[string]string{
+			"SIGIL_ENDPOINT":                    "https://sigil.example.net",
+			"SIGIL_AUTH_TENANT_ID":              "12345",
+			"SIGIL_AUTH_TOKEN":                  "glc_secret",
+			"SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT": "https://otlp.example.net/otlp",
+		})
+		assert.Equal(t, "https://sigil.example.net", got.Endpoint)
+		assert.Equal(t, "12345", got.TenantID)
+		assert.Equal(t, "https://otlp.example.net/otlp", got.OtlpEndpoint)
+		assert.True(t, got.TokenSet)
+		assert.Empty(t, got.Token)
+	})
+
+	t.Run("blank token is omitted so the writer preserves it", func(t *testing.T) {
+		u := Settings{Endpoint: "https://x", Guards: guardsOff, AutoUpdate: true, TokenSet: true}.Updates()
+		_, ok := u["SIGIL_AUTH_TOKEN"]
+		assert.False(t, ok)
+		assert.Equal(t, "https://x", u["SIGIL_ENDPOINT"])
+	})
+
+	t.Run("new token value is written", func(t *testing.T) {
+		u := Settings{Guards: guardsOff, AutoUpdate: true, TokenSet: true, Token: "glc_new"}.Updates()
+		assert.Equal(t, "glc_new", u["SIGIL_AUTH_TOKEN"])
+	})
+
+	t.Run("cleared token is deleted", func(t *testing.T) {
+		u := Settings{Guards: guardsOff, AutoUpdate: true, TokenSet: true, TokenCleared: true}.Updates()
+		v, ok := u["SIGIL_AUTH_TOKEN"]
+		assert.True(t, ok)
+		assert.Empty(t, v) // empty value = delete in WriteDotenv
+	})
+
+	t.Run("preview masks a set token and never shows the value", func(t *testing.T) {
+		p := Settings{Guards: guardsOff, AutoUpdate: true, TokenSet: true, Token: "glc_new"}.previewUpdates()
+		assert.Equal(t, tokenMask, p["SIGIL_AUTH_TOKEN"])
+
+		cleared := Settings{Guards: guardsOff, AutoUpdate: true, TokenSet: true, TokenCleared: true}.previewUpdates()
+		_, ok := cleared["SIGIL_AUTH_TOKEN"]
+		assert.False(t, ok)
+	})
+}
+
+// TestSettingsRoundTrip confirms parsing the keys Updates writes yields back
+// the same Settings (after default-dropping normalisation), so the saved
+// snapshot the server returns is stable.
+func TestSettingsRoundTrip(t *testing.T) {
+	in := Settings{
+		Capture:      "no_tool_content",
+		Tags:         []Tag{{Key: "team", Value: "ai"}},
+		Guards:       guardsFailClosed,
+		GuardTimeout: "3000",
+		Debug:        true,
+		AutoUpdate:   false,
+		UserID:       "alice",
+	}
+	got := ParseSettings(in.Updates())
+	assert.Equal(t, in, got)
+}

--- a/plugins/sigil/internal/local/web/app.css
+++ b/plugins/sigil/internal/local/web/app.css
@@ -45,6 +45,11 @@
 
       --primary-main: #3D71D9;
       --primary-text: #6E9FFF;
+      --primary-shade: rgb(90, 134, 222);
+      --primary-border: #3D71D9;
+
+      --secondary-main: rgba(204, 204, 220, 0.16);
+      --secondary-border: rgba(204, 204, 220, 0.25);
 
       --info-main: #3D71D9;    --info-text: #6E9FFF;    --info-border: #6E9FFF;    --info-transparent: #3D71D926;
       --success-main: #1A7F4B; --success-text: #6CCF8E; --success-border: #6CCF8E; --success-transparent: #1A7F4B26;
@@ -104,4 +109,18 @@
     }
     @media (prefers-reduced-motion: reduce) {
       .sigil-step-flash { animation: none; }
+    }
+
+    /* Settings: unsaved-changes bar slides up, toast fades down. Restrained,
+       per Saga. Disabled under reduced-motion. */
+    @keyframes sigil-barin {
+      from { opacity: 0; transform: translateY(10px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes sigil-tin {
+      from { opacity: 0; transform: translateY(-8px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      [style*="sigil-barin"], [style*="sigil-tin"] { animation: none !important; }
     }

--- a/plugins/sigil/internal/local/web/app.jsx
+++ b/plugins/sigil/internal/local/web/app.jsx
@@ -254,6 +254,10 @@
         alert:    <><path d="M12 9v4"/><circle cx="12" cy="16.5" r="0.6" fill="currentColor"/><path d="M10.3 4.1 2.7 17.4a2 2 0 0 0 1.7 3h15.2a2 2 0 0 0 1.7-3L13.7 4.1a2 2 0 0 0-3.4 0Z"/></>,
         empty:    <><circle cx="12" cy="12" r="9"/><path d="M8 12h8"/></>,
         extlink:  <path d="M7 17 17 7M9 7h8v8"/>,
+        info:     <><circle cx="12" cy="12" r="9"/><path d="M12 11v5"/><circle cx="12" cy="7.6" r="0.6" fill="currentColor"/></>,
+        plus:     <path d="M12 5v14M5 12h14"/>,
+        times:    <path d="M6 6l12 12M18 6 6 18"/>,
+        check:    <path d="M5 12l4.5 4.5L19 7"/>,
       };
       return (
         <svg width={size} height={size} viewBox="0 0 24 24" fill="none"
@@ -334,7 +338,36 @@
       color: "var(--fg2)", cursor: "pointer", borderRadius: 2,
     };
 
-    function TopBar({ breadcrumbs = [] }) {
+    // NavTab is a top-level header nav link. The current section gets a 2px
+    // brand underline bar and white text; other tabs render as faint links
+    // that brighten on hover and navigate on a plain left click (modifier
+    // clicks fall through so the anchor opens a new tab).
+    function NavTab({ label, href, onClick, state }) {
+      const current = state === "current";
+      return (
+        <a href={href}
+          onClick={e => {
+            if (!isPlainLeftClick(e)) return;
+            e.preventDefault();
+            onClick && onClick(e);
+          }}
+          onMouseEnter={e => { if (!current) e.currentTarget.style.color = "var(--fg-max)"; }}
+          onMouseLeave={e => { if (!current) e.currentTarget.style.color = "var(--fg2)"; }}
+          style={{
+            position: "relative", display: "inline-flex", alignItems: "center",
+            height: "100%", padding: "0 2px",
+            fontFamily: "var(--fontFamily)", fontSize: 13,
+            color: current ? "var(--fg-max)" : "var(--fg2)",
+            textDecoration: "none", whiteSpace: "nowrap", flexShrink: 0,
+            transition: "color .12s",
+          }}>
+          {label}
+          {current && <span style={{ position: "absolute", left: 0, right: 0, bottom: 0, height: 2, background: "var(--brandVertical)", borderRadius: 1 }}/>}
+        </a>
+      );
+    }
+
+    function TopBar({ tabs = [], trail = [] }) {
       return (
         <header style={{
           height: 48,
@@ -345,65 +378,18 @@
         }}>
           <Wordmark/>
           <div style={{ width: 1, height: 20, background: "var(--border-weak)", margin: "0 4px" }}/>
-          <nav style={{ display: "flex", alignItems: "center", alignSelf: "stretch", gap: 6, minWidth: 0, flex: 1, overflow: "hidden" }}>
-            {breadcrumbs.map((b, i) => {
-              const last = i === breadcrumbs.length - 1;
-              const activeBar = last && breadcrumbs.length === 1;
-              return (
-                <React.Fragment key={i}>
-                  {i > 0 && <Icon name="cright" size={11} style={{ color: "var(--fg3)", flexShrink: 0 }}/>}
-                  {last
-                    ? activeBar
-                      ? <span style={{
-                          position: "relative", display: "inline-flex", alignItems: "center",
-                          height: "100%",
-                          fontFamily: "var(--fontFamily)", fontSize: 13,
-                          color: "var(--fg-max)", whiteSpace: "nowrap",
-                        }}>
-                          {b.label}
-                          <span style={{ position: "absolute", left: 0, right: 0, bottom: 0, height: 2, background: "var(--brandVertical)", borderRadius: 1 }}/>
-                        </span>
-                      : <span style={{
-                          fontFamily: b.mono ? "var(--fontFamilyMonospace)" : "var(--fontFamily)",
-                          fontSize: 13,
-                          color: "var(--fg-max)",
-                          whiteSpace: "nowrap",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          minWidth: 0,
-                        }}>{b.label}</span>
-                    : b.href
-                      ? <a href={b.href}
-                          onClick={e => {
-                            if (!isPlainLeftClick(e)) return;
-                            e.preventDefault();
-                            b.onClick && b.onClick(e);
-                          }}
-                          style={{
-                            background: "transparent",
-                            padding: "2px 4px", cursor: "pointer",
-                            color: "var(--fg2)", fontSize: 13,
-                            fontFamily: b.mono ? "var(--fontFamilyMonospace)" : "var(--fontFamily)",
-                            whiteSpace: "nowrap", flexShrink: 0,
-                            textDecoration: "none",
-                          }}
-                          onMouseEnter={e => e.currentTarget.style.color = "var(--fg-max)"}
-                          onMouseLeave={e => e.currentTarget.style.color = "var(--fg2)"}
-                        >{b.label}</a>
-                      : <button onClick={b.onClick} style={{
-                          background: "transparent", border: "none",
-                          padding: "2px 4px", cursor: b.onClick ? "pointer" : "default",
-                          color: "var(--fg2)", fontSize: 13,
-                          fontFamily: b.mono ? "var(--fontFamilyMonospace)" : "var(--fontFamily)",
-                          whiteSpace: "nowrap", flexShrink: 0,
-                        }}
-                        onMouseEnter={e => b.onClick && (e.currentTarget.style.color = "var(--fg-max)")}
-                        onMouseLeave={e => b.onClick && (e.currentTarget.style.color = "var(--fg2)")}
-                        >{b.label}</button>
-                  }
-                </React.Fragment>
-              );
-            })}
+          <nav style={{ display: "flex", alignItems: "center", alignSelf: "stretch", gap: 14, minWidth: 0, flex: 1, overflow: "hidden" }}>
+            {tabs.map((t, i) => <NavTab key={i} {...t}/>)}
+            {trail.map((b, i) => (
+              <React.Fragment key={"trail-" + i}>
+                <Icon name="cright" size={11} style={{ color: "var(--fg3)", flexShrink: 0 }}/>
+                <span style={{
+                  fontFamily: b.mono ? "var(--fontFamilyMonospace)" : "var(--fontFamily)",
+                  fontSize: 13, color: "var(--fg-max)",
+                  whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", minWidth: 0,
+                }}>{b.label}</span>
+              </React.Fragment>
+            ))}
           </nav>
           <a
             href="https://grafana.com/auth/sign-up/create-user/?"
@@ -1640,6 +1626,407 @@
     }
 
     // ============================================================
+    // Settings — edits config.env via the daemon's /api/v1/config endpoints
+    // ============================================================
+
+    // Mono renders inline code in the monospace face used across the viewer.
+    function Mono({ children }) {
+      return <code style={{ fontFamily: "var(--fontFamilyMonospace)", color: "var(--fg2)" }}>{children}</code>;
+    }
+
+    // sameSettings is a field-wise deep compare for dirty tracking. Tag order
+    // is significant (it survives a round-trip), so it is compared positionally.
+    function sameSettings(a, b) {
+      if (!a || !b) return a === b;
+      if (a.endpoint !== b.endpoint || a.tenantId !== b.tenantId || a.otlpEndpoint !== b.otlpEndpoint
+        || a.token !== b.token || a.tokenCleared !== b.tokenCleared) return false;
+      if (a.capture !== b.capture || a.guards !== b.guards || a.guardTimeout !== b.guardTimeout
+        || a.debug !== b.debug || a.autoUpdate !== b.autoUpdate || a.userId !== b.userId) return false;
+      const at = a.tags || [], bt = b.tags || [];
+      if (at.length !== bt.length) return false;
+      for (let i = 0; i < at.length; i++) {
+        if (at[i].key !== bt[i].key || at[i].value !== bt[i].value) return false;
+      }
+      return true;
+    }
+
+    // cloneSettings deep-copies so the form and the saved snapshot never share
+    // the tags array (editing one must not mutate the other).
+    function cloneSettings(s) {
+      return { ...s, tags: (s.tags || []).map(t => ({ ...t })) };
+    }
+
+    function Segmented({ value, onChange, options }) {
+      return (
+        <div style={{ display: "inline-flex", padding: 3, gap: 3, background: "var(--bg-canvas)", border: "1px solid var(--border-medium)", borderRadius: 2 }}>
+          {options.map(o => {
+            const active = o.value === value;
+            return (
+              <button key={o.value} onClick={() => onChange(o.value)} style={{
+                padding: "6px 14px", borderRadius: 2, fontSize: 13, border: "none", cursor: "pointer",
+                background: active ? "var(--secondary-main)" : "transparent",
+                color: active ? "var(--fg-max)" : "var(--fg2)",
+                fontWeight: active ? 500 : 400, transition: "background .12s, color .12s",
+              }}>{o.label}</button>
+            );
+          })}
+        </div>
+      );
+    }
+
+    function Toggle({ checked, onChange }) {
+      return (
+        <button role="switch" aria-checked={checked} onClick={() => onChange(!checked)} style={{
+          position: "relative", width: 38, height: 22, borderRadius: 9999, border: "none",
+          cursor: "pointer", padding: 0, flexShrink: 0,
+          background: checked ? "var(--primary-main)" : "rgba(204,204,220,0.25)", transition: "background .15s",
+        }}>
+          <span style={{
+            position: "absolute", top: 3, left: 3, width: 16, height: 16, borderRadius: "50%",
+            background: "#fff", transform: checked ? "translateX(16px)" : "translateX(0)", transition: "transform .15s",
+          }}/>
+        </button>
+      );
+    }
+
+    function MonoInput({ value, onChange, placeholder, width, align, type }) {
+      return (
+        <input type={type || "text"} value={value} placeholder={placeholder}
+          onChange={e => onChange(e.target.value)}
+          onFocus={e => e.currentTarget.style.borderColor = "var(--primary-border)"}
+          onBlur={e => e.currentTarget.style.borderColor = "var(--border-medium)"}
+          style={{
+            height: 32, width: width || "auto", background: "var(--bg-canvas)",
+            border: "1px solid var(--border-medium)", borderRadius: 2, color: "var(--fg1)",
+            padding: "0 10px", fontFamily: "var(--fontFamilyMonospace)", fontSize: 12,
+            textAlign: align || "left", outline: "none",
+          }}/>
+      );
+    }
+
+    function PrimaryButton({ onClick, children }) {
+      return (
+        <button onClick={onClick}
+          onMouseEnter={e => { e.currentTarget.style.background = "var(--primary-shade)"; e.currentTarget.style.borderColor = "var(--primary-shade)"; }}
+          onMouseLeave={e => { e.currentTarget.style.background = "var(--primary-main)"; e.currentTarget.style.borderColor = "var(--primary-main)"; }}
+          style={{ height: 32, padding: "0 14px", background: "var(--primary-main)", border: "1px solid var(--primary-main)", color: "#fff", borderRadius: 2, fontSize: 13, fontWeight: 500, cursor: "pointer" }}>{children}</button>
+      );
+    }
+
+    function GhostButton({ onClick, children }) {
+      return (
+        <button onClick={onClick}
+          onMouseEnter={e => e.currentTarget.style.background = "var(--action-hover)"}
+          onMouseLeave={e => e.currentTarget.style.background = "transparent"}
+          style={{ height: 32, padding: "0 14px", background: "transparent", border: "1px solid var(--secondary-border)", color: "var(--fg1)", borderRadius: 2, fontSize: 13, cursor: "pointer" }}>{children}</button>
+      );
+    }
+
+    function SettingsCard({ children }) {
+      return <div style={{ background: "var(--bg-primary)", border: "1px solid var(--border-weak)", borderRadius: 2, padding: "4px 20px 10px", marginBottom: 16 }}>{children}</div>;
+    }
+
+    function SectionLabel({ children }) {
+      return <div style={{ padding: "16px 0 2px", fontSize: 11, fontWeight: 600, letterSpacing: ".06em", textTransform: "uppercase", color: "var(--fg3)" }}>{children}</div>;
+    }
+
+    // SettingRow is one label/help + control line inside a card. `full` stacks
+    // the control under the label for wide controls (the tags editor).
+    function SettingRow({ label, help, children, full }) {
+      const left = (
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontSize: 14, fontWeight: 500, color: "var(--fg1)" }}>{label}</div>
+          {help && <div style={{ fontSize: 12, lineHeight: 1.5, color: "var(--fg3)", maxWidth: 460, marginTop: 4 }}>{help}</div>}
+        </div>
+      );
+      if (full) {
+        return (
+          <div style={{ padding: "16px 0", borderTop: "1px solid var(--border-weak)" }}>
+            {left}
+            <div style={{ marginTop: 12 }}>{children}</div>
+          </div>
+        );
+      }
+      return (
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 32, padding: "16px 0", borderTop: "1px solid var(--border-weak)" }}>
+          {left}
+          <div style={{ flexShrink: 0 }}>{children}</div>
+        </div>
+      );
+    }
+
+    // PreviewBody renders the rendered config.env with key/value colouring:
+    // comments and `=` are dimmed, keys are blue, values green.
+    function PreviewBody({ text }) {
+      const lines = (text || "").split("\n");
+      if (lines.length && lines[lines.length - 1] === "") lines.pop();
+      return (
+        <div style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 12, lineHeight: 1.9, whiteSpace: "pre-wrap", wordBreak: "break-all" }}>
+          {lines.map((line, i) => {
+            if (line.startsWith("#")) return <div key={i} style={{ color: "var(--fg3)" }}>{line}</div>;
+            const eq = line.indexOf("=");
+            if (eq < 0) return <div key={i} style={{ color: "var(--fg1)" }}>{line || "\u00a0"}</div>;
+            return (
+              <div key={i}>
+                <span style={{ color: "var(--primary-text)" }}>{line.slice(0, eq)}</span>
+                <span style={{ color: "var(--fg3)" }}>=</span>
+                <span style={{ color: "var(--viz-green)" }}>{line.slice(eq + 1)}</span>
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
+
+    function UnsavedBar({ onReset, onSave }) {
+      return (
+        <div style={{ position: "fixed", left: 0, right: 0, bottom: 24, display: "flex", justifyContent: "center", pointerEvents: "none", zIndex: 20 }}>
+          <div style={{ pointerEvents: "auto", display: "flex", alignItems: "center", gap: 12, background: "var(--bg-secondary)", border: "1px solid var(--border-medium)", borderRadius: 2, padding: "9px 12px 9px 16px", boxShadow: "var(--shadow-z2)", animation: "sigil-barin .16s ease-out" }}>
+            <span style={{ width: 7, height: 7, borderRadius: "50%", background: "var(--brand-orange)" }}/>
+            <span style={{ fontSize: 13, color: "var(--fg2)" }}>Unsaved changes</span>
+            <GhostButton onClick={onReset}>Reset</GhostButton>
+            <PrimaryButton onClick={onSave}>Save to config.env</PrimaryButton>
+          </div>
+        </div>
+      );
+    }
+
+    function Toast({ message }) {
+      return (
+        <div style={{ position: "fixed", top: 60, right: 20, zIndex: 30, display: "flex", alignItems: "center", gap: 8, background: "var(--bg-secondary)", border: "1px solid var(--border-medium)", borderLeft: "3px solid var(--success-border)", borderRadius: 2, padding: "10px 14px", boxShadow: "var(--shadow-z2)", animation: "sigil-tin .2s ease-out" }}>
+          <Icon name="check" size={16} style={{ color: "var(--success-text)" }}/>
+          <span style={{ fontSize: 13, color: "var(--fg1)" }}>{message}</span>
+        </div>
+      );
+    }
+
+    const CAPTURE_OPTIONS = [{ value: "metadata_only", label: "Metadata only" }, { value: "full", label: "Full" }];
+    const GUARD_OPTIONS = [{ value: "off", label: "Disabled" }, { value: "failopen", label: "Fail-open" }, { value: "failclosed", label: "Fail-closed" }];
+
+    function SettingsView() {
+      const [form, setForm] = useState(null);
+      const [saved, setSaved] = useState(null);
+      const [preview, setPreview] = useState("");
+      const [path, setPath] = useState("~/.config/sigil/config.env");
+      const [loading, setLoading] = useState(true);
+      const [error, setError] = useState(null);
+      const [toast, setToast] = useState(null);
+      const toastTimer = useRef(null);
+
+      const showToast = useCallback((msg) => {
+        setToast(msg);
+        if (toastTimer.current) clearTimeout(toastTimer.current);
+        toastTimer.current = setTimeout(() => setToast(null), 2600);
+      }, []);
+      useEffect(() => () => { if (toastTimer.current) clearTimeout(toastTimer.current); }, []);
+
+      // Hydrate the form from config.env on mount.
+      useEffect(() => {
+        let alive = true;
+        setLoading(true);
+        setError(null);
+        fetch("/api/v1/config")
+          .then(r => r.ok ? r.json() : r.text().then(t => Promise.reject(new Error(t || `HTTP ${r.status}`))))
+          .then(body => {
+            if (!alive) return;
+            setForm(cloneSettings(body.settings));
+            setSaved(cloneSettings(body.settings));
+            setPreview(body.preview || "");
+            if (body.path) setPath(body.path);
+          })
+          .catch(e => { if (alive) setError(String(e.message || e)); })
+          .finally(() => { if (alive) setLoading(false); });
+        return () => { alive = false; };
+      }, []);
+
+      // Live preview: the daemon renders exactly what it would write, so the
+      // panel never drifts from the file. Debounced to coalesce keystrokes.
+      // Each run aborts the prior in-flight request and ignores its result, so
+      // a slow older response can never overwrite a newer one.
+      useEffect(() => {
+        if (!form) return;
+        let ignore = false;
+        const controller = new AbortController();
+        const t = setTimeout(() => {
+          fetch("/api/v1/config:preview", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ settings: form }), signal: controller.signal })
+            .then(r => r.ok ? r.json() : null)
+            .then(b => { if (!ignore && b && typeof b.preview === "string") setPreview(b.preview); })
+            .catch(() => {});
+        }, 180);
+        return () => { ignore = true; controller.abort(); clearTimeout(t); };
+      }, [form]);
+
+      const page = { maxWidth: 1300, margin: "0 auto", padding: "28px 24px 110px", width: "100%" };
+      if (loading && !form) {
+        return <div style={page}><Notice kind="info" title="Loading settings…">Reading config.env.</Notice></div>;
+      }
+      if (!form) {
+        return <div style={page}><Notice kind="error" title="Failed to load settings">{error}</Notice></div>;
+      }
+
+      const dirty = !sameSettings(form, saved);
+      const captureUnset = form.capture === "";
+      const advanced = form.capture === "no_tool_content" || form.capture === "full_with_metadata_spans";
+      const guardsOn = form.guards !== "off";
+      const set = (patch) => setForm(f => ({ ...f, ...patch }));
+      const setTag = (i, patch) => setForm(f => ({ ...f, tags: f.tags.map((t, j) => j === i ? { ...t, ...patch } : t) }));
+      const addTag = () => setForm(f => ({ ...f, tags: [...f.tags, { key: "", value: "" }] }));
+      const removeTag = (i) => setForm(f => ({ ...f, tags: f.tags.filter((_, j) => j !== i) }));
+      const reset = () => setForm(cloneSettings(saved));
+
+      const save = () => {
+        setError(null);
+        fetch("/api/v1/config", { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ settings: form }) })
+          .then(r => r.ok ? r.json() : r.text().then(t => Promise.reject(new Error(t || `HTTP ${r.status}`))))
+          .then(body => {
+            setForm(cloneSettings(body.settings));
+            setSaved(cloneSettings(body.settings));
+            if (typeof body.preview === "string") setPreview(body.preview);
+            showToast("Settings saved to config.env.");
+          })
+          .catch(e => setError(String(e.message || e)));
+      };
+      const copy = () => {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(preview).then(() => showToast("Copied to clipboard.")).catch(() => {});
+        }
+      };
+
+      return (
+        <div style={page}>
+          <h1 style={{ fontSize: 20, fontWeight: 500, color: "var(--fg-max)", margin: "0 0 20px" }}>Settings</h1>
+
+          {error && <div style={{ marginBottom: 16 }}><Notice kind="error" title="Couldn’t save settings">{error}</Notice></div>}
+
+          <div style={{ display: "flex", gap: 24, alignItems: "flex-start" }}>
+            <div style={{ flex: "1 1 0", minWidth: 0 }}>
+              <SettingsCard>
+                <SectionLabel>Connection</SectionLabel>
+                <div style={{ fontSize: 12, lineHeight: 1.5, color: "var(--fg3)", padding: "0 0 10px" }}>
+                  These values apply to your Grafana Cloud sessions.
+                </div>
+                <SettingRow label="Endpoint" help={<>Grafana AI Observability ingest URL.</>}>
+                  <MonoInput value={form.endpoint} onChange={v => set({ endpoint: v })} placeholder="https://sigil-prod-….grafana.net" width={320}/>
+                </SettingRow>
+                <SettingRow label="Tenant ID" help={<>Your stack instance ID.</>}>
+                  <MonoInput value={form.tenantId} onChange={v => set({ tenantId: v })} placeholder="123456" width={200}/>
+                </SettingRow>
+                <SettingRow label="Auth token" help={<>Stored locally with <Mono>0600</Mono> perms. Reset to replace or remove the saved token.</>}>
+                  {form.tokenSet && !form.tokenCleared && form.token === "" ? (
+                    <div style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                      <input value="" disabled placeholder="configured" style={{ height: 32, width: 200, background: "var(--bg-canvas)", border: "1px solid var(--border-medium)", borderRadius: 2, color: "var(--fg3)", padding: "0 10px", fontFamily: "var(--fontFamilyMonospace)", fontSize: 12, cursor: "not-allowed" }}/>
+                      <GhostButton onClick={() => set({ tokenCleared: true, token: "" })}>Reset</GhostButton>
+                    </div>
+                  ) : (
+                    <MonoInput type="password" value={form.token}
+                      onChange={v => set({ token: v, tokenCleared: form.tokenSet && v === "" })}
+                      placeholder={form.tokenSet ? "new token, or blank to remove" : "glc_…"} width={260}/>
+                  )}
+                </SettingRow>
+                <SettingRow label="OTLP endpoint" help={<>For SDK traces and metrics.</>}>
+                  <MonoInput value={form.otlpEndpoint} onChange={v => set({ otlpEndpoint: v })} placeholder="https://otlp-gateway-….grafana.net/otlp" width={320}/>
+                </SettingRow>
+                <SettingRow
+                  label="Content capture mode"
+                  help={<>
+                    What content sigil sends to Grafana Cloud for each generation. <Mono>--local</Mono> sessions always capture full content on this machine.
+                    {captureUnset && <div style={{ color: "var(--fg3)", marginTop: 6 }}>Not set: Grafana Cloud sessions capture metadata only. Pick a mode to pin it.</div>}
+                    {advanced && <div style={{ color: "var(--warning-text)", marginTop: 6 }}>Advanced mode <Mono>{form.capture}</Mono> is set in config.env and will be preserved.</div>}
+                  </>}
+                >
+                  <Segmented value={form.capture} onChange={v => set({ capture: v })} options={CAPTURE_OPTIONS}/>
+                </SettingRow>
+              </SettingsCard>
+
+              <SettingsCard>
+                <SectionLabel>Tags</SectionLabel>
+                <SettingRow full label="Session tags" help={<>Applied to every generation as <Mono>key=value</Mono>. Empty pairs are dropped on save.</>}>
+                  <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                    {form.tags.map((t, i) => (
+                      <div key={i} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                        <MonoInput value={t.key} onChange={v => setTag(i, { key: v })} placeholder="key" width={200}/>
+                        <span style={{ color: "var(--fg3)", fontFamily: "var(--fontFamilyMonospace)" }}>=</span>
+                        <MonoInput value={t.value} onChange={v => setTag(i, { value: v })} placeholder="value" width={200}/>
+                        <button onClick={() => removeTag(i)} title="Remove tag" aria-label="Remove tag" style={{
+                          width: 28, height: 28, display: "inline-flex", alignItems: "center", justifyContent: "center",
+                          background: "transparent", border: "1px solid transparent", color: "var(--fg3)", cursor: "pointer", borderRadius: 2,
+                        }}
+                          onMouseEnter={e => e.currentTarget.style.color = "var(--fg1)"}
+                          onMouseLeave={e => e.currentTarget.style.color = "var(--fg3)"}>
+                          <Icon name="times" size={14}/>
+                        </button>
+                      </div>
+                    ))}
+                    <button onClick={addTag} style={{
+                      alignSelf: "flex-start", display: "inline-flex", alignItems: "center", gap: 6,
+                      height: 30, padding: "0 12px", background: "transparent", border: "1px dashed var(--border-medium)",
+                      borderRadius: 2, color: "var(--fg2)", fontSize: 13, cursor: "pointer",
+                    }}
+                      onMouseEnter={e => e.currentTarget.style.borderColor = "var(--border-strong)"}
+                      onMouseLeave={e => e.currentTarget.style.borderColor = "var(--border-medium)"}>
+                      <Icon name="plus" size={13}/>Add tag
+                    </button>
+                  </div>
+                </SettingRow>
+              </SettingsCard>
+
+              <SettingsCard>
+                <SectionLabel>Guards</SectionLabel>
+                <SettingRow label="Pre-tool-use guards" help={<>Run safety checks before each tool call. <b style={{ fontWeight: 500, color: "var(--fg2)" }}>Fail-open</b> allows the action if a check errors or times out; <b style={{ fontWeight: 500, color: "var(--fg2)" }}>fail-closed</b> blocks it.</>}>
+                  <Segmented value={form.guards} onChange={v => set({ guards: v })} options={GUARD_OPTIONS}/>
+                </SettingRow>
+                {guardsOn && (
+                  <SettingRow label="Guard timeout" help={<>Max time for a guard check to respond. Clear the field to use the default of 1500 ms.</>}>
+                    <div style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                      <MonoInput value={form.guardTimeout} onChange={v => set({ guardTimeout: v })} placeholder="1500" width={110} align="right"/>
+                      <span style={{ fontSize: 12, color: "var(--fg3)" }}>ms</span>
+                    </div>
+                  </SettingRow>
+                )}
+              </SettingsCard>
+
+              <SettingsCard>
+                <SectionLabel>Runtime</SectionLabel>
+                <SettingRow label="Debug logging" help={<>Write a verbose log to <Mono>~/.local/state/sigil/logs/sigil.log</Mono>.</>}>
+                  <Toggle checked={form.debug} onChange={v => set({ debug: v })}/>
+                </SettingRow>
+                <SettingRow label="Automatic updates" help={<>Keep host agent plugins refreshed automatically. Turn off to pin the current versions.</>}>
+                  <Toggle checked={form.autoUpdate} onChange={v => set({ autoUpdate: v })}/>
+                </SettingRow>
+              </SettingsCard>
+
+              <SettingsCard>
+                <SectionLabel>Identity · Optional</SectionLabel>
+                <SettingRow label="User ID" help={<>Override the resolved user id used to attribute generations. Leave blank to auto-resolve.</>}>
+                  <MonoInput value={form.userId} onChange={v => set({ userId: v })} placeholder="auto" width={260}/>
+                </SettingRow>
+              </SettingsCard>
+            </div>
+
+            <div style={{ width: 440, flexShrink: 0, position: "sticky", top: 72 }}>
+              <div style={{ background: "var(--bg-primary)", border: "1px solid var(--border-weak)", borderRadius: 2 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "10px 14px", borderBottom: "1px solid var(--border-weak)" }}>
+                  <span style={{ fontSize: 12, color: "var(--fg2)", fontFamily: "var(--fontFamilyMonospace)", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{path}</span>
+                  <button onClick={copy} style={{ display: "inline-flex", alignItems: "center", gap: 5, background: "transparent", border: "1px solid var(--secondary-border)", color: "var(--fg1)", borderRadius: 2, height: 26, padding: "0 8px", fontSize: 12, cursor: "pointer" }}
+                    onMouseEnter={e => e.currentTarget.style.background = "var(--action-hover)"}
+                    onMouseLeave={e => e.currentTarget.style.background = "transparent"}>
+                    <Icon name="copy" size={13}/>Copy
+                  </button>
+                </div>
+                <div style={{ background: "var(--bg-canvas)", padding: "14px 16px", maxHeight: "calc(100vh - 220px)", overflow: "auto" }}>
+                  <PreviewBody text={preview}/>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {dirty && <UnsavedBar onReset={reset} onSave={save}/>}
+          {toast && <Toast message={toast}/>}
+        </div>
+      );
+    }
+
+    // ============================================================
     // App container — fetches from the daemon and routes between views.
     // ============================================================
 
@@ -1658,6 +2045,14 @@
 
     function conversationPath(id) {
       return `/conversations/${encodeURIComponent(id)}`;
+    }
+
+    // settingsRouteActive reports whether the URL is the Settings tab. It is
+    // the only non-conversation route; every other path is the conversations
+    // section (the list, or a detail when conversationIDFromPath matches).
+    function settingsRouteActive() {
+      if (typeof window === "undefined") return false;
+      return window.location.pathname.replace(/\/$/, "") === "/settings";
     }
 
     // Returns true for a plain primary-button click with no modifier keys.
@@ -1727,6 +2122,7 @@
 
     function App() {
       const [selectedID, setSelectedID] = useState(conversationIDFromPath);
+      const [showSettings, setShowSettings] = useState(settingsRouteActive);
       const [conversations, setConversations] = useState([]);
       const [tokenPoints, setTokenPoints] = useState([]);
       const [loadingList, setLoadingList] = useState(true);
@@ -1744,7 +2140,7 @@
       const [loadingDetail, setLoadingDetail] = useState(false);
       const [errDetail, setErrDetail] = useState(null);
 
-      const view = selectedID ? "conversation" : "conversations";
+      const view = showSettings ? "settings" : (selectedID ? "conversation" : "conversations");
       const selected = selectedID
         ? conversations.find(c => c.id === selectedID) || summaryFromDetail(detail, selectedID)
         : null;
@@ -1756,9 +2152,11 @@
         setTimeRange(v);
       }, [setTimeRange]);
 
-      const pageTitle = view === "conversation" && selected
-        ? `${selected.title || selected.id} — sigil local`
-        : "sigil — local";
+      const pageTitle = view === "settings"
+        ? "Settings — sigil local"
+        : view === "conversation" && selected
+          ? `${selected.title || selected.id} — sigil local`
+          : "sigil — local";
       useEffect(() => { document.title = pageTitle; }, [pageTitle]);
 
       const fetchList = useCallback(() => {
@@ -1806,7 +2204,10 @@
       useEffect(() => { refreshAll(); }, [refreshAll]);
 
       useEffect(() => {
-        const onPopState = () => setSelectedID(conversationIDFromPath());
+        const onPopState = () => {
+          setSelectedID(conversationIDFromPath());
+          setShowSettings(settingsRouteActive());
+        };
         window.addEventListener("popstate", onPopState);
         return () => window.removeEventListener("popstate", onPopState);
       }, []);
@@ -1833,26 +2234,33 @@
 
       const openConv = (c) => {
         window.history.pushState({}, "", conversationPath(c.id));
+        setShowSettings(false);
         setSelectedID(c.id);
       };
       const goHome = () => {
         window.history.pushState({}, "", "/");
+        setShowSettings(false);
         setSelectedID(null);
       };
+      const goSettings = () => {
+        window.history.pushState({}, "", "/settings");
+        setSelectedID(null);
+        setShowSettings(true);
+      };
 
-      const breadcrumbs = selected
-        ? [
-            { label: "Conversations", href: "/", onClick: goHome },
-            { label: selected.title || selected.id, mono: true },
-          ]
-        : [
-            { label: "Conversations" },
-          ];
+      const tabs = [
+        { label: "Conversations", href: "/", onClick: goHome, state: view === "conversations" ? "current" : "link" },
+        { label: "Settings", href: "/settings", onClick: goSettings, state: view === "settings" ? "current" : "link" },
+      ];
+      const trail = view === "conversation" && selected
+        ? [{ label: selected.title || selected.id, mono: true }]
+        : [];
 
       return (
         <div style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}>
-          <TopBar breadcrumbs={breadcrumbs}/>
+          <TopBar tabs={tabs} trail={trail}/>
           <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
+            {view === "settings" && <SettingsView/>}
             {view === "conversations" && (
               <ConversationsView
                 conversations={conversations}

--- a/plugins/sigil/internal/login/login.go
+++ b/plugins/sigil/internal/login/login.go
@@ -29,6 +29,7 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/grafana/sigil-sdk/plugins/sigil/internal/dotenv"
+	"github.com/grafana/sigil-sdk/plugins/sigil/internal/envconfig"
 	"golang.org/x/term"
 )
 
@@ -185,7 +186,7 @@ func Run(_ context.Context, opts RunOpts) error {
 	guards := seedGuards(existing["SIGIL_GUARDS_ENABLED"], existing["SIGIL_GUARDS_FAIL_OPEN"])
 	guardTimeout := strings.TrimSpace(existing["SIGIL_GUARDS_TIMEOUT_MS"])
 	if guardTimeout == "" {
-		guardTimeout = strconv.Itoa(defaultGuardTimeoutMs)
+		guardTimeout = strconv.Itoa(envconfig.DefaultGuardsTimeoutMs)
 	}
 
 	// Only metadata_only and full are offered. The advanced no_tool_content
@@ -378,10 +379,6 @@ const (
 	guardsClosed = "closed"
 )
 
-// defaultGuardTimeoutMs mirrors envconfig.defaultGuardsTimeoutMs so the
-// prefilled value matches what the plugin uses when the key is absent.
-const defaultGuardTimeoutMs = 1500
-
 // formValues holds the resolved field values the form produced. It exists so
 // buildUpdates can be unit-tested without driving the huh TUI.
 type formValues struct {
@@ -450,28 +447,13 @@ func normalizeContentMode(raw string) string {
 // fail-open keys. Fail-open defaults to true (matching the plugin), so an
 // enabled-but-unspecified config seeds the fail-open option.
 func seedGuards(enabledRaw, failOpenRaw string) string {
-	if !parseBoolDefault(enabledRaw, false) {
+	if !envconfig.ParseBoolDefault(enabledRaw, false) {
 		return guardsOff
 	}
-	if parseBoolDefault(failOpenRaw, true) {
+	if envconfig.ParseBoolDefault(failOpenRaw, true) {
 		return guardsOpen
 	}
 	return guardsClosed
-}
-
-// parseBoolDefault mirrors envconfig.resolveGuardsBool: empty or unrecognised
-// values fall back to def, while the usual truthy/falsy words are honoured.
-func parseBoolDefault(raw string, def bool) bool {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "":
-		return def
-	case "1", "true", "yes", "on":
-		return true
-	case "0", "false", "no", "off":
-		return false
-	default:
-		return def
-	}
 }
 
 // validateTags accepts an empty value (tags are optional) and otherwise


### PR DESCRIPTION
Add a Settings tab that manages `config.env`:

<img width="1764" height="1015" alt="image" src="https://github.com/user-attachments/assets/5437f0d4-624f-48ee-8734-25a078b504a0" />

