### PR TITLE
chore: update app plugin ID to grafana-agento11y-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ To attach custom key/values (team, project, env, request id, end-user id), see [
 All four connection values (API URL, Instance ID, API token, and OTLP endpoint) live on the Connection tab of the Agent Observability plugin in your stack:
 
 ```
-https://<your-stack>.grafana.net/plugins/grafana-sigil-app
+https://<your-stack>.grafana.net/plugins/grafana-agento11y-app
 ```
 
 Follow *Create a token in Cloud Access Policies* on the Connection page and create one token scoped with `sigil:write`, `metrics:write`, `traces:write`, and `logs:write`. The same token then covers both `AGENTO11Y_AUTH_TOKEN` (Agent Observability ingest) and `OTEL_EXPORTER_OTLP_HEADERS` (OTel traces and metrics).

--- a/examples/experiments/go/.env.example
+++ b/examples/experiments/go/.env.example
@@ -19,4 +19,4 @@ RUN_ID=go-experiment-local
 GIT_SHA=local
 
 # Optional: customize generated experiment links.
-# AGENTO11Y_EXPERIMENT_URL_TEMPLATE={base}/a/grafana-sigil-app/offline-experiments/experiments/{run_id}
+# AGENTO11Y_EXPERIMENT_URL_TEMPLATE={base}/a/grafana-agento11y-app/offline-experiments/experiments/{run_id}

--- a/examples/experiments/python/README.md
+++ b/examples/experiments/python/README.md
@@ -69,7 +69,7 @@ export AGENTO11Y_GRAFANA_URL=https://<your-stack>.grafana.net
 
 # Required only for stored-suite push/pull through the Grafana plugin proxy.
 # AGENTO11Y_CONTROL_ENDPOINT accepts the stack URL or app URL.
-export AGENTO11Y_CONTROL_ENDPOINT=https://<your-stack>.grafana.net/a/grafana-sigil-app
+export AGENTO11Y_CONTROL_ENDPOINT=https://<your-stack>.grafana.net/a/grafana-agento11y-app
 export AGENTO11Y_SERVICE_ACCOUNT_TOKEN=<your-grafana-service-account-token>
 
 # Optional: stable experiment id for CI retries / a real model.
@@ -126,7 +126,7 @@ You should see output like:
 ```
 Experiment 'experiment-example-manual' finished: 3 score(s) accepted.
 pass_rate=1.00 mean_score=1.00
-View in Agent Observability: https://<your-stack>.grafana.net/a/grafana-sigil-app/experiments/runs/experiment-example-manual
+View in Agent Observability: https://<your-stack>.grafana.net/a/grafana-agento11y-app/experiments/runs/experiment-example-manual
 ```
 
 > The deep link uses `AGENTO11Y_GRAFANA_URL`; keep it pointed at your Grafana stack

--- a/go/agento11y/experiments.go
+++ b/go/agento11y/experiments.go
@@ -310,7 +310,7 @@ func (c *Client) ExperimentURL(runID string) string {
 		out := strings.ReplaceAll(template, "{run_id}", normalized)
 		return strings.ReplaceAll(out, "{base}", base)
 	}
-	return strings.TrimRight(base, "/") + "/a/grafana-sigil-app/offline-experiments/experiments/" + url.PathEscape(normalized)
+	return strings.TrimRight(base, "/") + "/a/grafana-agento11y-app/offline-experiments/experiments/" + url.PathEscape(normalized)
 }
 
 func (c *Client) evalArgs() evalConnectionArgs {

--- a/llms.txt
+++ b/llms.txt
@@ -48,7 +48,7 @@ If skills are unavailable, the install fails, or the request matches Path A, con
 All four values (API URL, Instance ID, API token, and OTLP endpoint) live on the Connection tab of the Agent Observability plugin in the user's stack:
 
 ```
-https://<your-stack>.grafana.net/plugins/grafana-sigil-app
+https://<your-stack>.grafana.net/plugins/grafana-agento11y-app
 ```
 
 Follow *Create a token in Cloud Access Policies* on the Connection page and create one token scoped with `sigil:write`, `metrics:write`, `traces:write`, and `logs:write`. The same token then covers both `AGENTO11Y_AUTH_TOKEN` (Agent Observability ingest) and `OTEL_EXPORTER_OTLP_HEADERS` (OTel traces and metrics).

--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -51,7 +51,7 @@ AGENTO11Y_AUTH_TOKEN=glc_...
 AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
 ```
 
-Find these values in Grafana Cloud at `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`.
+Find these values in Grafana Cloud at `https://<your-grafana>.grafana.net/plugins/grafana-agento11y-app`.
 
 Then follow your agent's quickstart:
 

--- a/plugins/agento11y/internal/login/login.go
+++ b/plugins/agento11y/internal/login/login.go
@@ -38,12 +38,12 @@ import (
 // Grafana brand orange, applied throughout the prompt theme.
 const grafanaOrange = lipgloss.Color("#FF671D")
 
-const pluginURL = "https://<your-stack>.grafana.net/plugins/grafana-sigil-app"
+const pluginURL = "https://<your-stack>.grafana.net/plugins/grafana-agento11y-app"
 
 // observabilityURL points at the Agent Observability plugin route on the
 // user’s Grafana stack — the page where captured generations, traces, and
 // scores show up after a `agento11y claude` / `agento11y pi` session.
-const observabilityURL = "https://<your-stack>.grafana.net/a/grafana-sigil-app"
+const observabilityURL = "https://<your-stack>.grafana.net/a/grafana-agento11y-app"
 
 // docsURL points at the plugins directory so users can discover every
 // agent adapter we ship (claude-code, codex, cursor, pi, …). Linked as a

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -41,7 +41,7 @@ The script installs `agento11y` to `~/.local/bin`; `go install` uses `go env GOP
 
 ## 2. Credentials
 
-When `agento11y claude` prompts, copy values from `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure Agent Observability is enabled on your stack — an administrator opens **Observability → Agent Observability** once and accepts the terms.
+When `agento11y claude` prompts, copy values from `https://<your-grafana>.grafana.net/plugins/grafana-agento11y-app`. Make sure Agent Observability is enabled on your stack — an administrator opens **Observability → Agent Observability** once and accepts the terms.
 
 You need values from three Grafana Cloud pages:
 
@@ -95,7 +95,7 @@ Common culprits: `agento11y --version` doesn't work (binary not on `PATH`), a mi
 
 | Variable | Default | Description |
 |---|---|---|
-| `AGENTO11Y_ENDPOINT` | — | Agent Observability API URL. Find it at `/plugins/grafana-sigil-app`. |
+| `AGENTO11Y_ENDPOINT` | — | Agent Observability API URL. Find it at `/plugins/grafana-agento11y-app`. |
 | `AGENTO11Y_AUTH_TENANT_ID` | — | Grafana Cloud instance ID. |
 | `AGENTO11Y_AUTH_TOKEN` | — | `glc_…` Cloud Access Policy Token. |
 | `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the Agent Observability latency and tool-call panels stay empty. |

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -59,7 +59,7 @@ Restart Codex, open `/hooks`, and trust the five `sigil-codex@grafana-sigil` hoo
 
 ## 2. Credentials
 
-When `agento11y codex` prompts, copy values from `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure Agent Observability is enabled on your stack — an administrator opens **Observability → Agent Observability** once and accepts the terms.
+When `agento11y codex` prompts, copy values from `https://<your-grafana>.grafana.net/plugins/grafana-agento11y-app`. Make sure Agent Observability is enabled on your stack — an administrator opens **Observability → Agent Observability** once and accepts the terms.
 
 You need values from three Grafana Cloud pages:
 
@@ -111,7 +111,7 @@ tail -f ~/.local/state/agento11y/logs/agento11y.log
 
 | Variable | Default | Description |
 |---|---|---|
-| `AGENTO11Y_ENDPOINT` | — | Agent Observability API URL. Find it at `/plugins/grafana-sigil-app`. |
+| `AGENTO11Y_ENDPOINT` | — | Agent Observability API URL. Find it at `/plugins/grafana-agento11y-app`. |
 | `AGENTO11Y_AUTH_TENANT_ID` | — | Grafana Cloud instance ID. |
 | `AGENTO11Y_AUTH_TOKEN` | — | `glc_…` Cloud Access Policy Token. |
 | `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the Agent Observability latency and tool-call panels stay empty. |

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -52,7 +52,7 @@ For VS Code, no launch wrapper is needed — once `~/.copilot/hooks/agento11y.js
 
 ## 2. Credentials
 
-When `agento11y copilot` prompts, copy values from `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure Agent Observability is enabled on your stack — an administrator opens **Observability → Agent Observability** once and accepts the terms.
+When `agento11y copilot` prompts, copy values from `https://<your-grafana>.grafana.net/plugins/grafana-agento11y-app`. Make sure Agent Observability is enabled on your stack — an administrator opens **Observability → Agent Observability** once and accepts the terms.
 
 You need values from three Grafana Cloud pages:
 
@@ -157,7 +157,7 @@ Limits:
 
 | Variable | Default | Description |
 |---|---|---|
-| `AGENTO11Y_ENDPOINT` | — | Agent Observability API URL. Find it at `/plugins/grafana-sigil-app`. |
+| `AGENTO11Y_ENDPOINT` | — | Agent Observability API URL. Find it at `/plugins/grafana-agento11y-app`. |
 | `AGENTO11Y_AUTH_TENANT_ID` | — | Grafana Cloud instance ID. |
 | `AGENTO11Y_AUTH_TOKEN` | — | `glc_…` Cloud Access Policy Token. |
 | `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the Agent Observability latency and tool-call panels stay empty. |

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -53,7 +53,7 @@ Do not use both. `/add-plugin` and `agento11y cursor install` write to the same 
 
 ## 3. Add your credentials
 
-`agento11y cursor install` already prompts for these on first run; run `agento11y login` from a terminal to enter or change them later. The prompt asks for values from `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure Agent Observability is enabled on your stack — an administrator opens **Observability → Agent Observability** once and accepts the terms.
+`agento11y cursor install` already prompts for these on first run; run `agento11y login` from a terminal to enter or change them later. The prompt asks for values from `https://<your-grafana>.grafana.net/plugins/grafana-agento11y-app`. Make sure Agent Observability is enabled on your stack — an administrator opens **Observability → Agent Observability** once and accepts the terms.
 
 You need values from three Grafana Cloud pages:
 
@@ -104,7 +104,7 @@ tail -f ~/.local/state/agento11y/logs/agento11y.log
 
 | Variable | Default | Description |
 |---|---|---|
-| `AGENTO11Y_ENDPOINT` | — | Agent Observability API URL. Find it at `/plugins/grafana-sigil-app`. |
+| `AGENTO11Y_ENDPOINT` | — | Agent Observability API URL. Find it at `/plugins/grafana-agento11y-app`. |
 | `AGENTO11Y_AUTH_TENANT_ID` | — | Grafana Cloud instance ID. |
 | `AGENTO11Y_AUTH_TOKEN` | — | `glc_…` Cloud Access Policy Token. |
 | `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the Agent Observability latency and tool-call panels stay empty. |

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -45,7 +45,7 @@ The plugin reads `~/.config/agento11y/config.env` on every session start, whethe
 
 ## 2. Credentials
 
-When `agento11y opencode` or `agento11y login` prompts, copy values from `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure Agent Observability is enabled on your stack — an administrator opens **Observability → Agent Observability** once and accepts the terms.
+When `agento11y opencode` or `agento11y login` prompts, copy values from `https://<your-grafana>.grafana.net/plugins/grafana-agento11y-app`. Make sure Agent Observability is enabled on your stack — an administrator opens **Observability → Agent Observability** once and accepts the terms.
 
 You need values from three Grafana Cloud pages:
 
@@ -117,7 +117,7 @@ Built-in tags win collisions with user tags, matching the claude-code and cursor
 
 | Variable | Default | Description |
 |---|---|---|
-| `AGENTO11Y_ENDPOINT` | — | Agent Observability API URL. Find it at `/plugins/grafana-sigil-app`. Empty value disables the plugin. |
+| `AGENTO11Y_ENDPOINT` | — | Agent Observability API URL. Find it at `/plugins/grafana-agento11y-app`. Empty value disables the plugin. |
 | `AGENTO11Y_AUTH_TENANT_ID` | — | Grafana Cloud instance ID. |
 | `AGENTO11Y_AUTH_TOKEN` | — | `glc_…` Cloud Access Policy Token. |
 | `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the Agent Observability latency and tool-call panels stay empty. Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT`. |

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -45,7 +45,7 @@ The extension reads the same `~/.config/agento11y/config.env` file whether you s
 
 ## 2. Credentials
 
-When `agento11y pi` or `agento11y login` prompts, copy values from `https://<your-grafana>.grafana.net/plugins/grafana-sigil-app`. Make sure Agent Observability is enabled on your stack — an administrator opens **Observability → Agent Observability** once and accepts the terms.
+When `agento11y pi` or `agento11y login` prompts, copy values from `https://<your-grafana>.grafana.net/plugins/grafana-agento11y-app`. Make sure Agent Observability is enabled on your stack — an administrator opens **Observability → Agent Observability** once and accepts the terms.
 
 You need values from three Grafana Cloud pages:
 
@@ -144,7 +144,7 @@ Limits:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AGENTO11Y_ENDPOINT` | — | Agent Observability API URL (find it at `/plugins/grafana-sigil-app`) |
+| `AGENTO11Y_ENDPOINT` | — | Agent Observability API URL (find it at `/plugins/grafana-agento11y-app`) |
 | `AGENTO11Y_AUTH_TENANT_ID` | — | Grafana Cloud instance ID. Combined with `AGENTO11Y_AUTH_TOKEN` becomes Basic auth for Agent Observability and OTLP. |
 | `AGENTO11Y_AUTH_TOKEN` | — | Cloud access policy token (`glc_…`). |
 | `AGENTO11Y_AGENT_NAME` | `pi` | Agent name reported to Agent Observability. |

--- a/python-frameworks/litellm/example/README.md
+++ b/python-frameworks/litellm/example/README.md
@@ -40,7 +40,7 @@ curlie POST http://<proxy-host>:4000/chat/completions \
 
 ## Verify in Agent Observability
 
-Open `https://<your-stack>.grafana.net/a/grafana-sigil-app/conversations`. Generations appear with:
+Open `https://<your-stack>.grafana.net/a/grafana-agento11y-app/conversations`. Generations appear with:
 
 - `agent_name`: `litellm-proxy-integration-test`
 - `agento11y.framework.name`: `litellm`

--- a/python/agento11y/experiments/client.py
+++ b/python/agento11y/experiments/client.py
@@ -428,8 +428,8 @@ class Client:
         quoted = urllib.parse.quote(experiment_id, safe="")
         base = self.grafana_url
         if base:
-            return f"{base}/a/grafana-sigil-app/experiments/runs/{quoted}"
-        return f"{self.endpoint}/a/grafana-sigil-app/experiments/runs/{quoted}"
+            return f"{base}/a/grafana-agento11y-app/experiments/runs/{quoted}"
+        return f"{self.endpoint}/a/grafana-agento11y-app/experiments/runs/{quoted}"
 
     def shutdown(self) -> None:
         """Flushes and closes the underlying client if one was built."""

--- a/python/agento11y/experiments/suites.py
+++ b/python/agento11y/experiments/suites.py
@@ -17,8 +17,8 @@ from ..config import _warn_legacy_env
 from ..errors import ConflictError, ExperimentTransportError, NotFoundError, ValidationError
 from .types import TestCase, TestSuite, _first_nonblank
 
-_DEFAULT_CONTROL_PATH = "/api/plugins/grafana-sigil-app/resources/eval"
-_GRAFANA_APP_PATH = "/a/grafana-sigil-app"
+_DEFAULT_CONTROL_PATH = "/api/plugins/grafana-agento11y-app/resources/eval"
+_GRAFANA_APP_PATH = "/a/grafana-agento11y-app"
 _PORTABILITY_METADATA_KEY = "agento11y.sdk.portability"
 _PORTABILITY_VERSION = 1
 

--- a/python/skills/agento11y-experiments/SKILL.md
+++ b/python/skills/agento11y-experiments/SKILL.md
@@ -125,7 +125,7 @@ Stored suites use a Grafana service-account token in addition to the ingestion
 credential:
 
 ```bash
-export AGENTO11Y_CONTROL_ENDPOINT=https://<stack>.grafana.net/a/grafana-sigil-app
+export AGENTO11Y_CONTROL_ENDPOINT=https://<stack>.grafana.net/a/grafana-agento11y-app
 export AGENTO11Y_SERVICE_ACCOUNT_TOKEN=<grafana-service-account-token>
 ```
 
@@ -216,6 +216,6 @@ For all v1 environment and worker-lifecycle changes, see the
   instrumented; use `record_io(...)` when the experiment harness is the only
   instrumentation around the agent call.
 - The Grafana UI route is
-  `/a/grafana-sigil-app/experiments/runs/{experiment_id}`.
+  `/a/grafana-agento11y-app/experiments/runs/{experiment_id}`.
 - Catch evaluator failures outside each `with exp.trial(...)` block when one
   malformed judge response should fail only that trial and the run should continue.

--- a/python/tests/test_test_suites_client.py
+++ b/python/tests/test_test_suites_client.py
@@ -110,11 +110,11 @@ def test_endpoint_derivation_and_bearer_auth(monkeypatch: pytest.MonkeyPatch) ->
         suite = client.get_suite("dashboard")
         request = recorder.requests[0]
         assert request["method"] == "GET"
-        assert request["path"] == "/api/plugins/grafana-sigil-app/resources/eval/test-suites/dashboard"
+        assert request["path"] == "/api/plugins/grafana-agento11y-app/resources/eval/test-suites/dashboard"
         assert request["headers"]["authorization"] == "Bearer env-token"
         assert suite["suite_id"] == "dashboard"
         assert client.grafana_url == f"http://127.0.0.1:{server.server_address[1]}"
-        assert client.control_endpoint.endswith("/api/plugins/grafana-sigil-app/resources/eval")
+        assert client.control_endpoint.endswith("/api/plugins/grafana-agento11y-app/resources/eval")
         assert client.service_account_token == "env-token"
     finally:
         server.shutdown()
@@ -146,14 +146,14 @@ def test_control_endpoint_normalizes_grafana_app_url(monkeypatch: pytest.MonkeyP
     server = _serve(recorder)
     monkeypatch.setenv(
         "AGENTO11Y_CONTROL_ENDPOINT",
-        f"http://127.0.0.1:{server.server_address[1]}/a/grafana-sigil-app",
+        f"http://127.0.0.1:{server.server_address[1]}/a/grafana-agento11y-app",
     )
     monkeypatch.setenv("AGENTO11Y_SERVICE_ACCOUNT_TOKEN", "env-token")
     try:
         client = TestSuitesClient(timeout=2)
         client.get_suite("dashboard")
         request = recorder.requests[0]
-        assert request["path"] == "/api/plugins/grafana-sigil-app/resources/eval/test-suites/dashboard"
+        assert request["path"] == "/api/plugins/grafana-agento11y-app/resources/eval/test-suites/dashboard"
         assert request["headers"]["authorization"] == "Bearer env-token"
     finally:
         server.shutdown()
@@ -162,11 +162,11 @@ def test_control_endpoint_normalizes_grafana_app_url(monkeypatch: pytest.MonkeyP
 
 def test_control_endpoint_preserves_grafana_subpath() -> None:
     client = TestSuitesClient(
-        control_endpoint="https://example.test/grafana/a/grafana-sigil-app/experiments/test-suites",
+        control_endpoint="https://example.test/grafana/a/grafana-agento11y-app/experiments/test-suites",
         service_account_token="token",
     )
 
-    assert client.control_endpoint == ("https://example.test/grafana/api/plugins/grafana-sigil-app/resources/eval")
+    assert client.control_endpoint == ("https://example.test/grafana/api/plugins/grafana-agento11y-app/resources/eval")
 
 
 def test_direct_control_endpoint_keeps_separate_grafana_url(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -193,7 +193,7 @@ def test_legacy_control_environment_is_ignored(monkeypatch: pytest.MonkeyPatch) 
 
 def test_version_resolution_aliases() -> None:
     client = TestSuitesClient(
-        control_endpoint="http://example.test/api/plugins/grafana-sigil-app/resources/eval",
+        control_endpoint="http://example.test/api/plugins/grafana-agento11y-app/resources/eval",
         service_account_token="token",
     )
     suite = _suite_body()
@@ -224,7 +224,7 @@ def test_experiment_from_suite_requires_control_token() -> None:
     with pytest.raises(ValueError, match="service_account_token is required"):
         experiment_from_suite(
             "suite",
-            control_endpoint="https://example.test/a/grafana-sigil-app",
+            control_endpoint="https://example.test/a/grafana-agento11y-app",
             endpoint="https://ingest.example",
             ingest_token="token",
         )
@@ -392,11 +392,11 @@ def test_push_suite_creates_missing_suite_reuses_open_draft_upserts_and_publishe
         assert pushed.published is True
         assert pushed.pruned_case_ids == []
         assert [r["path"] for r in recorder.requests] == [
-            "/api/plugins/grafana-sigil-app/resources/eval/test-suites/local",
-            "/api/plugins/grafana-sigil-app/resources/eval/test-suites",
-            "/api/plugins/grafana-sigil-app/resources/eval/test-suites/local",
-            "/api/plugins/grafana-sigil-app/resources/eval/test-suites/local/versions/v2/test-cases",
-            "/api/plugins/grafana-sigil-app/resources/eval/test-suites/local/versions/v2:publish",
+            "/api/plugins/grafana-agento11y-app/resources/eval/test-suites/local",
+            "/api/plugins/grafana-agento11y-app/resources/eval/test-suites",
+            "/api/plugins/grafana-agento11y-app/resources/eval/test-suites/local",
+            "/api/plugins/grafana-agento11y-app/resources/eval/test-suites/local/versions/v2/test-cases",
+            "/api/plugins/grafana-agento11y-app/resources/eval/test-suites/local/versions/v2:publish",
         ]
         upsert = recorder.requests[3]["payload"]
         assert upsert["input"] == {"value": "question"}


### PR DESCRIPTION
The Grafana app plugin is renamed from grafana-sigil-app to grafana-agento11y-app as part of the agento11y rename. Updated experiment deep links, login prompts, and setup URLs.