### PR TITLE
feat(sdk/go): add cloud evaluation support for experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The experiments are offline evals: run an agent over a dataset, grade it, and pu
 |-------|---------|
 | Python | [`examples/experiments/python/`](examples/experiments/python/) |
 | Go | [`examples/experiments/go/`](examples/experiments/go/) |
+| Go (evaluator stored in your tenant) | [`examples/experiments/go/cloud-evaluator/`](examples/experiments/go/cloud-evaluator/) |
 
 The reference app is a fuller FastAPI service with framework callbacks and manual instrumentation side by side.
 

--- a/examples/experiments/README.md
+++ b/examples/experiments/README.md
@@ -24,6 +24,7 @@ A/B testing is just two runs with different experiment ids or tags over the same
 | Framework-free | Python + core `agento11y` | [`python/`](python/) |
 | Framework-free | Go + `agento11y/go` | [`go/`](go/) |
 | Prompt optimizer | Go + `agento11y/go/experiments` | [`go/prompt-optimization/`](go/prompt-optimization/) |
+| Stored evaluator | Go + `agento11y/go/experiments` | [`go/cloud-evaluator/`](go/cloud-evaluator/) |
 
 For credentials, see the [credentials section in the repo README](../../README.md#grafana-cloud-credentials).
 Each example's own README covers the run command and the canned-vs-real-model

--- a/examples/experiments/go/.env.example
+++ b/examples/experiments/go/.env.example
@@ -38,5 +38,10 @@ RUN_ID=go-experiment-local
 GIT_SHA=local
 N_ATTEMPTS=1
 
+# Optional stored-evaluator example configuration. The evaluator has to exist in
+# your tenant already; the example does not create one.
+# EVALUATOR_ID=helpfulness
+# EVALUATOR_VERSION=
+
 # Optional: customize generated experiment links.
 # AGENTO11Y_EXPERIMENT_URL_TEMPLATE={base}/a/grafana-agento11y-app/offline-experiments/experiments/{run_id}

--- a/examples/experiments/go/README.md
+++ b/examples/experiments/go/README.md
@@ -20,6 +20,30 @@ GOWORK=off go run .
 The canned agent makes no provider call. It needs only `AGENTO11Y_ENDPOINT`,
 `AGENTO11Y_AUTH_TOKEN`, and optional `AGENTO11Y_AUTH_TENANT_ID`.
 
+| Entry point | Command | What it demonstrates |
+| --- | --- | --- |
+| Streaming runner | `GOWORK=off go run .` | Candidate I/O, several verifier scores, usage, cost, artifact |
+| Stored evaluator | `GOWORK=off go run ./cloud-evaluator` | Binds the agent's conversation and grades it with an evaluator stored in your tenant, with no local score |
+| Prompt optimizer | `GOWORK=off go run ./prompt-optimization` | Real-model hill climbing on the finalized report score |
+
+## Stored evaluator
+
+[`cloud-evaluator/`](cloud-evaluator/) grades each trial with an evaluator that
+already exists in your tenant instead of scoring locally. `trial.Evaluate(...)`
+blocks until the worker finishes, so the run takes as long as the evaluations do:
+
+```bash
+export AGENTO11Y_EXPERIMENT_ID=cloud-evaluator-${GIT_SHA:-manual}
+export EVALUATOR_ID=<an-evaluator-id-in-your-tenant>
+# Optional: pin a version instead of the latest active one.
+export EVALUATOR_VERSION=<version>
+GOWORK=off go run ./cloud-evaluator
+```
+
+The example does not create the evaluator; define it in Agent Observability
+first. Trials close as `completed` with no local final score, and the backend
+counts the stored evaluator's scores.
+
 ## Prompt optimization
 
 [`prompt-optimization/`](prompt-optimization/) is a real-model example that

--- a/examples/experiments/go/cloud-evaluator/main.go
+++ b/examples/experiments/go/cloud-evaluator/main.go
@@ -1,0 +1,165 @@
+// Command cloud-evaluator grades experiment trials with an evaluator stored in
+// Agent Observability instead of a score computed in the runner.
+//
+// Use this shape when the grading prompt lives in your tenant. The runner only
+// has to make the agent's conversation findable:
+//
+//  1. Open an experiment with the ingest credential.
+//  2. For each case, run the already-instrumented agent and bind its conversation.
+//  3. Call trial.Evaluate(evaluatorID) and let the stored evaluator score it.
+//  4. Close the trial without a local FinalScore; the backend owns the verdict.
+//
+// The canned agent here publishes its own generation so the example runs without
+// a provider key. A real agent instrumented with the SDK or a provider wrapper
+// already emits that generation, and you only need its conversation ID.
+//
+// SDK config via env: AGENTO11Y_ENDPOINT, AGENTO11Y_AUTH_TOKEN, optional
+// AGENTO11Y_AUTH_TENANT_ID and AGENTO11Y_EXPERIMENT_ID. This example also reads
+// EVALUATOR_ID, EVALUATOR_VERSION, and GIT_SHA, which are its own knobs and not
+// SDK settings.
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"os"
+	"strings"
+
+	agento11y "github.com/grafana/agento11y/go/agento11y"
+	"github.com/grafana/agento11y/go/agento11y/experiments"
+)
+
+type evalCase struct {
+	ID       string
+	Question string
+}
+
+var cases = []evalCase{
+	{ID: "capital-france", Question: "What is the capital of France?"},
+	{ID: "two-plus-two", Question: "What is 2 + 2? Answer with just the number."},
+	{ID: "largest-planet", Question: "What is the largest planet in our solar system?"},
+}
+
+var answers = map[string]string{
+	"capital-france": "Paris",
+	"two-plus-two":   "4",
+	"largest-planet": "Jupiter",
+}
+
+func main() {
+	ctx := context.Background()
+	client, err := experiments.NewClientFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() { _ = client.Shutdown(context.Background()) }()
+
+	gitSHA := getenv("GIT_SHA", "manual")
+	experimentID := getenv("AGENTO11Y_EXPERIMENT_ID", "cloud-evaluator-"+gitSHA)
+	// The evaluator must already exist in your tenant; this example does not create one.
+	evaluatorID := getenv("EVALUATOR_ID", "helpfulness")
+	evaluatorVersion := getenv("EVALUATOR_VERSION", "")
+	planned := len(cases)
+
+	run, err := experiments.WithExperiment(ctx, client, experiments.ExperimentOptions{
+		ExperimentID:      experimentID,
+		Name:              "Go cloud evaluator example",
+		PlannedTrialCount: &planned,
+		Candidate:         &experiments.Candidate{AgentName: "example-agent", GitSHA: gitSHA},
+		Tags:              []string{"example", "go", "cloud-evaluator"},
+	}, func(ctx context.Context, run *experiments.Experiment) error {
+		for _, testCase := range cases {
+			if err := gradeCase(ctx, client, run, testCase, evaluatorID, evaluatorVersion); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		log.Fatalf("run experiment: %v", err)
+	}
+
+	report, err := run.Report(ctx)
+	if err != nil {
+		log.Fatalf("report: %v", err)
+	}
+	log.Printf("trials=%d completed=%d", report.Summary.TrialCount, report.Summary.CompletedCount)
+	// Only a score stored under the "final" key feeds report.Summary.PassRate, and a
+	// stored evaluator scores under its own key, so that stays nil. The rows below
+	// show what the backend actually attached.
+	for _, row := range report.Rows {
+		for _, result := range row.Trials {
+			keys := make([]string, 0, len(result.Scores))
+			for _, score := range result.Scores {
+				keys = append(keys, score.ScoreKey)
+			}
+			if len(keys) == 0 {
+				keys = append(keys, "none")
+			}
+			log.Printf("  %s: scores=%s", row.TestCaseID, strings.Join(keys, ", "))
+		}
+	}
+	log.Printf("View in Agent Observability: %s", run.URL())
+}
+
+func gradeCase(
+	ctx context.Context,
+	client *experiments.Client,
+	run *experiments.Experiment,
+	testCase evalCase,
+	evaluatorID, evaluatorVersion string,
+) error {
+	return run.WithTrialByCaseID(ctx, testCase.ID, func(ctx context.Context, trial *experiments.Trial) error {
+		answer := answers[testCase.ID]
+		// Stand-in for your instrumentation's conversation. With a real
+		// instrumented agent, bind the ID it already exported instead.
+		conversationID := trial.TrialID + "-agent"
+		if err := client.RecordGeneration(ctx, trial.GenerationID, experiments.GenerationOptions{
+			ConversationID: conversationID,
+			InputText:      testCase.Question,
+			OutputText:     answer,
+			ModelProvider:  "example",
+			ModelName:      "canned-answer",
+			AgentName:      "example-agent",
+			OperationName:  "answer_question",
+			Usage:          experiments.TokenUsage{InputTokens: 12, OutputTokens: 3},
+			Tags:           map[string]string{"experiment.run_id": run.ExperimentID, "task_id": testCase.ID},
+		}); err != nil {
+			return err
+		}
+		// The evaluator grades the conversation this binding points at.
+		trial.BindConversation(conversationID)
+
+		// Blocks until the worker finishes. No local FinalScore follows: the
+		// stored evaluator writes the score and the report counts it.
+		evaluation, err := trial.Evaluate(ctx, evaluatorID, experiments.EvaluateOptions{
+			EvaluatorVersion: evaluatorVersion,
+		})
+		if err != nil {
+			var failed *agento11y.TrialEvaluationFailedError
+			var timedOut *agento11y.TrialEvaluationTimeoutError
+			switch {
+			case errors.As(err, &failed):
+				log.Printf("%s: evaluation %s failed: %s", testCase.ID, failed.EvaluationID, failed.Detail)
+			case errors.As(err, &timedOut):
+				log.Printf("%s: evaluation %s still pending: %s", testCase.ID, timedOut.EvaluationID, timedOut.Detail)
+			}
+			return err
+		}
+		version := evaluation.EvaluatorVersion
+		if version == "" {
+			version = "latest"
+		}
+		log.Printf("%s: %s evaluator=%s@%s attempts=%d",
+			testCase.ID, evaluation.Status, evaluation.EvaluatorID, version, evaluation.Attempts)
+		return nil
+	})
+}
+
+func getenv(key, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/go/README.md
+++ b/go/README.md
@@ -348,6 +348,76 @@ continues to use the ingest credential. `NewExperimentFromSuite` and
 `WithExperimentFromSuite` resolve exact, `latest`, `latest_published`, or
 `draft` versions before starting, so the selected version is durable.
 
+### Grading with an evaluator stored in your tenant
+
+`Trial.Evaluate` grades the conversation Agent Observability already stored,
+using an evaluator defined in your tenant, instead of a score the runner
+computes. `Trial.EvaluateOutput` is the in-process judge; `Trial.Evaluate` is
+the stored one.
+
+```go
+if err := run.WithTrial(ctx, testCase, func(ctx context.Context, trial *experiments.Trial) error {
+	conversationID := runAgent(ctx, testCase.Input) // already instrumented
+	trial.BindConversation(conversationID)
+
+	// Blocks until the worker reaches a terminal status.
+	evaluation, err := trial.Evaluate(ctx, "helpfulness", experiments.EvaluateOptions{
+		EvaluatorVersion: "v3", // optional; empty pins the latest active version
+	})
+	if err != nil {
+		var failed *agento11y.TrialEvaluationFailedError
+		if errors.As(err, &failed) {
+			log.Printf("evaluation %s failed: %s", failed.EvaluationID, failed.Detail)
+		}
+		return err
+	}
+	log.Printf("stored evaluator finished: %s", evaluation.Status)
+	return nil // no FinalScore: the backend owns the verdict
+}); err != nil {
+	return err
+}
+```
+
+The call persists the trial's conversation binding and exports the anchor
+generation before queueing the evaluation, because the backend rejects an
+evaluation for a trial with no stored conversation. A trial graded this way
+closes as `completed` without a local `FinalScore`; an error returned from the
+trial callback afterwards still closes it as `errored`.
+
+`EvaluateOptions.Timeout` (default 300s) bounds the wait, and `ctx` cancellation
+ends it too. Worker failure returns `*agento11y.TrialEvaluationFailedError`, an
+exceeded deadline returns `*agento11y.TrialEvaluationTimeoutError`, and both
+carry the evaluation ID; `errors.Is` matches `agento11y.ErrTrialEvaluationFailed`
+and `agento11y.ErrTrialEvaluationTimeout`. The poll interval doubles from
+`EvaluateOptions.PollInterval` (default 500ms) up to 5s, so a long wait does not
+keep reading status at the floor rate. The evaluation is keyed by trial,
+conversation, evaluator, and resolved evaluator version, so triggering the same
+combination returns the existing evaluation instead of running it twice, and
+requeues it once it has failed.
+
+Leave `ScoreCount` unset when a run uses cloud evaluation. Agent Observability
+checks an asserted count against every stored score, including the ones the
+stored evaluator wrote, so a locally derived count conflicts. Both
+`experiments.Experiment` and the root-package `ExperimentRun` drop a count of
+their own once one of their trials queued a cloud evaluation. A trial built
+directly with `experiments.NewTrial` (or the root `agento11y.NewTrial`) has no
+run to mark, so a runner that finalizes such a run has to leave the count unset
+itself.
+
+The score is attached to the conversation and the trial with no generation ID, so
+read it from a trial's `Scores` in `Experiment.Report`, not from a per-generation
+lookup. It carries the evaluator's own score key, and only a score under the
+`final` key feeds the report's pass rate, so `Summary.PassRate` stays nil for a
+run graded only in the cloud.
+
+A wait that ends in a timeout, a cancelled context, or a transport error leaves
+the evaluation running server-side. Finalizing the run as `completed` while an
+evaluation is still queued returns `agento11y.ErrExperimentConflict`; call
+`Evaluate` again to wait for the same evaluation, then finalize. `Evaluate` also
+blocks the next trial, so to grade several at once trigger with
+`Client.TriggerTrialEvaluation` and poll `Client.GetTrialEvaluation` yourself,
+keeping both inside the experiment.
+
 Local `LLMJudge` and `RegexJudge` helpers require no platform evaluator.
 `Trial.RecordEvaluation` also accepts framework-owned evaluations without
 reinterpreting their transcript. If an evaluation includes a grader generation,
@@ -356,7 +426,8 @@ default for generations, scores, explanations, metadata, and text-like
 artifacts. Experimental trial spans and `gen_ai.evaluation.result` events are
 opt-in with `AGENTO11Y_USE_EXPERIMENTAL_OTEL=true`.
 
-See the runnable [Go streaming example](../examples/experiments/go/).
+See the runnable [Go streaming example](../examples/experiments/go/) and the
+[stored-evaluator example](../examples/experiments/go/cloud-evaluator/).
 
 ## Content Capture Mode
 

--- a/go/agento11y/errors.go
+++ b/go/agento11y/errors.go
@@ -52,6 +52,14 @@ var (
 	ErrExperimentConflict = errors.New("agento11y: experiment conflict")
 	// ErrExperimentTransportFailed wraps experiment lifecycle transport failures.
 	ErrExperimentTransportFailed = errors.New("agento11y: experiment transport failed")
+	// ErrTrialEvaluationFailed is returned when a stored evaluator finishes a
+	// trial evaluation unsuccessfully. Use errors.As with
+	// *TrialEvaluationFailedError to read the evaluation ID.
+	ErrTrialEvaluationFailed = errors.New("agento11y: trial evaluation failed")
+	// ErrTrialEvaluationTimeout is returned when waiting for a trial evaluation
+	// exceeds the caller's deadline. Use errors.As with
+	// *TrialEvaluationTimeoutError to read the evaluation ID.
+	ErrTrialEvaluationTimeout = errors.New("agento11y: trial evaluation timed out")
 	// ErrScoreValidationFailed wraps score export validation failures.
 	ErrScoreValidationFailed = errors.New("agento11y: score validation failed")
 	// ErrScoreExportFailed wraps score export transport failures or rejected scores.
@@ -88,4 +96,53 @@ func (e *HookDeniedError) Error() string {
 // Unwrap exposes ErrHookDenied for errors.Is matching.
 func (e *HookDeniedError) Unwrap() error {
 	return ErrHookDenied
+}
+
+// TrialEvaluationFailedError is returned when a stored evaluator ends a trial
+// evaluation unsuccessfully. The evaluation keeps its row server-side, so
+// triggering the same evaluator again requeues it.
+type TrialEvaluationFailedError struct {
+	EvaluationID string
+	Detail       string
+}
+
+// Error formats the backend failure reason and the evaluation it came from.
+func (e *TrialEvaluationFailedError) Error() string {
+	return trialEvaluationMessage("failed", e.EvaluationID, e.Detail)
+}
+
+// Unwrap exposes ErrTrialEvaluationFailed for errors.Is matching.
+func (e *TrialEvaluationFailedError) Unwrap() error {
+	return ErrTrialEvaluationFailed
+}
+
+// TrialEvaluationTimeoutError is returned when a trial evaluation has not
+// reached a terminal status before the caller's deadline. The evaluation keeps
+// running server-side.
+type TrialEvaluationTimeoutError struct {
+	EvaluationID string
+	Detail       string
+}
+
+// Error formats the wait that was abandoned and the evaluation it was for.
+func (e *TrialEvaluationTimeoutError) Error() string {
+	return trialEvaluationMessage("timed out", e.EvaluationID, e.Detail)
+}
+
+// Unwrap exposes ErrTrialEvaluationTimeout for errors.Is matching.
+func (e *TrialEvaluationTimeoutError) Unwrap() error {
+	return ErrTrialEvaluationTimeout
+}
+
+// trialEvaluationMessage formats one trial evaluation error. A blank detail is
+// dropped instead of restating the outcome.
+func trialEvaluationMessage(outcome, evaluationID, detail string) string {
+	id := strings.TrimSpace(evaluationID)
+	if id == "" {
+		id = "unknown"
+	}
+	if detail = strings.TrimSpace(detail); detail == "" {
+		return fmt.Sprintf("agento11y trial evaluation %s %s", id, outcome)
+	}
+	return fmt.Sprintf("agento11y trial evaluation %s %s: %s", id, outcome, detail)
 }

--- a/go/agento11y/experiment_run.go
+++ b/go/agento11y/experiment_run.go
@@ -37,6 +37,7 @@ type ExperimentRun struct {
 
 	mu                   sync.Mutex
 	accepted             int
+	cloudEvaluated       bool
 	finalized            bool
 	recorders            []*GenerationRecorder
 	trackedIDs           []string
@@ -270,12 +271,20 @@ func (r *ExperimentRun) Finalize(ctx context.Context, status ExperimentStatus, e
 		r.mu.Unlock()
 		return nil
 	}
-	scoreCount := r.accepted
+	var scoreCount *int
+	if !r.cloudEvaluated {
+		// A stored evaluator writes scores the runner never sees, and Agent
+		// Observability checks an asserted count against every stored score, so a
+		// locally accumulated count would conflict once one trial used cloud
+		// evaluation.
+		count := r.accepted
+		scoreCount = &count
+	}
 	r.mu.Unlock()
 	if err := r.client.Flush(ctx); err != nil {
 		return err
 	}
-	_, err := r.client.FinalizeExperiment(ctx, r.RunID, status, CompleteExperimentOptions{ScoreCount: &scoreCount, Error: errorText})
+	_, err := r.client.FinalizeExperiment(ctx, r.RunID, status, CompleteExperimentOptions{ScoreCount: scoreCount, Error: errorText})
 	if err != nil {
 		return err
 	}
@@ -312,6 +321,17 @@ func (r *ExperimentRun) AcceptedScores() int {
 func (r *ExperimentRun) recordAccepted(n int) {
 	r.mu.Lock()
 	r.accepted += n
+	r.mu.Unlock()
+}
+
+// markCloudEvaluated records that a stored evaluator graded one of this run's
+// trials, so finalization stops asserting a locally accumulated score count.
+func (r *ExperimentRun) markCloudEvaluated() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	r.cloudEvaluated = true
 	r.mu.Unlock()
 }
 

--- a/go/agento11y/experiments.go
+++ b/go/agento11y/experiments.go
@@ -208,6 +208,110 @@ func (c *Client) UpdateTrial(ctx context.Context, experimentID, trialID string, 
 	return &out, nil
 }
 
+// TriggerTrialEvaluation queues a stored tenant evaluator against the
+// conversation bound to a trial. The trial must exist, belong to a running
+// external experiment, and already have a conversation.
+//
+// A queued or claimed evaluation comes back with a non-terminal status; poll
+// GetTrialEvaluation until Status.Terminal() is true. The evaluation is keyed by
+// trial, conversation, evaluator, and resolved evaluator version, so triggering
+// the same combination returns the existing evaluation instead of running it
+// twice, and requeues it once it has failed.
+func (c *Client) TriggerTrialEvaluation(ctx context.Context, experimentID, trialID string, req TriggerTrialEvaluationRequest) (*TrialEvaluation, error) {
+	if c == nil {
+		return nil, ErrNilClient
+	}
+	normalizedRunID := strings.TrimSpace(experimentID)
+	if normalizedRunID == "" {
+		return nil, fmt.Errorf("%w: experiment_id is required for trial evaluation", ErrExperimentValidationFailed)
+	}
+	normalizedTrialID := strings.TrimSpace(trialID)
+	if normalizedTrialID == "" {
+		return nil, fmt.Errorf("%w: trial_id is required", ErrExperimentValidationFailed)
+	}
+	req.EvaluatorID = strings.TrimSpace(req.EvaluatorID)
+	if req.EvaluatorID == "" {
+		return nil, fmt.Errorf("%w: evaluator_id is required", ErrExperimentValidationFailed)
+	}
+	req.EvaluatorVersion = strings.TrimSpace(req.EvaluatorVersion)
+	args := c.evalArgs()
+	base, err := baseURLFromAPIEndpoint(args.endpoint, args.insecure)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrExperimentTransportFailed, err)
+	}
+	endpoint := strings.TrimRight(base, "/") + experimentRunsPrefix + "/" + url.PathEscape(normalizedRunID) +
+		"/trials/" + escapeTrialPathSegment(normalizedTrialID) + ":evaluate"
+	var out TrialEvaluation
+	if err := c.requestEvalJSON(ctx, http.MethodPost, endpoint, args.headers, req, &out, ErrExperimentTransportFailed, "trial evaluation trigger"); err != nil {
+		return nil, err
+	}
+	if err := validateTrialEvaluation(&out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetTrialEvaluation reads durable status for a triggered trial evaluation.
+func (c *Client) GetTrialEvaluation(ctx context.Context, experimentID, trialID, evaluationID string) (*TrialEvaluation, error) {
+	if c == nil {
+		return nil, ErrNilClient
+	}
+	normalizedRunID := strings.TrimSpace(experimentID)
+	if normalizedRunID == "" {
+		return nil, fmt.Errorf("%w: experiment_id is required for trial evaluation", ErrExperimentValidationFailed)
+	}
+	normalizedTrialID := strings.TrimSpace(trialID)
+	if normalizedTrialID == "" {
+		return nil, fmt.Errorf("%w: trial_id is required", ErrExperimentValidationFailed)
+	}
+	normalizedEvaluationID := strings.TrimSpace(evaluationID)
+	if normalizedEvaluationID == "" {
+		return nil, fmt.Errorf("%w: evaluation_id is required", ErrExperimentValidationFailed)
+	}
+	args := c.evalArgs()
+	base, err := baseURLFromAPIEndpoint(args.endpoint, args.insecure)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrExperimentTransportFailed, err)
+	}
+	endpoint := strings.TrimRight(base, "/") + experimentRunsPrefix + "/" + url.PathEscape(normalizedRunID) +
+		"/trials/" + escapeTrialPathSegment(normalizedTrialID) +
+		"/evaluations/" + url.PathEscape(normalizedEvaluationID)
+	var out TrialEvaluation
+	if err := c.requestEvalJSON(ctx, http.MethodGet, endpoint, args.headers, nil, &out, ErrExperimentTransportFailed, "trial evaluation status"); err != nil {
+		return nil, err
+	}
+	if err := validateTrialEvaluation(&out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// escapeTrialPathSegment escapes a trial id for the trial evaluation routes.
+// url.PathEscape leaves ":" alone, and the ingest router reads the ":evaluate"
+// verb off the raw path segment before it decodes the id, so an unescaped colon
+// in a trial id would change which route the request reaches.
+func escapeTrialPathSegment(value string) string {
+	return strings.ReplaceAll(url.PathEscape(value), ":", "%3A")
+}
+
+// validateTrialEvaluation rejects a response the SDK cannot act on. Status is a
+// named string type, so an unrecognized terminal state would otherwise read as
+// non-terminal and poll until the caller's deadline. A missing evaluation ID
+// would turn the next status read into a validation error that blames the
+// caller's arguments.
+func validateTrialEvaluation(out *TrialEvaluation) error {
+	switch out.Status {
+	case TrialEvaluationStatusQueued, TrialEvaluationStatusClaimed,
+		TrialEvaluationStatusSuccess, TrialEvaluationStatusFailed:
+	default:
+		return fmt.Errorf("%w: unsupported evaluation status %q", ErrExperimentTransportFailed, string(out.Status))
+	}
+	if strings.TrimSpace(out.EvaluationID) == "" {
+		return fmt.Errorf("%w: evaluation response carries no evaluation_id", ErrExperimentTransportFailed)
+	}
+	return nil
+}
+
 func (c *Client) UploadTrialArtifact(ctx context.Context, experimentID, trialID string, artifact TrialArtifactUpload) (*TrialArtifact, error) {
 	if c == nil {
 		return nil, ErrNilClient

--- a/go/agento11y/experiments/client.go
+++ b/go/agento11y/experiments/client.go
@@ -146,6 +146,26 @@ func (c *Client) UpdateTrial(ctx context.Context, experimentID, trialID string, 
 	return c.core.UpdateTrial(ctx, experimentID, trialID, req)
 }
 
+// TriggerTrialEvaluation queues a stored tenant evaluator for the conversation
+// bound to a trial. The returned evaluation is usually still queued; read
+// GetTrialEvaluation until Status.Terminal() is true, or use Trial.Evaluate to
+// wait. The evaluator ID and version are sent as given, like every other
+// resource identifier in this package.
+func (c *Client) TriggerTrialEvaluation(ctx context.Context, experimentID, trialID string, req TriggerTrialEvaluationRequest) (*TrialEvaluation, error) {
+	if c == nil || c.core == nil {
+		return nil, agento11y.ErrNilClient
+	}
+	return c.core.TriggerTrialEvaluation(ctx, experimentID, trialID, req)
+}
+
+// GetTrialEvaluation reads durable status for a triggered trial evaluation.
+func (c *Client) GetTrialEvaluation(ctx context.Context, experimentID, trialID, evaluationID string) (*TrialEvaluation, error) {
+	if c == nil || c.core == nil {
+		return nil, agento11y.ErrNilClient
+	}
+	return c.core.GetTrialEvaluation(ctx, experimentID, trialID, evaluationID)
+}
+
 func (c *Client) ExportScores(ctx context.Context, scores []ScoreItem) (*agento11y.ExportScoresResponse, error) {
 	if c == nil || c.core == nil {
 		return nil, agento11y.ErrNilClient

--- a/go/agento11y/experiments/experiment.go
+++ b/go/agento11y/experiments/experiment.go
@@ -50,12 +50,13 @@ type Experiment struct {
 	autoFinalize     bool
 	useOTel          bool
 
-	mu        sync.Mutex
-	status    ExperimentStatus
-	accepted  int
-	finalized bool
-	open      map[string]*Trial
-	claimed   map[string]struct{}
+	mu             sync.Mutex
+	status         ExperimentStatus
+	accepted       int
+	cloudEvaluated bool
+	finalized      bool
+	open           map[string]*Trial
+	claimed        map[string]struct{}
 }
 
 func NewExperiment(client *Client, opts ExperimentOptions) (*Experiment, error) {
@@ -306,7 +307,14 @@ func withTrial(ctx context.Context, trial *Trial, fn func(context.Context, *Tria
 }
 
 type FinalizeOptions struct {
-	Error      string
+	Error string
+	// ScoreCount asserts how many scores the run stored. Leave it unset unless a
+	// distributed runner knows the total: Agent Observability checks it against
+	// every score stored for the run, including ones a stored evaluator wrote
+	// through Trial.Evaluate, so a locally derived count in a cloud-evaluated run
+	// fails with agento11y.ErrExperimentConflict. Finalize drops the count when a
+	// trial of this Experiment used Trial.Evaluate in this process; a runner that
+	// evaluates in another process has to leave it unset itself.
 	ScoreCount *int
 }
 
@@ -335,6 +343,12 @@ func (e *Experiment) Finalize(ctx context.Context, status ExperimentStatus, opti
 		if err := trial.Close(ctx, nil); err != nil {
 			closeErrors = append(closeErrors, err)
 		}
+	}
+	e.mu.Lock()
+	cloudEvaluated := e.cloudEvaluated
+	e.mu.Unlock()
+	if cloudEvaluated {
+		opts.ScoreCount = nil
 	}
 	if len(closeErrors) > 0 {
 		status = ExperimentStatusFailed
@@ -401,6 +415,17 @@ func (e *Experiment) recordAccepted(count int) {
 	e.mu.Unlock()
 }
 
+// markCloudEvaluated records that a stored evaluator was queued for one of this
+// experiment's trials, so Finalize stops asserting a caller-supplied score count.
+func (e *Experiment) markCloudEvaluated() {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	e.cloudEvaluated = true
+	e.mu.Unlock()
+}
+
 type Trial struct {
 	client     *Client
 	experiment *Experiment
@@ -431,6 +456,7 @@ type Trial struct {
 	buffer             []ScoreItem
 	accepted           int
 	hasFinal           bool
+	cloudEvaluated     bool
 	finalPassed        *bool
 	occurrences        map[string]int
 	artifacts          []ExperimentArtifactRef
@@ -545,6 +571,10 @@ func (t *Trial) Close(ctx context.Context, callbackErr error) error {
 		t.Status, t.Error = TrialStatusErrored, callbackErr.Error()
 	} else if t.Status == TrialStatusRunning {
 		switch {
+		case !t.hasFinal && t.cloudEvaluated:
+			// A stored evaluator graded this trial; the verdict and the score count
+			// come from the backend, not from a local final score.
+			t.Status = TrialStatusCompleted
 		case !t.hasFinal:
 			t.Status, t.Error = TrialStatusFailed, "trial closed without a final score"
 		case t.finalPassed == nil:
@@ -849,6 +879,199 @@ func (t *Trial) RecordEvaluation(ctx context.Context, result EvaluationResult, o
 	}, scoreID)
 }
 
+const (
+	defaultEvaluationTimeout      = 300 * time.Second
+	defaultEvaluationPollInterval = 500 * time.Millisecond
+	// Ceiling for the Evaluate poll backoff, so a long wait does not keep reading
+	// status at the floor rate.
+	maxEvaluationPollInterval = 5 * time.Second
+)
+
+// EvaluateOptions configures Trial.Evaluate. A zero Timeout or PollInterval
+// uses the default; a negative one is rejected.
+type EvaluateOptions struct {
+	// EvaluatorVersion pins a stored evaluator version. Empty lets Agent
+	// Observability pin the latest active version.
+	EvaluatorVersion string
+	// Timeout bounds the wait for a terminal status. Defaults to 300s.
+	Timeout time.Duration
+	// PollInterval is the first delay between status reads, doubling up to 5s.
+	// Defaults to 500ms.
+	PollInterval time.Duration
+}
+
+func (o EvaluateOptions) resolve() (timeout, pollInterval time.Duration, err error) {
+	if o.Timeout < 0 {
+		return 0, 0, fmt.Errorf("%w: evaluation timeout must not be negative", agento11y.ErrExperimentValidationFailed)
+	}
+	if o.PollInterval < 0 {
+		return 0, 0, fmt.Errorf("%w: evaluation poll interval must not be negative", agento11y.ErrExperimentValidationFailed)
+	}
+	timeout, pollInterval = o.Timeout, o.PollInterval
+	if timeout == 0 {
+		timeout = defaultEvaluationTimeout
+	}
+	if pollInterval == 0 {
+		pollInterval = defaultEvaluationPollInterval
+	}
+	return timeout, pollInterval, nil
+}
+
+// Evaluate runs a stored evaluator against this trial's bound conversation.
+//
+// It grades the conversation Agent Observability already stored, using an
+// evaluator defined in your tenant. For an in-process judge, see EvaluateOutput.
+//
+// The current conversation binding is persisted and the anchor generation from
+// RecordIO is exported before the evaluation is queued, so the evaluator can
+// read the conversation it is asked to grade. A successful evaluation lets the
+// trial close as completed without a local FinalScore. Queuing one also makes
+// Experiment.Finalize drop a caller-supplied ScoreCount, since the evaluator
+// writes a score this process never sees.
+//
+// Options.Timeout and ctx both bound the wait. The timeout bounds the polling
+// loop, not the whole call: a status request already in flight spends its own
+// retry budget first. Worker failure returns *agento11y.TrialEvaluationFailedError
+// and an exceeded deadline returns *agento11y.TrialEvaluationTimeoutError, both
+// carrying the evaluation ID. A cancelled context returns ctx.Err(). A transport
+// error while polling propagates and abandons the wait; the evaluation keeps
+// running server-side, and triggering it again returns the same row.
+//
+// Only a trial created by Experiment.Trial or Experiment.WithTrial can mark its
+// experiment, so a caller who built this trial with NewTrial must leave
+// FinalizeOptions.ScoreCount unset when finalizing the run itself.
+func (t *Trial) Evaluate(ctx context.Context, evaluatorID string, options ...EvaluateOptions) (*TrialEvaluation, error) {
+	if t == nil || t.client == nil {
+		return nil, agento11y.ErrNilClient
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	opts := EvaluateOptions{}
+	if len(options) > 0 {
+		opts = options[0]
+	}
+	evaluatorID = strings.TrimSpace(evaluatorID)
+	if evaluatorID == "" {
+		return nil, fmt.Errorf("%w: evaluator_id is required", agento11y.ErrExperimentValidationFailed)
+	}
+	timeout, pollInterval, err := opts.resolve()
+	if err != nil {
+		return nil, err
+	}
+	t.mu.Lock()
+	conversationID := t.ConversationID
+	t.mu.Unlock()
+	if conversationID == "" {
+		return nil, fmt.Errorf("%w: bind a conversation before evaluating a trial", agento11y.ErrExperimentValidationFailed)
+	}
+
+	if err := t.create(ctx); err != nil {
+		return nil, evaluationRequestError(ctx, err)
+	}
+	// BindConversation and RecordIO are local until now, and the backend rejects
+	// an evaluation for a trial with no stored conversation.
+	if _, err := t.client.UpdateTrial(ctx, t.Ref.ExperimentID, t.TrialID, agento11y.UpdateTrialRequest{
+		ConversationID: conversationID,
+	}); err != nil {
+		return nil, evaluationRequestError(ctx, err)
+	}
+	// The evaluator reads the stored conversation, so the anchor generation has to
+	// exist before the wait starts, not when the trial closes.
+	if err := t.ensureGeneration(ctx); err != nil {
+		return nil, evaluationRequestError(ctx, err)
+	}
+	if err := t.client.Flush(ctx); err != nil {
+		return nil, evaluationRequestError(ctx, err)
+	}
+
+	deadline := time.Now().Add(timeout)
+	evaluation, err := t.client.TriggerTrialEvaluation(ctx, t.Ref.ExperimentID, t.TrialID, agento11y.TriggerTrialEvaluationRequest{
+		EvaluatorID: evaluatorID, EvaluatorVersion: opts.EvaluatorVersion,
+	})
+	if err != nil {
+		return nil, evaluationRequestError(ctx, err)
+	}
+	// The evaluation row exists from here on, and the score it writes counts toward
+	// the experiment's stored total whether or not this wait sees it finish.
+	t.experiment.markCloudEvaluated()
+	// Back off so a long wait costs tens of status reads, not hundreds. A caller
+	// who asked for a slower cadence than the cap keeps it.
+	interval := pollInterval
+	maxInterval := max(pollInterval, maxEvaluationPollInterval)
+	for {
+		switch evaluation.Status {
+		case agento11y.TrialEvaluationStatusSuccess:
+			// The trial's terminal state stays with Close: a cloud score is not a
+			// local verdict, and setting Status here would swallow an error the
+			// trial callback returns afterwards.
+			t.mu.Lock()
+			t.cloudEvaluated = true
+			t.mu.Unlock()
+			return evaluation, nil
+		case agento11y.TrialEvaluationStatusFailed:
+			return nil, &agento11y.TrialEvaluationFailedError{
+				EvaluationID: evaluation.EvaluationID, Detail: evaluation.Error,
+			}
+		case agento11y.TrialEvaluationStatusQueued, agento11y.TrialEvaluationStatusClaimed:
+		default:
+			// Unreachable: Client.TriggerTrialEvaluation and Client.GetTrialEvaluation
+			// reject a status the SDK does not know.
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, evaluationTimeoutError(evaluation.EvaluationID, timeout)
+		}
+		if err := sleepContext(ctx, min(interval, remaining)); err != nil {
+			return nil, err
+		}
+		interval = min(interval*2, maxInterval)
+		// Every sleep is followed by a status read, including the one clamped to the
+		// remaining budget, so an evaluation that finishes in the last window is not
+		// reported as a timeout.
+		evaluation, err = t.client.GetTrialEvaluation(ctx, t.Ref.ExperimentID, t.TrialID, evaluation.EvaluationID)
+		if err != nil {
+			return nil, evaluationRequestError(ctx, err)
+		}
+	}
+}
+
+// evaluationRequestError keeps cancellation a single error shape. The eval
+// transport reports a cancelled request as agento11y.ErrExperimentTransportFailed
+// with the context error only in its message, so errors.Is(err, context.Canceled)
+// would not hold for a caller who cancelled the wait.
+func evaluationRequestError(ctx context.Context, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	return err
+}
+
+func evaluationTimeoutError(evaluationID string, timeout time.Duration) error {
+	return &agento11y.TrialEvaluationTimeoutError{
+		EvaluationID: evaluationID,
+		Detail:       fmt.Sprintf("waited %s", timeout),
+	}
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	ctx = contextOrBackground(ctx)
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// EvaluateOutput grades the trial's output with an in-process evaluator and
+// records the result as a local score. For an evaluator stored in your tenant,
+// see Evaluate.
 func (t *Trial) EvaluateOutput(ctx context.Context, evaluator OutputEvaluator, input EvaluationInput, options ...RecordEvaluationOptions) (ScoreItem, error) {
 	if evaluator == nil {
 		return ScoreItem{}, errors.New("output evaluator is required")

--- a/go/agento11y/experiments/experiments_test.go
+++ b/go/agento11y/experiments/experiments_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	agento11y "github.com/grafana/agento11y/go/agento11y"
 	"go.opentelemetry.io/otel"
@@ -599,5 +600,505 @@ func TestExperimentOTelIsOptInAndRedactsEventExplanation(t *testing.T) {
 	spans = recorder.Ended()
 	if len(spans) != 2 || spans[1].Status().Code != codes.Error {
 		t.Fatalf("errored trial must end its span with error status: %#v", spans)
+	}
+}
+
+// trialEvaluationServer serves the ingest routes a cloud-evaluated trial uses.
+// evaluationStatuses is consumed in order by the trigger and each status read;
+// the last entry repeats, so a single "queued" entry keeps polling forever.
+type trialEvaluationServer struct {
+	mu                sync.Mutex
+	requests          []capturedRequest
+	statuses          []string
+	evaluationError   string
+	evaluationID      string
+	onStatusRequest   func(count int)
+	server            *httptest.Server
+	triggerStatusCode int
+	triggerBody       string
+}
+
+func newTrialEvaluationServer(t *testing.T, statuses ...string) *trialEvaluationServer {
+	t.Helper()
+	s := &trialEvaluationServer{statuses: statuses, evaluationID: "teval-1"}
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var body map[string]any
+		_ = json.Unmarshal(raw, &body)
+		s.mu.Lock()
+		s.requests = append(s.requests, capturedRequest{Method: r.Method, Path: r.URL.Path, Header: r.Header.Clone(), Body: body})
+		statusReads := 0
+		for _, request := range s.requests {
+			if strings.Contains(request.Path, "/evaluations/") {
+				statusReads++
+			}
+		}
+		hook := s.onStatusRequest
+		s.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/experiment-runs:upsert":
+			_, _ = w.Write([]byte(`{"experiment_id":"run-1","name":"run","status":"running"}`))
+		case strings.HasSuffix(r.URL.Path, ":finalize"):
+			_, _ = w.Write([]byte(`{"experiment_id":"run-1","name":"run","status":"completed"}`))
+		case r.URL.Path == "/api/v1/scores:export":
+			_, _ = w.Write([]byte(`{"accepted":1,"results":[{"score_id":"one","accepted":true}]}`))
+		case r.URL.Path == "/api/v1/generations:export":
+			// The exporter checks for one result per exported generation.
+			generations, _ := body["generations"].([]any)
+			results := make([]map[string]any, 0, len(generations))
+			for _, generation := range generations {
+				fields, _ := generation.(map[string]any)
+				id, _ := fields["id"].(string)
+				results = append(results, map[string]any{"generation_id": id, "accepted": true})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"results": results})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":evaluate"):
+			if s.triggerStatusCode != 0 {
+				w.WriteHeader(s.triggerStatusCode)
+				_, _ = w.Write([]byte(s.triggerBody))
+				return
+			}
+			s.writeEvaluation(w, s.nextStatus())
+		case strings.Contains(r.URL.Path, "/evaluations/"):
+			if hook != nil {
+				hook(statusReads)
+			}
+			s.writeEvaluation(w, s.nextStatus())
+		default:
+			_, _ = w.Write([]byte(`{"trial_id":"trial","experiment_id":"run-1","test_case_id":"case","attempt":1,"status":"running"}`))
+		}
+	}))
+	t.Cleanup(s.server.Close)
+	return s
+}
+
+func (s *trialEvaluationServer) nextStatus() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.statuses) == 0 {
+		return "queued"
+	}
+	status := s.statuses[len(s.statuses)-1]
+	if len(s.statuses) > 1 {
+		status = s.statuses[0]
+		s.statuses = s.statuses[1:]
+	}
+	return status
+}
+
+func (s *trialEvaluationServer) writeEvaluation(w http.ResponseWriter, status string) {
+	payload := map[string]any{
+		"evaluation_id": s.evaluationID, "experiment_id": "run-1", "trial_id": "trial",
+		"test_case_id": "case", "conversation_id": "conv-1",
+		"evaluator_id": "helpfulness", "evaluator_version": "v3",
+		"status": status, "attempts": 0,
+	}
+	code := http.StatusAccepted
+	if status == "success" || status == "failed" {
+		code = http.StatusOK
+	}
+	if status == "failed" {
+		payload["error"] = s.evaluationError
+	}
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func (s *trialEvaluationServer) captured() []capturedRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]capturedRequest(nil), s.requests...)
+}
+
+func (s *trialEvaluationServer) statusRequestCount() int {
+	count := 0
+	for _, request := range s.captured() {
+		if strings.Contains(request.Path, "/evaluations/") {
+			count++
+		}
+	}
+	return count
+}
+
+func (s *trialEvaluationServer) newClient(t *testing.T) *Client {
+	t.Helper()
+	client, err := NewClient(ClientOptions{
+		Endpoint: s.server.URL, TenantID: "123", IngestToken: "token",
+		UseExperimentalOTel: boolPointer(false),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
+	return client
+}
+
+func TestClientForwardsTrialEvaluationCalls(t *testing.T) {
+	server := newTrialEvaluationServer(t, "queued")
+	client := server.newClient(t)
+
+	evaluation, err := client.TriggerTrialEvaluation(context.Background(), "exp-1", "trial-1", TriggerTrialEvaluationRequest{
+		EvaluatorID: "helpfulness", EvaluatorVersion: "v3",
+	})
+	if err != nil {
+		t.Fatalf("trigger trial evaluation: %v", err)
+	}
+	if evaluation.Status != TrialEvaluationStatusQueued || evaluation.EvaluationID != "teval-1" {
+		t.Fatalf("unexpected evaluation: %#v", evaluation)
+	}
+	if _, err := client.GetTrialEvaluation(context.Background(), "exp-1", "trial-1", "teval-1"); err != nil {
+		t.Fatalf("get trial evaluation: %v", err)
+	}
+
+	requests := server.captured()
+	if len(requests) != 2 {
+		t.Fatalf("expected a trigger and a status request, got %#v", requests)
+	}
+	trigger := requests[0]
+	if trigger.Method != http.MethodPost || trigger.Path != "/api/v1/experiment-runs/exp-1/trials/trial-1:evaluate" {
+		t.Fatalf("unexpected trigger request %s %s", trigger.Method, trigger.Path)
+	}
+	if trigger.Body["evaluator_id"] != "helpfulness" || trigger.Body["evaluator_version"] != "v3" {
+		t.Fatalf("wrapper must forward evaluator identity unchanged: %#v", trigger.Body)
+	}
+	status := requests[1]
+	if status.Method != http.MethodGet || status.Path != "/api/v1/experiment-runs/exp-1/trials/trial-1/evaluations/teval-1" {
+		t.Fatalf("unexpected status request %s %s", status.Method, status.Path)
+	}
+}
+
+func TestNilClientTrialEvaluationCallsDoNotRequest(t *testing.T) {
+	server := newTrialEvaluationServer(t, "queued")
+	var client *Client
+	if _, err := client.TriggerTrialEvaluation(context.Background(), "exp-1", "trial-1", TriggerTrialEvaluationRequest{
+		EvaluatorID: "helpfulness",
+	}); !errors.Is(err, agento11y.ErrNilClient) {
+		t.Fatalf("expected ErrNilClient, got %v", err)
+	}
+	if _, err := client.GetTrialEvaluation(context.Background(), "exp-1", "trial-1", "teval-1"); !errors.Is(err, agento11y.ErrNilClient) {
+		t.Fatalf("expected ErrNilClient, got %v", err)
+	}
+	if len(server.captured()) != 0 {
+		t.Fatalf("a nil client must not issue requests, got %#v", server.captured())
+	}
+}
+
+func newCloudEvaluatedTrial(t *testing.T, server *trialEvaluationServer) (*Experiment, *Trial) {
+	t.Helper()
+	client := server.newClient(t)
+	experiment, err := NewExperiment(client, ExperimentOptions{
+		ExperimentID: "run-1", Name: "run",
+		Suite: &TestSuite{SuiteID: "suite", TestCases: []TestCase{{TestCaseID: "case", Input: "2+2"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := experiment.Enter(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	trial, err := experiment.NewTrialByCaseID("case")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := trial.Enter(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	return experiment, trial
+}
+
+func indexOfRequest(requests []capturedRequest, match func(capturedRequest) bool) int {
+	for i, request := range requests {
+		if match(request) {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestTrialEvaluatePersistsConversationAndClosesCompleted(t *testing.T) {
+	server := newTrialEvaluationServer(t, "queued", "claimed", "success")
+	_, trial := newCloudEvaluatedTrial(t, server)
+	trial.BindConversation("conv-1").RecordIO(RecordIOOptions{Input: "2+2", Output: "4"})
+
+	evaluation, err := trial.Evaluate(context.Background(), "helpfulness", EvaluateOptions{
+		EvaluatorVersion: "v3", PollInterval: time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if evaluation.Status != TrialEvaluationStatusSuccess {
+		t.Fatalf("unexpected evaluation: %#v", evaluation)
+	}
+	if err := trial.Close(context.Background(), nil); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if trial.Status != TrialStatusCompleted || trial.Error != "" {
+		t.Fatalf("cloud-evaluated trial must close completed: status=%q error=%q", trial.Status, trial.Error)
+	}
+
+	requests := server.captured()
+	trigger := indexOfRequest(requests, func(r capturedRequest) bool {
+		return r.Method == http.MethodPost && strings.HasSuffix(r.Path, ":evaluate")
+	})
+	if trigger < 0 {
+		t.Fatalf("no evaluation trigger request: %#v", requests)
+	}
+	binding := indexOfRequest(requests, func(r capturedRequest) bool {
+		return r.Method == http.MethodPatch && r.Body["conversation_id"] == "conv-1"
+	})
+	if binding < 0 || binding > trigger {
+		t.Fatalf("conversation must be persisted before the trigger: binding=%d trigger=%d %#v", binding, trigger, requests)
+	}
+	generation := indexOfRequest(requests, func(r capturedRequest) bool {
+		return r.Path == "/api/v1/generations:export"
+	})
+	if generation < 0 || generation > trigger {
+		t.Fatalf("anchor generation must be exported before the trigger: generation=%d trigger=%d", generation, trigger)
+	}
+	if server.statusRequestCount() != 2 {
+		t.Fatalf("expected two status reads for queued then claimed, got %d", server.statusRequestCount())
+	}
+	for _, request := range requests {
+		if request.Path == "/api/v1/scores:export" {
+			t.Fatalf("cloud evaluation must not export a local score: %#v", request.Body)
+		}
+	}
+	terminal := requests[len(requests)-1]
+	if terminal.Method != http.MethodPatch || terminal.Body["status"] != "completed" {
+		t.Fatalf("expected a completed terminal update, got %#v", terminal)
+	}
+	if _, exists := terminal.Body["error"]; exists {
+		t.Fatalf("completed trial must carry no error text: %#v", terminal.Body)
+	}
+}
+
+func TestTrialCallbackErrorAfterCloudEvaluationStillFails(t *testing.T) {
+	server := newTrialEvaluationServer(t, "success")
+	experiment, err := func() (*Experiment, error) {
+		client := server.newClient(t)
+		return NewExperiment(client, ExperimentOptions{ExperimentID: "run-1", Name: "run"})
+	}()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := experiment.Enter(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	callbackErr := errors.New("assertion failed after grading")
+	err = experiment.WithTrialByCaseID(context.Background(), "case", func(ctx context.Context, trial *Trial) error {
+		trial.BindConversation("conv-1")
+		if _, evalErr := trial.Evaluate(ctx, "helpfulness", EvaluateOptions{PollInterval: time.Millisecond}); evalErr != nil {
+			return evalErr
+		}
+		return callbackErr
+	})
+	if !errors.Is(err, callbackErr) {
+		t.Fatalf("expected the callback error, got %v", err)
+	}
+	requests := server.captured()
+	terminal := requests[len(requests)-1]
+	if terminal.Method != http.MethodPatch || terminal.Body["status"] != "failed" ||
+		terminal.Body["error"] != callbackErr.Error() {
+		t.Fatalf("callback error must win over cloud evaluation: %#v", terminal)
+	}
+}
+
+func TestTrialEvaluateSurfacesWorkerFailure(t *testing.T) {
+	server := newTrialEvaluationServer(t, "queued", "failed")
+	server.evaluationError = "evaluator budget exhausted"
+	_, trial := newCloudEvaluatedTrial(t, server)
+	trial.BindConversation("conv-1")
+
+	_, err := trial.Evaluate(context.Background(), "helpfulness", EvaluateOptions{PollInterval: time.Millisecond})
+	var failed *agento11y.TrialEvaluationFailedError
+	if !errors.As(err, &failed) {
+		t.Fatalf("expected *TrialEvaluationFailedError, got %v", err)
+	}
+	if failed.EvaluationID != "teval-1" || failed.Detail != "evaluator budget exhausted" {
+		t.Fatalf("unexpected failure detail: %#v", failed)
+	}
+	if !errors.Is(err, agento11y.ErrTrialEvaluationFailed) {
+		t.Fatalf("expected ErrTrialEvaluationFailed, got %v", err)
+	}
+	trial.mu.Lock()
+	cloudEvaluated := trial.cloudEvaluated
+	trial.mu.Unlock()
+	if cloudEvaluated {
+		t.Fatal("a failed evaluation must not mark the trial cloud-evaluated")
+	}
+}
+
+func TestTrialEvaluateTimesOutAndBacksOff(t *testing.T) {
+	server := newTrialEvaluationServer(t, "queued")
+	_, trial := newCloudEvaluatedTrial(t, server)
+	trial.BindConversation("conv-1")
+
+	start := time.Now()
+	_, err := trial.Evaluate(context.Background(), "helpfulness", EvaluateOptions{
+		Timeout: 50 * time.Millisecond, PollInterval: time.Millisecond,
+	})
+	elapsed := time.Since(start)
+	var timedOut *agento11y.TrialEvaluationTimeoutError
+	if !errors.As(err, &timedOut) {
+		t.Fatalf("expected *TrialEvaluationTimeoutError, got %v", err)
+	}
+	if timedOut.EvaluationID != "teval-1" {
+		t.Fatalf("timeout must carry the evaluation ID: %#v", timedOut)
+	}
+	if !errors.Is(err, agento11y.ErrTrialEvaluationTimeout) {
+		t.Fatalf("expected ErrTrialEvaluationTimeout, got %v", err)
+	}
+	// A fixed 1ms interval would issue tens of reads in 50ms.
+	if reads := server.statusRequestCount(); reads > 7 {
+		t.Fatalf("poll interval must back off, got %d status reads in %s", reads, elapsed)
+	}
+}
+
+func TestTrialEvaluateReadsStatusAfterTheFinalSleep(t *testing.T) {
+	server := newTrialEvaluationServer(t, "queued", "success")
+	_, trial := newCloudEvaluatedTrial(t, server)
+	trial.BindConversation("conv-1")
+
+	// A poll interval at least as long as the timeout clamps the only sleep to the
+	// whole budget. The status read still has to happen, or an evaluation that
+	// finishes inside that window is reported as a timeout.
+	evaluation, err := trial.Evaluate(context.Background(), "helpfulness", EvaluateOptions{
+		Timeout: 20 * time.Millisecond, PollInterval: 20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if evaluation.Status != TrialEvaluationStatusSuccess {
+		t.Fatalf("unexpected evaluation: %#v", evaluation)
+	}
+	if reads := server.statusRequestCount(); reads != 1 {
+		t.Fatalf("expected exactly one status read after the clamped sleep, got %d", reads)
+	}
+}
+
+func TestQueuedEvaluationDropsFinalizeScoreCount(t *testing.T) {
+	server := newTrialEvaluationServer(t, "queued")
+	experiment, trial := newCloudEvaluatedTrial(t, server)
+	trial.BindConversation("conv-1")
+
+	// The evaluation stays queued server-side and its score lands after this run
+	// finalizes, so a caller-supplied count cannot be asserted.
+	if _, err := trial.Evaluate(context.Background(), "helpfulness", EvaluateOptions{
+		Timeout: 5 * time.Millisecond, PollInterval: 10 * time.Millisecond,
+	}); !errors.Is(err, agento11y.ErrTrialEvaluationTimeout) {
+		t.Fatalf("expected ErrTrialEvaluationTimeout, got %v", err)
+	}
+	count := 0
+	if err := experiment.Finalize(context.Background(), ExperimentStatusFailed, FinalizeOptions{
+		ScoreCount: &count, Error: "evaluation timed out",
+	}); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	requests := server.captured()
+	finalize := indexOfRequest(requests, func(r capturedRequest) bool {
+		return strings.HasSuffix(r.Path, ":finalize")
+	})
+	if finalize < 0 {
+		t.Fatalf("no finalize request: %#v", requests)
+	}
+	if _, exists := requests[finalize].Body["score_count"]; exists {
+		t.Fatalf("a cloud-evaluated experiment must not assert a score count: %#v", requests[finalize].Body)
+	}
+}
+
+func TestTrialEvaluateSurfacesTriggerRejection(t *testing.T) {
+	server := newTrialEvaluationServer(t, "queued")
+	server.triggerStatusCode = http.StatusConflict
+	server.triggerBody = `{"error":"experiment is no longer running"}`
+	experiment, trial := newCloudEvaluatedTrial(t, server)
+	trial.BindConversation("conv-1")
+
+	if _, err := trial.Evaluate(context.Background(), "helpfulness", EvaluateOptions{
+		PollInterval: time.Millisecond,
+	}); !errors.Is(err, agento11y.ErrExperimentConflict) {
+		t.Fatalf("expected ErrExperimentConflict, got %v", err)
+	}
+	if server.statusRequestCount() != 0 {
+		t.Fatalf("a rejected trigger must not start polling, got %d status reads", server.statusRequestCount())
+	}
+	experiment.mu.Lock()
+	cloudEvaluated := experiment.cloudEvaluated
+	experiment.mu.Unlock()
+	if cloudEvaluated {
+		t.Fatal("a rejected trigger queues nothing, so the experiment must keep its own score count")
+	}
+}
+
+func TestTrialEvaluateHonorsContextCancellation(t *testing.T) {
+	server := newTrialEvaluationServer(t, "queued")
+	_, trial := newCloudEvaluatedTrial(t, server)
+	trial.BindConversation("conv-1")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	server.mu.Lock()
+	// Cancel during the wait. Whether cancellation lands on the in-flight status
+	// read or on the next sleep, Evaluate reports the context error.
+	server.onStatusRequest = func(count int) {
+		if count == 1 {
+			cancel()
+		}
+	}
+	server.mu.Unlock()
+	defer cancel()
+
+	_, err := trial.Evaluate(ctx, "helpfulness", EvaluateOptions{
+		Timeout: 5 * time.Second, PollInterval: time.Millisecond,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	var timedOut *agento11y.TrialEvaluationTimeoutError
+	var failed *agento11y.TrialEvaluationFailedError
+	if errors.As(err, &timedOut) || errors.As(err, &failed) {
+		t.Fatalf("cancellation must not be reported as timeout or failure: %v", err)
+	}
+}
+
+func TestTrialEvaluateRejectsInvalidOptions(t *testing.T) {
+	cases := []struct {
+		name           string
+		bindConversion bool
+		evaluatorID    string
+		options        EvaluateOptions
+	}{
+		{name: "no bound conversation", evaluatorID: "helpfulness"},
+		{name: "empty evaluator id", bindConversion: true, evaluatorID: "  "},
+		{name: "negative timeout", bindConversion: true, evaluatorID: "helpfulness", options: EvaluateOptions{Timeout: -time.Second}},
+		{name: "negative poll interval", bindConversion: true, evaluatorID: "helpfulness", options: EvaluateOptions{PollInterval: -time.Millisecond}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := newTrialEvaluationServer(t, "success")
+			client := server.newClient(t)
+			trial, err := NewTrial(client, TrialRef{ExperimentID: "run-1", TestCaseID: "case"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.bindConversion {
+				trial.BindConversation("conv-1")
+			}
+			if _, err := trial.Evaluate(context.Background(), tc.evaluatorID, tc.options); !errors.Is(err, agento11y.ErrExperimentValidationFailed) {
+				t.Fatalf("expected ErrExperimentValidationFailed, got %v", err)
+			}
+			if requests := server.captured(); len(requests) != 0 {
+				t.Fatalf("invalid options must not issue a request, got %#v", requests)
+			}
+		})
+	}
+}
+
+func TestTrialEvaluateDefaultsWaitOptions(t *testing.T) {
+	timeout, pollInterval, err := EvaluateOptions{EvaluatorVersion: "v3"}.resolve()
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if timeout != defaultEvaluationTimeout || pollInterval != defaultEvaluationPollInterval {
+		t.Fatalf("unset durations must use the defaults, got %s and %s", timeout, pollInterval)
 	}
 }

--- a/go/agento11y/experiments/suites.go
+++ b/go/agento11y/experiments/suites.go
@@ -36,6 +36,7 @@ type ConflictKind string
 
 const (
 	ConflictScoreCountMismatch ConflictKind = "score_count_mismatch"
+	ConflictPendingEvaluations ConflictKind = "pending_evaluations"
 	ConflictRunningTrials      ConflictKind = "running_trials"
 	ConflictTerminalState      ConflictKind = "terminal_state"
 	ConflictImmutableField     ConflictKind = "immutable_field"
@@ -60,6 +61,8 @@ func ClassifyConflict(err error) ConflictKind {
 	switch {
 	case strings.Contains(text, "score_count") || strings.Contains(text, "score count"):
 		return ConflictScoreCountMismatch
+	case strings.Contains(text, "pending evaluation"):
+		return ConflictPendingEvaluations
 	case strings.Contains(text, "running trial") || strings.Contains(text, "open trial"):
 		return ConflictRunningTrials
 	case strings.Contains(text, "terminal") || strings.Contains(text, "already finalized"):
@@ -798,15 +801,7 @@ func contextOrBackground(ctx context.Context) context.Context {
 	return ctx
 }
 func retryWait(ctx context.Context, attempt int) error {
-	delay := 100 * time.Millisecond * time.Duration(1<<min(attempt, 6))
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-timer.C:
-		return nil
-	case <-contextOrBackground(ctx).Done():
-		return contextOrBackground(ctx).Err()
-	}
+	return sleepContext(ctx, 100*time.Millisecond*time.Duration(1<<min(attempt, 6)))
 }
 func readBounded(reader io.Reader) ([]byte, error) {
 	data, err := io.ReadAll(io.LimitReader(reader, maxControlResponseBytes+1))

--- a/go/agento11y/experiments/suites_test.go
+++ b/go/agento11y/experiments/suites_test.go
@@ -3,6 +3,7 @@ package experiments
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -190,6 +191,30 @@ func TestResolveVersionAliasesAndDraftConflict(t *testing.T) {
 	}
 	if err := validateDraftOptions(suiteVersions(suite)[2], "new", false); ClassifyConflict(err) != ConflictOpenDraft {
 		t.Fatalf("unexpected conflict: %v (%s)", err, ClassifyConflict(err))
+	}
+}
+
+func TestClassifyConflictKinds(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want ConflictKind
+	}{
+		{
+			name: "pending evaluations",
+			text: "status 409: cannot complete experiment with 2 pending evaluation(s)",
+			want: ConflictPendingEvaluations,
+		},
+		{name: "running trials", text: "status 409: experiment has 1 running trial", want: ConflictRunningTrials},
+		{name: "terminal state", text: "status 409: experiment already finalized", want: ConflictTerminalState},
+		{name: "unrelated", text: "status 409: something else", want: ConflictUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyConflict(errors.New(tc.text)); got != tc.want {
+				t.Fatalf("ClassifyConflict(%q) = %s, want %s", tc.text, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/go/agento11y/experiments/types.go
+++ b/go/agento11y/experiments/types.go
@@ -35,6 +35,17 @@ const (
 	TrialStatusSkipped   = agento11y.TrialStatusSkipped
 )
 
+type TrialEvaluation = agento11y.TrialEvaluation
+type TrialEvaluationStatus = agento11y.TrialEvaluationStatus
+type TriggerTrialEvaluationRequest = agento11y.TriggerTrialEvaluationRequest
+
+const (
+	TrialEvaluationStatusQueued  = agento11y.TrialEvaluationStatusQueued
+	TrialEvaluationStatusClaimed = agento11y.TrialEvaluationStatusClaimed
+	TrialEvaluationStatusSuccess = agento11y.TrialEvaluationStatusSuccess
+	TrialEvaluationStatusFailed  = agento11y.TrialEvaluationStatusFailed
+)
+
 type EvaluatorKind = agento11y.EvaluatorKind
 
 const (

--- a/go/agento11y/experiments_models.go
+++ b/go/agento11y/experiments_models.go
@@ -23,6 +23,49 @@ const (
 	ExperimentSourceCollection ExperimentSource = "collection"
 )
 
+// TrialEvaluationStatus is the durable state of a stored evaluator run for an
+// experiment trial.
+type TrialEvaluationStatus string
+
+const (
+	TrialEvaluationStatusQueued  TrialEvaluationStatus = "queued"
+	TrialEvaluationStatusClaimed TrialEvaluationStatus = "claimed"
+	TrialEvaluationStatusSuccess TrialEvaluationStatus = "success"
+	TrialEvaluationStatusFailed  TrialEvaluationStatus = "failed"
+)
+
+// Terminal reports whether the worker has finished the evaluation.
+func (s TrialEvaluationStatus) Terminal() bool {
+	return s == TrialEvaluationStatusSuccess || s == TrialEvaluationStatusFailed
+}
+
+// TriggerTrialEvaluationRequest queues a stored evaluator for a trial.
+//
+// EvaluatorVersion is optional: an empty version lets Agent Observability pin
+// the latest active version.
+type TriggerTrialEvaluationRequest struct {
+	EvaluatorID      string `json:"evaluator_id"`
+	EvaluatorVersion string `json:"evaluator_version,omitempty"`
+}
+
+// TrialEvaluation is the work row a stored evaluator run is tracked by. Trigger
+// and status requests return the same object.
+type TrialEvaluation struct {
+	EvaluationID     string                `json:"evaluation_id"`
+	ExperimentID     string                `json:"experiment_id"`
+	TrialID          string                `json:"trial_id"`
+	TestCaseID       string                `json:"test_case_id"`
+	ConversationID   string                `json:"conversation_id"`
+	EvaluatorID      string                `json:"evaluator_id"`
+	EvaluatorVersion string                `json:"evaluator_version"`
+	Status           TrialEvaluationStatus `json:"status"`
+	Attempts         int                   `json:"attempts"`
+	ScheduledAt      *time.Time            `json:"scheduled_at,omitempty"`
+	CreatedAt        *time.Time            `json:"created_at,omitempty"`
+	UpdatedAt        *time.Time            `json:"updated_at,omitempty"`
+	Error            string                `json:"error,omitempty"`
+}
+
 type ScoreValue struct {
 	Number *float64 `json:"number,omitempty"`
 	Bool   *bool    `json:"bool,omitempty"`

--- a/go/agento11y/experiments_test.go
+++ b/go/agento11y/experiments_test.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -557,5 +558,294 @@ func TestListExperimentScoresParsesTypedScores(t *testing.T) {
 	score := response.Items[0]
 	if score.ScoreID != "score-1" || score.ScoreType != ScoreTypeNumber || score.Value.Number == nil || *score.Value.Number != 0.75 {
 		t.Fatalf("unexpected typed score: %#v", score)
+	}
+}
+
+func trialEvaluationBody(overrides map[string]any) map[string]any {
+	body := map[string]any{
+		"evaluation_id":     "teval-1",
+		"experiment_id":     "exp-1",
+		"trial_id":          "trial-1",
+		"test_case_id":      "case-1",
+		"conversation_id":   "conv-1",
+		"evaluator_id":      "helpfulness",
+		"evaluator_version": "v3",
+		"status":            "queued",
+		"attempts":          float64(0),
+		"scheduled_at":      "2026-07-23T21:30:00Z",
+		"created_at":        "2026-07-23T21:30:00Z",
+		"updated_at":        "2026-07-23T21:30:00Z",
+	}
+	maps.Copy(body, overrides)
+	return body
+}
+
+func TestTriggerTrialEvaluationSendsAdmittedKeysOnly(t *testing.T) {
+	cases := []struct {
+		name        string
+		request     TriggerTrialEvaluationRequest
+		wantPayload map[string]any
+	}{
+		{
+			name:        "unpinned version omits the key",
+			request:     TriggerTrialEvaluationRequest{EvaluatorID: "helpfulness"},
+			wantPayload: map[string]any{"evaluator_id": "helpfulness"},
+		},
+		{
+			name:        "pinned version is sent as given",
+			request:     TriggerTrialEvaluationRequest{EvaluatorID: "helpfulness", EvaluatorVersion: "v3"},
+			wantPayload: map[string]any{"evaluator_id": "helpfulness", "evaluator_version": "v3"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := &experimentRecorder{}
+			recorder.push(http.StatusAccepted, trialEvaluationBody(nil))
+			server := httptest.NewServer(recorder.handler(t))
+			defer server.Close()
+
+			client := newExperimentTestClient(t, server.URL)
+			evaluation, err := client.TriggerTrialEvaluation(context.Background(), "exp-1", "trial-1", tc.request)
+			if err != nil {
+				t.Fatalf("trigger trial evaluation: %v", err)
+			}
+			req := recorder.request(0)
+			if req.Method != http.MethodPost || req.Path != "/api/v1/experiment-runs/exp-1/trials/trial-1:evaluate" {
+				t.Fatalf("unexpected request %s %s", req.Method, req.Path)
+			}
+			if !maps.Equal(payloadStrings(t, req.Payload), tc.wantPayload) {
+				t.Fatalf("unexpected trigger body: %#v want %#v", req.Payload, tc.wantPayload)
+			}
+			if evaluation.EvaluationID != "teval-1" || evaluation.Status != TrialEvaluationStatusQueued {
+				t.Fatalf("unexpected evaluation: %#v", evaluation)
+			}
+			if evaluation.Status.Terminal() {
+				t.Fatal("queued evaluation must not be terminal")
+			}
+			if evaluation.CreatedAt == nil || evaluation.ScheduledAt == nil {
+				t.Fatalf("expected parsed timestamps, got %#v", evaluation)
+			}
+		})
+	}
+}
+
+// payloadStrings narrows a decoded JSON body to its string fields so a payload
+// can be compared key by key.
+func payloadStrings(t *testing.T, payload map[string]any) map[string]any {
+	t.Helper()
+	out := make(map[string]any, len(payload))
+	for key, value := range payload {
+		text, ok := value.(string)
+		if !ok {
+			t.Fatalf("unexpected non-string field %q: %#v", key, value)
+		}
+		out[key] = text
+	}
+	return out
+}
+
+func TestTrialEvaluationRoutesEscapeColonInTrialID(t *testing.T) {
+	recorder := &experimentRecorder{}
+	recorder.push(http.StatusAccepted, trialEvaluationBody(map[string]any{"trial_id": "trial:one"}))
+	server := httptest.NewServer(recorder.handler(t))
+	defer server.Close()
+
+	client := newExperimentTestClient(t, server.URL)
+	if _, err := client.TriggerTrialEvaluation(context.Background(), "exp-1", "trial:one", TriggerTrialEvaluationRequest{
+		EvaluatorID: "helpfulness",
+	}); err != nil {
+		t.Fatalf("trigger trial evaluation: %v", err)
+	}
+	if got := recorder.request(0).Path; got != "/api/v1/experiment-runs/exp-1/trials/trial%3Aone:evaluate" {
+		t.Fatalf("colon in a trial id must be percent-encoded, got %s", got)
+	}
+	if _, err := client.GetTrialEvaluation(context.Background(), "exp-1", "trial:one", "teval-1"); err != nil {
+		t.Fatalf("get trial evaluation: %v", err)
+	}
+	if got := recorder.request(1).Path; got != "/api/v1/experiment-runs/exp-1/trials/trial%3Aone/evaluations/teval-1" {
+		t.Fatalf("colon in a trial id must be percent-encoded, got %s", got)
+	}
+}
+
+func TestGetTrialEvaluationDecodesWorkerStatus(t *testing.T) {
+	cases := []struct {
+		name      string
+		overrides map[string]any
+		wantErr   error
+		errText   string
+		assert    func(*testing.T, *TrialEvaluation)
+	}{
+		{
+			name:      "success is terminal",
+			overrides: map[string]any{"status": "success", "attempts": float64(1)},
+			assert: func(t *testing.T, evaluation *TrialEvaluation) {
+				if evaluation.Status != TrialEvaluationStatusSuccess || !evaluation.Status.Terminal() || evaluation.Attempts != 1 {
+					t.Fatalf("unexpected evaluation: %#v", evaluation)
+				}
+			},
+		},
+		{
+			name:      "failure carries the worker error",
+			overrides: map[string]any{"status": "failed", "error": "budget exhausted"},
+			assert: func(t *testing.T, evaluation *TrialEvaluation) {
+				if !evaluation.Status.Terminal() || evaluation.Error != "budget exhausted" {
+					t.Fatalf("unexpected evaluation: %#v", evaluation)
+				}
+			},
+		},
+		{
+			name:      "claimed keeps polling",
+			overrides: map[string]any{"status": "claimed"},
+			assert: func(t *testing.T, evaluation *TrialEvaluation) {
+				if evaluation.Status != TrialEvaluationStatusClaimed || evaluation.Status.Terminal() {
+					t.Fatalf("unexpected evaluation: %#v", evaluation)
+				}
+			},
+		},
+		{
+			name:      "unsupported status is rejected",
+			overrides: map[string]any{"status": "abandoned"},
+			wantErr:   ErrExperimentTransportFailed,
+			errText:   "abandoned",
+		},
+		{
+			name:      "missing evaluation id is rejected",
+			overrides: map[string]any{"evaluation_id": ""},
+			wantErr:   ErrExperimentTransportFailed,
+			errText:   "evaluation_id",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := &experimentRecorder{}
+			recorder.push(http.StatusOK, trialEvaluationBody(tc.overrides))
+			server := httptest.NewServer(recorder.handler(t))
+			defer server.Close()
+
+			client := newExperimentTestClient(t, server.URL)
+			evaluation, err := client.GetTrialEvaluation(context.Background(), "exp-1", "trial-1", "teval-1")
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected %v, got %v", tc.wantErr, err)
+				}
+				if !strings.Contains(err.Error(), tc.errText) {
+					t.Fatalf("expected %q in the error, got %v", tc.errText, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("get trial evaluation: %v", err)
+			}
+			req := recorder.request(0)
+			if req.Method != http.MethodGet || req.Path != "/api/v1/experiment-runs/exp-1/trials/trial-1/evaluations/teval-1" {
+				t.Fatalf("unexpected request %s %s", req.Method, req.Path)
+			}
+			if req.Payload != nil || req.Headers.Get("Content-Type") != "" {
+				t.Fatalf("status reads must send no body, got payload %#v content type %q", req.Payload, req.Headers.Get("Content-Type"))
+			}
+			tc.assert(t, evaluation)
+		})
+	}
+}
+
+func TestTrialEvaluationValidatesIdentifiers(t *testing.T) {
+	recorder := &experimentRecorder{}
+	recorder.push(http.StatusAccepted, trialEvaluationBody(nil))
+	server := httptest.NewServer(recorder.handler(t))
+	defer server.Close()
+
+	client := newExperimentTestClient(t, server.URL)
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "trigger without experiment id",
+			call: func() error {
+				_, err := client.TriggerTrialEvaluation(context.Background(), "  ", "trial-1", TriggerTrialEvaluationRequest{EvaluatorID: "helpfulness"})
+				return err
+			},
+		},
+		{
+			name: "trigger without trial id",
+			call: func() error {
+				_, err := client.TriggerTrialEvaluation(context.Background(), "exp-1", "", TriggerTrialEvaluationRequest{EvaluatorID: "helpfulness"})
+				return err
+			},
+		},
+		{
+			name: "trigger without evaluator id",
+			call: func() error {
+				_, err := client.TriggerTrialEvaluation(context.Background(), "exp-1", "trial-1", TriggerTrialEvaluationRequest{EvaluatorID: " "})
+				return err
+			},
+		},
+		{
+			name: "status without experiment id",
+			call: func() error {
+				_, err := client.GetTrialEvaluation(context.Background(), "", "trial-1", "teval-1")
+				return err
+			},
+		},
+		{
+			name: "status without trial id",
+			call: func() error {
+				_, err := client.GetTrialEvaluation(context.Background(), "exp-1", "", "teval-1")
+				return err
+			},
+		},
+		{
+			name: "status without evaluation id",
+			call: func() error {
+				_, err := client.GetTrialEvaluation(context.Background(), "exp-1", "trial-1", " ")
+				return err
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.call(); !errors.Is(err, ErrExperimentValidationFailed) {
+				t.Fatalf("expected ErrExperimentValidationFailed, got %v", err)
+			}
+		})
+	}
+	if recorder.requestCount() != 0 {
+		t.Fatalf("validation must not issue a request, got %d", recorder.requestCount())
+	}
+}
+
+func TestTrialEvaluationMapsNotFoundAndConflict(t *testing.T) {
+	recorder := &experimentRecorder{}
+	recorder.push(http.StatusNotFound, map[string]any{"error": "missing trial"})
+	recorder.push(http.StatusConflict, map[string]any{"error": "experiment is no longer running"})
+	server := httptest.NewServer(recorder.handler(t))
+	defer server.Close()
+
+	client := newExperimentTestClient(t, server.URL)
+	if _, err := client.GetTrialEvaluation(context.Background(), "exp-1", "trial-1", "teval-missing"); !errors.Is(err, ErrExperimentNotFound) {
+		t.Fatalf("expected ErrExperimentNotFound, got %v", err)
+	}
+	if _, err := client.TriggerTrialEvaluation(context.Background(), "exp-1", "trial-1", TriggerTrialEvaluationRequest{
+		EvaluatorID: "helpfulness",
+	}); !errors.Is(err, ErrExperimentConflict) {
+		t.Fatalf("expected ErrExperimentConflict, got %v", err)
+	}
+}
+
+func TestTrialEvaluationRetriesServiceUnavailable(t *testing.T) {
+	recorder := &experimentRecorder{}
+	recorder.push(http.StatusServiceUnavailable, map[string]any{"error": "trial evaluation service is unavailable"})
+	recorder.push(http.StatusAccepted, trialEvaluationBody(nil))
+	server := httptest.NewServer(recorder.handler(t))
+	defer server.Close()
+
+	client := newExperimentTestClient(t, server.URL)
+	if _, err := client.TriggerTrialEvaluation(context.Background(), "exp-1", "trial-1", TriggerTrialEvaluationRequest{
+		EvaluatorID: "helpfulness",
+	}); err != nil {
+		t.Fatalf("trigger trial evaluation: %v", err)
+	}
+	if recorder.requestCount() != 2 {
+		t.Fatalf("expected one retry for a 503, got %d request(s)", recorder.requestCount())
 	}
 }

--- a/go/agento11y/trial.go
+++ b/go/agento11y/trial.go
@@ -60,11 +60,12 @@ type Trial struct {
 	usage              map[string]any
 	started            time.Time
 
-	buffer      []ScoreItem
-	accepted    int
-	hasFinal    bool
-	finalPassed *bool
-	artifacts   []map[string]any
+	buffer         []ScoreItem
+	accepted       int
+	hasFinal       bool
+	cloudEvaluated bool
+	finalPassed    *bool
+	artifacts      []map[string]any
 }
 
 func NewTrial(client *Client, ref TrialRef, opts ...TrialOption) *Trial {
@@ -140,6 +141,16 @@ func (t *Trial) resolveEndStatus(err error) {
 	if err != nil {
 		t.status = TrialStatusErrored
 		t.errorText = err.Error()
+		t.flushFailed = false
+		return
+	}
+	if !t.hasFinal && t.cloudEvaluated {
+		// A stored evaluator graded this trial; the verdict and the score count come
+		// from the backend, not from a local final score.
+		if t.status == TrialStatusRunning || t.flushFailed {
+			t.status = TrialStatusCompleted
+			t.errorText = ""
+		}
 		t.flushFailed = false
 		return
 	}
@@ -226,6 +237,173 @@ func (t *Trial) finalizeTrial(ctx context.Context) error {
 	}
 	_, err := t.client.UpdateTrial(ctx, t.ref.RunID, t.trialID, req)
 	return err
+}
+
+// EvaluateOptions configures Trial.Evaluate. A zero Timeout or PollInterval
+// uses the default; a negative one is rejected.
+type EvaluateOptions struct {
+	// EvaluatorVersion pins a stored evaluator version. Empty lets Agent
+	// Observability pin the latest active version.
+	EvaluatorVersion string
+	// Timeout bounds the wait for a terminal status. Defaults to 300s.
+	Timeout time.Duration
+	// PollInterval is the first delay between status reads, doubling up to 5s.
+	// Defaults to 500ms.
+	PollInterval time.Duration
+}
+
+const (
+	defaultEvaluationTimeout      = 300 * time.Second
+	defaultEvaluationPollInterval = 500 * time.Millisecond
+	// Ceiling for the Evaluate poll backoff, so a long wait does not keep reading
+	// status at the floor rate.
+	maxEvaluationPollInterval = 5 * time.Second
+)
+
+func (o EvaluateOptions) resolve() (timeout, pollInterval time.Duration, err error) {
+	if o.Timeout < 0 {
+		return 0, 0, fmt.Errorf("%w: evaluation timeout must not be negative", ErrExperimentValidationFailed)
+	}
+	if o.PollInterval < 0 {
+		return 0, 0, fmt.Errorf("%w: evaluation poll interval must not be negative", ErrExperimentValidationFailed)
+	}
+	timeout, pollInterval = o.Timeout, o.PollInterval
+	if timeout == 0 {
+		timeout = defaultEvaluationTimeout
+	}
+	if pollInterval == 0 {
+		pollInterval = defaultEvaluationPollInterval
+	}
+	return timeout, pollInterval, nil
+}
+
+// Evaluate runs a stored evaluator against this trial's bound conversation.
+//
+// It grades the conversation Agent Observability already stored, using an
+// evaluator defined in your tenant, instead of a score computed locally. The
+// current conversation binding is persisted and the recorded generation is
+// exported before the evaluation is queued, so the evaluator can read the
+// conversation it is asked to grade. A successful evaluation lets the trial end
+// as completed without a local FinalScore. Queuing one also makes the owning
+// ExperimentRun leave score counting to the backend, since the evaluator writes
+// a score this process never sees.
+//
+// Options.Timeout and ctx both bound the wait. Worker failure returns
+// *TrialEvaluationFailedError, an exceeded deadline returns
+// *TrialEvaluationTimeoutError, and a cancelled context returns ctx.Err(). A
+// transport error while polling propagates and abandons the wait; the evaluation
+// keeps running server-side, and triggering it again returns the same row.
+//
+// Only a trial created by ExperimentRun.Trial can mark its run, so a caller who
+// built this trial with NewTrial or NewTrialFromRef must leave
+// CompleteExperimentOptions.ScoreCount unset when finalizing the run itself.
+func (t *Trial) Evaluate(ctx context.Context, evaluatorID string, options ...EvaluateOptions) (*TrialEvaluation, error) {
+	if t == nil || t.client == nil {
+		return nil, ErrNilClient
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	opts := EvaluateOptions{}
+	if len(options) > 0 {
+		opts = options[0]
+	}
+	evaluatorID = strings.TrimSpace(evaluatorID)
+	if evaluatorID == "" {
+		return nil, fmt.Errorf("%w: evaluator_id is required", ErrExperimentValidationFailed)
+	}
+	timeout, pollInterval, err := opts.resolve()
+	if err != nil {
+		return nil, err
+	}
+	if t.conversationID == "" {
+		return nil, fmt.Errorf("%w: bind a conversation before evaluating a trial", ErrExperimentValidationFailed)
+	}
+
+	if err := t.createTrial(ctx); err != nil {
+		return nil, evaluationRequestError(ctx, err)
+	}
+	// BindConversation and RecordIO are local until now, and the backend rejects
+	// an evaluation for a trial with no stored conversation.
+	if _, err := t.client.UpdateTrial(ctx, t.ref.RunID, t.trialID, UpdateTrialRequest{
+		ConversationID: t.conversationID,
+	}); err != nil {
+		return nil, evaluationRequestError(ctx, err)
+	}
+	// The evaluator reads the stored conversation, so the generation has to exist
+	// before the wait starts, not when the trial ends.
+	if err := t.ensureGeneration(ctx); err != nil {
+		return nil, evaluationRequestError(ctx, err)
+	}
+	if err := t.client.Flush(ctx); err != nil {
+		return nil, evaluationRequestError(ctx, err)
+	}
+
+	deadline := time.Now().Add(timeout)
+	evaluation, err := t.client.TriggerTrialEvaluation(ctx, t.ref.RunID, t.trialID, TriggerTrialEvaluationRequest{
+		EvaluatorID: evaluatorID, EvaluatorVersion: opts.EvaluatorVersion,
+	})
+	if err != nil {
+		return nil, evaluationRequestError(ctx, err)
+	}
+	// The evaluation row exists from here on, and the score it writes counts toward
+	// the run's stored total whether or not this wait sees it finish. Marking the
+	// run only on success would leave a timed-out wait asserting a stale count.
+	t.experiment.markCloudEvaluated()
+	// Back off so a long wait costs tens of status reads, not hundreds. A caller
+	// who asked for a slower cadence than the cap keeps it.
+	interval := pollInterval
+	maxInterval := max(pollInterval, maxEvaluationPollInterval)
+	for {
+		switch evaluation.Status {
+		case TrialEvaluationStatusSuccess:
+			// End owns the trial's terminal state; a stored evaluator's verdict is not
+			// a local one. This only records that the score exists server-side.
+			t.cloudEvaluated = true
+			return evaluation, nil
+		case TrialEvaluationStatusFailed:
+			return nil, &TrialEvaluationFailedError{
+				EvaluationID: evaluation.EvaluationID, Detail: evaluation.Error,
+			}
+		case TrialEvaluationStatusQueued, TrialEvaluationStatusClaimed:
+		default:
+			// Unreachable: Client.TriggerTrialEvaluation and Client.GetTrialEvaluation
+			// reject a status the SDK does not know.
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, evaluationTimeoutError(evaluation.EvaluationID, timeout)
+		}
+		if err := sleepBackoff(ctx, min(interval, remaining)); err != nil {
+			return nil, err
+		}
+		interval = min(interval*2, maxInterval)
+		// Every sleep is followed by a status read, including the one clamped to the
+		// remaining budget, so an evaluation that finishes in the last window is not
+		// reported as a timeout.
+		evaluation, err = t.client.GetTrialEvaluation(ctx, t.ref.RunID, t.trialID, evaluation.EvaluationID)
+		if err != nil {
+			return nil, evaluationRequestError(ctx, err)
+		}
+	}
+}
+
+// evaluationRequestError keeps cancellation a single error shape. The eval
+// transport reports a cancelled request as ErrExperimentTransportFailed with the
+// context error only in its message, so errors.Is(err, context.Canceled) would
+// not hold for a caller who cancelled the wait.
+func evaluationRequestError(ctx context.Context, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	return err
+}
+
+func evaluationTimeoutError(evaluationID string, timeout time.Duration) error {
+	return &TrialEvaluationTimeoutError{
+		EvaluationID: evaluationID,
+		Detail:       fmt.Sprintf("waited %s", timeout),
+	}
 }
 
 func (t *Trial) BindTrace(traceID, spanID string) *Trial {

--- a/go/agento11y/trial_test.go
+++ b/go/agento11y/trial_test.go
@@ -3,9 +3,12 @@ package agento11y
 import (
 	"context"
 	"errors"
+	"maps"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestTrialLifecycleCreatesTypedTrialAndFinalScore(t *testing.T) {
@@ -291,5 +294,400 @@ func TestTrialSucceedWithoutFinalScoreFinalizesFailed(t *testing.T) {
 	}
 	if updateReq.Payload["error"] != "trial exited without a final score" {
 		t.Fatalf("expected missing final score error, got %#v", updateReq.Payload)
+	}
+}
+
+func trialEvaluationResponse(status string, overrides map[string]any) map[string]any {
+	body := map[string]any{
+		"evaluation_id":     "teval-1",
+		"experiment_id":     "run-cloud",
+		"trial_id":          "trial-cloud",
+		"test_case_id":      "case-cloud",
+		"conversation_id":   "conv-1",
+		"evaluator_id":      "helpfulness",
+		"evaluator_version": "v3",
+		"status":            status,
+		"attempts":          float64(0),
+	}
+	maps.Copy(body, overrides)
+	return body
+}
+
+func TestTrialEvaluateClosesCompletedAndRunOmitsScoreCount(t *testing.T) {
+	recorder := &experimentRecorder{}
+	recorder.push(http.StatusOK, map[string]any{"run": experimentBody(map[string]any{"experiment_id": "run-cloud"})})
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
+	recorder.push(http.StatusAccepted, trialEvaluationResponse("queued", nil))
+	recorder.push(http.StatusOK, trialEvaluationResponse("success", nil))
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
+	recorder.push(http.StatusOK, map[string]any{"run": experimentBody(map[string]any{"experiment_id": "run-cloud", "status": "completed"})})
+	server := httptest.NewServer(recorder.handler(t))
+	defer server.Close()
+
+	client := newExperimentTestClient(t, server.URL)
+	run := NewExperimentRun(ExperimentOptions{Client: client, RunID: "run-cloud", Name: "cloud run"})
+	if err := run.Enter(context.Background()); err != nil {
+		t.Fatalf("enter run: %v", err)
+	}
+	trial := run.TrialID("case-cloud")
+	if err := trial.Start(context.Background()); err != nil {
+		t.Fatalf("start trial: %v", err)
+	}
+	trial.BindConversation("conv-1").RecordIO(RecordIOOptions{Input: "2+2", Output: "4"})
+
+	evaluation, err := trial.Evaluate(context.Background(), "helpfulness", EvaluateOptions{
+		EvaluatorVersion: "v3", PollInterval: time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if evaluation.Status != TrialEvaluationStatusSuccess {
+		t.Fatalf("unexpected evaluation: %#v", evaluation)
+	}
+	if err := trial.End(context.Background(), nil); err != nil {
+		t.Fatalf("end trial: %v", err)
+	}
+	if trial.status != TrialStatusCompleted || trial.errorText != "" {
+		t.Fatalf("cloud-evaluated trial must end completed: status=%q error=%q", trial.status, trial.errorText)
+	}
+	if err := run.Finalize(context.Background(), ExperimentStatusCompleted, ""); err != nil {
+		t.Fatalf("finalize run: %v", err)
+	}
+
+	binding := recorder.request(2)
+	if binding.Method != http.MethodPatch || binding.Payload["conversation_id"] != "conv-1" {
+		t.Fatalf("expected the conversation to be persisted before the trigger, got %#v", binding)
+	}
+	trigger := recorder.request(3)
+	if trigger.Method != http.MethodPost || trigger.Path != "/api/v1/experiment-runs/run-cloud/trials/"+trial.trialID+":evaluate" {
+		t.Fatalf("unexpected trigger request %s %s", trigger.Method, trigger.Path)
+	}
+	if trigger.Payload["evaluator_id"] != "helpfulness" || trigger.Payload["evaluator_version"] != "v3" {
+		t.Fatalf("unexpected trigger body: %#v", trigger.Payload)
+	}
+	status := recorder.request(4)
+	if status.Method != http.MethodGet || status.Path != "/api/v1/experiment-runs/run-cloud/trials/"+trial.trialID+"/evaluations/teval-1" {
+		t.Fatalf("unexpected status request %s %s", status.Method, status.Path)
+	}
+	terminal := recorder.request(5)
+	if terminal.Method != http.MethodPatch || terminal.Payload["status"] != "completed" {
+		t.Fatalf("expected a completed terminal update, got %#v", terminal)
+	}
+	if _, exists := terminal.Payload["error"]; exists {
+		t.Fatalf("cloud-evaluated trial must not carry error text: %#v", terminal.Payload)
+	}
+	finalize := recorder.request(6)
+	if finalize.Method != http.MethodPost || finalize.Path != "/api/v1/experiment-runs/run-cloud:finalize" {
+		t.Fatalf("unexpected finalize request %s %s", finalize.Method, finalize.Path)
+	}
+	if _, exists := finalize.Payload["score_count"]; exists {
+		t.Fatalf("a cloud-evaluated run must leave score counting to the backend: %#v", finalize.Payload)
+	}
+}
+
+func TestExperimentRunFinalizeStillAssertsLocalScoreCount(t *testing.T) {
+	recorder := &experimentRecorder{}
+	recorder.push(http.StatusOK, map[string]any{"run": experimentBody(map[string]any{"experiment_id": "run-local"})})
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-local"})
+	recorder.push(http.StatusAccepted, map[string]any{"results": []map[string]any{{"score_id": "score-1", "accepted": true}}})
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-local"})
+	recorder.push(http.StatusOK, map[string]any{"run": experimentBody(map[string]any{"experiment_id": "run-local", "status": "completed"})})
+	server := httptest.NewServer(recorder.handler(t))
+	defer server.Close()
+
+	client := newExperimentTestClient(t, server.URL)
+	run := NewExperimentRun(ExperimentOptions{Client: client, RunID: "run-local", Name: "local run"})
+	if err := run.Enter(context.Background()); err != nil {
+		t.Fatalf("enter run: %v", err)
+	}
+	trial := run.TrialID("case-local")
+	if err := trial.Start(context.Background()); err != nil {
+		t.Fatalf("start trial: %v", err)
+	}
+	trial.FinalScore(BoolScoreValue(true), ScoreOptions{})
+	if err := trial.End(context.Background(), nil); err != nil {
+		t.Fatalf("end trial: %v", err)
+	}
+	if err := run.Finalize(context.Background(), ExperimentStatusCompleted, ""); err != nil {
+		t.Fatalf("finalize run: %v", err)
+	}
+	finalize := recorder.request(4)
+	if finalize.Payload["score_count"] != float64(1) {
+		t.Fatalf("a locally scored run must still assert its score count: %#v", finalize.Payload)
+	}
+}
+
+func TestTrialEvaluateSurfacesWorkerFailure(t *testing.T) {
+	recorder := &experimentRecorder{}
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
+	recorder.push(http.StatusAccepted, trialEvaluationResponse("queued", nil))
+	recorder.push(http.StatusOK, trialEvaluationResponse("failed", map[string]any{"error": "evaluator budget exhausted"}))
+	server := httptest.NewServer(recorder.handler(t))
+	defer server.Close()
+
+	client := newExperimentTestClient(t, server.URL)
+	trial := NewTrial(client, TrialRef{RunID: "run-cloud", TestCaseID: "case-cloud"})
+	if err := trial.Start(context.Background()); err != nil {
+		t.Fatalf("start trial: %v", err)
+	}
+	trial.BindConversation("conv-1")
+
+	_, err := trial.Evaluate(context.Background(), "helpfulness", EvaluateOptions{PollInterval: time.Millisecond})
+	var failed *TrialEvaluationFailedError
+	if !errors.As(err, &failed) {
+		t.Fatalf("expected *TrialEvaluationFailedError, got %v", err)
+	}
+	if failed.EvaluationID != "teval-1" || failed.Detail != "evaluator budget exhausted" {
+		t.Fatalf("unexpected failure detail: %#v", failed)
+	}
+	if !errors.Is(err, ErrTrialEvaluationFailed) {
+		t.Fatalf("expected ErrTrialEvaluationFailed, got %v", err)
+	}
+	if trial.cloudEvaluated {
+		t.Fatal("a failed evaluation must not mark the trial cloud-evaluated")
+	}
+}
+
+func TestTrialEvaluateTimesOutAfterBackingOff(t *testing.T) {
+	recorder := &experimentRecorder{}
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
+	recorder.push(http.StatusAccepted, trialEvaluationResponse("queued", nil))
+	server := httptest.NewServer(recorder.handler(t))
+	defer server.Close()
+
+	client := newExperimentTestClient(t, server.URL)
+	trial := NewTrial(client, TrialRef{RunID: "run-cloud", TestCaseID: "case-cloud"})
+	if err := trial.Start(context.Background()); err != nil {
+		t.Fatalf("start trial: %v", err)
+	}
+	trial.BindConversation("conv-1")
+
+	_, err := trial.Evaluate(context.Background(), "helpfulness", EvaluateOptions{
+		Timeout: 50 * time.Millisecond, PollInterval: time.Millisecond,
+	})
+	var timedOut *TrialEvaluationTimeoutError
+	if !errors.As(err, &timedOut) {
+		t.Fatalf("expected *TrialEvaluationTimeoutError, got %v", err)
+	}
+	if timedOut.EvaluationID != "teval-1" || !errors.Is(err, ErrTrialEvaluationTimeout) {
+		t.Fatalf("unexpected timeout error: %#v (%v)", timedOut, err)
+	}
+	// Doubling from 1ms cannot fit more than a handful of reads into 50ms.
+	if got := recorder.requestCount(); got > 9 {
+		t.Fatalf("poll interval must back off, got %d requests", got)
+	}
+}
+
+func TestTrialEvaluateReadsStatusAfterTheFinalSleep(t *testing.T) {
+	recorder := &experimentRecorder{}
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
+	recorder.push(http.StatusAccepted, trialEvaluationResponse("queued", nil))
+	recorder.push(http.StatusOK, trialEvaluationResponse("success", nil))
+	server := httptest.NewServer(recorder.handler(t))
+	defer server.Close()
+
+	client := newExperimentTestClient(t, server.URL)
+	trial := NewTrial(client, TrialRef{RunID: "run-cloud", TestCaseID: "case-cloud"})
+	if err := trial.Start(context.Background()); err != nil {
+		t.Fatalf("start trial: %v", err)
+	}
+	trial.BindConversation("conv-1")
+
+	// A poll interval at least as long as the timeout clamps the only sleep to the
+	// whole budget. The status read still has to happen, or an evaluation that
+	// finishes inside that window is reported as a timeout.
+	evaluation, err := trial.Evaluate(context.Background(), "helpfulness", EvaluateOptions{
+		Timeout: 20 * time.Millisecond, PollInterval: 20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if evaluation.Status != TrialEvaluationStatusSuccess {
+		t.Fatalf("unexpected evaluation: %#v", evaluation)
+	}
+	if got := recorder.requestCount(); got != 4 {
+		t.Fatalf("expected exactly one status read after the clamped sleep, got %d requests", got)
+	}
+}
+
+func TestTimedOutEvaluationStillOmitsScoreCount(t *testing.T) {
+	recorder := &experimentRecorder{}
+	recorder.push(http.StatusOK, map[string]any{"run": experimentBody(map[string]any{"experiment_id": "run-cloud"})})
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
+	recorder.push(http.StatusAccepted, trialEvaluationResponse("queued", nil))
+	recorder.push(http.StatusAccepted, trialEvaluationResponse("queued", nil))
+	recorder.push(http.StatusOK, map[string]any{"run": experimentBody(map[string]any{"experiment_id": "run-cloud", "status": "completed"})})
+	server := httptest.NewServer(recorder.handler(t))
+	defer server.Close()
+
+	client := newExperimentTestClient(t, server.URL)
+	run := NewExperimentRun(ExperimentOptions{Client: client, RunID: "run-cloud", Name: "cloud run"})
+	if err := run.Enter(context.Background()); err != nil {
+		t.Fatalf("enter run: %v", err)
+	}
+	trial := run.TrialID("case-cloud")
+	if err := trial.Start(context.Background()); err != nil {
+		t.Fatalf("start trial: %v", err)
+	}
+	trial.BindConversation("conv-1")
+
+	// One clamped sleep, one status read, then the deadline: the evaluation is
+	// still queued server-side and its score will land after this run finalizes.
+	if _, err := trial.Evaluate(context.Background(), "helpfulness", EvaluateOptions{
+		Timeout: 5 * time.Millisecond, PollInterval: 10 * time.Millisecond,
+	}); !errors.Is(err, ErrTrialEvaluationTimeout) {
+		t.Fatalf("expected ErrTrialEvaluationTimeout, got %v", err)
+	}
+	if err := run.Finalize(context.Background(), ExperimentStatusFailed, "evaluation timed out"); err != nil {
+		t.Fatalf("finalize run: %v", err)
+	}
+	finalize := recorder.request(recorder.requestCount() - 1)
+	if finalize.Method != http.MethodPost || finalize.Path != "/api/v1/experiment-runs/run-cloud:finalize" {
+		t.Fatalf("unexpected finalize request %s %s", finalize.Method, finalize.Path)
+	}
+	if _, exists := finalize.Payload["score_count"]; exists {
+		t.Fatalf("a queued evaluation still writes a score, so the count must be omitted: %#v", finalize.Payload)
+	}
+}
+
+func TestTrialEvaluateHonorsContextCancellation(t *testing.T) {
+	recorder := &experimentRecorder{}
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
+	recorder.push(http.StatusAccepted, trialEvaluationResponse("queued", nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	handler := recorder.handler(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/evaluations/") {
+			// Cancel during the wait. Whether cancellation lands on the in-flight
+			// status read or on the next sleep, Evaluate reports the context error.
+			cancel()
+		}
+		handler.ServeHTTP(w, r)
+	}))
+	defer server.Close()
+
+	client := newExperimentTestClient(t, server.URL)
+	trial := NewTrial(client, TrialRef{RunID: "run-cloud", TestCaseID: "case-cloud"})
+	if err := trial.Start(ctx); err != nil {
+		t.Fatalf("start trial: %v", err)
+	}
+	trial.BindConversation("conv-1")
+
+	_, err := trial.Evaluate(ctx, "helpfulness", EvaluateOptions{
+		Timeout: 5 * time.Second, PollInterval: time.Millisecond,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	var timedOut *TrialEvaluationTimeoutError
+	var failed *TrialEvaluationFailedError
+	if errors.As(err, &timedOut) || errors.As(err, &failed) {
+		t.Fatalf("cancellation must not be reported as timeout or failure: %v", err)
+	}
+}
+
+func TestTrialEvaluateValidatesOptionsWithoutRequests(t *testing.T) {
+	cases := []struct {
+		name             string
+		bindConversation bool
+		evaluatorID      string
+		options          EvaluateOptions
+	}{
+		{name: "no bound conversation", evaluatorID: "helpfulness"},
+		{name: "empty evaluator id", bindConversation: true, evaluatorID: " "},
+		{name: "negative timeout", bindConversation: true, evaluatorID: "helpfulness", options: EvaluateOptions{Timeout: -time.Second}},
+		{name: "negative poll interval", bindConversation: true, evaluatorID: "helpfulness", options: EvaluateOptions{PollInterval: -time.Millisecond}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := &experimentRecorder{}
+			recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
+			server := httptest.NewServer(recorder.handler(t))
+			defer server.Close()
+
+			client := newExperimentTestClient(t, server.URL)
+			trial := NewTrial(client, TrialRef{RunID: "run-cloud", TestCaseID: "case-cloud"})
+			if tc.bindConversation {
+				trial.BindConversation("conv-1")
+			}
+			if _, err := trial.Evaluate(context.Background(), tc.evaluatorID, tc.options); !errors.Is(err, ErrExperimentValidationFailed) {
+				t.Fatalf("expected ErrExperimentValidationFailed, got %v", err)
+			}
+			if recorder.requestCount() != 0 {
+				t.Fatalf("invalid options must not issue a request, got %d", recorder.requestCount())
+			}
+		})
+	}
+}
+
+func TestTrialCallbackErrorAfterCloudEvaluationEndsFailed(t *testing.T) {
+	recorder := &experimentRecorder{}
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
+	recorder.push(http.StatusOK, trialEvaluationResponse("success", nil))
+	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
+	server := httptest.NewServer(recorder.handler(t))
+	defer server.Close()
+
+	client := newExperimentTestClient(t, server.URL)
+	run := NewExperimentRun(ExperimentOptions{Client: client, RunID: "run-cloud", Name: "cloud run"})
+	callbackErr := errors.New("assertion failed after grading")
+	err := run.WithTrialID(context.Background(), "case-cloud", func(ctx context.Context, trial *Trial) error {
+		trial.BindConversation("conv-1")
+		if _, evalErr := trial.Evaluate(ctx, "helpfulness", EvaluateOptions{PollInterval: time.Millisecond}); evalErr != nil {
+			return evalErr
+		}
+		return callbackErr
+	})
+	if !errors.Is(err, callbackErr) {
+		t.Fatalf("expected the callback error, got %v", err)
+	}
+	terminal := recorder.request(recorder.requestCount() - 1)
+	if terminal.Method != http.MethodPatch || terminal.Payload["status"] != "failed" ||
+		terminal.Payload["error"] != callbackErr.Error() {
+		t.Fatalf("callback error must win over cloud evaluation: %#v", terminal)
+	}
+}
+
+func TestTrialEvaluationErrorMessageFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "worker failure with detail",
+			err:  &TrialEvaluationFailedError{EvaluationID: "teval-1", Detail: "evaluator budget exhausted"},
+			want: "agento11y trial evaluation teval-1 failed: evaluator budget exhausted",
+		},
+		{
+			name: "worker failure without detail",
+			err:  &TrialEvaluationFailedError{},
+			want: "agento11y trial evaluation unknown failed",
+		},
+		{
+			name: "timeout carries the wait",
+			err:  evaluationTimeoutError("teval-1", 200*time.Millisecond),
+			want: "agento11y trial evaluation teval-1 timed out: waited 200ms",
+		},
+		{
+			name: "timeout without detail",
+			err:  &TrialEvaluationTimeoutError{EvaluationID: " "},
+			want: "agento11y trial evaluation unknown timed out",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Fatalf("Error() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/llms.txt
+++ b/llms.txt
@@ -487,6 +487,21 @@ structured artifacts, and can `Flush` immediately after scoring for streaming
 runners. Stable experiment ID + case ID + explicit attempt gives resumable,
 idempotent identities.
 
+The Go SDK can also grade a trial with an evaluator stored in the tenant instead
+of a locally computed score: `trial.Evaluate(ctx, evaluatorID, ...)`. Bind the
+agent's conversation first; the call persists that binding, exports the anchor
+generation, queues the stored evaluator, and blocks until the worker reaches a
+terminal status. Such a trial closes as `completed` with no local final score,
+while an error returned from the trial callback after the call still closes it as
+errored. Leave `score_count` unset in a cloud-evaluated run: the asserted count
+is checked against every stored score, including the evaluator's. That score is
+attached to the conversation and the trial with no generation ID, so read it from
+the trial's scores in the report rather than a per-generation lookup; it carries
+the evaluator's own score key, and only a score under the `final` key feeds the
+report's pass rate. Worker failure is `*agento11y.TrialEvaluationFailedError` and
+an exceeded deadline is `*agento11y.TrialEvaluationTimeoutError`, both carrying
+the evaluation ID.
+
 Portable Go suites use `LoadSuite`/`MarshalSuite`/`WriteSuite` and accept both
 `id`/`test_case_id` and `cases`/`test_cases`. Stored suite synchronization uses
 `TestSuitesClient` with `AGENTO11Y_CONTROL_ENDPOINT` and


### PR DESCRIPTION
Adds `Trial.Evaluate` to the Go SDK: it grades the conversation a trial is bound to with an evaluator stored in Grafana Cloud, instead of a score the runner computes.

Example:

```go
err := run.WithTrial(ctx, testCase, func(ctx context.Context, trial *experiments.Trial) error {
	conversationID := runAgent(ctx, testCase.Input) // already instrumented
	trial.BindConversation(conversationID)

	// Blocks until the worker reaches a terminal status.
	evaluation, err := trial.Evaluate(ctx, "helpfulness", experiments.EvaluateOptions{
		EvaluatorVersion: "v3", // optional; empty pins the latest active version
	})
	if err != nil {
		var failed *agento11y.TrialEvaluationFailedError
		if errors.As(err, &failed) {
			log.Printf("evaluation %s failed: %s", failed.EvaluationID, failed.Detail)
		}
		return err
	}
	log.Printf("stored evaluator finished: %s", evaluation.Status)
	return nil // no FinalScore: the backend owns the verdict
})
```


Runnable example in [`examples/experiments/go/cloud-evaluator/`](https://github.com/grafana/agento11y/blob/ae536bf960d8036961e16f0baea046d3f63128f8/examples/experiments/go/cloud-evaluator/main.go).