### PR TITLE
feat(plugins): local viewer UI improvements

### DIFF
--- a/plugins/agento11y/internal/local/events.go
+++ b/plugins/agento11y/internal/local/events.go
@@ -1,0 +1,196 @@
+package local
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// changeEvent is the payload broadcast to SSE subscribers when the local
+// store changes. It carries identifiers only; the client refetches the
+// affected views over the existing JSON APIs. A missed list event
+// self-heals on the next event or the client-side 60s backstop poll;
+// the backstop refreshes only the list, so a missed event for the
+// currently-open detail view only recovers on another targeted event
+// or when the user reopens the conversation.
+type changeEvent struct {
+	ConversationID string `json:"conversation_id,omitempty"`
+	GenerationID   string `json:"generation_id,omitempty"`
+}
+
+// eventSubBuffer caps each subscriber's pending queue. The broadcaster
+// drops on full buffer rather than blocking, so a stalled viewer cannot
+// stall handleGenerations. The client refetches the full conversation
+// list on every event, so a dropped event during a burst self-heals for
+// the list view. The detail view of the dropped event's conversation is
+// only refreshed by the next targeted event or by the user reopening
+// it; the 60s backstop does not cover detail.
+const eventSubBuffer = 32
+
+// defaultEventPingInterval is the heartbeat the SSE handler writes when
+// no real events have arrived. Chosen well under typical proxy idle
+// timeouts (~30-60s) so half-open connections stay alive and a dead
+// daemon is detected. Exposed via s.eventPingInterval so tests can
+// shorten it without changing handler semantics.
+const defaultEventPingInterval = 25 * time.Second
+
+// eventSub is one viewer's subscription to the change stream.
+type eventSub struct {
+	ch chan changeEvent
+}
+
+// eventHub fans out changeEvents to every connected viewer. It is safe
+// for concurrent use; the zero value is not — call newEventHub.
+type eventHub struct {
+	mu     sync.Mutex
+	subs   map[*eventSub]struct{}
+	closed bool
+}
+
+func newEventHub() *eventHub {
+	return &eventHub{subs: make(map[*eventSub]struct{})}
+}
+
+// subscribe registers a new subscriber. Returns nil once closeAll has
+// been called so the caller can short-circuit to "stream closed" instead
+// of holding a connection open against a dead hub.
+func (h *eventHub) subscribe() *eventSub {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return nil
+	}
+	sub := &eventSub{ch: make(chan changeEvent, eventSubBuffer)}
+	h.subs[sub] = struct{}{}
+	return sub
+}
+
+// unsubscribe removes a subscriber and closes its channel. Safe to call
+// after closeAll: the subscriber is no longer registered, so the second
+// close is skipped.
+func (h *eventHub) unsubscribe(sub *eventSub) {
+	if sub == nil {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.subs[sub]; !ok {
+		return
+	}
+	delete(h.subs, sub)
+	close(sub.ch)
+}
+
+// broadcast non-blocking sends ev to every subscriber. A full buffer
+// drops the event for that subscriber. After closeAll the call is a
+// no-op so late ingest events do not panic on a closed channel.
+func (h *eventHub) broadcast(ev changeEvent) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
+	for sub := range h.subs {
+		select {
+		case sub.ch <- ev:
+		default:
+			// Subscriber is behind. The client refetches the full list
+			// on the next event or via the backstop poll, so dropping
+			// here keeps handleGenerations responsive without losing
+			// list correctness.
+		}
+	}
+}
+
+// closeAll closes every subscriber channel and marks the hub closed so
+// subsequent subscribe/broadcast calls are no-ops. Idempotent. Used at
+// shutdown so open SSE handlers return promptly instead of holding the
+// httpSrv.Shutdown deadline.
+func (h *eventHub) closeAll() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
+	h.closed = true
+	for sub := range h.subs {
+		close(sub.ch)
+	}
+	h.subs = nil
+}
+
+// handleEvents streams changeEvent JSON frames over Server-Sent Events.
+// One connection per viewer; the handler returns when the client
+// disconnects (r.Context().Done()) or the hub is closed at shutdown.
+// The browser EventSource auto-reconnects on transport errors, so we do
+// not need to keep a stalled connection alive on the server side.
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	sub := s.hub.subscribe()
+	if sub == nil {
+		// Hub already closed (server shutting down). Reply before
+		// writing the SSE headers so the client treats it as an
+		// ordinary failure and retries when the daemon is back.
+		http.Error(w, "server shutting down", http.StatusServiceUnavailable)
+		return
+	}
+	defer s.hub.unsubscribe(sub)
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	// Tell nginx-style reverse proxies not to buffer the response, or
+	// they hold every frame until the response closes.
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	// Initial comment + flush so the browser marks the stream open and
+	// any proxy that buffers headers sends them through immediately.
+	if _, err := io.WriteString(w, ":\n\n"); err != nil {
+		return
+	}
+	flusher.Flush()
+
+	interval := s.eventPingInterval
+	if interval <= 0 {
+		interval = defaultEventPingInterval
+	}
+	ping := time.NewTicker(interval)
+	defer ping.Stop()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-sub.ch:
+			if !ok {
+				// Hub closed the channel during shutdown.
+				return
+			}
+			data, err := json.Marshal(ev)
+			if err != nil {
+				// A marshal failure here is a developer bug; skip the
+				// frame so the stream stays usable for the next event.
+				continue
+			}
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+				return
+			}
+			flusher.Flush()
+		case <-ping.C:
+			if _, err := io.WriteString(w, ":\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}

--- a/plugins/agento11y/internal/local/events_test.go
+++ b/plugins/agento11y/internal/local/events_test.go
@@ -1,0 +1,435 @@
+package local
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestServer_Events_NotifiesOnGeneration boots the server behind
+// httptest.NewServer (httptest.NewRecorder cannot stream), subscribes
+// to the SSE endpoint, posts a generation, and asserts the broadcast
+// frame carries the expected identifiers.
+func TestServer_Events_NotifiesOnGeneration(t *testing.T) {
+	s, _ := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stream := openEventStream(t, ctx, ts.URL)
+	defer stream.close()
+
+	// Wait for the initial ":\n\n" comment so the subscription is
+	// registered on the server before we trigger a broadcast.
+	require.NoError(t, stream.waitForComment(2*time.Second))
+
+	body := `{"generations":[{"id":"gen-1","conversation_id":"conv-A"}]}`
+	postResp, err := http.Post(ts.URL+"/api/v1/generations:export", "application/json", strings.NewReader(body))
+	require.NoError(t, err)
+	postResp.Body.Close()
+
+	ev, err := stream.nextEvent(2 * time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, "conv-A", ev.ConversationID)
+	assert.Equal(t, "gen-1", ev.GenerationID)
+}
+
+// TestServer_Events_SetsSSEHeaders verifies the response advertises the
+// SSE content type and disables proxy buffering so frames are not held
+// behind reverse proxies.
+func TestServer_Events_SetsSSEHeaders(t *testing.T) {
+	s, _ := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/v1/events", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "no-cache", resp.Header.Get("Cache-Control"))
+	assert.Equal(t, "no", resp.Header.Get("X-Accel-Buffering"))
+}
+
+// TestServer_Events_ClosesOnClientCancel asserts the handler returns
+// when the client disconnects so a dropped browser tab does not leak a
+// goroutine.
+func TestServer_Events_ClosesOnClientCancel(t *testing.T) {
+	s, _ := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stream := openEventStream(t, ctx, ts.URL)
+	require.NoError(t, stream.waitForComment(2*time.Second))
+
+	cancel()
+
+	// The next read should fail (canceled context drains the body).
+	if err := stream.waitForEOF(2 * time.Second); err != nil {
+		t.Fatalf("stream did not close after client cancel: %v", err)
+	}
+	stream.close()
+}
+
+// TestServer_Events_ClosesOnServerClose asserts Server.Close drops open
+// streams so the daemon's shutdown is not blocked by an idle viewer.
+func TestServer_Events_ClosesOnServerClose(t *testing.T) {
+	s, _ := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream := openEventStream(t, ctx, ts.URL)
+	defer stream.close()
+	require.NoError(t, stream.waitForComment(2*time.Second))
+
+	s.Close()
+
+	if err := stream.waitForEOF(2 * time.Second); err != nil {
+		t.Fatalf("stream did not close after Server.Close: %v", err)
+	}
+}
+
+// TestServer_Events_BroadcastsEveryGenerationInBurst posts an export
+// with two generations and asserts both broadcast frames arrive on the
+// stream, so a burst export does not collapse into a single event on
+// the server side.
+func TestServer_Events_BroadcastsEveryGenerationInBurst(t *testing.T) {
+	s, _ := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream := openEventStream(t, ctx, ts.URL)
+	defer stream.close()
+	require.NoError(t, stream.waitForComment(2*time.Second))
+
+	body := `{"generations":[
+		{"id":"gen-1","conversation_id":"conv-A"},
+		{"id":"gen-2","conversation_id":"conv-B"}
+	]}`
+	postResp, err := http.Post(ts.URL+"/api/v1/generations:export", "application/json", strings.NewReader(body))
+	require.NoError(t, err)
+	postResp.Body.Close()
+
+	first, err := stream.nextEvent(2 * time.Second)
+	require.NoError(t, err)
+	second, err := stream.nextEvent(2 * time.Second)
+	require.NoError(t, err)
+
+	got := []changeEvent{first, second}
+	assert.Contains(t, got, changeEvent{ConversationID: "conv-A", GenerationID: "gen-1"})
+	assert.Contains(t, got, changeEvent{ConversationID: "conv-B", GenerationID: "gen-2"})
+}
+
+// TestServer_Events_HeartbeatComment exercises the ping branch of the
+// handler's select. Without this test the heartbeat path is dead code
+// in the suite — it triggers only on idle streams.
+func TestServer_Events_HeartbeatComment(t *testing.T) {
+	s, _ := newTestServer(t)
+	s.eventPingInterval = 50 * time.Millisecond
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream := openEventStream(t, ctx, ts.URL)
+	defer stream.close()
+	require.NoError(t, stream.waitForComment(2*time.Second))
+
+	// A second comment frame must arrive without any broadcast.
+	require.NoError(t, stream.waitForComment(2*time.Second))
+}
+
+// TestEventHub_FanOutDeliversToAllSubscribers asserts a single
+// broadcast reaches every subscriber rather than landing on one
+// subscriber arbitrarily — the multi-viewer story for the daemon.
+func TestEventHub_FanOutDeliversToAllSubscribers(t *testing.T) {
+	hub := newEventHub()
+	sub1 := hub.subscribe()
+	sub2 := hub.subscribe()
+	require.NotNil(t, sub1)
+	require.NotNil(t, sub2)
+
+	hub.broadcast(changeEvent{ConversationID: "conv-X", GenerationID: "gen-X"})
+
+	want := changeEvent{ConversationID: "conv-X", GenerationID: "gen-X"}
+	select {
+	case ev := <-sub1.ch:
+		assert.Equal(t, want, ev)
+	case <-time.After(time.Second):
+		t.Fatal("sub1 did not receive broadcast")
+	}
+	select {
+	case ev := <-sub2.ch:
+		assert.Equal(t, want, ev)
+	case <-time.After(time.Second):
+		t.Fatal("sub2 did not receive broadcast")
+	}
+}
+
+// TestServer_Events_HubClosedReturnsServiceUnavailable verifies that a
+// subscribe attempt after shutdown is rejected with 503 instead of
+// hanging the connection.
+func TestServer_Events_HubClosedReturnsServiceUnavailable(t *testing.T) {
+	s, _ := newTestServer(t)
+	s.Close()
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v1/events")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+// TestEventHub_BroadcastDropsOnFullBuffer exercises the hub directly:
+// fills one subscriber's buffer and asserts broadcast still returns
+// without blocking, and that the overflow event is silently dropped for
+// that subscriber.
+func TestEventHub_BroadcastDropsOnFullBuffer(t *testing.T) {
+	hub := newEventHub()
+	sub := hub.subscribe()
+	require.NotNil(t, sub)
+
+	// Fill the buffer.
+	for range eventSubBuffer {
+		hub.broadcast(changeEvent{GenerationID: "filler"})
+	}
+
+	// Overflow broadcast must not block.
+	done := make(chan struct{})
+	go func() {
+		hub.broadcast(changeEvent{GenerationID: "overflow"})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("broadcast blocked on full subscriber buffer")
+	}
+
+	// Drain and confirm the overflow event was the one dropped: the
+	// queued frames are the original fillers.
+	for range eventSubBuffer {
+		ev := <-sub.ch
+		assert.Equal(t, "filler", ev.GenerationID)
+	}
+	select {
+	case ev := <-sub.ch:
+		t.Fatalf("expected drained channel, got %+v", ev)
+	default:
+	}
+}
+
+// TestEventHub_CloseAllIsIdempotent asserts repeated closeAll calls do
+// not panic on already-closed subscriber channels.
+func TestEventHub_CloseAllIsIdempotent(t *testing.T) {
+	hub := newEventHub()
+	sub := hub.subscribe()
+	require.NotNil(t, sub)
+
+	hub.closeAll()
+	// Subscriber channel must be closed.
+	_, ok := <-sub.ch
+	assert.False(t, ok, "subscriber channel should be closed by closeAll")
+
+	// Second closeAll must be a no-op, not a double-close panic.
+	hub.closeAll()
+
+	// Subscribe after close returns nil so callers do not hold a dead
+	// subscription against the hub.
+	assert.Nil(t, hub.subscribe())
+
+	// Broadcast after close is a no-op (would panic if it tried to send
+	// to a closed channel).
+	hub.broadcast(changeEvent{GenerationID: "after-close"})
+}
+
+// TestEventHub_UnsubscribeAfterCloseAll asserts the late-unsubscribe
+// path (handler running closeAll's cleanup via defer) does not
+// double-close a channel closeAll already closed.
+func TestEventHub_UnsubscribeAfterCloseAll(t *testing.T) {
+	hub := newEventHub()
+	sub := hub.subscribe()
+	require.NotNil(t, sub)
+	hub.closeAll()
+	// Must not panic.
+	hub.unsubscribe(sub)
+}
+
+// TestEventHub_ConcurrentBroadcast is a smoke test for the hub under
+// concurrent broadcasters and subscribers — guards against a future
+// regression that drops the mutex around the subscriber map.
+func TestEventHub_ConcurrentBroadcast(t *testing.T) {
+	hub := newEventHub()
+	const subs = 4
+	const events = 200
+
+	var wg sync.WaitGroup
+	for range subs {
+		sub := hub.subscribe()
+		require.NotNil(t, sub)
+		wg.Go(func() {
+			for range sub.ch {
+				// Drain; we only care that no race or deadlock occurs.
+			}
+		})
+	}
+
+	for range events {
+		hub.broadcast(changeEvent{GenerationID: "x"})
+	}
+	hub.closeAll()
+	wg.Wait()
+}
+
+// eventStream is a tiny SSE reader used in tests. It owns the response
+// and a background goroutine that pumps lines into a channel so tests
+// can wait with explicit deadlines instead of hanging on Read.
+type eventStream struct {
+	resp  *http.Response
+	lines chan readResult
+	close func()
+}
+
+type readResult struct {
+	line string
+	err  error
+}
+
+func openEventStream(t *testing.T, ctx context.Context, baseURL string) *eventStream {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/v1/events", nil)
+	require.NoError(t, err)
+	// The returned eventStream owns resp.Body and closes it via close();
+	// the linter can't follow the indirection.
+	resp, err := http.DefaultClient.Do(req) //nolint:bodyclose
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	lines := make(chan readResult, 32)
+	reader := bufio.NewReader(resp.Body)
+	go func() {
+		defer close(lines)
+		for {
+			l, err := reader.ReadString('\n')
+			if l != "" {
+				lines <- readResult{line: l}
+			}
+			if err != nil {
+				lines <- readResult{err: err}
+				return
+			}
+		}
+	}()
+	return &eventStream{
+		resp:  resp,
+		lines: lines,
+		close: func() { _ = resp.Body.Close() },
+	}
+}
+
+// waitForComment reads until the initial ":\n" SSE comment + blank
+// terminator arrives, signalling the handler is past subscribe(). Used
+// to avoid a race where a test broadcasts before the subscriber is
+// actually registered.
+func (s *eventStream) waitForComment(timeout time.Duration) error {
+	deadline := time.After(timeout)
+	for {
+		select {
+		case res, ok := <-s.lines:
+			if !ok {
+				return io.EOF
+			}
+			if res.err != nil {
+				return res.err
+			}
+			if res.line == ":\n" {
+				// Consume the blank line that terminates the SSE
+				// message so subsequent reads start cleanly.
+				select {
+				case term := <-s.lines:
+					if term.err != nil {
+						return term.err
+					}
+				case <-deadline:
+					return context.DeadlineExceeded
+				}
+				return nil
+			}
+		case <-deadline:
+			return context.DeadlineExceeded
+		}
+	}
+}
+
+// nextEvent reads lines until a "data:" frame terminates with a blank
+// line, then decodes the JSON payload.
+func (s *eventStream) nextEvent(timeout time.Duration) (changeEvent, error) {
+	deadline := time.After(timeout)
+	var payload strings.Builder
+	for {
+		select {
+		case res, ok := <-s.lines:
+			if !ok {
+				return changeEvent{}, io.EOF
+			}
+			if res.err != nil {
+				return changeEvent{}, res.err
+			}
+			switch {
+			case strings.HasPrefix(res.line, "data:"):
+				payload.WriteString(strings.TrimSpace(strings.TrimPrefix(res.line, "data:")))
+			case res.line == "\n":
+				if payload.Len() > 0 {
+					var ev changeEvent
+					if err := json.Unmarshal([]byte(payload.String()), &ev); err != nil {
+						return changeEvent{}, err
+					}
+					return ev, nil
+				}
+			}
+		case <-deadline:
+			return changeEvent{}, context.DeadlineExceeded
+		}
+	}
+}
+
+// waitForEOF drains until the read goroutine reports an error (the
+// connection closed). Used to assert lifecycle teardown.
+func (s *eventStream) waitForEOF(timeout time.Duration) error {
+	deadline := time.After(timeout)
+	for {
+		select {
+		case res, ok := <-s.lines:
+			if !ok {
+				return nil
+			}
+			if res.err != nil {
+				return nil
+			}
+		case <-deadline:
+			return context.DeadlineExceeded
+		}
+	}
+}

--- a/plugins/agento11y/internal/local/manager.go
+++ b/plugins/agento11y/internal/local/manager.go
@@ -275,6 +275,9 @@ func Serve(ctx context.Context, dir string, port int, logger *log.Logger) error 
 	case <-ctx.Done():
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
+		// Close the event hub first so open SSE streams return immediately
+		// instead of holding the shutdown deadline open.
+		srv.Close()
 		_ = httpSrv.Shutdown(shutdownCtx)
 		return nil
 	case err := <-serveErr:

--- a/plugins/agento11y/internal/local/query.go
+++ b/plugins/agento11y/internal/local/query.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -34,6 +35,14 @@ type ConversationSummary struct {
 	// Status is "ok" or "err". "err" means at least one generation in
 	// the conversation recorded a call_error.
 	Status string `json:"status"`
+	// Workspace is the session's working directory (the cwd tag); Branch
+	// is the git.branch tag. The viewer groups and filters the list by
+	// these. Subagents is the number of subagent steps (generations whose
+	// agent_name carries a "parent/child" suffix) — a cheap signal for
+	// flagging orchestration-heavy conversations in the list.
+	Workspace string `json:"workspace,omitempty"`
+	Branch    string `json:"branch,omitempty"`
+	Subagents int    `json:"subagents,omitempty"`
 }
 
 // GenerationView is one step in the conversation thread.
@@ -62,8 +71,32 @@ type GenerationView struct {
 	Output       []agento11y.Message `json:"output,omitempty"`
 	Tools        []string            `json:"tools,omitempty"`
 	ToolPreview  string              `json:"tool_preview,omitempty"`
-	StopReason   string              `json:"stop_reason,omitempty"`
-	CallError    string              `json:"call_error,omitempty"`
+	// Skills is the on-demand skill set this generation loaded. Unlike
+	// Tools (derived from message content) it is read from the
+	// generation's `skills` field. Empty for the common no-skill turn.
+	Skills     []SkillView `json:"skills,omitempty"`
+	StopReason string      `json:"stop_reason,omitempty"`
+	CallError  string      `json:"call_error,omitempty"`
+	// ParentGenerationIDs links this step to the generation(s) that
+	// caused it. A cross-agent edge (parent has a different agent_name)
+	// marks a subagent launch; same-agent edges chain a single agent's
+	// steps. The viewer uses these to build the subagent tree/timeline.
+	ParentGenerationIDs []string `json:"parent_generation_ids,omitempty"`
+	// ThinkingEnabled reports that the model reasoned on this step. Claude
+	// Code transcripts record the flag but not the reasoning text, so the
+	// viewer can note "reasoning used" even when no thinking part exists.
+	ThinkingEnabled bool `json:"thinking_enabled,omitempty"`
+}
+
+// SkillView is one skill a generation loaded, as shown in the viewer.
+// Name is the full invoked string, plugin-qualified for plugin skills
+// (e.g. "workflow-toolkit:code-review"); the client splits the plugin
+// prefix for display.
+type SkillView struct {
+	Name        string `json:"name"`
+	ID          string `json:"id,omitempty"`
+	Description string `json:"description,omitempty"`
+	Version     string `json:"version,omitempty"`
 }
 
 // ConversationDetail is the payload for the detail screen — the
@@ -119,7 +152,7 @@ func summariseConversationFile(path string) (ConversationSummary, bool, error) {
 	var sum ConversationSummary
 	var hasError, seen bool
 
-	err := scanGenerationRecords(path, func(r generationRecord, gen storedGeneration) {
+	err := scanLatestGenerationRecords(path, func(r generationRecord, gen storedGeneration) {
 		seen = true
 		if sum.ID == "" {
 			sum.ID = r.ConversationID
@@ -128,7 +161,7 @@ func summariseConversationFile(path string) (ConversationSummary, bool, error) {
 		usage := gen.Usage.toSDK()
 		sum.InputTokens += usage.InputTokens
 		sum.OutputTokens += usage.OutputTokens
-		sum.TotalTokens += usage.Normalize().TotalTokens
+		sum.TotalTokens += totalTokensForView(usage, gen.Model.Provider)
 		sum.TokenBuckets = sum.TokenBuckets.plus(disjointTokenUsage(usage, gen.Model.Provider))
 
 		if !gen.StartedAt.IsZero() && (sum.StartedAt.IsZero() || gen.StartedAt.Before(sum.StartedAt)) {
@@ -160,6 +193,19 @@ func summariseConversationFile(path string) (ConversationSummary, bool, error) {
 		if gen.CallError != "" {
 			hasError = true
 		}
+		// cwd/branch are per-session and identical across a conversation's
+		// generations; take the first non-empty. A generation whose
+		// agent_name carries a subagent suffix ("claude-code/general-purpose")
+		// is one step of a spawned subagent.
+		if sum.Workspace == "" {
+			sum.Workspace = gen.Tags["cwd"]
+		}
+		if sum.Branch == "" {
+			sum.Branch = gen.Tags["git.branch"]
+		}
+		if strings.Contains(gen.AgentName, "/") {
+			sum.Subagents++
+		}
 	})
 	if err != nil {
 		return ConversationSummary{}, false, err
@@ -185,7 +231,7 @@ func (s *Storage) ConversationDetail(id string) (*ConversationDetail, error) {
 	}
 	path := filepath.Join(s.dir, ConversationsDir, id+".jsonl")
 	out := &ConversationDetail{ID: id}
-	err := scanGenerationRecords(path, func(_ generationRecord, gen storedGeneration) {
+	err := scanLatestGenerationRecords(path, func(_ generationRecord, gen storedGeneration) {
 		if out.Title == "" && gen.title() != "" {
 			out.Title = gen.title()
 		}
@@ -193,26 +239,28 @@ func (s *Storage) ConversationDetail(id string) (*ConversationDetail, error) {
 		input := gen.inputMessages()
 		output := gen.outputMessages()
 		view := GenerationView{
-			GenerationID: gen.ID,
-			AgentName:    gen.AgentName,
-			Model:        gen.modelName(),
-			Provider:     gen.Model.Provider,
-			StartedAt:    gen.StartedAt,
-			CompletedAt:  gen.CompletedAt,
-			InputTokens:  usage.InputTokens,
-			OutputTokens: usage.OutputTokens,
-			TotalTokens:  usage.Normalize().TotalTokens,
-			TokenBuckets: disjointTokenUsage(usage, gen.Model.Provider),
-			Messages:     threadMessages(input, output),
-			Input:        input,
-			Output:       output,
-			StopReason:   gen.StopReason,
-			CallError:    gen.CallError,
+			GenerationID:        gen.ID,
+			AgentName:           gen.AgentName,
+			Model:               gen.modelName(),
+			Provider:            gen.Model.Provider,
+			StartedAt:           gen.StartedAt,
+			CompletedAt:         gen.CompletedAt,
+			InputTokens:         usage.InputTokens,
+			OutputTokens:        usage.OutputTokens,
+			TotalTokens:         totalTokensForView(usage, gen.Model.Provider),
+			TokenBuckets:        disjointTokenUsage(usage, gen.Model.Provider),
+			Input:               input,
+			Output:              output,
+			StopReason:          gen.StopReason,
+			CallError:           gen.CallError,
+			ParentGenerationIDs: gen.ParentGenerationIDs,
+			ThinkingEnabled:     gen.ThinkingEnabled,
 		}
 		if !gen.StartedAt.IsZero() && !gen.CompletedAt.IsZero() {
 			view.DurationSeconds = gen.CompletedAt.Sub(gen.StartedAt).Seconds()
 		}
 		view.Tools, view.ToolPreview = extractTools(output)
+		view.Skills = gen.skillViews()
 		out.Generations = append(out.Generations, view)
 	})
 	if err != nil {
@@ -224,6 +272,16 @@ func (s *Storage) ConversationDetail(id string) (*ConversationDetail, error) {
 	sort.SliceStable(out.Generations, func(i, j int) bool {
 		return out.Generations[i].StartedAt.Before(out.Generations[j].StartedAt)
 	})
+
+	// Each step shows the data of exactly one model call: its own input (the
+	// user prompt, or the tool results the harness fed into THIS request)
+	// followed by its own output. A tool call's result lands in the NEXT
+	// request's input, so it renders on the step that received it — not folded
+	// back into the step that issued the call. That keeps every step's content
+	// and tokens aligned with the single generation it represents.
+	for i := range out.Generations {
+		out.Generations[i].Messages = threadMessages(out.Generations[i].Input, out.Generations[i].Output)
+	}
 	return out, nil
 }
 
@@ -277,7 +335,7 @@ func (s *Storage) TokenUsagePoints() ([]TokenUsagePoint, error) {
 		if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
 			continue
 		}
-		err := scanGenerationRecords(filepath.Join(dir, e.Name()), func(r generationRecord, gen storedGeneration) {
+		err := scanLatestGenerationRecords(filepath.Join(dir, e.Name()), func(r generationRecord, gen storedGeneration) {
 			if p, ok := tokenUsagePoint(r, gen); ok {
 				out = append(out, p)
 			}
@@ -408,88 +466,36 @@ func nonNeg(n int64) int64 {
 	return n
 }
 
-// scanGenerationRecords walks one per-conversation JSONL file calling visit
-// for every decodable record. A missing file is not an error; lines that
-// fail to decode (truncated mid-append, future-schema, …) are skipped.
+// totalTokensForView returns an explicit provider total when present; when
+// older records omit it, it falls back to the provider-aware disjoint buckets
+// so additive cache fields (notably Anthropic) are not silently dropped.
+func totalTokensForView(u agento11y.TokenUsage, provider string) int64 {
+	if u.TotalTokens != 0 {
+		return u.TotalTokens
+	}
+	b := disjointTokenUsage(u, provider)
+	return b.FreshInput + b.CacheRead + b.CacheWrite + b.Output + b.Reasoning
+}
+
+// threadMessages renders one generation's messages in display order: its own
+// input — the user prompt, or the tool results the harness fed into THIS
+// request — followed by its own output (the assistant's text and tool calls).
+// Results are shown on the step that received them (the request after the call
+// that produced them), never folded back into the issuing step, so each step
+// reflects only the data sent to and produced by that single model call.
 func threadMessages(input, output []agento11y.Message) []agento11y.Message {
 	if len(input) == 0 && len(output) == 0 {
 		return nil
 	}
-
-	inputWithoutResults := make([]agento11y.Message, 0, len(input))
-	toolResults := make([]agento11y.Message, 0, len(input))
-	for _, msg := range input {
-		if messageHasToolResult(msg) {
-			toolResults = append(toolResults, msg)
-			continue
-		}
-		inputWithoutResults = append(inputWithoutResults, msg)
-	}
-
-	if len(toolResults) == 0 {
-		messages := make([]agento11y.Message, 0, len(input)+len(output))
-		messages = append(messages, input...)
-		messages = append(messages, output...)
-		return messages
-	}
-
 	messages := make([]agento11y.Message, 0, len(input)+len(output))
-	messages = append(messages, inputWithoutResults...)
-	usedResults := make([]bool, len(toolResults))
-	for _, outputMsg := range output {
-		messages = append(messages, outputMsg)
-		callIDs := toolCallIDs(outputMsg)
-		if len(callIDs) == 0 {
-			continue
-		}
-		for i, resultMsg := range toolResults {
-			if usedResults[i] || !toolResultMatchesAny(resultMsg, callIDs) {
-				continue
-			}
-			messages = append(messages, resultMsg)
-			usedResults[i] = true
-		}
-	}
-	for i, resultMsg := range toolResults {
-		if !usedResults[i] {
-			messages = append(messages, resultMsg)
-		}
-	}
+	messages = append(messages, input...)
+	messages = append(messages, output...)
 	return messages
 }
 
-func messageHasToolResult(msg agento11y.Message) bool {
-	for _, part := range msg.Parts {
-		if part.Kind == agento11y.PartKindToolResult && part.ToolResult != nil {
-			return true
-		}
-	}
-	return false
-}
-
-func toolCallIDs(msg agento11y.Message) map[string]struct{} {
-	ids := map[string]struct{}{}
-	for _, part := range msg.Parts {
-		if part.Kind != agento11y.PartKindToolCall || part.ToolCall == nil || part.ToolCall.ID == "" {
-			continue
-		}
-		ids[part.ToolCall.ID] = struct{}{}
-	}
-	return ids
-}
-
-func toolResultMatchesAny(msg agento11y.Message, ids map[string]struct{}) bool {
-	for _, part := range msg.Parts {
-		if part.Kind != agento11y.PartKindToolResult || part.ToolResult == nil || part.ToolResult.ToolCallID == "" {
-			continue
-		}
-		if _, ok := ids[part.ToolResult.ToolCallID]; ok {
-			return true
-		}
-	}
-	return false
-}
-
+// scanGenerationRecords walks one per-conversation JSONL file calling visit
+// for every decodable record. A missing file is not an error; lines that
+// fail to decode (truncated mid-append, future-schema, …) are skipped.
 func scanGenerationRecords(path string, visit func(generationRecord, storedGeneration)) error {
 	f, err := os.Open(path)
 	if err != nil {
@@ -519,6 +525,41 @@ func scanGenerationRecords(path string, visit func(generationRecord, storedGener
 		visit(rec, gen)
 	}
 	return sc.Err()
+}
+
+type scannedGenerationRecord struct {
+	record generationRecord
+	gen    storedGeneration
+}
+
+func scanLatestGenerationRecords(path string, visit func(generationRecord, storedGeneration)) error {
+	indexByID := map[string]int{}
+	var records []scannedGenerationRecord
+	lineNo := 0
+	err := scanGenerationRecords(path, func(r generationRecord, gen storedGeneration) {
+		lineNo++
+		id := strings.TrimSpace(r.GenerationID)
+		if id == "" {
+			id = strings.TrimSpace(gen.ID)
+		}
+		if id == "" {
+			id = "\x00line:" + strconv.Itoa(lineNo)
+		}
+		scanned := scannedGenerationRecord{record: r, gen: gen}
+		if idx, ok := indexByID[id]; ok {
+			records[idx] = scanned
+			return
+		}
+		indexByID[id] = len(records)
+		records = append(records, scanned)
+	})
+	if err != nil {
+		return err
+	}
+	for _, r := range records {
+		visit(r.record, r.gen)
+	}
+	return nil
 }
 
 // extractTools walks the assistant's output messages and collects the

--- a/plugins/agento11y/internal/local/query_test.go
+++ b/plugins/agento11y/internal/local/query_test.go
@@ -167,6 +167,38 @@ func TestListConversations_Aggregates(t *testing.T) {
 	}
 }
 
+func TestConversationQueriesUseLatestGenerationRecord(t *testing.T) {
+	s := newStorage(t)
+
+	writeGen(t, s, "conv-retry", "g1", agento11y.Generation{
+		AgentName:   "cursor",
+		Model:       agento11y.ModelRef{Provider: "openai", Name: "gpt-5.5"},
+		StartedAt:   mustParse(t, "2026-05-21T10:00:00Z"),
+		CompletedAt: mustParse(t, "2026-05-21T10:00:01Z"),
+		Usage:       agento11y.TokenUsage{},
+	}, "2026-05-21T10:00:01Z")
+	writeGen(t, s, "conv-retry", "g1", agento11y.Generation{
+		AgentName:   "cursor",
+		Model:       agento11y.ModelRef{Provider: "openai", Name: "gpt-5.5"},
+		StartedAt:   mustParse(t, "2026-05-21T10:00:00Z"),
+		CompletedAt: mustParse(t, "2026-05-21T10:00:01Z"),
+		Usage:       agento11y.TokenUsage{InputTokens: 12, OutputTokens: 8, TotalTokens: 20},
+	}, "2026-05-21T10:00:02Z")
+
+	summaries, err := s.ListConversations(0)
+	require.NoError(t, err)
+	require.Len(t, summaries, 1)
+	assert.Equal(t, 1, summaries[0].Calls)
+	assert.Equal(t, int64(20), summaries[0].TotalTokens)
+
+	detail, err := s.ConversationDetail("conv-retry")
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+	require.Len(t, detail.Generations, 1)
+	assert.Equal(t, "g1", detail.Generations[0].GenerationID)
+	assert.Equal(t, int64(20), detail.Generations[0].TotalTokens)
+}
+
 // TestListConversations_LimitAndEmpty covers the limit knob and the
 // empty-store case in one table.
 func TestListConversations_LimitAndEmpty(t *testing.T) {
@@ -203,6 +235,83 @@ func TestListConversations_LimitAndEmpty(t *testing.T) {
 					t.Errorf("got[%d].id = %q, want %q", i, got[i].ID, id)
 				}
 			}
+		})
+	}
+}
+
+func TestListAndDetailUseCacheAwareTotalFallback(t *testing.T) {
+	s := newStorage(t)
+
+	writeGen(t, s, "conv-cache", "g-cache", agento11y.Generation{
+		Model:       agento11y.ModelRef{Provider: "anthropic", Name: "claude-sonnet-4"},
+		StartedAt:   mustParse(t, "2026-05-21T10:00:00Z"),
+		CompletedAt: mustParse(t, "2026-05-21T10:00:02Z"),
+		Usage: agento11y.TokenUsage{
+			InputTokens:           21,
+			OutputTokens:          10077,
+			CacheReadInputTokens:  297770,
+			CacheWriteInputTokens: 57497,
+		},
+	}, "2026-05-21T10:00:02Z")
+
+	summaries, err := s.ListConversations(0)
+	require.NoError(t, err)
+	require.Len(t, summaries, 1)
+	assert.Equal(t, int64(365365), summaries[0].TotalTokens)
+	assert.Equal(t, TokenBuckets{
+		FreshInput: 21,
+		CacheRead:  297770,
+		CacheWrite: 57497,
+		Output:     10077,
+	}, summaries[0].TokenBuckets)
+
+	detail, err := s.ConversationDetail("conv-cache")
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+	require.Len(t, detail.Generations, 1)
+	assert.Equal(t, int64(365365), detail.Generations[0].TotalTokens)
+}
+
+func TestTotalTokensForViewProviderAwareFallback(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider string
+		usage    agento11y.TokenUsage
+		want     int64
+	}{
+		{
+			name:     "explicit total wins",
+			provider: "anthropic",
+			usage:    agento11y.TokenUsage{InputTokens: 1, OutputTokens: 2, TotalTokens: 42, CacheReadInputTokens: 100},
+			want:     42,
+		},
+		{
+			name:     "anthropic cache is additive",
+			provider: "anthropic",
+			usage: agento11y.TokenUsage{
+				InputTokens:           21,
+				OutputTokens:          10077,
+				CacheReadInputTokens:  297770,
+				CacheWriteInputTokens: 57497,
+			},
+			want: 365365,
+		},
+		{
+			name:     "openai cache read is inside input",
+			provider: "openai",
+			usage:    agento11y.TokenUsage{InputTokens: 100, OutputTokens: 50, CacheReadInputTokens: 30, ReasoningTokens: 10},
+			want:     150,
+		},
+		{
+			name:     "gemini reasoning stays additive",
+			provider: "gemini",
+			usage:    agento11y.TokenUsage{InputTokens: 80, OutputTokens: 40, CacheReadInputTokens: 20, ReasoningTokens: 10},
+			want:     130,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, totalTokensForView(tc.usage, tc.provider))
 		})
 	}
 }
@@ -303,10 +412,10 @@ func TestConversationDetail(t *testing.T) {
 	})
 }
 
-// TestConversationDetail_ThreadMessages verifies the display-order thread
-// used by the local viewer. The raw generation split is still preserved in
-// Input/Output, but the viewer should not render tool results before their
-// matching assistant tool calls.
+// TestConversationDetail_ThreadMessages verifies the display-order thread used
+// by the local viewer: each step shows its own input followed by its own
+// output, nothing moved or dropped. A tool result is rendered on the step that
+// received it as input — not folded back into the step that issued the call.
 func TestConversationDetail_ThreadMessages(t *testing.T) {
 	toolInput, _ := json.Marshal(map[string]any{"command": "ls"})
 	toolOutput, _ := json.Marshal([]string{"README.md"})
@@ -322,45 +431,37 @@ func TestConversationDetail_ThreadMessages(t *testing.T) {
 		want []wantMessage
 	}{
 		{
-			name: "tool result follows matching tool call",
+			name: "step shows its input then its output",
 			gen: agento11y.Generation{
 				StartedAt:   mustParse(t, "2026-05-21T10:00:00Z"),
 				CompletedAt: mustParse(t, "2026-05-21T10:00:01Z"),
 				Input: []agento11y.Message{
 					{Role: agento11y.RoleUser, Parts: []agento11y.Part{{Kind: agento11y.PartKindText, Text: "list files"}}},
-					{Role: agento11y.RoleTool, Parts: []agento11y.Part{{Kind: agento11y.PartKindToolResult, ToolResult: &agento11y.ToolResult{ToolCallID: "call-1", Name: "Bash", ContentJSON: toolOutput}}}},
-				},
-				Output: []agento11y.Message{
-					{Role: agento11y.RoleAssistant, Parts: []agento11y.Part{{Kind: agento11y.PartKindToolCall, ToolCall: &agento11y.ToolCall{ID: "call-1", Name: "Bash", InputJSON: toolInput}}}},
-					{Role: agento11y.RoleAssistant, Parts: []agento11y.Part{{Kind: agento11y.PartKindText, Text: "README.md"}}},
-				},
-			},
-			want: []wantMessage{
-				{role: agento11y.RoleUser, partKind: agento11y.PartKindText, text: "list files"},
-				{role: agento11y.RoleAssistant, partKind: agento11y.PartKindToolCall, toolCallID: "call-1"},
-				{role: agento11y.RoleTool, partKind: agento11y.PartKindToolResult, toolCallID: "call-1"},
-				{role: agento11y.RoleAssistant, partKind: agento11y.PartKindText, text: "README.md"},
-			},
-		},
-		{
-			name: "assistant text before tool call stays before tool call",
-			gen: agento11y.Generation{
-				StartedAt:   mustParse(t, "2026-05-21T10:00:00Z"),
-				CompletedAt: mustParse(t, "2026-05-21T10:00:01Z"),
-				Input: []agento11y.Message{
-					{Role: agento11y.RoleUser, Parts: []agento11y.Part{{Kind: agento11y.PartKindText, Text: "list files"}}},
-					{Role: agento11y.RoleTool, Parts: []agento11y.Part{{Kind: agento11y.PartKindToolResult, ToolResult: &agento11y.ToolResult{ToolCallID: "call-1", Name: "Bash", ContentJSON: toolOutput}}}},
 				},
 				Output: []agento11y.Message{
 					{Role: agento11y.RoleAssistant, Parts: []agento11y.Part{{Kind: agento11y.PartKindText, Text: "checking"}}},
 					{Role: agento11y.RoleAssistant, Parts: []agento11y.Part{{Kind: agento11y.PartKindToolCall, ToolCall: &agento11y.ToolCall{ID: "call-1", Name: "Bash", InputJSON: toolInput}}}},
-					{Role: agento11y.RoleAssistant, Parts: []agento11y.Part{{Kind: agento11y.PartKindText, Text: "README.md"}}},
 				},
 			},
 			want: []wantMessage{
 				{role: agento11y.RoleUser, partKind: agento11y.PartKindText, text: "list files"},
 				{role: agento11y.RoleAssistant, partKind: agento11y.PartKindText, text: "checking"},
 				{role: agento11y.RoleAssistant, partKind: agento11y.PartKindToolCall, toolCallID: "call-1"},
+			},
+		},
+		{
+			name: "tool result renders on the step that received it",
+			gen: agento11y.Generation{
+				StartedAt:   mustParse(t, "2026-05-21T10:00:00Z"),
+				CompletedAt: mustParse(t, "2026-05-21T10:00:01Z"),
+				Input: []agento11y.Message{
+					{Role: agento11y.RoleTool, Parts: []agento11y.Part{{Kind: agento11y.PartKindToolResult, ToolResult: &agento11y.ToolResult{ToolCallID: "call-1", Name: "Bash", ContentJSON: toolOutput}}}},
+				},
+				Output: []agento11y.Message{
+					{Role: agento11y.RoleAssistant, Parts: []agento11y.Part{{Kind: agento11y.PartKindText, Text: "README.md"}}},
+				},
+			},
+			want: []wantMessage{
 				{role: agento11y.RoleTool, partKind: agento11y.PartKindToolResult, toolCallID: "call-1"},
 				{role: agento11y.RoleAssistant, partKind: agento11y.PartKindText, text: "README.md"},
 			},
@@ -685,4 +786,134 @@ func TestTokenUsagePoints_EmptyStore(t *testing.T) {
 	points, err := s.TokenUsagePoints()
 	require.NoError(t, err)
 	assert.Empty(t, points)
+}
+
+// TestListConversations_WorkspaceFacets checks that the list summary
+// derives the workspace and branch from the generation's cwd/git.branch
+// tags (first non-empty across the conversation) and counts subagent
+// steps by the "parent/child" agent_name suffix. These back the Sessions
+// view's workspace sidebar and orchestration signal.
+func TestListConversations_WorkspaceFacets(t *testing.T) {
+	s := newStorage(t)
+
+	writeGen(t, s, "conv-A", "g1", agento11y.Generation{
+		AgentName:   "claude-code",
+		Model:       agento11y.ModelRef{Name: "claude-opus-4-7"},
+		StartedAt:   mustParse(t, "2026-05-21T10:00:00Z"),
+		CompletedAt: mustParse(t, "2026-05-21T10:00:01Z"),
+		Usage:       agento11y.TokenUsage{InputTokens: 10, OutputTokens: 5},
+		Tags:        map[string]string{"cwd": "/some/repo", "git.branch": "main"},
+	}, "2026-05-21T10:00:01Z")
+	// A spawned subagent step: agent_name carries a "parent/child" suffix.
+	// cwd is left blank here to prove the first non-empty wins.
+	writeGen(t, s, "conv-A", "g2", agento11y.Generation{
+		AgentName:   "claude-code/general-purpose",
+		Model:       agento11y.ModelRef{Name: "claude-opus-4-7"},
+		StartedAt:   mustParse(t, "2026-05-21T10:00:02Z"),
+		CompletedAt: mustParse(t, "2026-05-21T10:00:03Z"),
+		Usage:       agento11y.TokenUsage{InputTokens: 4, OutputTokens: 2},
+	}, "2026-05-21T10:00:03Z")
+
+	writeGen(t, s, "conv-B", "g3", agento11y.Generation{
+		AgentName:   "pi",
+		Model:       agento11y.ModelRef{Name: "claude-sonnet-4"},
+		StartedAt:   mustParse(t, "2026-05-21T11:00:00Z"),
+		CompletedAt: mustParse(t, "2026-05-21T11:00:01Z"),
+		Usage:       agento11y.TokenUsage{InputTokens: 3, OutputTokens: 1},
+		Tags:        map[string]string{"cwd": "/other/repo"},
+	}, "2026-05-21T11:00:01Z")
+
+	got, err := s.ListConversations(0)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	byID := map[string]ConversationSummary{}
+	for _, c := range got {
+		byID[c.ID] = c
+	}
+
+	a := byID["conv-A"]
+	assert.Equal(t, "/some/repo", a.Workspace)
+	assert.Equal(t, "main", a.Branch)
+	assert.Equal(t, 1, a.Subagents, "one generation carries a parent/child agent_name suffix")
+
+	b := byID["conv-B"]
+	assert.Equal(t, "/other/repo", b.Workspace)
+	assert.Empty(t, b.Branch)
+	assert.Equal(t, 0, b.Subagents)
+}
+
+// TestConversationDetail_SubagentTreeAndThinking checks that the detail
+// view carries the ParentGenerationIDs edges (used to build the subagent
+// tree) and the thinking flag through to each step.
+func TestConversationDetail_SubagentTreeAndThinking(t *testing.T) {
+	s := newStorage(t)
+
+	thinking := true
+	writeGen(t, s, "conv-T", "parent-1", agento11y.Generation{
+		AgentName:       "claude-code",
+		Model:           agento11y.ModelRef{Name: "claude-opus-4-7"},
+		StartedAt:       mustParse(t, "2026-05-21T10:00:00Z"),
+		CompletedAt:     mustParse(t, "2026-05-21T10:00:01Z"),
+		Usage:           agento11y.TokenUsage{InputTokens: 10, OutputTokens: 5},
+		ThinkingEnabled: &thinking,
+	}, "2026-05-21T10:00:01Z")
+	writeGen(t, s, "conv-T", "child-1", agento11y.Generation{
+		AgentName:           "claude-code/general-purpose",
+		Model:               agento11y.ModelRef{Name: "claude-opus-4-7"},
+		StartedAt:           mustParse(t, "2026-05-21T10:00:02Z"),
+		CompletedAt:         mustParse(t, "2026-05-21T10:00:03Z"),
+		Usage:               agento11y.TokenUsage{InputTokens: 4, OutputTokens: 2},
+		ParentGenerationIDs: []string{"parent-1"},
+	}, "2026-05-21T10:00:03Z")
+
+	got, err := s.ConversationDetail("conv-T")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got.Generations, 2)
+
+	byID := map[string]GenerationView{}
+	for _, g := range got.Generations {
+		byID[g.GenerationID] = g
+	}
+
+	parent := byID["parent-1"]
+	assert.True(t, parent.ThinkingEnabled, "parent step reasoned")
+	assert.Empty(t, parent.ParentGenerationIDs)
+
+	child := byID["child-1"]
+	assert.False(t, child.ThinkingEnabled)
+	assert.Equal(t, []string{"parent-1"}, child.ParentGenerationIDs, "child links back to its spawning generation")
+}
+
+// TestConversationDetail_MediaPartsPreserved checks that media message
+// parts (upstream #386878f) survive the store round-trip and come back
+// through the query layer with their kind and ordering intact.
+func TestConversationDetail_MediaPartsPreserved(t *testing.T) {
+	s := newStorage(t)
+
+	writeGen(t, s, "conv-M", "g-media", agento11y.Generation{
+		AgentName:   "pi",
+		Model:       agento11y.ModelRef{Name: "claude-opus-4-7"},
+		StartedAt:   mustParse(t, "2026-05-21T10:00:00Z"),
+		CompletedAt: mustParse(t, "2026-05-21T10:00:01Z"),
+		Usage:       agento11y.TokenUsage{InputTokens: 10, OutputTokens: 5},
+		Input: []agento11y.Message{{Role: agento11y.RoleUser, Parts: []agento11y.Part{
+			{Kind: agento11y.PartKindText, Text: "look at this"},
+			{Kind: agento11y.PartKindMedia, Media: &agento11y.Media{Kind: "image", URL: "https://example.com/a.png", MIMEType: "image/png", Name: "a.png"}},
+		}}},
+	}, "2026-05-21T10:00:01Z")
+
+	got, err := s.ConversationDetail("conv-M")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got.Generations, 1)
+
+	parts := got.Generations[0].Input[0].Parts
+	require.Len(t, parts, 2)
+	assert.Equal(t, agento11y.PartKindText, parts[0].Kind)
+	require.Equal(t, agento11y.PartKindMedia, parts[1].Kind)
+	require.NotNil(t, parts[1].Media)
+	assert.Equal(t, "https://example.com/a.png", parts[1].Media.URL)
+	assert.Equal(t, "image/png", parts[1].Media.MIMEType)
 }

--- a/plugins/agento11y/internal/local/search.go
+++ b/plugins/agento11y/internal/local/search.go
@@ -1,0 +1,288 @@
+package local
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/grafana/agento11y/go/agento11y"
+)
+
+// snippetMaxLen caps the snippet length the search endpoint returns. The
+// viewer clamps to two lines visually, but bounding the bytes keeps the
+// response small even when a generation contains a giant tool result.
+const snippetMaxLen = 320
+
+// snippetWindow is how much text on either side of a match the snippet
+// preserves before truncation. Picked so a typical match still has enough
+// context for "rate limit" to make sense without flooding the row.
+const snippetWindow = 80
+
+// SearchHit is one ranked result for conversation search. The fields mirror
+// what ConversationSummary exposes so the viewer can reuse the existing
+// row idiom (agent/model pills, last_activity, total_tokens, status) and
+// adds search-specific extras: a contextual snippet, the per-conversation
+// match count, and the first matching generation id so a future detail
+// view can deep-link into the matched turn.
+type SearchHit struct {
+	ID           string       `json:"id"`
+	Title        string       `json:"title,omitempty"`
+	Agents       []string     `json:"agents"`
+	Models       []string     `json:"models"`
+	LastActivity time.Time    `json:"last_activity"`
+	TotalTokens  int64        `json:"total_tokens"`
+	Calls        int          `json:"calls"`
+	Status       string       `json:"status"`
+	Snippet      string       `json:"snippet,omitempty"`
+	MatchCount   int          `json:"match_count"`
+	GenerationID string       `json:"generation_id,omitempty"`
+	TokenBuckets TokenBuckets `json:"token_buckets"`
+}
+
+// SearchConversations runs a case-insensitive full-text search across
+// every recorded conversation. The match runs over title, agent and
+// model names, plus every text/thinking part and every tool-call input
+// and tool-result content in every generation. Hits are ranked by total
+// match count, with newer-last-activity as a tiebreak.
+//
+// query is split into whitespace-delimited terms; a hit must contain
+// every term at least once (an AND across terms). An empty or whitespace
+// query returns no hits without error, matching the endpoint contract.
+// limit ≤ 0 means no cap.
+func (s *Storage) SearchConversations(query string, limit int) ([]SearchHit, error) {
+	terms := searchTerms(query)
+	if len(terms) == 0 {
+		return nil, nil
+	}
+	dir := filepath.Join(s.dir, ConversationsDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	out := make([]SearchHit, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
+			continue
+		}
+		hit, ok, err := searchConversationFile(filepath.Join(dir, e.Name()), terms)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		out = append(out, hit)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].MatchCount != out[j].MatchCount {
+			return out[i].MatchCount > out[j].MatchCount
+		}
+		// Tiebreak by newest last_activity.
+		return out[i].LastActivity.After(out[j].LastActivity)
+	})
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// searchTerms splits the user query into lower-cased terms. Whitespace is
+// the only delimiter; punctuation stays in a term so a literal phrase
+// like "panic:" still matches itself. Duplicate terms are dropped so a
+// query like "limit limit" doesn't inflate the match count.
+func searchTerms(query string) []string {
+	terms := strings.Fields(strings.ToLower(strings.TrimSpace(query)))
+	if len(terms) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(terms))
+	out := make([]string, 0, len(terms))
+	for _, t := range terms {
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	return out
+}
+
+// searchConversationFile scans one conversation JSONL file, aggregating
+// the same summary fields ListConversations produces while counting
+// matches against the search terms. The first text fragment that
+// contains a term is captured for the snippet; the first generation
+// containing any term is captured for the matched generation id.
+//
+// Returns (_, false, nil) when the file has no decodable records OR
+// when at least one term does not appear anywhere in the conversation
+// (so the result satisfies the AND semantics across terms).
+func searchConversationFile(path string, terms []string) (SearchHit, bool, error) {
+	hit := SearchHit{}
+	agents := map[string]struct{}{}
+	models := map[string]struct{}{}
+	termHits := make(map[string]int, len(terms))
+	var snippet string
+	var snippetGenID string
+	var seen, hasError bool
+	var lastActivity time.Time
+
+	err := scanLatestGenerationRecords(path, func(r generationRecord, gen storedGeneration) {
+		seen = true
+		if hit.ID == "" {
+			hit.ID = r.ConversationID
+		}
+		hit.Calls++
+		usage := gen.Usage.toSDK()
+		hit.TotalTokens += totalTokensForView(usage, gen.Model.Provider)
+		hit.TokenBuckets = hit.TokenBuckets.plus(disjointTokenUsage(usage, gen.Model.Provider))
+
+		if gen.AgentName != "" {
+			agents[gen.AgentName] = struct{}{}
+		}
+		if name := gen.modelName(); name != "" {
+			models[name] = struct{}{}
+		}
+		if hit.Title == "" && gen.title() != "" {
+			hit.Title = gen.title()
+		}
+		if gen.CallError != "" {
+			hasError = true
+		}
+
+		// last_activity tracks the latest known timestamp on any
+		// generation, falling back to received_at when started/completed
+		// aren't populated — same rule as summariseConversationFile.
+		when := gen.CompletedAt
+		if when.IsZero() {
+			when = gen.StartedAt
+		}
+		if when.IsZero() {
+			when, _ = time.Parse(time.RFC3339Nano, r.ReceivedAt)
+		}
+		if when.After(lastActivity) {
+			lastActivity = when
+		}
+
+		// Walk every searchable piece of text in this generation. Each
+		// occurrence of a term contributes one match; the first hit per
+		// conversation also seeds the snippet and the matched generation
+		// id (for deep-linking into the matched turn in a future view).
+		visit := func(text string) {
+			if text == "" {
+				return
+			}
+			lower := strings.ToLower(text)
+			for _, term := range terms {
+				if term == "" {
+					continue
+				}
+				count := strings.Count(lower, term)
+				if count == 0 {
+					continue
+				}
+				termHits[term] += count
+				hit.MatchCount += count
+				if snippet == "" {
+					snippet = buildSnippet(text, lower, term)
+					snippetGenID = gen.ID
+				}
+			}
+		}
+
+		// Always include the cheap fields so a search on the agent or
+		// model name surfaces sessions that never wrote matching content.
+		visit(gen.AgentName)
+		visit(gen.modelName())
+		visit(gen.title())
+
+		for _, msg := range gen.inputMessages() {
+			visitMessageParts(msg, visit)
+		}
+		for _, msg := range gen.outputMessages() {
+			visitMessageParts(msg, visit)
+		}
+	})
+	if err != nil {
+		return SearchHit{}, false, err
+	}
+	if !seen {
+		return SearchHit{}, false, nil
+	}
+	// AND across terms: every term must have contributed at least once.
+	for _, term := range terms {
+		if termHits[term] == 0 {
+			return SearchHit{}, false, nil
+		}
+	}
+	hit.Agents = sortedKeys(agents)
+	hit.Models = sortedKeys(models)
+	hit.LastActivity = lastActivity
+	hit.Status = "ok"
+	if hasError {
+		hit.Status = "err"
+	}
+	hit.Snippet = snippet
+	hit.GenerationID = snippetGenID
+	return hit, true, nil
+}
+
+// visitMessageParts walks one message's parts and feeds every searchable
+// string fragment into visit. Tool-call inputs and tool-result JSON
+// bodies are passed through as raw JSON so a search for a key or value
+// inside an arguments blob still matches.
+func visitMessageParts(msg agento11y.Message, visit func(string)) {
+	for _, p := range msg.Parts {
+		switch p.Kind {
+		case agento11y.PartKindText:
+			visit(p.Text)
+		case agento11y.PartKindThinking:
+			visit(p.Thinking)
+		case agento11y.PartKindToolCall:
+			if p.ToolCall != nil {
+				visit(p.ToolCall.Name)
+				if len(p.ToolCall.InputJSON) > 0 {
+					visit(string(p.ToolCall.InputJSON))
+				}
+			}
+		case agento11y.PartKindToolResult:
+			if p.ToolResult != nil {
+				visit(p.ToolResult.Name)
+				visit(p.ToolResult.Content)
+				if len(p.ToolResult.ContentJSON) > 0 {
+					visit(string(p.ToolResult.ContentJSON))
+				}
+			}
+		default:
+			// Media parts carry no searchable prose.
+		}
+	}
+}
+
+// buildSnippet returns a short region of text containing the first match
+// of term in textLower. The snippet preserves surrounding context up to
+// snippetWindow runes on each side and is then UTF-8-safely truncated to
+// snippetMaxLen so the JSON payload stays bounded. text carries the
+// original casing; textLower must be the lower-cased copy used for the
+// match (so indices line up).
+func buildSnippet(text, textLower, term string) string {
+	idx := strings.Index(textLower, term)
+	if idx < 0 {
+		return truncate(strings.TrimSpace(text), snippetMaxLen)
+	}
+	start := max(idx-snippetWindow, 0)
+	// Slide start to a rune boundary so we never emit a half rune.
+	for start > 0 && (text[start]&0xC0) == 0x80 {
+		start--
+	}
+	end := min(idx+len(term)+snippetWindow, len(text))
+	frag := strings.TrimSpace(text[start:end])
+	if start > 0 {
+		frag = "…" + frag
+	}
+	return truncate(frag, snippetMaxLen)
+}

--- a/plugins/agento11y/internal/local/search_test.go
+++ b/plugins/agento11y/internal/local/search_test.go
@@ -1,0 +1,249 @@
+package local
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/grafana/agento11y/go/agento11y"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeGenWithMessages writes a generation with the given input and
+// output messages. The helper exists so tests can drop arbitrary text
+// and tool I/O into a generation without rebuilding the proto wire
+// shape by hand on every call.
+func writeGenWithMessages(t *testing.T, s *Storage, convID, genID string, input, output []agento11y.Message, receivedAt string) {
+	t.Helper()
+	gen := agento11y.Generation{
+		ID:             genID,
+		ConversationID: convID,
+		AgentName:      "pi",
+		Model:          agento11y.ModelRef{Provider: "anthropic", Name: "claude-opus-4-7"},
+		Input:          input,
+		Output:         output,
+		StartedAt:      mustParse(t, receivedAt),
+		CompletedAt:    mustParse(t, receivedAt),
+	}
+	writeGen(t, s, convID, genID, gen, receivedAt)
+}
+
+func textMsg(role agento11y.Role, body string) agento11y.Message {
+	return agento11y.Message{Role: role, Parts: []agento11y.Part{{Kind: agento11y.PartKindText, Text: body}}}
+}
+
+func toolCallMsg(name, input string) agento11y.Message {
+	return agento11y.Message{
+		Role: agento11y.RoleAssistant,
+		Parts: []agento11y.Part{{
+			Kind:     agento11y.PartKindToolCall,
+			ToolCall: &agento11y.ToolCall{ID: "tc-1", Name: name, InputJSON: json.RawMessage(input)},
+		}},
+	}
+}
+
+func toolResultMsg(name, content string) agento11y.Message {
+	return agento11y.Message{
+		Role: agento11y.RoleTool,
+		Parts: []agento11y.Part{{
+			Kind:       agento11y.PartKindToolResult,
+			ToolResult: &agento11y.ToolResult{ToolCallID: "tc-1", Name: name, Content: content},
+		}},
+	}
+}
+
+// TestSearchConversations covers the headline behaviours the design
+// handoff and the spec require: matching text/thinking/tool I/O,
+// ranking by total match count, newest-first tiebreak, the AND across
+// terms, case-insensitivity, and empty-query short-circuit.
+func TestSearchConversations(t *testing.T) {
+	s := newStorage(t)
+
+	// conv-A: one tool result mentioning "rate limit", one prompt
+	// repeating "rate".
+	writeGenWithMessages(t, s, "conv-A", "g1",
+		[]agento11y.Message{textMsg(agento11y.RoleUser, "Hit the rate limit on the gateway.")},
+		[]agento11y.Message{
+			toolCallMsg("bash", `{"command":"curl https://api"}`),
+			textMsg(agento11y.RoleAssistant, "rate limit means we should back off."),
+		},
+		"2026-05-21T10:00:00Z")
+	writeGenWithMessages(t, s, "conv-A", "g2",
+		nil,
+		[]agento11y.Message{toolResultMsg("bash", "HTTP/1.1 429 rate limit exceeded")},
+		"2026-05-21T10:00:05Z")
+
+	// conv-B: a single mention of "rate" (no "limit").
+	writeGenWithMessages(t, s, "conv-B", "g3",
+		[]agento11y.Message{textMsg(agento11y.RoleUser, "What is your rate of throughput?")},
+		[]agento11y.Message{textMsg(agento11y.RoleAssistant, "Depends on the model.")},
+		"2026-05-21T11:00:00Z")
+
+	// conv-C: newest, mentions "rate limit" once. Used to assert the
+	// last_activity tiebreak when match counts tie.
+	writeGenWithMessages(t, s, "conv-C", "g4",
+		nil,
+		[]agento11y.Message{textMsg(agento11y.RoleAssistant, "I think the rate limit was reset.")},
+		"2026-05-21T12:00:00Z")
+
+	t.Run("ranks by total match count then newest", func(t *testing.T) {
+		hits, err := s.SearchConversations("rate limit", 0)
+		require.NoError(t, err)
+		require.Len(t, hits, 2, "conv-B mentions only one of the two terms; AND filter drops it")
+
+		// conv-A has 4 matches (2 "rate" + 2 "limit"); conv-C has 2.
+		assert.Equal(t, "conv-A", hits[0].ID)
+		assert.Equal(t, "conv-C", hits[1].ID)
+		assert.Greater(t, hits[0].MatchCount, hits[1].MatchCount)
+		assert.NotEmpty(t, hits[0].Snippet)
+		assert.Equal(t, "g1", hits[0].GenerationID, "snippet should point at the first matching turn")
+	})
+
+	t.Run("tiebreak prefers newest last_activity", func(t *testing.T) {
+		// Both conversations match "limit" exactly once, so the tie
+		// is broken by last_activity.
+		hits, err := s.SearchConversations("limit", 0)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, len(hits), 2)
+		// conv-C (12:00) is newer than conv-A (10:00:05) but conv-A
+		// has more matches; assert conv-C precedes any equally-ranked
+		// older hit.
+		for i := 1; i < len(hits); i++ {
+			if hits[i-1].MatchCount == hits[i].MatchCount {
+				assert.False(t, hits[i-1].LastActivity.Before(hits[i].LastActivity),
+					"hit %d (%s) should not be older than hit %d (%s)",
+					i-1, hits[i-1].LastActivity, i, hits[i].LastActivity)
+			}
+		}
+	})
+
+	t.Run("case-insensitive substring matches", func(t *testing.T) {
+		hits, err := s.SearchConversations("RATE", 0)
+		require.NoError(t, err)
+		assert.NotEmpty(t, hits)
+	})
+
+	t.Run("matches inside tool-call input JSON", func(t *testing.T) {
+		hits, err := s.SearchConversations("curl", 0)
+		require.NoError(t, err)
+		require.Len(t, hits, 1)
+		assert.Equal(t, "conv-A", hits[0].ID)
+	})
+
+	t.Run("no match returns empty hits, not error", func(t *testing.T) {
+		hits, err := s.SearchConversations("absolutely-not-in-any-conversation-xyz", 0)
+		require.NoError(t, err)
+		assert.Empty(t, hits)
+	})
+
+	t.Run("empty query returns no hits and no error", func(t *testing.T) {
+		hits, err := s.SearchConversations("", 0)
+		require.NoError(t, err)
+		assert.Empty(t, hits)
+
+		hits, err = s.SearchConversations("    ", 0)
+		require.NoError(t, err)
+		assert.Empty(t, hits)
+	})
+
+	t.Run("limit caps the result count", func(t *testing.T) {
+		hits, err := s.SearchConversations("rate", 1)
+		require.NoError(t, err)
+		assert.Len(t, hits, 1)
+	})
+
+	t.Run("hit carries the summary fields the UI needs", func(t *testing.T) {
+		hits, err := s.SearchConversations("rate", 0)
+		require.NoError(t, err)
+		require.NotEmpty(t, hits)
+		hit := hits[0]
+		assert.False(t, hit.LastActivity.IsZero())
+		assert.NotEmpty(t, hit.Agents)
+		assert.NotEmpty(t, hit.Models)
+		assert.Greater(t, hit.Calls, 0)
+		assert.Equal(t, "ok", hit.Status)
+	})
+}
+
+// TestSearchLastActivityReceivedAtFallback pins the ordering when a
+// generation has no started/completed time and last_activity has to come
+// from received_at. Sub-second precision differs between the two sources,
+// so the comparison has to happen on parsed times, not on the strings.
+func TestSearchLastActivityReceivedAtFallback(t *testing.T) {
+	// bareGen writes a generation carrying text but no started/completed
+	// time, so the aggregator falls back to received_at.
+	bareGen := func(t *testing.T, s *Storage, convID, genID, body, receivedAt string) {
+		t.Helper()
+		writeGen(t, s, convID, genID, agento11y.Generation{
+			AgentName: "pi",
+			Model:     agento11y.ModelRef{Provider: "anthropic", Name: "claude-opus-4-7"},
+			Output:    []agento11y.Message{textMsg(agento11y.RoleAssistant, body)},
+		}, receivedAt)
+	}
+
+	t.Run("picks the newest generation within a conversation", func(t *testing.T) {
+		s := newStorage(t)
+		writeGenWithMessages(t, s, "conv-D", "g1", nil,
+			[]agento11y.Message{textMsg(agento11y.RoleAssistant, "quotacrunch alpha")},
+			"2026-05-21T13:00:05.5Z")
+		bareGen(t, s, "conv-D", "g2", "quotacrunch beta", "2026-05-21T13:00:05Z")
+
+		hits, err := s.SearchConversations("quotacrunch", 0)
+		require.NoError(t, err)
+		require.Len(t, hits, 1)
+		assert.True(t, hits[0].LastActivity.Equal(mustParse(t, "2026-05-21T13:00:05.5Z")),
+			"last_activity = %v, want g1's completed_at (the later time)", hits[0].LastActivity)
+	})
+
+	t.Run("tiebreak compares across timestamp sources", func(t *testing.T) {
+		s := newStorage(t)
+		bareGen(t, s, "conv-E", "g1", "quotacrunch once", "2026-05-21T13:00:05Z")
+		writeGenWithMessages(t, s, "conv-F", "g2", nil,
+			[]agento11y.Message{textMsg(agento11y.RoleAssistant, "quotacrunch once")},
+			"2026-05-21T13:00:05.5Z")
+
+		hits, err := s.SearchConversations("quotacrunch", 0)
+		require.NoError(t, err)
+		require.Len(t, hits, 2)
+		assert.Equal(t, hits[0].MatchCount, hits[1].MatchCount, "both hits should tie on match count")
+		assert.Equal(t, "conv-F", hits[0].ID, "newer conversation ranks first")
+	})
+}
+
+// TestSearchTerms checks the query tokenizer: case folding, whitespace
+// splitting, and dedup so a query like "limit limit" still scores as one
+// occurrence per match rather than doubling the score.
+func TestSearchTerms(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"whitespace only", "   ", nil},
+		{"single term", "rate", []string{"rate"}},
+		{"lower-cases input", "RATE", []string{"rate"}},
+		{"splits on whitespace", "rate  limit ", []string{"rate", "limit"}},
+		{"dedups repeated terms", "rate rate limit", []string{"rate", "limit"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, searchTerms(tc.in))
+		})
+	}
+}
+
+// TestBuildSnippet asserts the snippet preserves casing, surrounds the
+// match with context, and stays bounded under the byte cap.
+func TestBuildSnippet(t *testing.T) {
+	body := "Hit the rate limit on the gateway in production."
+	got := buildSnippet(body, "hit the rate limit on the gateway in production.", "rate")
+	assert.Contains(t, got, "rate", "snippet should contain the matched term with original casing")
+	assert.LessOrEqual(t, len(got), snippetMaxLen+4, "snippet stays bounded with room for the ellipsis")
+
+	// Big input should not blow the byte cap.
+	huge := strings.Repeat("x", 10_000) + " needle " + strings.Repeat("y", 10_000)
+	got = buildSnippet(huge, huge, "needle")
+	assert.LessOrEqual(t, len(got), snippetMaxLen+4)
+	assert.Contains(t, got, "needle")
+}

--- a/plugins/agento11y/internal/local/server.go
+++ b/plugins/agento11y/internal/local/server.go
@@ -5,10 +5,13 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
 	"github.com/grafana/agento11y/plugins/agento11y/internal/dotenv"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
 
 // Maximum body sizes accepted by the receiver. These guard against
@@ -28,6 +31,10 @@ type Server struct {
 	now        func() time.Time
 	configPath string
 	mux        *http.ServeMux
+	hub        *eventHub
+	// eventPingInterval overrides defaultEventPingInterval for tests; zero
+	// uses the default.
+	eventPingInterval time.Duration
 }
 
 // NewServer builds a Server backed by the given storage. logger may be
@@ -44,9 +51,17 @@ func NewServer(storage *Storage, logger *log.Logger, configPath string) *Server 
 		logger:     logger,
 		configPath: configPath,
 		now:        func() time.Time { return time.Now().UTC() },
+		hub:        newEventHub(),
 	}
 	s.mux = s.routes()
 	return s
+}
+
+// Close releases server resources. It closes the event hub so open SSE
+// connections return promptly instead of holding the HTTP shutdown
+// deadline. Safe to call more than once.
+func (s *Server) Close() {
+	s.hub.closeAll()
 }
 
 func (s *Server) routes() *http.ServeMux {
@@ -60,6 +75,9 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /assets/app.jsx", s.handleAppJSX)
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
 	mux.HandleFunc("GET /api/v1/conversations", s.handleListConversations)
+	mux.HandleFunc("GET /api/v1/search", s.handleSearch)
+	mux.HandleFunc("GET /api/v1/search/capabilities", s.handleSearchCapabilities)
+	mux.HandleFunc("GET /api/v1/events", s.handleEvents)
 	mux.HandleFunc("GET /api/v1/metrics/tokens", s.handleTokenMetrics)
 	mux.HandleFunc("GET /api/v1/config", s.handleGetConfig)
 	mux.HandleFunc("POST /api/v1/config:preview", s.handlePreviewConfig)
@@ -83,22 +101,38 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.mux.ServeHTTP(w, r)
 }
 
+// devAsset returns the on-disk copy of a web asset when the
+// AGENTO11Y_LOCAL_WEB_DIR (or legacy SIGIL_LOCAL_WEB_DIR) variable points
+// at the web/ source dir, so the frontend can be iterated on with a
+// browser reload instead of a Go rebuild. Unset returns the embedded copy.
+// Dev-only convenience — no caching, no file watching.
+func devAsset(name string, embedded []byte) []byte {
+	dir, _, ok := envconfig.LookupEnv("LOCAL_WEB_DIR")
+	if !ok {
+		return embedded
+	}
+	if b, err := os.ReadFile(filepath.Join(dir, name)); err == nil {
+		return b
+	}
+	return embedded
+}
+
 func (s *Server) handleIndex(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache")
-	_, _ = w.Write(indexHTML)
+	_, _ = w.Write(devAsset("index.html", indexHTML))
 }
 
 func (s *Server) handleAppCSS(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/css; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache")
-	_, _ = w.Write(appCSS)
+	_, _ = w.Write(devAsset("app.css", appCSS))
 }
 
 func (s *Server) handleAppJSX(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/babel; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache")
-	_, _ = w.Write(appJSX)
+	_, _ = w.Write(devAsset("app.jsx", appJSX))
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
@@ -175,6 +209,14 @@ func (s *Server) handleGenerations(w http.ResponseWriter, r *http.Request) {
 		resp.Results = append(resp.Results, generationResult{
 			GenerationID: gen.ID,
 			Accepted:     true,
+		})
+		// Notify connected viewers so the list (and any open matching
+		// conversation) refreshes without waiting for the backstop poll.
+		// Broadcast is non-blocking; a stalled subscriber cannot stall
+		// ingest.
+		s.hub.broadcast(changeEvent{
+			ConversationID: gen.ConversationID,
+			GenerationID:   gen.ID,
 		})
 	}
 	s.writeJSON(w, http.StatusOK, resp)
@@ -342,6 +384,63 @@ func (s *Server) handleListConversations(w http.ResponseWriter, r *http.Request)
 		convs = []ConversationSummary{}
 	}
 	s.writeJSON(w, http.StatusOK, map[string]any{"conversations": convs})
+}
+
+// searchResultLimit caps the number of hits the search endpoint returns
+// when the client does not pass a limit. The cap exists to bound the
+// response body on stores with thousands of conversations; the viewer
+// renders the full list it receives.
+const searchResultLimit = 100
+
+// handleSearch runs a full-text search across every recorded conversation
+// and returns the hits as JSON. Empty/whitespace queries are not an
+// error; they yield {"hits":[],"mode":"fts"} so the client can treat "no
+// query" the same as "no results" without a special case.
+//
+// The response carries mode ("fts") so the viewer can show a faint
+// backend hint. Semantic search is not wired up in this build, so the
+// mode is always "fts".
+func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("q")
+	limit := searchResultLimit
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	hits, err := s.storage.SearchConversations(q, limit)
+	if err != nil {
+		s.logger.Printf("local: search: %v", err)
+		http.Error(w, "search: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if hits == nil {
+		hits = []SearchHit{}
+	}
+	s.writeJSON(w, http.StatusOK, map[string]any{"hits": hits, "mode": "fts"})
+}
+
+// SearchCapabilities is the JSON shape /api/v1/search/capabilities
+// returns: whether full-text search is available (always true here),
+// whether semantic search is available (not in this build), and a short
+// status string the UI can show. The search endpoint always uses FTS.
+type SearchCapabilities struct {
+	FullText   bool   `json:"fts"`
+	Semantic   bool   `json:"semantic"`
+	IndexState string `json:"indexState"`
+	Status     string `json:"status"`
+}
+
+// handleSearchCapabilities reports the search backends available to the
+// viewer. Full-text search is always available; semantic search is not
+// wired up in this build, so it is reported unavailable.
+func (s *Server) handleSearchCapabilities(w http.ResponseWriter, _ *http.Request) {
+	s.writeJSON(w, http.StatusOK, SearchCapabilities{
+		FullText:   true,
+		Semantic:   false,
+		IndexState: "unavailable",
+		Status:     "Full-text search only",
+	})
 }
 
 // handleTokenMetrics returns one token-usage point per recorded

--- a/plugins/agento11y/internal/local/server_test.go
+++ b/plugins/agento11y/internal/local/server_test.go
@@ -659,3 +659,124 @@ func TestServer_Config_RejectsBadBody(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	resp.Body.Close()
 }
+
+// TestServer_APISearch covers the /api/v1/search endpoint: empty query,
+// ranked hits with the design shape, unknown query, and the default
+// limit. Semantic search is not wired up, so the mode is always "fts".
+func TestServer_APISearch(t *testing.T) {
+	srv, dir := newTestServer(t)
+	storage, err := NewStorage(dir)
+	require.NoError(t, err)
+
+	writeGenWithMessages(t, storage, "conv-A", "g1",
+		[]agento11y.Message{textMsg(agento11y.RoleUser, "hit the rate limit")},
+		[]agento11y.Message{textMsg(agento11y.RoleAssistant, "backoff once the rate limit clears")},
+		"2026-05-21T10:00:00Z")
+	writeGenWithMessages(t, storage, "conv-B", "g2",
+		nil,
+		[]agento11y.Message{textMsg(agento11y.RoleAssistant, "nothing useful here")},
+		"2026-05-21T11:00:00Z")
+
+	t.Run("empty query returns empty hits with fts mode", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=", nil)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+		var body struct {
+			Hits []SearchHit `json:"hits"`
+			Mode string      `json:"mode"`
+		}
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+		assert.Empty(t, body.Hits)
+		assert.Equal(t, "fts", body.Mode)
+	})
+
+	t.Run("populated store returns ranked hits with the design shape", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=rate+limit", nil)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+		var body struct {
+			Hits []SearchHit `json:"hits"`
+			Mode string      `json:"mode"`
+		}
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+		assert.Equal(t, "fts", body.Mode)
+		require.Len(t, body.Hits, 1, "only conv-A contains both terms")
+		hit := body.Hits[0]
+		assert.Equal(t, "conv-A", hit.ID)
+		assert.Greater(t, hit.MatchCount, 0)
+		assert.NotEmpty(t, hit.Snippet)
+		assert.Contains(t, strings.ToLower(hit.Snippet), "limit")
+		assert.Equal(t, "g1", hit.GenerationID)
+		assert.NotEmpty(t, hit.LastActivity)
+	})
+
+	t.Run("unknown query returns empty hits, not error", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=zzz-impossible", nil)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), `"hits":[]`)
+	})
+
+	t.Run("limit=0 falls back to the default cap", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=rate&limit=0", nil)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+		var body struct {
+			Hits []SearchHit `json:"hits"`
+		}
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+		assert.NotEmpty(t, body.Hits)
+	})
+}
+
+// TestServer_APISearchCapabilities checks that the capabilities endpoint
+// reports full-text search available and semantic search unavailable in
+// this build.
+func TestServer_APISearchCapabilities(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search/capabilities", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var caps SearchCapabilities
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &caps))
+	assert.True(t, caps.FullText, "full-text search is available")
+	assert.False(t, caps.Semantic, "semantic search is not wired up in this build")
+}
+
+// TestServer_DevAsset_EnvPrecedence checks that the preferred
+// AGENTO11Y_LOCAL_WEB_DIR wins over the legacy SIGIL_LOCAL_WEB_DIR, and
+// that the legacy spelling still works on its own.
+func TestServer_DevAsset_EnvPrecedence(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	preferred := t.TempDir()
+	legacy := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(preferred, "app.jsx"), []byte("// preferred"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(legacy, "app.jsx"), []byte("// legacy"), 0o600))
+
+	fetchJSX := func() string {
+		req := httptest.NewRequest(http.MethodGet, "/assets/app.jsx", nil)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+		return rr.Body.String()
+	}
+
+	t.Run("preferred wins over legacy", func(t *testing.T) {
+		t.Setenv("AGENTO11Y_LOCAL_WEB_DIR", preferred)
+		t.Setenv("SIGIL_LOCAL_WEB_DIR", legacy)
+		assert.Equal(t, "// preferred", fetchJSX())
+	})
+
+	t.Run("legacy is used as a fallback", func(t *testing.T) {
+		t.Setenv("AGENTO11Y_LOCAL_WEB_DIR", "")
+		t.Setenv("SIGIL_LOCAL_WEB_DIR", legacy)
+		assert.Equal(t, "// legacy", fetchJSX())
+	})
+}

--- a/plugins/agento11y/internal/local/web/app.css
+++ b/plugins/agento11y/internal/local/web/app.css
@@ -124,3 +124,28 @@
     @media (prefers-reduced-motion: reduce) {
       [style*="sigil-barin"], [style*="sigil-tin"] { animation: none !important; }
     }
+
+    /* Conversation search: a small spinner in the input's right cluster while a
+       request is in flight, and a 1.2s shimmer for skeleton rows shown before
+       the first results arrive. Both honour reduced-motion. */
+    @keyframes sigil-spin {
+      from { transform: rotate(0deg); }
+      to   { transform: rotate(360deg); }
+    }
+    @keyframes sigil-shim {
+      0%   { background-position: -200px 0; }
+      100% { background-position: calc(200px + 100%) 0; }
+    }
+    .sigil-spin { animation: sigil-spin .7s linear infinite; }
+    .sigil-shim {
+      background: linear-gradient(90deg,
+        rgba(204,204,220,0.04) 0%,
+        rgba(204,204,220,0.10) 50%,
+        rgba(204,204,220,0.04) 100%);
+      background-size: 200px 100%;
+      background-repeat: no-repeat;
+      animation: sigil-shim 1.2s ease-in-out infinite;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .sigil-spin, .sigil-shim { animation: none !important; }
+    }

--- a/plugins/agento11y/internal/local/web/app.jsx
+++ b/plugins/agento11y/internal/local/web/app.jsx
@@ -1,4 +1,4 @@
-    const { useState, useEffect, useMemo, useCallback, useRef } = React;
+    const { useState, useEffect, useMemo, useCallback, useRef, createContext, useContext } = React;
 
     // ============================================================
     // Formatters — all server responses ship raw numbers + RFC3339
@@ -67,6 +67,7 @@
       { value: "7d", label: "Last 7 days", ms: 7 * 24 * 60 * 60 * 1000 },
       { value: "all", label: "All", ms: null },
     ];
+    const FEED_TIME_RANGES = TIME_RANGES.filter(r => r.value !== "5m" && r.value !== "15m");
 
     function timeRangeOption(value) {
       return TIME_RANGES.find(r => r.value === value) || TIME_RANGES.find(r => r.value === "6h");
@@ -126,6 +127,13 @@
       return MODEL_COLORS[name] || "#808080";
     }
 
+    // shortModel trims the vendor prefix and dated snapshot suffix so a list
+    // pill reads "opus-4-8" / "haiku-4-5" instead of the full
+    // "claude-haiku-4-5-20251001". The dot still colours by the full id.
+    function shortModel(name) {
+      return (name || "").replace(/^claude-/, "").replace(/-\d{8}$/, "");
+    }
+
     // Token-usage chart series. The server splits each generation into
     // these five non-overlapping buckets (provider-aware, see
     // disjointTokenUsage in query.go), so stacking them never
@@ -145,6 +153,146 @@
       const lines = TOKEN_SERIES.filter(s => buckets[s.key] > 0)
         .map(s => `${s.label}: ${formatTokens(buckets[s.key])}`);
       return lines.length ? lines.join("\n") : undefined;
+    }
+
+    // Prompt-input cache hit rate: cache reads divided by all prompt-input
+    // cache outcomes. Cache writes are misses that populated future cache
+    // entries, so they belong in the denominator but never the numerator.
+    function cacheInputHitPercent(freshInput, cacheRead, cacheWrite) {
+      const fresh = Math.max(0, Number(freshInput) || 0);
+      const read = Math.max(0, Number(cacheRead) || 0);
+      const write = Math.max(0, Number(cacheWrite) || 0);
+      const denom = fresh + read + write;
+      if (denom === 0) return null;
+      if (read === denom) return 100;
+      return Math.min(99, Math.round((read / denom) * 100));
+    }
+
+    // Per-model price in USD per million tokens (input / output). Cache reads
+    // bill at ~0.1x input and 5-minute cache writes at ~1.25x input — the
+    // published Anthropic multipliers. Matched by substring so the bare model
+    // id (claude-opus-4-8) resolves without an exact-version table.
+    //
+    // Anthropic only — agento11y also captures OpenAI / Gemini / etc. sessions,
+    // and we don't carry authoritative prices for those (they drift). An
+    // unrecognised model returns null rather than a fabricated dollar figure:
+    // better to show "—" than to price a GPT/Gemini run at Claude rates.
+    // ponytail: add a row here when a provider's prices are known and stable;
+    // don't guess them.
+    const MODEL_PRICES = [
+      { match: "fable",  in: 10, out: 50 },
+      { match: "opus",   in: 5,  out: 25 },
+      { match: "sonnet", in: 3,  out: 15 },
+      { match: "haiku",  in: 1,  out: 5  },
+    ];
+
+    function modelPrice(model) {
+      const m = (model || "").toLowerCase();
+      return MODEL_PRICES.find(p => m.includes(p.match)) || null;
+    }
+
+    // models.dev is the authoritative, multi-provider price catalog (OpenAI,
+    // Anthropic, Gemini, …) — strictly better than the bundled table, and it
+    // carries explicit per-model cache_read / cache_write rates instead of the
+    // 0.1x / 1.25x assumption. We fetch it once, flatten to
+    // { modelId: {input, output, cache_read, cache_write} } in USD/MTok, and
+    // cache it in localStorage for a day. Offline or unknown id → the bundled
+    // Anthropic table (modelPrice) → null.
+    const MODELS_DEV_URL = "https://models.dev/api.json";
+    const PRICE_CACHE_KEY = "sigil.modelPrices.v1";
+    const PRICE_TTL_MS = 24 * 60 * 60 * 1000;
+    let modelPricesPromise = null;
+
+    function flattenModelsDev(data) {
+      const map = {};
+      for (const provider of Object.values(data || {})) {
+        const models = provider && provider.models;
+        if (!models) continue;
+        for (const [id, m] of Object.entries(models)) {
+          if (m && m.cost && m.cost.input != null) map[id] = m.cost;
+        }
+      }
+      return map;
+    }
+
+    function loadModelPrices() {
+      if (modelPricesPromise) return modelPricesPromise;
+      modelPricesPromise = (async () => {
+        try {
+          const cached = JSON.parse(localStorage.getItem(PRICE_CACHE_KEY) || "null");
+          if (cached && cached.map && Date.now() - cached.at < PRICE_TTL_MS) return cached.map;
+        } catch { /* corrupt cache — refetch */ }
+        const resp = await fetch(MODELS_DEV_URL);
+        if (!resp.ok) throw new Error(`models.dev ${resp.status}`);
+        const map = flattenModelsDev(await resp.json());
+        try { localStorage.setItem(PRICE_CACHE_KEY, JSON.stringify({ at: Date.now(), map })); } catch { /* quota — skip cache */ }
+        return map;
+      })();
+      return modelPricesPromise;
+    }
+
+    // useModelPrices resolves to the flattened models.dev map, or null while
+    // loading / when the fetch fails (the daemon may be offline). Callers must
+    // tolerate null and fall back to the bundled table.
+    function useModelPrices() {
+      const [prices, setPrices] = useState(null);
+      useEffect(() => {
+        let alive = true;
+        loadModelPrices().then(m => { if (alive) setPrices(m); }).catch(() => {});
+        return () => { alive = false; };
+      }, []);
+      return prices;
+    }
+
+    // conversationCost prices a conversation's disjoint token buckets at its
+    // primary model's rates. Prefers the live models.dev catalog (exact model
+    // id, all providers); falls back to the bundled Anthropic table for
+    // brand-new Claude ids or when offline. Exact for the single-model common
+    // case; a mixed-model conversation is priced at models[0] (the
+    // orchestrator), a close approximation. Returns null when the model can't
+    // be priced (unknown provider, or no model recorded) so callers show "—"
+    // instead of a fabricated number.
+    // ponytail: per-model attribution would need per-generation buckets — not
+    // worth it until mixed-model conversations are common.
+    function conversationCost(c, prices) {
+      const b = c && c.token_buckets;
+      if (!b) return null;
+      const model = (c.models || [])[0];
+      let inRate, outRate, cacheReadRate, cacheWriteRate;
+      const live = prices && model && prices[model];
+      if (live) {
+        inRate = live.input;
+        outRate = live.output != null ? live.output : live.input;
+        cacheReadRate = live.cache_read != null ? live.cache_read : live.input * 0.1;
+        cacheWriteRate = live.cache_write != null ? live.cache_write : live.input * 1.25;
+      } else {
+        const p = modelPrice(model);
+        if (!p) return null;
+        inRate = p.in; outRate = p.out;
+        cacheReadRate = p.in * 0.1; cacheWriteRate = p.in * 1.25;
+      }
+      return (
+        (b.fresh_input || 0) * inRate +
+        (b.cache_read || 0) * cacheReadRate +
+        (b.cache_write || 0) * cacheWriteRate +
+        ((b.output || 0) + (b.reasoning || 0)) * outRate
+      ) / 1e6;
+    }
+
+    function formatCost(usd) {
+      if (usd == null) return "—";       // unpriced model — distinct from $0
+      if (usd === 0) return "$0";
+      if (usd < 0.01) return "<$0.01";
+      if (usd < 1000) return "$" + usd.toFixed(2).replace(/\.00$/, "");
+      return "$" + (usd / 1000).toFixed(1) + "k";
+    }
+
+    // workspaceLabel shortens an absolute cwd to its last two path segments
+    // (repo/branch-ish) for the sidebar; the full path stays in the title.
+    function workspaceLabel(path) {
+      if (!path) return "(unknown)";
+      const parts = path.replace(/\/+$/, "").split("/").filter(Boolean);
+      return parts.slice(-2).join("/") || path;
     }
 
     // timeWindow computes a chart's [start, end] for a range selection.
@@ -235,7 +383,7 @@
     // Shell primitives
     // ============================================================
 
-    function Icon({ name, size = 16, style }) {
+    function Icon({ name, size = 16, style, className }) {
       const paths = {
         search:   <path d="M11 19a8 8 0 1 1 5.3-2L21 21M11 19a8 8 0 0 0 5.3-2L11 19Z" />,
         chevron:  <path d="m6 9 6 6 6-6" />,
@@ -246,6 +394,8 @@
         swap:     <path d="M7 7h13l-3-3M17 17H4l3 3"/>,
         refresh:  <path d="M3 12a9 9 0 0 1 15.5-6.3L21 8M21 3v5h-5M21 12a9 9 0 0 1-15.5 6.3L3 16M3 21v-5h5"/>,
         book:     <path d="M4 4h7a3 3 0 0 1 3 3v13a3 3 0 0 0-3-3H4V4ZM20 4h-3a3 3 0 0 0-3 3v13a3 3 0 0 1 3-3h3V4Z"/>,
+        bookopen: <path d="M12 6c-2-1.3-4.5-2-7-2v13c2.5 0 5 .7 7 2 2-1.3 4.5-2 7-2V4c-2.5 0-5 .7-7 2Zm0 0v13"/>,
+        box:      <path d="M3 7.5 12 3l9 4.5v9L12 21l-9-4.5v-9Zm0 0 9 4.5m0 0 9-4.5m-9 4.5V21"/>,
         dot:      <circle cx="12" cy="12" r="4"/>,
         download: <path d="M12 4v12m0 0-4-4m4 4 4-4M4 20h16"/>,
         copy:     <path d="M9 9h11v11H9zM4 4h11v3"/>,
@@ -254,14 +404,25 @@
         alert:    <><path d="M12 9v4"/><circle cx="12" cy="16.5" r="0.6" fill="currentColor"/><path d="M10.3 4.1 2.7 17.4a2 2 0 0 0 1.7 3h15.2a2 2 0 0 0 1.7-3L13.7 4.1a2 2 0 0 0-3.4 0Z"/></>,
         empty:    <><circle cx="12" cy="12" r="9"/><path d="M8 12h8"/></>,
         extlink:  <path d="M7 17 17 7M9 7h8v8"/>,
-        info:     <><circle cx="12" cy="12" r="9"/><path d="M12 11v5"/><circle cx="12" cy="7.6" r="0.6" fill="currentColor"/></>,
+        shield:   <path d="M12 3 5 6v6c0 4 3 6.5 7 9 4-2.5 7-5 7-9V6l-7-3Z"/>,
+        shieldcheck: <><path d="M12 3 5 6v6c0 4 3 6.5 7 9 4-2.5 7-5 7-9V6l-7-3Z"/><path d="m9 12 2 2 4-4"/></>,
         plus:     <path d="M12 5v14M5 12h14"/>,
+        play:     <path d="M7 5v14l11-7-11-7Z"/>,
+        pen:      <path d="M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/>,
+        trash:    <path d="M4 7h16M9 7V5h6v2M6 7l1 13h10l1-13"/>,
+        close:    <path d="M6 6l12 12M18 6 6 18"/>,
+        check:    <path d="m5 13 4 4L19 7"/>,
+        info:     <><circle cx="12" cy="12" r="9"/><path d="M12 11v5"/><circle cx="12" cy="8" r="0.6" fill="currentColor"/></>,
+        ban:      <><circle cx="12" cy="12" r="9"/><path d="m6 6 12 12"/></>,
+        key:      <><circle cx="8" cy="15" r="3.2"/><path d="m10.3 12.7 8-8M16 5l2.5 2.5M13.5 7.5 16 10"/></>,
         times:    <path d="M6 6l12 12M18 6 6 18"/>,
-        check:    <path d="M5 12l4.5 4.5L19 7"/>,
+        cloud:    <path d="M7 18a4 4 0 0 1-.5-7.97 5 5 0 0 1 9.6-1.37A3.5 3.5 0 0 1 16.5 18H7Z"/>,
+        sparkle:  <path d="M12 3l1.5 5L18 9.5l-5 1.5L12 16l-1.5-5.5L5 9.5 10.5 8 12 3Z"/>,
       };
       return (
         <svg width={size} height={size} viewBox="0 0 24 24" fill="none"
           stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round"
+          className={className}
           style={{ flexShrink: 0, display: "block", ...(style || {}) }}>
           {paths[name]}
         </svg>
@@ -294,30 +455,10 @@
       );
     }
 
-    function AgentPill({ name, size = "md" }) {
-      const small = size === "sm";
-      return (
-        <span style={{
-          display: "inline-flex", alignItems: "center", gap: small ? 5 : 6,
-          padding: small ? "1px 6px" : "2px 8px",
-          border: "1px solid var(--border-medium)",
-          borderRadius: 2,
-          background: "rgba(204,204,220,0.04)",
-          color: "var(--fg1)",
-          fontSize: small ? 11 : 12,
-          fontFamily: "var(--fontFamilyMonospace)",
-          whiteSpace: "nowrap",
-        }}>
-          <svg width={10} height={10} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></svg>
-          {name}
-        </span>
-      );
-    }
-
     function ModelPill({ name, dot }) {
       const color = dot || modelDot(name);
       return (
-        <span style={{
+        <span title={name} style={{
           display: "inline-flex", alignItems: "center", gap: 6,
           padding: "2px 8px",
           border: "1px solid var(--border-medium)",
@@ -326,8 +467,72 @@
           color: "var(--fg1)", fontSize: 12, fontFamily: "var(--fontFamilyMonospace)", whiteSpace: "nowrap",
         }}>
           <span style={{ width: 7, height: 7, borderRadius: "50%", background: color, boxShadow: `0 0 6px ${color}66` }}/>
-          {name}
+          {shortModel(name)}
         </span>
+      );
+    }
+
+    function AgentPill({ name, size }) {
+      const full = String(name || "");
+      if (!full) return null;
+      const sm = size === "sm";
+      return (
+        <span title={full} style={{
+          display: "inline-flex", alignItems: "center", gap: sm ? 4 : 5,
+          padding: sm ? "1px 6px" : "1px 7px",
+          border: "1px solid var(--border-medium)", borderRadius: 2,
+          background: "rgba(204,204,220,0.04)", color: "var(--fg1)",
+          fontSize: sm ? 10 : 11, fontFamily: "var(--fontFamilyMonospace)", whiteSpace: "nowrap",
+        }}>
+          <svg width={sm ? 9 : 10} height={sm ? 9 : 10} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></svg>
+          {agentShort(full)}
+        </span>
+      );
+    }
+
+    // agentHosts reduces the agents list to its distinct host launchers —
+    // the part before the first "/". "claude-code", "claude-code/explore" and
+    // "claude-code/general-purpose" all collapse to "claude-code"; the
+    // subagent breakdown lives in the ⊂N badge and the detail view. Built to
+    // distinguish hosts once we capture cursor / codex / copilot / opencode /
+    // pi sessions alongside claude-code.
+    function agentHosts(agents) {
+      return [...new Set((agents || []).map(a => String(a).split("/")[0]).filter(Boolean))];
+    }
+
+    function AgentCell({ agents }) {
+      const hosts = agentHosts(agents);
+      return (
+        <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap", minWidth: 0 }}>
+          {hosts.map(h => (
+            <span key={h} title={h} style={{
+              display: "inline-flex", alignItems: "center", gap: 5,
+              padding: "1px 7px", border: "1px solid var(--border-medium)", borderRadius: 2,
+              background: "rgba(204,204,220,0.04)", color: "var(--fg1)",
+              fontSize: 11, fontFamily: "var(--fontFamilyMonospace)", whiteSpace: "nowrap",
+            }}>
+              <svg width={10} height={10} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></svg>
+              {h}
+            </span>
+          ))}
+        </div>
+      );
+    }
+
+    // ModelCell shows a conversation's models as compact pills, capped at two
+    // with a "+N" overflow, so a multi-model run never wraps into the next
+    // column. The full list is in the title.
+    function ModelCell({ models }) {
+      const list = models || [];
+      const shown = list.slice(0, 2);
+      const extra = list.length - shown.length;
+      return (
+        <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap", minWidth: 0 }}>
+          {shown.map(m => <ModelPill key={m} name={m}/>)}
+          {extra > 0 && (
+            <span title={list.join(", ")} style={{ fontSize: 11, color: "var(--fg3)", fontFamily: "var(--fontFamilyMonospace)" }}>+{extra}</span>
+          )}
+        </div>
       );
     }
 
@@ -338,77 +543,97 @@
       color: "var(--fg2)", cursor: "pointer", borderRadius: 2,
     };
 
-    // NavTab is a top-level header nav link. The current section gets a 2px
-    // brand underline bar and white text; other tabs render as faint links
-    // that brighten on hover and navigate on a plain left click (modifier
-    // clicks fall through so the anchor opens a new tab).
-    function NavTab({ label, href, onClick, state }) {
-      const current = state === "current";
+    // NavTab is one top-nav section link (Sessions / Settings). The active
+    // tab carries the brand underline bar; the others are muted and hover to
+    // full white.
+    function NavTab({ label, href, active, onClick }) {
       return (
         <a href={href}
-          onClick={e => {
-            if (!isPlainLeftClick(e)) return;
-            e.preventDefault();
-            onClick && onClick(e);
-          }}
-          onMouseEnter={e => { if (!current) e.currentTarget.style.color = "var(--fg-max)"; }}
-          onMouseLeave={e => { if (!current) e.currentTarget.style.color = "var(--fg2)"; }}
+          onClick={e => { if (!isPlainLeftClick(e)) return; e.preventDefault(); onClick && onClick(e); }}
           style={{
             position: "relative", display: "inline-flex", alignItems: "center",
-            height: "100%", padding: "0 2px",
+            alignSelf: "stretch",
+            padding: "0 2px",
             fontFamily: "var(--fontFamily)", fontSize: 13,
-            color: current ? "var(--fg-max)" : "var(--fg2)",
-            textDecoration: "none", whiteSpace: "nowrap", flexShrink: 0,
-            transition: "color .12s",
-          }}>
+            color: active ? "var(--fg-max)" : "var(--fg2)",
+            textDecoration: "none", whiteSpace: "nowrap", cursor: "pointer",
+          }}
+          onMouseEnter={e => { if (!active) e.currentTarget.style.color = "var(--fg-max)"; }}
+          onMouseLeave={e => { if (!active) e.currentTarget.style.color = "var(--fg2)"; }}>
           {label}
-          {current && <span style={{ position: "absolute", left: 0, right: 0, bottom: 0, height: 2, background: "var(--brandVertical)", borderRadius: 1 }}/>}
+          {active && <span style={{ position: "absolute", left: 0, right: 0, bottom: 0, height: 2, background: "var(--brandVertical)", borderRadius: 1 }}/>}
         </a>
       );
     }
 
-    function TopBar({ tabs = [], trail = [] }) {
+    // HEADER_H is the sticky top-bar height. Sub-bars (breadcrumb, section
+    // tabs) and the sticky left rail offset themselves by this so they sit
+    // flush under the header.
+    const HEADER_H = 68;
+
+    function TopBar({ tabs = [], activeTab, trail = [] }) {
+      const active = tabs.find(t => t.key === activeTab);
       return (
-        <header style={{
-          height: 48,
-          borderBottom: "1px solid var(--border-weak)",
-          background: "var(--bg-primary)",
-          display: "flex", alignItems: "center", padding: "0 16px", gap: 16,
-          position: "sticky", top: 0, zIndex: 5,
-        }}>
-          <Wordmark/>
-          <div style={{ width: 1, height: 20, background: "var(--border-weak)", margin: "0 4px" }}/>
-          <nav style={{ display: "flex", alignItems: "center", alignSelf: "stretch", gap: 14, minWidth: 0, flex: 1, overflow: "hidden" }}>
-            {tabs.map((t, i) => <NavTab key={i} {...t}/>)}
-            {trail.map((b, i) => (
-              <React.Fragment key={"trail-" + i}>
-                <Icon name="cright" size={11} style={{ color: "var(--fg3)", flexShrink: 0 }}/>
-                <span style={{
-                  fontFamily: b.mono ? "var(--fontFamilyMonospace)" : "var(--fontFamily)",
-                  fontSize: 13, color: "var(--fg-max)",
-                  whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", minWidth: 0,
-                }}>{b.label}</span>
-              </React.Fragment>
-            ))}
-          </nav>
-          <a
-            href="https://grafana.com/auth/sign-up/create-user/?"
-            target="_blank"
-            rel="noreferrer"
-            style={{
-              display: "inline-flex", alignItems: "center", gap: 5,
-              color: "var(--fg2)",
-              textDecoration: "none",
-              fontSize: 12,
-              whiteSpace: "nowrap",
-              flexShrink: 0,
-            }}
-            onMouseEnter={e => e.currentTarget.style.color = "var(--fg-max)"}
-            onMouseLeave={e => e.currentTarget.style.color = "var(--fg2)"}>
-            Sign up for Grafana Cloud
-            <Icon name="extlink" size={11}/>
-          </a>
-        </header>
+        <>
+          <header style={{
+            height: HEADER_H,
+            background: "var(--bg-primary)",
+            display: "flex", alignItems: "center", padding: "0 16px", gap: 20,
+            position: "sticky", top: 0, zIndex: 5,
+          }}>
+            <Wordmark/>
+            <div style={{ width: 1, height: 28, background: "var(--border-weak)", margin: "0 4px" }}/>
+            <nav style={{ display: "flex", alignItems: "center", alignSelf: "stretch", gap: 18, minWidth: 0, flex: 1, overflow: "hidden" }}>
+              {tabs.map(t => (
+                <NavTab key={t.key} label={t.label} href={t.href} active={t.key === activeTab} onClick={t.onClick}/>
+              ))}
+            </nav>
+            <a
+              href="https://grafana.com/auth/sign-up/create-user/?"
+              target="_blank"
+              rel="noreferrer"
+              style={{
+                display: "inline-flex", alignItems: "center", gap: 5,
+                color: "var(--fg2)",
+                textDecoration: "none",
+                fontSize: 12,
+                whiteSpace: "nowrap",
+                flexShrink: 0,
+              }}
+              onMouseEnter={e => e.currentTarget.style.color = "var(--fg-max)"}
+              onMouseLeave={e => e.currentTarget.style.color = "var(--fg2)"}>
+              Sign up for Grafana Cloud
+              <Icon name="extlink" size={11}/>
+            </a>
+          </header>
+          {trail.length > 0 && (
+            // The breadcrumb lives on its own line under the menu so a long
+            // conversation title can't push the other tabs out of view.
+            <div style={{
+              display: "flex", alignItems: "center", gap: 8, height: 34, padding: "0 16px",
+              borderBottom: "1px solid var(--border-weak)", background: "var(--bg-primary)",
+              position: "sticky", top: HEADER_H, zIndex: 4, minWidth: 0, overflow: "hidden",
+            }}>
+              {active && (
+                <a href={active.href}
+                  onClick={active.onClick ? (e => { if (!isPlainLeftClick(e)) return; e.preventDefault(); active.onClick(); }) : undefined}
+                  style={{ fontSize: 13, color: "var(--fg2)", textDecoration: "none", whiteSpace: "nowrap", flexShrink: 0, cursor: "pointer" }}
+                  onMouseEnter={e => e.currentTarget.style.color = "var(--fg-max)"}
+                  onMouseLeave={e => e.currentTarget.style.color = "var(--fg2)"}>{active.label}</a>
+              )}
+              {trail.map((b, i) => (
+                <React.Fragment key={i}>
+                  <Icon name="cright" size={11} style={{ color: "var(--fg3)", flexShrink: 0 }}/>
+                  <span style={{
+                    fontFamily: b.mono ? "var(--fontFamilyMonospace)" : "var(--fontFamily)",
+                    fontSize: 13, color: "var(--fg-max)",
+                    whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", minWidth: 0,
+                  }}>{b.label}</span>
+                </React.Fragment>
+              ))}
+            </div>
+          )}
+        </>
       );
     }
 
@@ -418,8 +643,9 @@
 
     function Notice({ kind = "info", title, children }) {
       const tone = {
-        info:  { color: "var(--fg2)",        bg: "rgba(204,204,220,0.03)", border: "var(--border-weak)",   icon: "empty" },
-        error: { color: "var(--error-text)", bg: "rgba(209,14,92,0.06)",   border: "var(--error-border)",  icon: "alert" },
+        info:    { color: "var(--fg2)",          bg: "rgba(204,204,220,0.03)", border: "var(--border-weak)",   icon: "empty" },
+        warning: { color: "var(--warning-text)", bg: "var(--warning-transparent, rgba(247,148,30,0.06))", border: "var(--warning-border, var(--border-medium))", icon: "alert" },
+        error:   { color: "var(--error-text)",   bg: "rgba(209,14,92,0.06)",   border: "var(--error-border)",  icon: "alert" },
       }[kind] || {};
       return (
         <div style={{
@@ -440,6 +666,148 @@
       );
     }
 
+    const PAGE_MAX_WIDTH = 1392;
+    const SURFACE_BG = "rgba(24,27,31,0.88)";
+    const HERO_BG = "var(--bg-secondary)";
+    const ACTIVE_PILL_BG = "var(--action-selected, rgba(204,204,220,0.08))";
+    const PANEL_BG = "rgba(17,18,23,0.42)";
+
+    function Box({ as: Component = "div", style, children, ...props }) {
+      return <Component {...props} style={style}>{children}</Component>;
+    }
+
+    function Stack({ as = "div", direction = "column", gap, align, justify, wrap, style, children, ...props }) {
+      return (
+        <Box
+          as={as}
+          {...props}
+          style={{
+            display: "flex",
+            flexDirection: direction,
+            gap,
+            alignItems: align,
+            justifyContent: justify,
+            flexWrap: wrap,
+            ...(style || {}),
+          }}>
+          {children}
+        </Box>
+      );
+    }
+
+    function SurfaceCard({ children, style, ...rest }) {
+      return (
+        <Box style={{
+          position: "relative",
+          overflow: "hidden",
+          background: SURFACE_BG,
+          border: "1px solid var(--border-weak)",
+          borderRadius: 10,
+          boxShadow: "0 10px 24px rgba(0,0,0,0.14)",
+          ...(style || {}),
+        }} {...rest}>
+          {children}
+        </Box>
+      );
+    }
+
+    function ModalFrame({ title, desc, onClose, children, width = "min(860px, 100%)" }) {
+      return (
+        <div onClick={onClose} style={{ position: "fixed", inset: 0, zIndex: 70, background: "rgba(0,0,0,0.58)", display: "flex", alignItems: "flex-start", justifyContent: "center", padding: "9vh 18px 24px" }}>
+          <div onClick={e => e.stopPropagation()} style={{ width, maxHeight: "82vh", overflow: "hidden", background: "var(--bg-secondary)", border: "1px solid var(--border-strong)", borderRadius: 10, boxShadow: "0 18px 54px rgba(0,0,0,0.58)", display: "flex", flexDirection: "column" }}>
+            <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 16, padding: "16px 18px", borderBottom: "1px solid var(--border-weak)" }}>
+              <div style={{ minWidth: 0 }}>
+                <div style={{ color: "var(--fg-max)", fontSize: 15, fontWeight: 600, marginBottom: desc ? 5 : 0 }}>{title}</div>
+                {desc && <div style={{ color: "var(--fg3)", fontSize: 12.5, lineHeight: 1.45 }}>{desc}</div>}
+              </div>
+              <button type="button" onClick={onClose} style={{ border: "none", background: "transparent", color: "var(--fg3)", cursor: "pointer", padding: 4 }}>
+                <Icon name="close" size={16}/>
+              </button>
+            </div>
+            {children}
+          </div>
+        </div>
+      );
+    }
+
+    function PageShell({ children, maxWidth = PAGE_MAX_WIDTH, style }) {
+      return (
+        <Box style={{ width: "100%", maxWidth, margin: "0 auto", padding: "34px 24px 96px", ...(style || {}) }}>
+          {children}
+        </Box>
+      );
+    }
+
+    function HeroChip({ label, value, tone }) {
+      return (
+        <Stack gap={2} style={{ padding: "8px 10px", border: "1px solid var(--border-medium)", borderRadius: 8, background: PANEL_BG, minWidth: 108 }}>
+          <Box style={{ fontSize: 10, letterSpacing: ".08em", textTransform: "uppercase", color: "var(--fg3)", fontWeight: 700 }}>{label}</Box>
+          <Box style={{ fontSize: 12, color: tone || "var(--fg-max)", fontWeight: 600, whiteSpace: "nowrap" }}>{value}</Box>
+        </Stack>
+      );
+    }
+
+    function PageHero({ icon, kicker, title, desc, chips, actions, children, style }) {
+      return (
+        <Box style={{
+          position: "relative",
+          overflow: "hidden",
+          border: "1px solid var(--border-weak)",
+          borderRadius: 10,
+          padding: "22px 24px",
+          marginBottom: 18,
+          background: HERO_BG,
+          boxShadow: "0 12px 28px rgba(0,0,0,0.18)",
+          ...(style || {}),
+        }}>
+          <Box style={{ position: "absolute", left: 0, right: 0, top: 0, height: 2, background: "var(--brandVertical)" }}/>
+          <Stack direction="row" justify="space-between" gap={24} align="flex-end" wrap="wrap">
+            <Box style={{ minWidth: 0, flex: "1 1 360px" }}>
+              <Stack direction="row" align="center" gap={8} style={{ marginBottom: 8 }}>
+                {icon && <Icon name={icon} size={15} style={{ color: "var(--brand-orange-text)" }}/>}
+                <Box as="span" style={{ fontSize: 11, letterSpacing: ".12em", textTransform: "uppercase", color: "var(--fg3)", fontWeight: 700 }}>{kicker}</Box>
+              </Stack>
+              <h1 style={{ fontSize: 26, lineHeight: 1.15, fontWeight: 650, color: "var(--fg-max)", margin: 0, letterSpacing: "-0.03em" }}>{title}</h1>
+              {desc && <Box style={{ marginTop: 8, fontSize: 13, color: "var(--fg2)", maxWidth: 680 }}>{desc}</Box>}
+              {children && <Box style={{ marginTop: 10 }}>{children}</Box>}
+            </Box>
+            {(chips || actions) && (
+              <Stack direction="row" wrap="wrap" gap={8} justify="flex-end" align="center" style={{ minWidth: 0 }}>
+                {(chips || []).map(chip => <HeroChip key={chip.label} {...chip}/>)}
+                {actions}
+              </Stack>
+            )}
+          </Stack>
+        </Box>
+      );
+    }
+
+    function PillToggle({ options, value, onChange }) {
+      return (
+        <Stack direction="row" gap={3} style={{ display: "inline-flex", padding: 3, border: "1px solid var(--border-medium)", borderRadius: 999, background: PANEL_BG, overflow: "hidden", boxShadow: "inset 0 0 0 1px rgba(0,0,0,0.10)" }}>
+          {options.map(o => {
+            const active = o.value === value;
+            return (
+              <button key={o.value} type="button" onClick={() => onChange(o.value)} style={{
+                padding: "5px 13px",
+                borderRadius: 999,
+                background: active ? ACTIVE_PILL_BG : "transparent",
+                color: active ? "var(--primary-text)" : "var(--fg2)",
+                border: "none",
+                cursor: active ? "default" : "pointer",
+                fontSize: 12,
+                fontWeight: active ? 600 : 400,
+                fontFamily: "var(--fontFamily)",
+                boxShadow: active ? "inset 0 0 0 1px var(--primary-border)" : "none",
+              }}>
+                {o.label}
+              </button>
+            );
+          })}
+        </Stack>
+      );
+    }
+
     // ============================================================
     // Screen 1 — Conversations list
     // ============================================================
@@ -447,27 +815,11 @@
     // ChartSwitch picks which metric the single chart slot shows. It
     // doubles as the chart's title: the active segment names the data.
     function ChartSwitch({ value, onChange }) {
-      const opts = [
+      const options = [
         { value: "tokens", label: "Tokens" },
-        { value: "activity", label: "Conversations" },
+        { value: "activity", label: "Sessions" },
       ];
-      return (
-        <div style={{ display: "inline-flex", border: "1px solid var(--border-medium)", borderRadius: 2, overflow: "hidden" }}>
-          {opts.map((o, i) => {
-            const active = o.value === value;
-            return (
-              <button key={o.value} onClick={() => onChange(o.value)} style={{
-                padding: "4px 12px",
-                background: active ? "var(--action-selected)" : "transparent",
-                color: active ? "var(--fg-max)" : "var(--fg2)",
-                border: "none", borderLeft: i > 0 ? "1px solid var(--border-medium)" : "none",
-                cursor: active ? "default" : "pointer",
-                fontSize: 12, fontWeight: active ? 500 : 400, fontFamily: "var(--fontFamily)",
-              }}>{o.label}</button>
-            );
-          })}
-        </div>
-      );
+      return <PillToggle options={options} value={value} onChange={onChange}/>;
     }
 
     // ChartXLabels renders at most ~5 evenly-spaced bucket labels so the
@@ -513,7 +865,7 @@
       const [hover, setHover] = useState(null);
 
       return (
-        <div style={{ position: "relative", padding: "16px 20px 12px", background: "var(--bg-primary)", border: "1px solid var(--border-weak)", borderRadius: 2 }}>
+        <SurfaceCard style={{ position: "relative", padding: "16px 20px 12px", marginBottom: 0 }}>
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
             {switcher}
             <div style={{ display: "flex", alignItems: "center", gap: 12, fontSize: 11, color: "var(--fg3)", fontFamily: "var(--fontFamilyMonospace)" }}>
@@ -567,13 +919,13 @@
                   pointerEvents: "none",
                   boxShadow: "var(--shadow-z2)",
                 }}>
-                  <span style={{ color: "var(--fg3)" }}>{data[hover].t}</span> · {data[hover].c} {data[hover].c === 1 ? "conversation" : "conversations"}
+                  <span style={{ color: "var(--fg3)" }}>{data[hover].t}</span> · {data[hover].c} {data[hover].c === 1 ? "session" : "sessions"}
                 </div>
               )}
             </div>
             <ChartXLabels data={data}/>
           </div>
-        </div>
+        </SurfaceCard>
       );
     }
 
@@ -600,7 +952,7 @@
       const empty = grandTotal === 0;
 
       return (
-        <div style={{ position: "relative", padding: "16px 20px 12px", background: "var(--bg-primary)", border: "1px solid var(--border-weak)", borderRadius: 2 }}>
+        <SurfaceCard style={{ position: "relative", padding: "16px 20px 12px", marginBottom: 0 }}>
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10, gap: 12, flexWrap: "wrap" }}>
             {switcher}
             <div style={{ display: "flex", alignItems: "center", gap: 12, fontSize: 11, color: "var(--fg3)", fontFamily: "var(--fontFamilyMonospace)", flexWrap: "wrap" }}>
@@ -700,62 +1052,185 @@
             </div>
             <ChartXLabels data={data}/>
           </div>
+        </SurfaceCard>
+      );
+    }
+
+    function TimeRangePicker({ value, onChange, ranges = TIME_RANGES }) {
+      const [open, setOpen] = useState(false);
+      const selected = ranges.find(r => r.value === value) || ranges[ranges.length - 1] || TIME_RANGES[0];
+      return (
+        <div style={{ position: "relative", flex: "0 0 auto" }}>
+          <button type="button" onClick={() => setOpen(o => !o)}
+            onBlur={e => { if (!e.currentTarget.parentElement?.contains(e.relatedTarget)) setOpen(false); }}
+            title="Time range"
+            style={{
+              height: 34,
+              minWidth: 166,
+              padding: "0 10px",
+              border: "1px solid var(--border-medium)",
+              borderRadius: 8,
+              background: "rgba(24,27,31,0.78)",
+              color: "var(--fg1)",
+              fontSize: 13,
+              fontFamily: "var(--fontFamily)",
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 10,
+              cursor: "pointer",
+            }}>
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+              <Icon name="clock" size={14} style={{ color: "var(--fg3)" }}/>
+              {selected.label}
+            </span>
+            <Icon name="chevron" size={14} style={{ color: "var(--fg3)" }}/>
+          </button>
+          {open && (
+            <div style={{
+              position: "absolute",
+              top: 39,
+              right: 0,
+              zIndex: 30,
+              minWidth: 190,
+              padding: 4,
+              border: "1px solid var(--border-strong)",
+              borderRadius: 8,
+              background: "var(--bg-secondary)",
+              boxShadow: "0 12px 34px rgba(0,0,0,0.48)",
+            }}>
+              {ranges.map(r => {
+                const active = r.value === selected.value;
+                return (
+                  <button key={r.value} type="button"
+                    onMouseDown={e => e.preventDefault()}
+                    onClick={() => {
+                      onChange(r.value);
+                      setOpen(false);
+                    }}
+                    style={{
+                      width: "100%",
+                      height: 30,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                      gap: 10,
+                      padding: "0 9px",
+                      border: "none",
+                      borderRadius: 5,
+                      background: active ? ACTIVE_PILL_BG : "transparent",
+                      color: active ? "var(--primary-text)" : "var(--fg1)",
+                      fontSize: 12,
+                      fontFamily: "var(--fontFamily)",
+                      cursor: "pointer",
+                      textAlign: "left",
+                    }}>
+                    <span>{r.label}</span>
+                    {active && <Icon name="check" size={12}/>}
+                  </button>
+                );
+              })}
+            </div>
+          )}
         </div>
       );
     }
 
-    function FilterBar({ query, onQueryChange, timeRange, onTimeRangeChange, onRefresh, refreshing }) {
+    function FilterBar({
+      query, onQueryChange, inputRef,
+      timeRange, onTimeRangeChange,
+      agentFilter = "all", onAgentFilterChange, agentOptions = [],
+      modelFilter = "all", onModelFilterChange, modelOptions = [],
+      statusFilter = "all", onStatusFilterChange,
+      activeFilterCount = 0, onClearFilters,
+      onRefresh, refreshing,
+      placeholder = "Filter by title, id, workspace, agent, model…",
+      onInputKeyDown,
+      rightAdornment,
+    }) {
+      const showTimeRange = !!timeRange && !!onTimeRangeChange;
+      const showAgentFilter = !!onAgentFilterChange;
+      const showModelFilter = !!onModelFilterChange;
+      const showStatusFilter = !!onStatusFilterChange;
+      const selectStyle = {
+        height: 34,
+        minWidth: 132,
+        padding: "0 30px 0 11px",
+        border: "1px solid var(--border-medium)",
+        borderRadius: 8,
+        background: "rgba(24,27,31,0.78)",
+        color: "var(--fg1)",
+        fontSize: 13,
+        fontFamily: "var(--fontFamily)",
+      };
       return (
-        <div style={{ display: "flex", alignItems: "stretch", gap: 8, marginBottom: 16, fontSize: 13 }}>
-          <div style={{
-            flex: 1, display: "flex", alignItems: "center", gap: 8,
+        <Stack direction="row" align="stretch" gap={8} style={{ marginBottom: 16, fontSize: 13, flexWrap: "wrap" }}>
+          <Stack direction="row" align="center" gap={8} style={{
+            flex: "1 1 320px",
             padding: "0 11px",
             height: 34,
             border: "1px solid var(--border-medium)",
-            borderRadius: 2,
-            background: "var(--bg-primary)",
+            borderRadius: 8,
+            background: "rgba(24,27,31,0.78)",
             color: "var(--fg3)",
+            boxShadow: "inset 0 0 0 1px rgba(0,0,0,0.12)",
           }}>
             <Icon name="search" size={14}/>
             <input
+              ref={inputRef}
               value={query}
               onChange={e => onQueryChange(e.target.value)}
-              placeholder="Filter by id, agent, model…"
+              onKeyDown={onInputKeyDown}
+              placeholder={placeholder}
               style={{
                 flex: 1, background: "transparent", border: "none", outline: "none",
                 color: "var(--fg1)", fontSize: 13, fontFamily: "var(--fontFamily)",
               }}/>
-            <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--fg3)", padding: "1px 5px", border: "1px solid var(--border-weak)", borderRadius: 2 }}>⌘K</span>
-          </div>
-          <select
-            value={timeRange}
-            onChange={e => onTimeRangeChange(e.target.value)}
-            title="Time range"
-            style={{
-              height: 34,
-              minWidth: 150,
-              padding: "0 30px 0 11px",
-              border: "1px solid var(--border-medium)",
-              borderRadius: 2,
-              background: "var(--bg-primary)",
-              color: "var(--fg1)",
-              fontSize: 13,
-              fontFamily: "var(--fontFamily)",
-            }}>
-            {TIME_RANGES.map(r => <option key={r.value} value={r.value}>{r.label}</option>)}
-          </select>
+            {rightAdornment !== undefined ? rightAdornment : (
+              <span title="Press Command-K or Control-K to focus search" style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--fg3)", padding: "1px 6px", border: "1px solid var(--border-weak)", borderRadius: 999 }}>⌘K</span>
+            )}
+          </Stack>
+          {showTimeRange && <TimeRangePicker value={timeRange} onChange={onTimeRangeChange}/>}
+          {showAgentFilter && (
+            <select value={agentFilter} onChange={e => onAgentFilterChange(e.target.value)} title="Filter by agent" style={selectStyle}>
+              <option value="all">All agents</option>
+              {agentOptions.map(a => <option key={a} value={a}>{a}</option>)}
+            </select>
+          )}
+          {showModelFilter && (
+            <select value={modelFilter} onChange={e => onModelFilterChange(e.target.value)} title="Filter by model" style={{ ...selectStyle, minWidth: 150 }}>
+              <option value="all">All models</option>
+              {modelOptions.map(m => <option key={m} value={m}>{m}</option>)}
+            </select>
+          )}
+          {showStatusFilter && (
+            <select value={statusFilter} onChange={e => onStatusFilterChange(e.target.value)} title="Filter by status" style={selectStyle}>
+              <option value="all">All status</option>
+              <option value="errors">Errors</option>
+              <option value="subagents">Has subagents</option>
+            </select>
+          )}
+          {activeFilterCount > 0 && onClearFilters && (
+            <button onClick={onClearFilters}
+              style={{ ...iconBtn, height: 34, padding: "0 11px", border: "1px solid var(--border-medium)", borderRadius: 8, color: "var(--fg2)", gap: 6 }}
+              title="Clear session filters"
+              onMouseEnter={e => { e.currentTarget.style.background = "var(--action-hover)"; e.currentTarget.style.color = "var(--fg1)"; }}
+              onMouseLeave={e => { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = "var(--fg2)"; }}>
+              <Icon name="close" size={13}/>Clear
+            </button>
+          )}
           <button onClick={onRefresh} disabled={refreshing}
-            style={{ ...iconBtn, height: 34, width: 34, border: "1px solid var(--border-medium)", opacity: refreshing ? 0.5 : 1, cursor: refreshing ? "wait" : "pointer" }}
+            style={{ ...iconBtn, height: 34, width: 34, border: "1px solid var(--border-medium)", borderRadius: 8, opacity: refreshing ? 0.5 : 1, cursor: refreshing ? "wait" : "pointer" }}
             title="Refresh"
             onMouseEnter={e => { if (!refreshing) { e.currentTarget.style.background = "var(--action-hover)"; e.currentTarget.style.color = "var(--fg1)"; } }}
             onMouseLeave={e => { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = "var(--fg2)"; }}>
             <Icon name="refresh" size={14}/>
           </button>
-        </div>
+        </Stack>
       );
     }
 
-    function ConvRow({ c, now, onOpen }) {
+    function ConvRow({ c, now, onOpen, prices }) {
       const accent = c.status === "err" ? "var(--error-main)"
         : c.status === "warn" ? "var(--warning-main)"
         : "transparent";
@@ -769,7 +1244,7 @@
            }}
            style={{
           display: "grid",
-          gridTemplateColumns: "110px minmax(280px, 1.6fr) 150px 110px 130px 200px",
+          gridTemplateColumns: CONV_GRID,
           alignItems: "center",
           gap: 16,
           padding: "12px 16px",
@@ -787,31 +1262,40 @@
         >
           <span style={{ color: "var(--fg2)" }}>{formatAgo(c.last_activity, now)}</span>
           <div style={{ display: "flex", flexDirection: "column", gap: 2, minWidth: 0 }}>
-            <span style={{ fontFamily: "var(--fontFamily)", color: "var(--fg1)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{c.title || c.id}</span>
-            {c.title && c.title !== c.id && (
-              <span style={{ color: "var(--fg3)", fontSize: 11, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{c.id}</span>
-            )}
+            <span style={{ display: "flex", alignItems: "center", gap: 7, minWidth: 0 }}>
+              <span style={{ fontFamily: "var(--fontFamily)", color: "var(--fg1)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{c.title || c.id}</span>
+              {c.subagents > 0 && (
+                <span title={`${c.subagents} subagent ${c.subagents === 1 ? "step" : "steps"}`}
+                  style={{ flexShrink: 0, display: "inline-flex", alignItems: "center", gap: 3, padding: "0 6px", height: 16, borderRadius: 2, background: "rgba(204,204,220,0.06)", color: "var(--fg2)", fontSize: 10, fontFamily: "var(--fontFamilyMonospace)" }}>⊂ {c.subagents}</span>
+              )}
+            </span>
+            <span style={{ color: "var(--fg3)", fontSize: 11, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {c.workspace ? workspaceLabel(c.workspace) : c.id}
+            </span>
           </div>
-          <span style={{ color: "var(--fg2)" }}>
-            <span style={{ color: "var(--fg1)" }}>{formatDuration(wallSec)}</span>
-            <span style={{ color: "var(--fg3)", padding: "0 6px" }}>·</span>
-            <span style={{ color: "var(--fg1)" }}>{c.calls} {c.calls === 1 ? "call" : "calls"}</span>
-          </span>
+          <AgentCell agents={c.agents}/>
+          <span style={{ color: "var(--fg1)" }} title="Estimated cost">{formatCost(conversationCost(c, prices))}</span>
           <span style={{ display: "inline-flex", alignItems: "center", gap: 7 }} title={tokenBreakdownTitle(c.token_buckets)}>
             <span style={{ color: "var(--fg1)" }}>{formatTokens(c.total_tokens)}</span>
             {c.status === "err" && (
               <span style={{ display: "inline-flex", alignItems: "center", padding: "0 6px", height: 16, borderRadius: 2, background: "var(--error-transparent)", color: "var(--error-text)", fontSize: 10, letterSpacing: "0.04em" }}>ERR</span>
             )}
           </span>
-          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-            {(c.agents || []).map(a => <AgentPill key={a} name={a} size="sm"/>)}
-          </div>
-          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-            {(c.models || []).map(m => <ModelPill key={m} name={m}/>)}
-          </div>
+          <span style={{ color: "var(--fg2)" }}>
+            <span style={{ color: "var(--fg1)" }}>{formatDuration(wallSec)}</span>
+            <span style={{ color: "var(--fg3)", padding: "0 6px" }}>·</span>
+            <span style={{ color: "var(--fg1)" }}>{c.calls} {c.calls === 1 ? "call" : "calls"}</span>
+          </span>
+          <ModelCell models={c.models}/>
         </a>
       );
     }
+
+    // Shared by ConvRow and its header so the columns stay aligned:
+    // Last activity · Conversation · Agent · Cost · Tokens · Duration · Models.
+    // Agent shows the host launcher only (claude-code, …) — not the per-
+    // subagent rows, which were the noise; subagent presence is the ⊂N badge.
+    const CONV_GRID = "84px minmax(260px, 1.7fr) 132px 80px 96px 136px 176px";
 
     // SortHeader is a clickable list-header cell: click sorts by the
     // column, clicking again flips the direction.
@@ -836,7 +1320,7 @@
     // optional progress bar, and a sub line.
     function KpiTile({ label, value, valueColor, sub, dot, bar }) {
       return (
-        <div style={{ background: "var(--bg-primary)", border: "1px solid var(--border-weak)", borderRadius: 2, padding: "14px 16px", display: "flex", flexDirection: "column", gap: 7 }}>
+        <SurfaceCard style={{ padding: "14px 16px", display: "flex", flexDirection: "column", gap: 7, minHeight: 104 }}>
           <span style={{ fontSize: 11, color: "var(--fg3)" }}>{label}</span>
           <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
             {dot && <span style={{ width: 8, height: 8, borderRadius: "50%", background: dot, flexShrink: 0 }}/>}
@@ -848,7 +1332,7 @@
             </span>
           )}
           {sub != null && <span style={{ fontSize: 11, color: "var(--fg2)" }}>{sub}</span>}
-        </div>
+        </SurfaceCard>
       );
     }
 
@@ -861,22 +1345,112 @@
     function KpiStrip({ kpi }) {
       const avg = kpi.avgCalls.toFixed(1).replace(/\.0$/, "");
       return (
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(5, 1fr)", gap: 12, marginBottom: 16 }}>
-          <KpiTile label="Conversations" value={kpi.conversations} sub={kpi.conversationsSub}/>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(6, 1fr)", gap: 12, marginBottom: 16 }}>
+          <KpiTile label="Sessions" value={kpi.conversations} sub={kpi.conversationsSub}/>
+          <KpiTile label="Total cost" value={formatCost(kpi.cost)} sub={kpi.costSub}/>
           <KpiTile label="Total tokens" value={formatTokens(kpi.tokens)} sub={`${kpi.models} ${kpi.models === 1 ? "model" : "models"}`}/>
-          <KpiTile label="Cache hit rate" value={kpi.cachePct == null ? "\u2014" : `${kpi.cachePct}%`} bar={kpi.cachePct == null ? 0 : kpi.cachePct}/>
-          <KpiTile label="Tool calls" value={kpi.calls} sub={`${avg} avg / conversation`}/>
-          <KpiTile label="Errored conversations" value={kpi.errConvs}
+          <KpiTile label="Input cache hit" value={kpi.cachePct == null ? "\u2014" : `${kpi.cachePct}%`} bar={kpi.cachePct == null ? 0 : kpi.cachePct}/>
+          <KpiTile label="Tool calls" value={kpi.calls} sub={`${avg} avg / session`}/>
+          <KpiTile label="Errored sessions" value={kpi.errConvs}
             valueColor={kpi.errConvs > 0 ? "var(--error-text)" : "var(--fg-max)"}
             dot={kpi.errConvs > 0 ? "var(--error-text)" : undefined}
-            sub={`${kpi.errPct}% of conversations`}/>
+            sub={`${kpi.errPct}% of sessions`}/>
         </div>
       );
     }
 
-    function ConversationsView({ conversations, tokenPoints, loading, error, query, setQuery, timeRange, setTimeRange, tokenModel, setTokenModel, chartMetric, setChartMetric, bucketSel, setBucketSel, listSort, setListSort, onOpen, onRefresh, refreshing }) {
+    // WorkspaceSidebar is the landing page's primary navigation: one row per
+    // cwd in the current time range, each showing conversation count and
+    // estimated cost, with an "All" row on top. Selecting one filters the
+    // list, charts, and KPIs. Rows are sorted by most-recent activity so the
+    // workspace you're in now sits near the top.
+    // A workspace row reads like an observability leaderboard entry: name,
+    // count + estimated cost, and a thin bar showing this workspace's share
+    // of total spend. The "All" summary row is the full-bar reference and
+    // carries a heavier label. Selection tints the bar + left edge orange.
+    function WorkspaceItem({ label, title, count, cost, active, onClick, share, summary }) {
+      const pct = share > 0 ? Math.max(3, Math.min(100, Math.round(share * 100))) : 0;
+      return (
+        <button onClick={onClick} title={title}
+          style={{
+            display: "flex", flexDirection: "column", gap: 6,
+            width: "100%", textAlign: "left",
+            padding: "9px 11px",
+            border: "1px solid var(--border-weak)",
+            borderLeft: `2px solid ${active ? "var(--brand-orange)" : "var(--border-weak)"}`,
+            borderRadius: 8,
+            background: active ? ACTIVE_PILL_BG : "rgba(24,27,31,0.68)",
+            color: "inherit", cursor: "pointer", font: "inherit",
+            transition: "background 80ms ease, border-color 80ms ease",
+          }}
+          onMouseEnter={e => { if (!active) e.currentTarget.style.background = "rgba(204,204,220,0.04)"; }}
+          onMouseLeave={e => { if (!active) e.currentTarget.style.background = "rgba(24,27,31,0.68)"; }}>
+          <span style={{
+            fontFamily: "var(--fontFamily)", fontSize: 12.5, fontWeight: summary ? 600 : 400,
+            color: active ? "var(--fg1)" : "var(--fg2)",
+            overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+          }}>{label}</span>
+          <span style={{ display: "flex", alignItems: "center", gap: 8, fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--fg3)" }}>
+            <span>{count} {count === 1 ? "session" : "sessions"}</span>
+            <span style={{ marginLeft: "auto", color: active ? "var(--fg1)" : "var(--fg2)" }}>{formatCost(cost)}</span>
+          </span>
+          <span style={{ display: "block", height: 3, borderRadius: 2, background: "rgba(204,204,220,0.08)", overflow: "hidden" }}>
+            <span style={{
+              display: "block", height: "100%", width: `${pct}%`,
+              background: active ? "var(--brand-orange)" : "rgba(204,204,220,0.28)",
+              transition: "width 220ms ease",
+            }}/>
+          </span>
+        </button>
+      );
+    }
+
+    function WorkspaceSidebar({ workspaces, selected, onSelect, totalCount, totalCost }) {
+      return (
+        <div style={{
+          width: 248, flexShrink: 0,
+          borderRight: "1px solid var(--border-weak)",
+          background: "var(--bg-primary)",
+          display: "flex", flexDirection: "column",
+          maxHeight: `calc(100vh - ${HEADER_H}px)`, position: "sticky", top: HEADER_H,
+        }}>
+          {/* 34px caption slot: the first card below starts at the same
+             vertical offset as the search bar in the content column. */}
+          <div style={{ height: 34, padding: "14px 16px 0", display: "flex", alignItems: "flex-start", lineHeight: "14px", fontSize: 11, letterSpacing: "0.06em", color: "var(--fg3)", fontWeight: 500, textTransform: "uppercase" }}>
+            Workspaces
+          </div>
+          <div style={{ overflowY: "auto", padding: "0 8px 12px", display: "flex", flexDirection: "column", gap: 6 }}>
+            <WorkspaceItem label="All workspaces" title="All workspaces" count={totalCount} cost={totalCost}
+              share={1} summary active={selected == null} onClick={() => onSelect(null)}/>
+            {workspaces.map(w => (
+              <WorkspaceItem key={w.path || "(unknown)"} label={workspaceLabel(w.path)} title={w.path || "(unknown)"}
+                count={w.count} cost={w.cost} share={totalCost > 0 ? (w.cost || 0) / totalCost : 0}
+                active={selected === w.path} onClick={() => onSelect(w.path)}/>
+            ))}
+          </div>
+        </div>
+      );
+    }
+
+    function ConversationsView({ conversations, tokenPoints, loading, error, query, setQuery, searchInputRef, timeRange, setTimeRange, tokenModel, setTokenModel, chartMetric, setChartMetric, bucketSel, setBucketSel, listSort, setListSort, onOpen, onRefresh, refreshing }) {
       const now = Date.now();
+      const prices = useModelPrices();
       const range = timeRangeOption(timeRange);
+      const trimmedQuery = query.trim();
+      const searchActive = trimmedQuery.length > 0;
+      const search = useSearchResults(query);
+      const {
+        phase: searchPhase,
+        hits: searchHits,
+        mode: searchMode,
+        error: searchError,
+        selectedIndex: searchSelectedIndex,
+        setSelectedIndex: setSearchSelectedIndex,
+        retry: retrySearch,
+      } = search;
+      const [agentFilter, setAgentFilter] = useState("all");
+      const [modelFilter, setModelFilter] = useState("all");
+      const [statusFilter, setStatusFilter] = useState("all");
       const rangeFiltered = useMemo(() => {
         if (range.ms == null) return conversations;
         const from = now - range.ms;
@@ -885,16 +1459,116 @@
           return t != null && t >= from && t <= now;
         });
       }, [conversations, range.ms, now]);
+
+      // Workspace facet, derived from the time-range set (not the search or
+      // the selected workspace, so the rail stays stable while you browse).
+      // Sorted by most-recent activity so the workspace you're in now floats
+      // up. Selecting one narrows the list, charts, and KPIs alike.
+      // ponytail: local state — resets on navigate-away. Lift to App alongside
+      // bucketSel if cross-navigation persistence is wanted.
+      const [workspace, setWorkspace] = useState(null);
+      const workspaces = useMemo(() => {
+        const map = new Map();
+        for (const c of rangeFiltered) {
+          const w = c.workspace || "";
+          let e = map.get(w);
+          if (!e) { e = { path: w, count: 0, cost: 0, last: 0 }; map.set(w, e); }
+          e.count++;
+          e.cost += conversationCost(c, prices) || 0;
+          const t = conversationTime(c);
+          if (t != null && t > e.last) e.last = t;
+        }
+        return [...map.values()].sort((a, b) => b.last - a.last);
+      }, [rangeFiltered, prices]);
+      const totalCost = useMemo(() => rangeFiltered.reduce((s, c) => s + (conversationCost(c, prices) || 0), 0), [rangeFiltered, prices]);
+      // A selected workspace that vanishes from the set (range change) falls
+      // back to "all" by derivation, mirroring the token-model fallback.
+      const activeWorkspace = workspace != null && workspaces.some(w => w.path === workspace) ? workspace : null;
+      const wsFiltered = useMemo(
+        () => activeWorkspace == null ? rangeFiltered : rangeFiltered.filter(c => (c.workspace || "") === activeWorkspace),
+        [rangeFiltered, activeWorkspace]
+      );
+
+      const agentOptions = useMemo(() => {
+        const set = new Set();
+        for (const c of wsFiltered) for (const a of agentHosts(c.agents)) set.add(a);
+        return [...set].sort();
+      }, [wsFiltered]);
+      const activeAgentFilter = agentOptions.includes(agentFilter) ? agentFilter : "all";
+
+      const modelFacetOptions = useMemo(() => {
+        const set = new Set();
+        for (const c of wsFiltered) for (const m of c.models || []) if (m) set.add(m);
+        return [...set].sort();
+      }, [wsFiltered]);
+      const activeModelFilter = modelFacetOptions.includes(modelFilter) ? modelFilter : "all";
+      const activeStatusFilter = statusFilter === "errors" || statusFilter === "subagents" ? statusFilter : "all";
+
       const filtered = useMemo(() => {
-        if (!query) return rangeFiltered;
-        const q = query.toLowerCase();
-        return rangeFiltered.filter(c =>
-          c.id.toLowerCase().includes(q)
-          || (c.title || "").toLowerCase().includes(q)
-          || (c.agents || []).some(a => a.toLowerCase().includes(q))
-          || (c.models || []).some(m => m.toLowerCase().includes(q))
-        );
-      }, [rangeFiltered, query]);
+        return wsFiltered.filter(c => {
+          if (activeAgentFilter !== "all" && !agentHosts(c.agents).includes(activeAgentFilter)) return false;
+          if (activeModelFilter !== "all" && !(c.models || []).includes(activeModelFilter)) return false;
+          if (activeStatusFilter === "errors" && c.status !== "err") return false;
+          if (activeStatusFilter === "subagents" && !(c.subagents > 0)) return false;
+          return true;
+        });
+      }, [wsFiltered, activeAgentFilter, activeModelFilter, activeStatusFilter]);
+
+      const activeFilterCount = (activeAgentFilter !== "all" ? 1 : 0)
+        + (activeModelFilter !== "all" ? 1 : 0)
+        + (activeStatusFilter !== "all" ? 1 : 0);
+      const clearFilters = useCallback(() => {
+        setAgentFilter("all");
+        setModelFilter("all");
+        setStatusFilter("all");
+      }, []);
+      const clearSearch = useCallback(() => {
+        setQuery("");
+        setTimeout(() => {
+          const el = searchInputRef && searchInputRef.current;
+          if (el) el.focus();
+        }, 0);
+      }, [setQuery, searchInputRef]);
+      const onSearchInputKey = useCallback((e) => {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          clearSearch();
+          return;
+        }
+        if (!searchActive || searchHits.length === 0) return;
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          setSearchSelectedIndex(i => Math.min(searchHits.length - 1, i < 0 ? 0 : i + 1));
+        } else if (e.key === "ArrowUp") {
+          e.preventDefault();
+          setSearchSelectedIndex(i => Math.max(-1, i - 1));
+        } else if (e.key === "Enter" && searchSelectedIndex >= 0) {
+          e.preventDefault();
+          const hit = searchHits[searchSelectedIndex];
+          if (hit) onOpen({ id: hit.id, title: hit.title });
+        }
+      }, [clearSearch, searchActive, searchHits, searchSelectedIndex, setSearchSelectedIndex, onOpen]);
+      const searchRightAdornment = searchPhase === "loading" ? (
+        <span className="sigil-spin" style={{
+          width: 14, height: 14, borderRadius: "50%",
+          border: "2px solid var(--border-strong)", borderTopColor: "var(--fg2)",
+          display: "inline-block",
+        }} aria-label="Searching"/>
+      ) : searchActive ? (
+        <button type="button" onClick={clearSearch}
+          aria-label="Clear search"
+          title="Clear search"
+          style={{
+            width: 22, height: 22, display: "inline-flex", alignItems: "center", justifyContent: "center",
+            background: "transparent", border: "none", color: "var(--fg3)", cursor: "pointer", borderRadius: 2,
+          }}
+          onMouseEnter={e => { e.currentTarget.style.background = "var(--action-hover)"; e.currentTarget.style.color = "var(--fg1)"; }}
+          onMouseLeave={e => { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = "var(--fg3)"; }}>
+          <Icon name="times" size={14}/>
+        </button>
+      ) : (
+        <span title="Press Command-K or Control-K to focus search" style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--fg3)", padding: "1px 6px", border: "1px solid var(--border-weak)", borderRadius: 999 }}>⌘K</span>
+      );
 
       // Token chart has its own model filter and is driven only by the
       // time range, not the text query (token points carry model, not the
@@ -935,22 +1609,6 @@
         () => bucketTokenUsage(tokenFiltered, timeRange, now, { window: chartWindow }),
         [tokenFiltered, timeRange, now, chartWindow]
       );
-      // Distinct models that actually produced tokens inside the visible
-      // window. tokenModels spans the whole store (so the dropdown can
-      // still offer every model), but the headline count must agree with
-      // the windowed token total beside it — otherwise a 6h view reports
-      // models that only appear in older conversations.
-      const windowModelCount = useMemo(() => {
-        const seen = new Set();
-        for (const p of points) {
-          if (!p.model) continue;
-          const t = tokenPointTime(p);
-          if (!Number.isFinite(t) || t < chartWindow.start || t > chartWindow.end) continue;
-          seen.add(p.model);
-        }
-        return seen.size;
-      }, [points, chartWindow]);
-
       // Bucket drill-down from a chart bar click: the list narrows to
       // conversations active inside the picked bucket, while the charts
       // keep the full window and just highlight the selection.
@@ -979,58 +1637,117 @@
             return d == null ? -1 : d;
           }
           if (listSort.key === "tokens") return c.total_tokens || 0;
+          if (listSort.key === "cost") return conversationCost(c, prices) || 0;
           const t = conversationTime(c);
           return t == null ? 0 : t;
         };
         return [...listFiltered].sort((a, b) => (val(a) - val(b)) * dir);
-      }, [listFiltered, listSort]);
+      }, [listFiltered, listSort, prices]);
 
-      // KPI tiles read the range + search set (not the bucket drill-down).
-      // Conversation, tool-call and error counts come from that set; token
-      // and cache numbers come from the same series the chart draws, so the
-      // headline tokens always match the chart below, including its model
-      // dropdown and legend toggles. Conversation rows carry no per-model
-      // token breakdown, so that can only be honoured via the token series.
+      // KPI tiles read the range + workspace + search set (not the bucket
+      // drill-down), computed straight off each conversation's token buckets.
+      // This keeps the headline tokens, cost, and cache rate in agreement
+      // with the workspace rail and the rows below — all conversation-based —
+      // rather than the token-series chart, which keeps its own model filter.
       const kpi = useMemo(() => {
-        let calls = 0, errConvs = 0;
+        let calls = 0, errConvs = 0, cost = 0, priced = 0, unpriced = 0;
+        const tot = { fresh_input: 0, cache_read: 0, cache_write: 0, output: 0, reasoning: 0 };
+        const models = new Set();
         for (const c of filtered) {
           calls += c.calls || 0;
           if (c.status === "err") errConvs++;
+          const cc = conversationCost(c, prices);
+          if (cc == null) unpriced++; else { cost += cc; priced++; }
+          const b = c.token_buckets;
+          if (b) for (const k in tot) tot[k] += b[k] || 0;
+          for (const m of c.models || []) models.add(m);
         }
-        // Sum only the series the chart is currently showing, so hiding one
-        // in the legend pulls it out of the headline total too.
-        let tokens = 0;
-        for (const s of TOKEN_SERIES) {
-          if (!hiddenSeries.has(s.key)) tokens += tokenUsage.totals[s.key] || 0;
-        }
-        const fresh = tokenUsage.totals.fresh_input || 0;
-        const cacheRead = tokenUsage.totals.cache_read || 0;
-        const cacheDenom = fresh + cacheRead;
-        // Hiding either side of the ratio makes the rate meaningless, so
-        // blank it out the way the old chart header did. Otherwise only
-        // report a flat 100% when there is literally no fresh input; cap at
-        // 99% so 99.99% (a few fresh tokens against a huge cache) doesn't
-        // round up and read as a perfect cache.
-        const cacheHidden = hiddenSeries.has("fresh_input") || hiddenSeries.has("cache_read");
-        const cachePct = cacheHidden || cacheDenom === 0 ? null
-          : cacheRead === cacheDenom ? 100
-          : Math.min(99, Math.round((cacheRead / cacheDenom) * 100));
+        const tokens = tot.fresh_input + tot.cache_read + tot.cache_write + tot.output + tot.reasoning;
+        // Cost sub is honest about coverage: if some conversations ran on an
+        // unpriced (non-Anthropic) model, say so rather than implying the
+        // total covers everything.
+        const costSub = unpriced > 0
+          ? `${unpriced} unpriced · ${formatCost(priced ? cost / priced : 0)} avg`
+          : cost ? `${formatCost(cost / Math.max(1, priced))} avg / session` : "estimated";
         return {
           conversations: filtered.length,
-          conversationsSub: query ? "matching filter" : "active in range",
+          conversationsSub: activeWorkspace ? "in workspace" : "active in range",
           tokens,
-          models: effectiveModel === "all" ? windowModelCount : 1,
-          cachePct,
+          cost: priced ? cost : null,  // nothing priced → "—", not a misleading $0
+          costSub,
+          models: models.size,
+          cachePct: cacheInputHitPercent(tot.fresh_input, tot.cache_read, tot.cache_write),
           calls,
           avgCalls: filtered.length ? calls / filtered.length : 0,
           errConvs,
           errPct: filtered.length ? Math.round((errConvs / filtered.length) * 100) : 0,
         };
-      }, [filtered, tokenUsage, windowModelCount, effectiveModel, query, hiddenSeries]);
+      }, [filtered, activeWorkspace, prices]);
 
       return (
-        <div style={{ padding: 24, maxWidth: 1600, margin: "0 auto" }}>
-          <FilterBar query={query} onQueryChange={setQuery} timeRange={timeRange} onTimeRangeChange={setTimeRange} onRefresh={onRefresh} refreshing={refreshing}/>
+        <Stack direction="row" align="flex-start" style={{ width: "100%" }}>
+          {!searchActive && (
+            <WorkspaceSidebar workspaces={workspaces} selected={activeWorkspace} onSelect={setWorkspace}
+              totalCount={rangeFiltered.length} totalCost={totalCost}/>
+          )}
+          <PageShell maxWidth={1400} style={{ flex: 1, minWidth: 0 }}>
+          <PageHero
+            icon="list"
+            kicker="Local sessions"
+            title="Sessions"
+            desc={searchActive
+              ? "Search captured prompts, responses, and tool output across local sessions."
+              : "Review captured sessions, token usage, costs, and tool-call activity from local runs."}
+            chips={searchActive ? [
+              { label: "Index", value: searchMode === "semantic" ? "QMD" : "FTS", tone: "var(--primary-text)" },
+              { label: "Results", value: String(searchHits.length), tone: searchHits.length ? "var(--success-text)" : "var(--fg2)" },
+              { label: "Status", value: searchPhase === "loading" ? "Searching" : "Ready", tone: searchPhase === "loading" ? "var(--warning-text)" : "var(--fg2)" },
+            ] : [
+              { label: "Range", value: range.label, tone: "var(--fg2)" },
+              { label: "Workspaces", value: String(workspaces.length), tone: "var(--primary-text)" },
+              { label: "Cost", value: formatCost(totalCost), tone: "var(--brand-orange-text)" },
+            ]}>
+            <Box style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--fg3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {searchActive ? "Full-text search runs across all captured sessions." : "Local traces, token accounting, and model usage from this viewer."}
+            </Box>
+          </PageHero>
+          <FilterBar
+            query={query}
+            onQueryChange={setQuery}
+            inputRef={searchInputRef}
+            timeRange={searchActive ? null : timeRange}
+            onTimeRangeChange={searchActive ? null : setTimeRange}
+            agentFilter={searchActive ? undefined : activeAgentFilter}
+            onAgentFilterChange={searchActive ? undefined : setAgentFilter}
+            agentOptions={searchActive ? [] : agentOptions}
+            modelFilter={searchActive ? undefined : activeModelFilter}
+            onModelFilterChange={searchActive ? undefined : setModelFilter}
+            modelOptions={searchActive ? [] : modelFacetOptions}
+            statusFilter={searchActive ? undefined : activeStatusFilter}
+            onStatusFilterChange={searchActive ? undefined : setStatusFilter}
+            activeFilterCount={searchActive ? 0 : activeFilterCount}
+            onClearFilters={clearFilters}
+            onRefresh={onRefresh}
+            refreshing={refreshing}
+            placeholder="Search prompts, responses, tool output, title, agent, model…"
+            onInputKeyDown={onSearchInputKey}
+            rightAdornment={searchRightAdornment}
+          />
+          {searchActive ? (
+            <ConversationSearchPanel
+              query={trimmedQuery}
+              hits={searchHits}
+              phase={searchPhase}
+              mode={searchMode}
+              error={searchError}
+              selectedIndex={searchSelectedIndex}
+              setSelectedIndex={setSearchSelectedIndex}
+              retry={retrySearch}
+              now={now}
+              onOpen={onOpen}
+            />
+          ) : (
+          <React.Fragment>
           <KpiStrip kpi={kpi}/>
           {chartMetric === "activity"
             ? <ActivityChart data={activity.buckets} bucketLabel={activity.bucketLabel}
@@ -1053,16 +1770,13 @@
             </div>
           )}
 
-          <div style={{
+          <SurfaceCard style={{
             marginTop: 18,
-            border: "1px solid var(--border-weak)",
-            borderRadius: 2,
             overflow: "hidden",
-            background: "var(--bg-primary)",
           }}>
             <div style={{
               display: "grid",
-              gridTemplateColumns: "110px minmax(280px, 1.6fr) 150px 110px 130px 200px",
+              gridTemplateColumns: CONV_GRID,
               alignItems: "center", gap: 16,
               padding: "11px 16px 11px 19px",
               borderBottom: "1px solid var(--border-weak)",
@@ -1070,15 +1784,17 @@
               fontFamily: "var(--fontFamily)", fontSize: 12, color: "var(--fg3)", fontWeight: 500,
             }}>
               <SortHeader label="Last activity" sortKey="last_activity" sort={listSort} onSort={handleSort}/>
-              <span>Conversation</span>
-              <SortHeader label="Duration" sortKey="duration" sort={listSort} onSort={handleSort}/>
+              <span>Session</span>
+              <span>Agent</span>
+              <SortHeader label="Cost" sortKey="cost" sort={listSort} onSort={handleSort}/>
               <SortHeader label="Tokens" sortKey="tokens" sort={listSort} onSort={handleSort}/>
-              <span>Agents</span><span>Models</span>
+              <SortHeader label="Duration" sortKey="duration" sort={listSort} onSort={handleSort}/>
+              <span>Models</span>
             </div>
 
             {error && (
               <div style={{ padding: 16 }}>
-                <Notice kind="error" title="Failed to load conversations">{error}</Notice>
+                <Notice kind="error" title="Failed to load sessions">{error}</Notice>
               </div>
             )}
             {!error && loading && conversations.length === 0 && (
@@ -1086,37 +1802,41 @@
             )}
             {!error && !loading && conversations.length === 0 && (
               <div style={{ padding: 16 }}>
-                <Notice kind="info" title="No conversations yet">
+                <Notice kind="info" title="No sessions yet">
                   Run an agent against this daemon with <code style={{ color: "var(--fg1)" }}>agento11y pi --local</code> or <code style={{ color: "var(--fg1)" }}>agento11y claude --local</code>. Captured generations appear here as soon as the agent emits its first one.
                 </Notice>
               </div>
             )}
             {!error && conversations.length > 0 && rangeFiltered.length === 0 && (
               <div style={{ padding: "16px 18px", color: "var(--fg2)", fontSize: 12 }}>
-                No conversations in <code style={{ color: "var(--fg1)" }}>{range.label}</code>.
+                No sessions in <code style={{ color: "var(--fg1)" }}>{range.label}</code>.
               </div>
             )}
             {!error && filtered.length === 0 && rangeFiltered.length > 0 && (
               <div style={{ padding: "16px 18px", color: "var(--fg2)", fontSize: 12 }}>
-                No matches for <code style={{ color: "var(--fg1)" }}>{query}</code>.
+                No sessions match the current filters.
               </div>
             )}
             {!error && bucketSel && listFiltered.length === 0 && filtered.length > 0 && (
               <div style={{ padding: "16px 18px", color: "var(--fg2)", fontSize: 12 }}>
-                No conversations in the selected bucket.
+                No sessions in the selected bucket.
               </div>
             )}
-            {sorted.map(c => <ConvRow key={c.id} c={c} now={now} onOpen={onOpen}/>)}
-          </div>
+            {sorted.map(c => <ConvRow key={c.id} c={c} now={now} onOpen={onOpen} prices={prices}/>)}
+          </SurfaceCard>
 
           <div style={{
             marginTop: 14, padding: "10px 14px",
             fontSize: 11, color: "var(--fg3)",
             fontFamily: "var(--fontFamilyMonospace)",
           }}>
-            {sorted.length} of {filtered.length} {filtered.length === 1 ? "conversation" : "conversations"}
+            {sorted.length} of {filtered.length} {filtered.length === 1 ? "session" : "sessions"}
+            {activeFilterCount > 0 ? ` · ${activeFilterCount} ${activeFilterCount === 1 ? "filter" : "filters"} active` : ""}
           </div>
-        </div>
+          </React.Fragment>
+          )}
+          </PageShell>
+        </Stack>
       );
     }
 
@@ -1133,35 +1853,52 @@
     // MessageBubble renders one captured message (user / assistant / tool)
     // with its visible parts. The label and accent colour come from the role;
     // unknown roles fall back to a neutral grey label.
+    // partKind normalises a part to its kind, tolerating the shorthand shape
+    // where the kind is implied by which field is set.
+    function partKind(p) {
+      return p.kind || (p.text ? "text" : p.thinking ? "thinking" : p.tool_call ? "tool_call" : p.tool_result ? "tool_result" : "unknown");
+    }
+
+    // segMeta maps a (role, kind) to its block accent and label. Each part of
+    // a message renders as its own block, so the assistant's prose, its
+    // reasoning, and each tool call are visually distinct instead of sharing
+    // one "TOOL CALL" header. Tool call/result blocks carry their own inline
+    // header (→ name / ← result), so they need no separate label.
+    function segMeta(role, kind) {
+      if (kind === "thinking")    return { label: "",           color: "var(--viz-blue)" };
+      if (kind === "tool_call")   return { label: "",           color: "var(--warning-text)" };
+      if (kind === "tool_result") return { label: "",           color: "var(--viz-purple)" };
+      if (role === "user")        return { label: "USER",       color: "var(--viz-green)" };
+      if (role === "tool")        return { label: "",           color: "var(--viz-purple)" };
+      return { label: "ASSISTANT", color: "var(--brand-orange)" };
+    }
+
+    // partHasContent skips empties so we never draw a labelled block around
+    // nothing (e.g. an empty text part, or imported thinking whose content
+    // Claude Code didn't persist).
+    function partHasContent(p, kind) {
+      if (kind === "text") return !!(p.text || "").trim();
+      if (kind === "thinking") return !!(p.thinking || "").trim();
+      if (kind === "tool_call") return !!p.tool_call;
+      if (kind === "tool_result") return !!p.tool_result;
+      return false;
+    }
+
     function MessageBubble({ msg }) {
-      const isUser = msg.role === "user";
-      const isTool = msg.role === "tool";
-      const parts = msg.parts || [];
-      const isToolCall = !isUser && !isTool && parts.some(p => (p.kind === "tool_call") || p.tool_call);
-      // Role accents come straight from Grafana's brand secondary
-      // palette: green for the user (input side), purple for tool
-      // results, orange for the assistant so the primary brand colour
-      // attaches to the agent's own output.
-      const labelColor = isUser ? "var(--viz-green)" : (isTool ? "var(--viz-purple)" : (isToolCall ? "var(--warning-text)" : "var(--brand-orange)"));
-      const label = isTool ? "TOOL RESULT" : (isToolCall ? "TOOL CALL" : ((msg.role || "").toUpperCase() || "MESSAGE"));
-      return (
-        <div style={{
-          borderLeft: `2px solid ${labelColor}`,
-          padding: "6px 12px",
-          background: "var(--bg-canvas)",
-          borderRadius: 2,
-          marginBottom: 6,
-        }}>
-          <div style={{
-            fontFamily: "var(--fontFamilyMonospace)", fontSize: 10,
-            color: labelColor, letterSpacing: "0.08em", marginBottom: 4,
-          }}>{label}</div>
-          {parts.length === 0 && (
-            <div style={{ color: "var(--fg3)", fontSize: 12, fontStyle: "italic" }}>(no parts captured)</div>
-          )}
-          {parts.map((p, i) => <MessagePart key={i} part={p}/>)}
-        </div>
-      );
+      const role = msg.role || "";
+      const parts = (msg.parts || []).map(p => ({ p, kind: partKind(p) })).filter(({ p, kind }) => partHasContent(p, kind));
+      if (parts.length === 0) return null;
+      return parts.map(({ p, kind }, i) => {
+        const meta = segMeta(role, kind);
+        return (
+          <div key={i} style={{ borderLeft: `2px solid ${meta.color}`, padding: "6px 12px", background: "var(--bg-canvas)", borderRadius: 2, marginBottom: 6 }}>
+            {meta.label && (
+              <div style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 10, color: meta.color, letterSpacing: "0.08em", marginBottom: 4 }}>{meta.label}</div>
+            )}
+            <MessagePart part={p}/>
+          </div>
+        );
+      });
     }
 
     // ThinkingPart collapses a thinking block to a single toggle line so
@@ -1171,12 +1908,12 @@
     function ThinkingPart({ text }) {
       const [open, setOpen] = useState(false);
       return (
-        <div style={{ marginTop: 4 }}>
-          <div onClick={() => setOpen(o => !o)} style={{ display: "inline-flex", alignItems: "center", gap: 6, cursor: "pointer", color: "var(--fg3)", fontSize: 11, fontFamily: "var(--fontFamilyMonospace)" }}>
-            <Icon name={open ? "chevron" : "cright"} size={10} style={{ color: "var(--fg3)" }}/>
-            Thinking
+        <div>
+          <div onClick={() => setOpen(o => !o)} style={{ display: "inline-flex", alignItems: "center", gap: 6, cursor: "pointer", color: "var(--viz-blue)", fontSize: 10, letterSpacing: "0.08em", fontFamily: "var(--fontFamilyMonospace)" }}>
+            <Icon name={open ? "chevron" : "cright"} size={10} style={{ color: "var(--viz-blue)" }}/>
+            REASONING
           </div>
-          {open && <div style={{ fontSize: 12, color: "var(--fg2)", whiteSpace: "pre-wrap", marginTop: 4, fontStyle: "italic" }}>{text}</div>}
+          {open && <div style={{ fontSize: 12.5, color: "var(--fg2)", whiteSpace: "pre-wrap", marginTop: 6, fontStyle: "italic" }}>{text}</div>}
         </div>
       );
     }
@@ -1203,6 +1940,51 @@
       );
     }
 
+    // toolCallArgPreview is the one-line essence of a tool call's input, shown
+    // on the collapsed chip: the command for Bash, else the first meaningful
+    // field (path/pattern/query/url), else the raw JSON — truncated.
+    function toolCallArgPreview(input) {
+      if (!input) return "";
+      if (typeof input === "string") return input.length > 140 ? input.slice(0, 140) + "…" : input;
+      for (const k of ["command", "file_path", "path", "pattern", "query", "url", "cmd", "name"]) {
+        if (input[k] != null && input[k] !== "") return String(input[k]).replace(/\s+/g, " ");
+      }
+      try { const s = JSON.stringify(input); return s.length > 140 ? s.slice(0, 140) + "…" : s; } catch (_) { return ""; }
+    }
+
+    // ToolCallPart renders one tool call as a compact, collapse-first chip — an
+    // arrow, the tool name, and a one-line preview of its input — that expands
+    // on click to the full command/args.
+    function ToolCallPart({ tc }) {
+      const [show, setShow] = useState(false);
+      const input = tc.input_json || null;
+      const command = tc.name === "Bash" && input && typeof input === "object" && input.command ? input.command : "";
+      const description = tc.name === "Bash" && input && typeof input === "object" && input.description ? input.description : "";
+      const args = input ? (typeof input === "string" ? input : JSON.stringify(input, null, 2)) : "";
+      const preview = command || toolCallArgPreview(input);
+      const hasBody = !!(command || args);
+
+      return (
+        <div style={{ marginTop: 4, position: "relative" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <button onClick={() => hasBody && setShow(s => !s)}
+              style={{ flex: 1, minWidth: 0, display: "flex", alignItems: "center", gap: 7, background: "transparent", border: "none", padding: 0, cursor: hasBody ? "pointer" : "default", textAlign: "left", fontFamily: "var(--fontFamilyMonospace)", fontSize: 11 }}>
+              {hasBody && <Icon name={show ? "chevron" : "cright"} size={10} style={{ color: "var(--fg3)", flex: "none" }}/>}
+              <span style={{ color: "var(--warning-text)", fontSize: 9.5, letterSpacing: "0.08em", flex: "none" }}>OUT</span>
+              <span style={{ color: "var(--fg1)", fontWeight: 600, flex: "none" }}>{tc.name}</span>
+              {preview && <span style={{ color: "var(--fg3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }}>{preview}</span>}
+            </button>
+          </div>
+          {show && description && <div style={{ marginTop: 4, color: "var(--fg2)", fontSize: 12 }}>{description}</div>}
+          {show && (command ? (
+            <CappedBlock lineCount={command.split("\n").length}><span style={{ color: "var(--warning-text)" }}>$</span> {command}</CappedBlock>
+          ) : args && (
+            <CappedBlock lineCount={args.split("\n").length} preStyle={{ fontSize: 11 }}>{args}</CappedBlock>
+          ))}
+        </div>
+      );
+    }
+
     // MessagePart picks a renderer per part kind. Text and thinking are
     // wrapped pre-line so newlines from the model render naturally;
     // tool calls and tool results show a compact label + payload so the
@@ -1218,40 +2000,37 @@
         return <ThinkingPart text={part.thinking}/>;
       }
       if (kind === "tool_call" && part.tool_call) {
-        const tc = part.tool_call;
-        const input = tc.input_json || null;
-        const command = tc.name === "Bash" && input && typeof input === "object" && input.command ? input.command : "";
-        const description = tc.name === "Bash" && input && typeof input === "object" && input.description ? input.description : "";
-        const args = input ? (typeof input === "string" ? input : JSON.stringify(input, null, 2)) : "";
-        return (
-          <div style={{ marginTop: 4 }}>
-            <div style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--warning-text)" }}>
-              → {tc.name}{tc.id ? <span style={{ color: "var(--fg3)" }}> · {tc.id}</span> : null}
-            </div>
-            {description && <div style={{ marginTop: 4, color: "var(--fg2)", fontSize: 12 }}>{description}</div>}
-            {command ? (
-              <CappedBlock lineCount={command.split("\n").length}><span style={{ color: "var(--warning-text)" }}>$</span> {command}</CappedBlock>
-            ) : args && (
-              <CappedBlock lineCount={args.split("\n").length} preStyle={{ fontSize: 11 }}>{args}</CappedBlock>
-            )}
-          </div>
-        );
+        return <ToolCallPart tc={part.tool_call}/>;
       }
       if (kind === "tool_result" && part.tool_result) {
-        const tr = part.tool_result;
-        const body = tr.content || (tr.content_json ? (typeof tr.content_json === "string" ? tr.content_json : JSON.stringify(tr.content_json)) : "");
-        const isErr = !!tr.is_error;
-        const lineCount = body ? body.split("\n").length : 0;
-        return (
-          <div style={{ marginTop: 4 }}>
-            <div style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: isErr ? "var(--error-text)" : "var(--fg2)" }}>
-              ← result{tr.tool_call_id ? <span style={{ color: "var(--fg3)" }}> · {tr.tool_call_id}</span> : null}{lineCount > 0 ? <span style={{ color: "var(--fg3)" }}> · {lineCount} {lineCount === 1 ? "line" : "lines"}</span> : null}{isErr ? <span style={{ color: "var(--error-text)" }}> · error</span> : null}
-            </div>
-            {body && <CappedBlock lineCount={lineCount} preStyle={{ fontSize: 11 }}>{body}</CappedBlock>}
-          </div>
-        );
+        return <ToolResultPart tr={part.tool_result}/>;
       }
       return null;
+    }
+
+    // ToolResultPart renders a tool result as a collapse-first chip matching the
+    // tool call: a left arrow, line count / error flag, and a one-line preview
+    // of the output, expanding on click to the full body. Errors open expanded
+    // since they're the thing you came to read.
+    function ToolResultPart({ tr }) {
+      const body = tr.content || (tr.content_json ? (typeof tr.content_json === "string" ? tr.content_json : JSON.stringify(tr.content_json)) : "");
+      const isErr = !!tr.is_error;
+      const [show, setShow] = useState(isErr);
+      const lineCount = body ? body.split("\n").length : 0;
+      const hasBody = !!body;
+      const firstLine = body ? body.split("\n").find(l => l.trim()) || "" : "";
+      return (
+        <div style={{ marginTop: 4 }}>
+          <button onClick={() => hasBody && setShow(s => !s)}
+            style={{ display: "flex", alignItems: "center", gap: 7, width: "100%", minWidth: 0, background: "transparent", border: "none", padding: 0, cursor: hasBody ? "pointer" : "default", textAlign: "left", fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: isErr ? "var(--error-text)" : "var(--fg2)" }}>
+            {hasBody && <Icon name={show ? "chevron" : "cright"} size={10} style={{ color: "var(--fg3)", flex: "none" }}/>}
+            <span style={{ color: "var(--viz-green)", fontSize: 9.5, letterSpacing: "0.08em", flex: "none" }}>IN</span>
+            <span style={{ flex: "none" }}>result{lineCount > 0 ? <span style={{ color: "var(--fg3)" }}> · {lineCount} {lineCount === 1 ? "line" : "lines"}</span> : null}{isErr ? <span style={{ color: "var(--error-text)" }}> · error</span> : null}</span>
+            {!show && firstLine && <span style={{ color: "var(--fg3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }}>{firstLine}</span>}
+          </button>
+          {show && body && <CappedBlock lineCount={lineCount} preStyle={{ fontSize: 11 }}>{body}</CappedBlock>}
+        </div>
+      );
     }
 
     // MessageThread renders the captured messages for one step. The API's
@@ -1308,102 +2087,159 @@
       );
     }
 
-    function StepCard({ step, n, expanded, onToggle, innerRef, flash }) {
+    // firstUserText returns the fresh user prompt in a step's input — a
+    // user-role message with text — distinguishing a human turn from tool
+    // results (role "tool"). A generation is the assistant's response to its
+    // input, so the input carries the question that triggered the step.
+    function firstUserText(step) {
+      for (const m of (step.input || [])) {
+        if (m.role !== "user") continue;
+        for (const p of (m.parts || [])) {
+          if (p.kind === "text" && (p.text || "").trim()) return p.text.trim();
+        }
+      }
+      return "";
+    }
+
+    // stepGlance reduces a step to the one-line essence shown in a collapsed
+    // row, role-aware: a step triggered by a human prompt leads with that
+    // question (role "user"); otherwise it shows the assistant's work — the
+    // tool it ran as a chip plus its leading prose, or its final answer. This
+    // makes the thread scan as a real conversation: user asks → agent works →
+    // agent answers.
+    function stepGlance(step, i, total, skipUser) {
+      const userText = skipUser ? "" : firstUserText(step);
+      if (userText) return { role: "user", tool: "", text: userText, mono: false };
+      const tool = (step.tools && step.tools[0]) || "";
+      const prose = leadingAssistantText(step);
+      let text = prose || step.tool_preview || "";
+      if (!text) text = i === 0 ? "Initial prompt" : (i === total - 1 ? "Final response" : "Response");
+      return { role: "assistant", tool, text, mono: !prose && !!step.tool_preview };
+    }
+
+    // StepDetailBody is the expanded content of a step: a light meta line,
+    // the token split, any call error, the message thread, and a bare tool
+    // preview when no rendered tool calls carry it. Shared by the thread row
+    // and any other place that needs to show a step in full.
+    function StepDetailBody({ step }) {
       const hasError = !!step.call_error;
-      const dotColor = hasError ? "var(--error-text)" : "#73BF69";
+      const hasReasoning = (step.messages || step.output || []).some(m => (m.parts || []).some(p => (p.kind === "thinking" || p.thinking) && (p.thinking || "").trim()));
+      const reasonedNoText = step.thinking_enabled && !hasReasoning;
       return (
-        <div ref={innerRef} className={flash ? "sigil-step-flash" : undefined} style={{
-          border: "1px solid var(--border-weak)",
-          borderLeft: hasError ? "2px solid var(--error-main)" : "1px solid var(--border-weak)",
-          borderRadius: 2,
-          background: "var(--bg-primary)",
-          marginBottom: 12,
-        }}>
-          <div onClick={onToggle} style={{
-            display: "flex", alignItems: "center", gap: 12,
-            padding: "10px 14px",
-            cursor: "pointer",
-            borderBottom: expanded ? "1px solid var(--border-weak)" : "none",
-          }}>
-            <span style={{
-              display: "inline-flex", alignItems: "center", gap: 6,
-              padding: "2px 8px",
-              background: "rgba(204,204,220,0.06)",
-              borderRadius: 2,
-              fontFamily: "var(--fontFamilyMonospace)",
-              fontSize: 10, color: "var(--fg2)", textTransform: "uppercase", letterSpacing: "0.08em",
-            }}>Step {n}</span>
-            <span style={{ display: "inline-flex", alignItems: "center", gap: 6, color: "var(--fg1)", fontSize: 12, minWidth: 0 }}>
-              <span style={{ width: 7, height: 7, borderRadius: "50%", background: dotColor, flexShrink: 0 }}/>
-              {step.agent_name && <AgentPill name={step.agent_name} size="sm"/>}
-              {step.model && (
-                <span style={{ fontFamily: "var(--fontFamilyMonospace)", color: "var(--fg2)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{step.model}</span>
-              )}
-            </span>
-            {hasError && (
-              <span style={{ display: "inline-flex", alignItems: "center", height: 16, padding: "0 6px", borderRadius: 2, background: "var(--error-transparent)", color: "var(--error-text)", fontFamily: "var(--fontFamilyMonospace)", fontSize: 10, letterSpacing: "0.04em" }}>error</span>
-            )}
-            <span style={{ flex: 1 }}/>
-            <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--fg2)", display: "flex", gap: 12, whiteSpace: "nowrap", flexShrink: 0 }}>
-              <span>{formatDuration(step.duration_seconds)}</span>
-              <span>{formatTokens(step.total_tokens)} tok</span>
-            </span>
-            <Icon name={expanded ? "chevron" : "cright"} size={13} style={{ color: "var(--fg3)" }}/>
+        <div style={{ padding: "12px 16px 16px", background: "var(--bg-canvas)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 12, color: "var(--fg3)", fontSize: 11, fontFamily: "var(--fontFamilyMonospace)", flexWrap: "wrap" }}>
+            {step.model && <span style={{ color: "var(--fg2)" }}>{step.model}</span>}
+            <span>{formatTime(step.completed_at || step.started_at)}</span>
+            <span>{(step.tools || []).length} {(step.tools || []).length === 1 ? "tool" : "tools"}</span>
+            {step.provider && <span>{step.provider}</span>}
+            {step.stop_reason && <span>{step.stop_reason}</span>}
+            {hasReasoning && <span style={{ color: "var(--viz-blue)" }}>reasoning</span>}
+            {reasonedNoText && <span title="The model reasoned on this step, but Claude Code does not persist reasoning text to its transcript.">reasoning · not recorded</span>}
           </div>
-          {expanded && (
-            <div style={{ padding: "12px 14px 14px" }}>
-              <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 10, color: "var(--fg2)", fontSize: 12, flexWrap: "wrap" }}>
-                <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontFamily: "var(--fontFamilyMonospace)" }}>
-                  <span style={{ width: 18, height: 18, borderRadius: 2, background: "rgba(115,191,105,0.18)", color: "#73BF69", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 10 }}>{agentBadge(step.agent_name)}</span>
-                  <span style={{ color: "var(--fg2)" }}>{formatTime(step.completed_at || step.started_at)}</span>
-                </span>
-                <span style={{ display: "inline-flex", alignItems: "center", gap: 6, color: "var(--fg2)", fontFamily: "var(--fontFamilyMonospace)" }}>
-                  <Icon name="wrench" size={11}/>
-                  tools · {(step.tools || []).length}
-                </span>
-                {step.provider && (
-                  <span style={{ color: "var(--fg3)", fontFamily: "var(--fontFamilyMonospace)" }}>provider · {step.provider}</span>
-                )}
-              </div>
-
-              <StepTokenBar buckets={step.token_buckets}/>
-
-              {hasError && (
-                <div style={{ marginBottom: 10 }}>
-                  <Notice kind="error" title="Call error">{step.call_error}</Notice>
-                </div>
-              )}
-
-              <MessageThread step={step}/>
-
-              {step.tool_preview && !(step.output || []).some(m => (m.parts || []).some(p => p.kind === "tool_call" || p.tool_call)) && (
-                <div style={{
-                  background: "var(--bg-canvas)",
-                  border: "1px solid var(--border-weak)",
-                  borderRadius: 2,
-                  padding: "8px 12px",
-                  marginTop: 10,
-                  fontFamily: "var(--fontFamilyMonospace)", fontSize: 12,
-                  color: "var(--fg2)",
-                  display: "flex", alignItems: "flex-start", gap: 8,
-                }}>
-                  <span style={{ color: "var(--warning-text)" }}>$</span>
-                  <code style={{ color: "var(--fg1)", whiteSpace: "pre-wrap", wordBreak: "break-all" }}>{step.tool_preview}</code>
-                </div>
-              )}
+          <StepTokenBar buckets={step.token_buckets}/>
+          {hasError && <div style={{ marginBottom: 10 }}><Notice kind="error" title="Call error">{step.call_error}</Notice></div>}
+          <MessageThread step={step}/>
+          {step.tool_preview && !(step.output || []).some(m => (m.parts || []).some(p => p.kind === "tool_call" || p.tool_call)) && (
+            <div style={{ background: "var(--bg-primary)", border: "1px solid var(--border-weak)", borderRadius: 2, padding: "8px 12px", marginTop: 10, fontFamily: "var(--fontFamilyMonospace)", fontSize: 12, color: "var(--fg2)", display: "flex", alignItems: "flex-start", gap: 8 }}>
+              <span style={{ color: "var(--warning-text)" }}>$</span>
+              <code style={{ color: "var(--fg1)", whiteSpace: "pre-wrap", wordBreak: "break-all" }}>{step.tool_preview}</code>
             </div>
           )}
         </div>
       );
     }
 
-    // stepRailSummary picks a one-line label for a rail row: the first
-    // tool call's name + preview when the step ran a tool, otherwise
-    // "Initial prompt" for the opening step and "Final response" for a
-    // trailing text-only step. mono renders the tool form in Roboto Mono;
-    // prose labels stay in Inter. There is no "initial/final" flag in the
-    // data, so the position heuristic is the best we can do.
+    // StepCard is one row in the collapse-first thread list: a compact,
+    // scannable line (status dot, number, tool chip, summary, duration ·
+    // tokens) that expands inline to the full StepDetailBody. It lives inside
+    // a shared list container, so it draws only a bottom separator — no card
+    // chrome of its own. accent colours the status dot/active edge by agent.
+    function StepCard({ step, n, total, accent, expanded, onToggle, active, last, innerRef, flash, turnStart }) {
+      const hasError = !!step.call_error;
+      const glance = stepGlance(step, n - 1, total, turnStart);
+      const isUser = glance.role === "user";
+      const dot = hasError ? "var(--error-text)" : (accent || "var(--viz-green)");
+      const leftAccent = active ? "var(--brand-orange)" : (hasError ? "var(--error-main)" : (isUser ? "var(--viz-green)" : "transparent"));
+      return (
+        <div ref={innerRef} className={flash ? "sigil-step-flash" : undefined} style={{ borderBottom: last && !expanded ? "none" : "1px solid var(--border-weak)" }}>
+          <div onClick={onToggle} style={{
+            display: "grid", gridTemplateColumns: "auto auto 1fr auto auto", alignItems: "center", gap: 10,
+            padding: "0 12px", height: 34, cursor: "pointer",
+            borderLeft: `2px solid ${leftAccent}`,
+            background: active ? "var(--action-selected)" : (isUser ? "rgba(115,191,105,0.04)" : "transparent"),
+          }}
+          onMouseEnter={e => { if (!active) e.currentTarget.style.background = isUser ? "rgba(115,191,105,0.07)" : "rgba(204,204,220,0.03)"; }}
+          onMouseLeave={e => { if (!active) e.currentTarget.style.background = isUser ? "rgba(115,191,105,0.04)" : "transparent"; }}>
+            {isUser
+              ? <span style={{ width: 7, height: 7, borderRadius: "50%", border: "1.5px solid var(--viz-green)", boxSizing: "border-box", flexShrink: 0 }}/>
+              : <span style={{ width: 7, height: 7, borderRadius: "50%", background: dot, flexShrink: 0 }}/>}
+            <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 10, color: "var(--fg3)", minWidth: 16, textAlign: "right" }}>{n}</span>
+            <span style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+              {isUser && (
+                <span style={{ flexShrink: 0, fontFamily: "var(--fontFamilyMonospace)", fontSize: 10, letterSpacing: "0.06em", color: "var(--viz-green)", background: "rgba(115,191,105,0.1)", border: "1px solid rgba(115,191,105,0.25)", borderRadius: 2, padding: "0 6px", lineHeight: "16px" }}>USER</span>
+              )}
+              {!isUser && glance.tool && (
+                <span style={{ flexShrink: 0, fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--fg2)", background: "rgba(204,204,220,0.06)", border: "1px solid var(--border-weak)", borderRadius: 2, padding: "0 6px", lineHeight: "16px" }}>{glance.tool}</span>
+              )}
+              <span style={{ minWidth: 0, fontFamily: glance.mono ? "var(--fontFamilyMonospace)" : "var(--fontFamily)", fontSize: glance.mono ? 11.5 : 12.5, color: isUser ? "var(--fg-max)" : (glance.tool && glance.mono ? "var(--fg2)" : "var(--fg1)"), overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{glance.text}</span>
+            </span>
+            <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--fg3)", display: "flex", gap: 10, whiteSpace: "nowrap", justifyContent: "flex-end" }}>
+              <span>{formatDuration(step.duration_seconds)}</span>
+              <span style={{ minWidth: 42, textAlign: "right" }}>{formatTokens(step.total_tokens)}</span>
+            </span>
+            <Icon name={expanded ? "chevron" : "cright"} size={12} style={{ color: "var(--fg3)" }}/>
+          </div>
+          {expanded && <StepDetailBody step={step}/>}
+        </div>
+      );
+    }
+
+    // TurnHeader is the banner that opens a user turn: the prompt lifted out
+    // of the step it rode in on, so the loop reads user → steps → user instead
+    // of a "USER" row that hid the assistant's work. The rollup is honest about
+    // the two numbers that differ in an agentic loop — billed (cumulative spend
+    // across the turn) vs ctx (the live context size, which only climbs).
+    function TurnHeader({ turn, last }) {
+      return (
+        <div style={{
+          display: "flex", alignItems: "flex-start", gap: 10,
+          padding: "10px 12px", borderBottom: last ? "none" : "1px solid var(--border-weak)",
+          borderLeft: "2px solid var(--viz-green)", background: "rgba(115,191,105,0.06)",
+        }}>
+          <span style={{ flexShrink: 0, marginTop: 1, fontFamily: "var(--fontFamilyMonospace)", fontSize: 10, letterSpacing: "0.06em", color: "var(--viz-green)", background: "rgba(115,191,105,0.1)", border: "1px solid rgba(115,191,105,0.25)", borderRadius: 2, padding: "1px 6px", lineHeight: "16px" }}>USER</span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ color: "var(--fg-max)", fontSize: 13, lineHeight: 1.5, display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical", overflow: "hidden", whiteSpace: "pre-wrap", wordBreak: "break-word" }}>{turn.userText}</div>
+            <div style={{ marginTop: 5, fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--fg3)" }}>
+              turn {turn.index} · {turn.gens.length} {turn.gens.length === 1 ? "step" : "steps"} · <span style={{ color: "var(--fg2)" }}>{formatTokens(turn.billed)}</span> billed · <span style={{ color: "var(--fg2)" }}>{formatTokens(turn.generated)}</span> generated · ctx <span style={{ color: "var(--fg2)" }}>{formatTokens(turn.ctxIn)}</span>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // leadingAssistantText returns the step's first prose line — the assistant's
+    // narration that precedes any tool call (e.g. "Now let me explore the
+    // existing code structure."). It makes a far more legible rail label than
+    // the tool form, so it wins when present.
+    function leadingAssistantText(step) {
+      for (const m of (step.output || [])) {
+        for (const p of (m.parts || [])) {
+          if (p.kind === "text") {
+            const t = (p.text || "").trim();
+            if (t) return t;
+          }
+        }
+      }
+      return "";
+    }
+
+    // stepRailSummary picks a one-line label for a rail row: the assistant's
+    // leading prose when the step has any, else the first tool call's name +
+    // preview, else a position heuristic ("Initial prompt" / "Final response").
+    // mono renders the tool form in Roboto Mono; prose labels stay in Inter.
     function stepRailSummary(step, i, total) {
+      const prose = leadingAssistantText(step);
+      if (prose) return { label: prose, mono: false };
       const tool = (step.tools && step.tools[0]) || "";
       if (tool) {
         const preview = step.tool_preview ? ` · ${step.tool_preview}` : "";
@@ -1418,114 +2254,609 @@
     // mirrors a StepCard: number, a tool/prose summary, duration · tokens
     // (warning on the slowest step, error on a failed one), and a status
     // dot. Clicking a row expands and scrolls to that step.
-    function StepRail({ steps, activeStep, peakIdx, onSelect }) {
-      if (!steps || steps.length === 0) return null;
+    // ── Subagent forest ────────────────────────────────────────────────
+    // Generations arrive as a flat chronological list. parent_generation_ids
+    // links each step to the one that caused it: a same-agent edge chains one
+    // agent's calls; a cross-agent edge (parent has a different agent_name) is
+    // a subagent launch. We fold same-agent chains into "runs" (so a 100-call
+    // subagent is one nesting level, not 100), then nest each run under the
+    // generation that spawned it. Main-agent calls have no parent, so each is
+    // its own top-level run — together they are the primary thread.
+
+    const tsMs = s => { const t = s ? new Date(s).getTime() : 0; return Number.isFinite(t) ? t : 0; };
+
+    // agentShort drops the "claude-code/" prefix; agentColor tints a subagent
+    // by kind so lanes/badges are scannable. The main agent keeps the brand.
+    function agentShort(name) {
+      if (!name) return "main";
+      const i = name.indexOf("/");
+      return i === -1 ? name : name.slice(i + 1);
+    }
+    function isSubagent(name) { return !!name && name.indexOf("/") !== -1; }
+    function agentColor(name) {
+      const s = agentShort(name);
+      if (!isSubagent(name)) return "var(--brand-orange)";
+      if (s.includes("explore")) return "var(--viz-blue)";
+      if (s.includes("general")) return "var(--viz-purple)";
+      if (s.includes("fork")) return "var(--viz-green)";
+      return "var(--viz-yellow)";
+    }
+
+    function buildSubagentForest(gens) {
+      const byId = new Map((gens || []).map(g => [g.generation_id, g]));
+      const inConvParent = g => {
+        const p = (g.parent_generation_ids || [])[0];
+        return p && byId.has(p) ? byId.get(p) : null;
+      };
+      // Run root: walk up while the parent shares this agent_name.
+      const runRootId = g => {
+        let cur = g; const seen = new Set();
+        for (;;) {
+          if (seen.has(cur.generation_id)) return cur.generation_id; // cycle guard
+          seen.add(cur.generation_id);
+          const p = inConvParent(cur);
+          if (p && (p.agent_name || "") === (cur.agent_name || "")) { cur = p; continue; }
+          return cur.generation_id;
+        }
+      };
+      const runs = new Map();
+      for (const g of (gens || [])) {
+        const rid = runRootId(g);
+        let run = runs.get(rid);
+        if (!run) { run = { id: rid, agent: (byId.get(rid) || g).agent_name, gens: [] }; runs.set(rid, run); }
+        run.gens.push(g);
+      }
+      const spawnedBy = new Map(); // parentGenId -> [run]
+      const topRuns = [];
+      for (const run of runs.values()) {
+        run.gens.sort((a, b) => tsMs(a.started_at) - tsMs(b.started_at));
+        run.start = Math.min(...run.gens.map(g => tsMs(g.started_at) || Infinity));
+        run.end = Math.max(...run.gens.map(g => tsMs(g.completed_at) || tsMs(g.started_at) || 0));
+        run.totalTokens = run.gens.reduce((a, g) => a + (g.total_tokens || 0), 0);
+        run.hasError = run.gens.some(g => g.call_error);
+        // Only a cross-agent parent is a real spawn. A same-agent parent on a
+        // run root only happens when parent_generation_ids has a cycle (the
+        // run-root walk bailed on the guard); treat those as top-level so no
+        // run is orphaned.
+        const sp = inConvParent(byId.get(run.id));
+        if (sp && (sp.agent_name || "") !== (run.agent || "")) {
+          if (!spawnedBy.has(sp.generation_id)) spawnedBy.set(sp.generation_id, []);
+          spawnedBy.get(sp.generation_id).push(run);
+        } else {
+          topRuns.push(run);
+        }
+      }
+      for (const arr of spawnedBy.values()) arr.sort((a, b) => a.start - b.start);
+      topRuns.sort((a, b) => a.start - b.start);
+      const setDepth = (run, d) => {
+        run.depth = d;
+        run.gens.forEach(g => (spawnedBy.get(g.generation_id) || []).forEach(c => setDepth(c, d + 1)));
+      };
+      topRuns.forEach(r => setDepth(r, 0));
+      return { runs, spawnedBy, topRuns, byId };
+    }
+
+    // flattenForest walks the forest depth-first into render rows. Each row
+    // carries its nesting depth, owning run, the run-id path to it (for
+    // collapse), and isRunStart (true on a subagent run's first step, where
+    // the group header is drawn). Number = 1-based DFS order, stable across
+    // collapse, shared by the rail and the cards.
+    function flattenForest(forest) {
+      const out = [];
+      const seen = new Set(); // guards against cross-agent parent cycles
+      const visit = (run, depth, path) => {
+        if (seen.has(run.id)) return;
+        seen.add(run.id);
+        const rp = path.concat(run.id);
+        run.gens.forEach((gen, i) => {
+          out.push({ gen, depth, run, runPath: rp, isRunStart: i === 0 && depth > 0 });
+          (forest.spawnedBy.get(gen.generation_id) || []).forEach(child => visit(child, depth + 1, rp));
+        });
+      };
+      forest.topRuns.forEach(r => visit(r, 0, []));
+      // Belt-and-suspenders: any run not reached above (cycle-orphaned) is
+      // emitted at top level, so no generation is ever dropped from the view.
+      forest.runs.forEach(r => { if (!seen.has(r.id)) visit(r, 0, []); });
+      out.forEach((row, i) => { row.n = i + 1; });
+      return out;
+    }
+
+    // subagentRuns returns every spawned run (depth > 0) ordered by start —
+    // the timeline's non-main lanes.
+    function subagentRuns(forest) {
+      return [...forest.runs.values()].filter(r => r.depth > 0).sort((a, b) => a.start - b.start);
+    }
+
+    // stepTokenWork splits a step's tokens into what it actually did,
+    // excluding cache_read. cache_read is just the reused context size — it
+    // climbs monotonically through a run, so total_tokens is a misleading
+    // "biggest step" signal (it's almost always a late step). generated is
+    // what the model produced; ingested is new content the step pulled into
+    // context (a big file read, fresh prompt); work is the sum.
+    function stepTokenWork(gen) {
+      const tb = (gen && gen.token_buckets) || {};
+      const generated = (tb.output || 0) + (tb.reasoning || 0);
+      const ingested = (tb.fresh_input || 0) + (tb.cache_write || 0);
+      return { generated, ingested, work: generated + ingested };
+    }
+
+
+    // Hotspots is the "what's worth looking at" strip above the thread: a
+    // clickable chip for any errors, the slowest step, and the most
+    // token-hungry step. Each jumps to that step. This surfaces the outliers
+    // that a per-step minimap encoding can't on a long trace.
+    function Hotspots({ hot, onJump }) {
+      const chip = (color, head, sub, onClick) => (
+        <button onClick={onClick} title="Jump to this step" style={{
+          display: "inline-flex", alignItems: "center", gap: 6, height: 24, padding: "0 9px",
+          borderRadius: 12, cursor: "pointer", background: "transparent",
+          border: `1px solid ${color}`, color: "var(--fg1)", fontFamily: "var(--fontFamily)", fontSize: 11.5,
+        }}
+        onMouseEnter={e => e.currentTarget.style.background = "rgba(204,204,220,0.05)"}
+        onMouseLeave={e => e.currentTarget.style.background = "transparent"}>
+          <span style={{ width: 6, height: 6, borderRadius: "50%", background: color, flexShrink: 0 }}/>
+          <span style={{ color: "var(--fg2)" }}>{head}</span>
+          <span style={{ fontFamily: "var(--fontFamilyMonospace)", color: "var(--fg1)" }}>{sub}</span>
+        </button>
+      );
+      const r = (row, extra) => `#${row.n} · ${extra}`;
       return (
-        <aside style={{ flex: "none", width: 248, position: "sticky", top: 72 }}>
-          <div style={{ fontSize: 11, color: "var(--fg3)", fontWeight: 500, padding: "0 4px 10px", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-            <span>Steps</span>
-            <span style={{ fontFamily: "var(--fontFamilyMonospace)" }}>{steps.length}</span>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          <span style={{ fontSize: 11, color: "var(--fg3)" }}>Hotspots</span>
+          {hot.errors.length > 0 && chip("var(--error-text)", hot.errors.length === 1 ? "error" : `${hot.errors.length} errors`, `#${hot.errors[0].n}`, () => onJump(hot.errors[0].gen.generation_id))}
+          {chip("var(--warning-text)", "slowest", r(hot.slowest, formatDuration(hot.slowest.gen.duration_seconds)), () => onJump(hot.slowest.gen.generation_id))}
+          {chip("var(--viz-orange)", "most generated", r(hot.mostGenerated, formatTokens(stepTokenWork(hot.mostGenerated.gen).generated)), () => onJump(hot.mostGenerated.gen.generation_id))}
+          {chip("var(--viz-blue)", "most read", r(hot.mostRead, formatTokens(stepTokenWork(hot.mostRead.gen).ingested)), () => onJump(hot.mostRead.gen.generation_id))}
+        </div>
+      );
+    }
+
+    // TimelineView is the trace waterfall: a shared time axis with one lane
+    // for the main agent and one per subagent run, each bar a generation
+    // positioned by its real start/end. Concurrent subagents show as bars
+    // overlapping in time — the one thing the vertical thread can't express.
+    // Clicking a bar jumps to that step in the tree.
+    // mergedSpan returns the total wall time covered by at least one call
+    // (intervals unioned), so idle gaps between calls can be reported.
+    function mergedSpan(intervals) {
+      const iv = intervals.filter(x => x[1] > x[0]).sort((a, b) => a[0] - b[0]);
+      let total = 0, curS = -1, curE = -1;
+      for (const [s, e] of iv) {
+        if (s > curE) { if (curE > curS) total += curE - curS; curS = s; curE = e; }
+        else curE = Math.max(curE, e);
+      }
+      if (curE > curS) total += curE - curS;
+      return total;
+    }
+    // peakConcurrency is the most calls in flight at once — the timeline's
+    // headline number for parallelism.
+    function peakConcurrency(intervals) {
+      const ev = [];
+      intervals.forEach(([s, e]) => { if (e > s) { ev.push([s, 1]); ev.push([e, -1]); } });
+      ev.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+      let cur = 0, peak = 0;
+      for (const [, d] of ev) { cur += d; peak = Math.max(peak, cur); }
+      return peak;
+    }
+
+    // TimelineTooltip is the floating card shown while hovering a step bar or
+    // a turn marker. It follows the cursor (fixed-positioned, clamped to the
+    // viewport) and never intercepts pointer events.
+    function TimelineTooltip({ tip }) {
+      const W = tip.kind === "turn" ? 300 : 268;
+      const left = Math.min(tip.x + 14, window.innerWidth - W - 8);
+      const top = Math.min(tip.y + 14, window.innerHeight - 180);
+      const box = { position: "fixed", left, top, width: W, zIndex: 60, background: "var(--bg-canvas)", border: "1px solid var(--border-medium)", borderRadius: 4, padding: "9px 11px", boxShadow: "0 6px 22px rgba(0,0,0,0.5)", pointerEvents: "none" };
+      const row = (k, v, c) => (
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 18 }}>
+          <span style={{ color: "var(--fg3)", fontSize: 11.5 }}>{k}</span>
+          <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 12, color: c || "var(--fg1)" }}>{v}</span>
+        </div>
+      );
+      if (tip.kind === "turn") {
+        const t = tip.turn;
+        return (
+          <div style={box}>
+            <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+              <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontWeight: 600, fontSize: 12, color: "var(--fg-max)" }}>Turn {t.index}</span>
+              <span style={{ marginLeft: "auto", fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--fg3)" }}>{t.gens.length} steps · {formatTokens(t.billed)} billed</span>
+            </div>
+            <div style={{ fontSize: 11.5, color: "var(--fg2)", display: "-webkit-box", WebkitLineClamp: 4, WebkitBoxOrient: "vertical", overflow: "hidden", whiteSpace: "pre-wrap", wordBreak: "break-word" }}>{t.userText}</div>
           </div>
-          <div style={{ border: "1px solid var(--border-weak)", borderRadius: 2, overflow: "hidden", background: "var(--bg-primary)" }}>
-            {steps.map((s, i) => {
-              const n = i + 1;
-              const active = n === activeStep;
-              const hasError = !!s.call_error;
-              const summary = stepRailSummary(s, i, steps.length);
-              const isPeak = i === peakIdx;
-              const subColor = hasError ? "var(--error-text)" : (isPeak ? "var(--warning-text)" : "var(--fg3)");
-              return (
-                <div key={s.generation_id || i} onClick={() => onSelect(n)} style={{
-                  display: "grid", gridTemplateColumns: "24px 1fr auto", alignItems: "center", gap: 8,
-                  padding: "9px 11px",
-                  borderBottom: i === steps.length - 1 ? "none" : "1px solid var(--border-weak)",
-                  borderLeft: active ? "2px solid var(--brand-orange)" : "2px solid transparent",
-                  background: active ? "var(--action-selected)" : "transparent",
-                  cursor: "pointer",
-                }}
-                onMouseEnter={e => { if (!active) e.currentTarget.style.background = "rgba(204,204,220,0.03)"; }}
-                onMouseLeave={e => { if (!active) e.currentTarget.style.background = "transparent"; }}>
-                  <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--fg3)" }}>{n}</span>
-                  <span style={{ display: "flex", flexDirection: "column", gap: 1, minWidth: 0 }}>
-                    <span style={{ fontFamily: summary.mono ? "var(--fontFamilyMonospace)" : "var(--fontFamily)", fontSize: 12, color: active ? "var(--fg-max)" : "var(--fg1)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{summary.label}</span>
-                    <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 10, color: subColor, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                      {formatDuration(s.duration_seconds)} · {formatTokens(s.total_tokens)}{isPeak ? " · peak" : ""}
-                    </span>
+        );
+      }
+      const g = tip.gen, work = stepTokenWork(g), model = (g.model || "").replace(/-(20)?\d{6,8}.*$/, "").replace(/^claude-/, "");
+      return (
+        <div style={box}>
+          <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
+            <span style={{ width: 8, height: 8, borderRadius: 2, background: agentColor(g.agent_name) }}/>
+            <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontWeight: 600, fontSize: 12, color: "var(--fg-max)" }}>{agentShort(g.agent_name)}</span>
+            <span style={{ marginLeft: "auto", fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--fg3)" }}>step #{tip.n}</span>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+            {model && row("model", model)}
+            {row("started", formatTime(g.started_at))}
+            {row("duration", formatDuration(g.duration_seconds))}
+            {row("generated", `↑ ${formatTokens(work.generated)}`, "var(--viz-orange)")}
+            {row("ingested", `↓ ${formatTokens(work.ingested)}`, "var(--viz-blue)")}
+            {row("billed", formatTokens(g.total_tokens))}
+            {g.tools && g.tools.length > 0 && row("tools", g.tools.slice(0, 4).join(", "))}
+            {tip.turnIndex && row("turn", `T${tip.turnIndex}`)}
+            {g.call_error && row("status", "error", "var(--error-text)")}
+          </div>
+        </div>
+      );
+    }
+
+    // TimelineView is the trace waterfall: one lane for the main agent and one
+    // per subagent run, each step a bar positioned along a *compressed* clock —
+    // long idle gaps between calls collapse to a thin dashed break so the bars
+    // fill the width instead of clumping. Concurrent subagents overlap in time,
+    // the one thing the vertical thread can't show. A turn ribbon on top marks
+    // each user-prompt boundary (number only; the prompt text is in the hover).
+    // Bar height encodes real work (gen + fresh context, excluding cache_read,
+    // log-scaled); width encodes duration. Clicking a bar jumps to that step.
+    function TimelineView({ forest, onSelectGen, activeGenId, turns }) {
+      const [tip, setTip] = useState(null);
+      const allGens = [...forest.byId.values()].sort((a, b) => tsMs(a.started_at) - tsMs(b.started_at));
+      if (allGens.length === 0) return null;
+      const stepNo = new Map(allGens.map((g, i) => [g.generation_id, i + 1]));
+      const mainAgent = (forest.topRuns[0] && forest.topRuns[0].agent) || "main";
+      const mainGens = forest.topRuns.flatMap(r => r.gens).sort((a, b) => tsMs(a.started_at) - tsMs(b.started_at));
+      const subs = subagentRuns(forest);
+      const lanes = [{ key: "main", label: agentShort(mainAgent), agent: mainAgent, depth: 0, gens: mainGens }]
+        .concat(subs.map(r => ({ key: r.id, label: agentShort(r.agent), agent: r.agent, depth: r.depth, gens: r.gens })));
+
+      let tmin = Infinity, tmax = -Infinity, maxTok = 1;
+      const intervals = [];
+      for (const g of allGens) {
+        const s = tsMs(g.started_at), e = tsMs(g.completed_at) || s;
+        if (s) tmin = Math.min(tmin, s);
+        if (e) tmax = Math.max(tmax, e);
+        if (e > s) intervals.push([s, e]);
+        maxTok = Math.max(maxTok, stepTokenWork(g).work);
+      }
+      if (!Number.isFinite(tmin) || tmax <= tmin) { tmin = 0; tmax = 1; }
+
+      // Compressed clock: union the active windows (merging gaps under 8s),
+      // lay them end-to-end, and give each idle break a fixed sliver. mapPct
+      // turns a timestamp into a percentage along this compressed axis.
+      const sorted = intervals.slice().sort((a, b) => a[0] - b[0]);
+      const merged = [];
+      for (const [s, e] of sorted) {
+        const last = merged[merged.length - 1];
+        if (last && s <= last[1] + 8000) last[1] = Math.max(last[1], e);
+        else merged.push([s, e]);
+      }
+      if (merged.length === 0) merged.push([tmin, tmax]);
+      const GAP_PCT = 1.4;
+      const activeMs = merged.reduce((a, m) => a + (m[1] - m[0]), 0) || 1;
+      const gapsPct = (merged.length - 1) * GAP_PCT;
+      const segs = []; let cum = 0;
+      for (const m of merged) { segs.push({ s: m[0], e: m[1], start: cum }); cum += (m[1] - m[0]); }
+      const scale = (100 - gapsPct) / activeMs;
+      const mapPct = t => {
+        for (let i = 0; i < segs.length; i++) {
+          const m = segs[i];
+          if (t <= m.e + 1) { const within = Math.max(0, Math.min(m.e - m.s, t - m.s)); return m.start * scale + i * GAP_PCT + within * scale; }
+        }
+        return 100;
+      };
+
+      const H_MIN = 5, H_MAX = 30;
+      const barH = tok => H_MIN + (H_MAX - H_MIN) * (Math.log((tok || 0) + 1) / Math.log(maxTok + 1));
+
+      const wall = tmax - tmin;
+      const active = mergedSpan(intervals);
+      const idlePct = wall > 0 ? Math.max(0, Math.round((1 - active / wall) * 100)) : 0;
+      const peak = peakConcurrency(intervals);
+
+      // Turn markers: each user-prompt boundary, positioned on the compressed
+      // axis. A turn runs until the next prompt; we only need its start to draw
+      // the boundary, and its index to label it.
+      const turnMarks = (turns || [])
+        .map(t => { const g = forest.byId.get(t.startGenId); return g ? { turn: t, ms: tsMs(g.started_at) } : null; })
+        .filter(Boolean).sort((a, b) => a.ms - b.ms);
+      turnMarks.forEach((m, i) => { m.left = mapPct(m.ms); m.endLeft = i + 1 < turnMarks.length ? mapPct(turnMarks[i + 1].ms) : 100; });
+      const turnOf = ms => { let r = null; for (const m of turnMarks) { if (m.ms <= ms) r = m.turn; else break; } return r; };
+      // dashed idle breaks sit at the seam between adjacent active windows
+      const breaks = segs.slice(1).map((m, i) => m.start * scale + (i + 1) * GAP_PCT - GAP_PCT / 2);
+
+      const LANE_W = 184, LANE_H = 46;
+      const stat = (v, label, color) => (
+        <span style={{ display: "inline-flex", alignItems: "baseline", gap: 5 }}>
+          <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 13, color: color || "var(--fg-max)" }}>{v}</span>
+          <span style={{ fontSize: 11, color: "var(--fg3)" }}>{label}</span>
+        </span>
+      );
+
+      return (
+        <div style={{ border: "1px solid var(--border-weak)", borderRadius: 2, background: "var(--bg-primary)", overflow: "hidden" }} onMouseLeave={() => setTip(null)}>
+          {/* summary strip */}
+          <div style={{ display: "flex", alignItems: "center", gap: 18, padding: "10px 14px", borderBottom: "1px solid var(--border-weak)", flexWrap: "wrap" }}>
+            {stat(formatDuration(wall / 1000), "wall")}
+            {stat(formatDuration(active / 1000), "active")}
+            {stat(`${idlePct}%`, "idle", idlePct > 50 ? "var(--warning-text)" : undefined)}
+            {stat(peak === 1 ? "sequential" : `${peak}×`, peak === 1 ? "" : "peak parallel", peak > 1 ? "var(--viz-purple)" : undefined)}
+            {turnMarks.length > 0 && stat(String(turnMarks.length), turnMarks.length === 1 ? "turn" : "turns")}
+            {stat(String(subs.length), subs.length === 1 ? "subagent" : "subagents")}
+            <span style={{ flex: 1 }}/>
+            <span style={{ fontSize: 11, color: "var(--fg3)" }}>idle collapsed · height = work · width = duration</span>
+          </div>
+          {/* turn ribbon — numbered markers; prompt text is in the hover */}
+          {turnMarks.length > 0 && (
+            <div style={{ display: "flex", borderBottom: "1px solid var(--border-weak)", background: "rgba(204,204,220,0.03)" }}>
+              <div style={{ width: LANE_W, flex: "none", borderRight: "1px solid var(--border-weak)", padding: "0 12px", display: "flex", alignItems: "center", fontSize: 11, color: "var(--fg3)", height: 20 }}>Turns</div>
+              <div style={{ flex: 1, position: "relative", height: 20 }}>
+                {turnMarks.map((m, i) => (
+                  <div key={i} title={`T${m.turn.index}: ${m.turn.userText}`}
+                    onMouseMove={ev => setTip({ kind: "turn", turn: m.turn, x: ev.clientX, y: ev.clientY })}
+                    onMouseLeave={() => setTip(null)}
+                    onClick={() => onSelectGen(m.turn.startGenId)}
+                    style={{ position: "absolute", left: `${m.left}%`, width: `${Math.max(0, m.endLeft - m.left)}%`, top: 0, bottom: 0, borderLeft: "1px solid var(--border-weak)", display: "flex", alignItems: "center", paddingLeft: 4, overflow: "hidden", cursor: "pointer", background: i % 2 ? "rgba(204,204,220,0.03)" : "transparent" }}>
+                    <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 10, color: "var(--fg3)" }}>{m.turn.index}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          {/* lanes */}
+          {lanes.map((lane, li) => {
+            const c = agentColor(lane.agent);
+            const laneTok = lane.gens.reduce((a, g) => a + (g.total_tokens || 0), 0);
+            return (
+              <div key={lane.key} style={{ display: "flex", borderBottom: li === lanes.length - 1 ? "none" : "1px solid var(--border-weak)", background: li % 2 ? "rgba(204,204,220,0.015)" : "transparent" }}>
+                <div style={{ width: LANE_W, flex: "none", borderRight: "1px solid var(--border-weak)", padding: "0 12px", paddingLeft: 12 + lane.depth * 14, display: "flex", flexDirection: "column", justifyContent: "center", gap: 2, minWidth: 0, height: LANE_H }}>
+                  <span style={{ display: "flex", alignItems: "center", gap: 6, minWidth: 0 }}>
+                    {lane.depth > 0 && <span style={{ color: "var(--fg3)", fontSize: 11 }}>↳</span>}
+                    <span style={{ width: 7, height: 7, borderRadius: 2, background: c, flex: "none" }}/>
+                    <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 12, color: "var(--fg1)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{lane.label}</span>
                   </span>
-                  <span style={{ width: 6, height: 6, borderRadius: "50%", background: hasError ? "var(--error-text)" : "var(--viz-green)" }}/>
+                  <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 10, color: "var(--fg3)", paddingLeft: lane.depth > 0 ? 17 : 0 }}>{lane.gens.length} · {formatTokens(laneTok)} tok</span>
                 </div>
-              );
-            })}
-          </div>
-        </aside>
+                <div style={{ flex: 1, position: "relative", height: LANE_H }}>
+                  {turnMarks.slice(1).map((m, i) => <span key={`tn${i}`} style={{ position: "absolute", left: `${m.left}%`, top: 0, bottom: 0, width: 1, background: "var(--border-weak)" }}/>)}
+                  {breaks.map((x, i) => <span key={`br${i}`} style={{ position: "absolute", left: `${x}%`, top: 0, bottom: 0, width: 0, borderLeft: "1px dashed var(--viz-purple)", opacity: 0.35 }}/>)}
+                  {lane.gens.map((g, gi) => {
+                    const s = tsMs(g.started_at), e = tsMs(g.completed_at) || s;
+                    const left = mapPct(s);
+                    const w = Math.max(0.4, mapPct(e) - left);
+                    const work = stepTokenWork(g);
+                    const h = barH(work.work);
+                    const isActive = g.generation_id === activeGenId;
+                    return (
+                      <div key={g.generation_id || gi}
+                        onClick={() => onSelectGen(g.generation_id)}
+                        onMouseMove={ev => { const t = turnOf(s); setTip({ kind: "step", gen: g, n: stepNo.get(g.generation_id), turnIndex: t ? t.index : null, x: ev.clientX, y: ev.clientY }); }}
+                        onMouseLeave={() => setTip(null)}
+                        style={{
+                          position: "absolute", bottom: 8, height: h,
+                          left: `${left}%`, width: `${w}%`, minWidth: 3,
+                          background: g.call_error ? "var(--error-main)" : c,
+                          opacity: isActive || (tip && tip.gen === g) ? 1 : 0.8, borderRadius: 2, cursor: "pointer",
+                          outline: isActive ? "1.5px solid var(--fg-max)" : "none", outlineOffset: 1,
+                          boxShadow: isActive ? "0 0 8px rgba(255,255,255,0.25)" : "none",
+                        }}/>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+          {tip && <TimelineTooltip tip={tip}/>}
+        </div>
       );
     }
 
     function ConversationThread({ steps }) {
-      // First 4 cards default to expanded — the typical attention zone.
-      const [expanded, setExpanded] = useState(() => new Set(steps.slice(0, 4).map((_, i) => i + 1)));
-      const [activeStep, setActiveStep] = useState(1);
-      const [flashStep, setFlashStep] = useState(null);
+      const forest = useMemo(() => buildSubagentForest(steps), [steps]);
+      const rows = useMemo(() => flattenForest(forest), [forest]);
+      const hasSubagents = useMemo(() => rows.some(r => r.depth > 0), [rows]);
+
+      const [view, setView] = useState("tree"); // tree | timeline
+      // Collapse-first: every step starts collapsed to one line and every
+      // subagent run starts folded, so the thread opens as a clean scannable
+      // list. The reader expands only what they want to read.
+      const [collapsed, setCollapsed] = useState(() => new Set([...forest.runs.values()].filter(r => r.depth > 0).map(r => r.id)));
+      const [expanded, setExpanded] = useState(() => new Set());
+      const [activeN, setActiveN] = useState(1);
+      const [flashId, setFlashId] = useState(null);
+      const [hashGenID, setHashGenID] = useState(generationIDFromHash);
       const cardRefs = useRef({});
       const flashTimer = useRef(null);
-
       useEffect(() => () => { if (flashTimer.current) clearTimeout(flashTimer.current); }, []);
 
-      // Toggling a card header is also a focus signal, so keep the rail's
-      // active marker in sync with it — otherwise the highlight stays on
-      // the last rail-clicked step while the user works elsewhere.
-      const toggle = n => {
-        setActiveStep(n);
-        const next = new Set(expanded);
-        next.has(n) ? next.delete(n) : next.add(n);
-        setExpanded(next);
-      };
+      const rowByGen = useMemo(() => new Map(rows.map(r => [r.gen.generation_id, r])), [rows]);
 
-      // Rail click: expand the step, mark it active, smooth-scroll its card
-      // just below the sticky top bar, and trigger a brief orange glow. The
-      // page scrolls on the window (no ancestor has a definite height, so
-      // the inner main never becomes a scroll container), and 72px clears
-      // the 48px header plus a gap, matching the rail's sticky offset.
-      // Clearing flashStep before re-setting it restarts the animation when
-      // the same step is clicked twice; the nested rAF lets the expand
-      // reflow settle so the scroll target is measured against the final
-      // layout.
-      const selectStep = n => {
-        setExpanded(prev => prev.has(n) ? prev : new Set(prev).add(n));
-        setActiveStep(n);
-        setFlashStep(null);
+      // Turns: the human-readable loop boundary. A turn opens at a top-level
+      // (depth 0) generation whose input carries a fresh user prompt, and runs
+      // — through every step it triggers, including spawned subagents — until
+      // the next prompt. The prompt is lifted into a turn header so it stops
+      // masquerading as a step; the generation it lived on renders as the
+      // turn's first assistant step. Rollups: billed sums what the turn spent;
+      // ctxIn is the live context size at the turn's last top-level call (it
+      // climbs as the transcript is re-sent, so it's a "window fill", not a
+      // sum). See the steps-prototype for the model this implements.
+      const turns = useMemo(() => {
+        const out = [];
+        let cur = null;
+        rows.forEach(r => {
+          const ut = r.depth === 0 ? firstUserText(r.gen) : "";
+          if (ut) { cur = { startGenId: r.gen.generation_id, userText: ut, gens: [], lastTop: r.gen }; out.push(cur); }
+          if (cur) { cur.gens.push(r.gen); if (r.depth === 0) cur.lastTop = r.gen; }
+        });
+        out.forEach((t, i) => {
+          t.index = i + 1;
+          t.billed = t.gens.reduce((a, g) => a + (g.total_tokens || 0), 0);
+          t.generated = t.gens.reduce((a, g) => a + (((g.token_buckets || {}).output || 0) + ((g.token_buckets || {}).reasoning || 0)), 0);
+          const b = t.lastTop.token_buckets || {};
+          t.ctxIn = (b.fresh_input || 0) + (b.cache_read || 0) + (b.cache_write || 0);
+        });
+        return out;
+      }, [rows]);
+      const turnByStartId = useMemo(() => new Map(turns.map(t => [t.startGenId, t])), [turns]);
+
+      const toggleStep = id => {
+        setExpanded(prev => { const n = new Set(prev); n.has(id) ? n.delete(id) : n.add(id); return n; });
+      };
+      const toggleRun = id => setCollapsed(prev => { const n = new Set(prev); n.has(id) ? n.delete(id) : n.add(id); return n; });
+
+      // Jump to a step: switch to tree, open its ancestor runs and the card,
+      // mark it active, then scroll + flash once layout settles.
+      const jumpTo = id => {
+        const row = rowByGen.get(id);
+        if (!row) return;
+        setView("tree");
+        setCollapsed(prev => { const n = new Set(prev); row.runPath.forEach(r => n.delete(r)); return n; });
+        setExpanded(prev => prev.has(id) ? prev : new Set(prev).add(id));
+        setActiveN(row.n);
+        setFlashId(null);
         requestAnimationFrame(() => requestAnimationFrame(() => {
-          const card = cardRefs.current[n];
+          const card = cardRefs.current[id];
           if (card) {
-            const top = window.scrollY + card.getBoundingClientRect().top - 72;
+            // Offset by the sticky chrome (header + breadcrumb sub-bar) so the
+            // card lands just under it rather than behind it. Tracks HEADER_H
+            // so a header resize keeps the same tuck.
+            const top = window.scrollY + card.getBoundingClientRect().top - (HEADER_H + 24);
             window.scrollTo({ top: Math.max(0, top), behavior: "smooth" });
           }
-          setFlashStep(n);
+          setFlashId(id);
         }));
         if (flashTimer.current) clearTimeout(flashTimer.current);
-        flashTimer.current = setTimeout(() => setFlashStep(null), 1400);
+        flashTimer.current = setTimeout(() => setFlashId(null), 1400);
       };
 
+      // Deep links of the form /conversations/:id#generation_id open and flash
+      // the matching step once the detail payload is loaded.
+      useEffect(() => {
+        const syncHash = () => setHashGenID(generationIDFromHash());
+        window.addEventListener("hashchange", syncHash);
+        window.addEventListener("popstate", syncHash);
+        return () => {
+          window.removeEventListener("hashchange", syncHash);
+          window.removeEventListener("popstate", syncHash);
+        };
+      }, []);
+      useEffect(() => {
+        if (hashGenID && rowByGen.has(hashGenID)) jumpTo(hashGenID);
+      }, [hashGenID, rowByGen]);
+
       const totalSec = steps.reduce((acc, s) => acc + (s.duration_seconds || 0), 0);
-      const peakSec  = steps.reduce((acc, s) => Math.max(acc, s.duration_seconds || 0), 0);
       const totalTok = steps.reduce((acc, s) => acc + (s.total_tokens || 0), 0);
-      let peakIdx = -1;
-      steps.forEach((s, i) => { if (peakSec > 0 && peakIdx === -1 && (s.duration_seconds || 0) === peakSec) peakIdx = i; });
+      const nSub = subagentRuns(forest).length;
+      const allOpen = expanded.size >= rows.length;
+      const toggleAll = () => setExpanded(allOpen ? new Set() : new Set(rows.map(r => r.gen.generation_id)));
+
+      // Hotspots: the few steps actually worth looking at — the slowest, the
+      // most token-hungry, and any errors. Encoding every step is illegible
+      // on a long trace; flagging the outliers is what surfaces "what should
+      // I look at here". maxBy returns the row, not the value.
+      const hot = useMemo(() => {
+        if (rows.length === 0) return null;
+        const pick = val => rows.reduce((a, r) => (val(r) > val(a) ? r : a), rows[0]);
+        const errors = rows.filter(r => r.gen.call_error);
+        const slowest = pick(r => r.gen.duration_seconds || 0);
+        const mostGenerated = pick(r => stepTokenWork(r.gen).generated);
+        const mostRead = pick(r => stepTokenWork(r.gen).ingested);
+        // hotById matches each minimap nub / tooltip badge to its Hotspots
+        // chip. Assigned weakest-first so the strongest signal wins when a
+        // step is several hotspots at once: error > slowest > generated > read.
+        const hotById = new Map();
+        hotById.set(mostRead.gen.generation_id, { color: "var(--viz-blue)", label: "most read" });
+        hotById.set(mostGenerated.gen.generation_id, { color: "var(--viz-orange)", label: "most generated" });
+        hotById.set(slowest.gen.generation_id, { color: "var(--warning-text)", label: "slowest" });
+        errors.forEach(r => hotById.set(r.gen.generation_id, { color: "var(--error-text)", label: "error" }));
+        return { errors, slowest, mostGenerated, mostRead, hotById };
+      }, [rows]);
+
+      const hidden = row => row.runPath.some(id => collapsed.has(id));
+      const headerHidden = row => row.runPath.slice(0, -1).some(id => collapsed.has(id));
+
+      const linkBtn = { background: "transparent", border: "none", color: "var(--fg3)", cursor: "pointer", fontSize: 11, fontFamily: "var(--fontFamily)", padding: 0 };
+
+      const header = (
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <span style={{ fontSize: 13, color: "var(--fg1)", fontWeight: 500 }}>Thread</span>
+          <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--fg3)" }}>
+            {steps.length} {steps.length === 1 ? "call" : "calls"}{nSub > 0 ? ` · ${nSub} subagent${nSub === 1 ? "" : "s"}` : ""} · {formatTokens(totalTok)} tok · {formatDuration(totalSec)}
+          </span>
+          <span style={{ flex: 1 }}/>
+          {view === "tree" && <button onClick={toggleAll} style={linkBtn} onMouseEnter={e => e.currentTarget.style.color = "var(--fg1)"} onMouseLeave={e => e.currentTarget.style.color = "var(--fg3)"}>{allOpen ? "Collapse all" : "Expand all"}</button>}
+          {hasSubagents && (
+            <Segmented size="sm" value={view} onChange={setView} options={[{ value: "tree", label: "Steps" }, { value: "timeline", label: "Timeline" }]}/>
+          )}
+        </div>
+      );
+
+      if (view === "timeline") {
+        return (
+          <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+            {header}
+            <TimelineView forest={forest} turns={turns} onSelectGen={jumpTo} activeGenId={(rows[activeN - 1] || {}).gen ? rows[activeN - 1].gen.generation_id : null}/>
+            <div style={{ fontSize: 11, color: "var(--fg3)" }}>Click a bar to open that step.</div>
+          </div>
+        );
+      }
+
+      // Build the visible render list (interleaving subagent chips), so each
+      // item knows whether it is the last — for clean separator handling.
+      const items = [];
+      rows.forEach(row => {
+        const turn = turnByStartId.get(row.gen.generation_id);
+        if (turn && !hidden(row)) items.push({ kind: "turn", turn });
+        if (row.isRunStart && !headerHidden(row)) items.push({ kind: "head", row });
+        if (!hidden(row)) items.push({ kind: "step", row, turnStart: !!turn });
+      });
 
       return (
-        <div style={{ display: "flex", alignItems: "flex-start", gap: 24 }}>
-          <StepRail steps={steps} activeStep={activeStep} peakIdx={peakIdx} onSelect={selectStep}/>
-          <div style={{ flex: 1, minWidth: 0, maxWidth: 920, display: "flex", flexDirection: "column", gap: 12 }}>
-            <div style={{ borderBottom: "1px solid var(--border-weak)", paddingBottom: 9, display: "flex", alignItems: "center", gap: 8 }}>
-              <Icon name="list" size={13} style={{ color: "var(--fg3)" }}/>
-              <span style={{ fontSize: 13, color: "var(--fg1)", fontWeight: 500 }}>Conversation thread</span>
-              <span style={{ flex: 1 }}/>
-              <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--fg2)" }}>
-                {steps.length} {steps.length === 1 ? "call" : "calls"} · peak {formatDuration(peakSec)} · {formatTokens(totalTok)} tok · {formatDuration(totalSec)} aggregate
-              </span>
-            </div>
-            <div>
-              {steps.map((s, i) => <StepCard key={s.generation_id || i} step={s} n={i + 1} expanded={expanded.has(i + 1)} onToggle={() => toggle(i + 1)} innerRef={el => { cardRefs.current[i + 1] = el; }} flash={flashStep === i + 1}/>)}
+        <div style={{ display: "flex", justifyContent: "center" }}>
+          <div style={{ flex: 1, minWidth: 0, maxWidth: 940, display: "flex", flexDirection: "column", gap: 14 }}>
+            {header}
+            {hot && rows.length > 2 && <Hotspots hot={hot} onJump={jumpTo}/>}
+            <div style={{ border: "1px solid var(--border-weak)", borderRadius: 3, overflow: "hidden", background: "var(--bg-primary)" }}>
+              {items.length === 0 ? (
+                <div style={{ color: "var(--fg2)", fontSize: 12, fontFamily: "var(--fontFamilyMonospace)", padding: "14px 16px" }}>
+                  No turns match this filter. Clear it to see all {rows.length} steps.
+                </div>
+              ) : items.map((item, idx) => {
+                const last = idx === items.length - 1;
+                if (item.kind === "turn") {
+                  const t = item.turn;
+                  return <TurnHeader key={`t${t.startGenId}`} turn={t} last={last}/>;
+                }
+                const { row } = item;
+                const id = row.gen.generation_id;
+                const c = agentColor(row.run.agent);
+                if (item.kind === "head") {
+                  const run = row.run;
+                  const isCol = collapsed.has(run.id);
+                  return (
+                    <div key={`h${id}`} onClick={() => toggleRun(run.id)} style={{
+                      display: "flex", alignItems: "center", gap: 8,
+                      height: 32, paddingRight: 12, paddingLeft: 12 + (row.depth - 1) * 16,
+                      cursor: "pointer", borderBottom: last ? "none" : "1px solid var(--border-weak)",
+                      borderLeft: `2px solid ${c}`, background: "rgba(204,204,220,0.025)",
+                    }}>
+                      <Icon name={isCol ? "cright" : "chevron"} size={12} style={{ color: "var(--fg3)" }}/>
+                      <svg width={11} height={11} viewBox="0 0 24 24" fill="none" stroke={c} strokeWidth="2"><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></svg>
+                      <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 12, color: "var(--fg1)" }}>{agentShort(run.agent)}</span>
+                      {run.hasError && <span style={{ display: "inline-flex", alignItems: "center", height: 15, padding: "0 5px", borderRadius: 2, background: "var(--error-transparent)", color: "var(--error-text)", fontSize: 10, fontFamily: "var(--fontFamilyMonospace)" }}>error</span>}
+                      <span style={{ flex: 1 }}/>
+                      <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--fg3)" }}>
+                        {run.gens.length} {run.gens.length === 1 ? "step" : "steps"} · {formatDuration((run.end - run.start) / 1000)} · {formatTokens(run.totalTokens)}
+                      </span>
+                    </div>
+                  );
+                }
+                return (
+                  <div key={`s${id}`} style={{ position: "relative", paddingLeft: row.depth * 16 }}>
+                    {row.depth > 0 && <span style={{ position: "absolute", left: row.depth * 16 - 1, top: 0, bottom: 0, width: 2, background: c, opacity: 0.35 }}/>}
+                    <StepCard step={row.gen} n={row.n} total={rows.length} accent={c}
+                      expanded={expanded.has(id)} onToggle={() => toggleStep(id)} active={row.n === activeN} last={last}
+                      innerRef={el => { cardRefs.current[id] = el; }} flash={flashId === id} turnStart={item.turnStart}/>
+                  </div>
+                );
+              })}
             </div>
           </div>
         </div>
@@ -1538,25 +2869,22 @@
 
       // Cache rate from the per-step buckets: the conversation summary is
       // synthesised from the detail on a deep link and omits the aggregate
-      // buckets, so the steps are the reliable source. Mirror the list
-      // KPI: cache reads over cache reads + fresh input, capped at 99% so a
-      // near-perfect cache doesn't round up to a misleading 100%.
+      // buckets, so the steps are the reliable source. Mirror the list KPI:
+      // cache reads over cache reads + cache writes + fresh input.
       const cache = (steps || []).reduce((a, s) => {
         const b = s.token_buckets || {};
         a.read += b.cache_read || 0;
+        a.write += b.cache_write || 0;
         a.fresh += b.fresh_input || 0;
         return a;
-      }, { read: 0, fresh: 0 });
-      const cacheDenom = cache.read + cache.fresh;
-      const cachePct = cacheDenom === 0 ? null
-        : cache.read === cacheDenom ? 100
-        : Math.min(99, Math.round((cache.read / cacheDenom) * 100));
+      }, { read: 0, write: 0, fresh: 0 });
+      const cachePct = cacheInputHitPercent(cache.fresh, cache.read, cache.write);
 
       const stats = [
         { value: formatDuration(wallSec),         unit: "elapsed" },
         { value: String(conv.calls),              unit: conv.calls === 1 ? "call" : "calls" },
         { value: formatTokens(conv.total_tokens), unit: "tokens" },
-        ...(cachePct != null ? [{ value: `${cachePct}%`, unit: "cached", color: "var(--viz-green)" }] : []),
+        ...(cachePct != null ? [{ value: `${cachePct}%`, unit: "input cached", color: "var(--viz-green)" }] : []),
       ];
       const onExport = () => {
         const blob = new Blob([JSON.stringify({ ...conv, generations: steps }, null, 2)], { type: "application/json" });
@@ -1616,7 +2944,7 @@
           <DetailStats conv={conv} steps={detail ? detail.generations : []}/>
           <main style={{ padding: 24 }}>
             <div style={{ maxWidth: 1392, margin: "0 auto" }}>
-              {error && <Notice kind="error" title="Failed to load conversation">{error}</Notice>}
+              {error && <Notice kind="error" title="Failed to load session">{error}</Notice>}
               {!error && loading && <div style={{ color: "var(--fg3)", fontFamily: "var(--fontFamilyMonospace)", fontSize: 12 }}>Loading…</div>}
               {!error && !loading && detail && <ConversationThread steps={detail.generations}/>}
             </div>
@@ -1641,7 +2969,11 @@
       if (a.endpoint !== b.endpoint || a.tenantId !== b.tenantId || a.otlpEndpoint !== b.otlpEndpoint
         || a.token !== b.token || a.tokenCleared !== b.tokenCleared) return false;
       if (a.capture !== b.capture || a.guards !== b.guards || a.guardTimeout !== b.guardTimeout
-        || a.debug !== b.debug || a.autoUpdate !== b.autoUpdate || a.userId !== b.userId) return false;
+        || a.debug !== b.debug || a.autoUpdate !== b.autoUpdate || a.userId !== b.userId
+        || a.localForward !== b.localForward || a.semanticSearch !== b.semanticSearch
+        || a.securityFindingsExport !== b.securityFindingsExport
+        || a.securityAuditSchedule !== b.securityAuditSchedule
+        || a.promptGuardUrl !== b.promptGuardUrl) return false;
       const at = a.tags || [], bt = b.tags || [];
       if (at.length !== bt.length) return false;
       for (let i = 0; i < at.length; i++) {
@@ -1656,22 +2988,8 @@
       return { ...s, tags: (s.tags || []).map(t => ({ ...t })) };
     }
 
-    function Segmented({ value, onChange, options }) {
-      return (
-        <div style={{ display: "inline-flex", padding: 3, gap: 3, background: "var(--bg-canvas)", border: "1px solid var(--border-medium)", borderRadius: 2 }}>
-          {options.map(o => {
-            const active = o.value === value;
-            return (
-              <button key={o.value} onClick={() => onChange(o.value)} style={{
-                padding: "6px 14px", borderRadius: 2, fontSize: 13, border: "none", cursor: "pointer",
-                background: active ? "var(--secondary-main)" : "transparent",
-                color: active ? "var(--fg-max)" : "var(--fg2)",
-                fontWeight: active ? 500 : 400, transition: "background .12s, color .12s",
-              }}>{o.label}</button>
-            );
-          })}
-        </div>
-      );
+    function SettingsSegmented({ value, onChange, options }) {
+      return <PillToggle options={options} value={value} onChange={onChange}/>;
     }
 
     function Toggle({ checked, onChange }) {
@@ -1722,12 +3040,25 @@
       );
     }
 
-    function SettingsCard({ children }) {
-      return <div style={{ background: "var(--bg-primary)", border: "1px solid var(--border-weak)", borderRadius: 2, padding: "4px 20px 10px", marginBottom: 16 }}>{children}</div>;
+    function SettingsCard({ children, style }) {
+      return (
+        <SurfaceCard style={{
+          padding: "4px 20px 12px",
+          marginBottom: 16,
+          ...(style || {}),
+        }}>
+          {children}
+        </SurfaceCard>
+      );
     }
 
     function SectionLabel({ children }) {
-      return <div style={{ padding: "16px 0 2px", fontSize: 11, fontWeight: 600, letterSpacing: ".06em", textTransform: "uppercase", color: "var(--fg3)" }}>{children}</div>;
+      return (
+        <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "16px 0 2px" }}>
+          <span style={{ width: 18, height: 2, borderRadius: 999, background: "var(--brandVertical)" }}/>
+          <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: ".08em", textTransform: "uppercase", color: "var(--fg3)" }}>{children}</span>
+        </div>
+      );
     }
 
     // SettingRow is one label/help + control line inside a card. `full` stacks
@@ -1791,6 +3122,89 @@
       );
     }
 
+
+    function SettingsHero({ form, dirty, path }) {
+      const chips = [
+        { label: "Config", value: dirty ? "Unsaved" : "Synced", tone: dirty ? "var(--brand-orange-text)" : "var(--success-text)" },
+      ];
+      return (
+        <PageHero
+          icon="wrench"
+          kicker="Local viewer settings"
+          title="Settings"
+          desc="Set up cloud connection and local runtime options."
+          chips={chips}>
+          <Box style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--fg3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 720 }}>{path}</Box>
+        </PageHero>
+      );
+    }
+
+    function SettingsTabRail({ tabs, active, onChange }) {
+      return (
+        <div aria-label="Settings sections" style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(128px, 1fr))", gap: 8, marginBottom: 16 }}>
+          {tabs.map(tab => {
+            const isActive = tab.id === active;
+            return (
+              <button key={tab.id} type="button" aria-pressed={isActive} onClick={() => onChange(tab.id)}
+                style={{
+                  position: "relative",
+                  minHeight: 76,
+                  textAlign: "left",
+                  padding: "12px 12px",
+                  borderRadius: 8,
+                  border: `1px solid ${isActive ? "var(--primary-border)" : "var(--border-weak)"}`,
+                  background: isActive ? ACTIVE_PILL_BG : "rgba(24,27,31,0.68)",
+                  color: "var(--fg1)",
+                  cursor: "pointer",
+                  boxShadow: isActive ? "0 12px 28px rgba(0,0,0,0.20)" : "none",
+                }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+                  <span style={{ width: 26, height: 26, display: "inline-flex", alignItems: "center", justifyContent: "center", borderRadius: 7, background: isActive ? "var(--brandVertical)" : "rgba(204,204,220,0.06)", color: isActive ? "#fff" : "var(--fg2)" }}>
+                    <Icon name={tab.icon} size={14}/>
+                  </span>
+                  <span style={{ fontSize: 13, fontWeight: 650, color: isActive ? "var(--fg-max)" : "var(--fg1)" }}>{tab.label}</span>
+                </div>
+                <div style={{ fontSize: 11.5, lineHeight: 1.35, color: "var(--fg3)" }}>{tab.desc}</div>
+                {isActive && <span style={{ position: "absolute", left: 12, right: 12, bottom: -1, height: 2, borderRadius: 999, background: "var(--brandVertical)" }}/>}
+              </button>
+            );
+          })}
+        </div>
+      );
+    }
+
+    function SettingsPreviewPanel({ path, preview, onCopy }) {
+      return (
+        <div style={{ width: "min(440px, 100%)", flex: "1 1 360px", position: "sticky", top: 72 }}>
+          <div style={{
+            overflow: "hidden",
+            background: SURFACE_BG,
+            border: "1px solid var(--border-weak)",
+            borderRadius: 10,
+            boxShadow: "0 18px 42px rgba(0,0,0,0.22)",
+          }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "12px 14px", borderBottom: "1px solid var(--border-weak)" }}>
+              <span style={{ width: 28, height: 28, display: "inline-flex", alignItems: "center", justifyContent: "center", borderRadius: 8, background: "rgba(204,204,220,0.06)", color: "var(--fg2)" }}>
+                <Icon name="list" size={14}/>
+              </span>
+              <div style={{ minWidth: 0, flex: 1 }}>
+                <div style={{ fontSize: 12, fontWeight: 600, color: "var(--fg-max)" }}>config.env preview</div>
+                <div style={{ fontSize: 11, color: "var(--fg3)", fontFamily: "var(--fontFamilyMonospace)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{path}</div>
+              </div>
+              <button onClick={onCopy} style={{ display: "inline-flex", alignItems: "center", gap: 5, background: "transparent", border: "1px solid var(--secondary-border)", color: "var(--fg1)", borderRadius: 6, height: 28, padding: "0 9px", fontSize: 12, cursor: "pointer" }}
+                onMouseEnter={e => e.currentTarget.style.background = "var(--action-hover)"}
+                onMouseLeave={e => e.currentTarget.style.background = "transparent"}>
+                <Icon name="copy" size={13}/>Copy
+              </button>
+            </div>
+            <div style={{ background: "rgba(17,18,23,0.84)", padding: "14px 16px", maxHeight: "calc(100vh - 252px)", overflow: "auto" }}>
+              <PreviewBody text={preview}/>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
     function Toast({ message }) {
       return (
         <div style={{ position: "fixed", top: 60, right: 20, zIndex: 30, display: "flex", alignItems: "center", gap: 8, background: "var(--bg-secondary)", border: "1px solid var(--border-medium)", borderLeft: "3px solid var(--success-border)", borderRadius: 2, padding: "10px 14px", boxShadow: "var(--shadow-z2)", animation: "sigil-tin .2s ease-out" }}>
@@ -1800,8 +3214,126 @@
       );
     }
 
-    const CAPTURE_OPTIONS = [{ value: "metadata_only", label: "Metadata only" }, { value: "full", label: "Full" }];
-    const GUARD_OPTIONS = [{ value: "off", label: "Disabled" }, { value: "failopen", label: "Fail-open" }, { value: "failclosed", label: "Fail-closed" }];
+    const SETTINGS_TABS = [
+      { id: "cloud", label: "Cloud", icon: "cloud", desc: "Ingest and auth" },
+      { id: "local", label: "Local", icon: "box", desc: "Tags and runtime" },
+    ];
+    const SETTINGS_TAB_IDS = new Set(SETTINGS_TABS.map(t => t.id));
+
+    function settingsTabFromLocation() {
+      if (typeof window === "undefined") return "cloud";
+      const params = new URLSearchParams(window.location.search || "");
+      const tab = params.get("tab") || "";
+      return SETTINGS_TAB_IDS.has(tab) ? tab : "cloud";
+    }
+
+    function settingsPath(tab) {
+      const url = new URL("/settings", typeof window !== "undefined" ? window.location.origin : "http://localhost");
+      if (SETTINGS_TAB_IDS.has(tab) && tab !== "cloud") url.searchParams.set("tab", tab);
+      return url.pathname + url.search;
+    }
+
+    function SettingsCloudTab({ form, set }) {
+      return (
+        <SettingsCard>
+          <SectionLabel>Connection</SectionLabel>
+          <div style={{ fontSize: 12, lineHeight: 1.5, color: "var(--fg3)", padding: "0 0 10px" }}>
+            These values apply to your Grafana Cloud sessions.
+          </div>
+          <SettingRow label="Endpoint" help={<>Grafana AI Observability ingest URL.</>}>
+            <MonoInput value={form.endpoint} onChange={v => set({ endpoint: v })} placeholder="https://agento11y-prod-….grafana.net" width={320}/>
+          </SettingRow>
+          <SettingRow label="Tenant ID" help={<>Your stack instance ID.</>}>
+            <MonoInput value={form.tenantId} onChange={v => set({ tenantId: v })} placeholder="123456" width={200}/>
+          </SettingRow>
+          <SettingRow label="Auth token" help={<>Stored locally with <Mono>0600</Mono> perms. Reset to replace or remove the saved token.</>}>
+            {form.tokenSet && !form.tokenCleared && form.token === "" ? (
+              <div style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                <input value="" disabled placeholder="configured" style={{ height: 32, width: 200, background: "var(--bg-canvas)", border: "1px solid var(--border-medium)", borderRadius: 2, color: "var(--fg3)", padding: "0 10px", fontFamily: "var(--fontFamilyMonospace)", fontSize: 12, cursor: "not-allowed" }}/>
+                <GhostButton onClick={() => set({ tokenCleared: true, token: "" })}>Reset</GhostButton>
+              </div>
+            ) : (
+              <MonoInput type="password" value={form.token}
+                onChange={v => set({ token: v, tokenCleared: form.tokenSet && v === "" })}
+                placeholder={form.tokenSet ? "new token, or blank to remove" : "glc_…"} width={260}/>
+            )}
+          </SettingRow>
+          <SettingRow label="OTLP endpoint" help={<>For SDK traces and metrics.</>}>
+            <MonoInput value={form.otlpEndpoint} onChange={v => set({ otlpEndpoint: v })} placeholder="https://otlp-gateway-….grafana.net/otlp" width={320}/>
+          </SettingRow>
+        </SettingsCard>
+      );
+    }
+
+    function SettingsTagsEditor({ tags, setTag, addTag, removeTag }) {
+      return (
+        <SettingsCard>
+          <SectionLabel>Session tags</SectionLabel>
+          <SettingRow full label="Tags" help={<>Applied to every generation as <Mono>key=value</Mono>. Empty pairs are dropped on save.</>}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              {tags.map((t, i) => (
+                <div key={i} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <MonoInput value={t.key} onChange={v => setTag(i, { key: v })} placeholder="key" width={200}/>
+                  <span style={{ color: "var(--fg3)", fontFamily: "var(--fontFamilyMonospace)" }}>=</span>
+                  <MonoInput value={t.value} onChange={v => setTag(i, { value: v })} placeholder="value" width={200}/>
+                  <button onClick={() => removeTag(i)} title="Remove tag" aria-label="Remove tag" style={{
+                    width: 28, height: 28, display: "inline-flex", alignItems: "center", justifyContent: "center",
+                    background: "transparent", border: "1px solid transparent", color: "var(--fg3)", cursor: "pointer", borderRadius: 2,
+                  }}
+                    onMouseEnter={e => e.currentTarget.style.color = "var(--fg1)"}
+                    onMouseLeave={e => e.currentTarget.style.color = "var(--fg3)"}>
+                    <Icon name="times" size={14}/>
+                  </button>
+                </div>
+              ))}
+              <button onClick={addTag} style={{
+                alignSelf: "flex-start", display: "inline-flex", alignItems: "center", gap: 6,
+                height: 30, padding: "0 12px", background: "transparent", border: "1px dashed var(--border-medium)",
+                borderRadius: 999, color: "var(--fg2)", fontSize: 13, cursor: "pointer",
+              }}
+                onMouseEnter={e => e.currentTarget.style.borderColor = "var(--border-strong)"}
+                onMouseLeave={e => e.currentTarget.style.borderColor = "var(--border-medium)"}>
+                <Icon name="plus" size={13}/>Add tag
+              </button>
+            </div>
+          </SettingRow>
+        </SettingsCard>
+      );
+    }
+
+    function SettingsLocalTab({ form, set, setTag, addTag, removeTag }) {
+      return (
+        <>
+          <SettingsTagsEditor tags={form.tags} setTag={setTag} addTag={addTag} removeTag={removeTag}/>
+          <SettingsCard>
+            <SectionLabel>Runtime</SectionLabel>
+            <SettingRow label="Debug logging" help={<>Write a verbose log to <Mono>~/.local/state/agento11y/logs/agento11y.log</Mono>.</>}>
+              <Toggle checked={form.debug} onChange={v => set({ debug: v })}/>
+            </SettingRow>
+            <SettingRow label="Automatic updates" help={<>Keep host agent plugins refreshed automatically. Turn off to pin the current versions.</>}>
+              <Toggle checked={form.autoUpdate} onChange={v => set({ autoUpdate: v })}/>
+            </SettingRow>
+          </SettingsCard>
+          <SettingsCard>
+            <SectionLabel>Identity · Optional</SectionLabel>
+            <SettingRow label="User ID" help={<>Override the resolved user id used to attribute generations. Leave blank to auto-resolve.</>}>
+              <MonoInput value={form.userId} onChange={v => set({ userId: v })} placeholder="auto" width={260}/>
+            </SettingRow>
+          </SettingsCard>
+        </>
+      );
+    }
+
+    function SettingsTabPanels({ activeSettingsTab, form, set, setTag, addTag, removeTag }) {
+      return (
+        <>
+          {activeSettingsTab === "cloud" && <SettingsCloudTab form={form} set={set}/>}
+          {activeSettingsTab === "local" && (
+            <SettingsLocalTab form={form} set={set} setTag={setTag} addTag={addTag} removeTag={removeTag}/>
+          )}
+        </>
+      );
+    }
 
     function SettingsView() {
       const [form, setForm] = useState(null);
@@ -1811,6 +3343,8 @@
       const [loading, setLoading] = useState(true);
       const [error, setError] = useState(null);
       const [toast, setToast] = useState(null);
+      const [activeSettingsTab, setActiveSettingsTab] = useState(settingsTabFromLocation);
+      const [visitedSettingsTabs, setVisitedSettingsTabs] = useState(() => new Set([settingsTabFromLocation()]));
       const toastTimer = useRef(null);
 
       const showToast = useCallback((msg) => {
@@ -1839,6 +3373,16 @@
         return () => { alive = false; };
       }, []);
 
+      useEffect(() => {
+        const syncTab = () => {
+          const tab = settingsTabFromLocation();
+          setActiveSettingsTab(tab);
+          setVisitedSettingsTabs(prev => prev.has(tab) ? prev : new Set(prev).add(tab));
+        };
+        window.addEventListener("popstate", syncTab);
+        return () => window.removeEventListener("popstate", syncTab);
+      }, []);
+
       // Live preview: the daemon renders exactly what it would write, so the
       // panel never drifts from the file. Debounced to coalesce keystrokes.
       // Each run aborts the prior in-flight request and ignores its result, so
@@ -1856,7 +3400,7 @@
         return () => { ignore = true; controller.abort(); clearTimeout(t); };
       }, [form]);
 
-      const page = { maxWidth: 1300, margin: "0 auto", padding: "28px 24px 110px", width: "100%" };
+      const page = { maxWidth: 1360, margin: "0 auto", padding: "28px 24px 110px", width: "100%" };
       if (loading && !form) {
         return <div style={page}><Notice kind="info" title="Loading settings…">Reading config.env.</Notice></div>;
       }
@@ -1865,9 +3409,6 @@
       }
 
       const dirty = !sameSettings(form, saved);
-      const captureUnset = form.capture === "";
-      const advanced = form.capture === "no_tool_content" || form.capture === "full_with_metadata_spans";
-      const guardsOn = form.guards !== "off";
       const set = (patch) => setForm(f => ({ ...f, ...patch }));
       const setTag = (i, patch) => setForm(f => ({ ...f, tags: f.tags.map((t, j) => j === i ? { ...t, ...patch } : t) }));
       const addTag = () => setForm(f => ({ ...f, tags: [...f.tags, { key: "", value: "" }] }));
@@ -1891,133 +3432,33 @@
           navigator.clipboard.writeText(preview).then(() => showToast("Copied to clipboard.")).catch(() => {});
         }
       };
+      const selectTab = (tab) => {
+        if (!SETTINGS_TAB_IDS.has(tab)) return;
+        setActiveSettingsTab(tab);
+        setVisitedSettingsTabs(prev => prev.has(tab) ? prev : new Set(prev).add(tab));
+        if (typeof window !== "undefined") window.history.pushState({}, "", settingsPath(tab));
+      };
 
       return (
         <div style={page}>
-          <h1 style={{ fontSize: 20, fontWeight: 500, color: "var(--fg-max)", margin: "0 0 20px" }}>Settings</h1>
+          <SettingsHero form={form} dirty={dirty} path={path}/>
 
           {error && <div style={{ marginBottom: 16 }}><Notice kind="error" title="Couldn’t save settings">{error}</Notice></div>}
 
-          <div style={{ display: "flex", gap: 24, alignItems: "flex-start" }}>
-            <div style={{ flex: "1 1 0", minWidth: 0 }}>
-              <SettingsCard>
-                <SectionLabel>Connection</SectionLabel>
-                <div style={{ fontSize: 12, lineHeight: 1.5, color: "var(--fg3)", padding: "0 0 10px" }}>
-                  These values apply to your Grafana Cloud sessions.
-                </div>
-                <SettingRow label="Endpoint" help={<>Grafana Agent Observability ingest URL.</>}>
-                  <MonoInput value={form.endpoint} onChange={v => set({ endpoint: v })} placeholder="https://agento11y-prod-….grafana.net" width={320}/>
-                </SettingRow>
-                <SettingRow label="Tenant ID" help={<>Your stack instance ID.</>}>
-                  <MonoInput value={form.tenantId} onChange={v => set({ tenantId: v })} placeholder="123456" width={200}/>
-                </SettingRow>
-                <SettingRow label="Auth token" help={<>Stored locally with <Mono>0600</Mono> perms. Reset to replace or remove the saved token.</>}>
-                  {form.tokenSet && !form.tokenCleared && form.token === "" ? (
-                    <div style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
-                      <input value="" disabled placeholder="configured" style={{ height: 32, width: 200, background: "var(--bg-canvas)", border: "1px solid var(--border-medium)", borderRadius: 2, color: "var(--fg3)", padding: "0 10px", fontFamily: "var(--fontFamilyMonospace)", fontSize: 12, cursor: "not-allowed" }}/>
-                      <GhostButton onClick={() => set({ tokenCleared: true, token: "" })}>Reset</GhostButton>
-                    </div>
-                  ) : (
-                    <MonoInput type="password" value={form.token}
-                      onChange={v => set({ token: v, tokenCleared: form.tokenSet && v === "" })}
-                      placeholder={form.tokenSet ? "new token, or blank to remove" : "glc_…"} width={260}/>
-                  )}
-                </SettingRow>
-                <SettingRow label="OTLP endpoint" help={<>For SDK traces and metrics.</>}>
-                  <MonoInput value={form.otlpEndpoint} onChange={v => set({ otlpEndpoint: v })} placeholder="https://otlp-gateway-….grafana.net/otlp" width={320}/>
-                </SettingRow>
-                <SettingRow
-                  label="Content capture mode"
-                  help={<>
-                    What content agento11y sends to Grafana Cloud for each generation. <Mono>--local</Mono> sessions always capture full content on this machine.
-                    {captureUnset && <div style={{ color: "var(--fg3)", marginTop: 6 }}>Not set: Grafana Cloud sessions capture metadata only. Pick a mode to pin it.</div>}
-                    {advanced && <div style={{ color: "var(--warning-text)", marginTop: 6 }}>Advanced mode <Mono>{form.capture}</Mono> is set in config.env and will be preserved.</div>}
-                  </>}
-                >
-                  <Segmented value={form.capture} onChange={v => set({ capture: v })} options={CAPTURE_OPTIONS}/>
-                </SettingRow>
-              </SettingsCard>
-
-              <SettingsCard>
-                <SectionLabel>Tags</SectionLabel>
-                <SettingRow full label="Session tags" help={<>Applied to every generation as <Mono>key=value</Mono>. Empty pairs are dropped on save.</>}>
-                  <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                    {form.tags.map((t, i) => (
-                      <div key={i} style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                        <MonoInput value={t.key} onChange={v => setTag(i, { key: v })} placeholder="key" width={200}/>
-                        <span style={{ color: "var(--fg3)", fontFamily: "var(--fontFamilyMonospace)" }}>=</span>
-                        <MonoInput value={t.value} onChange={v => setTag(i, { value: v })} placeholder="value" width={200}/>
-                        <button onClick={() => removeTag(i)} title="Remove tag" aria-label="Remove tag" style={{
-                          width: 28, height: 28, display: "inline-flex", alignItems: "center", justifyContent: "center",
-                          background: "transparent", border: "1px solid transparent", color: "var(--fg3)", cursor: "pointer", borderRadius: 2,
-                        }}
-                          onMouseEnter={e => e.currentTarget.style.color = "var(--fg1)"}
-                          onMouseLeave={e => e.currentTarget.style.color = "var(--fg3)"}>
-                          <Icon name="times" size={14}/>
-                        </button>
-                      </div>
-                    ))}
-                    <button onClick={addTag} style={{
-                      alignSelf: "flex-start", display: "inline-flex", alignItems: "center", gap: 6,
-                      height: 30, padding: "0 12px", background: "transparent", border: "1px dashed var(--border-medium)",
-                      borderRadius: 2, color: "var(--fg2)", fontSize: 13, cursor: "pointer",
-                    }}
-                      onMouseEnter={e => e.currentTarget.style.borderColor = "var(--border-strong)"}
-                      onMouseLeave={e => e.currentTarget.style.borderColor = "var(--border-medium)"}>
-                      <Icon name="plus" size={13}/>Add tag
-                    </button>
-                  </div>
-                </SettingRow>
-              </SettingsCard>
-
-              <SettingsCard>
-                <SectionLabel>Guards</SectionLabel>
-                <SettingRow label="Pre-tool-use guards" help={<>Run safety checks before each tool call. <b style={{ fontWeight: 500, color: "var(--fg2)" }}>Fail-open</b> allows the action if a check errors or times out; <b style={{ fontWeight: 500, color: "var(--fg2)" }}>fail-closed</b> blocks it.</>}>
-                  <Segmented value={form.guards} onChange={v => set({ guards: v })} options={GUARD_OPTIONS}/>
-                </SettingRow>
-                {guardsOn && (
-                  <SettingRow label="Guard timeout" help={<>Max time for a guard check to respond. Clear the field to use the default of 1500 ms.</>}>
-                    <div style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
-                      <MonoInput value={form.guardTimeout} onChange={v => set({ guardTimeout: v })} placeholder="1500" width={110} align="right"/>
-                      <span style={{ fontSize: 12, color: "var(--fg3)" }}>ms</span>
-                    </div>
-                  </SettingRow>
-                )}
-              </SettingsCard>
-
-              <SettingsCard>
-                <SectionLabel>Runtime</SectionLabel>
-                <SettingRow label="Debug logging" help={<>Write a verbose log to <Mono>~/.local/state/agento11y/logs/agento11y.log</Mono>.</>}>
-                  <Toggle checked={form.debug} onChange={v => set({ debug: v })}/>
-                </SettingRow>
-                <SettingRow label="Automatic updates" help={<>Keep host agent plugins refreshed automatically. Turn off to pin the current versions.</>}>
-                  <Toggle checked={form.autoUpdate} onChange={v => set({ autoUpdate: v })}/>
-                </SettingRow>
-              </SettingsCard>
-
-              <SettingsCard>
-                <SectionLabel>Identity · Optional</SectionLabel>
-                <SettingRow label="User ID" help={<>Override the resolved user id used to attribute generations. Leave blank to auto-resolve.</>}>
-                  <MonoInput value={form.userId} onChange={v => set({ userId: v })} placeholder="auto" width={260}/>
-                </SettingRow>
-              </SettingsCard>
+          <div style={{ display: "flex", gap: 24, alignItems: "flex-start", flexWrap: "wrap" }}>
+            <div style={{ flex: "999 1 560px", minWidth: 0 }}>
+              <SettingsTabRail tabs={SETTINGS_TABS} active={activeSettingsTab} onChange={selectTab}/>
+              <SettingsTabPanels
+                activeSettingsTab={activeSettingsTab}
+                form={form}
+                set={set}
+                setTag={setTag}
+                addTag={addTag}
+                removeTag={removeTag}
+              />
             </div>
 
-            <div style={{ width: 440, flexShrink: 0, position: "sticky", top: 72 }}>
-              <div style={{ background: "var(--bg-primary)", border: "1px solid var(--border-weak)", borderRadius: 2 }}>
-                <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "10px 14px", borderBottom: "1px solid var(--border-weak)" }}>
-                  <span style={{ fontSize: 12, color: "var(--fg2)", fontFamily: "var(--fontFamilyMonospace)", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{path}</span>
-                  <button onClick={copy} style={{ display: "inline-flex", alignItems: "center", gap: 5, background: "transparent", border: "1px solid var(--secondary-border)", color: "var(--fg1)", borderRadius: 2, height: 26, padding: "0 8px", fontSize: 12, cursor: "pointer" }}
-                    onMouseEnter={e => e.currentTarget.style.background = "var(--action-hover)"}
-                    onMouseLeave={e => e.currentTarget.style.background = "transparent"}>
-                    <Icon name="copy" size={13}/>Copy
-                  </button>
-                </div>
-                <div style={{ background: "var(--bg-canvas)", padding: "14px 16px", maxHeight: "calc(100vh - 220px)", overflow: "auto" }}>
-                  <PreviewBody text={preview}/>
-                </div>
-              </div>
-            </div>
+            <SettingsPreviewPanel path={path} preview={preview} onCopy={copy}/>
           </div>
 
           {dirty && <UnsavedBar onReset={reset} onSave={save}/>}
@@ -2047,9 +3488,19 @@
       return `/conversations/${encodeURIComponent(id)}`;
     }
 
-    // settingsRouteActive reports whether the URL is the Settings tab. It is
-    // the only non-conversation route; every other path is the conversations
-    // section (the list, or a detail when conversationIDFromPath matches).
+    function conversationGenerationPath(id, generationID) {
+      const url = new URL(conversationPath(id), window.location.origin);
+      if (generationID) url.hash = generationID;
+      return url.pathname + url.hash;
+    }
+
+    function generationIDFromHash() {
+      const raw = (window.location.hash || "").replace(/^#/, "");
+      if (!raw) return "";
+      try { return decodeURIComponent(raw); } catch { return raw; }
+    }
+
+    // settingsRouteActive reports whether the URL is the Settings tab.
     function settingsRouteActive() {
       if (typeof window === "undefined") return false;
       return window.location.pathname.replace(/\/$/, "") === "/settings";
@@ -2120,6 +3571,379 @@
       return [value, set];
     }
 
+
+    // ---------- generic UI primitives ----------
+
+    function Switch({ checked, onChange, size = "md", title }) {
+      const w = size === "sm" ? 28 : 34, h = size === "sm" ? 16 : 20, knob = h - 4;
+      return (
+        <button type="button" role="switch" aria-checked={checked} title={title}
+          onClick={e => { e.stopPropagation(); onChange(!checked); }}
+          style={{
+            width: w, height: h, flexShrink: 0, borderRadius: 9999, border: "none", cursor: "pointer", padding: 0,
+            background: checked ? "var(--primary-main)" : "rgba(204,204,220,0.20)",
+            position: "relative", transition: "background 120ms ease",
+          }}>
+          <span style={{ position: "absolute", top: 2, left: checked ? w - knob - 2 : 2, width: knob, height: knob, borderRadius: "50%", background: "#fff", transition: "left 120ms ease" }}/>
+        </button>
+      );
+    }
+
+    function Segmented({ value, onChange, options, size = "md" }) {
+      return (
+        <div style={{ display: "inline-flex", border: "1px solid var(--border-medium)", borderRadius: 2, overflow: "hidden" }}>
+          {options.map((o, i) => {
+            const active = o.value === value;
+            return (
+              <button key={o.value} type="button" onClick={() => onChange(o.value)} style={{
+                padding: size === "sm" ? "3px 10px" : "5px 12px",
+                background: active ? "var(--action-selected)" : "transparent",
+                color: active ? "var(--fg-max)" : "var(--fg2)",
+                border: "none", borderLeft: i > 0 ? "1px solid var(--border-medium)" : "none",
+                cursor: active ? "default" : "pointer", fontSize: 12, fontWeight: active ? 500 : 400,
+                fontFamily: "var(--fontFamily)", whiteSpace: "nowrap",
+              }}>{o.label}</button>
+            );
+          })}
+        </div>
+      );
+    }
+
+    const BADGE_TONES = {
+      block:     { bg: "var(--error-transparent)",   fg: "var(--error-text)",   bd: "var(--error-border)" },
+      redact:    { bg: "var(--warning-transparent)", fg: "var(--warning-text)", bd: "var(--warning-border)" },
+      regex:     { bg: "var(--info-transparent)",    fg: "var(--primary-text)", bd: "var(--primary-text)" },
+      cloud:     { bg: "rgba(204,204,220,0.06)",     fg: "var(--fg2)",          bd: "var(--border-medium)" },
+      preflight: { bg: "transparent",                fg: "var(--warning-text)", bd: "var(--warning-border)" },
+    };
+    function Badge({ tone = "cloud", children }) {
+      const t = BADGE_TONES[tone] || BADGE_TONES.cloud;
+      return (
+        <span style={{
+          display: "inline-flex", alignItems: "center", height: 16, padding: "0 6px", borderRadius: 2,
+          background: t.bg, color: t.fg, border: `1px solid ${t.bd}`,
+          fontSize: 9.5, letterSpacing: "0.06em", textTransform: "uppercase",
+          fontFamily: "var(--fontFamilyMonospace)", whiteSpace: "nowrap",
+        }}>{children}</span>
+      );
+    }
+    function btnStyle(kind) {
+      const base = { display: "inline-flex", alignItems: "center", justifyContent: "center", gap: 6, height: 32, padding: "0 12px", borderRadius: 8, fontSize: 12.5, fontWeight: 500, fontFamily: "var(--fontFamily)", whiteSpace: "nowrap" };
+      if (kind === "primary") return { ...base, background: "var(--primary-main)", color: "#fff", border: "1px solid var(--primary-border)" };
+      if (kind === "danger")  return { ...base, background: "transparent", color: "var(--error-text)", border: "1px solid var(--error-border)" };
+      return { ...base, background: "rgba(17,18,23,0.30)", color: "var(--fg1)", border: "1px solid var(--border-medium)" };
+    }
+    function Button({ kind = "secondary", icon, children, disabled, onClick, title, style }) {
+      return (
+        <button type="button" title={title} disabled={disabled} onClick={onClick}
+          style={{ ...btnStyle(kind), opacity: disabled ? 0.45 : 1, cursor: disabled ? "not-allowed" : "pointer", ...(style || {}) }}>
+          {icon && <Icon name={icon} size={13}/>}{children}
+        </button>
+      );
+    }
+
+    const fieldInput = {
+      width: "100%", height: 34, padding: "0 10px", border: "1px solid var(--border-medium)", borderRadius: 2,
+      background: "var(--bg-canvas)", color: "var(--fg1)", fontSize: 13, fontFamily: "var(--fontFamily)", outline: "none",
+    };
+    const monoInput = { ...fieldInput, fontFamily: "var(--fontFamilyMonospace)", fontSize: 12 };
+    const sectionLabel = { display: "block", fontSize: 11, color: "var(--fg3)", textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 7 };
+
+    function FieldLabel({ children, hint }) {
+      return (
+        <label style={sectionLabel}>
+          {children}
+          {hint && <span style={{ textTransform: "none", letterSpacing: 0, color: "var(--fg3)", marginLeft: 8, fontSize: 11 }}>{hint}</span>}
+        </label>
+      );
+    }
+
+    function Section({ title, children, defaultOpen = true }) {
+      const [open, setOpen] = useState(defaultOpen);
+      return (
+        <div style={{ border: "1px solid var(--border-weak)", borderRadius: 2, marginBottom: 12 }}>
+          <button type="button" onClick={() => setOpen(o => !o)} style={{ display: "flex", alignItems: "center", gap: 8, width: "100%", padding: "10px 12px", background: "transparent", border: "none", cursor: "pointer", color: "var(--fg1)" }}>
+            <Icon name={open ? "chevron" : "cright"} size={12} style={{ color: "var(--fg3)" }}/>
+            <span style={{ fontSize: 12, fontWeight: 500, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--fg2)" }}>{title}</span>
+          </button>
+          {open && <div style={{ padding: "4px 14px 16px" }}>{children}</div>}
+        </div>
+      );
+    }
+
+
+    // SEARCH_DEBOUNCE_MS controls how long after the last keystroke the
+    // viewer waits before issuing the search request. 320ms matches the
+    // upper end of the design handoff's 320–340ms window: snappy enough to
+    // feel live, slow enough to coalesce typing into one network call.
+    const SEARCH_DEBOUNCE_MS = 320;
+
+    // escapeRegExp escapes the special-meaning characters in a query token
+    // before splicing into the alternation regex that drives highlighting.
+    // Keeps a literal "a+b" highlighting "a+b" rather than "aab".
+    function escapeRegExp(s) {
+      return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    }
+
+    // highlightTerms renders `text` with each whitespace-separated term in
+    // `query` wrapped in a `<mark>` carrying the warm-wash style. Tokens
+    // are lower-cased and deduped (so "rate rate" doesn't compile a
+    // doubled alternation), and the split keeps the original text casing
+    // outside the matches.
+    function highlightTerms(text, query) {
+      if (!text) return text;
+      const terms = String(query || "").toLowerCase().split(/\s+/).filter(Boolean);
+      if (terms.length === 0) return text;
+      const uniq = Array.from(new Set(terms)).map(escapeRegExp);
+      const re = new RegExp(`(${uniq.join("|")})`, "ig");
+      const parts = String(text).split(re);
+      const wash = {
+        color: "var(--fg-max)",
+        fontWeight: 500,
+        background: "rgba(245,183,61,0.18)",
+        boxShadow: "inset 0 -1px 0 rgba(245,183,61,0.45)",
+        borderRadius: 2,
+        padding: "0 2px",
+      };
+      return parts.map((part, i) => {
+        if (!part) return null;
+        return re.test(part)
+          ? <mark key={i} style={wash}>{part}</mark>
+          : <React.Fragment key={i}>{part}</React.Fragment>;
+      });
+    }
+
+    // SearchResultRow is one ranked hit. Stays consistent with ConvRow:
+    // dense mono grid, left status accent, agent/model pills, two-line
+    // clamp on the snippet. The row is a real anchor so cmd/ctrl-click
+    // opens in a new tab without us re-implementing the browser.
+    function SearchResultRow({ hit, now, query, selected, onSelect, onOpen }) {
+      // Status is "err" when any generation in the conversation
+      // recorded a CallError, otherwise "ok" — see
+      // searchConversationFile and the qmd-fallback summary path.
+      const accent = hit.status === "err" ? "var(--error-border)" : "var(--border-medium)";
+      const ago = hit.last_activity ? formatAgo(hit.last_activity, now) : "";
+      const titleEl = highlightTerms(hit.title || hit.id, query);
+      const snippetEl = highlightTerms(hit.snippet || "", query);
+      const matchCount = hit.match_count || 0;
+      return (
+        <a href={conversationPath(hit.id)}
+          onMouseEnter={onSelect}
+          onClick={e => {
+            if (!isPlainLeftClick(e)) return;
+            e.preventDefault();
+            onOpen(hit);
+          }}
+          style={{
+            display: "block",
+            padding: "11px 16px 12px",
+            borderBottom: "1px solid var(--border-weak)",
+            borderLeft: `3px solid ${accent}`,
+            background: selected ? "rgba(204,204,220,0.06)" : "transparent",
+            cursor: "pointer", textDecoration: "none", color: "inherit",
+            transition: "background 80ms ease",
+          }}
+          onMouseOver={e => { if (!selected) e.currentTarget.style.background = "var(--row-hover)"; }}
+          onMouseOut={e => { if (!selected) e.currentTarget.style.background = "transparent"; }}>
+          <div style={{
+            display: "grid",
+            gridTemplateColumns: "76px minmax(0,1fr) auto",
+            columnGap: 16,
+            alignItems: "baseline",
+          }}>
+            <span style={{ color: "var(--fg3)", fontFamily: "var(--fontFamilyMonospace)", fontSize: 12 }}>{ago}</span>
+            <div style={{ display: "flex", alignItems: "baseline", gap: 8, flexWrap: "wrap", minWidth: 0 }}>
+              <span style={{ fontFamily: "var(--fontFamily)", fontSize: 14, fontWeight: 500, color: "var(--fg1)" }}>{titleEl}</span>
+              {hit.title && hit.title !== hit.id && (
+                <span style={{ fontFamily: "var(--fontFamilyMonospace)", fontSize: 11, color: "var(--fg3)" }}>{hit.id}</span>
+              )}
+            </div>
+            <div style={{ display: "inline-flex", alignItems: "center", gap: 10, color: "var(--fg2)", fontFamily: "var(--fontFamilyMonospace)", fontSize: 12 }}>
+              {(hit.agents || []).map(a => <AgentPill key={a} name={a} size="sm"/>)}
+              {(hit.models || []).map(m => <ModelPill key={m} name={m}/>)}
+              <span>{formatTokens(hit.total_tokens)} · {hit.calls} {hit.calls === 1 ? "call" : "calls"}</span>
+            </div>
+          </div>
+          <div style={{
+            display: "grid",
+            gridTemplateColumns: "76px minmax(0,1fr)",
+            columnGap: 16,
+            marginTop: 7,
+          }}>
+            <span/>
+            <div style={{
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+              overflow: "hidden",
+              fontFamily: "var(--fontFamilyMonospace)",
+              fontSize: 12,
+              color: "var(--fg2)",
+              lineHeight: 1.5,
+            }}>
+              <span style={{
+                fontFamily: "var(--fontFamilyMonospace)",
+                fontSize: 11,
+                color: "var(--warning-main)",
+                background: "rgba(245,183,61,0.10)",
+                border: "1px solid rgba(245,183,61,0.30)",
+                borderRadius: 2,
+                padding: "0 5px",
+                marginRight: 8,
+              }}>{matchCount} {matchCount === 1 ? "match" : "matches"}</span>
+              {hit.snippet ? <>…{snippetEl}</> : <span style={{ color: "var(--fg3)" }}>No preview available.</span>}
+            </div>
+          </div>
+        </a>
+      );
+    }
+
+    function useSearchResults(query) {
+      const [phase, setPhase] = useState("done");      // "done" | "loading"
+      const [hits, setHits] = useState([]);
+      const [mode, setMode] = useState("fts");
+      const [error, setError] = useState(null);
+      const [selectedIndex, setSelectedIndex] = useState(-1);
+      const [retryNonce, setRetryNonce] = useState(0);
+      const debounceRef = useRef(null);
+      const abortRef = useRef(null);
+      const trimmed = query.trim();
+
+      useEffect(() => { setSelectedIndex(-1); }, [query]);
+
+      useEffect(() => {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        if (abortRef.current) abortRef.current.abort();
+
+        if (!trimmed) {
+          setPhase("done");
+          setHits([]);
+          setError(null);
+          return undefined;
+        }
+        setPhase("loading");
+        setError(null);
+        const controller = new AbortController();
+        abortRef.current = controller;
+        const timer = setTimeout(() => {
+          fetch(`/api/v1/search?q=${encodeURIComponent(trimmed)}`, { signal: controller.signal })
+            .then(r => r.ok ? r.json() : r.text().then(t => Promise.reject(new Error(t || `HTTP ${r.status}`))))
+            .then(body => {
+              setHits(Array.isArray(body.hits) ? body.hits : []);
+              setMode(body.mode || "fts");
+              setPhase("done");
+            })
+            .catch(e => {
+              if (e && e.name === "AbortError") return;
+              setError(String(e.message || e));
+              setPhase("done");
+            });
+        }, SEARCH_DEBOUNCE_MS);
+        debounceRef.current = timer;
+        return () => clearTimeout(timer);
+      }, [trimmed, retryNonce]);
+
+      useEffect(() => () => {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        if (abortRef.current) abortRef.current.abort();
+      }, []);
+
+      const retry = useCallback(() => setRetryNonce(n => n + 1), []);
+      return { phase, hits, mode, error, selectedIndex, setSelectedIndex, retry };
+    }
+
+    function ConversationSearchPanel({ query, hits, phase, mode, error, selectedIndex, setSelectedIndex, retry, now, onOpen }) {
+      const showResults = !!query && !error;
+      const showNoResults = showResults && phase === "done" && hits.length === 0;
+      const showLoadingSkeleton = showResults && phase === "loading" && hits.length === 0;
+
+      return (
+        <SurfaceCard style={{
+          overflow: "hidden",
+          opacity: phase === "loading" && hits.length > 0 ? 0.55 : 1,
+          transition: "opacity 120ms ease",
+        }}>
+          {error && (
+            <div style={{
+              margin: 12, padding: "12px 14px",
+              border: "1px solid var(--error-border)",
+              background: "var(--error-transparent)",
+              borderRadius: 2,
+              display: "flex", alignItems: "flex-start", gap: 11,
+            }}>
+              <Icon name="alert" size={16} style={{ color: "var(--error-text)", marginTop: 2 }}/>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 14, color: "var(--fg1)" }}>Couldn't run the search.</div>
+                <div style={{ fontSize: 13, color: "var(--fg2)", marginTop: 3 }}>
+                  The local viewer didn't respond. Check that <span style={{ fontFamily: "var(--fontFamilyMonospace)" }}>agento11y --local</span> is running, then try again.
+                </div>
+              </div>
+              <button type="button" onClick={retry} style={{
+                height: 28, padding: "0 12px", background: "transparent",
+                border: "1px solid var(--border-medium)", borderRadius: 2,
+                color: "var(--fg1)", fontSize: 12, cursor: "pointer",
+              }}
+                onMouseEnter={e => e.currentTarget.style.background = "var(--action-hover)"}
+                onMouseLeave={e => e.currentTarget.style.background = "transparent"}>Retry</button>
+            </div>
+          )}
+
+          {!error && showResults && hits.length > 0 && (
+            <React.Fragment>
+              <div style={{
+                display: "flex", alignItems: "center",
+                padding: "9px 16px", borderBottom: "1px solid var(--border-weak)",
+                fontFamily: "var(--fontFamilyMonospace)", fontSize: 12, color: "var(--fg3)",
+              }}>
+                <span>{hits.length} {hits.length === 1 ? "result" : "results"}</span>
+                <span style={{ flex: 1 }}/>
+                <span style={{ fontSize: 11, opacity: 0.7 }}>
+                  ranked by {mode === "semantic" ? "relevance (qmd)" : "matches"}
+                </span>
+              </div>
+              {hits.map((hit, i) => (
+                <SearchResultRow
+                  key={hit.id}
+                  hit={hit}
+                  now={now}
+                  query={query}
+                  selected={selectedIndex === i}
+                  onSelect={() => setSelectedIndex(i)}
+                  onOpen={h => onOpen({ id: h.id, title: h.title })}
+                />
+              ))}
+            </React.Fragment>
+          )}
+
+          {!error && showLoadingSkeleton && (
+            <React.Fragment>
+              {[0, 1, 2].map(i => (
+                <div key={i} style={{
+                  padding: "14px 16px",
+                  borderBottom: i < 2 ? "1px solid var(--border-weak)" : "none",
+                  borderLeft: "3px solid var(--border-medium)",
+                }}>
+                  <div className="sigil-shim" style={{ height: 14, width: "40%", borderRadius: 2 }}/>
+                  <div className="sigil-shim" style={{ height: 10, width: "80%", borderRadius: 2, marginTop: 8 }}/>
+                </div>
+              ))}
+            </React.Fragment>
+          )}
+
+          {!error && showNoResults && (
+            <div style={{ padding: "34px 16px 36px" }}>
+              <div style={{ fontSize: 14, color: "var(--fg1)" }}>
+                No matches for <span style={{ fontFamily: "var(--fontFamilyMonospace)", color: "var(--fg-max)" }}>“{query}”</span>.
+              </div>
+              <div style={{ fontSize: 13, color: "var(--fg3)", marginTop: 6 }}>
+                Check spelling, broaden terms, or search fewer words.
+              </div>
+            </div>
+          )}
+        </SurfaceCard>
+      );
+    }
+
     function App() {
       const [selectedID, setSelectedID] = useState(conversationIDFromPath);
       const [showSettings, setShowSettings] = useState(settingsRouteActive);
@@ -2128,6 +3952,7 @@
       const [loadingList, setLoadingList] = useState(true);
       const [errList, setErrList] = useState(null);
       const [query, setQuery] = useState("");
+      const conversationSearchRef = useRef(null);
       const [timeRange, setTimeRange] = usePersistedState("sigil.local.timeRange", "6h",
         v => TIME_RANGES.some(r => r.value === v));
       const [tokenModel, setTokenModel] = useState("all");
@@ -2140,7 +3965,8 @@
       const [loadingDetail, setLoadingDetail] = useState(false);
       const [errDetail, setErrDetail] = useState(null);
 
-      const view = showSettings ? "settings" : (selectedID ? "conversation" : "conversations");
+      const view = showSettings ? "settings"
+        : (selectedID ? "conversation" : "conversations");
       const selected = selectedID
         ? conversations.find(c => c.id === selectedID) || summaryFromDetail(detail, selectedID)
         : null;
@@ -2152,23 +3978,35 @@
         setTimeRange(v);
       }, [setTimeRange]);
 
-      const pageTitle = view === "settings"
-        ? "Settings — agento11y local"
-        : view === "conversation" && selected
-          ? `${selected.title || selected.id} — agento11y local`
-          : "agento11y — local";
+      const pageTitle = view === "settings" ? "Settings — agento11y local"
+        : view === "conversation" && selected ? `${selected.title || selected.id} — agento11y local`
+        : "agento11y — local";
       useEffect(() => { document.title = pageTitle; }, [pageTitle]);
 
+      // fetchList is driven from three sources (mount, SSE flush, 60s
+      // backstop), so a slower older response could otherwise overwrite
+      // a newer one. Each call captures a monotonically increasing
+      // sequence number and only applies its result if it is still the
+      // latest.
+      const listSeqRef = useRef(0);
       const fetchList = useCallback(() => {
+        const seq = ++listSeqRef.current;
         setLoadingList(true);
         setErrList(null);
         return fetch("/api/v1/conversations")
           .then(r => r.ok ? r.json() : r.text().then(t => Promise.reject(new Error(t || `HTTP ${r.status}`))))
           .then(body => {
+            if (listSeqRef.current !== seq) return;
             setConversations(body.conversations || []);
           })
-          .catch(e => setErrList(String(e.message || e)))
-          .finally(() => setLoadingList(false));
+          .catch(e => {
+            if (listSeqRef.current !== seq) return;
+            setErrList(String(e.message || e));
+          })
+          .finally(() => {
+            if (listSeqRef.current !== seq) return;
+            setLoadingList(false);
+          });
       }, []);
 
       // Token points back the usage chart. Failures are swallowed: the
@@ -2186,20 +4024,45 @@
         fetchTokens();
       }, [fetchList, fetchTokens]);
 
-      const fetchDetail = useCallback((id) => {
-        setLoadingDetail(true);
-        setErrDetail(null);
-        setDetail(null);
+      // fetchDetailCore is the shared fetch body for both an explicit
+      // open (quiet=false: shows a spinner and clears stale content) and
+      // a live-update refresh (quiet=true: updates in place, keeps the
+      // current view and scroll on success, swallows transient errors).
+      //
+      // The success path applies the body only if the user is still on
+      // the same conversation, and clears any prior error so a recovered
+      // live refresh doesn't stay hidden behind a stale error banner.
+      const fetchDetailCore = useCallback((id, quiet) => {
+        if (!quiet) {
+          setLoadingDetail(true);
+          setErrDetail(null);
+          setDetail(null);
+        }
         return fetch(`/api/v1/conversations/${encodeURIComponent(id)}`)
           .then(r => {
-            if (r.status === 404) throw new Error("Conversation not found in the local store.");
+            if (r.status === 404) throw new Error("Session not found in the local store.");
             if (!r.ok) return r.text().then(t => Promise.reject(new Error(t || `HTTP ${r.status}`)));
             return r.json();
           })
-          .then(setDetail)
-          .catch(e => setErrDetail(String(e.message || e)))
-          .finally(() => setLoadingDetail(false));
+          .then(body => {
+            if (selectedIDRef.current !== id) return;
+            setDetail(body);
+            setErrDetail(null);
+          })
+          .catch(e => {
+            if (selectedIDRef.current !== id) return;
+            // Quiet refresh failures are swallowed; the next event
+            // retries and the current view stays as-is instead of
+            // flashing an error banner over good content. The 60s
+            // backstop only refreshes the list, so a missed detail
+            // event only recovers on another targeted event or when
+            // the user reopens the conversation.
+            if (!quiet) setErrDetail(String(e.message || e));
+          })
+          .finally(() => { if (!quiet) setLoadingDetail(false); });
       }, []);
+      const fetchDetail = useCallback((id) => fetchDetailCore(id, false), [fetchDetailCore]);
+      const quietRefreshDetail = useCallback((id) => fetchDetailCore(id, true), [fetchDetailCore]);
 
       useEffect(() => { refreshAll(); }, [refreshAll]);
 
@@ -2222,43 +4085,133 @@
         fetchDetail(selectedID);
       }, [selectedID, fetchDetail]);
 
-      // Auto-refresh the list every 30s so newly-recorded generations
-      // surface without an explicit reload. Detail view is intentionally
-      // not auto-refreshed — opening a step shouldn't move under the
-      // user.
+      // Live updates from the daemon. One persistent SSE connection per
+      // viewer; the server pushes {conversation_id, generation_id}
+      // whenever a new generation is recorded so the list (and an open matching
+      // conversation) refresh within ~1s without polling. Refs hold the
+      // latest callbacks so the effect mounts once and doesn't drop the
+      // connection on every render.
+      const refreshAllRef = useRef(refreshAll);
+      const quietRefreshDetailRef = useRef(quietRefreshDetail);
+      const selectedIDRef = useRef(selectedID);
+      const viewRef = useRef(view);
+      useEffect(() => { refreshAllRef.current = refreshAll; }, [refreshAll]);
+      useEffect(() => { quietRefreshDetailRef.current = quietRefreshDetail; }, [quietRefreshDetail]);
+      useEffect(() => { selectedIDRef.current = selectedID; }, [selectedID]);
+      useEffect(() => { viewRef.current = view; }, [view]);
+
+      useEffect(() => {
+        // Browsers without EventSource (vanishingly rare on modern
+        // desktop browsers, but possible in some embedded webviews)
+        // fall back to the 60s backstop refresh below instead of
+        // throwing on the constructor.
+        if (typeof EventSource === "undefined") return;
+        let timer = null;
+        // Debounce so a burst export (one frame per generation) does
+        // not trigger one refresh per frame. We only need one list
+        // refresh per burst, plus one detail refresh if any event in
+        // the burst targets the open conversation.
+        let burstHasOpenConv = false;
+        const flush = () => {
+          timer = null;
+          const refreshOpen = burstHasOpenConv;
+          const openID = selectedIDRef.current;
+          burstHasOpenConv = false;
+          // Skip refetches when the user is on a non-conversation tab;
+          // the conversation list isn't rendered there, and the SSE
+          // connection itself is cheap to leave running.
+          const v = viewRef.current;
+          if (v !== "conversations" && v !== "conversation") return;
+          refreshAllRef.current();
+          if (refreshOpen && openID) {
+            quietRefreshDetailRef.current(openID);
+          }
+        };
+        const es = new EventSource("/api/v1/events");
+        es.onmessage = (e) => {
+          let ev = {};
+          try { ev = JSON.parse(e.data || "{}"); } catch (_) { /* ignore */ }
+          const openID = selectedIDRef.current;
+          if (openID && ev && ev.conversation_id === openID) {
+            burstHasOpenConv = true;
+          }
+          if (timer === null) timer = setTimeout(flush, 250);
+        };
+        // EventSource auto-reconnects on transport errors, so a daemon
+        // restart or proxy blip heals without an explicit handler.
+        // Cleanup closes the stream.
+        return () => {
+          if (timer !== null) clearTimeout(timer);
+          es.close();
+        };
+      }, []);
+
+      // Safety-net backstop: in case SSE stalls (a reverse proxy that
+      // buffers, a dropped event whose burst leaves the list out of
+      // date, an environment where EventSource is unavailable), refetch
+      // the list at a low rate. Detail view is intentionally not on the
+      // backstop — opening a step shouldn't move under the user except
+      // when a live event names it. As a consequence, a dropped detail
+      // event for the currently-open conversation only recovers when
+      // another targeted event arrives or the user reopens it.
       useEffect(() => {
         if (view !== "conversations") return;
-        const id = setInterval(refreshAll, 30_000);
+        const id = setInterval(() => refreshAllRef.current(), 60_000);
         return () => clearInterval(id);
-      }, [view, refreshAll]);
+      }, [view]);
 
       const openConv = (c) => {
         window.history.pushState({}, "", conversationPath(c.id));
         setShowSettings(false);
         setSelectedID(c.id);
       };
-      const goHome = () => {
+      const goConversations = () => {
         window.history.pushState({}, "", "/");
         setShowSettings(false);
         setSelectedID(null);
       };
-      const goSettings = () => {
-        window.history.pushState({}, "", "/settings");
+      const goSettings = (tab) => {
+        window.history.pushState({}, "", settingsPath(tab));
         setSelectedID(null);
         setShowSettings(true);
       };
+      const focusConversationSearch = useCallback(() => {
+        const focus = () => {
+          const el = conversationSearchRef.current;
+          if (!el) return;
+          el.focus();
+          if (typeof el.select === "function") el.select();
+        };
+        if (viewRef.current !== "conversations") {
+          window.history.pushState({}, "", "/");
+          setSelectedID(null);
+          setShowSettings(false);
+          setTimeout(focus, 0);
+          return;
+        }
+        focus();
+      }, []);
+      useEffect(() => {
+        const onKeyDown = (e) => {
+          if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && String(e.key).toLowerCase() === "k") {
+            e.preventDefault();
+            focusConversationSearch();
+          }
+        };
+        window.addEventListener("keydown", onKeyDown);
+        return () => window.removeEventListener("keydown", onKeyDown);
+      }, [focusConversationSearch]);
 
       const tabs = [
-        { label: "Conversations", href: "/", onClick: goHome, state: view === "conversations" ? "current" : "link" },
-        { label: "Settings", href: "/settings", onClick: goSettings, state: view === "settings" ? "current" : "link" },
+        { key: "conversations", label: "Sessions", href: "/", onClick: goConversations },
+        { key: "settings", label: "Settings", href: "/settings", onClick: goSettings },
       ];
-      const trail = view === "conversation" && selected
-        ? [{ label: selected.title || selected.id, mono: true }]
-        : [];
+      const activeTab = view === "settings" ? "settings" : "conversations";
+      const trail = view === "conversation" && selected ? [{ label: selected.title || selected.id, mono: true }] : [];
 
       return (
         <div style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}>
-          <TopBar tabs={tabs} trail={trail}/>
+          <TopBar tabs={tabs} activeTab={activeTab} trail={trail}/>
           <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
             {view === "settings" && <SettingsView/>}
             {view === "conversations" && (
@@ -2269,6 +4222,7 @@
                 error={errList}
                 query={query}
                 setQuery={setQuery}
+                searchInputRef={conversationSearchRef}
                 timeRange={timeRange}
                 setTimeRange={changeTimeRange}
                 tokenModel={tokenModel}
@@ -2291,5 +4245,4 @@
         </div>
       );
     }
-
     ReactDOM.createRoot(document.getElementById("root")).render(<App/>);

--- a/plugins/agento11y/internal/local/wire.go
+++ b/plugins/agento11y/internal/local/wire.go
@@ -69,6 +69,19 @@ func (u storedUsage) toSDK() agento11y.TokenUsage {
 	}
 }
 
+// storedSkill mirrors the per-generation skill entries the SDK/plugin
+// attaches under the generation's `skills` field. Skills are loaded on
+// demand, so unlike tools they are not derivable from the message
+// content and must be read straight off the stored generation.
+type storedSkill struct {
+	Name        string `json:"name,omitempty"`
+	ID          string `json:"id,omitempty"`
+	Description string `json:"description,omitempty"`
+	Version     string `json:"version,omitempty"`
+	Definition  string `json:"definition,omitempty"`
+	Source      string `json:"source,omitempty"`
+}
+
 type storedGeneration struct {
 	ID                string             `json:"id,omitempty"`
 	ConversationID    string             `json:"conversation_id,omitempty"`
@@ -82,8 +95,49 @@ type storedGeneration struct {
 	StopReason        string             `json:"stop_reason,omitempty"`
 	StartedAt         time.Time          `json:"started_at,omitzero"`
 	CompletedAt       time.Time          `json:"completed_at,omitzero"`
+	Skills            []storedSkill      `json:"skills,omitempty"`
 	Metadata          map[string]any     `json:"metadata,omitempty"`
 	CallError         string             `json:"call_error,omitempty"`
+	// Tags carry the agent's per-session context (cwd, git.branch,
+	// entrypoint, …). ParentGenerationIDs links a subagent's generations
+	// to the generation that spawned them, so the viewer can reconstruct
+	// the subagent tree. Both ride along on the wire verbatim and are only
+	// decoded here.
+	Tags                map[string]string `json:"tags,omitempty"`
+	ParentGenerationIDs []string          `json:"parent_generation_ids,omitempty"`
+	ThinkingEnabled     bool              `json:"thinking_enabled,omitempty"`
+}
+
+// skillViews returns the generation's skills as display-ready views,
+// deduped by name in first-seen order and dropping blank names. The
+// mapper already dedupes, but a generation can be re-exported from a
+// different source, so the viewer must not assume it.
+func (g storedGeneration) skillViews() []SkillView {
+	if len(g.Skills) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]SkillView, 0, len(g.Skills))
+	for _, s := range g.Skills {
+		name := strings.TrimSpace(s.Name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, SkillView{
+			Name:        name,
+			ID:          s.ID,
+			Description: s.Description,
+			Version:     s.Version,
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func (g storedGeneration) title() string {


### PR DESCRIPTION
Reworks the local viewer. The sessions list is now grouped by workspace (the `cwd` tag) with token, cost, and cache hit tiles for the selected time range, and search moves to the server.