### PR TITLE
fix(js): backfill Bedrock inference-profile model onto generation

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1431,7 +1431,7 @@ class GenerationRecorderImpl implements GenerationRecorder {
       agentVersion: firstNonEmptyString(this.result?.agentVersion, this.seed.agentVersion),
       mode: this.mode,
       operationName: this.result?.operationName ?? this.seed.operationName ?? defaultOperationNameForMode(this.mode),
-      model: cloneModelRef(this.seed.model),
+      model: cloneModelRef(this.result?.model ?? this.seed.model),
       systemPrompt: this.seed.systemPrompt,
       responseId: this.result?.responseId,
       responseModel: this.result?.responseModel,

--- a/js/src/frameworks/shared.ts
+++ b/js/src/frameworks/shared.ts
@@ -1,6 +1,13 @@
 import { type Span, SpanKind, SpanStatusCode, type Tracer, trace } from '@opentelemetry/api';
 import type { SigilClient } from '../client.js';
-import type { GenerationRecorder, GenerationResult, Message, TokenUsage, ToolExecutionRecorder } from '../types.js';
+import type {
+  GenerationRecorder,
+  GenerationResult,
+  Message,
+  ModelRef,
+  TokenUsage,
+  ToolExecutionRecorder,
+} from '../types.js';
 
 type AnyRecord = Record<string, unknown>;
 
@@ -43,6 +50,8 @@ interface RunState {
   recorder: GenerationRecorder;
   input: Message[];
   captureOutputs: boolean;
+  requestModel: string;
+  requestProvider: string;
   outputChunks: string[];
   firstTokenRecorded: boolean;
 }
@@ -135,6 +144,8 @@ export class SigilFrameworkHandler {
       recorder,
       input,
       captureOutputs: this.captureOutputs,
+      requestModel: modelName,
+      requestProvider: provider,
       outputChunks: [],
       firstTokenRecorded: false,
     });
@@ -179,6 +190,8 @@ export class SigilFrameworkHandler {
       recorder,
       input,
       captureOutputs: this.captureOutputs,
+      requestModel: modelName,
+      requestProvider: provider,
       outputChunks: [],
       firstTokenRecorded: false,
     });
@@ -213,9 +226,28 @@ export class SigilFrameworkHandler {
 
     try {
       const llmOutput = asRecord(read(output, 'llm_output'));
-      const responseModel = asString(read(llmOutput, 'model_name'));
-      const stopReason = asString(read(llmOutput, 'finish_reason'));
-      const usage = mapUsage(read(llmOutput, 'token_usage'));
+      // Streaming (and some integrations, e.g. ChatBedrock) don't populate
+      // `llm_output.model_name`/`finish_reason`; the model and stop reason land on the
+      // first generation message's `response_metadata` instead. Fall back to it so the
+      // backfill below fires for the streaming path, mirroring the Python handler.
+      const responseMessage = firstGenerationMessage(output);
+      const responseMetadata = asRecord(read(responseMessage, 'response_metadata'));
+      const responseModel = asString(read(llmOutput, 'model_name')) || asString(read(responseMetadata, 'model_name'));
+      const stopReason =
+        asString(read(llmOutput, 'finish_reason')) ||
+        asString(read(llmOutput, 'stop_reason')) ||
+        asString(read(responseMetadata, 'finish_reason')) ||
+        asString(read(responseMetadata, 'stop_reason'));
+      // Streaming reports token counts on the message's `usage_metadata`, not on
+      // `llm_output.token_usage`. Cost needs tokens, so fall back to the first source
+      // that actually yields counts, otherwise a resolved model still yields $0 for
+      // streams. `mapUsage` returns undefined for missing/all-zero input, so this also
+      // steps past a present-but-empty `token_usage` (which JS treats as truthy),
+      // matching the Python `or` chain that falls through an empty dict.
+      const usage =
+        mapUsage(read(llmOutput, 'token_usage')) ??
+        mapUsage(read(llmOutput, 'usage')) ??
+        mapUsage(read(responseMessage, 'usage_metadata'));
 
       let mappedOutput: Message[] | undefined;
       if (runState.captureOutputs) {
@@ -225,10 +257,26 @@ export class SigilFrameworkHandler {
         }
       }
 
+      // Some frameworks (e.g. LangChain/LangGraph with Bedrock inference profiles)
+      // do not surface the model at request start, so it was recorded as
+      // "unknown"/"custom". The real model only arrives on the response. Backfill it
+      // here so the generation and, critically, the token-usage metric (which drives
+      // cost) carry the resolvable model instead of "unknown". Only override when the
+      // request model was not already known, so an explicit request model is never
+      // clobbered.
+      let backfillModel: ModelRef | undefined;
+      if (isUnknownModel(runState.requestModel) && responseModel.length > 0) {
+        const provider = isUnknownProvider(runState.requestProvider)
+          ? inferProviderFromModelName(responseModel)
+          : runState.requestProvider;
+        backfillModel = { provider, name: responseModel };
+      }
+
       const result: GenerationResult = {
         input: runState.input,
         output: mappedOutput,
         usage,
+        model: backfillModel,
         responseModel: responseModel.length > 0 ? responseModel : undefined,
         stopReason: stopReason.length > 0 ? stopReason : undefined,
       };
@@ -1095,6 +1143,28 @@ function mapOutputMessages(output: unknown): Message[] {
   return [{ role: 'assistant', content: texts.join('\n') }];
 }
 
+// Returns the first generation's `message` object, mirroring the Python
+// `_first_generation_message`. Streaming responses carry the model / stop reason on
+// this message's `response_metadata` rather than on `llm_output`.
+function firstGenerationMessage(output: unknown): unknown {
+  const generations = read(output, 'generations');
+  if (!Array.isArray(generations)) {
+    return undefined;
+  }
+  for (const candidates of generations) {
+    if (!Array.isArray(candidates)) {
+      continue;
+    }
+    for (const candidate of candidates) {
+      const message = read(candidate, 'message');
+      if (message !== undefined && message !== null) {
+        return message;
+      }
+    }
+  }
+  return undefined;
+}
+
 function extractGenerationText(candidate: unknown): string {
   const text = asString(read(candidate, 'text'));
   if (text.length > 0) {
@@ -1177,6 +1247,62 @@ function mapUsage(rawUsage: unknown): TokenUsage | undefined {
   };
 }
 
+function isUnknownModel(modelName: string): boolean {
+  const normalized = modelName.trim().toLowerCase();
+  return normalized === '' || normalized === 'unknown';
+}
+
+function isUnknownProvider(provider: string): boolean {
+  const normalized = provider.trim().toLowerCase();
+  return normalized === '' || normalized === 'custom';
+}
+
+// Vendor->provider map for Bedrock model IDs. Matches the backend
+// `providerFromBedrockVendor` (sigil parseBedrockModelID) so SDK and backend agree.
+const BEDROCK_VENDOR_PROVIDERS: Record<string, string> = {
+  anthropic: 'anthropic',
+  amazon: 'amazon',
+  cohere: 'cohere',
+  meta: 'meta-llama',
+  mistral: 'mistralai',
+};
+
+// Longest markers first so a partial marker never matches ahead of the full one.
+const BEDROCK_RESOURCE_MARKERS = ['application-inference-profile/', 'inference-profile/', 'foundation-model/'];
+
+const BEDROCK_REGIONAL_PREFIXES = new Set(['us', 'eu', 'apac', 'jp', 'global']);
+
+// Mirror the backend's positional parse (sigil parseBedrockModelID): strip the
+// resource-ARN prefix, then read the vendor from a FIXED position — segment 0, or
+// segment 1 when segment 0 is a known regional prefix (us/eu/apac/jp/global).
+// Scanning every dotted segment would misclassify custom names that merely contain a
+// vendor word (e.g. "my-team.anthropic.foo") and diverge from the backend, so we
+// match its positional logic exactly.
+function inferProviderFromBedrockId(modelName: string): string {
+  let trimmed = modelName.trim().toLowerCase();
+  for (const marker of BEDROCK_RESOURCE_MARKERS) {
+    const idx = trimmed.indexOf(marker);
+    if (idx !== -1) {
+      trimmed = trimmed.slice(idx + marker.length).trim();
+      break;
+    }
+  }
+  const parts = trimmed.split('.');
+  if (parts.length < 2) {
+    return '';
+  }
+  let vendorIdx = 0;
+  if (parts.length >= 3 && BEDROCK_REGIONAL_PREFIXES.has(parts[0] ?? '')) {
+    vendorIdx = 1;
+  }
+  const vendor = parts[vendorIdx] ?? '';
+  return BEDROCK_VENDOR_PROVIDERS[vendor] ?? '';
+}
+
+// Called from two places: the request-start provider fallback in `resolveProvider`
+// (so a Bedrock-style model surfaced at start resolves to its vendor instead of
+// "custom") and the `onLLMEnd` model backfill. Both rely on the Bedrock branch below,
+// so keep it consistent with the backend.
 function inferProviderFromModelName(modelName: string): string {
   const normalized = modelName.trim().toLowerCase();
   if (
@@ -1192,6 +1318,13 @@ function inferProviderFromModelName(modelName: string): string {
   }
   if (normalized.startsWith('gemini-')) {
     return 'gemini';
+  }
+  // Bedrock inference-profile IDs / ARNs carry the vendor in a fixed dotted position
+  // (e.g. "global.anthropic.claude-sonnet-4-6" or an ".../inference-profile/..." ARN),
+  // so the plain prefix checks above miss them.
+  const bedrockProvider = inferProviderFromBedrockId(normalized);
+  if (bedrockProvider !== '') {
+    return bedrockProvider;
   }
   return 'custom';
 }

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -396,6 +396,12 @@ export interface GenerationResult {
   parentGenerationIds?: string[];
   /** See {@link GenerationStart.effectiveVersion}. */
   effectiveVersion?: string;
+  /**
+   * Overrides the request model captured at start. Set when a framework only surfaces
+   * the model on the response (e.g. Bedrock inference profiles), so the token-usage
+   * metric carries a resolvable model instead of "unknown".
+   */
+  model?: ModelRef;
   input?: Message[];
   output?: Message[];
   tools?: ToolDefinition[];

--- a/js/src/utils.ts
+++ b/js/src/utils.ts
@@ -207,6 +207,7 @@ export function cloneGeneration(generation: Generation): Generation {
 export function cloneGenerationResult(result: GenerationResult): GenerationResult {
   return {
     ...result,
+    model: result.model ? cloneModelRef(result.model) : undefined,
     input: result.input?.map(cloneMessage),
     output: result.output?.map(cloneMessage),
     tools: result.tools?.map(cloneToolDefinition),

--- a/js/test/frameworks.langchain.test.mjs
+++ b/js/test/frameworks.langchain.test.mjs
@@ -232,6 +232,162 @@ test('langchain provider mapping covers openai anthopic gemini and fallback', as
   assert.deepEqual(providers, ['openai', 'anthropic', 'gemini', 'custom']);
 });
 
+test('langchain backfills Bedrock inference-profile model from the response', async () => {
+  // Customer case: ChatBedrock with an inference profile does not surface the model at
+  // start (resolves to unknown/custom); the real model only arrives on the response.
+  // Backfill must land on generation.model so the token-usage metric is priceable.
+  const arnModel = 'arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-4-6-v1:0';
+  const generation = await captureSingleGeneration(async (client) => {
+    const handler = new SigilLangChainHandler(client);
+
+    await handler.handleChatModelStart({ name: 'ChatBedrock' }, [[{ type: 'human', content: 'hello' }]], 'run-bedrock');
+    await handler.handleLLMEnd(
+      {
+        generations: [[{ text: 'world' }]],
+        llm_output: {
+          model_name: arnModel,
+          token_usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+        },
+      },
+      'run-bedrock',
+    );
+  });
+
+  assert.equal(generation.model.name, arnModel);
+  assert.equal(generation.model.provider, 'anthropic');
+  assert.equal(generation.responseModel, arnModel);
+});
+
+test('langchain backfills Bedrock plain inference-profile id from the response', async () => {
+  const idModel = 'global.anthropic.claude-sonnet-4-6';
+  const generation = await captureSingleGeneration(async (client) => {
+    const handler = new SigilLangChainHandler(client);
+
+    await handler.handleChatModelStart({ name: 'ChatBedrock' }, [[{ type: 'human', content: 'hi' }]], 'run-bedrock-id');
+    await handler.handleLLMEnd(
+      { generations: [[{ text: 'ok' }]], llm_output: { model_name: idModel } },
+      'run-bedrock-id',
+    );
+  });
+
+  assert.equal(generation.model.name, idModel);
+  assert.equal(generation.model.provider, 'anthropic');
+});
+
+test('langchain backfills streaming Bedrock model+usage from generation response_metadata', async () => {
+  // Real langchain-core streaming shape: the model, stop reason, and token counts land
+  // on the first generation message (response_metadata / usage_metadata), NOT on
+  // llm_output. This is the actual customer scenario (streaming ChatBedrock).
+  const arnModel = 'arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-4-6-v1:0';
+  const generation = await captureSingleGeneration(async (client) => {
+    const handler = new SigilLangChainHandler(client);
+
+    await handler.handleChatModelStart(
+      { name: 'ChatBedrock' },
+      [[{ type: 'human', content: 'hello' }]],
+      'run-stream-bedrock',
+      undefined,
+      { invocation_params: { streaming: true } },
+    );
+    await handler.handleLLMNewToken('wor', undefined, 'run-stream-bedrock');
+    await handler.handleLLMNewToken('ld', undefined, 'run-stream-bedrock');
+    await handler.handleLLMEnd(
+      {
+        generations: [
+          [
+            {
+              text: 'world',
+              message: {
+                response_metadata: { model_name: arnModel, stop_reason: 'end_turn' },
+                usage_metadata: { input_tokens: 12, output_tokens: 8, total_tokens: 20 },
+              },
+            },
+          ],
+        ],
+        // llm_output carries no model / usage on the streaming path.
+        llm_output: {},
+      },
+      'run-stream-bedrock',
+    );
+  });
+
+  assert.equal(generation.model.name, arnModel);
+  assert.equal(generation.model.provider, 'anthropic');
+  assert.equal(generation.responseModel, arnModel);
+  assert.equal(generation.stopReason, 'end_turn');
+  assert.equal(generation.usage.inputTokens, 12);
+  assert.equal(generation.usage.outputTokens, 8);
+  assert.equal(generation.usage.totalTokens, 20);
+});
+
+test('langchain falls through an empty llm_output.token_usage to usage_metadata', async () => {
+  // A present-but-empty token_usage must not short-circuit the usage fallback, or a
+  // streaming response that also carries usage_metadata would report zero tokens ($0).
+  const generation = await captureSingleGeneration(async (client) => {
+    const handler = new SigilLangChainHandler(client);
+
+    await handler.handleChatModelStart(
+      { name: 'ChatBedrock' },
+      [[{ type: 'human', content: 'hi' }]],
+      'run-empty-usage',
+    );
+    await handler.handleLLMEnd(
+      {
+        generations: [
+          [{ text: 'ok', message: { usage_metadata: { input_tokens: 4, output_tokens: 3, total_tokens: 7 } } }],
+        ],
+        llm_output: { model_name: 'global.anthropic.claude-sonnet-4-6', token_usage: {} },
+      },
+      'run-empty-usage',
+    );
+  });
+
+  assert.equal(generation.usage.inputTokens, 4);
+  assert.equal(generation.usage.outputTokens, 3);
+  assert.equal(generation.usage.totalTokens, 7);
+});
+
+test('langchain does not clobber an explicit request model with the response model', async () => {
+  const generation = await captureSingleGeneration(async (client) => {
+    const handler = new SigilLangChainHandler(client);
+
+    await handler.handleLLMStart({}, ['x'], 'run-known', undefined, { invocation_params: { model: 'gpt-5' } });
+    // Response reports a different model — the known request model must win.
+    await handler.handleLLMEnd(
+      { generations: [[{ text: 'ok' }]], llm_output: { model_name: 'claude-sonnet-4-5' } },
+      'run-known',
+    );
+  });
+
+  assert.equal(generation.model.name, 'gpt-5');
+  assert.equal(generation.model.provider, 'openai');
+});
+
+test('langchain infers Bedrock provider at request start and keeps custom for lookalikes', async () => {
+  const providers = [];
+
+  await captureGenerations(
+    async (client) => {
+      const handler = new SigilLangChainHandler(client);
+
+      // Bedrock-style id surfaced at start resolves to its vendor, not "custom".
+      await handler.handleLLMStart({}, ['x'], 'run-bedrock-start', undefined, {
+        invocation_params: { model: 'us.anthropic.claude-sonnet-4-6-v1:0' },
+      });
+      await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-bedrock-start');
+
+      // A custom name that merely contains a vendor word must stay "custom" (positional parse).
+      await handler.handleLLMStart({}, ['x'], 'run-lookalike', undefined, {
+        invocation_params: { model: 'my-team.anthropic.foo' },
+      });
+      await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-lookalike');
+    },
+    (generation) => providers.push(generation.model.provider),
+  );
+
+  assert.deepEqual(providers, ['anthropic', 'custom']);
+});
+
 test('langchain handler sets call_error on llm error', async () => {
   const generation = await captureSingleGeneration(async (client) => {
     const handler = new SigilLangChainHandler(client);

--- a/js/test/frameworks.langgraph.test.mjs
+++ b/js/test/frameworks.langgraph.test.mjs
@@ -190,6 +190,26 @@ test('langgraph provider mapping covers openai anthopic gemini and fallback', as
   assert.deepEqual(providers, ['openai', 'anthropic', 'gemini', 'custom']);
 });
 
+test('langgraph backfills Bedrock inference-profile model from the response', async () => {
+  // langgraph delegates to the shared handler, so the Bedrock backfill applies here too.
+  const arnModel = 'arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-4-6-v1:0';
+  const generation = await captureSingleGeneration(async (client) => {
+    const handler = new SigilLangGraphHandler(client);
+
+    await handler.handleChatModelStart({ name: 'ChatBedrock' }, [[{ type: 'human', content: 'hi' }]], 'run-bedrock');
+    await handler.handleLLMEnd(
+      {
+        generations: [[{ text: 'ok' }]],
+        llm_output: { model_name: arnModel, token_usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 } },
+      },
+      'run-bedrock',
+    );
+  });
+
+  assert.equal(generation.model.name, arnModel);
+  assert.equal(generation.model.provider, 'anthropic');
+});
+
 test('langgraph handler sets call_error on llm error', async () => {
   const generation = await captureSingleGeneration(async (client) => {
     const handler = new SigilLangGraphHandler(client);


### PR DESCRIPTION
## What

LangChain/LangGraph with an AWS Bedrock **inference profile** does not surface the model at request start, so it resolves to `"unknown"` / provider `"custom"`. The real model — a Bedrock inference-profile ARN — only arrives on the LLM **response**. As a result the token-usage metric (which drives cost) was labeled `unknown`/`custom`, so **cost resolved to $0** even though tokens were counted.

This is the **JS port** of the already-merged Python fix (#371, released as `sigil-sdk` v0.9.3 on PyPI). The JS SDK had the exact same bug and no Bedrock handling.

## Fix

- Store the request model/provider on `RunState` (both start paths).
- In `onLLMEnd`, backfill a `ModelRef` (name + inferred provider) from the response model **when the request model was unknown**, before the generation is exported, so the token-usage metric carries a resolvable model. An explicit request model is never clobbered.
- Read the response model, stop reason, and token usage from the **first generation message's `response_metadata` / `usage_metadata`** as a fallback, not just `llm_output`. langchain-core **streaming** (the real ChatBedrock case) puts the model on `response_metadata` and tokens on `usage_metadata`, and leaves `llm_output` without them — without this fallback the backfill never fired for streams and cost stayed $0. Mirrors the Python handler.
- Provider inference for Bedrock IDs/ARNs reads the vendor from a **fixed dotted position** (segment 0, or segment 1 after a regional prefix `us/eu/apac/jp/global`), mirroring the Python fix and backend `parseBedrockModelID` so SDK and backend stay consistent. This also runs at request start, so a Bedrock-style model surfaced at start resolves to its vendor instead of `"custom"`.
- Add optional `model` override to `GenerationResult`; prefer it over the seed model at export (`client end()`).

## Tests

Regression tests added to the langchain and langgraph suites:
- Response backfill for the customer case (ChatBedrock + inference-profile ARN and plain id).
- The **streaming shape** (model + usage only in `response_metadata` / `usage_metadata` with empty `llm_output`).
- A present-but-empty `token_usage` falling through to `usage_metadata`.
- No-clobber of an explicit request model.
- Request-start provider inference, including the custom-name negative case.

`345/345` JS tests pass; typecheck and biome lint clean.

## Notes

No backend change needed — the backend resolver already normalizes Bedrock ARNs/inference-profile IDs. Residual $0 for a specific model after this ships would indicate a model-catalog gap, not this bug.


