### PR TITLE
fix(python): nest executor spans under the execute_tool span

### DIFF
--- a/python/sigil_sdk/client.py
+++ b/python/sigil_sdk/client.py
@@ -579,8 +579,17 @@ class Client:
                         content_capture=opts.content_capture,
                     )
                 )
+                # Run the executor inside the execute_tool span's context so any spans the
+                # executor creates (e.g. downstream RPCs) nest under it rather than becoming
+                # flat siblings of it in the trace. NoopToolExecutionRecorder has no span, so
+                # fall back to running without an active span in that case.
+                exec_span = getattr(rec, "span", None)
                 try:
-                    result = executor(name, arguments)
+                    if exec_span is not None:
+                        with use_span(exec_span, end_on_exit=False):
+                            result = executor(name, arguments)
+                    else:
+                        result = executor(name, arguments)
                     rec.set_result(arguments=arguments, result=result)
                     out.append(_build_tool_result_message(name, call_id, result, is_error=False))
                 except Exception as exc:  # noqa: BLE001

--- a/python/tests/test_tool_loop.py
+++ b/python/tests/test_tool_loop.py
@@ -125,6 +125,41 @@ def test_execute_tool_calls_executor_error() -> None:
         client.shutdown()
 
 
+def test_execute_tool_calls_nests_executor_spans_under_tool_span() -> None:
+    """Spans created inside the executor must nest under the execute_tool span, not become
+    flat siblings of it (i.e. the executor runs in the tool span's context)."""
+    exporter = CapturingGenerationExporter()
+    spans = InMemorySpanExporter()
+    tp = TracerProvider()
+    tp.add_span_processor(SimpleSpanProcessor(spans))
+    tracer = tp.get_tracer("test")
+    client = _new_client(exporter, spans)
+    try:
+        messages = [
+            Message(
+                role=MessageRole.ASSISTANT,
+                parts=[tool_call_part(ToolCall(id="c1", name="weather", input_json=b"{}"))],
+            )
+        ]
+
+        def run(_name: str, _args: object) -> object:
+            # An RPC-like span the executor opens while doing its work.
+            with tracer.start_as_current_span("downstream.rpc"):
+                pass
+            return {"ok": True}
+
+        client.execute_tool_calls(messages, run, options=ExecuteToolCallsOptions())
+
+        finished = {s.name: s for s in spans.get_finished_spans()}
+        tool_span = finished["execute_tool weather"]
+        child_span = finished["downstream.rpc"]
+        assert child_span.parent is not None
+        assert child_span.parent.span_id == tool_span.context.span_id
+        assert child_span.context.trace_id == tool_span.context.trace_id
+    finally:
+        client.shutdown()
+
+
 def test_execute_tool_calls_no_tool_parts() -> None:
     exporter = CapturingGenerationExporter()
     spans = InMemorySpanExporter()


### PR DESCRIPTION
## Summary

`Client.execute_tool_calls` creates the `execute_tool <name>` span with a **detached** `start_span` and then runs the caller's executor **without activating that span**. As a result, any spans the executor opens (e.g. downstream RPCs, DB calls) attach to the surrounding request/agent span and render as **flat siblings** of `execute_tool` in the trace, rather than nesting under it. The span times the work (`start`→`end` wraps the executor in wall-clock time) but does not parent it.

This fixes it by running the executor inside the span's context:

```python
exec_span = getattr(rec, "span", None)
if exec_span is not None:
    with use_span(exec_span, end_on_exit=False):
        result = executor(name, arguments)
else:
    result = executor(name, arguments)
```

- `end_on_exit=False` keeps `rec.end()` in charge of ending the span, so timing/status/error-recording behavior is unchanged.
- The `getattr` guard covers the `NoopToolExecutionRecorder` path (empty tool name), which has no span.

### Before
```
POST
├─ execute_tool get-recommendations        (leaf; times the work but no children)
├─ recommend_products
│   └─ recommendation_client.list_recommendations → gRPC
└─ product catalog ListProducts → gRPC
```

### After
```
POST
└─ execute_tool get-recommendations
    ├─ recommend_products
    │   └─ recommendation_client.list_recommendations → gRPC
    └─ product catalog ListProducts → gRPC
```

## Test plan

- [x] Added `test_execute_tool_calls_nests_executor_spans_under_tool_span`: opens a `downstream.rpc` span inside the executor and asserts its `parent.span_id` equals the `execute_tool` span's id (same trace). Fails without the fix, passes with it.
- [x] `pytest python/tests/test_tool_loop.py` — 7 passed
- [x] Full Python suite — 305 passed

## Notes

- Python only. The `executeToolCalls` helpers added in #135 for JS, Go, .NET, and Java almost certainly have the same detached-span behavior and likely warrant the equivalent fix for parity — happy to follow up.