### PR TITLE
feat(python-frameworks/litellm): support /v1/responses and /v1/messages routes

### DIFF
--- a/python-frameworks/litellm/README.md
+++ b/python-frameworks/litellm/README.md
@@ -185,11 +185,18 @@ The callback file reads connection details from environment variables. Adjust th
 ## Behavior
 
 - Mode mapping: non-stream calls -> `SYNC`, stream calls -> `STREAM` with first-token timestamp.
-- Provider detection: uses `custom_llm_provider` from LiteLLM's standard logging object.
+- Provider detection: uses `custom_llm_provider` from LiteLLM's standard logging object. A call that fails before the router picks a deployment, for example a budget or auth rejection, has no provider. It is reported under the provider `litellm` instead of being dropped.
+- Model name: a proxied call is reported with the bare model name (`gpt-4o-mini`), not the router deployment string (`openai/gpt-4o-mini`), so cost and catalog lookups match it. The router names are kept in generation metadata under `agento11y.framework.litellm.model`, `.model_group`, and `.model_id`. Embedding spans carry the model name only. An Azure deployment alias (`azure/my-deployment`) is reported as it is, because there is no catalog model with that name.
 - Failed calls are recorded with the error attached via `set_call_error`.
-- Chat completion call types (`completion`, `acompletion`, `text_completion`, `atext_completion`) are recorded as generations.
+- Recorded call types:
+  - chat completions (`completion`, `acompletion`)
+  - text completions (`text_completion`, `atext_completion`). The prompt is recorded as a user message. Pre-tokenized prompts (lists of token ids) carry no text and are skipped.
+  - the Responses API (`responses`, `aresponses`, `/v1/responses`). Text, reasoning, and tool calls in the output are recorded. That route has no `finish_reason`, so the stop reason comes from the response `status`: `completed` becomes `stop`, and an incomplete response reports `incomplete_details.reason`.
+  - the Anthropic Messages API (`anthropic_messages`, `aanthropic_messages`, `/v1/messages`)
+- Only text content is recorded. Images, audio, and other non-text parts are skipped. Anthropic-native `tool_use` and `tool_result` blocks on `/v1/messages` are skipped, as are `function_call` and `function_call_output` history items in `/v1/responses` input. OpenAI-format `tool_calls` and `tool` messages are recorded, and so are tool calls in `/v1/responses` output.
+- Tool definitions are read from the request `tools` in the OpenAI chat schema (`{"type": "function", "function": {...}}`). The flat Responses API tool schema is not recognized, so those requests report no tool definitions.
 - Embedding call types (`embedding`, `aembedding`) are recorded as OTel embedding spans (no generation export). The span carries input/token counts and dimensions; the input text is attached only when the handler's `capture_inputs` is set and the SDK's `EmbeddingCaptureConfig.capture_input=True`. Embedding spans require a configured OTel tracer.
-- Image, audio, and transcription call types are skipped.
+- Image generation, audio, and transcription call types are skipped.
 - Framework tags are always set:
   - `agento11y.framework.name=litellm`
   - `agento11y.framework.source=handler`

--- a/python-frameworks/litellm/agento11y_litellm/handler.py
+++ b/python-frameworks/litellm/agento11y_litellm/handler.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from collections.abc import Sequence
 from datetime import datetime, timezone
@@ -25,7 +24,8 @@ from agento11y.models import (
     ToolDefinition,
     ToolResult,
 )
-from agento11y.usage import from_openai_chat
+from agento11y.payload_mapping import content_parts, tool_definitions
+from agento11y.usage import map_usage
 from litellm.integrations.custom_logger import CustomLogger
 
 logger = logging.getLogger(__name__)
@@ -39,7 +39,43 @@ _CHAT_CALL_TYPES = frozenset(
     }
 )
 
+_RESPONSES_CALL_TYPES = frozenset({"responses", "aresponses"})
+
+_ANTHROPIC_MESSAGES_CALL_TYPES = frozenset({"anthropic_messages", "aanthropic_messages"})
+
+_GENERATION_CALL_TYPES = _CHAT_CALL_TYPES | _RESPONSES_CALL_TYPES | _ANTHROPIC_MESSAGES_CALL_TYPES
+
 _EMBEDDING_CALL_TYPES = frozenset({"embedding", "aembedding"})
+
+# Provider recorded when LiteLLM never resolved one. Failures raised before a
+# deployment is picked (budget, auth, no healthy deployment) carry an empty
+# custom_llm_provider, and the SDK rejects a generation without a provider, so
+# without a sentinel the failure is not recorded at all.
+#
+# The SDK's own marker for an unresolved provider is "custom"
+# (``_is_unknown_provider`` in ``agento11y/framework_handler.py``). The LiteLLM
+# name is used instead so the value points at what produced the event; the
+# tradeoff is that these events do not read as "provider unknown" to SDK-side
+# checks that only look for "" or "custom".
+_UNKNOWN_PROVIDER_SENTINEL = "litellm"
+
+_UNKNOWN_MODEL_SENTINEL = "unknown"
+
+# Responses API content part for a refused turn. It keeps its text in
+# ``refusal`` instead of ``text`` (LiteLLM's own ``ContentPartDonePartRefusal``).
+_REFUSAL_CONTENT_PART_TYPE = "refusal"
+
+# Content part types that carry plain text. ``text`` covers OpenAI chat and
+# Anthropic content blocks; ``input_text``/``output_text`` cover the Responses
+# API. A refusal is the only text a refused turn has, so it is read here too,
+# the way the OpenAI provider wrappers surface it.
+_TEXT_CONTENT_PART_TYPES = frozenset({"text", "input_text", "output_text", _REFUSAL_CONTENT_PART_TYPE})
+
+# Content part types inside a Responses API ``reasoning`` output item. OpenAI
+# sends ``summary_text``/``reasoning_text``; LiteLLM's chat-to-Responses bridge,
+# which serves every provider without a native Responses config, sends
+# ``output_text``.
+_REASONING_TEXT_PART_TYPES = frozenset({"summary_text", "reasoning_text", "output_text", "text"})
 
 # Metadata keys consulted, in order, to name the agent behind a request.
 # ``agent_id`` is LiteLLM's own identity field, filled in by the proxy from the
@@ -62,19 +98,47 @@ def _make_tool_call_part(*, call_id: str, name: str, arguments: str) -> Part:
     )
 
 
-def _map_messages(messages: list[dict[str, Any]] | None) -> tuple[list[Message], str]:
-    """Map OpenAI-format messages to agento11y Messages, extracting system prompt."""
+def _map_messages(messages: Any) -> tuple[list[Message], str]:
+    """Map a logged LiteLLM request to agento11y Messages, extracting system prompt.
+
+    Chat routes log OpenAI-format message dicts. Text completion routes log the
+    raw ``prompt`` instead (``function_setup`` in LiteLLM's ``utils.py``), which
+    is a string, a list of strings, or a list of token-id lists. Token ids carry
+    no text, so they are skipped.
+
+    ``/v1/messages`` is the exception: LiteLLM normalizes the *response* to chat
+    shape but logs the request messages as they arrived, so content is a list of
+    Anthropic blocks (``tool_use``, ``tool_result``, ``thinking``). The same
+    ``anthropic_messages`` call type can also carry OpenAI-shaped messages once
+    a caller replays LiteLLM's own normalized history, so both vocabularies are
+    read per message instead of branching on the route.
+    """
     if not messages:
+        return [], ""
+
+    if isinstance(messages, str):
+        messages = [messages]
+
+    if not isinstance(messages, list):
         return [], ""
 
     out: list[Message] = []
     system_chunks: list[str] = []
 
     for msg in messages:
+        if isinstance(msg, str):
+            if msg:
+                out.append(Message(role=MessageRole.USER, parts=[Part(kind=PartKind.TEXT, text=msg)]))
+            continue
+
+        if not isinstance(msg, dict):
+            continue
+
         role = (msg.get("role") or "").lower()
-        content = _extract_text_content(msg.get("content"))
+        raw_content = msg.get("content")
 
         if role in {"system", "developer"}:
+            content = _extract_text_content(raw_content)
             if content:
                 system_chunks.append(content)
             continue
@@ -85,29 +149,43 @@ def _map_messages(messages: list[dict[str, Any]] | None) -> tuple[list[Message],
         elif role == "tool":
             mapped_role = MessageRole.TOOL
 
-        parts: list[Part] = []
-
         if mapped_role == MessageRole.TOOL:
+            # OpenAI-shaped tool message: the result is the whole content and
+            # the ids live on the message. Anthropic puts results in
+            # ``tool_result`` blocks of a user message, handled below.
             out.append(
                 _tool_result_message(
-                    content=content,
+                    content=_extract_text_content(raw_content),
                     tool_call_id=msg.get("tool_call_id", ""),
                     name=msg.get("name", ""),
                 )
             )
             continue
 
-        if mapped_role == MessageRole.ASSISTANT:
-            parts.extend(_map_thinking_parts(msg))
+        parts = content_parts(raw_content)
 
-        if content:
-            parts.append(Part(kind=PartKind.TEXT, text=content))
+        if mapped_role == MessageRole.ASSISTANT and not any(part.kind == PartKind.THINKING for part in parts):
+            # OpenAI-shaped reasoning lives beside the content, not in it. Skip
+            # it when the content already carried thinking blocks, since
+            # ``reasoning_content`` repeats them.
+            parts = _map_thinking_parts(msg) + parts
+
+        if not parts:
+            # Content shapes ``content_parts`` has nothing to say about: a bare
+            # string, or a dict that only stringifies.
+            content = _extract_text_content(raw_content)
+            if content:
+                parts.append(Part(kind=PartKind.TEXT, text=content))
 
         if mapped_role == MessageRole.ASSISTANT:
             parts.extend(_map_tool_call_parts(msg.get("tool_calls")))
 
         if not parts:
             continue
+
+        if any(part.kind == PartKind.TOOL_RESULT for part in parts):
+            # An Anthropic ``tool_result`` block arrives on a user message.
+            mapped_role = MessageRole.TOOL
 
         out.append(Message(role=mapped_role, parts=parts))
 
@@ -191,6 +269,13 @@ def _map_response_output(response: Any) -> list[Message]:
 
     Reads from the StandardLoggingPayload ``response`` field (dict or str)
     so that LiteLLM redaction settings are honoured.
+
+    Chat shape (``choices[].message``) covers every route that reaches here,
+    including ``/v1/messages``: LiteLLM converts the Anthropic response to a
+    chat ``ModelResponse`` before it builds the payload
+    (``Logging._handle_anthropic_messages_response_logging``). A provider-shaped
+    payload still falls back to the Anthropic content blocks rather than
+    recording an empty turn.
     """
     if response is None:
         return []
@@ -205,7 +290,8 @@ def _map_response_output(response: Any) -> list[Message]:
 
     choices = response.get("choices")
     if not choices:
-        return []
+        parts = content_parts(response.get("content"), role_hint=MessageRole.ASSISTANT)
+        return [Message(role=MessageRole.ASSISTANT, parts=parts)] if parts else []
 
     out: list[Message] = []
     for choice in choices:
@@ -214,6 +300,10 @@ def _map_response_output(response: Any) -> list[Message]:
 
         response_message = choice.get("message")
         if not isinstance(response_message, dict):
+            # Text completions put the completion in choices[].text.
+            text = choice.get("text")
+            if isinstance(text, str) and text:
+                out.append(Message(role=MessageRole.ASSISTANT, parts=[Part(kind=PartKind.TEXT, text=text)]))
             continue
 
         content = response_message.get("content") or ""
@@ -234,8 +324,79 @@ def _map_response_output(response: Any) -> list[Message]:
     return out
 
 
+def _map_responses_output(response: Any) -> list[Message]:
+    """Map a Responses API SLO response to agento11y output Messages.
+
+    Unlike ``/v1/messages``, LiteLLM does not normalize ``/v1/responses`` to a
+    chat ``ModelResponse``, so the logged payload keeps the native
+    ``ResponsesAPIResponse`` shape: ``output`` is a list of items typed
+    ``message`` (``content[].output_text``), ``reasoning``, or
+    ``function_call``.
+    """
+    if isinstance(response, str):
+        return _map_response_output(response)
+
+    if not isinstance(response, dict):
+        return []
+
+    output = response.get("output")
+    if not isinstance(output, list):
+        return []
+
+    out: list[Message] = []
+    for item in output:
+        if not isinstance(item, dict):
+            continue
+
+        item_type = (item.get("type") or "").lower()
+
+        if item_type == "reasoning":
+            # ``summary`` and ``content`` hold different text (a visible summary
+            # and the raw reasoning), so both are kept when present.
+            parts = [
+                Part(kind=PartKind.THINKING, thinking=text)
+                for text in (
+                    _join_text_parts(item.get("summary"), _REASONING_TEXT_PART_TYPES),
+                    _join_text_parts(item.get("content"), _REASONING_TEXT_PART_TYPES),
+                )
+                if text
+            ]
+            if parts:
+                out.append(Message(role=MessageRole.ASSISTANT, parts=parts))
+            continue
+
+        if item_type == "function_call":
+            name = item.get("name") or ""
+            if not name:
+                continue
+            out.append(
+                Message(
+                    role=MessageRole.ASSISTANT,
+                    parts=[
+                        _make_tool_call_part(
+                            call_id=item.get("call_id") or item.get("id") or "",
+                            name=name,
+                            arguments=item.get("arguments") or "",
+                        )
+                    ],
+                )
+            )
+            continue
+
+        text = _extract_text_content(item.get("content"))
+        if text:
+            out.append(Message(role=MessageRole.ASSISTANT, parts=[Part(kind=PartKind.TEXT, text=text)]))
+
+    return out
+
+
 def _extract_text_content(content: Any) -> str:
     """Extract text from OpenAI message content (string or content parts array)."""
+    return _join_text_parts(content, _TEXT_CONTENT_PART_TYPES)
+
+
+def _join_text_parts(content: Any, part_types: frozenset[str]) -> str:
+    """Join the text of every content part whose ``type`` is in ``part_types``."""
     if content is None:
         return ""
     if isinstance(content, str):
@@ -243,8 +404,16 @@ def _extract_text_content(content: Any) -> str:
     if isinstance(content, list):
         texts = []
         for item in content:
-            if isinstance(item, dict) and item.get("type") == "text":
-                texts.append(item.get("text", ""))
+            if isinstance(item, dict):
+                part_type = item.get("type")
+                if part_type not in part_types:
+                    continue
+                # ``text`` can be present and null: LiteLLM's chat-to-Responses
+                # bridge emits one output_text part per choice even when the
+                # message content is None (a tool-call-only turn).
+                text = item.get("refusal") if part_type == _REFUSAL_CONTENT_PART_TYPE else item.get("text")
+                if isinstance(text, str) and text:
+                    texts.append(text)
             elif isinstance(item, str):
                 texts.append(item)
         return " ".join(texts)
@@ -270,46 +439,60 @@ def _datetime_to_utc(dt: datetime | None) -> datetime | None:
 
 
 def _extract_stop_reason(response: Any) -> str:
-    """Extract finish_reason from the SLO response dict."""
+    """Extract finish_reason from the SLO response dict.
+
+    Falls back to a top-level ``stop_reason`` for the same reason
+    ``_map_response_output`` falls back to content blocks: the payload is
+    normally chat-shaped, but a provider-shaped one should not lose the reason.
+    """
     if not isinstance(response, dict):
         return ""
     choices = response.get("choices")
     if not choices:
-        return ""
+        return str(response.get("stop_reason") or "")
     first_choice = choices[0]
     if not isinstance(first_choice, dict):
         return ""
     return first_choice.get("finish_reason") or ""
 
 
+def _extract_responses_stop_reason(response: Any) -> str:
+    """Derive a stop reason from the Responses API terminal status.
+
+    ``ResponsesAPIResponse`` has no ``finish_reason``, so ``status`` stands in
+    for it. Normalized the same way the OpenAI provider wrappers in Python, Go,
+    and JS do it: ``completed`` becomes ``stop``, an ``incomplete`` status
+    reports ``incomplete_details.reason``, anything else is the status itself.
+    """
+    if not isinstance(response, dict):
+        return ""
+
+    status = str(response.get("status") or "").lower()
+    details = response.get("incomplete_details")
+    reason = str((details.get("reason") if isinstance(details, dict) else "") or "").lower()
+
+    if status == "incomplete" and reason:
+        return reason
+    if status == "completed":
+        return "stop"
+    return status
+
+
 def _map_tool_definitions(kwargs: dict[str, Any]) -> list[ToolDefinition]:
-    """Extract tool schemas from optional_params."""
+    """Extract tool schemas from optional_params.
+
+    The shape follows the route, and one call type can produce more than one:
+    ``/v1/messages`` against Anthropic logs Anthropic tools (flat, with
+    ``input_schema``), the same call type bridged to a chat provider logs the
+    translated OpenAI tools (nested under ``function``), and ``/v1/responses``
+    logs flat tools with ``parameters``. ``tool_definitions`` reads all three.
+    """
     optional_params = kwargs.get("optional_params") or {}
     tools = optional_params.get("tools")
     if not tools or not isinstance(tools, list):
         return []
 
-    out: list[ToolDefinition] = []
-    for tool in tools:
-        if not isinstance(tool, dict):
-            continue
-        tool_type = tool.get("type", "")
-        function = tool.get("function") or {}
-        name = function.get("name", "")
-        if not name:
-            continue
-        description = function.get("description", "")
-        parameters = function.get("parameters")
-        schema_json = json.dumps(parameters).encode("utf-8") if parameters else b""
-        out.append(
-            ToolDefinition(
-                name=name,
-                description=description,
-                type=tool_type,
-                input_schema_json=schema_json,
-            )
-        )
-    return out
+    return tool_definitions(tools)
 
 
 def _safe_cast(params: dict[str, Any], key: str, cast: type) -> Any:
@@ -371,6 +554,47 @@ def _response_model(response_obj: Any) -> str:
     return getattr(response_obj, "model", "") or ""
 
 
+def _resolve_model_ref(slo: dict[str, Any]) -> ModelRef:
+    """Resolve the provider and a bare model name from a LiteLLM SLO.
+
+    ``slo["model"]`` is ``reconstruct_model_name`` output, which returns the
+    router deployment string, so a proxied call reports ``openai/gpt-4o-mini``
+    rather than ``gpt-4o-mini``. Cost and catalog lookups downstream match on
+    the bare name, so prefer ``hidden_params["litellm_model_name"]`` (the name
+    LiteLLM sent to the provider) over ``slo["model"]``, and strip one leading
+    ``<custom_llm_provider>/`` segment from whichever name is used. Only that one
+    prefix is stripped: an Azure deployment alias (``azure/my-deployment``) names
+    a deployment rather than a catalog model, and there is no catalog name to map
+    it to, so the alias is kept.
+
+    A failure raised before LiteLLM picked a deployment (budget, auth, no
+    healthy deployment) carries no provider and sometimes no model. Those get
+    sentinels so SDK validation keeps the event instead of rejecting it.
+    """
+    provider = str(slo.get("custom_llm_provider") or "").lower()
+    hidden_params = slo.get("hidden_params") or {}
+    name = str(hidden_params.get("litellm_model_name") or slo.get("model") or "")
+
+    if provider:
+        name = name.removeprefix(f"{provider}/")
+    else:
+        provider = _UNKNOWN_PROVIDER_SENTINEL
+        name = name or str(slo.get("model_group") or "")
+
+    return ModelRef(provider=provider, name=name or _UNKNOWN_MODEL_SENTINEL)
+
+
+def _routing_metadata(slo: dict[str, Any]) -> dict[str, str]:
+    """Keep the router deployment identity that ``_resolve_model_ref`` strips."""
+    hidden_params = slo.get("hidden_params") or {}
+    routing = {
+        "agento11y.framework.litellm.model": slo.get("model") or "",
+        "agento11y.framework.litellm.model_group": slo.get("model_group") or "",
+        "agento11y.framework.litellm.model_id": slo.get("model_id") or hidden_params.get("model_id") or "",
+    }
+    return {key: str(value) for key, value in routing.items() if value}
+
+
 def _metadata_sources(kwargs: dict[str, Any]) -> list[dict[str, Any]]:
     """Collect the metadata dicts LiteLLM may attach to a request.
 
@@ -406,7 +630,13 @@ def _first_metadata_value(sources: list[dict[str, Any]], keys: tuple[str, ...]) 
 
 
 def _extract_detailed_usage(response_obj: Any, slo: dict[str, Any]) -> TokenUsage:
-    """Build TokenUsage with detailed breakdowns from response_obj, basic counts from SLO."""
+    """Build TokenUsage with detailed breakdowns from response_obj, basic counts from SLO.
+
+    The breakdown field names differ per route: chat responses nest them under
+    ``prompt_tokens_details``/``completion_tokens_details``, the Responses API
+    under ``input_tokens_details``/``output_tokens_details``. ``map_usage``
+    picks the mapping from the shape it gets.
+    """
     usage = TokenUsage(
         input_tokens=slo.get("prompt_tokens") or 0,
         output_tokens=slo.get("completion_tokens") or 0,
@@ -420,7 +650,7 @@ def _extract_detailed_usage(response_obj: Any, slo: dict[str, Any]) -> TokenUsag
     if resp_usage is None:
         return usage
 
-    detail = from_openai_chat(resp_usage)
+    detail = map_usage(resp_usage)
     usage.cache_read_input_tokens = detail.cache_read_input_tokens
     usage.cache_write_input_tokens = detail.cache_write_input_tokens
     usage.reasoning_tokens = detail.reasoning_tokens
@@ -537,7 +767,7 @@ class Agento11yLiteLLMLogger(CustomLogger):
         is_failure: bool,
     ) -> None:
         call_type = slo.get("call_type") or ""
-        if call_type and call_type not in _CHAT_CALL_TYPES:
+        if call_type and call_type not in _GENERATION_CALL_TYPES:
             return
 
         is_stream = bool(slo.get("stream"))
@@ -554,7 +784,7 @@ class Agento11yLiteLLMLogger(CustomLogger):
         # extra_tags take precedence
         tags.update(self._extra_tags)
 
-        metadata: dict[str, Any] = dict(self._extra_metadata)
+        metadata: dict[str, Any] = {**_routing_metadata(slo), **self._extra_metadata}
 
         model_params = slo.get("model_parameters") or {}
         temperature = _safe_cast(model_params, "temperature", float)
@@ -564,12 +794,8 @@ class Agento11yLiteLLMLogger(CustomLogger):
         system_prompt = ""
         input_messages: list[Message] = []
         if self._capture_inputs:
-            raw_messages = slo.get("messages")
-            if isinstance(raw_messages, list):
-                input_messages, system_prompt = _map_messages(raw_messages)
+            input_messages, system_prompt = _map_messages(slo.get("messages"))
 
-        provider = (slo.get("custom_llm_provider") or "").lower()
-        model_name = slo.get("model") or ""
         gen_id = slo.get("id") or ""
         user_id = slo.get("end_user") or ""
         conversation_id = self._resolve_conversation_id(kwargs)
@@ -578,7 +804,7 @@ class Agento11yLiteLLMLogger(CustomLogger):
 
         seed = GenerationStart(
             id=gen_id,
-            model=ModelRef(provider=provider, name=model_name),
+            model=_resolve_model_ref(slo),
             mode=GenerationMode.STREAM if is_stream else GenerationMode.SYNC,
             system_prompt=system_prompt,
             temperature=temperature,
@@ -614,13 +840,14 @@ class Agento11yLiteLLMLogger(CustomLogger):
 
             slo_response = slo.get("response")
 
-            output_messages: list[Message] = []
-            if self._capture_outputs:
-                output_messages = _map_response_output(slo_response)
+            if call_type in _RESPONSES_CALL_TYPES:
+                map_output, extract_stop_reason = _map_responses_output, _extract_responses_stop_reason
+            else:
+                map_output, extract_stop_reason = _map_response_output, _extract_stop_reason
 
+            output_messages = map_output(slo_response) if self._capture_outputs else []
             usage = _extract_detailed_usage(response_obj, slo)
-
-            stop_reason = _extract_stop_reason(slo_response)
+            stop_reason = extract_stop_reason(slo_response)
 
             recorder.set_result(
                 generation=Generation(
@@ -635,7 +862,7 @@ class Agento11yLiteLLMLogger(CustomLogger):
             recorder.end()
             err = recorder.err()
             if err is not None:
-                logger.warning("agento11y: recorder error: %s", err)
+                logger.error("agento11y: generation dropped: %s", err)
 
     def _record_embedding(
         self,
@@ -647,11 +874,7 @@ class Agento11yLiteLLMLogger(CustomLogger):
         *,
         is_failure: bool,
     ) -> None:
-        model_name = slo.get("model") or ""
-        if not model_name:
-            return
-
-        provider = (slo.get("custom_llm_provider") or "").lower()
+        model_ref = _resolve_model_ref(slo)
         optional_params = kwargs.get("optional_params") or {}
         dimensions = _safe_cast(optional_params, "dimensions", int)
         encoding_format = optional_params.get("encoding_format") or ""
@@ -668,7 +891,7 @@ class Agento11yLiteLLMLogger(CustomLogger):
 
         recorder = self._client.start_embedding(
             EmbeddingStart(
-                model=ModelRef(provider=provider, name=model_name),
+                model=model_ref,
                 agent_name=self._resolve_agent_name(kwargs),
                 agent_version=self._resolve_agent_version(kwargs),
                 dimensions=dimensions,
@@ -696,7 +919,7 @@ class Agento11yLiteLLMLogger(CustomLogger):
                     input_count=_embedding_input_count(inputs),
                     input_tokens=slo.get("prompt_tokens") or 0,
                     input_texts=input_texts,
-                    response_model=_response_model(response_obj) or model_name,
+                    response_model=_response_model(response_obj) or model_ref.name,
                     dimensions=dimensions or _embedding_dimensions_from_response(response_obj),
                 )
             )
@@ -704,4 +927,6 @@ class Agento11yLiteLLMLogger(CustomLogger):
             recorder.end()
             err = recorder.err()
             if err is not None:
-                logger.warning("agento11y: embedding recorder error: %s", err)
+                # Unlike a generation, the embedding span is still emitted; it
+                # carries the validation error instead of the recorded values.
+                logger.error("agento11y: embedding validation failed: %s", err)

--- a/python-frameworks/litellm/tests/test_litellm_handler.py
+++ b/python-frameworks/litellm/tests/test_litellm_handler.py
@@ -1148,6 +1148,9 @@ def test_detailed_token_usage() -> None:
         response_obj = SimpleNamespace(
             choices=[SimpleNamespace(message=SimpleNamespace(content="Hi"), finish_reason="stop")],
             usage=SimpleNamespace(
+                prompt_tokens=100,
+                completion_tokens=50,
+                total_tokens=150,
                 prompt_tokens_details=SimpleNamespace(
                     cached_tokens=30,
                     cache_creation_tokens=20,
@@ -1188,6 +1191,9 @@ def test_zero_token_counts_preserved() -> None:
         response_obj = SimpleNamespace(
             choices=[SimpleNamespace(message=SimpleNamespace(content="Hi"), finish_reason="stop")],
             usage=SimpleNamespace(
+                prompt_tokens=100,
+                completion_tokens=50,
+                total_tokens=150,
                 prompt_tokens_details=SimpleNamespace(
                     cached_tokens=0,
                     cache_creation_tokens=0,
@@ -1767,5 +1773,826 @@ def test_input_assistant_thinking_dropped_when_inputs_disabled() -> None:
 
         gen = exporter.requests[0].generations[0]
         assert len(gen.input) == 0
+    finally:
+        client.shutdown()
+
+
+def test_router_prefixed_model_resolves_to_bare_name() -> None:
+    """A proxied deployment name (openai/gpt-4o-mini) exports as the bare model name."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="acompletion",
+            custom_llm_provider="openai",
+            model="openai/gpt-4o-mini",
+            model_group="gpt-4o-mini",
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.model.provider == "openai"
+        assert gen.model.name == "gpt-4o-mini"
+    finally:
+        client.shutdown()
+
+
+def test_litellm_model_name_preferred_over_router_model() -> None:
+    """hidden_params.litellm_model_name is the name LiteLLM sent to the provider."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            custom_llm_provider="bedrock",
+            model="bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+            hidden_params={"litellm_model_name": "us.anthropic.claude-3-5-sonnet-20240620-v1:0"},
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.model.provider == "bedrock"
+        assert gen.model.name == "us.anthropic.claude-3-5-sonnet-20240620-v1:0"
+    finally:
+        client.shutdown()
+
+
+def test_only_the_leading_provider_prefix_is_stripped() -> None:
+    """An Azure deployment alias keeps its name; only <provider>/ is removed."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(custom_llm_provider="azure", model="azure/my-deployment")
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.model.provider == "azure"
+        assert gen.model.name == "my-deployment"
+    finally:
+        client.shutdown()
+
+
+def test_routing_metadata_preserved() -> None:
+    """The router deployment identity stripped from the model name is kept in metadata."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            custom_llm_provider="openai",
+            model="openai/gpt-4o-mini",
+            model_group="fast-tier",
+            model_id="deployment-1",
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.metadata["agento11y.framework.litellm.model"] == "openai/gpt-4o-mini"
+        assert gen.metadata["agento11y.framework.litellm.model_group"] == "fast-tier"
+        assert gen.metadata["agento11y.framework.litellm.model_id"] == "deployment-1"
+    finally:
+        client.shutdown()
+
+
+def test_provider_less_failure_still_exported() -> None:
+    """A failure raised before a deployment is picked is kept under a sentinel provider."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            custom_llm_provider="",
+            model="",
+            model_group="gpt-4o-mini",
+            response={},
+            error_str="BudgetExceededError: exceeded budget for key",
+        )
+        handler.log_failure_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        assert len(exporter.requests) == 1
+        gen = exporter.requests[0].generations[0]
+        assert gen.model.provider == "litellm"
+        assert gen.model.name == "gpt-4o-mini"
+        assert gen.call_error is not None
+    finally:
+        client.shutdown()
+
+
+def test_provider_less_failure_without_model_uses_sentinel_name() -> None:
+    """With no provider, model, or model_group there is still an exported generation."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            custom_llm_provider="",
+            model="",
+            response={},
+            error_str="AuthenticationError: invalid virtual key",
+        )
+        handler.log_failure_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.model.provider == "litellm"
+        assert gen.model.name == "unknown"
+    finally:
+        client.shutdown()
+
+
+def test_embedding_failure_with_unresolved_model_still_recorded() -> None:
+    """An embedding failure with no resolved model is recorded under the sentinels."""
+    exporter = _CapturingExporter()
+    span_exporter = InMemorySpanExporter()
+    client = _new_span_client(exporter, span_exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_embedding_slo(
+            custom_llm_provider="",
+            model="",
+            error_str="BudgetExceededError: exceeded budget for key",
+        )
+        handler.log_failure_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].attributes.get("gen_ai.provider.name") == "litellm"
+        assert spans[0].attributes.get("gen_ai.request.model") == "unknown"
+    finally:
+        client.shutdown()
+
+
+def test_text_completion_string_prompt_captured() -> None:
+    """A string prompt becomes a USER message and choices[].text becomes the output."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="atext_completion",
+            custom_llm_provider="text-completion-openai",
+            model="gpt-3.5-turbo-instruct",
+            messages="Once upon a time",
+            response={"choices": [{"text": " there was a fox", "finish_reason": "length"}]},
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert [m.role for m in gen.input] == [MessageRole.USER]
+        assert gen.input[0].parts[0].text == "Once upon a time"
+        assert [m.role for m in gen.output] == [MessageRole.ASSISTANT]
+        assert gen.output[0].parts[0].text == " there was a fox"
+        assert gen.stop_reason == "length"
+    finally:
+        client.shutdown()
+
+
+def test_text_completion_list_prompt_captured() -> None:
+    """A list prompt maps one USER message per string."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="atext_completion",
+            custom_llm_provider="text-completion-openai",
+            model="gpt-3.5-turbo-instruct",
+            messages=["prompt a", "prompt b"],
+            response={"choices": [{"text": "x", "finish_reason": "stop"}]},
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        assert len(exporter.requests[0].generations) == 1
+        gen = exporter.requests[0].generations[0]
+        assert [m.role for m in gen.input] == [MessageRole.USER, MessageRole.USER]
+        assert [m.parts[0].text for m in gen.input] == ["prompt a", "prompt b"]
+        assert gen.output[0].parts[0].text == "x"
+    finally:
+        client.shutdown()
+
+
+def test_text_completion_token_id_prompt_produces_no_input() -> None:
+    """Pre-tokenized prompts carry no text, so they contribute no input messages."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="text_completion",
+            custom_llm_provider="text-completion-openai",
+            model="gpt-3.5-turbo-instruct",
+            messages=[[123, 456], [789]],
+            response={"choices": [{"text": "x", "finish_reason": "stop"}]},
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.input == []
+        assert gen.output[0].parts[0].text == "x"
+    finally:
+        client.shutdown()
+
+
+def test_responses_api_output_mapped() -> None:
+    """/v1/responses output[] items map to assistant messages."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="aresponses",
+            custom_llm_provider="openai",
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": [{"type": "input_text", "text": "say hello"}]}],
+            response={
+                "id": "resp_1",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "id": "msg_1",
+                        "status": "completed",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "hello"}],
+                    }
+                ],
+            },
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.input[0].parts[0].text == "say hello"
+        assert [m.role for m in gen.output] == [MessageRole.ASSISTANT]
+        assert gen.output[0].parts[0].text == "hello"
+        assert gen.stop_reason == "stop"
+    finally:
+        client.shutdown()
+
+
+def test_responses_api_reasoning_and_tool_call_mapped() -> None:
+    """reasoning items become THINKING parts and function_call items become TOOL_CALL parts."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="responses",
+            custom_llm_provider="openai",
+            model="openai/gpt-5",
+            messages="what is the weather in Berlin?",
+            response={
+                "id": "resp_2",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "reasoning",
+                        "id": "rs_1",
+                        "summary": [{"type": "summary_text", "text": "Need the weather tool."}],
+                    },
+                    {
+                        "type": "function_call",
+                        "id": "fc_1",
+                        "call_id": "call_1",
+                        "name": "get_weather",
+                        "arguments": '{"city": "Berlin"}',
+                    },
+                ],
+            },
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert [m.parts[0].kind for m in gen.output] == [PartKind.THINKING, PartKind.TOOL_CALL]
+        assert gen.output[0].parts[0].thinking == "Need the weather tool."
+        tool_call = gen.output[1].parts[0].tool_call
+        assert tool_call.id == "call_1"
+        assert tool_call.name == "get_weather"
+        assert tool_call.input_json == b'{"city": "Berlin"}'
+    finally:
+        client.shutdown()
+
+
+def test_anthropic_messages_output_mapped() -> None:
+    """/v1/messages is chat-normalized by LiteLLM, so the chat mappers apply.
+
+    ``Logging._handle_anthropic_messages_response_logging`` rewrites the
+    Anthropic response into a chat ``ModelResponse`` before the payload is
+    built, for the native route, the streaming route, and both bridges.
+    """
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="anthropic_messages",
+            custom_llm_provider="anthropic",
+            model="anthropic/claude-sonnet-4-5",
+            hidden_params={"litellm_model_name": "claude-sonnet-4-5-20250929"},
+            messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+            response=_make_slo_response(content="hello back", finish_reason="stop"),
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.model.provider == "anthropic"
+        assert gen.model.name == "claude-sonnet-4-5-20250929"
+        assert gen.input[0].parts[0].text == "hi"
+        assert gen.output[0].parts[0].text == "hello back"
+        assert gen.stop_reason == "stop"
+    finally:
+        client.shutdown()
+
+
+def test_aanthropic_messages_call_type_recorded() -> None:
+    """The async Anthropic Messages call type is recorded too."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(call_type="aanthropic_messages", custom_llm_provider="anthropic", model="claude-sonnet-4-5")
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        assert len(exporter.requests[0].generations) == 1
+    finally:
+        client.shutdown()
+
+
+def test_anthropic_messages_input_blocks_mapped() -> None:
+    """Request messages keep their Anthropic shape, so blocks carry the history.
+
+    LiteLLM normalizes the response but logs ``messages`` as they arrived, so a
+    tool call is a ``tool_use`` block on the assistant turn and its result is a
+    ``tool_result`` block on a *user* turn.
+    """
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="anthropic_messages",
+            custom_llm_provider="anthropic",
+            model="anthropic/claude-sonnet-4-5",
+            messages=[
+                {"role": "system", "content": "be terse"},
+                {"role": "user", "content": [{"type": "text", "text": "weather in Berlin?"}]},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "need the tool", "signature": "sig"},
+                        {"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {"city": "Berlin"}},
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": "toolu_1", "content": "20C"}],
+                },
+            ],
+            response=_make_slo_response(content="20C in Berlin", finish_reason="stop"),
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.system_prompt == "be terse"
+        assert [m.role for m in gen.input] == [MessageRole.USER, MessageRole.ASSISTANT, MessageRole.TOOL]
+
+        assert gen.input[0].parts[0].text == "weather in Berlin?"
+
+        thinking_part, tool_call_part = gen.input[1].parts
+        assert thinking_part.kind == PartKind.THINKING
+        assert thinking_part.thinking == "need the tool"
+        assert tool_call_part.tool_call.id == "toolu_1"
+        assert tool_call_part.tool_call.name == "get_weather"
+        assert tool_call_part.tool_call.input_json == b'{"city":"Berlin"}'
+
+        tool_result = gen.input[2].parts[0].tool_result
+        assert tool_result.tool_call_id == "toolu_1"
+        assert tool_result.content == "20C"
+    finally:
+        client.shutdown()
+
+
+def test_anthropic_messages_tool_definitions_captured() -> None:
+    """Anthropic tools are flat, with the schema under ``input_schema``."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(call_type="anthropic_messages", custom_llm_provider="anthropic", model="claude-sonnet-4-5")
+        kwargs = _make_kwargs(slo)
+        kwargs["optional_params"] = {
+            "tools": [
+                {
+                    "name": "get_weather",
+                    "description": "Get the current weather",
+                    "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}},
+                },
+                {"type": "web_search_20250305", "name": "web_search", "max_uses": 3},
+            ]
+        }
+        handler.log_success_event(
+            kwargs=kwargs,
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert [tool.name for tool in gen.tools] == ["get_weather", "web_search"]
+        assert gen.tools[0].type == "function"
+        assert gen.tools[0].description == "Get the current weather"
+        assert b'"city"' in gen.tools[0].input_schema_json
+        assert gen.tools[1].type == "web_search_20250305"
+        assert gen.tools[1].input_schema_json == b""
+    finally:
+        client.shutdown()
+
+
+def test_responses_api_tool_definitions_captured() -> None:
+    """Responses API tools are flat too, with the schema under ``parameters``."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(call_type="responses", custom_llm_provider="openai", model="openai/gpt-5")
+        kwargs = _make_kwargs(slo)
+        kwargs["optional_params"] = {
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "description": "Get the current weather",
+                    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                }
+            ]
+        }
+        handler.log_success_event(
+            kwargs=kwargs,
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert [tool.name for tool in gen.tools] == ["get_weather"]
+        assert gen.tools[0].type == "function"
+        assert b'"city"' in gen.tools[0].input_schema_json
+    finally:
+        client.shutdown()
+
+
+def test_provider_shaped_response_fallback() -> None:
+    """A payload without ``choices`` falls back to Anthropic content blocks.
+
+    Current LiteLLM always normalizes ``/v1/messages`` to chat shape before
+    logging, so this is the guard for a payload that skips that conversion
+    rather than a route we see today.
+    """
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="anthropic_messages",
+            custom_llm_provider="anthropic",
+            model="claude-sonnet-4-5",
+            response={
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "checking"},
+                    {"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {"city": "Berlin"}},
+                ],
+                "stop_reason": "tool_use",
+            },
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert [part.kind for part in gen.output[0].parts] == [PartKind.TEXT, PartKind.TOOL_CALL]
+        assert gen.output[0].parts[0].text == "checking"
+        assert gen.output[0].parts[1].tool_call.name == "get_weather"
+        assert gen.stop_reason == "tool_use"
+    finally:
+        client.shutdown()
+
+
+def test_responses_api_refusal_part_mapped() -> None:
+    """A refused turn keeps its text, which a refusal part holds in ``refusal``."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="aresponses",
+            custom_llm_provider="openai",
+            model="openai/gpt-4o-mini",
+            messages="how do I pick a lock?",
+            response={
+                "id": "resp_refusal",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "id": "msg_1",
+                        "status": "completed",
+                        "role": "assistant",
+                        "content": [{"type": "refusal", "refusal": "I'm sorry, I can't help with that."}],
+                    }
+                ],
+            },
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert [m.role for m in gen.output] == [MessageRole.ASSISTANT]
+        assert gen.output[0].parts[0].kind == PartKind.TEXT
+        assert gen.output[0].parts[0].text == "I'm sorry, I can't help with that."
+    finally:
+        client.shutdown()
+
+
+def test_responses_api_bridged_null_text_part_skipped() -> None:
+    """A bridged message item whose output_text is null keeps the rest of the generation.
+
+    LiteLLM's chat-to-Responses bridge, used for every provider without a native
+    Responses config, emits one output_text part per choice even when the message
+    content is None, which is what a tool-call-only turn looks like.
+    """
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="aresponses",
+            custom_llm_provider="anthropic",
+            model="anthropic/claude-sonnet-4-5",
+            messages="what is the weather in Berlin?",
+            response={
+                "id": "resp_bridged",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "id": "msg_1",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": None, "annotations": []}],
+                    },
+                    {
+                        "type": "function_call",
+                        "id": "fc_1",
+                        "call_id": "call_1",
+                        "name": "get_weather",
+                        "arguments": '{"city": "Berlin"}',
+                    },
+                ],
+            },
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.input[0].parts[0].text == "what is the weather in Berlin?"
+        assert [m.parts[0].kind for m in gen.output] == [PartKind.TOOL_CALL]
+        assert gen.output[0].parts[0].tool_call.name == "get_weather"
+        assert gen.usage.input_tokens == 10
+        assert gen.stop_reason == "stop"
+    finally:
+        client.shutdown()
+
+
+def test_responses_api_bridged_reasoning_content_mapped() -> None:
+    """A bridged reasoning item carries its text in content[].output_text, not summary."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="aresponses",
+            custom_llm_provider="anthropic",
+            model="anthropic/claude-sonnet-4-5",
+            messages="how many r in strawberry?",
+            response={
+                "id": "resp_bridged_reasoning",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "reasoning",
+                        "id": "rs_1",
+                        "summary": [],
+                        "content": [{"type": "output_text", "text": "Counting the letters."}],
+                    },
+                    {
+                        "type": "message",
+                        "id": "msg_1",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "three"}],
+                    },
+                ],
+            },
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert [m.parts[0].kind for m in gen.output] == [PartKind.THINKING, PartKind.TEXT]
+        assert gen.output[0].parts[0].thinking == "Counting the letters."
+        assert gen.output[1].parts[0].text == "three"
+    finally:
+        client.shutdown()
+
+
+def test_responses_api_usage_details_mapped() -> None:
+    """Responses API usage nests its breakdowns under input/output_tokens_details."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="aresponses",
+            custom_llm_provider="openai",
+            model="openai/gpt-5",
+            prompt_tokens=100,
+            completion_tokens=50,
+            total_tokens=150,
+            messages="hi",
+            response={"id": "resp_3", "status": "completed", "output": []},
+        )
+        response_obj = SimpleNamespace(
+            usage=SimpleNamespace(
+                input_tokens=100,
+                output_tokens=50,
+                total_tokens=150,
+                input_tokens_details=SimpleNamespace(cached_tokens=64),
+                output_tokens_details=SimpleNamespace(reasoning_tokens=32),
+            ),
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=response_obj,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.usage.input_tokens == 100
+        assert gen.usage.output_tokens == 50
+        assert gen.usage.cache_read_input_tokens == 64
+        assert gen.usage.reasoning_tokens == 32
+    finally:
+        client.shutdown()
+
+
+def test_responses_api_incomplete_stop_reason() -> None:
+    """An incomplete Responses call reports the incomplete_details reason."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="aresponses",
+            custom_llm_provider="openai",
+            model="openai/gpt-4o-mini",
+            messages="write an essay",
+            response={
+                "id": "resp_4",
+                "status": "incomplete",
+                "incomplete_details": {"reason": "max_output_tokens"},
+                "output": [
+                    {
+                        "type": "message",
+                        "id": "msg_1",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "partial"}],
+                    }
+                ],
+            },
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.stop_reason == "max_output_tokens"
     finally:
         client.shutdown()

--- a/python-providers/anthropic/agento11y_anthropic/provider.py
+++ b/python-providers/anthropic/agento11y_anthropic/provider.py
@@ -18,10 +18,8 @@ from agento11y import (
     ModelRef,
     Part,
     PartKind,
-    ToolCall,
-    ToolDefinition,
-    ToolResult,
 )
+from agento11y.payload_mapping import content_parts, content_text, tool_definitions
 from agento11y.usage import from_anthropic
 
 if TYPE_CHECKING:
@@ -166,7 +164,7 @@ def _messages_from_request_response(
     thinking_budget = _anthropic_thinking_budget(_read(request, "thinking"))
     input_messages, system_prompt = _map_input_messages(request)
     output_message = _map_output_message(response)
-    tools = _map_tools(_read(request, "tools"))
+    tools = tool_definitions(_read(request, "tools"))
     usage = from_anthropic(_read(response, "usage"))
     usage_metadata = _anthropic_usage_metadata(_read(response, "usage"))
 
@@ -235,7 +233,7 @@ def _messages_from_stream(
             thinking_enabled=_anthropic_thinking_enabled(_read(request, "thinking")),
             input=input_messages,
             output=[],
-            tools=_map_tools(_read(request, "tools")),
+            tools=tool_definitions(_read(request, "tools")),
             tags=dict(opts.tags),
             metadata=_merge_metadata(
                 _metadata_with_thinking_budget(
@@ -277,7 +275,7 @@ def _start_payload(request: MessageCreateParams, options: AnthropicOptions, mode
         top_p=_as_float_or_none(_read(request, "top_p")),
         tool_choice=_canonical_tool_choice(_read(request, "tool_choice")),
         thinking_enabled=_anthropic_thinking_enabled(_read(request, "thinking")),
-        tools=_map_tools(_read(request, "tools")),
+        tools=tool_definitions(_read(request, "tools")),
         tags=dict(options.tags),
         metadata=_metadata_with_thinking_budget(
             options.metadata,
@@ -292,9 +290,9 @@ def _map_input_messages(request: MessageCreateParams) -> tuple[list[Message], st
 
     for raw_message in _as_list(_read(request, "messages")):
         role = _normalize_role(_as_str(_read(raw_message, "role")))
-        parts = _map_parts(_read(raw_message, "content"), role_hint=role)
+        parts = content_parts(_read(raw_message, "content"), role_hint=role)
         if not parts:
-            text = _extract_text(_read(raw_message, "content"))
+            text = content_text(_read(raw_message, "content"))
             if text:
                 parts = [Part(kind=PartKind.TEXT, text=text)]
 
@@ -314,9 +312,9 @@ def _map_input_messages(request: MessageCreateParams) -> tuple[list[Message], st
 
 
 def _map_output_message(response: AnthropicMessage) -> Message | None:
-    parts = _map_parts(_read(response, "content"), role_hint=MessageRole.ASSISTANT)
+    parts = content_parts(_read(response, "content"), role_hint=MessageRole.ASSISTANT)
     if not parts:
-        text = _extract_text(_read(response, "content"))
+        text = content_text(_read(response, "content"))
         if text:
             parts = [Part(kind=PartKind.TEXT, text=text)]
 
@@ -327,69 +325,6 @@ def _map_output_message(response: AnthropicMessage) -> Message | None:
         role=MessageRole.ASSISTANT,
         parts=parts,
     )
-
-
-def _map_parts(content: Any, role_hint: MessageRole) -> list[Part]:
-    blocks = _as_list(content)
-    if not blocks and isinstance(content, str):
-        text = content.strip()
-        return [Part(kind=PartKind.TEXT, text=text)] if text else []
-
-    parts: list[Part] = []
-    for block in blocks:
-        block_type = _as_str(_read(block, "type")).lower()
-        if block_type == "text":
-            text = _as_str(_read(block, "text"))
-            if text:
-                parts.append(Part(kind=PartKind.TEXT, text=text))
-            continue
-
-        if block_type == "thinking":
-            thinking = _as_str(_read(block, "thinking")) or _as_str(_read(block, "text"))
-            if thinking:
-                parts.append(Part(kind=PartKind.THINKING, thinking=thinking))
-            continue
-
-        if block_type == "redacted_thinking":
-            thinking = _as_str(_read(block, "data")) or _as_str(_read(block, "text"))
-            if thinking:
-                parts.append(Part(kind=PartKind.THINKING, thinking=thinking))
-            continue
-
-        if block_type in {"tool_use", "server_tool_use", "mcp_tool_use"}:
-            tool_name = _as_str(_read(block, "name"))
-            tool_id = _as_str(_read(block, "id"))
-            tool_input = _read(block, "input")
-            parts.append(
-                Part(
-                    kind=PartKind.TOOL_CALL,
-                    tool_call=ToolCall(
-                        id=tool_id,
-                        name=tool_name,
-                        input_json=_json_bytes(tool_input),
-                    ),
-                )
-            )
-            continue
-
-        if block_type == "tool_result" or role_hint == MessageRole.TOOL:
-            tool_call_id = _as_str(_read(block, "tool_use_id")) or _as_str(_read(block, "tool_call_id"))
-            content_text = _extract_text(_read(block, "content"))
-            parts.append(
-                Part(
-                    kind=PartKind.TOOL_RESULT,
-                    tool_result=ToolResult(
-                        tool_call_id=tool_call_id,
-                        name=_as_str(_read(block, "name")),
-                        content=content_text,
-                        content_json=_json_bytes(_read(block, "content")),
-                        is_error=_as_bool(_read(block, "is_error")),
-                    ),
-                )
-            )
-            continue
-
-    return parts
 
 
 def _extract_system_prompt(raw_system: Any) -> str:
@@ -406,24 +341,6 @@ def _extract_system_prompt(raw_system: Any) -> str:
             chunks.append(text)
 
     return "\n".join(chunks)
-
-
-def _map_tools(raw_tools: Any) -> list[ToolDefinition]:
-    tools: list[ToolDefinition] = []
-    for raw_tool in _as_list(raw_tools):
-        name = _as_str(_read(raw_tool, "name"))
-        if not name:
-            continue
-        tools.append(
-            ToolDefinition(
-                name=name,
-                description=_as_str(_read(raw_tool, "description")),
-                type=_as_str(_read(raw_tool, "type")) or "function",
-                input_schema_json=_json_bytes(_read(raw_tool, "input_schema")),
-            )
-        )
-
-    return tools
 
 
 def _extract_stream_output_text(events: list[RawMessageStreamEvent]) -> str:
@@ -444,7 +361,7 @@ def _extract_stream_output_text(events: list[RawMessageStreamEvent]) -> str:
                 chunks.append(text)
                 continue
 
-        text = _extract_text(_read(event, "text"))
+        text = content_text(_read(event, "text"))
         if text:
             chunks.append(text)
 
@@ -604,43 +521,6 @@ def _to_plain(value: Any) -> Any:
     return str(value)
 
 
-def _extract_text(value: Any) -> str:
-    if value is None:
-        return ""
-
-    if isinstance(value, str):
-        return value.strip()
-
-    if isinstance(value, bytes):
-        return value.decode("utf-8", errors="replace").strip()
-
-    if isinstance(value, Mapping):
-        text = _as_str(value.get("text"))
-        if text:
-            return text
-        content = value.get("content")
-        if content is not None:
-            return _extract_text(content)
-        return ""
-
-    if isinstance(value, list | tuple):
-        chunks: list[str] = []
-        for item in value:
-            chunk = _extract_text(item)
-            if chunk:
-                chunks.append(chunk)
-        return "\n".join(chunks)
-
-    model_dump = getattr(value, "model_dump", None)
-    if callable(model_dump):
-        try:
-            return _extract_text(model_dump(mode="json"))
-        except TypeError:
-            return _extract_text(model_dump())
-
-    return _as_str(value)
-
-
 def _read(value: Any, key: str, default: Any = None) -> Any:
     if value is None:
         return default
@@ -679,18 +559,6 @@ def _as_str(value: Any) -> str:
     if isinstance(value, str):
         return value.strip()
     return str(value).strip()
-
-
-def _as_bool(value: Any) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        lowered = value.strip().lower()
-        if lowered in {"true", "1", "yes", "on"}:
-            return True
-        if lowered in {"false", "0", "no", "off"}:
-            return False
-    return False
 
 
 def _as_int(value: Any) -> int:

--- a/python/agento11y/payload_mapping.py
+++ b/python/agento11y/payload_mapping.py
@@ -1,0 +1,309 @@
+"""Shared mapping of provider payload fragments to agento11y models.
+
+Used by the first-party provider wrappers and framework handlers, not by
+application code. Two shapes show up in more than one package:
+
+- Content blocks. Anthropic ``/v1/messages`` messages carry typed blocks
+  (``text``, ``thinking``, ``tool_use``, ``tool_result``); OpenAI chat and the
+  Responses API carry ``text``/``input_text``/``output_text``/``refusal`` parts.
+  ``content_parts`` reads both vocabularies, so a caller that can receive either
+  shape (the LiteLLM handler receives both, sometimes for the same call type)
+  needs one pass instead of a shape guess.
+- Tool schemas. The same tool list is nested under ``function`` on OpenAI chat,
+  flat with ``parameters`` on the Responses API, and flat with ``input_schema``
+  on Anthropic. ``tool_definitions`` accepts all three.
+
+Values may be plain dicts or provider SDK objects (Pydantic models,
+dataclasses), so fields are read through ``_read`` rather than by subscript.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+from .models import MessageRole, Part, PartKind, ToolCall, ToolDefinition, ToolResult
+
+# Block types whose text lives in ``text``. ``text`` is Anthropic and OpenAI
+# chat; ``input_text``/``output_text`` are the Responses API.
+_TEXT_BLOCK_TYPES = frozenset({"text", "input_text", "output_text"})
+
+# A refused turn keeps its text in ``refusal``, and that is the only text it
+# has, so it is read as message text.
+_REFUSAL_BLOCK_TYPE = "refusal"
+
+_TOOL_CALL_BLOCK_TYPES = frozenset({"tool_use", "server_tool_use", "mcp_tool_use"})
+
+
+def content_parts(content: Any, *, role_hint: MessageRole = MessageRole.USER) -> list[Part]:
+    """Map provider content blocks to Parts, preserving block order.
+
+    ``role_hint`` is the role of the message the blocks came from. On a
+    tool-role message every block is treated as a tool result, which is how
+    frameworks that keep results in an untyped block report them.
+
+    Unknown block types (images, documents, citations) are skipped: they carry
+    no text we record today.
+    """
+    blocks = _as_list(content)
+    if not blocks and isinstance(content, str):
+        text = _raw_text(content)
+        return [Part(kind=PartKind.TEXT, text=text)] if text else []
+
+    parts: list[Part] = []
+    for block in blocks:
+        if isinstance(block, str):
+            text = _raw_text(block)
+            if text:
+                parts.append(Part(kind=PartKind.TEXT, text=text))
+            continue
+
+        block_type = _as_str(_read(block, "type")).lower()
+
+        if block_type in _TEXT_BLOCK_TYPES:
+            # ``text`` can be present and null: LiteLLM's chat-to-Responses
+            # bridge emits one output_text part per choice even when the
+            # message content is None (a tool-call-only turn).
+            text = _raw_text(_read(block, "text"))
+            if text:
+                parts.append(Part(kind=PartKind.TEXT, text=text))
+            continue
+
+        if block_type == _REFUSAL_BLOCK_TYPE:
+            text = _raw_text(_read(block, "refusal")) or _raw_text(_read(block, "text"))
+            if text:
+                parts.append(Part(kind=PartKind.TEXT, text=text))
+            continue
+
+        if block_type == "thinking":
+            thinking = _raw_text(_read(block, "thinking")) or _raw_text(_read(block, "text"))
+            if thinking:
+                parts.append(Part(kind=PartKind.THINKING, thinking=thinking))
+            continue
+
+        if block_type == "redacted_thinking":
+            thinking = _raw_text(_read(block, "data")) or _raw_text(_read(block, "text"))
+            if thinking:
+                parts.append(Part(kind=PartKind.THINKING, thinking=thinking))
+            continue
+
+        if block_type in _TOOL_CALL_BLOCK_TYPES:
+            name = _as_str(_read(block, "name"))
+            parts.append(
+                Part(
+                    kind=PartKind.TOOL_CALL,
+                    tool_call=ToolCall(
+                        id=_as_str(_read(block, "id")),
+                        name=name,
+                        input_json=_json_bytes(_read(block, "input")),
+                    ),
+                )
+            )
+            continue
+
+        if block_type == "tool_result" or role_hint == MessageRole.TOOL:
+            result_content = _read(block, "content")
+            parts.append(
+                Part(
+                    kind=PartKind.TOOL_RESULT,
+                    tool_result=ToolResult(
+                        tool_call_id=_as_str(_read(block, "tool_use_id")) or _as_str(_read(block, "tool_call_id")),
+                        name=_as_str(_read(block, "name")),
+                        content=content_text(result_content),
+                        content_json=_json_bytes(result_content),
+                        is_error=_as_bool(_read(block, "is_error")),
+                    ),
+                )
+            )
+            continue
+
+    return parts
+
+
+def content_text(value: Any) -> str:
+    """Extract the text of a content value: a string, a block, or a list of either."""
+    if value is None:
+        return ""
+
+    if isinstance(value, str):
+        return value.strip()
+
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace").strip()
+
+    if isinstance(value, Mapping):
+        text = _as_str(value.get("text"))
+        if text:
+            return text
+        content = value.get("content")
+        if content is not None:
+            return content_text(content)
+        return ""
+
+    if isinstance(value, (list, tuple)):
+        chunks: list[str] = []
+        for item in value:
+            chunk = content_text(item)
+            if chunk:
+                chunks.append(chunk)
+        return "\n".join(chunks)
+
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return content_text(model_dump(mode="json"))
+        except TypeError:
+            return content_text(model_dump())
+
+    return _as_str(value)
+
+
+def tool_definitions(value: Any) -> list[ToolDefinition]:
+    """Map a request tool list to ToolDefinitions, accepting all three shapes.
+
+    - OpenAI chat: ``{"type": "function", "function": {"name", "description", "parameters"}}``
+    - Responses API: ``{"type": "function", "name", "description", "parameters"}``
+    - Anthropic: ``{"name", "description", "input_schema"}``
+
+    Provider built-in tools (``web_search``, ``bash``, ...) have a type and a
+    name but no schema, and are recorded with the type the provider used. A
+    tool without a name is skipped: there is nothing to attribute a call to.
+    """
+    out: list[ToolDefinition] = []
+    for raw_tool in _as_list(value):
+        tool_type = _as_str(_read(raw_tool, "type")) or "function"
+
+        function = _read(raw_tool, "function")
+        payload = raw_tool if function is None else function
+
+        name = _as_str(_read(payload, "name"))
+        if not name:
+            continue
+
+        schema = _read(payload, "input_schema")
+        if schema is None:
+            schema = _read(payload, "parameters")
+
+        out.append(
+            ToolDefinition(
+                name=name,
+                description=_as_str(_read(payload, "description")),
+                type=tool_type,
+                # Absent schema stays empty rather than the JSON literal
+                # ``null``, matching the Go and JS providers.
+                input_schema_json=b"" if schema is None else _json_bytes(schema),
+            )
+        )
+
+    return out
+
+
+def _raw_text(value: Any) -> str:
+    """Return a text field unchanged, or "" when it is missing or blank.
+
+    Whitespace decides whether a block carries text, but the text itself is
+    recorded as sent: leading and trailing whitespace is meaningful to the model
+    that produced or consumed it. Matches the Go and JS providers.
+    """
+    if isinstance(value, str):
+        return value if value.strip() else ""
+    return _as_str(value)
+
+
+def _read(value: Any, key: str, default: Any = None) -> Any:
+    if value is None:
+        return default
+
+    if isinstance(value, Mapping):
+        return value.get(key, default)
+
+    if hasattr(value, key):
+        return getattr(value, key)
+
+    getter = getattr(value, "get", None)
+    if callable(getter):
+        try:
+            return getter(key, default)
+        except Exception:  # noqa: BLE001
+            return default
+
+    return default
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    if isinstance(value, Iterable) and not isinstance(value, (str, bytes, Mapping)):
+        return list(value)
+    return []
+
+
+def _as_str(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    return str(value).strip()
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+    return False
+
+
+def _json_bytes(value: Any) -> bytes:
+    return json.dumps(_to_plain(value), separators=(",", ":"), sort_keys=True, default=str).encode("utf-8")
+
+
+def _to_plain(value: Any) -> Any:
+    if value is None:
+        return None
+
+    if isinstance(value, (str, int, float, bool)):
+        return value
+
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+
+    if isinstance(value, Mapping):
+        return {str(key): _to_plain(inner) for key, inner in value.items()}
+
+    if isinstance(value, (list, tuple)):
+        return [_to_plain(inner) for inner in value]
+
+    if is_dataclass(value) and not isinstance(value, type):
+        return {key: _to_plain(inner) for key, inner in asdict(value).items()}
+
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            dumped = model_dump(mode="json")
+        except TypeError:
+            dumped = model_dump()
+        return _to_plain(dumped)
+
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        return _to_plain(to_dict())
+
+    dict_method = getattr(value, "dict", None)
+    if callable(dict_method):
+        return _to_plain(dict_method())
+
+    if hasattr(value, "__dict__"):
+        return _to_plain(vars(value))
+
+    return str(value)

--- a/python/tests/test_payload_mapping.py
+++ b/python/tests/test_payload_mapping.py
@@ -1,0 +1,205 @@
+"""Tests for the shared provider payload mapping module."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agento11y.models import MessageRole, PartKind
+from agento11y.payload_mapping import content_parts, content_text, tool_definitions
+
+
+class TestContentParts:
+    def test_string_content_is_one_text_part(self):
+        parts = content_parts("hello")
+        assert [part.kind for part in parts] == [PartKind.TEXT]
+        assert parts[0].text == "hello"
+
+    def test_blank_content_is_dropped(self):
+        assert content_parts("   ") == []
+        assert content_parts("") == []
+        assert content_parts(None) == []
+        assert content_parts([{"type": "text", "text": "  "}]) == []
+
+    def test_text_is_recorded_unstripped(self):
+        # Whitespace decides emptiness; the text itself is what the model saw.
+        parts = content_parts([{"type": "text", "text": "  padded\n"}])
+        assert parts[0].text == "  padded\n"
+
+    def test_anthropic_blocks_keep_order(self):
+        parts = content_parts(
+            [
+                {"type": "thinking", "thinking": "let me think", "signature": "sig"},
+                {"type": "text", "text": "the weather is"},
+                {"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {"city": "Berlin"}},
+            ],
+            role_hint=MessageRole.ASSISTANT,
+        )
+        assert [part.kind for part in parts] == [PartKind.THINKING, PartKind.TEXT, PartKind.TOOL_CALL]
+        assert parts[0].thinking == "let me think"
+        assert parts[2].tool_call.id == "toolu_1"
+        assert parts[2].tool_call.name == "get_weather"
+        assert parts[2].tool_call.input_json == b'{"city":"Berlin"}'
+
+    def test_redacted_thinking_reads_data(self):
+        parts = content_parts([{"type": "redacted_thinking", "data": "encrypted-blob"}])
+        assert parts[0].kind == PartKind.THINKING
+        assert parts[0].thinking == "encrypted-blob"
+
+    def test_server_and_mcp_tool_use_are_tool_calls(self):
+        parts = content_parts(
+            [
+                {"type": "server_tool_use", "id": "srvtoolu_1", "name": "web_search", "input": {"query": "x"}},
+                {"type": "mcp_tool_use", "id": "mcptoolu_1", "name": "list_files", "input": {}},
+            ]
+        )
+        assert [part.kind for part in parts] == [PartKind.TOOL_CALL, PartKind.TOOL_CALL]
+        assert parts[0].tool_call.name == "web_search"
+        assert parts[1].tool_call.input_json == b"{}"
+
+    def test_tool_result_block(self):
+        parts = content_parts([{"type": "tool_result", "tool_use_id": "toolu_1", "content": "20C", "is_error": False}])
+        assert parts[0].kind == PartKind.TOOL_RESULT
+        assert parts[0].tool_result.tool_call_id == "toolu_1"
+        assert parts[0].tool_result.content == "20C"
+        assert parts[0].tool_result.content_json == b'"20C"'
+        assert parts[0].tool_result.is_error is False
+
+    def test_tool_result_error_and_structured_content(self):
+        parts = content_parts(
+            [
+                {
+                    "type": "tool_result",
+                    "tool_call_id": "call_1",
+                    "name": "get_weather",
+                    "content": [{"type": "text", "text": "boom"}],
+                    "is_error": True,
+                }
+            ]
+        )
+        result = parts[0].tool_result
+        assert result.tool_call_id == "call_1"
+        assert result.name == "get_weather"
+        assert result.content == "boom"
+        assert result.is_error is True
+
+    def test_tool_role_hint_treats_untyped_block_as_result(self):
+        parts = content_parts([{"tool_use_id": "toolu_1", "content": "20C"}], role_hint=MessageRole.TOOL)
+        assert parts[0].kind == PartKind.TOOL_RESULT
+        assert parts[0].tool_result.tool_call_id == "toolu_1"
+
+    def test_openai_and_responses_text_part_types(self):
+        parts = content_parts(
+            [
+                {"type": "input_text", "text": "question"},
+                {"type": "output_text", "text": "answer", "annotations": []},
+                {"type": "refusal", "refusal": "I can't help with that."},
+            ]
+        )
+        assert [part.text for part in parts] == ["question", "answer", "I can't help with that."]
+
+    def test_null_text_part_is_dropped(self):
+        # LiteLLM's chat-to-Responses bridge emits an output_text part with a
+        # null text for a tool-call-only turn.
+        assert content_parts([{"type": "output_text", "text": None, "annotations": []}]) == []
+
+    def test_unknown_block_types_are_skipped(self):
+        parts = content_parts(
+            [
+                {"type": "image", "source": {"type": "base64", "data": "..."}},
+                {"type": "text", "text": "caption"},
+            ]
+        )
+        assert [part.text for part in parts] == ["caption"]
+
+    def test_bare_string_items(self):
+        parts = content_parts(["first", "  ", "second"])
+        assert [part.text for part in parts] == ["first", "second"]
+
+    def test_object_blocks(self):
+        @dataclass
+        class Block:
+            type: str
+            text: str
+
+        parts = content_parts([Block(type="text", text="from object")])
+        assert parts[0].text == "from object"
+
+
+class TestContentText:
+    def test_string_is_stripped(self):
+        assert content_text("  hi  ") == "hi"
+
+    def test_blocks_are_joined_by_newline(self):
+        assert content_text([{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]) == "a\nb"
+
+    def test_nested_content(self):
+        assert content_text({"content": [{"text": "inner"}]}) == "inner"
+
+    def test_bytes_and_none(self):
+        assert content_text(b"raw ") == "raw"
+        assert content_text(None) == ""
+
+
+class TestToolDefinitions:
+    def test_openai_chat_shape(self):
+        tools = tool_definitions(
+            [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get the weather",
+                        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                    },
+                }
+            ]
+        )
+        assert len(tools) == 1
+        assert tools[0].name == "get_weather"
+        assert tools[0].description == "Get the weather"
+        assert tools[0].type == "function"
+        assert b'"city"' in tools[0].input_schema_json
+
+    def test_responses_shape(self):
+        tools = tool_definitions(
+            [
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "description": "Get the weather",
+                    "parameters": {"type": "object"},
+                }
+            ]
+        )
+        assert tools[0].name == "get_weather"
+        assert tools[0].type == "function"
+        assert tools[0].input_schema_json == b'{"type":"object"}'
+
+    def test_anthropic_shape(self):
+        tools = tool_definitions(
+            [
+                {
+                    "name": "get_weather",
+                    "description": "Get the weather",
+                    "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}},
+                }
+            ]
+        )
+        assert tools[0].name == "get_weather"
+        # No type on the wire: a schema-carrying tool is a function.
+        assert tools[0].type == "function"
+        assert b'"city"' in tools[0].input_schema_json
+
+    def test_builtin_tool_keeps_provider_type_and_empty_schema(self):
+        tools = tool_definitions([{"type": "web_search_20250305", "name": "web_search", "max_uses": 3}])
+        assert tools[0].name == "web_search"
+        assert tools[0].type == "web_search_20250305"
+        # Absent schema stays empty rather than the JSON literal null.
+        assert tools[0].input_schema_json == b""
+
+    def test_nameless_tool_is_skipped(self):
+        assert tool_definitions([{"type": "web_search_preview"}, {"type": "function", "function": {}}]) == []
+
+    def test_non_list_input(self):
+        assert tool_definitions(None) == []
+        assert tool_definitions({"name": "not-a-list"}) == []


### PR DESCRIPTION
Adds `/v1/responses` and `/v1/messages` support to the LiteLLM handler.

LiteLLM normalizes Anthropic Messages to a chat response, so it goes through the existing
chat mappers. Responses output is mapped separately (text, reasoning, tool
calls), and its stop reason comes from `status`, like in the OpenAI provider
wrappers.
