### PR TITLE
chore(actions): default release version bump to minor

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -11,6 +11,7 @@ on:
           - patch
           - minor
           - major
+        default: minor
       dry-run:
         description: 'Preview only, do not publish or push tags'
         required: false

--- a/.github/workflows/go-sdk-tag.yml
+++ b/.github/workflows/go-sdk-tag.yml
@@ -11,6 +11,7 @@ on:
           - patch
           - minor
           - major
+        default: minor
       dry-run:
         description: 'Preview only, do not create or push tags'
         required: false

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -11,6 +11,7 @@ on:
           - patch
           - minor
           - major
+        default: minor
       dry-run:
         description: 'Preview only, do not publish or push tags'
         required: false

--- a/.github/workflows/js-sdk-publish.yml
+++ b/.github/workflows/js-sdk-publish.yml
@@ -11,6 +11,7 @@ on:
           - patch
           - minor
           - major
+        default: minor
       dry-run:
         description: 'Preview only, do not publish, open a PR, or push tags'
         required: false

--- a/.github/workflows/plugins-publish.yml
+++ b/.github/workflows/plugins-publish.yml
@@ -19,6 +19,7 @@ on:
           - patch
           - minor
           - major
+        default: minor
       dry-run:
         description: 'Preview only, do not publish, open a PR, or push tags'
         required: false

--- a/.github/workflows/python-sdks-publish.yml
+++ b/.github/workflows/python-sdks-publish.yml
@@ -11,6 +11,7 @@ on:
           - patch
           - minor
           - major
+        default: minor
       dry-run:
         description: 'Preview only, do not publish, open a PR, or push tags'
         required: false

--- a/.github/workflows/release-agento11y.yml
+++ b/.github/workflows/release-agento11y.yml
@@ -16,6 +16,7 @@ on:
           - patch
           - minor
           - major
+        default: minor
       dry-run:
         description: 'Preview only, do not open the release PR'
         required: false


### PR DESCRIPTION
The version choice inputs had no explicit default, so the GitHub UI preselected the first option (patch). Most releases add features rather than just fixes, so minor is the safer preselection.