### PR TITLE
feat(plugins/opencode): capture system prompt

### DIFF
--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -127,7 +127,7 @@ Built-in tags win collisions with user tags, matching the claude-code and cursor
 | `SIGIL_GUARDS_TIMEOUT_MS` | `1500` | Per-evaluation guard timeout in milliseconds. |
 | `SIGIL_GUARDS_FAIL_OPEN` | `true` | Allow tool calls if guard evaluation fails. Set to `false` to fail closed. |
 | `SIGIL_AGENT_NAME` | `opencode` | Agent name reported to Sigil. The plugin appends `:<mode>` for OpenCode's UI mode, such as `build` or `plan`. |
-| `SIGIL_AGENT_VERSION` | — | Optional version string reported with the agent. |
+| `SIGIL_AGENT_VERSION` | OpenCode version | Version string reported with the agent. |
 | `SIGIL_DEBUG` | `false` | Log lifecycle events to stderr. |
 
 File format: one `KEY=value` per line, `#` line comments, optional `export ` prefix, optional matching single or double quotes around the value. Only `SIGIL_*` keys plus `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_INSECURE`, and `OTEL_SERVICE_NAME` are honored — anything else (including stray `PATH=…` lines) is ignored.

--- a/plugins/opencode/biome.json
+++ b/plugins/opencode/biome.json
@@ -41,7 +41,7 @@
   },
   "overrides": [
     {
-      "includes": ["**/*.test.ts"],
+      "includes": ["**/*.test.ts", "**/*.testutil.ts"],
       "linter": {
         "rules": {
           "suspicious": {

--- a/plugins/opencode/src/golden.test.ts
+++ b/plugins/opencode/src/golden.test.ts
@@ -92,14 +92,13 @@ function closeServer(server: Server): Promise<void> {
   });
 }
 
-// opencodeMessageFixture builds an OpenCode AssistantMessage + Part list
-// representing a single turn that includes both an assistant text reply
-// and a completed tool call. New tool scenarios are a small extension of
-// this fixture: add another ToolPart to assistantParts with the desired
-// state.
+// Build one assistant reply with a completed tool call and the composed
+// system prompt OpenCode delivers through `experimental.chat.system.transform`.
 function opencodeMessageFixture() {
   const sessionID = "opencode-sess-1";
   const messageID = "msg-1";
+  // Leave `system` and `tools` unset. Real OpenCode sessions rarely set these
+  // per-request overrides.
   const userMessage = {
     id: "user-1",
     sessionID,
@@ -107,9 +106,11 @@ function opencodeMessageFixture() {
     time: { created: 1_700_000_000_000 },
     agent: "build",
     model: { providerID: "anthropic", modelID: "claude-sonnet-4-opencode" },
-    system: "you are a helpful assistant",
-    tools: { Bash: true, Read: true },
   } as const;
+  const effectiveSystem = [
+    "you are a helpful assistant",
+    "<env>cwd: /repo/oc-app</env>",
+  ];
   const userParts = [
     {
       id: "user-text-1",
@@ -169,6 +170,7 @@ function opencodeMessageFixture() {
     userParts,
     assistantMessage,
     assistantParts,
+    effectiveSystem,
   };
 }
 
@@ -223,6 +225,7 @@ describe("opencode plugin: real-SDK golden export", () => {
       userParts,
       assistantMessage,
       assistantParts,
+      effectiveSystem,
     } = opencodeMessageFixture();
 
     const config: SigilOpencodeConfig = {
@@ -252,13 +255,15 @@ describe("opencode plugin: real-SDK golden export", () => {
     const hooks = await createSigilHooks(config, fakeClient);
     if (!hooks) throw new Error("expected createSigilHooks to return hooks");
 
-    // chat.message stores the user-side context. message.updated fires
-    // once the assistant turn is terminal; the plugin then issues a
-    // session.message REST call to fetch assistant parts and exports the
-    // generation through the SDK.
+    // Store the user message, capture the composed system prompt, then
+    // export when the assistant message completes.
     hooks.chatMessage(
       { sessionID },
       { message: userMessage as any, parts: userParts as any },
+    );
+    hooks.systemTransform(
+      { sessionID, model: { id: assistantMessage.modelID } },
+      { system: effectiveSystem },
     );
     await hooks.event({
       event: {
@@ -346,11 +351,26 @@ describe("opencode plugin: real-SDK golden export", () => {
       contentCapture,
     );
     expect(messageFetches).toBe(contentCapture === "metadata_only" ? 0 : 1);
+    // Tool names come from the tools the turn used. This fixture never
+    // drives the tool.execute hooks, so in metadata_only (no parts fetch)
+    // there is no tool source at all.
     if (contentCapture === "metadata_only") {
-      expect(turn.tools.map((tool: any) => tool.name)).toEqual([
-        "Bash",
-        "Read",
-      ]);
+      expect(turn.tools ?? []).toEqual([]);
+    } else {
+      expect(turn.tools.map((tool: any) => tool.name)).toEqual(["Bash"]);
+      for (const tool of turn.tools) {
+        expect(tool.type).toBe("function");
+        expect(tool.description ?? "").toBe("");
+        expect(tool.input_schema_json ?? "").toBe("");
+      }
+    }
+    // metadata_only omits the system prompt.
+    if (contentCapture === "metadata_only") {
+      expect(turn.system_prompt ?? "").toBe("");
+    } else {
+      expect(turn.system_prompt).toBe(
+        "you are a helpful assistant\n<env>cwd: /repo/oc-app</env>",
+      );
     }
     // full_with_metadata_spans must keep tool bodies in the proto export
     // (the SDK splits content only on the OTel span side); see

--- a/plugins/opencode/src/hooks.capture.test.ts
+++ b/plugins/opencode/src/hooks.capture.test.ts
@@ -1,0 +1,393 @@
+// Tests system prompt capture via `experimental.chat.system.transform`,
+// name-only tool definitions, and host version capture.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createSigilClientMock, createTelemetryProvidersMock } = vi.hoisted(
+  () => ({
+    createSigilClientMock: vi.fn(),
+    createTelemetryProvidersMock: vi.fn(),
+  }),
+);
+
+vi.mock("./client.js", () => ({ createSigilClient: createSigilClientMock }));
+vi.mock("./telemetry.js", () => ({
+  createTelemetryProviders: createTelemetryProvidersMock,
+}));
+
+import { _resetHookState, createSigilHooks } from "./hooks.js";
+import {
+  assistantMessage,
+  baseConfig,
+  emitMessageUpdated,
+  emitSessionDeleted,
+  makeOpencodeClient,
+  makeSigilMock,
+  type TestHooks,
+} from "./hooks.testutil.js";
+
+function userMessage(sessionID: string) {
+  return {
+    id: "user-1",
+    sessionID,
+    role: "user",
+    time: { created: 1_700_000_000_000 },
+    agent: "build",
+    model: { providerID: "anthropic", modelID: "claude-sonnet-4" },
+    system: "legacy system",
+    tools: { legacybash: true, disabled: false },
+  } as any;
+}
+
+async function makeHooks(
+  config = baseConfig(),
+  client = makeOpencodeClient(),
+): Promise<TestHooks> {
+  const hooks = await createSigilHooks(config, client);
+  if (!hooks) throw new Error("expected hooks");
+  return hooks;
+}
+
+function emitTransform(
+  hooks: TestHooks,
+  sessionID: string,
+  system: string[],
+  modelID = "claude-sonnet-4",
+) {
+  hooks.systemTransform({ sessionID, model: { id: modelID } }, { system });
+}
+
+describe("opencode system prompt capture", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetHookState();
+  });
+
+  it("prefers the transform prompt over the legacy chat.message override", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks();
+
+    hooks.chatMessage(
+      { sessionID: "sess-1" },
+      { message: userMessage("sess-1"), parts: [] },
+    );
+    emitTransform(hooks, "sess-1", [
+      "composed prompt",
+      "<env>cwd: /repo</env>",
+    ]);
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.systemPrompt).toBe(
+      "composed prompt\n<env>cwd: /repo</env>",
+    );
+  });
+
+  it("uses the legacy chat.message override when no transform fired", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks();
+
+    hooks.chatMessage(
+      { sessionID: "sess-1" },
+      { message: userMessage("sess-1"), parts: [] },
+    );
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.systemPrompt).toBe("legacy system");
+  });
+
+  it("ignores a transform without a session ID", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks();
+
+    hooks.systemTransform(
+      { model: { id: "claude-sonnet-4" } },
+      { system: ["no session"] },
+    );
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.systemPrompt).toBeUndefined();
+  });
+
+  it("ignores a transform whose model differs from the chat model", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks();
+
+    hooks.chatMessage(
+      { sessionID: "sess-1" },
+      { message: userMessage("sess-1"), parts: [] },
+    );
+    emitTransform(hooks, "sess-1", ["main prompt"]);
+    // Concurrent title request on the small model shares the session ID.
+    emitTransform(hooks, "sess-1", ["title prompt"], "small-model");
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.systemPrompt).toBe("main prompt");
+  });
+
+  it("accepts a transform when the session model is unknown", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks();
+
+    emitTransform(hooks, "sess-1", ["prompt without chat.message"]);
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.systemPrompt).toBe(
+      "prompt without chat.message",
+    );
+  });
+
+  it("keeps the latest transform when several fire in one turn", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks();
+
+    emitTransform(hooks, "sess-1", ["first step"]);
+    emitTransform(hooks, "sess-1", ["second step"]);
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.systemPrompt).toBe("second step");
+  });
+
+  it("keeps the prompt for later turns in the same session", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks();
+
+    emitTransform(hooks, "sess-1", ["session prompt"]);
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-2"));
+
+    expect(generations).toHaveLength(2);
+    expect(generations[1]!.seed.systemPrompt).toBe("session prompt");
+  });
+
+  it("drops malformed system entries instead of throwing", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks();
+
+    expect(() =>
+      emitTransform(hooks, "sess-1", ["kept", 42, null] as any),
+    ).not.toThrow();
+    expect(() =>
+      hooks.systemTransform(
+        { sessionID: "sess-1", model: { id: "claude-sonnet-4" } },
+        { system: "not-an-array" as any },
+      ),
+    ).not.toThrow();
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.systemPrompt).toBe("kept");
+  });
+
+  it("omits the prompt in metadata_only", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks(
+      baseConfig({ contentCapture: "metadata_only" }),
+    );
+
+    emitTransform(hooks, "sess-1", ["session prompt"]);
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.systemPrompt).toBeUndefined();
+  });
+
+  it("keeps prompts of concurrent sessions separate", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks();
+
+    emitTransform(hooks, "sess-1", ["prompt one"]);
+    emitTransform(hooks, "sess-2", ["prompt two"]);
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+    await emitMessageUpdated(hooks, assistantMessage("sess-2", "msg-1"));
+
+    expect(generations).toHaveLength(2);
+    expect(generations[0]!.seed.systemPrompt).toBe("prompt one");
+    expect(generations[1]!.seed.systemPrompt).toBe("prompt two");
+  });
+
+  it("clears the prompt when the session is deleted", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks();
+
+    emitTransform(hooks, "sess-1", ["session prompt"]);
+    await emitSessionDeleted(hooks, "sess-1");
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.systemPrompt).toBeUndefined();
+  });
+});
+
+describe("opencode tool definitions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetHookState();
+  });
+
+  it("builds name-only definitions from used tools and legacy overrides", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks();
+
+    hooks.chatMessage(
+      { sessionID: "sess-1" },
+      { message: userMessage("sess-1"), parts: [] },
+    );
+    await hooks.toolExecuteBefore(
+      { tool: "write", sessionID: "sess-1", callID: "tc-1" },
+      { args: {} },
+    );
+    hooks.toolExecuteAfter(
+      { tool: "write", sessionID: "sess-1", callID: "tc-1", args: {} },
+      { title: "", output: "", metadata: {} },
+    );
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    // Sorted by name, deduplicated, disabled overrides excluded.
+    expect(generations[0]!.seed.tools).toEqual([
+      { name: "legacybash", type: "function" },
+      { name: "write", type: "function" },
+    ]);
+  });
+
+  it("keeps tool names in metadata_only from execution records", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks(
+      baseConfig({ contentCapture: "metadata_only" }),
+    );
+
+    await hooks.toolExecuteBefore(
+      { tool: "bash", sessionID: "sess-1", callID: "tc-1" },
+      { args: {} },
+    );
+    hooks.toolExecuteAfter(
+      { tool: "bash", sessionID: "sess-1", callID: "tc-1", args: {} },
+      { title: "", output: "", metadata: {} },
+    );
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.tools).toEqual([
+      { name: "bash", type: "function" },
+    ]);
+  });
+
+  it("includes a started tool that never completed", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks();
+
+    // tool.execute.after never fires for denied or interrupted tools.
+    await hooks.toolExecuteBefore(
+      { tool: "bash", sessionID: "sess-1", callID: "tc-1" },
+      { args: {} },
+    );
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.tools).toEqual([
+      { name: "bash", type: "function" },
+    ]);
+  });
+
+  it("omits tools when nothing was used or declared", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks();
+
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.tools).toBeUndefined();
+  });
+});
+
+describe("opencode host version", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetHookState();
+  });
+
+  async function emitSessionCreatedWithVersion(
+    hooks: TestHooks,
+    id: string,
+    version: string,
+  ) {
+    await hooks.event({
+      event: { type: "session.created", properties: { info: { id, version } } },
+    });
+  }
+
+  it("uses the OpenCode version as agent and effective version", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks(baseConfig({ agentVersion: undefined }));
+
+    await emitSessionCreatedWithVersion(hooks, "sess-1", "1.17.20");
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.agentVersion).toBe("1.17.20");
+    expect(generations[0]!.seed.effectiveVersion).toBe("1.17.20");
+  });
+
+  it("updates the version from session.updated", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks(baseConfig({ agentVersion: undefined }));
+
+    await hooks.event({
+      event: {
+        type: "session.updated",
+        properties: { info: { id: "sess-1", version: "1.18.0" } },
+      },
+    });
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.agentVersion).toBe("1.18.0");
+  });
+
+  it("prefers a configured SIGIL_AGENT_VERSION over the host version", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks(baseConfig({ agentVersion: "my-agent-2" }));
+
+    await emitSessionCreatedWithVersion(hooks, "sess-1", "1.17.20");
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.agentVersion).toBe("my-agent-2");
+    expect(generations[0]!.seed.effectiveVersion).toBe("my-agent-2");
+  });
+
+  it("leaves the version unset without config or session events", async () => {
+    const { sigil, generations } = makeSigilMock();
+    createSigilClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks(baseConfig({ agentVersion: undefined }));
+
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.agentVersion).toBeUndefined();
+  });
+});

--- a/plugins/opencode/src/hooks.lineage.test.ts
+++ b/plugins/opencode/src/hooks.lineage.test.ts
@@ -12,99 +12,18 @@ vi.mock("./telemetry.js", () => ({
   createTelemetryProviders: createTelemetryProvidersMock,
 }));
 
-import type { SigilOpencodeConfig } from "./config.js";
 import { createSigilHooks } from "./hooks.js";
+import {
+  assistantMessage,
+  baseConfig,
+  emitMessageUpdated,
+  emitPartUpdated,
+  emitSessionCreated,
+  emitSessionDeleted,
+  makeOpencodeClient,
+  makeSigilMock,
+} from "./hooks.testutil.js";
 import { stableOpencodeGenerationId } from "./lineage.js";
-
-type CapturedGeneration = {
-  seed: any;
-  firstTokenAt: Date | undefined;
-  result: unknown;
-  callError: unknown;
-};
-
-function makeSigilMock() {
-  const generations: CapturedGeneration[] = [];
-  const startStreamingGeneration = vi.fn(async (seed: any, run: any) => {
-    const entry: CapturedGeneration = {
-      seed,
-      firstTokenAt: undefined,
-      result: undefined,
-      callError: undefined,
-    };
-    generations.push(entry);
-    await run({
-      setResult: (r: unknown) => {
-        entry.result = r;
-      },
-      setCallError: (e: unknown) => {
-        entry.callError = e;
-      },
-      setFirstTokenAt: (d: Date) => {
-        entry.firstTokenAt = d;
-      },
-      setCacheDiagnostics: vi.fn(),
-      end: vi.fn(),
-      getError: () => undefined,
-    });
-  });
-  const startGeneration = vi.fn();
-  const sigil = {
-    startStreamingGeneration,
-    startGeneration,
-    startToolExecution: vi.fn(() => ({
-      setResult: vi.fn(),
-      setCallError: vi.fn(),
-      end: vi.fn(),
-      getError: vi.fn(),
-    })),
-    flush: vi.fn(async () => {}),
-    shutdown: vi.fn(async () => {}),
-  };
-  return { sigil, generations, startStreamingGeneration, startGeneration };
-}
-
-function makeOpencodeClient(parts: any[] = []) {
-  return {
-    session: { message: vi.fn(async () => ({ data: { parts } })) },
-  } as any;
-}
-
-function baseConfig(
-  overrides: Partial<SigilOpencodeConfig> = {},
-): SigilOpencodeConfig {
-  return {
-    endpoint: "http://127.0.0.1:1/api/v1/generations:export",
-    auth: { mode: "none" },
-    agentName: "opencode",
-    agentVersion: "test-version",
-    contentCapture: "full",
-    debug: false,
-    ...overrides,
-  };
-}
-
-function assistantMessage(sessionID: string, messageID: string) {
-  return {
-    id: messageID,
-    sessionID,
-    role: "assistant",
-    time: { created: 1_700_000_001_000, completed: 1_700_000_002_500 },
-    parentID: "user-1",
-    modelID: "claude-sonnet-4",
-    providerID: "anthropic",
-    mode: "build",
-    path: { cwd: "/repo", root: "/repo" },
-    cost: 0.001,
-    tokens: {
-      input: 10,
-      output: 5,
-      reasoning: 0,
-      cache: { read: 0, write: 0 },
-    },
-    finish: "end_turn",
-  } as const;
-}
 
 function textPart(
   sessionID: string,
@@ -119,43 +38,6 @@ function textPart(
     text: "hello",
     time: { start },
   };
-}
-
-async function emitMessageUpdated(
-  hooks: NonNullable<Awaited<ReturnType<typeof createSigilHooks>>>,
-  msg: unknown,
-): Promise<void> {
-  await hooks.event({
-    event: { type: "message.updated", properties: { info: msg } },
-  });
-}
-
-async function emitPartUpdated(
-  hooks: NonNullable<Awaited<ReturnType<typeof createSigilHooks>>>,
-  part: unknown,
-): Promise<void> {
-  await hooks.event({
-    event: { type: "message.part.updated", properties: { part } },
-  });
-}
-
-async function emitSessionDeleted(
-  hooks: NonNullable<Awaited<ReturnType<typeof createSigilHooks>>>,
-  sessionID: string,
-): Promise<void> {
-  await hooks.event({
-    event: { type: "session.deleted", properties: { info: { id: sessionID } } },
-  });
-}
-
-async function emitSessionCreated(
-  hooks: NonNullable<Awaited<ReturnType<typeof createSigilHooks>>>,
-  id: string,
-  parentID?: string,
-): Promise<void> {
-  await hooks.event({
-    event: { type: "session.created", properties: { info: { id, parentID } } },
-  });
 }
 
 describe("opencode generation lineage and streaming", () => {

--- a/plugins/opencode/src/hooks.testutil.ts
+++ b/plugins/opencode/src/hooks.testutil.ts
@@ -1,0 +1,143 @@
+// Shared factories and event helpers for hook tests. Each test file keeps its
+// own vi.mock calls because Vitest hoists them.
+
+import { vi } from "vitest";
+import type { SigilOpencodeConfig } from "./config.js";
+import type { createSigilHooks } from "./hooks.js";
+
+export type TestHooks = NonNullable<
+  Awaited<ReturnType<typeof createSigilHooks>>
+>;
+
+export type CapturedGeneration = {
+  seed: any;
+  firstTokenAt: Date | undefined;
+  result: unknown;
+  callError: unknown;
+};
+
+// The explicit return type avoids TS2883 when declarations are generated.
+export function makeSigilMock(): {
+  sigil: any;
+  generations: CapturedGeneration[];
+  startStreamingGeneration: any;
+  startGeneration: any;
+} {
+  const generations: CapturedGeneration[] = [];
+  const startStreamingGeneration = vi.fn(async (seed: any, run: any) => {
+    const entry: CapturedGeneration = {
+      seed,
+      firstTokenAt: undefined,
+      result: undefined,
+      callError: undefined,
+    };
+    generations.push(entry);
+    await run({
+      setResult: (r: unknown) => {
+        entry.result = r;
+      },
+      setCallError: (e: unknown) => {
+        entry.callError = e;
+      },
+      setFirstTokenAt: (d: Date) => {
+        entry.firstTokenAt = d;
+      },
+      setCacheDiagnostics: vi.fn(),
+      end: vi.fn(),
+      getError: () => undefined,
+    });
+  });
+  const startGeneration = vi.fn();
+  const sigil = {
+    startStreamingGeneration,
+    startGeneration,
+    startToolExecution: vi.fn(() => ({
+      setResult: vi.fn(),
+      setCallError: vi.fn(),
+      end: vi.fn(),
+      getError: vi.fn(),
+    })),
+    flush: vi.fn(async () => {}),
+    shutdown: vi.fn(async () => {}),
+  };
+  return { sigil, generations, startStreamingGeneration, startGeneration };
+}
+
+export function makeOpencodeClient(parts: any[] = []) {
+  return {
+    session: { message: vi.fn(async () => ({ data: { parts } })) },
+  } as any;
+}
+
+export function baseConfig(
+  overrides: Partial<SigilOpencodeConfig> = {},
+): SigilOpencodeConfig {
+  return {
+    endpoint: "http://127.0.0.1:1/api/v1/generations:export",
+    auth: { mode: "none" },
+    agentName: "opencode",
+    agentVersion: "test-version",
+    contentCapture: "full",
+    debug: false,
+    ...overrides,
+  };
+}
+
+export function assistantMessage(sessionID: string, messageID: string) {
+  return {
+    id: messageID,
+    sessionID,
+    role: "assistant",
+    time: { created: 1_700_000_001_000, completed: 1_700_000_002_500 },
+    parentID: "user-1",
+    modelID: "claude-sonnet-4",
+    providerID: "anthropic",
+    mode: "build",
+    path: { cwd: "/repo", root: "/repo" },
+    cost: 0.001,
+    tokens: {
+      input: 10,
+      output: 5,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+    finish: "end_turn",
+  } as const;
+}
+
+export async function emitMessageUpdated(
+  hooks: TestHooks,
+  msg: unknown,
+): Promise<void> {
+  await hooks.event({
+    event: { type: "message.updated", properties: { info: msg } },
+  });
+}
+
+export async function emitPartUpdated(
+  hooks: TestHooks,
+  part: unknown,
+): Promise<void> {
+  await hooks.event({
+    event: { type: "message.part.updated", properties: { part } },
+  });
+}
+
+export async function emitSessionDeleted(
+  hooks: TestHooks,
+  sessionID: string,
+): Promise<void> {
+  await hooks.event({
+    event: { type: "session.deleted", properties: { info: { id: sessionID } } },
+  });
+}
+
+export async function emitSessionCreated(
+  hooks: TestHooks,
+  id: string,
+  parentID?: string,
+): Promise<void> {
+  await hooks.event({
+    event: { type: "session.created", properties: { info: { id, parentID } } },
+  });
+}

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -12,7 +12,12 @@ import type { SigilOpencodeConfig } from "./config.js";
 import { resolveGitBranch } from "./git.js";
 import { runToolCallGuard } from "./guard.js";
 import { stableOpencodeGenerationId } from "./lineage.js";
-import { mapError, mapGeneration, mapToolDefinitions } from "./mappers.js";
+import {
+  legacyToolOverrideNames,
+  mapError,
+  mapGeneration,
+  mapToolDefinitions,
+} from "./mappers.js";
 import { Redactor } from "./redact.js";
 import { buildBuiltinTags } from "./tags.js";
 import {
@@ -73,6 +78,19 @@ type PendingGeneration = {
 };
 const pendingGenerations = new Map<string, PendingGeneration>();
 
+// Effective system prompt per session, captured from OpenCode's
+// `experimental.chat.system.transform` hook. The hook fires during request
+// preparation, after OpenCode composes the agent, runtime, and override
+// prompts, so this is what the model receives. The latest value wins and
+// stays until the session is deleted, because the prompt normally repeats
+// across turns. Title requests share the session ID; they are filtered out
+// by comparing the request model against the session's chat model.
+const latestSystemPromptBySession = new Map<string, string>();
+
+// OpenCode host version from `session.created`/`session.updated` events.
+// Used as the default agent and effective version, matching claude-code.
+let hostVersion: string | undefined;
+
 type SessionContext = {
   agent: string | undefined;
   model: { provider: string; name: string } | undefined;
@@ -120,6 +138,8 @@ export function _resetHookState(): void {
   parentGenerationByChildSession.clear();
   firstPartAtByMessage.clear();
   pendingGenerations.clear();
+  latestSystemPromptBySession.clear();
+  hostVersion = undefined;
   sessionContexts.clear();
   _resetToolExecutionState();
 }
@@ -175,6 +195,42 @@ function handleChatMessage(
   });
 }
 
+/**
+ * Called from the `experimental.chat.system.transform` hook. Stores the
+ * composed system prompt for the session. Read-only: this transform hook is
+ * shared with the host and other plugins, so `output.system` is never
+ * mutated here.
+ *
+ * The hook also fires for auxiliary requests such as title generation, which
+ * share the session ID but use OpenCode's small model. When the request
+ * model differs from the session's chat model (stored by `chat.message`),
+ * the prompt is skipped. If both requests use the same model the title
+ * prompt can win the race; this only affects a session's first turn.
+ */
+function handleSystemTransform(
+  input: { sessionID?: string; model?: { id?: string } },
+  output: { system: string[] },
+  debugLog: (msg: string, ...args: unknown[]) => void,
+): void {
+  const sessionID = input.sessionID;
+  if (!sessionID || !Array.isArray(output.system)) return;
+
+  const sessionModel = sessionContexts.get(sessionID)?.model?.name;
+  const requestModel = input.model?.id;
+  if (sessionModel && requestModel && sessionModel !== requestModel) {
+    debugLog(
+      `ignoring system prompt for session=${sessionID}: request model ${requestModel} differs from chat model ${sessionModel}`,
+    );
+    return;
+  }
+
+  const prompt = joinSystemPrompt(
+    output.system.filter((entry): entry is string => typeof entry === "string"),
+  );
+  if (prompt === undefined) return;
+  latestSystemPromptBySession.set(sessionID, prompt);
+}
+
 async function handleEvent(
   sigil: SigilClient,
   config: SigilOpencodeConfig,
@@ -184,8 +240,11 @@ async function handleEvent(
   projectDir: string,
   event: { type: string; properties: unknown },
 ): Promise<void> {
-  if (event.type === "session.created") {
-    recordSessionParent(event.properties);
+  if (event.type === "session.created" || event.type === "session.updated") {
+    recordHostVersion(event.properties);
+    if (event.type === "session.created") {
+      recordSessionParent(event.properties);
+    }
     return;
   }
   if (event.type === "message.part.updated") {
@@ -372,42 +431,20 @@ async function recordAssistantMessage(
     }
   }
 
-  const tools = mapToolDefinitions(pending?.tools);
-  // Resolved per turn so a mid-session checkout lands on the next
-  // generation. Always sent regardless of content capture mode:
-  // `git.branch` and `cwd` are low-cardinality session metadata, not
-  // message content, matching claude-code/cursor.
-  const builtinTags = buildBuiltinTags({
-    cwd: projectDir,
-    gitBranch: resolveGitBranch(projectDir),
-  });
-  const seed = {
-    id: genId,
-    conversationId: assistantMsg.sessionID,
-    agentName: buildAgentName(config.agentName, assistantMsg.mode),
-    agentVersion: config.agentVersion,
-    effectiveVersion: config.agentVersion,
-    model: { provider: assistantMsg.providerID, name: assistantMsg.modelID },
-    startedAt: new Date(assistantMsg.time.created),
-    contentCapture: config.contentCapture,
-    ...(parent && { parentGenerationIds: [parent] }),
-    ...(tools.length > 0 && { tools }),
-    ...(includeMessageBodies && { systemPrompt: pending?.systemPrompt }),
-    ...(builtinTags && { tags: builtinTags }),
-  };
+  // Prefer the composed prompt from the system transform hook; fall back to
+  // the optional legacy override from chat.message.
+  const systemPrompt =
+    latestSystemPromptBySession.get(assistantMsg.sessionID) ??
+    pending?.systemPrompt;
+  if (systemPrompt === undefined) {
+    debugLog(
+      `no system prompt captured for session=${assistantMsg.sessionID} message=${assistantMsg.id}`,
+    );
+  }
 
-  const result = mapGeneration(
-    assistantMsg,
-    includeMessageBodies ? (pending?.userParts ?? []) : [],
-    assistantParts,
-    redactor,
-    config.contentCapture,
-  );
-
-  // Span records prefer terminal `ToolPart.state.time` when assistant parts
-  // are already available. `assistantParts` is empty in `metadata_only` (we
-  // intentionally skip the REST fetch there), so hook records take over and
-  // give us per-tool spans without forcing a body fetch.
+  // Tool spans double as the tool catalog source. Prefer terminal
+  // `ToolPart.state.time` when assistant parts are available; hook records
+  // cover metadata_only, where parts are never fetched.
   const termRecords = toolSpansFromParts(
     assistantMsg.sessionID,
     assistantParts,
@@ -423,10 +460,51 @@ async function recordAssistantMessage(
     ...hookRecords,
     ...drainedRecords,
   ]);
+
+  // Name-only tool definitions, like claude-code: the tools this generation
+  // used plus any legacy overrides. OpenCode does not tell the plugin which
+  // tools were offered to the model.
+  const tools = mapToolDefinitions([
+    ...spanRecords.map((record) => record.toolName),
+    ...legacyToolOverrideNames(pending?.tools),
+  ]);
+
+  const agentVersion = config.agentVersion || hostVersion;
+  // Resolved per turn so a mid-session checkout shows up on the next
+  // generation. Always sent regardless of content capture mode:
+  // `git.branch` and `cwd` are low-cardinality session metadata, not
+  // message content, matching claude-code/cursor.
+  const builtinTags = buildBuiltinTags({
+    cwd: projectDir,
+    gitBranch: resolveGitBranch(projectDir),
+  });
+  const seed = {
+    id: genId,
+    conversationId: assistantMsg.sessionID,
+    agentName: buildAgentName(config.agentName, assistantMsg.mode),
+    agentVersion,
+    effectiveVersion: agentVersion,
+    model: { provider: assistantMsg.providerID, name: assistantMsg.modelID },
+    startedAt: new Date(assistantMsg.time.created),
+    contentCapture: config.contentCapture,
+    ...(parent && { parentGenerationIds: [parent] }),
+    ...(tools.length > 0 && { tools }),
+    ...(includeMessageBodies && { systemPrompt }),
+    ...(builtinTags && { tags: builtinTags }),
+  };
+
+  const result = mapGeneration(
+    assistantMsg,
+    includeMessageBodies ? (pending?.userParts ?? []) : [],
+    assistantParts,
+    redactor,
+    config.contentCapture,
+  );
+
   const spanOpts = {
     conversationId: assistantMsg.sessionID,
     agentName: buildAgentName(config.agentName, assistantMsg.mode),
-    agentVersion: config.agentVersion,
+    agentVersion,
     requestProvider: assistantMsg.providerID,
     requestModel: assistantMsg.modelID,
     contentCapture: config.contentCapture,
@@ -474,6 +552,19 @@ async function recordAssistantMessage(
 
 function isTerminalMessageUpdate(msg: MessageUpdatedInfo): boolean {
   return Boolean(msg.finish || msg.error || msg.time?.completed);
+}
+
+/** Join OpenCode's system entries. Omit the field when all are empty. */
+function joinSystemPrompt(system: string[]): string | undefined {
+  const joined = system.filter((entry) => entry.length > 0).join("\n");
+  return joined.length > 0 ? joined : undefined;
+}
+
+/** Remember the OpenCode host version from a session event. */
+function recordHostVersion(properties: unknown): void {
+  const info = recordField(properties, "info");
+  const version = stringField(info, "version");
+  if (version) hostVersion = version;
 }
 
 /**
@@ -550,6 +641,7 @@ async function handleLifecycle(
       lastGenerationIdBySession.delete(sessionId);
       parentGenerationByChildSession.delete(sessionId);
       pendingGenerations.delete(sessionId);
+      latestSystemPromptBySession.delete(sessionId);
       sessionContexts.delete(sessionId);
       completedToolExecutions.delete(sessionId);
       for (const key of activeToolExecutions.keys()) {
@@ -568,6 +660,7 @@ async function handleLifecycle(
   if (type === "global.disposed") {
     activeToolExecutions.clear();
     completedToolExecutions.clear();
+    latestSystemPromptBySession.clear();
     try {
       await sigil.shutdown();
     } catch {
@@ -606,7 +699,7 @@ async function handleToolExecuteBefore(
   const res = await runToolCallGuard({
     client: sigil,
     agentName: agentNameForSession(config, input.sessionID),
-    agentVersion: config.agentVersion,
+    agentVersion: config.agentVersion || hostVersion,
     model: modelForSession(input.sessionID),
     toolCallId: input.callID,
     toolName: input.tool,
@@ -682,7 +775,7 @@ async function handlePermissionAsk(
   const res = await runToolCallGuard({
     client: sigil,
     agentName: agentNameForSession(config, input.sessionID),
-    agentVersion: config.agentVersion,
+    agentVersion: config.agentVersion || hostVersion,
     model: modelForSession(input.sessionID),
     toolCallId: input.callID,
     toolName: input.type,
@@ -943,6 +1036,10 @@ export type SigilHooks = {
     },
     output: { message: UserMessage; parts: Part[] },
   ) => void;
+  systemTransform: (
+    input: { sessionID?: string; model?: { id?: string } },
+    output: { system: string[] },
+  ) => void;
   toolExecuteBefore: (
     input: { tool: string; sessionID: string; callID: string },
     output: { args: unknown },
@@ -1020,6 +1117,9 @@ export async function createSigilHooks(
     },
     chatMessage: (input, output) => {
       handleChatMessage(input, output);
+    },
+    systemTransform: (input, output) => {
+      handleSystemTransform(input, output, debugLog);
     },
     toolExecuteBefore: async (input, output) => {
       await handleToolExecuteBefore(sigil, config, debugLog, input, output);

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -15,6 +15,9 @@ export const SigilPlugin: Plugin = async ({ client, directory }) => {
     "chat.message": async (input, output) => {
       hooks.chatMessage(input, output);
     },
+    "experimental.chat.system.transform": async (input, output) => {
+      hooks.systemTransform(input, output);
+    },
     event: async ({ event }) => {
       await hooks.event({
         event: event as { type: string; properties: unknown },

--- a/plugins/opencode/src/mappers.test.ts
+++ b/plugins/opencode/src/mappers.test.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage, Part } from "@opencode-ai/sdk";
 import { describe, expect, it } from "vitest";
 import {
+  legacyToolOverrideNames,
   mapGeneration,
   mapInputMessages,
   mapOutputMessages,
@@ -359,18 +360,42 @@ describe("mapOutputMessages", () => {
   });
 });
 
-describe("mapToolDefinitions", () => {
-  it("maps enabled tools to ToolDefinition array, excludes disabled", () => {
-    const tools = { bash: true, read: true, write: false };
-    const result = mapToolDefinitions(tools);
-    expect(result).toHaveLength(2);
-    expect(result.map((t) => t.name)).toContain("bash");
-    expect(result.map((t) => t.name)).toContain("read");
-    expect(result.map((t) => t.name)).not.toContain("write");
+describe("legacyToolOverrideNames", () => {
+  it("returns enabled names and drops disabled ones", () => {
+    expect(
+      legacyToolOverrideNames({ bash: true, read: true, write: false }),
+    ).toEqual(["bash", "read"]);
   });
 
   it("returns empty array for undefined", () => {
-    expect(mapToolDefinitions(undefined)).toEqual([]);
+    expect(legacyToolOverrideNames(undefined)).toEqual([]);
+  });
+});
+
+describe("mapToolDefinitions", () => {
+  it("builds sorted name-only function definitions", () => {
+    expect(mapToolDefinitions(["write", "bash", "read"])).toEqual([
+      { name: "bash", type: "function" },
+      { name: "read", type: "function" },
+      { name: "write", type: "function" },
+    ]);
+  });
+
+  it("deduplicates names", () => {
+    expect(mapToolDefinitions(["bash", "bash", "read"])).toEqual([
+      { name: "bash", type: "function" },
+      { name: "read", type: "function" },
+    ]);
+  });
+
+  it("skips empty and non-string names", () => {
+    expect(mapToolDefinitions(["", "bash", 42 as unknown as string])).toEqual([
+      { name: "bash", type: "function" },
+    ]);
+  });
+
+  it("returns no definitions for no names", () => {
+    expect(mapToolDefinitions([])).toEqual([]);
   });
 });
 

--- a/plugins/opencode/src/mappers.ts
+++ b/plugins/opencode/src/mappers.ts
@@ -150,14 +150,28 @@ export function mapOutputMessages(
   return messages;
 }
 
-/** Convert opencode tool name map to Sigil ToolDefinition array. Only includes enabled tools. */
-export function mapToolDefinitions(
+/** Return the enabled tool names from legacy `UserMessage.tools` overrides. */
+export function legacyToolOverrideNames(
   tools: Record<string, boolean> | undefined,
-): ToolDefinition[] {
+): string[] {
   if (!tools) return [];
   return Object.entries(tools)
     .filter(([, enabled]) => enabled)
-    .map(([name]) => ({ name }));
+    .map(([name]) => name);
+}
+
+/**
+ * Name-only function tool definitions, deduplicated and sorted by name.
+ * OpenCode does not expose tool descriptions or schemas to the plugin, so
+ * this matches the claude-code plugin: the catalog builds up over time from
+ * the tools each generation used.
+ */
+export function mapToolDefinitions(names: Iterable<string>): ToolDefinition[] {
+  const uniq = new Set<string>();
+  for (const name of names) {
+    if (typeof name === "string" && name.length > 0) uniq.add(name);
+  }
+  return [...uniq].sort().map((name) => ({ name, type: "function" }));
 }
 
 /** Map an AssistantMessage + parts to a Sigil GenerationResult with content. */

--- a/plugins/opencode/src/testdata/golden/opencode-full-message.golden.json
+++ b/plugins/opencode/src/testdata/golden/opencode-full-message.golden.json
@@ -15,7 +15,7 @@
         },
         "response_id": "",
         "response_model": "claude-sonnet-4-opencode",
-        "system_prompt": "you are a helpful assistant",
+        "system_prompt": "you are a helpful assistant\n<env>cwd: /repo/oc-app</env>",
         "input": [
           {
             "role": "MESSAGE_ROLE_USER",
@@ -70,13 +70,7 @@
           {
             "name": "Bash",
             "description": "",
-            "type": "",
-            "input_schema_json": ""
-          },
-          {
-            "name": "Read",
-            "description": "",
-            "type": "",
+            "type": "function",
             "input_schema_json": ""
           }
         ],

--- a/plugins/opencode/tsconfig.build.json
+++ b/plugins/opencode/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.testutil.ts"]
 }


### PR DESCRIPTION
Capture the system prompt from the existing `experimental.chat.system.transform` hook, which fires after OpenCode combines the agent prompt with runtime context.

<img width="882" height="991" alt="image" src="https://github.com/user-attachments/assets/345676a9-555f-4742-9174-23dc442cda4c" />
