### PR TITLE
fix(plugins/opencode): shut down the SDK and OTel providers on teardown

### DIFF
--- a/plugins/opencode/src/golden.test.ts
+++ b/plugins/opencode/src/golden.test.ts
@@ -280,9 +280,10 @@ describe("opencode plugin: real-SDK golden export", () => {
       },
     });
 
-    // Lifecycle: session.idle triggers a flush. session.deleted clears
-    // in-memory dedup state between table cases. global.disposed shuts down
-    // the SDK so the HTTP exporter drains its outbox.
+    // Lifecycle: session.idle triggers a flush. session.deleted clears this
+    // session's in-memory dedup state. dispose() shuts the SDK down so the
+    // HTTP exporter drains its outbox before the assertions below read the
+    // captured requests.
     await hooks.event({
       event: {
         type: "session.idle",
@@ -295,12 +296,7 @@ describe("opencode plugin: real-SDK golden export", () => {
         properties: { info: { id: sessionID } },
       },
     });
-    await hooks.event({
-      event: {
-        type: "global.disposed",
-        properties: {},
-      },
-    });
+    await hooks.dispose();
 
     expect(serverEnv.errors).toEqual([]);
     expect(serverEnv.captures.length).toBeGreaterThanOrEqual(1);

--- a/plugins/opencode/src/hooks.dispose.test.ts
+++ b/plugins/opencode/src/hooks.dispose.test.ts
@@ -1,0 +1,269 @@
+// Teardown behavior: opencode's `Hooks.dispose` finalizer, the
+// `server.instance.disposed` event, and the `beforeExit` fallback all have to
+// reach one idempotent shutdown path.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createAgento11yClientMock, createTelemetryProvidersMock } = vi.hoisted(
+  () => ({
+    createAgento11yClientMock: vi.fn(),
+    createTelemetryProvidersMock: vi.fn(),
+  }),
+);
+
+vi.mock("./client.js", () => ({
+  createAgento11yClient: createAgento11yClientMock,
+}));
+vi.mock("./telemetry.js", () => ({
+  createTelemetryProviders: createTelemetryProvidersMock,
+}));
+
+import type { Agento11yOpencodeConfig } from "./config.js";
+import {
+  _peekToolExecutionState,
+  _resetHookState,
+  createAgento11yHooks,
+} from "./hooks.js";
+import {
+  baseConfig,
+  emitEvent,
+  emitServerInstanceDisposed,
+  makeAgento11yMock,
+  makeOpencodeClient,
+  type TestHooks,
+} from "./hooks.testutil.js";
+
+type TelemetryMock = {
+  telemetry: {
+    tracer: unknown;
+    meter: unknown;
+    forceFlush: ReturnType<typeof vi.fn>;
+    shutdown: ReturnType<typeof vi.fn>;
+  };
+};
+
+function makeTelemetryMock(calls: string[]): TelemetryMock {
+  return {
+    telemetry: {
+      tracer: {},
+      meter: {},
+      forceFlush: vi.fn(async () => {}),
+      shutdown: vi.fn(async () => {
+        calls.push("telemetry.shutdown");
+      }),
+    },
+  };
+}
+
+function otlpConfig(): Agento11yOpencodeConfig {
+  return baseConfig({
+    otlp: { endpoint: "http://127.0.0.1:1/otlp", headers: {} },
+  });
+}
+
+/**
+ * Builds a hooks instance with its own agento11y and telemetry mocks, plus a
+ * shared ordered log of shutdown calls.
+ */
+async function makeInstance(): Promise<{
+  hooks: TestHooks;
+  sigil: { shutdown: ReturnType<typeof vi.fn> };
+  telemetry: TelemetryMock["telemetry"];
+  calls: string[];
+}> {
+  const calls: string[] = [];
+  const { sigil } = makeAgento11yMock();
+  sigil.shutdown = vi.fn(async () => {
+    calls.push("sigil.shutdown");
+  });
+  const { telemetry } = makeTelemetryMock(calls);
+  createAgento11yClientMock.mockReturnValue(sigil);
+  createTelemetryProvidersMock.mockReturnValue(telemetry);
+
+  const hooks = await createAgento11yHooks(otlpConfig(), makeOpencodeClient());
+  if (!hooks) throw new Error("expected hooks");
+  return { hooks, sigil, telemetry, calls };
+}
+
+/** Leaves an active tool execution behind so state clearing is observable. */
+async function seedHookState(hooks: TestHooks): Promise<void> {
+  await hooks.toolExecuteBefore(
+    { sessionID: "sess-dispose", callID: "call-dispose", tool: "Bash" },
+    { args: { command: "ls" } },
+  );
+  expect(_peekToolExecutionState().active).toHaveLength(1);
+}
+
+describe("opencode plugin teardown", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetHookState();
+  });
+
+  it("shuts down agento11y before OTel and clears hook state on dispose", async () => {
+    const { hooks, sigil, telemetry, calls } = await makeInstance();
+    await seedHookState(hooks);
+
+    await hooks.dispose();
+
+    expect(sigil.shutdown).toHaveBeenCalledTimes(1);
+    expect(telemetry.shutdown).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(["sigil.shutdown", "telemetry.shutdown"]);
+    expect(_peekToolExecutionState().active).toHaveLength(0);
+  });
+
+  it("still shuts down OTel and clears state when agento11y shutdown rejects", async () => {
+    const { hooks, sigil, telemetry } = await makeInstance();
+    // Swapped in after construction: shutdownOnce reads the property at call
+    // time, so this is the mock it invokes.
+    sigil.shutdown = vi.fn(async () => {
+      throw new Error("test shutdown failure");
+    });
+    await seedHookState(hooks);
+
+    await expect(hooks.dispose()).resolves.toBeUndefined();
+
+    expect(sigil.shutdown).toHaveBeenCalledTimes(1);
+    expect(telemetry.shutdown).toHaveBeenCalledTimes(1);
+    expect(_peekToolExecutionState().active).toHaveLength(0);
+  });
+
+  it("keeps the idempotency guard per plugin instance", async () => {
+    const first = await makeInstance();
+    await first.hooks.dispose();
+    expect(first.sigil.shutdown).toHaveBeenCalledTimes(1);
+
+    const second = await makeInstance();
+    await second.hooks.dispose();
+
+    expect(second.sigil.shutdown).toHaveBeenCalledTimes(1);
+    expect(second.telemetry.shutdown).toHaveBeenCalledTimes(1);
+    // The first instance did not shut down a second time.
+    expect(first.sigil.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps module state while another instance is still live", async () => {
+    const first = await makeInstance();
+    const second = await makeInstance();
+    // Hook state is module-scoped and shared by both instances. One opencode
+    // server hosts an instance per directory, so a sibling can be mid-turn.
+    await seedHookState(second.hooks);
+
+    await first.hooks.dispose();
+
+    expect(first.sigil.shutdown).toHaveBeenCalledTimes(1);
+    expect(_peekToolExecutionState().active).toHaveLength(1);
+
+    await second.hooks.dispose();
+
+    expect(_peekToolExecutionState().active).toHaveLength(0);
+  });
+
+  it("shuts down on the server.instance.disposed event", async () => {
+    const { hooks, sigil, telemetry, calls } = await makeInstance();
+    await seedHookState(hooks);
+
+    await emitServerInstanceDisposed(hooks);
+
+    expect(sigil.shutdown).toHaveBeenCalledTimes(1);
+    expect(telemetry.shutdown).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(["sigil.shutdown", "telemetry.shutdown"]);
+    expect(_peekToolExecutionState().active).toHaveLength(0);
+  });
+
+  it("shuts down once when dispose and the disposal event both fire", async () => {
+    const { hooks, sigil, telemetry } = await makeInstance();
+
+    await hooks.dispose();
+    await emitServerInstanceDisposed(hooks);
+    await expect(hooks.dispose()).resolves.toBeUndefined();
+
+    expect(sigil.shutdown).toHaveBeenCalledTimes(1);
+    expect(telemetry.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it("shuts down once when triggers overlap before the first shutdown settles", async () => {
+    const calls: string[] = [];
+    const { sigil } = makeAgento11yMock();
+    let releaseSigilShutdown: (() => void) | undefined;
+    const sigilShutdownStarted = new Promise<void>((startResolve) => {
+      sigil.shutdown = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            calls.push("sigil.shutdown");
+            releaseSigilShutdown = resolve;
+            startResolve();
+          }),
+      );
+    });
+    const { telemetry } = makeTelemetryMock(calls);
+    createAgento11yClientMock.mockReturnValue(sigil);
+    createTelemetryProvidersMock.mockReturnValue(telemetry);
+    const hooks = await createAgento11yHooks(
+      otlpConfig(),
+      makeOpencodeClient(),
+    );
+    if (!hooks) throw new Error("expected hooks");
+
+    const disposing = hooks.dispose();
+    await sigilShutdownStarted;
+    // Second trigger arrives while the first shutdown is still in flight.
+    let eventTeardownSettled = false;
+    const eventTeardown = emitServerInstanceDisposed(hooks).then(() => {
+      eventTeardownSettled = true;
+    });
+    // setImmediate runs after the microtask queue drains, so a boolean
+    // "already shutting down" guard would have resolved the second trigger by
+    // now, while the exporters are still draining. The memoized promise makes
+    // it wait.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(eventTeardownSettled).toBe(false);
+
+    releaseSigilShutdown?.();
+    await Promise.all([disposing, eventTeardown]);
+
+    expect(eventTeardownSettled).toBe(true);
+    expect(sigil.shutdown).toHaveBeenCalledTimes(1);
+    expect(telemetry.shutdown).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(["sigil.shutdown", "telemetry.shutdown"]);
+  });
+
+  it("accepts only event names from the opencode Event union", async () => {
+    const { hooks, sigil, telemetry } = await makeInstance();
+
+    // The name the disposal branch used to be gated on. opencode never delivers
+    // it to the `event` hook and it is not in the `Event` union.
+    // @ts-expect-error not a member of the opencode Event union
+    await emitEvent(hooks, "global.disposed");
+
+    // Nothing in the plugin reacts to that name.
+    expect(sigil.shutdown).not.toHaveBeenCalled();
+    expect(telemetry.shutdown).not.toHaveBeenCalled();
+
+    await hooks.dispose();
+  });
+
+  it("delegates the beforeExit fallback to the same shutdown path", async () => {
+    const listenersBeforeCreate = process.listenerCount("beforeExit");
+    const { hooks, sigil, telemetry } = await makeInstance();
+    expect(process.listenerCount("beforeExit")).toBe(listenersBeforeCreate + 1);
+
+    process.emit("beforeExit", 0);
+    // A beforeExit listener cannot be awaited. Both shutdown mocks resolve
+    // immediately, so one macrotask is enough for the shutdown it started to
+    // run to completion.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(sigil.shutdown).toHaveBeenCalledTimes(1);
+    expect(telemetry.shutdown).toHaveBeenCalledTimes(1);
+    // The listener deregisters itself once shutdown starts, so a disposed
+    // instance stops holding a process listener and a later beforeExit is a
+    // no-op. A later dispose is stopped by the memoized promise instead.
+    expect(process.listenerCount("beforeExit")).toBe(listenersBeforeCreate);
+
+    process.emit("beforeExit", 0);
+    await hooks.dispose();
+    expect(sigil.shutdown).toHaveBeenCalledTimes(1);
+    expect(telemetry.shutdown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/opencode/src/hooks.guard.test.ts
+++ b/plugins/opencode/src/hooks.guard.test.ts
@@ -2,6 +2,7 @@ import { createServer, type Server } from "node:http";
 import { afterEach, describe, expect, it } from "vitest";
 import type { Agento11yOpencodeConfig } from "./config.js";
 import { createAgento11yHooks } from "./hooks.js";
+import { emitServerInstanceDisposed } from "./hooks.testutil.js";
 
 type HookServer = {
   server: Server;
@@ -133,7 +134,7 @@ describe("opencode guards", () => {
       },
     });
 
-    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+    await emitServerInstanceDisposed(hooks);
   });
 
   it("replaces frozen tool.execute.before args with the redacted set", async () => {
@@ -186,7 +187,7 @@ describe("opencode guards", () => {
     expect(output.args).toEqual({ command: "echo [REDACTED]" });
     expect(output.args.apiKey).toBeUndefined();
 
-    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+    await emitServerInstanceDisposed(hooks);
   });
 
   it("leaves tool.execute.before args unchanged when Agent Observability allows without a transform", async () => {
@@ -209,7 +210,7 @@ describe("opencode guards", () => {
 
     expect(args).toEqual({ command: "ls" });
 
-    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+    await emitServerInstanceDisposed(hooks);
   });
 
   it("strips all args when Agent Observability returns an empty-object transform", async () => {
@@ -248,7 +249,7 @@ describe("opencode guards", () => {
     // An intentional "strip all arguments" transform empties the object.
     expect(output.args).toEqual({});
 
-    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+    await emitServerInstanceDisposed(hooks);
   });
 
   it("fails open and leaves args untouched when args are not a plain object", async () => {
@@ -291,7 +292,7 @@ describe("opencode guards", () => {
     // Fail open: the original (unmutated) args are preserved.
     expect(args).toEqual(["ls", "-la"]);
 
-    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+    await emitServerInstanceDisposed(hooks);
   });
 
   it("sets permission.ask output to deny when Agent Observability denies", async () => {
@@ -339,6 +340,6 @@ describe("opencode guards", () => {
       },
     });
 
-    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+    await emitServerInstanceDisposed(hooks);
   });
 });

--- a/plugins/opencode/src/hooks.otlp.test.ts
+++ b/plugins/opencode/src/hooks.otlp.test.ts
@@ -271,11 +271,10 @@ describe("createAgento11yHooks OTLP wiring", () => {
         properties: { info: { id: sessionID } },
       },
     });
-    // session.idle's forceFlush is fire-and-forget; only global.disposed
-    // awaits shutdown, which drains the OTLP exporters.
-    await hooks.event({
-      event: { type: "global.disposed", properties: {} },
-    });
+    // session.idle's forceFlush is fire-and-forget, so it cannot be awaited
+    // here. Disposal is the awaited path: it shuts the providers down, which
+    // drains the OTLP exporters.
+    await hooks.dispose();
   }
 
   it("forwards agento11y SDK spans and metrics through the configured OTLP endpoint", async () => {
@@ -452,9 +451,7 @@ describe("createAgento11yHooks OTLP wiring", () => {
         properties: { info: { id: sessionID } },
       },
     });
-    await hooks.event({
-      event: { type: "global.disposed", properties: {} },
-    });
+    await hooks.dispose();
   }
 
   it("exports an error execute_tool span for a tool that never completes in metadata_only", async () => {

--- a/plugins/opencode/src/hooks.testutil.ts
+++ b/plugins/opencode/src/hooks.testutil.ts
@@ -3,11 +3,24 @@
 
 import { vi } from "vitest";
 import type { Agento11yOpencodeConfig } from "./config.js";
-import type { createAgento11yHooks } from "./hooks.js";
+import type { createAgento11yHooks, OpencodeEventType } from "./hooks.js";
 
 export type TestHooks = NonNullable<
   Awaited<ReturnType<typeof createAgento11yHooks>>
 >;
+
+/**
+ * Dispatches an event through the plugin's `event` hook. `type` is constrained
+ * to the `@opencode-ai/sdk` `Event` union, so a name outside opencode's
+ * declared event surface fails to compile.
+ */
+export async function emitEvent(
+  hooks: TestHooks,
+  type: OpencodeEventType,
+  properties: unknown = {},
+): Promise<void> {
+  await hooks.event({ event: { type, properties } });
+}
 
 export type CapturedGeneration = {
   seed: any;
@@ -109,27 +122,21 @@ export async function emitMessageUpdated(
   hooks: TestHooks,
   msg: unknown,
 ): Promise<void> {
-  await hooks.event({
-    event: { type: "message.updated", properties: { info: msg } },
-  });
+  await emitEvent(hooks, "message.updated", { info: msg });
 }
 
 export async function emitPartUpdated(
   hooks: TestHooks,
   part: unknown,
 ): Promise<void> {
-  await hooks.event({
-    event: { type: "message.part.updated", properties: { part } },
-  });
+  await emitEvent(hooks, "message.part.updated", { part });
 }
 
 export async function emitSessionDeleted(
   hooks: TestHooks,
   sessionID: string,
 ): Promise<void> {
-  await hooks.event({
-    event: { type: "session.deleted", properties: { info: { id: sessionID } } },
-  });
+  await emitEvent(hooks, "session.deleted", { info: { id: sessionID } });
 }
 
 export async function emitSessionCreated(
@@ -137,7 +144,12 @@ export async function emitSessionCreated(
   id: string,
   parentID?: string,
 ): Promise<void> {
-  await hooks.event({
-    event: { type: "session.created", properties: { info: { id, parentID } } },
-  });
+  await emitEvent(hooks, "session.created", { info: { id, parentID } });
+}
+
+/** Dispatches opencode's instance-teardown event. */
+export async function emitServerInstanceDisposed(
+  hooks: TestHooks,
+): Promise<void> {
+  await emitEvent(hooks, "server.instance.disposed", { directory: "/repo" });
 }

--- a/plugins/opencode/src/hooks.toolSpans.test.ts
+++ b/plugins/opencode/src/hooks.toolSpans.test.ts
@@ -14,6 +14,7 @@ import {
   type ToolExecutionRecord,
   toolSpansFromParts,
 } from "./hooks.js";
+import { emitServerInstanceDisposed } from "./hooks.testutil.js";
 import { Redactor } from "./redact.js";
 
 function mockAgento11yClient() {
@@ -592,7 +593,7 @@ describe("hook lifecycle records and guard denial", () => {
     );
     expect(_peekToolExecutionState().completed).toHaveLength(0);
 
-    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+    await emitServerInstanceDisposed(hooks);
   });
 
   it("drains an incomplete tool execution when the assistant message records (metadata_only)", async () => {
@@ -666,7 +667,7 @@ describe("hook lifecycle records and guard denial", () => {
 
     expect(_peekToolExecutionState().active).toHaveLength(0);
 
-    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+    await emitServerInstanceDisposed(hooks);
   });
 
   it("removes the stranded active entry in full mode when the error part is present", async () => {
@@ -759,7 +760,7 @@ describe("hook lifecycle records and guard denial", () => {
     // precedence is pinned by the mergeToolSpanRecords cases above.
     expect(_peekToolExecutionState().active).toHaveLength(0);
 
-    await hooks.event({ event: { type: "global.disposed", properties: {} } });
+    await emitServerInstanceDisposed(hooks);
   });
 
   it("clears active and completed records on session.deleted", async () => {

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -3,6 +3,7 @@ import type { Agento11yClient, ContentCaptureMode } from "@grafana/agento11y";
 import type { PluginInput } from "@opencode-ai/plugin";
 import type {
   AssistantMessage,
+  Event,
   Part,
   Permission,
   UserMessage,
@@ -26,6 +27,19 @@ import {
 } from "./telemetry.js";
 
 type OpencodeClient = PluginInput["client"];
+
+/**
+ * Event names opencode declares it can deliver to a plugin. opencode feeds the
+ * `event` hook from its own event bus and publishes members of the SDK's
+ * generated `Event` union. Typing the hook input against that union keeps a
+ * name outside it from compiling.
+ */
+export type OpencodeEventType = Event["type"];
+
+export type OpencodeEvent = {
+  type: OpencodeEventType;
+  properties: unknown;
+};
 
 // Track recorded messages per session for dedup and cleanup
 const recordedMessages = new Map<string, Set<string>>();
@@ -128,13 +142,25 @@ export function _resetToolExecutionState(): void {
   completedToolExecutions.clear();
 }
 
+// Plugin instances that have been created and not yet shut down. One opencode
+// server can host an instance per directory, and all the state above is
+// module-scoped, so a shutting-down instance must not clear it while a sibling
+// is mid-turn. Dropping `pendingGenerations` there would export that turn
+// without its input, tools, and system prompt. Only the last instance to shut
+// down clears the state, so an earlier instance's sessions stay in the maps
+// until then; `session.deleted` is what normally releases them.
+let liveInstances = 0;
+
 /**
  * Resets every module-level map: the dedup/generation tracking plus the
- * tool-execution maps. Integration tests that drive the full record path
- * (`chat.message` -> `message.updated`) need this between cases. Without it, a
- * reused session/message id hits the dedup early-return in
- * `recordAssistantMessage`, silently skips recording, and produces a
- * misleading green.
+ * tool-execution maps.
+ *
+ * Two callers. Plugin shutdown calls it once the last live plugin instance in
+ * the process has shut down, so this runs in production and not only in tests.
+ * Integration tests that drive the full record path (`chat.message` ->
+ * `message.updated`) also need it between cases: without it, a reused
+ * session/message id hits the dedup early-return in `recordAssistantMessage`,
+ * silently skips recording, and produces a misleading green.
  *
  * @internal Exported for testing.
  */
@@ -245,7 +271,7 @@ async function handleEvent(
   redactor: Redactor,
   debugLog: (msg: string, ...args: unknown[]) => void,
   projectDir: string,
-  event: { type: string; properties: unknown },
+  event: OpencodeEvent,
 ): Promise<void> {
   if (event.type === "session.created" || event.type === "session.updated") {
     recordHostVersion(event.properties);
@@ -623,9 +649,10 @@ async function handleLifecycle(
   sigil: Agento11yClient,
   telemetry: TelemetryProviders | null,
   debugLog: (msg: string, ...args: unknown[]) => void,
-  event: { type: string; properties: unknown },
+  shutdownOnce: () => Promise<void>,
+  event: OpencodeEvent,
 ): Promise<void> {
-  const type = event.type as string;
+  const type = event.type;
 
   if (type === "session.idle") {
     // Recording happens live on `message.updated` and `message.part.updated`
@@ -669,22 +696,14 @@ async function handleLifecycle(
     }
   }
 
-  if (type === "global.disposed") {
-    activeToolExecutions.clear();
-    completedToolExecutions.clear();
-    latestSystemPromptBySession.clear();
-    try {
-      await sigil.shutdown();
-    } catch {
-      // shutdown failure is non-fatal
-    }
-    if (telemetry) {
-      try {
-        await telemetry.shutdown();
-      } catch (err) {
-        debugLog("telemetry shutdown failed", err);
-      }
-    }
+  // Covers hosts older than @opencode-ai/plugin 1.15.11, which have no
+  // `Hooks.dispose`. On those, the per-instance event bus publishes this to its
+  // own subscribers as the instance tears down, so the `event` hook still sees
+  // it. On 1.16 and later the plugin's subscription is closed before the
+  // instance store publishes the event, and `Hooks.dispose` is the trigger that
+  // runs. Both share the same idempotent path.
+  if (type === "server.instance.disposed") {
+    await shutdownOnce();
   }
 }
 
@@ -1037,9 +1056,14 @@ export function emitToolSpans(
 }
 
 export type Agento11yHooks = {
-  event: (input: {
-    event: { type: string; properties: unknown };
-  }) => Promise<void>;
+  event: (input: { event: OpencodeEvent }) => Promise<void>;
+  /**
+   * Flushes and shuts down the agento11y client and the OTel providers. Clears
+   * the module-level hook state once no other plugin instance in the process
+   * is still live. Safe to call more than once: later calls wait on the first
+   * shutdown instead of starting another.
+   */
+  dispose: () => Promise<void>;
   chatMessage: (
     input: {
       sessionID: string;
@@ -1105,14 +1129,44 @@ export async function createAgento11yHooks(
 
   const redactor = new Redactor();
 
-  process.on("beforeExit", () => {
-    sigil.shutdown().catch(() => {});
-    if (telemetry) {
-      telemetry
-        .shutdown()
-        .catch((err) => debugLog("telemetry shutdown failed", err));
-    }
-  });
+  liveInstances += 1;
+
+  // Single shutdown path for every teardown trigger, memoized on a promise
+  // rather than gated by a boolean so a later trigger waits for the in-flight
+  // shutdown instead of returning while the exporters are still draining. The
+  // guard is per plugin instance.
+  let shutdownPromise: Promise<void> | null = null;
+  const shutdownOnce = (): Promise<void> => {
+    shutdownPromise ??= (async () => {
+      process.off("beforeExit", onBeforeExit);
+      liveInstances -= 1;
+      try {
+        await sigil.shutdown();
+      } catch (err) {
+        debugLog("agento11y shutdown failed", err);
+      }
+      if (telemetry) {
+        try {
+          await telemetry.shutdown();
+        } catch (err) {
+          debugLog("telemetry shutdown failed", err);
+        }
+      }
+      if (liveInstances <= 0) _resetHookState();
+    })();
+    return shutdownPromise;
+  };
+
+  const onBeforeExit = (): void => {
+    void shutdownOnce();
+  };
+
+  // Last-resort trigger for hosts that neither invoke `Hooks.dispose` (see the
+  // version note in index.ts) nor deliver the disposal event. It is a weak one,
+  // because `beforeExit` does not fire on SIGINT, SIGTERM, or `process.exit()`.
+  // Deregistering inside `shutdownOnce` keeps a disposed instance from holding a
+  // process listener.
+  process.on("beforeExit", onBeforeExit);
 
   return {
     event: async (input) => {
@@ -1125,7 +1179,16 @@ export async function createAgento11yHooks(
         projectDir,
         input.event,
       );
-      await handleLifecycle(sigil, telemetry, debugLog, input.event);
+      await handleLifecycle(
+        sigil,
+        telemetry,
+        debugLog,
+        shutdownOnce,
+        input.event,
+      );
+    },
+    dispose: async () => {
+      await shutdownOnce();
     },
     chatMessage: (input, output) => {
       handleChatMessage(input, output);

--- a/plugins/opencode/src/index.test.ts
+++ b/plugins/opencode/src/index.test.ts
@@ -1,0 +1,62 @@
+// The plugin object opencode actually receives. The hook tests drive
+// `createAgento11yHooks` directly, so this file covers the wiring between the
+// two.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { loadConfigMock, createAgento11yClientMock } = vi.hoisted(() => ({
+  loadConfigMock: vi.fn(),
+  createAgento11yClientMock: vi.fn(),
+}));
+
+vi.mock("./config.js", () => ({ loadConfig: loadConfigMock }));
+vi.mock("./client.js", () => ({
+  createAgento11yClient: createAgento11yClientMock,
+}));
+
+import { _resetHookState } from "./hooks.js";
+import {
+  baseConfig,
+  makeAgento11yMock,
+  makeOpencodeClient,
+} from "./hooks.testutil.js";
+import { Agento11yPlugin } from "./index.js";
+
+// `dispose` is not in the pinned `Hooks` type (see the version note in
+// index.ts), so the plugin's return type does not declare it either.
+type PluginHooks = Awaited<ReturnType<typeof Agento11yPlugin>> & {
+  dispose?: () => Promise<void>;
+};
+
+function pluginInput() {
+  return { client: makeOpencodeClient(), directory: "/repo" } as any;
+}
+
+describe("Agento11yPlugin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetHookState();
+  });
+
+  it("wires opencode's dispose hook to the plugin shutdown path", async () => {
+    const { sigil } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    loadConfigMock.mockResolvedValue(baseConfig());
+
+    const hooks = (await Agento11yPlugin(pluginInput())) as PluginHooks;
+
+    expect(hooks.dispose).toBeTypeOf("function");
+    await hooks.dispose?.();
+
+    expect(sigil.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers no hooks when no config is resolved", async () => {
+    loadConfigMock.mockResolvedValue(null);
+
+    const hooks = (await Agento11yPlugin(pluginInput())) as PluginHooks;
+
+    expect(Object.keys(hooks)).toEqual([]);
+    expect(createAgento11yClientMock).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -1,6 +1,17 @@
-import type { Plugin } from "@opencode-ai/plugin";
+import type { Hooks, Plugin } from "@opencode-ai/plugin";
 import { loadConfig } from "./config.js";
 import { createAgento11yHooks } from "./hooks.js";
+
+// opencode calls `dispose` on every plugin as a scope finalizer when it tears
+// the instance down (packages/opencode/src/plugin/index.ts). Both that call and
+// the field on the published `Hooks` type arrived in @opencode-ai/plugin
+// 1.15.11, and this package pins 1.3.13 for development against a ^1.2.16 peer
+// range, so the type has to be widened locally. Older hosts ignore the extra
+// property. Remove this alias once the pin reaches 1.15.11 or later.
+//
+// `dispose` is required here, unlike upstream, so dropping the wiring below
+// fails to compile instead of silently losing the primary shutdown trigger.
+type HooksWithDispose = Hooks & { dispose: () => Promise<void> };
 
 export const Agento11yPlugin: Plugin = async ({ client, directory }) => {
   const config = await loadConfig();
@@ -11,7 +22,7 @@ export const Agento11yPlugin: Plugin = async ({ client, directory }) => {
   });
   if (!hooks) return {};
 
-  return {
+  const pluginHooks: HooksWithDispose = {
     "chat.message": async (input, output) => {
       hooks.chatMessage(input, output);
     },
@@ -19,9 +30,7 @@ export const Agento11yPlugin: Plugin = async ({ client, directory }) => {
       hooks.systemTransform(input, output);
     },
     event: async ({ event }) => {
-      await hooks.event({
-        event: event as { type: string; properties: unknown },
-      });
+      await hooks.event({ event });
     },
     "tool.execute.before": async (input, output) => {
       await hooks.toolExecuteBefore(input, output);
@@ -32,5 +41,9 @@ export const Agento11yPlugin: Plugin = async ({ client, directory }) => {
     "permission.ask": async (input, output) => {
       await hooks.permissionAsk(input, output);
     },
+    dispose: async () => {
+      await hooks.dispose();
+    },
   };
+  return pluginHooks;
 };


### PR DESCRIPTION
Spans were not flushed when opencode shut down. The disposal branch in `handleLifecycle` waited for the `global.disposed` event, but opencode sends that event only after every instance is already gone, so `sigil.shutdown()` and `telemetry.shutdown()` never ran.

The plugin now shuts down from opencode's `Hooks.dispose`, which the agent waits for.