### PR TITLE
refactor(sdk-go): move metadata_only stripping into a contentcapture package

### DIFF
--- a/go/agento11y/client.go
+++ b/go/agento11y/client.go
@@ -16,6 +16,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/grafana/agento11y/go/agento11y/contentcapture"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -193,14 +194,19 @@ const (
 	sdkName             = "sdk-go"
 	sdkUserAgentProduct = "agento11y-sdk-go"
 
+	// Some keys below carry user content, and spanAttrErrorCategory carries the
+	// category that replaces redacted error text. Those resolve through
+	// agento11y/contentcapture so that a process reducing this SDK's payloads
+	// reads the same declarations as the emit sites. The remaining keys are
+	// metadata and are declared here.
 	spanAttrGenerationID           = "agento11y.generation.id"
 	spanAttrConversationID         = "gen_ai.conversation.id"
-	spanAttrConversationTitle      = "agento11y.conversation.title"
+	spanAttrConversationTitle      = contentcapture.ConversationTitleKey
 	spanAttrUserID                 = "user.id"
 	spanAttrAgentName              = "gen_ai.agent.name"
 	spanAttrAgentVersion           = "gen_ai.agent.version"
 	spanAttrErrorType              = "error.type"
-	spanAttrErrorCategory          = "error.category"
+	spanAttrErrorCategory          = contentcapture.ErrorCategoryAttributeKey
 	spanAttrOperationName          = "gen_ai.operation.name"
 	spanAttrProviderName           = "gen_ai.provider.name"
 	spanAttrRequestModel           = "gen_ai.request.model"
@@ -216,7 +222,7 @@ const (
 	spanAttrInputTokens            = "gen_ai.usage.input_tokens"
 	spanAttrOutputTokens           = "gen_ai.usage.output_tokens"
 	spanAttrEmbeddingInputCount    = "gen_ai.embeddings.input_count"
-	spanAttrEmbeddingInputTexts    = "gen_ai.embeddings.input_texts"
+	spanAttrEmbeddingInputTexts    = contentcapture.EmbeddingInputTextsAttributeKey
 	spanAttrEmbeddingDimCount      = "gen_ai.embeddings.dimension.count"
 	spanAttrRequestEncodingFormats = "gen_ai.request.encoding_formats"
 	spanAttrCacheReadTokens        = "gen_ai.usage.cache_read_input_tokens"
@@ -225,9 +231,9 @@ const (
 	spanAttrToolName               = "gen_ai.tool.name"
 	spanAttrToolCallID             = "gen_ai.tool.call.id"
 	spanAttrToolType               = "gen_ai.tool.type"
-	spanAttrToolDescription        = "gen_ai.tool.description"
-	spanAttrToolCallArguments      = "gen_ai.tool.call.arguments"
-	spanAttrToolCallResult         = "gen_ai.tool.call.result"
+	spanAttrToolDescription        = contentcapture.ToolDescriptionAttributeKey
+	spanAttrToolCallArguments      = contentcapture.ToolCallArgumentsAttributeKey
+	spanAttrToolCallResult         = contentcapture.ToolCallResultAttributeKey
 	spanAttrTagPrefix              = "agento11y.tag."
 
 	metricOperationDuration     = "gen_ai.client.operation.duration"
@@ -969,7 +975,7 @@ func (r *GenerationRecorder) End() {
 	if callErr != nil {
 		callErrorCategory = classifyErrorCategory(callErr, false)
 		if callErrorCategory == "" {
-			callErrorCategory = "sdk_error"
+			callErrorCategory = contentcapture.StrippedCallError
 		}
 	}
 
@@ -1119,9 +1125,9 @@ func syncCanonicalMetadataMirrors(g *Generation) {
 		delete(g.Metadata, spanAttrConversationTitle)
 	}
 	if g.CallError != "" {
-		g.Metadata["call_error"] = g.CallError
+		g.Metadata[metadataKeyCallError] = g.CallError
 	} else {
-		delete(g.Metadata, "call_error")
+		delete(g.Metadata, metadataKeyCallError)
 	}
 }
 
@@ -1494,7 +1500,7 @@ func (r *GenerationRecorder) normalizeGeneration(raw Generation, completedAt tim
 		if g.Metadata == nil {
 			g.Metadata = map[string]any{}
 		}
-		g.Metadata["call_error"] = callErr.Error()
+		g.Metadata[metadataKeyCallError] = callErr.Error()
 	}
 
 	g.Usage = g.Usage.Normalize()

--- a/go/agento11y/content_capture.go
+++ b/go/agento11y/content_capture.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/grafana/agento11y/go/agento11y/contentcapture"
 	"github.com/grafana/agento11y/go/agento11y/model"
 )
 
@@ -33,7 +34,10 @@ const (
 	//
 	// Note: user-provided Metadata and Tags are NOT stripped — callers are
 	// responsible for ensuring these maps do not contain sensitive content
-	// when using MetadataOnly mode.
+	// when using MetadataOnly mode. The exception is the metadata keys the SDK
+	// itself mirrors content into. The call error and the conversation title,
+	// under both the current and the pre-rename spelling, are removed no matter
+	// who wrote them.
 	ContentCaptureModeMetadataOnly
 	// ContentCaptureModeFullWithMetadataSpans splits the proto and span paths
 	// for generation content. Use this mode when the gRPC ingest destination is
@@ -61,7 +65,10 @@ const (
 const (
 	// Pinned to the model package so the shared validator and SDK stripping logic stay
 	// in lockstep.
-	metadataKeyContentCaptureMode                = model.MetadataKeyContentCaptureMode
+	metadataKeyContentCaptureMode = model.MetadataKeyContentCaptureMode
+	// Pinned to the contentcapture package. See its package doc for why the
+	// policy lives there.
+	metadataKeyCallError                         = contentcapture.MetadataKeyCallError
 	contentCaptureModeValueMetaOnly              = model.ContentCaptureModeMetadataOnly
 	contentCaptureModeValueFull                  = "full"
 	contentCaptureModeValueNoToolContent         = "no_tool_content"
@@ -115,50 +122,94 @@ func stampContentCaptureMetadata(g *Generation, mode ContentCaptureMode) {
 // message structure (roles, part kinds), tool names/IDs, usage, timing, and
 // all other metadata fields. errorCategory is the classified error category
 // (e.g. "rate_limit", "timeout") used to replace the raw CallError text.
+//
+// What counts as content lives in agento11y/contentcapture, shared with the
+// wire-proto shape a forwarder reduces.
 func stripContent(g *Generation, errorCategory string) {
-	g.SystemPrompt = ""
-	g.Artifacts = nil
+	contentcapture.Strip(generationTarget{g: g}, errorCategory)
+}
 
-	if g.CallError != "" {
-		if errorCategory != "" {
-			g.CallError = errorCategory
-		} else {
-			g.CallError = "sdk_error"
-		}
-	}
-	delete(g.Metadata, "call_error")
+// generationTarget adapts the public Generation struct to
+// contentcapture.Target.
+type generationTarget struct {
+	g *Generation
+}
 
-	g.ConversationTitle = ""
-	delete(g.Metadata, spanAttrConversationTitle)
+func (t generationTarget) ClearSystemPrompt() { t.g.SystemPrompt = "" }
 
-	for i := range g.Input {
-		stripMessageContent(&g.Input[i])
+func (t generationTarget) ClearArtifacts() { t.g.Artifacts = nil }
+
+func (t generationTarget) ClearConversationTitle() { t.g.ConversationTitle = "" }
+
+func (t generationTarget) CallError() string { return t.g.CallError }
+
+func (t generationTarget) SetCallError(callError string) { t.g.CallError = callError }
+
+func (t generationTarget) DeleteMetadata(key string) { delete(t.g.Metadata, key) }
+
+// NormalizeMetadata is a no-op on this shape: codec.ToProto encodes an emptied
+// metadata map as an unset Struct, so there is nothing to reconcile.
+func (t generationTarget) NormalizeMetadata() {}
+
+func (t generationTarget) EachPart(fn func(contentcapture.PartTarget)) {
+	for i := range t.g.Input {
+		eachStructPart(&t.g.Input[i], fn)
 	}
-	for i := range g.Output {
-		stripMessageContent(&g.Output[i])
-	}
-	for i := range g.Tools {
-		g.Tools[i].Description = ""
-		g.Tools[i].InputSchema = nil
+	for i := range t.g.Output {
+		eachStructPart(&t.g.Output[i], fn)
 	}
 }
 
-func stripMessageContent(m *Message) {
-	for i := range m.Parts {
-		m.Parts[i].Text = ""
-		m.Parts[i].Thinking = ""
-		if m.Parts[i].ToolCall != nil {
-			m.Parts[i].ToolCall.InputJSON = nil
-		}
-		if m.Parts[i].ToolResult != nil {
-			m.Parts[i].ToolResult.Content = ""
-			m.Parts[i].ToolResult.ContentJSON = nil
-		}
-		if m.Parts[i].Media != nil {
-			m.Parts[i].Media.URL = ""
-		}
+func (t generationTarget) EachTool(fn func(contentcapture.ToolTarget)) {
+	for i := range t.g.Tools {
+		fn(toolTarget{tool: &t.g.Tools[i]})
 	}
 }
+
+func eachStructPart(message *Message, fn func(contentcapture.PartTarget)) {
+	for i := range message.Parts {
+		fn(partTarget{part: &message.Parts[i]})
+	}
+}
+
+// partTarget adapts one Part to contentcapture.PartTarget. A struct part
+// carries each payload in its own field, so a clear that does not apply to the
+// part writes a zero value over a zero value.
+type partTarget struct {
+	part *Part
+}
+
+func (t partTarget) ClearText() { t.part.Text = "" }
+
+func (t partTarget) ClearThinking() { t.part.Thinking = "" }
+
+func (t partTarget) ClearToolCallInput() {
+	if t.part.ToolCall != nil {
+		t.part.ToolCall.InputJSON = nil
+	}
+}
+
+func (t partTarget) ClearToolResult() {
+	if t.part.ToolResult != nil {
+		t.part.ToolResult.Content = ""
+		t.part.ToolResult.ContentJSON = nil
+	}
+}
+
+func (t partTarget) ClearMediaURL() {
+	if t.part.Media != nil {
+		t.part.Media.URL = ""
+	}
+}
+
+// toolTarget adapts one ToolDefinition to contentcapture.ToolTarget.
+type toolTarget struct {
+	tool *ToolDefinition
+}
+
+func (t toolTarget) ClearDescription() { t.tool.Description = "" }
+
+func (t toolTarget) ClearInputSchema() { t.tool.InputSchema = nil }
 
 // resolveToolContentCaptureMode resolves the effective content capture mode for
 // a tool execution from the per-tool override, parent generation context, and

--- a/go/agento11y/contentcapture/contentcapture.go
+++ b/go/agento11y/contentcapture/contentcapture.go
@@ -1,0 +1,365 @@
+// Package contentcapture owns the metadata_only content-capture policy: which
+// generation fields carry user content, which OTel span attribute keys carry
+// user content, and the protocol values that replace removed content.
+//
+// The policy is one algorithm, Strip, written against the Target interfaces
+// instead of a concrete generation type. Content-bearing generations exist in
+// two shapes. The SDK reduces the public agento11y.Generation struct before
+// encoding it. A forwarder such as the local daemon never runs through that
+// path: it launches the agent with a full content-capture mode so the local
+// viewer keeps everything, and reduces the copy it sends on at forward time,
+// when all it holds is the wire proto. Each shape supplies a small adapter,
+// while the field list, the traversal, the metadata keys, and the
+// error-category rule live here. StripGeneration is the entry point for the
+// proto shape.
+//
+// Adding a content-bearing field means adding a method to Target or
+// PartTarget, which does not compile until every adapter handles it.
+//
+// Strip does not stamp model.MetadataKeyContentCaptureMode. The SDK stamps
+// every mode before reducing, while a forwarder has to overwrite an incoming
+// "full" stamp, so the relabel stays with the caller.
+package contentcapture
+
+import (
+	agento11yv1 "github.com/grafana/agento11y/go/proto/agento11y/v1"
+)
+
+// Keys whose values carry user content. IsTraceContentAttribute returns true
+// for every key in this block and for nothing else;
+// TestContentKeyBlockMatchesPredicate reads this file and fails if the two
+// disagree, because adding a key here and forgetting the predicate compiles
+// and leaves a content attribute relayed under a reduced mode.
+//
+// A key that carries no content belongs in the block below.
+//
+//contentcapture:content-keys
+const (
+	// ConversationTitleKey is the generation metadata key, and the span
+	// attribute key, that carries the conversation title. The proto
+	// Generation has no conversation_title field, so an SDK title reaches the
+	// wire only through this metadata mirror and the strip deletes the key
+	// rather than clearing a field.
+	ConversationTitleKey = "agento11y.conversation.title"
+
+	// LegacyConversationTitleKey is the pre-rename spelling of
+	// ConversationTitleKey. Nothing in this module writes it, but an older
+	// installed exporter (@grafana/agento11y-pi, @grafana/agento11y-opencode,
+	// or a sigil-era SDK) can still send it to a current forwarder, and a
+	// caller can put it in user metadata, so both spellings are declared here
+	// and both are stripped.
+	LegacyConversationTitleKey = "sigil.conversation.title"
+
+	// EmbeddingInputTextsAttributeKey holds the raw embedding input texts.
+	EmbeddingInputTextsAttributeKey = "gen_ai.embeddings.input_texts"
+
+	// ToolDescriptionAttributeKey holds a tool's description text.
+	ToolDescriptionAttributeKey = "gen_ai.tool.description"
+
+	// ToolCallArgumentsAttributeKey holds the arguments a tool was called with.
+	ToolCallArgumentsAttributeKey = "gen_ai.tool.call.arguments"
+
+	// ToolCallResultAttributeKey holds the value a tool call returned.
+	ToolCallResultAttributeKey = "gen_ai.tool.call.result"
+)
+
+// Protocol values that must not be treated as content. A forwarder that
+// deleted the error category or the stripped-error marker would drop the last
+// signal that a call failed, so these keys and values stay out of the block
+// above even though they sit next to redacted content.
+//
+//contentcapture:non-content-values
+const (
+	// ExceptionEventName is the span event name the OTel SDK's RecordError
+	// emits. Its exception.message and exception.stacktrace attributes can
+	// carry raw provider text, so a reduced forward drops the whole event.
+	ExceptionEventName = "exception"
+
+	// ErrorCategoryAttributeKey is the span attribute holding the classified
+	// error category. The category carries no content, so it is the
+	// replacement for a redacted error status message.
+	ErrorCategoryAttributeKey = "error.category"
+
+	// MetadataKeyCallError is the metadata key mirroring
+	// Generation.call_error, which the SDK writes alongside the field. The key
+	// is not a content attribute, but its value is raw provider text, so the
+	// strip deletes the mirror and replaces the field.
+	MetadataKeyCallError = "call_error"
+
+	// StrippedCallError replaces a generation's raw call error when no
+	// classified category is available.
+	StrippedCallError = "sdk_error"
+)
+
+// IsTraceContentAttribute reports whether an OTel span attribute key carries
+// user content and therefore must not leave the host under a reduced
+// content-capture mode. Its cases are exactly the content-key block above.
+// Exposing a predicate instead of a set keeps callers from adding or removing
+// keys.
+//
+// Generation prompt and response text never reaches spans; it travels in the
+// proto generation export.
+func IsTraceContentAttribute(key string) bool {
+	switch key {
+	case ConversationTitleKey,
+		LegacyConversationTitleKey,
+		EmbeddingInputTextsAttributeKey,
+		ToolDescriptionAttributeKey,
+		ToolCallArgumentsAttributeKey,
+		ToolCallResultAttributeKey:
+		return true
+	default:
+		return false
+	}
+}
+
+// Target is one generation shape Strip can reduce. An implementation adapts a
+// concrete generation type and holds no policy of its own, so a method that
+// has no meaning for a shape is a documented no-op rather than a branch in
+// Strip.
+type Target interface {
+	// ClearSystemPrompt clears the system prompt.
+	ClearSystemPrompt()
+
+	// ClearArtifacts drops the raw request and response artifacts.
+	ClearArtifacts()
+
+	// ClearConversationTitle clears a conversation title held in a field. The
+	// wire proto has no such field: a title reaches it only through the
+	// ConversationTitleKey metadata mirror, which Strip deletes on its own, so
+	// the proto shape implements this as a no-op.
+	ClearConversationTitle()
+
+	// CallError returns the current call error. Strip reads before writing
+	// because an absent call error has to stay absent.
+	CallError() string
+
+	// SetCallError replaces the call error with a value that carries no
+	// content.
+	SetCallError(callError string)
+
+	// DeleteMetadata removes one metadata key, and does nothing when the key
+	// is absent.
+	DeleteMetadata(key string)
+
+	// NormalizeMetadata runs after the metadata deletions. It reconciles an
+	// emptied metadata container with the way the encoder represents an empty
+	// one, so a generation reduced in either shape encodes to the same bytes.
+	NormalizeMetadata()
+
+	// EachPart calls fn for every part of every input and output message. No
+	// message-level field carries content, so Strip never handles a message
+	// itself.
+	EachPart(fn func(PartTarget))
+
+	// EachTool calls fn for every tool definition.
+	EachTool(fn func(ToolTarget))
+}
+
+// PartTarget is one message part. Strip calls every method on every part: a
+// part holds one kind of payload, and the calls that do not apply to it are
+// no-ops. A new content-bearing payload kind belongs here.
+type PartTarget interface {
+	// ClearText clears message text.
+	ClearText()
+
+	// ClearThinking clears reasoning text.
+	ClearThinking()
+
+	// ClearToolCallInput clears the arguments a tool was called with.
+	ClearToolCallInput()
+
+	// ClearToolResult clears both the text and the JSON form of a tool result.
+	ClearToolResult()
+
+	// ClearMediaURL clears a media URL, which can hold the bytes inline as a
+	// data: URI.
+	ClearMediaURL()
+}
+
+// ToolTarget is one tool definition.
+type ToolTarget interface {
+	// ClearDescription clears the description text.
+	ClearDescription()
+
+	// ClearInputSchema clears the input schema, whose property names and
+	// descriptions are authored text.
+	ClearInputSchema()
+}
+
+// Strip reduces target to metadata_only: it clears the system prompt, raw
+// artifacts, per-part text, thinking, tool arguments, tool results and media
+// payloads, tool descriptions and schemas, and the content-bearing metadata
+// mirrors. Part and message structure, roles, tool names and IDs, usage,
+// timing, tags, and all other metadata survive.
+//
+// errorCategory replaces a non-empty call error. Pass the classified category
+// ("rate_limit", "timeout") when one is available, or "" to fall back to
+// StrippedCallError. An absent call error stays absent.
+func Strip(target Target, errorCategory string) {
+	target.ClearSystemPrompt()
+	target.ClearArtifacts()
+
+	if target.CallError() != "" {
+		if errorCategory != "" {
+			target.SetCallError(errorCategory)
+		} else {
+			target.SetCallError(StrippedCallError)
+		}
+	}
+	target.DeleteMetadata(MetadataKeyCallError)
+
+	target.ClearConversationTitle()
+	target.DeleteMetadata(ConversationTitleKey)
+	target.DeleteMetadata(LegacyConversationTitleKey)
+
+	target.EachPart(func(part PartTarget) {
+		part.ClearText()
+		part.ClearThinking()
+		part.ClearToolCallInput()
+		part.ClearToolResult()
+		part.ClearMediaURL()
+	})
+
+	target.EachTool(func(tool ToolTarget) {
+		tool.ClearDescription()
+		tool.ClearInputSchema()
+	})
+
+	target.NormalizeMetadata()
+}
+
+// StripGeneration reduces a wire generation to metadata_only in place. See
+// Strip for what it clears and for the errorCategory argument.
+//
+// A caller that stamps the content-capture mode afterwards has to handle an
+// unset Metadata, because the strip leaves it unset when content keys were all
+// it held. A write through g.GetMetadata().GetFields() would assign to a nil
+// map.
+//
+// It is safe to call with a nil generation.
+func StripGeneration(g *agento11yv1.Generation, errorCategory string) {
+	if g == nil {
+		return
+	}
+	Strip(protoGeneration{g: g}, errorCategory)
+}
+
+// protoGeneration adapts the wire Generation to Target.
+type protoGeneration struct {
+	g *agento11yv1.Generation
+}
+
+func (t protoGeneration) ClearSystemPrompt() { t.g.SystemPrompt = "" }
+
+func (t protoGeneration) ClearArtifacts() { t.g.RawArtifacts = nil }
+
+// ClearConversationTitle is a no-op on the wire shape: the title lives only in
+// metadata. See Target.
+func (t protoGeneration) ClearConversationTitle() {}
+
+func (t protoGeneration) CallError() string { return t.g.GetCallError() }
+
+func (t protoGeneration) SetCallError(callError string) { t.g.CallError = callError }
+
+// DeleteMetadata needs no guard for an unset Struct: delete on a nil map is a
+// no-op, and NormalizeMetadata handles the empty case.
+func (t protoGeneration) DeleteMetadata(key string) {
+	delete(t.g.GetMetadata().GetFields(), key)
+}
+
+func (t protoGeneration) NormalizeMetadata() {
+	if len(t.g.GetMetadata().GetFields()) == 0 {
+		// codec.ToProto encodes an empty metadata map as an unset Struct, so
+		// clearing an emptied Struct keeps this shape's output identical to
+		// the struct shape's encoding. A forwarder decoding an incoming
+		// "metadata": {} from another exporter gets the same normalization.
+		t.g.Metadata = nil
+	}
+}
+
+func (t protoGeneration) EachPart(fn func(PartTarget)) {
+	for _, message := range t.g.GetInput() {
+		eachProtoPart(message, fn)
+	}
+	for _, message := range t.g.GetOutput() {
+		eachProtoPart(message, fn)
+	}
+}
+
+func (t protoGeneration) EachTool(fn func(ToolTarget)) {
+	for _, tool := range t.g.GetTools() {
+		if tool == nil {
+			continue
+		}
+		fn(protoTool{tool: tool})
+	}
+}
+
+// eachProtoPart visits the parts of one message. GetParts on a nil message
+// returns nil, so a nil message needs no guard of its own.
+func eachProtoPart(message *agento11yv1.Message, fn func(PartTarget)) {
+	for _, part := range message.GetParts() {
+		if part == nil {
+			continue
+		}
+		fn(protoPart{part: part})
+	}
+}
+
+// protoPart adapts one wire Part to PartTarget. The payload is a oneof, so
+// each method checks that the part holds the kind it clears.
+//
+// A typed-nil oneof wrapper is a non-nil interface holding a nil pointer, so
+// it satisfies its type assertion and each method has to check the wrapper
+// before writing through it. No decoder produces one; the guards keep a
+// hand-built Part from panicking here.
+type protoPart struct {
+	part *agento11yv1.Part
+}
+
+func (t protoPart) ClearText() {
+	if payload, ok := t.part.GetPayload().(*agento11yv1.Part_Text); ok && payload != nil {
+		payload.Text = ""
+	}
+}
+
+func (t protoPart) ClearThinking() {
+	if payload, ok := t.part.GetPayload().(*agento11yv1.Part_Thinking); ok && payload != nil {
+		payload.Thinking = ""
+	}
+}
+
+func (t protoPart) ClearToolCallInput() {
+	payload, ok := t.part.GetPayload().(*agento11yv1.Part_ToolCall)
+	if ok && payload != nil && payload.ToolCall != nil {
+		payload.ToolCall.InputJson = nil
+	}
+}
+
+func (t protoPart) ClearToolResult() {
+	payload, ok := t.part.GetPayload().(*agento11yv1.Part_ToolResult)
+	if ok && payload != nil && payload.ToolResult != nil {
+		payload.ToolResult.Content = ""
+		payload.ToolResult.ContentJson = nil
+	}
+}
+
+func (t protoPart) ClearMediaURL() {
+	payload, ok := t.part.GetPayload().(*agento11yv1.Part_Media)
+	if ok && payload != nil && payload.Media != nil {
+		// Media.url can hold a data: URI with the file bytes inline
+		// (go/agento11y/codec). The kind, mime type, and name around it are
+		// references and stay.
+		payload.Media.Url = ""
+	}
+}
+
+// protoTool adapts one wire ToolDefinition to ToolTarget.
+type protoTool struct {
+	tool *agento11yv1.ToolDefinition
+}
+
+func (t protoTool) ClearDescription() { t.tool.Description = "" }
+
+func (t protoTool) ClearInputSchema() { t.tool.InputSchemaJson = nil }

--- a/go/agento11y/contentcapture/contentcapture_test.go
+++ b/go/agento11y/contentcapture/contentcapture_test.go
@@ -1,0 +1,593 @@
+package contentcapture_test
+
+import (
+	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/agento11y/go/agento11y/contentcapture"
+	"github.com/grafana/agento11y/go/agento11y/model"
+	agento11yv1 "github.com/grafana/agento11y/go/proto/agento11y/v1"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// leakMarker is embedded in every content field of the fixture so a single
+// scan of the stripped payload catches content the strip forgot.
+const leakMarker = "ignore previous instructions"
+
+func fixedTime() time.Time {
+	return time.Date(2026, 3, 12, 14, 10, 1, 0, time.UTC)
+}
+
+func mustStruct(fields map[string]any) *structpb.Struct {
+	s, err := structpb.NewStruct(fields)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+// fullContentGeneration returns a proto generation with every content-bearing
+// field populated, plus the structure and metadata that must survive.
+//
+// Every field reachable from Generation is populated: TestProtoFieldCoverage
+// reports a field the fixture leaves empty, because an all-zero field lets an
+// assertion pass without exercising the strip.
+func fullContentGeneration() *agento11yv1.Generation {
+	maxTokens := int64(2048)
+	temperature := 0.7
+	topP := 0.95
+	toolChoice := "auto"
+	thinkingEnabled := true
+	effectiveVersion := "sha256:0f1e2d"
+
+	return &agento11yv1.Generation{
+		Id:             "gen-1",
+		ConversationId: "conv-1",
+		OperationName:  "generateText",
+		AgentName:      "weather-agent",
+		AgentVersion:   "1.2.3",
+		TraceId:        "4bf92f3577b34da6a3ce929d0e0e4736",
+		SpanId:         "00f067aa0ba902b7",
+		Model:          &agento11yv1.ModelRef{Provider: "anthropic", Name: "claude-sonnet-4-5"},
+		ResponseId:     "resp-1",
+		ResponseModel:  "claude-sonnet-4-5-20260101",
+		Mode:           agento11yv1.GenerationMode_GENERATION_MODE_SYNC,
+		SystemPrompt:   "You are helpful. " + leakMarker,
+		Input: []*agento11yv1.Message{
+			{
+				Role: agento11yv1.MessageRole_MESSAGE_ROLE_USER,
+				Name: "alex",
+				Parts: []*agento11yv1.Part{
+					{
+						Payload:  &agento11yv1.Part_Text{Text: "What is the weather? " + leakMarker},
+						Metadata: &agento11yv1.PartMetadata{ProviderType: "text"},
+					},
+					{Payload: &agento11yv1.Part_Media{Media: &agento11yv1.Media{
+						Kind:     "image",
+						Url:      "data:image/png;base64," + leakMarker,
+						MimeType: "image/png",
+						Name:     "map.png",
+					}}},
+				},
+			},
+			{
+				Role: agento11yv1.MessageRole_MESSAGE_ROLE_TOOL,
+				Parts: []*agento11yv1.Part{
+					{Payload: &agento11yv1.Part_ToolResult{ToolResult: &agento11yv1.ToolResult{
+						ToolCallId:  "call_1",
+						Name:        "weather",
+						Content:     "sunny 18C " + leakMarker,
+						ContentJson: []byte(`{"temp":"` + leakMarker + `"}`),
+						IsError:     true,
+					}}},
+				},
+			},
+		},
+		Output: []*agento11yv1.Message{
+			{
+				Role: agento11yv1.MessageRole_MESSAGE_ROLE_ASSISTANT,
+				Parts: []*agento11yv1.Part{
+					{Payload: &agento11yv1.Part_Thinking{Thinking: "let me think " + leakMarker}},
+					{Payload: &agento11yv1.Part_ToolCall{ToolCall: &agento11yv1.ToolCall{
+						Id:        "call_1",
+						Name:      "weather",
+						InputJson: []byte(`{"city":"` + leakMarker + `"}`),
+					}}},
+					{Payload: &agento11yv1.Part_Text{Text: "It is 18C in Paris. " + leakMarker}},
+				},
+			},
+		},
+		Tools: []*agento11yv1.ToolDefinition{
+			{
+				Name:            "weather",
+				Description:     "Get weather info " + leakMarker,
+				Type:            "function",
+				InputSchemaJson: []byte(`{"type":"object","title":"` + leakMarker + `"}`),
+				Deferred:        true,
+			},
+		},
+		Usage: &agento11yv1.TokenUsage{
+			InputTokens:           120,
+			OutputTokens:          42,
+			TotalTokens:           162,
+			CacheReadInputTokens:  16,
+			CacheWriteInputTokens: 8,
+			ReasoningTokens:       4,
+		},
+		StopReason:  "end_turn",
+		StartedAt:   timestamppb.New(fixedTime().Add(-time.Second)),
+		CompletedAt: timestamppb.New(fixedTime()),
+		Tags:        map[string]string{"env": "test"},
+		RawArtifacts: []*agento11yv1.Artifact{
+			{
+				Kind:        agento11yv1.ArtifactKind_ARTIFACT_KIND_REQUEST,
+				Name:        "request.json",
+				ContentType: "application/json",
+				Payload:     []byte(`{"prompt":"` + leakMarker + `"}`),
+				RecordId:    "rec-1",
+				Uri:         "https://example.invalid/artifacts/rec-1",
+			},
+		},
+		CallError:           "provider refused: " + leakMarker,
+		MaxTokens:           &maxTokens,
+		Temperature:         &temperature,
+		TopP:                &topP,
+		ToolChoice:          &toolChoice,
+		ThinkingEnabled:     &thinkingEnabled,
+		ParentGenerationIds: []string{"gen-parent-1"},
+		EffectiveVersion:    &effectiveVersion,
+		Metadata: mustStruct(map[string]any{
+			"call_error":                        "provider refused: " + leakMarker,
+			"agento11y.conversation.title":      "Weather chat " + leakMarker,
+			"sigil.conversation.title":          "Weather chat " + leakMarker,
+			"user.key":                          "keep me",
+			"agento11y.sdk.content_capture":     "not the mode key",
+			model.MetadataKeyContentCaptureMode: model.ContentCaptureModeMetadataOnly,
+		}),
+	}
+}
+
+func TestStripGeneration_ClearsContentKeepsStructure(t *testing.T) {
+	g := fullContentGeneration()
+	contentcapture.StripGeneration(g, "")
+
+	if g.GetSystemPrompt() != "" {
+		t.Errorf("system_prompt not cleared: %q", g.GetSystemPrompt())
+	}
+	if g.GetRawArtifacts() != nil {
+		t.Errorf("raw_artifacts not cleared: %v", g.GetRawArtifacts())
+	}
+
+	if got := len(g.GetInput()); got != 2 {
+		t.Fatalf("input message count = %d, want 2", got)
+	}
+	if got := len(g.GetOutput()); got != 1 {
+		t.Fatalf("output message count = %d, want 1", got)
+	}
+	if got := len(g.GetInput()[0].GetParts()); got != 2 {
+		t.Fatalf("input[0] part count = %d, want 2", got)
+	}
+	if got := len(g.GetOutput()[0].GetParts()); got != 3 {
+		t.Fatalf("output[0] part count = %d, want 3", got)
+	}
+
+	userText := g.GetInput()[0].GetParts()[0]
+	if userText.GetText() != "" {
+		t.Errorf("input text not cleared: %q", userText.GetText())
+	}
+	if _, ok := userText.GetPayload().(*agento11yv1.Part_Text); !ok {
+		t.Errorf("input text part lost its payload kind: %T", userText.GetPayload())
+	}
+
+	media := g.GetInput()[0].GetParts()[1].GetMedia()
+	if media.GetUrl() != "" {
+		t.Errorf("media url not cleared: %q", media.GetUrl())
+	}
+	if media.GetMimeType() != "image/png" || media.GetKind() != "image" || media.GetName() != "map.png" {
+		t.Errorf("media reference fields changed: %v", media)
+	}
+
+	result := g.GetInput()[1].GetParts()[0].GetToolResult()
+	if result.GetContent() != "" || result.GetContentJson() != nil {
+		t.Errorf("tool result content not cleared: %v", result)
+	}
+	if result.GetToolCallId() != "call_1" || result.GetName() != "weather" || !result.GetIsError() {
+		t.Errorf("tool result structure changed: %v", result)
+	}
+
+	if thinking := g.GetOutput()[0].GetParts()[0]; thinking.GetThinking() != "" {
+		t.Errorf("thinking not cleared: %q", thinking.GetThinking())
+	}
+	call := g.GetOutput()[0].GetParts()[1].GetToolCall()
+	if call.GetInputJson() != nil {
+		t.Errorf("tool call input_json not cleared: %s", call.GetInputJson())
+	}
+	if call.GetName() != "weather" || call.GetId() != "call_1" {
+		t.Errorf("tool call structure changed: %v", call)
+	}
+
+	tool := g.GetTools()[0]
+	if tool.GetDescription() != "" || tool.GetInputSchemaJson() != nil {
+		t.Errorf("tool definition content not cleared: %v", tool)
+	}
+	if tool.GetName() != "weather" || tool.GetType() != "function" {
+		t.Errorf("tool definition structure changed: %v", tool)
+	}
+
+	if got := g.GetUsage().GetTotalTokens(); got != 162 {
+		t.Errorf("usage.total_tokens = %d, want 162", got)
+	}
+	if g.GetStopReason() != "end_turn" {
+		t.Errorf("stop_reason = %q, want end_turn", g.GetStopReason())
+	}
+	if !g.GetCompletedAt().AsTime().Equal(fixedTime()) {
+		t.Errorf("completed_at = %v, want %v", g.GetCompletedAt().AsTime(), fixedTime())
+	}
+
+	// One scan over the encoded payload catches any content field the
+	// assertions above do not name.
+	raw, err := proto.Marshal(g)
+	if err != nil {
+		t.Fatalf("marshal stripped generation: %v", err)
+	}
+	if bytes.Contains(raw, []byte(leakMarker)) {
+		t.Errorf("stripped generation still contains the leak marker: %s", raw)
+	}
+}
+
+func TestStripGeneration_CallError(t *testing.T) {
+	tests := []struct {
+		name      string
+		callError string
+		category  string
+		want      string
+	}{
+		{
+			name:      "category replaces raw error",
+			callError: "429 too many requests for prompt " + leakMarker,
+			category:  "rate_limit",
+			want:      "rate_limit",
+		},
+		{
+			name:      "no category falls back to sdk_error",
+			callError: "429 too many requests for prompt " + leakMarker,
+			category:  "",
+			want:      contentcapture.StrippedCallError,
+		},
+		{
+			name:      "empty error stays empty",
+			callError: "",
+			category:  "rate_limit",
+			want:      "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &agento11yv1.Generation{CallError: tc.callError}
+			contentcapture.StripGeneration(g, tc.category)
+			if got := g.GetCallError(); got != tc.want {
+				t.Errorf("call_error = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStripGeneration_Metadata(t *testing.T) {
+	g := fullContentGeneration()
+	contentcapture.StripGeneration(g, "rate_limit")
+
+	fields := g.GetMetadata().GetFields()
+	for _, key := range []string{
+		contentcapture.MetadataKeyCallError,
+		contentcapture.ConversationTitleKey,
+		contentcapture.LegacyConversationTitleKey,
+	} {
+		if _, present := fields[key]; present {
+			t.Errorf("metadata key %q survived the strip", key)
+		}
+	}
+
+	if got := fields["user.key"].GetStringValue(); got != "keep me" {
+		t.Errorf("metadata user.key = %q, want %q", got, "keep me")
+	}
+	if got := fields["agento11y.sdk.content_capture"].GetStringValue(); got != "not the mode key" {
+		t.Errorf("unrelated metadata key was rewritten: %q", got)
+	}
+}
+
+// TestStripGeneration_DoesNotStampContentCaptureMode pins the split with the
+// caller: the strip itself never writes the mode marker.
+func TestStripGeneration_DoesNotStampContentCaptureMode(t *testing.T) {
+	const modeKey = "agento11y.sdk.content_capture_mode"
+
+	t.Run("absent stays absent", func(t *testing.T) {
+		g := &agento11yv1.Generation{
+			SystemPrompt: leakMarker,
+			Metadata:     mustStruct(map[string]any{"user.key": "keep me"}),
+		}
+		contentcapture.StripGeneration(g, "")
+		if _, present := g.GetMetadata().GetFields()[modeKey]; present {
+			t.Errorf("%s was stamped by the strip", modeKey)
+		}
+	})
+
+	t.Run("incoming full stamp is left alone", func(t *testing.T) {
+		g := &agento11yv1.Generation{
+			SystemPrompt: leakMarker,
+			Metadata:     mustStruct(map[string]any{modeKey: "full"}),
+		}
+		contentcapture.StripGeneration(g, "")
+		if got := g.GetMetadata().GetFields()[modeKey].GetStringValue(); got != "full" {
+			t.Errorf("%s = %q, want the caller's value to be untouched", modeKey, got)
+		}
+	})
+
+	t.Run("metadata holding only content keys is cleared", func(t *testing.T) {
+		g := &agento11yv1.Generation{
+			Metadata: mustStruct(map[string]any{contentcapture.ConversationTitleKey: leakMarker}),
+		}
+		contentcapture.StripGeneration(g, "")
+		if g.GetMetadata() != nil {
+			t.Errorf("emptied metadata struct survived: %v", g.GetMetadata())
+		}
+	})
+}
+
+// TestStripGeneration_NormalizesEmptyMetadata covers an input only a forwarder
+// sees: another exporter can send "metadata": {}, which decodes to a set but
+// empty Struct. The strip normalizes it to unset so both implementations still
+// encode to the same bytes.
+func TestStripGeneration_NormalizesEmptyMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata *structpb.Struct
+	}{
+		{name: "empty struct", metadata: &structpb.Struct{}},
+		{name: "struct with an empty field map", metadata: &structpb.Struct{Fields: map[string]*structpb.Value{}}},
+		{name: "unset", metadata: nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &agento11yv1.Generation{Id: "g1", Metadata: tc.metadata}
+			contentcapture.StripGeneration(g, "")
+			if g.GetMetadata() != nil {
+				t.Errorf("metadata = %v, want unset", g.GetMetadata())
+			}
+		})
+	}
+}
+
+func TestIsTraceContentAttribute(t *testing.T) {
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		{key: "gen_ai.tool.call.arguments", want: true},
+		{key: "gen_ai.tool.call.result", want: true},
+		{key: "gen_ai.tool.description", want: true},
+		{key: "gen_ai.embeddings.input_texts", want: true},
+		{key: "agento11y.conversation.title", want: true},
+		{key: "sigil.conversation.title", want: true},
+		{key: "gen_ai.tool.name", want: false},
+		{key: "gen_ai.usage.input_tokens", want: false},
+		{key: contentcapture.ErrorCategoryAttributeKey, want: false},
+		{key: contentcapture.MetadataKeyCallError, want: false},
+		{key: "agento11y.generation.id", want: false},
+		{key: "", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.key, func(t *testing.T) {
+			if got := contentcapture.IsTraceContentAttribute(tc.key); got != tc.want {
+				t.Errorf("IsTraceContentAttribute(%q) = %t, want %t", tc.key, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSharedDeclarations pins the wire spellings. Renaming any of these breaks
+// a reader: an OTel consumer reads the event and attribute names, and Cloud
+// reads the replacement error value.
+func TestSharedDeclarations(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "ExceptionEventName", got: contentcapture.ExceptionEventName, want: "exception"},
+		{name: "ErrorCategoryAttributeKey", got: contentcapture.ErrorCategoryAttributeKey, want: "error.category"},
+		{name: "StrippedCallError", got: contentcapture.StrippedCallError, want: "sdk_error"},
+		{name: "MetadataKeyCallError", got: contentcapture.MetadataKeyCallError, want: "call_error"},
+		{name: "ConversationTitleKey", got: contentcapture.ConversationTitleKey, want: "agento11y.conversation.title"},
+		{name: "LegacyConversationTitleKey", got: contentcapture.LegacyConversationTitleKey, want: "sigil.conversation.title"},
+		{name: "EmbeddingInputTextsAttributeKey", got: contentcapture.EmbeddingInputTextsAttributeKey, want: "gen_ai.embeddings.input_texts"},
+		{name: "ToolDescriptionAttributeKey", got: contentcapture.ToolDescriptionAttributeKey, want: "gen_ai.tool.description"},
+		{name: "ToolCallArgumentsAttributeKey", got: contentcapture.ToolCallArgumentsAttributeKey, want: "gen_ai.tool.call.arguments"},
+		{name: "ToolCallResultAttributeKey", got: contentcapture.ToolCallResultAttributeKey, want: "gen_ai.tool.call.result"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("%s = %q, want %q", tc.name, tc.got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStripGeneration_NilSafety(t *testing.T) {
+	contentcapture.StripGeneration(nil, "")
+
+	g := &agento11yv1.Generation{
+		Input: []*agento11yv1.Message{
+			nil,
+			{Parts: []*agento11yv1.Part{
+				nil,
+				{},
+				{Payload: &agento11yv1.Part_ToolCall{}},
+				{Payload: &agento11yv1.Part_ToolResult{}},
+				{Payload: &agento11yv1.Part_Media{}},
+				// Typed-nil oneof wrappers. A nil pointer in a payload
+				// interface is not a nil interface, so it reaches its case in
+				// stripMessage and the case has to guard the wrapper itself.
+				{Payload: (*agento11yv1.Part_Text)(nil)},
+				{Payload: (*agento11yv1.Part_Thinking)(nil)},
+				{Payload: (*agento11yv1.Part_ToolCall)(nil)},
+				{Payload: (*agento11yv1.Part_ToolResult)(nil)},
+				{Payload: (*agento11yv1.Part_Media)(nil)},
+			}},
+		},
+		Output: []*agento11yv1.Message{nil},
+		Tools:  []*agento11yv1.ToolDefinition{nil, {Name: "weather", Description: leakMarker}},
+	}
+	contentcapture.StripGeneration(g, "")
+
+	if got := len(g.GetInput()[1].GetParts()); got != 10 {
+		t.Errorf("part count = %d, want 10", got)
+	}
+	if got := g.GetTools()[1].GetDescription(); got != "" {
+		t.Errorf("tool description = %q, want empty", got)
+	}
+	if got := g.GetTools()[1].GetName(); got != "weather" {
+		t.Errorf("tool name = %q, want weather", got)
+	}
+}
+
+// Markers on the two constant blocks in contentcapture.go.
+const (
+	contentKeyMarker      = "//contentcapture:content-keys"
+	nonContentValueMarker = "//contentcapture:non-content-values"
+)
+
+// TestContentKeyBlockMatchesPredicate pins the content-key constant block to
+// IsTraceContentAttribute's cases.
+//
+// Go has no reflection over package constants, so the test reads the source.
+// Without it, adding a key to the content block and forgetting the predicate
+// compiles, keeps TestSharedDeclarations green (it only pins string values) and
+// keeps TestIsTraceContentAttribute green (it lists keys by hand), and a
+// forwarder relays the new attribute to Cloud under a reduced mode.
+func TestContentKeyBlockMatchesPredicate(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "contentcapture.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse contentcapture.go: %v", err)
+	}
+
+	contentKeys := markedStringConsts(t, file, contentKeyMarker)
+	nonContentValues := markedStringConsts(t, file, nonContentValueMarker)
+	switchCases := traceContentSwitchCases(t, file)
+
+	for _, name := range slices.Sorted(maps.Keys(contentKeys)) {
+		if !contentcapture.IsTraceContentAttribute(contentKeys[name]) {
+			t.Errorf("%s = %q is declared in the content-key block but IsTraceContentAttribute reports it as metadata: add it to the switch, or move the constant to the %s block if it carries no content",
+				name, contentKeys[name], nonContentValueMarker)
+		}
+	}
+	for _, name := range slices.Sorted(maps.Keys(nonContentValues)) {
+		if contentcapture.IsTraceContentAttribute(nonContentValues[name]) {
+			t.Errorf("%s = %q is declared as a non-content value but IsTraceContentAttribute reports it as content", name, nonContentValues[name])
+		}
+	}
+
+	if want, got := slices.Sorted(maps.Keys(contentKeys)), slices.Sorted(maps.Keys(switchCases)); !slices.Equal(want, got) {
+		t.Errorf("IsTraceContentAttribute cases = %v, want exactly the content-key block %v", got, want)
+	}
+}
+
+// markedStringConsts returns the name/value pairs of the string constants in
+// the const block carrying marker in its doc comment.
+func markedStringConsts(t *testing.T, file *ast.File, marker string) map[string]string {
+	t.Helper()
+
+	out := map[string]string{}
+	found := false
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST || !hasComment(gen.Doc, marker) {
+			continue
+		}
+		found = true
+		for _, spec := range gen.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range value.Names {
+				literal, ok := value.Values[i].(*ast.BasicLit)
+				if !ok || literal.Kind != token.STRING {
+					t.Errorf("%s: %s is not a string literal, so this test can no longer read the block", marker, name.Name)
+					continue
+				}
+				unquoted, err := strconv.Unquote(literal.Value)
+				if err != nil {
+					t.Errorf("%s: unquote %s: %v", marker, name.Name, err)
+					continue
+				}
+				out[name.Name] = unquoted
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no const block in contentcapture.go carries the %s marker: the marker is what pins the block to IsTraceContentAttribute, so restore it rather than deleting this test", marker)
+	}
+
+	return out
+}
+
+// traceContentSwitchCases returns the constant names IsTraceContentAttribute
+// matches on.
+func traceContentSwitchCases(t *testing.T, file *ast.File) map[string]bool {
+	t.Helper()
+
+	out := map[string]bool{}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "IsTraceContentAttribute" {
+			continue
+		}
+		ast.Inspect(fn, func(node ast.Node) bool {
+			clause, ok := node.(*ast.CaseClause)
+			if !ok {
+				return true
+			}
+			for _, expr := range clause.List {
+				ident, ok := expr.(*ast.Ident)
+				if !ok {
+					t.Errorf("IsTraceContentAttribute matches on %T rather than a named constant, so this test can no longer read it", expr)
+					continue
+				}
+				out[ident.Name] = true
+			}
+			return true
+		})
+		return out
+	}
+	t.Fatalf("IsTraceContentAttribute not found in contentcapture.go")
+
+	return nil
+}
+
+func hasComment(group *ast.CommentGroup, want string) bool {
+	if group == nil {
+		return false
+	}
+	for _, comment := range group.List {
+		if strings.TrimSpace(comment.Text) == want {
+			return true
+		}
+	}
+	return false
+}

--- a/go/agento11y/contentcapture/coverage_test.go
+++ b/go/agento11y/contentcapture/coverage_test.go
@@ -1,0 +1,478 @@
+package contentcapture_test
+
+// This file is the schema-drift guard for the strip. Strip is one algorithm
+// over the Target interfaces, so adding a method to those interfaces breaks
+// every adapter until it is handled; what the compiler cannot see is a new
+// proto field or a new Part.payload variant that nobody classified as content
+// or as retained structure. TestProtoFieldCoverage walks the descriptors and
+// fails on it. TestMetadataKeyCoverage does the same for the metadata keys,
+// which the descriptors cannot reach: metadata is one proto field holding a
+// mix of content mirrors and retained keys.
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/agento11y/go/agento11y/contentcapture"
+	"github.com/grafana/agento11y/go/agento11y/model"
+	agento11yv1 "github.com/grafana/agento11y/go/proto/agento11y/v1"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// contentClass is how one proto field survives, or does not survive, a
+// metadata_only strip.
+type contentClass string
+
+const (
+	// classContent is cleared by the strip: the fixture must populate it and
+	// the stripped proto must not carry it.
+	classContent contentClass = "content cleared by the strip"
+	// classRetained survives: structure, identifiers, usage, timing, tags,
+	// and metadata a reader needs to make sense of the stripped generation.
+	classRetained contentClass = "structure retained by the strip"
+	// classReplaced is call_error: the raw text is replaced by the classified
+	// error category rather than cleared.
+	classReplaced contentClass = "replaced with the error category"
+)
+
+// There is deliberately no "exempt" class. A field the fixture cannot populate
+// still has to be classified, and an exemption would let a new Part.payload
+// variant pass the coverage test having asserted nothing about the strip.
+
+// generationFieldClasses classifies every proto field reachable from
+// Generation, including each Part.payload oneof variant. A field missing here
+// fails TestProtoFieldCoverage with its proto path, so a new content field
+// cannot be added without someone deciding whether the strip has to clear it.
+var generationFieldClasses = map[string]contentClass{
+	"agento11y.v1.Generation.id":                    classRetained,
+	"agento11y.v1.Generation.conversation_id":       classRetained,
+	"agento11y.v1.Generation.operation_name":        classRetained,
+	"agento11y.v1.Generation.mode":                  classRetained,
+	"agento11y.v1.Generation.trace_id":              classRetained,
+	"agento11y.v1.Generation.span_id":               classRetained,
+	"agento11y.v1.Generation.model":                 classRetained,
+	"agento11y.v1.Generation.response_id":           classRetained,
+	"agento11y.v1.Generation.response_model":        classRetained,
+	"agento11y.v1.Generation.system_prompt":         classContent,
+	"agento11y.v1.Generation.input":                 classRetained,
+	"agento11y.v1.Generation.output":                classRetained,
+	"agento11y.v1.Generation.tools":                 classRetained,
+	"agento11y.v1.Generation.usage":                 classRetained,
+	"agento11y.v1.Generation.stop_reason":           classRetained,
+	"agento11y.v1.Generation.started_at":            classRetained,
+	"agento11y.v1.Generation.completed_at":          classRetained,
+	"agento11y.v1.Generation.tags":                  classRetained,
+	"agento11y.v1.Generation.metadata":              classRetained,
+	"agento11y.v1.Generation.raw_artifacts":         classContent,
+	"agento11y.v1.Generation.call_error":            classReplaced,
+	"agento11y.v1.Generation.agent_name":            classRetained,
+	"agento11y.v1.Generation.agent_version":         classRetained,
+	"agento11y.v1.Generation.max_tokens":            classRetained,
+	"agento11y.v1.Generation.temperature":           classRetained,
+	"agento11y.v1.Generation.top_p":                 classRetained,
+	"agento11y.v1.Generation.tool_choice":           classRetained,
+	"agento11y.v1.Generation.thinking_enabled":      classRetained,
+	"agento11y.v1.Generation.parent_generation_ids": classRetained,
+	"agento11y.v1.Generation.effective_version":     classRetained,
+
+	"agento11y.v1.ModelRef.provider": classRetained,
+	"agento11y.v1.ModelRef.name":     classRetained,
+
+	"agento11y.v1.Message.role":  classRetained,
+	"agento11y.v1.Message.name":  classRetained,
+	"agento11y.v1.Message.parts": classRetained,
+
+	// Part.payload variants. A sixth variant belongs here or the coverage test
+	// fails. That is the only guard against a new payload kind that no
+	// PartTarget method clears.
+	"agento11y.v1.Part.metadata":    classRetained,
+	"agento11y.v1.Part.text":        classContent,
+	"agento11y.v1.Part.thinking":    classContent,
+	"agento11y.v1.Part.tool_call":   classRetained,
+	"agento11y.v1.Part.tool_result": classRetained,
+	"agento11y.v1.Part.media":       classRetained,
+
+	"agento11y.v1.PartMetadata.provider_type": classRetained,
+
+	"agento11y.v1.ToolCall.id":         classRetained,
+	"agento11y.v1.ToolCall.name":       classRetained,
+	"agento11y.v1.ToolCall.input_json": classContent,
+
+	"agento11y.v1.ToolResult.tool_call_id": classRetained,
+	"agento11y.v1.ToolResult.name":         classRetained,
+	"agento11y.v1.ToolResult.content":      classContent,
+	"agento11y.v1.ToolResult.content_json": classContent,
+	"agento11y.v1.ToolResult.is_error":     classRetained,
+
+	// Media.url can hold a data: URI with the file bytes inline, so it counts
+	// as content. The fields around it are references and are retained.
+	"agento11y.v1.Media.kind":      classRetained,
+	"agento11y.v1.Media.url":       classContent,
+	"agento11y.v1.Media.mime_type": classRetained,
+	"agento11y.v1.Media.name":      classRetained,
+
+	"agento11y.v1.ToolDefinition.name":              classRetained,
+	"agento11y.v1.ToolDefinition.description":       classContent,
+	"agento11y.v1.ToolDefinition.type":              classRetained,
+	"agento11y.v1.ToolDefinition.input_schema_json": classContent,
+	"agento11y.v1.ToolDefinition.deferred":          classRetained,
+
+	"agento11y.v1.TokenUsage.input_tokens":             classRetained,
+	"agento11y.v1.TokenUsage.output_tokens":            classRetained,
+	"agento11y.v1.TokenUsage.total_tokens":             classRetained,
+	"agento11y.v1.TokenUsage.cache_read_input_tokens":  classRetained,
+	"agento11y.v1.TokenUsage.cache_write_input_tokens": classRetained,
+	"agento11y.v1.TokenUsage.reasoning_tokens":         classRetained,
+
+	// The whole raw_artifacts list is dropped, so no Artifact field survives.
+	"agento11y.v1.Artifact.kind":         classContent,
+	"agento11y.v1.Artifact.name":         classContent,
+	"agento11y.v1.Artifact.content_type": classContent,
+	"agento11y.v1.Artifact.payload":      classContent,
+	"agento11y.v1.Artifact.record_id":    classContent,
+	"agento11y.v1.Artifact.uri":          classContent,
+}
+
+func TestProtoFieldCoverage(t *testing.T) {
+	const category = "rate_limit"
+
+	universe := protoFieldUniverse((&agento11yv1.Generation{}).ProtoReflect().Descriptor())
+	for name := range universe {
+		if _, classified := generationFieldClasses[name]; !classified {
+			t.Errorf("proto field %s is not classified in generationFieldClasses: decide whether it carries content, and if it does, give it a clear method on contentcapture.Target or contentcapture.PartTarget so Strip reaches it in every shape", name)
+		}
+	}
+	for name := range generationFieldClasses {
+		if !universe[name] {
+			t.Errorf("generationFieldClasses classifies %s, which is no longer reachable from agento11y.v1.Generation", name)
+		}
+	}
+
+	before := fullContentGeneration()
+	after, ok := proto.Clone(before).(*agento11yv1.Generation)
+	if !ok {
+		t.Fatalf("clone fixture: unexpected type")
+	}
+	contentcapture.StripGeneration(after, category)
+
+	populatedBefore := nonEmptyByField(walkProtoFields(before.ProtoReflect(), ""))
+	afterOccurrences := walkProtoFields(after.ProtoReflect(), "")
+	populatedAfter := nonEmptyByField(afterOccurrences)
+
+	for _, name := range slices.Sorted(maps.Keys(generationFieldClasses)) {
+		switch class := generationFieldClasses[name]; class {
+		case classContent:
+			if !populatedBefore[name] {
+				t.Errorf("%s is classified as content but the fixture leaves it empty, so the strip is untested", name)
+			}
+			if populatedAfter[name] {
+				t.Errorf("%s is classified as content but survives the strip: %s", name, occurrencesOf(afterOccurrences, name))
+			}
+		case classRetained:
+			if !populatedBefore[name] {
+				t.Errorf("%s is classified as retained but the fixture leaves it empty, so retention is unverified", name)
+			}
+			if !populatedAfter[name] {
+				t.Errorf("%s is classified as retained but the strip cleared it", name)
+			}
+		case classReplaced:
+			if name != "agento11y.v1.Generation.call_error" {
+				t.Errorf("%s is classified as replaced, but only call_error has replacement semantics: extend this case before reusing the class", name)
+				continue
+			}
+			if got := after.GetCallError(); got != category {
+				t.Errorf("%s = %q, want the classified category %q", name, got, category)
+			}
+		default:
+			t.Errorf("%s has unknown class %q", name, class)
+		}
+	}
+}
+
+// generationMetadataKeyClasses classifies the metadata keys a generation
+// carries into the strip. generationFieldClasses classifies
+// agento11y.v1.Generation.metadata as one retained field, which cannot express
+// that some keys inside it are content: the call-error mirror and the
+// conversation title under both spellings are deleted, while user keys and the
+// content-capture stamp survive.
+var generationMetadataKeyClasses = map[string]contentClass{
+	contentcapture.MetadataKeyCallError:       classContent,
+	contentcapture.ConversationTitleKey:       classContent,
+	contentcapture.LegacyConversationTitleKey: classContent,
+	model.MetadataKeyContentCaptureMode:       classRetained,
+	"agento11y.sdk.content_capture":           classRetained,
+	"user.key":                                classRetained,
+}
+
+func TestMetadataKeyCoverage(t *testing.T) {
+	before := fullContentGeneration()
+	after, ok := proto.Clone(before).(*agento11yv1.Generation)
+	if !ok {
+		t.Fatalf("clone fixture: unexpected type")
+	}
+	contentcapture.StripGeneration(after, "rate_limit")
+
+	for _, key := range slices.Sorted(maps.Keys(before.GetMetadata().GetFields())) {
+		if _, classified := generationMetadataKeyClasses[key]; !classified {
+			t.Errorf("metadata key %q is not classified in generationMetadataKeyClasses: decide whether it mirrors content, and if it does, delete it in contentcapture.Strip", key)
+		}
+	}
+
+	for _, key := range slices.Sorted(maps.Keys(generationMetadataKeyClasses)) {
+		_, inFixture := before.GetMetadata().GetFields()[key]
+		value, survived := after.GetMetadata().GetFields()[key]
+
+		switch class := generationMetadataKeyClasses[key]; class {
+		case classContent:
+			if !inFixture {
+				t.Errorf("metadata key %q is classified as content but the fixture does not set it, so the strip is untested", key)
+			}
+			if survived {
+				t.Errorf("metadata key %q is classified as content but survives the strip: %v", key, value.AsInterface())
+			}
+		case classRetained:
+			if !inFixture {
+				t.Errorf("metadata key %q is classified as retained but the fixture does not set it, so retention is unverified", key)
+			}
+			if !survived {
+				t.Errorf("metadata key %q is classified as retained but the strip deleted it", key)
+			}
+		default:
+			t.Errorf("metadata key %q has class %q, which has no meaning for a metadata key: a key is either deleted or kept", key, class)
+		}
+	}
+}
+
+// protoFieldOccurrence is one populated field found in a message tree.
+type protoFieldOccurrence struct {
+	// path locates the value in the instance, e.g. input[0].parts[1].text.
+	path string
+	// field is the descriptor's full name, e.g. agento11y.v1.Part.text.
+	field string
+	// nonEmpty is false for a field that is set but holds its zero value,
+	// which is how a cleared oneof member (Part.text = "") looks.
+	nonEmpty bool
+	rendered string
+}
+
+// protoFieldUniverse returns every field reachable from md, keyed by
+// descriptor full name. Oneof members are ordinary fields, so a new
+// Part.payload variant shows up here. Well-known types are leaves: their
+// internals are not agento11y's schema. Map entries are leaves too; the
+// synthetic key/value pair carries no classification decision.
+func protoFieldUniverse(md protoreflect.MessageDescriptor) map[string]bool {
+	out := map[string]bool{}
+	seen := map[protoreflect.FullName]bool{}
+
+	var visit func(protoreflect.MessageDescriptor)
+	visit = func(md protoreflect.MessageDescriptor) {
+		if seen[md.FullName()] {
+			return
+		}
+		seen[md.FullName()] = true
+
+		fields := md.Fields()
+		for i := range fields.Len() {
+			fd := fields.Get(i)
+			out[string(fd.FullName())] = true
+			if fd.IsMap() {
+				continue
+			}
+			if msg := fd.Message(); msg != nil && !isWellKnownProto(msg) {
+				visit(msg)
+			}
+		}
+	}
+	visit(md)
+
+	return out
+}
+
+func isWellKnownProto(md protoreflect.MessageDescriptor) bool {
+	return md.FullName().Parent() == "google.protobuf"
+}
+
+// walkProtoFields records every populated field in a message tree. Unset
+// fields are skipped: in proto3 a zero scalar is indistinguishable from an
+// absent one, so "populated" is the only usable signal, and a set-but-zero
+// oneof member is recorded with nonEmpty false.
+func walkProtoFields(m protoreflect.Message, prefix string) []protoFieldOccurrence {
+	var out []protoFieldOccurrence
+	if m == nil || !m.IsValid() {
+		return out
+	}
+
+	fields := m.Descriptor().Fields()
+	for i := range fields.Len() {
+		fd := fields.Get(i)
+		if !m.Has(fd) {
+			continue
+		}
+		value := m.Get(fd)
+		path := prefix + string(fd.Name())
+
+		switch {
+		case fd.IsMap():
+			out = append(out, protoFieldOccurrence{
+				path:     path,
+				field:    string(fd.FullName()),
+				nonEmpty: value.Map().Len() > 0,
+				rendered: renderProtoMap(value.Map()),
+			})
+		case fd.IsList():
+			list := value.List()
+			out = append(out, protoFieldOccurrence{
+				path:     path,
+				field:    string(fd.FullName()),
+				nonEmpty: list.Len() > 0,
+				rendered: fmt.Sprintf("len=%d", list.Len()),
+			})
+			for j := range list.Len() {
+				out = append(out, walkProtoValue(fd, list.Get(j), fmt.Sprintf("%s[%d]", path, j))...)
+			}
+		default:
+			out = append(out, walkProtoValue(fd, value, path)...)
+		}
+	}
+
+	return out
+}
+
+func walkProtoValue(fd protoreflect.FieldDescriptor, value protoreflect.Value, path string) []protoFieldOccurrence {
+	name := string(fd.FullName())
+	if fd.Message() == nil {
+		return []protoFieldOccurrence{{
+			path:     path,
+			field:    name,
+			nonEmpty: !isZeroScalar(fd, value),
+			rendered: renderProtoScalar(fd, value),
+		}}
+	}
+	if isWellKnownProto(fd.Message()) {
+		return walkWellKnownProto(fd, value, path)
+	}
+	return append(
+		[]protoFieldOccurrence{{path: path, field: name, nonEmpty: true, rendered: "set"}},
+		walkProtoFields(value.Message(), path+".")...,
+	)
+}
+
+// walkWellKnownProto renders a well-known type without descending into its
+// generated schema. Struct is expanded one level so a metadata key shows up as
+// its own occurrence rather than as part of the whole map.
+func walkWellKnownProto(fd protoreflect.FieldDescriptor, value protoreflect.Value, path string) []protoFieldOccurrence {
+	name := string(fd.FullName())
+	switch message := value.Message().Interface().(type) {
+	case *timestamppb.Timestamp:
+		return []protoFieldOccurrence{{
+			path:     path,
+			field:    name,
+			nonEmpty: !message.AsTime().IsZero(),
+			rendered: message.AsTime().UTC().Format(time.RFC3339Nano),
+		}}
+	case *structpb.Struct:
+		out := []protoFieldOccurrence{{
+			path:     path,
+			field:    name,
+			nonEmpty: len(message.GetFields()) > 0,
+			rendered: fmt.Sprintf("fields=%d", len(message.GetFields())),
+		}}
+		for _, key := range slices.Sorted(maps.Keys(message.GetFields())) {
+			encoded, err := json.Marshal(message.GetFields()[key].AsInterface())
+			if err != nil {
+				encoded = fmt.Appendf(nil, "%q", err.Error())
+			}
+			out = append(out, protoFieldOccurrence{
+				path:     path + "." + key,
+				field:    name,
+				nonEmpty: true,
+				rendered: string(encoded),
+			})
+		}
+		return out
+	default:
+		return []protoFieldOccurrence{{
+			path:     path,
+			field:    name,
+			nonEmpty: true,
+			rendered: fmt.Sprintf("%v", message),
+		}}
+	}
+}
+
+func isZeroScalar(fd protoreflect.FieldDescriptor, value protoreflect.Value) bool {
+	switch fd.Kind() {
+	case protoreflect.StringKind:
+		return value.String() == ""
+	case protoreflect.BytesKind:
+		return len(value.Bytes()) == 0
+	case protoreflect.BoolKind:
+		return !value.Bool()
+	case protoreflect.EnumKind:
+		return value.Enum() == 0
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind,
+		protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+		return value.Int() == 0
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind,
+		protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		return value.Uint() == 0
+	case protoreflect.FloatKind, protoreflect.DoubleKind:
+		return value.Float() == 0
+	default:
+		return false
+	}
+}
+
+func renderProtoScalar(fd protoreflect.FieldDescriptor, value protoreflect.Value) string {
+	switch fd.Kind() {
+	case protoreflect.StringKind:
+		return fmt.Sprintf("%q", value.String())
+	case protoreflect.BytesKind:
+		return fmt.Sprintf("%q", string(value.Bytes()))
+	case protoreflect.EnumKind:
+		if vd := fd.Enum().Values().ByNumber(value.Enum()); vd != nil {
+			return string(vd.Name())
+		}
+		return fmt.Sprintf("enum(%d)", value.Enum())
+	default:
+		return fmt.Sprintf("%v", value.Interface())
+	}
+}
+
+func renderProtoMap(m protoreflect.Map) string {
+	entries := make([]string, 0, m.Len())
+	m.Range(func(k protoreflect.MapKey, v protoreflect.Value) bool {
+		entries = append(entries, fmt.Sprintf("%s=%v", k.String(), v.Interface()))
+		return true
+	})
+	slices.Sort(entries)
+	return fmt.Sprintf("{%s}", strings.Join(entries, ", "))
+}
+
+// nonEmptyByField reports, per descriptor field name, whether any occurrence
+// of that field in the tree holds a non-zero value.
+func nonEmptyByField(occurrences []protoFieldOccurrence) map[string]bool {
+	out := map[string]bool{}
+	for _, occ := range occurrences {
+		out[occ.field] = out[occ.field] || occ.nonEmpty
+	}
+	return out
+}
+
+func occurrencesOf(occurrences []protoFieldOccurrence, field string) string {
+	var matches []string
+	for _, occ := range occurrences {
+		if occ.field == field && occ.nonEmpty {
+			matches = append(matches, occ.path+"="+occ.rendered)
+		}
+	}
+	return strings.Join(matches, ", ")
+}


### PR DESCRIPTION
The SDK can strip content from the Generation struct before encoding it (based on content capture mode).

The logic is extracted into the new `go/agento11y/contentcapture` with additional tests, so that we can reuse it later in the `./plugins/agento11y`.