### PR TITLE
feat(sdk/js): add experiments with cloud evaluation support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,11 @@ jobs:
       - name: Hook conformance
         run: mise run test:sdk:hooks-conformance
 
+      # The experiment ingest routes have no generated stubs either, so
+      # conformance/experiments/ is their only cross-language contract.
+      - name: Experiment conformance
+        run: mise run test:sdk:experiments-conformance
+
   go-module:
     name: Go module
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ If you change shared-binary behavior, the four glue plugins all see it. The Open
 ## Cross-language conventions
 
 - Use `cache_write_input_tokens`, not `cache_creation_input_tokens`. This was renamed in cbe0363; pretrained models tend to suggest the old name, so don't follow them.
-- Conformance suites cross-check the SDKs. `mise run test:sdk:conformance` runs core, provider-wrapper, and framework-adapter conformance across Go/Python/JS/Java/.NET. If you change behavior in one SDK, expect to update fixtures or matching code in the others.
+- Conformance suites cross-check the SDKs. `mise run test:sdk:conformance` runs core, provider-wrapper, framework-adapter, hook, and experiment conformance across Go/Python/JS/Java/.NET. If you change behavior in one SDK, expect to update fixtures or matching code in the others.
 - Python has one package per framework (`agento11y-langgraph`, `agento11y-openai`, …). JS has one package with subpath exports (`@grafana/agento11y/langgraph`). Don't reflexively assume one layout for the other.
 - Python version bumps go through `mise run sdk:py:bump <VERSION>`. It updates all 13 `pyproject.toml` files and their internal `agento11y>=…` pins atomically. Hand-editing one file leaves the other twelve inconsistent.
 
@@ -55,9 +55,9 @@ If you change shared-binary behavior, the four glue plugins all see it. The Open
 
 [`llms.txt`](llms.txt) is what this repo ships. There is a second copy of the same prompt rendered by the Agent Observability onboarding wizard (a separate Grafana product). When you change user-facing semantics here (new SDK field, renamed env var, new framework adapter), the wizard copy needs the same change. If you're only fixing this repo's internals, the wizard copy doesn't move.
 
-## Hook wire fixtures are checked by hand
+## Hook and experiment wire fixtures are checked by hand
 
-`conformance/hooks/` pins the `POST /api/v1/hooks:evaluate` body and responses. That endpoint has no generated stubs, so the fixtures are the contract, and the SDK suites check themselves against the fixtures rather than against the server. If you change a fixture, run the new shape through the server's hook decoder yourself first. `conformance/hooks/README.md` documents the encodings, which the proto does not describe.
+`conformance/hooks/` pins the `POST /api/v1/hooks:evaluate` body and responses, and `conformance/experiments/` pins the experiment ingest bodies and responses. Neither endpoint group has generated stubs, so the fixtures are the contract, and the SDK suites check themselves against the fixtures rather than against the server. If you change a fixture, run the new shape through the server's decoder yourself first. Each directory's `README.md` documents the encodings, which the proto does not describe.
 
 ## Running checks
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The experiments are offline evals: run an agent over a dataset, grade it, and pu
 | Python | [`examples/experiments/python/`](examples/experiments/python/) |
 | Go | [`examples/experiments/go/`](examples/experiments/go/) |
 | Go (evaluator stored in your tenant) | [`examples/experiments/go/cloud-evaluator/`](examples/experiments/go/cloud-evaluator/) |
+| TypeScript (evaluator stored in your tenant) | [`examples/experiments/typescript/`](examples/experiments/typescript/) |
 
 The reference app is a fuller FastAPI service with framework callbacks and manual instrumentation side by side.
 

--- a/conformance/experiments/README.md
+++ b/conformance/experiments/README.md
@@ -1,0 +1,79 @@
+# Experiment wire fixtures
+
+The experiment ingest routes have no generated stubs, so these files are the only
+cross-language contract for their shape. Go, Python, and JavaScript each check
+themselves against them:
+
+| Suite | File |
+|-------|------|
+| Go | `go/agento11y/experiments/conformance_test.go` |
+| Python | `python/tests/test_experiments_conformance.py` |
+| JavaScript | `js/test/experiments.conformance.test.mjs` |
+
+`mise run test:sdk:experiments-conformance` runs all three, and
+`mise run test:sdk:conformance` includes it.
+
+| File | Contents |
+|------|----------|
+| `inputs.json` | The pinned inputs every suite feeds in: run, case, attempt, evaluator, conversation, and score identity. |
+| `ids.json` | `stable_id` vectors. A drift here breaks retry idempotency and cross-process trial handoff. |
+| `requests.json` | The method, encoded path, and JSON body each lifecycle call must produce. |
+| `responses.json` | Canned server responses every SDK must parse into the same logical result, including the two report envelopes and the two responses that must fail. |
+
+## The SDK id is the one field that differs
+
+`requests.json` writes `"id": "${SDK_ID}"` inside every `source` object. Each suite
+substitutes its own value before comparing: `go`, `python`, or `js`. Everything
+else in a body is identical across the three SDKs.
+
+Two things are deliberately not pinned here:
+
+- The ingest actor header. Python and JavaScript send `X-Agento11y-Ingest-Actor`;
+  Go still sends the pre-rename `X-Sigil-Ingest-Actor` (grafana/agento11y#469
+  renamed the others).
+- Fractional seconds on `created_at`. Go formats RFC3339Nano, Python uses
+  `datetime.isoformat`, and JavaScript uses `toISOString` with an all-zero fraction
+  removed. The three agree only on whole seconds, which is why `inputs.json` pins
+  `2026-01-01T00:00:00Z`.
+
+## Encodings the proto does not describe
+
+Every dynamic path segment is percent-encoded with no safe characters. Go's
+`url.PathEscape` leaves `:` alone, so it escapes the colon separately; Python uses
+`quote(..., safe="")`; JavaScript uses `encodeURIComponent`. The reason is in
+`trial_evaluate_reserved_trial_id`: the ingest router reads the trailing
+`:evaluate` verb off the raw path segment before it decodes the trial id, so an
+unescaped colon inside an id would change which route the request reaches.
+
+The run key is `experiment_id` on the wire. Go and Python expose it as `run_id` on
+their types, JavaScript as `runId`, but the ingest route keys on `experiment_id`
+and rejects unknown fields, so the rename happens at serialization.
+
+Blank optional fields are omitted, not sent empty. `trial_create` carries only the
+four fields the route requires. `trial_evaluate_latest_version` shows the same
+call without `evaluator_version`, which is how a caller asks for the latest active
+version.
+
+`evaluator_kind` is not part of the score body. It exists on the score object in
+all three SDKs and feeds the OpenTelemetry evaluation event, but no SDK sends it.
+`scores_export` is the contract.
+
+A score value is a one-of: `{"number": n}`, `{"bool": b}`, or `{"string": s}`;
+never two, never zero. `value.bool` is the key, not `value.boolean`.
+
+An unknown evaluation status is a hard error. `evaluation_unsupported_status` and
+`evaluation_missing_id` both have to fail the call. If an SDK read a newer terminal
+state as non-terminal, it would poll until the caller's deadline, and a missing id
+would turn the next status read into a validation error blaming the caller's
+arguments.
+
+Both report envelopes are accepted. The backend keys the run under `experiment`;
+older drafts used `run`. `report_experiment_envelope` and
+`report_run_envelope` must parse into equal report objects.
+
+## Changing a fixture
+
+Run the new shape through the server's request decoder before committing it. These
+files are the contract, and the suites check themselves against the files rather
+than against a running server, so an invented shape passes all three suites and
+fails only in production.

--- a/conformance/experiments/ids.json
+++ b/conformance/experiments/ids.json
@@ -1,0 +1,45 @@
+{
+  "comment": "stable_id vectors: SHA-1 over the parts joined with \\x1f, lowercase hex truncated to 16 characters, prefixed with the kind and a hyphen. A null part keeps its separator slot.",
+  "vectors": [
+    { "prefix": "trial", "parts": ["abc"], "id": "trial-a9993e364706816a" },
+    { "prefix": "trial", "parts": [1], "id": "trial-356a192b7913b04c" },
+    { "prefix": "trial", "parts": ["1"], "id": "trial-356a192b7913b04c" },
+    { "prefix": "trial", "parts": ["1.0"], "id": "trial-e8dc057d3346e56a" },
+    { "prefix": "trial", "parts": ["a", null, "b"], "id": "trial-e69b7ae7f775b317" },
+    {
+      "prefix": "trial",
+      "parts": ["conformance-run", "capital-france", 1],
+      "id": "trial-e82b5e46a40a37e5"
+    },
+    {
+      "prefix": "gen",
+      "parts": ["conformance-run", "capital-france", 1],
+      "id": "gen-e82b5e46a40a37e5"
+    },
+    {
+      "prefix": "conv",
+      "parts": ["conformance-run", "capital-france", 1],
+      "id": "conv-e82b5e46a40a37e5"
+    },
+    {
+      "prefix": "score",
+      "parts": ["conformance-run", "trial-e82b5e46a40a37e5", "final", "exact"],
+      "id": "score-06b71bce427d6b90"
+    },
+    {
+      "prefix": "score",
+      "parts": ["conformance-run", "trial-e82b5e46a40a37e5", "final", "exact", 2],
+      "id": "score-2f8734188d24d0a4"
+    },
+    {
+      "prefix": "gen",
+      "parts": ["score-06b71bce427d6b90", "grader"],
+      "id": "gen-fb285b0f7e8a31c3"
+    },
+    {
+      "prefix": "conv",
+      "parts": ["score-06b71bce427d6b90", "grader"],
+      "id": "conv-fb285b0f7e8a31c3"
+    }
+  ]
+}

--- a/conformance/experiments/inputs.json
+++ b/conformance/experiments/inputs.json
@@ -1,0 +1,18 @@
+{
+  "experiment_id": "conformance-run",
+  "experiment_name": "conformance run",
+  "suite_id": "conformance-suite",
+  "suite_version": "1.0.0",
+  "test_case_id": "capital-france",
+  "attempt": 1,
+  "conversation_id": "conv-agent-1",
+  "evaluator_id": "helpfulness",
+  "evaluator_version": "2",
+  "evaluation_id": "eval-conformance-1",
+  "score_evaluator_id": "exact",
+  "score_evaluator_version": "1",
+  "score_key": "final",
+  "score_created_at": "2026-01-01T00:00:00Z",
+  "planned_trial_count": 1,
+  "tags": ["conformance"]
+}

--- a/conformance/experiments/requests.json
+++ b/conformance/experiments/requests.json
@@ -1,0 +1,108 @@
+{
+  "run_upsert": {
+    "method": "POST",
+    "path": "/api/v1/experiment-runs:upsert",
+    "body": {
+      "name": "conformance run",
+      "source": { "kind": "sdk", "id": "${SDK_ID}" },
+      "experiment_id": "conformance-run",
+      "tags": ["conformance"],
+      "suite_id": "conformance-suite",
+      "suite_version": "1.0.0",
+      "planned_trial_count": 1
+    }
+  },
+  "trial_create": {
+    "method": "POST",
+    "path": "/api/v1/experiment-runs/conformance-run/trials",
+    "body": {
+      "trial_id": "trial-e82b5e46a40a37e5",
+      "test_case_id": "capital-france",
+      "attempt": 1,
+      "status": "running"
+    }
+  },
+  "trial_patch_conversation": {
+    "method": "PATCH",
+    "path": "/api/v1/experiment-runs/conformance-run/trials/trial-e82b5e46a40a37e5",
+    "body": {
+      "conversation_id": "conv-agent-1"
+    }
+  },
+  "trial_evaluate": {
+    "method": "POST",
+    "path": "/api/v1/experiment-runs/conformance-run/trials/trial-e82b5e46a40a37e5:evaluate",
+    "body": {
+      "evaluator_id": "helpfulness",
+      "evaluator_version": "2"
+    }
+  },
+  "trial_evaluate_latest_version": {
+    "method": "POST",
+    "path": "/api/v1/experiment-runs/conformance-run/trials/trial-e82b5e46a40a37e5:evaluate",
+    "body": {
+      "evaluator_id": "helpfulness"
+    }
+  },
+  "trial_evaluation_status": {
+    "method": "GET",
+    "path": "/api/v1/experiment-runs/conformance-run/trials/trial-e82b5e46a40a37e5/evaluations/eval-conformance-1",
+    "body": null
+  },
+  "trial_evaluate_reserved_trial_id": {
+    "comment": "A trial id containing ':' and '/' must not shadow the ':evaluate' verb.",
+    "method": "POST",
+    "path": "/api/v1/experiment-runs/conformance-run/trials/trial%3Aone%2Fblue:evaluate",
+    "body": {
+      "evaluator_id": "helpfulness"
+    }
+  },
+  "trial_patch_terminal": {
+    "method": "PATCH",
+    "path": "/api/v1/experiment-runs/conformance-run/trials/trial-e82b5e46a40a37e5",
+    "body": {
+      "status": "completed",
+      "conversation_id": "conv-agent-1"
+    }
+  },
+  "scores_export": {
+    "method": "POST",
+    "path": "/api/v1/scores:export",
+    "body": {
+      "scores": [
+        {
+          "score_id": "score-06b71bce427d6b90",
+          "evaluator_id": "exact",
+          "evaluator_version": "1",
+          "score_key": "final",
+          "value": { "bool": true },
+          "conversation_id": "conv-agent-1",
+          "experiment_id": "conformance-run",
+          "trial_id": "trial-e82b5e46a40a37e5",
+          "test_case_id": "capital-france",
+          "passed": true,
+          "explanation": "matched the expected answer",
+          "created_at": "2026-01-01T00:00:00Z",
+          "source": { "kind": "experiment", "id": "conformance-run" }
+        }
+      ]
+    }
+  },
+  "run_finalize": {
+    "method": "POST",
+    "path": "/api/v1/experiment-runs/conformance-run:finalize",
+    "body": {
+      "status": "completed",
+      "source": { "kind": "sdk", "id": "${SDK_ID}" }
+    }
+  },
+  "run_finalize_with_score_count": {
+    "method": "POST",
+    "path": "/api/v1/experiment-runs/conformance-run:finalize",
+    "body": {
+      "status": "completed",
+      "source": { "kind": "sdk", "id": "${SDK_ID}" },
+      "score_count": 1
+    }
+  }
+}

--- a/conformance/experiments/responses.json
+++ b/conformance/experiments/responses.json
@@ -1,0 +1,132 @@
+{
+  "evaluation_queued": {
+    "evaluation_id": "eval-conformance-1",
+    "experiment_id": "conformance-run",
+    "trial_id": "trial-e82b5e46a40a37e5",
+    "test_case_id": "capital-france",
+    "conversation_id": "conv-agent-1",
+    "evaluator_id": "helpfulness",
+    "evaluator_version": "2",
+    "status": "queued",
+    "attempts": 0,
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z"
+  },
+  "evaluation_claimed": {
+    "evaluation_id": "eval-conformance-1",
+    "experiment_id": "conformance-run",
+    "trial_id": "trial-e82b5e46a40a37e5",
+    "conversation_id": "conv-agent-1",
+    "evaluator_id": "helpfulness",
+    "evaluator_version": "2",
+    "status": "claimed",
+    "attempts": 1
+  },
+  "evaluation_success": {
+    "evaluation_id": "eval-conformance-1",
+    "experiment_id": "conformance-run",
+    "trial_id": "trial-e82b5e46a40a37e5",
+    "test_case_id": "capital-france",
+    "conversation_id": "conv-agent-1",
+    "evaluator_id": "helpfulness",
+    "evaluator_version": "2",
+    "status": "success",
+    "attempts": 1,
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:05Z"
+  },
+  "evaluation_failed": {
+    "evaluation_id": "eval-conformance-1",
+    "experiment_id": "conformance-run",
+    "trial_id": "trial-e82b5e46a40a37e5",
+    "conversation_id": "conv-agent-1",
+    "evaluator_id": "helpfulness",
+    "evaluator_version": "2",
+    "status": "failed",
+    "attempts": 3,
+    "error": "grader crashed"
+  },
+  "evaluation_unsupported_status": {
+    "comment": "An unrecognized status must fail the call, not poll again.",
+    "evaluation_id": "eval-conformance-1",
+    "status": "paused"
+  },
+  "evaluation_missing_id": {
+    "comment": "A response with no evaluation_id must fail the call.",
+    "status": "queued"
+  },
+  "run_upsert_response": {
+    "run": {
+      "experiment_id": "conformance-run",
+      "name": "conformance run",
+      "status": "running",
+      "suite_id": "conformance-suite",
+      "suite_version": "1.0.0",
+      "tags": ["conformance"]
+    }
+  },
+  "run_finalize_response": {
+    "run": {
+      "experiment_id": "conformance-run",
+      "name": "conformance run",
+      "status": "completed"
+    }
+  },
+  "report_experiment_envelope": {
+    "experiment": {
+      "experiment_id": "conformance-run",
+      "name": "conformance run",
+      "status": "completed"
+    },
+    "summary": {
+      "test_case_count": 1,
+      "trial_count": 1,
+      "completed_count": 1,
+      "failed_count": 0,
+      "canceled_count": 0
+    },
+    "rows": [
+      {
+        "test_case_id": "capital-france",
+        "trials": [
+          {
+            "trial": { "trial_id": "trial-e82b5e46a40a37e5", "status": "completed" },
+            "scores": [{ "score_key": "helpfulness", "evaluator_id": "helpfulness" }]
+          }
+        ]
+      }
+    ]
+  },
+  "report_run_envelope": {
+    "comment": "Older drafts key the run under 'run'; both envelopes must parse alike.",
+    "run": {
+      "experiment_id": "conformance-run",
+      "name": "conformance run",
+      "status": "completed"
+    },
+    "summary": {
+      "test_case_count": 1,
+      "trial_count": 1,
+      "completed_count": 1,
+      "failed_count": 0,
+      "canceled_count": 0
+    },
+    "rows": [
+      {
+        "test_case_id": "capital-france",
+        "trials": [
+          {
+            "trial": { "trial_id": "trial-e82b5e46a40a37e5", "status": "completed" },
+            "scores": [{ "score_key": "helpfulness", "evaluator_id": "helpfulness" }]
+          }
+        ]
+      }
+    ]
+  },
+  "scores_export_response": {
+    "results": [{ "score_id": "score-06b71bce427d6b90", "accepted": true }],
+    "accepted": 1,
+    "duplicates": 0,
+    "rejected": 0
+  }
+}

--- a/examples/experiments/README.md
+++ b/examples/experiments/README.md
@@ -25,6 +25,7 @@ A/B testing is just two runs with different experiment ids or tags over the same
 | Framework-free | Go + `agento11y/go` | [`go/`](go/) |
 | Prompt optimizer | Go + `agento11y/go/experiments` | [`go/prompt-optimization/`](go/prompt-optimization/) |
 | Stored evaluator | Go + `agento11y/go/experiments` | [`go/cloud-evaluator/`](go/cloud-evaluator/) |
+| Stored evaluator | TypeScript + `@grafana/agento11y/experiments` | [`typescript/`](typescript/) |
 
 For credentials, see the [credentials section in the repo README](../../README.md#grafana-cloud-credentials).
 Each example's own README covers the run command and the canned-vs-real-model

--- a/examples/experiments/typescript/.env.example
+++ b/examples/experiments/typescript/.env.example
@@ -1,0 +1,22 @@
+# Grafana Cloud ingest plane: runs, trials, generations, and scores.
+# Copy the API URL, tenant ID, and token from Grafana Cloud Agent Observability.
+AGENTO11Y_ENDPOINT=https://<your-agento11y-api-host>
+AGENTO11Y_AUTH_TENANT_ID=<your-tenant-id>
+AGENTO11Y_AUTH_TOKEN=<your-cloud-access-policy-token>
+
+# Stored-evaluator grading is experimental. Without this the example fails before
+# sending a single request.
+AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true
+
+# The evaluator has to exist in your tenant already; the example does not create
+# one. Leave the version unset to use the latest active version.
+AGENTO11Y_EVALUATOR_ID=helpfulness
+# AGENTO11Y_EVALUATOR_VERSION=
+
+# Optional. Used to build the run's deep link; without it the link falls back to
+# the API endpoint host.
+# AGENTO11Y_GRAFANA_URL=https://<your-stack>.grafana.net
+
+# Optional run identity. GIT_SHA also names the default experiment id.
+# AGENTO11Y_EXPERIMENT_ID=cloud-evaluator-local
+GIT_SHA=local

--- a/examples/experiments/typescript/README.md
+++ b/examples/experiments/typescript/README.md
@@ -1,0 +1,76 @@
+# TypeScript experiments example: stored evaluator
+
+This example grades each trial with an evaluator that already exists in your
+tenant, instead of computing the score in the runner. `trial.evaluate(...)` waits
+until the worker finishes, so the run takes as long as the evaluations do.
+
+The canned agent makes no provider call. The example needs `AGENTO11Y_ENDPOINT`,
+`AGENTO11Y_AUTH_TOKEN`, optional `AGENTO11Y_AUTH_TENANT_ID`, and an evaluator id.
+
+## Setup
+
+```bash
+cd examples/experiments/typescript
+cp .env.example .env
+# Fill in the endpoint, tenant, token, and evaluator id.
+npm install
+```
+
+The `@grafana/agento11y` package is installed from the local monorepo through a
+`file:` reference. Outside the monorepo, replace that reference with the
+published package.
+
+## Run
+
+Define the evaluator in Agent Observability first: the example does not create
+one. Stored-evaluator grading also needs the experimental opt-in, which
+`.env.example` already sets to `AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true`.
+
+```bash
+set -a && source .env && set +a
+npx tsx main.ts
+```
+
+Each trial closes as `completed` with no local final score, and the backend
+counts the stored evaluator's scores.
+
+If the opt-in is missing, the example prints
+`agento11y: cloud trial evaluation is experimental; …` and exits before sending
+any request.
+
+## What it shows
+
+| Step | Call |
+| --- | --- |
+| Open the run | `withExperiment(client, {...}, fn)` |
+| Publish the agent's turn | `client.exportGeneration({...})` |
+| Point the evaluator at the conversation | `trial.bindConversation(conversationId)` |
+| Queue the stored evaluator and wait | `trial.evaluate(evaluatorId, { evaluatorVersion })` |
+| Read the results | `experiment.report()` |
+
+A real instrumented agent already exports its generation, so you drop the
+`client.exportGeneration` call and bind only the conversation id the agent
+produced.
+
+## Reading the report
+
+`report.summary.passRate` stays unset for a cloud-evaluated run: only a score
+stored under the `final` key feeds it, and a stored evaluator writes under its own
+key. The example prints "not applicable for a stored evaluator" rather than `0`,
+which would read as "everything failed". The per-row score keys below it show what
+the backend actually attached.
+
+For the same reason, leave `scoreCount` unset when finalizing such a run. The SDK
+drops a caller-supplied count once any trial queued an evaluation, because the
+server checks it against every stored score, including the evaluator's.
+
+## Errors worth handling
+
+| Error | Meaning |
+| --- | --- |
+| `ExperimentalFeatureDisabledError` | The opt-in is missing; nothing was sent |
+| `TrialEvaluationFailedError` | The worker finished unsuccessfully; carries `evaluationId` and `detail` |
+| `TrialEvaluationTimeoutError` | The deadline passed while the evaluation was still queued; it keeps running server-side |
+
+For credentials, see the
+[credentials section in the repo README](../../../README.md#grafana-cloud-credentials).

--- a/examples/experiments/typescript/main.ts
+++ b/examples/experiments/typescript/main.ts
@@ -1,0 +1,159 @@
+/**
+ * Grades experiment trials with an evaluator stored in Agent Observability
+ * instead of a score computed in the runner.
+ *
+ * Use this shape when the grading prompt lives in your tenant. The runner only
+ * has to make the agent's conversation findable:
+ *
+ *   1. Open an experiment with the ingest credential.
+ *   2. For each case, run the already-instrumented agent and bind its conversation.
+ *   3. Call `trial.evaluate(evaluatorId)` and let the stored evaluator score it.
+ *   4. Close the trial without a local `finalScore`; the backend owns the verdict.
+ *
+ * The canned agent here publishes its own generation so the example runs without
+ * a provider key. A real agent instrumented with the SDK or a provider wrapper
+ * already emits that generation, and you only need its conversation id.
+ *
+ * SDK config via env: AGENTO11Y_ENDPOINT, AGENTO11Y_AUTH_TOKEN, optional
+ * AGENTO11Y_AUTH_TENANT_ID and AGENTO11Y_EXPERIMENT_ID. Stored-evaluator grading
+ * is experimental, so AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true is required.
+ * AGENTO11Y_EVALUATOR_ID, AGENTO11Y_EVALUATOR_VERSION, and GIT_SHA are this
+ * example's own knobs.
+ */
+
+import {
+  type Experiment,
+  ExperimentalFeatureDisabledError,
+  ExperimentsClient,
+  FEATURE_CLOUD_TRIAL_EVALUATION,
+  type Trial,
+  TrialEvaluationFailedError,
+  TrialEvaluationTimeoutError,
+  requireExperimental,
+  withExperiment,
+} from '@grafana/agento11y/experiments';
+
+interface EvalCase {
+  id: string;
+  question: string;
+  answer: string;
+}
+
+const cases: EvalCase[] = [
+  { id: 'capital-france', question: 'What is the capital of France?', answer: 'Paris' },
+  { id: 'two-plus-two', question: 'What is 2 + 2? Answer with just the number.', answer: '4' },
+  { id: 'largest-planet', question: 'What is the largest planet in our solar system?', answer: 'Jupiter' },
+];
+
+async function main(): Promise<void> {
+  // `trial.evaluate` checks this itself, but by then the run and its first trial
+  // already exist. Checking up front leaves nothing behind in the tenant.
+  requireExperimental(FEATURE_CLOUD_TRIAL_EVALUATION);
+
+  const gitSha = env('GIT_SHA', 'manual');
+  const experimentId = env('AGENTO11Y_EXPERIMENT_ID', `cloud-evaluator-${gitSha}`);
+  // The evaluator must already exist in your tenant; this example does not create one.
+  const evaluatorId = env('AGENTO11Y_EVALUATOR_ID', 'helpfulness');
+  const evaluatorVersion = env('AGENTO11Y_EVALUATOR_VERSION', '');
+
+  const client = new ExperimentsClient({
+    grafanaUrl: process.env.AGENTO11Y_GRAFANA_URL,
+  });
+
+  const experiment = await withExperiment(
+    client,
+    {
+      experimentId,
+      name: 'TypeScript cloud evaluator example',
+      plannedTrialCount: cases.length,
+      candidate: { agentName: 'example-agent', gitSha },
+      tags: ['example', 'typescript', 'cloud-evaluator'],
+    },
+    async (run) => {
+      for (const testCase of cases) {
+        await gradeCase(client, run, testCase, evaluatorId, evaluatorVersion);
+      }
+      return run;
+    },
+  );
+
+  const report = await experiment.report();
+  console.log(`trials=${report.summary.trialCount} completed=${report.summary.completedCount}`);
+  // Only a score under the "final" key feeds report.summary.passRate, and a stored
+  // evaluator scores under its own key, so it stays unset. Printing it as 0 would
+  // read as "everything failed".
+  console.log(`pass rate: ${report.summary.passRate ?? 'not applicable for a stored evaluator'}`);
+  for (const row of report.rows) {
+    const testCaseId = String(row.test_case_id ?? 'unknown');
+    for (const trialResult of asArray(row.trials)) {
+      const keys = asArray(trialResult.scores)
+        .map((score) => String(score.score_key ?? ''))
+        .filter((key) => key.length > 0);
+      console.log(`  ${testCaseId}: scores=${keys.length > 0 ? keys.join(', ') : 'none'}`);
+    }
+  }
+  console.log(`View in Agent Observability: ${experiment.url}`);
+}
+
+async function gradeCase(
+  client: ExperimentsClient,
+  experiment: Experiment,
+  testCase: EvalCase,
+  evaluatorId: string,
+  evaluatorVersion: string,
+): Promise<void> {
+  await experiment.withTrial(testCase.id, async (trial: Trial) => {
+    // Stand-in for your instrumentation's conversation. With a real instrumented
+    // agent, bind the id it already exported instead.
+    const conversationId = `${trial.trialId}-agent`;
+    await client.exportGeneration({
+      generationId: trial.generationId,
+      conversationId,
+      inputText: testCase.question,
+      outputText: testCase.answer,
+      modelProvider: 'example',
+      modelName: 'canned-answer',
+      agentName: 'example-agent',
+      operationName: 'answer_question',
+      usage: { inputTokens: 12, outputTokens: 3 },
+      tags: { 'experiment.run_id': experiment.experimentId, task_id: testCase.id },
+    });
+    // The evaluator grades the conversation this binding points at.
+    trial.bindConversation(conversationId);
+
+    try {
+      // Waits until the worker finishes. No local finalScore follows: the stored
+      // evaluator writes the score and the report counts it.
+      const evaluation = await trial.evaluate(evaluatorId, { evaluatorVersion });
+      const version = evaluation.evaluatorVersion.length > 0 ? evaluation.evaluatorVersion : 'latest';
+      console.log(
+        `${testCase.id}: ${evaluation.status} evaluator=${evaluation.evaluatorId}@${version} attempts=${evaluation.attempts}`,
+      );
+    } catch (error) {
+      if (error instanceof TrialEvaluationFailedError) {
+        console.error(`${testCase.id}: evaluation ${error.evaluationId} failed: ${error.detail}`);
+      } else if (error instanceof TrialEvaluationTimeoutError) {
+        console.error(`${testCase.id}: evaluation ${error.evaluationId} still pending: ${error.detail}`);
+      }
+      throw error;
+    }
+  });
+}
+
+function env(key: string, fallback: string): string {
+  const value = (process.env[key] ?? '').trim();
+  return value.length > 0 ? value : fallback;
+}
+
+function asArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter((entry): entry is Record<string, unknown> => typeof entry === 'object' && entry !== null) : [];
+}
+
+main().catch((error: unknown) => {
+  if (error instanceof ExperimentalFeatureDisabledError) {
+    console.error(`${error.message}\nNo request was sent.`);
+    process.exit(1);
+  }
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/experiments/typescript/package.json
+++ b/examples/experiments/typescript/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "agento11y-experiments-typescript",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "npx tsx main.ts",
+    "typecheck": "npx tsc --noEmit"
+  },
+  "dependencies": {
+    "@grafana/agento11y": "file:../../../js",
+    "tsx": "4.22.3",
+    "typescript": "5.9.3"
+  }
+}

--- a/examples/experiments/typescript/tsconfig.json
+++ b/examples/experiments/typescript/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["main.ts"]
+}

--- a/go/agento11y/experiments/conformance_test.go
+++ b/go/agento11y/experiments/conformance_test.go
@@ -1,0 +1,646 @@
+package experiments
+
+// Checks the Go experiments SDK against the shared wire fixtures in
+// conformance/experiments/. Python and JavaScript run the same fixtures; see
+// conformance/experiments/README.md.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	agento11y "github.com/grafana/agento11y/go/agento11y"
+)
+
+// sdkID is what this SDK substitutes for the ${SDK_ID} placeholder.
+const sdkID = "go"
+
+type conformanceInputs struct {
+	ExperimentID          string   `json:"experiment_id"`
+	ExperimentName        string   `json:"experiment_name"`
+	SuiteID               string   `json:"suite_id"`
+	SuiteVersion          string   `json:"suite_version"`
+	TestCaseID            string   `json:"test_case_id"`
+	Attempt               int      `json:"attempt"`
+	ConversationID        string   `json:"conversation_id"`
+	EvaluatorID           string   `json:"evaluator_id"`
+	EvaluatorVersion      string   `json:"evaluator_version"`
+	EvaluationID          string   `json:"evaluation_id"`
+	ScoreEvaluatorID      string   `json:"score_evaluator_id"`
+	ScoreEvaluatorVersion string   `json:"score_evaluator_version"`
+	ScoreKey              string   `json:"score_key"`
+	ScoreCreatedAt        string   `json:"score_created_at"`
+	PlannedTrialCount     int      `json:"planned_trial_count"`
+	Tags                  []string `json:"tags"`
+}
+
+type conformanceRequest struct {
+	Method string         `json:"method"`
+	Path   string         `json:"path"`
+	Body   map[string]any `json:"body"`
+}
+
+type capturedCall struct {
+	Method string
+	Path   string
+	Body   map[string]any
+	Raw    string
+}
+
+func TestExperimentsConformanceStableIDs(t *testing.T) {
+	var fixture struct {
+		Vectors []struct {
+			Prefix string `json:"prefix"`
+			Parts  []any  `json:"parts"`
+			ID     string `json:"id"`
+		} `json:"vectors"`
+	}
+	loadFixture(t, "ids.json", &fixture)
+	if len(fixture.Vectors) == 0 {
+		t.Fatal("no id vectors in the fixture")
+	}
+	for _, vector := range fixture.Vectors {
+		parts := make([]any, len(vector.Parts))
+		for i, part := range vector.Parts {
+			// JSON numbers decode as float64; the vectors use integers, and an
+			// attempt formatted as "1.0" hashes differently from "1".
+			if number, ok := part.(float64); ok && number == float64(int64(number)) {
+				parts[i] = int64(number)
+				continue
+			}
+			parts[i] = part
+		}
+		if got := agento11y.StableID(vector.Prefix, parts...); got != vector.ID {
+			t.Errorf("StableID(%q, %v) = %q, want %q", vector.Prefix, vector.Parts, got, vector.ID)
+		}
+	}
+}
+
+func TestExperimentsConformanceRequestBodies(t *testing.T) {
+	inputs := loadInputs(t)
+	requests := loadRequests(t)
+	trialID := agento11y.StableID("trial", inputs.ExperimentID, inputs.TestCaseID, inputs.Attempt)
+	createdAt, err := time.Parse(time.RFC3339, inputs.ScoreCreatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plannedCount := inputs.PlannedTrialCount
+	scoreID := agento11y.StableID("score", inputs.ExperimentID, trialID, inputs.ScoreKey, inputs.ScoreEvaluatorID)
+	passed := true
+
+	cases := []struct {
+		name    string
+		fixture string
+		call    func(context.Context, *Client) error
+	}{
+		{
+			name:    "run upsert",
+			fixture: "run_upsert",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.UpsertExperiment(ctx, agento11y.CreateExperimentRequest{
+					RunID: inputs.ExperimentID, Name: inputs.ExperimentName,
+					Source: agento11y.ExperimentSourceExternal, Tags: inputs.Tags,
+					SuiteID: inputs.SuiteID, SuiteVersion: inputs.SuiteVersion,
+					PlannedTrialCount: &plannedCount,
+				})
+				return err
+			},
+		},
+		{
+			name:    "trial create",
+			fixture: "trial_create",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.UpsertTrial(ctx, inputs.ExperimentID, agento11y.UpsertTrialRequest{
+					TrialID: trialID, TestCaseID: inputs.TestCaseID, Attempt: inputs.Attempt,
+				})
+				return err
+			},
+		},
+		{
+			name:    "conversation patch",
+			fixture: "trial_patch_conversation",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.UpdateTrial(ctx, inputs.ExperimentID, trialID, agento11y.UpdateTrialRequest{
+					ConversationID: inputs.ConversationID,
+				})
+				return err
+			},
+		},
+		{
+			name:    "terminal patch",
+			fixture: "trial_patch_terminal",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.UpdateTrial(ctx, inputs.ExperimentID, trialID, agento11y.UpdateTrialRequest{
+					Status: "completed", ConversationID: inputs.ConversationID,
+				})
+				return err
+			},
+		},
+		{
+			name:    "evaluate with a pinned version",
+			fixture: "trial_evaluate",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.TriggerTrialEvaluation(ctx, inputs.ExperimentID, trialID, TriggerTrialEvaluationRequest{
+					EvaluatorID: inputs.EvaluatorID, EvaluatorVersion: inputs.EvaluatorVersion,
+				})
+				return err
+			},
+		},
+		{
+			name:    "evaluate with the latest version",
+			fixture: "trial_evaluate_latest_version",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.TriggerTrialEvaluation(ctx, inputs.ExperimentID, trialID, TriggerTrialEvaluationRequest{
+					EvaluatorID: inputs.EvaluatorID,
+				})
+				return err
+			},
+		},
+		{
+			name:    "evaluate with a reserved trial id",
+			fixture: "trial_evaluate_reserved_trial_id",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.TriggerTrialEvaluation(ctx, inputs.ExperimentID, "trial:one/blue", TriggerTrialEvaluationRequest{
+					EvaluatorID: inputs.EvaluatorID,
+				})
+				return err
+			},
+		},
+		{
+			name:    "score export",
+			fixture: "scores_export",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.ExportScores(ctx, []ScoreItem{{
+					ScoreID: scoreID, EvaluatorID: inputs.ScoreEvaluatorID,
+					EvaluatorVersion: inputs.ScoreEvaluatorVersion,
+					// Local-only on purpose: no SDK puts the evaluator kind on the wire.
+					EvaluatorKind:  "deterministic",
+					ScoreKey:       inputs.ScoreKey,
+					Value:          agento11y.BoolScoreValue(true),
+					ConversationID: inputs.ConversationID, RunID: inputs.ExperimentID,
+					TrialID: trialID, TestCaseID: inputs.TestCaseID,
+					Passed: &passed, Explanation: "matched the expected answer",
+					CreatedAt: &createdAt,
+					Source:    &agento11y.ScoreSource{Kind: "experiment", ID: inputs.ExperimentID},
+				}})
+				return err
+			},
+		},
+		{
+			name:    "finalize",
+			fixture: "run_finalize",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.Finalize(ctx, inputs.ExperimentID, ExperimentStatusCompleted, nil, "")
+				return err
+			},
+		},
+		{
+			name:    "finalize with a score count",
+			fixture: "run_finalize_with_score_count",
+			call: func(ctx context.Context, client *Client) error {
+				count := 1
+				_, err := client.Finalize(ctx, inputs.ExperimentID, ExperimentStatusCompleted, &count, "")
+				return err
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			want, ok := requests[testCase.fixture]
+			if !ok {
+				t.Fatalf("fixture %q is missing from requests.json", testCase.fixture)
+			}
+			calls := captureCalls(t, func(ctx context.Context, client *Client) {
+				if err := testCase.call(ctx, client); err != nil {
+					t.Fatal(err)
+				}
+			})
+			if len(calls) != 1 {
+				t.Fatalf("got %d requests, want 1", len(calls))
+			}
+			assertMatchesFixture(t, calls[0], want)
+		})
+	}
+}
+
+func TestExperimentsConformanceEvaluationResponses(t *testing.T) {
+	inputs := loadInputs(t)
+	var responses map[string]json.RawMessage
+	loadFixture(t, "responses.json", &responses)
+
+	statuses := map[string]agento11y.TrialEvaluationStatus{
+		"evaluation_queued":  agento11y.TrialEvaluationStatusQueued,
+		"evaluation_claimed": agento11y.TrialEvaluationStatusClaimed,
+		"evaluation_success": agento11y.TrialEvaluationStatusSuccess,
+		"evaluation_failed":  agento11y.TrialEvaluationStatusFailed,
+	}
+	names := make([]string, 0, len(statuses))
+	for name := range statuses {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	// Every suite checks the same field list on the same fixtures, so a misparse in
+	// one SDK cannot pass while the others check a different subset.
+	for _, name := range names {
+		evaluation := parseEvaluationFixture(t, responses[name])
+		if evaluation.Status != statuses[name] {
+			t.Errorf("%s: status = %q, want %q", name, evaluation.Status, statuses[name])
+		}
+		if evaluation.EvaluationID != inputs.EvaluationID {
+			t.Errorf("%s: evaluation_id = %q, want %q", name, evaluation.EvaluationID, inputs.EvaluationID)
+		}
+		if evaluation.ExperimentID != inputs.ExperimentID {
+			t.Errorf("%s: experiment_id = %q, want %q", name, evaluation.ExperimentID, inputs.ExperimentID)
+		}
+		if want := agento11y.StableID("trial", inputs.ExperimentID, inputs.TestCaseID, inputs.Attempt); evaluation.TrialID != want {
+			t.Errorf("%s: trial_id = %q, want %q", name, evaluation.TrialID, want)
+		}
+		if evaluation.ConversationID != inputs.ConversationID {
+			t.Errorf("%s: conversation_id = %q, want %q", name, evaluation.ConversationID, inputs.ConversationID)
+		}
+		if evaluation.EvaluatorID != inputs.EvaluatorID {
+			t.Errorf("%s: evaluator_id = %q, want %q", name, evaluation.EvaluatorID, inputs.EvaluatorID)
+		}
+		if evaluation.EvaluatorVersion != inputs.EvaluatorVersion {
+			t.Errorf("%s: evaluator_version = %q, want %q", name, evaluation.EvaluatorVersion, inputs.EvaluatorVersion)
+		}
+	}
+
+	queued := parseEvaluationFixture(t, responses["evaluation_queued"])
+	if queued.Attempts != 0 || queued.TestCaseID != inputs.TestCaseID {
+		t.Errorf("queued evaluation: %#v", queued)
+	}
+	success := parseEvaluationFixture(t, responses["evaluation_success"])
+	if success.Attempts != 1 || success.TestCaseID != inputs.TestCaseID {
+		t.Errorf("success evaluation: %#v", success)
+	}
+	if success.CreatedAt == nil || !success.CreatedAt.Equal(mustParseTime(t, "2026-01-01T00:00:00Z")) {
+		t.Errorf("success created_at = %v", success.CreatedAt)
+	}
+	if success.UpdatedAt == nil || !success.UpdatedAt.Equal(mustParseTime(t, "2026-01-01T00:00:05Z")) {
+		t.Errorf("success updated_at = %v", success.UpdatedAt)
+	}
+
+	failed := parseEvaluationFixture(t, responses["evaluation_failed"])
+	if failed.Error != "grader crashed" || failed.Attempts != 3 {
+		t.Errorf("failed evaluation: %#v", failed)
+	}
+
+	// An unknown status and a missing id both have to fail the call rather than
+	// read as a non-terminal state the SDK would poll on.
+	for _, name := range []string{"evaluation_unsupported_status", "evaluation_missing_id"} {
+		body := responses[name]
+		calls := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			calls++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+		}))
+		client := newConformanceClient(t, server.URL)
+		_, err := client.GetTrialEvaluation(context.Background(), inputs.ExperimentID, "trial-1", inputs.EvaluationID)
+		server.Close()
+		if err == nil {
+			t.Errorf("%s: expected an error", name)
+		}
+		if calls != 1 {
+			t.Errorf("%s: sent %d requests, want 1", name, calls)
+		}
+	}
+}
+
+func TestExperimentsConformanceReportEnvelopes(t *testing.T) {
+	inputs := loadInputs(t)
+	var responses map[string]json.RawMessage
+	loadFixture(t, "responses.json", &responses)
+
+	var fromExperiment, fromRun agento11y.ExperimentReport
+	if err := json.Unmarshal(responses["report_experiment_envelope"], &fromExperiment); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(responses["report_run_envelope"], &fromRun); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(fromExperiment, fromRun) {
+		t.Fatalf("the two report envelopes parsed differently:\n%#v\n%#v", fromExperiment, fromRun)
+	}
+	if fromExperiment.Run.RunID != inputs.ExperimentID {
+		t.Errorf("run id = %q, want %q", fromExperiment.Run.RunID, inputs.ExperimentID)
+	}
+	if fromExperiment.Summary.TrialCount != 1 {
+		t.Errorf("trial count = %d, want 1", fromExperiment.Summary.TrialCount)
+	}
+	// Only a score under the "final" key feeds the pass rate, and a stored
+	// evaluator writes under its own key.
+	if fromExperiment.Summary.PassRateValue != nil {
+		t.Errorf("pass rate = %v, want unset", *fromExperiment.Summary.PassRateValue)
+	}
+}
+
+func TestExperimentsConformanceCloudEvaluatedTrialCallOrder(t *testing.T) {
+	inputs := loadInputs(t)
+	requests := loadRequests(t)
+	trialID := agento11y.StableID("trial", inputs.ExperimentID, inputs.TestCaseID, inputs.Attempt)
+	var responses map[string]json.RawMessage
+	loadFixture(t, "responses.json", &responses)
+
+	calls := captureCallsWith(t, func(path string, method string) json.RawMessage {
+		switch {
+		case strings.HasSuffix(path, ":evaluate"):
+			return responses["evaluation_success"]
+		case strings.Contains(path, "/evaluations/"):
+			return responses["evaluation_success"]
+		case strings.HasSuffix(path, ":upsert"):
+			return responses["run_upsert_response"]
+		case strings.HasSuffix(path, ":finalize"):
+			return responses["run_finalize_response"]
+		default:
+			_ = method
+			return json.RawMessage(`{"trial_id":"` + trialID + `"}`)
+		}
+	}, func(ctx context.Context, client *Client) {
+		count := inputs.PlannedTrialCount
+		experiment, err := NewExperiment(client, ExperimentOptions{
+			ExperimentID: inputs.ExperimentID, Name: inputs.ExperimentName,
+			Tags: inputs.Tags, PlannedTrialCount: &count,
+			Suite: &TestSuite{SuiteID: inputs.SuiteID, Version: inputs.SuiteVersion},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := experiment.Enter(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if err := experiment.WithTrialByCaseID(ctx, inputs.TestCaseID, func(ctx context.Context, trial *Trial) error {
+			trial.BindConversation(inputs.ConversationID)
+			_, err := trial.Evaluate(ctx, inputs.EvaluatorID, EvaluateOptions{
+				EvaluatorVersion: inputs.EvaluatorVersion,
+			})
+			return err
+		}); err != nil {
+			t.Fatal(err)
+		}
+		scoreCount := 1
+		if err := experiment.Finalize(ctx, ExperimentStatusCompleted, FinalizeOptions{ScoreCount: &scoreCount}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	got := make([]string, 0, len(calls))
+	for _, call := range calls {
+		got = append(got, call.Method+" "+call.Path)
+		if call.Path == "/api/v1/scores:export" {
+			t.Error("a cloud-evaluated trial must write no local score")
+		}
+	}
+	want := []string{
+		"POST /api/v1/experiment-runs:upsert",
+		"POST /api/v1/experiment-runs/" + inputs.ExperimentID + "/trials",
+		"PATCH /api/v1/experiment-runs/" + inputs.ExperimentID + "/trials/" + trialID,
+		"POST /api/v1/experiment-runs/" + inputs.ExperimentID + "/trials/" + trialID + ":evaluate",
+		"PATCH /api/v1/experiment-runs/" + inputs.ExperimentID + "/trials/" + trialID,
+		"POST /api/v1/experiment-runs/" + inputs.ExperimentID + ":finalize",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("call order:\ngot  %v\nwant %v", got, want)
+	}
+	assertMatchesFixture(t, calls[2], requests["trial_patch_conversation"])
+	assertMatchesFixture(t, calls[3], requests["trial_evaluate"])
+	// The caller's score count is dropped once a trial queued an evaluation.
+	assertMatchesFixture(t, calls[5], requests["run_finalize"])
+}
+
+// --- helpers -------------------------------------------------------------- //
+
+func fixturePath(t *testing.T, name string) string {
+	t.Helper()
+	// go/agento11y/experiments -> repository root
+	return filepath.Join("..", "..", "..", "conformance", "experiments", name)
+}
+
+func loadFixture(t *testing.T, name string, out any) {
+	t.Helper()
+	raw, err := os.ReadFile(fixturePath(t, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		t.Fatalf("%s: %v", name, err)
+	}
+}
+
+func loadInputs(t *testing.T) conformanceInputs {
+	t.Helper()
+	var inputs conformanceInputs
+	loadFixture(t, "inputs.json", &inputs)
+	return inputs
+}
+
+func loadRequests(t *testing.T) map[string]conformanceRequest {
+	t.Helper()
+	var requests map[string]conformanceRequest
+	loadFixture(t, "requests.json", &requests)
+	for name, request := range requests {
+		request.Body = substituteSDKID(request.Body).(map[string]any)
+		requests[name] = request
+	}
+	return requests
+}
+
+// substituteSDKID replaces the ${SDK_ID} placeholder every source object carries.
+func substituteSDKID(value any) any {
+	switch typed := value.(type) {
+	case string:
+		if typed == "${SDK_ID}" {
+			return sdkID
+		}
+		return typed
+	case []any:
+		for i, item := range typed {
+			typed[i] = substituteSDKID(item)
+		}
+		return typed
+	case map[string]any:
+		for key, item := range typed {
+			typed[key] = substituteSDKID(item)
+		}
+		return typed
+	default:
+		return value
+	}
+}
+
+func newConformanceClient(t *testing.T, endpoint string) *Client {
+	t.Helper()
+	useOTel := false
+	redact := false
+	client, err := NewClient(ClientOptions{
+		Endpoint: endpoint, IngestToken: "token",
+		UseExperimentalOTel: &useOTel, RedactSecrets: &redact,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func captureCalls(t *testing.T, run func(context.Context, *Client)) []capturedCall {
+	t.Helper()
+	var responses map[string]json.RawMessage
+	loadFixture(t, "responses.json", &responses)
+	// The evaluation routes validate their response, so they get the canned one.
+	return captureCallsWith(t, func(path string, _ string) json.RawMessage {
+		if strings.HasSuffix(path, ":evaluate") || strings.Contains(path, "/evaluations/") {
+			return responses["evaluation_queued"]
+		}
+		return json.RawMessage(`{}`)
+	}, run)
+}
+
+func captureCallsWith(
+	t *testing.T,
+	respond func(path string, method string) json.RawMessage,
+	run func(context.Context, *Client),
+) []capturedCall {
+	t.Helper()
+	var mu sync.Mutex
+	var calls []capturedCall
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var body map[string]any
+		if len(raw) > 0 {
+			_ = json.Unmarshal(raw, &body)
+		}
+		mu.Lock()
+		calls = append(calls, capturedCall{
+			Method: r.Method, Path: r.URL.EscapedPath(), Body: body, Raw: string(raw),
+		})
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(respond(r.URL.Path, r.Method))
+	}))
+	defer server.Close()
+
+	client := newConformanceClient(t, server.URL)
+	run(context.Background(), client)
+	_ = client.Shutdown(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+	return calls
+}
+
+func assertMatchesFixture(t *testing.T, got capturedCall, want conformanceRequest) {
+	t.Helper()
+	if got.Method != want.Method {
+		t.Errorf("method = %q, want %q", got.Method, want.Method)
+	}
+	if got.Path != want.Path {
+		t.Errorf("path = %q, want %q", got.Path, want.Path)
+	}
+	if differences := diffJSON(got.Body, want.Body, ""); len(differences) > 0 {
+		t.Errorf("body differs from the fixture:\n%s\ngot: %s", strings.Join(differences, "\n"), got.Raw)
+	}
+}
+
+// diffJSON reports structural differences as dotted JSON paths so a failure names
+// the offending field. A fixture's documentation-only "comment" key is ignored.
+func diffJSON(got, want any, path string) []string {
+	label := path
+	if label == "" {
+		label = "<root>"
+	}
+	switch wanted := want.(type) {
+	case map[string]any:
+		gotMap, ok := got.(map[string]any)
+		if !ok {
+			return []string{fmt.Sprintf("%s: got %v, want an object", label, got)}
+		}
+		var differences []string
+		keys := make([]string, 0, len(wanted))
+		for key := range wanted {
+			if key == "comment" {
+				continue
+			}
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		gotKeys := make([]string, 0, len(gotMap))
+		for key := range gotMap {
+			gotKeys = append(gotKeys, key)
+		}
+		sort.Strings(gotKeys)
+		for _, key := range gotKeys {
+			if _, expected := wanted[key]; !expected {
+				differences = append(differences, fmt.Sprintf("%s.%s: unexpected field %v", path, key, gotMap[key]))
+			}
+		}
+		for _, key := range keys {
+			value, present := gotMap[key]
+			if !present {
+				differences = append(differences, fmt.Sprintf("%s.%s: missing, want %v", path, key, wanted[key]))
+				continue
+			}
+			differences = append(differences, diffJSON(value, wanted[key], path+"."+key)...)
+		}
+		return differences
+	case []any:
+		gotSlice, ok := got.([]any)
+		if !ok {
+			return []string{fmt.Sprintf("%s: got %v, want an array", label, got)}
+		}
+		if len(gotSlice) != len(wanted) {
+			return []string{fmt.Sprintf("%s: got %d items, want %d", label, len(gotSlice), len(wanted))}
+		}
+		var differences []string
+		for i := range wanted {
+			differences = append(differences, diffJSON(gotSlice[i], wanted[i], fmt.Sprintf("%s[%d]", path, i))...)
+		}
+		return differences
+	default:
+		if !reflect.DeepEqual(got, want) {
+			return []string{fmt.Sprintf("%s: got %#v, want %#v", label, got, want)}
+		}
+		return nil
+	}
+}
+
+// parseEvaluationFixture serves the fixture and reads it back through
+// GetTrialEvaluation, so the assertions cover the SDK's own decode path rather
+// than a plain json.Unmarshal the SDK never performs.
+func parseEvaluationFixture(t *testing.T, raw json.RawMessage) agento11y.TrialEvaluation {
+	t.Helper()
+	inputs := loadInputs(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(raw)
+	}))
+	defer server.Close()
+	evaluation, err := newConformanceClient(t, server.URL).GetTrialEvaluation(
+		context.Background(), inputs.ExperimentID, "trial-1", inputs.EvaluationID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return *evaluation
+}
+
+func mustParseTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}

--- a/js/README.md
+++ b/js/README.md
@@ -560,3 +560,58 @@ console.log(result.rating.rating, result.summary.hasBadRating);
 ```
 
 `submitConversationRating` sends requests to `api.endpoint`, which should be the Grafana Cloud Agent Observability API URL from Agent Observability configuration, and uses the same generation-export auth headers already configured on the SDK client.
+
+## Experiments
+
+Offline evals: run an agent over a dataset, grade it, and publish runs, trials,
+and scores to Agent Observability. The API lives on a separate subpath, so
+importing the core package never pulls experiments code into an edge-runtime
+bundle:
+
+```ts
+import { ExperimentsClient, withExperiment } from "@grafana/agento11y/experiments";
+
+const client = new ExperimentsClient({
+  endpoint: process.env.AGENTO11Y_ENDPOINT,
+  tenantId: process.env.AGENTO11Y_AUTH_TENANT_ID,
+  ingestToken: process.env.AGENTO11Y_AUTH_TOKEN,
+});
+
+const suite = {
+  suiteId: "smoke",
+  name: "Smoke",
+  testCases: [{ testCaseId: "add", input: "2+2", expected: "4" }],
+};
+const verifier = { evaluatorId: "exact", version: "1", kind: "deterministic" };
+
+await withExperiment(client, { experimentId: "run-1", name: "smoke run", suite }, async (experiment) => {
+  for (const testCase of suite.testCases) {
+    await experiment.withTrial(testCase, async (trial) => {
+      const answer = await runAgent(testCase.input);
+      trial.recordIO({ input: testCase.input, output: answer });
+      trial.finalScore(answer === testCase.expected, { evaluator: verifier });
+    });
+  }
+});
+```
+
+`withExperiment` finalizes the run on both the success and the failure path, and
+`withTrial` closes the trial and terminalizes it as `errored` when the callback
+throws. Use `Experiment.start`, `trial.start()`, and `close()` directly when a
+runner owns its own control flow.
+
+An evaluator stored in your tenant can also grade a trial, instead of a score
+computed in the runner. That path is experimental and requires
+`AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true`:
+
+```ts
+await experiment.withTrial(testCase, async (trial) => {
+  const { conversationId } = await runInstrumentedAgent(testCase.input);
+  trial.bindConversation(conversationId);
+  await trial.evaluate("helpfulness");
+});
+```
+
+See [`docs/experiments.md`](docs/experiments.md) for the full surface: score
+kinds, local judges, artifacts, reports, portable and stored suites, cross-process
+trials, and experimental OpenTelemetry trial telemetry.

--- a/js/docs/experiments.md
+++ b/js/docs/experiments.md
@@ -1,0 +1,330 @@
+# Experiments
+
+Offline evals for the TypeScript and JavaScript SDK: run an agent over a dataset,
+grade it, and publish runs, trials, and scores to Agent Observability.
+
+The API ships as the `@grafana/agento11y/experiments` subpath, not as part of
+`@grafana/agento11y-core`: core must keep loading on edge runtimes without
+`process` or `Buffer`, and experiments needs crypto and environment access.
+Experiments only runs as an offline batch job, so the split does not limit what you
+can grade. The core client instruments an edge-deployed agent, and a separate
+runner grades it later.
+
+The surface matches the Python and Go experiments SDKs, in camelCase. Identities,
+request bodies, and the cloud-evaluation call order are shared across all three,
+so a run started by one SDK can be resumed by another. This guide calls the unit
+of work a run; the API spells it `experimentId`, and the ingest route keys on
+`experiment_id`.
+
+## Connect
+
+```ts
+import { ExperimentsClient } from "@grafana/agento11y/experiments";
+
+const client = new ExperimentsClient({
+  endpoint: process.env.AGENTO11Y_ENDPOINT,
+  tenantId: process.env.AGENTO11Y_AUTH_TENANT_ID,
+  ingestToken: process.env.AGENTO11Y_AUTH_TOKEN,
+});
+```
+
+Every option falls back to an environment variable:
+
+| Option | Environment variable | Purpose |
+|--------|----------------------|---------|
+| `endpoint` | `AGENTO11Y_ENDPOINT` | Agent Observability API URL |
+| `ingestToken` | `AGENTO11Y_AUTH_TOKEN` | Cloud ingestion API key |
+| `tenantId` | `AGENTO11Y_AUTH_TENANT_ID` | Stack id; when set, requests use basic auth |
+| `actor` | `AGENTO11Y_INGEST_ACTOR` | Ingest actor, default `ingest:sdk/js` |
+| `grafanaUrl` | `AGENTO11Y_GRAFANA_URL` | Base URL for `experiment.url` deep links |
+| `useExperimentalOtel` | `AGENTO11Y_USE_EXPERIMENTAL_OTEL` | Emit trial spans and evaluation events |
+
+Run, trial, generation, score, and artifact writes all use the ingest credential.
+Stored test suites are the exception: they live behind the Grafana plugin control
+plane and use `TestSuitesClient` with its own service-account token.
+
+The SDK reads only the `AGENTO11Y_*` names. It warns once per process about a
+removed `SIGIL_*` trial-handoff name, through the client logger or `console.warn`,
+and never reads its value.
+
+## Run an experiment
+
+```ts
+import { withExperiment } from "@grafana/agento11y/experiments";
+
+const suite = {
+  suiteId: "smoke",
+  name: "Smoke",
+  version: "1.0.0",
+  testCases: [
+    { testCaseId: "add", name: "Addition", input: "2+2", expected: "4" },
+    { testCaseId: "sub", input: "5-3", expected: "2" },
+  ],
+};
+const verifier = { evaluatorId: "exact", version: "1", kind: "deterministic" };
+
+await withExperiment(client, { experimentId: "nightly-42", name: "nightly", suite }, async (experiment) => {
+  for (const testCase of suite.testCases) {
+    await experiment.withTrial(testCase, async (trial) => {
+      const answer = await runAgent(testCase.input);
+      trial.recordIO({ input: testCase.input, output: answer });
+      trial.setUsage({ inputTokens: 120, outputTokens: 18 });
+      trial.finalScore(answer === testCase.expected, { evaluator: verifier });
+    });
+  }
+  console.log((await experiment.report()).summary);
+});
+```
+
+`withExperiment` upserts the run, then finalizes it as `completed` or, when the
+callback throws, as `failed` before rethrowing. `withTrial` starts the trial,
+closes it, and terminalizes it as `errored` when the callback throws.
+
+The explicit form suits a runner with its own control flow:
+
+```ts
+const experiment = await Experiment.start(client, { experimentId: "nightly-42", name: "nightly", suite });
+const trial = experiment.trial("add");
+await trial.start();
+trial.finalScore(0.82, { passed: true, evaluator: verifier });
+await trial.close();
+await experiment.finalize("completed");
+```
+
+Reusing the same case and attempt in one experiment is rejected: the second trial
+would derive the same trial and score identities as the first. Pass
+`{ attempt: 2 }` for a retry.
+
+## Trial close status
+
+| Situation | Trial status | Sent to the backend |
+|-----------|--------------|---------------------|
+| Callback threw | `errored` | `failed` with the error text |
+| No final score, no cloud evaluation | `failed` | `failed`, error `trial closed without a final score` |
+| Cloud evaluation succeeded | `completed` | `completed` |
+| Final score with a `passed` verdict | `passed` or `failed` | `completed` |
+| Final score without a verdict | `completed` | `completed` |
+
+The backend trial status reports the lifecycle, not the verdict. The pass/fail
+verdict lives in the final score's `passed`, which is what the report's pass rate
+counts.
+
+## Scores
+
+| Method | Use |
+|--------|-----|
+| `trial.finalScore(value, options)` | Headline score under the `final` key, plus the trial verdict |
+| `trial.checkScore(name, { passed })` | Deterministic check, for example `json_valid` |
+| `trial.rubricScore(name, value)` | One LLM-judge rubric criterion |
+| `trial.score(key, value, options)` | The general primitive |
+| `trial.recordEvaluation(result)` | A result produced by a framework or helper |
+| `trial.evaluateOutput(judge, io)` | Grade caller-supplied output with a local judge |
+
+Scores buffer locally and export on `trial.flush()` or `trial.close()`. An empty
+buffer sends no request. `flush()` keeps the buffer on failure, so a later close
+can publish it.
+
+`finalScore(true)` and `finalScore(false)` set the verdict from the boolean. A
+numeric score needs an explicit `passed` to become a verdict.
+
+## Local judges
+
+`LLMJudge` and `RegexJudge` need no evaluator stored in Grafana:
+
+```ts
+import { LLMJudge } from "@grafana/agento11y/experiments";
+
+const judge = new LLMJudge({
+  evaluatorId: "judge.helpfulness",
+  modelProvider: "anthropic",
+  modelName: "claude-sonnet-4",
+  invoke: async (prompt) => callYourModel(prompt),
+});
+
+await experiment.withTrial(testCase, async (trial) => {
+  const answer = await runAgent(testCase.input);
+  await trial.evaluateOutput(judge, { input: testCase.input, output: answer, expected: testCase.expected });
+});
+```
+
+The default parser reads the last JSON object in the response that carries a
+numeric `score`, so the SDK still reads a judge that narrates before its verdict.
+A top-level score always wins over a nested rubric score. Pass `parser` to take
+over parsing, and `usageExtractor` to take over token accounting.
+
+A judge result carries a grader transcript. `recordEvaluation` publishes it as a
+generation whose ids derive from the score id, so the grading call is visible next
+to the score. Pass `{ publishGrader: false }` to keep the transcript local.
+
+## Cloud evaluation (experimental)
+
+`trial.evaluate` grades the conversation Agent Observability already stored, using
+an evaluator defined in your tenant:
+
+```ts
+await experiment.withTrial(testCase, async (trial) => {
+  const { conversationId } = await runInstrumentedAgent(testCase.input);
+  trial.bindConversation(conversationId);
+  await trial.evaluate("helpfulness", { evaluatorVersion: "2", timeoutMs: 120_000 });
+});
+```
+
+This is experimental. Set `AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true`, or the
+call rejects with `ExperimentalFeatureDisabledError` before sending any request.
+The API can change or be removed in any release.
+
+The call persists the conversation binding, exports the anchor generation from
+`recordIO`, queues the evaluator, and polls until the worker reaches a terminal
+status. The poll interval starts at `pollIntervalMs` (default 500 ms) and doubles
+to a 5000 ms ceiling, and `timeoutMs` (default 300000 ms) bounds the whole wait.
+The SDK keeps a caller interval that is already above the ceiling. Pass `signal`
+to cancel: polling stops and the signal's own abort reason is rethrown unchanged.
+
+| Outcome | Rejection |
+|---------|-----------|
+| Worker reported `failed` | `TrialEvaluationFailedError` with `evaluationId` and `detail` |
+| Deadline passed | `TrialEvaluationTimeoutError` with `evaluationId` |
+| Gate closed | `ExperimentalFeatureDisabledError` |
+| Unrecognized status | Transport error, rather than polling forever |
+
+Three consequences for reading the results back:
+
+- The evaluator grades the conversation, not one generation, so its score carries
+  the trial's `conversationId` and `trialId` and no `generationId`. Read it from
+  the run's scores or the trial's scores in the report; a per-generation lookup
+  returns nothing.
+- `report.summary.passRate` stays unset, because only a score under the `final`
+  key feeds it while a stored evaluator writes under its own key. It is
+  `undefined`, not `0`: do not print it as a zero pass rate.
+- `experiment.finalize` drops a caller-supplied `scoreCount` once any trial queued
+  an evaluation. The server checks the count against every stored score, including
+  the evaluator's, which this process never sees.
+
+To evaluate several trials at once, trigger and poll yourself with
+`client.triggerTrialEvaluation(...)` and `client.getTrialEvaluation(...)`, keeping
+both inside the experiment block. Finalizing while an evaluation is still queued
+answers 409 with the `pending_evaluations` conflict kind.
+
+## Binding an already-instrumented agent
+
+When normal instrumentation already emitted the attempt, bind it instead of
+recording I/O again:
+
+| Method | Effect |
+|--------|--------|
+| `trial.bindConversation(id)` | Attaches the trial and its scores to a stored conversation |
+| `trial.bindGeneration(id, { conversationId })` | Attaches scores to an existing generation; no anchor generation is exported |
+| `await trial.bindTrace(traceId, spanId)` | Links the trial to a trace produced elsewhere |
+
+`recordIO` is the other direction: the harness owns the candidate's input and
+output, and the SDK exports one anchor generation so the attempt is visible.
+A failed anchor-generation export rejects, unlike `Agento11yClient.flush()`, which
+only warns. A trial that loses its conversation fails evaluation later with a
+confusing server-side error.
+
+## Artifacts
+
+```ts
+await trial.artifact("transcript.md", { text: renderTranscript(), kind: "markdown", mime: "text/markdown" });
+await trial.artifact("trace.json", { data: { steps } });
+await trial.artifact("screenshot.png", { bytes: png, mime: "image/png" });
+```
+
+Provide exactly one of `text`, `data`, or `bytes`. The artifact kind and MIME type
+are inferred when omitted: `data` becomes `application/json`, `text` becomes
+`text/plain`, and raw bytes become `application/octet-stream` unless a MIME type
+maps onto `image`, `json`, `markdown`, `pdf`, `csv`, or `text`.
+
+## Suites
+
+Portable suites are plain YAML, readable by all three SDKs:
+
+```ts
+import { parseSuiteYAML, stringifySuiteYAML } from "@grafana/agento11y/experiments";
+
+const suite = parseSuiteYAML(await readFile("suite.yaml", "utf8"));
+await writeFile("suite.yaml", stringifySuiteYAML(suite));
+```
+
+Loading accepts the legacy aliases: a suite id under `suite_id` or `id`, cases
+under `cases` or `test_cases`, and a case id under `id` or `test_case_id`. Saving
+always writes the canonical spelling, so a load-save round trip normalizes an
+older document.
+
+Stored suites use the control plane:
+
+```ts
+import { TestSuitesClient } from "@grafana/agento11y/experiments";
+
+const suites = new TestSuitesClient({
+  grafanaUrl: process.env.AGENTO11Y_GRAFANA_URL,
+  serviceAccountToken: process.env.AGENTO11Y_SERVICE_ACCOUNT_TOKEN,
+});
+const pulled = await suites.pullSuite("smoke", "latest_published");
+const pushed = await suites.pushSuite(localSuite, { publish: true, changelog: "add refusal cases" });
+```
+
+`TestSuitesClient` also takes `controlEndpoint` (environment variable
+`AGENTO11Y_CONTROL_ENDPOINT`), which falls back to `grafanaUrl`. It accepts a
+Grafana base URL, a UI app URL, or the resources path itself; all three normalize
+onto the plugin resources route. Versions resolve by exact name or through the
+`latest_published`, `latest`, and `draft` aliases.
+
+## Cross-process trials
+
+A separate container opens one trial from environment variables the parent set:
+
+```ts
+import { Trial, trialRefFromEnv, trialRefToEnv } from "@grafana/agento11y/experiments";
+
+// Parent
+const env = trialRefToEnv({ experimentId: "nightly-42", testCaseId: "add", attempt: 1 });
+
+// Child
+const ref = trialRefFromEnv();
+if (ref === undefined) {
+  throw new Error("missing Agent Observability trial environment");
+}
+const trial = await Trial.fromRef(client, ref).start();
+trial.finalScore(0.82, { passed: true });
+await trial.close();
+```
+
+Trial, generation, conversation, and score ids are derived, not random:
+`stableId` hashes the parts, so both processes compute the same identities and a
+retry is idempotent.
+
+## Telemetry
+
+Experimental OpenTelemetry trial telemetry is off by default. Set
+`AGENTO11Y_USE_EXPERIMENTAL_OTEL=true`, or pass `useExperimentalOtel: true`, to
+emit one `eval.trial <case>` span per trial with `test.*` identity attributes and
+one `gen_ai.evaluation.result` event per score. Some of those attribute names are
+still moving through the OpenTelemetry GenAI SIG, so the SDK stamps
+`agento11y.eval.schema.version` on the span. An upstream rename then shows up as a
+version bump rather than silent drift.
+
+`withTrial` runs its callback with the trial span active, so spans an instrumented
+agent emits inside the callback become children of the trial span. If you drive
+`start()` and `close()` by hand, wrap the agent call in
+`trial.runInTrialContext(fn)` to get the same parenting.
+
+Secret redaction is on by default and covers score explanations, score metadata,
+generation payloads, and text artifacts. Pass `redactSecrets: false` to send
+content unchanged.
+
+## Errors
+
+| Shape | Meaning |
+|-------|---------|
+| `agento11y experiment validation failed: …` | Rejected by the SDK, or HTTP 400/422 |
+| `agento11y experiment not found: …` | HTTP 404 |
+| `ExperimentConflictError` | HTTP 409, with a classified `kind` and `recoverable` |
+| `agento11y experiment transport failed: …` | Transport failure, unusable response, or exhausted retries |
+| `TrialEvaluationFailedError` | A stored evaluator ended the evaluation unsuccessfully |
+| `TrialEvaluationTimeoutError` | The evaluation did not finish before the deadline |
+| `ExperimentalFeatureDisabledError` | An experimental call ran without its opt-in |
+
+Transport failures, HTTP 429, and 5xx get four total attempts with backoff
+doubling from 100 ms to a 5000 ms ceiling. A 400, 404, 409, or 422 is a caller
+error and is not retried. Control-plane requests get six total attempts.

--- a/js/docs/index.md
+++ b/js/docs/index.md
@@ -6,6 +6,10 @@ This directory contains public SDK usage docs for the TypeScript/JavaScript pack
 
 - SDK overview and core API: `../README.md`
 
+## Feature Guides
+
+- `experiments.md`
+
 ## Provider Guides
 
 - `providers/openai.md`

--- a/js/package.json
+++ b/js/package.json
@@ -15,6 +15,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./experiments": {
+      "types": "./dist/experiments/index.d.ts",
+      "import": "./dist/experiments/index.js"
+    },
     "./langchain": {
       "types": "./dist/frameworks/langchain/index.d.ts",
       "import": "./dist/frameworks/langchain/index.js"
@@ -80,7 +84,8 @@
     "@opentelemetry/sdk-metrics": "^2.1.0",
     "@opentelemetry/sdk-trace-base": "^2.5.0",
     "llamaindex": "^0.12.1",
-    "openai": "^6.27.0"
+    "openai": "^6.27.0",
+    "yaml": "^2.8.3"
   },
   "peerDependencies": {
     "@strands-agents/sdk": "^1.0.0-rc.5"

--- a/js/scripts/check-js-dependency-pinning.mjs
+++ b/js/scripts/check-js-dependency-pinning.mjs
@@ -15,6 +15,7 @@ const publishedManifests = [
 ];
 const privateManifests = [
   "package.json",
+  "examples/experiments/typescript/package.json",
   "examples/getting-started/typescript/package.json",
   "examples/getting-started/typescript-hooks/package.json",
   "examples/getting-started/typescript-strands/package.json",

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -67,6 +67,7 @@ import type {
 } from './types.js';
 import {
   asError,
+  baseURLFromAPIEndpoint,
   cloneArtifact,
   cloneEmbeddingResult,
   cloneEmbeddingStart,
@@ -2189,30 +2190,8 @@ function normalizeConversationRatingInput(input: ConversationRatingInput): Conve
 }
 
 function buildConversationRatingEndpoint(endpoint: string, insecure: boolean, conversationId: string): string {
-  const baseURL = baseURLFromAPIEndpoint(endpoint, insecure);
+  const baseURL = baseURLFromAPIEndpoint(endpoint, insecure, 'agento11y conversation rating transport failed');
   return `${baseURL}/api/v1/conversations/${encodeURIComponent(conversationId)}/ratings`;
-}
-
-function baseURLFromAPIEndpoint(endpoint: string, insecure: boolean): string {
-  const trimmed = endpoint.trim();
-  if (trimmed.length === 0) {
-    throw new Error('agento11y conversation rating transport failed: api endpoint is required');
-  }
-
-  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
-    const parsed = new URL(trimmed);
-    // Preserve a path prefix so prefix-mounted Agent Observability deployments
-    // (https://host/sigil) route /api/v1/conversations/... under the prefix.
-    const path = parsed.pathname.replace(/\/+$/, '');
-    return `${parsed.protocol}//${parsed.host}${path}`;
-  }
-
-  const withoutScheme = trimmed.startsWith('grpc://') ? trimmed.slice('grpc://'.length) : trimmed;
-  const host = withoutScheme.split('/')[0]?.trim();
-  if (host === undefined || host.length === 0) {
-    throw new Error('agento11y conversation rating transport failed: api endpoint host is required');
-  }
-  return `${insecure ? 'http' : 'https'}://${host}`;
 }
 
 function parseSubmitConversationRatingResponse(payload: unknown): SubmitConversationRatingResponse {

--- a/js/src/config.ts
+++ b/js/src/config.ts
@@ -148,7 +148,7 @@ export function mergeConfig(
   };
 }
 
-function defaultEnv(): Record<string, string | undefined> {
+export function defaultEnv(): Record<string, string | undefined> {
   // Edge runtimes (for example Cloudflare Workers) may not define `process`.
   // Fall back to an empty env object so default config resolution stays safe.
   if (typeof process !== 'undefined' && process.env !== undefined) {
@@ -169,7 +169,7 @@ function envOverrides(env: Record<string, string | undefined>, logger: Agento11y
   if (protocol !== undefined)
     generationExport.protocol = protocol.value.toLowerCase() as GenerationExportConfig['protocol'];
   const insecure = envTrimmed(env, envInsecure);
-  if (insecure !== undefined) generationExport.insecure = parseBool(insecure.value);
+  if (insecure !== undefined) generationExport.insecure = parseTruthy(insecure.value);
   const headers = envTrimmed(env, envHeaders);
   if (headers !== undefined) generationExport.headers = parseCsvKv(headers.value);
 
@@ -219,7 +219,7 @@ function envOverrides(env: Record<string, string | undefined>, logger: Agento11y
     }
   }
   const debug = envTrimmed(env, envDebug);
-  if (debug !== undefined) out.debug = parseBool(debug.value);
+  if (debug !== undefined) out.debug = parseTruthy(debug.value);
 
   return out;
 }
@@ -284,7 +284,16 @@ export function envTrimmed(
   return undefined;
 }
 
-function parseBool(raw: string): boolean {
+/**
+ * Parses the SDK's accepted truthy spellings: `1`, `true`, `yes`, `on`, in any
+ * casing and with surrounding whitespace. Every other value, including an empty
+ * string, is false.
+ *
+ * Go (`ExperimentalFeaturesEnabled`) and Python (`_TRUTHY`) accept the same set.
+ * `redaction.ts` keeps its own list because it also has to tell a false value from
+ * a typo; every caller that only needs true or false uses this one.
+ */
+export function parseTruthy(raw: string): boolean {
   const v = raw.trim().toLowerCase();
   return v === '1' || v === 'true' || v === 'yes' || v === 'on';
 }
@@ -353,7 +362,7 @@ function mergeAuthConfig(config: ExportAuthConfig | undefined): ExportAuthConfig
 // rejecting cross-mode mixes only forced extra cleanup upstream. Callers who
 // want strict validation should check their AuthConfig before constructing
 // the client.
-function resolveHeadersWithAuth(
+export function resolveHeadersWithAuth(
   headers: Record<string, string> | undefined,
   auth: ExportAuthConfig,
   label: string,

--- a/js/src/experiments/client.ts
+++ b/js/src/experiments/client.ts
@@ -1,0 +1,688 @@
+import { defaultEnv, parseTruthy, resolveHeadersWithAuth } from '../config.js';
+import { redactSecretText, redactSecretValue } from '../redaction.js';
+import type { Agento11yLogger, TokenUsage } from '../types.js';
+import { baseURLFromAPIEndpoint } from '../utils.js';
+import { transportError, validationError } from './errors.js';
+import { FEATURE_CLOUD_TRIAL_EVALUATION, requireExperimental } from './experimental.js';
+import type {
+  CreateExperimentRequest,
+  Experiment,
+  ExperimentReport,
+  ExperimentStatus,
+  ScoreItem,
+  TrialEvaluation,
+} from './models.js';
+import {
+  isRecord,
+  normalizeCursor,
+  parseExperimentReport,
+  parseExperimentRunResponse,
+  parseExportScoresResponse,
+  parseTrialEvaluation,
+  str,
+} from './models.js';
+import * as routes from './routes.js';
+import {
+  EXPERIMENT_RUN_SOURCE,
+  putNonBlank,
+  serializeScore,
+  serializeUpsertRequest,
+  validateScore,
+} from './serialize.js';
+import type { ExperimentsConnection, ExperimentsRetryPolicy } from './transport.js';
+import { requestExperimentsJSON, sleepWithSignal, throwIfAborted } from './transport.js';
+
+/** Header that attributes an ingest write to the writing SDK. Python sends the same one. */
+export const INGEST_ACTOR_HEADER = 'X-Agento11y-Ingest-Actor';
+/** Default ingest actor for this SDK. Python sends `ingest:sdk/python`. */
+export const DEFAULT_INGEST_ACTOR = 'ingest:sdk/js';
+
+const ENV_ENDPOINT = 'AGENTO11Y_ENDPOINT';
+const ENV_AUTH_TOKEN = 'AGENTO11Y_AUTH_TOKEN';
+const ENV_AUTH_TENANT_ID = 'AGENTO11Y_AUTH_TENANT_ID';
+const ENV_INGEST_ACTOR = 'AGENTO11Y_INGEST_ACTOR';
+const ENV_GRAFANA_URL = 'AGENTO11Y_GRAFANA_URL';
+const ENV_USE_EXPERIMENTAL_OTEL = 'AGENTO11Y_USE_EXPERIMENTAL_OTEL';
+
+/** A client whose queued generations a trial flushes before starting an evaluation. */
+export interface FlushableGenerationClient {
+  flush(): Promise<void>;
+}
+
+export interface ExperimentsClientOptions {
+  /** Agent Observability endpoint. Falls back to `AGENTO11Y_ENDPOINT`. */
+  endpoint?: string;
+  /** Stack id. Falls back to `AGENTO11Y_AUTH_TENANT_ID`. Basic auth is used when set. */
+  tenantId?: string;
+  /** Cloud ingestion API key. Falls back to `AGENTO11Y_AUTH_TOKEN`. */
+  ingestToken?: string;
+  /** Ingest actor header value. Defaults to `ingest:sdk/js`. */
+  actor?: string;
+  /** Grafana base URL used to build experiment deep links. */
+  grafanaUrl?: string;
+  /** Per-attempt request timeout. */
+  timeoutMs?: number;
+  insecure?: boolean;
+  retry?: Partial<ExperimentsRetryPolicy>;
+  /** Redact known secret formats from scores, generations, and artifacts. Defaults to true. */
+  redactSecrets?: boolean;
+  /** Emit experimental trial spans and evaluation events. Falls back to `AGENTO11Y_USE_EXPERIMENTAL_OTEL`. */
+  useExperimentalOtel?: boolean;
+  /** An already-instrumented client whose generations a trial flushes before evaluating. */
+  coreClient?: FlushableGenerationClient;
+  fetchImpl?: typeof fetch;
+  /** Replaces every wait: transport backoff and evaluation poll delays. Test seam. */
+  sleep?: (durationMs: number, signal?: AbortSignal) => Promise<void>;
+  /** Replaces the monotonic clock the evaluation deadline reads. Test seam. */
+  now?: () => number;
+  env?: Record<string, string | undefined>;
+  logger?: Agento11yLogger;
+}
+
+export interface FinalizeExperimentOptions {
+  scoreCount?: number;
+  error?: string;
+}
+
+export interface UpsertTrialRequest {
+  trialId: string;
+  testCaseId: string;
+  attempt?: number;
+  status?: string;
+  conversationId?: string;
+  traceId?: string;
+  spanId?: string;
+  testCase?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface UpdateTrialRequest {
+  status?: string;
+  error?: string;
+  cost?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  durationMs?: number;
+  conversationId?: string;
+  traceId?: string;
+  spanId?: string;
+}
+
+export interface ExportGenerationRequest {
+  generationId: string;
+  conversationId?: string;
+  inputText?: string;
+  outputText?: string;
+  modelProvider?: string;
+  modelName?: string;
+  agentName?: string;
+  agentVersion?: string;
+  operationName?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  usage?: TokenUsage;
+  tags?: Record<string, string>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface UploadArtifactRequest {
+  experimentId: string;
+  /** The trial the artifact attaches to. */
+  parentId: string;
+  name: string;
+  kind: string;
+  content: Uint8Array;
+  mime?: string;
+  parentKind?: string;
+}
+
+export interface RequestOptions {
+  signal?: AbortSignal;
+}
+
+/**
+ * Connection and auth for experiment writes on a single ingest token.
+ *
+ * Every write (run upsert, trial upsert, score export, generation export,
+ * artifact upload, finalize) shares the tenant ingest credential. Stored test
+ * suites are the exception: they live behind the Grafana control plane and use
+ * `TestSuitesClient` with its own credential.
+ */
+export class ExperimentsClient {
+  readonly endpoint: string;
+  readonly tenantId: string;
+  readonly actor: string;
+  readonly grafanaUrl: string;
+  readonly redactSecrets: boolean;
+  readonly useExperimentalOtel: boolean;
+  /** The wait used by evaluation polling. Rejects with the signal's reason on abort. */
+  readonly sleepFn: (durationMs: number, signal?: AbortSignal) => Promise<void>;
+  /** The monotonic clock the evaluation deadline reads. */
+  readonly nowMs: () => number;
+
+  private readonly connection: ExperimentsConnection;
+  private readonly coreClient: FlushableGenerationClient | undefined;
+  private readonly logger: Agento11yLogger | undefined;
+
+  constructor(options: ExperimentsClientOptions = {}) {
+    const env = options.env ?? defaultEnv();
+    const endpoint = (options.endpoint ?? env[ENV_ENDPOINT] ?? '').trim();
+    if (endpoint.length === 0) {
+      throw new Error(
+        'agento11y experiments: endpoint is required; pass endpoint or set AGENTO11Y_ENDPOINT to your Grafana Cloud Agent Observability URL',
+      );
+    }
+    const ingestToken = (options.ingestToken ?? env[ENV_AUTH_TOKEN] ?? '').trim();
+    if (ingestToken.length === 0) {
+      throw new Error(
+        'agento11y experiments: ingestToken is required; pass ingestToken or set AGENTO11Y_AUTH_TOKEN to your Grafana Cloud ingestion API key',
+      );
+    }
+
+    this.endpoint = endpoint.replace(/\/+$/, '');
+    this.tenantId = (options.tenantId ?? env[ENV_AUTH_TENANT_ID] ?? '').trim();
+    // The backend derives the same identity from the run's sdk/js source. Sending
+    // it on every request also covers routes such as artifact upload, which
+    // cannot carry a JSON source object.
+    this.actor = (options.actor ?? env[ENV_INGEST_ACTOR] ?? '').trim() || DEFAULT_INGEST_ACTOR;
+    this.grafanaUrl = (options.grafanaUrl ?? env[ENV_GRAFANA_URL] ?? '').trim().replace(/\/+$/, '');
+    this.redactSecrets = options.redactSecrets ?? true;
+    this.useExperimentalOtel = options.useExperimentalOtel ?? parseTruthy(env[ENV_USE_EXPERIMENTAL_OTEL] ?? '');
+    this.coreClient = options.coreClient;
+    this.logger = options.logger;
+    this.sleepFn = options.sleep ?? sleepWithSignal;
+    this.nowMs = options.now ?? defaultMonotonicNow;
+
+    this.connection = {
+      endpoint: this.endpoint,
+      insecure: options.insecure ?? this.endpoint.startsWith('http://'),
+      headers: this.buildHeaders(ingestToken),
+      retry: { ...options.retry, ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}) },
+      ...(options.fetchImpl !== undefined ? { fetchImpl: options.fetchImpl } : {}),
+      ...(options.sleep !== undefined ? { sleep: options.sleep } : {}),
+    };
+  }
+
+  // --- experiment lifecycle ------------------------------------------------ //
+
+  /** Creates or idempotently claims an external run. */
+  async upsertExperiment(request: CreateExperimentRequest, options: RequestOptions = {}): Promise<Experiment> {
+    const body = await this.request(
+      {
+        method: 'POST',
+        path: routes.runUpsertPath(),
+        body: serializeUpsertRequest(request),
+        label: 'experiment create',
+      },
+      options,
+    );
+    return parseExperimentRunResponse(body);
+  }
+
+  /** Finalizes a run as `completed` or `failed`. */
+  async finalize(
+    experimentId: string,
+    status: ExperimentStatus | string = 'completed',
+    finalizeOptions: FinalizeExperimentOptions = {},
+    options: RequestOptions = {},
+  ): Promise<Experiment> {
+    // The backend's terminal success status is `completed`; `succeeded` is a
+    // friendly alias mapped onto the wire value the server validates.
+    let normalized = status.trim().toLowerCase();
+    if (normalized === 'succeeded' || normalized === 'completed') {
+      normalized = 'completed';
+    } else if (normalized !== 'failed') {
+      throw validationError('status must be completed or failed');
+    }
+    const runId = requireField(experimentId, 'run_id');
+    const payload: Record<string, unknown> = { status: normalized, source: { ...EXPERIMENT_RUN_SOURCE } };
+    if (finalizeOptions.scoreCount !== undefined) {
+      payload.score_count = finalizeOptions.scoreCount;
+    }
+    if (finalizeOptions.error !== undefined && finalizeOptions.error.length > 0) {
+      payload.error = finalizeOptions.error;
+    }
+    const body = await this.request(
+      { method: 'POST', path: routes.runFinalizePath(runId), body: payload, label: 'experiment finalize' },
+      options,
+    );
+    return parseExperimentRunResponse(body);
+  }
+
+  // --- trials -------------------------------------------------------------- //
+
+  /** Creates or idempotently upserts a typed trial under a run. */
+  async upsertTrial(
+    experimentId: string,
+    request: UpsertTrialRequest,
+    options: RequestOptions = {},
+  ): Promise<Record<string, unknown>> {
+    const runId = requireField(experimentId, 'experiment_id is required for trial create');
+    const payload: Record<string, unknown> = {
+      trial_id: requireField(request.trialId, 'trial_id'),
+      test_case_id: requireField(request.testCaseId, 'test_case_id'),
+      attempt: request.attempt ?? 1,
+      status: request.status ?? 'running',
+    };
+    putNonBlank(payload, 'conversation_id', request.conversationId);
+    putNonBlank(payload, 'trace_id', request.traceId);
+    putNonBlank(payload, 'span_id', request.spanId);
+    if (request.testCase !== undefined) {
+      payload.test_case = { ...request.testCase };
+    }
+    if (request.metadata !== undefined && Object.keys(request.metadata).length > 0) {
+      payload.metadata = { ...request.metadata };
+    }
+    const body = await this.request(
+      { method: 'POST', path: routes.trialsPath(runId), body: payload, label: 'test case trial create' },
+      options,
+    );
+    return isRecord(body) ? body : {};
+  }
+
+  /** Patches a typed trial's status, bindings, and usage rollups. */
+  async updateTrial(
+    experimentId: string,
+    trialId: string,
+    request: UpdateTrialRequest,
+    options: RequestOptions = {},
+  ): Promise<Record<string, unknown>> {
+    const runId = requireField(experimentId, 'experiment_id is required for trial update');
+    const normalizedTrialId = requireField(trialId, 'trial_id');
+    const payload: Record<string, unknown> = {};
+    putNonBlank(payload, 'status', request.status);
+    putNonBlank(payload, 'error', request.error);
+    if (request.cost !== undefined) {
+      payload.cost = request.cost;
+    }
+    if (request.inputTokens !== undefined) {
+      payload.input_tokens = Math.trunc(request.inputTokens);
+    }
+    if (request.outputTokens !== undefined) {
+      payload.output_tokens = Math.trunc(request.outputTokens);
+    }
+    if (request.durationMs !== undefined) {
+      payload.duration_ms = Math.trunc(request.durationMs);
+    }
+    putNonBlank(payload, 'conversation_id', request.conversationId);
+    putNonBlank(payload, 'trace_id', request.traceId);
+    putNonBlank(payload, 'span_id', request.spanId);
+    const body = await this.request(
+      {
+        method: 'PATCH',
+        path: routes.trialPath(runId, normalizedTrialId),
+        body: payload,
+        label: 'test case trial update',
+      },
+      options,
+    );
+    return isRecord(body) ? body : {};
+  }
+
+  /**
+   * Queues a stored evaluator for a trial's bound conversation.
+   *
+   * Experimental: requires `AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true`,
+   * otherwise it rejects with `ExperimentalFeatureDisabledError` without sending
+   * a request.
+   */
+  async triggerTrialEvaluation(
+    experimentId: string,
+    trialId: string,
+    evaluatorId: string,
+    evaluatorVersion = '',
+    options: RequestOptions = {},
+  ): Promise<TrialEvaluation> {
+    requireExperimental(FEATURE_CLOUD_TRIAL_EVALUATION);
+    const runId = requireTrialEvaluationField(experimentId, 'experiment_id');
+    const normalizedTrialId = requireTrialEvaluationField(trialId, 'trial_id');
+    const normalizedEvaluatorId = requireTrialEvaluationField(evaluatorId, 'evaluator_id');
+    const payload: Record<string, unknown> = { evaluator_id: normalizedEvaluatorId };
+    const version = evaluatorVersion.trim();
+    if (version.length > 0) {
+      payload.evaluator_version = version;
+    }
+    const body = await this.request(
+      {
+        method: 'POST',
+        path: routes.trialEvaluatePath(runId, normalizedTrialId),
+        body: payload,
+        label: 'trial evaluation trigger',
+      },
+      options,
+    );
+    return parseTrialEvaluation(body);
+  }
+
+  /**
+   * Reads durable status for a triggered trial evaluation.
+   *
+   * Experimental: requires `AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true`,
+   * otherwise it rejects with `ExperimentalFeatureDisabledError` without sending
+   * a request.
+   */
+  async getTrialEvaluation(
+    experimentId: string,
+    trialId: string,
+    evaluationId: string,
+    options: RequestOptions = {},
+  ): Promise<TrialEvaluation> {
+    requireExperimental(FEATURE_CLOUD_TRIAL_EVALUATION);
+    const runId = requireTrialEvaluationField(experimentId, 'experiment_id');
+    const normalizedTrialId = requireTrialEvaluationField(trialId, 'trial_id');
+    const normalizedEvaluationId = requireTrialEvaluationField(evaluationId, 'evaluation_id');
+    const body = await this.request(
+      {
+        method: 'GET',
+        path: routes.trialEvaluationPath(runId, normalizedTrialId, normalizedEvaluationId),
+        label: 'trial evaluation status',
+      },
+      options,
+    );
+    return parseTrialEvaluation(body);
+  }
+
+  // --- scores -------------------------------------------------------------- //
+
+  /**
+   * Exports scores and returns the count recorded, counting an idempotent
+   * duplicate as recorded. An empty list sends no request.
+   */
+  async exportScores(
+    scores: ScoreItem[],
+    exportOptions: { raiseOnReject?: boolean } = {},
+    options: RequestOptions = {},
+  ): Promise<number> {
+    if (scores.length === 0) {
+      return 0;
+    }
+    const prepared = scores.map((score) => (this.redactSecrets ? this.redactScore(score) : score));
+    for (const score of prepared) {
+      validateScore(score);
+    }
+    const body = await this.request(
+      {
+        method: 'POST',
+        path: routes.scoresExportPath(),
+        body: { scores: prepared.map(serializeScore) },
+        label: 'score export',
+      },
+      options,
+    );
+    const response = parseExportScoresResponse(body);
+    if ((exportOptions.raiseOnReject ?? true) && response.rejected.length > 0) {
+      const details = response.rejected
+        .map((result) => `${result.scoreId}: ${result.error.length > 0 ? result.error : 'rejected'}`)
+        .join('; ');
+      throw new Error(`agento11y score export rejected ${response.rejected.length} score(s): ${details}`);
+    }
+    return response.accepted + response.duplicates;
+  }
+
+  // --- generations --------------------------------------------------------- //
+
+  /**
+   * Exports one generation over the experiments transport.
+   *
+   * The response is checked, unlike `Agento11yClient.flush()`, which only warns.
+   * A trial that silently loses its anchor generation later fails evaluation with
+   * a confusing server-side "no conversation" error.
+   */
+  async exportGeneration(request: ExportGenerationRequest, options: RequestOptions = {}): Promise<string> {
+    const generationId = requireField(request.generationId, 'generation_id');
+    let generation: Record<string, unknown> = {
+      id: generationId,
+      operation_name:
+        request.operationName !== undefined && request.operationName.length > 0
+          ? request.operationName
+          : 'invoke_agent',
+      mode: 'GENERATION_MODE_SYNC',
+      model: {
+        provider:
+          request.modelProvider !== undefined && request.modelProvider.length > 0 ? request.modelProvider : 'eval',
+        name: request.modelName !== undefined && request.modelName.length > 0 ? request.modelName : 'experiment',
+      },
+    };
+    putNonBlank(generation, 'conversation_id', request.conversationId);
+    putNonBlank(generation, 'agent_name', request.agentName);
+    putNonBlank(generation, 'agent_version', request.agentVersion);
+    if (request.inputText !== undefined && request.inputText.length > 0) {
+      generation.input = [{ role: 'MESSAGE_ROLE_USER', parts: [{ text: request.inputText }] }];
+    }
+    if (request.outputText !== undefined && request.outputText.length > 0) {
+      generation.output = [{ role: 'MESSAGE_ROLE_ASSISTANT', parts: [{ text: request.outputText }] }];
+    }
+    if (request.tags !== undefined && Object.keys(request.tags).length > 0) {
+      generation.tags = { ...request.tags };
+    }
+    if (request.metadata !== undefined && Object.keys(request.metadata).length > 0) {
+      generation.metadata = { ...request.metadata };
+    }
+    const usage = normalizeUsage(
+      request.usage ?? { inputTokens: request.inputTokens ?? 0, outputTokens: request.outputTokens ?? 0 },
+    );
+    if (usage !== undefined) {
+      generation.usage = usage;
+    }
+    if (this.redactSecrets) {
+      generation = redactSecretValue(generation);
+    }
+
+    const body = await this.request(
+      {
+        method: 'POST',
+        path: routes.generationsExportPath(),
+        body: { generations: [generation] },
+        label: 'generation export',
+      },
+      options,
+    );
+    assertGenerationAccepted(body);
+    return generationId;
+  }
+
+  /** Alias for `exportGeneration`, matching Python's `record_generation`. */
+  async recordGeneration(request: ExportGenerationRequest, options: RequestOptions = {}): Promise<string> {
+    return this.exportGeneration(request, options);
+  }
+
+  /**
+   * Flushes an attached instrumented client, if one was supplied.
+   *
+   * The core client's `flush()` takes no signal, so an abort is honored before the
+   * flush starts rather than interrupting it.
+   */
+  async flushGenerations(options: RequestOptions = {}): Promise<void> {
+    throwIfAborted(options.signal);
+    await this.coreClient?.flush();
+  }
+
+  // --- artifacts ----------------------------------------------------------- //
+
+  /** Uploads artifact bytes and attaches them to a trial. */
+  async uploadArtifact(request: UploadArtifactRequest, options: RequestOptions = {}): Promise<Record<string, unknown>> {
+    if ((request.parentKind ?? 'test_case_trial') !== 'test_case_trial') {
+      throw validationError('only test_case_trial artifacts are supported by the experiments ingest client');
+    }
+    const runId = requireField(request.experimentId, 'experiment_id');
+    const trialId = requireField(request.parentId, 'trial_id');
+    const name = requireField(request.name, 'name');
+    const kind = requireField(request.kind, 'kind');
+    let content = request.content;
+    if (content.byteLength === 0) {
+      throw validationError('content is required');
+    }
+    const mime = (request.mime ?? '').trim();
+    if (this.redactSecrets && (['json', 'markdown', 'text', 'csv'].includes(kind) || mime.startsWith('text/'))) {
+      content = new TextEncoder().encode(redactSecretText(new TextDecoder().decode(content)));
+    }
+    const body = await this.request(
+      {
+        method: 'POST',
+        path: routes.trialArtifactUploadPath(runId, trialId),
+        query: { name, kind, mime },
+        bytes: content,
+        contentType: mime.length > 0 ? mime : 'application/octet-stream',
+        label: 'trial artifact upload',
+      },
+      options,
+    );
+    return isRecord(body) ? body : {};
+  }
+
+  // --- reads --------------------------------------------------------------- //
+
+  /** Fetches the aggregated report for a run. */
+  async getReport(experimentId: string, options: RequestOptions = {}): Promise<ExperimentReport> {
+    const runId = requireField(experimentId, 'run_id');
+    const body = await this.request(
+      { method: 'GET', path: routes.experimentReportPath(runId), label: 'experiment report' },
+      options,
+    );
+    return parseExperimentReport(body);
+  }
+
+  /** Lists stored scores for a run. */
+  async listScores(
+    experimentId: string,
+    listOptions: { limit?: number; cursor?: string } = {},
+    options: RequestOptions = {},
+  ): Promise<{ items: Record<string, unknown>[]; nextCursor?: string }> {
+    const runId = requireField(experimentId, 'run_id');
+    const limit = listOptions.limit !== undefined && listOptions.limit > 0 ? listOptions.limit : 50;
+    const query: Record<string, string> = { limit: String(limit) };
+    if (listOptions.cursor !== undefined && listOptions.cursor.trim().length > 0) {
+      query.cursor = listOptions.cursor.trim();
+    }
+    const body = await this.request(
+      { method: 'GET', path: routes.experimentScoresPath(runId), query, label: 'experiment scores list' },
+      options,
+    );
+    const items = isRecord(body) && Array.isArray(body.items) ? body.items.filter(isRecord) : [];
+    const nextCursor = normalizeCursor(isRecord(body) ? body.next_cursor : undefined);
+    return nextCursor !== undefined ? { items, nextCursor } : { items };
+  }
+
+  /** Best-effort deep link to the run in the Agent Observability UI. */
+  experimentUrl(experimentId: string): string {
+    const quoted = encodeURIComponent(experimentId.trim());
+    const base =
+      this.grafanaUrl.length > 0
+        ? this.grafanaUrl
+        : baseURLFromAPIEndpoint(this.endpoint, this.connection.insecure, 'agento11y experiments');
+    return `${base}/a/grafana-agento11y-app/experiments/runs/${quoted}`;
+  }
+
+  /** Flushes an attached instrumented client. Kept for symmetry with the core client. */
+  async shutdown(): Promise<void> {
+    await this.flushGenerations();
+  }
+
+  private async request(
+    request: Omit<Parameters<typeof requestExperimentsJSON>[1], 'signal'>,
+    options: RequestOptions,
+  ): Promise<unknown> {
+    return requestExperimentsJSON(this.connection, {
+      ...request,
+      ...(options.signal !== undefined ? { signal: options.signal } : {}),
+    });
+  }
+
+  private buildHeaders(ingestToken: string): Record<string, string> {
+    const headers =
+      this.tenantId.length > 0
+        ? resolveHeadersWithAuth(
+            undefined,
+            {
+              mode: 'basic',
+              tenantId: this.tenantId,
+              basicUser: this.tenantId,
+              basicPassword: ingestToken,
+            },
+            'agento11y experiments',
+          )
+        : resolveHeadersWithAuth(undefined, { mode: 'bearer', bearerToken: ingestToken }, 'agento11y experiments');
+    const out: Record<string, string> = { ...(headers ?? {}) };
+    if (this.actor.length > 0) {
+      out[INGEST_ACTOR_HEADER] = this.actor;
+    }
+    return out;
+  }
+
+  private redactScore(score: ScoreItem): ScoreItem {
+    const out: ScoreItem = { ...score, value: { ...score.value } };
+    if (out.value.string !== undefined) {
+      out.value.string = redactSecretText(out.value.string);
+    }
+    if (out.explanation !== undefined) {
+      out.explanation = redactSecretText(out.explanation);
+    }
+    if (out.metadata !== undefined) {
+      out.metadata = redactSecretValue(out.metadata);
+    }
+    return out;
+  }
+
+  /** Reports a non-fatal condition through the configured logger. */
+  warn(message: string): void {
+    this.logger?.warn?.(message);
+  }
+}
+
+function assertGenerationAccepted(body: unknown): void {
+  const results = isRecord(body) && Array.isArray(body.results) ? body.results : [];
+  const first = results[0];
+  if (!isRecord(first)) {
+    throw transportError('generation export: response did not include a result');
+  }
+  if (first.accepted === true) {
+    return;
+  }
+  const detail = str(first.error).length > 0 ? str(first.error) : 'rejected';
+  const normalized = detail.trim().toLowerCase();
+  // An idempotent retry of the same anchor generation is a success, not a loss.
+  if (normalized.includes('generation already exists') || normalized.includes('duplicate entry')) {
+    return;
+  }
+  throw transportError(`generation export rejected: ${detail}`);
+}
+
+function normalizeUsage(usage: TokenUsage): Record<string, number> | undefined {
+  const inputTokens = Math.max(0, Math.trunc(usage.inputTokens ?? 0));
+  const outputTokens = Math.max(0, Math.trunc(usage.outputTokens ?? 0));
+  const cacheReadInputTokens = Math.max(0, Math.trunc(usage.cacheReadInputTokens ?? 0));
+  const cacheWriteInputTokens = Math.max(0, Math.trunc(usage.cacheWriteInputTokens ?? 0));
+  const reasoningTokens = Math.max(0, Math.trunc(usage.reasoningTokens ?? 0));
+  const totalTokens = Math.max(0, Math.trunc(usage.totalTokens ?? 0)) || inputTokens + outputTokens;
+  if (totalTokens === 0) {
+    return undefined;
+  }
+  return {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    total_tokens: totalTokens,
+    cache_read_input_tokens: cacheReadInputTokens,
+    cache_write_input_tokens: cacheWriteInputTokens,
+    reasoning_tokens: reasoningTokens,
+  };
+}
+
+function requireField(value: string, name: string): string {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw validationError(name.includes(' ') ? name : `${name} is required`);
+  }
+  return normalized;
+}
+
+function requireTrialEvaluationField(value: string, name: string): string {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw new Error(`agento11y trial evaluation validation failed: ${name} is required`);
+  }
+  return normalized;
+}
+
+function defaultMonotonicNow(): number {
+  return typeof performance !== 'undefined' && typeof performance.now === 'function' ? performance.now() : Date.now();
+}

--- a/js/src/experiments/errors.ts
+++ b/js/src/experiments/errors.ts
@@ -1,0 +1,152 @@
+/**
+ * Error shapes for the experiments surface.
+ *
+ * The SDK convention is a stable message prefix acting as the sentinel, matching
+ * `submitConversationRating`. Only caller-actionable control flow gets a
+ * subclass: a disabled feature, a failed evaluation worker, a timeout, and a
+ * conflict whose kind decides whether the caller can retry.
+ */
+
+/** Prefix for a request the SDK rejected before sending it, and for HTTP 400/422. */
+export const VALIDATION_PREFIX = 'agento11y experiment validation failed';
+/** Prefix for HTTP 404. */
+export const NOT_FOUND_PREFIX = 'agento11y experiment not found';
+/** Prefix for HTTP 409. */
+export const CONFLICT_PREFIX = 'agento11y experiment conflict';
+/** Prefix for a transport failure, an unusable response, and an exhausted retry budget. */
+export const TRANSPORT_PREFIX = 'agento11y experiment transport failed';
+
+/** Stable categories for experiment and suite HTTP 409 responses. */
+export type ConflictKind =
+  | 'score_count_mismatch'
+  | 'running_trials'
+  | 'pending_evaluations'
+  | 'terminal'
+  | 'immutable_field'
+  | 'open_draft'
+  | 'unknown';
+
+/**
+ * Classifies backend conflict text so callers do not parse strings.
+ *
+ * Kept in sync with Python's `classify_conflict` and Go's `ClassifyConflict`.
+ */
+export function classifyConflict(message: string): ConflictKind {
+  const value = message.toLowerCase();
+  if (
+    value.includes('score_count') ||
+    value.includes('score count') ||
+    (value.includes('expected ') && value.includes(' scores, found '))
+  ) {
+    return 'score_count_mismatch';
+  }
+  if (value.includes('pending evaluation')) {
+    return 'pending_evaluations';
+  }
+  if (
+    value.includes('running trial') ||
+    value.includes('open trial') ||
+    (value.includes('cannot complete experiment with ') && value.includes(' trial'))
+  ) {
+    return 'running_trials';
+  }
+  if (
+    value.includes('terminal') ||
+    value.includes('already completed') ||
+    value.includes('already finalized') ||
+    value.includes('already published')
+  ) {
+    return 'terminal';
+  }
+  if (
+    value.includes('immutable') ||
+    value.includes('cannot change') ||
+    value.includes('conflicts with the existing experiment') ||
+    value.includes('not a draft')
+  ) {
+    return 'immutable_field';
+  }
+  if (value.includes('draft')) {
+    return 'open_draft';
+  }
+  return 'unknown';
+}
+
+/** A 409 whose classified kind tells the caller whether the state is recoverable. */
+export class ExperimentConflictError extends Error {
+  readonly kind: ConflictKind;
+
+  constructor(message: string, kind: ConflictKind) {
+    super(message);
+    this.name = 'ExperimentConflictError';
+    this.kind = kind;
+  }
+
+  /** Whether the conflict describes state a caller can wait out or correct. */
+  get recoverable(): boolean {
+    return (
+      this.kind === 'score_count_mismatch' ||
+      this.kind === 'running_trials' ||
+      this.kind === 'pending_evaluations' ||
+      this.kind === 'open_draft'
+    );
+  }
+}
+
+/**
+ * A stored evaluator ended a trial evaluation unsuccessfully. The evaluation keeps
+ * its row server-side, so triggering the same evaluator again requeues it.
+ */
+export class TrialEvaluationFailedError extends Error {
+  readonly evaluationId: string;
+  readonly detail: string;
+
+  constructor(evaluationId: string, detail: string) {
+    super(trialEvaluationMessage('failed', evaluationId, detail));
+    this.name = 'TrialEvaluationFailedError';
+    this.evaluationId = evaluationId.trim();
+    this.detail = detail.trim();
+  }
+}
+
+/**
+ * A trial evaluation did not reach a terminal status before the caller's
+ * deadline. The evaluation keeps running server-side.
+ */
+export class TrialEvaluationTimeoutError extends Error {
+  readonly evaluationId: string;
+  readonly detail: string;
+
+  constructor(evaluationId: string, detail: string) {
+    super(trialEvaluationMessage('timed out', evaluationId, detail));
+    this.name = 'TrialEvaluationTimeoutError';
+    this.evaluationId = evaluationId.trim();
+    this.detail = detail.trim();
+  }
+}
+
+/** Formats one trial evaluation error. A blank detail is dropped, not restated. */
+function trialEvaluationMessage(outcome: string, evaluationId: string, detail: string): string {
+  const id = evaluationId.trim().length > 0 ? evaluationId.trim() : 'unknown';
+  const normalizedDetail = detail.trim();
+  if (normalizedDetail.length === 0) {
+    return `agento11y trial evaluation ${id} ${outcome}`;
+  }
+  return `agento11y trial evaluation ${id} ${outcome}: ${normalizedDetail}`;
+}
+
+export function validationError(detail: string): Error {
+  return new Error(`${VALIDATION_PREFIX}: ${detail}`);
+}
+
+export function notFoundError(detail: string): Error {
+  return new Error(`${NOT_FOUND_PREFIX}: ${detail}`);
+}
+
+export function conflictError(detail: string): ExperimentConflictError {
+  return new ExperimentConflictError(`${CONFLICT_PREFIX}: ${detail}`, classifyConflict(detail));
+}
+
+export function transportError(detail: string): Error {
+  return new Error(`${TRANSPORT_PREFIX}: ${detail}`);
+}

--- a/js/src/experiments/evaluators.ts
+++ b/js/src/experiments/evaluators.ts
@@ -1,0 +1,461 @@
+import type { TokenUsage } from '../types.js';
+import type { Evaluator } from './models.js';
+
+export const DEFAULT_LLM_JUDGE_PROMPT = `Grade the candidate output against the input and expected result.
+
+Input:
+{input}
+
+Expected:
+{expected}
+
+Candidate output:
+{output}
+
+Return only JSON with this shape:
+{"score": <number from 0 to 1>, "passed": <boolean>, "explanation": "<brief reason>"}
+`;
+
+/** A grader request and response that can be published as a generation. */
+export interface GraderGeneration {
+  input: string;
+  output: string;
+  modelProvider: string;
+  modelName: string;
+  agentName?: string;
+  agentVersion?: string;
+  operationName?: string;
+  usage?: TokenUsage;
+}
+
+/** A local evaluator result ready to attach to a trial. */
+export interface EvaluationResult {
+  evaluator: Evaluator;
+  value: number | boolean | string;
+  passed: boolean;
+  explanation?: string;
+  scoreKey?: string;
+  metadata?: Record<string, unknown>;
+  grader?: GraderGeneration;
+}
+
+export interface EvaluateOutputInput {
+  input: unknown;
+  output: unknown;
+  expected?: unknown;
+}
+
+/** Evaluator that scores caller-supplied output without a platform definition. */
+export interface OutputEvaluator {
+  readonly evaluator: Evaluator;
+  evaluateOutput(input: EvaluateOutputInput): Promise<EvaluationResult> | EvaluationResult;
+}
+
+/** The parsed fields a judge response has to yield. */
+export interface ParsedJudgeResult {
+  score: number;
+  passed: boolean;
+  explanation: string;
+}
+
+export interface LLMJudgeOptions {
+  evaluatorId: string;
+  /** Receives the rendered prompt. May return a string or a provider response object. */
+  invoke: (prompt: string) => Promise<unknown> | unknown;
+  modelName: string;
+  promptTemplate?: string;
+  modelProvider?: string;
+  version?: string;
+  scoreKey?: string;
+  passThreshold?: number;
+  /** Replaces the default lenient JSON parsing. */
+  parser?: (raw: string) => ParsedJudgeResult;
+  /** Replaces the default token-usage extraction. */
+  usageExtractor?: (response: unknown) => TokenUsage | undefined;
+  agentName?: string;
+  agentVersion?: string;
+  operationName?: string;
+}
+
+/**
+ * Provider-neutral LLM judge with structured-result parsing.
+ *
+ * `invoke` receives the rendered prompt and may return a string or an object with
+ * a `content` field, which covers common provider and framework clients. No
+ * platform evaluator or control-plane credential is required.
+ */
+export class LLMJudge implements OutputEvaluator {
+  readonly evaluator: Evaluator;
+  readonly scoreKey: string;
+  readonly passThreshold: number;
+
+  private readonly invoke: (prompt: string) => Promise<unknown> | unknown;
+  private readonly modelName: string;
+  private readonly modelProvider: string;
+  private readonly promptTemplate: string;
+  private readonly parser: ((raw: string) => ParsedJudgeResult) | undefined;
+  private readonly usageExtractor: ((response: unknown) => TokenUsage | undefined) | undefined;
+  private readonly agentName: string;
+  private readonly agentVersion: string;
+  private readonly operationName: string;
+
+  constructor(options: LLMJudgeOptions) {
+    if (options.evaluatorId.trim().length === 0) {
+      throw new Error('evaluatorId is required');
+    }
+    if (typeof options.invoke !== 'function') {
+      throw new Error('invoke must be callable');
+    }
+    if (options.modelName.trim().length === 0) {
+      throw new Error('modelName is required');
+    }
+    const promptTemplate = options.promptTemplate ?? DEFAULT_LLM_JUDGE_PROMPT;
+    if (promptTemplate.trim().length === 0) {
+      throw new Error('promptTemplate is required');
+    }
+    const passThreshold = options.passThreshold ?? 0.5;
+    if (!(passThreshold >= 0 && passThreshold <= 1)) {
+      throw new Error('passThreshold must be between 0 and 1');
+    }
+    const version = options.version ?? '1';
+    this.evaluator = { evaluatorId: options.evaluatorId, version, kind: 'llm_judge' };
+    this.invoke = options.invoke;
+    this.modelName = options.modelName;
+    this.modelProvider = options.modelProvider ?? '';
+    this.promptTemplate = promptTemplate;
+    this.scoreKey = options.scoreKey ?? 'final';
+    this.passThreshold = passThreshold;
+    this.parser = options.parser;
+    this.usageExtractor = options.usageExtractor;
+    this.agentName = options.agentName ?? 'agento11y-llm-judge';
+    this.agentVersion = options.agentVersion ?? version;
+    this.operationName = options.operationName ?? 'llm-judge';
+  }
+
+  /** Grades explicit input and output values; it does not fetch a conversation. */
+  async evaluateOutput(input: EvaluateOutputInput): Promise<EvaluationResult> {
+    const prompt = renderPrompt(this.promptTemplate, input);
+    const response = await this.invoke(prompt);
+    const raw = responseText(response);
+    const usage = this.usageExtractor !== undefined ? this.usageExtractor(response) : responseUsage(response);
+    const parsed = this.parser !== undefined ? this.parser(raw) : this.parseDefault(raw);
+    const metadata: Record<string, unknown> = { judge_model: this.modelName };
+    if (this.modelProvider.length > 0) {
+      metadata.judge_provider = this.modelProvider;
+    }
+    return {
+      evaluator: this.evaluator,
+      value: parsed.score,
+      passed: parsed.passed,
+      explanation: parsed.explanation,
+      scoreKey: this.scoreKey,
+      metadata,
+      grader: {
+        input: prompt,
+        output: raw,
+        modelProvider: this.modelProvider,
+        modelName: this.modelName,
+        agentName: this.agentName,
+        agentVersion: this.agentVersion,
+        operationName: this.operationName,
+        ...(usage !== undefined ? { usage } : {}),
+      },
+    };
+  }
+
+  /**
+   * Reads the last JSON object in the response that carries a numeric `score`.
+   *
+   * Judges tend to narrate before the verdict, so unrelated leading JSON is
+   * skipped and the last scored object wins. A nested rubric score never replaces
+   * a top-level one, because the top-level object is the outermost match.
+   */
+  private parseDefault(raw: string): ParsedJudgeResult {
+    const objects = jsonObjects(raw);
+    if (objects.length === 0) {
+      throw new Error('LLM judge response did not contain a JSON object');
+    }
+    for (let index = objects.length - 1; index >= 0; index--) {
+      const payload = objects[index];
+      if (payload === undefined) {
+        continue;
+      }
+      const rawScore = payload.score;
+      const numeric = typeof rawScore === 'number' ? rawScore : Number(rawScore);
+      if (rawScore === undefined || rawScore === null || typeof rawScore === 'boolean' || !Number.isFinite(numeric)) {
+        continue;
+      }
+      const score = Math.max(0, Math.min(1, numeric));
+      const passed = parsePassed(payload.passed ?? payload.pass, score, this.passThreshold);
+      const explanation = String(payload.explanation ?? payload.reason ?? '').trim();
+      return { score, passed, explanation };
+    }
+    throw new Error("LLM judge response requires a numeric 'score'");
+  }
+}
+
+export interface RegexJudgeOptions {
+  evaluatorId: string;
+  pattern: string;
+  version?: string;
+  scoreKey?: string;
+  flags?: string;
+  fullMatch?: boolean;
+  negate?: boolean;
+  explanation?: string;
+}
+
+/** Deterministic regular-expression evaluator for candidate output. */
+export class RegexJudge implements OutputEvaluator {
+  readonly evaluator: Evaluator;
+  readonly scoreKey: string;
+
+  private readonly pattern: string;
+  private readonly compiled: RegExp;
+  private readonly fullMatch: boolean;
+  private readonly negate: boolean;
+  private readonly explanationOverride: string;
+
+  constructor(options: RegexJudgeOptions) {
+    if (options.evaluatorId.trim().length === 0) {
+      throw new Error('evaluatorId is required');
+    }
+    if (options.pattern.length === 0) {
+      throw new Error('pattern is required');
+    }
+    this.pattern = options.pattern;
+    this.fullMatch = options.fullMatch ?? false;
+    // Anchoring and the flag set are both fixed here, so the regex is compiled once
+    // and reused for every evaluation, as Python's copy does. `g` is dropped
+    // because `test` on a global regex advances `lastIndex` between calls.
+    const source = this.fullMatch ? `^(?:${options.pattern})$` : options.pattern;
+    this.compiled = new RegExp(source, (options.flags ?? '').replace(/g/g, ''));
+    this.negate = options.negate ?? false;
+    this.explanationOverride = options.explanation ?? '';
+    this.scoreKey = options.scoreKey ?? 'regex_match';
+    this.evaluator = {
+      evaluatorId: options.evaluatorId,
+      version: options.version ?? '1',
+      kind: 'deterministic',
+    };
+  }
+
+  evaluateOutput(input: EvaluateOutputInput): EvaluationResult {
+    const text = String(input.output);
+    const matched = this.compiled.test(text);
+    const passed = this.negate ? !matched : matched;
+    const explanation =
+      this.explanationOverride.length > 0
+        ? this.explanationOverride
+        : passed
+          ? `output ${this.negate ? 'did not match' : 'matched'} /${this.pattern}/`
+          : `output ${this.negate ? 'matched excluded' : 'did not match'} /${this.pattern}/`;
+    return {
+      evaluator: this.evaluator,
+      value: passed,
+      passed,
+      explanation,
+      scoreKey: this.scoreKey,
+      metadata: { pattern: this.pattern },
+    };
+  }
+}
+
+/** Replaces judge placeholders without treating JSON braces as formatting. */
+function renderPrompt(template: string, values: EvaluateOutputInput): string {
+  const replacements: Record<string, string> = {
+    input: String(values.input),
+    output: String(values.output),
+    expected: String(values.expected),
+  };
+  return template.replace(/\{(input|output|expected)\}/g, (_match, key: string) => replacements[key] ?? '');
+}
+
+function responseText(response: unknown): string {
+  const nested = field(response, 'content');
+  const content = nested !== undefined ? nested : response;
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const item of content) {
+      if (typeof item === 'string') {
+        parts.push(item);
+      } else if (isRecordLike(item) && typeof (item as { text?: unknown }).text === 'string') {
+        parts.push((item as { text: string }).text);
+      }
+    }
+    if (parts.length > 0) {
+      return parts.join('');
+    }
+  }
+  if (isRecordLike(content)) {
+    return JSON.stringify(content);
+  }
+  return String(content);
+}
+
+/** Extracts common SDK and framework token-usage shapes without owning them. */
+function responseUsage(response: unknown): TokenUsage | undefined {
+  const responseMetadata = field(response, 'response_metadata') ?? field(response, 'responseMetadata');
+  const candidates = [
+    field(response, 'usage_metadata') ?? field(response, 'usageMetadata'),
+    field(response, 'usage'),
+    field(responseMetadata, 'usage'),
+    field(responseMetadata, 'token_usage') ?? field(responseMetadata, 'tokenUsage'),
+  ];
+  for (const candidate of candidates) {
+    if (candidate === undefined || candidate === null) {
+      continue;
+    }
+    const inputDetails = field(candidate, 'input_token_details') ?? field(candidate, 'inputTokenDetails');
+    const outputDetails = field(candidate, 'output_token_details') ?? field(candidate, 'outputTokenDetails');
+    const usage: TokenUsage = {
+      inputTokens: firstInt(candidate, 'input_tokens', 'inputTokens', 'prompt_tokens', 'promptTokens'),
+      outputTokens: firstInt(candidate, 'output_tokens', 'outputTokens', 'completion_tokens', 'completionTokens'),
+      totalTokens: firstInt(candidate, 'total_tokens', 'totalTokens'),
+      cacheReadInputTokens:
+        firstInt(candidate, 'cache_read_input_tokens', 'cacheReadInputTokens', 'cache_read_tokens') ??
+        firstInt(inputDetails, 'cache_read', 'cache_read_tokens'),
+      // The field is cache_write_input_tokens, never cache_creation_input_tokens;
+      // the provider spellings below are only read, not emitted.
+      cacheWriteInputTokens:
+        firstInt(
+          candidate,
+          'cache_write_input_tokens',
+          'cacheWriteInputTokens',
+          'cache_creation_input_tokens',
+          'cache_creation_tokens',
+        ) ?? firstInt(inputDetails, 'cache_write', 'cache_creation', 'cache_creation_tokens'),
+      reasoningTokens:
+        firstInt(candidate, 'reasoning_tokens', 'reasoningTokens') ??
+        firstInt(outputDetails, 'reasoning', 'reasoning_tokens'),
+    };
+    if (Object.values(usage).some((value) => value !== undefined)) {
+      return normalizeUsage(usage);
+    }
+  }
+  return undefined;
+}
+
+function normalizeUsage(usage: TokenUsage): TokenUsage {
+  const inputTokens = usage.inputTokens ?? 0;
+  const outputTokens = usage.outputTokens ?? 0;
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens:
+      usage.totalTokens !== undefined && usage.totalTokens > 0 ? usage.totalTokens : inputTokens + outputTokens,
+    cacheReadInputTokens: usage.cacheReadInputTokens ?? 0,
+    cacheWriteInputTokens: usage.cacheWriteInputTokens ?? 0,
+    reasoningTokens: usage.reasoningTokens ?? 0,
+  };
+}
+
+/**
+ * Extracts complete JSON objects without merging unrelated brace ranges.
+ *
+ * A judge that emits two objects, or prose containing braces, would otherwise
+ * produce one unparseable slice.
+ */
+export function jsonObjects(raw: string): Record<string, unknown>[] {
+  const objects: Record<string, unknown>[] = [];
+  let cursor = 0;
+  while (cursor < raw.length) {
+    const start = raw.indexOf('{', cursor);
+    if (start < 0) {
+      break;
+    }
+    const end = matchingBrace(raw, start);
+    if (end < 0) {
+      cursor = start + 1;
+      continue;
+    }
+    try {
+      const value = JSON.parse(raw.slice(start, end + 1));
+      if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+        objects.push(value as Record<string, unknown>);
+      }
+      cursor = end + 1;
+    } catch {
+      cursor = start + 1;
+    }
+  }
+  return objects;
+}
+
+/** Finds the brace closing the object at `start`, skipping braces inside strings. */
+function matchingBrace(raw: string, start: number): number {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = start; index < raw.length; index++) {
+    const char = raw[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+    } else if (char === '{') {
+      depth++;
+    } else if (char === '}') {
+      depth--;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  return -1;
+}
+
+function parsePassed(value: unknown, score: number, threshold: number): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['true', 'yes', '1', 'pass', 'passed'].includes(normalized)) {
+      return true;
+    }
+    if (['false', 'no', '0', 'fail', 'failed'].includes(normalized)) {
+      return false;
+    }
+  }
+  return score >= threshold;
+}
+
+function field(value: unknown, name: string): unknown {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'object') {
+    return (value as Record<string, unknown>)[name];
+  }
+  return undefined;
+}
+
+function firstInt(value: unknown, ...names: string[]): number | undefined {
+  for (const name of names) {
+    const raw = field(value, name);
+    if (raw === undefined || raw === null || typeof raw === 'boolean') {
+      continue;
+    }
+    const parsed = typeof raw === 'number' ? Math.trunc(raw) : Number.parseInt(String(raw), 10);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+function isRecordLike(value: unknown): boolean {
+  return typeof value === 'object' && value !== null;
+}

--- a/js/src/experiments/experiment.ts
+++ b/js/src/experiments/experiment.ts
@@ -1,0 +1,1400 @@
+import {
+  isSpanContextValid,
+  context as otelContext,
+  type Span,
+  SpanKind,
+  SpanStatusCode,
+  trace,
+} from '@opentelemetry/api';
+import { redactSecretText } from '../redaction.js';
+import { asError } from '../utils.js';
+import type { ExperimentsClient } from './client.js';
+import { TrialEvaluationFailedError, TrialEvaluationTimeoutError, validationError } from './errors.js';
+import type { EvaluationResult, OutputEvaluator } from './evaluators.js';
+import { FEATURE_CLOUD_TRIAL_EVALUATION, requireExperimental } from './experimental.js';
+import { stableId } from './ids.js';
+import type {
+  Candidate,
+  Evaluator,
+  ExperimentReport,
+  ExperimentStatus,
+  ScoreItem,
+  ScoreValue,
+  TrialEvaluation,
+  TrialStatus,
+} from './models.js';
+import { normalizeEvaluatorKind } from './models.js';
+import * as otel from './otel.js';
+import { throwIfAborted } from './transport.js';
+import type { TestCase, TestSuite, TrialRef } from './types.js';
+import { candidateMetadata, suiteCase } from './types.js';
+
+/** Ceiling for `Trial.evaluate`'s poll backoff. Each status read costs an ingest call. */
+const MAX_EVALUATION_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_EVALUATION_TIMEOUT_MS = 300_000;
+const DEFAULT_EVALUATION_POLL_INTERVAL_MS = 500;
+
+const DEFAULT_EVALUATOR: Evaluator = { evaluatorId: 'sdk', version: '0' };
+
+export interface ExperimentOptions {
+  experimentId?: string;
+  name?: string;
+  suite?: TestSuite;
+  candidate?: Candidate;
+  defaultEvaluator?: Evaluator;
+  description?: string;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+  plannedTrialCount?: number;
+  useExperimentalOtel?: boolean;
+}
+
+export interface TrialOptions {
+  attempt?: number;
+  trajectoryId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface FinalizeOptions {
+  error?: string;
+  /**
+   * Asserts how many scores the run stored. Leave it unset unless a distributed
+   * runner knows the total: Agent Observability checks it against every score
+   * stored for the run, including ones a stored evaluator wrote through
+   * `Trial.evaluate`. `finalize` drops the count once a trial of this experiment
+   * queued an evaluation in this process; a runner that evaluates elsewhere has to
+   * leave it unset itself.
+   */
+  scoreCount?: number;
+}
+
+export interface EvaluateOptions {
+  evaluatorVersion?: string;
+  /** Bounds the polling loop, not the whole call. Defaults to 300000. */
+  timeoutMs?: number;
+  /** First poll delay, doubling to a 5000 ms ceiling. Defaults to 500. */
+  pollIntervalMs?: number;
+  /** Aborts the wait; the signal's own reason is rethrown unchanged. */
+  signal?: AbortSignal;
+}
+
+export interface RecordIOOptions {
+  input?: unknown;
+  output?: unknown;
+  modelProvider?: string;
+  modelName?: string;
+  agentName?: string;
+  agentVersion?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+export interface ScoreOptions {
+  evaluator?: Evaluator;
+  passed?: boolean;
+  explanation?: string;
+  generationId?: string;
+  graderConversationId?: string;
+  graderGenerationId?: string;
+  graderTraceId?: string;
+  metadata?: Record<string, unknown>;
+  /** Internal: reuses an id already minted by `recordEvaluation`. */
+  scoreId?: string;
+}
+
+export interface ArtifactOptions {
+  data?: unknown;
+  text?: string;
+  bytes?: Uint8Array;
+  kind?: string;
+  mime?: string;
+}
+
+/**
+ * One attempt at one test case: records scores and, when experimental OTel is on,
+ * emits a trial span with `gen_ai.evaluation.result` events.
+ *
+ * Scores buffer locally and export on `flush()` or `close()`. Open a trial with
+ * `experiment.trial(...)` then `await trial.start()`, or let
+ * `experiment.withTrial(...)` do both and close it on either path.
+ */
+export class Trial {
+  readonly ref: TrialRef;
+  readonly trialId: string;
+
+  status: TrialStatus = 'running';
+  conversationId = '';
+  traceId = '';
+  spanId = '';
+  error = '';
+  readonly artifacts: { name: string; kind: string; artifactId: string }[] = [];
+
+  private readonly client: ExperimentsClient;
+  private readonly experiment: Experiment | undefined;
+  private readonly testCase: TestCase | undefined;
+  private readonly candidate: Candidate | undefined;
+  private readonly defaultEvaluator: Evaluator;
+  private readonly metadata: Record<string, unknown>;
+  private readonly useExperimentalOtel: boolean;
+
+  /** Derived at construction, replaced by `bindGeneration`. Read through `generationId`. */
+  private anchorGenerationId: string;
+  private buffer: ScoreItem[] = [];
+  private accepted = 0;
+  private hasFinal = false;
+  private finalPassed: boolean | undefined;
+  private cloudEvaluated = false;
+  private closed = false;
+  private trialCreated = false;
+  private generationExported = false;
+  private hasGeneration = false;
+  private io: Record<string, unknown> = {};
+  private usage: { inputTokens?: number; outputTokens?: number; cost?: number } = {};
+  private startedAtMs: number | undefined;
+  private scoreOccurrences = new Map<string, number>();
+  private span: Span | undefined;
+
+  constructor(
+    client: ExperimentsClient,
+    ref: TrialRef,
+    options: {
+      experiment?: Experiment;
+      testCase?: TestCase;
+      candidate?: Candidate;
+      defaultEvaluator?: Evaluator;
+      metadata?: Record<string, unknown>;
+      useExperimentalOtel?: boolean;
+    } = {},
+  ) {
+    this.client = client;
+    this.ref = ref;
+    this.experiment = options.experiment;
+    this.testCase = options.testCase;
+    this.candidate = options.candidate;
+    this.defaultEvaluator = options.defaultEvaluator ?? DEFAULT_EVALUATOR;
+    this.metadata = { ...(options.metadata ?? {}) };
+    this.useExperimentalOtel = options.useExperimentalOtel ?? client.useExperimentalOtel;
+    this.trialId = stableId('trial', ref.experimentId, ref.testCaseId, ref.attempt);
+    // Scores attach to the typed trial; a generation is optional, exported only
+    // when the harness binds one or supplies I/O through recordIO.
+    this.anchorGenerationId = stableId('gen', ref.experimentId, ref.testCaseId, ref.attempt);
+  }
+
+  /** The generation this trial's scores attach to: derived, or the bound one. */
+  get generationId(): string {
+    return this.anchorGenerationId;
+  }
+
+  /** Opens a standalone trial bound to `client`, with no parent experiment. */
+  static fromRef(
+    client: ExperimentsClient,
+    ref: TrialRef | undefined,
+    options: {
+      candidate?: Candidate;
+      defaultEvaluator?: Evaluator;
+      useExperimentalOtel?: boolean;
+    } = {},
+  ): Trial {
+    if (ref === undefined) {
+      throw new Error('trial ref is required; set AGENTO11Y_EXPERIMENT_ID and AGENTO11Y_TEST_CASE_ID');
+    }
+    return new Trial(client, ref, options);
+  }
+
+  /** Creates the typed trial server-side and starts the optional trial span. */
+  async start(): Promise<Trial> {
+    if (this.closed) {
+      throw new Error('cannot start a closed trial');
+    }
+    this.startedAtMs = this.client.nowMs();
+    this.startSpan();
+    await this.createTrial();
+    return this;
+  }
+
+  /**
+   * Runs `fn` with this trial's span active, so generations an instrumented agent
+   * emits inside it join the trial's trace.
+   *
+   * `withTrial` wraps the callback in this. A caller driving `start()` and
+   * `close()` by hand wraps its own agent call. Without the trial span (the
+   * default, since spans are experimental) this only calls `fn`.
+   */
+  async runInTrialContext<T>(fn: () => Promise<T> | T): Promise<T> {
+    const span = this.span;
+    if (span === undefined) {
+      return fn();
+    }
+    return otelContext.with(trace.setSpan(otelContext.active(), span), fn);
+  }
+
+  // --- binding ------------------------------------------------------------- //
+
+  /** Links this trial's scores to a specific conversation. */
+  bindConversation(conversationId: string): Trial {
+    this.conversationId = conversationId.trim();
+    return this;
+  }
+
+  /** Links this trial's scores to a trace produced elsewhere. */
+  async bindTrace(traceId: string, spanId = ''): Promise<Trial> {
+    this.traceId = traceId.trim();
+    this.spanId = spanId.trim();
+    if (this.trialCreated) {
+      await this.client.updateTrial(this.ref.experimentId, this.trialId, {
+        traceId: this.traceId,
+        spanId: this.spanId,
+      });
+    }
+    return this;
+  }
+
+  /**
+   * Attaches this trial's scores to a generation the harness already exported.
+   * The trial then records no anchor generation of its own.
+   */
+  bindGeneration(generationId: string, options: { conversationId?: string } = {}): Trial {
+    const id = generationId.trim();
+    if (id.length > 0) {
+      // The bound id replaces the derived one for every score this trial writes,
+      // and the harness already exported it, so this trial exports nothing.
+      this.anchorGenerationId = id;
+      this.generationExported = true;
+      this.hasGeneration = true;
+    }
+    if (options.conversationId !== undefined && options.conversationId.length > 0) {
+      this.conversationId = options.conversationId.trim();
+    }
+    return this;
+  }
+
+  /**
+   * Records the attempt's input and output for the anchor generation.
+   *
+   * Stored now and exported as one generation when scores flush, so the attempt's
+   * conversation is visible in Agent Observability and the scores attach to it.
+   */
+  recordIO(options: RecordIOOptions): Trial {
+    this.hasGeneration = true;
+    // A real generation will back this trial; mint a conversation id if unbound.
+    if (this.conversationId.length === 0) {
+      this.conversationId = stableId('conv', this.ref.experimentId, this.ref.testCaseId, this.ref.attempt);
+    }
+    if (options.input !== undefined) {
+      this.io.inputText = typeof options.input === 'string' ? options.input : String(options.input);
+    }
+    if (options.output !== undefined) {
+      this.io.outputText = typeof options.output === 'string' ? options.output : String(options.output);
+    }
+    for (const [key, value] of [
+      ['modelProvider', options.modelProvider],
+      ['modelName', options.modelName],
+      ['agentName', options.agentName],
+      ['agentVersion', options.agentVersion],
+    ] as const) {
+      if (value !== undefined && value.length > 0) {
+        this.io[key] = value;
+      }
+    }
+    if (options.inputTokens !== undefined) {
+      this.io.inputTokens = Math.trunc(options.inputTokens);
+    }
+    if (options.outputTokens !== undefined) {
+      this.io.outputTokens = Math.trunc(options.outputTokens);
+    }
+    return this;
+  }
+
+  /**
+   * Records token usage and an optional cost override.
+   *
+   * Tokens go on the span as the standard `gen_ai.usage.*` signal. `cost` is an
+   * optional USD override: when omitted, Agent Observability derives cost at
+   * ingestion from token usage and model-card pricing. Pass `cost` only when a
+   * framework computes it itself; leave it unset rather than passing `0`.
+   */
+  setUsage(options: { inputTokens?: number; outputTokens?: number; cost?: number }): Trial {
+    if (options.inputTokens !== undefined) {
+      this.usage.inputTokens = Math.trunc(options.inputTokens);
+      this.span?.setAttribute('gen_ai.usage.input_tokens', Math.trunc(options.inputTokens));
+    }
+    if (options.outputTokens !== undefined) {
+      this.usage.outputTokens = Math.trunc(options.outputTokens);
+      this.span?.setAttribute('gen_ai.usage.output_tokens', Math.trunc(options.outputTokens));
+    }
+    if (options.cost !== undefined) {
+      this.usage.cost = options.cost;
+    }
+    return this;
+  }
+
+  // --- scoring ------------------------------------------------------------- //
+
+  /** Records a score for this trial. The general primitive. */
+  score(scoreKey: string, value: ScoreValue | number | boolean | string, options: ScoreOptions = {}): ScoreItem {
+    const evaluator = options.evaluator ?? this.defaultEvaluator;
+    const scoreValue = coerceValue(value);
+    let passed = options.passed;
+    if (scoreKey === 'final' && passed === undefined) {
+      passed = inferFinalPassed(scoreValue);
+    }
+    const scoreId =
+      options.scoreId !== undefined && options.scoreId.length > 0
+        ? options.scoreId
+        : this.nextScoreId(scoreKey, evaluator.evaluatorId);
+    const item: ScoreItem = {
+      scoreId,
+      evaluatorId: evaluator.evaluatorId,
+      evaluatorVersion: evaluator.version ?? '0',
+      evaluatorKind: normalizeEvaluatorKind(evaluator.kind ?? 'custom'),
+      scoreKey,
+      value: scoreValue,
+      // generation_id only when one exists; trial_id is what attributes the score.
+      generationId: options.generationId ?? (this.hasGeneration ? this.generationId : ''),
+      trialId: this.trialId,
+      conversationId: this.conversationId,
+      traceId: this.traceId,
+      spanId: this.spanId,
+      experimentId: this.ref.experimentId,
+      testCaseId: this.ref.testCaseId,
+      graderConversationId: options.graderConversationId ?? '',
+      graderGenerationId: options.graderGenerationId ?? '',
+      graderTraceId: options.graderTraceId ?? '',
+      ...(passed !== undefined ? { passed } : {}),
+      explanation: options.explanation ?? '',
+      metadata: {
+        task_id: this.ref.testCaseId,
+        trial_id: this.trialId,
+        attempt: this.ref.attempt,
+        ...this.metadata,
+        ...(options.metadata ?? {}),
+      },
+      source: { kind: 'experiment', id: this.ref.experimentId },
+    };
+    this.buffer.push(item);
+    this.emitScoreEvent(scoreKey, scoreValue, evaluator, passed, options.explanation ?? '', options.generationId ?? '');
+    if (scoreKey === 'final') {
+      this.hasFinal = true;
+      this.finalPassed = passed;
+    }
+    return item;
+  }
+
+  /**
+   * The headline score and trial verdict (`scoreKey: "final"`).
+   *
+   * `passed` is the verdict the report rollup uses. When omitted and `value` is
+   * boolean, the boolean is the verdict.
+   */
+  finalScore(value: ScoreValue | number | boolean | string, options: Omit<ScoreOptions, 'scoreId'> = {}): ScoreItem {
+    // `score` infers the verdict for the `final` key, so the rule lives there only.
+    return this.score('final', value, options);
+  }
+
+  /** A deterministic check, for example `json_valid` or `tool_used`. */
+  checkScore(
+    name: string,
+    options: { passed: boolean; value?: ScoreValue | number | boolean | string } & Omit<
+      ScoreOptions,
+      'passed' | 'scoreId'
+    >,
+  ): ScoreItem {
+    const evaluator =
+      options.evaluator ??
+      ({
+        evaluatorId: `${this.defaultEvaluator.evaluatorId}.${name}`,
+        version: this.defaultEvaluator.version ?? '0',
+        kind: 'deterministic',
+      } satisfies Evaluator);
+    return this.score(name, options.value ?? options.passed, { ...options, evaluator });
+  }
+
+  /** An LLM-judge rubric criterion score. */
+  rubricScore(
+    name: string,
+    value: ScoreValue | number | boolean | string,
+    options: Omit<ScoreOptions, 'scoreId'> = {},
+  ): ScoreItem {
+    const evaluator =
+      options.evaluator ??
+      ({
+        evaluatorId: `${this.defaultEvaluator.evaluatorId}.${name}`,
+        version: this.defaultEvaluator.version ?? '0',
+        kind: 'llm_judge',
+      } satisfies Evaluator);
+    return this.score(name, value, { ...options, evaluator });
+  }
+
+  /**
+   * Records an evaluation produced by a runner, framework, or helper.
+   *
+   * When the result carries a grader generation, it is published and linked to the
+   * score. Agent Observability does not fetch or normalize the evaluated
+   * conversation; callers bind its existing trace and conversation identifiers.
+   */
+  async recordEvaluation(
+    result: EvaluationResult,
+    options: { scoreKey?: string; publishGrader?: boolean; metadata?: Record<string, unknown> } = {},
+  ): Promise<ScoreItem> {
+    const scoreKey = options.scoreKey ?? result.scoreKey ?? 'final';
+    const scoreId = this.nextScoreId(scoreKey, result.evaluator.evaluatorId);
+    let graderGenerationId = '';
+    let graderConversationId = '';
+    if (result.grader !== undefined && (options.publishGrader ?? true)) {
+      graderGenerationId = stableId('gen', scoreId, 'grader');
+      graderConversationId = stableId('conv', scoreId, 'grader');
+      const grader = result.grader;
+      await this.client.exportGeneration({
+        generationId: graderGenerationId,
+        conversationId: graderConversationId,
+        inputText: grader.input,
+        outputText: grader.output,
+        modelProvider: grader.modelProvider,
+        modelName: grader.modelName,
+        agentName: grader.agentName ?? 'agento11y-llm-judge',
+        agentVersion: grader.agentVersion ?? '',
+        operationName: grader.operationName ?? 'evaluate',
+        ...(grader.usage !== undefined ? { usage: grader.usage } : {}),
+        tags: {
+          'experiment.run_id': this.ref.experimentId,
+          'test.case.id': this.ref.testCaseId,
+          'test.case.attempt': String(this.ref.attempt),
+          'evaluator.id': result.evaluator.evaluatorId,
+        },
+        metadata: {
+          experiment_run_id: this.ref.experimentId,
+          test_case_id: this.ref.testCaseId,
+          attempt: this.ref.attempt,
+          ...(result.metadata ?? {}),
+        },
+      });
+    }
+    return this.score(scoreKey, result.value, {
+      evaluator: result.evaluator,
+      passed: result.passed,
+      explanation: result.explanation ?? '',
+      graderConversationId,
+      graderGenerationId,
+      metadata: { ...(result.metadata ?? {}), ...(options.metadata ?? {}) },
+      scoreId,
+    });
+  }
+
+  /**
+   * Grades caller-supplied output with a local judge and records the result.
+   *
+   * This does not retrieve the trial's bound conversation. Use a framework-native
+   * evaluator with `recordEvaluation` for trajectory or transcript evaluation.
+   */
+  async evaluateOutput(
+    judge: OutputEvaluator,
+    options: {
+      input: unknown;
+      output: unknown;
+      expected?: unknown;
+      scoreKey?: string;
+      publishGrader?: boolean;
+      metadata?: Record<string, unknown>;
+    },
+  ): Promise<ScoreItem> {
+    const result = await judge.evaluateOutput({
+      input: options.input,
+      output: options.output,
+      expected: options.expected,
+    });
+    return this.recordEvaluation(result, {
+      ...(options.scoreKey !== undefined ? { scoreKey: options.scoreKey } : {}),
+      ...(options.publishGrader !== undefined ? { publishGrader: options.publishGrader } : {}),
+      ...(options.metadata !== undefined ? { metadata: options.metadata } : {}),
+    });
+  }
+
+  // --- cloud evaluation ---------------------------------------------------- //
+
+  /**
+   * Runs a stored evaluator against this trial's bound conversation.
+   *
+   * It grades the conversation Agent Observability already stored, using an
+   * evaluator defined in your tenant. For an in-process judge, see
+   * `evaluateOutput`.
+   *
+   * The conversation binding is persisted and the anchor generation from
+   * `recordIO` is exported before the evaluation is queued, so the evaluator can
+   * read the conversation it is asked to grade. A successful evaluation lets the
+   * trial close as `completed` without a local `finalScore`. Queuing one also makes
+   * `Experiment.finalize` drop a caller-supplied `scoreCount`, since the evaluator
+   * writes a score this process never sees.
+   *
+   * The evaluator grades the conversation, not one generation, so the stored score
+   * carries this trial's `conversationId` and `trialId` and no `generationId`. The
+   * report's `passRate` stays unset, because that verdict comes from a score under
+   * the `final` key and a stored evaluator writes under its own key.
+   *
+   * `timeoutMs` bounds the polling loop, not the whole call: a status request
+   * already in flight spends its own retry budget first. Worker failure rejects
+   * with `TrialEvaluationFailedError`, an exceeded deadline with
+   * `TrialEvaluationTimeoutError`, and an aborted `signal` with its own reason. A
+   * transport error while polling propagates and abandons the wait; the evaluation
+   * keeps running server-side.
+   *
+   * Experimental: requires `AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true`,
+   * otherwise it rejects with `ExperimentalFeatureDisabledError` without sending a
+   * request.
+   */
+  async evaluate(evaluatorId: string, options: EvaluateOptions = {}): Promise<TrialEvaluation> {
+    // Checked before the trial is created and the anchor generation is flushed, so
+    // a blocked call leaves nothing behind.
+    requireExperimental(FEATURE_CLOUD_TRIAL_EVALUATION);
+
+    const normalizedEvaluatorId = evaluatorId.trim();
+    if (normalizedEvaluatorId.length === 0) {
+      throw new Error('agento11y trial evaluation validation failed: evaluator_id is required');
+    }
+    if (this.conversationId.length === 0) {
+      throw new Error('agento11y trial evaluation validation failed: bind a conversation first');
+    }
+    const timeoutMs = options.timeoutMs ?? DEFAULT_EVALUATION_TIMEOUT_MS;
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      throw new Error('agento11y trial evaluation validation failed: timeoutMs must be greater than zero');
+    }
+    const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_EVALUATION_POLL_INTERVAL_MS;
+    if (!Number.isFinite(pollIntervalMs) || pollIntervalMs <= 0) {
+      throw new Error('agento11y trial evaluation validation failed: pollIntervalMs must be greater than zero');
+    }
+    const signal = options.signal;
+    throwIfAborted(signal);
+
+    // Every call here takes the caller's signal, so an abort stops the sequence at
+    // the current request instead of spending its retry budget first.
+    const signalOption = { ...(signal !== undefined ? { signal } : {}) };
+    await this.createTrial(signalOption);
+    // bindConversation and recordIO are local until now, and the backend rejects
+    // an evaluation for a trial with no stored conversation.
+    await this.client.updateTrial(
+      this.ref.experimentId,
+      this.trialId,
+      { conversationId: this.conversationId },
+      signalOption,
+    );
+    // The evaluator reads the stored conversation, so the anchor generation has to
+    // exist before the wait starts, not when the trial closes.
+    await this.ensureGeneration(signalOption);
+    await this.client.flushGenerations(signalOption);
+
+    const deadline = this.client.nowMs() + timeoutMs;
+    let evaluation = await this.client.triggerTrialEvaluation(
+      this.ref.experimentId,
+      this.trialId,
+      normalizedEvaluatorId,
+      options.evaluatorVersion ?? '',
+      signalOption,
+    );
+    // The evaluation row exists from here on, and the score it writes counts toward
+    // the experiment's stored total whether or not this wait sees it finish.
+    this.experiment?.markCloudEvaluated();
+
+    // Back off so a long wait costs tens of status reads, not hundreds. A caller
+    // who asked for a slower cadence than the cap keeps it.
+    let interval = pollIntervalMs;
+    const maxInterval = Math.max(pollIntervalMs, MAX_EVALUATION_POLL_INTERVAL_MS);
+    for (;;) {
+      if (evaluation.status === 'success') {
+        // The trial's terminal state stays with close(): a cloud score is not a
+        // local verdict, and setting status here would swallow an error the trial
+        // callback throws afterwards.
+        this.cloudEvaluated = true;
+        return evaluation;
+      }
+      if (evaluation.status === 'failed') {
+        throw new TrialEvaluationFailedError(evaluation.evaluationId, evaluation.error);
+      }
+      const remaining = deadline - this.client.nowMs();
+      if (remaining <= 0) {
+        throw new TrialEvaluationTimeoutError(evaluation.evaluationId, `waited ${timeoutMs}ms`);
+      }
+      await this.client.sleepFn(Math.min(interval, remaining), signal);
+      interval = Math.min(interval * 2, maxInterval);
+      // Every sleep is followed by a status read, including the one clamped to the
+      // remaining budget, so an evaluation that finishes in the last window is not
+      // reported as a timeout.
+      evaluation = await this.client.getTrialEvaluation(
+        this.ref.experimentId,
+        this.trialId,
+        evaluation.evaluationId,
+        signalOption,
+      );
+    }
+  }
+
+  // --- artifacts ----------------------------------------------------------- //
+
+  /**
+   * Attaches an artifact to this trial: a JSON object, text, or raw bytes.
+   *
+   * Exactly one of `data`, `text`, or `bytes` is required; passing two is rejected.
+   * `kind` and `mime` are inferred when omitted. Returns the created artifact
+   * record.
+   */
+  async artifact(name: string, options: ArtifactOptions = {}): Promise<Record<string, unknown>> {
+    const resolved = resolveArtifactContent(options);
+    const record = await this.client.uploadArtifact({
+      experimentId: this.ref.experimentId,
+      parentId: this.trialId,
+      name,
+      kind: resolved.kind,
+      content: resolved.content,
+      mime: resolved.mime,
+    });
+    const artifactId = typeof record.artifact_id === 'string' ? record.artifact_id : '';
+    this.artifacts.push({ name, kind: resolved.kind, artifactId });
+    this.span?.addEvent(otel.ARTIFACT_EVENT, {
+      [otel.ARTIFACT_NAME]: name,
+      [otel.ARTIFACT_KIND]: resolved.kind,
+    });
+    return record;
+  }
+
+  // --- export and close ---------------------------------------------------- //
+
+  /**
+   * Exports buffered scores and returns the number freshly accepted.
+   *
+   * Anchors the trial's generation first, when one is not externally bound, so the
+   * scores' `generationId` resolves under strict score ingest. An empty buffer
+   * sends no score request.
+   */
+  async flush(): Promise<number> {
+    await this.ensureGeneration();
+    await this.client.flushGenerations();
+    await this.createTrial();
+    if (this.buffer.length === 0) {
+      return 0;
+    }
+    const pending = this.buffer;
+    this.buffer = [];
+    let accepted: number;
+    try {
+      accepted = await this.client.exportScores(pending);
+    } catch (error) {
+      // Keep the scores buffered so a retry or close can publish them.
+      this.buffer = [...pending, ...this.buffer];
+      throw error;
+    }
+    this.accepted += accepted;
+    this.experiment?.recordAccepted(accepted);
+    return accepted;
+  }
+
+  /**
+   * Flushes and terminalizes this trial.
+   *
+   * The close status follows the same state machine as Go and Python: a callback
+   * error closes `errored`; no final score and no cloud evaluation closes `failed`
+   * with `trial closed without a final score`; a cloud-evaluated trial closes
+   * `completed`; a final score closes `passed` or `failed` on its verdict, or
+   * `completed` when the verdict is unknown.
+   */
+  async close(options: { error?: unknown } = {}): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    const callbackError = options.error;
+    if (callbackError !== undefined && this.status === 'running') {
+      this.status = 'errored';
+      this.error = asError(callbackError).message || 'error';
+    } else if (this.status === 'running') {
+      if (!this.hasFinal) {
+        if (this.cloudEvaluated) {
+          // A stored evaluator graded this trial; the verdict and score count come
+          // from the backend, not from a local final score.
+          this.status = 'completed';
+        } else {
+          this.status = 'failed';
+          this.error = 'trial closed without a final score';
+        }
+      } else if (this.finalPassed === undefined) {
+        this.status = 'completed';
+      } else {
+        this.status = this.finalPassed ? 'passed' : 'failed';
+      }
+    }
+    let flushError: unknown;
+    try {
+      await this.flush();
+    } catch (error) {
+      flushError = error;
+    }
+    try {
+      await this.finalizeTrial();
+    } catch (error) {
+      this.endSpan();
+      if (flushError !== undefined) {
+        // The finalize error is what the caller sees, but a failed score export is
+        // the more actionable half, so it travels along instead of vanishing.
+        // Python gets the same pairing from the exception's __context__.
+        reportSecondaryError(this.client, 'trial close: score export failed', error, flushError);
+      }
+      throw error;
+    }
+    this.endSpan();
+    this.closed = true;
+    this.experiment?.trialClosed(this);
+    if (flushError !== undefined) {
+      throw flushError;
+    }
+  }
+
+  get acceptedScores(): number {
+    return this.accepted;
+  }
+
+  get isClosed(): boolean {
+    return this.closed;
+  }
+
+  /** Whether a stored evaluator graded this trial successfully. */
+  get isCloudEvaluated(): boolean {
+    return this.cloudEvaluated;
+  }
+
+  /** The buffered, not yet exported scores. Test and diagnostic use. */
+  get pendingScores(): readonly ScoreItem[] {
+    return this.buffer;
+  }
+
+  // --- internals ----------------------------------------------------------- //
+
+  private async createTrial(options: { signal?: AbortSignal } = {}): Promise<void> {
+    if (this.trialCreated) {
+      return;
+    }
+    const snapshot = this.testCaseSnapshot();
+    await this.client.upsertTrial(
+      this.ref.experimentId,
+      {
+        trialId: this.trialId,
+        testCaseId: this.ref.testCaseId,
+        attempt: this.ref.attempt,
+        status: 'running',
+        conversationId: this.conversationId,
+        traceId: this.traceId,
+        spanId: this.spanId,
+        ...(snapshot !== undefined ? { testCase: snapshot } : {}),
+        ...(this.ref.testCaseName !== undefined && this.ref.testCaseName.length > 0
+          ? { metadata: { test_case_name: this.ref.testCaseName } }
+          : {}),
+      },
+      { ...(options.signal !== undefined ? { signal: options.signal } : {}) },
+    );
+    this.trialCreated = true;
+  }
+
+  private async finalizeTrial(): Promise<void> {
+    if (!this.trialCreated) {
+      return;
+    }
+    // Trial status is the lifecycle (completed/failed); the pass/fail verdict lives
+    // in the final score's `passed`, which drives the report pass rate.
+    const backendStatus = this.status === 'errored' ? 'failed' : 'completed';
+    await this.client.updateTrial(this.ref.experimentId, this.trialId, {
+      status: backendStatus,
+      error: this.error,
+      ...(this.usage.cost !== undefined ? { cost: this.usage.cost } : {}),
+      ...(this.usage.inputTokens !== undefined ? { inputTokens: this.usage.inputTokens } : {}),
+      ...(this.usage.outputTokens !== undefined ? { outputTokens: this.usage.outputTokens } : {}),
+      ...(this.durationMs() !== undefined ? { durationMs: this.durationMs() } : {}),
+      conversationId: this.conversationId,
+      traceId: this.traceId,
+      spanId: this.spanId,
+    });
+  }
+
+  private durationMs(): number | undefined {
+    if (this.startedAtMs === undefined) {
+      return undefined;
+    }
+    return Math.max(0, Math.trunc(this.client.nowMs() - this.startedAtMs));
+  }
+
+  /**
+   * Exports the anchor generation when `recordIO` supplied content.
+   *
+   * Generations are optional: the typed trial already attributes scores. One is
+   * exported only when the harness gave input or output, so the attempt's
+   * conversation is visible in Agent Observability.
+   */
+  private async ensureGeneration(options: { signal?: AbortSignal } = {}): Promise<void> {
+    if (this.generationExported || Object.keys(this.io).length === 0) {
+      return;
+    }
+    let caseInput = '';
+    const suiteTestCase = suiteCase(this.experiment?.suite, this.ref.testCaseId);
+    if (suiteTestCase?.input !== undefined && suiteTestCase.input !== null) {
+      caseInput = typeof suiteTestCase.input === 'string' ? suiteTestCase.input : String(suiteTestCase.input);
+    }
+    await this.client.exportGeneration(
+      {
+        generationId: this.generationId,
+        conversationId: this.conversationId,
+        inputText: stringField(this.io.inputText) ?? caseInput,
+        outputText: stringField(this.io.outputText) ?? '',
+        modelProvider: stringField(this.io.modelProvider) ?? this.candidate?.modelProvider ?? 'eval',
+        modelName: stringField(this.io.modelName) ?? this.candidate?.modelName ?? 'experiment',
+        agentName: stringField(this.io.agentName) ?? this.candidate?.agentName ?? '',
+        agentVersion: stringField(this.io.agentVersion) ?? this.candidate?.agentVersion ?? '',
+        ...(typeof this.io.inputTokens === 'number' ? { inputTokens: this.io.inputTokens } : {}),
+        ...(typeof this.io.outputTokens === 'number' ? { outputTokens: this.io.outputTokens } : {}),
+        tags: { 'experiment.run_id': this.ref.experimentId, task_id: this.ref.testCaseId },
+        metadata: {
+          experiment_run_id: this.ref.experimentId,
+          task_id: this.ref.testCaseId,
+          trial_id: this.trialId,
+          attempt: this.ref.attempt,
+        },
+      },
+      { ...(options.signal !== undefined ? { signal: options.signal } : {}) },
+    );
+    this.generationExported = true;
+  }
+
+  private nextScoreId(scoreKey: string, evaluatorId: string): string {
+    const identity = `${scoreKey}\u001f${evaluatorId}`;
+    const occurrence = this.scoreOccurrences.get(identity) ?? 0;
+    this.scoreOccurrences.set(identity, occurrence + 1);
+    const parts: unknown[] = [this.ref.experimentId, this.trialId, scoreKey, evaluatorId];
+    if (occurrence > 0) {
+      parts.push(occurrence + 1);
+    }
+    return stableId('score', ...parts);
+  }
+
+  private startSpan(): void {
+    // Experimental OTel is opt-in. Without it the trial is still created and scores
+    // still record; only spans and events are skipped.
+    if (!this.useExperimentalOtel) {
+      return;
+    }
+    const tracer = trace.getTracer(otel.INSTRUMENTATION_NAME);
+    const span = tracer.startSpan(`${otel.TRIAL_SPAN_NAME} ${this.ref.testCaseId}`, {
+      kind: SpanKind.INTERNAL,
+      attributes: this.identityAttributes(),
+    });
+    this.span = span;
+    const spanContext = span.spanContext();
+    // A trace id is 32 hex characters even when it is all zeros, which is what a
+    // non-recording span returns when no TracerProvider is registered. Storing it
+    // would point every trial and score at a trace that does not exist.
+    if (isSpanContextValid(spanContext)) {
+      this.traceId = spanContext.traceId;
+      this.spanId = spanContext.spanId;
+    }
+  }
+
+  private endSpan(): void {
+    const span = this.span;
+    if (span === undefined) {
+      return;
+    }
+    span.setAttributes(this.identityAttributes());
+    if (this.error.length > 0) {
+      const safeError = this.telemetryText(this.error);
+      span.setAttribute(otel.EVAL_EXPLANATION, safeError);
+      span.setStatus({ code: SpanStatusCode.ERROR, message: safeError });
+    } else {
+      span.setStatus({ code: SpanStatusCode.OK });
+    }
+    span.end();
+    this.span = undefined;
+  }
+
+  private identityAttributes(): Record<string, string | number> {
+    const attrs = otel.trialIdentityAttributes({
+      experimentId: this.ref.experimentId,
+      experimentName: this.experiment?.name ?? '',
+      suiteId: this.ref.suiteId ?? '',
+      suiteVersion: this.ref.suiteVersion ?? '',
+      suiteName: this.ref.suiteName ?? '',
+      testCaseId: this.ref.testCaseId,
+      testCaseName: this.ref.testCaseName ?? '',
+      attempt: this.ref.attempt,
+      trialId: this.trialId,
+      runStatus: this.experiment?.status ?? 'running',
+      trialStatus: this.status,
+      conversationId: this.conversationId,
+      operationName: 'invoke_agent',
+    }) as Record<string, string | number>;
+    if (this.candidate !== undefined) {
+      for (const [key, value] of [
+        ['gen_ai.agent.name', this.candidate.agentName],
+        ['gen_ai.agent.version', this.candidate.agentVersion],
+        ['gen_ai.provider.name', this.candidate.modelProvider],
+        ['gen_ai.request.model', this.candidate.modelName],
+      ] as const) {
+        if (value !== undefined && value.length > 0) {
+          attrs[key] = value;
+        }
+      }
+    }
+    return attrs;
+  }
+
+  private emitScoreEvent(
+    scoreKey: string,
+    value: ScoreValue,
+    evaluator: Evaluator,
+    passed: boolean | undefined,
+    explanation: string,
+    responseId: string,
+  ): void {
+    if (this.span === undefined) {
+      return;
+    }
+    this.span.addEvent(
+      otel.EVENT_EVAL_RESULT,
+      otel.scoreEventAttributes({
+        name: scoreKey,
+        value: eventValue(value),
+        ...(passed !== undefined ? { passed } : {}),
+        explanation: this.telemetryText(explanation),
+        evaluatorId: evaluator.evaluatorId,
+        evaluatorVersion: evaluator.version ?? '0',
+        evaluatorKind: normalizeEvaluatorKind(evaluator.kind ?? 'custom'),
+        referenceSetId: evaluator.referenceSetId ?? '',
+        referenceSetVersion: evaluator.referenceSetVersion ?? '',
+        responseId,
+      }),
+    );
+  }
+
+  private telemetryText(value: string): string {
+    return this.client.redactSecrets ? redactSecretText(value) : value;
+  }
+
+  private testCaseSnapshot(): Record<string, unknown> | undefined {
+    const testCase = this.testCase;
+    if (testCase === undefined) {
+      return undefined;
+    }
+    const artifactRefs = (testCase.artifactRefs ?? []).filter(
+      (ref) => ref.artifact_id !== undefined && ref.name !== undefined && ref.kind !== undefined,
+    );
+    return {
+      test_case_id: testCase.testCaseId,
+      suite_id: this.ref.suiteId ?? '',
+      suite_version: this.ref.suiteVersion ?? '',
+      name: testCase.name ?? '',
+      description: testCase.description ?? '',
+      tags: [...(testCase.tags ?? [])],
+      category: testCase.category ?? '',
+      input: objectValue(testCase.input),
+      expected: objectValue(testCase.expected),
+      metadata: { ...(testCase.metadata ?? {}) },
+      artifact_refs: artifactRefs.map((ref) => ({ ...ref })),
+    };
+  }
+}
+
+/**
+ * An external experiment run: upserted by `start`, finalized by `finalize`.
+ *
+ * `withExperiment` wraps both so the run is finalized on the success and the
+ * failure path, matching Go's `WithExperiment`.
+ */
+export class Experiment {
+  readonly experimentId: string;
+  readonly name: string;
+  readonly suite: TestSuite | undefined;
+  status: string = 'running';
+
+  private readonly client: ExperimentsClient;
+  private readonly candidate: Candidate | undefined;
+  private readonly defaultEvaluator: Evaluator | undefined;
+  private readonly description: string;
+  private readonly tags: string[];
+  private readonly metadata: Record<string, unknown>;
+  private readonly plannedTrialCount: number | undefined;
+  private readonly useExperimentalOtel: boolean;
+
+  private accepted = 0;
+  private finalized = false;
+  private cloudEvaluated = false;
+  private readonly openTrials = new Map<string, Trial>();
+  private readonly claimedTrialIds = new Set<string>();
+
+  private constructor(client: ExperimentsClient, options: ExperimentOptions) {
+    if (options.plannedTrialCount !== undefined && options.plannedTrialCount < 0) {
+      throw new Error('plannedTrialCount must be non-negative');
+    }
+    this.client = client;
+    this.experimentId =
+      options.experimentId !== undefined && options.experimentId.length > 0
+        ? options.experimentId
+        : stableId('exp', options.name ?? '', randomSuffix());
+    this.name = options.name !== undefined && options.name.length > 0 ? options.name : this.experimentId;
+    this.suite = options.suite;
+    this.candidate = options.candidate;
+    this.defaultEvaluator = options.defaultEvaluator;
+    this.description = options.description ?? '';
+    this.tags = [...(options.tags ?? [])];
+    this.metadata = { ...(options.metadata ?? {}) };
+    this.plannedTrialCount = options.plannedTrialCount;
+    this.useExperimentalOtel = options.useExperimentalOtel ?? client.useExperimentalOtel;
+  }
+
+  /** Upserts the run and returns the open experiment. */
+  static async start(client: ExperimentsClient, options: ExperimentOptions = {}): Promise<Experiment> {
+    const experiment = new Experiment(client, options);
+    const metadata: Record<string, unknown> = { ...experiment.metadata };
+    let suiteId = '';
+    let suiteVersion = '';
+    if (experiment.suite !== undefined) {
+      suiteId = experiment.suite.suiteId;
+      suiteVersion = experiment.suite.version ?? '';
+      metadata.suite_id ??= suiteId;
+      metadata.suite_version ??= suiteVersion;
+    }
+    const candidate = candidateMetadata(experiment.candidate);
+    Object.assign(metadata, candidate);
+    await client.upsertExperiment({
+      runId: experiment.experimentId,
+      name: experiment.name,
+      description: experiment.description,
+      tags: experiment.tags,
+      suiteId,
+      suiteVersion,
+      candidate,
+      ...(experiment.plannedTrialCount !== undefined ? { plannedTrialCount: experiment.plannedTrialCount } : {}),
+      metadata,
+    });
+    return experiment;
+  }
+
+  /**
+   * Claims one unique case attempt.
+   *
+   * Reusing the same case and attempt in one experiment is rejected: both map to
+   * the same durable trial and score identities. Increment `attempt` for a retry.
+   * The returned trial is not created server-side until `start()`.
+   */
+  trial(testCase: TestCase | string, options: TrialOptions = {}): Trial {
+    const attempt = options.attempt !== undefined && options.attempt > 0 ? Math.trunc(options.attempt) : 1;
+    const resolved = typeof testCase === 'string' ? suiteCase(this.suite, testCase) : testCase;
+    const testCaseId = (typeof testCase === 'string' ? testCase : testCase.testCaseId).trim();
+    if (testCaseId.length === 0) {
+      throw new Error('test case id is required');
+    }
+    const testCaseName = resolved?.name !== undefined && resolved.name.length > 0 ? resolved.name : testCaseId;
+    const ref: TrialRef = {
+      experimentId: this.experimentId,
+      testCaseId,
+      attempt,
+      suiteId: this.suite?.suiteId ?? '',
+      suiteVersion: this.suite?.version ?? '',
+      suiteName: this.suite?.name !== undefined && this.suite.name.length > 0 ? this.suite.name : this.name,
+      testCaseName,
+      trajectoryId: options.trajectoryId ?? '',
+    };
+    const trial = new Trial(this.client, ref, {
+      experiment: this,
+      ...(resolved !== undefined ? { testCase: resolved } : {}),
+      ...(this.candidate !== undefined ? { candidate: this.candidate } : {}),
+      ...(this.defaultEvaluator !== undefined ? { defaultEvaluator: this.defaultEvaluator } : {}),
+      ...(options.metadata !== undefined ? { metadata: options.metadata } : {}),
+      useExperimentalOtel: this.useExperimentalOtel,
+    });
+    // Read the id off the trial: one derivation, so the dedupe set cannot drift
+    // from the id the trial actually writes.
+    if (this.claimedTrialIds.has(trial.trialId)) {
+      throw new Error(
+        `trial for test case "${testCaseId}" attempt ${attempt} already exists; increment attempt for a retry`,
+      );
+    }
+    this.claimedTrialIds.add(trial.trialId);
+    this.openTrials.set(trial.trialId, trial);
+    return trial;
+  }
+
+  /**
+   * Opens a trial, runs `fn`, and closes the trial on both paths.
+   *
+   * A callback error terminalizes the trial as `errored` and is rethrown after the
+   * close completes.
+   */
+  async withTrial<T>(
+    testCase: TestCase | string,
+    fn: (trial: Trial) => Promise<T> | T,
+    options: TrialOptions = {},
+  ): Promise<T> {
+    const trial = this.trial(testCase, options);
+    try {
+      await trial.start();
+    } catch (error) {
+      this.trialAbandoned(trial);
+      throw error;
+    }
+    let result: T;
+    try {
+      result = await trial.runInTrialContext(() => fn(trial));
+    } catch (error) {
+      // The close still runs, so the trial is terminalized before the error leaves.
+      try {
+        await trial.close({ error });
+      } catch (closeError) {
+        reportSecondaryError(this.client, `trial ${trial.trialId} close failed`, error, closeError);
+      }
+      throw error;
+    }
+    await trial.close();
+    return result;
+  }
+
+  /**
+   * Finalizes the run. Safe to call twice; the second call is a no-op.
+   *
+   * Open trials are closed first. A close failure forces `failed`, drops
+   * `scoreCount`, and appends the failure to `error`.
+   */
+  async finalize(status: ExperimentStatus | string = 'completed', options: FinalizeOptions = {}): Promise<void> {
+    if (this.finalized) {
+      return;
+    }
+    let statusValue = String(status);
+    let scoreCount = options.scoreCount;
+    let error = options.error ?? '';
+    const closeErrors: Error[] = [];
+    for (const trial of [...this.openTrials.values()]) {
+      try {
+        await trial.close();
+      } catch (closeError) {
+        closeErrors.push(asError(closeError));
+      }
+    }
+    if (this.cloudEvaluated) {
+      // A stored evaluator wrote a score this process never saw, so a locally
+      // derived count would fail the server's check with a 409.
+      scoreCount = undefined;
+    }
+    if (closeErrors.length > 0) {
+      statusValue = 'failed';
+      scoreCount = undefined;
+      const summary = closeErrors.map((closeError) => closeError.message || closeError.name).join('; ');
+      error = [error, `trial close failed: ${summary}`].filter((part) => part.length > 0).join('; ');
+    }
+    this.status = statusValue;
+    await this.client.finalize(this.experimentId, statusValue, {
+      ...(scoreCount !== undefined ? { scoreCount } : {}),
+      ...(error.length > 0 ? { error } : {}),
+    });
+    this.finalized = true;
+    if (closeErrors.length > 0) {
+      const primary = closeErrors[0] as Error;
+      throw primary;
+    }
+  }
+
+  /** Fetches the aggregated report for this run. */
+  async report(): Promise<ExperimentReport> {
+    return this.client.getReport(this.experimentId);
+  }
+
+  /** Best-effort deep link to the run in the Agent Observability UI. */
+  get url(): string {
+    return this.client.experimentUrl(this.experimentId);
+  }
+
+  get acceptedScores(): number {
+    return this.accepted;
+  }
+
+  get isFinalized(): boolean {
+    return this.finalized;
+  }
+
+  /** Whether a stored evaluator was queued for one of this run's trials. */
+  get hasCloudEvaluatedTrial(): boolean {
+    return this.cloudEvaluated;
+  }
+
+  /** @internal Called by `Trial`; not part of the public API. */
+  markCloudEvaluated(): void {
+    this.cloudEvaluated = true;
+  }
+
+  /** @internal Called by `Trial`; not part of the public API. */
+  trialClosed(trial: Trial): void {
+    this.openTrials.delete(trial.trialId);
+  }
+
+  private trialAbandoned(trial: Trial): void {
+    this.openTrials.delete(trial.trialId);
+    this.claimedTrialIds.delete(trial.trialId);
+  }
+
+  /** @internal Called by `Trial`; not part of the public API. */
+  recordAccepted(count: number): void {
+    this.accepted += count;
+  }
+}
+
+/**
+ * Opens an experiment, runs `fn`, and finalizes the run on both paths.
+ *
+ * A callback error finalizes the run as `failed` and is rethrown; a finalization
+ * failure is attached as the cause so the original error still surfaces.
+ */
+export async function withExperiment<T>(
+  client: ExperimentsClient,
+  options: ExperimentOptions,
+  fn: (experiment: Experiment) => Promise<T> | T,
+): Promise<T> {
+  const experiment = await Experiment.start(client, options);
+  let result: T;
+  try {
+    result = await fn(experiment);
+  } catch (error) {
+    try {
+      await experiment.finalize('failed', { error: asError(error).message || 'error' });
+    } catch (finalizeError) {
+      reportSecondaryError(client, 'experiment finalize failed', error, finalizeError);
+    }
+    throw error;
+  }
+  await experiment.finalize('completed');
+  return result;
+}
+
+function coerceValue(value: ScoreValue | number | boolean | string): ScoreValue {
+  if (typeof value === 'boolean') {
+    return { boolean: value };
+  }
+  if (typeof value === 'number') {
+    return { number: value };
+  }
+  if (typeof value === 'string') {
+    return { string: value };
+  }
+  return { ...value };
+}
+
+function inferFinalPassed(value: ScoreValue): boolean | undefined {
+  return value.boolean;
+}
+
+function eventValue(value: ScoreValue): number | boolean | string | undefined {
+  if (value.number !== undefined) {
+    return value.number;
+  }
+  if (value.boolean !== undefined) {
+    return value.boolean;
+  }
+  return value.string;
+}
+
+/** Maps a MIME type onto an Agent Observability artifact kind. */
+export function artifactKindFromMime(mime: string): string {
+  const m = mime.toLowerCase();
+  if (m.startsWith('image/')) {
+    return 'image';
+  }
+  if (m === 'application/json') {
+    return 'json';
+  }
+  if (m === 'text/markdown' || m === 'text/x-markdown') {
+    return 'markdown';
+  }
+  if (m === 'application/pdf') {
+    return 'pdf';
+  }
+  if (m === 'text/csv') {
+    return 'csv';
+  }
+  if (m.startsWith('text/')) {
+    return 'text';
+  }
+  return 'binary';
+}
+
+function resolveArtifactContent(options: ArtifactOptions): { content: Uint8Array; kind: string; mime: string } {
+  const encoder = new TextEncoder();
+  const supplied = [options.data, options.text, options.bytes].filter((value) => value !== undefined).length;
+  if (supplied > 1) {
+    // Silently preferring one body would upload content the caller did not mean
+    // to send, so two bodies is an error rather than a precedence rule.
+    throw validationError('artifact takes exactly one of data, text, or bytes');
+  }
+  if (options.bytes !== undefined) {
+    const mime = options.mime !== undefined && options.mime.length > 0 ? options.mime : 'application/octet-stream';
+    return {
+      content: options.bytes,
+      kind: options.kind !== undefined && options.kind.length > 0 ? options.kind : artifactKindFromMime(mime),
+      mime,
+    };
+  }
+  if (options.data !== undefined) {
+    return {
+      content: encoder.encode(JSON.stringify(options.data)),
+      kind: options.kind !== undefined && options.kind.length > 0 ? options.kind : 'json',
+      mime: options.mime !== undefined && options.mime.length > 0 ? options.mime : 'application/json',
+    };
+  }
+  if (options.text !== undefined && options.text.length > 0) {
+    return {
+      content: encoder.encode(options.text),
+      kind: options.kind !== undefined && options.kind.length > 0 ? options.kind : 'text',
+      mime: options.mime !== undefined && options.mime.length > 0 ? options.mime : 'text/plain',
+    };
+  }
+  throw validationError('artifact requires one of data, text, or bytes');
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  if (value === undefined || value === null) {
+    return {};
+  }
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return { ...(value as Record<string, unknown>) };
+  }
+  return { value };
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Random suffix for a generated run id.
+ *
+ * `crypto.getRandomValues` is assumed present: the next statement in the caller
+ * hashes with SHA-1, which throws in any runtime without crypto, and experiments
+ * is explicitly outside the edge-runtime guarantee.
+ */
+function randomSuffix(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(8));
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Reports a cleanup failure that happened while another error was already leaving.
+ *
+ * The first error stays the thrown value, so a caller's `instanceof` check still
+ * works. The cleanup error is logged, and it is attached to the first free `cause`
+ * slot on the primary error's chain, so a caller reading `error.cause` finds it.
+ * Go joins the pair with `errors.Join`; Python attaches a note. None of the three
+ * drops the second error, which is usually a failed score export.
+ */
+function reportSecondaryError(client: ExperimentsClient, label: string, primary: unknown, secondary: unknown): void {
+  const secondaryError = asError(secondary);
+  client.warn(`agento11y: ${label}: ${secondaryError.message}`);
+  if (!(primary instanceof Error)) {
+    return;
+  }
+  let current = primary as Error & { cause?: unknown };
+  const seen = new Set<unknown>([current]);
+  while (current.cause instanceof Error && !seen.has(current.cause)) {
+    seen.add(current.cause);
+    current = current.cause as Error & { cause?: unknown };
+  }
+  if (current.cause === undefined) {
+    current.cause = secondaryError;
+  }
+}

--- a/js/src/experiments/experimental.ts
+++ b/js/src/experiments/experimental.ts
@@ -1,0 +1,50 @@
+import { parseTruthy } from '../config.js';
+
+/**
+ * Opt-in switch for SDK features that are not stable yet. Set it to `1`, `true`,
+ * `yes`, or `on`.
+ *
+ * An experimental feature can change or be removed in any release, and is not
+ * covered by the compatibility the rest of the SDK aims for.
+ *
+ * This gate is separate from `AGENTO11Y_USE_EXPERIMENTAL_OTEL`, which stays an
+ * independent opt-in for experimental trial spans and evaluation-result events.
+ */
+export const ENV_ENABLE_EXPERIMENTAL_FEATURES = 'AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES';
+
+/** Names the experimental feature that grades a trial with a stored evaluator. */
+export const FEATURE_CLOUD_TRIAL_EVALUATION = 'cloud trial evaluation';
+
+/** Thrown when an experimental feature is called without the opt-in env var. */
+export class ExperimentalFeatureDisabledError extends Error {
+  readonly feature: string;
+  readonly envVar: string;
+
+  constructor(feature: string, envVar: string = ENV_ENABLE_EXPERIMENTAL_FEATURES) {
+    const normalizedFeature = feature.trim().length > 0 ? feature.trim() : 'this feature';
+    const normalizedEnv = envVar.trim().length > 0 ? envVar.trim() : ENV_ENABLE_EXPERIMENTAL_FEATURES;
+    super(`agento11y: ${normalizedFeature} is experimental; set ${normalizedEnv}=true to use it`);
+    this.name = 'ExperimentalFeatureDisabledError';
+    this.feature = normalizedFeature;
+    this.envVar = normalizedEnv;
+  }
+}
+
+/** Reports whether the experimental opt-in is set to a truthy value. */
+export function experimentalFeaturesEnabled(env: Record<string, string | undefined> = processEnv()): boolean {
+  return parseTruthy(env[ENV_ENABLE_EXPERIMENTAL_FEATURES] ?? '');
+}
+
+/** Throws `ExperimentalFeatureDisabledError` unless the gate is set. */
+export function requireExperimental(feature: string, env: Record<string, string | undefined> = processEnv()): void {
+  if (!experimentalFeaturesEnabled(env)) {
+    throw new ExperimentalFeatureDisabledError(feature);
+  }
+}
+
+function processEnv(): Record<string, string | undefined> {
+  if (typeof process !== 'undefined' && process.env !== undefined) {
+    return process.env;
+  }
+  return {};
+}

--- a/js/src/experiments/ids.ts
+++ b/js/src/experiments/ids.ts
@@ -1,0 +1,29 @@
+import { sha1Hex } from '../utils.js';
+
+/** The separator `stable_id` joins parts with in every SDK. */
+const SEPARATOR = '\u001f';
+
+/**
+ * Deterministic identifier from `parts`, so a retry reuses the same row.
+ *
+ * The derivation is a cross-SDK contract and must stay byte-identical with Go's
+ * `StableID` and Python's `stable_id`: SHA-1 over the parts joined with `\x1f`,
+ * lowercase hex truncated to sixteen characters, prefixed with the kind and a
+ * hyphen. A `null` or `undefined` part keeps its separator slot, so dropping a
+ * blank field would produce a different id.
+ *
+ * Numbers use JavaScript's integer string form, so an attempt of `1` renders as
+ * `1`, matching Python's `str(1)` and Go's `%v`. A float such as `1.0` is a
+ * different input and yields a different id.
+ */
+export function stableId(prefix: string, ...parts: unknown[]): string {
+  const joined = parts.map(stringifyPart).join(SEPARATOR);
+  return `${prefix}-${sha1Hex(joined).slice(0, 16)}`;
+}
+
+function stringifyPart(part: unknown): string {
+  if (part === null || part === undefined) {
+    return '';
+  }
+  return String(part);
+}

--- a/js/src/experiments/index.ts
+++ b/js/src/experiments/index.ts
@@ -1,0 +1,187 @@
+/**
+ * Cloud experiments: run benchmarks and evals against Agent Observability with a
+ * single ingest token.
+ *
+ * This is the high-level surface for evaluation harnesses. It writes over the v1
+ * one-token ingest path (run upsert, trial upsert, generation export, score
+ * export, finalize). Experimental OpenTelemetry eval telemetry is emitted only
+ * when `useExperimentalOtel` or `AGENTO11Y_USE_EXPERIMENTAL_OTEL` is set.
+ *
+ * The module is published as `@grafana/agento11y/experiments`. It is deliberately
+ * not part of `@grafana/agento11y-core`: experiments needs crypto and environment
+ * access, while core must keep loading on edge runtimes.
+ *
+ * Quick start (`endpoint` is your Grafana Cloud Agent Observability URL,
+ * `tenantId` your stack id, and `ingestToken` your Cloud ingestion API key):
+ *
+ * ```ts
+ * import { ExperimentsClient, withExperiment } from '@grafana/agento11y/experiments';
+ *
+ * const client = new ExperimentsClient({
+ *   endpoint: process.env.AGENTO11Y_ENDPOINT,
+ *   tenantId: process.env.AGENTO11Y_AUTH_TENANT_ID,
+ *   ingestToken: process.env.AGENTO11Y_AUTH_TOKEN,
+ * });
+ * const suite = {
+ *   suiteId: 'smoke',
+ *   name: 'Smoke',
+ *   testCases: [{ testCaseId: 'add', input: '2+2', expected: '4' }],
+ * };
+ * const verifier = { evaluatorId: 'exact', version: '1', kind: 'deterministic' };
+ *
+ * await withExperiment(client, { experimentId: 'run-1', name: 'smoke run', suite }, async (experiment) => {
+ *   for (const testCase of suite.testCases) {
+ *     await experiment.withTrial(testCase, async (trial) => {
+ *       const answer = await runAgent(testCase.input);
+ *       trial.finalScore(answer === testCase.expected, { evaluator: verifier });
+ *     });
+ *   }
+ * });
+ * ```
+ *
+ * A stored Agent Observability evaluator can grade a conversation the agent's own
+ * instrumentation already emitted. That path is experimental and requires
+ * `AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true`:
+ *
+ * ```ts
+ * await experiment.withTrial(testCase, async (trial) => {
+ *   const { conversationId } = await runInstrumentedAgent(testCase.input);
+ *   trial.bindConversation(conversationId);
+ *   await trial.evaluate('helpfulness');
+ * });
+ * ```
+ *
+ * A separate process (for example a grading container) opens one trial from a
+ * serialized ref:
+ *
+ * ```ts
+ * import { Trial, trialRefFromEnv } from '@grafana/agento11y/experiments';
+ *
+ * const ref = trialRefFromEnv();
+ * if (ref === undefined) {
+ *   throw new Error('missing Agent Observability trial environment');
+ * }
+ * const trial = await Trial.fromRef(client, ref).start();
+ * trial.finalScore(0.82, { passed: true });
+ * await trial.close();
+ * ```
+ */
+
+export type {
+  ExperimentsClientOptions,
+  ExportGenerationRequest,
+  FinalizeExperimentOptions,
+  FlushableGenerationClient,
+  RequestOptions,
+  UpdateTrialRequest,
+  UploadArtifactRequest,
+  UpsertTrialRequest,
+} from './client.js';
+export { DEFAULT_INGEST_ACTOR, ExperimentsClient, INGEST_ACTOR_HEADER } from './client.js';
+export type { ConflictKind } from './errors.js';
+export {
+  CONFLICT_PREFIX,
+  classifyConflict,
+  ExperimentConflictError,
+  NOT_FOUND_PREFIX,
+  TRANSPORT_PREFIX,
+  TrialEvaluationFailedError,
+  TrialEvaluationTimeoutError,
+  VALIDATION_PREFIX,
+} from './errors.js';
+export type {
+  EvaluateOutputInput,
+  EvaluationResult,
+  GraderGeneration,
+  LLMJudgeOptions,
+  OutputEvaluator,
+  ParsedJudgeResult,
+  RegexJudgeOptions,
+} from './evaluators.js';
+
+export {
+  DEFAULT_LLM_JUDGE_PROMPT,
+  LLMJudge,
+  RegexJudge,
+} from './evaluators.js';
+export type {
+  ArtifactOptions,
+  EvaluateOptions,
+  ExperimentOptions,
+  FinalizeOptions,
+  RecordIOOptions,
+  ScoreOptions,
+  TrialOptions,
+} from './experiment.js';
+
+export { artifactKindFromMime, Experiment, Trial, withExperiment } from './experiment.js';
+export {
+  ENV_ENABLE_EXPERIMENTAL_FEATURES,
+  ExperimentalFeatureDisabledError,
+  experimentalFeaturesEnabled,
+  FEATURE_CLOUD_TRIAL_EVALUATION,
+  requireExperimental,
+} from './experimental.js';
+
+export { stableId } from './ids.js';
+export type {
+  Candidate,
+  CreateExperimentRequest,
+  Evaluator,
+  EvaluatorKind,
+  Experiment as ExperimentRun,
+  ExperimentReport,
+  ExperimentReportSummary,
+  ExperimentStatus,
+  ExportScoreResult,
+  ExportScoresResponse,
+  ScoreItem,
+  ScoreSource,
+  ScoreValue,
+  TrialEvaluation,
+  TrialEvaluationStatus,
+  TrialStatus,
+} from './models.js';
+export {
+  isTerminalEvaluationStatus,
+  normalizeEvaluatorKind,
+  parseExperiment,
+  parseExperimentReport,
+  parseExperimentRunResponse,
+  parseTrialEvaluation,
+} from './models.js';
+
+export * as otel from './otel.js';
+export * as routes from './routes.js';
+export type { ListOptions, PushedSuite, PushSuiteOptions, TestSuitesClientOptions } from './suites.js';
+export {
+  localCaseToRemote,
+  normalizeControlEndpoint,
+  remoteCaseToLocal,
+  TestSuitesClient,
+} from './suites.js';
+// The raw transport stays internal: it bypasses the validation, redaction, and
+// experimental gate every ExperimentsClient method applies. Only the retry policy
+// is public, because client options accept it.
+export type { ExperimentsRetryPolicy } from './transport.js';
+export type { TestCase, TestSuite, TrialRef } from './types.js';
+export {
+  candidateMetadata,
+  ENV_ATTEMPT,
+  ENV_EXPERIMENT_ID,
+  ENV_SUITE_ID,
+  ENV_SUITE_VERSION,
+  ENV_TEST_CASE_ID,
+  ENV_TRAJECTORY_ID,
+  suiteCase,
+  testCaseFromObject,
+  testCaseToObject,
+  testSuiteFromObject,
+  testSuiteToObject,
+  trialRefFromEnv,
+  trialRefFromJSON,
+  trialRefToEnv,
+  trialRefToJSON,
+} from './types.js';
+
+export { parseSuiteYAML, stringifySuiteYAML, validateSuite } from './yaml.js';

--- a/js/src/experiments/models.ts
+++ b/js/src/experiments/models.ts
@@ -1,0 +1,409 @@
+import { transportError } from './errors.js';
+
+/** Terminal status an external run can be finalized to (plus `running`). */
+export type ExperimentStatus = 'running' | 'completed' | 'failed';
+
+/** Lifecycle of a single trial (one test case attempt). */
+export type TrialStatus = 'running' | 'completed' | 'passed' | 'failed' | 'errored' | 'skipped';
+
+/** The OTel-aligned evaluator type vocabulary. */
+export type EvaluatorKind = 'llm_judge' | 'deterministic' | 'human' | 'custom';
+
+/** Durable state of a stored evaluator run for an experiment trial. */
+export type TrialEvaluationStatus = 'queued' | 'claimed' | 'success' | 'failed';
+
+const trialEvaluationStatuses: readonly TrialEvaluationStatus[] = ['queued', 'claimed', 'success', 'failed'];
+
+/** Whether the worker has finished the evaluation. */
+export function isTerminalEvaluationStatus(status: TrialEvaluationStatus): boolean {
+  return status === 'success' || status === 'failed';
+}
+
+/** Maps a free-form evaluator kind onto the OTel-aligned set. */
+export function normalizeEvaluatorKind(kind: string): EvaluatorKind {
+  const k = kind.trim().toLowerCase();
+  if (k === 'llm_judge' || k === 'llm-judge' || k === 'llm' || k === 'judge' || k === 'rubric') {
+    return 'llm_judge';
+  }
+  if (k === 'deterministic' || k === 'check' || k === 'rule' || k === 'exact' || k === 'code') {
+    return 'deterministic';
+  }
+  if (k === 'human' || k === 'manual' || k === 'annotator') {
+    return 'human';
+  }
+  return 'custom';
+}
+
+/** One score's value. Exactly one field is set. */
+export interface ScoreValue {
+  number?: number;
+  boolean?: boolean;
+  string?: string;
+}
+
+export interface ScoreSource {
+  kind?: string;
+  id?: string;
+}
+
+/** One score ready to publish through `POST /api/v1/scores:export`. */
+export interface ScoreItem {
+  scoreId: string;
+  evaluatorId: string;
+  evaluatorVersion: string;
+  evaluatorKind?: string;
+  scoreKey: string;
+  value: ScoreValue;
+  generationId?: string;
+  conversationId?: string;
+  experimentId?: string;
+  trialId?: string;
+  testCaseId?: string;
+  traceId?: string;
+  spanId?: string;
+  graderConversationId?: string;
+  graderGenerationId?: string;
+  graderTraceId?: string;
+  ruleId?: string;
+  passed?: boolean;
+  explanation?: string;
+  metadata?: Record<string, unknown>;
+  createdAt?: Date;
+  source?: ScoreSource;
+}
+
+export interface ExportScoreResult {
+  scoreId: string;
+  accepted: boolean;
+  status: string;
+  error: string;
+}
+
+export interface ExportScoresResponse {
+  results: ExportScoreResult[];
+  accepted: number;
+  duplicates: number;
+  rejectedCount: number;
+  /** Scores the backend refused outright, excluding idempotent duplicates. */
+  rejected: ExportScoreResult[];
+}
+
+/** The candidate under test, as recorded on a run and its trials. */
+export interface Candidate {
+  agentName?: string;
+  agentVersion?: string;
+  promptVersion?: string;
+  modelProvider?: string;
+  modelName?: string;
+  gitSha?: string;
+}
+
+/** Provenance for whatever produced a score. */
+export interface Evaluator {
+  evaluatorId: string;
+  version?: string;
+  kind?: string;
+  referenceSetId?: string;
+  referenceSetVersion?: string;
+}
+
+export interface CreateExperimentRequest {
+  runId?: string;
+  name: string;
+  description?: string;
+  tags?: string[];
+  suiteId?: string;
+  suiteVersion?: string;
+  candidate?: Record<string, unknown>;
+  plannedTrialCount?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ExperimentReportSummary {
+  testCaseCount: number;
+  trialCount: number;
+  completedCount: number;
+  failedCount: number;
+  canceledCount: number;
+  /** Unset when the backend omitted it, which is the case for a cloud-evaluated run. */
+  passRate?: number;
+  passAtK: Record<string, number>;
+  passPowerK: Record<string, number>;
+  finalScoreAvg?: number;
+  totalCost?: number;
+  totalTokens?: number;
+  passCount: number;
+  passDenominator: number;
+  finalScoreSum: number;
+  finalScoreCount: number;
+  tokenCoverage: string;
+  costCoverage: string;
+}
+
+/** An experiment run as the backend returns it. */
+export interface Experiment {
+  runId: string;
+  name: string;
+  status: string;
+  tenantId: string;
+  description: string;
+  tags: string[];
+  suiteId: string;
+  suiteVersion: string;
+  candidate: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+  error: string;
+  plannedTrialCount?: number;
+  resultStatus: string;
+  resultError: string;
+  result?: ExperimentReportSummary;
+  createdBy: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+  startedAt?: Date;
+  completedAt?: Date;
+}
+
+export interface ExperimentReport {
+  run: Experiment;
+  summary: ExperimentReportSummary;
+  rows: Record<string, unknown>[];
+}
+
+/** The work row a stored evaluator run is tracked by. */
+export interface TrialEvaluation {
+  evaluationId: string;
+  experimentId: string;
+  trialId: string;
+  testCaseId: string;
+  conversationId: string;
+  evaluatorId: string;
+  evaluatorVersion: string;
+  status: TrialEvaluationStatus;
+  attempts: number;
+  scheduledAt?: Date;
+  createdAt?: Date;
+  updatedAt?: Date;
+  error: string;
+}
+
+// --------------------------------------------------------------------------- //
+// Parsers
+// --------------------------------------------------------------------------- //
+
+export function parseExperiment(payload: unknown): Experiment {
+  if (!isRecord(payload)) {
+    throw transportError('invalid response payload');
+  }
+  return {
+    runId: str(payload.experiment_id) || str(payload.run_id),
+    name: str(payload.name),
+    status: str(payload.status),
+    tenantId: str(payload.tenant_id),
+    description: str(payload.description),
+    tags: strList(payload.tags),
+    suiteId: str(payload.suite_id),
+    suiteVersion: str(payload.suite_version),
+    candidate: record(payload.candidate),
+    metadata: record(payload.metadata),
+    error: str(payload.error),
+    plannedTrialCount: optionalInt(payload.planned_trial_count),
+    resultStatus: str(payload.result_status),
+    resultError: str(payload.result_error),
+    result: isRecord(payload.result) ? parseReportSummary(payload.result) : undefined,
+    createdBy: str(payload.created_by),
+    createdAt: parseTimestamp(payload.created_at),
+    updatedAt: parseTimestamp(payload.updated_at),
+    startedAt: parseTimestamp(payload.started_at),
+    completedAt: parseTimestamp(payload.completed_at),
+  };
+}
+
+/** Accepts both the `{run: {...}}` envelope and a bare run object. */
+export function parseExperimentRunResponse(payload: unknown): Experiment {
+  if (isRecord(payload) && isRecord(payload.run)) {
+    return parseExperiment(payload.run);
+  }
+  return parseExperiment(payload);
+}
+
+export function parseReportSummary(payload: unknown): ExperimentReportSummary {
+  const summary = isRecord(payload) ? payload : {};
+  return {
+    testCaseCount: int(summary.test_case_count),
+    trialCount: int(summary.trial_count),
+    completedCount: int(summary.completed_count),
+    failedCount: int(summary.failed_count),
+    canceledCount: int(summary.canceled_count),
+    passRate: optionalNumber(summary.pass_rate),
+    passAtK: numberMap(summary.pass_at_k),
+    passPowerK: numberMap(summary.pass_power_k),
+    finalScoreAvg: optionalNumber(summary.final_score_avg),
+    totalCost: optionalNumber(summary.total_cost),
+    totalTokens: optionalInt(summary.total_tokens),
+    passCount: int(summary.pass_count),
+    passDenominator: int(summary.pass_denominator),
+    finalScoreSum: num(summary.final_score_sum),
+    finalScoreCount: int(summary.final_score_count),
+    tokenCoverage: str(summary.token_coverage),
+    costCoverage: str(summary.cost_coverage),
+  };
+}
+
+/** Accepts both report envelopes: the backend keys the run under `experiment`, older drafts under `run`. */
+export function parseExperimentReport(payload: unknown): ExperimentReport {
+  if (!isRecord(payload)) {
+    throw transportError('invalid response payload');
+  }
+  const runPayload = isRecord(payload.experiment) ? payload.experiment : isRecord(payload.run) ? payload.run : {};
+  return {
+    run: parseExperiment(runPayload),
+    summary: parseReportSummary(payload.summary),
+    rows: Array.isArray(payload.rows) ? payload.rows.filter(isRecord) : [],
+  };
+}
+
+/**
+ * Parses one evaluation row.
+ *
+ * An unknown status is a hard error, not "keep polling": a newer terminal state
+ * would otherwise read as non-terminal and poll until the caller's deadline. A
+ * blank `evaluation_id` would turn the next status read into a validation error
+ * that blames the caller's arguments.
+ */
+export function parseTrialEvaluation(payload: unknown): TrialEvaluation {
+  if (!isRecord(payload)) {
+    throw transportError('invalid response payload');
+  }
+  const rawStatus = str(payload.status);
+  if (!trialEvaluationStatuses.includes(rawStatus as TrialEvaluationStatus)) {
+    throw transportError(`unsupported evaluation status "${rawStatus}"`);
+  }
+  const evaluationId = str(payload.evaluation_id).trim();
+  if (evaluationId.length === 0) {
+    throw transportError('evaluation response carries no evaluation_id');
+  }
+  return {
+    evaluationId,
+    experimentId: str(payload.experiment_id),
+    trialId: str(payload.trial_id),
+    testCaseId: str(payload.test_case_id),
+    conversationId: str(payload.conversation_id),
+    evaluatorId: str(payload.evaluator_id),
+    evaluatorVersion: str(payload.evaluator_version),
+    status: rawStatus as TrialEvaluationStatus,
+    attempts: int(payload.attempts),
+    scheduledAt: parseTimestamp(payload.scheduled_at),
+    createdAt: parseTimestamp(payload.created_at),
+    updatedAt: parseTimestamp(payload.updated_at),
+    error: str(payload.error),
+  };
+}
+
+export function parseExportScoresResponse(payload: unknown): ExportScoresResponse {
+  if (!isRecord(payload)) {
+    throw transportError('invalid response payload');
+  }
+  const results: ExportScoreResult[] = [];
+  for (const entry of Array.isArray(payload.results) ? payload.results : []) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+    results.push({
+      scoreId: str(entry.score_id),
+      accepted: entry.accepted === true,
+      status: str(entry.status),
+      error: str(entry.error),
+    });
+  }
+  const accepted = int(payload.accepted) || results.filter((result) => result.accepted).length;
+  const duplicates = int(payload.duplicates) || results.filter((result) => result.status === 'duplicate').length;
+  const rejected = results.filter((result) => !result.accepted && result.status !== 'duplicate');
+  return {
+    results,
+    accepted,
+    duplicates,
+    rejectedCount: int(payload.rejected) || rejected.length,
+    rejected,
+  };
+}
+
+// --------------------------------------------------------------------------- //
+// Field decoding
+// --------------------------------------------------------------------------- //
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function str(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+export function num(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+export function int(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.trunc(value) : 0;
+}
+
+export function optionalNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+export function optionalInt(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.trunc(value) : undefined;
+}
+
+function strList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : [];
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? { ...value } : {};
+}
+
+function numberMap(value: unknown): Record<string, number> {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const out: Record<string, number> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    out[key] = num(raw);
+  }
+  return out;
+}
+
+/** Parses an RFC 3339 timestamp, returning undefined for a blank or unparseable value. */
+export function parseTimestamp(value: unknown): Date | undefined {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return undefined;
+  }
+  const parsed = new Date(value.trim());
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+/**
+ * Formats a timestamp the way the backend expects it: RFC 3339 in UTC.
+ *
+ * Milliseconds survive, because two scores created 300 ms apart must not carry
+ * the same `created_at`. Only an all-zero fraction is dropped, which is what Go's
+ * `time.RFC3339Nano` does and what keeps the whole-second fixture in
+ * `conformance/experiments/requests.json` identical across the three SDKs.
+ */
+export function formatTimestamp(value: Date): string {
+  return value.toISOString().replace(/\.000Z$/, 'Z');
+}
+
+/** Reads a paging cursor, treating a blank value and `"0"` as "no more pages". */
+export function normalizeCursor(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const text = value.trim();
+  if (text.length === 0 || text === '0') {
+    return undefined;
+  }
+  return text;
+}

--- a/js/src/experiments/otel.ts
+++ b/js/src/experiments/otel.ts
@@ -1,0 +1,187 @@
+/**
+ * OpenTelemetry GenAI evaluation telemetry for Agent Observability experiments.
+ *
+ * The experiments surface writes scores over the v1 ingest path. When explicitly
+ * enabled, it also emits OpenTelemetry so already-instrumented agents line up
+ * with Agent Observability's eval model.
+ *
+ * OpenTelemetry names are emitted directly; there is no parallel `agento11y.*`
+ * mirror. Merged names go out as-is (the `gen_ai.evaluation.result` event and its
+ * attributes, `gen_ai.request.model` / `gen_ai.agent.*` on the candidate, and the
+ * `test.*` suite and case identity). Names Grafana is pushing through the OTel
+ * GenAI SIG are a best-effort prediction and can change until upstream adopts them;
+ * `agento11y.eval.schema.version` stamps which prediction generation a consumer
+ * is reading.
+ *
+ * Attribute names are kept identical to `python/agento11y/experiments/otel.py`.
+ */
+
+import type { AttributeValue } from '@opentelemetry/api';
+
+/**
+ * The OTel instrumentation scope name is a telemetry-visible data contract
+ * consumed outside this repository, so it intentionally keeps the pre-rename
+ * module name. Do not update it for the sigil-sdk -> agento11y rename without
+ * server-side dual-read support.
+ */
+export const INSTRUMENTATION_NAME = 'sigil_sdk.experiments';
+export const SCHEMA_VERSION = 'experiments-otel-2026-06';
+export const ATTR_SCHEMA_VERSION = 'agento11y.eval.schema.version';
+
+/** Trial span name prefix; the test case id is appended. */
+export const TRIAL_SPAN_NAME = 'eval.trial';
+
+export const EVENT_EVAL_RESULT = 'gen_ai.evaluation.result';
+export const EVAL_NAME = 'gen_ai.evaluation.name';
+export const EVAL_SCORE_VALUE = 'gen_ai.evaluation.score.value';
+export const EVAL_SCORE_LABEL = 'gen_ai.evaluation.score.label';
+export const EVAL_EXPLANATION = 'gen_ai.evaluation.explanation';
+export const RESPONSE_ID = 'gen_ai.response.id';
+
+export const EVAL_EVALUATOR_ID = 'gen_ai.evaluation.evaluator.id';
+export const EVAL_EVALUATOR_VERSION = 'gen_ai.evaluation.evaluator.version';
+export const EVAL_EVALUATOR_TYPE = 'gen_ai.evaluation.evaluator.type';
+export const EVAL_REFERENCE_SET_ID = 'gen_ai.evaluation.reference_set.id';
+export const EVAL_REFERENCE_SET_VERSION = 'gen_ai.evaluation.reference_set.version';
+
+export const TEST_SUITE_RUN_ID = 'test.suite.run.id';
+export const TEST_SUITE_NAME = 'test.suite.name';
+export const TEST_SUITE_RUN_STATUS = 'test.suite.run.status';
+export const TEST_SUITE_ID = 'test.suite.id';
+export const TEST_SUITE_VERSION = 'test.suite.version';
+export const TEST_CASE_ID = 'test.case.id';
+export const TEST_CASE_NAME = 'test.case.name';
+export const TEST_CASE_RESULT_STATUS = 'test.case.result.status';
+export const TEST_CASE_RUN_ID = 'test.case.run.id';
+export const TEST_CASE_RUN_ATTEMPT = 'test.case.run.attempt';
+
+export const OPERATION_NAME = 'gen_ai.operation.name';
+export const CONVERSATION_ID = 'gen_ai.conversation.id';
+
+export const ARTIFACT_EVENT = 'agento11y.eval.artifact';
+export const ARTIFACT_NAME = 'agento11y.eval.artifact.name';
+export const ARTIFACT_KIND = 'agento11y.eval.artifact.kind';
+
+/** Experiment/run status (API) mapped onto the general OTel `test.suite.run.status` enum. */
+const runStatusMap: Record<string, string> = {
+  running: 'in_progress',
+  succeeded: 'success',
+  completed: 'success',
+  failed: 'failure',
+  canceled: 'aborted',
+  cancelled: 'aborted',
+};
+
+/**
+ * Trial status (API) mapped onto `test.case.result.status`. The merged registry
+ * enum is `pass|fail` only, so non-verdict states emit nothing: the terminal state
+ * lives on the REST trial and the span status.
+ */
+const trialStatusMap: Record<string, string> = {
+  passed: 'pass',
+  failed: 'fail',
+};
+
+export function runStatusTelemetry(status: string): string {
+  return runStatusMap[status.trim().toLowerCase()] ?? 'in_progress';
+}
+
+export function trialStatusTelemetry(status: string): string {
+  return trialStatusMap[status.trim().toLowerCase()] ?? '';
+}
+
+/** The OTel `gen_ai.evaluation.score.label` for a pass/fail verdict. */
+export function scoreLabel(passed: boolean | undefined): string {
+  if (passed === undefined) {
+    return '';
+  }
+  return passed ? 'pass' : 'fail';
+}
+
+export interface TrialIdentityInput {
+  experimentId: string;
+  experimentName?: string;
+  suiteId?: string;
+  suiteVersion?: string;
+  suiteName?: string;
+  testCaseId?: string;
+  testCaseName?: string;
+  attempt?: number;
+  trialId?: string;
+  runStatus?: string;
+  trialStatus?: string;
+  conversationId?: string;
+  operationName?: string;
+}
+
+/** Builds the `test.*` identity attribute set for a trial span. */
+export function trialIdentityAttributes(input: TrialIdentityInput): Record<string, AttributeValue> {
+  const attrs: Record<string, AttributeValue> = { [ATTR_SCHEMA_VERSION]: SCHEMA_VERSION };
+  put(attrs, OPERATION_NAME, input.operationName ?? 'invoke_agent');
+  put(attrs, TEST_SUITE_RUN_ID, input.experimentId);
+  put(attrs, TEST_SUITE_NAME, firstNonBlank(input.suiteName, input.experimentName));
+  put(attrs, TEST_SUITE_RUN_STATUS, runStatusTelemetry(input.runStatus ?? 'running'));
+  put(attrs, TEST_SUITE_ID, input.suiteId);
+  put(attrs, TEST_SUITE_VERSION, input.suiteVersion);
+  put(attrs, TEST_CASE_ID, input.testCaseId);
+  put(attrs, TEST_CASE_NAME, firstNonBlank(input.testCaseName, input.testCaseId));
+  put(attrs, TEST_CASE_RESULT_STATUS, trialStatusTelemetry(input.trialStatus ?? 'running'));
+  put(attrs, TEST_CASE_RUN_ID, input.trialId);
+  attrs[TEST_CASE_RUN_ATTEMPT] = Math.trunc(input.attempt ?? 1);
+  put(attrs, CONVERSATION_ID, input.conversationId);
+  return attrs;
+}
+
+export interface ScoreEventInput {
+  name: string;
+  value: number | boolean | string | undefined;
+  passed?: boolean;
+  explanation?: string;
+  evaluatorId?: string;
+  evaluatorVersion?: string;
+  evaluatorKind?: string;
+  referenceSetId?: string;
+  referenceSetVersion?: string;
+  responseId?: string;
+}
+
+/** Builds the attribute set for one `gen_ai.evaluation.result` event. */
+export function scoreEventAttributes(input: ScoreEventInput): Record<string, AttributeValue> {
+  const attrs: Record<string, AttributeValue> = {};
+  put(attrs, EVAL_NAME, input.name);
+  // OTel score.value is a double, so only numeric and boolean values set it.
+  if (typeof input.value === 'boolean') {
+    attrs[EVAL_SCORE_VALUE] = input.value ? 1 : 0;
+  } else if (typeof input.value === 'number') {
+    attrs[EVAL_SCORE_VALUE] = input.value;
+  }
+  // The verdict lives in the label: pass/fail when known, else a categorical value.
+  let label = scoreLabel(input.passed);
+  if (label.length === 0 && typeof input.value === 'string') {
+    label = input.value;
+  }
+  put(attrs, EVAL_SCORE_LABEL, label);
+  put(attrs, EVAL_EXPLANATION, input.explanation);
+  put(attrs, RESPONSE_ID, input.responseId);
+  put(attrs, EVAL_EVALUATOR_ID, input.evaluatorId);
+  put(attrs, EVAL_EVALUATOR_VERSION, input.evaluatorVersion);
+  put(attrs, EVAL_EVALUATOR_TYPE, input.evaluatorKind);
+  put(attrs, EVAL_REFERENCE_SET_ID, input.referenceSetId);
+  put(attrs, EVAL_REFERENCE_SET_VERSION, input.referenceSetVersion);
+  return attrs;
+}
+
+function put(attrs: Record<string, AttributeValue>, key: string, value: string | undefined): void {
+  if (value !== undefined && value.length > 0) {
+    attrs[key] = value;
+  }
+}
+
+function firstNonBlank(...values: (string | undefined)[]): string | undefined {
+  for (const value of values) {
+    if (value !== undefined && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}

--- a/js/src/experiments/routes.ts
+++ b/js/src/experiments/routes.ts
@@ -1,0 +1,93 @@
+/**
+ * The experiment ingest and query routes, copied from
+ * `python/agento11y/_experiments_transport.py`.
+ *
+ * External writes go through the ingest lifecycle on the same tenant token used
+ * for generation export:
+ *
+ * ```
+ * POST   /api/v1/experiment-runs:upsert              create or claim an external run
+ * POST   /api/v1/experiment-runs/{runId}:finalize    finalize an external run
+ * POST   /api/v1/scores:export                       publish scores (attribute via experiment_id)
+ * POST   /api/v1/generations:export                  publish the trial's anchor generation
+ * POST   /api/v1/experiment-runs/{runId}/trials      create or claim a typed trial
+ * PATCH  /api/v1/experiment-runs/{runId}/trials/{trialId}
+ * POST   /api/v1/experiment-runs/{runId}/trials/{trialId}/artifacts:upload
+ * POST   /api/v1/experiment-runs/{runId}/trials/{trialId}:evaluate
+ * GET    /api/v1/experiment-runs/{runId}/trials/{trialId}/evaluations/{evaluationId}
+ * ```
+ *
+ * Reads use the Agent Observability query routes on the same endpoint and auth:
+ *
+ * ```
+ * GET    /api/v1/eval/experiments/{runId}            fetch a run
+ * GET    /api/v1/eval/experiments/{runId}/scores     list run scores (paginated)
+ * GET    /api/v1/eval/experiments/{runId}/report     aggregated run report
+ * ```
+ */
+
+export const DEFAULT_PATH_PREFIX = '/api/v1';
+export const EVAL_EXPERIMENTS_SUFFIX = '/eval/experiments';
+export const EXPERIMENT_RUNS_PREFIX = '/api/v1/experiment-runs';
+export const EXPERIMENT_RUNS_UPSERT_PATH = '/api/v1/experiment-runs:upsert';
+export const SCORES_EXPORT_PATH = '/api/v1/scores:export';
+export const GENERATIONS_EXPORT_PATH = '/api/v1/generations:export';
+
+/** Percent-encodes one dynamic path segment.
+ *
+ * `encodeURIComponent` is required, not `encodeURI`: a `:` inside a trial ID
+ * would otherwise shadow the trailing `:evaluate` and `:finalize` verbs, which
+ * the ingest router reads off the raw path segment before decoding the ID.
+ */
+export function segment(value: string): string {
+  return encodeURIComponent(value);
+}
+
+export function runUpsertPath(): string {
+  return EXPERIMENT_RUNS_UPSERT_PATH;
+}
+
+export function runFinalizePath(runId: string): string {
+  return `${EXPERIMENT_RUNS_PREFIX}/${segment(runId)}:finalize`;
+}
+
+export function scoresExportPath(): string {
+  return SCORES_EXPORT_PATH;
+}
+
+export function generationsExportPath(): string {
+  return GENERATIONS_EXPORT_PATH;
+}
+
+export function trialsPath(runId: string): string {
+  return `${EXPERIMENT_RUNS_PREFIX}/${segment(runId)}/trials`;
+}
+
+export function trialPath(runId: string, trialId: string): string {
+  return `${EXPERIMENT_RUNS_PREFIX}/${segment(runId)}/trials/${segment(trialId)}`;
+}
+
+export function trialArtifactUploadPath(runId: string, trialId: string): string {
+  return `${trialPath(runId, trialId)}/artifacts:upload`;
+}
+
+export function trialEvaluatePath(runId: string, trialId: string): string {
+  return `${trialPath(runId, trialId)}:evaluate`;
+}
+
+export function trialEvaluationPath(runId: string, trialId: string, evaluationId: string): string {
+  return `${trialPath(runId, trialId)}/evaluations/${segment(evaluationId)}`;
+}
+
+export function experimentReadPath(runId: string, pathPrefix: string = DEFAULT_PATH_PREFIX): string {
+  const prefix = `/${pathPrefix.trim().replace(/^\/+|\/+$/g, '')}`;
+  return `${prefix}${EVAL_EXPERIMENTS_SUFFIX}/${segment(runId)}`;
+}
+
+export function experimentScoresPath(runId: string, pathPrefix: string = DEFAULT_PATH_PREFIX): string {
+  return `${experimentReadPath(runId, pathPrefix)}/scores`;
+}
+
+export function experimentReportPath(runId: string, pathPrefix: string = DEFAULT_PATH_PREFIX): string {
+  return `${experimentReadPath(runId, pathPrefix)}/report`;
+}

--- a/js/src/experiments/serialize.ts
+++ b/js/src/experiments/serialize.ts
@@ -1,0 +1,135 @@
+import { validationError } from './errors.js';
+import type { CreateExperimentRequest, ScoreItem, ScoreValue } from './models.js';
+import { formatTimestamp } from './models.js';
+
+/** The `source` object every experiment-run and score write carries. */
+export const EXPERIMENT_RUN_SOURCE = { kind: 'sdk', id: 'js' } as const;
+
+/**
+ * Serializes a run upsert body.
+ *
+ * The backend ingest route keys on `experiment_id`, not `run_id`, and rejects
+ * unknown fields, so `runId` is renamed here rather than at the call site.
+ */
+export function serializeUpsertRequest(request: CreateExperimentRequest): Record<string, unknown> {
+  const name = request.name.trim();
+  if (name.length === 0) {
+    throw validationError('name is required');
+  }
+  const out: Record<string, unknown> = { name, source: { ...EXPERIMENT_RUN_SOURCE } };
+  if (request.runId !== undefined && request.runId.length > 0) {
+    out.experiment_id = request.runId;
+  }
+  if (request.description !== undefined && request.description.length > 0) {
+    out.description = request.description;
+  }
+  if (request.tags !== undefined && request.tags.length > 0) {
+    out.tags = [...request.tags];
+  }
+  if (request.suiteId !== undefined && request.suiteId.length > 0) {
+    out.suite_id = request.suiteId;
+  }
+  if (request.suiteVersion !== undefined && request.suiteVersion.length > 0) {
+    out.suite_version = request.suiteVersion;
+  }
+  if (request.candidate !== undefined && Object.keys(request.candidate).length > 0) {
+    out.candidate = { ...request.candidate };
+  }
+  if (request.plannedTrialCount !== undefined) {
+    if (request.plannedTrialCount < 0) {
+      throw validationError('planned_trial_count must be non-negative');
+    }
+    out.planned_trial_count = request.plannedTrialCount;
+  }
+  if (request.metadata !== undefined && Object.keys(request.metadata).length > 0) {
+    out.metadata = { ...request.metadata };
+  }
+  return out;
+}
+
+export function serializeScoreValue(value: ScoreValue): Record<string, unknown> {
+  if (value.number !== undefined) {
+    return { number: value.number };
+  }
+  if (value.boolean !== undefined) {
+    return { bool: value.boolean };
+  }
+  if (value.string !== undefined) {
+    return { string: value.string };
+  }
+  throw new Error('agento11y score validation failed: value must set one of number/boolean/string');
+}
+
+/**
+ * Builds the score body.
+ *
+ * `evaluatorKind` is missing on purpose: it names the evaluator type on the OTel
+ * evaluation event, and neither Go's nor Python's score body carries it.
+ */
+export function serializeScore(score: ScoreItem): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    score_id: score.scoreId,
+    evaluator_id: score.evaluatorId,
+    evaluator_version: score.evaluatorVersion,
+    score_key: score.scoreKey,
+    value: serializeScoreValue(score.value),
+  };
+  putNonBlank(out, 'generation_id', score.generationId);
+  putNonBlank(out, 'conversation_id', score.conversationId);
+  putNonBlank(out, 'experiment_id', score.experimentId);
+  putNonBlank(out, 'trial_id', score.trialId);
+  putNonBlank(out, 'test_case_id', score.testCaseId);
+  putNonBlank(out, 'trace_id', score.traceId);
+  putNonBlank(out, 'span_id', score.spanId);
+  putNonBlank(out, 'grader_conversation_id', score.graderConversationId);
+  putNonBlank(out, 'grader_generation_id', score.graderGenerationId);
+  putNonBlank(out, 'grader_trace_id', score.graderTraceId);
+  putNonBlank(out, 'rule_id', score.ruleId);
+  if (score.passed !== undefined) {
+    out.passed = score.passed;
+  }
+  putNonBlank(out, 'explanation', score.explanation);
+  if (score.metadata !== undefined && Object.keys(score.metadata).length > 0) {
+    out.metadata = { ...score.metadata };
+  }
+  if (score.createdAt !== undefined) {
+    out.created_at = formatTimestamp(score.createdAt);
+  }
+  if (score.source !== undefined && ((score.source.kind ?? '').length > 0 || (score.source.id ?? '').length > 0)) {
+    out.source = { kind: score.source.kind ?? '', id: score.source.id ?? '' };
+  }
+  return out;
+}
+
+/**
+ * Rejects a score the backend would reject, so the error names the missing field
+ * instead of arriving as a 400 body.
+ */
+export function validateScore(score: ScoreItem): void {
+  const missing: string[] = [];
+  for (const [name, raw] of [
+    ['score_id', score.scoreId],
+    ['evaluator_id', score.evaluatorId],
+    ['evaluator_version', score.evaluatorVersion],
+    ['score_key', score.scoreKey],
+  ] as const) {
+    if (raw.trim().length === 0) {
+      missing.push(name);
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(`agento11y score validation failed: missing required field(s): ${missing.join(', ')}`);
+  }
+  // The backend requires a generation_id OR a trial_id.
+  if ((score.generationId ?? '').trim().length === 0 && (score.trialId ?? '').trim().length === 0) {
+    throw new Error('agento11y score validation failed: generation_id or trial_id is required');
+  }
+  serializeScoreValue(score.value);
+}
+
+/** Sets `key` only when `value` has content, so blank optional fields are omitted. */
+export function putNonBlank(out: Record<string, unknown>, key: string, value: string | undefined): void {
+  if (value !== undefined && value.length > 0) {
+    out[key] = value;
+  }
+}

--- a/js/src/experiments/suites.ts
+++ b/js/src/experiments/suites.ts
@@ -1,0 +1,638 @@
+/**
+ * Control-plane client for stored Agent Observability test suites.
+ *
+ * Experiment ingest writes runs, trials, scores, and generations with the ingest
+ * token. Stored test suites live behind the Grafana plugin control plane, which
+ * takes a service-account token instead, so this client keeps its own credential
+ * and its own base URL.
+ */
+
+import { defaultEnv, resolveHeadersWithAuth } from '../config.js';
+import {
+  CONFLICT_PREFIX,
+  ExperimentConflictError,
+  NOT_FOUND_PREFIX,
+  notFoundError,
+  transportError,
+  validationError,
+} from './errors.js';
+import { isRecord, normalizeCursor, str } from './models.js';
+import type { ExperimentsRetryPolicy } from './transport.js';
+import { requestExperimentsJSON } from './transport.js';
+import type { TestCase, TestSuite } from './types.js';
+
+const DEFAULT_CONTROL_PATH = '/api/plugins/grafana-agento11y-app/resources/eval';
+const GRAFANA_APP_PATH = '/a/grafana-agento11y-app';
+const PORTABILITY_METADATA_KEY = 'agento11y.sdk.portability';
+const PORTABILITY_VERSION = 1;
+/**
+ * Control-plane requests get six total attempts, not the ingest transport's four:
+ * a stored-suite push is a long interactive operation and a lost draft costs the
+ * caller the whole push. Go uses the same budget; Python leaves its control-plane
+ * client on the default four.
+ */
+const CONTROL_MAX_RETRIES = 5;
+const DEFAULT_PAGE_LIMIT = 200;
+const DEFAULT_MAX_PAGES = 100;
+
+const ENV_GRAFANA_URL = 'AGENTO11Y_GRAFANA_URL';
+const ENV_CONTROL_ENDPOINT = 'AGENTO11Y_CONTROL_ENDPOINT';
+const ENV_SERVICE_ACCOUNT_TOKEN = 'AGENTO11Y_SERVICE_ACCOUNT_TOKEN';
+
+export interface TestSuitesClientOptions {
+  /** Grafana base URL. Falls back to `AGENTO11Y_GRAFANA_URL`. */
+  grafanaUrl?: string;
+  /** Control-plane base URL. Falls back to `AGENTO11Y_CONTROL_ENDPOINT`, then `grafanaUrl`. */
+  controlEndpoint?: string;
+  /** Grafana service-account token. Falls back to `AGENTO11Y_SERVICE_ACCOUNT_TOKEN`. */
+  serviceAccountToken?: string;
+  timeoutMs?: number;
+  retry?: Partial<ExperimentsRetryPolicy>;
+  fetchImpl?: typeof fetch;
+  sleep?: (durationMs: number, signal?: AbortSignal) => Promise<void>;
+  env?: Record<string, string | undefined>;
+}
+
+export interface ListOptions {
+  limit?: number;
+  maxPages?: number;
+}
+
+export interface PushSuiteOptions {
+  publish?: boolean;
+  changelog?: string;
+  emptyDraft?: boolean;
+  /** Deletes remote-only cases so the draft matches the local suite exactly. */
+  prune?: boolean;
+}
+
+/** Summary returned by `pushSuite`. */
+export interface PushedSuite {
+  suiteId: string;
+  suiteVersion: string;
+  published: boolean;
+  suite: TestSuite;
+  remoteSuite: Record<string, unknown>;
+  remoteVersion: Record<string, unknown>;
+  prunedCaseIds: string[];
+}
+
+export class TestSuitesClient {
+  readonly endpoint: string;
+  readonly grafanaUrl: string;
+
+  private readonly headers: Record<string, string>;
+  private readonly retry: Partial<ExperimentsRetryPolicy>;
+  private readonly fetchImpl: typeof fetch | undefined;
+  private readonly sleep: ((durationMs: number, signal?: AbortSignal) => Promise<void>) | undefined;
+
+  constructor(options: TestSuitesClientOptions = {}) {
+    const env = options.env ?? defaultEnv();
+    const grafana = (options.grafanaUrl ?? env[ENV_GRAFANA_URL] ?? '').trim();
+    let endpoint = (options.controlEndpoint ?? env[ENV_CONTROL_ENDPOINT] ?? '').trim();
+    if (endpoint.length === 0) {
+      if (grafana.length === 0) {
+        throw new Error('agento11y experiments: controlEndpoint is required (or set AGENTO11Y_CONTROL_ENDPOINT)');
+      }
+      endpoint = grafana;
+    }
+    const token = (options.serviceAccountToken ?? env[ENV_SERVICE_ACCOUNT_TOKEN] ?? '').trim();
+    if (token.length === 0) {
+      throw new Error(
+        'agento11y experiments: serviceAccountToken is required (or set AGENTO11Y_SERVICE_ACCOUNT_TOKEN)',
+      );
+    }
+    this.endpoint = normalizeControlEndpoint(endpoint);
+    const parsed = new URL(this.endpoint);
+    this.grafanaUrl = grafana.length > 0 ? grafana.replace(/\/+$/, '') : `${parsed.protocol}//${parsed.host}`;
+    this.headers = {
+      ...(resolveHeadersWithAuth(undefined, { mode: 'bearer', bearerToken: token }, 'agento11y test suites') ?? {}),
+    };
+    this.retry = {
+      maxRetries: CONTROL_MAX_RETRIES,
+      ...options.retry,
+      ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+    };
+    this.fetchImpl = options.fetchImpl;
+    this.sleep = options.sleep;
+  }
+
+  /** Lists every stored suite visible to the control-plane token. */
+  async listSuites(options: ListOptions = {}): Promise<Record<string, unknown>[]> {
+    return this.pageThrough('/test-suites', options, (items) => items, 'test suite list');
+  }
+
+  /** Fetches one stored suite record, including its version metadata. */
+  async getSuite(suiteId: string): Promise<Record<string, unknown>> {
+    const normalized = requireId(suiteId, 'suite_id');
+    const body = await this.request('GET', `/test-suites/${encodeURIComponent(normalized)}`);
+    return isRecord(body) ? body : {};
+  }
+
+  /** Lists every case in one exact stored suite version. */
+  async listCases(suiteId: string, version: string, options: ListOptions = {}): Promise<TestCase[]> {
+    const normalizedSuite = requireId(suiteId, 'suite_id');
+    const normalizedVersion = requireId(version, 'version');
+    return this.pageThrough(
+      `/test-suites/${encodeURIComponent(normalizedSuite)}/versions/${encodeURIComponent(normalizedVersion)}/test-cases`,
+      options,
+      (items) => items.map(remoteCaseToLocal),
+      'test case list',
+    );
+  }
+
+  /** Pulls a stored suite version into the SDK's portable `TestSuite` shape. */
+  async pullSuite(suiteId: string, version = 'latest_published'): Promise<TestSuite> {
+    const remote = await this.getSuite(suiteId);
+    const resolved = resolveVersion(remote, version);
+    const cases = await this.listCases(suiteId, resolved);
+    return {
+      suiteId: str(remote.suite_id).length > 0 ? str(remote.suite_id) : suiteId,
+      name: str(remote.name),
+      version: resolved,
+      description: str(remote.description),
+      tags: Array.isArray(remote.tags) ? remote.tags.filter((tag): tag is string => typeof tag === 'string') : [],
+      changelog: str(versionRecord(remote, resolved).changelog),
+      testCases: cases,
+    };
+  }
+
+  /**
+   * Pushes local suite metadata and cases into a mutable stored draft.
+   *
+   * Local cases are upserted into the draft. Set `prune` to delete remote-only
+   * cases and make the draft match the local suite exactly.
+   */
+  async pushSuite(suite: TestSuite, options: PushSuiteOptions = {}): Promise<PushedSuite> {
+    const suiteId = requireId(suite.suiteId, 'suite_id');
+    let remote = await this.ensureSuite(suite);
+    await this.patchSuiteMetadata(suite, remote);
+    remote = await this.getSuite(suiteId);
+    const changelog = options.changelog ?? suite.changelog ?? '';
+    let version = await this.ensureDraftVersion(suiteId, remote, changelog, options.emptyDraft ?? false);
+    const versionId = str(version.version);
+    if (versionId.length === 0) {
+      throw transportError('test suite version: missing version');
+    }
+
+    for (const testCase of suite.testCases) {
+      await this.upsertCase(suiteId, versionId, testCase);
+    }
+
+    const prunedCaseIds: string[] = [];
+    if (options.prune === true) {
+      const localIds = new Set(suite.testCases.map((testCase) => testCase.testCaseId));
+      for (const remoteCase of await this.listCases(suiteId, versionId)) {
+        if (!localIds.has(remoteCase.testCaseId)) {
+          await this.deleteCase(suiteId, versionId, remoteCase.testCaseId);
+          prunedCaseIds.push(remoteCase.testCaseId);
+        }
+      }
+    }
+
+    let published = false;
+    if (options.publish === true) {
+      const body = await this.request(
+        'POST',
+        `/test-suites/${encodeURIComponent(suiteId)}/versions/${encodeURIComponent(versionId)}:publish`,
+      );
+      version = isRecord(body) ? body : version;
+      published = isRecord(body) ? body.published === true : true;
+    }
+
+    return {
+      suiteId,
+      suiteVersion: versionId,
+      published,
+      suite: {
+        suiteId,
+        name: suite.name !== undefined && suite.name.length > 0 ? suite.name : str(remote.name),
+        version: versionId,
+        description:
+          suite.description !== undefined && suite.description.length > 0 ? suite.description : str(remote.description),
+        tags: suite.tags !== undefined && suite.tags.length > 0 ? [...suite.tags] : remoteTags(remote),
+        changelog,
+        testCases: [...suite.testCases],
+      },
+      remoteSuite: remote,
+      remoteVersion: version,
+      prunedCaseIds,
+    };
+  }
+
+  /** Resolves exact versions and the `latest_published`, `latest`, and `draft` aliases. */
+  resolveVersion(suite: Record<string, unknown>, version: string): string {
+    return resolveVersion(suite, version);
+  }
+
+  private async ensureSuite(suite: TestSuite): Promise<Record<string, unknown>> {
+    try {
+      return await this.getSuite(suite.suiteId);
+    } catch (error) {
+      if (!isNotFound(error)) {
+        throw error;
+      }
+      const payload: Record<string, unknown> = {
+        suite_id: suite.suiteId,
+        name: suite.name !== undefined && suite.name.length > 0 ? suite.name : suite.suiteId,
+      };
+      if (suite.description !== undefined && suite.description.length > 0) {
+        payload.description = suite.description;
+      }
+      if (suite.tags !== undefined && suite.tags.length > 0) {
+        payload.tags = [...suite.tags];
+      }
+      const body = await this.request('POST', '/test-suites', { payload });
+      return isRecord(body) ? body : {};
+    }
+  }
+
+  private async patchSuiteMetadata(suite: TestSuite, remote: Record<string, unknown>): Promise<void> {
+    const patch: Record<string, unknown> = {};
+    if (suite.name !== undefined && suite.name.length > 0 && suite.name !== remote.name) {
+      patch.name = suite.name;
+    }
+    if (suite.description !== undefined && suite.description.length > 0) {
+      patch.description = suite.description;
+    }
+    if (suite.tags !== undefined && suite.tags.length > 0) {
+      patch.tags = [...suite.tags];
+    }
+    if (Object.keys(patch).length > 0) {
+      await this.request('PATCH', `/test-suites/${encodeURIComponent(suite.suiteId)}`, { payload: patch });
+    }
+  }
+
+  private async ensureDraftVersion(
+    suiteId: string,
+    suite: Record<string, unknown>,
+    changelog: string,
+    emptyDraft: boolean,
+  ): Promise<Record<string, unknown>> {
+    const existing = draftVersion(versions(suite));
+    if (existing !== undefined) {
+      validateExistingDraftOptions(existing, changelog, emptyDraft);
+      return existing;
+    }
+    const payload: Record<string, unknown> = {};
+    if (changelog.length > 0) {
+      payload.changelog = changelog;
+    }
+    if (emptyDraft) {
+      payload.empty_draft = true;
+    }
+    try {
+      const body = await this.request('POST', `/test-suites/${encodeURIComponent(suiteId)}/versions`, { payload });
+      return isRecord(body) ? body : {};
+    } catch (error) {
+      if (!isConflict(error)) {
+        throw error;
+      }
+      // Another writer opened the draft between the read and this create.
+      const refreshed = await this.getSuite(suiteId);
+      const draft = draftVersion(versions(refreshed));
+      if (draft === undefined) {
+        throw error;
+      }
+      validateExistingDraftOptions(draft, changelog, emptyDraft);
+      return draft;
+    }
+  }
+
+  private async upsertCase(suiteId: string, version: string, testCase: TestCase): Promise<void> {
+    await this.request(
+      'POST',
+      `/test-suites/${encodeURIComponent(suiteId)}/versions/${encodeURIComponent(version)}/test-cases`,
+      { payload: localCaseToRemote(testCase) },
+    );
+  }
+
+  private async deleteCase(suiteId: string, version: string, testCaseId: string): Promise<void> {
+    await this.request(
+      'DELETE',
+      `/test-suites/${encodeURIComponent(suiteId)}/versions/${encodeURIComponent(version)}/test-cases/${encodeURIComponent(testCaseId)}`,
+    );
+  }
+
+  private async pageThrough<T>(
+    path: string,
+    options: ListOptions,
+    map: (items: Record<string, unknown>[]) => T[],
+    label: string,
+  ): Promise<T[]> {
+    const limit = options.limit !== undefined && options.limit > 0 ? options.limit : DEFAULT_PAGE_LIMIT;
+    const maxPages = options.maxPages !== undefined && options.maxPages > 0 ? options.maxPages : DEFAULT_MAX_PAGES;
+    const out: T[] = [];
+    let cursor: string | undefined;
+    for (let page = 0; page < maxPages; page++) {
+      const query: Record<string, string> = { limit: String(limit) };
+      if (cursor !== undefined) {
+        query.cursor = cursor;
+      }
+      const body = await this.request('GET', path, { query });
+      out.push(...map(items(body)));
+      cursor = normalizeCursor(isRecord(body) ? body.next_cursor : undefined);
+      if (cursor === undefined) {
+        return out;
+      }
+    }
+    throw transportError(`${label}: pagination did not terminate`);
+  }
+
+  private async request(
+    method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
+    path: string,
+    options: { payload?: Record<string, unknown>; query?: Record<string, string> } = {},
+  ): Promise<unknown> {
+    return requestExperimentsJSON(
+      {
+        // The normalized control endpoint already carries its own path prefix, so
+        // it is passed through as the base URL rather than as an API endpoint.
+        endpoint: this.endpoint,
+        insecure: this.endpoint.startsWith('http://'),
+        headers: this.headers,
+        retry: this.retry,
+        ...(this.fetchImpl !== undefined ? { fetchImpl: this.fetchImpl } : {}),
+        ...(this.sleep !== undefined ? { sleep: this.sleep } : {}),
+      },
+      {
+        method,
+        path: path.startsWith('/') ? path : `/${path}`,
+        ...(options.payload !== undefined ? { body: options.payload } : {}),
+        ...(options.query !== undefined ? { query: options.query } : {}),
+        label: 'test suite',
+      },
+    );
+  }
+}
+
+/**
+ * Normalizes a control endpoint onto the plugin resources path.
+ *
+ * A Grafana base URL, a URL that already points at the resources path, and a UI
+ * app URL all resolve to the same endpoint, so a caller can paste whichever URL
+ * they have.
+ */
+export function normalizeControlEndpoint(value: string): string {
+  const raw = value.trim().replace(/\/+$/, '');
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error('agento11y experiments: controlEndpoint must be an absolute URL');
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error('agento11y experiments: controlEndpoint must be an absolute URL');
+  }
+  const path = parsed.pathname.replace(/\/+$/, '');
+  let normalizedPath: string;
+  if (path.endsWith(DEFAULT_CONTROL_PATH) || path.endsWith('/api/v1/eval')) {
+    normalizedPath = path;
+  } else {
+    const appIndex = path.indexOf(GRAFANA_APP_PATH);
+    const prefix = appIndex >= 0 ? path.slice(0, appIndex) : path;
+    normalizedPath = prefix.replace(/\/+$/, '') + DEFAULT_CONTROL_PATH;
+  }
+  return `${parsed.protocol}//${parsed.host}${normalizedPath}`;
+}
+
+function resolveVersion(suite: Record<string, unknown>, version: string): string {
+  const requested = version.trim();
+  if (requested.length === 0) {
+    throw validationError('test suite: version is required');
+  }
+  const all = versions(suite);
+  let record: Record<string, unknown> | undefined;
+  if (requested === 'latest_published') {
+    record = latest(all.filter((item) => item.published === true));
+    if (record === undefined) {
+      throw notFoundError('test suite version: latest_published');
+    }
+  } else if (requested === 'latest') {
+    record = latest(all);
+    if (record === undefined) {
+      throw notFoundError('test suite version: latest');
+    }
+  } else if (requested === 'draft') {
+    record = draftVersion(all);
+    if (record === undefined) {
+      throw notFoundError('test suite version: draft');
+    }
+  } else {
+    if (all.some((item) => str(item.version) === requested)) {
+      return requested;
+    }
+    throw notFoundError(`test suite version: ${requested}`);
+  }
+  const resolved = str(record.version);
+  if (resolved.length === 0) {
+    throw notFoundError(`test suite version: ${requested}`);
+  }
+  return resolved;
+}
+
+function versions(suite: Record<string, unknown>): Record<string, unknown>[] {
+  return Array.isArray(suite.versions) ? suite.versions.filter(isRecord) : [];
+}
+
+function versionRecord(suite: Record<string, unknown>, version: string): Record<string, unknown> {
+  return versions(suite).find((item) => str(item.version) === version) ?? {};
+}
+
+function draftVersion(all: Record<string, unknown>[]): Record<string, unknown> | undefined {
+  return all.find((item) => item.published !== true);
+}
+
+/** Orders `v<N>` versions numerically and everything else lexically below them. */
+function latest(all: Record<string, unknown>[]): Record<string, unknown> | undefined {
+  let best: Record<string, unknown> | undefined;
+  let bestKey: [number, number, string] | undefined;
+  for (const item of all) {
+    const key = versionSortKey(str(item.version));
+    if (bestKey === undefined || compareKeys(key, bestKey) > 0) {
+      best = item;
+      bestKey = key;
+    }
+  }
+  return best;
+}
+
+function versionSortKey(value: string): [number, number, string] {
+  const match = /^v(\d+)$/.exec(value.trim());
+  if (match?.[1] !== undefined) {
+    return [1, Number.parseInt(match[1], 10), value];
+  }
+  return [0, 0, value];
+}
+
+function compareKeys(a: [number, number, string], b: [number, number, string]): number {
+  if (a[0] !== b[0]) {
+    return a[0] - b[0];
+  }
+  if (a[1] !== b[1]) {
+    return a[1] - b[1];
+  }
+  return a[2] < b[2] ? -1 : a[2] > b[2] ? 1 : 0;
+}
+
+/**
+ * Rejects push options an already-open draft cannot satisfy.
+ *
+ * Both cases are recoverable: the caller publishes or discards the draft and
+ * pushes again. They are classified `open_draft` so a caller branching on
+ * `ExperimentConflictError.recoverable` reaches that path, which is what Go does.
+ */
+function validateExistingDraftOptions(draft: Record<string, unknown>, changelog: string, emptyDraft: boolean): void {
+  const draftChangelog = str(draft.changelog);
+  if (changelog.length > 0 && changelog !== draftChangelog) {
+    throw new ExperimentConflictError(
+      'agento11y test suite conflict: an existing draft cannot apply a different changelog',
+      'open_draft',
+    );
+  }
+  if (emptyDraft) {
+    throw new ExperimentConflictError(
+      'agento11y test suite conflict: empty_draft only applies when creating a new draft',
+      'open_draft',
+    );
+  }
+}
+
+/** The remote suite's tags, used when the local suite leaves them unset. */
+function remoteTags(remote: Record<string, unknown>): string[] {
+  return Array.isArray(remote.tags) ? remote.tags.filter((tag): tag is string => typeof tag === 'string') : [];
+}
+
+/**
+ * Maps a local case onto the remote shape.
+ *
+ * The control plane stores `input` and `expected` as objects, so a scalar is
+ * wrapped as `{value: ...}` and the wrapping is recorded under the portability
+ * metadata key. `pullSuite` unwraps exactly the fields that record names, so a
+ * push-pull round trip returns the caller's original scalars.
+ */
+export function localCaseToRemote(testCase: TestCase): Record<string, unknown> {
+  if (testCase.testCaseId.trim().length === 0) {
+    throw validationError('test suite: test_case_id is required');
+  }
+  if (testCase.input === undefined || testCase.input === null) {
+    throw validationError('test suite: input is required');
+  }
+  const metadata: Record<string, unknown> = { ...(testCase.metadata ?? {}) };
+  const portability: Record<string, unknown> = { version: PORTABILITY_VERSION };
+  if (testCase.weight !== undefined && testCase.weight !== 1) {
+    portability.weight = testCase.weight;
+  }
+  const wrapped: string[] = [];
+  const [remoteInput, inputWrapped] = ensureObject(testCase.input);
+  if (inputWrapped) {
+    wrapped.push('input');
+  }
+  let remoteExpected: Record<string, unknown> | undefined;
+  if (testCase.expected !== undefined && testCase.expected !== null) {
+    const [value, expectedWrapped] = ensureObject(testCase.expected);
+    remoteExpected = value;
+    if (expectedWrapped) {
+      wrapped.push('expected');
+    }
+  }
+  if (wrapped.length > 0) {
+    portability.wrapped_fields = wrapped;
+  }
+  if (Object.keys(portability).length > 1) {
+    metadata[PORTABILITY_METADATA_KEY] = portability;
+  }
+
+  const out: Record<string, unknown> = { test_case_id: testCase.testCaseId, input: remoteInput };
+  if (testCase.name !== undefined && testCase.name.length > 0) {
+    out.name = testCase.name;
+  }
+  if (testCase.description !== undefined && testCase.description.length > 0) {
+    out.description = testCase.description;
+  }
+  if (testCase.tags !== undefined && testCase.tags.length > 0) {
+    out.tags = [...testCase.tags];
+  }
+  if (testCase.category !== undefined && testCase.category.length > 0) {
+    out.category = testCase.category;
+  }
+  if (remoteExpected !== undefined) {
+    out.expected = remoteExpected;
+  }
+  if (Object.keys(metadata).length > 0) {
+    out.metadata = metadata;
+  }
+  if (testCase.artifactRefs !== undefined && testCase.artifactRefs.length > 0) {
+    out.artifact_refs = testCase.artifactRefs.map((ref) => ({ ...ref }));
+  }
+  return out;
+}
+
+export function remoteCaseToLocal(data: Record<string, unknown>): TestCase {
+  const metadata: Record<string, unknown> = { ...(isRecord(data.metadata) ? data.metadata : {}) };
+  const rawPortability = metadata[PORTABILITY_METADATA_KEY];
+  let portability: Record<string, unknown> = {};
+  if (isRecord(rawPortability) && rawPortability.version === PORTABILITY_VERSION) {
+    portability = rawPortability;
+    delete metadata[PORTABILITY_METADATA_KEY];
+  }
+  const weight = typeof portability.weight === 'number' ? portability.weight : 1;
+  const wrapped = new Set(
+    Array.isArray(portability.wrapped_fields)
+      ? portability.wrapped_fields.filter((field): field is string => typeof field === 'string')
+      : [],
+  );
+  return {
+    testCaseId: str(data.test_case_id).length > 0 ? str(data.test_case_id) : str(data.id),
+    name: str(data.name),
+    description: str(data.description),
+    tags: Array.isArray(data.tags) ? data.tags.filter((tag): tag is string => typeof tag === 'string') : [],
+    category: str(data.category),
+    input: wrapped.has('input') ? unwrapValue(data.input) : data.input,
+    expected: wrapped.has('expected') ? unwrapValue(data.expected) : data.expected,
+    weight,
+    metadata,
+    artifactRefs: Array.isArray(data.artifact_refs)
+      ? data.artifact_refs.filter(isRecord).map((ref) => ({ ...ref }))
+      : [],
+  };
+}
+
+function ensureObject(value: unknown): [Record<string, unknown>, boolean] {
+  if (isRecord(value)) {
+    return [{ ...value }, false];
+  }
+  return [{ value }, true];
+}
+
+function unwrapValue(value: unknown): unknown {
+  if (isRecord(value) && Object.keys(value).length === 1 && 'value' in value) {
+    return value.value;
+  }
+  return value;
+}
+
+function items(body: unknown): Record<string, unknown>[] {
+  if (!isRecord(body) || !Array.isArray(body.items)) {
+    return [];
+  }
+  return body.items.filter(isRecord).map((item) => ({ ...item }));
+}
+
+function requireId(value: string, name: string): string {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw validationError(`test suite: ${name} is required`);
+  }
+  return normalized;
+}
+
+function isNotFound(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith(NOT_FOUND_PREFIX);
+}
+
+function isConflict(error: unknown): boolean {
+  return (
+    error instanceof ExperimentConflictError || (error instanceof Error && error.message.startsWith(CONFLICT_PREFIX))
+  );
+}

--- a/js/src/experiments/transport.ts
+++ b/js/src/experiments/transport.ts
@@ -1,0 +1,377 @@
+import { asError, baseURLFromAPIEndpoint } from '../utils.js';
+import { conflictError, notFoundError, TRANSPORT_PREFIX, transportError, validationError } from './errors.js';
+
+/** Response bodies above this size are abandoned instead of buffered. */
+export const MAX_RESPONSE_BYTES = 8 << 20;
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_INITIAL_BACKOFF_MS = 100;
+const DEFAULT_MAX_BACKOFF_MS = 5_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Retry behavior for experiment and score requests.
+ *
+ * Retries cover request timeouts, connection errors, HTTP 429, and HTTP 5xx,
+ * with exponential backoff bounded by `maxBackoffMs`. 4xx responses other than
+ * 429 are not retried (they are caller errors), and neither is a 503 that reports
+ * a backend capability gap rather than a transient outage.
+ */
+export interface ExperimentsRetryPolicy {
+  /** Retries after the first attempt. The default of 3 means four total attempts. */
+  maxRetries: number;
+  initialBackoffMs: number;
+  maxBackoffMs: number;
+  /** Per-attempt request timeout. Each attempt gets its own budget. */
+  timeoutMs: number;
+}
+
+export function resolveRetryPolicy(policy: Partial<ExperimentsRetryPolicy> | undefined): ExperimentsRetryPolicy {
+  return {
+    maxRetries: Math.max(0, policy?.maxRetries ?? DEFAULT_MAX_RETRIES),
+    initialBackoffMs: Math.max(0, policy?.initialBackoffMs ?? DEFAULT_INITIAL_BACKOFF_MS),
+    maxBackoffMs: Math.max(0, policy?.maxBackoffMs ?? DEFAULT_MAX_BACKOFF_MS),
+    timeoutMs: policy?.timeoutMs !== undefined && policy.timeoutMs > 0 ? policy.timeoutMs : DEFAULT_TIMEOUT_MS,
+  };
+}
+
+/** Connection and auth for the experiments routes. */
+export interface ExperimentsConnection {
+  /** The Agent Observability API endpoint. Absolute URL, `grpc://` URL, or `host:port`. */
+  endpoint: string;
+  insecure: boolean;
+  headers?: Record<string, string>;
+  retry?: Partial<ExperimentsRetryPolicy>;
+  fetchImpl?: typeof fetch;
+  /** Injected for tests so a backoff does not spend wall-clock time. */
+  sleep?: (durationMs: number, signal?: AbortSignal) => Promise<void>;
+}
+
+/**
+ * One experiments request.
+ *
+ * A request carries a JSON `body`, a raw `bytes` body, or neither. Passing both
+ * is rejected as a validation error rather than resolved by precedence.
+ */
+export interface ExperimentsRequest {
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  /** Path with every dynamic segment already percent-encoded (see `routes.ts`). */
+  path: string;
+  query?: Record<string, string>;
+  /** JSON request body. Must not be combined with `bytes`. */
+  body?: unknown;
+  /** Raw request body, used by artifact upload. Must not be combined with `body`. */
+  bytes?: Uint8Array;
+  contentType?: string;
+  /** Names the operation in error messages, e.g. `experiment create`. */
+  label: string;
+  signal?: AbortSignal;
+}
+
+/**
+ * Sends one experiments request and decodes its JSON response.
+ *
+ * Status mapping: 400 and 422 become validation errors, 404 not found, 409 a
+ * classified conflict; none of those are retried. Transport failures, 429, and
+ * 5xx are retried up to `retry.maxRetries` times. Everything else fails with the
+ * transport prefix.
+ *
+ * A caller `signal` aborts the wait immediately and rejects with the signal's own
+ * reason, so a cancellation is never reported as a timeout or transport failure.
+ */
+export async function requestExperimentsJSON(
+  connection: ExperimentsConnection,
+  request: ExperimentsRequest,
+): Promise<unknown> {
+  const policy = resolveRetryPolicy(connection.retry);
+  const fetchImpl = connection.fetchImpl ?? fetch;
+  const sleep = connection.sleep ?? sleepWithSignal;
+  const url = buildURL(connection, request);
+  const { headers, payload } = buildRequestInit(connection, request);
+
+  let backoffMs = policy.initialBackoffMs;
+
+  for (let attempt = 0; ; attempt++) {
+    throwIfAborted(request.signal);
+
+    const controller = new AbortController();
+    const unlink = linkSignal(request.signal, controller);
+    const timer = setTimeout(() => {
+      controller.abort(new Error(`request timed out after ${policy.timeoutMs}ms`));
+    }, policy.timeoutMs);
+
+    let outcome: AttemptOutcome;
+    try {
+      outcome = await sendAttempt(fetchImpl, url, request, headers, payload, controller.signal);
+    } catch (error) {
+      // The caller's own abort ends the call with the caller's reason.
+      throwIfAborted(request.signal);
+      if (error instanceof ResponseTooLargeError) {
+        throw transportError(`${request.label}: ${error.message}`);
+      }
+      outcome = { kind: 'failed', detail: asError(error).message, retryable: true };
+    } finally {
+      // The timeout and the caller link stay armed until the body has been read.
+      // A server that sends headers and then stalls the body must still fail the
+      // attempt instead of hanging the call.
+      clearTimeout(timer);
+      unlink();
+    }
+
+    if (outcome.kind === 'success') {
+      return decodeSuccess(outcome.text, request.label);
+    }
+    if (outcome.kind === 'fatal') {
+      throw outcome.error;
+    }
+    if (!outcome.retryable || attempt >= policy.maxRetries) {
+      throw transportError(`${request.label}: ${outcome.detail}`);
+    }
+
+    if (backoffMs > 0) {
+      await sleep(Math.min(backoffMs, policy.maxBackoffMs), request.signal);
+      backoffMs = Math.min(backoffMs * 2, policy.maxBackoffMs);
+    }
+  }
+}
+
+type AttemptOutcome =
+  | { kind: 'success'; text: string }
+  | { kind: 'fatal'; error: Error }
+  | { kind: 'failed'; detail: string; retryable: boolean };
+
+/**
+ * Runs one attempt and classifies its response.
+ *
+ * The body is read here, inside the caller's armed timeout, so a stalled body
+ * cannot outlive the per-attempt budget.
+ */
+async function sendAttempt(
+  fetchImpl: typeof fetch,
+  url: string,
+  request: ExperimentsRequest,
+  headers: Record<string, string>,
+  payload: BodyInit | undefined,
+  signal: AbortSignal,
+): Promise<AttemptOutcome> {
+  const response = await fetchImpl(url, {
+    method: request.method,
+    headers,
+    signal,
+    ...(payload !== undefined ? { body: payload } : {}),
+  });
+
+  if (response.status >= 200 && response.status < 300) {
+    return { kind: 'success', text: await readCappedText(response, request.label) };
+  }
+
+  const body = await readErrorBody(response);
+  const detail = body.length > 0 ? body : String(response.status);
+  if (response.status === 400 || response.status === 422) {
+    return { kind: 'fatal', error: validationError(`${request.label}: ${detail}`) };
+  }
+  if (response.status === 404) {
+    return { kind: 'fatal', error: notFoundError(`${request.label}: ${detail}`) };
+  }
+  if (response.status === 409) {
+    return { kind: 'fatal', error: conflictError(`${request.label}: ${detail}`) };
+  }
+  return {
+    kind: 'failed',
+    detail: `status ${response.status}: ${body.length > 0 ? body : 'unexpected status'}`,
+    retryable:
+      !isCapabilityGap(response, body) &&
+      (response.status === 429 || (response.status >= 500 && response.status < 600)),
+  };
+}
+
+/** Resolves after `durationMs`, rejecting with the signal's reason if it aborts first. */
+export function sleepWithSignal(durationMs: number, signal?: AbortSignal): Promise<void> {
+  if (durationMs <= 0) {
+    throwIfAborted(signal);
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted === true) {
+      reject(abortReason(signal));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, durationMs);
+    function onAbort(): void {
+      clearTimeout(timer);
+      reject(abortReason(signal));
+    }
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+export function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted === true) {
+    throw abortReason(signal);
+  }
+}
+
+function abortReason(signal: AbortSignal | undefined): unknown {
+  const reason = signal?.reason;
+  return reason !== undefined ? reason : new Error('aborted');
+}
+
+function linkSignal(signal: AbortSignal | undefined, controller: AbortController): () => void {
+  if (signal === undefined) {
+    return () => {};
+  }
+  const onAbort = (): void => {
+    controller.abort(signal.reason);
+  };
+  signal.addEventListener('abort', onAbort, { once: true });
+  return () => {
+    signal.removeEventListener('abort', onAbort);
+  };
+}
+
+function buildURL(connection: ExperimentsConnection, request: ExperimentsRequest): string {
+  const base = baseURLFromAPIEndpoint(connection.endpoint, connection.insecure, TRANSPORT_PREFIX);
+  const query = request.query;
+  if (query === undefined || Object.keys(query).length === 0) {
+    return `${base}${request.path}`;
+  }
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    params.set(key, value);
+  }
+  return `${base}${request.path}?${params.toString()}`;
+}
+
+function buildRequestInit(
+  connection: ExperimentsConnection,
+  request: ExperimentsRequest,
+): { headers: Record<string, string>; payload: BodyInit | undefined } {
+  const headers: Record<string, string> = { ...(connection.headers ?? {}) };
+  if (request.bytes !== undefined && request.body !== undefined) {
+    throw validationError(`${request.label}: a request carries either a JSON body or raw bytes, not both`);
+  }
+  if (request.bytes !== undefined) {
+    headers['Content-Type'] = request.contentType ?? 'application/octet-stream';
+    // A Uint8Array view is a valid fetch body; the DOM lib types only accept the
+    // narrower ArrayBuffer-backed spelling.
+    return { headers, payload: request.bytes as unknown as BodyInit };
+  }
+  if (request.body === undefined) {
+    return { headers, payload: undefined };
+  }
+  if (!hasHeader(headers, 'content-type')) {
+    headers['Content-Type'] = 'application/json';
+  }
+  return { headers, payload: JSON.stringify(request.body) };
+}
+
+function hasHeader(headers: Record<string, string>, name: string): boolean {
+  return Object.keys(headers).some((key) => key.toLowerCase() === name);
+}
+
+function decodeSuccess(text: string, label: string): unknown {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) {
+    return {};
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch (error) {
+    throw transportError(`${label}: invalid JSON response: ${asError(error).message}`);
+  }
+}
+
+async function readErrorBody(response: Response): Promise<string> {
+  try {
+    return (await readCappedText(response, 'error body')).trim();
+  } catch {
+    return '';
+  }
+}
+
+/** Signals the body cap so the retry loop reports it instead of retrying it. */
+class ResponseTooLargeError extends Error {
+  constructor(label: string) {
+    super(`${label}: response too large`);
+    this.name = 'ResponseTooLargeError';
+  }
+}
+
+/**
+ * Reads a response body, abandoning it once it passes `MAX_RESPONSE_BYTES`.
+ *
+ * On the streaming path reading stops at the cap and the stream is cancelled, so
+ * a runaway body is never buffered whole. A runtime whose response has no
+ * readable stream falls back to buffering the whole body and checking its size
+ * afterwards.
+ */
+async function readCappedText(response: Response, label: string): Promise<string> {
+  const body = response.body;
+  if (body === null || typeof body.getReader !== 'function') {
+    const text = await response.text();
+    if (new TextEncoder().encode(text).byteLength > MAX_RESPONSE_BYTES) {
+      throw new ResponseTooLargeError(label);
+    }
+    return text;
+  }
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value === undefined) {
+        continue;
+      }
+      total += value.byteLength;
+      if (total > MAX_RESPONSE_BYTES) {
+        throw new ResponseTooLargeError(label);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock?.();
+    if (total > MAX_RESPONSE_BYTES) {
+      await body.cancel().catch(() => {});
+    }
+  }
+  const joined = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(joined);
+}
+
+/**
+ * Shape of the plain-text message the ingest control plane returns with a 503:
+ * lowercase words ending in "is unavailable", such as "trial evaluation service
+ * is unavailable". Proxy and load balancer 503 pages do not match it: they are
+ * HTML, and their prose is capitalized and punctuated.
+ */
+const capabilityGapMessage = /^[a-z0-9][a-z0-9 ._-]* is unavailable$/;
+
+/**
+ * Whether a 503 means the backend cannot serve this route at all.
+ *
+ * Agent Observability answers 503 when the store behind a route does not
+ * implement the feature, so every retry returns the same thing and only spends
+ * the budget. The match stays narrow, and an unrecognized 503 still retries.
+ */
+function isCapabilityGap(response: Response, body: string): boolean {
+  if (response.status !== 503) {
+    return false;
+  }
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.trim().toLowerCase().startsWith('text/plain')) {
+    return false;
+  }
+  return capabilityGapMessage.test(body.trim());
+}

--- a/js/src/experiments/types.ts
+++ b/js/src/experiments/types.ts
@@ -1,0 +1,332 @@
+import { defaultEnv } from '../config.js';
+import type { Agento11yLogger } from '../types.js';
+import type { Candidate, Evaluator, EvaluatorKind } from './models.js';
+import { isRecord, normalizeEvaluatorKind } from './models.js';
+import { putNonBlank } from './serialize.js';
+
+export type { Candidate, Evaluator, EvaluatorKind };
+export { normalizeEvaluatorKind };
+
+/** One test case (scenario) in a suite. */
+export interface TestCase {
+  testCaseId: string;
+  name?: string;
+  description?: string;
+  tags?: string[];
+  category?: string;
+  input?: unknown;
+  expected?: unknown;
+  weight?: number;
+  metadata?: Record<string, unknown>;
+  artifactRefs?: Record<string, unknown>[];
+}
+
+/** A named, versioned collection of test cases. */
+export interface TestSuite {
+  suiteId: string;
+  name?: string;
+  version?: string;
+  description?: string;
+  tags?: string[];
+  changelog?: string;
+  testCases: TestCase[];
+}
+
+/** Returns the case with `testCaseId`, if the suite has one. */
+export function suiteCase(suite: TestSuite | undefined, testCaseId: string): TestCase | undefined {
+  return suite?.testCases.find((testCase) => testCase.testCaseId === testCaseId);
+}
+
+/** Builds a test case from a portable mapping, accepting `id` or `test_case_id`. */
+export function testCaseFromObject(data: unknown): TestCase {
+  if (!isRecord(data)) {
+    throw new Error(`test case must be a mapping, got ${describe(data)}`);
+  }
+  const testCaseId = String(data.test_case_id ?? data.testCaseId ?? data.id ?? '').trim();
+  if (testCaseId.length === 0) {
+    throw new Error("test case requires an 'id' (or 'test_case_id')");
+  }
+  const tags = data.tags ?? [];
+  if (!Array.isArray(tags) || !tags.every((tag) => typeof tag === 'string')) {
+    throw new Error(`test case "${testCaseId}" tags must be a list of strings`);
+  }
+  const metadata = data.metadata ?? {};
+  if (!isRecord(metadata)) {
+    throw new Error(`test case "${testCaseId}" metadata must be a mapping`);
+  }
+  const rawWeight = data.weight ?? 1;
+  const weight = typeof rawWeight === 'number' ? rawWeight : Number(rawWeight);
+  if (!Number.isFinite(weight)) {
+    throw new Error(`test case "${testCaseId}" weight must be numeric`);
+  }
+  const artifactRefs = Array.isArray(data.artifact_refs ?? data.artifactRefs)
+    ? ((data.artifact_refs ?? data.artifactRefs) as unknown[]).filter(isRecord).map((ref) => ({ ...ref }))
+    : [];
+  return {
+    testCaseId,
+    name: optionalString(data.name),
+    description: optionalString(data.description),
+    tags: [...tags],
+    category: optionalString(data.category),
+    input: data.input,
+    expected: data.expected,
+    weight,
+    metadata: { ...metadata },
+    artifactRefs,
+  };
+}
+
+/** Returns the portable YAML/JSON representation of one test case. */
+export function testCaseToObject(testCase: TestCase): Record<string, unknown> {
+  const out: Record<string, unknown> = { id: testCase.testCaseId };
+  putNonBlank(out, 'name', testCase.name);
+  putNonBlank(out, 'description', testCase.description);
+  if (testCase.tags !== undefined && testCase.tags.length > 0) {
+    out.tags = [...testCase.tags];
+  }
+  putNonBlank(out, 'category', testCase.category);
+  if (testCase.input !== undefined) {
+    out.input = testCase.input;
+  }
+  if (testCase.expected !== undefined) {
+    out.expected = testCase.expected;
+  }
+  if (testCase.weight !== undefined && testCase.weight !== 1) {
+    out.weight = testCase.weight;
+  }
+  if (testCase.metadata !== undefined && Object.keys(testCase.metadata).length > 0) {
+    out.metadata = { ...testCase.metadata };
+  }
+  if (testCase.artifactRefs !== undefined && testCase.artifactRefs.length > 0) {
+    out.artifact_refs = testCase.artifactRefs.map((ref) => ({ ...ref }));
+  }
+  return out;
+}
+
+/** Builds a suite from a portable mapping, accepting `cases` or `test_cases`. */
+export function testSuiteFromObject(data: unknown): TestSuite {
+  if (!isRecord(data)) {
+    throw new Error(`suite must be a mapping, got ${describe(data)}`);
+  }
+  const suiteId = String(data.suite_id ?? data.suiteId ?? data.id ?? '').trim();
+  if (suiteId.length === 0) {
+    throw new Error("suite requires a 'suite_id' (or 'id')");
+  }
+  const rawCases = data.cases ?? data.test_cases ?? data.testCases ?? [];
+  if (!Array.isArray(rawCases)) {
+    throw new Error('suite cases must be a list of mappings');
+  }
+  const tags = data.tags ?? [];
+  if (!Array.isArray(tags) || !tags.every((tag) => typeof tag === 'string')) {
+    throw new Error('suite tags must be a list of strings');
+  }
+  return {
+    suiteId,
+    name: optionalString(data.name),
+    version: suiteVersionFromObject(data.version),
+    description: optionalString(data.description),
+    tags: [...tags],
+    changelog: optionalString(data.changelog),
+    testCases: rawCases.map(testCaseFromObject),
+  };
+}
+
+/** Returns the portable YAML/JSON representation of a suite. */
+export function testSuiteToObject(suite: TestSuite): Record<string, unknown> {
+  const out: Record<string, unknown> = { suite_id: suite.suiteId };
+  putNonBlank(out, 'name', suite.name);
+  putNonBlank(out, 'version', suite.version);
+  putNonBlank(out, 'description', suite.description);
+  if (suite.tags !== undefined && suite.tags.length > 0) {
+    out.tags = [...suite.tags];
+  }
+  putNonBlank(out, 'changelog', suite.changelog);
+  out.cases = suite.testCases.map(testCaseToObject);
+  return out;
+}
+
+/** Maps a candidate onto the metadata keys a run and its trials carry. */
+export function candidateMetadata(candidate: Candidate | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (candidate === undefined) {
+    return out;
+  }
+  for (const [key, value] of [
+    ['agent_name', candidate.agentName],
+    ['agent_version', candidate.agentVersion],
+    ['prompt_version', candidate.promptVersion],
+    ['model_provider', candidate.modelProvider],
+    ['model_name', candidate.modelName],
+    ['git_sha', candidate.gitSha],
+  ] as const) {
+    if (value !== undefined && value.length > 0) {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+// --------------------------------------------------------------------------- //
+// TrialRef: handing one trial across a process or container boundary
+// --------------------------------------------------------------------------- //
+
+export const ENV_EXPERIMENT_ID = 'AGENTO11Y_EXPERIMENT_ID';
+export const ENV_TEST_CASE_ID = 'AGENTO11Y_TEST_CASE_ID';
+export const ENV_ATTEMPT = 'AGENTO11Y_ATTEMPT';
+export const ENV_SUITE_ID = 'AGENTO11Y_SUITE_ID';
+export const ENV_SUITE_VERSION = 'AGENTO11Y_SUITE_VERSION';
+export const ENV_TRAJECTORY_ID = 'AGENTO11Y_TRAJECTORY_ID';
+
+const legacyEnvRenames: Record<string, string> = {
+  SIGIL_EXPERIMENT_ID: ENV_EXPERIMENT_ID,
+  SIGIL_TEST_CASE_ID: ENV_TEST_CASE_ID,
+  SIGIL_ATTEMPT: ENV_ATTEMPT,
+  SIGIL_SUITE_ID: ENV_SUITE_ID,
+  SIGIL_SUITE_VERSION: ENV_SUITE_VERSION,
+  SIGIL_TRAJECTORY_ID: ENV_TRAJECTORY_ID,
+};
+
+/**
+ * A serializable pointer to one trial, openable in any process.
+ *
+ * `experimentId` is the canonical run identifier. `trajectoryId` is an optional
+ * stable per-attempt id used to correlate an out-of-band execution with this
+ * trial.
+ */
+export interface TrialRef {
+  experimentId: string;
+  testCaseId: string;
+  attempt: number;
+  suiteId?: string;
+  suiteVersion?: string;
+  suiteName?: string;
+  testCaseName?: string;
+  trajectoryId?: string;
+}
+
+export function trialRefToJSON(ref: TrialRef): Record<string, unknown> {
+  return {
+    experiment_id: ref.experimentId,
+    test_case_id: ref.testCaseId,
+    attempt: ref.attempt,
+    suite_id: ref.suiteId ?? '',
+    suite_version: ref.suiteVersion ?? '',
+    suite_name: ref.suiteName ?? '',
+    test_case_name: ref.testCaseName ?? '',
+    trajectory_id: ref.trajectoryId ?? '',
+  };
+}
+
+export function trialRefFromJSON(payload: unknown): TrialRef {
+  const data = isRecord(payload) ? payload : {};
+  const attempt = Number(data.attempt ?? 1);
+  return {
+    experimentId: String(data.experiment_id ?? data.run_id ?? '').trim(),
+    testCaseId: String(data.test_case_id ?? '').trim(),
+    attempt: Number.isFinite(attempt) && attempt > 0 ? Math.trunc(attempt) : 1,
+    suiteId: String(data.suite_id ?? '').trim(),
+    suiteVersion: String(data.suite_version ?? '').trim(),
+    suiteName: String(data.suite_name ?? '').trim(),
+    testCaseName: String(data.test_case_name ?? '').trim(),
+    trajectoryId: String(data.trajectory_id ?? '').trim(),
+  };
+}
+
+/** The environment variables that carry this ref to a child process. */
+export function trialRefToEnv(ref: TrialRef): Record<string, string> {
+  const env: Record<string, string> = {
+    [ENV_EXPERIMENT_ID]: ref.experimentId,
+    [ENV_TEST_CASE_ID]: ref.testCaseId,
+    [ENV_ATTEMPT]: String(ref.attempt),
+  };
+  if (ref.suiteId !== undefined && ref.suiteId.length > 0) {
+    env[ENV_SUITE_ID] = ref.suiteId;
+  }
+  if (ref.suiteVersion !== undefined && ref.suiteVersion.length > 0) {
+    env[ENV_SUITE_VERSION] = ref.suiteVersion;
+  }
+  if (ref.trajectoryId !== undefined && ref.trajectoryId.length > 0) {
+    env[ENV_TRAJECTORY_ID] = ref.trajectoryId;
+  }
+  return env;
+}
+
+/**
+ * Reads a ref from the environment, returning undefined when the experiment or
+ * test-case id is missing. A `SIGIL_*` spelling is reported and ignored, never
+ * read: the rename is complete, so silently honoring the old name would hide
+ * stale configuration.
+ */
+export function trialRefFromEnv(
+  env: Record<string, string | undefined> = defaultEnv(),
+  logger?: Agento11yLogger,
+): TrialRef | undefined {
+  warnLegacyTrialEnv(env, logger);
+  const experimentId = (env[ENV_EXPERIMENT_ID] ?? '').trim();
+  const testCaseId = (env[ENV_TEST_CASE_ID] ?? '').trim();
+  if (experimentId.length === 0 || testCaseId.length === 0) {
+    return undefined;
+  }
+  const parsedAttempt = Number.parseInt((env[ENV_ATTEMPT] ?? '').trim(), 10);
+  return {
+    experimentId,
+    testCaseId,
+    attempt: Number.isFinite(parsedAttempt) && parsedAttempt > 0 ? parsedAttempt : 1,
+    suiteId: (env[ENV_SUITE_ID] ?? '').trim(),
+    suiteVersion: (env[ENV_SUITE_VERSION] ?? '').trim(),
+    trajectoryId: (env[ENV_TRAJECTORY_ID] ?? '').trim(),
+  };
+}
+
+const warnedLegacyEnv = new Set<string>();
+
+export function warnLegacyTrialEnv(env: Record<string, string | undefined>, logger?: Agento11yLogger): void {
+  for (const [legacy, replacement] of Object.entries(legacyEnvRenames)) {
+    if (env[legacy] !== undefined && !warnedLegacyEnv.has(legacy)) {
+      warnedLegacyEnv.add(legacy);
+      const message = `agento11y: ${legacy} is ignored; rename it to ${replacement}`;
+      if (logger?.warn !== undefined) {
+        logger.warn(message);
+      } else {
+        console.warn(message);
+      }
+    }
+  }
+}
+
+/** Clears the once-per-process warning set. Test-only. */
+export function resetLegacyTrialEnvWarnings(): void {
+  warnedLegacyEnv.clear();
+}
+
+function optionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value.length === 0) {
+    return undefined;
+  }
+  return value;
+}
+
+function describe(value: unknown): string {
+  if (value === null) {
+    return 'null';
+  }
+  return Array.isArray(value) ? 'array' : typeof value;
+}
+
+/**
+ * Reads the suite version, which has to be a string.
+ *
+ * An unquoted `version: 1.0` parses to the number 1, and JavaScript cannot tell
+ * that from `1`, so it would reach the wire as "1" where Python sends "1.0". The
+ * version labels the suite in run upsert, in every trial snapshot, and in the OTel
+ * attributes, so rejecting the file beats disagreeing with the other SDKs.
+ */
+function suiteVersionFromObject(raw: unknown): string {
+  if (raw === undefined || raw === null || raw === '') {
+    return '1.0.0';
+  }
+  if (typeof raw !== 'string') {
+    throw new Error(`suite version must be a string, got ${describe(raw)}; quote it, for example version: "1.0"`);
+  }
+  return raw;
+}

--- a/js/src/experiments/yaml.ts
+++ b/js/src/experiments/yaml.ts
@@ -1,0 +1,51 @@
+import { parse as parseYAML, stringify as stringifyYAML } from 'yaml';
+import type { TestSuite } from './types.js';
+import { testSuiteFromObject, testSuiteToObject } from './types.js';
+
+/**
+ * Portable suite YAML: the same document Go's `ParseSuite` and Python's
+ * `TestSuite.from_yaml` read.
+ *
+ * Three legacy aliases are accepted on load: a suite id under `suite_id` or `id`,
+ * a case collection under `cases` or `test_cases`, and a case id under `id` or
+ * `test_case_id`. Saving always writes the canonical spelling (`suite_id`,
+ * `cases`, `id`), so a load-save round trip normalizes an older document.
+ */
+export function parseSuiteYAML(text: string): TestSuite {
+  let document: unknown;
+  try {
+    document = parseYAML(text);
+  } catch (error) {
+    throw new Error(`agento11y test suite validation failed: parse suite YAML: ${(error as Error).message}`);
+  }
+  const suite = testSuiteFromObject(document);
+  validateSuite(suite);
+  return suite;
+}
+
+/** Serializes a suite to portable YAML. */
+export function stringifySuiteYAML(suite: TestSuite): string {
+  validateSuite(suite);
+  return stringifyYAML(testSuiteToObject(suite));
+}
+
+/**
+ * Rejects a suite the control plane and the report rollup cannot use: a blank
+ * suite id, a blank case id, or two cases claiming the same id.
+ */
+export function validateSuite(suite: TestSuite): void {
+  if (suite.suiteId.trim().length === 0) {
+    throw new Error('agento11y test suite validation failed: suite_id is required');
+  }
+  const seen = new Set<string>();
+  for (const testCase of suite.testCases) {
+    const id = testCase.testCaseId.trim();
+    if (id.length === 0) {
+      throw new Error('agento11y test suite validation failed: test_case_id is required');
+    }
+    if (seen.has(id)) {
+      throw new Error(`agento11y test suite validation failed: duplicate test_case_id "${id}"`);
+    }
+    seen.add(id);
+  }
+}

--- a/js/src/hooks.ts
+++ b/js/src/hooks.ts
@@ -13,7 +13,7 @@ import type {
   ToolDefinition,
   ToolResultPart,
 } from './types.js';
-import { asError } from './utils.js';
+import { asError, baseURLFromAPIEndpoint } from './utils.js';
 
 const hooksEvaluatePath = '/api/v1/hooks:evaluate';
 const hookTimeoutHeader = 'X-Agento11y-Hook-Timeout-Ms';
@@ -165,30 +165,8 @@ function formatDenyMessage(reason: string, ruleId: string | undefined): string {
 }
 
 function buildHooksEvaluateEndpoint(endpoint: string, insecure: boolean): string {
-  const baseURL = baseURLFromAPIEndpoint(endpoint, insecure);
+  const baseURL = baseURLFromAPIEndpoint(endpoint, insecure, 'agento11y hook evaluation failed');
   return `${baseURL}${hooksEvaluatePath}`;
-}
-
-function baseURLFromAPIEndpoint(endpoint: string, insecure: boolean): string {
-  const trimmed = endpoint.trim();
-  if (trimmed.length === 0) {
-    throw new Error('agento11y hook evaluation failed: api endpoint is required');
-  }
-
-  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
-    const parsed = new URL(trimmed);
-    // Preserve a path prefix so prefix-mounted Agent Observability deployments
-    // (https://host/sigil) route /api/v1/hooks:evaluate under the prefix.
-    const path = parsed.pathname.replace(/\/+$/, '');
-    return `${parsed.protocol}//${parsed.host}${path}`;
-  }
-
-  const withoutScheme = trimmed.startsWith('grpc://') ? trimmed.slice('grpc://'.length) : trimmed;
-  const host = withoutScheme.split('/')[0]?.trim();
-  if (host === undefined || host.length === 0) {
-    throw new Error('agento11y hook evaluation failed: api endpoint host is required');
-  }
-  return `${insecure ? 'http' : 'https'}://${host}`;
 }
 
 function serializeRequest(request: HookEvaluateRequest): Record<string, unknown> {

--- a/js/src/redaction.ts
+++ b/js/src/redaction.ts
@@ -154,6 +154,67 @@ export function createSecretRedactionSanitizer(
   };
 }
 
+const sharedRedactor = new SecretRedactor(true);
+
+/**
+ * Redacts known secret formats from free text.
+ *
+ * Used by the experiments surface for score explanations, artifact text, and
+ * telemetry strings, matching Python's `redact_secret_text`.
+ */
+export function redactSecretText(value: string): string {
+  if (value.length === 0) {
+    return value;
+  }
+  return sharedRedactor.redact(value);
+}
+
+/**
+ * Redacts secrets in every string reachable from `value`, rebuilding arrays and
+ * objects. Matches Python's `redact_secret_value`.
+ *
+ * Every non-array object is walked, including a class instance and a
+ * `null`-prototype object. Missing a secret matters more here than preserving an
+ * exotic shape, and Python's `isinstance(item, dict)` covers subclasses the same
+ * way. A Date, Map, Set, RegExp, Error, or typed array passes through unchanged.
+ */
+export function redactSecretValue<T>(value: T): T {
+  if (typeof value === 'string') {
+    return redactSecretText(value) as unknown as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactSecretValue(entry)) as unknown as T;
+  }
+  if (isWalkableObject(value)) {
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      out[key] = redactSecretValue(entry);
+    }
+    return out as unknown as T;
+  }
+  return value;
+}
+
+/**
+ * Whether `value` is an object whose own string properties should be walked.
+ *
+ * A built-in wrapper (Date, Map, Set, RegExp, Error, a typed array) is left alone:
+ * rebuilding it as a plain object would change the payload's shape, and its
+ * secrets, if any, are not in its own enumerable string properties.
+ */
+function isWalkableObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  if (value instanceof Date || value instanceof RegExp || value instanceof Error) {
+    return false;
+  }
+  if (value instanceof Map || value instanceof Set || ArrayBuffer.isView(value)) {
+    return false;
+  }
+  return true;
+}
+
 function sanitizeMessage(message: Message, redactor: SecretRedactor, defaultTextMode: 'none' | 'light' | 'full'): void {
   if (typeof message.content === 'string') {
     message.content = redactString(message.content, redactor, defaultTextMode);

--- a/js/src/utils.ts
+++ b/js/src/utils.ts
@@ -170,22 +170,64 @@ type NodeHash = {
   digest(encoding: 'hex'): string;
 };
 
+type HashAlgorithm = 'sha1' | 'sha256';
+
 type NodeCrypto = {
-  createHash(algorithm: 'sha256'): NodeHash;
+  createHash(algorithm: HashAlgorithm): NodeHash;
 };
 
 function sha256Hex(input: string): string {
+  return hashHex('sha256', input);
+}
+
+/**
+ * SHA-1 hex digest. Used by the experiments stable-id derivation, which has to
+ * stay byte-identical with Go's and Python's `stable_id`.
+ */
+export function sha1Hex(input: string): string {
+  return hashHex('sha1', input);
+}
+
+function hashHex(algorithm: HashAlgorithm, input: string): string {
   const nodeCrypto = resolveNodeCrypto();
   if (nodeCrypto === undefined) {
-    throw new Error('sha256 hashing is unavailable in this JavaScript runtime');
+    throw new Error(`${algorithm} hashing is unavailable in this JavaScript runtime`);
   }
-  return nodeCrypto.createHash('sha256').update(input).digest('hex');
+  return nodeCrypto.createHash(algorithm).update(input).digest('hex');
 }
 
 function resolveNodeCrypto(): NodeCrypto | undefined {
   const processWithBuiltins = (globalThis as { process?: { getBuiltinModule?: (id: string) => unknown } }).process;
   const module = processWithBuiltins?.getBuiltinModule?.('crypto') as NodeCrypto | undefined;
   return typeof module?.createHash === 'function' ? module : undefined;
+}
+
+/**
+ * Converts a configured API endpoint into an HTTP base URL.
+ *
+ * Accepts an absolute `http(s)://` URL, a `grpc://` URL, or a bare `host:port`.
+ * A path prefix on an absolute URL is preserved so prefix-mounted deployments
+ * (`https://host/sigil`) keep routing under the prefix. `label` prefixes the
+ * error messages so a caller can tell which feature failed.
+ */
+export function baseURLFromAPIEndpoint(endpoint: string, insecure: boolean, label: string): string {
+  const trimmed = endpoint.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`${label}: api endpoint is required`);
+  }
+
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    const parsed = new URL(trimmed);
+    const path = parsed.pathname.replace(/\/+$/, '');
+    return `${parsed.protocol}//${parsed.host}${path}`;
+  }
+
+  const withoutScheme = trimmed.startsWith('grpc://') ? trimmed.slice('grpc://'.length) : trimmed;
+  const host = withoutScheme.split('/')[0]?.trim();
+  if (host === undefined || host.length === 0) {
+    throw new Error(`${label}: api endpoint host is required`);
+  }
+  return `${insecure ? 'http' : 'https'}://${host}`;
 }
 
 export function cloneGeneration(generation: Generation): Generation {

--- a/js/test/experiments.artifacts-report.test.mjs
+++ b/js/test/experiments.artifacts-report.test.mjs
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { artifactKindFromMime, Experiment } from '../.test-dist/experiments/experiment.js';
+import { parseExperimentReport, parseReportSummary } from '../.test-dist/experiments/models.js';
+import { FakeExperimentsClient } from './experimentsFakeClient.mjs';
+
+const suite = {
+  suiteId: 'smoke',
+  name: 'Smoke',
+  version: '1.0.0',
+  testCases: [{ testCaseId: 'add', input: '2+2', expected: '4' }],
+};
+
+async function openTrial(client) {
+  const experiment = await Experiment.start(client, { experimentId: 'run-1', name: 'artifacts', suite });
+  const trial = experiment.trial('add');
+  await trial.start();
+  return { experiment, trial };
+}
+
+test('a text artifact infers its kind and mime', async () => {
+  const client = new FakeExperimentsClient();
+  const { trial } = await openTrial(client);
+  const record = await trial.artifact('transcript.txt', { text: 'hello' });
+
+  assert.equal(record.artifact_id, 'art_transcript.txt');
+  assert.equal(client.artifacts[0].experimentId, 'run-1');
+  assert.equal(client.artifacts[0].parentId, trial.trialId);
+  assert.equal(client.artifacts[0].kind, 'text');
+  assert.equal(client.artifacts[0].mime, 'text/plain');
+  assert.equal(new TextDecoder().decode(client.artifacts[0].content), 'hello');
+  assert.deepEqual(trial.artifacts, [{ name: 'transcript.txt', kind: 'text', artifactId: 'art_transcript.txt' }]);
+});
+
+test('a data artifact is serialized as JSON', async () => {
+  const client = new FakeExperimentsClient();
+  const { trial } = await openTrial(client);
+  await trial.artifact('trace.json', { data: { steps: [1, 2] } });
+  assert.equal(client.artifacts[0].kind, 'json');
+  assert.equal(client.artifacts[0].mime, 'application/json');
+  assert.deepEqual(JSON.parse(new TextDecoder().decode(client.artifacts[0].content)), { steps: [1, 2] });
+});
+
+test('raw bytes default to binary and honor explicit metadata', async () => {
+  const client = new FakeExperimentsClient();
+  const { trial } = await openTrial(client);
+  await trial.artifact('screenshot', { bytes: new Uint8Array([1, 2, 3]) });
+  assert.equal(client.artifacts[0].kind, 'binary');
+  assert.equal(client.artifacts[0].mime, 'application/octet-stream');
+
+  await trial.artifact('screenshot.png', { bytes: new Uint8Array([1]), mime: 'image/png' });
+  assert.equal(client.artifacts[1].kind, 'image');
+
+  await trial.artifact('notes', { text: 'x', kind: 'markdown', mime: 'text/markdown' });
+  assert.equal(client.artifacts[2].kind, 'markdown');
+  assert.equal(client.artifacts[2].mime, 'text/markdown');
+});
+
+test('an artifact with no content is rejected', async () => {
+  const client = new FakeExperimentsClient();
+  const { trial } = await openTrial(client);
+  await assert.rejects(
+    trial.artifact('empty', {}),
+    /agento11y experiment validation failed: artifact requires one of data, text, or bytes/,
+  );
+  assert.equal(client.artifacts.length, 0);
+});
+
+const mimeCases = [
+  { mime: 'image/png', kind: 'image' },
+  { mime: 'application/json', kind: 'json' },
+  { mime: 'text/markdown', kind: 'markdown' },
+  { mime: 'text/x-markdown', kind: 'markdown' },
+  { mime: 'application/pdf', kind: 'pdf' },
+  { mime: 'text/csv', kind: 'csv' },
+  { mime: 'text/plain', kind: 'text' },
+  { mime: 'application/octet-stream', kind: 'binary' },
+  { mime: '', kind: 'binary' },
+];
+
+test('artifact kinds follow the documented MIME inference', () => {
+  for (const { mime, kind } of mimeCases) {
+    assert.equal(artifactKindFromMime(mime), kind, mime);
+  }
+});
+
+test('a report summary keeps omitted aggregates undefined', () => {
+  const summary = parseReportSummary({ trial_count: 4, completed_count: 3, pass_count: 2, pass_denominator: 4 });
+  assert.equal(summary.trialCount, 4);
+  assert.equal(summary.passRate, undefined, 'an omitted pass rate is not zero');
+  assert.equal(summary.finalScoreAvg, undefined);
+  assert.equal(summary.totalCost, undefined);
+  assert.equal(summary.totalTokens, undefined);
+  assert.deepEqual(summary.passAtK, {});
+});
+
+test('a report summary reads present aggregates', () => {
+  const summary = parseReportSummary({
+    test_case_count: 2,
+    trial_count: 4,
+    completed_count: 4,
+    failed_count: 0,
+    canceled_count: 0,
+    pass_rate: 0.75,
+    pass_at_k: { 1: 0.5, 2: 1 },
+    pass_power_k: { 2: 0.25 },
+    final_score_avg: 0.8,
+    total_cost: 0.02,
+    total_tokens: 1234,
+    pass_count: 3,
+    pass_denominator: 4,
+    final_score_sum: 3.2,
+    final_score_count: 4,
+    token_coverage: 'complete',
+    cost_coverage: 'partial',
+  });
+  assert.equal(summary.passRate, 0.75);
+  assert.deepEqual(summary.passAtK, { 1: 0.5, 2: 1 });
+  assert.deepEqual(summary.passPowerK, { 2: 0.25 });
+  assert.equal(summary.finalScoreAvg, 0.8);
+  assert.equal(summary.totalTokens, 1234);
+  assert.equal(summary.tokenCoverage, 'complete');
+  assert.equal(summary.costCoverage, 'partial');
+});
+
+test('both report envelopes normalize to the same report', () => {
+  const payload = {
+    summary: { trial_count: 1, completed_count: 1 },
+    rows: [{ test_case_id: 'add' }, 'not a row'],
+  };
+  const run = { experiment_id: 'run-1', name: 'nightly', status: 'completed', tags: ['nightly'] };
+  const fromExperiment = parseExperimentReport({ ...payload, experiment: run });
+  const fromRun = parseExperimentReport({ ...payload, run });
+  assert.deepEqual(fromExperiment, fromRun);
+  assert.equal(fromExperiment.run.runId, 'run-1');
+  assert.deepEqual(fromExperiment.run.tags, ['nightly']);
+  assert.equal(fromExperiment.rows.length, 1, 'a non-object row is dropped');
+});
+
+test('an experiment id under run_id is still read', () => {
+  const report = parseExperimentReport({ run: { run_id: 'run-legacy' }, summary: {} });
+  assert.equal(report.run.runId, 'run-legacy');
+});
+
+test('a non-object report payload is a transport error', () => {
+  assert.throws(() => parseExperimentReport('nope'), /agento11y experiment transport failed: invalid response payload/);
+});
+
+test('experiment.report goes through the client', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await Experiment.start(client, { experimentId: 'run-1', name: 'reported', suite });
+  const report = await experiment.report();
+  assert.equal(report.run.runId, 'run-1');
+  assert.ok(client.calls.includes('get_report'));
+});

--- a/js/test/experiments.client.test.mjs
+++ b/js/test/experiments.client.test.mjs
@@ -1,0 +1,553 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import test from 'node:test';
+
+import { DEFAULT_INGEST_ACTOR, ExperimentsClient, INGEST_ACTOR_HEADER } from '../.test-dist/experiments/client.js';
+
+test('a bearer-auth client sends the canonical actor header and sdk source', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({
+    status: 200,
+    body: { run: { experiment_id: 'run-1' } },
+  }));
+  try {
+    const client = new ExperimentsClient({ endpoint, ingestToken: 'tok-1', env: {} });
+    const experiment = await client.upsertExperiment({ runId: 'run-1', name: 'nightly', tags: ['a'] });
+    assert.equal(experiment.runId, 'run-1');
+    assert.equal(seen[0].headers.authorization, 'Bearer tok-1');
+    assert.equal(seen[0].headers[INGEST_ACTOR_HEADER.toLowerCase()], DEFAULT_INGEST_ACTOR);
+    assert.equal(seen[0].headers['x-sigil-ingest-actor'], undefined, 'the legacy header name is gone');
+    assert.equal(seen[0].headers['x-scope-orgid'], undefined);
+    assert.deepEqual(JSON.parse(seen[0].body), {
+      name: 'nightly',
+      source: { kind: 'sdk', id: 'js' },
+      experiment_id: 'run-1',
+      tags: ['a'],
+    });
+  } finally {
+    await close();
+  }
+});
+
+test('a tenant client sends basic auth and the tenant header', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({ status: 200, body: {} }));
+  try {
+    const client = new ExperimentsClient({ endpoint, tenantId: '12345', ingestToken: 'tok-2', env: {} });
+    await client.upsertExperiment({ name: 'nightly' });
+    assert.equal(seen[0].headers['x-scope-orgid'], '12345');
+    assert.equal(seen[0].headers.authorization, `Basic ${Buffer.from('12345:tok-2').toString('base64')}`);
+  } finally {
+    await close();
+  }
+});
+
+test('the client reads endpoint, token, tenant, and actor from the environment', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({ status: 200, body: {} }));
+  try {
+    const client = new ExperimentsClient({
+      env: {
+        AGENTO11Y_ENDPOINT: endpoint,
+        AGENTO11Y_AUTH_TOKEN: 'tok-env',
+        AGENTO11Y_INGEST_ACTOR: 'ingest:runner/nightly',
+        AGENTO11Y_GRAFANA_URL: 'https://stack.grafana.net/',
+      },
+    });
+    assert.equal(client.actor, 'ingest:runner/nightly');
+    assert.equal(client.grafanaUrl, 'https://stack.grafana.net');
+    await client.upsertExperiment({ name: 'nightly' });
+    assert.equal(seen[0].headers[INGEST_ACTOR_HEADER.toLowerCase()], 'ingest:runner/nightly');
+  } finally {
+    await close();
+  }
+});
+
+test('a missing endpoint or token fails at construction', () => {
+  assert.throws(() => new ExperimentsClient({ env: {} }), /endpoint is required/);
+  assert.throws(() => new ExperimentsClient({ endpoint: 'http://localhost:1', env: {} }), /ingestToken is required/);
+});
+
+test('finalize maps succeeded onto completed and rejects other statuses', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({ status: 200, body: {} }));
+  try {
+    const client = newClient(endpoint);
+    await client.finalize('run-1', 'succeeded', { scoreCount: 4, error: '' });
+    assert.equal(seen[0].url, '/api/v1/experiment-runs/run-1:finalize');
+    assert.deepEqual(JSON.parse(seen[0].body), {
+      status: 'completed',
+      source: { kind: 'sdk', id: 'js' },
+      score_count: 4,
+    });
+    await assert.rejects(
+      client.finalize('run-1', 'canceled'),
+      /agento11y experiment validation failed: status must be completed or failed/,
+    );
+    await assert.rejects(client.finalize('  ', 'completed'), /run_id is required/);
+  } finally {
+    await close();
+  }
+});
+
+test('trial create and update send only the fields the caller set', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({ status: 200, body: { trial_id: 'trial-1' } }));
+  try {
+    const client = newClient(endpoint);
+    await client.upsertTrial('run-1', { trialId: 'trial-1', testCaseId: 'add', attempt: 2 });
+    assert.equal(seen[0].method, 'POST');
+    assert.equal(seen[0].url, '/api/v1/experiment-runs/run-1/trials');
+    assert.deepEqual(JSON.parse(seen[0].body), {
+      trial_id: 'trial-1',
+      test_case_id: 'add',
+      attempt: 2,
+      status: 'running',
+    });
+
+    await client.updateTrial('run-1', 'trial-1', { conversationId: 'conv-1' });
+    assert.equal(seen[1].method, 'PATCH');
+    assert.equal(seen[1].url, '/api/v1/experiment-runs/run-1/trials/trial-1');
+    assert.deepEqual(JSON.parse(seen[1].body), { conversation_id: 'conv-1' });
+  } finally {
+    await close();
+  }
+});
+
+test('score export sends the wire body and counts duplicates as recorded', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({
+    status: 200,
+    body: {
+      results: [
+        { score_id: 'score-1', accepted: true },
+        { score_id: 'score-2', accepted: false, status: 'duplicate' },
+      ],
+    },
+  }));
+  try {
+    const client = newClient(endpoint);
+    const recorded = await client.exportScores([
+      {
+        scoreId: 'score-1',
+        evaluatorId: 'exact',
+        evaluatorVersion: '1',
+        evaluatorKind: 'check',
+        scoreKey: 'final',
+        value: { number: 0.5 },
+        trialId: 'trial-1',
+        experimentId: 'run-1',
+        passed: true,
+        explanation: 'ok',
+        metadata: { attempt: 1 },
+        source: { kind: 'experiment', id: 'run-1' },
+      },
+      {
+        scoreId: 'score-2',
+        evaluatorId: 'exact',
+        evaluatorVersion: '1',
+        scoreKey: 'final',
+        value: { boolean: true },
+        trialId: 'trial-1',
+      },
+    ]);
+    assert.equal(recorded, 2, 'one fresh plus one idempotent duplicate');
+    assert.equal(seen[0].url, '/api/v1/scores:export');
+    const body = JSON.parse(seen[0].body);
+    // No `evaluator_kind`: it stays local, matching Go's and Python's score body.
+    assert.deepEqual(body.scores[0], {
+      score_id: 'score-1',
+      evaluator_id: 'exact',
+      evaluator_version: '1',
+      score_key: 'final',
+      value: { number: 0.5 },
+      trial_id: 'trial-1',
+      experiment_id: 'run-1',
+      passed: true,
+      explanation: 'ok',
+      metadata: { attempt: 1 },
+      source: { kind: 'experiment', id: 'run-1' },
+    });
+    assert.deepEqual(body.scores[1].value, { bool: true });
+  } finally {
+    await close();
+  }
+});
+
+test('an empty score list sends no request', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({ status: 200, body: {} }));
+  try {
+    assert.equal(await newClient(endpoint).exportScores([]), 0);
+    assert.equal(seen.length, 0);
+  } finally {
+    await close();
+  }
+});
+
+test('a rejected score raises with the backend detail', async () => {
+  const { endpoint, close } = await startServer(() => ({
+    status: 200,
+    body: { results: [{ score_id: 'score-1', accepted: false, error: 'unknown trial' }] },
+  }));
+  try {
+    await assert.rejects(
+      newClient(endpoint).exportScores([
+        {
+          scoreId: 'score-1',
+          evaluatorId: 'exact',
+          evaluatorVersion: '1',
+          scoreKey: 'final',
+          value: { boolean: true },
+          trialId: 'trial-1',
+        },
+      ]),
+      /agento11y score export rejected 1 score\(s\): score-1: unknown trial/,
+    );
+  } finally {
+    await close();
+  }
+});
+
+test('a score missing an anchor is rejected before the request', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({ status: 200, body: {} }));
+  try {
+    await assert.rejects(
+      newClient(endpoint).exportScores([
+        { scoreId: 's', evaluatorId: 'e', evaluatorVersion: '1', scoreKey: 'final', value: { boolean: true } },
+      ]),
+      /agento11y score validation failed: generation_id or trial_id is required/,
+    );
+    assert.equal(seen.length, 0);
+  } finally {
+    await close();
+  }
+});
+
+test('generation export checks acceptance and tolerates a duplicate', async () => {
+  const responses = [
+    { results: [{ generation_id: 'gen-1', accepted: true }] },
+    { results: [{ generation_id: 'gen-1', accepted: false, error: 'generation already exists' }] },
+    { results: [{ generation_id: 'gen-1', accepted: false, error: 'conversation not found' }] },
+    { results: [] },
+  ];
+  let index = 0;
+  const { endpoint, seen, close } = await startServer(() => ({ status: 200, body: responses[index++] }));
+  try {
+    const client = newClient(endpoint);
+    assert.equal(await client.exportGeneration({ generationId: 'gen-1', conversationId: 'conv-1' }), 'gen-1');
+    assert.equal(seen[0].url, '/api/v1/generations:export');
+    const generation = JSON.parse(seen[0].body).generations[0];
+    assert.equal(generation.id, 'gen-1');
+    assert.equal(generation.conversation_id, 'conv-1');
+    assert.equal(generation.mode, 'GENERATION_MODE_SYNC');
+    assert.deepEqual(generation.model, { provider: 'eval', name: 'experiment' });
+
+    // A duplicate is the idempotent retry of the same anchor generation.
+    assert.equal(await client.exportGeneration({ generationId: 'gen-1' }), 'gen-1');
+    await assert.rejects(
+      client.exportGeneration({ generationId: 'gen-1' }),
+      /transport failed: generation export rejected: conversation not found/,
+    );
+    await assert.rejects(
+      client.exportGeneration({ generationId: 'gen-1' }),
+      /transport failed: generation export: response did not include a result/,
+    );
+  } finally {
+    await close();
+  }
+});
+
+test('generation export shapes input, output, and usage', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({
+    status: 200,
+    body: { results: [{ generation_id: 'gen-1', accepted: true }] },
+  }));
+  try {
+    await newClient(endpoint).exportGeneration({
+      generationId: 'gen-1',
+      conversationId: 'conv-1',
+      inputText: 'what is 2+2?',
+      outputText: '4',
+      modelProvider: 'openai',
+      modelName: 'gpt-5',
+      agentName: 'calc',
+      inputTokens: 10,
+      outputTokens: 2,
+      tags: { 'experiment.run_id': 'run-1' },
+      metadata: { attempt: 1 },
+    });
+    const generation = JSON.parse(seen[0].body).generations[0];
+    assert.deepEqual(generation.input, [{ role: 'MESSAGE_ROLE_USER', parts: [{ text: 'what is 2+2?' }] }]);
+    assert.deepEqual(generation.output, [{ role: 'MESSAGE_ROLE_ASSISTANT', parts: [{ text: '4' }] }]);
+    assert.deepEqual(generation.usage, {
+      input_tokens: 10,
+      output_tokens: 2,
+      total_tokens: 12,
+      cache_read_input_tokens: 0,
+      cache_write_input_tokens: 0,
+      reasoning_tokens: 0,
+    });
+    assert.equal(generation.agent_name, 'calc');
+  } finally {
+    await close();
+  }
+});
+
+test('a zero-token generation omits usage', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({
+    status: 200,
+    body: { results: [{ generation_id: 'gen-1', accepted: true }] },
+  }));
+  try {
+    await newClient(endpoint).exportGeneration({ generationId: 'gen-1' });
+    assert.equal(JSON.parse(seen[0].body).generations[0].usage, undefined);
+  } finally {
+    await close();
+  }
+});
+
+test('score explanations are redacted by default and left alone when disabled', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({
+    status: 200,
+    body: { results: [{ score_id: 'score-1', accepted: true }] },
+  }));
+  const secret = 'token is glc_abcdefghijklmnopqrstuvwxyz012345';
+  const score = {
+    scoreId: 'score-1',
+    evaluatorId: 'exact',
+    evaluatorVersion: '1',
+    scoreKey: 'final',
+    value: { boolean: true },
+    trialId: 'trial-1',
+    explanation: secret,
+  };
+  try {
+    await newClient(endpoint).exportScores([score]);
+    assert.match(JSON.parse(seen[0].body).scores[0].explanation, /\[REDACTED:grafana-cloud-token\]/);
+
+    await new ExperimentsClient({ endpoint, ingestToken: 'tok', redactSecrets: false, env: {} }).exportScores([score]);
+    assert.equal(JSON.parse(seen[1].body).scores[0].explanation, secret);
+  } finally {
+    await close();
+  }
+});
+
+test('score metadata is redacted through a null-prototype object and a class instance', async () => {
+  // The recursion used to stop at anything whose prototype was not exactly
+  // Object.prototype, so these two shapes carried their secrets through.
+  const { endpoint, seen, close } = await startServer(() => ({
+    status: 200,
+    body: { results: [{ score_id: 'score-1', accepted: true }] },
+  }));
+  const secret = 'glc_abcdefghijklmnopqrstuvwxyz012345';
+  class Detail {
+    constructor(note) {
+      this.note = note;
+    }
+  }
+  const bare = Object.create(null);
+  bare.note = `bare ${secret}`;
+  const score = {
+    scoreId: 'score-1',
+    evaluatorId: 'exact',
+    evaluatorVersion: '1',
+    scoreKey: 'final',
+    value: { boolean: true },
+    trialId: 'trial-1',
+    metadata: { bare, instance: new Detail(`instance ${secret}`) },
+  };
+  try {
+    await newClient(endpoint).exportScores([score]);
+    const sent = JSON.parse(seen[0].body).scores[0].metadata;
+    assert.match(sent.bare.note, /\[REDACTED:grafana-cloud-token\]/);
+    assert.match(sent.instance.note, /\[REDACTED:grafana-cloud-token\]/);
+  } finally {
+    await close();
+  }
+});
+
+test('artifact upload sends the metadata query and the raw bytes', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({ status: 200, body: { artifact_id: 'art-1' } }));
+  try {
+    const record = await newClient(endpoint).uploadArtifact({
+      experimentId: 'run-1',
+      parentId: 'trial-1',
+      name: 'transcript.md',
+      kind: 'markdown',
+      mime: 'text/markdown',
+      content: new TextEncoder().encode('# notes'),
+    });
+    assert.deepEqual(record, { artifact_id: 'art-1' });
+    assert.equal(
+      seen[0].url,
+      '/api/v1/experiment-runs/run-1/trials/trial-1/artifacts:upload?name=transcript.md&kind=markdown&mime=text%2Fmarkdown',
+    );
+    assert.equal(seen[0].headers['content-type'], 'text/markdown');
+    assert.equal(seen[0].body, '# notes');
+  } finally {
+    await close();
+  }
+});
+
+test('artifact upload rejects an unsupported parent and empty content', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({ status: 200, body: {} }));
+  try {
+    const client = newClient(endpoint);
+    await assert.rejects(
+      client.uploadArtifact({
+        experimentId: 'run-1',
+        parentId: 'trial-1',
+        name: 'a',
+        kind: 'text',
+        content: new Uint8Array(),
+        parentKind: 'experiment',
+      }),
+      /only test_case_trial artifacts are supported/,
+    );
+    await assert.rejects(
+      client.uploadArtifact({
+        experimentId: 'run-1',
+        parentId: 'trial-1',
+        name: 'a',
+        kind: 'text',
+        content: new Uint8Array(),
+      }),
+      /content is required/,
+    );
+    assert.equal(seen.length, 0);
+  } finally {
+    await close();
+  }
+});
+
+test('the report endpoint accepts either envelope', async () => {
+  const summary = { trial_count: 2, completed_count: 2, pass_count: 1, pass_denominator: 2, pass_rate: 0.5 };
+  const bodies = [
+    { experiment: { experiment_id: 'run-1', name: 'nightly' }, summary, rows: [{ test_case_id: 'add' }] },
+    { run: { experiment_id: 'run-1', name: 'nightly' }, summary, rows: [{ test_case_id: 'add' }] },
+  ];
+  let index = 0;
+  const { endpoint, seen, close } = await startServer(() => ({ status: 200, body: bodies[index++] }));
+  try {
+    const client = newClient(endpoint);
+    const fromExperiment = await client.getReport('run-1');
+    const fromRun = await client.getReport('run-1');
+    assert.equal(seen[0].url, '/api/v1/eval/experiments/run-1/report');
+    assert.deepEqual(fromExperiment, fromRun);
+    assert.equal(fromExperiment.run.runId, 'run-1');
+    assert.equal(fromExperiment.summary.passRate, 0.5);
+    assert.equal(fromExperiment.rows.length, 1);
+  } finally {
+    await close();
+  }
+});
+
+test('an omitted pass rate stays undefined instead of becoming zero', async () => {
+  const { endpoint, close } = await startServer(() => ({
+    status: 200,
+    body: { experiment: { experiment_id: 'run-1' }, summary: { trial_count: 1, completed_count: 1 } },
+  }));
+  try {
+    const report = await newClient(endpoint).getReport('run-1');
+    assert.equal(report.summary.passRate, undefined);
+    assert.equal(report.summary.finalScoreAvg, undefined);
+    assert.equal(report.summary.trialCount, 1);
+  } finally {
+    await close();
+  }
+});
+
+test('score listing defaults the page size and normalizes the cursor', async () => {
+  const bodies = [
+    { items: [{ score_id: 'score-1' }], next_cursor: 'abc' },
+    { items: [], next_cursor: '0' },
+  ];
+  let index = 0;
+  const { endpoint, seen, close } = await startServer(() => ({ status: 200, body: bodies[index++] }));
+  try {
+    const client = newClient(endpoint);
+    const first = await client.listScores('run-1');
+    assert.equal(seen[0].url, '/api/v1/eval/experiments/run-1/scores?limit=50');
+    assert.equal(first.nextCursor, 'abc');
+    const second = await client.listScores('run-1', { limit: 10, cursor: 'abc' });
+    assert.equal(seen[1].url, '/api/v1/eval/experiments/run-1/scores?limit=10&cursor=abc');
+    assert.equal(second.nextCursor, undefined, 'a zero cursor means no more pages');
+  } finally {
+    await close();
+  }
+});
+
+test('the experiment url prefers the grafana url', () => {
+  const withGrafana = new ExperimentsClient({
+    endpoint: 'https://ao.example',
+    ingestToken: 'tok',
+    grafanaUrl: 'https://stack.grafana.net',
+    env: {},
+  });
+  assert.equal(
+    withGrafana.experimentUrl('run 1'),
+    'https://stack.grafana.net/a/grafana-agento11y-app/experiments/runs/run%201',
+  );
+  const withoutGrafana = new ExperimentsClient({ endpoint: 'https://ao.example', ingestToken: 'tok', env: {} });
+  assert.equal(
+    withoutGrafana.experimentUrl('run-1'),
+    'https://ao.example/a/grafana-agento11y-app/experiments/runs/run-1',
+  );
+});
+
+test('an attached core client is flushed and shut down', async () => {
+  let flushes = 0;
+  const client = new ExperimentsClient({
+    endpoint: 'http://localhost:1',
+    ingestToken: 'tok',
+    env: {},
+    coreClient: {
+      async flush() {
+        flushes++;
+      },
+    },
+  });
+  await client.flushGenerations();
+  await client.shutdown();
+  assert.equal(flushes, 2);
+});
+
+test('useExperimentalOtel follows its environment variable', () => {
+  const base = { endpoint: 'http://localhost:1', ingestToken: 'tok' };
+  assert.equal(new ExperimentsClient({ ...base, env: {} }).useExperimentalOtel, false);
+  assert.equal(
+    new ExperimentsClient({ ...base, env: { AGENTO11Y_USE_EXPERIMENTAL_OTEL: 'true' } }).useExperimentalOtel,
+    true,
+  );
+  assert.equal(
+    new ExperimentsClient({ ...base, env: { AGENTO11Y_USE_EXPERIMENTAL_OTEL: 'true' }, useExperimentalOtel: false })
+      .useExperimentalOtel,
+    false,
+  );
+});
+
+function newClient(endpoint) {
+  return new ExperimentsClient({ endpoint, ingestToken: 'tok', env: {} });
+}
+
+async function startServer(respond) {
+  const seen = [];
+  const server = http.createServer((request, response) => {
+    const chunks = [];
+    request.on('data', (chunk) => chunks.push(chunk));
+    request.on('end', () => {
+      seen.push({
+        method: request.method,
+        url: request.url,
+        headers: request.headers,
+        body: Buffer.concat(chunks).toString('utf8'),
+      });
+      const { status, body } = respond(request);
+      response.writeHead(status, { 'content-type': 'application/json' });
+      response.end(JSON.stringify(body ?? {}));
+    });
+  });
+  await new Promise((resolve, reject) => {
+    server.listen(0, '127.0.0.1', (error) => (error ? reject(error) : resolve(undefined)));
+  });
+  const { port } = server.address();
+  return {
+    endpoint: `http://127.0.0.1:${port}`,
+    seen,
+    close: () => new Promise((resolve) => server.close(() => resolve(undefined))),
+  };
+}

--- a/js/test/experiments.cloud-eval.test.mjs
+++ b/js/test/experiments.cloud-eval.test.mjs
@@ -1,0 +1,481 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import test from 'node:test';
+
+import { ExperimentsClient } from '../.test-dist/experiments/client.js';
+import { TrialEvaluationFailedError, TrialEvaluationTimeoutError } from '../.test-dist/experiments/errors.js';
+import { Experiment } from '../.test-dist/experiments/experiment.js';
+import { ENV_ENABLE_EXPERIMENTAL_FEATURES } from '../.test-dist/experiments/experimental.js';
+import { evaluation, FakeExperimentsClient } from './experimentsFakeClient.mjs';
+
+const suite = {
+  suiteId: 'smoke',
+  name: 'Smoke',
+  version: '1.0.0',
+  testCases: [{ testCaseId: 'add', input: '2+2', expected: '4' }],
+};
+
+/** Runs `fn` with the experimental gate open, restoring the previous value. */
+async function withGate(fn) {
+  const previous = process.env[ENV_ENABLE_EXPERIMENTAL_FEATURES];
+  process.env[ENV_ENABLE_EXPERIMENTAL_FEATURES] = 'true';
+  try {
+    return await fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[ENV_ENABLE_EXPERIMENTAL_FEATURES];
+    } else {
+      process.env[ENV_ENABLE_EXPERIMENTAL_FEATURES] = previous;
+    }
+  }
+}
+
+async function openExperiment(client) {
+  return Experiment.start(client, { experimentId: 'run-1', name: 'cloud eval', suite });
+}
+
+test('a successful evaluation follows the pinned call order', async () => {
+  await withGate(async () => {
+    const client = new FakeExperimentsClient();
+    client.evaluationStatuses = [evaluation('queued'), evaluation('queued'), evaluation('success')];
+    client.evaluationResult = evaluation('queued');
+    const experiment = await openExperiment(client);
+    const trial = experiment.trial('add');
+    await trial.start();
+    trial.bindConversation('conv-real');
+
+    const result = await trial.evaluate('helpfulness', { pollIntervalMs: 500 });
+    assert.equal(result.status, 'success');
+    assert.equal(result.evaluationId, 'eval-123');
+    assert.deepEqual(client.evaluationOrder, ['update', 'flush', 'trigger', 'status', 'status', 'status']);
+    assert.deepEqual(client.triggeredEvaluations, [
+      { experimentId: 'run-1', trialId: trial.trialId, evaluatorId: 'helpfulness', evaluatorVersion: '' },
+    ]);
+    assert.equal(client.trialUpdates[0].conversationId, 'conv-real');
+    assert.ok(!client.calls.includes('export_scores'), 'a cloud-evaluated trial writes no local score');
+
+    await trial.close();
+    assert.equal(trial.status, 'completed', 'no local final score is still a completed trial');
+    assert.equal(trial.error, '');
+
+    await experiment.finalize('completed', { scoreCount: 3 });
+    assert.equal(client.finalized[0].scoreCount, undefined, 'a caller score count is dropped');
+    assert.ok(!client.calls.includes('export_scores'));
+  });
+});
+
+test('recordIO exports the anchor generation before the trigger', async () => {
+  await withGate(async () => {
+    const client = new FakeExperimentsClient();
+    const experiment = await openExperiment(client);
+    const trial = experiment.trial('add');
+    await trial.start();
+    trial.recordIO({ input: '2+2', output: '4' });
+
+    await trial.evaluate('helpfulness');
+    assert.deepEqual(client.evaluationOrder, ['update', 'generation', 'flush', 'trigger']);
+    assert.equal(client.generationCalls[0].conversationId, trial.conversationId);
+  });
+});
+
+test('a failed worker rejects with the evaluation id and detail', async () => {
+  await withGate(async () => {
+    const client = new FakeExperimentsClient();
+    client.evaluationResult = evaluation('failed', { error: 'grader crashed' });
+    const experiment = await openExperiment(client);
+    const trial = experiment.trial('add');
+    await trial.start();
+    trial.bindConversation('conv-real');
+
+    await assert.rejects(trial.evaluate('helpfulness'), (error) => {
+      assert.ok(error instanceof TrialEvaluationFailedError);
+      assert.equal(error.name, 'TrialEvaluationFailedError');
+      assert.equal(error.evaluationId, 'eval-123');
+      assert.equal(error.detail, 'grader crashed');
+      assert.equal(error.message, 'agento11y trial evaluation eval-123 failed: grader crashed');
+      return true;
+    });
+    assert.equal(trial.isCloudEvaluated, false);
+  });
+});
+
+test('a blank detail and a blank id still produce a readable message', () => {
+  assert.equal(new TrialEvaluationFailedError('eval-1', '   ').message, 'agento11y trial evaluation eval-1 failed');
+  assert.equal(
+    new TrialEvaluationTimeoutError('', 'waited 5ms').message,
+    'agento11y trial evaluation unknown timed out: waited 5ms',
+  );
+});
+
+test('the poll interval doubles to the ceiling and the deadline stops the wait', async () => {
+  await withGate(async () => {
+    const client = new FakeExperimentsClient();
+    // Every read stays queued, so only the deadline can end the loop.
+    client.evaluationResult = evaluation('queued');
+    const experiment = await openExperiment(client);
+    const trial = experiment.trial('add');
+    await trial.start();
+    trial.bindConversation('conv-real');
+
+    await assert.rejects(trial.evaluate('helpfulness', { timeoutMs: 30_000, pollIntervalMs: 500 }), (error) => {
+      assert.ok(error instanceof TrialEvaluationTimeoutError);
+      assert.equal(error.evaluationId, 'eval-123');
+      assert.equal(error.message, 'agento11y trial evaluation eval-123 timed out: waited 30000ms');
+      return true;
+    });
+    assert.deepEqual(client.sleeps.slice(0, 5), [500, 1000, 2000, 4000, 5000]);
+    assert.ok(
+      client.sleeps.every((delay) => delay <= 5000),
+      'the interval never passes the 5000 ms ceiling',
+    );
+    // The clamped last sleep exactly consumes the remaining budget.
+    assert.equal(
+      client.sleeps.reduce((total, delay) => total + delay, 0),
+      30_000,
+    );
+  });
+});
+
+test('a caller interval above the ceiling is preserved', async () => {
+  await withGate(async () => {
+    const client = new FakeExperimentsClient();
+    client.evaluationResult = evaluation('queued');
+    const experiment = await openExperiment(client);
+    const trial = experiment.trial('add');
+    await trial.start();
+    trial.bindConversation('conv-real');
+
+    await assert.rejects(
+      trial.evaluate('helpfulness', { timeoutMs: 60_000, pollIntervalMs: 20_000 }),
+      TrialEvaluationTimeoutError,
+    );
+    assert.deepEqual(client.sleeps, [20_000, 20_000, 20_000]);
+  });
+});
+
+test('a sleep clamped to the remaining budget is followed by one final status read', async () => {
+  await withGate(async () => {
+    const client = new FakeExperimentsClient();
+    // Queued, queued, then success on the read after the clamped sleep.
+    client.evaluationStatuses = [evaluation('queued'), evaluation('success')];
+    client.evaluationResult = evaluation('queued');
+    const experiment = await openExperiment(client);
+    const trial = experiment.trial('add');
+    await trial.start();
+    trial.bindConversation('conv-real');
+
+    const result = await trial.evaluate('helpfulness', { timeoutMs: 600, pollIntervalMs: 500 });
+    assert.equal(result.status, 'success');
+    // 500 then a 100 ms clamp; the read after the clamp is what saw success.
+    assert.deepEqual(client.sleeps, [500, 100]);
+    assert.deepEqual(client.evaluationOrder, ['update', 'flush', 'trigger', 'status', 'status']);
+  });
+});
+
+test('an aborted signal stops polling and rethrows its own reason', async () => {
+  await withGate(async () => {
+    const stop = new Error('stop');
+    const controller = new AbortController();
+    const client = new FakeExperimentsClient({
+      onSleep: () => {
+        controller.abort(stop);
+      },
+    });
+    client.evaluationResult = evaluation('queued');
+    const experiment = await openExperiment(client);
+    const trial = experiment.trial('add');
+    await trial.start();
+    trial.bindConversation('conv-real');
+
+    await assert.rejects(trial.evaluate('helpfulness', { signal: controller.signal }), (error) => {
+      assert.equal(error, stop, 'not wrapped as a timeout or transport error');
+      return true;
+    });
+    assert.equal(client.sleeps.length, 1, 'no further delay is scheduled');
+    assert.deepEqual(client.evaluationOrder, ['update', 'flush', 'trigger']);
+  });
+});
+
+test('an already aborted signal stops before any request', async () => {
+  await withGate(async () => {
+    const stop = new Error('too late');
+    const controller = new AbortController();
+    controller.abort(stop);
+    const client = new FakeExperimentsClient();
+    const experiment = await openExperiment(client);
+    const trial = experiment.trial('add');
+    await trial.start();
+    trial.bindConversation('conv-real');
+    const callsBefore = client.calls.length;
+
+    await assert.rejects(trial.evaluate('helpfulness', { signal: controller.signal }), (error) => {
+      assert.equal(error, stop);
+      return true;
+    });
+    assert.equal(client.calls.length, callsBefore);
+  });
+});
+
+test('evaluate validates its inputs before touching the network', async () => {
+  await withGate(async () => {
+    const client = new FakeExperimentsClient();
+    const experiment = await openExperiment(client);
+    const trial = experiment.trial('add');
+    await trial.start();
+    const callsBefore = client.calls.length;
+
+    await assert.rejects(
+      trial.evaluate('helpfulness'),
+      /agento11y trial evaluation validation failed: bind a conversation first/,
+    );
+    trial.bindConversation('conv-real');
+    await assert.rejects(
+      trial.evaluate('   '),
+      /agento11y trial evaluation validation failed: evaluator_id is required/,
+    );
+    await assert.rejects(
+      trial.evaluate('helpfulness', { timeoutMs: 0 }),
+      /agento11y trial evaluation validation failed: timeoutMs must be greater than zero/,
+    );
+    await assert.rejects(
+      trial.evaluate('helpfulness', { pollIntervalMs: -1 }),
+      /agento11y trial evaluation validation failed: pollIntervalMs must be greater than zero/,
+    );
+    assert.equal(client.calls.length, callsBefore);
+  });
+});
+
+test('an evaluation error still closes the trial as errored', async () => {
+  await withGate(async () => {
+    const client = new FakeExperimentsClient();
+    client.evaluationResult = evaluation('failed', { error: 'grader crashed' });
+    const experiment = await openExperiment(client);
+    await assert.rejects(
+      experiment.withTrial('add', async (trial) => {
+        trial.bindConversation('conv-real');
+        await trial.evaluate('helpfulness');
+      }),
+      TrialEvaluationFailedError,
+    );
+    assert.equal(client.trialUpdates.at(-1).status, 'failed');
+    assert.match(client.trialUpdates.at(-1).error, /^agento11y trial evaluation eval-123 failed: grader crashed$/);
+  });
+});
+
+test('a callback error after a successful evaluation closes the trial as errored', async () => {
+  await withGate(async () => {
+    const client = new FakeExperimentsClient();
+    const experiment = await openExperiment(client);
+    const failure = new Error('assertion failed after grading');
+    await assert.rejects(
+      experiment.withTrial('add', async (trial) => {
+        trial.bindConversation('conv-real');
+        await trial.evaluate('helpfulness');
+        throw failure;
+      }),
+      (error) => {
+        assert.equal(error, failure);
+        return true;
+      },
+    );
+    // The cloud verdict does not swallow an error raised after it.
+    assert.equal(client.trialUpdates.at(-1).status, 'failed');
+    assert.equal(client.trialUpdates.at(-1).error, 'assertion failed after grading');
+  });
+});
+
+test('an evaluated trial still accepts a local score, and finalize keeps dropping the count', async () => {
+  await withGate(async () => {
+    const client = new FakeExperimentsClient();
+    const experiment = await openExperiment(client);
+    await experiment.withTrial('add', async (trial) => {
+      trial.bindConversation('conv-real');
+      await trial.evaluate('helpfulness');
+      trial.checkScore('json_valid', { passed: true });
+    });
+    await experiment.finalize('completed', { scoreCount: 1 });
+    assert.equal(client.scores.length, 1);
+    assert.equal(client.finalized[0].scoreCount, undefined);
+    assert.equal(experiment.hasCloudEvaluatedTrial, true);
+  });
+});
+
+test('an evaluator version reaches the trigger', async () => {
+  await withGate(async () => {
+    const client = new FakeExperimentsClient();
+    const experiment = await openExperiment(client);
+    const trial = experiment.trial('add');
+    await trial.start();
+    trial.bindConversation('conv-real');
+    await trial.evaluate('helpfulness', { evaluatorVersion: '3' });
+    assert.equal(client.triggeredEvaluations[0].evaluatorVersion, '3');
+  });
+});
+
+// --- the gate ------------------------------------------------------------- //
+
+test('a closed gate blocks trial.evaluate without sending a request', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  const trial = experiment.trial('add');
+  await trial.start();
+  trial.bindConversation('conv-real');
+  const callsBefore = client.calls.length;
+
+  // Unset, not falsy: the absent case is the one the gate has to cover.
+  assert.equal(process.env[ENV_ENABLE_EXPERIMENTAL_FEATURES], undefined);
+  await assert.rejects(trial.evaluate('helpfulness'), (error) => {
+    assert.equal(error.name, 'ExperimentalFeatureDisabledError');
+    assert.equal(error.feature, 'cloud trial evaluation');
+    assert.equal(error.envVar, 'AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES');
+    return true;
+  });
+  assert.equal(client.calls.length, callsBefore);
+});
+
+test('a closed gate blocks both client entry points before any HTTP request', async () => {
+  const seen = [];
+  const server = http.createServer((request, response) => {
+    seen.push(request.url);
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end('{}');
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const endpoint = `http://127.0.0.1:${server.address().port}`;
+  try {
+    const client = new ExperimentsClient({ endpoint, ingestToken: 'tok', env: {} });
+    assert.equal(process.env[ENV_ENABLE_EXPERIMENTAL_FEATURES], undefined);
+    for (const call of [
+      () => client.triggerTrialEvaluation('run-1', 'trial-1', 'helpfulness'),
+      () => client.getTrialEvaluation('run-1', 'trial-1', 'eval-1'),
+    ]) {
+      await assert.rejects(call(), (error) => {
+        assert.equal(error.name, 'ExperimentalFeatureDisabledError');
+        assert.match(
+          error.message,
+          /^agento11y: cloud trial evaluation is experimental; set AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true to use it$/,
+        );
+        return true;
+      });
+    }
+    assert.deepEqual(seen, [], 'zero HTTP requests reach the server');
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test('an empty gate value is as closed as an unset one', async () => {
+  process.env[ENV_ENABLE_EXPERIMENTAL_FEATURES] = '';
+  try {
+    const client = new FakeExperimentsClient();
+    const experiment = await openExperiment(client);
+    const trial = experiment.trial('add');
+    await trial.start();
+    trial.bindConversation('conv-real');
+    await assert.rejects(trial.evaluate('helpfulness'), /is experimental/);
+  } finally {
+    delete process.env[ENV_ENABLE_EXPERIMENTAL_FEATURES];
+  }
+});
+
+// --- the real transport --------------------------------------------------- //
+
+test('the trigger and status routes carry the wire body and encoded ids', async () => {
+  await withGate(async () => {
+    const seen = [];
+    const server = http.createServer((request, response) => {
+      const chunks = [];
+      request.on('data', (chunk) => chunks.push(chunk));
+      request.on('end', () => {
+        seen.push({ method: request.method, url: request.url, body: Buffer.concat(chunks).toString('utf8') });
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({ evaluation_id: 'eval-1', status: 'queued', attempts: 1 }));
+      });
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const endpoint = `http://127.0.0.1:${server.address().port}`;
+    try {
+      const client = new ExperimentsClient({ endpoint, ingestToken: 'tok', env: {} });
+      const triggered = await client.triggerTrialEvaluation('run-1', 'trial:one', 'helpfulness', '2');
+      assert.equal(triggered.status, 'queued');
+      assert.equal(seen[0].method, 'POST');
+      assert.equal(seen[0].url, '/api/v1/experiment-runs/run-1/trials/trial%3Aone:evaluate');
+      assert.deepEqual(JSON.parse(seen[0].body), { evaluator_id: 'helpfulness', evaluator_version: '2' });
+
+      await client.getTrialEvaluation('run-1', 'trial:one', 'eval-1');
+      assert.equal(seen[1].method, 'GET');
+      assert.equal(seen[1].url, '/api/v1/experiment-runs/run-1/trials/trial%3Aone/evaluations/eval-1');
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+});
+
+test('an unrecognized status is a transport error, not another poll', async () => {
+  await withGate(async () => {
+    const server = http.createServer((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ evaluation_id: 'eval-1', status: 'paused' }));
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const endpoint = `http://127.0.0.1:${server.address().port}`;
+    try {
+      const client = new ExperimentsClient({ endpoint, ingestToken: 'tok', env: {} });
+      await assert.rejects(
+        client.triggerTrialEvaluation('run-1', 'trial-1', 'helpfulness'),
+        /agento11y experiment transport failed: unsupported evaluation status "paused"/,
+      );
+      await assert.rejects(
+        client.getTrialEvaluation('run-1', 'trial-1', 'eval-1'),
+        /agento11y experiment transport failed: unsupported evaluation status "paused"/,
+      );
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+});
+
+test('a response without an evaluation id is rejected', async () => {
+  await withGate(async () => {
+    const server = http.createServer((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ status: 'queued' }));
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const endpoint = `http://127.0.0.1:${server.address().port}`;
+    try {
+      await assert.rejects(
+        new ExperimentsClient({ endpoint, ingestToken: 'tok', env: {} }).triggerTrialEvaluation(
+          'run-1',
+          'trial-1',
+          'helpfulness',
+        ),
+        /evaluation response carries no evaluation_id/,
+      );
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+});
+
+test('the client rejects blank evaluation identifiers before requesting', async () => {
+  await withGate(async () => {
+    const client = new ExperimentsClient({ endpoint: 'http://127.0.0.1:1', ingestToken: 'tok', env: {} });
+    await assert.rejects(
+      client.triggerTrialEvaluation('  ', 'trial-1', 'helpfulness'),
+      /agento11y trial evaluation validation failed: experiment_id is required/,
+    );
+    await assert.rejects(
+      client.triggerTrialEvaluation('run-1', '  ', 'helpfulness'),
+      /agento11y trial evaluation validation failed: trial_id is required/,
+    );
+    await assert.rejects(
+      client.triggerTrialEvaluation('run-1', 'trial-1', '  '),
+      /agento11y trial evaluation validation failed: evaluator_id is required/,
+    );
+    await assert.rejects(
+      client.getTrialEvaluation('run-1', 'trial-1', '  '),
+      /agento11y trial evaluation validation failed: evaluation_id is required/,
+    );
+  });
+});

--- a/js/test/experiments.conformance.test.mjs
+++ b/js/test/experiments.conformance.test.mjs
@@ -1,0 +1,327 @@
+// Checks the JS experiments SDK against the shared wire fixtures in
+// `conformance/experiments/`. Go and Python run the same fixtures; see
+// `conformance/experiments/README.md`.
+
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import test from 'node:test';
+
+import { ExperimentsClient } from '../.test-dist/experiments/client.js';
+import { Experiment } from '../.test-dist/experiments/experiment.js';
+import { ENV_ENABLE_EXPERIMENTAL_FEATURES } from '../.test-dist/experiments/experimental.js';
+import { stableId } from '../.test-dist/experiments/ids.js';
+import { parseExperimentReport, parseTrialEvaluation } from '../.test-dist/experiments/models.js';
+import { diffJson, loadIds, loadInputs, loadRequests, loadResponses } from './experimentsFixtures.mjs';
+
+const inputs = loadInputs();
+const requests = loadRequests();
+const responses = loadResponses();
+
+test('stable ids match the shared vectors', () => {
+  for (const vector of loadIds().vectors) {
+    assert.equal(
+      stableId(vector.prefix, ...vector.parts),
+      vector.id,
+      `${vector.prefix} ${JSON.stringify(vector.parts)}`,
+    );
+  }
+});
+
+test('run upsert matches the fixture', async () => {
+  const captured = await capture(responses.run_upsert_response, (client) =>
+    client.upsertExperiment({
+      runId: inputs.experiment_id,
+      name: inputs.experiment_name,
+      tags: inputs.tags,
+      suiteId: inputs.suite_id,
+      suiteVersion: inputs.suite_version,
+      plannedTrialCount: inputs.planned_trial_count,
+    }),
+  );
+  assertMatches(captured[0], requests.run_upsert);
+});
+
+test('trial create matches the fixture', async () => {
+  const captured = await capture({ trial_id: trialId() }, (client) =>
+    client.upsertTrial(inputs.experiment_id, {
+      trialId: trialId(),
+      testCaseId: inputs.test_case_id,
+      attempt: inputs.attempt,
+    }),
+  );
+  assertMatches(captured[0], requests.trial_create);
+});
+
+test('the conversation patch matches the fixture', async () => {
+  const captured = await capture({ trial_id: trialId() }, (client) =>
+    client.updateTrial(inputs.experiment_id, trialId(), { conversationId: inputs.conversation_id }),
+  );
+  assertMatches(captured[0], requests.trial_patch_conversation);
+});
+
+test('the terminal patch matches the fixture', async () => {
+  const captured = await capture({ trial_id: trialId() }, (client) =>
+    client.updateTrial(inputs.experiment_id, trialId(), {
+      status: 'completed',
+      conversationId: inputs.conversation_id,
+    }),
+  );
+  assertMatches(captured[0], requests.trial_patch_terminal);
+});
+
+test('the evaluate trigger matches the fixture, with and without a version', async () => {
+  await withGate(async () => {
+    const pinned = await capture(responses.evaluation_queued, (client) =>
+      client.triggerTrialEvaluation(inputs.experiment_id, trialId(), inputs.evaluator_id, inputs.evaluator_version),
+    );
+    assertMatches(pinned[0], requests.trial_evaluate);
+
+    const latest = await capture(responses.evaluation_queued, (client) =>
+      client.triggerTrialEvaluation(inputs.experiment_id, trialId(), inputs.evaluator_id),
+    );
+    assertMatches(latest[0], requests.trial_evaluate_latest_version);
+  });
+});
+
+test('a trial id with reserved characters keeps the route verb', async () => {
+  await withGate(async () => {
+    const captured = await capture(responses.evaluation_queued, (client) =>
+      client.triggerTrialEvaluation(inputs.experiment_id, 'trial:one/blue', inputs.evaluator_id),
+    );
+    assertMatches(captured[0], requests.trial_evaluate_reserved_trial_id);
+  });
+});
+
+test('the evaluation status read matches the fixture', async () => {
+  await withGate(async () => {
+    const captured = await capture(responses.evaluation_success, (client) =>
+      client.getTrialEvaluation(inputs.experiment_id, trialId(), inputs.evaluation_id),
+    );
+    assert.equal(captured[0].method, requests.trial_evaluation_status.method);
+    assert.equal(captured[0].path, requests.trial_evaluation_status.path);
+    assert.equal(captured[0].body, '', 'a status read sends no body');
+  });
+});
+
+test('score export matches the fixture', async () => {
+  const captured = await capture(responses.scores_export_response, (client) =>
+    client.exportScores([
+      {
+        scoreId: stableId('score', inputs.experiment_id, trialId(), inputs.score_key, inputs.score_evaluator_id),
+        evaluatorId: inputs.score_evaluator_id,
+        evaluatorVersion: inputs.score_evaluator_version,
+        // Local-only on purpose: no SDK puts the evaluator kind on the wire.
+        evaluatorKind: 'deterministic',
+        scoreKey: inputs.score_key,
+        value: { boolean: true },
+        conversationId: inputs.conversation_id,
+        experimentId: inputs.experiment_id,
+        trialId: trialId(),
+        testCaseId: inputs.test_case_id,
+        passed: true,
+        explanation: 'matched the expected answer',
+        createdAt: new Date(inputs.score_created_at),
+        source: { kind: 'experiment', id: inputs.experiment_id },
+      },
+    ]),
+  );
+  assertMatches(captured[0], requests.scores_export);
+});
+
+test('run finalize matches the fixture, with and without a score count', async () => {
+  const plain = await capture(responses.run_finalize_response, (client) =>
+    client.finalize(inputs.experiment_id, 'completed'),
+  );
+  assertMatches(plain[0], requests.run_finalize);
+
+  const counted = await capture(responses.run_finalize_response, (client) =>
+    client.finalize(inputs.experiment_id, 'completed', { scoreCount: 1 }),
+  );
+  assertMatches(counted[0], requests.run_finalize_with_score_count);
+});
+
+test('the canned evaluation responses parse into the same logical result', () => {
+  // Every suite checks this field list on these fixtures, so a misparse in one SDK
+  // cannot pass while the others check a different subset.
+  for (const [name, status] of [
+    ['evaluation_queued', 'queued'],
+    ['evaluation_claimed', 'claimed'],
+    ['evaluation_success', 'success'],
+    ['evaluation_failed', 'failed'],
+  ]) {
+    const parsed = parseTrialEvaluation(responses[name]);
+    assert.equal(parsed.status, status, name);
+    assert.equal(parsed.evaluationId, inputs.evaluation_id, name);
+    assert.equal(parsed.experimentId, inputs.experiment_id, name);
+    assert.equal(parsed.trialId, trialId(), name);
+    assert.equal(parsed.conversationId, inputs.conversation_id, name);
+    assert.equal(parsed.evaluatorId, inputs.evaluator_id, name);
+    assert.equal(parsed.evaluatorVersion, inputs.evaluator_version, name);
+  }
+
+  const queued = parseTrialEvaluation(responses.evaluation_queued);
+  assert.equal(queued.attempts, 0);
+  assert.equal(queued.testCaseId, inputs.test_case_id);
+
+  const success = parseTrialEvaluation(responses.evaluation_success);
+  assert.equal(success.attempts, 1);
+  assert.equal(success.testCaseId, inputs.test_case_id);
+  assert.equal(success.createdAt.toISOString(), '2026-01-01T00:00:00.000Z');
+  assert.equal(success.updatedAt.toISOString(), '2026-01-01T00:00:05.000Z');
+
+  const failed = parseTrialEvaluation(responses.evaluation_failed);
+  assert.equal(failed.error, 'grader crashed');
+  assert.equal(failed.attempts, 3);
+});
+
+test('the two responses that must fail do fail', () => {
+  assert.throws(
+    () => parseTrialEvaluation(responses.evaluation_unsupported_status),
+    /unsupported evaluation status "paused"/,
+  );
+  assert.throws(
+    () => parseTrialEvaluation(responses.evaluation_missing_id),
+    /evaluation response carries no evaluation_id/,
+  );
+});
+
+test('both report envelopes parse alike', () => {
+  const fromExperiment = parseExperimentReport(responses.report_experiment_envelope);
+  const fromRun = parseExperimentReport(stripComment(responses.report_run_envelope));
+  assert.deepEqual(fromExperiment, fromRun);
+  assert.equal(fromExperiment.run.runId, inputs.experiment_id);
+  assert.equal(fromExperiment.summary.trialCount, 1);
+  assert.equal(fromExperiment.summary.passRate, undefined, 'a stored evaluator leaves the pass rate unset');
+});
+
+test('one cloud-evaluated trial produces the pinned request sequence', async () => {
+  await withGate(async () => {
+    const seen = [];
+    const bodies = [
+      responses.run_upsert_response,
+      { trial_id: trialId() },
+      { trial_id: trialId() },
+      responses.evaluation_queued,
+      responses.evaluation_success,
+      { trial_id: trialId() },
+      responses.run_finalize_response,
+    ];
+    const { endpoint, close } = await startServer(seen, () => bodies.shift() ?? {});
+    try {
+      const client = new ExperimentsClient({ endpoint, ingestToken: 'tok', env: {}, sleep: async () => {} });
+      const experiment = await Experiment.start(client, {
+        experimentId: inputs.experiment_id,
+        name: inputs.experiment_name,
+        tags: inputs.tags,
+        plannedTrialCount: inputs.planned_trial_count,
+        suite: { suiteId: inputs.suite_id, version: inputs.suite_version, testCases: [] },
+      });
+      await experiment.withTrial(inputs.test_case_id, async (trial) => {
+        trial.bindConversation(inputs.conversation_id);
+        await trial.evaluate(inputs.evaluator_id, { evaluatorVersion: inputs.evaluator_version });
+      });
+      await experiment.finalize('completed', { scoreCount: 1 });
+
+      assert.deepEqual(
+        seen.map((entry) => `${entry.method} ${entry.path}`),
+        [
+          'POST /api/v1/experiment-runs:upsert',
+          `POST /api/v1/experiment-runs/${inputs.experiment_id}/trials`,
+          `PATCH /api/v1/experiment-runs/${inputs.experiment_id}/trials/${trialId()}`,
+          `POST /api/v1/experiment-runs/${inputs.experiment_id}/trials/${trialId()}:evaluate`,
+          `GET /api/v1/experiment-runs/${inputs.experiment_id}/trials/${trialId()}/evaluations/${inputs.evaluation_id}`,
+          `PATCH /api/v1/experiment-runs/${inputs.experiment_id}/trials/${trialId()}`,
+          `POST /api/v1/experiment-runs/${inputs.experiment_id}:finalize`,
+        ],
+        'the Go and Python order plus one status read, because this fake answers :evaluate with queued',
+      );
+      assert.ok(
+        !seen.some((entry) => entry.path === '/api/v1/scores:export'),
+        'a cloud-evaluated trial writes no local score',
+      );
+      // The high-level wrapper adds one field the low-level fixture does not: it
+      // stamps the suite identity into the run's metadata for grouping.
+      assertMatches(seen[0], {
+        ...requests.run_upsert,
+        body: {
+          ...requests.run_upsert.body,
+          metadata: { suite_id: inputs.suite_id, suite_version: inputs.suite_version },
+        },
+      });
+      assertMatches(seen[2], requests.trial_patch_conversation);
+      assertMatches(seen[3], requests.trial_evaluate);
+      // The caller's score count is dropped once a trial queued an evaluation.
+      assertMatches(seen[6], requests.run_finalize);
+    } finally {
+      await close();
+    }
+  });
+});
+
+function trialId() {
+  return stableId('trial', inputs.experiment_id, inputs.test_case_id, inputs.attempt);
+}
+
+function assertMatches(captured, fixture) {
+  assert.equal(captured.method, fixture.method, 'method');
+  assert.equal(captured.path, fixture.path, 'encoded path');
+  const differences = diffJson(JSON.parse(captured.body), fixture.body);
+  assert.deepEqual(differences, [], `body differs from the fixture:\n${differences.join('\n')}`);
+}
+
+function stripComment(payload) {
+  const { comment, ...rest } = payload;
+  return rest;
+}
+
+async function capture(responseBody, run) {
+  const seen = [];
+  const { endpoint, close } = await startServer(seen, () => responseBody);
+  try {
+    await run(new ExperimentsClient({ endpoint, ingestToken: 'tok', env: {} }));
+  } finally {
+    await close();
+  }
+  return seen;
+}
+
+async function withGate(fn) {
+  const previous = process.env[ENV_ENABLE_EXPERIMENTAL_FEATURES];
+  process.env[ENV_ENABLE_EXPERIMENTAL_FEATURES] = 'true';
+  try {
+    return await fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[ENV_ENABLE_EXPERIMENTAL_FEATURES];
+    } else {
+      process.env[ENV_ENABLE_EXPERIMENTAL_FEATURES] = previous;
+    }
+  }
+}
+
+async function startServer(seen, respond) {
+  const server = http.createServer((request, response) => {
+    const chunks = [];
+    request.on('data', (chunk) => chunks.push(chunk));
+    request.on('end', () => {
+      const [path, query] = request.url.split('?');
+      seen.push({
+        method: request.method,
+        path,
+        query: query ?? '',
+        headers: request.headers,
+        body: Buffer.concat(chunks).toString('utf8'),
+      });
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify(respond(request) ?? {}));
+    });
+  });
+  await new Promise((resolve, reject) => {
+    server.listen(0, '127.0.0.1', (error) => (error ? reject(error) : resolve(undefined)));
+  });
+  const { port } = server.address();
+  return {
+    endpoint: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve) => server.close(() => resolve(undefined))),
+  };
+}

--- a/js/test/experiments.experimental.test.mjs
+++ b/js/test/experiments.experimental.test.mjs
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  ENV_ENABLE_EXPERIMENTAL_FEATURES,
+  ExperimentalFeatureDisabledError,
+  experimentalFeaturesEnabled,
+  FEATURE_CLOUD_TRIAL_EVALUATION,
+  requireExperimental,
+} from '../.test-dist/experiments/experimental.js';
+
+// Mirrors test_experimental_gate_reads_truthy_values in python/tests/test_experiments.py
+// and go/agento11y/experimental_test.go.
+const truthyTable = [
+  { value: '1', enabled: true },
+  { value: 'true', enabled: true },
+  { value: 'TRUE', enabled: true },
+  { value: 'True', enabled: true },
+  { value: 'yes', enabled: true },
+  { value: 'on', enabled: true },
+  { value: '  true  ', enabled: true },
+  { value: '0', enabled: false },
+  { value: 'false', enabled: false },
+  { value: 'no', enabled: false },
+  { value: 'off', enabled: false },
+  { value: 'maybe', enabled: false },
+];
+
+test('experimentalFeaturesEnabled accepts only the documented truthy spellings', () => {
+  for (const { value, enabled } of truthyTable) {
+    assert.equal(
+      experimentalFeaturesEnabled({ [ENV_ENABLE_EXPERIMENTAL_FEATURES]: value }),
+      enabled,
+      `value ${JSON.stringify(value)} should be ${enabled ? 'enabled' : 'disabled'}`,
+    );
+  }
+});
+
+test('an unset variable and an empty variable are both disabled', () => {
+  // Unset and empty are distinct inputs: a gate test that assigns a falsy value
+  // never exercises the absent case.
+  assert.equal(experimentalFeaturesEnabled({}), false);
+  assert.equal(experimentalFeaturesEnabled({ [ENV_ENABLE_EXPERIMENTAL_FEATURES]: '' }), false);
+  assert.equal(experimentalFeaturesEnabled({ [ENV_ENABLE_EXPERIMENTAL_FEATURES]: '   ' }), false);
+});
+
+test('requireExperimental throws a named error when the gate is closed', () => {
+  assert.throws(
+    () => requireExperimental(FEATURE_CLOUD_TRIAL_EVALUATION, {}),
+    (error) => {
+      assert.ok(error instanceof ExperimentalFeatureDisabledError);
+      assert.equal(error.name, 'ExperimentalFeatureDisabledError');
+      assert.equal(error.feature, 'cloud trial evaluation');
+      assert.equal(error.envVar, 'AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES');
+      assert.equal(
+        error.message,
+        'agento11y: cloud trial evaluation is experimental; set AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true to use it',
+      );
+      return true;
+    },
+  );
+});
+
+test('requireExperimental passes when the gate is open', () => {
+  requireExperimental(FEATURE_CLOUD_TRIAL_EVALUATION, { [ENV_ENABLE_EXPERIMENTAL_FEATURES]: 'yes' });
+});
+
+test('a blank feature name still names something', () => {
+  const error = new ExperimentalFeatureDisabledError('   ');
+  assert.equal(error.feature, 'this feature');
+  assert.match(error.message, /^agento11y: this feature is experimental/);
+});
+
+test('the gate reads process.env by default', () => {
+  assert.equal(experimentalFeaturesEnabled(), false);
+  process.env[ENV_ENABLE_EXPERIMENTAL_FEATURES] = 'on';
+  try {
+    assert.equal(experimentalFeaturesEnabled(), true);
+  } finally {
+    delete process.env[ENV_ENABLE_EXPERIMENTAL_FEATURES];
+  }
+  assert.equal(experimentalFeaturesEnabled(), false);
+});

--- a/js/test/experiments.ids.test.mjs
+++ b/js/test/experiments.ids.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { stableId } from '../.test-dist/experiments/ids.js';
+
+// Every literal below comes from running the same inputs through Python's
+// stable_id (and Go's StableID). A change here means a retry stops being
+// idempotent and the SDKs stop agreeing on trial identity.
+const vectors = [
+  { name: 'a known SHA-1 vector', args: ['trial', 'abc'], want: 'trial-a9993e364706816a' },
+  { name: 'an integer attempt', args: ['trial', 1], want: 'trial-356a192b7913b04c' },
+  { name: 'the string form of that attempt', args: ['trial', '1'], want: 'trial-356a192b7913b04c' },
+  { name: 'a float that is not the integer', args: ['trial', '1.0'], want: 'trial-e8dc057d3346e56a' },
+  { name: 'an experiment trial id', args: ['trial', 'run-1', 'case-1', 1], want: 'trial-b4dcde4aa6965898' },
+  { name: 'an anchor generation id', args: ['gen', 'run-1', 'case-1', 1], want: 'gen-b4dcde4aa6965898' },
+  { name: 'a minted conversation id', args: ['conv', 'run-1', 'case-1', 1], want: 'conv-b4dcde4aa6965898' },
+  {
+    name: 'a first-occurrence score id',
+    args: ['score', 'run-1', 'trial-b4dcde4aa6965898', 'final', 'exact'],
+    want: 'score-3dd1bb9385d48c0a',
+  },
+  {
+    name: 'a repeated score id',
+    args: ['score', 'run-1', 'trial-b4dcde4aa6965898', 'final', 'exact', 2],
+    want: 'score-8070a6fb2282feee',
+  },
+  { name: 'a grader generation id', args: ['gen', 'score-123', 'grader'], want: 'gen-cfd17a0e2cbaa495' },
+  { name: 'a grader conversation id', args: ['conv', 'score-123', 'grader'], want: 'conv-cfd17a0e2cbaa495' },
+];
+
+test('stableId matches the cross-SDK vectors', () => {
+  for (const { name, args, want } of vectors) {
+    assert.equal(stableId(...args), want, name);
+  }
+});
+
+test('a null part keeps its separator slot', () => {
+  // The parts join with \x1f before hashing, so a dropped null would shift every
+  // later part into the wrong slot.
+  assert.equal(stableId('trial', 'a', null, 'b'), 'trial-e69b7ae7f775b317');
+  assert.equal(stableId('trial', 'a', null, 'b'), stableId('trial', 'a', '', 'b'));
+  assert.equal(stableId('trial', 'a', undefined, 'b'), stableId('trial', 'a', '', 'b'));
+  assert.notEqual(stableId('trial', 'a', null, 'b'), stableId('trial', 'a', 'b'));
+});
+
+test('an integer attempt does not gain a decimal suffix', () => {
+  assert.equal(stableId('trial', 1), stableId('trial', '1'));
+  assert.notEqual(stableId('trial', 1), stableId('trial', '1.0'));
+});
+
+test('the prefix and digest length are fixed', () => {
+  const id = stableId('trial', 'run-1', 'case-1', 1);
+  const [prefix, digest] = id.split('-');
+  assert.equal(prefix, 'trial');
+  assert.equal(digest.length, 16);
+  assert.match(digest, /^[0-9a-f]{16}$/);
+});
+
+test('no parts hashes the empty string', () => {
+  assert.equal(stableId('exp'), 'exp-da39a3ee5e6b4b0d');
+});

--- a/js/test/experiments.judges.test.mjs
+++ b/js/test/experiments.judges.test.mjs
@@ -1,0 +1,403 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { DEFAULT_LLM_JUDGE_PROMPT, jsonObjects, LLMJudge, RegexJudge } from '../.test-dist/experiments/evaluators.js';
+import { Experiment } from '../.test-dist/experiments/experiment.js';
+import { stableId } from '../.test-dist/experiments/ids.js';
+import { FakeExperimentsClient } from './experimentsFakeClient.mjs';
+
+const suite = {
+  suiteId: 'smoke',
+  name: 'Smoke',
+  version: '1.0.0',
+  testCases: [{ testCaseId: 'add', input: '2+2', expected: '4' }],
+};
+
+function judge(response, options = {}) {
+  return new LLMJudge({
+    evaluatorId: 'judge.default',
+    modelName: 'claude-test',
+    modelProvider: 'anthropic',
+    invoke: () => response,
+    ...options,
+  });
+}
+
+// Mirrors python/tests/test_experiments.py's judge parsing cases.
+const parseCases = [
+  {
+    name: 'a plain scored object',
+    response: '{"score": 0.9, "passed": true, "explanation": "correct"}',
+    score: 0.9,
+    passed: true,
+    explanation: 'correct',
+  },
+  {
+    name: 'unrelated JSON before the verdict',
+    response:
+      'I first considered {"candidate": "incomplete"}.\n{"score": 0.8, "passed": true, "explanation": "grounded"}',
+    score: 0.8,
+    passed: true,
+    explanation: 'grounded',
+  },
+  {
+    name: 'a top-level score beating a nested rubric score',
+    response:
+      '{"score": 0.9, "passed": true, "explanation": "overall", "rubric": {"score": 0.2, "passed": false, "explanation": "nested"}}',
+    score: 0.9,
+    passed: true,
+    explanation: 'overall',
+  },
+  {
+    name: 'a fenced code block',
+    response: '```json\n{"score": 0.4, "explanation": "partial"}\n```',
+    score: 0.4,
+    passed: false,
+    explanation: 'partial',
+  },
+  {
+    name: 'a score outside the unit range, clamped',
+    response: '{"score": 7, "explanation": "over"}',
+    score: 1,
+    passed: true,
+    explanation: 'over',
+  },
+  {
+    name: 'a negative score, clamped',
+    response: '{"score": -2, "explanation": "under"}',
+    score: 0,
+    passed: false,
+    explanation: 'under',
+  },
+  {
+    name: 'a string verdict',
+    response: '{"score": 0.2, "passed": "yes", "explanation": "generous"}',
+    score: 0.2,
+    passed: true,
+    explanation: 'generous',
+  },
+  {
+    name: 'the reason alias',
+    response: '{"score": 0.5, "reason": "borderline"}',
+    score: 0.5,
+    passed: true,
+    explanation: 'borderline',
+  },
+  {
+    name: 'a numeric string score',
+    response: '{"score": "0.6"}',
+    score: 0.6,
+    passed: true,
+    explanation: '',
+  },
+  {
+    name: 'braces inside a string value',
+    response: '{"score": 0.3, "explanation": "saw {not json} in the output"}',
+    score: 0.3,
+    passed: false,
+    explanation: 'saw {not json} in the output',
+  },
+];
+
+test('LLMJudge parses the documented response shapes', async () => {
+  for (const testCase of parseCases) {
+    const result = await judge(testCase.response).evaluateOutput({ input: '2+2', output: '4', expected: '4' });
+    assert.equal(result.value, testCase.score, testCase.name);
+    assert.equal(result.passed, testCase.passed, testCase.name);
+    assert.equal(result.explanation, testCase.explanation, testCase.name);
+  }
+});
+
+test('LLMJudge rejects a response with no JSON object', async () => {
+  await assert.rejects(
+    judge('not structured').evaluateOutput({ input: '', output: 'answer' }),
+    /LLM judge response did not contain a JSON object/,
+  );
+});
+
+test('LLMJudge rejects a JSON object without a numeric score', async () => {
+  await assert.rejects(
+    judge('{"verdict": "good"}').evaluateOutput({ input: '', output: 'answer' }),
+    /LLM judge response requires a numeric 'score'/,
+  );
+  await assert.rejects(
+    judge('{"score": "not a number"}').evaluateOutput({ input: '', output: 'answer' }),
+    /LLM judge response requires a numeric 'score'/,
+  );
+  await assert.rejects(
+    judge('{"score": true}').evaluateOutput({ input: '', output: 'answer' }),
+    /LLM judge response requires a numeric 'score'/,
+  );
+});
+
+test('a malformed leading slice does not hide a later valid object', async () => {
+  const result = await judge('{"score": ,}\n{"score": 0.7}').evaluateOutput({ input: '', output: 'answer' });
+  assert.equal(result.value, 0.7);
+});
+
+test('the pass threshold decides when the judge omits a verdict', async () => {
+  const strict = await judge('{"score": 0.6}', { passThreshold: 0.7 }).evaluateOutput({ input: '', output: 'a' });
+  assert.equal(strict.passed, false);
+  const lenient = await judge('{"score": 0.6}', { passThreshold: 0.5 }).evaluateOutput({ input: '', output: 'a' });
+  assert.equal(lenient.passed, true);
+});
+
+test('placeholders render in one pass so a value cannot become a placeholder', async () => {
+  const prompts = [];
+  const rendering = judge('{"score": 1, "passed": true, "explanation": "ok"}', {
+    promptTemplate: 'Input={input}; Output={output}; Expected={expected}',
+    invoke: (prompt) => {
+      prompts.push(prompt);
+      return '{"score": 1, "passed": true, "explanation": "ok"}';
+    },
+  });
+  await rendering.evaluateOutput({ input: '{output}', output: '{expected}', expected: 'secret-answer' });
+  assert.deepEqual(prompts, ['Input={output}; Output={expected}; Expected=secret-answer']);
+});
+
+test('the default prompt keeps its JSON example intact after rendering', async () => {
+  const prompts = [];
+  const defaulted = new LLMJudge({
+    evaluatorId: 'judge.default-prompt',
+    modelName: 'test-model',
+    invoke: (prompt) => {
+      prompts.push(prompt);
+      return '{"score": 1}';
+    },
+  });
+  await defaulted.evaluateOutput({ input: '2+2', output: '4', expected: '4' });
+  assert.ok(DEFAULT_LLM_JUDGE_PROMPT.includes('{"score": <number from 0 to 1>'));
+  assert.ok(prompts[0].includes('{"score": <number from 0 to 1>'), 'the JSON example is not treated as a placeholder');
+  assert.ok(prompts[0].includes('Candidate output:\n4'));
+});
+
+test('the grader generation carries the prompt, response, and usage', async () => {
+  const withUsage = judge('{"score": 0.9, "passed": true}', {
+    invoke: () => ({
+      content: '{"score": 0.9, "passed": true}',
+      usage: { input_tokens: 120, output_tokens: 18 },
+    }),
+  });
+  const result = await withUsage.evaluateOutput({ input: '2+2', output: '4', expected: '4' });
+  assert.equal(result.grader.modelName, 'claude-test');
+  assert.equal(result.grader.modelProvider, 'anthropic');
+  assert.equal(result.grader.agentName, 'agento11y-llm-judge');
+  assert.equal(result.grader.operationName, 'llm-judge');
+  assert.equal(result.grader.output, '{"score": 0.9, "passed": true}');
+  assert.equal(result.grader.usage.inputTokens, 120);
+  assert.equal(result.grader.usage.outputTokens, 18);
+  assert.equal(result.grader.usage.totalTokens, 138);
+  assert.deepEqual(result.metadata, { judge_model: 'claude-test', judge_provider: 'anthropic' });
+  assert.equal(result.evaluator.kind, 'llm_judge');
+});
+
+test('usage is read from the common provider and framework shapes', async () => {
+  const shapes = [
+    { usage: { prompt_tokens: 5, completion_tokens: 7 } },
+    { usage_metadata: { input_tokens: 5, output_tokens: 7 } },
+    { response_metadata: { token_usage: { input_tokens: 5, output_tokens: 7 } } },
+  ];
+  for (const shape of shapes) {
+    const result = await judge('', {
+      invoke: () => ({ content: '{"score": 1}', ...shape }),
+    }).evaluateOutput({ input: '', output: '' });
+    assert.equal(result.grader.usage.inputTokens, 5, JSON.stringify(shape));
+    assert.equal(result.grader.usage.outputTokens, 7, JSON.stringify(shape));
+    assert.equal(result.grader.usage.totalTokens, 12, JSON.stringify(shape));
+  }
+});
+
+test('a cache-write field is read from either provider spelling', async () => {
+  const result = await judge('', {
+    invoke: () => ({ content: '{"score": 1}', usage: { input_tokens: 1, cache_creation_input_tokens: 9 } }),
+  }).evaluateOutput({ input: '', output: '' });
+  assert.equal(result.grader.usage.cacheWriteInputTokens, 9);
+});
+
+test('a custom parser and usage extractor replace the defaults', async () => {
+  const custom = judge('score=3', {
+    parser: (raw) => ({ score: Number(raw.split('=')[1]) / 10, passed: true, explanation: 'custom' }),
+    usageExtractor: () => ({ inputTokens: 1, outputTokens: 2, totalTokens: 3 }),
+  });
+  const result = await custom.evaluateOutput({ input: '', output: '' });
+  assert.equal(result.value, 0.3);
+  assert.equal(result.explanation, 'custom');
+  assert.equal(result.grader.usage.totalTokens, 3);
+});
+
+test('a list response is joined into text', async () => {
+  const result = await judge('', {
+    invoke: () => ({ content: [{ text: '{"score": ' }, { text: '0.25}' }] }),
+  }).evaluateOutput({ input: '', output: '' });
+  assert.equal(result.value, 0.25);
+});
+
+test('LLMJudge validates its own configuration', () => {
+  const base = { evaluatorId: 'judge', modelName: 'model', invoke: () => '' };
+  assert.throws(() => new LLMJudge({ ...base, evaluatorId: '  ' }), /evaluatorId is required/);
+  assert.throws(() => new LLMJudge({ ...base, invoke: undefined }), /invoke must be callable/);
+  assert.throws(() => new LLMJudge({ ...base, modelName: '  ' }), /modelName is required/);
+  assert.throws(() => new LLMJudge({ ...base, promptTemplate: '  ' }), /promptTemplate is required/);
+  assert.throws(() => new LLMJudge({ ...base, passThreshold: 1.5 }), /passThreshold must be between 0 and 1/);
+});
+
+const regexCases = [
+  { name: 'a search match', options: {}, pattern: '4', output: 'the answer is 4', passed: true },
+  { name: 'a full match', options: { fullMatch: true }, pattern: '^4$', output: '4', passed: true },
+  {
+    name: 'a full match that only matches partially',
+    options: { fullMatch: true },
+    pattern: '^4$',
+    output: 'x4',
+    passed: false,
+  },
+  { name: 'a negated match', options: { negate: true }, pattern: '4', output: 'the answer is 4', passed: false },
+  { name: 'a negated non-match', options: { negate: true }, pattern: '4', output: 'nothing here', passed: true },
+  { name: 'a case-insensitive flag', options: { flags: 'i' }, pattern: 'ANSWER', output: 'answer', passed: true },
+];
+
+test('RegexJudge scores deterministically', () => {
+  for (const testCase of regexCases) {
+    const judgeUnderTest = new RegexJudge({
+      evaluatorId: 'regex.answer',
+      pattern: testCase.pattern,
+      ...testCase.options,
+    });
+    const result = judgeUnderTest.evaluateOutput({ input: '2+2', output: testCase.output, expected: '4' });
+    assert.equal(result.passed, testCase.passed, testCase.name);
+    assert.equal(result.value, testCase.passed, testCase.name);
+    assert.equal(result.evaluator.kind, 'deterministic');
+    assert.equal(result.scoreKey, 'regex_match');
+    assert.equal(result.metadata.pattern, testCase.pattern, testCase.name);
+    assert.equal(result.grader, undefined, 'a deterministic judge publishes no grader transcript');
+  }
+});
+
+test('RegexJudge explains its verdict and accepts an override', () => {
+  const matched = new RegexJudge({ evaluatorId: 'regex.answer', pattern: '4' }).evaluateOutput({
+    input: '',
+    output: '4',
+  });
+  assert.equal(matched.explanation, 'output matched /4/');
+  const missed = new RegexJudge({ evaluatorId: 'regex.answer', pattern: '4' }).evaluateOutput({
+    input: '',
+    output: 'five',
+  });
+  assert.equal(missed.explanation, 'output did not match /4/');
+  const overridden = new RegexJudge({
+    evaluatorId: 'regex.answer',
+    pattern: '4',
+    explanation: 'checked the arithmetic',
+  }).evaluateOutput({ input: '', output: '4' });
+  assert.equal(overridden.explanation, 'checked the arithmetic');
+});
+
+test('RegexJudge validates its own configuration', () => {
+  assert.throws(() => new RegexJudge({ evaluatorId: '  ', pattern: '4' }), /evaluatorId is required/);
+  assert.throws(() => new RegexJudge({ evaluatorId: 'r', pattern: '' }), /pattern is required/);
+});
+
+test('jsonObjects does not merge unrelated brace ranges', () => {
+  assert.deepEqual(jsonObjects('{"a": 1} text {"b": 2}'), [{ a: 1 }, { b: 2 }]);
+  assert.deepEqual(jsonObjects('no objects here'), []);
+  assert.deepEqual(jsonObjects('{"a": {"b": 1}}'), [{ a: { b: 1 } }]);
+});
+
+// --- recordEvaluation ----------------------------------------------------- //
+
+test('recordEvaluation publishes the grader and derives its ids from the score id', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await Experiment.start(client, { experimentId: 'run-1', name: 'judged', suite });
+  let recorded;
+  await experiment.withTrial('add', async (trial) => {
+    recorded = await trial.evaluateOutput(judge('{"score": 0.9, "passed": true, "explanation": "correct"}'), {
+      input: '2+2',
+      output: '4',
+      expected: '4',
+      scoreKey: 'final',
+    });
+  });
+
+  assert.equal(recorded.scoreKey, 'final');
+  assert.equal(recorded.value.number, 0.9);
+  assert.equal(recorded.passed, true);
+  assert.equal(recorded.graderGenerationId, stableId('gen', recorded.scoreId, 'grader'));
+  assert.equal(recorded.graderConversationId, stableId('conv', recorded.scoreId, 'grader'));
+  assert.equal(client.generations[0], recorded.graderGenerationId);
+  assert.equal(client.generationCalls[0].conversationId, recorded.graderConversationId);
+  assert.equal(client.generationCalls[0].operationName, 'llm-judge');
+  assert.deepEqual(client.generationCalls[0].tags, {
+    'experiment.run_id': 'run-1',
+    'test.case.id': 'add',
+    'test.case.attempt': '1',
+    'evaluator.id': 'judge.default',
+  });
+  // The score reaches the export with its grader links attached.
+  assert.equal(client.scores.length, 1);
+  assert.equal(client.scores[0].graderGenerationId, recorded.graderGenerationId);
+  assert.equal(client.scores[0].evaluatorKind, 'llm_judge');
+});
+
+test('a deterministic judge records no grader generation', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await Experiment.start(client, { experimentId: 'run-regex', name: 'regex', suite });
+  let recorded;
+  await experiment.withTrial('add', async (trial) => {
+    recorded = await trial.evaluateOutput(
+      new RegexJudge({ evaluatorId: 'regex.answer', pattern: '^4$', fullMatch: true }),
+      {
+        input: '2+2',
+        output: '4',
+        expected: '4',
+        scoreKey: 'final',
+      },
+    );
+  });
+  assert.equal(recorded.passed, true);
+  assert.equal(recorded.value.boolean, true);
+  assert.equal(recorded.graderGenerationId, '');
+  assert.deepEqual(client.generations, []);
+});
+
+test('publishGrader false keeps the grader transcript local', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await Experiment.start(client, { experimentId: 'run-1', name: 'judged', suite });
+  let recorded;
+  await experiment.withTrial('add', async (trial) => {
+    recorded = await trial.evaluateOutput(judge('{"score": 0.9, "passed": true}'), {
+      input: '2+2',
+      output: '4',
+      publishGrader: false,
+    });
+  });
+  assert.equal(recorded.graderGenerationId, '');
+  assert.deepEqual(client.generations, []);
+});
+
+test('recordEvaluation accepts a framework-produced result', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await Experiment.start(client, { experimentId: 'run-framework', name: 'framework', suite });
+  let recorded;
+  await experiment.withTrial('add', async (trial) => {
+    recorded = await trial.recordEvaluation({
+      evaluator: { evaluatorId: 'harbor.rubric', version: '1', kind: 'llm_judge' },
+      value: 0.8,
+      passed: true,
+      explanation: 'framework-owned trajectory passed',
+      metadata: { harness: 'harbor' },
+      grader: {
+        input: 'harbor-rendered trajectory',
+        output: '{"score": 0.8}',
+        modelProvider: 'anthropic',
+        modelName: 'claude-test',
+        usage: { inputTokens: 30, outputTokens: 6, totalTokens: 36 },
+      },
+    });
+  });
+  assert.equal(recorded.evaluatorId, 'harbor.rubric');
+  assert.notEqual(recorded.graderGenerationId, '');
+  assert.equal(client.generationCalls[0].inputText, 'harbor-rendered trajectory');
+  assert.equal(client.generationCalls[0].usage.totalTokens, 36);
+  assert.equal(client.generationCalls[0].operationName, 'evaluate');
+  assert.equal(client.scores[0].metadata.harness, 'harbor');
+});

--- a/js/test/experiments.lifecycle.test.mjs
+++ b/js/test/experiments.lifecycle.test.mjs
@@ -1,0 +1,472 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { Experiment, Trial, withExperiment } from '../.test-dist/experiments/experiment.js';
+import { FakeExperimentsClient } from './experimentsFakeClient.mjs';
+
+const suite = {
+  suiteId: 'smoke',
+  name: 'Smoke',
+  version: '1.0.0',
+  testCases: [
+    { testCaseId: 'add', name: 'Addition', input: '2+2', expected: '4' },
+    { testCaseId: 'sub', input: '5-3', expected: '2' },
+  ],
+};
+
+const verifier = { evaluatorId: 'exact', version: '1', kind: 'deterministic' };
+
+async function openExperiment(client, options = {}) {
+  return Experiment.start(client, { experimentId: 'run-1', name: 'smoke run', suite, ...options });
+}
+
+test('a trial with a local final score completes in the documented call order', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  await experiment.withTrial(suite.testCases[0], (trial) => {
+    trial.finalScore(true, { evaluator: verifier, explanation: 'matched' });
+  });
+  await experiment.finalize('completed');
+
+  assert.deepEqual(client.calls, [
+    'upsert_experiment',
+    'upsert_trial',
+    'flush_generations',
+    'export_scores',
+    'update_trial',
+    'finalize',
+  ]);
+  assert.equal(client.upserts[0].runId, 'run-1');
+  assert.equal(client.upserts[0].suiteId, 'smoke');
+  assert.equal(client.trials[0].status, 'running');
+  assert.equal(client.trials[0].testCase.test_case_id, 'add');
+  assert.equal(client.trialUpdates[0].status, 'completed');
+  assert.equal(client.trialUpdates[0].error, '');
+  assert.equal(client.finalized[0].status, 'completed');
+  assert.equal(client.scores.length, 1);
+  assert.equal(client.scores[0].scoreKey, 'final');
+  assert.equal(client.scores[0].passed, true);
+  assert.equal(client.scores[0].trialId, client.trials[0].trialId);
+  assert.equal(client.scores[0].experimentId, 'run-1');
+  assert.equal(client.scores[0].generationId, '', 'no anchor generation without recordIO');
+});
+
+test('a boolean final score sets the trial verdict', async () => {
+  const cases = [
+    { value: true, status: 'passed' },
+    { value: false, status: 'failed' },
+  ];
+  for (const { value, status } of cases) {
+    const client = new FakeExperimentsClient();
+    const experiment = await openExperiment(client);
+    const trial = experiment.trial('add');
+    await trial.start();
+    trial.finalScore(value, { evaluator: verifier });
+    await trial.close();
+    assert.equal(trial.status, status, `value ${value}`);
+    // The backend trial status is the lifecycle, not the verdict.
+    assert.equal(client.trialUpdates[0].status, 'completed');
+    await experiment.finalize();
+  }
+});
+
+test('a numeric final score without a verdict closes completed', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  const trial = experiment.trial('add');
+  await trial.start();
+  trial.finalScore(0.82, { evaluator: verifier });
+  await trial.close();
+  assert.equal(trial.status, 'completed');
+  assert.equal(client.scores[0].passed, undefined);
+});
+
+test('a numeric final score with an explicit verdict keeps it', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  const trial = experiment.trial('add');
+  await trial.start();
+  trial.finalScore(0.82, { passed: true, evaluator: verifier });
+  await trial.close();
+  assert.equal(trial.status, 'passed');
+  assert.equal(client.scores[0].passed, true);
+});
+
+test('a trial closed without a final score fails with the documented error', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  const trial = experiment.trial('add');
+  await trial.start();
+  await trial.close();
+
+  assert.equal(trial.status, 'failed');
+  assert.equal(trial.error, 'trial closed without a final score');
+  assert.equal(client.trialUpdates[0].status, 'completed');
+  assert.equal(client.trialUpdates[0].error, 'trial closed without a final score');
+  assert.ok(!client.calls.includes('export_scores'), 'an empty buffer sends no score request');
+});
+
+test('a callback error terminalizes the trial and the run', async () => {
+  const client = new FakeExperimentsClient();
+  const failure = new Error('candidate failed');
+  await assert.rejects(
+    withExperiment(client, { experimentId: 'run-1', name: 'smoke run', suite }, async (experiment) => {
+      await experiment.withTrial('add', () => {
+        throw failure;
+      });
+    }),
+    (error) => {
+      assert.equal(error, failure);
+      return true;
+    },
+  );
+
+  assert.equal(client.trialUpdates.length, 1);
+  assert.equal(client.trialUpdates[0].status, 'failed', 'the backend maps errored onto failed');
+  assert.equal(client.trialUpdates[0].error, 'candidate failed');
+  assert.equal(client.finalized.length, 1, 'the run is still finalized');
+  assert.equal(client.finalized[0].status, 'failed');
+  assert.equal(client.finalized[0].error, 'candidate failed');
+});
+
+test('a close failure keeps both errors when the callback threw a non-Error', async () => {
+  // The other callback-error tests all throw an Error, so the path that used to
+  // drop the close error was never exercised: a thrown string has no cause slot.
+  const exportFailure = new Error('agento11y score export rejected 1 score(s): score-1: bad');
+  const client = new FakeExperimentsClient({ exportScoresError: exportFailure });
+  await assert.rejects(
+    withExperiment(client, { experimentId: 'run-1', name: 'smoke run', suite }, async (experiment) => {
+      await experiment.withTrial('add', (trial) => {
+        trial.finalScore(true, { evaluator: verifier });
+        throw 'boom';
+      });
+    }),
+    (error) => {
+      assert.equal(error, 'boom', 'the callback value is rethrown unchanged');
+      return true;
+    },
+  );
+  assert.ok(
+    client.warnings.some((message) => message.includes('score export rejected')),
+    `the score export failure must be reported, got ${JSON.stringify(client.warnings)}`,
+  );
+});
+
+test('a callback error that already carries a cause still reports the close failure', async () => {
+  const exportFailure = new Error('agento11y score export rejected 1 score(s): score-1: bad');
+  const client = new FakeExperimentsClient({ exportScoresError: exportFailure });
+  const rootCause = new Error('model refused');
+  const callbackError = new Error('candidate failed', { cause: rootCause });
+  const experiment = await openExperiment(client);
+  await assert.rejects(
+    experiment.withTrial('add', (trial) => {
+      trial.finalScore(true, { evaluator: verifier });
+      throw callbackError;
+    }),
+    (error) => {
+      assert.equal(error, callbackError);
+      return true;
+    },
+  );
+  assert.equal(callbackError.cause, rootCause, 'the caller cause is not overwritten');
+  assert.equal(rootCause.cause, exportFailure, 'the close failure joins the end of the chain');
+  assert.ok(client.warnings.some((message) => message.includes('score export rejected')));
+});
+
+test('close reports the terminal patch failure and keeps the score export failure', async () => {
+  const exportFailure = new Error('agento11y score export rejected 1 score(s): score-1: bad');
+  const patchFailure = new Error('agento11y experiment transport failed: test case trial update: status 500');
+  const client = new FakeExperimentsClient({ exportScoresError: exportFailure, updateTrialError: patchFailure });
+  const experiment = await openExperiment(client);
+  const trial = experiment.trial('add');
+  await trial.start();
+  trial.finalScore(true, { evaluator: verifier });
+  await assert.rejects(trial.close(), (error) => {
+    assert.equal(error, patchFailure);
+    return true;
+  });
+  assert.equal(patchFailure.cause, exportFailure, 'the flush failure travels with the patch failure');
+  assert.ok(client.warnings.some((message) => message.includes('score export rejected')));
+  assert.equal(trial.isClosed, false, 'the scores stay buffered so a retry can publish them');
+  assert.equal(trial.pendingScores.length, 1);
+});
+
+test('withExperiment finalizes completed on the success path', async () => {
+  const client = new FakeExperimentsClient();
+  const returned = await withExperiment(client, { experimentId: 'run-1', name: 'run', suite }, async (experiment) => {
+    await experiment.withTrial('add', (trial) => {
+      trial.finalScore(true, { evaluator: verifier });
+    });
+    return 'done';
+  });
+  assert.equal(returned, 'done');
+  assert.equal(client.finalized[0].status, 'completed');
+});
+
+test('finalize closes trials still open', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  const trial = experiment.trial('add');
+  await trial.start();
+  trial.finalScore(true, { evaluator: verifier });
+  await experiment.finalize('completed');
+
+  assert.equal(trial.isClosed, true);
+  assert.equal(client.trialUpdates.length, 1);
+  assert.equal(client.finalized.length, 1);
+});
+
+test('finalize runs once', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  await experiment.finalize('completed');
+  await experiment.finalize('failed');
+  assert.equal(client.finalized.length, 1);
+  assert.equal(client.finalized[0].status, 'completed');
+});
+
+test('reusing a case and attempt is rejected', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  const first = experiment.trial('add');
+  await first.start();
+  assert.throws(
+    () => experiment.trial('add'),
+    /trial for test case "add" attempt 1 already exists; increment attempt for a retry/,
+  );
+  // A retry with a new attempt is a different durable trial.
+  const retry = experiment.trial('add', { attempt: 2 });
+  assert.notEqual(retry.trialId, first.trialId);
+});
+
+test('an unbound trial mints no conversation until recordIO', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  const trial = experiment.trial('add');
+  await trial.start();
+  assert.equal(trial.conversationId, '');
+  trial.recordIO({ input: '2+2', output: '4' });
+  assert.match(trial.conversationId, /^conv-[0-9a-f]{16}$/);
+  trial.finalScore(true, { evaluator: verifier });
+  await trial.close();
+
+  assert.deepEqual(
+    client.calls,
+    ['upsert_experiment', 'upsert_trial', 'export_generation', 'flush_generations', 'export_scores', 'update_trial'],
+    'the anchor generation is exported before its scores',
+  );
+  assert.equal(client.generationCalls[0].inputText, '2+2');
+  assert.equal(client.generationCalls[0].outputText, '4');
+  assert.equal(client.generationCalls[0].conversationId, trial.conversationId);
+  assert.equal(client.scores[0].generationId, trial.generationId);
+});
+
+test('bindConversation keeps the caller conversation', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  const trial = experiment.trial('add');
+  await trial.start();
+  trial.bindConversation(' conv-real ');
+  trial.recordIO({ output: '4' });
+  assert.equal(trial.conversationId, 'conv-real');
+  trial.finalScore(true, { evaluator: verifier });
+  await trial.close();
+  assert.equal(client.generationCalls[0].conversationId, 'conv-real');
+  assert.equal(client.trialUpdates[0].conversationId, 'conv-real');
+});
+
+test('bindGeneration suppresses the anchor generation', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  const trial = experiment.trial('add');
+  await trial.start();
+  trial.bindGeneration('gen-external', { conversationId: 'conv-external' });
+  trial.recordIO({ input: '2+2', output: '4' });
+  trial.finalScore(true, { evaluator: verifier });
+  await trial.close();
+
+  assert.ok(!client.calls.includes('export_generation'));
+  assert.equal(client.scores[0].generationId, 'gen-external');
+  assert.equal(client.scores[0].conversationId, 'conv-external');
+});
+
+test('a rejected anchor generation surfaces instead of being swallowed', async () => {
+  const rejection = new Error('agento11y experiment transport failed: generation export rejected: bad conversation');
+  const client = new FakeExperimentsClient({ exportGenerationError: rejection });
+  const experiment = await openExperiment(client);
+  const trial = experiment.trial('add');
+  await trial.start();
+  trial.recordIO({ input: '2+2', output: '4' });
+  trial.finalScore(true, { evaluator: verifier });
+  await assert.rejects(trial.close(), (error) => {
+    assert.equal(error, rejection);
+    return true;
+  });
+  // The trial is still terminalized so the run does not hang on an open trial.
+  assert.equal(client.trialUpdates.length, 1);
+});
+
+test('scores buffer until flush and keep their buffered order', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  const trial = experiment.trial('add');
+  await trial.start();
+  trial.checkScore('json_valid', { passed: true });
+  trial.rubricScore('helpfulness', 0.9, { passed: true });
+  trial.finalScore(true, { evaluator: verifier });
+  assert.equal(trial.pendingScores.length, 3);
+  assert.equal(client.scores.length, 0);
+
+  const accepted = await trial.flush();
+  assert.equal(accepted, 3);
+  assert.equal(trial.pendingScores.length, 0);
+  assert.deepEqual(
+    client.scores.map((score) => score.scoreKey),
+    ['json_valid', 'helpfulness', 'final'],
+  );
+  assert.equal(client.scores[0].evaluatorId, 'sdk.json_valid');
+  assert.equal(client.scores[0].evaluatorKind, 'deterministic');
+  assert.equal(client.scores[1].evaluatorKind, 'llm_judge');
+  assert.equal(trial.acceptedScores, 3);
+  assert.equal(experiment.acceptedScores, 3);
+
+  // A second flush with an empty buffer sends nothing.
+  const before = client.calls.filter((call) => call === 'export_scores').length;
+  assert.equal(await trial.flush(), 0);
+  assert.equal(client.calls.filter((call) => call === 'export_scores').length, before);
+});
+
+test('repeating one score key and evaluator yields distinct ids', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  const trial = experiment.trial('add');
+  await trial.start();
+  const first = trial.score('accuracy', 1, { evaluator: verifier });
+  const second = trial.score('accuracy', 0, { evaluator: verifier });
+  assert.notEqual(first.scoreId, second.scoreId);
+  assert.match(first.scoreId, /^score-[0-9a-f]{16}$/);
+});
+
+test('score metadata carries the trial identity', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  const trial = experiment.trial('add', { attempt: 3, metadata: { shard: 'a' } });
+  await trial.start();
+  trial.finalScore(true, { evaluator: verifier, metadata: { extra: 1 } });
+  await trial.flush();
+  assert.deepEqual(client.scores[0].metadata, {
+    task_id: 'add',
+    trial_id: trial.trialId,
+    attempt: 3,
+    shard: 'a',
+    extra: 1,
+  });
+  assert.deepEqual(client.scores[0].source, { kind: 'experiment', id: 'run-1' });
+});
+
+test('setUsage reaches the terminal trial patch', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  const trial = experiment.trial('add');
+  await trial.start();
+  trial.setUsage({ inputTokens: 12, outputTokens: 34, cost: 0.02 });
+  trial.finalScore(true, { evaluator: verifier });
+  await trial.close();
+  assert.equal(client.trialUpdates[0].inputTokens, 12);
+  assert.equal(client.trialUpdates[0].outputTokens, 34);
+  assert.equal(client.trialUpdates[0].cost, 0.02);
+  assert.ok(client.trialUpdates[0].durationMs >= 0);
+});
+
+test('bindTrace patches an already created trial', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  const trial = experiment.trial('add');
+  await trial.start();
+  await trial.bindTrace('0af7651916cd43dd8448eb211c80319c', 'b7ad6b7169203331');
+  assert.equal(client.trialUpdates[0].traceId, '0af7651916cd43dd8448eb211c80319c');
+  assert.equal(client.trialUpdates[0].spanId, 'b7ad6b7169203331');
+});
+
+test('closing twice patches the trial once', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  const trial = experiment.trial('add');
+  await trial.start();
+  trial.finalScore(true, { evaluator: verifier });
+  await trial.close();
+  await trial.close();
+  assert.equal(client.trialUpdates.length, 1);
+});
+
+test('a trial opened from a ref works without a parent experiment', async () => {
+  const client = new FakeExperimentsClient();
+  const trial = Trial.fromRef(client, { experimentId: 'run-1', testCaseId: 'add', attempt: 1 });
+  await trial.start();
+  trial.finalScore(0.5, { passed: true, evaluator: verifier });
+  await trial.close();
+  assert.deepEqual(client.calls, ['upsert_trial', 'flush_generations', 'export_scores', 'update_trial']);
+  assert.equal(client.scores[0].trialId, trial.trialId);
+});
+
+test('Trial.fromRef rejects a missing ref', () => {
+  const client = new FakeExperimentsClient();
+  assert.throws(
+    () => Trial.fromRef(client, undefined),
+    /trial ref is required; set AGENTO11Y_EXPERIMENT_ID and AGENTO11Y_TEST_CASE_ID/,
+  );
+});
+
+test('a failed trial close forces the run to failed and drops the score count', async () => {
+  const exportFailure = new Error('agento11y score export rejected 1 score(s): score-1: bad');
+  const client = new FakeExperimentsClient({ exportScoresError: exportFailure });
+  const experiment = await openExperiment(client);
+  const trial = experiment.trial('add');
+  await trial.start();
+  trial.finalScore(true, { evaluator: verifier });
+  await assert.rejects(experiment.finalize('completed', { scoreCount: 1 }), (error) => {
+    assert.equal(error, exportFailure);
+    return true;
+  });
+  assert.equal(client.finalized[0].status, 'failed');
+  assert.equal(client.finalized[0].scoreCount, undefined);
+  assert.match(client.finalized[0].error, /^trial close failed: agento11y score export rejected/);
+});
+
+test('a caller score count reaches finalize when nothing was cloud evaluated', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  await experiment.withTrial('add', (trial) => {
+    trial.finalScore(true, { evaluator: verifier });
+  });
+  await experiment.finalize('completed', { scoreCount: 1 });
+  assert.equal(client.finalized[0].scoreCount, 1);
+});
+
+test('a plannedTrialCount below zero is rejected', async () => {
+  const client = new FakeExperimentsClient();
+  await assert.rejects(openExperiment(client, { plannedTrialCount: -1 }), /plannedTrialCount must be non-negative/);
+});
+
+test('an experiment without an id derives a stable one', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await Experiment.start(client, { name: 'nightly' });
+  assert.match(experiment.experimentId, /^exp-[0-9a-f]{16}$/);
+  assert.equal(experiment.name, 'nightly');
+  assert.equal(client.upserts[0].runId, experiment.experimentId);
+});
+
+test('the experiment url comes from the client', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  assert.equal(experiment.url, 'http://ui/run-1');
+});
+
+test('finalize passes its status and error to the client unchanged', async () => {
+  const client = new FakeExperimentsClient();
+  const experiment = await openExperiment(client);
+  // Status validation lives in the real client and is covered by the client suite.
+  await experiment.finalize('failed', { error: 'aborted by operator' });
+  assert.equal(client.finalized[0].status, 'failed');
+  assert.equal(client.finalized[0].error, 'aborted by operator');
+});

--- a/js/test/experiments.otel.test.mjs
+++ b/js/test/experiments.otel.test.mjs
@@ -1,0 +1,338 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { context, SpanStatusCode, trace } from '@opentelemetry/api';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+
+import { ExperimentsClient } from '../.test-dist/experiments/client.js';
+import { Experiment } from '../.test-dist/experiments/experiment.js';
+import {
+  runStatusTelemetry,
+  scoreEventAttributes,
+  scoreLabel,
+  trialIdentityAttributes,
+  trialStatusTelemetry,
+} from '../.test-dist/experiments/otel.js';
+import { FakeExperimentsClient } from './experimentsFakeClient.mjs';
+
+const suite = {
+  suiteId: 'smoke',
+  name: 'Smoke',
+  version: '2.0.0',
+  testCases: [{ testCaseId: 'add', name: 'Addition', input: '2+2', expected: '4' }],
+};
+
+const verifier = { evaluatorId: 'exact', version: '2', kind: 'deterministic' };
+
+/** Installs an in-memory exporter and restores the previous global provider. */
+function withRecorder() {
+  const exporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] });
+  trace.setGlobalTracerProvider(provider);
+  return {
+    exporter,
+    async dispose() {
+      await provider.shutdown();
+      trace.disable();
+    },
+  };
+}
+
+test('experimental telemetry is off by default', async () => {
+  const recorder = withRecorder();
+  try {
+    const client = new FakeExperimentsClient();
+    const experiment = await Experiment.start(client, { experimentId: 'run-1', name: 'quiet', suite });
+    await experiment.withTrial('add', (trial) => {
+      trial.finalScore(true, { evaluator: verifier });
+    });
+    await experiment.finalize('completed');
+    assert.deepEqual(recorder.exporter.getFinishedSpans(), [], 'no experiments span without the opt-in');
+  } finally {
+    await recorder.dispose();
+  }
+});
+
+test('the opt-in emits a trial span with the documented identity attributes', async () => {
+  const recorder = withRecorder();
+  try {
+    const client = new FakeExperimentsClient({ useExperimentalOtel: true });
+    const experiment = await Experiment.start(client, { experimentId: 'run-1', name: 'nightly', suite });
+    await experiment.withTrial('add', (trial) => {
+      trial.setUsage({ inputTokens: 11, outputTokens: 3 });
+      trial.finalScore(true, { evaluator: verifier, explanation: 'matched' });
+    });
+
+    const spans = recorder.exporter.getFinishedSpans();
+    assert.equal(spans.length, 1);
+    const span = spans[0];
+    assert.equal(span.name, 'eval.trial add');
+    assert.equal(span.instrumentationScope.name, 'sigil_sdk.experiments');
+    assert.equal(span.attributes['agento11y.eval.schema.version'], 'experiments-otel-2026-06');
+    assert.equal(span.attributes['test.suite.run.id'], 'run-1');
+    assert.equal(span.attributes['test.suite.id'], 'smoke');
+    assert.equal(span.attributes['test.suite.version'], '2.0.0');
+    assert.equal(span.attributes['test.suite.name'], 'Smoke');
+    assert.equal(span.attributes['test.suite.run.status'], 'in_progress');
+    assert.equal(span.attributes['test.case.id'], 'add');
+    assert.equal(span.attributes['test.case.name'], 'Addition');
+    assert.equal(span.attributes['test.case.run.attempt'], 1);
+    assert.equal(span.attributes['test.case.result.status'], 'pass');
+    assert.equal(span.attributes['gen_ai.operation.name'], 'invoke_agent');
+    assert.equal(span.attributes['gen_ai.usage.input_tokens'], 11);
+    assert.equal(span.attributes['gen_ai.usage.output_tokens'], 3);
+    assert.equal(span.status.code, SpanStatusCode.OK);
+  } finally {
+    await recorder.dispose();
+  }
+});
+
+test('each score emits a gen_ai.evaluation.result event', async () => {
+  const recorder = withRecorder();
+  try {
+    const client = new FakeExperimentsClient({ useExperimentalOtel: true });
+    const experiment = await Experiment.start(client, { experimentId: 'run-1', name: 'nightly', suite });
+    await experiment.withTrial('add', (trial) => {
+      trial.checkScore('json_valid', { passed: true });
+      trial.finalScore(0.9, { passed: true, evaluator: verifier, explanation: 'matched' });
+    });
+
+    const [span] = recorder.exporter.getFinishedSpans();
+    assert.equal(span.events.length, 2);
+    assert.ok(span.events.every((event) => event.name === 'gen_ai.evaluation.result'));
+
+    const final = span.events[1];
+    assert.equal(final.attributes['gen_ai.evaluation.name'], 'final');
+    assert.equal(final.attributes['gen_ai.evaluation.score.value'], 0.9);
+    assert.equal(final.attributes['gen_ai.evaluation.score.label'], 'pass');
+    assert.equal(final.attributes['gen_ai.evaluation.explanation'], 'matched');
+    assert.equal(final.attributes['gen_ai.evaluation.evaluator.id'], 'exact');
+    assert.equal(final.attributes['gen_ai.evaluation.evaluator.version'], '2');
+    assert.equal(final.attributes['gen_ai.evaluation.evaluator.type'], 'deterministic');
+
+    const check = span.events[0];
+    assert.equal(check.attributes['gen_ai.evaluation.name'], 'json_valid');
+    assert.equal(check.attributes['gen_ai.evaluation.score.value'], 1, 'a boolean value becomes 1 or 0');
+  } finally {
+    await recorder.dispose();
+  }
+});
+
+test('the trial span carries candidate identity and the bound conversation', async () => {
+  const recorder = withRecorder();
+  try {
+    const client = new FakeExperimentsClient({ useExperimentalOtel: true });
+    const experiment = await Experiment.start(client, {
+      experimentId: 'run-1',
+      name: 'nightly',
+      suite,
+      candidate: { agentName: 'calc', agentVersion: '3', modelProvider: 'openai', modelName: 'gpt-5' },
+    });
+    await experiment.withTrial('add', (trial) => {
+      trial.bindConversation('conv-real');
+      trial.finalScore(true, { evaluator: verifier });
+    });
+    const [span] = recorder.exporter.getFinishedSpans();
+    assert.equal(span.attributes['gen_ai.agent.name'], 'calc');
+    assert.equal(span.attributes['gen_ai.agent.version'], '3');
+    assert.equal(span.attributes['gen_ai.provider.name'], 'openai');
+    assert.equal(span.attributes['gen_ai.request.model'], 'gpt-5');
+    assert.equal(span.attributes['gen_ai.conversation.id'], 'conv-real');
+  } finally {
+    await recorder.dispose();
+  }
+});
+
+test('a trial that errors ends its span with the error status', async () => {
+  const recorder = withRecorder();
+  try {
+    const client = new FakeExperimentsClient({ useExperimentalOtel: true });
+    const experiment = await Experiment.start(client, { experimentId: 'run-1', name: 'nightly', suite });
+    await assert.rejects(
+      experiment.withTrial('add', () => {
+        throw new Error('candidate failed');
+      }),
+      /candidate failed/,
+    );
+    const [span] = recorder.exporter.getFinishedSpans();
+    assert.equal(span.status.code, SpanStatusCode.ERROR);
+    assert.equal(span.status.message, 'candidate failed');
+    assert.equal(span.attributes['gen_ai.evaluation.explanation'], 'candidate failed');
+    assert.equal(span.attributes['test.case.result.status'], undefined, 'errored is not a verdict');
+  } finally {
+    await recorder.dispose();
+  }
+});
+
+test('the trial adopts its span trace and span ids', async () => {
+  const recorder = withRecorder();
+  try {
+    const client = new FakeExperimentsClient({ useExperimentalOtel: true });
+    const experiment = await Experiment.start(client, { experimentId: 'run-1', name: 'nightly', suite });
+    const trial = experiment.trial('add');
+    await trial.start();
+    assert.match(trial.traceId, /^[0-9a-f]{32}$/);
+    assert.match(trial.spanId, /^[0-9a-f]{16}$/);
+    trial.finalScore(true, { evaluator: verifier });
+    await trial.close();
+    assert.equal(client.scores[0].traceId, trial.traceId);
+    assert.equal(client.trialUpdates[0].traceId, trial.traceId);
+  } finally {
+    await recorder.dispose();
+  }
+});
+
+test('a trial without a registered provider stores no trace id', async () => {
+  // Every other OTel test installs a provider, so this path was untested: the noop
+  // tracer returns an all-zero trace id that is still 32 characters long, and
+  // storing it would point the trial and its scores at a trace that never existed.
+  trace.disable();
+  const client = new FakeExperimentsClient({ useExperimentalOtel: true });
+  const experiment = await Experiment.start(client, { experimentId: 'run-1', name: 'nightly', suite });
+  const trial = experiment.trial('add');
+  await trial.start();
+  assert.equal(trial.traceId, '');
+  assert.equal(trial.spanId, '');
+  trial.finalScore(true, { evaluator: verifier });
+  await trial.close();
+  assert.equal(client.scores[0].traceId, '');
+  assert.equal(client.trialUpdates[0].traceId, '');
+});
+
+test('a span started inside the callback becomes a child of the trial span', async () => {
+  // Context propagation needs a context manager, which the OTel SDK installs
+  // through `provider.register()` in a real app. Mirrors client.metric-exemplar.
+  const contextManager = new AsyncLocalStorageContextManager().enable();
+  context.setGlobalContextManager(contextManager);
+  const recorder = withRecorder();
+  try {
+    const client = new FakeExperimentsClient({ useExperimentalOtel: true });
+    const experiment = await Experiment.start(client, { experimentId: 'run-1', name: 'nightly', suite });
+    await experiment.withTrial('add', (trial) => {
+      // Stands in for a generation an instrumented agent emits inside the trial.
+      trace.getTracer('test').startSpan('agent call').end();
+      trial.finalScore(true, { evaluator: verifier });
+    });
+
+    const spans = recorder.exporter.getFinishedSpans();
+    const trialSpan = spans.find((span) => span.name === 'eval.trial add');
+    const childSpan = spans.find((span) => span.name === 'agent call');
+    const parentSpanId = childSpan.parentSpanContext?.spanId ?? childSpan.parentSpanId;
+    assert.equal(parentSpanId, trialSpan.spanContext().spanId, 'the agent span hangs off the trial span');
+    assert.equal(childSpan.spanContext().traceId, trialSpan.spanContext().traceId);
+  } finally {
+    await recorder.dispose();
+    context.disable();
+    contextManager.disable();
+  }
+});
+
+test('an artifact adds an event to the trial span', async () => {
+  const recorder = withRecorder();
+  try {
+    const client = new FakeExperimentsClient({ useExperimentalOtel: true });
+    const experiment = await Experiment.start(client, { experimentId: 'run-1', name: 'nightly', suite });
+    await experiment.withTrial('add', async (trial) => {
+      await trial.artifact('notes.md', { text: '# notes', kind: 'markdown', mime: 'text/markdown' });
+      trial.finalScore(true, { evaluator: verifier });
+    });
+    const [span] = recorder.exporter.getFinishedSpans();
+    const artifactEvent = span.events.find((event) => event.name === 'agento11y.eval.artifact');
+    assert.equal(artifactEvent.attributes['agento11y.eval.artifact.name'], 'notes.md');
+    assert.equal(artifactEvent.attributes['agento11y.eval.artifact.kind'], 'markdown');
+  } finally {
+    await recorder.dispose();
+  }
+});
+
+test('the client opt-in follows AGENTO11Y_USE_EXPERIMENTAL_OTEL and the experiment can override it', async () => {
+  const recorder = withRecorder();
+  try {
+    const enabled = new FakeExperimentsClient({ useExperimentalOtel: true });
+    const experiment = await Experiment.start(enabled, {
+      experimentId: 'run-1',
+      name: 'nightly',
+      suite,
+      useExperimentalOtel: false,
+    });
+    await experiment.withTrial('add', (trial) => {
+      trial.finalScore(true, { evaluator: verifier });
+    });
+    assert.deepEqual(recorder.exporter.getFinishedSpans(), [], 'the experiment opt-out wins');
+
+    // The real client reads the environment variable.
+    const base = { endpoint: 'http://localhost:1', ingestToken: 'tok' };
+    assert.equal(new ExperimentsClient({ ...base, env: {} }).useExperimentalOtel, false);
+    assert.equal(
+      new ExperimentsClient({ ...base, env: { AGENTO11Y_USE_EXPERIMENTAL_OTEL: 'on' } }).useExperimentalOtel,
+      true,
+    );
+  } finally {
+    await recorder.dispose();
+  }
+});
+
+// --- attribute builders --------------------------------------------------- //
+
+test('status maps follow the documented enums', () => {
+  const runCases = [
+    ['running', 'in_progress'],
+    ['completed', 'success'],
+    ['succeeded', 'success'],
+    ['failed', 'failure'],
+    ['canceled', 'aborted'],
+    ['cancelled', 'aborted'],
+    ['nonsense', 'in_progress'],
+  ];
+  for (const [status, want] of runCases) {
+    assert.equal(runStatusTelemetry(status), want, status);
+  }
+  const trialCases = [
+    ['passed', 'pass'],
+    ['failed', 'fail'],
+    ['running', ''],
+    ['errored', ''],
+    ['skipped', ''],
+    ['completed', ''],
+  ];
+  for (const [status, want] of trialCases) {
+    assert.equal(trialStatusTelemetry(status), want, status);
+  }
+  assert.equal(scoreLabel(true), 'pass');
+  assert.equal(scoreLabel(false), 'fail');
+  assert.equal(scoreLabel(undefined), '');
+});
+
+test('blank identity fields are omitted rather than sent empty', () => {
+  const attrs = trialIdentityAttributes({ experimentId: 'run-1', attempt: 2 });
+  assert.deepEqual(Object.keys(attrs).sort(), [
+    'agento11y.eval.schema.version',
+    'gen_ai.operation.name',
+    'test.case.run.attempt',
+    'test.suite.run.id',
+    'test.suite.run.status',
+  ]);
+  assert.equal(attrs['test.case.run.attempt'], 2);
+});
+
+test('a categorical score value becomes the label', () => {
+  const attrs = scoreEventAttributes({ name: 'category', value: 'refusal' });
+  assert.equal(attrs['gen_ai.evaluation.score.label'], 'refusal');
+  assert.equal(attrs['gen_ai.evaluation.score.value'], undefined, 'a string is not a numeric score');
+
+  const withVerdict = scoreEventAttributes({ name: 'category', value: 'refusal', passed: false });
+  assert.equal(withVerdict['gen_ai.evaluation.score.label'], 'fail', 'the verdict wins over the category');
+});
+
+test('reference set provenance is emitted when present', () => {
+  const attrs = scoreEventAttributes({
+    name: 'final',
+    value: 1,
+    referenceSetId: 'golden',
+    referenceSetVersion: '4',
+    responseId: 'gen-1',
+  });
+  assert.equal(attrs['gen_ai.evaluation.reference_set.id'], 'golden');
+  assert.equal(attrs['gen_ai.evaluation.reference_set.version'], '4');
+  assert.equal(attrs['gen_ai.response.id'], 'gen-1');
+});

--- a/js/test/experiments.package.test.mjs
+++ b/js/test/experiments.package.test.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+test('the package publishes the experiments subpath', async () => {
+  const manifest = JSON.parse(await readFile(path.join(__dirname, '..', 'package.json'), 'utf8'));
+  assert.deepEqual(manifest.exports['./experiments'], {
+    types: './dist/experiments/index.d.ts',
+    import: './dist/experiments/index.js',
+  });
+  assert.equal(typeof manifest.dependencies.yaml, 'string', 'stored suites need a YAML parser at runtime');
+});
+
+test('the experiments entrypoint exports the public surface', async () => {
+  const module = await import('../.test-dist/experiments/index.js');
+  for (const name of [
+    'ExperimentsClient',
+    'Experiment',
+    'Trial',
+    'withExperiment',
+    'TestSuitesClient',
+    'LLMJudge',
+    'RegexJudge',
+    'stableId',
+    'requireExperimental',
+    'ExperimentalFeatureDisabledError',
+    'TrialEvaluationFailedError',
+    'TrialEvaluationTimeoutError',
+    'ExperimentConflictError',
+    'parseSuiteYAML',
+    'stringifySuiteYAML',
+    'trialRefFromEnv',
+    'otel',
+    'routes',
+  ]) {
+    assert.ok(name in module, `${name} is missing from the experiments export`);
+  }
+});
+
+test('experiments stays out of the core runtime boundary', async () => {
+  // core.ts is imported on edge runtimes without process or Buffer, while the
+  // experiments module needs crypto and environment access.
+  const coreSource = await readFile(path.join(__dirname, '..', 'src', 'core.ts'), 'utf8');
+  assert.ok(!coreSource.includes('experiments'), 'core.ts must not reach into the experiments tree');
+
+  const coreTsconfig = JSON.parse(await readFile(path.join(__dirname, '..', '..', 'js-core', 'tsconfig.json'), 'utf8'));
+  assert.ok(
+    !coreTsconfig.include.some((entry) => entry.includes('experiments')),
+    'the core package must not compile the experiments tree',
+  );
+
+  // Walk the compiled core graph: an experiments import anywhere in it would
+  // break the edge-runtime promise even when the smoke import happens to pass.
+  const testDist = path.join(__dirname, '..', '.test-dist');
+  const reached = await reachableModules(path.join(testDist, 'core.js'));
+  const experimentsModules = [...reached].filter((file) => file.includes(`${path.sep}experiments${path.sep}`));
+  assert.deepEqual(experimentsModules, [], 'the core module graph must not reach the experiments tree');
+
+  const coreEntryUrl = pathToFileURL(path.join(testDist, 'core.js')).href;
+  const script = `
+    delete globalThis.process;
+    delete globalThis.Buffer;
+    await import(${JSON.stringify(coreEntryUrl)});
+  `;
+  const result = spawnSync(process.execPath, ['--input-type=module', '--eval', script], { encoding: 'utf8' });
+  assert.equal(result.status, 0, `core import failed without process/Buffer:\n${result.stderr}`);
+});
+
+/** Collects every local module reachable from `entry` through relative imports. */
+async function reachableModules(entry, seen = new Set()) {
+  if (seen.has(entry)) {
+    return seen;
+  }
+  seen.add(entry);
+  const source = await readFile(entry, 'utf8');
+  const specifiers = [...source.matchAll(/from\s+'(\.[^']+)'/g)].map((match) => match[1]);
+  for (const specifier of specifiers) {
+    await reachableModules(path.resolve(path.dirname(entry), specifier), seen);
+  }
+  return seen;
+}

--- a/js/test/experiments.suites.test.mjs
+++ b/js/test/experiments.suites.test.mjs
@@ -1,0 +1,690 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import test from 'node:test';
+
+import { ExperimentConflictError } from '../.test-dist/experiments/errors.js';
+import {
+  localCaseToRemote,
+  normalizeControlEndpoint,
+  remoteCaseToLocal,
+  TestSuitesClient,
+} from '../.test-dist/experiments/suites.js';
+import {
+  ENV_ATTEMPT,
+  ENV_EXPERIMENT_ID,
+  ENV_SUITE_ID,
+  ENV_SUITE_VERSION,
+  ENV_TEST_CASE_ID,
+  ENV_TRAJECTORY_ID,
+  resetLegacyTrialEnvWarnings,
+  suiteCase,
+  testSuiteFromObject,
+  testSuiteToObject,
+  trialRefFromEnv,
+  trialRefFromJSON,
+  trialRefToEnv,
+  trialRefToJSON,
+} from '../.test-dist/experiments/types.js';
+import { parseSuiteYAML, stringifySuiteYAML } from '../.test-dist/experiments/yaml.js';
+
+// --- portable YAML -------------------------------------------------------- //
+
+test('the canonical YAML document loads', () => {
+  const suite = parseSuiteYAML(`
+suite_id: smoke
+name: Smoke
+version: 2.0.0
+description: sanity checks
+tags: [nightly]
+changelog: first cut
+cases:
+  - id: add
+    name: Addition
+    input: 2+2
+    expected: "4"
+    tags: [math]
+    weight: 2
+    metadata:
+      owner: alice
+`);
+  assert.equal(suite.suiteId, 'smoke');
+  assert.equal(suite.name, 'Smoke');
+  assert.equal(suite.version, '2.0.0');
+  assert.deepEqual(suite.tags, ['nightly']);
+  assert.equal(suite.changelog, 'first cut');
+  assert.equal(suite.testCases.length, 1);
+  assert.equal(suite.testCases[0].testCaseId, 'add');
+  assert.equal(suite.testCases[0].weight, 2);
+  assert.deepEqual(suite.testCases[0].metadata, { owner: 'alice' });
+});
+
+test('the legacy aliases load and round-trip to the canonical spelling', () => {
+  const suite = parseSuiteYAML(`
+id: suite-1
+test_cases:
+  - test_case_id: case-1
+    input: hello
+`);
+  assert.equal(suite.suiteId, 'suite-1');
+  assert.equal(suite.testCases[0].testCaseId, 'case-1');
+  assert.equal(suite.version, '1.0.0', 'a missing version defaults');
+
+  const reloaded = parseSuiteYAML(stringifySuiteYAML(suite));
+  assert.equal(reloaded.suiteId, 'suite-1');
+  assert.equal(reloaded.testCases[0].testCaseId, 'case-1');
+  assert.equal(reloaded.testCases[0].input, 'hello');
+  assert.deepEqual(testSuiteToObject(reloaded), testSuiteToObject(suite));
+});
+
+test('a save and reload preserves structured values', () => {
+  const suite = {
+    suiteId: 'structured',
+    name: 'Structured',
+    version: '1.2.3',
+    testCases: [
+      {
+        testCaseId: 'nested',
+        input: { question: '2+2', context: ['math'] },
+        expected: { answer: 4 },
+        tags: ['a', 'b'],
+        weight: 1,
+        metadata: { owner: 'bob' },
+        artifactRefs: [{ artifact_id: 'art-1', name: 'notes', kind: 'text' }],
+      },
+    ],
+  };
+  const reloaded = parseSuiteYAML(stringifySuiteYAML(suite));
+  assert.deepEqual(reloaded.testCases[0].input, { question: '2+2', context: ['math'] });
+  assert.deepEqual(reloaded.testCases[0].expected, { answer: 4 });
+  assert.deepEqual(reloaded.testCases[0].artifactRefs, [{ artifact_id: 'art-1', name: 'notes', kind: 'text' }]);
+  assert.equal(reloaded.testCases[0].weight, 1);
+});
+
+test('a default weight is omitted from the saved document', () => {
+  const yaml = stringifySuiteYAML({
+    suiteId: 's',
+    testCases: [{ testCaseId: 'c', input: 'x', weight: 1 }],
+  });
+  assert.ok(!yaml.includes('weight'));
+  assert.ok(
+    stringifySuiteYAML({ suiteId: 's', testCases: [{ testCaseId: 'c', input: 'x', weight: 3 }] }).includes('weight: 3'),
+  );
+});
+
+const invalidYamlCases = [
+  { name: 'a missing suite id', text: 'cases: []', message: /suite requires a 'suite_id'/ },
+  { name: 'a missing case id', text: 'suite_id: s\ncases:\n  - input: x\n', message: /test case requires an 'id'/ },
+  { name: 'a scalar document', text: '"just a string"', message: /suite must be a mapping, got string/ },
+  { name: 'non-string tags', text: 'suite_id: s\ntags: [1]\n', message: /suite tags must be a list of strings/ },
+  {
+    name: 'a non-mapping case list',
+    text: 'suite_id: s\ncases: not-a-list\n',
+    message: /suite cases must be a list of mappings/,
+  },
+  {
+    name: 'broken YAML',
+    text: 'suite_id: [unclosed',
+    message: /parse suite YAML:/,
+  },
+];
+
+test('an invalid suite document is rejected with a specific message', () => {
+  for (const { name, text, message } of invalidYamlCases) {
+    assert.throws(() => parseSuiteYAML(text), message, name);
+  }
+});
+
+test('duplicate case ids are rejected', () => {
+  assert.throws(
+    () => parseSuiteYAML('suite_id: s\ncases:\n  - id: dup\n    input: a\n  - id: dup\n    input: b\n'),
+    /agento11y test suite validation failed: duplicate test_case_id "dup"/,
+  );
+});
+
+test('suiteCase finds a case by id', () => {
+  const suite = testSuiteFromObject({ suite_id: 's', cases: [{ id: 'a', input: 1 }] });
+  assert.equal(suiteCase(suite, 'a').testCaseId, 'a');
+  assert.equal(suiteCase(suite, 'missing'), undefined);
+  assert.equal(suiteCase(undefined, 'a'), undefined);
+});
+
+// --- TrialRef ------------------------------------------------------------- //
+
+test('a TrialRef round-trips through the environment', () => {
+  const ref = {
+    experimentId: 'run-1',
+    testCaseId: 'case-1',
+    attempt: 3,
+    suiteId: 'smoke',
+    suiteVersion: '2.0.0',
+    trajectoryId: 'traj-1',
+  };
+  const env = trialRefToEnv(ref);
+  assert.deepEqual(env, {
+    [ENV_EXPERIMENT_ID]: 'run-1',
+    [ENV_TEST_CASE_ID]: 'case-1',
+    [ENV_ATTEMPT]: '3',
+    [ENV_SUITE_ID]: 'smoke',
+    [ENV_SUITE_VERSION]: '2.0.0',
+    [ENV_TRAJECTORY_ID]: 'traj-1',
+  });
+  const restored = trialRefFromEnv(env);
+  assert.equal(restored.experimentId, 'run-1');
+  assert.equal(restored.testCaseId, 'case-1');
+  assert.equal(restored.attempt, 3);
+  assert.equal(restored.suiteId, 'smoke');
+  assert.equal(restored.suiteVersion, '2.0.0');
+  assert.equal(restored.trajectoryId, 'traj-1');
+});
+
+test('a TrialRef without an experiment or case is undefined', () => {
+  assert.equal(trialRefFromEnv({}), undefined);
+  assert.equal(trialRefFromEnv({ [ENV_EXPERIMENT_ID]: 'run-1' }), undefined);
+  assert.equal(trialRefFromEnv({ [ENV_TEST_CASE_ID]: 'case-1' }), undefined);
+});
+
+test('a missing or unparseable attempt falls back to one', () => {
+  const base = { [ENV_EXPERIMENT_ID]: 'run-1', [ENV_TEST_CASE_ID]: 'case-1' };
+  assert.equal(trialRefFromEnv(base).attempt, 1);
+  assert.equal(trialRefFromEnv({ ...base, [ENV_ATTEMPT]: 'nonsense' }).attempt, 1);
+  assert.equal(trialRefFromEnv({ ...base, [ENV_ATTEMPT]: '0' }).attempt, 1);
+  assert.equal(trialRefFromEnv({ ...base, [ENV_ATTEMPT]: '4' }).attempt, 4);
+});
+
+test('a SIGIL_ spelling is reported and ignored', () => {
+  resetLegacyTrialEnvWarnings();
+  const warnings = [];
+  const ref = trialRefFromEnv(
+    { SIGIL_EXPERIMENT_ID: 'run-legacy', SIGIL_TEST_CASE_ID: 'case-legacy' },
+    { warn: (message) => warnings.push(message) },
+  );
+  assert.equal(ref, undefined, 'the legacy name is not read as a value');
+  assert.deepEqual(warnings, [
+    'agento11y: SIGIL_EXPERIMENT_ID is ignored; rename it to AGENTO11Y_EXPERIMENT_ID',
+    'agento11y: SIGIL_TEST_CASE_ID is ignored; rename it to AGENTO11Y_TEST_CASE_ID',
+  ]);
+
+  // The warning fires once per process, not once per read.
+  const again = [];
+  trialRefFromEnv({ SIGIL_EXPERIMENT_ID: 'run-legacy' }, { warn: (message) => again.push(message) });
+  assert.deepEqual(again, []);
+});
+
+test('a TrialRef round-trips through JSON, including the run_id alias', () => {
+  const ref = {
+    experimentId: 'run-1',
+    testCaseId: 'case-1',
+    attempt: 2,
+    suiteId: 'smoke',
+    suiteVersion: '1.0.0',
+    suiteName: 'Smoke',
+    testCaseName: 'Addition',
+    trajectoryId: 'traj-1',
+  };
+  assert.deepEqual(trialRefFromJSON(trialRefToJSON(ref)), ref);
+  assert.equal(trialRefFromJSON({ run_id: 'run-legacy', test_case_id: 'c' }).experimentId, 'run-legacy');
+});
+
+// --- control-plane routing ------------------------------------------------ //
+
+const endpointCases = [
+  {
+    input: 'https://stack.grafana.net',
+    want: 'https://stack.grafana.net/api/plugins/grafana-agento11y-app/resources/eval',
+  },
+  {
+    input: 'https://stack.grafana.net/',
+    want: 'https://stack.grafana.net/api/plugins/grafana-agento11y-app/resources/eval',
+  },
+  {
+    input: 'https://stack.grafana.net/a/grafana-agento11y-app/experiments',
+    want: 'https://stack.grafana.net/api/plugins/grafana-agento11y-app/resources/eval',
+  },
+  {
+    input: 'https://stack.grafana.net/api/plugins/grafana-agento11y-app/resources/eval',
+    want: 'https://stack.grafana.net/api/plugins/grafana-agento11y-app/resources/eval',
+  },
+  { input: 'https://host/prefix', want: 'https://host/prefix/api/plugins/grafana-agento11y-app/resources/eval' },
+  { input: 'https://host/api/v1/eval', want: 'https://host/api/v1/eval' },
+];
+
+test('control endpoints normalize onto the plugin resources path', () => {
+  for (const { input, want } of endpointCases) {
+    assert.equal(normalizeControlEndpoint(input), want, input);
+  }
+});
+
+test('a relative or non-http control endpoint is rejected', () => {
+  for (const value of ['stack.grafana.net', 'ftp://host/x', '']) {
+    assert.throws(() => normalizeControlEndpoint(value), /controlEndpoint must be an absolute URL/, value);
+  }
+});
+
+test('the client requires an endpoint and a token', () => {
+  assert.throws(() => new TestSuitesClient({ env: {} }), /controlEndpoint is required/);
+  assert.throws(
+    () => new TestSuitesClient({ grafanaUrl: 'https://stack.grafana.net', env: {} }),
+    /serviceAccountToken is required/,
+  );
+  const fromEnv = new TestSuitesClient({
+    env: {
+      AGENTO11Y_GRAFANA_URL: 'https://stack.grafana.net',
+      AGENTO11Y_SERVICE_ACCOUNT_TOKEN: 'glsa_token',
+    },
+  });
+  assert.equal(fromEnv.grafanaUrl, 'https://stack.grafana.net');
+  assert.equal(fromEnv.endpoint, 'https://stack.grafana.net/api/plugins/grafana-agento11y-app/resources/eval');
+});
+
+test('the grafana url is derived from the control endpoint when unset', () => {
+  const client = new TestSuitesClient({
+    controlEndpoint: 'https://stack.grafana.net/api/plugins/grafana-agento11y-app/resources/eval',
+    serviceAccountToken: 'glsa_token',
+    env: {},
+  });
+  assert.equal(client.grafanaUrl, 'https://stack.grafana.net');
+});
+
+test('suite reads use the control path, the bearer token, and the paging defaults', async () => {
+  const { endpoint, seen, close } = await startServer((request) => {
+    if (request.url.startsWith('/api/plugins/grafana-agento11y-app/resources/eval/test-suites?')) {
+      return { status: 200, body: { items: [{ suite_id: 'smoke' }], next_cursor: '0' } };
+    }
+    return { status: 200, body: {} };
+  });
+  try {
+    const client = newClient(endpoint);
+    const suites = await client.listSuites();
+    assert.deepEqual(suites, [{ suite_id: 'smoke' }]);
+    assert.equal(seen[0].url, '/api/plugins/grafana-agento11y-app/resources/eval/test-suites?limit=200');
+    assert.equal(seen[0].headers.authorization, 'Bearer glsa_token');
+  } finally {
+    await close();
+  }
+});
+
+test('paging follows the cursor and stops when it clears', async () => {
+  const pages = [
+    { items: [{ suite_id: 'a' }], next_cursor: 'p2' },
+    { items: [{ suite_id: 'b' }], next_cursor: '' },
+  ];
+  let index = 0;
+  const { endpoint, seen, close } = await startServer(() => ({ status: 200, body: pages[index++] }));
+  try {
+    const suites = await newClient(endpoint).listSuites({ limit: 1 });
+    assert.deepEqual(suites, [{ suite_id: 'a' }, { suite_id: 'b' }]);
+    assert.equal(seen[0].url.endsWith('?limit=1'), true);
+    assert.equal(seen[1].url.endsWith('?limit=1&cursor=p2'), true);
+  } finally {
+    await close();
+  }
+});
+
+test('a cursor that never clears stops at maxPages', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({
+    status: 200,
+    body: { items: [{ suite_id: 'a' }], next_cursor: 'always' },
+  }));
+  try {
+    await assert.rejects(
+      newClient(endpoint).listSuites({ maxPages: 3 }),
+      /agento11y experiment transport failed: test suite list: pagination did not terminate/,
+    );
+    assert.equal(seen.length, 3);
+  } finally {
+    await close();
+  }
+});
+
+test('version aliases resolve against the stored record', () => {
+  const client = newOfflineClient();
+  const suite = {
+    versions: [
+      { version: 'v1', published: true },
+      { version: 'v2', published: true },
+      { version: 'v3', published: false },
+    ],
+  };
+  assert.equal(client.resolveVersion(suite, 'latest_published'), 'v2');
+  assert.equal(client.resolveVersion(suite, 'latest'), 'v3');
+  assert.equal(client.resolveVersion(suite, 'draft'), 'v3');
+  assert.equal(client.resolveVersion(suite, 'v1'), 'v1');
+  assert.throws(() => client.resolveVersion(suite, 'v9'), /agento11y experiment not found: test suite version: v9/);
+  assert.throws(() => client.resolveVersion(suite, '  '), /test suite: version is required/);
+  assert.throws(
+    () => client.resolveVersion({ versions: [{ version: 'v1', published: false }] }, 'latest_published'),
+    /test suite version: latest_published/,
+  );
+  assert.throws(() => client.resolveVersion({ versions: [] }, 'latest'), /test suite version: latest/);
+  assert.throws(
+    () => client.resolveVersion({ versions: [{ version: 'v1', published: true }] }, 'draft'),
+    /test suite version: draft/,
+  );
+});
+
+test('pullSuite resolves the version and maps remote cases', async () => {
+  const { endpoint, seen, close } = await startServer((request) => {
+    if (request.url.includes('/test-cases')) {
+      return {
+        status: 200,
+        body: {
+          items: [
+            {
+              test_case_id: 'add',
+              name: 'Addition',
+              input: { value: '2+2' },
+              expected: { value: '4' },
+              metadata: {
+                owner: 'alice',
+                'agento11y.sdk.portability': { version: 1, weight: 2, wrapped_fields: ['input', 'expected'] },
+              },
+            },
+          ],
+        },
+      };
+    }
+    return {
+      status: 200,
+      body: {
+        suite_id: 'smoke',
+        name: 'Smoke',
+        description: 'sanity',
+        tags: ['nightly'],
+        versions: [
+          { version: 'v1', published: true, changelog: 'first' },
+          { version: 'v2', published: false },
+        ],
+      },
+    };
+  });
+  try {
+    const suite = await newClient(endpoint).pullSuite('smoke');
+    assert.equal(suite.suiteId, 'smoke');
+    assert.equal(suite.version, 'v1');
+    assert.equal(suite.changelog, 'first');
+    assert.equal(suite.testCases[0].input, '2+2', 'a wrapped scalar is unwrapped');
+    assert.equal(suite.testCases[0].expected, '4');
+    assert.equal(suite.testCases[0].weight, 2);
+    assert.deepEqual(suite.testCases[0].metadata, { owner: 'alice' }, 'the portability key is stripped');
+    assert.equal(
+      seen[1].url,
+      '/api/plugins/grafana-agento11y-app/resources/eval/test-suites/smoke/versions/v1/test-cases?limit=200',
+    );
+  } finally {
+    await close();
+  }
+});
+
+test('a local case wraps scalars and records the wrapping', () => {
+  const remote = localCaseToRemote({
+    testCaseId: 'add',
+    input: '2+2',
+    expected: '4',
+    weight: 2,
+    metadata: { owner: 'alice' },
+  });
+  assert.deepEqual(remote.input, { value: '2+2' });
+  assert.deepEqual(remote.expected, { value: '4' });
+  assert.deepEqual(remote.metadata['agento11y.sdk.portability'], {
+    version: 1,
+    weight: 2,
+    wrapped_fields: ['input', 'expected'],
+  });
+  // The round trip returns the caller's scalars.
+  const local = remoteCaseToLocal(remote);
+  assert.equal(local.input, '2+2');
+  assert.equal(local.expected, '4');
+  assert.equal(local.weight, 2);
+  assert.deepEqual(local.metadata, { owner: 'alice' });
+});
+
+test('an object input is stored as-is with no wrapping metadata', () => {
+  const remote = localCaseToRemote({ testCaseId: 'add', input: { question: '2+2' } });
+  assert.deepEqual(remote.input, { question: '2+2' });
+  assert.equal(remote.metadata, undefined);
+  assert.deepEqual(remoteCaseToLocal(remote).input, { question: '2+2' });
+});
+
+test('a local case without an id or input is rejected', () => {
+  assert.throws(() => localCaseToRemote({ testCaseId: '  ', input: 'x' }), /test suite: test_case_id is required/);
+  assert.throws(() => localCaseToRemote({ testCaseId: 'a' }), /test suite: input is required/);
+});
+
+test('pushSuite creates the suite, opens a draft, upserts cases, and publishes', async () => {
+  let suiteExists = false;
+  const { endpoint, seen, close } = await startServer((request) => {
+    const path = request.url.replace('/api/plugins/grafana-agento11y-app/resources/eval', '');
+    if (request.method === 'GET' && path === '/test-suites/smoke') {
+      if (!suiteExists) {
+        return { status: 404, body: 'suite not found' };
+      }
+      return { status: 200, body: { suite_id: 'smoke', name: 'Smoke', versions: [] } };
+    }
+    if (request.method === 'POST' && path === '/test-suites') {
+      suiteExists = true;
+      return { status: 200, body: { suite_id: 'smoke', name: 'Smoke', versions: [] } };
+    }
+    if (request.method === 'POST' && path === '/test-suites/smoke/versions') {
+      return { status: 200, body: { version: 'v1', published: false } };
+    }
+    if (request.method === 'POST' && path.endsWith(':publish')) {
+      return { status: 200, body: { version: 'v1', published: true } };
+    }
+    return { status: 200, body: {} };
+  });
+  try {
+    const pushed = await newClient(endpoint).pushSuite(
+      {
+        suiteId: 'smoke',
+        name: 'Smoke',
+        description: 'sanity',
+        testCases: [{ testCaseId: 'add', input: '2+2', expected: '4' }],
+      },
+      { publish: true, changelog: 'first cut' },
+    );
+    assert.equal(pushed.suiteId, 'smoke');
+    assert.equal(pushed.suiteVersion, 'v1');
+    assert.equal(pushed.published, true);
+    assert.deepEqual(pushed.prunedCaseIds, []);
+    const paths = seen.map((entry) => `${entry.method} ${entry.url.split('/resources/eval')[1]}`);
+    assert.deepEqual(paths, [
+      'GET /test-suites/smoke',
+      'POST /test-suites',
+      'PATCH /test-suites/smoke',
+      'GET /test-suites/smoke',
+      'POST /test-suites/smoke/versions',
+      'POST /test-suites/smoke/versions/v1/test-cases',
+      'POST /test-suites/smoke/versions/v1:publish',
+    ]);
+    assert.deepEqual(JSON.parse(seen[4].body), { changelog: 'first cut' });
+  } finally {
+    await close();
+  }
+});
+
+test('pushSuite reuses an existing draft and refuses a different changelog', async () => {
+  const { endpoint, close } = await startServer(() => ({
+    status: 200,
+    body: { suite_id: 'smoke', name: 'Smoke', versions: [{ version: 'v2', published: false, changelog: 'existing' }] },
+  }));
+  try {
+    const client = newClient(endpoint);
+    const pushed = await client.pushSuite({ suiteId: 'smoke', name: 'Smoke', testCases: [] });
+    assert.equal(pushed.suiteVersion, 'v2');
+
+    await assert.rejects(
+      client.pushSuite({ suiteId: 'smoke', name: 'Smoke', testCases: [] }, { changelog: 'different' }),
+      /an existing draft cannot apply a different changelog/,
+    );
+    await assert.rejects(
+      client.pushSuite({ suiteId: 'smoke', name: 'Smoke', testCases: [] }, { emptyDraft: true }),
+      /empty_draft only applies when creating a new draft/,
+    );
+  } finally {
+    await close();
+  }
+});
+
+test('pushSuite prunes remote-only cases when asked', async () => {
+  const { endpoint, seen, close } = await startServer((request) => {
+    const path = request.url.replace('/api/plugins/grafana-agento11y-app/resources/eval', '');
+    if (request.method === 'GET' && path.includes('/test-cases')) {
+      return {
+        status: 200,
+        body: {
+          items: [
+            { test_case_id: 'add', input: {} },
+            { test_case_id: 'stale', input: {} },
+          ],
+        },
+      };
+    }
+    if (request.method === 'GET' && path.startsWith('/test-suites/smoke')) {
+      return {
+        status: 200,
+        body: { suite_id: 'smoke', name: 'Smoke', versions: [{ version: 'v1', published: false }] },
+      };
+    }
+    return { status: 200, body: {} };
+  });
+  try {
+    const pushed = await newClient(endpoint).pushSuite(
+      { suiteId: 'smoke', name: 'Smoke', testCases: [{ testCaseId: 'add', input: '2+2' }] },
+      { prune: true },
+    );
+    assert.deepEqual(pushed.prunedCaseIds, ['stale']);
+    const deletes = seen.filter((entry) => entry.method === 'DELETE').map((entry) => entry.url);
+    assert.deepEqual(deletes, [
+      '/api/plugins/grafana-agento11y-app/resources/eval/test-suites/smoke/versions/v1/test-cases/stale',
+    ]);
+  } finally {
+    await close();
+  }
+});
+
+test('a draft opened by another writer is adopted after a 409', async () => {
+  let versionsField = [];
+  const { endpoint, close } = await startServer((request) => {
+    const path = request.url.replace('/api/plugins/grafana-agento11y-app/resources/eval', '');
+    if (request.method === 'POST' && path === '/test-suites/smoke/versions') {
+      // Another writer created the draft first.
+      versionsField = [{ version: 'v7', published: false }];
+      return { status: 409, body: 'a draft already exists' };
+    }
+    if (request.method === 'GET' && path === '/test-suites/smoke') {
+      return { status: 200, body: { suite_id: 'smoke', name: 'Smoke', versions: versionsField } };
+    }
+    return { status: 200, body: {} };
+  });
+  try {
+    const pushed = await newClient(endpoint).pushSuite({ suiteId: 'smoke', name: 'Smoke', testCases: [] });
+    assert.equal(pushed.suiteVersion, 'v7');
+  } finally {
+    await close();
+  }
+});
+
+test('a 409 is classified and sent exactly once', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({
+    status: 409,
+    body: 'suite version is already published and is terminal',
+  }));
+  try {
+    await assert.rejects(newClient(endpoint).getSuite('smoke'), (error) => {
+      assert.ok(error instanceof ExperimentConflictError);
+      assert.equal(error.kind, 'terminal');
+      assert.equal(error.recoverable, false);
+      return true;
+    });
+    assert.equal(seen.length, 1, 'a conflict is a caller error, not a transient failure');
+  } finally {
+    await close();
+  }
+});
+
+test('a retryable control-plane failure succeeds on the sixth attempt', async () => {
+  let calls = 0;
+  const delays = [];
+  const { endpoint, seen, close } = await startServer(() => {
+    calls++;
+    return calls <= 5 ? { status: 503, body: 'control plane churn' } : { status: 200, body: { suite_id: 'smoke' } };
+  });
+  try {
+    const client = new TestSuitesClient({
+      controlEndpoint: endpoint,
+      serviceAccountToken: 'glsa_token',
+      env: {},
+      sleep: async (durationMs) => {
+        delays.push(durationMs);
+      },
+    });
+    const suite = await client.getSuite('smoke');
+    assert.deepEqual(suite, { suite_id: 'smoke' });
+    assert.equal(seen.length, 6, 'five retries plus the first attempt');
+    assert.deepEqual(delays, [100, 200, 400, 800, 1600]);
+  } finally {
+    await close();
+  }
+});
+
+test('a blank suite id is rejected before any request', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({ status: 200, body: {} }));
+  try {
+    const client = newClient(endpoint);
+    await assert.rejects(client.getSuite('  '), /test suite: suite_id is required/);
+    await assert.rejects(client.listCases('smoke', '  '), /test suite: version is required/);
+    assert.equal(seen.length, 0);
+  } finally {
+    await close();
+  }
+});
+
+function newClient(endpoint) {
+  return new TestSuitesClient({
+    controlEndpoint: endpoint,
+    serviceAccountToken: 'glsa_token',
+    env: {},
+    sleep: async () => {},
+  });
+}
+
+function newOfflineClient() {
+  return new TestSuitesClient({
+    controlEndpoint: 'https://stack.grafana.net',
+    serviceAccountToken: 'glsa_token',
+    env: {},
+  });
+}
+
+async function startServer(respond) {
+  const seen = [];
+  const server = http.createServer((request, response) => {
+    const chunks = [];
+    request.on('data', (chunk) => chunks.push(chunk));
+    request.on('end', () => {
+      seen.push({
+        method: request.method,
+        url: request.url,
+        headers: request.headers,
+        body: Buffer.concat(chunks).toString('utf8'),
+      });
+      const { status, body } = respond(request);
+      if (typeof body === 'string') {
+        response.writeHead(status, { 'content-type': 'text/plain' });
+        response.end(body);
+        return;
+      }
+      response.writeHead(status, { 'content-type': 'application/json' });
+      response.end(JSON.stringify(body ?? {}));
+    });
+  });
+  await new Promise((resolve, reject) => {
+    server.listen(0, '127.0.0.1', (error) => (error ? reject(error) : resolve(undefined)));
+  });
+  const { port } = server.address();
+  return {
+    endpoint: `http://127.0.0.1:${port}`,
+    seen,
+    close: () => new Promise((resolve) => server.close(() => resolve(undefined))),
+  };
+}

--- a/js/test/experiments.transport.test.mjs
+++ b/js/test/experiments.transport.test.mjs
@@ -1,0 +1,500 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import test from 'node:test';
+
+import { ExperimentConflictError } from '../.test-dist/experiments/errors.js';
+import {
+  experimentReportPath,
+  experimentScoresPath,
+  runFinalizePath,
+  runUpsertPath,
+  scoresExportPath,
+  trialEvaluatePath,
+  trialEvaluationPath,
+  trialPath,
+  trialsPath,
+} from '../.test-dist/experiments/routes.js';
+import { requestExperimentsJSON } from '../.test-dist/experiments/transport.js';
+
+test('routes encode every dynamic segment', () => {
+  assert.equal(runUpsertPath(), '/api/v1/experiment-runs:upsert');
+  assert.equal(runFinalizePath('run-1'), '/api/v1/experiment-runs/run-1:finalize');
+  assert.equal(scoresExportPath(), '/api/v1/scores:export');
+  assert.equal(trialsPath('run-1'), '/api/v1/experiment-runs/run-1/trials');
+  assert.equal(trialPath('run-1', 'trial-1'), '/api/v1/experiment-runs/run-1/trials/trial-1');
+  assert.equal(trialEvaluatePath('run-1', 'trial-1'), '/api/v1/experiment-runs/run-1/trials/trial-1:evaluate');
+  assert.equal(
+    trialEvaluationPath('run-1', 'trial-1', 'eval-1'),
+    '/api/v1/experiment-runs/run-1/trials/trial-1/evaluations/eval-1',
+  );
+  assert.equal(experimentReportPath('run-1'), '/api/v1/eval/experiments/run-1/report');
+  assert.equal(experimentScoresPath('run-1'), '/api/v1/eval/experiments/run-1/scores');
+});
+
+test('a trial id containing reserved characters cannot shadow the route verb', () => {
+  const path = trialEvaluatePath('run/one', 'trial:one/blue');
+  assert.equal(path, '/api/v1/experiment-runs/run%2Fone/trials/trial%3Aone%2Fblue:evaluate');
+  assert.ok(path.endsWith(':evaluate'));
+  assert.equal(path.split(':').length, 2, 'the only literal colon left is the route verb');
+  assert.ok(!path.slice(0, -':evaluate'.length).includes(':'));
+});
+
+test('the transport sends the encoded path and the JSON body', async () => {
+  const seen = [];
+  const server = jsonServer(seen, () => ({ status: 200, body: { evaluation_id: 'eval-1' } }));
+  const endpoint = await listen(server);
+  try {
+    const body = await requestExperimentsJSON(
+      { endpoint, insecure: true, headers: { Authorization: 'Bearer tok' } },
+      {
+        method: 'POST',
+        path: trialEvaluatePath('run-1', 'trial:one/blue'),
+        body: { evaluator_id: 'helpfulness' },
+        label: 'trial evaluation trigger',
+      },
+    );
+    assert.deepEqual(body, { evaluation_id: 'eval-1' });
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].method, 'POST');
+    assert.equal(seen[0].url, '/api/v1/experiment-runs/run-1/trials/trial%3Aone%2Fblue:evaluate');
+    assert.equal(seen[0].headers.authorization, 'Bearer tok');
+    assert.equal(seen[0].headers['content-type'], 'application/json');
+    assert.deepEqual(JSON.parse(seen[0].body), { evaluator_id: 'helpfulness' });
+  } finally {
+    await close(server);
+  }
+});
+
+test('a GET request carries the query string and no body', async () => {
+  const seen = [];
+  const server = jsonServer(seen, () => ({ status: 200, body: { items: [] } }));
+  const endpoint = await listen(server);
+  try {
+    await requestExperimentsJSON(
+      { endpoint, insecure: true },
+      {
+        method: 'GET',
+        path: experimentScoresPath('run-1'),
+        query: { limit: '50', cursor: 'a b' },
+        label: 'experiment scores list',
+      },
+    );
+    assert.equal(seen[0].url, '/api/v1/eval/experiments/run-1/scores?limit=50&cursor=a+b');
+    assert.equal(seen[0].body, '');
+  } finally {
+    await close(server);
+  }
+});
+
+test('a 503 followed by success resolves after exactly two requests', async () => {
+  const seen = [];
+  let calls = 0;
+  const server = jsonServer(seen, () => {
+    calls++;
+    return calls === 1 ? { status: 503, body: 'backend churn' } : { status: 200, body: { ok: true } };
+  });
+  const endpoint = await listen(server);
+  try {
+    const body = await requestExperimentsJSON(
+      { endpoint, insecure: true, retry: { initialBackoffMs: 1, maxBackoffMs: 2 } },
+      { method: 'POST', path: runUpsertPath(), body: { name: 'run' }, label: 'experiment create' },
+    );
+    assert.deepEqual(body, { ok: true });
+    assert.equal(seen.length, 2);
+  } finally {
+    await close(server);
+  }
+});
+
+test('retryable failures exhaust the budget after four total requests', async () => {
+  const seen = [];
+  const delays = [];
+  const server = jsonServer(seen, () => ({ status: 503, body: 'still down' }));
+  const endpoint = await listen(server);
+  try {
+    await assert.rejects(
+      requestExperimentsJSON(
+        {
+          endpoint,
+          insecure: true,
+          sleep: async (durationMs) => {
+            delays.push(durationMs);
+          },
+        },
+        { method: 'POST', path: runUpsertPath(), body: { name: 'run' }, label: 'experiment create' },
+      ),
+      (error) => {
+        assert.match(error.message, /^agento11y experiment transport failed: experiment create: status 503/);
+        return true;
+      },
+    );
+    assert.equal(seen.length, 4, 'one attempt plus three retries');
+    assert.deepEqual(delays, [100, 200, 400]);
+    assert.ok(delays.every((delay) => delay <= 5000));
+  } finally {
+    await close(server);
+  }
+});
+
+test('the backoff never exceeds the ceiling', async () => {
+  const delays = [];
+  const server = jsonServer([], () => ({ status: 429, body: 'slow down' }));
+  const endpoint = await listen(server);
+  try {
+    await assert.rejects(
+      requestExperimentsJSON(
+        {
+          endpoint,
+          insecure: true,
+          retry: { maxRetries: 5, initialBackoffMs: 2_000, maxBackoffMs: 5_000 },
+          sleep: async (durationMs) => {
+            delays.push(durationMs);
+          },
+        },
+        { method: 'GET', path: experimentReportPath('run-1'), label: 'experiment report' },
+      ),
+      /transport failed/,
+    );
+    assert.deepEqual(delays, [2000, 4000, 5000, 5000, 5000]);
+  } finally {
+    await close(server);
+  }
+});
+
+const statusCases = [
+  { status: 400, message: 'agento11y experiment validation failed: experiment create: server said no' },
+  { status: 422, message: 'agento11y experiment validation failed: experiment create: server said no' },
+  { status: 404, message: 'agento11y experiment not found: experiment create: server said no' },
+  {
+    status: 418,
+    message: 'agento11y experiment transport failed: experiment create: status 418: server said no',
+  },
+];
+
+test('status codes map onto the stable error prefixes without retrying', async () => {
+  for (const { status, message } of statusCases) {
+    const seen = [];
+    const server = jsonServer(seen, () => ({ status, body: 'server said no' }));
+    const endpoint = await listen(server);
+    try {
+      await assert.rejects(
+        requestExperimentsJSON(
+          { endpoint, insecure: true, retry: { initialBackoffMs: 1 } },
+          { method: 'POST', path: runUpsertPath(), body: {}, label: 'experiment create' },
+        ),
+        (error) => {
+          assert.equal(error.message, message);
+          return true;
+        },
+      );
+      assert.equal(seen.length, 1, `status ${status} must not retry`);
+    } finally {
+      await close(server);
+    }
+  }
+});
+
+test('a 409 is classified and not retried', async () => {
+  const seen = [];
+  const server = jsonServer(seen, () => ({ status: 409, body: 'score_count mismatch: expected 4 scores, found 5' }));
+  const endpoint = await listen(server);
+  try {
+    await assert.rejects(
+      requestExperimentsJSON(
+        { endpoint, insecure: true },
+        { method: 'POST', path: runFinalizePath('run-1'), body: {}, label: 'experiment finalize' },
+      ),
+      (error) => {
+        assert.ok(error instanceof ExperimentConflictError);
+        assert.equal(error.kind, 'score_count_mismatch');
+        assert.equal(error.recoverable, true);
+        assert.match(error.message, /^agento11y experiment conflict: experiment finalize:/);
+        return true;
+      },
+    );
+    assert.equal(seen.length, 1);
+  } finally {
+    await close(server);
+  }
+});
+
+test('a 503 naming a capability gap is not retried', async () => {
+  const seen = [];
+  const server = http.createServer((request, response) => {
+    seen.push(request.url);
+    response.writeHead(503, { 'content-type': 'text/plain; charset=utf-8' });
+    response.end('trial evaluation service is unavailable');
+  });
+  const endpoint = await listen(server);
+  try {
+    await assert.rejects(
+      requestExperimentsJSON(
+        { endpoint, insecure: true, retry: { initialBackoffMs: 1 } },
+        { method: 'POST', path: trialEvaluatePath('run-1', 'trial-1'), body: {}, label: 'trial evaluation trigger' },
+      ),
+      /transport failed: trial evaluation trigger: status 503/,
+    );
+    assert.equal(seen.length, 1, 'a capability gap answers the same way on every retry');
+  } finally {
+    await close(server);
+  }
+});
+
+test('an empty success body decodes to an empty object', async () => {
+  const server = http.createServer((_request, response) => {
+    response.writeHead(204);
+    response.end();
+  });
+  const endpoint = await listen(server);
+  try {
+    const body = await requestExperimentsJSON(
+      { endpoint, insecure: true },
+      { method: 'DELETE', path: trialPath('run-1', 'trial-1'), label: 'test case trial update' },
+    );
+    assert.deepEqual(body, {});
+  } finally {
+    await close(server);
+  }
+});
+
+test('a malformed success body fails with the transport prefix', async () => {
+  const server = http.createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end('{not json');
+  });
+  const endpoint = await listen(server);
+  try {
+    await assert.rejects(
+      requestExperimentsJSON(
+        { endpoint, insecure: true },
+        { method: 'GET', path: experimentReportPath('run-1'), label: 'experiment report' },
+      ),
+      /^Error: agento11y experiment transport failed: experiment report: invalid JSON response/,
+    );
+  } finally {
+    await close(server);
+  }
+});
+
+test('a response above the body cap is abandoned', async () => {
+  const oversized = 'x'.repeat((8 << 20) + 16);
+  const server = http.createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(`"${oversized}"`);
+  });
+  const endpoint = await listen(server);
+  try {
+    await assert.rejects(
+      requestExperimentsJSON(
+        { endpoint, insecure: true },
+        { method: 'GET', path: experimentReportPath('run-1'), label: 'experiment report' },
+      ),
+      /transport failed: .*response too large/,
+    );
+  } finally {
+    await close(server);
+  }
+});
+
+test('a caller abort surfaces its own reason, not a transport error', async () => {
+  const server = http.createServer(() => {
+    // Never answers: the caller's abort is the only thing that ends the request.
+  });
+  const endpoint = await listen(server);
+  const controller = new AbortController();
+  const stop = new Error('stop');
+  try {
+    const pending = requestExperimentsJSON(
+      { endpoint, insecure: true },
+      { method: 'GET', path: experimentReportPath('run-1'), label: 'experiment report', signal: controller.signal },
+    );
+    setTimeout(() => controller.abort(stop), 20);
+    await assert.rejects(pending, (error) => {
+      assert.equal(error, stop);
+      return true;
+    });
+  } finally {
+    server.closeAllConnections?.();
+    await close(server);
+  }
+});
+
+test('an already aborted signal sends no request at all', async () => {
+  const seen = [];
+  const server = jsonServer(seen, () => ({ status: 200, body: {} }));
+  const endpoint = await listen(server);
+  const controller = new AbortController();
+  const stop = new Error('too late');
+  controller.abort(stop);
+  try {
+    await assert.rejects(
+      requestExperimentsJSON(
+        { endpoint, insecure: true },
+        { method: 'GET', path: experimentReportPath('run-1'), label: 'experiment report', signal: controller.signal },
+      ),
+      (error) => {
+        assert.equal(error, stop);
+        return true;
+      },
+    );
+    assert.equal(seen.length, 0);
+  } finally {
+    await close(server);
+  }
+});
+
+test('a per-attempt timeout is retried and reported as a transport failure', async () => {
+  const seen = [];
+  const server = http.createServer((request) => {
+    seen.push(request.url);
+    // Hangs so the per-attempt timeout is the only thing that ends the attempt.
+  });
+  const endpoint = await listen(server);
+  try {
+    await assert.rejects(
+      requestExperimentsJSON(
+        {
+          endpoint,
+          insecure: true,
+          retry: { maxRetries: 1, timeoutMs: 30 },
+          sleep: async () => {},
+        },
+        { method: 'GET', path: experimentReportPath('run-1'), label: 'experiment report' },
+      ),
+      /^Error: agento11y experiment transport failed: experiment report:/,
+    );
+    assert.equal(seen.length, 2);
+  } finally {
+    server.closeAllConnections?.();
+    await close(server);
+  }
+});
+
+test('a raw byte body sets the caller content type', async () => {
+  const seen = [];
+  const server = jsonServer(seen, () => ({ status: 200, body: { artifact_id: 'art-1' } }));
+  const endpoint = await listen(server);
+  try {
+    await requestExperimentsJSON(
+      { endpoint, insecure: true },
+      {
+        method: 'POST',
+        path: `${trialPath('run-1', 'trial-1')}/artifacts:upload`,
+        query: { name: 'transcript.txt', kind: 'text', mime: 'text/plain' },
+        bytes: new TextEncoder().encode('hello'),
+        contentType: 'text/plain',
+        label: 'trial artifact upload',
+      },
+    );
+    assert.equal(seen[0].headers['content-type'], 'text/plain');
+    assert.equal(seen[0].body, 'hello');
+    assert.equal(
+      seen[0].url,
+      '/api/v1/experiment-runs/run-1/trials/trial-1/artifacts:upload?name=transcript.txt&kind=text&mime=text%2Fplain',
+    );
+  } finally {
+    await close(server);
+  }
+});
+
+test('a stalled response body still hits the per-attempt timeout', async () => {
+  // The other timeout test never answers, so it only exercises the header phase.
+  // Here the headers arrive and the body stalls, which is the case that used to
+  // hang: the timeout has to stay armed while the body is read.
+  const server = http.createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.write('{"evaluation_id":');
+  });
+  const endpoint = await listen(server);
+  const started = Date.now();
+  try {
+    await assert.rejects(
+      requestExperimentsJSON(
+        { endpoint, insecure: true, retry: { maxRetries: 0, timeoutMs: 50 } },
+        { method: 'GET', path: experimentReportPath('run-1'), label: 'experiment report' },
+      ),
+      /^Error: agento11y experiment transport failed: experiment report:/,
+    );
+    assert.ok(Date.now() - started < 2_000, 'the call must not wait for the stalled body');
+  } finally {
+    server.closeAllConnections?.();
+    await close(server);
+  }
+});
+
+test('a caller abort during a stalled response body surfaces its own reason', async () => {
+  const server = http.createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.write('{"evaluation_id":');
+  });
+  const endpoint = await listen(server);
+  const controller = new AbortController();
+  const stop = new Error('stop');
+  try {
+    const pending = requestExperimentsJSON(
+      { endpoint, insecure: true, retry: { maxRetries: 0, timeoutMs: 30_000 } },
+      { method: 'GET', path: experimentReportPath('run-1'), label: 'experiment report', signal: controller.signal },
+    );
+    setTimeout(() => controller.abort(stop), 20);
+    await assert.rejects(pending, (error) => {
+      assert.equal(error, stop);
+      return true;
+    });
+  } finally {
+    server.closeAllConnections?.();
+    await close(server);
+  }
+});
+
+test('a blank endpoint fails before any request', async () => {
+  await assert.rejects(
+    requestExperimentsJSON(
+      { endpoint: '  ', insecure: true },
+      { method: 'GET', path: experimentReportPath('run-1'), label: 'experiment report' },
+    ),
+    /agento11y experiment transport failed: api endpoint is required/,
+  );
+});
+
+function jsonServer(seen, respond) {
+  return http.createServer((request, response) => {
+    const chunks = [];
+    request.on('data', (chunk) => chunks.push(chunk));
+    request.on('end', () => {
+      seen.push({
+        method: request.method,
+        url: request.url,
+        headers: request.headers,
+        body: Buffer.concat(chunks).toString('utf8'),
+      });
+      const { status, body } = respond(request);
+      if (typeof body === 'string') {
+        response.writeHead(status, { 'content-type': 'text/plain' });
+        response.end(body);
+        return;
+      }
+      response.writeHead(status, { 'content-type': 'application/json' });
+      response.end(JSON.stringify(body));
+    });
+  });
+}
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.listen(0, '127.0.0.1', (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(undefined);
+    });
+  });
+  const address = server.address();
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function close(server) {
+  await new Promise((resolve) => {
+    server.close(() => resolve(undefined));
+  });
+}

--- a/js/test/experimentsFakeClient.mjs
+++ b/js/test/experimentsFakeClient.mjs
@@ -1,0 +1,161 @@
+/**
+ * Recording stand-in for `ExperimentsClient`, mirroring `FakeClient` in
+ * python/tests/test_experiments.py so both suites assert the same call order.
+ *
+ * `evaluationOrder` records only the calls `trial.evaluate` makes, so a test can
+ * pin the ordering without filtering the full call log.
+ */
+export class FakeExperimentsClient {
+  constructor(options = {}) {
+    this.useExperimentalOtel = options.useExperimentalOtel ?? false;
+    this.redactSecrets = options.redactSecrets ?? false;
+    this.upserts = [];
+    this.scores = [];
+    this.finalized = [];
+    this.generations = [];
+    this.generationCalls = [];
+    this.trials = [];
+    this.trialUpdates = [];
+    this.artifacts = [];
+    this.calls = [];
+    this.warnings = [];
+    this.evaluationOrder = [];
+    this.triggeredEvaluations = [];
+    this.evaluationResult = evaluation('success');
+    this.evaluationStatuses = [];
+    this.exportScoresError = options.exportScoresError;
+    this.exportGenerationError = options.exportGenerationError;
+    this.updateTrialError = options.updateTrialError;
+    this.triggerError = options.triggerError;
+
+    // Fake clock: every sleep advances it, so a deadline is reached without
+    // spending wall-clock time.
+    this.clockMs = 0;
+    this.sleeps = [];
+    this.sleepFn = async (durationMs, signal) => {
+      if (signal?.aborted === true) {
+        throw signal.reason;
+      }
+      this.sleeps.push(durationMs);
+      this.clockMs += durationMs;
+      if (options.onSleep !== undefined) {
+        await options.onSleep(durationMs, this);
+      }
+      if (signal?.aborted === true) {
+        throw signal.reason;
+      }
+    };
+    this.nowMs = () => this.clockMs;
+  }
+
+  async upsertExperiment(request) {
+    this.calls.push('upsert_experiment');
+    this.upserts.push(request);
+    return { runId: request.runId ?? '', name: request.name, status: 'running' };
+  }
+
+  async exportScores(scores) {
+    this.calls.push('export_scores');
+    if (this.exportScoresError !== undefined) {
+      throw this.exportScoresError;
+    }
+    this.scores.push(...scores);
+    return scores.length;
+  }
+
+  async exportGeneration(request) {
+    this.calls.push('export_generation');
+    this.evaluationOrder.push('generation');
+    if (this.exportGenerationError !== undefined) {
+      throw this.exportGenerationError;
+    }
+    this.generations.push(request.generationId);
+    this.generationCalls.push(request);
+    return request.generationId;
+  }
+
+  async recordGeneration(request) {
+    return this.exportGeneration(request);
+  }
+
+  async flushGenerations() {
+    this.calls.push('flush_generations');
+    this.evaluationOrder.push('flush');
+  }
+
+  async upsertTrial(experimentId, request) {
+    this.calls.push('upsert_trial');
+    this.trials.push({ experimentId, ...request });
+    return { trial_id: request.trialId };
+  }
+
+  async updateTrial(experimentId, trialId, request) {
+    this.calls.push('update_trial');
+    this.evaluationOrder.push('update');
+    if (this.updateTrialError !== undefined) {
+      throw this.updateTrialError;
+    }
+    this.trialUpdates.push({ experimentId, trialId, ...request });
+    return { trial_id: trialId };
+  }
+
+  async triggerTrialEvaluation(experimentId, trialId, evaluatorId, evaluatorVersion = '') {
+    this.calls.push('trigger_trial_evaluation');
+    this.evaluationOrder.push('trigger');
+    this.triggeredEvaluations.push({ experimentId, trialId, evaluatorId, evaluatorVersion });
+    if (this.triggerError !== undefined) {
+      throw this.triggerError;
+    }
+    return this.evaluationResult;
+  }
+
+  async getTrialEvaluation() {
+    this.calls.push('get_trial_evaluation');
+    this.evaluationOrder.push('status');
+    if (this.evaluationStatuses.length > 0) {
+      return this.evaluationStatuses.shift();
+    }
+    return this.evaluationResult;
+  }
+
+  async uploadArtifact(request) {
+    this.calls.push('upload_artifact');
+    this.artifacts.push(request);
+    return { artifact_id: `art_${request.name}`, name: request.name, kind: request.kind };
+  }
+
+  async finalize(experimentId, status = 'completed', options = {}) {
+    this.calls.push('finalize');
+    this.finalized.push({ experimentId, status, ...options });
+    return { runId: experimentId, status };
+  }
+
+  async getReport(experimentId) {
+    this.calls.push('get_report');
+    return { run: { runId: experimentId }, summary: {}, rows: [] };
+  }
+
+  experimentUrl(experimentId) {
+    return `http://ui/${experimentId}`;
+  }
+
+  warn(message) {
+    this.warnings.push(message);
+  }
+}
+
+export function evaluation(status, overrides = {}) {
+  return {
+    evaluationId: 'eval-123',
+    experimentId: 'run-1',
+    trialId: 'trial-1',
+    testCaseId: 'case-1',
+    conversationId: 'conv-1',
+    evaluatorId: 'helpfulness',
+    evaluatorVersion: '1',
+    status,
+    attempts: 1,
+    error: '',
+    ...overrides,
+  };
+}

--- a/js/test/experimentsFixtures.mjs
+++ b/js/test/experimentsFixtures.mjs
@@ -1,0 +1,94 @@
+// Loaders for the cross-language experiment wire fixtures in
+// `conformance/experiments/`. See that directory's README.md for the encodings.
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// js/test -> repository root
+const fixtureDir = join(__dirname, '..', '..', 'conformance', 'experiments');
+
+/** The `source.id` this SDK substitutes for the fixture placeholder. */
+export const sdkId = 'js';
+
+/** The literal placeholder the fixtures carry inside every `source` object. */
+// biome-ignore lint/suspicious/noTemplateCurlyInString: the fixtures store this text verbatim
+const sdkIdPlaceholder = '${SDK_ID}';
+
+export function loadInputs() {
+  return readFixture('inputs.json');
+}
+
+export function loadIds() {
+  return readFixture('ids.json');
+}
+
+export function loadRequests() {
+  return withSdkId(readFixture('requests.json'));
+}
+
+export function loadResponses() {
+  return readFixture('responses.json');
+}
+
+function readFixture(name) {
+  return JSON.parse(readFileSync(join(fixtureDir, name), 'utf8'));
+}
+
+/** Replaces the SDK-id placeholder every `source` object carries. */
+function withSdkId(value) {
+  if (typeof value === 'string') {
+    return value === sdkIdPlaceholder ? sdkId : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(withSdkId);
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, withSdkId(entry)]));
+  }
+  return value;
+}
+
+/**
+ * Reports structural differences as dotted JSON paths plus both values, so a
+ * failure names the offending field instead of dumping two payloads. Keys the
+ * fixture uses for documentation (`comment`) are ignored.
+ */
+export function diffJson(got, want, path = '') {
+  const label = path === '' ? '<root>' : path;
+  if (Array.isArray(want)) {
+    if (!Array.isArray(got)) {
+      return [`${label}: got ${JSON.stringify(got)}, want an array`];
+    }
+    if (got.length !== want.length) {
+      return [`${label}: got ${got.length} items, want ${want.length}`];
+    }
+    return want.flatMap((item, index) => diffJson(got[index], item, `${path}[${index}]`));
+  }
+  if (want !== null && typeof want === 'object') {
+    if (got === null || typeof got !== 'object' || Array.isArray(got)) {
+      return [`${label}: got ${JSON.stringify(got)}, want an object`];
+    }
+    const wantKeys = Object.keys(want).filter((key) => key !== 'comment');
+    const gotKeys = Object.keys(got);
+    const differences = [];
+    for (const key of gotKeys) {
+      if (!wantKeys.includes(key)) {
+        differences.push(`${path}.${key}: unexpected field ${JSON.stringify(got[key])}`);
+      }
+    }
+    for (const key of wantKeys) {
+      if (!gotKeys.includes(key)) {
+        differences.push(`${path}.${key}: missing, want ${JSON.stringify(want[key])}`);
+        continue;
+      }
+      differences.push(...diffJson(got[key], want[key], `${path}.${key}`));
+    }
+    return differences;
+  }
+  if (got !== want) {
+    return [`${label}: got ${JSON.stringify(got)}, want ${JSON.stringify(want)}`];
+  }
+  return [];
+}

--- a/llms.txt
+++ b/llms.txt
@@ -452,7 +452,12 @@ Example: an orchestrator spawns agents A, B, C where C depends on A and B:
 - B: `parent_generation_ids = []` (no parents)
 - C: `parent_generation_ids = [A.generation_id, B.generation_id]`
 
-## Python and Go offline experiments
+## Offline experiments
+
+The experiments SDK exists in Python, Go, and JavaScript/TypeScript. The bullets
+below use the Python snake_case names. Go and JavaScript each get their own
+paragraph further down in this section; JavaScript is camelCase, so never copy a
+snake_case name into it.
 
 Use `agento11y.experiments` to track work run by an existing benchmark, CI job,
 notebook, or agent harness. The SDK records runs, trials, scores, usage,
@@ -472,9 +477,11 @@ a stored test suite.
 - Local `LLMJudge` and `RegexJudge` helpers do not require an evaluator created
   in Grafana. Frameworks can submit their native grader result and transcript
   through `trial.record_evaluation(...)`.
-- Python only: `trial.evaluate(evaluator_id)` grades the trial's bound
+- `trial.evaluate(evaluator_id)` grades the trial's bound
   conversation with an evaluator that already exists in the tenant, instead of a
-  locally computed score. Experimental: it requires
+  locally computed score. Go spells it `trial.Evaluate(ctx, evaluatorID)` and
+  JavaScript `trial.evaluate(evaluatorId)`, and the rest of this bullet holds for
+  all three. Experimental: it requires
   `AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true` and otherwise raises
   `ExperimentalFeatureDisabledError` without sending a request. It blocks until the worker finishes, and the trial then
   closes as `completed` with no local `final_score`. Requires
@@ -530,6 +537,32 @@ Portable Go suites use `LoadSuite`/`MarshalSuite`/`WriteSuite` and accept both
 stored version before running. Run/trial/generation/score/artifact writes always
 use the ingest credential. Secret redaction is on by default, and experiment
 OTel spans/events are opt-in via `AGENTO11Y_USE_EXPERIMENTAL_OTEL=true`.
+
+JavaScript and TypeScript use the `@grafana/agento11y/experiments` subpath, which
+is published from the same package but stays out of `@grafana/agento11y-core`
+because it needs crypto and environment access. Build an `ExperimentsClient` from
+`AGENTO11Y_*` ingest settings, then use `withExperiment` and
+`experiment.withTrial`, or the explicit trio `Experiment.start`, `trial.start()`,
+and `trial.close()`. Use these method names exactly, and do not derive others from
+the Python spelling: `bindConversation`, `bindGeneration`, `bindTrace`,
+`recordIO`, `finalScore`, `checkScore`, `rubricScore`, `score`,
+`recordEvaluation`, `evaluateOutput`, `setUsage`, `artifact`, and `flush`.
+Portable suites load and save through `parseSuiteYAML` and `stringifySuiteYAML`,
+and stored suites use `TestSuitesClient`.
+
+`trial.evaluate(evaluatorId, options)` is the JavaScript cloud-evaluation entry
+point. It requires `AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true` and otherwise
+rejects with `ExperimentalFeatureDisabledError` without sending a request. Bind the
+agent's conversation first; such a trial then closes as `completed` with no local
+`finalScore`. `options` takes `evaluatorVersion`, `timeoutMs` (default 300000 ms),
+`pollIntervalMs` (default 500 ms, doubling to a 5000 ms ceiling), and `signal`, an
+`AbortSignal` whose own abort reason is rethrown unchanged. Worker failure rejects
+with `TrialEvaluationFailedError`, an exceeded deadline rejects with
+`TrialEvaluationTimeoutError`, and both carry `evaluationId`. `experiment.finalize`
+drops a caller-supplied `scoreCount` once any trial queued an evaluation, so the
+server's score-count check cannot fail on a score this process never saw. For
+concurrent evaluations, use `client.triggerTrialEvaluation(...)` and
+`client.getTrialEvaluation(...)` inside the experiment block.
 
 ## Useful examples to copy patterns from
 

--- a/mise.toml
+++ b/mise.toml
@@ -220,6 +220,11 @@ description = "Run the Go SDK hook tests: wire fixtures and guard behavior"
 dir = "go"
 run = "GOWORK=off go test ./agento11y -run '^TestHook' -count=1"
 
+[tasks."test:go:sdk-experiments-conformance"]
+description = "Run the Go experiments wire-fixture conformance tests"
+dir = "go"
+run = "GOWORK=off go test ./agento11y/experiments -run '^TestExperimentsConformance' -count=1"
+
 # --- TypeScript/JavaScript SDK tests ---
 
 [tasks."test:ts:sdk-js"]
@@ -232,6 +237,18 @@ description = "Run TypeScript/JavaScript SDK core conformance tests"
 depends = ["deps"]
 dir = "js"
 run = "pnpm run test:build && node --test test/conformance.test.mjs"
+
+[tasks."test:ts:sdk-experiments"]
+description = "Run TypeScript/JavaScript SDK experiments tests"
+depends = ["deps"]
+dir = "js"
+run = "pnpm run test:build && node --import ./test/_setup.mjs --test test/experiments.*.test.mjs"
+
+[tasks."test:ts:sdk-experiments-conformance"]
+description = "Run TypeScript/JavaScript experiments wire-fixture conformance tests"
+depends = ["deps"]
+dir = "js"
+run = "pnpm run test:build && node --import ./test/_setup.mjs --test test/experiments.conformance.test.mjs"
 
 [tasks."test:ts:sdk-hooks-conformance"]
 description = "Run the TypeScript/JavaScript SDK hook tests: wire fixtures and guard behavior"
@@ -269,6 +286,10 @@ run = "uv run --python \"$PYTHON_BIN\" --with '.[dev]' --directory python pytest
 [tasks."test:py:sdk-hooks-conformance"]
 description = "Run the Python SDK hook tests: wire fixtures and guard behavior"
 run = "uv run --python \"$PYTHON_BIN\" --with '.[dev]' --directory python pytest tests/test_hooks_conformance.py tests/test_hooks_integration.py"
+
+[tasks."test:py:sdk-experiments-conformance"]
+description = "Run the Python experiments wire-fixture conformance tests"
+run = "uv run --python \"$PYTHON_BIN\" --with '.[dev]' --directory python pytest tests/test_experiments_conformance.py"
 
 [tasks."test:py:sdk-openai"]
 description = "Run Python OpenAI provider helper tests"
@@ -455,6 +476,19 @@ mise run test:ts:sdk-hooks-conformance
 mise run test:py:sdk-hooks-conformance
 """
 
+[tasks."test:sdk:experiments-conformance"]
+description = """
+Run the experiment wire-fixture tests in Go, Python, and TypeScript/JavaScript.
+Java and .NET have no experiments surface, so they are excluded.
+"""
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+mise run test:go:sdk-experiments-conformance
+mise run test:ts:sdk-experiments-conformance
+mise run test:py:sdk-experiments-conformance
+"""
+
 [tasks."test:sdk:provider-conformance"]
 description = "Run provider-wrapper conformance suites across all shipped SDKs"
 run = """
@@ -487,6 +521,7 @@ run = """
 set -euo pipefail
 mise run test:sdk:core-conformance
 mise run test:sdk:hooks-conformance
+mise run test:sdk:experiments-conformance
 mise run test:sdk:provider-conformance
 mise run test:sdk:framework-conformance
 """

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       openai:
         specifier: ^6.27.0
         version: 6.33.0(ws@8.21.0)(zod@4.3.6)
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
     devDependencies:
       '@opentelemetry/context-async-hooks':
         specifier: 2.6.1

--- a/python/agento11y/_experiments_transport.py
+++ b/python/agento11y/_experiments_transport.py
@@ -620,8 +620,15 @@ def _parse_trial_evaluation(payload: Any) -> TrialEvaluation:
         raise ExperimentTransportError(
             f"agento11y trial evaluation transport failed: unsupported evaluation status {raw_status!r}"
         ) from exc
+    evaluation_id = _str(payload.get("evaluation_id")).strip()
+    if not evaluation_id:
+        # Without an id the next status read would fail as a validation error that
+        # blames the caller's arguments. Go and JavaScript reject it here too.
+        raise ExperimentTransportError(
+            "agento11y trial evaluation transport failed: evaluation response carries no evaluation_id"
+        )
     return TrialEvaluation(
-        evaluation_id=_str(payload.get("evaluation_id")),
+        evaluation_id=evaluation_id,
         experiment_id=_str(payload.get("experiment_id")),
         trial_id=_str(payload.get("trial_id")),
         test_case_id=_str(payload.get("test_case_id")),

--- a/python/tests/test_experiments_conformance.py
+++ b/python/tests/test_experiments_conformance.py
@@ -1,0 +1,403 @@
+"""Experiment wire conformance for the Python SDK.
+
+Checks the requests the SDK serializes and the responses it parses against the
+shared fixtures in ``conformance/experiments/``, which are the only contract for
+routes with no generated stubs. Go and JavaScript run the same fixtures; see
+``conformance/experiments/README.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+import pytest
+from agento11y import _experiments_transport as transport
+from agento11y.errors import ExperimentTransportError
+from agento11y.experiments import Client as ExperimentClient
+from agento11y.experiments import Experiment, TestSuite, stable_id
+from agento11y.models import CreateExperimentRequest, ScoreItem, ScoreSource, ScoreValue
+
+# What this SDK substitutes for the ${SDK_ID} placeholder.
+SDK_ID = "python"
+
+FIXTURE_DIR = Path(__file__).resolve().parents[2] / "conformance" / "experiments"
+
+
+def _load(name: str) -> Any:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def _substitute_sdk_id(value: Any) -> Any:
+    """Replaces the ``${SDK_ID}`` placeholder every ``source`` object carries."""
+
+    if isinstance(value, str):
+        return SDK_ID if value == "${SDK_ID}" else value
+    if isinstance(value, list):
+        return [_substitute_sdk_id(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _substitute_sdk_id(item) for key, item in value.items()}
+    return value
+
+
+INPUTS = _load("inputs.json")
+REQUESTS = _substitute_sdk_id(_load("requests.json"))
+RESPONSES = _load("responses.json")
+TRIAL_ID = stable_id("trial", INPUTS["experiment_id"], INPUTS["test_case_id"], INPUTS["attempt"])
+
+
+class _Recorder:
+    """Captures every request and answers with a path-aware canned body."""
+
+    def __init__(self) -> None:
+        self.requests: list[dict[str, Any]] = []
+        self.lock = threading.Lock()
+
+    def respond(self, path: str) -> Any:
+        if path.endswith(":evaluate") or "/evaluations/" in path:
+            return RESPONSES["evaluation_queued"]
+        if path.endswith(":upsert"):
+            return RESPONSES["run_upsert_response"]
+        if path.endswith(":finalize"):
+            return RESPONSES["run_finalize_response"]
+        if path == "/api/v1/scores:export":
+            return RESPONSES["scores_export_response"]
+        return {"trial_id": TRIAL_ID}
+
+
+def _make_handler(recorder: _Recorder, override: Any = None):
+    class _Handler(BaseHTTPRequestHandler):
+        def _handle(self) -> None:
+            length = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(length) if length else b""
+            path = self.path.split("?", 1)[0]
+            with recorder.lock:
+                recorder.requests.append(
+                    {
+                        "method": self.command,
+                        "path": path,
+                        "headers": {k.lower(): v for k, v in self.headers.items()},
+                        "body": json.loads(raw.decode("utf-8")) if raw else None,
+                        "raw": raw.decode("utf-8"),
+                    }
+                )
+            body = override if override is not None else recorder.respond(path)
+            encoded = json.dumps(body).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        do_GET = _handle
+        do_POST = _handle
+        do_PATCH = _handle
+
+        def log_message(self, _format, *_args):  # noqa: A003
+            return
+
+    return _Handler
+
+
+def _capture(call, override: Any = None) -> list[dict[str, Any]]:
+    recorder = _Recorder()
+    server = HTTPServer(("127.0.0.1", 0), _make_handler(recorder, override))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        client = ExperimentClient(
+            f"http://127.0.0.1:{server.server_address[1]}",
+            ingest_token="token",
+            redact_secrets=False,
+            use_experimental_otel=False,
+        )
+        call(client)
+    finally:
+        server.shutdown()
+        server.server_close()
+    return recorder.requests
+
+
+def _diff_json(got: Any, want: Any, path: str = "") -> list[str]:
+    """Reports differences as dotted JSON paths, ignoring a fixture's ``comment``."""
+
+    label = path or "<root>"
+    if isinstance(want, dict):
+        if not isinstance(got, dict):
+            return [f"{label}: got {got!r}, want an object"]
+        differences: list[str] = []
+        want_keys = [key for key in want if key != "comment"]
+        for key in got:
+            if key not in want_keys:
+                differences.append(f"{path}.{key}: unexpected field {got[key]!r}")
+        for key in want_keys:
+            if key not in got:
+                differences.append(f"{path}.{key}: missing, want {want[key]!r}")
+                continue
+            differences.extend(_diff_json(got[key], want[key], f"{path}.{key}"))
+        return differences
+    if isinstance(want, list):
+        if not isinstance(got, list):
+            return [f"{label}: got {got!r}, want an array"]
+        if len(got) != len(want):
+            return [f"{label}: got {len(got)} items, want {len(want)}"]
+        return [
+            difference
+            for index, item in enumerate(want)
+            for difference in _diff_json(got[index], item, f"{path}[{index}]")
+        ]
+    if got != want:
+        return [f"{label}: got {got!r}, want {want!r}"]
+    return []
+
+
+def _assert_matches(captured: dict[str, Any], fixture: dict[str, Any]) -> None:
+    assert captured["method"] == fixture["method"]
+    assert captured["path"] == fixture["path"]
+    differences = _diff_json(captured["body"], fixture["body"])
+    assert differences == [], "body differs from the fixture:\n" + "\n".join(differences)
+
+
+def test_stable_ids_match_the_shared_vectors() -> None:
+    vectors = _load("ids.json")["vectors"]
+    assert vectors
+    for vector in vectors:
+        parts = [int(part) if isinstance(part, float) and part.is_integer() else part for part in vector["parts"]]
+        assert stable_id(vector["prefix"], *parts) == vector["id"], vector
+
+
+def test_run_upsert_matches_the_fixture() -> None:
+    captured = _capture(
+        lambda client: client.upsert_experiment(
+            CreateExperimentRequest(
+                run_id=INPUTS["experiment_id"],
+                name=INPUTS["experiment_name"],
+                source="external",
+                tags=INPUTS["tags"],
+                suite_id=INPUTS["suite_id"],
+                suite_version=INPUTS["suite_version"],
+                planned_trial_count=INPUTS["planned_trial_count"],
+            )
+        )
+    )
+    _assert_matches(captured[0], REQUESTS["run_upsert"])
+
+
+def test_trial_create_matches_the_fixture() -> None:
+    captured = _capture(
+        lambda client: client.upsert_trial(
+            INPUTS["experiment_id"],
+            trial_id=TRIAL_ID,
+            test_case_id=INPUTS["test_case_id"],
+            attempt=INPUTS["attempt"],
+        )
+    )
+    _assert_matches(captured[0], REQUESTS["trial_create"])
+
+
+@pytest.mark.parametrize(
+    ("fixture", "kwargs"),
+    [
+        ("trial_patch_conversation", {"conversation_id": INPUTS["conversation_id"]}),
+        (
+            "trial_patch_terminal",
+            {"status": "completed", "conversation_id": INPUTS["conversation_id"]},
+        ),
+    ],
+)
+def test_trial_patches_match_the_fixtures(fixture: str, kwargs: dict[str, Any]) -> None:
+    captured = _capture(lambda client: client.update_trial(INPUTS["experiment_id"], TRIAL_ID, **kwargs))
+    _assert_matches(captured[0], REQUESTS[fixture])
+
+
+@pytest.mark.parametrize(
+    ("fixture", "trial_id", "version"),
+    [
+        ("trial_evaluate", TRIAL_ID, INPUTS["evaluator_version"]),
+        ("trial_evaluate_latest_version", TRIAL_ID, ""),
+        ("trial_evaluate_reserved_trial_id", "trial:one/blue", ""),
+    ],
+)
+def test_evaluate_triggers_match_the_fixtures(fixture: str, trial_id: str, version: str) -> None:
+    captured = _capture(
+        lambda client: client.trigger_trial_evaluation(
+            INPUTS["experiment_id"], trial_id, INPUTS["evaluator_id"], version
+        )
+    )
+    _assert_matches(captured[0], REQUESTS[fixture])
+
+
+def test_evaluation_status_read_matches_the_fixture() -> None:
+    captured = _capture(
+        lambda client: client.get_trial_evaluation(INPUTS["experiment_id"], TRIAL_ID, INPUTS["evaluation_id"])
+    )
+    fixture = REQUESTS["trial_evaluation_status"]
+    assert captured[0]["method"] == fixture["method"]
+    assert captured[0]["path"] == fixture["path"]
+    assert captured[0]["raw"] == "", "a status read sends no body"
+
+
+def test_score_export_matches_the_fixture() -> None:
+    score = ScoreItem(
+        score_id=stable_id(
+            "score",
+            INPUTS["experiment_id"],
+            TRIAL_ID,
+            INPUTS["score_key"],
+            INPUTS["score_evaluator_id"],
+        ),
+        evaluator_id=INPUTS["score_evaluator_id"],
+        evaluator_version=INPUTS["score_evaluator_version"],
+        # Local-only on purpose: no SDK puts the evaluator kind on the wire.
+        evaluator_kind="deterministic",
+        score_key=INPUTS["score_key"],
+        value=ScoreValue(boolean=True),
+        conversation_id=INPUTS["conversation_id"],
+        experiment_id=INPUTS["experiment_id"],
+        trial_id=TRIAL_ID,
+        test_case_id=INPUTS["test_case_id"],
+        passed=True,
+        explanation="matched the expected answer",
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        source=ScoreSource(kind="experiment", id=INPUTS["experiment_id"]),
+    )
+    captured = _capture(lambda client: client.export_scores([score]))
+    _assert_matches(captured[0], REQUESTS["scores_export"])
+
+
+@pytest.mark.parametrize(
+    ("fixture", "score_count"),
+    [("run_finalize", None), ("run_finalize_with_score_count", 1)],
+)
+def test_finalize_matches_the_fixture(fixture: str, score_count: int | None) -> None:
+    captured = _capture(lambda client: client.finalize(INPUTS["experiment_id"], "completed", score_count=score_count))
+    _assert_matches(captured[0], REQUESTS[fixture])
+
+
+@pytest.mark.parametrize(
+    ("name", "status"),
+    [
+        ("evaluation_queued", "queued"),
+        ("evaluation_claimed", "claimed"),
+        ("evaluation_success", "success"),
+        ("evaluation_failed", "failed"),
+    ],
+)
+def test_canned_evaluations_parse_into_the_same_result(name: str, status: str) -> None:
+    # Every suite checks this field list on these fixtures, so a misparse in one SDK
+    # cannot pass while the others check a different subset.
+    parsed = transport._parse_trial_evaluation(RESPONSES[name])  # noqa: SLF001
+    assert parsed.status.value == status
+    assert parsed.evaluation_id == INPUTS["evaluation_id"]
+    assert parsed.experiment_id == INPUTS["experiment_id"]
+    assert parsed.trial_id == TRIAL_ID
+    assert parsed.conversation_id == INPUTS["conversation_id"]
+    assert parsed.evaluator_id == INPUTS["evaluator_id"]
+    assert parsed.evaluator_version == INPUTS["evaluator_version"]
+
+
+def test_failed_evaluation_carries_the_backend_detail() -> None:
+    parsed = transport._parse_trial_evaluation(RESPONSES["evaluation_failed"])  # noqa: SLF001
+    assert parsed.error == "grader crashed"
+    assert parsed.attempts == 3
+
+
+def test_evaluation_timestamps_and_case_id_parse() -> None:
+    queued = transport._parse_trial_evaluation(RESPONSES["evaluation_queued"])  # noqa: SLF001
+    assert queued.attempts == 0
+    assert queued.test_case_id == INPUTS["test_case_id"]
+    success = transport._parse_trial_evaluation(RESPONSES["evaluation_success"])  # noqa: SLF001
+    assert success.attempts == 1
+    assert success.test_case_id == INPUTS["test_case_id"]
+    assert success.created_at == datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert success.updated_at == datetime(2026, 1, 1, 0, 0, 5, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    ("name", "message"),
+    [
+        ("evaluation_unsupported_status", "unsupported evaluation status"),
+        ("evaluation_missing_id", "carries no evaluation_id"),
+    ],
+)
+def test_unusable_evaluation_responses_fail_the_call(name: str, message: str) -> None:
+    with pytest.raises(ExperimentTransportError, match=message):
+        transport._parse_trial_evaluation(RESPONSES[name])  # noqa: SLF001
+
+
+@pytest.mark.parametrize("name", ["evaluation_unsupported_status", "evaluation_missing_id"])
+def test_unusable_evaluation_responses_fail_a_status_read(name: str) -> None:
+    with pytest.raises(ExperimentTransportError):
+        _capture(
+            lambda client: client.get_trial_evaluation(INPUTS["experiment_id"], TRIAL_ID, INPUTS["evaluation_id"]),
+            override=RESPONSES[name],
+        )
+
+
+def test_both_report_envelopes_parse_alike() -> None:
+    from_experiment = transport._parse_report(RESPONSES["report_experiment_envelope"])  # noqa: SLF001
+    run_envelope = {key: value for key, value in RESPONSES["report_run_envelope"].items() if key != "comment"}
+    from_run = transport._parse_report(run_envelope)  # noqa: SLF001
+    assert from_experiment == from_run
+    assert from_experiment.run.run_id == INPUTS["experiment_id"]
+    assert from_experiment.summary.trial_count == 1
+    # Only a score under the "final" key feeds the pass rate, and a stored
+    # evaluator writes under its own key.
+    assert from_experiment.summary.pass_rate is None
+
+
+def test_cloud_evaluated_trial_produces_the_pinned_call_order(monkeypatch) -> None:
+    monkeypatch.setenv("AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES", "true")
+    recorder = _Recorder()
+
+    def respond(path: str) -> Any:
+        if path.endswith(":evaluate") or "/evaluations/" in path:
+            return RESPONSES["evaluation_success"]
+        return _Recorder.respond(recorder, path)
+
+    recorder.respond = respond  # type: ignore[method-assign]
+    server = HTTPServer(("127.0.0.1", 0), _make_handler(recorder))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        client = ExperimentClient(
+            f"http://127.0.0.1:{server.server_address[1]}",
+            ingest_token="token",
+            redact_secrets=False,
+            use_experimental_otel=False,
+        )
+        suite = TestSuite(suite_id=INPUTS["suite_id"], version=INPUTS["suite_version"])
+        with Experiment(
+            client,
+            experiment_id=INPUTS["experiment_id"],
+            name=INPUTS["experiment_name"],
+            suite=suite,
+            tags=list(INPUTS["tags"]),
+            planned_trial_count=INPUTS["planned_trial_count"],
+            auto_finalize=False,
+        ) as experiment:
+            with experiment.trial(INPUTS["test_case_id"]) as trial:
+                trial.bind_conversation(INPUTS["conversation_id"])
+                trial.evaluate(INPUTS["evaluator_id"], evaluator_version=INPUTS["evaluator_version"])
+            experiment.finalize("completed")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    calls = [f"{request['method']} {request['path']}" for request in recorder.requests]
+    assert calls == [
+        "POST /api/v1/experiment-runs:upsert",
+        f"POST /api/v1/experiment-runs/{INPUTS['experiment_id']}/trials",
+        f"PATCH /api/v1/experiment-runs/{INPUTS['experiment_id']}/trials/{TRIAL_ID}",
+        f"POST /api/v1/experiment-runs/{INPUTS['experiment_id']}/trials/{TRIAL_ID}:evaluate",
+        f"PATCH /api/v1/experiment-runs/{INPUTS['experiment_id']}/trials/{TRIAL_ID}",
+        f"POST /api/v1/experiment-runs/{INPUTS['experiment_id']}:finalize",
+    ]
+    assert "/api/v1/scores:export" not in [request["path"] for request in recorder.requests]
+    _assert_matches(recorder.requests[2], REQUESTS["trial_patch_conversation"])
+    _assert_matches(recorder.requests[3], REQUESTS["trial_evaluate"])
+    _assert_matches(recorder.requests[5], REQUESTS["run_finalize"])

--- a/skills/agento11y-eval-starter/SKILL.md
+++ b/skills/agento11y-eval-starter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agento11y-eval-starter
-description: Use early in an AI-agent project — before ship, before real traffic — to decide which evaluations to set up and to scaffold a starter experiment. Reads the agent's own code (system prompt, tools, task), recommends specific evaluators with reasons that cite real lines, and writes a labeled draft test suite as an Agent Observability suite YAML. It also assesses how runnable the agent is: for an easily-invoked agent it generates a runner stub (run_experiment.py) with one hole to fill and can optionally run it (only with permission, only against the endpoint the developer configured); for agents that need a harness or a full runtime it points to the existing eval infra instead of emitting a runner that can't call the agent. It never creates tenant-level evaluators, rules, or guards.
+description: Use early in an AI-agent project — before ship, before real traffic — to decide which evaluations to set up and to scaffold a starter experiment. Reads the agent's own code (system prompt, tools, task), recommends specific evaluators with reasons that cite real lines, and writes a labeled draft test suite as an Agent Observability suite YAML. It also assesses how runnable the agent is: for an easily-invoked agent it generates a runner stub (run_experiment.py, or run-experiment.ts for a TypeScript agent) with one hole to fill and can optionally run it (only with permission, only against the endpoint the developer configured); for agents that need a harness or a full runtime it points to the existing eval infra instead of emitting a runner that can't call the agent. It never creates tenant-level evaluators, rules, or guards.
 ---
 
 # Agent Observability eval starter
@@ -16,8 +16,9 @@ Always produce:
 
 Then, depending on how runnable the agent is (Step 1):
 
-3. For an easily-invoked agent, a **runner stub** (`run_experiment.py`) that wires the suite
-   to the SDK with one hole to fill — and optionally run it (Step 6), only with permission.
+3. For an easily-invoked agent, a **runner stub** (`run_experiment.py`, or
+   `run-experiment.ts` for a TypeScript agent) that wires the suite to the SDK
+   with one hole to fill — and optionally run it (Step 6), only with permission.
    For an agent that needs a harness or full runtime, point to the existing eval infra instead
    of a runner that can't actually call it.
 
@@ -75,13 +76,13 @@ scenario/ground-truth files in the repo. If a repo already has eval scenarios wi
 outputs, note them — they are better test cases than anything generated, and later steps
 should point to or reuse them.
 
-Separately, note the **agent's language**, because the agento11y experiments SDK exists only in
-**Python and Go** (not JS/TS, Java, or .NET yet). This is independent of runnability — a TS
-agent can be trivially runnable yet have no experiments SDK in its language. If the agent is
-Python or Go, the runner is native. If it is any other language, say so plainly: the runner
-must be Python or Go (calling the agent across a process boundary), or the developer waits for
-experiments support in their language. Do not imply a native JS/Java/.NET experiments API
-exists.
+Separately, note the **agent's language**, because the agento11y experiments SDK exists in
+**Python, Go, and JavaScript/TypeScript** (not Java or .NET yet). This is independent of
+runnability — a Java agent can be trivially runnable yet have no experiments SDK in its
+language. If the agent is Python, Go, or TypeScript, the runner is native. If it is Java or
+.NET, say so plainly: the runner must be Python, Go, or TypeScript (calling the agent across a
+process boundary), or the developer waits for experiments support in their language. Do not
+imply a native Java or .NET experiments API exists.
 
 ## Step 2 — Choose evaluators
 
@@ -193,8 +194,9 @@ and point to `agento11y-experiments` for depth.
 
 What you generate depends on the runnability you assessed in Step 1:
 
-- **easy** → generate the full `evals/run_experiment.py` below. One hole to fill
-  (`run_agent`).
+- **easy** → generate the full runner below: `evals/run_experiment.py` for a Python or Go
+  agent, `evals/run-experiment.ts` for a TypeScript agent. One hole to fill (`run_agent`).
+  A Go agent gets the Python runner, because this skill ships no Go template.
 - **in-process** → do NOT emit a Python `run_agent` that can't actually call the agent (e.g.
   a Go agent). Generate the same experiment wiring, but make `run_agent` shell out to a small
   harness in the agent's language (or write that harness), and say plainly the seam is the
@@ -206,17 +208,19 @@ What you generate depends on the runnability you assessed in Step 1:
   scenario/ground-truth files as the real test cases. Be explicit that isolated runs aren't
   the path here.
 
-Also branch on **language** (the experiments SDK is Python/Go only):
+Also branch on **language** (the experiments SDK covers Python, Go, and JavaScript/TypeScript):
 
-- **Python or Go agent** → native runner (`run_experiment.py`, or the Go `agento11y` package).
-- **TS / Java / .NET agent** → there is no experiments SDK in that language. Deliver
+- **Python, Go, or TypeScript agent** → native runner (`run_experiment.py`, the Go
+  `agento11y` package, or the `@grafana/agento11y/experiments` subpath).
+- **Java / .NET agent** → there is no experiments SDK in that language. Deliver
   recommendations + YAML (they are language-neutral), and be honest about the run path: the
-  runner must be Python or Go calling the agent across a process boundary (e.g. a Python
-  runner that shells out to `node your-agent.js` and reads its output), or the developer waits
-  for experiments support in their language. Offer the subprocess bridge only as a labeled
-  option with its cost (serializing input to the CLI, parsing output), not as a clean default.
+  runner must be Python, Go, or TypeScript calling the agent across a process boundary (e.g. a
+  Python runner that shells out to `java -jar your-agent.jar` and reads its output), or the
+  developer waits for experiments support in their language. Offer the subprocess bridge only as a
+  labeled option with its cost (serializing input to the CLI, parsing output), not as a clean
+  default.
 
-For an **easy Python/Go** agent, write `evals/run_experiment.py`. It must:
+For an **easy Python or Go** agent, write `evals/run_experiment.py`. It must:
 
 - Load the suite with `TestSuite.from_yaml(...)`.
 - Open an experiment (`experiments.experiment(...)`) and one `trial` per case.
@@ -303,6 +307,82 @@ if __name__ == "__main__":
     main()
 ```
 
+For an **easy TypeScript** agent, write `evals/run-experiment.ts` against the
+`@grafana/agento11y/experiments` subpath. Same shape and same one hole, in JS spellings:
+`parseSuiteYAML(...)` loads the suite, `withExperiment(client, {...}, ...)` and
+`experiment.withTrial(case, ...)` own the lifecycle, `trial.recordIO({input, output})` records
+I/O, and `trial.finalScore(score, {passed, explanation, evaluator})` publishes the verdict:
+
+```ts
+/**
+ * STARTER RUNNER - generated by agento11y-eval-starter, review before use.
+ *
+ * Runs <agent> over evals/<agent>-starter.yaml as an Agent Observability experiment and
+ * publishes scores.
+ *
+ * You still need to: (1) fill runAgent(case) to call YOUR agent; (2) tune the sketched judge;
+ * (3) set real credentials - AGENTO11Y_ENDPOINT + AGENTO11Y_AUTH_TOKEN for your Grafana Cloud
+ * stack. The SDK stores scores; it does not run the agent or the judge.
+ *
+ * Set AGENTO11Y_INGEST_ACTOR to a stable value: the run and its trials must share one actor,
+ * or trial creation fails with "401: experiment is owned by another actor".
+ *
+ *     AGENTO11Y_ENDPOINT=... AGENTO11Y_AUTH_TOKEN=... AGENTO11Y_INGEST_ACTOR=ingest:sdk/js \
+ *         npx tsx evals/run-experiment.ts
+ */
+import { readFileSync } from 'node:fs';
+import { ExperimentsClient, parseSuiteYAML, type TestCase, withExperiment } from '@grafana/agento11y/experiments';
+
+const suite = parseSuiteYAML(readFileSync(new URL('./<agent>-starter.yaml', import.meta.url), 'utf8'));
+const verifier = { evaluatorId: '<evaluator>', version: 'draft-0', kind: 'llm_judge' } as const;
+
+/** THE ONE HOLE YOU FILL - call your agent for this case and return its output text. */
+async function runAgent(testCase: TestCase): Promise<string> {
+  throw new Error('wire this to your agent entrypoint (see Step 1 refs)');
+}
+
+/** Sketched llm_judge - one model call returning a 0-1 score, a verdict, and an explanation. */
+async function judge(input: unknown, output: string): Promise<{ score: number; passed: boolean; why: string }> {
+  // Replace with your model call, reading the model id from GRADER_MODEL or MODEL_NAME.
+  // Use a live model id; there is no default, and a dead id 404s.
+  throw new Error('tune this judge');
+}
+
+// endpoint, tenantId, and ingestToken fall back to AGENTO11Y_ENDPOINT,
+// AGENTO11Y_AUTH_TENANT_ID, and AGENTO11Y_AUTH_TOKEN.
+const client = new ExperimentsClient({ actor: process.env.AGENTO11Y_INGEST_ACTOR ?? 'ingest:sdk/js' });
+
+await withExperiment(
+  client,
+  {
+    // A fresh id per run: reusing one created by another actor fails with 401.
+    experimentId: `<agent>-starter-${Math.floor(Date.now() / 1000)}`,
+    name: '<agent> starter',
+    suite,
+    tags: ['starter'],
+    candidate: {
+      agentName: '<agent>',
+      // Always declare a version. Without it Agent Observability derives one from the
+      // system-prompt hash, and scores cannot be attributed to a version.
+      agentVersion: process.env.AGENT_VERSION ?? 'v1',
+      modelName: process.env.MODEL_NAME ?? '',
+    },
+  },
+  async (experiment) => {
+    for (const testCase of suite.testCases) {
+      await experiment.withTrial(testCase, async (trial) => {
+        const output = await runAgent(testCase);
+        trial.recordIO({ input: JSON.stringify(testCase.input), output });
+        const { score, passed, why } = await judge(testCase.input, output);
+        trial.finalScore(score, { passed, explanation: why, evaluator: verifier });
+        console.log(`  ${testCase.testCaseId}: score=${score} passed=${passed}`);
+      });
+    }
+    console.log(`Experiment: ${experiment.url}`);
+  },
+);
+```
+
 Use a **fresh `experiment_id`** per run (a timestamp works) — reusing an id created by a
 different auth actor fails with `401: experiment is owned by another actor`.
 
@@ -313,10 +393,11 @@ Output, in this order:
 1. The picked evaluators, each with its kind and its `why` (with file:line).
    Add a one-line "once you have traffic, these criteria can also run online (Agent Observability rules or
    guard hooks) — separate surfaces, not set up here."
-2. The paths to the two written files (`evals/<agent>-starter.yaml` and
-   `evals/run_experiment.py`), and a one-line reminder to review the edge/adversarial cases
-   and add real ones.
-3. The three things they still do to run it: fill `run_agent(case)`, tune the sketched judge
+2. The paths to the two written files (`evals/<agent>-starter.yaml` and the runner:
+   `evals/run_experiment.py`, or `evals/run-experiment.ts` for TypeScript), and a one-line
+   reminder to review the edge/adversarial cases and add real ones.
+3. The three things they still do to run it: fill `run_agent(case)` (`runAgent` in TypeScript),
+   tune the sketched judge
    (and add the other recommended evaluators the same way), and set credentials
    (`AGENTO11Y_ENDPOINT` + `AGENTO11Y_AUTH_TOKEN`). State the boundary explicitly: this skill only
    bootstraps the first run; for anything past that — binding an already-instrumented agent's
@@ -326,10 +407,11 @@ Output, in this order:
 
 ## Step 6 — Offer to run it (optional, only with permission)
 
-Only offer this for an **easy** agent (clean function seam) **in Python or Go** (the languages
-with an experiments SDK). For `in-process`/`full-stack` agents, or agents in a language with no
-experiments SDK (TS/Java/.NET), don't offer to run — point to the existing harness/infra (or
-the subprocess-bridge option) and stop; a real run there is out of scope for this skill.
+Only offer this for an **easy** agent (clean function seam) **in Python, Go, or TypeScript**
+(the languages with an experiments SDK). For `in-process`/`full-stack` agents, or agents in a
+language with no experiments SDK (Java/.NET), don't offer to run — point to the existing
+harness/infra (or the subprocess-bridge option) and stop; a real run there is out of scope for
+this skill.
 
 After the summary, offer to run the starter experiment for them — do not run automatically.
 Ask: "Want me to try running this now?" Only proceed if they say yes.


### PR DESCRIPTION
Ports the experiments SDK to TypeScript as the `@grafana/agento11y/experiments` subpath, so a JS runner can grade an agent over a dataset and publish runs, trials, and scores to Agent Observability:

```ts
import { ExperimentsClient, withExperiment } from "@grafana/agento11y/experiments";

const client = new ExperimentsClient();
const verifier = { evaluatorId: "exact", version: "1", kind: "deterministic" };

await withExperiment(client, { experimentId: "nightly-42", name: "nightly", suite }, async (experiment) => {
  for (const testCase of suite.testCases) {
    await experiment.withTrial(testCase, async (trial) => {
      const answer = await runAgent(testCase.input);
      trial.recordIO({ input: testCase.input, output: answer });
      trial.finalScore(answer === testCase.expected, { evaluator: verifier });
    });
  }
  console.log((await experiment.report()).summary);
});
```

Local judges (`LLMJudge`, `RegexJudge`), stored test suites through `TestSuitesClient`, artifacts, and OTel trial spans are included. Cloud evaluation grades the conversation the backend already stored:

```ts
await experiment.withTrial(testCase, async (trial) => {
  const { conversationId } = await runInstrumentedAgent(testCase.input);
  trial.bindConversation(conversationId);
  await trial.evaluate("helpfulness", { evaluatorVersion: "2", timeoutMs: 120_000 });
});
```

That path stays behind `AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES`, matching Go and Python: without the flag the call rejects with `ExperimentalFeatureDisabledError` before any request goes out.