### PR TITLE
feat(sdk-go): add WithTag/WithTags for per-request dimensional tags

### DIFF
--- a/go/sigil/client.go
+++ b/go/sigil/client.go
@@ -98,7 +98,9 @@ type Config struct {
 	UserID string
 	// Tags are merged into every GenerationStart.Tags (per-call tags win on
 	// key conflict) and emitted on OTel spans/metrics as sigil.tag.<key>.
-	// Read from SIGIL_TAGS (CSV) by ConfigFromEnv.
+	// Read from SIGIL_TAGS (CSV) by ConfigFromEnv. These are static, process-
+	// level tags; for per-request dimensions that also reach spans and metrics
+	// use WithTag / WithTags on the request context.
 	Tags map[string]string
 	// Debug, when set, signals downstream consumers (plugins, telemetry) that
 	// the SDK is running in verbose mode. Read from SIGIL_DEBUG by ConfigFromEnv.
@@ -604,8 +606,14 @@ func (c *Client) startGeneration(ctx context.Context, start GenerationStart, def
 	if seed.AgentVersion == "" && c.config.AgentVersion != "" {
 		seed.AgentVersion = c.config.AgentVersion
 	}
-	if len(c.config.Tags) > 0 {
-		merged := cloneTags(c.config.Tags)
+	// dimensionalTags are the static client tags plus any per-request context
+	// tags set via WithTag / WithTags. They are emitted on the generation span
+	// and metrics as sigil.tag.<key> and merged into the exported generation's
+	// tags. The explicit GenerationStart.Tags field stays export-only and wins
+	// on key conflict.
+	dimensionalTags := mergeTags(c.config.Tags, TagsFromContext(ctx))
+	if len(dimensionalTags) > 0 {
+		merged := cloneTags(dimensionalTags)
 		maps.Copy(merged, seed.Tags)
 		seed.Tags = merged
 	}
@@ -646,7 +654,7 @@ func (c *Client) startGeneration(ctx context.Context, start GenerationStart, def
 
 	callCtx, span := c.startSpan(ctx, spanGeneration, trace.SpanKindClient, startedAt)
 	span.SetAttributes(generationSpanAttributes(spanGeneration)...)
-	setSpanTagAttributes(span, c.config.Tags)
+	setSpanTagAttributes(span, dimensionalTags)
 
 	callCtx = withContentCaptureMode(callCtx, ccMode)
 
@@ -1994,7 +2002,10 @@ func (c *Client) recordGenerationMetrics(ctx context.Context, generation Generat
 		generation.AgentName,
 		generation.AgentVersion,
 	)
-	tagAttrs := c.clientTagMetricAttributes()
+	// Include per-request context tags (WithTag/WithTags) as metric dimensions
+	// alongside the static client tags. Callers are responsible for keeping
+	// context-tag values low-cardinality since they become metric labels.
+	tagAttrs := tagAttributes(mergeTags(c.config.Tags, TagsFromContext(ctx)))
 	durationAttrs := append(
 		[]attribute.KeyValue{attribute.String(spanAttrOperationName, operationName(generation))},
 		identityAttrs...,

--- a/go/sigil/context.go
+++ b/go/sigil/context.go
@@ -1,12 +1,16 @@
 package sigil
 
-import "context"
+import (
+	"context"
+	"maps"
+)
 
 type conversationIDContextKey struct{}
 type conversationTitleContextKey struct{}
 type userIDContextKey struct{}
 type agentNameContextKey struct{}
 type agentVersionContextKey struct{}
+type tagsContextKey struct{}
 type contentCaptureModeContextKey struct{}
 type experimentRunContextKey struct{}
 type experimentRunIDContextKey struct{}
@@ -74,6 +78,57 @@ func WithAgentVersion(ctx context.Context, version string) context.Context {
 func AgentVersionFromContext(ctx context.Context) (string, bool) {
 	version, ok := ctx.Value(agentVersionContextKey{}).(string)
 	return version, ok && version != ""
+}
+
+// WithTag stores a single per-request tag in the context. Unlike the
+// GenerationStart.Tags field (which is export-only), context tags are treated
+// as dimensions: StartGeneration and StartStreamingGeneration merge them into
+// the generation's tags for export AND emit them on the generation span and
+// metrics as sigil.tag.<key>, alongside the static Config.Tags.
+//
+// Successive WithTag / WithTags calls accumulate; a later call overrides an
+// earlier value for the same key. An empty key is ignored.
+func WithTag(ctx context.Context, key, value string) context.Context {
+	if key == "" {
+		return ctx
+	}
+	merged := cloneContextTags(ctx)
+	merged[key] = value
+	return context.WithValue(ctx, tagsContextKey{}, merged)
+}
+
+// WithTags stores multiple per-request tags in the context. See WithTag for
+// how context tags propagate. Entries with an empty key are ignored; a nil or
+// empty map is a no-op.
+func WithTags(ctx context.Context, tags map[string]string) context.Context {
+	if len(tags) == 0 {
+		return ctx
+	}
+	merged := cloneContextTags(ctx)
+	for key, value := range tags {
+		if key == "" {
+			continue
+		}
+		merged[key] = value
+	}
+	return context.WithValue(ctx, tagsContextKey{}, merged)
+}
+
+// TagsFromContext returns a copy of the per-request tags stored by WithTag /
+// WithTags, or nil when none are set.
+func TagsFromContext(ctx context.Context) map[string]string {
+	existing, ok := ctx.Value(tagsContextKey{}).(map[string]string)
+	if !ok || len(existing) == 0 {
+		return nil
+	}
+	return maps.Clone(existing)
+}
+
+func cloneContextTags(ctx context.Context) map[string]string {
+	if existing, ok := ctx.Value(tagsContextKey{}).(map[string]string); ok && len(existing) > 0 {
+		return maps.Clone(existing)
+	}
+	return map[string]string{}
 }
 
 // withContentCaptureMode stores the resolved ContentCaptureMode in the context.

--- a/go/sigil/context_tags_test.go
+++ b/go/sigil/context_tags_test.go
@@ -1,0 +1,88 @@
+package sigil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+func TestContextTagsOnGenerationSpanMetricsAndExport(t *testing.T) {
+	metricReader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(metricReader))
+	t.Cleanup(func() {
+		_ = meterProvider.Shutdown(context.Background())
+	})
+
+	exporter := &capturingGenerationExporter{}
+	client, recorder, _ := newTestClient(t, Config{
+		Meter:                  meterProvider.Meter("sigil-test"),
+		testGenerationExporter: exporter,
+		Now: func() time.Time {
+			return time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+		},
+	})
+
+	ctx := WithTag(context.Background(), "origin", "workspace/open-in-sidebar")
+	_, genRec := client.StartGeneration(ctx, GenerationStart{
+		ConversationID: "conv-ctx-tags",
+		Model:          ModelRef{Provider: "openai", Name: "gpt-5"},
+	})
+	genRec.SetResult(Generation{
+		Usage: TokenUsage{InputTokens: 10, OutputTokens: 5},
+	}, nil)
+	genRec.End()
+
+	originTagKey := spanAttrTagPrefix + "origin"
+
+	// Trace: context tag present on the generation span as sigil.tag.origin.
+	span := onlyGenerationSpan(t, recorder.Ended())
+	if got := spanAttributeMap(span)[originTagKey].AsString(); got != "workspace/open-in-sidebar" {
+		t.Fatalf("expected %s on generation span, got %q", originTagKey, got)
+	}
+
+	// Metrics: context tag becomes a metric dimension.
+	collected := collectMetrics(t, metricReader)
+	_ = findHistogramPointForTags(t, findHistogram(t, collected, metricOperationDuration), map[string]string{
+		originTagKey: "workspace/open-in-sidebar",
+	})
+
+	// Export: context tag travels on the exported generation's tags.
+	if err := client.Flush(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if len(exporter.requests) != 1 || len(exporter.requests[0].Generations) != 1 {
+		t.Fatalf("expected one exported generation, got %#v", exporter.requests)
+	}
+	if got := exporter.requests[0].Generations[0].GetTags()["origin"]; got != "workspace/open-in-sidebar" {
+		t.Fatalf("expected origin on export tags, got %#v", exporter.requests[0].Generations[0].GetTags())
+	}
+}
+
+func TestWithTagAccumulatesAndOverrides(t *testing.T) {
+	ctx := WithTag(context.Background(), "origin", "a")
+	ctx = WithTag(ctx, "surface", "sidebar")
+	ctx = WithTag(ctx, "origin", "b") // override
+
+	got := TagsFromContext(ctx)
+	if got["origin"] != "b" {
+		t.Fatalf("expected origin override to b, got %q", got["origin"])
+	}
+	if got["surface"] != "sidebar" {
+		t.Fatalf("expected surface=sidebar, got %q", got["surface"])
+	}
+
+	// Mutating the returned copy must not affect the context.
+	got["origin"] = "mutated"
+	if TagsFromContext(ctx)["origin"] != "b" {
+		t.Fatalf("TagsFromContext must return a copy")
+	}
+}
+
+func TestContextTagEmptyKeyIsNoOp(t *testing.T) {
+	ctx := WithTag(context.Background(), "", "value")
+	if TagsFromContext(ctx) != nil {
+		t.Fatalf("empty key must be a no-op")
+	}
+}


### PR DESCRIPTION
## Summary

- Add context helpers `WithTag`, `WithTags`, and `TagsFromContext` to the Go SDK.
- Per-request context tags are treated as **dimensions**: merged into the generation's exported tags AND emitted on the generation span and metrics as `sigil.tag.<key>`, alongside the static `Config.Tags`.
- The explicit `GenerationStart.Tags` field is unchanged: it stays export-only and wins on key conflict.

## Why

Consumers need to attach high-value per-request dimensions (e.g. a chat's `origin`) that show up on traces, metrics, and conversations for filtering — without abusing static process-level `Config.Tags` or the export-only per-call `Tags` field.

## Notes

- Both sync (`StartGeneration`) and streaming (`StartStreamingGeneration`) route through the same path, so context tags propagate in both.
- Callers own cardinality: context-tag values become metric labels.

## Test plan

- [x] `go test ./sigil/...` (new `context_tags_test.go`: span + metric + export propagation, accumulation/override, empty-key no-op)
- [x] Existing `TestPerCallGenerationTagsStayExportOnly` and `TestClientTags…` still pass (export-only contract preserved)