### PR TITLE
chore: change grafana-sigil-app plugin id to grafana-agento11y-app

### DIFF
--- a/examples/experiments/go/.env.example
+++ b/examples/experiments/go/.env.example
@@ -30,7 +30,7 @@ AGENTO11Y_AUTH_TOKEN=<your-cloud-access-policy-token>
 
 # Optional stored-suite control plane. Not needed for suite-free publishing.
 # AGENTO11Y_GRAFANA_URL=https://<your-stack>.grafana.net
-# AGENTO11Y_CONTROL_ENDPOINT=https://<your-stack>.grafana.net/api/plugins/grafana-sigil-app/resources/eval
+# AGENTO11Y_CONTROL_ENDPOINT=https://<your-stack>.grafana.net/api/plugins/grafana-agento11y-app/resources/eval
 # AGENTO11Y_SERVICE_ACCOUNT_TOKEN=<service-account-token>
 
 # Optional run identity.

--- a/go/agento11y/experiments/client.go
+++ b/go/agento11y/experiments/client.go
@@ -230,7 +230,7 @@ func (c *Client) ExperimentURL(experimentID string) string {
 		return ""
 	}
 	if c.grafanaURL != "" {
-		return c.grafanaURL + "/a/grafana-sigil-app/offline-experiments/experiments/" + url.PathEscape(experimentID)
+		return c.grafanaURL + grafanaAppPath + "/offline-experiments/experiments/" + url.PathEscape(experimentID)
 	}
 	return c.core.ExperimentURL(experimentID)
 }

--- a/go/agento11y/experiments/suites.go
+++ b/go/agento11y/experiments/suites.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	defaultControlPath      = "/api/plugins/grafana-sigil-app/resources/eval"
+	grafanaAppPath          = "/a/grafana-agento11y-app"
+	defaultControlPath      = "/api/plugins/grafana-agento11y-app/resources/eval"
 	portabilityMetadataKey  = "agento11y.sdk.portability"
 	portabilityVersion      = 1
 	maxControlResponseBytes = 8 << 20
@@ -611,7 +612,7 @@ func normalizeControlEndpoint(value string) (string, error) {
 	}
 	path := strings.TrimRight(parsed.Path, "/")
 	if !strings.HasSuffix(path, defaultControlPath) && !strings.HasSuffix(path, "/api/v1/eval") {
-		if index := strings.Index(path, "/a/grafana-sigil-app"); index >= 0 {
+		if index := strings.Index(path, grafanaAppPath); index >= 0 {
 			path = path[:index]
 		}
 		path = strings.TrimRight(path, "/") + defaultControlPath

--- a/go/agento11y/experiments/suites_test.go
+++ b/go/agento11y/experiments/suites_test.go
@@ -43,7 +43,7 @@ func TestTestSuitesPullPortabilityAndBearerNormalization(t *testing.T) {
 	defer server.Close()
 
 	client, err := NewTestSuitesClient(TestSuitesClientOptions{
-		ControlEndpoint:     server.URL + "/a/grafana-sigil-app",
+		ControlEndpoint:     server.URL + "/a/grafana-agento11y-app",
 		ServiceAccountToken: "bearer token",
 	})
 	if err != nil {
@@ -190,5 +190,46 @@ func TestResolveVersionAliasesAndDraftConflict(t *testing.T) {
 	}
 	if err := validateDraftOptions(suiteVersions(suite)[2], "new", false); ClassifyConflict(err) != ConflictOpenDraft {
 		t.Fatalf("unexpected conflict: %v (%s)", err, ClassifyConflict(err))
+	}
+}
+
+func TestAppPluginPathsUseCurrentPluginID(t *testing.T) {
+	endpointCases := []struct {
+		name  string
+		given string
+		want  string
+	}{
+		{
+			name:  "app ui url is rewritten to the control path",
+			given: "https://stack.grafana.net/a/grafana-agento11y-app",
+			want:  "https://stack.grafana.net/api/plugins/grafana-agento11y-app/resources/eval",
+		},
+		{
+			name:  "deep app ui url drops everything after the app path",
+			given: "https://stack.grafana.net/a/grafana-agento11y-app/experiments/test-suites",
+			want:  "https://stack.grafana.net/api/plugins/grafana-agento11y-app/resources/eval",
+		},
+		{
+			name:  "control path is left alone",
+			given: "https://stack.grafana.net/api/plugins/grafana-agento11y-app/resources/eval",
+			want:  "https://stack.grafana.net/api/plugins/grafana-agento11y-app/resources/eval",
+		},
+	}
+	for _, tc := range endpointCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeControlEndpoint(tc.given)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("normalizeControlEndpoint(%q)=%q want %q", tc.given, got, tc.want)
+			}
+		})
+	}
+
+	client := &Client{grafanaURL: "https://stack.grafana.net"}
+	const wantURL = "https://stack.grafana.net/a/grafana-agento11y-app/offline-experiments/experiments/run%2F1"
+	if got := client.ExperimentURL("run/1"); got != wantURL {
+		t.Fatalf("ExperimentURL=%q want %q", got, wantURL)
 	}
 }


### PR DESCRIPTION
We renamed plugin to `grafana-agento11y-app` in https://github.com/grafana/agento11y/pull/452, but after that https://github.com/grafana/agento11y/pull/454 was merged with some old ids. Renaming.