### PR TITLE
feat(plugins/agento11y): redact secrets in Cursor content

### DIFF
--- a/plugins/agento11y/internal/agents/cursor/hook/emit.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/emit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/mapper"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/emit"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/otel"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/redact"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/useragent"
 )
 
@@ -62,12 +63,17 @@ func emitGeneration(ctx context.Context, client *agento11y.Client, frag *fragmen
 // spans interleave on the generation timeline in wall-clock order (CALL→TOOL
 // →CALL→TOOL) rather than collapsing onto the generation's completed_at.
 //
-// Tool argument/result content is forwarded as-is. Capture-mode clamping
-// happens at the fragment-write boundary (postToolUse drops bytes for any
-// mode other than `full`), so by the time we emit, t.ToolInput/Output are
-// already empty in metadata_only / no_tool_content. The SDK additionally
+// Tool argument/result content goes through the shared redactor before it
+// reaches the span, mirroring codex. This is a second boundary: the mapper
+// redacts the generation export, and the span carries its own copy of the
+// same bytes. t.ErrorMessage needs no pass here — postToolUse already
+// redacted it, the same split codex uses. Capture-mode clamping happens at
+// the fragment-write boundary (postToolUse drops bytes for any mode other
+// than `full`), so by the time we emit, t.ToolInput/Output and t.ErrorMessage
+// are already empty in metadata_only / no_tool_content. The SDK additionally
 // honors Generation.ContentCapture when serializing the span.
 func emitToolSpans(ctx context.Context, client *agento11y.Client, frag *fragment.Fragment, gen agento11y.Generation, logger *log.Logger) {
+	red := redact.New()
 	for i := range frag.Tools {
 		t := &frag.Tools[i]
 		if t.ToolName == "" {
@@ -87,12 +93,8 @@ func emitToolSpans(ctx context.Context, client *agento11y.Client, frag *fragment
 		})
 
 		end := agento11y.ToolExecutionEnd{CompletedAt: completedAt}
-		if len(t.ToolInput) > 0 {
-			end.Arguments = string(t.ToolInput)
-		}
-		if len(t.ToolOutput) > 0 {
-			end.Result = string(t.ToolOutput)
-		}
+		end.Arguments = red.RedactJSONForText(t.ToolInput)
+		end.Result = red.RedactJSONForText(t.ToolOutput)
 		if t.Status == "error" {
 			toolRec.SetExecError(emit.ToolError(t.ErrorMessage))
 		}

--- a/plugins/agento11y/internal/agents/cursor/hook/emit_test.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/emit_test.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/grafana/agento11y/go/agento11y"
 
@@ -70,6 +74,91 @@ func TestEmitGenerationSendsCursorUserAgent(t *testing.T) {
 
 	if !strings.HasPrefix(gotUA, "agento11y-plugin-cursor/") {
 		t.Fatalf("User-Agent = %q, want agento11y-plugin-cursor/ prefix", gotUA)
+	}
+}
+
+// Tool arguments and results reach the OTel span on a path the generation
+// export never touches, so the mapper's redaction does not cover them. The
+// span carries the same bytes and needs its own pass.
+func TestEmitToolSpans_RedactsContent(t *testing.T) {
+	const token = "glc_abcdefghijklmnopqrstuvwxyz"
+	const apiKey = "kR7fQ2wLmZ9xTb4vNc1JhY6s"
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	logger := log.New(io.Discard, "", 0)
+	client := agento11y.NewClient(agento11y.Config{
+		ContentCapture: agento11y.ContentCaptureModeFull,
+		Tracer:         tp.Tracer("test"),
+		Logger:         logger,
+	})
+	t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
+
+	frag := &fragment.Fragment{
+		ConversationID: "conv",
+		GenerationID:   "gen-1",
+		Tools: []fragment.ToolRecord{{
+			ToolName:    "Bash",
+			ToolUseID:   "tu-1",
+			ToolInput:   json.RawMessage(`{"command":"deploy.sh","api_key":"` + apiKey + `"}`),
+			ToolOutput:  json.RawMessage(`{"stdout":"authenticated with ` + token + `"}`),
+			Status:      "completed",
+			CompletedAt: "2026-04-28T12:00:05Z",
+		}},
+	}
+	gen := agento11y.Generation{
+		ID:             "gen-1",
+		ConversationID: "conv",
+		AgentName:      mapper.AgentName,
+		Model:          agento11y.ModelRef{Provider: "openai", Name: "gpt-5-cursor"},
+		CompletedAt:    time.Date(2026, 4, 28, 12, 0, 30, 0, time.UTC),
+	}
+
+	emitToolSpans(context.Background(), client, frag, gen, logger)
+	_ = client.Shutdown(context.Background())
+	_ = tp.Shutdown(context.Background())
+
+	var attrs map[string]string
+	for _, s := range recorder.Ended() {
+		if !strings.HasPrefix(s.Name(), "execute_tool ") {
+			continue
+		}
+		attrs = map[string]string{}
+		for _, kv := range s.Attributes() {
+			attrs[string(kv.Key)] = kv.Value.AsString()
+		}
+	}
+	if attrs == nil {
+		t.Fatal("no execute_tool span recorded")
+	}
+
+	cases := []struct {
+		attr     string
+		wantMark string
+	}{
+		{"gen_ai.tool.call.arguments", "[REDACTED:json-secret-field]"},
+		{"gen_ai.tool.call.result", "[REDACTED:grafana-cloud-token]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.attr, func(t *testing.T) {
+			got, ok := attrs[tc.attr]
+			if !ok {
+				t.Fatalf("span is missing %s; recorded attributes: %v", tc.attr, attrs)
+			}
+			for _, secret := range []string{token, apiKey} {
+				if strings.Contains(got, secret) {
+					t.Errorf("%s leaks %q: %s", tc.attr, secret, got)
+				}
+			}
+			if !strings.Contains(got, tc.wantMark) {
+				t.Errorf("%s = %s; want it to contain %s", tc.attr, got, tc.wantMark)
+			}
+		})
+	}
+	if args := attrs["gen_ai.tool.call.arguments"]; !strings.Contains(args, "deploy.sh") {
+		t.Errorf("non-secret argument dropped: %s", args)
 	}
 }
 

--- a/plugins/agento11y/internal/agents/cursor/hook/posttooluse.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/posttooluse.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/config"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/fragment"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/redact"
 )
 
 // PostToolUse appends a ToolRecord to the fragment. The same handler covers
@@ -15,9 +16,9 @@ import (
 // (postToolUseFailure) — pass isFailure=true for the latter so the resulting
 // record gets `status="error"` and the extracted error message.
 //
-// Tool input/output are dropped at fragment-write time when the active
-// content-capture mode isn't `full`. We never persist bytes we don't intend
-// to export.
+// Tool input/output and the failure message are dropped at fragment-write
+// time when the active content-capture mode isn't `full`. We never persist
+// bytes we don't intend to export.
 func PostToolUse(p Payload, cfg config.Config, logger *log.Logger, isFailure bool) {
 	if p.ConversationID == "" || p.GenerationID == "" {
 		label := "postToolUse"
@@ -32,7 +33,7 @@ func PostToolUse(p Payload, cfg config.Config, logger *log.Logger, isFailure boo
 	var errorMsg string
 	if isFailure {
 		status = "error"
-		errorMsg = extractToolError(p.Error)
+		errorMsg = errorMessageForMode(p.Error, cfg.ContentCapture)
 	}
 
 	rec := fragment.ToolRecord{
@@ -66,6 +67,18 @@ func PostToolUse(p Payload, cfg config.Config, logger *log.Logger, isFailure boo
 		logger.Printf("%s: save: %v", label, err)
 		return
 	}
+}
+
+// errorMessageForMode returns the redacted tool failure message in `full` mode
+// and "" in every other mode, so the span falls back to the generic "tool
+// returned error". The message is tool content, and it is the one content field
+// the SDK forwards to the span status and error event under no_tool_content.
+// codex and copilot gate and redact the same field the same way.
+func errorMessageForMode(raw json.RawMessage, mode agento11y.ContentCaptureMode) string {
+	if mode != agento11y.ContentCaptureModeFull {
+		return ""
+	}
+	return redact.New().Redact(extractToolError(raw))
 }
 
 // extractToolError parses the polymorphic `error` field into a single string.

--- a/plugins/agento11y/internal/agents/cursor/hook/posttooluse_test.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/posttooluse_test.go
@@ -80,20 +80,37 @@ func TestPostToolUse_KeepsContentInFullMode(t *testing.T) {
 	}
 }
 
+// The failure message is the one content field the SDK still forwards to the
+// span status and error event under no_tool_content, so it is gated on `full`
+// mode and redacted here rather than at emit.
 func TestPostToolUseFailure_RecordsErrorStatusAndMessage(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	logger := log.New(&bytes.Buffer{}, "", 0)
-	cfg := config.Config{ContentCapture: agento11y.ContentCaptureModeMetadataOnly}
 
 	cases := []struct {
 		name     string
+		mode     agento11y.ContentCaptureMode
 		errorRaw json.RawMessage
 		want     string
 	}{
-		{"string error", json.RawMessage(`"boom"`), "boom"},
-		{"object with message", json.RawMessage(`{"message":"timeout","code":"E1"}`), "timeout"},
-		{"empty error", json.RawMessage(``), ""},
-		{"object without message", json.RawMessage(`{"code":"E1"}`), ""},
+		{"string error", agento11y.ContentCaptureModeFull, json.RawMessage(`"boom"`), "boom"},
+		{"object with message", agento11y.ContentCaptureModeFull, json.RawMessage(`{"message":"timeout","code":"E1"}`), "timeout"},
+		{"empty error", agento11y.ContentCaptureModeFull, json.RawMessage(``), ""},
+		{"object without message", agento11y.ContentCaptureModeFull, json.RawMessage(`{"code":"E1"}`), ""},
+		{
+			"redacts tier 1 token",
+			agento11y.ContentCaptureModeFull,
+			json.RawMessage(`"deploy.sh exited 1: authenticated with glc_abcdefghijklmnopqrstuvwxyz"`),
+			"deploy.sh exited 1: authenticated with [REDACTED:grafana-cloud-token]",
+		},
+		{
+			"redacts tier 2 env assignment",
+			agento11y.ContentCaptureModeFull,
+			json.RawMessage(`{"message":"env dump: API_KEY=kR7fQ2wLmZ9xTb4vNc1JhY6s"}`),
+			"env dump:[REDACTED:env-secret-value]",
+		},
+		{"dropped in no_tool_content", agento11y.ContentCaptureModeNoToolContent, json.RawMessage(`"boom"`), ""},
+		{"dropped in metadata_only", agento11y.ContentCaptureModeMetadataOnly, json.RawMessage(`"boom"`), ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -104,7 +121,7 @@ func TestPostToolUseFailure_RecordsErrorStatusAndMessage(t *testing.T) {
 				GenerationID:   "gen",
 				ToolName:       "Bash",
 				Error:          tc.errorRaw,
-			}, cfg, logger, true)
+			}, config.Config{ContentCapture: tc.mode}, logger, true)
 
 			got := fragment.LoadTolerant("conv", "gen", logger)
 			if got == nil || len(got.Tools) != 1 {

--- a/plugins/agento11y/internal/agents/cursor/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/cursor/mapper/mapper.go
@@ -1,7 +1,10 @@
 // Package mapper turns the on-disk Fragment + Session + StopPayload into a
-// agento11y Generation suitable for emission via the Go SDK. Unlike the
-// claudecode mapper there is no redactor — content passes through verbatim
-// in `full` mode.
+// agento11y Generation suitable for emission via the Go SDK. Every content
+// field it exports — conversation title, user prompt, assistant text, tool
+// arguments, tool results and the stop error — goes through internal/redact
+// first. The mapper is the only redaction boundary for the generation
+// export: the emit client sets no GenerationSanitizer, so nothing downstream
+// scrubs. Tool spans take a separate path and are redacted in hook/emit.go.
 package mapper
 
 import (
@@ -16,6 +19,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/tags"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/gitbranch"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/mapperutil"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/redact"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/timeutil"
 )
 
@@ -90,6 +94,8 @@ func MapFragment(in Inputs) Mapped {
 
 	stopStatus := resolveStopStatus(in.Stop)
 
+	red := redact.New()
+
 	var workspaceRoot string
 	if in.Session != nil && len(in.Session.WorkspaceRoots) > 0 {
 		workspaceRoot = in.Session.WorkspaceRoots[0]
@@ -100,7 +106,9 @@ func MapFragment(in Inputs) Mapped {
 		cursorVersion = in.Session.CursorVersion
 		userEmail = in.Session.UserEmail
 		isBackgroundAgent = in.Session.IsBackgroundAgent
-		conversationTitle = in.Session.ConversationTitle
+		// Tier 1 only. The title is a truncated first prompt, so tier 2's
+		// `KEY: value` heuristic would over-redact ordinary human text.
+		conversationTitle = red.RedactLightweight(in.Session.ConversationTitle)
 	}
 
 	tagMap := tags.Build(tags.BuiltinInputs{
@@ -138,7 +146,7 @@ func MapFragment(in Inputs) Mapped {
 		ContentCapture:    in.ContentCapture,
 	}
 
-	input, output := buildMessages(frag, in.ContentCapture)
+	input, output := buildMessages(frag, in.ContentCapture, red)
 
 	gen := agento11y.Generation{
 		ID:                frag.GenerationID,
@@ -169,7 +177,7 @@ func MapFragment(in Inputs) Mapped {
 		StopStatus: stopStatus,
 	}
 	if stopStatus == StopStatusError {
-		mapped.CallError = extractCallError(in.Stop)
+		mapped.CallError = extractCallError(in.Stop, red)
 	}
 	return mapped
 }
@@ -195,19 +203,23 @@ func resolveStopStatus(stop *StopInput) StopStatus {
 // extractCallError reads Cursor's `error` field (string or {message, code})
 // from the StopInput. Returns errCursorStop when nothing parseable is
 // available.
-func extractCallError(stop *StopInput) error {
+//
+// The message reaches the export as `generation.call_error` and as the span
+// status, so it is redacted here. Tier 1 only: an error message is prose,
+// and the SDK's own sanitizer applies the same tier to call_error.
+func extractCallError(stop *StopInput, red *redact.Redactor) error {
 	if stop == nil || len(stop.Error) == 0 {
 		return errCursorStop
 	}
 	var asString string
 	if err := json.Unmarshal(stop.Error, &asString); err == nil && asString != "" {
-		return errors.New(asString)
+		return errors.New(red.RedactLightweight(asString))
 	}
 	var asObj struct {
 		Message string `json:"message"`
 	}
 	if err := json.Unmarshal(stop.Error, &asObj); err == nil && asObj.Message != "" {
-		return errors.New(asObj.Message)
+		return errors.New(red.RedactLightweight(asObj.Message))
 	}
 	return errCursorStop
 }
@@ -242,7 +254,7 @@ func buildToolDefinitions(tools []fragment.ToolRecord) []agento11y.ToolDefinitio
 	return mapperutil.SortedToolDefinitions(names)
 }
 
-func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode) (input, output []agento11y.Message) {
+func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode, red *redact.Redactor) (input, output []agento11y.Message) {
 	// Normalize so the rest of this function only deals with the three real
 	// content-gating modes. envconfig.ResolveContentMode does this at the
 	// config layer too, but mappers re-apply it for callers (including tests)
@@ -256,7 +268,7 @@ func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode) (
 		input = append(input, agento11y.Message{
 			Role: agento11y.RoleUser,
 			Parts: []agento11y.Part{
-				agento11y.TextPart(frag.UserPrompt),
+				agento11y.TextPart(red.Redact(frag.UserPrompt)),
 			},
 		})
 	}
@@ -276,7 +288,7 @@ func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode) (
 					Name: t.ToolName,
 					InputJSON: func() []byte {
 						if mode == agento11y.ContentCaptureModeFull {
-							return t.ToolInput
+							return red.RedactJSON(t.ToolInput)
 						}
 						return nil
 					}(),
@@ -301,7 +313,7 @@ func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode) (
 						ToolResult: &agento11y.ToolResult{
 							ToolCallID:  t.ToolUseID,
 							Name:        t.ToolName,
-							ContentJSON: t.ToolOutput,
+							ContentJSON: red.RedactJSON(t.ToolOutput),
 							IsError:     t.Status == "error",
 						},
 					},
@@ -339,7 +351,7 @@ func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode) (
 		if strings.TrimSpace(text) != "" {
 			output = append(output, agento11y.Message{
 				Role:  agento11y.RoleAssistant,
-				Parts: []agento11y.Part{agento11y.TextPart(text)},
+				Parts: []agento11y.Part{agento11y.TextPart(red.Redact(text))},
 			})
 		}
 	}

--- a/plugins/agento11y/internal/agents/cursor/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/cursor/mapper/mapper_test.go
@@ -1,13 +1,23 @@
 package mapper
 
 import (
+	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/grafana/agento11y/go/agento11y"
 
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/fragment"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/redact"
+)
+
+// Secrets reused across the redaction tests: a tier-1 token and a value
+// under a sensitive JSON key.
+const (
+	testToken  = "glc_abcdefghijklmnopqrstuvwxyz"
+	testAPIKey = "kR7fQ2wLmZ9xTb4vNc1JhY6s"
 )
 
 // fixedTime gives every test a deterministic "now".
@@ -63,6 +73,10 @@ func TestMapFragment_BasicFields(t *testing.T) {
 //     to MetadataOnly, but a caller that bypasses the config layer (or
 //     constructs Inputs directly in tests) might pass it through, so
 //     buildMessages re-applies the same mapping defensively.
+//
+// Every content field carries a secret, so each case also asserts that the
+// mode exports no raw secret and that the redaction marker appears exactly
+// in the modes that keep content.
 func TestMapFragment_ContentCaptureModes(t *testing.T) {
 	cases := []struct {
 		name            string
@@ -82,8 +96,14 @@ func TestMapFragment_ContentCaptureModes(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			frag := basicFragment(t)
+			frag.UserPrompt = "hello " + testToken
+			frag.Assistant = []fragment.AssistantSegment{{Text: "hi there " + testToken}}
+			frag.Tools[0].ToolInput = json.RawMessage(`{"path":"x","api_key":"` + testAPIKey + `"}`)
+			frag.Tools[0].ToolOutput = json.RawMessage(`"contents ` + testToken + `"`)
+
 			got := MapFragment(Inputs{
-				Fragment:       basicFragment(t),
+				Fragment:       frag,
 				ContentCapture: tc.mode,
 				Now:            fixedTime,
 			})
@@ -91,7 +111,7 @@ func TestMapFragment_ContentCaptureModes(t *testing.T) {
 			var gotPrompt, gotAssistant, gotToolInput, gotToolResult, gotToolContent bool
 			for _, msg := range got.Generation.Input {
 				for _, p := range msg.Parts {
-					if p.Text == "hello" {
+					if strings.HasPrefix(p.Text, "hello") {
 						gotPrompt = true
 					}
 				}
@@ -106,7 +126,7 @@ func TestMapFragment_ContentCaptureModes(t *testing.T) {
 			}
 			for _, msg := range got.Generation.Output {
 				for _, p := range msg.Parts {
-					if p.Text == "hi there" {
+					if strings.HasPrefix(p.Text, "hi there") {
 						gotAssistant = true
 					}
 					if p.ToolCall != nil && len(p.ToolCall.InputJSON) > 0 {
@@ -129,6 +149,223 @@ func TestMapFragment_ContentCaptureModes(t *testing.T) {
 			}
 			if gotToolContent != tc.wantToolContent {
 				t.Errorf("tool_result content present = %v; want %v", gotToolContent, tc.wantToolContent)
+			}
+
+			// ToolCall.InputJSON and ToolResult.ContentJSON are
+			// json.RawMessage, so marshaling the generation keeps them
+			// readable and one scan covers every content field.
+			body, err := json.Marshal(got.Generation)
+			if err != nil {
+				t.Fatalf("marshal generation: %v", err)
+			}
+			for _, secret := range []string{testToken, testAPIKey} {
+				if bytes.Contains(body, []byte(secret)) {
+					t.Errorf("mode %s leaks raw secret %q: %s", tc.mode, secret, body)
+				}
+			}
+			// The prompt carries the tier-1 token, so the marker is visible
+			// in exactly the modes that keep the prompt.
+			if marked := bytes.Contains(body, []byte("[REDACTED:")); marked != tc.wantUserPrompt {
+				t.Errorf("redaction marker present = %v; want %v: %s", marked, tc.wantUserPrompt, body)
+			}
+		})
+	}
+}
+
+// TestMapFragment_RedactsSecrets covers the redaction boundary: every
+// content field the mapper exports in full mode goes through the shared
+// redactor, and nothing else in the generation moves.
+func TestMapFragment_RedactsSecrets(t *testing.T) {
+	const token = testToken
+	const apiKey = testAPIKey
+
+	in, out := int64(80), int64(22)
+	frag := &fragment.Fragment{
+		ConversationID: "conv-1",
+		GenerationID:   "gen-1",
+		UserPrompt:     "deploy using " + token,
+		Assistant:      []fragment.AssistantSegment{{Text: "I used " + token}},
+		Tools: []fragment.ToolRecord{{
+			ToolName:   "Bash",
+			ToolUseID:  "t1",
+			ToolInput:  json.RawMessage(`{"command":"deploy.sh","api_key":"` + apiKey + `"}`),
+			ToolOutput: json.RawMessage(`{"stdout":"authenticated with ` + token + `"}`),
+			Status:     "completed",
+			Cwd:        "/repo/" + token,
+		}},
+		Model:      "gpt-5-cursor",
+		Provider:   "openai",
+		TokenUsage: &fragment.TokenCounts{InputTokens: &in, OutputTokens: &out},
+	}
+
+	got := MapFragment(Inputs{
+		Fragment:       frag,
+		Session:        &fragment.Session{ConversationTitle: "deploy using " + token},
+		ContentCapture: agento11y.ContentCaptureModeFull,
+		Now:            fixedTime,
+	})
+
+	var userText, assistantText, toolInput, toolOutput string
+	for _, msg := range got.Generation.Input {
+		for _, p := range msg.Parts {
+			if msg.Role == agento11y.RoleUser && p.Kind == agento11y.PartKindText {
+				userText = p.Text
+			}
+			if p.ToolResult != nil {
+				toolOutput = string(p.ToolResult.ContentJSON)
+			}
+		}
+	}
+	for _, msg := range got.Generation.Output {
+		for _, p := range msg.Parts {
+			if p.Kind == agento11y.PartKindText {
+				assistantText = p.Text
+			}
+			if p.ToolCall != nil {
+				toolInput = string(p.ToolCall.InputJSON)
+			}
+		}
+	}
+
+	fields := []struct {
+		name     string
+		value    string
+		wantMark string
+	}{
+		{"conversation_title", got.Generation.ConversationTitle, "[REDACTED:grafana-cloud-token]"},
+		{"start conversation_title", got.Start.ConversationTitle, "[REDACTED:grafana-cloud-token]"},
+		{"user prompt", userText, "[REDACTED:grafana-cloud-token]"},
+		{"assistant text", assistantText, "[REDACTED:grafana-cloud-token]"},
+		{"tool_call input", toolInput, "[REDACTED:json-secret-field]"},
+		{"tool_result content", toolOutput, "[REDACTED:grafana-cloud-token]"},
+	}
+	for _, f := range fields {
+		t.Run(f.name, func(t *testing.T) {
+			if f.value == "" {
+				t.Fatalf("%s is empty; expected redacted content", f.name)
+			}
+			if strings.Contains(f.value, token) {
+				t.Errorf("%s leaks the raw token: %s", f.name, f.value)
+			}
+			if strings.Contains(f.value, apiKey) {
+				t.Errorf("%s leaks the raw api_key: %s", f.name, f.value)
+			}
+			if !strings.Contains(f.value, f.wantMark) {
+				t.Errorf("%s = %s; want it to contain %s", f.name, f.value, f.wantMark)
+			}
+		})
+	}
+
+	t.Run("tool json stays structurally valid", func(t *testing.T) {
+		var input map[string]any
+		if err := json.Unmarshal([]byte(toolInput), &input); err != nil {
+			t.Fatalf("tool_call input is not valid JSON: %v (%s)", err, toolInput)
+		}
+		if input["command"] != "deploy.sh" {
+			t.Errorf("non-secret tool argument changed: command = %v; want deploy.sh", input["command"])
+		}
+		var output map[string]any
+		if err := json.Unmarshal([]byte(toolOutput), &output); err != nil {
+			t.Fatalf("tool_result content is not valid JSON: %v (%s)", err, toolOutput)
+		}
+	})
+
+	t.Run("metadata untouched", func(t *testing.T) {
+		if len(got.Generation.Tools) != 1 || got.Generation.Tools[0].Name != "Bash" {
+			t.Errorf("tool definitions = %+v; want a single Bash entry", got.Generation.Tools)
+		}
+		if got.Generation.Usage.InputTokens != 80 || got.Generation.Usage.OutputTokens != 22 {
+			t.Errorf("usage = %+v; want 80/22", got.Generation.Usage)
+		}
+		// A secret-shaped cwd proves the tag path skips the redactor:
+		// redaction touches content, not metadata.
+		if want := "/repo/" + token; got.Generation.Tags["cwd"] != want {
+			t.Errorf("cwd tag = %q; want %q", got.Generation.Tags["cwd"], want)
+		}
+		if got.Generation.ID != "gen-1" || got.Generation.ConversationID != "conv-1" {
+			t.Errorf("ids = %q/%q; want gen-1/conv-1", got.Generation.ID, got.Generation.ConversationID)
+		}
+		if got.Generation.Model.Name != "gpt-5-cursor" || got.Generation.Model.Provider != "openai" {
+			t.Errorf("model = %+v; want openai/gpt-5-cursor", got.Generation.Model)
+		}
+	})
+}
+
+// TestMapFragment_RedactionTiers pins the per-field tier split. The title
+// gets tier 1 only; the prompt and assistant text get tier 2 as well.
+// Without these cases either half can be swapped for the other with no test
+// turning red, because every other secret in the package is a tier-1 token
+// or a sensitive JSON key.
+func TestMapFragment_RedactionTiers(t *testing.T) {
+	cases := []struct {
+		name       string
+		title      string
+		text       string
+		wantTitle  string
+		wantPrompt string
+	}{
+		{
+			// Tier 2's `KEY: value` heuristic would swallow the rest of the
+			// line. Cursor titles are truncated first prompts, so ordinary
+			// text like this is the common case.
+			name:       "title survives the tier 2 heuristic",
+			title:      "fix the API key: rotation script",
+			text:       "hello",
+			wantTitle:  "fix the API key: rotation script",
+			wantPrompt: "hello",
+		},
+		{
+			name:       "tier 1 token is redacted everywhere",
+			title:      "deploy using " + testToken,
+			text:       "deploy using " + testToken,
+			wantTitle:  "deploy using [REDACTED:grafana-cloud-token]",
+			wantPrompt: "deploy using [REDACTED:grafana-cloud-token]",
+		},
+		{
+			name:       "prompt and assistant text get tier 2",
+			title:      "run the deploy",
+			text:       "run with PASSWORD=hunter2",
+			wantTitle:  "run the deploy",
+			wantPrompt: "run with[REDACTED:env-secret-value]",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			frag := basicFragment(t)
+			frag.UserPrompt = tc.text
+			frag.Assistant = []fragment.AssistantSegment{{Text: tc.text}}
+
+			got := MapFragment(Inputs{
+				Fragment:       frag,
+				Session:        &fragment.Session{ConversationTitle: tc.title},
+				ContentCapture: agento11y.ContentCaptureModeFull,
+				Now:            fixedTime,
+			})
+
+			if got.Generation.ConversationTitle != tc.wantTitle {
+				t.Errorf("title = %q; want %q", got.Generation.ConversationTitle, tc.wantTitle)
+			}
+			var prompt, assistant string
+			for _, msg := range got.Generation.Input {
+				for _, p := range msg.Parts {
+					if msg.Role == agento11y.RoleUser && p.Kind == agento11y.PartKindText {
+						prompt = p.Text
+					}
+				}
+			}
+			for _, msg := range got.Generation.Output {
+				for _, p := range msg.Parts {
+					if p.Kind == agento11y.PartKindText {
+						assistant = p.Text
+					}
+				}
+			}
+			if prompt != tc.wantPrompt {
+				t.Errorf("prompt = %q; want %q", prompt, tc.wantPrompt)
+			}
+			if assistant != tc.wantPrompt {
+				t.Errorf("assistant text = %q; want %q", assistant, tc.wantPrompt)
 			}
 		})
 	}
@@ -315,10 +552,26 @@ func TestExtractCallError(t *testing.T) {
 		{"json object with message", []byte(`{"message":"timeout","code":"E1"}`), "timeout"},
 		{"json object missing message", []byte(`{"code":"E1"}`), "cursor_stop_error"},
 		{"unparseable", []byte("garbage"), "cursor_stop_error"},
+		{
+			"secret in string is redacted",
+			[]byte(`"auth failed for glc_abcdefghijklmnopqrstuvwxyz"`),
+			"auth failed for [REDACTED:grafana-cloud-token]",
+		},
+		{
+			"secret in object message is redacted",
+			[]byte(`{"message":"auth failed for glc_abcdefghijklmnopqrstuvwxyz","code":"E1"}`),
+			"auth failed for [REDACTED:grafana-cloud-token]",
+		},
+		{
+			// Tier 1 only: a message like `retry limit: 3` must survive.
+			"tier 2 heuristic does not fire",
+			[]byte(`"request failed, retry limit: 3"`),
+			"request failed, retry limit: 3",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := extractCallError(&StopInput{Error: tc.in})
+			got := extractCallError(&StopInput{Error: tc.in}, redact.New())
 			if got.Error() != tc.want {
 				t.Errorf("got %q; want %q", got.Error(), tc.want)
 			}

--- a/plugins/agento11y/internal/entry/golden_integration_test.go
+++ b/plugins/agento11y/internal/entry/golden_integration_test.go
@@ -48,6 +48,7 @@ package entry
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -205,7 +206,7 @@ func runGoldenScenario(t *testing.T, name string) {
 	// normalization that drops or rewrites content cannot hide a leak.
 	for _, secret := range sc.RawSecrets {
 		for i, cap := range captured {
-			if strings.Contains(string(cap.body), secret) {
+			if secretLeaked(cap.body, secret) {
 				t.Fatalf("scenario %s: raw secret %q leaked in export request[%d]: %s",
 					name, secret, i, cap.body)
 			}
@@ -614,6 +615,90 @@ func normalizeCapturedBodies(t *testing.T, captured []capturedRequest) []goldenE
 		out = append(out, goldenExport{Path: cap.path, Generations: gens})
 	}
 	return out
+}
+
+// secretLeaked reports whether secret appears in an export body, either as
+// plain text or inside a base64-encoded bytes field. Proto JSON encodes
+// `bytes` fields — `tool_call.input_json` and `tool_result.content_json` —
+// as base64, so a plain substring search misses a secret that only lives in
+// tool arguments or tool results.
+func secretLeaked(body []byte, secret string) bool {
+	if bytes.Contains(body, []byte(secret)) {
+		return true
+	}
+	var decoded any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return false
+	}
+	return leafLeaks(decoded, secret)
+}
+
+// leafLeaks walks the decoded body and checks every string leaf twice: as
+// itself, and as base64. The plain check matters because the top-level scan
+// runs against the escaped body, so a secret containing a newline, quote or
+// backslash — a PEM private key, for one — hides behind its escape sequences
+// there.
+func leafLeaks(v any, secret string) bool {
+	switch x := v.(type) {
+	case string:
+		if strings.Contains(x, secret) {
+			return true
+		}
+		raw, err := base64.StdEncoding.DecodeString(x)
+		return err == nil && bytes.Contains(raw, []byte(secret))
+	case []any:
+		for _, item := range x {
+			if leafLeaks(item, secret) {
+				return true
+			}
+		}
+	case map[string]any:
+		for _, item := range x {
+			if leafLeaks(item, secret) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// The secret guard is the one assertion UPDATE_GOLDENS cannot launder, so it
+// gets its own test. Both encodings a secret can hide behind are covered:
+// base64, which protojson uses for `bytes` fields, and JSON string escapes.
+func TestSecretLeaked(t *testing.T) {
+	const pem = "-----BEGIN PRIVATE KEY-----\nMIIBVgIBADAN\n-----END PRIVATE KEY-----"
+	blob := base64.StdEncoding.EncodeToString([]byte(`{"api_key":"kR7fQ2wLmZ9xTb4vNc1JhY6s"}`))
+
+	cases := []struct {
+		name   string
+		body   string
+		secret string
+		want   bool
+	}{
+		{"plain text", `{"text":"use glc_token"}`, "glc_token", true},
+		{"base64 bytes field", `{"input_json":"` + blob + `"}`, "kR7fQ2wLmZ9xTb4vNc1JhY6s", true},
+		{"redacted base64 bytes field", `{"input_json":"` + base64.StdEncoding.EncodeToString([]byte(`{"api_key":"[REDACTED:json-secret-field]"}`)) + `"}`, "kR7fQ2wLmZ9xTb4vNc1JhY6s", false},
+		{"absent", `{"text":"nothing here"}`, "glc_token", false},
+		// The body stores this one as `\n` escapes, so only the decoded
+		// leaf matches.
+		{"escaped newlines", string(mustMarshalJSON(t, map[string]string{"text": pem})), pem, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := secretLeaked([]byte(tc.body), tc.secret); got != tc.want {
+				t.Errorf("secretLeaked(%s, %q) = %v; want %v", tc.body, tc.secret, got, tc.want)
+			}
+		})
+	}
+}
+
+func mustMarshalJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return data
 }
 
 // generationSortKey returns the `id` field of a generation so requests with

--- a/plugins/agento11y/internal/entry/testdata/golden/cursor-basic/export.golden.json
+++ b/plugins/agento11y/internal/entry/testdata/golden/cursor-basic/export.golden.json
@@ -13,7 +13,7 @@
           {
             "parts": [
               {
-                "text": "list go files"
+                "text": "list go files using [REDACTED:grafana-cloud-token]"
               }
             ],
             "role": "MESSAGE_ROLE_USER"
@@ -22,7 +22,7 @@
             "parts": [
               {
                 "tool_result": {
-                  "content_json": "eyJzdGRvdXQiOiJtYWluLmdvXG51dGlsLmdvIiwiZXhpdF9jb2RlIjowfQ==",
+                  "content_json": "eyJleGl0X2NvZGUiOjAsInN0ZG91dCI6Im1haW4uZ29cbnV0aWwuZ29cbmF1dGhlbnRpY2F0ZWQgd2l0aCBbUkVEQUNURUQ6Z3JhZmFuYS1jbG91ZC10b2tlbl0ifQ==",
                   "name": "Bash",
                   "tool_call_id": "tu-1"
                 }
@@ -32,7 +32,7 @@
           }
         ],
         "metadata": {
-          "agento11y.conversation.title": "list go files",
+          "agento11y.conversation.title": "list go files using [REDACTED:grafana-cloud-token]",
           "agento11y.sdk.content_capture_mode": "full",
           "agento11y.sdk.name": "sdk-go",
           "agento11y.user.id": "test-user"
@@ -49,7 +49,7 @@
               {
                 "tool_call": {
                   "id": "tu-1",
-                  "input_json": "eyJjb21tYW5kIjoibHMgKi5nbyJ9",
+                  "input_json": "eyJhcGlfa2V5IjoiW1JFREFDVEVEOmpzb24tc2VjcmV0LWZpZWxkXSIsImNvbW1hbmQiOiJscyAqLmdvIn0=",
                   "name": "Bash"
                 }
               }
@@ -59,7 +59,7 @@
           {
             "parts": [
               {
-                "text": "Found two go files: main.go and util.go."
+                "text": "Found two go files: main.go and util.go. Deployed with [REDACTED:grafana-cloud-token]."
               }
             ],
             "role": "MESSAGE_ROLE_ASSISTANT"

--- a/plugins/agento11y/internal/entry/testdata/golden/cursor-basic/scenario.json
+++ b/plugins/agento11y/internal/entry/testdata/golden/cursor-basic/scenario.json
@@ -14,7 +14,7 @@
       "hook_event_name": "beforeSubmitPrompt",
       "conversation_id": "conv-cursor-1",
       "generation_id": "gen-cursor-1",
-      "prompt": "list go files",
+      "prompt": "list go files using glc_abcdefghijklmnopqrstuvwxyz",
       "timestamp": "2026-05-01T12:00:01Z"
     },
     {
@@ -23,8 +23,8 @@
       "generation_id": "gen-cursor-1",
       "tool_name": "Bash",
       "tool_use_id": "tu-1",
-      "tool_input": {"command": "ls *.go"},
-      "tool_output": {"stdout": "main.go\nutil.go", "exit_code": 0},
+      "tool_input": {"command": "ls *.go", "api_key": "kR7fQ2wLmZ9xTb4vNc1JhY6s"},
+      "tool_output": {"stdout": "main.go\nutil.go\nauthenticated with glc_toolresultsecret0123456789ab", "exit_code": 0},
       "duration": 12.5,
       "status": "ok",
       "timestamp": "2026-05-01T12:00:02Z"
@@ -33,7 +33,7 @@
       "hook_event_name": "afterAgentResponse",
       "conversation_id": "conv-cursor-1",
       "generation_id": "gen-cursor-1",
-      "text": "Found two go files: main.go and util.go.",
+      "text": "Found two go files: main.go and util.go. Deployed with glc_assistantsecret0123456789ab.",
       "model": "gpt-5-cursor",
       "provider": "openai",
       "input_tokens": 80,
@@ -54,7 +54,12 @@
       "timestamp": "2026-05-01T12:00:04Z"
     }
   ],
-  "raw_secrets": [],
+  "raw_secrets": [
+    "glc_abcdefghijklmnopqrstuvwxyz",
+    "kR7fQ2wLmZ9xTb4vNc1JhY6s",
+    "glc_toolresultsecret0123456789ab",
+    "glc_assistantsecret0123456789ab"
+  ],
   "invariants": {
     "export_count": 1,
     "generations": 1,

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -82,13 +82,13 @@ AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana
 
 </details>
 
-To also send the conversation text, add this to your `config.env`:
+To also send the conversation text (with automatic secret redaction), add this to your `config.env`:
 
 ```dotenv
 AGENTO11Y_CONTENT_CAPTURE_MODE=full
 ```
 
-Cursor content is not passed through the shared redactor before export. Avoid `full` when prompts, replies, or tool output may contain secrets.
+Captured prompt, assistant, and tool content is redacted before export.
 
 ## 4. Verify
 


### PR DESCRIPTION
Cursor was the only content-exporting Go plugin without a redactor, so `AGENTO11Y_CONTENT_CAPTURE_MODE=full` did not support secret redaction of prompts, replies, and tool I/O before sending to Grafana Cloud.

The plugin now runs every content field through `redact` module, following the codex/copilot/vibe pattern.