### PR TITLE
feat(plugins): migrate legacy sigil plugin installs to agento11y

### DIFF
--- a/plugins/agento11y/internal/agents/claudecode/launch.go
+++ b/plugins/agento11y/internal/agents/claudecode/launch.go
@@ -23,11 +23,19 @@ const (
 	// `claude plugin marketplace add`.
 	marketplaceRepo = "grafana/agento11y"
 	// marketplaceAlias is the marketplace name declared in
-	// .claude-plugin/marketplace.json.
-	marketplaceAlias = "grafana-sigil"
+	// .claude-plugin/marketplace.json. Claude Code keys a marketplace by the
+	// name its manifest declared when the user added it and never re-keys,
+	// so registrations that predate the sigil rename answer only to
+	// legacyMarketplaceAlias.
+	marketplaceAlias       = "agento11y"
+	legacyMarketplaceAlias = "grafana-sigil"
 	// PluginName is the plugin name declared in
-	// plugins/claude-code/.claude-plugin/plugin.json.
-	PluginName = "sigil-cc"
+	// plugins/claude-code/.claude-plugin/plugin.json. legacyPluginName is the
+	// pre-rename name: the marketplace's renames map migrates legacy installs
+	// at session start (Claude Code >= 2.1.193), so the probe treats them as
+	// installed instead of reinstalling on top.
+	PluginName       = "agento11y-claude-code"
+	legacyPluginName = "sigil-cc"
 
 	updateCheckTTL = 24 * time.Hour
 )
@@ -38,10 +46,12 @@ var (
 	execFn     = syscall.Exec
 	runInstall = defaultRunInstall
 	runUpdate  = defaultRunUpdate
+	runSteps   = launcher.RunSteps
+	runFirst   = launcher.RunFirst
 	getwd      = os.Getwd
 )
 
-// Launch resolves the `claude` binary on PATH, ensures the sigil-cc plugin
+// Launch resolves the `claude` binary on PATH, ensures the Claude Code plugin
 // is registered in Claude Code's plugin store (running `claude plugin
 // marketplace add` + `claude plugin install` once if it is not), and then
 // exec's claude with the supplied args. When localEnv is non-nil, the
@@ -65,21 +75,40 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 		ProbeErrLog: "installed_plugins.json probe",
 		Install:     runInstall,
 		InstallRecoveryHint: func(w io.Writer) {
-			fmt.Fprintf(w, "          claude plugin install %s@%s\n", PluginName, marketplaceAlias)
+			fmt.Fprintf(w,
+				"          claude plugin marketplace add %s\n"+
+					"          claude plugin install %s@%s\n"+
+					"          (marketplaces added before the rename keep the %s alias; there run\n"+
+					"           claude plugin marketplace update %s\n"+
+					"           claude plugin install %s@%s)\n",
+				marketplaceRepo, PluginName, marketplaceAlias,
+				legacyMarketplaceAlias,
+				legacyMarketplaceAlias, PluginName, legacyMarketplaceAlias)
 		},
 		Update: runUpdate,
+		// The hint mirrors what defaultRunUpdate just attempted: the installed
+		// key's alias, not the current one, since pre-rename registrations
+		// keep the sticky legacy alias and commands against the current alias
+		// would fail for them.
 		UpdateRecoveryHint: func(w io.Writer) {
+			key := updateTargetKey()
+			alias := key[strings.IndexByte(key, '@')+1:]
 			fmt.Fprintf(w,
 				"          claude plugin marketplace update %s\n"+
-					"          claude plugin update %s@%s\n",
-				marketplaceAlias, PluginName, marketplaceAlias)
+					"          claude plugin update %s\n",
+				alias, key)
+			if strings.HasPrefix(key, legacyPluginName+"@") {
+				fmt.Fprintf(w,
+					"          (if the update no longer finds %s, run: claude plugin install %s@%s)\n",
+					key, PluginName, alias)
+			}
 		},
 		UpdateTTL:     updateCheckTTL,
 		BinaryVersion: binaryVersion,
 	})
 }
 
-// Status reports whether the sigil-cc plugin is installed for the current
+// Status reports whether the Claude Code plugin is installed for the current
 // working directory. It reuses the read-only pluginInstalled probe and never
 // installs, updates, or writes update-check state — `agento11y doctor` relies on
 // this. installed_plugins.json carries no version, so version is always empty
@@ -90,17 +119,56 @@ func Status(_ context.Context) (installed bool, version string, err error) {
 }
 
 func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {
-	return launcher.RunSteps(ctx, bin, w, [][]string{
-		{"plugin", "marketplace", "add", marketplaceRepo},
+	if err := runSteps(ctx, bin, w, [][]string{{"plugin", "marketplace", "add", marketplaceRepo}}); err != nil {
+		return err
+	}
+	// Adding is a no-op when the marketplace is already registered, and the
+	// registration keeps whatever name its manifest declared at the time. So
+	// the plugin may only be addressable via the legacy alias, and a
+	// marketplace copy that predates the rename lists only the legacy plugin
+	// name. Try the current names first, then fall back.
+	_, err := runFirst(ctx, bin, w, [][]string{
 		{"plugin", "install", PluginName + "@" + marketplaceAlias},
+		{"plugin", "install", PluginName + "@" + legacyMarketplaceAlias},
+		{"plugin", "install", legacyPluginName + "@" + legacyMarketplaceAlias},
 	})
+	return err
+}
+
+// updateTargetKey returns the `<plugin>@<marketplace>` key the update path
+// targets. The installed key wins because Claude Code never re-keys a
+// marketplace, so registrations that predate the rename answer only to the
+// sticky legacy alias. The probe reported the plugin installed just before
+// the update runs, so an empty or unreadable store here is exceptional —
+// fall back to the current names rather than failing the refresh.
+func updateTargetKey() string {
+	key, err := installedPluginKey()
+	if err != nil || key == "" {
+		return PluginName + "@" + marketplaceAlias
+	}
+	return key
 }
 
 func defaultRunUpdate(ctx context.Context, bin string, w io.Writer) error {
-	return launcher.RunSteps(ctx, bin, w, [][]string{
-		{"plugin", "marketplace", "update", marketplaceAlias},
-		{"plugin", "update", PluginName + "@" + marketplaceAlias},
+	key := updateTargetKey()
+	alias := key[strings.IndexByte(key, '@')+1:]
+	if err := runSteps(ctx, bin, w, [][]string{{"plugin", "marketplace", "update", alias}}); err != nil {
+		return err
+	}
+	if !strings.HasPrefix(key, legacyPluginName+"@") {
+		return runSteps(ctx, bin, w, [][]string{{"plugin", "update", key}})
+	}
+	// Legacy install. While the local marketplace copy predates the rename it
+	// still lists the legacy name and a plain update works. Once the refresh
+	// above pulls a post-rename copy the legacy name is gone: update fails,
+	// and installing the renamed plugin under the same (sticky) alias
+	// migrates the entry. Claude Code's renames map rewrites the remaining
+	// legacy settings keys at the next session start.
+	_, err := runFirst(ctx, bin, w, [][]string{
+		{"plugin", "update", key},
+		{"plugin", "install", PluginName + "@" + alias},
 	})
+	return err
 }
 
 // installedPluginsFile is the JSON shape Claude Code writes to
@@ -121,40 +189,52 @@ type installedPluginEntry struct {
 	ProjectPath string `json:"projectPath"`
 }
 
-// pluginInstalled reports whether the sigil-cc plugin is registered in
+// pluginInstalled reports whether the Claude Code plugin is registered in
 // Claude Code's plugin store *for the current working directory*.
+func pluginInstalled() (bool, error) {
+	key, err := installedPluginKey()
+	return key != "", err
+}
+
+// installedPluginKey returns the `<plugin>@<marketplace>` key registering
+// the plugin for the current working directory, preferring the current
+// plugin name over the legacy pre-rename one; empty when not installed.
+// Legacy keys count as installed because Claude Code itself migrates them to
+// the current name at session start via the marketplace renames map —
+// reinstalling on top would be redundant.
 //
 // Claude Code records per-entry `scope` and `projectPath`: `user` scope
 // is active in every session, while `project` and `local` only apply when
 // the session's cwd matches the recorded `projectPath`. Treating any
-// `sigil-cc@*` key as installed would let a per-directory install for an
+// matching key as installed would let a per-directory install for an
 // unrelated project suppress bootstrap here, leaving agento11y hooks inactive.
 // Marketplace alias is intentionally ignored so a foreign alias is not
 // reinstalled on top of.
-func pluginInstalled() (bool, error) {
+func installedPluginKey() (string, error) {
 	path, err := installedPluginsPath()
 	if err != nil {
-		return false, err
+		return "", err
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return false, nil
+			return "", nil
 		}
-		return false, fmt.Errorf("read %s: %w", path, err)
+		return "", fmt.Errorf("read %s: %w", path, err)
 	}
 	var f installedPluginsFile
 	if err := json.Unmarshal(data, &f); err != nil {
-		return false, fmt.Errorf("parse %s: %w", path, err)
+		return "", fmt.Errorf("parse %s: %w", path, err)
 	}
 	cwd, err := getwd()
 	if err != nil {
-		return false, fmt.Errorf("resolve cwd: %w", err)
+		return "", fmt.Errorf("resolve cwd: %w", err)
 	}
 	cwdClean := filepath.Clean(cwd)
-	prefix := PluginName + "@"
+	var legacyKey string
 	for key, raw := range f.Plugins {
-		if !strings.HasPrefix(key, prefix) {
+		isCurrent := strings.HasPrefix(key, PluginName+"@")
+		if !isCurrent && !strings.HasPrefix(key, legacyPluginName+"@") {
 			continue
 		}
 		var entries []installedPluginEntry
@@ -164,15 +244,17 @@ func pluginInstalled() (bool, error) {
 			continue
 		}
 		for _, e := range entries {
-			if e.Scope == "user" {
-				return true, nil
+			if e.Scope != "user" && (e.ProjectPath == "" || filepath.Clean(e.ProjectPath) != cwdClean) {
+				continue
 			}
-			if e.ProjectPath != "" && filepath.Clean(e.ProjectPath) == cwdClean {
-				return true, nil
+			if isCurrent {
+				return key, nil
 			}
+			legacyKey = key
+			break
 		}
 	}
-	return false, nil
+	return legacyKey, nil
 }
 
 // installedPluginsPath returns the path to Claude Code's

--- a/plugins/agento11y/internal/agents/claudecode/launch_test.go
+++ b/plugins/agento11y/internal/agents/claudecode/launch_test.go
@@ -197,8 +197,75 @@ func TestLaunch_InstallFailureContinuesToExec(t *testing.T) {
 	if !strings.Contains(got, "network down") {
 		t.Fatalf("stderr missing underlying error: %q", got)
 	}
-	if !strings.Contains(got, "claude plugin install "+PluginName+"@") {
+	if !strings.Contains(got, "claude plugin install "+PluginName+"@"+marketplaceAlias) {
 		t.Fatalf("stderr missing manual install hint: %q", got)
+	}
+	// Pre-rename marketplaces keep the sticky legacy alias; the hint must
+	// include a command that works there too.
+	if !strings.Contains(got, "claude plugin install "+PluginName+"@"+legacyMarketplaceAlias) {
+		t.Fatalf("stderr missing legacy-alias install hint: %q", got)
+	}
+}
+
+func TestLaunch_UpdateFailureHintUsesInstalledKey(t *testing.T) {
+	cases := []struct {
+		name        string
+		installed   string
+		wantLines   []string
+		absentLines []string
+	}{
+		{
+			name:      "current key",
+			installed: `{"version":2,"plugins":{"agento11y-claude-code@agento11y":[{"scope":"user"}]}}`,
+			wantLines: []string{
+				"claude plugin marketplace update agento11y\n",
+				"claude plugin update agento11y-claude-code@agento11y\n",
+			},
+			absentLines: []string{"grafana-sigil"},
+		},
+		{
+			name:      "migrated key keeps the sticky legacy alias",
+			installed: `{"version":2,"plugins":{"agento11y-claude-code@grafana-sigil":[{"scope":"user"}]}}`,
+			wantLines: []string{
+				"claude plugin marketplace update grafana-sigil\n",
+				"claude plugin update agento11y-claude-code@grafana-sigil\n",
+			},
+			absentLines: []string{"claude plugin install"},
+		},
+		{
+			name:      "legacy key adds the install fallback",
+			installed: `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"user"}]}}`,
+			wantLines: []string{
+				"claude plugin marketplace update grafana-sigil\n",
+				"claude plugin update sigil-cc@grafana-sigil\n",
+				"claude plugin install agento11y-claude-code@grafana-sigil",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			dir := t.TempDir()
+			writeInstalled(t, dir, tc.installed)
+			t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+			withLookPath(t, func(string) (string, error) { return "/usr/local/bin/claude", nil })
+			withRunUpdate(t, func(context.Context, string, io.Writer) error {
+				return errors.New("network down")
+			})
+			withExecFn(t, func(string, []string, []string) error { return nil })
+
+			var stderr bytes.Buffer
+			launchOK(t, nil, io.Discard, &stderr)
+			got := stderr.String()
+			require.Contains(t, got, "update of "+PluginName+" failed")
+			for _, line := range tc.wantLines {
+				require.Contains(t, got, line)
+			}
+			for _, line := range tc.absentLines {
+				require.NotContains(t, got, line)
+			}
+		})
 	}
 }
 
@@ -301,7 +368,19 @@ func TestPluginInstalled_KeyShapes(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name:     "user scope matches anywhere",
+			name:     "current name user scope matches anywhere",
+			write:    true,
+			contents: `{"version":2,"plugins":{"agento11y-claude-code@agento11y":[{"scope":"user"}]}}`,
+			want:     true,
+		},
+		{
+			name:     "current name at sticky legacy alias matches",
+			write:    true,
+			contents: `{"version":2,"plugins":{"agento11y-claude-code@grafana-sigil":[{"scope":"user"}]}}`,
+			want:     true,
+		},
+		{
+			name:     "legacy name user scope matches anywhere",
 			write:    true,
 			contents: `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"user"}]}}`,
 			want:     true,
@@ -416,6 +495,16 @@ func TestPluginInstalled_KeyShapes(t *testing.T) {
 	}
 }
 
+func TestInstalledPluginKey_PrefersCurrentName(t *testing.T) {
+	dir := t.TempDir()
+	writeInstalled(t, dir, `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"user"}],"agento11y-claude-code@grafana-sigil":[{"scope":"user"}]}}`)
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+	key, err := installedPluginKey()
+	require.NoError(t, err)
+	require.Equal(t, "agento11y-claude-code@grafana-sigil", key)
+}
+
 func TestPluginInstalled_GetwdFailureSurfaces(t *testing.T) {
 	dir := t.TempDir()
 	writeInstalled(t, dir, `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"project","projectPath":"/whatever"}]}}`)
@@ -471,6 +560,108 @@ func withRunUpdate(t *testing.T, fn func(context.Context, string, io.Writer) err
 	prev := runUpdate
 	t.Cleanup(func() { runUpdate = prev })
 	runUpdate = fn
+}
+
+func withRunSteps(t *testing.T, fn func(context.Context, string, io.Writer, [][]string) error) {
+	t.Helper()
+	prev := runSteps
+	t.Cleanup(func() { runSteps = prev })
+	runSteps = fn
+}
+
+func withRunFirst(t *testing.T, fn func(context.Context, string, io.Writer, [][]string) (int, error)) {
+	t.Helper()
+	prev := runFirst
+	t.Cleanup(func() { runFirst = prev })
+	runFirst = fn
+}
+
+// recordCommands stubs the runSteps/runFirst seams so the install/update
+// tests can assert the exact claude commands.
+func recordCommands(t *testing.T) (steps, candidates *[][]string) {
+	t.Helper()
+	steps, candidates = &[][]string{}, &[][]string{}
+	withRunSteps(t, func(_ context.Context, _ string, _ io.Writer, s [][]string) error {
+		*steps = append(*steps, s...)
+		return nil
+	})
+	withRunFirst(t, func(_ context.Context, _ string, _ io.Writer, c [][]string) (int, error) {
+		*candidates = append(*candidates, c...)
+		return 0, nil
+	})
+	return steps, candidates
+}
+
+func TestDefaultRunInstall_TriesCurrentNamesFirst(t *testing.T) {
+	steps, candidates := recordCommands(t)
+
+	require.NoError(t, defaultRunInstall(context.Background(), "/usr/local/bin/claude", io.Discard))
+	require.Equal(t, [][]string{{"plugin", "marketplace", "add", "grafana/agento11y"}}, *steps)
+	require.Equal(t, [][]string{
+		{"plugin", "install", "agento11y-claude-code@agento11y"},
+		{"plugin", "install", "agento11y-claude-code@grafana-sigil"},
+		{"plugin", "install", "sigil-cc@grafana-sigil"},
+	}, *candidates)
+}
+
+func TestDefaultRunUpdate_CommandSequences(t *testing.T) {
+	cases := []struct {
+		name           string
+		installed      string // installed_plugins.json content; empty means not written
+		wantSteps      [][]string
+		wantCandidates [][]string // empty means runFirst not called
+	}{
+		{
+			name:      "current key updates in place",
+			installed: `{"version":2,"plugins":{"agento11y-claude-code@agento11y":[{"scope":"user"}]}}`,
+			wantSteps: [][]string{
+				{"plugin", "marketplace", "update", "agento11y"},
+				{"plugin", "update", "agento11y-claude-code@agento11y"},
+			},
+		},
+		{
+			name:      "migrated key keeps the sticky legacy alias",
+			installed: `{"version":2,"plugins":{"agento11y-claude-code@grafana-sigil":[{"scope":"user"}]}}`,
+			wantSteps: [][]string{
+				{"plugin", "marketplace", "update", "grafana-sigil"},
+				{"plugin", "update", "agento11y-claude-code@grafana-sigil"},
+			},
+		},
+		{
+			name:      "legacy key falls back to installing the renamed plugin",
+			installed: `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"user"}]}}`,
+			wantSteps: [][]string{{"plugin", "marketplace", "update", "grafana-sigil"}},
+			wantCandidates: [][]string{
+				{"plugin", "update", "sigil-cc@grafana-sigil"},
+				{"plugin", "install", "agento11y-claude-code@grafana-sigil"},
+			},
+		},
+		{
+			name: "missing store falls back to current names",
+			wantSteps: [][]string{
+				{"plugin", "marketplace", "update", "agento11y"},
+				{"plugin", "update", "agento11y-claude-code@agento11y"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.installed != "" {
+				writeInstalled(t, dir, tc.installed)
+			}
+			t.Setenv("CLAUDE_CONFIG_DIR", dir)
+			steps, candidates := recordCommands(t)
+
+			require.NoError(t, defaultRunUpdate(context.Background(), "/usr/local/bin/claude", io.Discard))
+			require.Equal(t, tc.wantSteps, *steps)
+			if len(tc.wantCandidates) == 0 {
+				require.Empty(t, *candidates)
+			} else {
+				require.Equal(t, tc.wantCandidates, *candidates)
+			}
+		})
+	}
 }
 
 func launch(t *testing.T, args []string, stdout, stderr io.Writer) error {

--- a/plugins/agento11y/internal/agents/codex/launch.go
+++ b/plugins/agento11y/internal/agents/codex/launch.go
@@ -19,12 +19,20 @@ const (
 	// `codex plugin marketplace add`.
 	marketplaceRepo = "grafana/agento11y"
 	// marketplaceAlias is the marketplace name declared in
-	// .claude-plugin/marketplace.json (shared between Claude Code and Codex
-	// host plugins).
-	marketplaceAlias = "grafana-sigil"
+	// .agents/plugins/marketplace.json. Codex derives plugin keys from the
+	// marketplace manifest, so a local snapshot that predates the sigil
+	// rename exposes the plugin only as
+	// legacyPluginName@legacyMarketplaceAlias.
+	marketplaceAlias       = "agento11y"
+	legacyMarketplaceAlias = "grafana-sigil"
 	// PluginName is the codex plugin name declared in
-	// plugins/codex/.codex-plugin/plugin.json.
-	PluginName = "sigil-codex"
+	// plugins/codex/.codex-plugin/plugin.json; legacyPluginName is the
+	// pre-rename name. Codex has no rename mechanism: once the local
+	// marketplace snapshot is upgraded past the rename, a legacy install
+	// stops resolving and its config.toml entry lingers as an orphan, so the
+	// launcher migrates it (remove legacy + add current) itself.
+	PluginName       = "agento11y-codex"
+	legacyPluginName = "sigil-codex"
 
 	updateCheckTTL = 24 * time.Hour
 )
@@ -35,10 +43,13 @@ var (
 	execFn     = syscall.Exec
 	runInstall = defaultRunInstall
 	runUpdate  = defaultRunUpdate
+	runSteps   = launcher.RunSteps
+	runFirst   = launcher.RunFirst
+	runOutput  = launcher.Output
 	pluginList = defaultPluginList
 )
 
-// Launch resolves the `codex` binary on PATH, ensures the sigil-codex plugin
+// Launch resolves the `codex` binary on PATH, ensures the codex plugin
 // is registered and enabled in codex's plugin store (running
 // `codex plugin marketplace add` + `codex plugin add` once if it is not),
 // and then exec's codex with the supplied args. When localEnv is non-nil,
@@ -68,12 +79,12 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 				marketplaceRepo, PluginName, marketplaceAlias)
 		},
 		// One-time trust step the launcher cannot automate: codex requires
-		// the user to open /hooks inside the TUI and accept each
-		// sigil-codex hook on first run.
+		// the user to open /hooks inside the TUI and accept each hook after
+		// the plugin is installed (or reinstalled under a new name).
 		PostInstallHint: func(w io.Writer) {
 			fmt.Fprintf(w,
-				"agento11y: first run only — open /hooks inside codex and trust the\n"+
-					"           %s hooks to start exporting turns.\n", PluginName)
+				"agento11y: open /hooks inside codex and trust the agento11y hooks\n"+
+					"           to start exporting turns.\n")
 		},
 		Update: runUpdate,
 		UpdateRecoveryHint: func(w io.Writer) {
@@ -87,7 +98,7 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 	})
 }
 
-// Status reports whether the sigil-codex plugin is installed and enabled. It
+// Status reports whether the codex plugin is installed and enabled. It
 // reuses the read-only `codex plugin list` probe and never installs, updates,
 // or writes update-check state — `agento11y doctor` relies on this. codex's plugin
 // list does not expose a version, so version is always empty (best-effort).
@@ -101,28 +112,66 @@ func Status(ctx context.Context) (installed bool, version string, err error) {
 }
 
 func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {
-	return launcher.RunSteps(ctx, bin, w, [][]string{
-		{"plugin", "marketplace", "add", marketplaceRepo},
-		{"plugin", "add", PluginName + "@" + marketplaceAlias},
-	})
+	if err := runSteps(ctx, bin, w, [][]string{{"plugin", "marketplace", "add", marketplaceRepo}}); err != nil {
+		return err
+	}
+	return ensurePlugin(ctx, bin, w, false)
 }
 
 func defaultRunUpdate(ctx context.Context, bin string, w io.Writer) error {
-	return launcher.RunSteps(ctx, bin, w, [][]string{
-		{"plugin", "marketplace", "upgrade"},
+	// Snapshot the legacy state before the upgrade: when the refreshed
+	// marketplace copy drops the legacy name, ensurePlugin flips the install
+	// to the renamed plugin and the user must re-trust its hooks.
+	hadLegacy := false
+	if out, err := pluginList(ctx, bin); err == nil {
+		hadLegacy = keyEnabled(out, legacyPluginName+"@"+legacyMarketplaceAlias)
+	}
+	if err := runSteps(ctx, bin, w, [][]string{{"plugin", "marketplace", "upgrade"}}); err != nil {
+		return err
+	}
+	return ensurePlugin(ctx, bin, w, hadLegacy)
+}
+
+// ensurePlugin registers the plugin under its current name, falling back to
+// the legacy name when the local marketplace snapshot predates the rename.
+// After a successful current-name add it removes the legacy entry: the
+// snapshot is post-rename at that point, so a leftover legacy entry can
+// never resolve again and would sit in config.toml as an orphan. Removal is
+// best-effort and exits 0 even when nothing is registered, so it is safe on
+// fresh installs. migrated additionally prints the one-time /hooks re-trust
+// hint — codex treats the renamed plugin as a new hook identity.
+func ensurePlugin(ctx context.Context, bin string, w io.Writer, migrated bool) error {
+	idx, err := runFirst(ctx, bin, w, [][]string{
 		{"plugin", "add", PluginName + "@" + marketplaceAlias},
+		{"plugin", "add", legacyPluginName + "@" + legacyMarketplaceAlias},
 	})
+	if err != nil || idx != 0 {
+		return err
+	}
+	if migrated {
+		fmt.Fprintf(w,
+			"agento11y: migrated %s@%s to %s@%s — open /hooks inside codex and\n"+
+				"           trust the %s hooks to keep exporting turns.\n",
+			legacyPluginName, legacyMarketplaceAlias, PluginName, marketplaceAlias, PluginName)
+	}
+	_, _ = runOutput(ctx, bin, "plugin", "remove", legacyPluginName+"@"+legacyMarketplaceAlias)
+	return nil
 }
 
 // defaultPluginList shells out to `codex plugin list` and returns the raw
-// output. Output is human-formatted but stable: each plugin line looks like
-// `  <plugin>@<marketplace> (<state>)`.
+// output. Output is a human-formatted table but stable: each plugin row
+// starts with the `<plugin>@<marketplace>` key followed by a status column
+// like `installed, enabled` (verified against codex 0.144.6).
 func defaultPluginList(ctx context.Context, bin string) ([]byte, error) {
 	return launcher.Output(ctx, bin, "plugin", "list")
 }
 
-// pluginInstalled reports whether `sigil-codex@grafana-sigil` is registered
-// and enabled in codex's plugin store.
+// pluginInstalled reports whether the codex plugin is registered and enabled
+// in codex's plugin store, under either its current or its legacy key. A
+// legacy install counts: while the local marketplace snapshot predates the
+// rename it keeps working as-is, and the periodic update path performs the
+// migration once `codex plugin marketplace upgrade` pulls a post-rename
+// copy.
 //
 // We shell out to `codex plugin list` because it's the source of truth and
 // doesn't depend on the user's $XDG_CONFIG_HOME layout. Anything other than
@@ -135,18 +184,25 @@ func pluginInstalled(ctx context.Context, bin string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	needle := []byte(PluginName + "@" + marketplaceAlias)
+	return keyEnabled(out, PluginName+"@"+marketplaceAlias) ||
+		keyEnabled(out, legacyPluginName+"@"+legacyMarketplaceAlias), nil
+}
+
+// keyEnabled reports whether `codex plugin list` output marks the exact
+// `<plugin>@<marketplace>` key as installed and enabled.
+func keyEnabled(out []byte, key string) bool {
+	needle := []byte(key)
 	for line := range bytes.SplitSeq(out, []byte{'\n'}) {
 		// Anchor on the first whitespace-delimited token so suffix collisions
-		// like `my-sigil-codex@grafana-sigil` or
-		// `sigil-codex@grafana-sigil-staging` don't satisfy the check.
+		// like `my-agento11y-codex@agento11y` or
+		// `agento11y-codex@agento11y-staging` don't satisfy the check.
 		fields := bytes.Fields(line)
 		if len(fields) == 0 || !bytes.Equal(fields[0], needle) {
 			continue
 		}
 		if bytes.Contains(line, []byte("installed, enabled")) {
-			return true, nil
+			return true
 		}
 	}
-	return false, nil
+	return false
 }

--- a/plugins/agento11y/internal/agents/codex/launch_test.go
+++ b/plugins/agento11y/internal/agents/codex/launch_test.go
@@ -160,7 +160,7 @@ func TestLaunch_InstallFailureContinuesToExec(t *testing.T) {
 	if !strings.Contains(got, "codex plugin marketplace add grafana/agento11y") {
 		t.Fatalf("stderr missing marketplace add hint: %q", got)
 	}
-	if !strings.Contains(got, "codex plugin add sigil-codex@grafana-sigil") {
+	if !strings.Contains(got, "codex plugin add "+PluginName+"@"+marketplaceAlias) {
 		t.Fatalf("stderr missing plugin add hint: %q", got)
 	}
 	// The /hooks trust hint should NOT appear when install failed.
@@ -294,9 +294,24 @@ func TestPluginInstalled_ParsesPluginListOutput(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "installed enabled",
+			name: "current name installed enabled",
+			out:  "  agento11y-codex@agento11y (installed, enabled)\n",
+			want: true,
+		},
+		{
+			name: "legacy name installed enabled",
 			out:  "  sigil-codex@grafana-sigil (installed, enabled)\n",
 			want: true,
+		},
+		{
+			name: "current name at legacy alias does not count",
+			out:  "  agento11y-codex@grafana-sigil (installed, enabled)\n",
+			want: false,
+		},
+		{
+			name: "legacy name at current alias does not count",
+			out:  "  sigil-codex@agento11y (installed, enabled)\n",
+			want: false,
 		},
 		{
 			name: "installed disabled",
@@ -378,6 +393,27 @@ func withPluginList(t *testing.T, fn func(context.Context, string) ([]byte, erro
 	pluginList = fn
 }
 
+func withRunSteps(t *testing.T, fn func(context.Context, string, io.Writer, [][]string) error) {
+	t.Helper()
+	prev := runSteps
+	t.Cleanup(func() { runSteps = prev })
+	runSteps = fn
+}
+
+func withRunFirst(t *testing.T, fn func(context.Context, string, io.Writer, [][]string) (int, error)) {
+	t.Helper()
+	prev := runFirst
+	t.Cleanup(func() { runFirst = prev })
+	runFirst = fn
+}
+
+func withRunOutput(t *testing.T, fn func(context.Context, string, ...string) ([]byte, error)) {
+	t.Helper()
+	prev := runOutput
+	t.Cleanup(func() { runOutput = prev })
+	runOutput = fn
+}
+
 func envMap(env []string) map[string]string {
 	out := map[string]string{}
 	for _, kv := range env {
@@ -450,6 +486,96 @@ func TestLaunch_RefreshesInstalledPlugin(t *testing.T) {
 	if _, err := os.Stat(stamp); err != nil {
 		t.Fatalf("expected update stamp: %v", err)
 	}
+}
+
+// recordCommands stubs the runSteps/runFirst/runOutput seams so the
+// install/update tests can assert the exact codex commands. firstIdx is the
+// candidate index runFirst pretends succeeded.
+func recordCommands(t *testing.T, firstIdx int) (steps, candidates, outputs *[][]string) {
+	t.Helper()
+	steps, candidates, outputs = &[][]string{}, &[][]string{}, &[][]string{}
+	withRunSteps(t, func(_ context.Context, _ string, _ io.Writer, s [][]string) error {
+		*steps = append(*steps, s...)
+		return nil
+	})
+	withRunFirst(t, func(_ context.Context, _ string, _ io.Writer, c [][]string) (int, error) {
+		*candidates = append(*candidates, c...)
+		return firstIdx, nil
+	})
+	withRunOutput(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		*outputs = append(*outputs, args)
+		return nil, nil
+	})
+	return steps, candidates, outputs
+}
+
+func TestDefaultRunInstall_RegistersCurrentNameAndRemovesLegacy(t *testing.T) {
+	steps, candidates, outputs := recordCommands(t, 0)
+
+	var out bytes.Buffer
+	require.NoError(t, defaultRunInstall(context.Background(), "/usr/local/bin/codex", &out))
+	require.Equal(t, [][]string{{"plugin", "marketplace", "add", "grafana/agento11y"}}, *steps)
+	require.Equal(t, [][]string{
+		{"plugin", "add", "agento11y-codex@agento11y"},
+		{"plugin", "add", "sigil-codex@grafana-sigil"},
+	}, *candidates)
+	require.Equal(t, [][]string{{"plugin", "remove", "sigil-codex@grafana-sigil"}}, *outputs)
+	// Fresh install, not a migration: no re-trust line beyond PostInstallHint.
+	require.NotContains(t, out.String(), "migrated")
+}
+
+func TestDefaultRunInstall_PreRenameSnapshotFallsBackToLegacyName(t *testing.T) {
+	_, _, outputs := recordCommands(t, 1)
+
+	var out bytes.Buffer
+	require.NoError(t, defaultRunInstall(context.Background(), "/usr/local/bin/codex", &out))
+	// The legacy install is live; it must not be removed.
+	require.Empty(t, *outputs)
+	require.NotContains(t, out.String(), "migrated")
+}
+
+func TestDefaultRunUpdate_MigratesLegacyInstall(t *testing.T) {
+	withPluginList(t, func(context.Context, string) ([]byte, error) {
+		return []byte("  sigil-codex@grafana-sigil (installed, enabled)\n"), nil
+	})
+	steps, candidates, outputs := recordCommands(t, 0)
+
+	var out bytes.Buffer
+	require.NoError(t, defaultRunUpdate(context.Background(), "/usr/local/bin/codex", &out))
+	require.Equal(t, [][]string{{"plugin", "marketplace", "upgrade"}}, *steps)
+	require.Equal(t, [][]string{
+		{"plugin", "add", "agento11y-codex@agento11y"},
+		{"plugin", "add", "sigil-codex@grafana-sigil"},
+	}, *candidates)
+	require.Equal(t, [][]string{{"plugin", "remove", "sigil-codex@grafana-sigil"}}, *outputs)
+	got := out.String()
+	require.Contains(t, got, "migrated sigil-codex@grafana-sigil to agento11y-codex@agento11y")
+	require.Contains(t, got, "/hooks")
+}
+
+func TestDefaultRunUpdate_PreRenameSnapshotStaysOnLegacyName(t *testing.T) {
+	withPluginList(t, func(context.Context, string) ([]byte, error) {
+		return []byte("  sigil-codex@grafana-sigil (installed, enabled)\n"), nil
+	})
+	_, _, outputs := recordCommands(t, 1)
+
+	var out bytes.Buffer
+	require.NoError(t, defaultRunUpdate(context.Background(), "/usr/local/bin/codex", &out))
+	require.Empty(t, *outputs)
+	require.NotContains(t, out.String(), "migrated")
+}
+
+func TestDefaultRunUpdate_CurrentInstallRefreshesWithoutMigrationHint(t *testing.T) {
+	withPluginList(t, func(context.Context, string) ([]byte, error) {
+		return []byte("  agento11y-codex@agento11y (installed, enabled)\n"), nil
+	})
+	_, _, outputs := recordCommands(t, 0)
+
+	var out bytes.Buffer
+	require.NoError(t, defaultRunUpdate(context.Background(), "/usr/local/bin/codex", &out))
+	// Legacy removal stays a harmless no-op after migration.
+	require.Equal(t, [][]string{{"plugin", "remove", "sigil-codex@grafana-sigil"}}, *outputs)
+	require.NotContains(t, out.String(), "migrated")
 }
 
 func TestStatus(t *testing.T) {

--- a/plugins/agento11y/internal/agents/opencode/launch.go
+++ b/plugins/agento11y/internal/agents/opencode/launch.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -68,10 +69,18 @@ var configFileNames = []string{"opencode.json", "opencode.jsonc"}
 // SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT and placeholder auth values so it
 // talks to the in-process receiver instead of Grafana Cloud.
 func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, binaryVersion string) error {
+	// Rewrite a pre-rename @grafana/sigil-opencode config entry to the new
+	// package name before probing: the old package is frozen on npm, so a
+	// legacy entry would otherwise stay pinned to the last pre-rename release
+	// forever. Best-effort — a failure falls through to the legacy
+	// refresh-skip below.
+	migrateLegacyConfig(stderr, logger)
+
 	// The periodic refresh installs PluginSource. When the config still
-	// references the legacy package name, that would register the plugin a
-	// second time under the new name, so skip the refresh for legacy installs
-	// and leave the existing entry alone.
+	// references the legacy package name (because the migration above could
+	// not rewrite it), that would register the plugin a second time under the
+	// new name, so skip the refresh for legacy installs and leave the existing
+	// entry alone.
 	update := runUpdate
 	if src, found, err := installedPluginSource(); err == nil && found && stripNpmVersion(src) == legacyPluginName {
 		update = nil
@@ -116,6 +125,159 @@ func defaultRunUpdate(ctx context.Context, bin string, w io.Writer) error {
 	return launcher.RunSteps(ctx, bin, w, [][]string{
 		{"plugin", PluginSource, "--global", "--force"},
 	})
+}
+
+// migrateLegacyConfig rewrites legacy @grafana/sigil-opencode entries in
+// opencode's global config to the renamed @grafana/agento11y-opencode
+// package. The old package is frozen on npm (releases continue only under
+// the new name), so a legacy entry stays pinned to the last pre-rename
+// release forever. OpenCode installs the npm plugins listed in its config at
+// startup, so rewriting the entry is enough — no install command needed.
+// Version pins are dropped deliberately: pre-rename versions do not exist
+// under the new package name.
+//
+// The rewrite goes through hujson so comments, formatting, and tuple options
+// survive, and the file is replaced atomically (temp file + rename) so a
+// failure never leaves a half-written config. Best-effort: failures are
+// logged and never block the launch — patch/write failures also print a
+// manual-recovery hint on stderr, and the caller's legacy refresh-skip keeps
+// the frozen install working.
+func migrateLegacyConfig(stderr io.Writer, logger *log.Logger) {
+	path, data, err := readConfigFile()
+	if err != nil {
+		logger.Printf("opencode legacy migration: %v", err)
+		return
+	}
+	if data == nil {
+		return
+	}
+	v, err := hujson.Parse(data)
+	if err != nil {
+		logger.Printf("opencode legacy migration: parse %s: %v", path, err)
+		return
+	}
+	ops, err := legacyPluginOps(v)
+	if err != nil {
+		logger.Printf("opencode legacy migration: scan %s: %v", path, err)
+		return
+	}
+	if ops == nil {
+		return
+	}
+	fmt.Fprintf(stderr, "agento11y: migrating %s to %s in %s\n", legacyPluginName, PluginName, path)
+	if err := v.Patch(ops); err != nil {
+		logger.Printf("opencode legacy migration: patch %s: %v", path, err)
+		printMigrationRecoveryHint(stderr, err, path)
+		return
+	}
+	if err := writeConfigAtomic(path, v.Pack()); err != nil {
+		logger.Printf("opencode legacy migration: write %s: %v", path, err)
+		printMigrationRecoveryHint(stderr, err, path)
+		return
+	}
+}
+
+// printMigrationRecoveryHint tells the user how to finish the rename by hand
+// when the automatic rewrite failed, mirroring Bootstrap's recovery wording.
+func printMigrationRecoveryHint(w io.Writer, err error, path string) {
+	fmt.Fprintf(w,
+		"agento11y: migration of %s failed: %v\n"+
+			"agento11y: continuing with the installed version. To migrate manually, edit\n"+
+			"          %s and replace %s with %s.\n",
+		legacyPluginName, err, path, legacyPluginName, PluginName)
+}
+
+// legacyPluginOps builds the RFC 6902 operations rewriting legacy
+// @grafana/sigil-opencode entries in the parsed config: the first legacy
+// entry is replaced with the bare renamed package (a tuple entry keeps its
+// options — only element 0 is replaced), any further legacy entries are
+// removed, and when the new name is already present every legacy entry is
+// removed instead. Matching is version-insensitive. Returns nil when the
+// config has no legacy entry.
+func legacyPluginOps(v hujson.Value) ([]byte, error) {
+	std := v.Clone()
+	std.Standardize()
+	var c opencodeConfig
+	if err := json.Unmarshal(std.Pack(), &c); err != nil {
+		return nil, err
+	}
+	type legacyEntry struct {
+		index int
+		tuple bool
+	}
+	var legacy []legacyEntry
+	hasNew := false
+	for i, raw := range c.Plugin {
+		name, isTuple, ok := pluginEntryName(raw)
+		if !ok {
+			continue
+		}
+		switch stripNpmVersion(name) {
+		case legacyPluginName:
+			legacy = append(legacy, legacyEntry{index: i, tuple: isTuple})
+		case PluginName:
+			hasNew = true
+		}
+	}
+	if len(legacy) == 0 {
+		return nil, nil
+	}
+	type patchOp struct {
+		Op    string `json:"op"`
+		Path  string `json:"path"`
+		Value string `json:"value,omitempty"`
+	}
+	var ops []patchOp
+	// Higher indices first: a removal shifts every entry after it, so
+	// operating back-to-front keeps every remaining path valid.
+	for i, e := range slices.Backward(legacy) {
+		if hasNew || i > 0 {
+			ops = append(ops, patchOp{Op: "remove", Path: fmt.Sprintf("/plugin/%d", e.index)})
+			continue
+		}
+		op := patchOp{Op: "replace", Path: fmt.Sprintf("/plugin/%d", e.index), Value: PluginName}
+		if e.tuple {
+			op.Path += "/0"
+		}
+		ops = append(ops, op)
+	}
+	return json.Marshal(ops)
+}
+
+// writeConfigAtomic replaces path with content through a temp file in the
+// same directory plus rename, so a crash never leaves a half-written config.
+// The original file's permission bits are preserved when they can be read.
+func writeConfigAtomic(path string, content []byte) error {
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("temp file in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("chmod temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("rename to %s: %w", path, err)
+	}
+	return nil
 }
 
 // opencodeConfig is the subset of opencode's global config this launcher
@@ -165,26 +327,9 @@ func Status(_ context.Context) (installed bool, version string, err error) {
 // configured. The file is parsed as JSONC because opencode's docs allow
 // comments and trailing commas.
 func installedPluginSource() (source string, found bool, err error) {
-	dir, err := configDirFn()
+	path, data, err := readConfigFile()
 	if err != nil {
 		return "", false, err
-	}
-	var (
-		data []byte
-		path string
-	)
-	for _, name := range configFileNames {
-		candidate := filepath.Join(dir, name)
-		b, err := os.ReadFile(candidate)
-		if err == nil {
-			data = b
-			path = candidate
-			break
-		}
-		if errors.Is(err, os.ErrNotExist) {
-			continue
-		}
-		return "", false, fmt.Errorf("read %s: %w", candidate, err)
 	}
 	if data == nil {
 		return "", false, nil
@@ -198,23 +343,8 @@ func installedPluginSource() (source string, found bool, err error) {
 		return "", false, fmt.Errorf("parse %s: %w", path, err)
 	}
 	for _, raw := range c.Plugin {
-		var asString string
-		if err := json.Unmarshal(raw, &asString); err == nil {
-			if sourceMatchesPlugin(asString) {
-				return asString, true, nil
-			}
-			continue
-		}
-		// Tuple form: ["@grafana/agento11y-opencode", {...}]
-		var asTuple []json.RawMessage
-		if err := json.Unmarshal(raw, &asTuple); err != nil {
-			continue
-		}
-		if len(asTuple) == 0 {
-			continue
-		}
-		var name string
-		if err := json.Unmarshal(asTuple[0], &name); err != nil {
+		name, _, ok := pluginEntryName(raw)
+		if !ok {
 			continue
 		}
 		if sourceMatchesPlugin(name) {
@@ -222,6 +352,46 @@ func installedPluginSource() (source string, found bool, err error) {
 		}
 	}
 	return "", false, nil
+}
+
+// pluginEntryName decodes one plugin-array entry, which is either a plain
+// string naming the plugin module or a [name, options] tuple. Returns the
+// entry's name (version pin included, if any), whether the entry was a
+// tuple, and whether decoding succeeded.
+func pluginEntryName(raw json.RawMessage) (name string, tuple, ok bool) {
+	if err := json.Unmarshal(raw, &name); err == nil {
+		return name, false, true
+	}
+	var asTuple []json.RawMessage
+	if err := json.Unmarshal(raw, &asTuple); err != nil || len(asTuple) == 0 {
+		return "", false, false
+	}
+	if err := json.Unmarshal(asTuple[0], &name); err != nil {
+		return "", false, false
+	}
+	return name, true, true
+}
+
+// readConfigFile locates and reads opencode's global config, probing the
+// recognised basenames in precedence order. A missing file returns
+// ("", nil, nil) — opencode has never been configured.
+func readConfigFile() (path string, data []byte, err error) {
+	dir, err := configDirFn()
+	if err != nil {
+		return "", nil, err
+	}
+	for _, name := range configFileNames {
+		candidate := filepath.Join(dir, name)
+		b, err := os.ReadFile(candidate)
+		if err == nil {
+			return candidate, b, nil
+		}
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		return "", nil, fmt.Errorf("read %s: %w", candidate, err)
+	}
+	return "", nil, nil
 }
 
 // versionFromNpmSpec returns the pinned version of a scoped npm spec, e.g.

--- a/plugins/agento11y/internal/agents/opencode/launch_test.go
+++ b/plugins/agento11y/internal/agents/opencode/launch_test.go
@@ -3,6 +3,7 @@ package opencode
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"log"
@@ -15,6 +16,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/local"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tailscale/hujson"
 )
 
 func TestLaunch(t *testing.T) {
@@ -424,10 +426,114 @@ func TestLaunch_RefreshesInstalledPluginWhenUpdateDue(t *testing.T) {
 	}
 }
 
-// A config that still references the legacy @grafana/sigil-opencode name must
-// not be refreshed: the refresh installs the renamed package, which would
-// register the plugin twice (once per name).
-func TestLaunch_SkipsRefreshForLegacyPluginName(t *testing.T) {
+// A config that still references the legacy @grafana/sigil-opencode name is
+// rewritten to the renamed package before the probe runs: the old package is
+// frozen on npm, so a legacy entry never sees updates again. OpenCode
+// installs npm plugins listed in its config at startup, so the rewrite alone
+// is enough.
+func TestLaunch_MigratesLegacyConfig(t *testing.T) {
+	const binPath = "/usr/local/bin/opencode"
+
+	cases := []struct {
+		name            string
+		file            string // config basename; "" = opencode.json
+		config          string
+		wantContains    []string
+		wantNotContains []string
+		wantPluginCount int // 0 = skip the standardized entry-count check
+	}{
+		{
+			name:            "string entry replaced",
+			config:          `{"plugin":["@grafana/sigil-opencode"]}`,
+			wantContains:    []string{`"@grafana/agento11y-opencode"`},
+			wantNotContains: []string{"sigil-opencode"},
+			wantPluginCount: 1,
+		},
+		{
+			name:            "pinned entry loses its pin",
+			config:          `{"plugin":["@grafana/sigil-opencode@0.13.0"]}`,
+			wantContains:    []string{`"@grafana/agento11y-opencode"`},
+			wantNotContains: []string{"sigil-opencode", "0.13.0"},
+			wantPluginCount: 1,
+		},
+		{
+			name:            "tuple entry keeps options",
+			config:          `{"plugin":[["@grafana/sigil-opencode@0.13.0",{"enabled":true}]]}`,
+			wantContains:    []string{`"@grafana/agento11y-opencode"`, `{"enabled":true}`},
+			wantNotContains: []string{"sigil-opencode"},
+			wantPluginCount: 1,
+		},
+		{
+			name:            "jsonc comments survive",
+			file:            "opencode.jsonc",
+			config:          "{\n  // my config\n  \"plugin\": [\"@grafana/sigil-opencode\"]\n}\n",
+			wantContains:    []string{"// my config", `"@grafana/agento11y-opencode"`},
+			wantNotContains: []string{"sigil-opencode"},
+			wantPluginCount: 1,
+		},
+		{
+			name:            "both names present removes the legacy entry",
+			config:          `{"plugin":["@grafana/sigil-opencode","@grafana/agento11y-opencode"]}`,
+			wantContains:    []string{`"@grafana/agento11y-opencode"`},
+			wantNotContains: []string{"sigil-opencode"},
+			wantPluginCount: 1,
+		},
+		{
+			name:            "multiple legacy entries collapse to one new entry",
+			config:          `{"plugin":["@grafana/sigil-opencode","@grafana/sigil-opencode@0.13.0"]}`,
+			wantContains:    []string{`"@grafana/agento11y-opencode"`},
+			wantNotContains: []string{"sigil-opencode"},
+			wantPluginCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SIGIL_AUTO_UPDATE", "false")
+			file := tc.file
+			if file == "" {
+				file = "opencode.json"
+			}
+			dir := withConfigFiles(t, map[string]string{file: tc.config})
+			withLookPath(t, func(string) (string, error) { return binPath, nil })
+			withRunInstall(t, func(context.Context, string, io.Writer) error {
+				t.Error("runInstall must not be called: the migrated entry counts as installed")
+				return nil
+			})
+			execCalled := false
+			withExecFn(t, func(string, []string, []string) error {
+				execCalled = true
+				return nil
+			})
+
+			var stderr bytes.Buffer
+			require.NoError(t, Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger(), "dev"))
+			assert.True(t, execCalled, "exec must run after migration")
+			assert.Contains(t, stderr.String(), "migrating "+legacyPluginName+" to "+PluginName)
+
+			rewritten, err := os.ReadFile(filepath.Join(dir, file))
+			require.NoError(t, err)
+			for _, want := range tc.wantContains {
+				assert.Contains(t, string(rewritten), want)
+			}
+			for _, notWant := range tc.wantNotContains {
+				assert.NotContains(t, string(rewritten), notWant)
+			}
+			if tc.wantPluginCount > 0 {
+				std, err := hujson.Standardize(rewritten)
+				require.NoError(t, err)
+				var c opencodeConfig
+				require.NoError(t, json.Unmarshal(std, &c))
+				assert.Len(t, c.Plugin, tc.wantPluginCount)
+			}
+		})
+	}
+}
+
+// After a successful migration the probe sees the new package name, so the
+// legacy refresh suppression no longer applies and the normal 24-hour
+// refresh runs.
+func TestLaunch_MigrationRestoresRefresh(t *testing.T) {
 	const binPath = "/usr/local/bin/opencode"
 	state := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", state)
@@ -436,17 +542,63 @@ func TestLaunch_SkipsRefreshForLegacyPluginName(t *testing.T) {
 	withConfig(t, `{"plugin":["@grafana/sigil-opencode"]}`)
 	withLookPath(t, func(string) (string, error) { return binPath, nil })
 	withRunInstall(t, func(context.Context, string, io.Writer) error {
-		t.Fatal("runInstall must not be called when the legacy plugin is installed")
+		t.Fatal("runInstall must not be called: the migrated entry counts as installed")
 		return nil
 	})
+	updateCalls := 0
 	withRunUpdate(t, func(context.Context, string, io.Writer) error {
-		t.Fatal("runUpdate must not be called for a legacy plugin entry")
+		updateCalls++
 		return nil
 	})
 	withExecFn(t, func(string, []string, []string) error { return nil })
 
 	var stderr bytes.Buffer
 	require.NoError(t, Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger(), "dev"))
+	assert.Equal(t, 1, updateCalls, "refresh must run once migration replaced the legacy entry")
+}
+
+// When the config cannot be rewritten (read-only directory), the migration
+// fails without blocking the launch: the error is logged, a recovery hint
+// reaches stderr, and the legacy refresh-skip stays active so the plugin is
+// not registered twice.
+func TestLaunch_MigrationFailureFallsBackToLegacySkip(t *testing.T) {
+	const binPath = "/usr/local/bin/opencode"
+	state := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", state)
+	t.Setenv("SIGIL_AUTO_UPDATE", "")
+
+	dir := withConfig(t, `{"plugin":["@grafana/sigil-opencode"]}`)
+	require.NoError(t, os.Chmod(dir, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	withLookPath(t, func(string) (string, error) { return binPath, nil })
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		t.Fatal("runInstall must not be called when the legacy plugin is installed")
+		return nil
+	})
+	withRunUpdate(t, func(context.Context, string, io.Writer) error {
+		t.Fatal("runUpdate must not be called while the legacy entry remains")
+		return nil
+	})
+	execCalled := false
+	withExecFn(t, func(string, []string, []string) error {
+		execCalled = true
+		return nil
+	})
+
+	var stderr bytes.Buffer
+	var logbuf bytes.Buffer
+	logger := log.New(&logbuf, "", 0)
+	require.NoError(t, Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, logger, "dev"))
+	assert.True(t, execCalled, "exec must run even when migration fails")
+	assert.Contains(t, stderr.String(), "migration of "+legacyPluginName+" failed")
+	assert.Contains(t, stderr.String(), PluginName)
+	assert.Contains(t, stderr.String(), filepath.Join(dir, "opencode.json"))
+	assert.Contains(t, logbuf.String(), "opencode legacy migration")
+
+	unchanged, err := os.ReadFile(filepath.Join(dir, "opencode.json"))
+	require.NoError(t, err)
+	assert.Equal(t, `{"plugin":["@grafana/sigil-opencode"]}`, string(unchanged), "config must stay untouched on failure")
 }
 
 func TestLaunch_SkipsRefreshWhenUpdateDisabled(t *testing.T) {
@@ -484,19 +636,19 @@ func TestDefaultConfigDir(t *testing.T) {
 
 // withConfig points configDirFn at a temp directory, optionally
 // seeding it with an opencode.json containing the given contents.
-// Pass "" to leave the directory empty.
-func withConfig(t *testing.T, contents string) {
+// Pass "" to leave the directory empty. Returns the config directory.
+func withConfig(t *testing.T, contents string) string {
 	t.Helper()
 	files := map[string]string{}
 	if contents != "" {
 		files["opencode.json"] = contents
 	}
-	withConfigFiles(t, files)
+	return withConfigFiles(t, files)
 }
 
 // withConfigFiles points configDirFn at a temp directory and writes the
-// supplied {basename: contents} files into it.
-func withConfigFiles(t *testing.T, files map[string]string) {
+// supplied {basename: contents} files into it. Returns the config directory.
+func withConfigFiles(t *testing.T, files map[string]string) string {
 	t.Helper()
 	dir := t.TempDir()
 	for name, contents := range files {
@@ -507,6 +659,7 @@ func withConfigFiles(t *testing.T, files map[string]string) {
 	prev := configDirFn
 	t.Cleanup(func() { configDirFn = prev })
 	configDirFn = func() (string, error) { return dir, nil }
+	return dir
 }
 
 func withLookPath(t *testing.T, fn func(string) (string, error)) {

--- a/plugins/agento11y/internal/agents/pi/launch.go
+++ b/plugins/agento11y/internal/agents/pi/launch.go
@@ -35,7 +35,10 @@ const (
 	// still reference it; treating it as installed avoids registering the
 	// extension twice under both names.
 	legacyPluginName = "@grafana/sigil-pi"
-	npmPrefix        = "npm:"
+	// legacyPluginSource is the npm spec of the pre-rename package, used for
+	// the `pi remove` migration step and the manual recovery hints.
+	legacyPluginSource = npmPrefix + legacyPluginName
+	npmPrefix          = "npm:"
 	// projectConfigDirName is pi's default project config directory. Pi
 	// allows overriding this via package.json `piConfig.configDir`, but the
 	// default `.pi` covers every shipped install.
@@ -47,6 +50,7 @@ var (
 	lookPath   = exec.LookPath
 	execFn     = syscall.Exec
 	runInstall = defaultRunInstall
+	runPi      = defaultRunPi
 )
 
 // Launch resolves the `pi` binary on PATH, ensures the @grafana/agento11y-pi
@@ -59,6 +63,12 @@ var (
 // auto-update checks (pi's own installer handles upgrades) so it is
 // accepted to satisfy the launcher signature and ignored.
 func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, _ string) error {
+	// Rewrite a pre-rename @grafana/sigil-pi npm install to the new package
+	// name before probing: the old package is frozen on npm, so a legacy
+	// entry would otherwise stay pinned to the last pre-rename release
+	// forever. Best-effort — a failure never blocks the launch; a legacy
+	// entry that survives keeps working but never updates.
+	migrateLegacyInstall(ctx, stderr, logger)
 	return launcher.Bootstrap(ctx, launcher.BootstrapSpec{
 		BinName:     "pi",
 		PluginLabel: PluginSource,
@@ -85,10 +95,138 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 }
 
 func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {
-	cmd := exec.CommandContext(ctx, bin, "install", PluginSource)
+	return defaultRunPi(ctx, bin, w, "install", PluginSource)
+}
+
+// defaultRunPi runs `bin args...` writing the child's output to w. The
+// migration uses it for the `pi remove` / `pi install` steps.
+func defaultRunPi(ctx context.Context, bin string, w io.Writer, args ...string) error {
+	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Stdout = w
 	cmd.Stderr = w
 	return cmd.Run()
+}
+
+// migrateLegacyInstall rewrites a legacy npm install of @grafana/sigil-pi to
+// the renamed @grafana/agento11y-pi package by running `pi remove` and then
+// `pi install` in each settings scope that still references the legacy spec.
+// The old package is frozen on npm (releases continue only under the new
+// name), so without this rewrite existing installs never see updates again.
+// Version pins are dropped deliberately: pre-rename versions do not exist
+// under the new package name. Local-path installs whose package.json declares
+// the legacy name are developer checkouts, not npm installs, and are left
+// alone.
+//
+// Remove-first is deliberate: if the install step fails, the next probe sees
+// no registered plugin and Bootstrap retries the install through its normal
+// path. Best-effort per scope — failures are logged and never block the
+// launch; remove/install failures also print a manual-recovery hint on
+// stderr. When pi itself is missing from PATH the pre-step stays silent and
+// leaves the reporting to Bootstrap.
+func migrateLegacyInstall(ctx context.Context, stderr io.Writer, logger *log.Logger) {
+	bin, err := lookPath("pi")
+	if err != nil {
+		return
+	}
+	scopes := []struct {
+		pathFn  func() (string, error)
+		project bool
+	}{
+		{settingsPath, false},
+		{projectSettingsPath, true},
+	}
+	for _, scope := range scopes {
+		path, err := scope.pathFn()
+		if err != nil {
+			logger.Printf("pi legacy migration: %v", err)
+			continue
+		}
+		hasLegacy, hasNew, err := scopeLegacyStatus(path)
+		if err != nil {
+			logger.Printf("pi legacy migration probe: %v", err)
+			continue
+		}
+		if !hasLegacy {
+			continue
+		}
+		migrateScope(ctx, bin, scope.project, hasNew, stderr, logger)
+	}
+}
+
+// migrateScope runs the pi CLI commands migrating one settings scope. When
+// the renamed package is already registered there (hasNew), only the legacy
+// entry is removed — installing again would duplicate it. `pi remove` matches
+// npm sources by name only, so a pinned legacy spec is removed too.
+func migrateScope(ctx context.Context, bin string, project, hasNew bool, stderr io.Writer, logger *log.Logger) {
+	suffix := ""
+	if project {
+		suffix = " -l"
+	}
+	fmt.Fprintf(stderr, "agento11y: migrating %s to %s in pi\n", legacyPluginSource, PluginSource)
+	removeArgs := []string{"remove", legacyPluginSource}
+	installArgs := []string{"install", PluginSource}
+	if project {
+		removeArgs = append(removeArgs, "-l")
+		installArgs = append(installArgs, "-l")
+	}
+	if err := runPi(ctx, bin, stderr, removeArgs...); err != nil {
+		logger.Printf("remove %s: %v", legacyPluginSource, err)
+		fmt.Fprintf(stderr,
+			"agento11y: migration of %s failed: %v\n"+
+				"agento11y: continuing with the legacy package. To migrate manually:\n"+
+				"          pi remove %s%s\n",
+			legacyPluginSource, err, legacyPluginSource, suffix)
+		if !hasNew {
+			fmt.Fprintf(stderr, "          pi install %s%s\n", PluginSource, suffix)
+		}
+		return
+	}
+	if hasNew {
+		return
+	}
+	if err := runPi(ctx, bin, stderr, installArgs...); err != nil {
+		logger.Printf("install %s: %v", PluginSource, err)
+		fmt.Fprintf(stderr,
+			"agento11y: migration install of %s failed: %v\n"+
+				"agento11y: to finish the migration manually:\n"+
+				"          pi install %s%s\n",
+			PluginSource, err, PluginSource, suffix)
+	}
+}
+
+// scopeLegacyStatus reports whether one pi settings file registers the legacy
+// @grafana/sigil-pi package through an npm spec (hasLegacy), and whether the
+// renamed package is already registered in the same file through an npm spec
+// or a local path (hasNew). Local-path entries whose package.json declares
+// the legacy name never count as hasLegacy — they are developer checkouts. A
+// missing file means the scope is unused.
+func scopeLegacyStatus(path string) (hasLegacy, hasNew bool, err error) {
+	sources, err := settingsSources(path)
+	if err != nil {
+		return false, false, err
+	}
+	settingsDir := filepath.Dir(path)
+	for _, src := range sources {
+		if after, ok := strings.CutPrefix(src, npmPrefix); ok {
+			switch stripNpmVersion(after) {
+			case legacyPluginName:
+				hasLegacy = true
+			case pluginName:
+				hasNew = true
+			}
+			continue
+		}
+		if filepath.IsAbs(src) || strings.HasPrefix(src, "./") || strings.HasPrefix(src, "../") {
+			p := src
+			if !filepath.IsAbs(p) {
+				p = filepath.Join(settingsDir, p)
+			}
+			if name, ok := localPackageName(p); ok && name == pluginName {
+				hasNew = true
+			}
+		}
+	}
+	return hasLegacy, hasNew, nil
 }
 
 // piSettings is the subset of pi's settings.json this launcher inspects.
@@ -158,18 +296,35 @@ func installedPluginSource() (source string, found bool, err error) {
 // string registering the @grafana/agento11y-pi extension, if any. A missing file
 // is not an error — that scope is just unused.
 func readSettingsAndCheck(path string) (source string, found bool, err error) {
+	sources, err := settingsSources(path)
+	if err != nil {
+		return "", false, err
+	}
+	settingsDir := filepath.Dir(path)
+	for _, src := range sources {
+		if sourceMatchesPlugin(src, settingsDir) {
+			return src, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// settingsSources loads one pi settings file and returns the source string of
+// every package entry, unwrapping both plain-string and `{"source": ...}`
+// object shapes. A missing file is not an error — that scope is just unused.
+func settingsSources(path string) ([]string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return "", false, nil
+			return nil, nil
 		}
-		return "", false, fmt.Errorf("read %s: %w", path, err)
+		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
 	var s piSettings
 	if err := json.Unmarshal(data, &s); err != nil {
-		return "", false, fmt.Errorf("parse %s: %w", path, err)
+		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}
-	settingsDir := filepath.Dir(path)
+	sources := make([]string, 0, len(s.Packages))
 	for _, raw := range s.Packages {
 		var src string
 		if err := json.Unmarshal(raw, &src); err != nil {
@@ -181,11 +336,9 @@ func readSettingsAndCheck(path string) (source string, found bool, err error) {
 			}
 			src = asObj.Source
 		}
-		if sourceMatchesPlugin(src, settingsDir) {
-			return src, true, nil
-		}
+		sources = append(sources, src)
 	}
-	return "", false, nil
+	return sources, nil
 }
 
 // versionFromPiSource returns the pinned version of an npm-spec source, e.g.
@@ -250,26 +403,32 @@ func matchesPluginName(name string) bool {
 
 // localPathIsPlugin returns true when path is a directory containing a
 // package.json whose name matches the plugin (current or legacy pre-rename
-// name). Any IO/parse failure means we can't
-// confirm the match — treat as a non-match rather than an error, since the
-// settings file may legitimately reference other local packages we don't
-// own.
+// name).
 func localPathIsPlugin(path string) bool {
+	name, ok := localPackageName(path)
+	return ok && matchesPluginName(name)
+}
+
+// localPackageName returns the package.json name of a local package
+// directory. Any IO/parse failure means we can't confirm the name — treat as
+// unknown rather than an error, since the settings file may legitimately
+// reference other local packages we don't own.
+func localPackageName(path string) (string, bool) {
 	info, err := os.Stat(path)
 	if err != nil || !info.IsDir() {
-		return false
+		return "", false
 	}
 	data, err := os.ReadFile(filepath.Join(path, "package.json"))
 	if err != nil {
-		return false
+		return "", false
 	}
 	var pkg struct {
 		Name string `json:"name"`
 	}
 	if err := json.Unmarshal(data, &pkg); err != nil {
-		return false
+		return "", false
 	}
-	return matchesPluginName(pkg.Name)
+	return pkg.Name, true
 }
 
 // settingsPath returns the path to pi's global settings.json, honouring

--- a/plugins/agento11y/internal/agents/pi/launch_test.go
+++ b/plugins/agento11y/internal/agents/pi/launch_test.go
@@ -55,22 +55,194 @@ func TestLaunch_SkipsInstallWhenPackagePresent(t *testing.T) {
 }
 
 // A settings file that still references the pre-rename @grafana/sigil-pi
-// package counts as installed: running `pi install` again would register the
-// extension a second time under the new name.
-func TestLaunch_SkipsInstallWhenLegacyPackagePresent(t *testing.T) {
-	dir := t.TempDir()
-	writeSettings(t, dir, `{"packages":["npm:@grafana/sigil-pi"]}`)
-	t.Setenv("PI_CODING_AGENT_DIR", dir)
+// package is migrated to the renamed package before Bootstrap runs: the old
+// package is frozen on npm, so a legacy entry never sees updates again. The
+// runPi stub does not rewrite the settings file, so the Bootstrap probe still
+// sees the legacy entry as installed afterwards — runInstall must never fire.
+func TestLaunch_MigratesLegacyInstall(t *testing.T) {
+	const (
+		binPath        = "/usr/local/bin/pi"
+		removeGlobal   = "remove npm:@grafana/sigil-pi"
+		installGlobal  = "install npm:@grafana/agento11y-pi"
+		removeProject  = removeGlobal + " -l"
+		installProject = installGlobal + " -l"
+	)
 
-	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/pi", nil })
-	withRunInstall(t, func(context.Context, string, io.Writer) error {
-		t.Fatal("runInstall must not be called when the legacy package is present")
-		return nil
-	})
-	withExecFn(t, func(string, []string, []string) error { return nil })
+	cases := []struct {
+		name      string
+		global    string // global settings.json contents ("" = don't create)
+		project   string // <cwd>/.pi/settings.json contents ("" = don't create)
+		localPkg  string // package.json written to <globalDir>/local-plugin
+		piErrs    map[string]error
+		missingPi bool
 
-	if err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, io.Discard, nopLogger(), "dev"); err != nil {
-		t.Fatalf("Launch returned err: %v", err)
+		wantPiCalls  []string
+		wantStderr   []string
+		wantNoStderr []string
+		wantErr      string
+	}{
+		{
+			name:        "bare legacy entry in global settings",
+			global:      `{"packages":["npm:@grafana/sigil-pi"]}`,
+			wantPiCalls: []string{removeGlobal, installGlobal},
+			wantStderr:  []string{"migrating npm:@grafana/sigil-pi to npm:@grafana/agento11y-pi"},
+		},
+		{
+			name:        "pinned legacy entry",
+			global:      `{"packages":["npm:@grafana/sigil-pi@0.17.0"]}`,
+			wantPiCalls: []string{removeGlobal, installGlobal},
+		},
+		{
+			name:        "object-shaped legacy entry",
+			global:      `{"packages":[{"source":"npm:@grafana/sigil-pi@0.17.0"}]}`,
+			wantPiCalls: []string{removeGlobal, installGlobal},
+		},
+		{
+			name:        "project-scope legacy entry uses -l",
+			global:      `{"packages":[]}`,
+			project:     `{"packages":["npm:@grafana/sigil-pi@0.17.0"]}`,
+			wantPiCalls: []string{removeProject, installProject},
+		},
+		{
+			name:        "legacy entries in both scopes migrate both",
+			global:      `{"packages":["npm:@grafana/sigil-pi"]}`,
+			project:     `{"packages":["npm:@grafana/sigil-pi"]}`,
+			wantPiCalls: []string{removeGlobal, installGlobal, removeProject, installProject},
+		},
+		{
+			name:        "both names present removes only the legacy entry",
+			global:      `{"packages":["npm:@grafana/sigil-pi","npm:@grafana/agento11y-pi"]}`,
+			wantPiCalls: []string{removeGlobal},
+		},
+		{
+			name:         "local-path legacy checkout is left alone",
+			global:       `{"packages":["./local-plugin"]}`,
+			localPkg:     `{"name":"@grafana/sigil-pi"}`,
+			wantNoStderr: []string{"migrating"},
+		},
+		{
+			name:        "remove failure skips install and continues",
+			global:      `{"packages":["npm:@grafana/sigil-pi"]}`,
+			piErrs:      map[string]error{removeGlobal: errors.New("remove boom")},
+			wantPiCalls: []string{removeGlobal},
+			wantStderr: []string{
+				"migration of npm:@grafana/sigil-pi failed",
+				"remove boom",
+				"pi remove npm:@grafana/sigil-pi",
+				"pi install npm:@grafana/agento11y-pi",
+			},
+		},
+		{
+			name:        "remove failure in project scope hints -l",
+			global:      `{"packages":[]}`,
+			project:     `{"packages":["npm:@grafana/sigil-pi"]}`,
+			piErrs:      map[string]error{removeProject: errors.New("remove boom")},
+			wantPiCalls: []string{removeProject},
+			wantStderr: []string{
+				"pi remove npm:@grafana/sigil-pi -l",
+				"pi install npm:@grafana/agento11y-pi -l",
+			},
+		},
+		{
+			name:        "install failure continues",
+			global:      `{"packages":["npm:@grafana/sigil-pi"]}`,
+			piErrs:      map[string]error{installGlobal: errors.New("install boom")},
+			wantPiCalls: []string{removeGlobal, installGlobal},
+			wantStderr: []string{
+				"install boom",
+				"pi install npm:@grafana/agento11y-pi",
+			},
+		},
+		{
+			name:         "missing pi binary skips migration silently",
+			global:       `{"packages":["npm:@grafana/sigil-pi"]}`,
+			missingPi:    true,
+			wantNoStderr: []string{"migrating"},
+			wantErr:      "pi CLI not found",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			globalDir := t.TempDir()
+			projectRoot := t.TempDir()
+			if tc.global != "" {
+				writeSettings(t, globalDir, tc.global)
+			}
+			if tc.project != "" {
+				projectPiDir := filepath.Join(projectRoot, ".pi")
+				if err := os.MkdirAll(projectPiDir, 0o755); err != nil {
+					t.Fatalf("mkdir project .pi: %v", err)
+				}
+				writeSettings(t, projectPiDir, tc.project)
+			}
+			if tc.localPkg != "" {
+				pkgDir := filepath.Join(globalDir, "local-plugin")
+				if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+					t.Fatalf("mkdir local plugin: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(tc.localPkg), 0o600); err != nil {
+					t.Fatalf("write local package.json: %v", err)
+				}
+			}
+			t.Setenv("PI_CODING_AGENT_DIR", globalDir)
+			t.Chdir(projectRoot)
+
+			if tc.missingPi {
+				withLookPath(t, func(string) (string, error) { return "", exec.ErrNotFound })
+			} else {
+				withLookPath(t, func(string) (string, error) { return binPath, nil })
+			}
+			withRunInstall(t, func(context.Context, string, io.Writer) error {
+				t.Error("runInstall must not be called: the probe still sees a registered entry")
+				return nil
+			})
+
+			var piCalls []string
+			withRunPi(t, func(_ context.Context, bin string, _ io.Writer, args ...string) error {
+				if bin != binPath {
+					t.Errorf("runPi bin = %q, want %q", bin, binPath)
+				}
+				call := strings.Join(args, " ")
+				piCalls = append(piCalls, call)
+				return tc.piErrs[call]
+			})
+
+			execCalled := false
+			withExecFn(t, func(string, []string, []string) error {
+				execCalled = true
+				return nil
+			})
+
+			var stderr bytes.Buffer
+			err := Launch(context.Background(), nil, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger(), "dev")
+
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want contains %q", err, tc.wantErr)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Launch returned err: %v", err)
+				}
+				if !execCalled {
+					t.Error("execFn was not called: migration must never block the launch")
+				}
+			}
+			if !reflect.DeepEqual(piCalls, tc.wantPiCalls) {
+				t.Errorf("pi calls = %v, want %v", piCalls, tc.wantPiCalls)
+			}
+			for _, want := range tc.wantStderr {
+				if !strings.Contains(stderr.String(), want) {
+					t.Errorf("stderr missing %q: %q", want, stderr.String())
+				}
+			}
+			for _, notWant := range tc.wantNoStderr {
+				if strings.Contains(stderr.String(), notWant) {
+					t.Errorf("stderr must not contain %q: %q", notWant, stderr.String())
+				}
+			}
+		})
 	}
 }
 
@@ -606,6 +778,13 @@ func withRunInstall(t *testing.T, fn func(context.Context, string, io.Writer) er
 	prev := runInstall
 	t.Cleanup(func() { runInstall = prev })
 	runInstall = fn
+}
+
+func withRunPi(t *testing.T, fn func(context.Context, string, io.Writer, ...string) error) {
+	t.Helper()
+	prev := runPi
+	t.Cleanup(func() { runPi = prev })
+	runPi = fn
 }
 
 func withExecFn(t *testing.T, fn func(string, []string, []string) error) {

--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -4,8 +4,8 @@
 // Vibe agent plugins. It accepts:
 //
 //	agento11y <agent> hook                                — dispatch a JSON hook payload on stdin to <agent>
-//	agento11y claude   [--local] [--tag k=v] [-- args...] — exec claude after bootstrapping the sigil-cc plugin
-//	agento11y codex    [--local] [--tag k=v] [-- args...] — exec codex after bootstrapping the sigil-codex plugin
+//	agento11y claude   [--local] [--tag k=v] [-- args...] — exec claude after bootstrapping the agento11y-claude-code plugin
+//	agento11y codex    [--local] [--tag k=v] [-- args...] — exec codex after bootstrapping the agento11y-codex plugin
 //	agento11y copilot  [--local] [--tag k=v] [-- args...] — exec copilot after bootstrapping the sigil-copilot plugin
 //	agento11y opencode [--local] [--tag k=v] [-- args...] — exec opencode after bootstrapping the @grafana/agento11y-opencode plugin
 //	agento11y pi       [--local] [--tag k=v] [-- args...] — exec pi after bootstrapping the @grafana/agento11y-pi extension

--- a/plugins/agento11y/internal/launcher/launcher.go
+++ b/plugins/agento11y/internal/launcher/launcher.go
@@ -12,6 +12,7 @@ package launcher
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -76,6 +77,37 @@ func RunSteps(ctx context.Context, bin string, w io.Writer, steps [][]string) er
 		}
 	}
 	return nil
+}
+
+// RunFirst invokes `bin argv...` for each candidate in order until one
+// succeeds, then writes only the successful command's combined output to w
+// and returns the candidate's index. Earlier candidates are expected to fail
+// against plugin stores that predate (or postdate) a plugin rename, so their
+// output is captured into the returned error instead of streamed at the
+// user. When every candidate fails, the index is -1 and the per-candidate
+// errors are joined.
+func RunFirst(ctx context.Context, bin string, w io.Writer, candidates [][]string) (int, error) {
+	name := bin
+	if idx := strings.LastIndexByte(bin, '/'); idx >= 0 {
+		name = bin[idx+1:]
+	}
+	var errs []error
+	for i, argv := range candidates {
+		cmd := exec.CommandContext(ctx, bin, argv...)
+		var buf bytes.Buffer
+		cmd.Stdout = &buf
+		cmd.Stderr = &buf
+		if err := cmd.Run(); err != nil {
+			if msg := bytes.TrimSpace(buf.Bytes()); len(msg) > 0 {
+				err = fmt.Errorf("%w: %s", err, msg)
+			}
+			errs = append(errs, fmt.Errorf("%s %s: %w", name, strings.Join(argv, " "), err))
+			continue
+		}
+		_, _ = w.Write(buf.Bytes())
+		return i, nil
+	}
+	return -1, errors.Join(errs...)
 }
 
 // BootstrapSpec describes the per-agent variation Bootstrap needs to drive

--- a/plugins/agento11y/internal/launcher/launcher_test.go
+++ b/plugins/agento11y/internal/launcher/launcher_test.go
@@ -118,6 +118,80 @@ func TestRunSteps(t *testing.T) {
 	}
 }
 
+func TestRunFirst(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses unix shell utilities")
+	}
+	cases := []struct {
+		name         string
+		candidates   [][]string
+		wantIdx      int
+		wantErr      bool
+		wantErrSub   []string
+		wantOutput   []string
+		forbidOutput []string
+	}{
+		{
+			name: "first success wins",
+			candidates: [][]string{
+				{"-c", "echo first"},
+				{"-c", "echo second"},
+			},
+			wantIdx:      0,
+			wantOutput:   []string{"first"},
+			forbidOutput: []string{"second"},
+		},
+		{
+			name: "falls back past failing candidates without streaming their output",
+			candidates: [][]string{
+				{"-c", "echo not this one; exit 1"},
+				{"-c", "echo winner"},
+			},
+			wantIdx:      1,
+			wantOutput:   []string{"winner"},
+			forbidOutput: []string{"not this one"},
+		},
+		{
+			name: "all candidates fail joins errors with captured output",
+			candidates: [][]string{
+				{"-c", "echo boom-a >&2; exit 1"},
+				{"-c", "echo boom-b >&2; exit 2"},
+			},
+			wantIdx:    -1,
+			wantErr:    true,
+			wantErrSub: []string{"boom-a", "boom-b", "sh -c echo boom-a >&2; exit 1"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			idx, err := RunFirst(context.Background(), "/bin/sh", &buf, tc.candidates)
+			if idx != tc.wantIdx {
+				t.Fatalf("idx = %d, want %d", idx, tc.wantIdx)
+			}
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			for _, sub := range tc.wantErrSub {
+				if !strings.Contains(err.Error(), sub) {
+					t.Errorf("err = %v; want substring %q", err, sub)
+				}
+			}
+			got := buf.String()
+			for _, want := range tc.wantOutput {
+				if !strings.Contains(got, want) {
+					t.Errorf("output = %q; want substring %q", got, want)
+				}
+			}
+			for _, forbidden := range tc.forbidOutput {
+				if strings.Contains(got, forbidden) {
+					t.Errorf("output = %q; should not contain %q", got, forbidden)
+				}
+			}
+		})
+	}
+}
+
 func TestOutput(t *testing.T) {
 	cases := []struct {
 		name       string


### PR DESCRIPTION
Migrates legacy `sigil-*` plugin installs to the `agento11y` names in the pi, opencode, claude-code, and codex launchers automatically.

All migrations are best-effort: failures are logged and do not block the launch. Version pins are dropped since pre-rename versions don't exist under the new names.
