### PR TITLE
fix(cc):  Treat duplicate generation export results as idempotent success

### DIFF
--- a/go/sigil/client_test.go
+++ b/go/sigil/client_test.go
@@ -2058,6 +2058,49 @@ func TestFlushReturnsErrorOnRejectedGenerationResult(t *testing.T) {
 	}
 }
 
+func TestFlushTreatsDuplicateGenerationResultAsSuccess(t *testing.T) {
+	exporter := &capturingGenerationExporter{
+		response: &sigilv1.ExportGenerationsResponse{
+			Results: []*sigilv1.ExportGenerationResult{
+				{
+					GenerationId: "gen-duplicate",
+					Accepted:     false,
+					Error:        "generation already exists",
+				},
+			},
+		},
+	}
+	client, _, _ := newTestClient(t, Config{
+		GenerationExport: GenerationExportConfig{
+			MaxRetries:     1,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+		},
+		testGenerationExporter: exporter,
+	})
+
+	_, rec := client.StartGeneration(context.Background(), GenerationStart{
+		ID:    "gen-duplicate",
+		Model: ModelRef{Provider: "openai", Name: "gpt-5.4"},
+	})
+	rec.SetResult(Generation{
+		Output: []Message{AssistantTextMessage("hello")},
+	}, nil)
+	rec.End()
+	if err := rec.Err(); err != nil {
+		t.Fatalf("unexpected recorder error: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Flush(ctx); err != nil {
+		t.Fatalf("expected duplicate generation result to succeed, got %v", err)
+	}
+	if got := exporter.requestCount(); got != 1 {
+		t.Fatalf("requestCount = %d, want 1", got)
+	}
+}
+
 func TestFlushReturnsErrorOnNilGenerationExportResponse(t *testing.T) {
 	exporter := &capturingGenerationExporter{
 		export: func(context.Context, *sigilv1.ExportGenerationsRequest) (*sigilv1.ExportGenerationsResponse, error) {

--- a/go/sigil/exporter.go
+++ b/go/sigil/exporter.go
@@ -815,7 +815,7 @@ func isRetryableExportValidationError(err error) bool {
 
 func logRejectedExportResults(c *Client, response *sigilv1.ExportGenerationsResponse) {
 	for _, result := range response.GetResults() {
-		if result == nil || result.Accepted {
+		if result == nil || result.Accepted || duplicateGenerationExportResult(result) {
 			continue
 		}
 		c.logf("sigil generation rejected id=%s error=%s", result.GenerationId, result.Error)
@@ -850,6 +850,9 @@ func validateExportResponse(request *sigilv1.ExportGenerationsRequest, response 
 		if result.Accepted {
 			continue
 		}
+		if duplicateGenerationExportResult(result) {
+			continue
+		}
 		msg := strings.TrimSpace(result.Error)
 		if msg == "" {
 			msg = "rejected without error"
@@ -863,6 +866,16 @@ func validateExportResponse(request *sigilv1.ExportGenerationsRequest, response 
 		return &exportValidationError{err: fmt.Errorf("generation export malformed response: %s", strings.Join(malformed, "; ")), retryable: true}
 	}
 	return nil
+}
+
+func duplicateGenerationExportResult(result *sigilv1.ExportGenerationResult) bool {
+	if result == nil || result.Accepted {
+		return false
+	}
+	msg := strings.ToLower(strings.TrimSpace(result.Error))
+	return msg == "generation already exists" ||
+		strings.Contains(msg, "generation already exists") ||
+		strings.Contains(msg, "duplicate entry")
 }
 
 func validateWorkflowStepExportResponse(request *sigilv1.ExportWorkflowStepsRequest, response *sigilv1.ExportWorkflowStepsResponse) error {


### PR DESCRIPTION
## Summary

Hardens the Go SDK generation exporter so duplicate generation responses from Sigil are treated as idempotent success instead of `Flush()` failures.

This prevents Claude Code and other transcript-backed plugins from getting stuck in a retry loop when they re-send a generation that Sigil already persisted. In that failure mode, the server returns a duplicate response, the SDK reports `Flush()` as failed, and the plugin does not advance its local transcript offset. The next hook invocation then re-reads the same transcript bytes and sends the same deterministic generation IDs again.

## Changes

- Treat duplicate generation export results as successful no-ops when the server response contains duplicate indicators such as:
  - `generation already exists`
  - `Duplicate entry`
- Skip duplicate results in rejected-export logging.
- Keep non-duplicate rejected export results as errors.
- Add a regression test covering `Flush()` behavior for duplicate generation results.

## Testing

- `go test ./go/sigil`