### PR TITLE
feat(python-frameworks/litellm): support preflight guards

### DIFF
--- a/python-frameworks/litellm/README.md
+++ b/python-frameworks/litellm/README.md
@@ -115,6 +115,86 @@ handler = Agento11yLiteLLMLogger(
 
 A key alias names a credential rather than an agent, so it is not consulted by default: rotating a key would rename the agent, and a shared key would merge unrelated callers. Conversely, pass `("agent_name",)` to ignore LiteLLM's `agent_id` and keep every generation under the static name.
 
+## Guards
+
+`Agento11yLiteLLMGuardrail` evaluates Agent Observability preflight guards before a request reaches the provider, and blocks it with HTTP 400 when a guard denies. It is a `CustomGuardrail`, so it gets LiteLLM's per-request and per-team opt-in, `default_on`, guardrail results in the standard logging payload, and an OTel guardrail span.
+
+Enforcement only works behind the LiteLLM proxy. Pre-call hooks are a proxy-only LiteLLM feature; a direct `litellm.completion()` SDK call never invokes them and is never guarded.
+
+Only preflight is supported. The guardrail defaults to `event_hook="pre_call"`, and constructing it with `event_hook="post_call"` or `event_hook="during_call"` raises at proxy startup rather than registering a guardrail that silently never runs.
+
+Guards are configured in Agent Observability, not in `config.yaml`. Refer to [Set up guards](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/guides/guards/) for guard types, priority, and match filters.
+
+Evaluator guards work as documented there, against the request: messages, system prompt, and tool definitions. `deny` returns 400 to the proxy client and the provider is never called; `warn` allows the request and records the verdict. Three things behave differently through this adapter:
+
+- Redact guards do not change what the model sees. That page says the SDK uses `transformed_input` for the LLM call; this adapter ignores it. Redaction still applies to evaluators in later guards, which run server-side against the redacted input.
+- Tool filter guards match tool calls that are already in the request history, which means the client has executed them. They block the next call in an agent loop rather than the tool itself. Blocking a proposed call before it runs is postflight, which is not implemented here.
+- `model.provider` match filters are unreliable, because the provider is not known until LiteLLM's router picks a deployment, which happens after the guard runs. Match on `agent_name`, `model.name`, or tags instead.
+
+### Guarded routes
+
+The guard reads the request body as the client sent it, before LiteLLM translates it to provider format, and every route puts the input somewhere else:
+
+| Route | Messages | System prompt |
+|---|---|---|
+| `/v1/chat/completions` | `messages` | `system` and `developer` messages |
+| `/v1/completions` | `prompt` (string or list of strings; token ids carry no text) | none |
+| `/v1/messages` | `messages`, including Anthropic content blocks | top-level `system` |
+| `/v1/responses` | `input` (string or input items) | `instructions` |
+| `/v1/images/generations` | `prompt` | none |
+
+Every other route LiteLLM runs pre-call hooks on is skipped: embeddings, moderation, rerank, audio, realtime, MCP tool calls, and native pass-through endpoints (`/anthropic/v1/messages`, `/vertex_ai/...`). Their bodies are provider-native or carry no messages, so there is nothing for a content or system-prompt rule to match. They are skipped rather than evaluated against empty input, because an evaluation with no input returns allow and records a verdict that reads like a completed check. A skipped request records no verdict at all, and nothing on those routes is ever blocked, including by rules that only match on `agent_name`, `model.name`, or tags.
+
+A guarded request whose input maps to no text is skipped the same way: a token-id `prompt`, or content that is entirely images or audio.
+
+Enable hooks on the agento11y client and list the guardrail next to the logger:
+
+```python
+# agento11y_callback.py, next to config.yaml
+from agento11y import Client, ClientConfig, HooksConfig
+from agento11y_litellm import Agento11yLiteLLMGuardrail, Agento11yLiteLLMLogger
+
+client = Client(ClientConfig(hooks=HooksConfig(enabled=True, timeout_seconds=2.0)))
+
+agento11y_handler = Agento11yLiteLLMLogger(client=client, agent_name="litellm-proxy")
+agento11y_guards = Agento11yLiteLLMGuardrail(client=client, agent_name="litellm-proxy", default_on=True)
+```
+
+```yaml
+# config.yaml
+litellm_settings:
+  callbacks:
+    - agento11y_callback.agento11y_handler
+    - agento11y_callback.agento11y_guards
+```
+
+LiteLLM runs any `CustomGuardrail` in `litellm.callbacks` on the pre-call path, so the guardrail needs no separate `guardrails:` block.
+
+With `default_on=False`, a request opts in with `"guardrails": ["agento11y"]` in its metadata.
+
+Lower `HooksConfig.timeout_seconds` from its 15 second default for proxy use. It bounds how long a worker thread stays occupied after the guardrail has already given up on the evaluation.
+
+Guardrail options are keyword-only, and `create_agento11y_litellm_guardrail` accepts the same ones:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `client` | `agento11y.Client` | required | agento11y SDK client instance, with `hooks.enabled=True` |
+| `agent_name` | `str` | `""` | Fallback agent name when the request carries no agent identity |
+| `agent_name_metadata_keys` | `Sequence[str]` | `("agent_name", "agent_id")` | Metadata keys consulted, in order, to name the agent |
+| `agent_version` | `str` | `""` | Fallback agent version |
+| `max_concurrent_evaluations` | `int` | `32` | Ceiling on hook evaluations in flight at once |
+| `request_timeout_seconds` | `float` | `2.0` | How long the proxy waits for a free thread plus a verdict |
+| `extra_tags` | `dict[str, str]` | `None` | Additional tags merged into every hook evaluation context |
+| `guardrail_name` | `str` | `"agento11y"` | Name used for per-request opt-in and in the 400 response |
+| `default_on` | `bool` | `False` | Run on every request instead of only on opted-in ones |
+
+Runtime behavior:
+
+- Evaluation runs on a pool of `max_concurrent_evaluations` threads, so it does not block the proxy event loop. `request_timeout_seconds` covers waiting for a free thread as well as the evaluation itself, and a thread stays busy until its evaluation actually finishes, so a slow evaluator can keep the pool saturated for longer than that timeout.
+- A timeout or an unexpected error follows `HooksConfig.fail_open`: allow and log at WARNING when `True` (the default), raise `HookTransportError` when `False`. A dead evaluator allows all traffic, and the log line is the only sign of it.
+- Hook evaluations correlate to the proxy request span, so a guard verdict lines up with its request in traces.
+- Register both the guardrail and the logger. The guardrail does not export generations, and having both in `litellm.callbacks` still exports exactly one generation per request.
+
 ## LiteLLM Proxy (Docker)
 
 When running LiteLLM as a proxy server in Docker, register the handler via a callback file next to your config.
@@ -193,13 +273,13 @@ The callback file reads connection details from environment variables. Adjust th
   - text completions (`text_completion`, `atext_completion`). The prompt is recorded as a user message. Pre-tokenized prompts (lists of token ids) carry no text and are skipped.
   - the Responses API (`responses`, `aresponses`, `/v1/responses`). Text, reasoning, and tool calls in the output are recorded. That route has no `finish_reason`, so the stop reason comes from the response `status`: `completed` becomes `stop`, and an incomplete response reports `incomplete_details.reason`.
   - the Anthropic Messages API (`anthropic_messages`, `aanthropic_messages`, `/v1/messages`)
-- Only text content is recorded. Images, audio, and other non-text parts are skipped. Anthropic-native `tool_use` and `tool_result` blocks on `/v1/messages` are skipped, as are `function_call` and `function_call_output` history items in `/v1/responses` input. OpenAI-format `tool_calls` and `tool` messages are recorded, and so are tool calls in `/v1/responses` output.
+- Only text content is recorded. Images, audio, and other non-text parts are skipped. Tool history is recorded in each request shape that carries it: OpenAI-format `tool_calls` and `tool` messages, Anthropic `tool_use` and `tool_result` blocks on `/v1/messages`, and top-level `function_call` and `function_call_output` items in `/v1/responses` input. The remaining Responses input items (`computer_call`, `mcp_call`, `image_generation_call`) are skipped. Tool calls in `/v1/responses` output are recorded.
 - Tool definitions are read from the request `tools` in the OpenAI chat schema (`{"type": "function", "function": {...}}`). The flat Responses API tool schema is not recognized, so those requests report no tool definitions.
 - Embedding call types (`embedding`, `aembedding`) are recorded as OTel embedding spans (no generation export). The span carries input/token counts and dimensions; the input text is attached only when the handler's `capture_inputs` is set and the SDK's `EmbeddingCaptureConfig.capture_input=True`. Embedding spans require a configured OTel tracer.
 - Image generation, audio, and transcription call types are skipped.
 - Framework tags are always set:
   - `agento11y.framework.name=litellm`
-  - `agento11y.framework.source=handler`
+  - `agento11y.framework.source=handler` (`guardrail` on hook evaluation contexts)
   - `agento11y.framework.language=python`
 - LiteLLM `request_tags` are forwarded as `litellm.tag.<value>`.
 - Token usage includes detailed breakdowns (cached tokens, reasoning tokens) when the provider returns them.

--- a/python-frameworks/litellm/agento11y_litellm/__init__.py
+++ b/python-frameworks/litellm/agento11y_litellm/__init__.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from agento11y import Client
 
+from .guard import DEFAULT_GUARDRAIL_NAME, Agento11yLiteLLMGuardrail
 from .handler import DEFAULT_AGENT_NAME_METADATA_KEYS, Agento11yLiteLLMLogger
 
 
@@ -34,8 +35,41 @@ def create_agento11y_litellm_logger(
     )
 
 
+def create_agento11y_litellm_guardrail(
+    *,
+    client: Client,
+    agent_name: str = "",
+    agent_name_metadata_keys: Sequence[str] = DEFAULT_AGENT_NAME_METADATA_KEYS,
+    agent_version: str = "",
+    max_concurrent_evaluations: int = 32,
+    request_timeout_seconds: float = 2.0,
+    extra_tags: dict[str, str] | None = None,
+    guardrail_name: str = DEFAULT_GUARDRAIL_NAME,
+    default_on: bool = False,
+) -> Agento11yLiteLLMGuardrail:
+    """Create a LiteLLM guardrail that enforces agento11y preflight hook rules.
+
+    Enforcement only happens behind the LiteLLM proxy; pre-call hooks are never
+    invoked on the ``litellm.completion()`` SDK path.
+    """
+    return Agento11yLiteLLMGuardrail(
+        client=client,
+        agent_name=agent_name,
+        agent_name_metadata_keys=agent_name_metadata_keys,
+        agent_version=agent_version,
+        max_concurrent_evaluations=max_concurrent_evaluations,
+        request_timeout_seconds=request_timeout_seconds,
+        extra_tags=extra_tags,
+        guardrail_name=guardrail_name,
+        default_on=default_on,
+    )
+
+
 __all__ = [
     "DEFAULT_AGENT_NAME_METADATA_KEYS",
+    "DEFAULT_GUARDRAIL_NAME",
+    "Agento11yLiteLLMGuardrail",
     "Agento11yLiteLLMLogger",
+    "create_agento11y_litellm_guardrail",
     "create_agento11y_litellm_logger",
 ]

--- a/python-frameworks/litellm/agento11y_litellm/guard.py
+++ b/python-frameworks/litellm/agento11y_litellm/guard.py
@@ -1,0 +1,447 @@
+"""LiteLLM guardrail that enforces Agent Observability preflight hook rules.
+
+Pre-call hooks are a proxy-only LiteLLM feature: ``ProxyLogging.pre_call_hook``
+invokes them, and nothing on the ``litellm.completion()`` SDK path does. A direct
+SDK call is therefore never guarded by this class.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import copy_context
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any
+
+import litellm
+from agento11y import Client
+from agento11y.errors import HookTransportError
+from agento11y.hooks import (
+    HookAction,
+    HookContext,
+    HookEvaluateRequest,
+    HookEvaluateResponse,
+    HookInput,
+    HookModel,
+    HookPhase,
+    hook_denied_from_response,
+)
+from agento11y.models import Message, MessageRole, PartKind
+from litellm.exceptions import GuardrailRaisedException
+from litellm.integrations.custom_guardrail import CustomGuardrail, log_guardrail_information
+from litellm.types.guardrails import GuardrailEventHooks
+
+from .handler import (
+    DEFAULT_AGENT_NAME_METADATA_KEYS,
+    FRAMEWORK_TAGS,
+    _extract_text_content,
+    _first_metadata_value,
+    _map_messages,
+    _map_tools_list,
+    _metadata_sources_from,
+    _request_tags_from,
+    _resolve_conversation_id_from,
+)
+
+if TYPE_CHECKING:
+    from litellm.caching import DualCache
+    from litellm.proxy._types import UserAPIKeyAuth
+else:
+    DualCache = Any
+    UserAPIKeyAuth = Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_GUARDRAIL_NAME = "agento11y"
+
+# Sent when the model identity cannot be resolved from the request. The hooks
+# API rejects an empty provider or name, and a rejected evaluation fails open,
+# so a placeholder is the difference between rules running and rules never
+# running. Matches the placeholder the agento11y CLI tool-call guard sends.
+UNKNOWN_PROVIDER = "unknown"
+UNKNOWN_MODEL = "unknown"
+
+# Only preflight is wired up. post_call arrives with postflight support.
+SUPPORTED_EVENT_HOOKS = (GuardrailEventHooks.pre_call,)
+
+# Call types this adapter can read request input from.
+#
+# ``ProxyLogging.pre_call_hook`` runs every registered CustomGuardrail on every
+# route it covers, including embeddings, moderation, rerank, audio, realtime,
+# MCP tool calls, and native pass-through. Those bodies carry no messages this
+# adapter maps, and evaluating one would send empty input, get an allow back,
+# and record a verdict that reads like a completed check. They are skipped
+# instead, so a request that was never checked is not reported as allowed.
+#
+# Kept separate from the logger's ``_GENERATION_CALL_TYPES`` on purpose: what
+# the logger records and what this guard can inspect are different questions,
+# and a change to one should not silently move the other. Adding a route here
+# means teaching ``_hook_input`` where that route keeps its input.
+GUARDED_CALL_TYPES = frozenset(
+    {
+        "completion",
+        "acompletion",
+        "text_completion",
+        "atext_completion",
+        "responses",
+        "aresponses",
+        "anthropic_messages",
+        "aanthropic_messages",
+        "image_generation",
+        "aimage_generation",
+    }
+)
+
+# Body keys that carry conversation input, in precedence order. Chat and
+# ``/v1/messages`` use ``messages``, ``/v1/responses`` uses ``input``, text
+# completion and image generation use ``prompt``.
+_INPUT_KEYS = ("messages", "input", "prompt")
+
+# Body keys that carry the system prompt outside the message list:
+# ``/v1/messages`` sends ``system``, ``/v1/responses`` sends ``instructions``.
+_SYSTEM_PROMPT_KEYS = ("system", "instructions")
+
+_GUARD_FRAMEWORK_TAGS = {**FRAMEWORK_TAGS, "agento11y.framework.source": "guardrail"}
+
+
+class Agento11yLiteLLMGuardrail(CustomGuardrail):
+    """Evaluates agento11y hook rules before a proxy request reaches the provider.
+
+    Deliberately not a subclass of ``Agento11yLiteLLMLogger``. Both objects sit
+    in ``litellm.callbacks`` at once, and a bare ``CustomGuardrail`` is harmless
+    there only because it inherits ``CustomLogger``'s no-op logging methods. Give
+    this class the logger's export behavior and every generation exports twice.
+
+    ``ProxyLogging.pre_call_hook`` walks ``litellm.callbacks`` and runs every
+    ``CustomGuardrail`` it finds, so a dotted path next to the logger is enough::
+
+        litellm_settings:
+          callbacks:
+            - agento11y_callback.agento11y_handler
+            - agento11y_callback.agento11y_guards
+    """
+
+    def __init__(
+        self,
+        *,
+        client: Client,
+        agent_name: str = "",
+        agent_name_metadata_keys: Sequence[str] = DEFAULT_AGENT_NAME_METADATA_KEYS,
+        agent_version: str = "",
+        max_concurrent_evaluations: int = 32,
+        request_timeout_seconds: float = 2.0,
+        extra_tags: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if max_concurrent_evaluations <= 0:
+            raise ValueError(f"max_concurrent_evaluations must be greater than zero, got {max_concurrent_evaluations}")
+        if request_timeout_seconds <= 0:
+            raise ValueError(f"request_timeout_seconds must be greater than zero, got {request_timeout_seconds}")
+
+        event_hook = kwargs.pop("event_hook", None)
+        _reject_unsupported_event_hooks(event_hook)
+
+        super().__init__(
+            guardrail_name=kwargs.pop("guardrail_name", None) or DEFAULT_GUARDRAIL_NAME,
+            supported_event_hooks=list(SUPPORTED_EVENT_HOOKS),
+            # Kept as configured so LiteLLM's tag-conditional Mode form keeps
+            # working.
+            event_hook=GuardrailEventHooks.pre_call if event_hook is None else event_hook,
+            **kwargs,
+        )
+        self._client = client
+        self._agent_name = agent_name
+        self._agent_name_metadata_keys = tuple(agent_name_metadata_keys)
+        self._agent_version = agent_version
+        self._max_concurrent_evaluations = max_concurrent_evaluations
+        self._request_timeout_seconds = request_timeout_seconds
+        self._extra_tags = dict(extra_tags) if extra_tags else {}
+        self._executor = ThreadPoolExecutor(max_workers=self._max_concurrent_evaluations)
+
+    async def async_pre_call_hook(
+        self,
+        user_api_key_dict: UserAPIKeyAuth,
+        cache: DualCache,
+        data: dict,
+        call_type: str,
+    ) -> None:
+        """Blocks the request when an agento11y preflight rule denies it.
+
+        Returns ``None`` on allow so the proxy forwards the request body
+        untouched.
+
+        Every gate that ends in "do not evaluate" sits outside the decorated
+        body, so a request this guardrail did not check records no verdict at
+        all: the guardrail is not enabled for the request, the route carries
+        input this adapter cannot map, or the mapped input is empty. The proxy
+        applies the enablement gate before calling in, so that one only matters
+        for direct invocation.
+        """
+        if not self.should_run_guardrail(data, GuardrailEventHooks.pre_call):
+            return None
+
+        if call_type not in GUARDED_CALL_TYPES:
+            logger.debug("agento11y: skipping preflight evaluation, call type %r carries no mappable input", call_type)
+            return None
+
+        hook_input = _hook_input(data)
+        if not hook_input.messages and not hook_input.system_prompt:
+            # A body whose input this adapter reads but cannot turn into text:
+            # token-id prompts, or content that is entirely images or audio.
+            logger.debug("agento11y: skipping preflight evaluation, request carries no evaluable text")
+            return None
+
+        return await self._run_preflight(user_api_key_dict=user_api_key_dict, data=data, hook_input=hook_input)
+
+    @log_guardrail_information
+    async def _run_preflight(self, *, user_api_key_dict: UserAPIKeyAuth, data: dict, hook_input: HookInput) -> None:
+        """Evaluate preflight rules and translate a deny into a proxy 400.
+
+        ``transformed_input`` from the evaluator is ignored: applying it would
+        drop every tool call and tool result, because the SDK's wire parser
+        keeps only text and thinking parts.
+        """
+        request = HookEvaluateRequest(
+            phase=HookPhase.PREFLIGHT.value,
+            context=self._context(data, user_api_key_dict),
+            input=hook_input,
+        )
+
+        response = await self._evaluate(request)
+        denied = hook_denied_from_response(response)
+        if denied is None:
+            return None
+
+        detail = f"{denied.reason} (rule {denied.rule_id})" if denied.rule_id else denied.reason
+        raise GuardrailRaisedException(
+            guardrail_name=self.guardrail_name,
+            message=f"blocked by guardrail {self.guardrail_name}: {detail}",
+            should_wrap_with_default_message=False,
+        )
+
+    def _context(self, data: dict, user_api_key_dict: Any) -> HookContext:
+        """Build the hook context from the raw proxy request body.
+
+        Agent identity follows the same metadata precedence as the logger, so a
+        rule matching on ``agent_name`` selects the same traffic in both. Trace
+        correlation uses the proxy request span. The ambient span during a
+        pre-call hook is often an unrelated phase span.
+
+        The model provider and name are resolved from the request rather than
+        left empty: the hooks API requires both, and an evaluation it rejects
+        fails open, so every rule would be skipped.
+        """
+        sources = _metadata_sources_from(data)
+        tags: dict[str, str] = dict(_GUARD_FRAMEWORK_TAGS)
+        for tag_value in _request_tags_from(sources):
+            tags[f"litellm.tag.{tag_value}"] = tag_value
+        tags.update(self._extra_tags)
+
+        trace_id, span_id = _span_ids(getattr(user_api_key_dict, "parent_otel_span", None))
+
+        model_name = str(data.get("model") or "")
+        # The hooks API requires a name as well as a provider, so a route that
+        # carries no model still has to send something.
+        provider = _resolve_provider(data, model_name)
+        model_name = model_name.strip() or UNKNOWN_MODEL
+
+        return HookContext(
+            model=HookModel(provider=provider, name=model_name),
+            agent_name=_first_metadata_value(sources, self._agent_name_metadata_keys) or self._agent_name,
+            agent_version=_first_metadata_value(sources, ("agent_version",)) or self._agent_version,
+            tags=tags,
+            conversation_id=_resolve_conversation_id_from(data, sources),
+            trace_id=trace_id,
+            span_id=span_id,
+        )
+
+    async def _evaluate(self, request: HookEvaluateRequest) -> HookEvaluateResponse:
+        """Evaluate hook rules without blocking the proxy event loop.
+
+        ``Client.evaluate_hook`` blocks on urllib, so a dedicated worker pool
+        limits concurrent evaluations without consuming asyncio's default
+        executor. Context variables are copied so SDK conversation and trace
+        fallbacks remain available in the worker. The timeout covers time queued
+        for a worker and time running the evaluation. A timed-out evaluation
+        that has started keeps its pool slot until urllib finishes.
+
+        Transport failures are already resolved inside the SDK according to
+        ``HooksConfig.fail_open``; the adapter's own timeout and unexpected
+        failures follow the same policy.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+            context = copy_context()
+            evaluation = loop.run_in_executor(
+                self._executor,
+                context.run,
+                self._client.evaluate_hook,
+                request,
+            )
+            return await asyncio.wait_for(evaluation, self._request_timeout_seconds)
+        except HookTransportError:
+            raise
+        except asyncio.TimeoutError:
+            return self._fail_open_or_raise(f"timed out after {self._request_timeout_seconds}s")
+        except Exception as exc:  # noqa: BLE001
+            return self._fail_open_or_raise(f"{type(exc).__name__}: {exc}")
+
+    def _fail_open_or_raise(self, detail: str) -> HookEvaluateResponse:
+        if self._client.hooks_config.fail_open:
+            logger.warning("agento11y: preflight hook evaluation failed, allowing request (fail_open): %s", detail)
+            return HookEvaluateResponse(action=HookAction.ALLOW.value)
+        raise HookTransportError(f"agento11y hook evaluation failed: {detail}")
+
+
+def _resolve_provider(data: dict, model_name: str) -> str:
+    """Resolve the provider for the planned call, falling back to a placeholder.
+
+    A request may carry ``custom_llm_provider`` outright. Otherwise the model
+    string is mapped through LiteLLM, which covers both a prefixed model
+    (``openai/gpt-4o-mini``) and a bare name LiteLLM knows (``gpt-4o``).
+
+    Proxy deployment aliases resolve to ``UNKNOWN_PROVIDER``: pre-call runs
+    before the router picks a deployment, and a model group can span providers,
+    so the real provider is not knowable here. Rules that match on
+    ``model.provider`` are unreliable through this adapter for that reason;
+    match on ``model.name``, ``agent_name``, or tags instead.
+    """
+    explicit = data.get("custom_llm_provider")
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit.strip().lower()
+    return _provider_for_model(model_name)
+
+
+@lru_cache(maxsize=512)
+def _provider_for_model(model_name: str) -> str:
+    """Map a model string to a provider, cached because this is a hot path.
+
+    ``get_llm_provider`` walks LiteLLM's model map and raises on anything it
+    cannot place. Caching keeps that off every request, and keeps LiteLLM's
+    provider-list banner to once per unresolved model per process.
+    """
+    if not model_name.strip():
+        return UNKNOWN_PROVIDER
+    try:
+        _, provider, _, _ = litellm.get_llm_provider(model=model_name)
+    except Exception:  # noqa: BLE001
+        return UNKNOWN_PROVIDER
+    provider = (provider or "").strip().lower()
+    return provider or UNKNOWN_PROVIDER
+
+
+def _reject_unsupported_event_hooks(event_hook: Any) -> None:
+    """Raise on any configured mode other than ``pre_call``.
+
+    A guardrail configured with an unsupported mode would silently never run;
+    failing at construction surfaces the misconfiguration at proxy startup.
+    """
+    supported = {hook.value for hook in SUPPORTED_EVENT_HOOKS}
+    for mode in _event_hook_values(event_hook):
+        if mode not in supported:
+            raise ValueError(
+                f"Agento11yLiteLLMGuardrail does not support mode {mode!r}; "
+                f"supported modes: {sorted(supported)}. Postflight evaluation is not implemented yet."
+            )
+
+
+def _event_hook_values(event_hook: Any) -> list[str]:
+    """Flatten LiteLLM's several ``event_hook`` shapes into mode strings."""
+    if event_hook is None:
+        return []
+    if isinstance(event_hook, GuardrailEventHooks):
+        return [event_hook.value]
+    if isinstance(event_hook, str):
+        return [event_hook]
+    if isinstance(event_hook, (list, tuple, set)):
+        out: list[str] = []
+        for item in event_hook:
+            out.extend(_event_hook_values(item))
+        return out
+    # litellm.types.guardrails.Mode: tag-conditional modes plus a default.
+    tags = getattr(event_hook, "tags", None)
+    default = getattr(event_hook, "default", None)
+    if tags is None and default is None:
+        return [str(event_hook)]
+    out = []
+    if isinstance(tags, dict):
+        for value in tags.values():
+            out.extend(_event_hook_values(value))
+    out.extend(_event_hook_values(default))
+    return out
+
+
+def _span_ids(span: Any) -> tuple[str, str]:
+    """Read hex trace/span ids off an OTel span, tolerating anything else."""
+    if span is None:
+        return "", ""
+    try:
+        span_context = span.get_span_context()
+        if not span_context.is_valid:
+            return "", ""
+        return format(span_context.trace_id, "032x"), format(span_context.span_id, "016x")
+    except Exception:  # noqa: BLE001
+        return "", ""
+
+
+def _hook_input(data: dict) -> HookInput:
+    """Build hook input from the raw proxy request body.
+
+    The guard runs before LiteLLM translates the body, so the shape is whatever
+    the route accepts: chat and ``/v1/messages`` carry ``messages``,
+    ``/v1/responses`` carries ``input``, text completion and image generation
+    carry ``prompt``. The system prompt is part of the message list only on chat
+    routes; ``/v1/messages`` sends it as top-level ``system`` and
+    ``/v1/responses`` as ``instructions``.
+
+    Keys are read by shape rather than by call type, because one call type
+    carries more than one shape: LiteLLM's Anthropic adapter route runs an
+    Anthropic body, ``messages`` plus top-level ``system``, through
+    ``pre_call_hook`` as call type ``text_completion``.
+    """
+    messages, message_system_prompt = _map_messages(_first_present(data, _INPUT_KEYS))
+    system_chunks = [_top_level_system_prompt(data), message_system_prompt]
+    return HookInput(
+        messages=messages,
+        tools=_map_tools_list(data.get("tools")),
+        system_prompt="\n\n".join(chunk for chunk in system_chunks if chunk),
+        conversation_preview=_last_user_text(messages),
+    )
+
+
+def _first_present(data: dict, keys: Sequence[str]) -> Any:
+    """Return the first non-empty value among ``keys``."""
+    for key in keys:
+        value = data.get(key)
+        if value:
+            return value
+    return None
+
+
+def _top_level_system_prompt(data: dict) -> str:
+    """Join the system prompt fields that sit outside the message list.
+
+    Anthropic ``system`` is a string or a list of text blocks; Responses API
+    ``instructions`` is a string. A body carries at most one of them, but both
+    are read so neither route depends on the call type being recognized.
+    """
+    chunks = [_extract_text_content(data.get(key)) for key in _SYSTEM_PROMPT_KEYS]
+    return "\n\n".join(chunk for chunk in chunks if chunk)
+
+
+def _last_user_text(messages: Sequence[Message]) -> str:
+    """Return the text of the last user message, for rule preview matching.
+
+    Reads mapped messages rather than the request body, so a text-completion
+    ``prompt`` and a ``/v1/responses`` ``input`` item are covered too: both
+    arrive here as user messages.
+    """
+    for message in reversed(messages):
+        if message.role != MessageRole.USER:
+            continue
+        text = " ".join(part.text for part in message.parts if part.kind == PartKind.TEXT and part.text)
+        if text:
+            return text
+    return ""

--- a/python-frameworks/litellm/agento11y_litellm/handler.py
+++ b/python-frameworks/litellm/agento11y_litellm/handler.py
@@ -77,6 +77,15 @@ _TEXT_CONTENT_PART_TYPES = frozenset({"text", "input_text", "output_text", _REFU
 # ``output_text``.
 _REASONING_TEXT_PART_TYPES = frozenset({"summary_text", "reasoning_text", "output_text", "text"})
 
+# Responses API items that carry tool history. Chat hangs a call off an assistant
+# message and sends the result as a ``tool`` role message; the Responses API
+# sends both as top-level items with no role at all. Other tool item types
+# (``computer_call``, ``mcp_call``, ``image_generation_call``) keep their payload
+# in shapes of their own and are not mapped.
+_RESPONSES_TOOL_CALL_ITEM_TYPE = "function_call"
+_RESPONSES_TOOL_RESULT_ITEM_TYPE = "function_call_output"
+_RESPONSES_TOOL_ITEM_TYPES = frozenset({_RESPONSES_TOOL_CALL_ITEM_TYPE, _RESPONSES_TOOL_RESULT_ITEM_TYPE})
+
 # Metadata keys consulted, in order, to name the agent behind a request.
 # ``agent_id`` is LiteLLM's own identity field, filled in by the proxy from the
 # ``x-litellm-agent-id`` header or from an ``agent_id`` on the calling virtual
@@ -84,6 +93,17 @@ _REASONING_TEXT_PART_TYPES = frozenset({"summary_text", "reasoning_text", "outpu
 # themselves rather than to the proxy. Override via ``agent_name_metadata_keys``
 # to consult different keys, or pass ``("agent_name",)`` to opt out.
 DEFAULT_AGENT_NAME_METADATA_KEYS = ("agent_name", "agent_id")
+
+# Metadata keys consulted, in order, to group requests into one conversation,
+# followed by LiteLLM's own session fields.
+_CONVERSATION_ID_METADATA_KEYS = ("conversation_id", "session_id", "thread_id")
+_LITELLM_SESSION_KEYS = ("litellm_session_id", "litellm_trace_id")
+
+FRAMEWORK_TAGS = {
+    "agento11y.framework.name": "litellm",
+    "agento11y.framework.source": "handler",
+    "agento11y.framework.language": "python",
+}
 
 
 def _make_tool_call_part(*, call_id: str, name: str, arguments: str) -> Part:
@@ -112,6 +132,11 @@ def _map_messages(messages: Any) -> tuple[list[Message], str]:
     ``anthropic_messages`` call type can also carry OpenAI-shaped messages once
     a caller replays LiteLLM's own normalized history, so both vocabularies are
     read per message instead of branching on the route.
+
+    ``/v1/responses`` sends its ``input`` list here too, and tool history in that
+    list is not role-shaped: the model's call is a top-level ``function_call``
+    item and the result a ``function_call_output`` item, both mapped before the
+    role dispatch.
     """
     if not messages:
         return [], ""
@@ -132,6 +157,13 @@ def _map_messages(messages: Any) -> tuple[list[Message], str]:
             continue
 
         if not isinstance(msg, dict):
+            continue
+
+        item_type = str(msg.get("type") or "").lower()
+        if item_type in _RESPONSES_TOOL_ITEM_TYPES:
+            tool_message = _map_responses_tool_item(msg, item_type)
+            if tool_message is not None:
+                out.append(tool_message)
             continue
 
         role = (msg.get("role") or "").lower()
@@ -190,6 +222,43 @@ def _map_messages(messages: Any) -> tuple[list[Message], str]:
         out.append(Message(role=mapped_role, parts=parts))
 
     return out, "\n\n".join(system_chunks)
+
+
+def _map_responses_tool_item(item: dict[str, Any], item_type: str) -> Message | None:
+    """Map a Responses API ``function_call``/``function_call_output`` item.
+
+    A ``function_call`` becomes an assistant TOOL_CALL and a
+    ``function_call_output`` a TOOL_RESULT, which is what the chat shape maps to,
+    so a rule that matches tool history matches the same conversation on either
+    route. Dropping them would leave a tool-using turn looking like it called
+    nothing: preflight tool filters would see no history to deny on, and the
+    recorded generation would lose its calls and results.
+
+    ``call_id`` pairs a call with its result. ``id`` is the item's own id and is
+    only a fallback, matching ``_map_responses_output``.
+    """
+    call_id = str(item.get("call_id") or item.get("id") or "")
+    name = str(item.get("name") or "")
+
+    if item_type == _RESPONSES_TOOL_CALL_ITEM_TYPE:
+        if not name:
+            return None
+        return Message(
+            role=MessageRole.ASSISTANT,
+            parts=[_make_tool_call_part(call_id=call_id, name=name, arguments=str(item.get("arguments") or ""))],
+        )
+
+    if item_type != _RESPONSES_TOOL_RESULT_ITEM_TYPE:
+        return None
+
+    # ``output`` is a string or a list of content parts. A result whose output is
+    # not text still records the pairing, so the call it answers does not read as
+    # unanswered.
+    return _tool_result_message(
+        content=_extract_text_content(item.get("output")),
+        tool_call_id=call_id,
+        name=name,
+    )
 
 
 def _map_thinking_parts(message: dict[str, Any]) -> list[Part]:
@@ -365,22 +434,10 @@ def _map_responses_output(response: Any) -> list[Message]:
                 out.append(Message(role=MessageRole.ASSISTANT, parts=parts))
             continue
 
-        if item_type == "function_call":
-            name = item.get("name") or ""
-            if not name:
-                continue
-            out.append(
-                Message(
-                    role=MessageRole.ASSISTANT,
-                    parts=[
-                        _make_tool_call_part(
-                            call_id=item.get("call_id") or item.get("id") or "",
-                            name=name,
-                            arguments=item.get("arguments") or "",
-                        )
-                    ],
-                )
-            )
+        if item_type == _RESPONSES_TOOL_CALL_ITEM_TYPE:
+            tool_message = _map_responses_tool_item(item, item_type)
+            if tool_message is not None:
+                out.append(tool_message)
             continue
 
         text = _extract_text_content(item.get("content"))
@@ -488,7 +545,16 @@ def _map_tool_definitions(kwargs: dict[str, Any]) -> list[ToolDefinition]:
     logs flat tools with ``parameters``. ``tool_definitions`` reads all three.
     """
     optional_params = kwargs.get("optional_params") or {}
-    tools = optional_params.get("tools")
+    return _map_tools_list(optional_params.get("tools"))
+
+
+def _map_tools_list(tools: Any) -> list[ToolDefinition]:
+    """Map an OpenAI-format ``tools`` list to agento11y ToolDefinitions.
+
+    Takes the list itself so it serves both the logging path
+    (``kwargs["optional_params"]["tools"]``) and the proxy pre-call path
+    (``data["tools"]``).
+    """
     if not tools or not isinstance(tools, list):
         return []
 
@@ -596,16 +662,26 @@ def _routing_metadata(slo: dict[str, Any]) -> dict[str, str]:
 
 
 def _metadata_sources(kwargs: dict[str, Any]) -> list[dict[str, Any]]:
-    """Collect the metadata dicts LiteLLM may attach to a request.
+    """Collect the metadata dicts LiteLLM may attach to a logged request."""
+    return _metadata_sources_from(kwargs.get("litellm_params") or {})
+
+
+def _metadata_sources_from(container: dict[str, Any]) -> list[dict[str, Any]]:
+    """Collect the metadata dicts LiteLLM may attach under ``container``.
 
     Chat completions carry client metadata in ``metadata``; assistant and thread
     routes use ``litellm_metadata``; metadata passed through the Router lands one
     level deeper, under ``metadata.metadata``.
+
+    The container is ``kwargs["litellm_params"]`` on the logging path and the raw
+    request body on the proxy pre-call path, where the same keys sit at the top
+    level.
     """
-    litellm_params = kwargs.get("litellm_params") or {}
+    if not isinstance(container, dict):
+        return []
     sources: list[dict[str, Any]] = []
     for key in ("metadata", "litellm_metadata"):
-        candidate = litellm_params.get(key)
+        candidate = container.get(key)
         if not isinstance(candidate, dict):
             continue
         sources.append(candidate)
@@ -613,6 +689,34 @@ def _metadata_sources(kwargs: dict[str, Any]) -> list[dict[str, Any]]:
         if isinstance(nested, dict):
             sources.append(nested)
     return sources
+
+
+def _resolve_conversation_id_from(container: dict[str, Any], sources: list[dict[str, Any]]) -> str:
+    """Resolve a conversation id from metadata, then LiteLLM's session fields.
+
+    Checks metadata keys first (conversation_id, session_id, thread_id), then
+    LiteLLM's built-in session tracking fields (litellm_session_id,
+    litellm_trace_id) in both metadata and ``container``. Returns "" when none
+    is present, so callers can apply their own fallback.
+    """
+    value = _first_metadata_value(sources, _CONVERSATION_ID_METADATA_KEYS)
+    if value:
+        return value
+
+    for key in _LITELLM_SESSION_KEYS:
+        value = _first_metadata_value(sources, (key,)) or container.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def _request_tags_from(sources: list[dict[str, Any]]) -> list[str]:
+    """Collect LiteLLM request tags (``metadata.tags``) from metadata sources."""
+    for source in sources:
+        tags = source.get("tags")
+        if isinstance(tags, list):
+            return [str(tag) for tag in tags if tag]
+    return []
 
 
 def _first_metadata_value(sources: list[dict[str, Any]], keys: tuple[str, ...]) -> str:
@@ -744,17 +848,9 @@ class Agento11yLiteLLMLogger(CustomLogger):
         then LiteLLM's built-in session tracking fields (litellm_session_id,
         litellm_trace_id) in both metadata and litellm_params.
         """
-        sources = _metadata_sources(kwargs)
-        value = _first_metadata_value(sources, ("conversation_id", "session_id", "thread_id"))
-        if value:
-            return value
-
         litellm_params = kwargs.get("litellm_params") or {}
-        for key in ("litellm_session_id", "litellm_trace_id"):
-            value = _first_metadata_value(sources, (key,)) or litellm_params.get(key)
-            if value:
-                return str(value)
-        return self._conversation_id
+        resolved = _resolve_conversation_id_from(litellm_params, _metadata_sources_from(litellm_params))
+        return resolved or self._conversation_id
 
     def _record_generation(
         self,
@@ -772,11 +868,7 @@ class Agento11yLiteLLMLogger(CustomLogger):
 
         is_stream = bool(slo.get("stream"))
 
-        tags: dict[str, str] = {
-            "agento11y.framework.name": "litellm",
-            "agento11y.framework.source": "handler",
-            "agento11y.framework.language": "python",
-        }
+        tags: dict[str, str] = dict(FRAMEWORK_TAGS)
         request_tags = slo.get("request_tags") or []
         for tag_value in request_tags:
             tag_str = str(tag_value)
@@ -879,11 +971,7 @@ class Agento11yLiteLLMLogger(CustomLogger):
         dimensions = _safe_cast(optional_params, "dimensions", int)
         encoding_format = optional_params.get("encoding_format") or ""
 
-        tags: dict[str, str] = {
-            "agento11y.framework.name": "litellm",
-            "agento11y.framework.source": "handler",
-            "agento11y.framework.language": "python",
-        }
+        tags: dict[str, str] = dict(FRAMEWORK_TAGS)
         for tag_value in slo.get("request_tags") or []:
             tag_str = str(tag_value)
             tags[f"litellm.tag.{tag_str}"] = tag_str

--- a/python-frameworks/litellm/example/README.md
+++ b/python-frameworks/litellm/example/README.md
@@ -50,6 +50,20 @@ Open `https://<your-stack>.grafana.net/a/grafana-agento11y-app/conversations`. G
 
 `config.yaml` defines the available models. Add more by following the [LiteLLM model list format](https://docs.litellm.ai/docs/proxy/configs).
 
+## Preflight rule enforcement
+
+`config.yaml` lists `agento11y_callback.agento11y_guards` as a second callback, which evaluates Agent Observability preflight guards before each request reaches the provider. Guards live in Agent Observability, not in this config; refer to [Set up guards](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/guides/guards/) for how to create one, and to the [package README](../README.md#guards) for what a rule does through this adapter.
+
+Three outcomes:
+
+- Allow (no rule matches, or every rule passes): the request goes through and the generation is exported as usual.
+- Deny: the proxy answers `400` with `blocked by guardrail agento11y: <reason> (rule <rule-id>)` and never calls the provider.
+- Evaluator unreachable: `HooksConfig.fail_open` is `True` in `agento11y_callback.py`, so the request is allowed and the proxy logs `agento11y: hook evaluation failed, allowing request (fail_open): ...`. Set `fail_open=False` to fail closed instead; the request then fails with a transport error before the provider is called.
+
+To see the fail-open path, point `AGENTO11Y_ENDPOINT` at an unreachable host and watch the proxy logs while making a request.
+
+Enforcement only happens through the proxy. A direct `litellm.completion()` call in your own process is not guarded, because LiteLLM never runs pre-call hooks on the SDK path.
+
 ## Attributing generations to the calling agent
 
 `agento11y_callback.py` names generations after the proxy only when a request
@@ -87,7 +101,9 @@ Point `config.yaml` at it:
 
 ```yaml
 litellm_settings:
-  callbacks: agento11y_callback_agent_from_key_alias.agento11y_handler
+  callbacks:
+    - agento11y_callback_agent_from_key_alias.agento11y_handler
+    - agento11y_callback.agento11y_guards
 ```
 
 and mount it alongside `config.yaml` in `docker-compose.yaml`:

--- a/python-frameworks/litellm/example/agento11y_callback.py
+++ b/python-frameworks/litellm/example/agento11y_callback.py
@@ -3,10 +3,11 @@
 import os
 
 from agento11y import Client
-from agento11y.config import AuthConfig, ClientConfig, GenerationExportConfig
-from agento11y_litellm import Agento11yLiteLLMLogger
+from agento11y.config import ApiConfig, AuthConfig, ClientConfig, GenerationExportConfig, HooksConfig
+from agento11y_litellm import Agento11yLiteLLMGuardrail, Agento11yLiteLLMLogger
 
 _endpoint = os.environ["AGENTO11Y_ENDPOINT"]
+_agent_name = "litellm-proxy-integration-test"
 
 client = Client(
     ClientConfig(
@@ -19,10 +20,23 @@ client = Client(
                 basic_password=os.environ.get("AGENTO11Y_AUTH_TOKEN", ""),
             ),
         ),
+        api=ApiConfig(endpoint=_endpoint),
+        # Preflight rule enforcement. 15s (the default) is too long to hold a
+        # proxy worker thread; keep it just above the guardrail's own timeout.
+        hooks=HooksConfig(enabled=True, timeout_seconds=3.0),
     )
 )
 
 agento11y_handler = Agento11yLiteLLMLogger(
     client=client,
-    agent_name="litellm-proxy-integration-test",
+    agent_name=_agent_name,
+)
+
+# Blocks denied requests before they reach the provider. Only active through the
+# proxy: LiteLLM never runs pre-call hooks on the direct SDK path.
+agento11y_guards = Agento11yLiteLLMGuardrail(
+    client=client,
+    agent_name=_agent_name,
+    request_timeout_seconds=2.0,
+    default_on=True,
 )

--- a/python-frameworks/litellm/example/config.yaml
+++ b/python-frameworks/litellm/example/config.yaml
@@ -8,7 +8,12 @@ model_list:
       model: anthropic/claude-sonnet-4-20250514
 
 litellm_settings:
-  callbacks: agento11y_callback.agento11y_handler
-  # Swap in this callback instead to name callers that send no agent identity
-  # after their virtual key rather than after the proxy:
-  # callbacks: agento11y_callback_agent_from_key_alias.agento11y_handler
+  callbacks:
+    # Swap in agento11y_callback_agent_from_key_alias.agento11y_handler to name
+    # callers that send no agent identity after their virtual key rather than
+    # after the proxy.
+    - agento11y_callback.agento11y_handler
+    # Preflight rule enforcement. Runs on every request; construct it with
+    # default_on=False to require callers to opt in with
+    # "guardrails": ["agento11y"] in their metadata.
+    - agento11y_callback.agento11y_guards

--- a/python-frameworks/litellm/tests/conftest.py
+++ b/python-frameworks/litellm/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Shared fixtures for the agento11y LiteLLM framework tests."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from agento11y.config import _WARNED_LEGACY_ENV
+
+
+@pytest.fixture(autouse=True)
+def _clear_agento11y_env(monkeypatch):
+    """Strip ambient AGENTO11Y_* / SIGIL_* / OTEL_* so Client() ignores the local shell.
+
+    Mirrors ``python/tests/conftest.py``. Without it, a developer who exports
+    ``AGENTO11Y_CONTENT_CAPTURE_MODE`` or ``AGENTO11Y_REDACT_INPUT_MESSAGES``
+    sees content-capture assertions fail here even though CI passes.
+    """
+    for key in list(os.environ):
+        if key.startswith(("AGENTO11Y_", "SIGIL_", "OTEL_")):
+            monkeypatch.delenv(key, raising=False)
+    _WARNED_LEGACY_ENV.clear()
+    yield
+    _WARNED_LEGACY_ENV.clear()

--- a/python-frameworks/litellm/tests/test_litellm_guard.py
+++ b/python-frameworks/litellm/tests/test_litellm_guard.py
@@ -1,0 +1,889 @@
+"""LiteLLM guardrail (preflight hook enforcement) tests."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+import threading
+import time
+import types
+from datetime import timedelta
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+import litellm
+import pytest
+from agento11y import ApiConfig, Client, ClientConfig, GenerationExportConfig, HooksConfig
+from agento11y.context import with_conversation_id
+from agento11y.errors import HookTransportError
+from agento11y.models import ExportGenerationResult, ExportGenerationsResponse
+from agento11y_litellm import (
+    DEFAULT_GUARDRAIL_NAME,
+    Agento11yLiteLLMGuardrail,
+    Agento11yLiteLLMLogger,
+    create_agento11y_litellm_guardrail,
+)
+from litellm.exceptions import GuardrailRaisedException
+from litellm.types.guardrails import GuardrailEventHooks
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+
+
+class _CapturingExporter:
+    def __init__(self) -> None:
+        self.requests: list[Any] = []
+
+    def export_generations(self, request: Any) -> ExportGenerationsResponse:
+        self.requests.append(request)
+        return ExportGenerationsResponse(
+            results=[ExportGenerationResult(generation_id=g.id, accepted=True) for g in request.generations]
+        )
+
+    def shutdown(self) -> None:
+        pass
+
+
+class _HookServer:
+    """Local hook-evaluation server with programmable responses and delays."""
+
+    def __init__(self) -> None:
+        self.requests: list[dict[str, Any]] = []
+        self.response: dict[str, Any] = {"action": "allow"}
+        self.status = 200
+        self.delay = 0.0
+        self.in_flight = 0
+        self.max_in_flight = 0
+        self._lock = threading.Lock()
+
+        server = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.0"
+
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", "0"))
+                body = self.rfile.read(length)
+                with server._lock:
+                    server.requests.append(
+                        {
+                            "path": self.path,
+                            "payload": json.loads(body.decode("utf-8")),
+                        }
+                    )
+                    server.in_flight += 1
+                    server.max_in_flight = max(server.max_in_flight, server.in_flight)
+                try:
+                    if server.delay:
+                        time.sleep(server.delay)
+                    encoded = json.dumps(server.response).encode("utf-8")
+                    self.send_response(server.status)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(encoded)))
+                    self.end_headers()
+                    self.wfile.write(encoded)
+                finally:
+                    with server._lock:
+                        server.in_flight -= 1
+
+            def log_message(self, _format, *_args):
+                return
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._server.daemon_threads = True
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self._server.server_address[1]}"
+
+    @property
+    def payloads(self) -> list[dict[str, Any]]:
+        return [entry["payload"] for entry in self.requests]
+
+    def close(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+
+
+@pytest.fixture
+def hook_server():
+    server = _HookServer()
+    try:
+        yield server
+    finally:
+        server.close()
+
+
+def _new_client(
+    api_endpoint: str,
+    *,
+    hooks: HooksConfig | None = None,
+    exporter: _CapturingExporter | None = None,
+) -> Client:
+    return Client(
+        ClientConfig(
+            generation_export=GenerationExportConfig(
+                batch_size=10,
+                flush_interval=timedelta(seconds=60),
+            ),
+            generation_exporter=exporter or _CapturingExporter(),
+            api=ApiConfig(endpoint=api_endpoint),
+            hooks=hooks if hooks is not None else HooksConfig(enabled=True, timeout_seconds=5.0),
+        )
+    )
+
+
+class _UserAPIKey:
+    """Stands in for ``litellm.proxy._types.UserAPIKeyAuth``.
+
+    The guardrail reads exactly one attribute off it, and importing the real
+    proxy type drags in optional proxy dependencies.
+    """
+
+    def __init__(self, parent_otel_span: Any = None) -> None:
+        self.parent_otel_span = parent_otel_span
+
+
+def _request_data(**overrides: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "hello"}],
+        "metadata": {},
+    }
+    data.update(overrides)
+    return data
+
+
+def _call(
+    guard: Agento11yLiteLLMGuardrail,
+    data: dict[str, Any],
+    user_api_key: Any = None,
+    call_type: str = "completion",
+) -> Any:
+    return asyncio.run(
+        guard.async_pre_call_hook(
+            user_api_key_dict=user_api_key or _UserAPIKey(),
+            cache=None,
+            data=data,
+            call_type=call_type,
+        )
+    )
+
+
+def test_preflight_allow_returns_none_and_leaves_data_untouched(hook_server):
+    hook_server.response = {"action": "allow"}
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+    data = _request_data()
+    before = json.dumps(data, sort_keys=True, default=str)
+
+    assert _call(guard, data) is None
+
+    assert len(hook_server.requests) == 1
+    assert hook_server.requests[0]["path"] == "/api/v1/hooks:evaluate"
+    assert data["messages"] == json.loads(before)["messages"]
+    assert data["model"] == "gpt-4o"
+    assert "tools" not in data
+
+
+def test_preflight_deny_raises_guardrail_exception(hook_server):
+    hook_server.response = {"action": "deny", "rule_id": "no-secrets", "reason": "contains a credential"}
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True, guardrail_name="agento11y-preflight")
+
+    with pytest.raises(GuardrailRaisedException) as excinfo:
+        _call(guard, _request_data())
+
+    assert "contains a credential" in str(excinfo.value)
+    assert "no-secrets" in str(excinfo.value)
+    assert "agento11y-preflight" in str(excinfo.value)
+    assert excinfo.value.guardrail_name == "agento11y-preflight"
+    assert excinfo.value.status_code == 400
+
+
+def test_preflight_request_shape(hook_server):
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(
+        client=client,
+        default_on=True,
+        agent_version="1.2.3",
+        extra_tags={"team": "search"},
+    )
+    data = _request_data(
+        messages=[
+            {"role": "system", "content": "policy"},
+            {"role": "user", "content": "hello"},
+        ],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": "look things up",
+                    "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+                },
+            }
+        ],
+        metadata={"agent_id": "search-agent", "tags": ["prod"], "session_id": "conv-7"},
+    )
+
+    assert _call(guard, data) is None
+
+    payload = hook_server.payloads[0]
+    assert payload["phase"] == "preflight"
+    assert payload["context"]["agent_name"] == "search-agent"
+    assert payload["context"]["agent_version"] == "1.2.3"
+    assert payload["context"]["conversation_id"] == "conv-7"
+    assert payload["context"]["model"] == {"provider": "openai", "name": "gpt-4o"}
+    assert payload["context"]["tags"] == {
+        "agento11y.framework.name": "litellm",
+        "agento11y.framework.source": "guardrail",
+        "agento11y.framework.language": "python",
+        "litellm.tag.prod": "prod",
+        "team": "search",
+    }
+    assert payload["input"]["system_prompt"] == "policy"
+    assert [m["parts"][0]["text"] for m in payload["input"]["messages"]] == ["hello"]
+    assert [t["name"] for t in payload["input"]["tools"]] == ["lookup"]
+    assert payload["input"]["conversation_preview"] == "hello"
+    assert [part["kind"] for m in payload["input"]["messages"] for part in m["parts"]] == ["text"]
+
+
+@pytest.mark.parametrize(
+    ("call_type", "data", "want_texts", "want_system_prompt", "want_preview"),
+    [
+        pytest.param(
+            "atext_completion",
+            {"model": "gpt-3.5-turbo-instruct", "prompt": "my password is hunter2", "metadata": {}},
+            ["my password is hunter2"],
+            "",
+            "my password is hunter2",
+            id="text_completion_prompt",
+        ),
+        pytest.param(
+            "atext_completion",
+            {"model": "gpt-3.5-turbo-instruct", "prompt": ["first", "second"], "metadata": {}},
+            ["first", "second"],
+            "",
+            "second",
+            id="text_completion_prompt_list",
+        ),
+        pytest.param(
+            "anthropic_messages",
+            {
+                "model": "claude-sonnet-4-20250514",
+                "system": [{"type": "text", "text": "you are a pirate"}],
+                "messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+                "metadata": {},
+            },
+            ["hello"],
+            "you are a pirate",
+            "hello",
+            id="anthropic_top_level_system",
+        ),
+        pytest.param(
+            "aresponses",
+            {
+                "model": "gpt-4o",
+                "instructions": "you are a pirate",
+                "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+                "metadata": {},
+            },
+            ["hello"],
+            "you are a pirate",
+            "hello",
+            id="responses_input_and_instructions",
+        ),
+        pytest.param(
+            "aresponses",
+            {"model": "gpt-4o", "input": "hello", "metadata": {}},
+            ["hello"],
+            "",
+            "hello",
+            id="responses_string_input",
+        ),
+        pytest.param(
+            "aimage_generation",
+            {"model": "dall-e-3", "prompt": "a cat wearing a hat", "metadata": {}},
+            ["a cat wearing a hat"],
+            "",
+            "a cat wearing a hat",
+            id="image_generation_prompt",
+        ),
+    ],
+)
+def test_non_chat_routes_send_their_input(hook_server, call_type, data, want_texts, want_system_prompt, want_preview):
+    """Every guarded route reaches the evaluator with its text.
+
+    The guard sees the request body before LiteLLM translates it, so the input
+    is under ``prompt`` on text completion and image generation, under ``input``
+    on ``/v1/responses``, and the system prompt is top-level on ``/v1/messages``
+    (``system``) and ``/v1/responses`` (``instructions``). Reading ``messages``
+    alone leaves content and system-prompt rules matching nothing on those
+    routes, which allows traffic a deny rule was written to block.
+    """
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+
+    assert _call(guard, data, call_type=call_type) is None
+
+    payload = hook_server.payloads[0]
+    assert [part["text"] for m in payload["input"]["messages"] for part in m["parts"]] == want_texts
+    assert payload["input"].get("system_prompt", "") == want_system_prompt
+    assert payload["input"].get("conversation_preview", "") == want_preview
+
+
+def test_deny_blocks_a_route_whose_input_is_not_in_messages(hook_server):
+    hook_server.response = {"action": "deny", "rule_id": "no-secrets", "reason": "contains a credential"}
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+    data = {"model": "gpt-3.5-turbo-instruct", "prompt": "my password is hunter2", "metadata": {}}
+
+    with pytest.raises(GuardrailRaisedException):
+        _call(guard, data, call_type="atext_completion")
+
+
+@pytest.mark.parametrize(
+    ("call_type", "data"),
+    [
+        pytest.param("aembedding", {"model": "text-embedding-3-small", "input": "hello"}, id="embedding"),
+        pytest.param("amoderation", {"model": "omni-moderation-latest", "input": "hello"}, id="moderation"),
+        pytest.param("arerank", {"model": "rerank-v3", "query": "hello", "documents": ["a"]}, id="rerank"),
+        pytest.param("aspeech", {"model": "tts-1", "input": "hello"}, id="speech"),
+        pytest.param("call_mcp_tool", {"name": "lookup", "arguments": {}}, id="mcp_tool_call"),
+        pytest.param("pass_through_endpoint", {"contents": [{"parts": [{"text": "hello"}]}]}, id="pass_through"),
+    ],
+)
+def test_routes_without_mappable_input_record_no_verdict(hook_server, call_type, data):
+    """An unmapped route is skipped rather than evaluated against empty input.
+
+    ``ProxyLogging.pre_call_hook`` runs this guardrail on every route it covers.
+    Evaluating one whose body this adapter cannot read would return allow and
+    record a verdict that reads like a completed check.
+    """
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+    data = {**data, "metadata": {}}
+
+    assert _call(guard, data, call_type=call_type) is None
+    assert hook_server.requests == []
+    assert "standard_logging_guardrail_information" not in data["metadata"]
+
+
+@pytest.mark.parametrize(
+    ("call_type", "body"),
+    [
+        pytest.param("acompletion", {"messages": []}, id="no_messages"),
+        pytest.param("atext_completion", {"prompt": [[1233, 8765]]}, id="token_id_prompt"),
+        pytest.param(
+            "acompletion",
+            {"messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "data:..."}}]}]},
+            id="image_only_content",
+        ),
+    ],
+)
+def test_request_without_evaluable_text_records_no_verdict(hook_server, call_type, body):
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+    data = {"model": "gpt-4o", "metadata": {}, **body}
+
+    assert _call(guard, data, call_type=call_type) is None
+    assert hook_server.requests == []
+    assert "standard_logging_guardrail_information" not in data["metadata"]
+
+
+@pytest.mark.parametrize(
+    ("call_type", "body"),
+    [
+        pytest.param(
+            "acompletion",
+            {
+                "messages": [
+                    {"role": "user", "content": "list the temp dir"},
+                    {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "shell_exec", "arguments": '{"cmd":"ls /tmp"}'},
+                            }
+                        ],
+                    },
+                    {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+                ]
+            },
+            id="chat_tool_calls",
+        ),
+        pytest.param(
+            "aresponses",
+            {
+                "input": [
+                    {"role": "user", "content": [{"type": "input_text", "text": "list the temp dir"}]},
+                    {
+                        "type": "function_call",
+                        "id": "fc_1",
+                        "call_id": "call_1",
+                        "name": "shell_exec",
+                        "arguments": '{"cmd":"ls /tmp"}',
+                    },
+                    {"type": "function_call_output", "call_id": "call_1", "output": "ok"},
+                ]
+            },
+            id="responses_function_call_items",
+        ),
+    ],
+)
+def test_tool_calls_in_history_keep_their_kind_on_the_wire(hook_server, call_type, body):
+    """A tool-filter guard only sees tool calls that arrive as ``tool_call`` parts.
+
+    The server dispatches on ``kind`` and recovers a missing one for text only,
+    so a mapped tool call without it reaches rule evaluation as an empty part
+    and every blocked_names pattern silently matches nothing.
+
+    ``/v1/responses`` keeps the same history in top-level ``function_call`` and
+    ``function_call_output`` items instead of role messages, so a mapper that
+    reads only chat shapes sends the turn with no tool history at all and rules
+    written against it match nothing.
+    """
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+    data = {"model": "gpt-4o", "metadata": {}, **body}
+
+    assert _call(guard, data, call_type=call_type) is None
+
+    messages = hook_server.payloads[0]["input"]["messages"]
+    assert [[part["kind"] for part in m["parts"]] for m in messages] == [["text"], ["tool_call"], ["tool_result"]]
+    assert [m["role"] for m in messages] == ["user", "assistant", "tool"]
+    tool_call = messages[1]["parts"][0]["tool_call"]
+    assert tool_call["name"] == "shell_exec"
+    assert tool_call["id"] == "call_1"
+    # Argument-level patterns such as shell_exec(*ls*) match against this, so it
+    # has to be the arguments themselves and not an encoded blob.
+    assert tool_call["input_json"] == {"cmd": "ls /tmp"}
+    assert messages[2]["parts"][0]["tool_result"]["tool_call_id"] == "call_1"
+    assert messages[2]["parts"][0]["tool_result"]["content"] == "ok"
+
+
+@pytest.mark.parametrize(
+    ("data_overrides", "want_provider", "want_name"),
+    [
+        pytest.param({"model": "gpt-4o"}, "openai", "gpt-4o", id="bare_name_in_model_map"),
+        pytest.param({"model": "openai/gpt-4o-mini"}, "openai", "openai/gpt-4o-mini", id="prefixed_model"),
+        pytest.param({"model": "claude-sonnet-4-5"}, "anthropic", "claude-sonnet-4-5", id="other_provider"),
+        pytest.param({"model": "prod-fast-alias"}, "unknown", "prod-fast-alias", id="deployment_alias"),
+        pytest.param({"model": ""}, "unknown", "unknown", id="missing_model"),
+        pytest.param(
+            {"model": "prod-fast-alias", "custom_llm_provider": "Bedrock"},
+            "bedrock",
+            "prod-fast-alias",
+            id="explicit_provider_wins",
+        ),
+    ],
+)
+def test_model_identity_is_never_empty(hook_server, data_overrides, want_provider, want_name):
+    """The hooks API rejects an empty provider or name, and a rejected evaluation fails open.
+
+    Sending either one empty means every rule is skipped and nothing is ever
+    denied, so the placeholder matters as much as a correct resolution.
+    """
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+
+    assert _call(guard, _request_data(**data_overrides)) is None
+
+    assert hook_server.payloads[0]["context"]["model"] == {"provider": want_provider, "name": want_name}
+
+
+def test_evaluation_preserves_context_variables(hook_server):
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+
+    with with_conversation_id("context-conversation"):
+        assert _call(guard, _request_data()) is None
+
+    assert hook_server.payloads[0]["context"]["conversation_id"] == "context-conversation"
+
+
+def test_trace_ids_come_from_parent_otel_span_not_ambient(hook_server):
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+    tracer = TracerProvider().get_tracer("agento11y-litellm-guard-test")
+    request_span = tracer.start_span("proxy-request")
+    request_ctx = request_span.get_span_context()
+
+    with tracer.start_as_current_span("auth-phase") as ambient:
+        ambient_ctx = ambient.get_span_context()
+        assert trace.get_current_span().get_span_context().span_id == ambient_ctx.span_id
+        _call(guard, _request_data(), _UserAPIKey(parent_otel_span=request_span))
+
+    context = hook_server.payloads[0]["context"]
+    assert context["trace_id"] == format(request_ctx.trace_id, "032x")
+    assert context["span_id"] == format(request_ctx.span_id, "016x")
+    assert context["span_id"] != format(ambient_ctx.span_id, "016x")
+
+
+def test_transformed_input_is_ignored(hook_server):
+    hook_server.response = {
+        "action": "allow",
+        "transformed_input": {
+            "system_prompt": "rewritten policy",
+            "messages": [{"role": "user", "parts": [{"text": "redacted"}]}],
+        },
+    }
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+    data = _request_data()
+
+    assert _call(guard, data) is None
+    assert data["messages"] == [{"role": "user", "content": "hello"}]
+
+
+@pytest.mark.parametrize("mode", ["post_call", "during_call", "logging_only"])
+def test_unsupported_modes_rejected_at_construction(mode):
+    client = _new_client("http://127.0.0.1:1")
+    with pytest.raises(ValueError, match=mode):
+        Agento11yLiteLLMGuardrail(client=client, event_hook=mode)
+
+
+@pytest.mark.parametrize(
+    "event_hook",
+    ["pre_call", GuardrailEventHooks.pre_call, ["pre_call"]],
+    ids=["string", "enum", "list"],
+)
+def test_pre_call_mode_is_accepted_in_every_shape(hook_server, event_hook):
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, event_hook=event_hook, default_on=True)
+
+    assert guard.event_hook == event_hook
+    assert _call(guard, _request_data()) is None
+    assert len(hook_server.requests) == 1
+
+
+def test_unsupported_mode_in_list_rejected_at_construction():
+    client = _new_client("http://127.0.0.1:1")
+    with pytest.raises(ValueError, match="post_call"):
+        Agento11yLiteLLMGuardrail(client=client, event_hook=["pre_call", "post_call"])
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"max_concurrent_evaluations": 0}, "max_concurrent_evaluations"),
+        ({"request_timeout_seconds": 0}, "request_timeout_seconds"),
+        ({"request_timeout_seconds": -1.0}, "request_timeout_seconds"),
+    ],
+)
+def test_invalid_limits_rejected_at_construction(kwargs, match):
+    client = _new_client("http://127.0.0.1:1")
+    with pytest.raises(ValueError, match=match):
+        Agento11yLiteLLMGuardrail(client=client, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "hooks",
+    [
+        HooksConfig(enabled=False),
+        HooksConfig(enabled=True, phases=["postflight"]),
+    ],
+    ids=["hooks-disabled", "preflight-phase-not-configured"],
+)
+def test_sdk_hook_configuration_short_circuits(hook_server, hooks):
+    client = _new_client(hook_server.url, hooks=hooks)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+
+    assert _call(guard, _request_data()) is None
+    assert hook_server.requests == []
+
+
+def test_guardrail_not_enabled_for_request_is_skipped(hook_server):
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=False)
+    data = _request_data()
+
+    assert guard.should_run_guardrail(data, GuardrailEventHooks.pre_call) is False
+    assert _call(guard, data) is None
+    assert hook_server.requests == []
+    assert "standard_logging_guardrail_information" not in data["metadata"]
+
+
+def test_constructor_defaults_are_enough_for_a_plain_callbacks_entry(hook_server):
+    """Registration is a ``litellm.callbacks`` entry, with no ``guardrails:`` block.
+
+    ``ProxyLogging.pre_call_hook`` walks ``litellm.callbacks`` and runs every
+    ``CustomGuardrail`` whose ``should_run_guardrail`` returns True, so the mode
+    and the per-request gate both have to come from the constructor.
+    """
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+
+    assert guard.event_hook == GuardrailEventHooks.pre_call
+    assert guard.should_run_guardrail(_request_data(), GuardrailEventHooks.pre_call) is True
+
+
+def test_guardrail_requested_per_request_runs(hook_server):
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=False)
+    data = _request_data(metadata={"guardrails": [DEFAULT_GUARDRAIL_NAME]})
+
+    assert _call(guard, data) is None
+    assert len(hook_server.requests) == 1
+
+
+def test_transport_failure_fail_open_allows_and_warns(hook_server, caplog):
+    hook_server.close()  # nothing is listening on that port any more
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, timeout_seconds=1.0, fail_open=True))
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True, request_timeout_seconds=5.0)
+
+    with caplog.at_level(logging.WARNING):
+        assert _call(guard, _request_data()) is None
+
+    assert any("allowing request (fail_open)" in record.getMessage() for record in caplog.records)
+
+
+def test_transport_failure_fail_closed_raises(hook_server):
+    hook_server.close()
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, timeout_seconds=1.0, fail_open=False))
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True, request_timeout_seconds=5.0)
+
+    with pytest.raises(HookTransportError):
+        _call(guard, _request_data())
+
+
+def test_slow_server_honors_request_timeout_and_fails_open(hook_server, caplog):
+    hook_server.delay = 1.0
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, timeout_seconds=5.0, fail_open=True))
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True, request_timeout_seconds=0.1)
+
+    async def _run() -> tuple[Any, float]:
+        started = time.monotonic()
+        result = await _evaluate(guard, _request_data())
+        return result, time.monotonic() - started
+
+    with caplog.at_level(logging.WARNING):
+        # Timed inside the loop: asyncio.run() joins the default executor on the
+        # way out, so it would also wait for the abandoned worker thread.
+        result, elapsed = asyncio.run(_run())
+
+    assert result is None
+    assert elapsed < 0.9
+    assert any("timed out after 0.1s" in record.getMessage() for record in caplog.records)
+
+
+def test_adapter_timeout_respects_fail_closed(hook_server):
+    hook_server.delay = 1.0
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, timeout_seconds=5.0, fail_open=False))
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True, request_timeout_seconds=0.1)
+
+    with pytest.raises(HookTransportError, match="timed out"):
+        _call(guard, _request_data())
+
+
+def test_event_loop_stays_responsive_during_evaluation(hook_server):
+    hook_server.delay = 0.5
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True, request_timeout_seconds=5.0)
+    order: list[str] = []
+
+    async def _heartbeat() -> None:
+        for _ in range(5):
+            await asyncio.sleep(0.01)
+        order.append("heartbeat")
+
+    async def _run() -> None:
+        beat = asyncio.create_task(_heartbeat())
+        await guard.async_pre_call_hook(
+            user_api_key_dict=_UserAPIKey(),
+            cache=None,
+            data=_request_data(),
+            call_type="completion",
+        )
+        order.append("hook")
+        await beat
+
+    asyncio.run(_run())
+
+    assert order == ["heartbeat", "hook"]
+    assert len(hook_server.requests) == 1
+
+
+def test_concurrency_ceiling_is_respected(hook_server):
+    hook_server.delay = 0.2
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(
+        client=client,
+        default_on=True,
+        max_concurrent_evaluations=2,
+        request_timeout_seconds=10.0,
+    )
+
+    async def _run() -> None:
+        await asyncio.gather(*(_evaluate(guard, _request_data()) for _ in range(3)))
+
+    asyncio.run(_run())
+
+    assert len(hook_server.requests) == 3
+    assert hook_server.max_in_flight <= 2
+
+
+def test_timed_out_waits_do_not_release_the_slot_early(hook_server):
+    """A worker still blocked in urllib keeps holding its concurrency slot.
+
+    Releasing on coroutine timeout instead would let a third evaluation start
+    while both workers are still in flight, putting three threads on the wire
+    with ``max_concurrent_evaluations=2``.
+    """
+    hook_server.delay = 0.6
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, timeout_seconds=5.0, fail_open=True))
+    guard = Agento11yLiteLLMGuardrail(
+        client=client,
+        default_on=True,
+        max_concurrent_evaluations=2,
+        request_timeout_seconds=0.25,
+    )
+
+    async def _late() -> None:
+        await asyncio.sleep(0.1)
+        await _evaluate(guard, _request_data())
+
+    async def _run() -> None:
+        await asyncio.gather(
+            _evaluate(guard, _request_data()),
+            _evaluate(guard, _request_data()),
+            _late(),
+        )
+        # Let the detached workers finish before the server is torn down.
+        await asyncio.sleep(0.6)
+
+    asyncio.run(_run())
+
+    assert len(hook_server.requests) == 2
+    assert hook_server.max_in_flight == 2
+
+
+def test_guardrail_information_is_recorded_in_request_metadata(hook_server):
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+    data = _request_data()
+
+    _call(guard, data)
+
+    entries = data["metadata"]["standard_logging_guardrail_information"]
+    assert len(entries) == 1
+    assert entries[0]["guardrail_name"] == DEFAULT_GUARDRAIL_NAME
+    assert entries[0]["guardrail_status"] == "success"
+
+
+def test_guardrail_deny_is_recorded_in_request_metadata(hook_server):
+    hook_server.response = {"action": "deny", "rule_id": "no-secrets", "reason": "contains a credential"}
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+    data = _request_data()
+
+    with pytest.raises(GuardrailRaisedException):
+        _call(guard, data)
+
+    entries = data["metadata"]["standard_logging_guardrail_information"]
+    assert len(entries) == 1
+    assert entries[0]["guardrail_status"] == "guardrail_intervened"
+
+
+def test_guardrail_span_is_emitted_for_the_request(hook_server, monkeypatch):
+    """LiteLLM's decorator hands each execution to its OTel guardrail emitter.
+
+    The span itself is built by LiteLLM and parented to the proxy request span
+    (``resolve_request_span_context``), which only exists inside a running
+    proxy; what this asserts is that our decorated hook reaches that emitter
+    with an entry naming this guardrail.
+    """
+    emitted: list[Any] = []
+    stub = types.ModuleType("litellm.integrations.otel.logger")
+    stub.emit_guardrail_span = emitted.append
+    # Stubbed as a module because importing the real one pulls in optional
+    # proxy dependencies that the SDK test environment does not have.
+    monkeypatch.setitem(sys.modules, "litellm.integrations.otel.logger", stub)
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+
+    _call(guard, _request_data())
+
+    assert [entry["guardrail_name"] for entry in emitted] == [DEFAULT_GUARDRAIL_NAME]
+    assert emitted[0]["guardrail_mode"] == GuardrailEventHooks.pre_call
+
+
+def test_guardrail_and_logger_register_without_double_export(hook_server):
+    """Both objects sit in ``litellm.callbacks``; only the logger may export."""
+    exporter = _CapturingExporter()
+    client = _new_client(hook_server.url, exporter=exporter)
+    logger_callback = Agento11yLiteLLMLogger(client=client)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+
+    original = list(litellm.callbacks)
+    try:
+        litellm.logging_callback_manager.add_litellm_callback(logger_callback)
+        litellm.logging_callback_manager.add_litellm_callback(guard)
+        registered = [cb for cb in litellm.callbacks if cb in (logger_callback, guard)]
+        assert registered == [logger_callback, guard]
+
+        kwargs, response_obj, start, end = _success_event()
+
+        async def _run() -> None:
+            for callback in registered:
+                await callback.async_log_success_event(kwargs, response_obj, start, end)
+
+        asyncio.run(_run())
+    finally:
+        litellm.callbacks = original
+
+    client.shutdown()
+    generations = [g for request in exporter.requests for g in request.generations]
+    assert len(generations) == 1
+
+
+def test_public_factory_builds_a_configured_guardrail():
+    client = _new_client("http://127.0.0.1:1")
+    guard = create_agento11y_litellm_guardrail(
+        client=client,
+        agent_name="static-agent",
+        guardrail_name="agento11y-preflight",
+        default_on=True,
+        max_concurrent_evaluations=4,
+        request_timeout_seconds=0.5,
+    )
+
+    assert isinstance(guard, Agento11yLiteLLMGuardrail)
+    assert guard.guardrail_name == "agento11y-preflight"
+    assert guard.default_on is True
+    assert guard.event_hook is GuardrailEventHooks.pre_call
+
+
+async def _evaluate(guard: Agento11yLiteLLMGuardrail, data: dict[str, Any]) -> Any:
+    return await guard.async_pre_call_hook(
+        user_api_key_dict=_UserAPIKey(),
+        cache=None,
+        data=data,
+        call_type="completion",
+    )
+
+
+def _success_event() -> tuple[dict[str, Any], Any, Any, Any]:
+    from datetime import datetime, timezone
+
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc)
+    slo = {
+        "call_type": "acompletion",
+        "id": "gen-1",
+        "model": "gpt-4o",
+        "custom_llm_provider": "openai",
+        "messages": [{"role": "user", "content": "hello"}],
+        "response": {"choices": [{"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}]},
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }
+    kwargs = {"standard_logging_object": slo, "litellm_params": {"metadata": {}}}
+    return kwargs, None, start, end

--- a/python-frameworks/litellm/tests/test_litellm_handler.py
+++ b/python-frameworks/litellm/tests/test_litellm_handler.py
@@ -2145,6 +2145,70 @@ def test_responses_api_reasoning_and_tool_call_mapped() -> None:
         client.shutdown()
 
 
+def test_responses_api_input_tool_items_mapped() -> None:
+    """Responses input keeps tool history in items without a role.
+
+    The logged ``messages`` are the ``input`` list as it arrived: the model's
+    call is a top-level ``function_call`` item and the result a
+    ``function_call_output`` item, neither carrying a role. Mapping only
+    role-shaped messages records a tool-using turn as if nothing was called.
+    """
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="aresponses",
+            custom_llm_provider="openai",
+            model="openai/gpt-4o-mini",
+            messages=[
+                {"role": "user", "content": [{"type": "input_text", "text": "weather in Berlin?"}]},
+                {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "get_weather",
+                    "arguments": '{"city": "Berlin"}',
+                },
+                {"type": "function_call_output", "call_id": "call_1", "output": "20C"},
+            ],
+            response={
+                "id": "resp_3",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "20C in Berlin"}],
+                    }
+                ],
+            },
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert [m.role for m in gen.input] == [MessageRole.USER, MessageRole.ASSISTANT, MessageRole.TOOL]
+        assert gen.input[0].parts[0].text == "weather in Berlin?"
+
+        tool_call = gen.input[1].parts[0].tool_call
+        # ``call_id`` pairs the call with its result; ``fc_1`` is the item's own id.
+        assert tool_call.id == "call_1"
+        assert tool_call.name == "get_weather"
+        assert tool_call.input_json == b'{"city": "Berlin"}'
+
+        tool_result = gen.input[2].parts[0].tool_result
+        assert tool_result.tool_call_id == "call_1"
+        assert tool_result.content == "20C"
+    finally:
+        client.shutdown()
+
+
 def test_anthropic_messages_output_mapped() -> None:
     """/v1/messages is chat-normalized by LiteLLM, so the chat mappers apply.
 

--- a/python/agento11y/client.py
+++ b/python/agento11y/client.py
@@ -22,7 +22,7 @@ from opentelemetry.trace import Span, SpanKind, Status, StatusCode, use_span
 
 from . import _experiments_transport
 from . import conversations as _conversations
-from .config import ClientConfig, resolve_config
+from .config import ClientConfig, HooksConfig, resolve_config
 from .context import (
     _pop_capture_mode,
     _push_capture_mode,
@@ -602,6 +602,17 @@ class Client:
                     rec.end()
 
         return out
+
+    @property
+    def hooks_config(self) -> HooksConfig:
+        """Returns a copy of the resolved hook configuration.
+
+        Adapters that call :meth:`evaluate_hook` behind their own timeout need
+        to know the configured fail-open policy so a timeout on their side
+        resolves the same way a transport failure does inside the SDK.
+        """
+
+        return copy.deepcopy(self._config.hooks)
 
     def evaluate_hook(self, request: HookEvaluateRequest) -> HookEvaluateResponse:
         """Evaluates synchronous hook rules for the given request.

--- a/python/agento11y/hooks.py
+++ b/python/agento11y/hooks.py
@@ -275,20 +275,33 @@ def _message_role_wire(role: Any) -> str:
 
 
 def _serialize_message(message: Message) -> dict[str, Any]:
+    """Serializes a message for the hooks API.
+
+    Every part carries its ``kind``. The server dispatches on that field and
+    only recovers a missing one for text, so a ``kind``-less thinking, tool
+    call, or tool result part reaches rule evaluation as an empty part: a
+    tool-filter guard sees no tool calls and allows the request.
+
+    Tool arguments and tool result payloads go out as embedded JSON, not
+    base64. The hooks API reads them as raw JSON, so a base64 blob is what
+    argument-level rules end up matching against. Generation export is the
+    other way around, because that is protobuf JSON.
+    """
+
     parts: list[dict[str, Any]] = []
     for part in message.parts:
         if part.kind == PartKind.TEXT and part.text:
-            parts.append({"text": part.text})
+            parts.append({"kind": PartKind.TEXT.value, "text": part.text})
         elif part.kind == PartKind.THINKING and part.thinking:
-            parts.append({"thinking": part.thinking})
+            parts.append({"kind": PartKind.THINKING.value, "thinking": part.thinking})
         elif part.kind == PartKind.TOOL_CALL and part.tool_call is not None:
             payload: dict[str, Any] = {
                 "id": part.tool_call.id,
                 "name": part.tool_call.name,
             }
             if part.tool_call.input_json:
-                payload["input_json"] = base64.b64encode(part.tool_call.input_json).decode("ascii")
-            parts.append({"tool_call": payload})
+                payload["input_json"] = _embedded_json(part.tool_call.input_json)
+            parts.append({"kind": PartKind.TOOL_CALL.value, "tool_call": payload})
         elif part.kind == PartKind.TOOL_RESULT and part.tool_result is not None:
             tr = part.tool_result
             tr_payload: dict[str, Any] = {
@@ -300,19 +313,39 @@ def _serialize_message(message: Message) -> dict[str, Any]:
             if tr.name:
                 tr_payload["name"] = tr.name
             if tr.content_json:
-                tr_payload["content_json"] = base64.b64encode(tr.content_json).decode("ascii")
-            parts.append({"tool_result": tr_payload})
+                tr_payload["content_json"] = _embedded_json(tr.content_json)
+            parts.append({"kind": PartKind.TOOL_RESULT.value, "tool_result": tr_payload})
         else:
             # Fallback: emit a minimal text part so the payload remains valid JSON.
             if part.text:
-                parts.append({"text": part.text})
+                parts.append({"kind": PartKind.TEXT.value, "text": part.text})
     out: dict[str, Any] = {"role": _message_role_wire(message.role), "parts": parts}
     if message.name:
         out["name"] = message.name
     return out
 
 
+def _embedded_json(raw: bytes) -> Any:
+    """Decodes JSON bytes for embedding in the hook payload.
+
+    Bytes that do not parse are sent as a JSON string, which keeps the request
+    body valid and leaves the text visible to rules instead of dropping it.
+    """
+
+    try:
+        return json.loads(raw)
+    except Exception:  # noqa: BLE001
+        return raw.decode("utf-8", errors="replace")
+
+
 def _serialize_tool(tool: ToolDefinition) -> dict[str, Any]:
+    """Serializes a tool definition for the hooks API.
+
+    ``input_schema_json`` stays base64 even though tool call arguments do not:
+    the server decodes the tools list straight into its protobuf type, which
+    rejects embedded JSON for a bytes field.
+    """
+
     out: dict[str, Any] = {"name": tool.name}
     if tool.description:
         out["description"] = tool.description

--- a/python/agento11y/hooks.py
+++ b/python/agento11y/hooks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
@@ -17,6 +18,8 @@ from .config import HooksConfig
 from .context import conversation_id_from_context
 from .errors import HookDeniedError, HookTransportError
 from .models import Message, MessageRole, Part, PartKind, ToolDefinition
+
+_logger = logging.getLogger("agento11y")
 
 HOOKS_EVALUATE_PATH = "/api/v1/hooks:evaluate"
 HOOK_TIMEOUT_HEADER = "X-Agento11y-Hook-Timeout-Ms"
@@ -203,6 +206,9 @@ def _allow_response() -> HookEvaluateResponse:
 
 def _fail_open_or_raise(fail_open: bool, detail: str) -> HookEvaluateResponse:
     if fail_open:
+        # A dead evaluator allows every request. Without this line that is
+        # completely silent, so an outage looks identical to a clean allow.
+        _logger.warning("agento11y: hook evaluation failed, allowing request (fail_open): %s", detail)
         return _allow_response()
     raise HookTransportError(f"agento11y hook evaluation failed: {detail}")
 

--- a/python/tests/test_hooks_transport.py
+++ b/python/tests/test_hooks_transport.py
@@ -25,8 +25,13 @@ from agento11y import (
     HookPhase,
     HooksConfig,
     HookTransportError,
+    Message,
     MessageRole,
+    Part,
+    PartKind,
+    ToolCall,
     ToolDefinition,
+    ToolResult,
     hook_denied_from_response,
     user_text_message,
     with_conversation_id,
@@ -388,6 +393,92 @@ def test_evaluate_hook_serializes_tool_definitions_including_deferred() -> None:
     assert [t["name"] for t in tools] == ["search", "approve_refund"]
     assert "deferred" not in tools[0]
     assert tools[1]["deferred"] is True
+
+
+def test_evaluate_hook_tags_every_part_with_its_kind() -> None:
+    """Guards dispatch on ``kind``, and only a text part survives without one.
+
+    A tool call sent without ``kind`` arrives at rule evaluation as an empty
+    part, so a tool-filter guard finds no tool calls and allows the request.
+    Tool arguments have to be embedded JSON for the same reason: the server
+    reads them as raw JSON, so a base64 blob is what an argument-level rule
+    like ``shell_exec(*cmd*)`` would match against.
+    """
+
+    messages = [
+        Message(
+            role=MessageRole.ASSISTANT,
+            parts=[
+                Part(kind=PartKind.THINKING, thinking="weighing options"),
+                Part(kind=PartKind.TEXT, text="running it"),
+                Part(
+                    kind=PartKind.TOOL_CALL,
+                    tool_call=ToolCall(id="call_1", name="shell_exec", input_json=b'{"cmd":"ls"}'),
+                ),
+            ],
+        ),
+        Message(
+            role=MessageRole.TOOL,
+            parts=[
+                Part(
+                    kind=PartKind.TOOL_RESULT,
+                    tool_result=ToolResult(tool_call_id="call_1", content="ok", content_json=b'{"status":"ok"}'),
+                )
+            ],
+        ),
+    ]
+
+    with _capturing_hook_server({"action": "allow", "evaluations": []}) as (captured, base_url):
+        client = _new_client(base_url, hooks=HooksConfig(enabled=True, phases=["preflight"]))
+        try:
+            client.evaluate_hook(
+                HookEvaluateRequest(
+                    phase=HookPhase.PREFLIGHT.value,
+                    context=HookContext(model=HookModel(provider="openai", name="gpt-4o")),
+                    input=HookInput(messages=messages),
+                )
+            )
+        finally:
+            client.shutdown()
+
+    wire_messages = captured["payload"]["input"]["messages"]
+    assert [[part["kind"] for part in message["parts"]] for message in wire_messages] == [
+        ["thinking", "text", "tool_call"],
+        ["tool_result"],
+    ]
+    tool_call = wire_messages[0]["parts"][2]["tool_call"]
+    assert tool_call["name"] == "shell_exec"
+    assert tool_call["input_json"] == {"cmd": "ls"}
+    tool_result = wire_messages[1]["parts"][0]["tool_result"]
+    assert tool_result["tool_call_id"] == "call_1"
+    assert tool_result["content_json"] == {"status": "ok"}
+
+
+def test_evaluate_hook_keeps_unparseable_tool_args_as_text() -> None:
+    """Bytes that are not JSON still have to leave the SDK as valid JSON."""
+
+    messages = [
+        Message(
+            role=MessageRole.ASSISTANT,
+            parts=[Part(kind=PartKind.TOOL_CALL, tool_call=ToolCall(name="shell_exec", input_json=b"not json"))],
+        )
+    ]
+
+    with _capturing_hook_server({"action": "allow", "evaluations": []}) as (captured, base_url):
+        client = _new_client(base_url, hooks=HooksConfig(enabled=True, phases=["preflight"]))
+        try:
+            client.evaluate_hook(
+                HookEvaluateRequest(
+                    phase=HookPhase.PREFLIGHT.value,
+                    context=HookContext(model=HookModel(provider="openai", name="gpt-4o")),
+                    input=HookInput(messages=messages),
+                )
+            )
+        finally:
+            client.shutdown()
+
+    tool_call = captured["payload"]["input"]["messages"][0]["parts"][0]["tool_call"]
+    assert tool_call["input_json"] == "not json"
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Adds preflight [guards](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/guides/guards/) support to the LiteLLM adapter. A denied request gets HTTP 400 instead of being sent to the model.

It is a `litellm.integrations.custom_guardrail.CustomGuardrail`, so it inherits LiteLLM's per-request and per-team opt-in, `default_on`, guardrail results in the standard logging payload, and the guardrail OTel span.

Example:

```python
# agento11y_callback.py, next to config.yaml
from agento11y import Client, ClientConfig, HooksConfig
from agento11y_litellm import Agento11yLiteLLMGuardrail, Agento11yLiteLLMLogger

client = Client(ClientConfig(hooks=HooksConfig(enabled=True, timeout_seconds=2.0)))

agento11y_handler = Agento11yLiteLLMLogger(client=client, agent_name="litellm-proxy")
agento11y_guards = Agento11yLiteLLMGuardrail(client=client, agent_name="litellm-proxy", default_on=True)
```

```yaml
# config.yaml
litellm_settings:
  callbacks:
    - agento11y_callback.agento11y_handler
    - agento11y_callback.agento11y_guards
```

- A timeout or an unexpected error in the guardrail follows `HooksConfig.fail_open` setting.
- `transformed_input` from the evaluator is ignored for now.
