### PR TITLE
fix(sdk-go): skip empty thinking blocks in anthropic generation mapping

### DIFF
--- a/go-providers/anthropic/mapper.go
+++ b/go-providers/anthropic/mapper.go
@@ -171,6 +171,19 @@ func mapResponseMessages(content []asdk.BetaContentBlockUnion) []sigil.Message {
 	return out
 }
 
+// thinkingPart builds a thinking Part, skipping blocks with empty content.
+// Adaptive thinking (e.g. Claude Sonnet 5) can emit signature-only thinking
+// blocks with no text; a Part without a payload fails generation validation,
+// so empty blocks are dropped like empty text blocks.
+func thinkingPart(content, providerType string) (sigil.Part, bool) {
+	if content == "" {
+		return sigil.Part{}, false
+	}
+	part := sigil.ThinkingPart(content)
+	part.Metadata.ProviderType = providerType
+	return part, true
+}
+
 func mapRequestBlock(block asdk.BetaContentBlockParamUnion) (sigil.Part, bool) {
 	if block.OfText != nil {
 		text := block.OfText.Text
@@ -180,14 +193,10 @@ func mapRequestBlock(block asdk.BetaContentBlockParamUnion) (sigil.Part, bool) {
 		return sigil.TextPart(text), true
 	}
 	if block.OfThinking != nil {
-		part := sigil.ThinkingPart(block.OfThinking.Thinking)
-		part.Metadata.ProviderType = "thinking"
-		return part, true
+		return thinkingPart(block.OfThinking.Thinking, "thinking")
 	}
 	if block.OfRedactedThinking != nil {
-		part := sigil.ThinkingPart(block.OfRedactedThinking.Data)
-		part.Metadata.ProviderType = "redacted_thinking"
-		return part, true
+		return thinkingPart(block.OfRedactedThinking.Data, "redacted_thinking")
 	}
 	if block.OfToolUse != nil {
 		inputJSON, _ := marshalAny(block.OfToolUse.Input)
@@ -304,13 +313,9 @@ func mapRequestBlock(block asdk.BetaContentBlockParamUnion) (sigil.Part, bool) {
 		}
 		return sigil.TextPart(text), true
 	case "thinking":
-		part := sigil.ThinkingPart(derefString(block.GetThinking()))
-		part.Metadata.ProviderType = typ
-		return part, true
+		return thinkingPart(derefString(block.GetThinking()), typ)
 	case "redacted_thinking":
-		part := sigil.ThinkingPart(derefString(block.GetData()))
-		part.Metadata.ProviderType = typ
-		return part, true
+		return thinkingPart(derefString(block.GetData()), typ)
 	case "tool_use", "server_tool_use", "mcp_tool_use":
 		inputJSON, _ := marshalAny(derefAny(block.GetInput()))
 		providerType := providerTypeForToolUse(typ, derefString(block.GetName()))
@@ -353,13 +358,9 @@ func mapResponseBlock(block asdk.BetaContentBlockUnion) (sigil.Part, bool) {
 		}
 		return sigil.TextPart(text), true
 	case "thinking":
-		part := sigil.ThinkingPart(block.Thinking)
-		part.Metadata.ProviderType = block.Type
-		return part, true
+		return thinkingPart(block.Thinking, block.Type)
 	case "redacted_thinking":
-		part := sigil.ThinkingPart(block.Data)
-		part.Metadata.ProviderType = block.Type
-		return part, true
+		return thinkingPart(block.Data, block.Type)
 	case "tool_use", "server_tool_use", "mcp_tool_use":
 		inputJSON, _ := marshalAny(block.Input)
 		providerType := providerTypeForToolUse(block.Type, block.Name)

--- a/go-providers/anthropic/mapper_test.go
+++ b/go-providers/anthropic/mapper_test.go
@@ -1026,3 +1026,59 @@ func testRequest() asdk.BetaMessageNewParams {
 		Tools: []asdk.BetaToolUnionParam{weatherTool},
 	}
 }
+
+func TestFromRequestResponseSkipsEmptyThinkingBlocks(t *testing.T) {
+	// Adaptive thinking (e.g. Claude Sonnet 5) can emit signature-only
+	// thinking blocks with empty text. They must be skipped: a thinking Part
+	// without a payload fails generation validation and would previously
+	// zero out the whole generation.
+	req := testRequest()
+	req.Messages = append(req.Messages, asdk.BetaMessageParam{
+		Role: asdk.BetaMessageParamRoleAssistant,
+		Content: []asdk.BetaContentBlockParamUnion{
+			{OfThinking: &asdk.BetaThinkingBlockParam{Thinking: "", Signature: "sig-1"}},
+			{OfRedactedThinking: &asdk.BetaRedactedThinkingBlockParam{Data: ""}},
+			{OfText: &asdk.BetaTextBlockParam{Text: "prior turn", Type: "text"}},
+		},
+	})
+
+	resp := &asdk.BetaMessage{
+		ID:         "msg_1",
+		Model:      asdk.Model("claude-sonnet-5"),
+		StopReason: asdk.BetaStopReasonEndTurn,
+		Content: []asdk.BetaContentBlockUnion{
+			{Type: "thinking", Thinking: "", Signature: "sig-2"},
+			{Type: "redacted_thinking", Data: ""},
+			{Type: "thinking", Thinking: "kept", Signature: "sig-3"},
+			{Type: "text", Text: "done"},
+		},
+	}
+
+	generation, err := FromRequestResponse(req, resp)
+	if err != nil {
+		t.Fatalf("from request/response: %v", err)
+	}
+
+	for _, message := range append(generation.Input, generation.Output...) {
+		for _, part := range message.Parts {
+			if part.Kind == sigil.PartKindThinking && part.Thinking == "" {
+				t.Fatalf("empty thinking part leaked into generation: %+v", part)
+			}
+		}
+	}
+
+	if len(generation.Output) == 0 {
+		t.Fatal("expected output messages")
+	}
+	parts := generation.Output[0].Parts
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 output parts (non-empty thinking + text), got %d: %+v", len(parts), parts)
+	}
+	if parts[0].Thinking != "kept" || parts[1].Text != "done" {
+		t.Fatalf("unexpected output parts: %+v", parts)
+	}
+
+	if verr := sigil.ValidateGeneration(generation); verr != nil {
+		t.Fatalf("generation failed validation: %v", verr)
+	}
+}


### PR DESCRIPTION
## What

The Go anthropic provider mapped `thinking` / `redacted_thinking` content blocks to Sigil thinking parts without checking for empty text. Adaptive-thinking models (Claude Sonnet 5 is always-adaptive on Bedrock) routinely emit signature-only thinking blocks with empty text. An empty thinking part fails `ValidateGeneration` ("must set exactly one payload field"), and since `FromRequestResponse` fails the whole mapping, the recorder persists a zero-value generation: **no input, no output, no system prompt, no usage, error null**.

Fix: skip empty thinking blocks in request and response mapping, matching the existing behavior for empty text blocks, the Go stream accumulator (`streamBlock.toPart`), and the Python and JS providers, which already guard this.

## Testing

- New regression test `TestFromRequestResponseSkipsEmptyThinkingBlocks` (fails on main with the validation error above).
- `go test ./...` in `go/` and `go-providers/anthropic/`, `mise run lint:go` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)