### PR TITLE
fix(plugins/agento11y): correct doctor version, alignment, and agent install state

### DIFF
--- a/plugins/agento11y/internal/doctor/agents.go
+++ b/plugins/agento11y/internal/doctor/agents.go
@@ -66,7 +66,9 @@ func defaultCollectAgents(ctx context.Context, binaryVersion string) []AgentStat
 }
 
 func probeAgent(ctx context.Context, probe agentProbe, binaryVersion string) AgentStatus {
-	a := AgentStatus{Name: probe.name, Note: probe.note, notInstalledLabel: probe.notInstalledLabel}
+	// Unknown until a probe says otherwise: every early return below leaves
+	// the install state undetermined.
+	a := AgentStatus{Name: probe.name, Install: InstallStateUnknown, Note: probe.note, notInstalledLabel: probe.notInstalledLabel}
 	_, lookErr := lookPath(probe.bin)
 	a.OnPath = lookErr == nil
 
@@ -94,15 +96,18 @@ func probeAgent(ctx context.Context, probe agentProbe, binaryVersion string) Age
 
 	installed, version, err := probe.status(ctx)
 	if err != nil {
+		// The state stays unknown and the renderer says so; the note carries
+		// the reason the probe could not answer.
 		a.Health = HealthWarn
-		a.Note = appendNote(a.Note, "install state unknown: "+err.Error())
+		a.Note = appendNote(a.Note, err.Error())
 		return a
 	}
-	a.Installed = installed
 	a.Version = version
 	if installed {
+		a.Install = InstallStateInstalled
 		a.Health = HealthOK
 	} else {
+		a.Install = InstallStateNotInstalled
 		a.Health = HealthWarn
 	}
 	return a

--- a/plugins/agento11y/internal/doctor/agents_test.go
+++ b/plugins/agento11y/internal/doctor/agents_test.go
@@ -2,7 +2,9 @@ package doctor
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -38,23 +40,60 @@ func TestDefaultCollectAgents(t *testing.T) {
 		byName[a.Name] = a
 	}
 
-	if a := byName["claude"]; !a.OnPath || !a.Installed || a.Version != "0.3.0" || a.Health != HealthOK {
+	if a := byName["claude"]; !a.OnPath || a.Install != InstallStateInstalled || a.Version != "0.3.0" || a.Health != HealthOK {
 		t.Fatalf("claude = %+v", a)
 	}
-	if a := byName["codex"]; a.OnPath || a.Health != HealthSkipped {
-		t.Fatalf("codex = %+v, want not-on-path/skipped", a)
+	if a := byName["codex"]; a.OnPath || a.Health != HealthSkipped || a.Install != InstallStateUnknown {
+		t.Fatalf("codex = %+v, want not-on-path/skipped/unknown", a)
 	}
-	if a := byName["cfgcli"]; a.OnPath || !a.Installed || a.Version != "2.0.0" || a.Health != HealthOK {
+	if a := byName["cfgcli"]; a.OnPath || a.Install != InstallStateInstalled || a.Version != "2.0.0" || a.Health != HealthOK {
 		t.Fatalf("cfgcli = %+v, want not-on-path but installed/ok via config probe", a)
 	} else if a.notInstalledLabel != "not configured" {
 		t.Fatalf("cfgcli notInstalledLabel = %q, want propagated from probe", a.notInstalledLabel)
 	}
-	if a := byName["errcli"]; !a.OnPath || a.Health != HealthWarn || a.Installed {
-		t.Fatalf("errcli = %+v, want on-path/warn/not-installed", a)
-	} else if a.Note == "" {
-		t.Fatalf("errcli note should record the probe error")
+	// A probe that errors leaves the state unknown. Reporting not_installed
+	// here would put a false negative in the --json contract.
+	if a := byName["errcli"]; !a.OnPath || a.Health != HealthWarn || a.Install != InstallStateUnknown {
+		t.Fatalf("errcli = %+v, want on-path/warn/unknown", a)
+	} else if !strings.Contains(a.Note, "probe boom") {
+		t.Fatalf("errcli note = %q, want the probe error", a.Note)
 	}
 	if a := byName["cursor"]; !a.OnPath || !a.HookBased || a.Version != "9.9.9" || a.Health != HealthOK {
 		t.Fatalf("cursor = %+v, want on-path/hook-based/sigil-version/ok", a)
+	}
+
+	// The JSON contract carries the tri-state, not a bool that would read as
+	// "not installed" for a state doctor never determined.
+	encoded, err := json.Marshal(byName["errcli"])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if fields["install_state"] != string(InstallStateUnknown) {
+		t.Fatalf("errcli install_state = %v, want %q", fields["install_state"], InstallStateUnknown)
+	}
+	if _, ok := fields["installed"]; ok {
+		t.Fatalf("errcli JSON still carries an installed bool: %s", encoded)
+	}
+}
+
+// An AgentStatus built without an install state must not read as a definite
+// "not installed" in either output. The zero value is outside the domain, so
+// both the renderer and the JSON contract map it to unknown.
+func TestAgentStatus_UnsetInstallStateIsUnknown(t *testing.T) {
+	a := AgentStatus{Name: "claude", OnPath: true, Health: HealthWarn}
+
+	if got, want := describeAgent(palette{}, a), "install state unknown"; got != want {
+		t.Fatalf("describeAgent = %q, want %q", got, want)
+	}
+	encoded, err := json.Marshal(a)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"install_state":"unknown"`) {
+		t.Fatalf("JSON = %s, want install_state unknown", encoded)
 	}
 }

--- a/plugins/agento11y/internal/doctor/doctor.go
+++ b/plugins/agento11y/internal/doctor/doctor.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -25,6 +26,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/grafana/agento11y/go/proto/agento11y/wire"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/dotenv"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/local"
@@ -209,18 +211,48 @@ type AnalyticsSection struct {
 	Probe       *AnalyticsProbe `json:"probe,omitempty"`
 }
 
+// InstallState is the outcome of an agent's install probe. It is tri-state
+// because the probe can fail (an unreadable hook file, a CLI that errors):
+// reporting such an agent as not installed would state a fact doctor never
+// established.
+type InstallState string
+
+const (
+	InstallStateInstalled    InstallState = "installed"
+	InstallStateNotInstalled InstallState = "not_installed"
+	InstallStateUnknown      InstallState = "unknown"
+)
+
+// orUnknown maps any value outside the domain, including the zero value, to
+// unknown. A status built without the field must not read as a definite
+// "not installed", which is the false negative the tri-state removes.
+func (s InstallState) orUnknown() InstallState {
+	switch s {
+	case InstallStateInstalled, InstallStateNotInstalled, InstallStateUnknown:
+		return s
+	default:
+		return InstallStateUnknown
+	}
+}
+
+// MarshalJSON keeps the JSON contract inside the domain: the field is always
+// one of the three states, never an empty string.
+func (s InstallState) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(s.orUnknown()))
+}
+
 // AgentStatus reports one host agent's detection + install state. HookBased is
 // set for agents the agento11y binary never installs (cursor): their capture is
 // wired into the host's own hook settings, so install state isn't something
 // doctor can read.
 type AgentStatus struct {
-	Name      string `json:"name"`
-	OnPath    bool   `json:"on_path"`
-	Installed bool   `json:"installed"`
-	HookBased bool   `json:"hook_based,omitempty"`
-	Version   string `json:"version,omitempty"`
-	Note      string `json:"note,omitempty"`
-	Health    Health `json:"status"`
+	Name      string       `json:"name"`
+	OnPath    bool         `json:"on_path"`
+	Install   InstallState `json:"install_state"`
+	HookBased bool         `json:"hook_based,omitempty"`
+	Version   string       `json:"version,omitempty"`
+	Note      string       `json:"note,omitempty"`
+	Health    Health       `json:"status"`
 
 	// notInstalledLabel overrides the human "plugin not installed" wording for
 	// non-plugin agents (copilot). Human-only; not part of the JSON contract.
@@ -388,6 +420,15 @@ func collectConversations(osEnv, fileEnv map[string]string) ConversationsSection
 			missing = append(missing, "AGENTO11Y_AUTH_TOKEN")
 		}
 		sec.Messages = append(sec.Messages, "incomplete credentials; missing "+strings.Join(missing, ", "))
+	}
+	// A set endpoint still has to be a URL the exporter can build a request
+	// from. Without this the offline run calls a malformed endpoint healthy and
+	// only --probe, which needs the network, reports the problem.
+	if endpoint.set {
+		if _, err := wire.NormalizeGenerationExportURL(endpoint.value, resolveInsecure(osEnv, fileEnv)); err != nil {
+			sec.Health = HealthError
+			sec.Messages = append(sec.Messages, fmt.Sprintf("%s is not a usable endpoint: %v", endpoint.key, err))
+		}
 	}
 	for _, r := range []resolved{endpoint, tenant, token} {
 		if r.conflict {
@@ -619,11 +660,20 @@ func hookForwardReason(resolve func(suffix string, osEnv, fileEnv map[string]str
 	)
 }
 
+// resolveInsecure reads the INSECURE flag, which picks http over https for a
+// scheme-less endpoint. The offline endpoint check and the live probe resolve
+// it here so they cannot disagree about the same endpoint.
+func resolveInsecure(osEnv, fileEnv map[string]string) bool {
+	return envconfig.ParseBool(resolveFamily("INSECURE", osEnv, fileEnv).value)
+}
+
 func runProbes(ctx context.Context, r *Report, osEnv, fileEnv map[string]string) {
-	if r.Conversations.configured() {
+	// An endpoint the offline check already rejected has nothing to probe:
+	// probing it would report the same fault a second and third time. Inside
+	// configured(), HealthError can only come from that check.
+	if r.Conversations.configured() && r.Conversations.Health != HealthError {
 		token := resolveFamily("AUTH_TOKEN", osEnv, fileEnv).value
-		insecure := envconfig.ParseBool(resolveFamily("INSECURE", osEnv, fileEnv).value)
-		res := probeConversationsFn(ctx, r.Conversations.Endpoint.Value, r.Conversations.TenantID.Value, token, insecure)
+		res := probeConversationsFn(ctx, r.Conversations.Endpoint.Value, r.Conversations.TenantID.Value, token, resolveInsecure(osEnv, fileEnv))
 		r.Conversations.Probe = res
 		switch {
 		case res.authFailure():

--- a/plugins/agento11y/internal/doctor/doctor_test.go
+++ b/plugins/agento11y/internal/doctor/doctor_test.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
 
 // mergeEnv returns the union of the given env maps, later entries winning.
@@ -22,13 +24,26 @@ func mergeEnv(envs ...map[string]string) map[string]string {
 }
 
 // isolateEnv points the dotenv/state roots at a fresh tempdir and clears the
-// tracked env vars so a test never reads the developer's real config.
+// branded env vars so a test never reads the developer's real config.
+//
+// It clears every AGENTO11Y_* and SIGIL_* key the shell exports rather than a
+// hand-listed subset: doctor and envconfig read families that trackedKeys does
+// not cover (GUARDS_TIMEOUT_MS, GUARDS_FAIL_OPEN), so on a configured machine
+// the host value would decide the result.
 func isolateEnv(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
 	t.Setenv("XDG_STATE_HOME", filepath.Join(dir, "state"))
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(key, "AGENTO11Y_") || strings.HasPrefix(key, "SIGIL_") {
+			t.Setenv(key, "")
+		}
+	}
+	// trackedKeys adds the unbranded OTel vars and any branded key the shell
+	// happens not to export.
 	for _, k := range trackedKeys {
 		t.Setenv(k, "")
 	}
@@ -165,6 +180,27 @@ func TestCollectConversations(t *testing.T) {
 			osEnv:      map[string]string{"SIGIL_ENDPOINT": "https://x", "SIGIL_AUTH_TENANT_ID": "1", "SIGIL_AUTH_TOKEN": "glc_t"},
 			wantHealth: HealthOK,
 			wantMsg:    "preferred names are AGENTO11Y_*",
+		},
+		{
+			// Set credentials alone are not a working config: an endpoint the
+			// exporter cannot build a request from fails without --probe.
+			name:       "malformed endpoint fails offline",
+			osEnv:      map[string]string{"AGENTO11Y_ENDPOINT": "not a url ://", "AGENTO11Y_AUTH_TENANT_ID": "1", "AGENTO11Y_AUTH_TOKEN": "glc_t"},
+			wantHealth: HealthError,
+			wantMsg:    "AGENTO11Y_ENDPOINT is not a usable endpoint",
+		},
+		{
+			name:       "endpoint with an empty host fails offline",
+			osEnv:      map[string]string{"AGENTO11Y_ENDPOINT": "https:///generations", "AGENTO11Y_AUTH_TENANT_ID": "1", "AGENTO11Y_AUTH_TOKEN": "glc_t"},
+			wantHealth: HealthError,
+			wantMsg:    "not a usable endpoint",
+		},
+		{
+			// The exporter prepends https:// (http:// under INSECURE) to a
+			// scheme-less endpoint, so it is usable and doctor must accept it.
+			name:       "scheme-less endpoint stays valid",
+			osEnv:      map[string]string{"AGENTO11Y_ENDPOINT": "collector.local:4317", "AGENTO11Y_AUTH_TENANT_ID": "1", "AGENTO11Y_AUTH_TOKEN": "glc_t"},
+			wantHealth: HealthOK,
 		},
 	}
 	for _, tc := range tests {
@@ -327,11 +363,14 @@ func TestCollectAnalytics(t *testing.T) {
 
 func TestRunProbes(t *testing.T) {
 	tests := []struct {
-		name          string
-		conv          *ProbeResult
-		otlp          *AnalyticsProbe
-		wantConv      Health
-		wantAnalytics Health
+		name string
+		conv *ProbeResult
+		otlp *AnalyticsProbe
+		// convHealth is the verdict the offline collectors reached; "" means ok.
+		convHealth      Health
+		wantConv        Health
+		wantAnalytics   Health
+		wantConvSkipped bool
 	}{
 		{
 			name:          "all reachable",
@@ -368,6 +407,17 @@ func TestRunProbes(t *testing.T) {
 			wantConv:      HealthOK,
 			wantAnalytics: HealthOK,
 		},
+		{
+			// The offline endpoint check already failed, so probing would
+			// report the same fault a second and third time.
+			name:            "endpoint already rejected offline is not probed",
+			conv:            &ProbeResult{StatusCode: 0, Message: "invalid endpoint: parse …"},
+			otlp:            &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 200, OK: true}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			convHealth:      HealthError,
+			wantConv:        HealthError,
+			wantAnalytics:   HealthOK,
+			wantConvSkipped: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -376,12 +426,17 @@ func TestRunProbes(t *testing.T) {
 			probeConversationsFn = func(context.Context, string, string, string, bool) *ProbeResult { return tc.conv }
 			probeOTLPFn = func(context.Context) *AnalyticsProbe { return tc.otlp }
 
+			convHealth := tc.convHealth
+			if convHealth == "" {
+				convHealth = HealthOK
+			}
 			r := &Report{
 				Conversations: ConversationsSection{
 					Endpoint: envValue{Set: true, Value: "https://sigil.example.net"},
 					TenantID: envValue{Set: true, Value: "t"},
 					Token:    tokenValue{Set: true},
-					Health:   HealthOK,
+					Health:   convHealth,
+					Messages: []string{"AGENTO11Y_ENDPOINT is not a usable endpoint: …"},
 				},
 				Analytics: AnalyticsSection{
 					Endpoint: envValue{Set: true, Value: "https://otlp.example.net"},
@@ -391,6 +446,16 @@ func TestRunProbes(t *testing.T) {
 			runProbes(context.Background(), r, map[string]string{}, nil)
 			if r.Conversations.Health != tc.wantConv {
 				t.Fatalf("conversations health = %q, want %q", r.Conversations.Health, tc.wantConv)
+			}
+			if tc.wantConvSkipped {
+				if r.Conversations.Probe != nil {
+					t.Fatalf("conversations probe ran = %+v, want skipped", r.Conversations.Probe)
+				}
+				if len(r.Conversations.Messages) != 1 {
+					t.Fatalf("conversations messages = %v, want the offline message alone", r.Conversations.Messages)
+				}
+			} else if r.Conversations.Probe == nil {
+				t.Fatal("conversations probe did not run")
 			}
 			if r.Analytics.Health != tc.wantAnalytics {
 				t.Fatalf("analytics health = %q, want %q", r.Analytics.Health, tc.wantAnalytics)
@@ -550,12 +615,12 @@ func TestCollectConfig_Guards(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			// ResolveGuards reads the process env directly, so isolateEnv has to
+			// clear the host's GUARDS_* values before the case sets its own.
 			isolateEnv(t)
-			// ResolveGuards reads the process env directly, so clear the guard
-			// vars first to keep the baseline independent of the host shell.
-			t.Setenv("SIGIL_GUARDS_ENABLED", tc.enabled)
-			t.Setenv("SIGIL_GUARDS_TIMEOUT_MS", tc.timeout)
-			t.Setenv("SIGIL_GUARDS_FAIL_OPEN", tc.failOpen)
+			t.Setenv(envconfig.PreferredKey("GUARDS_ENABLED"), tc.enabled)
+			t.Setenv(envconfig.PreferredKey("GUARDS_TIMEOUT_MS"), tc.timeout)
+			t.Setenv(envconfig.PreferredKey("GUARDS_FAIL_OPEN"), tc.failOpen)
 
 			sec := collectConfig(nil, nil)
 			if sec.GuardsEnabled != tc.wantEnabled {

--- a/plugins/agento11y/internal/doctor/probe_test.go
+++ b/plugins/agento11y/internal/doctor/probe_test.go
@@ -130,9 +130,12 @@ func TestProbeOTLP(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", srv.URL)
-	t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant-1")
-	t.Setenv("SIGIL_AUTH_TOKEN", "glc_tok")
+	// The probe reads the process env, so clear the host's config and point
+	// the preferred spelling at the test server.
+	isolateEnv(t)
+	t.Setenv("AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT", srv.URL)
+	t.Setenv("AGENTO11Y_AUTH_TENANT_ID", "tenant-1")
+	t.Setenv("AGENTO11Y_AUTH_TOKEN", "glc_tok")
 	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "")
 
 	probe := defaultProbeOTLP(context.Background())
@@ -150,9 +153,12 @@ func TestProbeOTLP(t *testing.T) {
 	}
 }
 
+// With no OTLP endpoint configured there is nothing to probe. isolateEnv
+// clears every spelling of the endpoint, including the preferred
+// AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT, so a configured host shell cannot
+// turn this into a live request.
 func TestProbeOTLP_NoEndpoint(t *testing.T) {
-	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "")
-	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	isolateEnv(t)
 	if got := defaultProbeOTLP(context.Background()); got != nil {
 		t.Fatalf("expected nil probe when no endpoint configured, got %+v", got)
 	}

--- a/plugins/agento11y/internal/doctor/render.go
+++ b/plugins/agento11y/internal/doctor/render.go
@@ -73,43 +73,86 @@ func (p palette) glyph(h Health) string {
 	}
 }
 
+// reportBody accumulates the human report so key/value lines can be padded
+// once the whole report is known. The column width is the widest key the run
+// actually rendered; a constant would be overflowed by the longest keys.
+type reportBody struct {
+	lines    []bodyLine
+	keyWidth int
+}
+
+// bodyLine is either a literal line (text) or a key/value pair padded when
+// the body is flushed. isKV is the discriminator, so an empty key still
+// renders its line instead of dropping it.
+type bodyLine struct {
+	text  string
+	key   string
+	value string
+	isKV  bool
+}
+
+func (b *reportBody) textf(format string, args ...any) {
+	b.lines = append(b.lines, bodyLine{text: fmt.Sprintf(format, args...)})
+}
+
+func (b *reportBody) kv(key, value string) {
+	b.lines = append(b.lines, bodyLine{key: key, value: value, isKV: true})
+	if w := len(key) + len(":"); w > b.keyWidth {
+		b.keyWidth = w
+	}
+}
+
+func (b *reportBody) flush(p palette) string {
+	var out strings.Builder
+	for _, line := range b.lines {
+		if !line.isKV {
+			out.WriteString(line.text)
+			continue
+		}
+		fmt.Fprintf(&out, "  %s %s\n", p.faint(padRight(line.key+":", b.keyWidth)), line.value)
+	}
+	return out.String()
+}
+
 // renderHuman writes the colored (or plain) report. probed reports whether
 // live probes ran; when they didn't, a hint nudges the user toward --probe
 // since the section verdicts are config-only and don't test credentials.
 func renderHuman(w io.Writer, r *Report, color, probed bool) {
 	p := palette{color: color}
-	var b strings.Builder
+	var b reportBody
 
-	fmt.Fprintf(&b, "%s %s\n\n", p.heading("agento11y doctor"), p.faint("v"+r.Binary.Version))
+	// Print the version as stamped, the way `agento11y --version` does. The
+	// release ldflags already carry the `v` prefix.
+	b.textf("%s %s\n\n", p.heading("agento11y doctor"), p.faint(r.Binary.Version))
 
 	// Conversations pipeline.
 	writeSection(&b, p, "Conversations (generation export)", r.Conversations.Health)
-	writeKV(&b, p, "endpoint", describeEnv(r.Conversations.Endpoint))
-	writeKV(&b, p, "tenant id", describeEnv(r.Conversations.TenantID))
-	writeKV(&b, p, "auth token", describeToken(r.Conversations.Token))
+	b.kv("endpoint", describeEnv(r.Conversations.Endpoint))
+	b.kv("tenant id", describeEnv(r.Conversations.TenantID))
+	b.kv("auth token", describeToken(r.Conversations.Token))
 	if r.Conversations.Probe != nil {
-		writeKV(&b, p, "probe", describeProbe(r.Conversations.Probe))
+		b.kv("probe", describeProbe(r.Conversations.Probe))
 	}
 	writeMessages(&b, p, r.Conversations.Messages)
-	b.WriteString("\n")
+	b.textf("\n")
 
 	// Analytics pipeline.
 	writeSection(&b, p, "Analytics (OTLP metrics & traces)", r.Analytics.Health)
 	if r.Analytics.Endpoint.Set {
-		writeKV(&b, p, "endpoint", fmt.Sprintf("%s %s", r.Analytics.Endpoint.Value, p.faint("("+r.Analytics.EndpointVar+", "+r.Analytics.Endpoint.Source+")")))
+		b.kv("endpoint", fmt.Sprintf("%s %s", r.Analytics.Endpoint.Value, p.faint("("+r.Analytics.EndpointVar+", "+r.Analytics.Endpoint.Source+")")))
 	} else {
-		writeKV(&b, p, "endpoint", p.faint("not set"))
+		b.kv("endpoint", p.faint("not set"))
 	}
 	if r.Analytics.Probe != nil {
 		if r.Analytics.Probe.Metrics != nil {
-			writeKV(&b, p, "metrics probe", describeProbe(r.Analytics.Probe.Metrics))
+			b.kv("metrics probe", describeProbe(r.Analytics.Probe.Metrics))
 		}
 		if r.Analytics.Probe.Traces != nil {
-			writeKV(&b, p, "traces probe", describeProbe(r.Analytics.Probe.Traces))
+			b.kv("traces probe", describeProbe(r.Analytics.Probe.Traces))
 		}
 	}
 	writeMessages(&b, p, r.Analytics.Messages)
-	b.WriteString("\n")
+	b.textf("\n")
 
 	// Config.
 	writeSection(&b, p, "Config", r.Config.Health)
@@ -117,44 +160,44 @@ func renderHuman(w io.Writer, r *Report, color, probed bool) {
 	if r.Config.Exists {
 		exists = "present"
 	}
-	writeKV(&b, p, "file", fmt.Sprintf("%s %s", r.Config.Path, p.faint("("+exists+")")))
+	b.kv("file", fmt.Sprintf("%s %s", r.Config.Path, p.faint("("+exists+")")))
 	mode := r.Config.ContentCaptureMode
 	if r.Config.ContentModeFellBack {
 		mode += " " + p.faint("(invalid value, fell back)")
 	}
-	writeKV(&b, p, "content capture", mode)
-	writeKV(&b, p, "guards", describeGuards(p, r.Config))
+	b.kv("content capture", mode)
+	b.kv("guards", describeGuards(p, r.Config))
 	if len(r.Config.Tags) > 0 {
-		writeKV(&b, p, "tags", fmt.Sprintf("%s %s", formatTags(r.Config.Tags), p.faint("("+r.Config.TagsSource+")")))
+		b.kv("tags", fmt.Sprintf("%s %s", formatTags(r.Config.Tags), p.faint("("+r.Config.TagsSource+")")))
 	}
 	if r.Config.Local.Set {
 		localMode := describeEnv(r.Config.Local)
 		if r.Config.LocalInvalid {
 			localMode += " " + p.faint("(invalid value, local mode is off)")
 		}
-		writeKV(&b, p, "local mode", localMode)
+		b.kv("local mode", localMode)
 	}
 	if r.Config.LocalForward.Set {
-		writeKV(&b, p, "local forwarding", describeEnv(r.Config.LocalForward))
+		b.kv("local forwarding", describeEnv(r.Config.LocalForward))
 	}
 	// Only worth a line once the user has opted into forwarding: with
 	// LOCAL_FORWARD unset chaining is always off, and that is already what the
 	// absent line above says.
 	if r.Config.LocalForward.Set {
-		writeKV(&b, p, "local guard checks", describeLocalHookForward(p, r.Config.LocalHookForward))
+		b.kv("local guard checks", describeLocalHookForward(p, r.Config.LocalHookForward))
 	}
 	writeMessages(&b, p, r.Config.Messages)
-	b.WriteString("\n")
+	b.textf("\n")
 
 	// Agents.
-	fmt.Fprintf(&b, "%s\n", p.sectionTitle("Coding agents", HealthOK))
+	b.textf("%s\n", p.sectionTitle("Coding agents", HealthOK))
 	for _, a := range r.Agents {
-		writeKV(&b, p, a.Name, describeAgent(p, a))
+		b.kv(a.Name, describeAgent(p, a))
 	}
 	if r.AutoUpdateDisabled {
-		writeKV(&b, p, "auto-update", p.faint("disabled (SIGIL_AUTO_UPDATE)"))
+		b.kv("auto-update", p.faint("disabled (SIGIL_AUTO_UPDATE)"))
 	}
-	b.WriteString("\n")
+	b.textf("\n")
 
 	// Summary.
 	writeSummary(&b, p, r)
@@ -162,34 +205,30 @@ func renderHuman(w io.Writer, r *Report, color, probed bool) {
 		writeProbeHint(&b, p, r)
 	}
 
-	_, _ = io.WriteString(w, b.String())
+	_, _ = io.WriteString(w, b.flush(p))
 }
 
 // writeProbeHint nudges toward --probe when the report is config-only and
 // there is something to probe. Without it, the section verdicts reflect only
 // that credentials are present, not that they work.
-func writeProbeHint(b *strings.Builder, p palette, r *Report) {
+func writeProbeHint(b *reportBody, p palette, r *Report) {
 	if !r.Conversations.configured() && !r.Analytics.Endpoint.Set {
 		return
 	}
-	fmt.Fprintf(b, "\n%s\n", p.faint("Verdicts above check configuration only. Run `agento11y doctor --probe` to test credentials against the endpoints."))
+	b.textf("\n%s\n", p.faint("Verdicts above check configuration only. Run `agento11y doctor --probe` to test credentials against the endpoints."))
 }
 
-func writeSection(b *strings.Builder, p palette, title string, h Health) {
-	fmt.Fprintf(b, "%s %s\n", p.glyph(h), p.sectionTitle(title, h))
+func writeSection(b *reportBody, p palette, title string, h Health) {
+	b.textf("%s %s\n", p.glyph(h), p.sectionTitle(title, h))
 }
 
-func writeKV(b *strings.Builder, p palette, key, value string) {
-	fmt.Fprintf(b, "  %s %s\n", p.faint(padRight(key+":", 16)), value)
-}
-
-func writeMessages(b *strings.Builder, p palette, messages []string) {
+func writeMessages(b *reportBody, p palette, messages []string) {
 	for _, m := range messages {
-		fmt.Fprintf(b, "  %s %s\n", p.glyph(HealthWarn), m)
+		b.textf("  %s %s\n", p.glyph(HealthWarn), m)
 	}
 }
 
-func writeSummary(b *strings.Builder, p palette, r *Report) {
+func writeSummary(b *reportBody, p palette, r *Report) {
 	var broken []string
 	if r.Conversations.Health == HealthError {
 		broken = append(broken, "conversations")
@@ -201,11 +240,10 @@ func writeSummary(b *strings.Builder, p palette, r *Report) {
 		broken = append(broken, "config")
 	}
 	if len(broken) == 0 {
-		fmt.Fprintf(b, "%s %s\n", p.glyph(HealthOK), "no problems detected")
+		b.textf("%s %s\n", p.glyph(HealthOK), "no problems detected")
 		return
 	}
-	fmt.Fprintf(b, "%s %s\n", p.glyph(HealthError),
-		fmt.Sprintf("%d problem(s): %s misconfigured", len(broken), strings.Join(broken, ", ")))
+	b.textf("%s %d problem(s): %s misconfigured\n", p.glyph(HealthError), len(broken), strings.Join(broken, ", "))
 }
 
 func describeEnv(v envValue) string {
@@ -270,32 +308,42 @@ func describeProbe(p *ProbeResult) string {
 }
 
 func describeAgent(p palette, a AgentStatus) string {
-	// Hook-only agents (cursor) are detected purely by PATH presence.
+	// Hook-only agents (cursor) are detected purely by PATH presence. Their
+	// version is the agento11y binary's, so it is rendered exactly as the
+	// report heading renders it.
 	if a.HookBased {
-		return agentNote(p, joinAgent("detected", a.Version), a.Note)
+		return agentNote(p, joinVersion("detected", a.Version), a.Note)
 	}
 	// The install probe never ran: a CLI-dependent agent whose binary is
 	// absent, or a hook-only agent off PATH.
 	if a.Health == HealthSkipped {
 		return agentNote(p, p.faint("not found on PATH"), a.Note)
 	}
+	// The probe ran and errored, or the state was never set. Say the state is
+	// unknown instead of picking one of the two known states; the note carries
+	// the reason.
+	install := a.Install.orUnknown()
+	if install == InstallStateUnknown {
+		return agentNote(p, "install state unknown", a.Note)
+	}
+	installed := install == InstallStateInstalled
 	// Hook-file based agent (copilot, vibe): capture doesn't depend on the CLI being
 	// on PATH, so report install state with its own wording and no PATH
 	// qualifiers.
 	if a.notInstalledLabel != "" {
 		state := a.notInstalledLabel
-		if a.Installed {
+		if installed {
 			state = "installed"
 		}
 		return agentNote(p, joinAgent(state, a.Version), a.Note)
 	}
-	// The probe ran. Report install state, only claiming "on PATH" when true so
-	// config-based agents installed without the CLI present aren't mislabeled.
+	// Report install state, only claiming "on PATH" when true so config-based
+	// agents installed without the CLI present aren't mislabeled.
 	var state string
 	switch {
-	case a.Installed && a.OnPath:
+	case installed && a.OnPath:
 		state = "installed"
-	case a.Installed:
+	case installed:
 		state = "installed " + p.faint("(CLI not on PATH)")
 	case a.OnPath:
 		state = "on PATH, plugin not installed"
@@ -305,11 +353,25 @@ func describeAgent(p palette, a AgentStatus) string {
 	return agentNote(p, joinAgent(state, a.Version), a.Note)
 }
 
+// joinAgent appends a host agent's own version to its state, prefixed with
+// `v` when it is a bare number. Some agents report a dist-tag instead of a
+// number (opencode and pi return the tail of an npm spec, so a `@next`
+// install reports `next`), and `vnext` would be wrong.
 func joinAgent(state, version string) string {
-	if version != "" {
-		return state + " v" + version
+	if version != "" && version[0] >= '0' && version[0] <= '9' {
+		version = "v" + version
 	}
-	return state
+	return joinVersion(state, version)
+}
+
+// joinVersion appends a version to a state as-is. The agento11y binary version
+// goes through here, so the heading and cursor's line print the same string
+// the build stamped, and the `v` prefix stays in the ldflags alone.
+func joinVersion(state, version string) string {
+	if version == "" {
+		return state
+	}
+	return state + " " + version
 }
 
 func agentNote(p palette, body, note string) string {

--- a/plugins/agento11y/internal/doctor/render_golden_test.go
+++ b/plugins/agento11y/internal/doctor/render_golden_test.go
@@ -1,0 +1,172 @@
+package doctor
+
+// TestRenderHumanGolden snapshots the whole rendered report for representative
+// states, so a change to any line the reader sees shows up as a diff. The
+// other render tests assert on fragments, which cannot catch a wrong prefix or
+// a misaligned column.
+//
+// Sections whose collector is pure (conversations, analytics) are built by
+// calling it, so the fixtures carry the messages doctor really writes. The
+// config section is hand-built because collectConfig reads the process
+// environment and the filesystem; its message strings are copied from
+// collectConfig.
+//
+// Golden files live in testdata/render/<scenario>.golden.txt. Set
+// UPDATE_GOLDENS=1 to reseed them, matching the harness in
+// internal/entry/golden_integration_test.go.
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/local"
+)
+
+func TestRenderHumanGolden(t *testing.T) {
+	tests := []struct {
+		name   string
+		report *Report
+		probed bool
+	}{
+		{name: "healthy", report: goldenHealthyReport()},
+		{name: "minimal", report: goldenMinimalReport()},
+		{name: "broken", report: goldenBrokenReport()},
+		{name: "probed", report: goldenProbedReport(), probed: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			renderHuman(&buf, tc.report, false, tc.probed)
+			assertGoldenText(t, filepath.Join("testdata", "render", tc.name+".golden.txt"), buf.String())
+		})
+	}
+}
+
+// goldenHealthyReport is a fully configured install. It opts into local
+// forwarding so the two longest keys ("local forwarding", "local guard
+// checks") are rendered and the column is as wide as it gets.
+func goldenHealthyReport() *Report {
+	osEnv := map[string]string{
+		"AGENTO11Y_ENDPOINT":                    "https://sigil.example",
+		"AGENTO11Y_AUTH_TENANT_ID":              "12345",
+		"AGENTO11Y_AUTH_TOKEN":                  "glc_secret",
+		"AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT": "https://otlp.example/otlp",
+	}
+	conversations := collectConversations(osEnv, nil)
+	return &Report{
+		Binary:        BinarySection{Version: "v0.22.0"},
+		Conversations: conversations,
+		Analytics:     collectAnalytics(osEnv, nil, conversations.configured()),
+		Config: ConfigSection{
+			Path: "/home/u/.config/agento11y/config.env", Exists: true,
+			ContentCaptureMode: "full",
+			GuardsEnabled:      true, GuardsTimeoutMs: 1500, GuardsFailOpen: true,
+			Tags:             map[string]string{"team": "assistant", "env": "prod"},
+			TagsSource:       sourceConfig,
+			LocalForward:     envValue{Set: true, Value: "true", Source: sourceEnv, Key: "AGENTO11Y_LOCAL_FORWARD"},
+			LocalHookForward: HookForwardSection{Enabled: true},
+			Health:           HealthOK,
+		},
+		Agents: []AgentStatus{
+			{Name: "claude", OnPath: true, Install: InstallStateInstalled, Version: "0.3.0", Health: HealthOK},
+			{Name: "codex", OnPath: false, Install: InstallStateUnknown, Health: HealthSkipped},
+			{Name: "cursor", OnPath: true, HookBased: true, Version: "v0.22.0", Note: "hook-based; configured in Cursor settings", Health: HealthOK},
+		},
+	}
+}
+
+// goldenMinimalReport is a fresh install with nothing configured. It renders
+// no tags and no local forwarding, so its widest key is shorter than the
+// healthy report's: the two files together pin the column to the widest key
+// rendered rather than to a constant.
+func goldenMinimalReport() *Report {
+	return &Report{
+		Binary:        BinarySection{Version: "v0.22.0"},
+		Conversations: collectConversations(nil, nil),
+		Analytics:     collectAnalytics(nil, nil, false),
+		Config: ConfigSection{
+			Path: "/home/u/.config/agento11y/config.env",
+			// The daemon's answer with LOCAL_FORWARD unset. The line itself is
+			// suppressed, which is what this fixture pins.
+			LocalHookForward:   HookForwardSection{Reason: local.HookForwardReason(false, false, "", "", "")},
+			ContentCaptureMode: "full",
+			GuardsTimeoutMs:    1500, GuardsFailOpen: true,
+			Health: HealthOK,
+		},
+		Agents: []AgentStatus{
+			{Name: "claude", OnPath: false, Install: InstallStateNotInstalled, Health: HealthWarn},
+		},
+	}
+}
+
+// goldenBrokenReport is the support case: a malformed endpoint, no OTLP
+// endpoint, a config that fell back, and an agent whose install probe errored.
+func goldenBrokenReport() *Report {
+	conversations := collectConversations(
+		map[string]string{"AGENTO11Y_ENDPOINT": "not a url ://"},
+		map[string]string{"AGENTO11Y_AUTH_TENANT_ID": "12345", "SIGIL_AUTH_TOKEN": "glc_secret"},
+	)
+	return &Report{
+		Binary:        BinarySection{Version: "dev"},
+		Conversations: conversations,
+		Analytics:     collectAnalytics(nil, nil, conversations.configured()),
+		Config: ConfigSection{
+			Path: "/home/u/.config/agento11y/config.env", Exists: true,
+			ContentCaptureMode: "metadata_only", ContentModeFellBack: true,
+			GuardsEnabled: false, GuardsFellBack: true,
+			LocalForward: envValue{Set: true, Value: "true", Source: sourceConfig, Key: "AGENTO11Y_LOCAL_FORWARD"},
+			// Forwarding is on but guards are off, so nothing is chained.
+			LocalHookForward: HookForwardSection{Reason: local.HookForwardReason(true, false, "", "", "")},
+			DisallowedKeys:   []string{"AWS_SECRET"},
+			Health:           HealthWarn,
+			Messages: []string{
+				"config.env has keys agento11y ignores: AWS_SECRET",
+				"the CONTENT_CAPTURE_MODE value is invalid; using metadata_only",
+				"a GUARDS_* value is invalid; falling back to defaults",
+			},
+		},
+		Agents: []AgentStatus{
+			// The probe errored: the line says the state is unknown instead of
+			// asserting "not configured" and "unknown" at once.
+			{Name: "copilot", OnPath: false, Install: InstallStateUnknown, notInstalledLabel: "not configured", Note: "hook-based; stat /home/u/.copilot/hooks/agento11y.json: operation not permitted", Health: HealthWarn},
+			{Name: "pi", OnPath: true, Install: InstallStateNotInstalled, Health: HealthWarn},
+		},
+		AutoUpdateDisabled: true,
+	}
+}
+
+// goldenProbedReport is a --probe run: every probe line is present and the
+// config-only hint is suppressed.
+func goldenProbedReport() *Report {
+	r := goldenHealthyReport()
+	r.Conversations.Probe = &ProbeResult{URL: "https://sigil.example/api/v1/generations:export", StatusCode: 200, OK: true}
+	r.Analytics.Probe = &AnalyticsProbe{
+		Metrics: &ProbeResult{URL: "https://otlp.example/otlp/v1/metrics", StatusCode: 200, OK: true},
+		Traces:  &ProbeResult{URL: "https://otlp.example/otlp/v1/traces", StatusCode: 403, Message: "missing metrics:write/traces:write scope"},
+	}
+	r.Analytics.Health = HealthError
+	r.Analytics.Messages = []string{"OTLP endpoint rejected auth (401/403) — the token is likely missing metrics:write/traces:write scope"}
+	return r
+}
+
+// assertGoldenText compares got against the file at path, or rewrites the file
+// when UPDATE_GOLDENS=1.
+func assertGoldenText(t *testing.T, path, got string) {
+	t.Helper()
+	if os.Getenv("UPDATE_GOLDENS") == "1" {
+		if err := os.WriteFile(path, []byte(got), 0o600); err != nil {
+			t.Fatalf("write golden %s: %v", path, err)
+		}
+		t.Logf("UPDATE_GOLDENS=1: wrote %s", path)
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden %s (run with UPDATE_GOLDENS=1 to seed): %v", path, err)
+	}
+	if string(want) != got {
+		t.Fatalf("golden mismatch for %s\nwant:\n%s\ngot:\n%s", path, want, got)
+	}
+}

--- a/plugins/agento11y/internal/doctor/render_test.go
+++ b/plugins/agento11y/internal/doctor/render_test.go
@@ -9,7 +9,7 @@ import (
 
 func sampleReport() *Report {
 	return &Report{
-		Binary: BinarySection{Version: "1.2.3"},
+		Binary: BinarySection{Version: "v1.2.3"},
 		Config: ConfigSection{
 			Path: "/tmp/agento11y/config.env", Exists: true,
 			ContentCaptureMode: "metadata_only", Health: HealthOK,
@@ -25,8 +25,8 @@ func sampleReport() *Report {
 			Messages: []string{"no OTLP endpoint set"},
 		},
 		Agents: []AgentStatus{
-			{Name: "claude", OnPath: true, Installed: true, Version: "0.3.0", Health: HealthOK},
-			{Name: "cursor", OnPath: true, HookBased: true, Version: "1.2.3", Note: "hook-based", Health: HealthOK},
+			{Name: "claude", OnPath: true, Install: InstallStateInstalled, Version: "0.3.0", Health: HealthOK},
+			{Name: "cursor", OnPath: true, HookBased: true, Version: "v1.2.3", Note: "hook-based", Health: HealthOK},
 		},
 	}
 }
@@ -70,6 +70,62 @@ func TestRenderHuman_NoColorIsPlain(t *testing.T) {
 	}
 }
 
+// The binary version is printed exactly as the build stamped it, in the
+// heading and in cursor's line, which reports the same string. The `v` prefix
+// lives in the release ldflags (-X main.version=v{{ .Version }}) and nowhere
+// else, so a build that stamps it and one that doesn't both render one `v`.
+func TestRenderHuman_BinaryVersionPrintedAsStamped(t *testing.T) {
+	for _, version := range []string{"v0.22.0", "0.22.0", "dev"} {
+		t.Run(version, func(t *testing.T) {
+			r := sampleReport()
+			r.Binary.Version = version
+			r.Agents = []AgentStatus{{Name: "cursor", OnPath: true, HookBased: true, Version: version, Health: HealthOK}}
+			var buf bytes.Buffer
+			renderHuman(&buf, r, false, false)
+			out := buf.String()
+			heading, _, _ := strings.Cut(out, "\n")
+			if want := "agento11y doctor " + version; heading != want {
+				t.Fatalf("heading = %q, want %q", heading, want)
+			}
+			if want := "detected " + version + "\n"; !strings.Contains(out, want) {
+				t.Fatalf("cursor line missing %q:\n%s", want, out)
+			}
+		})
+	}
+}
+
+// Every value starts in the same column, whatever the longest key is.
+func TestReportBody_PadsToWidestKey(t *testing.T) {
+	var b reportBody
+	b.kv("tags", "my_label=my_value")
+	b.kv("local forwarding", "true")
+	b.kv("local guard checks", "not forwarded")
+
+	want := strings.Join([]string{
+		"  tags:               my_label=my_value",
+		"  local forwarding:   true",
+		"  local guard checks: not forwarded",
+		"",
+	}, "\n")
+	if got := b.flush(palette{}); got != want {
+		t.Fatalf("flush =\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// A key/value line renders whatever its key is. The line kind, not the key's
+// content, decides how it is written, so an agent whose name resolves to an
+// empty string still gets a row.
+func TestReportBody_EmptyKeyStillRenders(t *testing.T) {
+	var b reportBody
+	b.kv("", "orphan")
+	b.kv("k", "v")
+
+	want := "  :  orphan\n  k: v\n"
+	if got := b.flush(palette{}); got != want {
+		t.Fatalf("flush = %q, want %q", got, want)
+	}
+}
+
 func TestRenderHuman_ProbeHint(t *testing.T) {
 	const hint = "agento11y doctor --probe"
 	nothingProbeable := func() *Report {
@@ -106,14 +162,26 @@ func TestDescribeAgent(t *testing.T) {
 		agent AgentStatus
 		want  string
 	}{
-		{name: "hook-based", agent: AgentStatus{HookBased: true, OnPath: true, Version: "1.2.3", Note: "hook-based", Health: HealthOK}, want: "detected v1.2.3 (hook-based)"},
-		{name: "skipped not on path", agent: AgentStatus{OnPath: false, Health: HealthSkipped}, want: "not found on PATH"},
-		{name: "installed on path", agent: AgentStatus{OnPath: true, Installed: true, Version: "0.3.0", Health: HealthOK}, want: "installed v0.3.0"},
-		{name: "config-based installed without cli", agent: AgentStatus{OnPath: false, Installed: true, Version: "2.0.0", Health: HealthOK}, want: "installed (CLI not on PATH) v2.0.0"},
-		{name: "on path not installed", agent: AgentStatus{OnPath: true, Installed: false, Health: HealthWarn}, want: "on PATH, plugin not installed"},
-		{name: "config-based not installed without cli", agent: AgentStatus{OnPath: false, Installed: false, Health: HealthWarn}, want: "plugin not installed"},
-		{name: "hook-file based installed (copilot)", agent: AgentStatus{OnPath: false, Installed: true, notInstalledLabel: "not configured", Note: "hook-based", Health: HealthOK}, want: "installed (hook-based)"},
-		{name: "hook-file based not configured ignores PATH (copilot)", agent: AgentStatus{OnPath: true, Installed: false, notInstalledLabel: "not configured", Note: "hook-based", Health: HealthWarn}, want: "not configured (hook-based)"},
+		// cursor reports the agento11y binary version, which the release ldflags
+		// stamp with the `v` and a dev build reports as a bare word. It is
+		// printed as stamped, the way the heading prints it.
+		{name: "hook-based", agent: AgentStatus{HookBased: true, OnPath: true, Version: "v1.2.3", Note: "hook-based", Health: HealthOK}, want: "detected v1.2.3 (hook-based)"},
+		{name: "hook-based unstamped version", agent: AgentStatus{HookBased: true, OnPath: true, Version: "0.22.0", Health: HealthOK}, want: "detected 0.22.0"},
+		{name: "hook-based dev version", agent: AgentStatus{HookBased: true, OnPath: true, Version: "dev", Health: HealthOK}, want: "detected dev"},
+		// A host agent's own version is numeric (claude) or a dist-tag
+		// (opencode, pi, from an npm spec); only the number takes the prefix.
+		{name: "agent dist-tag version", agent: AgentStatus{OnPath: true, Install: InstallStateInstalled, Version: "next", Health: HealthOK}, want: "installed next"},
+		{name: "skipped not on path", agent: AgentStatus{OnPath: false, Install: InstallStateUnknown, Health: HealthSkipped}, want: "not found on PATH"},
+		{name: "installed on path", agent: AgentStatus{OnPath: true, Install: InstallStateInstalled, Version: "0.3.0", Health: HealthOK}, want: "installed v0.3.0"},
+		{name: "config-based installed without cli", agent: AgentStatus{OnPath: false, Install: InstallStateInstalled, Version: "2.0.0", Health: HealthOK}, want: "installed (CLI not on PATH) v2.0.0"},
+		{name: "on path not installed", agent: AgentStatus{OnPath: true, Install: InstallStateNotInstalled, Health: HealthWarn}, want: "on PATH, plugin not installed"},
+		{name: "config-based not installed without cli", agent: AgentStatus{OnPath: false, Install: InstallStateNotInstalled, Health: HealthWarn}, want: "plugin not installed"},
+		{name: "hook-file based installed (copilot)", agent: AgentStatus{OnPath: false, Install: InstallStateInstalled, notInstalledLabel: "not configured", Note: "hook-based", Health: HealthOK}, want: "installed (hook-based)"},
+		{name: "hook-file based not configured ignores PATH (copilot)", agent: AgentStatus{OnPath: true, Install: InstallStateNotInstalled, notInstalledLabel: "not configured", Note: "hook-based", Health: HealthWarn}, want: "not configured (hook-based)"},
+		// A probe that errored: one line must not assert a known state and an
+		// unknown one at the same time.
+		{name: "probe errored", agent: AgentStatus{OnPath: true, Install: InstallStateUnknown, Note: "stat hooks.json: operation not permitted", Health: HealthWarn}, want: "install state unknown (stat hooks.json: operation not permitted)"},
+		{name: "hook-file based probe errored (copilot)", agent: AgentStatus{OnPath: false, Install: InstallStateUnknown, notInstalledLabel: "not configured", Note: "hook-based; stat hooks.json: operation not permitted", Health: HealthWarn}, want: "install state unknown (hook-based; stat hooks.json: operation not permitted)"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/plugins/agento11y/internal/doctor/testdata/render/broken.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/broken.golden.txt
@@ -1,0 +1,31 @@
+agento11y doctor dev
+
+✗ Conversations (generation export)
+  endpoint:           not a url :// (env)
+  tenant id:          12345 (config.env)
+  auth token:         set (glc_…, config.env)
+  ! AGENTO11Y_ENDPOINT is not a usable endpoint: parse generation export endpoint "not a url ://": parse "https://not a url ://": invalid character " " in host name
+  ! configured via legacy SIGIL_* names — these keep working, but the preferred names are AGENTO11Y_*
+
+✗ Analytics (OTLP metrics & traces)
+  endpoint:           not set
+  ! no OTLP endpoint set — metrics and traces will not be exported even though conversations are configured. Set AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT (e.g. https://otlp-gateway-prod-<region>.grafana.net/otlp).
+
+! Config
+  file:               /home/u/.config/agento11y/config.env (present)
+  content capture:    metadata_only (invalid value, fell back)
+  guards:             disabled (invalid value, fell back)
+  local forwarding:   true (config.env)
+  local guard checks: not forwarded (AGENTO11Y_GUARDS_ENABLED is off, so there are no guards to enforce)
+  ! config.env has keys agento11y ignores: AWS_SECRET
+  ! the CONTENT_CAPTURE_MODE value is invalid; using metadata_only
+  ! a GUARDS_* value is invalid; falling back to defaults
+
+Coding agents
+  copilot:            install state unknown (hook-based; stat /home/u/.copilot/hooks/agento11y.json: operation not permitted)
+  pi:                 on PATH, plugin not installed
+  auto-update:        disabled (SIGIL_AUTO_UPDATE)
+
+✗ 2 problem(s): conversations, analytics misconfigured
+
+Verdicts above check configuration only. Run `agento11y doctor --probe` to test credentials against the endpoints.

--- a/plugins/agento11y/internal/doctor/testdata/render/healthy.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/healthy.golden.txt
@@ -1,0 +1,26 @@
+agento11y doctor v0.22.0
+
+✓ Conversations (generation export)
+  endpoint:           https://sigil.example (env)
+  tenant id:          12345 (env)
+  auth token:         set (glc_…, env)
+
+✓ Analytics (OTLP metrics & traces)
+  endpoint:           https://otlp.example/otlp (AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT, env)
+
+✓ Config
+  file:               /home/u/.config/agento11y/config.env (present)
+  content capture:    full
+  guards:             enabled (timeout 1500ms, fail-open)
+  tags:               env=prod, team=assistant (config.env)
+  local forwarding:   true (env)
+  local guard checks: local hook evaluation reaches Cloud (tool calls, and the conversation an agent runs a preflight check on, are sent for evaluation whatever the capture mode)
+
+Coding agents
+  claude:             installed v0.3.0
+  codex:              not found on PATH
+  cursor:             detected v0.22.0 (hook-based; configured in Cursor settings)
+
+✓ no problems detected
+
+Verdicts above check configuration only. Run `agento11y doctor --probe` to test credentials against the endpoints.

--- a/plugins/agento11y/internal/doctor/testdata/render/minimal.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/minimal.golden.txt
@@ -1,0 +1,21 @@
+agento11y doctor v0.22.0
+
+! Conversations (generation export)
+  endpoint:        not set
+  tenant id:       not set
+  auth token:      not set
+  ! not configured — run `agento11y login` or set AGENTO11Y_ENDPOINT, AGENTO11Y_AUTH_TENANT_ID and AGENTO11Y_AUTH_TOKEN
+
+! Analytics (OTLP metrics & traces)
+  endpoint:        not set
+  ! no OTLP endpoint set; analytics export is disabled
+
+✓ Config
+  file:            /home/u/.config/agento11y/config.env (missing)
+  content capture: full
+  guards:          disabled
+
+Coding agents
+  claude:          plugin not installed
+
+✓ no problems detected

--- a/plugins/agento11y/internal/doctor/testdata/render/probed.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/probed.golden.txt
@@ -1,0 +1,28 @@
+agento11y doctor v0.22.0
+
+✓ Conversations (generation export)
+  endpoint:           https://sigil.example (env)
+  tenant id:          12345 (env)
+  auth token:         set (glc_…, env)
+  probe:              HTTP 200
+
+✗ Analytics (OTLP metrics & traces)
+  endpoint:           https://otlp.example/otlp (AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT, env)
+  metrics probe:      HTTP 200
+  traces probe:       HTTP 403 — missing metrics:write/traces:write scope
+  ! OTLP endpoint rejected auth (401/403) — the token is likely missing metrics:write/traces:write scope
+
+✓ Config
+  file:               /home/u/.config/agento11y/config.env (present)
+  content capture:    full
+  guards:             enabled (timeout 1500ms, fail-open)
+  tags:               env=prod, team=assistant (config.env)
+  local forwarding:   true (env)
+  local guard checks: local hook evaluation reaches Cloud (tool calls, and the conversation an agent runs a preflight check on, are sent for evaluation whatever the capture mode)
+
+Coding agents
+  claude:             installed v0.3.0
+  codex:              not found on PATH
+  cursor:             detected v0.22.0 (hook-based; configured in Cursor settings)
+
+✗ 1 problem(s): analytics misconfigured


### PR DESCRIPTION
A few fixes for `agento11y doctor`:

- **Heading printed `vv0.22.0` with double 'v'.
- Padding was hardcoded to 16 columns, so `local forwarding:` (17) and `local guard checks:` (19) overflowed
- A malformed url in `AGENTO11Y_ENDPOINT` passed the offline check.
