### PR TITLE
feat(sdk): send new X-Agento11y-* request headers

### DIFF
--- a/go/agento11y/hooks.go
+++ b/go/agento11y/hooks.go
@@ -35,7 +35,7 @@ const (
 
 const (
 	hooksEvaluatePath      = "/api/v1/hooks:evaluate"
-	hookTimeoutHeader      = "X-Sigil-Hook-Timeout-Ms"
+	hookTimeoutHeader      = "X-Agento11y-Hook-Timeout-Ms"
 	defaultHookTimeout     = 15 * time.Second
 	maxHookEvaluateRespLen = 4 << 20
 )
@@ -48,10 +48,10 @@ type HooksConfig struct {
 	// Phases the SDK is allowed to evaluate. Defaults to {HookPhasePreflight}.
 	// Requests whose phase isn't listed short-circuit to allow.
 	Phases []HookPhase
-	// Timeout is the per-request HTTP timeout. Defaults to 15s, capped by the
-	// server at 120s. The value is also propagated via the
-	// X-Sigil-Hook-Timeout-Ms header so the server can scope its evaluator
-	// budget accordingly.
+	// Timeout is the per-request HTTP timeout, also sent as
+	// X-Agento11y-Hook-Timeout-Ms so the server can scope its evaluator budget.
+	// Defaults to 15s. The server honours 1..119999 ms and falls back to its own
+	// budget for anything else.
 	Timeout time.Duration
 	// FailOpen returns HookActionAllow on transport / decode failures when
 	// non-nil and *FailOpen == true. Set to a pointer to false to surface

--- a/go/agento11y/hooks_test.go
+++ b/go/agento11y/hooks_test.go
@@ -91,8 +91,11 @@ func TestEvaluateHookSendsRequestAndParsesAllow(t *testing.T) {
 	if capturedHeaders.Get("Content-Type") != "application/json" {
 		t.Fatalf("missing content-type header")
 	}
-	if capturedHeaders.Get("X-Sigil-Hook-Timeout-Ms") == "" {
-		t.Fatalf("missing timeout header")
+	if got := capturedHeaders.Get("X-Agento11y-Hook-Timeout-Ms"); got != "15000" {
+		t.Fatalf("unexpected timeout header: %q", got)
+	}
+	if got := capturedHeaders.Get("X-Sigil-Hook-Timeout-Ms"); got != "" {
+		t.Fatalf("legacy timeout header should not be sent, got %q", got)
 	}
 	if capturedBody.Phase != HookPhasePreflight {
 		t.Fatalf("unexpected phase: %q", capturedBody.Phase)
@@ -109,6 +112,30 @@ func TestEvaluateHookSendsRequestAndParsesAllow(t *testing.T) {
 	}
 	if len(resp.Evaluations) != 1 || resp.Evaluations[0].RuleID != "pii" {
 		t.Fatalf("unexpected evaluations: %#v", resp.Evaluations)
+	}
+}
+
+func TestEvaluateHookCallerHeaderOverridesTimeoutHeader(t *testing.T) {
+	var capturedHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		capturedHeaders = req.Header.Clone()
+		_, _ = w.Write([]byte(`{"action":"allow","evaluations":[]}`))
+	}))
+	defer server.Close()
+
+	client := newHookTestClient(t, hookTestClientOptions{
+		apiEndpoint:  server.URL,
+		hooksEnabled: true,
+		headers:      map[string]string{hookTimeoutHeader: "500"},
+	})
+	t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
+
+	if _, err := client.EvaluateHook(context.Background(), HookEvaluateRequest{Phase: HookPhasePreflight}); err != nil {
+		t.Fatalf("evaluate hook: %v", err)
+	}
+
+	if got := capturedHeaders.Get("X-Agento11y-Hook-Timeout-Ms"); got != "500" {
+		t.Fatalf("caller header should win, got %q", got)
 	}
 }
 
@@ -382,6 +409,7 @@ type hookTestClientOptions struct {
 	hooksEnabled bool
 	phases       []HookPhase
 	failOpen     *bool
+	headers      map[string]string
 }
 
 func newHookTestClient(t *testing.T, options hookTestClientOptions) *Client {
@@ -399,6 +427,7 @@ func newHookTestClient(t *testing.T, options hookTestClientOptions) *Client {
 			InitialBackoff:  time.Millisecond,
 			MaxBackoff:      time.Millisecond,
 			PayloadMaxBytes: 1 << 20,
+			Headers:         options.headers,
 		},
 		API: APIConfig{Endpoint: options.apiEndpoint},
 		Hooks: HooksConfig{

--- a/js/src/hooks.ts
+++ b/js/src/hooks.ts
@@ -15,7 +15,7 @@ import type {
 import { asError } from './utils.js';
 
 const hooksEvaluatePath = '/api/v1/hooks:evaluate';
-const hookTimeoutHeader = 'X-Sigil-Hook-Timeout-Ms';
+const hookTimeoutHeader = 'X-Agento11y-Hook-Timeout-Ms';
 
 /**
  * Thrown by framework adapters when hook evaluation returns `action: 'deny'`.

--- a/js/test/client.hooks.test.mjs
+++ b/js/test/client.hooks.test.mjs
@@ -82,7 +82,8 @@ test('evaluateHook posts JSON to /api/v1/hooks:evaluate and parses allow respons
 
     assert.equal(receivedPath, '/api/v1/hooks:evaluate');
     assert.equal(receivedHeaders['content-type'], 'application/json');
-    assert.equal(receivedHeaders['x-sigil-hook-timeout-ms'], '15000');
+    assert.equal(receivedHeaders['x-agento11y-hook-timeout-ms'], '15000');
+    assert.equal(receivedHeaders['x-sigil-hook-timeout-ms'], undefined);
     assert.deepEqual(receivedBody, {
       phase: 'preflight',
       context: {

--- a/python/agento11y/_experiments_transport.py
+++ b/python/agento11y/_experiments_transport.py
@@ -64,6 +64,7 @@ _DEFAULT_TIMEOUT = 30.0
 _MAX_RESPONSE_BYTES = 8 << 20
 _EXPERIMENT_RUN_SOURCE = {"kind": "sdk", "id": "python"}
 DEFAULT_INGEST_ACTOR = "ingest:sdk/python"
+INGEST_ACTOR_HEADER = "X-Agento11y-Ingest-Actor"
 
 
 @dataclass(slots=True)

--- a/python/agento11y/client.py
+++ b/python/agento11y/client.py
@@ -757,7 +757,7 @@ class Client:
         headers = dict(self._config.generation_export.headers)
         actor = (self._config.ingest_actor or "").strip()
         if actor:
-            headers["X-Sigil-Ingest-Actor"] = actor
+            headers[_experiments_transport.INGEST_ACTOR_HEADER] = actor
         args: dict[str, Any] = {
             "api_endpoint": self._config.api.endpoint,
             "insecure": bool(self._config.generation_export.insecure),

--- a/python/agento11y/experiments/client.py
+++ b/python/agento11y/experiments/client.py
@@ -27,7 +27,7 @@ from ..redaction import redact_secret_text, redact_secret_value
 from .types import _first_nonblank
 
 TENANT_HEADER = "X-Scope-OrgID"
-INGEST_ACTOR_HEADER = "X-Sigil-Ingest-Actor"
+INGEST_ACTOR_HEADER = _transport.INGEST_ACTOR_HEADER
 
 
 class Client:

--- a/python/agento11y/hooks.py
+++ b/python/agento11y/hooks.py
@@ -19,7 +19,7 @@ from .errors import HookDeniedError, HookTransportError
 from .models import Message, MessageRole, Part, PartKind, ToolDefinition
 
 HOOKS_EVALUATE_PATH = "/api/v1/hooks:evaluate"
-HOOK_TIMEOUT_HEADER = "X-Sigil-Hook-Timeout-Ms"
+HOOK_TIMEOUT_HEADER = "X-Agento11y-Hook-Timeout-Ms"
 DEFAULT_HOOK_TIMEOUT = 15.0
 _MAX_HOOK_RESPONSE_BYTES = 4 << 20
 

--- a/python/tests/test_experiments_transport.py
+++ b/python/tests/test_experiments_transport.py
@@ -494,7 +494,8 @@ def test_experiment_client_uploads_trial_artifact_to_ingest_route() -> None:
         )
         assert request["path"] == expected_path
         assert request["headers"]["authorization"] == _basic("tenant-a", "ingest-token-a")
-        assert request["headers"]["x-sigil-ingest-actor"] == "ingest:sdk/python"
+        assert request["headers"]["x-agento11y-ingest-actor"] == "ingest:sdk/python"
+        assert "x-sigil-ingest-actor" not in request["headers"]
         assert request["raw_payload"] == b'{"ok":true}'
         assert record["artifact_id"] == "art-1"
     finally:
@@ -506,7 +507,8 @@ def test_experiment_client_uses_one_default_actor_for_all_lifecycle_requests() -
     client = ExperimentClient("http://example.test", ingest_token="token")
 
     assert client.actor == "ingest:sdk/python"
-    assert client._headers()["X-Sigil-Ingest-Actor"] == "ingest:sdk/python"  # noqa: SLF001
+    assert client._headers()["X-Agento11y-Ingest-Actor"] == "ingest:sdk/python"  # noqa: SLF001
+    assert "X-Sigil-Ingest-Actor" not in client._headers()  # noqa: SLF001
 
 
 def test_experiment_client_preserves_explicit_actor() -> None:

--- a/python/tests/test_hooks_transport.py
+++ b/python/tests/test_hooks_transport.py
@@ -164,7 +164,8 @@ def test_evaluate_hook_posts_to_hooks_evaluate() -> None:
         assert captured["path"] == "/api/v1/hooks:evaluate"
         headers = captured["headers"]
         assert isinstance(headers, dict)
-        assert headers.get("x-sigil-hook-timeout-ms") == "15000"
+        assert headers.get("x-agento11y-hook-timeout-ms") == "15000"
+        assert "x-sigil-hook-timeout-ms" not in headers
         assert headers.get("x-scope-orgid") == "tenant-a"
         assert headers.get("content-type") == "application/json"
         payload = captured["payload"]


### PR DESCRIPTION
The API now reads `X-Agento11y-*` request headers and keeps the `X-Sigil-*` only as accepted aliases, so the SDKs move to the new names. Two headers are affected:

- `X-Agento11y-Hook-Timeout-Ms` on `POST /api/v1/hooks:evaluate` (Go, Python, JS)
- `X-Agento11y-Ingest-Actor` on experiment ingest and lifecycle requests (Python)