### PR TITLE
fix(python-frameworks/litellm): stop logging unevaluated requests as guards success

### DIFF
--- a/python-frameworks/litellm/README.md
+++ b/python-frameworks/litellm/README.md
@@ -178,7 +178,7 @@ Guardrail options are keyword-only, and `create_agento11y_litellm_guardrail` acc
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `client` | `agento11y.Client` | required | agento11y SDK client instance, with `hooks.enabled=True` |
+| `client` | `agento11y.Client` | required | agento11y SDK client instance, with `hooks.enabled=True` and `"preflight"` in `hooks.phases` |
 | `agent_name` | `str` | `""` | Fallback agent name when the request carries no agent identity |
 | `agent_name_metadata_keys` | `Sequence[str]` | `("agent_name", "agent_id")` | Metadata keys consulted, in order, to name the agent |
 | `agent_version` | `str` | `""` | Fallback agent version |
@@ -191,7 +191,7 @@ Guardrail options are keyword-only, and `create_agento11y_litellm_guardrail` acc
 Runtime behavior:
 
 - Evaluation runs on a pool of `max_concurrent_evaluations` threads, so it does not block the proxy event loop. `request_timeout_seconds` covers waiting for a free thread as well as the evaluation itself, and a thread stays busy until its evaluation actually finishes, so a slow evaluator can keep the pool saturated for longer than that timeout.
-- A timeout or an unexpected error follows `HooksConfig.fail_open`: allow and log at WARNING when `True` (the default), raise `HookTransportError` when `False`. A dead evaluator allows all traffic, and the log line is the only sign of it.
+- A transport failure, a timeout, or an unexpected error follows `HooksConfig.fail_open`: allow and log at WARNING when `True` (the default), raise `HookTransportError` when `False`. Either way the verdict is recorded as `guardrail_failed_to_respond`, not `success`, so a dead evaluator shows up in spend logs and logging callbacks.
 - Hook evaluations correlate to the proxy request span, so a guard verdict lines up with its request in traces.
 - Register both the guardrail and the logger. The guardrail does not export generations, and having both in `litellm.callbacks` still exports exactly one generation per request.
 

--- a/python-frameworks/litellm/agento11y_litellm/guard.py
+++ b/python-frameworks/litellm/agento11y_litellm/guard.py
@@ -12,14 +12,14 @@ import logging
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextvars import copy_context
-from functools import lru_cache
+from dataclasses import replace
+from functools import lru_cache, partial
 from typing import TYPE_CHECKING, Any
 
 import litellm
 from agento11y import Client
 from agento11y.errors import HookTransportError
 from agento11y.hooks import (
-    HookAction,
     HookContext,
     HookEvaluateRequest,
     HookEvaluateResponse,
@@ -152,6 +152,25 @@ class Agento11yLiteLLMGuardrail(CustomGuardrail):
             **kwargs,
         )
         self._client = client
+        # Snapshotted once: ``Client.hooks_config`` deep-copies on every read,
+        # and the client resolves its configuration at construction, so a
+        # per-request read would only pay for the copy.
+        hooks = client.hooks_config
+        # ``resolve_config`` normalizes an empty phase list to ``["preflight"]``,
+        # and the SDK defends against an empty one anyway; mirroring that keeps
+        # an empty list from reading as "preflight not configured".
+        phases = hooks.phases or [HookPhase.PREFLIGHT.value]
+        self._preflight_configured = hooks.enabled and HookPhase.PREFLIGHT.value in phases
+        self._fail_open = hooks.fail_open
+        # Evaluations are submitted fail-closed so an SDK-side transport failure
+        # reaches this adapter instead of resolving to a synthetic allow.
+        self._fail_closed_hooks = replace(hooks, fail_open=False)
+        if not self._preflight_configured:
+            logger.warning(
+                "agento11y: guardrail %r is registered but the client's hooks config does not enable preflight; "
+                "no request will be evaluated",
+                self.guardrail_name,
+            )
         self._agent_name = agent_name
         self._agent_name_metadata_keys = tuple(agent_name_metadata_keys)
         self._agent_version = agent_version
@@ -174,11 +193,22 @@ class Agento11yLiteLLMGuardrail(CustomGuardrail):
 
         Every gate that ends in "do not evaluate" sits outside the decorated
         body, so a request this guardrail did not check records no verdict at
-        all: the guardrail is not enabled for the request, the route carries
-        input this adapter cannot map, or the mapped input is empty. The proxy
-        applies the enablement gate before calling in, so that one only matters
-        for direct invocation.
+        all: the client's hooks config does not enable preflight, the guardrail
+        is not enabled for the request, the route carries input this adapter
+        cannot map, or the mapped input is empty. The proxy applies the
+        enablement gate before calling in, so that one only matters for direct
+        invocation.
+
+        A failed evaluation does record a verdict: the exception crosses
+        ``_run_preflight``'s decorator, which files
+        ``guardrail_failed_to_respond``, and this method then applies
+        ``HooksConfig.fail_open``.
         """
+        # Checked first: the result cannot change per request.
+        if not self._preflight_configured:
+            logger.debug("agento11y: skipping preflight evaluation, the client's hooks config disables preflight")
+            return None
+
         if not self.should_run_guardrail(data, GuardrailEventHooks.pre_call):
             return None
 
@@ -193,7 +223,17 @@ class Agento11yLiteLLMGuardrail(CustomGuardrail):
             logger.debug("agento11y: skipping preflight evaluation, request carries no evaluable text")
             return None
 
-        return await self._run_preflight(user_api_key_dict=user_api_key_dict, data=data, hook_input=hook_input)
+        try:
+            return await self._run_preflight(user_api_key_dict=user_api_key_dict, data=data, hook_input=hook_input)
+        except HookTransportError as exc:
+            if not self._fail_open:
+                raise
+            logger.warning(
+                "agento11y: guardrail %r allowing request (fail_open): %s",
+                self.guardrail_name,
+                exc,
+            )
+            return None
 
     @log_guardrail_information
     async def _run_preflight(self, *, user_api_key_dict: UserAPIKeyAuth, data: dict, hook_input: HookInput) -> None:
@@ -267,9 +307,15 @@ class Agento11yLiteLLMGuardrail(CustomGuardrail):
         for a worker and time running the evaluation. A timed-out evaluation
         that has started keeps its pool slot until urllib finishes.
 
-        Transport failures are already resolved inside the SDK according to
-        ``HooksConfig.fail_open``; the adapter's own timeout and unexpected
-        failures follow the same policy.
+        The call goes out fail-closed regardless of the configured policy, so a
+        transport failure raises here instead of resolving to an allow inside
+        the SDK: an allow the SDK synthesized is indistinguishable from a server
+        allow. Never return a synthetic allow from here, because LiteLLM files
+        it as a completed check. Every failure crosses the recording decorator
+        instead, and LiteLLM files it as ``guardrail_failed_to_respond`` with
+        the real duration. ``async_pre_call_hook`` applies
+        ``HooksConfig.fail_open`` afterwards, so the allow-or-raise outcome
+        still follows the configured policy.
         """
         try:
             loop = asyncio.get_running_loop()
@@ -277,22 +323,20 @@ class Agento11yLiteLLMGuardrail(CustomGuardrail):
             evaluation = loop.run_in_executor(
                 self._executor,
                 context.run,
-                self._client.evaluate_hook,
+                # Bound with partial because run_in_executor takes no keyword
+                # arguments.
+                partial(self._client.evaluate_hook, hooks=self._fail_closed_hooks),
                 request,
             )
             return await asyncio.wait_for(evaluation, self._request_timeout_seconds)
         except HookTransportError:
             raise
-        except asyncio.TimeoutError:
-            return self._fail_open_or_raise(f"timed out after {self._request_timeout_seconds}s")
+        except asyncio.TimeoutError as exc:
+            raise HookTransportError(
+                f"agento11y hook evaluation failed: timed out after {self._request_timeout_seconds}s"
+            ) from exc
         except Exception as exc:  # noqa: BLE001
-            return self._fail_open_or_raise(f"{type(exc).__name__}: {exc}")
-
-    def _fail_open_or_raise(self, detail: str) -> HookEvaluateResponse:
-        if self._client.hooks_config.fail_open:
-            logger.warning("agento11y: preflight hook evaluation failed, allowing request (fail_open): %s", detail)
-            return HookEvaluateResponse(action=HookAction.ALLOW.value)
-        raise HookTransportError(f"agento11y hook evaluation failed: {detail}")
+            raise HookTransportError(f"agento11y hook evaluation failed: {type(exc).__name__}: {exc}") from exc
 
 
 def _resolve_provider(data: dict, model_name: str) -> str:

--- a/python-frameworks/litellm/tests/test_litellm_guard.py
+++ b/python-frameworks/litellm/tests/test_litellm_guard.py
@@ -591,12 +591,40 @@ def test_invalid_limits_rejected_at_construction(kwargs, match):
     ],
     ids=["hooks-disabled", "preflight-phase-not-configured"],
 )
-def test_sdk_hook_configuration_short_circuits(hook_server, hooks):
+def test_client_without_preflight_records_no_verdict(hook_server, hooks):
+    """A client that does not enable preflight makes the guardrail a no-op.
+
+    Reaching the SDK would return a synthetic allow, which LiteLLM records as a
+    completed check: a proxy whose hooks are switched off would report a green
+    guard verdict on every request.
+    """
     client = _new_client(hook_server.url, hooks=hooks)
     guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+    data = _request_data()
 
-    assert _call(guard, _request_data()) is None
+    assert _call(guard, data) is None
     assert hook_server.requests == []
+    assert "standard_logging_guardrail_information" not in data["metadata"]
+
+
+@pytest.mark.parametrize(
+    "hooks",
+    [
+        HooksConfig(enabled=False),
+        HooksConfig(enabled=True, phases=["postflight"]),
+    ],
+    ids=["hooks-disabled", "preflight-phase-not-configured"],
+)
+def test_client_without_preflight_warns_at_construction(hook_server, caplog, hooks):
+    client = _new_client(hook_server.url, hooks=hooks)
+
+    with caplog.at_level(logging.WARNING):
+        Agento11yLiteLLMGuardrail(client=client, default_on=True, guardrail_name="agento11y-preflight")
+
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "agento11y-preflight" in warnings[0].getMessage()
+    assert "no request will be evaluated" in warnings[0].getMessage()
 
 
 def test_guardrail_not_enabled_for_request_is_skipped(hook_server):
@@ -637,20 +665,53 @@ def test_transport_failure_fail_open_allows_and_warns(hook_server, caplog):
     hook_server.close()  # nothing is listening on that port any more
     client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, timeout_seconds=1.0, fail_open=True))
     guard = Agento11yLiteLLMGuardrail(client=client, default_on=True, request_timeout_seconds=5.0)
+    data = _request_data()
 
     with caplog.at_level(logging.WARNING):
-        assert _call(guard, _request_data()) is None
+        assert _call(guard, data) is None
 
-    assert any("allowing request (fail_open)" in record.getMessage() for record in caplog.records)
+    warnings = [record for record in caplog.records if "allowing request (fail_open)" in record.getMessage()]
+    assert len(warnings) == 1
+    entry = _only_guardrail_entry(data)
+    assert entry["guardrail_status"] == "guardrail_failed_to_respond"
+    assert entry["duration"] > 0
 
 
 def test_transport_failure_fail_closed_raises(hook_server):
     hook_server.close()
     client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, timeout_seconds=1.0, fail_open=False))
     guard = Agento11yLiteLLMGuardrail(client=client, default_on=True, request_timeout_seconds=5.0)
+    data = _request_data()
 
     with pytest.raises(HookTransportError):
-        _call(guard, _request_data())
+        _call(guard, data)
+
+    entry = _only_guardrail_entry(data)
+    assert entry["guardrail_status"] == "guardrail_failed_to_respond"
+    assert entry["duration"] > 0
+
+
+def test_unexpected_evaluation_error_is_recorded_as_failed_to_respond(hook_server, monkeypatch):
+    """An adapter bug must not be filed as a completed guard check.
+
+    Fail-open still allows the request, but the recorded verdict has to say the
+    evaluation never produced one.
+    """
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, timeout_seconds=1.0, fail_open=True))
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True, request_timeout_seconds=5.0)
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(client, "evaluate_hook", _boom)
+    data = _request_data()
+
+    assert _call(guard, data) is None
+
+    entry = _only_guardrail_entry(data)
+    assert entry["guardrail_status"] == "guardrail_failed_to_respond"
+    assert "RuntimeError" in str(entry["guardrail_response"])
+    assert "boom" in str(entry["guardrail_response"])
 
 
 def test_slow_server_honors_request_timeout_and_fails_open(hook_server, caplog):
@@ -658,9 +719,11 @@ def test_slow_server_honors_request_timeout_and_fails_open(hook_server, caplog):
     client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, timeout_seconds=5.0, fail_open=True))
     guard = Agento11yLiteLLMGuardrail(client=client, default_on=True, request_timeout_seconds=0.1)
 
+    data = _request_data()
+
     async def _run() -> tuple[Any, float]:
         started = time.monotonic()
-        result = await _evaluate(guard, _request_data())
+        result = await _evaluate(guard, data)
         return result, time.monotonic() - started
 
     with caplog.at_level(logging.WARNING):
@@ -670,16 +733,26 @@ def test_slow_server_honors_request_timeout_and_fails_open(hook_server, caplog):
 
     assert result is None
     assert elapsed < 0.9
-    assert any("timed out after 0.1s" in record.getMessage() for record in caplog.records)
+    warnings = [record for record in caplog.records if "allowing request (fail_open)" in record.getMessage()]
+    assert len(warnings) == 1
+    assert "timed out after 0.1s" in warnings[0].getMessage()
+    entry = _only_guardrail_entry(data)
+    assert entry["guardrail_status"] == "guardrail_failed_to_respond"
+    assert entry["duration"] >= 0.1
 
 
 def test_adapter_timeout_respects_fail_closed(hook_server):
     hook_server.delay = 1.0
     client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, timeout_seconds=5.0, fail_open=False))
     guard = Agento11yLiteLLMGuardrail(client=client, default_on=True, request_timeout_seconds=0.1)
+    data = _request_data()
 
     with pytest.raises(HookTransportError, match="timed out"):
-        _call(guard, _request_data())
+        _call(guard, data)
+
+    entry = _only_guardrail_entry(data)
+    assert entry["guardrail_status"] == "guardrail_failed_to_respond"
+    assert entry["duration"] >= 0.1
 
 
 def test_event_loop_stays_responsive_during_evaluation(hook_server):
@@ -858,6 +931,13 @@ def test_public_factory_builds_a_configured_guardrail():
     assert guard.guardrail_name == "agento11y-preflight"
     assert guard.default_on is True
     assert guard.event_hook is GuardrailEventHooks.pre_call
+
+
+def _only_guardrail_entry(data: dict[str, Any]) -> dict[str, Any]:
+    """Return the single guardrail entry LiteLLM recorded for the request."""
+    entries = data["metadata"]["standard_logging_guardrail_information"]
+    assert len(entries) == 1
+    return entries[0]
 
 
 async def _evaluate(guard: Agento11yLiteLLMGuardrail, data: dict[str, Any]) -> Any:

--- a/python/README.md
+++ b/python/README.md
@@ -311,6 +311,16 @@ if response.transformed_input is not None:
 
 `HooksConfig` defaults to `phases=["preflight"]`, `timeout_seconds=15.0`, and `fail_open=True`. With fail-open enabled, hook transport errors resolve to allow so an unavailable evaluator does not block production traffic. Set `fail_open=False` for strict paths that should fail closed.
 
+`evaluate_hook` also takes a keyword-only `hooks` override that replaces the client's resolved hook configuration for that one call. It does not mutate the client, so later calls use the client configuration again:
+
+```python
+from dataclasses import replace
+
+response = client.evaluate_hook(request, hooks=replace(client.hooks_config, fail_open=False))
+```
+
+Use it when your caller has to tell a server allow from an allow the SDK synthesized after a failure. The response carries no marker separating the two, so a fail-open allow otherwise looks like a completed evaluation. `agento11y-litellm` calls fail-closed this way and applies the configured `fail_open` policy itself, after recording the failure as a guardrail verdict.
+
 Set `HookContext.conversation_id` to the same ID used by `start_generation(...)`. The SDK also reads `with_conversation_id(...)` and the active OpenTelemetry span when explicit correlation fields are omitted. This lets Agent Observability retain denied preflight attempts even though no LLM generation is created.
 
 If you use transformed input, pass the transformed messages/system prompt to the provider and record those same values in `start_generation(...)`. For a runnable example, see `../examples/getting-started/python-hooks/`.

--- a/python/agento11y/client.py
+++ b/python/agento11y/client.py
@@ -614,7 +614,12 @@ class Client:
 
         return copy.deepcopy(self._config.hooks)
 
-    def evaluate_hook(self, request: HookEvaluateRequest) -> HookEvaluateResponse:
+    def evaluate_hook(
+        self,
+        request: HookEvaluateRequest,
+        *,
+        hooks: HooksConfig | None = None,
+    ) -> HookEvaluateResponse:
         """Evaluates synchronous hook rules for the given request.
 
         Use this to enforce preflight (or postflight, when supported) guardrails
@@ -627,6 +632,20 @@ class Client:
         transport/decode failures also resolve to ``allow`` so the LLM call
         proceeds; set ``hooks.fail_open=False`` to surface
         :class:`agento11y.errors.HookTransportError` instead.
+
+        ``hooks`` replaces the resolved client configuration for this call only,
+        field for field. It is not a partial override: the JS SDK's
+        ``evaluateHook(request, hooksConfigOverride)`` merges the fields it is
+        given over the client configuration, while this parameter substitutes
+        the whole dataclass, so an omitted field falls back to the
+        ``HooksConfig`` default rather than the client's value. Build the
+        override from :attr:`hooks_config` with :func:`dataclasses.replace` to
+        keep every field the caller does not mean to change.
+
+        An adapter that reports the verdict to an external system passes
+        ``fail_open=False`` here: an allow the SDK synthesized for a dead
+        evaluator is otherwise indistinguishable from a server allow, so the
+        adapter would file a failed evaluation as a completed check.
         """
 
         self._assert_open()
@@ -634,7 +653,7 @@ class Client:
             api_endpoint=self._config.api.endpoint,
             insecure=self._config.generation_export.insecure,
             extra_headers=self._config.generation_export.headers,
-            hooks=self._config.hooks,
+            hooks=self._config.hooks if hooks is None else hooks,
             request=request,
         )
 

--- a/python/tests/test_hooks_transport.py
+++ b/python/tests/test_hooks_transport.py
@@ -6,6 +6,7 @@ import contextlib
 import json
 import threading
 from collections.abc import Iterator
+from dataclasses import replace
 from datetime import timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
@@ -367,6 +368,62 @@ def test_evaluate_hook_skips_mismatched_phase() -> None:
         client.shutdown()
         server.shutdown()
         server.server_close()
+
+
+def test_evaluate_hook_override_forces_fail_closed() -> None:
+    """A per-call override lets a caller see the transport failure itself.
+
+    An adapter that reports a verdict to an external system has to distinguish
+    a server allow from an SDK fail-open allow, and the response carries no
+    marker separating the two.
+    """
+    client = _new_client("http://127.0.0.1:1", hooks=HooksConfig(enabled=True, fail_open=True))
+    try:
+        with pytest.raises(HookTransportError):
+            client.evaluate_hook(
+                _preflight_request(),
+                hooks=replace(client.hooks_config, fail_open=False),
+            )
+
+        assert client.hooks_config.fail_open is True
+    finally:
+        client.shutdown()
+
+
+def test_evaluate_hook_override_enables_a_disabled_client_for_one_call() -> None:
+    with _capturing_hook_server({"action": "allow"}) as (captured, base_url):
+        client = _new_client(base_url, hooks=HooksConfig(enabled=False))
+        try:
+            response = client.evaluate_hook(
+                _preflight_request(),
+                hooks=HooksConfig(enabled=True, phases=["preflight"], fail_open=False),
+            )
+            assert response.action == "allow"
+            assert captured["path"] == "/api/v1/hooks:evaluate"
+
+            assert client.hooks_config.enabled is False
+            # The client's own configuration still short-circuits.
+            captured.clear()
+            assert client.evaluate_hook(_preflight_request()).action == "allow"
+            assert captured == {}
+        finally:
+            client.shutdown()
+
+
+def test_evaluate_hook_without_override_keeps_client_configuration() -> None:
+    client = _new_client("http://127.0.0.1:1", hooks=HooksConfig(enabled=True, fail_open=True))
+    try:
+        assert client.evaluate_hook(_preflight_request()).action == "allow"
+    finally:
+        client.shutdown()
+
+
+def _preflight_request() -> HookEvaluateRequest:
+    return HookEvaluateRequest(
+        phase=HookPhase.PREFLIGHT.value,
+        context=HookContext(model=HookModel(provider="openai", name="gpt-4o")),
+        input=HookInput(),
+    )
 
 
 def test_evaluate_hook_serializes_tool_definitions_including_deferred() -> None:


### PR DESCRIPTION
The guardrail recorded `guardrail_status: "success"` for requests where
no evaluation ran.

A verdict is now recorded only when an evaluation happened. If the
client's hooks config does not enable preflight, the guardrail warns once
at startup and skips every request. A failed evaluation, including a
timeout, is recorded as `guardrail_failed_to_respond`. `fail_open` still
decides whether such a request is allowed or raises.