### PR TITLE
Correlate guard decisions with conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The reference app is a fuller FastAPI service with framework callbacks and manua
 
 ## Hooks and guards
 
-Application SDK hooks evaluate Agent Observability guard rules on your request path before a provider call. A guard can allow the request, deny it, or return transformed input such as redacted messages. See the Go, Python, and TypeScript SDK READMEs for manual hook evaluation, and the runnable [`examples/getting-started/go-hooks/`](examples/getting-started/go-hooks/), [`examples/getting-started/python-hooks/`](examples/getting-started/python-hooks/), and [`examples/getting-started/typescript-hooks/`](examples/getting-started/typescript-hooks/) examples for preflight guard setups.
+Application SDK hooks evaluate Agent Observability guard rules on your request path before a provider call. A guard can allow the request, deny it, or return transformed input such as redacted messages. Go, Python, and TypeScript hook requests propagate the active conversation and OpenTelemetry trace correlation so Agent Observability can show a denied preflight attempt in conversation detail even when no generation was created. See the SDK READMEs for manual hook evaluation, and the runnable [`examples/getting-started/go-hooks/`](examples/getting-started/go-hooks/), [`examples/getting-started/python-hooks/`](examples/getting-started/python-hooks/), and [`examples/getting-started/typescript-hooks/`](examples/getting-started/typescript-hooks/) examples for preflight guard setups.
 
 ## Content capture and privacy
 

--- a/examples/getting-started/go-hooks/README.md
+++ b/examples/getting-started/go-hooks/README.md
@@ -26,4 +26,4 @@ go run .
 
 If the guard allows the request, the example applies any `transformed_input` returned by Agent Observability, calls OpenAI, records the generation, and prints `Done`.
 
-If the guard denies the request, the example catches `HookDeniedError`, prints the rule and reason, and does not call OpenAI.
+If the guard denies the request, the example catches `HookDeniedError`, prints the rule and reason, and does not call OpenAI. It uses the same conversation ID for the hook and generation, so Agent Observability can retain the denied attempt as a conversation event even when OpenAI is never called.

--- a/examples/getting-started/go-hooks/main.go
+++ b/examples/getting-started/go-hooks/main.go
@@ -78,9 +78,10 @@ func main() {
 	hookResponse, err := agento11yClient.EvaluateHook(ctx, agento11y.HookEvaluateRequest{
 		Phase: agento11y.HookPhasePreflight,
 		Context: agento11y.HookContext{
-			AgentName:    "getting-started-hooks",
-			AgentVersion: "1.0.0",
-			Model:        &agento11y.HookModel{Provider: "openai", Name: model},
+			AgentName:      "getting-started-hooks",
+			AgentVersion:   "1.0.0",
+			Model:          &agento11y.HookModel{Provider: "openai", Name: model},
+			ConversationID: "getting-started-go-hooks",
 		},
 		Input: agento11y.HookInput{
 			Messages:            inputMessages,

--- a/examples/getting-started/python-hooks/README.md
+++ b/examples/getting-started/python-hooks/README.md
@@ -29,4 +29,4 @@ python main.py
 
 If the guard allows the request, the example applies any `transformed_input` returned by Agent Observability, calls OpenAI, records the generation, and prints `Done`.
 
-If the guard denies the request, the example catches `HookDeniedError`, prints the rule and reason, and does not call OpenAI.
+If the guard denies the request, the example catches `HookDeniedError`, prints the rule and reason, and does not call OpenAI. It uses the same conversation ID for the hook and generation, so Agent Observability can retain the denied attempt as a conversation event even when OpenAI is never called.

--- a/examples/getting-started/python-hooks/main.py
+++ b/examples/getting-started/python-hooks/main.py
@@ -106,6 +106,7 @@ try:
                 agent_name="getting-started-hooks",
                 agent_version="1.0.0",
                 model=HookModel(provider="openai", name=model),
+                conversation_id="getting-started-python-hooks",
             ),
             input=HookInput(
                 messages=input_messages,

--- a/examples/getting-started/typescript-hooks/README.md
+++ b/examples/getting-started/typescript-hooks/README.md
@@ -31,4 +31,4 @@ npx tsx main.ts
 
 If the guard allows the request, the example applies any `transformedInput` returned by Agent Observability, calls OpenAI, records the generation, and prints `Done`.
 
-If the guard denies the request, the example reads `action: "deny"` from the hook response, prints the rule and reason, and does not call OpenAI.
+If the guard denies the request, the example reads `action: "deny"` from the hook response, prints the rule and reason, and does not call OpenAI. It uses the same conversation ID for the hook and generation, so Agent Observability can retain the denied attempt as a conversation event even when OpenAI is never called.

--- a/examples/getting-started/typescript-hooks/main.ts
+++ b/examples/getting-started/typescript-hooks/main.ts
@@ -101,6 +101,7 @@ const hookRequest: HookEvaluateRequest = {
     agentName: "getting-started-hooks",
     agentVersion: "1.0.0",
     model: { provider: "openai", name: model },
+    conversationId: "getting-started-typescript-hooks",
   },
   input: {
     messages: inputMessages,

--- a/go/README.md
+++ b/go/README.md
@@ -228,6 +228,7 @@ response, err := client.EvaluateHook(ctx, agento11y.HookEvaluateRequest{
 		AgentName:    "support-agent",
 		AgentVersion: "1.0.0",
 		Model:        &agento11y.HookModel{Provider: "openai", Name: "gpt-5"},
+		ConversationID: "support-case-42",
 	},
 	Input: agento11y.HookInput{
 		Messages:            messages,
@@ -247,6 +248,8 @@ if response.TransformedInput != nil && len(response.TransformedInput.Messages) >
 ```
 
 `HooksConfig` defaults to `Phases: []HookPhase{HookPhasePreflight}`, `Timeout: 15s`, and fail-open behavior. With fail-open enabled, hook transport errors resolve to allow so an unavailable evaluator does not block production traffic. Set `FailOpen` to `agento11y.BoolPtr(false)` for strict paths that should fail closed.
+
+Set `HookContext.ConversationID` to the same ID used by `StartGeneration(...)`. The SDK also reads `WithConversationID(...)` and the active OpenTelemetry span when explicit correlation fields are omitted. This lets Agent Observability retain denied preflight attempts even though no LLM generation is created.
 
 If you use transformed input, pass the transformed messages/system prompt to the provider and record those same values in `StartGeneration(...)`. For a runnable example, see [`../examples/getting-started/go-hooks/`](../examples/getting-started/go-hooks/).
 

--- a/go/agento11y/hooks.go
+++ b/go/agento11y/hooks.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"go.opentelemetry.io/otel/trace"
 )
 
 // HookPhase enumerates evaluation phases.
@@ -111,10 +113,13 @@ type HookModel struct {
 
 // HookContext is metadata used to match hook rules against this evaluation.
 type HookContext struct {
-	AgentName    string            `json:"agent_name,omitempty"`
-	AgentVersion string            `json:"agent_version,omitempty"`
-	Model        *HookModel        `json:"model,omitempty"`
-	Tags         map[string]string `json:"tags,omitempty"`
+	AgentName      string            `json:"agent_name,omitempty"`
+	AgentVersion   string            `json:"agent_version,omitempty"`
+	Model          *HookModel        `json:"model,omitempty"`
+	Tags           map[string]string `json:"tags,omitempty"`
+	ConversationID string            `json:"conversation_id,omitempty"`
+	TraceID        string            `json:"trace_id,omitempty"`
+	SpanID         string            `json:"span_id,omitempty"`
 }
 
 // HookInput carries the evaluable payload (request for preflight,
@@ -185,6 +190,7 @@ func (c *Client) EvaluateHook(ctx context.Context, req HookEvaluateRequest) (*Ho
 	if !phaseEnabled(hooksCfg.Phases, req.Phase) {
 		return allowResponse(), nil
 	}
+	enrichHookCorrelation(ctx, &req.Context)
 
 	timeout := hooksCfg.Timeout
 	if timeout <= 0 {
@@ -252,6 +258,27 @@ func (c *Client) EvaluateHook(ctx context.Context, req HookEvaluateRequest) (*Ho
 		out.Action = HookActionAllow
 	}
 	return &out, nil
+}
+
+func enrichHookCorrelation(ctx context.Context, hookCtx *HookContext) {
+	if hookCtx == nil {
+		return
+	}
+	if hookCtx.ConversationID == "" {
+		if conversationID, ok := ConversationIDFromContext(ctx); ok {
+			hookCtx.ConversationID = conversationID
+		}
+	}
+	spanCtx := trace.SpanContextFromContext(ctx)
+	if !spanCtx.IsValid() {
+		return
+	}
+	if hookCtx.TraceID == "" {
+		hookCtx.TraceID = spanCtx.TraceID().String()
+	}
+	if hookCtx.SpanID == "" {
+		hookCtx.SpanID = spanCtx.SpanID().String()
+	}
 }
 
 // HookDeniedFromResponse converts a denied HookEvaluateResponse into a typed

--- a/go/agento11y/hooks_test.go
+++ b/go/agento11y/hooks_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 )
 
@@ -108,6 +109,42 @@ func TestEvaluateHookSendsRequestAndParsesAllow(t *testing.T) {
 	}
 	if len(resp.Evaluations) != 1 || resp.Evaluations[0].RuleID != "pii" {
 		t.Fatalf("unexpected evaluations: %#v", resp.Evaluations)
+	}
+}
+
+func TestEvaluateHookAddsCorrelationFromContext(t *testing.T) {
+	var captured HookEvaluateRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if err := json.NewDecoder(req.Body).Decode(&captured); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"action":"allow","evaluations":[]}`))
+	}))
+	defer server.Close()
+
+	client := newHookTestClient(t, hookTestClientOptions{apiEndpoint: server.URL, hooksEnabled: true})
+	t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
+
+	traceID, _ := trace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+	spanID, _ := trace.SpanIDFromHex("0123456789abcdef")
+	ctx := WithConversationID(context.Background(), "conv-guarded")
+	ctx = trace.ContextWithSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: traceID,
+		SpanID:  spanID,
+	}))
+
+	_, err := client.EvaluateHook(ctx, HookEvaluateRequest{
+		Phase:   HookPhasePreflight,
+		Context: HookContext{Model: &HookModel{Provider: "openai", Name: "gpt-4o"}},
+	})
+	if err != nil {
+		t.Fatalf("evaluate hook: %v", err)
+	}
+	if captured.Context.ConversationID != "conv-guarded" {
+		t.Fatalf("expected conversation correlation, got %#v", captured.Context)
+	}
+	if captured.Context.TraceID != traceID.String() || captured.Context.SpanID != spanID.String() {
+		t.Fatalf("expected trace correlation, got %#v", captured.Context)
 	}
 }
 

--- a/js/README.md
+++ b/js/README.md
@@ -210,6 +210,7 @@ const response = await client.evaluateHook({
     agentName: "support-agent",
     agentVersion: "1.0.0",
     model: { provider: "openai", name: "gpt-5" },
+    conversationId: "support-case-42",
   },
   input: {
     messages,
@@ -226,6 +227,8 @@ messages = response.transformedInput?.messages ?? messages;
 ```
 
 With `failOpen: true`, hook transport errors resolve to allow so an unavailable evaluator does not block production traffic. Set `failOpen: false` for strict paths that should fail closed.
+
+Set `context.conversationId` to the same ID used by `startGeneration(...)`. The SDK also reads `withConversationId(...)` and the active OpenTelemetry span when explicit correlation fields are omitted. This lets Agent Observability retain denied preflight attempts even though no LLM generation is created.
 
 If you use transformed input, pass the transformed messages/system prompt to the provider and record those same values in `startGeneration(...)`. If you use the Vercel AI SDK adapter, see `docs/frameworks/vercel-ai-sdk.md` for automatic preflight hook wiring.
 

--- a/js/docs/frameworks/vercel-ai-sdk.md
+++ b/js/docs/frameworks/vercel-ai-sdk.md
@@ -78,6 +78,9 @@ try {
 }
 ```
 
+The adapter passes the resolved `conversationId` with every preflight hook request. Agent Observability can therefore
+record a denied step in that conversation even when the provider call and generation never happen.
+
 The adapter sends the step messages, model, agent name/version, and conversation preview to Agent Observability. If a guard returns `action: "deny"`, the adapter throws `HookDeniedError` and the provider call is aborted. If a guard returns `transformed_input.messages`, the adapter records the transformed input in the generation; when the AI SDK calls `prepareStep` and the transformed messages can be represented as AI SDK model messages, the adapter also returns those transformed messages to the provider. If a transform is requested but cannot be applied to the provider call, the adapter aborts rather than sending the original messages.
 
 `enableHooks` overrides the client-level switch for this instrumentation. Leave it unset to use `client.config.hooks.enabled`, or set it to `false` to disable hook evaluation for calls made through this adapter. With `failOpen: true`, hook transport errors resolve to allow; set `failOpen: false` for strict paths that should fail closed.

--- a/js/src/frameworks/vercel-ai-sdk/hooks.ts
+++ b/js/src/frameworks/vercel-ai-sdk/hooks.ts
@@ -201,26 +201,20 @@ export class Agento11yVercelAiSdkInstrumentation {
       stepStartEvent: StepStartEvent;
       startedAt: Date;
       inputMessages: Message[];
+      conversation: ConversationResolution;
     }): StepState => {
-      const conversation = resolveConversationId({
-        explicitConversationId,
-        resolver: this.resolveConversationIdFn,
-        stepStartEvent: params.stepStartEvent,
-        fallbackSeed: `${callID}:step-${params.stepNumber}`,
-      });
-
       const stepState: StepState = {
         recorder:
           mode === 'STREAM' && hasStepStartModelRef(params.stepStartEvent)
             ? createGenerationRecorder({
                 stepStartEvent: params.stepStartEvent,
-                conversationId: conversation.conversationId,
+                conversationId: params.conversation.conversationId,
                 startedAt: params.startedAt,
               })
             : undefined,
         startedAt: params.startedAt,
         inputMessages: params.inputMessages,
-        conversation,
+        conversation: params.conversation,
         fallbackSeed: `${callID}:step-${params.stepNumber}`,
         firstTokenRecorded: false,
         firstTokenAt: undefined,
@@ -236,6 +230,13 @@ export class Agento11yVercelAiSdkInstrumentation {
       kickOffOutputSchemaExtraction(stepState);
       return stepState;
     };
+    const resolveStepConversation = (stepNumber: number, stepStartEvent: StepStartEvent): ConversationResolution =>
+      resolveConversationId({
+        explicitConversationId,
+        resolver: this.resolveConversationIdFn,
+        stepStartEvent,
+        fallbackSeed: `${callID}:step-${stepNumber}`,
+      });
     const kickOffOutputSchemaExtraction = (stepState: StepState): void => {
       const outputRef = stepState.stepStartEvent.output;
       if (outputRef === undefined || outputRef === null) {
@@ -285,6 +286,7 @@ export class Agento11yVercelAiSdkInstrumentation {
         stepStartEvent: syntheticStepStartEvent,
         startedAt: syntheticStartedAt,
         inputMessages: [],
+        conversation: resolveStepConversation(syntheticStepNumber, syntheticStepStartEvent),
       });
       return { stepNumber: syntheticStepNumber, stepState: syntheticStepState };
     };
@@ -314,6 +316,7 @@ export class Agento11yVercelAiSdkInstrumentation {
         stepStartEvent: syntheticStepStartEvent,
         startedAt: params.observedAt,
         inputMessages: [],
+        conversation: resolveStepConversation(syntheticStepNumber, syntheticStepStartEvent),
       });
       return { stepNumber: syntheticStepNumber, stepState: syntheticStepState };
     };
@@ -496,6 +499,7 @@ export class Agento11yVercelAiSdkInstrumentation {
     const runPreflight = async (
       event: StepStartEvent,
       inputMessages: Message[],
+      conversationId: string,
     ): Promise<{ messages: Message[]; providerMessages?: VercelAiSdkModelMessage[]; transformed: boolean }> => {
       const model = mapModelFromStepStart(event);
       // evaluateHook honors fail-open internally; an exception here means
@@ -510,6 +514,7 @@ export class Agento11yVercelAiSdkInstrumentation {
             agentVersion: this.agentVersion,
             model: { provider: model.provider, name: model.modelName },
             tags,
+            conversationId,
           },
           input: {
             messages: inputMessages.length > 0 ? inputMessages : undefined,
@@ -549,6 +554,7 @@ export class Agento11yVercelAiSdkInstrumentation {
       state.nextSyntheticStepNumber = Math.max(state.nextSyntheticStepNumber + 1, stepNumber + 1);
 
       const inputMessages = mapInputMessages(event.messages);
+      const conversation = resolveStepConversation(stepNumber, event);
       const finalize = (
         resolvedMessages: Message[],
         providerMessages: VercelAiSdkModelMessage[] | undefined,
@@ -572,6 +578,7 @@ export class Agento11yVercelAiSdkInstrumentation {
           stepStartEvent: event,
           startedAt: new Date(),
           inputMessages: this.captureInputs ? resolvedMessages : [],
+          conversation,
         });
         if (returnPreparedMessages && providerMessages !== undefined) {
           return { messages: providerMessages };
@@ -586,8 +593,8 @@ export class Agento11yVercelAiSdkInstrumentation {
       // Preflight evaluates against the actual prompt/messages even when
       // captureInputs is disabled — the hook server only sees them in
       // memory and never persists them.
-      return runPreflight(event, inputMessages).then(({ messages, providerMessages, transformed }) =>
-        finalize(messages, providerMessages, transformed),
+      return runPreflight(event, inputMessages, conversation.conversationId).then(
+        ({ messages, providerMessages, transformed }) => finalize(messages, providerMessages, transformed),
       );
     };
 

--- a/js/src/hooks.ts
+++ b/js/src/hooks.ts
@@ -1,3 +1,5 @@
+import { context as otelContext, trace } from '@opentelemetry/api';
+import { conversationIdFromContext } from './context.js';
 import type {
   HookEvaluateRequest,
   HookEvaluateResponse,
@@ -174,18 +176,31 @@ function serializeRequest(request: HookEvaluateRequest): Record<string, unknown>
   return body;
 }
 
-function serializeContext(context: HookEvaluateRequest['context']): Record<string, unknown> {
+function serializeContext(hookContext: HookEvaluateRequest['context']): Record<string, unknown> {
   const out: Record<string, unknown> = {
-    model: { provider: context.model.provider, name: context.model.name },
+    model: { provider: hookContext.model.provider, name: hookContext.model.name },
   };
-  if (context.agentName !== undefined && context.agentName.length > 0) {
-    out.agent_name = context.agentName;
+  if (hookContext.agentName !== undefined && hookContext.agentName.length > 0) {
+    out.agent_name = hookContext.agentName;
   }
-  if (context.agentVersion !== undefined && context.agentVersion.length > 0) {
-    out.agent_version = context.agentVersion;
+  if (hookContext.agentVersion !== undefined && hookContext.agentVersion.length > 0) {
+    out.agent_version = hookContext.agentVersion;
   }
-  if (context.tags !== undefined && Object.keys(context.tags).length > 0) {
-    out.tags = { ...context.tags };
+  if (hookContext.tags !== undefined && Object.keys(hookContext.tags).length > 0) {
+    out.tags = { ...hookContext.tags };
+  }
+  const conversationId = hookContext.conversationId ?? conversationIdFromContext();
+  if (conversationId !== undefined && conversationId.length > 0) {
+    out.conversation_id = conversationId;
+  }
+  const spanContext = trace.getSpan(otelContext.active())?.spanContext();
+  const traceId = hookContext.traceId ?? spanContext?.traceId;
+  const spanId = hookContext.spanId ?? spanContext?.spanId;
+  if (traceId !== undefined && traceId.length > 0) {
+    out.trace_id = traceId;
+  }
+  if (spanId !== undefined && spanId.length > 0) {
+    out.span_id = spanId;
   }
   return out;
 }

--- a/js/src/hooks.ts
+++ b/js/src/hooks.ts
@@ -1,4 +1,4 @@
-import { context as otelContext, trace } from '@opentelemetry/api';
+import { isSpanContextValid, context as otelContext, trace } from '@opentelemetry/api';
 import { conversationIdFromContext } from './context.js';
 import type {
   HookEvaluateRequest,
@@ -193,7 +193,9 @@ function serializeContext(hookContext: HookEvaluateRequest['context']): Record<s
   if (conversationId !== undefined && conversationId.length > 0) {
     out.conversation_id = conversationId;
   }
-  const spanContext = trace.getSpan(otelContext.active())?.spanContext();
+  const activeSpanContext = trace.getSpan(otelContext.active())?.spanContext();
+  const spanContext =
+    activeSpanContext !== undefined && isSpanContextValid(activeSpanContext) ? activeSpanContext : undefined;
   const traceId = hookContext.traceId ?? spanContext?.traceId;
   const spanId = hookContext.spanId ?? spanContext?.spanId;
   if (traceId !== undefined && traceId.length > 0) {

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -639,6 +639,9 @@ export interface HookContext {
   agentVersion?: string;
   model: HookModel;
   tags?: Record<string, string>;
+  conversationId?: string;
+  traceId?: string;
+  spanId?: string;
 }
 
 /**

--- a/js/test/client.hooks.test.mjs
+++ b/js/test/client.hooks.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { createServer } from 'node:http';
 import test from 'node:test';
 import { trace } from '@opentelemetry/api';
-import { Agento11yClient, defaultConfig, HookDeniedError } from '../.test-dist/index.js';
+import { Agento11yClient, defaultConfig, HookDeniedError, withConversationId } from '../.test-dist/index.js';
 
 test('evaluateHook returns allow without contacting server when disabled', async () => {
   const client = newClient({
@@ -110,6 +110,45 @@ test('evaluateHook posts JSON to /api/v1/hooks:evaluate and parses allow respons
     assert.equal(response.evaluations[0].passed, true);
     assert.equal(response.evaluations[0].latencyMs, 12);
     assert.equal(response.evaluations[0].explanation, 'no PII matches');
+  } finally {
+    await client.shutdown();
+    await close(server);
+  }
+});
+
+test('evaluateHook adds conversation correlation and explicit trace identifiers', async () => {
+  let receivedBody = {};
+  const server = createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    receivedBody = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ action: 'allow', evaluations: [] }));
+  });
+  await listen(server);
+  const address = server.address();
+  const client = newClient({
+    apiEndpoint: `http://127.0.0.1:${address.port}`,
+    hooksEnabled: true,
+  });
+
+  try {
+    await withConversationId('conv-guarded', () =>
+      client.evaluateHook({
+        phase: 'preflight',
+        context: {
+          model: { provider: 'openai', name: 'gpt-4o' },
+          traceId: '0123456789abcdef0123456789abcdef',
+          spanId: '0123456789abcdef',
+        },
+        input: {},
+      }),
+    );
+    assert.equal(receivedBody.context.conversation_id, 'conv-guarded');
+    assert.equal(receivedBody.context.trace_id, '0123456789abcdef0123456789abcdef');
+    assert.equal(receivedBody.context.span_id, '0123456789abcdef');
   } finally {
     await client.shutdown();
     await close(server);

--- a/js/test/client.hooks.test.mjs
+++ b/js/test/client.hooks.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { createServer } from 'node:http';
 import test from 'node:test';
-import { trace } from '@opentelemetry/api';
+import { context, trace } from '@opentelemetry/api';
 import { Agento11yClient, defaultConfig, HookDeniedError, withConversationId } from '../.test-dist/index.js';
 
 test('evaluateHook returns allow without contacting server when disabled', async () => {
@@ -149,6 +149,45 @@ test('evaluateHook adds conversation correlation and explicit trace identifiers'
     assert.equal(receivedBody.context.conversation_id, 'conv-guarded');
     assert.equal(receivedBody.context.trace_id, '0123456789abcdef0123456789abcdef');
     assert.equal(receivedBody.context.span_id, '0123456789abcdef');
+  } finally {
+    await client.shutdown();
+    await close(server);
+  }
+});
+
+test('evaluateHook omits invalid active trace identifiers', async () => {
+  let receivedBody = {};
+  const server = createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    receivedBody = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ action: 'allow', evaluations: [] }));
+  });
+  await listen(server);
+  const address = server.address();
+  const client = newClient({
+    apiEndpoint: `http://127.0.0.1:${address.port}`,
+    hooksEnabled: true,
+  });
+  const invalidSpan = trace.wrapSpanContext({
+    traceId: '00000000000000000000000000000000',
+    spanId: '0000000000000000',
+    traceFlags: 0,
+  });
+
+  try {
+    await context.with(trace.setSpan(context.active(), invalidSpan), () =>
+      client.evaluateHook({
+        phase: 'preflight',
+        context: { model: { provider: 'openai', name: 'gpt-4o' } },
+        input: {},
+      }),
+    );
+    assert.equal(receivedBody.context.trace_id, undefined);
+    assert.equal(receivedBody.context.span_id, undefined);
   } finally {
     await client.shutdown();
     await close(server);

--- a/js/test/frameworks.vercel-ai-sdk.hooks.test.mjs
+++ b/js/test/frameworks.vercel-ai-sdk.hooks.test.mjs
@@ -58,6 +58,7 @@ test('vercel ai sdk preflight allows step when hook returns allow', async () => 
     assert.equal(receivedBody.context.agent_version, '2.0.0');
     assert.equal(receivedBody.context.model.provider, 'openai');
     assert.equal(receivedBody.context.model.name, 'gpt-4o');
+    assert.equal(receivedBody.context.conversation_id, 'conv-allow');
     assert.equal(receivedBody.input.messages[0].role, 'user');
   } finally {
     await client.shutdown();

--- a/python/README.md
+++ b/python/README.md
@@ -291,6 +291,7 @@ response = client.evaluate_hook(
             agent_name="support-agent",
             agent_version="1.0.0",
             model=HookModel(provider="openai", name="gpt-5"),
+            conversation_id="support-case-42",
         ),
         input=HookInput(
             messages=messages,
@@ -309,6 +310,8 @@ if response.transformed_input is not None:
 ```
 
 `HooksConfig` defaults to `phases=["preflight"]`, `timeout_seconds=15.0`, and `fail_open=True`. With fail-open enabled, hook transport errors resolve to allow so an unavailable evaluator does not block production traffic. Set `fail_open=False` for strict paths that should fail closed.
+
+Set `HookContext.conversation_id` to the same ID used by `start_generation(...)`. The SDK also reads `with_conversation_id(...)` and the active OpenTelemetry span when explicit correlation fields are omitted. This lets Agent Observability retain denied preflight attempts even though no LLM generation is created.
 
 If you use transformed input, pass the transformed messages/system prompt to the provider and record those same values in `start_generation(...)`. For a runnable example, see `../examples/getting-started/python-hooks/`.
 

--- a/python/agento11y/hooks.py
+++ b/python/agento11y/hooks.py
@@ -11,7 +11,10 @@ from urllib import error as urllib_error
 from urllib import parse as urllib_parse
 from urllib import request as urllib_request
 
+from opentelemetry import trace
+
 from .config import HooksConfig
+from .context import conversation_id_from_context
 from .errors import HookDeniedError, HookTransportError
 from .models import Message, MessageRole, Part, PartKind, ToolDefinition
 
@@ -51,6 +54,9 @@ class HookContext:
     agent_name: str = ""
     agent_version: str = ""
     tags: dict[str, str] = field(default_factory=dict)
+    conversation_id: str = ""
+    trace_id: str = ""
+    span_id: str = ""
 
 
 @dataclass(slots=True)
@@ -222,6 +228,19 @@ def _serialize_context(context: HookContext) -> dict[str, Any]:
         out["agent_version"] = context.agent_version
     if context.tags:
         out["tags"] = dict(context.tags)
+    conversation_id = context.conversation_id or conversation_id_from_context() or ""
+    if conversation_id:
+        out["conversation_id"] = conversation_id
+    span_context = trace.get_current_span().get_span_context()
+    trace_id = context.trace_id
+    span_id = context.span_id
+    if span_context.is_valid:
+        trace_id = trace_id or format(span_context.trace_id, "032x")
+        span_id = span_id or format(span_context.span_id, "016x")
+    if trace_id:
+        out["trace_id"] = trace_id
+    if span_id:
+        out["span_id"] = span_id
     return out
 
 

--- a/python/tests/test_hooks_transport.py
+++ b/python/tests/test_hooks_transport.py
@@ -29,7 +29,9 @@ from agento11y import (
     ToolDefinition,
     hook_denied_from_response,
     user_text_message,
+    with_conversation_id,
 )
+from opentelemetry import context as otel_context
 from opentelemetry import trace
 
 
@@ -180,6 +182,38 @@ def test_evaluate_hook_posts_to_hooks_evaluate() -> None:
         client.shutdown()
         server.shutdown()
         server.server_close()
+
+
+def test_evaluate_hook_adds_correlation_from_context() -> None:
+    with _capturing_hook_server({"action": "allow", "evaluations": []}) as (captured, endpoint):
+        client = _new_client(endpoint, hooks=HooksConfig(enabled=True))
+        span_context = trace.SpanContext(
+            trace_id=int("0123456789abcdef0123456789abcdef", 16),
+            span_id=int("0123456789abcdef", 16),
+            is_remote=False,
+            trace_flags=trace.TraceFlags(1),
+        )
+        token = otel_context.attach(trace.set_span_in_context(trace.NonRecordingSpan(span_context)))
+        try:
+            with with_conversation_id("conv-guarded"):
+                client.evaluate_hook(
+                    HookEvaluateRequest(
+                        phase=HookPhase.PREFLIGHT.value,
+                        context=HookContext(model=HookModel(provider="openai", name="gpt-4o")),
+                        input=HookInput(),
+                    )
+                )
+        finally:
+            otel_context.detach(token)
+            client.shutdown()
+
+    payload = captured["payload"]
+    assert isinstance(payload, dict)
+    context_payload = payload["context"]
+    assert isinstance(context_payload, dict)
+    assert context_payload["conversation_id"] == "conv-guarded"
+    assert context_payload["trace_id"] == "0123456789abcdef0123456789abcdef"
+    assert context_payload["span_id"] == "0123456789abcdef"
 
 
 def test_evaluate_hook_deny() -> None:


### PR DESCRIPTION
## Summary

- add optional conversation, trace, and span correlation to Go, Python, and TypeScript hook contexts
- derive omitted identifiers from active agento11y conversation and OpenTelemetry contexts
- pass the resolved conversation ID through Vercel AI SDK preflight hooks
- update examples and SDK documentation for denied-attempt visibility

## Why

A guard can deny the first preflight request before an LLM generation exists. Correlation lets Agent Observability retain that decision in the intended conversation instead of leaving it visible only as an aggregate metric.

Companion app/backend PR: https://github.com/grafana/sigil/pull/1403

## Validation

- mise run test:go:sdk-core
- UV_CONFIG_FILE=/dev/null mise run test:py:sdk-core (389 passed)
- mise run test:ts:sdk-js (369 passed)
- mise run test:ts:sdk-js-frameworks (117 passed)
- mise run typecheck:ts:sdk-js
- Go, Python, and TypeScript lint for the changed SDKs

The broader cross-language conformance run passed Go, TypeScript, and Python, then stopped because this machine has no Java runtime.