### PR TITLE
fix(plugins/agento11y): separate 401 and 403 in doctor --probe

### DIFF
--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -107,11 +107,13 @@ The two pipelines are independent and fail independently:
 
 The common failure is conversations showing up while the analytics page stays empty: the OTLP endpoint is unset, or the token lacks the metrics/traces scopes. `agento11y doctor` flags that case explicitly and exits non-zero when a pipeline is broken.
 
-Add `--probe` to send a lightweight request to each endpoint and report the HTTP status (a 401/403 on the OTLP path means the token is missing `metrics:write`/`traces:write`):
+Add `--probe` to send a lightweight request to each endpoint and report the HTTP status:
 
 ```sh
 agento11y doctor --probe
 ```
+
+A 403 means the token is missing a write scope. A 401 means the endpoint refused the credentials without saying why: the token may be invalid or expired, or `AGENTO11Y_AUTH_TENANT_ID` may be wrong.
 
 For support, capture the machine-readable report — it never includes the auth token value:
 

--- a/plugins/agento11y/internal/doctor/doctor.go
+++ b/plugins/agento11y/internal/doctor/doctor.go
@@ -268,13 +268,26 @@ type ProbeResult struct {
 }
 
 func (p *ProbeResult) authFailure() bool {
-	return p != nil && (p.StatusCode == 401 || p.StatusCode == 403)
+	return p.credentialsRejected() || p.scopeDenied()
+}
+
+// credentialsRejected reports HTTP 401: the endpoint refused the credentials.
+// The status does not say which credential is wrong, so each probe names the
+// candidates for its own endpoint.
+func (p *ProbeResult) credentialsRejected() bool {
+	return p != nil && p.StatusCode == 401
+}
+
+// scopeDenied reports HTTP 403: the credentials authenticated, but the token
+// is not allowed to write.
+func (p *ProbeResult) scopeDenied() bool {
+	return p != nil && p.StatusCode == 403
 }
 
 // unreachable reports a probe outcome that means a configured pipeline can't
 // deliver: a transport error (no HTTP response, e.g. DNS failure, connection
 // refused, or timeout) or a 5xx server error. 401/403 are handled separately
-// as a scope problem (authFailure). Other 4xx are not treated as broken because
+// as an auth problem (authFailure). Other 4xx are not treated as broken because
 // the minimal probe body ({}) can draw a benign 400/415 from an endpoint that
 // validates the body before auth.
 func (p *ProbeResult) unreachable() bool {
@@ -673,12 +686,12 @@ func runProbes(ctx context.Context, r *Report, osEnv, fileEnv map[string]string)
 	// configured(), HealthError can only come from that check.
 	if r.Conversations.configured() && r.Conversations.Health != HealthError {
 		token := resolveFamily("AUTH_TOKEN", osEnv, fileEnv).value
-		res := probeConversationsFn(ctx, r.Conversations.Endpoint.Value, r.Conversations.TenantID.Value, token, resolveInsecure(osEnv, fileEnv))
+		res := probeConversationsFn(ctx, r.Conversations.Endpoint.Value, r.Conversations.TenantID, token, resolveInsecure(osEnv, fileEnv))
 		r.Conversations.Probe = res
 		switch {
 		case res.authFailure():
+			// No section message: the probe line states the cause.
 			r.Conversations.Health = HealthError
-			r.Conversations.Messages = append(r.Conversations.Messages, res.Message)
 		case res.unreachable():
 			r.Conversations.Health = HealthError
 			r.Conversations.Messages = append(r.Conversations.Messages,
@@ -686,14 +699,14 @@ func runProbes(ctx context.Context, r *Report, osEnv, fileEnv map[string]string)
 		}
 	}
 	if r.Analytics.Endpoint.Set {
-		probe := probeOTLPFn(ctx)
+		probe := probeOTLPFn(ctx, otlpProbeTenant(r.Conversations.TenantID, osEnv, fileEnv))
 		r.Analytics.Probe = probe
 		if probe != nil {
 			switch {
 			case probe.Metrics.authFailure() || probe.Traces.authFailure():
+				// No section message: each signal's probe line states
+				// its own cause.
 				r.Analytics.Health = HealthError
-				r.Analytics.Messages = append(r.Analytics.Messages,
-					"OTLP endpoint rejected auth (401/403) — the token is likely missing metrics:write/traces:write scope")
 			case probe.Metrics.unreachable() || probe.Traces.unreachable():
 				r.Analytics.Health = HealthError
 				r.Analytics.Messages = append(r.Analytics.Messages,
@@ -701,6 +714,18 @@ func runProbes(ctx context.Context, r *Report, osEnv, fileEnv map[string]string)
 			}
 		}
 	}
+}
+
+// otlpProbeTenant is the tenant id the OTLP request authenticates with, or a
+// zero value when it authenticates with something else. internal/otel builds
+// Basic auth from the tenant id only when OTEL_EXPORTER_OTLP_HEADERS carries
+// no Authorization entry (otel.ExporterHeaders); with an explicit header the
+// tenant id never reaches the request, so a 401 must not point at it.
+func otlpProbeTenant(tenant envValue, osEnv, fileEnv map[string]string) envValue {
+	if headersHaveAuthorization(resolveEnv("OTEL_EXPORTER_OTLP_HEADERS", osEnv, fileEnv).value) {
+		return envValue{}
+	}
+	return tenant
 }
 
 // resolved is the effective value of an env var plus where it came from:

--- a/plugins/agento11y/internal/doctor/doctor_test.go
+++ b/plugins/agento11y/internal/doctor/doctor_test.go
@@ -59,10 +59,10 @@ func stubSeams(t *testing.T) {
 		collectAgents, probeConversationsFn, probeOTLPFn = prevAgents, prevConv, prevOTLP
 	})
 	collectAgents = func(context.Context, string) []AgentStatus { return nil }
-	probeConversationsFn = func(context.Context, string, string, string, bool) *ProbeResult {
+	probeConversationsFn = func(context.Context, string, envValue, string, bool) *ProbeResult {
 		return &ProbeResult{StatusCode: 200, OK: true}
 	}
-	probeOTLPFn = func(context.Context) *AnalyticsProbe { return nil }
+	probeOTLPFn = func(context.Context, envValue) *AnalyticsProbe { return nil }
 }
 
 func writeConfig(t *testing.T, content string) {
@@ -371,6 +371,8 @@ func TestRunProbes(t *testing.T) {
 		wantConv        Health
 		wantAnalytics   Health
 		wantConvSkipped bool
+		wantConvMsgs    int
+		wantOTLPMsgs    int
 	}{
 		{
 			name:          "all reachable",
@@ -380,9 +382,18 @@ func TestRunProbes(t *testing.T) {
 			wantAnalytics: HealthOK,
 		},
 		{
-			name:          "auth failure escalates",
+			// The probe line already prints the message, so the
+			// section must not repeat it.
+			name:          "401 escalates without repeating the probe message",
+			conv:          &ProbeResult{StatusCode: 401, Message: "credentials rejected"},
+			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 401, Message: "credentials rejected"}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			wantConv:      HealthError,
+			wantAnalytics: HealthError,
+		},
+		{
+			name:          "403 escalates without repeating the probe message",
 			conv:          &ProbeResult{StatusCode: 403, Message: "missing sigil:write"},
-			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 401}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 200, OK: true}, Traces: &ProbeResult{StatusCode: 403, Message: "missing traces:write"}},
 			wantConv:      HealthError,
 			wantAnalytics: HealthError,
 		},
@@ -392,6 +403,8 @@ func TestRunProbes(t *testing.T) {
 			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 0, Message: "timeout"}, Traces: &ProbeResult{StatusCode: 0, Message: "timeout"}},
 			wantConv:      HealthError,
 			wantAnalytics: HealthError,
+			wantConvMsgs:  1,
+			wantOTLPMsgs:  1,
 		},
 		{
 			name:          "5xx escalates",
@@ -399,6 +412,8 @@ func TestRunProbes(t *testing.T) {
 			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 500}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
 			wantConv:      HealthError,
 			wantAnalytics: HealthError,
+			wantConvMsgs:  1,
+			wantOTLPMsgs:  1,
 		},
 		{
 			name:          "benign 4xx stays healthy",
@@ -417,26 +432,35 @@ func TestRunProbes(t *testing.T) {
 			wantConv:        HealthError,
 			wantAnalytics:   HealthOK,
 			wantConvSkipped: true,
+			wantConvMsgs:    1, // the offline message, alone
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			prevConv, prevOTLP := probeConversationsFn, probeOTLPFn
 			t.Cleanup(func() { probeConversationsFn, probeOTLPFn = prevConv, prevOTLP })
-			probeConversationsFn = func(context.Context, string, string, string, bool) *ProbeResult { return tc.conv }
-			probeOTLPFn = func(context.Context) *AnalyticsProbe { return tc.otlp }
+			probeConversationsFn = func(context.Context, string, envValue, string, bool) *ProbeResult { return tc.conv }
+			var gotOTLPTenant envValue
+			probeOTLPFn = func(_ context.Context, tenant envValue) *AnalyticsProbe {
+				gotOTLPTenant = tenant
+				return tc.otlp
+			}
 
-			convHealth := tc.convHealth
+			// A case that starts in error reached that verdict offline, so it
+			// carries the offline check's message into the probe stage.
+			convHealth, convMsgs := tc.convHealth, []string(nil)
 			if convHealth == "" {
 				convHealth = HealthOK
+			} else {
+				convMsgs = []string{"AGENTO11Y_ENDPOINT is not a usable endpoint: …"}
 			}
 			r := &Report{
 				Conversations: ConversationsSection{
 					Endpoint: envValue{Set: true, Value: "https://sigil.example.net"},
-					TenantID: envValue{Set: true, Value: "t"},
+					TenantID: envValue{Set: true, Value: "t", Key: "AGENTO11Y_AUTH_TENANT_ID"},
 					Token:    tokenValue{Set: true},
 					Health:   convHealth,
-					Messages: []string{"AGENTO11Y_ENDPOINT is not a usable endpoint: …"},
+					Messages: convMsgs,
 				},
 				Analytics: AnalyticsSection{
 					Endpoint: envValue{Set: true, Value: "https://otlp.example.net"},
@@ -451,14 +475,54 @@ func TestRunProbes(t *testing.T) {
 				if r.Conversations.Probe != nil {
 					t.Fatalf("conversations probe ran = %+v, want skipped", r.Conversations.Probe)
 				}
-				if len(r.Conversations.Messages) != 1 {
-					t.Fatalf("conversations messages = %v, want the offline message alone", r.Conversations.Messages)
-				}
 			} else if r.Conversations.Probe == nil {
 				t.Fatal("conversations probe did not run")
+			} else if r.Conversations.Probe.Message != tc.conv.Message {
+				// The section drops its own message on an auth failure, so the
+				// probe result must keep the explanation both renderers print.
+				t.Fatalf("probe message = %q, want %q", r.Conversations.Probe.Message, tc.conv.Message)
 			}
 			if r.Analytics.Health != tc.wantAnalytics {
 				t.Fatalf("analytics health = %q, want %q", r.Analytics.Health, tc.wantAnalytics)
+			}
+			if gotOTLPTenant != r.Conversations.TenantID {
+				t.Fatalf("OTLP probe tenant = %+v, want %+v", gotOTLPTenant, r.Conversations.TenantID)
+			}
+			if len(r.Conversations.Messages) != tc.wantConvMsgs {
+				t.Fatalf("conversations messages = %v, want %d", r.Conversations.Messages, tc.wantConvMsgs)
+			}
+			if len(r.Analytics.Messages) != tc.wantOTLPMsgs {
+				t.Fatalf("analytics messages = %v, want %d", r.Analytics.Messages, tc.wantOTLPMsgs)
+			}
+		})
+	}
+}
+
+func TestOTLPProbeTenant(t *testing.T) {
+	tenant := envValue{Set: true, Value: "t", Key: "AGENTO11Y_AUTH_TENANT_ID"}
+	tests := []struct {
+		name    string
+		headers string
+		want    envValue
+	}{
+		{name: "no headers", want: tenant},
+		{name: "headers without authorization", headers: "X-Extra=1", want: tenant},
+		{
+			// An explicit Authorization header replaces the Basic auth
+			// built from the tenant id, so the request never reads it.
+			name:    "explicit authorization drops the tenant",
+			headers: "Authorization=Bearer explicit",
+		},
+		{name: "authorization with no value is ignored", headers: "Authorization=", want: tenant},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			osEnv := map[string]string{}
+			if tc.headers != "" {
+				osEnv["OTEL_EXPORTER_OTLP_HEADERS"] = tc.headers
+			}
+			if got := otlpProbeTenant(tenant, osEnv, nil); got != tc.want {
+				t.Fatalf("tenant = %+v, want %+v", got, tc.want)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/doctor/probe.go
+++ b/plugins/agento11y/internal/doctor/probe.go
@@ -1,13 +1,16 @@
 package doctor
 
 import (
+	"cmp"
 	"context"
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/grafana/agento11y/go/proto/agento11y/wire"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/otel"
 )
 
@@ -30,7 +33,7 @@ var probeClient = &http.Client{Timeout: probeTimeout}
 // abort the report. insecure mirrors SIGIL_INSECURE so a scheme-less endpoint
 // resolves to http here just as the SDK exporter does; otherwise the probe
 // would hit https and report a cleartext setup as unreachable.
-func defaultProbeConversations(ctx context.Context, endpoint, tenant, token string, insecure bool) *ProbeResult {
+func defaultProbeConversations(ctx context.Context, endpoint string, tenant envValue, token string, insecure bool) *ProbeResult {
 	target, err := wire.NormalizeGenerationExportURL(endpoint, insecure)
 	if err != nil {
 		return &ProbeResult{Message: "invalid endpoint: " + err.Error()}
@@ -44,39 +47,64 @@ func defaultProbeConversations(ctx context.Context, endpoint, tenant, token stri
 		return &ProbeResult{URL: target, Message: err.Error()}
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if tenant != "" {
-		req.Header.Set("X-Scope-OrgID", tenant)
+	if tenant.Value != "" {
+		req.Header.Set("X-Scope-OrgID", tenant.Value)
 	}
 	if token != "" {
-		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(tenant+":"+token)))
+		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(tenant.Value+":"+token)))
 	}
 
 	res := doProbe(target, req)
-	if res.authFailure() {
+	switch {
+	case res.credentialsRejected():
+		// Sigil's tenant auth answers 401 for every auth failure on this
+		// endpoint, a missing write scope included, so name the scope here
+		// too — last, because it is the rarest cause.
+		res.Message = credentialsRejectedMessage(tenant) +
+			". A token without the sigil:write scope is rejected the same way"
+	case res.scopeDenied():
 		res.Message = "endpoint rejected auth — token likely missing sigil:write scope"
 	}
 	return res
 }
 
+// credentialsRejectedMessage explains an HTTP 401: the endpoint refused the
+// credentials and does not say which one is wrong. Name the token first and
+// the tenant id second, with its resolved value, because a wrong tenant id
+// reads exactly like a bad token from here. tenant is the tenant id the
+// request authenticated with; a zero value means the request did not use one,
+// and then the message says nothing about a variable the request never read.
+func credentialsRejectedMessage(tenant envValue) string {
+	const rejected = "credentials rejected: the token may be invalid or expired"
+	if !tenant.Set {
+		return rejected
+	}
+	return fmt.Sprintf("%s, or %s (%s) may be wrong",
+		rejected, cmp.Or(tenant.Key, envconfig.PreferredKey("AUTH_TENANT_ID")), tenant.Value)
+}
+
 // defaultProbeOTLP checks the OTLP metrics and traces endpoints, reusing the
 // resolved signal URLs and synthesized auth headers from internal/otel. Each
 // signal is POSTed an empty JSON body so the edge auth layer is exercised
-// without pushing data; 401/403 indicate the token is missing
-// metrics:write/traces:write. The real exporter sends protobuf, so an endpoint
-// that validates content-type before auth could answer 400/415 here; against
-// Grafana's OTLP gateway auth precedes parsing, so 200/401/403 is what's seen.
-func defaultProbeOTLP(ctx context.Context) *AnalyticsProbe {
+// without pushing data; 401 means the credentials were refused and 403 that
+// the token is missing metrics:write/traces:write. The real exporter sends
+// protobuf, so an endpoint that validates content-type before auth could
+// answer 400/415 here; against Grafana's OTLP gateway auth precedes parsing,
+// so 200/401/403 is what's seen. tenant is the tenant id the exporter
+// authenticates with, zero when an explicit Authorization header does instead;
+// it is only used to name the variable in a 401 message.
+func defaultProbeOTLP(ctx context.Context, tenant envValue) *AnalyticsProbe {
 	metrics, traces, ok := otel.ProbeConfig()
 	if !ok {
 		return nil
 	}
 	return &AnalyticsProbe{
-		Metrics: probeOTLPSignal(ctx, metrics),
-		Traces:  probeOTLPSignal(ctx, traces),
+		Metrics: probeOTLPSignal(ctx, metrics, tenant),
+		Traces:  probeOTLPSignal(ctx, traces, tenant),
 	}
 }
 
-func probeOTLPSignal(ctx context.Context, target otel.ProbeTarget) *ProbeResult {
+func probeOTLPSignal(ctx context.Context, target otel.ProbeTarget, tenant envValue) *ProbeResult {
 	ctx, cancel := context.WithTimeout(ctx, probeTimeout)
 	defer cancel()
 
@@ -90,7 +118,10 @@ func probeOTLPSignal(ctx context.Context, target otel.ProbeTarget) *ProbeResult 
 	}
 
 	res := doProbe(target.URL, req)
-	if res.authFailure() {
+	switch {
+	case res.credentialsRejected():
+		res.Message = credentialsRejectedMessage(tenant)
+	case res.scopeDenied():
 		res.Message = "missing metrics:write/traces:write scope"
 	}
 	return res

--- a/plugins/agento11y/internal/doctor/probe_test.go
+++ b/plugins/agento11y/internal/doctor/probe_test.go
@@ -12,18 +12,38 @@ import (
 	"github.com/grafana/agento11y/go/proto/agento11y/wire"
 )
 
+// probeTenant is a resolved AUTH_TENANT_ID as runProbes passes it: value plus
+// the spelling it came from.
+var probeTenant = envValue{Set: true, Value: "tenant-1", Key: "AGENTO11Y_AUTH_TENANT_ID", Source: sourceEnv}
+
 func TestProbeConversations(t *testing.T) {
 	tests := []struct {
-		name        string
-		status      int
-		badURL      bool // probe an unparseable endpoint instead of the test server
-		wantOK      bool
-		wantAuthMsg bool
-		wantErr     bool // transport error: status 0 with a message, server never hit
+		name    string
+		status  int
+		badURL  bool // probe an unparseable endpoint instead of the test server
+		wantOK  bool
+		wantMsg []string // substrings the probe message must contain
+		skipMsg []string // substrings the probe message must not contain
+		wantErr bool     // transport error: status 0 with a message, server never hit
 	}{
 		{name: "200 ok", status: 200, wantOK: true},
-		{name: "401 unauthorized", status: 401, wantAuthMsg: true},
-		{name: "403 forbidden", status: 403, wantAuthMsg: true},
+		{
+			// 401 is what a bad token and a wrong tenant id both
+			// return, so the message must not blame the scope.
+			name:   "401 blames credentials and tenant",
+			status: 401,
+			wantMsg: []string{
+				"credentials rejected", "invalid or expired",
+				"AGENTO11Y_AUTH_TENANT_ID (tenant-1)", "without the sigil:write scope",
+			},
+			skipMsg: []string{"likely missing sigil:write"},
+		},
+		{
+			name:    "403 blames scope",
+			status:  403,
+			wantMsg: []string{"missing sigil:write scope"},
+			skipMsg: []string{"credentials rejected"},
+		},
 		{name: "400 reachable", status: 400, wantOK: false},
 		{name: "invalid endpoint", badURL: true, wantErr: true},
 	}
@@ -42,7 +62,7 @@ func TestProbeConversations(t *testing.T) {
 			if tc.badURL {
 				url = "://bad"
 			}
-			res := defaultProbeConversations(context.Background(), url, "tenant-1", "glc_tok", false)
+			res := defaultProbeConversations(context.Background(), url, probeTenant, "glc_tok", false)
 
 			if tc.wantErr {
 				if res.StatusCode != 0 || res.Message == "" {
@@ -56,8 +76,15 @@ func TestProbeConversations(t *testing.T) {
 			if res.OK != tc.wantOK {
 				t.Fatalf("ok = %v, want %v", res.OK, tc.wantOK)
 			}
-			if tc.wantAuthMsg && !strings.Contains(res.Message, "sigil:write") {
-				t.Fatalf("expected auth message, got %q", res.Message)
+			for _, want := range tc.wantMsg {
+				if !strings.Contains(res.Message, want) {
+					t.Fatalf("message %q missing %q", res.Message, want)
+				}
+			}
+			for _, skip := range tc.skipMsg {
+				if strings.Contains(res.Message, skip) {
+					t.Fatalf("message %q must not contain %q", res.Message, skip)
+				}
 			}
 			if gotPath != wire.GenerationExportHTTPPath {
 				t.Fatalf("probe hit %q, want %q", gotPath, wire.GenerationExportHTTPPath)
@@ -81,7 +108,7 @@ func TestProbeConversations_Timeout(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	res := defaultProbeConversations(context.Background(), srv.URL, "t", "tok", false)
+	res := defaultProbeConversations(context.Background(), srv.URL, probeTenant, "tok", false)
 	if res.StatusCode != 0 || res.Message == "" {
 		t.Fatalf("expected timeout error, got %+v", res)
 	}
@@ -108,48 +135,139 @@ func TestProbeConversations_InsecureScheme(t *testing.T) {
 
 	// srv.Listener.Addr() is a scheme-less host:port; with insecure the probe
 	// must reach it over http.
-	res := defaultProbeConversations(context.Background(), srv.Listener.Addr().String(), "t", "tok", true)
+	res := defaultProbeConversations(context.Background(), srv.Listener.Addr().String(), probeTenant, "tok", true)
 	if !res.OK || gotScheme != "http" {
 		t.Fatalf("insecure probe = %+v, server scheme %q, want http reach", res, gotScheme)
 	}
 }
 
 func TestProbeOTLP(t *testing.T) {
-	var hitMetrics, hitTraces bool
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/v1/metrics":
-			hitMetrics = true
-		case "/v1/traces":
-			hitTraces = true
-		}
-		if r.Header.Get("Authorization") == "" {
-			t.Errorf("OTLP probe sent no auth header")
-		}
-		w.WriteHeader(403)
-	}))
-	defer srv.Close()
+	tests := []struct {
+		name    string
+		status  int
+		tenant  envValue
+		headers string // OTEL_EXPORTER_OTLP_HEADERS
+		wantMsg []string
+		skipMsg []string
+	}{
+		{
+			name:    "401 blames credentials and tenant",
+			status:  401,
+			tenant:  probeTenant,
+			wantMsg: []string{"credentials rejected", "invalid or expired", "AGENTO11Y_AUTH_TENANT_ID (tenant-1)"},
+			skipMsg: []string{"missing metrics:write/traces:write scope"},
+		},
+		{
+			// runProbes passes a zero tenant id when an explicit
+			// Authorization header authenticates the export, because the
+			// tenant id never reaches the request.
+			name:    "401 without a tenant id names only the token",
+			status:  401,
+			headers: "Authorization=Bearer explicit",
+			wantMsg: []string{"credentials rejected", "invalid or expired"},
+			skipMsg: []string{"AUTH_TENANT_ID"},
+		},
+		{
+			name:    "403 blames scope",
+			status:  403,
+			tenant:  probeTenant,
+			wantMsg: []string{"missing metrics:write/traces:write scope"},
+			skipMsg: []string{"credentials rejected"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var hitMetrics, hitTraces bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/v1/metrics":
+					hitMetrics = true
+				case "/v1/traces":
+					hitTraces = true
+				}
+				if r.Header.Get("Authorization") == "" {
+					t.Errorf("OTLP probe sent no auth header")
+				}
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
 
-	// The probe reads the process env, so clear the host's config and point
-	// the preferred spelling at the test server.
-	isolateEnv(t)
-	t.Setenv("AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT", srv.URL)
-	t.Setenv("AGENTO11Y_AUTH_TENANT_ID", "tenant-1")
-	t.Setenv("AGENTO11Y_AUTH_TOKEN", "glc_tok")
-	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "")
+			// The probe reads the process env, so clear the host's config and
+			// point the preferred spelling at the test server.
+			isolateEnv(t)
+			t.Setenv("AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT", srv.URL)
+			t.Setenv("AGENTO11Y_AUTH_TENANT_ID", "tenant-1")
+			t.Setenv("AGENTO11Y_AUTH_TOKEN", "glc_tok")
+			t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", tc.headers)
 
-	probe := defaultProbeOTLP(context.Background())
-	if probe == nil {
-		t.Fatal("expected a probe result")
+			probe := defaultProbeOTLP(context.Background(), tc.tenant)
+			if probe == nil {
+				t.Fatal("expected a probe result")
+			}
+			if !hitMetrics || !hitTraces {
+				t.Fatalf("both signals must be probed: metrics=%v traces=%v", hitMetrics, hitTraces)
+			}
+			if probe.Metrics.StatusCode != tc.status || !probe.Metrics.authFailure() {
+				t.Fatalf("metrics probe = %+v", probe.Metrics)
+			}
+			for _, signal := range []*ProbeResult{probe.Metrics, probe.Traces} {
+				for _, want := range tc.wantMsg {
+					if !strings.Contains(signal.Message, want) {
+						t.Fatalf("message %q missing %q", signal.Message, want)
+					}
+				}
+				for _, skip := range tc.skipMsg {
+					if strings.Contains(signal.Message, skip) {
+						t.Fatalf("message %q must not contain %q", signal.Message, skip)
+					}
+				}
+			}
+		})
 	}
-	if !hitMetrics || !hitTraces {
-		t.Fatalf("both signals must be probed: metrics=%v traces=%v", hitMetrics, hitTraces)
+}
+
+func TestCredentialsRejectedMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		tenant  envValue
+		wantMsg []string
+		skipMsg []string
+	}{
+		{
+			name:    "resolved tenant is named with its value",
+			tenant:  probeTenant,
+			wantMsg: []string{"the token may be invalid or expired", "AGENTO11Y_AUTH_TENANT_ID (tenant-1) may be wrong"},
+		},
+		{
+			// The legacy spelling is the one the user set, so it is the
+			// one to check.
+			name:    "legacy spelling is named as set",
+			tenant:  envValue{Set: true, Value: "tenant-1", Key: "SIGIL_AUTH_TENANT_ID", Source: sourceEnv},
+			wantMsg: []string{"SIGIL_AUTH_TENANT_ID (tenant-1) may be wrong"},
+			skipMsg: []string{"AGENTO11Y_AUTH_TENANT_ID"},
+		},
+		{
+			// No tenant id took part in the request, so pointing at one
+			// would send the user to the wrong variable.
+			name:    "no tenant id names only the token",
+			wantMsg: []string{"the token may be invalid or expired"},
+			skipMsg: []string{"AUTH_TENANT_ID"},
+		},
 	}
-	if probe.Metrics.StatusCode != 403 || !probe.Metrics.authFailure() {
-		t.Fatalf("metrics probe = %+v", probe.Metrics)
-	}
-	if !strings.Contains(probe.Metrics.Message, "metrics:write/traces:write") {
-		t.Fatalf("metrics message = %q", probe.Metrics.Message)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := credentialsRejectedMessage(tc.tenant)
+			for _, want := range tc.wantMsg {
+				if !strings.Contains(msg, want) {
+					t.Fatalf("message %q missing %q", msg, want)
+				}
+			}
+			for _, skip := range tc.skipMsg {
+				if strings.Contains(msg, skip) {
+					t.Fatalf("message %q must not contain %q", msg, skip)
+				}
+			}
+		})
 	}
 }
 
@@ -159,7 +277,7 @@ func TestProbeOTLP(t *testing.T) {
 // turn this into a live request.
 func TestProbeOTLP_NoEndpoint(t *testing.T) {
 	isolateEnv(t)
-	if got := defaultProbeOTLP(context.Background()); got != nil {
+	if got := defaultProbeOTLP(context.Background(), probeTenant); got != nil {
 		t.Fatalf("expected nil probe when no endpoint configured, got %+v", got)
 	}
 }


### PR DESCRIPTION
`agento11y doctor --probe` blamed the token scope for every auth failure. Auth answers 401 for an invalid token, an expired token and a wrong tenant id, so a wrong `AGENTO11Y_AUTH_TENANT_ID` produced a confusing message.