### PR TITLE
fix(plugins/pi): stop a forked session from linking to a missing parent

### DIFF
--- a/docs/concepts/tags-and-metadata.md
+++ b/docs/concepts/tags-and-metadata.md
@@ -126,6 +126,8 @@ Codex and copilot also add their own `codex.*` and `copilot.*` keys, so this tab
 | `pi.tokens_before` | Pi's estimate of the context size before a compaction, in tokens. Compaction generations only. The estimate covers the whole conversation, not this call's input tokens. | pi |
 | `pi.compaction.reason` | What triggered the compaction: `manual` (`/compact` or `ctx.compact()`), `threshold` (context limit), or `overflow` (context-overflow recovery). | pi |
 | `pi.compaction.will_retry` | `true` when pi retries the turn it aborted to run this compaction. Only overflow recovery retries. | pi |
+| `pi.fork.parent_session_id` | Conversation id of the session a fork was taken from. On the fork's first generation only. | pi |
+| `pi.fork.parent_generation_id` | Generation id of the trunk turn the fork continues from. Ships as metadata rather than a parent edge, because the trunk only holds that generation if it ran instrumented. | pi |
 
 ## See also
 

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -127,6 +127,15 @@ The plugin exports each of those calls as its own generation so they show up in 
 
 Two cases export nothing, because no model call happened: an extension supplied the compaction, or you navigated the tree without asking for a summary. Older pi versions record no usage on the entry; those still export a generation, with timing and metadata but no token counts.
 
+## Forked sessions
+
+`pi --fork` and the in-TUI `/fork` and `/clone` start a new conversation that carries a copy of the trunk's history. The fork's first generation gets no `parent_generation_ids`, because the trunk turn it continues from was only exported if the trunk itself ran instrumented, and a fork can be taken from a session recorded before this plugin was installed. The link to the trunk ships as metadata instead:
+
+- `pi.fork.parent_session_id` — conversation id of the trunk.
+- `pi.fork.parent_generation_id` — generation id of the trunk turn the fork continues from.
+
+The fork's own turns link to each other as usual. Both keys are omitted when the plugin cannot name the trunk turn: the trunk session file is unreadable, the fork header carries no usable timestamp, or the trunk inherited the turn from an older session instead of running it (a fork of a fork). If `pi --fork` starts on a session file whose header cannot be read, the plugin cannot tell the fork from a resume and links turns as usual; a fork taken inside the session is recognized either way, because pi reports it.
+
 ## Redaction
 
 Before any generation leaves the process, the SDK scrubs known token formats, PEM private keys, database URLs, `KEY=value` pairs, bearer tokens, and email addresses. Matches become `[REDACTED:<id>]`. User input messages are redacted by default; set `AGENTO11Y_REDACT_INPUT_MESSAGES=false` to leave them unchanged.

--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   loadConfigMock,
@@ -3876,6 +3879,531 @@ describe("extension lifecycle", () => {
       expect(seeds[0]!.id).toBe(stablePiGenerationId("pi-conv-1", "c1"));
       expect(seeds[0]!.parentGenerationIds).toBeUndefined();
       expect(loggerMock.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("generation lineage on a forked session", () => {
+    // These tests drive the real header read in sessionOrigin.ts against
+    // session files on disk, so they cover the wiring, not just the pure
+    // lineage function.
+    const TRUNK_ID = "0199aaaa-1111-7000-8000-aaaaaaaaaaaa";
+    const FORK_ID = "0199bbbb-2222-7000-8000-bbbbbbbbbbbb";
+    const TRUNK_STARTED_AT = "2020-01-01T00:00:00.000Z";
+    const BEFORE_FORK = "2020-01-01T00:00:30.000Z";
+    const FORKED_AT = "2020-01-01T00:01:00.000Z";
+    const AFTER_FORK = "2020-01-01T00:02:00.000Z";
+
+    let dir: string;
+    let trunkFile: string;
+    let forkFile: string;
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), "pi-fork-lineage-"));
+      trunkFile = join(dir, "trunk.jsonl");
+      forkFile = join(dir, "fork.jsonl");
+      writeSessionFile(trunkFile, trunkHeader());
+      writeSessionFile(forkFile, forkHeader());
+    });
+
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    function writeSessionFile(path: string, header: Record<string, unknown>) {
+      writeFileSync(path, `${JSON.stringify(header)}\n`);
+    }
+
+    function trunkHeader(): Record<string, unknown> {
+      return {
+        type: "session",
+        version: 3,
+        id: TRUNK_ID,
+        timestamp: TRUNK_STARTED_AT,
+        cwd: "/fixture/worktree",
+      };
+    }
+
+    function forkHeader(
+      overrides: Record<string, unknown> = {},
+    ): Record<string, unknown> {
+      return {
+        type: "session",
+        version: 3,
+        id: FORK_ID,
+        timestamp: FORKED_AT,
+        cwd: "/fixture/worktree",
+        parentSession: trunkFile,
+        ...overrides,
+      };
+    }
+
+    interface ForkSeed {
+      id?: string;
+      parentGenerationIds?: string[];
+      metadata?: Record<string, unknown>;
+    }
+
+    function setupForkClient() {
+      const seeds: ForkSeed[] = [];
+      const recorder = {
+        setResult: vi.fn(),
+        setCallError: vi.fn(),
+        setFirstTokenAt: vi.fn(),
+      };
+      const sigil: Agento11yLike = {
+        startStreamingGeneration: vi.fn(async (seed, run) => {
+          seeds.push(seed as ForkSeed);
+          await run(recorder);
+        }),
+        startGeneration: vi.fn(async (seed, run) => {
+          seeds.push(seed as ForkSeed);
+          await run(recorder);
+        }),
+        startToolExecution: vi.fn(() => ({
+          setResult: vi.fn(),
+          setCallError: vi.fn(),
+          end: vi.fn(),
+          getError: vi.fn(),
+        })),
+        shutdown: vi.fn(async () => {}),
+      };
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+      });
+      createAgento11yClientMock.mockReturnValue(sigil);
+      return { sigil, seeds };
+    }
+
+    function messageEntry(
+      id: string,
+      parentId: string | null,
+      role: string,
+      timestamp: string,
+      message: unknown = { role },
+    ) {
+      return { type: "message", id, parentId, timestamp, message };
+    }
+
+    /**
+     * The fork's branch: `a1` was copied from the trunk with its id and
+     * timestamp intact, `u2` and `a2` are the fork's own first turn.
+     */
+    function forkBranch(assistantMsg: unknown) {
+      return [
+        messageEntry("u1", null, "user", BEFORE_FORK),
+        messageEntry("a1", "u1", "assistant", BEFORE_FORK),
+        messageEntry("u2", "a1", "user", AFTER_FORK),
+        messageEntry("a2", "u2", "assistant", AFTER_FORK, assistantMsg),
+      ];
+    }
+
+    /** The fork's second turn, appended to `forkBranch`. */
+    function forkBranchTurnTwo(first: unknown, second: unknown) {
+      return [
+        ...forkBranch(first),
+        messageEntry("u3", "a2", "user", "2020-01-01T00:03:00.000Z"),
+        messageEntry(
+          "a3",
+          "u3",
+          "assistant",
+          "2020-01-01T00:03:01.000Z",
+          second,
+        ),
+      ];
+    }
+
+    function ctxForSession(
+      sessionFile: string,
+      sessionId: string,
+      branch: unknown[],
+    ) {
+      return {
+        sessionManager: {
+          getSessionFile: () => sessionFile,
+          getSessionId: () => sessionId,
+          getBranch: () => branch,
+        },
+      };
+    }
+
+    it("suppresses the parent edge and records the trunk link as metadata", async () => {
+      const { seeds } = setupForkClient();
+      const msg = assistantMessage();
+      const ctx = ctxForSession(forkFile, FORK_ID, forkBranch(msg));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: msg, toolResults: [] }, ctx);
+
+      expect(seeds).toHaveLength(1);
+      expect(seeds[0]!.id).toBe(stablePiGenerationId(FORK_ID, "a2"));
+      expect(seeds[0]!.parentGenerationIds).toBeUndefined();
+      expect(seeds[0]!.metadata).toEqual({
+        "pi.fork.parent_session_id": TRUNK_ID,
+        "pi.fork.parent_generation_id": stablePiGenerationId(TRUNK_ID, "a1"),
+      });
+    });
+
+    it("links the fork's second turn to its first", async () => {
+      const { seeds } = setupForkClient();
+      const first = assistantMessage();
+      const second = assistantMessage();
+      let branch: unknown[] = forkBranch(first);
+      const ctx = {
+        sessionManager: {
+          getSessionFile: () => forkFile,
+          getSessionId: () => FORK_ID,
+          getBranch: () => branch,
+        },
+      };
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: first, toolResults: [] }, ctx);
+
+      branch = forkBranchTurnTwo(first, second);
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: second, toolResults: [] }, ctx);
+
+      expect(seeds).toHaveLength(2);
+      expect(seeds[1]!.id).toBe(stablePiGenerationId(FORK_ID, "a3"));
+      expect(seeds[1]!.parentGenerationIds).toEqual([
+        stablePiGenerationId(FORK_ID, "a2"),
+      ]);
+      expect(seeds[1]!.metadata).toBeUndefined();
+    });
+
+    it("links a resumed fork's turn to the fork's own earlier turn", async () => {
+      // `pi -c` on a forked session: the header still says fork, and this
+      // plugin instance has exported nothing yet, but the parent turn was
+      // added after the fork so its generation exists under FORK_ID.
+      const { seeds } = setupForkClient();
+      const second = assistantMessage();
+      const ctx = ctxForSession(
+        forkFile,
+        FORK_ID,
+        forkBranchTurnTwo(assistantMessage(), second),
+      );
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: second, toolResults: [] }, ctx);
+
+      expect(seeds[0]!.parentGenerationIds).toEqual([
+        stablePiGenerationId(FORK_ID, "a2"),
+      ]);
+      expect(seeds[0]!.metadata).toBeUndefined();
+    });
+
+    it("keeps the edge on a --session continuation of the trunk", async () => {
+      // Same branch shape, but the header has no parentSession. A fresh
+      // process resuming the trunk has exported nothing yet, and the
+      // parent generation exists under this very conversation id.
+      const { seeds } = setupForkClient();
+      const msg = assistantMessage();
+      const ctx = ctxForSession(trunkFile, TRUNK_ID, forkBranch(msg));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: msg, toolResults: [] }, ctx);
+
+      expect(seeds[0]!.parentGenerationIds).toEqual([
+        stablePiGenerationId(TRUNK_ID, "a1"),
+      ]);
+      expect(seeds[0]!.metadata).toBeUndefined();
+    });
+
+    it("re-resolves fork state when the session is cloned mid-process", async () => {
+      // `/clone` emits session_start with reason "fork" and hands the
+      // extension a session manager pointing at the new file
+      // (agent-session-runtime.js). The trunk's answer must not be reused.
+      const { seeds } = setupForkClient();
+      const trunkMsg = assistantMessage();
+      const forkMsg = assistantMessage();
+      let sessionFile = trunkFile;
+      let sessionId = TRUNK_ID;
+      let branch: unknown[] = forkBranch(trunkMsg);
+      const ctx = {
+        sessionManager: {
+          getSessionFile: () => sessionFile,
+          getSessionId: () => sessionId,
+          getBranch: () => branch,
+        },
+      };
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: trunkMsg, toolResults: [] }, ctx);
+
+      sessionFile = forkFile;
+      sessionId = FORK_ID;
+      branch = forkBranch(forkMsg);
+      await pi.emit(
+        "session_start",
+        { reason: "fork", previousSessionFile: trunkFile },
+        ctx,
+      );
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: forkMsg, toolResults: [] }, ctx);
+
+      expect(seeds).toHaveLength(2);
+      expect(seeds[0]!.parentGenerationIds).toEqual([
+        stablePiGenerationId(TRUNK_ID, "a1"),
+      ]);
+      expect(seeds[1]!.parentGenerationIds).toBeUndefined();
+      expect(seeds[1]!.metadata).toEqual({
+        "pi.fork.parent_session_id": TRUNK_ID,
+        "pi.fork.parent_generation_id": stablePiGenerationId(TRUNK_ID, "a1"),
+      });
+    });
+
+    it("suppresses the edge without metadata when the trunk file is unreadable", async () => {
+      writeSessionFile(
+        forkFile,
+        forkHeader({ parentSession: join(dir, "deleted-trunk.jsonl") }),
+      );
+      const { seeds } = setupForkClient();
+      const msg = assistantMessage();
+      const ctx = ctxForSession(forkFile, FORK_ID, forkBranch(msg));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: msg, toolResults: [] }, ctx);
+
+      expect(seeds[0]!.parentGenerationIds).toBeUndefined();
+      expect(seeds[0]!.metadata).toBeUndefined();
+    });
+
+    it("suppresses the edge without metadata when the fork header has no timestamp", async () => {
+      // Nothing places the parent on either side of the fork, so neither
+      // an edge nor a trunk pointer can be trusted.
+      const { seeds } = setupForkClient();
+      const header = forkHeader();
+      delete header.timestamp;
+      writeSessionFile(forkFile, header);
+      const msg = assistantMessage();
+      const ctx = ctxForSession(forkFile, FORK_ID, forkBranch(msg));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: msg, toolResults: [] }, ctx);
+
+      expect(seeds[0]!.parentGenerationIds).toBeUndefined();
+      expect(seeds[0]!.metadata).toBeUndefined();
+    });
+
+    it("uses getHeader when the runtime exposes it, without touching the file", async () => {
+      // The production path: a real SessionManager answers getHeader() from
+      // memory, so only the trunk file is ever read.
+      const { seeds } = setupForkClient();
+      const msg = assistantMessage();
+      const getSessionFile = vi.fn(() => forkFile);
+      const ctx = {
+        sessionManager: {
+          getHeader: () => forkHeader(),
+          getSessionFile,
+          getSessionId: () => FORK_ID,
+          getBranch: () => forkBranch(msg),
+        },
+      };
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: msg, toolResults: [] }, ctx);
+
+      expect(seeds[0]!.parentGenerationIds).toBeUndefined();
+      expect(seeds[0]!.metadata).toEqual({
+        "pi.fork.parent_session_id": TRUNK_ID,
+        "pi.fork.parent_generation_id": stablePiGenerationId(TRUNK_ID, "a1"),
+      });
+      expect(getSessionFile).not.toHaveBeenCalled();
+    });
+
+    it("reads the fork header once per conversation", async () => {
+      const { seeds } = setupForkClient();
+      const msg = assistantMessage();
+      const getSessionFile = vi.fn(() => forkFile);
+      const ctx = {
+        sessionManager: {
+          getSessionFile,
+          getSessionId: () => FORK_ID,
+          getBranch: () => forkBranch(msg),
+        },
+      };
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      for (let i = 0; i < 3; i++) {
+        await pi.emit("turn_start", {}, ctx);
+        await pi.emit("turn_end", { message: msg, toolResults: [] }, ctx);
+      }
+
+      expect(seeds).toHaveLength(3);
+      expect(getSessionFile).toHaveBeenCalledTimes(1);
+    });
+
+    it("omits the trunk generation id when the parent predates the trunk session", async () => {
+      // A fork of a fork: the trunk copied `a1` in from an older session and
+      // never exported it, so no generation for it exists under TRUNK_ID
+      // either. The edge stays suppressed, the metadata goes away.
+      writeSessionFile(trunkFile, {
+        ...trunkHeader(),
+        timestamp: "2020-01-01T00:00:45.000Z",
+      });
+      const { seeds } = setupForkClient();
+      const msg = assistantMessage();
+      const ctx = ctxForSession(forkFile, FORK_ID, forkBranch(msg));
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: msg, toolResults: [] }, ctx);
+
+      expect(seeds[0]!.parentGenerationIds).toBeUndefined();
+      expect(seeds[0]!.metadata).toBeUndefined();
+    });
+
+    it("suppresses the edge on an in-memory fork, whose header names no trunk", async () => {
+      // `pi --no-session` plus `/fork`: createBranchedSession writes no
+      // `parentSession` when the manager does not persist, and there is no
+      // session file either, so the session_start reason and the trunk the
+      // plugin was already on are all it has to work from.
+      const { seeds } = setupForkClient();
+      const trunkMsg = assistantMessage();
+      const forkMsg = assistantMessage();
+      // An in-memory manager answers getHeader() from memory. The header
+      // carries the new id and the fork instant, but no parentSession.
+      let header: Record<string, unknown> = {
+        type: "session",
+        id: TRUNK_ID,
+        timestamp: TRUNK_STARTED_AT,
+      };
+      let branch: unknown[] = forkBranch(trunkMsg);
+      const ctx = {
+        sessionManager: {
+          getHeader: () => header,
+          getSessionFile: () => undefined,
+          getSessionId: () => header.id as string,
+          getBranch: () => branch,
+        },
+      };
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", { reason: "startup" }, ctx);
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: trunkMsg, toolResults: [] }, ctx);
+
+      header = { type: "session", id: FORK_ID, timestamp: FORKED_AT };
+      branch = forkBranch(forkMsg);
+      await pi.emit("session_start", { reason: "fork" }, ctx);
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: forkMsg, toolResults: [] }, ctx);
+
+      expect(seeds).toHaveLength(2);
+      expect(seeds[0]!.parentGenerationIds).toEqual([
+        stablePiGenerationId(TRUNK_ID, "a1"),
+      ]);
+      // The defect this guards against: hashing the copied entry with the
+      // fork's conversation id names a generation nobody exported.
+      expect(seeds[1]!.id).toBe(stablePiGenerationId(FORK_ID, "a2"));
+      expect(seeds[1]!.parentGenerationIds).toBeUndefined();
+      expect(seeds[1]!.metadata).toEqual({
+        "pi.fork.parent_session_id": TRUNK_ID,
+        "pi.fork.parent_generation_id": stablePiGenerationId(TRUNK_ID, "a1"),
+      });
+    });
+
+    it("suppresses the edge on an in-memory fork with no trunk to name", async () => {
+      // Same path, but the plugin never saw the trunk conversation, so it
+      // has no trunk id. The edge must still go.
+      const { seeds } = setupForkClient();
+      const msg = assistantMessage();
+      const ctx = {
+        sessionManager: {
+          getHeader: () => ({
+            type: "session",
+            id: FORK_ID,
+            timestamp: FORKED_AT,
+          }),
+          getSessionFile: () => undefined,
+          getSessionId: () => FORK_ID,
+          getBranch: () => forkBranch(msg),
+        },
+      };
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", { reason: "fork" }, ctx);
+      await pi.emit("turn_start", {}, ctx);
+      await pi.emit("turn_end", { message: msg, toolResults: [] }, ctx);
+
+      expect(seeds[0]!.parentGenerationIds).toBeUndefined();
+      expect(seeds[0]!.metadata).toBeUndefined();
+    });
+
+    it("suppresses the edge for a compaction taken before the fork's first turn", async () => {
+      // The summary's parent is the inherited assistant entry, so it sits on
+      // the trunk side of the fork just as a turn's parent would.
+      const { seeds } = setupForkClient();
+      const compaction = {
+        type: "compaction",
+        id: "c1",
+        parentId: "a1",
+        timestamp: AFTER_FORK,
+        summary: "Earlier: we forked and compacted straight away.",
+      };
+      const ctx = {
+        sessionManager: {
+          getSessionFile: () => forkFile,
+          getSessionId: () => FORK_ID,
+          getBranch: () => [
+            messageEntry("u1", null, "user", BEFORE_FORK),
+            messageEntry("a1", "u1", "assistant", BEFORE_FORK),
+            compaction,
+          ],
+        },
+        model: defaultModel,
+      };
+
+      const pi = new FakePi();
+      registerExtension(pi as any);
+      await pi.emit("session_start", {}, ctx);
+      await pi.emit("session_before_compact", { reason: "manual" }, ctx);
+      await pi.emit(
+        "session_compact",
+        { compactionEntry: compaction, fromExtension: false },
+        ctx,
+      );
+
+      expect(seeds).toHaveLength(1);
+      expect(seeds[0]!.id).toBe(stablePiGenerationId(FORK_ID, "c1"));
+      expect(seeds[0]!.parentGenerationIds).toBeUndefined();
+      expect(seeds[0]!.metadata).toEqual({
+        "pi.fork.parent_session_id": TRUNK_ID,
+        "pi.fork.parent_generation_id": stablePiGenerationId(TRUNK_ID, "a1"),
+      });
     });
   });
 });

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -12,6 +12,7 @@ import { detectPiVersion } from "./detectPiVersion.js";
 import { resolveGitBranch } from "./git.js";
 import { runPreflightTransform, runToolCallGuard } from "./guard.js";
 import {
+  type PiGenerationParent,
   resolvePiGenerationLineage,
   resolvePiSummaryLineage,
   type SessionManagerLike,
@@ -41,6 +42,14 @@ import {
   toolResultText,
   userMessageText,
 } from "./mappers.js";
+import {
+  type ConversationRecord,
+  NOT_FORKED,
+  resolveSessionOrigin,
+  resolveSessionStart,
+  type SessionHeaderSourceLike,
+  type SessionOrigin,
+} from "./sessionOrigin.js";
 import { buildBuiltinTags } from "./tags.js";
 import {
   createTelemetryProviders,
@@ -110,6 +119,20 @@ export default function (pi: ExtensionAPI) {
   // `getBranch()`; this set covers the fallback.
   const exportedSummaryEntryIds = new Set<string>();
 
+  // Where each conversation came from. Filled at `session_start` and, for a
+  // conversation id that appears without one, on first sight at `turn_end`,
+  // so the session header is read once per conversation rather than per
+  // turn. Cleared by resetSessionState.
+  const sessionOrigins = new Map<string, SessionOrigin>();
+
+  // Conversation the plugin is attributing turns to, and when that
+  // conversation began. Set on every `session_start`, and deliberately kept
+  // across `resetSessionState` and `session_shutdown`: a fork tears the old
+  // session down first (agent-session-runtime.js teardownCurrent), and a
+  // `--no-session` fork writes no `parentSession`, so this record is the
+  // only reference to the trunk it came from. See sessionOrigin.ts.
+  let currentConversation: ConversationRecord | undefined;
+
   function resetTurnState() {
     turnStartTime = 0;
     firstTokenTime = 0;
@@ -137,6 +160,7 @@ export default function (pi: ExtensionAPI) {
     compactionStartedAt = undefined;
     branchSummaryStartedAt = undefined;
     exportedSummaryEntryIds.clear();
+    sessionOrigins.clear();
   }
 
   /**
@@ -212,7 +236,7 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
-    const conversationId = sessionManager?.getSessionId?.() || undefined;
+    const conversationId = readSessionId(sessionManager);
 
     // Entry timestamps are ISO strings stamped when the entry is appended,
     // i.e. after the summarization call finished. No pi event carries a
@@ -240,10 +264,17 @@ export default function (pi: ExtensionAPI) {
       logger.debug("getSessionName failed", err);
     }
 
+    // A summary taken right after a fork sits on top of an inherited turn,
+    // so its parent is subject to the same trunk boundary as a turn's. See
+    // sessionOrigin.ts.
+    const origin: SessionOrigin = conversationId
+      ? sessionOriginFor(conversationId, sessionManager)
+      : NOT_FORKED;
     const lineage = resolvePiSummaryLineage(
       sessionManager,
       entryId,
       conversationId,
+      { origin },
     );
 
     const seed = mapSummaryGenerationStart({
@@ -261,7 +292,8 @@ export default function (pi: ExtensionAPI) {
       startedAt,
       tags,
       generationId: lineage.generationId,
-      parentGenerationIds: lineage.parentGenerationIds,
+      parentGenerationIds: parentEdge(lineage.parent),
+      metadata: forkMetadata(lineage.parent, origin),
     });
 
     const result = mapSummaryGenerationResult({
@@ -289,6 +321,40 @@ export default function (pi: ExtensionAPI) {
     );
   }
 
+  /**
+   * Origin of `conversationId`, read from the session header on first sight
+   * and cached for the rest of the conversation. A session's header never
+   * changes; a fork produces a new conversation id and so a fresh lookup.
+   */
+  function sessionOriginFor(
+    conversationId: string,
+    sessionManager: SessionHeaderSourceLike | undefined | null,
+  ): SessionOrigin {
+    const cached = sessionOrigins.get(conversationId);
+    if (cached) return cached;
+    const origin = resolveSessionOrigin(sessionManager);
+    sessionOrigins.set(conversationId, origin);
+    return origin;
+  }
+
+  /**
+   * Current conversation id, or undefined when the runtime cannot report
+   * one. Never throws: a failure here must not disable the plugin.
+   */
+  function readSessionId(
+    sessionManager:
+      | { getSessionId?: () => string | undefined }
+      | undefined
+      | null,
+  ): string | undefined {
+    try {
+      return sessionManager?.getSessionId?.() || undefined;
+    } catch (err) {
+      logger.debug("getSessionId failed", err);
+      return undefined;
+    }
+  }
+
   function cacheAssistantModel(message: PiAssistantMessage) {
     lastSeenModel = {
       provider: message.provider,
@@ -296,7 +362,7 @@ export default function (pi: ExtensionAPI) {
     };
   }
 
-  pi.on("session_start", async (_event, ctx) => {
+  pi.on("session_start", async (event, ctx) => {
     try {
       if (sigil) {
         try {
@@ -307,7 +373,25 @@ export default function (pi: ExtensionAPI) {
       }
 
       sigil = null;
+      const trunk = currentConversation;
       await resetSessionState();
+
+      // Resolve the origin here, while the conversation the session came
+      // from is still known: with `--no-session` the header cannot say.
+      const startedConversationId = readSessionId(ctx.sessionManager);
+      const { startedAt, origin } = resolveSessionStart(ctx.sessionManager, {
+        forked: event.reason === "fork",
+        trunk,
+      });
+      if (startedConversationId) {
+        currentConversation = {
+          id: startedConversationId,
+          startedAt: startedAt ?? new Date().toISOString(),
+        };
+        sessionOrigins.set(startedConversationId, origin);
+      } else {
+        currentConversation = undefined;
+      }
 
       config = await loadConfig();
       if (!config) return;
@@ -316,17 +400,19 @@ export default function (pi: ExtensionAPI) {
         config = { ...config, agentVersion: detectPiVersion() };
       }
 
-      // Note: conversationId is read fresh per turn from
-      // ctx.sessionManager.getSessionId() so fork/branch reassignments
-      // (session-manager.js:927,961) are reflected without restarting
-      // the plugin. We intentionally do NOT cache it here.
+      // Note: the conversation id a generation carries is read fresh per
+      // turn from ctx.sessionManager.getSessionId() so fork/branch
+      // reassignments (session-manager.js:927,961) are reflected without
+      // restarting the plugin. `currentConversation` above records which
+      // conversation this process is on, and is only read when a later fork
+      // needs to name its trunk.
 
       // Set up OTel providers if OTLP is configured.
       // Pass the pi session id as service.instance.id so concurrent pi
       // sessions on the same machine emit distinct OTel metric series.
       if (config.otlp) {
         try {
-          const instanceId = ctx.sessionManager.getSessionId() || randomUUID();
+          const instanceId = startedConversationId ?? randomUUID();
           telemetry = createTelemetryProviders(config.otlp, instanceId);
         } catch (err) {
           logger.error("failed to create OTel providers", err);
@@ -651,10 +737,17 @@ export default function (pi: ExtensionAPI) {
       // so the assistant entry is not yet in the tree at that point. By
       // `turn_end` it has been appended and any subsequent extension
       // mutations have settled.
-      const lineage = resolvePiGenerationLineage(
+      //
+      // A fork's parent turn may belong to the trunk conversation, in which
+      // case no edge is emitted. See sessionOrigin.ts.
+      const origin: SessionOrigin = conversationId
+        ? sessionOriginFor(conversationId, ctx.sessionManager)
+        : NOT_FORKED;
+      const { generationId, parent } = resolvePiGenerationLineage(
         ctx.sessionManager,
         msg,
         conversationId,
+        { origin },
       );
 
       // Prefer pi's user-set session name; otherwise derive from the first
@@ -683,8 +776,9 @@ export default function (pi: ExtensionAPI) {
         tags: builtinTags,
         systemPrompt: currentSystemPrompt,
         requestControls: currentRequestControls,
-        generationId: lineage.generationId,
-        parentGenerationIds: lineage.parentGenerationIds,
+        generationId,
+        parentGenerationIds: parentEdge(parent),
+        metadata: forkMetadata(parent, origin),
       });
 
       const toolResults = (event.toolResults ?? []) as PiToolResult[];
@@ -841,11 +935,48 @@ export default function (pi: ExtensionAPI) {
  * be read without importing pi's model types.
  */
 interface PiSummaryContext {
-  sessionManager?: SessionManagerLike & {
-    getSessionId?: () => string | undefined;
-    getSessionName?: () => string | undefined;
-  };
+  sessionManager?: SessionManagerLike &
+    SessionHeaderSourceLike & {
+      getSessionId?: () => string | undefined;
+      getSessionName?: () => string | undefined;
+    };
   model?: { provider?: unknown; id?: unknown };
+}
+
+/**
+ * The parent edge to export. Only a parent generation that belongs to this
+ * conversation can be one; see `lineage.ts`.
+ */
+function parentEdge(
+  parent: PiGenerationParent | undefined,
+): string[] | undefined {
+  return parent?.kind === "own" ? parent.generationIds : undefined;
+}
+
+/**
+ * The trunk link a fork cannot express as an edge.
+ *
+ * It ships as metadata because the trunk generation only exists in the
+ * backend if the trunk itself ran instrumented, and a fork can be taken from
+ * a session recorded before this plugin was installed. Metadata, not a tag,
+ * because tags are low-cardinality session context (`cwd`, `git.branch`) and
+ * a session id is not. The key names follow `codex.parent_session_id`
+ * (plugins/agento11y/internal/agents/codex/mapper/mapper.go), which emits the
+ * edge when it can resolve the parent generation and falls back to metadata
+ * when it cannot.
+ */
+function forkMetadata(
+  parent: PiGenerationParent | undefined,
+  origin: SessionOrigin,
+): Record<string, string> | undefined {
+  if (parent?.kind !== "trunk") return undefined;
+  if (!parent.trunkGenerationId || !origin.trunkConversationId) {
+    return undefined;
+  }
+  return {
+    "pi.fork.parent_session_id": origin.trunkConversationId,
+    "pi.fork.parent_generation_id": parent.trunkGenerationId,
+  };
 }
 
 /**

--- a/plugins/pi/src/lineage.test.ts
+++ b/plugins/pi/src/lineage.test.ts
@@ -1,29 +1,38 @@
 import { describe, expect, it } from "vitest";
 import {
+  type PiGenerationLineage,
   resolvePiGenerationLineage,
   resolvePiSummaryLineage,
   type SessionEntryLike,
   stablePiGenerationId,
 } from "./lineage.js";
+import { NOT_FORKED, type SessionOrigin } from "./sessionOrigin.js";
 
 function assistantEntry(
   id: string,
   parentId: string | null,
   message: unknown = { role: "assistant" },
+  timestamp?: string,
 ): SessionEntryLike {
   return {
     type: "message",
     id,
     parentId,
+    timestamp,
     message: message as { role?: string },
   };
 }
 
-function userEntry(id: string, parentId: string | null): SessionEntryLike {
+function userEntry(
+  id: string,
+  parentId: string | null,
+  timestamp?: string,
+): SessionEntryLike {
   return {
     type: "message",
     id,
     parentId,
+    timestamp,
     message: { role: "user" },
   };
 }
@@ -38,6 +47,13 @@ function toolResultEntry(
     parentId,
     message: { role: "toolResult" },
   };
+}
+
+/** The parent edge the caller would export, if any. */
+function ownParentIds(lineage: PiGenerationLineage): string[] | undefined {
+  return lineage.parent?.kind === "own"
+    ? lineage.parent.generationIds
+    : undefined;
 }
 
 function nonMessageEntry(
@@ -161,9 +177,7 @@ describe("resolvePiGenerationLineage", () => {
     const sm = { getBranch: () => branch };
     const lineage = resolvePiGenerationLineage(sm, assistantMsg, "conv");
     expect(lineage.generationId).toBe(stablePiGenerationId("conv", "a2"));
-    expect(lineage.parentGenerationIds).toEqual([
-      stablePiGenerationId("conv", "a1"),
-    ]);
+    expect(ownParentIds(lineage)).toEqual([stablePiGenerationId("conv", "a1")]);
   });
 
   it("falls back to latest assistant entry when message identity does not match", () => {
@@ -180,7 +194,7 @@ describe("resolvePiGenerationLineage", () => {
       "conv",
     );
     expect(lineage.generationId).toBe(stablePiGenerationId("conv", "a1"));
-    expect(lineage.parentGenerationIds).toBeUndefined();
+    expect(ownParentIds(lineage)).toBeUndefined();
   });
 
   it("omits parentGenerationIds for the first assistant turn", () => {
@@ -192,7 +206,7 @@ describe("resolvePiGenerationLineage", () => {
     const sm = { getBranch: () => branch };
     const lineage = resolvePiGenerationLineage(sm, assistantMsg, "conv");
     expect(lineage.generationId).toBe(stablePiGenerationId("conv", "a1"));
-    expect(lineage.parentGenerationIds).toBeUndefined();
+    expect(ownParentIds(lineage)).toBeUndefined();
   });
 
   it("links a linear second assistant turn to the first one", () => {
@@ -206,9 +220,7 @@ describe("resolvePiGenerationLineage", () => {
     const sm = { getBranch: () => branch };
     const lineage = resolvePiGenerationLineage(sm, second, "conv");
     expect(lineage.generationId).toBe(stablePiGenerationId("conv", "a2"));
-    expect(lineage.parentGenerationIds).toEqual([
-      stablePiGenerationId("conv", "a1"),
-    ]);
+    expect(ownParentIds(lineage)).toEqual([stablePiGenerationId("conv", "a1")]);
   });
 
   it("walks through non-message entries when finding the parent assistant", () => {
@@ -224,9 +236,7 @@ describe("resolvePiGenerationLineage", () => {
     ];
     const sm = { getBranch: () => branch };
     const lineage = resolvePiGenerationLineage(sm, assistantMsg, "conv");
-    expect(lineage.parentGenerationIds).toEqual([
-      stablePiGenerationId("conv", "a1"),
-    ]);
+    expect(ownParentIds(lineage)).toEqual([stablePiGenerationId("conv", "a1")]);
   });
 
   it("walks through user entries to the previous assistant on the branch", () => {
@@ -242,9 +252,7 @@ describe("resolvePiGenerationLineage", () => {
     ];
     const sm = { getBranch: () => branch };
     const lineage = resolvePiGenerationLineage(sm, assistantMsg, "conv");
-    expect(lineage.parentGenerationIds).toEqual([
-      stablePiGenerationId("conv", "a1"),
-    ]);
+    expect(ownParentIds(lineage)).toEqual([stablePiGenerationId("conv", "a1")]);
   });
 
   it("picks the assistant entry on the active branch, not the most recent chronological one", () => {
@@ -263,11 +271,9 @@ describe("resolvePiGenerationLineage", () => {
     const sm = { getBranch: () => branch };
     const lineage = resolvePiGenerationLineage(sm, assistantMsg, "conv");
     expect(lineage.generationId).toBe(stablePiGenerationId("conv", "a3"));
-    expect(lineage.parentGenerationIds).toEqual([
-      stablePiGenerationId("conv", "a1"),
-    ]);
+    expect(ownParentIds(lineage)).toEqual([stablePiGenerationId("conv", "a1")]);
     // Should not link to the abandoned sibling assistant entry.
-    expect(lineage.parentGenerationIds).not.toContain(
+    expect(ownParentIds(lineage)).not.toContain(
       stablePiGenerationId("conv", "a2"),
     );
   });
@@ -333,9 +339,7 @@ describe("resolvePiSummaryLineage", () => {
     const sm = { getBranch: () => branch };
     const lineage = resolvePiSummaryLineage(sm, "c1", "conv");
     expect(lineage.generationId).toBe(stablePiGenerationId("conv", "c1"));
-    expect(lineage.parentGenerationIds).toEqual([
-      stablePiGenerationId("conv", "a1"),
-    ]);
+    expect(ownParentIds(lineage)).toEqual([stablePiGenerationId("conv", "a1")]);
   });
 
   it("walks through an intervening toolResult message entry", () => {
@@ -348,9 +352,9 @@ describe("resolvePiSummaryLineage", () => {
       compactionEntry("c1", "t1"),
     ];
     const sm = { getBranch: () => branch };
-    expect(
-      resolvePiSummaryLineage(sm, "c1", "conv").parentGenerationIds,
-    ).toEqual([stablePiGenerationId("conv", "a1")]);
+    expect(ownParentIds(resolvePiSummaryLineage(sm, "c1", "conv"))).toEqual([
+      stablePiGenerationId("conv", "a1"),
+    ]);
   });
 
   it("walks through an intervening model_change entry", () => {
@@ -361,9 +365,9 @@ describe("resolvePiSummaryLineage", () => {
       compactionEntry("c1", "mc1"),
     ];
     const sm = { getBranch: () => branch };
-    expect(
-      resolvePiSummaryLineage(sm, "c1", "conv").parentGenerationIds,
-    ).toEqual([stablePiGenerationId("conv", "a1")]);
+    expect(ownParentIds(resolvePiSummaryLineage(sm, "c1", "conv"))).toEqual([
+      stablePiGenerationId("conv", "a1"),
+    ]);
   });
 
   it("walks through both a toolResult and a model_change entry", () => {
@@ -377,9 +381,7 @@ describe("resolvePiSummaryLineage", () => {
     const sm = { getBranch: () => branch };
     const lineage = resolvePiSummaryLineage(sm, "c1", "conv");
     expect(lineage.generationId).toBe(stablePiGenerationId("conv", "c1"));
-    expect(lineage.parentGenerationIds).toEqual([
-      stablePiGenerationId("conv", "a1"),
-    ]);
+    expect(ownParentIds(lineage)).toEqual([stablePiGenerationId("conv", "a1")]);
   });
 
   it("omits parentGenerationIds when no assistant entry precedes the summary", () => {
@@ -390,7 +392,7 @@ describe("resolvePiSummaryLineage", () => {
     const sm = { getBranch: () => branch };
     const lineage = resolvePiSummaryLineage(sm, "c1", "conv");
     expect(lineage.generationId).toBe(stablePiGenerationId("conv", "c1"));
-    expect(lineage.parentGenerationIds).toBeUndefined();
+    expect(ownParentIds(lineage)).toBeUndefined();
   });
 
   it("resolves a branch_summary entry the same way", () => {
@@ -402,9 +404,7 @@ describe("resolvePiSummaryLineage", () => {
     const sm = { getBranch: () => branch };
     const lineage = resolvePiSummaryLineage(sm, "b1", "conv");
     expect(lineage.generationId).toBe(stablePiGenerationId("conv", "b1"));
-    expect(lineage.parentGenerationIds).toEqual([
-      stablePiGenerationId("conv", "a1"),
-    ]);
+    expect(ownParentIds(lineage)).toEqual([stablePiGenerationId("conv", "a1")]);
   });
 
   it("differs from the turn generation id for the same conversation", () => {
@@ -417,5 +417,215 @@ describe("resolvePiSummaryLineage", () => {
     expect(resolvePiSummaryLineage(sm, "c1", "conv").generationId).not.toBe(
       stablePiGenerationId("conv", "a1"),
     );
+  });
+
+  it("reports a trunk parent for a summary taken right after a fork", () => {
+    // Compacting before the fork's first turn parents the summary on an
+    // inherited assistant entry, whose generation belongs to the trunk.
+    const branch: SessionEntryLike[] = [
+      userEntry("u1", null, "2020-01-01T00:00:30.000Z"),
+      assistantEntry(
+        "a1",
+        "u1",
+        { role: "assistant" },
+        "2020-01-01T00:00:30.000Z",
+      ),
+      { ...compactionEntry("c1", "a1"), timestamp: "2020-01-01T00:02:00.000Z" },
+    ];
+    const sm = { getBranch: () => branch };
+    const lineage = resolvePiSummaryLineage(sm, "c1", "fork-conv", {
+      origin: {
+        forked: true,
+        forkedAt: "2020-01-01T00:01:00.000Z",
+        trunkConversationId: "trunk-conv",
+        trunkStartedAt: "2020-01-01T00:00:00.000Z",
+      },
+    });
+
+    expect(lineage.generationId).toBe(stablePiGenerationId("fork-conv", "c1"));
+    expect(lineage.parent).toEqual({
+      kind: "trunk",
+      trunkGenerationId: stablePiGenerationId("trunk-conv", "a1"),
+    });
+  });
+});
+
+describe("resolvePiGenerationLineage on a forked session", () => {
+  // `a1` below was copied from the trunk, so it keeps its trunk id and a
+  // timestamp older than the fork. See sessionOrigin.ts for that boundary.
+  const TRUNK = "trunk-conv";
+  const FORK = "fork-conv";
+  const TRUNK_STARTED_AT = "2020-01-01T00:00:00.000Z";
+  const BEFORE_FORK = "2020-01-01T00:00:30.000Z";
+  const FORKED_AT = "2020-01-01T00:01:00.000Z";
+  const AFTER_FORK = "2020-01-01T00:02:00.000Z";
+
+  const forkOrigin: SessionOrigin = {
+    forked: true,
+    forkedAt: FORKED_AT,
+    trunkConversationId: TRUNK,
+    trunkStartedAt: TRUNK_STARTED_AT,
+  };
+
+  /**
+   * Inherited assistant `a1`, then the fork's own `u2` -> `a2`. `parentAt`
+   * stamps the inherited turn; `null` leaves it unstamped.
+   */
+  function forkBranch(
+    assistantMsg: unknown,
+    parentAt: string | null = BEFORE_FORK,
+  ): SessionEntryLike[] {
+    const at = parentAt ?? undefined;
+    return [
+      userEntry("u1", null, at),
+      assistantEntry("a1", "u1", { role: "assistant" }, at),
+      userEntry("u2", "a1", AFTER_FORK),
+      assistantEntry("a2", "u2", assistantMsg, AFTER_FORK),
+    ];
+  }
+
+  it.each([
+    {
+      name: "the parent was copied from the trunk",
+      options: { origin: forkOrigin },
+      parentAt: BEFORE_FORK,
+      wantParent: {
+        kind: "trunk",
+        trunkGenerationId: stablePiGenerationId(TRUNK, "a1"),
+      },
+    },
+    {
+      name: "the parent is stamped exactly at the fork instant",
+      options: { origin: forkOrigin },
+      parentAt: FORKED_AT,
+      wantParent: {
+        kind: "trunk",
+        trunkGenerationId: stablePiGenerationId(TRUNK, "a1"),
+      },
+    },
+    {
+      name: "the trunk conversation id is unknown",
+      options: { origin: { forked: true, forkedAt: FORKED_AT } },
+      parentAt: BEFORE_FORK,
+      wantParent: { kind: "trunk", trunkGenerationId: undefined },
+    },
+    {
+      name: "the trunk's own start time is unknown",
+      options: {
+        origin: {
+          forked: true,
+          forkedAt: FORKED_AT,
+          trunkConversationId: TRUNK,
+        },
+      },
+      parentAt: BEFORE_FORK,
+      wantParent: { kind: "trunk", trunkGenerationId: undefined },
+    },
+    {
+      name: "the parent predates the trunk session, as on a fork of a fork",
+      // The trunk inherited `a1` from an older session and never exported
+      // it, so no generation for it exists under the trunk either.
+      options: {
+        origin: { ...forkOrigin, trunkStartedAt: "2020-01-01T00:00:45.000Z" },
+      },
+      parentAt: BEFORE_FORK,
+      wantParent: { kind: "trunk", trunkGenerationId: undefined },
+    },
+    {
+      name: "the fork header carries no timestamp",
+      options: { origin: { forked: true, trunkConversationId: TRUNK } },
+      parentAt: BEFORE_FORK,
+      wantParent: { kind: "unknown" },
+    },
+    {
+      name: "the fork header timestamp is unparseable",
+      options: {
+        origin: {
+          forked: true,
+          forkedAt: "whenever",
+          trunkConversationId: TRUNK,
+        },
+      },
+      parentAt: BEFORE_FORK,
+      wantParent: { kind: "unknown" },
+    },
+    {
+      name: "the parent entry carries no timestamp",
+      options: { origin: forkOrigin },
+      parentAt: null,
+      wantParent: { kind: "unknown" },
+    },
+    {
+      name: "the session is a --session continuation, not a fork",
+      // The generation for `a1` exists under this very conversation id.
+      // Suppressing here would split one conversation into two roots.
+      options: { origin: NOT_FORKED },
+      parentAt: BEFORE_FORK,
+      wantParent: {
+        kind: "own",
+        generationIds: [stablePiGenerationId(FORK, "a1")],
+      },
+    },
+    {
+      name: "no options are passed at all",
+      options: undefined,
+      parentAt: BEFORE_FORK,
+      wantParent: {
+        kind: "own",
+        generationIds: [stablePiGenerationId(FORK, "a1")],
+      },
+    },
+  ])("resolves the parent as $wantParent.kind when $name", ({
+    options,
+    parentAt,
+    wantParent,
+  }) => {
+    const assistantMsg = { role: "assistant" };
+    const sm = { getBranch: () => forkBranch(assistantMsg, parentAt) };
+
+    const lineage = resolvePiGenerationLineage(sm, assistantMsg, FORK, options);
+
+    expect(lineage.generationId).toBe(stablePiGenerationId(FORK, "a2"));
+    expect(lineage.parent).toEqual(wantParent);
+  });
+
+  it("emits the edge when the parent was added after the fork", () => {
+    // The fork's second turn. Nothing here depends on what this process
+    // exported, so a process that resumed the fork resolves it the same way.
+    const assistantMsg = { role: "assistant" };
+    const branch: SessionEntryLike[] = [
+      ...forkBranch({ role: "assistant" }),
+      userEntry("u3", "a2", "2020-01-01T00:03:00.000Z"),
+      assistantEntry("a3", "u3", assistantMsg, "2020-01-01T00:03:01.000Z"),
+    ];
+    const sm = { getBranch: () => branch };
+
+    const lineage = resolvePiGenerationLineage(sm, assistantMsg, FORK, {
+      origin: forkOrigin,
+    });
+
+    expect(lineage.generationId).toBe(stablePiGenerationId(FORK, "a3"));
+    expect(lineage.parent).toEqual({
+      kind: "own",
+      generationIds: [stablePiGenerationId(FORK, "a2")],
+    });
+  });
+
+  it("reports no parent for a fork taken before the first turn", () => {
+    // A fork with nothing inherited: the first generation is a genuine root
+    // and there is no trunk link.
+    const assistantMsg = { role: "assistant" };
+    const branch: SessionEntryLike[] = [
+      userEntry("u1", null, AFTER_FORK),
+      assistantEntry("a1", "u1", assistantMsg, AFTER_FORK),
+    ];
+    const sm = { getBranch: () => branch };
+
+    const lineage = resolvePiGenerationLineage(sm, assistantMsg, FORK, {
+      origin: forkOrigin,
+    });
+
+    expect(lineage.generationId).toBe(stablePiGenerationId(FORK, "a1"));
+    expect(lineage.parent).toBeUndefined();
   });
 });

--- a/plugins/pi/src/lineage.ts
+++ b/plugins/pi/src/lineage.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import type { SessionOrigin } from "./sessionOrigin.js";
 
 /**
  * Lineage helpers for deterministic, branch-aware Pi generation IDs.
@@ -37,13 +38,44 @@ export interface SessionEntryLike {
   type?: string;
   id?: string;
   parentId?: string | null;
+  /** ISO-8601, set by pi when the entry is appended. */
+  timestamp?: string;
   message?: { role?: string } | null;
 }
+
+/** Extra context that decides whether a parent edge is safe to emit. */
+export interface ResolveLineageOptions {
+  /** Where this session came from. See `sessionOrigin.ts`. */
+  origin?: SessionOrigin;
+}
+
+/**
+ * The turn that precedes the one being exported. Exactly one shape, so a
+ * caller cannot emit an edge and a trunk pointer at the same time.
+ */
+export type PiGenerationParent =
+  /** The parent generation exists under this conversation id. */
+  | { kind: "own"; generationIds: string[] }
+  /**
+   * A fork copied the parent entry in, so its generation belongs to the
+   * trunk conversation and no edge is emitted. `trunkGenerationId` names
+   * that generation, and is absent when the trunk is unknown or cannot have
+   * exported the entry.
+   */
+  | { kind: "trunk"; trunkGenerationId?: string }
+  /**
+   * A fork where either the header timestamp or the parent entry's
+   * timestamp is missing or unparseable, so the parent cannot be placed on
+   * either side of the fork. Nothing is emitted: an id built on a guess
+   * would name a generation that may not exist.
+   */
+  | { kind: "unknown" };
 
 /** What `resolvePiGenerationLineage` returns. Empty when no lineage. */
 export interface PiGenerationLineage {
   generationId?: string;
-  parentGenerationIds?: string[];
+  /** Absent for the first assistant turn on the branch. */
+  parent?: PiGenerationParent;
 }
 
 /**
@@ -63,8 +95,8 @@ export function stablePiGenerationId(
 }
 
 /**
- * Resolve `{ generationId, parentGenerationIds }` for the assistant turn
- * currently being exported.
+ * Resolve `{ generationId, parent }` for the assistant turn currently being
+ * exported.
  *
  * Strategy:
  *  1. Read the active branch via `sessionManager.getBranch()`. Bail with an
@@ -78,11 +110,15 @@ export function stablePiGenerationId(
  * The first assistant turn on a branch produces no parent. When the branch
  * is unavailable (older runtimes) or no assistant entry can be found, the
  * helper returns `{}` so the SDK keeps its existing fallback behavior.
+ *
+ * On a forked session the parent may be an entry copied from the trunk. See
+ * `sessionOrigin.ts` for why such a parent gets no edge.
  */
 export function resolvePiGenerationLineage(
   sessionManager: SessionManagerLike | undefined | null,
   assistantMessage: unknown,
   conversationId: string | undefined,
+  options: ResolveLineageOptions = {},
 ): PiGenerationLineage {
   if (!conversationId) return {};
   if (!sessionManager || typeof sessionManager.getBranch !== "function") {
@@ -131,18 +167,24 @@ export function resolvePiGenerationLineage(
   // assistant turn; on branched trees it is the assistant turn at the
   // branch point, not the most recent chronological assistant entry from
   // a sibling branch.
-  const parentId = findParentAssistantEntryId(currentEntry, branch);
-  if (!parentId) return { generationId };
+  const parentEntry = findParentAssistantEntry(currentEntry, branch);
+  const parentId = parentEntry?.id;
+  if (!parentEntry || typeof parentId !== "string") return { generationId };
 
   return {
     generationId,
-    parentGenerationIds: [stablePiGenerationId(conversationId, parentId)],
+    parent: resolveParent(
+      parentEntry,
+      parentId,
+      conversationId,
+      options.origin,
+    ),
   };
 }
 
 /**
- * Resolve `{ generationId, parentGenerationIds }` for a host summarization
- * entry (`compaction` or `branch_summary`) identified by its entry id.
+ * Resolve `{ generationId, parent }` for a host summarization entry
+ * (`compaction` or `branch_summary`) identified by its entry id.
  *
  * Unlike {@link resolvePiGenerationLineage}, the subject is not a message, so
  * there is nothing to match by object identity: pi hands us the entry itself.
@@ -154,12 +196,14 @@ export function resolvePiGenerationLineage(
  * summary entry as a child of the current leaf, which is frequently a
  * `toolResult` message or a `model_change` entry rather than an assistant
  * message, so the walk goes through the parentId chain instead of assuming the
- * immediate parent.
+ * immediate parent. On a fork that parent can be an entry copied from the
+ * trunk, which gets no edge for the same reason a turn's does not.
  */
 export function resolvePiSummaryLineage(
   sessionManager: SessionManagerLike | undefined | null,
   entryId: string,
   conversationId: string | undefined,
+  options: ResolveLineageOptions = {},
 ): PiGenerationLineage {
   if (!conversationId || !entryId) return {};
 
@@ -180,25 +224,111 @@ export function resolvePiSummaryLineage(
   const entry = branch.find((e) => e.id === entryId);
   if (!entry) return { generationId };
 
-  const parentId = findParentAssistantEntryId(entry, branch);
-  if (!parentId) return { generationId };
+  const parentEntry = findParentAssistantEntry(entry, branch);
+  const parentId = parentEntry?.id;
+  if (!parentEntry || typeof parentId !== "string") return { generationId };
 
   return {
     generationId,
-    parentGenerationIds: [stablePiGenerationId(conversationId, parentId)],
+    parent: resolveParent(
+      parentEntry,
+      parentId,
+      conversationId,
+      options.origin,
+    ),
   };
 }
 
 /**
- * Walk the parentId chain from `entry` toward the root and return the id of
- * the nearest ancestor that is an assistant message entry. `branch` is used to
- * look up entries by id. Returns `undefined` for the first assistant turn on
- * the branch.
+ * Build the pointer to the parent turn's generation. `entry` is the assistant
+ * message entry that precedes the exported one, and `entryId` its id.
  */
-function findParentAssistantEntryId(
+function resolveParent(
+  entry: SessionEntryLike,
+  entryId: string,
+  conversationId: string,
+  origin: SessionOrigin | undefined,
+): PiGenerationParent {
+  switch (classifyParentEntry(entry, origin)) {
+    case "own":
+      return {
+        kind: "own",
+        generationIds: [stablePiGenerationId(conversationId, entryId)],
+      };
+    case "trunk":
+      return {
+        kind: "trunk",
+        trunkGenerationId: trunkGenerationIdFor(entry, entryId, origin),
+      };
+    default:
+      return { kind: "unknown" };
+  }
+}
+
+/**
+ * Decide which conversation the parent entry's generation belongs to.
+ *
+ * Outside a fork it is always this one: either this process exported the
+ * parent turn, or an earlier process did under the same conversation id (a
+ * `--session` continuation). The edge assumes that export succeeded; a turn
+ * whose export threw leaves the next turn pointing at a generation that was
+ * never ingested.
+ *
+ * Inside a fork the boundary is the header timestamp. A fork copies the
+ * trunk's entries with their timestamps and stamps its header at fork time,
+ * so every entry at or before that instant came from the trunk. Both
+ * timestamps come from the fork's own session file, so the check works in
+ * the process that forked and in any later one that resumes it.
+ */
+function classifyParentEntry(
+  entry: SessionEntryLike,
+  origin: SessionOrigin | undefined,
+): "own" | "trunk" | "unknown" {
+  if (!origin?.forked) return "own";
+  const forkedAt = parseTimestamp(origin.forkedAt);
+  const entryAt = parseTimestamp(entry.timestamp);
+  if (forkedAt === undefined || entryAt === undefined) return "unknown";
+  return entryAt <= forkedAt ? "trunk" : "own";
+}
+
+/**
+ * Generation id of the copied parent turn in the trunk conversation.
+ *
+ * Absent when the trunk cannot have exported that turn. A fork of a fork
+ * inherits entries the intermediate session copied in and never exported
+ * itself; those are stamped before the trunk's own start, so the trunk holds
+ * no generation for them and hashing one with the trunk's id would name
+ * nothing.
+ */
+function trunkGenerationIdFor(
+  entry: SessionEntryLike,
+  entryId: string,
+  origin: SessionOrigin | undefined,
+): string | undefined {
+  if (!origin?.trunkConversationId) return undefined;
+  const trunkStartedAt = parseTimestamp(origin.trunkStartedAt);
+  const entryAt = parseTimestamp(entry.timestamp);
+  if (trunkStartedAt === undefined || entryAt === undefined) return undefined;
+  if (entryAt <= trunkStartedAt) return undefined;
+  return stablePiGenerationId(origin.trunkConversationId, entryId);
+}
+
+function parseTimestamp(value: string | undefined): number | undefined {
+  if (typeof value !== "string") return undefined;
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
+/**
+ * Walk the parentId chain from `entry` toward the root and return the
+ * nearest ancestor that is an assistant message entry. Returns `undefined`
+ * for the first assistant turn on the branch. `branch` is used to look up
+ * entries by id.
+ */
+function findParentAssistantEntry(
   entry: SessionEntryLike,
   branch: SessionEntryLike[],
-): string | undefined {
+): SessionEntryLike | undefined {
   const byId = new Map<string, SessionEntryLike>();
   for (const e of branch) {
     if (typeof e.id === "string") byId.set(e.id, e);
@@ -210,7 +340,7 @@ function findParentAssistantEntryId(
     seen.add(cursor);
     const parent = byId.get(cursor);
     if (!parent) return undefined;
-    if (isAssistantMessageEntry(parent)) return cursor;
+    if (isAssistantMessageEntry(parent)) return parent;
     cursor = parent.parentId ?? null;
   }
   return undefined;

--- a/plugins/pi/src/mappers.test.ts
+++ b/plugins/pi/src/mappers.test.ts
@@ -266,6 +266,42 @@ describe("mapGenerationStart", () => {
     expect(start.metadata).toBeUndefined();
   });
 
+  it("passes caller metadata through", () => {
+    const start = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+      metadata: { "pi.fork.parent_session_id": "trunk-conv" },
+    });
+    expect(start.metadata).toEqual({
+      "pi.fork.parent_session_id": "trunk-conv",
+    });
+  });
+
+  it("merges caller metadata with the thinking budget instead of overwriting it", () => {
+    const start = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+      metadata: { "pi.fork.parent_session_id": "trunk-conv" },
+      requestControls: { thinkingBudgetTokens: 4096 },
+    });
+    expect(start.metadata).toEqual({
+      "pi.fork.parent_session_id": "trunk-conv",
+      "agento11y.gen_ai.request.thinking.budget_tokens": 4096,
+    });
+  });
+
+  it("omits metadata when the caller passes an empty bag", () => {
+    const start = mapGenerationStart(makeMsg(), {
+      conversationId: "s",
+      agentName: "pi",
+      startedAt: 0,
+      metadata: {},
+    });
+    expect(start.metadata).toBeUndefined();
+  });
+
   it("copies generationId to start.id when set", () => {
     const start = mapGenerationStart(makeMsg(), {
       conversationId: "s",
@@ -1582,6 +1618,20 @@ describe("mapSummaryGenerationStart", () => {
     });
     expect(start.id).toBeUndefined();
     expect(start.parentGenerationIds).toBeUndefined();
+  });
+
+  it("copies supplied metadata, e.g. a fork's trunk link", () => {
+    const metadata = { "pi.fork.parent_session_id": "trunk-conv" };
+    const start = mapSummaryGenerationStart({ ...baseOpts, metadata });
+    expect(start.metadata).toEqual(metadata);
+    expect(start.metadata).not.toBe(metadata);
+  });
+
+  it("omits metadata when none is supplied", () => {
+    expect(mapSummaryGenerationStart(baseOpts).metadata).toBeUndefined();
+    expect(
+      mapSummaryGenerationStart({ ...baseOpts, metadata: {} }).metadata,
+    ).toBeUndefined();
   });
 });
 

--- a/plugins/pi/src/mappers.ts
+++ b/plugins/pi/src/mappers.ts
@@ -202,6 +202,11 @@ export interface MapGenerationStartOptions {
    * previous assistant turn on the same branch.
    */
   parentGenerationIds?: string[];
+  /**
+   * Extra generation metadata. Merged with the metadata this mapper derives
+   * from `requestControls`; derived keys win on collision.
+   */
+  metadata?: Record<string, unknown>;
 }
 
 /** Build the GenerationStart seed from an assistant message and context. */
@@ -221,6 +226,7 @@ export function mapGenerationStart(
     requestControls,
     generationId,
     parentGenerationIds,
+    metadata,
   } = opts;
   // Tags on the seed override client-level SIGIL_TAGS (the SDK merges
   // `{...clientTags, ...seedTags}`), matching claude-code/cursor.
@@ -247,6 +253,7 @@ export function mapGenerationStart(
   if (systemPrompt && systemPrompt.length > 0) {
     start.systemPrompt = systemPrompt;
   }
+  const startMetadata: Record<string, unknown> = { ...metadata };
   if (requestControls) {
     if (typeof requestControls.maxTokens === "number") {
       start.maxTokens = requestControls.maxTokens;
@@ -263,11 +270,12 @@ export function mapGenerationStart(
     if (typeof requestControls.thinkingBudgetTokens === "number") {
       // The SDK reads `agento11y.gen_ai.request.thinking.budget_tokens` from
       // generation metadata and surfaces it as the matching span attribute.
-      start.metadata = {
-        "agento11y.gen_ai.request.thinking.budget_tokens":
-          requestControls.thinkingBudgetTokens,
-      };
+      startMetadata["agento11y.gen_ai.request.thinking.budget_tokens"] =
+        requestControls.thinkingBudgetTokens;
     }
+  }
+  if (Object.keys(startMetadata).length > 0) {
+    start.metadata = startMetadata;
   }
   return start;
 }
@@ -408,6 +416,8 @@ export interface MapSummaryGenerationStartOptions {
   tags?: Record<string, string>;
   generationId?: string;
   parentGenerationIds?: string[];
+  /** Extra generation metadata, e.g. the fork's trunk link. */
+  metadata?: Record<string, unknown>;
 }
 
 /**
@@ -437,6 +447,9 @@ export function mapSummaryGenerationStart(
   }
   if (opts.parentGenerationIds && opts.parentGenerationIds.length > 0) {
     start.parentGenerationIds = opts.parentGenerationIds;
+  }
+  if (opts.metadata && Object.keys(opts.metadata).length > 0) {
+    start.metadata = { ...opts.metadata };
   }
   return start;
 }

--- a/plugins/pi/src/sessionOrigin.test.ts
+++ b/plugins/pi/src/sessionOrigin.test.ts
@@ -1,0 +1,469 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("./logger.js", () => ({ logger: loggerMock }));
+
+import {
+  resolveSessionOrigin,
+  resolveSessionStart,
+  type SessionOrigin,
+} from "./sessionOrigin.js";
+
+const TRUNK_ID = "0199aaaa-1111-7000-8000-aaaaaaaaaaaa";
+const FORK_ID = "0199bbbb-2222-7000-8000-bbbbbbbbbbbb";
+const TRUNK_STARTED_AT = "2020-01-01T00:00:00.000Z";
+const FORKED_AT = "2020-01-01T00:01:00.000Z";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "pi-session-origin-"));
+  loggerMock.debug.mockClear();
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** Write a session file: header line followed by a couple of entries. */
+function writeSession(
+  name: string,
+  header: Record<string, unknown>,
+  entries: Record<string, unknown>[] = [],
+): string {
+  const path = join(dir, name);
+  const lines = [header, ...entries].map((o) => JSON.stringify(o));
+  writeFileSync(path, `${lines.join("\n")}\n`);
+  return path;
+}
+
+function trunkHeader(): Record<string, unknown> {
+  return {
+    type: "session",
+    version: 3,
+    id: TRUNK_ID,
+    timestamp: TRUNK_STARTED_AT,
+    cwd: "/fixture/worktree",
+  };
+}
+
+/** A fork header: the trunk's shape plus a new id, time and parentSession. */
+function forkHeader(
+  parentSession: string,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    ...trunkHeader(),
+    id: FORK_ID,
+    timestamp: FORKED_AT,
+    parentSession,
+    ...overrides,
+  };
+}
+
+function messageEntry(id: string, parentId: string | null) {
+  return {
+    type: "message",
+    id,
+    parentId,
+    timestamp: "2020-01-01T00:00:01.000Z",
+    message: { role: "assistant" },
+  };
+}
+
+/**
+ * A session manager double that only knows its file, which is the fallback
+ * path in `resolveSessionOrigin`: `getHeader` is absent, so the header comes
+ * off disk.
+ */
+function fileOnlyManager(sessionFile: string | undefined) {
+  return { getSessionFile: () => sessionFile };
+}
+
+describe("resolveSessionOrigin", () => {
+  it("resolves the trunk conversation id and start time from a forked header", () => {
+    const trunk = writeSession("trunk.jsonl", trunkHeader(), [
+      messageEntry("e1", null),
+    ]);
+    const fork = writeSession(
+      "fork.jsonl",
+      forkHeader(trunk),
+      // A fork copies the trunk's entries keeping their ids.
+      [messageEntry("e1", null)],
+    );
+
+    expect(resolveSessionOrigin(fileOnlyManager(fork))).toEqual<SessionOrigin>({
+      forked: true,
+      forkedAt: FORKED_AT,
+      trunkConversationId: TRUNK_ID,
+      trunkStartedAt: TRUNK_STARTED_AT,
+    });
+  });
+
+  it("resolves a relative parentSession against the cwd in the header", () => {
+    // `pi --fork ../elsewhere/sess.jsonl` stores the path as typed, so a
+    // process running elsewhere must not resolve it against its own cwd.
+    const trunk = writeSession("trunk.jsonl", trunkHeader());
+    const fork = writeSession(
+      "fork.jsonl",
+      forkHeader(basename(trunk), { cwd: dir }),
+    );
+
+    expect(resolveSessionOrigin(fileOnlyManager(fork))).toEqual<SessionOrigin>({
+      forked: true,
+      forkedAt: FORKED_AT,
+      trunkConversationId: TRUNK_ID,
+      trunkStartedAt: TRUNK_STARTED_AT,
+    });
+  });
+
+  it("prefers getHeader over reading the session file", () => {
+    const trunk = writeSession("trunk.jsonl", trunkHeader());
+    const getSessionFile = vi.fn(() => join(dir, "never-read.jsonl"));
+
+    const origin = resolveSessionOrigin({
+      getHeader: () => ({
+        type: "session",
+        id: FORK_ID,
+        timestamp: FORKED_AT,
+        parentSession: trunk,
+      }),
+      getSessionFile,
+    });
+
+    expect(origin).toEqual<SessionOrigin>({
+      forked: true,
+      forkedAt: FORKED_AT,
+      trunkConversationId: TRUNK_ID,
+      trunkStartedAt: TRUNK_STARTED_AT,
+    });
+    expect(getSessionFile).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "getHeader is absent", getHeader: undefined },
+    { name: "getHeader returns null", getHeader: () => null },
+  ])("falls back to the session file when $name", ({ getHeader }) => {
+    const trunk = writeSession("trunk.jsonl", trunkHeader());
+    const fork = writeSession("fork.jsonl", forkHeader(trunk));
+
+    expect(
+      resolveSessionOrigin({ getHeader, getSessionFile: () => fork }),
+    ).toEqual<SessionOrigin>({
+      forked: true,
+      forkedAt: FORKED_AT,
+      trunkConversationId: TRUNK_ID,
+      trunkStartedAt: TRUNK_STARTED_AT,
+    });
+  });
+
+  it.each([
+    {
+      name: "a header without parentSession",
+      sm: () => fileOnlyManager(writeSession("plain.jsonl", trunkHeader())),
+    },
+    {
+      name: "a header with an empty parentSession",
+      sm: () =>
+        fileOnlyManager(
+          writeSession("empty-parent.jsonl", {
+            ...trunkHeader(),
+            parentSession: "",
+          }),
+        ),
+    },
+    {
+      name: "a missing file",
+      sm: () => fileOnlyManager(join(dir, "does-not-exist.jsonl")),
+    },
+    {
+      name: "an empty file",
+      sm: () => {
+        const path = join(dir, "empty.jsonl");
+        writeFileSync(path, "");
+        return fileOnlyManager(path);
+      },
+    },
+    {
+      name: "a first line that is not JSON",
+      sm: () => {
+        const path = join(dir, "garbage.jsonl");
+        writeFileSync(path, "not json at all\n");
+        return fileOnlyManager(path);
+      },
+    },
+    {
+      name: "a first line that is an entry, not a header",
+      sm: () => {
+        const path = join(dir, "headerless.jsonl");
+        writeFileSync(path, `${JSON.stringify(messageEntry("e1", null))}\n`);
+        return fileOnlyManager(path);
+      },
+    },
+    {
+      name: "a header line longer than the bounded read",
+      sm: () =>
+        fileOnlyManager(
+          writeSession(
+            "huge.jsonl",
+            forkHeader(join(dir, "trunk.jsonl"), {
+              padding: "x".repeat(70 * 1024),
+            }),
+          ),
+        ),
+    },
+    { name: "an empty path", sm: () => fileOnlyManager("") },
+    { name: "a directory, not a file", sm: () => fileOnlyManager(dir) },
+    { name: "no session manager", sm: () => undefined },
+    { name: "a null session manager", sm: () => null },
+    { name: "a session manager with neither method", sm: () => ({}) },
+    {
+      name: "getHeader reporting a non-forked session",
+      sm: () => ({ getHeader: () => ({ type: "session", id: TRUNK_ID }) }),
+    },
+    {
+      name: "a getSessionFile that points at a missing file",
+      sm: () => fileOnlyManager("pi-session.jsonl"),
+    },
+    {
+      name: "a getSessionFile returning undefined (in-memory session)",
+      sm: () => fileOnlyManager(undefined),
+    },
+  ])("returns not-forked for $name", ({ sm }) => {
+    expect(resolveSessionOrigin(sm())).toEqual<SessionOrigin>({
+      forked: false,
+    });
+  });
+
+  it("logs when no header can be read at all", () => {
+    // The one degradation that puts a fork back on a dangling parent id, so
+    // it must not be silent.
+    expect(
+      resolveSessionOrigin(fileOnlyManager(join(dir, "gone.jsonl"))),
+    ).toEqual<SessionOrigin>({ forked: false });
+    expect(loggerMock.debug).toHaveBeenCalledWith(
+      expect.stringContaining("no session header available"),
+    );
+  });
+
+  it.each([
+    {
+      name: "the trunk file is gone",
+      trunk: () => join(dir, "deleted-trunk.jsonl"),
+    },
+    {
+      name: "the trunk file is empty",
+      trunk: () => {
+        const path = join(dir, "empty-trunk.jsonl");
+        writeFileSync(path, "");
+        return path;
+      },
+    },
+    {
+      name: "the trunk's first line is an entry, not a header",
+      trunk: () => {
+        const path = join(dir, "headerless-trunk.jsonl");
+        writeFileSync(path, `${JSON.stringify(messageEntry("e1", null))}\n`);
+        return path;
+      },
+    },
+    {
+      name: "the trunk header has no id",
+      trunk: () =>
+        writeSession("idless-trunk.jsonl", {
+          type: "session",
+          version: 3,
+          cwd: "/fixture/worktree",
+        }),
+    },
+  ])("reports forked without a trunk id, and logs, when $name", ({ trunk }) => {
+    const fork = writeSession("fork.jsonl", forkHeader(trunk()));
+
+    expect(resolveSessionOrigin(fileOnlyManager(fork))).toEqual<SessionOrigin>({
+      forked: true,
+      forkedAt: FORKED_AT,
+    });
+    expect(loggerMock.debug).toHaveBeenCalledWith(
+      expect.stringContaining("no readable conversation id in trunk"),
+    );
+  });
+
+  it("reports forked without a trunk start time when the trunk header has no timestamp", () => {
+    const header = trunkHeader();
+    delete header.timestamp;
+    const trunk = writeSession("trunk.jsonl", header);
+    const fork = writeSession("fork.jsonl", forkHeader(trunk));
+
+    expect(resolveSessionOrigin(fileOnlyManager(fork))).toEqual<SessionOrigin>({
+      forked: true,
+      forkedAt: FORKED_AT,
+      trunkConversationId: TRUNK_ID,
+    });
+  });
+
+  it("reports forked without a fork time when the header has no timestamp", () => {
+    const trunk = writeSession("trunk.jsonl", trunkHeader());
+    const header = forkHeader(trunk);
+    delete header.timestamp;
+    const fork = writeSession("fork.jsonl", header);
+
+    expect(resolveSessionOrigin(fileOnlyManager(fork))).toEqual<SessionOrigin>({
+      forked: true,
+      trunkConversationId: TRUNK_ID,
+      trunkStartedAt: TRUNK_STARTED_AT,
+    });
+    expect(loggerMock.debug).toHaveBeenCalledWith(
+      expect.stringContaining("fork header has no timestamp"),
+    );
+  });
+
+  it("reads a header file that has no trailing newline", () => {
+    const trunk = join(dir, "no-newline-trunk.jsonl");
+    writeFileSync(trunk, JSON.stringify(trunkHeader()));
+    const fork = writeSession("fork.jsonl", forkHeader(trunk));
+
+    expect(resolveSessionOrigin(fileOnlyManager(fork))).toEqual<SessionOrigin>({
+      forked: true,
+      forkedAt: FORKED_AT,
+      trunkConversationId: TRUNK_ID,
+      trunkStartedAt: TRUNK_STARTED_AT,
+    });
+  });
+
+  it.each([
+    {
+      name: "getHeader",
+      sm: {
+        getHeader: () => {
+          throw new Error("session gone");
+        },
+      },
+    },
+    {
+      name: "getSessionFile",
+      sm: {
+        getSessionFile: () => {
+          throw new Error("session gone");
+        },
+      },
+    },
+  ])("returns not-forked when $name throws", ({ sm }) => {
+    expect(resolveSessionOrigin(sm)).toEqual<SessionOrigin>({ forked: false });
+    expect(loggerMock.debug).toHaveBeenCalled();
+  });
+});
+
+describe("resolveSessionStart", () => {
+  const trunkRecord = { id: TRUNK_ID, startedAt: TRUNK_STARTED_AT };
+  const now = new Date("2021-09-09T09:09:09.000Z");
+
+  it("reports when a fresh session began, and that it is not a fork", () => {
+    const session = writeSession("plain.jsonl", trunkHeader());
+
+    expect(
+      resolveSessionStart(fileOnlyManager(session), { forked: false }),
+    ).toEqual({
+      startedAt: TRUNK_STARTED_AT,
+      origin: { forked: false },
+    });
+  });
+
+  it("takes the header's answer for a persisted fork", () => {
+    const trunk = writeSession("trunk.jsonl", trunkHeader());
+    const fork = writeSession("fork.jsonl", forkHeader(trunk));
+
+    expect(
+      resolveSessionStart(fileOnlyManager(fork), {
+        forked: true,
+        trunk: {
+          id: "another-conversation",
+          startedAt: "2020-06-01T00:00:00.000Z",
+        },
+        now,
+      }),
+    ).toEqual({
+      startedAt: FORKED_AT,
+      origin: {
+        forked: true,
+        forkedAt: FORKED_AT,
+        trunkConversationId: TRUNK_ID,
+        trunkStartedAt: TRUNK_STARTED_AT,
+      },
+    });
+  });
+
+  it("reports a fork from the header even when pi calls the start something else", () => {
+    // `--session <fork file>` resumes a fork: the header still names the
+    // trunk, and the copied entries still belong to it.
+    const trunk = writeSession("trunk.jsonl", trunkHeader());
+    const fork = writeSession("fork.jsonl", forkHeader(trunk));
+
+    expect(
+      resolveSessionStart(fileOnlyManager(fork), { forked: false }).origin,
+    ).toEqual<SessionOrigin>({
+      forked: true,
+      forkedAt: FORKED_AT,
+      trunkConversationId: TRUNK_ID,
+      trunkStartedAt: TRUNK_STARTED_AT,
+    });
+  });
+
+  it("falls back to the in-process record when the header cannot say", () => {
+    // `--no-session`: createBranchedSession writes no parentSession, so the
+    // header of an in-memory fork looks like a fresh session. Its timestamp
+    // is still the fork instant.
+    const facts = resolveSessionStart(
+      {
+        getHeader: () => ({
+          type: "session",
+          id: FORK_ID,
+          timestamp: FORKED_AT,
+        }),
+      },
+      { forked: true, trunk: trunkRecord, now },
+    );
+
+    expect(facts).toEqual({
+      startedAt: FORKED_AT,
+      origin: {
+        forked: true,
+        forkedAt: FORKED_AT,
+        trunkConversationId: TRUNK_ID,
+        trunkStartedAt: TRUNK_STARTED_AT,
+      },
+    });
+  });
+
+  it("stamps the fork instant itself when the header carries no timestamp", () => {
+    const facts = resolveSessionStart(
+      { getHeader: () => ({ type: "session", id: FORK_ID }) },
+      { forked: true, trunk: trunkRecord, now },
+    );
+
+    expect(facts).toEqual({
+      startedAt: undefined,
+      origin: {
+        forked: true,
+        forkedAt: now.toISOString(),
+        trunkConversationId: TRUNK_ID,
+        trunkStartedAt: TRUNK_STARTED_AT,
+      },
+    });
+  });
+
+  it("still reports a fork when the trunk conversation is unknown", () => {
+    // No trunk to name, but the copied entries must still lose their edge.
+    expect(
+      resolveSessionStart(undefined, { forked: true, now }).origin,
+    ).toEqual<SessionOrigin>({
+      forked: true,
+      forkedAt: now.toISOString(),
+    });
+  });
+});

--- a/plugins/pi/src/sessionOrigin.ts
+++ b/plugins/pi/src/sessionOrigin.ts
@@ -1,0 +1,324 @@
+/**
+ * Where the current pi session came from: a fresh start, a resume, or a
+ * fork.
+ *
+ * `pi --fork`, the in-TUI `/fork` and `/clone` write a new session file
+ * whose header carries `parentSession`, the path of the session the entries
+ * came from, and a `timestamp` stamped at fork time
+ * (`SessionManager.forkFrom`, `SessionManager.createBranchedSession`,
+ * `SessionManager.newSession`). A session started fresh has no
+ * `parentSession`. A resume keeps whatever the header already had, so a
+ * resumed fork still reports one.
+ *
+ * Lineage needs both fields. A fork copies the trunk's entries keeping
+ * their ids and timestamps. The trunk already exported those entries as
+ * `stablePiGenerationId(trunkId, entryId)`, so hashing one with the fork's
+ * conversation id points at a generation that exists nowhere. The header
+ * timestamp separates the copied entries from the fork's own. Both values
+ * live in the fork's own file, so they hold after the fork is resumed in
+ * another process.
+ *
+ * An unpersisted fork writes no `parentSession` at all. `resolveSessionStart`
+ * covers that case from what this process has already seen.
+ */
+import { closeSync, openSync, readSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+import { isMissingFileError } from "./fsErrors.js";
+import { logger } from "./logger.js";
+
+/** Origin of a pi session. */
+export interface SessionOrigin {
+  /** True when the session was created by `--fork`, `/fork` or `/clone`. */
+  readonly forked: boolean;
+  /**
+   * ISO-8601 header timestamp of the fork. Entries stamped at or before it
+   * were copied from the trunk. Absent when the session is not a fork, or
+   * when its header carries no timestamp.
+   */
+  readonly forkedAt?: string;
+  /**
+   * Conversation id of the session this one was forked from. Absent when
+   * the session is not a fork, or when the trunk file could not be read.
+   */
+  readonly trunkConversationId?: string;
+  /**
+   * ISO-8601 time the trunk conversation began: its own header timestamp.
+   * A parent entry stamped at or before it was inherited by the trunk from
+   * an older session rather than created in it, so the trunk exported no
+   * generation for it. Absent when the trunk file could not be read.
+   */
+  readonly trunkStartedAt?: string;
+}
+
+/** A conversation this process has been attributing turns to. */
+export interface ConversationRecord {
+  readonly id: string;
+  /** ISO-8601 time the conversation began: its session header timestamp. */
+  readonly startedAt: string;
+}
+
+/**
+ * Shared answer for a session that is not a fork. Frozen: callers cache it
+ * and pass it around by reference.
+ */
+export const NOT_FORKED: SessionOrigin = Object.freeze({ forked: false });
+
+/**
+ * Subset of the pi session manager used to locate the session header. Both
+ * methods are part of `ReadonlySessionManager` in pi-coding-agent, and both
+ * follow a mid-process fork: the runtime reads `ctx.sessionManager` per
+ * event, and the fork either replaces the manager or rewrites its header in
+ * place.
+ */
+export interface SessionHeaderSourceLike {
+  getHeader?: () => SessionHeaderLike | null | undefined;
+  getSessionFile?: () => string | undefined;
+}
+
+/** Minimal `SessionHeader` shape: just the fields we read. */
+export interface SessionHeaderLike {
+  type?: string;
+  id?: string;
+  timestamp?: string;
+  parentSession?: string;
+  /** Working directory pi recorded for the session. */
+  cwd?: string;
+}
+
+/**
+ * Only the first line of a session file is needed. Session files grow to
+ * tens of megabytes on long conversations, so read a bounded prefix rather
+ * than the whole file. 64 KiB is far more than a header needs and still one
+ * cheap syscall.
+ */
+const HEADER_READ_BYTES = 64 * 1024;
+
+/**
+ * Resolve the origin of the session `sessionManager` currently points at.
+ *
+ * Any failure degrades to `NOT_FORKED`. The opposite default would suppress
+ * parent edges on every `--session` continuation, which is far more common
+ * than a fork.
+ */
+export function resolveSessionOrigin(
+  sessionManager: SessionHeaderSourceLike | undefined | null,
+): SessionOrigin {
+  return originFromHeader(resolveSessionHeader(sessionManager));
+}
+
+/** What the `session_start` handler learns from the new session's header. */
+export interface SessionStartFacts {
+  /**
+   * ISO-8601 time this conversation began. Absent when no header is
+   * available or it carries no timestamp.
+   */
+  readonly startedAt?: string;
+  /** Where the session came from. */
+  readonly origin: SessionOrigin;
+}
+
+/**
+ * Read the new session's header once and report both facts the
+ * `session_start` handler needs: when the conversation began, and where it
+ * came from.
+ *
+ * Pass `forked` from pi's own `session_start` reason. A persisted fork names
+ * the trunk in its header and needs no help, but a `--no-session` fork does:
+ * `createBranchedSession` writes `parentSession` only when the session
+ * manager persists (`session-manager.js`), while the conversation id changes
+ * either way. In that mode `trunk`, the conversation this process was
+ * attributing turns to before the fork, is the only record of where the
+ * copied entries came from. An in-memory session cannot be resumed in
+ * another process, so the in-process record is complete for it.
+ */
+export function resolveSessionStart(
+  sessionManager: SessionHeaderSourceLike | undefined | null,
+  options: {
+    forked: boolean;
+    trunk?: ConversationRecord;
+    now?: Date;
+  },
+): SessionStartFacts {
+  const header = resolveSessionHeader(sessionManager);
+  const startedAt = nonEmptyString(header?.timestamp);
+  const fromHeader = originFromHeader(header);
+  if (fromHeader.forked || !options.forked) {
+    return { startedAt, origin: fromHeader };
+  }
+  return {
+    startedAt,
+    origin: {
+      forked: true,
+      // The header of an in-memory fork still carries the fork instant, the
+      // same value the persisted path reads.
+      forkedAt: startedAt ?? (options.now ?? new Date()).toISOString(),
+      trunkConversationId: options.trunk?.id,
+      trunkStartedAt: options.trunk?.startedAt,
+    },
+  };
+}
+
+/**
+ * Header of the session `sessionManager` currently points at.
+ *
+ * Prefers `getHeader()`, which returns the in-memory header and needs no
+ * file access. Falls back to a bounded read of `getSessionFile()` for
+ * runtimes (or test doubles) that do not expose `getHeader`.
+ */
+function resolveSessionHeader(
+  sessionManager: SessionHeaderSourceLike | undefined | null,
+): SessionHeaderLike | undefined {
+  if (!sessionManager) return undefined;
+
+  const header =
+    callGetHeader(sessionManager) ??
+    readSessionHeader(callGetSessionFile(sessionManager));
+  if (!header) {
+    // The costly degradation: with no header, a real fork looks like a
+    // resume, and its first turn goes back to naming a parent generation
+    // nothing exported. Logged here, where "no header at all" is still
+    // distinguishable from "a header that says this is not a fork".
+    logger.debug("no session header available, treating session as not forked");
+  }
+  return header;
+}
+
+function originFromHeader(
+  header: SessionHeaderLike | undefined,
+): SessionOrigin {
+  const parentSession = nonEmptyString(header?.parentSession);
+  if (!parentSession) return NOT_FORKED;
+
+  const forkedAt = nonEmptyString(header?.timestamp);
+  if (!forkedAt) {
+    logger.debug(
+      `fork header has no timestamp, parent edges stay suppressed (parentSession=${parentSession})`,
+    );
+  }
+  const trunkPath = trunkSessionPath(parentSession, header?.cwd);
+  // The trunk file's own header holds its authoritative conversation id and
+  // start time, so we never parse either out of the file name.
+  const trunkHeader = readSessionHeader(trunkPath);
+  const trunkConversationId = nonEmptyString(trunkHeader?.id);
+  if (!trunkConversationId) {
+    logger.debug(`no readable conversation id in trunk ${trunkPath}`);
+  }
+  return {
+    forked: true,
+    forkedAt,
+    trunkConversationId,
+    trunkStartedAt: nonEmptyString(trunkHeader?.timestamp),
+  };
+}
+
+/**
+ * Absolute path of the trunk session file.
+ *
+ * `pi --fork ../elsewhere/sess.jsonl` stores the path as typed
+ * (`resolveSessionPath` in pi's `main.js` returns a path argument
+ * unchanged), so a relative `parentSession` is relative to the cwd the
+ * header records, not to the cwd of whichever process reads it later.
+ */
+function trunkSessionPath(
+  parentSession: string,
+  headerCwd: string | undefined,
+): string {
+  if (isAbsolute(parentSession)) return parentSession;
+  const cwd = nonEmptyString(headerCwd);
+  return cwd ? resolve(cwd, parentSession) : parentSession;
+}
+
+function callGetHeader(
+  sessionManager: SessionHeaderSourceLike,
+): SessionHeaderLike | undefined {
+  if (typeof sessionManager.getHeader !== "function") return undefined;
+  try {
+    const header = sessionManager.getHeader();
+    return isSessionHeader(header) ? header : undefined;
+  } catch (err) {
+    logger.debug("getHeader failed", err);
+    return undefined;
+  }
+}
+
+function callGetSessionFile(
+  sessionManager: SessionHeaderSourceLike,
+): string | undefined {
+  if (typeof sessionManager.getSessionFile !== "function") return undefined;
+  try {
+    return sessionManager.getSessionFile();
+  } catch (err) {
+    logger.debug("getSessionFile failed", err);
+    return undefined;
+  }
+}
+
+/**
+ * Parse the first line of `sessionFile` as a pi session header. Returns
+ * `undefined` when the file is missing, the first line is not JSON, or the
+ * parsed object is not a session header.
+ */
+function readSessionHeader(
+  sessionFile: string | undefined,
+): SessionHeaderLike | undefined {
+  if (typeof sessionFile !== "string" || sessionFile.length === 0) {
+    return undefined;
+  }
+
+  const line = readFirstLine(sessionFile);
+  if (line === undefined) return undefined;
+
+  try {
+    const parsed: unknown = JSON.parse(line);
+    return isSessionHeader(parsed) ? parsed : undefined;
+  } catch (err) {
+    logger.debug(`session header of ${sessionFile} is not JSON`, err);
+    return undefined;
+  }
+}
+
+function readFirstLine(path: string): string | undefined {
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, "r");
+    const buffer = Buffer.allocUnsafe(HEADER_READ_BYTES);
+    const bytesRead = readSync(fd, buffer, 0, HEADER_READ_BYTES, 0);
+    if (bytesRead === 0) return undefined;
+
+    const chunk = buffer.subarray(0, bytesRead);
+    const newline = chunk.indexOf(0x0a);
+    if (newline >= 0) return chunk.subarray(0, newline).toString("utf-8");
+    // No newline in the prefix. A file shorter than the buffer is a
+    // complete single line; a longer one has a header we refuse to read.
+    if (bytesRead < HEADER_READ_BYTES) return chunk.toString("utf-8");
+    logger.debug(
+      `session header of ${path} exceeds ${HEADER_READ_BYTES} bytes`,
+    );
+    return undefined;
+  } catch (err) {
+    if (!isMissingFileError(err)) {
+      logger.debug(`failed to read session header of ${path}`, err);
+    }
+    return undefined;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        // Nothing useful to do if the descriptor is already gone.
+      }
+    }
+  }
+}
+
+function isSessionHeader(value: unknown): value is SessionHeaderLike {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { type?: unknown }).type === "session"
+  );
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}


### PR DESCRIPTION
A generation id is sha256(conversation id + entry id). A fork copies the trunk's entries but gets a new conversation id, so a copied parent entry hashed to an id the backend never received. The forked conversation had no root and one orphaned generation.

The plugin now reads the fork and trunk headers to tell where a parent turn came from.