### PR TITLE
feat(plugins/pi): export compaction and branch-summary generations

### DIFF
--- a/docs/concepts/tags-and-metadata.md
+++ b/docs/concepts/tags-and-metadata.md
@@ -108,8 +108,24 @@ The coding-agent plugins (claude-code, codex, copilot, cursor, opencode, pi, vib
 | `cwd` | Working directory of the session. For pi, the directory pi was launched from, which can be a subdirectory of the repo. | all launchers |
 | `git.branch` | Branch checked out in that directory, or a short commit SHA when HEAD is detached. Omitted outside a git checkout. | all launchers |
 | `subagent` | `"true"` on generations from a subagent run. Absent otherwise, never `"false"`. | claude-code, codex, cursor, opencode |
+| `pi.call_kind` | The host made this model call outside a user turn: `compaction` for context compaction, `branch_summary` for a tree-navigation summary. Absent on ordinary turns. | pi |
 
 Launchers also set a few keys specific to one host, so this table is not the full list of what arrives on a generation.
+
+## Built-in metadata from the agent launchers
+
+Metadata is exported but never turned into a metric label, so launchers use it for numbers and for keys with too many distinct values to be a tag.
+
+Codex and copilot also add their own `codex.*` and `copilot.*` keys, so this table is not the full list. A launcher's own docs are the place to look for them.
+
+| Key | Value | Emitted by |
+| --- | --- | --- |
+| `cost_usd` | Cost the host itself reported for the call, in US dollars. Present whenever pi priced the call, including a cost of `0`. | pi |
+| `vibe.cost_usd` | Cost vibe reported for the turn, in US dollars. Omitted when the cost is `0`. | vibe |
+| `cost` | Cost opencode reported for the turn, in US dollars. | opencode |
+| `pi.tokens_before` | Pi's estimate of the context size before a compaction, in tokens. Compaction generations only. The estimate covers the whole conversation, not this call's input tokens. | pi |
+| `pi.compaction.reason` | What triggered the compaction: `manual` (`/compact` or `ctx.compact()`), `threshold` (context limit), or `overflow` (context-overflow recovery). | pi |
+| `pi.compaction.will_retry` | `true` when pi retries the turn it aborted to run this compaction. Only overflow recovery retries. | pi |
 
 ## See also
 

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -107,7 +107,25 @@ The plugin always attaches two built-in tags to every generation:
 - `git.branch` — current branch from the working directory, or a 12-char short SHA on detached HEAD. Omitted when not inside a git checkout.
 - `cwd` — the process working directory.
 
-Built-in tags win collisions with user tags, matching the claude-code and cursor launchers.
+One more tag appears on generations pi produces outside a user turn:
+
+- `pi.call_kind` — `compaction` or `branch_summary`. Absent on ordinary turns. See [Compaction and summarization](#compaction-and-summarization).
+
+Built-in tags win collisions with user tags, matching the claude-code and cursor launchers. See [Tags and Metadata](../../docs/concepts/tags-and-metadata.md#built-in-tags-from-the-agent-launchers) for the tags the launchers share and the metadata keys pi adds.
+
+## Compaction and summarization
+
+Pi makes model calls of its own outside the agent loop. It compacts the context when the conversation approaches the model's window, when you run `/compact`, and while recovering from a context overflow. It summarizes the abandoned branch when you navigate the session tree with summarization on. A compaction on a large-window model can be a six-figure-token request at full price, because pi sends it with cache retention off.
+
+The plugin exports each of those calls as its own generation so they show up in the session's token and cost totals:
+
+- The tag `pi.call_kind` is `compaction` or `branch_summary`. That is the marker to filter on.
+- `operation_name` is `generateText` rather than the `streamText` a turn gets, because there is no token stream to time.
+- The parent generation is the nearest assistant turn above the entry in pi's session tree. For a compaction that is the turn it followed. For a branch summary it is the turn above the navigation target, which can sit earlier in the session than the branch that was summarized.
+- Metadata carries `cost_usd` whenever pi priced the call, on the same rule as a turn. Compactions add `pi.tokens_before`, `pi.compaction.reason`, and `pi.compaction.will_retry`. Branch summaries carry none of those three, because pi records no pre-summary context estimate and no trigger reason for them.
+- The summary text is exported as assistant output, so `AGENTO11Y_CONTENT_CAPTURE_MODE=metadata_only` drops it while keeping tokens, cost, and timing. The request side is not exported: these generations carry no input messages and no system prompt, so input tokens are reported without the text they came from.
+
+Two cases export nothing, because no model call happened: an extension supplied the compaction, or you navigated the tree without asking for a summary. Older pi versions record no usage on the entry; those still export a generation, with timing and metadata but no token counts.
 
 ## Redaction
 

--- a/plugins/pi/biome.json
+++ b/plugins/pi/biome.json
@@ -7,7 +7,7 @@
     "root": "../.."
   },
   "files": {
-    "includes": ["**", "!!**/dist", "!!vendor"]
+    "includes": ["**", "!!**/dist", "!!vendor", "!**/testdata/golden"]
   },
   "formatter": {
     "enabled": true,

--- a/plugins/pi/src/golden.test.ts
+++ b/plugins/pi/src/golden.test.ts
@@ -31,6 +31,15 @@ const GOLDEN_PATH = join(
   "golden",
   "pi-full-turn.golden.json",
 );
+// Host summarization (compaction) exports through a separate, synchronous
+// path, so it gets its own driver and fixture rather than extending the
+// full-turn one.
+const COMPACTION_GOLDEN_PATH = join(
+  __dirname,
+  "testdata",
+  "golden",
+  "pi-compaction.golden.json",
+);
 
 interface CapturedExport {
   path: string;
@@ -293,6 +302,114 @@ describe("pi plugin: real-SDK golden export", () => {
 
     return { exports, turn };
   }
+
+  // piCompactionFixture returns the persisted compaction entry pi writes after
+  // a threshold auto-compaction, including the usage of the summarization call.
+  function piCompactionFixture() {
+    return {
+      type: "compaction" as const,
+      id: "c1",
+      parentId: "a1",
+      timestamp: "2025-01-01T00:00:05.000Z",
+      summary: "The user asked about go files; main.go and util.go were found.",
+      firstKeptEntryId: "u1",
+      tokensBefore: 152_000,
+      usage: {
+        input: 120_000,
+        output: 8_000,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 128_000,
+        cost: {
+          input: 0.36,
+          output: 0.12,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0.48,
+        },
+      },
+    };
+  }
+
+  // runCompaction drives a threshold auto-compaction end to end. It is a
+  // separate driver on purpose: runFullTurn is shared by several assertions
+  // and its fixture would have to be regenerated if compaction were folded
+  // into it.
+  async function runCompaction(): Promise<{
+    exports: { path: string; generations: unknown[] }[];
+    compaction: any;
+  }> {
+    const pi = new FakePi();
+    registerExtension(pi as any);
+
+    const { userMsg, assistantMsg } = piTurnFixture();
+    const compactionEntry = piCompactionFixture();
+
+    // Branch: user u1 -> assistant a1 -> compaction c1. The compaction is the
+    // leaf, which is where pi appends it, and a1 becomes its lineage parent.
+    const ctx = {
+      sessionManager: {
+        getSessionFile: () => "pi-session.jsonl",
+        getSessionId: () => "pi-conv-1",
+        getBranch: () => [
+          { type: "message", id: "u1", parentId: null, message: userMsg },
+          { type: "message", id: "a1", parentId: "u1", message: assistantMsg },
+          compactionEntry,
+        ],
+      },
+      model: { provider: "anthropic", id: "claude-sonnet-4-pi" },
+    };
+
+    await pi.emit("session_start", {}, ctx);
+    await pi.emit(
+      "session_before_compact",
+      { reason: "threshold", willRetry: false },
+      ctx,
+    );
+    await pi.emit(
+      "session_compact",
+      {
+        compactionEntry,
+        fromExtension: false,
+        reason: "threshold",
+        willRetry: false,
+      },
+      ctx,
+    );
+    await pi.emit("session_shutdown", {}, ctx);
+
+    expect(serverEnv.errors).toEqual([]);
+
+    const exports = serverEnv.captures.map((c) => ({
+      path: c.path,
+      generations: c.generations.map(normalizeAny),
+    }));
+    for (const exp of exports) {
+      expect(exp.path).toBe("/api/v1/generations:export");
+    }
+    const allGen = exports.flatMap((e) => e.generations) as any[];
+    expect(allGen).toHaveLength(1);
+
+    return { exports, compaction: allGen[0] };
+  }
+
+  it("matches the recorded golden export for a host compaction", async () => {
+    const { exports, compaction } = await runCompaction();
+
+    // generateText (not streamText) is what discriminates a host
+    // summarization call from a turn.
+    expect(compaction.operation_name).toBe("generateText");
+    expect(compaction.mode).toBe("GENERATION_MODE_SYNC");
+    expect(compaction.conversation_id).toBe("pi-conv-1");
+    expect(compaction.id).toMatch(/^pi-[a-f0-9]{24}$/);
+    expect(compaction.parent_generation_ids).toHaveLength(1);
+    expect(compaction.tags["pi.call_kind"]).toBe("compaction");
+    expect(String(compaction.usage.input_tokens)).toBe("120000");
+    expect(String(compaction.usage.output_tokens)).toBe("8000");
+    expect(compaction.output[0].parts[0].text).toContain("main.go");
+
+    assertGoldenJSON(COMPACTION_GOLDEN_PATH, exports);
+  });
 
   // The proto export uses a oneof for `parts`, so a part is identified by
   // which field is populated (`tool_call`, `tool_result`, `text`, ...), not

--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -38,6 +38,7 @@ vi.mock("./git.js", () => ({
 
 import type { Agento11yClient } from "@grafana/agento11y";
 import registerExtension, { emitToolSpans } from "./index.js";
+import { stablePiGenerationId } from "./lineage.js";
 import type {
   PiAssistantMessage,
   PiToolResult,
@@ -59,6 +60,16 @@ interface ToolRecorderLike {
 
 interface Agento11yLike {
   startStreamingGeneration: (
+    seed: unknown,
+    run: (recorder: RecorderLike) => Promise<void>,
+  ) => Promise<void>;
+  // Host summarization calls (compaction, branch summary) go through the
+  // synchronous path. Optional, because the fakes in turn-path tests leave it
+  // off. Any test that expects a summary export needs it: FakePi.emit
+  // swallows a missing handler and the plugin's handlers swallow throws into
+  // logger.error, so a fake without startGeneration makes a broken export
+  // look like a passing test.
+  startGeneration?: (
     seed: unknown,
     run: (recorder: RecorderLike) => Promise<void>,
   ) => Promise<void>;
@@ -110,19 +121,27 @@ class FakePi {
   }
 }
 
+// Pi's live model, as exposed on ctx.model. `id` (not `name`) is what
+// assistant messages carry as their model, so the summary export path reads
+// `id`.
+const defaultModel = { provider: "anthropic", id: "claude-sonnet-4" };
+
 const defaultCtx = {
   sessionManager: {
     getSessionFile: () => "session-1",
     getSessionId: () => "sess-default-id",
   },
+  model: defaultModel,
 };
 
 function makeCtx({
   sessionFile,
   sessionId,
+  model = defaultModel,
 }: {
   sessionFile?: string | (() => string | undefined);
   sessionId: string | (() => string);
+  model?: { provider: string; id: string };
 }) {
   const fileFn =
     typeof sessionFile === "function"
@@ -134,6 +153,44 @@ function makeCtx({
       getSessionFile: fileFn,
       getSessionId: idFn,
     },
+    model,
+  };
+}
+
+// A fake session entry as returned by ReadonlySessionManager.getBranch().
+// Loose on purpose: message entries carry `message`, compaction and
+// branch_summary entries carry summary/usage/timestamp instead.
+interface FakeBranchEntry {
+  type: string;
+  id: string;
+  parentId: string | null;
+  message?: unknown;
+  timestamp?: string;
+  summary?: string;
+  tokensBefore?: number;
+  usage?: unknown;
+  fromHook?: boolean;
+}
+
+// ctxWithBranch is a fake ReadonlySessionManager that returns a static
+// session branch. Turn tests track which assistant entry each turn_end
+// should hit by swapping a shared `currentMessage` reference between turns,
+// mirroring how the real pi runtime appends entries to the tree. Pass
+// `{ model: null }` to simulate a session with no resolvable model.
+function ctxWithBranch(
+  sessionId: string,
+  branch: FakeBranchEntry[] | (() => FakeBranchEntry[]),
+  opts?: { model?: { provider: string; id: string } | null },
+) {
+  const model = opts ? (opts.model ?? undefined) : defaultModel;
+  const branchFn = typeof branch === "function" ? branch : () => branch;
+  return {
+    sessionManager: {
+      getSessionFile: () => "pi-session.jsonl",
+      getSessionId: () => sessionId,
+      getBranch: branchFn,
+    },
+    model,
   };
 }
 
@@ -2568,28 +2625,6 @@ describe("extension lifecycle", () => {
       return { sigil, seeds };
     }
 
-    // ctxWithBranch is a fake ReadonlySessionManager that returns a static
-    // session branch. We track which assistant entry each turn_end should
-    // hit by swapping a shared `currentMessage` reference between turns,
-    // mirroring how the real pi runtime appends entries to the tree.
-    function ctxWithBranch(
-      sessionId: string,
-      branch: Array<{
-        type: string;
-        id: string;
-        parentId: string | null;
-        message?: { role: string } | null;
-      }>,
-    ) {
-      return {
-        sessionManager: {
-          getSessionFile: () => "pi-session.jsonl",
-          getSessionId: () => sessionId,
-          getBranch: () => branch,
-        },
-      };
-    }
-
     it("emits deterministic pi-* generation id when branch data is available", async () => {
       const { sigil, seeds } = setupClient();
       loadConfigMock.mockResolvedValue({
@@ -2798,6 +2833,1049 @@ describe("extension lifecycle", () => {
 
       expect(seeds[0]!.id).toBeUndefined();
       expect(seeds[0]!.parentGenerationIds).toBeUndefined();
+    });
+  });
+
+  // --- Host summarization calls (compaction, branch summary) ---
+  //
+  // These run outside pi's agent loop: no turn_*, message_*, or provider
+  // events fire, so the only signals are session_before_compact /
+  // session_compact and session_before_tree / session_tree.
+  describe("host summarization export", () => {
+    interface CapturedSeed {
+      id?: string;
+      conversationId?: string;
+      conversationTitle?: string;
+      agentName?: string;
+      agentVersion?: string;
+      operationName?: string;
+      model?: { provider: string; name: string };
+      startedAt?: Date;
+      tags?: Record<string, string>;
+      parentGenerationIds?: string[];
+    }
+    interface CapturedResult {
+      usage?: Record<string, number>;
+      metadata?: Record<string, unknown>;
+      output?: Array<{ role: string; parts: Array<Record<string, unknown>> }>;
+      completedAt?: Date;
+      stopReason?: string;
+      responseModel?: string;
+    }
+
+    function setupClient(opts?: { startGenerationError?: Error }) {
+      const seeds: CapturedSeed[] = [];
+      const results: CapturedResult[] = [];
+      const turnSeeds: Array<Record<string, unknown>> = [];
+      const turnResults: Array<Record<string, unknown>> = [];
+      const sigil: Agento11yLike = {
+        startStreamingGeneration: vi.fn(async (seed, run) => {
+          turnSeeds.push(seed as Record<string, unknown>);
+          await run({
+            setResult: (value: unknown) => {
+              turnResults.push(value as Record<string, unknown>);
+            },
+            setCallError: vi.fn(),
+            setFirstTokenAt: vi.fn(),
+          });
+        }),
+        startGeneration: vi.fn(async (seed, run) => {
+          if (opts?.startGenerationError) throw opts.startGenerationError;
+          seeds.push(seed as CapturedSeed);
+          await run({
+            setResult: (value: unknown) => {
+              results.push(value as CapturedResult);
+            },
+            setCallError: vi.fn(),
+          });
+        }),
+        startToolExecution: vi.fn(() => ({
+          setResult: vi.fn(),
+          setCallError: vi.fn(),
+          end: vi.fn(),
+          getError: vi.fn(),
+        })),
+        shutdown: vi.fn(async () => {}),
+      };
+      return { sigil, seeds, results, turnSeeds, turnResults };
+    }
+
+    function useConfig(
+      sigil: Agento11yLike,
+      contentCapture:
+        | "metadata_only"
+        | "full"
+        | "no_tool_content"
+        | "full_with_metadata_spans" = "full",
+    ) {
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        agentVersion: "0.82.1",
+        contentCapture,
+      });
+      createAgento11yClientMock.mockReturnValue(sigil);
+    }
+
+    const COMPACTION_TS = "2025-01-01T00:00:05.000Z";
+    const COMPACTION_AT = Date.parse(COMPACTION_TS);
+
+    function compactionEntry(
+      overrides?: Partial<FakeBranchEntry>,
+    ): FakeBranchEntry {
+      return {
+        type: "compaction",
+        id: "c1",
+        parentId: "a1",
+        timestamp: COMPACTION_TS,
+        summary: "Earlier: we split the exporter and fixed two tests.",
+        tokensBefore: 152000,
+        usage: {
+          input: 120000,
+          output: 8000,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 128000,
+          cost: { total: 2.5 },
+        },
+        ...overrides,
+      };
+    }
+
+    // u1 -> a1 -> <summary entry>: the shape pi produces when compaction runs
+    // right after an assistant turn.
+    function branchWith(...tail: FakeBranchEntry[]): FakeBranchEntry[] {
+      return [
+        {
+          type: "message",
+          id: "u1",
+          parentId: null,
+          message: { role: "user" },
+        },
+        {
+          type: "message",
+          id: "a1",
+          parentId: "u1",
+          message: { role: "assistant" },
+        },
+        ...tail,
+      ];
+    }
+
+    it("exports one generation for a threshold auto-compaction", async () => {
+      const { sigil, seeds, results } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry();
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("session_before_compact", { reason: "threshold" }, ctx);
+      await pi.emit(
+        "session_compact",
+        {
+          compactionEntry: entry,
+          fromExtension: false,
+          reason: "threshold",
+          willRetry: false,
+        },
+        ctx,
+      );
+
+      expect(sigil.startGeneration).toHaveBeenCalledTimes(1);
+      // Not the streaming path: there is no token stream to time.
+      expect(sigil.startStreamingGeneration).not.toHaveBeenCalled();
+      expect(seeds).toHaveLength(1);
+      expect(seeds[0]!.id).toMatch(/^pi-[a-f0-9]{24}$/);
+      expect(seeds[0]!.id).toBe(stablePiGenerationId("pi-conv-1", "c1"));
+      expect(seeds[0]!.tags?.["pi.call_kind"]).toBe("compaction");
+      expect(seeds[0]!.conversationId).toBe("pi-conv-1");
+      expect(seeds[0]!.agentName).toBe("pi");
+      expect(seeds[0]!.model).toEqual({
+        provider: "anthropic",
+        name: "claude-sonnet-4",
+      });
+      // No explicit operationName: the SYNC path defaults it to generateText.
+      expect(seeds[0]!.operationName).toBeUndefined();
+      // Parent is the assistant turn that preceded the compaction.
+      expect(seeds[0]!.parentGenerationIds).toEqual([
+        stablePiGenerationId("pi-conv-1", "a1"),
+      ]);
+      expect(results[0]!.usage).toEqual({
+        inputTokens: 120000,
+        outputTokens: 8000,
+        totalTokens: 128000,
+        cacheReadInputTokens: 0,
+        cacheWriteInputTokens: 0,
+      });
+      expect(results[0]!.stopReason).toBe("end_turn");
+      expect(results[0]!.completedAt).toEqual(new Date(COMPACTION_AT));
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    // willRetry is only true on overflow recovery, so the reason and the retry
+    // flag travel together.
+    it.each([
+      { reason: "manual", willRetry: false },
+      { reason: "threshold", willRetry: false },
+      { reason: "overflow", willRetry: true },
+    ])("exports metadata for a $reason compaction", async (event) => {
+      const { sigil, seeds, results } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry();
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("session_before_compact", { reason: event.reason }, ctx);
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: entry, fromExtension: false, ...event },
+        ctx,
+      );
+
+      expect(sigil.startGeneration).toHaveBeenCalledTimes(1);
+      expect(seeds[0]!.tags?.["pi.call_kind"]).toBe("compaction");
+      expect(seeds[0]!.operationName).toBeUndefined();
+      expect(results[0]!.metadata).toEqual({
+        cost_usd: 2.5,
+        "pi.tokens_before": 152000,
+        "pi.compaction.reason": event.reason,
+        "pi.compaction.will_retry": event.willRetry,
+      });
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("records a zero cost, matching the turn path", async () => {
+      const { sigil, results } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry({
+        usage: {
+          input: 10,
+          output: 2,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 12,
+          cost: { total: 0 },
+        },
+      });
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: entry, fromExtension: false },
+        ctx,
+      );
+
+      expect(results[0]!.metadata?.cost_usd).toBe(0);
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("skips extension-supplied compaction (fromExtension)", async () => {
+      const { sigil } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry({ fromHook: true });
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("session_before_compact", {}, ctx);
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: entry, fromExtension: true },
+        ctx,
+      );
+
+      expect(sigil.startGeneration).not.toHaveBeenCalled();
+      expect(
+        loggerMock.debug.mock.calls.map(([m]) => String(m)),
+      ).toContainEqual(expect.stringContaining("supplied by an extension"));
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("skips a compaction entry marked fromHook even when fromExtension is false", async () => {
+      const { sigil } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry({ fromHook: true });
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: entry, fromExtension: false },
+        ctx,
+      );
+
+      expect(sigil.startGeneration).not.toHaveBeenCalled();
+      expect(
+        loggerMock.debug.mock.calls.map(([m]) => String(m)),
+      ).toContainEqual(expect.stringContaining("came from an extension"));
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("exports nothing for plain tree navigation without a summary", async () => {
+      const { sigil } = setupClient();
+      useConfig(sigil);
+      const ctx = ctxWithBranch("pi-conv-1", branchWith());
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("session_before_tree", {}, ctx);
+      await pi.emit(
+        "session_tree",
+        { newLeafId: "a1", oldLeafId: "a1", summaryEntry: undefined },
+        ctx,
+      );
+
+      expect(sigil.startGeneration).not.toHaveBeenCalled();
+      expect(loggerMock.error).not.toHaveBeenCalled();
+      // Plain navigation is the common case and stays out of the log.
+      expect(
+        loggerMock.debug.mock.calls.map(([m]) => String(m)),
+      ).not.toContainEqual(expect.stringContaining("branch_summary"));
+    });
+
+    it("exports a branch_summary generation for a summarizing tree navigation", async () => {
+      const { sigil, seeds, results } = setupClient();
+      useConfig(sigil);
+      const entry: FakeBranchEntry = {
+        type: "branch_summary",
+        id: "b1",
+        parentId: "a1",
+        timestamp: COMPACTION_TS,
+        summary: "The abandoned branch explored a caching layer.",
+        usage: {
+          input: 40000,
+          output: 900,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 40900,
+          cost: { total: 0.4 },
+        },
+      };
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("session_before_tree", {}, ctx);
+      await pi.emit(
+        "session_tree",
+        { newLeafId: "b1", oldLeafId: "a1", summaryEntry: entry },
+        ctx,
+      );
+
+      expect(seeds).toHaveLength(1);
+      expect(seeds[0]!.operationName).toBeUndefined();
+      expect(seeds[0]!.tags?.["pi.call_kind"]).toBe("branch_summary");
+      expect(seeds[0]!.id).toBe(stablePiGenerationId("pi-conv-1", "b1"));
+      expect(seeds[0]!.parentGenerationIds).toEqual([
+        stablePiGenerationId("pi-conv-1", "a1"),
+      ]);
+      // tokensBefore only exists on compaction entries.
+      expect(results[0]!.metadata).toEqual({ cost_usd: 0.4 });
+      expect(results[0]!.output?.[0]?.parts[0]).toEqual({
+        type: "text",
+        text: "The abandoned branch explored a caching layer.",
+      });
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("exports the entry session_tree carried, not the newest one on the branch", async () => {
+      // session_tree resolves its entry with getEntry(summaryId), an exact id
+      // lookup, so the event's entry is authoritative. The positional branch
+      // scan exists only to correct session_compact's find-by-summary-text.
+      const { sigil, seeds } = setupClient();
+      useConfig(sigil);
+      const eventEntry: FakeBranchEntry = {
+        type: "branch_summary",
+        id: "b1",
+        parentId: "a1",
+        timestamp: COMPACTION_TS,
+        summary: "Explored a caching layer.",
+      };
+      const laterEntry: FakeBranchEntry = {
+        ...eventEntry,
+        id: "b9",
+        parentId: "b1",
+      };
+      const ctx = ctxWithBranch(
+        "pi-conv-1",
+        branchWith(eventEntry, laterEntry),
+      );
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit(
+        "session_tree",
+        { newLeafId: "b9", oldLeafId: "a1", summaryEntry: eventEntry },
+        ctx,
+      );
+
+      expect(seeds).toHaveLength(1);
+      expect(seeds[0]!.id).toBe(stablePiGenerationId("pi-conv-1", "b1"));
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("does not re-export the same summary entry twice", async () => {
+      const { sigil } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry();
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      const event = { compactionEntry: entry, fromExtension: false };
+      await pi.emit("session_compact", event, ctx);
+      await pi.emit("session_compact", event, ctx);
+
+      expect(sigil.startGeneration).toHaveBeenCalledTimes(1);
+      expect(
+        loggerMock.debug.mock.calls.map(([m]) => String(m)),
+      ).toContainEqual(expect.stringContaining("already exported"));
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("resolves the newest branch entry when the event hands back an older duplicate", async () => {
+      // session_compact finds its entry by summary text, first match in the
+      // whole session file, so two byte-identical summaries make it carry the
+      // older entry. Resolving positionally from the branch avoids re-sending
+      // an already-exported generation id.
+      const { sigil, seeds } = setupClient();
+      useConfig(sigil);
+      const first = compactionEntry({ id: "c1", parentId: "a1" });
+      const second = compactionEntry({ id: "c2", parentId: "a2" });
+      let branch = branchWith(first);
+      const ctx = ctxWithBranch("pi-conv-1", () => branch);
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: first, fromExtension: false },
+        ctx,
+      );
+
+      branch = [
+        ...branch,
+        {
+          type: "message",
+          id: "u2",
+          parentId: "c1",
+          message: { role: "user" },
+        },
+        {
+          type: "message",
+          id: "a2",
+          parentId: "u2",
+          message: { role: "assistant" },
+        },
+        second,
+      ];
+      // Pi hands us `first` again because the summaries are identical.
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: first, fromExtension: false },
+        ctx,
+      );
+
+      expect(seeds.map((s) => s.id)).toEqual([
+        stablePiGenerationId("pi-conv-1", "c1"),
+        stablePiGenerationId("pi-conv-1", "c2"),
+      ]);
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("is a silent no-op before session_start and after session_shutdown", async () => {
+      const { sigil } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry();
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+      const event = { compactionEntry: entry, fromExtension: false };
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+
+      await pi.emit("session_compact", event, ctx);
+      expect(sigil.startGeneration).not.toHaveBeenCalled();
+
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("session_shutdown", {}, ctx);
+      await pi.emit("session_compact", event, ctx);
+
+      expect(sigil.startGeneration).not.toHaveBeenCalled();
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("prefers ctx.model over the model cached from the last assistant message", async () => {
+      const { sigil, seeds } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry();
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit(
+        "message_end",
+        {
+          message: {
+            ...assistantMessage(),
+            provider: "openai",
+            model: "gpt-5",
+          },
+        },
+        ctx,
+      );
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: entry, fromExtension: false },
+        ctx,
+      );
+
+      expect(seeds[0]!.model).toEqual({
+        provider: "anthropic",
+        name: "claude-sonnet-4",
+      });
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the last seen model when ctx.model is unavailable", async () => {
+      const { sigil, seeds, results } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry();
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry), {
+        model: null,
+      });
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit(
+        "message_end",
+        {
+          message: {
+            ...assistantMessage(),
+            provider: "openai",
+            model: "gpt-5",
+          },
+        },
+        ctx,
+      );
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: entry, fromExtension: false },
+        ctx,
+      );
+
+      expect(seeds[0]!.model).toEqual({ provider: "openai", name: "gpt-5" });
+      expect(results[0]!.responseModel).toBe("gpt-5");
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("skips the export when no model can be resolved", async () => {
+      const { sigil } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry();
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry), {
+        model: null,
+      });
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: entry, fromExtension: false },
+        ctx,
+      );
+
+      expect(sigil.startGeneration).not.toHaveBeenCalled();
+      expect(
+        loggerMock.debug.mock.calls.map(([m]) => String(m)),
+      ).toContainEqual(expect.stringContaining("no model could be resolved"));
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("drops the summary text in metadata_only but keeps usage, tags and metadata", async () => {
+      const { sigil, seeds, results } = setupClient();
+      useConfig(sigil, "metadata_only");
+      const entry = compactionEntry();
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: entry, fromExtension: false },
+        ctx,
+      );
+
+      expect(results[0]!.output).toBeUndefined();
+      expect(results[0]!.usage?.inputTokens).toBe(120000);
+      expect(seeds[0]!.tags?.["pi.call_kind"]).toBe("compaction");
+      expect(results[0]!.metadata?.["pi.tokens_before"]).toBe(152000);
+      // The summary must not leak through metadata or tags, which content
+      // capture never strips.
+      expect(JSON.stringify([seeds[0], results[0]])).not.toContain(
+        "split the exporter",
+      );
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    // The summary is assistant text, not a tool body, so the no_tool_content
+    // split does not apply to it: every mode except metadata_only keeps it.
+    it.each([
+      "full",
+      "no_tool_content",
+      "full_with_metadata_spans",
+    ] as const)("keeps the summary text in %s", async (contentCapture) => {
+      const { sigil, results } = setupClient();
+      useConfig(sigil, contentCapture);
+      const entry = compactionEntry();
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: entry, fromExtension: false },
+        ctx,
+      );
+
+      expect(results[0]!.output).toEqual([
+        {
+          role: "assistant",
+          parts: [
+            {
+              type: "text",
+              text: "Earlier: we split the exporter and fixed two tests.",
+            },
+          ],
+        },
+      ]);
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("exports without a usage block when the host reports no usage", async () => {
+      const { sigil, results } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry({ usage: undefined });
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: entry, fromExtension: false },
+        ctx,
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0]!.usage).toBeUndefined();
+      // The pre-compaction context estimate is still reported; it is not a
+      // substitute for the missing input token count.
+      expect(results[0]!.metadata?.["pi.tokens_before"]).toBe(152000);
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      {
+        name: "a usage object with a cost but no token counts",
+        usage: { cost: { total: 1.75 } },
+        cost: 1.75,
+      },
+      {
+        name: "a usage object with nothing mappable",
+        usage: { input: "lots", cost: { total: "free" } },
+        cost: undefined,
+      },
+    ])("omits the usage block for $name", async ({ usage, cost }) => {
+      // Zeros would read as "this call used no tokens"; the truth is that
+      // the host did not report any. A cost still survives on its own.
+      const { sigil, results } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry({ usage });
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: entry, fromExtension: false },
+        ctx,
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0]!.usage).toBeUndefined();
+      expect(results[0]!.metadata?.cost_usd).toBe(cost);
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { name: "missing", timestamp: undefined },
+      { name: "not a parseable date", timestamp: "whenever" },
+    ])("falls back to the current time when the entry timestamp is $name", async ({
+      timestamp,
+    }) => {
+      const { sigil, seeds, results } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry({ timestamp });
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+      const now = Date.parse("2025-02-02T03:04:05.000Z");
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+
+      try {
+        const pi = new FakePi();
+        registerExtension(pi as any);
+        await pi.emit("session_start", {}, ctx);
+        await pi.emit(
+          "session_compact",
+          { compactionEntry: entry, fromExtension: false },
+          ctx,
+        );
+      } finally {
+        nowSpy.mockRestore();
+      }
+
+      expect(results).toHaveLength(1);
+      expect(results[0]!.completedAt).toEqual(new Date(now));
+      // No start signal was seen, so startedAt collapses onto completedAt
+      // rather than inverting the window.
+      expect(seeds[0]!.startedAt).toEqual(new Date(now));
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("takes startedAt from session_before_compact", async () => {
+      const { sigil, seeds, results } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry();
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+      const startedAt = COMPACTION_AT - 5_000;
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(startedAt);
+
+      try {
+        const pi = new FakePi();
+        registerExtension(pi as any);
+        await pi.emit("session_start", {}, ctx);
+        await pi.emit("session_before_compact", {}, ctx);
+        await pi.emit(
+          "session_compact",
+          { compactionEntry: entry, fromExtension: false },
+          ctx,
+        );
+      } finally {
+        nowSpy.mockRestore();
+      }
+
+      expect(seeds[0]!.startedAt).toEqual(new Date(startedAt));
+      expect(results[0]!.completedAt).toEqual(new Date(COMPACTION_AT));
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the entry timestamp when no start signal was seen", async () => {
+      const { sigil, seeds, results } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry();
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: entry, fromExtension: false },
+        ctx,
+      );
+
+      expect(seeds[0]!.startedAt).toEqual(new Date(COMPACTION_AT));
+      expect(results[0]!.completedAt).toEqual(new Date(COMPACTION_AT));
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("overwrites an orphaned start from an aborted compaction", async () => {
+      // An aborted or failed compaction emits no session_compact at all, so
+      // its start timestamp must not be reused by the next attempt.
+      const { sigil, seeds } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry();
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+      const orphaned = COMPACTION_AT - 60_000;
+      const real = COMPACTION_AT - 3_000;
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(orphaned);
+
+      try {
+        const pi = new FakePi();
+        registerExtension(pi as any);
+        await pi.emit("session_start", {}, ctx);
+        await pi.emit("session_before_compact", {}, ctx);
+        // ... aborted, no session_compact ...
+        nowSpy.mockReturnValue(real);
+        await pi.emit("session_before_compact", {}, ctx);
+        await pi.emit(
+          "session_compact",
+          { compactionEntry: entry, fromExtension: false },
+          ctx,
+        );
+      } finally {
+        nowSpy.mockRestore();
+      }
+
+      expect(seeds[0]!.startedAt).toEqual(new Date(real));
+      expect(seeds[0]!.startedAt).not.toEqual(new Date(orphaned));
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("does not reuse a consumed start for a later compaction", async () => {
+      const { sigil, seeds } = setupClient();
+      useConfig(sigil);
+      const first = compactionEntry({ id: "c1" });
+      const second = compactionEntry({
+        id: "c2",
+        parentId: "c1",
+        timestamp: "2025-01-01T00:10:05.000Z",
+      });
+      let branch = branchWith(first);
+      const ctx = ctxWithBranch("pi-conv-1", () => branch);
+      const firstStart = COMPACTION_AT - 5_000;
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(firstStart);
+
+      try {
+        const pi = new FakePi();
+        registerExtension(pi as any);
+        await pi.emit("session_start", {}, ctx);
+        await pi.emit("session_before_compact", {}, ctx);
+        await pi.emit(
+          "session_compact",
+          { compactionEntry: first, fromExtension: false },
+          ctx,
+        );
+        branch = branchWith(first, second);
+        await pi.emit(
+          "session_compact",
+          { compactionEntry: second, fromExtension: false },
+          ctx,
+        );
+      } finally {
+        nowSpy.mockRestore();
+      }
+
+      expect(seeds[0]!.startedAt).toEqual(new Date(firstStart));
+      // Second export has no start of its own, so it falls back to its own
+      // entry timestamp instead of inheriting the first one's start.
+      expect(seeds[1]!.startedAt).toEqual(
+        new Date(Date.parse("2025-01-01T00:10:05.000Z")),
+      );
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("clamps startedAt so it never exceeds completedAt", async () => {
+      const { sigil, seeds, results } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry();
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+      // Clock jumped forward after the entry was written (or the entry came
+      // from a machine with a different clock).
+      const nowSpy = vi
+        .spyOn(Date, "now")
+        .mockReturnValue(COMPACTION_AT + 60_000);
+
+      try {
+        const pi = new FakePi();
+        registerExtension(pi as any);
+        await pi.emit("session_start", {}, ctx);
+        await pi.emit("session_before_compact", {}, ctx);
+        await pi.emit(
+          "session_compact",
+          { compactionEntry: entry, fromExtension: false },
+          ctx,
+        );
+      } finally {
+        nowSpy.mockRestore();
+      }
+
+      expect(seeds[0]!.startedAt).toEqual(new Date(COMPACTION_AT));
+      expect(results[0]!.completedAt).toEqual(new Date(COMPACTION_AT));
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("discards the turn state that a manual mid-stream /compact abandons", async () => {
+      // Manual /compact disconnects from the agent before aborting, so the
+      // in-flight turn's turn_end never arrives. Its buffered prompt must not
+      // be attributed to the next turn.
+      const { sigil, turnResults } = setupClient();
+      useConfig(sigil, "full");
+      const msg = assistantMessage();
+      const ctx = ctxWithBranch("pi-conv-1", branchWith());
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit(
+        "message_end",
+        {
+          message: {
+            role: "user",
+            content: "abandoned prompt",
+            timestamp: Date.now(),
+          },
+        },
+        ctx,
+      );
+      await pi.emit("session_before_compact", { reason: "manual" }, ctx);
+
+      // Next turn, with a fresh prompt.
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit(
+        "message_end",
+        {
+          message: {
+            role: "user",
+            content: "fresh prompt",
+            timestamp: Date.now(),
+          },
+        },
+        ctx,
+      );
+      await pi.emit("turn_end", { message: msg, toolResults: [] }, ctx);
+
+      const input = turnResults[0]?.input as
+        | Array<{ parts: Array<{ text?: string }> }>
+        | undefined;
+      expect(input).toHaveLength(1);
+      expect(input?.[0]?.parts[0]?.text).toBe("fresh prompt");
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("swallows an export failure into logger.error", async () => {
+      const { sigil } = setupClient({
+        startGenerationError: new Error("queue closed"),
+      });
+      useConfig(sigil);
+      const entry = compactionEntry();
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: entry, fromExtension: false },
+        ctx,
+      );
+
+      // The log names the entry: this catch is the only place an export
+      // failure surfaces, and the two summary kinds interleave in the log.
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        "session_compact failed, entry=c1",
+        expect.any(Error),
+      );
+    });
+
+    it("retries a previously failed entry on the next event", async () => {
+      // The entry id is only recorded once the recorder accepted it, so a
+      // transient export failure does not permanently drop the generation.
+      let fail = true;
+      const seeds: CapturedSeed[] = [];
+      const sigil: Agento11yLike = {
+        startStreamingGeneration: vi.fn(async () => {}),
+        startGeneration: vi.fn(async (seed, run) => {
+          if (fail) {
+            fail = false;
+            throw new Error("transient");
+          }
+          seeds.push(seed as CapturedSeed);
+          await run({ setResult: vi.fn(), setCallError: vi.fn() });
+        }),
+        startToolExecution: vi.fn(),
+        shutdown: vi.fn(async () => {}),
+      };
+      useConfig(sigil);
+      const entry = compactionEntry();
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      const event = { compactionEntry: entry, fromExtension: false };
+      await pi.emit("session_compact", event, ctx);
+      await pi.emit("session_compact", event, ctx);
+
+      expect(seeds).toHaveLength(1);
+      expect(seeds[0]!.id).toBe(stablePiGenerationId("pi-conv-1", "c1"));
+    });
+
+    it("clears summary state across sessions", async () => {
+      // A new session_start must not inherit the previous session's exported
+      // entry ids or pending starts.
+      const { sigil, seeds } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry();
+      const ctx = ctxWithBranch("pi-conv-1", branchWith(entry));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: entry, fromExtension: false },
+        ctx,
+      );
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: entry, fromExtension: false },
+        ctx,
+      );
+
+      expect(seeds).toHaveLength(2);
+      expect(seeds[0]!.id).toBe(seeds[1]!.id);
+      expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the event entry when getBranch is unavailable", async () => {
+      const { sigil, seeds } = setupClient();
+      useConfig(sigil);
+      const entry = compactionEntry();
+      const ctx = {
+        sessionManager: {
+          getSessionFile: () => "pi-session.jsonl",
+          getSessionId: () => "pi-conv-1",
+        },
+        model: defaultModel,
+      };
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: entry, fromExtension: false },
+        ctx,
+      );
+
+      expect(seeds).toHaveLength(1);
+      expect(seeds[0]!.id).toBe(stablePiGenerationId("pi-conv-1", "c1"));
+      expect(seeds[0]!.parentGenerationIds).toBeUndefined();
+      expect(loggerMock.error).not.toHaveBeenCalled();
     });
   });
 });

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -11,7 +11,11 @@ import { loadConfig } from "./config.js";
 import { detectPiVersion } from "./detectPiVersion.js";
 import { resolveGitBranch } from "./git.js";
 import { runPreflightTransform, runToolCallGuard } from "./guard.js";
-import { resolvePiGenerationLineage } from "./lineage.js";
+import {
+  resolvePiGenerationLineage,
+  resolvePiSummaryLineage,
+  type SessionManagerLike,
+} from "./lineage.js";
 import { logger } from "./logger.js";
 import {
   applyRedactedText,
@@ -20,11 +24,17 @@ import {
   mapAgentMessagesForHook,
   mapGenerationResult,
   mapGenerationStart,
+  mapSummaryGenerationResult,
+  mapSummaryGenerationStart,
   mapTools,
   mapUserMessage,
+  PI_USAGE_TOKEN_FIELDS,
   type PiAssistantMessage,
+  type PiSummaryEntryLike,
+  type PiSummaryKind,
   type PiToolInfo,
   type PiToolResult,
+  type PiUsageLike,
   type PiUserMessage,
   resolveConversationTitle,
   type ToolTiming,
@@ -85,6 +95,21 @@ export default function (pi: ExtensionAPI) {
   // boundaries (never in resetTurnState).
   let firstUserText: string | undefined;
 
+  // Start timestamps for pi's own summarization LLM calls. Written by the
+  // `session_before_*` handler, which is the only start signal pi gives us
+  // (those events are `hasHandlers`-gated, so registering the handler is what
+  // makes pi emit them), and consumed by the matching terminal event. A new
+  // start overwrites any pending one, because an aborted or failed compaction
+  // emits no terminal event at all and would otherwise leak its start time
+  // into a later export.
+  let compactionStartedAt: number | undefined;
+  let branchSummaryStartedAt: number | undefined;
+  // Summary entry ids already exported, so one entry never produces two
+  // generations with the same id. `resolveSummaryEntry` corrects the entry
+  // `session_compact` hands back, but only on runtimes that expose
+  // `getBranch()`; this set covers the fallback.
+  const exportedSummaryEntryIds = new Set<string>();
+
   function resetTurnState() {
     turnStartTime = 0;
     firstTokenTime = 0;
@@ -109,6 +134,159 @@ export default function (pi: ExtensionAPI) {
     lastSeenModel = null;
     currentSystemPrompt = undefined;
     currentRequestControls = {};
+    compactionStartedAt = undefined;
+    branchSummaryStartedAt = undefined;
+    exportedSummaryEntryIds.clear();
+  }
+
+  /**
+   * Resolve the model for a summarization call. Compaction and branch
+   * summaries run outside the agent loop and carry no model metadata, so read
+   * pi's live `ctx.model` first and fall back to the model cached from the
+   * last assistant message.
+   */
+  function resolveSummaryModel(
+    ctx: PiSummaryContext,
+  ): { provider: string; name: string } | null {
+    const provider = ctx?.model?.provider;
+    const id = ctx?.model?.id;
+    if (
+      typeof provider === "string" &&
+      provider.length > 0 &&
+      typeof id === "string" &&
+      id.length > 0
+    ) {
+      // Assistant messages carry `model.id` as their `model` field, so use the
+      // id (not the display name) to keep turn and summary generations on the
+      // same model identity.
+      return { provider, name: id };
+    }
+    return lastSeenModel;
+  }
+
+  /**
+   * Export one generation for a completed pi summarization call.
+   *
+   * Skips are logged at debug level. An extension-supplied summary and an
+   * event outside an active session are routine; the rest are anomalies that
+   * still must not interrupt the host.
+   */
+  async function exportSummaryGeneration(
+    kind: PiSummaryKind,
+    eventEntry: unknown,
+    ctx: PiSummaryContext,
+    extras: {
+      startedAt?: number;
+      reason?: string;
+      willRetry?: boolean;
+    },
+  ): Promise<void> {
+    if (!sigil || !config) {
+      logger.debug(`${kind}: skipped, no active session`);
+      return;
+    }
+
+    const sessionManager = ctx?.sessionManager;
+    const entry = resolveSummaryEntry(kind, sessionManager, eventEntry);
+    if (!entry) {
+      logger.debug(`${kind}: skipped, no summary entry on the event`);
+      return;
+    }
+    if (entry.fromHook === true) {
+      logger.debug(`${kind}: skipped, summary came from an extension`);
+      return;
+    }
+    const entryId = entry.id;
+    if (!entryId) {
+      logger.debug(`${kind}: skipped, summary entry has no id`);
+      return;
+    }
+    if (exportedSummaryEntryIds.has(entryId)) {
+      logger.debug(`${kind}: skipped, entry ${entryId} already exported`);
+      return;
+    }
+
+    const model = resolveSummaryModel(ctx);
+    if (!model) {
+      logger.debug(`${kind}: skipped, no model could be resolved`);
+      return;
+    }
+
+    const conversationId = sessionManager?.getSessionId?.() || undefined;
+
+    // Entry timestamps are ISO strings stamped when the entry is appended,
+    // i.e. after the summarization call finished. No pi event carries a
+    // timestamp, so this is the only end time available.
+    const parsedCompletedAt = entry.timestamp
+      ? Date.parse(entry.timestamp)
+      : Number.NaN;
+    const completedAt = Number.isFinite(parsedCompletedAt)
+      ? parsedCompletedAt
+      : Date.now();
+    // Clamp: a start recorded before a clock adjustment (or an entry
+    // timestamp written by another machine) must not invert the window.
+    const startedAt = Math.min(extras.startedAt ?? completedAt, completedAt);
+
+    const summaryCwd = process.cwd();
+    const tags = buildBuiltinTags({
+      cwd: summaryCwd,
+      gitBranch: resolveGitBranch(summaryCwd),
+    });
+
+    let sessionName: string | undefined;
+    try {
+      sessionName = sessionManager?.getSessionName?.();
+    } catch (err) {
+      logger.debug("getSessionName failed", err);
+    }
+
+    const lineage = resolvePiSummaryLineage(
+      sessionManager,
+      entryId,
+      conversationId,
+    );
+
+    const seed = mapSummaryGenerationStart({
+      kind,
+      conversationId,
+      conversationTitle: resolveConversationTitle({
+        sessionName,
+        firstUserText,
+        conversationId,
+        contentCapture: config.contentCapture,
+      }),
+      agentName: config.agentName,
+      agentVersion: config.agentVersion,
+      model,
+      startedAt,
+      tags,
+      generationId: lineage.generationId,
+      parentGenerationIds: lineage.parentGenerationIds,
+    });
+
+    const result = mapSummaryGenerationResult({
+      entry,
+      contentCapture: config.contentCapture,
+      completedAt,
+      responseModel: model.name,
+      reason: extras.reason,
+      willRetry: extras.willRetry,
+    });
+
+    // SYNC, not STREAM: there is no token stream and no TTFT signal for these
+    // calls. The SYNC path defaults `operationName` to `generateText`, which
+    // also discriminates them from turns (`streamText`).
+    await sigil.startGeneration(seed, async (recorder) => {
+      recorder.setResult(result);
+    });
+    // Only mark the entry exported once the recorder accepted it, so a
+    // failed export can be retried by a later event for the same entry.
+    exportedSummaryEntryIds.add(entryId);
+    logger.debug(
+      `summary generation queued, kind=${kind} entry=${entryId} tokens=${
+        result.usage?.totalTokens ?? "unknown"
+      }`,
+    );
   }
 
   function cacheAssistantModel(message: PiAssistantMessage) {
@@ -570,6 +748,78 @@ export default function (pi: ExtensionAPI) {
     }
   });
 
+  // Pi runs compaction and branch summarization outside the agent loop, so
+  // none of the turn/message events fire for them. The `session_before_*`
+  // events are the only start signal, and registering a handler is what makes
+  // pi emit them at all (`hasHandlers`-gated). These handlers must not return
+  // a value: pi reads a returned object as a cancel/replace instruction.
+  pi.on("session_before_compact", async (_event, _ctx) => {
+    compactionStartedAt = Date.now();
+    // Manual /compact disconnects from the agent before aborting the in-flight
+    // turn, so that turn's `turn_end` never reaches us. Drop its buffered
+    // state here instead of letting the abandoned prompt and stale timers
+    // attach to the next exported generation. Threshold and overflow
+    // compaction run after `turn_end`, where this is a no-op: the buffer is
+    // already drained and the next `turn_start` resets the timers.
+    resetTurnState();
+    pendingInputMessages.length = 0;
+    currentRequestControls = {};
+  });
+
+  pi.on("session_before_tree", async (_event, _ctx) => {
+    branchSummaryStartedAt = Date.now();
+  });
+
+  pi.on("session_compact", async (event, ctx) => {
+    // Consume the pending start unconditionally, including on the skip paths
+    // below: a start that produced no export must not be reused by the next
+    // compaction.
+    const startedAt = compactionStartedAt;
+    compactionStartedAt = undefined;
+    try {
+      if (event.fromExtension === true) {
+        logger.debug("compaction: skipped, supplied by an extension");
+        return;
+      }
+      // `reason` and `willRetry` were added to this event after the pinned pi
+      // version, so read them structurally.
+      const raw = event as { reason?: unknown; willRetry?: unknown };
+      await exportSummaryGeneration("compaction", event.compactionEntry, ctx, {
+        startedAt,
+        reason: typeof raw.reason === "string" ? raw.reason : undefined,
+        willRetry:
+          typeof raw.willRetry === "boolean" ? raw.willRetry : undefined,
+      });
+    } catch (err) {
+      logger.error(
+        `session_compact failed, entry=${entryIdOf(event.compactionEntry)}`,
+        err,
+      );
+    }
+  });
+
+  pi.on("session_tree", async (event, ctx) => {
+    const startedAt = branchSummaryStartedAt;
+    branchSummaryStartedAt = undefined;
+    try {
+      // `session_tree` fires for every navigation; only the summarizing ones
+      // carry a summary entry, and only those involved a model call.
+      if (!event.summaryEntry) return;
+      if (event.fromExtension === true) {
+        logger.debug("branch_summary: skipped, supplied by an extension");
+        return;
+      }
+      await exportSummaryGeneration("branch_summary", event.summaryEntry, ctx, {
+        startedAt,
+      });
+    } catch (err) {
+      logger.error(
+        `session_tree failed, entry=${entryIdOf(event.summaryEntry)}`,
+        err,
+      );
+    }
+  });
+
   pi.on("session_shutdown", async (_event, _ctx) => {
     if (sigil) {
       try {
@@ -583,6 +833,110 @@ export default function (pi: ExtensionAPI) {
     lastSeenModel = null;
     await resetSessionState();
   });
+}
+
+/**
+ * Slice of pi's `ExtensionContext` the summary export path reads. Structural
+ * so the test fakes stay small and so `ctx.model` (typed as `Model<any>`) can
+ * be read without importing pi's model types.
+ */
+interface PiSummaryContext {
+  sessionManager?: SessionManagerLike & {
+    getSessionId?: () => string | undefined;
+    getSessionName?: () => string | undefined;
+  };
+  model?: { provider?: unknown; id?: unknown };
+}
+
+/**
+ * Pick the entry to export.
+ *
+ * Only compaction needs a lookup of its own. `session_compact` resolves its
+ * entry by summary text and takes the first match in the whole session file,
+ * so two byte-identical summaries make the event point at an older entry. The
+ * correction is positional, not textual: pi appends the compaction entry and
+ * emits the event immediately after, so the newest `compaction` entry on the
+ * active branch is the one that was just written. `session_tree` looks its
+ * entry up by id (`getEntry(summaryId)`), so its event entry is already exact
+ * and is used as-is.
+ */
+function resolveSummaryEntry(
+  kind: PiSummaryKind,
+  sessionManager: PiSummaryContext["sessionManager"],
+  eventEntry: unknown,
+): PiSummaryEntryLike | null {
+  if (kind !== "compaction") return toPiSummaryEntry(eventEntry);
+  try {
+    const branch = sessionManager?.getBranch?.();
+    if (Array.isArray(branch)) {
+      for (let i = branch.length - 1; i >= 0; i--) {
+        const candidate = branch[i] as { type?: unknown } | undefined;
+        if (!candidate || candidate.type !== "compaction") continue;
+        const mapped = toPiSummaryEntry(candidate);
+        if (mapped?.id) return mapped;
+        break;
+      }
+    }
+  } catch (err) {
+    logger.debug("getBranch failed while resolving the summary entry", err);
+  }
+  return toPiSummaryEntry(eventEntry);
+}
+
+/** Entry id for a log line, or `unknown` when the value carries none. */
+function entryIdOf(value: unknown): string {
+  return toPiSummaryEntry(value)?.id ?? "unknown";
+}
+
+/**
+ * Read pi's `CompactionEntry` / `BranchSummaryEntry` structurally. `usage` is
+ * absent from the dev-pinned pi types and `tokensBefore` only exists on
+ * compaction entries, so nothing here may assume a field is present.
+ */
+function toPiSummaryEntry(value: unknown): PiSummaryEntryLike | null {
+  if (!value || typeof value !== "object") return null;
+  const src = value as Record<string, unknown>;
+  const entry: PiSummaryEntryLike = {};
+  if (typeof src.id === "string" && src.id.length > 0) entry.id = src.id;
+  if (typeof src.timestamp === "string") entry.timestamp = src.timestamp;
+  if (typeof src.summary === "string") entry.summary = src.summary;
+  if (typeof src.tokensBefore === "number") {
+    entry.tokensBefore = src.tokensBefore;
+  }
+  if (src.fromHook === true) entry.fromHook = true;
+  const usage = toPiUsage(src.usage);
+  if (usage) entry.usage = usage;
+  return entry;
+}
+
+/**
+ * Copy the numeric fields of a pi `Usage` object. Returns `undefined` when the
+ * value is not an object or carries no finite number, so a malformed usage
+ * object is indistinguishable from an absent one. Whether the token block
+ * itself is exported is decided by `mapSummaryGenerationResult`, which needs
+ * at least one token count and ignores a cost-only object.
+ */
+function toPiUsage(value: unknown): PiUsageLike | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const src = value as Record<string, unknown>;
+  const out: PiUsageLike = {};
+  let seen = false;
+  for (const key of PI_USAGE_TOKEN_FIELDS) {
+    const raw = src[key];
+    if (typeof raw === "number" && Number.isFinite(raw)) {
+      out[key] = raw;
+      seen = true;
+    }
+  }
+  const cost = src.cost;
+  if (cost && typeof cost === "object") {
+    const total = (cost as Record<string, unknown>).total;
+    if (typeof total === "number" && Number.isFinite(total)) {
+      out.cost = { total };
+      seen = true;
+    }
+  }
+  return seen ? out : undefined;
 }
 
 /** @internal Exported for testing. */

--- a/plugins/pi/src/lineage.test.ts
+++ b/plugins/pi/src/lineage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   resolvePiGenerationLineage,
+  resolvePiSummaryLineage,
   type SessionEntryLike,
   stablePiGenerationId,
 } from "./lineage.js";
@@ -27,13 +28,35 @@ function userEntry(id: string, parentId: string | null): SessionEntryLike {
   };
 }
 
+function toolResultEntry(
+  id: string,
+  parentId: string | null,
+): SessionEntryLike {
+  return {
+    type: "message",
+    id,
+    parentId,
+    message: { role: "toolResult" },
+  };
+}
+
 function nonMessageEntry(
   id: string,
   parentId: string | null,
 ): SessionEntryLike {
-  // e.g. thinking_level_change, model_change, compaction. Lineage must
-  // ignore these and follow the parent chain through them.
+  // e.g. thinking_level_change, model_change. Lineage must ignore these as
+  // parent candidates and follow the parent chain through them.
   return { type: "model_change", id, parentId };
+}
+
+// Compaction and branch_summary entries are never lineage parents, but they
+// are lineage subjects: resolvePiSummaryLineage hashes them into their own
+// generation id.
+function compactionEntry(
+  id: string,
+  parentId: string | null,
+): SessionEntryLike {
+  return { type: "compaction", id, parentId };
 }
 
 describe("stablePiGenerationId", () => {
@@ -246,6 +269,153 @@ describe("resolvePiGenerationLineage", () => {
     // Should not link to the abandoned sibling assistant entry.
     expect(lineage.parentGenerationIds).not.toContain(
       stablePiGenerationId("conv", "a2"),
+    );
+  });
+});
+
+describe("resolvePiSummaryLineage", () => {
+  it("returns empty when conversationId is missing", () => {
+    const sm = { getBranch: () => [compactionEntry("c1", "a1")] };
+    expect(resolvePiSummaryLineage(sm, "c1", undefined)).toEqual({});
+  });
+
+  it("returns empty when the entry id is empty", () => {
+    const sm = { getBranch: () => [compactionEntry("c1", "a1")] };
+    expect(resolvePiSummaryLineage(sm, "", "conv")).toEqual({});
+  });
+
+  it("keeps the deterministic id when getBranch is unavailable", () => {
+    // The id only needs conversationId + entryId, both of which pi hands us
+    // directly, so an older runtime without getBranch still gets a stable id.
+    const sm = { getSessionId: () => "x" } as Record<string, unknown>;
+    expect(
+      resolvePiSummaryLineage(
+        sm as unknown as Parameters<typeof resolvePiSummaryLineage>[0],
+        "c1",
+        "conv",
+      ),
+    ).toEqual({ generationId: stablePiGenerationId("conv", "c1") });
+    expect(resolvePiSummaryLineage(undefined, "c1", "conv")).toEqual({
+      generationId: stablePiGenerationId("conv", "c1"),
+    });
+    expect(resolvePiSummaryLineage(null, "c1", "conv")).toEqual({
+      generationId: stablePiGenerationId("conv", "c1"),
+    });
+  });
+
+  it("keeps the deterministic id when getBranch throws or is empty", () => {
+    const throwing = {
+      getBranch: () => {
+        throw new Error("not a real session");
+      },
+    };
+    expect(resolvePiSummaryLineage(throwing, "c1", "conv")).toEqual({
+      generationId: stablePiGenerationId("conv", "c1"),
+    });
+    expect(
+      resolvePiSummaryLineage({ getBranch: () => [] }, "c1", "conv"),
+    ).toEqual({ generationId: stablePiGenerationId("conv", "c1") });
+  });
+
+  it("keeps the deterministic id when the entry is not on the branch", () => {
+    const sm = { getBranch: () => [assistantEntry("a1", null)] };
+    expect(resolvePiSummaryLineage(sm, "c1", "conv")).toEqual({
+      generationId: stablePiGenerationId("conv", "c1"),
+    });
+  });
+
+  it("parents a compaction entry on the previous assistant entry", () => {
+    const branch: SessionEntryLike[] = [
+      userEntry("u1", null),
+      assistantEntry("a1", "u1"),
+      compactionEntry("c1", "a1"),
+    ];
+    const sm = { getBranch: () => branch };
+    const lineage = resolvePiSummaryLineage(sm, "c1", "conv");
+    expect(lineage.generationId).toBe(stablePiGenerationId("conv", "c1"));
+    expect(lineage.parentGenerationIds).toEqual([
+      stablePiGenerationId("conv", "a1"),
+    ]);
+  });
+
+  it("walks through an intervening toolResult message entry", () => {
+    // Compaction is appended as a child of the current leaf, which after a
+    // tool-using turn is the toolResult message, not the assistant message.
+    const branch: SessionEntryLike[] = [
+      userEntry("u1", null),
+      assistantEntry("a1", "u1"),
+      toolResultEntry("t1", "a1"),
+      compactionEntry("c1", "t1"),
+    ];
+    const sm = { getBranch: () => branch };
+    expect(
+      resolvePiSummaryLineage(sm, "c1", "conv").parentGenerationIds,
+    ).toEqual([stablePiGenerationId("conv", "a1")]);
+  });
+
+  it("walks through an intervening model_change entry", () => {
+    const branch: SessionEntryLike[] = [
+      userEntry("u1", null),
+      assistantEntry("a1", "u1"),
+      nonMessageEntry("mc1", "a1"),
+      compactionEntry("c1", "mc1"),
+    ];
+    const sm = { getBranch: () => branch };
+    expect(
+      resolvePiSummaryLineage(sm, "c1", "conv").parentGenerationIds,
+    ).toEqual([stablePiGenerationId("conv", "a1")]);
+  });
+
+  it("walks through both a toolResult and a model_change entry", () => {
+    const branch: SessionEntryLike[] = [
+      userEntry("u1", null),
+      assistantEntry("a1", "u1"),
+      toolResultEntry("t1", "a1"),
+      nonMessageEntry("m1", "t1"),
+      compactionEntry("c1", "m1"),
+    ];
+    const sm = { getBranch: () => branch };
+    const lineage = resolvePiSummaryLineage(sm, "c1", "conv");
+    expect(lineage.generationId).toBe(stablePiGenerationId("conv", "c1"));
+    expect(lineage.parentGenerationIds).toEqual([
+      stablePiGenerationId("conv", "a1"),
+    ]);
+  });
+
+  it("omits parentGenerationIds when no assistant entry precedes the summary", () => {
+    const branch: SessionEntryLike[] = [
+      userEntry("u1", null),
+      compactionEntry("c1", "u1"),
+    ];
+    const sm = { getBranch: () => branch };
+    const lineage = resolvePiSummaryLineage(sm, "c1", "conv");
+    expect(lineage.generationId).toBe(stablePiGenerationId("conv", "c1"));
+    expect(lineage.parentGenerationIds).toBeUndefined();
+  });
+
+  it("resolves a branch_summary entry the same way", () => {
+    const branch: SessionEntryLike[] = [
+      userEntry("u1", null),
+      assistantEntry("a1", "u1"),
+      { type: "branch_summary", id: "b1", parentId: "a1" },
+    ];
+    const sm = { getBranch: () => branch };
+    const lineage = resolvePiSummaryLineage(sm, "b1", "conv");
+    expect(lineage.generationId).toBe(stablePiGenerationId("conv", "b1"));
+    expect(lineage.parentGenerationIds).toEqual([
+      stablePiGenerationId("conv", "a1"),
+    ]);
+  });
+
+  it("differs from the turn generation id for the same conversation", () => {
+    const branch: SessionEntryLike[] = [
+      userEntry("u1", null),
+      assistantEntry("a1", "u1"),
+      compactionEntry("c1", "a1"),
+    ];
+    const sm = { getBranch: () => branch };
+    expect(resolvePiSummaryLineage(sm, "c1", "conv").generationId).not.toBe(
+      stablePiGenerationId("conv", "a1"),
     );
   });
 });

--- a/plugins/pi/src/lineage.ts
+++ b/plugins/pi/src/lineage.ts
@@ -28,8 +28,10 @@ export interface SessionManagerLike {
 /**
  * Minimal `SessionEntry` shape: just the fields we read. `getBranch()`
  * returns mixed entry types (message, thinking_level_change, model_change,
- * compaction, …); we only treat `type === "message"` entries with an
- * assistant message as relevant.
+ * compaction, branch_summary, …). Only `type === "message"` entries with an
+ * assistant message can be a lineage parent; the other types are walked
+ * through. `compaction` and `branch_summary` entries get a generation id of
+ * their own instead, see {@link resolvePiSummaryLineage}.
  */
 export interface SessionEntryLike {
   type?: string;
@@ -129,11 +131,56 @@ export function resolvePiGenerationLineage(
   // assistant turn; on branched trees it is the assistant turn at the
   // branch point, not the most recent chronological assistant entry from
   // a sibling branch.
-  const parentId = findParentAssistantEntryId(
-    currentEntry,
-    branch,
-    assistantEntries,
-  );
+  const parentId = findParentAssistantEntryId(currentEntry, branch);
+  if (!parentId) return { generationId };
+
+  return {
+    generationId,
+    parentGenerationIds: [stablePiGenerationId(conversationId, parentId)],
+  };
+}
+
+/**
+ * Resolve `{ generationId, parentGenerationIds }` for a host summarization
+ * entry (`compaction` or `branch_summary`) identified by its entry id.
+ *
+ * Unlike {@link resolvePiGenerationLineage}, the subject is not a message, so
+ * there is nothing to match by object identity: pi hands us the entry itself.
+ * The id is hashed straight from `entryId`, which means it stays deterministic
+ * even on runtimes that do not expose `getBranch()`; only the parent lookup
+ * needs the branch.
+ *
+ * The parent is the nearest ancestor assistant message entry. Pi appends the
+ * summary entry as a child of the current leaf, which is frequently a
+ * `toolResult` message or a `model_change` entry rather than an assistant
+ * message, so the walk goes through the parentId chain instead of assuming the
+ * immediate parent.
+ */
+export function resolvePiSummaryLineage(
+  sessionManager: SessionManagerLike | undefined | null,
+  entryId: string,
+  conversationId: string | undefined,
+): PiGenerationLineage {
+  if (!conversationId || !entryId) return {};
+
+  const generationId = stablePiGenerationId(conversationId, entryId);
+
+  if (!sessionManager || typeof sessionManager.getBranch !== "function") {
+    return { generationId };
+  }
+
+  let branch: SessionEntryLike[];
+  try {
+    branch = sessionManager.getBranch();
+  } catch {
+    return { generationId };
+  }
+  if (!Array.isArray(branch) || branch.length === 0) return { generationId };
+
+  const entry = branch.find((e) => e.id === entryId);
+  if (!entry) return { generationId };
+
+  const parentId = findParentAssistantEntryId(entry, branch);
   if (!parentId) return { generationId };
 
   return {
@@ -144,25 +191,17 @@ export function resolvePiGenerationLineage(
 
 /**
  * Walk the parentId chain from `entry` toward the root and return the id of
- * the nearest ancestor that is an assistant message entry. Returns
- * `undefined` for the first assistant turn on the branch.
- *
- * `branch` is used to look up entries by id; `assistantEntries` is the
- * pre-filtered list, used to detect when an ancestor is itself an
- * assistant entry.
+ * the nearest ancestor that is an assistant message entry. `branch` is used to
+ * look up entries by id. Returns `undefined` for the first assistant turn on
+ * the branch.
  */
 function findParentAssistantEntryId(
   entry: SessionEntryLike,
   branch: SessionEntryLike[],
-  assistantEntries: SessionEntryLike[],
 ): string | undefined {
   const byId = new Map<string, SessionEntryLike>();
   for (const e of branch) {
     if (typeof e.id === "string") byId.set(e.id, e);
-  }
-  const assistantIds = new Set<string>();
-  for (const e of assistantEntries) {
-    if (typeof e.id === "string") assistantIds.add(e.id);
   }
 
   let cursor = entry.parentId;
@@ -171,7 +210,7 @@ function findParentAssistantEntryId(
     seen.add(cursor);
     const parent = byId.get(cursor);
     if (!parent) return undefined;
-    if (assistantIds.has(cursor)) return cursor;
+    if (isAssistantMessageEntry(parent)) return cursor;
     cursor = parent.parentId ?? null;
   }
   return undefined;

--- a/plugins/pi/src/mappers.test.ts
+++ b/plugins/pi/src/mappers.test.ts
@@ -7,10 +7,14 @@ import {
   mapAgentMessagesForHook,
   mapGenerationResult,
   mapGenerationStart,
+  mapPiUsage,
+  mapSummaryGenerationResult,
+  mapSummaryGenerationStart,
   mapTools,
   mapUserMessage,
   type PiAgentMessage,
   type PiAssistantMessage,
+  type PiSummaryEntryLike,
   type PiToolInfo,
   type PiToolResult,
   type PiUserMessage,
@@ -1404,5 +1408,341 @@ describe("applyRedactedText", () => {
       type: "text",
       text: "original",
     });
+  });
+});
+
+describe("mapPiUsage", () => {
+  it.each([
+    {
+      name: "full usage block",
+      usage: {
+        input: 120000,
+        output: 8000,
+        cacheRead: 40,
+        cacheWrite: 12,
+        totalTokens: 128052,
+        cost: { total: 2.5 },
+      },
+      want: {
+        inputTokens: 120000,
+        outputTokens: 8000,
+        totalTokens: 128052,
+        cacheReadInputTokens: 40,
+        cacheWriteInputTokens: 12,
+      },
+    },
+    {
+      name: "missing optional fields default to 0",
+      usage: { input: 10, output: 5 },
+      want: {
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 0,
+        cacheReadInputTokens: 0,
+        cacheWriteInputTokens: 0,
+      },
+    },
+    {
+      name: "absent cost is not part of the token mapping",
+      usage: {
+        input: 1,
+        output: 2,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 3,
+      },
+      want: {
+        inputTokens: 1,
+        outputTokens: 2,
+        totalTokens: 3,
+        cacheReadInputTokens: 0,
+        cacheWriteInputTokens: 0,
+      },
+    },
+    {
+      name: "empty usage maps to all zeros",
+      usage: {},
+      want: {
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        cacheReadInputTokens: 0,
+        cacheWriteInputTokens: 0,
+      },
+    },
+  ])("maps $name", ({ usage, want }) => {
+    expect(mapPiUsage(usage)).toEqual(want);
+  });
+
+  it("produces the same fields the turn path exports", () => {
+    // Guard against drift: mapGenerationResult must stay byte-identical to
+    // mapPiUsage so turn and summary generations report tokens the same way.
+    const msg = makeMsg();
+    expect(mapGenerationResult(msg, [], "metadata_only").usage).toEqual(
+      mapPiUsage(msg.usage),
+    );
+  });
+});
+
+function makeSummaryEntry(
+  overrides?: Partial<PiSummaryEntryLike>,
+): PiSummaryEntryLike {
+  return {
+    id: "c1",
+    timestamp: "2025-01-01T00:00:05.000Z",
+    summary: "Earlier we refactored the exporter and fixed two tests.",
+    tokensBefore: 152000,
+    usage: {
+      input: 120000,
+      output: 8000,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 128000,
+      cost: { total: 2.5 },
+    },
+    ...overrides,
+  };
+}
+
+describe("mapSummaryGenerationStart", () => {
+  const baseOpts = {
+    kind: "compaction" as const,
+    conversationId: "conv-1",
+    conversationTitle: "refactor the exporter",
+    agentName: "pi",
+    agentVersion: "0.82.1",
+    model: { provider: "anthropic", name: "claude-sonnet-4" },
+    startedAt: 1_700_000_000_000,
+  };
+
+  it("maps conversation, agent, model and timing fields", () => {
+    const start = mapSummaryGenerationStart(baseOpts);
+    expect(start.conversationId).toBe("conv-1");
+    expect(start.conversationTitle).toBe("refactor the exporter");
+    expect(start.agentName).toBe("pi");
+    expect(start.agentVersion).toBe("0.82.1");
+    expect(start.effectiveVersion).toBe("0.82.1");
+    expect(start.model).toEqual({
+      provider: "anthropic",
+      name: "claude-sonnet-4",
+    });
+    expect(start.startedAt).toEqual(new Date(1_700_000_000_000));
+  });
+
+  it("does not set operationName so the SYNC default generateText applies", () => {
+    expect(mapSummaryGenerationStart(baseOpts).operationName).toBeUndefined();
+  });
+
+  it("omits conversationTitle when it is unavailable", () => {
+    const start = mapSummaryGenerationStart({
+      ...baseOpts,
+      conversationTitle: undefined,
+    });
+    expect("conversationTitle" in start).toBe(false);
+  });
+
+  it("adds pi.call_kind on top of the built-in tags", () => {
+    const start = mapSummaryGenerationStart({
+      ...baseOpts,
+      tags: { cwd: "/repo", "git.branch": "main" },
+    });
+    expect(start.tags).toEqual({
+      cwd: "/repo",
+      "git.branch": "main",
+      "pi.call_kind": "compaction",
+    });
+  });
+
+  it.each(["compaction", "branch_summary"] as const)("tags kind %s", (kind) => {
+    const start = mapSummaryGenerationStart({ ...baseOpts, kind });
+    expect(start.tags?.["pi.call_kind"]).toBe(kind);
+  });
+
+  it("emits pi.call_kind even when there are no built-in tags", () => {
+    expect(
+      mapSummaryGenerationStart({ ...baseOpts, tags: undefined }).tags,
+    ).toEqual({ "pi.call_kind": "compaction" });
+  });
+
+  it("sets the deterministic id and parent lineage when supplied", () => {
+    const start = mapSummaryGenerationStart({
+      ...baseOpts,
+      generationId: "pi-abc",
+      parentGenerationIds: ["pi-def"],
+    });
+    expect(start.id).toBe("pi-abc");
+    expect(start.parentGenerationIds).toEqual(["pi-def"]);
+  });
+
+  it("omits id and parentGenerationIds when lineage is unavailable", () => {
+    const start = mapSummaryGenerationStart({
+      ...baseOpts,
+      generationId: undefined,
+      parentGenerationIds: [],
+    });
+    expect(start.id).toBeUndefined();
+    expect(start.parentGenerationIds).toBeUndefined();
+  });
+});
+
+describe("mapSummaryGenerationResult", () => {
+  const completedAt = 1_700_000_005_000;
+
+  it("maps usage, stop reason, completion time and metadata", () => {
+    const result = mapSummaryGenerationResult({
+      entry: makeSummaryEntry(),
+      contentCapture: "full",
+      completedAt,
+      reason: "threshold",
+      willRetry: false,
+    });
+    expect(result.usage).toEqual({
+      inputTokens: 120000,
+      outputTokens: 8000,
+      totalTokens: 128000,
+      cacheReadInputTokens: 0,
+      cacheWriteInputTokens: 0,
+    });
+    expect(result.stopReason).toBe("end_turn");
+    expect(result.completedAt).toEqual(new Date(completedAt));
+    expect(result.metadata).toEqual({
+      cost_usd: 2.5,
+      "pi.tokens_before": 152000,
+      "pi.compaction.reason": "threshold",
+      "pi.compaction.will_retry": false,
+    });
+  });
+
+  it.each([
+    "full",
+    "no_tool_content",
+    "full_with_metadata_spans",
+  ] as const)("keeps the summary as one assistant text part in %s", (contentCapture) => {
+    const result = mapSummaryGenerationResult({
+      entry: makeSummaryEntry(),
+      contentCapture,
+      completedAt,
+    });
+    expect(result.output).toEqual([
+      {
+        role: "assistant",
+        parts: [
+          {
+            type: "text",
+            text: "Earlier we refactored the exporter and fixed two tests.",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("drops the summary text in metadata_only but keeps usage and metadata", () => {
+    const result = mapSummaryGenerationResult({
+      entry: makeSummaryEntry(),
+      contentCapture: "metadata_only",
+      completedAt,
+    });
+    expect(result.output).toBeUndefined();
+    expect(result.usage).toBeDefined();
+    expect(result.metadata?.["pi.tokens_before"]).toBe(152000);
+    // The summary must not be smuggled through metadata: content capture
+    // never strips metadata or tags.
+    expect(JSON.stringify(result)).not.toContain("refactored the exporter");
+  });
+
+  it("omits output for an empty or whitespace-only summary", () => {
+    expect(
+      mapSummaryGenerationResult({
+        entry: makeSummaryEntry({ summary: "   " }),
+        contentCapture: "full",
+        completedAt,
+      }).output,
+    ).toBeUndefined();
+    expect(
+      mapSummaryGenerationResult({
+        entry: makeSummaryEntry({ summary: undefined }),
+        contentCapture: "full",
+        completedAt,
+      }).output,
+    ).toBeUndefined();
+  });
+
+  it("omits usage entirely when the entry has none", () => {
+    const result = mapSummaryGenerationResult({
+      entry: makeSummaryEntry({ usage: undefined }),
+      contentCapture: "full",
+      completedAt,
+    });
+    expect(result.usage).toBeUndefined();
+    // tokensBefore is a context estimate, not this call's input tokens, so it
+    // must not be substituted for the missing usage.
+    expect(result.metadata?.["pi.tokens_before"]).toBe(152000);
+    expect(result.metadata?.cost_usd).toBeUndefined();
+  });
+
+  it("omits usage when the entry reports a cost but no token counts", () => {
+    // Mapping this would export five zeros, which reads as "no tokens used"
+    // instead of "the host did not report tokens". The cost still stands on
+    // its own.
+    const result = mapSummaryGenerationResult({
+      entry: makeSummaryEntry({ usage: { cost: { total: 1.75 } } }),
+      contentCapture: "full",
+      completedAt,
+    });
+    expect(result.usage).toBeUndefined();
+    expect(result.metadata?.cost_usd).toBe(1.75);
+  });
+
+  it("records a zero cost, like the turn path does", () => {
+    const result = mapSummaryGenerationResult({
+      entry: makeSummaryEntry({
+        usage: { input: 1, output: 2, totalTokens: 3, cost: { total: 0 } },
+      }),
+      contentCapture: "full",
+      completedAt,
+    });
+    expect(result.metadata?.cost_usd).toBe(0);
+  });
+
+  it("omits cost_usd when pi priced nothing", () => {
+    const result = mapSummaryGenerationResult({
+      entry: makeSummaryEntry({
+        usage: { input: 1, output: 2, totalTokens: 3, cost: {} },
+      }),
+      contentCapture: "full",
+      completedAt,
+    });
+    expect(result.metadata).not.toHaveProperty("cost_usd");
+  });
+
+  it("omits compaction-only metadata for a branch summary", () => {
+    const result = mapSummaryGenerationResult({
+      entry: makeSummaryEntry({ tokensBefore: undefined }),
+      contentCapture: "full",
+      completedAt,
+    });
+    expect(result.metadata).toEqual({ cost_usd: 2.5 });
+  });
+
+  it("records will_retry=true for overflow recovery", () => {
+    const result = mapSummaryGenerationResult({
+      entry: makeSummaryEntry(),
+      contentCapture: "full",
+      completedAt,
+      reason: "overflow",
+      willRetry: true,
+    });
+    expect(result.metadata?.["pi.compaction.reason"]).toBe("overflow");
+    expect(result.metadata?.["pi.compaction.will_retry"]).toBe(true);
+  });
+
+  it("sets responseModel when the resolved model is known", () => {
+    const result = mapSummaryGenerationResult({
+      entry: makeSummaryEntry(),
+      contentCapture: "full",
+      completedAt,
+      responseModel: "claude-sonnet-4",
+    });
+    expect(result.responseModel).toBe("claude-sonnet-4");
   });
 });

--- a/plugins/pi/src/mappers.ts
+++ b/plugins/pi/src/mappers.ts
@@ -3,6 +3,7 @@ import type {
   GenerationResult,
   GenerationStart,
   Message,
+  TokenUsage,
   ToolDefinition,
 } from "@grafana/agento11y";
 
@@ -18,6 +19,14 @@ function includesToolBodies(contentCapture: ContentCaptureMode): boolean {
     contentCapture === "full" || contentCapture === "full_with_metadata_spans"
   );
 }
+
+/**
+ * Tag key marking a generation that pi's host made outside a user turn.
+ * Values: `compaction` (context compaction) and `branch_summary` (tree
+ * navigation summary). Prefixed with `pi.` because no cross-launcher
+ * convention exists for host-initiated model calls.
+ */
+const PI_CALL_KIND_TAG = "pi.call_kind";
 
 /**
  * Pi's ToolInfo shape from @mariozechner/pi-coding-agent.
@@ -283,13 +292,7 @@ export function mapGenerationResult(
   const result: GenerationResult = {
     responseId: msg.responseId,
     responseModel: msg.model,
-    usage: {
-      inputTokens: msg.usage.input,
-      outputTokens: msg.usage.output,
-      totalTokens: msg.usage.totalTokens,
-      cacheReadInputTokens: msg.usage.cacheRead,
-      cacheWriteInputTokens: msg.usage.cacheWrite,
-    },
+    usage: mapPiUsage(msg.usage),
     stopReason: mapStopReason(msg.stopReason),
     completedAt: new Date(completedAtMs ?? msg.timestamp),
     metadata:
@@ -310,6 +313,206 @@ export function mapGenerationResult(
   ];
   if (output.length > 0) {
     result.output = output;
+  }
+
+  return result;
+}
+
+/**
+ * Pi's `Usage` shape, read structurally. Every field is optional because the
+ * plugin also reads usage off persisted session entries written by older pi
+ * versions, where the field may be missing entirely.
+ */
+export interface PiUsageLike {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  totalTokens?: number;
+  cost?: { total?: number };
+}
+
+/**
+ * Map pi usage to the SDK's `TokenUsage`. Shared by the turn path and the
+ * summary path so the two cannot drift.
+ *
+ * The field set is narrower than pi's `Usage`. `reasoning` and `cacheWrite1h`
+ * are not forwarded, and `totalTokens` is passed through as pi computes it
+ * (`input + output + cacheRead + cacheWrite`) instead of being recomputed to
+ * the Go launchers' `input + output`. Either change would move existing golden
+ * fixtures, so both stay as they are.
+ */
+export function mapPiUsage(usage: PiUsageLike): TokenUsage {
+  return {
+    inputTokens: usage.input ?? 0,
+    outputTokens: usage.output ?? 0,
+    totalTokens: usage.totalTokens ?? 0,
+    cacheReadInputTokens: usage.cacheRead ?? 0,
+    cacheWriteInputTokens: usage.cacheWrite ?? 0,
+  };
+}
+
+/** Token-count fields on pi's `Usage`. The `cost` block is not one of them. */
+export const PI_USAGE_TOKEN_FIELDS = [
+  "input",
+  "output",
+  "cacheRead",
+  "cacheWrite",
+  "totalTokens",
+] as const;
+
+/**
+ * True when the host reported at least one token count. A usage object that
+ * carries only a cost says nothing about tokens, and every token field is
+ * serialized on the exported record, so mapping it would report "0 tokens"
+ * where the truth is "unknown".
+ */
+function hasPiTokenCounts(usage: PiUsageLike): boolean {
+  return PI_USAGE_TOKEN_FIELDS.some((key) => Number.isFinite(usage[key]));
+}
+
+/**
+ * Which host summarization call produced a generation. `compaction` covers
+ * manual `/compact`, `ctx.compact()`, threshold auto-compaction, and
+ * context-overflow recovery; `branch_summary` covers tree-navigation
+ * summaries.
+ */
+export type PiSummaryKind = "compaction" | "branch_summary";
+
+/**
+ * Fields read off pi's persisted `CompactionEntry` / `BranchSummaryEntry`.
+ * Structural and fully optional: `usage` was added to those entries after the
+ * dev-pinned pi version, so it must degrade to `undefined` rather than fail
+ * type checking.
+ */
+export interface PiSummaryEntryLike {
+  id?: string;
+  timestamp?: string;
+  summary?: string;
+  /** Pre-compaction context estimate. Compaction entries only. */
+  tokensBefore?: number;
+  usage?: PiUsageLike;
+  /** True when an extension supplied the summary and no model call happened. */
+  fromHook?: boolean;
+}
+
+/** Inputs for {@link mapSummaryGenerationStart}. */
+export interface MapSummaryGenerationStartOptions {
+  kind: PiSummaryKind;
+  conversationId?: string;
+  conversationTitle?: string;
+  agentName: string;
+  agentVersion?: string;
+  model: { provider: string; name: string };
+  startedAt: number;
+  tags?: Record<string, string>;
+  generationId?: string;
+  parentGenerationIds?: string[];
+}
+
+/**
+ * Build the `GenerationStart` seed for a host summarization call.
+ *
+ * No `operationName` is set on purpose: the SYNC path (`startGeneration`)
+ * defaults it to `generateText`, which discriminates these calls from turns
+ * (`streamText`) without adding a new `gen_ai.operation.name` label value.
+ */
+export function mapSummaryGenerationStart(
+  opts: MapSummaryGenerationStartOptions,
+): GenerationStart {
+  const start: GenerationStart = {
+    conversationId: opts.conversationId,
+    ...(opts.conversationTitle
+      ? { conversationTitle: opts.conversationTitle }
+      : {}),
+    agentName: opts.agentName,
+    agentVersion: opts.agentVersion,
+    effectiveVersion: opts.agentVersion,
+    model: opts.model,
+    startedAt: new Date(opts.startedAt),
+    tags: { ...opts.tags, [PI_CALL_KIND_TAG]: opts.kind },
+  };
+  if (opts.generationId) {
+    start.id = opts.generationId;
+  }
+  if (opts.parentGenerationIds && opts.parentGenerationIds.length > 0) {
+    start.parentGenerationIds = opts.parentGenerationIds;
+  }
+  return start;
+}
+
+/** Inputs for {@link mapSummaryGenerationResult}. */
+export interface MapSummaryGenerationResultOptions {
+  entry: PiSummaryEntryLike;
+  contentCapture: ContentCaptureMode;
+  completedAt: number;
+  responseModel?: string;
+  /** `manual` | `threshold` | `overflow`, compaction only. */
+  reason?: string;
+  /** True when the aborted turn is retried after this compaction. */
+  willRetry?: boolean;
+}
+
+/**
+ * Build the `GenerationResult` for a host summarization call.
+ *
+ * The summary text goes in `output` as a single assistant text part, never in
+ * metadata or tags: content capture strips `output` but never touches
+ * `metadata`/`tags`, so a summary in metadata would leak in `metadata_only`.
+ * The gate is `contentCapture !== "metadata_only"`, matching assistant text on
+ * the turn path — the summary is assistant text, not a tool body, so the
+ * `no_tool_content` split does not apply to it.
+ *
+ * `usage` is omitted entirely when the entry reports no token counts. The
+ * exported record always serializes every token field, so a zeroed block
+ * reads as "this call used 0 tokens" rather than "the host did not say".
+ * `tokensBefore` is a context estimate for the whole conversation, not this
+ * call's input token count, so it stays in metadata.
+ *
+ * `cost_usd` is set whenever pi priced the call, including a cost of `0`,
+ * which is what the turn path does in {@link mapGenerationResult}.
+ */
+export function mapSummaryGenerationResult(
+  opts: MapSummaryGenerationResultOptions,
+): GenerationResult {
+  const { entry, contentCapture, completedAt } = opts;
+
+  const metadata: Record<string, unknown> = {};
+  const cost = entry.usage?.cost?.total;
+  if (typeof cost === "number") {
+    metadata.cost_usd = cost;
+  }
+  if (typeof entry.tokensBefore === "number") {
+    metadata["pi.tokens_before"] = entry.tokensBefore;
+  }
+  if (typeof opts.reason === "string" && opts.reason.length > 0) {
+    metadata["pi.compaction.reason"] = opts.reason;
+  }
+  if (typeof opts.willRetry === "boolean") {
+    metadata["pi.compaction.will_retry"] = opts.willRetry;
+  }
+
+  const result: GenerationResult = {
+    stopReason: "end_turn",
+    completedAt: new Date(completedAt),
+    metadata,
+  };
+  if (opts.responseModel) {
+    result.responseModel = opts.responseModel;
+  }
+  if (entry.usage && hasPiTokenCounts(entry.usage)) {
+    result.usage = mapPiUsage(entry.usage);
+  }
+
+  const summary = entry.summary;
+  if (
+    contentCapture !== "metadata_only" &&
+    typeof summary === "string" &&
+    summary.trim().length > 0
+  ) {
+    result.output = [
+      { role: "assistant", parts: [{ type: "text", text: summary }] },
+    ];
   }
 
   return result;

--- a/plugins/pi/src/testdata/golden/pi-compaction.golden.json
+++ b/plugins/pi/src/testdata/golden/pi-compaction.golden.json
@@ -1,0 +1,68 @@
+[
+  {
+    "path": "/api/v1/generations:export",
+    "generations": [
+      {
+        "id": "pi-0768336eaf3ef1a25ccb1d82",
+        "conversation_id": "pi-conv-1",
+        "operation_name": "generateText",
+        "mode": "GENERATION_MODE_SYNC",
+        "trace_id": "<NORMALIZED>",
+        "span_id": "<NORMALIZED>",
+        "model": {
+          "provider": "anthropic",
+          "name": "claude-sonnet-4-pi"
+        },
+        "response_id": "",
+        "response_model": "claude-sonnet-4-pi",
+        "system_prompt": "",
+        "input": [],
+        "output": [
+          {
+            "role": "MESSAGE_ROLE_ASSISTANT",
+            "name": "",
+            "parts": [
+              {
+                "text": "The user asked about go files; main.go and util.go were found."
+              }
+            ]
+          }
+        ],
+        "tools": [],
+        "usage": {
+          "input_tokens": "120000",
+          "output_tokens": "8000",
+          "total_tokens": "128000",
+          "cache_read_input_tokens": "0",
+          "cache_write_input_tokens": "0",
+          "reasoning_tokens": "0"
+        },
+        "stop_reason": "end_turn",
+        "started_at": "<NORMALIZED>",
+        "completed_at": "<NORMALIZED>",
+        "tags": {
+          "git.branch": "<NORMALIZED>",
+          "cwd": "<NORMALIZED>",
+          "pi.call_kind": "compaction"
+        },
+        "metadata": {
+          "cost_usd": 0.48,
+          "pi.tokens_before": 152000,
+          "pi.compaction.reason": "threshold",
+          "pi.compaction.will_retry": false,
+          "agento11y.conversation.title": "pi-conv-1",
+          "agento11y.sdk.name": "sdk-js",
+          "agento11y.sdk.content_capture_mode": "full"
+        },
+        "raw_artifacts": [],
+        "call_error": "",
+        "agent_name": "pi",
+        "agent_version": "test-version",
+        "parent_generation_ids": [
+          "pi-7d0cc91aec6a3962f720b126"
+        ],
+        "effective_version": "<NORMALIZED>"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
pi compacts the context and summarizes branches outside the agent loop, so no `turn_*` event fires and those model calls never reached Agent Observability. Handle `session_before_compact` / `session_compact` and `session_before_tree` / `session_tree`, and export one generation per call.