### PR TITLE
feat(plugins/agento11y): opt-in Cloud forwarding for local sessions

### DIFF
--- a/plugins/agento11y/internal/doctor/doctor.go
+++ b/plugins/agento11y/internal/doctor/doctor.go
@@ -62,6 +62,7 @@ var trackedSuffixes = []string{
 	"CONTENT_CAPTURE_MODE",
 	"TAGS",
 	"AUTO_UPDATE",
+	"LOCAL_FORWARD",
 }
 
 // trackedKeys is the full key set SnapshotEnv records: both spellings of the
@@ -142,8 +143,15 @@ type ConfigSection struct {
 	GuardsFellBack      bool              `json:"guards_fell_back,omitempty"`
 	Tags                map[string]string `json:"tags,omitempty"`
 	TagsSource          string            `json:"tags_source,omitempty"`
-	Health              Health            `json:"status"`
-	Messages            []string          `json:"messages,omitempty"`
+	// LocalForward is the resolved LOCAL_FORWARD family: whether a `--local`
+	// daemon also forwards what it captures to Cloud, and where the value came
+	// from. The daemon itself resolves config.env ahead of its own environment
+	// (so a viewer edit takes effect without a restart), which is the opposite
+	// of the shell-first precedence reported here; a conflict is called out in
+	// Messages.
+	LocalForward envValue `json:"local_forward"`
+	Health       Health   `json:"status"`
+	Messages     []string `json:"messages,omitempty"`
 }
 
 // ConversationsSection reports the generation-export pipeline.
@@ -489,6 +497,11 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 		}
 	}
 
+	// LOCAL_FORWARD sends a copy of every --local session to Cloud, so make the
+	// effective value and its source visible.
+	forward := resolveFamily("LOCAL_FORWARD", osEnv, fileEnv)
+	sec.LocalForward = forward.envValue()
+
 	if len(sec.DisallowedKeys) > 0 {
 		sec.Health = HealthWarn
 		sec.Messages = append(sec.Messages,
@@ -511,6 +524,10 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 	if tags.legacyWon() {
 		sec.Messages = append(sec.Messages,
 			"tags set via legacy SIGIL_TAGS — this keeps working, but the preferred name is AGENTO11Y_TAGS")
+	}
+	if forward.set && forward.source == sourceEnv && strings.TrimSpace(fileEnv[envconfig.PreferredKey("LOCAL_FORWARD")]+fileEnv[envconfig.LegacyKey("LOCAL_FORWARD")]) != "" {
+		sec.Messages = append(sec.Messages, fmt.Sprintf(
+			"%s is set in the environment and in config.env; the local daemon uses the config.env value", forward.key))
 	}
 	return sec
 }

--- a/plugins/agento11y/internal/doctor/doctor_test.go
+++ b/plugins/agento11y/internal/doctor/doctor_test.go
@@ -633,6 +633,73 @@ func TestCollectConfig_Tags(t *testing.T) {
 	}
 }
 
+// TestCollectConfig_LocalForward covers the LOCAL_FORWARD attribution: doctor
+// reports shell-first like every other family, and calls out the case where the
+// local daemon (which prefers config.env) would use the other value.
+func TestCollectConfig_LocalForward(t *testing.T) {
+	tests := []struct {
+		name       string
+		osEnv      map[string]string
+		fileEnv    map[string]string
+		wantSet    bool
+		wantValue  string
+		wantSource string
+		wantMsg    string
+	}{
+		{name: "unset"},
+		{
+			name:      "from config.env",
+			fileEnv:   map[string]string{"AGENTO11Y_LOCAL_FORWARD": "true"},
+			wantSet:   true,
+			wantValue: "true", wantSource: sourceConfig,
+		},
+		{
+			name:      "from env",
+			osEnv:     map[string]string{"SIGIL_LOCAL_FORWARD": "true"},
+			wantSet:   true,
+			wantValue: "true", wantSource: sourceEnv,
+		},
+		{
+			// The daemon prefers config.env so it forwards nothing, while
+			// doctor's shell-first precedence reports true.
+			name:      "env and config.env disagree",
+			osEnv:     map[string]string{"AGENTO11Y_LOCAL_FORWARD": "true"},
+			fileEnv:   map[string]string{"AGENTO11Y_LOCAL_FORWARD": "false"},
+			wantSet:   true,
+			wantValue: "true", wantSource: sourceEnv,
+			wantMsg: "the local daemon uses the config.env value",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateEnv(t)
+			for k, v := range tc.osEnv {
+				t.Setenv(k, v)
+			}
+			sec := collectConfig(tc.osEnv, tc.fileEnv)
+			if sec.LocalForward.Set != tc.wantSet {
+				t.Fatalf("LocalForward.Set = %v, want %v", sec.LocalForward.Set, tc.wantSet)
+			}
+			if sec.LocalForward.Value != tc.wantValue {
+				t.Fatalf("LocalForward.Value = %q, want %q", sec.LocalForward.Value, tc.wantValue)
+			}
+			if sec.LocalForward.Source != tc.wantSource {
+				t.Fatalf("LocalForward.Source = %q, want %q", sec.LocalForward.Source, tc.wantSource)
+			}
+			joined := strings.Join(sec.Messages, " ")
+			if tc.wantMsg == "" {
+				if strings.Contains(joined, "LOCAL_FORWARD") {
+					t.Fatalf("unexpected LOCAL_FORWARD message: %v", sec.Messages)
+				}
+				return
+			}
+			if !strings.Contains(joined, tc.wantMsg) {
+				t.Fatalf("messages %v missing %q", sec.Messages, tc.wantMsg)
+			}
+		})
+	}
+}
+
 func TestRun(t *testing.T) {
 	convOnly := map[string]string{
 		"SIGIL_ENDPOINT":       "https://sigil.example.net",

--- a/plugins/agento11y/internal/doctor/render.go
+++ b/plugins/agento11y/internal/doctor/render.go
@@ -127,6 +127,9 @@ func renderHuman(w io.Writer, r *Report, color, probed bool) {
 	if len(r.Config.Tags) > 0 {
 		writeKV(&b, p, "tags", fmt.Sprintf("%s %s", formatTags(r.Config.Tags), p.faint("("+r.Config.TagsSource+")")))
 	}
+	if r.Config.LocalForward.Set {
+		writeKV(&b, p, "local forwarding", describeEnv(r.Config.LocalForward))
+	}
 	writeMessages(&b, p, r.Config.Messages)
 	b.WriteString("\n")
 

--- a/plugins/agento11y/internal/dotenv/dotenv.go
+++ b/plugins/agento11y/internal/dotenv/dotenv.go
@@ -105,24 +105,37 @@ func ApplyEnv(logger *log.Logger) map[string]string {
 	return fileEnv
 }
 
-// LoadDotenv parses the file at path. Missing files return an empty map
-// silently; other errors are logged. Only keys matching AllowedDotenvKey
-// are honoured — defense-in-depth so a stray entry can't override unrelated
-// process state.
+// LoadDotenv parses the file at path, ignoring read errors: a missing,
+// unopenable, or partly unreadable file yields whatever could be parsed (often
+// nothing). Callers that must distinguish "no file" from "could not read the
+// file" want ReadDotenv instead.
+func LoadDotenv(path string, logger *log.Logger) map[string]string {
+	out, _ := ReadDotenv(path, logger)
+	return out
+}
+
+// ReadDotenv parses the file at path and reports read failures. A missing file
+// returns an empty map and a nil error; an open or scan failure returns the
+// pairs parsed so far and the error (also logged). Only keys matching
+// AllowedDotenvKey are honoured — defense-in-depth so a stray entry can't
+// override unrelated process state.
 //
 // Format:
 //   - `KEY=value` one pair per line
 //   - `# comment` lines and trailing ` # comment` on unquoted values
 //   - optional single- or double-quoted values
 //   - optional leading `export ` prefix
-func LoadDotenv(path string, logger *log.Logger) map[string]string {
+func ReadDotenv(path string, logger *log.Logger) (map[string]string, error) {
 	out := map[string]string{}
 	f, err := os.Open(path)
 	if err != nil {
-		if !os.IsNotExist(err) && logger != nil {
+		if os.IsNotExist(err) {
+			return out, nil
+		}
+		if logger != nil {
 			logger.Printf("dotenv: read %s: %v", path, err)
 		}
-		return out
+		return out, err
 	}
 	defer func() { _ = f.Close() }()
 
@@ -145,10 +158,13 @@ func LoadDotenv(path string, logger *log.Logger) map[string]string {
 			out[key] = value
 		}
 	}
-	if err := scanner.Err(); err != nil && logger != nil {
-		logger.Printf("dotenv: scan %s: %v", path, err)
+	if err := scanner.Err(); err != nil {
+		if logger != nil {
+			logger.Printf("dotenv: scan %s: %v", path, err)
+		}
+		return out, err
 	}
-	return out
+	return out, nil
 }
 
 // AllowedDotenvKey limits which keys the dotenv loader will copy into the

--- a/plugins/agento11y/internal/dotenv/dotenv_test.go
+++ b/plugins/agento11y/internal/dotenv/dotenv_test.go
@@ -98,13 +98,59 @@ SIGIL_UNTERMINATED="oops
 
 func TestLoadDotenvMissingFileSilent(t *testing.T) {
 	var buf bytes.Buffer
-	got := LoadDotenv("/nonexistent/path/config.env", log.New(&buf, "", 0))
+	got, err := ReadDotenv("/nonexistent/path/config.env", log.New(&buf, "", 0))
+	if err != nil {
+		t.Errorf("missing file should not error, got %v", err)
+	}
 	if len(got) != 0 {
 		t.Errorf("expected empty map, got %v", got)
 	}
 	if buf.Len() != 0 {
 		t.Errorf("missing file should not log; got %q", buf.String())
 	}
+}
+
+// TestReadDotenvReportsReadFailures covers what LoadDotenv cannot express:
+// callers that must fail closed need to tell "no file" apart from "the file is
+// there but unreadable".
+func TestReadDotenvReportsReadFailures(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("open fails", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root ignores file permissions")
+		}
+		path := filepath.Join(dir, "unreadable.env")
+		if err := os.WriteFile(path, []byte("AGENTO11Y_LOCAL_FORWARD=false\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(path, 0o000); err != nil {
+			t.Fatal(err)
+		}
+
+		var buf bytes.Buffer
+		got, err := ReadDotenv(path, log.New(&buf, "", 0))
+		if err == nil {
+			t.Fatalf("expected an error, got map %v", got)
+		}
+		if buf.Len() == 0 {
+			t.Error("an unreadable file should log")
+		}
+		if len(LoadDotenv(path, nil)) != 0 {
+			t.Error("LoadDotenv should still swallow the error and return no pairs")
+		}
+	})
+
+	t.Run("read fails", func(t *testing.T) {
+		// A directory opens fine and fails on the first read.
+		path := filepath.Join(dir, "config.env.d")
+		if err := os.Mkdir(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := ReadDotenv(path, nil); err == nil {
+			t.Error("expected a scan error for a directory")
+		}
+	})
 }
 
 func TestApplyEnv(t *testing.T) {

--- a/plugins/agento11y/internal/envconfig/envconfig.go
+++ b/plugins/agento11y/internal/envconfig/envconfig.go
@@ -46,6 +46,7 @@ var AliasSuffixes = []string{
 	"USER_ID_SOURCE",
 	"BIN",
 	"COPILOT_HOOK_SURFACE",
+	"LOCAL_FORWARD", // opt a --local daemon into forwarding to Cloud
 }
 
 // LookupEnv resolves a branded variable from the process env: the first
@@ -55,6 +56,19 @@ var AliasSuffixes = []string{
 func LookupEnv(suffix string) (value, key string, ok bool) {
 	for _, k := range []string{PreferredKey(suffix), LegacyKey(suffix)} {
 		if v := strings.TrimSpace(os.Getenv(k)); v != "" {
+			return v, k, true
+		}
+	}
+	return "", "", false
+}
+
+// LookupMap resolves a branded variable from a config map (as returned by
+// dotenv.LoadDotenv) with the same preferred-first precedence LookupEnv
+// applies to the process environment. The returned key names the spelling the
+// value came from.
+func LookupMap(env map[string]string, suffix string) (value, key string, ok bool) {
+	for _, k := range []string{PreferredKey(suffix), LegacyKey(suffix)} {
+		if v := strings.TrimSpace(env[k]); v != "" {
 			return v, k, true
 		}
 	}
@@ -168,6 +182,12 @@ func IsLocalEndpoint(endpoint string) bool {
 	}
 }
 
+// LocalAuthPlaceholder is the stand-in credential used for local endpoints,
+// which do not validate auth. Consumers that must distinguish a placeholder
+// from a real credential (the local daemon's Cloud forwarder refuses to ship
+// to a Cloud tenant with it) compare against this constant.
+const LocalAuthPlaceholder = "local"
+
 // LocalAuthPlaceholders returns non-empty stand-in auth values for local
 // endpoints. The local server does not validate auth, but hook/export code
 // still expects these variables to be populated before it proceeds.
@@ -176,10 +196,10 @@ func LocalAuthPlaceholders(endpoint, tenantID, authToken string) (string, string
 		return tenantID, authToken
 	}
 	if strings.TrimSpace(tenantID) == "" {
-		tenantID = "local"
+		tenantID = LocalAuthPlaceholder
 	}
 	if strings.TrimSpace(authToken) == "" {
-		authToken = "local"
+		authToken = LocalAuthPlaceholder
 	}
 	return tenantID, authToken
 }
@@ -251,13 +271,25 @@ func ParseExtraTags(s string) map[string]string {
 // write to stderr, so callers pass their adapter logger here — the helper
 // never touches stderr itself.
 func ResolveContentMode(logger *log.Logger) agento11y.ContentCaptureMode {
-	v, key, ok := LookupEnv("CONTENT_CAPTURE_MODE")
-	if !ok {
+	v, key, _ := LookupEnv("CONTENT_CAPTURE_MODE")
+	return ResolveContentModeValue(logger, key, v)
+}
+
+// ResolveContentModeValue resolves a ContentCaptureMode from an explicit raw
+// value, applying the same empty/unknown -> metadata_only fall-back as
+// ResolveContentMode. key names the spelling raw came from and is used only in
+// the diagnostic message; an empty key falls back to the preferred spelling.
+func ResolveContentModeValue(logger *log.Logger, key, raw string) agento11y.ContentCaptureMode {
+	v := strings.TrimSpace(raw)
+	if v == "" {
 		return agento11y.ContentCaptureModeMetadataOnly
 	}
 	var mode agento11y.ContentCaptureMode
 	if err := mode.UnmarshalText([]byte(v)); err != nil {
 		if logger != nil {
+			if key == "" {
+				key = PreferredKey("CONTENT_CAPTURE_MODE")
+			}
 			logger.Printf("config: unknown %s=%q; using metadata_only", key, v)
 		}
 		return agento11y.ContentCaptureModeMetadataOnly
@@ -318,6 +350,18 @@ func ResolveGuards(logger *log.Logger) GuardsConfig {
 func resolveGuardsBool(logger *log.Logger, suffix string, def bool) bool {
 	raw, key, ok := LookupEnv(suffix)
 	if !ok {
+		return def
+	}
+	return BoolValue(logger, key, raw, def)
+}
+
+// BoolValue parses a config boolean from raw using the guards whitelist
+// (1/true/yes/on => true, 0/false/no/off => false). Empty returns def; an
+// unrecognised value is reported via logger (when non-nil) and returns def.
+// key is used only in the diagnostic message.
+func BoolValue(logger *log.Logger, key, raw string, def bool) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
 		return def
 	}
 	switch strings.ToLower(raw) {

--- a/plugins/agento11y/internal/envconfig/envconfig_test.go
+++ b/plugins/agento11y/internal/envconfig/envconfig_test.go
@@ -5,8 +5,11 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/grafana/agento11y/go/agento11y"
 )
 
 func TestParseBool(t *testing.T) {
@@ -228,6 +231,12 @@ func TestLookupEnv(t *testing.T) {
 			if value != tc.wantValue || key != tc.wantKey || ok != tc.wantOK {
 				t.Errorf("LookupEnv() = (%q, %q, %v), want (%q, %q, %v)", value, key, ok, tc.wantValue, tc.wantKey, tc.wantOK)
 			}
+			// LookupMap applies the same precedence to a config map, which is
+			// what the settings page and the local forwarder read.
+			mapValue, mapKey, mapOK := LookupMap(tc.env, "ENDPOINT")
+			if mapValue != tc.wantValue || mapKey != tc.wantKey || mapOK != tc.wantOK {
+				t.Errorf("LookupMap() = (%q, %q, %v), want (%q, %q, %v)", mapValue, mapKey, mapOK, tc.wantValue, tc.wantKey, tc.wantOK)
+			}
 		})
 	}
 }
@@ -243,6 +252,98 @@ func TestSetBothEnv(t *testing.T) {
 		if got := os.Getenv(key); got != "https://x" {
 			t.Errorf("%s = %q, want https://x", key, got)
 		}
+	}
+}
+
+func TestBoolValue(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		def     bool
+		want    bool
+		wantLog string
+	}{
+		{name: "empty_uses_default_true", raw: "", def: true, want: true},
+		{name: "empty_uses_default_false", raw: "", def: false, want: false},
+		{name: "whitespace_uses_default", raw: "   ", def: true, want: true},
+		{name: "true", raw: "true", want: true},
+		{name: "mixed_case_on", raw: "On", want: true},
+		{name: "one", raw: "1", want: true},
+		{name: "yes", raw: "yes", want: true},
+		{name: "padded_true", raw: "  true ", want: true},
+		{name: "false_overrides_default", raw: "false", def: true, want: false},
+		{name: "off_overrides_default", raw: "off", def: true, want: false},
+		{name: "zero_overrides_default", raw: "0", def: true, want: false},
+		{name: "typo_logs_and_uses_default", raw: "ture", def: true, want: true, wantLog: `invalid AGENTO11Y_LOCAL_FORWARD="ture"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := log.New(&buf, "", 0)
+			if got := BoolValue(logger, PreferredKey("LOCAL_FORWARD"), tc.raw, tc.def); got != tc.want {
+				t.Errorf("BoolValue(%q, def=%v) = %v, want %v", tc.raw, tc.def, got, tc.want)
+			}
+			if tc.wantLog != "" && !strings.Contains(buf.String(), tc.wantLog) {
+				t.Errorf("log output = %q, want substring %q", buf.String(), tc.wantLog)
+			}
+			if tc.wantLog == "" && buf.Len() != 0 {
+				t.Errorf("unexpected log output: %q", buf.String())
+			}
+		})
+	}
+}
+
+func TestResolveContentModeValue(t *testing.T) {
+	cases := []struct {
+		name    string
+		key     string
+		raw     string
+		want    agento11y.ContentCaptureMode
+		wantLog string
+	}{
+		{name: "empty_is_metadata_only", raw: "", want: agento11y.ContentCaptureModeMetadataOnly},
+		{name: "whitespace_is_metadata_only", raw: "  ", want: agento11y.ContentCaptureModeMetadataOnly},
+		{name: "full", raw: "full", want: agento11y.ContentCaptureModeFull},
+		{name: "padded_full", raw: " full ", want: agento11y.ContentCaptureModeFull},
+		{name: "no_tool_content", raw: "no_tool_content", want: agento11y.ContentCaptureModeNoToolContent},
+		{name: "explicit_default_is_metadata_only", raw: "default", want: agento11y.ContentCaptureModeMetadataOnly},
+		{
+			name:    "unknown_logs_reported_key",
+			key:     LegacyKey("CONTENT_CAPTURE_MODE"),
+			raw:     "fully",
+			want:    agento11y.ContentCaptureModeMetadataOnly,
+			wantLog: `unknown SIGIL_CONTENT_CAPTURE_MODE="fully"`,
+		},
+		{
+			name:    "unknown_without_key_names_preferred",
+			raw:     "fully",
+			want:    agento11y.ContentCaptureModeMetadataOnly,
+			wantLog: `unknown AGENTO11Y_CONTENT_CAPTURE_MODE="fully"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := log.New(&buf, "", 0)
+			if got := ResolveContentModeValue(logger, tc.key, tc.raw); got != tc.want {
+				t.Errorf("ResolveContentModeValue(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+			if tc.wantLog != "" && !strings.Contains(buf.String(), tc.wantLog) {
+				t.Errorf("log output = %q, want substring %q", buf.String(), tc.wantLog)
+			}
+			if tc.wantLog == "" && buf.Len() != 0 {
+				t.Errorf("unexpected log output: %q", buf.String())
+			}
+		})
+	}
+}
+
+// TestAliasSuffixesCoversLocalForward pins LOCAL_FORWARD into the alias
+// families so PinAliasEnvBlank clears it in tests and ExpandAliases mirrors it
+// on write.
+func TestAliasSuffixesCoversLocalForward(t *testing.T) {
+	if !slices.Contains(AliasSuffixes, "LOCAL_FORWARD") {
+		t.Fatal("AliasSuffixes must contain LOCAL_FORWARD")
 	}
 }
 

--- a/plugins/agento11y/internal/local/env.go
+++ b/plugins/agento11y/internal/local/env.go
@@ -83,8 +83,8 @@ func (e LaunchEnv) Apply(env []string) []string {
 	}
 	for _, suffix := range defaultFamilies {
 		if !keptFamilies[suffix] {
-			out = append(out, envconfig.PreferredKey(suffix)+"=local")
-			out = append(out, envconfig.LegacyKey(suffix)+"=local")
+			out = append(out, envconfig.PreferredKey(suffix)+"="+envconfig.LocalAuthPlaceholder)
+			out = append(out, envconfig.LegacyKey(suffix)+"="+envconfig.LocalAuthPlaceholder)
 		}
 	}
 	return out

--- a/plugins/agento11y/internal/local/forward.go
+++ b/plugins/agento11y/internal/local/forward.go
@@ -1,0 +1,912 @@
+package local
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/grafana/agento11y/go/agento11y"
+	"github.com/grafana/agento11y/go/agento11y/model"
+	agento11yv1 "github.com/grafana/agento11y/go/proto/agento11y/v1"
+	"github.com/grafana/agento11y/go/proto/agento11y/wire"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/dotenv"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/otel"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// maxInFlightForwards bounds the number of concurrent best-effort Cloud
+// forwards. Local capture never blocks on forwarding, so excess payloads are
+// dropped (and recorded) rather than queued.
+const maxInFlightForwards = 8
+
+// maxRecordedForwardFailures caps the failure ring the loader keeps for
+// forwardStatus. The daemon's logger writes to io.Discard unless debug logging
+// is on, so the status endpoint is the only channel a runtime failure (rotated
+// token, unreachable Cloud) can reach the user through.
+const maxRecordedForwardFailures = 5
+
+// forwardLabelGenerations names the generation-export leg in the failure ring.
+// The two legs are recorded and cleared independently, so the label a queued
+// payload is dropped under must match the one its POST reports.
+const forwardLabelGenerations = "generations"
+
+// otlpForwardLabel names one OTLP signal leg in the failure ring.
+func otlpForwardLabel(signal string) string { return "otlp/" + signal }
+
+// forwardMarkerHeader is set on every forwarded request. A daemon that
+// receives a payload carrying it does not forward again, so two daemons
+// pointed at each other (or one pointed at itself through a hand-written
+// local ingest endpoint) exchange one copy instead of looping.
+const forwardMarkerHeader = "X-Agento11y-Local-Forwarded"
+
+// strippedCallError replaces a generation's raw CallError when forwarding a
+// reduced copy. The SDK's stripContent uses a classified error category here;
+// the daemon does not classify, so it mirrors stripContent's no-category
+// fall-back.
+const strippedCallError = "sdk_error"
+
+// metadataKeyCallError mirrors the metadata key the SDK uses to surface the
+// raw call error. Stripping deletes it and replaces CallError itself.
+const metadataKeyCallError = "call_error"
+
+// legacyConversationTitleKey is the pre-rename spelling of
+// metadataKeyConversationTitle (see wire.go). An older installed plugin
+// (@grafana/agento11y-pi, -opencode, or a sigil-era SDK) can export to a
+// freshly updated daemon, so the strip path drops both.
+const legacyConversationTitleKey = "sigil.conversation.title"
+
+// exceptionEventName is the span event RecordError emits. Its
+// exception.message/exception.stacktrace attributes can carry raw content, so
+// the daemon drops these events when forwarding a reduced content mode.
+const exceptionEventName = "exception"
+
+// spanAttrErrorCategory is the classified error category the SDK sets
+// alongside an error status (go/agento11y/client.go). It carries no content,
+// so the reduced trace forward reuses it as the replacement status message.
+const spanAttrErrorCategory = "error.category"
+
+// traceContentAttributes are the span attribute keys that carry user content.
+// Under a reduced forward mode the daemon deletes these before relaying spans
+// to Cloud. The set mirrors the content-bearing span attribute constants in
+// go/agento11y/client.go: tool call arguments/results, tool descriptions, the
+// conversation title (the same string as the metadata key), and embedding input
+// texts. Generation prompt/response text never reaches spans (it travels via
+// the proto generation export).
+var traceContentAttributes = map[string]struct{}{
+	"gen_ai.tool.call.arguments":    {},
+	"gen_ai.tool.call.result":       {},
+	"gen_ai.tool.description":       {},
+	metadataKeyConversationTitle:    {},
+	legacyConversationTitleKey:      {},
+	"gen_ai.embeddings.input_texts": {},
+}
+
+// forwardConfig is the resolved forwarding configuration for one load cycle.
+// The two legs resolve independently: generation export needs Cloud
+// credentials, while the OTLP relay needs an OTLP endpoint and authenticates
+// the way the real exporter does. Either can be live while the other is
+// refused, and the matching reason field says why.
+type forwardConfig struct {
+	// enabled reports whether any leg would forward.
+	enabled bool
+	// strip reports whether the forwarded copy must be reduced to
+	// metadata_only. Full content is forwarded only when the resolved
+	// CONTENT_CAPTURE_MODE is exactly "full"; every other mode forwards the
+	// reduced copy so opting into Cloud forwarding never widens what leaves
+	// the host beyond what the user configured.
+	strip bool
+
+	genURL     string            // normalized /api/v1/generations:export URL ("" = not forwarded)
+	genHeaders map[string]string // Basic auth + tenant header
+	genReason  string            // why generations are not forwarded
+
+	otlpEndpoint string            // base OTLP endpoint ("" = not forwarded)
+	otlpHeaders  map[string]string // the exporter's header set for this endpoint
+	otlpReason   string            // why OTLP is not forwarded
+}
+
+// disabledReasons joins the per-leg refusal reasons for logging, or "" when
+// both legs are live (or forwarding is simply off). One reason shared by both
+// legs is a whole-config refusal and drops the per-leg prefixes.
+func (c forwardConfig) disabledReasons() string {
+	if c.genReason == c.otlpReason {
+		return c.genReason
+	}
+	parts := make([]string, 0, 2)
+	if c.genReason != "" {
+		parts = append(parts, "generations: "+c.genReason)
+	}
+	if c.otlpReason != "" {
+		parts = append(parts, "otlp: "+c.otlpReason)
+	}
+	return strings.Join(parts, "; ")
+}
+
+// forwardLoader resolves forwarding configuration from config.env and relays
+// captured telemetry to Grafana Cloud. The daemon is a long-lived singleton, so
+// it re-reads config.env on size/mtime change instead of freezing config at
+// boot, letting a config.env edit take effect without an `agento11y local
+// restart`.
+type forwardLoader struct {
+	path   string
+	logger *log.Logger
+	client *http.Client
+
+	sem chan struct{}
+	wg  sync.WaitGroup
+
+	mu           sync.Mutex
+	haveStat     bool
+	statMtime    time.Time
+	statSize     int64
+	cached       forwardConfig
+	loggedReason string // last refusal logged, so we log it only once
+
+	// failMu guards the failure ring, which is written from forward
+	// goroutines and read by the status endpoint.
+	failMu   sync.Mutex
+	failures []forwardFailure
+}
+
+func newForwardLoader(path string, logger *log.Logger) *forwardLoader {
+	if logger == nil {
+		logger = log.New(io.Discard, "", 0)
+	}
+	return &forwardLoader{
+		path:   path,
+		logger: logger,
+		client: &http.Client{Timeout: 10 * time.Second},
+		sem:    make(chan struct{}, maxInFlightForwards),
+	}
+}
+
+// load returns the current forwarding configuration, re-resolving from
+// config.env when the file's size or mtime changes. A missing file is not an
+// error: the daemon's process environment (populated from config.env at boot)
+// is consulted instead, and a later-created file is picked up on the next call.
+// An unreadable file disables forwarding entirely — the file is the only place
+// that can express an explicit "off", so failing closed is the safe direction.
+func (l *forwardLoader) load() forwardConfig {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	info, err := os.Stat(l.path)
+	switch {
+	case err == nil:
+		if l.haveStat && info.Size() == l.statSize && info.ModTime().Equal(l.statMtime) {
+			return l.cached
+		}
+		var readErr error
+		l.cached, readErr = l.resolve()
+		// A read failure is not cached against size/mtime: fixing the file's
+		// permissions changes neither, so a cached refusal could outlive the
+		// problem until the contents happen to change.
+		l.haveStat = readErr == nil
+		l.statMtime = info.ModTime()
+		l.statSize = info.Size()
+	case os.IsNotExist(err):
+		l.haveStat = false
+		l.cached, _ = l.resolve()
+	default:
+		// os.Stat's error already names the path.
+		l.cached = l.unreadableConfig(err)
+		l.haveStat = false
+	}
+	return l.cached
+}
+
+// forwardStatus is a snapshot of how the daemon forwards captured sessions to
+// Cloud right now, for the viewer's config and conversations pages. It reads
+// the same resolved configuration the forward path uses, so the two cannot
+// disagree.
+type forwardStatus struct {
+	// Enabled reports whether a forwarded copy would actually be sent.
+	Enabled bool `json:"enabled"`
+	// Mode is one of forwardMode{Off,MetadataOnly,Full}.
+	Mode string `json:"mode"`
+	// Generations and OTLP report the two legs separately: a configuration
+	// can forward generations with no OTLP endpoint, or relay OTLP with
+	// credentials the generation export cannot use.
+	Generations bool `json:"generations"`
+	OTLP        bool `json:"otlp"`
+	// Reason explains why generations are not forwarded although the user
+	// opted in (empty endpoint, placeholder credentials, unreadable config).
+	// Empty when forwarding is simply not enabled.
+	Reason string `json:"reason,omitempty"`
+	// OTLPReason is the same for the OTLP leg (no endpoint configured, or a
+	// local endpoint that would loop back into this daemon).
+	OTLPReason string `json:"otlpReason,omitempty"`
+	// Failures are the forward attempts that failed since the last success,
+	// most recent first. Non-empty means the current posture is not actually
+	// delivering, which no other channel would tell the user about: the
+	// daemon's logger is discarded unless debug logging is on.
+	Failures []forwardFailure `json:"failures,omitempty"`
+}
+
+// forwardFailure is one failed forward attempt, kept so the viewer can show
+// that a live-looking posture is not delivering.
+type forwardFailure struct {
+	At     string `json:"at"`
+	Label  string `json:"label"`
+	Detail string `json:"detail"`
+}
+
+const (
+	forwardModeOff          = "off"
+	forwardModeMetadataOnly = "metadata_only"
+	forwardModeFull         = "full"
+)
+
+// status reports the current forwarding posture. It goes through load() rather
+// than re-resolving so the viewer reflects exactly what the forward path does,
+// including the cache and the unreadable-config refusal.
+func (l *forwardLoader) status() forwardStatus {
+	cfg := l.load()
+	st := forwardStatus{
+		Enabled:     cfg.enabled,
+		Mode:        forwardModeOff,
+		Generations: cfg.genURL != "",
+		OTLP:        cfg.otlpEndpoint != "",
+		Reason:      cfg.genReason,
+		OTLPReason:  cfg.otlpReason,
+		Failures:    l.recentFailures(),
+	}
+	switch {
+	case !cfg.enabled:
+	case cfg.strip:
+		st.Mode = forwardModeMetadataOnly
+	default:
+		st.Mode = forwardModeFull
+	}
+	return st
+}
+
+// resolve reads config.env plus the process environment and logs any refusal
+// once. It returns the read error alongside the configuration so the caller
+// knows not to cache a refusal. Must be called with l.mu held.
+func (l *forwardLoader) resolve() (forwardConfig, error) {
+	get, err := l.reader()
+	if err != nil {
+		// The file exists but cannot be read, so its explicit "off" (if any)
+		// is invisible and the process environment still holds the boot-time
+		// values. Fail closed rather than forward on stale config.
+		return l.unreadableConfig(err), err
+	}
+	cfg := resolveForwardConfig(l.logger, get)
+	l.logDisabled(cfg.disabledReasons())
+	return cfg, nil
+}
+
+// unreadableConfig is the fail-closed configuration for a config.env the
+// daemon could not read, with the reason logged once. Must be called with
+// l.mu held.
+func (l *forwardLoader) unreadableConfig(err error) forwardConfig {
+	// Both os.Stat's and os.Open's errors already name the path.
+	cfg := forwardConfig{genReason: "config.env unreadable: " + err.Error()}
+	cfg.otlpReason = cfg.genReason
+	l.logDisabled(cfg.disabledReasons())
+	return cfg
+}
+
+// resolveForwardConfig builds the forwarding configuration from a config
+// snapshot. It is the single resolution path: both the forward legs and the
+// viewer's status read it, so they cannot drift.
+func resolveForwardConfig(logger *log.Logger, get envReader) forwardConfig {
+	if !boolFamily(logger, get, "LOCAL_FORWARD", false) {
+		return forwardConfig{}
+	}
+
+	endpoint, _ := get.family("ENDPOINT")
+	tenant, _ := get.family("AUTH_TENANT_ID")
+	token, _ := get.family("AUTH_TOKEN")
+
+	cfg := forwardConfig{strip: contentModeFamily(logger, get) != agento11y.ContentCaptureModeFull}
+
+	if reason := forwardDisabledReason(endpoint, tenant, token); reason != "" {
+		cfg.genReason = reason
+	} else if genURL, err := wire.NormalizeGenerationExportURL(endpoint, false); err != nil {
+		cfg.genReason = "generation endpoint: " + err.Error()
+	} else {
+		cfg.genURL = genURL
+		cfg.genHeaders = generationForwardHeaders(tenant, token)
+	}
+
+	otlpEndpoint, otlpReason := otlpForwardTarget(get)
+	if otlpReason != "" {
+		cfg.otlpReason = otlpReason
+	} else {
+		cfg.otlpEndpoint = otlpEndpoint
+		cfg.otlpHeaders = otlpForwardHeaders(get, tenant)
+	}
+
+	cfg.enabled = cfg.genURL != "" || cfg.otlpEndpoint != ""
+	return cfg
+}
+
+// generationForwardHeaders builds the auth headers the generation export
+// expects: Basic tenant:token plus the tenant header. A local target needs
+// neither, in which case both values are blank and post() omits them.
+func generationForwardHeaders(tenant, token string) map[string]string {
+	value, _ := otel.BasicAuthHeaderValue(tenant, token)
+	return map[string]string{
+		"Authorization":       value,
+		wire.TenantHeaderName: tenant,
+	}
+}
+
+// otlpForwardTarget resolves the base OTLP endpoint to relay to, or a reason
+// why the OTLP leg stays off. Scheme and the insecure downgrade are applied
+// the way internal/otel builds exporter URLs, and the resulting URL is checked
+// against the local-receiver guard last so an insecure downgrade cannot
+// reintroduce a loop back into this daemon.
+func otlpForwardTarget(get envReader) (endpoint, reason string) {
+	raw, _ := get.family("OTEL_EXPORTER_OTLP_ENDPOINT")
+	if raw == "" {
+		raw = get.key("OTEL_EXPORTER_OTLP_ENDPOINT")
+	}
+	if raw == "" {
+		return "", "no OTLP endpoint configured, so traces and metrics are not forwarded"
+	}
+
+	endpoint = ensureEndpointScheme(raw)
+	insecure, _ := get.family("OTEL_EXPORTER_OTLP_INSECURE")
+	if insecure == "" {
+		insecure = get.key("OTEL_EXPORTER_OTLP_INSECURE")
+	}
+	if envconfig.ParseBool(insecure) {
+		if rest, ok := strings.CutPrefix(endpoint, "https://"); ok {
+			endpoint = "http://" + rest
+		}
+	}
+	if envconfig.IsLocalEndpoint(endpoint) {
+		return "", "OTLP endpoint " + endpoint + " is local, so relaying it would loop back into this daemon"
+	}
+	return endpoint, ""
+}
+
+// otlpForwardHeaders builds the header set the real OTLP exporter would send
+// for this configuration: explicit OTEL_EXPORTER_OTLP_HEADERS win, otherwise
+// Basic auth from the tenant plus OTEL_AUTH_TOKEN with AUTH_TOKEN as the
+// fall-back. Without this the relay would ignore a dedicated OTLP gateway
+// token that `agento11y doctor` tells users to configure.
+func otlpForwardHeaders(get envReader, tenant string) map[string]string {
+	otelToken, _ := get.family("OTEL_AUTH_TOKEN")
+	authToken, _ := get.family("AUTH_TOKEN")
+	return otel.ExporterHeaders(get.key("OTEL_EXPORTER_OTLP_HEADERS"), tenant, otelToken, authToken)
+}
+
+// envReader resolves configuration values from a config.env snapshot with a
+// process-environment fall-back.
+//
+// The file wins, which inverts dotenv.ApplyEnv (and the precedence
+// `agento11y doctor` reports). That is deliberate and is what makes a
+// config.env edit take effect without a daemon restart: the daemon's own
+// environment was populated from config.env at boot, so an env-first order
+// would pin the boot-time values forever.
+type envReader struct {
+	file map[string]string
+}
+
+// reader snapshots config.env for one resolve pass. A missing file is not an
+// error; a file that exists but cannot be read is.
+func (l *forwardLoader) reader() (envReader, error) {
+	file, err := dotenv.ReadDotenv(l.path, l.logger)
+	if err != nil {
+		return envReader{}, err
+	}
+	return envReader{file: file}, nil
+}
+
+// key resolves a single exact key (for non-branded variables such as the bare
+// OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_EXPORTER_OTLP_HEADERS).
+func (r envReader) key(k string) string {
+	if v := strings.TrimSpace(r.file[k]); v != "" {
+		return v
+	}
+	return strings.TrimSpace(os.Getenv(k))
+}
+
+// family resolves a branded alias family preferred-first within each source:
+// file AGENTO11Y_*, file SIGIL_*, env AGENTO11Y_*, env SIGIL_*. The returned
+// key names the spelling the value came from so diagnostics report what the
+// user actually set; it is empty when nothing is set.
+func (r envReader) family(suffix string) (value, key string) {
+	if v, k, ok := envconfig.LookupMap(r.file, suffix); ok {
+		return v, k
+	}
+	if v, k, ok := envconfig.LookupEnv(suffix); ok {
+		return v, k
+	}
+	return "", ""
+}
+
+// boolFamily parses a branded boolean toggle out of an envReader, reporting an
+// unrecognised value under the spelling it was set with.
+func boolFamily(logger *log.Logger, r envReader, suffix string, def bool) bool {
+	raw, key := r.family(suffix)
+	if key == "" {
+		key = envconfig.PreferredKey(suffix)
+	}
+	return envconfig.BoolValue(logger, key, raw, def)
+}
+
+// contentModeFamily resolves the configured content capture mode out of an
+// envReader. This is the mode the forwarded copy is reduced to; the local store
+// always keeps full content.
+func contentModeFamily(logger *log.Logger, r envReader) agento11y.ContentCaptureMode {
+	raw, key := r.family("CONTENT_CAPTURE_MODE")
+	return envconfig.ResolveContentModeValue(logger, key, raw)
+}
+
+// ensureEndpointScheme prepends https:// to a schemeless endpoint, mirroring
+// wire.NormalizeGenerationExportURL so otel.SignalEndpointURL yields an
+// absolute URL. A relative URL survives http.NewRequest and fails later in
+// client.Do with "unsupported protocol scheme", which would turn a typo into a
+// per-payload transport error. An empty endpoint is returned unchanged.
+func ensureEndpointScheme(endpoint string) string {
+	e := strings.TrimSpace(endpoint)
+	if e == "" {
+		return ""
+	}
+	lower := strings.ToLower(e)
+	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
+		return e
+	}
+	return "https://" + e
+}
+
+// forwardDisabledReason returns a non-empty reason when generation forwarding
+// must be refused for the given Cloud target, guarding against shipping to a
+// bogus endpoint with placeholder credentials.
+func forwardDisabledReason(endpoint, tenant, token string) string {
+	if endpoint == "" {
+		return envconfig.PreferredKey("ENDPOINT") + " is empty"
+	}
+	// A local receiver (http://127.0.0.1, ::1, localhost) is a valid forward
+	// target — e.g. a separate daemon — and does not validate auth, so empty
+	// or placeholder credentials must not pause forwarding to it. The
+	// forwardMarkerHeader on the outbound request is what stops a daemon
+	// pointed at itself from relaying the same payload again.
+	if envconfig.IsLocalEndpoint(endpoint) {
+		return ""
+	}
+	switch {
+	case tenant == "" || token == "":
+		return envconfig.PreferredKey("AUTH_TENANT_ID") + "/" + envconfig.PreferredKey("AUTH_TOKEN") + " are empty"
+	case tenant == envconfig.LocalAuthPlaceholder || token == envconfig.LocalAuthPlaceholder:
+		return "credentials are the " + envconfig.LocalAuthPlaceholder + " placeholder"
+	default:
+		return ""
+	}
+}
+
+// logDisabled logs a refusal once, suppressing repeats while the reason stays
+// the same. An empty reason clears the latch so a later refusal logs again.
+// Must be called with l.mu held.
+func (l *forwardLoader) logDisabled(reason string) {
+	if l.loggedReason == reason {
+		return
+	}
+	l.loggedReason = reason
+	if reason != "" {
+		l.logger.Printf("local forward: %s", reason)
+	}
+}
+
+// recordFailuref appends a failed attempt to the ring the status endpoint
+// serves, keeping the most recent maxRecordedForwardFailures. It also logs,
+// which only reaches a user who enabled debug logging.
+func (l *forwardLoader) recordFailuref(label, format string, args ...any) {
+	detail := fmt.Sprintf(format, args...)
+	l.logger.Printf("local forward: %s: %s", label, detail)
+
+	l.failMu.Lock()
+	defer l.failMu.Unlock()
+	l.failures = append(l.failures, forwardFailure{
+		At:     time.Now().UTC().Format(time.RFC3339),
+		Label:  label,
+		Detail: detail,
+	})
+	if len(l.failures) > maxRecordedForwardFailures {
+		l.failures = l.failures[len(l.failures)-maxRecordedForwardFailures:]
+	}
+}
+
+// recordSuccess clears the recorded failures for one leg, so
+// forwardStatus.Failures means "failing since that leg's last delivery" rather
+// than "failed at some point". Generations and OTLP fail independently: a
+// healthy metrics relay must not hide a generation export Cloud keeps
+// rejecting.
+func (l *forwardLoader) recordSuccess(label string) {
+	l.failMu.Lock()
+	defer l.failMu.Unlock()
+	l.failures = slices.DeleteFunc(l.failures, func(f forwardFailure) bool {
+		return f.Label == label
+	})
+}
+
+// recentFailures returns the recorded failures most recent first.
+func (l *forwardLoader) recentFailures() []forwardFailure {
+	l.failMu.Lock()
+	defer l.failMu.Unlock()
+	if len(l.failures) == 0 {
+		return nil
+	}
+	out := make([]forwardFailure, 0, len(l.failures))
+	for _, f := range slices.Backward(l.failures) {
+		out = append(out, f)
+	}
+	return out
+}
+
+// enqueue runs fn on a bounded goroutine. When the in-flight limit is reached
+// the payload is dropped (best-effort) rather than blocking the caller. The
+// drop is recorded under the leg's own label so that leg's next success clears
+// it.
+func (l *forwardLoader) enqueue(label string, fn func()) {
+	l.wg.Add(1)
+	select {
+	case l.sem <- struct{}{}:
+		go func() {
+			defer l.wg.Done()
+			defer func() { <-l.sem }()
+			fn()
+		}()
+	default:
+		l.wg.Done()
+		l.recordFailuref(label, "%d forwards in flight, dropping payload", cap(l.sem))
+	}
+}
+
+// wait blocks until all in-flight forwards complete. Used by tests; the daemon
+// never calls it.
+func (l *forwardLoader) wait() { l.wg.Wait() }
+
+// forwardGenerations relays the given raw proto-JSON generations to Cloud,
+// stripping content first when cfg.strip is set.
+func (l *forwardLoader) forwardGenerations(cfg forwardConfig, raw []json.RawMessage) {
+	if !cfg.enabled || cfg.genURL == "" || len(raw) == 0 {
+		return
+	}
+	payload, err := buildGenerationPayload(raw, cfg.strip)
+	if err != nil {
+		l.recordFailuref(forwardLabelGenerations, "build payload: %v (dropping payload)", err)
+		return
+	}
+	l.post(cfg.genURL, wire.ContentTypeJSON, "", cfg.genHeaders, payload, forwardLabelGenerations)
+}
+
+// buildGenerationPayload wraps the raw generations back into an
+// ExportGenerationsRequest envelope. When strip is set it decodes the proto,
+// reduces each generation to metadata_only, and re-encodes.
+func buildGenerationPayload(raw []json.RawMessage, strip bool) ([]byte, error) {
+	envelope, err := json.Marshal(generationsRequest{Generations: raw})
+	if err != nil {
+		return nil, err
+	}
+	if !strip {
+		return envelope, nil
+	}
+	// DiscardUnknown, unlike wire.UnmarshalExportGenerationsJSON: an exporter
+	// newer than this daemon (the pi and opencode plugins ship on their own
+	// npm cadence) would otherwise cost the whole batch, and discarding a
+	// field the daemon cannot strip is the safe direction for a reduced copy.
+	var req agento11yv1.ExportGenerationsRequest
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(envelope, &req); err != nil {
+		return nil, err
+	}
+	for _, gen := range req.GetGenerations() {
+		stripGenerationProto(gen)
+	}
+	return wire.MarshalExportGenerationsJSON(&req)
+}
+
+// stripGenerationProto reduces a generation to metadata_only on the wire-level
+// proto: it clears the system prompt, raw artifacts, conversation title, and
+// per-message text/thinking/tool/media content, replaces the raw call error,
+// drops tool descriptions and schemas, and stamps the metadata_only marker.
+//
+// The field list has to track the SDK's stripContent/stripMessageContent
+// (go/agento11y/content_capture.go) by hand: those operate on
+// agento11y.Generation and there is no reverse mapping from the wire proto, so
+// a new content field in the proto must be added here too.
+func stripGenerationProto(g *agento11yv1.Generation) {
+	if g == nil {
+		return
+	}
+	g.SystemPrompt = ""
+	g.RawArtifacts = nil
+	if g.CallError != "" {
+		g.CallError = strippedCallError
+	}
+	for _, m := range g.GetInput() {
+		stripMessageProto(m)
+	}
+	for _, m := range g.GetOutput() {
+		stripMessageProto(m)
+	}
+	for _, tool := range g.GetTools() {
+		if tool == nil {
+			continue
+		}
+		tool.Description = ""
+		tool.InputSchemaJson = nil
+	}
+	stripGenerationMetadata(g)
+}
+
+func stripMessageProto(m *agento11yv1.Message) {
+	if m == nil {
+		return
+	}
+	for _, p := range m.GetParts() {
+		switch payload := p.GetPayload().(type) {
+		case *agento11yv1.Part_Text:
+			payload.Text = ""
+		case *agento11yv1.Part_Thinking:
+			payload.Thinking = ""
+		case *agento11yv1.Part_ToolCall:
+			if payload.ToolCall != nil {
+				payload.ToolCall.InputJson = nil
+			}
+		case *agento11yv1.Part_ToolResult:
+			if payload.ToolResult != nil {
+				payload.ToolResult.Content = ""
+				payload.ToolResult.ContentJson = nil
+			}
+		case *agento11yv1.Part_Media:
+			// Media.url carries data: URIs for pasted images and files
+			// (go/agento11y/codec), so it is content, not a reference.
+			if payload.Media != nil {
+				payload.Media.Url = ""
+			}
+		}
+	}
+}
+
+// stripGenerationMetadata drops the content-bearing metadata mirrors
+// (call_error, conversation title under both spellings) and overwrites the
+// content-capture marker to metadata_only. The incoming marker is "full" (the
+// local child captures full), so it must be rewritten or Cloud-side validation
+// would reject the now-empty parts.
+func stripGenerationMetadata(g *agento11yv1.Generation) {
+	md := g.GetMetadata()
+	if md == nil {
+		md = &structpb.Struct{}
+		g.Metadata = md
+	}
+	if md.Fields == nil {
+		md.Fields = map[string]*structpb.Value{}
+	}
+	delete(md.Fields, metadataKeyCallError)
+	delete(md.Fields, metadataKeyConversationTitle)
+	delete(md.Fields, legacyConversationTitleKey)
+	md.Fields[model.MetadataKeyContentCaptureMode] = structpb.NewStringValue(model.ContentCaptureModeMetadataOnly)
+}
+
+// forwardOTLP relays an OTLP payload to the corresponding Cloud signal URL.
+// Metrics and full traces are relayed byte-for-byte with the inbound
+// Content-Encoding preserved. Traces under a reduced content mode have content
+// attributes, exception events, and error status messages stripped before
+// relay; that path decompresses a gzip body so the proto can be parsed and
+// relays the re-marshaled payload uncompressed.
+func (l *forwardLoader) forwardOTLP(cfg forwardConfig, signal, contentType, contentEncoding string, body []byte) {
+	if !cfg.enabled || cfg.otlpEndpoint == "" || len(body) == 0 {
+		return
+	}
+	label := otlpForwardLabel(signal)
+	out, ct, enc := body, contentType, contentEncoding
+	if signal == "traces" && cfg.strip {
+		decoded := body
+		if isGzipEncoding(contentEncoding) {
+			d, err := gunzip(body)
+			if err != nil {
+				l.recordFailuref(label, "gunzip: %v (dropping payload)", err)
+				return
+			}
+			decoded = d
+		}
+		stripped, newCT, err := stripTracePayload(decoded, contentType)
+		if err != nil {
+			l.recordFailuref(label, "strip content: %v (dropping payload)", err)
+			return
+		}
+		out, ct, enc = stripped, newCT, ""
+	}
+	if strings.TrimSpace(ct) == "" {
+		ct = wire.ContentTypeProto
+	}
+	l.post(otel.SignalEndpointURL(cfg.otlpEndpoint, signal), ct, enc, cfg.otlpHeaders, out, label)
+}
+
+// isGzipEncoding reports whether a Content-Encoding header value is gzip.
+func isGzipEncoding(encoding string) bool {
+	return strings.EqualFold(strings.TrimSpace(encoding), "gzip")
+}
+
+// gunzip decompresses a gzip-encoded body.
+func gunzip(body []byte) ([]byte, error) {
+	zr, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = zr.Close() }()
+	return io.ReadAll(zr)
+}
+
+// stripTracePayload decodes an OTLP trace export (protobuf, or JSON when the
+// content type says so), strips content from every span, and re-encodes in the
+// same format. The returned content type matches the encoding used.
+func stripTracePayload(body []byte, contentType string) ([]byte, string, error) {
+	isJSON := strings.Contains(strings.ToLower(contentType), "json")
+	var req coltracepb.ExportTraceServiceRequest
+	if isJSON {
+		if err := protojson.Unmarshal(body, &req); err != nil {
+			return nil, "", err
+		}
+	} else if err := proto.Unmarshal(body, &req); err != nil {
+		return nil, "", err
+	}
+	stripTraceContent(&req)
+	if isJSON {
+		out, err := protojson.Marshal(&req)
+		return out, wire.ContentTypeJSON, err
+	}
+	out, err := proto.Marshal(&req)
+	return out, wire.ContentTypeProto, err
+}
+
+func stripTraceContent(req *coltracepb.ExportTraceServiceRequest) {
+	for _, rs := range req.GetResourceSpans() {
+		for _, ss := range rs.GetScopeSpans() {
+			for _, span := range ss.GetSpans() {
+				if span == nil {
+					continue
+				}
+				// The status message is read before the attribute filter so
+				// the replacement category is still available.
+				stripSpanStatus(span)
+				span.Attributes = filterContentAttributes(span.GetAttributes())
+				span.Events = stripSpanEvents(span.GetEvents())
+			}
+		}
+	}
+}
+
+// stripSpanStatus replaces an error span's status message, which the SDK sets
+// from the same raw provider error string it puts on the exception event
+// (go/agento11y/client.go). Dropping the event and keeping the status would
+// leave prompt fragments and tool output echoed by a provider 4xx on the
+// forwarded span. The span's own error.category is the replacement when
+// present, mirroring what the SDK writes under a reduced mode.
+func stripSpanStatus(span *tracepb.Span) {
+	status := span.GetStatus()
+	if status == nil || status.GetMessage() == "" {
+		return
+	}
+	if status.GetCode() != tracepb.Status_STATUS_CODE_ERROR {
+		// A non-error status carries no meaning in the message field.
+		status.Message = ""
+		return
+	}
+	if category := stringAttribute(span.GetAttributes(), spanAttrErrorCategory); category != "" {
+		status.Message = category
+		return
+	}
+	status.Message = strippedCallError
+}
+
+// stringAttribute returns the string value of one span attribute, or "".
+func stringAttribute(attrs []*commonpb.KeyValue, key string) string {
+	for _, kv := range attrs {
+		if kv.GetKey() == key {
+			return kv.GetValue().GetStringValue()
+		}
+	}
+	return ""
+}
+
+func filterContentAttributes(attrs []*commonpb.KeyValue) []*commonpb.KeyValue {
+	out := attrs[:0]
+	for _, kv := range attrs {
+		if kv == nil {
+			continue
+		}
+		if _, blocked := traceContentAttributes[kv.GetKey()]; blocked {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+func stripSpanEvents(events []*tracepb.Span_Event) []*tracepb.Span_Event {
+	out := events[:0]
+	for _, e := range events {
+		if e == nil {
+			continue
+		}
+		if e.GetName() == exceptionEventName {
+			continue
+		}
+		e.Attributes = filterContentAttributes(e.GetAttributes())
+		out = append(out, e)
+	}
+	return out
+}
+
+// post issues a best-effort POST. Failures are recorded, never returned: a
+// Cloud error must not affect the already-completed local store or the child's
+// ack. The outcome lands in forwardStatus, which is the only channel that
+// reaches a user without debug logging enabled.
+func (l *forwardLoader) post(url, contentType, contentEncoding string, headers map[string]string, body []byte, label string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		l.recordFailuref(label, "build request for %s: %v", url, err)
+		return
+	}
+	req.Header.Set("Content-Type", contentType)
+	if contentEncoding != "" {
+		req.Header.Set("Content-Encoding", contentEncoding)
+	}
+	req.Header.Set(forwardMarkerHeader, "1")
+	for k, v := range headers {
+		if v != "" {
+			req.Header.Set(k, v)
+		}
+	}
+	resp, err := l.client.Do(req)
+	if err != nil {
+		l.recordFailuref(label, "POST %s: %v", url, err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		// The body names the offending field when ingest validation rejects a
+		// stripped payload, which is the only way a drift between this
+		// daemon's field list and the SDK's becomes diagnosable.
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		l.recordFailuref(label, "POST %s status %d: %s", url, resp.StatusCode, strings.TrimSpace(string(snippet)))
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	l.recordSuccess(label)
+}
+
+// isForwardedRequest reports whether an inbound payload already came from
+// another daemon's forwarder. Relaying it again would loop between two daemons
+// pointed at each other, or between one daemon and itself when the ingest
+// endpoint is hand-set to this daemon's own address.
+func isForwardedRequest(r *http.Request) bool {
+	return r.Header.Get(forwardMarkerHeader) != ""
+}
+
+// otlpSignalFromPath maps an OTLP receiver path to its signal name.
+func otlpSignalFromPath(path string) string {
+	switch {
+	case strings.HasSuffix(path, "/traces"):
+		return "traces"
+	case strings.HasSuffix(path, "/metrics"):
+		return "metrics"
+	default:
+		return ""
+	}
+}

--- a/plugins/agento11y/internal/local/forward_test.go
+++ b/plugins/agento11y/internal/local/forward_test.go
@@ -1,0 +1,989 @@
+package local
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/agento11y/go/agento11y/model"
+	agento11yv1 "github.com/grafana/agento11y/go/proto/agento11y/v1"
+	"github.com/grafana/agento11y/go/proto/agento11y/wire"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/otel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// clearForwardEnv blanks every variable the forward loader reads so a test's
+// config.env file, not the ambient environment, decides the outcome. Without
+// this a developer with AGENTO11Y_LOCAL_FORWARD and real credentials exported
+// would have the suite POST to their live tenant.
+func clearForwardEnv(t *testing.T) {
+	t.Helper()
+	envconfig.PinAliasEnvBlank(t)
+	// The loader also falls back to the bare OTLP variables, which are not part
+	// of an alias family.
+	for _, k := range []string{"OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_HEADERS", "OTEL_EXPORTER_OTLP_INSECURE"} {
+		t.Setenv(k, "")
+	}
+}
+
+func writeConfigEnvFile(t *testing.T, lines map[string]string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.env")
+	var b []byte
+	for k, v := range lines {
+		b = fmt.Appendf(b, "%s=%s\n", k, v)
+	}
+	require.NoError(t, os.WriteFile(path, b, 0o600))
+	return path
+}
+
+func TestForwardLoader_Resolve(t *testing.T) {
+	const cloud = "https://cloud.example.test/"
+	cases := []struct {
+		name             string
+		lines            map[string]string
+		wantEnabled      bool
+		wantStrip        bool
+		wantStatusMode   string
+		wantStatusReason bool
+		wantOTLP         bool
+	}{
+		{
+			// Credentials the generation export cannot use, but a usable OTLP
+			// target: the OTLP leg forwards on its own and the status says so.
+			name: "otlp_only_when_generation_creds_missing",
+			lines: map[string]string{
+				"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": cloud,
+				"AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT": "https://otlp.example.test",
+				"OTEL_EXPORTER_OTLP_HEADERS":            "Authorization=Bearer gateway-token",
+			},
+			wantEnabled:      true,
+			wantStrip:        true,
+			wantStatusMode:   forwardModeMetadataOnly,
+			wantStatusReason: true,
+			wantOTLP:         true,
+		},
+		{
+			name:           "disabled_when_toggle_unset",
+			lines:          map[string]string{"AGENTO11Y_ENDPOINT": cloud, "AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k"},
+			wantEnabled:    false,
+			wantStatusMode: forwardModeOff,
+		},
+		{
+			name:           "enabled_defaults_to_metadata_only",
+			lines:          map[string]string{"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": cloud, "AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k"},
+			wantEnabled:    true,
+			wantStrip:      true,
+			wantStatusMode: forwardModeMetadataOnly,
+		},
+		{
+			name:           "enabled_full_does_not_strip",
+			lines:          map[string]string{"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": cloud, "AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k", "AGENTO11Y_CONTENT_CAPTURE_MODE": "full"},
+			wantEnabled:    true,
+			wantStrip:      false,
+			wantStatusMode: forwardModeFull,
+		},
+		{
+			name:           "advanced_capture_mode_still_strips",
+			lines:          map[string]string{"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": cloud, "AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k", "AGENTO11Y_CONTENT_CAPTURE_MODE": "no_tool_content"},
+			wantEnabled:    true,
+			wantStrip:      true,
+			wantStatusMode: forwardModeMetadataOnly,
+		},
+		{
+			name:           "legacy_spellings_resolve",
+			lines:          map[string]string{"SIGIL_LOCAL_FORWARD": "true", "SIGIL_ENDPOINT": cloud, "SIGIL_AUTH_TENANT_ID": "t", "SIGIL_AUTH_TOKEN": "k", "SIGIL_CONTENT_CAPTURE_MODE": "full"},
+			wantEnabled:    true,
+			wantStrip:      false,
+			wantStatusMode: forwardModeFull,
+		},
+		{
+			// Both spellings present: the preferred one decides, matching
+			// ParseSettings and dotenv.ApplyEnv.
+			name: "preferred_spelling_wins",
+			lines: map[string]string{
+				"AGENTO11Y_LOCAL_FORWARD": "true", "SIGIL_LOCAL_FORWARD": "false",
+				"AGENTO11Y_ENDPOINT": cloud, "SIGIL_ENDPOINT": "https://other.example.test",
+				"AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+				"AGENTO11Y_CONTENT_CAPTURE_MODE": "full", "SIGIL_CONTENT_CAPTURE_MODE": "metadata_only",
+			},
+			wantEnabled:    true,
+			wantStrip:      false,
+			wantStatusMode: forwardModeFull,
+		},
+		{
+			name:           "allows_local_endpoint",
+			lines:          map[string]string{"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": "http://127.0.0.1:4317", "AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k"},
+			wantEnabled:    true,
+			wantStrip:      true,
+			wantStatusMode: forwardModeMetadataOnly,
+		},
+		{
+			name:           "allows_local_endpoint_with_placeholder_creds",
+			lines:          map[string]string{"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": "http://127.0.0.1:8080", "AGENTO11Y_AUTH_TENANT_ID": "local", "AGENTO11Y_AUTH_TOKEN": "local"},
+			wantEnabled:    true,
+			wantStrip:      true,
+			wantStatusMode: forwardModeMetadataOnly,
+		},
+		{
+			name:           "allows_local_endpoint_without_creds",
+			lines:          map[string]string{"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": "http://localhost:8080"},
+			wantEnabled:    true,
+			wantStrip:      true,
+			wantStatusMode: forwardModeMetadataOnly,
+		},
+		{
+			name:             "refuses_placeholder_creds",
+			lines:            map[string]string{"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": cloud, "AGENTO11Y_AUTH_TENANT_ID": "local", "AGENTO11Y_AUTH_TOKEN": "local"},
+			wantEnabled:      false,
+			wantStatusMode:   forwardModeOff,
+			wantStatusReason: true,
+		},
+		{
+			name:             "refuses_empty_endpoint",
+			lines:            map[string]string{"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k"},
+			wantEnabled:      false,
+			wantStatusMode:   forwardModeOff,
+			wantStatusReason: true,
+		},
+		{
+			name:             "refuses_invalid_endpoint",
+			lines:            map[string]string{"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": "http://%", "AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k"},
+			wantEnabled:      false,
+			wantStatusMode:   forwardModeOff,
+			wantStatusReason: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearForwardEnv(t)
+			l := newForwardLoader(writeConfigEnvFile(t, tc.lines), nil)
+			cfg := l.load()
+			assert.Equal(t, tc.wantEnabled, cfg.enabled)
+			if tc.wantEnabled {
+				assert.Equal(t, tc.wantStrip, cfg.strip)
+				assert.Equal(t, tc.wantOTLP, cfg.otlpEndpoint != "")
+			}
+			st := l.status()
+			assert.Equal(t, tc.wantEnabled, st.Enabled)
+			assert.Equal(t, tc.wantStatusMode, st.Mode)
+			assert.Equal(t, tc.wantOTLP, st.OTLP)
+			assert.Equal(t, cfg.genURL != "", st.Generations)
+			if tc.wantStatusReason {
+				assert.NotEmpty(t, st.Reason)
+			} else {
+				assert.Empty(t, st.Reason)
+			}
+		})
+	}
+}
+
+// TestForwardLoader_ResolvesFromProcessEnv covers the process-environment
+// fall-back: a value exported in the shell that launched the daemon enables
+// forwarding even with no config.env entry.
+func TestForwardLoader_ResolvesFromProcessEnv(t *testing.T) {
+	clearForwardEnv(t)
+	t.Setenv(envconfig.PreferredKey("LOCAL_FORWARD"), "true")
+	t.Setenv(envconfig.PreferredKey("ENDPOINT"), "https://cloud.example.test/")
+	t.Setenv(envconfig.PreferredKey("AUTH_TENANT_ID"), "t")
+	t.Setenv(envconfig.PreferredKey("AUTH_TOKEN"), "k")
+
+	l := newForwardLoader(filepath.Join(t.TempDir(), "missing-config.env"), nil)
+	assert.True(t, l.load().enabled)
+	assert.Equal(t, forwardModeMetadataOnly, l.status().Mode)
+}
+
+// TestForwardLoader_ConfigFileBeatsProcessEnv covers the no-restart
+// requirement from the other direction: the daemon's process env is populated
+// from config.env at boot, so an edited file value must win over the stale
+// exported one.
+func TestForwardLoader_ConfigFileBeatsProcessEnv(t *testing.T) {
+	clearForwardEnv(t)
+	t.Setenv(envconfig.PreferredKey("LOCAL_FORWARD"), "false")
+	path := writeConfigEnvFile(t, map[string]string{
+		"AGENTO11Y_LOCAL_FORWARD":  "true",
+		"AGENTO11Y_ENDPOINT":       "https://cloud.example.test/",
+		"AGENTO11Y_AUTH_TENANT_ID": "t",
+		"AGENTO11Y_AUTH_TOKEN":     "k",
+	})
+	assert.True(t, newForwardLoader(path, nil).load().enabled)
+}
+
+func TestEnsureEndpointScheme(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty_unchanged", in: "", want: ""},
+		{name: "schemeless_gets_https", in: "otlp.example.test:4318", want: "https://otlp.example.test:4318"},
+		{name: "https_unchanged", in: "https://otlp.example.test", want: "https://otlp.example.test"},
+		{name: "http_unchanged", in: "http://otlp.example.test", want: "http://otlp.example.test"},
+		{name: "trims_whitespace", in: "  otlp.example.test  ", want: "https://otlp.example.test"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ensureEndpointScheme(tc.in))
+		})
+	}
+}
+
+func TestOTLPSignalFromPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{path: "/otlp/v1/traces", want: "traces"},
+		{path: "/otlp/v1/metrics", want: "metrics"},
+		{path: "/otlp/v1/logs", want: ""},
+		{path: "/api/v1/generations:export", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			assert.Equal(t, tc.want, otlpSignalFromPath(tc.path))
+		})
+	}
+}
+
+// TestForwardLoader_OTLPEndpointResolution covers the OTLP relay target: a
+// schemeless endpoint must resolve to an absolute URL (a relative one only
+// fails at request time, per payload), the bare OTEL_EXPORTER_OTLP_ENDPOINT is
+// the fall-back, and a local receiver is dropped so the daemon never relays
+// back to itself.
+func TestForwardLoader_OTLPEndpointResolution(t *testing.T) {
+	const cloud = "https://cloud.example.test/"
+	base := map[string]string{
+		"AGENTO11Y_LOCAL_FORWARD":  "true",
+		"AGENTO11Y_ENDPOINT":       cloud,
+		"AGENTO11Y_AUTH_TENANT_ID": "t",
+		"AGENTO11Y_AUTH_TOKEN":     "k",
+	}
+	cases := []struct {
+		name     string
+		extra    map[string]string
+		bareEnv  string
+		wantOTLP string
+	}{
+		{
+			name:     "schemeless_gets_https",
+			extra:    map[string]string{"AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT": "otlp.example.test:4318"},
+			wantOTLP: "https://otlp.example.test:4318",
+		},
+		{
+			name:     "legacy_spelling_resolves",
+			extra:    map[string]string{"SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT": "https://otlp.example.test"},
+			wantOTLP: "https://otlp.example.test",
+		},
+		{
+			name:     "falls_back_to_bare_otel_var",
+			bareEnv:  "https://otlp.example.test/otlp",
+			wantOTLP: "https://otlp.example.test/otlp",
+		},
+		{
+			name:     "local_receiver_dropped",
+			extra:    map[string]string{"AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:8765/otlp"},
+			wantOTLP: "",
+		},
+		{
+			name:     "unset_stays_empty",
+			wantOTLP: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearForwardEnv(t)
+			if tc.bareEnv != "" {
+				t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", tc.bareEnv)
+			}
+			lines := map[string]string{}
+			maps.Copy(lines, base)
+			maps.Copy(lines, tc.extra)
+			cfg := newForwardLoader(writeConfigEnvFile(t, lines), nil).load()
+			require.True(t, cfg.enabled)
+			assert.Equal(t, tc.wantOTLP, cfg.otlpEndpoint)
+		})
+	}
+}
+
+// TestForwardLoader_ReloadsOnConfigChange covers the no-restart requirement:
+// flipping the toggle in config.env is observed on the next load once the file
+// mtime advances.
+func TestForwardLoader_ReloadsOnConfigChange(t *testing.T) {
+	clearForwardEnv(t)
+	const cloud = "https://cloud.example.test/"
+	path := writeConfigEnvFile(t, map[string]string{
+		"AGENTO11Y_ENDPOINT": cloud, "AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+	})
+	l := newForwardLoader(path, nil)
+	require.False(t, l.load().enabled)
+
+	require.NoError(t, os.WriteFile(path, []byte(
+		"AGENTO11Y_LOCAL_FORWARD=true\nAGENTO11Y_ENDPOINT="+cloud+"\nAGENTO11Y_AUTH_TENANT_ID=t\nAGENTO11Y_AUTH_TOKEN=k\n"), 0o600))
+	// Force a distinct mtime so the size+mtime cache notices the edit even when
+	// the rewrite lands within the filesystem's timestamp granularity.
+	future := time.Now().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(path, future, future))
+
+	assert.True(t, l.load().enabled)
+}
+
+// TestStripGenerationProto_ClearsContentKeepsStructure asserts the daemon-side
+// proto strip clears the content fields the SDK's stripContent /
+// stripMessageContent clear (go/agento11y/content_capture.go) while preserving
+// message structure, tool names, usage, tags, and unrelated metadata. The two
+// lists are kept in sync by hand, so a new content field in the proto needs a
+// case here and in stripGenerationProto.
+func TestStripGenerationProto_ClearsContentKeepsStructure(t *testing.T) {
+	g := contentRichGeneration(t)
+	stripGenerationProto(g)
+
+	assert.Empty(t, g.GetSystemPrompt(), "system prompt cleared")
+	assert.Nil(t, g.GetRawArtifacts(), "raw artifacts cleared")
+	assert.Equal(t, strippedCallError, g.GetCallError(), "call error replaced")
+
+	// Input user text cleared; part still present (kind preserved).
+	require.Len(t, g.GetInput()[0].GetParts(), 2)
+	assert.Empty(t, g.GetInput()[0].GetParts()[0].GetText())
+
+	// Output thinking + tool-call arguments cleared; tool-call name kept.
+	out := g.GetOutput()[0].GetParts()
+	assert.Empty(t, out[0].GetThinking())
+	assert.Nil(t, out[1].GetToolCall().GetInputJson())
+	assert.Equal(t, "do_thing", out[1].GetToolCall().GetName())
+
+	// Tool-result content cleared; identifiers kept.
+	tr := g.GetInput()[1].GetParts()[0].GetToolResult()
+	assert.Empty(t, tr.GetContent())
+	assert.Nil(t, tr.GetContentJson())
+	assert.Equal(t, "t1", tr.GetToolCallId())
+
+	// Media URL cleared (it carries data: URIs for pasted images and files);
+	// the part and its descriptive fields stay.
+	media := g.GetInput()[0].GetParts()[1].GetMedia()
+	assert.Empty(t, media.GetUrl())
+	assert.Equal(t, "image", media.GetKind())
+	assert.Equal(t, "screenshot.png", media.GetName())
+
+	// Tool description + schema cleared; name kept.
+	assert.Empty(t, g.GetTools()[0].GetDescription())
+	assert.Nil(t, g.GetTools()[0].GetInputSchemaJson())
+	assert.Equal(t, "do_thing", g.GetTools()[0].GetName())
+
+	// Metadata: content mirrors dropped (both the current and the pre-rename
+	// title key), marker rewritten, unrelated keys kept.
+	fields := g.GetMetadata().GetFields()
+	assert.NotContains(t, fields, metadataKeyCallError)
+	assert.NotContains(t, fields, metadataKeyConversationTitle)
+	assert.NotContains(t, fields, legacyConversationTitleKey)
+	assert.Equal(t, "metadata_only", fields[model.MetadataKeyContentCaptureMode].GetStringValue())
+	assert.Equal(t, "structural", fields["keep_me"].GetStringValue())
+
+	// Structural top-level fields untouched.
+	assert.Equal(t, "gen-1", g.GetId())
+	assert.Equal(t, "conv-1", g.GetConversationId())
+	assert.Equal(t, int64(10), g.GetUsage().GetInputTokens())
+	assert.Equal(t, "test", g.GetTags()["env"])
+}
+
+func TestForwardLoader_ForwardGenerations(t *testing.T) {
+	cases := []struct {
+		name       string
+		strip      bool
+		wantMarker string
+		wantSystem string
+	}{
+		{name: "full_keeps_content", strip: false, wantMarker: "full", wantSystem: "secret system prompt"},
+		{name: "metadata_only_strips_content", strip: true, wantMarker: "metadata_only", wantSystem: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			received := make(chan []byte, 1)
+			var gotPath, gotAuth, gotTenant string
+			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotAuth = r.Header.Get("Authorization")
+				gotTenant = r.Header.Get(wire.TenantHeaderName)
+				b, _ := io.ReadAll(r.Body)
+				received <- b
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			l := newForwardLoader(filepath.Join(t.TempDir(), "config.env"), nil)
+			l.client = srv.Client()
+			cfg := fakeForwardConfig(t, srv.URL, tc.strip)
+
+			raw := generationRawJSON(t, contentRichGeneration(t))
+			l.enqueue(forwardLabelGenerations, func() { l.forwardGenerations(cfg, []json.RawMessage{raw}) })
+			l.wait()
+
+			body := <-received
+			assert.Equal(t, wire.GenerationExportHTTPPath, gotPath)
+			assert.Equal(t, cfg.genHeaders["Authorization"], gotAuth)
+			assert.Equal(t, "tenant-x", gotTenant)
+
+			req, err := wire.UnmarshalExportGenerationsJSON(body)
+			require.NoError(t, err)
+			require.Len(t, req.GetGenerations(), 1)
+			g := req.GetGenerations()[0]
+
+			// Structural fields survive regardless of mode.
+			assert.Equal(t, "gen-1", g.GetId())
+			assert.Equal(t, "do_thing", g.GetTools()[0].GetName())
+			assert.Equal(t, int64(10), g.GetUsage().GetInputTokens())
+
+			assert.Equal(t, tc.wantSystem, g.GetSystemPrompt())
+			assert.Equal(t, tc.wantMarker, g.GetMetadata().GetFields()[model.MetadataKeyContentCaptureMode].GetStringValue())
+			if tc.strip {
+				assert.Empty(t, g.GetOutput()[0].GetParts()[0].GetThinking())
+				assert.Nil(t, g.GetOutput()[0].GetParts()[1].GetToolCall().GetInputJson())
+				assert.NotContains(t, g.GetMetadata().GetFields(), metadataKeyConversationTitle)
+			} else {
+				assert.Equal(t, "thinking secret", g.GetOutput()[0].GetParts()[0].GetThinking())
+				assert.Equal(t, "secret title", g.GetMetadata().GetFields()[metadataKeyConversationTitle].GetStringValue())
+			}
+		})
+	}
+}
+
+// TestForwardLoader_ForwardGenerationsSkipsWhenDisabled covers the opt-in
+// guarantee at the relay level: a disabled config never issues a request.
+func TestForwardLoader_ForwardGenerationsSkipsWhenDisabled(t *testing.T) {
+	hits := make(chan struct{}, 1)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	l := newForwardLoader(filepath.Join(t.TempDir(), "config.env"), nil)
+	l.client = srv.Client()
+	cfg := fakeForwardConfig(t, srv.URL, true)
+	cfg.enabled = false
+
+	raw := generationRawJSON(t, contentRichGeneration(t))
+	l.forwardGenerations(cfg, []json.RawMessage{raw})
+	l.forwardOTLP(cfg, "traces", "application/x-protobuf", "", []byte("body"))
+	l.wait()
+	assert.Empty(t, hits)
+}
+
+// TestForwardLoader_ForwardOTLP covers the relay matrix: which signal, whether
+// the reduced content mode applies, and the inbound encoding. Metrics and full
+// traces must arrive byte-identical with their encoding preserved; reduced
+// traces are decompressed, stripped, and relayed uncompressed.
+func TestForwardLoader_ForwardOTLP(t *testing.T) {
+	type capture struct {
+		path            string
+		contentType     string
+		contentEncoding string
+		body            []byte
+	}
+	received := make(chan capture, 4)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		received <- capture{
+			path:            r.URL.Path,
+			contentType:     r.Header.Get("Content-Type"),
+			contentEncoding: r.Header.Get("Content-Encoding"),
+			body:            b,
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	l := newForwardLoader(filepath.Join(t.TempDir(), "config.env"), nil)
+	l.client = srv.Client()
+
+	metricsBody := []byte("\x00\x01\x02metrics-protobuf-bytes")
+	tracesBody, err := proto.Marshal(traceRequestWithContent())
+	require.NoError(t, err)
+	tracesJSON, err := protojson.Marshal(traceRequestWithContent())
+	require.NoError(t, err)
+
+	cases := []struct {
+		name string
+		// signal, strip, and the inbound body/headers are the whole input.
+		signal      string
+		strip       bool
+		contentType string
+		gzip        bool
+		body        []byte
+		// wantPath is the Cloud signal path; wantVerbatim asserts a
+		// byte-identical relay (with the encoding preserved), otherwise the
+		// body must decode as a stripped trace export.
+		wantPath        string
+		wantVerbatim    bool
+		wantContentType string
+	}{
+		{
+			name: "metrics_relayed_verbatim_even_when_stripping",
+			// strip must never touch metrics: they carry no content.
+			signal: "metrics", strip: true, contentType: "application/x-protobuf", body: metricsBody,
+			wantPath: "/v1/metrics", wantVerbatim: true,
+		},
+		{
+			name:   "gzip_metrics_keeps_encoding",
+			signal: "metrics", strip: true, contentType: "application/x-protobuf", gzip: true, body: metricsBody,
+			wantPath: "/v1/metrics", wantVerbatim: true,
+		},
+		{
+			name:   "full_traces_relayed_verbatim",
+			signal: "traces", strip: false, contentType: "application/x-protobuf", body: tracesBody,
+			wantPath: "/v1/traces", wantVerbatim: true,
+		},
+		{
+			name:   "gzip_full_traces_keeps_encoding",
+			signal: "traces", strip: false, contentType: "application/x-protobuf", gzip: true, body: tracesBody,
+			wantPath: "/v1/traces", wantVerbatim: true,
+		},
+		{
+			name:   "reduced_traces_stripped",
+			signal: "traces", strip: true, contentType: "application/x-protobuf", body: tracesBody,
+			wantPath: "/v1/traces", wantContentType: wire.ContentTypeProto,
+		},
+		{
+			name:   "gzip_reduced_traces_decompressed_then_stripped",
+			signal: "traces", strip: true, contentType: "application/x-protobuf", gzip: true, body: tracesBody,
+			wantPath: "/v1/traces", wantContentType: wire.ContentTypeProto,
+		},
+		{
+			// The JSON branch of stripTracePayload: an exporter configured for
+			// OTLP/JSON must round-trip through the same strip.
+			name:   "reduced_json_traces_stripped",
+			signal: "traces", strip: true, contentType: "application/json", body: tracesJSON,
+			wantPath: "/v1/traces", wantContentType: wire.ContentTypeJSON,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := fakeForwardConfig(t, srv.URL, tc.strip)
+			body, encoding := tc.body, ""
+			if tc.gzip {
+				body, encoding = gzipBytes(t, tc.body), "gzip"
+			}
+			l.enqueue(otlpForwardLabel(tc.signal), func() { l.forwardOTLP(cfg, tc.signal, tc.contentType, encoding, body) })
+			l.wait()
+
+			c := <-received
+			assert.Equal(t, tc.wantPath, c.path)
+			if tc.wantVerbatim {
+				assert.Equal(t, body, c.body)
+				assert.Equal(t, encoding, c.contentEncoding)
+				assert.Equal(t, tc.contentType, c.contentType)
+				return
+			}
+			// The stripped payload is re-marshaled uncompressed, so the gzip
+			// encoding must be dropped.
+			assert.Empty(t, c.contentEncoding)
+			assert.Equal(t, tc.wantContentType, c.contentType)
+			assertTraceStripped(t, c.body, c.contentType)
+		})
+	}
+}
+
+// TestForwardLoader_OTLPHeaderParity covers the OTLP leg authenticating the way
+// the real exporter does: a dedicated OTEL_AUTH_TOKEN wins over AUTH_TOKEN, and
+// an explicit Authorization in OTEL_EXPORTER_OTLP_HEADERS wins over both.
+func TestForwardLoader_OTLPHeaderParity(t *testing.T) {
+	basic := func(tenant, token string) string {
+		v, ok := otel.BasicAuthHeaderValue(tenant, token)
+		require.True(t, ok)
+		return v
+	}
+	cases := []struct {
+		name  string
+		extra map[string]string
+		want  string
+	}{
+		{
+			name: "falls_back_to_auth_token",
+			want: basic("t", "k"),
+		},
+		{
+			name:  "otel_auth_token_wins",
+			extra: map[string]string{"AGENTO11Y_OTEL_AUTH_TOKEN": "gateway"},
+			want:  basic("t", "gateway"),
+		},
+		{
+			name:  "explicit_authorization_header_wins",
+			extra: map[string]string{"OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer explicit"},
+			want:  "Bearer explicit",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearForwardEnv(t)
+			lines := map[string]string{
+				"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": "https://cloud.example.test/",
+				"AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+				"AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT": "https://otlp.example.test",
+			}
+			maps.Copy(lines, tc.extra)
+			cfg := newForwardLoader(writeConfigEnvFile(t, lines), nil).load()
+			require.True(t, cfg.enabled)
+			assert.Equal(t, tc.want, cfg.otlpHeaders["Authorization"])
+			// The generation leg always uses the tenant/token pair.
+			assert.Equal(t, basic("t", "k"), cfg.genHeaders["Authorization"])
+		})
+	}
+}
+
+// TestForwardLoader_InsecureOTLPEndpointStaysLocalGuarded covers the insecure
+// downgrade: OTEL_EXPORTER_OTLP_INSECURE drops https to http the way the
+// exporter does, and the local-receiver guard runs on the resulting URL so the
+// downgrade cannot reintroduce a relay loop.
+func TestForwardLoader_InsecureOTLPEndpointStaysLocalGuarded(t *testing.T) {
+	cases := []struct {
+		name     string
+		otlp     string
+		wantOTLP string
+	}{
+		{name: "downgrades_remote_to_http", otlp: "otlp.example.test:4318", wantOTLP: "http://otlp.example.test:4318"},
+		{name: "downgraded_local_is_dropped", otlp: "127.0.0.1:4318", wantOTLP: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearForwardEnv(t)
+			cfg := newForwardLoader(writeConfigEnvFile(t, map[string]string{
+				"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": "https://cloud.example.test/",
+				"AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+				"AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT": tc.otlp,
+				"OTEL_EXPORTER_OTLP_INSECURE":           "true",
+			}), nil).load()
+			assert.Equal(t, tc.wantOTLP, cfg.otlpEndpoint)
+		})
+	}
+}
+
+// TestForwardLoader_StatusReportsFailures covers the only channel a runtime
+// forward failure reaches the user through: the daemon's logger is discarded
+// unless debug logging is on, so forwardStatus carries the failures since the
+// last success.
+func TestForwardLoader_StatusReportsFailures(t *testing.T) {
+	var status int
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(`{"error":"unknown field parts.media.url"}`))
+	}))
+	defer srv.Close()
+
+	clearForwardEnv(t)
+	l := newForwardLoader(writeConfigEnvFile(t, map[string]string{
+		"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": srv.URL,
+		"AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+	}), nil)
+	l.client = srv.Client()
+	cfg := l.load()
+	require.True(t, cfg.enabled)
+	assert.Empty(t, l.status().Failures)
+
+	status = http.StatusBadRequest
+	raw := generationRawJSON(t, contentRichGeneration(t))
+	l.forwardGenerations(cfg, []json.RawMessage{raw})
+	failures := l.status().Failures
+	require.Len(t, failures, 1)
+	assert.Equal(t, forwardLabelGenerations, failures[0].Label)
+	// The response body is the only place the rejected field name appears.
+	assert.Contains(t, failures[0].Detail, "status 400")
+	assert.Contains(t, failures[0].Detail, "parts.media.url")
+	assert.NotEmpty(t, failures[0].At)
+
+	// A success clears the leg, so a non-empty Failures means "failing now".
+	status = http.StatusOK
+	l.forwardGenerations(cfg, []json.RawMessage{raw})
+	assert.Empty(t, l.status().Failures)
+
+	// Only the leg that delivered is cleared. config.env cannot configure the
+	// OTLP leg at a 127.0.0.1 test server (otlpForwardTarget refuses a loopback
+	// endpoint as a relay loop), so point it at the same server by hand.
+	cfg.otlpEndpoint = srv.URL
+	status = http.StatusBadRequest
+	l.forwardGenerations(cfg, []json.RawMessage{raw})
+	require.Len(t, l.status().Failures, 1)
+
+	status = http.StatusOK
+	l.forwardOTLP(cfg, "metrics", wire.ContentTypeProto, "", []byte("metrics-payload"))
+	failures = l.status().Failures
+	require.Len(t, failures, 1, "a metrics success must not clear a generations failure")
+	assert.Equal(t, forwardLabelGenerations, failures[0].Label)
+
+	l.forwardGenerations(cfg, []json.RawMessage{raw})
+	assert.Empty(t, l.status().Failures)
+}
+
+// TestForwardLoader_StatusReportsUnreadableConfig covers the fail-closed
+// branch: an unreadable config.env disables forwarding and says why, rather
+// than falling back to the daemon's boot-time environment.
+func TestForwardLoader_StatusReportsUnreadableConfig(t *testing.T) {
+	clearForwardEnv(t)
+	t.Setenv(envconfig.PreferredKey("LOCAL_FORWARD"), "true")
+	t.Setenv(envconfig.PreferredKey("ENDPOINT"), "https://cloud.example.test/")
+	t.Setenv(envconfig.PreferredKey("AUTH_TENANT_ID"), "t")
+	t.Setenv(envconfig.PreferredKey("AUTH_TOKEN"), "k")
+
+	// Two ways to be unreadable: os.Stat itself fails (a path whose parent is
+	// a file errors with ENOTDIR rather than IsNotExist), or os.Stat succeeds
+	// and the open fails. Both must refuse to forward, since the daemon's
+	// process environment still holds the boot-time LOCAL_FORWARD=true.
+	t.Run("stat fails", func(t *testing.T) {
+		parent := filepath.Join(t.TempDir(), "not-a-dir")
+		require.NoError(t, os.WriteFile(parent, []byte("x"), 0o600))
+		assertForwardRefusedAsUnreadable(t, filepath.Join(parent, "config.env"))
+	})
+
+	t.Run("open fails", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root ignores file permissions")
+		}
+		path := filepath.Join(t.TempDir(), "config.env")
+		require.NoError(t, os.WriteFile(path, []byte(envconfig.PreferredKey("LOCAL_FORWARD")+"=false\n"), 0o600))
+		require.NoError(t, os.Chmod(path, 0o000))
+
+		l := assertForwardRefusedAsUnreadable(t, path)
+
+		// Chmod changes neither size nor mtime, so the refusal must not be
+		// cached against them: the file's own "off" has to win once it can be
+		// read.
+		require.NoError(t, os.Chmod(path, 0o600))
+		st := l.status()
+		assert.False(t, st.Enabled)
+		assert.Empty(t, st.Reason)
+	})
+}
+
+// assertForwardRefusedAsUnreadable asserts a loader over path forwards nothing
+// and reports the config as unreadable, and returns the loader.
+func assertForwardRefusedAsUnreadable(t *testing.T, path string) *forwardLoader {
+	t.Helper()
+	l := newForwardLoader(path, nil)
+
+	assert.False(t, l.load().enabled)
+	st := l.status()
+	assert.False(t, st.Enabled)
+	assert.Equal(t, forwardModeOff, st.Mode)
+	assert.Contains(t, st.Reason, "config.env unreadable")
+	return l
+}
+
+// TestBuildGenerationPayload_DiscardsUnknownFields covers version skew: a
+// generation from an exporter newer than this daemon must still forward (minus
+// the field the daemon cannot strip) rather than costing the whole batch.
+func TestBuildGenerationPayload_DiscardsUnknownFields(t *testing.T) {
+	raw := json.RawMessage(`{"id":"gen-1","system_prompt":"secret","not_a_field_yet":{"x":1}}`)
+	payload, err := buildGenerationPayload([]json.RawMessage{raw}, true)
+	require.NoError(t, err)
+	req, err := wire.UnmarshalExportGenerationsJSON(payload)
+	require.NoError(t, err)
+	require.Len(t, req.GetGenerations(), 1)
+	assert.Empty(t, req.GetGenerations()[0].GetSystemPrompt())
+	assert.NotContains(t, string(payload), "not_a_field_yet")
+}
+
+// assertTraceStripped decodes an uncompressed OTLP trace export and asserts the
+// content attributes, exception event, and raw error status message were
+// removed while structural attributes and events survive.
+func assertTraceStripped(t *testing.T, body []byte, contentType string) {
+	t.Helper()
+	var got coltracepb.ExportTraceServiceRequest
+	if strings.Contains(contentType, "json") {
+		require.NoError(t, protojson.Unmarshal(body, &got))
+	} else {
+		require.NoError(t, proto.Unmarshal(body, &got))
+	}
+	span := got.GetResourceSpans()[0].GetScopeSpans()[0].GetSpans()[0]
+	keys := attributeKeys(span.GetAttributes())
+	for _, blocked := range []string{
+		"gen_ai.tool.call.arguments", "gen_ai.tool.call.result",
+		"gen_ai.tool.description", metadataKeyConversationTitle,
+		legacyConversationTitleKey, "gen_ai.embeddings.input_texts",
+	} {
+		assert.NotContains(t, keys, blocked)
+	}
+	assert.Contains(t, keys, "gen_ai.tool.name")
+	assert.Contains(t, keys, "gen_ai.usage.input_tokens")
+
+	// Exception event (raw error text) dropped; structural event kept.
+	require.Len(t, span.GetEvents(), 1)
+	assert.Equal(t, "structural-event", span.GetEvents()[0].GetName())
+
+	// The status message carries the same raw provider error the exception
+	// event did, so it is replaced by the classified category.
+	assert.Equal(t, "invalid_request", span.GetStatus().GetMessage())
+	assert.Equal(t, tracepb.Status_STATUS_CODE_ERROR, span.GetStatus().GetCode())
+}
+
+// fakeForwardConfig builds a resolved config that targets the given Cloud URL,
+// bypassing the local-endpoint guard so tests can point at a local TLS server.
+func fakeForwardConfig(t *testing.T, cloudURL string, strip bool) forwardConfig {
+	t.Helper()
+	genURL, err := wire.NormalizeGenerationExportURL(cloudURL, false)
+	require.NoError(t, err)
+	auth, ok := otel.BasicAuthHeaderValue("tenant-x", "token-y")
+	require.True(t, ok)
+	return forwardConfig{
+		enabled:      true,
+		strip:        strip,
+		genURL:       genURL,
+		genHeaders:   map[string]string{"Authorization": auth, wire.TenantHeaderName: "tenant-x"},
+		otlpEndpoint: cloudURL,
+		otlpHeaders:  map[string]string{"Authorization": auth},
+	}
+}
+
+func contentRichGeneration(t *testing.T) *agento11yv1.Generation {
+	t.Helper()
+	return &agento11yv1.Generation{
+		Id:             "gen-1",
+		ConversationId: "conv-1",
+		Model:          &agento11yv1.ModelRef{Provider: "anthropic", Name: "claude"},
+		SystemPrompt:   "secret system prompt",
+		CallError:      "boom: secret detail",
+		Usage:          &agento11yv1.TokenUsage{InputTokens: 10, OutputTokens: 5},
+		Tags:           map[string]string{"env": "test"},
+		Input: []*agento11yv1.Message{
+			{
+				Role: agento11yv1.MessageRole_MESSAGE_ROLE_USER,
+				Parts: []*agento11yv1.Part{
+					{Payload: &agento11yv1.Part_Text{Text: "user secret"}},
+					{Payload: &agento11yv1.Part_Media{Media: &agento11yv1.Media{
+						Kind:     "image",
+						Url:      "data:image/png;base64,SECRET_IMAGE_BYTES",
+						MimeType: "image/png",
+						Name:     "screenshot.png",
+					}}},
+				},
+			},
+			{
+				Role: agento11yv1.MessageRole_MESSAGE_ROLE_TOOL,
+				Parts: []*agento11yv1.Part{{Payload: &agento11yv1.Part_ToolResult{ToolResult: &agento11yv1.ToolResult{
+					ToolCallId:  "t1",
+					Name:        "do_thing",
+					Content:     "secret result",
+					ContentJson: []byte(`{"r":"secret"}`),
+				}}}},
+			},
+		},
+		Output: []*agento11yv1.Message{{
+			Role: agento11yv1.MessageRole_MESSAGE_ROLE_ASSISTANT,
+			Parts: []*agento11yv1.Part{
+				{Payload: &agento11yv1.Part_Thinking{Thinking: "thinking secret"}},
+				{Payload: &agento11yv1.Part_ToolCall{ToolCall: &agento11yv1.ToolCall{
+					Id:        "t1",
+					Name:      "do_thing",
+					InputJson: []byte(`{"arg":"secret"}`),
+				}}},
+			},
+		}},
+		Tools: []*agento11yv1.ToolDefinition{{
+			Name:            "do_thing",
+			Description:     "secret tool description",
+			InputSchemaJson: []byte(`{"type":"object"}`),
+		}},
+		RawArtifacts: []*agento11yv1.Artifact{{
+			Kind:    agento11yv1.ArtifactKind_ARTIFACT_KIND_REQUEST,
+			Payload: []byte("secret raw artifact"),
+		}},
+		Metadata: mustStruct(t, map[string]any{
+			model.MetadataKeyContentCaptureMode: "full",
+			metadataKeyConversationTitle:        "secret title",
+			legacyConversationTitleKey:          "secret legacy title",
+			metadataKeyCallError:                "boom: secret detail",
+			"keep_me":                           "structural",
+		}),
+	}
+}
+
+func generationRawJSON(t *testing.T, g *agento11yv1.Generation) json.RawMessage {
+	t.Helper()
+	envelope, err := wire.MarshalExportGenerationsJSON(&agento11yv1.ExportGenerationsRequest{
+		Generations: []*agento11yv1.Generation{g},
+	})
+	require.NoError(t, err)
+	var req generationsRequest
+	require.NoError(t, json.Unmarshal(envelope, &req))
+	require.Len(t, req.Generations, 1)
+	return req.Generations[0]
+}
+
+func traceRequestWithContent() *coltracepb.ExportTraceServiceRequest {
+	span := &tracepb.Span{
+		Name: "chat claude",
+		// The SDK builds the status message from the same raw provider error it
+		// records on the exception event, so it can echo prompt fragments.
+		Status: &tracepb.Status{
+			Code:    tracepb.Status_STATUS_CODE_ERROR,
+			Message: "secret provider error: messages.1.content secret prompt fragment",
+		},
+		Attributes: []*commonpb.KeyValue{
+			stringKV(spanAttrErrorCategory, "invalid_request"),
+			stringKV("gen_ai.tool.call.arguments", "secret args"),
+			stringKV("gen_ai.tool.call.result", "secret result"),
+			stringKV("gen_ai.tool.description", "secret description"),
+			stringKV(metadataKeyConversationTitle, "secret title"),
+			stringKV(legacyConversationTitleKey, "secret legacy title"),
+			stringKV("gen_ai.embeddings.input_texts", "secret texts"),
+			stringKV("gen_ai.tool.name", "do_thing"),
+			stringKV("gen_ai.usage.input_tokens", "10"),
+		},
+		Events: []*tracepb.Span_Event{
+			{Name: "exception", Attributes: []*commonpb.KeyValue{stringKV("exception.message", "secret error text")}},
+			{Name: "structural-event", Attributes: []*commonpb.KeyValue{stringKV("gen_ai.tool.name", "do_thing")}},
+		},
+	}
+	return &coltracepb.ExportTraceServiceRequest{
+		ResourceSpans: []*tracepb.ResourceSpans{{
+			ScopeSpans: []*tracepb.ScopeSpans{{Spans: []*tracepb.Span{span}}},
+		}},
+	}
+}
+
+func stringKV(key, value string) *commonpb.KeyValue {
+	return &commonpb.KeyValue{
+		Key:   key,
+		Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: value}},
+	}
+}
+
+func gzipBytes(t *testing.T, in []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write(in)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func attributeKeys(attrs []*commonpb.KeyValue) []string {
+	out := make([]string, 0, len(attrs))
+	for _, kv := range attrs {
+		out = append(out, kv.GetKey())
+	}
+	return out
+}
+
+func mustStruct(t *testing.T, m map[string]any) *structpb.Struct {
+	t.Helper()
+	s, err := structpb.NewStruct(m)
+	require.NoError(t, err)
+	return s
+}

--- a/plugins/agento11y/internal/local/server.go
+++ b/plugins/agento11y/internal/local/server.go
@@ -31,6 +31,7 @@ type Server struct {
 	now        func() time.Time
 	configPath string
 	mux        *http.ServeMux
+	forward    *forwardLoader
 	hub        *eventHub
 	// eventPingInterval overrides defaultEventPingInterval for tests; zero
 	// uses the default.
@@ -39,7 +40,8 @@ type Server struct {
 
 // NewServer builds a Server backed by the given storage. logger may be
 // nil — the server logs only diagnostic information. configPath is the
-// dotenv file the Settings API reads and writes; an empty path disables
+// dotenv file the Settings API reads and writes, and the same file the
+// Cloud forwarder resolves its configuration from; an empty path disables
 // persistence (reads return defaults, writes fail) but keeps the rest of
 // the server usable for tests.
 func NewServer(storage *Storage, logger *log.Logger, configPath string) *Server {
@@ -51,6 +53,7 @@ func NewServer(storage *Storage, logger *log.Logger, configPath string) *Server 
 		logger:     logger,
 		configPath: configPath,
 		now:        func() time.Time { return time.Now().UTC() },
+		forward:    newForwardLoader(configPath, logger),
 		hub:        newEventHub(),
 	}
 	s.mux = s.routes()
@@ -185,17 +188,19 @@ func (s *Server) handleGenerations(w http.ResponseWriter, r *http.Request) {
 
 	receivedAt := s.now().Format(time.RFC3339Nano)
 	resp := generationsResponse{Results: make([]generationResult, 0, len(req.Generations))}
+	accepted := make([]json.RawMessage, 0, len(req.Generations))
 	for _, raw := range req.Generations {
 		var gen storedGeneration
 		if err := json.Unmarshal(raw, &gen); err != nil {
 			resp.Results = append(resp.Results, generationResult{Accepted: false, Error: "decode generation: " + err.Error()})
 			continue
 		}
+		stored := append(json.RawMessage(nil), raw...)
 		rec := generationRecord{
 			ReceivedAt:     receivedAt,
 			GenerationID:   gen.ID,
 			ConversationID: gen.ConversationID,
-			Generation:     append(json.RawMessage(nil), raw...),
+			Generation:     stored,
 		}
 		if err := s.storage.AppendGeneration(rec); err != nil {
 			s.logger.Printf("local: append generations: %v", err)
@@ -206,6 +211,7 @@ func (s *Server) handleGenerations(w http.ResponseWriter, r *http.Request) {
 			})
 			continue
 		}
+		accepted = append(accepted, stored)
 		resp.Results = append(resp.Results, generationResult{
 			GenerationID: gen.ID,
 			Accepted:     true,
@@ -219,6 +225,18 @@ func (s *Server) handleGenerations(w http.ResponseWriter, r *http.Request) {
 			GenerationID:   gen.ID,
 		})
 	}
+
+	// Best-effort Cloud forwarding runs after the local store so a Cloud
+	// failure can never affect the JSONL write or the ack below. Off by
+	// default: when forwarding is disabled load() returns enabled=false and we
+	// spawn nothing.
+	if len(accepted) > 0 && !isForwardedRequest(r) {
+		if cfg := s.forward.load(); cfg.enabled {
+			gens := accepted
+			s.forward.enqueue(forwardLabelGenerations, func() { s.forward.forwardGenerations(cfg, gens) })
+		}
+	}
+
 	s.writeJSON(w, http.StatusOK, resp)
 }
 
@@ -226,6 +244,9 @@ func (s *Server) handleGenerations(w http.ResponseWriter, r *http.Request) {
 // leak spans or metrics to a user-configured global collector. The viewer
 // does not read these signals yet, so the endpoint drains and acknowledges
 // them without persisting a second local data model.
+//
+// When Cloud forwarding is enabled the payload is also relayed to the
+// configured Cloud OTLP endpoint.
 func (s *Server) handleOTLP(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxOTLPBodyBytes+1))
 	if err != nil {
@@ -236,6 +257,17 @@ func (s *Server) handleOTLP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "body too large", http.StatusRequestEntityTooLarge)
 		return
 	}
+
+	// Best-effort Cloud forwarding: metrics relay unchanged, trace content is
+	// stripped under a reduced content mode inside forwardOTLP.
+	if signal := otlpSignalFromPath(r.URL.Path); signal != "" && !isForwardedRequest(r) {
+		if cfg := s.forward.load(); cfg.enabled {
+			contentType := r.Header.Get("Content-Type")
+			contentEncoding := r.Header.Get("Content-Encoding")
+			s.forward.enqueue(otlpForwardLabel(signal), func() { s.forward.forwardOTLP(cfg, signal, contentType, contentEncoding, body) })
+		}
+	}
+
 	// OTLP/HTTP collectors return an empty protobuf message on success;
 	// 200 + empty body is accepted by the otlphttp exporter.
 	w.Header().Set("Content-Type", "application/octet-stream")
@@ -272,10 +304,15 @@ func (s *Server) handleHookEvaluate(w http.ResponseWriter, r *http.Request) {
 // path for the file. It never includes the endpoint, tenant id, or auth
 // token — those keys are not part of Settings and are never read back into
 // the response.
+//
+// It also carries the daemon's current Cloud forwarding posture so the viewer
+// can show what would leave this machine right now, including a reason when
+// the user opted in but the target is unusable.
 type configResponse struct {
-	Settings Settings `json:"settings"`
-	Preview  string   `json:"preview"`
-	Path     string   `json:"path"`
+	Settings      Settings      `json:"settings"`
+	Preview       string        `json:"preview"`
+	Path          string        `json:"path"`
+	ForwardStatus forwardStatus `json:"forwardStatus"`
 }
 
 // configRequest is the POST :preview / PUT body: the form state the viewer
@@ -336,9 +373,10 @@ func (s *Server) writeConfigResponse(w http.ResponseWriter, settings Settings) {
 		return
 	}
 	s.writeJSON(w, http.StatusOK, configResponse{
-		Settings: settings,
-		Preview:  string(preview),
-		Path:     displayConfigPath(s.configPath),
+		Settings:      settings,
+		Preview:       string(preview),
+		Path:          displayConfigPath(s.configPath),
+		ForwardStatus: s.forward.status(),
 	})
 }
 

--- a/plugins/agento11y/internal/local/server_test.go
+++ b/plugins/agento11y/internal/local/server_test.go
@@ -12,9 +12,13 @@ import (
 	"testing"
 
 	"github.com/grafana/agento11y/go/agento11y"
+	"github.com/grafana/agento11y/go/agento11y/model"
+	"github.com/grafana/agento11y/go/proto/agento11y/wire"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/dotenv"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestServer_GenerationsExport_RecordsAndAccepts(t *testing.T) {
@@ -400,6 +404,10 @@ func TestServer_APIConversations_EmptyStorage(t *testing.T) {
 
 func newTestServer(t *testing.T) (*Server, string) {
 	t.Helper()
+	// The forward loader falls back to the process environment, so a developer
+	// with forwarding and real credentials exported would otherwise have this
+	// suite POST to their live tenant.
+	clearForwardEnv(t)
 	dir := filepath.Join(t.TempDir(), "local")
 	storage, err := NewStorage(dir)
 	if err != nil {
@@ -529,9 +537,15 @@ func TestServer_Config_RoundTrip(t *testing.T) {
 	assert.Empty(t, got.Settings.Capture) // unset until the user picks a mode
 	assert.True(t, got.Settings.AutoUpdate)
 	assert.Equal(t, guardsOff, got.Settings.Guards)
+	assert.False(t, got.Settings.LocalForward)
+	assert.Equal(t, forwardStatus{Mode: forwardModeOff}, got.ForwardStatus)
+	assert.Empty(t, got.ForwardStatus.Reason, "forwarding off by default is not a paused state")
 
 	// Save a non-default configuration.
 	resp := putConfig(t, srv, Settings{
+		Endpoint:     "https://cloud.example.test",
+		TenantID:     "12345",
+		Token:        "glc_token",
 		Capture:      "metadata_only",
 		Tags:         []Tag{{Key: "team", Value: "ai"}},
 		Guards:       guardsFailClosed,
@@ -539,6 +553,7 @@ func TestServer_Config_RoundTrip(t *testing.T) {
 		Debug:        true,
 		AutoUpdate:   false,
 		UserID:       "alice",
+		LocalForward: true,
 	})
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -550,12 +565,25 @@ func TestServer_Config_RoundTrip(t *testing.T) {
 	assert.True(t, saved.Settings.Debug)
 	assert.False(t, saved.Settings.AutoUpdate)
 	assert.Equal(t, "alice", saved.Settings.UserID)
+	assert.True(t, saved.Settings.LocalForward)
+	// The saved toggle plus usable credentials resolve to a live forwarding
+	// posture, reduced to metadata_only by the saved capture mode. No OTLP
+	// endpoint was configured, so that leg reports why it stays off.
+	assert.Equal(t, forwardStatus{
+		Enabled:     true,
+		Mode:        forwardModeMetadataOnly,
+		Generations: true,
+		OTLPReason:  "no OTLP endpoint configured, so traces and metrics are not forwarded",
+	}, saved.ForwardStatus)
 
 	// Preview and on-disk file agree, sorted with the managed header.
 	onDisk, err := os.ReadFile(configPathFor(dir))
 	require.NoError(t, err)
 	assert.Contains(t, string(onDisk), "SIGIL_CONTENT_CAPTURE_MODE=metadata_only")
 	assert.Contains(t, string(onDisk), "SIGIL_GUARDS_TIMEOUT_MS=2000")
+	// Both spellings are written so an older binary still reads the toggle.
+	assert.Contains(t, string(onDisk), "AGENTO11Y_LOCAL_FORWARD=true")
+	assert.Contains(t, string(onDisk), "SIGIL_LOCAL_FORWARD=true")
 	assert.Contains(t, saved.Preview, "SIGIL_USER_ID=alice")
 	assert.True(t, strings.HasPrefix(saved.Preview, "# Managed by `agento11y login`."))
 
@@ -588,6 +616,11 @@ func TestServer_Config_Preview(t *testing.T) {
 	// Opt-out/opt-in keys at their defaults must not appear.
 	assert.NotContains(t, got.Preview, "SIGIL_AUTO_UPDATE")
 	assert.NotContains(t, got.Preview, "SIGIL_DEBUG")
+	// LOCAL_FORWARD is the exception: off is written as an explicit false,
+	// because the daemon prefers config.env and a missing key cannot override
+	// the value it inherited into its own environment at boot.
+	assert.Contains(t, got.Preview, "AGENTO11Y_LOCAL_FORWARD=false")
+	assert.Contains(t, got.Preview, "SIGIL_LOCAL_FORWARD=false")
 	// Preview is read-only: no file should have been created.
 	_, statErr := os.Stat(configPathFor(dir))
 	assert.True(t, os.IsNotExist(statErr))
@@ -658,6 +691,168 @@ func TestServer_Config_RejectsBadBody(t *testing.T) {
 	resp := post(t, srv, "/api/v1/config:preview", "application/json", "{not json")
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	resp.Body.Close()
+}
+
+// newForwardingTestServer builds a server whose config.env enables (or not)
+// Cloud forwarding to the given fake Cloud server. The forward client is
+// pointed at the fake server so its self-signed TLS cert is trusted.
+func newForwardingTestServer(t *testing.T, cloud *httptest.Server, env map[string]string) (*Server, string) {
+	t.Helper()
+	clearForwardEnv(t)
+	dir := filepath.Join(t.TempDir(), "local")
+	storage, err := NewStorage(dir)
+	require.NoError(t, err)
+	s := NewServer(storage, nil, writeConfigEnvFile(t, env))
+	s.forward.client = cloud.Client()
+	return s, dir
+}
+
+// TestServer_Forwarding_OffByDefault covers the opt-in guarantee: without the
+// LOCAL_FORWARD toggle the daemon stores locally and never contacts Cloud.
+func TestServer_Forwarding_OffByDefault(t *testing.T) {
+	hits := make(chan struct{}, 8)
+	cloud := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer cloud.Close()
+
+	s, dir := newForwardingTestServer(t, cloud, map[string]string{
+		"AGENTO11Y_ENDPOINT": cloud.URL, "AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+	})
+
+	postDiscard(t, s, "/api/v1/generations:export", "application/json",
+		`{"generations":[{"id":"gen-1","conversation_id":"conv-A","model":{"name":"m"}}]}`)
+	postDiscard(t, s, "/otlp/v1/traces", "application/x-protobuf", "")
+	s.forward.wait()
+
+	assert.Len(t, readLines(t, filepath.Join(dir, ConversationsDir, "conv-A.jsonl")), 1)
+	assert.Empty(t, hits, "no Cloud request should be made when forwarding is off")
+}
+
+// TestServer_Forwarding_OnForwardsGeneration covers the toggle-on path through
+// the handler: a stored generation is also POSTed to Cloud, stripped to the
+// configured (default metadata_only) content level.
+func TestServer_Forwarding_OnForwardsGeneration(t *testing.T) {
+	received := make(chan []byte, 1)
+	var gotPath string
+	cloud := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		received <- b
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer cloud.Close()
+
+	s, dir := newForwardingTestServer(t, cloud, map[string]string{
+		"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": cloud.URL,
+		"AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+	})
+
+	postDiscard(t, s, "/api/v1/generations:export", "application/json",
+		`{"generations":[{"id":"gen-1","conversation_id":"conv-A","model":{"provider":"p","name":"m"},"system_prompt":"secret"}]}`)
+	s.forward.wait()
+
+	// The local store keeps the full content the forwarded copy dropped.
+	lines := readLines(t, filepath.Join(dir, ConversationsDir, "conv-A.jsonl"))
+	require.Len(t, lines, 1)
+	assert.Contains(t, lines[0], "secret")
+
+	body := <-received
+	assert.Equal(t, wire.GenerationExportHTTPPath, gotPath)
+	req, err := wire.UnmarshalExportGenerationsJSON(body)
+	require.NoError(t, err)
+	require.Len(t, req.GetGenerations(), 1)
+	g := req.GetGenerations()[0]
+	assert.Equal(t, "gen-1", g.GetId())
+	assert.Empty(t, g.GetSystemPrompt(), "default content mode strips the forwarded copy")
+	assert.Equal(t, "metadata_only", g.GetMetadata().GetFields()[model.MetadataKeyContentCaptureMode].GetStringValue())
+}
+
+// TestServer_Forwarding_FailureKeepsLocalStore covers the best-effort
+// guarantee: a Cloud failure leaves the local store and the child's ack intact.
+func TestServer_Forwarding_FailureKeepsLocalStore(t *testing.T) {
+	cloud := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer cloud.Close()
+
+	s, dir := newForwardingTestServer(t, cloud, map[string]string{
+		"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": cloud.URL,
+		"AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+	})
+
+	resp := post(t, s, "/api/v1/generations:export", "application/json",
+		`{"generations":[{"id":"gen-1","conversation_id":"conv-A","model":{"name":"m"}}]}`)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var out generationsResponse
+	decodeJSON(t, resp.Body, &out)
+	require.Len(t, out.Results, 1)
+	assert.True(t, out.Results[0].Accepted, "child ack succeeds despite Cloud failure")
+
+	s.forward.wait()
+	assert.Len(t, readLines(t, filepath.Join(dir, ConversationsDir, "conv-A.jsonl")), 1)
+}
+
+// TestServer_Forwarding_RejectedGenerationNotForwarded covers the ordering
+// contract: only generations the local store accepted are relayed.
+func TestServer_Forwarding_RejectedGenerationNotForwarded(t *testing.T) {
+	received := make(chan []byte, 1)
+	cloud := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		received <- b
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer cloud.Close()
+
+	s, _ := newForwardingTestServer(t, cloud, map[string]string{
+		"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": cloud.URL,
+		"AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+	})
+
+	postDiscard(t, s, "/api/v1/generations:export", "application/json",
+		`{"generations":["not-an-object",{"id":"gen-ok","conversation_id":"conv-A","model":{"name":"m"}}]}`)
+	s.forward.wait()
+
+	req, err := wire.UnmarshalExportGenerationsJSON(<-received)
+	require.NoError(t, err)
+	require.Len(t, req.GetGenerations(), 1)
+	assert.Equal(t, "gen-ok", req.GetGenerations()[0].GetId())
+}
+
+// TestServer_Forwarding_RelaysOTLP covers the OTLP leg through the handler:
+// traces are relayed to the configured Cloud OTLP endpoint (stripped, because
+// the default content mode is reduced) while the local ack stays a 200.
+func TestServer_Forwarding_RelaysOTLP(t *testing.T) {
+	type capture struct {
+		path string
+		body []byte
+	}
+	received := make(chan capture, 2)
+	cloud := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		received <- capture{path: r.URL.Path, body: b}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer cloud.Close()
+
+	s, _ := newForwardingTestServer(t, cloud, map[string]string{
+		"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": cloud.URL,
+		"AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+		"AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT": cloud.URL,
+	})
+
+	traces, err := proto.Marshal(traceRequestWithContent())
+	require.NoError(t, err)
+	resp := postBytes(t, s, "/otlp/v1/traces", "application/x-protobuf", traces)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	s.forward.wait()
+
+	c := <-received
+	assert.Equal(t, "/v1/traces", c.path)
+	assertTraceStripped(t, c.body, wire.ContentTypeProto)
 }
 
 // TestServer_APISearch covers the /api/v1/search endpoint: empty query,
@@ -779,4 +974,83 @@ func TestServer_DevAsset_EnvPrecedence(t *testing.T) {
 		t.Setenv("SIGIL_LOCAL_WEB_DIR", legacy)
 		assert.Equal(t, "// legacy", fetchJSX())
 	})
+}
+
+// TestServer_Forwarding_ToggleOffStopsForwarding covers the config.env write
+// path end to end for the case the daemon's own environment disagrees: `local
+// serve` materializes config.env into its process env at boot, so a deleted key
+// would leave forwarding on. Saving Off must write an explicit false and stop
+// the relay without a daemon restart.
+func TestServer_Forwarding_ToggleOffStopsForwarding(t *testing.T) {
+	hits := make(chan struct{}, 4)
+	cloud := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer cloud.Close()
+
+	s, _ := newForwardingTestServer(t, cloud, map[string]string{
+		"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": cloud.URL,
+		"AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+	})
+	// What dotenv.ApplyEnv(nil) does at daemon start: both spellings of every
+	// config.env key land in the daemon's own environment.
+	t.Setenv(envconfig.PreferredKey("LOCAL_FORWARD"), "true")
+	t.Setenv(envconfig.LegacyKey("LOCAL_FORWARD"), "true")
+	require.True(t, s.forward.load().enabled)
+
+	resp := putConfig(t, s, Settings{
+		Endpoint: cloud.URL,
+		TenantID: "t",
+		Guards:   guardsOff,
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var saved configResponse
+	decodeJSON(t, resp.Body, &saved)
+	assert.False(t, saved.Settings.LocalForward)
+	assert.Equal(t, forwardStatus{Mode: forwardModeOff}, saved.ForwardStatus)
+
+	onDisk, err := os.ReadFile(s.configPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(onDisk), "AGENTO11Y_LOCAL_FORWARD=false")
+
+	postDiscard(t, s, "/api/v1/generations:export", "application/json",
+		`{"generations":[{"id":"gen-1","conversation_id":"conv-A","model":{"name":"m"}}]}`)
+	s.forward.wait()
+	assert.Empty(t, hits, "forwarding must stop as soon as config.env says false")
+}
+
+// TestServer_Forwarding_DoesNotRelayForwardedPayload covers the loop guard: a
+// payload that already carries another daemon's forward marker is stored but
+// not forwarded again, so two daemons pointed at each other (or one pointed at
+// itself) exchange one copy instead of looping.
+func TestServer_Forwarding_DoesNotRelayForwardedPayload(t *testing.T) {
+	hits := make(chan struct{}, 4)
+	cloud := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer cloud.Close()
+
+	s, dir := newForwardingTestServer(t, cloud, map[string]string{
+		"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": cloud.URL,
+		"AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+		"AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT": cloud.URL,
+	})
+
+	for _, path := range []string{"/api/v1/generations:export", "/otlp/v1/traces"} {
+		req := httptest.NewRequest(http.MethodPost, path,
+			strings.NewReader(`{"generations":[{"id":"gen-1","conversation_id":"conv-A","model":{"name":"m"}}]}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(forwardMarkerHeader, "1")
+		rr := httptest.NewRecorder()
+		s.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+	}
+	s.forward.wait()
+
+	// Stored locally, never relayed.
+	assert.Len(t, readLines(t, filepath.Join(dir, ConversationsDir, "conv-A.jsonl")), 1)
+	assert.Empty(t, hits)
 }

--- a/plugins/agento11y/internal/local/settings.go
+++ b/plugins/agento11y/internal/local/settings.go
@@ -54,6 +54,12 @@ type Settings struct {
 	Debug        bool   `json:"debug"`
 	AutoUpdate   bool   `json:"autoUpdate"`
 	UserID       string `json:"userId"`
+	// LocalForward mirrors AGENTO11Y_LOCAL_FORWARD: when on, a `--local`
+	// daemon also forwards the telemetry it captures to Grafana Cloud. The
+	// local viewer always keeps full content; Capture reduces the forwarded
+	// copy (full vs metadata_only) and, being the shared
+	// CONTENT_CAPTURE_MODE key, also applies to non-local Cloud sessions.
+	LocalForward bool `json:"localForward"`
 }
 
 // ParseSettings hydrates Settings from a dotenv map (as returned by
@@ -65,10 +71,8 @@ type Settings struct {
 // enabled.
 func ParseSettings(env map[string]string) Settings {
 	fam := func(suffix string) string {
-		if v := strings.TrimSpace(env[envconfig.PreferredKey(suffix)]); v != "" {
-			return v
-		}
-		return strings.TrimSpace(env[envconfig.LegacyKey(suffix)])
+		v, _, _ := envconfig.LookupMap(env, suffix)
+		return v
 	}
 	return Settings{
 		Endpoint:     fam("ENDPOINT"),
@@ -83,8 +87,9 @@ func ParseSettings(env map[string]string) Settings {
 		Debug:        envconfig.ParseBoolDefault(fam("DEBUG"), false),
 		// AUTO_UPDATE is opt-out: unset means enabled. This matches
 		// updatecheck.Disabled (only explicit falsey values disable updates).
-		AutoUpdate: envconfig.ParseBoolDefault(fam("AUTO_UPDATE"), true),
-		UserID:     fam("USER_ID"),
+		AutoUpdate:   envconfig.ParseBoolDefault(fam("AUTO_UPDATE"), true),
+		UserID:       fam("USER_ID"),
+		LocalForward: envconfig.ParseBoolDefault(fam("LOCAL_FORWARD"), false),
 	}
 }
 
@@ -150,6 +155,17 @@ func (s Settings) Updates() map[string]string {
 		u["SIGIL_AUTO_UPDATE"] = ""
 	} else {
 		u["SIGIL_AUTO_UPDATE"] = "false"
+	}
+
+	// SIGIL_LOCAL_FORWARD is written explicitly in both directions rather than
+	// deleted when off, the same trick SIGIL_AUTO_UPDATE uses above. The local
+	// daemon materializes its own environment from config.env at boot and falls
+	// back to it, so a deleted key cannot express "off": only an explicit false
+	// on disk turns a running daemon's forwarding off.
+	if s.LocalForward {
+		u["SIGIL_LOCAL_FORWARD"] = "true"
+	} else {
+		u["SIGIL_LOCAL_FORWARD"] = "false"
 	}
 
 	u["SIGIL_USER_ID"] = strings.TrimSpace(s.UserID)

--- a/plugins/agento11y/internal/local/settings_test.go
+++ b/plugins/agento11y/internal/local/settings_test.go
@@ -34,6 +34,7 @@ func TestParseSettings(t *testing.T) {
 				"SIGIL_DEBUG":                "true",
 				"SIGIL_AUTO_UPDATE":          "false",
 				"SIGIL_USER_ID":              "alice",
+				"SIGIL_LOCAL_FORWARD":        "true",
 			},
 			want: Settings{
 				Capture:      "metadata_only",
@@ -43,7 +44,21 @@ func TestParseSettings(t *testing.T) {
 				Debug:        true,
 				AutoUpdate:   false,
 				UserID:       "alice",
+				LocalForward: true,
 			},
+		},
+		{
+			name: "local forward is opt-in and only truthy values enable it",
+			env:  map[string]string{"SIGIL_LOCAL_FORWARD": "nope"},
+			want: Settings{Capture: "", Tags: []Tag{}, Guards: guardsOff, AutoUpdate: true},
+		},
+		{
+			name: "preferred local forward spelling wins over legacy",
+			env: map[string]string{
+				"AGENTO11Y_LOCAL_FORWARD": "true",
+				"SIGIL_LOCAL_FORWARD":     "false",
+			},
+			want: Settings{Capture: "", Tags: []Tag{}, Guards: guardsOff, AutoUpdate: true, LocalForward: true},
 		},
 		{
 			name: "advanced capture mode is preserved",
@@ -180,6 +195,21 @@ func TestSettingsUpdates(t *testing.T) {
 				"SIGIL_USER_ID":              "",
 			},
 		},
+		{
+			name: "local forward on is written",
+			in:   Settings{Capture: "full", Guards: guardsOff, AutoUpdate: true, LocalForward: true},
+			want: map[string]string{
+				"SIGIL_CONTENT_CAPTURE_MODE": "full",
+				"SIGIL_TAGS":                 "",
+				"SIGIL_GUARDS_ENABLED":       "false",
+				"SIGIL_GUARDS_FAIL_OPEN":     "",
+				"SIGIL_GUARDS_TIMEOUT_MS":    "",
+				"SIGIL_DEBUG":                "",
+				"SIGIL_AUTO_UPDATE":          "",
+				"SIGIL_USER_ID":              "",
+				"SIGIL_LOCAL_FORWARD":        "true",
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -191,6 +221,12 @@ func TestSettingsUpdates(t *testing.T) {
 			want["SIGIL_ENDPOINT"] = ""
 			want["SIGIL_AUTH_TENANT_ID"] = ""
 			want["SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT"] = ""
+			// LOCAL_FORWARD is written explicitly in both directions: only a
+			// literal false on disk can override the value the daemon
+			// materialized into its own environment at boot.
+			if _, ok := want["SIGIL_LOCAL_FORWARD"]; !ok {
+				want["SIGIL_LOCAL_FORWARD"] = "false"
+			}
 			assert.Equal(t, envconfig.ExpandAliases(want), tc.in.Updates())
 		})
 	}
@@ -254,6 +290,7 @@ func TestSettingsRoundTrip(t *testing.T) {
 		Debug:        true,
 		AutoUpdate:   false,
 		UserID:       "alice",
+		LocalForward: true,
 	}
 	got := ParseSettings(in.Updates())
 	assert.Equal(t, in, got)

--- a/plugins/agento11y/internal/local/web/app.jsx
+++ b/plugins/agento11y/internal/local/web/app.jsx
@@ -1432,7 +1432,7 @@
       );
     }
 
-    function ConversationsView({ conversations, tokenPoints, loading, error, query, setQuery, searchInputRef, timeRange, setTimeRange, tokenModel, setTokenModel, chartMetric, setChartMetric, bucketSel, setBucketSel, listSort, setListSort, onOpen, onRefresh, refreshing }) {
+    function ConversationsView({ conversations, tokenPoints, loading, error, query, setQuery, searchInputRef, timeRange, setTimeRange, tokenModel, setTokenModel, chartMetric, setChartMetric, bucketSel, setBucketSel, listSort, setListSort, onOpen, onRefresh, refreshing, onOpenSettings }) {
       const now = Date.now();
       const prices = useModelPrices();
       const range = timeRangeOption(timeRange);
@@ -1711,6 +1711,7 @@
               {searchActive ? "Full-text search runs across all captured sessions." : "Local traces, token accounting, and model usage from this viewer."}
             </Box>
           </PageHero>
+          <ForwardBanner onOpenSettings={onOpenSettings}/>
           <FilterBar
             query={query}
             onQueryChange={setQuery}
@@ -2988,6 +2989,118 @@
       return { ...s, tags: (s.tags || []).map(t => ({ ...t })) };
     }
 
+    // forwardBannerMeta turns the daemon's reported forwarding status into the
+    // pill, accent, and sentence the banner and the settings hero both show.
+    // The saved toggle is deliberately not an input: config.env and the
+    // daemon's own environment can disagree, and only the daemon knows what it
+    // would actually send.
+    function forwardBannerMeta(st) {
+      if (!st) {
+        return { accent: "warning", pill: "Unknown", line: "Couldn't read the daemon's forwarding status." };
+      }
+      if (!st.enabled) {
+        if (st.reason) return { accent: "warning", pill: "Paused", line: `Forwarding is on but paused: ${st.reason}` };
+        return { accent: "success", pill: "Off", line: "Cloud forwarding is off — nothing from local sessions leaves this device." };
+      }
+      const failure = (st.failures || [])[0];
+      if (failure) {
+        return { accent: "error", pill: "Failing", line: `Forwarding is on but the last attempts failed — ${failure.label}: ${failure.detail}` };
+      }
+      // An unrecognised mode must not read as the narrower one: a future mode
+      // could forward more, not less.
+      if (st.mode !== "full" && st.mode !== "metadata_only") {
+        return { accent: "warning", pill: "On", line: `Forwarding is on in a mode this viewer does not know (${st.mode || "unset"}).` };
+      }
+      const parts = [st.mode === "full"
+        ? "Full session content is forwarded to your organization's Grafana Cloud."
+        : "Only usage and session metadata is forwarded — prompts, responses, reasoning text, tool inputs/results, and attached media stay local."];
+      if (!st.generations && st.reason) parts.push(`Generations are paused: ${st.reason}`);
+      if (!st.otlp) parts.push("Traces and metrics are not forwarded.");
+      return {
+        accent: st.mode === "full" ? "warning" : "info",
+        pill: st.mode === "full" ? "Full content" : "Metadata only",
+        line: parts.join(" "),
+      };
+    }
+
+    // ForwardBanner shows what the daemon would send to Cloud, above the
+    // session list. The daemon is shared, so this is machine-wide policy for
+    // every later --local session, not a property of the sessions listed below.
+    //
+    // It is read-only. Changing it means a full config.env write, which the
+    // Cloud settings tab owns; a second writer here would silently revert a
+    // config.env change made after this component mounted.
+    function ForwardBanner({ onOpenSettings }) {
+      const [st, setSt] = useState(null);
+      const [loaded, setLoaded] = useState(false);
+      useEffect(() => {
+        let alive = true;
+        const load = () => {
+          fetch("/api/v1/config")
+            .then(r => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)))
+            .then(b => { if (alive) setSt(b && b.forwardStatus ? b.forwardStatus : null); })
+            .catch(() => { if (alive) setSt(null); })
+            .finally(() => { if (alive) setLoaded(true); });
+        };
+        load();
+        // The daemon re-reads config.env whenever it changes, so the posture
+        // moves under an open viewer (an edit, a second tab, agento11y login).
+        // A privacy disclosure that froze at mount would be the wrong default.
+        const id = setInterval(load, 30_000);
+        return () => { alive = false; clearInterval(id); };
+      }, []);
+      if (!loaded) return null;
+      const meta = forwardBannerMeta(st);
+      const accent = meta.accent;
+      return (
+        <div style={{ display: "flex", alignItems: "center", gap: 12, padding: "10px 14px", marginBottom: 14, borderRadius: 2, border: "1px solid var(--border-weak)", borderLeft: `3px solid var(--${accent}-border)`, background: `var(--${accent}-transparent)` }}>
+          <Icon name="cloud" size={15} style={{ color: `var(--${accent}-text)`, flex: "none" }}/>
+          <span style={{ fontSize: 10.5, textTransform: "uppercase", letterSpacing: 0.6, color: "var(--fg3)", flex: "none" }}>What leaves this machine</span>
+          <span style={{ fontSize: 12.5, fontWeight: 600, color: `var(--${accent}-text)`, flex: "none" }}>{meta.pill}</span>
+          <span title={meta.line} style={{ fontSize: 12.5, color: "var(--fg2)", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{meta.line}</span>
+          <span style={{ flex: 1 }}/>
+          <button type="button" onClick={() => onOpenSettings && onOpenSettings("cloud")} style={{
+            flex: "none", background: "transparent", border: "1px solid var(--border-medium)", borderRadius: 2,
+            color: "var(--fg2)", fontSize: 11.5, fontFamily: "var(--fontFamily)", padding: "3px 9px", cursor: "pointer",
+          }}>Change</button>
+        </div>
+      );
+    }
+
+    // captureForwardMode reports which of the two segmented values a
+    // CONTENT_CAPTURE_MODE forwards as. Everything that is not "full" is
+    // reduced to metadata by the forwarder, so the advanced modes
+    // (no_tool_content, full_with_metadata_spans) read as metadata_only.
+    function captureForwardMode(capture) {
+      return capture === "full" ? "full" : "metadata_only";
+    }
+
+    // forwardLocalMode collapses the two persisted keys the forwarding control
+    // spans (LOCAL_FORWARD and CONTENT_CAPTURE_MODE) into the one segmented
+    // value the UI shows.
+    function forwardLocalMode(form) {
+      if (!form.localForward) return "off";
+      return captureForwardMode(form.capture);
+    }
+
+    // applyForwardLocalMode writes the segmented value back onto both keys.
+    // capture is only rewritten when the mode already set forwards differently,
+    // so an advanced mode set in config.env survives a round-trip through the
+    // toggle: turning the control off leaves capture alone, and picking
+    // Metadata only again does not flatten no_tool_content to metadata_only.
+    // Re-picking the value already shown is a no-op too, which matters because
+    // the segmented control fires for the active option.
+    function applyForwardLocalMode(set, form, mode) {
+      if (mode === forwardLocalMode(form)) return;
+      if (mode === "off") {
+        set({ localForward: false });
+        return;
+      }
+      const patch = { localForward: true };
+      if (captureForwardMode(form.capture) !== mode) patch.capture = mode;
+      set(patch);
+    }
+
     function SettingsSegmented({ value, onChange, options }) {
       return <PillToggle options={options} value={value} onChange={onChange}/>;
     }
@@ -3123,8 +3236,10 @@
     }
 
 
-    function SettingsHero({ form, dirty, path }) {
+    function SettingsHero({ dirty, path, forwardStatus }) {
+      const forwardMeta = forwardBannerMeta(forwardStatus);
       const chips = [
+        { label: "Cloud copy", value: forwardMeta.pill, tone: `var(--${forwardMeta.accent}-text)` },
         { label: "Config", value: dirty ? "Unsaved" : "Synced", tone: dirty ? "var(--brand-orange-text)" : "var(--success-text)" },
       ];
       return (
@@ -3214,8 +3329,13 @@
       );
     }
 
+    const FORWARD_LOCAL_OPTIONS = [
+      { value: "off", label: "Off" },
+      { value: "metadata_only", label: "Metadata only" },
+      { value: "full", label: "Full" },
+    ];
     const SETTINGS_TABS = [
-      { id: "cloud", label: "Cloud", icon: "cloud", desc: "Ingest and auth" },
+      { id: "cloud", label: "Cloud", icon: "cloud", desc: "Ingest, auth, forwarding" },
       { id: "local", label: "Local", icon: "box", desc: "Tags and runtime" },
     ];
     const SETTINGS_TAB_IDS = new Set(SETTINGS_TABS.map(t => t.id));
@@ -3233,12 +3353,18 @@
       return url.pathname + url.search;
     }
 
-    function SettingsCloudTab({ form, set }) {
+    function SettingsCloudTab({ form, set, forwardStatus }) {
+      const forwardMode = forwardLocalMode(form);
+      const advanced = form.capture === "no_tool_content" || form.capture === "full_with_metadata_spans";
+      // The daemon prefers config.env, but it also inherits LOCAL_FORWARD into
+      // its own environment at boot, so "off here, on there" is reachable until
+      // an explicit false is saved.
+      const daemonStillOn = !!(forwardStatus && forwardStatus.enabled) && !form.localForward;
       return (
         <SettingsCard>
           <SectionLabel>Connection</SectionLabel>
           <div style={{ fontSize: 12, lineHeight: 1.5, color: "var(--fg3)", padding: "0 0 10px" }}>
-            These values apply to your Grafana Cloud sessions.
+            These values apply to your Grafana Cloud sessions and to optional forwarding from local mode.
           </div>
           <SettingRow label="Endpoint" help={<>Grafana AI Observability ingest URL.</>}>
             <MonoInput value={form.endpoint} onChange={v => set({ endpoint: v })} placeholder="https://agento11y-prod-….grafana.net" width={320}/>
@@ -3260,6 +3386,16 @@
           </SettingRow>
           <SettingRow label="OTLP endpoint" help={<>For SDK traces and metrics.</>}>
             <MonoInput value={form.otlpEndpoint} onChange={v => set({ otlpEndpoint: v })} placeholder="https://otlp-gateway-….grafana.net/otlp" width={320}/>
+          </SettingRow>
+          <SettingRow
+            label="Forward local sessions to Cloud"
+            help={<>
+              Also send <Mono>--local</Mono> sessions to Grafana Cloud. Needs the credentials above, and applies to every local session on this machine until you turn it off. The local viewer always keeps full content; <b style={{ fontWeight: 500, color: "var(--fg2)" }}>Metadata only</b> forwards usage and session metadata, and <b style={{ fontWeight: 500, color: "var(--fg2)" }}>Full</b> forwards prompts, responses, and tool I/O too. Metadata only and Full write <Mono>CONTENT_CAPTURE_MODE</Mono>, which also decides how much content your non-local Cloud sessions capture.
+              {advanced && <div style={{ color: "var(--warning-text)", marginTop: 6 }}>Advanced capture mode <Mono>{form.capture}</Mono> is set in config.env. Forwarding reduces it to metadata only and <b style={{ fontWeight: 500, color: "var(--fg2)" }}>Metadata only</b> leaves it in place; picking <b style={{ fontWeight: 500, color: "var(--fg2)" }}>Full</b> replaces it for Cloud sessions too.</div>}
+              {daemonStillOn && <div style={{ color: "var(--warning-text)", marginTop: 6 }}>The running daemon is still forwarding — <Mono>LOCAL_FORWARD</Mono> is set in its environment. Saving writes an explicit <Mono>false</Mono> to config.env, which the daemon prefers.</div>}
+            </>}
+          >
+            <SettingsSegmented value={forwardMode} onChange={v => applyForwardLocalMode(set, form, v)} options={FORWARD_LOCAL_OPTIONS}/>
           </SettingRow>
         </SettingsCard>
       );
@@ -3324,10 +3460,10 @@
       );
     }
 
-    function SettingsTabPanels({ activeSettingsTab, form, set, setTag, addTag, removeTag }) {
+    function SettingsTabPanels({ activeSettingsTab, form, set, setTag, addTag, removeTag, forwardStatus }) {
       return (
         <>
-          {activeSettingsTab === "cloud" && <SettingsCloudTab form={form} set={set}/>}
+          {activeSettingsTab === "cloud" && <SettingsCloudTab form={form} set={set} forwardStatus={forwardStatus}/>}
           {activeSettingsTab === "local" && (
             <SettingsLocalTab form={form} set={set} setTag={setTag} addTag={addTag} removeTag={removeTag}/>
           )}
@@ -3340,6 +3476,9 @@
       const [saved, setSaved] = useState(null);
       const [preview, setPreview] = useState("");
       const [path, setPath] = useState("~/.config/agento11y/config.env");
+      // Effective forwarding posture as the daemon resolves it, which can
+      // differ from the saved toggle (unusable endpoint, placeholder creds).
+      const [forwardStatus, setForwardStatus] = useState(null);
       const [loading, setLoading] = useState(true);
       const [error, setError] = useState(null);
       const [toast, setToast] = useState(null);
@@ -3367,6 +3506,7 @@
             setSaved(cloneSettings(body.settings));
             setPreview(body.preview || "");
             if (body.path) setPath(body.path);
+            if (body.forwardStatus) setForwardStatus(body.forwardStatus);
           })
           .catch(e => { if (alive) setError(String(e.message || e)); })
           .finally(() => { if (alive) setLoading(false); });
@@ -3423,6 +3563,7 @@
             setForm(cloneSettings(body.settings));
             setSaved(cloneSettings(body.settings));
             if (typeof body.preview === "string") setPreview(body.preview);
+            if (body.forwardStatus) setForwardStatus(body.forwardStatus);
             showToast("Settings saved to config.env.");
           })
           .catch(e => setError(String(e.message || e)));
@@ -3441,7 +3582,7 @@
 
       return (
         <div style={page}>
-          <SettingsHero form={form} dirty={dirty} path={path}/>
+          <SettingsHero dirty={dirty} path={path} forwardStatus={forwardStatus}/>
 
           {error && <div style={{ marginBottom: 16 }}><Notice kind="error" title="Couldn’t save settings">{error}</Notice></div>}
 
@@ -3455,6 +3596,7 @@
                 setTag={setTag}
                 addTag={addTag}
                 removeTag={removeTag}
+                forwardStatus={forwardStatus}
               />
             </div>
 
@@ -4236,6 +4378,7 @@
                 onOpen={openConv}
                 onRefresh={refreshAll}
                 refreshing={loadingList}
+                onOpenSettings={goSettings}
               />
             )}
             {view === "conversation" && selected && (

--- a/plugins/agento11y/internal/otel/otel.go
+++ b/plugins/agento11y/internal/otel/otel.go
@@ -202,13 +202,13 @@ func ProbeConfig() (metrics, traces ProbeTarget, ok bool) {
 		true
 }
 
-// probeSignalURL is signalEndpointURL adjusted for the insecure setting. When
+// probeSignalURL is SignalEndpointURL adjusted for the insecure setting. When
 // the exporter is configured insecure, the SDK's WithInsecure() forces
 // cleartext to the same host:port regardless of the endpoint scheme, so a
 // probe over https would exercise a different transport than real export. Drop
 // to http here to match what export actually does.
 func probeSignalURL(cfg exporterConfig, signal string) string {
-	u := signalEndpointURL(cfg.endpoint, signal)
+	u := SignalEndpointURL(cfg.endpoint, signal)
 	if cfg.insecure {
 		if rest, ok := strings.CutPrefix(u, "https://"); ok {
 			return "http://" + rest
@@ -224,8 +224,12 @@ func cloneHeaders(in map[string]string) map[string]string {
 }
 
 func exporterConfigFromEnv(endpoint string) exporterConfig {
-	headers := parseHeaders(os.Getenv("OTEL_EXPORTER_OTLP_HEADERS"))
-	addAuthHeaderIfMissing(headers)
+	headers := ExporterHeaders(
+		os.Getenv("OTEL_EXPORTER_OTLP_HEADERS"),
+		envconfig.Getenv("AUTH_TENANT_ID"),
+		envconfig.Getenv("OTEL_AUTH_TOKEN"),
+		envconfig.Getenv("AUTH_TOKEN"),
+	)
 	return exporterConfig{
 		endpoint: endpoint,
 		headers:  headers,
@@ -234,7 +238,7 @@ func exporterConfigFromEnv(endpoint string) exporterConfig {
 }
 
 func traceOptions(cfg exporterConfig) []otlptracehttp.Option {
-	opts := []otlptracehttp.Option{otlptracehttp.WithEndpointURL(signalEndpointURL(cfg.endpoint, "traces"))}
+	opts := []otlptracehttp.Option{otlptracehttp.WithEndpointURL(SignalEndpointURL(cfg.endpoint, "traces"))}
 	if len(cfg.headers) > 0 {
 		opts = append(opts, otlptracehttp.WithHeaders(cfg.headers))
 	}
@@ -245,7 +249,7 @@ func traceOptions(cfg exporterConfig) []otlptracehttp.Option {
 }
 
 func metricOptions(cfg exporterConfig) []otlpmetrichttp.Option {
-	opts := []otlpmetrichttp.Option{otlpmetrichttp.WithEndpointURL(signalEndpointURL(cfg.endpoint, "metrics"))}
+	opts := []otlpmetrichttp.Option{otlpmetrichttp.WithEndpointURL(SignalEndpointURL(cfg.endpoint, "metrics"))}
 	if len(cfg.headers) > 0 {
 		opts = append(opts, otlpmetrichttp.WithHeaders(cfg.headers))
 	}
@@ -255,7 +259,11 @@ func metricOptions(cfg exporterConfig) []otlpmetrichttp.Option {
 	return opts
 }
 
-func signalEndpointURL(endpoint, signal string) string {
+// SignalEndpointURL appends the OTLP signal path (/v1/traces or /v1/metrics)
+// to a base endpoint, replacing any existing signal suffix. Exported so other
+// packages — notably the local daemon's Cloud forwarder — build the exact URLs
+// the exporter targets instead of duplicating the path logic.
+func SignalEndpointURL(endpoint, signal string) string {
 	base := strings.TrimRight(strings.TrimSpace(endpoint), "/")
 	for _, suffix := range []string{"/v1/traces", "/v1/metrics"} {
 		base = strings.TrimSuffix(base, suffix)
@@ -263,20 +271,37 @@ func signalEndpointURL(endpoint, signal string) string {
 	return base + "/v1/" + signal
 }
 
-// addAuthHeaderIfMissing synthesizes Basic auth from the branded tenant and
-// token families. Token order: AGENTO11Y_OTEL_AUTH_TOKEN > SIGIL_OTEL_AUTH_TOKEN
-// > AGENTO11Y_AUTH_TOKEN > SIGIL_AUTH_TOKEN. An explicit Authorization value
-// in OTEL_EXPORTER_OTLP_HEADERS always wins over the synthesized header.
-func addAuthHeaderIfMissing(headers map[string]string) {
-	tenant := envconfig.Getenv("AUTH_TENANT_ID")
-	token := firstNonBlank(envconfig.Getenv("OTEL_AUTH_TOKEN"), envconfig.Getenv("AUTH_TOKEN"))
+// BasicAuthHeaderValue returns the Authorization header value the OTLP and
+// generation exporters synthesize from a tenant/token pair:
+// "Basic base64(tenant:token)". ok is false when either credential is blank
+// (after trimming), so callers can decide whether to attach the header.
+func BasicAuthHeaderValue(tenant, token string) (value string, ok bool) {
+	tenant = strings.TrimSpace(tenant)
+	token = strings.TrimSpace(token)
 	if tenant == "" || token == "" {
-		return
+		return "", false
 	}
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(tenant+":"+token)), true
+}
+
+// ExporterHeaders builds the OTLP header set from a raw
+// OTEL_EXPORTER_OTLP_HEADERS value and the tenant/token credentials: the
+// explicit headers, plus Basic auth synthesized from the tenant and the first
+// non-blank of otelToken (OTEL_AUTH_TOKEN) and authToken (AUTH_TOKEN). An
+// explicit Authorization header always wins over the synthesized one.
+//
+// Exported so the local daemon's Cloud forwarder authenticates its OTLP relay
+// exactly the way the real exporter does; passing the values in keeps this
+// usable from a config.env snapshot rather than only the process environment.
+func ExporterHeaders(rawHeaders, tenant, otelToken, authToken string) map[string]string {
+	headers := parseHeaders(rawHeaders)
 	if hasAuthorizationHeader(headers) {
-		return
+		return headers
 	}
-	headers["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(tenant+":"+token))
+	if value, ok := BasicAuthHeaderValue(tenant, firstNonBlank(otelToken, authToken)); ok {
+		headers["Authorization"] = value
+	}
+	return headers
 }
 
 func firstNonBlank(values ...string) string {

--- a/plugins/agento11y/internal/otel/otel_test.go
+++ b/plugins/agento11y/internal/otel/otel_test.go
@@ -142,11 +142,89 @@ func TestProbeConfigNoEndpoint(t *testing.T) {
 }
 
 func TestSignalEndpointURLAppendsOTLPHTTPPaths(t *testing.T) {
-	if got := signalEndpointURL("https://otlp.example/otlp", "traces"); got != "https://otlp.example/otlp/v1/traces" {
+	if got := SignalEndpointURL("https://otlp.example/otlp", "traces"); got != "https://otlp.example/otlp/v1/traces" {
 		t.Fatalf("trace endpoint = %q", got)
 	}
-	if got := signalEndpointURL("https://otlp.example/otlp/v1/traces", "metrics"); got != "https://otlp.example/otlp/v1/metrics" {
+	if got := SignalEndpointURL("https://otlp.example/otlp/v1/traces", "metrics"); got != "https://otlp.example/otlp/v1/metrics" {
 		t.Fatalf("metric endpoint = %q", got)
+	}
+}
+
+// TestExporterHeaders covers the exported header builder the local daemon's
+// Cloud forwarder shares with the exporter: explicit headers pass through, an
+// explicit Authorization wins, and OTEL_AUTH_TOKEN outranks AUTH_TOKEN.
+func TestExporterHeaders(t *testing.T) {
+	basic := func(pair string) string {
+		return "Basic " + base64.StdEncoding.EncodeToString([]byte(pair))
+	}
+	cases := []struct {
+		name       string
+		raw        string
+		tenant     string
+		otelToken  string
+		authToken  string
+		wantAuth   string
+		wantExtras map[string]string
+	}{
+		{
+			name: "synthesizes_from_auth_token", tenant: "tenant", authToken: "token",
+			wantAuth: basic("tenant:token"),
+		},
+		{
+			name: "otel_token_wins", tenant: "tenant", otelToken: "otel", authToken: "token",
+			wantAuth: basic("tenant:otel"),
+		},
+		{
+			name: "explicit_authorization_wins", raw: "Authorization=Bearer explicit",
+			tenant: "tenant", authToken: "token", wantAuth: "Bearer explicit",
+		},
+		{
+			name: "keeps_other_headers", raw: "X-Extra=ok", tenant: "tenant", authToken: "token",
+			wantAuth: basic("tenant:token"), wantExtras: map[string]string{"X-Extra": "ok"},
+		},
+		{
+			name: "no_credentials_means_no_authorization", raw: "X-Extra=ok",
+			wantExtras: map[string]string{"X-Extra": "ok"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExporterHeaders(tc.raw, tc.tenant, tc.otelToken, tc.authToken)
+			if got["Authorization"] != tc.wantAuth {
+				t.Fatalf("Authorization = %q, want %q", got["Authorization"], tc.wantAuth)
+			}
+			for k, v := range tc.wantExtras {
+				if got[k] != v {
+					t.Fatalf("header %s = %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestBasicAuthHeaderValue(t *testing.T) {
+	cases := []struct {
+		name   string
+		tenant string
+		token  string
+		want   string
+		wantOK bool
+	}{
+		{name: "tenant and token", tenant: "123456", token: "glc_secret", want: "Basic " + base64.StdEncoding.EncodeToString([]byte("123456:glc_secret")), wantOK: true},
+		{name: "trims whitespace", tenant: "  123456  ", token: "  glc_secret  ", want: "Basic " + base64.StdEncoding.EncodeToString([]byte("123456:glc_secret")), wantOK: true},
+		{name: "blank tenant", tenant: "  ", token: "glc_secret"},
+		{name: "blank token", tenant: "123456", token: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := BasicAuthHeaderValue(tc.tenant, tc.token)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Fatalf("value = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Local sessions keep everything on disk and send nothing to Grafana Cloud. Enable forwarding to Cloud, which is off unless `AGENTO11Y_LOCAL_FORWARD` is true. Local capture always keeps full content. `AGENTO11Y_CONTENT_CAPTURE_MODE` controls only the forwarded copy.

Forwarding is best effort and never affects the local write or the response to the agent. Configuration is re-read when `config.env` changes size or mtime, so the toggle takes effect without restarting the daemon.