### PR TITLE
docs: promote agento11y instrumentation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,35 @@
 
 ## Quick start (with an AI coding agent)
 
-Drop [`llms.txt`](llms.txt) into your repo and ask your agent what you want. It handles either case, depending on what your repo is:
+If you want your own app or agent code instrumented, the recommended path is the `agento11y-instrument` agent skill. [`gcx`](https://github.com/grafana/gcx) is Grafana's CLI for working with Grafana Cloud resources; see the [`gcx` installation docs](https://github.com/grafana/gcx#installation) if you want more detail.
+
+Install `gcx` with the quick install script:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | sh
+```
+
+Or with Homebrew:
+
+```sh
+brew install grafana/grafana/gcx
+```
+
+Then install the skill:
+
+```sh
+gcx agent skills install agento11y-instrument
+```
+
+If `gcx` is already installed but the skill is missing, update `gcx` first. Homebrew users can run `brew update && brew upgrade gcx`; script users can re-run the quick install script.
+
+```text
+Use the `agento11y-instrument` skill to instrument this codebase with Grafana AI observability.
+```
+
+The skill inspects your code, applies the SDK with small diffs after confirmation, and verifies that data lands in Grafana Cloud with `gcx agento11y`.
+
+If you want to capture sessions from your coding agent instead, or if your agent does not support skills, drop [`llms.txt`](llms.txt) into your repo and ask your agent what you want. It handles either case, depending on what your repo is:
 
 - `Instrument this codebase with Grafana AI observability`: the agent wires the [SDK](#sdks) into your app or agent code.
 - `Set up Grafana AI observability for my coding agent`: the agent installs one of the [`plugins/`](plugins/) launchers to capture sessions from popular coding agents.

--- a/llms.txt
+++ b/llms.txt
@@ -9,6 +9,34 @@ There are two distinct things this file covers. Pick the path that matches the r
 
 If you cannot tell, ask one clarifying question and stop.
 
+If the request matches Path B and this agent supports external skills, prefer the `agento11y-instrument` skill over these static instructions. `gcx` is Grafana's CLI for working with Grafana Cloud resources; see the `gcx` installation docs at https://github.com/grafana/gcx#installation if you want more detail. Install or update `gcx`, install the skill, invoke it, and use this file only as the SDK reference it points back to.
+
+Install `gcx` with the quick install script:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | sh
+```
+
+Or with Homebrew:
+
+```sh
+brew install grafana/grafana/gcx
+```
+
+Then install the skill:
+
+```sh
+gcx agent skills install agento11y-instrument
+```
+
+If `gcx` is already installed but the skill is missing, update `gcx` first. Homebrew users can run `brew update && brew upgrade gcx`; script users can re-run the quick install script.
+
+```text
+Use the `agento11y-instrument` skill to instrument this codebase with Grafana AI observability.
+```
+
+If skills are unavailable, the install fails, or the request matches Path A, continue with the matching path below.
+
 ## Resources
 
 - Product docs: https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/


### PR DESCRIPTION
## Summary
- Promote the `agento11y-instrument` skill as the recommended path for SDK users instrumenting their own app or agent code.
- Add `gcx` install context, script/Homebrew options, update guidance, and fallback instructions for agents without skill support.

## Test plan
- `git diff --check -- README.md llms.txt`
- ReadLints on `README.md` and `llms.txt`