### PR TITLE
feat(go,js,python): workflow-step ingest with cross-language parity

### DIFF
--- a/go/proto/sigil/wire/wire.go
+++ b/go/proto/sigil/wire/wire.go
@@ -72,7 +72,10 @@ func normalizeExportURL(endpoint string, insecure bool, defaultPath string, sibl
 	}
 	if parsed.Path == "" || parsed.Path == "/" {
 		parsed.Path = defaultPath
-	} else if siblingPath != "" && parsed.Path == siblingPath {
+	} else if siblingPath != "" && strings.TrimRight(parsed.Path, "/") == siblingPath {
+		// Trim trailing slashes before the sibling comparison so an endpoint
+		// like ".../generations:export/" is still rewritten to the
+		// workflow-step path, matching the JS and Python SDKs.
 		parsed.Path = defaultPath
 	}
 	return parsed.String(), nil

--- a/go/proto/sigil/wire/wire.go
+++ b/go/proto/sigil/wire/wire.go
@@ -25,6 +25,8 @@ const (
 	AuthorizationHeaderName = "Authorization"
 	// GenerationExportHTTPPath is the HTTP path for ExportGenerations.
 	GenerationExportHTTPPath = "/api/v1/generations:export"
+	// WorkflowStepExportHTTPPath is the HTTP path for ExportWorkflowSteps.
+	WorkflowStepExportHTTPPath = "/api/v1/workflow-steps:export"
 	// ContentTypeJSON identifies the protojson body shape.
 	ContentTypeJSON = "application/json"
 	// ContentTypeProto identifies the binary protobuf body shape.
@@ -36,6 +38,17 @@ const (
 // exporter behavior. If endpoint has no scheme, https is assumed unless
 // insecure is true (in which case http is used).
 func NormalizeGenerationExportURL(endpoint string, insecure bool) (string, error) {
+	return normalizeExportURL(endpoint, insecure, GenerationExportHTTPPath, "")
+}
+
+// NormalizeWorkflowStepExportURL returns endpoint with the Sigil workflow-step
+// export HTTP path applied when no path is present. If the generation export
+// path is supplied, it is rewritten to the workflow-step sibling path.
+func NormalizeWorkflowStepExportURL(endpoint string, insecure bool) (string, error) {
+	return normalizeExportURL(endpoint, insecure, WorkflowStepExportHTTPPath, GenerationExportHTTPPath)
+}
+
+func normalizeExportURL(endpoint string, insecure bool, defaultPath string, siblingPath string) (string, error) {
 	trimmed := strings.TrimSpace(endpoint)
 	if trimmed == "" {
 		return "", errors.New("endpoint is required")
@@ -58,7 +71,9 @@ func NormalizeGenerationExportURL(endpoint string, insecure bool) (string, error
 		return "", fmt.Errorf("endpoint %q has empty host", endpoint)
 	}
 	if parsed.Path == "" || parsed.Path == "/" {
-		parsed.Path = GenerationExportHTTPPath
+		parsed.Path = defaultPath
+	} else if siblingPath != "" && parsed.Path == siblingPath {
+		parsed.Path = defaultPath
 	}
 	return parsed.String(), nil
 }
@@ -96,6 +111,45 @@ func MarshalExportGenerationsResponseJSON(resp *sigilv1.ExportGenerationsRespons
 // an ExportGenerationsResponse.
 func UnmarshalExportGenerationsResponseJSON(data []byte) (*sigilv1.ExportGenerationsResponse, error) {
 	var resp sigilv1.ExportGenerationsResponse
+	if err := protojson.Unmarshal(data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// MarshalExportWorkflowStepsJSON marshals an ExportWorkflowStepsRequest with
+// proto field names, matching the SDK's HTTP wire format.
+func MarshalExportWorkflowStepsJSON(req *sigilv1.ExportWorkflowStepsRequest) ([]byte, error) {
+	if req == nil {
+		return nil, errors.New("nil ExportWorkflowStepsRequest")
+	}
+	return protojson.MarshalOptions{UseProtoNames: true}.Marshal(req)
+}
+
+// UnmarshalExportWorkflowStepsJSON decodes a protojson-encoded
+// ExportWorkflowStepsRequest produced by MarshalExportWorkflowStepsJSON or the
+// SDK exporter.
+func UnmarshalExportWorkflowStepsJSON(data []byte) (*sigilv1.ExportWorkflowStepsRequest, error) {
+	var req sigilv1.ExportWorkflowStepsRequest
+	if err := protojson.Unmarshal(data, &req); err != nil {
+		return nil, err
+	}
+	return &req, nil
+}
+
+// MarshalExportWorkflowStepsResponseJSON marshals an ExportWorkflowStepsResponse
+// with proto field names.
+func MarshalExportWorkflowStepsResponseJSON(resp *sigilv1.ExportWorkflowStepsResponse) ([]byte, error) {
+	if resp == nil {
+		return nil, errors.New("nil ExportWorkflowStepsResponse")
+	}
+	return protojson.MarshalOptions{UseProtoNames: true}.Marshal(resp)
+}
+
+// UnmarshalExportWorkflowStepsResponseJSON decodes an HTTP response body into
+// an ExportWorkflowStepsResponse.
+func UnmarshalExportWorkflowStepsResponseJSON(data []byte) (*sigilv1.ExportWorkflowStepsResponse, error) {
+	var resp sigilv1.ExportWorkflowStepsResponse
 	if err := protojson.Unmarshal(data, &resp); err != nil {
 		return nil, err
 	}

--- a/go/proto/sigil/wire/wire_test.go
+++ b/go/proto/sigil/wire/wire_test.go
@@ -95,6 +95,11 @@ func TestNormalizeWorkflowStepExportURL(t *testing.T) {
 			want:     "https://sigil.example.com" + wire.WorkflowStepExportHTTPPath,
 		},
 		{
+			name:     "generation path with trailing slash rewrites to workflow-step path",
+			endpoint: "https://sigil.example.com" + wire.GenerationExportHTTPPath + "/",
+			want:     "https://sigil.example.com" + wire.WorkflowStepExportHTTPPath,
+		},
+		{
 			name:     "custom path is preserved",
 			endpoint: "https://sigil.example.com/custom/path",
 			want:     "https://sigil.example.com/custom/path",

--- a/go/proto/sigil/wire/wire_test.go
+++ b/go/proto/sigil/wire/wire_test.go
@@ -77,6 +77,49 @@ func TestNormalizeGenerationExportURL(t *testing.T) {
 	}
 }
 
+func TestNormalizeWorkflowStepExportURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		endpoint string
+		insecure bool
+		want     string
+	}{
+		{
+			name:     "https host without path",
+			endpoint: "https://sigil.example.com",
+			want:     "https://sigil.example.com" + wire.WorkflowStepExportHTTPPath,
+		},
+		{
+			name:     "generation path rewrites to workflow-step path",
+			endpoint: "https://sigil.example.com" + wire.GenerationExportHTTPPath,
+			want:     "https://sigil.example.com" + wire.WorkflowStepExportHTTPPath,
+		},
+		{
+			name:     "custom path is preserved",
+			endpoint: "https://sigil.example.com/custom/path",
+			want:     "https://sigil.example.com/custom/path",
+		},
+		{
+			name:     "scheme-less with insecure picks http",
+			endpoint: "sigil.example.com",
+			insecure: true,
+			want:     "http://sigil.example.com" + wire.WorkflowStepExportHTTPPath,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := wire.NormalizeWorkflowStepExportURL(tc.endpoint, tc.insecure)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("want %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
 func TestJSONRoundTripUsesProtoNames(t *testing.T) {
 	req := &sigilv1.ExportGenerationsRequest{
 		Generations: []*sigilv1.Generation{{
@@ -109,6 +152,39 @@ func TestJSONRoundTripUsesProtoNames(t *testing.T) {
 	}
 }
 
+func TestWorkflowStepJSONRoundTripUsesProtoNames(t *testing.T) {
+	req := &sigilv1.ExportWorkflowStepsRequest{
+		WorkflowSteps: []*sigilv1.WorkflowStep{{
+			Id:             "wfs-1",
+			ConversationId: "conv-1",
+			StepName:       "route",
+			AgentName:      "test-agent",
+		}},
+	}
+
+	data, err := wire.MarshalExportWorkflowStepsJSON(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	encoded := string(data)
+	for _, name := range []string{"workflow_steps", "conversation_id", "step_name", "agent_name"} {
+		if !strings.Contains(encoded, name) {
+			t.Errorf("expected proto field %q in JSON payload, got %s", name, encoded)
+		}
+	}
+	if strings.Contains(encoded, "workflowSteps") || strings.Contains(encoded, "stepName") {
+		t.Errorf("expected snake_case field names, got camelCase: %s", encoded)
+	}
+
+	decoded, err := wire.UnmarshalExportWorkflowStepsJSON(data)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !proto.Equal(decoded, req) {
+		t.Fatalf("round-trip mismatch: want %v, got %v", req, decoded)
+	}
+}
+
 func TestJSONResponseRoundTrip(t *testing.T) {
 	resp := &sigilv1.ExportGenerationsResponse{
 		Results: []*sigilv1.ExportGenerationResult{
@@ -124,6 +200,29 @@ func TestJSONResponseRoundTrip(t *testing.T) {
 		t.Fatalf("expected proto field generation_id in payload, got %s", data)
 	}
 	decoded, err := wire.UnmarshalExportGenerationsResponseJSON(data)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !proto.Equal(decoded, resp) {
+		t.Fatalf("round-trip mismatch: want %v, got %v", resp, decoded)
+	}
+}
+
+func TestWorkflowStepJSONResponseRoundTrip(t *testing.T) {
+	resp := &sigilv1.ExportWorkflowStepsResponse{
+		Results: []*sigilv1.ExportWorkflowStepResult{
+			{StepId: "wfs-1", Accepted: true},
+			{StepId: "wfs-2", Accepted: false, Error: "bad payload"},
+		},
+	}
+	data, err := wire.MarshalExportWorkflowStepsResponseJSON(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), "step_id") {
+		t.Fatalf("expected proto field step_id in payload, got %s", data)
+	}
+	decoded, err := wire.UnmarshalExportWorkflowStepsResponseJSON(data)
 	if err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -198,6 +297,22 @@ func TestMarshalNilReturnsError(t *testing.T) {
 			wantErr: "nil ExportGenerationsResponse",
 		},
 		{
+			name: "workflow request JSON marshal",
+			marshal: func() error {
+				_, err := wire.MarshalExportWorkflowStepsJSON(nil)
+				return err
+			},
+			wantErr: "nil ExportWorkflowStepsRequest",
+		},
+		{
+			name: "workflow response JSON marshal",
+			marshal: func() error {
+				_, err := wire.MarshalExportWorkflowStepsResponseJSON(nil)
+				return err
+			},
+			wantErr: "nil ExportWorkflowStepsResponse",
+		},
+		{
 			name: "response proto marshal",
 			marshal: func() error {
 				_, err := wire.MarshalExportGenerationsResponseProto(nil)
@@ -229,6 +344,7 @@ func TestConstants(t *testing.T) {
 		{name: "tenant header", got: wire.TenantHeaderName, want: "X-Scope-OrgID"},
 		{name: "authorization header", got: wire.AuthorizationHeaderName, want: "Authorization"},
 		{name: "generation export path", got: wire.GenerationExportHTTPPath, want: "/api/v1/generations:export"},
+		{name: "workflow step export path", got: wire.WorkflowStepExportHTTPPath, want: "/api/v1/workflow-steps:export"},
 		{name: "JSON content type", got: wire.ContentTypeJSON, want: "application/json"},
 		{name: "protobuf content type", got: wire.ContentTypeProto, want: "application/x-protobuf"},
 	}

--- a/go/sigil/client.go
+++ b/go/sigil/client.go
@@ -297,8 +297,9 @@ type Client struct {
 	instruments telemetryInstruments
 	exporter    generationExporter
 
-	queue    chan queuedGeneration
-	flushReq chan chan error
+	queue             chan queuedGeneration
+	workflowStepQueue chan queuedWorkflowStep
+	flushReq          chan chan error
 
 	queueMu      sync.RWMutex
 	shutdown     bool
@@ -489,6 +490,7 @@ func NewClient(config Config) *Client {
 	}
 	client.exporter = exporter
 	client.queue = make(chan queuedGeneration, cfg.GenerationExport.QueueSize)
+	client.workflowStepQueue = make(chan queuedWorkflowStep, cfg.GenerationExport.QueueSize)
 
 	if !cfg.testDisableWorker {
 		client.startWorker()
@@ -516,6 +518,34 @@ func (c *Client) StartGeneration(ctx context.Context, start GenerationStart) (co
 // If the client is nil a no-op recorder is returned (instrumentation never crashes business logic).
 func (c *Client) StartStreamingGeneration(ctx context.Context, start GenerationStart) (context.Context, *GenerationRecorder) {
 	return c.startGeneration(ctx, start, GenerationModeStream)
+}
+
+// EnqueueWorkflowStep enqueues a workflow execution node for export.
+func (c *Client) EnqueueWorkflowStep(step WorkflowStep) error {
+	if c == nil {
+		return ErrNilClient
+	}
+	normalized := cloneWorkflowStep(step)
+	if err := ValidateWorkflowStep(normalized); err != nil {
+		return fmt.Errorf("%w: %v", ErrWorkflowStepValidationFailed, err)
+	}
+	if normalized.StartedAt.IsZero() {
+		normalized.StartedAt = c.now().UTC()
+	} else {
+		normalized.StartedAt = normalized.StartedAt.UTC()
+	}
+	if normalized.CompletedAt.IsZero() {
+		normalized.CompletedAt = normalized.StartedAt
+	} else {
+		normalized.CompletedAt = normalized.CompletedAt.UTC()
+	}
+	if len(c.config.Tags) > 0 {
+		normalized.Tags = mergeTags(c.config.Tags, normalized.Tags)
+	}
+	if err := c.enqueueWorkflowStep(normalized); err != nil {
+		return fmt.Errorf("%w: %w", ErrWorkflowStepEnqueueFailed, err)
+	}
+	return nil
 }
 
 func (c *Client) startGeneration(ctx context.Context, start GenerationStart, defaultMode GenerationMode) (context.Context, *GenerationRecorder) {

--- a/go/sigil/client_test.go
+++ b/go/sigil/client_test.go
@@ -1656,6 +1656,164 @@ func TestSentinelErrorsAreMatchable(t *testing.T) {
 	}
 }
 
+func TestEnqueueWorkflowStepFlushesExport(t *testing.T) {
+	exporter := &capturingGenerationExporter{}
+	client, _, _ := newTestClient(t, Config{
+		GenerationExport: GenerationExportConfig{
+			BatchSize:     10,
+			FlushInterval: time.Hour,
+		},
+		testGenerationExporter: exporter,
+	})
+
+	startedAt := time.Date(2026, 2, 11, 12, 0, 0, 0, time.UTC)
+	err := client.EnqueueWorkflowStep(WorkflowStep{
+		ID:                  "wfs-route",
+		ConversationID:      "conv-workflow",
+		StepName:            "route",
+		Framework:           "custom",
+		StartedAt:           startedAt,
+		CompletedAt:         startedAt.Add(time.Second),
+		InputState:          map[string]any{"prompt": "hello"},
+		OutputState:         map[string]any{"route": "answer"},
+		Tags:                map[string]string{"env": "test"},
+		LinkedGenerationIDs: []string{"gen-route"},
+		ParentStepIDs:       []string{"wfs-root"},
+		AgentName:           "agent-workflow",
+		AgentVersion:        "v1",
+		TraceID:             "trace-1",
+		SpanID:              "span-1",
+		Metadata:            map[string]any{"run_id": "run-1"},
+	})
+	if err != nil {
+		t.Fatalf("enqueue workflow step: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Flush(ctx); err != nil {
+		t.Fatalf("flush workflow step: %v", err)
+	}
+
+	if got := exporter.workflowStepRequestCount(); got != 1 {
+		t.Fatalf("workflowStepRequestCount = %d, want 1", got)
+	}
+	exporter.mu.Lock()
+	request := exporter.workflowStepRequests[0]
+	exporter.mu.Unlock()
+	if len(request.WorkflowSteps) != 1 {
+		t.Fatalf("expected 1 workflow step, got %d", len(request.WorkflowSteps))
+	}
+	step := request.WorkflowSteps[0]
+	if step.GetId() != "wfs-route" {
+		t.Fatalf("expected workflow step id wfs-route, got %q", step.GetId())
+	}
+	if step.GetConversationId() != "conv-workflow" {
+		t.Fatalf("expected conversation id conv-workflow, got %q", step.GetConversationId())
+	}
+	if step.GetInputState().GetFields()["prompt"].GetStringValue() != "hello" {
+		t.Fatalf("expected input_state.prompt=hello, got %#v", step.GetInputState())
+	}
+}
+
+func TestShutdownFlushesPendingWorkflowStepExport(t *testing.T) {
+	exporter := &capturingGenerationExporter{}
+	client, _, _ := newTestClient(t, Config{
+		GenerationExport: GenerationExportConfig{
+			BatchSize:     10,
+			FlushInterval: time.Hour,
+		},
+		testGenerationExporter: exporter,
+	})
+
+	if err := client.EnqueueWorkflowStep(WorkflowStep{
+		ID:             "wfs-shutdown",
+		ConversationID: "conv-workflow",
+		StepName:       "finalize",
+	}); err != nil {
+		t.Fatalf("enqueue workflow step: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Shutdown(ctx); err != nil {
+		t.Fatalf("shutdown client: %v", err)
+	}
+
+	if got := exporter.workflowStepRequestCount(); got != 1 {
+		t.Fatalf("workflowStepRequestCount = %d, want 1", got)
+	}
+	exporter.mu.Lock()
+	request := exporter.workflowStepRequests[0]
+	exporter.mu.Unlock()
+	if len(request.WorkflowSteps) != 1 {
+		t.Fatalf("expected 1 workflow step, got %d", len(request.WorkflowSteps))
+	}
+	if got := request.WorkflowSteps[0].GetId(); got != "wfs-shutdown" {
+		t.Fatalf("workflow step id = %q, want wfs-shutdown", got)
+	}
+}
+
+func TestFlushRetriesWorkflowStepExport(t *testing.T) {
+	attempts := 0
+	exporter := &capturingGenerationExporter{
+		exportWorkflowSteps: func(_ context.Context, req *sigilv1.ExportWorkflowStepsRequest) (*sigilv1.ExportWorkflowStepsResponse, error) {
+			attempts++
+			if attempts < 3 {
+				return nil, errors.New("transient")
+			}
+			results := make([]*sigilv1.ExportWorkflowStepResult, len(req.WorkflowSteps))
+			for i := range req.WorkflowSteps {
+				results[i] = &sigilv1.ExportWorkflowStepResult{
+					StepId:   req.WorkflowSteps[i].Id,
+					Accepted: true,
+				}
+			}
+			return &sigilv1.ExportWorkflowStepsResponse{Results: results}, nil
+		},
+	}
+	client, _, _ := newTestClient(t, Config{
+		GenerationExport: GenerationExportConfig{
+			MaxRetries:     2,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     time.Millisecond,
+			FlushInterval:  time.Hour,
+		},
+		testGenerationExporter: exporter,
+	})
+
+	if err := client.EnqueueWorkflowStep(WorkflowStep{
+		ID:             "wfs-retry",
+		ConversationID: "conv-workflow",
+		StepName:       "answer",
+	}); err != nil {
+		t.Fatalf("enqueue workflow step: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Flush(ctx); err != nil {
+		t.Fatalf("flush workflow step: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestEnqueueWorkflowStepValidationErrorIsMatchable(t *testing.T) {
+	client, _, _ := newTestClient(t, Config{})
+
+	err := client.EnqueueWorkflowStep(WorkflowStep{
+		ID:             "wfs-invalid",
+		ConversationID: "conv-workflow",
+	})
+	if err == nil {
+		t.Fatal("expected workflow step validation error")
+	}
+	if !errors.Is(err, ErrWorkflowStepValidationFailed) {
+		t.Fatalf("expected errors.Is(err, ErrWorkflowStepValidationFailed), got %v", err)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
@@ -1686,12 +1844,17 @@ func newTestClient(t *testing.T, config Config) (*Client, *tracetest.SpanRecorde
 }
 
 type capturingGenerationExporter struct {
-	mu       sync.Mutex
-	requests []*sigilv1.ExportGenerationsRequest
-	attempts int
-	err      error
-	response *sigilv1.ExportGenerationsResponse
-	export   func(context.Context, *sigilv1.ExportGenerationsRequest) (*sigilv1.ExportGenerationsResponse, error)
+	mu                   sync.Mutex
+	requests             []*sigilv1.ExportGenerationsRequest
+	workflowStepRequests []*sigilv1.ExportWorkflowStepsRequest
+	attempts             int
+	workflowStepAttempts int
+	err                  error
+	workflowStepErr      error
+	response             *sigilv1.ExportGenerationsResponse
+	workflowStepResponse *sigilv1.ExportWorkflowStepsResponse
+	export               func(context.Context, *sigilv1.ExportGenerationsRequest) (*sigilv1.ExportGenerationsResponse, error)
+	exportWorkflowSteps  func(context.Context, *sigilv1.ExportWorkflowStepsRequest) (*sigilv1.ExportWorkflowStepsResponse, error)
 }
 
 func (e *capturingGenerationExporter) Export(ctx context.Context, req *sigilv1.ExportGenerationsRequest) (*sigilv1.ExportGenerationsResponse, error) {
@@ -1724,6 +1887,36 @@ func (e *capturingGenerationExporter) Export(ctx context.Context, req *sigilv1.E
 	return &sigilv1.ExportGenerationsResponse{Results: results}, nil
 }
 
+func (e *capturingGenerationExporter) ExportWorkflowSteps(ctx context.Context, req *sigilv1.ExportWorkflowStepsRequest) (*sigilv1.ExportWorkflowStepsResponse, error) {
+	e.mu.Lock()
+	e.workflowStepAttempts++
+	err := e.workflowStepErr
+	if err == nil {
+		e.workflowStepRequests = append(e.workflowStepRequests, req)
+	}
+	e.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+
+	if e.exportWorkflowSteps != nil {
+		return e.exportWorkflowSteps(ctx, req)
+	}
+
+	if e.workflowStepResponse != nil {
+		return e.workflowStepResponse, nil
+	}
+
+	results := make([]*sigilv1.ExportWorkflowStepResult, len(req.WorkflowSteps))
+	for i := range req.WorkflowSteps {
+		results[i] = &sigilv1.ExportWorkflowStepResult{
+			StepId:   req.WorkflowSteps[i].Id,
+			Accepted: true,
+		}
+	}
+	return &sigilv1.ExportWorkflowStepsResponse{Results: results}, nil
+}
+
 func (e *capturingGenerationExporter) Shutdown(_ context.Context) error {
 	return nil
 }
@@ -1732,6 +1925,12 @@ func (e *capturingGenerationExporter) requestCount() int {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return len(e.requests)
+}
+
+func (e *capturingGenerationExporter) workflowStepRequestCount() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.workflowStepRequests)
 }
 
 func TestFlushReturnsErrorOnRejectedGenerationResult(t *testing.T) {

--- a/go/sigil/client_test.go
+++ b/go/sigil/client_test.go
@@ -1814,6 +1814,32 @@ func TestEnqueueWorkflowStepValidationErrorIsMatchable(t *testing.T) {
 	}
 }
 
+func TestEnqueueWorkflowStepQueueFullMessageNamesWorkflowStep(t *testing.T) {
+	client, _, _ := newTestClient(t, Config{
+		GenerationExport:  GenerationExportConfig{QueueSize: 1},
+		testDisableWorker: true,
+	})
+
+	step := WorkflowStep{ID: "wfs", ConversationID: "conv-workflow", StepName: "route"}
+	if err := client.EnqueueWorkflowStep(step); err != nil {
+		t.Fatalf("first enqueue: %v", err)
+	}
+	// Worker is disabled, so the second enqueue fills the queue of size 1.
+	err := client.EnqueueWorkflowStep(step)
+	if err == nil {
+		t.Fatal("expected queue-full error")
+	}
+	if !errors.Is(err, ErrWorkflowStepQueueFull) {
+		t.Fatalf("expected errors.Is(err, ErrWorkflowStepQueueFull), got %v", err)
+	}
+	if !errors.Is(err, ErrWorkflowStepEnqueueFailed) {
+		t.Fatalf("expected errors.Is(err, ErrWorkflowStepEnqueueFailed), got %v", err)
+	}
+	if strings.Contains(err.Error(), "generation queue") {
+		t.Fatalf("queue-full message should not name the generation queue, got %q", err.Error())
+	}
+}
+
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------

--- a/go/sigil/client_test.go
+++ b/go/sigil/client_test.go
@@ -1840,6 +1840,58 @@ func TestEnqueueWorkflowStepQueueFullMessageNamesWorkflowStep(t *testing.T) {
 	}
 }
 
+func TestFlushReportsBothGenerationAndWorkflowStepAsyncErrors(t *testing.T) {
+	genErr := errors.New("generation boom")
+	wfErr := errors.New("workflow step boom")
+	exporter := &capturingGenerationExporter{err: genErr, workflowStepErr: wfErr}
+
+	// BatchSize 1 makes each enqueue flush asynchronously in the worker, so
+	// both the generation and the workflow-step export fail before the
+	// explicit Flush. Both async failures must survive to the Flush result.
+	client, _, _ := newTestClient(t, Config{
+		GenerationExport: GenerationExportConfig{
+			BatchSize:      1,
+			MaxRetries:     0,
+			FlushInterval:  time.Hour,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     time.Millisecond,
+		},
+		testGenerationExporter: exporter,
+	})
+
+	ctx, rec := client.StartGeneration(context.Background(), GenerationStart{
+		ConversationID: "conv-async",
+		Model:          ModelRef{Provider: "anthropic", Name: "claude-sonnet-4-6"},
+	})
+	rec.SetResult(Generation{
+		Input:  []Message{UserTextMessage("hi")},
+		Output: []Message{AssistantTextMessage("yo")},
+	}, nil)
+	rec.End()
+	_ = ctx
+
+	if err := client.EnqueueWorkflowStep(WorkflowStep{
+		ID:             "wfs-async",
+		ConversationID: "conv-async",
+		StepName:       "route",
+	}); err != nil {
+		t.Fatalf("enqueue workflow step: %v", err)
+	}
+
+	flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := client.Flush(flushCtx)
+	if err == nil {
+		t.Fatal("expected Flush to report async export failures")
+	}
+	if !errors.Is(err, genErr) {
+		t.Fatalf("Flush error should include the generation failure, got %v", err)
+	}
+	if !errors.Is(err, wfErr) {
+		t.Fatalf("Flush error should include the workflow-step failure, got %v", err)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------

--- a/go/sigil/conformance_helpers_test.go
+++ b/go/sigil/conformance_helpers_test.go
@@ -112,6 +112,7 @@ func newConformanceEnv(t *testing.T, opts ...conformanceEnvOption) *conformanceE
 	ingest := &fakeIngestServer{}
 	grpcServer := grpc.NewServer()
 	sigilv1.RegisterGenerationIngestServiceServer(grpcServer, ingest)
+	sigilv1.RegisterWorkflowStepIngestServiceServer(grpcServer, ingest)
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -242,14 +243,21 @@ func (e *conformanceEnv) CollectMetrics(t *testing.T) metricdata.ResourceMetrics
 
 type fakeIngestServer struct {
 	sigilv1.UnimplementedGenerationIngestServiceServer
+	sigilv1.UnimplementedWorkflowStepIngestServiceServer
 
-	mu       sync.Mutex
-	requests []*sigilv1.ExportGenerationsRequest
+	mu                   sync.Mutex
+	requests             []*sigilv1.ExportGenerationsRequest
+	workflowStepRequests []*sigilv1.ExportWorkflowStepsRequest
 }
 
 func (s *fakeIngestServer) ExportGenerations(_ context.Context, req *sigilv1.ExportGenerationsRequest) (*sigilv1.ExportGenerationsResponse, error) {
 	s.capture(req)
 	return acceptanceResponse(req), nil
+}
+
+func (s *fakeIngestServer) ExportWorkflowSteps(_ context.Context, req *sigilv1.ExportWorkflowStepsRequest) (*sigilv1.ExportWorkflowStepsResponse, error) {
+	s.captureWorkflowSteps(req)
+	return workflowStepAcceptanceResponse(req), nil
 }
 
 func (s *fakeIngestServer) capture(req *sigilv1.ExportGenerationsRequest) {
@@ -281,6 +289,21 @@ func (s *fakeIngestServer) SingleGeneration(t *testing.T) *sigilv1.Generation {
 		t.Fatalf("expected exactly one generation in request, got %d", len(s.requests[0].Generations))
 	}
 	return s.requests[0].Generations[0]
+}
+
+func (s *fakeIngestServer) SingleWorkflowStep(t *testing.T) *sigilv1.WorkflowStep {
+	t.Helper()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.workflowStepRequests) != 1 {
+		t.Fatalf("expected exactly one workflow step export request, got %d", len(s.workflowStepRequests))
+	}
+	if len(s.workflowStepRequests[0].WorkflowSteps) != 1 {
+		t.Fatalf("expected exactly one workflow step in request, got %d", len(s.workflowStepRequests[0].WorkflowSteps))
+	}
+	return s.workflowStepRequests[0].WorkflowSteps[0]
 }
 
 func (s *fakeIngestServer) RequestCount() int {
@@ -321,12 +344,39 @@ func (s *fakeIngestServer) GenerationCount() int {
 	return total
 }
 
+func (s *fakeIngestServer) captureWorkflowSteps(req *sigilv1.ExportWorkflowStepsRequest) {
+	if req == nil {
+		return
+	}
+
+	clone := proto.Clone(req)
+	typed, ok := clone.(*sigilv1.ExportWorkflowStepsRequest)
+	if !ok {
+		return
+	}
+
+	s.mu.Lock()
+	s.workflowStepRequests = append(s.workflowStepRequests, typed)
+	s.mu.Unlock()
+}
+
 func acceptanceResponse(req *sigilv1.ExportGenerationsRequest) *sigilv1.ExportGenerationsResponse {
 	response := &sigilv1.ExportGenerationsResponse{Results: make([]*sigilv1.ExportGenerationResult, len(req.GetGenerations()))}
 	for i := range req.GetGenerations() {
 		response.Results[i] = &sigilv1.ExportGenerationResult{
 			GenerationId: req.Generations[i].GetId(),
 			Accepted:     true,
+		}
+	}
+	return response
+}
+
+func workflowStepAcceptanceResponse(req *sigilv1.ExportWorkflowStepsRequest) *sigilv1.ExportWorkflowStepsResponse {
+	response := &sigilv1.ExportWorkflowStepsResponse{Results: make([]*sigilv1.ExportWorkflowStepResult, len(req.GetWorkflowSteps()))}
+	for i := range req.GetWorkflowSteps() {
+		response.Results[i] = &sigilv1.ExportWorkflowStepResult{
+			StepId:   req.WorkflowSteps[i].GetId(),
+			Accepted: true,
 		}
 	}
 	return response

--- a/go/sigil/conformance_test.go
+++ b/go/sigil/conformance_test.go
@@ -467,6 +467,76 @@ func TestConformance_FullGenerationRoundtrip(t *testing.T) {
 	}
 }
 
+func TestConformance_WorkflowStepRoundtrip(t *testing.T) {
+	now := time.Date(2026, time.March, 12, 12, 0, 0, 0, time.UTC)
+	env := newConformanceEnv(t, withConformanceConfig(func(cfg *sigil.Config) {
+		cfg.Now = func() time.Time { return now }
+		cfg.Tags = map[string]string{
+			"client": "tag",
+			"shared": "client",
+		}
+	}))
+
+	if err := env.Client.EnqueueWorkflowStep(sigil.WorkflowStep{
+		ID:                  "wfs-roundtrip",
+		ConversationID:      "conv-workflow",
+		StepName:            "route",
+		Framework:           "custom",
+		InputState:          map[string]any{"prompt": "hello", "count": 1},
+		OutputState:         map[string]any{"route": "answer"},
+		Tags:                map[string]string{"shared": "step"},
+		LinkedGenerationIDs: []string{"gen-roundtrip"},
+		ParentStepIDs:       []string{"wfs-root"},
+		AgentName:           "agent-workflow",
+		AgentVersion:        "v1",
+		TraceID:             "0123456789abcdef0123456789abcdef",
+		SpanID:              "0123456789abcdef",
+		Metadata:            map[string]any{"run_id": "run-1"},
+	}); err != nil {
+		t.Fatalf("enqueue workflow step: %v", err)
+	}
+
+	env.Shutdown(t)
+
+	step := env.Ingest.SingleWorkflowStep(t)
+	if got := step.GetId(); got != "wfs-roundtrip" {
+		t.Fatalf("workflow step id = %q, want wfs-roundtrip", got)
+	}
+	if got := step.GetConversationId(); got != "conv-workflow" {
+		t.Fatalf("conversation id = %q, want conv-workflow", got)
+	}
+	if got := step.GetStepName(); got != "route" {
+		t.Fatalf("step name = %q, want route", got)
+	}
+	if got := step.GetStartedAt().AsTime(); !got.Equal(now) {
+		t.Fatalf("started_at = %s, want %s", got, now)
+	}
+	if got := step.GetCompletedAt().AsTime(); !got.Equal(now) {
+		t.Fatalf("completed_at = %s, want %s", got, now)
+	}
+	if got := step.GetTags()["client"]; got != "tag" {
+		t.Fatalf("client tag = %q, want tag", got)
+	}
+	if got := step.GetTags()["shared"]; got != "step" {
+		t.Fatalf("shared tag = %q, want step", got)
+	}
+	if got := step.GetInputState().GetFields()["prompt"].GetStringValue(); got != "hello" {
+		t.Fatalf("input_state.prompt = %q, want hello", got)
+	}
+	if got := step.GetOutputState().GetFields()["route"].GetStringValue(); got != "answer" {
+		t.Fatalf("output_state.route = %q, want answer", got)
+	}
+	if got := step.GetMetadata().GetFields()["run_id"].GetStringValue(); got != "run-1" {
+		t.Fatalf("metadata.run_id = %q, want run-1", got)
+	}
+	if got := step.GetLinkedGenerationIds(); !slices.Equal(got, []string{"gen-roundtrip"}) {
+		t.Fatalf("linked_generation_ids = %#v, want gen-roundtrip", got)
+	}
+	if got := step.GetParentStepIds(); !slices.Equal(got, []string{"wfs-root"}) {
+		t.Fatalf("parent_step_ids = %#v, want wfs-root", got)
+	}
+}
+
 func TestConformance_ConversationTitleSemantics(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/go/sigil/errors.go
+++ b/go/sigil/errors.go
@@ -24,6 +24,10 @@ var (
 	ErrEmbeddingValidationFailed = errors.New("sigil: embedding validation failed")
 	// ErrEnqueueFailed wraps generation enqueue failures.
 	ErrEnqueueFailed = errors.New("sigil: generation enqueue failed")
+	// ErrWorkflowStepValidationFailed wraps workflow-step validation failures.
+	ErrWorkflowStepValidationFailed = errors.New("sigil: workflow step validation failed")
+	// ErrWorkflowStepEnqueueFailed wraps workflow-step enqueue failures.
+	ErrWorkflowStepEnqueueFailed = errors.New("sigil: workflow step enqueue failed")
 	// ErrQueueFull is returned when the generation queue is at capacity.
 	ErrQueueFull = errors.New("sigil: generation queue is full")
 	// ErrClientShutdown is returned when enqueue happens after shutdown starts.

--- a/go/sigil/errors.go
+++ b/go/sigil/errors.go
@@ -30,6 +30,10 @@ var (
 	ErrWorkflowStepEnqueueFailed = errors.New("sigil: workflow step enqueue failed")
 	// ErrQueueFull is returned when the generation queue is at capacity.
 	ErrQueueFull = errors.New("sigil: generation queue is full")
+	// ErrWorkflowStepQueueFull is returned when the workflow-step queue is at
+	// capacity. It is a distinct sentinel from ErrQueueFull (which names the
+	// generation queue), mirroring the JS and Python SDKs' separate messages.
+	ErrWorkflowStepQueueFull = errors.New("sigil: workflow step queue is full")
 	// ErrClientShutdown is returned when enqueue happens after shutdown starts.
 	ErrClientShutdown = errors.New("sigil: client is shutting down")
 	// ErrMappingFailed wraps provider-to-generation mapping failures.

--- a/go/sigil/experiment_capture_test.go
+++ b/go/sigil/experiment_capture_test.go
@@ -32,6 +32,19 @@ func (e *capturingExperimentExporter) Export(_ context.Context, request *sigilv1
 	return response, nil
 }
 
+func (e *capturingExperimentExporter) ExportWorkflowSteps(_ context.Context, request *sigilv1.ExportWorkflowStepsRequest) (*sigilv1.ExportWorkflowStepsResponse, error) {
+	response := &sigilv1.ExportWorkflowStepsResponse{
+		Results: make([]*sigilv1.ExportWorkflowStepResult, 0, len(request.GetWorkflowSteps())),
+	}
+	for _, step := range request.GetWorkflowSteps() {
+		response.Results = append(response.Results, &sigilv1.ExportWorkflowStepResult{
+			StepId:   step.GetId(),
+			Accepted: true,
+		})
+	}
+	return response, nil
+}
+
 func (e *capturingExperimentExporter) Shutdown(context.Context) error { return nil }
 
 func (e *capturingExperimentExporter) firstGeneration() *sigilv1.Generation {

--- a/go/sigil/exporter.go
+++ b/go/sigil/exporter.go
@@ -30,8 +30,13 @@ type queuedGeneration struct {
 	generation *sigilv1.Generation
 }
 
+type queuedWorkflowStep struct {
+	workflowStep *sigilv1.WorkflowStep
+}
+
 type generationExporter interface {
 	Export(ctx context.Context, request *sigilv1.ExportGenerationsRequest) (*sigilv1.ExportGenerationsResponse, error)
+	ExportWorkflowSteps(ctx context.Context, request *sigilv1.ExportWorkflowStepsRequest) (*sigilv1.ExportWorkflowStepsResponse, error)
 	Shutdown(ctx context.Context) error
 }
 
@@ -62,14 +67,34 @@ func (e *noopGenerationExporter) Export(_ context.Context, request *sigilv1.Expo
 	return response, nil
 }
 
+func (e *noopGenerationExporter) ExportWorkflowSteps(_ context.Context, request *sigilv1.ExportWorkflowStepsRequest) (*sigilv1.ExportWorkflowStepsResponse, error) {
+	if e.err != nil {
+		return nil, e.err
+	}
+	if request == nil {
+		return &sigilv1.ExportWorkflowStepsResponse{}, nil
+	}
+	response := &sigilv1.ExportWorkflowStepsResponse{
+		Results: make([]*sigilv1.ExportWorkflowStepResult, 0, len(request.GetWorkflowSteps())),
+	}
+	for _, step := range request.GetWorkflowSteps() {
+		response.Results = append(response.Results, &sigilv1.ExportWorkflowStepResult{
+			StepId:   step.GetId(),
+			Accepted: true,
+		})
+	}
+	return response, nil
+}
+
 func (e *noopGenerationExporter) Shutdown(_ context.Context) error {
 	return nil
 }
 
 type grpcGenerationExporter struct {
-	client  sigilv1.GenerationIngestServiceClient
-	conn    *grpc.ClientConn
-	headers map[string]string
+	client             sigilv1.GenerationIngestServiceClient
+	workflowStepClient sigilv1.WorkflowStepIngestServiceClient
+	conn               *grpc.ClientConn
+	headers            map[string]string
 }
 
 func newGRPCGenerationExporter(cfg GenerationExportConfig) (generationExporter, error) {
@@ -113,9 +138,10 @@ func newGRPCGenerationExporter(cfg GenerationExportConfig) (generationExporter, 
 	}
 
 	return &grpcGenerationExporter{
-		client:  sigilv1.NewGenerationIngestServiceClient(conn),
-		conn:    conn,
-		headers: headers,
+		client:             sigilv1.NewGenerationIngestServiceClient(conn),
+		workflowStepClient: sigilv1.NewWorkflowStepIngestServiceClient(conn),
+		conn:               conn,
+		headers:            headers,
 	}, nil
 }
 
@@ -143,6 +169,13 @@ func (e *grpcGenerationExporter) Export(ctx context.Context, request *sigilv1.Ex
 	return e.client.ExportGenerations(ctx, request)
 }
 
+func (e *grpcGenerationExporter) ExportWorkflowSteps(ctx context.Context, request *sigilv1.ExportWorkflowStepsRequest) (*sigilv1.ExportWorkflowStepsResponse, error) {
+	if len(e.headers) > 0 {
+		ctx = metadata.NewOutgoingContext(ctx, metadata.New(e.headers))
+	}
+	return e.workflowStepClient.ExportWorkflowSteps(ctx, request)
+}
+
 func (e *grpcGenerationExporter) Shutdown(_ context.Context) error {
 	if e.conn != nil {
 		return e.conn.Close()
@@ -151,14 +184,19 @@ func (e *grpcGenerationExporter) Shutdown(_ context.Context) error {
 }
 
 type httpGenerationExporter struct {
-	endpoint  string
-	userAgent string
-	headers   map[string]string
-	client    *http.Client
+	endpoint             string
+	workflowStepEndpoint string
+	userAgent            string
+	headers              map[string]string
+	client               *http.Client
 }
 
 func newHTTPGenerationExporter(cfg GenerationExportConfig) (generationExporter, error) {
 	urlString, err := wire.NormalizeGenerationExportURL(cfg.Endpoint, insecureValue(cfg.Insecure))
+	if err != nil {
+		return nil, err
+	}
+	workflowStepURLString, err := wire.NormalizeWorkflowStepExportURL(cfg.Endpoint, insecureValue(cfg.Insecure))
 	if err != nil {
 		return nil, err
 	}
@@ -168,9 +206,10 @@ func newHTTPGenerationExporter(cfg GenerationExportConfig) (generationExporter, 
 	// User-Agent entry removed so it can't blank out the resolved value below.
 	userAgent, headers := splitUserAgent(cfg.Headers)
 	return &httpGenerationExporter{
-		endpoint:  urlString,
-		userAgent: userAgent,
-		headers:   headers,
+		endpoint:             urlString,
+		workflowStepEndpoint: workflowStepURLString,
+		userAgent:            userAgent,
+		headers:              headers,
 		client: &http.Client{
 			Timeout: 10 * time.Second,
 		},
@@ -212,6 +251,46 @@ func (e *httpGenerationExporter) Export(ctx context.Context, request *sigilv1.Ex
 	exportResponse, err := wire.UnmarshalExportGenerationsResponseJSON(body)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal generation response: %w", err)
+	}
+
+	return exportResponse, nil
+}
+
+func (e *httpGenerationExporter) ExportWorkflowSteps(ctx context.Context, request *sigilv1.ExportWorkflowStepsRequest) (*sigilv1.ExportWorkflowStepsResponse, error) {
+	payload, err := wire.MarshalExportWorkflowStepsJSON(request)
+	if err != nil {
+		return nil, fmt.Errorf("marshal workflow step request: %w", err)
+	}
+
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, e.workflowStepEndpoint, strings.NewReader(string(payload)))
+	if err != nil {
+		return nil, fmt.Errorf("build workflow step request: %w", err)
+	}
+	httpRequest.Header.Set("Content-Type", wire.ContentTypeJSON)
+	httpRequest.Header.Set("User-Agent", e.userAgent)
+	for key, value := range e.headers {
+		httpRequest.Header.Set(key, value)
+	}
+
+	response, err := e.client.Do(httpRequest)
+	if err != nil {
+		return nil, fmt.Errorf("http workflow step export failed: %w", err)
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read workflow step response: %w", err)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("http workflow step export status %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	exportResponse, err := wire.UnmarshalExportWorkflowStepsResponseJSON(body)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal workflow step response: %w", err)
 	}
 
 	return exportResponse, nil
@@ -442,20 +521,34 @@ func (c *Client) startWorker() {
 func (c *Client) runExportWorker() {
 	defer close(c.workerDone)
 
-	batch := make([]*sigilv1.Generation, 0, c.config.GenerationExport.BatchSize)
+	generationBatch := make([]*sigilv1.Generation, 0, c.config.GenerationExport.BatchSize)
+	workflowStepBatch := make([]*sigilv1.WorkflowStep, 0, c.config.GenerationExport.BatchSize)
 	flushInterval := c.config.GenerationExport.FlushInterval
 	timer := time.NewTimer(flushInterval)
 	defer timer.Stop()
 
-	flush := func() error {
-		if len(batch) == 0 {
+	flushGenerations := func() error {
+		if len(generationBatch) == 0 {
 			return nil
 		}
 
-		request := &sigilv1.ExportGenerationsRequest{Generations: batch}
+		request := &sigilv1.ExportGenerationsRequest{Generations: generationBatch}
 		err := c.exportWithRetry(request)
-		batch = batch[:0]
+		generationBatch = generationBatch[:0]
 		return err
+	}
+	flushWorkflowSteps := func() error {
+		if len(workflowStepBatch) == 0 {
+			return nil
+		}
+
+		request := &sigilv1.ExportWorkflowStepsRequest{WorkflowSteps: workflowStepBatch}
+		err := c.exportWorkflowStepsWithRetry(request)
+		workflowStepBatch = workflowStepBatch[:0]
+		return err
+	}
+	flushAll := func() error {
+		return errors.Join(flushGenerations(), flushWorkflowSteps())
 	}
 
 	// pendingErr captures the first failure from an async flush (timer or
@@ -471,26 +564,46 @@ func (c *Client) runExportWorker() {
 		pendingErr = err
 	}
 
+	generationQueue := c.queue
+	workflowStepQueue := c.workflowStepQueue
 	for {
-		select {
-		case queued, ok := <-c.queue:
-			if !ok {
-				if err := flush(); err != nil {
-					c.logf("sigil generation export flush on shutdown failed: %v", err)
-				}
-				return
+		if generationQueue == nil && workflowStepQueue == nil {
+			if err := flushAll(); err != nil {
+				c.logf("sigil export flush on shutdown failed: %v", err)
 			}
-			batch = append(batch, queued.generation)
-			if len(batch) >= c.config.GenerationExport.BatchSize {
-				if err := flush(); err != nil {
+			return
+		}
+
+		select {
+		case queued, ok := <-generationQueue:
+			if !ok {
+				generationQueue = nil
+				continue
+			}
+			generationBatch = append(generationBatch, queued.generation)
+			if len(generationBatch) >= c.config.GenerationExport.BatchSize {
+				if err := flushGenerations(); err != nil {
 					c.logf("sigil generation export failed: %v", err)
 					recordAsyncErr(err)
 				}
 				resetTimer(timer, flushInterval)
 			}
+		case queued, ok := <-workflowStepQueue:
+			if !ok {
+				workflowStepQueue = nil
+				continue
+			}
+			workflowStepBatch = append(workflowStepBatch, queued.workflowStep)
+			if len(workflowStepBatch) >= c.config.GenerationExport.BatchSize {
+				if err := flushWorkflowSteps(); err != nil {
+					c.logf("sigil workflow step export failed: %v", err)
+					recordAsyncErr(err)
+				}
+				resetTimer(timer, flushInterval)
+			}
 		case ack := <-c.flushReq:
-			// Drain anything the worker hadn't yet pulled off c.queue so
-			// that an explicit Flush sees every generation enqueued before
+			// Drain anything the worker hadn't yet pulled off its queues so
+			// that an explicit Flush sees every export enqueued before
 			// the call. Without this, the worker's select can service
 			// flushReq before an already-queued item, returning nil while
 			// the item still lingers on the channel.
@@ -510,38 +623,60 @@ func (c *Client) runExportWorker() {
 				}
 				flushErr = errors.Join(flushErr, err)
 			}
-			queueClosed := false
+			generationClosed := false
+			workflowStepClosed := false
 		draining:
 			for {
 				select {
-				case queued, ok := <-c.queue:
+				case queued, ok := <-generationQueue:
 					if !ok {
-						queueClosed = true
-						break draining
+						generationQueue = nil
+						generationClosed = true
+						if workflowStepQueue == nil {
+							break draining
+						}
+						continue
 					}
-					batch = append(batch, queued.generation)
-					if len(batch) >= c.config.GenerationExport.BatchSize {
-						joinFlush(flush())
+					generationBatch = append(generationBatch, queued.generation)
+					if len(generationBatch) >= c.config.GenerationExport.BatchSize {
+						joinFlush(flushGenerations())
+					}
+				case queued, ok := <-workflowStepQueue:
+					if !ok {
+						workflowStepQueue = nil
+						workflowStepClosed = true
+						if generationQueue == nil {
+							break draining
+						}
+						continue
+					}
+					workflowStepBatch = append(workflowStepBatch, queued.workflowStep)
+					if len(workflowStepBatch) >= c.config.GenerationExport.BatchSize {
+						joinFlush(flushWorkflowSteps())
 					}
 				default:
 					break draining
 				}
 			}
-			joinFlush(flush())
+			joinFlush(flushAll())
 			if pendingErr != nil {
 				joinFlush(pendingErr)
 				pendingErr = nil
 			}
 			ack <- flushErr
-			if queueClosed {
+			if generationClosed && workflowStepClosed {
 				// Shutdown raced with Flush — caller has been acked, exit
 				// the worker like the regular shutdown path.
 				return
 			}
 			resetTimer(timer, flushInterval)
 		case <-timer.C:
-			if err := flush(); err != nil {
+			if err := flushGenerations(); err != nil {
 				c.logf("sigil generation export failed: %v", err)
+				recordAsyncErr(err)
+			}
+			if err := flushWorkflowSteps(); err != nil {
+				c.logf("sigil workflow step export failed: %v", err)
 				recordAsyncErr(err)
 			}
 			resetTimer(timer, flushInterval)
@@ -608,6 +743,55 @@ func (c *Client) exportWithRetry(request *sigilv1.ExportGenerationsRequest) erro
 	return lastErr
 }
 
+func (c *Client) exportWorkflowStepsWithRetry(request *sigilv1.ExportWorkflowStepsRequest) error {
+	attempts := c.config.GenerationExport.MaxRetries + 1
+	backoff := c.config.GenerationExport.InitialBackoff
+	if backoff <= 0 {
+		backoff = 100 * time.Millisecond
+	}
+
+	var lastErr error
+	for attempt := range attempts {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		response, err := c.exporter.ExportWorkflowSteps(timeoutCtx, request)
+		cancel()
+		if err == nil {
+			resultsCount := 0
+			if response != nil {
+				resultsCount = len(response.GetResults())
+			}
+			c.logf(
+				"sigil workflow step export response requested=%d results=%d",
+				len(request.GetWorkflowSteps()),
+				resultsCount,
+			)
+			logRejectedWorkflowStepExportResults(c, response)
+			validateErr := validateWorkflowStepExportResponse(request, response)
+			if validateErr == nil {
+				return nil
+			}
+			lastErr = validateErr
+			if !isRetryableExportValidationError(validateErr) {
+				return validateErr
+			}
+		} else {
+			lastErr = err
+		}
+		if attempt == attempts-1 {
+			break
+		}
+		time.Sleep(backoff)
+		if backoff < c.config.GenerationExport.MaxBackoff {
+			backoff *= 2
+			if backoff > c.config.GenerationExport.MaxBackoff {
+				backoff = c.config.GenerationExport.MaxBackoff
+			}
+		}
+	}
+
+	return lastErr
+}
+
 type exportValidationError struct {
 	err       error
 	retryable bool
@@ -632,6 +816,15 @@ func logRejectedExportResults(c *Client, response *sigilv1.ExportGenerationsResp
 			continue
 		}
 		c.logf("sigil generation rejected id=%s error=%s", result.GenerationId, result.Error)
+	}
+}
+
+func logRejectedWorkflowStepExportResults(c *Client, response *sigilv1.ExportWorkflowStepsResponse) {
+	for _, result := range response.GetResults() {
+		if result == nil || result.Accepted {
+			continue
+		}
+		c.logf("sigil workflow step rejected id=%s error=%s", result.StepId, result.Error)
 	}
 }
 
@@ -669,6 +862,40 @@ func validateExportResponse(request *sigilv1.ExportGenerationsRequest, response 
 	return nil
 }
 
+func validateWorkflowStepExportResponse(request *sigilv1.ExportWorkflowStepsRequest, response *sigilv1.ExportWorkflowStepsResponse) error {
+	if response == nil {
+		return &exportValidationError{err: errors.New("nil workflow step export response"), retryable: true}
+	}
+	requested := len(request.GetWorkflowSteps())
+	results := response.GetResults()
+	if len(results) != requested {
+		return &exportValidationError{err: fmt.Errorf("workflow step export result count mismatch: requested=%d results=%d", requested, len(results)), retryable: true}
+	}
+	malformed := make([]string, 0, len(results))
+	rejected := make([]string, 0, len(results))
+	for _, result := range results {
+		if result == nil {
+			malformed = append(malformed, "<nil result>")
+			continue
+		}
+		if result.Accepted {
+			continue
+		}
+		msg := strings.TrimSpace(result.Error)
+		if msg == "" {
+			msg = "rejected without error"
+		}
+		rejected = append(rejected, fmt.Sprintf("%s: %s", result.StepId, msg))
+	}
+	if len(rejected) > 0 {
+		return &exportValidationError{err: fmt.Errorf("workflow step export rejected: %s", strings.Join(rejected, "; "))}
+	}
+	if len(malformed) > 0 {
+		return &exportValidationError{err: fmt.Errorf("workflow step export malformed response: %s", strings.Join(malformed, "; ")), retryable: true}
+	}
+	return nil
+}
+
 func (c *Client) enqueueGeneration(generation Generation) error {
 	protoGeneration, err := generationToProto(generation)
 	if err != nil {
@@ -690,6 +917,33 @@ func (c *Client) enqueueGeneration(generation Generation) error {
 
 	select {
 	case c.queue <- queuedGeneration{generation: protoGeneration}:
+		return nil
+	default:
+		return ErrQueueFull
+	}
+}
+
+func (c *Client) enqueueWorkflowStep(step WorkflowStep) error {
+	protoStep, err := workflowStepToProto(step)
+	if err != nil {
+		return err
+	}
+
+	if maxPayload := c.config.GenerationExport.PayloadMaxBytes; maxPayload > 0 {
+		if payloadSize := proto.Size(protoStep); payloadSize > maxPayload {
+			return fmt.Errorf("workflow step payload exceeds max bytes (%d > %d)", payloadSize, maxPayload)
+		}
+	}
+
+	c.queueMu.RLock()
+	defer c.queueMu.RUnlock()
+
+	if c.shutdown {
+		return ErrClientShutdown
+	}
+
+	select {
+	case c.workflowStepQueue <- queuedWorkflowStep{workflowStep: protoStep}:
 		return nil
 	default:
 		return ErrQueueFull
@@ -738,6 +992,7 @@ func (c *Client) Shutdown(ctx context.Context) error {
 		c.queueMu.Lock()
 		c.shutdown = true
 		close(c.queue)
+		close(c.workflowStepQueue)
 		c.queueMu.Unlock()
 
 		select {

--- a/go/sigil/exporter.go
+++ b/go/sigil/exporter.go
@@ -551,17 +551,20 @@ func (c *Client) runExportWorker() {
 		return errors.Join(flushGenerations(), flushWorkflowSteps())
 	}
 
-	// pendingErr captures the first failure from an async flush (timer or
-	// batch-size triggered) since the last explicit Flush call. It's
-	// returned to and cleared by the next flushReq handler so callers who
-	// use Flush as a durability checkpoint can detect silent data loss
-	// instead of treating an empty post-failure batch as success.
+	// pendingErr captures failures from async flushes (timer or batch-size
+	// triggered) since the last explicit Flush call. It's returned to and
+	// cleared by the next flushReq handler so callers who use Flush as a
+	// durability checkpoint can detect silent data loss instead of treating an
+	// empty post-failure batch as success. Errors are joined rather than
+	// keeping only the first: a single timer tick flushes the generation and
+	// workflow-step queues separately, so both can fail in the same cycle and
+	// neither failure should be dropped.
 	var pendingErr error
 	recordAsyncErr := func(err error) {
-		if err == nil || pendingErr != nil {
+		if err == nil {
 			return
 		}
-		pendingErr = err
+		pendingErr = errors.Join(pendingErr, err)
 	}
 
 	generationQueue := c.queue

--- a/go/sigil/exporter.go
+++ b/go/sigil/exporter.go
@@ -946,7 +946,7 @@ func (c *Client) enqueueWorkflowStep(step WorkflowStep) error {
 	case c.workflowStepQueue <- queuedWorkflowStep{workflowStep: protoStep}:
 		return nil
 	default:
-		return ErrQueueFull
+		return ErrWorkflowStepQueueFull
 	}
 }
 

--- a/go/sigil/exporter_transport_test.go
+++ b/go/sigil/exporter_transport_test.go
@@ -46,6 +46,24 @@ func TestSDKExportsGenerationOverGRPC_AllPropertiesRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSDKExportsWorkflowStepOverHTTP_AllPropertiesRoundTrip(t *testing.T) {
+	step := workflowStepPayloadFromSeed(42)
+	expected, received := runSDKWorkflowStepRoundTrip(t, exportTransportHTTP, step)
+
+	if !proto.Equal(expected, received) {
+		t.Fatalf("http workflow step roundtrip mismatch\nexpected=%s\nreceived=%s", protojson.Format(expected), protojson.Format(received))
+	}
+}
+
+func TestSDKExportsWorkflowStepOverGRPC_AllPropertiesRoundTrip(t *testing.T) {
+	step := workflowStepPayloadFromSeed(99)
+	expected, received := runSDKWorkflowStepRoundTrip(t, exportTransportGRPC, step)
+
+	if !proto.Equal(expected, received) {
+		t.Fatalf("grpc workflow step roundtrip mismatch\nexpected=%s\nreceived=%s", protojson.Format(expected), protojson.Format(received))
+	}
+}
+
 func TestSDKExportsGenerationOverGRPCAboveDefaultMessageLimit(t *testing.T) {
 	ingest := &capturingIngestServer{}
 
@@ -231,6 +249,35 @@ func runSDKRoundTrip(t *testing.T, transport exportTransport, start GenerationSt
 	return expected, request.Generations[0]
 }
 
+func runSDKWorkflowStepRoundTrip(t *testing.T, transport exportTransport, step WorkflowStep) (*sigilv1.WorkflowStep, *sigilv1.WorkflowStep) {
+	t.Helper()
+
+	ingest := &capturingIngestServer{}
+	client := newTransportTestClient(t, transport, ingest)
+
+	if err := client.EnqueueWorkflowStep(step); err != nil {
+		t.Fatalf("enqueue workflow step: %v", err)
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("shutdown client: %v", err)
+	}
+
+	request := ingest.singleWorkflowStepRequest(t)
+	if len(request.WorkflowSteps) != 1 {
+		t.Fatalf("expected 1 workflow step, got %d", len(request.WorkflowSteps))
+	}
+
+	expected, err := workflowStepToProto(step)
+	if err != nil {
+		t.Fatalf("convert expected workflow step to proto: %v", err)
+	}
+
+	return expected, request.WorkflowSteps[0]
+}
+
 func newTransportTestClient(t *testing.T, transport exportTransport, ingest *capturingIngestServer) *Client {
 	t.Helper()
 
@@ -260,6 +307,27 @@ func newTransportTestClient(t *testing.T, transport exportTransport, ingest *cap
 				return
 			}
 
+			if r.URL.Path == "/api/v1/workflow-steps:export" {
+				request := &sigilv1.ExportWorkflowStepsRequest{}
+				if err := protojson.Unmarshal(payload, request); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				ingest.captureWorkflowSteps(request)
+
+				response := workflowStepAcceptanceResponse(request)
+				encoded, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(response)
+				if err != nil {
+					http.Error(w, "marshal response", http.StatusInternalServerError)
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusAccepted)
+				_, _ = w.Write(encoded)
+				return
+			}
+
 			request := &sigilv1.ExportGenerationsRequest{}
 			if err := protojson.Unmarshal(payload, request); err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)
@@ -285,6 +353,7 @@ func newTransportTestClient(t *testing.T, transport exportTransport, ingest *cap
 	case exportTransportGRPC:
 		grpcServer := grpc.NewServer()
 		sigilv1.RegisterGenerationIngestServiceServer(grpcServer, ingest)
+		sigilv1.RegisterWorkflowStepIngestServiceServer(grpcServer, ingest)
 
 		listener, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
@@ -406,6 +475,44 @@ func payloadFromSeed(seed uint64) (GenerationStart, Generation) {
 	return start, result
 }
 
+func workflowStepPayloadFromSeed(seed uint64) WorkflowStep {
+	rnd := rand.New(rand.NewSource(int64(seed)))
+	startedAt := time.Unix(int64(seed%1_000_000), int64(seed%1000)*int64(time.Millisecond)).UTC()
+	completedAt := startedAt.Add(250 * time.Millisecond)
+
+	return WorkflowStep{
+		ID:             "wfs-" + randomASCII(rnd, 10),
+		ConversationID: "conv-" + randomASCII(rnd, 8),
+		StepName:       "step-" + randomASCII(rnd, 6),
+		Framework:      "framework-" + randomASCII(rnd, 5),
+		StartedAt:      startedAt,
+		CompletedAt:    completedAt,
+		InputState: map[string]any{
+			"seed":    seed % 10000,
+			"enabled": seed%2 == 0,
+			"nested":  map[string]any{"n": rnd.Intn(100)},
+		},
+		OutputState: map[string]any{
+			"route": "answer-" + randomASCII(rnd, 5),
+		},
+		Error: "error-" + randomASCII(rnd, 4),
+		Tags: map[string]string{
+			"seed": fmt.Sprintf("%d", seed),
+			"env":  "test",
+		},
+		LinkedGenerationIDs: []string{"gen-" + randomASCII(rnd, 8), "gen-" + randomASCII(rnd, 8)},
+		ParentStepIDs:       []string{"wfs-parent-" + randomASCII(rnd, 5)},
+		AgentName:           "agent-" + randomASCII(rnd, 8),
+		AgentVersion:        "v-" + randomASCII(rnd, 6),
+		TraceID:             randomHex(rnd, 32),
+		SpanID:              randomHex(rnd, 16),
+		Metadata: map[string]any{
+			"run_id": "run-" + randomASCII(rnd, 8),
+			"seed":   seed % 10000,
+		},
+	}
+}
+
 func randomASCII(rnd *rand.Rand, n int) string {
 	const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
 	bytes := make([]byte, n)
@@ -442,10 +549,12 @@ func boolPtr(value bool) *bool {
 
 type capturingIngestServer struct {
 	sigilv1.UnimplementedGenerationIngestServiceServer
+	sigilv1.UnimplementedWorkflowStepIngestServiceServer
 
-	mu         sync.Mutex
-	requests   []*sigilv1.ExportGenerationsRequest
-	userAgents []string
+	mu                   sync.Mutex
+	requests             []*sigilv1.ExportGenerationsRequest
+	workflowStepRequests []*sigilv1.ExportWorkflowStepsRequest
+	userAgents           []string
 }
 
 func (s *capturingIngestServer) ExportGenerations(ctx context.Context, req *sigilv1.ExportGenerationsRequest) (*sigilv1.ExportGenerationsResponse, error) {
@@ -458,6 +567,18 @@ func (s *capturingIngestServer) ExportGenerations(ctx context.Context, req *sigi
 	}
 	s.capture(req)
 	return acceptanceResponse(req), nil
+}
+
+func (s *capturingIngestServer) ExportWorkflowSteps(ctx context.Context, req *sigilv1.ExportWorkflowStepsRequest) (*sigilv1.ExportWorkflowStepsResponse, error) {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if vals := md.Get("user-agent"); len(vals) > 0 {
+			s.mu.Lock()
+			s.userAgents = append(s.userAgents, vals[0])
+			s.mu.Unlock()
+		}
+	}
+	s.captureWorkflowSteps(req)
+	return workflowStepAcceptanceResponse(req), nil
 }
 
 func (s *capturingIngestServer) singleUserAgent(t *testing.T) string {
@@ -498,10 +619,45 @@ func (s *capturingIngestServer) singleRequest(t *testing.T) *sigilv1.ExportGener
 	return s.requests[0]
 }
 
+func (s *capturingIngestServer) captureWorkflowSteps(req *sigilv1.ExportWorkflowStepsRequest) {
+	if req == nil {
+		return
+	}
+
+	clone := proto.Clone(req)
+	typed, ok := clone.(*sigilv1.ExportWorkflowStepsRequest)
+	if !ok {
+		return
+	}
+
+	s.mu.Lock()
+	s.workflowStepRequests = append(s.workflowStepRequests, typed)
+	s.mu.Unlock()
+}
+
+func (s *capturingIngestServer) singleWorkflowStepRequest(t *testing.T) *sigilv1.ExportWorkflowStepsRequest {
+	t.Helper()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.workflowStepRequests) != 1 {
+		t.Fatalf("expected exactly one workflow step export request, got %d", len(s.workflowStepRequests))
+	}
+	return s.workflowStepRequests[0]
+}
+
 func acceptanceResponse(req *sigilv1.ExportGenerationsRequest) *sigilv1.ExportGenerationsResponse {
 	response := &sigilv1.ExportGenerationsResponse{Results: make([]*sigilv1.ExportGenerationResult, len(req.GetGenerations()))}
 	for i := range req.GetGenerations() {
 		response.Results[i] = &sigilv1.ExportGenerationResult{GenerationId: req.Generations[i].Id, Accepted: true}
+	}
+	return response
+}
+
+func workflowStepAcceptanceResponse(req *sigilv1.ExportWorkflowStepsRequest) *sigilv1.ExportWorkflowStepsResponse {
+	response := &sigilv1.ExportWorkflowStepsResponse{Results: make([]*sigilv1.ExportWorkflowStepResult, len(req.GetWorkflowSteps()))}
+	for i := range req.GetWorkflowSteps() {
+		response.Results[i] = &sigilv1.ExportWorkflowStepResult{StepId: req.WorkflowSteps[i].Id, Accepted: true}
 	}
 	return response
 }

--- a/go/sigil/proto_mapping.go
+++ b/go/sigil/proto_mapping.go
@@ -12,3 +12,9 @@ import (
 func generationToProto(g Generation) (*sigilv1.Generation, error) {
 	return sigilcodec.ToProto(g)
 }
+
+// workflowStepToProto translates the SDK's WorkflowStep value into the
+// wire-level protobuf message.
+func workflowStepToProto(step WorkflowStep) (*sigilv1.WorkflowStep, error) {
+	return sigilcodec.WorkflowStepToProto(step)
+}

--- a/go/sigil/sigilcodec/codec.go
+++ b/go/sigil/sigilcodec/codec.go
@@ -82,6 +82,48 @@ func ToProto(g sigilmodel.Generation) (*sigilv1.Generation, error) {
 	return out, nil
 }
 
+// WorkflowStepToProto converts a sigilmodel.WorkflowStep into the wire-level
+// proto used by the workflow-step ingest service.
+func WorkflowStepToProto(step sigilmodel.WorkflowStep) (*sigilv1.WorkflowStep, error) {
+	inputState, err := metadataToStruct(step.InputState)
+	if err != nil {
+		return nil, fmt.Errorf("map input_state: %w", err)
+	}
+	outputState, err := metadataToStruct(step.OutputState)
+	if err != nil {
+		return nil, fmt.Errorf("map output_state: %w", err)
+	}
+	metadata, err := metadataToStruct(step.Metadata)
+	if err != nil {
+		return nil, fmt.Errorf("map metadata: %w", err)
+	}
+
+	out := &sigilv1.WorkflowStep{
+		Id:                  step.ID,
+		ConversationId:      step.ConversationID,
+		StepName:            step.StepName,
+		Framework:           step.Framework,
+		InputState:          inputState,
+		OutputState:         outputState,
+		Error:               step.Error,
+		Tags:                cloneTags(step.Tags),
+		LinkedGenerationIds: cloneStringSlice(step.LinkedGenerationIDs),
+		ParentStepIds:       cloneStringSlice(step.ParentStepIDs),
+		AgentName:           step.AgentName,
+		AgentVersion:        step.AgentVersion,
+		TraceId:             step.TraceID,
+		SpanId:              step.SpanID,
+		Metadata:            metadata,
+	}
+	if !step.StartedAt.IsZero() {
+		out.StartedAt = timestamppb.New(step.StartedAt)
+	}
+	if !step.CompletedAt.IsZero() {
+		out.CompletedAt = timestamppb.New(step.CompletedAt)
+	}
+	return out, nil
+}
+
 func metadataToStruct(metadata map[string]any) (*structpb.Struct, error) {
 	if len(metadata) == 0 {
 		return nil, nil

--- a/go/sigil/sigilcodec/codec_test.go
+++ b/go/sigil/sigilcodec/codec_test.go
@@ -100,6 +100,83 @@ func TestToProtoRolesAndParts(t *testing.T) {
 	}
 }
 
+func TestWorkflowStepToProtoMapsAllFields(t *testing.T) {
+	startedAt := time.Date(2026, 2, 11, 12, 0, 0, 0, time.UTC)
+	completedAt := startedAt.Add(time.Second)
+
+	got, err := sigilcodec.WorkflowStepToProto(sigilmodel.WorkflowStep{
+		ID:                  "wfs-route",
+		ConversationID:      "conv-workflow",
+		StepName:            "route",
+		Framework:           "custom",
+		StartedAt:           startedAt,
+		CompletedAt:         completedAt,
+		InputState:          map[string]any{"prompt": "hello", "count": 1},
+		OutputState:         map[string]any{"route": "answer"},
+		Error:               "boom",
+		Tags:                map[string]string{"env": "test"},
+		LinkedGenerationIDs: []string{"gen-1", "gen-2"},
+		ParentStepIDs:       []string{"wfs-root"},
+		AgentName:           "agent-workflow",
+		AgentVersion:        "v1",
+		TraceID:             "trace-1",
+		SpanID:              "span-1",
+		Metadata:            map[string]any{"run_id": "run-1"},
+	})
+	if err != nil {
+		t.Fatalf("WorkflowStepToProto: %v", err)
+	}
+
+	if got.GetId() != "wfs-route" {
+		t.Fatalf("expected id wfs-route, got %q", got.GetId())
+	}
+	if got.GetConversationId() != "conv-workflow" {
+		t.Fatalf("expected conversation id conv-workflow, got %q", got.GetConversationId())
+	}
+	if got.GetStepName() != "route" {
+		t.Fatalf("expected step name route, got %q", got.GetStepName())
+	}
+	if got.GetFramework() != "custom" {
+		t.Fatalf("expected framework custom, got %q", got.GetFramework())
+	}
+	if got.GetStartedAt().AsTime() != startedAt {
+		t.Fatalf("expected startedAt %s, got %s", startedAt, got.GetStartedAt().AsTime())
+	}
+	if got.GetCompletedAt().AsTime() != completedAt {
+		t.Fatalf("expected completedAt %s, got %s", completedAt, got.GetCompletedAt().AsTime())
+	}
+	if got.GetInputState().GetFields()["prompt"].GetStringValue() != "hello" {
+		t.Fatalf("expected input_state.prompt=hello, got %#v", got.GetInputState())
+	}
+	if got.GetInputState().GetFields()["count"].GetNumberValue() != 1 {
+		t.Fatalf("expected input_state.count=1, got %#v", got.GetInputState())
+	}
+	if got.GetOutputState().GetFields()["route"].GetStringValue() != "answer" {
+		t.Fatalf("expected output_state.route=answer, got %#v", got.GetOutputState())
+	}
+	if got.GetError() != "boom" {
+		t.Fatalf("expected error boom, got %q", got.GetError())
+	}
+	if got.GetTags()["env"] != "test" {
+		t.Fatalf("expected env tag, got %#v", got.GetTags())
+	}
+	if strings.Join(got.GetLinkedGenerationIds(), ",") != "gen-1,gen-2" {
+		t.Fatalf("unexpected linked generation ids: %#v", got.GetLinkedGenerationIds())
+	}
+	if strings.Join(got.GetParentStepIds(), ",") != "wfs-root" {
+		t.Fatalf("unexpected parent step ids: %#v", got.GetParentStepIds())
+	}
+	if got.GetAgentName() != "agent-workflow" || got.GetAgentVersion() != "v1" {
+		t.Fatalf("unexpected agent fields: %q %q", got.GetAgentName(), got.GetAgentVersion())
+	}
+	if got.GetTraceId() != "trace-1" || got.GetSpanId() != "span-1" {
+		t.Fatalf("unexpected trace fields: %q %q", got.GetTraceId(), got.GetSpanId())
+	}
+	if got.GetMetadata().GetFields()["run_id"].GetStringValue() != "run-1" {
+		t.Fatalf("expected metadata.run_id=run-1, got %#v", got.GetMetadata())
+	}
+}
+
 func TestToProtoArtifacts(t *testing.T) {
 	g := sigilmodel.Generation{
 		Artifacts: []sigilmodel.Artifact{

--- a/go/sigil/sigilmodel/validation.go
+++ b/go/sigil/sigilmodel/validation.go
@@ -21,6 +21,11 @@ func (g Generation) Validate() error {
 	return ValidateGeneration(g)
 }
 
+// Validate enforces the workflow-step invariants required by ingest.
+func (s WorkflowStep) Validate() error {
+	return ValidateWorkflowStep(s)
+}
+
 // ValidateGeneration is the package-level form of Generation.Validate.
 func ValidateGeneration(g Generation) error {
 	contentStripped := isContentStripped(g)
@@ -60,6 +65,23 @@ func ValidateGeneration(g Generation) error {
 		}
 	}
 
+	return nil
+}
+
+// ValidateWorkflowStep is the package-level form of WorkflowStep.Validate.
+func ValidateWorkflowStep(step WorkflowStep) error {
+	if strings.TrimSpace(step.ID) == "" {
+		return errors.New("workflow step id is required")
+	}
+	if strings.TrimSpace(step.ConversationID) == "" {
+		return errors.New("workflow step conversation_id is required")
+	}
+	if strings.TrimSpace(step.StepName) == "" {
+		return errors.New("workflow step step_name is required")
+	}
+	if !step.StartedAt.IsZero() && !step.CompletedAt.IsZero() && step.CompletedAt.Before(step.StartedAt) {
+		return errors.New("workflow step completed_at must not be earlier than started_at")
+	}
 	return nil
 }
 

--- a/go/sigil/sigilmodel/workflow_step.go
+++ b/go/sigil/sigilmodel/workflow_step.go
@@ -11,8 +11,8 @@ type WorkflowStep struct {
 	ConversationID      string            `json:"conversation_id,omitempty"`
 	StepName            string            `json:"step_name,omitempty"`
 	Framework           string            `json:"framework,omitempty"`
-	StartedAt           time.Time         `json:"started_at,omitempty"`
-	CompletedAt         time.Time         `json:"completed_at,omitempty"`
+	StartedAt           time.Time         `json:"started_at"`
+	CompletedAt         time.Time         `json:"completed_at"`
 	InputState          map[string]any    `json:"input_state,omitempty"`
 	OutputState         map[string]any    `json:"output_state,omitempty"`
 	Error               string            `json:"error,omitempty"`

--- a/go/sigil/sigilmodel/workflow_step.go
+++ b/go/sigil/sigilmodel/workflow_step.go
@@ -1,0 +1,27 @@
+package sigilmodel
+
+import "time"
+
+// WorkflowStep describes one execution node in an agentic workflow.
+//
+// A step can represent non-LLM work such as routing, retrieval, validation, or
+// tool orchestration, and can link to the generations that ran inside it.
+type WorkflowStep struct {
+	ID                  string            `json:"id,omitempty"`
+	ConversationID      string            `json:"conversation_id,omitempty"`
+	StepName            string            `json:"step_name,omitempty"`
+	Framework           string            `json:"framework,omitempty"`
+	StartedAt           time.Time         `json:"started_at,omitempty"`
+	CompletedAt         time.Time         `json:"completed_at,omitempty"`
+	InputState          map[string]any    `json:"input_state,omitempty"`
+	OutputState         map[string]any    `json:"output_state,omitempty"`
+	Error               string            `json:"error,omitempty"`
+	Tags                map[string]string `json:"tags,omitempty"`
+	LinkedGenerationIDs []string          `json:"linked_generation_ids,omitempty"`
+	ParentStepIDs       []string          `json:"parent_step_ids,omitempty"`
+	AgentName           string            `json:"agent_name,omitempty"`
+	AgentVersion        string            `json:"agent_version,omitempty"`
+	TraceID             string            `json:"trace_id,omitempty"`
+	SpanID              string            `json:"span_id,omitempty"`
+	Metadata            map[string]any    `json:"metadata,omitempty"`
+}

--- a/go/sigil/validation.go
+++ b/go/sigil/validation.go
@@ -14,6 +14,12 @@ func ValidateGeneration(g Generation) error {
 	return sigilmodel.ValidateGeneration(g)
 }
 
+// ValidateWorkflowStep enforces the Sigil workflow-step invariants required by
+// the ingest pipeline.
+func ValidateWorkflowStep(step WorkflowStep) error {
+	return sigilmodel.ValidateWorkflowStep(step)
+}
+
 func ValidateEmbeddingStart(start EmbeddingStart) error {
 	if strings.TrimSpace(start.Model.Provider) == "" {
 		return errors.New("embedding.model.provider is required")

--- a/go/sigil/workflow_step.go
+++ b/go/sigil/workflow_step.go
@@ -1,0 +1,28 @@
+package sigil
+
+import "github.com/grafana/sigil-sdk/go/sigil/sigilmodel"
+
+// WorkflowStep describes one execution node in an agentic workflow.
+type WorkflowStep = sigilmodel.WorkflowStep
+
+func cloneWorkflowStep(in WorkflowStep) WorkflowStep {
+	return WorkflowStep{
+		ID:                  in.ID,
+		ConversationID:      in.ConversationID,
+		StepName:            in.StepName,
+		Framework:           in.Framework,
+		StartedAt:           in.StartedAt,
+		CompletedAt:         in.CompletedAt,
+		InputState:          cloneMetadata(in.InputState),
+		OutputState:         cloneMetadata(in.OutputState),
+		Error:               in.Error,
+		Tags:                cloneTags(in.Tags),
+		LinkedGenerationIDs: cloneStringSlice(in.LinkedGenerationIDs),
+		ParentStepIDs:       cloneStringSlice(in.ParentStepIDs),
+		AgentName:           in.AgentName,
+		AgentVersion:        in.AgentVersion,
+		TraceID:             in.TraceID,
+		SpanID:              in.SpanID,
+		Metadata:            cloneMetadata(in.Metadata),
+	}
+}

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -291,8 +291,12 @@ export class SigilClient {
       throw new Error(`sigil workflow step validation failed: ${validationError.message}`);
     }
     const normalized = this.normalizeWorkflowStep(step);
-    this.workflowSteps.push(cloneWorkflowStep(normalized));
+    // Enqueue first: internalEnqueueWorkflowStep throws on a payload/queue
+    // rejection, and enqueueWorkflowStep propagates it. Recording into the
+    // debug buffer only after a successful enqueue keeps debugSnapshot from
+    // listing a step the caller was told failed to enqueue.
     this.internalEnqueueWorkflowStep(normalized);
+    this.workflowSteps.push(cloneWorkflowStep(normalized));
   }
 
   /**

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -63,6 +63,7 @@ import type {
   ToolExecutionRecorder,
   ToolExecutionResult,
   ToolExecutionStart,
+  WorkflowStep,
 } from './types.js';
 import {
   asError,
@@ -78,6 +79,7 @@ import {
   cloneToolExecution,
   cloneToolExecutionResult,
   cloneToolExecutionStart,
+  cloneWorkflowStep,
   defaultOperationNameForMode,
   defaultSleep,
   encodedSizeBytes,
@@ -87,6 +89,7 @@ import {
   validateEmbeddingStart,
   validateGeneration,
   validateToolExecution,
+  validateWorkflowStep,
 } from './utils.js';
 
 const spanAttrGenerationID = 'sigil.generation.id';
@@ -228,8 +231,10 @@ export class SigilClient {
   private readonly ttftHistogram: Histogram;
   private readonly toolCallsHistogram: Histogram;
   private readonly generations: Generation[] = [];
+  private readonly workflowSteps: WorkflowStep[] = [];
   private readonly toolExecutions: ToolExecution[] = [];
   private readonly pendingGenerations: Generation[] = [];
+  private readonly pendingWorkflowSteps: WorkflowStep[] = [];
 
   private flushPromise: Promise<void> | undefined;
   private flushRequested = false;
@@ -272,6 +277,22 @@ export class SigilClient {
       }, this.config.generationExport.flushIntervalMs);
       maybeUnref(this.flushTimer);
     }
+  }
+
+  /** Enqueues a workflow execution node for export. */
+  enqueueWorkflowStep(step: WorkflowStep): void {
+    this.assertOpen();
+    // Validate the raw input before defaulting timestamps, matching Go and
+    // Python. The completedAt < startedAt rule only fires when the caller
+    // supplied both; defaulting startedAt to now() first would spuriously
+    // reject a step for which the caller only provided completedAt.
+    const validationError = validateWorkflowStep(step);
+    if (validationError !== undefined) {
+      throw new Error(`sigil workflow step validation failed: ${validationError.message}`);
+    }
+    const normalized = this.normalizeWorkflowStep(step);
+    this.workflowSteps.push(cloneWorkflowStep(normalized));
+    this.internalEnqueueWorkflowStep(normalized);
   }
 
   /**
@@ -589,8 +610,10 @@ export class SigilClient {
   debugSnapshot(): SigilDebugSnapshot {
     return {
       generations: this.generations.map(cloneGeneration),
+      workflowSteps: this.workflowSteps.map(cloneWorkflowStep),
       toolExecutions: this.toolExecutions.map(cloneToolExecution),
       queueSize: this.pendingGenerations.length,
+      workflowStepQueueSize: this.pendingWorkflowSteps.length,
     };
   }
 
@@ -646,6 +669,41 @@ export class SigilClient {
     if (this.pendingGenerations.length >= batchSize) {
       this.triggerAsyncFlush();
     }
+  }
+
+  internalEnqueueWorkflowStep(step: WorkflowStep): void {
+    if (this.shuttingDown || this.closed) {
+      throw new Error('sigil client is shutdown');
+    }
+
+    const payloadMaxBytes = this.config.generationExport.payloadMaxBytes;
+    if (payloadMaxBytes > 0) {
+      const payloadBytes = encodedSizeBytes(step);
+      if (payloadBytes > payloadMaxBytes) {
+        throw new Error(`workflow step payload exceeds max bytes (${payloadBytes} > ${payloadMaxBytes})`);
+      }
+    }
+
+    const queueSize = Math.max(1, this.config.generationExport.queueSize);
+    if (this.pendingWorkflowSteps.length >= queueSize) {
+      throw new Error('workflow step queue is full');
+    }
+
+    this.pendingWorkflowSteps.push(cloneWorkflowStep(step));
+
+    const batchSize = Math.max(1, this.config.generationExport.batchSize);
+    if (this.pendingWorkflowSteps.length >= batchSize) {
+      this.triggerAsyncFlush();
+    }
+  }
+
+  private normalizeWorkflowStep(step: WorkflowStep): WorkflowStep {
+    const normalized = cloneWorkflowStep(step);
+    const startedAt = normalized.startedAt ?? this.internalNow();
+    normalized.startedAt = new Date(startedAt);
+    normalized.completedAt = new Date(normalized.completedAt ?? normalized.startedAt);
+    normalized.tags = mergeStringRecords(this.config.tags, normalized.tags);
+    return normalized;
   }
 
   internalLogWarn(message: string, error?: unknown): void {
@@ -1105,23 +1163,45 @@ export class SigilClient {
       return this.flushPromise;
     }
 
-    this.flushPromise = this.drainPendingGenerations().finally(() => {
+    this.flushPromise = this.drainPendingExports().finally(() => {
       this.flushPromise = undefined;
     });
 
     return this.flushPromise;
   }
 
-  private async drainPendingGenerations(): Promise<void> {
+  private async drainPendingExports(): Promise<void> {
+    const errors: Error[] = [];
     do {
       this.flushRequested = false;
 
       while (this.pendingGenerations.length > 0) {
         const batchSize = Math.max(1, this.config.generationExport.batchSize);
         const batch = this.pendingGenerations.splice(0, batchSize).map(cloneGeneration);
-        await this.exportWithRetry(batch);
+        try {
+          await this.exportWithRetry(batch);
+        } catch (error) {
+          errors.push(asError(error));
+        }
       }
-    } while (this.flushRequested || this.pendingGenerations.length > 0);
+
+      while (this.pendingWorkflowSteps.length > 0) {
+        const batchSize = Math.max(1, this.config.generationExport.batchSize);
+        const batch = this.pendingWorkflowSteps.splice(0, batchSize).map(cloneWorkflowStep);
+        try {
+          await this.exportWorkflowStepsWithRetry(batch);
+        } catch (error) {
+          errors.push(asError(error));
+        }
+      }
+    } while (this.flushRequested || this.pendingGenerations.length > 0 || this.pendingWorkflowSteps.length > 0);
+
+    if (errors.length === 1) {
+      throw errors[0];
+    }
+    if (errors.length > 1) {
+      throw new AggregateError(errors, 'sigil export failed');
+    }
   }
 
   private async exportWithRetry(generations: Generation[]): Promise<void> {
@@ -1156,10 +1236,50 @@ export class SigilClient {
     throw lastError ?? new Error('generation export failed');
   }
 
+  private async exportWorkflowStepsWithRetry(workflowSteps: WorkflowStep[]): Promise<void> {
+    const maxRetries = Math.max(0, this.config.generationExport.maxRetries);
+    const attempts = maxRetries + 1;
+    const baseBackoffMs =
+      this.config.generationExport.initialBackoffMs > 0 ? this.config.generationExport.initialBackoffMs : 100;
+    const maxBackoffMs =
+      this.config.generationExport.maxBackoffMs > 0 ? this.config.generationExport.maxBackoffMs : baseBackoffMs;
+
+    let backoffMs = baseBackoffMs;
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      try {
+        const response = await this.generationExporter.exportWorkflowSteps({
+          workflowSteps: workflowSteps.map(cloneWorkflowStep),
+        });
+        this.logRejectedWorkflowStepResults(response.results);
+        return;
+      } catch (error) {
+        lastError = asError(error);
+        if (attempt === attempts - 1) {
+          break;
+        }
+
+        await this.sleepFn(backoffMs);
+        backoffMs = Math.min(backoffMs * 2, maxBackoffMs);
+      }
+    }
+
+    throw lastError ?? new Error('workflow step export failed');
+  }
+
   private logRejectedResults(results: Array<{ generationId: string; accepted: boolean; error?: string }>): void {
     for (const result of results) {
       if (!result.accepted) {
         this.logWarn(`sigil generation rejected id=${result.generationId}`, result.error);
+      }
+    }
+  }
+
+  private logRejectedWorkflowStepResults(results: Array<{ stepId: string; accepted: boolean; error?: string }>): void {
+    for (const result of results) {
+      if (!result.accepted) {
+        this.logWarn(`sigil workflow step rejected id=${result.stepId}`, result.error);
       }
     }
   }

--- a/js/src/core.ts
+++ b/js/src/core.ts
@@ -38,6 +38,9 @@ export type {
   ExportGenerationResult,
   ExportGenerationsRequest,
   ExportGenerationsResponse,
+  ExportWorkflowStepResult,
+  ExportWorkflowStepsRequest,
+  ExportWorkflowStepsResponse,
   Generation,
   GenerationExportConfig,
   GenerationExporter,
@@ -74,6 +77,7 @@ export type {
   ToolExecutionResult,
   ToolExecutionStart,
   ToolResultPart,
+  WorkflowStep,
 } from './types.js';
 export { SDK_VERSION, userAgent } from './version.js';
 

--- a/js/src/exporters/default.ts
+++ b/js/src/exporters/default.ts
@@ -1,6 +1,8 @@
 import type {
   ExportGenerationsRequest,
   ExportGenerationsResponse,
+  ExportWorkflowStepsRequest,
+  ExportWorkflowStepsResponse,
   GenerationExportConfig,
   GenerationExporter,
 } from '../types.js';
@@ -30,12 +32,25 @@ class NoopGenerationExporter implements GenerationExporter {
       })),
     };
   }
+
+  async exportWorkflowSteps(request: ExportWorkflowStepsRequest): Promise<ExportWorkflowStepsResponse> {
+    return {
+      results: request.workflowSteps.map((step) => ({
+        stepId: step.id,
+        accepted: true,
+      })),
+    };
+  }
 }
 
 class UnavailableGenerationExporter implements GenerationExporter {
   constructor(private readonly reason: Error) {}
 
   async exportGenerations(): Promise<never> {
+    throw this.reason;
+  }
+
+  async exportWorkflowSteps(): Promise<never> {
     throw this.reason;
   }
 }
@@ -59,6 +74,11 @@ class LazyGRPCGenerationExporter implements GenerationExporter {
   async exportGenerations(request: ExportGenerationsRequest): Promise<ExportGenerationsResponse> {
     const exporter = await this.getExporter();
     return exporter.exportGenerations(request);
+  }
+
+  async exportWorkflowSteps(request: ExportWorkflowStepsRequest): Promise<ExportWorkflowStepsResponse> {
+    const exporter = await this.getExporter();
+    return exporter.exportWorkflowSteps(request);
   }
 
   async shutdown(): Promise<void> {

--- a/js/src/exporters/grpc.ts
+++ b/js/src/exporters/grpc.ts
@@ -6,12 +6,15 @@ import type {
   Artifact,
   ExportGenerationsRequest,
   ExportGenerationsResponse,
+  ExportWorkflowStepsRequest,
+  ExportWorkflowStepsResponse,
   Generation,
   GenerationExporter,
   Message,
   MessagePart,
   TokenUsage,
   ToolDefinition,
+  WorkflowStep,
 } from '../types.js';
 import { canonicalEffectiveVersion } from '../utils.js';
 import { userAgent } from '../version.js';
@@ -22,14 +25,25 @@ type ExportGenerationsMethod = (
   callback: (error: grpc.ServiceError | null, response: unknown) => void,
 ) => void;
 
-type GRPCServiceClient = grpc.Client & {
+type ExportWorkflowStepsMethod = (
+  request: unknown,
+  metadata: grpc.Metadata,
+  callback: (error: grpc.ServiceError | null, response: unknown) => void,
+) => void;
+
+type GRPCGenerationServiceClient = grpc.Client & {
   ExportGenerations?: ExportGenerationsMethod;
+};
+
+type GRPCWorkflowStepServiceClient = grpc.Client & {
+  ExportWorkflowSteps?: ExportWorkflowStepsMethod;
 };
 
 type LoadedGRPCPackage = {
   sigil?: {
     v1?: {
       GenerationIngestService?: grpc.ServiceClientConstructor;
+      WorkflowStepIngestService?: grpc.ServiceClientConstructor;
     };
   };
 };
@@ -53,7 +67,8 @@ export class GRPCGenerationExporter implements GenerationExporter {
   private readonly userAgent: string;
 
   private initPromise: Promise<void> | undefined;
-  private client: GRPCServiceClient | undefined;
+  private generationClient: GRPCGenerationServiceClient | undefined;
+  private workflowStepClient: GRPCWorkflowStepServiceClient | undefined;
 
   constructor(endpoint: string, headers?: Record<string, string>, insecure = false) {
     const parsed = parseGRPCEndpoint(endpoint);
@@ -69,7 +84,7 @@ export class GRPCGenerationExporter implements GenerationExporter {
 
   async exportGenerations(request: ExportGenerationsRequest): Promise<ExportGenerationsResponse> {
     await this.ensureClient();
-    const client = this.client;
+    const client = this.generationClient;
     if (client === undefined || typeof client.ExportGenerations !== 'function') {
       throw new Error('grpc exporter client is unavailable');
     }
@@ -96,15 +111,48 @@ export class GRPCGenerationExporter implements GenerationExporter {
     return parseGRPCExportResponse(response, request);
   }
 
+  async exportWorkflowSteps(request: ExportWorkflowStepsRequest): Promise<ExportWorkflowStepsResponse> {
+    await this.ensureClient();
+    const client = this.workflowStepClient;
+    if (client === undefined || typeof client.ExportWorkflowSteps !== 'function') {
+      throw new Error('grpc workflow-step exporter client is unavailable');
+    }
+
+    const metadata = new grpc.Metadata();
+    for (const [key, value] of Object.entries(this.headers)) {
+      metadata.set(key, value);
+    }
+
+    const grpcRequest = {
+      workflowSteps: request.workflowSteps.map(mapWorkflowStepToProto),
+    };
+
+    const response = await new Promise<unknown>((resolve, reject) => {
+      client.ExportWorkflowSteps?.(grpcRequest, metadata, (error, result) => {
+        if (error !== null) {
+          reject(error);
+          return;
+        }
+        resolve(result);
+      });
+    });
+
+    return parseGRPCWorkflowStepExportResponse(response, request);
+  }
+
   async shutdown(): Promise<void> {
-    if (this.client !== undefined) {
-      this.client.close();
-      this.client = undefined;
+    if (this.generationClient !== undefined) {
+      this.generationClient.close();
+      this.generationClient = undefined;
+    }
+    if (this.workflowStepClient !== undefined) {
+      this.workflowStepClient.close();
+      this.workflowStepClient = undefined;
     }
   }
 
   private async ensureClient(): Promise<void> {
-    if (this.client !== undefined) {
+    if (this.generationClient !== undefined && this.workflowStepClient !== undefined) {
       return;
     }
     if (this.initPromise !== undefined) {
@@ -120,15 +168,22 @@ export class GRPCGenerationExporter implements GenerationExporter {
   private async initializeClient(): Promise<void> {
     const packageDefinition = await protoLoader.load(defaultProtoPath, protoLoadOptions);
     const loaded = grpc.loadPackageDefinition(packageDefinition) as unknown as LoadedGRPCPackage;
-    const clientCtor = loaded.sigil?.v1?.GenerationIngestService;
-    if (clientCtor === undefined) {
+    const generationClientCtor = loaded.sigil?.v1?.GenerationIngestService;
+    if (generationClientCtor === undefined) {
       throw new Error('failed to load sigil.v1.GenerationIngestService from proto');
+    }
+    const workflowStepClientCtor = loaded.sigil?.v1?.WorkflowStepIngestService;
+    if (workflowStepClientCtor === undefined) {
+      throw new Error('failed to load sigil.v1.WorkflowStepIngestService from proto');
     }
 
     const credentials = this.insecure ? grpc.credentials.createInsecure() : grpc.credentials.createSsl();
-    this.client = new clientCtor(this.endpoint, credentials, {
+    this.generationClient = new generationClientCtor(this.endpoint, credentials, {
       'grpc.primary_user_agent': this.userAgent,
-    }) as GRPCServiceClient;
+    }) as GRPCGenerationServiceClient;
+    this.workflowStepClient = new workflowStepClientCtor(this.endpoint, credentials, {
+      'grpc.primary_user_agent': this.userAgent,
+    }) as GRPCWorkflowStepServiceClient;
   }
 }
 
@@ -201,6 +256,29 @@ function parseGRPCExportResponse(response: unknown, request: ExportGenerationsRe
   };
 }
 
+function parseGRPCWorkflowStepExportResponse(
+  response: unknown,
+  request: ExportWorkflowStepsRequest,
+): ExportWorkflowStepsResponse {
+  if (!isObject(response) || !Array.isArray(response.results)) {
+    throw new Error('invalid grpc workflow step export response payload');
+  }
+
+  return {
+    results: response.results.map((result, index) => {
+      if (!isObject(result)) {
+        throw new Error('invalid grpc workflow step export result payload');
+      }
+
+      return {
+        stepId: asString(result.stepId) ?? asString(result.step_id) ?? request.workflowSteps[index]?.id ?? '',
+        accepted: Boolean(result.accepted),
+        error: asString(result.error),
+      };
+    }),
+  };
+}
+
 function mapGenerationToProto(generation: Generation): Record<string, unknown> {
   const proto: Record<string, unknown> = {
     id: generation.id,
@@ -242,6 +320,28 @@ function mapGenerationToProto(generation: Generation): Record<string, unknown> {
   }
 
   return proto;
+}
+
+function mapWorkflowStepToProto(step: WorkflowStep): Record<string, unknown> {
+  return {
+    id: step.id,
+    conversationId: step.conversationId,
+    stepName: step.stepName,
+    framework: step.framework ?? '',
+    startedAt: step.startedAt === undefined ? undefined : mapTimestamp(step.startedAt),
+    completedAt: step.completedAt === undefined ? undefined : mapTimestamp(step.completedAt),
+    inputState: mapStructToProto(step.inputState),
+    outputState: mapStructToProto(step.outputState),
+    error: step.error ?? '',
+    tags: step.tags ?? {},
+    linkedGenerationIds: step.linkedGenerationIds ?? [],
+    parentStepIds: step.parentStepIds ?? [],
+    agentName: step.agentName ?? '',
+    agentVersion: step.agentVersion ?? '',
+    traceId: step.traceId ?? '',
+    spanId: step.spanId ?? '',
+    metadata: mapStructToProto(step.metadata),
+  };
 }
 
 function mapMessageToProto(message: Message): Record<string, unknown> {
@@ -438,6 +538,11 @@ function mapStructValue(value: unknown): Record<string, unknown> | undefined {
   }
 }
 
+// Resolution is milliseconds by design: JS `Date` only holds millisecond
+// precision, so `nanos` is always a multiple of 1e6. Go (`time.Time`, ns) and
+// Python (`datetime`, µs) preserve finer precision when the caller supplies it,
+// but a JS caller cannot express it in the first place. Shared by generation
+// and workflow-step mappers.
 function mapTimestamp(date: Date): Record<string, number | string> {
   const milliseconds = date.getTime();
   const seconds = Math.floor(milliseconds / 1_000);

--- a/js/src/exporters/http.ts
+++ b/js/src/exporters/http.ts
@@ -3,22 +3,28 @@ import type {
   ExportGenerationResult,
   ExportGenerationsRequest,
   ExportGenerationsResponse,
+  ExportWorkflowStepResult,
+  ExportWorkflowStepsRequest,
+  ExportWorkflowStepsResponse,
   Generation,
   GenerationExporter,
   Message,
   MessagePart,
   TokenUsage,
   ToolDefinition,
+  WorkflowStep,
 } from '../types.js';
 import { canonicalEffectiveVersion, isRecord } from '../utils.js';
 import { userAgent } from '../version.js';
 
 export class HTTPGenerationExporter implements GenerationExporter {
-  private readonly endpoint: string;
+  private readonly generationEndpoint: string;
+  private readonly workflowStepEndpoint: string;
   private readonly headers: Record<string, string>;
 
   constructor(endpoint: string, headers?: Record<string, string>) {
-    this.endpoint = normalizeHTTPGenerationEndpoint(endpoint);
+    this.generationEndpoint = normalizeHTTPGenerationEndpoint(endpoint);
+    this.workflowStepEndpoint = normalizeHTTPWorkflowStepEndpoint(endpoint);
     // Resolve the User-Agent like the gRPC exporter: a non-blank caller override
     // (case-insensitive) wins, otherwise the SDK default. A blank/whitespace
     // override is dropped so it can't blank out the default.
@@ -37,7 +43,7 @@ export class HTTPGenerationExporter implements GenerationExporter {
   }
 
   async exportGenerations(request: ExportGenerationsRequest): Promise<ExportGenerationsResponse> {
-    const response = await fetch(this.endpoint, {
+    const response = await fetch(this.generationEndpoint, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
@@ -55,6 +61,27 @@ export class HTTPGenerationExporter implements GenerationExporter {
 
     const payload = (await response.json()) as unknown;
     return parseExportGenerationsResponse(payload, request);
+  }
+
+  async exportWorkflowSteps(request: ExportWorkflowStepsRequest): Promise<ExportWorkflowStepsResponse> {
+    const response = await fetch(this.workflowStepEndpoint, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...this.headers,
+      },
+      body: JSON.stringify({
+        workflow_steps: request.workflowSteps.map(mapWorkflowStepToProtoJSON),
+      }),
+    });
+
+    if (!response.ok) {
+      const responseText = (await response.text()).trim();
+      throw new Error(`http workflow step export status ${response.status}: ${responseText}`);
+    }
+
+    const payload = (await response.json()) as unknown;
+    return parseExportWorkflowStepsResponse(payload, request);
   }
 }
 
@@ -88,9 +115,19 @@ function parseExportGenerationsResponse(
 }
 
 const HTTP_GENERATION_EXPORT_PATH = '/api/v1/generations:export';
+const HTTP_WORKFLOW_STEP_EXPORT_PATH = '/api/v1/workflow-steps:export';
 
 /** @internal Exported for tests; not part of the public API. */
 export function normalizeHTTPGenerationEndpoint(endpoint: string): string {
+  return normalizeHTTPEndpoint(endpoint, HTTP_GENERATION_EXPORT_PATH);
+}
+
+/** @internal Exported for tests; not part of the public API. */
+export function normalizeHTTPWorkflowStepEndpoint(endpoint: string): string {
+  return normalizeHTTPEndpoint(endpoint, HTTP_WORKFLOW_STEP_EXPORT_PATH, HTTP_GENERATION_EXPORT_PATH);
+}
+
+function normalizeHTTPEndpoint(endpoint: string, defaultPath: string, siblingPath?: string): string {
   const trimmed = endpoint.trim();
   if (trimmed.length === 0) {
     throw new Error('generation export endpoint is required');
@@ -107,8 +144,11 @@ export function normalizeHTTPGenerationEndpoint(endpoint: string): string {
     const detail = e instanceof Error ? e.message : String(e);
     throw new Error(`parse generation export endpoint "${endpoint}": ${detail}`);
   }
+  const comparablePath = url.pathname.replace(/\/+$/, '');
   if (url.pathname === '' || url.pathname === '/') {
-    url.pathname = HTTP_GENERATION_EXPORT_PATH;
+    url.pathname = defaultPath;
+  } else if (siblingPath !== undefined && comparablePath === siblingPath) {
+    url.pathname = defaultPath;
   }
   return url.toString();
 }
@@ -166,6 +206,62 @@ function mapGenerationToProtoJSON(generation: Generation): Record<string, unknow
     proto.effective_version = effectiveVersion;
   }
 
+  return proto;
+}
+
+function parseExportWorkflowStepsResponse(
+  payload: unknown,
+  request: ExportWorkflowStepsRequest,
+): ExportWorkflowStepsResponse {
+  if (!isRecord(payload) || !Array.isArray(payload.results)) {
+    throw new Error('invalid workflow step export response payload');
+  }
+
+  const results: ExportWorkflowStepResult[] = payload.results.map((result, index) => {
+    if (!isRecord(result)) {
+      throw new Error('invalid workflow step export result payload');
+    }
+
+    const fallbackStepID = request.workflowSteps[index]?.id ?? '';
+    return {
+      stepId:
+        typeof result.stepId === 'string'
+          ? result.stepId
+          : typeof result.step_id === 'string'
+            ? result.step_id
+            : fallbackStepID,
+      accepted: Boolean(result.accepted),
+      error: typeof result.error === 'string' ? result.error : undefined,
+    };
+  });
+
+  return { results };
+}
+
+function mapWorkflowStepToProtoJSON(step: WorkflowStep): Record<string, unknown> {
+  const proto: Record<string, unknown> = {
+    id: step.id,
+    conversation_id: step.conversationId,
+    step_name: step.stepName,
+    framework: step.framework ?? '',
+    input_state: normalizeMetadata(step.inputState),
+    output_state: normalizeMetadata(step.outputState),
+    error: step.error ?? '',
+    tags: step.tags ?? {},
+    linked_generation_ids: step.linkedGenerationIds ?? [],
+    parent_step_ids: step.parentStepIds ?? [],
+    agent_name: step.agentName ?? '',
+    agent_version: step.agentVersion ?? '',
+    trace_id: step.traceId ?? '',
+    span_id: step.spanId ?? '',
+    metadata: normalizeMetadata(step.metadata),
+  };
+  if (step.startedAt !== undefined) {
+    proto.started_at = step.startedAt.toISOString();
+  }
+  if (step.completedAt !== undefined) {
+    proto.completed_at = step.completedAt.toISOString();
+  }
   return proto;
 }
 

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -123,6 +123,23 @@ export interface ExportGenerationsResponse {
   results: ExportGenerationResult[];
 }
 
+/** Per-workflow-step ingest result. */
+export interface ExportWorkflowStepResult {
+  stepId: string;
+  accepted: boolean;
+  error?: string;
+}
+
+/** Workflow-step export request payload. */
+export interface ExportWorkflowStepsRequest {
+  workflowSteps: WorkflowStep[];
+}
+
+/** Workflow-step export response payload. */
+export interface ExportWorkflowStepsResponse {
+  results: ExportWorkflowStepResult[];
+}
+
 /** Allowed conversation rating values. */
 export type ConversationRatingValue = 'CONVERSATION_RATING_VALUE_GOOD' | 'CONVERSATION_RATING_VALUE_BAD';
 
@@ -170,6 +187,7 @@ export interface SubmitConversationRatingResponse {
 /** Pluggable generation exporter interface. */
 export interface GenerationExporter {
   exportGenerations(request: ExportGenerationsRequest): Promise<ExportGenerationsResponse>;
+  exportWorkflowSteps(request: ExportWorkflowStepsRequest): Promise<ExportWorkflowStepsResponse>;
   shutdown?(): Promise<void> | void;
 }
 
@@ -447,6 +465,27 @@ export interface Generation {
   callError?: string;
 }
 
+/** Workflow execution node exported beside generations. */
+export interface WorkflowStep {
+  id: string;
+  conversationId: string;
+  stepName: string;
+  framework?: string;
+  startedAt?: Date;
+  completedAt?: Date;
+  inputState?: Record<string, unknown>;
+  outputState?: Record<string, unknown>;
+  error?: string;
+  tags?: Record<string, string>;
+  linkedGenerationIds?: string[];
+  parentStepIds?: string[];
+  agentName?: string;
+  agentVersion?: string;
+  traceId?: string;
+  spanId?: string;
+  metadata?: Record<string, unknown>;
+}
+
 /** Tool execution start seed fields. */
 export interface ToolExecutionStart {
   toolName: string;
@@ -542,8 +581,10 @@ export interface ToolExecutionRecorder {
 /** In-memory snapshot for tests/debugging. */
 export interface SigilDebugSnapshot {
   generations: Generation[];
+  workflowSteps: WorkflowStep[];
   toolExecutions: ToolExecution[];
   queueSize: number;
+  workflowStepQueueSize: number;
 }
 
 /** Callback form used by recorder helper APIs. */

--- a/js/src/utils.ts
+++ b/js/src/utils.ts
@@ -13,6 +13,7 @@ import type {
   ToolExecution,
   ToolExecutionResult,
   ToolExecutionStart,
+  WorkflowStep,
 } from './types.js';
 
 const textEncoder = new TextEncoder();
@@ -116,6 +117,26 @@ export function validateEmbeddingResult(result: EmbeddingResult): Error | undefi
   }
   if (result.dimensions !== undefined && result.dimensions <= 0) {
     return new Error('embedding.dimensions must be > 0');
+  }
+  return undefined;
+}
+
+export function validateWorkflowStep(step: WorkflowStep): Error | undefined {
+  if (step.id.trim().length === 0) {
+    return new Error('workflow step id is required');
+  }
+  if (step.conversationId.trim().length === 0) {
+    return new Error('workflow step conversationId is required');
+  }
+  if (step.stepName.trim().length === 0) {
+    return new Error('workflow step stepName is required');
+  }
+  if (
+    step.startedAt !== undefined &&
+    step.completedAt !== undefined &&
+    step.completedAt.getTime() < step.startedAt.getTime()
+  ) {
+    return new Error('workflow step completedAt must not be earlier than startedAt');
   }
   return undefined;
 }
@@ -244,6 +265,20 @@ export function cloneToolExecutionResult(result: ToolExecutionResult): ToolExecu
   return {
     ...result,
     completedAt: result.completedAt ? new Date(result.completedAt) : undefined,
+  };
+}
+
+export function cloneWorkflowStep(step: WorkflowStep): WorkflowStep {
+  return {
+    ...step,
+    startedAt: step.startedAt ? new Date(step.startedAt) : undefined,
+    completedAt: step.completedAt ? new Date(step.completedAt) : undefined,
+    inputState: step.inputState ? { ...step.inputState } : undefined,
+    outputState: step.outputState ? { ...step.outputState } : undefined,
+    tags: step.tags ? { ...step.tags } : undefined,
+    linkedGenerationIds: step.linkedGenerationIds ? [...step.linkedGenerationIds] : undefined,
+    parentStepIds: step.parentStepIds ? [...step.parentStepIds] : undefined,
+    metadata: step.metadata ? { ...step.metadata } : undefined,
   };
 }
 

--- a/js/test/client.runtime.test.mjs
+++ b/js/test/client.runtime.test.mjs
@@ -218,6 +218,25 @@ test('workflow step enqueue validates raw input before defaulting timestamps', a
   }
 });
 
+test('workflow step enqueue rejection does not record the step in the debug snapshot', async () => {
+  const exporter = new MockGenerationExporter();
+  const client = newClient(exporter, { batchSize: 10, flushIntervalMs: 60_000, queueSize: 1 });
+
+  try {
+    client.enqueueWorkflowStep({ id: 'wfs-1', conversationId: 'c1', stepName: 'route' });
+    // Queue size is 1 and the worker has not flushed, so the second enqueue
+    // is rejected. The rejected step must not appear in the debug snapshot.
+    assert.throws(
+      () => client.enqueueWorkflowStep({ id: 'wfs-2', conversationId: 'c1', stepName: 'answer' }),
+      /workflow step queue is full/,
+    );
+    assert.equal(client.debugSnapshot().workflowSteps.length, 1);
+    assert.equal(client.debugSnapshot().workflowSteps[0].id, 'wfs-1');
+  } finally {
+    await client.shutdown();
+  }
+});
+
 test('flush retries failed workflow step exports with backoff and succeeds', async () => {
   const exporter = new MockGenerationExporter();
   exporter.workflowStepFailuresBeforeSuccess = 2;

--- a/js/test/client.runtime.test.mjs
+++ b/js/test/client.runtime.test.mjs
@@ -6,7 +6,9 @@ import { defaultConfig, SigilClient } from '../.test-dist/index.js';
 
 class MockGenerationExporter {
   requests = [];
+  workflowStepRequests = [];
   attempts = 0;
+  workflowStepAttempts = 0;
   shutdownCalls = 0;
 
   constructor(failuresBeforeSuccess = 0) {
@@ -25,6 +27,23 @@ class MockGenerationExporter {
     return {
       results: request.generations.map((generation) => ({
         generationId: generation.id,
+        accepted: true,
+      })),
+    };
+  }
+
+  async exportWorkflowSteps(request) {
+    this.workflowStepAttempts++;
+    this.workflowStepRequests.push(structuredClone(request));
+
+    if (this.workflowStepFailuresBeforeSuccess > 0) {
+      this.workflowStepFailuresBeforeSuccess--;
+      throw new Error('forced workflow-step export failure');
+    }
+
+    return {
+      results: request.workflowSteps.map((step) => ({
+        stepId: step.id,
         accepted: true,
       })),
     };
@@ -91,6 +110,165 @@ test('flush retries failed exports with backoff and succeeds', async () => {
   }
 });
 
+test('flushes workflow step exports and records debug snapshots', async () => {
+  const exporter = new MockGenerationExporter();
+  const client = newClient(exporter, {
+    batchSize: 10,
+    flushIntervalMs: 60_000,
+  });
+
+  try {
+    client.enqueueWorkflowStep({
+      id: 'wfs-route',
+      conversationId: 'conv-workflow',
+      stepName: 'route',
+      framework: 'custom',
+      startedAt: new Date(Date.UTC(2026, 1, 12, 10, 0, 0)),
+      completedAt: new Date(Date.UTC(2026, 1, 12, 10, 0, 1)),
+      linkedGenerationIds: ['gen-route'],
+    });
+
+    assert.equal(client.debugSnapshot().workflowSteps.length, 1);
+    assert.equal(client.debugSnapshot().workflowStepQueueSize, 1);
+
+    await client.flush();
+
+    assert.equal(exporter.workflowStepRequests.length, 1);
+    assert.equal(exporter.workflowStepRequests[0].workflowSteps[0].id, 'wfs-route');
+    assert.equal(client.debugSnapshot().workflowStepQueueSize, 0);
+  } finally {
+    await client.shutdown();
+  }
+});
+
+test('workflow step enqueue defaults timestamps with client clock and merges tags', async () => {
+  const exporter = new MockGenerationExporter();
+  const now = new Date(Date.UTC(2026, 1, 12, 10, 0, 0));
+  const client = newClient(
+    exporter,
+    {
+      batchSize: 10,
+      flushIntervalMs: 60_000,
+    },
+    {
+      now: () => new Date(now),
+      tags: {
+        client: 'tag',
+        shared: 'client',
+      },
+    },
+  );
+
+  try {
+    client.enqueueWorkflowStep({
+      id: 'wfs-defaults',
+      conversationId: 'conv-workflow',
+      stepName: 'route',
+      tags: {
+        shared: 'step',
+      },
+    });
+
+    const snapshotStep = client.debugSnapshot().workflowSteps[0];
+    assert.equal(snapshotStep.startedAt.toISOString(), now.toISOString());
+    assert.equal(snapshotStep.completedAt.toISOString(), now.toISOString());
+    assert.deepEqual(snapshotStep.tags, {
+      client: 'tag',
+      shared: 'step',
+    });
+
+    await client.flush();
+
+    const exportedStep = exporter.workflowStepRequests[0].workflowSteps[0];
+    assert.equal(exportedStep.startedAt.toISOString(), now.toISOString());
+    assert.equal(exportedStep.completedAt.toISOString(), now.toISOString());
+    assert.deepEqual(exportedStep.tags, {
+      client: 'tag',
+      shared: 'step',
+    });
+  } finally {
+    await client.shutdown();
+  }
+});
+
+test('workflow step enqueue validates raw input before defaulting timestamps', async () => {
+  const exporter = new MockGenerationExporter();
+  const now = new Date(Date.UTC(2026, 1, 12, 10, 0, 0));
+  const completedAt = new Date(Date.UTC(2020, 0, 1, 0, 0, 0));
+  const client = newClient(exporter, { batchSize: 10, flushIntervalMs: 60_000 }, { now: () => new Date(now) });
+
+  try {
+    // Only completedAt is supplied. The completed < started rule must not fire
+    // (started is unset), and defaulting started to now() must not retroactively
+    // reject it. Matches Go and Python.
+    client.enqueueWorkflowStep({
+      id: 'wfs-completed-only',
+      conversationId: 'conv-workflow',
+      stepName: 'route',
+      completedAt,
+    });
+
+    await client.flush();
+
+    const exportedStep = exporter.workflowStepRequests[0].workflowSteps[0];
+    assert.equal(exportedStep.startedAt.toISOString(), now.toISOString());
+    assert.equal(exportedStep.completedAt.toISOString(), completedAt.toISOString());
+  } finally {
+    await client.shutdown();
+  }
+});
+
+test('flush retries failed workflow step exports with backoff and succeeds', async () => {
+  const exporter = new MockGenerationExporter();
+  exporter.workflowStepFailuresBeforeSuccess = 2;
+  const client = newClient(exporter, {
+    batchSize: 10,
+    flushIntervalMs: 60_000,
+    maxRetries: 2,
+    initialBackoffMs: 1,
+    maxBackoffMs: 1,
+  });
+
+  try {
+    client.enqueueWorkflowStep({
+      id: 'wfs-retry',
+      conversationId: 'conv-workflow',
+      stepName: 'answer',
+    });
+
+    await client.flush();
+    assert.equal(exporter.workflowStepAttempts, 3);
+    assert.equal(exporter.workflowStepRequests.length, 3);
+  } finally {
+    await client.shutdown();
+  }
+});
+
+test('flush attempts workflow steps even when generation export fails', async () => {
+  const exporter = new MockGenerationExporter(1);
+  const client = newClient(exporter, {
+    batchSize: 10,
+    flushIntervalMs: 60_000,
+    maxRetries: 0,
+  });
+
+  try {
+    endWithSuccess(client.startGeneration(seedGeneration(11)), 11);
+    client.enqueueWorkflowStep({
+      id: 'wfs-isolated',
+      conversationId: 'conv-workflow',
+      stepName: 'route',
+    });
+
+    await assert.rejects(client.flush(), /forced export failure/);
+    assert.equal(exporter.requests.length, 1);
+    assert.equal(exporter.workflowStepRequests.length, 1);
+    assert.equal(exporter.workflowStepRequests[0].workflowSteps[0].id, 'wfs-isolated');
+  } finally {
+    await client.shutdown();
+  }
+});
+
 test('shutdown flushes pending generation batch', async () => {
   const exporter = new MockGenerationExporter();
   const client = newClient(exporter, {
@@ -104,6 +282,26 @@ test('shutdown flushes pending generation batch', async () => {
 
   assert.equal(exporter.requests.length, 1);
   assert.equal(exporter.requests[0].generations.length, 1);
+  assert.equal(exporter.shutdownCalls, 1);
+});
+
+test('shutdown flushes pending workflow step batch', async () => {
+  const exporter = new MockGenerationExporter();
+  const client = newClient(exporter, {
+    batchSize: 10,
+    flushIntervalMs: 60_000,
+  });
+
+  client.enqueueWorkflowStep({
+    id: 'wfs-shutdown',
+    conversationId: 'conv-workflow',
+    stepName: 'finalize',
+  });
+
+  await client.shutdown();
+
+  assert.equal(exporter.workflowStepRequests.length, 1);
+  assert.equal(exporter.workflowStepRequests[0].workflowSteps.length, 1);
   assert.equal(exporter.shutdownCalls, 1);
 });
 
@@ -132,6 +330,56 @@ test('queue-full recorder local error is exposed and callback style throws', asy
     );
   } finally {
     await client.shutdown();
+  }
+});
+
+test('workflow step queue full and payload size errors are surfaced locally', async () => {
+  const exporter = new MockGenerationExporter();
+  const queueClient = newClient(exporter, {
+    batchSize: 10,
+    queueSize: 1,
+    flushIntervalMs: 60_000,
+  });
+
+  try {
+    queueClient.enqueueWorkflowStep({
+      id: 'wfs-queued',
+      conversationId: 'conv-workflow',
+      stepName: 'route',
+    });
+    assert.throws(
+      () =>
+        queueClient.enqueueWorkflowStep({
+          id: 'wfs-overflow',
+          conversationId: 'conv-workflow',
+          stepName: 'answer',
+        }),
+      /workflow step queue is full/,
+    );
+  } finally {
+    await queueClient.shutdown();
+  }
+
+  const payloadClient = newClient(new MockGenerationExporter(), {
+    batchSize: 10,
+    payloadMaxBytes: 10,
+    flushIntervalMs: 60_000,
+  });
+  try {
+    assert.throws(
+      () =>
+        payloadClient.enqueueWorkflowStep({
+          id: 'wfs-large',
+          conversationId: 'conv-workflow',
+          stepName: 'route',
+          inputState: {
+            prompt: 'this payload is intentionally too large',
+          },
+        }),
+      /workflow step payload exceeds max bytes/,
+    );
+  } finally {
+    await payloadClient.shutdown();
   }
 });
 
@@ -251,10 +499,11 @@ test('embedding recorder does not enqueue generation exports', async () => {
   }
 });
 
-function newClient(generationExporter, overrides) {
+function newClient(generationExporter, overrides, clientOverrides = {}) {
   const defaults = defaultConfig();
   return new SigilClient({
     tracer: trace.getTracer('sigil-sdk-js-test'),
+    ...clientOverrides,
     generationExport: {
       ...defaults.generationExport,
       ...overrides,

--- a/js/test/client.transport.test.mjs
+++ b/js/test/client.transport.test.mjs
@@ -139,6 +139,106 @@ test('gRPC transport roundtrip preserves full generation payload shape', async (
   }
 });
 
+test('HTTP transport roundtrip exports workflow steps to sibling endpoint', async () => {
+  const receivedWorkflowSteps = [];
+  const receivedPaths = [];
+
+  const server = createServer(async (request, response) => {
+    receivedPaths.push(request.url);
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+
+    const payload = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    for (const step of payload.workflow_steps ?? []) {
+      receivedWorkflowSteps.push(step);
+    }
+
+    response.writeHead(202, { 'content-type': 'application/json' });
+    response.end(
+      JSON.stringify({
+        results: (payload.workflow_steps ?? []).map((step) => ({
+          step_id: step.id,
+          accepted: true,
+        })),
+      }),
+    );
+  });
+
+  await listen(server);
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('failed to resolve transport test server address');
+  }
+
+  const defaults = defaultConfig();
+  const client = new SigilClient({
+    tracer: trace.getTracer('sigil-sdk-js-test'),
+    generationExport: {
+      ...defaults.generationExport,
+      protocol: 'http',
+      endpoint: `http://127.0.0.1:${address.port}/api/v1/generations:export`,
+      batchSize: 1,
+      flushIntervalMs: 60_000,
+      maxRetries: 1,
+      initialBackoffMs: 1,
+      maxBackoffMs: 1,
+    },
+  });
+
+  try {
+    const step = workflowStepFromSeed(1);
+    client.enqueueWorkflowStep(step);
+    await waitFor(() => receivedWorkflowSteps.length === 1, 2_000);
+
+    assert.equal(receivedPaths[0], '/api/v1/workflow-steps:export');
+    assert.deepEqual(canonicalizeProtoJSONWorkflowStep(receivedWorkflowSteps[0]), canonicalizeSDKWorkflowStep(step));
+  } finally {
+    await client.shutdown();
+    await close(server);
+  }
+});
+
+test('gRPC transport roundtrip exports workflow steps through workflow service', async () => {
+  const receivedWorkflowSteps = [];
+  const grpcServer = await startGRPCServer(
+    () => {},
+    (request) => {
+      for (const step of request.workflowSteps ?? []) {
+        receivedWorkflowSteps.push(step);
+      }
+    },
+  );
+
+  const defaults = defaultConfig();
+  const client = new SigilClient({
+    tracer: trace.getTracer('sigil-sdk-js-test'),
+    generationExport: {
+      ...defaults.generationExport,
+      protocol: 'grpc',
+      endpoint: `127.0.0.1:${grpcServer.port}`,
+      insecure: true,
+      batchSize: 1,
+      flushIntervalMs: 60_000,
+      maxRetries: 1,
+      initialBackoffMs: 1,
+      maxBackoffMs: 1,
+    },
+  });
+
+  try {
+    const step = workflowStepFromSeed(2);
+    client.enqueueWorkflowStep(step);
+    await waitFor(() => receivedWorkflowSteps.length === 1, 2_000);
+
+    assert.deepEqual(canonicalizeProtoWorkflowStep(receivedWorkflowSteps[0]), canonicalizeSDKWorkflowStep(step));
+  } finally {
+    await client.shutdown();
+    await stopGRPCServer(grpcServer.server);
+  }
+});
+
 test('gRPC transport maps typed message parts to proto payloads', async () => {
   const receivedGenerations = [];
   const grpcServer = await startGRPCServer((request) => {
@@ -502,6 +602,39 @@ function payloadFromSeed(seed) {
   };
 }
 
+function workflowStepFromSeed(seed) {
+  return {
+    id: `wfs-${seed}`,
+    conversationId: `conv-${seed}`,
+    stepName: `step-${seed}`,
+    framework: 'custom',
+    startedAt: new Date(Date.UTC(2026, 1, 12, 11, seed, 0)),
+    completedAt: new Date(Date.UTC(2026, 1, 12, 11, seed, 1)),
+    inputState: {
+      input: `input-${seed}`,
+      nested: { seed },
+    },
+    outputState: {
+      output: `output-${seed}`,
+    },
+    error: seed % 2 === 0 ? `error-${seed}` : undefined,
+    tags: {
+      env: 'test',
+      seed: String(seed),
+    },
+    linkedGenerationIds: [`gen-${seed}`],
+    parentStepIds: seed > 1 ? [`wfs-${seed - 1}`] : [],
+    agentName: `agent-${seed}`,
+    agentVersion: `v-${seed}`,
+    traceId: `trace-${seed}`,
+    spanId: `span-${seed}`,
+    metadata: {
+      source: 'transport-test',
+      seed,
+    },
+  };
+}
+
 function canonicalizeSDKGeneration(generation) {
   const usage = generation.usage ?? {};
   const inputTokens = asNumber(usage.inputTokens);
@@ -699,6 +832,75 @@ function canonicalizeProtoGeneration(generation) {
       uri: artifact.uri ?? '',
     })),
     callError: generation.callError ?? '',
+  };
+}
+
+function canonicalizeSDKWorkflowStep(step) {
+  return {
+    id: step.id,
+    conversationId: step.conversationId,
+    stepName: step.stepName,
+    framework: step.framework ?? '',
+    startedAt: new Date(step.startedAt).toISOString(),
+    completedAt: new Date(step.completedAt).toISOString(),
+    inputState: step.inputState ?? {},
+    outputState: step.outputState ?? {},
+    error: step.error ?? '',
+    tags: step.tags ?? {},
+    linkedGenerationIds: step.linkedGenerationIds ?? [],
+    parentStepIds: step.parentStepIds ?? [],
+    agentName: step.agentName ?? '',
+    agentVersion: step.agentVersion ?? '',
+    traceId: step.traceId ?? '',
+    spanId: step.spanId ?? '',
+    metadata: step.metadata ?? {},
+  };
+}
+
+function canonicalizeProtoJSONWorkflowStep(step) {
+  if (!isRecord(step)) {
+    throw new Error('invalid proto-json workflow step payload');
+  }
+  return {
+    id: asString(step.id),
+    conversationId: asString(step.conversation_id),
+    stepName: asString(step.step_name),
+    framework: asString(step.framework),
+    startedAt: timestampStringToISO(step.started_at),
+    completedAt: timestampStringToISO(step.completed_at),
+    inputState: normalizeProtoJSONMetadata(step.input_state),
+    outputState: normalizeProtoJSONMetadata(step.output_state),
+    error: asString(step.error),
+    tags: normalizeProtoJSONStringMap(step.tags),
+    linkedGenerationIds: Array.isArray(step.linked_generation_ids) ? step.linked_generation_ids.map(asString) : [],
+    parentStepIds: Array.isArray(step.parent_step_ids) ? step.parent_step_ids.map(asString) : [],
+    agentName: asString(step.agent_name),
+    agentVersion: asString(step.agent_version),
+    traceId: asString(step.trace_id),
+    spanId: asString(step.span_id),
+    metadata: normalizeProtoJSONMetadata(step.metadata),
+  };
+}
+
+function canonicalizeProtoWorkflowStep(step) {
+  return {
+    id: step.id ?? '',
+    conversationId: step.conversationId ?? '',
+    stepName: step.stepName ?? '',
+    framework: step.framework ?? '',
+    startedAt: timestampToISO(step.startedAt),
+    completedAt: timestampToISO(step.completedAt),
+    inputState: normalizeProtoMetadata(step.inputState),
+    outputState: normalizeProtoMetadata(step.outputState),
+    error: step.error ?? '',
+    tags: step.tags ?? {},
+    linkedGenerationIds: step.linkedGenerationIds ?? [],
+    parentStepIds: step.parentStepIds ?? [],
+    agentName: step.agentName ?? '',
+    agentVersion: step.agentVersion ?? '',
+    traceId: step.traceId ?? '',
+    spanId: step.spanId ?? '',
+    metadata: normalizeProtoMetadata(step.metadata),
   };
 }
 
@@ -945,18 +1147,30 @@ function close(server) {
   });
 }
 
-async function startGRPCServer(onRequest) {
+async function startGRPCServer(onRequest, onWorkflowStepRequest = () => {}) {
   const packageDefinition = await protoLoader.load(protoPath, protoLoadOptions);
   const loaded = grpc.loadPackageDefinition(packageDefinition);
-  const service = loaded.sigil.v1.GenerationIngestService;
+  const generationService = loaded.sigil.v1.GenerationIngestService;
+  const workflowStepService = loaded.sigil.v1.WorkflowStepIngestService;
 
   const server = new grpc.Server();
-  server.addService(service.service, {
+  server.addService(generationService.service, {
     ExportGenerations(call, callback) {
       onRequest(call.request, call.metadata.getMap());
       callback(null, {
         results: (call.request.generations ?? []).map((generation) => ({
           generationId: generation.id,
+          accepted: true,
+        })),
+      });
+    },
+  });
+  server.addService(workflowStepService.service, {
+    ExportWorkflowSteps(call, callback) {
+      onWorkflowStepRequest(call.request, call.metadata.getMap());
+      callback(null, {
+        results: (call.request.workflowSteps ?? []).map((step) => ({
+          stepId: step.id,
           accepted: true,
         })),
       });

--- a/js/test/conformance.test.mjs
+++ b/js/test/conformance.test.mjs
@@ -160,6 +160,56 @@ test('conformance sync roundtrip semantics', async () => {
   }
 });
 
+test('conformance workflow step roundtrip semantics', async () => {
+  const now = new Date(Date.UTC(2026, 2, 12, 12, 0, 0));
+  const env = await createConformanceEnv({
+    clientConfig: {
+      now: () => new Date(now),
+      tags: {
+        client: 'tag',
+        shared: 'client',
+      },
+    },
+  });
+
+  try {
+    env.client.enqueueWorkflowStep({
+      id: 'wfs-roundtrip',
+      conversationId: 'conv-workflow',
+      stepName: 'route',
+      framework: 'custom',
+      inputState: { prompt: 'hello', count: 1 },
+      outputState: { route: 'answer' },
+      tags: { shared: 'step' },
+      linkedGenerationIds: ['gen-roundtrip'],
+      parentStepIds: ['wfs-root'],
+      agentName: 'agent-workflow',
+      agentVersion: 'v1',
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: '0123456789abcdef',
+      metadata: { run_id: 'run-1' },
+    });
+
+    await env.client.shutdown();
+
+    const step = env.singleWorkflowStep();
+    assert.equal(step.id, 'wfs-roundtrip');
+    assert.equal(step.conversationId, 'conv-workflow');
+    assert.equal(step.stepName, 'route');
+    assert.equal(toDate(step.startedAt).toISOString(), now.toISOString());
+    assert.equal(toDate(step.completedAt).toISOString(), now.toISOString());
+    assert.equal(step.tags?.client, 'tag');
+    assert.equal(step.tags?.shared, 'step');
+    assert.equal(step.inputState?.fields?.prompt?.stringValue, 'hello');
+    assert.equal(step.outputState?.fields?.route?.stringValue, 'answer');
+    assert.equal(step.metadata?.fields?.run_id?.stringValue, 'run-1');
+    assert.deepEqual(step.linkedGenerationIds, ['gen-roundtrip']);
+    assert.deepEqual(step.parentStepIds, ['wfs-root']);
+  } finally {
+    await env.close();
+  }
+});
+
 for (const testCase of [
   {
     name: 'explicit wins',
@@ -676,8 +726,14 @@ test('conformance shutdown flush semantics', async () => {
 
 async function createConformanceEnv(options = {}) {
   const receivedRequests = [];
-  const grpcServer = await startGRPCServer((request) => {
-    receivedRequests.push(request);
+  const receivedWorkflowStepRequests = [];
+  const grpcServer = await startGRPCServer({
+    onGenerationRequest(request) {
+      receivedRequests.push(request);
+    },
+    onWorkflowStepRequest(request) {
+      receivedWorkflowStepRequests.push(request);
+    },
   });
 
   let ratingPath = '';
@@ -732,6 +788,7 @@ async function createConformanceEnv(options = {}) {
   const client = new SigilClient({
     tracer: tracerProvider.getTracer('sigil-conformance-test'),
     meter: meterProvider.getMeter('sigil-conformance-test'),
+    ...(options.clientConfig ?? {}),
     generationExport: {
       ...defaults.generationExport,
       protocol: 'grpc',
@@ -753,6 +810,7 @@ async function createConformanceEnv(options = {}) {
   return {
     client,
     receivedRequests,
+    receivedWorkflowStepRequests,
     get ratingPath() {
       return ratingPath;
     },
@@ -763,6 +821,11 @@ async function createConformanceEnv(options = {}) {
       assert.equal(receivedRequests.length, 1);
       assert.equal(receivedRequests[0].generations?.length, 1);
       return receivedRequests[0].generations[0];
+    },
+    singleWorkflowStep() {
+      assert.equal(receivedWorkflowStepRequests.length, 1);
+      assert.equal(receivedWorkflowStepRequests[0].workflowSteps?.length, 1);
+      return receivedWorkflowStepRequests[0].workflowSteps[0];
     },
     latestGenerationSpan() {
       const spans = spanExporter.getFinishedSpans().filter((span) => {
@@ -851,18 +914,36 @@ function close(server) {
   });
 }
 
-async function startGRPCServer(onRequest) {
+function toDate(timestamp) {
+  const seconds = Number(timestamp?.seconds ?? 0);
+  const nanos = Number(timestamp?.nanos ?? 0);
+  return new Date(seconds * 1000 + Math.floor(nanos / 1_000_000));
+}
+
+async function startGRPCServer({ onGenerationRequest, onWorkflowStepRequest }) {
   const packageDefinition = await protoLoader.load(protoPath, protoLoadOptions);
   const loaded = grpc.loadPackageDefinition(packageDefinition);
-  const service = loaded.sigil.v1.GenerationIngestService;
+  const generationService = loaded.sigil.v1.GenerationIngestService;
+  const workflowStepService = loaded.sigil.v1.WorkflowStepIngestService;
 
   const server = new grpc.Server();
-  server.addService(service.service, {
+  server.addService(generationService.service, {
     ExportGenerations(call, callback) {
-      onRequest(call.request, call.metadata.getMap());
+      onGenerationRequest(call.request, call.metadata.getMap());
       callback(null, {
         results: (call.request.generations ?? []).map((generation) => ({
           generationId: generation.id,
+          accepted: true,
+        })),
+      });
+    },
+  });
+  server.addService(workflowStepService.service, {
+    ExportWorkflowSteps(call, callback) {
+      onWorkflowStepRequest(call.request, call.metadata.getMap());
+      callback(null, {
+        results: (call.request.workflowSteps ?? []).map((step) => ({
+          stepId: step.id,
           accepted: true,
         })),
       });

--- a/js/test/exporter.http.test.mjs
+++ b/js/test/exporter.http.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { normalizeHTTPGenerationEndpoint } from '../.test-dist/exporters/http.js';
+import { normalizeHTTPGenerationEndpoint, normalizeHTTPWorkflowStepEndpoint } from '../.test-dist/exporters/http.js';
 
 const cases = [
   {
@@ -55,4 +55,23 @@ for (const tc of cases) {
 test('normalizeHTTPGenerationEndpoint: empty input throws', () => {
   assert.throws(() => normalizeHTTPGenerationEndpoint(''), /endpoint is required/);
   assert.throws(() => normalizeHTTPGenerationEndpoint('   '), /endpoint is required/);
+});
+
+test('normalizeHTTPWorkflowStepEndpoint: appends and rewrites workflow-step path', () => {
+  assert.equal(
+    normalizeHTTPWorkflowStepEndpoint('http://localhost:8080'),
+    'http://localhost:8080/api/v1/workflow-steps:export',
+  );
+  assert.equal(
+    normalizeHTTPWorkflowStepEndpoint('http://localhost:8080/api/v1/generations:export'),
+    'http://localhost:8080/api/v1/workflow-steps:export',
+  );
+  assert.equal(
+    normalizeHTTPWorkflowStepEndpoint('http://localhost:8080/api/v1/generations:export/'),
+    'http://localhost:8080/api/v1/workflow-steps:export',
+  );
+  assert.equal(
+    normalizeHTTPWorkflowStepEndpoint('http://localhost:8080/custom/ingest'),
+    'http://localhost:8080/custom/ingest',
+  );
 });

--- a/python/sigil_sdk/client.py
+++ b/python/sigil_sdk/client.py
@@ -69,7 +69,7 @@ from .models import (
     _metadata_key_content_capture_mode,
     tool_result_part,
 )
-from .proto_mapping import generation_to_proto
+from .proto_mapping import generation_to_proto, workflow_step_to_proto
 from .validation import validate_embedding_result, validate_embedding_start, validate_generation
 
 _span_attr_generation_id = "sigil.generation.id"
@@ -912,26 +912,50 @@ class Client:
             self._trigger_async_flush()
 
     def enqueue_workflow_step(self, step: WorkflowStep) -> None:
-        """Enqueues a fully-built ``WorkflowStep`` for background export.
+        """Enqueues a workflow execution node for background export.
 
-        This is a low-level primitive intended for advanced cases such as
-        forwarding pre-built steps from another system. For general use, prefer
-        a framework adapter (LangGraph, LangChain) or the upcoming
-        ``Client.start_workflow_step`` recorder API, which automatically
-        handles step IDs, timestamps, identity inheritance, and
-        ``linked_generation_ids`` for nested generations.
+        The step is normalized the same way generations are: timestamps default
+        to the client clock (UTC), client-level ``tags`` are merged in (the
+        step's own tags win on conflict), and the step is validated before it is
+        queued. This matches the Go and JS SDKs, so an identical input produces
+        an identical exported step across languages.
 
-        Design doc:
-        ``sigil/docs/design-docs/2026-05-07-workflow-step-recorder-api.md``
-        in the grafana/sigil repository.
+        For framework-driven capture prefer a framework adapter (LangGraph,
+        LangChain), which additionally handles step IDs, identity inheritance,
+        and ``linked_generation_ids`` for nested generations.
         """
         if self._shutting_down or self._closed:
             raise ClientShutdownError("sigil: client is shutting down")
+
+        # Validate the raw input before defaulting timestamps, matching Go and
+        # JS. The completed_at < started_at rule only fires when the caller
+        # supplied both; defaulting started_at to now() first would spuriously
+        # reject a step for which the caller only provided completed_at.
+        normalized = copy.deepcopy(step)
+        _validate_workflow_step(normalized)
+
+        normalized.started_at = (
+            _to_utc(normalized.started_at) if normalized.started_at is not None else _to_utc(self._now())
+        )
+        normalized.completed_at = (
+            _to_utc(normalized.completed_at) if normalized.completed_at is not None else normalized.started_at
+        )
+        if self._config.tags:
+            merged: dict[str, str] = dict(self._config.tags)
+            merged.update(normalized.tags)
+            normalized.tags = merged
+
+        max_payload_bytes = self._config.generation_export.payload_max_bytes
+        if max_payload_bytes > 0:
+            payload_size = workflow_step_to_proto(normalized).ByteSize()
+            if payload_size > max_payload_bytes:
+                raise EnqueueError(f"workflow step payload exceeds max bytes ({payload_size} > {max_payload_bytes})")
+
         should_trigger_flush = False
         with self._pending_lock:
             if len(self._pending_workflow_steps) >= self._config.generation_export.queue_size:
                 raise QueueFullError("sigil: workflow step queue is full")
-            self._pending_workflow_steps.append(copy.deepcopy(step))
+            self._pending_workflow_steps.append(normalized)
             if len(self._pending_workflow_steps) >= self._config.generation_export.batch_size:
                 should_trigger_flush = True
         if should_trigger_flush:
@@ -2093,6 +2117,17 @@ def _to_utc(value: datetime) -> datetime:
     if value.tzinfo is None:
         return value.replace(tzinfo=timezone.utc)
     return value.astimezone(timezone.utc)
+
+
+def _validate_workflow_step(step: WorkflowStep) -> None:
+    if not step.id.strip():
+        raise ValidationError("sigil workflow step validation failed: id is required")
+    if not step.conversation_id.strip():
+        raise ValidationError("sigil workflow step validation failed: conversation_id is required")
+    if not step.step_name.strip():
+        raise ValidationError("sigil workflow step validation failed: step_name is required")
+    if step.started_at is not None and step.completed_at is not None and step.completed_at < step.started_at:
+        raise ValidationError("sigil workflow step validation failed: completed_at must not be earlier than started_at")
 
 
 def _datetime_to_ns(value: datetime) -> int:

--- a/python/tests/test_conformance.py
+++ b/python/tests/test_conformance.py
@@ -7,6 +7,7 @@ import copy
 import json
 import socket
 import threading
+from collections.abc import Callable
 from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -40,6 +41,7 @@ from sigil_sdk import (
     ToolExecutionEnd,
     ToolExecutionStart,
     ToolResult,
+    WorkflowStep,
     with_agent_name,
     with_agent_version,
     with_conversation_title,
@@ -55,9 +57,13 @@ _span_attr_conversation_title = "sigil.conversation.title"
 _span_attr_user_id = "user.id"
 
 
-class _CapturingGenerationServicer(sigil_pb2_grpc.GenerationIngestServiceServicer):
+class _CapturingGenerationServicer(
+    sigil_pb2_grpc.GenerationIngestServiceServicer,
+    sigil_pb2_grpc.WorkflowStepIngestServiceServicer,
+):
     def __init__(self) -> None:
         self.requests: list[sigil_pb2.ExportGenerationsRequest] = []
+        self.workflow_step_requests: list[sigil_pb2.ExportWorkflowStepsRequest] = []
         self._lock = threading.Lock()
 
     def ExportGenerations(self, request, _context):  # noqa: N802
@@ -70,10 +76,24 @@ class _CapturingGenerationServicer(sigil_pb2_grpc.GenerationIngestServiceService
             ]
         )
 
+    def ExportWorkflowSteps(self, request, _context):  # noqa: N802
+        with self._lock:
+            self.workflow_step_requests.append(copy.deepcopy(request))
+        return sigil_pb2.ExportWorkflowStepsResponse(
+            results=[
+                sigil_pb2.ExportWorkflowStepResult(step_id=step.id, accepted=True) for step in request.workflow_steps
+            ]
+        )
+
     def single_generation(self) -> sigil_pb2.Generation:
         assert len(self.requests) == 1
         assert len(self.requests[0].generations) == 1
         return self.requests[0].generations[0]
+
+    def single_workflow_step(self) -> sigil_pb2.WorkflowStep:
+        assert len(self.workflow_step_requests) == 1
+        assert len(self.workflow_step_requests[0].workflow_steps) == 1
+        return self.workflow_step_requests[0].workflow_steps[0]
 
 
 class _RatingCaptureServer:
@@ -133,10 +153,18 @@ class _RatingCaptureServer:
 
 
 class _ConformanceEnv:
-    def __init__(self, *, batch_size: int = 1, flush_interval: timedelta | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        batch_size: int = 1,
+        flush_interval: timedelta | None = None,
+        now: Callable[[], datetime] | None = None,
+        tags: dict[str, str] | None = None,
+    ) -> None:
         self.servicer = _CapturingGenerationServicer()
         self.grpc_server = grpc.server(concurrent.futures.ThreadPoolExecutor(max_workers=2))
         sigil_pb2_grpc.add_GenerationIngestServiceServicer_to_server(self.servicer, self.grpc_server)
+        sigil_pb2_grpc.add_WorkflowStepIngestServiceServicer_to_server(self.servicer, self.grpc_server)
 
         sock = socket.socket()
         sock.bind(("127.0.0.1", 0))
@@ -169,6 +197,8 @@ class _ConformanceEnv:
                 meter=self.meter_provider.get_meter("sigil-conformance-test"),
                 generation_export=export_config,
                 api=ApiConfig(endpoint=self.rating_server.endpoint),
+                now=now,
+                tags=tags,
             )
         )
         self._closed = False
@@ -332,6 +362,56 @@ def test_conformance_sync_roundtrip_semantics() -> None:
             and point.attributes.get("gen_ai.token.type") == "input"
             for point in metrics["gen_ai.client.token.usage"].data_points
         )
+    finally:
+        env.shutdown()
+
+
+def test_conformance_workflow_step_roundtrip_semantics() -> None:
+    # Mirror the Go and JS conformance inputs exactly: no timestamps (to exercise
+    # enqueue-time defaulting to the client clock) and client-level tags that the
+    # step's own tags override on conflict.
+    now = datetime(2026, 3, 12, 12, 0, 0, tzinfo=timezone.utc)
+    env = _ConformanceEnv(
+        now=lambda: now,
+        tags={"client": "tag", "shared": "client"},
+    )
+    try:
+        env.client.enqueue_workflow_step(
+            WorkflowStep(
+                id="wfs-roundtrip",
+                conversation_id="conv-workflow",
+                step_name="route",
+                framework="custom",
+                input_state={"prompt": "hello", "count": 1},
+                output_state={"route": "answer"},
+                tags={"shared": "step"},
+                linked_generation_ids=["gen-roundtrip"],
+                parent_step_ids=["wfs-root"],
+                agent_name="agent-workflow",
+                agent_version="v1",
+                trace_id="0123456789abcdef0123456789abcdef",
+                span_id="0123456789abcdef",
+                metadata={"run_id": "run-1"},
+            )
+        )
+        env.shutdown()
+
+        step = env.servicer.single_workflow_step()
+        assert step.id == "wfs-roundtrip"
+        assert step.conversation_id == "conv-workflow"
+        assert step.step_name == "route"
+        assert step.framework == "custom"
+        assert step.started_at.ToDatetime(tzinfo=timezone.utc) == now
+        assert step.completed_at.ToDatetime(tzinfo=timezone.utc) == now
+        assert step.tags["client"] == "tag"
+        assert step.tags["shared"] == "step"
+        assert step.input_state.fields["prompt"].string_value == "hello"
+        assert step.output_state.fields["route"].string_value == "answer"
+        assert list(step.linked_generation_ids) == ["gen-roundtrip"]
+        assert list(step.parent_step_ids) == ["wfs-root"]
+        assert step.agent_name == "agent-workflow"
+        assert step.agent_version == "v1"
+        assert step.metadata.fields["run_id"].string_value == "run-1"
     finally:
         env.shutdown()
 

--- a/python/tests/test_workflow_steps.py
+++ b/python/tests/test_workflow_steps.py
@@ -12,7 +12,9 @@ from uuid import uuid4
 from sigil_sdk import (
     Client,
     ClientConfig,
+    EnqueueError,
     GenerationExportConfig,
+    ValidationError,
     WorkflowStep,
 )
 from sigil_sdk.exporters.http import HTTPGenerationExporter, _normalize_endpoint
@@ -255,6 +257,113 @@ def test_client_retries_workflow_step_export() -> None:
 
     assert len(exporter.wf_batches) == 1
     assert exporter.wf_batches[0][0].id == "wfs_b"
+
+
+def test_enqueue_workflow_step_defaults_timestamps_and_merges_tags() -> None:
+    now = datetime(2026, 3, 12, 12, 0, 0, tzinfo=timezone.utc)
+    exporter = _RecordingExporter()
+    client = Client(
+        ClientConfig(
+            now=lambda: now,
+            tags={"client": "tag", "shared": "client"},
+            generation_export=GenerationExportConfig(
+                batch_size=10,
+                flush_interval=timedelta(0),
+            ),
+            generation_exporter=exporter,
+        )
+    )
+    try:
+        # No timestamps supplied: both default to the client clock. The step's
+        # own tag overrides the client-level tag on conflict.
+        client.enqueue_workflow_step(
+            WorkflowStep(id="wfs_a", conversation_id="c1", step_name="route", tags={"shared": "step"})
+        )
+        client.flush()
+    finally:
+        client.shutdown()
+
+    step = exporter.wf_batches[0][0]
+    assert step.started_at == now
+    assert step.completed_at == now
+    assert step.tags == {"client": "tag", "shared": "step"}
+
+
+def test_enqueue_workflow_step_rejects_invalid_step() -> None:
+    exporter = _RecordingExporter()
+    client = _client_with_exporter(exporter)
+    try:
+        # Missing step_name fails validation before it is queued.
+        try:
+            client.enqueue_workflow_step(WorkflowStep(id="wfs_a", conversation_id="c1"))
+            raise AssertionError("expected ValidationError")
+        except ValidationError:
+            pass
+        client.flush()
+    finally:
+        client.shutdown()
+
+    assert exporter.wf_batches == []
+
+
+def test_enqueue_workflow_step_validates_raw_input_before_defaulting() -> None:
+    # A step with only completed_at (started_at unset) is valid: the
+    # completed < started rule only applies when the caller supplied both.
+    # Validation runs on the raw input, so defaulting started_at to now() must
+    # not turn this into a spurious rejection. Matches Go and JS.
+    now = datetime(2026, 3, 12, 12, 0, 0, tzinfo=timezone.utc)
+    completed = datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    exporter = _RecordingExporter()
+    client = Client(
+        ClientConfig(
+            now=lambda: now,
+            generation_export=GenerationExportConfig(batch_size=10, flush_interval=timedelta(0)),
+            generation_exporter=exporter,
+        )
+    )
+    try:
+        client.enqueue_workflow_step(
+            WorkflowStep(id="wfs_a", conversation_id="c1", step_name="route", completed_at=completed)
+        )
+        client.flush()
+    finally:
+        client.shutdown()
+
+    step = exporter.wf_batches[0][0]
+    assert step.started_at == now  # defaulted
+    assert step.completed_at == completed  # caller-supplied, preserved
+
+
+def test_enqueue_workflow_step_rejects_oversized_payload() -> None:
+    exporter = _RecordingExporter()
+    client = Client(
+        ClientConfig(
+            generation_export=GenerationExportConfig(
+                batch_size=10,
+                flush_interval=timedelta(0),
+                payload_max_bytes=32,
+            ),
+            generation_exporter=exporter,
+        )
+    )
+    try:
+        try:
+            client.enqueue_workflow_step(
+                WorkflowStep(
+                    id="wfs_a",
+                    conversation_id="c1",
+                    step_name="route",
+                    input_state={"blob": "x" * 1000},
+                )
+            )
+            raise AssertionError("expected EnqueueError")
+        except EnqueueError:
+            pass
+        client.flush()
+    finally:
+        client.shutdown()
+
+    assert exporter.wf_batches == []
 
 
 def test_noop_exporter_accepts_workflow_steps() -> None:


### PR DESCRIPTION
## What
Adds `WorkflowStep` ingest/export to the **Go** and **JS** SDKs, and aligns the enqueue semantics across **Go, JS, and Python** so an identical input produces an identical exported step (or an identical rejection) in every language.

## Parity fixes uncovered during review
- **Validation order**: validate the raw input *before* defaulting timestamps (JS, Python) to match Go. The `completed_at < started_at` rule only fires when the caller supplied both — so defaulting `started_at` to `now()` no longer spuriously rejects a step that only set `completed_at`.
- **payload_max_bytes**: now enforced on workflow-step enqueue in Python (Go/JS and Python's own generation path already did).
- **Python `enqueue_workflow_step`** now defaults timestamps to the client clock and merges client-level tags, matching Go/JS.

## Conformance
The Go/JS/Python workflow-step roundtrip tests now feed **identical input** and assert **identical output**, so the suites actually cross-check behavior instead of each exercising a different scenario.

## Notes
- Timestamp resolution stays millisecond in JS by design (JS `Date` holds no finer precision); documented on the shared `mapTimestamp` helper.
- Framework-level workflow-step *capture* (langgraph/langchain etc.) is still Python-only and out of scope here — this PR covers the SDK ingest layer + parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)