### PR TITLE
feat(plugins/agento11y): support Cloud guards in --local mode

### DIFF
--- a/plugins/agento11y/internal/agents/guard/marker_sync_test.go
+++ b/plugins/agento11y/internal/agents/guard/marker_sync_test.go
@@ -1,0 +1,39 @@
+package guard
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// markerLiteral matches the TypeScript copies of EvaluationFailureRuleID.
+var markerLiteral = regexp.MustCompile(`EVALUATION_FAILURE_RULE_ID\s*=\s*"([^"]+)"`)
+
+// TestEvaluationFailureRuleID_MatchesPlugins compares the marker rule ID
+// against the two TypeScript copies of it.
+//
+// The Go tests bind to the symbol and each TS test hardcodes its own copy, so
+// changing the Go value alone leaves every suite green while the two plugins
+// stop recognising a fail-closed deny.
+func TestEvaluationFailureRuleID_MatchesPlugins(t *testing.T) {
+	// This test file lives at plugins/agento11y/internal/agents/guard.
+	plugins, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
+	require.NoError(t, err)
+
+	for _, plugin := range []string{"pi", "opencode"} {
+		t.Run(plugin, func(t *testing.T) {
+			path := filepath.Join(plugins, plugin, "src", "guard.ts")
+			src, err := os.ReadFile(path)
+			require.NoError(t, err, "the marker must stay comparable across languages; if %s moved, update this test", path)
+
+			m := markerLiteral.FindSubmatch(src)
+			require.NotNil(t, m, "%s no longer declares EVALUATION_FAILURE_RULE_ID as a string literal", path)
+			assert.Equal(t, EvaluationFailureRuleID, string(m[1]),
+				"%s must use the same marker as guard.EvaluationFailureRuleID, or a fail-closed deny is rendered as a policy denial", path)
+		})
+	}
+}

--- a/plugins/agento11y/internal/agents/guard/toolcall.go
+++ b/plugins/agento11y/internal/agents/guard/toolcall.go
@@ -38,10 +38,29 @@ func formatPolicyDeny(toolName, reason string) string {
 	return msg + "\n\n" + guardBehaviorHint
 }
 
-// formatEvalFailure is the fail-closed message used when the guard could not
+// EvaluationFailureRuleID marks a deny that reports a failed guard evaluation
+// rather than a policy decision. The local daemon sets it on the fail-closed
+// response it returns when its chained Cloud hook call fails, and every
+// consumer of a deny checks for it before wrapping the reason in
+// "a policy blocked this call" language, which would be wrong here.
+//
+// The value is chosen not to collide with a Cloud rule ID rather than
+// guaranteed not to: nothing in this repo validates Cloud's ID space. A rule
+// that did use this exact string would have its deny rendered as an evaluation
+// failure.
+//
+// Mirrored in plugins/pi/src/guard.ts and plugins/opencode/src/guard.ts. The
+// three are compared by TestEvaluationFailureRuleID_MatchesPlugins, because a
+// silent drift here would revert the honest fail-closed message with every
+// suite still green.
+const EvaluationFailureRuleID = "__agento11y_guard_evaluation_failure"
+
+// FormatEvalFailure is the fail-closed message used when the guard could not
 // be evaluated (missing credentials or transport failure). It explicitly
-// distinguishes the infrastructure failure from a policy decision.
-func formatEvalFailure(toolName, detail string) string {
+// distinguishes the infrastructure failure from a policy decision. Exported so
+// the local daemon's chained Cloud hook call produces the same wording as the
+// cloud-only path.
+func FormatEvalFailure(toolName, detail string) string {
 	msg := fmt.Sprintf("agento11y could not evaluate the Grafana Agent Observability guard for the %q tool call, so it was blocked as a safety measure.", toolName)
 	if d := strings.TrimSpace(detail); d != "" {
 		msg += " Details: " + d
@@ -131,7 +150,7 @@ func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCa
 		}
 		return Result{
 			Action: agento11y.HookActionDeny,
-			Reason: formatEvalFailure(in.ToolName, "missing AGENTO11Y_ENDPOINT/AGENTO11Y_AUTH_TENANT_ID/AGENTO11Y_AUTH_TOKEN"),
+			Reason: FormatEvalFailure(in.ToolName, "missing AGENTO11Y_ENDPOINT/AGENTO11Y_AUTH_TENANT_ID/AGENTO11Y_AUTH_TOKEN"),
 		}
 	}
 
@@ -204,7 +223,7 @@ func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCa
 		}
 		return Result{
 			Action: agento11y.HookActionDeny,
-			Reason: formatEvalFailure(in.ToolName, err.Error()),
+			Reason: FormatEvalFailure(in.ToolName, err.Error()),
 		}
 	}
 
@@ -239,6 +258,15 @@ func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCa
 		ruleID := ""
 		if resp != nil {
 			ruleID = resp.RuleID
+		}
+		// No rule produced this deny, and its reason already says so, so it must
+		// not go through formatPolicyDeny. See EvaluationFailureRuleID.
+		if ruleID == EvaluationFailureRuleID {
+			return Result{
+				Action: agento11y.HookActionDeny,
+				Reason: ruleReason,
+				RuleID: ruleID,
+			}
 		}
 		return Result{
 			Action: agento11y.HookActionDeny,

--- a/plugins/agento11y/internal/agents/guard/toolcall_test.go
+++ b/plugins/agento11y/internal/agents/guard/toolcall_test.go
@@ -33,6 +33,8 @@ func TestEvaluateToolCall(t *testing.T) {
 		toolName               string
 		wantAction             agento11y.HookAction
 		wantReasonSub          string
+		wantNoReasonSub        string
+		wantRuleID             string
 		wantUpdatedInput       string
 		wantLogSub             string
 		wantNoLogSub           string
@@ -77,6 +79,7 @@ func TestEvaluateToolCall(t *testing.T) {
 			toolName:         "bash",
 			wantAction:       agento11y.HookActionDeny,
 			wantReasonSub:    "blocked tool",
+			wantRuleID:       "r-1",
 			wantServerCalled: true,
 		},
 		{
@@ -174,6 +177,19 @@ func TestEvaluateToolCall(t *testing.T) {
 			toolName:         "bash",
 			wantAction:       agento11y.HookActionDeny,
 			wantReasonSub:    "blocked tool",
+			wantRuleID:       "r-1",
+			wantServerCalled: true,
+		},
+		{
+			// No rule ran, so the reason must reach the user as written.
+			name:             "evaluation-failure deny is not reported as a policy deny",
+			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:   `{"action":"deny","rule_id":"` + EvaluationFailureRuleID + `","reason":"` + "agento11y could not evaluate the guard" + `"}`,
+			toolName:         "bash",
+			wantAction:       agento11y.HookActionDeny,
+			wantReasonSub:    "could not evaluate",
+			wantNoReasonSub:  "policy blocked",
+			wantRuleID:       EvaluationFailureRuleID,
 			wantServerCalled: true,
 		},
 		{
@@ -242,6 +258,12 @@ func TestEvaluateToolCall(t *testing.T) {
 			}
 			if tt.wantReasonSub != "" && !strings.Contains(res.Reason, tt.wantReasonSub) {
 				t.Fatalf("Reason = %q, want substring %q", res.Reason, tt.wantReasonSub)
+			}
+			if tt.wantNoReasonSub != "" && strings.Contains(res.Reason, tt.wantNoReasonSub) {
+				t.Fatalf("Reason = %q, must not contain %q", res.Reason, tt.wantNoReasonSub)
+			}
+			if res.RuleID != tt.wantRuleID {
+				t.Errorf("RuleID = %q, want %q", res.RuleID, tt.wantRuleID)
 			}
 			if string(res.UpdatedInputJSON) != tt.wantUpdatedInput {
 				t.Errorf("UpdatedInputJSON = %q, want %q", res.UpdatedInputJSON, tt.wantUpdatedInput)

--- a/plugins/agento11y/internal/doctor/doctor.go
+++ b/plugins/agento11y/internal/doctor/doctor.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/grafana/agento11y/plugins/agento11y/internal/dotenv"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/local"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/updatecheck"
 )
 
@@ -63,6 +64,11 @@ var trackedSuffixes = []string{
 	"TAGS",
 	"AUTO_UPDATE",
 	"LOCAL_FORWARD",
+	// GUARDS_ENABLED is tracked for LocalHookForward only. Everything else
+	// reads the guard settings through envconfig.ResolveGuards, which is the
+	// hook process's view; the local daemon resolves this one config.env-first
+	// and that comparison needs both sources attributed.
+	"GUARDS_ENABLED",
 }
 
 // trackedKeys is the full key set SnapshotEnv records: both spellings of the
@@ -150,8 +156,26 @@ type ConfigSection struct {
 	// of the shell-first precedence reported here; a conflict is called out in
 	// Messages.
 	LocalForward envValue `json:"local_forward"`
-	Health       Health   `json:"status"`
-	Messages     []string `json:"messages,omitempty"`
+	// LocalHookForward is the combination users cannot infer from the two
+	// settings above: whether a `--local` session's guard checks are relayed to
+	// Cloud, which sends the content being evaluated whatever the capture mode
+	// says. See handleHookEvaluate in internal/local/server.go.
+	LocalHookForward HookForwardSection `json:"local_hook_forward"`
+	Health           Health             `json:"status"`
+	Messages         []string           `json:"messages,omitempty"`
+}
+
+// HookForwardSection is the resolved local-mode guard chaining posture. The
+// gate itself lives in the local package so the daemon and this report cannot
+// describe different rules.
+//
+// Its inputs are resolved config.env-first, unlike every other field here,
+// because this line describes what the daemon does and the daemon prefers
+// config.env over its own boot-time environment. When the two precedences
+// disagree about the answer, ConfigSection.Messages says so.
+type HookForwardSection struct {
+	Enabled bool   `json:"enabled"`
+	Reason  string `json:"reason,omitempty"`
 }
 
 // ConversationsSection reports the generation-export pipeline.
@@ -502,6 +526,23 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 	forward := resolveFamily("LOCAL_FORWARD", osEnv, fileEnv)
 	sec.LocalForward = forward.envValue()
 
+	// Guard chaining needs the forwarding opt-in, guards, a Cloud endpoint,
+	// and real credentials. Each of those is reported separately above and in
+	// the conversations section; the combination is what decides whether tool
+	// calls from a --local session are sent to Cloud, so state it outright.
+	//
+	// The daemon owns this decision and resolves config.env ahead of its own
+	// environment, so the inputs are resolved that way here too. Reporting the
+	// shell-first answer would let doctor print "not forwarded" while the daemon
+	// relays every tool call.
+	hookReason := hookForwardReason(daemonFamily, osEnv, fileEnv)
+	sec.LocalHookForward = HookForwardSection{Enabled: hookReason == "", Reason: hookReason}
+	if shellReason := hookForwardReason(resolveFamily, osEnv, fileEnv); (shellReason == "") != (hookReason == "") {
+		sec.Health = HealthWarn
+		sec.Messages = append(sec.Messages,
+			"config.env and the environment disagree about local guard chaining; the line above reports the daemon's answer, which prefers config.env")
+	}
+
 	if len(sec.DisallowedKeys) > 0 {
 		sec.Health = HealthWarn
 		sec.Messages = append(sec.Messages,
@@ -530,6 +571,21 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 			"%s is set in the environment and in config.env; the local daemon uses the config.env value", forward.key))
 	}
 	return sec
+}
+
+// hookForwardReason resolves the local guard-chaining gate with the given
+// precedence, so the same inputs can be read the daemon's way (config.env
+// first) and the shell's way and compared.
+func hookForwardReason(resolve func(suffix string, osEnv, fileEnv map[string]string) resolved, osEnv, fileEnv map[string]string) string {
+	forward := resolve("LOCAL_FORWARD", osEnv, fileEnv)
+	guards := resolve("GUARDS_ENABLED", osEnv, fileEnv)
+	return local.HookForwardReason(
+		forward.set && envconfig.ParseBool(forward.value),
+		guards.set && envconfig.ParseBool(guards.value),
+		resolve("ENDPOINT", osEnv, fileEnv).value,
+		resolve("AUTH_TENANT_ID", osEnv, fileEnv).value,
+		resolve("AUTH_TOKEN", osEnv, fileEnv).value,
+	)
 }
 
 func runProbes(ctx context.Context, r *Report, osEnv, fileEnv map[string]string) {
@@ -624,6 +680,26 @@ func resolveFamily(suffix string, osEnv, fileEnv map[string]string) resolved {
 	}
 	winner.conflict = other.set && other.value != winner.value
 	return winner
+}
+
+// daemonFamily resolves an alias family the way the local daemon does — file
+// preferred > file legacy > shell preferred > shell legacy — which is the
+// inverse of resolveFamily's source precedence. The daemon's own environment
+// was populated from config.env at boot, so preferring the file is what lets a
+// config.env edit reach a running daemon; anything describing daemon behavior
+// has to read it the same way.
+func daemonFamily(suffix string, osEnv, fileEnv map[string]string) resolved {
+	for _, env := range []struct {
+		values map[string]string
+		source string
+	}{{fileEnv, sourceConfig}, {osEnv, sourceEnv}} {
+		for _, key := range []string{envconfig.PreferredKey(suffix), envconfig.LegacyKey(suffix)} {
+			if v, ok := env.values[key]; ok && strings.TrimSpace(v) != "" {
+				return resolved{set: true, value: strings.TrimSpace(v), source: env.source, key: key}
+			}
+		}
+	}
+	return resolved{}
 }
 
 // tokenPrefix returns the non-sensitive scheme marker of a token (everything

--- a/plugins/agento11y/internal/doctor/doctor_test.go
+++ b/plugins/agento11y/internal/doctor/doctor_test.go
@@ -4,11 +4,22 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
+
+// mergeEnv returns the union of the given env maps, later entries winning.
+func mergeEnv(envs ...map[string]string) map[string]string {
+	out := map[string]string{}
+	for _, env := range envs {
+		maps.Copy(out, env)
+	}
+	return out
+}
 
 // isolateEnv points the dotenv/state roots at a fresh tempdir and clears the
 // tracked env vars so a test never reads the developer's real config.
@@ -695,6 +706,157 @@ func TestCollectConfig_LocalForward(t *testing.T) {
 			}
 			if !strings.Contains(joined, tc.wantMsg) {
 				t.Fatalf("messages %v missing %q", sec.Messages, tc.wantMsg)
+			}
+		})
+	}
+}
+
+// TestCollectConfig_LocalHookForward covers the derived line: whether a
+// --local session's guard checks reach Cloud. It is the combination of four
+// separately reported settings, and it is the one that decides whether tool
+// calls leave the machine under a reduced capture mode.
+func TestCollectConfig_LocalHookForward(t *testing.T) {
+	const cloud = "https://cloud.example.test"
+	// The table below builds osEnv by hand, so it cannot catch a family
+	// missing from the snapshot the binary actually passes in. Without this,
+	// a shell-exported guard toggle is invisible to doctor while the daemon
+	// acts on it.
+	for _, suffix := range []string{"LOCAL_FORWARD", "GUARDS_ENABLED", "ENDPOINT", "AUTH_TENANT_ID", "AUTH_TOKEN"} {
+		if !slices.Contains(trackedSuffixes, suffix) {
+			t.Fatalf("%s must be in trackedSuffixes or SnapshotEnv drops it and this report reads it as unset", suffix)
+		}
+	}
+	cloudCreds := map[string]string{
+		"AGENTO11Y_ENDPOINT": cloud, "AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+	}
+	tests := []struct {
+		name        string
+		env         map[string]string // shell
+		fileEnv     map[string]string // config.env
+		wantEnabled bool
+		wantReason  string // substring
+		wantMessage string // substring of a ConfigSection message; "" means none
+	}{
+		{
+			name: "forward and guards on with credentials",
+			env: map[string]string{
+				"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_GUARDS_ENABLED": "true",
+				"AGENTO11Y_ENDPOINT": cloud, "AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+			},
+			wantEnabled: true,
+		},
+		{
+			name: "forwarding off",
+			env: map[string]string{
+				"AGENTO11Y_GUARDS_ENABLED": "true",
+				"AGENTO11Y_ENDPOINT":       cloud, "AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+			},
+			wantReason: "LOCAL_FORWARD",
+		},
+		{
+			name: "guards off",
+			env: map[string]string{
+				"AGENTO11Y_LOCAL_FORWARD": "true",
+				"AGENTO11Y_ENDPOINT":      cloud, "AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+			},
+			wantReason: "GUARDS_ENABLED",
+		},
+		{
+			name: "local endpoint",
+			env: map[string]string{
+				"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_GUARDS_ENABLED": "true",
+				"AGENTO11Y_ENDPOINT": "http://127.0.0.1:8765", "AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+			},
+			wantReason: "is local",
+		},
+		{
+			name: "placeholder credentials",
+			env: map[string]string{
+				"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_GUARDS_ENABLED": "true",
+				"AGENTO11Y_ENDPOINT": cloud, "AGENTO11Y_AUTH_TENANT_ID": "local", "AGENTO11Y_AUTH_TOKEN": "local",
+			},
+			wantReason: "placeholder",
+		},
+		{
+			name: "missing credentials",
+			env: map[string]string{
+				"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_GUARDS_ENABLED": "true",
+				"AGENTO11Y_ENDPOINT": cloud,
+			},
+			wantReason: "Cloud credentials",
+		},
+		{
+			// The daemon prefers config.env over its own environment, so a
+			// config.env that turns guards on is what it acts on. Reporting
+			// the shell's answer here would print "not forwarded" while every
+			// tool call is being sent to Cloud.
+			name:        "config.env enables what the shell disables",
+			env:         mergeEnv(cloudCreds, map[string]string{"AGENTO11Y_GUARDS_ENABLED": "false"}),
+			fileEnv:     map[string]string{"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_GUARDS_ENABLED": "true"},
+			wantEnabled: true,
+			wantMessage: "disagree about local guard chaining",
+		},
+		{
+			name:        "config.env disables what the shell enables",
+			env:         mergeEnv(cloudCreds, map[string]string{"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_GUARDS_ENABLED": "true"}),
+			fileEnv:     map[string]string{"AGENTO11Y_GUARDS_ENABLED": "false"},
+			wantReason:  "GUARDS_ENABLED",
+			wantMessage: "disagree about local guard chaining",
+		},
+		{
+			// Agreeing sources must not produce the warning.
+			name:        "both sources agree",
+			env:         mergeEnv(cloudCreds, map[string]string{"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_GUARDS_ENABLED": "true"}),
+			fileEnv:     map[string]string{"AGENTO11Y_GUARDS_ENABLED": "true"},
+			wantEnabled: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateEnv(t)
+			// ResolveGuards reads the process environment directly, so the
+			// guard toggle has to be exported as well as passed in.
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+
+			sec := collectConfig(tc.env, tc.fileEnv)
+			if tc.wantMessage == "" {
+				for _, m := range sec.Messages {
+					if strings.Contains(m, "disagree about local guard chaining") {
+						t.Fatalf("unexpected precedence warning: %q", m)
+					}
+				}
+			} else if !slices.ContainsFunc(sec.Messages, func(m string) bool { return strings.Contains(m, tc.wantMessage) }) {
+				t.Fatalf("messages = %q, want one containing %q", sec.Messages, tc.wantMessage)
+			}
+			if sec.LocalHookForward.Enabled != tc.wantEnabled {
+				t.Fatalf("LocalHookForward.Enabled = %v, want %v (reason %q)", sec.LocalHookForward.Enabled, tc.wantEnabled, sec.LocalHookForward.Reason)
+			}
+			if tc.wantReason == "" {
+				if sec.LocalHookForward.Reason != "" {
+					t.Fatalf("Reason = %q, want empty", sec.LocalHookForward.Reason)
+				}
+			} else if !strings.Contains(sec.LocalHookForward.Reason, tc.wantReason) {
+				t.Fatalf("Reason = %q, want substring %q", sec.LocalHookForward.Reason, tc.wantReason)
+			}
+
+			// The rendered report must state the Cloud reach only when it is
+			// real, and must give the reason otherwise.
+			var buf bytes.Buffer
+			renderHuman(&buf, &Report{Config: sec}, false, false)
+			rendered := buf.String()
+			if tc.wantEnabled {
+				if !strings.Contains(rendered, "local hook evaluation reaches Cloud") {
+					t.Fatalf("rendered report missing the Cloud reach line:\n%s", rendered)
+				}
+				return
+			}
+			if strings.Contains(rendered, "local hook evaluation reaches Cloud") {
+				t.Fatalf("rendered report claims Cloud reach when the leg is off:\n%s", rendered)
+			}
+			if sec.LocalForward.Set && !strings.Contains(rendered, tc.wantReason) {
+				t.Fatalf("rendered report missing reason %q:\n%s", tc.wantReason, rendered)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/doctor/render.go
+++ b/plugins/agento11y/internal/doctor/render.go
@@ -130,6 +130,12 @@ func renderHuman(w io.Writer, r *Report, color, probed bool) {
 	if r.Config.LocalForward.Set {
 		writeKV(&b, p, "local forwarding", describeEnv(r.Config.LocalForward))
 	}
+	// Only worth a line once the user has opted into forwarding: with
+	// LOCAL_FORWARD unset chaining is always off, and that is already what the
+	// absent line above says.
+	if r.Config.LocalForward.Set {
+		writeKV(&b, p, "local guard checks", describeLocalHookForward(p, r.Config.LocalHookForward))
+	}
 	writeMessages(&b, p, r.Config.Messages)
 	b.WriteString("\n")
 
@@ -230,6 +236,16 @@ func describeGuards(p palette, c ConfigSection) string {
 		out += " " + p.faint("(invalid value, fell back)")
 	}
 	return out
+}
+
+// describeLocalHookForward renders whether a --local session's guard checks
+// reach Cloud, which is how a user learns their tool calls leave the machine
+// even under a reduced content capture mode.
+func describeLocalHookForward(p palette, h HookForwardSection) string {
+	if h.Enabled {
+		return "local hook evaluation reaches Cloud " + p.faint("(tool calls, and the conversation an agent runs a preflight check on, are sent for evaluation whatever the capture mode)")
+	}
+	return p.faint("not forwarded (" + h.Reason + ")")
 }
 
 func describeProbe(p *ProbeResult) string {

--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -72,14 +72,37 @@ var (
 	localBannerURL   = lipgloss.NewStyle().Underline(true)
 )
 
-func renderLocalBanner(uiURL string) string {
-	lines := []string{
-		localBannerTitle.Render("agento11y local mode"),
-		localBannerLabel.Render("Captured agent data stays on this machine."),
-		"",
-		localBannerLabel.Render("View ") + localBannerURL.Render(uiURL),
+func renderLocalBanner(uiURL string, posture local.ForwardPosture, postureErr error) string {
+	privacy := localPrivacyLines(posture, postureErr == nil)
+	lines := make([]string, 0, len(privacy)+3)
+	lines = append(lines, localBannerTitle.Render("agento11y local mode"))
+	for _, line := range privacy {
+		lines = append(lines, localBannerLabel.Render(line))
 	}
+	lines = append(lines, "", localBannerLabel.Render("View ")+localBannerURL.Render(uiURL))
 	return localBannerBox.Render(strings.Join(lines, "\n"))
+}
+
+// localPrivacyLines describes what leaves the machine in this session. The
+// daemon is shared and re-reads config.env, so the claim has to come from the
+// posture it reports rather than from the fact that --local was passed.
+func localPrivacyLines(posture local.ForwardPosture, known bool) []string {
+	switch {
+	case !known:
+		// The daemon did not answer. Say what is certain (the local store)
+		// rather than guess at the forwarding posture.
+		return []string{"Captured agent data is recorded on this machine."}
+	case !posture.Enabled:
+		return []string{"Captured agent data stays on this machine."}
+	case posture.Hooks:
+		return []string{
+			"Captured agent data is also forwarded to Grafana Cloud (" + posture.Mode + ").",
+			"Guard checks send tool calls, and any conversation checked before it is sent",
+			"to the model, to Cloud regardless of that mode.",
+		}
+	default:
+		return []string{"Captured agent data is also forwarded to Grafana Cloud (" + posture.Mode + ")."}
+	}
 }
 
 const usageLine = "usage: agento11y login | agento11y doctor [--json] [--probe] | agento11y local start|status|stop | agento11y cursor install|uninstall | agento11y <agent> hook | agento11y <claude|codex|copilot|opencode|pi|vibe> [--local] [--tag key=value]... [-- args...]"
@@ -593,7 +616,13 @@ func setupLocalLaunch(stderr io.Writer) (endpoint, otlp string, err error) {
 	endpoint = status.Endpoint
 	otlp = status.Endpoint + "/otlp"
 
-	_, _ = fmt.Fprintln(stderr, renderLocalBanner(status.Endpoint))
+	posture, postureErr := local.FetchForwardPosture(ctx, status.Endpoint)
+	if postureErr != nil {
+		// The banner falls back to wording that is true in every posture, which
+		// on its own reads like "nothing is forwarded". Say why it is hedged.
+		_, _ = fmt.Fprintf(stderr, "agento11y: could not read the daemon's forwarding posture: %v\n", postureErr)
+	}
+	_, _ = fmt.Fprintln(stderr, renderLocalBanner(status.Endpoint, posture, postureErr))
 	return endpoint, otlp, nil
 }
 

--- a/plugins/agento11y/internal/entry/entry_test.go
+++ b/plugins/agento11y/internal/entry/entry_test.go
@@ -885,6 +885,60 @@ func inProcessDaemon(t *testing.T) (dir string, baseURL string) {
 	return dir, ts.URL
 }
 
+// TestRenderLocalBanner_PrivacyClaimTracksPosture covers the one sentence in
+// the launcher banner that can be false: with forwarding on, and especially
+// with guard evaluation chained to Cloud, "stays on this machine" is wrong.
+func TestRenderLocalBanner_PrivacyClaimTracksPosture(t *testing.T) {
+	cases := []struct {
+		name       string
+		posture    local.ForwardPosture
+		postureErr error
+		want       []string
+		wantNone   []string
+	}{
+		{
+			name:     "forwarding_off",
+			want:     []string{"stays on this machine"},
+			wantNone: []string{"Grafana Cloud"},
+		},
+		{
+			name:     "forwarding_on",
+			posture:  local.ForwardPosture{Enabled: true, Mode: "metadata_only"},
+			want:     []string{"forwarded to Grafana Cloud", "metadata_only"},
+			wantNone: []string{"stays on this machine", "Guard checks"},
+		},
+		{
+			name:    "guards_chained",
+			posture: local.ForwardPosture{Enabled: true, Mode: "metadata_only", Hooks: true},
+			// Naming only tool calls would be too narrow: pi checks the
+			// outgoing conversation before it is sent to the model, and that
+			// request is relayed too.
+			want:     []string{"forwarded to Grafana Cloud", "Guard checks send tool calls", "before it is sent"},
+			wantNone: []string{"stays on this machine"},
+		},
+		{
+			// The daemon did not answer, so no posture may be claimed either
+			// way.
+			name:       "posture_unknown",
+			posture:    local.ForwardPosture{Enabled: true, Hooks: true},
+			postureErr: errors.New("connection refused"),
+			want:       []string{"recorded on this machine"},
+			wantNone:   []string{"stays on this machine", "Grafana Cloud"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := renderLocalBanner("http://127.0.0.1:8765", tc.posture, tc.postureErr)
+			for _, want := range tc.want {
+				assert.Contains(t, got, want)
+			}
+			for _, none := range tc.wantNone {
+				assert.NotContains(t, got, none)
+			}
+		})
+	}
+}
+
 // TestRun_LauncherLocalFlagInjectsOpts checks that --local before --
 // boots the receiver and surfaces a populated local env to every launcher.
 // The full launcher path (env injection, exec) is covered by each agent's

--- a/plugins/agento11y/internal/envconfig/envconfig.go
+++ b/plugins/agento11y/internal/envconfig/envconfig.go
@@ -335,14 +335,7 @@ func ResolveGuards(logger *log.Logger) GuardsConfig {
 		FailOpen:  resolveGuardsBool(logger, "GUARDS_FAIL_OPEN", defaultGuardsFailOpen),
 	}
 	if v, key, ok := LookupEnv("GUARDS_TIMEOUT_MS"); ok {
-		n, err := strconv.Atoi(v)
-		if err != nil || n <= 0 {
-			if logger != nil {
-				logger.Printf("config: invalid %s=%q; using %d", key, v, DefaultGuardsTimeoutMs)
-			}
-		} else {
-			cfg.TimeoutMs = n
-		}
+		cfg.TimeoutMs = IntValue(logger, key, v, DefaultGuardsTimeoutMs)
 	}
 	return cfg
 }
@@ -353,6 +346,24 @@ func resolveGuardsBool(logger *log.Logger, suffix string, def bool) bool {
 		return def
 	}
 	return BoolValue(logger, key, raw, def)
+}
+
+// IntValue parses a positive config integer from raw. Empty returns def; a
+// non-numeric, zero, or negative value is reported via logger (when non-nil)
+// and returns def. key is used only in the diagnostic message.
+func IntValue(logger *log.Logger, key, raw string, def int) int {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return def
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		if logger != nil {
+			logger.Printf("config: invalid %s=%q; using %d", key, raw, def)
+		}
+		return def
+	}
+	return n
 }
 
 // BoolValue parses a config boolean from raw using the guards whitelist

--- a/plugins/agento11y/internal/local/cloudguard.go
+++ b/plugins/agento11y/internal/local/cloudguard.go
@@ -1,0 +1,270 @@
+package local
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grafana/agento11y/go/agento11y"
+	"github.com/grafana/agento11y/go/proto/agento11y/wire"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/guard"
+)
+
+// hookTimeoutHeader carries the calling agent's hook budget to the daemon and
+// on to Cloud. It matches the SDK's own header (go/agento11y/hooks.go), which
+// is unexported there; this module builds against the released
+// github.com/grafana/agento11y/go tag, so the literal is duplicated and kept in
+// sync by hand.
+const hookTimeoutHeader = "X-Agento11y-Hook-Timeout-Ms"
+
+// legacyHookTimeoutHeader is the pre-rename spelling. Shipped Go hook
+// processes still send it: go v0.15.0, which this module is pinned to, has the
+// old name baked in. Both spellings are read so a mixed-version machine (new
+// daemon, older installed hook binary or plugin) still propagates its deadline.
+const legacyHookTimeoutHeader = "X-Sigil-Hook-Timeout-Ms"
+
+// hookTimeoutMargin is shaved off the agent-propagated hook budget before the
+// daemon issues its own Cloud call. The agent's HTTP client times out the
+// agent->daemon leg at the full budget, so the Cloud call has to return first
+// or the agent gives up and never sees the verdict.
+const hookTimeoutMargin = 250 * time.Millisecond
+
+// maxHookResponseBytes caps the Cloud hook response the daemon will decode,
+// mirroring the SDK's own limit.
+const maxHookResponseBytes = 4 << 20
+
+// maxHookFailureDetail caps how much of a Cloud error body ends up in a
+// recorded failure. That string is also the deny reason a fail-closed
+// evaluation hands the model, so an HTML error page from a proxy must not
+// become a multi-hundred-kilobyte tool result. Matches the cap post() applies
+// to the same kind of snippet.
+const maxHookFailureDetail = 512
+
+// evaluateCloudHook relays one hook request to Cloud and returns the parsed
+// verdict. A non-nil error means no verdict was obtained and the caller decides
+// what to do with it based on cfg.failOpen.
+//
+// body is the exact payload the calling agent sent. Relaying it verbatim means
+// the daemon cannot drop a field an agent's newer SDK knows about and this one
+// does not, and it sidesteps the released SDK client's phase filter: v0.15.0
+// defaults HooksConfig.Phases to preflight only, so routing this through the
+// SDK client would answer allow without contacting Cloud for exactly the
+// postflight tool-call checks this repo's own guard path sends.
+//
+// Failures are recorded in the forwarding failure ring, so the viewer shows a
+// hook leg that looks live but is not delivering.
+func (l *forwardLoader) evaluateCloudHook(ctx context.Context, cfg forwardConfig, timeout time.Duration, body []byte) (agento11y.HookEvaluateResponse, error) {
+	var out agento11y.HookEvaluateResponse
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.hookURL, bytes.NewReader(body))
+	if err != nil {
+		return out, l.recordHookFailure("build request for %s: %v", cfg.hookURL, err)
+	}
+	req.Header.Set("Content-Type", wire.ContentTypeJSON)
+	// The marker is what stops a daemon whose ENDPOINT was hand-set to its own
+	// address from chaining the relayed copy again.
+	req.Header.Set(forwardMarkerHeader, "1")
+	req.Header.Set(hookTimeoutHeader, strconv.FormatInt(timeout.Milliseconds(), 10))
+	for k, v := range cfg.hookHeaders {
+		if v != "" {
+			req.Header.Set(k, v)
+		}
+	}
+
+	// The shared client's 10s timeout is meant for the best-effort background
+	// legs; here the caller's budget is the authority, and it can legitimately
+	// be longer (a slow llm_judge evaluator). Copying the client keeps the
+	// injected transport, which is how tests reach a fake Cloud.
+	client := *l.client
+	client.Timeout = timeout
+	resp, err := client.Do(req)
+	if err != nil {
+		// A cancelled request context means the agent gave up (or the user
+		// interrupted) before Cloud answered. Cloud saw nothing wrong, and the
+		// verdict no longer has a reader, so it must not dilute the ring —
+		// which is the only place a real fail-open event is reported.
+		if isCallerAbort(err) {
+			return out, fmt.Errorf("POST %s: %w", cfg.hookURL, err)
+		}
+		return out, l.recordHookFailure("POST %s: %v", cfg.hookURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxHookResponseBytes+1))
+	if err != nil {
+		return out, l.recordHookFailure("read response from %s: %v", cfg.hookURL, err)
+	}
+	if len(respBody) > maxHookResponseBytes {
+		return out, l.recordHookFailure("response from %s is larger than %d bytes", cfg.hookURL, maxHookResponseBytes)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return out, l.recordHookFailure("POST %s status %d: %s", cfg.hookURL, resp.StatusCode, hookFailureDetail(respBody, http.StatusText(resp.StatusCode)))
+	}
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return out, l.recordHookFailure("decode response from %s: %v", cfg.hookURL, err)
+	}
+	// Mirrors the SDK's own decode: an omitted action is an allow.
+	if out.Action == "" {
+		out.Action = agento11y.HookActionAllow
+	}
+	// Cloud omits an empty evaluations list. Answer with the same shape the
+	// local verdict uses so the field is an array in every response the daemon
+	// serves, whether or not it was chained.
+	if out.Evaluations == nil {
+		out.Evaluations = []agento11y.HookEvaluation{}
+	}
+
+	l.recordSuccess(forwardLabelHooks)
+	return out, nil
+}
+
+// isCallerAbort reports whether a failed Cloud hook call means the caller went
+// away rather than the call going wrong: the agent's context was cancelled
+// before Cloud answered. Such an attempt produced no verdict anyone reads, so
+// it is kept out of both the failure ring and the fail-open count.
+//
+// The daemon's own deadline (context.DeadlineExceeded) is not an abort: Cloud
+// was too slow, the agent is still waiting, and the resolved fail mode decides
+// what it gets.
+func isCallerAbort(err error) bool {
+	return errors.Is(err, context.Canceled)
+}
+
+// hookFailureDetail reduces a Cloud error body to something safe to put in a
+// failure record: trimmed, truncated, and replaced by the given fall-back when
+// the body is empty.
+func hookFailureDetail(body []byte, fallback string) string {
+	detail := strings.TrimSpace(string(body))
+	if detail == "" {
+		return fallback
+	}
+	if len(detail) > maxHookFailureDetail {
+		return detail[:maxHookFailureDetail] + "… (truncated)"
+	}
+	return detail
+}
+
+// recordHookFailure records a failed Cloud hook call in the forwarding failure
+// ring and returns it as an error, so one call site both reports the failure to
+// the viewer and hands the caller the detail for a fail-closed deny reason.
+func (l *forwardLoader) recordHookFailure(format string, args ...any) error {
+	l.recordFailuref(forwardLabelHooks, format, args...)
+	return fmt.Errorf(format, args...)
+}
+
+// hookTimeoutFromHeader resolves the budget for the daemon's Cloud hook call
+// from the deadline the calling agent propagated, falling back to the given
+// value when no usable header is present. Both header spellings are read, the
+// branded one wins, and a margin is shaved off so the Cloud call returns before
+// the agent's own hook deadline fires.
+//
+// fallback is expected to be positive; intFamily guarantees that for the only
+// production caller.
+func hookTimeoutFromHeader(r *http.Request, fallback time.Duration) time.Duration {
+	timeout := fallback
+	for _, name := range []string{hookTimeoutHeader, legacyHookTimeoutHeader} {
+		ms, err := strconv.Atoi(strings.TrimSpace(r.Header.Get(name)))
+		if err == nil && ms > 0 {
+			timeout = time.Duration(ms) * time.Millisecond
+			break
+		}
+	}
+	// Subtract the margin when the budget can absorb it, otherwise halve it: a
+	// tiny budget still has to leave a positive window that returns before the
+	// agent->daemon leg expires, and keeping the full value would defeat the
+	// margin exactly where it matters most.
+	if timeout > hookTimeoutMargin {
+		return timeout - hookTimeoutMargin
+	}
+	return timeout / 2
+}
+
+// denyFromCloudError builds the fail-closed deny returned when the Cloud hook
+// call failed and GUARDS_FAIL_OPEN is false. It carries
+// guard.EvaluationFailureRuleID so every consumer can tell an infrastructure
+// failure from a policy decision, and reuses guard.FormatEvalFailure so the
+// wording matches the cloud-only path word for word.
+func denyFromCloudError(body []byte, err error) agento11y.HookEvaluateResponse {
+	detail := ""
+	if err != nil {
+		detail = err.Error()
+	}
+	return agento11y.HookEvaluateResponse{
+		Action:      agento11y.HookActionDeny,
+		RuleID:      guard.EvaluationFailureRuleID,
+		Reason:      guard.FormatEvalFailure(hookRequestToolName(body), detail),
+		Evaluations: []agento11y.HookEvaluation{},
+	}
+}
+
+// hookRequestToolName returns the name of the first tool call in a hook
+// request body (output messages first, then input messages) so the fail-closed
+// reason can name the blocked call. The body is decoded leniently and only for
+// this: a request the daemon cannot read is still relayed verbatim, and a
+// request with no tool call (a pi preflight context event) has no name to give.
+func hookRequestToolName(body []byte) string {
+	var req hookToolCallProbe
+	if err := json.Unmarshal(body, &req); err != nil {
+		return unknownToolName
+	}
+	for _, msgs := range [][]hookProbeMessage{req.Input.Output, req.Input.Messages} {
+		for _, m := range msgs {
+			for _, p := range m.Parts {
+				if name := strings.TrimSpace(p.toolCallName()); name != "" {
+					return name
+				}
+			}
+		}
+	}
+	return unknownToolName
+}
+
+// hookToolCallProbe is a lenient view of a hook request: just enough to name a
+// tool call. It is deliberately not agento11y.HookEvaluateRequest, which binds
+// the Go SDK's `kind` / `tool_call` spelling only. The JS SDK sends
+// `type` / `toolCall` (js/src/types.ts), so requests from the pi and opencode
+// plugins would decode into zero tool calls and every fail-closed message
+// would name the tool "unknown".
+type hookToolCallProbe struct {
+	Input struct {
+		Output   []hookProbeMessage `json:"output"`
+		Messages []hookProbeMessage `json:"messages"`
+	} `json:"input"`
+}
+
+type hookProbeMessage struct {
+	Parts []hookProbePart `json:"parts"`
+}
+
+// hookProbePart accepts both spellings of the tool-call payload. The two JSON
+// tags do not collide: encoding/json's case-insensitive fall-back compares
+// "tool_call" and "toolcall", which differ.
+type hookProbePart struct {
+	ToolCall   *hookProbeToolCall `json:"tool_call"`
+	ToolCallJS *hookProbeToolCall `json:"toolCall"`
+}
+
+func (p hookProbePart) toolCallName() string {
+	if p.ToolCall != nil {
+		return p.ToolCall.Name
+	}
+	if p.ToolCallJS != nil {
+		return p.ToolCallJS.Name
+	}
+	return ""
+}
+
+type hookProbeToolCall struct {
+	Name string `json:"name"`
+}
+
+// unknownToolName stands in when the hook request names no tool call, so the
+// fail-closed message reads as a sentence rather than referring to "".
+const unknownToolName = "unknown"

--- a/plugins/agento11y/internal/local/cloudguard_test.go
+++ b/plugins/agento11y/internal/local/cloudguard_test.go
@@ -1,0 +1,341 @@
+package local
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/agento11y/go/agento11y"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/guard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hookLoader builds a forward loader with the hook leg pointed at the fake
+// Cloud. resolveForwardConfig refuses a loopback endpoint, which is the whole
+// point of that gate, so the resolved config is assembled here by hand; the
+// gate itself is covered through the server in server_test.go.
+func hookLoader(t *testing.T, f *hookCloud) (*forwardLoader, forwardConfig) {
+	t.Helper()
+	clearForwardEnv(t)
+	l := newForwardLoader(writeConfigEnvFile(t, nil), nil)
+	l.client = f.srv.Client()
+	cfg := forwardConfig{
+		enabled:     true,
+		hookURL:     f.srv.URL + hookEvaluatePath,
+		hookHeaders: generationForwardHeaders("tenant-1", "token-1"),
+		failOpen:    true,
+		timeoutMs:   1500,
+	}
+	return l, cfg
+}
+
+// TestEvaluateCloudHook covers the verdicts and failure modes of the relay.
+// The caller applies cfg.failOpen; this level only reports whether a verdict
+// was obtained.
+func TestEvaluateCloudHook(t *testing.T) {
+	cases := []struct {
+		name          string
+		status        int
+		respond       string
+		delay         time.Duration
+		closeCloud    bool
+		timeout       time.Duration // defaults to a second
+		abortMidCall  bool          // cancel the caller's context while Cloud stalls
+		wantAction    agento11y.HookAction
+		wantRuleID    string
+		wantReason    string
+		wantFailure   string // substring of the returned error; "" means a verdict was obtained
+		assertMore    func(t *testing.T, resp agento11y.HookEvaluateResponse)
+		assertFailure func(t *testing.T, err error, failures []forwardFailure)
+	}{
+		{
+			name:       "allow",
+			respond:    `{"action":"allow","evaluations":[]}`,
+			wantAction: agento11y.HookActionAllow,
+		},
+		{
+			name:       "deny_keeps_rule_and_reason",
+			respond:    `{"action":"deny","rule_id":"r1","reason":"blocked by policy"}`,
+			wantAction: agento11y.HookActionDeny,
+			wantRuleID: "r1",
+			wantReason: "blocked by policy",
+		},
+		{
+			name:       "missing_action_is_allow",
+			respond:    `{}`,
+			wantAction: agento11y.HookActionAllow,
+		},
+		{
+			name:       "transform_survives_the_relay",
+			respond:    `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"c1","name":"bash","input_json":{"command":"echo safe"}}}]}]}}`,
+			wantAction: agento11y.HookActionAllow,
+			assertMore: func(t *testing.T, resp agento11y.HookEvaluateResponse) {
+				require.NotNil(t, resp.TransformedInput)
+				require.Len(t, resp.TransformedInput.Output, 1)
+				parts := resp.TransformedInput.Output[0].Parts
+				require.Len(t, parts, 1)
+				require.NotNil(t, parts[0].ToolCall)
+				assert.JSONEq(t, `{"command":"echo safe"}`, string(parts[0].ToolCall.InputJSON))
+			},
+		},
+		{
+			name:       "evaluations_survive_in_order",
+			respond:    `{"action":"allow","evaluations":[{"rule_id":"r1","passed":true},{"rule_id":"r2","passed":false}]}`,
+			wantAction: agento11y.HookActionAllow,
+			assertMore: func(t *testing.T, resp agento11y.HookEvaluateResponse) {
+				require.Len(t, resp.Evaluations, 2)
+				assert.Equal(t, "r1", resp.Evaluations[0].RuleID)
+				assert.Equal(t, "r2", resp.Evaluations[1].RuleID)
+			},
+		},
+		{
+			name:        "non_2xx",
+			status:      http.StatusServiceUnavailable,
+			respond:     `{"error":"upstream down"}`,
+			wantFailure: "status 503",
+		},
+		{
+			name:        "bad_json",
+			respond:     `{"action":`,
+			wantFailure: "decode response",
+		},
+		{
+			// A runaway Cloud response is a failure the caller's fail mode
+			// handles, not something the daemon buffers without limit.
+			name:        "oversized_response",
+			respond:     fmt.Sprintf(`{"action":"allow","reason":%q}`, strings.Repeat("x", maxHookResponseBytes)),
+			timeout:     5 * time.Second,
+			wantFailure: "larger than",
+		},
+		{
+			// A Cloud call that outlasts the budget is a failure, not a hang,
+			// so the caller can apply its fail mode before the agent's own
+			// hook deadline fires.
+			name:        "timeout",
+			respond:     `{"action":"allow"}`,
+			delay:       300 * time.Millisecond,
+			timeout:     30 * time.Millisecond,
+			wantFailure: "context deadline exceeded",
+		},
+		{
+			// An unreachable Cloud lands in the ring the viewer reads, which
+			// is the only channel a user without debug logging has.
+			name:        "transport_failure",
+			closeCloud:  true,
+			wantFailure: "POST",
+		},
+		{
+			// The Cloud error detail becomes the deny reason a fail-closed
+			// evaluation hands the model, so an HTML error page from a proxy
+			// must not arrive as a multi-hundred-kilobyte tool result. The
+			// viewer renders the same string.
+			name:        "oversized_error_body_is_truncated",
+			status:      http.StatusBadGateway,
+			respond:     strings.Repeat("<html>proxy is unhappy</html>", 4000),
+			wantFailure: "truncated",
+			assertFailure: func(t *testing.T, err error, failures []forwardFailure) {
+				assert.Less(t, len(err.Error()), maxHookFailureDetail+256)
+				assert.Less(t, len(failures[0].Detail), maxHookFailureDetail+256)
+			},
+		},
+		{
+			// The one error that must stay out of the ring: the agent gave up
+			// (or the user interrupted) before Cloud answered, so nothing was
+			// delivered but Cloud saw no problem either. Recording it would
+			// dilute the only channel that reports real fail-open events.
+			name:         "caller_abort_is_not_a_failure",
+			delay:        time.Second,
+			timeout:      time.Minute,
+			abortMidCall: true,
+			wantFailure:  context.Canceled.Error(),
+			assertFailure: func(t *testing.T, err error, _ []forwardFailure) {
+				require.ErrorIs(t, err, context.Canceled)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newHookCloud(t)
+			if tc.status != 0 {
+				f.status = tc.status
+			}
+			if tc.respond != "" {
+				f.respond = tc.respond
+			}
+			f.delay = tc.delay
+			l, cfg := hookLoader(t, f)
+			if tc.closeCloud {
+				f.srv.Close()
+			}
+			timeout := tc.timeout
+			if timeout == 0 {
+				timeout = time.Second
+			}
+
+			ctx, cancel := context.WithTimeout(t.Context(), timeout)
+			defer cancel()
+			if tc.abortMidCall {
+				go func() {
+					time.Sleep(20 * time.Millisecond)
+					cancel()
+				}()
+			}
+			resp, err := l.evaluateCloudHook(ctx, cfg, timeout, []byte(`{"phase":"postflight"}`))
+
+			failures := l.status().Failures
+			if tc.wantFailure == "" {
+				require.NoError(t, err)
+				assert.Equal(t, 1, f.count())
+				assert.Empty(t, failures)
+				assert.Equal(t, tc.wantAction, resp.Action)
+				assert.Equal(t, tc.wantRuleID, resp.RuleID)
+				assert.Equal(t, tc.wantReason, resp.Reason)
+				assert.NotNil(t, resp.Evaluations, "the response shape stays stable for consumers that index it")
+				if tc.assertMore != nil {
+					tc.assertMore(t, resp)
+				}
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantFailure)
+			if tc.abortMidCall {
+				assert.Empty(t, failures, "a caller-side abort is not a Cloud delivery failure")
+			} else {
+				require.Len(t, failures, 1)
+				assert.Equal(t, forwardLabelHooks, failures[0].Label)
+				assert.Contains(t, failures[0].Detail, tc.wantFailure)
+			}
+			if tc.assertFailure != nil {
+				tc.assertFailure(t, err, failures)
+			}
+		})
+	}
+}
+
+// TestEvaluateCloudHook_SuccessClearsFailures covers the ring's semantics for
+// the hook leg: a delivered evaluation means the leg is healthy now.
+func TestEvaluateCloudHook_SuccessClearsFailures(t *testing.T) {
+	f := newHookCloud(t)
+	f.status = http.StatusInternalServerError
+	l, cfg := hookLoader(t, f)
+
+	_, err := l.evaluateCloudHook(t.Context(), cfg, time.Second, []byte(`{}`))
+	require.Error(t, err)
+	require.Len(t, l.status().Failures, 1)
+
+	f.status = http.StatusOK
+	_, err = l.evaluateCloudHook(t.Context(), cfg, time.Second, []byte(`{}`))
+	require.NoError(t, err)
+	assert.Empty(t, l.status().Failures)
+}
+
+// TestHookTimeoutFromHeader covers the budget the daemon gives its Cloud call.
+// Two header spellings are in the wild: shipped Go hook processes send the
+// legacy one, JS plugins send the branded one.
+func TestHookTimeoutFromHeader(t *testing.T) {
+	const fallback = 1500 * time.Millisecond
+	cases := []struct {
+		name    string
+		headers map[string]string
+		want    time.Duration
+	}{
+		{name: "branded_header", headers: map[string]string{hookTimeoutHeader: "5000"}, want: 4750 * time.Millisecond},
+		{name: "legacy_header", headers: map[string]string{legacyHookTimeoutHeader: "5000"}, want: 4750 * time.Millisecond},
+		{
+			name:    "branded_wins_over_legacy",
+			headers: map[string]string{hookTimeoutHeader: "5000", legacyHookTimeoutHeader: "9000"},
+			want:    4750 * time.Millisecond,
+		},
+		// The margin applies to the fallback too: GUARDS_TIMEOUT_MS is the same
+		// knob the agent uses for its own hook deadline, so the daemon still
+		// has to return first.
+		{name: "no_header_uses_fallback", want: fallback - hookTimeoutMargin},
+		{name: "budget_smaller_than_margin_is_halved", headers: map[string]string{hookTimeoutHeader: "100"}, want: 50 * time.Millisecond},
+		{name: "budget_equal_to_margin_is_halved", headers: map[string]string{hookTimeoutHeader: "250"}, want: 125 * time.Millisecond},
+		{name: "non_numeric_falls_back", headers: map[string]string{hookTimeoutHeader: "soon"}, want: fallback - hookTimeoutMargin},
+		{name: "zero_falls_back", headers: map[string]string{hookTimeoutHeader: "0"}, want: fallback - hookTimeoutMargin},
+		{name: "negative_falls_back", headers: map[string]string{hookTimeoutHeader: "-100"}, want: fallback - hookTimeoutMargin},
+		{
+			// An unusable branded value must not shadow a usable legacy one.
+			name:    "invalid_branded_falls_through_to_legacy",
+			headers: map[string]string{hookTimeoutHeader: "soon", legacyHookTimeoutHeader: "5000"},
+			want:    4750 * time.Millisecond,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, hookEvaluatePath, nil)
+			for k, v := range tc.headers {
+				r.Header.Set(k, v)
+			}
+			assert.Equal(t, tc.want, hookTimeoutFromHeader(r, fallback))
+			assert.Positive(t, hookTimeoutFromHeader(r, fallback), "a non-positive budget would fail the call instantly")
+		})
+	}
+}
+
+// TestDenyFromCloudError covers the fail-closed response. Its rule ID is the
+// marker every consumer checks, and its wording has to say the guard could not
+// be evaluated rather than that a policy blocked the call.
+func TestDenyFromCloudError(t *testing.T) {
+	body := []byte(`{"phase":"postflight","input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"c1","name":"Bash"}}]}]}}`)
+	resp := denyFromCloudError(body, errors.New("POST https://cloud.example.test/api/v1/hooks:evaluate: connection refused"))
+
+	assert.Equal(t, agento11y.HookActionDeny, resp.Action)
+	assert.Equal(t, guard.EvaluationFailureRuleID, resp.RuleID)
+	assert.Equal(t, guard.FormatEvalFailure("Bash", "POST https://cloud.example.test/api/v1/hooks:evaluate: connection refused"), resp.Reason)
+	assert.Contains(t, resp.Reason, "could not evaluate")
+	assert.NotContains(t, resp.Reason, "policy blocked")
+	assert.NotNil(t, resp.Evaluations)
+}
+
+// TestHookRequestToolName covers naming the blocked call in the fail-closed
+// message across the request shapes the daemon receives. The Go and JS SDKs
+// serialize a tool-call part differently, and the JS shape is what the pi and
+// opencode plugins send.
+func TestHookRequestToolName(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "go_sdk_output_tool_call",
+			body: `{"input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"name":"Bash"}}]}]}}`,
+			want: "Bash",
+		},
+		{
+			name: "js_sdk_output_tool_call",
+			body: `{"input":{"output":[{"role":"assistant","parts":[{"type":"tool_call","toolCall":{"id":"c1","name":"bash","inputJSON":"{}"}}]}]}}`,
+			want: "bash",
+		},
+		{
+			name: "falls_back_to_input_messages",
+			body: `{"input":{"messages":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"name":"Read"}}]}]}}`,
+			want: "Read",
+		},
+		{
+			name: "output_wins_over_messages",
+			body: `{"input":{"messages":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"name":"Read"}}]}],"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"name":"Bash"}}]}]}}`,
+			want: "Bash",
+		},
+		{
+			name: "skips_parts_without_a_tool_call",
+			body: `{"input":{"output":[{"role":"assistant","parts":[{"type":"text","text":"running it"},{"type":"tool_call","toolCall":{"name":"Edit"}}]}]}}`,
+			want: "Edit",
+		},
+		{name: "preflight_without_tool_call", body: `{"phase":"preflight","input":{"messages":[]}}`, want: unknownToolName},
+		{name: "undecodable_body", body: `{"phase":`, want: unknownToolName},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, hookRequestToolName([]byte(tc.body)))
+		})
+	}
+}

--- a/plugins/agento11y/internal/local/forward.go
+++ b/plugins/agento11y/internal/local/forward.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"slices"
 	"strings"
@@ -36,15 +37,30 @@ import (
 const maxInFlightForwards = 8
 
 // maxRecordedForwardFailures caps the failure ring the loader keeps for
-// forwardStatus. The daemon's logger writes to io.Discard unless debug logging
-// is on, so the status endpoint is the only channel a runtime failure (rotated
-// token, unreachable Cloud) can reach the user through.
+// forwardStatus, per leg. The daemon's logger writes to io.Discard unless debug
+// logging is on, so the status endpoint is the only channel a runtime failure
+// (rotated token, unreachable Cloud) can reach the user through. The cap is
+// per-label because the legs fail at wildly different rates: the hook leg
+// records once per tool call, and a global ring would let it evict a
+// generation export Cloud has been rejecting all session.
 const maxRecordedForwardFailures = 5
 
 // forwardLabelGenerations names the generation-export leg in the failure ring.
-// The two legs are recorded and cleared independently, so the label a queued
+// The legs are recorded and cleared independently, so the label a queued
 // payload is dropped under must match the one its POST reports.
 const forwardLabelGenerations = "generations"
+
+// forwardLabelHooks names the guard-evaluation leg in the failure ring. Unlike
+// the other two legs this one is synchronous: a failure here changes the
+// verdict the agent acts on, so it is worth surfacing in the same place.
+const forwardLabelHooks = "hooks"
+
+// hookEvaluatePath is the Cloud hook endpoint the daemon relays to. There is
+// no wire.HooksEvaluateHTTPPath constant, and adding one to
+// go/proto/agento11y/wire would not help: this module builds against the
+// released github.com/grafana/agento11y/go tag, so a new constant there is
+// unusable until the next go/v* release.
+const hookEvaluatePath = "/api/v1/hooks:evaluate"
 
 // otlpForwardLabel names one OTLP signal leg in the failure ring.
 func otlpForwardLabel(signal string) string { return "otlp/" + signal }
@@ -119,21 +135,37 @@ type forwardConfig struct {
 	otlpEndpoint string            // base OTLP endpoint ("" = not forwarded)
 	otlpHeaders  map[string]string // the exporter's header set for this endpoint
 	otlpReason   string            // why OTLP is not forwarded
+
+	hookURL     string            // Cloud /api/v1/hooks:evaluate URL ("" = not chained)
+	hookHeaders map[string]string // Basic auth + tenant header, same pair as generations
+	hookReason  string            // why hook evaluation is not chained to Cloud
+
+	// failOpen and timeoutMs are the guard policy the chained hook call
+	// applies: whether a failed Cloud evaluation allows the tool call, and
+	// the budget used when the agent propagates no deadline of its own. They
+	// hold their documented defaults (fail open, DefaultGuardsTimeoutMs) on
+	// every path that refuses the hook leg, so a partially resolved config
+	// never reads as an explicit "fail closed".
+	failOpen  bool
+	timeoutMs int
 }
 
 // disabledReasons joins the per-leg refusal reasons for logging, or "" when
-// both legs are live (or forwarding is simply off). One reason shared by both
+// every leg is live (or forwarding is simply off). One reason shared by all
 // legs is a whole-config refusal and drops the per-leg prefixes.
 func (c forwardConfig) disabledReasons() string {
-	if c.genReason == c.otlpReason {
+	if c.genReason == c.otlpReason && c.genReason == c.hookReason {
 		return c.genReason
 	}
-	parts := make([]string, 0, 2)
+	parts := make([]string, 0, 3)
 	if c.genReason != "" {
 		parts = append(parts, "generations: "+c.genReason)
 	}
 	if c.otlpReason != "" {
 		parts = append(parts, "otlp: "+c.otlpReason)
+	}
+	if c.hookReason != "" {
+		parts = append(parts, "hooks: "+c.hookReason)
 	}
 	return strings.Join(parts, "; ")
 }
@@ -158,10 +190,12 @@ type forwardLoader struct {
 	cached       forwardConfig
 	loggedReason string // last refusal logged, so we log it only once
 
-	// failMu guards the failure ring, which is written from forward
-	// goroutines and read by the status endpoint.
-	failMu   sync.Mutex
-	failures []forwardFailure
+	// failMu guards the failure ring and the fail-open counter, which are
+	// written from forward goroutines and the hook handler and read by the
+	// status endpoint.
+	failMu    sync.Mutex
+	failures  []forwardFailure
+	failOpens int
 }
 
 func newForwardLoader(path string, logger *log.Logger) *forwardLoader {
@@ -225,6 +259,10 @@ type forwardStatus struct {
 	// credentials the generation export cannot use.
 	Generations bool `json:"generations"`
 	OTLP        bool `json:"otlp"`
+	// Hooks reports whether guard evaluation from a --local session is
+	// relayed to Cloud. It is gated harder than the other two legs, so it can
+	// be off while both of them deliver.
+	Hooks bool `json:"hooks"`
 	// Reason explains why generations are not forwarded although the user
 	// opted in (empty endpoint, placeholder credentials, unreadable config).
 	// Empty when forwarding is simply not enabled.
@@ -232,11 +270,20 @@ type forwardStatus struct {
 	// OTLPReason is the same for the OTLP leg (no endpoint configured, or a
 	// local endpoint that would loop back into this daemon).
 	OTLPReason string `json:"otlpReason,omitempty"`
+	// HookReason is the same for the hook leg (guards off, a local endpoint
+	// with no Cloud rules to consult, or unusable credentials).
+	HookReason string `json:"hookReason,omitempty"`
 	// Failures are the forward attempts that failed since the last success,
 	// most recent first. Non-empty means the current posture is not actually
 	// delivering, which no other channel would tell the user about: the
 	// daemon's logger is discarded unless debug logging is on.
 	Failures []forwardFailure `json:"failures,omitempty"`
+	// HookFailOpens counts the tool calls allowed since the daemon started
+	// because a chained guard evaluation failed and GUARDS_FAIL_OPEN was on.
+	// Unlike Failures it is never cleared: the agent cannot tell such an allow
+	// from a Cloud allow, so a count that a later success wiped would leave no
+	// trace that the guard did not run.
+	HookFailOpens int `json:"hookFailOpens,omitempty"`
 }
 
 // forwardFailure is one failed forward attempt, kept so the viewer can show
@@ -259,13 +306,16 @@ const (
 func (l *forwardLoader) status() forwardStatus {
 	cfg := l.load()
 	st := forwardStatus{
-		Enabled:     cfg.enabled,
-		Mode:        forwardModeOff,
-		Generations: cfg.genURL != "",
-		OTLP:        cfg.otlpEndpoint != "",
-		Reason:      cfg.genReason,
-		OTLPReason:  cfg.otlpReason,
-		Failures:    l.recentFailures(),
+		Enabled:       cfg.enabled,
+		Mode:          forwardModeOff,
+		Generations:   cfg.genURL != "",
+		OTLP:          cfg.otlpEndpoint != "",
+		Hooks:         cfg.hookURL != "",
+		Reason:        cfg.genReason,
+		OTLPReason:    cfg.otlpReason,
+		HookReason:    cfg.hookReason,
+		Failures:      l.recentFailures(),
+		HookFailOpens: l.recentFailOpens(),
 	}
 	switch {
 	case !cfg.enabled:
@@ -298,8 +348,18 @@ func (l *forwardLoader) resolve() (forwardConfig, error) {
 // l.mu held.
 func (l *forwardLoader) unreadableConfig(err error) forwardConfig {
 	// Both os.Stat's and os.Open's errors already name the path.
-	cfg := forwardConfig{genReason: "config.env unreadable: " + err.Error()}
+	//
+	// The guard knobs hold their defaults rather than their zero values: an
+	// unreadable file is not an explicit "fail closed", and the hook leg is
+	// refused here anyway, so a tool call proceeds. The two telemetry legs fail
+	// closed, the enforcement leg effectively fails open.
+	cfg := forwardConfig{
+		failOpen:  true,
+		timeoutMs: envconfig.DefaultGuardsTimeoutMs,
+		genReason: "config.env unreadable: " + err.Error(),
+	}
 	cfg.otlpReason = cfg.genReason
+	cfg.hookReason = cfg.genReason
 	l.logDisabled(cfg.disabledReasons())
 	return cfg
 }
@@ -308,15 +368,19 @@ func (l *forwardLoader) unreadableConfig(err error) forwardConfig {
 // snapshot. It is the single resolution path: both the forward legs and the
 // viewer's status read it, so they cannot drift.
 func resolveForwardConfig(logger *log.Logger, get envReader) forwardConfig {
+	// Refusing every leg still resolves the guard policy to its defaults, so
+	// no caller can read a half-built config as an explicit "fail closed".
+	off := forwardConfig{failOpen: true, timeoutMs: envconfig.DefaultGuardsTimeoutMs}
 	if !boolFamily(logger, get, "LOCAL_FORWARD", false) {
-		return forwardConfig{}
+		return off
 	}
 
 	endpoint, _ := get.family("ENDPOINT")
 	tenant, _ := get.family("AUTH_TENANT_ID")
 	token, _ := get.family("AUTH_TOKEN")
 
-	cfg := forwardConfig{strip: contentModeFamily(logger, get) != agento11y.ContentCaptureModeFull}
+	cfg := off
+	cfg.strip = contentModeFamily(logger, get) != agento11y.ContentCaptureModeFull
 
 	if reason := forwardDisabledReason(endpoint, tenant, token); reason != "" {
 		cfg.genReason = reason
@@ -335,8 +399,71 @@ func resolveForwardConfig(logger *log.Logger, get envReader) forwardConfig {
 		cfg.otlpHeaders = otlpForwardHeaders(get, tenant)
 	}
 
-	cfg.enabled = cfg.genURL != "" || cfg.otlpEndpoint != ""
+	// The guard knobs are resolved through the same file-first reader as
+	// everything else here, not envconfig.ResolveGuards: that helper reads the
+	// process environment only, so a config.env edit would not reach the
+	// running daemon.
+	cfg.failOpen = boolFamily(logger, get, "GUARDS_FAIL_OPEN", true)
+	cfg.timeoutMs = intFamily(logger, get, "GUARDS_TIMEOUT_MS", envconfig.DefaultGuardsTimeoutMs)
+	if reason := hookForwardDisabledReason(boolFamily(logger, get, "GUARDS_ENABLED", false), endpoint, tenant, token); reason != "" {
+		cfg.hookReason = reason
+	} else if hookURL := hookEvaluateURL(endpoint); hookURL == "" {
+		cfg.hookReason = "hook endpoint: " + endpoint + " has no host"
+	} else {
+		cfg.hookURL = hookURL
+		cfg.hookHeaders = generationForwardHeaders(tenant, token)
+	}
+
+	cfg.enabled = cfg.genURL != "" || cfg.otlpEndpoint != "" || cfg.hookURL != ""
 	return cfg
+}
+
+// hookForwardDisabledReason reports why hook evaluation from a --local session
+// must not be relayed to Cloud, or "" when it may be.
+//
+// The hook leg is gated harder than the generation leg on purpose.
+// forwardDisabledReason accepts a local endpoint with empty or placeholder
+// credentials because posting telemetry to a second local daemon is a
+// legitimate setup; a hook chain to a local endpoint is not. It is either this
+// daemon (a recursion) or another always-allow stub, which would answer allow
+// while the user believes their Cloud rules ran.
+func hookForwardDisabledReason(guardsEnabled bool, endpoint, tenant, token string) string {
+	switch {
+	case !guardsEnabled:
+		return envconfig.PreferredKey("GUARDS_ENABLED") + " is off, so there are no guards to enforce"
+	case endpoint == "":
+		return envconfig.PreferredKey("ENDPOINT") + " is empty"
+	case envconfig.IsLocalEndpoint(endpoint):
+		return "endpoint " + endpoint + " is local, so there are no Cloud rules to consult"
+	case tenant == "" || token == "" || tenant == envconfig.LocalAuthPlaceholder || token == envconfig.LocalAuthPlaceholder:
+		return "Cloud credentials are missing or are the " + envconfig.LocalAuthPlaceholder + " placeholder"
+	default:
+		return ""
+	}
+}
+
+// HookForwardReason reports why `agento11y <agent> --local` would not relay
+// guard evaluation to Cloud for the given resolved settings, or "" when it
+// would. Exported so `agento11y doctor` reports the gate the daemon actually
+// applies instead of reconstructing it from the same inputs.
+func HookForwardReason(forwardEnabled, guardsEnabled bool, endpoint, tenant, token string) string {
+	if !forwardEnabled {
+		return envconfig.PreferredKey("LOCAL_FORWARD") + " is off, so local sessions never contact Cloud"
+	}
+	return hookForwardDisabledReason(guardsEnabled, strings.TrimSpace(endpoint), strings.TrimSpace(tenant), strings.TrimSpace(token))
+}
+
+// hookEvaluateURL builds the Cloud hook URL for an API endpoint: scheme and
+// host are kept, any path is dropped, and the hook path is appended. Mirrors
+// the SDK's baseURLFromAPIEndpoint (go/agento11y/rating.go), which is
+// unexported. Returns "" when the endpoint has no usable host, which the
+// caller reports as a refusal rather than POSTing to a relative URL.
+func hookEvaluateURL(endpoint string) string {
+	u, err := url.Parse(ensureEndpointScheme(endpoint))
+	if err != nil || strings.TrimSpace(u.Host) == "" {
+		return ""
+	}
+	return u.Scheme + "://" + u.Host + hookEvaluatePath
 }
 
 // generationForwardHeaders builds the auth headers the generation export
@@ -446,6 +573,20 @@ func boolFamily(logger *log.Logger, r envReader, suffix string, def bool) bool {
 	return envconfig.BoolValue(logger, key, raw, def)
 }
 
+// intFamily parses a branded integer setting out of an envReader. A
+// non-numeric, zero, or negative value is reported under the spelling it was
+// set with and falls back to def, as does a value that is not set at all.
+// Validation is envconfig.IntValue, shared with envconfig.ResolveGuards, so
+// the daemon and the cloud-only hook path agree on what an invalid value means.
+// The returned value is always positive when def is.
+func intFamily(logger *log.Logger, r envReader, suffix string, def int) int {
+	raw, key := r.family(suffix)
+	if key == "" {
+		key = envconfig.PreferredKey(suffix)
+	}
+	return envconfig.IntValue(logger, key, raw, def)
+}
+
 // contentModeFamily resolves the configured content capture mode out of an
 // envReader. This is the mode the forwarded copy is reduced to; the local store
 // always keeps full content.
@@ -510,8 +651,8 @@ func (l *forwardLoader) logDisabled(reason string) {
 }
 
 // recordFailuref appends a failed attempt to the ring the status endpoint
-// serves, keeping the most recent maxRecordedForwardFailures. It also logs,
-// which only reaches a user who enabled debug logging.
+// serves, keeping the most recent maxRecordedForwardFailures for that leg. It
+// also logs, which only reaches a user who enabled debug logging.
 func (l *forwardLoader) recordFailuref(label, format string, args ...any) {
 	detail := fmt.Sprintf(format, args...)
 	l.logger.Printf("local forward: %s: %s", label, detail)
@@ -523,22 +664,50 @@ func (l *forwardLoader) recordFailuref(label, format string, args ...any) {
 		Label:  label,
 		Detail: detail,
 	})
-	if len(l.failures) > maxRecordedForwardFailures {
-		l.failures = l.failures[len(l.failures)-maxRecordedForwardFailures:]
+	// Trim this leg only. The hook leg records once per tool call, so a
+	// global trim would silently drop the one entry another leg had.
+	// Iterating backwards makes the deletions safe: they only shift entries
+	// after i, and every index this loop still has to visit is before it.
+	kept := 0
+	for i, f := range slices.Backward(l.failures) {
+		if f.Label != label {
+			continue
+		}
+		kept++
+		if kept > maxRecordedForwardFailures {
+			l.failures = slices.Delete(l.failures, i, i+1)
+		}
 	}
+}
+
+// recordFailOpen counts a tool call that was allowed without a Cloud verdict.
+// Unlike the failure ring this counter is never cleared: a fail-open allow is
+// byte-identical to a Cloud allow in the response the agent acts on, so the
+// count is the only durable trace that the guard did not actually run.
+func (l *forwardLoader) recordFailOpen() {
+	l.failMu.Lock()
+	defer l.failMu.Unlock()
+	l.failOpens++
 }
 
 // recordSuccess clears the recorded failures for one leg, so
 // forwardStatus.Failures means "failing since that leg's last delivery" rather
-// than "failed at some point". Generations and OTLP fail independently: a
-// healthy metrics relay must not hide a generation export Cloud keeps
-// rejecting.
+// than "failed at some point". The legs fail independently: a healthy metrics
+// relay must not hide a generation export Cloud keeps rejecting.
 func (l *forwardLoader) recordSuccess(label string) {
 	l.failMu.Lock()
 	defer l.failMu.Unlock()
 	l.failures = slices.DeleteFunc(l.failures, func(f forwardFailure) bool {
 		return f.Label == label
 	})
+}
+
+// recentFailOpens returns how many tool calls have been allowed without a
+// Cloud verdict since the daemon started.
+func (l *forwardLoader) recentFailOpens() int {
+	l.failMu.Lock()
+	defer l.failMu.Unlock()
+	return l.failOpens
 }
 
 // recentFailures returns the recorded failures most recent first.

--- a/plugins/agento11y/internal/local/forward_test.go
+++ b/plugins/agento11y/internal/local/forward_test.go
@@ -33,10 +33,17 @@ import (
 // clearForwardEnv blanks every variable the forward loader reads so a test's
 // config.env file, not the ambient environment, decides the outcome. Without
 // this a developer with AGENTO11Y_LOCAL_FORWARD and real credentials exported
-// would have the suite POST to their live tenant.
+// would have the suite POST to their live tenant, and one with
+// AGENTO11Y_GUARDS_ENABLED=true would have the hook leg chain to it.
+//
+// PinAliasEnvBlank covers both spellings of every alias family, which includes
+// LOCAL_FORWARD and the three GUARDS_* keys the hook leg reads.
 func clearForwardEnv(t *testing.T) {
 	t.Helper()
 	envconfig.PinAliasEnvBlank(t)
+	for _, suffix := range []string{"LOCAL_FORWARD", "GUARDS_ENABLED", "GUARDS_FAIL_OPEN", "GUARDS_TIMEOUT_MS"} {
+		require.Contains(t, envconfig.AliasSuffixes, suffix, "clearForwardEnv relies on PinAliasEnvBlank covering %s", suffix)
+	}
 	// The loader also falls back to the bare OTLP variables, which are not part
 	// of an alias family.
 	for _, k := range []string{"OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_HEADERS", "OTEL_EXPORTER_OTLP_INSECURE"} {
@@ -55,6 +62,10 @@ func writeConfigEnvFile(t *testing.T, lines map[string]string) string {
 	return path
 }
 
+// guardsOffHookReason is the hook leg's refusal for every case that enables
+// forwarding without enabling guards, which is most of the table below.
+const guardsOffHookReason = "GUARDS_ENABLED is off"
+
 func TestForwardLoader_Resolve(t *testing.T) {
 	const cloud = "https://cloud.example.test/"
 	cases := []struct {
@@ -65,6 +76,8 @@ func TestForwardLoader_Resolve(t *testing.T) {
 		wantStatusMode   string
 		wantStatusReason bool
 		wantOTLP         bool
+		wantHookURL      string
+		wantHookReason   string // substring; "" means the reason must be empty
 	}{
 		{
 			// Credentials the generation export cannot use, but a usable OTLP
@@ -80,6 +93,7 @@ func TestForwardLoader_Resolve(t *testing.T) {
 			wantStatusMode:   forwardModeMetadataOnly,
 			wantStatusReason: true,
 			wantOTLP:         true,
+			wantHookReason:   guardsOffHookReason,
 		},
 		{
 			name:           "disabled_when_toggle_unset",
@@ -93,6 +107,7 @@ func TestForwardLoader_Resolve(t *testing.T) {
 			wantEnabled:    true,
 			wantStrip:      true,
 			wantStatusMode: forwardModeMetadataOnly,
+			wantHookReason: guardsOffHookReason,
 		},
 		{
 			name:           "enabled_full_does_not_strip",
@@ -100,6 +115,7 @@ func TestForwardLoader_Resolve(t *testing.T) {
 			wantEnabled:    true,
 			wantStrip:      false,
 			wantStatusMode: forwardModeFull,
+			wantHookReason: guardsOffHookReason,
 		},
 		{
 			name:           "advanced_capture_mode_still_strips",
@@ -107,6 +123,7 @@ func TestForwardLoader_Resolve(t *testing.T) {
 			wantEnabled:    true,
 			wantStrip:      true,
 			wantStatusMode: forwardModeMetadataOnly,
+			wantHookReason: guardsOffHookReason,
 		},
 		{
 			name:           "legacy_spellings_resolve",
@@ -114,6 +131,7 @@ func TestForwardLoader_Resolve(t *testing.T) {
 			wantEnabled:    true,
 			wantStrip:      false,
 			wantStatusMode: forwardModeFull,
+			wantHookReason: guardsOffHookReason,
 		},
 		{
 			// Both spellings present: the preferred one decides, matching
@@ -128,6 +146,7 @@ func TestForwardLoader_Resolve(t *testing.T) {
 			wantEnabled:    true,
 			wantStrip:      false,
 			wantStatusMode: forwardModeFull,
+			wantHookReason: guardsOffHookReason,
 		},
 		{
 			name:           "allows_local_endpoint",
@@ -135,6 +154,7 @@ func TestForwardLoader_Resolve(t *testing.T) {
 			wantEnabled:    true,
 			wantStrip:      true,
 			wantStatusMode: forwardModeMetadataOnly,
+			wantHookReason: guardsOffHookReason,
 		},
 		{
 			name:           "allows_local_endpoint_with_placeholder_creds",
@@ -142,6 +162,7 @@ func TestForwardLoader_Resolve(t *testing.T) {
 			wantEnabled:    true,
 			wantStrip:      true,
 			wantStatusMode: forwardModeMetadataOnly,
+			wantHookReason: guardsOffHookReason,
 		},
 		{
 			name:           "allows_local_endpoint_without_creds",
@@ -149,6 +170,7 @@ func TestForwardLoader_Resolve(t *testing.T) {
 			wantEnabled:    true,
 			wantStrip:      true,
 			wantStatusMode: forwardModeMetadataOnly,
+			wantHookReason: guardsOffHookReason,
 		},
 		{
 			name:             "refuses_placeholder_creds",
@@ -156,6 +178,7 @@ func TestForwardLoader_Resolve(t *testing.T) {
 			wantEnabled:      false,
 			wantStatusMode:   forwardModeOff,
 			wantStatusReason: true,
+			wantHookReason:   guardsOffHookReason,
 		},
 		{
 			name:             "refuses_empty_endpoint",
@@ -163,6 +186,7 @@ func TestForwardLoader_Resolve(t *testing.T) {
 			wantEnabled:      false,
 			wantStatusMode:   forwardModeOff,
 			wantStatusReason: true,
+			wantHookReason:   guardsOffHookReason,
 		},
 		{
 			name:             "refuses_invalid_endpoint",
@@ -170,6 +194,84 @@ func TestForwardLoader_Resolve(t *testing.T) {
 			wantEnabled:      false,
 			wantStatusMode:   forwardModeOff,
 			wantStatusReason: true,
+			wantHookReason:   guardsOffHookReason,
+		},
+		{
+			// The hook leg needs both toggles. Forwarding alone leaves guard
+			// evaluation local, which is what every existing case above
+			// asserts implicitly.
+			name: "hooks_refused_when_guards_off",
+			lines: map[string]string{
+				"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": cloud,
+				"AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+			},
+			wantEnabled:    true,
+			wantStrip:      true,
+			wantStatusMode: forwardModeMetadataOnly,
+			wantHookReason: "GUARDS_ENABLED",
+		},
+		{
+			name: "hooks_chain_when_guards_on",
+			lines: map[string]string{
+				"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": cloud,
+				"AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+				"AGENTO11Y_GUARDS_ENABLED": "true",
+			},
+			wantEnabled:    true,
+			wantStrip:      true,
+			wantStatusMode: forwardModeMetadataOnly,
+			wantHookURL:    "https://cloud.example.test/api/v1/hooks:evaluate",
+		},
+		{
+			// A local endpoint is a legitimate generation target but never a
+			// hook target: it is either this daemon or another always-allow
+			// stub.
+			name: "hooks_refused_for_local_endpoint",
+			lines: map[string]string{
+				"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": "http://127.0.0.1:8080",
+				"AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+				"AGENTO11Y_GUARDS_ENABLED": "true",
+			},
+			wantEnabled:    true,
+			wantStrip:      true,
+			wantStatusMode: forwardModeMetadataOnly,
+			wantHookReason: "is local",
+		},
+		{
+			name: "hooks_refused_without_credentials",
+			lines: map[string]string{
+				"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": cloud,
+				"AGENTO11Y_AUTH_TENANT_ID": "t",
+				"AGENTO11Y_GUARDS_ENABLED": "true",
+			},
+			wantEnabled:      false,
+			wantStatusMode:   forwardModeOff,
+			wantStatusReason: true,
+			wantHookReason:   "Cloud credentials are missing",
+		},
+		{
+			name: "hooks_refused_for_placeholder_credentials",
+			lines: map[string]string{
+				"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": cloud,
+				"AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": envconfig.LocalAuthPlaceholder,
+				"AGENTO11Y_GUARDS_ENABLED": "true",
+			},
+			wantEnabled:      false,
+			wantStatusMode:   forwardModeOff,
+			wantStatusReason: true,
+			wantHookReason:   "placeholder",
+		},
+		{
+			name: "hooks_resolve_from_legacy_spellings",
+			lines: map[string]string{
+				"SIGIL_LOCAL_FORWARD": "true", "SIGIL_ENDPOINT": cloud,
+				"SIGIL_AUTH_TENANT_ID": "t", "SIGIL_AUTH_TOKEN": "k",
+				"SIGIL_GUARDS_ENABLED": "true",
+			},
+			wantEnabled:    true,
+			wantStrip:      true,
+			wantStatusMode: forwardModeMetadataOnly,
+			wantHookURL:    "https://cloud.example.test/api/v1/hooks:evaluate",
 		},
 	}
 	for _, tc := range cases {
@@ -182,11 +284,30 @@ func TestForwardLoader_Resolve(t *testing.T) {
 				assert.Equal(t, tc.wantStrip, cfg.strip)
 				assert.Equal(t, tc.wantOTLP, cfg.otlpEndpoint != "")
 			}
+			// The guard policy resolves to its documented defaults on every
+			// path, including the ones that refuse every leg, so no consumer
+			// can read a half-built config as an explicit "fail closed".
+			assert.Equal(t, envconfig.DefaultGuardsTimeoutMs, cfg.timeoutMs)
+			assert.True(t, cfg.failOpen)
+
+			assert.Equal(t, tc.wantHookURL, cfg.hookURL)
+			switch {
+			case tc.wantHookURL != "":
+				assert.Empty(t, cfg.hookReason, "a live hook leg has nothing to explain")
+			case tc.wantHookReason == "":
+				// Forwarding off at all is not a paused state, so the reason
+				// is empty there too, same as the generations leg.
+				assert.Empty(t, cfg.hookReason)
+			default:
+				assert.Contains(t, cfg.hookReason, tc.wantHookReason)
+			}
 			st := l.status()
 			assert.Equal(t, tc.wantEnabled, st.Enabled)
 			assert.Equal(t, tc.wantStatusMode, st.Mode)
 			assert.Equal(t, tc.wantOTLP, st.OTLP)
 			assert.Equal(t, cfg.genURL != "", st.Generations)
+			assert.Equal(t, tc.wantHookURL != "", st.Hooks)
+			assert.Equal(t, cfg.hookReason, st.HookReason)
 			if tc.wantStatusReason {
 				assert.NotEmpty(t, st.Reason)
 			} else {
@@ -225,6 +346,145 @@ func TestForwardLoader_ConfigFileBeatsProcessEnv(t *testing.T) {
 		"AGENTO11Y_AUTH_TOKEN":     "k",
 	})
 	assert.True(t, newForwardLoader(path, nil).load().enabled)
+}
+
+// TestHookEvaluateURL covers the URL join the hook leg uses: any path on the
+// configured API endpoint is dropped before the hook path is appended, and a
+// hostless endpoint yields "" so the caller refuses instead of POSTing to a
+// relative URL.
+func TestHookEvaluateURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "appends_path", in: "https://cloud.example.test", want: "https://cloud.example.test/api/v1/hooks:evaluate"},
+		{name: "drops_trailing_slash", in: "https://cloud.example.test/", want: "https://cloud.example.test/api/v1/hooks:evaluate"},
+		{name: "drops_existing_path", in: "https://cloud.example.test/api/v1/generations:export", want: "https://cloud.example.test/api/v1/hooks:evaluate"},
+		{name: "keeps_port", in: "https://cloud.example.test:8443/base", want: "https://cloud.example.test:8443/api/v1/hooks:evaluate"},
+		{name: "schemeless_gets_https", in: "cloud.example.test", want: "https://cloud.example.test/api/v1/hooks:evaluate"},
+		{name: "keeps_http_scheme", in: "http://cloud.example.test", want: "http://cloud.example.test/api/v1/hooks:evaluate"},
+		{name: "empty_endpoint", in: "", want: ""},
+		{name: "unparseable_endpoint", in: "http://%", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, hookEvaluateURL(tc.in))
+		})
+	}
+}
+
+// TestForwardLoader_GuardPolicyResolution covers the two guard knobs the
+// chained hook call applies. They go through the file-first envReader rather
+// than envconfig.ResolveGuards, so a config.env edit reaches a running daemon.
+func TestForwardLoader_GuardPolicyResolution(t *testing.T) {
+	const cloud = "https://cloud.example.test/"
+	base := map[string]string{
+		"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": cloud,
+		"AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+		"AGENTO11Y_GUARDS_ENABLED": "true",
+	}
+	cases := []struct {
+		name          string
+		extra         map[string]string
+		processEnv    map[string]string
+		wantFailOpen  bool
+		wantTimeoutMs int
+	}{
+		{
+			name:          "defaults",
+			wantFailOpen:  true,
+			wantTimeoutMs: envconfig.DefaultGuardsTimeoutMs,
+		},
+		{
+			name:          "explicit_values",
+			extra:         map[string]string{"AGENTO11Y_GUARDS_FAIL_OPEN": "false", "AGENTO11Y_GUARDS_TIMEOUT_MS": "9000"},
+			wantFailOpen:  false,
+			wantTimeoutMs: 9000,
+		},
+		{
+			name:          "legacy_spellings",
+			extra:         map[string]string{"SIGIL_GUARDS_FAIL_OPEN": "no", "SIGIL_GUARDS_TIMEOUT_MS": "2500"},
+			wantFailOpen:  false,
+			wantTimeoutMs: 2500,
+		},
+		{
+			name:          "invalid_timeout_falls_back",
+			extra:         map[string]string{"AGENTO11Y_GUARDS_TIMEOUT_MS": "soon"},
+			wantFailOpen:  true,
+			wantTimeoutMs: envconfig.DefaultGuardsTimeoutMs,
+		},
+		{
+			name:          "non_positive_timeout_falls_back",
+			extra:         map[string]string{"AGENTO11Y_GUARDS_TIMEOUT_MS": "-1"},
+			wantFailOpen:  true,
+			wantTimeoutMs: envconfig.DefaultGuardsTimeoutMs,
+		},
+		{
+			// The daemon's own environment holds the boot-time values, so the
+			// file has to win or a viewer edit would need a restart.
+			name:          "config_file_beats_process_env",
+			extra:         map[string]string{"AGENTO11Y_GUARDS_TIMEOUT_MS": "4000", "AGENTO11Y_GUARDS_FAIL_OPEN": "false"},
+			processEnv:    map[string]string{"AGENTO11Y_GUARDS_TIMEOUT_MS": "1000", "AGENTO11Y_GUARDS_FAIL_OPEN": "true"},
+			wantFailOpen:  false,
+			wantTimeoutMs: 4000,
+		},
+		{
+			name:          "process_env_used_when_file_is_silent",
+			processEnv:    map[string]string{"AGENTO11Y_GUARDS_TIMEOUT_MS": "1000", "AGENTO11Y_GUARDS_FAIL_OPEN": "false"},
+			wantFailOpen:  false,
+			wantTimeoutMs: 1000,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearForwardEnv(t)
+			for k, v := range tc.processEnv {
+				t.Setenv(k, v)
+			}
+			lines := map[string]string{}
+			maps.Copy(lines, base)
+			maps.Copy(lines, tc.extra)
+			cfg := newForwardLoader(writeConfigEnvFile(t, lines), nil).load()
+			require.NotEmpty(t, cfg.hookURL)
+			assert.Equal(t, tc.wantFailOpen, cfg.failOpen)
+			assert.Equal(t, tc.wantTimeoutMs, cfg.timeoutMs)
+		})
+	}
+}
+
+// TestHookForwardReason covers the gate `agento11y doctor` shares with the
+// daemon, so the report cannot describe a posture the daemon does not apply.
+func TestHookForwardReason(t *testing.T) {
+	const cloud = "https://cloud.example.test/"
+	cases := []struct {
+		name       string
+		forward    bool
+		guards     bool
+		endpoint   string
+		tenant     string
+		token      string
+		wantReason string // substring; "" means chaining is live
+	}{
+		{name: "live", forward: true, guards: true, endpoint: cloud, tenant: "t", token: "k"},
+		{name: "forward_off", guards: true, endpoint: cloud, tenant: "t", token: "k", wantReason: "LOCAL_FORWARD"},
+		{name: "guards_off", forward: true, endpoint: cloud, tenant: "t", token: "k", wantReason: "GUARDS_ENABLED"},
+		{name: "empty_endpoint", forward: true, guards: true, tenant: "t", token: "k", wantReason: "ENDPOINT"},
+		{name: "local_endpoint", forward: true, guards: true, endpoint: "http://localhost:8080", tenant: "t", token: "k", wantReason: "is local"},
+		{name: "missing_token", forward: true, guards: true, endpoint: cloud, tenant: "t", wantReason: "Cloud credentials"},
+		{name: "placeholder_tenant", forward: true, guards: true, endpoint: cloud, tenant: envconfig.LocalAuthPlaceholder, token: "k", wantReason: "placeholder"},
+		{name: "whitespace_token", forward: true, guards: true, endpoint: cloud, tenant: "t", token: "  ", wantReason: "Cloud credentials"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := HookForwardReason(tc.forward, tc.guards, tc.endpoint, tc.tenant, tc.token)
+			if tc.wantReason == "" {
+				assert.Empty(t, got)
+			} else {
+				assert.Contains(t, got, tc.wantReason)
+			}
+		})
+	}
 }
 
 func TestEnsureEndpointScheme(t *testing.T) {
@@ -730,6 +990,33 @@ func TestForwardLoader_StatusReportsFailures(t *testing.T) {
 	assert.Empty(t, l.status().Failures)
 }
 
+// TestForwardLoader_FailureRingIsPerLeg covers the ring's capacity: the hook
+// leg records once per tool call, so a global cap would let a chatty leg evict
+// the one entry another leg had, which is the only report that leg gets.
+func TestForwardLoader_FailureRingIsPerLeg(t *testing.T) {
+	clearForwardEnv(t)
+	l := newForwardLoader(writeConfigEnvFile(t, nil), nil)
+
+	l.recordFailuref(forwardLabelGenerations, "generation export rejected")
+	l.recordFailuref(otlpForwardLabel("traces"), "traces rejected")
+	for i := range maxRecordedForwardFailures * 2 {
+		l.recordFailuref(forwardLabelHooks, "hook call %d failed", i)
+	}
+
+	byLabel := map[string]int{}
+	for _, f := range l.status().Failures {
+		byLabel[f.Label]++
+	}
+	assert.Equal(t, map[string]int{
+		forwardLabelGenerations:    1,
+		otlpForwardLabel("traces"): 1,
+		forwardLabelHooks:          maxRecordedForwardFailures,
+	}, byLabel)
+
+	// Within a leg the cap keeps the most recent attempts.
+	assert.Contains(t, l.status().Failures[0].Detail, "hook call 9 failed")
+}
+
 // TestForwardLoader_StatusReportsUnreadableConfig covers the fail-closed
 // branch: an unreadable config.env disables forwarding and says why, rather
 // than falling back to the daemon's boot-time environment.
@@ -781,6 +1068,13 @@ func assertForwardRefusedAsUnreadable(t *testing.T, path string) *forwardLoader 
 	assert.False(t, st.Enabled)
 	assert.Equal(t, forwardModeOff, st.Mode)
 	assert.Contains(t, st.Reason, "config.env unreadable")
+	assert.Contains(t, st.HookReason, "config.env unreadable")
+	// The guard knobs keep their documented defaults. An unreadable file is
+	// not an explicit "fail closed", and reading it as one would be the
+	// opposite of what a user who never set the key asked for.
+	cfg := l.load()
+	assert.True(t, cfg.failOpen)
+	assert.Equal(t, envconfig.DefaultGuardsTimeoutMs, cfg.timeoutMs)
 	return l
 }
 

--- a/plugins/agento11y/internal/local/manager.go
+++ b/plugins/agento11y/internal/local/manager.go
@@ -333,6 +333,58 @@ func processLooksLikeDaemon(pid int) (bool, error) {
 	return strings.HasPrefix(base, "agento11y") || strings.HasPrefix(base, "sigil") || base == "main", nil
 }
 
+// ForwardPosture is what a running daemon would send to Cloud right now, for
+// callers outside the viewer. The launcher prints a privacy claim before
+// handing the terminal to the agent, and only the daemon knows the resolved
+// answer: it reads config.env ahead of its own environment, so the launcher's
+// process environment can disagree with it.
+type ForwardPosture struct {
+	// Enabled reports whether captured sessions are forwarded at all.
+	Enabled bool
+	// Mode is the content level of the forwarded copy (forwardMode*).
+	Mode string
+	// Hooks reports whether guard evaluation is relayed to Cloud, which sends
+	// the content being evaluated regardless of Mode. See handleHookEvaluate.
+	Hooks bool
+}
+
+// FetchForwardPosture asks a running daemon what it would forward. A non-nil
+// error means the daemon could not be reached or did not answer in time, in
+// which case the caller must not claim any particular posture, and should say
+// why: the hedged wording it falls back to is otherwise indistinguishable from
+// a daemon that reported "nothing is forwarded".
+func FetchForwardPosture(ctx context.Context, endpoint string) (ForwardPosture, error) {
+	if strings.TrimSpace(endpoint) == "" {
+		return ForwardPosture{}, errors.New("no daemon endpoint")
+	}
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(endpoint, "/")+"/api/v1/config", nil)
+	if err != nil {
+		return ForwardPosture{}, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ForwardPosture{}, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return ForwardPosture{}, fmt.Errorf("GET %s returned HTTP %d", req.URL, resp.StatusCode)
+	}
+	var body configResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&body); err != nil {
+		return ForwardPosture{}, fmt.Errorf("decode config from %s: %w", req.URL, err)
+	}
+	return ForwardPosture{
+		Enabled: body.ForwardStatus.Enabled,
+		Mode:    body.ForwardStatus.Mode,
+		Hooks:   body.ForwardStatus.Hooks,
+	}, nil
+}
+
 // endpointAlive returns true when GET <endpoint>/healthz responds within
 // 500ms. /healthz is the JSON liveness probe; / now serves the viewer
 // HTML and would be wasteful (and ambiguous) to fetch on every check.

--- a/plugins/agento11y/internal/local/server.go
+++ b/plugins/agento11y/internal/local/server.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"log"
@@ -10,6 +11,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/grafana/agento11y/go/agento11y"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/dotenv"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
@@ -95,7 +97,7 @@ func (s *Server) routes() *http.ServeMux {
 	// the path from API.Endpoint before appending /api/v1/hooks:evaluate,
 	// so we must accept the bare path too — otherwise local hook
 	// evaluation 404s.
-	mux.HandleFunc("POST /api/v1/hooks:evaluate", s.handleHookEvaluate)
+	mux.HandleFunc("POST "+hookEvaluatePath, s.handleHookEvaluate)
 	return mux
 }
 
@@ -274,14 +276,18 @@ func (s *Server) handleOTLP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// hookResponse is the allow-only payload returned to the SDK. It matches
-// the agento11y.HookEvaluateResponse JSON shape so the SDK decodes it
-// without complaint.
-type hookResponse struct {
-	Action      string `json:"action"`
-	Evaluations []any  `json:"evaluations"`
-}
-
+// handleHookEvaluate answers the synchronous guard check every host agent runs
+// before (or right after) a tool call. The local verdict is always allow —
+// there is no local guards engine yet — but when the daemon is configured to
+// forward and guards are on, the request is relayed to Cloud so `--local` still
+// enforces the rules the user configured there.
+//
+// Note what that means for content: a chained evaluation sends whatever the
+// agent asked to have checked — the tool call for a postflight check, the whole
+// outgoing conversation for a preflight one — to Cloud in full, whatever
+// CONTENT_CAPTURE_MODE says, because a guard cannot evaluate what it cannot
+// see. The viewer, the launcher banner, and `agento11y doctor` all report the
+// resolved posture for that reason.
 func (s *Server) handleHookEvaluate(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxHookBodyBytes+1))
 	if err != nil {
@@ -296,7 +302,47 @@ func (s *Server) handleHookEvaluate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid JSON body", http.StatusBadRequest)
 		return
 	}
-	s.writeJSON(w, http.StatusOK, hookResponse{Action: "allow", Evaluations: []any{}})
+
+	resp := agento11y.HookEvaluateResponse{
+		Action:      agento11y.HookActionAllow,
+		Evaluations: []agento11y.HookEvaluation{},
+	}
+
+	// Never chain a payload another daemon relayed here, which would loop.
+	if !isForwardedRequest(r) {
+		if cfg := s.forward.load(); cfg.hookURL != "" {
+			s.chainHookEvaluate(r, cfg, body, &resp)
+		}
+	}
+	s.writeJSON(w, http.StatusOK, resp)
+}
+
+// chainHookEvaluate replaces the local verdict with Cloud's. A failed call
+// follows the resolved fail mode: fail-open keeps the local allow, fail-closed
+// denies with a response labelled as an evaluation failure so no consumer
+// reports it as a policy decision.
+func (s *Server) chainHookEvaluate(r *http.Request, cfg forwardConfig, body []byte, resp *agento11y.HookEvaluateResponse) {
+	timeout := hookTimeoutFromHeader(r, time.Duration(cfg.timeoutMs)*time.Millisecond)
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
+	defer cancel()
+
+	cloud, err := s.forward.evaluateCloudHook(ctx, cfg, timeout, body)
+	switch {
+	case err == nil:
+		*resp = cloud
+	case isCallerAbort(err):
+		// The agent stopped waiting, so whatever this handler writes is not a
+		// verdict anything acted on. Leaving the counters alone here is the
+		// same call evaluateCloudHook makes for the failure ring: a count of
+		// abandoned waits would report unchecked allows that never happened.
+	case cfg.failOpen:
+		// The agent cannot tell this allow from a Cloud allow, so count it:
+		// the failure ring is cleared by the next success, and a guard that
+		// silently stopped enforcing would otherwise leave no trace.
+		s.forward.recordFailOpen()
+	default:
+		*resp = denyFromCloudError(body, err)
+	}
 }
 
 // configResponse is the GET /api/v1/config and PUT /api/v1/config payload:

--- a/plugins/agento11y/internal/local/server_test.go
+++ b/plugins/agento11y/internal/local/server_test.go
@@ -2,18 +2,25 @@ package local
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/grafana/agento11y/go/agento11y"
 	"github.com/grafana/agento11y/go/agento11y/model"
 	"github.com/grafana/agento11y/go/proto/agento11y/wire"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/guard"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/dotenv"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 	"github.com/stretchr/testify/assert"
@@ -118,9 +125,9 @@ func TestServer_HookEvaluate_Allow(t *testing.T) {
 	resp := post(t, s, "/api/v1/hooks:evaluate", "application/json", body)
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-	var out hookResponse
+	var out agento11y.HookEvaluateResponse
 	decodeJSON(t, resp.Body, &out)
-	assert.Equal(t, "allow", out.Action)
+	assert.Equal(t, agento11y.HookActionAllow, out.Action)
 	assert.NotNil(t, out.Evaluations)
 
 	_, err := os.Stat(filepath.Join(dir, "hooks.jsonl"))
@@ -160,6 +167,8 @@ func TestServer_Routing(t *testing.T) {
 		{name: "healthz serves JSON", method: http.MethodGet, path: "/healthz", want: http.StatusOK, wantContentType: "application/json", wantBodyHas: `"status":"ok"`},
 		{name: "unknown route", method: http.MethodPost, path: "/api/v1/unknown", body: "{}", want: http.StatusNotFound},
 		{name: "wrong method on generations export", method: http.MethodPut, path: "/api/v1/generations:export", body: "{}", want: http.StatusMethodNotAllowed},
+		{name: "hook evaluate serves JSON", method: http.MethodPost, path: "/api/v1/hooks:evaluate", body: `{"phase":"postflight"}`, want: http.StatusOK, wantContentType: "application/json", wantBodyHas: `"action":"allow"`},
+		{name: "wrong method on hook evaluate", method: http.MethodGet, path: "/api/v1/hooks:evaluate", want: http.StatusMethodNotAllowed},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -568,11 +577,13 @@ func TestServer_Config_RoundTrip(t *testing.T) {
 	assert.True(t, saved.Settings.LocalForward)
 	// The saved toggle plus usable credentials resolve to a live forwarding
 	// posture, reduced to metadata_only by the saved capture mode. No OTLP
-	// endpoint was configured, so that leg reports why it stays off.
+	// endpoint was configured, so that leg reports why it stays off. Guards
+	// were saved on, so the hook leg is live as well.
 	assert.Equal(t, forwardStatus{
 		Enabled:     true,
 		Mode:        forwardModeMetadataOnly,
 		Generations: true,
+		Hooks:       true,
 		OTLPReason:  "no OTLP endpoint configured, so traces and metrics are not forwarded",
 	}, saved.ForwardStatus)
 
@@ -853,6 +864,448 @@ func TestServer_Forwarding_RelaysOTLP(t *testing.T) {
 	c := <-received
 	assert.Equal(t, "/v1/traces", c.path)
 	assertTraceStripped(t, c.body, wire.ContentTypeProto)
+}
+
+// hookCloud is a fake Cloud hook endpoint: it records what the daemon relayed
+// and answers with a canned status and body, both settable between calls.
+//
+// It serves TLS because resolveForwardConfig refuses an http://127.0.0.1
+// endpoint as a hook target, so an https test server is what lets the server
+// tests go through the real gate instead of around it. newForwardingTestServer
+// trusts its cert, and the relay-level tests inject srv.Client() themselves.
+type hookCloud struct {
+	srv *httptest.Server
+
+	// Set before or between calls, read by the handler.
+	status  int
+	respond string
+	delay   time.Duration
+
+	// The hook path is synchronous, so unlike the generations and OTLP legs
+	// no wait() is needed before reading these — but the other legs in this
+	// file are async against the same server, so recording is still guarded.
+	mu      sync.Mutex
+	n       int
+	path    string
+	body    string
+	headers http.Header
+}
+
+func newHookCloud(t *testing.T) *hookCloud {
+	t.Helper()
+	c := &hookCloud{status: http.StatusOK, respond: `{"action":"allow","evaluations":[]}`}
+	c.srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		c.record(r.URL.Path, body, r.Header.Clone())
+		if c.delay > 0 {
+			time.Sleep(c.delay)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(c.status)
+		_, _ = io.WriteString(w, c.respond)
+	}))
+	t.Cleanup(c.srv.Close)
+	return c
+}
+
+func (c *hookCloud) record(path string, body []byte, headers http.Header) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.n++
+	c.path, c.body, c.headers = path, string(body), headers
+}
+
+func (c *hookCloud) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n
+}
+
+func (c *hookCloud) lastCall() (path, body string, headers http.Header) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.path, c.body, c.headers
+}
+
+// hookEnv is the config.env a chaining daemon needs: forwarding on, guards on,
+// and usable Cloud credentials pointed at the fake Cloud.
+// An override with an empty value removes the key, so a case can express "this
+// one gate is not satisfied" without restating the other four.
+func hookEnv(cloudURL string, extra map[string]string) map[string]string {
+	env := map[string]string{
+		"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": cloudURL,
+		"AGENTO11Y_AUTH_TENANT_ID": "t", "AGENTO11Y_AUTH_TOKEN": "k",
+		"AGENTO11Y_GUARDS_ENABLED": "true",
+	}
+	maps.Copy(env, extra)
+	maps.DeleteFunc(env, func(_, v string) bool { return v == "" })
+	return env
+}
+
+// postHook issues a hook evaluation and returns the status plus the verdict
+// the calling agent would act on. Each opt rewrites the request before it is
+// served.
+func postHook(t *testing.T, s *Server, body string, headers map[string]string, opts ...func(*http.Request) *http.Request) (int, agento11y.HookEvaluateResponse) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks:evaluate", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	for _, opt := range opts {
+		req = opt(req)
+	}
+	rr := httptest.NewRecorder()
+	s.ServeHTTP(rr, req)
+	resp := rr.Result()
+	defer func() { _ = resp.Body.Close() }()
+	var out agento11y.HookEvaluateResponse
+	if resp.StatusCode == http.StatusOK {
+		decodeJSON(t, resp.Body, &out)
+	}
+	return resp.StatusCode, out
+}
+
+const hookToolCallBody = `{"phase":"postflight","context":{"agent_name":"claude-code"},"input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"c1","name":"Bash"}}]}]}}`
+
+// abortDuringCall is a postHook option that cancels the request context shortly
+// after the request is issued, the way an agent that hit its own hook deadline
+// (or a user who interrupted) drops the call while Cloud is still stalling.
+// Pair it with a Cloud delay longer than the cancel.
+func abortDuringCall(t *testing.T) func(*http.Request) *http.Request {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	return func(r *http.Request) *http.Request { return r.WithContext(ctx) }
+}
+
+// TestServer_HookEvaluate_Gates covers when a --local hook evaluation reaches
+// Cloud. Chaining needs both the forwarding opt-in and guards: telemetry
+// forwarding is what the user consented to, and a guard check ships the tool
+// call itself.
+func TestServer_HookEvaluate_Gates(t *testing.T) {
+	cases := []struct {
+		name      string
+		override  map[string]string // applied on top of hookEnv
+		wantChain bool
+		wantWhy   string // substring of forwardStatus.HookReason
+	}{
+		{
+			name:     "forwarding_off",
+			override: map[string]string{"AGENTO11Y_LOCAL_FORWARD": ""},
+			// Forwarding off at all is not a paused state, so no leg has
+			// anything to explain.
+			wantWhy: "",
+		},
+		{
+			name:     "guards_off",
+			override: map[string]string{"AGENTO11Y_GUARDS_ENABLED": ""},
+			wantWhy:  "GUARDS_ENABLED",
+		},
+		{
+			name:     "placeholder_credentials",
+			override: map[string]string{"AGENTO11Y_AUTH_TOKEN": envconfig.LocalAuthPlaceholder},
+			wantWhy:  "placeholder",
+		},
+		{name: "both_on", wantChain: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := newHookCloud(t)
+			cloud.respond = `{"action":"deny","rule_id":"r1","reason":"nope"}`
+			s, _ := newForwardingTestServer(t, cloud.srv, hookEnv(cloud.srv.URL, tc.override))
+
+			status, out := postHook(t, s, hookToolCallBody, nil)
+			require.Equal(t, http.StatusOK, status)
+			st := s.forward.status()
+			assert.Equal(t, tc.wantChain, st.Hooks)
+			if tc.wantChain {
+				assert.Equal(t, 1, cloud.count())
+				assert.Equal(t, agento11y.HookActionDeny, out.Action)
+				assert.Empty(t, st.HookReason, "a live hook leg has nothing to explain")
+				return
+			}
+			assert.Zero(t, cloud.count(), "a refused hook leg must make no outbound request")
+			assert.Equal(t, agento11y.HookActionAllow, out.Action)
+			if tc.wantWhy == "" {
+				assert.Empty(t, st.HookReason)
+			} else {
+				assert.Contains(t, st.HookReason, tc.wantWhy)
+			}
+		})
+	}
+}
+
+// TestServer_HookEvaluate_CloudVerdict covers the verdicts a chained call
+// returns to the calling agent: the action, the rule that produced it, a
+// transform, and the per-rule evaluations.
+func TestServer_HookEvaluate_CloudVerdict(t *testing.T) {
+	cases := []struct {
+		name       string
+		respond    string
+		wantAction agento11y.HookAction
+		wantRuleID string
+		wantReason string
+		assertMore func(t *testing.T, out agento11y.HookEvaluateResponse)
+	}{
+		{
+			name:       "allow",
+			respond:    `{"action":"allow","evaluations":[]}`,
+			wantAction: agento11y.HookActionAllow,
+		},
+		{
+			name:       "deny",
+			respond:    `{"action":"deny","rule_id":"r1","reason":"blocked by policy"}`,
+			wantAction: agento11y.HookActionDeny,
+			wantRuleID: "r1",
+			wantReason: "blocked by policy",
+		},
+		{
+			name:       "transform",
+			respond:    `{"action":"allow","transformed_input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"c1","name":"Bash","input_json":{"command":"echo safe"}}}]}]}}`,
+			wantAction: agento11y.HookActionAllow,
+			assertMore: func(t *testing.T, out agento11y.HookEvaluateResponse) {
+				require.NotNil(t, out.TransformedInput)
+				require.Len(t, out.TransformedInput.Output, 1)
+				parts := out.TransformedInput.Output[0].Parts
+				require.Len(t, parts, 1)
+				require.NotNil(t, parts[0].ToolCall)
+				assert.JSONEq(t, `{"command":"echo safe"}`, string(parts[0].ToolCall.InputJSON))
+			},
+		},
+		{
+			name:       "evaluations_preserved_in_order",
+			respond:    `{"action":"allow","evaluations":[{"rule_id":"first","passed":true},{"rule_id":"second","passed":false}]}`,
+			wantAction: agento11y.HookActionAllow,
+			assertMore: func(t *testing.T, out agento11y.HookEvaluateResponse) {
+				require.Len(t, out.Evaluations, 2)
+				assert.Equal(t, "first", out.Evaluations[0].RuleID)
+				assert.Equal(t, "second", out.Evaluations[1].RuleID)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := newHookCloud(t)
+			cloud.respond = tc.respond
+			s, _ := newForwardingTestServer(t, cloud.srv, hookEnv(cloud.srv.URL, nil))
+
+			status, out := postHook(t, s, hookToolCallBody, nil)
+			require.Equal(t, http.StatusOK, status)
+			require.Equal(t, 1, cloud.count())
+			path, _, _ := cloud.lastCall()
+			assert.Equal(t, hookEvaluatePath, path)
+			assert.Equal(t, tc.wantAction, out.Action)
+			assert.Equal(t, tc.wantRuleID, out.RuleID)
+			assert.Equal(t, tc.wantReason, out.Reason)
+			if tc.assertMore != nil {
+				tc.assertMore(t, out)
+			}
+			st := s.forward.status()
+			assert.Empty(t, st.Failures)
+			assert.Zero(t, st.HookFailOpens)
+		})
+	}
+}
+
+// TestServer_HookEvaluate_FailModes covers what the agent is told when the
+// Cloud call does not produce a verdict. Fail-open keeps the local allow;
+// fail-closed denies, and that deny has to be labelled as an evaluation
+// failure or every consumer renders it as "a policy blocked this call".
+func TestServer_HookEvaluate_FailModes(t *testing.T) {
+	cases := []struct {
+		name         string
+		status       int
+		respond      string
+		closeCloud   bool
+		abortMidCall bool // the agent stops waiting while Cloud stalls
+		failOpen     bool
+		wantAction   agento11y.HookAction
+		wantFailure  string // substring of the recorded failure; "" means none
+	}{
+		{name: "unreachable_fail_open", closeCloud: true, failOpen: true, wantAction: agento11y.HookActionAllow, wantFailure: "POST"},
+		{name: "unreachable_fail_closed", closeCloud: true, wantAction: agento11y.HookActionDeny, wantFailure: "POST"},
+		{name: "status_503_fail_closed", status: http.StatusServiceUnavailable, respond: `{"error":"down"}`, wantAction: agento11y.HookActionDeny, wantFailure: "status 503"},
+		{name: "bad_json_fail_open", respond: `{"action":`, failOpen: true, wantAction: agento11y.HookActionAllow, wantFailure: "decode response"},
+		{name: "bad_json_fail_closed", respond: `{"action":`, wantAction: agento11y.HookActionDeny, wantFailure: "decode response"},
+		// An abandoned wait is neither: the agent already applied its own fail
+		// mode, so no verdict this handler writes is acted on. Counting it
+		// would report an unchecked allow that never reached an agent.
+		{name: "caller_abort_fail_open", abortMidCall: true, failOpen: true},
+		{name: "caller_abort_fail_closed", abortMidCall: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := newHookCloud(t)
+			if tc.status != 0 {
+				cloud.status = tc.status
+			}
+			if tc.respond != "" {
+				cloud.respond = tc.respond
+			}
+			var opts []func(*http.Request) *http.Request
+			if tc.abortMidCall {
+				cloud.delay = 500 * time.Millisecond
+				opts = append(opts, abortDuringCall(t))
+			}
+			s, _ := newForwardingTestServer(t, cloud.srv, hookEnv(cloud.srv.URL, map[string]string{
+				"AGENTO11Y_GUARDS_FAIL_OPEN": strconv.FormatBool(tc.failOpen),
+			}))
+			if tc.closeCloud {
+				cloud.srv.Close()
+			}
+
+			code, out := postHook(t, s, hookToolCallBody, nil, opts...)
+			st := s.forward.status()
+
+			if tc.abortMidCall {
+				assert.Empty(t, st.Failures, "a caller-side abort is not a Cloud delivery failure")
+				assert.Zero(t, st.HookFailOpens, "nor a tool call allowed without a verdict")
+				return
+			}
+
+			require.Equal(t, http.StatusOK, code, "a failed evaluation is still a verdict, not an HTTP error")
+			assert.Equal(t, tc.wantAction, out.Action)
+
+			if tc.wantAction == agento11y.HookActionDeny {
+				assert.Equal(t, guard.EvaluationFailureRuleID, out.RuleID)
+				assert.Contains(t, out.Reason, "could not evaluate")
+				assert.Contains(t, out.Reason, `"Bash"`, "the reason names the blocked call")
+				assert.NotContains(t, out.Reason, "policy blocked")
+			}
+
+			require.Len(t, st.Failures, 1)
+			assert.Equal(t, forwardLabelHooks, st.Failures[0].Label)
+			assert.Contains(t, st.Failures[0].Detail, tc.wantFailure)
+			// A fail-open allow is byte-identical to a Cloud allow, so the
+			// sticky counter is the only durable trace that no guard ran.
+			if tc.failOpen {
+				assert.Equal(t, 1, st.HookFailOpens)
+			} else {
+				assert.Zero(t, st.HookFailOpens)
+			}
+		})
+	}
+}
+
+// TestServer_HookEvaluate_FailOpenCountSurvivesRecovery covers why the
+// fail-open count is not part of the failure ring: the ring is cleared by the
+// next delivery, and a guard that stopped enforcing for a while has to stay
+// visible after Cloud comes back.
+func TestServer_HookEvaluate_FailOpenCountSurvivesRecovery(t *testing.T) {
+	cloud := newHookCloud(t)
+	cloud.status = http.StatusServiceUnavailable
+	s, _ := newForwardingTestServer(t, cloud.srv, hookEnv(cloud.srv.URL, nil))
+
+	_, out := postHook(t, s, hookToolCallBody, nil)
+	require.Equal(t, agento11y.HookActionAllow, out.Action)
+	require.Equal(t, 1, s.forward.status().HookFailOpens)
+
+	cloud.status = http.StatusOK
+	_, out = postHook(t, s, hookToolCallBody, nil)
+	require.Equal(t, agento11y.HookActionAllow, out.Action)
+
+	st := s.forward.status()
+	assert.Empty(t, st.Failures, "a delivered evaluation clears the ring")
+	assert.Equal(t, 1, st.HookFailOpens, "but not the record that one call went unchecked")
+}
+
+// TestServer_HookEvaluate_RelayShape covers what the daemon puts on the wire:
+// the received bytes unchanged, the loop marker, Cloud auth, and the budget
+// derived from the calling agent's own deadline.
+func TestServer_HookEvaluate_RelayShape(t *testing.T) {
+	cloud := newHookCloud(t)
+	cloud.respond = `{"action":"allow"}`
+	s, _ := newForwardingTestServer(t, cloud.srv, hookEnv(cloud.srv.URL, nil))
+
+	// A preflight request carrying a field this daemon's SDK version does not
+	// know about. Relaying the bytes is what keeps that field intact.
+	body := `{"phase":"preflight","context":{"agent_name":"pi"},"future_field":{"trace_id":"t1"}}`
+	status, out := postHook(t, s, body, map[string]string{legacyHookTimeoutHeader: "5000"})
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, agento11y.HookActionAllow, out.Action)
+
+	require.Equal(t, 1, cloud.count())
+	_, sent, headers := cloud.lastCall()
+	assert.Equal(t, body, sent)
+	assert.NotEmpty(t, headers.Get(forwardMarkerHeader))
+	assert.Equal(t, "t", headers.Get(wire.TenantHeaderName))
+	assert.True(t, strings.HasPrefix(headers.Get("Authorization"), "Basic "))
+	// The legacy spelling was propagated under the branded one, minus the
+	// margin that keeps the Cloud call ahead of the agent's own deadline.
+	assert.Equal(t, "4750", headers.Get(hookTimeoutHeader))
+}
+
+// TestServer_HookEvaluate_DoesNotChainRelayedRequest covers the loop guard: a
+// daemon whose ENDPOINT was hand-set to another daemon must answer a relayed
+// request from its own verdict.
+func TestServer_HookEvaluate_DoesNotChainRelayedRequest(t *testing.T) {
+	cloud := newHookCloud(t)
+	cloud.respond = `{"action":"deny","rule_id":"r1"}`
+	s, _ := newForwardingTestServer(t, cloud.srv, hookEnv(cloud.srv.URL, nil))
+
+	status, out := postHook(t, s, hookToolCallBody, map[string]string{forwardMarkerHeader: "1"})
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, agento11y.HookActionAllow, out.Action)
+	assert.Zero(t, cloud.count())
+}
+
+// TestServer_HookEvaluate_RejectsBadRequestsBeforeChaining covers the
+// validation the chaining must not weaken: neither a malformed body nor an
+// oversized one may reach Cloud.
+func TestServer_HookEvaluate_RejectsBadRequestsBeforeChaining(t *testing.T) {
+	cases := []struct {
+		name       string
+		body       string
+		wantStatus int
+	}{
+		{name: "invalid_json", body: `{"phase":`, wantStatus: http.StatusBadRequest},
+		{name: "oversized_body", body: `{"phase":"postflight","pad":"` + strings.Repeat("x", maxHookBodyBytes) + `"}`, wantStatus: http.StatusRequestEntityTooLarge},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := newHookCloud(t)
+			s, _ := newForwardingTestServer(t, cloud.srv, hookEnv(cloud.srv.URL, nil))
+
+			status, _ := postHook(t, s, tc.body, nil)
+			assert.Equal(t, tc.wantStatus, status)
+			assert.Zero(t, cloud.count(), "a request the daemon rejects never reaches Cloud")
+		})
+	}
+}
+
+// TestServer_HookEvaluate_ConfigChangeAppliesWithoutRestart covers the
+// no-restart contract for the guard knobs: they are resolved through the
+// file-first reader, not envconfig.ResolveGuards, so flipping guards in
+// config.env reaches a running daemon.
+func TestServer_HookEvaluate_ConfigChangeAppliesWithoutRestart(t *testing.T) {
+	cloud := newHookCloud(t)
+	cloud.respond = `{"action":"deny","rule_id":"r1","reason":"nope"}`
+	env := hookEnv(cloud.srv.URL, map[string]string{"AGENTO11Y_GUARDS_ENABLED": "false"})
+	s, _ := newForwardingTestServer(t, cloud.srv, env)
+
+	_, out := postHook(t, s, hookToolCallBody, nil)
+	require.Equal(t, agento11y.HookActionAllow, out.Action)
+	require.Zero(t, cloud.count())
+
+	env["AGENTO11Y_GUARDS_ENABLED"] = "true"
+	var b []byte
+	for k, v := range env {
+		b = fmt.Appendf(b, "%s=%s\n", k, v)
+	}
+	require.NoError(t, os.WriteFile(s.configPath, b, 0o600))
+	// Force a distinct mtime so the loader's size+mtime cache notices an edit
+	// that landed inside the filesystem's timestamp granularity.
+	future := time.Now().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(s.configPath, future, future))
+
+	_, out = postHook(t, s, hookToolCallBody, nil)
+	assert.Equal(t, agento11y.HookActionDeny, out.Action)
+	assert.Equal(t, 1, cloud.count())
 }
 
 // TestServer_APISearch covers the /api/v1/search endpoint: empty query,

--- a/plugins/agento11y/internal/local/web/app.jsx
+++ b/plugins/agento11y/internal/local/web/app.jsx
@@ -2989,6 +2989,11 @@
       return { ...s, tags: (s.tags || []).map(t => ({ ...t })) };
     }
 
+    // GUARD_CONTENT_NOTE is the one carve-out in the capture-mode promise: a
+    // chained guard check relays the content being evaluated. See
+    // handleHookEvaluate in internal/local/server.go.
+    const GUARD_CONTENT_NOTE = "Guards are on: tool calls, and the conversation an agent runs a preflight check on, are sent to Cloud for evaluation regardless of the capture mode.";
+
     // forwardBannerMeta turns the daemon's reported forwarding status into the
     // pill, accent, and sentence the banner and the settings hero both show.
     // The saved toggle is deliberately not an input: config.env and the
@@ -3000,25 +3005,54 @@
       }
       if (!st.enabled) {
         if (st.reason) return { accent: "warning", pill: "Paused", line: `Forwarding is on but paused: ${st.reason}` };
+        // The hook leg is one of the legs st.enabled sums, so nothing is
+        // relayed here.
         return { accent: "success", pill: "Off", line: "Cloud forwarding is off — nothing from local sessions leaves this device." };
       }
-      const failure = (st.failures || [])[0];
+      // Guard disclosures hold whatever else the status says, so every branch
+      // below that reports forwarding as on appends them. Failures are kept per
+      // leg: a failing generations or OTLP leg must not hide that guard checks
+      // are still shipping content, nor swallow the unchecked-allow count.
+      const disclosures = [];
+      if (st.hooks) disclosures.push(GUARD_CONTENT_NOTE);
+      if (st.hookFailOpens > 0) disclosures.push(st.hookFailOpens === 1
+        ? "1 guard check ran without a Cloud verdict and was allowed."
+        : `${st.hookFailOpens} guard checks ran without a Cloud verdict and were allowed.`);
+      const failures = st.failures || [];
+      const failure = failures[0];
       if (failure) {
-        return { accent: "error", pill: "Failing", line: `Forwarding is on but the last attempts failed — ${failure.label}: ${failure.detail}` };
+        // Name the other failing legs instead of letting the most recent one
+        // stand for all of them.
+        const others = [...new Set(failures.map(f => f.label))].filter(l => l !== failure.label);
+        const also = others.length > 0 ? ` (also failing: ${others.join(", ")})` : "";
+        return {
+          accent: "error",
+          pill: "Failing",
+          line: [`Forwarding is on but the last attempts failed — ${failure.label}: ${failure.detail}${also}`, ...disclosures].join(" "),
+        };
       }
       // An unrecognised mode must not read as the narrower one: a future mode
       // could forward more, not less.
       if (st.mode !== "full" && st.mode !== "metadata_only") {
-        return { accent: "warning", pill: "On", line: `Forwarding is on in a mode this viewer does not know (${st.mode || "unset"}).` };
+        return { accent: "warning", pill: "On", line: [`Forwarding is on in a mode this viewer does not know (${st.mode || "unset"}).`, ...disclosures].join(" ") };
       }
+      // With guards chained, only reasoning text and media are still local:
+      // the guard request carries tool calls, and for a preflight check the
+      // prompts and responses too, so those cannot be listed as local here.
+      const metadataLine = st.hooks
+        ? "Session capture forwards usage and session metadata only — reasoning text and attached media stay local."
+        : "Only usage and session metadata is forwarded — prompts, responses, reasoning text, tool inputs/results, and attached media stay local.";
       const parts = [st.mode === "full"
         ? "Full session content is forwarded to your organization's Grafana Cloud."
-        : "Only usage and session metadata is forwarded — prompts, responses, reasoning text, tool inputs/results, and attached media stay local."];
+        : metadataLine];
       if (!st.generations && st.reason) parts.push(`Generations are paused: ${st.reason}`);
       if (!st.otlp) parts.push("Traces and metrics are not forwarded.");
+      parts.push(...disclosures);
       return {
-        accent: st.mode === "full" ? "warning" : "info",
-        pill: st.mode === "full" ? "Full content" : "Metadata only",
+        // A metadata_only forward with guards chained still ships content, so
+        // it does not get the calm accent or the reassuring pill.
+        accent: st.mode === "full" || st.hooks ? "warning" : "info",
+        pill: st.mode === "full" ? "Full content" : (st.hooks ? "Metadata + guard content" : "Metadata only"),
         line: parts.join(" "),
       };
     }
@@ -3360,6 +3394,9 @@
       // its own environment at boot, so "off here, on there" is reachable until
       // an explicit false is saved.
       const daemonStillOn = !!(forwardStatus && forwardStatus.enabled) && !form.localForward;
+      // Say it next to the control that sets the capture mode, not only in the
+      // banner.
+      const guardsChained = !!(forwardStatus && forwardStatus.hooks);
       return (
         <SettingsCard>
           <SectionLabel>Connection</SectionLabel>
@@ -3393,6 +3430,7 @@
               Also send <Mono>--local</Mono> sessions to Grafana Cloud. Needs the credentials above, and applies to every local session on this machine until you turn it off. The local viewer always keeps full content; <b style={{ fontWeight: 500, color: "var(--fg2)" }}>Metadata only</b> forwards usage and session metadata, and <b style={{ fontWeight: 500, color: "var(--fg2)" }}>Full</b> forwards prompts, responses, and tool I/O too. Metadata only and Full write <Mono>CONTENT_CAPTURE_MODE</Mono>, which also decides how much content your non-local Cloud sessions capture.
               {advanced && <div style={{ color: "var(--warning-text)", marginTop: 6 }}>Advanced capture mode <Mono>{form.capture}</Mono> is set in config.env. Forwarding reduces it to metadata only and <b style={{ fontWeight: 500, color: "var(--fg2)" }}>Metadata only</b> leaves it in place; picking <b style={{ fontWeight: 500, color: "var(--fg2)" }}>Full</b> replaces it for Cloud sessions too.</div>}
               {daemonStillOn && <div style={{ color: "var(--warning-text)", marginTop: 6 }}>The running daemon is still forwarding — <Mono>LOCAL_FORWARD</Mono> is set in its environment. Saving writes an explicit <Mono>false</Mono> to config.env, which the daemon prefers.</div>}
+              {guardsChained && <div style={{ color: "var(--warning-text)", marginTop: 6 }}>{GUARD_CONTENT_NOTE} The daemon relays <Mono>--local</Mono> guard checks to Cloud so your Cloud rules still apply; turn off <Mono>GUARDS_ENABLED</Mono> or forwarding to stop it.</div>}
             </>}
           >
             <SettingsSegmented value={forwardMode} onChange={v => applyForwardLocalMode(set, form, v)} options={FORWARD_LOCAL_OPTIONS}/>

--- a/plugins/opencode/src/guard.test.ts
+++ b/plugins/opencode/src/guard.test.ts
@@ -73,6 +73,36 @@ describe("runToolCallGuard", () => {
     expect(block.reason).toContain("Stop and tell the user");
   });
 
+  it("returns the raw reason for an evaluation-failure deny", async () => {
+    // The local daemon answers with this rule id when its own chained Cloud
+    // hook call failed under GUARDS_FAIL_OPEN=false. No policy ran, so the
+    // message must not claim one blocked the call.
+    const client = {
+      evaluateHook: async () => ({
+        action: "deny",
+        ruleId: "__agento11y_guard_evaluation_failure",
+        reason:
+          'agento11y could not evaluate the Grafana Agent Observability guard for the "bash" tool call, so it was blocked as a safety measure. Details: connection refused',
+        evaluations: [],
+      }),
+    };
+
+    const res = await runToolCallGuard({
+      client: client as any,
+      agentName: "opencode",
+      model: { provider: "anthropic", name: "claude" },
+      toolCallId: "c1",
+      toolName: "bash",
+      input: { command: "ls" },
+      failOpen: true,
+    });
+
+    const block = asBlock(res);
+    expect(block.reason).toContain("could not evaluate");
+    expect(block.reason).toContain("connection refused");
+    expect(block.reason).not.toContain("A Grafana Agent Observability policy");
+  });
+
   it("omits the Reason clause when Agent Observability denies without a reason", async () => {
     const client = {
       evaluateHook: async () => ({

--- a/plugins/opencode/src/guard.ts
+++ b/plugins/opencode/src/guard.ts
@@ -58,6 +58,18 @@ function formatPolicyDeny(
 }
 
 /**
+ * Marks a deny that reports a failed guard evaluation rather than a policy
+ * decision. The local daemon returns it when its chained Cloud hook call fails
+ * and `GUARDS_FAIL_OPEN` is false, and its reason already explains that, so it
+ * must not be wrapped by `formatPolicyDeny`.
+ *
+ * Mirrors `EvaluationFailureRuleID` in
+ * `plugins/agento11y/internal/agents/guard/toolcall.go` and the same constant in
+ * `plugins/pi/src/guard.ts`. Keep the three in sync.
+ */
+const EVALUATION_FAILURE_RULE_ID = "__agento11y_guard_evaluation_failure";
+
+/**
  * Fail-closed message used when the guard evaluation request fails. Explicitly
  * distinguishes the infrastructure failure from a policy decision.
  *
@@ -115,6 +127,13 @@ export async function runToolCallGuard(args: GuardArgs): Promise<GuardResult> {
 
     const resp = await args.client.evaluateHook(req, { enabled: true });
     if (resp.action === "deny") {
+      // No rule produced this deny, and its reason already says so.
+      if (resp.ruleId === EVALUATION_FAILURE_RULE_ID) {
+        return {
+          block: true,
+          reason: resp.reason ?? formatEvalFailure(args.toolName, undefined),
+        };
+      }
       return {
         block: true,
         reason: formatPolicyDeny(args.toolName, resp.reason),

--- a/plugins/pi/src/guard.test.ts
+++ b/plugins/pi/src/guard.test.ts
@@ -94,6 +94,25 @@ describe("runToolCallGuard", () => {
     expect(result.reason).toContain("Stop and tell the user");
   });
 
+  it("returns the raw reason for an evaluation-failure deny", async () => {
+    // The local daemon answers with this rule id when its own chained Cloud
+    // hook call failed under GUARDS_FAIL_OPEN=false. No policy ran, so the
+    // message must not claim one blocked the call.
+    const { client } = makeClient(async () => ({
+      action: "deny",
+      ruleId: "__agento11y_guard_evaluation_failure",
+      reason:
+        'agento11y could not evaluate the Grafana Agent Observability guard for the "bash" tool call, so it was blocked as a safety measure. Details: connection refused',
+      evaluations: [],
+    }));
+
+    const result = await runToolCallGuard(makeArgs({ client }));
+    expectBlock(result);
+    expect(result.reason).toContain("could not evaluate");
+    expect(result.reason).toContain("connection refused");
+    expect(result.reason).not.toContain("A Grafana Agent Observability policy");
+  });
+
   it("omits the Reason clause when the deny reason is empty", async () => {
     const { client } = makeClient(async () => ({
       action: "deny",

--- a/plugins/pi/src/guard.ts
+++ b/plugins/pi/src/guard.ts
@@ -53,6 +53,18 @@ function formatPolicyDeny(
 }
 
 /**
+ * Marks a deny that reports a failed guard evaluation rather than a policy
+ * decision. The local daemon returns it when its chained Cloud hook call fails
+ * and `GUARDS_FAIL_OPEN` is false, and its reason already explains that, so it
+ * must not be wrapped by `formatPolicyDeny`.
+ *
+ * Mirrors `EvaluationFailureRuleID` in
+ * `plugins/agento11y/internal/agents/guard/toolcall.go` and the same constant in
+ * `plugins/opencode/src/guard.ts`. Keep the three in sync.
+ */
+const EVALUATION_FAILURE_RULE_ID = "__agento11y_guard_evaluation_failure";
+
+/**
  * Fail-closed message used when the guard could not be evaluated (transport
  * failure or, on the Go side, missing credentials). Explicitly distinguishes
  * the infrastructure failure from a policy decision.
@@ -164,6 +176,13 @@ export async function runToolCallGuard(args: GuardArgs): Promise<GuardResult> {
 
     const resp = await args.client.evaluateHook(req, { enabled: true });
     if (resp.action === "deny") {
+      // No rule produced this deny, and its reason already says so.
+      if (resp.ruleId === EVALUATION_FAILURE_RULE_ID) {
+        return {
+          block: true,
+          reason: resp.reason ?? formatEvalFailure(args.toolName, undefined),
+        };
+      }
       return {
         block: true,
         reason: formatPolicyDeny(args.toolName, resp.reason),


### PR DESCRIPTION
`agento11y <agent> --local` now can use guards from Grafana Cloud. The daemon now relays hook requests to Cloud, same as generations and OTLP when forwarding to Cloud is enabled. To make it work, all of these are needed:

- `AGENTO11Y_LOCAL_FORWARD=true`
- `AGENTO11Y_GUARDS_ENABLED=true`
- `AGENTO11Y_ENDPOINT`
- credentials