### PR TITLE
feat(plugins): move CLI config to ~/.config/agento11y/config.env

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -62,7 +62,7 @@ Install the `agento11y` binary (renamed from `sigil`; the old name still works b
 
 The script installs to `~/.local/bin`; `go install` puts the binary in `go env GOPATH`/bin (or `GOBIN`). Make sure that directory is on your `PATH`.
 
-Then launch your agent with `agento11y <agent>`, where `<agent>` is `claude`, `codex`, `copilot`, `opencode`, or `pi`. On first run it installs the plugin, prompts for credentials, writes `~/.config/sigil/config.env`, and launches the agent.
+Then launch your agent with `agento11y <agent>`, where `<agent>` is `claude`, `codex`, `copilot`, `opencode`, or `pi`. On first run it installs the plugin, prompts for credentials, writes `~/.config/agento11y/config.env`, and launches the agent.
 
 Cursor has no launcher (it is a GUI app). After installing the binary, wire its hooks once with `agento11y cursor install` (it merges into `~/.cursor/hooks.json` and prompts for credentials on first run); `agento11y cursor uninstall` removes them. See [`plugins/cursor/`](https://github.com/grafana/sigil-sdk/tree/main/plugins/cursor) for details.
 
@@ -79,7 +79,7 @@ To re-enter credentials later, run `agento11y login`.
 
 ## Content capture
 
-Coding-agent plugins default to `metadata_only`: only model, tokens, tool names, timing, and cost are sent. Prompts, responses, and tool I/O stay on the local machine. To opt into sending content, set `AGENTO11Y_CONTENT_CAPTURE_MODE` in `~/.config/sigil/config.env`.
+Coding-agent plugins default to `metadata_only`: only model, tokens, tool names, timing, and cost are sent. Prompts, responses, and tool I/O stay on the local machine. To opt into sending content, set `AGENTO11Y_CONTENT_CAPTURE_MODE` in `~/.config/agento11y/config.env`.
 
 Accepted values depend on the plugin surface:
 
@@ -91,7 +91,7 @@ Unknown values fall back to `metadata_only` with a warning. Secret redaction is 
 
 1. Run the agent normally for one turn (any prompt).
 2. Open Grafana Cloud → AI Observability → Conversations. A new conversation should appear within a few seconds.
-3. If it doesn't, check the launcher's stderr for `agento11y:` warnings and confirm `~/.config/sigil/config.env` is readable.
+3. If it doesn't, check the launcher's stderr for `agento11y:` warnings and confirm `~/.config/agento11y/config.env` is readable. If you only have the old `~/.config/sigil/config.env`, that file is used instead.
 
 ---
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -30,7 +30,7 @@ The command was renamed from `sigil`; the old name still works but will be remov
 
 ## Launch your agent
 
-Launch with `agento11y <agent>`, where `<agent>` is `claude`, `codex`, `copilot`, `opencode`, `pi`, or `vibe`. On first run it installs the agent plugin or extension, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches the agent.
+Launch with `agento11y <agent>`, where `<agent>` is `claude`, `codex`, `copilot`, `opencode`, `pi`, or `vibe`. On first run it installs the agent plugin or extension, prompts for missing Grafana Cloud credentials, writes `~/.config/agento11y/config.env`, and then launches the agent.
 
 Cursor has no launcher; see [`cursor/README.md`](cursor/README.md) for setup.
 
@@ -46,4 +46,4 @@ Cursor has no launcher; see [`cursor/README.md`](cursor/README.md) for setup.
 | [Pi](https://github.com/earendil-works/pi) | [`pi/`](pi/) | Available |
 | [Vibe](https://github.com/mistralai/vibe) | [`vibe/`](vibe/) | Experimental |
 
-Plugins backed by the `agento11y` launcher share one config file at `~/.config/sigil/config.env`. The launcher creates or updates it on first run; `agento11y login` re-runs the same prompt later. Cursor has no launcher, so register its plugin in-app and run `agento11y login` once for the shared config.
+Plugins backed by the `agento11y` launcher share one config file at `~/.config/agento11y/config.env`. If you only have the old `~/.config/sigil/config.env`, that file is read and updated instead. The launcher creates or updates it on first run; `agento11y login` re-runs the same prompt later. Cursor has no launcher, so register its plugin in-app and run `agento11y login` once for the shared config.

--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -40,7 +40,7 @@ Verify the install with `agento11y --version`.
 
 ## Configure
 
-All hosts read the same config file at `~/.config/sigil/config.env`. The first run of `agento11y claude`, `agento11y opencode`, or `agento11y pi` prompts for your endpoint, tenant ID, token, and OTLP endpoint and writes them there; run `agento11y login` to re-enter them later. After the connection details, `agento11y login` shows an optional preferences step for content capture mode, session tags, and guards — leave it at the defaults to keep the current behaviour. Cursor has no launcher, so wire it once with `agento11y cursor install` (which also prompts on first run) and remove it with `agento11y cursor uninstall`.
+All hosts read the same config file at `~/.config/agento11y/config.env`. If you only have the old `~/.config/sigil/config.env`, that file is read and updated instead. The first run of `agento11y claude`, `agento11y opencode`, or `agento11y pi` prompts for your endpoint, tenant ID, token, and OTLP endpoint and writes them there; run `agento11y login` to re-enter them later. After the connection details, `agento11y login` shows an optional preferences step for content capture mode, session tags, and guards — leave it at the defaults to keep the current behaviour. Cursor has no launcher, so wire it once with `agento11y cursor install` (which also prompts on first run) and remove it with `agento11y cursor uninstall`.
 
 To preconfigure without the prompt, create the file:
 
@@ -76,7 +76,7 @@ The same flag works for every launcher (`claude`, `codex`, `copilot`, `opencode`
 
 ## Content capture
 
-The shared `agento11y` binary defaults to `metadata_only`: only model, tokens, tool names, timing, and cost ship to Grafana AI Observability. Prompts, responses, and tool I/O stay on the local machine. To opt into sending content, set `AGENTO11Y_CONTENT_CAPTURE_MODE` in `~/.config/sigil/config.env`. The shared binary parser accepts every mode the SDKs support:
+The shared `agento11y` binary defaults to `metadata_only`: only model, tokens, tool names, timing, and cost ship to Grafana AI Observability. Prompts, responses, and tool I/O stay on the local machine. To opt into sending content, set `AGENTO11Y_CONTENT_CAPTURE_MODE` in `~/.config/agento11y/config.env`. The shared binary parser accepts every mode the SDKs support:
 
 ```dotenv
 # valid values: full | no_tool_content | metadata_only | full_with_metadata_spans
@@ -118,4 +118,4 @@ For support, capture the machine-readable report — it never includes the auth 
 agento11y doctor --json
 ```
 
-If you need lower-level detail, hooks always exit 0, so problems only show up in the debug log. Set `AGENTO11Y_DEBUG=true` in `~/.config/sigil/config.env` and tail `~/.local/state/sigil/logs/sigil.log`.
+If you need lower-level detail, hooks always exit 0, so problems only show up in the debug log. Set `AGENTO11Y_DEBUG=true` in `~/.config/agento11y/config.env` and tail `~/.local/state/sigil/logs/sigil.log`.

--- a/plugins/agento11y/internal/agents/codex/config/config.go
+++ b/plugins/agento11y/internal/agents/codex/config/config.go
@@ -25,13 +25,13 @@ func HasCredentials() bool {
 
 // FilePath returns the dotenv config path for the consolidated binary.
 func FilePath() string {
-	return dotenv.FilePath("sigil")
+	return dotenv.FilePath()
 }
 
 // ApplyEnv loads the shared sigil dotenv config and writes keys whose OS
 // env value is empty.
 func ApplyEnv(logger *log.Logger) map[string]string {
-	return dotenv.ApplyEnv("sigil", logger)
+	return dotenv.ApplyEnv(logger)
 }
 
 // LoadDotenv parses a dotenv file at path. Exported for tests that need

--- a/plugins/agento11y/internal/agents/codex/config/config_test.go
+++ b/plugins/agento11y/internal/agents/codex/config/config_test.go
@@ -9,7 +9,7 @@ import (
 // TestLoad_Guards pins the env-var contract and defaults for codex against
 // the shared envconfig resolver, mirroring the copilot config test so the
 // two agents stay byte-identical on the guard knobs that ship in
-// ~/.config/sigil/config.env.
+// ~/.config/agento11y/config.env.
 func TestLoad_Guards(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/plugins/agento11y/internal/agents/copilot/config/config.go
+++ b/plugins/agento11y/internal/agents/copilot/config/config.go
@@ -25,7 +25,7 @@ func HasCredentials() bool {
 }
 
 // Load returns the copilot-local subset of config from OS env. Call
-// dotenv.ApplyEnv("sigil", logger) first so dotenv-only values are
+// dotenv.ApplyEnv(logger) first so dotenv-only values are
 // reflected in the OS env.
 func Load(logger *log.Logger) Config {
 	return Config{

--- a/plugins/agento11y/internal/agents/cursor/config/config.go
+++ b/plugins/agento11y/internal/agents/cursor/config/config.go
@@ -34,13 +34,13 @@ func HasCredentials() bool {
 
 // FilePath is the dotenv config path for the consolidated binary.
 func FilePath() string {
-	return dotenv.FilePath("sigil")
+	return dotenv.FilePath()
 }
 
 // ApplyEnv loads the shared sigil dotenv config and writes keys whose OS
 // env value is empty.
 func ApplyEnv(logger *log.Logger) map[string]string {
-	return dotenv.ApplyEnv("sigil", logger)
+	return dotenv.ApplyEnv(logger)
 }
 
 // LoadDotenv parses a dotenv file at path. Exported for tests that need

--- a/plugins/agento11y/internal/doctor/doctor.go
+++ b/plugins/agento11y/internal/doctor/doctor.go
@@ -288,7 +288,7 @@ func parseFlags(args []string, stderr io.Writer) (Options, error) {
 // Collect builds the report. It reads config.env and the env snapshot but
 // performs no mutations. Network probes run only when opts.Probe is set.
 func Collect(ctx context.Context, opts Options, p Params) *Report {
-	fileEnv := dotenv.LoadDotenv(dotenv.FilePath("sigil"), nil)
+	fileEnv := dotenv.LoadDotenv(dotenv.FilePath(), nil)
 	osEnv := p.OSEnv
 	if osEnv == nil {
 		osEnv = map[string]string{}
@@ -452,7 +452,7 @@ func headersHaveAuthorization(raw string) bool {
 }
 
 func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
-	path := dotenv.FilePath("sigil")
+	path := dotenv.FilePath()
 	sec := ConfigSection{Path: path, Health: HealthOK}
 	if _, err := os.Stat(path); err == nil {
 		sec.Exists = true

--- a/plugins/agento11y/internal/doctor/doctor_test.go
+++ b/plugins/agento11y/internal/doctor/doctor_test.go
@@ -41,7 +41,12 @@ func stubSeams(t *testing.T) {
 
 func writeConfig(t *testing.T, content string) {
 	t.Helper()
-	path := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "sigil", "config.env")
+	writeConfigApp(t, "agento11y", content)
+}
+
+func writeConfigApp(t *testing.T, app, content string) {
+	t.Helper()
+	path := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), app, "config.env")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -442,10 +447,45 @@ func TestDisallowedKeys(t *testing.T) {
 		"RANDOM_KEY=dup", // duplicate reported once
 	}, "\n"))
 
-	got := disallowedKeys(filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "sigil", "config.env"))
+	got := disallowedKeys(filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "agento11y", "config.env"))
 	want := []string{"RANDOM_KEY", "AWS_SECRET"}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("disallowedKeys = %v, want %v", got, want)
+	}
+}
+
+// TestCollectConfig_PathResolution pins the reported config path to the
+// dotenv resolver: the new agento11y path wins when present, the legacy
+// sigil path is still reported while only it exists, and a missing config
+// reports the new default with Exists=false.
+func TestCollectConfig_PathResolution(t *testing.T) {
+	tests := []struct {
+		name       string
+		apps       []string
+		wantApp    string
+		wantExists bool
+	}{
+		{name: "no config reports new default", wantApp: "agento11y", wantExists: false},
+		{name: "new only", apps: []string{"agento11y"}, wantApp: "agento11y", wantExists: true},
+		{name: "legacy only", apps: []string{"sigil"}, wantApp: "sigil", wantExists: true},
+		{name: "both prefer new", apps: []string{"agento11y", "sigil"}, wantApp: "agento11y", wantExists: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateEnv(t)
+			for _, app := range tc.apps {
+				writeConfigApp(t, app, "SIGIL_ENDPOINT=https://x\n")
+			}
+
+			sec := collectConfig(nil, nil)
+			want := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), tc.wantApp, "config.env")
+			if sec.Path != want {
+				t.Fatalf("Path = %q, want %q", sec.Path, want)
+			}
+			if sec.Exists != tc.wantExists {
+				t.Fatalf("Exists = %v, want %v", sec.Exists, tc.wantExists)
+			}
+		})
 	}
 }
 

--- a/plugins/agento11y/internal/doctor/render_test.go
+++ b/plugins/agento11y/internal/doctor/render_test.go
@@ -11,7 +11,7 @@ func sampleReport() *Report {
 	return &Report{
 		Sigil: SigilSection{Version: "1.2.3"},
 		Config: ConfigSection{
-			Path: "/tmp/sigil/config.env", Exists: true,
+			Path: "/tmp/agento11y/config.env", Exists: true,
 			ContentCaptureMode: "metadata_only", Health: HealthOK,
 		},
 		Conversations: ConversationsSection{

--- a/plugins/agento11y/internal/dotenv/dotenv.go
+++ b/plugins/agento11y/internal/dotenv/dotenv.go
@@ -1,5 +1,6 @@
-// Package dotenv loads KEY=value pairs from $XDG_CONFIG_HOME/<app>/config.env
-// and writes them into the process environment where the OS env is empty.
+// Package dotenv loads KEY=value pairs from the launcher config file
+// (see FilePath) and writes them into the process environment where the OS
+// env is empty.
 //
 // This lets hooks pick up branded credentials when the agent runs them under
 // a stripped environment (e.g. Cursor's hook runtime, Codex's headless mode).
@@ -15,10 +16,32 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/xdg"
 )
 
-// FilePath returns the dotenv config path for an app:
-// $XDG_CONFIG_HOME/<appName>/config.env (with sensible fallbacks).
-func FilePath(appName string) string {
-	return xdg.ConfigFilePath(appName, "config.env")
+const (
+	// appName is the preferred config directory name.
+	appName = "agento11y"
+	// legacyAppName is the pre-rename config directory, still read during
+	// the transition so existing installs keep working. Old binaries only
+	// know this path, so the file is never moved or copied.
+	legacyAppName = "sigil"
+)
+
+// FilePath returns the dotenv config path:
+// $XDG_CONFIG_HOME/agento11y/config.env if that file exists, otherwise the
+// legacy $XDG_CONFIG_HOME/sigil/config.env if that exists, otherwise the new
+// path (with the usual xdg config-root fallbacks). Preferring the new path
+// when both exist mirrors the AGENTO11Y_* > SIGIL_* env precedence. Writers
+// (login, the local settings server) use the same resolution so reads and
+// writes stay on one file.
+func FilePath() string {
+	preferred := xdg.ConfigFilePath(appName, "config.env")
+	if _, err := os.Stat(preferred); err == nil {
+		return preferred
+	}
+	legacy := xdg.ConfigFilePath(legacyAppName, "config.env")
+	if _, err := os.Stat(legacy); err == nil {
+		return legacy
+	}
+	return preferred
 }
 
 // HasCredentials reports whether the branded credentials are populated in the
@@ -30,8 +53,9 @@ func HasCredentials() bool {
 		envconfig.Getenv("AUTH_TOKEN") != ""
 }
 
-// ApplyEnv loads the dotenv file for appName and merges it into the process
-// environment. Supported alias families resolve source-first, spelling-second:
+// ApplyEnv loads the dotenv file (see FilePath) and merges it into the
+// process environment. Supported alias families resolve source-first,
+// spelling-second:
 //
 //	shell AGENTO11Y_* > shell SIGIL_* > file AGENTO11Y_* > file SIGIL_*
 //
@@ -42,8 +66,8 @@ func HasCredentials() bool {
 // step. Keys outside the alias registry keep the old exact-key semantics:
 // the file value is applied only where the OS env is empty. Returns the
 // parsed dotenv map for callers that need to introspect (tests).
-func ApplyEnv(appName string, logger *log.Logger) map[string]string {
-	fileEnv := LoadDotenv(FilePath(appName), logger)
+func ApplyEnv(logger *log.Logger) map[string]string {
+	fileEnv := LoadDotenv(FilePath(), logger)
 
 	aliasKeys := map[string]bool{}
 	for _, suffix := range envconfig.AliasSuffixes {

--- a/plugins/agento11y/internal/dotenv/dotenv_test.go
+++ b/plugins/agento11y/internal/dotenv/dotenv_test.go
@@ -144,7 +144,7 @@ func TestApplyEnv(t *testing.T) {
 					t.Fatalf("write: %v", err)
 				}
 			}
-			ApplyEnv("sigil", log.New(&bytes.Buffer{}, "", 0))
+			ApplyEnv(log.New(&bytes.Buffer{}, "", 0))
 			if got := os.Getenv(key); got != tc.want {
 				t.Fatalf("%s = %q, want %q", key, got, tc.want)
 			}
@@ -209,7 +209,7 @@ func TestApplyEnvAliasFamilies(t *testing.T) {
 					t.Fatalf("write: %v", err)
 				}
 			}
-			ApplyEnv("sigil", log.New(&bytes.Buffer{}, "", 0))
+			ApplyEnv(log.New(&bytes.Buffer{}, "", 0))
 			if got := os.Getenv("AGENTO11Y_ENDPOINT"); got != tc.want {
 				t.Fatalf("AGENTO11Y_ENDPOINT = %q, want %q", got, tc.want)
 			}
@@ -224,8 +224,8 @@ func TestFilePath(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
-	got := FilePath("sigil")
-	wantSuffix := filepath.Join("sigil", "config.env")
+	got := FilePath()
+	wantSuffix := filepath.Join("agento11y", "config.env")
 	if !strings.HasPrefix(got, dir) || !strings.HasSuffix(got, wantSuffix) {
 		t.Fatalf("FilePath() = %q, want inside %q ending %q", got, dir, wantSuffix)
 	}
@@ -236,9 +236,44 @@ func TestFilePathDefaultsToHomeDotConfigWhenXDGUnset(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("HOME", home)
 
-	got := FilePath("sigil")
-	want := filepath.Join(home, ".config", "sigil", "config.env")
+	got := FilePath()
+	want := filepath.Join(home, ".config", "agento11y", "config.env")
 	if got != want {
 		t.Fatalf("FilePath() = %q, want %q", got, want)
+	}
+}
+
+func TestFilePathResolution(t *testing.T) {
+	cases := []struct {
+		name       string
+		makeNew    bool
+		makeLegacy bool
+		wantApp    string
+	}{
+		{name: "neither exists defaults to new", wantApp: "agento11y"},
+		{name: "only new exists", makeNew: true, wantApp: "agento11y"},
+		{name: "only legacy exists", makeLegacy: true, wantApp: "sigil"},
+		{name: "both exist prefers new", makeNew: true, makeLegacy: true, wantApp: "agento11y"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("XDG_CONFIG_HOME", dir)
+			for app, make := range map[string]bool{"agento11y": tc.makeNew, "sigil": tc.makeLegacy} {
+				if !make {
+					continue
+				}
+				if err := os.MkdirAll(filepath.Join(dir, app), 0o755); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, app, "config.env"), []byte("SIGIL_ENDPOINT=x\n"), 0o600); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+			}
+			want := filepath.Join(dir, tc.wantApp, "config.env")
+			if got := FilePath(); got != want {
+				t.Fatalf("FilePath() = %q, want %q", got, want)
+			}
+		})
 	}
 }

--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -193,10 +193,10 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 	isHookCall := len(args) >= 2 && args[1] == "hook" && isHookAgent
 	if launcher, ok := launchers[args[0]]; ok && !isHookCall {
 		// dotenv must run before parseLauncherArgs so XDG_STATE_HOME set
-		// only in $XDG_CONFIG_HOME/sigil/config.env reaches local.StateDir()
+		// only in $XDG_CONFIG_HOME/agento11y/config.env reaches local.StateDir()
 		// when --local is used. Otherwise the daemon dir is resolved against
 		// the wrong root.
-		dotenv.ApplyEnv("sigil", nil)
+		dotenv.ApplyEnv(nil)
 		launcherArgs, localEnv, ok := parseLauncherArgs(args[0], args[1:], stderr)
 		if !ok {
 			return
@@ -289,10 +289,10 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 	useragent.SigilVersion = version
 
 	// Apply the dotenv file before initialising the logger so SIGIL_DEBUG=true
-	// set only in $XDG_CONFIG_HOME/sigil/config.env still enables file logging.
+	// set only in $XDG_CONFIG_HOME/agento11y/config.env still enables file logging.
 	// Cursor (and Codex headless) launch hooks under a stripped environment
 	// where the dotenv is the only place SIGIL_DEBUG could come from.
-	dotenv.ApplyEnv("sigil", nil)
+	dotenv.ApplyEnv(nil)
 	logger := cli.InitLogger("sigil", agent)
 	defer cli.RecoverAndLog(logger)
 
@@ -303,7 +303,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 
 // runLoginCommand handles `sigil login`. The flow is interactive-only: any
 // args (including unknown flags) are rejected with exit 2. Non-interactive
-// callers should set SIGIL_* env vars or edit $XDG_CONFIG_HOME/sigil/config.env
+// callers should set SIGIL_* env vars or edit $XDG_CONFIG_HOME/agento11y/config.env
 // directly.
 func runLoginCommand(args []string, stderr io.Writer) {
 	fs := flag.NewFlagSet("login", flag.ContinueOnError)
@@ -311,7 +311,8 @@ func runLoginCommand(args []string, stderr io.Writer) {
 	fs.Usage = func() {
 		_, _ = fmt.Fprintln(stderr, "usage: agento11y login")
 		_, _ = fmt.Fprintln(stderr)
-		_, _ = fmt.Fprintln(stderr, "Interactively save Sigil credentials to $XDG_CONFIG_HOME/sigil/config.env.")
+		_, _ = fmt.Fprintln(stderr, "Interactively save Sigil credentials to $XDG_CONFIG_HOME/agento11y/config.env")
+		_, _ = fmt.Fprintln(stderr, "(or the old $XDG_CONFIG_HOME/sigil/config.env if only that file exists).")
 	}
 	if err := fs.Parse(args); err != nil {
 		exit(2)
@@ -323,7 +324,7 @@ func runLoginCommand(args []string, stderr io.Writer) {
 		return
 	}
 
-	dotenv.ApplyEnv("sigil", nil)
+	dotenv.ApplyEnv(nil)
 	logger := cli.InitLogger("sigil", "login")
 
 	err := loginRun(context.Background(), login.RunOpts{
@@ -357,9 +358,9 @@ func runLoginCommand(args []string, stderr io.Writer) {
 // same way the launchers do; uninstall removes the hook entries.
 func runCursorInstall(verb string, stdout, stderr io.Writer) {
 	// dotenv must run before InitLogger so SIGIL_DEBUG=true set only in
-	// $XDG_CONFIG_HOME/sigil/config.env still enables file logging, and
+	// $XDG_CONFIG_HOME/agento11y/config.env still enables file logging, and
 	// before HasCredentials so dotenv-supplied credentials are visible.
-	dotenv.ApplyEnv("sigil", nil)
+	dotenv.ApplyEnv(nil)
 	logger := cli.InitLogger("sigil", "cursor")
 
 	if verb == "uninstall" {
@@ -405,7 +406,7 @@ func runCursorInstall(verb string, stdout, stderr io.Writer) {
 // is applied so doctor can attribute each value to the OS env vs config.env.
 func runDoctorCommand(args []string, stdout, stderr io.Writer) {
 	osEnv := doctor.SnapshotEnv()
-	dotenv.ApplyEnv("sigil", nil)
+	dotenv.ApplyEnv(nil)
 	code := doctor.Run(context.Background(), args, doctor.Params{
 		Version: version,
 		OSEnv:   osEnv,
@@ -604,9 +605,9 @@ func runLocalCommand(args []string, stdout, stderr io.Writer) {
 		return
 	}
 	// Apply dotenv before resolving the state dir so XDG_STATE_HOME set
-	// only in $XDG_CONFIG_HOME/sigil/config.env reaches local.StateDir().
+	// only in $XDG_CONFIG_HOME/agento11y/config.env reaches local.StateDir().
 	// Each verb relies on that resolution.
-	dotenv.ApplyEnv("sigil", nil)
+	dotenv.ApplyEnv(nil)
 	dir := local.StateDir()
 	switch args[0] {
 	case "start":

--- a/plugins/agento11y/internal/entry/entry_test.go
+++ b/plugins/agento11y/internal/entry/entry_test.go
@@ -31,7 +31,7 @@ import (
 // It also points HOME/XDG_* at a throwaway dir for the whole package: run()
 // applies the dotenv config via os.Setenv, which t.Setenv cannot undo, so a
 // single hook or launcher dispatch test reading the developer's real
-// ~/.config/sigil/config.env would leak SIGIL_* values (e.g. guard flags)
+// ~/.config/agento11y/config.env would leak SIGIL_* values (e.g. guard flags)
 // into every later test in the package.
 func TestMain(m *testing.M) {
 	loginRun = func(context.Context, login.RunOpts) error { return login.ErrNotInteractive }
@@ -139,45 +139,53 @@ func TestRun_DispatchesToMatchingAgentHook(t *testing.T) {
 
 // TestRun_DotenvSIGILDebugEnablesLogging guards the ordering invariant in
 // run(): dotenv.ApplyEnv must run before cli.InitLogger so SIGIL_DEBUG=true
-// set only in $XDG_CONFIG_HOME/sigil/config.env still routes the logger to
-// the per-app log file. Cursor and Codex headless launch hooks under a
-// stripped environment where the dotenv is the only source of SIGIL_DEBUG.
+// set only in the dotenv config still routes the logger to the per-app log
+// file. Cursor and Codex headless launch hooks under a stripped environment
+// where the dotenv is the only source of SIGIL_DEBUG. Runs against both the
+// preferred agento11y config dir and the legacy sigil fallback.
 func TestRun_DotenvSIGILDebugEnablesLogging(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
-	t.Setenv("XDG_STATE_HOME", filepath.Join(dir, "state"))
-	t.Setenv("SIGIL_DEBUG", "")
+	for _, app := range []string{"agento11y", "sigil"} {
+		t.Run(app, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("HOME", dir)
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+			t.Setenv("XDG_STATE_HOME", filepath.Join(dir, "state"))
+			// ApplyEnv materializes the winner under both spellings via
+			// os.Setenv, so pin both blank to keep the subtests hermetic.
+			t.Setenv("SIGIL_DEBUG", "")
+			t.Setenv("AGENTO11Y_DEBUG", "")
 
-	cfgDir := filepath.Join(dir, "config", "sigil")
-	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(cfgDir, "config.env"), []byte("SIGIL_DEBUG=true\n"), 0o600); err != nil {
-		t.Fatalf("write dotenv: %v", err)
-	}
+			cfgDir := filepath.Join(dir, "config", app)
+			if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(cfgDir, "config.env"), []byte("SIGIL_DEBUG=true\n"), 0o600); err != nil {
+				t.Fatalf("write dotenv: %v", err)
+			}
 
-	prev := agents
-	t.Cleanup(func() { agents = prev })
-	agents = map[string]agentHook{
-		"claude-code": func(_ context.Context, _ io.Reader, _ io.Writer, logger *log.Logger) error {
-			logger.Print("hook ran")
-			return nil
-		},
-	}
+			prev := agents
+			t.Cleanup(func() { agents = prev })
+			agents = map[string]agentHook{
+				"claude-code": func(_ context.Context, _ io.Reader, _ io.Writer, logger *log.Logger) error {
+					logger.Print("hook ran")
+					return nil
+				},
+			}
 
-	var stdout, stderr bytes.Buffer
-	withExit(t, func() {
-		run([]string{"claude-code", "hook"}, strings.NewReader(`{}`), &stdout, &stderr)
-	})
+			var stdout, stderr bytes.Buffer
+			withExit(t, func() {
+				run([]string{"claude-code", "hook"}, strings.NewReader(`{}`), &stdout, &stderr)
+			})
 
-	logPath := filepath.Join(dir, "state", "sigil", "logs", "sigil.log")
-	data, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatalf("debug log not created at %s: %v", logPath, err)
-	}
-	if !strings.Contains(string(data), "hook ran") {
-		t.Fatalf("debug log missing expected line; got %q", data)
+			logPath := filepath.Join(dir, "state", "sigil", "logs", "sigil.log")
+			data, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Fatalf("debug log not created at %s: %v", logPath, err)
+			}
+			if !strings.Contains(string(data), "hook ran") {
+				t.Fatalf("debug log missing expected line; got %q", data)
+			}
+		})
 	}
 }
 

--- a/plugins/agento11y/internal/envconfig/envconfig.go
+++ b/plugins/agento11y/internal/envconfig/envconfig.go
@@ -270,7 +270,7 @@ func ResolveContentMode(logger *log.Logger) sigil.ContentCaptureMode {
 
 // GuardsConfig is the resolved guard feature flags for a hook handler.
 // Mirrors plugins/pi/src/config.ts::GuardsFeatureConfig so a single
-// ~/.config/sigil/config.env drives both plugins.
+// ~/.config/agento11y/config.env drives both plugins.
 type GuardsConfig struct {
 	Enabled   bool
 	TimeoutMs int

--- a/plugins/agento11y/internal/local/manager.go
+++ b/plugins/agento11y/internal/local/manager.go
@@ -239,7 +239,7 @@ func Serve(ctx context.Context, dir string, port int, logger *log.Logger) error 
 		return fmt.Errorf("listen: %w", err)
 	}
 	actualPort := listener.Addr().(*net.TCPAddr).Port
-	srv := NewServer(storage, logger, dotenv.FilePath("sigil"))
+	srv := NewServer(storage, logger, dotenv.FilePath())
 	httpSrv := &http.Server{
 		Handler:           srv,
 		ReadHeaderTimeout: 5 * time.Second,

--- a/plugins/agento11y/internal/local/settings.go
+++ b/plugins/agento11y/internal/local/settings.go
@@ -269,7 +269,7 @@ func seedGuards(enabledRaw, failOpenRaw string) string {
 }
 
 // displayConfigPath collapses the user's home prefix to ~ for display so the
-// viewer shows ~/.config/sigil/config.env rather than an absolute path.
+// viewer shows ~/.config/agento11y/config.env rather than an absolute path.
 func displayConfigPath(path string) string {
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
 		if rel, ok := strings.CutPrefix(path, home+string(os.PathSeparator)); ok {

--- a/plugins/agento11y/internal/local/web/app.jsx
+++ b/plugins/agento11y/internal/local/web/app.jsx
@@ -1807,7 +1807,7 @@
       const [form, setForm] = useState(null);
       const [saved, setSaved] = useState(null);
       const [preview, setPreview] = useState("");
-      const [path, setPath] = useState("~/.config/sigil/config.env");
+      const [path, setPath] = useState("~/.config/agento11y/config.env");
       const [loading, setLoading] = useState(true);
       const [error, setError] = useState(null);
       const [toast, setToast] = useState(null);

--- a/plugins/agento11y/internal/login/login.go
+++ b/plugins/agento11y/internal/login/login.go
@@ -6,13 +6,15 @@
 // SIGIL_AUTH_TENANT_ID, SIGIL_AUTH_TOKEN and an optional OTel OTLP endpoint)
 // followed by an optional preferences group (content capture mode, session
 // tags, and guards), then writes them to the standard dotenv at
-// $XDG_CONFIG_HOME/sigil/config.env. Existing allowed keys not covered by
+// $XDG_CONFIG_HOME/agento11y/config.env (or the legacy
+// $XDG_CONFIG_HOME/sigil/config.env when only that file exists; see
+// dotenv.FilePath). Existing allowed keys not covered by
 // prompts are preserved by the underlying writer.
 //
 // Prompts use github.com/charmbracelet/huh, the same library gcx uses. The
 // flow is interactive-only: callers without a TTY receive ErrNotInteractive
 // and should either run from a terminal or set SIGIL_* env vars / write
-// $XDG_CONFIG_HOME/sigil/config.env directly.
+// $XDG_CONFIG_HOME/agento11y/config.env directly.
 package login
 
 import (
@@ -105,7 +107,7 @@ func grafanaTheme() *huh.Theme {
 // RunOpts controls the login flow.
 type RunOpts struct {
 	// ConfigPath overrides the dotenv path; empty resolves to
-	// dotenv.FilePath("sigil").
+	// dotenv.FilePath().
 	ConfigPath string
 
 	// ShowNextStep prints a `Try sigil claude or sigil pi.` hint after a
@@ -149,7 +151,7 @@ func Run(_ context.Context, opts RunOpts) error {
 	}
 	configPath := opts.ConfigPath
 	if configPath == "" {
-		configPath = dotenv.FilePath("sigil")
+		configPath = dotenv.FilePath()
 	}
 
 	if !term.IsTerminal(int(opts.Stdin.Fd())) {

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -27,7 +27,7 @@ agento11y claude
 
 The script installs `agento11y` to `~/.local/bin`; `go install` uses `go env GOPATH`/bin (or `GOBIN`). Make sure that directory is on your `PATH`. See the [`agento11y` binary README](../agento11y/README.md#install) for all install options. The command was renamed from `sigil`; the old name still works but will be removed in a future release.
 
-`agento11y claude` registers the `sigil-cc` plugin on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches Claude Code.
+`agento11y claude` registers the `sigil-cc` plugin on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/agento11y/config.env`, and then launches Claude Code.
 
 <details>
 <summary>Manual plugin registration</summary>
@@ -61,7 +61,7 @@ Run `agento11y login` later to update saved credentials.
 <details>
 <summary>Non-interactive config.env</summary>
 
-Create or update `~/.config/sigil/config.env`:
+Create or update `~/.config/agento11y/config.env` (if you already have the old `~/.config/sigil/config.env`, edit that one instead):
 
 ```dotenv
 AGENTO11Y_ENDPOINT=https://sigil-prod-<region>.grafana.net
@@ -72,7 +72,7 @@ AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana
 
 </details>
 
-To also send the conversation text (with automatic secret redaction), add this to `~/.config/sigil/config.env`:
+To also send the conversation text (with automatic secret redaction), add this to your `config.env`:
 
 ```dotenv
 AGENTO11Y_CONTENT_CAPTURE_MODE=full

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -29,7 +29,7 @@ agento11y codex
 
 The script installs `agento11y` to `~/.local/bin`; `go install` uses `go env GOPATH`/bin (or `GOBIN`). Make sure that directory is on your `PATH`. See the [`agento11y` binary README](../agento11y/README.md#install) for all install options. The command was renamed from `sigil`; the old name still works but will be removed in a future release.
 
-`agento11y codex` registers `sigil-codex@grafana-sigil` on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches Codex.
+`agento11y codex` registers `sigil-codex@grafana-sigil` on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/agento11y/config.env`, and then launches Codex.
 
 On first launch only, open `/hooks` inside Codex and trust each `sigil-codex@grafana-sigil` hook. Codex requires this manual review after plugin install.
 
@@ -79,7 +79,7 @@ Run `agento11y login` later to update saved credentials.
 <details>
 <summary>Non-interactive config.env</summary>
 
-Create or update `~/.config/sigil/config.env`:
+Create or update `~/.config/agento11y/config.env` (if you already have the old `~/.config/sigil/config.env`, edit that one instead):
 
 ```dotenv
 AGENTO11Y_ENDPOINT=https://sigil-prod-<region>.grafana.net
@@ -90,7 +90,7 @@ AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana
 
 </details>
 
-To also send the conversation text (with automatic secret redaction), add this to `~/.config/sigil/config.env`:
+To also send the conversation text (with automatic secret redaction), add this to your `config.env`:
 
 ```dotenv
 AGENTO11Y_CONTENT_CAPTURE_MODE=full

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -40,7 +40,7 @@ agento11y copilot -- <copilot args>
 
 The script installs `agento11y` to `~/.local/bin`; `go install` uses `go env GOPATH`/bin (or `GOBIN`). Make sure that directory is on your `PATH`. See the [`agento11y` binary README](../agento11y/README.md#install) for all install options. The command was renamed from `sigil`; the old name still works but will be removed in a future release.
 
-`agento11y copilot` writes the shared hooks file to `~/.copilot/hooks/sigil.json`, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, removes any legacy `sigil-copilot` plugin left by older versions, and then launches Copilot CLI.
+`agento11y copilot` writes the shared hooks file to `~/.copilot/hooks/sigil.json`, prompts for missing Grafana Cloud credentials, writes `~/.config/agento11y/config.env`, removes any legacy `sigil-copilot` plugin left by older versions, and then launches Copilot CLI.
 
 For VS Code, no launch wrapper is needed — once `~/.copilot/hooks/sigil.json` exists, add `~/.copilot/hooks` to the `chat.hookFilesLocations` setting and Copilot Chat picks it up.
 
@@ -72,7 +72,7 @@ Run `agento11y login` later to update saved credentials.
 <details>
 <summary>Non-interactive config.env</summary>
 
-Create or update `~/.config/sigil/config.env`:
+Create or update `~/.config/agento11y/config.env` (if you already have the old `~/.config/sigil/config.env`, edit that one instead):
 
 ```dotenv
 AGENTO11Y_ENDPOINT=https://sigil-prod-<region>.grafana.net
@@ -83,7 +83,7 @@ AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana
 
 </details>
 
-To also send the conversation text (with automatic secret redaction), add this to `~/.config/sigil/config.env`:
+To also send the conversation text (with automatic secret redaction), add this to your `config.env`:
 
 ```dotenv
 AGENTO11Y_CONTENT_CAPTURE_MODE=full

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -71,7 +71,7 @@ You need values from three Grafana Cloud pages:
 <details>
 <summary>Non-interactive config.env</summary>
 
-Create or update `~/.config/sigil/config.env`:
+Create or update `~/.config/agento11y/config.env` (if you already have the old `~/.config/sigil/config.env`, edit that one instead):
 
 ```dotenv
 AGENTO11Y_ENDPOINT=https://sigil-prod-<region>.grafana.net
@@ -82,7 +82,7 @@ AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana
 
 </details>
 
-To also send the conversation text, add this to `~/.config/sigil/config.env`:
+To also send the conversation text, add this to your `config.env`:
 
 ```dotenv
 AGENTO11Y_CONTENT_CAPTURE_MODE=full
@@ -94,7 +94,7 @@ Cursor content is not passed through the shared redactor before export. Avoid `f
 
 Use Cursor's agent for one turn, then open **AI Observability → Conversations** in Grafana Cloud. A new generation should appear within a few seconds.
 
-If nothing shows up, add `AGENTO11Y_DEBUG=true` to `~/.config/sigil/config.env` (Cursor launches from the GUI, so a shell env var won't reach the hooks) and tail the log:
+If nothing shows up, add `AGENTO11Y_DEBUG=true` to `~/.config/agento11y/config.env` (Cursor launches from the GUI, so a shell env var won't reach the hooks) and tail the log:
 
 ```sh
 tail -f ~/.local/state/sigil/logs/sigil.log

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -29,7 +29,7 @@ agento11y opencode
 
 The script installs `agento11y` to `~/.local/bin`; `go install` uses `go env GOPATH`/bin (or `GOBIN`). Make sure that directory is on your `PATH`. See the [`agento11y` binary README](../agento11y/README.md#install) for all install options. The command was renamed from `sigil`; the old name still works but will be removed in a future release.
 
-`agento11y opencode` installs `@grafana/agento11y-opencode` into OpenCode on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches OpenCode. Pass arguments to OpenCode after `--`, e.g. `agento11y opencode -- run "say hi"`.
+`agento11y opencode` installs `@grafana/agento11y-opencode` into OpenCode on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/agento11y/config.env`, and then launches OpenCode. Pass arguments to OpenCode after `--`, e.g. `agento11y opencode -- run "say hi"`.
 
 <details>
 <summary>Manual plugin registration</summary>
@@ -39,7 +39,7 @@ opencode plugin @grafana/agento11y-opencode --global
 agento11y login
 ```
 
-The plugin reads `~/.config/sigil/config.env` on every session start, whether you start OpenCode with `agento11y opencode` or plain `opencode`.
+The plugin reads `~/.config/agento11y/config.env` on every session start, whether you start OpenCode with `agento11y opencode` or plain `opencode`. If you only have the old `~/.config/sigil/config.env`, that file is used instead.
 
 </details>
 
@@ -65,7 +65,7 @@ Run `agento11y login` later to update saved credentials.
 <details>
 <summary>Non-interactive config.env</summary>
 
-Create or update `~/.config/sigil/config.env`:
+Create or update `~/.config/agento11y/config.env` (if you already have the old `~/.config/sigil/config.env`, edit that one instead):
 
 ```dotenv
 AGENTO11Y_ENDPOINT=https://sigil-prod-<region>.grafana.net
@@ -78,7 +78,7 @@ AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana
 
 When `AGENTO11Y_AUTH_TENANT_ID` and `AGENTO11Y_AUTH_TOKEN` are set, the plugin uses them for Sigil and OTLP auth. If the OpenTelemetry card shows a different Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>`.
 
-To include conversation text, add this to `~/.config/sigil/config.env`:
+To include conversation text, add this to your `config.env`:
 
 ```dotenv
 AGENTO11Y_CONTENT_CAPTURE_MODE=full
@@ -90,7 +90,7 @@ OpenCode redacts assistant and tool content before export. User prompt text is s
 
 Run one OpenCode turn, then open **AI Observability → Conversations** in Grafana Cloud. A new generation should appear within a few seconds.
 
-If nothing shows up, set `AGENTO11Y_DEBUG=true` in `~/.config/sigil/config.env`, run another turn, and check OpenCode stderr.
+If nothing shows up, set `AGENTO11Y_DEBUG=true` in `~/.config/agento11y/config.env`, run another turn, and check OpenCode stderr.
 
 ## Tagging sessions
 
@@ -102,7 +102,7 @@ agento11y opencode --tag project=hackathon --tag team=ai
 agento11y opencode --tag team=ai -- run "say hi"
 ```
 
-`--tag` is shorthand for `AGENTO11Y_TAGS`; flag tags merge onto (and override) any `AGENTO11Y_TAGS` already in the environment or `~/.config/sigil/config.env`. The merge happens in the SDK, so user tags reach every generation without the plugin reparsing them.
+`--tag` is shorthand for `AGENTO11Y_TAGS`; flag tags merge onto (and override) any `AGENTO11Y_TAGS` already in the environment or `~/.config/agento11y/config.env`. The merge happens in the SDK, so user tags reach every generation without the plugin reparsing them.
 
 The plugin always attaches two built-in tags to every generation:
 
@@ -113,7 +113,7 @@ Built-in tags win collisions with user tags, matching the claude-code and cursor
 
 ## All options
 
-`~/.config/sigil/config.env` is the only configuration file. Every option is set via env var.
+`~/.config/agento11y/config.env` is the only configuration file. Every option is set via env var.
 
 | Variable | Default | Description |
 |---|---|---|

--- a/plugins/opencode/src/config.test.ts
+++ b/plugins/opencode/src/config.test.ts
@@ -451,7 +451,7 @@ describe("normalizeBaseEndpoint", () => {
   });
 });
 
-describe("loadConfig reads ~/.config/sigil/config.env", () => {
+describe("loadConfig reads ~/.config/agento11y/config.env", () => {
   let dir: string;
   let homeBackup: string | undefined;
 
@@ -476,7 +476,7 @@ describe("loadConfig reads ~/.config/sigil/config.env", () => {
   });
 
   it("picks up SIGIL_* credentials from config.env when no shell env is set", async () => {
-    const cfgDir = join(dir, "sigil");
+    const cfgDir = join(dir, "agento11y");
     mkdirSync(cfgDir, { recursive: true });
     writeFileSync(
       join(cfgDir, "config.env"),

--- a/plugins/opencode/src/sigilDotenv.test.ts
+++ b/plugins/opencode/src/sigilDotenv.test.ts
@@ -1,7 +1,24 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { homedirOverride } = vi.hoisted(() => ({
+  homedirOverride: { value: undefined as string | undefined },
+}));
+
+// sigilConfigEnvPath stats files under the resolved config root, so tests
+// exercising the $HOME/.config fallback must not consult the developer's
+// real home (which may contain a live config.env). Overridable homedir,
+// pass-through otherwise.
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return {
+    ...actual,
+    homedir: () => homedirOverride.value ?? actual.homedir(),
+  };
+});
+
 import {
   applySigilDotenv,
   loadSigilDotenv,
@@ -98,19 +115,61 @@ OTEL_RESOURCE_ATTRIBUTES=service.name=other
 });
 
 describe("sigilConfigEnvPath", () => {
-  beforeEach(clearSigilEnv);
-  afterEach(clearSigilEnv);
+  let fakeHome: string;
+
+  beforeEach(() => {
+    clearSigilEnv();
+    fakeHome = mkdtempSync(join(tmpdir(), "sigil-opencode-home-"));
+    homedirOverride.value = fakeHome;
+  });
+
+  afterEach(() => {
+    homedirOverride.value = undefined;
+    rmSync(fakeHome, { recursive: true, force: true });
+    clearSigilEnv();
+  });
 
   it("honors an absolute XDG_CONFIG_HOME", () => {
-    process.env.XDG_CONFIG_HOME = "/tmp/custom-config";
-    expect(sigilConfigEnvPath()).toBe("/tmp/custom-config/sigil/config.env");
+    // Fresh dir, not a fixed /tmp path: resolution is stat-based, so a
+    // leftover sigil/config.env at a shared path would flip the result.
+    const xdg = join(fakeHome, "custom-config");
+    process.env.XDG_CONFIG_HOME = xdg;
+    expect(sigilConfigEnvPath()).toBe(join(xdg, "agento11y", "config.env"));
   });
 
-  it("falls back to $HOME/.config/sigil/config.env when XDG_CONFIG_HOME is unset", () => {
+  it("falls back to $HOME/.config/agento11y/config.env when XDG_CONFIG_HOME is unset", () => {
     expect(sigilConfigEnvPath()).toBe(
-      join(homedir(), ".config", "sigil", "config.env"),
+      join(fakeHome, ".config", "agento11y", "config.env"),
     );
   });
+
+  // Mirrors plugins/agento11y/internal/dotenv/dotenv_test.go::TestFilePathResolution.
+  const resolutionCases: {
+    name: string;
+    apps: string[];
+    wantApp: string;
+  }[] = [
+    { name: "neither exists defaults to new", apps: [], wantApp: "agento11y" },
+    { name: "only new exists", apps: ["agento11y"], wantApp: "agento11y" },
+    { name: "only legacy exists", apps: ["sigil"], wantApp: "sigil" },
+    {
+      name: "both exist prefers new",
+      apps: ["agento11y", "sigil"],
+      wantApp: "agento11y",
+    },
+  ];
+  for (const tc of resolutionCases) {
+    it(tc.name, () => {
+      process.env.XDG_CONFIG_HOME = fakeHome;
+      for (const app of tc.apps) {
+        mkdirSync(join(fakeHome, app), { recursive: true });
+        writeFileSync(join(fakeHome, app, "config.env"), "SIGIL_ENDPOINT=x\n");
+      }
+      expect(sigilConfigEnvPath()).toBe(
+        join(fakeHome, tc.wantApp, "config.env"),
+      );
+    });
+  }
 });
 
 describe("loadSigilDotenv", () => {

--- a/plugins/opencode/src/sigilDotenv.ts
+++ b/plugins/opencode/src/sigilDotenv.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import { isMissingFileError } from "./fsErrors.js";
@@ -50,25 +50,49 @@ const ALIAS_SUFFIXES = [
   "GUARDS_TIMEOUT_MS",
 ];
 
-/**
- * Resolve the path the sigil dotenv loader reads. Mirrors
- * `plugins/agento11y/internal/xdg/xdg.go::ConfigRoot` so every Sigil agent reads
- * the same file:
- *
- * 1. `$XDG_CONFIG_HOME/sigil/config.env` when XDG_CONFIG_HOME is an absolute path.
- * 2. `$HOME/.config/sigil/config.env` when the user has a resolvable home.
- * 3. `<tmpdir>/sigil/config.env` as a last-resort fallback.
- */
-export function sigilConfigEnvPath(): string {
+// Preferred config directory name and the pre-rename fallback. The legacy
+// directory is still read during the transition so existing installs keep
+// working; the file is never moved or copied.
+const APP_NAME = "agento11y";
+const LEGACY_APP_NAME = "sigil";
+
+// Resolve the config root the same way as
+// `plugins/agento11y/internal/xdg/xdg.go::ConfigRoot`:
+//
+// 1. `$XDG_CONFIG_HOME` when it is an absolute path.
+// 2. `$HOME/.config` when the user has a resolvable home.
+// 3. `<tmpdir>` as a last-resort fallback.
+function configRoot(): string {
   const xdg = (process.env.XDG_CONFIG_HOME ?? "").trim();
   if (xdg && isAbsolute(xdg)) {
-    return join(xdg, "sigil", "config.env");
+    return xdg;
   }
   const home = homedir();
   if (home && isAbsolute(home)) {
-    return join(home, ".config", "sigil", "config.env");
+    return join(home, ".config");
   }
-  return join(tmpdir(), "sigil", "config.env");
+  return tmpdir();
+}
+
+/**
+ * Resolve the path the sigil dotenv loader reads. Mirrors
+ * `plugins/agento11y/internal/dotenv/dotenv.go::FilePath` so every Sigil
+ * agent reads the same file: `<config root>/agento11y/config.env` if that
+ * file exists, otherwise the legacy `<config root>/sigil/config.env` if that
+ * exists, otherwise the new path. Preferring the new path when both exist
+ * mirrors the AGENTO11Y_* > SIGIL_* env precedence.
+ */
+export function sigilConfigEnvPath(): string {
+  const root = configRoot();
+  const preferred = join(root, APP_NAME, "config.env");
+  if (existsSync(preferred)) {
+    return preferred;
+  }
+  const legacy = join(root, LEGACY_APP_NAME, "config.env");
+  if (existsSync(legacy)) {
+    return legacy;
+  }
+  return preferred;
 }
 
 /**

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -29,7 +29,7 @@ agento11y pi
 
 The script installs `agento11y` to `~/.local/bin`; `go install` uses `go env GOPATH`/bin (or `GOBIN`). Make sure that directory is on your `PATH`. See the [`agento11y` binary README](../agento11y/README.md#install) for all install options. The command was renamed from `sigil`; the old name still works but will be removed in a future release.
 
-`agento11y pi` installs the `@grafana/agento11y-pi` extension on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then launches pi.
+`agento11y pi` installs the `@grafana/agento11y-pi` extension on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/agento11y/config.env`, and then launches pi.
 
 <details>
 <summary>Manual extension registration</summary>
@@ -39,7 +39,7 @@ pi install npm:@grafana/agento11y-pi
 agento11y login
 ```
 
-The extension reads the same `~/.config/sigil/config.env` file whether you start pi with `agento11y pi` or plain `pi`.
+The extension reads the same `~/.config/agento11y/config.env` file whether you start pi with `agento11y pi` or plain `pi`. If you only have the old `~/.config/sigil/config.env`, that file is used instead.
 
 </details>
 
@@ -65,7 +65,7 @@ Run `agento11y login` later to update saved credentials.
 <details>
 <summary>Non-interactive config.env</summary>
 
-Create or update `~/.config/sigil/config.env`:
+Create or update `~/.config/agento11y/config.env` (if you already have the old `~/.config/sigil/config.env`, edit that one instead):
 
 ```dotenv
 AGENTO11Y_ENDPOINT=https://sigil-prod-<region>.grafana.net
@@ -78,7 +78,7 @@ AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana
 
 When `AGENTO11Y_AUTH_TENANT_ID` and `AGENTO11Y_AUTH_TOKEN` are set, the extension uses them for Sigil and OTLP auth. If the OpenTelemetry card shows a different Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>`.
 
-To include conversation text (with automatic secret redaction), add this to `~/.config/sigil/config.env`:
+To include conversation text (with automatic secret redaction), add this to your `config.env`:
 
 ```dotenv
 AGENTO11Y_CONTENT_CAPTURE_MODE=full
@@ -88,7 +88,7 @@ AGENTO11Y_CONTENT_CAPTURE_MODE=full
 
 Run one pi turn, then open **AI Observability → Conversations** in Grafana Cloud. A new generation should appear within a few seconds.
 
-If nothing shows up, set `AGENTO11Y_DEBUG=true` in `~/.config/sigil/config.env`, run another turn, and check the debug log at `~/.local/state/sigil/logs/sigil.log` (honors `XDG_STATE_HOME`).
+If nothing shows up, set `AGENTO11Y_DEBUG=true` in `~/.config/agento11y/config.env`, run another turn, and check the debug log at `~/.local/state/sigil/logs/sigil.log` (honors `XDG_STATE_HOME`).
 
 ## Tagging sessions
 
@@ -100,7 +100,7 @@ agento11y pi --tag project=hackathon --tag team=ai
 agento11y pi --tag team=ai -- --resume
 ```
 
-`--tag` is shorthand for `AGENTO11Y_TAGS`; flag tags merge onto (and override) any `AGENTO11Y_TAGS` already in the environment or `~/.config/sigil/config.env`. The merge happens in the SDK, so user tags reach every generation without the plugin reparsing them.
+`--tag` is shorthand for `AGENTO11Y_TAGS`; flag tags merge onto (and override) any `AGENTO11Y_TAGS` already in the environment or `~/.config/agento11y/config.env`. The merge happens in the SDK, so user tags reach every generation without the plugin reparsing them.
 
 The plugin always attaches two built-in tags to every generation:
 
@@ -123,7 +123,7 @@ AGENTO11Y_GUARDS_ENABLED=true agento11y pi
 
 By default, transport errors and timeouts let the request through. Set `AGENTO11Y_GUARDS_FAIL_OPEN=false` to block tool calls on errors instead. Raise or lower `AGENTO11Y_GUARDS_TIMEOUT_MS` (default `1500`) to trade latency against tolerance for slow evaluators.
 
-The same three variables are honored by the [Claude Code plugin](../claude-code/README.md); both plugins read them from `~/.config/sigil/config.env`.
+The same three variables are honored by the [Claude Code plugin](../claude-code/README.md); both plugins read them from `~/.config/agento11y/config.env`.
 
 ### Transform guards (redaction)
 
@@ -140,7 +140,7 @@ Limits:
 
 ## All options
 
-`~/.config/sigil/config.env` is the only configuration file. Every option is set via env var.
+`~/.config/agento11y/config.env` is the only configuration file. Every option is set via env var.
 
 | Variable | Default | Description |
 |----------|---------|-------------|

--- a/plugins/pi/src/config.test.ts
+++ b/plugins/pi/src/config.test.ts
@@ -494,7 +494,7 @@ describe("resolveConfig guards", () => {
   });
 });
 
-describe("loadConfig reads ~/.config/sigil/config.env", () => {
+describe("loadConfig reads ~/.config/agento11y/config.env", () => {
   let dir: string;
   let homeBackup: string | undefined;
 
@@ -517,7 +517,7 @@ describe("loadConfig reads ~/.config/sigil/config.env", () => {
   });
 
   it("picks up SIGIL_* credentials from config.env when no shell env is set", async () => {
-    const cfgDir = join(dir, "sigil");
+    const cfgDir = join(dir, "agento11y");
     mkdirSync(cfgDir, { recursive: true });
     writeFileSync(
       join(cfgDir, "config.env"),

--- a/plugins/pi/src/sigilDotenv.test.ts
+++ b/plugins/pi/src/sigilDotenv.test.ts
@@ -1,13 +1,26 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { loggerMock } = vi.hoisted(() => ({
+const { loggerMock, homedirOverride } = vi.hoisted(() => ({
   loggerMock: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  homedirOverride: { value: undefined as string | undefined },
 }));
 
 vi.mock("./logger.js", () => ({ logger: loggerMock }));
+
+// sigilConfigEnvPath stats files under the resolved config root, so tests
+// exercising the $HOME/.config fallback must not consult the developer's
+// real home (which may contain a live config.env). Overridable homedir,
+// pass-through otherwise.
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return {
+    ...actual,
+    homedir: () => homedirOverride.value ?? actual.homedir(),
+  };
+});
 
 import {
   applySigilDotenv,
@@ -121,33 +134,75 @@ OTEL_RESOURCE_ATTRIBUTES=service.name=other
 });
 
 describe("sigilConfigEnvPath", () => {
-  beforeEach(clearSigilEnv);
-  afterEach(clearSigilEnv);
+  let fakeHome: string;
+
+  beforeEach(() => {
+    clearSigilEnv();
+    fakeHome = mkdtempSync(join(tmpdir(), "sigil-pi-home-"));
+    homedirOverride.value = fakeHome;
+  });
+
+  afterEach(() => {
+    homedirOverride.value = undefined;
+    rmSync(fakeHome, { recursive: true, force: true });
+    clearSigilEnv();
+  });
 
   it("honors an absolute XDG_CONFIG_HOME", () => {
-    process.env.XDG_CONFIG_HOME = "/tmp/custom-config";
-    expect(sigilConfigEnvPath()).toBe("/tmp/custom-config/sigil/config.env");
+    // Fresh dir, not a fixed /tmp path: resolution is stat-based, so a
+    // leftover sigil/config.env at a shared path would flip the result.
+    const xdg = join(fakeHome, "custom-config");
+    process.env.XDG_CONFIG_HOME = xdg;
+    expect(sigilConfigEnvPath()).toBe(join(xdg, "agento11y", "config.env"));
   });
 
   it("ignores a relative XDG_CONFIG_HOME and falls back to $HOME/.config", () => {
     process.env.XDG_CONFIG_HOME = "relative-path";
     expect(sigilConfigEnvPath()).toBe(
-      join(homedir(), ".config", "sigil", "config.env"),
+      join(fakeHome, ".config", "agento11y", "config.env"),
     );
   });
 
-  it("falls back to $HOME/.config/sigil/config.env when XDG_CONFIG_HOME is unset", () => {
+  it("falls back to $HOME/.config/agento11y/config.env when XDG_CONFIG_HOME is unset", () => {
     expect(sigilConfigEnvPath()).toBe(
-      join(homedir(), ".config", "sigil", "config.env"),
+      join(fakeHome, ".config", "agento11y", "config.env"),
     );
   });
 
   it("ignores an XDG_CONFIG_HOME that is whitespace only", () => {
     process.env.XDG_CONFIG_HOME = "   ";
     expect(sigilConfigEnvPath()).toBe(
-      join(homedir(), ".config", "sigil", "config.env"),
+      join(fakeHome, ".config", "agento11y", "config.env"),
     );
   });
+
+  // Mirrors plugins/agento11y/internal/dotenv/dotenv_test.go::TestFilePathResolution.
+  const resolutionCases: {
+    name: string;
+    apps: string[];
+    wantApp: string;
+  }[] = [
+    { name: "neither exists defaults to new", apps: [], wantApp: "agento11y" },
+    { name: "only new exists", apps: ["agento11y"], wantApp: "agento11y" },
+    { name: "only legacy exists", apps: ["sigil"], wantApp: "sigil" },
+    {
+      name: "both exist prefers new",
+      apps: ["agento11y", "sigil"],
+      wantApp: "agento11y",
+    },
+  ];
+  for (const tc of resolutionCases) {
+    it(tc.name, () => {
+      process.env.XDG_CONFIG_HOME = fakeHome;
+      for (const app of tc.apps) {
+        mkdirSync(join(fakeHome, app), { recursive: true });
+        writeFileSync(join(fakeHome, app, "config.env"), "SIGIL_ENDPOINT=x\n");
+      }
+      expect(sigilConfigEnvPath()).toBe(
+        join(fakeHome, tc.wantApp, "config.env"),
+      );
+    });
+  }
 });
 
 describe("loadSigilDotenv", () => {

--- a/plugins/pi/src/sigilDotenv.ts
+++ b/plugins/pi/src/sigilDotenv.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import { isMissingFileError } from "./fsErrors.js";
@@ -59,25 +59,49 @@ function legacyKey(suffix: string): string {
   return `SIGIL_${suffix}`;
 }
 
-/**
- * Resolve the path the sigil dotenv loader reads. Mirrors
- * `plugins/agento11y/internal/xdg/xdg.go::ConfigRoot` so plain pi and `sigil pi`
- * read the same file:
- *
- * 1. `$XDG_CONFIG_HOME/sigil/config.env` when XDG_CONFIG_HOME is an absolute path.
- * 2. `$HOME/.config/sigil/config.env` when the user has a resolvable home.
- * 3. `<tmpdir>/sigil/config.env` as a last-resort fallback.
- */
-export function sigilConfigEnvPath(): string {
+// Preferred config directory name and the pre-rename fallback. The legacy
+// directory is still read during the transition so existing installs keep
+// working; the file is never moved or copied.
+const APP_NAME = "agento11y";
+const LEGACY_APP_NAME = "sigil";
+
+// Resolve the config root the same way as
+// `plugins/agento11y/internal/xdg/xdg.go::ConfigRoot`:
+//
+// 1. `$XDG_CONFIG_HOME` when it is an absolute path.
+// 2. `$HOME/.config` when the user has a resolvable home.
+// 3. `<tmpdir>` as a last-resort fallback.
+function configRoot(): string {
   const xdg = (process.env.XDG_CONFIG_HOME ?? "").trim();
   if (xdg && isAbsolute(xdg)) {
-    return join(xdg, "sigil", "config.env");
+    return xdg;
   }
   const home = homedir();
   if (home && isAbsolute(home)) {
-    return join(home, ".config", "sigil", "config.env");
+    return join(home, ".config");
   }
-  return join(tmpdir(), "sigil", "config.env");
+  return tmpdir();
+}
+
+/**
+ * Resolve the path the sigil dotenv loader reads. Mirrors
+ * `plugins/agento11y/internal/dotenv/dotenv.go::FilePath` so plain pi and
+ * `agento11y pi` read the same file: `<config root>/agento11y/config.env`
+ * if that file exists, otherwise the legacy `<config root>/sigil/config.env`
+ * if that exists, otherwise the new path. Preferring the new path when both
+ * exist mirrors the AGENTO11Y_* > SIGIL_* env precedence.
+ */
+export function sigilConfigEnvPath(): string {
+  const root = configRoot();
+  const preferred = join(root, APP_NAME, "config.env");
+  if (existsSync(preferred)) {
+    return preferred;
+  }
+  const legacy = join(root, LEGACY_APP_NAME, "config.env");
+  if (existsSync(legacy)) {
+    return legacy;
+  }
+  return preferred;
 }
 
 /**

--- a/plugins/vibe/README.md
+++ b/plugins/vibe/README.md
@@ -31,7 +31,7 @@ agento11y vibe
 
 The command was renamed from `sigil`; the old name still works but will be removed in a future release.
 
-`agento11y vibe` resolves the `vibe` binary on `PATH`, upserts the three sigil-owned `[[hooks]]` entries into `~/.vibe/hooks.toml` (or `$VIBE_HOME/hooks.toml`) on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/sigil/config.env`, and then execs it. Repeated runs are no-ops: each entry is matched by name (`sigil`, `sigil-before-tool`, `sigil-after-tool`) and any hand-authored hooks in the same file are preserved.
+`agento11y vibe` resolves the `vibe` binary on `PATH`, upserts the three sigil-owned `[[hooks]]` entries into `~/.vibe/hooks.toml` (or `$VIBE_HOME/hooks.toml`) on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/agento11y/config.env`, and then execs it. Repeated runs are no-ops: each entry is matched by name (`sigil`, `sigil-before-tool`, `sigil-after-tool`) and any hand-authored hooks in the same file are preserved.
 
 The launcher always sets `VIBE_ENABLE_EXPERIMENTAL_HOOKS=true` in Mistral Vibe's environment because these events are gated behind that flag.
 
@@ -68,7 +68,7 @@ Then export `VIBE_ENABLE_EXPERIMENTAL_HOOKS=true` in the shell where you run `vi
 
 ## 2. Credentials
 
-Credentials are shared with every other `agento11y` launcher; see [`pi/README.md`](../pi/README.md#2-credentials) for the field-by-field walkthrough. Once `~/.config/sigil/config.env` exists, every launcher (and the Mistral Vibe hook) picks it up.
+Credentials are shared with every other `agento11y` launcher; see [`pi/README.md`](../pi/README.md#2-credentials) for the field-by-field walkthrough. Once `~/.config/agento11y/config.env` exists, every launcher (and the Mistral Vibe hook) picks it up. If you only have the old `~/.config/sigil/config.env`, that file is used instead.
 
 ## 3. Verify
 


### PR DESCRIPTION
The Go launcher and the `pi`/`opencode` plugins that read the config file from `~/.config/sigil/config.env` now prefer `~/.config/agento11y/config.env` and fall back to the old path when only that file exists, so existing installs keep working and fresh installs get the new location.

Part of https://github.com/grafana/sigil/issues/1282