### PR TITLE
fix(sdk-js): capture Vercel AI SDK step inputs

### DIFF
--- a/js/docs/frameworks/vercel-ai-sdk.md
+++ b/js/docs/frameworks/vercel-ai-sdk.md
@@ -1,12 +1,13 @@
 # Vercel AI SDK Hooks (`@grafana/sigil-sdk-js/vercel-ai-sdk`)
 
-Use `createSigilVercelAiSdk(...)` to instrument Vercel AI SDK v5 calls with Sigil generation export, spans, metrics, tool execution spans, and streaming TTFT.
+Use `createSigilVercelAiSdk(...)` to instrument Vercel AI SDK v5 and v6 calls with Sigil generation export, spans, metrics, tool execution spans, and streaming TTFT.
 
 Supported AI SDK line:
 
-- `ai` v5 (`generateText`, `streamText`)
-- Baseline generation export uses `onStepFinish` (and `onError` for streams). This path is v5-compatible and records tool executions from step `toolResults`.
-- When `experimental_onStepStart`, `experimental_onToolCallStart`, and `experimental_onToolCallFinish` are available (v6+), Sigil also captures richer per-step input messages and tool timing correlation.
+- `generateText` and `streamText` on `ai` v5 and v6
+- `ToolLoopAgent` on `ai` v6
+- Baseline input capture uses `prepareStep`; generation export uses `onStepFinish` (and `onError` for streams). This path is v5/v6-compatible and records tool executions from step `toolResults`.
+- When `experimental_onStepStart`, `experimental_onToolCallStart`, and `experimental_onToolCallFinish` are available (v6.0.97+ across all three supported surfaces), Sigil also captures output schemas and richer tool timing correlation.
 - Experimental callbacks can change in patch releases. Keep `ai` pinned to a tested minor line (`v5.x` or `v6.x`) in production.
 
 ## Install
@@ -118,7 +119,7 @@ const result = await generateText({
 Each model step emits one generation with:
 
 - `metadata["sigil.framework.step_type"]` (`initial`, `continue`, `tool-result`)
-- per-step input captured when `experimental_onStepStart` is available (including prior tool result messages)
+- per-step input captured through `prepareStep` (including prior tool result messages)
 
 ## Streaming (`streamText`) and TTFT
 

--- a/js/src/frameworks/vercel-ai-sdk/hooks.ts
+++ b/js/src/frameworks/vercel-ai-sdk/hooks.ts
@@ -39,6 +39,7 @@ interface StepState {
   recorder?: GenerationRecorder;
   startedAt: Date;
   inputMessages: Message[];
+  observedInputMessages: Message[];
   conversation: ConversationResolution;
   fallbackSeed: string;
   firstTokenRecorded: boolean;
@@ -216,7 +217,8 @@ export class SigilVercelAiSdkInstrumentation {
               })
             : undefined,
         startedAt: params.startedAt,
-        inputMessages: params.inputMessages,
+        inputMessages: this.captureInputs ? params.inputMessages : [],
+        observedInputMessages: params.inputMessages,
         conversation,
         fallbackSeed: `${callID}:step-${params.stepNumber}`,
         firstTokenRecorded: false,
@@ -259,18 +261,19 @@ export class SigilVercelAiSdkInstrumentation {
       noteStreamObservedStartAt(observedAt);
       const stepNumber = extractStepNumber(event, state.nextSyntheticStepNumber);
       state.nextSyntheticStepNumber = Math.max(state.nextSyntheticStepNumber, stepNumber + 1);
-      const inputMessages = mapInputMessages(event.messages);
+      const inputMessages = event.messages !== undefined ? mapInputMessages(event.messages) : undefined;
       const existingState = state.stepStates.get(stepNumber);
       if (existingState === undefined) {
+        const observedInputMessages = inputMessages ?? [];
         return {
           stepNumber,
           stepState: createStepState({
             stepNumber,
             stepStartEvent: event,
             startedAt: observedAt,
-            inputMessages: this.captureInputs ? inputMessages : [],
+            inputMessages: observedInputMessages,
           }),
-          inputMessages,
+          inputMessages: observedInputMessages,
         };
       }
 
@@ -279,7 +282,8 @@ export class SigilVercelAiSdkInstrumentation {
         ...existingState.stepStartEvent,
         ...event,
       };
-      if (event.messages !== undefined) {
+      if (inputMessages !== undefined) {
+        existingState.observedInputMessages = inputMessages;
         existingState.inputMessages = this.captureInputs ? inputMessages : [];
       }
       if (event.output !== undefined && event.output !== previousOutput) {
@@ -288,7 +292,11 @@ export class SigilVercelAiSdkInstrumentation {
         existingState.outputSchemaResolved = false;
         kickOffOutputSchemaExtraction(existingState);
       }
-      return { stepNumber, stepState: existingState, inputMessages };
+      return {
+        stepNumber,
+        stepState: existingState,
+        inputMessages: inputMessages ?? existingState.observedInputMessages,
+      };
     };
     const resolveOrCreateStepStateForFinish = (params: {
       eventStepNumber: unknown;
@@ -576,6 +584,7 @@ export class SigilVercelAiSdkInstrumentation {
       experimental_onStepStart: (event) => {
         const { stepState, inputMessages } = captureStepStart(event, new Date());
         const finalize = (resolvedMessages: Message[]): void => {
+          stepState.observedInputMessages = resolvedMessages;
           stepState.inputMessages = this.captureInputs ? resolvedMessages : [];
         };
 

--- a/js/src/frameworks/vercel-ai-sdk/hooks.ts
+++ b/js/src/frameworks/vercel-ai-sdk/hooks.ts
@@ -252,6 +252,44 @@ export class SigilVercelAiSdkInstrumentation {
       );
       stepState.outputSchemaPromise = promise;
     };
+    const captureStepStart = (
+      event: StepStartEvent,
+      observedAt: Date,
+    ): { stepNumber: number; stepState: StepState; inputMessages: Message[] } => {
+      noteStreamObservedStartAt(observedAt);
+      const stepNumber = extractStepNumber(event, state.nextSyntheticStepNumber);
+      state.nextSyntheticStepNumber = Math.max(state.nextSyntheticStepNumber, stepNumber + 1);
+      const inputMessages = mapInputMessages(event.messages);
+      const existingState = state.stepStates.get(stepNumber);
+      if (existingState === undefined) {
+        return {
+          stepNumber,
+          stepState: createStepState({
+            stepNumber,
+            stepStartEvent: event,
+            startedAt: observedAt,
+            inputMessages: this.captureInputs ? inputMessages : [],
+          }),
+          inputMessages,
+        };
+      }
+
+      const previousOutput = existingState.stepStartEvent.output;
+      existingState.stepStartEvent = {
+        ...existingState.stepStartEvent,
+        ...event,
+      };
+      if (event.messages !== undefined) {
+        existingState.inputMessages = this.captureInputs ? inputMessages : [];
+      }
+      if (event.output !== undefined && event.output !== previousOutput) {
+        existingState.outputSchemaPromise = undefined;
+        existingState.outputSchemaTool = undefined;
+        existingState.outputSchemaResolved = false;
+        kickOffOutputSchemaExtraction(existingState);
+      }
+      return { stepNumber, stepState: existingState, inputMessages };
+    };
     const resolveOrCreateStepStateForFinish = (params: {
       eventStepNumber: unknown;
       responseModel: string | undefined;
@@ -526,26 +564,19 @@ export class SigilVercelAiSdkInstrumentation {
     };
 
     const hooks: StreamTextHooks = {
+      // prepareStep is available throughout AI SDK v5 and v6. Returning an
+      // empty result observes the step without changing the model request.
+      prepareStep: (event) => {
+        captureStepStart(event, new Date());
+        return {};
+      },
       // Returns Promise<void> when preflight is enabled, void otherwise.
       // The Vercel AI SDK awaits both shapes; keeping the sync path avoids
       // microtask scheduling for callers that don't use hooks.
       experimental_onStepStart: (event) => {
-        noteStreamObservedStartAt(new Date());
-        const fallbackStep = state.nextSyntheticStepNumber;
-        const stepNumber = extractStepNumber(event, fallbackStep);
-        state.nextSyntheticStepNumber = Math.max(state.nextSyntheticStepNumber + 1, stepNumber + 1);
-        if (state.stepStates.has(stepNumber)) {
-          return;
-        }
-
-        const inputMessages = mapInputMessages(event.messages);
+        const { stepState, inputMessages } = captureStepStart(event, new Date());
         const finalize = (resolvedMessages: Message[]): void => {
-          createStepState({
-            stepNumber,
-            stepStartEvent: event,
-            startedAt: new Date(),
-            inputMessages: this.captureInputs ? resolvedMessages : [],
-          });
+          stepState.inputMessages = this.captureInputs ? resolvedMessages : [];
         };
 
         if (!this.preflightEnabled()) {

--- a/js/src/frameworks/vercel-ai-sdk/types.ts
+++ b/js/src/frameworks/vercel-ai-sdk/types.ts
@@ -12,7 +12,7 @@ export interface StepStartModelRef {
 export interface StepStartEvent {
   stepNumber?: unknown;
   messages?: unknown;
-  model?: StepStartModelRef;
+  model?: StepStartModelRef | string;
   /**
    * Output configuration the AI SDK passes through (e.g. `Output.object(...)`).
    * Not declared on the public AI SDK type — surfaced at runtime on the step-start
@@ -122,6 +122,11 @@ export interface CallOptions {
 }
 
 export interface GenerateTextHooks {
+  /**
+   * Stable AI SDK v5/v6 callback invoked before every model step.
+   * Sigil observes the step without overriding any per-step settings.
+   */
+  prepareStep?: (event: StepStartEvent) => Record<string, never>;
   experimental_onStepStart?: (event: StepStartEvent) => HookResult;
   onStepFinish?: (event: StepFinishEvent) => HookResult;
   experimental_onToolCallStart?: (event: ToolCallStartEvent) => HookResult;

--- a/js/test/frameworks.vercel-ai-sdk.hooks.test.mjs
+++ b/js/test/frameworks.vercel-ai-sdk.hooks.test.mjs
@@ -65,6 +65,47 @@ test('vercel ai sdk preflight allows step when hook returns allow', async () => 
   }
 });
 
+test('vercel ai sdk preflight retains prepareStep input when experimental step start omits messages', async () => {
+  let receivedBody;
+  const server = createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    receivedBody = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ action: 'allow', evaluations: [] }));
+  });
+  await listen(server);
+  const address = server.address();
+
+  const client = newClient({
+    apiEndpoint: `http://127.0.0.1:${address.port}`,
+    hooksEnabled: true,
+  });
+
+  try {
+    const sigil = createSigilVercelAiSdk(client, { agentName: 'guarded-agent' });
+    const hooks = sigil.generateTextHooks({ conversationId: 'conv-prepare-step' });
+
+    hooks.prepareStep({
+      stepNumber: 0,
+      model: { provider: 'openai', modelId: 'gpt-4o' },
+      messages: [{ role: 'user', content: 'keep this prompt' }],
+    });
+    await hooks.experimental_onStepStart({
+      stepNumber: 0,
+      model: { provider: 'openai', modelId: 'gpt-4o' },
+    });
+
+    assert.equal(receivedBody.input.messages[0].role, 'user');
+    assert.equal(receivedBody.input.messages[0].content, 'keep this prompt');
+  } finally {
+    await client.shutdown();
+    await close(server);
+  }
+});
+
 test('vercel ai sdk preflight throws HookDeniedError on deny', async () => {
   const server = createServer(async (request, response) => {
     for await (const _ of request) {

--- a/js/test/frameworks.vercel-ai-sdk.test.mjs
+++ b/js/test/frameworks.vercel-ai-sdk.test.mjs
@@ -87,6 +87,11 @@ test('vercel ai sdk captures step input through the v5 and early-v6 prepareStep 
     });
     assert.deepEqual(prepareResult, {});
 
+    hooks.experimental_onStepStart?.({
+      stepNumber: 0,
+      model: { provider: 'openai', modelId: 'gpt-5' },
+    });
+
     await hooks.onStepFinish?.({
       stepNumber: 0,
       finishReason: 'stop',

--- a/js/test/frameworks.vercel-ai-sdk.test.mjs
+++ b/js/test/frameworks.vercel-ai-sdk.test.mjs
@@ -75,6 +75,30 @@ test('vercel ai sdk generateText hooks record single-step success', async () => 
   assert.equal(generation.metadata['sigil.framework.reasoning_text'], 'reasoning detail');
 });
 
+test('vercel ai sdk captures step input through the v5 and early-v6 prepareStep lifecycle', async () => {
+  const generation = await captureSingleGeneration(async (client) => {
+    const sigil = createSigilVercelAiSdk(client, { agentName: 'prepare-step-agent' });
+    const hooks = sigil.generateTextHooks({ conversationId: 'conv-prepare-step' });
+
+    const prepareResult = hooks.prepareStep?.({
+      stepNumber: 0,
+      model: { provider: 'openai', modelId: 'gpt-5' },
+      messages: [{ role: 'user', content: 'captured before the model call' }],
+    });
+    assert.deepEqual(prepareResult, {});
+
+    await hooks.onStepFinish?.({
+      stepNumber: 0,
+      finishReason: 'stop',
+      text: 'captured after the model call',
+      response: { id: 'resp-prepare-step', modelId: 'gpt-5' },
+    });
+  });
+
+  assert.equal(generation.input[0].content, 'captured before the model call');
+  assert.equal(generation.output[0].content, 'captured after the model call');
+});
+
 test('vercel ai sdk generateText hooks record single-step error', async () => {
   const { generations } = await captureSession(async (client) => {
     const sigil = createSigilVercelAiSdk(client);
@@ -394,6 +418,11 @@ test('vercel ai sdk streamText hooks capture TTFT once and record streaming resu
       const sigil = createSigilVercelAiSdk(client);
       const hooks = sigil.streamTextHooks({ conversationId: 'conv-stream' });
 
+      hooks.prepareStep?.({
+        stepNumber: 0,
+        model: { modelId: 'claude-sonnet-4-5' },
+        messages: [{ role: 'user', content: 'stream hello' }],
+      });
       hooks.experimental_onStepStart?.({
         stepNumber: 0,
         model: { modelId: 'claude-sonnet-4-5' },
@@ -1146,6 +1175,11 @@ test('vercel ai sdk captures Output.object schema into Generation.tools', async 
   const { generations } = await captureSession(async (client) => {
     const sigil = createSigilVercelAiSdk(client, { agentName: 'structured-agent' });
     const hooks = sigil.generateTextHooks({ conversationId: 'conv-output-schema' });
+    hooks.prepareStep?.({
+      stepNumber: 0,
+      model: { provider: 'openai', modelId: 'gpt-5' },
+      messages: [{ role: 'user', content: 'generate a question' }],
+    });
     hooks.experimental_onStepStart?.({
       stepNumber: 0,
       model: { provider: 'openai', modelId: 'gpt-5' },
@@ -1177,6 +1211,7 @@ test('vercel ai sdk captures Output.object schema into Generation.tools', async 
   assert.equal(tool.type, 'output_schema');
   assert.equal(tool.description, 'Question with associated skills');
   assert.deepEqual(JSON.parse(tool.inputSchemaJSON), schema);
+  assert.equal(generation.input[0].content, 'generate a question');
 });
 
 test('vercel ai sdk omits tools entry when no output schema is configured', async () => {


### PR DESCRIPTION
## What changed

- capture per-step input through the stable Vercel AI SDK `prepareStep` callback
- reuse the same step state when newer experimental callbacks also run
- preserve output-schema and tool lifecycle enrichment on newer AI SDK v6 releases
- document support for AI SDK v5 and v6

## Root cause

The adapter relied on `experimental_onStepStart` to capture input messages. That callback is unavailable in AI SDK v5 and early v6 releases, including `ai@6.0.48`.

As a result, `onStepFinish` created synthetic step state without input messages, producing generations with an empty input array.

## Impact

Users of AI SDK v5 and early v6 now get input capture for `generateText`, `streamText`, and the v6 `ToolLoopAgent` without needing to upgrade AI SDK.

`prepareStep` returns an empty result, so it observes each step without modifying the model request. Newer experimental callbacks enrich the existing state instead of creating duplicates.

## Testing

- `pnpm --filter @grafana/sigil-sdk-js run typecheck`
- `pnpm --filter @grafana/sigil-sdk-js run build`
- `pnpm --filter @grafana/sigil-sdk-js run test` (349 passed)
- `biome check .`
- packed SDK runtime verification with `ai@5.0.213` for `generateText` and `streamText`
- packed SDK runtime verification with affected `ai@6.0.48` for `generateText`, `streamText`, and `ToolLoopAgent`
- TypeScript spread compatibility verified against AI SDK v5 and v6.0.48

Fixes #387
