### PR TITLE
feat(plugins/opencode): send the session title as conversationTitle

### DIFF
--- a/plugins/opencode/src/golden.test.ts
+++ b/plugins/opencode/src/golden.test.ts
@@ -97,6 +97,7 @@ function closeServer(server: Server): Promise<void> {
 function opencodeMessageFixture() {
   const sessionID = "opencode-sess-1";
   const messageID = "msg-1";
+  const sessionTitle = "List the Go files in the repo";
   // Leave `system` and `tools` unset. Real OpenCode sessions rarely set these
   // per-request overrides.
   const userMessage = {
@@ -166,6 +167,7 @@ function opencodeMessageFixture() {
   ];
   return {
     sessionID,
+    sessionTitle,
     userMessage,
     userParts,
     assistantMessage,
@@ -228,6 +230,7 @@ describe("opencode plugin: real-SDK golden export", () => {
   ) {
     const {
       sessionID,
+      sessionTitle,
       userMessage,
       userParts,
       assistantMessage,
@@ -262,6 +265,13 @@ describe("opencode plugin: real-SDK golden export", () => {
     const hooks = await createAgento11yHooks(config, fakeClient);
     if (!hooks)
       throw new Error("expected createAgento11yHooks to return hooks");
+
+    await hooks.event({
+      event: {
+        type: "session.created",
+        properties: { info: { id: sessionID, title: sessionTitle } },
+      },
+    });
 
     // Store the user message, capture the composed system prompt, then
     // export when the assistant message completes.
@@ -319,7 +329,7 @@ describe("opencode plugin: real-SDK golden export", () => {
     const turn = allGen.find((g) => g.conversation_id === sessionID);
     expect(turn, "expected a generation for the session").toBeDefined();
 
-    return { exports, sessionID, turn, messageFetches };
+    return { exports, sessionID, sessionTitle, turn, messageFetches };
   }
 
   function expectCommonTurnFields(turn: any): void {
@@ -331,10 +341,14 @@ describe("opencode plugin: real-SDK golden export", () => {
   }
 
   it("matches the recorded golden for a complete assistant turn", async () => {
-    const { exports, turn, messageFetches } = await runCompleteAssistantTurn();
+    const { exports, sessionTitle, turn, messageFetches } =
+      await runCompleteAssistantTurn();
 
     // Invariant assertions on top of the golden diff.
     expectCommonTurnFields(turn);
+    // The proto Generation has no conversation_title field; the SDK carries
+    // the title in metadata (spanAttrConversationTitle in js/src/client.ts).
+    expect(turn.metadata["agento11y.conversation.title"]).toBe(sessionTitle);
     expect(messageFetches).toBe(1);
 
     assertGoldenJSON(GOLDEN_PATH, exports);
@@ -346,11 +360,17 @@ describe("opencode plugin: real-SDK golden export", () => {
     "metadata_only",
     "full_with_metadata_spans",
   ] as const)("propagates content capture mode %s to the SDK export", async (contentCapture) => {
-    const { turn, messageFetches } = await runCompleteAssistantTurn({
-      contentCapture,
-    });
+    const { sessionTitle, turn, messageFetches } =
+      await runCompleteAssistantTurn({
+        contentCapture,
+      });
 
     expectCommonTurnFields(turn);
+    if (contentCapture === "metadata_only") {
+      expect(turn.metadata["agento11y.conversation.title"]).toBeUndefined();
+    } else {
+      expect(turn.metadata["agento11y.conversation.title"]).toBe(sessionTitle);
+    }
     expect(turn.metadata["agento11y.sdk.content_capture_mode"]).toBe(
       contentCapture,
     );

--- a/plugins/opencode/src/hooks.capture.test.ts
+++ b/plugins/opencode/src/hooks.capture.test.ts
@@ -1,5 +1,5 @@
 // Tests system prompt capture via `experimental.chat.system.transform`,
-// name-only tool definitions, and host version capture.
+// name-only tool definitions, host version capture, and session title capture.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -17,12 +17,14 @@ vi.mock("./telemetry.js", () => ({
   createTelemetryProviders: createTelemetryProvidersMock,
 }));
 
+import type { Agento11yOpencodeConfig } from "./config.js";
 import { _resetHookState, createAgento11yHooks } from "./hooks.js";
 import {
   assistantMessage,
   baseConfig,
   emitMessageUpdated,
   emitSessionDeleted,
+  emitSessionEvent,
   makeAgento11yMock,
   makeOpencodeClient,
   type TestHooks,
@@ -329,22 +331,15 @@ describe("opencode host version", () => {
     _resetHookState();
   });
 
-  async function emitSessionCreatedWithVersion(
-    hooks: TestHooks,
-    id: string,
-    version: string,
-  ) {
-    await hooks.event({
-      event: { type: "session.created", properties: { info: { id, version } } },
-    });
-  }
-
   it("uses the OpenCode version as agent and effective version", async () => {
     const { sigil, generations } = makeAgento11yMock();
     createAgento11yClientMock.mockReturnValue(sigil);
     const hooks = await makeHooks(baseConfig({ agentVersion: undefined }));
 
-    await emitSessionCreatedWithVersion(hooks, "sess-1", "1.17.20");
+    await emitSessionEvent(hooks, "session.created", {
+      id: "sess-1",
+      version: "1.17.20",
+    });
     await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
 
     expect(generations).toHaveLength(1);
@@ -357,11 +352,9 @@ describe("opencode host version", () => {
     createAgento11yClientMock.mockReturnValue(sigil);
     const hooks = await makeHooks(baseConfig({ agentVersion: undefined }));
 
-    await hooks.event({
-      event: {
-        type: "session.updated",
-        properties: { info: { id: "sess-1", version: "1.18.0" } },
-      },
+    await emitSessionEvent(hooks, "session.updated", {
+      id: "sess-1",
+      version: "1.18.0",
     });
     await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
 
@@ -374,7 +367,10 @@ describe("opencode host version", () => {
     createAgento11yClientMock.mockReturnValue(sigil);
     const hooks = await makeHooks(baseConfig({ agentVersion: "my-agent-2" }));
 
-    await emitSessionCreatedWithVersion(hooks, "sess-1", "1.17.20");
+    await emitSessionEvent(hooks, "session.created", {
+      id: "sess-1",
+      version: "1.17.20",
+    });
     await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
 
     expect(generations).toHaveLength(1);
@@ -391,5 +387,221 @@ describe("opencode host version", () => {
 
     expect(generations).toHaveLength(1);
     expect(generations[0]!.seed.agentVersion).toBeUndefined();
+  });
+});
+
+describe("opencode conversation title", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetHookState();
+  });
+
+  const title = "Fix flaky auth test";
+  // opencode's own creation defaults, replaced only once its small model
+  // produces a real title.
+  const newPlaceholder = "New session - 2026-01-12T13:07:53.510Z";
+  const childPlaceholder = "Child session - 2026-01-12T13:07:53.510Z";
+
+  function emitTitle(
+    hooks: TestHooks,
+    type: "session.created" | "session.updated",
+    sessionTitle: string | undefined,
+    id = "sess-1",
+  ): Promise<void> {
+    return emitSessionEvent(hooks, type, { id, title: sessionTitle });
+  }
+
+  const cases: {
+    name: string;
+    config?: Agento11yOpencodeConfig;
+    run: (hooks: TestHooks) => Promise<void>;
+    // Expected seed.conversationTitle per exported generation, in order.
+    want: (string | undefined)[];
+  }[] = [
+    {
+      name: "uses the title from session.created",
+      run: async (hooks) => {
+        await emitTitle(hooks, "session.created", title);
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+      },
+      want: [title],
+    },
+    {
+      name: "keeps the title for later turns in the same session",
+      run: async (hooks) => {
+        await emitTitle(hooks, "session.created", title);
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-2"));
+      },
+      want: [title, title],
+    },
+    {
+      name: "replaces the stored title on a later session.updated",
+      run: async (hooks) => {
+        await emitTitle(hooks, "session.created", "Investigate auth failure");
+        await emitTitle(hooks, "session.updated", title);
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+      },
+      want: [title],
+    },
+    {
+      name: "keeps the previous title when an update is blank",
+      run: async (hooks) => {
+        await emitTitle(hooks, "session.created", title);
+        await emitTitle(hooks, "session.updated", "");
+        await emitTitle(hooks, "session.updated", "   ");
+        await emitTitle(hooks, "session.updated", undefined);
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+      },
+      want: [title],
+    },
+    {
+      name: "ignores an empty title",
+      run: async (hooks) => {
+        await emitTitle(hooks, "session.created", "");
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+      },
+      want: [undefined],
+    },
+    {
+      name: "ignores the placeholder opencode sets at session creation",
+      run: async (hooks) => {
+        await emitTitle(hooks, "session.created", newPlaceholder);
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+        await emitTitle(hooks, "session.updated", title);
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-2"));
+      },
+      want: [undefined, title],
+    },
+    {
+      name: "ignores the placeholder opencode sets on a subagent session",
+      run: async (hooks) => {
+        await emitTitle(hooks, "session.created", childPlaceholder);
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+      },
+      want: [undefined],
+    },
+    {
+      name: "keeps a real title when a placeholder update arrives",
+      run: async (hooks) => {
+        await emitTitle(hooks, "session.created", title);
+        await emitTitle(hooks, "session.updated", newPlaceholder);
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+      },
+      want: [title],
+    },
+    {
+      name: "keeps a title that only looks like a placeholder",
+      run: async (hooks) => {
+        await emitTitle(
+          hooks,
+          "session.created",
+          "New session - what changed?",
+        );
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+      },
+      want: ["New session - what changed?"],
+    },
+    {
+      name: "applies a late title prospectively, leaving the first turn untitled",
+      run: async (hooks) => {
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+        await emitTitle(hooks, "session.updated", title);
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-2"));
+      },
+      want: [undefined, title],
+    },
+    {
+      name: "keeps titles of concurrent sessions separate",
+      run: async (hooks) => {
+        await emitTitle(hooks, "session.created", "title one", "sess-1");
+        await emitTitle(hooks, "session.created", "title two", "sess-2");
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+        await emitMessageUpdated(hooks, assistantMessage("sess-2", "msg-1"));
+      },
+      want: ["title one", "title two"],
+    },
+    {
+      name: "clears the title when the session is deleted",
+      run: async (hooks) => {
+        await emitTitle(hooks, "session.created", title);
+        await emitSessionDeleted(hooks, "sess-1");
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+      },
+      want: [undefined],
+    },
+    {
+      name: "clears the title on hook state reset",
+      run: async (hooks) => {
+        await emitTitle(hooks, "session.created", title);
+        _resetHookState();
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+      },
+      want: [undefined],
+    },
+    {
+      name: "still sets the title in metadata_only",
+      config: baseConfig({ contentCapture: "metadata_only" }),
+      run: async (hooks) => {
+        await emitTitle(hooks, "session.created", title);
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+      },
+      want: [title],
+    },
+    {
+      name: "redacts a secret the titling model copied from the prompt",
+      run: async (hooks) => {
+        await emitTitle(
+          hooks,
+          "session.created",
+          "Rotate glc_abcdefghijklmnopqrstuvwxyz1234",
+        );
+        await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+      },
+      want: ["Rotate [REDACTED:grafana-cloud-token]"],
+    },
+  ];
+
+  it.each(cases)("$name", async ({ config, run, want }) => {
+    const { sigil, generations } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks(config);
+
+    await run(hooks);
+
+    expect(generations.map((g) => g.seed.conversationTitle)).toEqual(want);
+  });
+
+  it("omits the field instead of sending an empty title", async () => {
+    const { sigil, generations } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks();
+
+    await emitTitle(hooks, "session.created", newPlaceholder);
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect("conversationTitle" in generations[0]!.seed).toBe(false);
+  });
+
+  it("carries the title on the tool spans nested under the turn", async () => {
+    const { sigil } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks();
+
+    await emitTitle(hooks, "session.created", title);
+    await hooks.toolExecuteBefore(
+      { tool: "bash", sessionID: "sess-1", callID: "tc-1" },
+      { args: {} },
+    );
+    hooks.toolExecuteAfter(
+      { tool: "bash", sessionID: "sess-1", callID: "tc-1", args: {} },
+      { title: "bash", output: "ok", metadata: {} },
+    );
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(sigil.startToolExecution).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationTitle: title }),
+    );
   });
 });

--- a/plugins/opencode/src/hooks.testutil.ts
+++ b/plugins/opencode/src/hooks.testutil.ts
@@ -139,12 +139,21 @@ export async function emitSessionDeleted(
   await emitEvent(hooks, "session.deleted", { info: { id: sessionID } });
 }
 
+/** Emit a session lifecycle event carrying an arbitrary `Session` subset. */
+export async function emitSessionEvent(
+  hooks: TestHooks,
+  type: "session.created" | "session.updated",
+  info: Record<string, unknown>,
+): Promise<void> {
+  await emitEvent(hooks, type, { info });
+}
+
 export async function emitSessionCreated(
   hooks: TestHooks,
   id: string,
   parentID?: string,
 ): Promise<void> {
-  await emitEvent(hooks, "session.created", { info: { id, parentID } });
+  await emitSessionEvent(hooks, "session.created", { id, parentID });
 }
 
 /** Dispatches opencode's instance-teardown event. */

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -111,6 +111,22 @@ const latestSystemPromptBySession = new Map<string, string>();
 // Used as the default agent and effective version, matching claude-code.
 let hostVersion: string | undefined;
 
+// Latest real `Session.title` per session, from the same
+// `session.created`/`session.updated` events that carry the host version.
+// Latest wins: opencode generates the title asynchronously with its small
+// model (so it usually arrives after the first turn has been exported) and a
+// user can rename a session at any time. Blank and placeholder titles are
+// never stored, so they cannot clear a real one.
+const latestSessionTitleBySession = new Map<string, string>();
+
+// At session creation opencode seeds a placeholder rather than an empty title:
+// `New session - <ISO>`, or `Child session - <ISO>` for subagents. The ISO
+// string is the session's creation time, so sending a placeholder is worse than
+// sending nothing: unique per session, and no use as a conversation name. Same
+// regex opencode uses on its own placeholders.
+const placeholderSessionTitle =
+  /^(New session - |Child session - )\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
 type SessionContext = {
   agent: string | undefined;
   model: { provider: string; name: string } | undefined;
@@ -172,6 +188,7 @@ export function _resetHookState(): void {
   firstPartAtByMessage.clear();
   pendingGenerations.clear();
   latestSystemPromptBySession.clear();
+  latestSessionTitleBySession.clear();
   hostVersion = undefined;
   sessionContexts.clear();
   _resetToolExecutionState();
@@ -275,6 +292,7 @@ async function handleEvent(
 ): Promise<void> {
   if (event.type === "session.created" || event.type === "session.updated") {
     recordHostVersion(event.properties);
+    recordSessionTitle(event.properties, redactor);
     if (event.type === "session.created") {
       recordSessionParent(event.properties);
     }
@@ -512,6 +530,13 @@ async function recordAssistantMessage(
     gitBranch: resolveGitBranch(projectDir),
     isSubagent: subagentSessions.has(assistantMsg.sessionID),
   });
+  // Sent regardless of content capture mode: the title is host-provided
+  // session metadata that opencode shows in its own UI, and the SDK drops it
+  // from a `metadata_only` export itself. Already redacted by
+  // `recordSessionTitle`.
+  const conversationTitle = latestSessionTitleBySession.get(
+    assistantMsg.sessionID,
+  );
   const seed = {
     id: genId,
     conversationId: assistantMsg.sessionID,
@@ -521,6 +546,7 @@ async function recordAssistantMessage(
     model: { provider: assistantMsg.providerID, name: assistantMsg.modelID },
     startedAt: new Date(assistantMsg.time.created),
     contentCapture: config.contentCapture,
+    ...(conversationTitle && { conversationTitle }),
     ...(parent && { parentGenerationIds: [parent] }),
     ...(tools.length > 0 && { tools }),
     ...(includeMessageBodies && { systemPrompt }),
@@ -537,6 +563,7 @@ async function recordAssistantMessage(
 
   const spanOpts = {
     conversationId: assistantMsg.sessionID,
+    conversationTitle,
     agentName: buildAgentName(config.agentName, assistantMsg.mode),
     agentVersion,
     requestProvider: assistantMsg.providerID,
@@ -599,6 +626,21 @@ function recordHostVersion(properties: unknown): void {
   const info = recordField(properties, "info");
   const version = stringField(info, "version");
   if (version) hostVersion = version;
+}
+
+/**
+ * Remember the latest real `Session.title` from a session event, redacted here so
+ * the map only holds exportable text. `plugins/opencode/src/client.ts` installs no
+ * SDK `generationSanitizer` the way pi does, so this is the title's only
+ * redaction, and opencode's small model writes it from the user's prompt, which
+ * may contain a pasted token.
+ */
+function recordSessionTitle(properties: unknown, redactor: Redactor): void {
+  const info = recordField(properties, "info");
+  const id = stringField(info, "id");
+  const title = stringField(info, "title")?.trim();
+  if (!id || !title || placeholderSessionTitle.test(title)) return;
+  latestSessionTitleBySession.set(id, redactor.redactLightweight(title));
 }
 
 /**
@@ -681,6 +723,7 @@ async function handleLifecycle(
       subagentSessions.delete(sessionId);
       pendingGenerations.delete(sessionId);
       latestSystemPromptBySession.delete(sessionId);
+      latestSessionTitleBySession.delete(sessionId);
       sessionContexts.delete(sessionId);
       completedToolExecutions.delete(sessionId);
       for (const key of activeToolExecutions.keys()) {
@@ -1001,6 +1044,7 @@ export function emitToolSpans(
   records: ToolExecutionRecord[],
   opts: {
     conversationId: string;
+    conversationTitle?: string;
     agentName: string;
     agentVersion?: string;
     requestProvider: string;
@@ -1020,6 +1064,7 @@ export function emitToolSpans(
         toolCallId: record.toolCallId,
         toolType: "function",
         conversationId: opts.conversationId,
+        conversationTitle: opts.conversationTitle,
         agentName: opts.agentName,
         agentVersion: opts.agentVersion,
         requestProvider: opts.requestProvider,

--- a/plugins/opencode/src/testdata/golden/opencode-full-message.golden.json
+++ b/plugins/opencode/src/testdata/golden/opencode-full-message.golden.json
@@ -91,6 +91,7 @@
         },
         "metadata": {
           "cost": 0.005,
+          "agento11y.conversation.title": "List the Go files in the repo",
           "agento11y.sdk.name": "sdk-js",
           "agento11y.sdk.content_capture_mode": "full"
         },


### PR DESCRIPTION
Similar to other coding agent plugins, send session title as conversation title.