### PR TITLE
docs: reference Dependencies and Workflow tabs in SDK docs

### DIFF
--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -55,6 +55,8 @@ After running an example, open the AI Observability plugin in your Grafana Cloud
 - A new generation under the conversation ID used in the example.
 - Model name, provider, token usage, and latency filled in.
 - The input prompt and assistant response visible in the conversation drilldown.
+- The **Dependencies** tab in the conversation drilldown. Multi-agent examples add `parent_generation_ids`, so this tab shows edges between LLM calls; single-generation examples show one independent node.
+- The **Workflow** tab when you use a framework example that enables workflow-step capture. This tab shows framework steps and the generations linked to each step.
 - Traces in your Grafana Cloud Traces datasource and metrics in Grafana Cloud Metrics.
 
 ## Custom tags and metadata

--- a/python-frameworks/langgraph/README.md
+++ b/python-frameworks/langgraph/README.md
@@ -82,8 +82,9 @@ client.shutdown()
 ## Workflow step capture
 
 Enable `capture_workflow_steps=True` to record each graph node as a Sigil workflow step.
-This builds a visual DAG in the Sigil UI showing node execution order, duration, input/output state,
-and which LLM generations ran inside each node.
+This enables the **Workflow** tab in the conversation detail view, showing node execution order,
+duration, input/output state, and which LLM generations ran inside each node. The **Dependencies**
+tab remains available for the generation-level DAG built from `parent_generation_ids`.
 
 Always set `conversation_title` to a short human-readable label — it appears as the conversation
 name in the Sigil UI. Without it, the title falls back to an opaque auto-generated ID.


### PR DESCRIPTION
## Summary

- Add **Dependencies** and **Workflow** tab references to the getting-started "What to look for" section so users know what to expect in the conversation detail view after running examples.
- Update the LangGraph README so `capture_workflow_steps=True` explains it enables the **Workflow** tab alongside the existing **Dependencies** tab.

Companion PR: grafana/sigil docs/dependencies-workflow-tabs

## Test plan

- [ ] Verify the updated READMEs render correctly on GitHub.
- [ ] Cross-check tab names against the live conversation detail UI.