### PR TITLE
fix(plugins/opencode): link subagent sessions to the spawning parent

### DIFF
--- a/plugins/opencode/src/hooks.lineage.test.ts
+++ b/plugins/opencode/src/hooks.lineage.test.ts
@@ -148,6 +148,16 @@ async function emitSessionDeleted(
   });
 }
 
+async function emitSessionCreated(
+  hooks: NonNullable<Awaited<ReturnType<typeof createSigilHooks>>>,
+  id: string,
+  parentID?: string,
+): Promise<void> {
+  await hooks.event({
+    event: { type: "session.created", properties: { info: { id, parentID } } },
+  });
+}
+
 describe("opencode generation lineage and streaming", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -215,6 +225,100 @@ describe("opencode generation lineage and streaming", () => {
     expect(generations[0]!.seed.id).toBe(id);
     expect(generations[1]!.seed.id).toBe(id);
     expect(generations[1]!.seed.parentGenerationIds).toBeUndefined();
+  });
+
+  it("links a subagent child session's first generation to the parent session's latest generation", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await createSigilHooks(baseConfig(), makeOpencodeClient());
+    if (!hooks) throw new Error("expected hooks");
+
+    // Parent session runs a turn, then spawns a subagent (child session).
+    await emitMessageUpdated(hooks, assistantMessage("sess-parent", "msg-1"));
+    await emitSessionCreated(hooks, "sess-child", "sess-parent");
+    await emitMessageUpdated(hooks, assistantMessage("sess-child", "msg-c1"));
+
+    const parentId = stableOpencodeGenerationId("sess-parent", "msg-1");
+    const childId = stableOpencodeGenerationId("sess-child", "msg-c1");
+    expect(generations).toHaveLength(2);
+    expect(generations[0]!.seed.id).toBe(parentId);
+    expect(generations[1]!.seed.id).toBe(childId);
+    // Child's first generation parents onto the spawning session's latest gen.
+    expect(generations[1]!.seed.parentGenerationIds).toEqual([parentId]);
+  });
+
+  it("keeps intra-session chaining for a child session's later generations", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await createSigilHooks(baseConfig(), makeOpencodeClient());
+    if (!hooks) throw new Error("expected hooks");
+
+    await emitMessageUpdated(hooks, assistantMessage("sess-parent-2", "msg-1"));
+    await emitSessionCreated(hooks, "sess-child-2", "sess-parent-2");
+    await emitMessageUpdated(hooks, assistantMessage("sess-child-2", "msg-c1"));
+    await emitMessageUpdated(hooks, assistantMessage("sess-child-2", "msg-c2"));
+
+    const childId1 = stableOpencodeGenerationId("sess-child-2", "msg-c1");
+    const childId2 = stableOpencodeGenerationId("sess-child-2", "msg-c2");
+    // The child's second turn chains to its own first turn, not the parent.
+    expect(generations[2]!.seed.id).toBe(childId2);
+    expect(generations[2]!.seed.parentGenerationIds).toEqual([childId1]);
+  });
+
+  it("freezes the parent link at session.created, not at child-record time", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await createSigilHooks(baseConfig(), makeOpencodeClient());
+    if (!hooks) throw new Error("expected hooks");
+
+    // Parent turn 1 is recorded, then the subagent is spawned. The parent then
+    // records a LATER turn 2 *before* the child's turn is recorded. The child
+    // must link to turn 1 — the turn frozen at session.created, the one it was
+    // spawned from — not the parent's latest turn 2. Recording turn 2 before
+    // the child record is what distinguishes freeze-at-creation from a lazy
+    // resolver that would read the parent's current-latest gen (turn 2) at
+    // child-record time.
+    await emitMessageUpdated(hooks, assistantMessage("sess-parent-3", "msg-1"));
+    await emitSessionCreated(hooks, "sess-child-3", "sess-parent-3");
+    await emitMessageUpdated(hooks, assistantMessage("sess-parent-3", "msg-2"));
+    await emitMessageUpdated(hooks, assistantMessage("sess-child-3", "msg-c1"));
+
+    const parentTurn1 = stableOpencodeGenerationId("sess-parent-3", "msg-1");
+    const parentTurn2 = stableOpencodeGenerationId("sess-parent-3", "msg-2");
+    const childId = stableOpencodeGenerationId("sess-child-3", "msg-c1");
+    const child = generations.find((g) => g.seed.id === childId);
+    expect(child?.seed.parentGenerationIds).toEqual([parentTurn1]);
+    // Explicitly assert it did NOT pick the parent's later turn.
+    expect(child?.seed.parentGenerationIds).not.toEqual([parentTurn2]);
+  });
+
+  it("does not link a subagent when the parent has no recorded generation yet", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await createSigilHooks(baseConfig(), makeOpencodeClient());
+    if (!hooks) throw new Error("expected hooks");
+
+    // session.created arrives before the parent has recorded any generation.
+    // No parent generation exists to freeze, so the child records unlinked
+    // (fails safe) rather than guessing.
+    await emitSessionCreated(hooks, "sess-child-4", "sess-parent-4");
+    await emitMessageUpdated(hooks, assistantMessage("sess-child-4", "msg-c1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.parentGenerationIds).toBeUndefined();
+  });
+
+  it("does not link a root session with no parentID", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await createSigilHooks(baseConfig(), makeOpencodeClient());
+    if (!hooks) throw new Error("expected hooks");
+
+    await emitSessionCreated(hooks, "sess-root");
+    await emitMessageUpdated(hooks, assistantMessage("sess-root", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.parentGenerationIds).toBeUndefined();
   });
 
   it("records first-token time from the first streamed part", async () => {

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -35,6 +35,25 @@ const recordedMessages = new Map<string, Set<string>>();
 // dedups.
 const lastGenerationIdBySession = new Map<string, string>();
 
+// Maps a child (subagent) session id to the parent generation its first
+// assistant turn should link to. opencode runs a subagent in a fresh session
+// whose `Session.parentID` points at the spawning session, surfaced via the
+// `session.created` event. We resolve the parent generation *at creation time*
+// — the spawning session's latest recorded generation — and freeze it here.
+//
+// Freezing at creation (rather than at child-record time) is deliberate: a
+// subagent is launched from a tool call inside the parent's assistant turn, so
+// the parent's *current* turn is still in flight and unrecorded when the child
+// runs. The already-recorded prior parent generation is the turn the subagent
+// was spawned from, which is the meaningful link. Resolving lazily at
+// child-record time would usually find no parent generation yet and drop the
+// edge.
+//
+// `AssistantMessage.parentID` is a message-level pointer within one session and
+// is NOT the same as `Session.parentID`; only the latter crosses the
+// parent/subagent boundary.
+const parentGenerationByChildSession = new Map<string, string>();
+
 // First streamed assistant part time per message, keyed by
 // `${sessionID}\x00${messageID}`. Captured from `message.part.updated`
 // before the message completes so it survives `metadata_only` (where we
@@ -98,6 +117,7 @@ export function _resetToolExecutionState(): void {
 export function _resetHookState(): void {
   recordedMessages.clear();
   lastGenerationIdBySession.clear();
+  parentGenerationByChildSession.clear();
   firstPartAtByMessage.clear();
   pendingGenerations.clear();
   sessionContexts.clear();
@@ -164,6 +184,10 @@ async function handleEvent(
   projectDir: string,
   event: { type: string; properties: unknown },
 ): Promise<void> {
+  if (event.type === "session.created") {
+    recordSessionParent(event.properties);
+    return;
+  }
   if (event.type === "message.part.updated") {
     await handleMessagePartUpdated(
       sigil,
@@ -322,7 +346,7 @@ async function recordAssistantMessage(
     assistantMsg.sessionID,
     assistantMsg.id,
   );
-  const parent = lastGenerationIdBySession.get(assistantMsg.sessionID);
+  const parent = resolveParentGenerationId(assistantMsg.sessionID);
   lastGenerationIdBySession.set(assistantMsg.sessionID, genId);
 
   // Look up pending generation (user-side data)
@@ -452,6 +476,47 @@ function isTerminalMessageUpdate(msg: MessageUpdatedInfo): boolean {
   return Boolean(msg.finish || msg.error || msg.time?.completed);
 }
 
+/**
+ * Record the parent/subagent link from a `session.created` event. opencode
+ * sets `Session.parentID` on a subagent's session to the spawning session;
+ * root sessions omit it. We resolve the spawning session's latest
+ * already-recorded generation now and freeze it as the child's parent (see
+ * `parentGenerationByChildSession`).
+ *
+ * `session.created` fires exactly once, at spawn time, so the frozen edge
+ * always points at the parent turn the subagent was launched from. We
+ * deliberately do NOT listen on `session.updated`: it fires repeatedly over a
+ * session's life, and freezing on a late update could capture a parent turn
+ * recorded *after* the spawning one. If the parent has no recorded generation
+ * yet at creation (rare — the spawning turn's predecessor is normally already
+ * recorded), we skip: an unlinked child is better than a wrong link. The
+ * `has(id)` guard is defensive against a duplicate `session.created`.
+ */
+function recordSessionParent(properties: unknown): void {
+  const info = recordField(properties, "info");
+  if (!info) return;
+  const id = stringField(info, "id");
+  const parentID = stringField(info, "parentID");
+  if (!id || !parentID || id === parentID) return;
+  if (parentGenerationByChildSession.has(id)) return;
+  const parentGeneration = lastGenerationIdBySession.get(parentID);
+  if (!parentGeneration) return;
+  parentGenerationByChildSession.set(id, parentGeneration);
+}
+
+/**
+ * Resolve the parent generation id for a session's next assistant generation.
+ * Prefer the previous assistant generation recorded for this same session
+ * (intra-session chain). When this is the session's first generation and the
+ * session is a subagent child, fall back to the parent generation frozen at
+ * `session.created`, linking the subagent run to the turn it was spawned from.
+ */
+function resolveParentGenerationId(sessionID: string): string | undefined {
+  const intra = lastGenerationIdBySession.get(sessionID);
+  if (intra) return intra;
+  return parentGenerationByChildSession.get(sessionID);
+}
+
 async function handleLifecycle(
   sigil: SigilClient,
   telemetry: TelemetryProviders | null,
@@ -483,6 +548,7 @@ async function handleLifecycle(
     if (sessionId) {
       recordedMessages.delete(sessionId);
       lastGenerationIdBySession.delete(sessionId);
+      parentGenerationByChildSession.delete(sessionId);
       pendingGenerations.delete(sessionId);
       sessionContexts.delete(sessionId);
       completedToolExecutions.delete(sessionId);


### PR DESCRIPTION
## What

When OpenCode invokes a subagent, it runs in a fresh session whose `Session.parentID` points at the spawning session (delivered on the `session.created` event). The plugin previously chained generations only *within* a session, so a subagent run showed up as an **unrelated conversation** instead of a child of the run that spawned it.

This resolves the spawning session's latest already-recorded generation at `session.created` time and freezes it as the child's parent, so the child's first assistant generation links back (via `parentGenerationIds`) to the turn it was launched from. Subsequent turns of the child still chain intra-session.

related to https://github.com/grafana/support-escalations/issues/23291 
Addresses issue num.2 of the OpenCode plugin escalation (Guard transform/message-evaluation (issue num.3) is a separate follow-up.

## Why this design

- **Freeze at creation, not at child-record time.** A subagent is launched from a tool call inside the parent's assistant turn, so the parent's *spawning* turn is still in flight (unrecorded) when the child runs. A lazy lookup at child-record time would usually find no parent generation yet and drop the edge. The parent turn already recorded at `session.created` is the meaningful link.
- **Listen only on `session.created`, not `session.updated`.** `session.created` fires once, at spawn. `session.updated` fires repeatedly and could freeze onto a *later*, non-spawning parent turn (a race the second review caught).
- **Fail safe.** If the parent has no recorded generation at creation, the child is left unlinked rather than mislinked. Root sessions (no `parentID`) are unaffected — behavior there is byte-identical to before.

`AssistantMessage.parentID` is a message-level pointer within one session and is **distinct** from `Session.parentID`; only the latter crosses the parent/subagent boundary.

## Tests

Added lineage tests: subagent→parent linking, intra-session chaining of the child's later turns, freeze-at-creation (asserts it does *not* pick a later parent turn — verified this test fails under a lazy-resolution mutation), fail-safe when the parent has no generation yet, and root-session no-op. Full suite: 158 tests pass; typecheck and lint clean.

## ⚠️ Verification gap

This is verified with **synthetic events** only. It relies on OpenCode's real event ordering — that `session.created` (carrying `parentID`) arrives before the subagent's first message, and that the parent already has a recorded generation at that point. This has **not** been confirmed against a live OpenCode subagent run. Fails safe (unlinked, never mislinked) if the ordering assumption doesn't hold. A real run or debug log would close this.



