### PR TITLE
feat(plugins/opencode): emit the subagent built-in tag

### DIFF
--- a/docs/concepts/tags-and-metadata.md
+++ b/docs/concepts/tags-and-metadata.md
@@ -99,6 +99,18 @@ await agento11y.startGeneration(
 );
 ```
 
+## Built-in tags from the agent launchers
+
+The coding-agent plugins (claude-code, codex, copilot, cursor, opencode, pi, vibe) add tags of their own to every generation, on top of whatever you set in `AGENTO11Y_TAGS`. A built-in key wins if you set the same key yourself. A tag is left off when the launcher has no value for it, so a missing key means "unknown" rather than "false".
+
+| Tag | Value | Emitted by |
+| --- | --- | --- |
+| `cwd` | Working directory of the session. For pi, the directory pi was launched from, which can be a subdirectory of the repo. | all launchers |
+| `git.branch` | Branch checked out in that directory, or a short commit SHA when HEAD is detached. Omitted outside a git checkout. | all launchers |
+| `subagent` | `"true"` on generations from a subagent run. Absent otherwise, never `"false"`. | claude-code, codex, cursor, opencode |
+
+Launchers also set a few keys specific to one host, so this table is not the full list of what arrives on a generation.
+
 ## See also
 
 - [Content Capture Modes](content-capture-modes.md) — which content fields ship. Content capture does not strip `tags` or `metadata`; both are always exported.

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -104,12 +104,13 @@ agento11y opencode --tag team=ai -- run "say hi"
 
 `--tag` is shorthand for `AGENTO11Y_TAGS`; flag tags merge onto (and override) any `AGENTO11Y_TAGS` already in the environment or `~/.config/agento11y/config.env`. The merge happens in the SDK, so user tags reach every generation without the plugin reparsing them.
 
-The plugin always attaches two built-in tags to every generation:
+The plugin attaches built-in tags of its own:
 
 - `git.branch` — current branch from the opencode project directory, or a 12-char short SHA on detached HEAD. Omitted when not inside a git checkout.
-- `cwd` — the opencode project directory (from `PluginInput.directory`).
+- `cwd` — the opencode project directory.
+- `subagent` — `"true"` on generations from a subagent session. Omitted for ordinary sessions, and for a subagent that opencode started before the plugin loaded.
 
-Built-in tags win collisions with user tags, matching the claude-code and cursor launchers.
+Built-in tags win collisions with user tags, matching the claude-code and cursor launchers. See [Tags and Metadata](../../docs/concepts/tags-and-metadata.md#built-in-tags-from-the-agent-launchers) for the tags the launchers share.
 
 ## All options
 

--- a/plugins/opencode/src/hooks.lineage.test.ts
+++ b/plugins/opencode/src/hooks.lineage.test.ts
@@ -14,7 +14,7 @@ vi.mock("./telemetry.js", () => ({
   createTelemetryProviders: createTelemetryProvidersMock,
 }));
 
-import { createAgento11yHooks } from "./hooks.js";
+import { _resetHookState, createAgento11yHooks } from "./hooks.js";
 import {
   assistantMessage,
   baseConfig,
@@ -45,6 +45,7 @@ function textPart(
 describe("opencode generation lineage and streaming", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetHookState();
   });
 
   it("assigns a deterministic opencode- generation id from session and message id", async () => {
@@ -197,7 +198,7 @@ describe("opencode generation lineage and streaming", () => {
     expect(child?.seed.parentGenerationIds).not.toEqual([parentTurn2]);
   });
 
-  it("does not link a subagent when the parent has no recorded generation yet", async () => {
+  it("tags a subagent but does not link it when the parent has no recorded generation yet", async () => {
     const { sigil, generations } = makeAgento11yMock();
     createAgento11yClientMock.mockReturnValue(sigil);
     const hooks = await createAgento11yHooks(
@@ -208,15 +209,17 @@ describe("opencode generation lineage and streaming", () => {
 
     // session.created arrives before the parent has recorded any generation.
     // No parent generation exists to freeze, so the child records unlinked
-    // (fails safe) rather than guessing.
+    // (fails safe) rather than guessing. The tag comes from `Session.parentID`
+    // alone, so it survives the dropped lineage edge.
     await emitSessionCreated(hooks, "sess-child-4", "sess-parent-4");
     await emitMessageUpdated(hooks, assistantMessage("sess-child-4", "msg-c1"));
 
     expect(generations).toHaveLength(1);
     expect(generations[0]!.seed.parentGenerationIds).toBeUndefined();
+    expect(generations[0]!.seed.tags?.subagent).toBe("true");
   });
 
-  it("does not link a root session with no parentID", async () => {
+  it("does not link or tag a root session with no parentID", async () => {
     const { sigil, generations } = makeAgento11yMock();
     createAgento11yClientMock.mockReturnValue(sigil);
     const hooks = await createAgento11yHooks(
@@ -230,6 +233,81 @@ describe("opencode generation lineage and streaming", () => {
 
     expect(generations).toHaveLength(1);
     expect(generations[0]!.seed.parentGenerationIds).toBeUndefined();
+    expect(generations[0]!.seed.tags?.subagent).toBeUndefined();
+  });
+
+  it("tags a child session's generations with subagent=true", async () => {
+    const { sigil, generations } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await createAgento11yHooks(
+      baseConfig(),
+      makeOpencodeClient(),
+    );
+    if (!hooks) throw new Error("expected hooks");
+
+    await emitMessageUpdated(hooks, assistantMessage("sess-parent-tag", "m-1"));
+    await emitSessionCreated(hooks, "sess-child-tag", "sess-parent-tag");
+    await emitMessageUpdated(hooks, assistantMessage("sess-child-tag", "m-c1"));
+
+    expect(generations).toHaveLength(2);
+    // The spawning session is not a subagent itself.
+    expect(generations[0]!.seed.tags?.subagent).toBeUndefined();
+    expect(generations[1]!.seed.tags?.subagent).toBe("true");
+    // Agent naming stays mode-based; subagent status lives in the tag only.
+    expect(generations[1]!.seed.agentName).toBe("opencode:build");
+  });
+
+  it("does not tag a self-parenting session", async () => {
+    const { sigil, generations } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await createAgento11yHooks(
+      baseConfig(),
+      makeOpencodeClient(),
+    );
+    if (!hooks) throw new Error("expected hooks");
+
+    await emitSessionCreated(hooks, "sess-self-tag", "sess-self-tag");
+    await emitMessageUpdated(hooks, assistantMessage("sess-self-tag", "m-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.tags?.subagent).toBeUndefined();
+  });
+
+  it("drops subagent classification on session.deleted", async () => {
+    const { sigil, generations } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await createAgento11yHooks(
+      baseConfig(),
+      makeOpencodeClient(),
+    );
+    if (!hooks) throw new Error("expected hooks");
+
+    await emitSessionCreated(hooks, "sess-del-tag", "sess-parent-del");
+    await emitSessionDeleted(hooks, "sess-del-tag");
+    // The id is reused as a root session; the stale classification must be gone.
+    await emitSessionCreated(hooks, "sess-del-tag");
+    await emitMessageUpdated(hooks, assistantMessage("sess-del-tag", "m-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.tags?.subagent).toBeUndefined();
+  });
+
+  it("drops subagent classification on _resetHookState", async () => {
+    const { sigil, generations } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await createAgento11yHooks(
+      baseConfig(),
+      makeOpencodeClient(),
+    );
+    if (!hooks) throw new Error("expected hooks");
+
+    await emitSessionCreated(hooks, "sess-reset-tag", "sess-parent-reset");
+    _resetHookState();
+    await emitSessionCreated(hooks, "sess-reset-tag");
+    await emitMessageUpdated(hooks, assistantMessage("sess-reset-tag", "m-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.tags?.subagent).toBeUndefined();
   });
 
   it("records first-token time from the first streamed part", async () => {

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -59,6 +59,12 @@ const lastGenerationIdBySession = new Map<string, string>();
 // parent/subagent boundary.
 const parentGenerationByChildSession = new Map<string, string>();
 
+// Sessions opencode created as subagents, i.e. `session.created` carried a
+// `Session.parentID` pointing at a different session. Kept separate from
+// `parentGenerationByChildSession`, which only holds children whose parent had
+// an already-recorded generation to freeze.
+const subagentSessions = new Set<string>();
+
 // First streamed assistant part time per message, keyed by
 // `${sessionID}\x00${messageID}`. Captured from `message.part.updated`
 // before the message completes so it survives `metadata_only` (where we
@@ -136,6 +142,7 @@ export function _resetHookState(): void {
   recordedMessages.clear();
   lastGenerationIdBySession.clear();
   parentGenerationByChildSession.clear();
+  subagentSessions.clear();
   firstPartAtByMessage.clear();
   pendingGenerations.clear();
   latestSystemPromptBySession.clear();
@@ -470,13 +477,14 @@ async function recordAssistantMessage(
   ]);
 
   const agentVersion = config.agentVersion || hostVersion;
-  // Resolved per turn so a mid-session checkout shows up on the next
-  // generation. Always sent regardless of content capture mode:
-  // `git.branch` and `cwd` are low-cardinality session metadata, not
-  // message content, matching claude-code/cursor.
+  // `git.branch` is resolved per turn so a mid-session checkout shows up on
+  // the next generation. These are sent regardless of content capture mode:
+  // they are low-cardinality session metadata, not message content, matching
+  // claude-code/cursor.
   const builtinTags = buildBuiltinTags({
     cwd: projectDir,
     gitBranch: resolveGitBranch(projectDir),
+    isSubagent: subagentSessions.has(assistantMsg.sessionID),
   });
   const seed = {
     id: genId,
@@ -580,8 +588,10 @@ function recordHostVersion(properties: unknown): void {
  * session's life, and freezing on a late update could capture a parent turn
  * recorded *after* the spawning one. If the parent has no recorded generation
  * yet at creation (rare — the spawning turn's predecessor is normally already
- * recorded), we skip: an unlinked child is better than a wrong link. The
- * `has(id)` guard is defensive against a duplicate `session.created`.
+ * recorded), we skip the lineage edge: an unlinked child is better than a wrong
+ * link. The `subagent` tag does not depend on that edge, so the session is
+ * still classified as a subagent. The `has(id)` guard is defensive against a
+ * duplicate `session.created`.
  */
 function recordSessionParent(properties: unknown): void {
   const info = recordField(properties, "info");
@@ -589,6 +599,7 @@ function recordSessionParent(properties: unknown): void {
   const id = stringField(info, "id");
   const parentID = stringField(info, "parentID");
   if (!id || !parentID || id === parentID) return;
+  subagentSessions.add(id);
   if (parentGenerationByChildSession.has(id)) return;
   const parentGeneration = lastGenerationIdBySession.get(parentID);
   if (!parentGeneration) return;
@@ -640,6 +651,7 @@ async function handleLifecycle(
       recordedMessages.delete(sessionId);
       lastGenerationIdBySession.delete(sessionId);
       parentGenerationByChildSession.delete(sessionId);
+      subagentSessions.delete(sessionId);
       pendingGenerations.delete(sessionId);
       latestSystemPromptBySession.delete(sessionId);
       sessionContexts.delete(sessionId);

--- a/plugins/opencode/src/tags.test.ts
+++ b/plugins/opencode/src/tags.test.ts
@@ -32,6 +32,26 @@ describe("buildBuiltinTags", () => {
       in: { cwd: "", gitBranch: "" },
       want: undefined,
     },
+    {
+      name: "subagent set alongside the other keys",
+      in: { cwd: "/repo", gitBranch: "main", isSubagent: true },
+      want: { "git.branch": "main", cwd: "/repo", subagent: "true" },
+    },
+    {
+      name: "subagent absent when false",
+      in: { cwd: "/workspace/repo", gitBranch: "main", isSubagent: false },
+      want: { "git.branch": "main", cwd: "/workspace/repo" },
+    },
+    {
+      name: "subagent only",
+      in: { isSubagent: true },
+      want: { subagent: "true" },
+    },
+    {
+      name: "empty-string inputs with subagent false return undefined",
+      in: { cwd: "", gitBranch: "", isSubagent: false },
+      want: undefined,
+    },
   ];
 
   it.each(cases)("$name", ({ in: input, want }) => {

--- a/plugins/opencode/src/tags.ts
+++ b/plugins/opencode/src/tags.ts
@@ -10,6 +10,7 @@
 export interface BuiltinTagInputs {
   cwd?: string;
   gitBranch?: string;
+  isSubagent?: boolean;
 }
 
 export function buildBuiltinTags(
@@ -21,6 +22,9 @@ export function buildBuiltinTags(
   }
   if (in_.cwd) {
     out.cwd = in_.cwd;
+  }
+  if (in_.isSubagent) {
+    out.subagent = "true";
   }
   if (Object.keys(out).length === 0) {
     return undefined;


### PR DESCRIPTION
Adds the `subagent` built-in tag to the opencode plugin, matching claude-code, codex, and cursor: `subagent="true"` on generations from a session opencode created with a parent session.

Also documents the built-in launcher tags (`cwd`, `git.branch`, `subagent`) in `docs/concepts/tags-and-metadata.md`.
