### PR TITLE
fix(plugins/claude-code): declare hook timeouts in seconds

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -16,7 +16,7 @@
           {
             "type": "command",
             "command": "agento11y claude-code hook || sigil claude-code hook",
-            "timeout": 2000
+            "timeout": 5
           }
         ]
       }
@@ -28,7 +28,7 @@
           {
             "type": "command",
             "command": "agento11y claude-code hook || sigil claude-code hook",
-            "timeout": 2000
+            "timeout": 10
           }
         ]
       }
@@ -40,7 +40,7 @@
           {
             "type": "command",
             "command": "agento11y claude-code hook || sigil claude-code hook",
-            "timeout": 10000
+            "timeout": 20
           }
         ]
       }
@@ -52,7 +52,7 @@
           {
             "type": "command",
             "command": "agento11y claude-code hook || sigil claude-code hook",
-            "timeout": 10000
+            "timeout": 20
           }
         ]
       }


### PR DESCRIPTION
Docs: https://code.claude.com/docs/en/hooks#common-fields

- `timeout`: `Seconds before canceling. ...`

Fixes #492