### PR TITLE
fix(plugins/opencode): apply guard tool-call argument transforms

### DIFF
--- a/plugins/opencode/src/guard.test.ts
+++ b/plugins/opencode/src/guard.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, it } from "vitest";
+import type { GuardResult } from "./guard.js";
 import { runToolCallGuard } from "./guard.js";
+
+/** Narrow a GuardResult to a block result, failing the test otherwise. */
+function asBlock(res: GuardResult): { block: true; reason: string } {
+  if (!res || !("block" in res)) {
+    throw new Error(`expected a block result, got ${JSON.stringify(res)}`);
+  }
+  return res;
+}
+
+/** Narrow a GuardResult to a transform result, failing the test otherwise. */
+function asTransform(res: GuardResult): { transform: Record<string, unknown> } {
+  if (!res || !("transform" in res)) {
+    throw new Error(`expected a transform result, got ${JSON.stringify(res)}`);
+  }
+  return res;
+}
 
 describe("runToolCallGuard", () => {
   it("returns undefined when Sigil allows the tool call", async () => {
@@ -48,11 +65,12 @@ describe("runToolCallGuard", () => {
       failOpen: true,
     });
 
-    expect(res?.block).toBe(true);
-    expect(res?.reason).toContain("A Grafana AI Observability policy");
-    expect(res?.reason).toContain('"bash"');
-    expect(res?.reason).toContain("Reason: blocked by rule");
-    expect(res?.reason).toContain("Stop and tell the user");
+    const block = asBlock(res);
+    expect(block.block).toBe(true);
+    expect(block.reason).toContain("A Grafana AI Observability policy");
+    expect(block.reason).toContain('"bash"');
+    expect(block.reason).toContain("Reason: blocked by rule");
+    expect(block.reason).toContain("Stop and tell the user");
   });
 
   it("omits the Reason clause when Sigil denies without a reason", async () => {
@@ -74,11 +92,12 @@ describe("runToolCallGuard", () => {
       failOpen: true,
     });
 
-    expect(res?.block).toBe(true);
-    expect(res?.reason).toContain("A Grafana AI Observability policy");
-    expect(res?.reason).toContain('"bash"');
-    expect(res?.reason).not.toContain("Reason:");
-    expect(res?.reason).toContain("Stop and tell the user");
+    const block = asBlock(res);
+    expect(block.block).toBe(true);
+    expect(block.reason).toContain("A Grafana AI Observability policy");
+    expect(block.reason).toContain('"bash"');
+    expect(block.reason).not.toContain("Reason:");
+    expect(block.reason).toContain("Stop and tell the user");
   });
 
   it("returns a wrapped fail-closed message when the SDK throws (fail-closed mode)", async () => {
@@ -98,12 +117,13 @@ describe("runToolCallGuard", () => {
       failOpen: false,
     });
 
-    expect(res?.block).toBe(true);
-    expect(res?.reason).toContain("could not evaluate");
-    expect(res?.reason).toContain("safety measure");
-    expect(res?.reason).toContain('"bash"');
-    expect(res?.reason).toContain("network down");
-    expect(res?.reason).not.toContain(
+    const block = asBlock(res);
+    expect(block.block).toBe(true);
+    expect(block.reason).toContain("could not evaluate");
+    expect(block.reason).toContain("safety measure");
+    expect(block.reason).toContain('"bash"');
+    expect(block.reason).toContain("network down");
+    expect(block.reason).not.toContain(
       "A Grafana AI Observability policy blocked",
     );
   });
@@ -145,6 +165,160 @@ describe("runToolCallGuard", () => {
       toolCallId: "c1",
       toolName: "bash",
       input: circular,
+      failOpen: true,
+    });
+
+    expect(res).toBeUndefined();
+  });
+
+  it("returns a transform when the server redacts the tool arguments", async () => {
+    const client = {
+      evaluateHook: async () => ({
+        action: "allow",
+        evaluations: [],
+        transformedInput: {
+          output: [
+            {
+              role: "assistant",
+              parts: [
+                {
+                  type: "tool_call",
+                  toolCall: {
+                    id: "c1",
+                    name: "bash",
+                    inputJSON: JSON.stringify({ command: "echo [REDACTED]" }),
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    };
+
+    const res = await runToolCallGuard({
+      client: client as any,
+      agentName: "opencode",
+      model: { provider: "anthropic", name: "claude" },
+      toolCallId: "c1",
+      toolName: "bash",
+      input: { command: "echo sonia@grafana.com" },
+      failOpen: true,
+    });
+
+    const t = asTransform(res);
+    expect(t.transform).toEqual({ command: "echo [REDACTED]" });
+  });
+
+  it("prefers a deny over a transform when the server returns both", async () => {
+    const client = {
+      evaluateHook: async () => ({
+        action: "deny",
+        reason: "pii detected",
+        evaluations: [],
+        transformedInput: {
+          output: [
+            {
+              role: "assistant",
+              parts: [
+                {
+                  type: "tool_call",
+                  toolCall: {
+                    id: "c1",
+                    name: "bash",
+                    inputJSON: JSON.stringify({ command: "redacted" }),
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    };
+
+    const res = await runToolCallGuard({
+      client: client as any,
+      agentName: "opencode",
+      model: { provider: "anthropic", name: "claude" },
+      toolCallId: "c1",
+      toolName: "bash",
+      input: { command: "leak" },
+      failOpen: true,
+    });
+
+    expect(asBlock(res).reason).toContain("Reason: pii detected");
+  });
+
+  it("ignores a transform whose tool_call id does not match", async () => {
+    const client = {
+      evaluateHook: async () => ({
+        action: "allow",
+        evaluations: [],
+        transformedInput: {
+          output: [
+            {
+              role: "assistant",
+              parts: [
+                {
+                  type: "tool_call",
+                  toolCall: {
+                    id: "other-call",
+                    name: "bash",
+                    inputJSON: JSON.stringify({ command: "x" }),
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    };
+
+    const res = await runToolCallGuard({
+      client: client as any,
+      agentName: "opencode",
+      model: { provider: "anthropic", name: "claude" },
+      toolCallId: "c1",
+      toolName: "bash",
+      input: { command: "ls" },
+      failOpen: true,
+    });
+
+    expect(res).toBeUndefined();
+  });
+
+  it("drops a transform whose arguments are not a JSON object", async () => {
+    const client = {
+      evaluateHook: async () => ({
+        action: "allow",
+        evaluations: [],
+        transformedInput: {
+          output: [
+            {
+              role: "assistant",
+              parts: [
+                {
+                  type: "tool_call",
+                  toolCall: {
+                    id: "c1",
+                    name: "bash",
+                    inputJSON: JSON.stringify(["not", "an", "object"]),
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    };
+
+    const res = await runToolCallGuard({
+      client: client as any,
+      agentName: "opencode",
+      model: { provider: "anthropic", name: "claude" },
+      toolCallId: "c1",
+      toolName: "bash",
+      input: { command: "ls" },
       failOpen: true,
     });
 

--- a/plugins/opencode/src/guard.ts
+++ b/plugins/opencode/src/guard.ts
@@ -1,4 +1,8 @@
-import type { HookEvaluateRequest, SigilClient } from "@grafana/sigil-sdk-js";
+import type {
+  HookEvaluateRequest,
+  Message,
+  SigilClient,
+} from "@grafana/sigil-sdk-js";
 
 export interface GuardArgs {
   client: SigilClient;
@@ -9,9 +13,19 @@ export interface GuardArgs {
   toolName: string;
   input: unknown;
   failOpen: boolean;
+  logger?: { warn: (msg: string) => void };
 }
 
 export type GuardBlockResult = { block: true; reason: string };
+
+/**
+ * A postflight transform the server applied to the tool call's arguments. The
+ * caller replaces the tool input with this redacted/sanitized argument set
+ * before the tool runs.
+ */
+export type GuardTransformResult = { transform: Record<string, unknown> };
+
+export type GuardResult = GuardBlockResult | GuardTransformResult | undefined;
 
 /**
  * Instructs the model how to react to a guard deny verdict, so the reason is
@@ -63,13 +77,12 @@ function formatEvalFailure(
 
 /**
  * Evaluates the Sigil postflight hook for a tool call. Returns a block result
- * when the server denies the call. On transport/timeout/serialization errors,
- * returns `undefined` (allow) when `failOpen` is true and a block result when
- * `failOpen` is false.
+ * when the server denies the call, or a transform result when the server
+ * redacted/sanitized the call's arguments. On transport/timeout/serialization
+ * errors, returns `undefined` (allow) when `failOpen` is true and a block
+ * result when `failOpen` is false.
  */
-export async function runToolCallGuard(
-  args: GuardArgs,
-): Promise<GuardBlockResult | undefined> {
+export async function runToolCallGuard(args: GuardArgs): Promise<GuardResult> {
   try {
     const req: HookEvaluateRequest = {
       phase: "postflight",
@@ -107,8 +120,17 @@ export async function runToolCallGuard(
         reason: formatPolicyDeny(args.toolName, resp.reason),
       };
     }
+    const transform = extractToolCallTransform(
+      resp.transformedInput?.output,
+      args.toolCallId,
+      args.logger,
+    );
+    if (transform) {
+      return { transform };
+    }
     return undefined;
   } catch (err) {
+    args.logger?.warn(`guard eval failed: ${err}`);
     if (!args.failOpen) {
       return {
         block: true,
@@ -117,4 +139,54 @@ export async function runToolCallGuard(
     }
     return undefined;
   }
+}
+
+/**
+ * Walks the server-returned `transformed_input.output` for the tool_call part
+ * matching `toolCallId` and parses its `inputJSON` into an object. Returns
+ * `undefined` on any mismatch or parse failure so the caller falls through to
+ * the original tool input unchanged.
+ *
+ * Mirrors `extractToolCallTransform` in `plugins/pi/src/guard.ts`; keep the two
+ * aligned so both plugins consume the server transform identically.
+ */
+function extractToolCallTransform(
+  output: Message[] | undefined,
+  toolCallId: string | undefined,
+  logger?: { warn: (msg: string) => void },
+): Record<string, unknown> | undefined {
+  if (!output || output.length === 0 || !toolCallId) return undefined;
+  for (const msg of output) {
+    if (!msg.parts) continue;
+    for (const part of msg.parts) {
+      if (part.type !== "tool_call") continue;
+      const tc = part.toolCall;
+      if (!tc || tc.id !== toolCallId) continue;
+      const raw = tc.inputJSON;
+      if (typeof raw !== "string" || raw.length === 0) {
+        logger?.warn(
+          `tool-call transform for ${toolCallId} dropped: empty arguments`,
+        );
+        return undefined;
+      }
+      try {
+        const parsed = JSON.parse(raw) as unknown;
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          logger?.warn(`tool-call transform for ${toolCallId} applied`);
+          return parsed as Record<string, unknown>;
+        }
+        logger?.warn(
+          `tool-call transform for ${toolCallId} dropped: arguments were not a JSON object`,
+        );
+        return undefined;
+      } catch {
+        logger?.warn(
+          `tool-call transform for ${toolCallId} dropped: invalid JSON arguments`,
+        );
+        return undefined;
+      }
+    }
+  }
+  logger?.warn(`tool-call transform present but no part matched ${toolCallId}`);
+  return undefined;
 }

--- a/plugins/opencode/src/guard.ts
+++ b/plugins/opencode/src/guard.ts
@@ -172,7 +172,8 @@ function extractToolCallTransform(
       try {
         const parsed = JSON.parse(raw) as unknown;
         if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-          logger?.warn(`tool-call transform for ${toolCallId} applied`);
+          // Extraction only — the caller logs whether the transform was
+          // actually applied, so a parse here is never mistaken for success.
           return parsed as Record<string, unknown>;
         }
         logger?.warn(

--- a/plugins/opencode/src/hooks.guard.test.ts
+++ b/plugins/opencode/src/hooks.guard.test.ts
@@ -136,6 +136,158 @@ describe("opencode guards", () => {
     await hooks.event({ event: { type: "global.disposed", properties: {} } });
   });
 
+  it("rewrites tool.execute.before args in place when Sigil returns a transform", async () => {
+    const hookServer = await startHookServer({
+      action: "allow",
+      evaluations: [],
+      transformed_input: {
+        output: [
+          {
+            role: "assistant",
+            parts: [
+              {
+                type: "tool_call",
+                toolCall: {
+                  id: "call-1",
+                  name: "bash",
+                  inputJSON: JSON.stringify({ command: "echo [REDACTED]" }),
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    servers.push(hookServer.server);
+
+    const hooks = await createSigilHooks(config(hookServer.baseUrl), {
+      session: { message: async () => ({ data: { parts: [] } }) },
+    } as any);
+    if (!hooks) throw new Error("expected hooks");
+
+    // A secret key alongside the command; the server drops it and rewrites
+    // command, so the applied args must contain only the redacted command.
+    const args: Record<string, unknown> = {
+      command: "echo sonia@grafana.com",
+      apiKey: "sk-secret",
+    };
+
+    // Must not throw (allow + transform, not a block).
+    await hooks.toolExecuteBefore(
+      { sessionID: "sess-1", callID: "call-1", tool: "bash" },
+      { args },
+    );
+
+    // Wholesale replacement: dropped key gone, command redacted, same object.
+    expect(args).toEqual({ command: "echo [REDACTED]" });
+    expect(args.apiKey).toBeUndefined();
+
+    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+  });
+
+  it("leaves tool.execute.before args unchanged when Sigil allows without a transform", async () => {
+    const hookServer = await startHookServer({
+      action: "allow",
+      evaluations: [],
+    });
+    servers.push(hookServer.server);
+
+    const hooks = await createSigilHooks(config(hookServer.baseUrl), {
+      session: { message: async () => ({ data: { parts: [] } }) },
+    } as any);
+    if (!hooks) throw new Error("expected hooks");
+
+    const args: Record<string, unknown> = { command: "ls" };
+    await hooks.toolExecuteBefore(
+      { sessionID: "sess-1", callID: "call-1", tool: "bash" },
+      { args },
+    );
+
+    expect(args).toEqual({ command: "ls" });
+
+    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+  });
+
+  it("strips all args when Sigil returns an empty-object transform", async () => {
+    const hookServer = await startHookServer({
+      action: "allow",
+      evaluations: [],
+      transformed_input: {
+        output: [
+          {
+            role: "assistant",
+            parts: [
+              {
+                type: "tool_call",
+                toolCall: { id: "call-1", name: "bash", inputJSON: "{}" },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    servers.push(hookServer.server);
+
+    const hooks = await createSigilHooks(config(hookServer.baseUrl), {
+      session: { message: async () => ({ data: { parts: [] } }) },
+    } as any);
+    if (!hooks) throw new Error("expected hooks");
+
+    const args: Record<string, unknown> = { command: "secret", apiKey: "x" };
+    await hooks.toolExecuteBefore(
+      { sessionID: "sess-1", callID: "call-1", tool: "bash" },
+      { args },
+    );
+
+    // An intentional "strip all arguments" transform empties the object.
+    expect(args).toEqual({});
+
+    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+  });
+
+  it("fails open and leaves args untouched when args are not a plain object", async () => {
+    const hookServer = await startHookServer({
+      action: "allow",
+      evaluations: [],
+      transformed_input: {
+        output: [
+          {
+            role: "assistant",
+            parts: [
+              {
+                type: "tool_call",
+                toolCall: {
+                  id: "call-1",
+                  name: "bash",
+                  inputJSON: JSON.stringify({ 0: "x" }),
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    servers.push(hookServer.server);
+
+    const hooks = await createSigilHooks(config(hookServer.baseUrl), {
+      session: { message: async () => ({ data: { parts: [] } }) },
+    } as any);
+    if (!hooks) throw new Error("expected hooks");
+
+    // opencode hands tool args as an object; an array here stands in for any
+    // non-plain-object value the apply path must refuse to mutate.
+    const args: unknown[] = ["ls", "-la"];
+    await hooks.toolExecuteBefore(
+      { sessionID: "sess-1", callID: "call-1", tool: "bash" },
+      { args },
+    );
+
+    // Fail open: the original (unmutated) args are preserved.
+    expect(args).toEqual(["ls", "-la"]);
+
+    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+  });
+
   it("sets permission.ask output to deny when Sigil denies", async () => {
     const hookServer = await startHookServer({
       action: "deny",

--- a/plugins/opencode/src/hooks.guard.test.ts
+++ b/plugins/opencode/src/hooks.guard.test.ts
@@ -136,7 +136,7 @@ describe("opencode guards", () => {
     await hooks.event({ event: { type: "global.disposed", properties: {} } });
   });
 
-  it("rewrites tool.execute.before args in place when Sigil returns a transform", async () => {
+  it("replaces frozen tool.execute.before args with the redacted set", async () => {
     const hookServer = await startHookServer({
       action: "allow",
       evaluations: [],
@@ -165,22 +165,26 @@ describe("opencode guards", () => {
     } as any);
     if (!hooks) throw new Error("expected hooks");
 
-    // A secret key alongside the command; the server drops it and rewrites
-    // command, so the applied args must contain only the redacted command.
-    const args: Record<string, unknown> = {
-      command: "echo sonia@grafana.com",
-      apiKey: "sk-secret",
+    // opencode >=1.14 freezes output.args. A secret key sits alongside the
+    // command; the server drops it and rewrites command. The redacted set must
+    // replace output.args even though the original is frozen — an in-place
+    // mutation would throw and silently leak the original.
+    const output = {
+      args: Object.freeze({
+        command: "echo sonia@grafana.com",
+        apiKey: "sk-secret",
+      }) as Record<string, unknown>,
     };
 
     // Must not throw (allow + transform, not a block).
     await hooks.toolExecuteBefore(
       { sessionID: "sess-1", callID: "call-1", tool: "bash" },
-      { args },
+      output,
     );
 
-    // Wholesale replacement: dropped key gone, command redacted, same object.
-    expect(args).toEqual({ command: "echo [REDACTED]" });
-    expect(args.apiKey).toBeUndefined();
+    // Wholesale replacement: dropped key gone, command redacted.
+    expect(output.args).toEqual({ command: "echo [REDACTED]" });
+    expect(output.args.apiKey).toBeUndefined();
 
     await hooks.event({ event: { type: "global.disposed", properties: {} } });
   });
@@ -233,14 +237,16 @@ describe("opencode guards", () => {
     } as any);
     if (!hooks) throw new Error("expected hooks");
 
-    const args: Record<string, unknown> = { command: "secret", apiKey: "x" };
+    const output: { args: Record<string, unknown> } = {
+      args: { command: "secret", apiKey: "x" },
+    };
     await hooks.toolExecuteBefore(
       { sessionID: "sess-1", callID: "call-1", tool: "bash" },
-      { args },
+      output,
     );
 
     // An intentional "strip all arguments" transform empties the object.
-    expect(args).toEqual({});
+    expect(output.args).toEqual({});
 
     await hooks.event({ event: { type: "global.disposed", properties: {} } });
   });

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -586,18 +586,20 @@ async function handleLifecycle(
 async function handleToolExecuteBefore(
   sigil: SigilClient,
   config: SigilOpencodeConfig,
+  debugLog: (msg: string, ...args: unknown[]) => void,
   input: { tool: string; sessionID: string; callID: string },
   output: { args: unknown },
 ): Promise<void> {
   const key = toolExecutionKey(input.sessionID, input.callID);
-  activeToolExecutions.set(key, {
+  const record: ToolExecutionRecord = {
     sessionID: input.sessionID,
     toolName: input.tool,
     toolCallId: input.callID,
     startedAt: Date.now(),
     completedAt: 0,
     input: output.args,
-  });
+  };
+  activeToolExecutions.set(key, record);
 
   const guards = config.guards;
   if (guards?.enabled !== true) return;
@@ -610,10 +612,39 @@ async function handleToolExecuteBefore(
     toolName: input.tool,
     input: output.args ?? {},
     failOpen: guards.failOpen,
+    logger: { warn: (msg: string) => debugLog(msg) },
   });
-  if (res?.block) {
+  if (!res) return;
+  if ("block" in res) {
     activeToolExecutions.delete(key);
     throw new Error(res.reason);
+  }
+  // Postflight transform: the server returned the complete redacted argument
+  // set, so replace the tool input wholesale. A plain Object.assign would merge
+  // instead, leaving any key the server dropped (an unredacted original) in
+  // place. opencode reads the mutated `output.args` at execution time. Redaction
+  // fails open: if the patch cannot be applied (args not a plain object, frozen,
+  // etc.) log and let the original arguments through rather than throwing, which
+  // opencode would treat as a tool failure.
+  try {
+    const args = output.args;
+    if (args && typeof args === "object" && !Array.isArray(args)) {
+      const argsObj = args as Record<string, unknown>;
+      for (const argKey of Object.keys(argsObj)) {
+        if (!Object.hasOwn(res.transform, argKey)) {
+          delete argsObj[argKey];
+        }
+      }
+      Object.assign(argsObj, res.transform);
+      // Keep the recorded span consistent with what actually runs.
+      record.input = argsObj;
+    } else {
+      debugLog(
+        `tool-call transform for ${input.callID} dropped: args are not a plain object`,
+      );
+    }
+  } catch (err) {
+    debugLog(`tool-call transform apply failed for ${input.callID}`, err);
   }
 }
 
@@ -658,8 +689,11 @@ async function handlePermissionAsk(
       metadata: input.metadata,
     },
     failOpen: guards.failOpen,
+    logger: { warn: (msg: string) => debugLog(msg) },
   });
-  if (res?.block) {
+  // permission.ask carries no tool arguments to rewrite, so only a block is
+  // actionable here; a transform result (if any) is ignored.
+  if (res && "block" in res) {
     output.status = "deny";
     // Log the reason so it's recoverable from the debug log; opencode's
     // permission.ask output API has no field to surface it to the model or
@@ -985,7 +1019,7 @@ export async function createSigilHooks(
       handleChatMessage(input, output);
     },
     toolExecuteBefore: async (input, output) => {
-      await handleToolExecuteBefore(sigil, config, input, output);
+      await handleToolExecuteBefore(sigil, config, debugLog, input, output);
     },
     toolExecuteAfter: (input, output) => {
       handleToolExecuteAfter(input, output);

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -620,29 +620,32 @@ async function handleToolExecuteBefore(
     throw new Error(res.reason);
   }
   // Postflight transform: the server returned the complete redacted argument
-  // set, so replace the tool input wholesale. A plain Object.assign would merge
-  // instead, leaving any key the server dropped (an unredacted original) in
-  // place. opencode reads the mutated `output.args` at execution time. Redaction
-  // fails open: if the patch cannot be applied (args not a plain object, frozen,
-  // etc.) log and let the original arguments through rather than throwing, which
-  // opencode would treat as a tool failure.
+  // set. Replace `output.args` with a fresh object rather than mutating the
+  // existing one in place: opencode freezes `output.args` on newer versions
+  // (>=1.14), so an in-place `delete`/`Object.assign` would throw and, caught
+  // below, silently run the ORIGINAL unredacted arguments. Reassigning the
+  // property on the (unfrozen) `output` container sidesteps that and still
+  // gives opencode the redacted set at execution time. A fresh object also
+  // enforces wholesale replacement — keys the server dropped do not survive.
+  //
+  // Redaction fails open: if the args aren't a plain object or reassignment
+  // throws, log and let the original arguments through rather than throwing,
+  // which opencode would treat as a tool failure. Because a silently-skipped
+  // redaction is indistinguishable from a leak, only log success once the
+  // replacement has actually happened (not when the transform was parsed).
+  const args = output.args;
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    debugLog(
+      `tool-call transform for ${input.callID} dropped: args are not a plain object`,
+    );
+    return;
+  }
   try {
-    const args = output.args;
-    if (args && typeof args === "object" && !Array.isArray(args)) {
-      const argsObj = args as Record<string, unknown>;
-      for (const argKey of Object.keys(argsObj)) {
-        if (!Object.hasOwn(res.transform, argKey)) {
-          delete argsObj[argKey];
-        }
-      }
-      Object.assign(argsObj, res.transform);
-      // Keep the recorded span consistent with what actually runs.
-      record.input = argsObj;
-    } else {
-      debugLog(
-        `tool-call transform for ${input.callID} dropped: args are not a plain object`,
-      );
-    }
+    const redacted = { ...res.transform };
+    output.args = redacted;
+    // Keep the recorded span consistent with what actually runs.
+    record.input = redacted;
+    debugLog(`tool-call transform for ${input.callID} applied`);
   } catch (err) {
     debugLog(`tool-call transform apply failed for ${input.callID}`, err);
   }


### PR DESCRIPTION
## What

The OpenCode guard previously only honored a `deny` verdict and **ignored** the server's `transformedInput`. So a Sigil transform/redaction guard targeting tool-call arguments would evaluate but never actually redact what the tool ran with — the gap reported in the escalation (Transform-type guards "did not work at all").

This extends `runToolCallGuard` to return a transform result when the server redacts a tool call's arguments, and applies it in `tool.execute.before` by replacing `output.args` **wholesale** (delete keys the server dropped, then assign the redacted set). The tool then executes with — and the exported tool span records — the redacted arguments.

Mirrors `extractToolCallTransform` in `plugins/pi/src/guard.ts` so both plugins consume the server transform identically.

Addresses the Transform-guard part of issue num.3 of the OpenCode plugin [escalation](https://github.com/grafana/support-escalations/issues/23291) 

## Scope

This covers **tool-call argument** redaction (postflight), which is the path the escalation's repro exercised (`git config --global user.email` flowing through a tool). It does **not** cover redacting the initial user message or subagent Task-request payloads — OpenCode only exposes an `experimental.*` message-transform hook for that, and building a security-grade feature on it needs empirical verification that the mutation reaches the provider. Tracked as a separate follow-up.

## ⚠️ Design decision to confirm: redaction fails open

If the transform **can't be applied** — args aren't a plain object, `inputJSON` is unparseable/non-object, or no `tool_call` part matches the call id — the original (unredacted) args run and the reason is logged. This is **asymmetric** with `deny`/eval-failure, which fail *closed* when `failOpen=false`.

Rationale: a mangled transform is a data/version-skew problem, and blocking every call on it is a severe availability hit. It also matches the already-shipped Pi plugin. **But** it means a server relying on transform-based redaction gets no hard guarantee it was applied. A reviewer with the threat model in mind may want the *matched-but-unparseable* case (a strong signal of intended redaction) to fail closed even when `failOpen=true`. Flagging for a decision — left fail-open here for Pi parity.

## permission.ask

Unchanged in spirit: it has no tool arguments to rewrite, so it continues to honor only a block and ignores any transform.

## Tests

`guard.test.ts`: transform returned on redaction, deny-takes-precedence-over-transform, no-matching-tool-call → no transform, non-object args → no transform. `hooks.guard.test.ts` (real HTTP server): in-place mutation of `output.args` observed on the caller's own reference (proves the redacted args reach execution), allow-without-transform leaves args unchanged, empty-object transform strips all args, and non-plain-object args fail open. 166 tests pass; typecheck and lint clean.



