### PR TITLE
chore(plugins): rename plugin manifests to agento11y

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,11 +1,11 @@
 {
-  "name": "grafana-sigil",
+  "name": "agento11y",
   "interface": {
-    "displayName": "Grafana Sigil"
+    "displayName": "Grafana Agent Observability"
   },
   "plugins": [
     {
-      "name": "sigil-codex",
+      "name": "agento11y-codex",
       "source": {
         "source": "local",
         "path": "./plugins/codex"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,17 +1,19 @@
 {
-  "name": "grafana-sigil",
+  "name": "agento11y",
   "owner": {
     "name": "Grafana Labs"
   },
   "plugins": [
     {
-      "name": "sigil-cc",
+      "name": "agento11y-claude-code",
       "source": "./plugins/claude-code",
       "description": "Send Claude Code session telemetry to Grafana Agent Observability",
-      "version": "0.4.0",
       "author": {
         "name": "Grafana Labs"
       }
     }
-  ]
+  ],
+  "renames": {
+    "sigil-cc": "agento11y-claude-code"
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,7 @@ python-providers/*/build/
 
 *.db
 coverage.out
-plugins/claude-code/sigil-cc
-plugins/codex/sigil-codex
+plugins/agento11y/agento11y
 examples/experiments/go/go
 examples/getting-started/go/go
 examples/getting-started/go-hooks/go-hooks

--- a/llms.txt
+++ b/llms.txt
@@ -73,7 +73,7 @@ The user wants Grafana Agent observability to capture sessions from their coding
 
 | Agent | Plugin | Mechanism |
 |-------|--------|-----------|
-| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | [`plugins/claude-code/`](https://github.com/grafana/agento11y/tree/main/plugins/claude-code) | Shared `agento11y` Go binary, plugin name `sigil-cc` |
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | [`plugins/claude-code/`](https://github.com/grafana/agento11y/tree/main/plugins/claude-code) | Shared `agento11y` Go binary, plugin name `agento11y-claude-code` |
 | [Codex](https://developers.openai.com/codex) | [`plugins/codex/`](https://github.com/grafana/agento11y/tree/main/plugins/codex) | Shared `agento11y` Go binary via hooks |
 | [Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) | [`plugins/copilot/`](https://github.com/grafana/agento11y/tree/main/plugins/copilot) | Shared `agento11y` Go binary via hooks |
 | [Cursor](https://cursor.com) | [`plugins/cursor/`](https://github.com/grafana/agento11y/tree/main/plugins/cursor) | Shared `agento11y` Go binary via hooks |

--- a/plugins/agento11y/Makefile
+++ b/plugins/agento11y/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build test lint install
 
 build:
-	GOWORK=off go build -o sigil ./cmd/sigil
+	GOWORK=off go build -o agento11y ./cmd/agento11y
 
 test:
 	GOWORK=off go test ./...
@@ -10,4 +10,4 @@ lint:
 	golangci-lint run ./...
 
 install:
-	GOWORK=off go install ./cmd/sigil
+	GOWORK=off go install ./cmd/agento11y

--- a/plugins/agento11y/internal/agents/codex/launch.go
+++ b/plugins/agento11y/internal/agents/codex/launch.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os/exec"
+	"strings"
 	"syscall"
 	"time"
 
@@ -19,10 +20,9 @@ const (
 	// `codex plugin marketplace add`.
 	marketplaceRepo = "grafana/agento11y"
 	// marketplaceAlias is the marketplace name declared in
-	// .agents/plugins/marketplace.json. Codex derives plugin keys from the
-	// marketplace manifest, so a local snapshot that predates the sigil
-	// rename exposes the plugin only as
-	// legacyPluginName@legacyMarketplaceAlias.
+	// .agents/plugins/marketplace.json. A local snapshot that predates the
+	// sigil rename exposes the plugin only under legacyMarketplaceAlias; see
+	// pluginKeys for the keys that follow from that.
 	marketplaceAlias       = "agento11y"
 	legacyMarketplaceAlias = "grafana-sigil"
 	// PluginName is the codex plugin name declared in
@@ -115,47 +115,82 @@ func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {
 	if err := runSteps(ctx, bin, w, [][]string{{"plugin", "marketplace", "add", marketplaceRepo}}); err != nil {
 		return err
 	}
-	return ensurePlugin(ctx, bin, w, false)
+	return ensurePlugin(ctx, bin, w, "")
 }
 
 func defaultRunUpdate(ctx context.Context, bin string, w io.Writer) error {
-	// Snapshot the legacy state before the upgrade: when the refreshed
-	// marketplace copy drops the legacy name, ensurePlugin flips the install
-	// to the renamed plugin and the user must re-trust its hooks.
-	hadLegacy := false
+	// Snapshot the key that answers today. The upgrade below can drop the name
+	// or the alias that key uses, and ensurePlugin then lands on a different
+	// one; codex treats that as a new hook identity, so the user has to
+	// re-trust the hooks.
+	installedKey := ""
 	if out, err := pluginList(ctx, bin); err == nil {
-		hadLegacy = keyEnabled(out, legacyPluginName+"@"+legacyMarketplaceAlias)
+		installedKey = enabledKey(out)
 	}
 	if err := runSteps(ctx, bin, w, [][]string{{"plugin", "marketplace", "upgrade"}}); err != nil {
 		return err
 	}
-	return ensurePlugin(ctx, bin, w, hadLegacy)
+	return ensurePlugin(ctx, bin, w, installedKey)
 }
 
-// ensurePlugin registers the plugin under its current name, falling back to
-// the legacy name when the local marketplace snapshot predates the rename.
+// ensurePlugin registers the plugin under the first key of pluginKeys that
+// codex accepts, then reconciles the state that key implies.
+//
 // After a successful current-name add it removes the legacy entry: the
 // snapshot is post-rename at that point, so a leftover legacy entry can
 // never resolve again and would sit in config.toml as an orphan. Removal is
 // best-effort and exits 0 even when nothing is registered, so it is safe on
-// fresh installs. migrated additionally prints the one-time /hooks re-trust
-// hint — codex treats the renamed plugin as a new hook identity.
-func ensurePlugin(ctx context.Context, bin string, w io.Writer, migrated bool) error {
-	idx, err := runFirst(ctx, bin, w, [][]string{
-		{"plugin", "add", PluginName + "@" + marketplaceAlias},
-		{"plugin", "add", legacyPluginName + "@" + legacyMarketplaceAlias},
-	})
-	if err != nil || idx != 0 {
+// fresh installs.
+//
+// installedKey is the key that answered before this call, empty on a fresh
+// install. When the winning key differs, the install moved and codex sees a
+// new hook identity, so print the one-time /hooks re-trust hint naming the
+// key the user will now find there.
+func ensurePlugin(ctx context.Context, bin string, w io.Writer, installedKey string) error {
+	keys := pluginKeys()
+	candidates := make([][]string, 0, len(keys))
+	for _, k := range keys {
+		candidates = append(candidates, []string{"plugin", "add", k})
+	}
+	idx, err := runFirst(ctx, bin, w, candidates)
+	if err != nil {
 		return err
 	}
-	if migrated {
+	key := keys[idx]
+	// Only the legacy plugin name resolving means the snapshot still predates
+	// the rename: that install is live, so leave it alone.
+	if strings.HasPrefix(key, legacyPluginName+"@") {
+		return nil
+	}
+	if installedKey != "" && installedKey != key {
 		fmt.Fprintf(w,
-			"agento11y: migrated %s@%s to %s@%s — open /hooks inside codex and\n"+
+			"agento11y: migrated %s to %s — open /hooks inside codex and\n"+
 				"           trust the %s hooks to keep exporting turns.\n",
-			legacyPluginName, legacyMarketplaceAlias, PluginName, marketplaceAlias, PluginName)
+			installedKey, key, PluginName)
 	}
 	_, _ = runOutput(ctx, bin, "plugin", "remove", legacyPluginName+"@"+legacyMarketplaceAlias)
 	return nil
+}
+
+// pluginKeys lists the `<plugin>@<marketplace>` keys the launcher installs and
+// accepts, in preference order. codex derives plugin keys from the marketplace
+// manifest and does not document whether `plugin marketplace upgrade` re-keys
+// an existing registration to the manifest's new name, so a registration made
+// before the rename may keep answering to legacyMarketplaceAlias while already
+// serving the renamed plugin. That middle key is therefore a first-class state
+// rather than a fallback.
+//
+// legacyPluginName@marketplaceAlias is deliberately absent: the alias comes
+// from the manifest name, so a snapshot that still lists legacyPluginName is
+// named legacyMarketplaceAlias and the pair cannot occur. Counting it would
+// suppress bootstrap for a key codex can never resolve, and removing it would
+// delete an unrelated marketplace's plugin.
+func pluginKeys() []string {
+	return []string{
+		PluginName + "@" + marketplaceAlias,
+		PluginName + "@" + legacyMarketplaceAlias,
+		legacyPluginName + "@" + legacyMarketplaceAlias,
+	}
 }
 
 // defaultPluginList shells out to `codex plugin list` and returns the raw
@@ -166,12 +201,11 @@ func defaultPluginList(ctx context.Context, bin string) ([]byte, error) {
 	return launcher.Output(ctx, bin, "plugin", "list")
 }
 
-// pluginInstalled reports whether the codex plugin is registered and enabled
-// in codex's plugin store, under either its current or its legacy key. A
-// legacy install counts: while the local marketplace snapshot predates the
-// rename it keeps working as-is, and the periodic update path performs the
-// migration once `codex plugin marketplace upgrade` pulls a post-rename
-// copy.
+// pluginInstalled reports whether any key in pluginKeys is registered and
+// enabled in codex's plugin store. A legacy install counts: while the local
+// marketplace snapshot predates the rename it keeps working as-is, and the
+// periodic update path performs the migration once
+// `codex plugin marketplace upgrade` pulls a post-rename copy.
 //
 // We shell out to `codex plugin list` because it's the source of truth and
 // doesn't depend on the user's $XDG_CONFIG_HOME layout. Anything other than
@@ -184,8 +218,18 @@ func pluginInstalled(ctx context.Context, bin string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return keyEnabled(out, PluginName+"@"+marketplaceAlias) ||
-		keyEnabled(out, legacyPluginName+"@"+legacyMarketplaceAlias), nil
+	return enabledKey(out) != "", nil
+}
+
+// enabledKey returns the first key of pluginKeys that `codex plugin list`
+// marks installed and enabled; empty when none is.
+func enabledKey(out []byte) string {
+	for _, key := range pluginKeys() {
+		if keyEnabled(out, key) {
+			return key
+		}
+	}
+	return ""
 }
 
 // keyEnabled reports whether `codex plugin list` output marks the exact

--- a/plugins/agento11y/internal/agents/codex/launch_test.go
+++ b/plugins/agento11y/internal/agents/codex/launch_test.go
@@ -28,31 +28,42 @@ func TestLaunch_MissingCodexBinary(t *testing.T) {
 }
 
 func TestLaunch_SkipsInstallWhenPluginInstalledAndEnabled(t *testing.T) {
-	t.Setenv("SIGIL_AUTO_UPDATE", "false")
-	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/codex", nil })
-	withPluginList(t, func(context.Context, string) ([]byte, error) {
-		return []byte("  sigil-codex@grafana-sigil (installed, enabled)\n"), nil
-	})
-	withRunInstall(t, func(context.Context, string, io.Writer) error {
-		t.Fatal("runInstall must not be called when plugin is installed and enabled")
-		return nil
-	})
+	for _, tc := range []struct {
+		name string
+		out  string
+	}{
+		{name: "legacy key", out: "  sigil-codex@grafana-sigil (installed, enabled)\n"},
+		{name: "current key", out: "  agento11y-codex@agento11y (installed, enabled)\n"},
+		{name: "current name at legacy alias", out: "  agento11y-codex@grafana-sigil (installed, enabled)\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SIGIL_AUTO_UPDATE", "false")
+			withLookPath(t, func(string) (string, error) { return "/usr/local/bin/codex", nil })
+			withPluginList(t, func(context.Context, string) ([]byte, error) {
+				return []byte(tc.out), nil
+			})
+			withRunInstall(t, func(context.Context, string, io.Writer) error {
+				t.Fatal("runInstall must not be called when plugin is installed and enabled")
+				return nil
+			})
 
-	var execArgv []string
-	withExecFn(t, func(_ string, argv []string, _ []string) error {
-		execArgv = append([]string{}, argv...)
-		return nil
-	})
+			var execArgv []string
+			withExecFn(t, func(_ string, argv []string, _ []string) error {
+				execArgv = append([]string{}, argv...)
+				return nil
+			})
 
-	var stderr bytes.Buffer
-	if err := Launch(context.Background(), []string{"exec", "hi"}, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger(), "dev"); err != nil {
-		t.Fatalf("Launch returned err: %v", err)
-	}
-	if !reflect.DeepEqual(execArgv, []string{"/usr/local/bin/codex", "exec", "hi"}) {
-		t.Fatalf("exec argv = %v", execArgv)
-	}
-	if stderr.Len() != 0 {
-		t.Fatalf("stderr non-empty: %q", stderr.String())
+			var stderr bytes.Buffer
+			if err := Launch(context.Background(), []string{"exec", "hi"}, nil, strings.NewReader(""), io.Discard, &stderr, nopLogger(), "dev"); err != nil {
+				t.Fatalf("Launch returned err: %v", err)
+			}
+			if !reflect.DeepEqual(execArgv, []string{"/usr/local/bin/codex", "exec", "hi"}) {
+				t.Fatalf("exec argv = %v", execArgv)
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr non-empty: %q", stderr.String())
+			}
+		})
 	}
 }
 
@@ -304,9 +315,9 @@ func TestPluginInstalled_ParsesPluginListOutput(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "current name at legacy alias does not count",
+			name: "current name at legacy alias counts",
 			out:  "  agento11y-codex@grafana-sigil (installed, enabled)\n",
-			want: false,
+			want: true,
 		},
 		{
 			name: "legacy name at current alias does not count",
@@ -509,73 +520,139 @@ func recordCommands(t *testing.T, firstIdx int) (steps, candidates, outputs *[][
 	return steps, candidates, outputs
 }
 
-func TestDefaultRunInstall_RegistersCurrentNameAndRemovesLegacy(t *testing.T) {
-	steps, candidates, outputs := recordCommands(t, 0)
-
-	var out bytes.Buffer
-	require.NoError(t, defaultRunInstall(context.Background(), "/usr/local/bin/codex", &out))
-	require.Equal(t, [][]string{{"plugin", "marketplace", "add", "grafana/agento11y"}}, *steps)
-	require.Equal(t, [][]string{
-		{"plugin", "add", "agento11y-codex@agento11y"},
-		{"plugin", "add", "sigil-codex@grafana-sigil"},
-	}, *candidates)
-	require.Equal(t, [][]string{{"plugin", "remove", "sigil-codex@grafana-sigil"}}, *outputs)
-	// Fresh install, not a migration: no re-trust line beyond PostInstallHint.
-	require.NotContains(t, out.String(), "migrated")
+// codexAddCandidates is the exact `plugin add` sequence ensurePlugin offers,
+// in preference order.
+var codexAddCandidates = [][]string{
+	{"plugin", "add", "agento11y-codex@agento11y"},
+	{"plugin", "add", "agento11y-codex@grafana-sigil"},
+	{"plugin", "add", "sigil-codex@grafana-sigil"},
 }
 
-func TestDefaultRunInstall_PreRenameSnapshotFallsBackToLegacyName(t *testing.T) {
-	_, _, outputs := recordCommands(t, 1)
+const legacyRemoval = "sigil-codex@grafana-sigil"
 
-	var out bytes.Buffer
-	require.NoError(t, defaultRunInstall(context.Background(), "/usr/local/bin/codex", &out))
-	// The legacy install is live; it must not be removed.
-	require.Empty(t, *outputs)
-	require.NotContains(t, out.String(), "migrated")
+func TestDefaultRunInstall_CommandSequences(t *testing.T) {
+	cases := []struct {
+		name        string
+		firstIdx    int
+		wantOutputs [][]string
+	}{
+		{
+			name:        "current key registers and drops the orphaned legacy entry",
+			firstIdx:    0,
+			wantOutputs: [][]string{{"plugin", "remove", legacyRemoval}},
+		},
+		{
+			name:        "registration that kept its pre-rename alias still serves the current name",
+			firstIdx:    1,
+			wantOutputs: [][]string{{"plugin", "remove", legacyRemoval}},
+		},
+		{
+			// The legacy install is live while the snapshot predates the
+			// rename; it must not be removed.
+			name:     "pre-rename snapshot falls back to the legacy name",
+			firstIdx: 2,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			steps, candidates, outputs := recordCommands(t, tc.firstIdx)
+
+			var out bytes.Buffer
+			require.NoError(t, defaultRunInstall(context.Background(), "/usr/local/bin/codex", &out))
+			require.Equal(t, [][]string{{"plugin", "marketplace", "add", "grafana/agento11y"}}, *steps)
+			require.Equal(t, codexAddCandidates, *candidates)
+			if len(tc.wantOutputs) == 0 {
+				require.Empty(t, *outputs)
+			} else {
+				require.Equal(t, tc.wantOutputs, *outputs)
+			}
+			// A fresh install is not a migration: no re-trust line beyond
+			// PostInstallHint.
+			require.NotContains(t, out.String(), "migrated")
+		})
+	}
 }
 
-func TestDefaultRunUpdate_MigratesLegacyInstall(t *testing.T) {
-	withPluginList(t, func(context.Context, string) ([]byte, error) {
-		return []byte("  sigil-codex@grafana-sigil (installed, enabled)\n"), nil
-	})
-	steps, candidates, outputs := recordCommands(t, 0)
+func TestDefaultRunUpdate_CommandSequences(t *testing.T) {
+	cases := []struct {
+		name        string
+		list        string // `codex plugin list` output before the upgrade
+		listErr     bool
+		firstIdx    int
+		wantOutputs [][]string
+		wantHint    string // migration line the user must see; empty means none
+	}{
+		{
+			name:        "legacy install migrates to the current key",
+			list:        "  sigil-codex@grafana-sigil (installed, enabled)\n",
+			firstIdx:    0,
+			wantOutputs: [][]string{{"plugin", "remove", legacyRemoval}},
+			wantHint:    "migrated sigil-codex@grafana-sigil to agento11y-codex@agento11y",
+		},
+		{
+			name:        "legacy install migrates under a registration that kept its alias",
+			list:        "  sigil-codex@grafana-sigil (installed, enabled)\n",
+			firstIdx:    1,
+			wantOutputs: [][]string{{"plugin", "remove", legacyRemoval}},
+			wantHint:    "migrated sigil-codex@grafana-sigil to agento11y-codex@grafana-sigil",
+		},
+		{
+			name:     "pre-rename snapshot stays on the legacy name",
+			list:     "  sigil-codex@grafana-sigil (installed, enabled)\n",
+			firstIdx: 2,
+		},
+		{
+			// The plugin name does not change here, but the key does, and
+			// codex identifies hooks by the whole key.
+			name:        "current name moving off the legacy alias also needs re-trust",
+			list:        "  agento11y-codex@grafana-sigil (installed, enabled)\n",
+			firstIdx:    0,
+			wantOutputs: [][]string{{"plugin", "remove", legacyRemoval}},
+			wantHint:    "migrated agento11y-codex@grafana-sigil to agento11y-codex@agento11y",
+		},
+		{
+			name:        "install already on the current key just refreshes",
+			list:        "  agento11y-codex@agento11y (installed, enabled)\n",
+			firstIdx:    0,
+			wantOutputs: [][]string{{"plugin", "remove", legacyRemoval}},
+		},
+		{
+			// Without a readable key there is nothing to compare against, so
+			// stay quiet rather than guess at a migration.
+			name:        "unreadable plugin list suppresses the hint",
+			listErr:     true,
+			firstIdx:    0,
+			wantOutputs: [][]string{{"plugin", "remove", legacyRemoval}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withPluginList(t, func(context.Context, string) ([]byte, error) {
+				if tc.listErr {
+					return nil, errors.New("codex plugin list failed")
+				}
+				return []byte(tc.list), nil
+			})
+			steps, candidates, outputs := recordCommands(t, tc.firstIdx)
 
-	var out bytes.Buffer
-	require.NoError(t, defaultRunUpdate(context.Background(), "/usr/local/bin/codex", &out))
-	require.Equal(t, [][]string{{"plugin", "marketplace", "upgrade"}}, *steps)
-	require.Equal(t, [][]string{
-		{"plugin", "add", "agento11y-codex@agento11y"},
-		{"plugin", "add", "sigil-codex@grafana-sigil"},
-	}, *candidates)
-	require.Equal(t, [][]string{{"plugin", "remove", "sigil-codex@grafana-sigil"}}, *outputs)
-	got := out.String()
-	require.Contains(t, got, "migrated sigil-codex@grafana-sigil to agento11y-codex@agento11y")
-	require.Contains(t, got, "/hooks")
-}
-
-func TestDefaultRunUpdate_PreRenameSnapshotStaysOnLegacyName(t *testing.T) {
-	withPluginList(t, func(context.Context, string) ([]byte, error) {
-		return []byte("  sigil-codex@grafana-sigil (installed, enabled)\n"), nil
-	})
-	_, _, outputs := recordCommands(t, 1)
-
-	var out bytes.Buffer
-	require.NoError(t, defaultRunUpdate(context.Background(), "/usr/local/bin/codex", &out))
-	require.Empty(t, *outputs)
-	require.NotContains(t, out.String(), "migrated")
-}
-
-func TestDefaultRunUpdate_CurrentInstallRefreshesWithoutMigrationHint(t *testing.T) {
-	withPluginList(t, func(context.Context, string) ([]byte, error) {
-		return []byte("  agento11y-codex@agento11y (installed, enabled)\n"), nil
-	})
-	_, _, outputs := recordCommands(t, 0)
-
-	var out bytes.Buffer
-	require.NoError(t, defaultRunUpdate(context.Background(), "/usr/local/bin/codex", &out))
-	// Legacy removal stays a harmless no-op after migration.
-	require.Equal(t, [][]string{{"plugin", "remove", "sigil-codex@grafana-sigil"}}, *outputs)
-	require.NotContains(t, out.String(), "migrated")
+			var out bytes.Buffer
+			require.NoError(t, defaultRunUpdate(context.Background(), "/usr/local/bin/codex", &out))
+			require.Equal(t, [][]string{{"plugin", "marketplace", "upgrade"}}, *steps)
+			require.Equal(t, codexAddCandidates, *candidates)
+			if len(tc.wantOutputs) == 0 {
+				require.Empty(t, *outputs)
+			} else {
+				require.Equal(t, tc.wantOutputs, *outputs)
+			}
+			got := out.String()
+			if tc.wantHint == "" {
+				require.NotContains(t, got, "migrated")
+				return
+			}
+			require.Contains(t, got, tc.wantHint)
+			require.Contains(t, got, "/hooks")
+		})
+	}
 }
 
 func TestStatus(t *testing.T) {

--- a/plugins/agento11y/internal/local/manager.go
+++ b/plugins/agento11y/internal/local/manager.go
@@ -84,6 +84,12 @@ func LoadStatus(dir string) (*Status, error) {
 }
 
 // SaveStatus writes the daemon's status file with 0o600 permissions.
+//
+// The bytes go to a temp file in dir and are renamed into place, so a reader
+// never sees a half-written file. Writing in place would truncate first, and
+// LoadStatus takes no lock: EnsureRunning probes the status before acquiring
+// the daemon lock, and `local status` reads it at any time, so those readers
+// would fail on an empty file while a daemon records itself.
 func SaveStatus(dir string, s Status) error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
@@ -92,8 +98,27 @@ func SaveStatus(dir string, s Status) error {
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(dir, StatusFile)
-	return os.WriteFile(path, data, 0o600)
+	f, err := os.CreateTemp(dir, StatusFile+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	// A no-op once the rename below succeeds; on any earlier return it keeps
+	// a failed write from leaving the temp file behind.
+	defer func() { _ = os.Remove(tmp) }()
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	// CreateTemp opens at 0o600 already; set it explicitly so the file mode
+	// does not depend on the caller's umask.
+	if err := os.Chmod(tmp, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, filepath.Join(dir, StatusFile))
 }
 
 // RemoveStatus deletes the status file. Missing-file errors are ignored.

--- a/plugins/agento11y/internal/local/manager_test.go
+++ b/plugins/agento11y/internal/local/manager_test.go
@@ -33,6 +33,63 @@ func TestStop_RemovesStatusWhenProcessGone(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "stale status file should be removed")
 }
 
+// TestSaveStatus_ConcurrentReadersSeeWholeFile pins down the atomic write.
+// LoadStatus takes no lock, so an in-place write truncates the file under
+// readers and they fail with "unexpected end of JSON input" - which is how
+// TestEnsureRunning_ConcurrentCallersSpawnOnce used to flake.
+func TestSaveStatus_ConcurrentReadersSeeWholeFile(t *testing.T) {
+	dir := t.TempDir()
+	want := Status{
+		PID:       os.Getpid(),
+		Port:      8765,
+		Endpoint:  "http://127.0.0.1:8765",
+		StartedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	require.NoError(t, SaveStatus(dir, want))
+
+	const writes = 500
+	writing := make(chan struct{})
+	writeErr := make(chan error, 1)
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		defer close(writing)
+		for range writes {
+			if err := SaveStatus(dir, want); err != nil {
+				writeErr <- err
+				return
+			}
+		}
+	})
+
+	var readErr error
+	partial := 0
+	for done := false; !done; {
+		select {
+		case <-writing:
+			done = true
+		default:
+		}
+		s, err := LoadStatus(dir)
+		switch {
+		case err != nil:
+			if readErr == nil {
+				readErr = err
+			}
+		case s == nil || *s != want:
+			partial++
+		}
+	}
+	wg.Wait()
+
+	select {
+	case err := <-writeErr:
+		require.NoError(t, err)
+	default:
+	}
+	require.NoError(t, readErr, "LoadStatus read a status file mid-write")
+	assert.Zero(t, partial, "LoadStatus returned a status that was never written")
+}
+
 func TestStop_EndpointDeadButProcessAlive(t *testing.T) {
 	if _, err := exec.LookPath("sleep"); err != nil {
 		t.Skip("sleep command unavailable")

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
-  "name": "sigil-cc",
-  "version": "0.4.0",
+  "name": "agento11y-claude-code",
   "description": "Send Claude Code session telemetry to Grafana Agent Observability",
   "author": {
     "name": "Grafana Labs"
@@ -8,7 +7,7 @@
   "repository": "https://github.com/grafana/agento11y",
   "homepage": "https://github.com/grafana/agento11y/tree/main/plugins/claude-code",
   "license": "Apache-2.0",
-  "keywords": ["telemetry", "observability", "sigil", "grafana"],
+  "keywords": ["telemetry", "observability", "grafana"],
   "hooks": {
     "SessionStart": [
       {

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -27,14 +27,14 @@ agento11y claude
 
 The script installs `agento11y` to `~/.local/bin`; `go install` uses `go env GOPATH`/bin (or `GOBIN`). Make sure that directory is on your `PATH`. See the [`agento11y` binary README](../agento11y/README.md#install) for all install options. The command was renamed from `sigil`; the old name still works but will be removed in a future release.
 
-`agento11y claude` registers the `sigil-cc` plugin on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/agento11y/config.env`, and then launches Claude Code.
+`agento11y claude` registers the `agento11y-claude-code` plugin on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/agento11y/config.env`, and then launches Claude Code.
 
 <details>
 <summary>Manual plugin registration</summary>
 
 ```
 /plugin marketplace add grafana/agento11y
-/plugin install sigil-cc@grafana-sigil
+/plugin install agento11y-claude-code@agento11y
 ```
 
 </details>
@@ -105,7 +105,7 @@ Common culprits: `agento11y --version` doesn't work (binary not on `PATH`), a mi
 | `AGENTO11Y_USER_ID` | from `~/.claude.json` | Override the user id. |
 | `AGENTO11Y_USER_ID_SOURCE` | `email` | Which field to read from `~/.claude.json`: `email` or `accountUuid`. |
 | `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
-| `AGENTO11Y_AUTO_UPDATE` | `true` | Refresh the `sigil-cc` plugin automatically. Set `false` to pin the installed version. |
+| `AGENTO11Y_AUTO_UPDATE` | `true` | Refresh the `agento11y-claude-code` plugin automatically. Set `false` to pin the installed version. |
 | `AGENTO11Y_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Claude Code `PreToolUse` hook calls the Agent Observability `/api/v1/hooks:evaluate` API and blocks tool calls denied by guard rules. |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |
 | `AGENTO11Y_GUARDS_TIMEOUT_MS` | `1500` | Per-call timeout. Lower = less added latency on every tool call, higher = better tolerance for slow `llm_judge` evaluators. |

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
-  "name": "sigil-codex",
-  "version": "0.4.0",
+  "name": "agento11y-codex",
+  "version": "0.5.0",
   "description": "Send Codex session telemetry to Grafana Agent Observability",
   "author": {
     "name": "Grafana Labs"
@@ -8,7 +8,7 @@
   "repository": "https://github.com/grafana/agento11y",
   "homepage": "https://github.com/grafana/agento11y/tree/main/plugins/codex",
   "license": "Apache-2.0",
-  "keywords": ["telemetry", "observability", "sigil", "grafana", "codex"],
+  "keywords": ["telemetry", "observability", "grafana", "codex"],
   "hooks": "./hooks/hooks.json",
   "interface": {
     "displayName": "Grafana Agent Observability for Codex",

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -29,22 +29,22 @@ agento11y codex
 
 The script installs `agento11y` to `~/.local/bin`; `go install` uses `go env GOPATH`/bin (or `GOBIN`). Make sure that directory is on your `PATH`. See the [`agento11y` binary README](../agento11y/README.md#install) for all install options. The command was renamed from `sigil`; the old name still works but will be removed in a future release.
 
-`agento11y codex` registers `sigil-codex@grafana-sigil` on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/agento11y/config.env`, and then launches Codex.
+`agento11y codex` registers `agento11y-codex@agento11y` on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/agento11y/config.env`, and then launches Codex.
 
-On first launch only, open `/hooks` inside Codex and trust each `sigil-codex@grafana-sigil` hook. Codex requires this manual review after plugin install.
+On first launch only, open `/hooks` inside Codex and trust each `agento11y-codex@agento11y` hook. Codex requires this manual review after plugin install.
 
 <details>
 <summary>Manual plugin registration</summary>
 
 ```sh
 codex plugin marketplace add grafana/agento11y
-codex plugin add sigil-codex@grafana-sigil
+codex plugin add agento11y-codex@agento11y
 ```
 
 On current Codex builds the `hooks` and `plugin_hooks` features are stable by default (`codex features list` confirms this), so no `config.toml` edits are needed. Older builds gated this on feature flags — if `/hooks` is empty after install, add the following to `~/.codex/config.toml`:
 
 ```toml
-[plugins."sigil-codex@grafana-sigil"]
+[plugins."agento11y-codex@agento11y"]
 enabled = true
 
 [features]
@@ -53,7 +53,7 @@ codex_hooks = true
 
 Older Codex builds use `hooks = true` and `plugin_hooks = true` instead of `codex_hooks`. Run `codex features list` to see which flag names your build accepts.
 
-Restart Codex, open `/hooks`, and trust the five `sigil-codex@grafana-sigil` hooks (first-run review is expected).
+Restart Codex, open `/hooks`, and trust the five `agento11y-codex@agento11y` hooks (first-run review is expected).
 
 </details>
 
@@ -123,7 +123,7 @@ tail -f ~/.local/state/agento11y/logs/agento11y.log
 | `AGENTO11Y_GUARDS_ENABLED` | `false` | Enable Codex `PreToolUse` guards against Agent Observability rules. |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | Allow the tool call when the guard request fails (set `false` for fail-closed). |
 | `AGENTO11Y_GUARDS_TIMEOUT_MS` | `1500` | Per-call guard timeout. |
-| `AGENTO11Y_AUTO_UPDATE` | `true` | Refresh the `sigil-codex` plugin automatically. Set `false` to pin the installed version. |
+| `AGENTO11Y_AUTO_UPDATE` | `true` | Refresh the `agento11y-codex` plugin automatically. Set `false` to pin the installed version. |
 
 Guard rules can block a tool call or rewrite its arguments (Transform rules, e.g. redacting a secret before the tool runs). Guards only intercept tool calls that Codex routes through `PreToolUse` — Bash, the `apply_patch` variants, and MCP tools. See the [Codex hooks docs](https://developers.openai.com/codex/hooks) for the supported set.
 
@@ -133,7 +133,7 @@ If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your Agent
 
 | Symptom | Try |
 |---|---|
-| `/hooks` is empty | Enable the hook feature flags (`codex features list`), enable `plugins."sigil-codex@grafana-sigil"`, restart Codex. |
+| `/hooks` is empty | Enable the hook feature flags (`codex features list`), enable `plugins."agento11y-codex@agento11y"`, restart Codex. |
 | Hooks listed but inactive | Open `/hooks` and trust each one. |
 | Command not found | Reinstall `agento11y` (see step 1). Check `agento11y --version` and that its install dir is on `PATH`. |
 | No data appears | Let turns finish (interrupted turns are not exported). Then check the debug log. |


### PR DESCRIPTION
Renames the Claude Code and Codex plugin manifests: 
- marketplace `grafana-sigil` becomes `agento11y`
- `sigil-cc` becomes `agento11y-claude-code`
- `sigil-codex` becomes `agento11y-codex`

Existing installs:

- Claude Code [migrates](https://code.claude.com/docs/en/plugin-marketplaces#rename-or-remove-a-plugin) through the marketplace `renames` map at session start, so the launcher's probe treats a legacy key as installed instead of reinstalling on top of it.
- Codex has no rename mechanism, so the launcher does it.