### PR TITLE
feat(plugins): rename launcher state folder to agento11y

### DIFF
--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -118,4 +118,4 @@ For support, capture the machine-readable report — it never includes the auth 
 agento11y doctor --json
 ```
 
-If you need lower-level detail, hooks always exit 0, so problems only show up in the debug log. Set `AGENTO11Y_DEBUG=true` in `~/.config/agento11y/config.env` and tail `~/.local/state/sigil/logs/sigil.log`.
+If you need lower-level detail, hooks always exit 0, so problems only show up in the debug log. Set `AGENTO11Y_DEBUG=true` in `~/.config/agento11y/config.env` and tail `~/.local/state/agento11y/logs/agento11y.log`. Installs that still have the pre-rename `~/.local/state/sigil` directory keep using it (with the new `agento11y.log` file name) until it is removed.

--- a/plugins/agento11y/internal/agents/claudecode/hook.go
+++ b/plugins/agento11y/internal/agents/claudecode/hook.go
@@ -1,6 +1,6 @@
 // Package claudecode implements the Claude Code agent adapter for the
-// consolidated sigil binary. The dispatcher in cmd/sigil routes
-// `sigil claude-code hook` here.
+// consolidated agento11y binary. The dispatcher in cmd/agento11y routes
+// `agento11y claude-code hook` here.
 package claudecode
 
 import (
@@ -19,10 +19,10 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/claudecode/state"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/claudecode/transcript"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/guard"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/emit"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/otel"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/redact"
-	"github.com/grafana/agento11y/plugins/agento11y/internal/sigilemit"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/useragent"
 )
 
@@ -31,7 +31,7 @@ import (
 // it as a package var so tests can override it freely.
 var Version = "dev"
 
-// AgentName is the Sigil identity attached to every generation this agent
+// AgentName is the agent identity attached to every generation this agent
 // emits. Stable across versions so dashboards survive renames.
 const AgentName = "claude-code"
 
@@ -89,7 +89,7 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 
 	st := state.Load(input.SessionID)
 
-	// Route lightweight events that do not need real Sigil credentials first.
+	// Route lightweight events that do not need real agento11y credentials first.
 	// SessionStart only updates local state; PreToolUse calls into the shared
 	// guard helper which manages its own credentials, timeouts, and
 	// fail-open/closed behaviour. Routing these before the missing-creds
@@ -113,7 +113,7 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 		return nil
 	}
 
-	sigilEndpoint := envconfig.Getenv("ENDPOINT")
+	endpoint := envconfig.Getenv("ENDPOINT")
 	tenantID := envconfig.Getenv("AUTH_TENANT_ID")
 	authToken := envconfig.Getenv("AUTH_TOKEN")
 
@@ -121,12 +121,12 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 	// launcher injects placeholders, but a user running the hook
 	// directly (e.g. for testing) might leave them empty — fill in
 	// stand-ins so the SDK proceeds.
-	tenantID, authToken = envconfig.LocalAuthPlaceholders(sigilEndpoint, tenantID, authToken)
+	tenantID, authToken = envconfig.LocalAuthPlaceholders(endpoint, tenantID, authToken)
 
 	missing := envconfig.MissingEnvVars(
 		[]string{"AGENTO11Y_ENDPOINT", "AGENTO11Y_AUTH_TENANT_ID", "AGENTO11Y_AUTH_TOKEN"},
 		map[string]string{
-			"AGENTO11Y_ENDPOINT":       sigilEndpoint,
+			"AGENTO11Y_ENDPOINT":       endpoint,
 			"AGENTO11Y_AUTH_TENANT_ID": tenantID,
 			"AGENTO11Y_AUTH_TOKEN":     authToken,
 		},
@@ -184,7 +184,7 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 	logger.Printf("produced %d generations", len(gens))
 
 	cfg := agento11y.Config{
-		GenerationExport: exportConfig(sigilEndpoint, tenantID, authToken),
+		GenerationExport: exportConfig(endpoint, tenantID, authToken),
 	}
 
 	if otelProviders != nil {
@@ -213,7 +213,7 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 			Metadata:            gen.Metadata,
 		}
 
-		if err := sigilemit.Record(hookCtx, client, genStart, gen, nil, func(genCtx context.Context) {
+		if err := emit.Record(hookCtx, client, genStart, gen, nil, func(genCtx context.Context) {
 			emitToolSpans(genCtx, client, gen, toolResults)
 		}); err != nil {
 			logger.Printf("enqueue: %v", err)
@@ -241,10 +241,10 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 	return nil
 }
 
-// handlePreToolUse evaluates the tool call against Sigil guards and writes a
+// handlePreToolUse evaluates the tool call against agento11y guards and writes a
 // PreToolUse deny envelope to stdout when the call is blocked, or an
 // allow+updatedInput envelope when a Transform rule redacted the tool
-// arguments. A plain allow stays silent on stdout. All Sigil transport,
+// arguments. A plain allow stays silent on stdout. All agento11y transport,
 // credential, fail-open/closed, and local-endpoint placeholder behaviour
 // lives in the shared guard helper so this stays in lockstep with the codex
 // and copilot agents.

--- a/plugins/agento11y/internal/agents/claudecode/launch.go
+++ b/plugins/agento11y/internal/agents/claudecode/launch.go
@@ -47,8 +47,8 @@ var (
 // exec's claude with the supplied args. When localEnv is non-nil, the
 // child receives local-mode SIGIL_ENDPOINT, SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT
 // and placeholder auth values so it talks to the in-process receiver
-// instead of Sigil Cloud.
-func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, sigilVersion string) error {
+// instead of Grafana Cloud.
+func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, binaryVersion string) error {
 	return launcher.Bootstrap(ctx, launcher.BootstrapSpec{
 		BinName:     "claude",
 		PluginLabel: PluginName,
@@ -74,14 +74,14 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 					"          claude plugin update %s@%s\n",
 				marketplaceAlias, PluginName, marketplaceAlias)
 		},
-		UpdateTTL:    updateCheckTTL,
-		SigilVersion: sigilVersion,
+		UpdateTTL:     updateCheckTTL,
+		BinaryVersion: binaryVersion,
 	})
 }
 
 // Status reports whether the sigil-cc plugin is installed for the current
 // working directory. It reuses the read-only pluginInstalled probe and never
-// installs, updates, or writes update-check state — `sigil doctor` relies on
+// installs, updates, or writes update-check state — `agento11y doctor` relies on
 // this. installed_plugins.json carries no version, so version is always empty
 // (best-effort).
 func Status(_ context.Context) (installed bool, version string, err error) {
@@ -128,7 +128,7 @@ type installedPluginEntry struct {
 // is active in every session, while `project` and `local` only apply when
 // the session's cwd matches the recorded `projectPath`. Treating any
 // `sigil-cc@*` key as installed would let a per-directory install for an
-// unrelated project suppress bootstrap here, leaving Sigil hooks inactive.
+// unrelated project suppress bootstrap here, leaving agento11y hooks inactive.
 // Marketplace alias is intentionally ignored so a foreign alias is not
 // reinstalled on top of.
 func pluginInstalled() (bool, error) {

--- a/plugins/agento11y/internal/agents/claudecode/launch_test.go
+++ b/plugins/agento11y/internal/agents/claudecode/launch_test.go
@@ -519,7 +519,7 @@ func TestLaunch_RefreshesInstalledPlugin(t *testing.T) {
 	if !strings.Contains(stderr.String(), "refreshing "+PluginName+" in claude") {
 		t.Fatalf("stderr missing refresh message: %q", stderr.String())
 	}
-	stamp := filepath.Join(state, "sigil", "update-checks", PluginName+".stamp")
+	stamp := filepath.Join(state, "agento11y", "update-checks", PluginName+".stamp")
 	if _, err := os.Stat(stamp); err != nil {
 		t.Fatalf("expected update stamp: %v", err)
 	}

--- a/plugins/agento11y/internal/agents/claudecode/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/claudecode/mapper/mapper.go
@@ -146,7 +146,7 @@ type agentCall struct {
 // Claude Code subagents do not produce their own transcript lines — the only
 // evidence of their execution is the Agent tool_use (spawn) and the matching
 // tool_result (output). Process synthesises a generation for each completed
-// Agent call so that the Sigil dependency graph can display the DAG.
+// Agent call so that the agento11y dependency graph can display the DAG.
 func Process(lines []transcript.Line, st *state.Session, opts Options, r *redact.Redactor) []agento11y.Generation {
 	var (
 		gens []agento11y.Generation

--- a/plugins/agento11y/internal/agents/claudecode/state/state.go
+++ b/plugins/agento11y/internal/agents/claudecode/state/state.go
@@ -14,12 +14,12 @@ type Session struct {
 	Offset int64  `json:"offset"`
 	Title  string `json:"title,omitempty"`
 	// Model is captured from SessionStart so tool hooks can include model context
-	// when calling Sigil guards (PreToolUse events do not include model fields).
+	// when calling agento11y guards (PreToolUse events do not include model fields).
 	Model string `json:"model,omitempty"`
 }
 
 func dir() string {
-	return filepath.Join(xdg.StateRoot("sigil"), "claude-code")
+	return filepath.Join(xdg.AppStateRoot(), "claude-code")
 }
 
 // SanitizeSessionID delegates to xdg.SafeComponent so session-ID-derived

--- a/plugins/agento11y/internal/agents/codex/config/config.go
+++ b/plugins/agento11y/internal/agents/codex/config/config.go
@@ -28,7 +28,7 @@ func FilePath() string {
 	return dotenv.FilePath()
 }
 
-// ApplyEnv loads the shared sigil dotenv config and writes keys whose OS
+// ApplyEnv loads the shared agento11y dotenv config and writes keys whose OS
 // env value is empty.
 func ApplyEnv(logger *log.Logger) map[string]string {
 	return dotenv.ApplyEnv(logger)

--- a/plugins/agento11y/internal/agents/codex/fragment/fragment.go
+++ b/plugins/agento11y/internal/agents/codex/fragment/fragment.go
@@ -64,7 +64,7 @@ type Fragment struct {
 	CompletedAt          string       `json:"completedAt,omitempty"`
 	LastEventAt          string       `json:"lastEventAt,omitempty"`
 	// PendingRetry is set when a Stop attempt completed the read-side work
-	// (mapping, etc.) but failed to export via Sigil. The next Stop event for
+	// (mapping, etc.) but failed to export via agento11y. The next Stop event for
 	// the same session sweeps these and tries again so a transient ingest
 	// hiccup doesn't silently lose a turn after the 24h cleanup.
 	PendingRetry bool `json:"pendingRetry,omitempty"`

--- a/plugins/agento11y/internal/agents/codex/fragment/paths.go
+++ b/plugins/agento11y/internal/agents/codex/fragment/paths.go
@@ -6,14 +6,12 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/xdg"
 )
 
-const appName = "sigil"
-
-// agentSubdir scopes codex fragments under the shared sigil state root so
-// agent-side data layouts can evolve independently.
+// agentSubdir scopes codex fragments under the shared agento11y state root
+// so agent-side data layouts can evolve independently.
 const agentSubdir = "codex"
 
 func StateRoot() string {
-	return filepath.Join(xdg.StateRoot(appName), agentSubdir)
+	return filepath.Join(xdg.AppStateRoot(), agentSubdir)
 }
 
 func TurnsDir(sessionID string) string {

--- a/plugins/agento11y/internal/agents/codex/fragment/paths_test.go
+++ b/plugins/agento11y/internal/agents/codex/fragment/paths_test.go
@@ -12,7 +12,7 @@ func TestFragmentFilePathSanitizesIDs(t *testing.T) {
 	if strings.Contains(got, "..") {
 		t.Fatalf("path was not sanitized: %q", got)
 	}
-	wantSuffix := filepath.Join(filepath.Join("sigil", "codex"), "turns", safeComponent("../session"), safeComponent("turn/one")+".json")
+	wantSuffix := filepath.Join(filepath.Join("agento11y", "codex"), "turns", safeComponent("../session"), safeComponent("turn/one")+".json")
 	if !strings.HasSuffix(got, wantSuffix) {
 		t.Fatalf("path = %q, want suffix %q", got, wantSuffix)
 	}
@@ -24,7 +24,7 @@ func TestSessionFilePathSanitizesID(t *testing.T) {
 	if strings.Contains(got, "..") {
 		t.Fatalf("path was not sanitized: %q", got)
 	}
-	wantSuffix := filepath.Join(filepath.Join("sigil", "codex"), "sessions", safeComponent("../session")+".json")
+	wantSuffix := filepath.Join(filepath.Join("agento11y", "codex"), "sessions", safeComponent("../session")+".json")
 	if !strings.HasSuffix(got, wantSuffix) {
 		t.Fatalf("path = %q, want suffix %q", got, wantSuffix)
 	}
@@ -36,7 +36,7 @@ func TestSubagentLinkFilePathSanitizesID(t *testing.T) {
 	if strings.Contains(got, "..") {
 		t.Fatalf("path was not sanitized: %q", got)
 	}
-	wantSuffix := filepath.Join(filepath.Join("sigil", "codex"), "subagents", safeComponent("../session")+".json")
+	wantSuffix := filepath.Join(filepath.Join("agento11y", "codex"), "subagents", safeComponent("../session")+".json")
 	if !strings.HasSuffix(got, wantSuffix) {
 		t.Fatalf("path = %q, want suffix %q", got, wantSuffix)
 	}

--- a/plugins/agento11y/internal/agents/codex/hook.go
+++ b/plugins/agento11y/internal/agents/codex/hook.go
@@ -1,5 +1,5 @@
 // Package codex implements the Codex agent adapter for the consolidated
-// sigil binary. The dispatcher in cmd/sigil routes `sigil codex hook` here.
+// agento11y binary. The dispatcher in cmd/agento11y routes `agento11y codex hook` here.
 package codex
 
 import (

--- a/plugins/agento11y/internal/agents/codex/hook/handlers.go
+++ b/plugins/agento11y/internal/agents/codex/hook/handlers.go
@@ -15,10 +15,10 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/codex/fragment"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/codex/mapper"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/guard"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/emit"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/otel"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/redact"
-	"github.com/grafana/agento11y/plugins/agento11y/internal/sigilemit"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/useragent"
 )
 
@@ -78,7 +78,7 @@ func UserPromptSubmit(p Payload, cfg config.Config, logger *log.Logger) {
 	}
 }
 
-// PreToolUse evaluates a Codex tool call against Sigil guard rules. It writes
+// PreToolUse evaluates a Codex tool call against agento11y guard rules. It writes
 // a PreToolUse deny envelope to stdout when the call must be blocked, an
 // allow+updatedInput envelope when a Transform rule redacted the tool
 // arguments, and stays silent on a plain allow. Transport setup, credential
@@ -212,7 +212,7 @@ func Stop(p Payload, cfg config.Config, logger *log.Logger) {
 	tokenSnapshot := tokenSnapshotForStop(p, frag, logger)
 	ctx, cancel := context.WithTimeout(context.Background(), stopExportTimeout)
 	defer cancel()
-	providers := sigilemit.SetupOTel(ctx, p.SessionID, logger)
+	providers := emit.SetupOTel(ctx, p.SessionID, logger)
 	if providers != nil {
 		defer func() {
 			if err := providers.Shutdown(ctx); err != nil {
@@ -239,7 +239,7 @@ func Stop(p Payload, cfg config.Config, logger *log.Logger) {
 	sweptPaths := sweepPendingRetries(ctx, client, cfg, p.SessionID, p.TurnID, logger)
 
 	if err := client.Flush(ctx); err != nil {
-		logger.Printf("stop: sigil flush: %v", err)
+		logger.Printf("stop: agento11y flush: %v", err)
 		markPendingRetry(p.SessionID, p.TurnID, logger)
 		return
 	}
@@ -465,11 +465,11 @@ func applySessionDefaults(f *fragment.Fragment, s *fragment.Session) {
 	}
 }
 
-// buildClient constructs the Sigil client with the shared HTTP/basic-auth
+// buildClient constructs the agento11y client with the shared HTTP/basic-auth
 // export defaults. Endpoint, tenant ID, and token come from the SDK's automatic
 // SIGIL_* env resolution, matching copilot and cursor.
 func buildClient(cfg config.Config, providers *otel.Providers, logger *log.Logger) *agento11y.Client {
-	return sigilemit.NewClient(sigilemit.ClientOptions{
+	return emit.NewClient(emit.ClientOptions{
 		InstrumentationName: otelInstrumentationName,
 		ContentCapture:      cfg.ContentCapture,
 		Logger:              logger,
@@ -480,7 +480,7 @@ func buildClient(cfg config.Config, providers *otel.Providers, logger *log.Logge
 
 func emitGeneration(ctx context.Context, client *agento11y.Client, frag *fragment.Fragment, mapped mapper.Mapped, mode agento11y.ContentCaptureMode, logger *log.Logger) error {
 	// codex never promotes a call error, so callErr is always nil here.
-	return sigilemit.Record(ctx, client, mapped.Start, mapped.Generation, nil, func(genCtx context.Context) {
+	return emit.Record(ctx, client, mapped.Start, mapped.Generation, nil, func(genCtx context.Context) {
 		emitToolSpans(genCtx, client, frag, mapped.Generation, mode, logger)
 	})
 }
@@ -495,7 +495,7 @@ func emitToolSpans(ctx context.Context, client *agento11y.Client, frag *fragment
 		if t.ToolName == "" {
 			continue
 		}
-		startedAt, completedAt := sigilemit.ToolSpanWindow(t.CompletedAt, t.DurationMs, gen.CompletedAt)
+		startedAt, completedAt := emit.ToolSpanWindow(t.CompletedAt, t.DurationMs, gen.CompletedAt)
 		_, rec := client.StartToolExecution(ctx, agento11y.ToolExecutionStart{
 			ToolName:        t.ToolName,
 			ToolCallID:      t.ToolUseID,
@@ -515,7 +515,7 @@ func emitToolSpans(ctx context.Context, client *agento11y.Client, frag *fragment
 			end.Result = redactSpanContent(red, t.ToolResponse)
 		}
 		if t.Status == "error" {
-			rec.SetExecError(sigilemit.ToolError(t.ErrorMessage))
+			rec.SetExecError(emit.ToolError(t.ErrorMessage))
 		}
 		rec.SetResult(end)
 		rec.End()

--- a/plugins/agento11y/internal/agents/codex/launch.go
+++ b/plugins/agento11y/internal/agents/codex/launch.go
@@ -44,8 +44,8 @@ var (
 // and then exec's codex with the supplied args. When localEnv is non-nil,
 // the child receives local-mode SIGIL_ENDPOINT,
 // SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT and placeholder auth values so it talks
-// to the in-process receiver instead of Sigil Cloud.
-func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, sigilVersion string) error {
+// to the in-process receiver instead of Grafana Cloud.
+func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, binaryVersion string) error {
 	return launcher.Bootstrap(ctx, launcher.BootstrapSpec{
 		BinName:     "codex",
 		PluginLabel: PluginName,
@@ -82,14 +82,14 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 					"          codex plugin add %s@%s\n",
 				PluginName, marketplaceAlias)
 		},
-		UpdateTTL:    updateCheckTTL,
-		SigilVersion: sigilVersion,
+		UpdateTTL:     updateCheckTTL,
+		BinaryVersion: binaryVersion,
 	})
 }
 
 // Status reports whether the sigil-codex plugin is installed and enabled. It
 // reuses the read-only `codex plugin list` probe and never installs, updates,
-// or writes update-check state — `sigil doctor` relies on this. codex's plugin
+// or writes update-check state — `agento11y doctor` relies on this. codex's plugin
 // list does not expose a version, so version is always empty (best-effort).
 func Status(ctx context.Context) (installed bool, version string, err error) {
 	bin, err := lookPath("codex")

--- a/plugins/agento11y/internal/agents/codex/launch_test.go
+++ b/plugins/agento11y/internal/agents/codex/launch_test.go
@@ -446,7 +446,7 @@ func TestLaunch_RefreshesInstalledPlugin(t *testing.T) {
 	if !strings.Contains(stderr.String(), "refreshing "+PluginName+" in codex") {
 		t.Fatalf("stderr missing refresh message: %q", stderr.String())
 	}
-	stamp := filepath.Join(state, "sigil", "update-checks", PluginName+".stamp")
+	stamp := filepath.Join(state, "agento11y", "update-checks", PluginName+".stamp")
 	if _, err := os.Stat(stamp); err != nil {
 		t.Fatalf("expected update stamp: %v", err)
 	}

--- a/plugins/agento11y/internal/agents/copilot/fragment/paths.go
+++ b/plugins/agento11y/internal/agents/copilot/fragment/paths.go
@@ -6,14 +6,12 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/xdg"
 )
 
-const appName = "sigil"
-
-// agentSubdir scopes copilot fragments under the shared sigil state root so
-// agent-side data layouts can evolve independently.
+// agentSubdir scopes copilot fragments under the shared agento11y state root
+// so agent-side data layouts can evolve independently.
 const agentSubdir = "copilot"
 
 func StateRoot() string {
-	return filepath.Join(xdg.StateRoot(appName), agentSubdir)
+	return filepath.Join(xdg.AppStateRoot(), agentSubdir)
 }
 
 func TurnsDir(sessionID string) string {

--- a/plugins/agento11y/internal/agents/copilot/hook.go
+++ b/plugins/agento11y/internal/agents/copilot/hook.go
@@ -1,6 +1,6 @@
 // Package copilot implements the GitHub Copilot CLI agent adapter for the
-// consolidated sigil binary. The dispatcher in cmd/sigil routes
-// `sigil copilot hook` here.
+// consolidated agento11y binary. The dispatcher in cmd/agento11y routes
+// `agento11y copilot hook` here.
 package copilot
 
 import (

--- a/plugins/agento11y/internal/agents/copilot/hook/handlers.go
+++ b/plugins/agento11y/internal/agents/copilot/hook/handlers.go
@@ -18,10 +18,10 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/copilot/mapper"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/copilot/transcript"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/guard"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/emit"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/otel"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/redact"
-	"github.com/grafana/agento11y/plugins/agento11y/internal/sigilemit"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/timeutil"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/useragent"
 )
@@ -127,7 +127,7 @@ func PreToolUse(ctx context.Context, stdout io.Writer, p Payload, cfg config.Con
 		// fragment. Copilot's preToolUse payload doesn't carry model, but
 		// once enrichFromTranscript has run for a prior turn we may have
 		// it cached. The guard helper falls back to "unknown" when blank,
-		// which keeps the request well-formed for Sigil.
+		// which keeps the request well-formed for agento11y.
 		var provider, modelName string
 		if session := fragment.LoadSessionTolerant(sessionID, logger); session != nil && session.ActiveTurnID != "" {
 			if frag := loadFragment(sessionID, session.ActiveTurnID, logger); frag != nil {
@@ -138,7 +138,7 @@ func PreToolUse(ctx context.Context, stdout io.Writer, p Payload, cfg config.Con
 		res := guard.EvaluateToolCall(ctx, cfg.Guards, guard.ToolCallInput{
 			AgentName: mapper.AgentName,
 			ToolName:  p.ToolName(),
-			// Copilot delivers tool args as a JSON-encoded string; the Sigil
+			// Copilot delivers tool args as a JSON-encoded string; the agento11y
 			// server only transforms tool-call input that is a JSON object, so
 			// decode the wrapper before evaluating or redaction never happens.
 			ToolInputJSON: decodeStringEncodedToolInput(toolArgs),
@@ -208,7 +208,7 @@ const surfaceCopilotCLI = "copilot-cli"
 
 // decodeStringEncodedToolInput unwraps tool arguments that the Copilot CLI
 // delivers as a JSON-encoded string (e.g. `"{\"command\":\"…\"}"`) into the
-// underlying JSON object. The Sigil server only applies Transform rules to
+// underlying JSON object. The agento11y server only applies Transform rules to
 // tool-call input that is a JSON object: given a JSON string it returns no
 // transform at all, so Copilot's arguments are never redacted without this.
 // Returns raw unchanged when it is already an object, or a string that does
@@ -259,7 +259,7 @@ func writeDeny(stdout io.Writer, reason string) {
 		return
 	}
 	if strings.TrimSpace(reason) == "" {
-		reason = "tool call denied by Sigil guard"
+		reason = "tool call denied by agento11y guard"
 	}
 	_ = json.NewEncoder(stdout).Encode(preToolUseDeny{
 		PermissionDecision:       "deny",
@@ -481,7 +481,7 @@ func Stop(p Payload, cfg config.Config, logger *log.Logger) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), stopExportTimeout)
 	defer cancel()
-	providers := sigilemit.SetupOTel(ctx, sessionID, logger)
+	providers := emit.SetupOTel(ctx, sessionID, logger)
 	if providers != nil {
 		defer func() {
 			if err := providers.Shutdown(ctx); err != nil {
@@ -514,7 +514,7 @@ func Stop(p Payload, cfg config.Config, logger *log.Logger) {
 		return
 	}
 	if err := client.Flush(ctx); err != nil {
-		logger.Printf("stop: sigil flush: %v", err)
+		logger.Printf("stop: agento11y flush: %v", err)
 		return
 	}
 	if providers != nil {
@@ -705,11 +705,11 @@ func shouldPreferTranscriptSnapshot(current transcript.Snapshot, haveCurrent boo
 	return false
 }
 
-// buildClient constructs the Sigil client. copilot leaves endpoint, tenant ID,
+// buildClient constructs the agento11y client. copilot leaves endpoint, tenant ID,
 // and token to the SDK's automatic SIGIL_* env resolution, so it only needs the
 // shared HTTP/basic-auth export defaults plus the OTel wiring.
 func buildClient(cfg config.Config, providers *otel.Providers, logger *log.Logger) *agento11y.Client {
-	return sigilemit.NewClient(sigilemit.ClientOptions{
+	return emit.NewClient(emit.ClientOptions{
 		InstrumentationName: otelInstrumentationName,
 		ContentCapture:      cfg.ContentCapture,
 		Logger:              logger,
@@ -719,7 +719,7 @@ func buildClient(cfg config.Config, providers *otel.Providers, logger *log.Logge
 }
 
 func emitGeneration(ctx context.Context, client *agento11y.Client, frag *fragment.Fragment, mapped mapper.Mapped, logger *log.Logger) error {
-	return sigilemit.Record(ctx, client, mapped.Start, mapped.Generation, mapped.CallError, func(genCtx context.Context) {
+	return emit.Record(ctx, client, mapped.Start, mapped.Generation, mapped.CallError, func(genCtx context.Context) {
 		emitToolSpans(genCtx, client, frag, mapped.Generation, logger)
 	})
 }
@@ -788,7 +788,7 @@ func mappedContentCapture(gen agento11y.Generation) agento11y.ContentCaptureMode
 	return agento11y.ContentCaptureModeMetadataOnly
 }
 
-// toolSpanWindow differs from sigilemit.ToolSpanWindow: copilot records a
+// toolSpanWindow differs from emit.ToolSpanWindow: copilot records a
 // per-tool StartedAt at preToolUse, but the historical behavior gives a
 // reported DurationMs precedence when it is present. StartedAt is only used
 // when DurationMs is missing.
@@ -805,7 +805,7 @@ func toolSpanWindow(t fragment.ToolRecord, genCompletedAt time.Time) (startedAt,
 }
 
 // toolErrorOr trims whitespace before the empty check, unlike
-// sigilemit.ToolError, so a whitespace-only tool error message collapses to the
+// emit.ToolError, so a whitespace-only tool error message collapses to the
 // generic sentinel. Kept local to preserve that behavior.
 func toolErrorOr(msg string) error {
 	if strings.TrimSpace(msg) == "" {

--- a/plugins/agento11y/internal/agents/copilot/launch.go
+++ b/plugins/agento11y/internal/agents/copilot/launch.go
@@ -28,9 +28,15 @@ const (
 
 	// userHooksFileName is the file the launcher writes into the user-level
 	// Copilot hooks directory. This single file drives capture for both
-	// Copilot Chat in VS Code and the copilot CLI. A dedicated, sigil-owned
-	// filename lets us overwrite it without touching hand-authored hooks.
-	userHooksFileName = "sigil.json"
+	// Copilot Chat in VS Code and the copilot CLI. A dedicated,
+	// agento11y-owned filename lets us overwrite it without touching
+	// hand-authored hooks.
+	userHooksFileName = "agento11y.json"
+
+	// legacyUserHooksFileName is the pre-rename hooks file. It is removed
+	// when the new file is written so Copilot does not run both and fire
+	// every hook twice.
+	legacyUserHooksFileName = "sigil.json"
 )
 
 // Test seams.
@@ -47,7 +53,7 @@ var (
 // version, and exec's copilot with the supplied args. When localEnv is
 // non-nil, the child receives local-mode SIGIL_ENDPOINT,
 // SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT and placeholder auth values so it talks
-// to the in-process receiver instead of Sigil Cloud.
+// to the in-process receiver instead of Grafana Cloud.
 //
 // The launcher deliberately does NOT register the copilot plugin: the CLI
 // loads hooks from the plugin store AND ~/.copilot/hooks and runs both, so a
@@ -142,8 +148,8 @@ func copilotHooksDir() (string, error) {
 	return filepath.Join(home, ".copilot", "hooks"), nil
 }
 
-// writeUserHooks renders the Sigil hook config and writes it to
-// <copilot-hooks-dir>/sigil.json. The write is atomic (temp file + rename)
+// writeUserHooks renders the agento11y hook config and writes it to
+// <copilot-hooks-dir>/agento11y.json. The write is atomic (temp file + rename)
 // and idempotent: when the on-disk content already matches, it is left
 // untouched and wrote is false. It returns the target path so callers can
 // report where the hooks landed.
@@ -155,8 +161,8 @@ func writeUserHooks() (path string, wrote bool, err error) {
 	path = filepath.Join(dir, userHooksFileName)
 	// The hook command points at this executable's own path (a hardcoded
 	// binary name would break `go install` users who only have agento11y or
-	// only sigil on PATH). The whole file is sigil-owned and rewritten when
-	// content differs, so entries written by an older version with the
+	// only sigil on PATH). The whole file is agento11y-owned and rewritten
+	// when content differs, so entries written by an older version with the
 	// literal `sigil copilot hook` command are replaced in place.
 	command, err := execpath.HookCommand("copilot hook")
 	if err != nil {
@@ -167,6 +173,7 @@ func writeUserHooks() (path string, wrote bool, err error) {
 		return "", false, err
 	}
 	if existing, readErr := os.ReadFile(path); readErr == nil && bytes.Equal(existing, content) {
+		removeLegacyUserHooks(dir)
 		return path, false, nil
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -196,7 +203,17 @@ func writeUserHooks() (path string, wrote bool, err error) {
 		cleanup()
 		return "", false, fmt.Errorf("rename to %s: %w", path, err)
 	}
+	removeLegacyUserHooks(dir)
 	return path, true, nil
+}
+
+// removeLegacyUserHooks deletes the pre-rename hooks file: Copilot runs every
+// file in the hooks directory, so leaving sigil.json next to agento11y.json
+// would double-fire each hook. Called only after the new file is confirmed on
+// disk, so a failed write never leaves the install with no hooks file at all.
+// Best-effort; a leftover file surfaces as duplicate capture, not breakage.
+func removeLegacyUserHooks(dir string) {
+	_ = os.Remove(filepath.Join(dir, legacyUserHooksFileName))
 }
 
 // hookCommand mirrors a single command-hook entry in a Copilot hooks file.
@@ -278,12 +295,12 @@ func defaultPluginList(ctx context.Context, bin string) ([]byte, error) {
 	return launcher.Output(ctx, bin, "plugin", "list")
 }
 
-// Status reports whether Sigil capture is configured for Copilot. Capture is
+// Status reports whether agento11y capture is configured for Copilot. Capture is
 // driven by the shared user-level hooks file the launcher writes (see
 // writeUserHooks), NOT by a plugin — the launcher deliberately avoids
 // registering a plugin and removes any legacy one — so doctor must check for
 // that file. The hooks file has no version, so version is always empty. It
-// never installs, updates, or removes anything — `sigil doctor` relies on this.
+// never installs, updates, or removes anything — `agento11y doctor` relies on this.
 func Status(_ context.Context) (installed bool, version string, err error) {
 	installed, err = HooksInstalled()
 	return installed, "", err
@@ -292,19 +309,22 @@ func Status(_ context.Context) (installed bool, version string, err error) {
 // HooksInstalled reports whether the shared user-level Copilot hooks file that
 // drives capture is present. Read-only, and reuses copilotHooksDir so it
 // honors COPILOT_HOME exactly like the launcher's write path. The CLI need not
-// be on PATH: Copilot Chat in VS Code reads this file without it.
+// be on PATH: Copilot Chat in VS Code reads this file without it. The legacy
+// sigil.json also counts: it keeps capturing until the next launch replaces
+// it, and doctor must not report a working install as broken.
 func HooksInstalled() (bool, error) {
 	dir, err := copilotHooksDir()
 	if err != nil {
 		return false, err
 	}
-	if _, err := os.Stat(filepath.Join(dir, userHooksFileName)); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return false, nil
+	for _, name := range []string{userHooksFileName, legacyUserHooksFileName} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			return true, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return false, err
 		}
-		return false, err
 	}
-	return true, nil
+	return false, nil
 }
 
 // pluginInstalled reports whether `sigil-copilot` is registered in copilot's

--- a/plugins/agento11y/internal/agents/copilot/launch_test.go
+++ b/plugins/agento11y/internal/agents/copilot/launch_test.go
@@ -334,10 +334,10 @@ func nopLogger() *log.Logger {
 	return log.New(io.Discard, "", 0)
 }
 
-// userHooksPath returns the sigil.json path under the test's COPILOT_HOME.
+// userHooksPath returns the agento11y.json path under the test's COPILOT_HOME.
 func userHooksPath(t *testing.T) string {
 	t.Helper()
-	return filepath.Join(os.Getenv("COPILOT_HOME"), "hooks", "sigil.json")
+	return filepath.Join(os.Getenv("COPILOT_HOME"), "hooks", "agento11y.json")
 }
 
 // withExecutable pins the executable path hook commands are built from, so
@@ -437,9 +437,9 @@ func TestLaunch_InstallsAndKeepsUserHooks(t *testing.T) {
 	assertValidUserHooks(t, userHooksPath(t), "/usr/local/bin/agento11y copilot hook")
 }
 
-// A hooks file written by an older version with the literal `sigil copilot
-// hook` command must be replaced with the executable-path form, in place and
-// without duplicate entries (the whole file is sigil-owned).
+// A legacy sigil.json hooks file written by an older version must be removed
+// and replaced by agento11y.json with the executable-path command, so Copilot
+// does not run both files and fire every hook twice.
 func TestLaunch_ReplacesLegacyLiteralHookCommand(t *testing.T) {
 	t.Setenv("COPILOT_HOME", t.TempDir())
 	withExecutable(t, "/usr/local/bin/agento11y")
@@ -457,6 +457,46 @@ func TestLaunch_ReplacesLegacyLiteralHookCommand(t *testing.T) {
 	data, err := os.ReadFile(userHooksPath(t))
 	require.NoError(t, err)
 	assert.NotContains(t, string(data), `"sigil copilot hook"`)
+	assert.NoFileExists(t, filepath.Join(dir, "sigil.json"), "legacy hooks file must be removed")
+}
+
+// A failed write must leave the legacy sigil.json in place: it is the only
+// hooks file the install has, and removing it before the new file exists
+// would silently stop capture.
+func TestWriteUserHooks_KeepsLegacyFileOnFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COPILOT_HOME", home)
+	dir := filepath.Join(home, "hooks")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	legacyPath := filepath.Join(dir, "sigil.json")
+	require.NoError(t, os.WriteFile(legacyPath, []byte("{}"), 0o644))
+
+	prev := execpath.Executable
+	t.Cleanup(func() { execpath.Executable = prev })
+	execpath.Executable = func() (string, error) { return "", errors.New("boom") }
+
+	_, _, err := writeUserHooks()
+	require.Error(t, err)
+	assert.FileExists(t, legacyPath, "legacy hooks file must survive a failed write")
+}
+
+// When agento11y.json is already up to date the write is skipped, but a
+// leftover legacy sigil.json must still be removed or every hook fires twice.
+func TestWriteUserHooks_RemovesLegacyFileWhenUpToDate(t *testing.T) {
+	t.Setenv("COPILOT_HOME", t.TempDir())
+	withExecutable(t, "/usr/local/bin/agento11y")
+
+	_, wrote, err := writeUserHooks()
+	require.NoError(t, err)
+	require.True(t, wrote)
+
+	legacyPath := filepath.Join(os.Getenv("COPILOT_HOME"), "hooks", "sigil.json")
+	require.NoError(t, os.WriteFile(legacyPath, []byte("{}"), 0o644))
+
+	_, wrote, err = writeUserHooks()
+	require.NoError(t, err)
+	require.False(t, wrote, "content already matches, no rewrite expected")
+	assert.NoFileExists(t, legacyPath)
 }
 
 // The generated hook command must shell-quote executable paths a shell would
@@ -509,20 +549,21 @@ func TestParsePluginListStatus_Version(t *testing.T) {
 func TestStatus(t *testing.T) {
 	tests := []struct {
 		name          string
-		writeHooks    bool
+		hooksFile     string
 		wantInstalled bool
 	}{
-		{name: "hooks file present", writeHooks: true, wantInstalled: true},
-		{name: "hooks file absent", writeHooks: false, wantInstalled: false},
+		{name: "hooks file present", hooksFile: "agento11y.json", wantInstalled: true},
+		{name: "legacy hooks file present", hooksFile: "sigil.json", wantInstalled: true},
+		{name: "hooks file absent", wantInstalled: false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			home := t.TempDir()
 			t.Setenv("COPILOT_HOME", home)
-			if tc.writeHooks {
+			if tc.hooksFile != "" {
 				dir := filepath.Join(home, "hooks")
 				require.NoError(t, os.MkdirAll(dir, 0o755))
-				require.NoError(t, os.WriteFile(filepath.Join(dir, "sigil.json"), []byte("{}"), 0o644))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, tc.hooksFile), []byte("{}"), 0o644))
 			}
 
 			installed, version, err := Status(context.Background())

--- a/plugins/agento11y/internal/agents/cursor/config/config.go
+++ b/plugins/agento11y/internal/agents/cursor/config/config.go
@@ -1,5 +1,5 @@
 // Package config resolves the cursor adapter's runtime knobs from OS env
-// and the shared sigil dotenv file.
+// and the shared agento11y dotenv file.
 //
 // Cursor launches hooks under a stripped environment (shell rc files do not
 // run), so the dotenv is the reliable place to put credentials. ApplyEnv
@@ -37,7 +37,7 @@ func FilePath() string {
 	return dotenv.FilePath()
 }
 
-// ApplyEnv loads the shared sigil dotenv config and writes keys whose OS
+// ApplyEnv loads the shared agento11y dotenv config and writes keys whose OS
 // env value is empty.
 func ApplyEnv(logger *log.Logger) map[string]string {
 	return dotenv.ApplyEnv(logger)

--- a/plugins/agento11y/internal/agents/cursor/fragment/paths.go
+++ b/plugins/agento11y/internal/agents/cursor/fragment/paths.go
@@ -8,17 +8,16 @@ import (
 )
 
 const (
-	appName        = "sigil"
 	agentSubdir    = "cursor"
 	fragmentPrefix = "gen-"
 	fragmentSuffix = ".json"
 )
 
 // StateRoot returns the root state directory for the cursor adapter.
-// Scoped under the shared sigil state root so agent data layouts can evolve
-// independently.
+// Scoped under the shared agento11y state root so agent data layouts can
+// evolve independently.
 func StateRoot() string {
-	return filepath.Join(xdg.StateRoot(appName), agentSubdir)
+	return filepath.Join(xdg.AppStateRoot(), agentSubdir)
 }
 
 // ConversationDir is the directory holding all fragments for one conversation.

--- a/plugins/agento11y/internal/agents/cursor/fragment/paths_test.go
+++ b/plugins/agento11y/internal/agents/cursor/fragment/paths_test.go
@@ -8,15 +8,15 @@ import (
 
 func TestStateRoot_XDGOverride(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", "/custom/state")
-	if got := StateRoot(); got != "/custom/state/sigil/cursor" {
-		t.Errorf("got %q want /custom/state/sigil/cursor", got)
+	if got := StateRoot(); got != "/custom/state/agento11y/cursor" {
+		t.Errorf("got %q want /custom/state/agento11y/cursor", got)
 	}
 }
 
 func TestFragmentFilePath_Layout(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", "/x")
 	got := FragmentFilePath("conv-uuid", "gen-id")
-	prefix := filepath.Join("/x", "sigil", "cursor") + "/"
+	prefix := filepath.Join("/x", "agento11y", "cursor") + "/"
 	if !strings.HasPrefix(got, prefix) || !strings.HasSuffix(got, ".json") {
 		t.Errorf("got %q, want path under %s ending in .json", got, prefix)
 	}
@@ -25,7 +25,7 @@ func TestFragmentFilePath_Layout(t *testing.T) {
 func TestFragmentFilePath_PathTraversalNeutralised(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", "/x")
 	got := FragmentFilePath("../../etc/passwd", "gen")
-	stateRoot := filepath.Join("/x", "sigil", "cursor")
+	stateRoot := filepath.Join("/x", "agento11y", "cursor")
 	rel, err := filepath.Rel(stateRoot, got)
 	if err != nil {
 		t.Fatalf("Rel error: %v", err)
@@ -61,7 +61,7 @@ func TestSessionFilePath_LooksRight(t *testing.T) {
 	if !strings.HasSuffix(got, "/session.json") {
 		t.Errorf("got %q does not end with /session.json", got)
 	}
-	if !strings.Contains(got, "/sigil/cursor/conv1") {
-		t.Errorf("got %q missing /sigil/cursor/conv1 segment", got)
+	if !strings.Contains(got, "/agento11y/cursor/conv1") {
+		t.Errorf("got %q missing /agento11y/cursor/conv1 segment", got)
 	}
 }

--- a/plugins/agento11y/internal/agents/cursor/hook.go
+++ b/plugins/agento11y/internal/agents/cursor/hook.go
@@ -1,5 +1,5 @@
 // Package cursor implements the Cursor agent adapter for the consolidated
-// sigil binary. The dispatcher in cmd/sigil routes `sigil cursor hook` here.
+// agento11y binary. The dispatcher in cmd/agento11y routes `agento11y cursor hook` here.
 //
 // Cursor expects a permissive JSON response on pre-execution events when the
 // plugin wants to allow the action — a missing or non-JSON stdout on those

--- a/plugins/agento11y/internal/agents/cursor/hook/emit.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/emit.go
@@ -9,8 +9,8 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/config"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/fragment"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/mapper"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/emit"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/otel"
-	"github.com/grafana/agento11y/plugins/agento11y/internal/sigilemit"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/useragent"
 )
 
@@ -27,17 +27,17 @@ const otelInstrumentationName = "agento11y.cursor"
 // natively; the plugin only provides convenience auth-header injection from
 // SIGIL_AUTH_*.
 func setupOTelIfConfigured(ctx context.Context, instanceID string, logger *log.Logger) *otel.Providers {
-	return sigilemit.SetupOTel(ctx, instanceID, logger)
+	return emit.SetupOTel(ctx, instanceID, logger)
 }
 
-// buildClient constructs the Sigil client. Endpoint, tenant ID, and token
+// buildClient constructs the agento11y client. Endpoint, tenant ID, and token
 // come from the SDK's automatic SIGIL_* env resolution (config.ApplyEnv has
 // already injected dotenv values into the OS env). The plugin only owns the
 // pieces the SDK can't infer: HTTP protocol, the `/api/v1/generations:export`
 // path suffix, basic-auth mode, and the OTel tracer/meter wiring. cursor does
 // not pass a logger, so the SDK client stays silent.
 func buildClient(cfg config.Config, providers *otel.Providers) *agento11y.Client {
-	return sigilemit.NewClient(sigilemit.ClientOptions{
+	return emit.NewClient(emit.ClientOptions{
 		InstrumentationName: otelInstrumentationName,
 		ContentCapture:      cfg.ContentCapture,
 		Providers:           providers,
@@ -52,7 +52,7 @@ func buildClient(cfg config.Config, providers *otel.Providers) *agento11y.Client
 // Flushing/shutdown is the caller's responsibility — sessionEnd batches
 // multiple generations through one client.
 func emitGeneration(ctx context.Context, client *agento11y.Client, frag *fragment.Fragment, mapped mapper.Mapped, logger *log.Logger) error {
-	return sigilemit.Record(ctx, client, mapped.Start, mapped.Generation, mapped.CallError, func(genCtx context.Context) {
+	return emit.Record(ctx, client, mapped.Start, mapped.Generation, mapped.CallError, func(genCtx context.Context) {
 		emitToolSpans(genCtx, client, frag, mapped.Generation, logger)
 	})
 }
@@ -73,7 +73,7 @@ func emitToolSpans(ctx context.Context, client *agento11y.Client, frag *fragment
 		if t.ToolName == "" {
 			continue
 		}
-		startedAt, completedAt := sigilemit.ToolSpanWindow(t.CompletedAt, t.DurationMs, gen.CompletedAt)
+		startedAt, completedAt := emit.ToolSpanWindow(t.CompletedAt, t.DurationMs, gen.CompletedAt)
 		_, toolRec := client.StartToolExecution(ctx, agento11y.ToolExecutionStart{
 			ToolName:        t.ToolName,
 			ToolCallID:      t.ToolUseID,
@@ -94,7 +94,7 @@ func emitToolSpans(ctx context.Context, client *agento11y.Client, frag *fragment
 			end.Result = string(t.ToolOutput)
 		}
 		if t.Status == "error" {
-			toolRec.SetExecError(sigilemit.ToolError(t.ErrorMessage))
+			toolRec.SetExecError(emit.ToolError(t.ErrorMessage))
 		}
 		toolRec.SetResult(end)
 		toolRec.End()

--- a/plugins/agento11y/internal/agents/cursor/hook/emit_test.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/emit_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/config"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/fragment"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/mapper"
-	"github.com/grafana/agento11y/plugins/agento11y/internal/sigilemit"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/emit"
 )
 
-// buildClient passes the cursor User-Agent token to sigilemit; this guards the
+// buildClient passes the cursor User-Agent token to the emit package; this guards the
 // wiring end to end through a real export request.
 func TestEmitGenerationSendsCursorUserAgent(t *testing.T) {
 	var gotUA string
@@ -76,14 +76,14 @@ func TestEmitGenerationSendsCursorUserAgent(t *testing.T) {
 // Two tool records with different completedAt timestamps must produce
 // distinct, non-overlapping windows so the UI can show the real
 // CALL→TOOL→CALL→TOOL interleaving instead of stacking spans at the end.
-// The window math lives in sigilemit.ToolSpanWindow; this guards cursor's
+// The window math lives in emit.ToolSpanWindow; this guards cursor's
 // reliance on it.
 func TestToolSpanWindow_PreservesInterleaving(t *testing.T) {
 	genEnd := time.Date(2026, 4, 28, 12, 0, 30, 0, time.UTC)
 	dur := func(ms float64) *float64 { return &ms }
 
-	_, firstEnd := sigilemit.ToolSpanWindow("2026-04-28T12:00:05Z", dur(1000), genEnd)
-	secondStart, _ := sigilemit.ToolSpanWindow("2026-04-28T12:00:20Z", dur(1000), genEnd)
+	_, firstEnd := emit.ToolSpanWindow("2026-04-28T12:00:05Z", dur(1000), genEnd)
+	secondStart, _ := emit.ToolSpanWindow("2026-04-28T12:00:20Z", dur(1000), genEnd)
 	if !firstEnd.Before(secondStart) {
 		t.Errorf("first.completedAt (%s) should precede second.startedAt (%s)", firstEnd, secondStart)
 	}

--- a/plugins/agento11y/internal/agents/cursor/hook/pretooluse.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/pretooluse.go
@@ -22,10 +22,10 @@ type preToolUseResponse struct {
 	UpdatedInput json.RawMessage `json:"updated_input,omitempty"`
 }
 
-// PreToolUse evaluates the tool call against Sigil guards and writes exactly
+// PreToolUse evaluates the tool call against agento11y guards and writes exactly
 // one preToolUse response to stdout: deny with the policy reason when
 // blocked, allow with updated_input when a Transform rule redacted the
-// arguments, plain allow otherwise (including guards disabled). All Sigil
+// arguments, plain allow otherwise (including guards disabled). All agento11y
 // transport, credential, fail-open/closed, and transform-extraction
 // behaviour lives in the shared guard helper so this stays in lockstep with
 // the other agents.

--- a/plugins/agento11y/internal/agents/cursor/hook/stop.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/stop.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/mapper"
 )
 
-// Stop maps the accumulated fragment to a Sigil Generation and emits it.
+// Stop maps the accumulated fragment to an agento11y Generation and emits it.
 // On flush failure the fragment is preserved on disk (with the stop payload's
 // status/error stamped onto it) so the sessionEnd sweeper can retry rather
 // than silently drop the data.

--- a/plugins/agento11y/internal/agents/cursor/install/install.go
+++ b/plugins/agento11y/internal/agents/cursor/install/install.go
@@ -1,17 +1,17 @@
-// Package install wires Sigil's Cursor hook into the user-level
+// Package install wires agento11y's Cursor hook into the user-level
 // ~/.cursor/hooks.json from the command line.
 //
 // Cursor is a GUI app with no exec launch point, so unlike the other agents
-// there is no `sigil cursor` launcher to bootstrap capture on first run.
-// `sigil cursor install` writes the hook entry directly, the same way
-// `sigil copilot` writes Copilot's hooks file.
+// there is no `agento11y cursor` launcher to bootstrap capture on first run.
+// `agento11y cursor install` writes the hook entry directly, the same way
+// `agento11y copilot` writes Copilot's hooks file.
 //
 // hooks.json is shared with other tools (the live file holds superconductor
-// and superset entries alongside Sigil's), so install MERGES into it rather
+// and superset entries alongside agento11y's), so install MERGES into it rather
 // than overwriting: it keeps unknown top-level keys and every event entry it
 // does not own, and replaces its own entry in place so re-runs do not
 // double-fire. The legacy /add-plugin run.sh entry is recognised on a
-// best-effort basis (see isSigilHook), so users should not run direct install
+// best-effort basis (see isOursHook), so users should not run direct install
 // and /add-plugin together.
 package install
 
@@ -30,9 +30,9 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/execpath"
 )
 
-// cursorEvents are the hook events Sigil wires, matching the set shipped in
+// cursorEvents are the hook events agento11y wires, matching the set shipped in
 // plugins/cursor/hooks/hooks.json. The Cursor dispatcher infers the event
-// from hook_event_name in the payload, so the same `sigil cursor hook`
+// from hook_event_name in the payload, so the same `agento11y cursor hook`
 // command serves all nine.
 var cursorEvents = []string{
 	"sessionStart",
@@ -50,16 +50,16 @@ var cursorEvents = []string{
 var userHomeDir = os.UserHomeDir
 
 // hookEntry is a single Cursor hook command entry. Cursor entries may carry
-// other fields, but Sigil only ever writes the command; extra fields on other
+// other fields, but agento11y only ever writes the command; extra fields on other
 // tools' entries are preserved as raw JSON, not through this type.
 type hookEntry struct {
 	Command string `json:"command"`
 }
 
-// Run wires `sigil cursor hook` into ~/.cursor/hooks.json for all eight
+// Run wires `agento11y cursor hook` into ~/.cursor/hooks.json for all eight
 // Cursor hook events, creating the file and parent directory when absent. It
 // merges into an existing file: unknown top-level keys and other tools'
-// entries are preserved, and a recognised pre-existing Sigil entry (a previous
+// entries are preserved, and a recognised pre-existing agento11y entry (a previous
 // install, or a legacy run.sh entry when detectable) is replaced in place to
 // avoid double-firing capture. The write is atomic and idempotent — when the
 // result already matches what is on disk, the file is left untouched.
@@ -84,7 +84,7 @@ func Run(stdout, _ io.Writer, logger *log.Logger) error {
 		return fmt.Errorf("encode cursor hook entry: %w", err)
 	}
 	for _, event := range cursorEvents {
-		doc.hooks[event] = upsertSigil(doc.hooks[event], entry)
+		doc.hooks[event] = upsertOurs(doc.hooks[event], entry)
 	}
 
 	wrote, err := writeHooks(path, doc)
@@ -99,9 +99,9 @@ func Run(stdout, _ io.Writer, logger *log.Logger) error {
 	return nil
 }
 
-// Uninstall removes Sigil's hook entries from ~/.cursor/hooks.json, leaving
+// Uninstall removes agento11y's hook entries from ~/.cursor/hooks.json, leaving
 // other tools' entries and unknown keys intact. Event arrays left empty are
-// dropped. The write is atomic and idempotent — a file with no Sigil entries
+// dropped. The write is atomic and idempotent — a file with no agento11y entries
 // is left untouched, and a missing file is a no-op (no file is created).
 func Uninstall(stdout, _ io.Writer, logger *log.Logger) error {
 	path, err := cursorHooksPath()
@@ -120,7 +120,7 @@ func Uninstall(stdout, _ io.Writer, logger *log.Logger) error {
 		return err
 	}
 	for event, entries := range doc.hooks {
-		kept := removeSigil(entries)
+		kept := removeOurs(entries)
 		if len(kept) == 0 {
 			delete(doc.hooks, event)
 			continue
@@ -159,10 +159,10 @@ func cursorHooksPath() (string, error) {
 // registers (plugins/cursor/hooks/hooks.json). Cursor usually expands
 // CURSOR_PLUGIN_ROOT when it copies the entry into the user-level hooks.json,
 // leaving the repo's plugins/cursor/scripts/run.sh tail in the path, but it may
-// also keep the literal, so isSigilHook checks for both.
+// also keep the literal, so isOursHook checks for both.
 const legacyRunShLiteral = "${CURSOR_PLUGIN_ROOT}/scripts/run.sh"
 
-// isSigilHook reports whether an existing entry's command is one of ours, so
+// isOursHook reports whether an existing entry's command is one of ours, so
 // re-runs and the legacy /add-plugin run.sh wiring update in place instead of
 // double-firing. It matches any command of the form `<binary> cursor hook`
 // where the binary's basename is agento11y or sigil, plus the legacy run.sh
@@ -170,7 +170,7 @@ const legacyRunShLiteral = "${CURSOR_PLUGIN_ROOT}/scripts/run.sh"
 // the expanded form Cursor writes once it resolves CURSOR_PLUGIN_ROOT. Legacy
 // detection is best-effort: an expanded path that no longer carries the
 // plugins/cursor segment is not recognised.
-func isSigilHook(cmd string) bool {
+func isOursHook(cmd string) bool {
 	c := strings.TrimSpace(cmd)
 	if strings.Contains(c, legacyRunShLiteral) ||
 		strings.Contains(c, filepath.Join("plugins", "cursor", "scripts", "run.sh")) {
@@ -185,14 +185,14 @@ func isSigilHook(cmd string) bool {
 	return bin != "" && (base == "agento11y" || base == "sigil")
 }
 
-// upsertSigil replaces the first Sigil-owned entry in entries with cmd (in
+// upsertOurs replaces the first agento11y-owned entry in entries with cmd (in
 // place, so other tools' entries keep their order) and drops any further
-// Sigil entries; when none is present it appends cmd.
-func upsertSigil(entries []json.RawMessage, cmd json.RawMessage) []json.RawMessage {
+// agento11y entries; when none is present it appends cmd.
+func upsertOurs(entries []json.RawMessage, cmd json.RawMessage) []json.RawMessage {
 	out := make([]json.RawMessage, 0, len(entries)+1)
 	inserted := false
 	for _, raw := range entries {
-		if isSigilHook(commandOf(raw)) {
+		if isOursHook(commandOf(raw)) {
 			if !inserted {
 				out = append(out, cmd)
 				inserted = true
@@ -207,11 +207,11 @@ func upsertSigil(entries []json.RawMessage, cmd json.RawMessage) []json.RawMessa
 	return out
 }
 
-// removeSigil returns entries with every Sigil-owned entry dropped.
-func removeSigil(entries []json.RawMessage) []json.RawMessage {
+// removeOurs returns entries with every agento11y-owned entry dropped.
+func removeOurs(entries []json.RawMessage) []json.RawMessage {
 	out := make([]json.RawMessage, 0, len(entries))
 	for _, raw := range entries {
-		if isSigilHook(commandOf(raw)) {
+		if isOursHook(commandOf(raw)) {
 			continue
 		}
 		out = append(out, raw)
@@ -221,7 +221,7 @@ func removeSigil(entries []json.RawMessage) []json.RawMessage {
 
 // commandOf extracts the "command" string from a hook entry, returning ""
 // when the entry is not an object or has no command (such entries are never
-// treated as Sigil's).
+// treated as agento11y's).
 func commandOf(raw json.RawMessage) string {
 	var e hookEntry
 	if err := json.Unmarshal(raw, &e); err != nil {

--- a/plugins/agento11y/internal/agents/cursor/install/install_test.go
+++ b/plugins/agento11y/internal/agents/cursor/install/install_test.go
@@ -397,7 +397,7 @@ func TestIsSigilHook(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.cmd, func(t *testing.T) {
-			assert.Equal(t, tc.want, isSigilHook(tc.cmd))
+			assert.Equal(t, tc.want, isOursHook(tc.cmd))
 		})
 	}
 }
@@ -455,7 +455,7 @@ func readEntries(t *testing.T, path string) map[string][]string {
 func sigilCommands(cmds []string) []string {
 	var out []string
 	for _, c := range cmds {
-		if isSigilHook(c) {
+		if isOursHook(c) {
 			out = append(out, c)
 		}
 	}
@@ -465,7 +465,7 @@ func sigilCommands(cmds []string) []string {
 func nonSigilCommands(cmds []string) []string {
 	var out []string
 	for _, c := range cmds {
-		if !isSigilHook(c) {
+		if !isOursHook(c) {
 			out = append(out, c)
 		}
 	}

--- a/plugins/agento11y/internal/agents/cursor/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/cursor/mapper/mapper.go
@@ -1,5 +1,5 @@
 // Package mapper turns the on-disk Fragment + Session + StopPayload into a
-// Sigil Generation suitable for emission via the Go SDK. Unlike the
+// agento11y Generation suitable for emission via the Go SDK. Unlike the
 // claudecode mapper there is no redactor — content passes through verbatim
 // in `full` mode.
 package mapper
@@ -63,7 +63,7 @@ type Mapped struct {
 	CallError  error
 }
 
-// MapFragment builds the Sigil Generation for a finished turn.
+// MapFragment builds the agento11y Generation for a finished turn.
 func MapFragment(in Inputs) Mapped {
 	frag := in.Fragment
 	now := in.Now
@@ -174,7 +174,7 @@ func MapFragment(in Inputs) Mapped {
 	return mapped
 }
 
-// resolveStopStatus normalizes Cursor's stop.status to the subset Sigil uses.
+// resolveStopStatus normalizes Cursor's stop.status to the subset agento11y uses.
 // Unknown values (and missing payloads) → "completed" so we never silently
 // drop a turn.
 func resolveStopStatus(stop *StopInput) StopStatus {
@@ -261,7 +261,7 @@ func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode) (
 		})
 	}
 
-	// Tool calls + results, interleaved per Sigil's convention:
+	// Tool calls + results, interleaved per agento11y's convention:
 	// assistant → tool_call, then a tool message → tool_result.
 	for i := range frag.Tools {
 		t := &frag.Tools[i]

--- a/plugins/agento11y/internal/agents/guard/toolcall.go
+++ b/plugins/agento11y/internal/agents/guard/toolcall.go
@@ -1,4 +1,4 @@
-// Package guard evaluates tool calls against Sigil guard policy and
+// Package guard evaluates tool calls against agento11y guard policy and
 // returns a host-neutral result. Callers translate the result into their
 // own stdout response shape; convenience writers are provided for shapes
 // shared by more than one host agent (e.g. WriteHookSpecificOutputDeny
@@ -42,7 +42,7 @@ func formatPolicyDeny(toolName, reason string) string {
 // be evaluated (missing credentials or transport failure). It explicitly
 // distinguishes the infrastructure failure from a policy decision.
 func formatEvalFailure(toolName, detail string) string {
-	msg := fmt.Sprintf("Sigil could not evaluate the Grafana AI Observability guard for the %q tool call, so it was blocked as a safety measure.", toolName)
+	msg := fmt.Sprintf("agento11y could not evaluate the Grafana AI Observability guard for the %q tool call, so it was blocked as a safety measure.", toolName)
 	if d := strings.TrimSpace(detail); d != "" {
 		msg += " Details: " + d
 	}
@@ -50,7 +50,7 @@ func formatEvalFailure(toolName, detail string) string {
 }
 
 // ToolCallInput is the host-neutral set of fields needed to evaluate a
-// tool call against Sigil guards.
+// tool call against agento11y guards.
 type ToolCallInput struct {
 	// AgentName identifies the host agent (e.g. "copilot", "claude-code").
 	AgentName string
@@ -71,13 +71,13 @@ type ToolCallInput struct {
 type Result struct {
 	// Action is allow or deny.
 	Action agento11y.HookAction
-	// Reason is the deny reason from Sigil or the host-friendly description
+	// Reason is the deny reason from agento11y or the host-friendly description
 	// of a fail-closed transport/config error.
 	Reason string
 	// RuleID identifies the rule that produced a deny verdict, when known.
 	RuleID string
 	// UpdatedInputJSON carries the transformed (redacted) tool arguments
-	// when Sigil returned a usable Transform verdict for this tool call.
+	// when agento11y returned a usable Transform verdict for this tool call.
 	// Nil when no transform applies; always nil on deny.
 	UpdatedInputJSON json.RawMessage
 }
@@ -87,7 +87,7 @@ func (r Result) Blocked() bool {
 	return r.Action == agento11y.HookActionDeny
 }
 
-// EvaluateToolCall asks Sigil whether the tool call should proceed. It
+// EvaluateToolCall asks agento11y whether the tool call should proceed. It
 // reads the branded ENDPOINT / AUTH_TENANT_ID / AUTH_TOKEN families (either
 // spelling) from the process environment and honours envconfig.GuardsConfig
 // for the enabled/timeout/fail-open knobs. Callers are expected to gate this
@@ -97,16 +97,16 @@ func (r Result) Blocked() bool {
 //   - guards disabled or tool name empty: returns allow.
 //   - credentials missing and fail-open: returns allow.
 //   - credentials missing and fail-closed: returns deny with a credentials reason.
-//   - Sigil returns allow: returns allow. When the response carries a
+//   - agento11y returns allow: returns allow. When the response carries a
 //     transformed_input with redacted arguments for this tool call,
 //     UpdatedInputJSON is set so the host can rewrite the tool input.
-//   - Sigil returns deny: returns deny with the rule reason.
+//   - agento11y returns deny: returns deny with the rule reason.
 //   - transport error and fail-open: returns allow (matches SDK behaviour).
 //   - transport error and fail-closed: returns deny with a transport reason.
 //
 // A local-mode endpoint (http://127.0.0.1, http://localhost, http://[::1])
 // uses stand-in placeholder credentials for the credential check so that
-// running against a local Sigil instance does not require real cloud creds.
+// running against a local agento11y instance does not require real cloud creds.
 func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCallInput, logger *log.Logger) Result {
 	if !cfg.Enabled {
 		return Result{Action: agento11y.HookActionAllow}
@@ -314,7 +314,7 @@ func extractToolCallTransform(resp *agento11y.HookEvaluateResponse, toolCallID s
 }
 
 // unwrapProtoJSONBytes unwraps transform arguments that arrived as a JSON
-// string. The Sigil server marshals the proto `bytes input_json` field with
+// string. The agento11y server marshals the proto `bytes input_json` field with
 // encoding/json, which base64-encodes it; other emitters may put plain JSON
 // text in the string. Values that are not JSON strings pass through
 // unchanged. Same purpose as the JS SDK's maybeDecodeGoProtoJSONBytes, but
@@ -351,7 +351,7 @@ func WriteHookSpecificOutputDeny(stdout io.Writer, reason string) {
 		return
 	}
 	if strings.TrimSpace(reason) == "" {
-		reason = "tool call denied by Sigil guard"
+		reason = "tool call denied by agento11y guard"
 	}
 	_ = json.NewEncoder(stdout).Encode(hookSpecificOutputDeny{
 		HookSpecificOutput: hookSpecificOutputDenyBody{

--- a/plugins/agento11y/internal/agents/guard/toolcall_test.go
+++ b/plugins/agento11y/internal/agents/guard/toolcall_test.go
@@ -276,12 +276,12 @@ func TestWriteHookSpecificOutputDeny(t *testing.T) {
 		{
 			name:    "blank reason falls back to generic",
 			reason:  "",
-			wantSub: []string{`"permissionDecisionReason":"tool call denied by Sigil guard"`},
+			wantSub: []string{`"permissionDecisionReason":"tool call denied by agento11y guard"`},
 		},
 		{
 			name:    "whitespace reason falls back to generic",
 			reason:  "   ",
-			wantSub: []string{`"permissionDecisionReason":"tool call denied by Sigil guard"`},
+			wantSub: []string{`"permissionDecisionReason":"tool call denied by agento11y guard"`},
 		},
 	}
 	for _, tt := range tests {

--- a/plugins/agento11y/internal/agents/opencode/launch.go
+++ b/plugins/agento11y/internal/agents/opencode/launch.go
@@ -1,5 +1,5 @@
 // Package opencode implements the opencode launcher adapter for the
-// consolidated sigil binary. The dispatcher in cmd/sigil routes
+// consolidated agento11y binary. The dispatcher in cmd/agento11y routes
 // `sigil opencode [-- args...]` here.
 //
 // Unlike the hook adapters, this adapter owns the user's terminal: it
@@ -66,8 +66,8 @@ var configFileNames = []string{"opencode.json", "opencode.jsonc"}
 // once if it is not), and then exec's opencode with the supplied args.
 // When localEnv is non-nil, the child receives local-mode SIGIL_ENDPOINT,
 // SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT and placeholder auth values so it
-// talks to the in-process receiver instead of Sigil Cloud.
-func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, sigilVersion string) error {
+// talks to the in-process receiver instead of Grafana Cloud.
+func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, binaryVersion string) error {
 	// The periodic refresh installs PluginSource. When the config still
 	// references the legacy package name, that would register the plugin a
 	// second time under the new name, so skip the refresh for legacy installs
@@ -101,8 +101,8 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 		UpdateRecoveryHint: func(w io.Writer) {
 			fmt.Fprintf(w, "          opencode plugin %s --global --force\n", PluginSource)
 		},
-		UpdateTTL:    updateCheckTTL,
-		SigilVersion: sigilVersion,
+		UpdateTTL:     updateCheckTTL,
+		BinaryVersion: binaryVersion,
 	})
 }
 

--- a/plugins/agento11y/internal/agents/opencode/launch_test.go
+++ b/plugins/agento11y/internal/agents/opencode/launch_test.go
@@ -418,7 +418,7 @@ func TestLaunch_RefreshesInstalledPluginWhenUpdateDue(t *testing.T) {
 	if !strings.Contains(stderr.String(), "refreshing "+PluginSource+" in opencode") {
 		t.Fatalf("stderr missing refresh message: %q", stderr.String())
 	}
-	stamp := filepath.Join(state, "sigil", "update-checks", PluginName+".stamp")
+	stamp := filepath.Join(state, "agento11y", "update-checks", PluginName+".stamp")
 	if _, err := os.Stat(stamp); err != nil {
 		t.Fatalf("expected update stamp: %v", err)
 	}

--- a/plugins/agento11y/internal/agents/pi/launch.go
+++ b/plugins/agento11y/internal/agents/pi/launch.go
@@ -1,5 +1,5 @@
 // Package pi implements the pi launcher adapter for the consolidated sigil
-// binary. The dispatcher in cmd/sigil routes `sigil pi [-- args...]` here.
+// binary. The dispatcher in cmd/agento11y routes `sigil pi [-- args...]` here.
 //
 // Unlike the hook adapters, this adapter owns the user's terminal: it
 // bootstraps the @grafana/agento11y-pi extension in pi's settings file on first
@@ -54,7 +54,7 @@ var (
 // once if it is not), and then exec's pi with the supplied args. When
 // localEnv is non-nil, the child receives local-mode SIGIL_ENDPOINT,
 // SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT and placeholder auth values so it
-// talks to the in-process receiver instead of Sigil Cloud. The trailing
+// talks to the in-process receiver instead of Grafana Cloud. The trailing
 // string arg is the sigil build version; the pi adapter does not run
 // auto-update checks (pi's own installer handles upgrades) so it is
 // accepted to satisfy the launcher signature and ignored.

--- a/plugins/agento11y/internal/agents/pi/launch_test.go
+++ b/plugins/agento11y/internal/agents/pi/launch_test.go
@@ -113,7 +113,7 @@ func TestLaunch_RunsInstallWhenPackageMissing(t *testing.T) {
 
 // A failed `pi install` should not block the user's session. The launcher
 // must print the failure and a manual-retry hint on stderr, then still exec
-// pi so the workflow keeps moving (just without Sigil capture).
+// pi so the workflow keeps moving (just without agento11y capture).
 func TestLaunch_InstallFailureContinuesToExec(t *testing.T) {
 	dir := t.TempDir()
 	writeSettings(t, dir, `{"packages":[]}`)

--- a/plugins/agento11y/internal/agents/vibe/hook/handlers.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/handlers.go
@@ -36,7 +36,7 @@ const otelInstrumentationName = "agento11y.vibe"
 // replays on the next fire.
 //
 // The handler never returns an error. Every failure is logged and
-// swallowed so a Sigil outage cannot interrupt the user's vibe session.
+// swallowed so an agento11y outage cannot interrupt the user's vibe session.
 // The caller (vibe.Hook) writes nothing to stdout and always exits 0.
 func PostAgentTurn(ctx context.Context, p Payload, logger *log.Logger) {
 	if p.SessionID == "" {
@@ -66,7 +66,7 @@ func PostAgentTurn(ctx context.Context, p Payload, logger *log.Logger) {
 	}
 
 	// Resolve credentials. A user running the hook directly without
-	// Sigil creds (e.g. during testing) shouldn't have their session
+	// agento11y creds (e.g. during testing) shouldn't have their session
 	// crash; we just log and bail without advancing the offset.
 	envconfig.ApplyLocalAuthPlaceholders()
 	endpoint := envconfig.Getenv("ENDPOINT")

--- a/plugins/agento11y/internal/agents/vibe/hook/tool.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/tool.go
@@ -20,7 +20,7 @@ import (
 // handler; the SDK's own timeout (cfg.TimeoutMs) does the real work.
 const guardEvalBuffer = 500 * time.Millisecond
 
-// BeforeTool evaluates a tool call against Sigil guard policy before vibe
+// BeforeTool evaluates a tool call against agento11y guard policy before vibe
 // runs it. With guards disabled (the default) it is a pass-through that
 // writes nothing, which vibe reads as "allow". A deny writes vibe's
 // structured deny response so the call never runs; a redaction transform
@@ -129,7 +129,7 @@ func writeBeforeToolDeny(stdout io.Writer, reason string) {
 		return
 	}
 	if strings.TrimSpace(reason) == "" {
-		reason = "tool call denied by Sigil guard"
+		reason = "tool call denied by agento11y guard"
 	}
 	_ = json.NewEncoder(stdout).Encode(beforeToolDeny{Decision: "deny", Reason: reason})
 }

--- a/plugins/agento11y/internal/agents/vibe/hook/tool_test.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/tool_test.go
@@ -91,7 +91,7 @@ func TestBeforeToolWriters(t *testing.T) {
 	t.Run("deny falls back to a default reason", func(t *testing.T) {
 		var out bytes.Buffer
 		writeBeforeToolDeny(&out, "  ")
-		if !strings.Contains(out.String(), "denied by Sigil guard") {
+		if !strings.Contains(out.String(), "denied by agento11y guard") {
 			t.Errorf("missing default reason: %s", out.String())
 		}
 	})

--- a/plugins/agento11y/internal/agents/vibe/install.go
+++ b/plugins/agento11y/internal/agents/vibe/install.go
@@ -30,24 +30,32 @@ type hooksFileEntry struct {
 	Match   string `toml:"match,omitempty"`
 }
 
-// desiredHooks returns the sigil-owned [[hooks]] entries vibe runs. Vibe
+// desiredHooks returns the agento11y-owned [[hooks]] entries vibe runs. Vibe
 // defines exactly three event types and we wire all three: post_agent_turn
 // for the per-turn generation export, before_tool for guard enforcement, and
 // after_tool for per-tool span timing. before_tool/after_tool take a "*"
 // matcher (every tool); match is forbidden on post_agent_turn. Each entry is
-// upserted by its unique name so repeated installs are idempotent, old
-// entries written with the literal `sigil vibe hook` command are updated in
-// place, and hand-authored hooks in the same file are preserved.
+// upserted by its unique name so repeated installs are idempotent and
+// hand-authored hooks in the same file are preserved.
 //
 // command is the shell command vibe runs for each fire, built from this
 // executable's own path so hooks keep working for users who installed only
 // the agento11y (or only the legacy sigil) command.
 func desiredHooks(command string) []hooksFileEntry {
 	return []hooksFileEntry{
-		{Name: "sigil", Type: "post_agent_turn", Command: command, Timeout: hookTimeoutSec},
-		{Name: "sigil-before-tool", Type: "before_tool", Command: command, Timeout: hookTimeoutSec, Match: "*"},
-		{Name: "sigil-after-tool", Type: "after_tool", Command: command, Timeout: hookTimeoutSec, Match: "*"},
+		{Name: "agento11y", Type: "post_agent_turn", Command: command, Timeout: hookTimeoutSec},
+		{Name: "agento11y-before-tool", Type: "before_tool", Command: command, Timeout: hookTimeoutSec, Match: "*"},
+		{Name: "agento11y-after-tool", Type: "after_tool", Command: command, Timeout: hookTimeoutSec, Match: "*"},
 	}
+}
+
+// legacyHookNames are the pre-rename entry names. They are dropped on merge
+// so an install refreshed from an older version does not fire every hook
+// twice (once per name).
+var legacyHookNames = map[string]bool{
+	"sigil":             true,
+	"sigil-before-tool": true,
+	"sigil-after-tool":  true,
 }
 
 // vibeHome returns the root vibe config directory. It honors VIBE_HOME
@@ -73,7 +81,7 @@ func hooksFilePath() (string, error) {
 	return filepath.Join(home, "hooks.toml"), nil
 }
 
-// ensureHookInstalled merges a sigil-owned post_agent_turn entry into
+// ensureHookInstalled merges an agento11y-owned post_agent_turn entry into
 // vibe's hooks.toml. The write is atomic (temp file + rename), idempotent
 // (skipped when the entry already matches), and preserves any
 // hand-authored hooks that share the same file.
@@ -134,8 +142,9 @@ func ensureHookInstalled() (string, bool, error) {
 	return path, true, nil
 }
 
-// mergeHooksTOML decodes the existing hooks.toml bytes, upserts every
-// sigil-owned entry in desiredHooks (each by its unique name), and
+// mergeHooksTOML decodes the existing hooks.toml bytes, drops entries with
+// legacy pre-rename names, upserts every agento11y-owned entry in
+// desiredHooks (each by its unique name), and
 // re-encodes. If the result matches the input byte-for-byte after
 // re-encoding, changed is false and the original bytes are returned so we
 // never rewrite a file just to reformat whitespace.
@@ -152,6 +161,7 @@ func mergeHooksTOML(existing []byte, command string) (out []byte, changed bool, 
 	}
 
 	hooks, _ := doc["hooks"].([]any)
+	hooks = dropLegacyHooks(hooks)
 	for _, desired := range desiredHooks(command) {
 		hooks = upsertHook(hooks, desired)
 	}
@@ -193,4 +203,18 @@ func upsertHook(hooks []any, desired hooksFileEntry) []any {
 		}
 	}
 	return append(hooks, fields)
+}
+
+// dropLegacyHooks removes entries whose name matches a pre-rename hook name.
+func dropLegacyHooks(hooks []any) []any {
+	out := hooks[:0]
+	for _, raw := range hooks {
+		if entry, ok := raw.(map[string]any); ok {
+			if name, _ := entry["name"].(string); legacyHookNames[name] {
+				continue
+			}
+		}
+		out = append(out, raw)
+	}
+	return out
 }

--- a/plugins/agento11y/internal/agents/vibe/install_test.go
+++ b/plugins/agento11y/internal/agents/vibe/install_test.go
@@ -41,9 +41,9 @@ func TestEnsureHookInstalled_FreshWrite(t *testing.T) {
 		t.Fatalf("hooks len = %d, want 3 (post_agent_turn + before_tool + after_tool)", len(hooks))
 	}
 	byName := hooksByName(hooks)
-	post, ok := byName["sigil"]
+	post, ok := byName["agento11y"]
 	if !ok {
-		t.Fatalf("missing sigil post_agent_turn entry; got %v", keys(byName))
+		t.Fatalf("missing agento11y post_agent_turn entry; got %v", keys(byName))
 	}
 	if post["type"] != "post_agent_turn" {
 		t.Errorf("type = %v, want post_agent_turn", post["type"])
@@ -51,7 +51,7 @@ func TestEnsureHookInstalled_FreshWrite(t *testing.T) {
 	if post["command"] != wantCommand {
 		t.Errorf("command = %v, want %q", post["command"], wantCommand)
 	}
-	for name, wantType := range map[string]string{"sigil-before-tool": "before_tool", "sigil-after-tool": "after_tool"} {
+	for name, wantType := range map[string]string{"agento11y-before-tool": "before_tool", "agento11y-after-tool": "after_tool"} {
 		entry, ok := byName[name]
 		if !ok {
 			t.Fatalf("missing %q entry; got %v", name, keys(byName))
@@ -92,7 +92,7 @@ func TestEnsureHookInstalled_PreservesExistingHook(t *testing.T) {
 	t.Setenv("VIBE_HOME", dir)
 
 	// A user already has a hand-authored hook in hooks.toml. Install
-	// must keep it and add (not replace) the sigil entry.
+	// must keep it and add (not replace) the agento11y entry.
 	pre := `[[hooks]]
 name = "user-custom"
 type = "after_tool"
@@ -109,10 +109,10 @@ timeout = 5
 	got := readTOML(t, path)
 	hooks, _ := got["hooks"].([]any)
 	if len(hooks) != 4 {
-		t.Fatalf("hooks len = %d, want 4 (user-custom + 3 sigil)", len(hooks))
+		t.Fatalf("hooks len = %d, want 4 (user-custom + 3 agento11y)", len(hooks))
 	}
 	byName := hooksByName(hooks)
-	for _, want := range []string{"user-custom", "sigil", "sigil-before-tool", "sigil-after-tool"} {
+	for _, want := range []string{"user-custom", "agento11y", "agento11y-before-tool", "agento11y-after-tool"} {
 		if _, ok := byName[want]; !ok {
 			t.Errorf("missing hook %q; got %v", want, keys(byName))
 		}
@@ -123,10 +123,10 @@ timeout = 5
 	}
 }
 
-func TestEnsureHookInstalled_UpdatesStaleSigilEntry(t *testing.T) {
-	// A previous sigil version wrote the literal `sigil vibe hook` command.
-	// The merge must overwrite our own entry (matched by name) with the
-	// executable-path command without producing a duplicate.
+func TestEnsureHookInstalled_ReplacesLegacySigilEntries(t *testing.T) {
+	// A previous version wrote hooks under the pre-rename sigil names. The
+	// merge must drop those entries and install the agento11y-named ones so
+	// vibe does not fire every hook twice.
 	dir := t.TempDir()
 	t.Setenv("VIBE_HOME", dir)
 	withExecutable(t, "/usr/local/bin/agento11y")
@@ -136,6 +136,13 @@ name = "sigil"
 type = "post_agent_turn"
 command = "sigil vibe hook"
 timeout = 10
+
+[[hooks]]
+name = "sigil-before-tool"
+type = "before_tool"
+command = "sigil vibe hook"
+timeout = 10
+match = "*"
 `
 	path := filepath.Join(dir, "hooks.toml")
 	if err := os.WriteFile(path, []byte(pre), 0o644); err != nil {
@@ -147,11 +154,16 @@ timeout = 10
 	got := readTOML(t, path)
 	hooks, _ := got["hooks"].([]any)
 	if len(hooks) != 3 {
-		t.Fatalf("hooks len = %d, want 3 (stale sigil entry updated in place + before/after appended)", len(hooks))
+		t.Fatalf("hooks len = %d, want 3 (legacy entries dropped, agento11y entries installed)", len(hooks))
 	}
 	byName := hooksByName(hooks)
-	if byName["sigil"]["command"] != wantCommand {
-		t.Errorf("command = %v, want refreshed %q", byName["sigil"]["command"], wantCommand)
+	for _, legacy := range []string{"sigil", "sigil-before-tool", "sigil-after-tool"} {
+		if _, ok := byName[legacy]; ok {
+			t.Errorf("legacy hook %q still present; got %v", legacy, keys(byName))
+		}
+	}
+	if byName["agento11y"]["command"] != wantCommand {
+		t.Errorf("command = %v, want refreshed %q", byName["agento11y"]["command"], wantCommand)
 	}
 }
 
@@ -168,8 +180,8 @@ func TestEnsureHookInstalled_QuotesExecutablePath(t *testing.T) {
 	hooks, _ := got["hooks"].([]any)
 	byName := hooksByName(hooks)
 	want := "'/Users/Jane Doe/bin/agento11y' vibe hook"
-	if byName["sigil"]["command"] != want {
-		t.Errorf("command = %v, want %q", byName["sigil"]["command"], want)
+	if byName["agento11y"]["command"] != want {
+		t.Errorf("command = %v, want %q", byName["agento11y"]["command"], want)
 	}
 }
 

--- a/plugins/agento11y/internal/agents/vibe/launch.go
+++ b/plugins/agento11y/internal/agents/vibe/launch.go
@@ -17,7 +17,7 @@ var (
 	execFn   = syscall.Exec
 )
 
-// Launch resolves the `vibe` binary on PATH, ensures the sigil-owned
+// Launch resolves the `vibe` binary on PATH, ensures the agento11y-owned
 // post_agent_turn hook is installed into vibe's hooks.toml, and then
 // execs vibe with the supplied args.
 //
@@ -29,7 +29,7 @@ var (
 //
 // When localEnv is non-nil, the child receives local-mode SIGIL_ENDPOINT,
 // SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT and placeholder auth values so it
-// talks to the in-process receiver instead of Sigil Cloud.
+// talks to the in-process receiver instead of Grafana Cloud.
 func Launch(_ context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, _ string) error {
 	bin, err := lookPath("vibe")
 	if err != nil {
@@ -48,7 +48,7 @@ func Launch(_ context.Context, args []string, localEnv *local.LaunchEnv, _ io.Re
 
 // installHook upserts the sigil entry into hooks.toml and reports the
 // outcome on stderr. Failures are logged but never block the launch:
-// the user explicitly asked to run vibe, so a Sigil install hiccup must
+// the user explicitly asked to run vibe, so an agento11y install hiccup must
 // not gate that.
 func installHook(stderr io.Writer, logger *log.Logger) {
 	path, wrote, err := ensureHookInstalled()

--- a/plugins/agento11y/internal/agents/vibe/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/vibe/mapper/mapper.go
@@ -1,8 +1,8 @@
 // Package mapper turns a slice of new vibe transcript lines plus the
-// session's meta.json into a agento11y.Generation ready for export.
+// session's meta.json into an agento11y.Generation ready for export.
 //
 // One mapper.Map call produces exactly one generation per
-// post_agent_turn hook fire. Sigil groups records by ConversationID
+// post_agent_turn hook fire. agento11y groups records by ConversationID
 // (= vibe session_id), so multi-turn sessions get one generation per
 // turn under the same conversation.
 package mapper
@@ -25,7 +25,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/redact"
 )
 
-// AgentName is the Sigil identity attached to every generation emitted
+// AgentName is the agento11y identity attached to every generation emitted
 // by the vibe agent adapter. Stable across versions.
 const AgentName = "mistral-vibe"
 
@@ -313,7 +313,7 @@ func latestTurnLines(lines []transcript.Line) []transcript.Line {
 	return lines
 }
 
-// buildMessages converts transcript lines into Sigil input/output messages.
+// buildMessages converts transcript lines into agento11y input/output messages.
 // Order convention matches the codex mapper: user prompts and tool
 // results land in Input; assistant text and tool calls land in Output.
 //
@@ -423,7 +423,7 @@ func buildMessages(lines []transcript.Line, mode agento11y.ContentCaptureMode) (
 }
 
 // buildToolDefinitions copies meta.json's tools_available[] to the
-// Sigil ToolDefinition shape. Parameters land in InputSchema verbatim.
+// agento11y ToolDefinition shape. Parameters land in InputSchema verbatim.
 func buildToolDefinitions(tools []meta.ToolDef) []agento11y.ToolDefinition {
 	if len(tools) == 0 {
 		return nil
@@ -451,7 +451,7 @@ func buildToolDefinitions(tools []meta.ToolDef) []agento11y.ToolDefinition {
 
 // GenerationID is a stable per-turn ID derived from session_id and the
 // turn sequence so reruns of the same hook against the same transcript
-// produce the same ID (and Sigil dedupes them on the server side).
+// produce the same ID (and agento11y dedupes them on the server side).
 func GenerationID(sessionID string, turnSeq int) string {
 	sum := sha256.Sum256([]byte(sessionID + "\x00" + strconv.Itoa(turnSeq)))
 	return "vibe-" + hex.EncodeToString(sum[:])[:24]

--- a/plugins/agento11y/internal/agents/vibe/state/state.go
+++ b/plugins/agento11y/internal/agents/vibe/state/state.go
@@ -38,7 +38,7 @@ type Session struct {
 }
 
 func dir() string {
-	return filepath.Join(xdg.StateRoot("sigil"), "vibe")
+	return filepath.Join(xdg.AppStateRoot(), "vibe")
 }
 
 // SanitizeSessionID delegates to xdg.SafeComponent so session-ID-derived

--- a/plugins/agento11y/internal/agents/vibe/toolevents/toolevents.go
+++ b/plugins/agento11y/internal/agents/vibe/toolevents/toolevents.go
@@ -55,7 +55,7 @@ func (e Event) ErrorOr() error {
 }
 
 func root() string {
-	return filepath.Join(xdg.StateRoot("sigil"), "vibe", "tools")
+	return filepath.Join(xdg.AppStateRoot(), "vibe", "tools")
 }
 
 func sessionDir(sessionID string) string {

--- a/plugins/agento11y/internal/agents/vibe/vibe.go
+++ b/plugins/agento11y/internal/agents/vibe/vibe.go
@@ -1,11 +1,11 @@
 // Package vibe implements the Mistral Vibe agent adapter for the
-// consolidated sigil binary. The dispatcher in cmd/sigil routes
-// `sigil vibe hook` here.
+// consolidated agento11y binary. The dispatcher in cmd/agento11y routes
+// `agento11y vibe hook` here.
 //
 // Vibe fires hooks for three event types, all wired here:
 //   - post_agent_turn exports one generation per turn from the on-disk
 //     <session_dir>/messages.jsonl plus the sibling meta.json.
-//   - before_tool evaluates the tool call against Sigil guard policy and may
+//   - before_tool evaluates the tool call against agento11y guard policy and may
 //     deny or rewrite it (when guards are enabled).
 //   - after_tool records the tool's timing/status for its execute_tool span.
 package vibe

--- a/plugins/agento11y/internal/cli/cli.go
+++ b/plugins/agento11y/internal/cli/cli.go
@@ -1,4 +1,4 @@
-// Package cli wires the sigil binary's logger and panic recovery. Logging
+// Package cli wires the agento11y binary's logger and panic recovery. Logging
 // is gated on a debug env key so hooks default to silent; failures to open
 // the log file fall back to /dev/null because hooks must not surface
 // anything to stderr/stdout that the agent might misinterpret.
@@ -14,17 +14,21 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/xdg"
 )
 
-// InitLogger returns a logger that writes to the per-app log file when the
+// appName prefixes every log line so entries are attributable when the log
+// file is shared with other tooling.
+const appName = "agento11y"
+
+// InitLogger returns a logger that writes to the shared log file when the
 // branded DEBUG family (AGENTO11Y_DEBUG, SIGIL_DEBUG fallback) is truthy,
 // and /dev/null otherwise.
 //
-// agentName is woven into the line prefix (`<app>[<agent>]: `) so log
+// agentName is woven into the line prefix (`agento11y[<agent>]: `) so log
 // entries from concurrently-running agents stay distinguishable in the
 // shared log file. Pass "" to omit the agent tag.
 //
-// The log file lives at xdg.LogFilePath(appName); the directory is created
+// The log file lives at xdg.LogFilePath(); the directory is created
 // if missing. Any open failure falls back silently to io.Discard.
-func InitLogger(appName, agentName string) *log.Logger {
+func InitLogger(agentName string) *log.Logger {
 	prefix := appName + ": "
 	if agentName != "" {
 		prefix = appName + "[" + agentName + "]: "
@@ -33,7 +37,7 @@ func InitLogger(appName, agentName string) *log.Logger {
 	if !envconfig.ParseBool(envconfig.Getenv("DEBUG")) {
 		return logger
 	}
-	path := xdg.LogFilePath(appName)
+	path := xdg.LogFilePath()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return logger
 	}

--- a/plugins/agento11y/internal/doctor/agents.go
+++ b/plugins/agento11y/internal/doctor/agents.go
@@ -23,7 +23,7 @@ type agentProbe struct {
 	// bin is the executable looked up on PATH.
 	bin string
 	// status is the package's read-only install probe, or nil for hook-only
-	// agents (cursor) that the sigil binary never installs.
+	// agents (cursor) that the agento11y binary never installs.
 	status statusFn
 	// configBased is true when status reads install state from files and needs
 	// no binary on PATH (claude, opencode, pi, copilot). For these, doctor
@@ -42,7 +42,7 @@ var lookPath = exec.LookPath
 
 // agentProbes is the detection/probe table. cursor is hook-only (no launcher),
 // so it has no install probe: its capture is wired into Cursor's own hook
-// settings, and its effective version is the sigil binary's.
+// settings, and its effective version is the agento11y binary's.
 var agentProbes = []agentProbe{
 	{name: "claude", bin: "claude", status: claudecode.Status, configBased: true},
 	{name: "codex", bin: "codex", status: codex.Status},
@@ -53,31 +53,31 @@ var agentProbes = []agentProbe{
 }
 
 // defaultCollectAgents runs the PATH sweep and per-agent read-only status
-// probe. sigilVersion is reported as cursor's version (its hooks call the
-// sigil binary, so they move together).
-func defaultCollectAgents(ctx context.Context, sigilVersion string) []AgentStatus {
+// probe. binaryVersion is reported as cursor's version (its hooks call the
+// agento11y binary, so they move together).
+func defaultCollectAgents(ctx context.Context, binaryVersion string) []AgentStatus {
 	out := make([]AgentStatus, 0, len(agentProbes))
 	for _, probe := range agentProbes {
-		out = append(out, probeAgent(ctx, probe, sigilVersion))
+		out = append(out, probeAgent(ctx, probe, binaryVersion))
 	}
 	return out
 }
 
-func probeAgent(ctx context.Context, probe agentProbe, sigilVersion string) AgentStatus {
+func probeAgent(ctx context.Context, probe agentProbe, binaryVersion string) AgentStatus {
 	a := AgentStatus{Name: probe.name, Note: probe.note, notInstalledLabel: probe.notInstalledLabel}
 	_, lookErr := lookPath(probe.bin)
 	a.OnPath = lookErr == nil
 
 	// Hook-only agent (cursor): no install probe, detection is PATH presence.
-	// Capture is configured in the host's own settings, which the sigil binary
-	// doesn't manage, so report it as present with the sigil binary version.
+	// Capture is configured in the host's own settings, which the agento11y binary
+	// doesn't manage, so report it as present with the agento11y binary version.
 	if probe.status == nil {
 		if !a.OnPath {
 			a.Health = HealthSkipped
 			return a
 		}
 		a.HookBased = true
-		a.Version = sigilVersion
+		a.Version = binaryVersion
 		a.Health = HealthOK
 		return a
 	}

--- a/plugins/agento11y/internal/doctor/doctor.go
+++ b/plugins/agento11y/internal/doctor/doctor.go
@@ -1,4 +1,4 @@
-// Package doctor implements `sigil doctor`: a read-only diagnostic that
+// Package doctor implements `agento11y doctor`: a read-only diagnostic that
 // reports the health of the two export pipelines (conversations and
 // analytics), config validity, and installed host-agent plugins in one place.
 //
@@ -93,7 +93,7 @@ type Params struct {
 // Report is the full diagnostic. Field names and the `status` strings are the
 // stable contract for `--json` / support tooling.
 type Report struct {
-	Sigil              SigilSection         `json:"sigil"`
+	Binary             BinarySection        `json:"agento11y"`
 	Config             ConfigSection        `json:"config"`
 	Conversations      ConversationsSection `json:"conversations"`
 	Analytics          AnalyticsSection     `json:"analytics"`
@@ -101,8 +101,8 @@ type Report struct {
 	AutoUpdateDisabled bool                 `json:"auto_update_disabled"`
 }
 
-// SigilSection reports the binary's build version.
-type SigilSection struct {
+// BinarySection reports the binary's build version.
+type BinarySection struct {
 	Version string `json:"version"`
 }
 
@@ -170,7 +170,7 @@ type AnalyticsSection struct {
 }
 
 // AgentStatus reports one host agent's detection + install state. HookBased is
-// set for agents the sigil binary never installs (cursor): their capture is
+// set for agents the agento11y binary never installs (cursor): their capture is
 // wired into the host's own hook settings, so install state isn't something
 // doctor can read.
 type AgentStatus struct {
@@ -295,11 +295,11 @@ func Collect(ctx context.Context, opts Options, p Params) *Report {
 	}
 
 	r := &Report{}
-	r.Sigil = SigilSection{Version: normalizeVersion(p.Version)}
+	r.Binary = BinarySection{Version: normalizeVersion(p.Version)}
 	r.Conversations = collectConversations(osEnv, fileEnv)
 	r.Analytics = collectAnalytics(osEnv, fileEnv, r.Conversations.configured())
 	r.Config = collectConfig(osEnv, fileEnv)
-	r.Agents = collectAgents(ctx, r.Sigil.Version)
+	r.Agents = collectAgents(ctx, r.Binary.Version)
 	r.AutoUpdateDisabled = updatecheck.Disabled()
 
 	if opts.Probe {
@@ -492,7 +492,7 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 	if len(sec.DisallowedKeys) > 0 {
 		sec.Health = HealthWarn
 		sec.Messages = append(sec.Messages,
-			"config.env has keys sigil ignores: "+strings.Join(sec.DisallowedKeys, ", "))
+			"config.env has keys agento11y ignores: "+strings.Join(sec.DisallowedKeys, ", "))
 	}
 	if sec.ContentModeFellBack {
 		sec.Health = HealthWarn
@@ -620,7 +620,7 @@ func tokenPrefix(token string) string {
 	return ""
 }
 
-// disallowedKeys lists keys in config.env that sigil's dotenv loader ignores.
+// disallowedKeys lists keys in config.env that agento11y's dotenv loader ignores.
 // It mirrors dotenv.LoadDotenv's line handling so the same lines are parsed,
 // but reports the rejected keys the loader silently drops.
 func disallowedKeys(path string) []string {

--- a/plugins/agento11y/internal/doctor/doctor_test.go
+++ b/plugins/agento11y/internal/doctor/doctor_test.go
@@ -668,7 +668,7 @@ func TestRun(t *testing.T) {
 				if err := json.Unmarshal([]byte(stdout), &report); err != nil {
 					t.Fatalf("invalid JSON: %v", err)
 				}
-				for _, key := range []string{"sigil", "config", "conversations", "analytics", "agents"} {
+				for _, key := range []string{"agento11y", "config", "conversations", "analytics", "agents"} {
 					if _, ok := report[key]; !ok {
 						t.Fatalf("JSON missing section %q", key)
 					}

--- a/plugins/agento11y/internal/doctor/render.go
+++ b/plugins/agento11y/internal/doctor/render.go
@@ -80,7 +80,7 @@ func renderHuman(w io.Writer, r *Report, color, probed bool) {
 	p := palette{color: color}
 	var b strings.Builder
 
-	fmt.Fprintf(&b, "%s %s\n\n", p.heading("agento11y doctor"), p.faint("v"+r.Sigil.Version))
+	fmt.Fprintf(&b, "%s %s\n\n", p.heading("agento11y doctor"), p.faint("v"+r.Binary.Version))
 
 	// Conversations pipeline.
 	writeSection(&b, p, "Conversations (generation export)", r.Conversations.Health)

--- a/plugins/agento11y/internal/doctor/render_test.go
+++ b/plugins/agento11y/internal/doctor/render_test.go
@@ -9,7 +9,7 @@ import (
 
 func sampleReport() *Report {
 	return &Report{
-		Sigil: SigilSection{Version: "1.2.3"},
+		Binary: BinarySection{Version: "1.2.3"},
 		Config: ConfigSection{
 			Path: "/tmp/agento11y/config.env", Exists: true,
 			ContentCaptureMode: "metadata_only", Health: HealthOK,

--- a/plugins/agento11y/internal/emit/emit.go
+++ b/plugins/agento11y/internal/emit/emit.go
@@ -1,5 +1,5 @@
-// Package sigilemit holds the Sigil emission mechanics shared by the agent
-// adapters: OTel provider setup, Sigil client construction, the generation
+// Package emit holds the agento11y emission mechanics shared by the agent
+// adapters: OTel provider setup, client construction, the generation
 // recorder lifecycle, and tool-span helpers.
 //
 // The per-turn adapters (codex, copilot, cursor) use all of it. claudecode
@@ -12,7 +12,7 @@
 // and content-capture mode. Content handling that is genuinely agent-specific
 // (redaction, capture-mode clamping) stays at the call site; this package
 // only owns the mechanics that are identical.
-package sigilemit
+package emit
 
 import (
 	"context"
@@ -68,7 +68,7 @@ func exportConfig(userAgent string) agento11y.GenerationExportConfig {
 	return export
 }
 
-// NewClient builds a Sigil client with the shared HTTP/basic-auth generation
+// NewClient builds an agento11y client with the shared HTTP/basic-auth generation
 // export defaults and optional OTel providers.
 func NewClient(opts ClientOptions) *agento11y.Client {
 	c := agento11y.Config{

--- a/plugins/agento11y/internal/emit/emit_test.go
+++ b/plugins/agento11y/internal/emit/emit_test.go
@@ -1,4 +1,4 @@
-package sigilemit
+package emit
 
 import (
 	"testing"

--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -1,5 +1,5 @@
 // Package entry implements the shared CLI entrypoint behind the
-// cmd/agento11y and cmd/sigil binaries. Both commands are the same single
+// cmd/agento11y and cmd/agento11y binaries. Both commands are the same single
 // binary used by the Claude Code, Codex, Copilot, Cursor, OpenCode, pi, and
 // Vibe agent plugins. It accepts:
 //
@@ -97,9 +97,9 @@ type agentHook func(ctx context.Context, stdin io.Reader, stdout io.Writer, log 
 // unchanged to the underlying CLI via process replacement. localEnv is
 // non-nil when the caller requested `--local`, in which case the agent's
 // child inherits local-mode SIGIL_* env vars from local.LaunchEnv.Apply.
-// sigilVersion is the build version forwarded so launchers can stamp
+// binaryVersion is the build version forwarded so launchers can stamp
 // update-check state with the version that performed the refresh.
-type agentLauncher func(ctx context.Context, args []string, localEnv *local.LaunchEnv, stdin io.Reader, stdout, stderr io.Writer, log *log.Logger, sigilVersion string) error
+type agentLauncher func(ctx context.Context, args []string, localEnv *local.LaunchEnv, stdin io.Reader, stdout, stderr io.Writer, log *log.Logger, binaryVersion string) error
 
 // agents maps the argv agent name to its adapter Hook. The map is a package
 // var so tests can substitute mock hooks.
@@ -132,13 +132,13 @@ var exit = os.Exit
 var loginRun = login.Run
 
 // cursorInstall and cursorUninstall are package vars so tests can stub the
-// filesystem-touching `sigil cursor install`/`uninstall` flow.
+// filesystem-touching `agento11y cursor install`/`uninstall` flow.
 var (
 	cursorInstall   = cursorinstall.Run
 	cursorUninstall = cursorinstall.Uninstall
 )
 
-// Main is the entrypoint shared by cmd/agento11y and cmd/sigil.
+// Main is the entrypoint shared by cmd/agento11y and cmd/agento11y.
 // buildVersion is the caller's -ldflags-stamped main.version; each main
 // package declares its own variable so the -X flag does not depend on this
 // module's import path.
@@ -159,7 +159,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 		return
 	}
 
-	// `sigil login` is a top-level subcommand handled before launcher and
+	// `agento11y login` is a top-level subcommand handled before launcher and
 	// hook dispatch so it can run without a verb argument and without an
 	// agent name. It owns its own flag parsing.
 	if args[0] == "login" {
@@ -172,7 +172,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 		return
 	}
 
-	// `sigil doctor` is a read-only diagnostic, dispatched before launcher
+	// `agento11y doctor` is a read-only diagnostic, dispatched before launcher
 	// dispatch like `local`. It owns its own flag parsing.
 	if args[0] == "doctor" {
 		runDoctorCommand(args[1:], stdout, stderr)
@@ -185,7 +185,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 	//
 	// One exception: when a name appears in both maps (today: `codex`,
 	// which is both a launcher and a hook agent), the literal verb `hook`
-	// always means hook dispatch. Without this guard `sigil codex hook`
+	// always means hook dispatch. Without this guard `agento11y codex hook`
 	// would hit the launcher branch, fail parseLauncherArgs because there
 	// is no `--`, and exit 2 — breaking every hook fired by
 	// plugins/codex/hooks/hooks.json.
@@ -202,7 +202,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 			return
 		}
 
-		logger := cli.InitLogger("sigil", args[0])
+		logger := cli.InitLogger(args[0])
 
 		// Auto-prompt for credentials on first run. login.Run returns
 		// ErrNotInteractive when stdin is not a TTY (e.g. CI, piped input);
@@ -214,7 +214,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 		//
 		// In --local mode we never prompt: the launcher will inject
 		// placeholder credentials so the SDK proceeds without contacting
-		// Sigil Cloud.
+		// Grafana Cloud.
 		if localEnv == nil && !dotenv.HasCredentials() {
 			err := loginRun(context.Background(), login.RunOpts{
 				Stderr: stderr,
@@ -264,10 +264,10 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 		return
 	}
 
-	// Cursor has no launcher (it is a GUI app), so `sigil cursor install`
+	// Cursor has no launcher (it is a GUI app), so `agento11y cursor install`
 	// wires its hooks directly. This branch sits before the generic
 	// non-`hook` verb rejection below so `install`/`uninstall` reach the
-	// installer while `sigil cursor hook` still falls through to dispatch.
+	// installer while `agento11y cursor hook` still falls through to dispatch.
 	if agent == "cursor" && (verb == "install" || verb == "uninstall") {
 		runCursorInstall(verb, stdout, stderr)
 		return
@@ -286,14 +286,14 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 
 	// Propagate the build version to the generation-export User-Agent so each
 	// agent plugin identifies itself, e.g. "agento11y-plugin-cursor/<ver> ...".
-	useragent.SigilVersion = version
+	useragent.Version = version
 
 	// Apply the dotenv file before initialising the logger so SIGIL_DEBUG=true
 	// set only in $XDG_CONFIG_HOME/agento11y/config.env still enables file logging.
 	// Cursor (and Codex headless) launch hooks under a stripped environment
 	// where the dotenv is the only place SIGIL_DEBUG could come from.
 	dotenv.ApplyEnv(nil)
-	logger := cli.InitLogger("sigil", agent)
+	logger := cli.InitLogger(agent)
 	defer cli.RecoverAndLog(logger)
 
 	if err := hook(context.Background(), stdin, stdout, logger); err != nil {
@@ -301,7 +301,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 	}
 }
 
-// runLoginCommand handles `sigil login`. The flow is interactive-only: any
+// runLoginCommand handles `agento11y login`. The flow is interactive-only: any
 // args (including unknown flags) are rejected with exit 2. Non-interactive
 // callers should set SIGIL_* env vars or edit $XDG_CONFIG_HOME/agento11y/config.env
 // directly.
@@ -311,7 +311,7 @@ func runLoginCommand(args []string, stderr io.Writer) {
 	fs.Usage = func() {
 		_, _ = fmt.Fprintln(stderr, "usage: agento11y login")
 		_, _ = fmt.Fprintln(stderr)
-		_, _ = fmt.Fprintln(stderr, "Interactively save Sigil credentials to $XDG_CONFIG_HOME/agento11y/config.env")
+		_, _ = fmt.Fprintln(stderr, "Interactively save agento11y credentials to $XDG_CONFIG_HOME/agento11y/config.env")
 		_, _ = fmt.Fprintln(stderr, "(or the old $XDG_CONFIG_HOME/sigil/config.env if only that file exists).")
 	}
 	if err := fs.Parse(args); err != nil {
@@ -325,10 +325,10 @@ func runLoginCommand(args []string, stderr io.Writer) {
 	}
 
 	dotenv.ApplyEnv(nil)
-	logger := cli.InitLogger("sigil", "login")
+	logger := cli.InitLogger("login")
 
 	err := loginRun(context.Background(), login.RunOpts{
-		// Only the explicit `sigil login` shows the “Try sigil claude/pi”
+		// Only the explicit `agento11y login` shows the “Try sigil claude/pi”
 		// hint. The launcher auto-prompt path leaves this false because the
 		// launcher is about to exec the agent anyway.
 		ShowNextStep: true,
@@ -352,8 +352,8 @@ func runLoginCommand(args []string, stderr io.Writer) {
 	}
 }
 
-// runCursorInstall handles `sigil cursor install` and `sigil cursor
-// uninstall`. install wires Sigil's hook into ~/.cursor/hooks.json and, when
+// runCursorInstall handles `agento11y cursor install` and `sigil cursor
+// uninstall`. install wires agento11y's hook into ~/.cursor/hooks.json and, when
 // no credentials are configured yet, chains the interactive login prompt the
 // same way the launchers do; uninstall removes the hook entries.
 func runCursorInstall(verb string, stdout, stderr io.Writer) {
@@ -361,7 +361,7 @@ func runCursorInstall(verb string, stdout, stderr io.Writer) {
 	// $XDG_CONFIG_HOME/agento11y/config.env still enables file logging, and
 	// before HasCredentials so dotenv-supplied credentials are visible.
 	dotenv.ApplyEnv(nil)
-	logger := cli.InitLogger("sigil", "cursor")
+	logger := cli.InitLogger("cursor")
 
 	if verb == "uninstall" {
 		if err := cursorUninstall(stdout, stderr, logger); err != nil {
@@ -382,7 +382,7 @@ func runCursorInstall(verb string, stdout, stderr io.Writer) {
 	// Wiring the hook does nothing without credentials, so chain the login
 	// prompt on first install, mirroring the launcher auto-prompt. login.Run
 	// returns ErrNotInteractive when stdin is not a TTY (CI, piped input), in
-	// which case we skip silently and leave `sigil login` for later. A failed
+	// which case we skip silently and leave `agento11y login` for later. A failed
 	// or aborted login never fails the install: the hook is already wired.
 	if !dotenv.HasCredentials() {
 		err := loginRun(context.Background(), login.RunOpts{
@@ -401,7 +401,7 @@ func runCursorInstall(verb string, stdout, stderr io.Writer) {
 	}
 }
 
-// runDoctorCommand handles `sigil doctor`. doctor is strictly read-only and
+// runDoctorCommand handles `agento11y doctor`. doctor is strictly read-only and
 // owns its own flag parsing. The OS environment is snapshotted before dotenv
 // is applied so doctor can attribute each value to the OS env vs config.env.
 func runDoctorCommand(args []string, stdout, stderr io.Writer) {
@@ -435,7 +435,7 @@ func runDoctorCommand(args []string, stdout, stderr io.Writer) {
 //
 // Diagnostics distinguish two cases:
 //   - No `--` and there are unrecognised tokens: the user probably
-//     forgot the separator, so we point them at `sigil <name> -- <args>`.
+//     forgot the separator, so we point them at `agento11y <name> -- <args>`.
 //   - `--` is present but unrecognised tokens precede it: those are
 //     genuinely unknown sigil-side options, so we name them explicitly.
 func parseLauncherArgs(name string, rest []string, stderr io.Writer) ([]string, *local.LaunchEnv, bool) {
@@ -447,33 +447,33 @@ func parseLauncherArgs(name string, rest []string, stderr io.Writer) ([]string, 
 		}
 	}
 
-	var sigilSide []string
+	var launcherSide []string
 	var forwarded []string
 	if sep < 0 {
-		sigilSide = rest
+		launcherSide = rest
 	} else {
-		sigilSide = rest[:sep]
+		launcherSide = rest[:sep]
 		forwarded = rest[sep+1:]
 	}
 
 	localRequested := false
 	var flagTags []string
 	var unknown []string
-	for i := 0; i < len(sigilSide); i++ {
-		tok := sigilSide[i]
+	for i := 0; i < len(launcherSide); i++ {
+		tok := launcherSide[i]
 		switch {
 		case tok == "--local":
 			localRequested = true
 		case tok == "--tag":
-			if i+1 >= len(sigilSide) {
+			if i+1 >= len(launcherSide) {
 				_, _ = fmt.Fprintln(stderr, "agento11y: --tag requires a key=value argument")
 				exit(2)
 				return nil, nil, false
 			}
 			i++
-			kv, ok := normalizeTag(sigilSide[i])
+			kv, ok := normalizeTag(launcherSide[i])
 			if !ok {
-				_, _ = fmt.Fprintf(stderr, "agento11y: invalid --tag %q (want key=value)\n", sigilSide[i])
+				_, _ = fmt.Fprintf(stderr, "agento11y: invalid --tag %q (want key=value)\n", launcherSide[i])
 				exit(2)
 				return nil, nil, false
 			}
@@ -597,7 +597,7 @@ func setupLocalLaunch(stderr io.Writer) (endpoint, otlp string, err error) {
 	return endpoint, otlp, nil
 }
 
-// runLocalCommand dispatches `sigil local <verb>` subcommands.
+// runLocalCommand dispatches `agento11y local <verb>` subcommands.
 func runLocalCommand(args []string, stdout, stderr io.Writer) {
 	if len(args) == 0 {
 		_, _ = fmt.Fprintln(stderr, "usage: agento11y local start | status | stop | restart | serve")
@@ -663,7 +663,7 @@ func runLocalCommand(args []string, stdout, stderr io.Writer) {
 		_, _ = fmt.Fprintf(stdout, "agento11y local receiver running at %s (pid %d)\n", status.Endpoint, status.PID)
 	case "serve":
 		// Internal: invoked by the daemon child. Blocks until SIGTERM.
-		logger := cli.InitLogger("sigil", "local")
+		logger := cli.InitLogger("local")
 		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 		defer cancel()
 		if err := local.Serve(ctx, dir, local.DefaultPort, logger); err != nil {

--- a/plugins/agento11y/internal/entry/entry_test.go
+++ b/plugins/agento11y/internal/entry/entry_test.go
@@ -177,7 +177,7 @@ func TestRun_DotenvSIGILDebugEnablesLogging(t *testing.T) {
 				run([]string{"claude-code", "hook"}, strings.NewReader(`{}`), &stdout, &stderr)
 			})
 
-			logPath := filepath.Join(dir, "state", "sigil", "logs", "sigil.log")
+			logPath := filepath.Join(dir, "state", "agento11y", "logs", "agento11y.log")
 			data, err := os.ReadFile(logPath)
 			if err != nil {
 				t.Fatalf("debug log not created at %s: %v", logPath, err)

--- a/plugins/agento11y/internal/entry/golden_integration_test.go
+++ b/plugins/agento11y/internal/entry/golden_integration_test.go
@@ -190,9 +190,9 @@ func runGoldenScenario(t *testing.T, name string) {
 		if !t.Failed() {
 			return
 		}
-		logPath := filepath.Join(stateDir, "sigil", "logs", "sigil.log")
+		logPath := filepath.Join(stateDir, "agento11y", "logs", "agento11y.log")
 		if data, err := os.ReadFile(logPath); err == nil {
-			t.Logf("sigil debug log (%s):\n%s", logPath, data)
+			t.Logf("agento11y debug log (%s):\n%s", logPath, data)
 		}
 		for _, line := range eventOutput {
 			t.Log(line)
@@ -740,7 +740,7 @@ func setHookExportEnv(t *testing.T, endpoint string) {
 		t.Setenv(envconfig.PreferredKey(suffix), "")
 	}
 	// Enable SIGIL_DEBUG so the dispatcher writes per-event logs into
-	// $XDG_STATE_HOME/sigil/logs/sigil.log. When a scenario fails the test
+	// $XDG_STATE_HOME/agento11y/logs/agento11y.log. When a scenario fails the test
 	// reads that file back so the failure message includes the trail.
 	t.Setenv("SIGIL_DEBUG", "true")
 }

--- a/plugins/agento11y/internal/launcher/launcher.go
+++ b/plugins/agento11y/internal/launcher/launcher.go
@@ -127,7 +127,7 @@ type BootstrapSpec struct {
 	Install func(ctx context.Context, bin string, w io.Writer) error
 	// InstallRecoveryHint prints manual-retry commands to Stderr when Install
 	// fails. Bootstrap emits the generic "install of <label> failed" /
-	// "continuing without Sigil capture" lines before calling this; the hook
+	// "continuing without agento11y capture" lines before calling this; the hook
 	// only contributes the indented command lines.
 	InstallRecoveryHint func(w io.Writer)
 	// PostInstallHint, when non-nil, runs after a successful Install. codex
@@ -139,7 +139,7 @@ type BootstrapSpec struct {
 	Update             func(ctx context.Context, bin string, w io.Writer) error
 	UpdateRecoveryHint func(w io.Writer)
 	UpdateTTL          time.Duration
-	SigilVersion       string
+	BinaryVersion      string
 
 	// RegisterMessage overrides the default
 	// "agento11y: registering <label> with <bin>\n" line printed before Install.
@@ -177,7 +177,7 @@ func Bootstrap(ctx context.Context, spec BootstrapSpec) error {
 			spec.Logger.Printf("install %s: %v", spec.PluginLabel, err)
 			fmt.Fprintf(spec.Stderr,
 				"agento11y: install of %s failed: %v\n"+
-					"agento11y: continuing without Sigil capture. To retry manually:\n",
+					"agento11y: continuing without agento11y capture. To retry manually:\n",
 				spec.PluginLabel, err)
 			if spec.InstallRecoveryHint != nil {
 				spec.InstallRecoveryHint(spec.Stderr)
@@ -185,7 +185,7 @@ func Bootstrap(ctx context.Context, spec BootstrapSpec) error {
 		} else if spec.PostInstallHint != nil {
 			spec.PostInstallHint(spec.Stderr)
 		}
-	case spec.Update != nil && updatecheck.ShouldRun(spec.PluginLabel, spec.UpdateTTL, spec.SigilVersion):
+	case spec.Update != nil && updatecheck.ShouldRun(spec.PluginLabel, spec.UpdateTTL, spec.BinaryVersion):
 		fmt.Fprintf(spec.Stderr, "agento11y: refreshing %s in %s\n", spec.PluginLabel, spec.BinName)
 		if err := spec.Update(ctx, bin, spec.Stderr); err != nil {
 			spec.Logger.Printf("update %s: %v", spec.PluginLabel, err)
@@ -197,7 +197,7 @@ func Bootstrap(ctx context.Context, spec BootstrapSpec) error {
 				spec.UpdateRecoveryHint(spec.Stderr)
 			}
 		}
-		updatecheck.Record(spec.PluginLabel, spec.SigilVersion)
+		updatecheck.Record(spec.PluginLabel, spec.BinaryVersion)
 	}
 
 	return Exec(spec.ExecFn, bin, spec.BinName, spec.Args, spec.Env)

--- a/plugins/agento11y/internal/launcher/launcher_test.go
+++ b/plugins/agento11y/internal/launcher/launcher_test.go
@@ -310,7 +310,7 @@ func TestBootstrap(t *testing.T) {
 				got := h.stderr.String()
 				for _, want := range []string{
 					"install of sigil-toy failed: network down",
-					"continuing without Sigil capture",
+					"continuing without agento11y capture",
 					"toy install sigil-toy",
 				} {
 					if !strings.Contains(got, want) {
@@ -351,7 +351,7 @@ func TestBootstrap(t *testing.T) {
 				h.spec.PluginLabel = fmt.Sprintf("sigil-bootstrap-update-%d", time.Now().UnixNano())
 				h.spec.Update = func(context.Context, string, io.Writer) error { h.updateCalls++; return nil }
 				h.spec.UpdateTTL = time.Hour
-				h.spec.SigilVersion = "v-test"
+				h.spec.BinaryVersion = "v-test"
 			},
 			run: func(t *testing.T, h *bootstrapHarness) error {
 				if err := Bootstrap(context.Background(), h.spec); err != nil {
@@ -393,7 +393,7 @@ func TestBootstrap(t *testing.T) {
 			name: "no update when update is nil",
 			setup: func(t *testing.T, h *bootstrapHarness) {
 				h.spec.UpdateTTL = time.Hour
-				h.spec.SigilVersion = "v-test"
+				h.spec.BinaryVersion = "v-test"
 			},
 			assert: func(t *testing.T, h *bootstrapHarness) {
 				if strings.Contains(h.stderr.String(), "refreshing") {

--- a/plugins/agento11y/internal/local/daemon_unix.go
+++ b/plugins/agento11y/internal/local/daemon_unix.go
@@ -37,7 +37,7 @@ func (l *daemonLock) release() {
 	_ = l.f.Close()
 }
 
-// startDaemon launches `sigil local serve` as a detached child process.
+// startDaemon launches `agento11y local serve` as a detached child process.
 // The parent waits for the child to write its status file, then returns
 // the recorded endpoint. The child detaches by setting its own session
 // (SysProcAttr.Setsid) so it survives the parent exiting.
@@ -47,7 +47,7 @@ func startDaemon(ctx context.Context, dir string, logger *log.Logger) (*Status, 
 	}
 	bin, err := os.Executable()
 	if err != nil {
-		return nil, fmt.Errorf("resolve sigil binary: %w", err)
+		return nil, fmt.Errorf("resolve agento11y binary: %w", err)
 	}
 
 	logPath := filepath.Join(dir, "server.log")

--- a/plugins/agento11y/internal/local/env.go
+++ b/plugins/agento11y/internal/local/env.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
 
-// LaunchEnv encodes the env-var contract between the sigil launcher and
+// LaunchEnv encodes the env-var contract between the agento11y launcher and
 // a local-mode agent process. Endpoint and OTLPEndpoint are required;
 // the agent reads them via the branded ENDPOINT and
 // OTEL_EXPORTER_OTLP_ENDPOINT families (either spelling).
@@ -37,7 +37,7 @@ func Environ(e *LaunchEnv) []string {
 // downgrades local capture. The AUTH_TENANT_ID and AUTH_TOKEN families are
 // only filled when the user hasn't already configured either spelling, so a
 // user with Cloud credentials in their shell doesn't get them clobbered by
-// `sigil <agent> --local`.
+// `agento11y <agent> --local`.
 //
 // Placeholder auth values are injected so existing hook code (which
 // short-circuits when the tenant / token families are empty) still exports

--- a/plugins/agento11y/internal/local/manager.go
+++ b/plugins/agento11y/internal/local/manager.go
@@ -127,7 +127,7 @@ func IsRunning(dir string) (*Status, error) {
 // EnsureRunning returns the current daemon status, starting it if no
 // healthy daemon is recorded. Concurrent callers are serialised by an
 // exclusive flock on dir/LockFile so a race between two `--local`
-// launches (or `sigil local start`) cannot spawn duplicate daemons.
+// launches (or `agento11y local start`) cannot spawn duplicate daemons.
 func EnsureRunning(ctx context.Context, dir string, logger *log.Logger) (*Status, error) {
 	if s, err := IsRunning(dir); err != nil {
 		return nil, err
@@ -179,9 +179,9 @@ func SetStartDaemonForTesting(fn func(ctx context.Context, dir string, logger *l
 }
 
 // Stop sends SIGTERM to the recorded daemon after verifying the live PID
-// still looks like `sigil local serve`. Returns (false, nil) when no
+// still looks like `agento11y local serve`. Returns (false, nil) when no
 // daemon is recorded, the recorded process is gone, or the live PID is
-// not a sigil daemon. Endpoint health is not required: an alive process
+// not an agento11y daemon. Endpoint health is not required: an alive process
 // with a dead /healthz endpoint may be a wedged daemon, and leaving it
 // alive lets a later start orphan it. Returns a non-nil error when the
 // daemon identity cannot be checked or the daemon does not exit within

--- a/plugins/agento11y/internal/local/server.go
+++ b/plugins/agento11y/internal/local/server.go
@@ -70,7 +70,7 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("POST /api/v1/generations:export", s.handleGenerations)
 	mux.HandleFunc("POST /otlp/v1/traces", s.handleOTLP)
 	mux.HandleFunc("POST /otlp/v1/metrics", s.handleOTLP)
-	// Cloud-style hook endpoint with no run prefix. The Sigil SDK strips
+	// Cloud-style hook endpoint with no run prefix. The agento11y SDK strips
 	// the path from API.Endpoint before appending /api/v1/hooks:evaluate,
 	// so we must accept the bare path too — otherwise local hook
 	// evaluation 404s.
@@ -114,7 +114,7 @@ type generationsRequest struct {
 }
 
 // generationsResponse is the JSON shape the SDK's HTTP exporter parses.
-// Matches sigilv1.ExportGenerationsResponse / ExportGenerationResult.
+// Matches agento11y.v1 ExportGenerationsResponse / ExportGenerationResult.
 type generationsResponse struct {
 	Results []generationResult `json:"results"`
 }

--- a/plugins/agento11y/internal/local/storage.go
+++ b/plugins/agento11y/internal/local/storage.go
@@ -1,7 +1,7 @@
 // Package local implements the in-process HTTP receiver used by
-// `sigil pi --local` and `sigil claude --local`. It stores generation
-// exports to JSONL files under the Sigil state root so agent sessions can
-// be inspected with standard shell tools, without requiring a Sigil Cloud
+// `agento11y pi --local` and `agento11y claude --local`. It stores generation
+// exports to JSONL files under the agento11y state root so agent sessions can
+// be inspected with standard shell tools, without requiring a Grafana Cloud
 // or local stack deployment.
 package local
 
@@ -30,7 +30,7 @@ const (
 // StateDir returns the root directory for local capture data.
 // All JSONL files and the server status file live under this directory.
 func StateDir() string {
-	return filepath.Join(xdg.StateRoot("sigil"), "local")
+	return filepath.Join(xdg.AppStateRoot(), "local")
 }
 
 // Storage owns the JSONL files under StateDir and serialises writes so

--- a/plugins/agento11y/internal/local/web/app.jsx
+++ b/plugins/agento11y/internal/local/web/app.jsx
@@ -1087,7 +1087,7 @@
             {!error && !loading && conversations.length === 0 && (
               <div style={{ padding: 16 }}>
                 <Notice kind="info" title="No conversations yet">
-                  Run an agent against this daemon with <code style={{ color: "var(--fg1)" }}>sigil pi --local</code> or <code style={{ color: "var(--fg1)" }}>sigil claude --local</code>. Captured generations appear here as soon as the agent emits its first one.
+                  Run an agent against this daemon with <code style={{ color: "var(--fg1)" }}>agento11y pi --local</code> or <code style={{ color: "var(--fg1)" }}>agento11y claude --local</code>. Captured generations appear here as soon as the agent emits its first one.
                 </Notice>
               </div>
             )}
@@ -1929,7 +1929,7 @@
                 <SettingRow
                   label="Content capture mode"
                   help={<>
-                    What content sigil sends to Grafana Cloud for each generation. <Mono>--local</Mono> sessions always capture full content on this machine.
+                    What content agento11y sends to Grafana Cloud for each generation. <Mono>--local</Mono> sessions always capture full content on this machine.
                     {captureUnset && <div style={{ color: "var(--fg3)", marginTop: 6 }}>Not set: Grafana Cloud sessions capture metadata only. Pick a mode to pin it.</div>}
                     {advanced && <div style={{ color: "var(--warning-text)", marginTop: 6 }}>Advanced mode <Mono>{form.capture}</Mono> is set in config.env and will be preserved.</div>}
                   </>}
@@ -1987,7 +1987,7 @@
 
               <SettingsCard>
                 <SectionLabel>Runtime</SectionLabel>
-                <SettingRow label="Debug logging" help={<>Write a verbose log to <Mono>~/.local/state/sigil/logs/sigil.log</Mono>.</>}>
+                <SettingRow label="Debug logging" help={<>Write a verbose log to <Mono>~/.local/state/agento11y/logs/agento11y.log</Mono>.</>}>
                   <Toggle checked={form.debug} onChange={v => set({ debug: v })}/>
                 </SettingRow>
                 <SettingRow label="Automatic updates" help={<>Keep host agent plugins refreshed automatically. Turn off to pin the current versions.</>}>
@@ -2153,10 +2153,10 @@
       }, [setTimeRange]);
 
       const pageTitle = view === "settings"
-        ? "Settings — sigil local"
+        ? "Settings — agento11y local"
         : view === "conversation" && selected
-          ? `${selected.title || selected.id} — sigil local`
-          : "sigil — local";
+          ? `${selected.title || selected.id} — agento11y local`
+          : "agento11y — local";
       useEffect(() => { document.title = pageTitle; }, [pageTitle]);
 
       const fetchList = useCallback(() => {

--- a/plugins/agento11y/internal/local/web/index.html
+++ b/plugins/agento11y/internal/local/web/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>sigil — local</title>
+  <title>agento11y — local</title>
   <link rel="stylesheet" href="/assets/app.css"/>
 
   <script src="https://unpkg.com/react@18.3.1/umd/react.development.js"

--- a/plugins/agento11y/internal/login/login.go
+++ b/plugins/agento11y/internal/login/login.go
@@ -1,6 +1,6 @@
-// Package login owns the interactive Sigil credentials flow used by both
-// the explicit `sigil login` subcommand and the auto-prompt that runs
-// before `sigil claude` / `sigil pi` when no credentials are configured.
+// Package login owns the interactive agento11y credentials flow used by both
+// the explicit `agento11y login` subcommand and the auto-prompt that runs
+// before `agento11y claude` / `agento11y pi` when no credentials are configured.
 //
 // The flow prompts for the connection details (SIGIL_ENDPOINT,
 // SIGIL_AUTH_TENANT_ID, SIGIL_AUTH_TOKEN and an optional OTel OTLP endpoint)
@@ -42,7 +42,7 @@ const pluginURL = "https://<your-stack>.grafana.net/plugins/grafana-sigil-app"
 
 // observabilityURL points at the AI Observability plugin route on the
 // user’s Grafana stack — the page where captured generations, traces, and
-// scores show up after a `sigil claude` / `sigil pi` session.
+// scores show up after a `agento11y claude` / `agento11y pi` session.
 const observabilityURL = "https://<your-stack>.grafana.net/a/grafana-sigil-app"
 
 // docsURL points at the plugins directory so users can discover every
@@ -112,7 +112,7 @@ type RunOpts struct {
 
 	// ShowNextStep prints a `Try sigil claude or sigil pi.` hint after a
 	// successful save so users know what to run next. Set by the explicit
-	// `sigil login` command; left false when login auto-fires from a
+	// `agento11y login` command; left false when login auto-fires from a
 	// launcher (the launcher is about to start the agent anyway, so the
 	// hint would just be noise).
 	ShowNextStep bool

--- a/plugins/agento11y/internal/mapperutil/mapperutil.go
+++ b/plugins/agento11y/internal/mapperutil/mapperutil.go
@@ -1,5 +1,5 @@
 // Package mapperutil holds helpers shared by the per-agent mappers that turn
-// captured hook fragments into Sigil generations: deterministic ID hashing,
+// captured hook fragments into agento11y generations: deterministic ID hashing,
 // content-mode normalization, tool-definition building, map cloning, and
 // model→provider inference.
 //
@@ -97,7 +97,7 @@ func SortedToolDefinitions(names []string) []agento11y.ToolDefinition {
 	return out
 }
 
-// InferProvider maps a model name to a Sigil provider using loose substring
+// InferProvider maps a model name to an agento11y provider using loose substring
 // matching for Claude/Gemini and prefix matching for the OpenAI families.
 // Returns "" when nothing matches so callers can supply their own fallback.
 //

--- a/plugins/agento11y/internal/otel/otel.go
+++ b/plugins/agento11y/internal/otel/otel.go
@@ -1,13 +1,14 @@
-// Package otel sets up OTLP HTTP trace + metric providers for the sigil
+// Package otel sets up OTLP HTTP trace + metric providers for the agento11y
 // plugin binary.
 //
 // Configuration precedence (high to low):
-//   - SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT — sigil-specific override
+//   - AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT (SIGIL_* fallback) — agento11y-specific override
 //   - OTEL_EXPORTER_OTLP_ENDPOINT — standard OTel env var
 //
 // When OTEL_EXPORTER_OTLP_HEADERS lacks an Authorization entry, the package
 // synthesizes `Authorization=Basic base64(tenant:token)` from
-// SIGIL_AUTH_TENANT_ID + (SIGIL_OTEL_AUTH_TOKEN or SIGIL_AUTH_TOKEN). Users
+// AGENTO11Y_AUTH_TENANT_ID + (AGENTO11Y_OTEL_AUTH_TOKEN or
+// AGENTO11Y_AUTH_TOKEN), each with the SIGIL_* spelling as fallback. Users
 // who want a different scheme can set the header themselves and the plugin
 // won't touch it.
 package otel
@@ -36,8 +37,9 @@ import (
 
 // DefaultServiceName is written to OTEL_SERVICE_NAME if unset before exporter
 // construction. Agents share this name so traces from any dispatched agent
-// land under a single service in the backend.
-const DefaultServiceName = "sigil"
+// end up under a single service in the backend. Renamed from "sigil";
+// dashboards filtering on the old service name need to update.
+const DefaultServiceName = "agento11y"
 
 // Providers holds initialized OTel providers. All methods are nil-safe.
 type Providers struct {
@@ -186,7 +188,7 @@ type ProbeTarget struct {
 // ProbeConfig resolves the OTLP endpoint and returns the per-signal probe
 // targets for metrics and traces, reusing the same endpoint resolution,
 // signal-URL construction, and auth-header synthesis as Setup. ok is false
-// when no OTLP endpoint is configured. Used by `sigil doctor --probe` to send
+// when no OTLP endpoint is configured. Used by `agento11y doctor --probe` to send
 // a lightweight request to each signal and report the HTTP status without
 // standing up the full exporter pipeline.
 func ProbeConfig() (metrics, traces ProbeTarget, ok bool) {

--- a/plugins/agento11y/internal/otel/otel_test.go
+++ b/plugins/agento11y/internal/otel/otel_test.go
@@ -218,7 +218,7 @@ func newTestServer(t *testing.T, handler http.Handler) *httptest.Server {
 }
 
 func TestSetupAttachesServiceInstanceID(t *testing.T) {
-	t.Setenv("OTEL_SERVICE_NAME", "sigil")
+	t.Setenv("OTEL_SERVICE_NAME", "agento11y")
 
 	captured := newOTLPCapture(t)
 	defer captured.server.Close()
@@ -252,16 +252,16 @@ func TestSetupAttachesServiceInstanceID(t *testing.T) {
 	if got := findAttr(traceAttrs, "service.instance.id"); got != "sess-abc" {
 		t.Fatalf("trace service.instance.id = %q, want %q", got, "sess-abc")
 	}
-	if got := findAttr(traceAttrs, "service.name"); got != "sigil" {
-		t.Fatalf("trace service.name = %q, want %q", got, "sigil")
+	if got := findAttr(traceAttrs, "service.name"); got != "agento11y" {
+		t.Fatalf("trace service.name = %q, want %q", got, "agento11y")
 	}
 
 	metricAttrs := captured.metricResourceAttrs(t)
 	if got := findAttr(metricAttrs, "service.instance.id"); got != "sess-abc" {
 		t.Fatalf("metric service.instance.id = %q, want %q", got, "sess-abc")
 	}
-	if got := findAttr(metricAttrs, "service.name"); got != "sigil" {
-		t.Fatalf("metric service.name = %q, want %q", got, "sigil")
+	if got := findAttr(metricAttrs, "service.name"); got != "agento11y" {
+		t.Fatalf("metric service.name = %q, want %q", got, "agento11y")
 	}
 }
 

--- a/plugins/agento11y/internal/updatecheck/check.go
+++ b/plugins/agento11y/internal/updatecheck/check.go
@@ -11,15 +11,13 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/xdg"
 )
 
-const appName = "sigil"
-
 var (
-	stateRoot = func() string { return xdg.StateRoot(appName) }
+	stateRoot = xdg.AppStateRoot
 	now       = time.Now
 )
 
 // ShouldRun reports whether agent's refresh should run.
-func ShouldRun(agent string, ttl time.Duration, sigilVersion string) bool {
+func ShouldRun(agent string, ttl time.Duration, binaryVersion string) bool {
 	if Disabled() {
 		return false
 	}
@@ -35,7 +33,7 @@ func ShouldRun(agent string, ttl time.Duration, sigilVersion string) bool {
 	if err != nil {
 		return true
 	}
-	if strings.TrimSpace(string(data)) != normalizeVersion(sigilVersion) {
+	if strings.TrimSpace(string(data)) != normalizeVersion(binaryVersion) {
 		return true
 	}
 	return now().Sub(info.ModTime()) >= ttl
@@ -43,12 +41,12 @@ func ShouldRun(agent string, ttl time.Duration, sigilVersion string) bool {
 
 // Record marks agent's refresh as attempted. Errors are ignored so update
 // bookkeeping cannot block launching the wrapped CLI.
-func Record(agent, sigilVersion string) {
+func Record(agent, binaryVersion string) {
 	path := stampPath(agent)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return
 	}
-	if err := os.WriteFile(path, []byte(normalizeVersion(sigilVersion)), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(normalizeVersion(binaryVersion)), 0o600); err != nil {
 		return
 	}
 	t := now()

--- a/plugins/agento11y/internal/useragent/useragent.go
+++ b/plugins/agento11y/internal/useragent/useragent.go
@@ -1,4 +1,4 @@
-// Package useragent builds the generation-export User-Agent for the sigil
+// Package useragent builds the generation-export User-Agent for the agento11y
 // binary's coding-agent plugins. Each plugin identifies itself with its own
 // most-specific token followed by the SDK default, e.g.
 // "agento11y-plugin-claude-code/<ver> agento11y-sdk-go/<ver>".
@@ -6,11 +6,11 @@ package useragent
 
 import "github.com/grafana/agento11y/go/agento11y"
 
-// SigilVersion is the sigil binary build version, set once from main.
-var SigilVersion = "dev"
+// Version is the agento11y binary build version, set once from main.
+var Version = "dev"
 
 // For returns the generation-export User-Agent for an agent plugin:
-// "agento11y-plugin-<agent>/<SigilVersion> agento11y-sdk-go/<sdkVersion>".
+// "agento11y-plugin-<agent>/<Version> agento11y-sdk-go/<sdkVersion>".
 func For(agent string) string {
-	return "agento11y-plugin-" + agent + "/" + SigilVersion + " " + agento11y.UserAgent()
+	return "agento11y-plugin-" + agent + "/" + Version + " " + agento11y.UserAgent()
 }

--- a/plugins/agento11y/internal/useragent/useragent_test.go
+++ b/plugins/agento11y/internal/useragent/useragent_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func TestFor(t *testing.T) {
-	old := SigilVersion
-	t.Cleanup(func() { SigilVersion = old })
-	SigilVersion = "1.2.3"
+	old := Version
+	t.Cleanup(func() { Version = old })
+	Version = "1.2.3"
 
 	for _, agent := range []string{"claude-code", "cursor", "codex", "copilot"} {
 		t.Run(agent, func(t *testing.T) {

--- a/plugins/agento11y/internal/xdg/xdg.go
+++ b/plugins/agento11y/internal/xdg/xdg.go
@@ -1,4 +1,4 @@
-// Package xdg resolves XDG base directory paths for the sigil plugin
+// Package xdg resolves XDG base directory paths for the agento11y plugin
 // binary. All paths land under a single appName-suffixed directory so all
 // agents share state and logs.
 package xdg
@@ -13,6 +13,32 @@ import (
 )
 
 var unsafePath = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+const (
+	// appName is the preferred state directory name.
+	appName = "agento11y"
+	// legacyAppName is the pre-rename state directory, still used when it is
+	// the only one present so existing installs keep their fragments, local
+	// data, and update stamps. The directory is never moved or copied.
+	legacyAppName = "sigil"
+)
+
+// AppStateRoot returns the launcher state root:
+// $XDG_STATE_HOME/agento11y if that directory exists, otherwise the legacy
+// $XDG_STATE_HOME/sigil if that exists, otherwise the new path (with the
+// usual state-root fallbacks). Preferring the new path when both exist
+// mirrors the config.env resolution in the dotenv package.
+func AppStateRoot() string {
+	preferred := StateRoot(appName)
+	if _, err := os.Stat(preferred); err == nil {
+		return preferred
+	}
+	legacy := StateRoot(legacyAppName)
+	if _, err := os.Stat(legacy); err == nil {
+		return legacy
+	}
+	return preferred
+}
 
 // StateRoot returns the root state directory.
 // Honors XDG_STATE_HOME, falls back to $HOME/.local/state, then OS tempdir.
@@ -44,9 +70,11 @@ func ConfigRoot(appName string) string {
 	return filepath.Join(home, ".config", appName)
 }
 
-// LogFilePath is where SIGIL_DEBUG=true writes its log.
-func LogFilePath(appName string) string {
-	return filepath.Join(StateRoot(appName), "logs", appName+".log")
+// LogFilePath is where AGENTO11Y_DEBUG=true (SIGIL_DEBUG fallback) writes
+// its log. The file name is always agento11y.log even when AppStateRoot
+// resolves to the legacy sigil directory.
+func LogFilePath() string {
+	return filepath.Join(AppStateRoot(), "logs", appName+".log")
 }
 
 // ConfigFilePath returns the path to a dotenv config file.

--- a/plugins/agento11y/internal/xdg/xdg_test.go
+++ b/plugins/agento11y/internal/xdg/xdg_test.go
@@ -1,6 +1,7 @@
 package xdg
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -48,11 +49,39 @@ func TestStateRootHonorsAbsoluteXDGStateHome(t *testing.T) {
 }
 
 func TestLogFilePathUsesStateRoot(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", "/tmp/test-state")
-	got := LogFilePath("sigil")
-	want := filepath.Join("/tmp/test-state", "sigil", "logs", "sigil.log")
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+	got := LogFilePath()
+	want := filepath.Join(dir, "agento11y", "logs", "agento11y.log")
 	if got != want {
 		t.Fatalf("LogFilePath() = %q, want %q", got, want)
+	}
+}
+
+func TestAppStateRoot(t *testing.T) {
+	cases := []struct {
+		name     string
+		existing []string
+		want     string
+	}{
+		{name: "fresh install uses new dir", existing: nil, want: "agento11y"},
+		{name: "legacy only keeps legacy dir", existing: []string{"sigil"}, want: "sigil"},
+		{name: "new only uses new dir", existing: []string{"agento11y"}, want: "agento11y"},
+		{name: "both prefer new dir", existing: []string{"sigil", "agento11y"}, want: "agento11y"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("XDG_STATE_HOME", dir)
+			for _, name := range tc.existing {
+				if err := os.MkdirAll(filepath.Join(dir, name), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got, want := AppStateRoot(), filepath.Join(dir, tc.want); got != want {
+				t.Fatalf("AppStateRoot() = %q, want %q", got, want)
+			}
+		})
 	}
 }
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -86,7 +86,7 @@ If nothing shows up:
 
 ```sh
 AGENTO11Y_DEBUG=true agento11y claude  # one turn
-tail -f ~/.local/state/sigil/logs/sigil.log
+tail -f ~/.local/state/agento11y/logs/agento11y.log
 ```
 
 Common culprits: `agento11y --version` doesn't work (binary not on `PATH`), a missing token, or a token without the `sigil:write` scope.
@@ -104,7 +104,7 @@ Common culprits: `agento11y --version` doesn't work (binary not on `PATH`), a mi
 | `AGENTO11Y_TAGS` | — | `key=value,key=value` tags on every generation and as `agento11y.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). |
 | `AGENTO11Y_USER_ID` | from `~/.claude.json` | Override the user id. |
 | `AGENTO11Y_USER_ID_SOURCE` | `email` | Which field to read from `~/.claude.json`: `email` or `accountUuid`. |
-| `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
+| `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
 | `AGENTO11Y_AUTO_UPDATE` | `true` | Refresh the `sigil-cc` plugin automatically. Set `false` to pin the installed version. |
 | `AGENTO11Y_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Claude Code `PreToolUse` hook calls Sigil's `/api/v1/hooks:evaluate` and blocks tool calls denied by guard rules. |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -104,7 +104,7 @@ If nothing shows up:
 
 ```sh
 AGENTO11Y_DEBUG=true agento11y codex  # one turn
-tail -f ~/.local/state/sigil/logs/sigil.log
+tail -f ~/.local/state/agento11y/logs/agento11y.log
 ```
 
 ## All options
@@ -119,7 +119,7 @@ tail -f ~/.local/state/sigil/logs/sigil.log
 | `AGENTO11Y_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md). |
 | `AGENTO11Y_TAGS` | — | `key=value,key=value` tags on every generation and as `agento11y.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). |
 | `AGENTO11Y_USER_ID` | — | Override the user id. |
-| `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
+| `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
 | `AGENTO11Y_GUARDS_ENABLED` | `false` | Enable Codex `PreToolUse` guards against Sigil rules. |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | Allow the tool call when the guard request fails (set `false` for fail-closed). |
 | `AGENTO11Y_GUARDS_TIMEOUT_MS` | `1500` | Per-call guard timeout. |

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -4,7 +4,7 @@ Forwards completed GitHub Copilot turns, hook-visible tool calls, error
 metadata, subagent lifecycle metadata, and optional prompt/tool content to
 [Grafana AI Observability](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/).
 Powered by the shared `agento11y` binary and driven by a single hooks file at
-`~/.copilot/hooks/sigil.json`, which is read by **both** the GitHub Copilot CLI
+`~/.copilot/hooks/agento11y.json`, which is read by **both** the GitHub Copilot CLI
 and Copilot Chat in **VS Code**. Each exported turn is tagged with the host it
 came from (`hook.surface` = `copilot-cli` or `vscode`).
 
@@ -40,9 +40,9 @@ agento11y copilot -- <copilot args>
 
 The script installs `agento11y` to `~/.local/bin`; `go install` uses `go env GOPATH`/bin (or `GOBIN`). Make sure that directory is on your `PATH`. See the [`agento11y` binary README](../agento11y/README.md#install) for all install options. The command was renamed from `sigil`; the old name still works but will be removed in a future release.
 
-`agento11y copilot` writes the shared hooks file to `~/.copilot/hooks/sigil.json`, prompts for missing Grafana Cloud credentials, writes `~/.config/agento11y/config.env`, removes any legacy `sigil-copilot` plugin left by older versions, and then launches Copilot CLI.
+`agento11y copilot` writes the shared hooks file to `~/.copilot/hooks/agento11y.json`, prompts for missing Grafana Cloud credentials, writes `~/.config/agento11y/config.env`, removes any legacy `sigil-copilot` plugin left by older versions, and then launches Copilot CLI.
 
-For VS Code, no launch wrapper is needed — once `~/.copilot/hooks/sigil.json` exists, add `~/.copilot/hooks` to the `chat.hookFilesLocations` setting and Copilot Chat picks it up.
+For VS Code, no launch wrapper is needed — once `~/.copilot/hooks/agento11y.json` exists, add `~/.copilot/hooks` to the `chat.hookFilesLocations` setting and Copilot Chat picks it up.
 
 > The integration deliberately does **not** register a Copilot CLI plugin. The
 > CLI runs hooks from the plugin store *and* `~/.copilot/hooks`, so a plugin
@@ -100,7 +100,7 @@ If nothing shows up:
 
 ```sh
 AGENTO11Y_DEBUG=true agento11y copilot   # one turn
-tail -f ~/.local/state/sigil/logs/sigil.log
+tail -f ~/.local/state/agento11y/logs/agento11y.log
 ```
 
 ## Supported Hook Events
@@ -165,7 +165,7 @@ Limits:
 | `AGENTO11Y_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. |
 | `AGENTO11Y_TAGS` | — | `key=value,key=value` tags on every generation and as `agento11y.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). |
 | `AGENTO11Y_USER_ID` | — | Override the user id. |
-| `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
+| `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
 | `AGENTO11Y_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Copilot `preToolUse` hook is evaluated against Sigil: tool calls denied by guard rules are blocked, and Transform rules redact tool arguments in `copilot-cli`. |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |
 | `AGENTO11Y_GUARDS_TIMEOUT_MS` | `1500` | Per-call timeout. Lower = less added latency on every tool call, higher = better tolerance for slow `llm_judge` evaluators. |
@@ -200,7 +200,7 @@ Exported generations are always tagged with:
 ### Surface detection (`copilot-cli` vs `vscode`)
 
 The Copilot hook payload carries no host identifier, and one shared
-`~/.copilot/hooks/sigil.json` serves both hosts, so the surface is resolved at
+`~/.copilot/hooks/agento11y.json` serves both hosts, so the surface is resolved at
 runtime:
 
 1. An explicit `AGENTO11Y_COPILOT_HOOK_SURFACE` env var wins (the in-repo
@@ -221,13 +221,13 @@ field and the `AGENTO11Y_DEBUG` log line (`dispatch: event=… surface=…`).
 - Current observed Copilot CLI transcripts expose assistant text, model, request ids, message ids, native turn ids, reasoning effort, and output token counts. They do not appear to expose input token counts, cache token counts, or reasoning token counts for completed turns, so usage and cost can still be partial.
 - Copilot does not document a stable native turn ID in these hook payloads. This plugin creates a local monotonic turn ID per session and hashes it into the Sigil generation id.
 - Subagent hooks do not currently expose enough durable identity to synthesize separate child generations safely, so subagent activity is exported as parent-turn metadata only.
-- This package targets the local Copilot CLI and Copilot Chat in VS Code via the shared `~/.copilot/hooks/sigil.json`. Copilot cloud agent uses repository-level `.github/hooks/*.json` instead, and GitHub documents cloud-agent outbound network access as restricted by the firewall by default.
+- This package targets the local Copilot CLI and Copilot Chat in VS Code via the shared `~/.copilot/hooks/agento11y.json`. Copilot cloud agent uses repository-level `.github/hooks/*.json` instead, and GitHub documents cloud-agent outbound network access as restricted by the firewall by default.
 
 ## Troubleshooting
 
 | Symptom | Try |
 |---|---|
-| Hooks file missing at `~/.copilot/hooks/sigil.json` | Re-run `agento11y copilot -- <args>` (it writes the file before launching). For VS Code, also add `~/.copilot/hooks` to `chat.hookFilesLocations`. |
+| Hooks file missing at `~/.copilot/hooks/agento11y.json` | Re-run `agento11y copilot -- <args>` (it writes the file before launching). For VS Code, also add `~/.copilot/hooks` to `chat.hookFilesLocations`. |
 | Turns appear twice in Sigil | A leftover `sigil-copilot` plugin is firing alongside the shared file. Remove it: `copilot plugin uninstall sigil-copilot` (newer `agento11y copilot` runs do this automatically). |
 | Command not found | Reinstall `agento11y` (see step 1). Check `agento11y --version` and that its install dir is on `PATH`. |
 | Hooks run but nothing appears in Sigil | Check `AGENTO11Y_ENDPOINT`, `AGENTO11Y_AUTH_TENANT_ID`, and `AGENTO11Y_AUTH_TOKEN`. Without all three, the plugin discards the completed fragment. |

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -97,7 +97,7 @@ Use Cursor's agent for one turn, then open **AI Observability → Conversations*
 If nothing shows up, add `AGENTO11Y_DEBUG=true` to `~/.config/agento11y/config.env` (Cursor launches from the GUI, so a shell env var won't reach the hooks) and tail the log:
 
 ```sh
-tail -f ~/.local/state/sigil/logs/sigil.log
+tail -f ~/.local/state/agento11y/logs/agento11y.log
 ```
 
 ## All options
@@ -112,7 +112,7 @@ tail -f ~/.local/state/sigil/logs/sigil.log
 | `AGENTO11Y_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md). |
 | `AGENTO11Y_TAGS` | — | `key=value,key=value` tags on every generation and as `agento11y.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). Built-ins (`git.branch`, `cwd`, `subagent`) win on generation-export tag collision. |
 | `AGENTO11Y_USER_ID` | from Cursor | Override the user id. |
-| `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/sigil/logs/sigil.log`. |
+| `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
 | `AGENTO11Y_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Cursor `preToolUse` hook is evaluated against Sigil: tool calls denied by guard rules are blocked, and Transform rules rewrite the tool arguments before execution. |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |
 | `AGENTO11Y_GUARDS_TIMEOUT_MS` | `1500` | Per-call timeout. Lower = less added latency on every tool call, higher = better tolerance for slow `llm_judge` evaluators. |

--- a/plugins/opencode/src/guard.ts
+++ b/plugins/opencode/src/guard.ts
@@ -67,7 +67,7 @@ function formatEvalFailure(
   toolName: string,
   detail: string | undefined,
 ): string {
-  let msg = `Sigil could not evaluate the Grafana AI Observability guard for the "${toolName}" tool call, so it was blocked as a safety measure.`;
+  let msg = `agento11y could not evaluate the Grafana AI Observability guard for the "${toolName}" tool call, so it was blocked as a safety measure.`;
   const trimmed = detail?.trim();
   if (trimmed) {
     msg += ` Details: ${trimmed}`;

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -88,7 +88,7 @@ AGENTO11Y_CONTENT_CAPTURE_MODE=full
 
 Run one pi turn, then open **AI Observability → Conversations** in Grafana Cloud. A new generation should appear within a few seconds.
 
-If nothing shows up, set `AGENTO11Y_DEBUG=true` in `~/.config/agento11y/config.env`, run another turn, and check the debug log at `~/.local/state/sigil/logs/sigil.log` (honors `XDG_STATE_HOME`).
+If nothing shows up, set `AGENTO11Y_DEBUG=true` in `~/.config/agento11y/config.env`, run another turn, and check the debug log at `~/.local/state/agento11y/logs/agento11y.log` (honors `XDG_STATE_HOME`).
 
 ## Tagging sessions
 
@@ -150,7 +150,7 @@ Limits:
 | `AGENTO11Y_AGENT_NAME` | `pi` | Agent name reported to Sigil. |
 | `AGENTO11Y_AGENT_VERSION` | — | Optional version string reported with the agent. |
 | `AGENTO11Y_CONTENT_CAPTURE_MODE` | `metadata_only` | One of `full`, `no_tool_content`, `metadata_only`, or `full_with_metadata_spans`. `default` is accepted as an alias for `metadata_only`. |
-| `AGENTO11Y_DEBUG` | `false` | Write lifecycle events to `~/.local/state/sigil/logs/sigil.log` (honors `XDG_STATE_HOME`). Never written to the terminal, to avoid corrupting pi's TUI. |
+| `AGENTO11Y_DEBUG` | `false` | Write lifecycle events to `~/.local/state/agento11y/logs/agento11y.log` (honors `XDG_STATE_HOME`). Never written to the terminal, to avoid corrupting pi's TUI. |
 | `AGENTO11Y_REDACT_INPUT_MESSAGES` | `true` | Redact known secret patterns in user input messages before export. |
 | `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP HTTP endpoint. Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT`. |
 | `AGENTO11Y_OTEL_AUTH_TOKEN` | `AGENTO11Y_AUTH_TOKEN` | Override the OTLP password. |

--- a/plugins/pi/src/guard.ts
+++ b/plugins/pi/src/guard.ts
@@ -63,7 +63,7 @@ function formatEvalFailure(
   toolName: string,
   detail: string | undefined,
 ): string {
-  let msg = `Sigil could not evaluate the Grafana AI Observability guard for the "${toolName}" tool call, so it was blocked as a safety measure.`;
+  let msg = `agento11y could not evaluate the Grafana AI Observability guard for the "${toolName}" tool call, so it was blocked as a safety measure.`;
   const trimmed = detail?.trim();
   if (trimmed) {
     msg += ` Details: ${trimmed}`;

--- a/plugins/pi/src/logger.test.ts
+++ b/plugins/pi/src/logger.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -22,14 +22,31 @@ describe("logFilePath", () => {
 
   it("honors an absolute XDG_STATE_HOME", () => {
     process.env.XDG_STATE_HOME = "/var/state";
-    expect(stateRoot()).toBe("/var/state/sigil");
-    expect(logFilePath()).toBe("/var/state/sigil/logs/sigil.log");
+    expect(stateRoot()).toBe("/var/state/agento11y");
+    expect(logFilePath()).toBe("/var/state/agento11y/logs/agento11y.log");
   });
 
   it("ignores a relative XDG_STATE_HOME and falls back to HOME", () => {
     process.env.XDG_STATE_HOME = "relative/path";
     process.env.HOME = "/home/alex";
-    expect(logFilePath()).toBe("/home/alex/.local/state/sigil/logs/sigil.log");
+    expect(logFilePath()).toBe(
+      "/home/alex/.local/state/agento11y/logs/agento11y.log",
+    );
+  });
+
+  it("falls back to an existing legacy sigil state dir", () => {
+    const dir = mkdtempSync(join(tmpdir(), "agento11y-pi-state-"));
+    try {
+      process.env.XDG_STATE_HOME = dir;
+      mkdirSync(join(dir, "sigil"), { recursive: true });
+      expect(stateRoot()).toBe(join(dir, "sigil"));
+      expect(logFilePath()).toBe(join(dir, "sigil", "logs", "agento11y.log"));
+      // The new dir wins once it exists.
+      mkdirSync(join(dir, "agento11y"), { recursive: true });
+      expect(stateRoot()).toBe(join(dir, "agento11y"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -41,7 +58,7 @@ describe("logger", () => {
   };
 
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "sigil-pi-log-"));
+    dir = mkdtempSync(join(tmpdir(), "agento11y-pi-log-"));
     process.env.XDG_STATE_HOME = dir;
     delete process.env.SIGIL_DEBUG;
     delete process.env.AGENTO11Y_DEBUG;
@@ -58,7 +75,10 @@ describe("logger", () => {
   });
 
   function readLog(): string {
-    return readFileSync(join(dir, "sigil", "logs", "sigil.log"), "utf-8");
+    return readFileSync(
+      join(dir, "agento11y", "logs", "agento11y.log"),
+      "utf-8",
+    );
   }
 
   it("writes nothing when SIGIL_DEBUG is off", () => {
@@ -76,13 +96,13 @@ describe("logger", () => {
     logger.error("boom", new Error("nope"));
 
     const body = readLog();
-    expect(body).toContain("sigil[pi]:");
+    expect(body).toContain("agento11y[pi]:");
     expect(body).toContain("debug queued model=claude");
     expect(body).toContain("warn heads up");
     expect(body).toContain("error boom");
     expect(body).toContain("nope");
     // One line per call plus the Error's multi-line stack trace.
-    expect(body.split("sigil[pi]:")).toHaveLength(4);
+    expect(body.split("agento11y[pi]:")).toHaveLength(4);
   });
 
   it("re-reads SIGIL_DEBUG per call so dotenv-applied values take effect", () => {

--- a/plugins/pi/src/logger.ts
+++ b/plugins/pi/src/logger.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
 import { format } from "node:util";
@@ -6,14 +6,16 @@ import { format } from "node:util";
 // The pi plugin runs in-process inside pi's TUI. Anything written to the
 // terminal via console.* corrupts the live TUI frame (pi does not take over
 // stdout in interactive mode — see core/output-guard.ts). So all diagnostics
-// go to a file instead, matching the shared sigil binary, which writes its
-// debug log to $XDG_STATE_HOME/sigil/logs/sigil.log (see
+// go to a file instead, matching the shared agento11y binary, which writes
+// its debug log to $XDG_STATE_HOME/agento11y/logs/agento11y.log (see
 // plugins/agento11y/internal/xdg and internal/cli InitLogger). Logging is silent
 // unless AGENTO11Y_DEBUG (SIGIL_DEBUG fallback) is truthy.
-const APP_NAME = "sigil";
+const APP_NAME = "agento11y";
+// Pre-rename state directory, still used when it is the only one present so
+// existing installs keep their state in one place. Never moved or copied.
+const LEGACY_APP_NAME = "sigil";
 
-/** Mirrors plugins/agento11y/internal/xdg.StateRoot for app "sigil". */
-export function stateRoot(appName = APP_NAME): string {
+function stateRootFor(appName: string): string {
   const xdg = (process.env.XDG_STATE_HOME ?? "").trim();
   if (xdg && isAbsolute(xdg)) return join(xdg, appName);
   const home = homedir();
@@ -21,9 +23,22 @@ export function stateRoot(appName = APP_NAME): string {
   return join(tmpdir(), appName);
 }
 
-/** Mirrors plugins/agento11y/internal/xdg.LogFilePath for app "sigil". */
-export function logFilePath(appName = APP_NAME): string {
-  return join(stateRoot(appName), "logs", `${appName}.log`);
+/**
+ * Mirrors plugins/agento11y/internal/xdg.AppStateRoot: the agento11y state
+ * dir if it exists, otherwise the legacy sigil dir if it exists, otherwise
+ * the agento11y dir.
+ */
+export function stateRoot(): string {
+  const preferred = stateRootFor(APP_NAME);
+  if (existsSync(preferred)) return preferred;
+  const legacy = stateRootFor(LEGACY_APP_NAME);
+  if (existsSync(legacy)) return legacy;
+  return preferred;
+}
+
+/** Mirrors plugins/agento11y/internal/xdg.LogFilePath. */
+export function logFilePath(): string {
+  return join(stateRoot(), "logs", `${APP_NAME}.log`);
 }
 
 export interface Agento11yPiLogger {
@@ -62,12 +77,12 @@ function ensureLogDir(path: string): boolean {
 }
 
 function emit(level: string, message: string, args: unknown[]): void {
-  // Re-read the env per write: loadConfig() applies the sigil dotenv file,
+  // Re-read the env per write: loadConfig() applies the launcher dotenv file,
   // which may set the debug variable after the module first loads.
   if (!debugEnabled()) return;
   const path = logFilePath();
   if (!ensureLogDir(path)) return;
-  const line = `sigil[pi]: ${new Date().toISOString()} ${level} ${format(message, ...args)}\n`;
+  const line = `agento11y[pi]: ${new Date().toISOString()} ${level} ${format(message, ...args)}\n`;
   try {
     appendFileSync(path, line, { mode: 0o600 });
   } catch {

--- a/plugins/vibe/README.md
+++ b/plugins/vibe/README.md
@@ -31,7 +31,7 @@ agento11y vibe
 
 The command was renamed from `sigil`; the old name still works but will be removed in a future release.
 
-`agento11y vibe` resolves the `vibe` binary on `PATH`, upserts the three sigil-owned `[[hooks]]` entries into `~/.vibe/hooks.toml` (or `$VIBE_HOME/hooks.toml`) on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/agento11y/config.env`, and then execs it. Repeated runs are no-ops: each entry is matched by name (`sigil`, `sigil-before-tool`, `sigil-after-tool`) and any hand-authored hooks in the same file are preserved.
+`agento11y vibe` resolves the `vibe` binary on `PATH`, upserts the three agento11y-owned `[[hooks]]` entries into `~/.vibe/hooks.toml` (or `$VIBE_HOME/hooks.toml`) on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/agento11y/config.env`, and then execs it. Repeated runs are no-ops: each entry is matched by name (`agento11y`, `agento11y-before-tool`, `agento11y-after-tool`); entries under the pre-rename `sigil*` names are replaced and any hand-authored hooks in the same file are preserved.
 
 The launcher always sets `VIBE_ENABLE_EXPERIMENTAL_HOOKS=true` in Mistral Vibe's environment because these events are gated behind that flag.
 
@@ -42,20 +42,20 @@ Add these blocks to `~/.vibe/hooks.toml`:
 
 ```toml
 [[hooks]]
-name = "sigil"
+name = "agento11y"
 type = "post_agent_turn"
 command = "agento11y vibe hook"
 timeout = 30
 
 [[hooks]]
-name = "sigil-before-tool"
+name = "agento11y-before-tool"
 type = "before_tool"
 command = "agento11y vibe hook"
 timeout = 30
 match = "*"
 
 [[hooks]]
-name = "sigil-after-tool"
+name = "agento11y-after-tool"
 type = "after_tool"
 command = "agento11y vibe hook"
 timeout = 30


### PR DESCRIPTION
Renames the remaining `sigil` namings in the launcher: state dir, debug log, OTel service name, vibe/Copilot hook entries, and the `doctor` JSON section. Follow-up for #401.

- state moves to `~/.local/state/agento11y` with the same resolution as the config file in #401: legacy `~/.local/state/sigil` is used when exists
- the debug log is now `logs/agento11y.log`
- vibe `hooks.toml` entries and the Copilot `~/.copilot/hooks/sigil.json` file are replaced on the next launch so hooks don't fire twice

Plugin IDs (`sigil-cc`, `sigil-copilot`), the `grafana-sigil-app` URLs, and the marketplace repo names are unchanged for now.