### PR TITLE
feat(sdk): emit client tags on OTel spans and metrics in Python, Java, and .NET

### DIFF
--- a/docs/concepts/tags-and-metadata.md
+++ b/docs/concepts/tags-and-metadata.md
@@ -8,7 +8,7 @@ Each SDK README links here for the language-specific config fields.
 
 | Mechanism | Set where | Cardinality | Generation export (Sigil UI) | OTel spans (traces) | OTel metrics |
 | --- | --- | --- | --- | --- | --- |
-| **Client tags** (`SIGIL_TAGS` / config `tags`) | Once, on the client | Keep low | Yes, merged into every generation | Yes, as `sigil.tag.<key>` (Go/JS only) | Yes, as `sigil.tag.<key>` (Go/JS only) |
+| **Client tags** (`SIGIL_TAGS` / config `tags`) | Once, on the client | Keep low | Yes, merged into every generation | Yes, as `sigil.tag.<key>` | Yes, as `sigil.tag.<key>` |
 | **Per-generation `tags`** | Per `startGeneration` call | Any | Yes | No | No |
 | **`metadata`** (struct/dict) | Per `startGeneration` call | Any | Yes | No | No |
 
@@ -18,9 +18,9 @@ There is also a dedicated **`user_id`** field (`SIGIL_USER_ID` / config / per-ca
 
 `user.id` is emitted on the generation span by all five SDKs (Go, Python, JS, Java, .NET).
 
-Client tags are merged into the generation export by all five SDKs, but only **Go and JS** also emit them as `sigil.tag.<key>` attributes on OTel spans and metrics. In Python, Java, and .NET, client tags are export-only today. If you need a tag as a metric/trace label in those languages, set it on the OTel `Resource` (for example `service.name`, or a custom resource attribute) when you configure the providers.
+All five SDKs merge client tags into the generation export and emit them as `sigil.tag.<key>` attributes on OTel spans and metrics.
 
-Client tags become OTel metric attributes on Go/JS, which become Prometheus label values: one time series per distinct value.
+Client tags become OTel metric attributes, which become Prometheus label values: one time series per distinct value.
 
 ## Setting them
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -294,7 +294,7 @@ Resolution precedence for tool executions (highest to lowest):
 3. `SigilClientConfig.ContentCaptureResolver` return value
 4. `SigilClientConfig.ContentCapture` (defaults to `ContentCaptureMode.NoToolContent`)
 
-User-provided `Metadata` and `Tags` are not stripped by any capture mode. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content. See [Tags and Metadata](../docs/concepts/tags-and-metadata.md) for where client tags, per-generation tags, metadata, and `UserId` each show up. .NET merges client tags into the generation export only; it does not emit `sigil.tag.<key>` on spans/metrics.
+User-provided `Metadata` and `Tags` are not stripped by any capture mode. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content. See [Tags and Metadata](../docs/concepts/tags-and-metadata.md) for where client tags, per-generation tags, metadata, and `UserId` each show up (export vs spans vs metrics).
 
 ## Context defaults
 
@@ -378,7 +378,7 @@ SDK schema defaults fill the rest.
 | `SIGIL_AGENT_NAME` | `SigilClientConfig.AgentName` |
 | `SIGIL_AGENT_VERSION` | `SigilClientConfig.AgentVersion` |
 | `SIGIL_USER_ID` | `SigilClientConfig.UserId` |
-| `SIGIL_TAGS` | `SigilClientConfig.Tags` (CSV; merged into generation export only. Only Go/JS emit `sigil.tag.<key>` on spans/metrics; see [Tags and Metadata](../docs/concepts/tags-and-metadata.md)) |
+| `SIGIL_TAGS` | `SigilClientConfig.Tags` (CSV; applied to generations, spans, and metrics; see [Tags and Metadata](../docs/concepts/tags-and-metadata.md)) |
 | `SIGIL_CONTENT_CAPTURE_MODE` | `SigilClientConfig.ContentCapture` |
 | `SIGIL_DEBUG` | `SigilClientConfig.Debug` (tri-state `bool?`) |
 

--- a/dotnet/src/Grafana.Sigil/SigilClient.cs
+++ b/dotnet/src/Grafana.Sigil/SigilClient.cs
@@ -52,6 +52,7 @@ public sealed partial class SigilClient : IAsyncDisposable
     internal const string SpanAttrToolDescription = "gen_ai.tool.description";
     internal const string SpanAttrToolCallArguments = "gen_ai.tool.call.arguments";
     internal const string SpanAttrToolCallResult = "gen_ai.tool.call.result";
+    internal const string SpanAttrTagPrefix = "sigil.tag.";
     private const int MaxRatingConversationIdLen = 255;
     private const int MaxRatingIdLen = 128;
     private const int MaxRatingGenerationIdLen = 255;
@@ -233,6 +234,7 @@ public sealed partial class SigilClient : IAsyncDisposable
         if (activity != null)
         {
             ApplyEmbeddingStartSpanAttributes(activity, seed);
+            ApplyClientTagAttributes(activity);
         }
 
         return new EmbeddingRecorder(this, seed, seed.StartedAt.Value, activity, embeddingMode);
@@ -323,6 +325,7 @@ public sealed partial class SigilClient : IAsyncDisposable
         if (activity != null)
         {
             ApplyToolSpanAttributes(activity, seed);
+            ApplyClientTagAttributes(activity);
         }
 
         // Tools have no proto export; under both stripped modes the span
@@ -617,6 +620,7 @@ public sealed partial class SigilClient : IAsyncDisposable
         if (activity != null)
         {
             ApplyGenerationSpanAttributes(activity, spanGeneration);
+            ApplyClientTagAttributes(activity);
         }
 
         var recorder = new GenerationRecorder(this, seed, seed.StartedAt!.Value, ccMode, activity);
@@ -1480,7 +1484,7 @@ public sealed partial class SigilClient : IAsyncDisposable
 
         _operationDurationHistogram.Record(
             durationSeconds,
-            WithAgentVersionTag(generation.AgentVersion, [
+            WithMetricTags(generation.AgentVersion, [
                 new(SpanAttrOperationName, OperationName(generation)),
                 new(SpanAttrProviderName, generation.Model.Provider ?? string.Empty),
                 new(SpanAttrRequestModel, generation.Model.Name ?? string.Empty),
@@ -1497,7 +1501,7 @@ public sealed partial class SigilClient : IAsyncDisposable
 
         _toolCallsHistogram.Record(
             CountToolCallParts(generation.Output),
-            WithAgentVersionTag(generation.AgentVersion, [
+            WithMetricTags(generation.AgentVersion, [
                 new(SpanAttrProviderName, generation.Model.Provider ?? string.Empty),
                 new(SpanAttrRequestModel, generation.Model.Name ?? string.Empty),
                 new(SpanAttrAgentName, generation.AgentName ?? string.Empty),
@@ -1511,7 +1515,7 @@ public sealed partial class SigilClient : IAsyncDisposable
             {
                 _ttftHistogram.Record(
                     ttftSeconds,
-                    WithAgentVersionTag(generation.AgentVersion, [
+                    WithMetricTags(generation.AgentVersion, [
                         new(SpanAttrProviderName, generation.Model.Provider ?? string.Empty),
                         new(SpanAttrRequestModel, generation.Model.Name ?? string.Empty),
                         new(SpanAttrAgentName, generation.AgentName ?? string.Empty),
@@ -1532,7 +1536,7 @@ public sealed partial class SigilClient : IAsyncDisposable
         var durationSeconds = Math.Max(0d, (completedAt - startedAt).TotalSeconds);
         _operationDurationHistogram.Record(
             durationSeconds,
-            WithAgentVersionTag(seed.AgentVersion, [
+            WithMetricTags(seed.AgentVersion, [
                 new(SpanAttrOperationName, DefaultOperationNameEmbedding),
                 new(SpanAttrProviderName, seed.Model.Provider ?? string.Empty),
                 new(SpanAttrRequestModel, seed.Model.Name ?? string.Empty),
@@ -1545,7 +1549,7 @@ public sealed partial class SigilClient : IAsyncDisposable
         {
             _tokenUsageHistogram.Record(
                 result.InputTokens,
-                WithAgentVersionTag(seed.AgentVersion, [
+                WithMetricTags(seed.AgentVersion, [
                     new(SpanAttrOperationName, DefaultOperationNameEmbedding),
                     new(SpanAttrProviderName, seed.Model.Provider ?? string.Empty),
                     new(SpanAttrRequestModel, seed.Model.Name ?? string.Empty),
@@ -1568,7 +1572,7 @@ public sealed partial class SigilClient : IAsyncDisposable
 
         _operationDurationHistogram.Record(
             durationSeconds,
-            WithAgentVersionTag(seed.AgentVersion, [
+            WithMetricTags(seed.AgentVersion, [
                 new(SpanAttrOperationName, "execute_tool"),
                 new(SpanAttrProviderName, (seed.RequestProvider ?? string.Empty).Trim()),
                 new(SpanAttrRequestModel, (seed.RequestModel ?? string.Empty).Trim()),
@@ -1636,7 +1640,7 @@ public sealed partial class SigilClient : IAsyncDisposable
 
         _tokenUsageHistogram.Record(
             value,
-            WithAgentVersionTag(generation.AgentVersion, [
+            WithMetricTags(generation.AgentVersion, [
                 new(SpanAttrOperationName, OperationName(generation)),
                 new(SpanAttrProviderName, generation.Model.Provider ?? string.Empty),
                 new(SpanAttrRequestModel, generation.Model.Name ?? string.Empty),
@@ -1645,20 +1649,72 @@ public sealed partial class SigilClient : IAsyncDisposable
             ]));
     }
 
-    private static KeyValuePair<string, object?>[] WithAgentVersionTag(
+    internal static KeyValuePair<string, object?>[] TagAttributes(IReadOnlyDictionary<string, string>? tags)
+    {
+        if (tags == null || tags.Count == 0)
+        {
+            return [];
+        }
+
+        var pairs = new List<KeyValuePair<string, string>>(tags.Count);
+        foreach (var entry in tags)
+        {
+            var key = (entry.Key ?? string.Empty).Trim();
+            if (key.Length == 0)
+            {
+                continue;
+            }
+
+            pairs.Add(new KeyValuePair<string, string>(key, (entry.Value ?? string.Empty).Trim()));
+        }
+
+        pairs.Sort(static (a, b) => string.CompareOrdinal(a.Key, b.Key));
+        var attributes = new KeyValuePair<string, object?>[pairs.Count];
+        for (var i = 0; i < pairs.Count; i++)
+        {
+            attributes[i] = new KeyValuePair<string, object?>(SpanAttrTagPrefix + pairs[i].Key, pairs[i].Value);
+        }
+
+        return attributes;
+    }
+
+    // Recomputed on every call: SigilClientConfig.Tags exposes the live
+    // dictionary, so post-construction mutation must stay visible.
+    private KeyValuePair<string, object?>[] ClientTagAttributes()
+    {
+        return TagAttributes(_config.Tags);
+    }
+
+    private void ApplyClientTagAttributes(Activity activity)
+    {
+        foreach (var attribute in ClientTagAttributes())
+        {
+            activity.SetTag(attribute.Key, attribute.Value);
+        }
+    }
+
+    private KeyValuePair<string, object?>[] WithMetricTags(
         string? agentVersion,
         KeyValuePair<string, object?>[] tags
     )
     {
         var version = (agentVersion ?? string.Empty).Trim();
-        if (version.Length == 0)
+        var clientTags = ClientTagAttributes();
+        var extra = clientTags.Length + (version.Length == 0 ? 0 : 1);
+        if (extra == 0)
         {
             return tags;
         }
 
-        var outTags = new KeyValuePair<string, object?>[tags.Length + 1];
+        var outTags = new KeyValuePair<string, object?>[tags.Length + extra];
         Array.Copy(tags, outTags, tags.Length);
-        outTags[tags.Length] = new KeyValuePair<string, object?>(SpanAttrAgentVersion, version);
+        var index = tags.Length;
+        if (version.Length != 0)
+        {
+            outTags[index++] = new KeyValuePair<string, object?>(SpanAttrAgentVersion, version);
+        }
+
+        Array.Copy(clientTags, 0, outTags, index, clientTags.Length);
         return outTags;
     }
 

--- a/dotnet/tests/Grafana.Sigil.Tests/ClientTagsTests.cs
+++ b/dotnet/tests/Grafana.Sigil.Tests/ClientTagsTests.cs
@@ -1,0 +1,268 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Xunit;
+
+namespace Grafana.Sigil.Tests;
+
+public sealed class ClientTagsTests
+{
+    private const string ClientTagProjectKey = "sigil.tag.project";
+
+    private sealed class TagsHarness : IAsyncDisposable
+    {
+        private readonly ActivityListener _activityListener;
+        private readonly MeterListener _meterListener;
+
+        public CapturingGenerationExporter Exporter { get; } = new();
+        public SigilClient Client { get; }
+        public ConcurrentQueue<Activity> Spans { get; } = new();
+        public ConcurrentQueue<(string Name, Dictionary<string, object?> Tags)> Measurements { get; } = new();
+
+        public TagsHarness(Dictionary<string, string>? tags = null)
+        {
+            _activityListener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == "github.com/grafana/sigil/sdks/dotnet",
+                Sample = static (ref _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = activity => Spans.Enqueue(activity),
+            };
+            ActivitySource.AddActivityListener(_activityListener);
+
+            _meterListener = new MeterListener();
+            _meterListener.InstrumentPublished += (instrument, listener) =>
+            {
+                if (instrument.Name.StartsWith("gen_ai.client.", StringComparison.Ordinal))
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            _meterListener.SetMeasurementEventCallback<double>((instrument, _, tags, _) =>
+            {
+                var tagMap = new Dictionary<string, object?>(StringComparer.Ordinal);
+                foreach (var tag in tags)
+                {
+                    tagMap[tag.Key] = tag.Value;
+                }
+                Measurements.Enqueue((instrument.Name, tagMap));
+            });
+            _meterListener.Start();
+
+            var config = TestHelpers.TestConfig(Exporter);
+            if (tags != null)
+            {
+                config.Tags = tags;
+            }
+            Client = new SigilClient(config);
+        }
+
+        public void AssertMeasurementsCarryTag(string metricName, string key, string value)
+        {
+            var measurements = Measurements.Where(m => string.Equals(m.Name, metricName, StringComparison.Ordinal)).ToList();
+            Assert.NotEmpty(measurements);
+            foreach (var measurement in measurements)
+            {
+                Assert.True(
+                    measurement.Tags.TryGetValue(key, out var got) && string.Equals(got?.ToString(), value, StringComparison.Ordinal),
+                    $"expected {key}={value} on every {metricName} measurement"
+                );
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Client.ShutdownAsync();
+            _meterListener.Dispose();
+            _activityListener.Dispose();
+        }
+    }
+
+    private static Activity SingleSpan(TagsHarness harness, string? operationName = null)
+    {
+        var spans = harness.Spans.Where(span =>
+        {
+            var operation = span.GetTagItem("gen_ai.operation.name")?.ToString();
+            return operationName == null
+                ? operation != "execute_tool" && operation != "embeddings"
+                : operation == operationName;
+        }).ToList();
+        Assert.Single(spans);
+        return spans[0];
+    }
+
+    [Fact]
+    public async Task ClientTags_OnGenerationSpanAndMetrics()
+    {
+        await using var harness = new TagsHarness(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["project"] = "checkout-svc",
+        });
+
+        var start = TestHelpers.CreateSeedStart("gen-client-tags");
+        start.Mode = null;
+        start.OperationName = string.Empty;
+        var recorder = harness.Client.StartStreamingGeneration(start);
+        recorder.SetFirstTokenAt(start.StartedAt!.Value.AddMilliseconds(250));
+
+        var result = TestHelpers.CreateSeedResult("gen-client-tags");
+        result.Mode = GenerationMode.Stream;
+        result.OperationName = "streamText";
+        recorder.SetResult(result);
+        recorder.End();
+
+        var span = SingleSpan(harness);
+        Assert.Equal("checkout-svc", span.GetTagItem(ClientTagProjectKey)?.ToString());
+
+        harness.AssertMeasurementsCarryTag("gen_ai.client.operation.duration", ClientTagProjectKey, "checkout-svc");
+        harness.AssertMeasurementsCarryTag("gen_ai.client.token.usage", ClientTagProjectKey, "checkout-svc");
+        harness.AssertMeasurementsCarryTag("gen_ai.client.time_to_first_token", ClientTagProjectKey, "checkout-svc");
+        harness.AssertMeasurementsCarryTag("gen_ai.client.tool_calls_per_operation", ClientTagProjectKey, "checkout-svc");
+    }
+
+    [Fact]
+    public async Task ClientTags_OnEmbeddingAndToolSpansAndMetrics()
+    {
+        await using var harness = new TagsHarness(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["project"] = "embed-tools",
+        });
+
+        var embedding = harness.Client.StartEmbedding(new EmbeddingStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "text-embedding-3-small" },
+        });
+        embedding.SetResult(new EmbeddingResult { InputTokens = 1 });
+        embedding.End();
+
+        var tool = harness.Client.StartToolExecution(new ToolExecutionStart
+        {
+            ToolName = "weather",
+        });
+        tool.SetResult(new ToolExecutionEnd { Result = "sunny" });
+        tool.End();
+
+        var embeddingSpan = SingleSpan(harness, "embeddings");
+        Assert.Equal("embed-tools", embeddingSpan.GetTagItem(ClientTagProjectKey)?.ToString());
+
+        var toolSpan = SingleSpan(harness, "execute_tool");
+        Assert.Equal("embed-tools", toolSpan.GetTagItem(ClientTagProjectKey)?.ToString());
+
+        // Embedding duration + tool duration share the operation.duration
+        // instrument; embedding token usage is the token.usage instrument.
+        harness.AssertMeasurementsCarryTag("gen_ai.client.operation.duration", ClientTagProjectKey, "embed-tools");
+        harness.AssertMeasurementsCarryTag("gen_ai.client.token.usage", ClientTagProjectKey, "embed-tools");
+    }
+
+    [Fact]
+    public async Task ClientTags_AreNormalizedAndSorted()
+    {
+        var attributes = SigilClient.TagAttributes(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [" z "] = " last ",
+            ["   "] = "discard",
+            [" a "] = "",
+        });
+
+        Assert.Equal(2, attributes.Length);
+        Assert.Equal("sigil.tag.a", attributes[0].Key);
+        Assert.Equal("", attributes[0].Value);
+        Assert.Equal("sigil.tag.z", attributes[1].Key);
+        Assert.Equal("last", attributes[1].Value);
+
+        await using var harness = new TagsHarness(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [" z "] = " last ",
+            ["   "] = "discard",
+            [" a "] = "",
+        });
+
+        var recorder = harness.Client.StartGeneration(TestHelpers.CreateSeedStart("gen-normalized"));
+        recorder.SetResult(TestHelpers.CreateSeedResult("gen-normalized"));
+        recorder.End();
+
+        var span = SingleSpan(harness);
+        Assert.Equal("", span.GetTagItem("sigil.tag.a")?.ToString());
+        Assert.Equal("last", span.GetTagItem("sigil.tag.z")?.ToString());
+        foreach (var tag in span.TagObjects)
+        {
+            Assert.Equal(tag.Key, tag.Key.Trim());
+        }
+    }
+
+    [Fact]
+    public async Task EmptyClientTags_AreNoOp()
+    {
+        await using var harness = new TagsHarness();
+
+        var recorder = harness.Client.StartGeneration(TestHelpers.CreateSeedStart("gen-no-tags"));
+        recorder.SetResult(TestHelpers.CreateSeedResult("gen-no-tags"));
+        recorder.End();
+
+        var embedding = harness.Client.StartEmbedding(new EmbeddingStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "text-embedding-3-small" },
+        });
+        embedding.SetResult(new EmbeddingResult { InputTokens = 1 });
+        embedding.End();
+
+        var tool = harness.Client.StartToolExecution(new ToolExecutionStart
+        {
+            ToolName = "weather",
+        });
+        tool.SetResult(new ToolExecutionEnd { Result = "sunny" });
+        tool.End();
+
+        foreach (var span in harness.Spans)
+        {
+            foreach (var tag in span.TagObjects)
+            {
+                Assert.False(
+                    tag.Key.StartsWith(SigilClient.SpanAttrTagPrefix, StringComparison.Ordinal),
+                    $"unexpected {tag.Key} on span {span.DisplayName}"
+                );
+            }
+        }
+
+        foreach (var measurement in harness.Measurements)
+        {
+            foreach (var tag in measurement.Tags)
+            {
+                Assert.False(
+                    tag.Key.StartsWith(SigilClient.SpanAttrTagPrefix, StringComparison.Ordinal),
+                    $"unexpected {tag.Key} on metric {measurement.Name}"
+                );
+            }
+        }
+    }
+
+    [Fact]
+    public async Task PerCallGenerationTags_StayExportOnly()
+    {
+        await using var harness = new TagsHarness();
+
+        var start = TestHelpers.CreateSeedStart("gen-per-call");
+        start.Tags.Clear();
+        start.Tags["call_only"] = "yes";
+        var recorder = harness.Client.StartGeneration(start);
+        var result = TestHelpers.CreateSeedResult("gen-per-call");
+        result.Tags.Clear();
+        recorder.SetResult(result);
+        recorder.End();
+        await harness.Client.FlushAsync(TestContext.Current.CancellationToken);
+
+        var span = SingleSpan(harness);
+        Assert.Null(span.GetTagItem("sigil.tag.call_only"));
+
+        foreach (var measurement in harness.Measurements)
+        {
+            Assert.False(
+                measurement.Tags.ContainsKey("sigil.tag.call_only"),
+                $"per-call tag must not appear on metric {measurement.Name}"
+            );
+        }
+
+        Assert.Single(harness.Exporter.Requests);
+        var generation = harness.Exporter.Requests[0].Generations[0];
+        Assert.Equal("yes", generation.Tags["call_only"]);
+    }
+}

--- a/dotnet/tests/Grafana.Sigil.Tests/ConformanceTests.cs
+++ b/dotnet/tests/Grafana.Sigil.Tests/ConformanceTests.cs
@@ -608,6 +608,35 @@ public sealed class ConformanceTests
     }
 
     [Fact]
+    public async Task ClientTagAttributes()
+    {
+        await using var env = new ConformanceEnv(tags: new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["team"] = "payments",
+        });
+        var recorder = env.Client.StartGeneration(new GenerationStart
+        {
+            Model = new ModelRef { Provider = "openai", Name = "gpt-5" },
+            Tags = new Dictionary<string, string>(StringComparer.Ordinal) { ["call_only"] = "yes" },
+        });
+        recorder.SetResult(new Generation
+        {
+            Usage = new TokenUsage { InputTokens = 4, OutputTokens = 2 },
+        });
+        recorder.End();
+        await env.ShutdownAsync();
+
+        var span = env.GenerationSpan();
+        Assert.Equal("payments", span.GetTagItem("sigil.tag.team")?.ToString());
+        Assert.Null(span.GetTagItem("sigil.tag.call_only"));
+
+        Assert.True(
+            env.HasMetricTag("gen_ai.client.operation.duration", "sigil.tag.team", "payments"),
+            "operation duration metrics should include the client tag"
+        );
+    }
+
+    [Fact]
     public async Task ShutdownFlushSemantics()
     {
         await using var env = new ConformanceEnv(batchSize: 10);
@@ -643,7 +672,7 @@ public sealed class ConformanceTests
         public ConcurrentDictionary<string, byte> MetricNames { get; } = new(StringComparer.Ordinal);
         public ConcurrentQueue<MetricMeasurement> MetricMeasurements { get; } = new();
 
-        public ConformanceEnv(int batchSize = 1)
+        public ConformanceEnv(int batchSize = 1, Dictionary<string, string>? tags = null)
         {
             _activityListener = new ActivityListener
             {
@@ -703,7 +732,7 @@ public sealed class ConformanceTests
                     )
                 )
             );
-            Client = new SigilClient(new SigilClientConfig
+            var config = new SigilClientConfig
             {
                 Api = new ApiConfig
                 {
@@ -721,7 +750,12 @@ public sealed class ConformanceTests
                     InitialBackoff = TimeSpan.FromMilliseconds(1),
                     MaxBackoff = TimeSpan.FromMilliseconds(2),
                 },
-            });
+            };
+            if (tags != null)
+            {
+                config.Tags = tags;
+            }
+            Client = new SigilClient(config);
         }
 
         public async Task ShutdownAsync()

--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -63,7 +63,7 @@ After running an example, open the AI Observability plugin in your Grafana Cloud
 
 ## Custom tags and metadata
 
-The Python, TypeScript, and Go single-generation examples set a client-level tag, a per-generation tag, `metadata`, and `user_id` so you can see where each one shows up. Client tags reach the generation plus (on Go/JS) OTel spans/metrics as `sigil.tag.<key>`; per-generation tags and metadata are export-only; `user_id` becomes the `user.id` span attribute. See [Tags and Metadata](../../docs/concepts/tags-and-metadata.md) for the full routing table and cardinality rules.
+The Python, TypeScript, and Go single-generation examples set a client-level tag, a per-generation tag, `metadata`, and `user_id` so you can see where each one shows up. Client tags show up on the generation and as `sigil.tag.<key>` on OTel spans/metrics; per-generation tags and metadata are export-only; `user_id` becomes the `user.id` span attribute. See [Tags and Metadata](../../docs/concepts/tags-and-metadata.md) for the full routing table and cardinality rules.
 
 ## Next steps
 

--- a/examples/getting-started/go/main.go
+++ b/examples/getting-started/go/main.go
@@ -57,9 +57,9 @@ func main() {
 		TenantID:      os.Getenv("SIGIL_AUTH_TENANT_ID"),
 		BasicPassword: os.Getenv("SIGIL_AUTH_TOKEN"),
 	}
-	// Client tags attach to every generation. On Go/JS they also become
-	// sigil.tag.<key> attributes on OTel spans and metrics, so keep them
-	// low-cardinality (team, env). See docs/concepts/tags-and-metadata.md.
+	// Client tags attach to every generation and become sigil.tag.<key>
+	// attributes on OTel spans and metrics, so keep them low-cardinality
+	// (team, env). See docs/concepts/tags-and-metadata.md.
 	cfg.Tags = map[string]string{"team": "checkout", "env": "dev"}
 	sigilClient := sigil.NewClient(cfg)
 	defer func() { _ = sigilClient.Shutdown(ctx) }()

--- a/examples/getting-started/python/main.py
+++ b/examples/getting-started/python/main.py
@@ -52,9 +52,9 @@ sigil = Client(
                 basic_password=os.environ["SIGIL_AUTH_TOKEN"],
             ),
         ),
-        # Client tags attach to every generation. In Python they are merged
-        # into the generation export only (Go/JS also emit sigil.tag.<key> on
-        # spans/metrics). See docs/concepts/tags-and-metadata.md.
+        # Client tags attach to every generation and become sigil.tag.<key>
+        # attributes on OTel spans and metrics, so keep them low-cardinality
+        # (team, env). See docs/concepts/tags-and-metadata.md.
         tags={"team": "checkout", "env": "dev"},
     )
 )

--- a/examples/getting-started/typescript/main.ts
+++ b/examples/getting-started/typescript/main.ts
@@ -44,9 +44,9 @@ const sigil = createSigilClient({
       basicPassword: process.env.SIGIL_AUTH_TOKEN!,
     },
   },
-  // Client tags attach to every generation. On Go/JS they also become
-  // sigil.tag.<key> attributes on OTel spans and metrics, so keep them
-  // low-cardinality (team, env). See docs/concepts/tags-and-metadata.md.
+  // Client tags attach to every generation and become sigil.tag.<key>
+  // attributes on OTel spans and metrics, so keep them low-cardinality
+  // (team, env). See docs/concepts/tags-and-metadata.md.
   tags: { team: "checkout", env: "dev" },
 });
 

--- a/go/sigil/conformance_test.go
+++ b/go/sigil/conformance_test.go
@@ -1646,6 +1646,37 @@ func TestConformance_RatingHelper(t *testing.T) {
 	}
 }
 
+func TestConformance_ClientTagAttributes(t *testing.T) {
+	env := newConformanceEnv(t, withConformanceConfig(func(cfg *sigil.Config) {
+		cfg.Tags = map[string]string{"team": "payments"}
+	}))
+
+	_, recorder := env.Client.StartGeneration(context.Background(), sigil.GenerationStart{
+		Model: conformanceModel,
+		Tags:  map[string]string{"call_only": "yes"},
+	})
+	recorder.SetResult(sigil.Generation{
+		Usage: sigil.TokenUsage{InputTokens: 4, OutputTokens: 2},
+	}, nil)
+	recorder.End()
+	if err := recorder.Err(); err != nil {
+		t.Fatalf("record generation: %v", err)
+	}
+
+	span := findSpan(t, env.Spans.Ended(), conformanceOperationName)
+	attrs := spanAttrs(span)
+	requireSpanAttr(t, attrs, "sigil.tag.team", "payments")
+	requireSpanAttrAbsent(t, attrs, "sigil.tag.call_only")
+
+	metrics := env.CollectMetrics(t)
+	duration := findHistogram[float64](t, metrics, metricOperationDuration)
+	requireHistogramPointWithAttrs(t, duration, map[string]string{
+		"sigil.tag.team": "payments",
+	})
+
+	env.Shutdown(t)
+}
+
 func TestConformance_ShutdownFlushesPendingGeneration(t *testing.T) {
 	env := newConformanceEnv(t, withConformanceConfig(func(cfg *sigil.Config) {
 		cfg.GenerationExport.BatchSize = 10

--- a/java/README.md
+++ b/java/README.md
@@ -199,7 +199,7 @@ Resolution precedence for tool executions (highest to lowest):
 3. `ContentCaptureResolver` return value
 4. `SigilClientConfig.contentCapture` (defaults to `NO_TOOL_CONTENT`)
 
-User-provided `metadata` and `tags` are not stripped by any capture mode. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content. See [Tags and Metadata](../docs/concepts/tags-and-metadata.md) for where client tags, per-generation tags, metadata, and `userId` each show up. Java merges client tags into the generation export only; it does not emit `sigil.tag.<key>` on spans/metrics.
+User-provided `metadata` and `tags` are not stripped by any capture mode. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content. See [Tags and Metadata](../docs/concepts/tags-and-metadata.md) for where client tags, per-generation tags, metadata, and `userId` each show up (export vs spans vs metrics).
 
 ## Embedding Observability
 
@@ -370,7 +370,7 @@ SDK schema defaults fill the rest.
 | `SIGIL_AGENT_NAME` | `SigilClientConfig.agentName` |
 | `SIGIL_AGENT_VERSION` | `SigilClientConfig.agentVersion` |
 | `SIGIL_USER_ID` | `SigilClientConfig.userId` |
-| `SIGIL_TAGS` | `SigilClientConfig.tags` (CSV; merged into generation export only. Only Go/JS emit `sigil.tag.<key>` on spans/metrics; see [Tags and Metadata](../docs/concepts/tags-and-metadata.md)) |
+| `SIGIL_TAGS` | `SigilClientConfig.tags` (CSV; applied to generations, spans, and metrics; see [Tags and Metadata](../docs/concepts/tags-and-metadata.md)) |
 | `SIGIL_CONTENT_CAPTURE_MODE` | `SigilClientConfig.contentCapture` |
 | `SIGIL_DEBUG` | `SigilClientConfig.debug` (tri-state) |
 

--- a/java/core/src/main/java/com/grafana/sigil/sdk/SigilClient.java
+++ b/java/core/src/main/java/com/grafana/sigil/sdk/SigilClient.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -77,6 +78,7 @@ public final class SigilClient implements AutoCloseable {
     static final String SPAN_ATTR_TOOL_DESCRIPTION = "gen_ai.tool.description";
     static final String SPAN_ATTR_TOOL_CALL_ARGUMENTS = "gen_ai.tool.call.arguments";
     static final String SPAN_ATTR_TOOL_CALL_RESULT = "gen_ai.tool.call.result";
+    static final String SPAN_ATTR_TAG_PREFIX = "sigil.tag.";
     private static final int MAX_RATING_CONVERSATION_ID_LEN = 255;
     private static final int MAX_RATING_ID_LEN = 128;
     private static final int MAX_RATING_GENERATION_ID_LEN = 255;
@@ -252,6 +254,7 @@ public final class SigilClient implements AutoCloseable {
                 .setStartTimestamp(startedAt)
                 .startSpan();
         setEmbeddingStartSpanAttributes(span, seed);
+        span.setAllAttributes(clientTagAttributes());
 
         return new EmbeddingRecorder(this, seed, span, startedAt, embeddingMode);
     }
@@ -375,6 +378,7 @@ public final class SigilClient implements AutoCloseable {
                 .setStartTimestamp(startedAt)
                 .startSpan();
         setToolSpanAttributes(span, seed);
+        span.setAllAttributes(clientTagAttributes());
 
         return new ToolExecutionRecorder(this, seed, span, startedAt, resolvedToolMode, legacyIncludeContent);
     }
@@ -730,6 +734,7 @@ public final class SigilClient implements AutoCloseable {
             initial.setConversationTitle("");
         }
         setGenerationSpanAttributes(span, initial);
+        span.setAllAttributes(clientTagAttributes());
 
         Scope contentCaptureScope = SigilContext.withContentCaptureMode(ccMode);
         return new GenerationRecorder(this, seed, span, startedAt, ccMode, contentCaptureScope);
@@ -1237,6 +1242,29 @@ public final class SigilClient implements AutoCloseable {
         }
     }
 
+    static Attributes tagAttributes(Map<String, String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return Attributes.empty();
+        }
+        Map<String, String> normalized = new TreeMap<>();
+        for (Map.Entry<String, String> entry : tags.entrySet()) {
+            String key = entry.getKey() == null ? "" : entry.getKey().trim();
+            if (key.isEmpty()) {
+                continue;
+            }
+            normalized.put(key, entry.getValue() == null ? "" : entry.getValue().trim());
+        }
+        AttributesBuilder builder = Attributes.builder();
+        for (Map.Entry<String, String> entry : normalized.entrySet()) {
+            builder.put(SPAN_ATTR_TAG_PREFIX + entry.getKey(), entry.getValue());
+        }
+        return builder.build();
+    }
+
+    Attributes clientTagAttributes() {
+        return tagAttributes(config.getTags());
+    }
+
     private static AttributesBuilder metricIdentityAttributes(String provider, String model, String agentName, String agentVersion) {
         AttributesBuilder builder = Attributes.builder()
                 .put(SPAN_ATTR_PROVIDER_NAME, provider == null ? "" : provider.trim())
@@ -1263,10 +1291,12 @@ public final class SigilClient implements AutoCloseable {
                 generation.getAgentName(),
                 generation.getAgentVersion()
         ).build();
+        Attributes tagAttributes = clientTagAttributes();
         operationDurationHistogram.record(
                 durationSeconds,
                 identityAttributes.toBuilder()
                         .put(SPAN_ATTR_OPERATION_NAME, operationName(generation))
+                        .putAll(tagAttributes)
                         .put(SPAN_ATTR_ERROR_TYPE, errorType == null ? "" : errorType)
                         .put(SPAN_ATTR_ERROR_CATEGORY, errorCategory == null ? "" : errorCategory)
                         .build()
@@ -1283,7 +1313,7 @@ public final class SigilClient implements AutoCloseable {
 
         toolCallsHistogram.record(
                 (double) countToolCalls(generation.getOutput()),
-                identityAttributes
+                identityAttributes.toBuilder().putAll(tagAttributes).build()
         );
 
         if (defaultOperationName(GenerationMode.STREAM).equals(operationName(generation)) && firstTokenAt != null) {
@@ -1291,7 +1321,7 @@ public final class SigilClient implements AutoCloseable {
             if (ttftSeconds >= 0d) {
                 ttftHistogram.record(
                         ttftSeconds,
-                        identityAttributes
+                        identityAttributes.toBuilder().putAll(tagAttributes).build()
                 );
             }
         }
@@ -1315,10 +1345,12 @@ public final class SigilClient implements AutoCloseable {
                 seed.getAgentName(),
                 seed.getAgentVersion()
         ).build();
+        Attributes tagAttributes = clientTagAttributes();
         operationDurationHistogram.record(
                 durationSeconds,
                 identityAttributes.toBuilder()
                         .put(SPAN_ATTR_OPERATION_NAME, DEFAULT_EMBEDDING_OPERATION_NAME)
+                        .putAll(tagAttributes)
                         .put(SPAN_ATTR_ERROR_TYPE, errorType == null ? "" : errorType)
                         .put(SPAN_ATTR_ERROR_CATEGORY, errorCategory == null ? "" : errorCategory)
                         .build()
@@ -1329,6 +1361,7 @@ public final class SigilClient implements AutoCloseable {
                     (double) result.getInputTokens(),
                     identityAttributes.toBuilder()
                             .put(SPAN_ATTR_OPERATION_NAME, DEFAULT_EMBEDDING_OPERATION_NAME)
+                            .putAll(tagAttributes)
                             .put(METRIC_ATTR_TOKEN_TYPE, METRIC_TOKEN_TYPE_INPUT)
                             .build()
             );
@@ -1348,6 +1381,7 @@ public final class SigilClient implements AutoCloseable {
                         generation.getAgentVersion()
                 )
                         .put(SPAN_ATTR_OPERATION_NAME, operationName(generation))
+                        .putAll(clientTagAttributes())
                         .put(METRIC_ATTR_TOKEN_TYPE, tokenType)
                         .build()
         );
@@ -1371,6 +1405,7 @@ public final class SigilClient implements AutoCloseable {
                 metricIdentityAttributes(seed.getRequestProvider(), seed.getRequestModel(), seed.getAgentName(), seed.getAgentVersion())
                         .put(SPAN_ATTR_OPERATION_NAME, TOOL_EXECUTION_OPERATION_NAME)
                         .put(SPAN_ATTR_TOOL_NAME, seed.getToolName().trim())
+                        .putAll(clientTagAttributes())
                         .put(SPAN_ATTR_ERROR_TYPE, errorType)
                         .put(SPAN_ATTR_ERROR_CATEGORY, errorCategory)
                         .build()

--- a/java/core/src/test/java/com/grafana/sigil/sdk/ConformanceTest.java
+++ b/java/core/src/test/java/com/grafana/sigil/sdk/ConformanceTest.java
@@ -531,6 +531,29 @@ class ConformanceTest {
     }
 
     @Test
+    void clientTagAttributes() throws Exception {
+        try (ConformanceEnv env = new ConformanceEnv(1, Map.of("team", "payments"))) {
+            GenerationRecorder recorder = env.client.startGeneration(new GenerationStart()
+                    .setModel(new ModelRef().setProvider("openai").setName("gpt-5"))
+                    .setTags(Map.of("call_only", "yes")));
+            recorder.setResult(new GenerationResult()
+                    .setUsage(new TokenUsage().setInputTokens(4).setOutputTokens(2)));
+            recorder.end();
+            env.client.shutdown();
+
+            SpanData span = env.latestGenerationSpan();
+            assertThat(span.getAttributes().get(AttributeKey.stringKey("sigil.tag.team"))).isEqualTo("payments");
+            assertThat(span.getAttributes().get(AttributeKey.stringKey("sigil.tag.call_only"))).isNull();
+
+            MetricData duration = env.metricData(SigilClient.METRIC_OPERATION_DURATION);
+            boolean tagged = duration.getHistogramData().getPoints().stream()
+                    .anyMatch(point -> "payments".equals(
+                            point.getAttributes().get(AttributeKey.stringKey("sigil.tag.team"))));
+            assertThat(tagged).as("expected sigil.tag.team on operation.duration data point").isTrue();
+        }
+    }
+
+    @Test
     void shutdownFlushSemantics() throws Exception {
         try (ConformanceEnv env = new ConformanceEnv(10)) {
             GenerationRecorder recorder = env.client.startGeneration(new GenerationStart()
@@ -602,6 +625,10 @@ class ConformanceTest {
         private final SigilClient client;
 
         ConformanceEnv(int batchSize) throws Exception {
+            this(batchSize, null);
+        }
+
+        ConformanceEnv(int batchSize, Map<String, String> tags) throws Exception {
             GenerationIngestServiceGrpc.GenerationIngestServiceImplBase service =
                     new GenerationIngestServiceGrpc.GenerationIngestServiceImplBase() {
                         @Override
@@ -655,7 +682,7 @@ class ConformanceTest {
             });
             ratingServer.start();
 
-            client = new SigilClient(new SigilClientConfig()
+            SigilClientConfig config = new SigilClientConfig()
                     .setTracer(tracerProvider.get("sigil-conformance-test"))
                     .setMeter(meterProvider.get("sigil-conformance-test"))
                     .setApi(new ApiConfig().setEndpoint("http://127.0.0.1:" + ratingServer.getAddress().getPort()))
@@ -668,7 +695,11 @@ class ConformanceTest {
                             .setFlushInterval(Duration.ofHours(1))
                             .setMaxRetries(1)
                             .setInitialBackoff(Duration.ofMillis(1))
-                            .setMaxBackoff(Duration.ofMillis(2))));
+                            .setMaxBackoff(Duration.ofMillis(2)));
+            if (tags != null) {
+                config.setTags(tags);
+            }
+            client = new SigilClient(config);
         }
 
         GenerationIngest.Generation singleGeneration() {

--- a/java/core/src/test/java/com/grafana/sigil/sdk/SigilClientTagsTest.java
+++ b/java/core/src/test/java/com/grafana/sigil/sdk/SigilClientTagsTest.java
@@ -1,0 +1,220 @@
+package com.grafana.sigil.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.HistogramPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class SigilClientTagsTest {
+    private static final AttributeKey<String> CLIENT_TAG_PROJECT_KEY =
+            AttributeKey.stringKey(SigilClient.SPAN_ATTR_TAG_PREFIX + "project");
+
+    private final InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+    private final SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+            .build();
+    private final InMemoryMetricReader metricReader = InMemoryMetricReader.create();
+    private final SdkMeterProvider meterProvider = SdkMeterProvider.builder()
+            .registerMetricReader(metricReader)
+            .build();
+    private final TestFixtures.CapturingExporter exporter = new TestFixtures.CapturingExporter();
+
+    @AfterEach
+    void shutdownProviders() {
+        tracerProvider.shutdown();
+        meterProvider.shutdown();
+    }
+
+    private SigilClient newClient(Map<String, String> tags) {
+        SigilClientConfig config = new SigilClientConfig()
+                .setTracer(tracerProvider.get("sigil-test"))
+                .setMeter(meterProvider.get("sigil-test"))
+                .setGenerationExporter(exporter)
+                .setGenerationExport(new GenerationExportConfig()
+                        .setBatchSize(100)
+                        .setQueueSize(100)
+                        .setFlushInterval(Duration.ofMinutes(10))
+                        .setMaxRetries(0));
+        if (tags != null) {
+            config.setTags(tags);
+        }
+        return new SigilClient(config);
+    }
+
+    @Test
+    void clientTagsOnGenerationSpanAndMetrics() {
+        try (SigilClient client = newClient(Map.of("project", "checkout-svc"))) {
+            GenerationStart start = TestFixtures.startFixture();
+            GenerationRecorder recorder = client.startStreamingGeneration(start);
+            recorder.setFirstTokenAt(start.getStartedAt().plusMillis(250));
+            recorder.setResult(TestFixtures.resultFixture());
+            recorder.end();
+        }
+
+        SpanData span = singleSpan();
+        assertThat(span.getAttributes().get(CLIENT_TAG_PROJECT_KEY)).isEqualTo("checkout-svc");
+
+        Collection<MetricData> metrics = metricReader.collectAllMetrics();
+        for (String metricName : List.of(
+                SigilClient.METRIC_OPERATION_DURATION,
+                SigilClient.METRIC_TOKEN_USAGE,
+                SigilClient.METRIC_TTFT,
+                SigilClient.METRIC_TOOL_CALLS_PER_OPERATION)) {
+            for (HistogramPointData point : histogramPoints(metrics, metricName)) {
+                assertThat(point.getAttributes().get(CLIENT_TAG_PROJECT_KEY))
+                        .as("expected sigil.tag.project on %s", metricName)
+                        .isEqualTo("checkout-svc");
+            }
+        }
+    }
+
+    @Test
+    void clientTagsOnEmbeddingAndToolSpansAndMetrics() {
+        try (SigilClient client = newClient(Map.of("project", "embed-tools"))) {
+            EmbeddingRecorder embedding = client.startEmbedding(new EmbeddingStart()
+                    .setModel(new ModelRef().setProvider("openai").setName("text-embedding-3-small")));
+            embedding.setResult(new EmbeddingResult().setInputTokens(1));
+            embedding.end();
+
+            ToolExecutionRecorder tool = client.startToolExecution(new ToolExecutionStart()
+                    .setToolName("weather"));
+            tool.setResult(new ToolExecutionResult().setResult("sunny"));
+            tool.end();
+        }
+
+        List<SpanData> spans = spanExporter.getFinishedSpanItems();
+        assertThat(spans).hasSize(2);
+        for (SpanData span : spans) {
+            assertThat(span.getAttributes().get(CLIENT_TAG_PROJECT_KEY))
+                    .as("expected sigil.tag.project on span %s", span.getName())
+                    .isEqualTo("embed-tools");
+        }
+
+        Collection<MetricData> metrics = metricReader.collectAllMetrics();
+        // Embedding duration + tool duration share the operation.duration
+        // instrument; embedding token usage is the token.usage instrument.
+        for (String metricName : List.of(SigilClient.METRIC_OPERATION_DURATION, SigilClient.METRIC_TOKEN_USAGE)) {
+            for (HistogramPointData point : histogramPoints(metrics, metricName)) {
+                assertThat(point.getAttributes().get(CLIENT_TAG_PROJECT_KEY))
+                        .as("expected sigil.tag.project on %s", metricName)
+                        .isEqualTo("embed-tools");
+            }
+        }
+    }
+
+    @Test
+    void clientTagsAreNormalizedAndSorted() {
+        Attributes attributes = SigilClient.tagAttributes(Map.of(
+                " z ", " last ",
+                "   ", "discard",
+                " a ", ""));
+
+        assertThat(attributes.size()).isEqualTo(2);
+        assertThat(attributes.get(AttributeKey.stringKey("sigil.tag.a"))).isEmpty();
+        assertThat(attributes.get(AttributeKey.stringKey("sigil.tag.z"))).isEqualTo("last");
+
+        try (SigilClient client = newClient(Map.of(" z ", " last ", "   ", "discard", " a ", ""))) {
+            GenerationRecorder recorder = client.startGeneration(TestFixtures.startFixture());
+            recorder.setResult(TestFixtures.resultFixture());
+            recorder.end();
+        }
+
+        SpanData span = singleSpan();
+        assertThat(span.getAttributes().get(AttributeKey.stringKey("sigil.tag.a"))).isEmpty();
+        assertThat(span.getAttributes().get(AttributeKey.stringKey("sigil.tag.z"))).isEqualTo("last");
+        span.getAttributes().forEach((key, value) ->
+                assertThat(key.getKey().trim()).isEqualTo(key.getKey()));
+    }
+
+    @Test
+    void emptyClientTagsAreNoOp() {
+        try (SigilClient client = newClient(null)) {
+            GenerationRecorder recorder = client.startGeneration(TestFixtures.startFixture());
+            recorder.setResult(TestFixtures.resultFixture());
+            recorder.end();
+
+            EmbeddingRecorder embedding = client.startEmbedding(new EmbeddingStart()
+                    .setModel(new ModelRef().setProvider("openai").setName("text-embedding-3-small")));
+            embedding.setResult(new EmbeddingResult().setInputTokens(1));
+            embedding.end();
+
+            ToolExecutionRecorder tool = client.startToolExecution(new ToolExecutionStart()
+                    .setToolName("weather"));
+            tool.setResult(new ToolExecutionResult().setResult("sunny"));
+            tool.end();
+        }
+
+        for (SpanData span : spanExporter.getFinishedSpanItems()) {
+            span.getAttributes().forEach((key, value) ->
+                    assertThat(key.getKey())
+                            .as("unexpected tag attribute on span %s", span.getName())
+                            .doesNotStartWith(SigilClient.SPAN_ATTR_TAG_PREFIX));
+        }
+
+        for (MetricData metric : metricReader.collectAllMetrics()) {
+            for (HistogramPointData point : metric.getHistogramData().getPoints()) {
+                point.getAttributes().forEach((key, value) ->
+                        assertThat(key.getKey())
+                                .as("unexpected tag attribute on metric %s", metric.getName())
+                                .doesNotStartWith(SigilClient.SPAN_ATTR_TAG_PREFIX));
+            }
+        }
+    }
+
+    @Test
+    void perCallGenerationTagsStayExportOnly() {
+        try (SigilClient client = newClient(null)) {
+            GenerationStart start = TestFixtures.startFixture()
+                    .setTags(Map.of("call_only", "yes"));
+            GenerationRecorder recorder = client.startGeneration(start);
+            recorder.setResult(TestFixtures.resultFixture());
+            recorder.end();
+            client.flush();
+        }
+
+        SpanData span = singleSpan();
+        assertThat(span.getAttributes().get(AttributeKey.stringKey("sigil.tag.call_only"))).isNull();
+
+        for (MetricData metric : metricReader.collectAllMetrics()) {
+            for (HistogramPointData point : metric.getHistogramData().getPoints()) {
+                assertThat(point.getAttributes().get(AttributeKey.stringKey("sigil.tag.call_only")))
+                        .as("per-call tag must not appear on metric %s", metric.getName())
+                        .isNull();
+            }
+        }
+
+        assertThat(exporter.getRequests()).hasSize(1);
+        Generation generation = exporter.getRequests().get(0).get(0);
+        assertThat(generation.getTags()).containsEntry("call_only", "yes");
+    }
+
+    private SpanData singleSpan() {
+        List<SpanData> spans = spanExporter.getFinishedSpanItems();
+        assertThat(spans).hasSize(1);
+        return spans.get(0);
+    }
+
+    private static List<HistogramPointData> histogramPoints(Collection<MetricData> metrics, String name) {
+        MetricData metric = metrics.stream()
+                .filter(m -> name.equals(m.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("missing metric " + name));
+        List<HistogramPointData> points = List.copyOf(metric.getHistogramData().getPoints());
+        assertThat(points).as("expected data points for %s", name).isNotEmpty();
+        return points;
+    }
+}

--- a/js/test/conformance.test.mjs
+++ b/js/test/conformance.test.mjs
@@ -699,6 +699,38 @@ test('conformance effective_version result overrides start', async () => {
   }
 });
 
+test('conformance client tag attributes', async () => {
+  const env = await createConformanceEnv({
+    clientConfig: {
+      tags: { team: 'payments' },
+    },
+  });
+
+  try {
+    const recorder = env.client.startGeneration({
+      model: { provider: 'openai', name: 'gpt-5' },
+      tags: { call_only: 'yes' },
+    });
+    recorder.setResult({
+      usage: { inputTokens: 4, outputTokens: 2 },
+    });
+    recorder.end();
+    assert.equal(recorder.getError(), undefined);
+
+    const span = env.latestGenerationSpan();
+    assert.equal(span.attributes['sigil.tag.team'], 'payments');
+    assert.equal(span.attributes['sigil.tag.call_only'], undefined);
+
+    const durationAttributes = await env.metricDataPointAttributes('gen_ai.client.operation.duration');
+    assert.ok(
+      durationAttributes.some((attributes) => attributes['sigil.tag.team'] === 'payments'),
+      'expected sigil.tag.team on operation.duration data point',
+    );
+  } finally {
+    await env.close();
+  }
+});
+
 test('conformance shutdown flush semantics', async () => {
   const env = await createConformanceEnv({ batchSize: 10 });
 

--- a/llms.txt
+++ b/llms.txt
@@ -109,7 +109,7 @@ SIGIL_PROTOCOL=http
 SIGIL_AUTH_MODE=basic
 SIGIL_AUTH_TENANT_ID=<your-instance-id>
 SIGIL_AUTH_TOKEN=<glc_... token>
-SIGIL_TAGS=team=checkout,env=prod   # optional client tags; on Go/JS also emitted as sigil.tag.<key> on OTel spans/metrics
+SIGIL_TAGS=team=checkout,env=prod   # optional client tags; also emitted as sigil.tag.<key> on OTel spans/metrics
 SIGIL_USER_ID=<end-user id>          # optional; sets the user.id span attribute (all SDKs)
 
 # OTel traces and metrics (separate channel; same token)
@@ -131,7 +131,7 @@ This default differs from coding-agent plugin defaults (Path A), which ship `met
 
 To attach custom key/values, pick the mechanism by where it must show up. See [`docs/concepts/tags-and-metadata.md`](https://github.com/grafana/sigil-sdk/blob/main/docs/concepts/tags-and-metadata.md) for the full table.
 
-- **Client tags** (`SIGIL_TAGS` / config `tags`): merged into every generation export; on **Go/JS** also emitted as `sigil.tag.<key>` on OTel spans and metrics (Python/Java/.NET are export-only). Use for low-cardinality values you want to slice metrics/traces by (team, project, env). Do not put high-cardinality values (user, request id) here, they blow up metric label cardinality.
+- **Client tags** (`SIGIL_TAGS` / config `tags`): merged into every generation export; also emitted as `sigil.tag.<key>` on OTel spans and metrics in all SDKs. Use for low-cardinality values you want to slice metrics/traces by (team, project, env). Do not put high-cardinality values (user, request id) here, they blow up metric label cardinality.
 - **Per-generation `tags` / `metadata`**: export-only, never on spans/metrics. Use for searchable per-request data.
 - **`user_id`** (`SIGIL_USER_ID` / per-call / context): sets the `user.id` span attribute (all SDKs) plus the export; not a metric label. Use this for end-user identity instead of a tag.
 
@@ -447,7 +447,7 @@ In the grafana/sigil-sdk repo:
   - `stop_reason` / `finish_reason`
   - Full token usage including `cache_read_input_tokens`, `cache_write_input_tokens`, and `reasoning_tokens` when the provider returns them
 - Always check `rec.err()` / `Err()` after the generation recorder closes; SDK validation or enqueue errors are otherwise silent.
-- Use `SIGIL_TAGS` (client-level) or `tags` on `GenerationStart` for filtering: both export tags on generations. Client-level tags also appear as `sigil.tag.<key>` on OTel spans and metrics on Go/JS only (Python/Java/.NET are export-only); per-generation tags and `metadata` are export-only everywhere. For end-user identity use `user_id` (sets `user.id` span attribute), not a tag. See [`docs/concepts/tags-and-metadata.md`](https://github.com/grafana/sigil-sdk/blob/main/docs/concepts/tags-and-metadata.md).
+- Use `SIGIL_TAGS` (client-level) or `tags` on `GenerationStart` for filtering: both export tags on generations. Client-level tags also appear as `sigil.tag.<key>` on OTel spans and metrics in all SDKs; per-generation tags and `metadata` are export-only everywhere. For end-user identity use `user_id` (sets `user.id` span attribute), not a tag. See [`docs/concepts/tags-and-metadata.md`](https://github.com/grafana/sigil-sdk/blob/main/docs/concepts/tags-and-metadata.md).
 
 ## Validation checklist
 

--- a/python/README.md
+++ b/python/README.md
@@ -442,7 +442,7 @@ with with_conversation_id("conv-ctx"), with_agent_name("planner"), with_agent_ve
 
 `FULL_WITH_METADATA_SPANS` is the right mode when the gRPC ingest destination is private but the OTel trace/metric destination is shared and must not receive any content. Tool execution and embedding spans behave like `METADATA_ONLY` under this mode because they have no separate gRPC export.
 
-User-provided `metadata` and `tags` are **not** stripped by any capture mode; callers must avoid putting sensitive content in those dicts when using `METADATA_ONLY` or `FULL_WITH_METADATA_SPANS`. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content. See [Tags and Metadata](../docs/concepts/tags-and-metadata.md) for where client tags, per-generation tags, metadata, and `user_id` each show up (Python merges client tags into the generation export only, not onto spans/metrics).
+User-provided `metadata` and `tags` are **not** stripped by any capture mode; callers must avoid putting sensitive content in those dicts when using `METADATA_ONLY` or `FULL_WITH_METADATA_SPANS`. SDK-internal metadata keys that carry content (e.g. `call_error`, `sigil.conversation.title`) are stripped along with the matching content. See [Tags and Metadata](../docs/concepts/tags-and-metadata.md) for where client tags, per-generation tags, metadata, and `user_id` each show up (export vs spans vs metrics).
 
 ### Client-level default
 

--- a/python/sigil_sdk/client.py
+++ b/python/sigil_sdk/client.py
@@ -117,6 +117,7 @@ _span_attr_tool_description = "gen_ai.tool.description"
 _span_attr_tool_call_arguments = "gen_ai.tool.call.arguments"
 _span_attr_tool_call_result = "gen_ai.tool.call.result"
 _span_attr_parent_generation_ids = "sigil.generation.parent_generation_ids"
+_span_attr_tag_prefix = "sigil.tag."
 _max_rating_conversation_id_len = 255
 _max_rating_id_len = 128
 _max_rating_generation_id_len = 255
@@ -439,6 +440,7 @@ class Client:
             start_time=_datetime_to_ns(started_at),
         )
         _set_embedding_start_span_attributes(span, seed)
+        self._set_client_tag_attributes(span)
 
         return EmbeddingRecorder(
             client=self,
@@ -508,6 +510,7 @@ class Client:
             start_time=_datetime_to_ns(started_at),
         )
         _set_tool_span_attributes(span, seed)
+        self._set_client_tag_attributes(span)
 
         return ToolExecutionRecorder(
             client=self,
@@ -888,6 +891,7 @@ class Client:
                 parent_generation_ids=list(seed.parent_generation_ids),
             ),
         )
+        self._set_client_tag_attributes(span)
 
         recorder = GenerationRecorder(
             client=self,
@@ -1095,6 +1099,14 @@ class Client:
             return
         self._logger.warning("%s: %s", message, error)
 
+    def _client_tag_attributes(self) -> dict[str, str]:
+        return _tag_attributes(self._config.tags)
+
+    def _set_client_tag_attributes(self, span: Span) -> None:
+        tag_attrs = self._client_tag_attributes()
+        if tag_attrs:
+            span.set_attributes(tag_attrs)
+
     def _record_generation_metrics(
         self,
         generation: Generation,
@@ -1114,11 +1126,13 @@ class Client:
             generation.agent_name,
             generation.agent_version,
         )
+        tag_attributes = self._client_tag_attributes()
         self._operation_duration_histogram.record(
             duration_seconds,
             attributes={
                 _span_attr_operation_name: generation.operation_name,
                 **identity_attributes,
+                **tag_attributes,
                 _span_attr_error_type: error_type,
                 _span_attr_error_category: error_category,
             },
@@ -1135,6 +1149,7 @@ class Client:
             _count_tool_call_parts(generation.output),
             attributes={
                 **identity_attributes,
+                **tag_attributes,
             },
         )
 
@@ -1145,6 +1160,7 @@ class Client:
                     ttft_seconds,
                     attributes={
                         **identity_attributes,
+                        **tag_attributes,
                     },
                 )
 
@@ -1164,11 +1180,13 @@ class Client:
             seed.agent_name,
             seed.agent_version,
         )
+        tag_attributes = self._client_tag_attributes()
         self._operation_duration_histogram.record(
             duration_seconds,
             attributes={
                 _span_attr_operation_name: _default_embedding_operation_name,
                 **identity_attributes,
+                **tag_attributes,
                 _span_attr_error_type: error_type,
                 _span_attr_error_category: error_category,
             },
@@ -1180,6 +1198,7 @@ class Client:
                 attributes={
                     _span_attr_operation_name: _default_embedding_operation_name,
                     **identity_attributes,
+                    **tag_attributes,
                     _metric_attr_token_type: _metric_token_type_input,
                 },
             )
@@ -1197,6 +1216,7 @@ class Client:
                     generation.agent_name,
                     generation.agent_version,
                 ),
+                **self._client_tag_attributes(),
                 _metric_attr_token_type: token_type,
             },
         )
@@ -1226,6 +1246,7 @@ class Client:
                     seed.agent_name,
                     seed.agent_version,
                 ),
+                **self._client_tag_attributes(),
                 _span_attr_error_type: error_type,
                 _span_attr_error_category: error_category,
             },
@@ -2100,6 +2121,19 @@ def _default_operation_name(mode: GenerationMode | None) -> str:
     if mode == GenerationMode.STREAM:
         return "streamText"
     return "generateText"
+
+
+def _tag_attributes(tags: dict[str, str] | None) -> dict[str, str]:
+    if not tags:
+        return {}
+    pairs: list[tuple[str, str]] = []
+    for k, v in tags.items():
+        key = k.strip()
+        if not key:
+            continue
+        pairs.append((key, (v or "").strip()))
+    pairs.sort()
+    return {f"{_span_attr_tag_prefix}{key}": value for key, value in pairs}
 
 
 def _metric_identity_attributes(

--- a/python/tests/test_client_tags.py
+++ b/python/tests/test_client_tags.py
@@ -1,0 +1,227 @@
+"""Tests that client-level tags are emitted as ``sigil.tag.<key>`` span and metric attributes."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from conftest import CapturingGenerationExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from sigil_sdk import (
+    Client,
+    ClientConfig,
+    EmbeddingResult,
+    EmbeddingStart,
+    Generation,
+    GenerationExportConfig,
+    GenerationStart,
+    Message,
+    MessageRole,
+    ModelRef,
+    Part,
+    PartKind,
+    TokenUsage,
+    ToolCall,
+    ToolExecutionStart,
+)
+
+_OPENAI = ModelRef(provider="openai", name="gpt-5")
+_EMBEDDING_MODEL = ModelRef(provider="openai", name="text-embedding-3-small")
+_CLIENT_TAG_PROJECT_KEY = "sigil.tag.project"
+
+
+class _TagsHarness:
+    """In-memory OTel span + metric plumbing for client tag tests."""
+
+    def __init__(self, tags: dict[str, str] | None = None) -> None:
+        self.span_exporter = InMemorySpanExporter()
+        self.tracer_provider = TracerProvider()
+        self.tracer_provider.add_span_processor(SimpleSpanProcessor(self.span_exporter))
+
+        self.metric_reader = InMemoryMetricReader()
+        self.meter_provider = MeterProvider(metric_readers=[self.metric_reader])
+
+        self.generation_exporter = CapturingGenerationExporter()
+        self.client = Client(
+            ClientConfig(
+                tracer=self.tracer_provider.get_tracer("sigil-test"),
+                meter=self.meter_provider.get_meter("sigil-test"),
+                generation_export=GenerationExportConfig(
+                    batch_size=10,
+                    flush_interval=timedelta(seconds=60),
+                    queue_size=10,
+                    max_retries=1,
+                    initial_backoff=timedelta(milliseconds=1),
+                    max_backoff=timedelta(milliseconds=1),
+                ),
+                generation_exporter=self.generation_exporter,
+                tags=tags,
+            )
+        )
+
+    def shutdown(self) -> None:
+        self.client.shutdown()
+        self.tracer_provider.shutdown()
+        self.meter_provider.shutdown()
+
+    def spans_for_operation(self, operation_name: str | None):
+        spans = self.span_exporter.get_finished_spans()
+        if operation_name is None:
+            return [s for s in spans if s.attributes.get("gen_ai.operation.name") not in ("execute_tool", "embeddings")]
+        return [s for s in spans if s.attributes.get("gen_ai.operation.name") == operation_name]
+
+    def single_span(self, operation_name: str | None):
+        spans = self.spans_for_operation(operation_name)
+        assert len(spans) == 1, f"expected 1 span for {operation_name!r}, got {len(spans)}"
+        return spans[0]
+
+    def metric_data_points(self, metric_name: str):
+        data = self.metric_reader.get_metrics_data()
+        points = []
+        for resource_metric in data.resource_metrics:
+            for scope_metric in resource_metric.scope_metrics:
+                for metric in scope_metric.metrics:
+                    if metric.name == metric_name:
+                        points.extend(metric.data.data_points)
+        assert points, f"expected data points for {metric_name}"
+        return points
+
+    def assert_metric_points_carry_tag(self, metric_name: str, key: str, value: str) -> None:
+        points = self.metric_data_points(metric_name)
+        for point in points:
+            assert dict(point.attributes).get(key) == value, (
+                f"expected {key}={value!r} on every {metric_name} data point, got {dict(point.attributes)}"
+            )
+
+
+def test_client_tags_on_generation_span_and_metrics():
+    h = _TagsHarness(tags={"project": "checkout-svc"})
+    try:
+        rec = h.client.start_streaming_generation(GenerationStart(model=_OPENAI))
+        rec.set_first_token_at(datetime.now(timezone.utc))
+        rec.set_result(
+            Generation(
+                output=[
+                    Message(
+                        role=MessageRole.ASSISTANT,
+                        parts=[
+                            Part(
+                                kind=PartKind.TOOL_CALL,
+                                tool_call=ToolCall(id="call-1", name="weather"),
+                            )
+                        ],
+                    )
+                ],
+                usage=TokenUsage(input_tokens=10, output_tokens=5),
+            )
+        )
+        rec.end()
+        assert rec.err() is None
+
+        span = h.single_span(None)
+        assert span.attributes.get(_CLIENT_TAG_PROJECT_KEY) == "checkout-svc"
+
+        for metric_name in (
+            "gen_ai.client.operation.duration",
+            "gen_ai.client.token.usage",
+            "gen_ai.client.tool_calls_per_operation",
+            "gen_ai.client.time_to_first_token",
+        ):
+            h.assert_metric_points_carry_tag(metric_name, _CLIENT_TAG_PROJECT_KEY, "checkout-svc")
+    finally:
+        h.shutdown()
+
+
+def test_client_tags_on_embedding_and_tool_spans_and_metrics():
+    h = _TagsHarness(tags={"project": "embed-tools"})
+    try:
+        embed = h.client.start_embedding(EmbeddingStart(model=_EMBEDDING_MODEL))
+        embed.set_result(EmbeddingResult(input_tokens=1))
+        embed.end()
+        assert embed.err() is None
+
+        embed_span = h.single_span("embeddings")
+        assert embed_span.attributes.get(_CLIENT_TAG_PROJECT_KEY) == "embed-tools"
+
+        tool = h.client.start_tool_execution(ToolExecutionStart(tool_name="weather"))
+        tool.set_result(result={"temp": 72})
+        tool.end()
+        assert tool.err() is None
+
+        tool_span = h.single_span("execute_tool")
+        assert tool_span.attributes.get(_CLIENT_TAG_PROJECT_KEY) == "embed-tools"
+
+        # Embedding duration + tool duration share the operation.duration
+        # instrument; embedding token usage is the token.usage instrument.
+        h.assert_metric_points_carry_tag("gen_ai.client.operation.duration", _CLIENT_TAG_PROJECT_KEY, "embed-tools")
+        h.assert_metric_points_carry_tag("gen_ai.client.token.usage", _CLIENT_TAG_PROJECT_KEY, "embed-tools")
+    finally:
+        h.shutdown()
+
+
+def test_client_tags_are_normalized_and_sorted():
+    h = _TagsHarness(tags={" z ": " last ", "   ": "discard", " a ": ""})
+    try:
+        rec = h.client.start_generation(GenerationStart(model=_OPENAI))
+        rec.set_result(Generation())
+        rec.end()
+        assert rec.err() is None
+
+        span = h.single_span(None)
+        tag_attrs = [(k, v) for k, v in span.attributes.items() if k.startswith("sigil.tag.")]
+        assert tag_attrs == [("sigil.tag.a", ""), ("sigil.tag.z", "last")]
+    finally:
+        h.shutdown()
+
+
+def test_empty_client_tags_are_noop():
+    h = _TagsHarness()
+    try:
+        rec = h.client.start_generation(GenerationStart(model=_OPENAI))
+        rec.set_result(Generation(usage=TokenUsage(input_tokens=1)))
+        rec.end()
+        assert rec.err() is None
+
+        embed = h.client.start_embedding(EmbeddingStart(model=_EMBEDDING_MODEL))
+        embed.set_result(EmbeddingResult(input_tokens=1))
+        embed.end()
+
+        tool = h.client.start_tool_execution(ToolExecutionStart(tool_name="weather"))
+        tool.set_result(result="sunny")
+        tool.end()
+
+        for span in h.span_exporter.get_finished_spans():
+            for key in span.attributes:
+                assert not key.startswith("sigil.tag."), f"unexpected {key} on span {span.name}"
+
+        for metric_name in ("gen_ai.client.operation.duration", "gen_ai.client.token.usage"):
+            for point in h.metric_data_points(metric_name):
+                for key in dict(point.attributes):
+                    assert not key.startswith("sigil.tag."), f"unexpected {key} on {metric_name}"
+    finally:
+        h.shutdown()
+
+
+def test_per_call_generation_tags_stay_export_only():
+    h = _TagsHarness()
+    try:
+        rec = h.client.start_generation(GenerationStart(model=_OPENAI, tags={"call_only": "yes"}))
+        rec.set_result(Generation(usage=TokenUsage(input_tokens=1)))
+        rec.end()
+        assert rec.err() is None
+
+        span = h.single_span(None)
+        assert "sigil.tag.call_only" not in span.attributes
+
+        for point in h.metric_data_points("gen_ai.client.operation.duration"):
+            assert "sigil.tag.call_only" not in dict(point.attributes)
+
+        h.client.flush()
+        assert len(h.generation_exporter.requests) == 1
+        generation = h.generation_exporter.requests[0].generations[0]
+        assert generation.tags["call_only"] == "yes"
+    finally:
+        h.shutdown()

--- a/python/tests/test_conformance.py
+++ b/python/tests/test_conformance.py
@@ -911,6 +911,32 @@ def test_conformance_rating_submission_semantics() -> None:
         env.shutdown()
 
 
+def test_conformance_client_tag_attributes() -> None:
+    env = _ConformanceEnv(tags={"team": "payments"})
+    try:
+        recorder = env.client.start_generation(
+            GenerationStart(
+                model=ModelRef(provider="openai", name="gpt-5"),
+                tags={"call_only": "yes"},
+            )
+        )
+        recorder.set_result(Generation(usage=TokenUsage(input_tokens=4, output_tokens=2)))
+        recorder.end()
+        env.shutdown()
+
+        span = env.generation_span()
+        assert span.attributes["sigil.tag.team"] == "payments"
+        assert "sigil.tag.call_only" not in span.attributes
+
+        metrics = env.metrics()
+        assert any(
+            point.attributes.get("sigil.tag.team") == "payments"
+            for point in metrics["gen_ai.client.operation.duration"].data_points
+        )
+    finally:
+        env.shutdown()
+
+
 def test_conformance_shutdown_flush_semantics() -> None:
     env = _ConformanceEnv(batch_size=10)
     try:


### PR DESCRIPTION
Go and JS have emitted client-level tags as `sigil.tag.<key>` attributes on spans and metrics since #284, but Python, Java, and .NET only put them in the generation export. For apps in those languages the `sigil_tag_<key>` Prometheus labels and the Sigil app tag filters did not work.

The three SDKs now follow the same rules as Go and JS.

Fixes #365