### PR TITLE
chore(docs): clean up example references

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -45,11 +45,12 @@ var sigil = new SigilClient(new SigilClientConfig
     GenerationExport = new GenerationExportConfig
     {
         Protocol = GenerationExportProtocol.Http,
-        Endpoint = "http://localhost:8080",
+        Endpoint = "https://sigil-prod-<region>.grafana.net",
         Auth = new AuthConfig
         {
-            Mode = ExportAuthMode.Tenant,
-            TenantId = "dev-tenant",
+            Mode = ExportAuthMode.Basic,
+            TenantId = Environment.GetEnvironmentVariable("SIGIL_AUTH_TENANT_ID"),
+            BasicPassword = Environment.GetEnvironmentVariable("SIGIL_AUTH_TOKEN"),
         },
         BatchSize = 100,
         FlushInterval = TimeSpan.FromSeconds(1),
@@ -57,7 +58,7 @@ var sigil = new SigilClient(new SigilClientConfig
     },
     Api = new ApiConfig
     {
-        Endpoint = "http://localhost:8080",
+        Endpoint = "https://sigil-prod-<region>.grafana.net",
     },
 });
 
@@ -329,7 +330,7 @@ var result = await client.SubmitConversationRatingAsync(
 Console.WriteLine($"{result.Rating.Rating} hasBad={result.Summary.HasBadRating}");
 ```
 
-`SubmitConversationRatingAsync(...)` sends requests to `SigilClientConfig.Api.Endpoint` (default `http://localhost:8080`) and uses the same generation-export auth headers (`tenant` or `bearer`) already configured on the SDK client.
+`SubmitConversationRatingAsync(...)` sends requests to `SigilClientConfig.Api.Endpoint`, which should be the Grafana Cloud Sigil API URL from AI Observability configuration, and uses the same generation-export auth headers already configured on the SDK client.
 
 ## .NET best practices
 

--- a/dotnet/src/Grafana.Sigil.Anthropic/README.md
+++ b/dotnet/src/Grafana.Sigil.Anthropic/README.md
@@ -27,16 +27,17 @@ var sigilConfig = new SigilClientConfig
     GenerationExport = new GenerationExportConfig
     {
         Protocol = GenerationExportProtocol.Http,
-        Endpoint = "http://localhost:8080",
+        Endpoint = "https://sigil-prod-<region>.grafana.net",
         Auth = new AuthConfig
         {
-            Mode = ExportAuthMode.Tenant,
-            TenantId = "dev-tenant",
+            Mode = ExportAuthMode.Basic,
+            TenantId = Environment.GetEnvironmentVariable("SIGIL_AUTH_TENANT_ID"),
+            BasicPassword = Environment.GetEnvironmentVariable("SIGIL_AUTH_TOKEN"),
         },
     },
     Api = new ApiConfig
     {
-        Endpoint = "http://localhost:8080",
+        Endpoint = "https://sigil-prod-<region>.grafana.net",
     },
 };
 var sigil = new SigilClient(sigilConfig);

--- a/dotnet/src/Grafana.Sigil.Gemini/README.md
+++ b/dotnet/src/Grafana.Sigil.Gemini/README.md
@@ -33,16 +33,17 @@ var sigilConfig = new SigilClientConfig
     GenerationExport = new GenerationExportConfig
     {
         Protocol = GenerationExportProtocol.Http,
-        Endpoint = "http://localhost:8080",
+        Endpoint = "https://sigil-prod-<region>.grafana.net",
         Auth = new AuthConfig
         {
-            Mode = ExportAuthMode.Tenant,
-            TenantId = "dev-tenant",
+            Mode = ExportAuthMode.Basic,
+            TenantId = Environment.GetEnvironmentVariable("SIGIL_AUTH_TENANT_ID"),
+            BasicPassword = Environment.GetEnvironmentVariable("SIGIL_AUTH_TOKEN"),
         },
     },
     Api = new ApiConfig
     {
-        Endpoint = "http://localhost:8080",
+        Endpoint = "https://sigil-prod-<region>.grafana.net",
     },
 };
 var sigil = new SigilClient(sigilConfig);

--- a/dotnet/src/Grafana.Sigil.OpenAI/README.md
+++ b/dotnet/src/Grafana.Sigil.OpenAI/README.md
@@ -45,16 +45,17 @@ var sigilConfig = new SigilClientConfig
     GenerationExport = new GenerationExportConfig
     {
         Protocol = GenerationExportProtocol.Http,
-        Endpoint = "http://localhost:8080",
+        Endpoint = "https://sigil-prod-<region>.grafana.net",
         Auth = new AuthConfig
         {
-            Mode = ExportAuthMode.Tenant,
-            TenantId = "dev-tenant",
+            Mode = ExportAuthMode.Basic,
+            TenantId = Environment.GetEnvironmentVariable("SIGIL_AUTH_TENANT_ID"),
+            BasicPassword = Environment.GetEnvironmentVariable("SIGIL_AUTH_TOKEN"),
         },
     },
     Api = new ApiConfig
     {
-        Endpoint = "http://localhost:8080",
+        Endpoint = "https://sigil-prod-<region>.grafana.net",
     },
 };
 var sigil = new SigilClient(sigilConfig);

--- a/dotnet/src/Grafana.Sigil/Config.cs
+++ b/dotnet/src/Grafana.Sigil/Config.cs
@@ -44,7 +44,7 @@ public sealed class GenerationExportConfig
     public GenerationExportProtocol? Protocol { get; set; }
     /// <summary>
     /// Export endpoint. Empty string means "not set" — env layer or
-    /// <c>ConfigResolver</c> resolves it to <c>localhost:4317</c>. An explicit
+    /// <c>ConfigResolver</c> resolves it from <c>SIGIL_ENDPOINT</c> when configured. An explicit
     /// non-empty value is preserved (caller-wins) and not overridden by
     /// <c>SIGIL_ENDPOINT</c>.
     /// </summary>

--- a/dotnet/src/Grafana.Sigil/README.md
+++ b/dotnet/src/Grafana.Sigil/README.md
@@ -17,12 +17,13 @@ var client = new SigilClient(new SigilClientConfig
 {
     GenerationExport = new GenerationExportConfig
     {
-        Protocol = GenerationExportProtocol.Grpc,
-        Endpoint = "localhost:4317",
+        Protocol = GenerationExportProtocol.Http,
+        Endpoint = "https://sigil-prod-<region>.grafana.net",
         Auth = new AuthConfig
         {
-            Mode = ExportAuthMode.Tenant,
-            TenantId = "dev-tenant",
+            Mode = ExportAuthMode.Basic,
+            TenantId = Environment.GetEnvironmentVariable("SIGIL_AUTH_TENANT_ID"),
+            BasicPassword = Environment.GetEnvironmentVariable("SIGIL_AUTH_TOKEN"),
         },
         BatchSize = 100,
         FlushInterval = TimeSpan.FromSeconds(1),
@@ -33,7 +34,7 @@ var client = new SigilClient(new SigilClientConfig
     },
     Api = new ApiConfig
     {
-        Endpoint = "http://localhost:8080",
+        Endpoint = "https://sigil-prod-<region>.grafana.net",
     },
 });
 ```

--- a/examples/experiments/go/README.md
+++ b/examples/experiments/go/README.md
@@ -20,7 +20,7 @@ This example uses the production-style shape you would use for LLMSpec or A2A:
 
 When the runner and agent are in the same process, use `run.Context(ctx)` instead; that also captures generation IDs automatically. When the agent is behind HTTP, A2A, or a task queue, propagate the run ID explicitly and restore it with `WithExperimentRunID`.
 
-This example is designed for Grafana Cloud AI Observability. There is no supported local Grafana path for users; local/self-hosted Sigil is only a development override for SDK contributors.
+This example is designed for Grafana Cloud AI Observability.
 
 ## Run
 

--- a/examples/experiments/python-langgraph/README.md
+++ b/examples/experiments/python-langgraph/README.md
@@ -29,7 +29,7 @@ A/B testing is just two runs with different `run_id`/`tags` over the same items.
 ## Prerequisites
 
 - Python 3.11+ and [uv](https://docs.astral.sh/uv/)
-- A running Sigil stack (defaults to `http://localhost:8080`)
+- Grafana Cloud AI Observability credentials from your stack's Connection page
 - Optional: `OPENAI_API_KEY` (without it, a deterministic fake model is used so
   the example runs fully offline)
 
@@ -38,11 +38,18 @@ A/B testing is just two runs with different `run_id`/`tags` over the same items.
 ```bash
 uv sync
 
-# Point at your stack (defaults shown)
-export SIGIL_ENDPOINT=http://localhost:8080
-export SIGIL_AUTH_TENANT_ID=fake
+# Grafana Cloud ingest plane: generations and scores.
+export SIGIL_ENDPOINT=https://<your-sigil-api-host>
+export SIGIL_AUTH_TENANT_ID=<your-tenant-id>
+export SIGIL_AUTH_TOKEN=<your-cloud-access-policy-token>
+
+# Grafana Cloud eval control plane: experiment create/update/finalize/report.
+export SIGIL_EVAL_ENDPOINT=https://<your-stack>.grafana.net
+export SIGIL_EVAL_PATH_PREFIX=/api/plugins/grafana-sigil-app/resources
+export SIGIL_EVAL_AUTH_TOKEN=<your-grafana-service-account-token>
+
 # Optional: stable run id for CI retries / a real model
-export RUN_ID=langgraph-example-$(git rev-parse --short HEAD 2>/dev/null || echo local)
+export RUN_ID=langgraph-example-$(git rev-parse --short HEAD 2>/dev/null || echo dev)
 # export OPENAI_API_KEY=sk-...
 
 uv run python -m app.run_experiment
@@ -51,14 +58,13 @@ uv run python -m app.run_experiment
 You should see output like:
 
 ```
-Experiment 'langgraph-example-local' finished: 3 score(s) accepted.
+Experiment 'langgraph-example-abc123' finished: 3 score(s) accepted.
 pass_rate=1.00 mean_score=1.00
-View in Sigil: http://localhost:8080/a/grafana-sigil-app/evaluation/experiments/langgraph-example-local
+View in Sigil: https://<your-stack>.grafana.net/a/grafana-sigil-app/evaluation/experiments/langgraph-example-abc123
 ```
 
-> The deep link is derived from `SIGIL_ENDPOINT`. If your Grafana UI is served
-> from a different host, set `SIGIL_EXPERIMENT_URL_TEMPLATE`, e.g.
-> `https://grafana.example.com/a/grafana-sigil-app/evaluation/experiments/{run_id}`.
+> The deep link is derived from `SIGIL_EVAL_ENDPOINT`. Set
+> `SIGIL_EXPERIMENT_URL_TEMPLATE` only if your UI needs a custom URL shape.
 
 ## Adapt it
 

--- a/examples/experiments/python-langgraph/app/run_experiment.py
+++ b/examples/experiments/python-langgraph/app/run_experiment.py
@@ -8,9 +8,8 @@ This is the shape a CI job or local script would take:
   4. The runner creates the experiment, runs+grades each item, exports scores
      attributed to the run, finalizes the run, and prints a link.
 
-Config via env: SIGIL_ENDPOINT, SIGIL_AUTH_TENANT_ID (or SIGIL_AUTH_* /
-SIGIL_PROTOCOL), RUN_ID, GIT_SHA. With no OPENAI_API_KEY the agent uses a
-deterministic fake model so the flow runs offline against a local Sigil.
+Config via env: SIGIL_ENDPOINT, SIGIL_AUTH_TENANT_ID, SIGIL_AUTH_TOKEN, RUN_ID,
+GIT_SHA. With no OPENAI_API_KEY the agent uses a deterministic fake model.
 """
 
 from __future__ import annotations
@@ -52,16 +51,24 @@ DATASET: list[DatasetItem] = [
 ]
 
 
+def required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if value == "":
+        raise RuntimeError(f"{name} is required; copy it from Grafana Cloud AI Observability")
+    return value
+
+
 def build_client() -> Client:
-    endpoint = os.environ.get("SIGIL_ENDPOINT", "http://localhost:8080")
-    tenant_id = os.environ.get("SIGIL_AUTH_TENANT_ID", "fake")
+    endpoint = required_env("SIGIL_ENDPOINT").rstrip("/")
+    tenant_id = required_env("SIGIL_AUTH_TENANT_ID")
+    auth_token = required_env("SIGIL_AUTH_TOKEN")
     return Client(
         ClientConfig(
             api=ApiConfig(endpoint=endpoint),
             generation_export=GenerationExportConfig(
                 protocol="http",
                 endpoint=f"{endpoint}/api/v1/generations:export",
-                auth=AuthConfig(mode="tenant", tenant_id=tenant_id),
+                auth=AuthConfig(mode="basic", tenant_id=tenant_id, basic_password=auth_token),
             ),
         )
     )

--- a/examples/experiments/python/README.md
+++ b/examples/experiments/python/README.md
@@ -34,7 +34,7 @@ A/B testing is just two runs with different `run_id`/`tags` over the same items.
 ## Prerequisites
 
 - Python 3.11+ and [uv](https://docs.astral.sh/uv/)
-- A running Sigil stack (defaults to `http://localhost:8080`)
+- Grafana Cloud AI Observability credentials from your stack's Connection page
 - Optional: `OPENAI_API_KEY` (without it, deterministic canned answers are used
   so the example runs fully offline)
 
@@ -43,11 +43,18 @@ A/B testing is just two runs with different `run_id`/`tags` over the same items.
 ```bash
 uv sync
 
-# Point at your stack (defaults shown)
-export SIGIL_ENDPOINT=http://localhost:8080
-export SIGIL_AUTH_TENANT_ID=fake
+# Grafana Cloud ingest plane: generations and scores.
+export SIGIL_ENDPOINT=https://<your-sigil-api-host>
+export SIGIL_AUTH_TENANT_ID=<your-tenant-id>
+export SIGIL_AUTH_TOKEN=<your-cloud-access-policy-token>
+
+# Grafana Cloud eval control plane: experiment create/update/finalize/report.
+export SIGIL_EVAL_ENDPOINT=https://<your-stack>.grafana.net
+export SIGIL_EVAL_PATH_PREFIX=/api/plugins/grafana-sigil-app/resources
+export SIGIL_EVAL_AUTH_TOKEN=<your-grafana-service-account-token>
+
 # Optional: stable run id for CI retries / a real model
-export RUN_ID=experiment-example-$(git rev-parse --short HEAD 2>/dev/null || echo local)
+export RUN_ID=experiment-example-$(git rev-parse --short HEAD 2>/dev/null || echo dev)
 # export OPENAI_API_KEY=sk-...
 
 uv run python -m app.run_experiment
@@ -56,14 +63,13 @@ uv run python -m app.run_experiment
 You should see output like:
 
 ```
-Experiment 'experiment-example-local' finished: 3 score(s) accepted.
+Experiment 'experiment-example-abc123' finished: 3 score(s) accepted.
 pass_rate=1.00 mean_score=1.00
-View in Sigil: http://localhost:8080/a/grafana-sigil-app/evaluation/experiments/experiment-example-local
+View in Sigil: https://<your-stack>.grafana.net/a/grafana-sigil-app/evaluation/experiments/experiment-example-abc123
 ```
 
-> The deep link is derived from `SIGIL_ENDPOINT`. If your Grafana UI is served
-> from a different host, set `SIGIL_EXPERIMENT_URL_TEMPLATE`, e.g.
-> `https://grafana.example.com/a/grafana-sigil-app/evaluation/experiments/{run_id}`.
+> The deep link is derived from `SIGIL_EVAL_ENDPOINT`. Set
+> `SIGIL_EXPERIMENT_URL_TEMPLATE` only if your UI needs a custom URL shape.
 
 ## Adapt it
 

--- a/examples/experiments/python/app/agent.py
+++ b/examples/experiments/python/app/agent.py
@@ -2,7 +2,7 @@
 
 When ``OPENAI_API_KEY`` is set, the agent calls a real OpenAI chat model.
 Otherwise it falls back to a deterministic offline "model" (a dict of canned
-answers) so the example runs fully offline against a local Sigil.
+answers).
 
 The point of the example is the *experiment plumbing*, not the agent — swap this
 out for your real agent and record its call via ``run.start_generation(...)``.

--- a/examples/experiments/python/app/run_experiment.py
+++ b/examples/experiments/python/app/run_experiment.py
@@ -9,9 +9,8 @@ supported framework adapter (LangGraph, LangChain, ...):
   3. The runner creates the experiment, runs+grades each item, exports scores
      attributed to the run, finalizes the run, and prints a link.
 
-Config via env: SIGIL_ENDPOINT, SIGIL_AUTH_TENANT_ID, RUN_ID, GIT_SHA. With no
-OPENAI_API_KEY the agent uses deterministic canned answers so the flow runs
-offline against a local Sigil.
+Config via env: SIGIL_ENDPOINT, SIGIL_AUTH_TENANT_ID, SIGIL_AUTH_TOKEN, RUN_ID,
+GIT_SHA. With no OPENAI_API_KEY the agent uses deterministic canned answers.
 """
 
 from __future__ import annotations
@@ -65,16 +64,24 @@ DATASET: list[DatasetItem] = [
 CANNED = {str(item.input): str(item.expected) for item in DATASET}
 
 
+def required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if value == "":
+        raise RuntimeError(f"{name} is required; copy it from Grafana Cloud AI Observability")
+    return value
+
+
 def build_client() -> Client:
-    endpoint = os.environ.get("SIGIL_ENDPOINT", "http://localhost:8080")
-    tenant_id = os.environ.get("SIGIL_AUTH_TENANT_ID", "fake")
+    endpoint = required_env("SIGIL_ENDPOINT").rstrip("/")
+    tenant_id = required_env("SIGIL_AUTH_TENANT_ID")
+    auth_token = required_env("SIGIL_AUTH_TOKEN")
     return Client(
         ClientConfig(
             api=ApiConfig(endpoint=endpoint),
             generation_export=GenerationExportConfig(
                 protocol="http",
                 endpoint=f"{endpoint}/api/v1/generations:export",
-                auth=AuthConfig(mode="tenant", tenant_id=tenant_id),
+                auth=AuthConfig(mode="basic", tenant_id=tenant_id, basic_password=auth_token),
             ),
         )
     )
@@ -86,9 +93,7 @@ def target(item: DatasetItem, run: ExperimentRun) -> TargetResult:
     question = str(item.input)
     # Recording through run.start_generation(...) tags the generation with the
     # experiment run_id and captures its id so the score below attaches to it.
-    with run.start_generation(
-        GenerationStart(model=ModelRef(provider="openai", name="gpt-4o-mini"))
-    ) as rec:
+    with run.start_generation(GenerationStart(model=ModelRef(provider="openai", name="gpt-4o-mini"))) as rec:
         answer = answer_question(question, canned=CANNED)
         rec.set_result(
             Generation(

--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -45,7 +45,7 @@ See the [credentials section in the SDK README](../../README.md#grafana-cloud-cr
 The SDK emits OpenTelemetry spans and metrics (`gen_ai.client.operation.duration`, `gen_ai.client.token.usage`, etc.). These need an OTLP endpoint:
 
 - **Direct to Cloud** — set `OTEL_EXPORTER_OTLP_ENDPOINT` to your Cloud OTLP gateway URL (find it in the Grafana Cloud portal → stack Details page, [docs](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp)) and `OTEL_EXPORTER_OTLP_HEADERS` with Basic auth credentials.
-- **Via Alloy** — set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318` if you have a local Alloy/collector forwarding to Cloud.
+- **Via Alloy or an OTel Collector** — set `OTEL_EXPORTER_OTLP_ENDPOINT` to the collector endpoint your deployment provides, with the collector forwarding to Grafana Cloud.
 
 Set all values as environment variables before running an example.
 

--- a/examples/getting-started/go-hooks/.env.example
+++ b/examples/getting-started/go-hooks/.env.example
@@ -28,5 +28,5 @@ SIGIL_AUTH_TOKEN=
 OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
 OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp_instance_id:cloud_api_token)>
 
-# Option B - Via local Alloy / OTel Collector (no auth needed):
-# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+# Optional: set OTEL_EXPORTER_OTLP_ENDPOINT to your Alloy / OTel Collector endpoint
+# if your deployment forwards telemetry to Grafana Cloud through a collector.

--- a/examples/getting-started/go/.env.example
+++ b/examples/getting-started/go/.env.example
@@ -25,5 +25,5 @@ SIGIL_AUTH_TOKEN=
 OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
 OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp_instance_id:cloud_api_token)>
 
-# Option B — Via local Alloy / OTel Collector (no auth needed):
-# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+# Optional: set OTEL_EXPORTER_OTLP_ENDPOINT to your Alloy / OTel Collector endpoint
+# if your deployment forwards telemetry to Grafana Cloud through a collector.

--- a/examples/getting-started/python-hooks/.env.example
+++ b/examples/getting-started/python-hooks/.env.example
@@ -28,5 +28,5 @@ SIGIL_AUTH_TOKEN=
 OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
 OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp_instance_id:cloud_api_token)>
 
-# Option B - Via local Alloy / OTel Collector (no auth needed):
-# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+# Optional: set OTEL_EXPORTER_OTLP_ENDPOINT to your Alloy / OTel Collector endpoint
+# if your deployment forwards telemetry to Grafana Cloud through a collector.

--- a/examples/getting-started/python-multi-agent/.env.example
+++ b/examples/getting-started/python-multi-agent/.env.example
@@ -23,5 +23,5 @@ GRAFANA_CLOUD_TOKEN=
 OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
 OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instance_id:cloud_api_token)>
 
-# Option B — Via local Alloy / OTel Collector (no auth needed):
-# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+# Optional: set OTEL_EXPORTER_OTLP_ENDPOINT to your Alloy / OTel Collector endpoint
+# if your deployment forwards telemetry to Grafana Cloud through a collector.

--- a/examples/getting-started/python-pydantic-ai/.env.example
+++ b/examples/getting-started/python-pydantic-ai/.env.example
@@ -18,8 +18,8 @@ SIGIL_AUTH_TOKEN=
 #   OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
 #   OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64 of OTLP_INSTANCE_ID:SIGIL_AUTH_TOKEN>
 #   # for example: printf '%s' "$OTLP_INSTANCE_ID:$SIGIL_AUTH_TOKEN" | base64 | tr -d '\n'
-# Option B — Via local Alloy/collector:
-#   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+# Optional: set OTEL_EXPORTER_OTLP_ENDPOINT to your Alloy / OTel Collector endpoint
+# if your deployment forwards telemetry to Grafana Cloud through a collector.
 OTEL_EXPORTER_OTLP_ENDPOINT=
 OTEL_EXPORTER_OTLP_HEADERS=
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf

--- a/examples/getting-started/python/.env.example
+++ b/examples/getting-started/python/.env.example
@@ -25,5 +25,5 @@ SIGIL_AUTH_TOKEN=
 OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
 OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp_instance_id:cloud_api_token)>
 
-# Option B — Via local Alloy / OTel Collector (no auth needed):
-# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+# Optional: set OTEL_EXPORTER_OTLP_ENDPOINT to your Alloy / OTel Collector endpoint
+# if your deployment forwards telemetry to Grafana Cloud through a collector.

--- a/examples/getting-started/typescript-hooks/.env.example
+++ b/examples/getting-started/typescript-hooks/.env.example
@@ -28,5 +28,5 @@ SIGIL_AUTH_TOKEN=
 OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
 OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp_instance_id:cloud_api_token)>
 
-# Option B - Via local Alloy / OTel Collector (no auth needed):
-# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+# Optional: set OTEL_EXPORTER_OTLP_ENDPOINT to your Alloy / OTel Collector endpoint
+# if your deployment forwards telemetry to Grafana Cloud through a collector.

--- a/examples/getting-started/typescript/.env.example
+++ b/examples/getting-started/typescript/.env.example
@@ -25,5 +25,5 @@ SIGIL_AUTH_TOKEN=
 OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
 OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp_instance_id:cloud_api_token)>
 
-# Option B — Via local Alloy / OTel Collector (no auth needed):
-# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+# Optional: set OTEL_EXPORTER_OTLP_ENDPOINT to your Alloy / OTel Collector endpoint
+# if your deployment forwards telemetry to Grafana Cloud through a collector.

--- a/examples/python-langchain/.env.example
+++ b/examples/python-langchain/.env.example
@@ -17,17 +17,14 @@ SIGIL_AUTH_TENANT_ID=
 
 # Cloud Access Policy Token (`glc_…`) with `sigil:write` scope.
 # Required for Grafana Cloud (basic-auth password).
-# Leave unset when pointing at a Sigil that doesn't require auth —
-# the client falls back to tenant-only mode.
 SIGIL_AUTH_TOKEN=
 
 # --- OTel traces + metrics exporter ---
 # Option A — Direct to Cloud (get URL from Cloud portal → stack Details):
 #   OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
 #   OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instance_id:cloud_api_token)>
-# Option B — Via local Alloy/collector (default for docker-compose):
-#   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
-# Leave unset to use the exporter's built-in default (localhost:4317 for gRPC).
+# Optional: set OTEL_EXPORTER_OTLP_ENDPOINT to your Alloy / OTel Collector endpoint
+# if your deployment forwards telemetry to Grafana Cloud through a collector.
 # OTEL_EXPORTER_OTLP_ENDPOINT=
 OTEL_SERVICE_NAME=sigil-langchain-weather-example
 

--- a/examples/python-langchain/README.md
+++ b/examples/python-langchain/README.md
@@ -45,17 +45,17 @@ uv run uvicorn app.main:app --reload --port 8000
 
 ```bash
 # On-topic: agent uses the tool, classifier returns ON_TOPIC
-curl -s localhost:8000/chat \
+curl -s http://<app-host>:8000/chat \
   -H 'content-type: application/json' \
   -d '{"message": "Whats the weather in Paris on 2026-04-18?"}' | jq
 
 # Off-topic: agent declines, classifier returns OFF_TOPIC
-curl -s localhost:8000/chat \
+curl -s http://<app-host>:8000/chat \
   -H 'content-type: application/json' \
   -d '{"message": "Write me a limerick about kubernetes."}' | jq
 ```
 
-FastAPI also serves interactive docs at [http://localhost:8000/docs](http://localhost:8000/docs).
+FastAPI also serves interactive docs at `http://<app-host>:8000/docs`.
 
 ## What to look for in Sigil
 
@@ -87,13 +87,12 @@ See `[.env.example](./.env.example)`.
 | Variable                           | Purpose                                                                                                                               |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `ANTHROPIC_API_KEY`                | Required. Used by both the agent and the classifier.                                                                                  |
-| `SIGIL_ENDPOINT`                   | API URL from AI Observability → Configuration. Default `http://localhost:8080`.                                                       |
-| `SIGIL_API_ENDPOINT`               | Sigil REST API base used by helper endpoints such as ratings. Default `http://localhost:8080`.                                        |
+| `SIGIL_ENDPOINT`                   | API URL from AI Observability → Configuration. Required for Grafana Cloud.                                                            |
+| `SIGIL_API_ENDPOINT`               | Sigil REST API base used by helper endpoints such as ratings. Same host as `SIGIL_ENDPOINT` for Grafana Cloud.                       |
 | `SIGIL_AUTH_TENANT_ID`             | Numeric instance ID. Sent as `X-Scope-OrgID` and used as basic-auth user.                                                             |
 | `SIGIL_AUTH_TOKEN`                 | Cloud Access Policy Token (`glc_…`) with `sigil:write` scope. Required for Cloud.                                                     |
-| `OTEL_EXPORTER_OTLP_ENDPOINT`      | OTLP gRPC target for traces + metrics. Default `http://localhost:4317`.                                                               |
-| `OTEL_EXPORTER_OTLP_INSECURE`      | `true` for plaintext gRPC (local dev).                                                                                                |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`      | OTLP target for traces + metrics. Use the Grafana Cloud OTLP gateway URL or your collector endpoint.                                  |
+| `OTEL_EXPORTER_OTLP_INSECURE`      | Set only when your collector endpoint explicitly requires plaintext gRPC.                                                             |
 | `OTEL_SERVICE_NAME`                | Service name tag on spans / metrics.                                                                                                  |
 | `AGENT_MODEL` / `CLASSIFIER_MODEL` | Anthropic model IDs.                                                                                                                  |
-
 

--- a/examples/python-langchain/app/telemetry.py
+++ b/examples/python-langchain/app/telemetry.py
@@ -9,8 +9,8 @@ Send traces and metrics to Grafana Cloud either:
   A) Direct — set OTEL_EXPORTER_OTLP_ENDPOINT to your Cloud OTLP gateway
      URL (from Cloud portal → stack Details) and OTEL_EXPORTER_OTLP_HEADERS
      with Basic auth.
-  B) Via Alloy — set OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
-     and let Alloy handle Cloud auth.
+  B) Via Alloy or an OTel Collector — set OTEL_EXPORTER_OTLP_ENDPOINT to
+     your collector endpoint and let the collector forward to Cloud.
 """
 
 from __future__ import annotations

--- a/go/README.md
+++ b/go/README.md
@@ -112,12 +112,13 @@ cfg := sigil.DefaultConfig()
 // cfg.Tracer = myTracer
 // cfg.Meter = myMeter
 
-// Generation export (custom ingest)
-cfg.GenerationExport.Protocol = sigil.GenerationExportProtocolGRPC // default; or sigil.GenerationExportProtocolHTTP / sigil.GenerationExportProtocolNone
-cfg.GenerationExport.Endpoint = "localhost:4317" // HTTP parity: "http://localhost:8080" (SDK auto-appends /api/v1/generations:export)
+// Generation export to Grafana Cloud.
+cfg.GenerationExport.Protocol = sigil.GenerationExportProtocolHTTP
+cfg.GenerationExport.Endpoint = "https://sigil-prod-<region>.grafana.net"
 cfg.GenerationExport.Auth = sigil.AuthConfig{
-	Mode:     sigil.ExportAuthModeTenant,
-	TenantID: "dev-tenant",
+	Mode:          sigil.ExportAuthModeBasic,
+	TenantID:      os.Getenv("SIGIL_AUTH_TENANT_ID"),
+	BasicPassword: os.Getenv("SIGIL_AUTH_TOKEN"),
 }
 cfg.GenerationExport.BatchSize = 100
 cfg.GenerationExport.FlushInterval = time.Second
@@ -130,7 +131,7 @@ cfg.GenerationExport.GRPCMaxReceiveMessageBytes = 16 << 20
 cfg.GenerationExport.PayloadMaxBytes = 16 << 20
 
 // Sigil API base used by helpers like SubmitConversationRating.
-cfg.API.Endpoint = "http://localhost:8080"
+cfg.API.Endpoint = "https://sigil-prod-<region>.grafana.net"
 
 client := sigil.NewClient(cfg)
 defer func() {
@@ -401,7 +402,7 @@ if err != nil {
 fmt.Printf("rating=%s has_bad=%v\n", rating.Rating.Rating, rating.Summary.HasBadRating)
 ```
 
-`SubmitConversationRating` sends requests to `cfg.API.Endpoint` (default `http://localhost:8080`) and uses the same generation-export auth headers (`tenant` or `bearer`) that your client config already resolves.
+`SubmitConversationRating` sends requests to `cfg.API.Endpoint`, which should be the Grafana Cloud Sigil API URL from AI Observability configuration, and uses the same generation-export auth headers that your client config already resolves.
 
 ## Lifecycle requirement
 

--- a/java/README.md
+++ b/java/README.md
@@ -55,11 +55,14 @@ The snippet below configures the SDK explicitly. As an alternative, set `SIGIL_*
 ```java
 SigilClient client = new SigilClient(new SigilClientConfig()
     .setApi(new ApiConfig()
-        .setEndpoint("http://localhost:8080"))
+        .setEndpoint("https://sigil-prod-<region>.grafana.net"))
     .setGenerationExport(new GenerationExportConfig()
         .setProtocol(GenerationExportProtocol.HTTP)
-        .setEndpoint("http://localhost:8080")
-        .setAuth(new AuthConfig().setMode(AuthMode.TENANT).setTenantId("dev-tenant"))));
+        .setEndpoint("https://sigil-prod-<region>.grafana.net")
+        .setAuth(new AuthConfig()
+            .setMode(AuthMode.BASIC)
+            .setTenantId(System.getenv("SIGIL_AUTH_TENANT_ID"))
+            .setBasicPassword(System.getenv("SIGIL_AUTH_TOKEN")))));
 
 try {
     client.withGeneration(
@@ -312,7 +315,7 @@ SubmitConversationRatingResponse result = client.submitConversationRating(
 System.out.println(result.getRating().getRating() + " hasBad=" + result.getSummary().isHasBadRating());
 ```
 
-`submitConversationRating(...)` sends requests to `ApiConfig.endpoint` (default `http://localhost:8080`) and uses the same generation-export auth headers (`tenant` or `bearer`) already configured on the SDK client.
+`submitConversationRating(...)` sends requests to `ApiConfig.endpoint`, which should be the Grafana Cloud Sigil API URL from AI Observability configuration, and uses the same generation-export auth headers already configured on the SDK client.
 
 ## Lifecycle
 

--- a/java/core/src/main/java/com/grafana/sigil/sdk/GenerationExportConfig.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/GenerationExportConfig.java
@@ -15,7 +15,7 @@ public final class GenerationExportConfig {
     private GenerationExportProtocol protocol;
     /**
      * Export endpoint. Empty string means "not set" — env layer or
-     * {@link SigilClient} resolves it to {@code http://localhost:8080}.
+     * {@link SigilClient} resolves it from {@code SIGIL_ENDPOINT} when configured.
      * The HTTP exporter auto-appends {@code /api/v1/generations:export}
      * when the URL has no path. An explicit non-empty value is preserved
      * (caller-wins) and not overridden by {@code SIGIL_ENDPOINT}.

--- a/js/README.md
+++ b/js/README.md
@@ -40,11 +40,15 @@ import { SigilClient } from "@grafana/sigil-sdk-js";
 const client = new SigilClient({
   generationExport: {
     protocol: "http",
-    endpoint: "http://localhost:8080",
-    auth: { mode: "tenant", tenantId: "dev-tenant" },
+    endpoint: "https://sigil-prod-<region>.grafana.net",
+    auth: {
+      mode: "basic",
+      tenantId: process.env.SIGIL_AUTH_TENANT_ID,
+      basicPassword: process.env.SIGIL_AUTH_TOKEN,
+    },
   },
   api: {
-    endpoint: "http://localhost:8080",
+    endpoint: "https://sigil-prod-<region>.grafana.net",
   },
 });
 
@@ -461,11 +465,15 @@ If explicit headers already contain `Authorization` or `X-Scope-OrgID`, explicit
 const client = new SigilClient({
   generationExport: {
     protocol: "http",
-    endpoint: "http://localhost:8080",
-    auth: { mode: "tenant", tenantId: "prod-tenant" },
+    endpoint: "https://sigil-prod-<region>.grafana.net",
+    auth: {
+      mode: "basic",
+      tenantId: process.env.SIGIL_AUTH_TENANT_ID,
+      basicPassword: process.env.SIGIL_AUTH_TOKEN,
+    },
   },
   api: {
-    endpoint: "http://localhost:8080",
+    endpoint: "https://sigil-prod-<region>.grafana.net",
   },
 });
 ```
@@ -509,14 +517,18 @@ const generationBearerToken = (process.env.MY_APP_SIGIL_TOKEN ?? "").trim();
 const client = new SigilClient({
   generationExport: {
     protocol: "http",
-    endpoint: "http://localhost:8080",
+    endpoint: "https://sigil-prod-<region>.grafana.net",
     auth:
       generationBearerToken.length > 0
         ? { mode: "bearer", bearerToken: generationBearerToken }
-        : { mode: "tenant", tenantId: "dev-tenant" },
+        : {
+            mode: "basic",
+            tenantId: process.env.SIGIL_AUTH_TENANT_ID,
+            basicPassword: process.env.SIGIL_AUTH_TOKEN,
+          },
   },
   api: {
-    endpoint: "http://localhost:8080",
+    endpoint: "https://sigil-prod-<region>.grafana.net",
   },
 });
 ```
@@ -544,4 +556,4 @@ const result = await client.submitConversationRating("conv-123", {
 console.log(result.rating.rating, result.summary.hasBadRating);
 ```
 
-`submitConversationRating` sends requests to `api.endpoint` (default `http://localhost:8080`) and uses the same generation-export auth headers (`tenant` or `bearer`) already configured on the SDK client.
+`submitConversationRating` sends requests to `api.endpoint`, which should be the Grafana Cloud Sigil API URL from AI Observability configuration, and uses the same generation-export auth headers already configured on the SDK client.

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -85,7 +85,7 @@ export interface GenerationExportConfig {
 
 /** Sigil HTTP API settings used by non-ingest helper endpoints. */
 export interface ApiConfig {
-  /** Sigil API base endpoint, for example `http://localhost:8080`. */
+  /** Sigil API base endpoint, for example the Grafana Cloud AI Observability API URL. */
   endpoint: string;
 }
 

--- a/llms.txt
+++ b/llms.txt
@@ -183,7 +183,7 @@ Send OTLP straight to the Grafana Cloud OTLP gateway. Authentication uses Basic 
 
 ### Option B: Via Alloy / OTel Collector (optional)
 
-Run a local Alloy or OTel Collector that receives unauthenticated OTLP and forwards to Cloud with credentials. Useful for centralized token management, retries, relabeling, and metadata enrichment. Common local ports: 4318 (OTLP/HTTP), 4317 (OTLP/gRPC). In this mode set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318` and skip the headers.
+Run Alloy or an OTel Collector in your deployment and forward telemetry to Grafana Cloud with credentials. Useful for centralized token management, retries, relabeling, and metadata enrichment. Set `OTEL_EXPORTER_OTLP_ENDPOINT` to the collector endpoint your deployment provides.
 
 ### Provider setup snippets
 

--- a/plugins/opencode/skills/sigil/SKILL.md
+++ b/plugins/opencode/skills/sigil/SKILL.md
@@ -17,6 +17,11 @@ You are acting as a coding agent inside this repository. Your goal is to add or 
 4. Add or update tests for changed instrumentation behavior.
 5. Explain what was instrumented and why.
 
+Sigil is a Grafana Cloud-only product for user-facing setup. Do not suggest
+non-Cloud or development-only endpoints in docs, examples, or generated
+instructions. Use the Grafana Cloud API URL from AI Observability configuration
+and Cloud `basic` auth.
+
 ## Output contract (required)
 
 Return:
@@ -68,11 +73,11 @@ The OTel SDK exporters read these env vars automatically — no extra code neede
 
 ### Option B — Via Alloy / OTel Collector (optional)
 
-Run a local Alloy or OTel Collector that receives unauthenticated OTLP and forwards to Cloud with credentials. Useful for centralized token management, retries, relabeling, and metadata enrichment. Common local ports: 4318 (OTLP/HTTP), 4317 (OTLP/gRPC).
+Run Alloy or an OTel Collector in the user's deployment and forward telemetry to Grafana Cloud with credentials. Useful for centralized token management, retries, relabeling, and metadata enrichment.
 
 Env vars:
 ```
-OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+OTEL_EXPORTER_OTLP_ENDPOINT=<your-collector-otlp-endpoint>
 ```
 
 ### Provider setup (required for both options)

--- a/python-frameworks/langgraph/skills/sigil-langgraph-experiments/SKILL.md
+++ b/python-frameworks/langgraph/skills/sigil-langgraph-experiments/SKILL.md
@@ -15,6 +15,11 @@ existing generation instrumentation. The flow is generation-first and publishes
 continuously: create the run, then per item run the agent (generations export
 automatically), grade, and export scores under the same `run_id`.
 
+Sigil is a Grafana Cloud-only product for user-facing setup. Do not suggest
+non-Cloud or development-only endpoints in docs, examples, or generated
+instructions. Use the Grafana Cloud API URL from AI Observability configuration
+and Cloud `basic` auth.
+
 ## Setup
 
 ```bash
@@ -27,18 +32,27 @@ Configure the client from env (works in CI):
 import os
 from sigil_sdk import ApiConfig, AuthConfig, Client, ClientConfig, GenerationExportConfig
 
-endpoint = os.environ.get("SIGIL_ENDPOINT", "http://localhost:8080")
+endpoint = os.environ["SIGIL_ENDPOINT"].rstrip("/")
 client = Client(
     ClientConfig(
         api=ApiConfig(endpoint=endpoint),
         generation_export=GenerationExportConfig(
             protocol="http",
             endpoint=f"{endpoint}/api/v1/generations:export",
-            auth=AuthConfig(mode="tenant", tenant_id=os.environ.get("SIGIL_AUTH_TENANT_ID", "fake")),
+            auth=AuthConfig(
+                mode="basic",
+                tenant_id=os.environ["SIGIL_AUTH_TENANT_ID"],
+                basic_password=os.environ["SIGIL_AUTH_TOKEN"],
+            ),
         ),
     )
 )
 ```
+
+For Grafana Cloud experiments, also set `SIGIL_EVAL_ENDPOINT`,
+`SIGIL_EVAL_PATH_PREFIX=/api/plugins/grafana-sigil-app/resources`, and
+`SIGIL_EVAL_AUTH_TOKEN` so the experiment lifecycle uses the Grafana plugin
+resource proxy.
 
 ## Pattern 1 — Run a new experiment over a dataset (recommended)
 

--- a/python-frameworks/litellm/example/README.md
+++ b/python-frameworks/litellm/example/README.md
@@ -19,12 +19,12 @@ SIGIL_ENDPOINT=https://your-sigil.grafana.net \
   docker compose up --build
 ```
 
-The proxy starts on `http://localhost:4000`.
+The proxy starts on the published Docker Compose port `4000`.
 
 ## Make a request
 
 ```bash
-curlie POST http://localhost:4000/chat/completions \
+curlie POST http://<proxy-host>:4000/chat/completions \
   model=gpt-4o-mini \
   messages:='[{"role":"user","content":"What is 2+2?"}]'
 ```
@@ -32,7 +32,7 @@ curlie POST http://localhost:4000/chat/completions \
 Or with streaming:
 
 ```bash
-curlie POST http://localhost:4000/chat/completions \
+curlie POST http://<proxy-host>:4000/chat/completions \
   model=gpt-4o-mini \
   messages:='[{"role":"user","content":"Give me three reliability tips."}]' \
   stream:=true
@@ -40,7 +40,7 @@ curlie POST http://localhost:4000/chat/completions \
 
 ## Verify in Sigil
 
-Open `http://localhost:3000/a/grafana-sigil-app/conversations`. Generations appear with:
+Open `https://<your-stack>.grafana.net/a/grafana-sigil-app/conversations`. Generations appear with:
 
 - `agent_name`: `litellm-proxy-integration-test`
 - `sigil.framework.name`: `litellm`

--- a/python/README.md
+++ b/python/README.md
@@ -172,14 +172,19 @@ client.shutdown()
 Explicit configuration form:
 
 ```python
+import os
 from sigil_sdk import AuthConfig, Client, ClientConfig, GenerationExportConfig
 
 client = Client(
     ClientConfig(
         generation_export=GenerationExportConfig(
             protocol="http",
-            endpoint="http://localhost:8080",
-            auth=AuthConfig(mode="tenant", tenant_id="dev-tenant"),
+            endpoint="https://sigil-prod-<region>.grafana.net",
+            auth=AuthConfig(
+                mode="basic",
+                tenant_id=os.environ["SIGIL_AUTH_TENANT_ID"],
+                basic_password=os.environ["SIGIL_AUTH_TOKEN"],
+            ),
         ),
     )
 )
@@ -516,29 +521,20 @@ Exceptions in the resolver are caught and treated as `METADATA_ONLY` (fail-close
 ### HTTP generation export
 
 ```python
+import os
 from sigil_sdk import ApiConfig, AuthConfig, ClientConfig, GenerationExportConfig
 
 cfg = ClientConfig(
     generation_export=GenerationExportConfig(
         protocol="http",
-        endpoint="http://localhost:8080",
-        auth=AuthConfig(mode="tenant", tenant_id="dev-tenant"),
+        endpoint="https://sigil-prod-<region>.grafana.net",
+        auth=AuthConfig(
+            mode="basic",
+            tenant_id=os.environ["SIGIL_AUTH_TENANT_ID"],
+            basic_password=os.environ["SIGIL_AUTH_TOKEN"],
+        ),
     ),
-    api=ApiConfig(endpoint="http://localhost:8080"),
-)
-```
-
-### gRPC generation export
-
-```python
-cfg = ClientConfig(
-    generation_export=GenerationExportConfig(
-        protocol="grpc",
-        endpoint="localhost:50051",
-        insecure=True,
-        auth=AuthConfig(mode="tenant", tenant_id="dev-tenant"),
-    ),
-    api=ApiConfig(endpoint="http://localhost:8080"),
+    api=ApiConfig(endpoint="https://sigil-prod-<region>.grafana.net"),
 )
 ```
 
@@ -556,15 +552,20 @@ Invalid mode/field combinations fail fast in `resolve_config(...)`.
 If explicit `headers` already include `Authorization` or `X-Scope-OrgID`, explicit headers win.
 
 ```python
+import os
 from sigil_sdk import ApiConfig, AuthConfig, ClientConfig, GenerationExportConfig
 
 cfg = ClientConfig(
     generation_export=GenerationExportConfig(
         protocol="http",
-        endpoint="http://localhost:8080",
-        auth=AuthConfig(mode="tenant", tenant_id="prod-tenant"),
+        endpoint="https://sigil-prod-<region>.grafana.net",
+        auth=AuthConfig(
+            mode="basic",
+            tenant_id=os.environ["SIGIL_AUTH_TENANT_ID"],
+            basic_password=os.environ["SIGIL_AUTH_TOKEN"],
+        ),
     ),
-    api=ApiConfig(endpoint="http://localhost:8080"),
+    api=ApiConfig(endpoint="https://sigil-prod-<region>.grafana.net"),
 )
 ```
 
@@ -643,7 +644,7 @@ result = client.submit_conversation_rating(
 print(result.rating.rating, result.summary.has_bad_rating)
 ```
 
-`submit_conversation_rating(...)` sends requests to `ClientConfig.api.endpoint` (default `http://localhost:8080`) and uses the same generation-export auth headers (`tenant` or `bearer`) already configured on the SDK client.
+`submit_conversation_rating(...)` sends requests to `ClientConfig.api.endpoint`, which should be the Grafana Cloud Sigil API URL from AI Observability configuration, and uses the same generation-export auth headers already configured on the SDK client.
 
 ## Instrumentation-only mode (no generation send)
 

--- a/python/skills/sigil-experiments/SKILL.md
+++ b/python/skills/sigil-experiments/SKILL.md
@@ -18,6 +18,11 @@ flow is generation-first and publishes continuously: create the run, then per
 item run the agent (recording generations tagged with the `run_id`), grade, and
 export scores under the same `run_id`.
 
+Sigil is a Grafana Cloud-only product for user-facing setup. Do not suggest
+non-Cloud or development-only endpoints in docs, examples, or generated
+instructions. Use the Grafana Cloud API URL from AI Observability configuration
+and Cloud `basic` auth.
+
 If the project already uses a supported framework (LangGraph, LangChain, OpenAI
 Agents, LlamaIndex, Strands, Google ADK, LiteLLM), prefer that framework's
 experiments skill — it auto-captures generation ids from the framework callback.
@@ -35,18 +40,27 @@ Configure the client from env (works in CI):
 import os
 from sigil_sdk import ApiConfig, AuthConfig, Client, ClientConfig, GenerationExportConfig
 
-endpoint = os.environ.get("SIGIL_ENDPOINT", "http://localhost:8080")
+endpoint = os.environ["SIGIL_ENDPOINT"].rstrip("/")
 client = Client(
     ClientConfig(
         api=ApiConfig(endpoint=endpoint),
         generation_export=GenerationExportConfig(
             protocol="http",
             endpoint=f"{endpoint}/api/v1/generations:export",
-            auth=AuthConfig(mode="tenant", tenant_id=os.environ.get("SIGIL_AUTH_TENANT_ID", "fake")),
+            auth=AuthConfig(
+                mode="basic",
+                tenant_id=os.environ["SIGIL_AUTH_TENANT_ID"],
+                basic_password=os.environ["SIGIL_AUTH_TOKEN"],
+            ),
         ),
     )
 )
 ```
+
+For Grafana Cloud experiments, also set `SIGIL_EVAL_ENDPOINT`,
+`SIGIL_EVAL_PATH_PREFIX=/api/plugins/grafana-sigil-app/resources`, and
+`SIGIL_EVAL_AUTH_TOKEN` so the experiment lifecycle uses the Grafana plugin
+resource proxy.
 
 ## Pattern 1 — Run a new experiment over a dataset (recommended)
 


### PR DESCRIPTION
## Notes

Cleaning up docs to point at Grafana cloud endpoints rather than local Sigil collection endpoints