### PR TITLE
fix(sdk-js): support Vercel AI SDK v6 prepareStep

### DIFF
--- a/js/docs/frameworks/vercel-ai-sdk.md
+++ b/js/docs/frameworks/vercel-ai-sdk.md
@@ -1,13 +1,14 @@
 # Vercel AI SDK Hooks (`@grafana/sigil-sdk-js/vercel-ai-sdk`)
 
-Use `createSigilVercelAiSdk(...)` to instrument Vercel AI SDK v5 calls with Sigil generation export, spans, metrics, tool execution spans, and streaming TTFT.
+Use `createSigilVercelAiSdk(...)` to instrument Vercel AI SDK calls with Sigil generation export, spans, metrics, tool execution spans, and streaming TTFT.
 
 Supported AI SDK line:
 
-- `ai` v5 (`generateText`, `streamText`)
+- `ai` v5 and v6 (`generateText`, `streamText`)
 - Baseline generation export uses `onStepFinish` (and `onError` for streams). This path is v5-compatible and records tool executions from step `toolResults`.
-- When `experimental_onStepStart`, `experimental_onToolCallStart`, and `experimental_onToolCallFinish` are available (v6+), Sigil also captures richer per-step input messages and tool timing correlation.
-- Experimental callbacks can change in patch releases. Keep `ai` pinned to a tested minor line (`v5.x` or `v6.x`) in production.
+- Step input capture uses `prepareStep` when available. The older `experimental_onStepStart` callback is still emitted for AI SDK versions that call it.
+- When `experimental_onToolCallStart` and `experimental_onToolCallFinish` are available, Sigil also captures richer tool timing correlation.
+- Experimental callbacks can change in patch releases. Keep `ai` pinned to a tested minor line in production.
 
 ## Install
 
@@ -77,7 +78,7 @@ try {
 }
 ```
 
-The adapter sends the step messages, model, agent name/version, and conversation preview to Sigil. If a guard returns `action: "deny"`, the adapter throws `HookDeniedError` and the provider call is aborted. If a guard returns `transformed_input.messages`, the adapter sends those transformed messages to the provider and records the transformed input in the generation.
+The adapter sends the step messages, model, agent name/version, and conversation preview to Sigil. If a guard returns `action: "deny"`, the adapter throws `HookDeniedError` and the provider call is aborted. If a guard returns `transformed_input.messages`, the adapter records the transformed input in the generation; when the AI SDK calls `prepareStep` and the transformed messages can be represented as AI SDK model messages, the adapter also returns those transformed messages to the provider. If a transform is requested but cannot be applied to the provider call, the adapter aborts rather than sending the original messages.
 
 `enableHooks` overrides the client-level switch for this instrumentation. Leave it unset to use `client.config.hooks.enabled`, or set it to `false` to disable hook evaluation for calls made through this adapter. With `failOpen: true`, hook transport errors resolve to allow; set `failOpen: false` for strict paths that should fail closed.
 
@@ -118,7 +119,7 @@ const result = await generateText({
 Each model step emits one generation with:
 
 - `metadata["sigil.framework.step_type"]` (`initial`, `continue`, `tool-result`)
-- per-step input captured when `experimental_onStepStart` is available (including prior tool result messages)
+- per-step input captured from `prepareStep` or `experimental_onStepStart` (including prior tool result messages)
 
 ## Streaming (`streamText`) and TTFT
 

--- a/js/src/frameworks/vercel-ai-sdk/hooks.ts
+++ b/js/src/frameworks/vercel-ai-sdk/hooks.ts
@@ -28,11 +28,14 @@ import type {
   CallOptions,
   ConversationResolution,
   GenerateTextHooks,
+  PrepareStepEvent,
+  PrepareStepResult,
   SigilVercelAiSdkOptions,
   StepStartEvent,
   StreamTextHooks,
   ToolCallFinishEvent,
   ToolCallStartEvent,
+  VercelAiSdkModelMessage,
 } from './types.js';
 
 interface StepState {
@@ -490,7 +493,10 @@ export class SigilVercelAiSdkInstrumentation {
       return firstError;
     };
 
-    const runPreflight = async (event: StepStartEvent, inputMessages: Message[]): Promise<Message[]> => {
+    const runPreflight = async (
+      event: StepStartEvent,
+      inputMessages: Message[],
+    ): Promise<{ messages: Message[]; providerMessages?: VercelAiSdkModelMessage[]; transformed: boolean }> => {
       const model = mapModelFromStepStart(event);
       // evaluateHook honors fail-open internally; an exception here means
       // fail_open=false and the LLM call should be aborted.
@@ -520,43 +526,82 @@ export class SigilVercelAiSdkInstrumentation {
       }
       const ti = response.transformedInput?.messages;
       if (ti !== undefined && ti.length > 0) {
-        return ti;
+        return {
+          messages: ti,
+          providerMessages: toVercelAiSdkModelMessages(ti),
+          transformed: true,
+        };
       }
-      return inputMessages;
+      return { messages: inputMessages, transformed: false };
+    };
+
+    const handleStepStart = (
+      event: StepStartEvent,
+      returnPreparedMessages: boolean,
+    ): PrepareStepResult | PromiseLike<PrepareStepResult> => {
+      noteStreamObservedStartAt(new Date());
+      const fallbackStep = state.nextSyntheticStepNumber;
+      const stepNumber = extractStepNumber(event, fallbackStep);
+      if (state.stepStates.has(stepNumber)) {
+        state.nextSyntheticStepNumber = Math.max(state.nextSyntheticStepNumber, stepNumber + 1);
+        return undefined;
+      }
+      state.nextSyntheticStepNumber = Math.max(state.nextSyntheticStepNumber + 1, stepNumber + 1);
+
+      const inputMessages = mapInputMessages(event.messages);
+      const finalize = (
+        resolvedMessages: Message[],
+        providerMessages: VercelAiSdkModelMessage[] | undefined,
+        transformed: boolean,
+      ): PrepareStepResult => {
+        if (transformed) {
+          if (!returnPreparedMessages) {
+            throw new Error(
+              'sigil preflight transformed_input.messages cannot be applied by experimental_onStepStart; use prepareStep-capable AI SDK instrumentation',
+            );
+          }
+          if (providerMessages === undefined) {
+            throw new Error(
+              'sigil preflight transformed_input.messages could not be converted to Vercel AI SDK model messages',
+            );
+          }
+        }
+
+        createStepState({
+          stepNumber,
+          stepStartEvent: event,
+          startedAt: new Date(),
+          inputMessages: this.captureInputs ? resolvedMessages : [],
+        });
+        if (returnPreparedMessages && providerMessages !== undefined) {
+          return { messages: providerMessages };
+        }
+        return undefined;
+      };
+
+      if (!this.preflightEnabled()) {
+        return finalize(inputMessages, undefined, false);
+      }
+
+      // Preflight evaluates against the actual prompt/messages even when
+      // captureInputs is disabled — the hook server only sees them in
+      // memory and never persists them.
+      return runPreflight(event, inputMessages).then(({ messages, providerMessages, transformed }) =>
+        finalize(messages, providerMessages, transformed),
+      );
     };
 
     const hooks: StreamTextHooks = {
+      prepareStep: (event: PrepareStepEvent) => handleStepStart(event, true),
       // Returns Promise<void> when preflight is enabled, void otherwise.
       // The Vercel AI SDK awaits both shapes; keeping the sync path avoids
       // microtask scheduling for callers that don't use hooks.
       experimental_onStepStart: (event) => {
-        noteStreamObservedStartAt(new Date());
-        const fallbackStep = state.nextSyntheticStepNumber;
-        const stepNumber = extractStepNumber(event, fallbackStep);
-        state.nextSyntheticStepNumber = Math.max(state.nextSyntheticStepNumber + 1, stepNumber + 1);
-        if (state.stepStates.has(stepNumber)) {
-          return;
+        const result = handleStepStart(event, false);
+        if (isPromiseLike(result)) {
+          return Promise.resolve(result).then(() => undefined);
         }
-
-        const inputMessages = mapInputMessages(event.messages);
-        const finalize = (resolvedMessages: Message[]): void => {
-          createStepState({
-            stepNumber,
-            stepStartEvent: event,
-            startedAt: new Date(),
-            inputMessages: this.captureInputs ? resolvedMessages : [],
-          });
-        };
-
-        if (!this.preflightEnabled()) {
-          finalize(inputMessages);
-          return;
-        }
-
-        // Preflight evaluates against the actual prompt/messages even when
-        // captureInputs is disabled — the hook server only sees them in
-        // memory and never persists them.
-        return runPreflight(event, inputMessages).then(finalize);
+        return undefined;
       },
       onStepFinish: (event) => {
         const response = mapResponseFromStepFinish(event);
@@ -951,4 +996,145 @@ function normalizeOptionalString(value: string | undefined): string | undefined 
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
+  return value !== null && typeof value === 'object' && typeof (value as { then?: unknown }).then === 'function';
+}
+
+type VercelAiSdkRole = VercelAiSdkModelMessage['role'];
+
+function toVercelAiSdkModelMessages(messages: Message[]): VercelAiSdkModelMessage[] | undefined {
+  const output: VercelAiSdkModelMessage[] = [];
+
+  for (const message of messages) {
+    const role = toVercelAiSdkRole(message.role);
+    if (role === undefined) {
+      return undefined;
+    }
+    const content = toVercelAiSdkMessageContent(role, message);
+    if (content === undefined) {
+      return undefined;
+    }
+    output.push({ role, content } as VercelAiSdkModelMessage);
+  }
+
+  return output.length > 0 ? output : undefined;
+}
+
+function toVercelAiSdkRole(role: string): VercelAiSdkRole | undefined {
+  const normalized = role.trim().toLowerCase();
+  if (normalized === 'system' || normalized === 'user' || normalized === 'assistant' || normalized === 'tool') {
+    return normalized;
+  }
+  return undefined;
+}
+
+function toVercelAiSdkMessageContent(role: VercelAiSdkRole, message: Message): unknown | undefined {
+  const textContent = normalizeOptionalString(message.content);
+  if (message.parts === undefined || message.parts.length === 0) {
+    return role === 'tool' ? undefined : textContent;
+  }
+
+  const parts: unknown[] = [];
+  for (const part of message.parts) {
+    if (part.type === 'text') {
+      if (role === 'tool') {
+        return undefined;
+      }
+      parts.push({ type: 'text', text: part.text });
+      continue;
+    }
+
+    if (part.type === 'thinking') {
+      if (role !== 'assistant') {
+        return undefined;
+      }
+      parts.push({ type: 'reasoning', text: part.thinking });
+      continue;
+    }
+
+    if (part.type === 'tool_call') {
+      if (role !== 'assistant') {
+        return undefined;
+      }
+      const toolCallId = normalizeOptionalString(part.toolCall.id);
+      if (toolCallId === undefined) {
+        return undefined;
+      }
+      parts.push({
+        type: 'tool-call',
+        toolCallId,
+        toolName: part.toolCall.name,
+        input: parseOptionalJSON(part.toolCall.inputJSON) ?? {},
+      });
+      continue;
+    }
+
+    if (part.type === 'tool_result') {
+      if (role !== 'assistant' && role !== 'tool') {
+        return undefined;
+      }
+      const toolCallId = normalizeOptionalString(part.toolResult.toolCallId);
+      const toolName = normalizeOptionalString(part.toolResult.name);
+      if (toolCallId === undefined || toolName === undefined) {
+        return undefined;
+      }
+      parts.push({
+        type: 'tool-result',
+        toolCallId,
+        toolName,
+        output: toVercelAiSdkToolOutput(part.toolResult.content, part.toolResult.contentJSON, part.toolResult.isError),
+      });
+    }
+  }
+
+  if (role === 'system') {
+    const text = parts
+      .map((part) => (isTextPart(part) ? part.text.trim() : ''))
+      .filter((text) => text.length > 0)
+      .join(' ')
+      .trim();
+    return text.length > 0 ? text : textContent;
+  }
+
+  return parts.length > 0 ? parts : textContent;
+}
+
+function toVercelAiSdkToolOutput(
+  content: string | undefined,
+  contentJSON: string | undefined,
+  isError: boolean | undefined,
+): unknown {
+  const parsedJSON = parseOptionalJSON(contentJSON);
+  if (parsedJSON !== undefined) {
+    return {
+      type: isError ? 'error-json' : 'json',
+      value: parsedJSON,
+    };
+  }
+
+  return {
+    type: isError ? 'error-text' : 'text',
+    value: content ?? '',
+  };
+}
+
+function parseOptionalJSON(value: string | undefined): unknown | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function isTextPart(value: unknown): value is { type: 'text'; text: string } {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const part = value as { type?: unknown; text?: unknown };
+  return part.type === 'text' && typeof part.text === 'string';
 }

--- a/js/src/frameworks/vercel-ai-sdk/index.ts
+++ b/js/src/frameworks/vercel-ai-sdk/index.ts
@@ -24,6 +24,8 @@ export type {
   CallOptions,
   ConversationResolution,
   GenerateTextHooks,
+  PrepareStepEvent,
+  PrepareStepResult,
   SigilVercelAiSdkOptions,
   StepFinishEvent,
   StepOutputMapping,
@@ -33,6 +35,7 @@ export type {
   StreamTextHooks,
   ToolCallFinishEvent,
   ToolCallStartEvent,
+  VercelAiSdkModelMessage,
 } from './types.js';
 
 export function createSigilVercelAiSdk(

--- a/js/src/frameworks/vercel-ai-sdk/types.ts
+++ b/js/src/frameworks/vercel-ai-sdk/types.ts
@@ -21,6 +21,25 @@ export interface StepStartEvent {
   output?: unknown;
 }
 
+export interface PrepareStepEvent extends StepStartEvent {
+  steps?: unknown;
+  experimental_context?: unknown;
+}
+
+export type VercelAiSdkModelMessage =
+  | { role: 'system'; content: any; providerOptions?: Record<string, unknown> }
+  | { role: 'user'; content: any; providerOptions?: Record<string, unknown> }
+  | { role: 'assistant'; content: any; providerOptions?: Record<string, unknown> }
+  | { role: 'tool'; content: any; providerOptions?: Record<string, unknown> };
+
+export type PrepareStepResult =
+  | {
+      messages?: VercelAiSdkModelMessage[];
+    }
+  | undefined;
+
+type PrepareStepHookResult = PrepareStepResult | PromiseLike<PrepareStepResult>;
+
 export interface StepFinishResponseRef {
   id?: unknown;
   modelId?: unknown;
@@ -122,6 +141,7 @@ export interface CallOptions {
 }
 
 export interface GenerateTextHooks {
+  prepareStep?: (event: PrepareStepEvent) => PrepareStepHookResult;
   experimental_onStepStart?: (event: StepStartEvent) => HookResult;
   onStepFinish?: (event: StepFinishEvent) => HookResult;
   experimental_onToolCallStart?: (event: ToolCallStartEvent) => HookResult;

--- a/js/test/frameworks.vercel-ai-sdk.hooks.test.mjs
+++ b/js/test/frameworks.vercel-ai-sdk.hooks.test.mjs
@@ -65,6 +65,152 @@ test('vercel ai sdk preflight allows step when hook returns allow', async () => 
   }
 });
 
+test('vercel ai sdk prepareStep preflight returns transformed messages for ai sdk v6', async () => {
+  let receivedBody;
+  const server = createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    receivedBody = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(
+      JSON.stringify({
+        action: 'allow',
+        evaluations: [],
+        transformed_input: {
+          messages: [{ role: 'user', content: 'redacted question' }],
+        },
+      }),
+    );
+  });
+  await listen(server);
+  const address = server.address();
+
+  const client = newClient({
+    apiEndpoint: `http://127.0.0.1:${address.port}`,
+    hooksEnabled: true,
+  });
+
+  try {
+    const sigil = createSigilVercelAiSdk(client, {
+      agentName: 'guarded-agent',
+      agentVersion: '2.0.0',
+    });
+    const hooks = sigil.generateTextHooks({ conversationId: 'conv-prepare-transform' });
+
+    const prepareResult = await hooks.prepareStep({
+      stepNumber: 0,
+      model: { provider: 'openai', modelId: 'gpt-4o' },
+      messages: [{ role: 'user', content: 'original secret question' }],
+      steps: [],
+      experimental_context: undefined,
+    });
+    hooks.onStepFinish({
+      stepNumber: 0,
+      finishReason: 'stop',
+      text: 'safe answer',
+      response: { id: 'resp-prepare-transform', modelId: 'gpt-4o' },
+    });
+
+    assert.equal(receivedBody.input.messages[0].content, 'original secret question');
+    assert.deepEqual(prepareResult, {
+      messages: [{ role: 'user', content: 'redacted question' }],
+    });
+  } finally {
+    await client.shutdown();
+    await close(server);
+  }
+});
+
+test('vercel ai sdk prepareStep preflight rejects unsupported transformed message shapes', async () => {
+  const server = createServer(async (request, response) => {
+    for await (const _ of request) {
+      // drain
+    }
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(
+      JSON.stringify({
+        action: 'allow',
+        evaluations: [],
+        transformed_input: {
+          messages: [{ role: 'tool', content: 'redacted tool result' }],
+        },
+      }),
+    );
+  });
+  await listen(server);
+  const address = server.address();
+
+  const client = newClient({
+    apiEndpoint: `http://127.0.0.1:${address.port}`,
+    hooksEnabled: true,
+  });
+
+  try {
+    const sigil = createSigilVercelAiSdk(client, { agentName: 'guarded-agent' });
+    const hooks = sigil.generateTextHooks({ conversationId: 'conv-prepare-unsupported-transform' });
+
+    await assert.rejects(
+      () =>
+        hooks.prepareStep({
+          stepNumber: 0,
+          model: { provider: 'openai', modelId: 'gpt-4o' },
+          messages: [{ role: 'user', content: 'original secret question' }],
+          steps: [],
+          experimental_context: undefined,
+        }),
+      /could not be converted to Vercel AI SDK model messages/,
+    );
+  } finally {
+    await client.shutdown();
+    await close(server);
+  }
+});
+
+test('vercel ai sdk legacy step-start preflight rejects transformed messages that cannot be applied', async () => {
+  const server = createServer(async (request, response) => {
+    for await (const _ of request) {
+      // drain
+    }
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(
+      JSON.stringify({
+        action: 'allow',
+        evaluations: [],
+        transformed_input: {
+          messages: [{ role: 'user', content: 'redacted question' }],
+        },
+      }),
+    );
+  });
+  await listen(server);
+  const address = server.address();
+
+  const client = newClient({
+    apiEndpoint: `http://127.0.0.1:${address.port}`,
+    hooksEnabled: true,
+  });
+
+  try {
+    const sigil = createSigilVercelAiSdk(client, { agentName: 'guarded-agent' });
+    const hooks = sigil.generateTextHooks({ conversationId: 'conv-legacy-transform' });
+
+    await assert.rejects(
+      () =>
+        hooks.experimental_onStepStart({
+          stepNumber: 0,
+          model: { provider: 'openai', modelId: 'gpt-4o' },
+          messages: [{ role: 'user', content: 'original secret question' }],
+        }),
+      /cannot be applied by experimental_onStepStart/,
+    );
+  } finally {
+    await client.shutdown();
+    await close(server);
+  }
+});
+
 test('vercel ai sdk preflight throws HookDeniedError on deny', async () => {
   const server = createServer(async (request, response) => {
     for await (const _ of request) {

--- a/js/test/frameworks.vercel-ai-sdk.test.mjs
+++ b/js/test/frameworks.vercel-ai-sdk.test.mjs
@@ -75,6 +75,71 @@ test('vercel ai sdk generateText hooks record single-step success', async () => 
   assert.equal(generation.metadata['sigil.framework.reasoning_text'], 'reasoning detail');
 });
 
+test('vercel ai sdk prepareStep records input messages for ai sdk v6', async () => {
+  const { generations } = await captureSession(async (client) => {
+    const sigil = createSigilVercelAiSdk(client);
+    const hooks = sigil.generateTextHooks({ conversationId: 'conv-v6-prepare-step' });
+
+    const prepareResult = hooks.prepareStep?.({
+      stepNumber: 0,
+      model: { provider: 'openai', modelId: 'gpt-5' },
+      messages: [{ role: 'user', content: 'hello from v6' }],
+      steps: [],
+      experimental_context: undefined,
+    });
+    assert.equal(prepareResult, undefined);
+
+    hooks.onStepFinish?.({
+      stepNumber: 0,
+      stepType: 'initial',
+      text: 'hello back',
+      finishReason: 'stop',
+      response: { id: 'resp-v6-prepare-step', modelId: 'gpt-5' },
+    });
+  });
+
+  assert.equal(generations.length, 1);
+  assert.equal(generations[0].conversationId, 'conv-v6-prepare-step');
+  assert.equal(generations[0].input[0].content, 'hello from v6');
+  assert.equal(generations[0].output[0].content, 'hello back');
+});
+
+test('vercel ai sdk streamText prepareStep records input messages for ai sdk v6', async () => {
+  const { generations } = await captureSession(async (client) => {
+    const sigil = createSigilVercelAiSdk(client);
+    const hooks = sigil.streamTextHooks({ conversationId: 'conv-v6-stream-prepare-step' });
+
+    const prepareResult = hooks.prepareStep?.({
+      stepNumber: 0,
+      model: { provider: 'anthropic', modelId: 'claude-sonnet-4-5' },
+      messages: [{ role: 'user', content: 'stream from v6' }],
+      steps: [],
+      experimental_context: undefined,
+    });
+    assert.equal(prepareResult, undefined);
+
+    hooks.onChunk?.({
+      stepNumber: 0,
+      chunk: {
+        type: 'text-delta',
+        text: 'hel',
+      },
+    });
+    hooks.onStepFinish?.({
+      stepNumber: 0,
+      stepType: 'initial',
+      text: 'hello stream',
+      finishReason: 'stop',
+      response: { id: 'resp-v6-stream-prepare-step', modelId: 'claude-sonnet-4-5' },
+    });
+  });
+
+  assert.equal(generations.length, 1);
+  assert.equal(generations[0].mode, 'STREAM');
+  assert.equal(generations[0].input[0].content, 'stream from v6');
+  assert.equal(generations[0].output[0].content, 'hello stream');
+});
+
 test('vercel ai sdk generateText hooks record single-step error', async () => {
   const { generations } = await captureSession(async (client) => {
     const sigil = createSigilVercelAiSdk(client);


### PR DESCRIPTION
## Summary
- add Vercel AI SDK v6 `prepareStep` hook support for input capture
- keep `experimental_onStepStart` compatibility for older AI SDK versions
- update docs and add v6 regression tests for `generateText`, `streamText`, and preflight transforms

## Tests
- `pnpm --filter @grafana/sigil-sdk-js run test:ci`
- `pnpm --filter @grafana/sigil-sdk-js run typecheck`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/sven/.codex/worktrees/ab25/sigil-sdk/mise.toml mise x -- pnpm --filter @grafana/sigil-sdk-js run lint`