### PR TITLE
feat(python-frameworks/litellm): support postflight guards

### DIFF
--- a/python-frameworks/litellm/README.md
+++ b/python-frameworks/litellm/README.md
@@ -117,18 +117,18 @@ A key alias names a credential rather than an agent, so it is not consulted by d
 
 ## Guards
 
-`Agento11yLiteLLMGuardrail` evaluates Agent Observability preflight guards before a request reaches the provider, and blocks it with HTTP 400 when a guard denies. It is a `CustomGuardrail`, so it gets LiteLLM's per-request and per-team opt-in, `default_on`, guardrail results in the standard logging payload, and an OTel guardrail span.
+`Agento11yLiteLLMGuardrail` evaluates Agent Observability guards on a proxy request: preflight guards before the request reaches the provider, postflight guards against the provider response. A deny returns HTTP 400 to the caller, including on a request that asked to stream, which is rejected before the first chunk. The one exception is a postflight deny on a streamed response: the output is already delivered, so the verdict is only recorded. It is a `CustomGuardrail`, so it gets LiteLLM's per-request and per-team opt-in, `default_on`, guardrail results in the standard logging payload, and an OTel guardrail span.
 
-Enforcement only works behind the LiteLLM proxy. Pre-call hooks are a proxy-only LiteLLM feature; a direct `litellm.completion()` SDK call never invokes them and is never guarded.
+Enforcement only works behind the LiteLLM proxy. Call hooks are a proxy-only LiteLLM feature; a direct `litellm.completion()` SDK call never invokes them and is never guarded.
 
-Only preflight is supported. The guardrail defaults to `event_hook="pre_call"`, and constructing it with `event_hook="post_call"` or `event_hook="during_call"` raises at proxy startup rather than registering a guardrail that silently never runs.
+`event_hook` selects the phases: `"pre_call"` (the default) for preflight, `"post_call"` for postflight, `["pre_call", "post_call"]` for both. `"during_call"` raises at proxy startup: LiteLLM runs it in parallel with the provider call, so it cannot save spend, and it is never given the response, so all it could do is repeat the preflight check after the call has started.
 
 Guards are configured in Agent Observability, not in `config.yaml`. Refer to [Set up guards](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/guides/guards/) for guard types, priority, and match filters.
 
-Evaluator guards work as documented there, against the request: messages, system prompt, and tool definitions. `deny` returns 400 to the proxy client and the provider is never called; `warn` allows the request and records the verdict. Three things behave differently through this adapter:
+Evaluator guards work as documented there: preflight sees messages, system prompt, and tool definitions; postflight adds the response. `deny` returns 400 to the proxy client, except for a postflight deny on a streamed response, which is only recorded (see [Postflight](#postflight)); `warn` allows the request and records the verdict. Three things behave differently through this adapter:
 
 - Redact guards do not change what the model sees. That page says the SDK uses `transformed_input` for the LLM call; this adapter ignores it. Redaction still applies to evaluators in later guards, which run server-side against the redacted input.
-- Tool filter guards match tool calls that are already in the request history, which means the client has executed them. They block the next call in an agent loop rather than the tool itself. Blocking a proposed call before it runs is postflight, which is not implemented here.
+- Preflight tool filter guards match tool calls that are already in the request history, which means the client has executed them. They block the next call in an agent loop rather than the tool itself. To block a proposed call before the client runs it, put the tool filter guard in the postflight phase, which sees the tool calls the model just produced.
 - `model.provider` match filters are unreliable, because the provider is not known until LiteLLM's router picks a deployment, which happens after the guard runs. Match on `agent_name`, `model.name`, or tags instead.
 
 ### Guarded routes
@@ -145,7 +145,34 @@ The guard reads the request body as the client sent it, before LiteLLM translate
 
 Every other route LiteLLM runs pre-call hooks on is skipped: embeddings, moderation, rerank, audio, realtime, MCP tool calls, and native pass-through endpoints (`/anthropic/v1/messages`, `/vertex_ai/...`). Their bodies are provider-native or carry no messages, so there is nothing for a content or system-prompt rule to match. They are skipped rather than evaluated against empty input, because an evaluation with no input returns allow and records a verdict that reads like a completed check. A skipped request records no verdict at all, and nothing on those routes is ever blocked, including by rules that only match on `agent_name`, `model.name`, or tags.
 
+Postflight skips the same routes, by a different test. The post-call hook is not given a call type, so the guard reads the request body: a body it cannot take messages, a prompt, or a system prompt from is skipped, which is what a pass-through body looks like (the provider-native payload sits one level down, under `data`).
+
 A guarded request whose input maps to no text is skipped the same way: a token-id `prompt`, or content that is entirely images or audio.
+
+### Postflight
+
+Postflight guards run after the provider has answered. They see the same request input as preflight plus the response, and they cannot prevent spend: the call is already made and billed by the time the rule runs. Postflight decides whether the output reaches the caller, not whether it costs money.
+
+What a deny does depends on how the response is delivered. This was verified against a running proxy on LiteLLM 1.89.1:
+
+| Delivery | Deny outcome |
+|---|---|
+| Non-streaming (`/v1/chat/completions`, `/v1/responses`, `/v1/messages`) | The caller gets HTTP 400 naming the guardrail and the rule's reason. The provider output never leaves the proxy. |
+| Streaming (`/v1/chat/completions`) | The caller already has the whole response. The verdict is recorded and logged at WARNING; nothing is blocked. |
+| Streaming (`/v1/responses`, `/v1/messages`) | Nothing runs. No hook request, no verdict, no log line. |
+
+Neither streaming case is a configuration choice. On a streamed chat completion LiteLLM flushes every chunk, then runs post-call guardrails on the assembled response (`_run_deferred_stream_guardrails`) and swallows whatever they raise. It attaches that deferred pass only to a `CustomStreamWrapper`, and `/v1/responses` and `/v1/messages` stream through their own iterators, so postflight never runs on them at all. Treat postflight on streaming traffic as detection that feeds evaluation and alerting, not as enforcement, and do not rely on it for those two routes.
+
+Postflight has two independent gates, and both must be open:
+
+- LiteLLM: the guardrail is constructed with `event_hook="post_call"` (or a list containing it). With the default `"pre_call"`, LiteLLM never calls the post-call hook.
+- SDK: `HooksConfig.phases` must contain `"postflight"`. It defaults to `["preflight"]`, and `evaluate_hook` returns allow without contacting the server for a phase that is not listed.
+
+A guardrail whose mode has no matching `HooksConfig.phases` entry logs a WARNING at startup and evaluates nothing for that phase. The request is skipped rather than evaluated, so it records no verdict either.
+
+The response is mapped per route: `choices[].message` for chat completions and for an assembled stream, `output` items for `/v1/responses`, and Anthropic content blocks for `/v1/messages`. Tool calls in the response keep their `tool_call` kind, so a postflight tool filter guard matches them. A response with no mappable text (an embedding, an image, an empty turn) is skipped and records no verdict.
+
+The guard reads the response the provider produced, not the copy LiteLLM logs, so `turn_off_message_logging` does not apply to it. Enabling postflight sends response content to the hooks API even on a deployment that keeps it out of its logs.
 
 Enable hooks on the agento11y client and list the guardrail next to the logger:
 
@@ -154,10 +181,24 @@ Enable hooks on the agento11y client and list the guardrail next to the logger:
 from agento11y import Client, ClientConfig, HooksConfig
 from agento11y_litellm import Agento11yLiteLLMGuardrail, Agento11yLiteLLMLogger
 
-client = Client(ClientConfig(hooks=HooksConfig(enabled=True, timeout_seconds=2.0)))
+client = Client(
+    ClientConfig(
+        hooks=HooksConfig(
+            enabled=True,
+            timeout_seconds=2.0,
+            # Drop "postflight" to run request rules only.
+            phases=["preflight", "postflight"],
+        )
+    )
+)
 
 agento11y_handler = Agento11yLiteLLMLogger(client=client, agent_name="litellm-proxy")
-agento11y_guards = Agento11yLiteLLMGuardrail(client=client, agent_name="litellm-proxy", default_on=True)
+agento11y_guards = Agento11yLiteLLMGuardrail(
+    client=client,
+    agent_name="litellm-proxy",
+    default_on=True,
+    event_hook=["pre_call", "post_call"],
+)
 ```
 
 ```yaml
@@ -168,7 +209,7 @@ litellm_settings:
     - agento11y_callback.agento11y_guards
 ```
 
-LiteLLM runs any `CustomGuardrail` in `litellm.callbacks` on the pre-call path, so the guardrail needs no separate `guardrails:` block.
+LiteLLM runs any `CustomGuardrail` in `litellm.callbacks` on both the pre-call and post-call paths, so the guardrail needs no separate `guardrails:` block.
 
 With `default_on=False`, a request opts in with `"guardrails": ["agento11y"]` in its metadata.
 
@@ -178,7 +219,7 @@ Guardrail options are keyword-only, and `create_agento11y_litellm_guardrail` acc
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `client` | `agento11y.Client` | required | agento11y SDK client instance, with `hooks.enabled=True` and `"preflight"` in `hooks.phases` |
+| `client` | `agento11y.Client` | required | agento11y SDK client instance, with `hooks.enabled=True` and the phase to evaluate in `hooks.phases` |
 | `agent_name` | `str` | `""` | Fallback agent name when the request carries no agent identity |
 | `agent_name_metadata_keys` | `Sequence[str]` | `("agent_name", "agent_id")` | Metadata keys consulted, in order, to name the agent |
 | `agent_version` | `str` | `""` | Fallback agent version |
@@ -187,13 +228,15 @@ Guardrail options are keyword-only, and `create_agento11y_litellm_guardrail` acc
 | `extra_tags` | `dict[str, str]` | `None` | Additional tags merged into every hook evaluation context |
 | `guardrail_name` | `str` | `"agento11y"` | Name used for per-request opt-in and in the 400 response |
 | `default_on` | `bool` | `False` | Run on every request instead of only on opted-in ones |
+| `event_hook` | `str \| Sequence[str]` | `"pre_call"` | Phases to run: `"pre_call"`, `"post_call"`, or both |
 
 Runtime behavior:
 
 - Evaluation runs on a pool of `max_concurrent_evaluations` threads, so it does not block the proxy event loop. `request_timeout_seconds` covers waiting for a free thread as well as the evaluation itself, and a thread stays busy until its evaluation actually finishes, so a slow evaluator can keep the pool saturated for longer than that timeout.
-- A transport failure, a timeout, or an unexpected error follows `HooksConfig.fail_open`: allow and log at WARNING when `True` (the default), raise `HookTransportError` when `False`. Either way the verdict is recorded as `guardrail_failed_to_respond`, not `success`, so a dead evaluator shows up in spend logs and logging callbacks.
+- A transport failure, a timeout, or an unexpected error follows `HooksConfig.fail_open`: allow and log at WARNING when `True` (the default), raise `HookTransportError` when `False`. Either way the verdict is recorded as `guardrail_failed_to_respond`, not `success`, so a dead evaluator shows up in spend logs and logging callbacks. Fail-closed costs more on postflight than on preflight: the provider has already answered and billed, and the caller gets HTTP 500 instead of the response.
 - Hook evaluations correlate to the proxy request span, so a guard verdict lines up with its request in traces.
 - Register both the guardrail and the logger. The guardrail does not export generations, and having both in `litellm.callbacks` still exports exactly one generation per request.
+- A non-streaming postflight deny costs a generation record. LiteLLM defers success logging until after post-call guardrails run and drops it when one of them raises, and the failure path does not reach this package's callback either, so the blocked request exports no generation at all. The provider was still called and billed. The verdict itself is in `standard_logging_guardrail_information`. A streamed deny keeps its generation, because nothing is raised there.
 
 ## LiteLLM Proxy (Docker)
 

--- a/python-frameworks/litellm/agento11y_litellm/__init__.py
+++ b/python-frameworks/litellm/agento11y_litellm/__init__.py
@@ -46,11 +46,15 @@ def create_agento11y_litellm_guardrail(
     extra_tags: dict[str, str] | None = None,
     guardrail_name: str = DEFAULT_GUARDRAIL_NAME,
     default_on: bool = False,
+    event_hook: str | Sequence[str] | None = None,
 ) -> Agento11yLiteLLMGuardrail:
-    """Create a LiteLLM guardrail that enforces agento11y preflight hook rules.
+    """Create a LiteLLM guardrail that enforces agento11y hook rules.
 
-    Enforcement only happens behind the LiteLLM proxy; pre-call hooks are never
+    Enforcement only happens behind the LiteLLM proxy; call hooks are never
     invoked on the ``litellm.completion()`` SDK path.
+
+    ``event_hook`` selects the phases: ``"pre_call"`` (the default) for
+    preflight, ``"post_call"`` for postflight, or both as a list.
     """
     return Agento11yLiteLLMGuardrail(
         client=client,
@@ -62,6 +66,7 @@ def create_agento11y_litellm_guardrail(
         extra_tags=extra_tags,
         guardrail_name=guardrail_name,
         default_on=default_on,
+        event_hook=event_hook,
     )
 
 

--- a/python-frameworks/litellm/agento11y_litellm/guard.py
+++ b/python-frameworks/litellm/agento11y_litellm/guard.py
@@ -1,8 +1,9 @@
-"""LiteLLM guardrail that enforces Agent Observability preflight hook rules.
+"""LiteLLM guardrail that enforces Agent Observability hook rules.
 
-Pre-call hooks are a proxy-only LiteLLM feature: ``ProxyLogging.pre_call_hook``
-invokes them, and nothing on the ``litellm.completion()`` SDK path does. A direct
-SDK call is therefore never guarded by this class.
+Call hooks are a proxy-only LiteLLM feature: ``ProxyLogging.pre_call_hook`` and
+``ProxyLogging.post_call_success_hook`` invoke them, and nothing on the
+``litellm.completion()`` SDK path does. A direct SDK call is therefore never
+guarded by this class.
 """
 
 from __future__ import annotations
@@ -13,13 +14,15 @@ from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextvars import copy_context
 from dataclasses import replace
+from datetime import datetime
 from functools import lru_cache, partial
 from typing import TYPE_CHECKING, Any
 
 import litellm
 from agento11y import Client
-from agento11y.errors import HookTransportError
+from agento11y.errors import HookDeniedError, HookTransportError
 from agento11y.hooks import (
+    HookAction,
     HookContext,
     HookEvaluateRequest,
     HookEvaluateResponse,
@@ -39,6 +42,8 @@ from .handler import (
     _extract_text_content,
     _first_metadata_value,
     _map_messages,
+    _map_response_output,
+    _map_responses_output,
     _map_tools_list,
     _metadata_sources_from,
     _request_tags_from,
@@ -63,8 +68,18 @@ DEFAULT_GUARDRAIL_NAME = "agento11y"
 UNKNOWN_PROVIDER = "unknown"
 UNKNOWN_MODEL = "unknown"
 
-# Only preflight is wired up. post_call arrives with postflight support.
-SUPPORTED_EVENT_HOOKS = (GuardrailEventHooks.pre_call,)
+# ``during_call`` (``async_moderation_hook``) is not supported. It runs in
+# parallel with the provider call, so it cannot save spend, and it is never
+# handed the response, so all it can do is repeat the preflight check after the
+# call has already started. A ``during_call`` deny does suppress the output:
+# LiteLLM awaits the moderation gather before it reads the provider response.
+SUPPORTED_EVENT_HOOKS = (GuardrailEventHooks.pre_call, GuardrailEventHooks.post_call)
+
+# The hook phase each supported mode evaluates.
+PHASE_FOR_EVENT_HOOK = {
+    GuardrailEventHooks.pre_call.value: HookPhase.PREFLIGHT.value,
+    GuardrailEventHooks.post_call.value: HookPhase.POSTFLIGHT.value,
+}
 
 # Call types this adapter can read request input from.
 #
@@ -107,20 +122,25 @@ _GUARD_FRAMEWORK_TAGS = {**FRAMEWORK_TAGS, "agento11y.framework.source": "guardr
 
 
 class Agento11yLiteLLMGuardrail(CustomGuardrail):
-    """Evaluates agento11y hook rules before a proxy request reaches the provider.
+    """Evaluates agento11y hook rules around a proxy request.
 
     Deliberately not a subclass of ``Agento11yLiteLLMLogger``. Both objects sit
     in ``litellm.callbacks`` at once, and a bare ``CustomGuardrail`` is harmless
     there only because it inherits ``CustomLogger``'s no-op logging methods. Give
     this class the logger's export behavior and every generation exports twice.
 
-    ``ProxyLogging.pre_call_hook`` walks ``litellm.callbacks`` and runs every
-    ``CustomGuardrail`` it finds, so a dotted path next to the logger is enough::
+    ``ProxyLogging.pre_call_hook`` and ``ProxyLogging.post_call_success_hook``
+    walk ``litellm.callbacks`` and run every ``CustomGuardrail`` they find, so a
+    dotted path next to the logger is enough::
 
         litellm_settings:
           callbacks:
             - agento11y_callback.agento11y_handler
             - agento11y_callback.agento11y_guards
+
+    ``event_hook`` selects the phases: ``pre_call`` (the default) evaluates
+    preflight rules before the provider is called, ``post_call`` evaluates
+    postflight rules against the response, and a list runs both.
     """
 
     def __init__(
@@ -140,14 +160,15 @@ class Agento11yLiteLLMGuardrail(CustomGuardrail):
         if request_timeout_seconds <= 0:
             raise ValueError(f"request_timeout_seconds must be greater than zero, got {request_timeout_seconds}")
 
-        event_hook = kwargs.pop("event_hook", None)
-        _reject_unsupported_event_hooks(event_hook)
+        event_hook = _normalized_event_hook(kwargs.pop("event_hook", None))
 
         super().__init__(
             guardrail_name=kwargs.pop("guardrail_name", None) or DEFAULT_GUARDRAIL_NAME,
             supported_event_hooks=list(SUPPORTED_EVENT_HOOKS),
             # Kept as configured so LiteLLM's tag-conditional Mode form keeps
-            # working.
+            # working. An unset mode means preflight only: LiteLLM reads None as
+            # "every phase", which would start sending postflight evaluations
+            # for every existing deployment on upgrade.
             event_hook=GuardrailEventHooks.pre_call if event_hook is None else event_hook,
             **kwargs,
         )
@@ -158,19 +179,20 @@ class Agento11yLiteLLMGuardrail(CustomGuardrail):
         hooks = client.hooks_config
         # ``resolve_config`` normalizes an empty phase list to ``["preflight"]``,
         # and the SDK defends against an empty one anyway; mirroring that keeps
-        # an empty list from reading as "preflight not configured".
+        # an empty list from reading as "no phase configured".
         phases = hooks.phases or [HookPhase.PREFLIGHT.value]
-        self._preflight_configured = hooks.enabled and HookPhase.PREFLIGHT.value in phases
+        self._configured_phases = frozenset(phases) if hooks.enabled else frozenset()
+        # The phases the configured modes evaluate. An unset mode is preflight,
+        # the same default ``super().__init__`` is given above.
+        self._guarded_phases = frozenset(
+            PHASE_FOR_EVENT_HOOK[mode]
+            for mode in _event_hook_values(event_hook) or [GuardrailEventHooks.pre_call.value]
+        )
         self._fail_open = hooks.fail_open
         # Evaluations are submitted fail-closed so an SDK-side transport failure
         # reaches this adapter instead of resolving to a synthetic allow.
         self._fail_closed_hooks = replace(hooks, fail_open=False)
-        if not self._preflight_configured:
-            logger.warning(
-                "agento11y: guardrail %r is registered but the client's hooks config does not enable preflight; "
-                "no request will be evaluated",
-                self.guardrail_name,
-            )
+        self._warn_about_unconfigured_phases()
         self._agent_name = agent_name
         self._agent_name_metadata_keys = tuple(agent_name_metadata_keys)
         self._agent_version = agent_version
@@ -193,11 +215,10 @@ class Agento11yLiteLLMGuardrail(CustomGuardrail):
 
         Every gate that ends in "do not evaluate" sits outside the decorated
         body, so a request this guardrail did not check records no verdict at
-        all: the client's hooks config does not enable preflight, the guardrail
-        is not enabled for the request, the route carries input this adapter
-        cannot map, or the mapped input is empty. The proxy applies the
-        enablement gate before calling in, so that one only matters for direct
-        invocation.
+        all: the SDK is not configured for the phase, the guardrail is not
+        enabled for the request, the route carries input this adapter cannot
+        map, or the mapped input is empty. The proxy applies the enablement gate
+        before calling in, so that one only matters for direct invocation.
 
         A failed evaluation does record a verdict: the exception crosses
         ``_run_preflight``'s decorator, which files
@@ -205,8 +226,8 @@ class Agento11yLiteLLMGuardrail(CustomGuardrail):
         ``HooksConfig.fail_open``.
         """
         # Checked first: the result cannot change per request.
-        if not self._preflight_configured:
-            logger.debug("agento11y: skipping preflight evaluation, the client's hooks config disables preflight")
+        if not self._phase_configured(HookPhase.PREFLIGHT):
+            logger.debug("agento11y: skipping preflight evaluation, the SDK is not configured for the phase")
             return None
 
         if not self.should_run_guardrail(data, GuardrailEventHooks.pre_call):
@@ -235,6 +256,97 @@ class Agento11yLiteLLMGuardrail(CustomGuardrail):
             )
             return None
 
+    async def async_post_call_success_hook(
+        self,
+        data: dict,
+        user_api_key_dict: UserAPIKeyAuth,
+        response: Any,
+    ) -> None:
+        """Evaluates agento11y postflight rules against the provider response.
+
+        Returns ``None`` so LiteLLM keeps the response it already has; a deny is
+        signalled by raising, not by returning a replacement.
+
+        The provider has already been called and billed by the time this runs.
+        Postflight decides whether the output reaches the caller, not whether the
+        request costs money.
+
+        What a deny can do depends on how the response is delivered:
+
+        - Non-streaming: ``ProxyLogging.post_call_success_hook`` is awaited in
+          ``base_process_llm_request`` before the route serializes anything, so
+          raising returns HTTP 400 and the provider output never leaves the
+          proxy.
+        - Streaming: LiteLLM has already flushed every chunk and calls this hook
+          on the assembled response from ``_run_deferred_stream_guardrails``,
+          which catches whatever it raises. A deny is recorded and logged in
+          ``_detect_postflight`` instead of raised, because raising buys nothing
+          and costs a traceback in the proxy log. Only a ``CustomStreamWrapper``
+          gets that deferred pass, so a streamed ``/v1/responses`` or
+          ``/v1/messages`` response never reaches this hook at all and produces
+          no verdict.
+
+        This class deliberately implements neither
+        ``async_post_call_streaming_iterator_hook`` nor ``apply_guardrail``.
+        Defining either makes ``_run_deferred_stream_guardrails`` take a
+        different branch and skip this hook on the streaming path, and
+        ``apply_guardrail`` also reroutes the non-streaming path through
+        ``UnifiedLLMGuardrails``, which bypasses this method as well.
+
+        Every gate that ends in "do not evaluate" sits above the two evaluating
+        methods, so a request this guardrail did not check records no verdict.
+
+        A failed evaluation does record a verdict: it is filed as
+        ``guardrail_failed_to_respond``, by the decorator on the enforcing path
+        and by hand on the streamed one, and this method then applies
+        ``HooksConfig.fail_open``.
+        """
+        # Checked first: the result cannot change per request.
+        if not self._phase_configured(HookPhase.POSTFLIGHT):
+            logger.debug("agento11y: skipping postflight evaluation, the SDK is not configured for the phase")
+            return None
+
+        if not self.should_run_guardrail(data, GuardrailEventHooks.post_call):
+            return None
+
+        hook_input = _hook_input(data)
+        if not hook_input.messages and not hook_input.system_prompt:
+            # Stands in for the call-type gate preflight applies: this hook is
+            # not given a call type, and a body this adapter cannot read input
+            # from is the same signal. It is also what a native pass-through
+            # request looks like, whose provider-native body sits under
+            # ``data["data"]``, so those routes stay unguarded on both phases.
+            logger.debug("agento11y: skipping postflight evaluation, request carries no evaluable text")
+            return None
+
+        output = _map_output_messages(response)
+        if not output:
+            # An embedding, an image, or a turn whose content this adapter
+            # cannot turn into text. Evaluating it would send empty output, get
+            # an allow back, and record a verdict that reads like a check.
+            logger.debug("agento11y: skipping postflight evaluation, response carries no evaluable text")
+            return None
+
+        hook_input.output = output
+
+        # LiteLLM decides to stream on ``data["stream"] is True``, so a body
+        # carrying ``1`` or ``"true"`` is served non-streamed and has to take the
+        # enforcing branch. The value is whatever the client sent; nothing
+        # coerces it before the hook runs.
+        run = self._detect_postflight if data.get("stream") is True else self._enforce_postflight
+
+        try:
+            return await run(user_api_key_dict=user_api_key_dict, data=data, hook_input=hook_input)
+        except HookTransportError as exc:
+            if not self._fail_open:
+                raise
+            logger.warning(
+                "agento11y: guardrail %r allowing the response (fail_open): %s",
+                self.guardrail_name,
+                exc,
+            )
+            return None
+
     @log_guardrail_information
     async def _run_preflight(self, *, user_api_key_dict: UserAPIKeyAuth, data: dict, hook_input: HookInput) -> None:
         """Evaluate preflight rules and translate a deny into a proxy 400.
@@ -254,10 +366,161 @@ class Agento11yLiteLLMGuardrail(CustomGuardrail):
         if denied is None:
             return None
 
-        detail = f"{denied.reason} (rule {denied.rule_id})" if denied.rule_id else denied.reason
-        raise GuardrailRaisedException(
+        raise self._denied_exception(denied)
+
+    @log_guardrail_information
+    async def _enforce_postflight(
+        self,
+        *,
+        user_api_key_dict: UserAPIKeyAuth,
+        data: dict,
+        hook_input: HookInput,
+    ) -> None:
+        """Evaluate postflight rules and translate a deny into a proxy 400.
+
+        Runs for a response the proxy has not sent yet. ``transformed_input`` is
+        ignored for the same reason as preflight: the SDK's wire parser keeps
+        only text and thinking parts, so applying it would drop tool calls and
+        tool results.
+
+        The decorator infers the recorded guardrail mode from the wrapped
+        function's name and falls back to ``self.event_hook`` for a name it does
+        not know (``custom_guardrail.py``). A guardrail registered for both modes
+        therefore records both modes on each entry; the phase is unambiguous in
+        the hook request itself.
+        """
+        response = await self._evaluate(self._postflight_request(data, user_api_key_dict, hook_input))
+        denied = hook_denied_from_response(response)
+        if denied is None:
+            return None
+
+        raise self._denied_exception(denied)
+
+    async def _detect_postflight(
+        self,
+        *,
+        user_api_key_dict: UserAPIKeyAuth,
+        data: dict,
+        hook_input: HookInput,
+    ) -> None:
+        """Evaluate postflight rules for a response the caller already has.
+
+        A deny cannot be enforced on a streamed response, so it is recorded as an
+        intervention that says so and nothing is raised.
+
+        Deliberately not wrapped in ``log_guardrail_information``: a deny has to
+        be filed by hand, and the decorator files a normal return as ``success``
+        on top of it. Its flag for a guardrail that records its own verdict
+        (``_guardrail_self_recorded``) only exists from LiteLLM 1.95.0, and this
+        package supports 1.82.3, so relying on it would double-file every
+        streamed verdict on an older proxy. Every outcome is therefore recorded
+        here, including the two the decorator would have handled.
+        """
+        request = self._postflight_request(data, user_api_key_dict, hook_input)
+
+        started = datetime.now()
+        try:
+            response = await self._evaluate(request)
+        except HookTransportError as exc:
+            self._record_postflight_verdict(data, started, "guardrail_failed_to_respond", str(exc))
+            raise
+
+        denied = hook_denied_from_response(response)
+        if denied is None:
+            self._record_postflight_verdict(data, started, "success", {"action": HookAction.ALLOW.value})
+            return None
+
+        logger.warning(
+            "agento11y: postflight rule denied a streamed response that has already been delivered "
+            "to the caller, recording the verdict only: %s",
+            _denial_detail(denied),
+        )
+        self._record_postflight_verdict(
+            data,
+            started,
+            "guardrail_intervened",
+            {
+                "action": HookAction.DENY.value,
+                "rule_id": denied.rule_id,
+                "reason": denied.reason,
+                # The only field that tells a recorded deny from an enforced one.
+                "enforced": False,
+            },
+        )
+        return None
+
+    def _postflight_request(
+        self,
+        data: dict,
+        user_api_key_dict: UserAPIKeyAuth,
+        hook_input: HookInput,
+    ) -> HookEvaluateRequest:
+        return HookEvaluateRequest(
+            phase=HookPhase.POSTFLIGHT.value,
+            context=self._context(data, user_api_key_dict),
+            input=hook_input,
+        )
+
+    def _record_postflight_verdict(self, data: dict, started: datetime, status: str, payload: Any) -> None:
+        """File one postflight verdict the way the decorator would.
+
+        The timings are passed for the reason the decorator passes them: without
+        them the OTel exporter stamps the guardrail span at export time and
+        reports a near-zero duration.
+        """
+        ended = datetime.now()
+        self.add_standard_logging_guardrail_information_to_request_data(
+            guardrail_json_response=payload,
+            request_data=data,
+            guardrail_status=status,
+            start_time=started.timestamp(),
+            end_time=ended.timestamp(),
+            duration=(ended - started).total_seconds(),
+            event_type=GuardrailEventHooks.post_call,
+        )
+
+    def _phase_configured(self, phase: HookPhase) -> bool:
+        """Whether the SDK will evaluate this phase against the server.
+
+        Mirrors the gate in ``agento11y.hooks.evaluate_hook``, which returns
+        allow without contacting the server when hooks are disabled or the phase
+        is not listed. Reading it here keeps that case out of the decorated
+        body: the decorator would otherwise record a passed check, so an
+        operator who set ``event_hook="post_call"`` but left ``HooksConfig``
+        alone would see "N evaluated, N passed" for rules that never ran.
+        """
+        return phase.value in self._configured_phases
+
+    def _warn_about_unconfigured_phases(self) -> None:
+        """Warn at startup about a phase this guardrail runs but the SDK will not evaluate.
+
+        A guardrail whose mode has no matching ``HooksConfig.phases`` entry is
+        silent otherwise: it skips every request and records no verdict.
+        """
+        unconfigured = sorted(self._guarded_phases - self._configured_phases)
+        if not unconfigured:
+            return
+
+        if self._guarded_phases & self._configured_phases:
+            logger.warning(
+                "agento11y: guardrail %r runs on %s but the client's hooks config does not enable it; "
+                "that phase will not be evaluated",
+                self.guardrail_name,
+                ", ".join(unconfigured),
+            )
+            return
+
+        logger.warning(
+            "agento11y: guardrail %r is registered but the client's hooks config does not enable %s; "
+            "no request will be evaluated",
+            self.guardrail_name,
+            ", ".join(unconfigured),
+        )
+
+    def _denied_exception(self, denied: HookDeniedError) -> GuardrailRaisedException:
+        return GuardrailRaisedException(
             guardrail_name=self.guardrail_name,
-            message=f"blocked by guardrail {self.guardrail_name}: {detail}",
+            message=f"blocked by guardrail {self.guardrail_name}: {_denial_detail(denied)}",
             should_wrap_with_default_message=False,
         )
 
@@ -313,9 +576,9 @@ class Agento11yLiteLLMGuardrail(CustomGuardrail):
         allow. Never return a synthetic allow from here, because LiteLLM files
         it as a completed check. Every failure crosses the recording decorator
         instead, and LiteLLM files it as ``guardrail_failed_to_respond`` with
-        the real duration. ``async_pre_call_hook`` applies
-        ``HooksConfig.fail_open`` afterwards, so the allow-or-raise outcome
-        still follows the configured policy.
+        the real duration. The calling hook applies ``HooksConfig.fail_open``
+        afterwards, so the allow-or-raise outcome still follows the configured
+        policy.
         """
         try:
             loop = asyncio.get_running_loop()
@@ -333,10 +596,50 @@ class Agento11yLiteLLMGuardrail(CustomGuardrail):
             raise
         except asyncio.TimeoutError as exc:
             raise HookTransportError(
-                f"agento11y hook evaluation failed: timed out after {self._request_timeout_seconds}s"
+                f"agento11y {request.phase} hook evaluation failed: timed out after {self._request_timeout_seconds}s"
             ) from exc
         except Exception as exc:  # noqa: BLE001
-            raise HookTransportError(f"agento11y hook evaluation failed: {type(exc).__name__}: {exc}") from exc
+            raise HookTransportError(
+                f"agento11y {request.phase} hook evaluation failed: {type(exc).__name__}: {exc}"
+            ) from exc
+
+
+def _denial_detail(denied: HookDeniedError) -> str:
+    """Render a deny verdict as one line of reason plus rule id."""
+    return f"{denied.reason} (rule {denied.rule_id})" if denied.rule_id else denied.reason
+
+
+def _map_output_messages(response: Any) -> list[Message]:
+    """Map a provider response into agento11y output messages.
+
+    Each route hands the post-call hook a different object: a ``ModelResponse``
+    for chat completions and for an assembled stream, a ``ResponsesAPIResponse``
+    for ``/v1/responses``, and a plain Anthropic-shaped dict for ``/v1/messages``
+    (LiteLLM normalizes that one to chat shape for logging, but not here).
+
+    The shape is read off the payload rather than off a call type, because this
+    hook is not given one.
+    """
+    payload = _response_payload(response)
+    if payload is None:
+        return []
+    if isinstance(payload, dict) and not payload.get("choices") and isinstance(payload.get("output"), list):
+        return _map_responses_output(payload)
+    return _map_response_output(payload)
+
+
+def _response_payload(response: Any) -> Any:
+    """Reduce a LiteLLM response object to the dict or string the mappers read."""
+    if response is None or isinstance(response, (str, dict)):
+        return response
+    dump = getattr(response, "model_dump", None)
+    if dump is None:
+        return None
+    try:
+        return dump()
+    except Exception:  # noqa: BLE001
+        logger.debug("agento11y: could not read %s as a response payload", type(response).__name__)
+        return None
 
 
 def _resolve_provider(data: dict, model_name: str) -> str:
@@ -376,19 +679,35 @@ def _provider_for_model(model_name: str) -> str:
     return provider or UNKNOWN_PROVIDER
 
 
-def _reject_unsupported_event_hooks(event_hook: Any) -> None:
-    """Raise on any configured mode other than ``pre_call``.
+def _normalized_event_hook(event_hook: Any) -> Any:
+    """Validate the configured mode and coerce it to a shape LiteLLM matches.
 
-    A guardrail configured with an unsupported mode would silently never run;
-    failing at construction surfaces the misconfiguration at proxy startup.
+    A guardrail that runs on no phase runs silently, so both ways of building
+    one fail at construction instead:
+
+    - A mode this adapter does not implement. ``during_call`` and
+      ``logging_only`` are valid LiteLLM modes, so nothing downstream objects.
+    - A sequence with no modes in it, which matches nothing whatever its type.
+
+    A tuple or a set is rewritten as a list. ``_event_hook_is_event_type``
+    special-cases a list and a ``Mode`` and compares everything else to the mode
+    string, an equality no tuple or set can satisfy.
     """
     supported = {hook.value for hook in SUPPORTED_EVENT_HOOKS}
-    for mode in _event_hook_values(event_hook):
+    modes = _event_hook_values(event_hook)
+    for mode in modes:
         if mode not in supported:
             raise ValueError(
-                f"Agento11yLiteLLMGuardrail does not support mode {mode!r}; "
-                f"supported modes: {sorted(supported)}. Postflight evaluation is not implemented yet."
+                f"Agento11yLiteLLMGuardrail does not support mode {mode!r}; supported modes: {sorted(supported)}."
             )
+    if isinstance(event_hook, (list, tuple, set)):
+        if not modes:
+            raise ValueError(
+                f"Agento11yLiteLLMGuardrail needs at least one mode, got {event_hook!r}; "
+                f"supported modes: {sorted(supported)}."
+            )
+        return modes
+    return event_hook
 
 
 def _event_hook_values(event_hook: Any) -> list[str]:

--- a/python-frameworks/litellm/agento11y_litellm/handler.py
+++ b/python-frameworks/litellm/agento11y_litellm/handler.py
@@ -336,8 +336,11 @@ def _tool_result_message(*, content: str, tool_call_id: str, name: str) -> Messa
 def _map_response_output(response: Any) -> list[Message]:
     """Map SLO response to agento11y output Messages.
 
-    Reads from the StandardLoggingPayload ``response`` field (dict or str)
-    so that LiteLLM redaction settings are honoured.
+    Takes a response payload as a dict or a string. The logger passes the
+    StandardLoggingPayload ``response`` field, which LiteLLM has already
+    redacted. The guard passes the live response object instead, because a rule
+    has to see the content the caller would see, so a postflight evaluation
+    sends unredacted output even under ``turn_off_message_logging``.
 
     Chat shape (``choices[].message``) covers every route that reaches here,
     including ``/v1/messages``: LiteLLM converts the Anthropic response to a

--- a/python-frameworks/litellm/tests/test_litellm_guard.py
+++ b/python-frameworks/litellm/tests/test_litellm_guard.py
@@ -26,7 +26,10 @@ from agento11y_litellm import (
     create_agento11y_litellm_guardrail,
 )
 from litellm.exceptions import GuardrailRaisedException
+from litellm.integrations import custom_guardrail
 from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.llms.openai import ResponsesAPIResponse
+from litellm.types.utils import ModelResponse
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 
@@ -542,7 +545,7 @@ def test_transformed_input_is_ignored(hook_server):
     assert data["messages"] == [{"role": "user", "content": "hello"}]
 
 
-@pytest.mark.parametrize("mode", ["post_call", "during_call", "logging_only"])
+@pytest.mark.parametrize("mode", ["during_call", "logging_only"])
 def test_unsupported_modes_rejected_at_construction(mode):
     client = _new_client("http://127.0.0.1:1")
     with pytest.raises(ValueError, match=mode):
@@ -565,8 +568,39 @@ def test_pre_call_mode_is_accepted_in_every_shape(hook_server, event_hook):
 
 def test_unsupported_mode_in_list_rejected_at_construction():
     client = _new_client("http://127.0.0.1:1")
-    with pytest.raises(ValueError, match="post_call"):
-        Agento11yLiteLLMGuardrail(client=client, event_hook=["pre_call", "post_call"])
+    with pytest.raises(ValueError, match="during_call"):
+        Agento11yLiteLLMGuardrail(client=client, event_hook=["pre_call", "during_call"])
+
+
+@pytest.mark.parametrize("event_hook", [[], (), set()], ids=["list", "tuple", "set"])
+def test_empty_event_hook_rejected_at_construction(event_hook):
+    """An empty sequence matches no mode, so the guardrail would never run."""
+    client = _new_client("http://127.0.0.1:1")
+    with pytest.raises(ValueError, match="at least one mode"):
+        Agento11yLiteLLMGuardrail(client=client, event_hook=event_hook)
+
+
+@pytest.mark.parametrize(
+    ("event_hook", "want"),
+    [
+        pytest.param(("pre_call", "post_call"), ["pre_call", "post_call"], id="tuple"),
+        pytest.param({"pre_call"}, ["pre_call"], id="set"),
+        pytest.param((GuardrailEventHooks.pre_call,), ["pre_call"], id="tuple-of-enums"),
+    ],
+)
+def test_a_sequence_of_modes_is_normalized_to_a_list(hook_server, event_hook, want):
+    """LiteLLM matches a list and compares anything else to the mode string.
+
+    A tuple or a set never equals ``"pre_call"``, so an unnormalized one builds
+    a guardrail that runs on no phase and says nothing about it.
+    """
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, event_hook=event_hook, default_on=True)
+
+    assert guard.event_hook == want
+    assert guard.should_run_guardrail(_request_data(), GuardrailEventHooks.pre_call) is True
+    assert _call(guard, _request_data()) is None
+    assert len(hook_server.requests) == 1
 
 
 @pytest.mark.parametrize(
@@ -608,23 +642,55 @@ def test_client_without_preflight_records_no_verdict(hook_server, hooks):
 
 
 @pytest.mark.parametrize(
-    "hooks",
+    ("kwargs", "hooks", "want"),
     [
-        HooksConfig(enabled=False),
-        HooksConfig(enabled=True, phases=["postflight"]),
+        pytest.param(
+            {},
+            HooksConfig(enabled=False),
+            ("preflight", "no request will be evaluated"),
+            id="hooks-disabled",
+        ),
+        pytest.param(
+            {},
+            HooksConfig(enabled=True, phases=["postflight"]),
+            ("preflight", "no request will be evaluated"),
+            id="preflight-phase-not-configured",
+        ),
+        pytest.param(
+            {"event_hook": "post_call"},
+            HooksConfig(enabled=True, phases=["preflight"]),
+            ("postflight", "no request will be evaluated"),
+            id="postflight-phase-not-configured",
+        ),
+        pytest.param(
+            {"event_hook": ["pre_call", "post_call"]},
+            HooksConfig(enabled=True, phases=["preflight"]),
+            ("postflight", "that phase will not be evaluated"),
+            id="one-of-two-phases-configured",
+        ),
     ],
-    ids=["hooks-disabled", "preflight-phase-not-configured"],
 )
-def test_client_without_preflight_warns_at_construction(hook_server, caplog, hooks):
+def test_guardrail_warns_at_construction_about_an_unconfigured_phase(hook_server, caplog, kwargs, hooks, want):
+    """A mode with no matching ``HooksConfig.phases`` entry is silent otherwise."""
     client = _new_client(hook_server.url, hooks=hooks)
 
     with caplog.at_level(logging.WARNING):
-        Agento11yLiteLLMGuardrail(client=client, default_on=True, guardrail_name="agento11y-preflight")
+        Agento11yLiteLLMGuardrail(client=client, default_on=True, guardrail_name="agento11y-guard", **kwargs)
 
     warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
     assert len(warnings) == 1
-    assert "agento11y-preflight" in warnings[0].getMessage()
-    assert "no request will be evaluated" in warnings[0].getMessage()
+    assert "agento11y-guard" in warnings[0].getMessage()
+    for fragment in want:
+        assert fragment in warnings[0].getMessage()
+
+
+def test_a_guardrail_whose_every_phase_is_configured_warns_about_nothing(hook_server, caplog):
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, phases=["preflight", "postflight"]))
+
+    with caplog.at_level(logging.WARNING):
+        Agento11yLiteLLMGuardrail(client=client, default_on=True, event_hook=["pre_call", "post_call"])
+
+    assert [record for record in caplog.records if record.levelno == logging.WARNING] == []
 
 
 def test_guardrail_not_enabled_for_request_is_skipped(hook_server):
@@ -916,6 +982,487 @@ def test_guardrail_and_logger_register_without_double_export(hook_server):
     assert len(generations) == 1
 
 
+def _chat_response(content: str = "here is the secret") -> ModelResponse:
+    return ModelResponse(
+        id="chatcmpl-1",
+        model="gpt-4o",
+        choices=[{"index": 0, "finish_reason": "stop", "message": {"role": "assistant", "content": content}}],
+    )
+
+
+def _responses_api_response(content: str = "here is the secret") -> ResponsesAPIResponse:
+    return ResponsesAPIResponse(
+        id="resp-1",
+        created_at=1,
+        model="gpt-4o",
+        object="response",
+        output=[
+            {
+                "type": "message",
+                "id": "msg-1",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": content, "annotations": []}],
+            }
+        ],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+        status="completed",
+    )
+
+
+_NO_RESPONSE = object()
+
+
+def _post_call(
+    guard: Agento11yLiteLLMGuardrail,
+    data: dict[str, Any],
+    response: Any = _NO_RESPONSE,
+) -> Any:
+    """Run the post-call hook, defaulting to a plain chat response.
+
+    ``None`` is itself a response under test, so the default is a sentinel.
+    """
+    return asyncio.run(
+        guard.async_post_call_success_hook(
+            data=data,
+            user_api_key_dict=_UserAPIKey(),
+            response=_chat_response() if response is _NO_RESPONSE else response,
+        )
+    )
+
+
+def _postflight_guard(client: Client, **kwargs: Any) -> Agento11yLiteLLMGuardrail:
+    return Agento11yLiteLLMGuardrail(client=client, event_hook="post_call", default_on=True, **kwargs)
+
+
+def test_postflight_allow_returns_none_and_leaves_the_response_untouched(hook_server):
+    hook_server.response = {"action": "allow"}
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, phases=["preflight", "postflight"]))
+    guard = _postflight_guard(client)
+    response = _chat_response()
+    before = response.model_dump()
+
+    assert _post_call(guard, _request_data(), response) is None
+
+    assert len(hook_server.requests) == 1
+    assert response.model_dump() == before
+
+
+def test_postflight_request_carries_the_phase_the_request_and_the_output(hook_server):
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, phases=["postflight"]))
+    guard = _postflight_guard(client, agent_version="1.2.3", extra_tags={"team": "search"})
+    data = _request_data(
+        messages=[
+            {"role": "system", "content": "policy"},
+            {"role": "user", "content": "hello"},
+        ],
+        metadata={"agent_id": "search-agent", "session_id": "conv-7"},
+    )
+
+    assert _post_call(guard, data) is None
+
+    payload = hook_server.payloads[0]
+    assert payload["phase"] == "postflight"
+    assert payload["context"]["agent_name"] == "search-agent"
+    assert payload["context"]["conversation_id"] == "conv-7"
+    assert payload["context"]["model"] == {"provider": "openai", "name": "gpt-4o"}
+    assert payload["context"]["tags"]["team"] == "search"
+    assert payload["input"]["system_prompt"] == "policy"
+    assert [m["parts"][0]["text"] for m in payload["input"]["messages"]] == ["hello"]
+    assert [m["role"] for m in payload["input"]["output"]] == ["assistant"]
+    assert [part["text"] for m in payload["input"]["output"] for part in m["parts"]] == ["here is the secret"]
+
+
+@pytest.mark.parametrize(
+    ("response", "want_texts"),
+    [
+        pytest.param(_chat_response("chat text"), ["chat text"], id="chat_model_response"),
+        pytest.param(_responses_api_response("responses text"), ["responses text"], id="responses_api_response"),
+        pytest.param(
+            {
+                "id": "msg-1",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "anthropic text"}],
+                "stop_reason": "end_turn",
+            },
+            ["anthropic text"],
+            id="anthropic_messages_dict",
+        ),
+    ],
+)
+def test_postflight_maps_the_output_of_every_response_shape(hook_server, response, want_texts):
+    """Each route hands the hook a different object.
+
+    ``/v1/chat/completions`` and streamed responses arrive as a ``ModelResponse``,
+    ``/v1/responses`` as a ``ResponsesAPIResponse``, and ``/v1/messages`` as a
+    plain Anthropic-shaped dict. A mapper that reads only ``choices`` sends an
+    empty output for two of the three, and a rule written against the response
+    matches nothing.
+    """
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, phases=["postflight"]))
+    guard = _postflight_guard(client)
+
+    assert _post_call(guard, _request_data(), response) is None
+
+    output = hook_server.payloads[0]["input"]["output"]
+    assert [part["text"] for m in output for part in m["parts"]] == want_texts
+
+
+def test_postflight_tool_calls_in_the_output_keep_their_kind(hook_server):
+    """A tool-filter guard blocks a proposed call only if it arrives as a tool_call part."""
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, phases=["postflight"]))
+    guard = _postflight_guard(client)
+    response = ModelResponse(
+        id="chatcmpl-1",
+        model="gpt-4o",
+        choices=[
+            {
+                "index": 0,
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "shell_exec", "arguments": '{"cmd":"rm -rf /"}'},
+                        }
+                    ],
+                },
+            }
+        ],
+    )
+
+    assert _post_call(guard, _request_data(), response) is None
+
+    output = hook_server.payloads[0]["input"]["output"]
+    assert [[part["kind"] for part in m["parts"]] for m in output] == [["tool_call"]]
+    assert output[0]["parts"][0]["tool_call"]["name"] == "shell_exec"
+    assert output[0]["parts"][0]["tool_call"]["input_json"] == {"cmd": "rm -rf /"}
+
+
+def test_postflight_deny_blocks_a_non_streaming_response(hook_server):
+    """A non-streaming deny reaches the caller as a 400 and the output is suppressed.
+
+    Verified against a live proxy: ``ProxyLogging.post_call_success_hook`` is
+    awaited before the route serializes the response, so the exception replaces
+    the provider output instead of arriving after it.
+    """
+    hook_server.response = {"action": "deny", "rule_id": "no-secrets", "reason": "sensitive output"}
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, phases=["postflight"]))
+    guard = _postflight_guard(client, guardrail_name="agento11y-postflight")
+    data = _request_data()
+
+    with pytest.raises(GuardrailRaisedException) as excinfo:
+        _post_call(guard, data)
+
+    assert "sensitive output" in str(excinfo.value)
+    assert "no-secrets" in str(excinfo.value)
+    assert excinfo.value.guardrail_name == "agento11y-postflight"
+    assert excinfo.value.status_code == 400
+    entries = data["metadata"]["standard_logging_guardrail_information"]
+    assert [entry["guardrail_status"] for entry in entries] == ["guardrail_intervened"]
+
+
+def test_postflight_deny_on_a_streamed_response_records_without_blocking(hook_server, caplog):
+    """A streamed response is already delivered, so a deny can only be recorded.
+
+    LiteLLM runs this hook on the assembled response after the last chunk has
+    been flushed (``_run_deferred_stream_guardrails``) and swallows whatever it
+    raises, so raising would produce a proxy traceback and nothing else.
+    """
+    hook_server.response = {"action": "deny", "rule_id": "no-secrets", "reason": "sensitive output"}
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, phases=["postflight"]))
+    guard = _postflight_guard(client)
+    data = _request_data(stream=True)
+    response = _chat_response()
+
+    with caplog.at_level(logging.WARNING):
+        assert _post_call(guard, data, response) is None
+
+    assert response.choices[0].message.content == "here is the secret"
+    assert any("already been delivered" in record.getMessage() for record in caplog.records)
+    entries = data["metadata"]["standard_logging_guardrail_information"]
+    assert [entry["guardrail_status"] for entry in entries] == ["guardrail_intervened"]
+    assert entries[0]["guardrail_response"]["reason"] == "sensitive output"
+    # The only field that tells a recorded deny apart from an enforced one.
+    assert entries[0]["guardrail_response"]["enforced"] is False
+
+
+def test_streamed_deny_record_carries_its_own_timings(hook_server):
+    """The record is written by hand, so it has to carry what the decorator would.
+
+    Without timings the OTel exporter stamps the guardrail span at export time
+    and reports a near-zero duration.
+    """
+    hook_server.response = {"action": "deny", "rule_id": "no-secrets", "reason": "sensitive output"}
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, phases=["postflight"]))
+    guard = _postflight_guard(client)
+    data = _request_data(stream=True)
+
+    assert _post_call(guard, data) is None
+
+    entry = data["metadata"]["standard_logging_guardrail_information"][0]
+    assert entry["start_time"] is not None
+    assert entry["end_time"] >= entry["start_time"]
+    assert entry["duration"] >= 0
+
+
+class _NeverSelfRecorded:
+    """Stands in for the flag LiteLLM added in 1.95.0, on a version without it."""
+
+    def set(self, value: bool) -> None:
+        return None
+
+    def get(self) -> bool:
+        return False
+
+    def reset(self, token: Any) -> None:
+        return None
+
+
+@pytest.mark.parametrize(
+    ("hook_response", "hook_status", "want_status"),
+    [
+        pytest.param({"action": "allow"}, 200, "success", id="allow"),
+        pytest.param(
+            {"action": "deny", "rule_id": "no-secrets", "reason": "sensitive output"},
+            200,
+            "guardrail_intervened",
+            id="deny",
+        ),
+        pytest.param({}, 500, "guardrail_failed_to_respond", id="evaluation-failed"),
+    ],
+)
+def test_a_streamed_verdict_is_recorded_once_without_litellm_s_self_record_flag(
+    hook_server,
+    monkeypatch,
+    hook_response,
+    hook_status,
+    want_status,
+):
+    """LiteLLM before 1.95.0 has no flag for a guardrail that files its own verdict.
+
+    On those versions ``log_guardrail_information`` appends a passing entry after
+    a normal return whatever the wrapped function recorded, so a hand-filed deny
+    reads as denied and passed at once. This package supports 1.82.3, so the
+    streamed path files every verdict itself and stays undecorated.
+    """
+    monkeypatch.setattr(custom_guardrail, "_guardrail_self_recorded", _NeverSelfRecorded(), raising=False)
+    hook_server.response = hook_response
+    hook_server.status = hook_status
+    client = _new_client(
+        hook_server.url,
+        hooks=HooksConfig(enabled=True, phases=["postflight"], timeout_seconds=1.0, fail_open=True),
+    )
+    guard = _postflight_guard(client)
+    data = _request_data(stream=True)
+
+    assert _post_call(guard, data) is None
+
+    assert _only_guardrail_entry(data)["guardrail_status"] == want_status
+
+
+@pytest.mark.parametrize("stream", [1, "true", "True"], ids=["int", "lowercase-string", "string"])
+def test_postflight_deny_blocks_a_request_whose_stream_flag_is_truthy_but_not_true(hook_server, stream):
+    """LiteLLM streams on ``data["stream"] is True`` and nothing coerces the value.
+
+    A client that sends ``"stream": 1`` is served non-streamed, so a deny has to
+    raise. Reading the flag as truthy would take the record-only branch and hand
+    the denied content to the caller with HTTP 200.
+    """
+    hook_server.response = {"action": "deny", "rule_id": "no-secrets", "reason": "sensitive output"}
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, phases=["postflight"]))
+    guard = _postflight_guard(client)
+
+    with pytest.raises(GuardrailRaisedException):
+        _post_call(guard, _request_data(stream=stream))
+
+
+def test_preflight_deny_blocks_a_streaming_request(hook_server):
+    """Only postflight downgrades to recording on a stream.
+
+    Preflight runs before routing, so a streamed request is rejected before the
+    first chunk and the caller still gets a 400.
+    """
+    hook_server.response = {"action": "deny", "rule_id": "no-secrets", "reason": "blocked"}
+    client = _new_client(hook_server.url)
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+
+    with pytest.raises(GuardrailRaisedException):
+        _call(guard, _request_data(stream=True))
+
+
+def test_postflight_allow_records_a_success_verdict(hook_server):
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, phases=["postflight"]))
+    guard = _postflight_guard(client)
+    data = _request_data()
+
+    _post_call(guard, data)
+
+    entries = data["metadata"]["standard_logging_guardrail_information"]
+    assert [entry["guardrail_status"] for entry in entries] == ["success"]
+    assert entries[0]["guardrail_name"] == DEFAULT_GUARDRAIL_NAME
+
+
+@pytest.mark.parametrize(
+    "hooks",
+    [
+        HooksConfig(enabled=False),
+        HooksConfig(enabled=True),
+        HooksConfig(enabled=True, phases=["preflight"]),
+    ],
+    ids=["hooks-disabled", "default-phases", "postflight-phase-not-configured"],
+)
+def test_postflight_does_not_run_when_the_sdk_phase_is_not_configured(hook_server, hooks):
+    """``mode: post_call`` is only one of the two gates; ``HooksConfig.phases`` is the other.
+
+    The gate has to sit outside the decorated body. Left to
+    ``Client.evaluate_hook``, it returns allow without contacting the server and
+    the decorator records a passed check, so a deployment that enabled
+    ``post_call`` and left ``HooksConfig`` alone reports every response as
+    evaluated and passed.
+    """
+    client = _new_client(hook_server.url, hooks=hooks)
+    guard = _postflight_guard(client)
+    response = _chat_response()
+    data = _request_data()
+
+    assert _post_call(guard, data, response) is None
+    assert hook_server.requests == []
+    assert "standard_logging_guardrail_information" not in data["metadata"]
+
+
+def test_postflight_does_not_run_on_a_body_it_cannot_read_input_from(hook_server):
+    """Stands in for the call-type gate preflight applies.
+
+    The post-call hook is not given a call type, and a native pass-through body
+    sits under ``data["data"]``, so the request input is the only signal that
+    this is not a route the adapter guards.
+    """
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, phases=["postflight"]))
+    guard = _postflight_guard(client)
+    data = {
+        "model": "claude-3-5-sonnet",
+        "data": {"messages": [{"role": "user", "content": "hello"}]},
+        "metadata": {},
+    }
+
+    assert _post_call(guard, data) is None
+    assert hook_server.requests == []
+    assert "standard_logging_guardrail_information" not in data["metadata"]
+
+
+def test_postflight_transport_failure_fail_closed_raises(hook_server):
+    """Fail-closed turns an already-billed provider success into a proxy 500."""
+    hook_server.status = 500
+    client = _new_client(
+        hook_server.url,
+        hooks=HooksConfig(enabled=True, phases=["postflight"], timeout_seconds=1.0, fail_open=False),
+    )
+    guard = _postflight_guard(client)
+    data = _request_data()
+
+    with pytest.raises(HookTransportError):
+        _post_call(guard, data)
+
+    assert _only_guardrail_entry(data)["guardrail_status"] == "guardrail_failed_to_respond"
+
+
+def test_postflight_does_not_run_when_the_guardrail_is_not_enabled_for_the_request(hook_server):
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, phases=["postflight"]))
+    guard = Agento11yLiteLLMGuardrail(client=client, event_hook="post_call", default_on=False)
+    data = _request_data()
+
+    assert _post_call(guard, data) is None
+    assert hook_server.requests == []
+    assert "standard_logging_guardrail_information" not in data["metadata"]
+
+
+def test_postflight_does_not_run_on_a_preflight_only_guardrail(hook_server):
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, phases=["preflight", "postflight"]))
+    guard = Agento11yLiteLLMGuardrail(client=client, default_on=True)
+
+    assert _post_call(guard, _request_data()) is None
+    assert hook_server.requests == []
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        pytest.param(litellm.ImageResponse(created=1, data=[{"url": "https://example.test/cat.png"}]), id="image"),
+        pytest.param(_chat_response(""), id="empty_content"),
+        pytest.param(None, id="no_response"),
+    ],
+)
+def test_postflight_records_no_verdict_when_the_response_carries_no_text(hook_server, response):
+    """A response this adapter cannot read is skipped rather than sent as empty output.
+
+    An evaluation with no output returns allow and records a verdict that reads
+    like a completed check.
+    """
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, phases=["postflight"]))
+    guard = _postflight_guard(client)
+    data = _request_data()
+
+    assert _post_call(guard, data, response) is None
+    assert hook_server.requests == []
+    assert "standard_logging_guardrail_information" not in data["metadata"]
+
+
+def test_both_phases_evaluate_exactly_once_each_for_one_request(hook_server):
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, phases=["preflight", "postflight"]))
+    guard = Agento11yLiteLLMGuardrail(client=client, event_hook=["pre_call", "post_call"], default_on=True)
+    data = _request_data()
+
+    assert _call(guard, data) is None
+    assert _post_call(guard, data) is None
+
+    assert [payload["phase"] for payload in hook_server.payloads] == ["preflight", "postflight"]
+    entries = data["metadata"]["standard_logging_guardrail_information"]
+    assert len(entries) == 2
+
+
+@pytest.mark.parametrize(
+    "event_hook",
+    ["post_call", GuardrailEventHooks.post_call, ["post_call"]],
+    ids=["string", "enum", "list"],
+)
+def test_post_call_mode_is_accepted_in_every_shape(hook_server, event_hook):
+    client = _new_client(hook_server.url, hooks=HooksConfig(enabled=True, phases=["postflight"]))
+    guard = Agento11yLiteLLMGuardrail(client=client, event_hook=event_hook, default_on=True)
+
+    assert guard.event_hook == event_hook
+    assert _post_call(guard, _request_data()) is None
+    assert len(hook_server.requests) == 1
+
+
+def test_postflight_slow_server_honors_request_timeout_and_names_the_phase(hook_server, caplog):
+    hook_server.delay = 1.0
+    client = _new_client(
+        hook_server.url,
+        hooks=HooksConfig(enabled=True, phases=["postflight"], timeout_seconds=5.0, fail_open=True),
+    )
+    guard = _postflight_guard(client, request_timeout_seconds=0.1)
+
+    data = _request_data()
+
+    with caplog.at_level(logging.WARNING):
+        assert _post_call(guard, data) is None
+
+    assert any(
+        "postflight hook evaluation failed" in record.getMessage() and "timed out after 0.1s" in record.getMessage()
+        for record in caplog.records
+    )
+    entry = _only_guardrail_entry(data)
+    assert entry["guardrail_status"] == "guardrail_failed_to_respond"
+    assert entry["duration"] >= 0.1
+
+
 def test_public_factory_builds_a_configured_guardrail():
     client = _new_client("http://127.0.0.1:1")
     guard = create_agento11y_litellm_guardrail(
@@ -931,6 +1478,13 @@ def test_public_factory_builds_a_configured_guardrail():
     assert guard.guardrail_name == "agento11y-preflight"
     assert guard.default_on is True
     assert guard.event_hook is GuardrailEventHooks.pre_call
+
+
+def test_public_factory_accepts_postflight_mode():
+    client = _new_client("http://127.0.0.1:1")
+    guard = create_agento11y_litellm_guardrail(client=client, event_hook=["pre_call", "post_call"])
+
+    assert guard.event_hook == ["pre_call", "post_call"]
 
 
 def _only_guardrail_entry(data: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
Adds postflight [guards](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/guides/guards/) to the LiteLLM adapter. Postflight rules run after the provider has answered and see the request input plus the response.

`event_hook` selects the phases: `"pre_call"` for preflight, `"post_call"` for postflight, a list for both. `"pre_call"` stays the default, so an existing deployment keeps evaluating preflight only until it opts in.

Example:

```python
# agento11y_callback.py, next to config.yaml
from agento11y import Client, ClientConfig, HooksConfig
from agento11y_litellm import Agento11yLiteLLMGuardrail, Agento11yLiteLLMLogger

client = Client(
    ClientConfig(
        hooks=HooksConfig(
            enabled=True,
            timeout_seconds=2.0,
            phases=["preflight", "postflight"],
        )
    )
)

agento11y_handler = Agento11yLiteLLMLogger(client=client, agent_name="litellm-proxy")
agento11y_guards = Agento11yLiteLLMGuardrail(
    client=client,
    agent_name="litellm-proxy",
    default_on=True,
    event_hook=["pre_call", "post_call"],
)
```

```yaml
litellm_settings:
  callbacks:
    - agento11y_callback.agento11y_handler
    - agento11y_callback.agento11y_guards
```