### PR TITLE
[codex] refine go experiment api

### DIFF
--- a/examples/experiments/go/README.md
+++ b/examples/experiments/go/README.md
@@ -1,12 +1,12 @@
 # Go Experiment Example
 
-Runs a tiny framework-free Go agent over a dataset as a Sigil experiment.
+Runs a tiny framework-free Go agent over a test suite as a Sigil experiment.
 
 The shape mirrors the Python v1 experiment examples:
 
 1. Build a Sigil client.
 2. Define a `TestSuite` with `TestCase` entries.
-3. Open an `ExperimentRun`, create one `Trial` per test case, record scores, finalize the run, and print a link.
+3. Open an `ExperimentRun`, run one `WithTrial` callback per test case, record scores, finalize the run, and print a link.
 
 Go does not have a LangGraph adapter in this repo. Existing Go agents should keep their normal `client.StartGeneration(ctx, ...)` instrumentation.
 
@@ -18,7 +18,7 @@ This example uses the production-style shape you would use for LLMSpec or A2A:
 4. Existing `client.StartGeneration(ctx, ...)` instrumentation automatically tags generations with `experiment.run_id` and `experiment_run_id`.
 5. The service returns the generated `generationID` so scores can attach to the right generation.
 
-When the runner and agent are in the same process, use `run.Context(ctx)` instead; that also captures generation IDs automatically. When the agent is behind HTTP, A2A, or a task queue, propagate the run ID explicitly and restore it with `WithExperimentRunID`.
+When the runner and agent are in the same process, use the context passed to `WithTrial` or `run.Context(ctx)`; both tag existing generation instrumentation automatically. When the agent is behind HTTP, A2A, or a task queue, propagate the run ID explicitly and restore it with `WithExperimentRunID`.
 
 This example is designed for Grafana Cloud AI Observability.
 

--- a/examples/experiments/go/main.go
+++ b/examples/experiments/go/main.go
@@ -67,7 +67,7 @@ func main() {
 		log.Fatalf("run experiment: %v", err)
 	}
 
-	log.Printf("Experiment %q finished: %d score(s) accepted.", run.ExperimentID, run.AcceptedScores())
+	log.Printf("Experiment %q finished: %d score(s) accepted.", run.RunID, run.AcceptedScores())
 	if report, err := run.Report(ctx); err == nil {
 		log.Printf("pass_rate=%.2f final_score_avg=%.2f", report.Summary.PassRate, report.Summary.FinalScoreAvg)
 	}
@@ -75,23 +75,15 @@ func main() {
 }
 
 func runTestCase(ctx context.Context, client *sigil.Client, exp *sigil.ExperimentRun, testCase sigil.TestCase, evaluator sigil.Evaluator) (err error) {
-	trial := exp.Trial(testCase, sigil.WithTrialMetadata(testCase.Metadata))
-	if err := trial.Start(ctx); err != nil {
-		return err
-	}
-	defer func() {
-		if endErr := trial.End(ctx, err); err == nil {
-			err = endErr
+	return exp.WithTrial(ctx, testCase, func(ctx context.Context, trial *sigil.Trial) error {
+		response, err := callRemoteInstrumentedAgent(ctx, client, exp.RunID, testCase)
+		if err != nil {
+			return err
 		}
-	}()
-
-	response, err := callRemoteInstrumentedAgent(ctx, client, exp.ExperimentID, testCase)
-	if err != nil {
-		return err
-	}
-	trial.BindGeneration(response.GenerationID, response.ConversationID)
-	exactMatchScore(trial, testCase, response.Answer, evaluator)
-	return nil
+		trial.BindGeneration(response.GenerationID, response.ConversationID)
+		exactMatchScore(trial, testCase, response.Answer, evaluator)
+		return nil
+	}, sigil.WithTrialMetadata(testCase.Metadata))
 }
 
 func buildClient() *sigil.Client {

--- a/go/sigil/experiment.go
+++ b/go/sigil/experiment.go
@@ -75,19 +75,19 @@ func (s *TestSuite) Cases() []TestCase {
 	if s == nil {
 		return nil
 	}
-	return s.TestCases
+	return cloneTestCases(s.TestCases)
 }
 
-func (s *TestSuite) Case(testCaseID string) *TestCase {
+func (s *TestSuite) Case(testCaseID string) (TestCase, bool) {
 	if s == nil {
-		return nil
+		return TestCase{}, false
 	}
 	for i := range s.TestCases {
 		if s.TestCases[i].TestCaseID == testCaseID {
-			return &s.TestCases[i]
+			return cloneTestCase(s.TestCases[i]), true
 		}
 	}
-	return nil
+	return TestCase{}, false
 }
 
 type Candidate struct {
@@ -155,7 +155,7 @@ func NormalizeEvaluatorKind(kind string) EvaluatorKind {
 }
 
 type TrialRef struct {
-	ExperimentID string
+	RunID        string
 	TestCaseID   string
 	Attempt      int
 	SuiteID      string
@@ -165,17 +165,13 @@ type TrialRef struct {
 	TrajectoryID string
 }
 
-func (r TrialRef) RunID() string {
-	return r.ExperimentID
-}
-
 func (r TrialRef) ToJSON() map[string]any {
 	attempt := r.Attempt
-	if attempt == 0 {
+	if attempt <= 0 {
 		attempt = 1
 	}
 	return map[string]any{
-		"experiment_id":  r.ExperimentID,
+		"experiment_id":  r.RunID,
 		"test_case_id":   r.TestCaseID,
 		"attempt":        attempt,
 		"suite_id":       r.SuiteID,
@@ -198,8 +194,11 @@ func TrialRefFromJSON(payload map[string]any) TrialRef {
 			attempt = parsed
 		}
 	}
+	if attempt <= 0 {
+		attempt = 1
+	}
 	return TrialRef{
-		ExperimentID: strings.TrimSpace(firstString(payload["experiment_id"], payload["run_id"])),
+		RunID:        strings.TrimSpace(firstString(payload["experiment_id"], payload["run_id"])),
 		TestCaseID:   strings.TrimSpace(firstString(payload["test_case_id"])),
 		Attempt:      attempt,
 		SuiteID:      strings.TrimSpace(firstString(payload["suite_id"])),
@@ -212,11 +211,11 @@ func TrialRefFromJSON(payload map[string]any) TrialRef {
 
 func (r TrialRef) ToEnv() map[string]string {
 	attempt := r.Attempt
-	if attempt == 0 {
+	if attempt <= 0 {
 		attempt = 1
 	}
 	env := map[string]string{
-		EnvExperimentID: r.ExperimentID,
+		EnvExperimentID: r.RunID,
 		EnvTestCaseID:   r.TestCaseID,
 		EnvAttempt:      strconv.Itoa(attempt),
 	}
@@ -243,7 +242,7 @@ func TrialRefFromEnv() (*TrialRef, bool) {
 		attempt = parsed
 	}
 	return &TrialRef{
-		ExperimentID: experimentID,
+		RunID:        experimentID,
 		TestCaseID:   testCaseID,
 		Attempt:      attempt,
 		SuiteID:      strings.TrimSpace(os.Getenv(EnvSuiteID)),
@@ -253,25 +252,23 @@ func TrialRefFromEnv() (*TrialRef, bool) {
 }
 
 type ExperimentOptions struct {
-	Client              *Client
-	ExperimentID        string
-	RunID               string
-	Name                string
-	Suite               *TestSuite
-	Candidate           *Candidate
-	DefaultEvaluator    *Evaluator
-	Description         string
-	Tags                []string
-	Metadata            map[string]any
-	AutoFinalize        *bool
-	UseExperimentalOTel bool
+	Client           *Client
+	RunID            string
+	Name             string
+	Suite            *TestSuite
+	Candidate        *Candidate
+	DefaultEvaluator *Evaluator
+	Description      string
+	Tags             []string
+	Metadata         map[string]any
+	AutoFinalize     *bool
 }
 
 type ExperimentRun struct {
 	client           *Client
-	ExperimentID     string
+	RunID            string
 	Name             string
-	Suite            *TestSuite
+	suite            *TestSuite
 	candidate        *Candidate
 	defaultEvaluator Evaluator
 	description      string
@@ -289,13 +286,13 @@ type ExperimentRun struct {
 }
 
 func NewExperimentRun(opts ExperimentOptions) *ExperimentRun {
-	experimentID := firstNonBlank(opts.ExperimentID, opts.RunID)
-	if experimentID == "" {
-		experimentID = StableID("exp", opts.Name, experimentRandomHex(8))
+	runID := strings.TrimSpace(opts.RunID)
+	if runID == "" {
+		runID = StableID("exp", opts.Name, experimentRandomHex(8))
 	}
 	name := opts.Name
 	if name == "" {
-		name = experimentID
+		name = runID
 	}
 	defaultEvaluator := Evaluator{EvaluatorID: "sdk", Version: "0", Kind: EvaluatorKindCustom}
 	if opts.DefaultEvaluator != nil {
@@ -307,10 +304,10 @@ func NewExperimentRun(opts ExperimentOptions) *ExperimentRun {
 	}
 	return &ExperimentRun{
 		client:           opts.Client,
-		ExperimentID:     experimentID,
+		RunID:            runID,
 		Name:             name,
-		Suite:            opts.Suite,
-		candidate:        opts.Candidate,
+		suite:            cloneTestSuite(opts.Suite),
+		candidate:        cloneCandidate(opts.Candidate),
 		defaultEvaluator: defaultEvaluator,
 		description:      opts.Description,
 		tags:             append([]string(nil), opts.Tags...),
@@ -328,19 +325,19 @@ func (r *ExperimentRun) Enter(ctx context.Context) error {
 	if metadata == nil {
 		metadata = map[string]any{}
 	}
-	if r.Suite != nil {
-		if r.Suite.SuiteID != "" {
-			metadata["suite_id"] = r.Suite.SuiteID
+	if r.suite != nil {
+		if r.suite.SuiteID != "" {
+			metadata["suite_id"] = r.suite.SuiteID
 		}
-		if r.Suite.Version != "" {
-			metadata["suite_version"] = r.Suite.Version
+		if r.suite.Version != "" {
+			metadata["suite_version"] = r.suite.Version
 		}
 	}
 	if r.candidate != nil {
 		maps.Copy(metadata, r.candidate.AsMetadata())
 	}
 	_, err := r.client.CreateExperiment(ctx, CreateExperimentRequest{
-		RunID:       r.ExperimentID,
+		RunID:       r.RunID,
 		Name:        r.Name,
 		Source:      ExperimentSourceExternal,
 		Description: r.description,
@@ -375,7 +372,7 @@ func WithExperiment(ctx context.Context, opts ExperimentOptions, fn func(context
 	defer cancel()
 	if err != nil {
 		if finalizeErr := run.Finalize(finalizeCtx, ExperimentStatusFailed, err.Error()); finalizeErr != nil {
-			return run, errors.Join(err, finalizeErr)
+			return run, errors.Join(err, fmt.Errorf("finalize experiment %q: %w", run.RunID, finalizeErr))
 		}
 		return run, err
 	}
@@ -402,47 +399,89 @@ func (r *ExperimentRun) Context(ctx context.Context) context.Context {
 	return withExperimentRun(ctx, r)
 }
 
-func (r *ExperimentRun) Trial(testCase any, opts ...TrialOption) *Trial {
-	testCaseID, testCaseName := r.resolveTestCase(testCase)
+func (r *ExperimentRun) Suite() *TestSuite {
+	if r == nil {
+		return nil
+	}
+	return cloneTestSuite(r.suite)
+}
+
+func (r *ExperimentRun) Trial(testCase TestCase, opts ...TrialOption) *Trial {
+	testCaseID := strings.TrimSpace(testCase.TestCaseID)
+	testCaseName := firstNonBlank(testCase.Name, testCaseID)
+	return r.trial(testCaseID, testCaseName, opts...)
+}
+
+func (r *ExperimentRun) TrialID(testCaseID string, opts ...TrialOption) *Trial {
+	testCaseID = strings.TrimSpace(testCaseID)
+	testCaseName := testCaseID
+	if r != nil && r.suite != nil {
+		if existing, ok := r.suite.Case(testCaseID); ok {
+			testCaseName = firstNonBlank(existing.Name, testCaseID)
+		}
+	}
+	return r.trial(testCaseID, testCaseName, opts...)
+}
+
+func (r *ExperimentRun) WithTrial(ctx context.Context, testCase TestCase, fn func(context.Context, *Trial) error, opts ...TrialOption) (err error) {
+	if fn == nil {
+		return fmt.Errorf("%w: trial callback is required", ErrExperimentValidationFailed)
+	}
+	ctx = r.Context(ctx)
+	trial := r.Trial(testCase, opts...)
+	if err := trial.Start(ctx); err != nil {
+		return fmt.Errorf("start trial %q: %w", trial.ref.TestCaseID, err)
+	}
+	defer func() {
+		if endErr := trial.End(ctx, err); endErr != nil {
+			err = errors.Join(err, fmt.Errorf("end trial %q: %w", trial.ref.TestCaseID, endErr))
+		}
+	}()
+	return fn(ctx, trial)
+}
+
+func (r *ExperimentRun) WithTrialID(ctx context.Context, testCaseID string, fn func(context.Context, *Trial) error, opts ...TrialOption) (err error) {
+	if fn == nil {
+		return fmt.Errorf("%w: trial callback is required", ErrExperimentValidationFailed)
+	}
+	ctx = r.Context(ctx)
+	trial := r.TrialID(testCaseID, opts...)
+	if err := trial.Start(ctx); err != nil {
+		return fmt.Errorf("start trial %q: %w", trial.ref.TestCaseID, err)
+	}
+	defer func() {
+		if endErr := trial.End(ctx, err); endErr != nil {
+			err = errors.Join(err, fmt.Errorf("end trial %q: %w", trial.ref.TestCaseID, endErr))
+		}
+	}()
+	return fn(ctx, trial)
+}
+
+func (r *ExperimentRun) trial(testCaseID, testCaseName string, opts ...TrialOption) *Trial {
+	if r == nil {
+		return NewTrial(nil, TrialRef{
+			TestCaseID:   strings.TrimSpace(testCaseID),
+			Attempt:      1,
+			TestCaseName: firstNonBlank(testCaseName, strings.TrimSpace(testCaseID)),
+		}, opts...)
+	}
 	ref := TrialRef{
-		ExperimentID: r.ExperimentID,
-		TestCaseID:   testCaseID,
+		RunID:        r.RunID,
+		TestCaseID:   strings.TrimSpace(testCaseID),
 		Attempt:      1,
 		SuiteName:    r.Name,
-		TestCaseName: testCaseName,
+		TestCaseName: firstNonBlank(testCaseName, strings.TrimSpace(testCaseID)),
 	}
-	if r.Suite != nil {
-		ref.SuiteID = r.Suite.SuiteID
-		ref.SuiteVersion = r.Suite.Version
-		ref.SuiteName = firstNonBlank(r.Suite.Name, r.Name)
+	if r.suite != nil {
+		ref.SuiteID = r.suite.SuiteID
+		ref.SuiteVersion = r.suite.Version
+		ref.SuiteName = firstNonBlank(r.suite.Name, r.Name)
 	}
 	t := NewTrial(r.client, ref, opts...)
 	t.experiment = r
 	t.candidate = r.candidate
 	t.defaultEvaluator = r.defaultEvaluator
 	return t
-}
-
-func (r *ExperimentRun) resolveTestCase(testCase any) (string, string) {
-	switch tc := testCase.(type) {
-	case TestCase:
-		return tc.TestCaseID, firstNonBlank(tc.Name, tc.TestCaseID)
-	case *TestCase:
-		if tc == nil {
-			return "", ""
-		}
-		return tc.TestCaseID, firstNonBlank(tc.Name, tc.TestCaseID)
-	case string:
-		if r != nil && r.Suite != nil {
-			if existing := r.Suite.Case(tc); existing != nil {
-				return tc, firstNonBlank(existing.Name, tc)
-			}
-		}
-		return tc, tc
-	default:
-		id := fmt.Sprint(testCase)
-		return id, id
-	}
 }
 
 func (r *ExperimentRun) Finalize(ctx context.Context, status ExperimentStatus, errorText string) error {
@@ -457,7 +496,7 @@ func (r *ExperimentRun) Finalize(ctx context.Context, status ExperimentStatus, e
 	scoreCount := r.accepted
 	r.status = string(status)
 	r.mu.Unlock()
-	_, err := r.client.FinalizeExperiment(ctx, r.ExperimentID, status, CompleteExperimentOptions{ScoreCount: &scoreCount, Error: errorText})
+	_, err := r.client.FinalizeExperiment(ctx, r.RunID, status, CompleteExperimentOptions{ScoreCount: &scoreCount, Error: errorText})
 	if err != nil {
 		return err
 	}
@@ -471,14 +510,14 @@ func (r *ExperimentRun) Report(ctx context.Context) (*ExperimentReport, error) {
 	if r == nil || r.client == nil {
 		return nil, ErrNilClient
 	}
-	return r.client.GetExperimentReport(ctx, r.ExperimentID)
+	return r.client.GetExperimentReport(ctx, r.RunID)
 }
 
 func (r *ExperimentRun) URL() string {
 	if r == nil || r.client == nil {
 		return ""
 	}
-	return r.client.ExperimentURL(r.ExperimentID)
+	return r.client.ExperimentURL(r.RunID)
 }
 
 func (r *ExperimentRun) AcceptedScores() int {
@@ -574,7 +613,7 @@ func (r *ExperimentRun) prepareGeneration(start GenerationStart) GenerationStart
 		conversationID = strings.TrimSpace(r.activeConversationID)
 	}
 	if conversationID == "" {
-		conversationID = StableID("conv", r.ExperimentID, experimentRandomHex(8))
+		conversationID = StableID("conv", r.RunID, experimentRandomHex(8))
 	}
 	r.activeConversationID = conversationID
 	r.mu.Unlock()
@@ -584,14 +623,14 @@ func (r *ExperimentRun) prepareGeneration(start GenerationStart) GenerationStart
 	if tags == nil {
 		tags = map[string]string{}
 	}
-	tags[ExperimentRunIDTag] = r.ExperimentID
+	tags[ExperimentRunIDTag] = r.RunID
 	start.Tags = tags
 
 	metadata := cloneMetadata(start.Metadata)
 	if metadata == nil {
 		metadata = map[string]any{}
 	}
-	metadata[ExperimentRunIDMetadataKey] = r.ExperimentID
+	metadata[ExperimentRunIDMetadataKey] = r.RunID
 	start.Metadata = metadata
 
 	if start.AgentName == "" && r.candidate != nil {
@@ -630,8 +669,8 @@ func WithTrialAttempt(attempt int) TrialOption {
 	return func(t *Trial) {
 		if attempt > 0 {
 			t.ref.Attempt = attempt
-			t.trialID = StableID("trial", t.ref.ExperimentID, t.ref.TestCaseID, t.ref.Attempt)
-			t.generationID = StableID("gen", t.ref.ExperimentID, t.ref.TestCaseID, t.ref.Attempt)
+			t.trialID = StableID("trial", t.ref.RunID, t.ref.TestCaseID, t.ref.Attempt)
+			t.generationID = StableID("gen", t.ref.RunID, t.ref.TestCaseID, t.ref.Attempt)
 		}
 	}
 }
@@ -681,7 +720,9 @@ type Trial struct {
 }
 
 func NewTrial(client *Client, ref TrialRef, opts ...TrialOption) *Trial {
-	if ref.Attempt == 0 {
+	ref.RunID = strings.TrimSpace(ref.RunID)
+	ref.TestCaseID = strings.TrimSpace(ref.TestCaseID)
+	if ref.Attempt <= 0 {
 		ref.Attempt = 1
 	}
 	t := &Trial{
@@ -689,9 +730,9 @@ func NewTrial(client *Client, ref TrialRef, opts ...TrialOption) *Trial {
 		ref:              ref,
 		defaultEvaluator: Evaluator{EvaluatorID: "sdk", Version: "0", Kind: EvaluatorKindCustom},
 		metadata:         map[string]any{},
-		trialID:          StableID("trial", ref.ExperimentID, ref.TestCaseID, ref.Attempt),
+		trialID:          StableID("trial", ref.RunID, ref.TestCaseID, ref.Attempt),
 		status:           TrialStatusRunning,
-		generationID:     StableID("gen", ref.ExperimentID, ref.TestCaseID, ref.Attempt),
+		generationID:     StableID("gen", ref.RunID, ref.TestCaseID, ref.Attempt),
 		io:               map[string]any{},
 		usage:            map[string]any{},
 	}
@@ -713,6 +754,12 @@ func NewTrialFromRef(client *Client, ref *TrialRef, opts ...TrialOption) (*Trial
 func (t *Trial) Start(ctx context.Context) error {
 	if t == nil || t.client == nil {
 		return ErrNilClient
+	}
+	if t.ref.RunID == "" {
+		return fmt.Errorf("%w: run_id is required", ErrExperimentValidationFailed)
+	}
+	if t.ref.TestCaseID == "" {
+		return fmt.Errorf("%w: test_case_id is required", ErrExperimentValidationFailed)
 	}
 	t.started = time.Now()
 	return t.createTrial(ctx)
@@ -744,6 +791,8 @@ func (t *Trial) End(ctx context.Context, err error) error {
 	}
 	_, flushErr := t.Flush(cleanupCtx)
 	if flushErr != nil {
+		t.status = TrialStatusErrored
+		t.errorText = flushErr.Error()
 		return flushErr
 	}
 	return t.finalizeTrial(cleanupCtx)
@@ -766,7 +815,7 @@ func (t *Trial) createTrial(ctx context.Context) error {
 	if len(metadata) == 0 {
 		metadata = nil
 	}
-	_, err := t.client.UpsertTrial(ctx, t.ref.ExperimentID, UpsertTrialRequest{
+	_, err := t.client.UpsertTrial(ctx, t.ref.RunID, UpsertTrialRequest{
 		TrialID:        t.trialID,
 		TestCaseID:     t.ref.TestCaseID,
 		Attempt:        t.ref.Attempt,
@@ -810,7 +859,7 @@ func (t *Trial) finalizeTrial(ctx context.Context) error {
 		ms := int(time.Since(t.started).Milliseconds())
 		req.DurationMillis = &ms
 	}
-	_, err := t.client.UpdateTrial(ctx, t.ref.ExperimentID, t.trialID, req)
+	_, err := t.client.UpdateTrial(ctx, t.ref.RunID, t.trialID, req)
 	return err
 }
 
@@ -875,7 +924,7 @@ func (t *Trial) RecordIO(opts RecordIOOptions) *Trial {
 	if t.hasRecordedGenerationData() {
 		t.hasGeneration = true
 		if t.conversationID == "" {
-			t.conversationID = StableID("conv", t.ref.ExperimentID, t.ref.TestCaseID, t.ref.Attempt)
+			t.conversationID = StableID("conv", t.ref.RunID, t.ref.TestCaseID, t.ref.Attempt)
 		}
 	}
 	return t
@@ -924,7 +973,7 @@ func (t *Trial) Score(scoreKey string, value ScoreValue, opts ScoreOptions) Scor
 	if opts.Evaluator != nil {
 		ev = opts.Evaluator.normalized()
 	}
-	scoreID := StableID("score", t.ref.ExperimentID, t.trialID, scoreKey, ev.EvaluatorID)
+	scoreID := StableID("score", t.ref.RunID, t.trialID, scoreKey, ev.EvaluatorID)
 	metadata := map[string]any{}
 	maps.Copy(metadata, t.metadata)
 	maps.Copy(metadata, opts.Metadata)
@@ -947,7 +996,7 @@ func (t *Trial) Score(scoreKey string, value ScoreValue, opts ScoreOptions) Scor
 		ConversationID:       t.conversationID,
 		TraceID:              t.traceID,
 		SpanID:               t.spanID,
-		ExperimentID:         t.ref.ExperimentID,
+		RunID:                t.ref.RunID,
 		TestCaseID:           t.ref.TestCaseID,
 		GraderConversationID: opts.GraderConversationID,
 		GraderGenerationID:   opts.GraderGenerationID,
@@ -955,7 +1004,7 @@ func (t *Trial) Score(scoreKey string, value ScoreValue, opts ScoreOptions) Scor
 		Passed:               opts.Passed,
 		Explanation:          opts.Explanation,
 		Metadata:             metadata,
-		Source:               &ScoreSource{Kind: "experiment", ID: t.ref.ExperimentID},
+		Source:               &ScoreSource{Kind: "experiment", ID: t.ref.RunID},
 	}
 	t.buffer = append(t.buffer, item)
 	if scoreKey == "final" {
@@ -1040,7 +1089,7 @@ func (t *Trial) Artifact(ctx context.Context, opts ArtifactOptions) (*TrialArtif
 			mime = "text/plain"
 		}
 	}
-	record, err := t.client.UploadTrialArtifact(ctx, t.ref.ExperimentID, t.trialID, TrialArtifactUpload{
+	record, err := t.client.UploadTrialArtifact(ctx, t.ref.RunID, t.trialID, TrialArtifactUpload{
 		Name:    opts.Name,
 		Kind:    kind,
 		MIME:    mime,
@@ -1082,8 +1131,8 @@ func (t *Trial) ensureGeneration(ctx context.Context) error {
 		return nil
 	}
 	caseInput := ""
-	if t.experiment != nil && t.experiment.Suite != nil {
-		if tc := t.experiment.Suite.Case(t.ref.TestCaseID); tc != nil && tc.Input != nil {
+	if t.experiment != nil && t.experiment.suite != nil {
+		if tc, ok := t.experiment.suite.Case(t.ref.TestCaseID); ok && tc.Input != nil {
 			caseInput = fmt.Sprint(tc.Input)
 		}
 	}
@@ -1096,9 +1145,9 @@ func (t *Trial) ensureGeneration(ctx context.Context) error {
 		Model:          ModelRef{Provider: provider, Name: model},
 		AgentName:      agentName,
 		OperationName:  "invoke_agent",
-		Tags:           map[string]string{"experiment.run_id": t.ref.ExperimentID, "task_id": t.ref.TestCaseID},
+		Tags:           map[string]string{"experiment.run_id": t.ref.RunID, "task_id": t.ref.TestCaseID},
 		Metadata: map[string]any{
-			"experiment_run_id": t.ref.ExperimentID,
+			"experiment_run_id": t.ref.RunID,
 			"task_id":           t.ref.TestCaseID,
 			"trial_id":          t.trialID,
 			"attempt":           t.ref.Attempt,
@@ -1196,6 +1245,41 @@ func acceptedOrError(response *ExportScoresResponse) (int, error) {
 		parts[i] = result.ScoreID + ": " + detail
 	}
 	return 0, fmt.Errorf("%w: rejected %d score(s): %s", ErrScoreExportFailed, len(rejected), strings.Join(parts, "; "))
+}
+
+func cloneTestSuite(in *TestSuite) *TestSuite {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	out.Tags = append([]string(nil), in.Tags...)
+	out.TestCases = cloneTestCases(in.TestCases)
+	return &out
+}
+
+func cloneTestCases(in []TestCase) []TestCase {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]TestCase, len(in))
+	for i := range in {
+		out[i] = cloneTestCase(in[i])
+	}
+	return out
+}
+
+func cloneTestCase(in TestCase) TestCase {
+	in.Tags = append([]string(nil), in.Tags...)
+	in.Metadata = cloneMetadata(in.Metadata)
+	return in
+}
+
+func cloneCandidate(in *Candidate) *Candidate {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
 }
 
 func experimentRandomHex(n int) string {

--- a/go/sigil/experiments.go
+++ b/go/sigil/experiments.go
@@ -86,13 +86,12 @@ type ScoreItem struct {
 	TraceID              string         `json:"trace_id,omitempty"`
 	SpanID               string         `json:"span_id,omitempty"`
 	RuleID               string         `json:"rule_id,omitempty"`
-	ExperimentID         string         `json:"experiment_id,omitempty"`
+	RunID                string         `json:"-"`
 	TrialID              string         `json:"trial_id,omitempty"`
 	TestCaseID           string         `json:"test_case_id,omitempty"`
 	GraderConversationID string         `json:"grader_conversation_id,omitempty"`
 	GraderGenerationID   string         `json:"grader_generation_id,omitempty"`
 	GraderTraceID        string         `json:"grader_trace_id,omitempty"`
-	RunID                string         `json:"-"`
 	Passed               *bool          `json:"passed,omitempty"`
 	Explanation          string         `json:"explanation,omitempty"`
 	Metadata             map[string]any `json:"metadata,omitempty"`
@@ -100,10 +99,7 @@ type ScoreItem struct {
 	Source               *ScoreSource   `json:"source,omitempty"`
 }
 
-func (s ScoreItem) ResolvedExperimentID() string {
-	if strings.TrimSpace(s.ExperimentID) != "" {
-		return strings.TrimSpace(s.ExperimentID)
-	}
+func (s ScoreItem) ResolvedRunID() string {
 	return strings.TrimSpace(s.RunID)
 }
 
@@ -163,20 +159,17 @@ type ExperimentEvaluator struct {
 }
 
 type CreateExperimentRequest struct {
-	RunID        string                `json:"run_id,omitempty"`
-	Name         string                `json:"name"`
-	Source       ExperimentSource      `json:"source"`
-	Description  string                `json:"description,omitempty"`
-	Tags         []string              `json:"tags,omitempty"`
-	CollectionID string                `json:"collection_id,omitempty"`
-	Evaluators   []ExperimentEvaluator `json:"evaluators,omitempty"`
-	Metadata     map[string]any        `json:"metadata,omitempty"`
+	RunID       string           `json:"run_id,omitempty"`
+	Name        string           `json:"name"`
+	Source      ExperimentSource `json:"source"`
+	Description string           `json:"description,omitempty"`
+	Tags        []string         `json:"tags,omitempty"`
+	Metadata    map[string]any   `json:"metadata,omitempty"`
 }
 
 type CompleteExperimentOptions struct {
 	ScoreCount *int
 	Error      string
-	Metadata   map[string]any
 }
 
 type UpsertTrialRequest struct {
@@ -209,8 +202,8 @@ type TestCaseSnapshot struct {
 	Description  string                  `json:"description,omitempty"`
 	Tags         []string                `json:"tags,omitempty"`
 	Category     string                  `json:"category,omitempty"`
-	Input        map[string]any          `json:"input,omitempty"`
-	Expected     map[string]any          `json:"expected,omitempty"`
+	Input        any                     `json:"input,omitempty"`
+	Expected     any                     `json:"expected,omitempty"`
 	Metadata     map[string]any          `json:"metadata,omitempty"`
 	ArtifactRefs []ExperimentArtifactRef `json:"artifact_refs,omitempty"`
 }
@@ -992,8 +985,8 @@ func serializeScore(score ScoreItem) map[string]any {
 	if score.ConversationID != "" {
 		out["conversation_id"] = score.ConversationID
 	}
-	if experimentID := score.ResolvedExperimentID(); experimentID != "" {
-		out["experiment_id"] = experimentID
+	if runID := score.ResolvedRunID(); runID != "" {
+		out["experiment_id"] = runID
 	}
 	if score.TrialID != "" {
 		out["trial_id"] = score.TrialID

--- a/go/sigil/experiments_test.go
+++ b/go/sigil/experiments_test.go
@@ -222,7 +222,7 @@ func TestExportScoresUsesExperimentIDAndTrialID(t *testing.T) {
 		{
 			ScoreID:          "sc2",
 			TrialID:          "trial-1",
-			ExperimentID:     "run_1",
+			RunID:            "run_1",
 			EvaluatorID:      "smoke.reward",
 			EvaluatorVersion: "2026-05-28",
 			ScoreKey:         "pass",
@@ -231,7 +231,7 @@ func TestExportScoresUsesExperimentIDAndTrialID(t *testing.T) {
 		{
 			ScoreID:          "sc3",
 			TrialID:          "trial-1",
-			ExperimentID:     "run_1",
+			RunID:            "run_1",
 			EvaluatorID:      "smoke.reward",
 			EvaluatorVersion: "2026-05-28",
 			ScoreKey:         "bad",
@@ -367,7 +367,8 @@ func TestGetExperimentReportParsesTypedTrialSummary(t *testing.T) {
 			"test_case_snapshot": map[string]any{
 				"test_case_id": "t1",
 				"name":         "Case 1",
-				"input":        map[string]any{"prompt": "2+2"},
+				"input":        "2+2",
+				"expected":     "4",
 			},
 			"summary": map[string]any{
 				"trial_count":     float64(1),
@@ -425,7 +426,7 @@ func TestGetExperimentReportParsesTypedTrialSummary(t *testing.T) {
 		t.Fatalf("unexpected report: %#v", report)
 	}
 	row := report.Rows[0]
-	if row.TestCaseID != "t1" || row.TestCaseSnapshot == nil || row.TestCaseSnapshot.Name != "Case 1" {
+	if row.TestCaseID != "t1" || row.TestCaseSnapshot == nil || row.TestCaseSnapshot.Name != "Case 1" || row.TestCaseSnapshot.Input != "2+2" || row.TestCaseSnapshot.Expected != "4" {
 		t.Fatalf("unexpected typed row: %#v", row)
 	}
 	if len(row.Trials) != 1 || row.Trials[0].Trial.TrialID != "trial-1" || row.Trials[0].FinalScore == nil {
@@ -554,7 +555,7 @@ func TestTrialEndCreatesTrialWhenStartWasSkipped(t *testing.T) {
 	defer server.Close()
 
 	client := newExperimentTestClient(t, server.URL)
-	trial := NewTrial(client, TrialRef{ExperimentID: "run-no-start", TestCaseID: "case-no-start"})
+	trial := NewTrial(client, TrialRef{RunID: "run-no-start", TestCaseID: "case-no-start"})
 	trial.FinalScore(BoolScoreValue(true), ScoreOptions{})
 	if err := trial.End(context.Background(), nil); err != nil {
 		t.Fatalf("end trial without start: %v", err)
@@ -581,7 +582,7 @@ func TestRecordIOTokensAreIncludedInTrialUpdate(t *testing.T) {
 	client := newExperimentTestClient(t, server.URL)
 	inputTokens := 11
 	outputTokens := 7
-	trial := NewTrial(client, TrialRef{ExperimentID: "run-usage", TestCaseID: "case-usage"})
+	trial := NewTrial(client, TrialRef{RunID: "run-usage", TestCaseID: "case-usage"})
 	if err := trial.Start(context.Background()); err != nil {
 		t.Fatalf("start trial: %v", err)
 	}
@@ -605,7 +606,7 @@ func TestTrialEndUsesCleanupContextAfterCallerContextCanceled(t *testing.T) {
 	defer server.Close()
 
 	client := newExperimentTestClient(t, server.URL)
-	trial := NewTrial(client, TrialRef{ExperimentID: "run-canceled", TestCaseID: "case-canceled"})
+	trial := NewTrial(client, TrialRef{RunID: "run-canceled", TestCaseID: "case-canceled"})
 	if err := trial.Start(context.Background()); err != nil {
 		t.Fatalf("start trial: %v", err)
 	}
@@ -637,7 +638,7 @@ func TestTrialEndDoesNotFinalizeWhenScoreFlushFails(t *testing.T) {
 
 	client := newExperimentTestClient(t, server.URL)
 	client.config.GenerationExport.MaxRetries = 0
-	trial := NewTrial(client, TrialRef{ExperimentID: "run-flush-fails", TestCaseID: "case-flush-fails"})
+	trial := NewTrial(client, TrialRef{RunID: "run-flush-fails", TestCaseID: "case-flush-fails"})
 	if err := trial.Start(context.Background()); err != nil {
 		t.Fatalf("start trial: %v", err)
 	}
@@ -654,9 +655,9 @@ func TestTrialEndDoesNotFinalizeWhenScoreFlushFails(t *testing.T) {
 	}
 }
 
-func TestExperimentRunTrialStringWithoutSuiteDoesNotPanic(t *testing.T) {
+func TestExperimentRunTrialIDWithoutSuiteDoesNotPanic(t *testing.T) {
 	exp := NewExperimentRun(ExperimentOptions{RunID: "run-no-suite", Name: "no suite"})
-	trial := exp.Trial("case-1")
+	trial := exp.TrialID("case-1")
 	if trial == nil {
 		t.Fatal("expected trial")
 	}
@@ -665,8 +666,82 @@ func TestExperimentRunTrialStringWithoutSuiteDoesNotPanic(t *testing.T) {
 	}
 }
 
+func TestExperimentRunCopiesSuiteAtBoundary(t *testing.T) {
+	suite := &TestSuite{
+		SuiteID: "suite-1",
+		TestCases: []TestCase{{
+			TestCaseID: "case-1",
+			Tags:       []string{"original"},
+			Metadata:   map[string]any{"key": "value"},
+		}},
+	}
+	exp := NewExperimentRun(ExperimentOptions{RunID: "run-1", Suite: suite})
+
+	suite.TestCases[0].TestCaseID = "mutated"
+	suite.TestCases[0].Tags[0] = "mutated"
+	suite.TestCases[0].Metadata["key"] = "mutated"
+
+	cases := exp.Suite().Cases()
+	if len(cases) != 1 || cases[0].TestCaseID != "case-1" || cases[0].Tags[0] != "original" || cases[0].Metadata["key"] != "value" {
+		t.Fatalf("experiment retained caller-owned suite data: %#v", cases)
+	}
+
+	cases[0].Tags[0] = "caller-mutated"
+	cases[0].Metadata["key"] = "caller-mutated"
+	fresh := exp.Suite().Cases()
+	if fresh[0].Tags[0] != "original" || fresh[0].Metadata["key"] != "value" {
+		t.Fatalf("suite accessor returned mutable internals: %#v", fresh)
+	}
+}
+
+func TestExperimentRunWithTrialEndsLifecycle(t *testing.T) {
+	recorder := &experimentRecorder{}
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-1"})
+	recorder.push(http.StatusAccepted, map[string]any{"results": []map[string]any{{"score_id": "score-1", "accepted": true}}})
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-1"})
+	server := httptest.NewServer(recorder.handler(t))
+	defer server.Close()
+
+	client := newExperimentTestClient(t, server.URL)
+	testCase := TestCase{TestCaseID: "case-1", Name: "Case 1", Metadata: map[string]any{"task": "demo"}}
+	exp := NewExperimentRun(ExperimentOptions{Client: client, RunID: "run-1", Name: "run"})
+	evaluator := Evaluator{EvaluatorID: "exact", Version: "1", Kind: EvaluatorKindDeterministic}
+	err := exp.WithTrial(context.Background(), testCase, func(ctx context.Context, trial *Trial) error {
+		run, ok := experimentRunFromContext(ctx)
+		if !ok || run.RunID != "run-1" {
+			t.Fatalf("expected experiment-aware callback context, got run=%#v ok=%v", run, ok)
+		}
+		trial.FinalScore(BoolScoreValue(true), ScoreOptions{Evaluator: &evaluator})
+		return nil
+	}, WithTrialMetadata(testCase.Metadata))
+	if err != nil {
+		t.Fatalf("with trial: %v", err)
+	}
+	if recorder.requestCount() != 3 {
+		t.Fatalf("expected create, score export, update; got %d request(s)", recorder.requestCount())
+	}
+	if got := exp.AcceptedScores(); got != 1 {
+		t.Fatalf("expected one accepted score, got %d", got)
+	}
+	updateReq := recorder.request(2)
+	if updateReq.Payload["status"] != "completed" {
+		t.Fatalf("expected completed trial update, got %#v", updateReq.Payload)
+	}
+}
+
+func TestExperimentRunWithTrialRequiresTestCaseID(t *testing.T) {
+	client := newExperimentTestClient(t, "http://example.invalid")
+	exp := NewExperimentRun(ExperimentOptions{Client: client, RunID: "run-1", Name: "run"})
+	err := exp.WithTrial(context.Background(), TestCase{}, func(context.Context, *Trial) error {
+		return nil
+	})
+	if !errors.Is(err, ErrExperimentValidationFailed) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
 func TestFinalScoreBoolInfersPassed(t *testing.T) {
-	trial := NewTrial(nil, TrialRef{ExperimentID: "run-1", TestCaseID: "case-1"})
+	trial := NewTrial(nil, TrialRef{RunID: "run-1", TestCaseID: "case-1"})
 	score := trial.FinalScore(BoolScoreValue(true), ScoreOptions{})
 	if score.Passed == nil || !*score.Passed {
 		t.Fatalf("expected bool final score to infer passed, got %#v", score.Passed)
@@ -675,7 +750,7 @@ func TestFinalScoreBoolInfersPassed(t *testing.T) {
 		t.Fatalf("expected trial final verdict to be true, got %#v", trial.finalPassed)
 	}
 
-	trial = NewTrial(nil, TrialRef{ExperimentID: "run-1", TestCaseID: "case-2"})
+	trial = NewTrial(nil, TrialRef{RunID: "run-1", TestCaseID: "case-2"})
 	score = trial.Score("final", BoolScoreValue(false), ScoreOptions{})
 	if score.Passed == nil || *score.Passed {
 		t.Fatalf("expected Score(\"final\", bool) to infer failed, got %#v", score.Passed)
@@ -686,7 +761,7 @@ func TestFinalScoreBoolInfersPassed(t *testing.T) {
 }
 
 func TestFinalScoreNumberRequiresExplicitPassed(t *testing.T) {
-	trial := NewTrial(nil, TrialRef{ExperimentID: "run-1", TestCaseID: "case-1"})
+	trial := NewTrial(nil, TrialRef{RunID: "run-1", TestCaseID: "case-1"})
 	score := trial.FinalScore(NumberScoreValue(0.2), ScoreOptions{})
 	if score.Passed != nil {
 		t.Fatalf("expected numeric final score to require explicit passed, got %#v", score.Passed)
@@ -755,7 +830,7 @@ func TestWithExperimentFinalizesWithCleanupContextAfterCancel(t *testing.T) {
 }
 
 func TestTrialRefEnvRoundTrip(t *testing.T) {
-	ref := TrialRef{ExperimentID: "run-4", TestCaseID: "c1", Attempt: 3, SuiteID: "s", SuiteVersion: "2.0.0"}
+	ref := TrialRef{RunID: "run-4", TestCaseID: "c1", Attempt: 3, SuiteID: "s", SuiteVersion: "2.0.0"}
 	env := ref.ToEnv()
 	if env[EnvExperimentID] != "run-4" || env[EnvAttempt] != "3" {
 		t.Fatalf("unexpected env: %#v", env)
@@ -766,7 +841,7 @@ func TestTrialRefEnvRoundTrip(t *testing.T) {
 	t.Setenv(EnvSuiteID, env[EnvSuiteID])
 	t.Setenv(EnvSuiteVersion, env[EnvSuiteVersion])
 	restored, ok := TrialRefFromEnv()
-	if !ok || restored.ExperimentID != "run-4" || restored.TestCaseID != "c1" || restored.Attempt != 3 {
+	if !ok || restored.RunID != "run-4" || restored.TestCaseID != "c1" || restored.Attempt != 3 {
 		t.Fatalf("unexpected ref: %#v ok=%v", restored, ok)
 	}
 }
@@ -835,7 +910,7 @@ func TestRecordIOWithoutIOOrUsageDoesNotAttachGenerationID(t *testing.T) {
 	defer server.Close()
 
 	client := newExperimentTestClient(t, server.URL)
-	trial := NewTrial(client, TrialRef{ExperimentID: "run-empty-io", TestCaseID: "case-empty-io"})
+	trial := NewTrial(client, TrialRef{RunID: "run-empty-io", TestCaseID: "case-empty-io"})
 	trial.RecordIO(RecordIOOptions{
 		ModelProvider: "example",
 		ModelName:     "agent",
@@ -900,7 +975,7 @@ func TestBindGenerationWithRecordIOExportsBoundGeneration(t *testing.T) {
 	})
 	t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
 
-	trial := NewTrial(client, TrialRef{ExperimentID: "run-recorded", TestCaseID: "case-recorded"})
+	trial := NewTrial(client, TrialRef{RunID: "run-recorded", TestCaseID: "case-recorded"})
 	trial.BindGeneration("gen-recorded", "conv-recorded")
 	trial.RecordIO(RecordIOOptions{Input: "question", Output: "answer", ModelProvider: "example", ModelName: "agent"})
 	trial.FinalScore(BoolScoreValue(true), ScoreOptions{})
@@ -968,7 +1043,7 @@ func TestTrialFlushFlushesBoundGenerationBeforeScores(t *testing.T) {
 	}, nil)
 	recorder.End()
 
-	trial := NewTrial(client, TrialRef{ExperimentID: "run-bound", TestCaseID: "case-bound"})
+	trial := NewTrial(client, TrialRef{RunID: "run-bound", TestCaseID: "case-bound"})
 	trial.BindGeneration("gen-bound", "conv-bound")
 	trial.RecordIO(RecordIOOptions{Input: "question", Output: "answer", ModelProvider: "example", ModelName: "agent"})
 	trial.FinalScore(BoolScoreValue(true), ScoreOptions{Evaluator: &Evaluator{EvaluatorID: "exact", Version: "1", Kind: EvaluatorKindDeterministic}})


### PR DESCRIPTION
## Summary

This stacks on `jgordley/go-sdk-experiments-v1` and tightens the new Go experiments API before it settles:

- standardizes high-level experiment identity around `RunID`
- replaces `ExperimentRun.Trial(any)` with typed `Trial(TestCase)` and explicit `TrialID(string)` helpers
- adds `WithTrial` / `WithTrialID` lifecycle helpers that start, end, and join cleanup errors
- removes exported request/options fields that were not wired into behavior
- copies suite/test case data at API boundaries
- lets report snapshots decode primitive `input` / `expected` values
- finalizes trials as failed when score flush fails instead of reporting a clean completion
- updates the Go experiment example to use the safer lifecycle helper

## Validation

- `git diff --check`
- `go test ./go/sigil`
- `GOWORK=off go test ./...` from `go/`
- `GOWORK=off go test ./...` from `examples/experiments/go/`
