### PR TITLE
fix(sdk/go): detach retained metric label strings

### DIFF
--- a/go/agento11y/client.go
+++ b/go/agento11y/client.go
@@ -2246,7 +2246,10 @@ func (c *Client) clientTagMetricAttributes() []attribute.KeyValue {
 func metricIdentityAttributes(provider, model, agentName, agentVersion string) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		attribute.String(spanAttrProviderName, strings.TrimSpace(provider)),
-		attribute.String(spanAttrRequestModel, strings.TrimSpace(model)),
+		// Cumulative metric aggregators retain the first attribute set for each
+		// series. Some provider decoders return model names backed by the complete
+		// JSON request, so detach this small value before handing it to OTel.
+		attribute.String(spanAttrRequestModel, strings.Clone(strings.TrimSpace(model))),
 		attribute.String(spanAttrAgentName, strings.TrimSpace(agentName)),
 	}
 	if version := strings.TrimSpace(agentVersion); version != "" {

--- a/go/agento11y/client.go
+++ b/go/agento11y/client.go
@@ -2050,15 +2050,15 @@ func (c *Client) recordGenerationMetrics(ctx context.Context, generation Generat
 	// Include per-request context tags (WithTag/WithTags) as metric dimensions
 	// alongside the static client tags. Callers are responsible for keeping
 	// context-tag values low-cardinality since they become metric labels.
-	tagAttrs := tagAttributes(mergeTags(c.config.Tags, TagsFromContext(ctx)))
+	tagAttrs := metricTagAttributes(mergeTags(c.config.Tags, TagsFromContext(ctx)))
 	durationAttrs := append(
-		[]attribute.KeyValue{attribute.String(spanAttrOperationName, operationName(generation))},
+		[]attribute.KeyValue{metricStringAttribute(spanAttrOperationName, operationName(generation))},
 		identityAttrs...,
 	)
 	durationAttrs = append(durationAttrs, tagAttrs...)
 	durationAttrs = append(durationAttrs,
-		attribute.String(spanAttrErrorType, errorType),
-		attribute.String(spanAttrErrorCategory, errorCategory),
+		metricStringAttribute(spanAttrErrorType, errorType),
+		metricStringAttribute(spanAttrErrorCategory, errorCategory),
 	)
 	c.instruments.operationDuration.Record(ctx, duration, metric.WithAttributes(durationAttrs...))
 
@@ -2067,11 +2067,11 @@ func (c *Client) recordGenerationMetrics(ctx context.Context, generation Generat
 			return
 		}
 		tokenAttrs := append(
-			[]attribute.KeyValue{attribute.String(spanAttrOperationName, operationName(generation))},
+			[]attribute.KeyValue{metricStringAttribute(spanAttrOperationName, operationName(generation))},
 			identityAttrs...,
 		)
 		tokenAttrs = append(tokenAttrs, tagAttrs...)
-		tokenAttrs = append(tokenAttrs, attribute.String(metricAttrTokenType, tokenType))
+		tokenAttrs = append(tokenAttrs, metricStringAttribute(metricAttrTokenType, tokenType))
 		c.instruments.tokenUsage.Record(ctx, value, metric.WithAttributes(tokenAttrs...))
 	}
 
@@ -2132,13 +2132,13 @@ func (c *Client) recordEmbeddingMetrics(
 	identityAttrs := metricIdentityAttributes(provider, model, agentName, seed.AgentVersion)
 	tagAttrs := c.clientTagMetricAttributes()
 	durationAttrs := append(
-		[]attribute.KeyValue{attribute.String(spanAttrOperationName, defaultEmbeddingOperationName)},
+		[]attribute.KeyValue{metricStringAttribute(spanAttrOperationName, defaultEmbeddingOperationName)},
 		identityAttrs...,
 	)
 	durationAttrs = append(durationAttrs, tagAttrs...)
 	durationAttrs = append(durationAttrs,
-		attribute.String(spanAttrErrorType, errorType),
-		attribute.String(spanAttrErrorCategory, errorCategory),
+		metricStringAttribute(spanAttrErrorType, errorType),
+		metricStringAttribute(spanAttrErrorCategory, errorCategory),
 	)
 	c.instruments.operationDuration.Record(
 		ctx,
@@ -2148,11 +2148,11 @@ func (c *Client) recordEmbeddingMetrics(
 
 	if result.InputTokens != 0 {
 		tokenAttrs := append(
-			[]attribute.KeyValue{attribute.String(spanAttrOperationName, defaultEmbeddingOperationName)},
+			[]attribute.KeyValue{metricStringAttribute(spanAttrOperationName, defaultEmbeddingOperationName)},
 			identityAttrs...,
 		)
 		tokenAttrs = append(tokenAttrs, tagAttrs...)
-		tokenAttrs = append(tokenAttrs, attribute.String(metricAttrTokenType, metricTokenTypeInput))
+		tokenAttrs = append(tokenAttrs, metricStringAttribute(metricAttrTokenType, metricTokenTypeInput))
 		c.instruments.tokenUsage.Record(
 			ctx,
 			result.InputTokens,
@@ -2183,13 +2183,13 @@ func (c *Client) recordToolExecutionMetrics(ctx context.Context, seed ToolExecut
 	}
 	attrs := metricIdentityAttributes(seed.RequestProvider, seed.RequestModel, seed.AgentName, seed.AgentVersion)
 	attrs = append([]attribute.KeyValue{
-		attribute.String(spanAttrOperationName, "execute_tool"),
-		attribute.String(spanAttrToolName, strings.TrimSpace(seed.ToolName)),
+		metricStringAttribute(spanAttrOperationName, "execute_tool"),
+		metricStringAttribute(spanAttrToolName, strings.TrimSpace(seed.ToolName)),
 	}, attrs...)
 	attrs = append(attrs, c.clientTagMetricAttributes()...)
 	attrs = append(attrs,
-		attribute.String(spanAttrErrorType, errorType),
-		attribute.String(spanAttrErrorCategory, errorCategory),
+		metricStringAttribute(spanAttrErrorType, errorType),
+		metricStringAttribute(spanAttrErrorCategory, errorCategory),
 	)
 	c.instruments.operationDuration.Record(
 		ctx,
@@ -2240,22 +2240,34 @@ func (c *Client) clientTagMetricAttributes() []attribute.KeyValue {
 	if c == nil {
 		return nil
 	}
-	return tagAttributes(c.config.Tags)
+	return metricTagAttributes(c.config.Tags)
 }
 
 func metricIdentityAttributes(provider, model, agentName, agentVersion string) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
-		attribute.String(spanAttrProviderName, strings.TrimSpace(provider)),
-		// Cumulative metric aggregators retain the first attribute set for each
-		// series. Some provider decoders return model names backed by the complete
-		// JSON request, so detach this small value before handing it to OTel.
-		attribute.String(spanAttrRequestModel, strings.Clone(strings.TrimSpace(model))),
-		attribute.String(spanAttrAgentName, strings.TrimSpace(agentName)),
+		metricStringAttribute(spanAttrProviderName, strings.TrimSpace(provider)),
+		metricStringAttribute(spanAttrRequestModel, strings.TrimSpace(model)),
+		metricStringAttribute(spanAttrAgentName, strings.TrimSpace(agentName)),
 	}
 	if version := strings.TrimSpace(agentVersion); version != "" {
-		attrs = append(attrs, attribute.String(spanAttrAgentVersion, version))
+		attrs = append(attrs, metricStringAttribute(spanAttrAgentVersion, version))
 	}
 	return attrs
+}
+
+func metricTagAttributes(tags map[string]string) []attribute.KeyValue {
+	attrs := tagAttributes(tags)
+	for i := range attrs {
+		attrs[i] = metricStringAttribute(string(attrs[i].Key), attrs[i].Value.AsString())
+	}
+	return attrs
+}
+
+// metricStringAttribute detaches label values from caller-owned backing
+// storage. Cumulative metric aggregators may retain the first attribute set for
+// every series for the lifetime of the process.
+func metricStringAttribute(key, value string) attribute.KeyValue {
+	return attribute.String(key, strings.Clone(value))
 }
 
 func countToolCalls(messages []Message) int {

--- a/go/agento11y/client_test.go
+++ b/go/agento11y/client_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 	"unicode/utf8"
+	"unsafe"
 
 	agento11yv1 "github.com/grafana/agento11y/go/proto/agento11y/v1"
 	"go.opentelemetry.io/otel/attribute"
@@ -29,6 +30,27 @@ func TestDefaultConfigGenerationExportMessageAndPayloadLimits(t *testing.T) {
 	}
 	if cfg.GenerationExport.PayloadMaxBytes != defaultGenerationPayloadMaxBytes {
 		t.Fatalf("expected payload max bytes %d, got %d", defaultGenerationPayloadMaxBytes, cfg.GenerationExport.PayloadMaxBytes)
+	}
+}
+
+func TestMetricIdentityAttributesDetachModelStorage(t *testing.T) {
+	backing := "prefix " + strings.Repeat("model", 32) + " suffix"
+	model := backing[len("prefix ") : len(backing)-len(" suffix")]
+
+	attrs := metricIdentityAttributes("anthropic", model, "assistant", "")
+	var got string
+	for _, attr := range attrs {
+		if attr.Key == spanAttrRequestModel {
+			got = attr.Value.AsString()
+			break
+		}
+	}
+
+	if got != model {
+		t.Fatalf("model attribute = %q, want %q", got, model)
+	}
+	if unsafe.StringData(got) == unsafe.StringData(model) {
+		t.Fatal("model attribute still shares the caller's backing storage")
 	}
 }
 

--- a/go/agento11y/client_test.go
+++ b/go/agento11y/client_test.go
@@ -33,24 +33,34 @@ func TestDefaultConfigGenerationExportMessageAndPayloadLimits(t *testing.T) {
 	}
 }
 
-func TestMetricIdentityAttributesDetachModelStorage(t *testing.T) {
-	backing := "prefix " + strings.Repeat("model", 32) + " suffix"
-	model := backing[len("prefix ") : len(backing)-len(" suffix")]
+func TestMetricStringAttributeDetachesStorage(t *testing.T) {
+	backing := "prefix " + strings.Repeat("value", 32) + " suffix"
+	value := backing[len("prefix ") : len(backing)-len(" suffix")]
 
-	attrs := metricIdentityAttributes("anthropic", model, "assistant", "")
-	var got string
-	for _, attr := range attrs {
-		if attr.Key == spanAttrRequestModel {
-			got = attr.Value.AsString()
-			break
-		}
-	}
+	got := metricStringAttribute("key", value).Value.AsString()
 
-	if got != model {
-		t.Fatalf("model attribute = %q, want %q", got, model)
+	if got != value {
+		t.Fatalf("metric attribute = %q, want %q", got, value)
 	}
-	if unsafe.StringData(got) == unsafe.StringData(model) {
-		t.Fatal("model attribute still shares the caller's backing storage")
+	if unsafe.StringData(got) == unsafe.StringData(value) {
+		t.Fatal("metric attribute still shares the caller's backing storage")
+	}
+}
+
+func TestMetricTagAttributesDetachStorage(t *testing.T) {
+	backing := "prefix " + strings.Repeat("tag", 32) + " suffix"
+	value := backing[len("prefix ") : len(backing)-len(" suffix")]
+
+	attrs := metricTagAttributes(map[string]string{"stack_id": value})
+	if len(attrs) != 1 {
+		t.Fatalf("metric tag attribute count = %d, want 1", len(attrs))
+	}
+	got := attrs[0].Value.AsString()
+	if got != value {
+		t.Fatalf("metric tag attribute = %q, want %q", got, value)
+	}
+	if unsafe.StringData(got) == unsafe.StringData(value) {
+		t.Fatal("metric tag attribute still shares the caller's backing storage")
 	}
 }
 


### PR DESCRIPTION
Clone every string-valued metric label before storing it in OpenTelemetry attribute sets. This covers identity, operation, error, token-type, tool-name, and static or per-request tag values.

Some provider decoders return small strings backed by complete serialized requests. Because cumulative metric aggregators retain the first attributes for each series, a label could otherwise keep an entire request alive. The regression tests verify that ordinary and context-tag label values remain equal while owning separate backing storage.

**Testing:**
- `mise run test:go:sdk-core`
- `GOWORK=off go vet ./...` in `go/`
