### PR TITLE
feat(python-frameworks/litellm)!: resolve agent_name from LiteLLM's agent_id

### DIFF
--- a/python-frameworks/litellm/README.md
+++ b/python-frameworks/litellm/README.md
@@ -63,7 +63,8 @@ All options are keyword-only on `Agento11yLiteLLMLogger`:
 | `client` | `agento11y.Client` | required | agento11y SDK client instance |
 | `capture_inputs` | `bool` | `True` | Record input messages |
 | `capture_outputs` | `bool` | `True` | Record output messages |
-| `agent_name` | `str` | `""` | Default agent name (see below for per-request) |
+| `agent_name` | `str` | `""` | Fallback agent name, used when the request carries no agent identity (see below for per-request) |
+| `agent_name_metadata_keys` | `Sequence[str]` | `("agent_name", "agent_id")` | Metadata keys consulted, in order, to name the agent |
 | `agent_version` | `str` | `""` | Default agent version (see below for per-request) |
 | `conversation_id` | `str` | `""` | Default conversation ID (see below for per-request) |
 | `extra_tags` | `dict[str, str]` | `None` | Additional tags merged into every generation |
@@ -88,6 +89,31 @@ response = litellm.completion(
 ```
 
 For `conversation_id`, the handler also checks `session_id` and `thread_id` metadata keys as fallbacks.
+
+When no `agent_name` is set, the handler falls back to LiteLLM's own `agent_id`, which the proxy fills in from the `x-litellm-agent-id` header or from an `agent_id` on the calling virtual key. Callers behind a proxy are then attributed to themselves without having to know about agento11y:
+
+```bash
+curl http://localhost:4000/v1/chat/completions \
+  -H 'x-litellm-agent-id: search-agent' \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello!"}]}'
+```
+
+Metadata is read from `litellm_params["metadata"]`, from `litellm_metadata` (used by assistant and thread routes), and from metadata nested one level deeper under `metadata.metadata` (where the Router puts SDK-supplied metadata). Keys are matched in priority order across all of those, so an `agent_name` in any of them beats an `agent_id` in another.
+
+`agent_name_metadata_keys` controls which keys are consulted. Add your own, or LiteLLM's key alias for deployments where one virtual key means one agent:
+
+```python
+from agento11y_litellm import DEFAULT_AGENT_NAME_METADATA_KEYS, Agento11yLiteLLMLogger
+
+handler = Agento11yLiteLLMLogger(
+    client=client,
+    agent_name_metadata_keys=(*DEFAULT_AGENT_NAME_METADATA_KEYS, "user_api_key_alias"),
+    agent_name="litellm-proxy",
+)
+```
+
+A key alias names a credential rather than an agent, so it is not consulted by default: rotating a key would rename the agent, and a shared key would merge unrelated callers. Conversely, pass `("agent_name",)` to ignore LiteLLM's `agent_id` and keep every generation under the static name.
 
 ## LiteLLM Proxy (Docker)
 

--- a/python-frameworks/litellm/agento11y_litellm/__init__.py
+++ b/python-frameworks/litellm/agento11y_litellm/__init__.py
@@ -1,10 +1,11 @@
 """Public exports for agento11y LiteLLM callback handler."""
 
+from collections.abc import Sequence
 from typing import Any
 
 from agento11y import Client
 
-from .handler import Agento11yLiteLLMLogger
+from .handler import DEFAULT_AGENT_NAME_METADATA_KEYS, Agento11yLiteLLMLogger
 
 
 def create_agento11y_litellm_logger(
@@ -13,6 +14,7 @@ def create_agento11y_litellm_logger(
     capture_inputs: bool = True,
     capture_outputs: bool = True,
     agent_name: str = "",
+    agent_name_metadata_keys: Sequence[str] = DEFAULT_AGENT_NAME_METADATA_KEYS,
     agent_version: str = "",
     conversation_id: str = "",
     extra_tags: dict[str, str] | None = None,
@@ -24,6 +26,7 @@ def create_agento11y_litellm_logger(
         capture_inputs=capture_inputs,
         capture_outputs=capture_outputs,
         agent_name=agent_name,
+        agent_name_metadata_keys=agent_name_metadata_keys,
         agent_version=agent_version,
         conversation_id=conversation_id,
         extra_tags=extra_tags,
@@ -32,6 +35,7 @@ def create_agento11y_litellm_logger(
 
 
 __all__ = [
+    "DEFAULT_AGENT_NAME_METADATA_KEYS",
     "Agento11yLiteLLMLogger",
     "create_agento11y_litellm_logger",
 ]

--- a/python-frameworks/litellm/agento11y_litellm/handler.py
+++ b/python-frameworks/litellm/agento11y_litellm/handler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from typing import Any
 
@@ -39,6 +40,14 @@ _CHAT_CALL_TYPES = frozenset(
 )
 
 _EMBEDDING_CALL_TYPES = frozenset({"embedding", "aembedding"})
+
+# Metadata keys consulted, in order, to name the agent behind a request.
+# ``agent_id`` is LiteLLM's own identity field, filled in by the proxy from the
+# ``x-litellm-agent-id`` header or from an ``agent_id`` on the calling virtual
+# key, so callers that know nothing about agento11y are still attributed to
+# themselves rather than to the proxy. Override via ``agent_name_metadata_keys``
+# to consult different keys, or pass ``("agent_name",)`` to opt out.
+DEFAULT_AGENT_NAME_METADATA_KEYS = ("agent_name", "agent_id")
 
 
 def _make_tool_call_part(*, call_id: str, name: str, arguments: str) -> Part:
@@ -362,6 +371,40 @@ def _response_model(response_obj: Any) -> str:
     return getattr(response_obj, "model", "") or ""
 
 
+def _metadata_sources(kwargs: dict[str, Any]) -> list[dict[str, Any]]:
+    """Collect the metadata dicts LiteLLM may attach to a request.
+
+    Chat completions carry client metadata in ``metadata``; assistant and thread
+    routes use ``litellm_metadata``; metadata passed through the Router lands one
+    level deeper, under ``metadata.metadata``.
+    """
+    litellm_params = kwargs.get("litellm_params") or {}
+    sources: list[dict[str, Any]] = []
+    for key in ("metadata", "litellm_metadata"):
+        candidate = litellm_params.get(key)
+        if not isinstance(candidate, dict):
+            continue
+        sources.append(candidate)
+        nested = candidate.get("metadata")
+        if isinstance(nested, dict):
+            sources.append(nested)
+    return sources
+
+
+def _first_metadata_value(sources: list[dict[str, Any]], keys: tuple[str, ...]) -> str:
+    """Return the first non-empty value for ``keys``, in key priority order.
+
+    Keys are the outer loop so that a lower-priority key in the first source
+    never beats a higher-priority key in a later one.
+    """
+    for key in keys:
+        for source in sources:
+            value = source.get(key)
+            if value:
+                return str(value)
+    return ""
+
+
 def _extract_detailed_usage(response_obj: Any, slo: dict[str, Any]) -> TokenUsage:
     """Build TokenUsage with detailed breakdowns from response_obj, basic counts from SLO."""
     usage = TokenUsage(
@@ -399,6 +442,7 @@ class Agento11yLiteLLMLogger(CustomLogger):
         capture_inputs: bool = True,
         capture_outputs: bool = True,
         agent_name: str = "",
+        agent_name_metadata_keys: Sequence[str] = DEFAULT_AGENT_NAME_METADATA_KEYS,
         agent_version: str = "",
         conversation_id: str = "",
         extra_tags: dict[str, str] | None = None,
@@ -410,6 +454,7 @@ class Agento11yLiteLLMLogger(CustomLogger):
         self._capture_inputs = capture_inputs
         self._capture_outputs = capture_outputs
         self._agent_name = agent_name
+        self._agent_name_metadata_keys = tuple(agent_name_metadata_keys)
         self._agent_version = agent_version
         self._conversation_id = conversation_id
         self._extra_tags = dict(extra_tags) if extra_tags else {}
@@ -455,21 +500,12 @@ class Agento11yLiteLLMLogger(CustomLogger):
 
     def _resolve_agent_name(self, kwargs: dict[str, Any]) -> str:
         """Resolve agent_name from per-request metadata, falling back to static."""
-        litellm_params = kwargs.get("litellm_params") or {}
-        metadata = litellm_params.get("metadata") or {}
-        value = metadata.get("agent_name")
-        if value:
-            return str(value)
-        return self._agent_name
+        keys = self._agent_name_metadata_keys
+        return _first_metadata_value(_metadata_sources(kwargs), keys) or self._agent_name
 
     def _resolve_agent_version(self, kwargs: dict[str, Any]) -> str:
         """Resolve agent_version from per-request metadata, falling back to static."""
-        litellm_params = kwargs.get("litellm_params") or {}
-        metadata = litellm_params.get("metadata") or {}
-        value = metadata.get("agent_version")
-        if value:
-            return str(value)
-        return self._agent_version
+        return _first_metadata_value(_metadata_sources(kwargs), ("agent_version",)) or self._agent_version
 
     def _resolve_conversation_id(self, kwargs: dict[str, Any]) -> str:
         """Resolve conversation_id from per-request metadata, falling back to static.
@@ -478,14 +514,14 @@ class Agento11yLiteLLMLogger(CustomLogger):
         then LiteLLM's built-in session tracking fields (litellm_session_id,
         litellm_trace_id) in both metadata and litellm_params.
         """
+        sources = _metadata_sources(kwargs)
+        value = _first_metadata_value(sources, ("conversation_id", "session_id", "thread_id"))
+        if value:
+            return value
+
         litellm_params = kwargs.get("litellm_params") or {}
-        metadata = litellm_params.get("metadata") or {}
-        for key in ("conversation_id", "session_id", "thread_id"):
-            value = metadata.get(key)
-            if value:
-                return str(value)
         for key in ("litellm_session_id", "litellm_trace_id"):
-            value = metadata.get(key) or litellm_params.get(key)
+            value = _first_metadata_value(sources, (key,)) or litellm_params.get(key)
             if value:
                 return str(value)
         return self._conversation_id

--- a/python-frameworks/litellm/example/README.md
+++ b/python-frameworks/litellm/example/README.md
@@ -49,3 +49,50 @@ Open `https://<your-stack>.grafana.net/a/grafana-agento11y-app/conversations`. G
 ## Configuration
 
 `config.yaml` defines the available models. Add more by following the [LiteLLM model list format](https://docs.litellm.ai/docs/proxy/configs).
+
+## Attributing generations to the calling agent
+
+`agento11y_callback.py` names generations after the proxy only when a request
+says nothing about who is calling. Identify the caller in the request body:
+
+```bash
+curlie POST http://<proxy-host>:4000/chat/completions \
+  model=gpt-4o-mini \
+  messages:='[{"role":"user","content":"What is 2+2?"}]' \
+  metadata:='{"agent_name":"search-agent"}'
+```
+
+or with the header LiteLLM already understands, which needs no client-side
+knowledge of agento11y:
+
+```bash
+curlie POST http://<proxy-host>:4000/chat/completions \
+  x-litellm-agent-id:search-agent \
+  model=gpt-4o-mini \
+  messages:='[{"role":"user","content":"What is 2+2?"}]'
+```
+
+## Naming agents after the calling key
+
+`agento11y_callback_agent_from_key_alias.py` covers callers that send no agent
+identity at all: instead of collapsing them into one proxy-wide name, it adds
+the virtual key's alias (then the team's) to `agent_name_metadata_keys`, so each
+key shows up as its own agent.
+
+Only use it when your keys map one-to-one onto agents. A key alias names a
+credential, not an agent, so rotating a key renames the agent and a shared key
+merges unrelated callers.
+
+Point `config.yaml` at it:
+
+```yaml
+litellm_settings:
+  callbacks: agento11y_callback_agent_from_key_alias.agento11y_handler
+```
+
+and mount it alongside `config.yaml` in `docker-compose.yaml`:
+
+```yaml
+    volumes:
+      - ./agento11y_callback_agent_from_key_alias.py:/app/agento11y_callback_agent_from_key_alias.py
+```

--- a/python-frameworks/litellm/example/agento11y_callback_agent_from_key_alias.py
+++ b/python-frameworks/litellm/example/agento11y_callback_agent_from_key_alias.py
@@ -1,0 +1,46 @@
+"""agento11y callback for LiteLLM proxy that names agents after the calling key.
+
+The handler already resolves ``agent_name`` from per-request metadata and from
+LiteLLM's own ``agent_id``, so callers that identify themselves need nothing
+extra. This variant covers the remaining case: callers that send no agent
+identity at all, which would otherwise collapse into one proxy-wide name. It
+appends the virtual key's alias to the keys the handler consults, so each key
+shows up as its own agent.
+
+Only worth it when your keys map one-to-one onto agents. A key alias names a
+credential, not an agent, so rotating a key renames the agent and a shared key
+merges unrelated callers.
+"""
+
+import os
+
+from agento11y import Client
+from agento11y.config import AuthConfig, ClientConfig, GenerationExportConfig
+from agento11y_litellm import DEFAULT_AGENT_NAME_METADATA_KEYS, Agento11yLiteLLMLogger
+
+_endpoint = os.environ["AGENTO11Y_ENDPOINT"]
+
+client = Client(
+    ClientConfig(
+        generation_export=GenerationExportConfig(
+            protocol="http",
+            endpoint=_endpoint,
+            auth=AuthConfig(
+                mode="basic",
+                tenant_id=os.environ.get("AGENTO11Y_AUTH_TENANT_ID", ""),
+                basic_password=os.environ.get("AGENTO11Y_AUTH_TOKEN", ""),
+            ),
+        ),
+    )
+)
+
+agento11y_handler = Agento11yLiteLLMLogger(
+    client=client,
+    agent_name_metadata_keys=(
+        *DEFAULT_AGENT_NAME_METADATA_KEYS,
+        "user_api_key_alias",
+        "user_api_key_team_alias",
+    ),
+    # Used only when a request matches none of the keys above.
+    agent_name="litellm-proxy-integration-test",
+)

--- a/python-frameworks/litellm/example/config.yaml
+++ b/python-frameworks/litellm/example/config.yaml
@@ -9,3 +9,6 @@ model_list:
 
 litellm_settings:
   callbacks: agento11y_callback.agento11y_handler
+  # Swap in this callback instead to name callers that send no agent identity
+  # after their virtual key rather than after the proxy:
+  # callbacks: agento11y_callback_agent_from_key_alias.agento11y_handler

--- a/python-frameworks/litellm/tests/test_litellm_handler.py
+++ b/python-frameworks/litellm/tests/test_litellm_handler.py
@@ -613,6 +613,181 @@ def test_per_request_agent_name_falls_back_to_static() -> None:
         client.shutdown()
 
 
+def test_agent_name_from_litellm_agent_id() -> None:
+    """LiteLLM's own agent_id names the agent when agent_name is absent."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client, agent_name="litellm-proxy")
+        handler.log_success_event(
+            kwargs=_make_kwargs(_base_slo(), agent_id="billing-agent"),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.agent_name == "billing-agent"
+    finally:
+        client.shutdown()
+
+
+def test_agent_name_takes_precedence_over_agent_id() -> None:
+    """Explicit agent_name wins over LiteLLM's agent_id."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        handler.log_success_event(
+            kwargs=_make_kwargs(_base_slo(), agent_name="search-agent", agent_id="key-agent-id"),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.agent_name == "search-agent"
+    finally:
+        client.shutdown()
+
+
+def test_identity_resolved_from_litellm_metadata() -> None:
+    """Assistant/thread routes carry metadata under litellm_metadata."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client, agent_name="litellm-proxy")
+        kwargs: dict[str, Any] = {
+            "standard_logging_object": _base_slo(),
+            "litellm_params": {
+                "litellm_metadata": {
+                    "agent_name": "assistant-agent",
+                    "agent_version": "v7",
+                    "conversation_id": "conv-thread-1",
+                },
+            },
+        }
+        handler.log_success_event(
+            kwargs=kwargs,
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.agent_name == "assistant-agent"
+        assert gen.agent_version == "v7"
+        assert gen.conversation_id == "conv-thread-1"
+    finally:
+        client.shutdown()
+
+
+def test_identity_resolved_from_nested_router_metadata() -> None:
+    """Router-supplied metadata nested under metadata.metadata is read too."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client, agent_name="litellm-proxy")
+        kwargs: dict[str, Any] = {
+            "standard_logging_object": _base_slo(),
+            "litellm_params": {
+                "metadata": {
+                    "agent_id": "key-agent-id",
+                    "metadata": {"agent_name": "search-agent"},
+                },
+            },
+        }
+        handler.log_success_event(
+            kwargs=kwargs,
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.agent_name == "search-agent"
+    finally:
+        client.shutdown()
+
+
+def test_key_alias_is_not_used_as_agent_name_by_default() -> None:
+    """A virtual key alias names a credential, not an agent, so it is ignored."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client, agent_name="litellm-proxy")
+        handler.log_success_event(
+            kwargs=_make_kwargs(_base_slo(), user_api_key_alias="team-key"),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.agent_name == "litellm-proxy"
+    finally:
+        client.shutdown()
+
+
+def test_custom_agent_name_metadata_keys() -> None:
+    """agent_name_metadata_keys opts extra keys in, keeping the configured order."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(
+            client=client,
+            agent_name="litellm-proxy",
+            agent_name_metadata_keys=("agent_name", "agent_id", "user_api_key_alias"),
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(_base_slo(), user_api_key_alias="team-key"),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(_base_slo(), agent_id="billing-agent", user_api_key_alias="team-key"),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        generations = [gen for request in exporter.requests for gen in request.generations]
+        assert [gen.agent_name for gen in generations] == ["team-key", "billing-agent"]
+    finally:
+        client.shutdown()
+
+
+def test_agent_name_metadata_keys_can_opt_out_of_agent_id() -> None:
+    """Passing only agent_name pins generations to the static proxy-wide name."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(
+            client=client,
+            agent_name="litellm-proxy",
+            agent_name_metadata_keys=("agent_name",),
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(_base_slo(), agent_id="key-agent-id"),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.agent_name == "litellm-proxy"
+    finally:
+        client.shutdown()
+
+
 def test_create_agento11y_litellm_logger_factory() -> None:
     """Factory function creates a properly configured logger."""
     exporter = _CapturingExporter()


### PR DESCRIPTION
## Summary

The LiteLLM handler read `agent_name` from exactly one key in exactly one dict (`litellm_params["metadata"]["agent_name"]`). Callers behind a proxy who identify themselves the LiteLLM way — the `x-litellm-agent-id` header, or an `agent_id` on their virtual key — matched nothing and all collapsed into a single proxy-wide agent name.

- `agent_name` now falls back to LiteLLM's own `agent_id`, so callers are attributed to themselves without knowing anything about agento11y.
- All three identity resolvers (`agent_name`, `agent_version`, `conversation_id`) share the same metadata sources: `metadata`, `litellm_metadata` (assistant and thread routes), and the Router's nested `metadata.metadata`. Lookup is key-major, so an `agent_name` in any source beats an `agent_id` in another.
- New `agent_name_metadata_keys` option makes the key list configurable, with `DEFAULT_AGENT_NAME_METADATA_KEYS` exported so callers can extend rather than retype it.
- Adds `example/agento11y_callback_agent_from_key_alias.py`, a drop-in proxy callback for deployments where one virtual key means one agent.

Key aliases are deliberately **not** in the default: an alias names a credential, not an agent, so rotating a key would rename the agent and a shared key would merge unrelated callers. A test pins that exclusion.

## Breaking change

Deployments whose virtual keys carry an `agent_id`, or whose callers send `x-litellm-agent-id`, will see generations attributed to that identity instead of the static `agent_name`. That fragments existing filters and dashboards, and splits the `gen_ai.agent.version` metric join. Pass `agent_name_metadata_keys=("agent_name",)` to keep the previous behavior.

Worth knowing: LiteLLM resolves the key's `agent_id` ahead of the header (`_key_agent_id or _existing_agent_id`), and by callback time the two are indistinguishable, so the ambient key value wins over a deliberate per-request header. That is upstream behavior we cannot see or correct here.

## Test plan

- [x] `mise run test:py:sdk-litellm` — 56 passing, including 7 new tests: `agent_id` fallback, `agent_name` precedence over `agent_id`, resolution from `litellm_metadata` and from nested Router metadata, key aliases excluded by default, custom key lists, and opting out via `("agent_name",)`
- [x] `mise run lint:py`
- [x] Both example callback files smoke-tested against the real handler (explicit name, `agent_id`, alias, team alias, and no-identity fallback all resolve as documented)
- [ ] Sanity-check against a live proxy with a virtual key that carries an `agent_id`

Note: `mise run test:py:sdk-litellm` installs the framework as a non-editable path dependency, and uv can serve a wheel built from pre-edit sources — neither `--reinstall-package` nor `--refresh` busted it, only a fresh `UV_CACHE_DIR`. CI starts cold so it is unaffected, but local runs after editing the package can test stale code.