### PR TITLE
chore(sdk): add tests for hooks:evaluate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,54 @@ jobs:
       - name: Check protobuf stubs are in sync
         run: mise run check:proto
 
+  conformance:
+    name: Cross-SDK conformance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          global-json-file: dotnet/global.json
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Setup mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          install: true
+          cache: true
+
+      - name: Install JS deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Core conformance
+        run: mise run test:sdk:core-conformance
+
+      # The hooks:evaluate wire format has no generated stubs, so
+      # conformance/hooks/ is its only contract. check:proto cannot see a
+      # divergence here, so this task runs as its own step.
+      - name: Hook conformance
+        run: mise run test:sdk:hooks-conformance
+
   go-module:
     name: Go module
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,10 @@ If you change shared-binary behavior, the four glue plugins all see it. The Open
 
 [`llms.txt`](llms.txt) is what this repo ships. There is a second copy of the same prompt rendered by the Agent Observability onboarding wizard (a separate Grafana product). When you change user-facing semantics here (new SDK field, renamed env var, new framework adapter), the wizard copy needs the same change. If you're only fixing this repo's internals, the wizard copy doesn't move.
 
+## Hook wire fixtures are checked by hand
+
+`conformance/hooks/` pins the `POST /api/v1/hooks:evaluate` body and responses. That endpoint has no generated stubs, so the fixtures are the contract, and the SDK suites check themselves against the fixtures rather than against the server. If you change a fixture, run the new shape through the server's hook decoder yourself first. `conformance/hooks/README.md` documents the encodings, which the proto does not describe.
+
 ## Running checks
 
 `mise run check` is the full local CI gate: lint + typecheck + proto-drift + every SDK suite. For a focused change, run the matching narrow task (e.g. `mise run test:py:sdk-langgraph`); the full gate is slow.

--- a/conformance/hooks/README.md
+++ b/conformance/hooks/README.md
@@ -1,0 +1,88 @@
+# Hook wire fixtures
+
+`POST /api/v1/hooks:evaluate` is the request-path guard endpoint. It has no
+generated stubs on either side, so these files are the only cross-language contract
+for its shape.
+
+| File | Contents |
+|------|----------|
+| `request-preflight.json` | The preflight request body every SDK must produce: all four part kinds under `input.messages`, two tool definitions, and every context field the server matches rules on. |
+| `request-postflight-guard.json` | The postflight body the shipped guards send: one tool call under `input.output`. The server's tool filter scans `input.output` before `input.messages`, so this is the field a tool-filter rule reads in production. |
+| `responses.json` | Canned server responses (`allow`, `deny`, `allow_with_transformed_input`) every SDK must parse into the same logical result. |
+
+## The two directions use opposite encodings
+
+`proto/agento11y/v1/generation_ingest.proto` describes neither convention. Both come
+from how the server decodes and encodes each field. Each SDK repeats the rule for a
+field in the comment next to the code that encodes it.
+
+| Field | Request | Response |
+|-------|---------|----------|
+| `tool_call.input_json` | embedded JSON | base64 |
+| `tool_result.content_json` | embedded JSON | base64 |
+| `tools[].input_schema_json` | base64 | base64 |
+
+The server dispatches a part on a snake_case `kind`: `text`, `thinking`, `tool_call`,
+`tool_result`. It decodes a part with a missing or renamed discriminator to an empty
+part, which is invisible to rule evaluation, so the guard allows the request.
+
+Parsing a response part follows the same dispatch, and all three SDKs drop a part
+with nothing to recover: an empty `text`, an empty `thinking`, a `tool_call` or
+`tool_result` without its payload object, a `tool_call` without a name, and any kind
+an SDK does not know that arrives without `text`. An unknown kind that carries `text` becomes a text part,
+because that is the only way the server can have described it.
+
+The kind decides which field a parser reads, and no parser reads a second one. A
+`tool_call` without its payload object is dropped even when the part carries `text`,
+and a `text` part with an empty `text` is dropped even when the part carries
+`thinking`. Recovering the leftover field would report a part the rule never wrote,
+and a different `transformed_input` per SDK for one body. A part with no `kind` at
+all is the one case a parser reads whichever payload field is set: the server always
+sets `kind`, so that shape can only come from a hand-written or protobuf-JSON body.
+
+A message carries its body in `parts`, in both directions. There is no `content`
+field on a wire message, so a text shorthand has to travel as a text part.
+
+## Response payloads always parse back as JSON
+
+A response payload is base64 of whatever bytes the proto field held, and nothing
+guarantees those bytes are JSON. All three SDKs resolve one string the same way:
+
+1. Strict base64 that decodes to a JSON document becomes that document.
+2. Strict base64 that decodes to anything else is kept as a JSON string holding the
+   decoded text.
+3. A string that is not base64 but is itself a JSON document is kept as is.
+4. Anything else is kept as a JSON string holding the original text.
+
+Every SDK has to end up with a valid JSON document. Go holds these payloads in a
+`json.RawMessage`, so invalid bytes there fail every later marshal of that part, and
+the caller can neither re-export nor re-send the transform. Request serialization
+follows the same rule in reverse: an unparsable payload travels as a JSON string, and
+the request still goes out.
+
+## What the fixtures deliberately leave out
+
+`ToolDefinition.deferred` is absent, because the JS `ToolDefinition` type has no such
+field and adding it would change a public type and the generation-export mapping. Go
+and Python cover the field in their own tests.
+
+Media parts are absent, because only Go's `model.Part` can hold one and the server
+has no `media` kind. All three SDKs drop a media part, and a message left with no
+parts serializes as `"parts": []`.
+
+## Comparison rule
+
+Compare parsed JSON structures, not bytes. Key order and the whitespace inside
+embedded JSON are not part of the contract.
+
+This contract allows exactly one normalization, and only the Go suite needs it: drop
+`metadata` keys whose value is an empty object, which Go emits because
+`model.Part.Metadata` is a value-type struct. Do not normalize anything else. A
+different encoding or a renamed key is what these fixtures are here to catch.
+
+## Where the shape comes from
+
+These suites check the SDKs against the fixtures. The shape recorded here came from
+reading the server's hook decoder, running both request fixtures through it, and
+bringing an equivalent response back out through its encoder. If you change a
+fixture, repeat that check first. Do not edit a fixture to make an SDK suite green.

--- a/conformance/hooks/request-postflight-guard.json
+++ b/conformance/hooks/request-postflight-guard.json
@@ -1,0 +1,30 @@
+{
+  "phase": "postflight",
+  "context": {
+    "agent_name": "conformance-guard",
+    "agent_version": "1.2.3",
+    "model": {
+      "provider": "anthropic",
+      "name": "claude-sonnet-4"
+    }
+  },
+  "input": {
+    "output": [
+      {
+        "role": "assistant",
+        "parts": [
+          {
+            "kind": "tool_call",
+            "tool_call": {
+              "id": "call-bash",
+              "name": "Bash",
+              "input_json": {
+                "command": "rm -rf /tmp/cache"
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/conformance/hooks/request-preflight.json
+++ b/conformance/hooks/request-preflight.json
@@ -1,0 +1,111 @@
+{
+  "phase": "preflight",
+  "context": {
+    "agent_name": "conformance-agent",
+    "agent_version": "1.2.3",
+    "model": {
+      "provider": "anthropic",
+      "name": "claude-sonnet-4"
+    },
+    "tags": {
+      "env": "test",
+      "team": "agent-observability"
+    },
+    "conversation_id": "conv-hooks-conformance",
+    "trace_id": "0123456789abcdef0123456789abcdef",
+    "span_id": "0123456789abcdef"
+  },
+  "input": {
+    "system_prompt": "You are a careful assistant.",
+    "messages": [
+      {
+        "role": "user",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "Delete the cache directory under /tmp."
+          }
+        ]
+      },
+      {
+        "role": "assistant",
+        "parts": [
+          {
+            "kind": "thinking",
+            "thinking": "The request is destructive, so inspect the directory first."
+          },
+          {
+            "kind": "tool_call",
+            "tool_call": {
+              "id": "call-read",
+              "name": "read_file",
+              "input_json": {
+                "path": "/tmp/cache/manifest.json"
+              }
+            }
+          },
+          {
+            "kind": "tool_call",
+            "tool_call": {
+              "id": "call-bash",
+              "name": "Bash",
+              "input_json": {
+                "command": "rm -rf /tmp/cache"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "name": "read_file",
+        "parts": [
+          {
+            "kind": "tool_result",
+            "tool_result": {
+              "tool_call_id": "call-read",
+              "name": "read_file",
+              "content": "3 entries",
+              "content_json": {
+                "entries": 3
+              }
+            }
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "name": "Bash",
+        "parts": [
+          {
+            "kind": "tool_result",
+            "tool_result": {
+              "tool_call_id": "call-bash",
+              "name": "Bash",
+              "is_error": true,
+              "content": "rm: cannot remove '/tmp/cache': Permission denied",
+              "content_json": {
+                "exit_code": 1
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "tools": [
+      {
+        "name": "Bash",
+        "description": "Run a shell command.",
+        "type": "function",
+        "input_schema_json": "eyJ0eXBlIjoib2JqZWN0IiwicHJvcGVydGllcyI6eyJjb21tYW5kIjp7InR5cGUiOiJzdHJpbmciLCJkZXNjcmlwdGlvbiI6IlNoZWxsIGNvbW1hbmQgdG8gcnVuLiJ9fSwicmVxdWlyZWQiOlsiY29tbWFuZCJdfQ=="
+      },
+      {
+        "name": "read_file",
+        "description": "Read a file from disk.",
+        "type": "function",
+        "input_schema_json": "eyJ0eXBlIjoib2JqZWN0IiwicHJvcGVydGllcyI6eyJwYXRoIjp7InR5cGUiOiJzdHJpbmcifX0sInJlcXVpcmVkIjpbInBhdGgiXX0="
+      }
+    ],
+    "conversation_preview": "user: Delete the cache directory under /tmp."
+  }
+}

--- a/conformance/hooks/responses.json
+++ b/conformance/hooks/responses.json
@@ -1,0 +1,90 @@
+{
+  "allow": {
+    "action": "allow",
+    "evaluations": [
+      {
+        "rule_id": "pii-detect",
+        "evaluator_id": "evaluator-pii",
+        "evaluator_kind": "regex",
+        "passed": true,
+        "latency_ms": 12,
+        "explanation": "no PII matches"
+      }
+    ]
+  },
+  "deny": {
+    "action": "deny",
+    "rule_id": "block-destructive-bash",
+    "reason": "Bash(*rm*) is not allowed in this environment",
+    "evaluations": [
+      {
+        "rule_id": "block-destructive-bash",
+        "evaluator_id": "evaluator-tool-filter",
+        "evaluator_kind": "tool_filter",
+        "passed": false,
+        "latency_ms": 3,
+        "reason": "blocked tool Bash"
+      }
+    ]
+  },
+  "allow_with_transformed_input": {
+    "action": "allow",
+    "transformed_input": {
+      "messages": [
+        {
+          "role": "user",
+          "parts": [
+            {
+              "kind": "text",
+              "text": "Delete the cache directory under [REDACTED]."
+            }
+          ]
+        },
+        {
+          "role": "assistant",
+          "parts": [
+            {
+              "kind": "thinking",
+              "thinking": "The request is destructive, so inspect the directory first."
+            },
+            {
+              "kind": "tool_call",
+              "tool_call": {
+                "id": "call-bash",
+                "name": "Bash",
+                "input_json": "eyJjb21tYW5kIjoicm0gLXJmIC90bXAvY2FjaGUifQ=="
+              }
+            }
+          ]
+        },
+        {
+          "role": "tool",
+          "name": "Bash",
+          "parts": [
+            {
+              "kind": "tool_result",
+              "tool_result": {
+                "tool_call_id": "call-bash",
+                "name": "Bash",
+                "content": "rm: cannot remove '/tmp/cache': Permission denied",
+                "content_json": "eyJleGl0X2NvZGUiOjF9",
+                "is_error": true
+              }
+            }
+          ]
+        }
+      ],
+      "tools": [
+        {
+          "name": "Bash",
+          "description": "Run a shell command.",
+          "type": "function",
+          "input_schema_json": "eyJ0eXBlIjoib2JqZWN0IiwicHJvcGVydGllcyI6eyJjb21tYW5kIjp7InR5cGUiOiJzdHJpbmciLCJkZXNjcmlwdGlvbiI6IlNoZWxsIGNvbW1hbmQgdG8gcnVuLiJ9fSwicmVxdWlyZWQiOlsiY29tbWFuZCJdfQ=="
+        }
+      ],
+      "system_prompt": "You are a careful assistant.",
+      "conversation_preview": "user: Delete the cache directory under [REDACTED]."
+    },
+    "evaluations": []
+  }
+}

--- a/go/agento11y/hooks.go
+++ b/go/agento11y/hooks.go
@@ -3,6 +3,7 @@ package agento11y
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	agento11yv1 "github.com/grafana/agento11y/go/proto/agento11y/v1"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -159,6 +161,430 @@ type HookEvaluateResponse struct {
 	Evaluations      []HookEvaluation `json:"evaluations"`
 }
 
+// The hooks:evaluate endpoint has no generated stubs on either side: the server
+// decodes the request with a hand-rolled decoder and encodes its response from
+// protobuf structs with encoding/json. The two directions disagree on how JSON
+// payloads are carried, and neither convention matches the public SDK types. The
+// wire types below own that translation so HookInput, model.Message, and
+// model.ToolDefinition stay shared with generation export.
+// conformance/hooks/README.md documents the contract. The fixtures under
+// conformance/hooks/ pin it.
+
+type hookWireRequest struct {
+	Phase   HookPhase            `json:"phase"`
+	Context HookContext          `json:"context"`
+	Input   hookWireRequestInput `json:"input"`
+}
+
+// hookWireRequestInput keeps model.Message for parts, whose snake_case,
+// embedded-JSON shape the server already reads, and swaps tool definitions for
+// hookWireTool.
+type hookWireRequestInput struct {
+	Messages            []Message      `json:"messages,omitempty"`
+	Tools               []hookWireTool `json:"tools,omitempty"`
+	SystemPrompt        string         `json:"system_prompt,omitempty"`
+	Output              []Message      `json:"output,omitempty"`
+	ConversationPreview string         `json:"conversation_preview,omitempty"`
+}
+
+// hookWireTool carries request tool definitions the way the server reads them.
+// The server decodes input.tools straight into its protobuf ToolDefinition with
+// encoding/json, where the bytes field input_schema_json must be base64.
+//
+// model.ToolDefinition puts raw JSON under input_schema instead. The server
+// ignores that unknown key, so every tool schema disappears from the request.
+// Raw JSON under input_schema_json fails the decode, and the server answers 400
+// for the whole evaluation.
+type hookWireTool struct {
+	Name            string `json:"name"`
+	Description     string `json:"description,omitempty"`
+	Type            string `json:"type,omitempty"`
+	InputSchemaJSON []byte `json:"input_schema_json,omitempty"`
+	Deferred        bool   `json:"deferred,omitempty"`
+}
+
+// hookWireResponseTool decodes response tool definitions. input_schema_json is
+// json.RawMessage rather than []byte on purpose. A []byte field rejects anything
+// that is not base64, and that error fails json.Unmarshal of the whole response
+// body. The caller then loses a deny it has to enforce and falls open to allow.
+// Each payload is decoded on its own instead, matching Python and JS.
+type hookWireResponseTool struct {
+	Name            string          `json:"name"`
+	Description     string          `json:"description,omitempty"`
+	Type            string          `json:"type,omitempty"`
+	InputSchemaJSON json.RawMessage `json:"input_schema_json,omitempty"`
+	Deferred        bool            `json:"deferred,omitempty"`
+}
+
+type hookWireResponse struct {
+	Action           HookAction       `json:"action"`
+	RuleID           string           `json:"rule_id,omitempty"`
+	Reason           string           `json:"reason,omitempty"`
+	TransformedInput *hookWireInput   `json:"transformed_input,omitempty"`
+	Evaluations      []HookEvaluation `json:"evaluations"`
+}
+
+type hookWireInput struct {
+	Messages            []hookWireMessage      `json:"messages,omitempty"`
+	Tools               []hookWireResponseTool `json:"tools,omitempty"`
+	SystemPrompt        string                 `json:"system_prompt,omitempty"`
+	Output              []hookWireMessage      `json:"output,omitempty"`
+	ConversationPreview string                 `json:"conversation_preview,omitempty"`
+}
+
+type hookWireMessage struct {
+	Role  hookWireRole   `json:"role"`
+	Name  string         `json:"name,omitempty"`
+	Parts []hookWirePart `json:"parts,omitempty"`
+}
+
+type hookWirePart struct {
+	Kind       PartKind            `json:"kind"`
+	Text       string              `json:"text,omitempty"`
+	Thinking   string              `json:"thinking,omitempty"`
+	ToolCall   *hookWireToolCall   `json:"tool_call,omitempty"`
+	ToolResult *hookWireToolResult `json:"tool_result,omitempty"`
+}
+
+type hookWireToolCall struct {
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name"`
+	InputJSON json.RawMessage `json:"input_json,omitempty"`
+}
+
+type hookWireToolResult struct {
+	ToolCallID  string          `json:"tool_call_id,omitempty"`
+	Name        string          `json:"name,omitempty"`
+	IsError     bool            `json:"is_error,omitempty"`
+	Content     string          `json:"content,omitempty"`
+	ContentJSON json.RawMessage `json:"content_json,omitempty"`
+}
+
+// hookWireRole accepts both the string roles the hooks API emits and the integer
+// enum values an emitter that marshals the generated proto structs with
+// encoding/json would send. Python and JS accept the same two forms.
+type hookWireRole Role
+
+func (r *hookWireRole) UnmarshalJSON(data []byte) error {
+	var name string
+	if err := json.Unmarshal(data, &name); err == nil {
+		switch strings.ToLower(strings.TrimSpace(name)) {
+		case string(RoleAssistant):
+			*r = hookWireRole(RoleAssistant)
+		case string(RoleTool):
+			*r = hookWireRole(RoleTool)
+		default:
+			*r = hookWireRole(RoleUser)
+		}
+		return nil
+	}
+	var enum int32
+	if err := json.Unmarshal(data, &enum); err != nil {
+		return fmt.Errorf("cannot unmarshal hook message role %s", string(data))
+	}
+	switch enum {
+	case int32(agento11yv1.MessageRole_MESSAGE_ROLE_ASSISTANT):
+		*r = hookWireRole(RoleAssistant)
+	case int32(agento11yv1.MessageRole_MESSAGE_ROLE_TOOL):
+		*r = hookWireRole(RoleTool)
+	default:
+		*r = hookWireRole(RoleUser)
+	}
+	return nil
+}
+
+func newHookWireRequest(req HookEvaluateRequest) hookWireRequest {
+	return hookWireRequest{
+		Phase:   req.Phase,
+		Context: req.Context,
+		Input: hookWireRequestInput{
+			Messages:            newHookWireRequestMessages(req.Input.Messages),
+			Tools:               newHookWireTools(req.Input.Tools),
+			SystemPrompt:        req.Input.SystemPrompt,
+			Output:              newHookWireRequestMessages(req.Input.Output),
+			ConversationPreview: req.Input.ConversationPreview,
+		},
+	}
+}
+
+// newHookWireRequestMessages copies messages into the subset of model.Message
+// the server can read. It makes three adjustments. Python already makes all
+// three, and the narrower JS part union produces the same result:
+//
+//   - It drops a part that has no payload for its kind, and a part whose kind
+//     the server does not know. A part with no known kind but with text is the
+//     exception: that one travels as a text part. A media part therefore
+//     disappears rather than reaching the server's default branch, which
+//     recovers text only and decodes it to a part with no payload.
+//   - Parts is never nil, so a message with no parts serializes as [] rather
+//     than null.
+//   - A tool payload that is not valid JSON travels as a JSON string. Streaming
+//     providers accumulate input_json_delta without validating it, and
+//     json.Marshal of an invalid json.RawMessage fails the whole request. The
+//     caller would then see a fail-open allow or a fail-closed error for what is
+//     only a payload problem.
+func newHookWireRequestMessages(msgs []Message) []Message {
+	if len(msgs) == 0 {
+		return nil
+	}
+	out := make([]Message, 0, len(msgs))
+	for _, msg := range msgs {
+		converted := msg
+		converted.Parts = make([]Part, 0, len(msg.Parts))
+		for _, part := range msg.Parts {
+			switch part.Kind {
+			case PartKindText:
+				if part.Text != "" {
+					converted.Parts = append(converted.Parts, part)
+				}
+			case PartKindThinking:
+				if part.Thinking != "" {
+					converted.Parts = append(converted.Parts, part)
+				}
+			case PartKindToolCall:
+				if part.ToolCall == nil {
+					continue
+				}
+				call := *part.ToolCall
+				call.InputJSON = hookRequestPayloadJSON(call.InputJSON)
+				part.ToolCall = &call
+				converted.Parts = append(converted.Parts, part)
+			case PartKindToolResult:
+				if part.ToolResult == nil {
+					continue
+				}
+				result := *part.ToolResult
+				result.ContentJSON = hookRequestPayloadJSON(result.ContentJSON)
+				part.ToolResult = &result
+				converted.Parts = append(converted.Parts, part)
+			default:
+				if part.Text != "" {
+					converted.Parts = append(converted.Parts, Part{
+						Kind:     PartKindText,
+						Text:     part.Text,
+						Metadata: part.Metadata,
+					})
+				}
+			}
+		}
+		out = append(out, converted)
+	}
+	return out
+}
+
+// hookRequestPayloadJSON keeps a request-side payload valid JSON. Request parts
+// carry embedded JSON, so an unparsable payload is sent as a JSON string, which
+// leaves its text visible to rules instead of failing the marshal.
+func hookRequestPayloadJSON(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	if json.Valid(raw) {
+		return raw
+	}
+	return hookJSONString(string(raw))
+}
+
+func newHookWireTools(tools []ToolDefinition) []hookWireTool {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]hookWireTool, 0, len(tools))
+	for _, tool := range tools {
+		out = append(out, hookWireTool{
+			Name:            tool.Name,
+			Description:     tool.Description,
+			Type:            tool.Type,
+			InputSchemaJSON: tool.InputSchema,
+			Deferred:        tool.Deferred,
+		})
+	}
+	return out
+}
+
+func (w hookWireResponse) toResponse() HookEvaluateResponse {
+	out := HookEvaluateResponse{
+		Action:      w.Action,
+		RuleID:      w.RuleID,
+		Reason:      w.Reason,
+		Evaluations: w.Evaluations,
+	}
+	if w.TransformedInput != nil {
+		out.TransformedInput = w.TransformedInput.toHookInput()
+	}
+	return out
+}
+
+func (w *hookWireInput) toHookInput() *HookInput {
+	if w == nil {
+		return nil
+	}
+	out := &HookInput{
+		Messages:            hookWireMessagesToMessages(w.Messages),
+		Tools:               hookWireToolsToToolDefinitions(w.Tools),
+		SystemPrompt:        w.SystemPrompt,
+		Output:              hookWireMessagesToMessages(w.Output),
+		ConversationPreview: w.ConversationPreview,
+	}
+	if len(out.Messages) == 0 && len(out.Tools) == 0 && len(out.Output) == 0 &&
+		out.SystemPrompt == "" && out.ConversationPreview == "" {
+		// An empty transformed_input is not a transform. Returning a non-nil
+		// HookInput here would let a caller checking only for nil replace the
+		// prompt with nothing. Python and JS return no transform for this body.
+		return nil
+	}
+	return out
+}
+
+func hookWireToolsToToolDefinitions(tools []hookWireResponseTool) []ToolDefinition {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]ToolDefinition, 0, len(tools))
+	for _, tool := range tools {
+		converted := ToolDefinition{
+			Name:        tool.Name,
+			Description: tool.Description,
+			Type:        tool.Type,
+			Deferred:    tool.Deferred,
+		}
+		if schema := decodeHookWireJSON(tool.InputSchemaJSON); len(schema) > 0 {
+			converted.InputSchema = schema
+		}
+		out = append(out, converted)
+	}
+	return out
+}
+
+func hookWireMessagesToMessages(msgs []hookWireMessage) []Message {
+	if len(msgs) == 0 {
+		return nil
+	}
+	out := make([]Message, 0, len(msgs))
+	for _, msg := range msgs {
+		converted := Message{
+			Role:  Role(msg.Role),
+			Name:  msg.Name,
+			Parts: make([]Part, 0, len(msg.Parts)),
+		}
+		if converted.Role == "" {
+			converted.Role = RoleUser
+		}
+		for _, part := range msg.Parts {
+			if parsed, ok := part.toPart(); ok {
+				converted.Parts = append(converted.Parts, parsed)
+			}
+		}
+		out = append(out, converted)
+	}
+	return out
+}
+
+// toPart converts one response part, reporting false for a part with nothing to
+// recover so it is dropped rather than turned into an empty text part. Python
+// and JS drop the same shape.
+func (p hookWirePart) toPart() (Part, bool) {
+	kind := p.Kind
+	if kind == "" {
+		// A part without a discriminator is still recoverable from whichever
+		// payload field is set. The server always sets kind, so this only covers a
+		// hand-written or proto-JSON body.
+		switch {
+		case p.ToolCall != nil:
+			kind = PartKindToolCall
+		case p.ToolResult != nil:
+			kind = PartKindToolResult
+		case p.Thinking != "":
+			kind = PartKindThinking
+		case p.Text != "":
+			kind = PartKindText
+		default:
+			return Part{}, false
+		}
+	}
+	switch kind {
+	case PartKindThinking:
+		if p.Thinking == "" {
+			return Part{}, false
+		}
+		return Part{Kind: PartKindThinking, Thinking: p.Thinking}, true
+	case PartKindToolCall:
+		// A call without a name cannot be routed or re-sent, so there is nothing to
+		// recover from it either.
+		if p.ToolCall == nil || p.ToolCall.Name == "" {
+			return Part{}, false
+		}
+		return Part{Kind: PartKindToolCall, ToolCall: &ToolCall{
+			ID:        p.ToolCall.ID,
+			Name:      p.ToolCall.Name,
+			InputJSON: decodeHookWireJSON(p.ToolCall.InputJSON),
+		}}, true
+	case PartKindToolResult:
+		if p.ToolResult == nil {
+			return Part{}, false
+		}
+		return Part{Kind: PartKindToolResult, ToolResult: &ToolResult{
+			ToolCallID:  p.ToolResult.ToolCallID,
+			Name:        p.ToolResult.Name,
+			IsError:     p.ToolResult.IsError,
+			Content:     p.ToolResult.Content,
+			ContentJSON: decodeHookWireJSON(p.ToolResult.ContentJSON),
+		}}, true
+	default:
+		// Text, and any kind this SDK does not know, which the server can only have
+		// sent as text. Without the text there is nothing to recover.
+		if p.Text == "" {
+			return Part{}, false
+		}
+		return Part{Kind: PartKindText, Text: p.Text}, true
+	}
+}
+
+// decodeHookWireJSON recovers a response-side JSON payload. The server marshals
+// the protobuf bytes fields input_json, content_json, and input_schema_json with
+// encoding/json, so they arrive base64-encoded inside a JSON string.
+//
+// The result is always a valid JSON document, because ToolCall.InputJSON and
+// friends are json.RawMessage and invalid bytes there make every later
+// json.Marshal of that part fail. Base64 that decodes to something other than
+// JSON, and a string that is neither base64 nor JSON, are therefore kept as a
+// JSON string so the text survives. Python and JS apply the same rule; see
+// conformance/hooks/README.md.
+func decodeHookWireJSON(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err != nil {
+		// An embedded JSON document rather than the proto encoding.
+		if json.Valid(raw) {
+			return raw
+		}
+		return nil
+	}
+	if text == "" {
+		return nil
+	}
+	if decoded, err := base64.StdEncoding.DecodeString(text); err == nil {
+		if json.Valid(decoded) {
+			return decoded
+		}
+		return hookJSONString(string(decoded))
+	}
+	if json.Valid([]byte(text)) {
+		return json.RawMessage(text)
+	}
+	return hookJSONString(text)
+}
+
+func hookJSONString(text string) json.RawMessage {
+	quoted, err := json.Marshal(text)
+	if err != nil {
+		return nil
+	}
+	return quoted
+}
+
 // EvaluateHook calls POST /api/v1/hooks:evaluate to run synchronous hook
 // rules for the given request. The returned response distinguishes allow
 // (proceed with the LLM call) from deny (block — typically wrapped into a
@@ -199,13 +625,13 @@ func (c *Client) EvaluateHook(ctx context.Context, req HookEvaluateRequest) (*Ho
 
 	baseURL, err := baseURLFromAPIEndpoint(c.config.API.Endpoint, insecureValue(c.config.GenerationExport.Insecure))
 	if err != nil {
-		return failOpenOrError(failOpen, fmt.Errorf("%w: %v", ErrHookTransportFailed, err))
+		return c.failOpenOrError(failOpen, fmt.Errorf("%w: %v", ErrHookTransportFailed, err))
 	}
 	endpoint := strings.TrimRight(baseURL, "/") + hooksEvaluatePath
 
-	payload, err := json.Marshal(req)
+	payload, err := json.Marshal(newHookWireRequest(req))
 	if err != nil {
-		return failOpenOrError(failOpen, fmt.Errorf("%w: marshal hook request: %v", ErrHookTransportFailed, err))
+		return c.failOpenOrError(failOpen, fmt.Errorf("%w: marshal hook request: %v", ErrHookTransportFailed, err))
 	}
 
 	hookCtx, cancel := context.WithTimeout(ctx, timeout)
@@ -213,13 +639,13 @@ func (c *Client) EvaluateHook(ctx context.Context, req HookEvaluateRequest) (*Ho
 
 	httpReq, err := http.NewRequestWithContext(hookCtx, http.MethodPost, endpoint, bytes.NewReader(payload))
 	if err != nil {
-		return failOpenOrError(failOpen, fmt.Errorf("%w: build hook request: %v", ErrHookTransportFailed, err))
+		return c.failOpenOrError(failOpen, fmt.Errorf("%w: build hook request: %v", ErrHookTransportFailed, err))
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set(hookTimeoutHeader, strconv.FormatInt(timeout.Milliseconds(), 10))
 	resolvedHeaders, err := resolveHeadersWithAuth(c.config.GenerationExport.Headers, c.config.GenerationExport.Auth)
 	if err != nil {
-		return failOpenOrError(failOpen, fmt.Errorf("%w: resolve auth headers: %v", ErrHookTransportFailed, err))
+		return c.failOpenOrError(failOpen, fmt.Errorf("%w: resolve auth headers: %v", ErrHookTransportFailed, err))
 	}
 	for key, value := range resolvedHeaders {
 		httpReq.Header.Set(key, value)
@@ -228,7 +654,7 @@ func (c *Client) EvaluateHook(ctx context.Context, req HookEvaluateRequest) (*Ho
 	httpClient := &http.Client{Timeout: timeout}
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
-		return failOpenOrError(failOpen, fmt.Errorf("%w: %v", ErrHookTransportFailed, err))
+		return c.failOpenOrError(failOpen, fmt.Errorf("%w: %v", ErrHookTransportFailed, err))
 	}
 	defer func() {
 		_ = httpResp.Body.Close()
@@ -236,10 +662,10 @@ func (c *Client) EvaluateHook(ctx context.Context, req HookEvaluateRequest) (*Ho
 
 	body, err := io.ReadAll(io.LimitReader(httpResp.Body, int64(maxHookEvaluateRespLen)+1))
 	if err != nil {
-		return failOpenOrError(failOpen, fmt.Errorf("%w: read hook response: %v", ErrHookTransportFailed, err))
+		return c.failOpenOrError(failOpen, fmt.Errorf("%w: read hook response: %v", ErrHookTransportFailed, err))
 	}
 	if len(body) > maxHookEvaluateRespLen {
-		return failOpenOrError(failOpen, fmt.Errorf("%w: hook response too large", ErrHookTransportFailed))
+		return c.failOpenOrError(failOpen, fmt.Errorf("%w: hook response too large", ErrHookTransportFailed))
 	}
 
 	if httpResp.StatusCode != http.StatusOK {
@@ -247,13 +673,14 @@ func (c *Client) EvaluateHook(ctx context.Context, req HookEvaluateRequest) (*Ho
 		if bodyText == "" {
 			bodyText = http.StatusText(httpResp.StatusCode)
 		}
-		return failOpenOrError(failOpen, fmt.Errorf("%w: status %d: %s", ErrHookTransportFailed, httpResp.StatusCode, bodyText))
+		return c.failOpenOrError(failOpen, fmt.Errorf("%w: status %d: %s", ErrHookTransportFailed, httpResp.StatusCode, bodyText))
 	}
 
-	var out HookEvaluateResponse
-	if err := json.Unmarshal(body, &out); err != nil {
-		return failOpenOrError(failOpen, fmt.Errorf("%w: decode hook response: %v", ErrHookTransportFailed, err))
+	var wire hookWireResponse
+	if err := json.Unmarshal(body, &wire); err != nil {
+		return c.failOpenOrError(failOpen, fmt.Errorf("%w: decode hook response: %v", ErrHookTransportFailed, err))
 	}
+	out := wire.toResponse()
 	if out.Action == "" {
 		out.Action = HookActionAllow
 	}
@@ -299,8 +726,10 @@ func allowResponse() *HookEvaluateResponse {
 	return &HookEvaluateResponse{Action: HookActionAllow}
 }
 
-func failOpenOrError(failOpen bool, err error) (*HookEvaluateResponse, error) {
+func (c *Client) failOpenOrError(failOpen bool, err error) (*HookEvaluateResponse, error) {
 	if failOpen {
+		// Fail-open turns an evaluator outage into a silent allow, so record it.
+		c.logf("agento11y: hook evaluation failed, allowing request (fail_open): %v", err)
 		return allowResponse(), nil
 	}
 	return nil, err

--- a/go/agento11y/hooks_conformance_test.go
+++ b/go/agento11y/hooks_conformance_test.go
@@ -1,0 +1,673 @@
+package agento11y
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Hook wire conformance: the request the SDK serializes and the responses it
+// parses are checked against the shared fixtures in conformance/hooks/, which
+// are the only contract for an endpoint with no generated stubs.
+
+func TestHooksRequestConformance(t *testing.T) {
+	for _, tc := range []struct {
+		fixture string
+		request HookEvaluateRequest
+	}{
+		{fixture: "request-preflight.json", request: preflightHookRequest()},
+		{fixture: "request-postflight-guard.json", request: postflightGuardHookRequest()},
+	} {
+		t.Run(tc.fixture, func(t *testing.T) {
+			payload, err := json.Marshal(newHookWireRequest(tc.request))
+			if err != nil {
+				t.Fatalf("marshal hook request: %v", err)
+			}
+
+			var got any
+			if err := json.Unmarshal(payload, &got); err != nil {
+				t.Fatalf("decode serialized request: %v", err)
+			}
+
+			for _, diff := range diffJSON("", stripEmptyHookMetadata(got), loadHookFixture(t, tc.fixture)) {
+				t.Errorf("request does not match conformance/hooks/%s: %s", tc.fixture, diff)
+			}
+		})
+	}
+}
+
+// TestHookFixtureComparisonNamesDivergentFields pins the comparator, not the
+// serializer. TestHooksRequestConformance is what checks the SDK's own output.
+// Each case takes the fixture, applies one divergence the server cannot read,
+// and asserts the diff names the offending path. Without this test, a comparator
+// that accepted a renamed discriminator or a re-encoded payload would pass every
+// conformance case while checking nothing.
+func TestHookFixtureComparisonNamesDivergentFields(t *testing.T) {
+	want := loadHookFixture(t, "request-preflight.json")
+
+	tests := []struct {
+		name     string
+		mutate   func(map[string]any)
+		wantPath string
+	}{
+		{
+			name: "renamed part discriminator",
+			mutate: func(body map[string]any) {
+				part := hookFixturePart(t, body, 0, 0)
+				delete(part, "kind")
+				part["type"] = "text"
+			},
+			wantPath: "input.messages[0].parts[0].kind",
+		},
+		{
+			name: "unknown part discriminator value",
+			mutate: func(body map[string]any) {
+				hookFixturePart(t, body, 0, 0)["kind"] = "message"
+			},
+			wantPath: "input.messages[0].parts[0].kind",
+		},
+		{
+			name: "base64 tool call input",
+			mutate: func(body map[string]any) {
+				toolCall, ok := hookFixturePart(t, body, 1, 1)["tool_call"].(map[string]any)
+				if !ok {
+					t.Fatalf("fixture tool_call part is not an object")
+				}
+				raw, err := json.Marshal(toolCall["input_json"])
+				if err != nil {
+					t.Fatalf("marshal input_json: %v", err)
+				}
+				toolCall["input_json"] = base64.StdEncoding.EncodeToString(raw)
+			},
+			wantPath: "input.messages[1].parts[1].tool_call.input_json",
+		},
+		{
+			name: "base64 tool result content",
+			mutate: func(body map[string]any) {
+				toolResult, ok := hookFixturePart(t, body, 2, 0)["tool_result"].(map[string]any)
+				if !ok {
+					t.Fatalf("fixture tool_result part is not an object")
+				}
+				raw, err := json.Marshal(toolResult["content_json"])
+				if err != nil {
+					t.Fatalf("marshal content_json: %v", err)
+				}
+				toolResult["content_json"] = base64.StdEncoding.EncodeToString(raw)
+			},
+			wantPath: "input.messages[2].parts[0].tool_result.content_json",
+		},
+		{
+			name: "raw JSON tool schema",
+			mutate: func(body map[string]any) {
+				tools, ok := hookFixtureInput(t, body)["tools"].([]any)
+				if !ok || len(tools) == 0 {
+					t.Fatalf("fixture has no tools")
+				}
+				tool, ok := tools[0].(map[string]any)
+				if !ok {
+					t.Fatalf("fixture tool is not an object")
+				}
+				delete(tool, "input_schema_json")
+				tool["input_schema"] = map[string]any{"type": "object"}
+			},
+			wantPath: "input.tools[0].input_schema_json",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mutated, ok := reparseHookJSON(t, want).(map[string]any)
+			if !ok {
+				t.Fatalf("fixture is not a JSON object")
+			}
+			tc.mutate(mutated)
+			diffs := diffJSON("", mutated, want)
+			if len(diffs) == 0 {
+				t.Fatalf("comparison accepted a divergent payload")
+			}
+			found := false
+			for _, diff := range diffs {
+				if len(diff) >= len(tc.wantPath) && diff[:len(tc.wantPath)] == tc.wantPath {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("diff did not name %s: %v", tc.wantPath, diffs)
+			}
+		})
+	}
+}
+
+// deferred is Go/Python only, so it is not part of the shared fixtures. Keep the
+// hook-side encoding covered here.
+func TestHooksRequestSerializesDeferredToolDefinitions(t *testing.T) {
+	payload, err := json.Marshal(newHookWireRequest(HookEvaluateRequest{
+		Phase: HookPhasePreflight,
+		Input: HookInput{Tools: []ToolDefinition{
+			{Name: "search", Type: "function", InputSchema: readFileToolSchema},
+			{Name: "approve_refund", Type: "function", Deferred: true},
+		}},
+	}))
+	if err != nil {
+		t.Fatalf("marshal hook request: %v", err)
+	}
+	var body struct {
+		Input struct {
+			Tools []map[string]any `json:"tools"`
+		} `json:"input"`
+	}
+	if err := json.Unmarshal(payload, &body); err != nil {
+		t.Fatalf("decode serialized request: %v", err)
+	}
+	if len(body.Input.Tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(body.Input.Tools))
+	}
+	if _, ok := body.Input.Tools[0]["deferred"]; ok {
+		t.Errorf("non-deferred tool should omit deferred: %v", body.Input.Tools[0])
+	}
+	if body.Input.Tools[1]["deferred"] != true {
+		t.Errorf("deferred tool lost its flag: %v", body.Input.Tools[1])
+	}
+	schema, ok := body.Input.Tools[0]["input_schema_json"].(string)
+	if !ok {
+		t.Fatalf("tool schema is not a base64 string: %v", body.Input.Tools[0])
+	}
+	decoded, err := base64.StdEncoding.DecodeString(schema)
+	if err != nil {
+		t.Fatalf("tool schema is not base64: %v", err)
+	}
+	if string(decoded) != string(readFileToolSchema) {
+		t.Errorf("tool schema round-trip failed: %s", decoded)
+	}
+}
+
+func TestHooksResponseConformanceAllow(t *testing.T) {
+	resp := parseHookFixtureResponse(t, "allow")
+
+	if resp.Action != HookActionAllow {
+		t.Fatalf("expected allow, got %q", resp.Action)
+	}
+	if len(resp.Evaluations) != 1 {
+		t.Fatalf("expected 1 evaluation, got %d", len(resp.Evaluations))
+	}
+	eval := resp.Evaluations[0]
+	if eval.RuleID != "pii-detect" || eval.EvaluatorID != "evaluator-pii" || eval.EvaluatorKind != "regex" {
+		t.Errorf("unexpected evaluation identity: %#v", eval)
+	}
+	if !eval.Passed || eval.LatencyMs != 12 || eval.Explanation != "no PII matches" {
+		t.Errorf("unexpected evaluation outcome: %#v", eval)
+	}
+	if resp.TransformedInput != nil {
+		t.Errorf("allow response should carry no transformed input: %#v", resp.TransformedInput)
+	}
+}
+
+func TestHooksResponseConformanceDeny(t *testing.T) {
+	resp := parseHookFixtureResponse(t, "deny")
+
+	if resp.Action != HookActionDeny {
+		t.Fatalf("expected deny, got %q", resp.Action)
+	}
+	if resp.RuleID != "block-destructive-bash" {
+		t.Errorf("unexpected rule id: %q", resp.RuleID)
+	}
+	if resp.Reason != "Bash(*rm*) is not allowed in this environment" {
+		t.Errorf("unexpected reason: %q", resp.Reason)
+	}
+	err := HookDeniedFromResponse(&resp)
+	if err == nil {
+		t.Fatal("expected a HookDeniedError for a deny response")
+	}
+	denied, ok := err.(*HookDeniedError)
+	if !ok {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	if denied.RuleID != "block-destructive-bash" || denied.Reason != resp.Reason {
+		t.Errorf("denied error lost rule identity: %#v", denied)
+	}
+}
+
+func TestHooksResponseConformanceTransformedInput(t *testing.T) {
+	resp := parseHookFixtureResponse(t, "allow_with_transformed_input")
+
+	if resp.Action != HookActionAllow {
+		t.Fatalf("expected allow, got %q", resp.Action)
+	}
+	input := resp.TransformedInput
+	if input == nil {
+		t.Fatal("transformed input was dropped")
+	}
+	if input.SystemPrompt != "You are a careful assistant." {
+		t.Errorf("unexpected system prompt: %q", input.SystemPrompt)
+	}
+	if input.ConversationPreview != "user: Delete the cache directory under [REDACTED]." {
+		t.Errorf("unexpected conversation preview: %q", input.ConversationPreview)
+	}
+	if len(input.Messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(input.Messages))
+	}
+
+	if input.Messages[0].Role != RoleUser || len(input.Messages[0].Parts) != 1 {
+		t.Fatalf("unexpected first message: %#v", input.Messages[0])
+	}
+	if part := input.Messages[0].Parts[0]; part.Kind != PartKindText ||
+		part.Text != "Delete the cache directory under [REDACTED]." {
+		t.Errorf("text part was not preserved: %#v", part)
+	}
+
+	assistant := input.Messages[1]
+	if assistant.Role != RoleAssistant || len(assistant.Parts) != 2 {
+		t.Fatalf("unexpected assistant message: %#v", assistant)
+	}
+	if assistant.Parts[0].Kind != PartKindThinking ||
+		assistant.Parts[0].Thinking != "The request is destructive, so inspect the directory first." {
+		t.Errorf("thinking part was not preserved: %#v", assistant.Parts[0])
+	}
+	callPart := assistant.Parts[1]
+	if callPart.Kind != PartKindToolCall || callPart.ToolCall == nil {
+		t.Fatalf("tool call part was dropped: %#v", callPart)
+	}
+	if callPart.ToolCall.ID != "call-bash" || callPart.ToolCall.Name != "Bash" {
+		t.Errorf("tool call identity lost: %#v", callPart.ToolCall)
+	}
+	if got := string(callPart.ToolCall.InputJSON); got != `{"command":"rm -rf /tmp/cache"}` {
+		t.Errorf("tool call arguments not base64-decoded: %s", got)
+	}
+
+	toolMsg := input.Messages[2]
+	if toolMsg.Role != RoleTool || toolMsg.Name != "Bash" || len(toolMsg.Parts) != 1 {
+		t.Fatalf("unexpected tool message: %#v", toolMsg)
+	}
+	resultPart := toolMsg.Parts[0]
+	if resultPart.Kind != PartKindToolResult || resultPart.ToolResult == nil {
+		t.Fatalf("tool result part was dropped: %#v", resultPart)
+	}
+	result := resultPart.ToolResult
+	if result.ToolCallID != "call-bash" || result.Name != "Bash" || !result.IsError {
+		t.Errorf("tool result identity lost: %#v", result)
+	}
+	if result.Content != "rm: cannot remove '/tmp/cache': Permission denied" {
+		t.Errorf("tool result content lost: %q", result.Content)
+	}
+	if got := string(result.ContentJSON); got != `{"exit_code":1}` {
+		t.Errorf("tool result content not base64-decoded: %s", got)
+	}
+
+	if len(input.Tools) != 1 {
+		t.Fatalf("expected 1 tool definition, got %d", len(input.Tools))
+	}
+	tool := input.Tools[0]
+	if tool.Name != "Bash" || tool.Description != "Run a shell command." || tool.Type != "function" {
+		t.Errorf("tool definition lost fields: %#v", tool)
+	}
+	if got := string(tool.InputSchema); got != string(bashToolSchema) {
+		t.Errorf("tool schema not base64-decoded: %s", got)
+	}
+}
+
+func TestHooksResponseConformanceAcceptsProtoJSONRoles(t *testing.T) {
+	// Any emitter that marshals the proto enum directly sends integer roles.
+	var wire hookWireResponse
+	body := []byte(`{"action":"allow","transformed_input":{"messages":[
+		{"role":2,"parts":[{"text":"hello"}]},
+		{"role":3,"parts":[{"kind":"tool_result","tool_result":{"tool_call_id":"call-1","content":"ok"}}]}
+	]},"evaluations":[]}`)
+	if err := json.Unmarshal(body, &wire); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	resp := wire.toResponse()
+	if resp.TransformedInput == nil || len(resp.TransformedInput.Messages) != 2 {
+		t.Fatalf("unexpected transformed input: %#v", resp.TransformedInput)
+	}
+	first := resp.TransformedInput.Messages[0]
+	if first.Role != RoleAssistant {
+		t.Errorf("numeric assistant role not mapped: %q", first.Role)
+	}
+	if len(first.Parts) != 1 || first.Parts[0].Kind != PartKindText || first.Parts[0].Text != "hello" {
+		t.Errorf("kindless text part not recovered: %#v", first.Parts)
+	}
+	second := resp.TransformedInput.Messages[1]
+	if second.Role != RoleTool || len(second.Parts) != 1 || second.Parts[0].ToolResult == nil {
+		t.Errorf("numeric tool role or tool result lost: %#v", second)
+	}
+}
+
+func TestHooksResponsePayloadDecodingIsAlwaysJSON(t *testing.T) {
+	// Response payloads are base64 of whatever bytes the proto field held, and
+	// nothing guarantees those bytes are JSON. Whatever comes back has to stay a
+	// valid JSON document: ToolCall.InputJSON is a json.RawMessage, so invalid
+	// bytes there fail every later marshal of that part. Python and JS resolve
+	// these four cases the same way; see conformance/hooks/README.md.
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "base64 of JSON",
+			value: base64.StdEncoding.EncodeToString([]byte(`{"command":"ls /tmp"}`)),
+			want:  `{"command":"ls /tmp"}`,
+		},
+		{
+			name:  "base64 of plain text",
+			value: base64.StdEncoding.EncodeToString([]byte("plain text tool output")),
+			want:  `"plain text tool output"`,
+		},
+		{
+			name:  "embedded JSON text",
+			value: `{"command":"ls /tmp"}`,
+			want:  `{"command":"ls /tmp"}`,
+		},
+		{
+			name:  "neither base64 nor JSON",
+			value: "not base64 either",
+			want:  `"not base64 either"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := json.Marshal(map[string]any{
+				"action": "allow",
+				"transformed_input": map[string]any{
+					"messages": []any{map[string]any{
+						"role": "assistant",
+						"parts": []any{map[string]any{
+							"kind":      "tool_call",
+							"tool_call": map[string]any{"id": "call-1", "name": "Bash", "input_json": tc.value},
+						}},
+					}},
+				},
+			})
+			if err != nil {
+				t.Fatalf("build response: %v", err)
+			}
+			var wire hookWireResponse
+			if err := json.Unmarshal(body, &wire); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			resp := wire.toResponse()
+			if resp.TransformedInput == nil || len(resp.TransformedInput.Messages) != 1 {
+				t.Fatalf("transformed input was dropped: %#v", resp.TransformedInput)
+			}
+			part := resp.TransformedInput.Messages[0].Parts[0]
+			if part.ToolCall == nil {
+				t.Fatalf("tool call part was dropped: %#v", part)
+			}
+			if got := string(part.ToolCall.InputJSON); got != tc.want {
+				t.Errorf("decoded payload: got %s, want %s", got, tc.want)
+			}
+			// A transformed part a caller cannot re-export or re-send is not a
+			// usable transform.
+			if _, err := json.Marshal(part); err != nil {
+				t.Errorf("transformed part cannot be marshalled again: %v", err)
+			}
+		})
+	}
+}
+
+func TestHooksResponseMalformedToolSchemaKeepsTheVerdict(t *testing.T) {
+	// input_schema_json is base64 on the response path. A value that is not
+	// decodable must not fail the unmarshal of the whole body. That error routes to
+	// failOpenOrError, and the caller loses a deny it has to enforce.
+	tests := []struct {
+		name   string
+		schema string
+	}{
+		{name: "raw JSON object", schema: `{"type":"object"}`},
+		{name: "unpadded base64", schema: `"eyJhIjoxfQ"`},
+		{name: "plain text", schema: `"not base64 either"`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := fmt.Sprintf(
+				`{"action":"deny","rule_id":"block-destructive-bash","reason":"denied",
+				  "transformed_input":{"tools":[{"name":"Bash","input_schema_json":%s}]},
+				  "evaluations":[]}`, tc.schema)
+			var wire hookWireResponse
+			if err := json.Unmarshal([]byte(body), &wire); err != nil {
+				t.Fatalf("a malformed tool schema must not fail the response decode: %v", err)
+			}
+			resp := wire.toResponse()
+			if resp.Action != HookActionDeny || resp.RuleID != "block-destructive-bash" {
+				t.Fatalf("deny was lost: %#v", resp)
+			}
+			if HookDeniedFromResponse(&resp) == nil {
+				t.Error("deny response must still produce a denial")
+			}
+		})
+	}
+}
+
+func TestHooksRequestKeepsAnUnparsablePayload(t *testing.T) {
+	// Streaming providers accumulate input_json_delta without validating it, so a
+	// truncated payload reaches the hook path. Failing the marshal would turn a
+	// payload problem into a fail-open allow or a fail-closed error, and Python
+	// and JS both send the text instead.
+	payload, err := json.Marshal(newHookWireRequest(HookEvaluateRequest{
+		Phase: HookPhasePreflight,
+		Input: HookInput{Messages: []Message{{
+			Role: RoleAssistant,
+			Parts: []Part{
+				ToolCallPart(ToolCall{ID: "call-1", Name: "Bash", InputJSON: json.RawMessage(`{"command":"truncat`)}),
+				ToolResultPart(ToolResult{ToolCallID: "call-1", ContentJSON: json.RawMessage(`{"exit_code`)}),
+			},
+		}}},
+	}))
+	if err != nil {
+		t.Fatalf("an unparsable payload must not fail the request marshal: %v", err)
+	}
+
+	var body struct {
+		Input struct {
+			Messages []struct {
+				Parts []map[string]any `json:"parts"`
+			} `json:"messages"`
+		} `json:"input"`
+	}
+	if err := json.Unmarshal(payload, &body); err != nil {
+		t.Fatalf("decode serialized request: %v", err)
+	}
+	parts := body.Input.Messages[0].Parts
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(parts))
+	}
+	call, ok := parts[0]["tool_call"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool call part lost its payload: %v", parts[0])
+	}
+	if got := call["input_json"]; got != `{"command":"truncat` {
+		t.Errorf("unparsable tool arguments: got %#v, want the original text as a JSON string", got)
+	}
+	result, ok := parts[1]["tool_result"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool result part lost its payload: %v", parts[1])
+	}
+	if got := result["content_json"]; got != `{"exit_code` {
+		t.Errorf("unparsable tool result content: got %#v, want the original text as a JSON string", got)
+	}
+}
+
+func TestHooksRequestDropsPartsTheServerCannotRead(t *testing.T) {
+	// Only Go's model.Part can hold a media part or a kind-less part. The server
+	// has no media kind, and its default branch would decode one as an empty text
+	// part. The hook serializer therefore drops any part without a payload the
+	// server can read, which is what Python and JS do. A message left with no parts
+	// serializes as [] in all three SDKs.
+	payload, err := json.Marshal(newHookWireRequest(HookEvaluateRequest{
+		Phase: HookPhasePreflight,
+		Input: HookInput{Messages: []Message{
+			{Role: RoleUser, Parts: []Part{
+				{Kind: PartKindMedia, Media: &Media{Kind: "image", URL: "https://example.test/a.png"}},
+				TextPart(""),
+				ThinkingPart(""),
+				{Kind: PartKindToolCall},
+				{Kind: PartKindToolResult},
+				TextPart("describe this"),
+			}},
+			{Role: RoleUser, Parts: []Part{
+				{Kind: PartKindMedia, Media: &Media{Kind: "image", URL: "https://example.test/b.png"}},
+			}},
+		}},
+	}))
+	if err != nil {
+		t.Fatalf("marshal hook request: %v", err)
+	}
+
+	var body struct {
+		Input struct {
+			Messages []map[string]any `json:"messages"`
+		} `json:"input"`
+	}
+	if err := json.Unmarshal(payload, &body); err != nil {
+		t.Fatalf("decode serialized request: %v", err)
+	}
+	if len(body.Input.Messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(body.Input.Messages))
+	}
+	first, ok := body.Input.Messages[0]["parts"].([]any)
+	if !ok || len(first) != 1 {
+		t.Fatalf("expected only the non-empty text part to survive, got %v", body.Input.Messages[0]["parts"])
+	}
+	if kind := first[0].(map[string]any)["kind"]; kind != string(PartKindText) {
+		t.Errorf("surviving part is not text: %v", first[0])
+	}
+	second, ok := body.Input.Messages[1]["parts"].([]any)
+	if !ok {
+		t.Fatalf("a part-less message must serialize parts as [], got %v", body.Input.Messages[1]["parts"])
+	}
+	if len(second) != 0 {
+		t.Errorf("expected no parts, got %v", second)
+	}
+}
+
+func TestHooksResponseEmptyTransformedInputIsNoTransform(t *testing.T) {
+	// The server emits transformed_input:{} whenever a rule returns a non-nil but
+	// empty HookGenerationInput. A caller checking only for nil would replace the
+	// prompt with nothing. Python and JS report no transform for this body.
+	var wire hookWireResponse
+	if err := json.Unmarshal([]byte(`{"action":"allow","transformed_input":{},"evaluations":[]}`), &wire); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp := wire.toResponse(); resp.TransformedInput != nil {
+		t.Errorf("an empty transformed_input is not a transform: %#v", resp.TransformedInput)
+	}
+}
+
+func TestHooksResponsePartParsing(t *testing.T) {
+	// kind names the field the parser reads, and the parser commits to it: a part
+	// that lost that field is dropped rather than rebuilt from a leftover field,
+	// which would report a part the rule never wrote. An empty payload carries no
+	// content either, and keeping it would append an empty part that the request
+	// serializer drops on the way back out. A tool call without a name goes too,
+	// because the caller can neither route nor re-send it. A part with no kind at
+	// all is still read from whichever payload field is set, because the server
+	// always sets kind, so that shape only reaches the SDK from a hand-written or
+	// protobuf-JSON body.
+	//
+	// Python and JS resolve every case here the same way.
+	tests := []struct {
+		name string
+		part string
+		want *Part
+	}{
+		{name: "text", part: `{"kind":"text","text":"kept"}`, want: &Part{Kind: PartKindText, Text: "kept"}},
+		{name: "text without text", part: `{"kind":"text","text":""}`},
+		// The shape the server emits for an empty text part: its encoder omits the
+		// field rather than sending "".
+		{name: "text without a text field", part: `{"kind":"text"}`},
+		{
+			name: "thinking",
+			part: `{"kind":"thinking","thinking":"planning"}`,
+			want: &Part{Kind: PartKindThinking, Thinking: "planning"},
+		},
+		{name: "thinking without thinking", part: `{"kind":"thinking","thinking":""}`},
+		{name: "thinking without a thinking field", part: `{"kind":"thinking"}`},
+		{
+			name: "tool call",
+			part: `{"kind":"tool_call","tool_call":{"id":"call-1","name":"Bash"}}`,
+			want: &Part{Kind: PartKindToolCall, ToolCall: &ToolCall{ID: "call-1", Name: "Bash"}},
+		},
+		{name: "tool call without payload", part: `{"kind":"tool_call"}`},
+		{name: "tool call without name", part: `{"kind":"tool_call","tool_call":{"id":"call-1"}}`},
+		{
+			name: "tool result",
+			part: `{"kind":"tool_result","tool_result":{"tool_call_id":"call-1","content":"ok"}}`,
+			want: &Part{Kind: PartKindToolResult, ToolResult: &ToolResult{ToolCallID: "call-1", Content: "ok"}},
+		},
+		{name: "tool result without payload", part: `{"kind":"tool_result"}`},
+		{name: "unknown kind", part: `{"kind":"image"}`},
+		{
+			name: "unknown kind with text",
+			part: `{"kind":"image","text":"described by the server as text"}`,
+			want: &Part{Kind: PartKindText, Text: "described by the server as text"},
+		},
+		{name: "unknown kind with a tool call", part: `{"kind":"image","tool_call":{"name":"Bash"}}`},
+		{name: "tool call kind with leftover text", part: `{"kind":"tool_call","text":"not a tool call"}`},
+		{name: "tool result kind with leftover text", part: `{"kind":"tool_result","text":"not a tool result"}`},
+		{name: "thinking kind with leftover text", part: `{"kind":"thinking","thinking":"","text":"not thinking"}`},
+		{name: "text kind with leftover thinking", part: `{"kind":"text","text":"","thinking":"not text"}`},
+		{name: "text kind with a leftover tool call", part: `{"kind":"text","text":"","tool_call":{"name":"Bash"}}`},
+		{name: "no kind with text", part: `{"text":"recovered text"}`, want: &Part{Kind: PartKindText, Text: "recovered text"}},
+		{
+			name: "no kind with thinking",
+			part: `{"thinking":"recovered thinking"}`,
+			want: &Part{Kind: PartKindThinking, Thinking: "recovered thinking"},
+		},
+		{
+			name: "no kind with a tool call",
+			part: `{"tool_call":{"id":"call-1","name":"Bash"}}`,
+			want: &Part{Kind: PartKindToolCall, ToolCall: &ToolCall{ID: "call-1", Name: "Bash"}},
+		},
+		{
+			name: "no kind with a tool result",
+			part: `{"tool_result":{"tool_call_id":"call-1","content":"ok"}}`,
+			want: &Part{Kind: PartKindToolResult, ToolResult: &ToolResult{ToolCallID: "call-1", Content: "ok"}},
+		},
+		{name: "empty part", part: `{}`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := fmt.Sprintf(
+				`{"action":"allow","transformed_input":{"messages":[{"role":"assistant","parts":[%s]}]},"evaluations":[]}`,
+				tc.part)
+			var wire hookWireResponse
+			if err := json.Unmarshal([]byte(body), &wire); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			resp := wire.toResponse()
+			if resp.TransformedInput == nil || len(resp.TransformedInput.Messages) != 1 {
+				t.Fatalf("unexpected transformed input: %#v", resp.TransformedInput)
+			}
+			want := make([]Part, 0, 1)
+			if tc.want != nil {
+				want = append(want, *tc.want)
+			}
+			got := resp.TransformedInput.Messages[0].Parts
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("got %s, want %s", formatParts(got), formatParts(want))
+			}
+		})
+	}
+}
+
+// formatParts renders parts with their payloads dereferenced, which %#v does not.
+func formatParts(parts []Part) string {
+	rendered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		switch {
+		case part.ToolCall != nil:
+			rendered = append(rendered, fmt.Sprintf("{%s %#v}", part.Kind, *part.ToolCall))
+		case part.ToolResult != nil:
+			rendered = append(rendered, fmt.Sprintf("{%s %#v}", part.Kind, *part.ToolResult))
+		default:
+			rendered = append(rendered, fmt.Sprintf("{%s %q %q}", part.Kind, part.Text, part.Thinking))
+		}
+	}
+	return "[" + strings.Join(rendered, " ") + "]"
+}

--- a/go/agento11y/hooks_fixtures_test.go
+++ b/go/agento11y/hooks_fixtures_test.go
@@ -1,0 +1,327 @@
+package agento11y
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// Shared helpers for the hook conformance and integration suites: the fixture
+// loader, the preflight request builder, the one allowed normalization, and a
+// path-reporting JSON diff.
+
+var bashToolSchema = json.RawMessage(
+	`{"type":"object","properties":{"command":{"type":"string","description":"Shell command to run."}},"required":["command"]}`,
+)
+
+var readFileToolSchema = json.RawMessage(
+	`{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}`,
+)
+
+// hookFixturePath resolves a fixture from the working directory, which `go test`
+// sets to the package directory: go/agento11y is two levels below the repository
+// root.
+func hookFixturePath(t *testing.T, name string) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("resolve working directory: %v", err)
+	}
+	return filepath.Join(wd, "..", "..", "conformance", "hooks", name)
+}
+
+func loadHookFixture(t *testing.T, name string) any {
+	t.Helper()
+	data, err := os.ReadFile(hookFixturePath(t, name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	var out any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("decode fixture %s: %v", name, err)
+	}
+	return out
+}
+
+func loadHookResponseFixture(t *testing.T, name string) json.RawMessage {
+	t.Helper()
+	data, err := os.ReadFile(hookFixturePath(t, "responses.json"))
+	if err != nil {
+		t.Fatalf("read responses fixture: %v", err)
+	}
+	var fixtures map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fixtures); err != nil {
+		t.Fatalf("decode responses fixture: %v", err)
+	}
+	body, ok := fixtures[name]
+	if !ok {
+		t.Fatalf("responses.json has no %q scenario", name)
+	}
+	return body
+}
+
+func parseHookFixtureResponse(t *testing.T, name string) HookEvaluateResponse {
+	t.Helper()
+	var wire hookWireResponse
+	if err := json.Unmarshal(loadHookResponseFixture(t, name), &wire); err != nil {
+		t.Fatalf("parse %s response: %v", name, err)
+	}
+	return wire.toResponse()
+}
+
+func reparseHookJSON(t *testing.T, value any) any {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal value: %v", err)
+	}
+	var out any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal value: %v", err)
+	}
+	return out
+}
+
+func hookFixtureInput(t *testing.T, body map[string]any) map[string]any {
+	t.Helper()
+	input, ok := body["input"].(map[string]any)
+	if !ok {
+		t.Fatalf("fixture has no input object")
+	}
+	return input
+}
+
+func hookFixturePart(t *testing.T, body map[string]any, message, part int) map[string]any {
+	t.Helper()
+	messages, ok := hookFixtureInput(t, body)["messages"].([]any)
+	if !ok || len(messages) <= message {
+		t.Fatalf("fixture has no message %d", message)
+	}
+	msg, ok := messages[message].(map[string]any)
+	if !ok {
+		t.Fatalf("fixture message %d is not an object", message)
+	}
+	parts, ok := msg["parts"].([]any)
+	if !ok || len(parts) <= part {
+		t.Fatalf("fixture message %d has no part %d", message, part)
+	}
+	out, ok := parts[part].(map[string]any)
+	if !ok {
+		t.Fatalf("fixture message %d part %d is not an object", message, part)
+	}
+	return out
+}
+
+// stripEmptyHookMetadata removes `metadata` keys whose value is an empty object.
+// model.Part.Metadata is a value-type struct, so `omitempty` cannot apply and
+// every Go part carries `"metadata":{}`. This is the only normalization the
+// contract allows; see conformance/hooks/README.md.
+func stripEmptyHookMetadata(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, item := range typed {
+			if key == "metadata" {
+				if nested, ok := item.(map[string]any); ok && len(nested) == 0 {
+					continue
+				}
+			}
+			out[key] = stripEmptyHookMetadata(item)
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, stripEmptyHookMetadata(item))
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+// diffJSON reports every structural difference between got and want as a
+// dotted JSON path plus the two values, so a failure names the offending field
+// instead of dumping two payloads.
+func diffJSON(path string, got, want any) []string {
+	switch wantTyped := want.(type) {
+	case map[string]any:
+		gotTyped, ok := got.(map[string]any)
+		if !ok {
+			return []string{fmt.Sprintf("%s: got %s, want an object", hookDiffPath(path), hookDiffValue(got))}
+		}
+		var diffs []string
+		for _, key := range sortedHookKeys(wantTyped, gotTyped) {
+			gotValue, gotHas := gotTyped[key]
+			wantValue, wantHas := wantTyped[key]
+			childPath := key
+			if path != "" {
+				childPath = path + "." + key
+			}
+			switch {
+			case !gotHas:
+				diffs = append(diffs, fmt.Sprintf("%s: missing, want %s", childPath, hookDiffValue(wantValue)))
+			case !wantHas:
+				diffs = append(diffs, fmt.Sprintf("%s: unexpected %s", childPath, hookDiffValue(gotValue)))
+			default:
+				diffs = append(diffs, diffJSON(childPath, gotValue, wantValue)...)
+			}
+		}
+		return diffs
+	case []any:
+		gotTyped, ok := got.([]any)
+		if !ok {
+			return []string{fmt.Sprintf("%s: got %s, want an array", hookDiffPath(path), hookDiffValue(got))}
+		}
+		if len(gotTyped) != len(wantTyped) {
+			return []string{fmt.Sprintf("%s: got %d items, want %d", hookDiffPath(path), len(gotTyped), len(wantTyped))}
+		}
+		var diffs []string
+		for i := range wantTyped {
+			diffs = append(diffs, diffJSON(fmt.Sprintf("%s[%d]", path, i), gotTyped[i], wantTyped[i])...)
+		}
+		return diffs
+	default:
+		if !reflect.DeepEqual(got, want) {
+			return []string{fmt.Sprintf("%s: got %s, want %s", hookDiffPath(path), hookDiffValue(got), hookDiffValue(want))}
+		}
+		return nil
+	}
+}
+
+func hookDiffPath(path string) string {
+	if path == "" {
+		return "<root>"
+	}
+	return path
+}
+
+func hookDiffValue(value any) string {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprintf("%v", value)
+	}
+	return string(data)
+}
+
+func sortedHookKeys(maps ...map[string]any) []string {
+	seen := map[string]struct{}{}
+	for _, m := range maps {
+		for key := range m {
+			seen[key] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// postflightGuardHookRequest builds
+// conformance/hooks/request-postflight-guard.json from the public Go SDK types.
+// The shipped guards evaluate a tool call under input.output, and the server's
+// tool filter scans that field before input.messages.
+func postflightGuardHookRequest() HookEvaluateRequest {
+	return HookEvaluateRequest{
+		Phase: HookPhasePostflight,
+		Context: HookContext{
+			AgentName:    "conformance-guard",
+			AgentVersion: "1.2.3",
+			Model:        &HookModel{Provider: "anthropic", Name: "claude-sonnet-4"},
+		},
+		Input: HookInput{
+			Output: []Message{{
+				Role: RoleAssistant,
+				Parts: []Part{ToolCallPart(ToolCall{
+					ID:        "call-bash",
+					Name:      "Bash",
+					InputJSON: json.RawMessage(`{"command":"rm -rf /tmp/cache"}`),
+				})},
+			}},
+		},
+	}
+}
+
+// preflightHookRequest builds conformance/hooks/request-preflight.json from the
+// public Go SDK types.
+func preflightHookRequest() HookEvaluateRequest {
+	return HookEvaluateRequest{
+		Phase: HookPhasePreflight,
+		Context: HookContext{
+			AgentName:      "conformance-agent",
+			AgentVersion:   "1.2.3",
+			Model:          &HookModel{Provider: "anthropic", Name: "claude-sonnet-4"},
+			Tags:           map[string]string{"env": "test", "team": "agent-observability"},
+			ConversationID: "conv-hooks-conformance",
+			TraceID:        "0123456789abcdef0123456789abcdef",
+			SpanID:         "0123456789abcdef",
+		},
+		Input: HookInput{
+			SystemPrompt: "You are a careful assistant.",
+			Messages: []Message{
+				{
+					Role:  RoleUser,
+					Parts: []Part{TextPart("Delete the cache directory under /tmp.")},
+				},
+				{
+					Role: RoleAssistant,
+					Parts: []Part{
+						ThinkingPart("The request is destructive, so inspect the directory first."),
+						ToolCallPart(ToolCall{
+							ID:        "call-read",
+							Name:      "read_file",
+							InputJSON: json.RawMessage(`{"path":"/tmp/cache/manifest.json"}`),
+						}),
+						ToolCallPart(ToolCall{
+							ID:        "call-bash",
+							Name:      "Bash",
+							InputJSON: json.RawMessage(`{"command":"rm -rf /tmp/cache"}`),
+						}),
+					},
+				},
+				{
+					Role: RoleTool,
+					Name: "read_file",
+					Parts: []Part{ToolResultPart(ToolResult{
+						ToolCallID:  "call-read",
+						Name:        "read_file",
+						Content:     "3 entries",
+						ContentJSON: json.RawMessage(`{"entries":3}`),
+					})},
+				},
+				{
+					Role: RoleTool,
+					Name: "Bash",
+					Parts: []Part{ToolResultPart(ToolResult{
+						ToolCallID:  "call-bash",
+						Name:        "Bash",
+						IsError:     true,
+						Content:     "rm: cannot remove '/tmp/cache': Permission denied",
+						ContentJSON: json.RawMessage(`{"exit_code":1}`),
+					})},
+				},
+			},
+			Tools: []ToolDefinition{
+				{
+					Name:        "Bash",
+					Description: "Run a shell command.",
+					Type:        "function",
+					InputSchema: bashToolSchema,
+				},
+				{
+					Name:        "read_file",
+					Description: "Read a file from disk.",
+					Type:        "function",
+					InputSchema: readFileToolSchema,
+				},
+			},
+			ConversationPreview: "user: Delete the cache directory under /tmp.",
+		},
+	}
+}

--- a/go/agento11y/hooks_integration_test.go
+++ b/go/agento11y/hooks_integration_test.go
@@ -1,0 +1,495 @@
+package agento11y
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// Guard behavior of the Go SDK against a real local HTTP server. The other hook
+// tests decode the captured body back into the SDK's own request type, so an
+// encoding the server cannot read round-trips cleanly and looks identical to a
+// correct one. These cases run the full transport and compare each captured body
+// with conformance/hooks/request-preflight.json instead.
+
+// hookServerResponse is what the responder returns for one hooks:evaluate
+// request: the per-request responder model of the JS plugins/pi/src/testHttp.ts
+// helper, whose status, body, and delay cover allow, deny, transport failure,
+// timeout, and malformed-response cases from one server.
+type hookServerResponse struct {
+	status int
+	body   string
+	delay  time.Duration
+}
+
+type hookServerRequest struct {
+	path    string
+	headers http.Header
+	raw     string
+	payload any
+}
+
+type hookTestServer struct {
+	*httptest.Server
+	mu          sync.Mutex
+	requests    []hookServerRequest
+	inFlight    int
+	maxInFlight int
+}
+
+func startHookTestServer(t *testing.T, respond func(hookServerRequest) hookServerResponse) *hookTestServer {
+	t.Helper()
+	server := &hookTestServer{}
+	server.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		raw, _ := io.ReadAll(req.Body)
+		call := hookServerRequest{
+			path:    req.URL.Path,
+			headers: req.Header.Clone(),
+			raw:     string(raw),
+		}
+		_ = json.Unmarshal(raw, &call.payload)
+
+		server.mu.Lock()
+		server.requests = append(server.requests, call)
+		server.inFlight++
+		if server.inFlight > server.maxInFlight {
+			server.maxInFlight = server.inFlight
+		}
+		server.mu.Unlock()
+		defer func() {
+			server.mu.Lock()
+			server.inFlight--
+			server.mu.Unlock()
+		}()
+
+		out := respond(call)
+		if out.delay > 0 {
+			time.Sleep(out.delay)
+		}
+		status := out.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		// The client aborts on timeout, so a delayed write can fail. That is
+		// the case under test.
+		_, _ = w.Write([]byte(out.body))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func (s *hookTestServer) calls() []hookServerRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]hookServerRequest(nil), s.requests...)
+}
+
+func (s *hookTestServer) concurrentPeak() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.maxInFlight
+}
+
+func respondWith(status int, body string) func(hookServerRequest) hookServerResponse {
+	return func(hookServerRequest) hookServerResponse {
+		return hookServerResponse{status: status, body: body}
+	}
+}
+
+type hookIntegrationOptions struct {
+	enabled  bool
+	failOpen bool
+	phases   []HookPhase
+	timeout  time.Duration
+	auth     AuthConfig
+}
+
+func newHookIntegrationClient(t *testing.T, endpoint string, options hookIntegrationOptions) (*Client, *bytes.Buffer) {
+	t.Helper()
+	logs := &bytes.Buffer{}
+	phases := options.phases
+	if phases == nil {
+		phases = []HookPhase{HookPhasePreflight}
+	}
+	timeout := options.timeout
+	if timeout == 0 {
+		timeout = 5 * time.Second
+	}
+	failOpen := options.failOpen
+	client := NewClient(Config{
+		Tracer: noop.NewTracerProvider().Tracer("agento11y-go-hooks-integration"),
+		Logger: log.New(logs, "", 0),
+		GenerationExport: GenerationExportConfig{
+			Protocol:        GenerationExportProtocolHTTP,
+			Endpoint:        endpoint + "/api/v1/generations:export",
+			Insecure:        BoolPtr(true),
+			Auth:            options.auth,
+			BatchSize:       1,
+			FlushInterval:   time.Hour,
+			QueueSize:       1,
+			MaxRetries:      1,
+			InitialBackoff:  time.Millisecond,
+			MaxBackoff:      time.Millisecond,
+			PayloadMaxBytes: 1 << 20,
+		},
+		API: APIConfig{Endpoint: endpoint},
+		Hooks: HooksConfig{
+			Enabled:  options.enabled,
+			Phases:   phases,
+			Timeout:  timeout,
+			FailOpen: &failOpen,
+		},
+		testGenerationExporter: newNoopGenerationExporter(nil),
+		testDisableWorker:      true,
+	})
+	t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
+	return client, logs
+}
+
+func hookFixtureResponseBody(t *testing.T, name string) string {
+	t.Helper()
+	return string(loadHookResponseFixture(t, name))
+}
+
+// assertPreflightHookRequest checks the body the SDK actually put on the wire.
+func assertPreflightHookRequest(t *testing.T, server *hookTestServer) {
+	t.Helper()
+	calls := server.calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly one hook request, got %d", len(calls))
+	}
+	call := calls[0]
+	if call.path != hooksEvaluatePath {
+		t.Errorf("unexpected path %q", call.path)
+	}
+	if got := call.headers.Get("Content-Type"); got != "application/json" {
+		t.Errorf("unexpected content type %q", got)
+	}
+	for _, diff := range diffJSON("", stripEmptyHookMetadata(call.payload), loadHookFixture(t, "request-preflight.json")) {
+		t.Errorf("captured request body does not match the shared fixture: %s", diff)
+	}
+}
+
+func assertFailOpenWarning(t *testing.T, logs *bytes.Buffer, wantSubstring string) {
+	t.Helper()
+	text := logs.String()
+	if !strings.Contains(text, "allowing request (fail_open)") {
+		t.Errorf("a swallowed hook failure must be logged, got %q", text)
+	}
+	if wantSubstring != "" && !strings.Contains(text, wantSubstring) {
+		t.Errorf("warning does not mention %q, got %q", wantSubstring, text)
+	}
+}
+
+func TestHooksIntegrationAllowUnderBothPolicies(t *testing.T) {
+	for _, failOpen := range []bool{true, false} {
+		t.Run(hookPolicyName(failOpen), func(t *testing.T) {
+			server := startHookTestServer(t, respondWith(http.StatusOK, hookFixtureResponseBody(t, "allow")))
+			client, _ := newHookIntegrationClient(t, server.URL, hookIntegrationOptions{enabled: true, failOpen: failOpen})
+
+			resp, err := client.EvaluateHook(context.Background(), preflightHookRequest())
+			if err != nil {
+				t.Fatalf("evaluate hook: %v", err)
+			}
+			if resp.Action != HookActionAllow {
+				t.Fatalf("expected allow, got %q", resp.Action)
+			}
+			if HookDeniedFromResponse(resp) != nil {
+				t.Error("allow response must not produce a denial")
+			}
+			if len(resp.Evaluations) != 1 || resp.Evaluations[0].RuleID != "pii-detect" {
+				t.Errorf("unexpected evaluations: %#v", resp.Evaluations)
+			}
+			assertPreflightHookRequest(t, server)
+		})
+	}
+}
+
+func TestHooksIntegrationDenyUnderBothPolicies(t *testing.T) {
+	for _, failOpen := range []bool{true, false} {
+		t.Run(hookPolicyName(failOpen), func(t *testing.T) {
+			server := startHookTestServer(t, respondWith(http.StatusOK, hookFixtureResponseBody(t, "deny")))
+			client, _ := newHookIntegrationClient(t, server.URL, hookIntegrationOptions{enabled: true, failOpen: failOpen})
+
+			resp, err := client.EvaluateHook(context.Background(), preflightHookRequest())
+			if err != nil {
+				t.Fatalf("evaluate hook: %v", err)
+			}
+			if resp.Action != HookActionDeny {
+				t.Fatalf("expected deny, got %q", resp.Action)
+			}
+			denied := HookDeniedFromResponse(resp)
+			if denied == nil {
+				t.Fatal("deny response must produce a denial")
+			}
+			var typed *HookDeniedError
+			if !errors.As(denied, &typed) {
+				t.Fatalf("unexpected error type %T", denied)
+			}
+			if typed.RuleID != "block-destructive-bash" {
+				t.Errorf("unexpected rule id %q", typed.RuleID)
+			}
+			if typed.Reason != "Bash(*rm*) is not allowed in this environment" {
+				t.Errorf("unexpected reason %q", typed.Reason)
+			}
+			assertPreflightHookRequest(t, server)
+		})
+	}
+}
+
+func TestHooksIntegrationHTTPErrorStatuses(t *testing.T) {
+	for _, status := range []int{http.StatusTooManyRequests, http.StatusServiceUnavailable} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Run("fail-open", func(t *testing.T) {
+				server := startHookTestServer(t, respondWith(status, "upstream unavailable"))
+				client, logs := newHookIntegrationClient(t, server.URL, hookIntegrationOptions{enabled: true, failOpen: true})
+
+				resp, err := client.EvaluateHook(context.Background(), preflightHookRequest())
+				if err != nil {
+					t.Fatalf("fail-open must not surface an error: %v", err)
+				}
+				if resp.Action != HookActionAllow {
+					t.Fatalf("expected allow, got %q", resp.Action)
+				}
+				assertFailOpenWarning(t, logs, fmt.Sprintf("status %d", status))
+				assertPreflightHookRequest(t, server)
+			})
+			t.Run("fail-closed", func(t *testing.T) {
+				server := startHookTestServer(t, respondWith(status, "upstream unavailable"))
+				client, _ := newHookIntegrationClient(t, server.URL, hookIntegrationOptions{enabled: true})
+
+				_, err := client.EvaluateHook(context.Background(), preflightHookRequest())
+				if !errors.Is(err, ErrHookTransportFailed) {
+					t.Fatalf("expected a transport error, got %v", err)
+				}
+				assertPreflightHookRequest(t, server)
+			})
+		})
+	}
+}
+
+func TestHooksIntegrationMalformedResponseBody(t *testing.T) {
+	const malformed = `{"action": "allow"`
+
+	t.Run("fail-open", func(t *testing.T) {
+		server := startHookTestServer(t, respondWith(http.StatusOK, malformed))
+		client, logs := newHookIntegrationClient(t, server.URL, hookIntegrationOptions{enabled: true, failOpen: true})
+
+		resp, err := client.EvaluateHook(context.Background(), preflightHookRequest())
+		if err != nil {
+			t.Fatalf("fail-open must not surface an error: %v", err)
+		}
+		if resp.Action != HookActionAllow {
+			t.Fatalf("expected allow, got %q", resp.Action)
+		}
+		assertFailOpenWarning(t, logs, "decode hook response")
+		assertPreflightHookRequest(t, server)
+	})
+
+	t.Run("fail-closed", func(t *testing.T) {
+		server := startHookTestServer(t, respondWith(http.StatusOK, malformed))
+		client, _ := newHookIntegrationClient(t, server.URL, hookIntegrationOptions{enabled: true})
+
+		_, err := client.EvaluateHook(context.Background(), preflightHookRequest())
+		if !errors.Is(err, ErrHookTransportFailed) {
+			t.Fatalf("expected a transport error, got %v", err)
+		}
+		assertPreflightHookRequest(t, server)
+	})
+}
+
+func TestHooksIntegrationClientTimeout(t *testing.T) {
+	const serverDelay = 2 * time.Second
+	slow := func(hookServerRequest) hookServerResponse {
+		return hookServerResponse{status: http.StatusOK, body: `{"action":"deny","rule_id":"late"}`, delay: serverDelay}
+	}
+
+	t.Run("fail-open", func(t *testing.T) {
+		server := startHookTestServer(t, slow)
+		client, logs := newHookIntegrationClient(t, server.URL, hookIntegrationOptions{
+			enabled:  true,
+			failOpen: true,
+			timeout:  250 * time.Millisecond,
+		})
+
+		started := time.Now()
+		resp, err := client.EvaluateHook(context.Background(), preflightHookRequest())
+		elapsed := time.Since(started)
+		if err != nil {
+			t.Fatalf("fail-open must not surface an error: %v", err)
+		}
+		if resp.Action != HookActionAllow {
+			t.Fatalf("expected allow, got %q", resp.Action)
+		}
+		if elapsed >= serverDelay {
+			t.Errorf("client waited %s, so it did not enforce its own timeout", elapsed)
+		}
+		assertFailOpenWarning(t, logs, "")
+		assertPreflightHookRequest(t, server)
+	})
+
+	t.Run("fail-closed", func(t *testing.T) {
+		server := startHookTestServer(t, slow)
+		client, _ := newHookIntegrationClient(t, server.URL, hookIntegrationOptions{
+			enabled: true,
+			timeout: 250 * time.Millisecond,
+		})
+
+		started := time.Now()
+		_, err := client.EvaluateHook(context.Background(), preflightHookRequest())
+		elapsed := time.Since(started)
+		if !errors.Is(err, ErrHookTransportFailed) {
+			t.Fatalf("expected a transport error, got %v", err)
+		}
+		if elapsed >= serverDelay {
+			t.Errorf("client waited %s, so it did not enforce its own timeout", elapsed)
+		}
+		assertPreflightHookRequest(t, server)
+	})
+}
+
+func TestHooksIntegrationUnconfiguredPhaseSendsNoRequest(t *testing.T) {
+	for _, failOpen := range []bool{true, false} {
+		t.Run(hookPolicyName(failOpen), func(t *testing.T) {
+			server := startHookTestServer(t, respondWith(http.StatusInternalServerError, "should not be called"))
+			client, _ := newHookIntegrationClient(t, server.URL, hookIntegrationOptions{
+				enabled:  true,
+				failOpen: failOpen,
+				phases:   []HookPhase{HookPhasePostflight},
+			})
+
+			resp, err := client.EvaluateHook(context.Background(), preflightHookRequest())
+			if err != nil {
+				t.Fatalf("evaluate hook: %v", err)
+			}
+			if resp.Action != HookActionAllow {
+				t.Fatalf("expected allow, got %q", resp.Action)
+			}
+			if calls := server.calls(); len(calls) != 0 {
+				t.Errorf("expected no hook request, got %d", len(calls))
+			}
+		})
+	}
+}
+
+func TestHooksIntegrationDisabledHooksSendNoRequest(t *testing.T) {
+	for _, failOpen := range []bool{true, false} {
+		t.Run(hookPolicyName(failOpen), func(t *testing.T) {
+			server := startHookTestServer(t, respondWith(http.StatusInternalServerError, "should not be called"))
+			client, _ := newHookIntegrationClient(t, server.URL, hookIntegrationOptions{failOpen: failOpen})
+
+			resp, err := client.EvaluateHook(context.Background(), preflightHookRequest())
+			if err != nil {
+				t.Fatalf("evaluate hook: %v", err)
+			}
+			if resp.Action != HookActionAllow {
+				t.Fatalf("expected allow, got %q", resp.Action)
+			}
+			if calls := server.calls(); len(calls) != 0 {
+				t.Errorf("expected no hook request, got %d", len(calls))
+			}
+		})
+	}
+}
+
+func TestHooksIntegrationConfiguredAuthReachesServer(t *testing.T) {
+	server := startHookTestServer(t, respondWith(http.StatusOK, hookFixtureResponseBody(t, "allow")))
+	client, _ := newHookIntegrationClient(t, server.URL, hookIntegrationOptions{
+		enabled: true,
+		auth: AuthConfig{
+			Mode:          ExportAuthModeBasic,
+			BasicUser:     "12345",
+			BasicPassword: "glc-token",
+			TenantID:      "12345",
+		},
+	})
+
+	if _, err := client.EvaluateHook(context.Background(), preflightHookRequest()); err != nil {
+		t.Fatalf("evaluate hook: %v", err)
+	}
+
+	calls := server.calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected one hook request, got %d", len(calls))
+	}
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("12345:glc-token"))
+	if got := calls[0].headers.Get("Authorization"); got != want {
+		t.Errorf("unexpected authorization header %q", got)
+	}
+	if got := calls[0].headers.Get("X-Scope-OrgID"); got != "12345" {
+		t.Errorf("unexpected tenant header %q", got)
+	}
+	if got := calls[0].headers.Get(hookTimeoutHeader); got != "5000" {
+		t.Errorf("unexpected hook timeout header %q", got)
+	}
+	assertPreflightHookRequest(t, server)
+}
+
+func TestHooksIntegrationConcurrentEvaluations(t *testing.T) {
+	// A guard on the request path must not funnel every caller through one
+	// connection.
+	server := startHookTestServer(t, func(hookServerRequest) hookServerResponse {
+		return hookServerResponse{
+			status: http.StatusOK,
+			body:   hookFixtureResponseBody(t, "allow"),
+			delay:  200 * time.Millisecond,
+		}
+	})
+	client, _ := newHookIntegrationClient(t, server.URL, hookIntegrationOptions{enabled: true})
+
+	var wg sync.WaitGroup
+	errs := make([]error, 4)
+	actions := make([]HookAction, 4)
+	for i := range errs {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			resp, err := client.EvaluateHook(context.Background(), preflightHookRequest())
+			errs[index] = err
+			if resp != nil {
+				actions[index] = resp.Action
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("evaluation %d failed: %v", i, err)
+		}
+		if actions[i] != HookActionAllow {
+			t.Errorf("evaluation %d: expected allow, got %q", i, actions[i])
+		}
+	}
+	if peak := server.concurrentPeak(); peak < 2 {
+		t.Errorf("evaluations were serialized: peak in-flight %d", peak)
+	}
+	fixture := loadHookFixture(t, "request-preflight.json")
+	for i, call := range server.calls() {
+		for _, diff := range diffJSON("", stripEmptyHookMetadata(call.payload), fixture) {
+			t.Errorf("request %d does not match the shared fixture: %s", i, diff)
+		}
+	}
+}
+
+func hookPolicyName(failOpen bool) string {
+	if failOpen {
+		return "fail-open"
+	}
+	return "fail-closed"
+}

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -577,6 +577,7 @@ export class Agento11yClient {
       extraHeaders: this.config.generationExport.headers,
       hooks: effectiveHooks,
       request,
+      logger: this.logger,
     });
   }
 

--- a/js/src/hooks.ts
+++ b/js/src/hooks.ts
@@ -1,6 +1,7 @@
 import { isSpanContextValid, context as otelContext, trace } from '@opentelemetry/api';
 import { conversationIdFromContext } from './context.js';
 import type {
+  Agento11yLogger,
   HookEvaluateRequest,
   HookEvaluateResponse,
   HookEvaluation,
@@ -56,6 +57,8 @@ export async function evaluateHook(params: {
   hooks: HooksConfig;
   request: HookEvaluateRequest;
   fetchImpl?: typeof fetch;
+  /** Receives a warning whenever a failure is swallowed by `failOpen`. */
+  logger?: Agento11yLogger;
 }): Promise<HookEvaluateResponse> {
   const fetchImpl = params.fetchImpl ?? fetch;
   if (!params.hooks.enabled) {
@@ -93,12 +96,14 @@ export async function evaluateHook(params: {
         new Error(
           `agento11y hook evaluation failed: status ${response.status}: ${hookErrorText(responseText, response.status)}`,
         ),
+        params.logger,
       );
     }
     if (responseText.length === 0) {
       return failOpenOrThrow(
         params.hooks.failOpen,
         new Error('agento11y hook evaluation failed: empty response payload'),
+        params.logger,
       );
     }
 
@@ -109,19 +114,38 @@ export async function evaluateHook(params: {
       return failOpenOrThrow(
         params.hooks.failOpen,
         new Error(`agento11y hook evaluation failed: invalid JSON response: ${asError(error).message}`),
+        params.logger,
       );
     }
 
     return parseEvaluateResponse(payload);
   } catch (error) {
-    return failOpenOrThrow(params.hooks.failOpen, asError(error));
+    return failOpenOrThrow(params.hooks.failOpen, hookTransportError(error), params.logger);
   } finally {
     clearTimeout(timer);
   }
 }
 
-function failOpenOrThrow(failOpen: boolean, error: Error): HookEvaluateResponse {
+/**
+ * Labels every transport failure, including the `AbortError` a timeout raises, so
+ * a fail-closed caller can tell a hook failure from any other thrown error. Go
+ * wraps ErrHookTransportFailed and Python raises HookTransportError for the same
+ * reason.
+ */
+function hookTransportError(error: unknown): Error {
+  const converted = asError(error);
+  if (converted.message.startsWith('agento11y hook evaluation failed')) {
+    return converted;
+  }
+  const labelled = new Error(`agento11y hook evaluation failed: ${converted.message}`);
+  labelled.cause = converted;
+  return labelled;
+}
+
+function failOpenOrThrow(failOpen: boolean, error: Error, logger?: Agento11yLogger): HookEvaluateResponse {
   if (failOpen) {
+    // Fail-open turns an evaluator outage into a silent allow, so record it.
+    logger?.warn?.(`agento11y: hook evaluation failed, allowing request (failOpen): ${error.message}`);
     return allowResponse();
   }
   throw error;
@@ -210,21 +234,146 @@ function serializeContext(hookContext: HookEvaluateRequest['context']): Record<s
 function serializeInput(input: HookEvaluateRequest['input']): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   if (input.messages !== undefined && input.messages.length > 0) {
-    out.messages = input.messages;
+    out.messages = input.messages.map(serializeMessage);
   }
   if (input.tools !== undefined && input.tools.length > 0) {
-    out.tools = input.tools;
+    out.tools = input.tools.map(serializeTool);
   }
   if (input.systemPrompt !== undefined && input.systemPrompt.length > 0) {
     out.system_prompt = input.systemPrompt;
   }
   if (input.output !== undefined && input.output.length > 0) {
-    out.output = input.output;
+    out.output = input.output.map(serializeMessage);
   }
   if (input.conversationPreview !== undefined && input.conversationPreview.length > 0) {
     out.conversation_preview = input.conversationPreview;
   }
   return out;
+}
+
+/**
+ * Maps an SDK message onto the hook wire shape.
+ *
+ * The public `MessagePart` union is camelCase and discriminated by `type`. The
+ * server never reads `type`. It dispatches on a snake_case `kind`, and it
+ * recovers a missing discriminator for text only.
+ *
+ * Passing an SDK object straight to `JSON.stringify` therefore sends every
+ * thinking, tool-call, and tool-result part as an empty part. A tool-filter
+ * guard sees no tool calls in it and allows the request. See
+ * `conformance/hooks/README.md`.
+ */
+function serializeMessage(message: Message): Record<string, unknown> {
+  const parts: Record<string, unknown>[] = [];
+  for (const part of message.parts ?? []) {
+    const serialized = serializeMessagePart(part);
+    if (serialized !== undefined) {
+      parts.push(serialized);
+    }
+  }
+  // `content` is the text shorthand the SDK maps to a text part on export. Do
+  // the same here so rules see the message body.
+  if (parts.length === 0 && message.content !== undefined && message.content.length > 0) {
+    parts.push({ kind: 'text', text: message.content });
+  }
+  const out: Record<string, unknown> = { role: message.role, parts };
+  if (message.name !== undefined && message.name.length > 0) {
+    out.name = message.name;
+  }
+  return out;
+}
+
+function serializeMessagePart(part: MessagePart): Record<string, unknown> | undefined {
+  switch (part.type) {
+    case 'text':
+      return part.text.length > 0 ? { kind: 'text', text: part.text } : undefined;
+    case 'thinking':
+      return part.thinking.length > 0 ? { kind: 'thinking', thinking: part.thinking } : undefined;
+    case 'tool_call': {
+      const call: Record<string, unknown> = { name: part.toolCall.name };
+      if (part.toolCall.id !== undefined && part.toolCall.id.length > 0) {
+        call.id = part.toolCall.id;
+      }
+      if (part.toolCall.inputJSON !== undefined && part.toolCall.inputJSON.length > 0) {
+        call.input_json = embeddedJSON(part.toolCall.inputJSON);
+      }
+      return { kind: 'tool_call', tool_call: call };
+    }
+    case 'tool_result': {
+      const result: Record<string, unknown> = {};
+      if (part.toolResult.toolCallId !== undefined && part.toolResult.toolCallId.length > 0) {
+        result.tool_call_id = part.toolResult.toolCallId;
+      }
+      if (part.toolResult.name !== undefined && part.toolResult.name.length > 0) {
+        result.name = part.toolResult.name;
+      }
+      if (part.toolResult.isError === true) {
+        result.is_error = true;
+      }
+      if (part.toolResult.content !== undefined && part.toolResult.content.length > 0) {
+        result.content = part.toolResult.content;
+      }
+      if (part.toolResult.contentJSON !== undefined && part.toolResult.contentJSON.length > 0) {
+        result.content_json = embeddedJSON(part.toolResult.contentJSON);
+      }
+      return { kind: 'tool_result', tool_result: result };
+    }
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Tool definitions travel base64 even though tool-call arguments do not: the
+ * server decodes `input.tools` straight into its protobuf `ToolDefinition`,
+ * whose `input_schema_json` is a bytes field. A schema under any other key is
+ * ignored, and raw JSON under `input_schema_json` fails that decode, which makes
+ * the server answer 400 for the whole evaluation.
+ */
+function serializeTool(tool: ToolDefinition): Record<string, unknown> {
+  const out: Record<string, unknown> = { name: tool.name };
+  if (tool.description !== undefined && tool.description.length > 0) {
+    out.description = tool.description;
+  }
+  if (tool.type !== undefined && tool.type.length > 0) {
+    out.type = tool.type;
+  }
+  if (tool.inputSchemaJSON !== undefined && tool.inputSchemaJSON.length > 0) {
+    out.input_schema_json = base64FromUtf8(tool.inputSchemaJSON);
+  }
+  return out;
+}
+
+/**
+ * Embeds a JSON payload the server reads as raw JSON. Text that does not parse
+ * is sent as a JSON string, which keeps the body valid and leaves the value
+ * visible to rules instead of dropping it. Go and Python do the same.
+ */
+function embeddedJSON(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function base64FromUtf8(text: string): string {
+  const g = globalThis as typeof globalThis & {
+    Buffer?: { from(data: string, enc: string): { toString(enc: string): string } };
+    btoa?: (data: string) => string;
+  };
+  if (g.Buffer !== undefined) {
+    return g.Buffer.from(text, 'utf8').toString('base64');
+  }
+  const bytes = new TextEncoder().encode(text);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  if (g.btoa !== undefined) {
+    return g.btoa(binary);
+  }
+  throw new Error('agento11y hook evaluation failed: no base64 encoder available');
 }
 
 function parseEvaluateResponse(payload: unknown): HookEvaluateResponse {
@@ -334,29 +483,63 @@ function parseWireToolDefinition(rec: Record<string, unknown>): ToolDefinition |
   }
   const schemaKey = rec.input_schema_json ?? rec.inputSchemaJson ?? rec.inputSchemaJSON;
   if (typeof schemaKey === 'string' && schemaKey.length > 0) {
-    out.inputSchemaJSON = maybeDecodeGoProtoJSONBytes(schemaKey);
+    out.inputSchemaJSON = decodeWireJSONPayload(schemaKey);
   }
   return out;
 }
 
-function maybeDecodeGoProtoJSONBytes(value: string): string {
-  if (!/^[A-Za-z0-9+/]+=*$/.test(value) || value.length < 4) {
+/**
+ * Recovers a response-side JSON payload. The server marshals the protobuf bytes
+ * fields `input_json`, `content_json`, and `input_schema_json` with Go's
+ * `encoding/json`, so they arrive base64-encoded inside a JSON string.
+ *
+ * The result is always a JSON document: base64 that decodes to something else,
+ * and a string that is neither base64 nor JSON, are kept as a JSON string so the
+ * text survives. Go and Python apply the same rule; see
+ * `conformance/hooks/README.md`.
+ */
+function decodeWireJSONPayload(value: string): string {
+  const decoded = base64ToUtf8(value);
+  if (decoded !== undefined) {
+    return isJSONDocument(decoded) ? decoded : JSON.stringify(decoded);
+  }
+  if (isJSONDocument(value)) {
     return value;
   }
+  return JSON.stringify(value);
+}
+
+function isJSONDocument(text: string): boolean {
   try {
-    const g = globalThis as typeof globalThis & {
-      Buffer?: { from(data: string, enc: string): { toString(enc: string): string } };
-    };
+    JSON.parse(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Decodes strict base64, matching Go's `StdEncoding` and Python's `validate=True`. */
+function base64ToUtf8(value: string): string | undefined {
+  if (value.length === 0 || value.length % 4 !== 0 || !/^[A-Za-z0-9+/]+={0,2}$/.test(value)) {
+    return undefined;
+  }
+  const g = globalThis as typeof globalThis & {
+    Buffer?: { from(data: string, enc: string): { toString(enc: string): string } };
+    atob?: (data: string) => string;
+  };
+  try {
     if (g.Buffer !== undefined) {
-      const text = g.Buffer.from(value, 'base64').toString('utf8');
-      if (text.length > 0) {
-        return text;
-      }
+      return g.Buffer.from(value, 'base64').toString('utf8');
+    }
+    if (g.atob !== undefined) {
+      const binary = g.atob(value);
+      const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+      return new TextDecoder().decode(bytes);
     }
   } catch {
-    /* ignore */
+    return undefined;
   }
-  return value;
+  return undefined;
 }
 
 function parseWireMessages(raw: unknown): Message[] | undefined {
@@ -417,61 +600,123 @@ function wireRoleToSdk(role: unknown): string {
   return 'user';
 }
 
-function parseWireMessagePart(rec: Record<string, unknown>): MessagePart | undefined {
-  const typ = rec.type;
-  if (typ === 'text' && typeof rec.text === 'string') {
-    return { type: 'text', text: rec.text };
-  }
-  if (typ === 'thinking' && typeof rec.thinking === 'string') {
-    return { type: 'thinking', thinking: rec.thinking };
-  }
-  if (typ === 'tool_call' && isRecord(rec.toolCall)) {
-    const tc = parseWireToolCallPart(rec.toolCall);
-    return tc !== undefined ? { type: 'tool_call', toolCall: tc } : undefined;
-  }
-  if (typ === 'tool_result' && isRecord(rec.toolResult)) {
-    const tr = parseWireToolResultPart(rec.toolResult);
-    return tr !== undefined ? { type: 'tool_result', toolResult: tr } : undefined;
-  }
+/** The part kinds the server dispatches on, and the only ones this SDK can hold. */
+type WirePartKind = 'text' | 'thinking' | 'tool_call' | 'tool_result';
 
+/** The payload fields of one wire part, read out of whichever shape carried them. */
+interface WirePartFields {
+  text?: string;
+  thinking?: string;
+  toolCall?: Record<string, unknown>;
+  toolResult?: Record<string, unknown>;
+}
+
+function parseWireMessagePart(rec: Record<string, unknown>): MessagePart | undefined {
+  const fields = wirePartFields(rec);
+  const kind = wirePartKind(rec, fields);
+  if (kind === undefined) {
+    return undefined;
+  }
+  switch (kind) {
+    case 'text':
+      return fields.text !== undefined ? { type: 'text', text: fields.text } : undefined;
+    case 'thinking':
+      return fields.thinking !== undefined ? { type: 'thinking', thinking: fields.thinking } : undefined;
+    case 'tool_call': {
+      if (fields.toolCall === undefined) {
+        return undefined;
+      }
+      const tc = parseWireToolCallPart(fields.toolCall);
+      return tc !== undefined ? { type: 'tool_call', toolCall: tc } : undefined;
+    }
+    case 'tool_result': {
+      if (fields.toolResult === undefined) {
+        return undefined;
+      }
+      const tr = parseWireToolResultPart(fields.toolResult);
+      return tr !== undefined ? { type: 'tool_result', toolResult: tr } : undefined;
+    }
+  }
+}
+
+/**
+ * Reads the payload fields of one wire part.
+ *
+ * Three shapes reach this parser: the server's snake_case body, an echo of this
+ * SDK's own camelCase part, and a protobuf `Part` marshalled with Go's
+ * `encoding/json`, which nests the oneof under a capitalized `Payload` object. A
+ * `Payload` that holds none of the four fields is ignored rather than treated as
+ * an empty part, so the top-level fields still get their chance.
+ */
+function wirePartFields(rec: Record<string, unknown>): WirePartFields {
   const payload = rec.Payload ?? rec.payload;
   if (isRecord(payload)) {
-    if (typeof payload.Text === 'string') {
-      return { type: 'text', text: payload.Text };
-    }
-    if (typeof payload.Thinking === 'string') {
-      return { type: 'thinking', thinking: payload.Thinking };
-    }
-    if (isRecord(payload.ToolCall)) {
-      const tc = parseWireToolCallPart(payload.ToolCall);
-      return tc !== undefined ? { type: 'tool_call', toolCall: tc } : undefined;
-    }
-    if (isRecord(payload.ToolResult)) {
-      const tr = parseWireToolResultPart(payload.ToolResult);
-      return tr !== undefined ? { type: 'tool_result', toolResult: tr } : undefined;
+    const nested = collectWirePartFields(payload.Text, payload.Thinking, payload.ToolCall, payload.ToolResult);
+    if (Object.keys(nested).length > 0) {
+      return nested;
     }
   }
+  return collectWirePartFields(
+    rec.text,
+    rec.thinking,
+    rec.tool_call ?? rec.toolCall,
+    rec.tool_result ?? rec.toolResult,
+  );
+}
 
-  const kind = typeof rec.kind === 'string' ? rec.kind : '';
-  if (kind === 'text' && typeof rec.text === 'string') {
-    return { type: 'text', text: rec.text };
-  }
-  if (kind === 'thinking' && typeof rec.thinking === 'string') {
-    return { type: 'thinking', thinking: rec.thinking };
-  }
-  if (kind === 'tool_call') {
-    const rawTc = rec.tool_call ?? rec.toolCall;
-    if (isRecord(rawTc)) {
-      const tc = parseWireToolCallPart(rawTc);
-      return tc !== undefined ? { type: 'tool_call', toolCall: tc } : undefined;
+function collectWirePartFields(
+  rawText: unknown,
+  rawThinking: unknown,
+  rawToolCall: unknown,
+  rawToolResult: unknown,
+): WirePartFields {
+  const text = optionalStringField(rawText);
+  const thinking = optionalStringField(rawThinking);
+  return {
+    ...(text !== undefined ? { text } : {}),
+    ...(thinking !== undefined ? { thinking } : {}),
+    ...(isRecord(rawToolCall) ? { toolCall: rawToolCall } : {}),
+    ...(isRecord(rawToolResult) ? { toolResult: rawToolResult } : {}),
+  };
+}
+
+/**
+ * Resolves the kind to read a part as, and commits to it. A part that names its
+ * kind is never rebuilt from another kind's field, so a `tool_call` that arrives
+ * without its payload object is dropped rather than turned into the text that
+ * happens to sit next to it. Go and Python resolve the kind the same way; see
+ * `conformance/hooks/README.md`.
+ */
+function wirePartKind(rec: Record<string, unknown>, fields: WirePartFields): WirePartKind | undefined {
+  const declared = optionalStringField(rec.kind) ?? optionalStringField(rec.type);
+  if (declared !== undefined) {
+    switch (declared) {
+      case 'text':
+      case 'thinking':
+      case 'tool_call':
+      case 'tool_result':
+        return declared;
+      default:
+        // A kind this SDK does not know, which the server can only have sent as
+        // text, so text is all there is to recover from it.
+        return 'text';
     }
   }
-  if (kind === 'tool_result') {
-    const rawTr = rec.tool_result ?? rec.toolResult;
-    if (isRecord(rawTr)) {
-      const tr = parseWireToolResultPart(rawTr);
-      return tr !== undefined ? { type: 'tool_result', toolResult: tr } : undefined;
-    }
+  // A part without a discriminator is still recoverable from whichever payload
+  // field is set, and dropping it would lose a transform the caller was asked to
+  // apply. The server always sets `kind`, so this only covers a hand-written,
+  // proto-JSON, or Go-marshalled body. Go and Python keep the same tolerance.
+  if (fields.toolCall !== undefined) {
+    return 'tool_call';
+  }
+  if (fields.toolResult !== undefined) {
+    return 'tool_result';
+  }
+  if (fields.thinking !== undefined) {
+    return 'thinking';
+  }
+  if (fields.text !== undefined) {
+    return 'text';
   }
   return undefined;
 }
@@ -487,7 +732,9 @@ function parseWireToolCallPart(rec: Record<string, unknown>): ToolCallPart | und
   }
   const rawInput = rec.input_json ?? rec.inputJson ?? rec.inputJSON;
   if (typeof rawInput === 'string' && rawInput.length > 0) {
-    out.inputJSON = maybeDecodeGoProtoJSONBytes(rawInput);
+    out.inputJSON = decodeWireJSONPayload(rawInput);
+  } else if (isRecord(rawInput) || Array.isArray(rawInput)) {
+    out.inputJSON = JSON.stringify(rawInput);
   }
   return out;
 }
@@ -507,7 +754,9 @@ function parseWireToolResultPart(rec: Record<string, unknown>): ToolResultPart |
   }
   const rawCj = rec.content_json ?? rec.contentJson ?? rec.contentJSON;
   if (typeof rawCj === 'string' && rawCj.length > 0) {
-    out.contentJSON = maybeDecodeGoProtoJSONBytes(rawCj);
+    out.contentJSON = decodeWireJSONPayload(rawCj);
+  } else if (isRecord(rawCj) || Array.isArray(rawCj)) {
+    out.contentJSON = JSON.stringify(rawCj);
   }
   if (rec.is_error === true || rec.isError === true) {
     out.isError = true;

--- a/js/test/client.hooks.test.mjs
+++ b/js/test/client.hooks.test.mjs
@@ -97,7 +97,10 @@ test('evaluateHook posts JSON to /api/v1/hooks:evaluate and parses allow respons
         messages: [
           {
             role: 'user',
-            parts: [{ type: 'text', text: 'hello world' }],
+            // The server dispatches parts on a snake_case `kind`; the SDK's
+            // `type` discriminator never reaches it. See
+            // conformance/hooks/README.md.
+            parts: [{ kind: 'text', text: 'hello world' }],
           },
         ],
       },

--- a/js/test/frameworks.vercel-ai-sdk.hooks.test.mjs
+++ b/js/test/frameworks.vercel-ai-sdk.hooks.test.mjs
@@ -59,7 +59,9 @@ test('vercel ai sdk preflight allows step when hook returns allow', async () => 
     assert.equal(receivedBody.context.model.provider, 'openai');
     assert.equal(receivedBody.context.model.name, 'gpt-4o');
     assert.equal(receivedBody.context.conversation_id, 'conv-allow');
-    assert.equal(receivedBody.input.messages[0].role, 'user');
+    assert.deepEqual(receivedBody.input.messages, [
+      { role: 'user', parts: [{ kind: 'text', text: 'how do I make pasta?' }] },
+    ]);
   } finally {
     await client.shutdown();
     await close(server);
@@ -79,8 +81,10 @@ test('vercel ai sdk prepareStep preflight returns transformed messages for ai sd
       JSON.stringify({
         action: 'allow',
         evaluations: [],
+        // The server returns messages as parts; its wire message has no
+        // `content` field. conformance/hooks/README.md.
         transformed_input: {
-          messages: [{ role: 'user', content: 'redacted question' }],
+          messages: [{ role: 'user', parts: [{ kind: 'text', text: 'redacted question' }] }],
         },
       }),
     );
@@ -114,9 +118,14 @@ test('vercel ai sdk prepareStep preflight returns transformed messages for ai sd
       response: { id: 'resp-prepare-transform', modelId: 'gpt-4o' },
     });
 
-    assert.equal(receivedBody.input.messages[0].content, 'original secret question');
+    // The adapter maps AI SDK messages to the `content` shorthand. The hooks
+    // API has no `content` field on a message, so it only reaches rule
+    // evaluation as a text part. conformance/hooks/README.md.
+    assert.deepEqual(receivedBody.input.messages, [
+      { role: 'user', parts: [{ kind: 'text', text: 'original secret question' }] },
+    ]);
     assert.deepEqual(prepareResult, {
-      messages: [{ role: 'user', content: 'redacted question' }],
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'redacted question' }] }],
     });
   } finally {
     await client.shutdown();
@@ -134,8 +143,10 @@ test('vercel ai sdk prepareStep preflight rejects unsupported transformed messag
       JSON.stringify({
         action: 'allow',
         evaluations: [],
+        // A tool message whose only part is text has no AI SDK equivalent, and
+        // this is the shape the server emits for it.
         transformed_input: {
-          messages: [{ role: 'tool', content: 'redacted tool result' }],
+          messages: [{ role: 'tool', parts: [{ kind: 'text', text: 'redacted tool result' }] }],
         },
       }),
     );
@@ -180,7 +191,7 @@ test('vercel ai sdk legacy step-start preflight rejects transformed messages tha
         action: 'allow',
         evaluations: [],
         transformed_input: {
-          messages: [{ role: 'user', content: 'redacted question' }],
+          messages: [{ role: 'user', parts: [{ kind: 'text', text: 'redacted question' }] }],
         },
       }),
     );

--- a/js/test/hooks.conformance.test.mjs
+++ b/js/test/hooks.conformance.test.mjs
@@ -1,0 +1,449 @@
+// Hook wire conformance for the JS SDK.
+//
+// Checks the request the SDK serializes and the responses it parses against the
+// shared fixtures in `conformance/hooks/`, which are the only contract for an
+// endpoint with no generated stubs.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { evaluateHook } from '../.test-dist/hooks.js';
+import {
+  bashToolSchema,
+  diffJson,
+  loadPostflightGuardRequest,
+  loadPreflightRequest,
+  loadResponses,
+  postflightGuardRequest,
+  preflightRequest,
+} from './hooksFixtures.mjs';
+
+const hooksConfig = { enabled: true, phases: ['preflight', 'postflight'], timeoutMs: 5_000, failOpen: false };
+
+/** Runs evaluateHook against a stub fetch, returning the serialized body and the parsed response. */
+async function runHook(request, responseBody, { status = 200 } = {}) {
+  let capturedBody;
+  const fetchImpl = async (_url, init) => {
+    capturedBody = JSON.parse(init.body);
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => JSON.stringify(responseBody),
+    };
+  };
+  const response = await evaluateHook({
+    apiEndpoint: 'http://127.0.0.1:9/agent-observability',
+    insecure: true,
+    extraHeaders: undefined,
+    hooks: hooksConfig,
+    request,
+    fetchImpl,
+  });
+  return { body: capturedBody, response };
+}
+
+for (const [fixtureName, build, load] of [
+  ['request-preflight.json', preflightRequest, loadPreflightRequest],
+  ['request-postflight-guard.json', postflightGuardRequest, loadPostflightGuardRequest],
+]) {
+  test(`hook request matches ${fixtureName}`, async () => {
+    const { body } = await runHook(build(), { action: 'allow', evaluations: [] });
+    const diffs = diffJson(body, load());
+    assert.deepEqual(diffs, [], `request does not match conformance/hooks/${fixtureName}:\n${diffs.join('\n')}`);
+  });
+}
+
+test('the fixture comparison names divergent fields', () => {
+  // Pins the comparator, not the serializer. The tests above are what check the
+  // SDK's own output. Each case applies one divergence the server cannot read and
+  // asserts the diff names the offending path. Without this test, a comparator
+  // that accepted a renamed discriminator or a re-encoded payload would pass
+  // every case above while checking nothing.
+  const fixture = loadPreflightRequest();
+  const cases = [
+    {
+      name: 'renamed discriminator',
+      mutate: (body) => {
+        const part = body.input.messages[0].parts[0];
+        part.type = part.kind;
+        delete part.kind;
+      },
+      wantPath: 'input.messages[0].parts[0].kind',
+    },
+    {
+      name: 'camelCase tool call payload',
+      mutate: (body) => {
+        const part = body.input.messages[1].parts[1];
+        part.toolCall = part.tool_call;
+        delete part.tool_call;
+      },
+      wantPath: 'input.messages[1].parts[1].tool_call',
+    },
+    {
+      name: 'base64 tool call input',
+      mutate: (body) => {
+        const call = body.input.messages[1].parts[1].tool_call;
+        call.input_json = Buffer.from(JSON.stringify(call.input_json), 'utf8').toString('base64');
+      },
+      wantPath: 'input.messages[1].parts[1].tool_call.input_json',
+    },
+    {
+      name: 'base64 tool result content',
+      mutate: (body) => {
+        const result = body.input.messages[2].parts[0].tool_result;
+        result.content_json = Buffer.from(JSON.stringify(result.content_json), 'utf8').toString('base64');
+      },
+      wantPath: 'input.messages[2].parts[0].tool_result.content_json',
+    },
+    {
+      name: 'raw JSON tool schema',
+      mutate: (body) => {
+        const tool = body.input.tools[0];
+        tool.inputSchemaJSON = Buffer.from(tool.input_schema_json, 'base64').toString('utf8');
+        delete tool.input_schema_json;
+      },
+      wantPath: 'input.tools[0].input_schema_json',
+    },
+  ];
+
+  for (const testCase of cases) {
+    const mutated = structuredClone(fixture);
+    testCase.mutate(mutated);
+    const diffs = diffJson(mutated, fixture);
+    assert.ok(diffs.length > 0, `comparison accepted a divergent payload (${testCase.name})`);
+    assert.ok(
+      diffs.some((diff) => diff.startsWith(testCase.wantPath)),
+      `diff did not name ${testCase.wantPath}: ${diffs.join(', ')}`,
+    );
+  }
+});
+
+test('the text shorthand reaches the server as a text part', async () => {
+  const request = {
+    phase: 'preflight',
+    context: { model: { provider: 'openai', name: 'gpt-4o' } },
+    input: { messages: [{ role: 'user', content: 'hello world' }] },
+  };
+  const { body } = await runHook(request, { action: 'allow', evaluations: [] });
+  assert.deepEqual(body.input.messages, [{ role: 'user', parts: [{ kind: 'text', text: 'hello world' }] }]);
+});
+
+test('allow response parses into evaluations', async () => {
+  const { response } = await runHook(preflightRequest(), loadResponses().allow);
+
+  assert.equal(response.action, 'allow');
+  assert.equal(response.transformedInput, undefined);
+  assert.equal(response.evaluations.length, 1);
+  assert.deepEqual(response.evaluations[0], {
+    ruleId: 'pii-detect',
+    evaluatorId: 'evaluator-pii',
+    evaluatorKind: 'regex',
+    passed: true,
+    latencyMs: 12,
+    explanation: 'no PII matches',
+    reason: undefined,
+  });
+});
+
+test('deny response preserves rule id and reason', async () => {
+  const { response } = await runHook(preflightRequest(), loadResponses().deny);
+
+  assert.equal(response.action, 'deny');
+  assert.equal(response.ruleId, 'block-destructive-bash');
+  assert.equal(response.reason, 'Bash(*rm*) is not allowed in this environment');
+  assert.equal(response.evaluations.length, 1);
+  assert.equal(response.evaluations[0].passed, false);
+  assert.equal(response.evaluations[0].reason, 'blocked tool Bash');
+});
+
+test('transformed input keeps every part kind and decodes tool payloads', async () => {
+  const { response } = await runHook(preflightRequest(), loadResponses().allow_with_transformed_input);
+
+  assert.equal(response.action, 'allow');
+  const input = response.transformedInput;
+  assert.ok(input, 'transformed input was dropped');
+  assert.equal(input.systemPrompt, 'You are a careful assistant.');
+  assert.equal(input.conversationPreview, 'user: Delete the cache directory under [REDACTED].');
+  assert.equal(input.messages.length, 3);
+
+  const [user, assistant, tool] = input.messages;
+  assert.equal(user.role, 'user');
+  assert.deepEqual(user.parts, [{ type: 'text', text: 'Delete the cache directory under [REDACTED].' }]);
+
+  assert.equal(assistant.role, 'assistant');
+  assert.deepEqual(
+    assistant.parts.map((part) => part.type),
+    ['thinking', 'tool_call'],
+  );
+  assert.equal(assistant.parts[0].thinking, 'The request is destructive, so inspect the directory first.');
+  assert.deepEqual(assistant.parts[1].toolCall, {
+    id: 'call-bash',
+    name: 'Bash',
+    inputJSON: '{"command":"rm -rf /tmp/cache"}',
+  });
+
+  assert.equal(tool.role, 'tool');
+  assert.equal(tool.name, 'Bash');
+  assert.deepEqual(
+    tool.parts.map((part) => part.type),
+    ['tool_result'],
+  );
+  assert.deepEqual(tool.parts[0].toolResult, {
+    toolCallId: 'call-bash',
+    name: 'Bash',
+    content: "rm: cannot remove '/tmp/cache': Permission denied",
+    contentJSON: '{"exit_code":1}',
+    isError: true,
+  });
+
+  assert.deepEqual(input.tools, [
+    {
+      name: 'Bash',
+      description: 'Run a shell command.',
+      type: 'function',
+      inputSchemaJSON: bashToolSchema,
+    },
+  ]);
+});
+
+test('transformed input accepts proto-JSON integer roles', async () => {
+  const { response } = await runHook(preflightRequest(), {
+    action: 'allow',
+    transformed_input: {
+      messages: [
+        { role: 2, parts: [{ text: 'hello' }] },
+        { role: 3, parts: [{ kind: 'tool_result', tool_result: { tool_call_id: 'call-1', content: 'ok' } }] },
+      ],
+    },
+    evaluations: [],
+  });
+
+  const input = response.transformedInput;
+  assert.ok(input);
+  assert.equal(input.messages[0].role, 'assistant');
+  assert.deepEqual(input.messages[0].parts, [{ type: 'text', text: 'hello' }]);
+  assert.equal(input.messages[1].role, 'tool');
+  assert.deepEqual(input.messages[1].parts[0].toolResult, { toolCallId: 'call-1', content: 'ok' });
+});
+
+// Response payloads are base64 of whatever bytes the proto field held, and
+// nothing guarantees those bytes are JSON. Whatever comes back has to stay a JSON
+// document so a transform can be re-exported or re-sent. Go and Python resolve
+// these four cases the same way; see `conformance/hooks/README.md`.
+const payloadDecodingCases = [
+  {
+    name: 'base64 of JSON',
+    value: Buffer.from('{"command":"ls /tmp"}', 'utf8').toString('base64'),
+    want: '{"command":"ls /tmp"}',
+  },
+  {
+    name: 'base64 of plain text',
+    value: Buffer.from('plain text tool output', 'utf8').toString('base64'),
+    want: '"plain text tool output"',
+  },
+  { name: 'embedded JSON text', value: '{"command":"ls /tmp"}', want: '{"command":"ls /tmp"}' },
+  { name: 'neither base64 nor JSON', value: 'not base64 either', want: '"not base64 either"' },
+];
+
+for (const testCase of payloadDecodingCases) {
+  test(`a transformed tool payload stays JSON: ${testCase.name}`, async () => {
+    const { response } = await runHook(preflightRequest(), {
+      action: 'allow',
+      transformed_input: {
+        messages: [
+          {
+            role: 'assistant',
+            parts: [{ kind: 'tool_call', tool_call: { id: 'call-1', name: 'Bash', input_json: testCase.value } }],
+          },
+        ],
+      },
+      evaluations: [],
+    });
+
+    const call = response.transformedInput?.messages?.[0]?.parts?.[0]?.toolCall;
+    assert.ok(call, 'tool call part was dropped');
+    assert.equal(call.inputJSON, testCase.want);
+    JSON.parse(call.inputJSON);
+  });
+}
+
+for (const schema of [{ type: 'object' }, 'eyJhIjoxfQ', 'not base64 either']) {
+  test(`a malformed tool schema keeps the verdict: ${JSON.stringify(schema)}`, async () => {
+    const { response } = await runHook(preflightRequest(), {
+      action: 'deny',
+      rule_id: 'block-destructive-bash',
+      reason: 'denied',
+      transformed_input: { tools: [{ name: 'Bash', input_schema_json: schema }] },
+      evaluations: [],
+    });
+
+    assert.equal(response.action, 'deny');
+    assert.equal(response.ruleId, 'block-destructive-bash');
+  });
+}
+
+test('an unparsable tool payload reaches the server as text', async () => {
+  // Streaming providers accumulate tool arguments without validating them, so a
+  // truncated payload has to travel as text rather than break the request. Go and
+  // Python send the same text.
+  const request = {
+    phase: 'preflight',
+    context: { model: { provider: 'anthropic', name: 'claude-sonnet-4' } },
+    input: {
+      messages: [
+        {
+          role: 'assistant',
+          parts: [
+            { type: 'tool_call', toolCall: { id: 'call-1', name: 'Bash', inputJSON: '{"command":"truncat' } },
+            { type: 'tool_result', toolResult: { toolCallId: 'call-1', contentJSON: '{"exit_code' } },
+          ],
+        },
+      ],
+    },
+  };
+  const { body } = await runHook(request, { action: 'allow', evaluations: [] });
+
+  const [call, result] = body.input.messages[0].parts;
+  assert.equal(call.tool_call.input_json, '{"command":"truncat');
+  assert.equal(result.tool_result.content_json, '{"exit_code');
+});
+
+test('a part-less message serializes parts as an empty array', async () => {
+  // All three SDKs send `"parts": []` rather than null.
+  const request = {
+    phase: 'preflight',
+    context: { model: { provider: 'anthropic', name: 'claude-sonnet-4' } },
+    input: { messages: [{ role: 'user', parts: [] }] },
+  };
+  const { body } = await runHook(request, { action: 'allow', evaluations: [] });
+
+  assert.deepEqual(body.input.messages, [{ role: 'user', parts: [] }]);
+});
+
+test('an empty transformed_input is no transform', async () => {
+  // The server emits `transformed_input:{}` for a rule that returns an empty input.
+  // Reporting a transform for that body would let a caller replace the prompt
+  // with nothing. Go and Python also report no transform.
+  const { response } = await runHook(preflightRequest(), {
+    action: 'allow',
+    transformed_input: {},
+    evaluations: [],
+  });
+
+  assert.equal(response.transformedInput, undefined);
+});
+
+// One response part, and the part the SDK must report for it.
+//
+// `kind` names the field the parser reads, and the parser commits to it: a part
+// that lost that field is dropped rather than rebuilt from a leftover field, which
+// would report a part the rule never wrote. An empty payload carries no content
+// either, and keeping it would append an empty part that the request serializer
+// drops on the way back out. A tool call without a name goes too, because the
+// caller can neither route nor re-send it. A part with no `kind` at all is still
+// read from whichever payload field is set, because the server always sets `kind`,
+// so that shape only reaches the SDK from a hand-written or proto-JSON body.
+//
+// Go and Python resolve every case here the same way.
+const responsePartCases = [
+  ['text', { kind: 'text', text: 'kept' }, { type: 'text', text: 'kept' }],
+  ['text without text', { kind: 'text', text: '' }, undefined],
+  // The shape the server emits for an empty text part: its encoder omits the field
+  // rather than sending ''.
+  ['text without a text field', { kind: 'text' }, undefined],
+  ['thinking', { kind: 'thinking', thinking: 'planning' }, { type: 'thinking', thinking: 'planning' }],
+  ['thinking without thinking', { kind: 'thinking', thinking: '' }, undefined],
+  ['thinking without a thinking field', { kind: 'thinking' }, undefined],
+  [
+    'tool call',
+    { kind: 'tool_call', tool_call: { id: 'call-1', name: 'Bash' } },
+    { type: 'tool_call', toolCall: { name: 'Bash', id: 'call-1' } },
+  ],
+  ['tool call without payload', { kind: 'tool_call' }, undefined],
+  ['tool call without name', { kind: 'tool_call', tool_call: { id: 'call-1' } }, undefined],
+  [
+    'tool result',
+    { kind: 'tool_result', tool_result: { tool_call_id: 'call-1', content: 'ok' } },
+    { type: 'tool_result', toolResult: { toolCallId: 'call-1', content: 'ok' } },
+  ],
+  ['tool result without payload', { kind: 'tool_result' }, undefined],
+  ['unknown kind', { kind: 'image' }, undefined],
+  [
+    'unknown kind with text',
+    { kind: 'image', text: 'described by the server as text' },
+    { type: 'text', text: 'described by the server as text' },
+  ],
+  ['unknown kind with a tool call', { kind: 'image', tool_call: { name: 'Bash' } }, undefined],
+  ['tool call kind with leftover text', { kind: 'tool_call', text: 'not a tool call' }, undefined],
+  ['tool result kind with leftover text', { kind: 'tool_result', text: 'not a tool result' }, undefined],
+  ['thinking kind with leftover text', { kind: 'thinking', thinking: '', text: 'not thinking' }, undefined],
+  ['text kind with leftover thinking', { kind: 'text', text: '', thinking: 'not text' }, undefined],
+  ['text kind with a leftover tool call', { kind: 'text', text: '', tool_call: { name: 'Bash' } }, undefined],
+  ['no kind with text', { text: 'recovered text' }, { type: 'text', text: 'recovered text' }],
+  ['no kind with thinking', { thinking: 'recovered thinking' }, { type: 'thinking', thinking: 'recovered thinking' }],
+  [
+    'no kind with a tool call',
+    { tool_call: { id: 'call-1', name: 'Bash' } },
+    { type: 'tool_call', toolCall: { name: 'Bash', id: 'call-1' } },
+  ],
+  [
+    'no kind with a tool result',
+    { tool_result: { tool_call_id: 'call-1', content: 'ok' } },
+    { type: 'tool_result', toolResult: { toolCallId: 'call-1', content: 'ok' } },
+  ],
+  ['empty part', {}, undefined],
+];
+
+for (const [name, part, want] of responsePartCases) {
+  test(`a response part is parsed by its kind: ${name}`, async () => {
+    const { response } = await runHook(preflightRequest(), {
+      action: 'allow',
+      transformed_input: { messages: [{ role: 'assistant', parts: [part] }] },
+      evaluations: [],
+    });
+
+    const parts = response.transformedInput?.messages?.[0]?.parts ?? [];
+    assert.deepEqual(parts, want === undefined ? [] : [want]);
+  });
+}
+
+// The three shapes only the JS parser has to tolerate. The server sends a
+// snake_case `kind`, but this SDK also parses an echo of its own camelCase part
+// and a protobuf `Part` marshalled with Go's `encoding/json`, which nests the
+// oneof under a capitalized `Payload`.
+const responsePartEncodingCases = [
+  ['sdk text', { type: 'text', text: 'echoed' }, { type: 'text', text: 'echoed' }],
+  ['sdk thinking', { type: 'thinking', thinking: 'echoed' }, { type: 'thinking', thinking: 'echoed' }],
+  [
+    'sdk tool call',
+    { type: 'tool_call', toolCall: { id: 'call-1', name: 'Bash', inputJSON: '{"command":"ls"}' } },
+    { type: 'tool_call', toolCall: { name: 'Bash', id: 'call-1', inputJSON: '{"command":"ls"}' } },
+  ],
+  [
+    'sdk tool result',
+    { type: 'tool_result', toolResult: { toolCallId: 'call-1', content: 'ok' } },
+    { type: 'tool_result', toolResult: { toolCallId: 'call-1', content: 'ok' } },
+  ],
+  ['sdk tool call without payload', { type: 'tool_call' }, undefined],
+  ['go text', { Payload: { Text: 'marshalled' } }, { type: 'text', text: 'marshalled' }],
+  ['go thinking', { Payload: { Thinking: 'marshalled' } }, { type: 'thinking', thinking: 'marshalled' }],
+  ['go tool call', { Payload: { ToolCall: { name: 'Bash' } } }, { type: 'tool_call', toolCall: { name: 'Bash' } }],
+  [
+    'go tool result',
+    { Payload: { ToolResult: { tool_call_id: 'call-1' } } },
+    { type: 'tool_result', toolResult: { toolCallId: 'call-1' } },
+  ],
+  ['go nil oneof', { Payload: null, kind: 'text', text: 'kept' }, { type: 'text', text: 'kept' }],
+];
+
+for (const [name, part, want] of responsePartEncodingCases) {
+  test(`a response part in an alternate encoding is parsed: ${name}`, async () => {
+    const { response } = await runHook(preflightRequest(), {
+      action: 'allow',
+      transformed_input: { messages: [{ role: 'assistant', parts: [part] }] },
+      evaluations: [],
+    });
+
+    const parts = response.transformedInput?.messages?.[0]?.parts ?? [];
+    assert.deepEqual(parts, want === undefined ? [] : [want]);
+  });
+}

--- a/js/test/hooks.integration.test.mjs
+++ b/js/test/hooks.integration.test.mjs
@@ -1,0 +1,339 @@
+// Guard behavior of the JS SDK against a real local HTTP server.
+//
+// The other hook tests assert on fields of the captured body they already expect,
+// so an encoding the server cannot read looks identical to a correct one. These
+// cases run the full transport and compare each captured body with
+// `conformance/hooks/request-preflight.json`.
+
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import test from 'node:test';
+import { Agento11yClient, defaultConfig } from '../.test-dist/index.js';
+import { diffJson, loadPreflightRequest, loadResponses, preflightRequest } from './hooksFixtures.mjs';
+
+const hooksEvaluatePath = '/api/v1/hooks:evaluate';
+const responses = loadResponses();
+
+/**
+ * Starts a local server whose status, body, and delay come from a per-request
+ * responder. Same programmable model as `plugins/pi/src/testHttp.ts`, kept local
+ * so the SDK suite does not depend on the pi plugin.
+ */
+async function startHookServer(respond) {
+  const state = { requests: [], inFlight: 0, maxInFlight: 0, errors: [] };
+  const server = createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) {
+      chunks.push(chunk);
+    }
+    const raw = Buffer.concat(chunks).toString('utf8');
+    const call = { path: request.url ?? '', headers: { ...request.headers }, raw, payload: undefined };
+    try {
+      call.payload = JSON.parse(raw);
+    } catch {
+      call.payload = undefined;
+    }
+    state.requests.push(call);
+    state.inFlight += 1;
+    state.maxInFlight = Math.max(state.maxInFlight, state.inFlight);
+
+    const out = respond(call) ?? {};
+    const send = () => {
+      state.inFlight -= 1;
+      try {
+        response.writeHead(out.status ?? 200, { 'content-type': 'application/json' });
+        response.end(out.body ?? JSON.stringify({ action: 'allow', evaluations: [] }));
+      } catch (error) {
+        // A client that aborted on timeout leaves a torn-down response here.
+        // Record it: the timeout cases expect it, and every other case asserts
+        // this list is empty.
+        state.errors.push(`could not write the response: ${String(error)}`);
+      }
+    };
+    response.on('error', (error) => {
+      state.errors.push(`response stream error: ${String(error)}`);
+    });
+    if (out.delayMs !== undefined && out.delayMs > 0) {
+      setTimeout(send, out.delayMs).unref();
+      return;
+    }
+    send();
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+  return {
+    ...state,
+    requests: state.requests,
+    errors: state.errors,
+    baseUrl: `http://127.0.0.1:${port}`,
+    get maxInFlight() {
+      return state.maxInFlight;
+    },
+    async close() {
+      server.closeAllConnections?.();
+      await new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    },
+  };
+}
+
+function respondWith(status, body) {
+  return () => ({ status, body });
+}
+
+function newClient(options) {
+  const warnings = [];
+  const client = new Agento11yClient({
+    ...defaultConfig(),
+    api: { endpoint: options.baseUrl },
+    generationExport: {
+      ...defaultConfig().generationExport,
+      protocol: 'http',
+      endpoint: `${options.baseUrl}/api/v1/generations:export`,
+      insecure: true,
+      auth: options.auth ?? { mode: 'none' },
+    },
+    hooks: {
+      enabled: options.enabled ?? true,
+      phases: options.phases ?? ['preflight'],
+      timeoutMs: options.timeoutMs ?? 5_000,
+      failOpen: options.failOpen ?? true,
+    },
+    logger: {
+      warn: (message) => warnings.push(String(message)),
+      error: () => {},
+      debug: () => {},
+    },
+    generationExporter: { exportGenerations: async () => ({ results: [] }), shutdown: async () => {} },
+  });
+  return { client, warnings };
+}
+
+function assertPreflightRequest(server, { expectResponseWritten = true } = {}) {
+  assert.equal(server.requests.length, 1, `expected exactly one hook request, got ${server.requests.length}`);
+  if (expectResponseWritten) {
+    // A server that failed to answer makes the client fail open, and a fail-open
+    // assertion passes whether or not the response was ever sent.
+    assert.deepEqual(server.errors, [], `the test server could not answer: ${server.errors.join('; ')}`);
+  }
+  const [call] = server.requests;
+  assert.equal(call.path, hooksEvaluatePath);
+  assert.equal(call.headers['content-type'], 'application/json');
+  const diffs = diffJson(call.payload, loadPreflightRequest());
+  assert.deepEqual(diffs, [], `captured request body does not match the shared fixture:\n${diffs.join('\n')}`);
+}
+
+function assertFailOpenWarning(warnings, wantSubstring) {
+  const matched = warnings.filter((line) => line.includes('allowing request (failOpen)'));
+  assert.ok(matched.length > 0, `a swallowed hook failure must be logged, got ${JSON.stringify(warnings)}`);
+  if (wantSubstring !== undefined) {
+    assert.ok(
+      matched.some((line) => line.includes(wantSubstring)),
+      `warning does not mention ${wantSubstring}: ${JSON.stringify(matched)}`,
+    );
+  }
+}
+
+for (const failOpen of [true, false]) {
+  const policy = failOpen ? 'fail-open' : 'fail-closed';
+
+  test(`allow proceeds under ${policy}`, async () => {
+    const server = await startHookServer(respondWith(200, JSON.stringify(responses.allow)));
+    const { client } = newClient({ baseUrl: server.baseUrl, failOpen });
+    try {
+      const response = await client.evaluateHook(preflightRequest());
+      assert.equal(response.action, 'allow');
+      assert.equal(response.evaluations[0].ruleId, 'pii-detect');
+      assertPreflightRequest(server);
+    } finally {
+      await client.shutdown();
+      await server.close();
+    }
+  });
+
+  test(`deny is enforced under ${policy}`, async () => {
+    const server = await startHookServer(respondWith(200, JSON.stringify(responses.deny)));
+    const { client } = newClient({ baseUrl: server.baseUrl, failOpen });
+    try {
+      const response = await client.evaluateHook(preflightRequest());
+      assert.equal(response.action, 'deny');
+      assert.equal(response.ruleId, 'block-destructive-bash');
+      assert.equal(response.reason, 'Bash(*rm*) is not allowed in this environment');
+      assertPreflightRequest(server);
+    } finally {
+      await client.shutdown();
+      await server.close();
+    }
+  });
+
+  test(`an unconfigured phase sends no request under ${policy}`, async () => {
+    const server = await startHookServer(respondWith(500, 'should not be called'));
+    const { client } = newClient({ baseUrl: server.baseUrl, failOpen, phases: ['postflight'] });
+    try {
+      const response = await client.evaluateHook(preflightRequest());
+      assert.equal(response.action, 'allow');
+      assert.equal(server.requests.length, 0);
+    } finally {
+      await client.shutdown();
+      await server.close();
+    }
+  });
+
+  test(`disabled hooks send no request under ${policy}`, async () => {
+    const server = await startHookServer(respondWith(500, 'should not be called'));
+    const { client } = newClient({ baseUrl: server.baseUrl, failOpen, enabled: false });
+    try {
+      const response = await client.evaluateHook(preflightRequest());
+      assert.equal(response.action, 'allow');
+      assert.equal(server.requests.length, 0);
+    } finally {
+      await client.shutdown();
+      await server.close();
+    }
+  });
+}
+
+for (const status of [429, 503]) {
+  test(`status ${status} fails open with a warning`, async () => {
+    const server = await startHookServer(respondWith(status, 'upstream unavailable'));
+    const { client, warnings } = newClient({ baseUrl: server.baseUrl, failOpen: true });
+    try {
+      const response = await client.evaluateHook(preflightRequest());
+      assert.equal(response.action, 'allow');
+      assertFailOpenWarning(warnings, `status ${status}`);
+      assertPreflightRequest(server);
+    } finally {
+      await client.shutdown();
+      await server.close();
+    }
+  });
+
+  test(`status ${status} fails closed`, async () => {
+    const server = await startHookServer(respondWith(status, 'upstream unavailable'));
+    const { client } = newClient({ baseUrl: server.baseUrl, failOpen: false });
+    try {
+      await assert.rejects(() => client.evaluateHook(preflightRequest()), /hook evaluation failed: status/);
+      assertPreflightRequest(server);
+    } finally {
+      await client.shutdown();
+      await server.close();
+    }
+  });
+}
+
+test('a malformed response body fails open with a warning', async () => {
+  const server = await startHookServer(respondWith(200, '{"action": "allow"'));
+  const { client, warnings } = newClient({ baseUrl: server.baseUrl, failOpen: true });
+  try {
+    const response = await client.evaluateHook(preflightRequest());
+    assert.equal(response.action, 'allow');
+    assertFailOpenWarning(warnings, 'invalid JSON response');
+    assertPreflightRequest(server);
+  } finally {
+    await client.shutdown();
+    await server.close();
+  }
+});
+
+test('a malformed response body fails closed', async () => {
+  const server = await startHookServer(respondWith(200, '{"action": "allow"'));
+  const { client } = newClient({ baseUrl: server.baseUrl, failOpen: false });
+  try {
+    await assert.rejects(() => client.evaluateHook(preflightRequest()), /invalid JSON response/);
+    assertPreflightRequest(server);
+  } finally {
+    await client.shutdown();
+    await server.close();
+  }
+});
+
+const slowResponseDelayMs = 2_000;
+const slowResponse = () => ({
+  status: 200,
+  body: JSON.stringify({ action: 'deny', rule_id: 'late' }),
+  delayMs: slowResponseDelayMs,
+});
+
+test('a response slower than the client timeout fails open with a warning', async () => {
+  const server = await startHookServer(slowResponse);
+  const { client, warnings } = newClient({ baseUrl: server.baseUrl, failOpen: true, timeoutMs: 250 });
+  try {
+    const started = Date.now();
+    const response = await client.evaluateHook(preflightRequest());
+    const elapsed = Date.now() - started;
+    assert.equal(response.action, 'allow');
+    assert.ok(elapsed < slowResponseDelayMs, `client waited ${elapsed}ms, so it did not enforce its own timeout`);
+    assertFailOpenWarning(warnings);
+    // The client is gone by the time the delayed write runs, so a write error is
+    // the case under test rather than a broken server.
+    assertPreflightRequest(server, { expectResponseWritten: false });
+  } finally {
+    await client.shutdown();
+    await server.close();
+  }
+});
+
+test('a response slower than the client timeout fails closed', async () => {
+  const server = await startHookServer(slowResponse);
+  const { client } = newClient({ baseUrl: server.baseUrl, failOpen: false, timeoutMs: 250 });
+  try {
+    const started = Date.now();
+    await assert.rejects(
+      () => client.evaluateHook(preflightRequest()),
+      /hook evaluation failed/,
+      'a timeout must surface as a hook transport failure, not as any thrown error',
+    );
+    const elapsed = Date.now() - started;
+    assert.ok(elapsed < slowResponseDelayMs, `client waited ${elapsed}ms, so it did not enforce its own timeout`);
+    assertPreflightRequest(server, { expectResponseWritten: false });
+  } finally {
+    await client.shutdown();
+    await server.close();
+  }
+});
+
+test('configured auth reaches the server', async () => {
+  const server = await startHookServer(respondWith(200, JSON.stringify(responses.allow)));
+  const { client } = newClient({
+    baseUrl: server.baseUrl,
+    auth: { mode: 'basic', basicUser: '12345', basicPassword: 'glc-token', tenantId: '12345' },
+  });
+  try {
+    await client.evaluateHook(preflightRequest());
+    const [call] = server.requests;
+    assert.equal(call.headers.authorization, `Basic ${Buffer.from('12345:glc-token', 'utf8').toString('base64')}`);
+    assert.equal(call.headers['x-scope-orgid'], '12345');
+    assert.equal(call.headers['x-agento11y-hook-timeout-ms'], '5000');
+    assertPreflightRequest(server);
+  } finally {
+    await client.shutdown();
+    await server.close();
+  }
+});
+
+test('concurrent evaluations are not serialized', async () => {
+  // A guard on the request path must not funnel every caller through one
+  // connection.
+  const server = await startHookServer(() => ({
+    status: 200,
+    body: JSON.stringify(responses.allow),
+    delayMs: 200,
+  }));
+  const { client } = newClient({ baseUrl: server.baseUrl });
+  try {
+    const results = await Promise.all([0, 1, 2, 3].map(() => client.evaluateHook(preflightRequest())));
+    assert.deepEqual(
+      results.map((r) => r.action),
+      ['allow', 'allow', 'allow', 'allow'],
+    );
+    assert.ok(server.maxInFlight > 1, `evaluations were serialized: peak in-flight ${server.maxInFlight}`);
+    assert.deepEqual(server.errors, []);
+    const fixture = loadPreflightRequest();
+    for (const call of server.requests) {
+      assert.deepEqual(diffJson(call.payload, fixture), []);
+    }
+  } finally {
+    await client.shutdown();
+    await server.close();
+  }
+});

--- a/js/test/hooksFixtures.mjs
+++ b/js/test/hooksFixtures.mjs
@@ -1,0 +1,184 @@
+// Loaders for the cross-language hook wire fixtures in `conformance/hooks/`.
+//
+// The preflight request is built from public SDK types so the conformance suite
+// compares what a caller can actually produce against the shared contract. See
+// `conformance/hooks/README.md` for the encoding rules.
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// js/test -> repository root
+const fixtureDir = join(__dirname, '..', '..', 'conformance', 'hooks');
+
+export const bashToolSchema =
+  '{"type":"object","properties":{"command":{"type":"string","description":"Shell command to run."}},"required":["command"]}';
+
+export const readFileToolSchema = '{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}';
+
+export function loadPreflightRequest() {
+  return JSON.parse(readFileSync(join(fixtureDir, 'request-preflight.json'), 'utf8'));
+}
+
+export function loadPostflightGuardRequest() {
+  return JSON.parse(readFileSync(join(fixtureDir, 'request-postflight-guard.json'), 'utf8'));
+}
+
+export function loadResponses() {
+  return JSON.parse(readFileSync(join(fixtureDir, 'responses.json'), 'utf8'));
+}
+
+/**
+ * Reports structural differences as dotted JSON paths plus both values, so a
+ * failure names the offending field instead of dumping two payloads.
+ */
+export function diffJson(got, want, path = '') {
+  const label = path === '' ? '<root>' : path;
+  if (Array.isArray(want)) {
+    if (!Array.isArray(got)) {
+      return [`${label}: got ${JSON.stringify(got)}, want an array`];
+    }
+    if (got.length !== want.length) {
+      return [`${label}: got ${got.length} items, want ${want.length}`];
+    }
+    return want.flatMap((item, index) => diffJson(got[index], item, `${path}[${index}]`));
+  }
+  if (want !== null && typeof want === 'object') {
+    if (got === null || typeof got !== 'object' || Array.isArray(got)) {
+      return [`${label}: got ${JSON.stringify(got)}, want an object`];
+    }
+    const keys = [...new Set([...Object.keys(want), ...Object.keys(got)])].sort();
+    const diffs = [];
+    for (const key of keys) {
+      const child = path === '' ? key : `${path}.${key}`;
+      if (!(key in got)) {
+        diffs.push(`${child}: missing, want ${JSON.stringify(want[key])}`);
+      } else if (!(key in want)) {
+        diffs.push(`${child}: unexpected ${JSON.stringify(got[key])}`);
+      } else {
+        diffs.push(...diffJson(got[key], want[key], child));
+      }
+    }
+    return diffs;
+  }
+  if (got !== want) {
+    return [`${label}: got ${JSON.stringify(got)}, want ${JSON.stringify(want)}`];
+  }
+  return [];
+}
+
+/**
+ * Builds `request-postflight-guard.json` from the public JS SDK types.
+ *
+ * The shipped guards evaluate a tool call under `input.output`, and the server's
+ * tool filter scans that field before `input.messages`.
+ */
+export function postflightGuardRequest() {
+  return {
+    phase: 'postflight',
+    context: {
+      agentName: 'conformance-guard',
+      agentVersion: '1.2.3',
+      model: { provider: 'anthropic', name: 'claude-sonnet-4' },
+    },
+    input: {
+      output: [
+        {
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool_call',
+              toolCall: { id: 'call-bash', name: 'Bash', inputJSON: '{"command":"rm -rf /tmp/cache"}' },
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+/** Builds `request-preflight.json` from the public JS SDK types. */
+export function preflightRequest() {
+  return {
+    phase: 'preflight',
+    context: {
+      agentName: 'conformance-agent',
+      agentVersion: '1.2.3',
+      model: { provider: 'anthropic', name: 'claude-sonnet-4' },
+      tags: { env: 'test', team: 'agent-observability' },
+      conversationId: 'conv-hooks-conformance',
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: '0123456789abcdef',
+    },
+    input: {
+      systemPrompt: 'You are a careful assistant.',
+      messages: [
+        {
+          role: 'user',
+          parts: [{ type: 'text', text: 'Delete the cache directory under /tmp.' }],
+        },
+        {
+          role: 'assistant',
+          parts: [
+            { type: 'thinking', thinking: 'The request is destructive, so inspect the directory first.' },
+            {
+              type: 'tool_call',
+              toolCall: { id: 'call-read', name: 'read_file', inputJSON: '{"path":"/tmp/cache/manifest.json"}' },
+            },
+            {
+              type: 'tool_call',
+              toolCall: { id: 'call-bash', name: 'Bash', inputJSON: '{"command":"rm -rf /tmp/cache"}' },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          name: 'read_file',
+          parts: [
+            {
+              type: 'tool_result',
+              toolResult: {
+                toolCallId: 'call-read',
+                name: 'read_file',
+                content: '3 entries',
+                contentJSON: '{"entries":3}',
+              },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          name: 'Bash',
+          parts: [
+            {
+              type: 'tool_result',
+              toolResult: {
+                toolCallId: 'call-bash',
+                name: 'Bash',
+                isError: true,
+                content: "rm: cannot remove '/tmp/cache': Permission denied",
+                contentJSON: '{"exit_code":1}',
+              },
+            },
+          ],
+        },
+      ],
+      tools: [
+        {
+          name: 'Bash',
+          description: 'Run a shell command.',
+          type: 'function',
+          inputSchemaJSON: bashToolSchema,
+        },
+        {
+          name: 'read_file',
+          description: 'Read a file from disk.',
+          type: 'function',
+          inputSchemaJSON: readFileToolSchema,
+        },
+      ],
+      conversationPreview: 'user: Delete the cache directory under /tmp.',
+    },
+  };
+}

--- a/mise.toml
+++ b/mise.toml
@@ -215,6 +215,11 @@ description = "Run the Go SDK core conformance harness"
 dir = "go"
 run = "GOWORK=off go test ./agento11y -run '^TestConformance' -count=1"
 
+[tasks."test:go:sdk-hooks-conformance"]
+description = "Run the Go SDK hook tests: wire fixtures and guard behavior"
+dir = "go"
+run = "GOWORK=off go test ./agento11y -run '^TestHook' -count=1"
+
 # --- TypeScript/JavaScript SDK tests ---
 
 [tasks."test:ts:sdk-js"]
@@ -227,6 +232,12 @@ description = "Run TypeScript/JavaScript SDK core conformance tests"
 depends = ["deps"]
 dir = "js"
 run = "pnpm run test:build && node --test test/conformance.test.mjs"
+
+[tasks."test:ts:sdk-hooks-conformance"]
+description = "Run the TypeScript/JavaScript SDK hook tests: wire fixtures and guard behavior"
+depends = ["deps"]
+dir = "js"
+run = "pnpm run test:build && node --test test/hooks.conformance.test.mjs test/hooks.integration.test.mjs"
 
 [tasks."test:ts:sdk-provider-conformance"]
 description = "Run TypeScript/JavaScript provider-wrapper conformance tests"
@@ -254,6 +265,10 @@ run = "uv run --python \"$PYTHON_BIN\" --with '.[dev]' --directory python pytest
 [tasks."test:py:sdk-conformance"]
 description = "Run Python SDK core conformance tests"
 run = "uv run --python \"$PYTHON_BIN\" --with '.[dev]' --directory python pytest tests/test_conformance.py"
+
+[tasks."test:py:sdk-hooks-conformance"]
+description = "Run the Python SDK hook tests: wire fixtures and guard behavior"
+run = "uv run --python \"$PYTHON_BIN\" --with '.[dev]' --directory python pytest tests/test_hooks_conformance.py tests/test_hooks_integration.py"
 
 [tasks."test:py:sdk-openai"]
 description = "Run Python OpenAI provider helper tests"
@@ -427,6 +442,19 @@ mise run test:java:sdk-conformance
 mise run test:cs:sdk-conformance
 """
 
+[tasks."test:sdk:hooks-conformance"]
+description = """
+Run the hook tests in Go, Python, and TypeScript/JavaScript: wire fixtures and
+guard behavior. Java and .NET have no hook support, so they are excluded.
+"""
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+mise run test:go:sdk-hooks-conformance
+mise run test:ts:sdk-hooks-conformance
+mise run test:py:sdk-hooks-conformance
+"""
+
 [tasks."test:sdk:provider-conformance"]
 description = "Run provider-wrapper conformance suites across all shipped SDKs"
 run = """
@@ -458,6 +486,7 @@ run = """
 #!/usr/bin/env bash
 set -euo pipefail
 mise run test:sdk:core-conformance
+mise run test:sdk:hooks-conformance
 mise run test:sdk:provider-conformance
 mise run test:sdk:framework-conformance
 """

--- a/plugins/opencode/src/hooks.guard.test.ts
+++ b/plugins/opencode/src/hooks.guard.test.ts
@@ -46,6 +46,11 @@ function closeServer(server: Server): Promise<void> {
   });
 }
 
+/** Encodes a transformed tool payload the way the server does. */
+function base64Json(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+
 function config(endpoint: string): Agento11yOpencodeConfig {
   return {
     endpoint,
@@ -121,11 +126,11 @@ describe("opencode guards", () => {
             role: "assistant",
             parts: [
               {
-                type: "tool_call",
-                toolCall: {
+                kind: "tool_call",
+                tool_call: {
                   id: "call-1",
                   name: "third-party-test-mcp_third_party_test_mcp_leak_fake_credential",
-                  inputJSON: JSON.stringify({ demo: true }),
+                  input_json: { demo: true },
                 },
               },
             ],
@@ -147,11 +152,14 @@ describe("opencode guards", () => {
             role: "assistant",
             parts: [
               {
-                type: "tool_call",
-                toolCall: {
+                kind: "tool_call",
+                tool_call: {
                   id: "call-1",
                   name: "bash",
-                  inputJSON: JSON.stringify({ command: "echo [REDACTED]" }),
+                  // The server base64-encodes response payloads, so a stub
+                  // sending raw JSON here would exercise a shape it never
+                  // emits. conformance/hooks/README.md.
+                  input_json: base64Json({ command: "echo [REDACTED]" }),
                 },
               },
             ],
@@ -223,8 +231,12 @@ describe("opencode guards", () => {
             role: "assistant",
             parts: [
               {
-                type: "tool_call",
-                toolCall: { id: "call-1", name: "bash", inputJSON: "{}" },
+                kind: "tool_call",
+                tool_call: {
+                  id: "call-1",
+                  name: "bash",
+                  input_json: base64Json({}),
+                },
               },
             ],
           },
@@ -262,11 +274,11 @@ describe("opencode guards", () => {
             role: "assistant",
             parts: [
               {
-                type: "tool_call",
-                toolCall: {
+                kind: "tool_call",
+                tool_call: {
                   id: "call-1",
                   name: "bash",
-                  inputJSON: JSON.stringify({ 0: "x" }),
+                  input_json: base64Json({ 0: "x" }),
                 },
               },
             ],
@@ -328,15 +340,17 @@ describe("opencode guards", () => {
     expect(
       hookServer.captures[0]?.input?.output?.[0]?.parts?.[0],
     ).toMatchObject({
-      type: "tool_call",
-      toolCall: {
+      kind: "tool_call",
+      tool_call: {
         id: "call-1",
         name: "bash",
-        inputJSON: JSON.stringify({
+        // Tool arguments travel as embedded JSON, which is what an
+        // argument-level rule matches on. conformance/hooks/README.md.
+        input_json: {
           pattern: "rm *",
           title: "Run shell command",
           metadata: { command: "rm -rf /tmp/demo" },
-        }),
+        },
       },
     });
 

--- a/python/agento11y/hooks.py
+++ b/python/agento11y/hooks.py
@@ -17,7 +17,7 @@ from opentelemetry import trace
 from .config import HooksConfig
 from .context import conversation_id_from_context
 from .errors import HookDeniedError, HookTransportError
-from .models import Message, MessageRole, Part, PartKind, ToolDefinition
+from .models import Message, MessageRole, Part, PartKind, ToolCall, ToolDefinition, ToolResult
 
 _logger = logging.getLogger("agento11y")
 
@@ -25,6 +25,12 @@ HOOKS_EVALUATE_PATH = "/api/v1/hooks:evaluate"
 HOOK_TIMEOUT_HEADER = "X-Agento11y-Hook-Timeout-Ms"
 DEFAULT_HOOK_TIMEOUT = 15.0
 _MAX_HOOK_RESPONSE_BYTES = 4 << 20
+
+# MessageRole enum values from proto/agento11y/v1/generation_ingest.proto, as an
+# emitter that marshals the generated structs with a plain JSON encoder sends
+# them. Kept as literals so the hook path does not pull in the protobuf stubs.
+_PROTO_ROLE_ASSISTANT = 2
+_PROTO_ROLE_TOOL = 3
 
 
 class HookPhase(str, Enum):
@@ -206,8 +212,7 @@ def _allow_response() -> HookEvaluateResponse:
 
 def _fail_open_or_raise(fail_open: bool, detail: str) -> HookEvaluateResponse:
     if fail_open:
-        # A dead evaluator allows every request. Without this line that is
-        # completely silent, so an outage looks identical to a clean allow.
+        # Fail-open turns an evaluator outage into a silent allow, so record it.
         _logger.warning("agento11y: hook evaluation failed, allowing request (fail_open): %s", detail)
         return _allow_response()
     raise HookTransportError(f"agento11y hook evaluation failed: {detail}")
@@ -277,15 +282,15 @@ def _message_role_wire(role: Any) -> str:
 def _serialize_message(message: Message) -> dict[str, Any]:
     """Serializes a message for the hooks API.
 
-    Every part carries its ``kind``. The server dispatches on that field and
-    only recovers a missing one for text, so a ``kind``-less thinking, tool
-    call, or tool result part reaches rule evaluation as an empty part: a
-    tool-filter guard sees no tool calls and allows the request.
+    Every part carries its ``kind``. The server dispatches on that field, and it
+    recovers a missing one for text only. A ``kind``-less thinking, tool call, or
+    tool result part therefore reaches rule evaluation as an empty part, and a
+    tool-filter guard sees no tool calls in it and allows the request.
 
-    Tool arguments and tool result payloads go out as embedded JSON, not
-    base64. The hooks API reads them as raw JSON, so a base64 blob is what
-    argument-level rules end up matching against. Generation export is the
-    other way around, because that is protobuf JSON.
+    Tool arguments and tool result payloads go out as embedded JSON, not base64.
+    The hooks API reads them as raw JSON, so a base64 blob is what argument-level
+    rules end up matching against. Responses come back the other way around,
+    because those are protobuf JSON. See ``conformance/hooks/README.md``.
     """
 
     parts: list[dict[str, Any]] = []
@@ -295,23 +300,23 @@ def _serialize_message(message: Message) -> dict[str, Any]:
         elif part.kind == PartKind.THINKING and part.thinking:
             parts.append({"kind": PartKind.THINKING.value, "thinking": part.thinking})
         elif part.kind == PartKind.TOOL_CALL and part.tool_call is not None:
-            payload: dict[str, Any] = {
-                "id": part.tool_call.id,
-                "name": part.tool_call.name,
-            }
+            payload: dict[str, Any] = {"name": part.tool_call.name}
+            if part.tool_call.id:
+                payload["id"] = part.tool_call.id
             if part.tool_call.input_json:
                 payload["input_json"] = _embedded_json(part.tool_call.input_json)
             parts.append({"kind": PartKind.TOOL_CALL.value, "tool_call": payload})
         elif part.kind == PartKind.TOOL_RESULT and part.tool_result is not None:
             tr = part.tool_result
-            tr_payload: dict[str, Any] = {
-                "is_error": tr.is_error,
-                "content": tr.content,
-            }
+            tr_payload: dict[str, Any] = {}
             if tr.tool_call_id:
                 tr_payload["tool_call_id"] = tr.tool_call_id
             if tr.name:
                 tr_payload["name"] = tr.name
+            if tr.is_error:
+                tr_payload["is_error"] = True
+            if tr.content:
+                tr_payload["content"] = tr.content
             if tr.content_json:
                 tr_payload["content_json"] = _embedded_json(tr.content_json)
             parts.append({"kind": PartKind.TOOL_RESULT.value, "tool_result": tr_payload})
@@ -326,10 +331,11 @@ def _serialize_message(message: Message) -> dict[str, Any]:
 
 
 def _embedded_json(raw: bytes) -> Any:
-    """Decodes JSON bytes for embedding in the hook payload.
+    """Decodes JSON bytes for embedding in a hook request.
 
     Bytes that do not parse are sent as a JSON string, which keeps the request
-    body valid and leaves the text visible to rules instead of dropping it.
+    body valid and leaves the text visible to rules instead of dropping it. Go
+    and JS do the same.
     """
 
     try:
@@ -341,9 +347,11 @@ def _embedded_json(raw: bytes) -> Any:
 def _serialize_tool(tool: ToolDefinition) -> dict[str, Any]:
     """Serializes a tool definition for the hooks API.
 
-    ``input_schema_json`` stays base64 even though tool call arguments do not:
-    the server decodes the tools list straight into its protobuf type, which
-    rejects embedded JSON for a bytes field.
+    ``input_schema_json`` stays base64 even though tool call arguments do not: the
+    server decodes the tools list straight into its protobuf type, whose
+    ``input_schema_json`` is a bytes field. A schema under any other key is
+    ignored, and embedded JSON under this key fails that decode, which makes the
+    server answer 400 for the whole evaluation.
     """
 
     out: dict[str, Any] = {"name": tool.name}
@@ -408,18 +416,50 @@ def _parse_hook_input_wire(data: Any) -> HookInput | None:
     sp = data.get("system_prompt")
     if isinstance(sp, str) and sp != "":
         out.system_prompt = sp
-    raw_msgs = data.get("messages")
-    if isinstance(raw_msgs, list):
-        msgs: list[Message] = []
-        for item in raw_msgs:
-            m = _parse_wire_message_dict(item)
-            if m is not None:
-                msgs.append(m)
-        if msgs:
-            out.messages = msgs
-    if out.messages or out.conversation_preview or out.system_prompt:
+    messages = _parse_wire_messages(data.get("messages"))
+    if messages:
+        out.messages = messages
+    output = _parse_wire_messages(data.get("output"))
+    if output:
+        out.output = output
+    raw_tools = data.get("tools")
+    if isinstance(raw_tools, list):
+        tools: list[ToolDefinition] = []
+        for item in raw_tools:
+            tool = _parse_wire_tool_dict(item)
+            if tool is not None:
+                tools.append(tool)
+        if tools:
+            out.tools = tools
+    if out.messages or out.output or out.tools or out.conversation_preview or out.system_prompt:
         return out
     return None
+
+
+def _parse_wire_messages(raw: Any) -> list[Message]:
+    if not isinstance(raw, list):
+        return []
+    out: list[Message] = []
+    for item in raw:
+        message = _parse_wire_message_dict(item)
+        if message is not None:
+            out.append(message)
+    return out
+
+
+def _parse_wire_tool_dict(item: Any) -> ToolDefinition | None:
+    if not isinstance(item, dict):
+        return None
+    name = _string_field(item.get("name"))
+    if name == "":
+        return None
+    return ToolDefinition(
+        name=name,
+        description=_string_field(item.get("description")),
+        type=_string_field(item.get("type")),
+        input_schema_json=_wire_json_bytes(item.get("input_schema_json")),
+        deferred=item.get("deferred") is True,
+    )
 
 
 def _parse_wire_message_dict(item: Any) -> Message | None:
@@ -428,9 +468,9 @@ def _parse_wire_message_dict(item: Any) -> Message | None:
     role_val = item.get("role", "user")
     role = MessageRole.USER
     if isinstance(role_val, int):
-        if role_val == 2:
+        if role_val == _PROTO_ROLE_ASSISTANT:
             role = MessageRole.ASSISTANT
-        elif role_val == 3:
+        elif role_val == _PROTO_ROLE_TOOL:
             role = MessageRole.TOOL
     else:
         role_raw = str(role_val).lower()
@@ -443,18 +483,118 @@ def _parse_wire_message_dict(item: Any) -> Message | None:
         return Message(role=role, parts=[])
     parts: list[Part] = []
     for pr in parts_raw:
-        if not isinstance(pr, dict):
-            continue
-        txt = pr.get("text")
-        if isinstance(txt, str) and txt != "":
-            parts.append(Part(kind=PartKind.TEXT, text=txt))
-            continue
-        think = pr.get("thinking")
-        if isinstance(think, str) and think != "":
-            parts.append(Part(kind=PartKind.THINKING, thinking=think))
+        part = _parse_wire_part_dict(pr)
+        if part is not None:
+            parts.append(part)
     name = item.get("name")
     n = str(name) if isinstance(name, str) else ""
     return Message(role=role, parts=parts, name=n)
+
+
+def _parse_wire_part_dict(pr: Any) -> Part | None:
+    """Reconstructs one wire part, keying off ``kind`` and falling back to payload keys.
+
+    Tool call and tool result payloads arrive base64-encoded because the server
+    marshals its protobuf bytes fields with encoding/json. A parser that skipped
+    those two kinds would drop the transform a guard asked the caller to apply,
+    and report nothing.
+
+    The server always sets ``kind``, so the payload-key fallback only covers a
+    hand-written or protobuf-JSON body. Go and JS keep the same tolerance.
+    """
+
+    if not isinstance(pr, dict):
+        return None
+    kind = _string_field(pr.get("kind"))
+    raw_call = pr.get("tool_call")
+    raw_result = pr.get("tool_result")
+    if kind == "":
+        if isinstance(raw_call, dict):
+            kind = PartKind.TOOL_CALL.value
+        elif isinstance(raw_result, dict):
+            kind = PartKind.TOOL_RESULT.value
+        elif isinstance(pr.get("thinking"), str) and pr.get("thinking") != "":
+            kind = PartKind.THINKING.value
+        elif isinstance(pr.get("text"), str) and pr.get("text") != "":
+            kind = PartKind.TEXT.value
+        else:
+            return None
+    if kind == PartKind.TOOL_CALL.value:
+        if not isinstance(raw_call, dict):
+            return None
+        name = _string_field(raw_call.get("name"))
+        if name == "":
+            return None
+        return Part(
+            kind=PartKind.TOOL_CALL,
+            tool_call=ToolCall(
+                name=name,
+                id=_string_field(raw_call.get("id")),
+                input_json=_wire_json_bytes(raw_call.get("input_json")),
+            ),
+        )
+    if kind == PartKind.TOOL_RESULT.value:
+        if not isinstance(raw_result, dict):
+            return None
+        return Part(
+            kind=PartKind.TOOL_RESULT,
+            tool_result=ToolResult(
+                tool_call_id=_string_field(raw_result.get("tool_call_id")),
+                name=_string_field(raw_result.get("name")),
+                content=_string_field(raw_result.get("content")),
+                content_json=_wire_json_bytes(raw_result.get("content_json")),
+                is_error=raw_result.get("is_error") is True,
+            ),
+        )
+    if kind == PartKind.THINKING.value:
+        thinking = _string_field(pr.get("thinking"))
+        return Part(kind=PartKind.THINKING, thinking=thinking) if thinking else None
+    text = _string_field(pr.get("text"))
+    return Part(kind=PartKind.TEXT, text=text) if text else None
+
+
+def _wire_json_bytes(value: Any) -> bytes:
+    """Recovers a response-side JSON payload as raw bytes.
+
+    The server base64-encodes protobuf bytes fields, so the common case is a
+    base64 string holding a JSON document. The result is always a JSON document:
+    base64 that decodes to something else, and a string that is neither base64
+    nor JSON, are kept as a JSON string so the text survives. Go and JS apply the
+    same rule; see ``conformance/hooks/README.md``.
+    """
+
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, separators=(",", ":")).encode("utf-8")
+    if not isinstance(value, str) or value == "":
+        return b""
+    decoded = _decode_base64(value)
+    if decoded is not None:
+        if _is_json_document(decoded):
+            return decoded
+        return _json_string_bytes(decoded.decode("utf-8", errors="replace"))
+    raw = value.encode("utf-8")
+    if _is_json_document(raw):
+        return raw
+    return _json_string_bytes(value)
+
+
+def _decode_base64(value: str) -> bytes | None:
+    try:
+        return base64.b64decode(value, validate=True)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _is_json_document(raw: bytes) -> bool:
+    try:
+        json.loads(raw)
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
+def _json_string_bytes(text: str) -> bytes:
+    return json.dumps(text).encode("utf-8")
 
 
 def _string_field(value: Any) -> str:

--- a/python/tests/hooks_fixtures.py
+++ b/python/tests/hooks_fixtures.py
@@ -1,0 +1,219 @@
+"""Loaders for the cross-language hook wire fixtures in `conformance/hooks/`.
+
+The preflight request is built with public SDK types so the conformance suite
+compares what a caller can actually produce against the shared contract. See
+`conformance/hooks/README.md` for the encoding rules.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from agento11y import (
+    HookContext,
+    HookEvaluateRequest,
+    HookInput,
+    HookModel,
+    HookPhase,
+    Message,
+    MessageRole,
+    Part,
+    PartKind,
+    ToolCall,
+    ToolDefinition,
+    ToolResult,
+)
+
+FIXTURE_DIR = Path(__file__).resolve().parents[2] / "conformance" / "hooks"
+
+BASH_SCHEMA = (
+    b'{"type":"object","properties":{"command":{"type":"string",'
+    b'"description":"Shell command to run."}},"required":["command"]}'
+)
+READ_FILE_SCHEMA = b'{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}'
+
+
+def load_preflight_request() -> dict[str, Any]:
+    """Returns the parsed `request-preflight.json` fixture."""
+
+    return json.loads((FIXTURE_DIR / "request-preflight.json").read_text(encoding="utf-8"))
+
+
+def load_postflight_guard_request() -> dict[str, Any]:
+    """Returns the parsed `request-postflight-guard.json` fixture."""
+
+    return json.loads((FIXTURE_DIR / "request-postflight-guard.json").read_text(encoding="utf-8"))
+
+
+def load_responses() -> dict[str, Any]:
+    """Returns the parsed `responses.json` fixture keyed by scenario name."""
+
+    return json.loads((FIXTURE_DIR / "responses.json").read_text(encoding="utf-8"))
+
+
+def diff_json(got: Any, want: Any, path: str = "") -> list[str]:
+    """Reports structural differences as dotted JSON paths plus both values.
+
+    A failure has to name the offending field: the divergences this suite exists
+    to catch are single renamed keys and single re-encoded payloads.
+    """
+
+    label = path or "<root>"
+    if isinstance(want, dict):
+        if not isinstance(got, dict):
+            return [f"{label}: got {json.dumps(got)}, want an object"]
+        diffs: list[str] = []
+        for key in sorted(set(want) | set(got)):
+            child = f"{path}.{key}" if path else key
+            if key not in got:
+                diffs.append(f"{child}: missing, want {json.dumps(want[key])}")
+            elif key not in want:
+                diffs.append(f"{child}: unexpected {json.dumps(got[key])}")
+            else:
+                diffs.extend(diff_json(got[key], want[key], child))
+        return diffs
+    if isinstance(want, list):
+        if not isinstance(got, list):
+            return [f"{label}: got {json.dumps(got)}, want an array"]
+        if len(got) != len(want):
+            return [f"{label}: got {len(got)} items, want {len(want)}"]
+        diffs = []
+        for index, (got_item, want_item) in enumerate(zip(got, want, strict=True)):
+            diffs.extend(diff_json(got_item, want_item, f"{path}[{index}]"))
+        return diffs
+    if got != want or isinstance(got, bool) != isinstance(want, bool):
+        return [f"{label}: got {json.dumps(got)}, want {json.dumps(want)}"]
+    return []
+
+
+def postflight_guard_request() -> HookEvaluateRequest:
+    """Builds the postflight guard request from public Python SDK types.
+
+    The shipped guards evaluate a tool call under `input.output`, and the server's
+    tool filter scans that field before `input.messages`.
+    """
+
+    return HookEvaluateRequest(
+        phase=HookPhase.POSTFLIGHT.value,
+        context=HookContext(
+            agent_name="conformance-guard",
+            agent_version="1.2.3",
+            model=HookModel(provider="anthropic", name="claude-sonnet-4"),
+        ),
+        input=HookInput(
+            output=[
+                Message(
+                    role=MessageRole.ASSISTANT,
+                    parts=[
+                        Part(
+                            kind=PartKind.TOOL_CALL,
+                            tool_call=ToolCall(
+                                id="call-bash",
+                                name="Bash",
+                                input_json=b'{"command":"rm -rf /tmp/cache"}',
+                            ),
+                        )
+                    ],
+                )
+            ]
+        ),
+    )
+
+
+def preflight_request() -> HookEvaluateRequest:
+    """Builds the preflight hook request from public Python SDK types."""
+
+    return HookEvaluateRequest(
+        phase=HookPhase.PREFLIGHT.value,
+        context=HookContext(
+            agent_name="conformance-agent",
+            agent_version="1.2.3",
+            model=HookModel(provider="anthropic", name="claude-sonnet-4"),
+            tags={"env": "test", "team": "agent-observability"},
+            conversation_id="conv-hooks-conformance",
+            trace_id="0123456789abcdef0123456789abcdef",
+            span_id="0123456789abcdef",
+        ),
+        input=HookInput(
+            system_prompt="You are a careful assistant.",
+            messages=[
+                Message(
+                    role=MessageRole.USER,
+                    parts=[Part(kind=PartKind.TEXT, text="Delete the cache directory under /tmp.")],
+                ),
+                Message(
+                    role=MessageRole.ASSISTANT,
+                    parts=[
+                        Part(
+                            kind=PartKind.THINKING,
+                            thinking="The request is destructive, so inspect the directory first.",
+                        ),
+                        Part(
+                            kind=PartKind.TOOL_CALL,
+                            tool_call=ToolCall(
+                                id="call-read",
+                                name="read_file",
+                                input_json=b'{"path":"/tmp/cache/manifest.json"}',
+                            ),
+                        ),
+                        Part(
+                            kind=PartKind.TOOL_CALL,
+                            tool_call=ToolCall(
+                                id="call-bash",
+                                name="Bash",
+                                input_json=b'{"command":"rm -rf /tmp/cache"}',
+                            ),
+                        ),
+                    ],
+                ),
+                Message(
+                    role=MessageRole.TOOL,
+                    name="read_file",
+                    parts=[
+                        Part(
+                            kind=PartKind.TOOL_RESULT,
+                            tool_result=ToolResult(
+                                tool_call_id="call-read",
+                                name="read_file",
+                                content="3 entries",
+                                content_json=b'{"entries":3}',
+                            ),
+                        )
+                    ],
+                ),
+                Message(
+                    role=MessageRole.TOOL,
+                    name="Bash",
+                    parts=[
+                        Part(
+                            kind=PartKind.TOOL_RESULT,
+                            tool_result=ToolResult(
+                                tool_call_id="call-bash",
+                                name="Bash",
+                                is_error=True,
+                                content="rm: cannot remove '/tmp/cache': Permission denied",
+                                content_json=b'{"exit_code":1}',
+                            ),
+                        )
+                    ],
+                ),
+            ],
+            tools=[
+                ToolDefinition(
+                    name="Bash",
+                    description="Run a shell command.",
+                    type="function",
+                    input_schema_json=BASH_SCHEMA,
+                ),
+                ToolDefinition(
+                    name="read_file",
+                    description="Read a file from disk.",
+                    type="function",
+                    input_schema_json=READ_FILE_SCHEMA,
+                ),
+            ],
+            conversation_preview="user: Delete the cache directory under /tmp.",
+        ),
+    )

--- a/python/tests/hooks_server.py
+++ b/python/tests/hooks_server.py
@@ -1,0 +1,113 @@
+"""Programmable local `hooks:evaluate` server for the Python hook tests.
+
+One server whose status, body, and delay are set per test. That covers allow,
+deny, transport failure, timeout, and malformed-response cases without a second
+server. The server captures each request, so a test can compare the body it
+actually sent with the shared fixture.
+
+`plugins/pi/src/testHttp.ts` takes a per-request responder callback instead. The
+programmable attributes here suit pytest fixtures better, and the `errors` list
+does the same job in both.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+HOOKS_EVALUATE_PATH = "/api/v1/hooks:evaluate"
+
+
+class HookServer:
+    """Local hook-evaluation server with programmable responses and delays."""
+
+    def __init__(self) -> None:
+        self.requests: list[dict[str, Any]] = []
+        self.response: dict[str, Any] = {"action": "allow", "evaluations": []}
+        # raw_body overrides `response` so a test can return a malformed payload.
+        self.raw_body: str | None = None
+        self.status = 200
+        self.delay = 0.0
+        self.in_flight = 0
+        self.max_in_flight = 0
+        # Non-empty when the server could not answer a request. A test that only
+        # asserts a fail-open allow passes either way, so the assertion helpers
+        # check this list instead of trusting a silent handler.
+        self.errors: list[str] = []
+        self._lock = threading.Lock()
+
+        server = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.0"
+
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", "0"))
+                body = self.rfile.read(length)
+                with server._lock:
+                    entry: dict[str, Any] = {
+                        "path": self.path,
+                        "headers": {k.lower(): v for k, v in self.headers.items()},
+                        "raw": body.decode("utf-8", errors="replace"),
+                    }
+                    try:
+                        entry["payload"] = json.loads(body.decode("utf-8"))
+                    except Exception:  # noqa: BLE001
+                        entry["payload"] = None
+                    server.requests.append(entry)
+                    server.in_flight += 1
+                    server.max_in_flight = max(server.max_in_flight, server.in_flight)
+                try:
+                    payload = server.raw_body if server.raw_body is not None else json.dumps(server.response)
+                    encoded = payload.encode("utf-8")
+                    status = server.status
+                    delay = server.delay
+                except Exception as exc:  # noqa: BLE001
+                    with server._lock:
+                        server.errors.append(f"could not render the response: {exc}")
+                        server.in_flight -= 1
+                    return
+                try:
+                    if delay:
+                        time.sleep(delay)
+                    self.send_response(status)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(encoded)))
+                    self.end_headers()
+                    self.wfile.write(encoded)
+                except Exception as exc:  # noqa: BLE001
+                    # A client that aborted on timeout leaves a closed socket
+                    # here. Record it: the timeout cases expect it, and every
+                    # other case asserts this list is empty.
+                    with server._lock:
+                        server.errors.append(f"could not write the response: {exc}")
+                finally:
+                    with server._lock:
+                        server.in_flight -= 1
+
+            def log_message(self, _format, *_args):  # noqa: A003
+                return
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._server.daemon_threads = True
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self._server.server_address[1]}"
+
+    @property
+    def payloads(self) -> list[dict[str, Any]]:
+        return [entry["payload"] for entry in self.requests]
+
+    @property
+    def request_count(self) -> int:
+        return len(self.requests)
+
+    def close(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()

--- a/python/tests/test_hooks_conformance.py
+++ b/python/tests/test_hooks_conformance.py
@@ -1,0 +1,479 @@
+"""Hook wire conformance for the Python SDK.
+
+Checks the request the SDK serializes and the responses it parses against the
+shared fixtures in `conformance/hooks/`, which are the only contract for an
+endpoint with no generated stubs.
+"""
+
+from __future__ import annotations
+
+import base64
+import copy
+import json
+from typing import Any
+
+import pytest
+from agento11y import (
+    HookContext,
+    HookEvaluateRequest,
+    HookInput,
+    HookModel,
+    Message,
+    MessageRole,
+    Part,
+    PartKind,
+    ToolCall,
+    ToolResult,
+)
+from agento11y.hooks import _parse_response, _serialize_request
+from hooks_fixtures import (
+    BASH_SCHEMA,
+    diff_json,
+    load_postflight_guard_request,
+    load_preflight_request,
+    load_responses,
+    postflight_guard_request,
+    preflight_request,
+)
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "build", "load"),
+    [
+        pytest.param("request-preflight.json", preflight_request, load_preflight_request, id="request-preflight"),
+        pytest.param(
+            "request-postflight-guard.json",
+            postflight_guard_request,
+            load_postflight_guard_request,
+            id="request-postflight-guard",
+        ),
+    ],
+)
+def test_hooks_request_conformance(fixture_name: str, build: Any, load: Any) -> None:
+    serialized = json.loads(json.dumps(_serialize_request(build())))
+    diffs = diff_json(serialized, load())
+    assert diffs == [], f"request does not match conformance/hooks/{fixture_name}:\n" + "\n".join(diffs)
+
+
+@pytest.mark.parametrize(
+    ("name", "mutate", "want_path"),
+    [
+        pytest.param(
+            "renamed discriminator",
+            lambda body: _rename_kind(_part(body, 0, 0)),
+            "input.messages[0].parts[0].kind",
+            id="renamed-discriminator",
+        ),
+        pytest.param(
+            "unknown discriminator value",
+            lambda body: _part(body, 0, 0).update({"kind": "message"}),
+            "input.messages[0].parts[0].kind",
+            id="unknown-discriminator",
+        ),
+        pytest.param(
+            "base64 tool call input",
+            lambda body: _base64_encode_in_place(_part(body, 1, 1)["tool_call"], "input_json"),
+            "input.messages[1].parts[1].tool_call.input_json",
+            id="base64-tool-call-input",
+        ),
+        pytest.param(
+            "base64 tool result content",
+            lambda body: _base64_encode_in_place(_part(body, 2, 0)["tool_result"], "content_json"),
+            "input.messages[2].parts[0].tool_result.content_json",
+            id="base64-tool-result-content",
+        ),
+        pytest.param(
+            "raw JSON tool schema",
+            lambda body: _raw_json_schema(body["input"]["tools"][0]),
+            "input.tools[0].input_schema_json",
+            id="raw-json-tool-schema",
+        ),
+    ],
+)
+def test_hook_fixture_comparison_names_divergent_fields(name: str, mutate: Any, want_path: str) -> None:
+    """Pins the comparator, not the serializer.
+
+    ``test_hooks_request_conformance`` is what checks the SDK's own output. Each
+    case here applies one divergence the server cannot read and asserts the diff
+    names the offending path. Without this test, a comparator that accepted a
+    renamed discriminator or a re-encoded payload would pass every conformance
+    case while checking nothing.
+    """
+
+    fixture = load_preflight_request()
+    mutated = copy.deepcopy(fixture)
+    mutate(mutated)
+
+    diffs = diff_json(mutated, fixture)
+    assert diffs, f"comparison accepted a divergent payload ({name})"
+    assert any(diff.startswith(want_path) for diff in diffs), f"diff did not name {want_path}: {diffs}"
+
+
+def test_hooks_response_conformance_allow() -> None:
+    parsed = _parse_response(load_responses()["allow"])
+
+    assert parsed.action == "allow"
+    assert not parsed.is_deny
+    assert parsed.transformed_input is None
+    assert len(parsed.evaluations) == 1
+    evaluation = parsed.evaluations[0]
+    assert evaluation.rule_id == "pii-detect"
+    assert evaluation.evaluator_id == "evaluator-pii"
+    assert evaluation.evaluator_kind == "regex"
+    assert evaluation.passed is True
+    assert evaluation.latency_ms == 12
+    assert evaluation.explanation == "no PII matches"
+
+
+def test_hooks_response_conformance_deny() -> None:
+    parsed = _parse_response(load_responses()["deny"])
+
+    assert parsed.is_deny
+    assert parsed.rule_id == "block-destructive-bash"
+    assert parsed.reason == "Bash(*rm*) is not allowed in this environment"
+    assert len(parsed.evaluations) == 1
+    assert parsed.evaluations[0].passed is False
+    assert parsed.evaluations[0].reason == "blocked tool Bash"
+
+
+def test_hooks_response_conformance_transformed_input() -> None:
+    parsed = _parse_response(load_responses()["allow_with_transformed_input"])
+
+    assert parsed.action == "allow"
+    transformed = parsed.transformed_input
+    assert transformed is not None
+    assert transformed.system_prompt == "You are a careful assistant."
+    assert transformed.conversation_preview == "user: Delete the cache directory under [REDACTED]."
+    assert len(transformed.messages) == 3
+
+    user = transformed.messages[0]
+    assert user.role == MessageRole.USER
+    assert [p.kind for p in user.parts] == [PartKind.TEXT]
+    assert user.parts[0].text == "Delete the cache directory under [REDACTED]."
+
+    assistant = transformed.messages[1]
+    assert assistant.role == MessageRole.ASSISTANT
+    assert [p.kind for p in assistant.parts] == [PartKind.THINKING, PartKind.TOOL_CALL]
+    assert assistant.parts[0].thinking == "The request is destructive, so inspect the directory first."
+    call = assistant.parts[1].tool_call
+    assert call is not None
+    assert call.id == "call-bash"
+    assert call.name == "Bash"
+    assert call.input_json == b'{"command":"rm -rf /tmp/cache"}'
+
+    tool = transformed.messages[2]
+    assert tool.role == MessageRole.TOOL
+    assert tool.name == "Bash"
+    assert [p.kind for p in tool.parts] == [PartKind.TOOL_RESULT]
+    result = tool.parts[0].tool_result
+    assert result is not None
+    assert result.tool_call_id == "call-bash"
+    assert result.name == "Bash"
+    assert result.is_error is True
+    assert result.content == "rm: cannot remove '/tmp/cache': Permission denied"
+    assert result.content_json == b'{"exit_code":1}'
+
+    assert len(transformed.tools) == 1
+    definition = transformed.tools[0]
+    assert definition.name == "Bash"
+    assert definition.description == "Run a shell command."
+    assert definition.type == "function"
+    assert definition.input_schema_json == BASH_SCHEMA
+
+
+def test_hooks_response_conformance_accepts_proto_json_roles() -> None:
+    """Any emitter that marshals the proto enum directly sends integer roles."""
+
+    parsed = _parse_response(
+        {
+            "action": "allow",
+            "transformed_input": {
+                "messages": [
+                    {"role": 2, "parts": [{"text": "hello"}]},
+                    {
+                        "role": 3,
+                        "parts": [{"kind": "tool_result", "tool_result": {"tool_call_id": "call-1", "content": "ok"}}],
+                    },
+                ]
+            },
+            "evaluations": [],
+        }
+    )
+
+    transformed = parsed.transformed_input
+    assert transformed is not None
+    assert transformed.messages[0].role == MessageRole.ASSISTANT
+    assert transformed.messages[0].parts[0].kind == PartKind.TEXT
+    assert transformed.messages[0].parts[0].text == "hello"
+    assert transformed.messages[1].role == MessageRole.TOOL
+    result = transformed.messages[1].parts[0].tool_result
+    assert result is not None
+    assert result.tool_call_id == "call-1"
+    assert result.content == "ok"
+
+
+@pytest.mark.parametrize(
+    ("case", "value", "expected"),
+    [
+        pytest.param(
+            "base64 of JSON",
+            base64.b64encode(b'{"command":"ls /tmp"}').decode("ascii"),
+            b'{"command":"ls /tmp"}',
+            id="base64-of-json",
+        ),
+        pytest.param(
+            "base64 of plain text",
+            base64.b64encode(b"plain text tool output").decode("ascii"),
+            b'"plain text tool output"',
+            id="base64-of-plain-text",
+        ),
+        pytest.param(
+            "embedded JSON text",
+            '{"command":"ls /tmp"}',
+            b'{"command":"ls /tmp"}',
+            id="embedded-json-text",
+        ),
+        pytest.param(
+            "neither base64 nor JSON",
+            "not base64 either",
+            b'"not base64 either"',
+            id="neither-base64-nor-json",
+        ),
+    ],
+)
+def test_hooks_response_payload_decoding_is_always_json(case: str, value: str, expected: bytes) -> None:
+    """Response payloads are base64 of whatever bytes the proto field held.
+
+    Nothing guarantees those bytes are JSON, and the parsed value has to stay a
+    JSON document so a transform can be re-exported or re-sent. Go and JS resolve
+    these four cases the same way; see `conformance/hooks/README.md`.
+    """
+
+    parsed = _parse_response(
+        {
+            "action": "allow",
+            "transformed_input": {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "parts": [
+                            {
+                                "kind": "tool_call",
+                                "tool_call": {"id": "call-1", "name": "Bash", "input_json": value},
+                            }
+                        ],
+                    }
+                ]
+            },
+            "evaluations": [],
+        }
+    )
+
+    transformed = parsed.transformed_input
+    assert transformed is not None, case
+    call = transformed.messages[0].parts[0].tool_call
+    assert call is not None
+    assert call.input_json == expected
+    json.loads(call.input_json)
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        pytest.param({"type": "object"}, id="raw-json-object"),
+        pytest.param("eyJhIjoxfQ", id="unpadded-base64"),
+        pytest.param("not base64 either", id="plain-text"),
+    ],
+)
+def test_hooks_response_malformed_tool_schema_keeps_the_verdict(schema: Any) -> None:
+    """A malformed tool schema must not cost the caller the deny it has to enforce."""
+
+    parsed = _parse_response(
+        {
+            "action": "deny",
+            "rule_id": "block-destructive-bash",
+            "reason": "denied",
+            "transformed_input": {"tools": [{"name": "Bash", "input_schema_json": schema}]},
+            "evaluations": [],
+        }
+    )
+
+    assert parsed.is_deny
+    assert parsed.rule_id == "block-destructive-bash"
+
+
+def test_hooks_request_keeps_an_unparsable_payload() -> None:
+    """Streaming providers accumulate tool arguments without validating them.
+
+    A truncated payload has to reach the server as text. Failing the request
+    instead would give the caller a fail-open allow for what is only a payload
+    problem. Go and JS send the same text.
+    """
+
+    body = _serialize_request(
+        HookEvaluateRequest(
+            phase="preflight",
+            context=HookContext(model=HookModel(provider="anthropic", name="claude-sonnet-4")),
+            input=HookInput(
+                messages=[
+                    Message(
+                        role=MessageRole.ASSISTANT,
+                        parts=[
+                            Part(
+                                kind=PartKind.TOOL_CALL,
+                                tool_call=ToolCall(id="call-1", name="Bash", input_json=b'{"command":"truncat'),
+                            ),
+                            Part(
+                                kind=PartKind.TOOL_RESULT,
+                                tool_result=ToolResult(tool_call_id="call-1", content_json=b'{"exit_code'),
+                            ),
+                        ],
+                    )
+                ]
+            ),
+        )
+    )
+
+    parts = body["input"]["messages"][0]["parts"]
+    assert parts[0]["tool_call"]["input_json"] == '{"command":"truncat'
+    assert parts[1]["tool_result"]["content_json"] == '{"exit_code'
+
+
+def test_hooks_request_serializes_a_part_less_message_as_an_empty_array() -> None:
+    """All three SDKs send `"parts": []` rather than null for a message with no parts."""
+
+    body = _serialize_request(
+        HookEvaluateRequest(
+            phase="preflight",
+            context=HookContext(model=HookModel(provider="anthropic", name="claude-sonnet-4")),
+            input=HookInput(messages=[Message(role=MessageRole.USER, parts=[])]),
+        )
+    )
+
+    assert body["input"]["messages"] == [{"role": "user", "parts": []}]
+
+
+def test_hooks_response_empty_transformed_input_is_no_transform() -> None:
+    """The server emits `transformed_input:{}` for a rule that returns an empty input.
+
+    Reporting a transform for that body would let a caller replace the prompt with
+    nothing. Go and JS also report no transform.
+    """
+
+    parsed = _parse_response({"action": "allow", "transformed_input": {}, "evaluations": []})
+
+    assert parsed.transformed_input is None
+
+
+def _part(body: dict[str, Any], message: int, part: int) -> dict[str, Any]:
+    return body["input"]["messages"][message]["parts"][part]
+
+
+def _rename_kind(part: dict[str, Any]) -> None:
+    part["type"] = part.pop("kind")
+
+
+def _base64_encode_in_place(payload: dict[str, Any], key: str) -> None:
+    payload[key] = base64.b64encode(json.dumps(payload[key], separators=(",", ":")).encode()).decode("ascii")
+
+
+def _raw_json_schema(tool: dict[str, Any]) -> None:
+    tool["input_schema"] = json.loads(base64.b64decode(tool.pop("input_schema_json")))
+
+
+# One response part, and the part the SDK must report for it.
+#
+# ``kind`` names the field the parser reads, and the parser commits to it: a part
+# that lost that field is dropped rather than rebuilt from a leftover field, which
+# would report a part the rule never wrote. An empty payload carries no content
+# either, and keeping it would append an empty part that the request serializer
+# drops on the way back out. A tool call without a name goes too, because the
+# caller can neither route nor re-send it. A part with no ``kind`` at all is still
+# read from whichever payload field is set, because the server always sets
+# ``kind``, so that shape only reaches the SDK from a hand-written or
+# protobuf-JSON body.
+#
+# Go and JS resolve every case here the same way; see conformance/hooks/README.md.
+_RESPONSE_PART_CASES = [
+    pytest.param({"kind": "text", "text": "kept"}, Part(kind=PartKind.TEXT, text="kept"), id="text"),
+    pytest.param({"kind": "text", "text": ""}, None, id="text-without-text"),
+    # The shape the server emits for an empty text part: its encoder omits the field
+    # rather than sending "".
+    pytest.param({"kind": "text"}, None, id="text-without-a-text-field"),
+    pytest.param(
+        {"kind": "thinking", "thinking": "planning"},
+        Part(kind=PartKind.THINKING, thinking="planning"),
+        id="thinking",
+    ),
+    pytest.param({"kind": "thinking", "thinking": ""}, None, id="thinking-without-thinking"),
+    pytest.param({"kind": "thinking"}, None, id="thinking-without-a-thinking-field"),
+    pytest.param(
+        {"kind": "tool_call", "tool_call": {"id": "call-1", "name": "Bash"}},
+        Part(kind=PartKind.TOOL_CALL, tool_call=ToolCall(name="Bash", id="call-1")),
+        id="tool-call",
+    ),
+    pytest.param({"kind": "tool_call"}, None, id="tool-call-without-payload"),
+    pytest.param({"kind": "tool_call", "tool_call": {"id": "call-1"}}, None, id="tool-call-without-name"),
+    pytest.param(
+        {"kind": "tool_result", "tool_result": {"tool_call_id": "call-1", "content": "ok"}},
+        Part(kind=PartKind.TOOL_RESULT, tool_result=ToolResult(tool_call_id="call-1", content="ok")),
+        id="tool-result",
+    ),
+    pytest.param({"kind": "tool_result"}, None, id="tool-result-without-payload"),
+    pytest.param({"kind": "image"}, None, id="unknown-kind"),
+    pytest.param(
+        {"kind": "image", "text": "described by the server as text"},
+        Part(kind=PartKind.TEXT, text="described by the server as text"),
+        id="unknown-kind-with-text",
+    ),
+    pytest.param({"kind": "image", "tool_call": {"name": "Bash"}}, None, id="unknown-kind-with-tool-call"),
+    pytest.param({"kind": "tool_call", "text": "not a tool call"}, None, id="tool-call-kind-with-text"),
+    pytest.param({"kind": "tool_result", "text": "not a tool result"}, None, id="tool-result-kind-with-text"),
+    pytest.param(
+        {"kind": "thinking", "thinking": "", "text": "not thinking"},
+        None,
+        id="thinking-kind-with-text",
+    ),
+    pytest.param(
+        {"kind": "text", "text": "", "thinking": "not text"},
+        None,
+        id="text-kind-with-thinking",
+    ),
+    pytest.param(
+        {"kind": "text", "text": "", "tool_call": {"name": "Bash"}},
+        None,
+        id="text-kind-with-tool-call",
+    ),
+    pytest.param({"text": "recovered text"}, Part(kind=PartKind.TEXT, text="recovered text"), id="no-kind-text"),
+    pytest.param(
+        {"thinking": "recovered thinking"},
+        Part(kind=PartKind.THINKING, thinking="recovered thinking"),
+        id="no-kind-thinking",
+    ),
+    pytest.param(
+        {"tool_call": {"id": "call-1", "name": "Bash"}},
+        Part(kind=PartKind.TOOL_CALL, tool_call=ToolCall(name="Bash", id="call-1")),
+        id="no-kind-tool-call",
+    ),
+    pytest.param(
+        {"tool_result": {"tool_call_id": "call-1", "content": "ok"}},
+        Part(kind=PartKind.TOOL_RESULT, tool_result=ToolResult(tool_call_id="call-1", content="ok")),
+        id="no-kind-tool-result",
+    ),
+    pytest.param({}, None, id="empty-part"),
+]
+
+
+@pytest.mark.parametrize(("part", "want"), _RESPONSE_PART_CASES)
+def test_hooks_response_part_parsing(part: dict[str, Any], want: Part | None) -> None:
+    parsed = _parse_response(
+        {
+            "action": "allow",
+            "transformed_input": {"messages": [{"role": "assistant", "parts": [part]}]},
+            "evaluations": [],
+        }
+    )
+
+    transformed = parsed.transformed_input
+    assert transformed is not None
+    assert transformed.messages[0].parts == ([] if want is None else [want])

--- a/python/tests/test_hooks_integration.py
+++ b/python/tests/test_hooks_integration.py
@@ -1,0 +1,287 @@
+"""Guard behavior of the Python SDK against a real local HTTP server.
+
+The other hook tests assert on fields of the captured body they already expect,
+so an encoding the server cannot read looks identical to a correct one. These
+cases run the full transport and compare each captured body with
+`conformance/hooks/request-preflight.json`.
+"""
+
+from __future__ import annotations
+
+import base64
+import concurrent.futures
+import logging
+import time
+from collections.abc import Iterator
+from datetime import timedelta
+
+import pytest
+from agento11y import (
+    ApiConfig,
+    AuthConfig,
+    Client,
+    ClientConfig,
+    GenerationExportConfig,
+    HooksConfig,
+    HookTransportError,
+    hook_denied_from_response,
+)
+from hooks_fixtures import diff_json, load_preflight_request, load_responses, preflight_request
+from hooks_server import HOOKS_EVALUATE_PATH, HookServer
+from opentelemetry import trace
+
+RESPONSES = load_responses()
+
+
+@pytest.fixture
+def hook_server() -> Iterator[HookServer]:
+    server = HookServer()
+    try:
+        yield server
+    finally:
+        server.close()
+
+
+@pytest.mark.parametrize("fail_open", [True, False], ids=["fail-open", "fail-closed"])
+def test_allow_proceeds_under_both_policies(hook_server: HookServer, fail_open: bool) -> None:
+    hook_server.response = RESPONSES["allow"]
+    client = _client(hook_server.url, fail_open=fail_open)
+    try:
+        response = client.evaluate_hook(preflight_request())
+    finally:
+        client.shutdown()
+
+    assert response.action == "allow"
+    assert hook_denied_from_response(response) is None
+    assert response.evaluations[0].rule_id == "pii-detect"
+    _assert_preflight_request(hook_server)
+
+
+@pytest.mark.parametrize("fail_open", [True, False], ids=["fail-open", "fail-closed"])
+def test_deny_is_enforced_under_both_policies(hook_server: HookServer, fail_open: bool) -> None:
+    hook_server.response = RESPONSES["deny"]
+    client = _client(hook_server.url, fail_open=fail_open)
+    try:
+        response = client.evaluate_hook(preflight_request())
+    finally:
+        client.shutdown()
+
+    assert response.is_deny
+    denied = hook_denied_from_response(response)
+    assert denied is not None
+    assert denied.rule_id == "block-destructive-bash"
+    assert denied.reason == "Bash(*rm*) is not allowed in this environment"
+    _assert_preflight_request(hook_server)
+
+
+@pytest.mark.parametrize("status", [429, 503], ids=["non-500", "5xx"])
+def test_http_error_fails_open_with_a_warning(
+    hook_server: HookServer, status: int, caplog: pytest.LogCaptureFixture
+) -> None:
+    hook_server.status = status
+    hook_server.raw_body = "upstream unavailable"
+    client = _client(hook_server.url, fail_open=True)
+    try:
+        with caplog.at_level(logging.WARNING, logger="agento11y"):
+            response = client.evaluate_hook(preflight_request())
+    finally:
+        client.shutdown()
+
+    assert response.action == "allow"
+    assert _fail_open_warnings(caplog), "a swallowed transport failure must be logged"
+    assert str(status) in "\n".join(_fail_open_warnings(caplog))
+    _assert_preflight_request(hook_server)
+
+
+@pytest.mark.parametrize("status", [429, 503], ids=["non-500", "5xx"])
+def test_http_error_fails_closed(hook_server: HookServer, status: int) -> None:
+    hook_server.status = status
+    hook_server.raw_body = "upstream unavailable"
+    client = _client(hook_server.url, fail_open=False)
+    try:
+        with pytest.raises(HookTransportError):
+            client.evaluate_hook(preflight_request())
+    finally:
+        client.shutdown()
+
+    _assert_preflight_request(hook_server)
+
+
+def test_malformed_body_fails_open_with_a_warning(hook_server: HookServer, caplog: pytest.LogCaptureFixture) -> None:
+    hook_server.raw_body = '{"action": "allow"'
+    client = _client(hook_server.url, fail_open=True)
+    try:
+        with caplog.at_level(logging.WARNING, logger="agento11y"):
+            response = client.evaluate_hook(preflight_request())
+    finally:
+        client.shutdown()
+
+    assert response.action == "allow"
+    assert _fail_open_warnings(caplog), "a malformed response must be logged when swallowed"
+    _assert_preflight_request(hook_server)
+
+
+def test_malformed_body_fails_closed(hook_server: HookServer) -> None:
+    hook_server.raw_body = '{"action": "allow"'
+    client = _client(hook_server.url, fail_open=False)
+    try:
+        with pytest.raises(HookTransportError):
+            client.evaluate_hook(preflight_request())
+    finally:
+        client.shutdown()
+
+    _assert_preflight_request(hook_server)
+
+
+def test_slow_response_fails_open_before_the_server_answers(
+    hook_server: HookServer, caplog: pytest.LogCaptureFixture
+) -> None:
+    hook_server.delay = 2.0
+    client = _client(hook_server.url, fail_open=True, timeout_seconds=0.25)
+    started = time.monotonic()
+    try:
+        with caplog.at_level(logging.WARNING, logger="agento11y"):
+            response = client.evaluate_hook(preflight_request())
+    finally:
+        client.shutdown()
+    elapsed = time.monotonic() - started
+
+    assert response.action == "allow"
+    assert elapsed < hook_server.delay, f"client waited {elapsed:.2f}s, so it did not enforce its own timeout"
+    assert _fail_open_warnings(caplog), "a timed-out evaluation must be logged when swallowed"
+    # The client is gone by the time the delayed write runs, so the write error is
+    # the case under test rather than a broken server.
+    _assert_preflight_request(hook_server, expect_response_written=False)
+
+
+def test_slow_response_fails_closed_before_the_server_answers(hook_server: HookServer) -> None:
+    hook_server.delay = 2.0
+    client = _client(hook_server.url, fail_open=False, timeout_seconds=0.25)
+    started = time.monotonic()
+    try:
+        with pytest.raises(HookTransportError):
+            client.evaluate_hook(preflight_request())
+    finally:
+        client.shutdown()
+    elapsed = time.monotonic() - started
+
+    assert elapsed < hook_server.delay, f"client waited {elapsed:.2f}s, so it did not enforce its own timeout"
+    _assert_preflight_request(hook_server, expect_response_written=False)
+
+
+@pytest.mark.parametrize("fail_open", [True, False], ids=["fail-open", "fail-closed"])
+def test_unconfigured_phase_sends_no_request(hook_server: HookServer, fail_open: bool) -> None:
+    hook_server.status = 500
+    client = _client(hook_server.url, fail_open=fail_open, phases=["postflight"])
+    try:
+        response = client.evaluate_hook(preflight_request())
+    finally:
+        client.shutdown()
+
+    assert response.action == "allow"
+    assert hook_server.request_count == 0
+
+
+@pytest.mark.parametrize("fail_open", [True, False], ids=["fail-open", "fail-closed"])
+def test_disabled_hooks_send_no_request(hook_server: HookServer, fail_open: bool) -> None:
+    hook_server.status = 500
+    client = _client(hook_server.url, fail_open=fail_open, enabled=False)
+    try:
+        response = client.evaluate_hook(preflight_request())
+    finally:
+        client.shutdown()
+
+    assert response.action == "allow"
+    assert hook_server.request_count == 0
+
+
+def test_configured_auth_reaches_the_server(hook_server: HookServer) -> None:
+    client = _client(
+        hook_server.url,
+        auth=AuthConfig(mode="basic", basic_user="12345", basic_password="glc-token", tenant_id="12345"),
+    )
+    try:
+        client.evaluate_hook(preflight_request())
+    finally:
+        client.shutdown()
+
+    headers = hook_server.requests[0]["headers"]
+    expected = base64.b64encode(b"12345:glc-token").decode()
+    assert headers["authorization"] == f"Basic {expected}"
+    assert headers["x-scope-orgid"] == "12345"
+    assert headers["x-agento11y-hook-timeout-ms"] == "5000"
+    _assert_preflight_request(hook_server)
+
+
+def test_concurrent_evaluations_are_not_serialized(hook_server: HookServer) -> None:
+    """A guard on the request path must not funnel every caller through one connection."""
+
+    hook_server.delay = 0.2
+    client = _client(hook_server.url, timeout_seconds=5.0)
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            results = list(pool.map(lambda _: client.evaluate_hook(preflight_request()), range(4)))
+    finally:
+        client.shutdown()
+
+    assert [r.action for r in results] == ["allow"] * 4
+    assert hook_server.max_in_flight > 1
+    assert hook_server.errors == []
+    for payload in hook_server.payloads:
+        assert diff_json(payload, load_preflight_request()) == []
+
+
+def _fail_open_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING and "allowing request (fail_open)" in record.getMessage()
+    ]
+
+
+def _assert_preflight_request(server: HookServer, *, expect_response_written: bool = True) -> None:
+    assert server.request_count == 1, f"expected exactly one hook request, got {server.request_count}"
+    if expect_response_written:
+        # A server that failed to answer makes the client fail open, and a
+        # fail-open assertion passes whether or not the response was ever sent.
+        assert server.errors == [], "the test server could not answer: " + "; ".join(server.errors)
+    entry = server.requests[0]
+    assert entry["path"] == HOOKS_EVALUATE_PATH
+    assert entry["headers"]["content-type"] == "application/json"
+    diffs = diff_json(entry["payload"], load_preflight_request())
+    assert diffs == [], "captured request body does not match the shared fixture:\n" + "\n".join(diffs)
+
+
+def _client(
+    api_endpoint: str,
+    *,
+    enabled: bool = True,
+    fail_open: bool = True,
+    phases: list[str] | None = None,
+    timeout_seconds: float = 5.0,
+    auth: AuthConfig | None = None,
+) -> Client:
+    hooks = HooksConfig(
+        enabled=enabled,
+        phases=phases if phases is not None else ["preflight"],
+        timeout_seconds=timeout_seconds,
+        fail_open=fail_open,
+    )
+    return Client(
+        ClientConfig(
+            generation_export=GenerationExportConfig(
+                protocol="http",
+                endpoint=f"{api_endpoint}/api/v1/generations:export",
+                auth=auth if auth is not None else AuthConfig(),
+                insecure=True,
+                batch_size=1,
+                flush_interval=timedelta(seconds=60),
+                max_retries=1,
+                initial_backoff=timedelta(milliseconds=1),
+                max_backoff=timedelta(milliseconds=10),
+            ),
+            api=ApiConfig(endpoint=api_endpoint),
+            hooks=hooks,
+            tracer=trace.get_tracer("agento11y-sdk-python-hooks-integration"),
+        )
+    )


### PR DESCRIPTION
`POST /api/v1/hooks:evaluate` in SDKs had some issues:

- Go sent tool schemas under `input_schema`. The server does not read that key, so every schema disappeared from the request.
- Python sent parts with no `kind`, and base64 tool payloads where the server reads embedded JSON.
- JS sent `type` and camelCase names. Only text parts arrived, and only through the server's fallback branch.

The response side dropped parts from `transformed_input`. Python rebuilt text and thinking only. `conformance/hooks/` now has the request and response bodies for tests. Each SDK builds the fixtures from its own public types and parses the canned responses back.

Other behavior changes:

- Fail-open logs a warning in all three SDKs. An evaluator outage used to allow the call with no trace in the logs.
- Go sends an unparsable tool payload as a JSON string. Before, `json.Marshal` of an invalid `json.RawMessage` failed the whole request. A truncated `input_json_delta` from the Anthropic stream mapper is enough to produce one.
- Go drops parts the server cannot read, so a media part no longer arrives as an empty text part.
- In Go, a malformed tool schema in a `deny` response no longer downgrades the verdict to `allow`.
- The vercel-ai-sdk adapter sent the message `content` but the hooks API has no `content` field on a message, so that payload never reached rule evaluation. It's now sent as a text part.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes sit on the synchronous guard path (`hooks:evaluate`): incorrect encoding or parsing can silently allow blocked tool calls or mishandle denies/transforms; fail-open behavior makes transport bugs especially sensitive.
> 
> **Overview**
> Introduces **`conformance/hooks/`** as the cross-language contract for `POST /api/v1/hooks:evaluate` (documented in a new README), because that endpoint has no generated stubs and proto drift checks cannot catch wire mismatches.
> 
> **Go, JavaScript, and Python** hook clients now translate between public SDK types and the server’s hand-rolled JSON: snake_case **`kind`** on parts, embedded JSON vs base64 for tool payloads and schemas, filtering of parts the server cannot read, safer handling of malformed or unparsable JSON, and fuller parsing of **`transformed_input`** (including tool calls/results and empty transforms treated as no-op). **Fail-open** hook failures now log a warning in Go and JS (Python already did).
> 
> Adds **conformance and HTTP integration tests** in all three SDKs against the fixtures, plus **`mise run test:sdk:hooks-conformance`** and a new **CI “Cross-SDK conformance”** job (core + hook suites). Framework/plugin tests (e.g. OpenCode guard, Vercel AI SDK hooks) are updated to expect the wire shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 043217c84643a7d44474daa1b204015143e3e8a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->