### PR TITLE
fix(sdk): non-canonical provider hint no longer blocks Bedrock model inference

### DIFF
--- a/js/src/frameworks/shared.ts
+++ b/js/src/frameworks/shared.ts
@@ -681,18 +681,31 @@ function resolveProvider(
     return resolved.length > 0 ? resolved : 'custom';
   }
 
+  // A framework hint (`provider`/`ls_provider`) wins only when it is a canonical
+  // provider. LangChain often reports a non-canonical hint for Bedrock (e.g.
+  // `ls_provider: 'amazon_bedrock'`), which `normalizeProvider` collapses to `custom`;
+  // treating that as authoritative would short-circuit the model-name inference that
+  // can recover the real vendor from a Bedrock id. So a `custom` hint is only kept as a
+  // last resort — model-name inference is tried first.
+  let hintProvider = '';
   for (const payload of [asRecord(invocationParams), asRecord(serialized)]) {
-    const fromProvider = normalizeProvider(asString(read(payload, 'provider')));
-    if (fromProvider.length > 0) {
-      return fromProvider;
-    }
-    const fromLsProvider = normalizeProvider(asString(read(payload, 'ls_provider')));
-    if (fromLsProvider.length > 0) {
-      return fromLsProvider;
+    for (const key of ['provider', 'ls_provider']) {
+      const normalized = normalizeProvider(asString(read(payload, key)));
+      if (normalized.length === 0) {
+        continue;
+      }
+      if (normalized !== 'custom') {
+        return normalized;
+      }
+      hintProvider = normalized;
     }
   }
 
-  return inferProviderFromModelName(modelName);
+  const inferred = inferProviderFromModelName(modelName);
+  if (inferred !== 'custom') {
+    return inferred;
+  }
+  return hintProvider.length > 0 ? hintProvider : inferred;
 }
 
 function resolveModelName(serialized: unknown, invocationParams: unknown): string {

--- a/js/test/frameworks.langchain.test.mjs
+++ b/js/test/frameworks.langchain.test.mjs
@@ -388,6 +388,46 @@ test('langchain infers Bedrock provider at request start and keeps custom for lo
   assert.deepEqual(providers, ['anthropic', 'custom']);
 });
 
+test('langchain non-canonical provider hint does not block Bedrock model inference', async () => {
+  // LangChain reports Bedrock as `ls_provider: 'amazon_bedrock'` (and sometimes
+  // `provider`). That hint normalizes to "custom" and must NOT short-circuit the
+  // model-name inference that recovers the real vendor from the Bedrock id.
+  const providers = [];
+
+  await captureGenerations(
+    async (client) => {
+      const handler = new SigilLangChainHandler(client);
+
+      // ls_provider hint -> still resolves anthropic from the model id.
+      await handler.handleLLMStart({}, ['x'], 'run-ls', undefined, {
+        invocation_params: { model: 'us.anthropic.claude-sonnet-4-6-v1:0', ls_provider: 'amazon_bedrock' },
+      });
+      await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-ls');
+
+      // provider hint -> same.
+      await handler.handleLLMStart({}, ['x'], 'run-prov', undefined, {
+        invocation_params: { model: 'us.anthropic.claude-sonnet-4-6-v1:0', provider: 'amazon_bedrock' },
+      });
+      await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-prov');
+
+      // Canonical hint still wins over model-name inference.
+      await handler.handleLLMStart({}, ['x'], 'run-canon', undefined, {
+        invocation_params: { model: 'claude-sonnet-4-5', ls_provider: 'openai' },
+      });
+      await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-canon');
+
+      // Genuinely custom model + non-canonical hint -> stays custom (no invented provider).
+      await handler.handleLLMStart({}, ['x'], 'run-custom', undefined, {
+        invocation_params: { model: 'my-inhouse-model', ls_provider: 'my_platform' },
+      });
+      await handler.handleLLMEnd({ generations: [[{ text: 'ok' }]] }, 'run-custom');
+    },
+    (generation) => providers.push(generation.model.provider),
+  );
+
+  assert.deepEqual(providers, ['anthropic', 'anthropic', 'openai', 'custom']);
+});
+
 test('langchain handler sets call_error on llm error', async () => {
   const generation = await captureSingleGeneration(async (client) => {
     const handler = new SigilLangChainHandler(client);

--- a/python-frameworks/langchain/tests/test_langchain_handler.py
+++ b/python-frameworks/langchain/tests/test_langchain_handler.py
@@ -283,6 +283,52 @@ def test_langchain_infers_bedrock_provider_at_request_start() -> None:
         client.shutdown()
 
 
+def test_langchain_non_canonical_provider_hint_does_not_block_bedrock_inference() -> None:
+    """LangChain reports Bedrock as ls_provider="amazon_bedrock" (and sometimes
+    "provider"). That hint normalizes to "custom" and must NOT short-circuit the
+    model-name inference that recovers the real vendor from the Bedrock id. A canonical
+    hint still wins, and a genuinely custom model keeps "custom"."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    cases = [
+        # (run label, invocation_params, expected provider)
+        ("ls", {"model": "us.anthropic.claude-sonnet-4-6-v1:0", "ls_provider": "amazon_bedrock"}, "anthropic"),
+        ("prov", {"model": "us.anthropic.claude-sonnet-4-6-v1:0", "provider": "amazon_bedrock"}, "anthropic"),
+        ("canonical", {"model": "claude-sonnet-4-5", "ls_provider": "openai"}, "openai"),
+        ("genuine_custom", {"model": "my-inhouse-model", "ls_provider": "my_platform"}, "custom"),
+    ]
+
+    try:
+        handler = SigilLangChainHandler(client=client, provider_resolver="auto")
+        run_ids = {}
+        for label, invocation_params, _ in cases:
+            run_id = uuid4()
+            run_ids[label] = run_id
+            handler.on_chat_model_start(
+                {"name": "ChatBedrock"},
+                [[{"type": "human", "content": "hello"}]],
+                run_id=run_id,
+                invocation_params=invocation_params,
+            )
+            handler.on_llm_end(
+                {
+                    "generations": [[{"text": "world"}]],
+                    "llm_output": {"model_name": invocation_params["model"]},
+                },
+                run_id=run_id,
+            )
+
+        client.flush()
+        generations = exporter.requests[0].generations
+        by_model = {g.model.name: g for g in generations}
+        for label, invocation_params, expected in cases:
+            gen = by_model[invocation_params["model"]]
+            assert gen.model.provider == expected, f"{label}: got {gen.model.provider}, want {expected}"
+    finally:
+        client.shutdown()
+
+
 def test_langchain_sync_lifecycle_extracts_anthropic_style_usage_and_stop_reason() -> None:
     """ChatAnthropic puts token usage under 'usage' (not 'token_usage') and
     stop reason under 'stop_reason' (not 'finish_reason')."""

--- a/python/sigil_sdk/framework_handler.py
+++ b/python/sigil_sdk/framework_handler.py
@@ -1016,15 +1016,26 @@ def _resolve_provider(
         resolved = _normalize_provider_name(provider_resolver(model_name, serialized, invocation_params))
         return resolved if resolved != "" else "custom"
 
+    # A framework hint (`provider`/`ls_provider`) wins only when it is a canonical
+    # provider. LangChain often reports a non-canonical hint for Bedrock (e.g.
+    # `ls_provider="amazon_bedrock"`), which `_normalize_provider_name` collapses to
+    # "custom"; treating that as authoritative would short-circuit the model-name
+    # inference that can recover the real vendor from a Bedrock id. So a "custom" hint
+    # is only kept as a last resort — model-name inference is tried first.
+    hint_provider = ""
     for payload in (invocation_params, serialized):
-        provider = _normalize_provider_name(_as_str(_read(payload, "provider")))
-        if provider != "":
-            return provider
-        provider = _normalize_provider_name(_as_str(_read(payload, "ls_provider")))
-        if provider != "":
-            return provider
+        for key in ("provider", "ls_provider"):
+            normalized = _normalize_provider_name(_as_str(_read(payload, key)))
+            if normalized == "":
+                continue
+            if normalized != "custom":
+                return normalized
+            hint_provider = normalized
 
-    return _infer_provider_from_model_name(model_name)
+    inferred = _infer_provider_from_model_name(model_name)
+    if inferred != "custom":
+        return inferred
+    return hint_provider if hint_provider != "" else inferred
 
 
 def _resolve_model_name(serialized: dict[str, Any] | None, invocation_params: dict[str, Any] | None) -> str:


### PR DESCRIPTION
## What

LangChain/LangGraph reports AWS Bedrock with a **non-canonical provider hint** — e.g. `ls_provider: "amazon_bedrock"` (sometimes `provider`). Both the JS and Python framework handlers normalized any non-openai/anthropic/gemini hint to `"custom"` and **returned it immediately**, short-circuiting the model-name inference that would otherwise recover the real vendor from a Bedrock id (e.g. `us.anthropic.claude-sonnet-4-6-v1:0` → `anthropic`). Result: the generation's provider was stamped `custom` instead of `anthropic`.

**Impact:** cosmetic for cost (the backend re-derives the provider from the model id when pricing), but **wrong for provider-based grouping/filtering in the UI**. Pre-existing bug, present since the langchain/langgraph integrations were added — **not** introduced by the recent Bedrock cost fix (#375 / #371).

## Fix

In `resolveProvider` (JS `js/src/frameworks/shared.ts`) and `_resolve_provider` (Python `python/sigil_sdk/framework_handler.py`): a framework hint wins **only when it is a canonical provider**. A hint that normalizes to `custom` is kept only as a last resort — model-name inference runs first, and `custom` is used only if inference also yields nothing better.

Resulting precedence (most specific signal wins): **explicit provider arg → provider_resolver callback → canonical hint → model-name inference → custom hint → custom**.

- Canonical hints still win over model-name inference (unchanged).
- A genuinely custom model with a non-canonical hint stays `custom` (no invented provider).
- Monotonically better-or-equal than the old behavior: the old code returned the `custom` hint without ever calling inference, so the new code can only equal or improve on it.

## Tests

Regression tests added to both langchain suites:
- `ls_provider` / `provider` = `amazon_bedrock` still resolve `anthropic` from the Bedrock id.
- A canonical hint still wins over model-name inference.
- A genuinely custom model + non-canonical hint stays `custom`.

JS `346/346`, Python langchain `17/17`; typecheck, biome, and ruff clean. Verified end-to-end against the compiled SDK (real handler → exported generation), and cross-checked with an adversarial review for precedence regressions and JS↔Python parity.

