### PR TITLE
feat(examples): add Claude Agent SDK multi-agent getting-started example

### DIFF
--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -27,9 +27,10 @@ Minimal, self-contained examples that make a real LLM call and record the genera
 ### Multi-agent dependency graph
 
 
-| Language | Directory                                    | LLM provider      |
-| -------- | -------------------------------------------- | ----------------- |
-| Python   | `[python-multi-agent/](python-multi-agent/)` | OpenAI            |
+| Language                  | Directory                                                                      | LLM provider |
+| ------------------------- | ------------------------------------------------------------------------------ | ------------ |
+| Python                    | `[python-multi-agent/](python-multi-agent/)`                                   | OpenAI       |
+| Python + Claude Agent SDK | `[python-claude-agent-sdk-multi-agent/](python-claude-agent-sdk-multi-agent/)` | Anthropic    |
 
 
 Each example configures OpenTelemetry, creates an SDK client, makes LLM calls, records generations, and shuts down cleanly.

--- a/examples/getting-started/python-claude-agent-sdk-multi-agent/.env.example
+++ b/examples/getting-started/python-claude-agent-sdk-multi-agent/.env.example
@@ -1,0 +1,28 @@
+# --- LLM provider (Claude Agent SDK) ---
+# The Claude Agent SDK authenticates the same way as Claude Code. For
+# programmatic/headless use, set an Anthropic API key:
+ANTHROPIC_API_KEY=
+
+# --- Sigil generation export (Grafana Cloud) ---
+# Sigil API URL. See the Grafana Cloud AI Observability getting started docs:
+# https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/get-started/grafana-cloud/
+# Copy the API URL from Observability → AI Observability → Configuration.
+SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
+
+# Your Grafana Cloud stack / instance ID (numeric).
+# Shown under Instance ID in AI Observability → Configuration or in the Cloud Portal stack details.
+GRAFANA_INSTANCE_ID=
+
+# A Grafana Cloud access policy token with sigil:write.
+# Create one in Security → Access Policies as described in the docs above.
+GRAFANA_CLOUD_TOKEN=
+
+# --- OTel traces + metrics ---
+# Option A — Direct to Grafana Cloud OTLP gateway:
+#   Find the endpoint in your Cloud portal → stack Details → OpenTelemetry.
+#   The header is: Authorization=Basic <base64(instance_id:cloud_api_token)>
+OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otlp-gateway-url>
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instance_id:cloud_api_token)>
+
+# Optional: set OTEL_EXPORTER_OTLP_ENDPOINT to your Alloy / OTel Collector endpoint
+# if your deployment forwards telemetry to Grafana Cloud through a collector.

--- a/examples/getting-started/python-claude-agent-sdk-multi-agent/README.md
+++ b/examples/getting-started/python-claude-agent-sdk-multi-agent/README.md
@@ -1,0 +1,47 @@
+# Getting Started — Multi-Agent Dependency Graph (Claude Agent SDK)
+
+The same dependency graph as [`../python-multi-agent`](../python-multi-agent), but
+each agent is a [Claude Agent SDK](https://docs.anthropic.com/en/docs/claude-code/sdk)
+`query()` run instead of a raw OpenAI call:
+
+```
+researcher ──┐
+             ├──► synthesizer
+critic ──────┘
+```
+
+The Claude Agent SDK has **no Sigil framework adapter**, so this example shows
+**manual instrumentation with the core SDK**: it drains each `query()` message
+stream to collect the assistant text and token usage, then records one
+generation per agent with `sigil.start_generation` and links them with
+`parent_generation_ids`. The Anthropic `cache_creation_input_tokens` count is
+mapped onto Sigil's `cache_write_input_tokens` field.
+
+## Setup
+
+```bash
+cd examples/getting-started/python-claude-agent-sdk-multi-agent
+cp .env.example .env
+# Fill in your credentials in .env — see the SDK README for where to find each value.
+```
+
+```bash
+pip install -r requirements.txt
+```
+
+The Claude Agent SDK requires Python ≥ 3.10 and authenticates the same way as
+Claude Code. For headless runs, set `ANTHROPIC_API_KEY` in `.env`.
+
+## Run
+
+```bash
+python main.py
+```
+
+Open the AI Observability plugin in your Grafana Cloud stack. In the conversation
+detail you should see:
+
+- Three generations, each with its own `agent_name`, provider `anthropic`, and
+  Claude token usage (including cache read/write when present).
+- The **Graph** tab showing `researcher` and `critic` as root nodes, with
+  `synthesizer` depending on both.

--- a/examples/getting-started/python-claude-agent-sdk-multi-agent/main.py
+++ b/examples/getting-started/python-claude-agent-sdk-multi-agent/main.py
@@ -1,0 +1,185 @@
+"""Multi-agent dependency graph example — Python + Claude Agent SDK.
+
+Same shape as ../python-multi-agent, but each agent is a Claude Agent SDK
+``query()`` run instead of a raw OpenAI call. The Claude Agent SDK has no
+Sigil framework adapter, so this shows manual instrumentation with the core
+SDK: collect each run's text + token usage from the message stream, then
+record one generation per agent and link them with parent_generation_ids.
+
+    researcher ──┐
+                 ├──► synthesizer
+    critic ──────┘
+"""
+
+import asyncio
+import os
+from dataclasses import dataclass, field
+
+from claude_agent_sdk import (
+    AssistantMessage,
+    ClaudeAgentOptions,
+    ResultMessage,
+    TextBlock,
+    query,
+)
+from dotenv import load_dotenv
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from sigil_sdk import (
+    AuthConfig,
+    Client,
+    ClientConfig,
+    GenerationExportConfig,
+    GenerationStart,
+    ModelRef,
+    TokenUsage,
+    assistant_text_message,
+    user_text_message,
+)
+
+load_dotenv()
+
+resource = Resource.create({"service.name": "getting-started-claude-agent-sdk"})
+
+tp = TracerProvider(resource=resource)
+tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+trace.set_tracer_provider(tp)
+
+mp = MeterProvider(
+    resource=resource,
+    metric_readers=[PeriodicExportingMetricReader(OTLPMetricExporter())],
+)
+metrics.set_meter_provider(mp)
+
+model = "claude-sonnet-4-5"
+
+sigil = Client(
+    ClientConfig(
+        generation_export=GenerationExportConfig(
+            protocol="http",
+            endpoint=os.environ["SIGIL_ENDPOINT"],
+            auth=AuthConfig(
+                mode="basic",
+                tenant_id=os.environ["GRAFANA_INSTANCE_ID"],
+                basic_password=os.environ["GRAFANA_CLOUD_TOKEN"],
+            ),
+        ),
+    )
+)
+
+topic = "the impact of LLM observability on production AI reliability"
+
+CONVERSATION_ID = "getting-started-claude-agent-sdk"
+CONVERSATION_TITLE = "Multi-Agent Example (Claude Agent SDK)"
+
+
+@dataclass(slots=True)
+class AgentRun:
+    """Everything collected from one Claude Agent SDK query()."""
+
+    prompt: str
+    text: str = ""
+    response_model: str = model
+    response_id: str = ""
+    stop_reason: str = ""
+    usage: dict = field(default_factory=dict)
+
+
+async def run_agent(system: str, prompt: str) -> AgentRun:
+    """Run a one-shot Claude Agent SDK query and collect text + usage."""
+    run = AgentRun(prompt=prompt)
+    parts: list[str] = []
+    options = ClaudeAgentOptions(system_prompt=system, model=model, max_turns=1)
+    async for message in query(prompt=prompt, options=options):
+        if isinstance(message, AssistantMessage):
+            run.response_model = message.model or run.response_model
+            run.response_id = getattr(message, "message_id", "") or run.response_id
+            parts += [b.text for b in message.content if isinstance(b, TextBlock)]
+        elif isinstance(message, ResultMessage):
+            run.usage = message.usage or {}
+            run.response_id = run.response_id or (message.session_id or "")
+            run.stop_reason = getattr(message, "stop_reason", "") or message.subtype or ""
+            run.text = "".join(parts) or (message.result or "")
+    return run
+
+
+def record(rec, run: AgentRun) -> None:
+    """Record one Claude Agent SDK run on a generation recorder."""
+    usage = run.usage
+    rec.set_result(
+        input=[user_text_message(run.prompt)],
+        output=[assistant_text_message(run.text)],
+        response_id=run.response_id,
+        response_model=run.response_model,
+        stop_reason=run.stop_reason,
+        usage=TokenUsage(
+            input_tokens=usage.get("input_tokens", 0),
+            output_tokens=usage.get("output_tokens", 0),
+            cache_read_input_tokens=usage.get("cache_read_input_tokens", 0),
+            # Anthropic reports cache writes as cache_creation_input_tokens;
+            # Sigil's field is cache_write_input_tokens (see CLAUDE.md).
+            cache_write_input_tokens=usage.get("cache_creation_input_tokens", 0),
+        ),
+    )
+
+
+def generation(agent_name: str, parents: list[str] | None = None) -> GenerationStart:
+    """Build a GenerationStart seed shared by every agent in this example."""
+    return GenerationStart(
+        conversation_id=CONVERSATION_ID,
+        conversation_title=CONVERSATION_TITLE,
+        agent_name=agent_name,
+        model=ModelRef(provider="anthropic", name=model),
+        parent_generation_ids=parents or [],
+    )
+
+
+async def main() -> None:
+    # ── Step 1: fan-out — researcher and critic (no parents) ────────────────
+    research = await run_agent(
+        "You are a research analyst. Give a 2-sentence factual overview.", topic
+    )
+    print(f"Researcher: {research.text}\n")
+    with sigil.start_generation(generation("researcher")) as researcher_rec:
+        record(researcher_rec, research)
+    if researcher_rec.err() is not None:
+        print("SDK error:", researcher_rec.err())
+    researcher_id = researcher_rec.last_generation.id
+
+    critique = await run_agent(
+        "You are a critical reviewer. List 2 counterarguments in 2 sentences.", topic
+    )
+    print(f"Critic: {critique.text}\n")
+    with sigil.start_generation(generation("critic")) as critic_rec:
+        record(critic_rec, critique)
+    if critic_rec.err() is not None:
+        print("SDK error:", critic_rec.err())
+    critic_id = critic_rec.last_generation.id
+
+    # ── Step 2: fan-in — synthesizer depends on both ────────────────────────
+    synth_prompt = f"Research:\n{research.text}\n\nCritique:\n{critique.text}"
+    synthesis = await run_agent(
+        "Combine the research and critique into a balanced 2-sentence summary.", synth_prompt
+    )
+    print(f"Synthesizer: {synthesis.text}\n")
+    with sigil.start_generation(
+        generation("synthesizer", parents=[researcher_id, critic_id])
+    ) as synth_rec:
+        record(synth_rec, synthesis)
+    if synth_rec.err() is not None:
+        print("SDK error:", synth_rec.err())
+
+
+asyncio.run(main())
+
+# ── Shutdown ─────────────────────────────────────────────────────────────
+sigil.shutdown()
+tp.shutdown()
+mp.shutdown()
+print("Done — check the Graph tab in the conversation detail in AI Observability.")

--- a/examples/getting-started/python-claude-agent-sdk-multi-agent/requirements.txt
+++ b/examples/getting-started/python-claude-agent-sdk-multi-agent/requirements.txt
@@ -1,0 +1,5 @@
+claude-agent-sdk
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-http
+python-dotenv
+sigil-sdk


### PR DESCRIPTION
## What

Adds a getting-started example that instruments a Claude Agent SDK multi-agent pipeline with the core Sigil SDK, mirroring the existing `python-multi-agent` example but with Anthropic's Claude Agent SDK instead of raw OpenAI calls.

## Why

The Claude Agent SDK (`claude-agent-sdk`) has no Sigil framework adapter, and it runs its own internal agent loop rather than exposing a raw `messages.create()` call for a provider wrapper to sit around. The supported path is manual instrumentation with the core SDK, but no example demonstrated that. This fills the gap and shows the recommended pattern: drain each `query()` message stream, then record one generation per agent.

## Changes

- New `examples/getting-started/python-claude-agent-sdk-multi-agent/`:
  - `main.py` — researcher → critic → synthesizer graph. Each agent is an async Claude Agent SDK `query()` run; `run_agent()` collects assistant text + token usage from the message stream, then records a generation via `sigil.start_generation`. The synthesizer declares `parent_generation_ids=[researcher, critic]` for the fan-in DAG. Anthropic's `cache_creation_input_tokens` is mapped onto Sigil's `cache_write_input_tokens` (per the repo naming convention).
  - `requirements.txt` — `claude-agent-sdk` in place of `openai`.
  - `.env.example` — `ANTHROPIC_API_KEY` for the provider; Grafana Cloud + OTLP vars unchanged.
  - `README.md` — explains why instrumentation is manual and how to run.
- Adds a row for the new example to `examples/getting-started/README.md` (multi-agent table).

## Testing

- `ruff check` (repo-pinned 0.15.12) passes; `py_compile` succeeds.
- Live run verified end-to-end against a Grafana Cloud stack: conversation `getting-started-claude-agent-sdk` recorded 3 generations (provider `anthropic`, model `claude-sonnet-4-5`, 0 errors) with the correct dependency graph (synthesizer fans in from researcher + critic) and populated token usage including `cache_write_input_tokens`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)