### PR TITLE
fix(sdk/go): release exported batch references

### DIFF
--- a/go/agento11y/exporter.go
+++ b/go/agento11y/exporter.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -539,9 +540,9 @@ func (c *Client) runExportWorker() {
 			return nil
 		}
 
-		request := &agento11yv1.ExportGenerationsRequest{Generations: generationBatch}
+		request := &agento11yv1.ExportGenerationsRequest{Generations: slices.Clone(generationBatch)}
 		err := c.exportWithRetry(request)
-		generationBatch = generationBatch[:0]
+		generationBatch = resetBatch(generationBatch)
 		return err
 	}
 	flushWorkflowSteps := func() error {
@@ -549,9 +550,9 @@ func (c *Client) runExportWorker() {
 			return nil
 		}
 
-		request := &agento11yv1.ExportWorkflowStepsRequest{WorkflowSteps: workflowStepBatch}
+		request := &agento11yv1.ExportWorkflowStepsRequest{WorkflowSteps: slices.Clone(workflowStepBatch)}
 		err := c.exportWorkflowStepsWithRetry(request)
-		workflowStepBatch = workflowStepBatch[:0]
+		workflowStepBatch = resetBatch(workflowStepBatch)
 		return err
 	}
 	flushAll := func() error {
@@ -692,6 +693,13 @@ func (c *Client) runExportWorker() {
 			resetTimer(timer, flushInterval)
 		}
 	}
+}
+
+// resetBatch clears pointer slots before reusing the backing array so exported
+// payloads can be garbage collected while the batch is empty.
+func resetBatch[T any](batch []*T) []*T {
+	clear(batch)
+	return batch[:0]
 }
 
 func resetTimer(timer *time.Timer, duration time.Duration) {

--- a/go/agento11y/exporter_test.go
+++ b/go/agento11y/exporter_test.go
@@ -171,6 +171,24 @@ func TestGenerationExporterFlushesByInterval(t *testing.T) {
 	}
 }
 
+func TestResetBatchClearsReferences(t *testing.T) {
+	first := 1
+	second := 2
+	batch := []*int{&first, &second}
+	backing := batch
+
+	batch = resetBatch(batch)
+
+	if len(batch) != 0 {
+		t.Fatalf("reset batch length = %d, want 0", len(batch))
+	}
+	for i, value := range backing {
+		if value != nil {
+			t.Errorf("backing array slot %d still retains a reference", i)
+		}
+	}
+}
+
 func TestShutdownFlushesPendingGenerations(t *testing.T) {
 	exporter := &capturingGenerationExporter{}
 	client := NewClient(Config{


### PR DESCRIPTION
## What changed

- detach export request slices from the worker's reusable batch storage
- clear generation and workflow-step batch pointer slots after every flush
- add a regression test covering reference cleanup

## Why

The export worker previously reset batches with `batch = batch[:0]`. Because the backing arrays contain pointers, that kept the most recently exported payload reachable until each slot was overwritten by a later export.

For large generation payloads, this can retain the previous request while the next request is being mapped and serialized, causing a substantial temporary heap overlap. Clearing the pointer slots lets the payload be collected immediately after the synchronous export completes. Cloning the small request slice preserves the existing exporter contract for implementations that retain the request after `Export` returns.

## Validation

- `mise run test:go:sdk-core`
- `GOWORK=off go vet ./...` in `go/`
- `golangci-lint v2.12.2 run ./...` in `go/`
