### PR TITLE
feat(plugins/agento11y): enable local mode with AGENTO11Y_LOCAL env var

### DIFF
--- a/plugins/agento11y/internal/doctor/doctor.go
+++ b/plugins/agento11y/internal/doctor/doctor.go
@@ -63,6 +63,7 @@ var trackedSuffixes = []string{
 	"CONTENT_CAPTURE_MODE",
 	"TAGS",
 	"AUTO_UPDATE",
+	"LOCAL",
 	"LOCAL_FORWARD",
 	// GUARDS_ENABLED is tracked for LocalHookForward only. Everything else
 	// reads the guard settings through envconfig.ResolveGuards, which is the
@@ -149,6 +150,13 @@ type ConfigSection struct {
 	GuardsFellBack      bool              `json:"guards_fell_back,omitempty"`
 	Tags                map[string]string `json:"tags,omitempty"`
 	TagsSource          string            `json:"tags_source,omitempty"`
+	// Local is the resolved LOCAL family: whether `agento11y <agent>` starts in
+	// local mode without --local, and where the value came from.
+	Local envValue `json:"local"`
+	// LocalInvalid reports that the LOCAL value is set to something outside the
+	// boolean whitelist. The launcher ignores such a value, so the report has to
+	// say the setting is not in effect.
+	LocalInvalid bool `json:"local_invalid,omitempty"`
 	// LocalForward is the resolved LOCAL_FORWARD family: whether a `--local`
 	// daemon also forwards what it captures to Cloud, and where the value came
 	// from. The daemon itself resolves config.env ahead of its own environment
@@ -521,6 +529,13 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 		}
 	}
 
+	// LOCAL turns every launcher run into a local session, so report the
+	// effective value and where it came from.
+	localMode := resolveFamily("LOCAL", osEnv, fileEnv)
+	localOn, localValid := envconfig.ParseBoolValue(localMode.value)
+	sec.Local = localMode.envValue()
+	sec.LocalInvalid = localMode.set && !localValid
+
 	// LOCAL_FORWARD sends a copy of every --local session to Cloud, so make the
 	// effective value and its source visible.
 	forward := resolveFamily("LOCAL_FORWARD", osEnv, fileEnv)
@@ -569,6 +584,22 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 	if forward.set && forward.source == sourceEnv && strings.TrimSpace(fileEnv[envconfig.PreferredKey("LOCAL_FORWARD")]+fileEnv[envconfig.LegacyKey("LOCAL_FORWARD")]) != "" {
 		sec.Messages = append(sec.Messages, fmt.Sprintf(
 			"%s is set in the environment and in config.env; the local daemon uses the config.env value", forward.key))
+	}
+	if sec.LocalInvalid {
+		sec.Health = HealthWarn
+		sec.Messages = append(sec.Messages, fmt.Sprintf(
+			"the %s value is not a boolean; local mode stays off", localMode.key))
+	}
+	if localMode.legacyWon() {
+		sec.Messages = append(sec.Messages,
+			"local mode set via legacy SIGIL_LOCAL — this keeps working, but the preferred name is AGENTO11Y_LOCAL")
+	}
+	if localOn {
+		// The launcher is the only thing that reads this family, so a user who
+		// reads it as "nothing leaves this machine" is wrong about every other
+		// way a session starts.
+		sec.Messages = append(sec.Messages,
+			"local mode covers `agento11y <agent>` launches; sessions the host agent starts on its own, such as Cursor or a plain `claude`, keep exporting to the configured endpoint")
 	}
 	return sec
 }

--- a/plugins/agento11y/internal/doctor/doctor_test.go
+++ b/plugins/agento11y/internal/doctor/doctor_test.go
@@ -644,6 +644,152 @@ func TestCollectConfig_Tags(t *testing.T) {
 	}
 }
 
+// TestCollectConfig_Local covers the LOCAL row: doctor reports the value the
+// launcher acts on (shell before config.env), renders it, warns when the value
+// is not a boolean, and states that local mode stops at the launcher.
+func TestCollectConfig_Local(t *testing.T) {
+	// The table below builds osEnv by hand, so it cannot catch a family missing
+	// from the snapshot the binary actually passes in. Without the entry, a
+	// shell-exported AGENTO11Y_LOCAL reads as unset here while the launcher acts
+	// on it.
+	if !slices.Contains(trackedSuffixes, "LOCAL") {
+		t.Fatal("LOCAL must be in trackedSuffixes or SnapshotEnv drops it and this report reads it as unset")
+	}
+	const scopeMsg = "local mode covers `agento11y <agent>` launches"
+	tests := []struct {
+		name            string
+		osEnv           map[string]string
+		fileEnv         map[string]string
+		wantValue       string // "" means the family is unset
+		wantSource      string
+		wantInvalid     bool
+		wantHealth      Health
+		wantScopeMsg    bool
+		wantMsg         string // substring of a ConfigSection message
+		wantRendered    []string
+		wantNotRendered []string
+	}{
+		{
+			name:            "unset",
+			wantHealth:      HealthOK,
+			wantNotRendered: []string{"local mode"},
+		},
+		{
+			name:         "from config.env",
+			fileEnv:      map[string]string{"AGENTO11Y_LOCAL": "true"},
+			wantValue:    "true",
+			wantSource:   sourceConfig,
+			wantHealth:   HealthOK,
+			wantScopeMsg: true,
+			wantRendered: []string{"local mode", "true (config.env)"},
+		},
+		{
+			name:         "from env",
+			osEnv:        map[string]string{"AGENTO11Y_LOCAL": "true"},
+			wantValue:    "true",
+			wantSource:   sourceEnv,
+			wantHealth:   HealthOK,
+			wantScopeMsg: true,
+			wantRendered: []string{"local mode", "true (env)"},
+		},
+		{
+			name:         "legacy spelling",
+			osEnv:        map[string]string{"SIGIL_LOCAL": "on"},
+			wantValue:    "on",
+			wantSource:   sourceEnv,
+			wantHealth:   HealthOK,
+			wantScopeMsg: true,
+			wantMsg:      "the preferred name is AGENTO11Y_LOCAL",
+			wantRendered: []string{"on (env)"},
+		},
+		{
+			// The one-off Cloud session: the shell value is what the launcher
+			// acts on, so it is what doctor must report.
+			name:            "shell false overrides config.env true",
+			osEnv:           map[string]string{"AGENTO11Y_LOCAL": "false"},
+			fileEnv:         map[string]string{"AGENTO11Y_LOCAL": "true"},
+			wantValue:       "false",
+			wantSource:      sourceEnv,
+			wantHealth:      HealthOK,
+			wantRendered:    []string{"false (env)"},
+			wantNotRendered: []string{"invalid value"},
+		},
+		{
+			// The launcher ignores a value outside the boolean whitelist, so a
+			// report that prints it plainly confirms the wrong belief.
+			name:         "value outside the boolean whitelist",
+			osEnv:        map[string]string{"AGENTO11Y_LOCAL": "enabled"},
+			wantValue:    "enabled",
+			wantSource:   sourceEnv,
+			wantInvalid:  true,
+			wantHealth:   HealthWarn,
+			wantMsg:      "the AGENTO11Y_LOCAL value is not a boolean; local mode stays off",
+			wantRendered: []string{"enabled (env)", "invalid value, local mode is off"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateEnv(t)
+			sec := collectConfig(tc.osEnv, tc.fileEnv)
+			if sec.Local.Set != (tc.wantValue != "") {
+				t.Fatalf("Local.Set = %v, want %v", sec.Local.Set, tc.wantValue != "")
+			}
+			if sec.Local.Value != tc.wantValue {
+				t.Fatalf("Local.Value = %q, want %q", sec.Local.Value, tc.wantValue)
+			}
+			if sec.Local.Source != tc.wantSource {
+				t.Fatalf("Local.Source = %q, want %q", sec.Local.Source, tc.wantSource)
+			}
+			if sec.LocalInvalid != tc.wantInvalid {
+				t.Fatalf("LocalInvalid = %v, want %v", sec.LocalInvalid, tc.wantInvalid)
+			}
+			if sec.Health != tc.wantHealth {
+				t.Fatalf("Health = %q, want %q (messages %v)", sec.Health, tc.wantHealth, sec.Messages)
+			}
+
+			joined := strings.Join(sec.Messages, " ")
+			if tc.wantMsg != "" && !strings.Contains(joined, tc.wantMsg) {
+				t.Fatalf("messages %v missing %q", sec.Messages, tc.wantMsg)
+			}
+			if got := strings.Contains(joined, scopeMsg); got != tc.wantScopeMsg {
+				t.Fatalf("scope message present = %v, want %v (messages %v)", got, tc.wantScopeMsg, sec.Messages)
+			}
+
+			var buf bytes.Buffer
+			renderHuman(&buf, &Report{Config: sec}, false, false)
+			rendered := buf.String()
+			for _, want := range tc.wantRendered {
+				if !strings.Contains(rendered, want) {
+					t.Fatalf("rendered report missing %q:\n%s", want, rendered)
+				}
+			}
+			for _, none := range tc.wantNotRendered {
+				if strings.Contains(rendered, none) {
+					t.Fatalf("rendered report contains %q:\n%s", none, rendered)
+				}
+			}
+		})
+	}
+}
+
+// TestCollect_LocalModeScopeReachesTheReport pins the wiring: the scope message
+// has to survive Collect, not just collectConfig, or the whole warning is
+// invisible in the command a user actually runs.
+func TestCollect_LocalModeScopeReachesTheReport(t *testing.T) {
+	isolateEnv(t)
+	stubSeams(t)
+	writeConfig(t, "AGENTO11Y_LOCAL=true\n")
+
+	r := Collect(context.Background(), Options{}, Params{Version: "1.2.3"})
+	if !r.Config.Local.Set || r.Config.Local.Value != "true" {
+		t.Fatalf("Config.Local = %+v, want the config.env value", r.Config.Local)
+	}
+	joined := strings.Join(r.Config.Messages, " ")
+	if !strings.Contains(joined, "local mode covers `agento11y <agent>` launches") {
+		t.Fatalf("report messages %v missing the local-mode scope message", r.Config.Messages)
+	}
+}
+
 // TestCollectConfig_LocalForward covers the LOCAL_FORWARD attribution: doctor
 // reports shell-first like every other family, and calls out the case where the
 // local daemon (which prefers config.env) would use the other value.
@@ -683,10 +829,9 @@ func TestCollectConfig_LocalForward(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			// collectConfig resolves LOCAL_FORWARD from its arguments, so the
+			// table needs no exported values.
 			isolateEnv(t)
-			for k, v := range tc.osEnv {
-				t.Setenv(k, v)
-			}
 			sec := collectConfig(tc.osEnv, tc.fileEnv)
 			if sec.LocalForward.Set != tc.wantSet {
 				t.Fatalf("LocalForward.Set = %v, want %v", sec.LocalForward.Set, tc.wantSet)

--- a/plugins/agento11y/internal/doctor/render.go
+++ b/plugins/agento11y/internal/doctor/render.go
@@ -127,6 +127,13 @@ func renderHuman(w io.Writer, r *Report, color, probed bool) {
 	if len(r.Config.Tags) > 0 {
 		writeKV(&b, p, "tags", fmt.Sprintf("%s %s", formatTags(r.Config.Tags), p.faint("("+r.Config.TagsSource+")")))
 	}
+	if r.Config.Local.Set {
+		localMode := describeEnv(r.Config.Local)
+		if r.Config.LocalInvalid {
+			localMode += " " + p.faint("(invalid value, local mode is off)")
+		}
+		writeKV(&b, p, "local mode", localMode)
+	}
 	if r.Config.LocalForward.Set {
 		writeKV(&b, p, "local forwarding", describeEnv(r.Config.LocalForward))
 	}

--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -3,19 +3,23 @@
 // binary used by the Claude Code, Codex, Copilot, Cursor, OpenCode, pi, and
 // Vibe agent plugins. It accepts:
 //
-//	agento11y <agent> hook                                — dispatch a JSON hook payload on stdin to <agent>
-//	agento11y claude   [--local] [--tag k=v] [-- args...] — exec claude after bootstrapping the agento11y-claude-code plugin
-//	agento11y codex    [--local] [--tag k=v] [-- args...] — exec codex after bootstrapping the agento11y-codex plugin
-//	agento11y copilot  [--local] [--tag k=v] [-- args...] — exec copilot after bootstrapping the sigil-copilot plugin
-//	agento11y opencode [--local] [--tag k=v] [-- args...] — exec opencode after bootstrapping the @grafana/agento11y-opencode plugin
-//	agento11y pi       [--local] [--tag k=v] [-- args...] — exec pi after bootstrapping the @grafana/agento11y-pi extension
-//	agento11y vibe     [--local] [--tag k=v] [-- args...] — exec vibe after installing the sigil hook in vibe's hooks.toml
-//	agento11y cursor   install|uninstall                  — wire (or remove) the Cursor hook in ~/.cursor/hooks.json
-//	agento11y local start|status|stop                     — manage the local capture daemon
-//	agento11y --version                                   — print the build version
+//	agento11y <agent> hook                                            — dispatch a JSON hook payload on stdin to <agent>
+//	agento11y claude   [--local|--no-local] [--tag k=v] [-- args...]  — exec claude after bootstrapping the agento11y-claude-code plugin
+//	agento11y codex    [--local|--no-local] [--tag k=v] [-- args...]  — exec codex after bootstrapping the agento11y-codex plugin
+//	agento11y copilot  [--local|--no-local] [--tag k=v] [-- args...]  — exec copilot after bootstrapping the sigil-copilot plugin
+//	agento11y opencode [--local|--no-local] [--tag k=v] [-- args...]  — exec opencode after bootstrapping the @grafana/agento11y-opencode plugin
+//	agento11y pi       [--local|--no-local] [--tag k=v] [-- args...]  — exec pi after bootstrapping the @grafana/agento11y-pi extension
+//	agento11y vibe     [--local|--no-local] [--tag k=v] [-- args...]  — exec vibe after installing the sigil hook in vibe's hooks.toml
+//	agento11y cursor   install|uninstall                              — wire (or remove) the Cursor hook in ~/.cursor/hooks.json
+//	agento11y local start|status|stop                                 — manage the local capture daemon
+//	agento11y --version                                               — print the build version
 //
 // --tag is repeatable and adds key=value pairs to SIGIL_TAGS so they land
 // on every generation the launched session produces.
+//
+// --local can also be turned on for every launch with AGENTO11Y_LOCAL=true in
+// the shell or in config.env. --no-local runs one session against Cloud while
+// that setting stays on.
 //
 // Unknown agents and unknown verbs exit with code 2 and a usage message on
 // stderr. For hook agents the binary must never crash the calling agent
@@ -72,10 +76,17 @@ var (
 	localBannerURL   = lipgloss.NewStyle().Underline(true)
 )
 
-func renderLocalBanner(uiURL string, posture local.ForwardPosture, postureErr error) string {
+// renderLocalBanner draws the local-mode banner. envKey names the variable that
+// turned local mode on (AGENTO11Y_LOCAL or the legacy SIGIL_LOCAL), and is
+// empty when a flag on this command line did.
+func renderLocalBanner(uiURL string, posture local.ForwardPosture, postureErr error, envKey string) string {
 	privacy := localPrivacyLines(posture, postureErr == nil)
 	lines := make([]string, 0, len(privacy)+3)
-	lines = append(lines, localBannerTitle.Render("agento11y local mode"))
+	title := localBannerTitle.Render("agento11y local mode")
+	if envKey != "" {
+		title += "  " + localBannerLabel.Render("(enabled by "+envKey+")")
+	}
+	lines = append(lines, title)
 	for _, line := range privacy {
 		lines = append(lines, localBannerLabel.Render(line))
 	}
@@ -105,7 +116,7 @@ func localPrivacyLines(posture local.ForwardPosture, known bool) []string {
 	}
 }
 
-const usageLine = "usage: agento11y login | agento11y doctor [--json] [--probe] | agento11y local start|status|stop | agento11y cursor install|uninstall | agento11y <agent> hook | agento11y <claude|codex|copilot|opencode|pi|vibe> [--local] [--tag key=value]... [-- args...]"
+const usageLine = "usage: agento11y login | agento11y doctor [--json] [--probe] | agento11y local start|status|stop | agento11y cursor install|uninstall | agento11y <agent> hook | agento11y <claude|codex|copilot|opencode|pi|vibe> [--local|--no-local] [--tag key=value]... [-- args...]"
 
 // version is the build version received from the calling main package via
 // Main. It stays a package var (defaulting to "dev") so tests can override
@@ -219,8 +230,18 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 		// only in $XDG_CONFIG_HOME/agento11y/config.env reaches local.StateDir()
 		// when --local is used. Otherwise the daemon dir is resolved against
 		// the wrong root.
-		dotenv.ApplyEnv(nil)
-		launcherArgs, localEnv, ok := parseLauncherArgs(args[0], args[1:], stderr)
+		//
+		// The LOCAL family is read around that merge, not after it: ApplyEnv
+		// writes the winning value under both spellings, which erases which one
+		// the user set, and the banner names that spelling.
+		localValue, localKey, inShell := envconfig.LookupEnv("LOCAL")
+		fileEnv := dotenv.ApplyEnv(nil)
+		if !inShell {
+			localValue, localKey, _ = envconfig.LookupMap(fileEnv, "LOCAL")
+		}
+		envLocal := localEnvRequest{on: envconfig.ParseBool(localValue), key: localKey}
+
+		launcherArgs, localEnv, ok := parseLauncherArgs(args[0], args[1:], stderr, envLocal)
 		if !ok {
 			return
 		}
@@ -441,9 +462,22 @@ func runDoctorCommand(args []string, stdout, stderr io.Writer) {
 	}
 }
 
+// localEnvRequest is the LOCAL family as the launcher acts on it: whether it
+// turns local mode on, and the spelling that set it so diagnostics can name a
+// variable the user actually set.
+type localEnvRequest struct {
+	on  bool
+	key string
+}
+
 // parseLauncherArgs splits sigil-side tokens from forwarded args at the
 // first `--`. Recognised sigil-side flags are:
 //   - `--local`, which redirects the launched agent at the local receiver.
+//     envLocal carries the same request from the LOCAL env family, which the
+//     caller resolves across the shell and config.env.
+//   - `--no-local`, which forces a Cloud session for this run. It wins over
+//     both `--local` and the env family, whatever the argument order, so a
+//     user with local mode on by default can opt out once.
 //   - `--tag key=value` (repeatable; also `--tag=key=value`), which adds
 //     a tag to SIGIL_TAGS so it lands on every generation the session
 //     produces. Flag tags merge onto (and override) any SIGIL_TAGS already
@@ -451,8 +485,9 @@ func runDoctorCommand(args []string, stdout, stderr io.Writer) {
 //
 // Any other token before `--` is an error.
 //
-// Returns the forwarded args plus a non-nil *local.LaunchEnv when --local
-// was set; the env values point at the local daemon. When --tag is used,
+// Returns the forwarded args plus a non-nil *local.LaunchEnv when the session
+// is local, that is when `--local` or the env family asked for it and
+// `--no-local` did not; the env values point at the local daemon. When --tag is used,
 // SIGIL_TAGS is updated in the current process environment so the exec'd
 // child (which inherits os.Environ via local.Environ) sees it.
 //
@@ -461,7 +496,7 @@ func runDoctorCommand(args []string, stdout, stderr io.Writer) {
 //     forgot the separator, so we point them at `agento11y <name> -- <args>`.
 //   - `--` is present but unrecognised tokens precede it: those are
 //     genuinely unknown sigil-side options, so we name them explicitly.
-func parseLauncherArgs(name string, rest []string, stderr io.Writer) ([]string, *local.LaunchEnv, bool) {
+func parseLauncherArgs(name string, rest []string, stderr io.Writer, envLocal localEnvRequest) ([]string, *local.LaunchEnv, bool) {
 	sep := -1
 	for i, a := range rest {
 		if a == "--" {
@@ -479,14 +514,17 @@ func parseLauncherArgs(name string, rest []string, stderr io.Writer) ([]string, 
 		forwarded = rest[sep+1:]
 	}
 
-	localRequested := false
+	localFlag := false
+	noLocalFlag := false
 	var flagTags []string
 	var unknown []string
 	for i := 0; i < len(launcherSide); i++ {
 		tok := launcherSide[i]
 		switch {
 		case tok == "--local":
-			localRequested = true
+			localFlag = true
+		case tok == "--no-local":
+			noLocalFlag = true
 		case tok == "--tag":
 			if i+1 >= len(launcherSide) {
 				_, _ = fmt.Fprintln(stderr, "agento11y: --tag requires a key=value argument")
@@ -531,9 +569,23 @@ func parseLauncherArgs(name string, rest []string, stderr io.Writer) ([]string, 
 		envconfig.SetBothEnv("TAGS", mergeTags(envconfig.Getenv("TAGS"), flagTags))
 	}
 
+	if noLocalFlag {
+		// The agent, its hooks, and any nested agento11y call inherit this
+		// environment, where dotenv already materialized the family under both
+		// spellings. Leaving it true there would describe a session that is not
+		// local. --tag writes back for the same reason.
+		envconfig.SetBothEnv("LOCAL", "false")
+	}
+
 	var localEnv *local.LaunchEnv
-	if localRequested {
-		endpoint, otlp, err := setupLocalLaunch(stderr)
+	if !noLocalFlag && (localFlag || envLocal.on) {
+		// An explicit --local speaks for itself, so name the variable only when
+		// it is what turned local mode on.
+		sourceKey := envLocal.key
+		if localFlag {
+			sourceKey = ""
+		}
+		endpoint, otlp, err := setupLocalLaunch(stderr, sourceKey)
 		if err != nil {
 			exit(1)
 			return nil, nil, false
@@ -601,8 +653,9 @@ func mergeTags(existing string, flagTags []string) string {
 }
 
 // setupLocalLaunch starts the local receiver if needed and returns the
-// endpoint URLs the launcher should pass to the agent.
-func setupLocalLaunch(stderr io.Writer) (endpoint, otlp string, err error) {
+// endpoint URLs the launcher should pass to the agent. envKey names the
+// variable that turned local mode on, or is empty when a flag did.
+func setupLocalLaunch(stderr io.Writer, envKey string) (endpoint, otlp string, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -610,6 +663,12 @@ func setupLocalLaunch(stderr io.Writer) (endpoint, otlp string, err error) {
 	status, err := local.EnsureRunning(ctx, dir, nil)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "agento11y: failed to start local receiver: %v\n", err)
+		if envKey != "" {
+			// The user did not ask for local mode in this command, so the
+			// failure looks like the launcher is broken. Name the setting and
+			// the way past it.
+			_, _ = fmt.Fprintf(stderr, "agento11y: local mode is on because %s is set; pass --no-local to run this session against Grafana Cloud\n", envKey)
+		}
 		return "", "", err
 	}
 
@@ -622,7 +681,7 @@ func setupLocalLaunch(stderr io.Writer) (endpoint, otlp string, err error) {
 		// on its own reads like "nothing is forwarded". Say why it is hedged.
 		_, _ = fmt.Fprintf(stderr, "agento11y: could not read the daemon's forwarding posture: %v\n", postureErr)
 	}
-	_, _ = fmt.Fprintln(stderr, renderLocalBanner(status.Endpoint, posture, postureErr))
+	_, _ = fmt.Fprintln(stderr, renderLocalBanner(status.Endpoint, posture, postureErr, envKey))
 	return endpoint, otlp, nil
 }
 

--- a/plugins/agento11y/internal/entry/entry_test.go
+++ b/plugins/agento11y/internal/entry/entry_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,8 +34,17 @@ import (
 // single hook or launcher dispatch test reading the developer's real
 // ~/.config/agento11y/config.env would leak SIGIL_* values (e.g. guard flags)
 // into every later test in the package.
+//
+// It clears both spellings of every alias family for the same reason, and
+// isolateDotenvHome pins them per test on top of that. A developer shell that
+// exports AGENTO11Y_LOCAL=true would otherwise route every launcher test into
+// local mode, and the daemon those tests would start is this test binary.
 func TestMain(m *testing.M) {
 	loginRun = func(context.Context, login.RunOpts) error { return login.ErrNotInteractive }
+	for _, suffix := range envconfig.AliasSuffixes {
+		_ = os.Unsetenv(envconfig.PreferredKey(suffix))
+		_ = os.Unsetenv(envconfig.LegacyKey(suffix))
+	}
 	tmp, err := os.MkdirTemp("", "sigil-entry-test-home-*")
 	if err != nil {
 		panic(err)
@@ -45,6 +55,20 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	_ = os.RemoveAll(tmp)
 	os.Exit(code)
+}
+
+// TestAliasEnvIsScrubbedForThePackage pins the TestMain guard. Launcher tests
+// that do not call isolateDotenvHome run against the process environment, and a
+// shell AGENTO11Y_LOCAL=true would send them into local mode, where the daemon
+// they start is this test binary running the whole suite again.
+func TestAliasEnvIsScrubbedForThePackage(t *testing.T) {
+	for _, suffix := range envconfig.AliasSuffixes {
+		for _, key := range []string{envconfig.PreferredKey(suffix), envconfig.LegacyKey(suffix)} {
+			if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+				t.Errorf("%s = %q at test start; TestMain must clear every alias family", key, v)
+			}
+		}
+	}
 }
 
 func TestRun_VersionFlag(t *testing.T) {
@@ -78,6 +102,9 @@ func TestRun_UsageOnZeroArgs(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "usage:") {
 		t.Fatalf("stderr missing usage message: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "[--local|--no-local]") {
+		t.Fatalf("usage does not offer --no-local: %q", stderr.String())
 	}
 }
 
@@ -853,6 +880,15 @@ func intPtr(c int) *int { return &c }
 // uses, so URL routing and JSONL writes are real.
 func inProcessDaemon(t *testing.T) (dir string, baseURL string) {
 	t.Helper()
+	dir, baseURL, _ = inProcessDaemonWithStartCount(t)
+	return dir, baseURL
+}
+
+// inProcessDaemonWithStartCount is inProcessDaemon plus a counter of daemon
+// starts, so a test can prove that a suppressed local mode starts nothing.
+func inProcessDaemonWithStartCount(t *testing.T) (dir string, baseURL string, starts *int) {
+	t.Helper()
+	starts = new(int)
 	dir = filepath.Join(t.TempDir(), "local")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -872,6 +908,7 @@ func inProcessDaemon(t *testing.T) (dir string, baseURL string) {
 	colon := strings.LastIndex(host, ":")
 	port, _ := strconv.Atoi(host[colon+1:])
 	restore := local.SetStartDaemonForTesting(func(_ context.Context, _ string, _ *log.Logger) (*local.Status, error) {
+		*starts++
 		s := local.Status{
 			PID:       os.Getpid(),
 			Port:      port,
@@ -882,7 +919,7 @@ func inProcessDaemon(t *testing.T) (dir string, baseURL string) {
 		return &s, nil
 	})
 	t.Cleanup(restore)
-	return dir, ts.URL
+	return dir, ts.URL, starts
 }
 
 // TestRenderLocalBanner_PrivacyClaimTracksPosture covers the one sentence in
@@ -928,7 +965,7 @@ func TestRenderLocalBanner_PrivacyClaimTracksPosture(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := renderLocalBanner("http://127.0.0.1:8765", tc.posture, tc.postureErr)
+			got := renderLocalBanner("http://127.0.0.1:8765", tc.posture, tc.postureErr, "")
 			for _, want := range tc.want {
 				assert.Contains(t, got, want)
 			}
@@ -975,6 +1012,201 @@ func TestRun_LauncherLocalFlagInjectsOpts(t *testing.T) {
 			assert.Equal(t, daemonURL, gotEnv.Endpoint)
 			assert.Equal(t, daemonURL+"/otlp", gotEnv.OTLPEndpoint)
 			assert.Contains(t, stderr.String(), "agento11y local mode")
+		})
+	}
+}
+
+// TestRun_LauncherLocalFromEnv covers the LOCAL alias family as a persistent
+// stand-in for --local, plus the two ways to force one Cloud session while it
+// is on: a shell override and --no-local.
+func TestRun_LauncherLocalFromEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		shellEnv   map[string]string
+		configEnv  string   // config.env contents; written when non-empty
+		argv       []string // launcher-side args, before any `--`
+		wantLocal  bool
+		wantSource string // variable the banner names, or "" for no source line
+	}{
+		{
+			name:       "shell preferred spelling",
+			shellEnv:   map[string]string{"AGENTO11Y_LOCAL": "true"},
+			wantLocal:  true,
+			wantSource: "AGENTO11Y_LOCAL",
+		},
+		{
+			name:       "config.env",
+			configEnv:  "AGENTO11Y_LOCAL=true\n",
+			wantLocal:  true,
+			wantSource: "AGENTO11Y_LOCAL",
+		},
+		{
+			// The banner names the spelling the user set, so a legacy setter
+			// greps for a variable that is in their config.
+			name:       "shell legacy spelling",
+			shellEnv:   map[string]string{"SIGIL_LOCAL": "on"},
+			wantLocal:  true,
+			wantSource: "SIGIL_LOCAL",
+		},
+		{
+			name:       "config.env legacy spelling",
+			configEnv:  "SIGIL_LOCAL=true\n",
+			wantLocal:  true,
+			wantSource: "SIGIL_LOCAL",
+		},
+		{
+			// A shell value beats a config.env one, so this is the one-off
+			// Cloud session for a user who set the file value.
+			name:      "shell false beats config.env true",
+			shellEnv:  map[string]string{"AGENTO11Y_LOCAL": "false"},
+			configEnv: "AGENTO11Y_LOCAL=true\n",
+		},
+		{
+			name:     "unsupported boolean",
+			shellEnv: map[string]string{"AGENTO11Y_LOCAL": "enabled"},
+		},
+		{
+			name:     "no-local beats env",
+			shellEnv: map[string]string{"AGENTO11Y_LOCAL": "true"},
+			argv:     []string{"--no-local"},
+		},
+		{
+			name:     "no-local after local",
+			shellEnv: map[string]string{"AGENTO11Y_LOCAL": "true"},
+			argv:     []string{"--local", "--no-local"},
+		},
+		{
+			name:     "local after no-local",
+			shellEnv: map[string]string{"AGENTO11Y_LOCAL": "true"},
+			argv:     []string{"--no-local", "--local"},
+		},
+		{
+			// Nothing in the environment asked for local mode, so the banner
+			// must not blame one.
+			name:      "flag only",
+			argv:      []string{"--local"},
+			wantLocal: true,
+		},
+		{
+			// The user asked for local mode in this command, so the setting is
+			// not what they need to know about.
+			name:      "flag with env on",
+			shellEnv:  map[string]string{"AGENTO11Y_LOCAL": "true"},
+			argv:      []string{"--local"},
+			wantLocal: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := isolateDotenvHome(t)
+			if tc.configEnv != "" {
+				cfgDir := filepath.Join(dir, "config", "agento11y")
+				require.NoError(t, os.MkdirAll(cfgDir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "config.env"), []byte(tc.configEnv), 0o600))
+			}
+			for k, v := range tc.shellEnv {
+				t.Setenv(k, v)
+			}
+			_, daemonURL, starts := inProcessDaemonWithStartCount(t)
+
+			// No credentials are configured, so a Cloud session prompts for
+			// login and a local one does not.
+			loginCalls := 0
+			withStubLoginRun(t, func(context.Context, login.RunOpts) error {
+				loginCalls++
+				return login.ErrNotInteractive
+			})
+
+			var gotEnv *local.LaunchEnv
+			called := false
+			withStubLauncher(t, "claude", func(_ context.Context, _ []string, env *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger, _ string) error {
+				called = true
+				gotEnv = env
+				return nil
+			})
+
+			var stdout, stderr bytes.Buffer
+			gotExit := withExit(t, func() {
+				run(append([]string{"claude"}, tc.argv...), strings.NewReader(""), &stdout, &stderr)
+			})
+			require.Nil(t, gotExit, "stderr=%q", stderr.String())
+			require.True(t, called, "launcher was not called")
+
+			if !tc.wantLocal {
+				assert.Nil(t, gotEnv)
+				assert.Equal(t, 0, *starts, "daemon must not start")
+				assert.NotContains(t, stderr.String(), "agento11y local mode")
+				assert.Equal(t, 1, loginCalls, "a Cloud session with no credentials prompts for login")
+				if slices.Contains(tc.argv, "--no-local") {
+					// The agent and anything it starts inherit this environment,
+					// where dotenv materialized the family under both spellings.
+					assert.Equal(t, "false", envconfig.Getenv("LOCAL"))
+				}
+				return
+			}
+
+			require.NotNil(t, gotEnv)
+			assert.Equal(t, daemonURL, gotEnv.Endpoint)
+			assert.Equal(t, daemonURL+"/otlp", gotEnv.OTLPEndpoint)
+			assert.Contains(t, stderr.String(), "agento11y local mode")
+			assert.Equal(t, 0, loginCalls, "local mode injects placeholder credentials instead of prompting")
+			if tc.wantSource != "" {
+				assert.Contains(t, stderr.String(), "(enabled by "+tc.wantSource+")")
+			} else {
+				assert.NotContains(t, stderr.String(), "(enabled by")
+			}
+		})
+	}
+}
+
+// TestRun_LauncherLocalDaemonFailure covers the failure a user did not ask for:
+// with the setting on, a daemon that will not start blocks every launch, and
+// the error has to name the setting and the way past it.
+func TestRun_LauncherLocalDaemonFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		shellEnv map[string]string
+		argv     []string
+		wantHint bool
+	}{
+		{
+			name:     "env driven",
+			shellEnv: map[string]string{"AGENTO11Y_LOCAL": "true"},
+			wantHint: true,
+		},
+		{
+			// The user asked for local mode in this command, so a bare failure
+			// is the whole answer.
+			name: "flag only",
+			argv: []string{"--local"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateDotenvHome(t)
+			for k, v := range tc.shellEnv {
+				t.Setenv(k, v)
+			}
+			restore := local.SetStartDaemonForTesting(func(context.Context, string, *log.Logger) (*local.Status, error) {
+				return nil, errors.New("port 8765 is taken")
+			})
+			t.Cleanup(restore)
+			withStubLauncher(t, "claude", func(_ context.Context, _ []string, _ *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger, _ string) error {
+				t.Fatal("launcher must not be called when the receiver did not start")
+				return nil
+			})
+
+			var stdout, stderr bytes.Buffer
+			gotExit := withExit(t, func() {
+				run(append([]string{"claude"}, tc.argv...), strings.NewReader(""), &stdout, &stderr)
+			})
+			require.NotNil(t, gotExit)
+			assert.Equal(t, 1, *gotExit)
+			assert.Contains(t, stderr.String(), "failed to start local receiver")
+			if tc.wantHint {
+				assert.Contains(t, stderr.String(), "local mode is on because AGENTO11Y_LOCAL is set")
+				assert.Contains(t, stderr.String(), "--no-local")
+			} else {
+				assert.NotContains(t, stderr.String(), "--no-local")
+			}
 		})
 	}
 }

--- a/plugins/agento11y/internal/envconfig/envconfig.go
+++ b/plugins/agento11y/internal/envconfig/envconfig.go
@@ -46,6 +46,7 @@ var AliasSuffixes = []string{
 	"USER_ID_SOURCE",
 	"BIN",
 	"COPILOT_HOOK_SURFACE",
+	"LOCAL",         // default `agento11y <agent>` launches to local mode, as if --local was passed
 	"LOCAL_FORWARD", // opt a --local daemon into forwarding to Cloud
 }
 
@@ -129,29 +130,37 @@ func ExpandAliases(updates map[string]string) map[string]string {
 	return out
 }
 
-// ParseBool mirrors the SDK's parseBool whitelist (1/true/yes/on).
-func ParseBool(raw string) bool {
+// ParseBoolValue parses a boolean config value against the 1/true/yes/on and
+// 0/false/no/off whitelist. ok is false for anything else, so a caller can tell
+// an unrecognised value from a false one and report it.
+func ParseBoolValue(raw string) (value, ok bool) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "1", "true", "yes", "on":
-		return true
+		return true, true
+	case "0", "false", "no", "off":
+		return false, true
 	default:
-		return false
+		return false, false
 	}
 }
 
+// ParseBool mirrors the SDK's parseBool whitelist (1/true/yes/on). Every other
+// value is false, whether it is a recognised negative or a typo.
+func ParseBool(raw string) bool {
+	value, _ := ParseBoolValue(raw)
+	return value
+}
+
 // ParseBoolDefault parses a boolean config value, returning def when the value
-// is empty or unrecognised. It honours the same 1/true/yes/on and
-// 0/false/no/off whitelist as resolveGuardsBool, so callers that read SIGIL_*
-// booleans from a dotenv map (rather than os.Getenv) get identical semantics.
+// is empty or unrecognised. It honours the same whitelist as resolveGuardsBool,
+// so callers that read SIGIL_* booleans from a dotenv map (rather than
+// os.Getenv) get identical semantics.
 func ParseBoolDefault(raw string, def bool) bool {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "1", "true", "yes", "on":
-		return true
-	case "0", "false", "no", "off":
-		return false
-	default:
+	value, ok := ParseBoolValue(raw)
+	if !ok {
 		return def
 	}
+	return value
 }
 
 // EnvOr returns the value of key if non-empty (after trimming), else fallback.

--- a/plugins/agento11y/internal/envconfig/envconfig_test.go
+++ b/plugins/agento11y/internal/envconfig/envconfig_test.go
@@ -35,6 +35,42 @@ func TestParseBool(t *testing.T) {
 	}
 }
 
+// TestParseBoolValue covers the whole whitelist, which the README documents as
+// the accepted values for AGENTO11Y_LOCAL, and the ok flag callers use to tell
+// an unrecognised value from a false one.
+func TestParseBoolValue(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   bool
+		wantOK bool
+	}{
+		{in: "1", want: true, wantOK: true},
+		{in: "true", want: true, wantOK: true},
+		{in: "yes", want: true, wantOK: true},
+		{in: "on", want: true, wantOK: true},
+		{in: " ON ", want: true, wantOK: true},
+		{in: "0", wantOK: true},
+		{in: "false", wantOK: true},
+		{in: "no", wantOK: true},
+		{in: "off", wantOK: true},
+		{in: ""},
+		{in: "enabled"},
+	}
+	for _, tc := range cases {
+		got, gotOK := ParseBoolValue(tc.in)
+		if got != tc.want || gotOK != tc.wantOK {
+			t.Errorf("ParseBoolValue(%q) = (%v, %v), want (%v, %v)", tc.in, got, gotOK, tc.want, tc.wantOK)
+		}
+		// An unrecognised value is the only case where the default shows.
+		if got := ParseBoolDefault(tc.in, true); got != (tc.want || !tc.wantOK) {
+			t.Errorf("ParseBoolDefault(%q, true) = %v, want %v", tc.in, got, tc.want || !tc.wantOK)
+		}
+		if got := ParseBoolDefault(tc.in, false); got != tc.want {
+			t.Errorf("ParseBoolDefault(%q, false) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestEnvOr(t *testing.T) {
 	t.Setenv("SIGIL_TEST_PRESENT", "present")
 	t.Setenv("SIGIL_TEST_EMPTY", "")
@@ -338,12 +374,16 @@ func TestResolveContentModeValue(t *testing.T) {
 	}
 }
 
-// TestAliasSuffixesCoversLocalForward pins LOCAL_FORWARD into the alias
-// families so PinAliasEnvBlank clears it in tests and ExpandAliases mirrors it
-// on write.
-func TestAliasSuffixesCoversLocalForward(t *testing.T) {
-	if !slices.Contains(AliasSuffixes, "LOCAL_FORWARD") {
-		t.Fatal("AliasSuffixes must contain LOCAL_FORWARD")
+// TestAliasSuffixesCoversLocalFamilies pins LOCAL and LOCAL_FORWARD into the
+// alias families so PinAliasEnvBlank clears them in tests and ExpandAliases
+// mirrors them on write. LOCAL decides whether a launcher starts in local mode,
+// so an unpinned developer shell value would silently reroute launcher tests to
+// the local daemon.
+func TestAliasSuffixesCoversLocalFamilies(t *testing.T) {
+	for _, suffix := range []string{"LOCAL", "LOCAL_FORWARD"} {
+		if !slices.Contains(AliasSuffixes, suffix) {
+			t.Fatalf("AliasSuffixes must contain %s", suffix)
+		}
 	}
 }
 


### PR DESCRIPTION
`AGENTO11Y_LOCAL=true` in the shell or in config.env makes every `agento11y <agent>` launch behave as if `--local` was passed. The new `--no-local` flag disables local mode even when the env var is set.