### PR TITLE
fix(go): clone media message parts

### DIFF
--- a/go/sigil/generation.go
+++ b/go/sigil/generation.go
@@ -203,6 +203,11 @@ func cloneParts(in []Part) []Part {
 			result.ContentJSON = append([]byte(nil), result.ContentJSON...)
 			out[i].ToolResult = &result
 		}
+
+		if in[i].Media != nil {
+			media := *in[i].Media
+			out[i].Media = &media
+		}
 	}
 
 	return out

--- a/go/sigil/generation_test.go
+++ b/go/sigil/generation_test.go
@@ -1,0 +1,35 @@
+package sigil
+
+import "testing"
+
+func TestCloneGenerationClonesMediaParts(t *testing.T) {
+	original := Generation{
+		Input: []Message{
+			{
+				Role: RoleUser,
+				Parts: []Part{
+					MediaPart(Media{
+						Kind:     "image",
+						URL:      "data:image/png;base64,abc123",
+						MIMEType: "image/png",
+						Name:     "weather-map.png",
+					}),
+				},
+			},
+		},
+	}
+
+	cloned := cloneGeneration(original)
+
+	if cloned.Input[0].Parts[0].Media == nil {
+		t.Fatal("expected cloned media part to keep media payload")
+	}
+	if got := cloned.Input[0].Parts[0].Media.URL; got != "data:image/png;base64,abc123" {
+		t.Fatalf("unexpected cloned media URL: %q", got)
+	}
+
+	original.Input[0].Parts[0].Media.URL = "changed"
+	if got := cloned.Input[0].Parts[0].Media.URL; got != "data:image/png;base64,abc123" {
+		t.Fatalf("cloned media changed after mutating original: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- deep-copy `Media` payloads in Go SDK generation part cloning
- add a regression test for media part clone preservation

## Why
`GenerationRecorder.End` clones mapped generations before validation and export. Media parts added in `v0.14.0` were not copied by `cloneParts`, so image-bearing generations could fail validation or lose media before ingest.

## Test plan
- `cd go && go test ./...`
