### PR TITLE
fix(plugins/opencode): accumulate step-finish tokens across a message

### DIFF
--- a/plugins/opencode/src/golden.test.ts
+++ b/plugins/opencode/src/golden.test.ts
@@ -94,6 +94,9 @@ function closeServer(server: Server): Promise<void> {
 
 // Build one assistant reply with a completed tool call and the composed
 // system prompt OpenCode delivers through `experimental.chat.system.transform`.
+// One provider step, as OpenCode 1.18.x emits for a normal turn, so the step's
+// tokens and `assistantMessage.tokens` agree; multi-step summation is covered in
+// hooks.tokens.test.ts.
 function opencodeMessageFixture() {
   const sessionID = "opencode-sess-1";
   const messageID = "msg-1";
@@ -140,6 +143,22 @@ function opencodeMessageFixture() {
     },
     finish: "end_turn",
   } as const;
+  const stepFinishParts = [
+    {
+      id: "assist-step-1",
+      sessionID,
+      messageID,
+      type: "step-finish",
+      reason: "end_turn",
+      cost: 0.005,
+      tokens: {
+        input: 200,
+        output: 50,
+        reasoning: 0,
+        cache: { read: 30, write: 0 },
+      },
+    },
+  ];
   const assistantParts = [
     {
       id: "assist-text-1",
@@ -172,6 +191,7 @@ function opencodeMessageFixture() {
     userParts,
     assistantMessage,
     assistantParts,
+    stepFinishParts,
     effectiveSystem,
   };
 }
@@ -235,6 +255,7 @@ describe("opencode plugin: real-SDK golden export", () => {
       userParts,
       assistantMessage,
       assistantParts,
+      stepFinishParts,
       effectiveSystem,
     } = opencodeMessageFixture();
 
@@ -283,6 +304,11 @@ describe("opencode plugin: real-SDK golden export", () => {
       { sessionID, model: { id: assistantMessage.modelID } },
       { system: effectiveSystem },
     );
+    for (const part of stepFinishParts) {
+      await hooks.event({
+        event: { type: "message.part.updated", properties: { part } },
+      });
+    }
     await hooks.event({
       event: {
         type: "message.updated",
@@ -336,8 +362,10 @@ describe("opencode plugin: real-SDK golden export", () => {
     expect(turn.agent_name).toBe("opencode:build");
     expect(turn.model.name).toBe("claude-sonnet-4-opencode");
     expect(turn.model.provider).toBe("anthropic");
+    // Accumulated from the step-finish part, not read off the message.
     expect(String(turn.usage.input_tokens)).toBe("200");
     expect(String(turn.usage.output_tokens)).toBe("50");
+    expect(String(turn.usage.cache_read_input_tokens)).toBe("30");
   }
 
   it("matches the recorded golden for a complete assistant turn", async () => {

--- a/plugins/opencode/src/hooks.testutil.ts
+++ b/plugins/opencode/src/hooks.testutil.ts
@@ -1,6 +1,7 @@
 // Shared factories and event helpers for hook tests. Each test file keeps its
 // own vi.mock calls because Vitest hoists them.
 
+import type { AssistantMessage, StepFinishPart } from "@opencode-ai/sdk";
 import { vi } from "vitest";
 import type { Agento11yOpencodeConfig } from "./config.js";
 import type { createAgento11yHooks, OpencodeEventType } from "./hooks.js";
@@ -96,7 +97,11 @@ export function baseConfig(
   };
 }
 
-export function assistantMessage(sessionID: string, messageID: string) {
+export function assistantMessage(
+  sessionID: string,
+  messageID: string,
+  overrides: Partial<AssistantMessage> = {},
+): AssistantMessage {
   return {
     id: messageID,
     sessionID,
@@ -115,7 +120,59 @@ export function assistantMessage(sessionID: string, messageID: string) {
       cache: { read: 0, write: 0 },
     },
     finish: "end_turn",
-  } as const;
+    ...overrides,
+  };
+}
+
+/**
+ * An assistant message mid-turn: opencode sets `finish` at every `step-finish`
+ * and only sets `time.completed` when the turn actually ends, so this shape is
+ * what the plugin sees between steps.
+ */
+export function inFlightAssistantMessage(
+  sessionID: string,
+  messageID: string,
+  overrides: Omit<Partial<AssistantMessage>, "time"> = {},
+): AssistantMessage {
+  return assistantMessage(sessionID, messageID, {
+    ...overrides,
+    time: { created: 1_700_000_001_000 },
+  });
+}
+
+/**
+ * A `step-finish` part carrying one provider step's usage. Token fields
+ * default to 0 so a case only states the numbers it cares about.
+ */
+export function stepFinishPart(
+  sessionID: string,
+  messageID: string,
+  tokens: {
+    input?: number;
+    output?: number;
+    reasoning?: number;
+    cache?: { read?: number; write?: number };
+  } = {},
+  overrides: Omit<Partial<StepFinishPart>, "tokens"> = {},
+): StepFinishPart {
+  return {
+    id: `prt-step-${messageID}`,
+    sessionID,
+    messageID,
+    type: "step-finish",
+    reason: "tool-calls",
+    cost: 0.002,
+    tokens: {
+      input: tokens.input ?? 0,
+      output: tokens.output ?? 0,
+      reasoning: tokens.reasoning ?? 0,
+      cache: {
+        read: tokens.cache?.read ?? 0,
+        write: tokens.cache?.write ?? 0,
+      },
+    },
+    ...overrides,
+  };
 }
 
 export async function emitMessageUpdated(

--- a/plugins/opencode/src/hooks.tokens.test.ts
+++ b/plugins/opencode/src/hooks.tokens.test.ts
@@ -1,0 +1,399 @@
+// Tests terminal detection (`finish` is not a completion signal) and token
+// accumulation across the provider steps of one assistant message.
+
+import type { AssistantMessage } from "@opencode-ai/sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createAgento11yClientMock, createTelemetryProvidersMock } = vi.hoisted(
+  () => ({
+    createAgento11yClientMock: vi.fn(),
+    createTelemetryProvidersMock: vi.fn(),
+  }),
+);
+
+vi.mock("./client.js", () => ({
+  createAgento11yClient: createAgento11yClientMock,
+}));
+vi.mock("./telemetry.js", () => ({
+  createTelemetryProviders: createTelemetryProvidersMock,
+}));
+
+import { _resetHookState, createAgento11yHooks } from "./hooks.js";
+import {
+  assistantMessage,
+  baseConfig,
+  type CapturedGeneration,
+  emitMessageUpdated,
+  emitPartUpdated,
+  emitSessionDeleted,
+  inFlightAssistantMessage,
+  makeAgento11yMock,
+  makeOpencodeClient,
+  stepFinishPart,
+  type TestHooks,
+} from "./hooks.testutil.js";
+
+async function setup(
+  config = baseConfig(),
+  client = makeOpencodeClient(),
+): Promise<{
+  hooks: TestHooks;
+  generations: CapturedGeneration[];
+  client: ReturnType<typeof makeOpencodeClient>;
+}> {
+  const { sigil, generations } = makeAgento11yMock();
+  createAgento11yClientMock.mockReturnValue(sigil);
+  const hooks = await createAgento11yHooks(config, client);
+  if (!hooks) throw new Error("expected hooks");
+  return { hooks, generations, client };
+}
+
+function usageOf(generation: CapturedGeneration): Record<string, number> {
+  return (generation.result as { usage: Record<string, number> }).usage;
+}
+
+function costOf(generation: CapturedGeneration): number {
+  return (generation.result as { metadata: { cost: number } }).metadata.cost;
+}
+
+const completedTime = {
+  created: 1_700_000_001_000,
+  completed: 1_700_000_003_000,
+};
+
+describe("opencode terminal detection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetHookState();
+  });
+
+  it("does not export while only finish is set", async () => {
+    const { hooks, generations } = await setup();
+
+    // opencode sets `finish` and publishes message.updated at every
+    // step-finish, so four steps means four non-terminal updates.
+    for (let step = 0; step < 4; step++) {
+      await emitPartUpdated(hooks, stepFinishPart("s1", "m1", { input: 10 }));
+      await emitMessageUpdated(hooks, inFlightAssistantMessage("s1", "m1"));
+    }
+
+    expect(generations).toHaveLength(0);
+  });
+
+  it("exports once on the first time.completed and ignores repeats", async () => {
+    const { hooks, generations } = await setup();
+
+    await emitMessageUpdated(hooks, inFlightAssistantMessage("s1", "m1"));
+    expect(generations).toHaveLength(0);
+
+    await emitMessageUpdated(hooks, assistantMessage("s1", "m1"));
+    await emitMessageUpdated(hooks, assistantMessage("s1", "m1"));
+
+    expect(generations).toHaveLength(1);
+  });
+
+  it("does not fetch the message body on step-finish parts", async () => {
+    const { hooks, generations, client } = await setup();
+
+    await emitPartUpdated(hooks, stepFinishPart("s1", "m1", { input: 10 }));
+
+    expect(generations).toHaveLength(0);
+    expect(client.session.message).not.toHaveBeenCalled();
+  });
+
+  it("does not re-export recorded turns on session.idle", async () => {
+    const { hooks, generations, client } = await setup();
+
+    await emitMessageUpdated(hooks, assistantMessage("s1", "m1"));
+    const fetchesAfterRecord = client.session.message.mock.calls.length;
+    await hooks.event({
+      event: { type: "session.idle", properties: { info: { id: "s1" } } },
+    });
+
+    expect(generations).toHaveLength(1);
+    // Idle must not walk session history looking for older messages (#315).
+    expect(client.session.message.mock.calls.length).toBe(fetchesAfterRecord);
+  });
+});
+
+describe("opencode token accumulation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetHookState();
+  });
+
+  // `assistantMessage` defaults to tokens {input: 10, output: 5}, which is the
+  // last-step value the fallback cases expect.
+  const cases: {
+    name: string;
+    parts: unknown[];
+    final: AssistantMessage;
+    wantUsage: Record<string, number>;
+    wantCost?: number;
+    wantError?: string;
+  }[] = [
+    {
+      name: "sums every step of the message",
+      parts: [
+        stepFinishPart("s1", "m1", {
+          input: 100,
+          output: 20,
+          reasoning: 5,
+          cache: { read: 30, write: 10 },
+        }),
+        stepFinishPart("s1", "m1", {
+          input: 120,
+          output: 25,
+          reasoning: 7,
+          cache: { read: 40, write: 0 },
+        }),
+        stepFinishPart("s1", "m1", {
+          input: 90,
+          output: 15,
+          reasoning: 3,
+          cache: { read: 0, write: 4 },
+        }),
+      ],
+      final: assistantMessage("s1", "m1", { cost: 0.06 }),
+      wantUsage: {
+        inputTokens: 310,
+        outputTokens: 60,
+        reasoningTokens: 15,
+        cacheReadInputTokens: 70,
+        cacheWriteInputTokens: 14,
+      },
+      // Cost is the message aggregate, which upstream sums over the same steps.
+      wantCost: 0.06,
+    },
+    {
+      name: "reports a single step unchanged",
+      parts: [
+        stepFinishPart("s1", "m1", {
+          input: 80,
+          output: 12,
+          reasoning: 3,
+          cache: { read: 4, write: 2 },
+        }),
+      ],
+      final: assistantMessage("s1", "m1"),
+      // `input` stays cache-adjusted (80, not 80+4+2) and `output` keeps
+      // reasoning out (12, not 12+3), matching opencode's `Session.getUsage`.
+      wantUsage: {
+        inputTokens: 80,
+        outputTokens: 12,
+        reasoningTokens: 3,
+        cacheReadInputTokens: 4,
+        cacheWriteInputTokens: 2,
+      },
+    },
+    {
+      name: "falls back to the message totals when no step part was seen",
+      parts: [],
+      final: assistantMessage("s1", "m1"),
+      wantUsage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        reasoningTokens: 0,
+        cacheReadInputTokens: 0,
+        cacheWriteInputTokens: 0,
+      },
+    },
+    {
+      name: "falls back when no step part carried a parseable count",
+      parts: [
+        { ...stepFinishPart("s1", "m1"), tokens: undefined },
+        {
+          ...stepFinishPart("s1", "m1"),
+          tokens: { input: "12", output: null, cache: "nope" },
+        },
+      ],
+      final: assistantMessage("s1", "m1"),
+      // Zeros from a malformed payload must not pass as observed usage. That
+      // would export zero tokens next to a non-zero cost.
+      wantUsage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        reasoningTokens: 0,
+        cacheReadInputTokens: 0,
+        cacheWriteInputTokens: 0,
+      },
+    },
+    {
+      name: "skips unparseable fields next to a valid step",
+      parts: [
+        {
+          ...stepFinishPart("s1", "m1"),
+          tokens: { input: "12", output: null, cache: "nope" },
+        },
+        stepFinishPart("s1", "m1", { input: 5 }),
+      ],
+      wantUsage: {
+        inputTokens: 5,
+        outputTokens: 0,
+        reasoningTokens: 0,
+        cacheReadInputTokens: 0,
+        cacheWriteInputTokens: 0,
+      },
+      final: assistantMessage("s1", "m1"),
+    },
+    {
+      name: "exports the tokens accumulated before an abort",
+      parts: [
+        stepFinishPart("s1", "m1", { input: 40, output: 8 }),
+        stepFinishPart("s1", "m1", { input: 60, output: 7 }),
+      ],
+      final: assistantMessage("s1", "m1", {
+        time: completedTime,
+        error: { name: "MessageAbortedError", data: { message: "aborted" } },
+      }),
+      wantUsage: {
+        inputTokens: 100,
+        outputTokens: 15,
+        reasoningTokens: 0,
+        cacheReadInputTokens: 0,
+        cacheWriteInputTokens: 0,
+      },
+      wantError: "aborted",
+    },
+    {
+      name: "exports the tokens accumulated before a mid-stream error",
+      parts: [
+        stepFinishPart("s1", "m1", { input: 25, output: 4 }),
+        stepFinishPart("s1", "m1", { input: 35, output: 6 }),
+      ],
+      // A provider error can arrive before `time.completed` is set.
+      final: inFlightAssistantMessage("s1", "m1", {
+        error: {
+          name: "APIError",
+          data: { message: "boom", statusCode: 500, isRetryable: false },
+        },
+      }),
+      wantUsage: {
+        inputTokens: 60,
+        outputTokens: 10,
+        reasoningTokens: 0,
+        cacheReadInputTokens: 0,
+        cacheWriteInputTokens: 0,
+      },
+      wantError: "api_error: 500",
+    },
+  ];
+
+  for (const tc of cases) {
+    it(tc.name, async () => {
+      const { hooks, generations } = await setup();
+
+      for (const part of tc.parts) await emitPartUpdated(hooks, part);
+      await emitMessageUpdated(hooks, tc.final);
+
+      expect(generations).toHaveLength(1);
+      expect(usageOf(generations[0]!)).toEqual(tc.wantUsage);
+      if (tc.wantCost !== undefined) {
+        expect(costOf(generations[0]!)).toBe(tc.wantCost);
+      }
+      if (tc.wantError !== undefined) {
+        expect((generations[0]!.callError as Error).message).toBe(tc.wantError);
+      }
+    });
+  }
+
+  const clearCases: {
+    name: string;
+    clear: (hooks: TestHooks) => Promise<void>;
+  }[] = [
+    {
+      name: "drops partial totals when the session is deleted",
+      clear: (hooks) => emitSessionDeleted(hooks, "s1"),
+    },
+    {
+      name: "drops partial totals on hook state reset",
+      clear: async () => {
+        _resetHookState();
+      },
+    },
+  ];
+
+  for (const tc of clearCases) {
+    it(tc.name, async () => {
+      const { hooks, generations } = await setup();
+
+      await emitPartUpdated(hooks, stepFinishPart("s1", "m1", { input: 100 }));
+      await tc.clear(hooks);
+
+      await emitPartUpdated(hooks, stepFinishPart("s1", "m1", { input: 7 }));
+      await emitMessageUpdated(hooks, assistantMessage("s1", "m1"));
+
+      expect(generations).toHaveLength(1);
+      expect(usageOf(generations[0]!).inputTokens).toBe(7);
+    });
+  }
+
+  it("keeps concurrent messages and sessions separate", async () => {
+    const { hooks, generations } = await setup();
+
+    await emitPartUpdated(hooks, stepFinishPart("s1", "m1", { input: 11 }));
+    await emitPartUpdated(hooks, stepFinishPart("s1", "m2", { input: 22 }));
+    await emitPartUpdated(hooks, stepFinishPart("s2", "m1", { input: 33 }));
+    await emitMessageUpdated(hooks, assistantMessage("s1", "m1"));
+    await emitMessageUpdated(hooks, assistantMessage("s1", "m2"));
+    await emitMessageUpdated(hooks, assistantMessage("s2", "m1"));
+
+    expect(generations.map((gen) => usageOf(gen).inputTokens)).toEqual([
+      11, 22, 33,
+    ]);
+  });
+
+  it("does not reuse a recorded message's totals for the next turn", async () => {
+    const { hooks, generations } = await setup();
+
+    await emitPartUpdated(hooks, stepFinishPart("s1", "m1", { input: 40 }));
+    await emitMessageUpdated(hooks, assistantMessage("s1", "m1"));
+    await emitPartUpdated(hooks, stepFinishPart("s1", "m2", { input: 7 }));
+    await emitMessageUpdated(hooks, assistantMessage("s1", "m2"));
+
+    expect(usageOf(generations[1]!).inputTokens).toBe(7);
+  });
+
+  it("accumulates in metadata_only without fetching the message body", async () => {
+    const { hooks, generations, client } = await setup(
+      baseConfig({ contentCapture: "metadata_only" }),
+    );
+
+    await emitPartUpdated(
+      hooks,
+      stepFinishPart("s1", "m1", { input: 10, output: 2 }),
+    );
+    await emitPartUpdated(
+      hooks,
+      stepFinishPart("s1", "m1", { input: 20, output: 3 }),
+    );
+    await emitMessageUpdated(hooks, assistantMessage("s1", "m1"));
+
+    expect(usageOf(generations[0]!).inputTokens).toBe(30);
+    expect(usageOf(generations[0]!).outputTokens).toBe(5);
+    expect(client.session.message).not.toHaveBeenCalled();
+  });
+
+  // The exported payload does not say which source the tokens came from. The
+  // log line is the only signal that a host stopped emitting step-finish parts
+  // and put last-step tokens back next to all-steps cost.
+  it("debug-logs the fallback and stays quiet when steps were observed", async () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fellBack = () =>
+      logged.mock.calls.some(
+        ([msg]) =>
+          typeof msg === "string" && msg.includes("no step-finish tokens"),
+      );
+    const { hooks } = await setup(baseConfig({ debug: true }));
+
+    await emitMessageUpdated(hooks, assistantMessage("s1", "m1"));
+    expect(fellBack()).toBe(true);
+
+    logged.mockClear();
+    await emitPartUpdated(hooks, stepFinishPart("s1", "m2", { input: 5 }));
+    await emitMessageUpdated(hooks, assistantMessage("s1", "m2"));
+    expect(fellBack()).toBe(false);
+
+    logged.mockRestore();
+  });
+});

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -18,6 +18,7 @@ import {
   mapError,
   mapGeneration,
   mapToolDefinitions,
+  type OpencodeTokens,
 } from "./mappers.js";
 import { Redactor } from "./redact.js";
 import { buildBuiltinTags } from "./tags.js";
@@ -86,8 +87,29 @@ const subagentSessions = new Set<string>();
 // recorded.
 const firstPartAtByMessage = new Map<string, number>();
 
+// Token counts summed over every provider step of one assistant message, keyed
+// by `${sessionID}\x00${messageID}`. opencode adds each step's cost to
+// `AssistantMessage.cost` but overwrites `AssistantMessage.tokens` with the
+// latest step, so a multi-step message pairs last-step tokens with all-steps
+// cost. `StepFinishPart` carries the per-step counts on `message.part.updated`,
+// so this also works in `metadata_only`, where message bodies are never
+// fetched. Consumed and cleared when the message is recorded.
+//
+// opencode 1.18.x runs one step per message, except when `Effect.retry` in
+// `session/processor.ts` retries a stream attempt. This code still sums,
+// because hosts back to `@opencode-ai/plugin` ^1.2.16 are supported.
+const stepTokensByMessage = new Map<string, OpencodeTokens>();
+
 function messageKey(sessionID: string, messageID: string): string {
   return `${sessionID}\x00${messageID}`;
+}
+
+/** Drop every entry of a message-keyed map that belongs to one session. */
+function deleteSessionEntries<V>(map: Map<string, V>, sessionID: string): void {
+  const prefix = `${sessionID}\x00`;
+  for (const key of map.keys()) {
+    if (key.startsWith(prefix)) map.delete(key);
+  }
 }
 
 // Pending generation store: user-side data captured before assistant responds
@@ -186,6 +208,7 @@ export function _resetHookState(): void {
   parentGenerationByChildSession.clear();
   subagentSessions.clear();
   firstPartAtByMessage.clear();
+  stepTokensByMessage.clear();
   pendingGenerations.clear();
   latestSystemPromptBySession.clear();
   latestSessionTitleBySession.clear();
@@ -299,15 +322,7 @@ async function handleEvent(
     return;
   }
   if (event.type === "message.part.updated") {
-    await handleMessagePartUpdated(
-      sigil,
-      config,
-      client,
-      redactor,
-      debugLog,
-      projectDir,
-      event.properties,
-    );
+    handleMessagePartUpdated(event.properties);
     return;
   }
   if (event.type !== "message.updated") return;
@@ -354,40 +369,66 @@ async function handleEvent(
   );
 }
 
-async function handleMessagePartUpdated(
-  sigil: Agento11yClient,
-  config: Agento11yOpencodeConfig,
-  client: OpencodeClient,
-  redactor: Redactor,
-  debugLog: (msg: string, ...args: unknown[]) => void,
-  projectDir: string,
-  properties: unknown,
-): Promise<void> {
+/**
+ * Consume a streamed part: the time-to-first-token signal and, for
+ * `step-finish`, that step's token counts.
+ *
+ * Does not export. `Session.updateMessage` publishes `message.updated` at every
+ * step-finish and again on completion, abort, and error. A host that delivers
+ * parts therefore delivers the terminal message update too, so recording waits
+ * for that instead.
+ */
+function handleMessagePartUpdated(properties: unknown): void {
   const part = recordField(properties, "part");
-  recordFirstPartTime(part);
-  if (stringField(part, "type") !== "step-finish") return;
+  if (!part) return;
+  // `Session.fork` clones a finished message under fresh ids, then republishes
+  // its parts. Nothing reads per-message state after the message is recorded,
+  // so drop those parts rather than let them fill the maps.
   const sessionID = stringField(part, "sessionID");
   const messageID = stringField(part, "messageID");
   if (!sessionID || !messageID) return;
+  if (recordedMessages.get(sessionID)?.has(messageID)) return;
+  recordFirstPartTime(part, sessionID, messageID);
+  accumulateStepTokens(part, messageKey(sessionID, messageID));
+}
 
-  try {
-    const response = await client.session.message({
-      path: { id: sessionID, messageID },
-    });
-    if (response.data?.info?.role !== "assistant") return;
-    await recordAssistantMessage(
-      sigil,
-      config,
-      client,
-      redactor,
-      debugLog,
-      projectDir,
-      response.data.info as AssistantMessage,
-      response.data.parts ?? [],
-    );
-  } catch (err) {
-    debugLog("failed to export terminal message part", err);
-  }
+/**
+ * Add one `step-finish` part's token counts to its message's running totals.
+ * A field that is not a finite number contributes nothing, so a malformed
+ * payload cannot poison the totals with NaN. opencode floors its own counts at
+ * zero in `Session.getUsage`, so only junk reaches that guard.
+ */
+function accumulateStepTokens(
+  part: Record<string, unknown>,
+  key: string,
+): void {
+  if (stringField(part, "type") !== "step-finish") return;
+  const tokens = recordField(part, "tokens");
+  if (!tokens) return;
+  const cache = recordField(tokens, "cache");
+  const step = {
+    input: numberField(tokens, "input"),
+    output: numberField(tokens, "output"),
+    reasoning: numberField(tokens, "reasoning"),
+    read: numberField(cache, "read"),
+    write: numberField(cache, "write"),
+  };
+  // No parseable count means no observed usage. Storing zeros here would look
+  // like a real all-zero step and suppress the `msg.tokens` fallback.
+  if (Object.values(step).every((count) => count === undefined)) return;
+
+  const totals = stepTokensByMessage.get(key) ?? {
+    input: 0,
+    output: 0,
+    reasoning: 0,
+    cache: { read: 0, write: 0 },
+  };
+  totals.input += step.input ?? 0;
+  totals.output += step.output ?? 0;
+  totals.reasoning += step.reasoning ?? 0;
+  totals.cache.read += step.read ?? 0;
+  totals.cache.write += step.write ?? 0;
+  stepTokensByMessage.set(key, totals);
 }
 
 /**
@@ -402,13 +443,13 @@ async function handleMessagePartUpdated(
  * parts (whose timestamp lives under `state.time`) and any part lacking a
  * `time` field still yield a signal. First write wins.
  */
-function recordFirstPartTime(part: Record<string, unknown> | undefined): void {
-  if (!part) return;
+function recordFirstPartTime(
+  part: Record<string, unknown>,
+  sessionID: string,
+  messageID: string,
+): void {
   const type = stringField(part, "type");
   if (type !== "text" && type !== "reasoning" && type !== "tool") return;
-  const sessionID = stringField(part, "sessionID");
-  const messageID = stringField(part, "messageID");
-  if (!sessionID || !messageID) return;
   const key = messageKey(sessionID, messageID);
   if (firstPartAtByMessage.has(key)) return;
   const rawStart = recordField(part, "time")?.start;
@@ -436,10 +477,12 @@ async function recordAssistantMessage(
     },
   });
 
-  // Only record terminal messages
-  const isTerminal =
-    assistantMsg.finish || assistantMsg.error || assistantMsg.time.completed;
+  // Only record terminal messages. `finish` is not terminal: opencode sets it
+  // at every `step-finish`, so only `error` or `time.completed` end a message.
+  const isTerminal = assistantMsg.error || assistantMsg.time.completed;
   if (!isTerminal) return;
+
+  const msgKey = messageKey(assistantMsg.sessionID, assistantMsg.id);
 
   // Dedup
   const sessionSet =
@@ -553,12 +596,23 @@ async function recordAssistantMessage(
     ...(builtinTags && { tags: builtinTags }),
   };
 
+  // Without an observed step the export pairs last-step tokens with all-steps
+  // cost, the mismatch this accumulator removes. A turn that aborts before its
+  // first step-finish hits the fallback legitimately, so log at debug.
+  const stepTokens = stepTokensByMessage.get(msgKey);
+  if (stepTokens === undefined) {
+    debugLog(
+      `no step-finish tokens observed for session=${assistantMsg.sessionID} message=${assistantMsg.id}; using the message's own token counts`,
+    );
+  }
+
   const result = mapGeneration(
     assistantMsg,
     includeMessageBodies ? (pending?.userParts ?? []) : [],
     assistantParts,
     redactor,
     config.contentCapture,
+    stepTokens,
   );
 
   const spanOpts = {
@@ -576,9 +630,7 @@ async function recordAssistantMessage(
   // opencode streams provider responses, so generations are exported with
   // mode=STREAM. The SDK only records the gen_ai.client.time_to_first_token
   // histogram for streaming generations.
-  const firstAt = firstPartAtByMessage.get(
-    messageKey(assistantMsg.sessionID, assistantMsg.id),
-  );
+  const firstAt = firstPartAtByMessage.get(msgKey);
 
   try {
     if (assistantMsg.error) {
@@ -606,13 +658,12 @@ async function recordAssistantMessage(
   // another export path fires for the same session.
   pendingGenerations.delete(assistantMsg.sessionID);
   completedToolExecutions.delete(assistantMsg.sessionID);
-  firstPartAtByMessage.delete(
-    messageKey(assistantMsg.sessionID, assistantMsg.id),
-  );
+  firstPartAtByMessage.delete(msgKey);
+  stepTokensByMessage.delete(msgKey);
 }
 
 function isTerminalMessageUpdate(msg: MessageUpdatedInfo): boolean {
-  return Boolean(msg.finish || msg.error || msg.time?.completed);
+  return Boolean(msg.error || msg.time?.completed);
 }
 
 /** Join OpenCode's system entries. Omit the field when all are empty. */
@@ -697,9 +748,8 @@ async function handleLifecycle(
   const type = event.type;
 
   if (type === "session.idle") {
-    // Recording happens live on `message.updated` and `message.part.updated`
-    // (step-finish). Idle only flushes already-recorded events; it does not
-    // refetch session history.
+    // Recording happens live on `message.updated`. Idle only flushes
+    // already-recorded events; it does not refetch session history.
     //
     // Fire-and-forget: a stuck OTLP endpoint must not block session.idle for
     // up to ~30s (BatchSpanProcessor default) per turn.
@@ -726,16 +776,9 @@ async function handleLifecycle(
       latestSessionTitleBySession.delete(sessionId);
       sessionContexts.delete(sessionId);
       completedToolExecutions.delete(sessionId);
-      for (const key of activeToolExecutions.keys()) {
-        if (key.startsWith(`${sessionId}\x00`)) {
-          activeToolExecutions.delete(key);
-        }
-      }
-      for (const key of firstPartAtByMessage.keys()) {
-        if (key.startsWith(`${sessionId}\x00`)) {
-          firstPartAtByMessage.delete(key);
-        }
-      }
+      deleteSessionEntries(activeToolExecutions, sessionId);
+      deleteSessionEntries(firstPartAtByMessage, sessionId);
+      deleteSessionEntries(stepTokensByMessage, sessionId);
     }
   }
 
@@ -922,6 +965,14 @@ function recordField(
   const field = (value as Record<string, unknown>)[key];
   return field && typeof field === "object"
     ? (field as Record<string, unknown>)
+    : undefined;
+}
+
+function numberField(value: unknown, key: string): number | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const field = (value as Record<string, unknown>)[key];
+  return typeof field === "number" && Number.isFinite(field)
+    ? field
     : undefined;
 }
 

--- a/plugins/opencode/src/mappers.test.ts
+++ b/plugins/opencode/src/mappers.test.ts
@@ -434,4 +434,42 @@ describe("mapGeneration", () => {
     expect(result.stopReason).toBe("end_turn");
     expect(result.completedAt).toBeInstanceOf(Date);
   });
+
+  it("prefers accumulated step tokens over the message's last-step tokens", () => {
+    // msg.cost covers every step; msg.tokens only the last one.
+    const msg = makeAssistantMsg({ cost: 0.06 });
+    const result = mapGeneration(msg, [], [], redactor, "full", {
+      input: 310,
+      output: 60,
+      reasoning: 15,
+      cache: { read: 70, write: 14 },
+    });
+    expect(result.usage).toEqual({
+      inputTokens: 310,
+      outputTokens: 60,
+      reasoningTokens: 15,
+      cacheReadInputTokens: 70,
+      cacheWriteInputTokens: 14,
+    });
+    expect(result.metadata?.cost).toBe(0.06);
+  });
+
+  it("keeps input cache-adjusted and reasoning out of output", () => {
+    // opencode's getUsage subtracts cache read/write from input and reasoning
+    // from output, so these pass through as reported: 80, not 80 + 20 + 10, and
+    // 25, not 25 + 7.
+    const result = mapGeneration(makeAssistantMsg(), [], [], redactor, "full", {
+      input: 80,
+      output: 25,
+      reasoning: 7,
+      cache: { read: 20, write: 10 },
+    });
+    expect(result.usage).toEqual({
+      inputTokens: 80,
+      outputTokens: 25,
+      reasoningTokens: 7,
+      cacheReadInputTokens: 20,
+      cacheWriteInputTokens: 10,
+    });
+  });
 });

--- a/plugins/opencode/src/mappers.ts
+++ b/plugins/opencode/src/mappers.ts
@@ -174,23 +174,38 @@ export function mapToolDefinitions(names: Iterable<string>): ToolDefinition[] {
   return [...uniq].sort().map((name) => ({ name, type: "function" }));
 }
 
-/** Map an AssistantMessage + parts to an agento11y GenerationResult with content. */
+/**
+ * Token counts in opencode's shape, shared by `AssistantMessage.tokens` and
+ * `StepFinishPart.tokens`. `input` excludes cached tokens and `output` excludes
+ * reasoning tokens; `Session.getUsage` subtracts both upstream.
+ */
+export type OpencodeTokens = AssistantMessage["tokens"];
+
+/**
+ * Map an AssistantMessage + parts to an agento11y GenerationResult with content.
+ *
+ * `tokens` are the per-step counts summed over the whole message, which the
+ * caller accumulates from `step-finish` parts. Omit them to use `msg.tokens`,
+ * which on a multi-step message covers only the last step.
+ */
 export function mapGeneration(
   msg: AssistantMessage,
   userParts: Part[],
   assistantParts: Part[],
   redactor: Redactor,
   contentCapture: ContentCaptureMode = "full",
+  tokens?: OpencodeTokens,
 ): GenerationResult {
+  const usage = tokens ?? msg.tokens;
   return {
     input: mapInputMessages(userParts, contentCapture),
     output: mapOutputMessages(assistantParts, redactor, contentCapture),
     usage: {
-      inputTokens: msg.tokens.input,
-      outputTokens: msg.tokens.output,
-      reasoningTokens: msg.tokens.reasoning,
-      cacheReadInputTokens: msg.tokens.cache.read,
-      cacheWriteInputTokens: msg.tokens.cache.write,
+      inputTokens: usage.input,
+      outputTokens: usage.output,
+      reasoningTokens: usage.reasoning,
+      cacheReadInputTokens: usage.cache.read,
+      cacheWriteInputTokens: usage.cache.write,
     },
     responseModel: msg.modelID,
     stopReason: msg.finish,


### PR DESCRIPTION
This PR fixes an issue in the opencode plugin when it adds each step's cost to `AssistantMessage.cost` but overwrites `AssistantMessage.tokens` with the latest step, so a multi-step message exported last-step tokens with to all-steps cost.