### PR TITLE
fix(python): backfill Bedrock inference-profile model onto generation

### DIFF
--- a/python-frameworks/langchain/tests/test_langchain_handler.py
+++ b/python-frameworks/langchain/tests/test_langchain_handler.py
@@ -118,6 +118,171 @@ def test_langchain_sync_lifecycle_sets_framework_tags_and_metadata() -> None:
         client.shutdown()
 
 
+def test_langchain_backfills_model_from_response_when_request_model_unknown() -> None:
+    """Regression: LangChain/LangGraph with a Bedrock inference profile does not
+    surface the model at request start, so it resolves to "unknown"/"custom".
+    The real model (a Bedrock inference-profile ARN) only arrives on the
+    response. It must be backfilled onto the generation model so the
+    token-usage metric (which drives cost) carries a resolvable model instead
+    of "unknown"."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    arn = "arn:aws:bedrock:ap-south-1:500440857146:inference-profile/global.anthropic.claude-sonnet-4-6"
+
+    try:
+        run_id = uuid4()
+        handler = SigilLangChainHandler(
+            client=client,
+            agent_name="agent-langchain",
+            agent_version="v1",
+            provider_resolver="auto",
+        )
+
+        # No "model" key in invocation_params — mirrors ChatBedrock with an
+        # auto-provisioner default config, where the model is only known on
+        # the response.
+        handler.on_chat_model_start(
+            {"name": "ChatBedrock"},
+            [[{"type": "human", "content": "hello"}]],
+            run_id=run_id,
+            invocation_params={},
+        )
+        handler.on_llm_end(
+            {
+                "generations": [[{"text": "world"}]],
+                "llm_output": {
+                    "model_name": arn,
+                    "finish_reason": "stop",
+                    "token_usage": {
+                        "prompt_tokens": 17011,
+                        "completion_tokens": 217,
+                        "total_tokens": 17228,
+                    },
+                },
+            },
+            run_id=run_id,
+        )
+
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        # Model is backfilled from the response so cost can resolve.
+        assert generation.model.name == arn
+        assert generation.model.provider == "anthropic"
+        # response_model is still recorded.
+        assert generation.response_model == arn
+        assert generation.usage.input_tokens == 17011
+        assert generation.usage.output_tokens == 217
+    finally:
+        client.shutdown()
+
+
+def test_langchain_does_not_override_explicit_request_model() -> None:
+    """When the request model IS known, an ARN response model must not clobber
+    it — the explicit request model wins."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        run_id = uuid4()
+        handler = SigilLangChainHandler(
+            client=client,
+            agent_name="agent-langchain",
+            agent_version="v1",
+            provider_resolver="auto",
+        )
+
+        handler.on_chat_model_start(
+            {"name": "ChatAnthropic"},
+            [[{"type": "human", "content": "hello"}]],
+            run_id=run_id,
+            invocation_params={"model": "claude-haiku-4-5-20251001"},
+        )
+        handler.on_llm_end(
+            {
+                "generations": [[{"text": "world"}]],
+                "llm_output": {
+                    "model_name": "some-other-response-model",
+                    "finish_reason": "stop",
+                    "token_usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                },
+            },
+            run_id=run_id,
+        )
+
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        assert generation.model.name == "claude-haiku-4-5-20251001"
+        assert generation.model.provider == "anthropic"
+        assert generation.response_model == "some-other-response-model"
+    finally:
+        client.shutdown()
+
+
+def test_langchain_infers_bedrock_provider_at_request_start() -> None:
+    """When a Bedrock-style model id IS surfaced at request start (no explicit
+    provider), the provider fallback must classify it from the vendor segment
+    instead of falling back to "custom", so the start span is resolvable too.
+    Uses positional vendor parsing that mirrors the backend: a dotted custom
+    name whose vendor word is not in the vendor position stays "custom"."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        # Bedrock inference-profile id surfaced at start -> provider inferred.
+        run_id = uuid4()
+        handler = SigilLangChainHandler(
+            client=client,
+            agent_name="agent-langchain",
+            agent_version="v1",
+            provider_resolver="auto",
+        )
+        handler.on_chat_model_start(
+            {"name": "ChatBedrock"},
+            [[{"type": "human", "content": "hello"}]],
+            run_id=run_id,
+            invocation_params={"model": "us.anthropic.claude-sonnet-4-6"},
+        )
+        handler.on_llm_end(
+            {
+                "generations": [[{"text": "world"}]],
+                "llm_output": {
+                    "finish_reason": "stop",
+                    "token_usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                },
+            },
+            run_id=run_id,
+        )
+
+        # A dotted custom name with a vendor word out of position stays "custom".
+        custom_run_id = uuid4()
+        handler.on_chat_model_start(
+            {"name": "ChatCustom"},
+            [[{"type": "human", "content": "hello"}]],
+            run_id=custom_run_id,
+            invocation_params={"model": "my-team.anthropic.internal-model"},
+        )
+        handler.on_llm_end(
+            {
+                "generations": [[{"text": "world"}]],
+                "llm_output": {
+                    "finish_reason": "stop",
+                    "token_usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                },
+            },
+            run_id=custom_run_id,
+        )
+
+        client.flush()
+        generations = exporter.requests[0].generations
+        bedrock_gen = next(g for g in generations if g.model.name == "us.anthropic.claude-sonnet-4-6")
+        assert bedrock_gen.model.provider == "anthropic"
+        custom_gen = next(g for g in generations if g.model.name == "my-team.anthropic.internal-model")
+        assert custom_gen.model.provider == "custom"
+    finally:
+        client.shutdown()
+
+
 def test_langchain_sync_lifecycle_extracts_anthropic_style_usage_and_stop_reason() -> None:
     """ChatAnthropic puts token usage under 'usage' (not 'token_usage') and
     stop reason under 'stop_reason' (not 'finish_reason')."""

--- a/python/sigil_sdk/framework_handler.py
+++ b/python/sigil_sdk/framework_handler.py
@@ -86,6 +86,8 @@ class _RunState:
     recorder: Any
     input_messages: list[Message]
     capture_outputs: bool
+    request_model: str = ""
+    request_provider: str = ""
     output_chunks: list[str] = field(default_factory=list)
     first_token_recorded: bool = False
 
@@ -386,6 +388,8 @@ class SigilFrameworkHandlerBase:
             recorder=recorder,
             input_messages=input_messages,
             capture_outputs=self._capture_outputs,
+            request_model=model_name,
+            request_provider=provider_name,
         )
 
     def _on_chat_model_start(
@@ -497,6 +501,8 @@ class SigilFrameworkHandlerBase:
             recorder=recorder,
             input_messages=input_messages,
             capture_outputs=self._capture_outputs,
+            request_model=model_name,
+            request_provider=provider_name,
         )
 
     def _on_llm_new_token(self, *, token: str, run_id: UUID) -> None:
@@ -550,11 +556,26 @@ class SigilFrameworkHandlerBase:
                         )
                     ]
 
+            # Some frameworks (e.g. LangChain/LangGraph with Bedrock inference
+            # profiles) do not surface the model at request start, so it was
+            # recorded as "unknown"/"custom". The real model only arrives on the
+            # response. Backfill it here so the generation and, critically, the
+            # token-usage metric (which drives cost) carry the resolvable model
+            # instead of "unknown". Only override when the request model was not
+            # already known, so an explicit request model is never clobbered.
+            backfill_model: ModelRef | None = None
+            if _is_unknown_model(run_state.request_model) and response_model != "":
+                provider = run_state.request_provider
+                if _is_unknown_provider(provider):
+                    provider = _infer_provider_from_model_name(response_model)
+                backfill_model = ModelRef(provider=provider, name=response_model)
+
             run_state.recorder.set_result(
                 Generation(
                     input=run_state.input_messages,
                     output=output_messages,
                     usage=usage,
+                    model=backfill_model if backfill_model is not None else ModelRef(),
                     response_model=response_model,
                     stop_reason=stop_reason,
                 )
@@ -1022,7 +1043,30 @@ def _resolve_model_name(serialized: dict[str, Any] | None, invocation_params: di
     return "unknown"
 
 
+_BEDROCK_VENDOR_PROVIDERS = {
+    "anthropic": "anthropic",
+    "amazon": "amazon",
+    "cohere": "cohere",
+    "meta": "meta-llama",
+    "mistral": "mistralai",
+}
+
+
+def _is_unknown_model(model_name: str) -> bool:
+    normalized = model_name.strip().lower()
+    return normalized == "" or normalized == "unknown"
+
+
+def _is_unknown_provider(provider: str) -> bool:
+    normalized = provider.strip().lower()
+    return normalized == "" or normalized == "custom"
+
+
 def _infer_provider_from_model_name(model_name: str) -> str:
+    # Called from two places: the request-start provider fallback in
+    # `_resolve_provider` (so a Bedrock-style model surfaced at start resolves to
+    # its vendor instead of "custom") and the `_on_llm_end` model backfill. Both
+    # rely on the Bedrock branch below, so keep it consistent with the backend.
     normalized = model_name.strip().lower()
     if (
         normalized.startswith("gpt-")
@@ -1035,7 +1079,45 @@ def _infer_provider_from_model_name(model_name: str) -> str:
         return "anthropic"
     if normalized.startswith("gemini-"):
         return "gemini"
+    # Bedrock inference-profile IDs / ARNs carry the vendor in a fixed dotted
+    # position (e.g. "global.anthropic.claude-sonnet-4-6" or an
+    # ".../inference-profile/..." ARN), so the plain prefix checks above miss them.
+    bedrock_provider = _infer_provider_from_bedrock_id(normalized)
+    if bedrock_provider != "":
+        return bedrock_provider
     return "custom"
+
+
+_BEDROCK_RESOURCE_MARKERS = (
+    # Longest markers first so a partial marker never matches ahead of the full one.
+    "application-inference-profile/",
+    "inference-profile/",
+    "foundation-model/",
+)
+
+_BEDROCK_REGIONAL_PREFIXES = frozenset({"us", "eu", "apac", "jp", "global"})
+
+
+def _infer_provider_from_bedrock_id(model_name: str) -> str:
+    # Mirror the backend's positional parse (sigil parseBedrockModelID): strip the
+    # resource-ARN prefix, then read the vendor from a FIXED position — segment 0,
+    # or segment 1 when segment 0 is a known regional prefix (us/eu/apac/jp/global).
+    # Scanning every dotted segment (an earlier approach) misclassified custom names
+    # that merely contain a vendor word (e.g. "my-team.anthropic.foo") and diverged
+    # from the backend, so we match its positional logic exactly.
+    trimmed = model_name.strip().lower()
+    for marker in _BEDROCK_RESOURCE_MARKERS:
+        _, sep, after = trimmed.partition(marker)
+        if sep != "":
+            trimmed = after.strip()
+            break
+    parts = trimmed.split(".")
+    if len(parts) < 2:
+        return ""
+    vendor_idx = 0
+    if len(parts) >= 3 and parts[0] in _BEDROCK_REGIONAL_PREFIXES:
+        vendor_idx = 1
+    return _BEDROCK_VENDOR_PROVIDERS.get(parts[vendor_idx], "")
 
 
 def _normalize_provider_name(value: str) -> str:


### PR DESCRIPTION
## What

LangChain/LangGraph with an AWS Bedrock **inference profile** does not surface the model at request start, so it resolves to `"unknown"` / provider `"custom"`. The real model — a Bedrock inference-profile ARN — only arrives on the LLM response. As a result the token-usage metric (which drives cost) was labeled `gen_ai_request_model="unknown"` / `gen_ai_provider_name="custom"`, so **cost resolved to $0** even though tokens were counted.

more context here https://raintank-corp.slack.com/archives/C0AL71QRJQ6/p1783702964451819

## Fix

- Store the request model/provider on `_RunState` (both start paths).
- At `_on_llm_end`, backfill `ModelRef` (name + inferred provider) from `response_model` **when the request model was unknown**, before the token-usage metric is recorded, so the metric carries a resolvable model. An explicit request model is never clobbered.
- Provider inference for Bedrock IDs/ARNs reads the vendor from a **fixed dotted position** (segment 0, or segment 1 after a regional prefix `us/eu/apac/jp/global`), mirroring the backend `parseBedrockModelID` exactly so SDK and backend stay consistent and custom names that merely contain a vendor word are not misclassified. The vendor→provider map matches the backend `providerFromBedrockVendor` byte-for-byte.
- This inference also runs at request start (`_resolve_provider`), so a Bedrock-style model surfaced at start now resolves to its vendor instead of `"custom"`.

## Tests

Regression tests added:
- Response backfill for the real customer case (ChatBedrock + inference-profile ARN).
- No-clobber of an explicit request model.
- Request-start provider inference, including the custom-name negative case.

`16/16` langchain + `310/310` core pass.

## Notes

- No backend change needed — the backend resolver already normalizes Bedrock ARNs/inference-profile IDs; the gap was purely that the SDK stamped `unknown/custom` on the cost-driving metric.
- Residual `$0` for a specific model after this ships would indicate a model-catalog gap (separate, engineering-side), not this bug.

