### PR TITLE
fix(plugins/agento11y): give Claude Code spans real time windows

### DIFF
--- a/plugins/agento11y/internal/agents/claudecode/hook.go
+++ b/plugins/agento11y/internal/agents/claudecode/hook.go
@@ -171,7 +171,7 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 		r = redact.New()
 	}
 
-	gens := mapper.Process(lines, &st, mapper.Options{
+	gens, toolResultAt := mapper.Process(lines, &st, mapper.Options{
 		SessionID: input.SessionID,
 		Logger:    logger,
 		ExtraTags: extraTags,
@@ -199,22 +199,8 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 	toolResults := buildToolResultMap(gens)
 
 	for _, gen := range gens {
-		genStart := agento11y.GenerationStart{
-			ID:                  gen.ID,
-			ConversationID:      gen.ConversationID,
-			ConversationTitle:   gen.ConversationTitle,
-			AgentName:           gen.AgentName,
-			AgentVersion:        gen.AgentVersion,
-			Mode:                gen.Mode,
-			OperationName:       gen.OperationName,
-			Model:               gen.Model,
-			ParentGenerationIDs: gen.ParentGenerationIDs,
-			Tags:                gen.Tags,
-			Metadata:            gen.Metadata,
-		}
-
-		if err := emit.Record(hookCtx, client, genStart, gen, nil, func(genCtx context.Context) {
-			emitToolSpans(genCtx, client, gen, toolResults)
+		if err := emit.Record(hookCtx, client, generationStart(gen), gen, nil, func(genCtx context.Context) {
+			emitToolSpans(genCtx, client, gen, toolResults, toolResultAt)
 		}); err != nil {
 			logger.Printf("enqueue: %v", err)
 		}
@@ -376,6 +362,31 @@ func parseHookInput(r io.Reader) (*hookInput, error) {
 	return &input, nil
 }
 
+// generationStart projects a mapped generation onto the span seed the SDK
+// needs to open the generation span.
+//
+// StartedAt has to travel with it. When it is zero the SDK stamps the span
+// start with time.Now(), while End stamps the span end with the transcript's
+// CompletedAt. The hook runs after the turn finished, so the window inverts and
+// a trace store renders the unsigned wrap of a negative duration: 2^64
+// nanoseconds, or 213504 days.
+func generationStart(gen agento11y.Generation) agento11y.GenerationStart {
+	return agento11y.GenerationStart{
+		ID:                  gen.ID,
+		ConversationID:      gen.ConversationID,
+		ConversationTitle:   gen.ConversationTitle,
+		AgentName:           gen.AgentName,
+		AgentVersion:        gen.AgentVersion,
+		Mode:                gen.Mode,
+		OperationName:       gen.OperationName,
+		Model:               gen.Model,
+		ParentGenerationIDs: gen.ParentGenerationIDs,
+		Tags:                gen.Tags,
+		Metadata:            gen.Metadata,
+		StartedAt:           gen.StartedAt,
+	}
+}
+
 // buildToolResultMap indexes tool results by their call ID across all generations.
 // Tool results appear in the Input of the generation that follows the tool call.
 func buildToolResultMap(gens []agento11y.Generation) map[string]*agento11y.ToolResult {
@@ -392,14 +403,41 @@ func buildToolResultMap(gens []agento11y.Generation) map[string]*agento11y.ToolR
 	return m
 }
 
-// emitToolSpans creates execute_tool spans for each tool call in the generation output.
-func emitToolSpans(ctx context.Context, client *agento11y.Client, gen agento11y.Generation, results map[string]*agento11y.ToolResult) {
+// toolSpanWindow resolves the [start, end] window of an execute_tool span from
+// the completion of the turn that requested the tool and the timestamp of the
+// matching tool_result line. Either can be missing or out of order, and any such
+// pair collapses to a zero-width span rather than one that inverts.
+//
+// A zero genCompletedAt is the case worth spelling out: the SDK then stamps the
+// span start with the current time, which is after every transcript timestamp,
+// so pairing it with a result timestamp would invert the window. Anchor both
+// ends on the result instead.
+//
+// This differs from emit.ToolSpanWindow, which backdates a known duration from
+// the tool's own completion timestamp. Claude Code reports no tool duration, and
+// the window measures the gap between two transcript lines, so it includes any
+// time the user spent approving the call.
+func toolSpanWindow(genCompletedAt, resultAt time.Time) (startedAt, completedAt time.Time) {
+	if genCompletedAt.IsZero() {
+		return resultAt, resultAt
+	}
+	if !resultAt.After(genCompletedAt) {
+		return genCompletedAt, genCompletedAt
+	}
+	return genCompletedAt, resultAt
+}
+
+// emitToolSpans creates execute_tool spans for each tool call in the generation
+// output, windowed by toolSpanWindow from the generation's completion and the
+// matching tool_result timestamp in resultAt.
+func emitToolSpans(ctx context.Context, client *agento11y.Client, gen agento11y.Generation, results map[string]*agento11y.ToolResult, resultAt map[string]time.Time) {
 	for _, msg := range gen.Output {
 		for _, part := range msg.Parts {
 			if part.ToolCall == nil {
 				continue
 			}
 			tc := part.ToolCall
+			startedAt, completedAt := toolSpanWindow(gen.CompletedAt, resultAt[tc.ID])
 			start := agento11y.ToolExecutionStart{
 				ToolName:        tc.Name,
 				ToolCallID:      tc.ID,
@@ -409,12 +447,12 @@ func emitToolSpans(ctx context.Context, client *agento11y.Client, gen agento11y.
 				AgentVersion:    gen.AgentVersion,
 				RequestModel:    gen.Model.Name,
 				RequestProvider: gen.Model.Provider,
-				StartedAt:       gen.CompletedAt,
+				StartedAt:       startedAt,
 			}
 			_, toolRec := client.StartToolExecution(ctx, start)
 
 			end := agento11y.ToolExecutionEnd{
-				CompletedAt: gen.CompletedAt,
+				CompletedAt: completedAt,
 				Arguments:   string(tc.InputJSON),
 			}
 			if tr, ok := results[tc.ID]; ok {

--- a/plugins/agento11y/internal/agents/claudecode/hook_test.go
+++ b/plugins/agento11y/internal/agents/claudecode/hook_test.go
@@ -17,7 +17,9 @@ import (
 
 	"github.com/grafana/agento11y/go/agento11y"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/claudecode/state"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/emit"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
@@ -335,11 +337,19 @@ func runHookForTest(t *testing.T, input hookInput) string {
 	return logs.String()
 }
 
+// hookFixtureTimestamp is the timestamp every fixture line shares unless a
+// test needs distinct times to assert span windows.
+const hookFixtureTimestamp = "2025-06-01T12:00:00Z"
+
 func buildHookUserJSONL(sessionID, text string) string {
+	return buildHookUserJSONLAt(sessionID, text, hookFixtureTimestamp)
+}
+
+func buildHookUserJSONLAt(sessionID, text, ts string) string {
 	line := map[string]any{
 		"type":      "user",
 		"sessionId": sessionID,
-		"timestamp": "2025-06-01T12:00:00Z",
+		"timestamp": ts,
 		"version":   "1.0.0",
 		"message": map[string]any{
 			"role":    "user",
@@ -351,17 +361,36 @@ func buildHookUserJSONL(sessionID, text string) string {
 }
 
 func buildHookAssistantJSONL(sessionID, requestID, stopReason, text string, outputTokens int64) string {
+	return buildHookAssistantJSONLAt(sessionID, requestID, stopReason, text, outputTokens, hookFixtureTimestamp)
+}
+
+func buildHookAssistantJSONLAt(sessionID, requestID, stopReason, text string, outputTokens int64, ts string) string {
+	return buildHookAssistantLineAt(sessionID, requestID, stopReason, ts,
+		[]any{map[string]any{"type": "text", "text": text}}, outputTokens)
+}
+
+// buildHookAssistantToolUseJSONLAt builds an assistant turn that calls one tool.
+func buildHookAssistantToolUseJSONLAt(sessionID, requestID, toolUseID, toolName, ts string) string {
+	return buildHookAssistantLineAt(sessionID, requestID, "tool_use", ts, []any{map[string]any{
+		"type":  "tool_use",
+		"id":    toolUseID,
+		"name":  toolName,
+		"input": map[string]any{"command": "ls"},
+	}}, 7)
+}
+
+func buildHookAssistantLineAt(sessionID, requestID, stopReason, ts string, content []any, outputTokens int64) string {
 	line := map[string]any{
 		"type":      "assistant",
 		"sessionId": sessionID,
-		"timestamp": "2025-06-01T12:00:00Z",
+		"timestamp": ts,
 		"version":   "1.0.0",
 		"requestId": requestID,
 		"message": map[string]any{
 			"model":       "claude-opus-4",
 			"stop_reason": stopReason,
 			"usage":       map[string]any{"input_tokens": 3, "output_tokens": outputTokens},
-			"content":     []any{map[string]any{"type": "text", "text": text}},
+			"content":     content,
 		},
 	}
 	data, _ := json.Marshal(line)
@@ -369,10 +398,14 @@ func buildHookAssistantJSONL(sessionID, requestID, stopReason, text string, outp
 }
 
 func buildHookToolResultJSONL(sessionID, toolUseID, content string) string {
+	return buildHookToolResultJSONLAt(sessionID, toolUseID, content, hookFixtureTimestamp)
+}
+
+func buildHookToolResultJSONLAt(sessionID, toolUseID, content, ts string) string {
 	line := map[string]any{
 		"type":      "user",
 		"sessionId": sessionID,
-		"timestamp": "2025-06-01T12:00:00Z",
+		"timestamp": ts,
 		"version":   "1.0.0",
 		"message": map[string]any{
 			"role": "user",
@@ -669,6 +702,9 @@ func newSpanRecordingClient(t *testing.T, mode agento11y.ContentCaptureMode) (*a
 	client := agento11y.NewClient(agento11y.Config{
 		Tracer:         tp.Tracer("test"),
 		ContentCapture: mode,
+		// Spans are the subject here; keep the export transport out of it so
+		// shutdown does not try to reach a real endpoint.
+		GenerationExport: agento11y.GenerationExportConfig{Protocol: agento11y.GenerationExportProtocolNone},
 	})
 	t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
 	return client, recorder
@@ -693,18 +729,214 @@ func spanAttr(s sdktrace.ReadOnlySpan, key string) string {
 	return ""
 }
 
+// TestGenerationStart_CarriesStartedAt pins the field the span window depends
+// on: the projection must carry the mapped StartedAt, not drop it.
+func TestGenerationStart_CarriesStartedAt(t *testing.T) {
+	completed := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		gen  agento11y.Generation
+	}{
+		{
+			name: "normal turn",
+			gen: agento11y.Generation{
+				ID:             "gen-1",
+				ConversationID: "sess-1",
+				AgentName:      AgentName,
+				StartedAt:      completed.Add(-2 * time.Second),
+				CompletedAt:    completed,
+			},
+		},
+		{
+			name: "zero start",
+			gen: agento11y.Generation{
+				ID:          "gen-2",
+				AgentName:   AgentName,
+				CompletedAt: completed,
+			},
+		},
+		{
+			name: "synthesized subagent",
+			gen: agento11y.Generation{
+				ID:                  "gen-3",
+				AgentName:           AgentName + "/explorer",
+				ParentGenerationIDs: []string{"gen-1"},
+				StartedAt:           completed,
+				CompletedAt:         completed.Add(1200 * time.Millisecond),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := generationStart(tt.gen)
+			if !got.StartedAt.Equal(tt.gen.StartedAt) {
+				t.Errorf("StartedAt = %v, want %v", got.StartedAt, tt.gen.StartedAt)
+			}
+			if got.ID != tt.gen.ID || got.AgentName != tt.gen.AgentName {
+				t.Errorf("identity fields not carried: %+v", got)
+			}
+		})
+	}
+}
+
+// TestRecord_GenerationSpanWindowNotInverted pins the reported symptom: a Stop
+// hook replays a turn that finished 30 seconds earlier, so a span start taken
+// from wall clock falls after the span end.
+func TestRecord_GenerationSpanWindowNotInverted(t *testing.T) {
+	client, recorder := newSpanRecordingClient(t, agento11y.ContentCaptureModeMetadataOnly)
+
+	completed := time.Now().Add(-30 * time.Second)
+	gen := agento11y.Generation{
+		ID:             "gen-late-export",
+		ConversationID: "sess-1",
+		AgentName:      AgentName,
+		Mode:           agento11y.GenerationModeSync,
+		OperationName:  "generateText",
+		Model:          agento11y.ModelRef{Provider: "anthropic", Name: "claude-sonnet-4-20250514"},
+		StartedAt:      completed.Add(-2 * time.Second),
+		CompletedAt:    completed,
+	}
+
+	if err := emit.Record(context.Background(), client, generationStart(gen), gen, nil, nil); err != nil {
+		t.Fatalf("emit.Record: %v", err)
+	}
+	_ = client.Shutdown(context.Background())
+
+	spans := spansByName(recorder.Ended(), "generateText")
+	if len(spans) != 1 {
+		t.Fatalf("got %d generateText spans, want 1", len(spans))
+	}
+	got := spans[0].EndTime().Sub(spans[0].StartTime())
+	if got < 0 {
+		t.Fatalf("span duration = %v, want non-negative (start %v after end %v)",
+			got, spans[0].StartTime(), spans[0].EndTime())
+	}
+	if got != 2*time.Second {
+		t.Errorf("span duration = %v, want 2s from the mapped window", got)
+	}
+}
+
+// TestHook_SpanWindowsFromTranscript runs Hook itself over a transcript with
+// distinct timestamps and asserts the recorded span windows. It covers the
+// wiring the helper-level tests cannot: re-inlining the GenerationStart literal
+// in Hook, or dropping the tool-result timestamps on the way to emitToolSpans,
+// fails here.
+func TestHook_SpanWindowsFromTranscript(t *testing.T) {
+	const (
+		sessionID = "span-window-session"
+		promptAt  = "2025-06-01T12:00:00Z"
+		callAt    = "2025-06-01T12:00:01Z"
+		resultAt  = "2025-06-01T12:00:02.2Z"
+		replyAt   = "2025-06-01T12:00:03Z"
+	)
+
+	jsonl := strings.Join([]string{
+		buildHookUserJSONLAt(sessionID, "list the files", promptAt),
+		buildHookAssistantToolUseJSONLAt(sessionID, "req_a", "tu_1", "Bash", callAt),
+		buildHookToolResultJSONLAt(sessionID, "tu_1", "a.go\nb.go", resultAt),
+		buildHookAssistantJSONLAt(sessionID, "req_b", "end_turn", "two files", 5, replyAt),
+	}, "\n") + "\n"
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	if err := os.WriteFile(path, []byte(jsonl), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := installGlobalSpanRecorder(t)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(dir, "state"))
+	// AGENTO11Y_* wins over SIGIL_*, so pin both spellings before pointing the
+	// export at the stub: an ambient endpoint would send this fixture to a real
+	// backend.
+	envconfig.PinAliasEnvBlank(t)
+	server := httptest.NewServer(http.HandlerFunc(acceptGenerationExport))
+	defer server.Close()
+	setHookExportEnv(t, server.URL)
+
+	logs := runHookForTest(t, hookInput{
+		HookEventName:  "Stop",
+		SessionID:      sessionID,
+		TranscriptPath: path,
+	})
+	if !strings.Contains(logs, "produced 2 generations") {
+		t.Fatalf("hook did not produce two generations:\n%s", logs)
+	}
+
+	genSpans := spansByName(recorder.Ended(), "generateText")
+	if len(genSpans) != 2 {
+		t.Fatalf("got %d generateText spans, want 2", len(genSpans))
+	}
+	// The tool-use turn runs from the prompt to its own completion, the closing
+	// turn from the tool result to its completion.
+	wantGenDurations := []time.Duration{time.Second, 800 * time.Millisecond}
+	for i, want := range wantGenDurations {
+		if got := genSpans[i].EndTime().Sub(genSpans[i].StartTime()); got != want {
+			t.Errorf("generateText span[%d] duration = %v, want %v", i, got, want)
+		}
+	}
+
+	toolSpans := spansByName(recorder.Ended(), "execute_tool")
+	if len(toolSpans) != 1 {
+		t.Fatalf("got %d execute_tool spans, want 1", len(toolSpans))
+	}
+	if got := toolSpans[0].EndTime().Sub(toolSpans[0].StartTime()); got != 1200*time.Millisecond {
+		t.Errorf("execute_tool span duration = %v, want 1.2s (call to tool_result)", got)
+	}
+}
+
+// installGlobalSpanRecorder records the spans Hook produces. Hook builds its own
+// client and only sets a tracer when an OTLP endpoint is configured, so with the
+// endpoint blank the SDK falls back to the global provider.
+func installGlobalSpanRecorder(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previous)
+		_ = tp.Shutdown(context.Background())
+	})
+	return recorder
+}
+
+// acceptGenerationExport accepts every generation in the request so the SDK's
+// cardinality check passes and the exporter does not retry.
+func acceptGenerationExport(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Generations []struct {
+			ID string `json:"id"`
+		} `json:"generations"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&req)
+
+	resp := struct {
+		Results []map[string]any `json:"results"`
+	}{Results: make([]map[string]any, 0, len(req.Generations))}
+	for _, g := range req.Generations {
+		resp.Results = append(resp.Results, map[string]any{"generation_id": g.ID, "accepted": true})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 func TestEmitToolSpans(t *testing.T) {
 	ts := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
 
 	tests := []struct {
-		name        string
-		gen         agento11y.Generation
-		results     map[string]*agento11y.ToolResult
-		contentMode agento11y.ContentCaptureMode
-		wantSpans   int
-		wantNames   []string
-		wantArgs    map[string]string
-		wantResults map[string]string
+		name          string
+		gen           agento11y.Generation
+		results       map[string]*agento11y.ToolResult
+		resultAt      map[string]time.Time
+		contentMode   agento11y.ContentCaptureMode
+		wantSpans     int
+		wantNames     []string
+		wantArgs      map[string]string
+		wantResults   map[string]string
+		wantStarts    map[string]time.Time
+		wantDurations map[string]time.Duration
 	}{
 		{
 			name: "no tool calls",
@@ -737,9 +969,10 @@ func TestEmitToolSpans(t *testing.T) {
 					}},
 				}},
 			},
-			contentMode: agento11y.ContentCaptureModeMetadataOnly,
-			wantSpans:   1,
-			wantNames:   []string{"Read"},
+			contentMode:   agento11y.ContentCaptureModeMetadataOnly,
+			wantSpans:     1,
+			wantNames:     []string{"Read"},
+			wantDurations: map[string]time.Duration{"Read": 0},
 		},
 		{
 			name: "multiple tool calls with full content and results",
@@ -822,6 +1055,107 @@ func TestEmitToolSpans(t *testing.T) {
 			wantSpans:   1,
 			wantNames:   []string{"Write"},
 		},
+		{
+			name: "tool result timestamp drives duration",
+			gen: agento11y.Generation{
+				CompletedAt: ts,
+				Output: []agento11y.Message{{
+					Role: agento11y.RoleAssistant,
+					Parts: []agento11y.Part{{
+						Kind:     agento11y.PartKindToolCall,
+						ToolCall: &agento11y.ToolCall{ID: "tc_1", Name: "Bash"},
+					}},
+				}},
+			},
+			resultAt:      map[string]time.Time{"tc_1": ts.Add(1200 * time.Millisecond)},
+			contentMode:   agento11y.ContentCaptureModeMetadataOnly,
+			wantSpans:     1,
+			wantNames:     []string{"Bash"},
+			wantDurations: map[string]time.Duration{"Bash": 1200 * time.Millisecond},
+		},
+		{
+			name: "zero result timestamp collapses to zero width",
+			gen: agento11y.Generation{
+				CompletedAt: ts,
+				Output: []agento11y.Message{{
+					Role: agento11y.RoleAssistant,
+					Parts: []agento11y.Part{{
+						Kind:     agento11y.PartKindToolCall,
+						ToolCall: &agento11y.ToolCall{ID: "tc_1", Name: "Bash"},
+					}},
+				}},
+			},
+			// The mapper drops unparseable timestamps rather than storing the
+			// zero value, so this pins the window against a caller that does not.
+			resultAt:      map[string]time.Time{"tc_1": {}},
+			contentMode:   agento11y.ContentCaptureModeMetadataOnly,
+			wantSpans:     1,
+			wantNames:     []string{"Bash"},
+			wantDurations: map[string]time.Duration{"Bash": 0},
+		},
+		{
+			// A zero generation completion is the case that used to invert the
+			// span: the SDK stamps the start with the current time, which is
+			// after every transcript timestamp. Both ends move to the result.
+			name: "zero generation completion anchors on the result",
+			gen: agento11y.Generation{
+				Output: []agento11y.Message{{
+					Role: agento11y.RoleAssistant,
+					Parts: []agento11y.Part{{
+						Kind:     agento11y.PartKindToolCall,
+						ToolCall: &agento11y.ToolCall{ID: "tc_1", Name: "Bash"},
+					}},
+				}},
+			},
+			resultAt:      map[string]time.Time{"tc_1": ts},
+			contentMode:   agento11y.ContentCaptureModeMetadataOnly,
+			wantSpans:     1,
+			wantNames:     []string{"Bash"},
+			wantStarts:    map[string]time.Time{"Bash": ts},
+			wantDurations: map[string]time.Duration{"Bash": 0},
+		},
+		{
+			name: "result before the call clamps to zero width",
+			gen: agento11y.Generation{
+				CompletedAt: ts,
+				Output: []agento11y.Message{{
+					Role: agento11y.RoleAssistant,
+					Parts: []agento11y.Part{{
+						Kind:     agento11y.PartKindToolCall,
+						ToolCall: &agento11y.ToolCall{ID: "tc_1", Name: "Bash"},
+					}},
+				}},
+			},
+			resultAt:      map[string]time.Time{"tc_1": ts.Add(-time.Second)},
+			contentMode:   agento11y.ContentCaptureModeMetadataOnly,
+			wantSpans:     1,
+			wantNames:     []string{"Bash"},
+			wantDurations: map[string]time.Duration{"Bash": 0},
+		},
+		{
+			name: "parallel calls keep distinct ends",
+			gen: agento11y.Generation{
+				CompletedAt: ts,
+				Output: []agento11y.Message{{
+					Role: agento11y.RoleAssistant,
+					Parts: []agento11y.Part{
+						{Kind: agento11y.PartKindToolCall, ToolCall: &agento11y.ToolCall{ID: "tc_1", Name: "Read"}},
+						{Kind: agento11y.PartKindToolCall, ToolCall: &agento11y.ToolCall{ID: "tc_2", Name: "Bash"}},
+					},
+				}},
+			},
+			resultAt: map[string]time.Time{
+				"tc_1": ts.Add(500 * time.Millisecond),
+				"tc_2": ts.Add(1200 * time.Millisecond),
+			},
+			contentMode: agento11y.ContentCaptureModeMetadataOnly,
+			wantSpans:   2,
+			wantNames:   []string{"Read", "Bash"},
+			wantDurations: map[string]time.Duration{
+				"Read": 500 * time.Millisecond,
+				"Bash": 1200 * time.Millisecond,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -832,7 +1166,7 @@ func TestEmitToolSpans(t *testing.T) {
 				results = map[string]*agento11y.ToolResult{}
 			}
 
-			emitToolSpans(context.Background(), client, tt.gen, results)
+			emitToolSpans(context.Background(), client, tt.gen, results, tt.resultAt)
 			_ = client.Shutdown(context.Background())
 
 			toolSpans := spansByName(recorder.Ended(), "execute_tool")
@@ -865,6 +1199,16 @@ func TestEmitToolSpans(t *testing.T) {
 						}
 					}
 				}
+				if want, ok := tt.wantStarts[wantName]; ok {
+					if got := s.StartTime(); !got.Equal(want) {
+						t.Errorf("span[%d] start = %v, want %v", i, got, want)
+					}
+				}
+				if want, ok := tt.wantDurations[wantName]; ok {
+					if got := s.EndTime().Sub(s.StartTime()); got != want {
+						t.Errorf("span[%d] duration = %v, want %v", i, got, want)
+					}
+				}
 			}
 		})
 	}
@@ -888,7 +1232,7 @@ func TestEmitToolSpans_ErrorStatus(t *testing.T) {
 		"tc_err": {ToolCallID: "tc_err", Content: "denied", IsError: true},
 	}
 
-	emitToolSpans(context.Background(), client, gen, results)
+	emitToolSpans(context.Background(), client, gen, results, nil)
 	_ = client.Shutdown(context.Background())
 
 	spans := spansByName(recorder.Ended(), "execute_tool")

--- a/plugins/agento11y/internal/agents/claudecode/mapper/integration_test.go
+++ b/plugins/agento11y/internal/agents/claudecode/mapper/integration_test.go
@@ -36,7 +36,7 @@ func TestIntegration_EndToEnd(t *testing.T) {
 	}
 
 	coalesced, safeOffset := Coalesce(lines)
-	gens := Process(coalesced, &st, Options{SessionID: "sess-integration"}, redact.New())
+	gens, _ := Process(coalesced, &st, Options{SessionID: "sess-integration"}, redact.New())
 	if len(gens) == 0 {
 		t.Fatal("expected at least 1 generation")
 	}
@@ -97,7 +97,7 @@ func TestIntegration_EndToEnd(t *testing.T) {
 	}
 
 	coalesced3, _ := Coalesce(lines3)
-	gens3 := Process(coalesced3, &st2, Options{SessionID: "sess-integration"}, nil)
+	gens3, _ := Process(coalesced3, &st2, Options{SessionID: "sess-integration"}, nil)
 	if len(gens3) != 1 {
 		t.Fatalf("third run produced %d generations, want 1", len(gens3))
 	}
@@ -122,7 +122,7 @@ func TestIntegration_ConversationTitlePersistence(t *testing.T) {
 	st := state.Load(sessionID)
 	lines, _, _ := transcript.Read(jsonlPath, 0)
 	coalesced, offset := Coalesce(lines)
-	Process(coalesced, &st, Options{SessionID: "sess-title"}, nil)
+	_, _ = Process(coalesced, &st, Options{SessionID: "sess-title"}, nil)
 	st.Offset = offset
 	if err := state.Save(sessionID, st); err != nil {
 		t.Fatal(err)
@@ -170,7 +170,7 @@ func TestIntegration_StreamingFragments(t *testing.T) {
 		t.Fatalf("got %d coalesced lines, want 2", len(coalesced))
 	}
 
-	gens := Process(coalesced, st, Options{SessionID: "sess-stream"}, nil)
+	gens, _ := Process(coalesced, st, Options{SessionID: "sess-stream"}, nil)
 	if len(gens) != 1 {
 		t.Fatalf("got %d generations, want 1", len(gens))
 	}

--- a/plugins/agento11y/internal/agents/claudecode/mapper/live_transcripts_test.go
+++ b/plugins/agento11y/internal/agents/claudecode/mapper/live_transcripts_test.go
@@ -49,7 +49,7 @@ func TestLiveTranscripts(t *testing.T) {
 			}
 			coalesced, safeOffset := Coalesce(lines)
 			st := &state.Session{}
-			gens := Process(coalesced, st, Options{SessionID: "live-test"}, nil)
+			gens, _ := Process(coalesced, st, Options{SessionID: "live-test"}, nil)
 
 			var inTokens, outTokens int64
 			var fieldErrors []string

--- a/plugins/agento11y/internal/agents/claudecode/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/claudecode/mapper/mapper.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/claudecode/transcript"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/mapperutil"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/redact"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/timeutil"
 )
 
 const (
@@ -140,32 +141,46 @@ type agentCall struct {
 	subagentType string               // lowercased subagent_type from tool input; empty falls back to "subagent"
 }
 
-// Process walks transcript lines and produces Generation records.
-// It updates st.Title with the conversation title if discovered.
+// Process walks transcript lines and produces Generation records, plus the
+// timestamp of every tool_result line keyed by tool call ID. The caller uses
+// those timestamps as the end of each execute_tool span; without them a tool
+// span has no width, because a tool call and its result live on separate lines.
+// A tool call ID is present in that map only when its result line carried a
+// parseable timestamp, so a present key always means a usable end time.
+// Process updates st.Title with the conversation title if discovered.
 //
-// Claude Code subagents do not produce their own transcript lines — the only
-// evidence of their execution is the Agent tool_use (spawn) and the matching
-// tool_result (output). Process synthesises a generation for each completed
-// Agent call so that the agento11y dependency graph can display the DAG.
-func Process(lines []transcript.Line, st *state.Session, opts Options, r *redact.Redactor) []agento11y.Generation {
+// Claude Code subagents do not produce their own lines in the main transcript —
+// the only evidence of their execution is the Agent tool_use (spawn) and the
+// matching tool_result (output). Process synthesises a generation for each
+// completed Agent call so that the agento11y dependency graph can display the
+// DAG.
+func Process(lines []transcript.Line, st *state.Session, opts Options, r *redact.Redactor) ([]agento11y.Generation, map[string]time.Time) {
 	var (
 		gens []agento11y.Generation
 		uctx userContext
+		// toolResultAt records when each tool call's result arrived.
+		toolResultAt = map[string]time.Time{}
 		// agentCalls indexes Agent tool_use call IDs to the generation that
 		// emitted them, so we can synthesise subagent generations when the
 		// matching tool_result arrives.
 		agentCalls = make(map[string]agentCall)
+		// prevAt holds the timestamp of the previous processed line per chain,
+		// keyed by line.IsSidechain. A sidechain line belongs to a subagent turn,
+		// so the two chains must not hand each other a request time. Claude Code
+		// writes sidechain lines to separate subagent transcripts, so on the
+		// current format only the main-chain key is ever set.
+		prevAt = map[bool]time.Time{}
 	)
 
 	for _, line := range lines {
 		switch line.Type {
 		case "user":
-			processUserLine(line, &uctx, st, r, opts)
+			processUserLine(line, &uctx, st, r, opts, toolResultAt)
 			// Synthesise subagent generations from Agent tool results.
 			gens = append(gens, synthesiseSubagentGens(line, &uctx, agentCalls, opts)...)
 
 		case "assistant":
-			if gen, ok := processAssistantLine(line, &uctx, st, opts, r); ok {
+			if gen, ok := processAssistantLine(line, &uctx, st, opts, r, prevAt[line.IsSidechain]); ok {
 				// Index Agent tool calls from this generation's output.
 				for _, msg := range gen.Output {
 					for _, part := range msg.Parts {
@@ -185,6 +200,12 @@ func Process(lines []transcript.Line, st *state.Session, opts Options, r *redact
 				gens = append(gens, gen)
 			}
 		}
+
+		// Advance the cursor only after the line is handled: an assistant line
+		// must not seed its own start, or every window collapses to zero.
+		if at := timeutil.ParseTimestamp(line.Timestamp, time.Time{}); !at.IsZero() {
+			prevAt[line.IsSidechain] = at
+		}
 	}
 
 	title := conversationTitle(st, opts.SessionID, r)
@@ -192,7 +213,20 @@ func Process(lines []transcript.Line, st *state.Session, opts Options, r *redact
 		gens[i].ConversationTitle = title
 	}
 
-	return gens
+	return gens, toolResultAt
+}
+
+// clampSpanStart returns the start of a generation window whose end is fixed at
+// completedAt. derivedStart comes from another transcript line, so it is used
+// only when it is present and not after completedAt; anything else collapses the
+// window to completedAt. Transcript timestamps are optional and not strictly
+// monotonic, and a window that inverts reaches the trace store as the unsigned
+// wrap of a negative duration instead of a latency.
+func clampSpanStart(derivedStart, completedAt time.Time) time.Time {
+	if derivedStart.IsZero() || derivedStart.After(completedAt) {
+		return completedAt
+	}
+	return derivedStart
 }
 
 // conversationTitle returns a truncated version of the session title derived
@@ -234,7 +268,11 @@ func synthesiseSubagentGens(line transcript.Line, uctx *userContext, calls map[s
 				continue
 			}
 
-			completedAt, _ := time.Parse(time.RFC3339Nano, line.Timestamp)
+			completedAt := timeutil.ParseTimestamp(line.Timestamp, time.Time{})
+
+			// The subagent ran between the spawning turn's completion and the
+			// tool_result that carries its output.
+			startedAt := clampSpanStart(ac.parentGen.CompletedAt, completedAt)
 
 			suffix := ac.subagentType
 			if suffix == "" {
@@ -253,7 +291,7 @@ func synthesiseSubagentGens(line transcript.Line, uctx *userContext, calls map[s
 				OperationName:       "generateText",
 				Model:               ac.parentGen.Model,
 				StopReason:          "end_turn",
-				StartedAt:           ac.parentGen.CompletedAt,
+				StartedAt:           startedAt,
 				CompletedAt:         completedAt,
 				Tags:                buildTags(line, true, opts.ExtraTags),
 			}
@@ -279,7 +317,11 @@ func subagentGenID(sessionID, toolCallID string) string {
 	return uuid.NewSHA1(uuid.NameSpaceDNS, []byte(sessionID+":subagent:"+toolCallID)).String()
 }
 
-func processUserLine(line transcript.Line, uctx *userContext, st *state.Session, r *redact.Redactor, opts Options) {
+// processUserLine folds one user line into uctx: a plain prompt, or the tool
+// results that answer the previous assistant turn. Every tool result with a
+// parseable line timestamp also records it in toolResultAt, so the caller can
+// give the execute_tool span a real end time.
+func processUserLine(line transcript.Line, uctx *userContext, st *state.Session, r *redact.Redactor, opts Options, toolResultAt map[string]time.Time) {
 	var msg transcript.UserMessage
 	if err := json.Unmarshal(line.Message, &msg); err != nil {
 		opts.logf("unmarshal user message: %v", err)
@@ -301,6 +343,9 @@ func processUserLine(line transcript.Line, uctx *userContext, st *state.Session,
 		return
 	}
 
+	// Every tool_result block on this line shares the line's timestamp.
+	resultAt := timeutil.ParseTimestamp(line.Timestamp, time.Time{})
+
 	var toolParts []agento11y.Part
 	for _, b := range blocks {
 		if b.Type == "text" && b.Text != "" {
@@ -311,6 +356,9 @@ func processUserLine(line transcript.Line, uctx *userContext, st *state.Session,
 			}
 		}
 		if b.Type == "tool_result" {
+			if b.ToolUseID != "" && !resultAt.IsZero() {
+				toolResultAt[b.ToolUseID] = resultAt
+			}
 			content := b.Content()
 			if r != nil {
 				content = r.Redact(content)
@@ -333,7 +381,10 @@ func processUserLine(line transcript.Line, uctx *userContext, st *state.Session,
 	}
 }
 
-func processAssistantLine(line transcript.Line, uctx *userContext, _ *state.Session, opts Options, r *redact.Redactor) (agento11y.Generation, bool) {
+// processAssistantLine maps one coalesced assistant line to a generation.
+// requestAt is the timestamp of the previous line on the same chain, zero when
+// the batch opens on an assistant line.
+func processAssistantLine(line transcript.Line, uctx *userContext, _ *state.Session, opts Options, r *redact.Redactor, requestAt time.Time) (agento11y.Generation, bool) {
 	var msg transcript.AssistantMessage
 	if err := json.Unmarshal(line.Message, &msg); err != nil {
 		opts.logf("unmarshal assistant message: %v", err)
@@ -349,7 +400,12 @@ func processAssistantLine(line transcript.Line, uctx *userContext, _ *state.Sess
 
 	isSidechain := line.IsSidechain
 
-	completedAt, _ := time.Parse(time.RFC3339Nano, line.Timestamp)
+	completedAt := timeutil.ParseTimestamp(line.Timestamp, time.Time{})
+
+	// The transcript records no request-start time. The previous line on this
+	// chain (the user prompt, or the tool_result that unblocked the turn) is the
+	// closest real one.
+	startedAt := clampSpanStart(requestAt, completedAt)
 
 	usage := agento11y.TokenUsage{
 		InputTokens:           msg.Usage.InputTokens,
@@ -376,7 +432,7 @@ func processAssistantLine(line transcript.Line, uctx *userContext, _ *state.Sess
 		ResponseModel: msg.Model,
 		Usage:         usage,
 		StopReason:    msg.StopReason,
-		StartedAt:     completedAt, // no real start time; set equal to avoid zero-value skip in SDK metrics
+		StartedAt:     startedAt,
 		CompletedAt:   completedAt,
 		Tags:          buildTags(line, isSidechain, opts.ExtraTags),
 	}

--- a/plugins/agento11y/internal/agents/claudecode/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/claudecode/mapper/mapper_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/grafana/agento11y/go/agento11y"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/claudecode/state"
@@ -83,6 +84,113 @@ func makeMultiToolResultLine(results map[string]string) transcript.Line {
 	}
 }
 
+// atTime returns a copy of line stamped with ts, so timing tests can order
+// lines without changing the shared fixture builders.
+func atTime(line transcript.Line, ts string) transcript.Line {
+	line.Timestamp = ts
+	return line
+}
+
+// onSidechain marks a line as belonging to a subagent chain.
+func onSidechain(line transcript.Line) transcript.Line {
+	line.IsSidechain = true
+	return line
+}
+
+// TestProcess_GenerationWindowFromPrecedingLine covers the derived generation
+// start: the transcript has no request-start field, so the previous line on the
+// same chain stands in for it, clamped because transcript timestamps are not
+// strictly monotonic.
+func TestProcess_GenerationWindowFromPrecedingLine(t *testing.T) {
+	const (
+		t0      = "2025-06-01T12:00:00Z"
+		t0Plus1 = "2025-06-01T12:00:01Z"
+		t0Plus2 = "2025-06-01T12:00:02Z"
+		t0Plus3 = "2025-06-01T12:00:03Z"
+	)
+	reply := func(requestID, ts string) transcript.Line {
+		return atTime(makeAssistantFragment(requestID, 40, []transcript.ContentBlock{
+			{Type: "text", Text: "done"},
+		}, "end_turn"), ts)
+	}
+
+	// window is the expected window of one produced generation, in order.
+	type window struct {
+		start     string
+		duration  time.Duration
+		sidechain bool
+	}
+
+	tests := []struct {
+		name  string
+		lines []transcript.Line
+		want  []window
+	}{
+		{
+			name: "assistant reply after tool result",
+			lines: []transcript.Line{
+				atTime(makeToolResultLine("tu_1", "ok"), t0),
+				reply("req-a", t0Plus2),
+			},
+			want: []window{{start: t0, duration: 2 * time.Second}},
+		},
+		{
+			name: "non-monotonic transcript clamps to completion",
+			lines: []transcript.Line{
+				atTime(makeUserLine("hello"), t0Plus1),
+				reply("req-a", t0),
+			},
+			want: []window{{start: t0, duration: 0}},
+		},
+		{
+			name:  "batch starts with an assistant line",
+			lines: []transcript.Line{reply("req-a", t0)},
+			want:  []window{{start: t0, duration: 0}},
+		},
+		{
+			// The reason prevAt is keyed by chain: each reply must take the
+			// timestamp of its own chain's previous line, not of the line that
+			// happens to sit before it in the file.
+			name: "interleaved chains keep separate cursors",
+			lines: []transcript.Line{
+				onSidechain(atTime(makeUserLine("spawn subagent work"), t0)),
+				atTime(makeUserLine("unrelated main-chain prompt"), t0Plus1),
+				onSidechain(reply("req-side", t0Plus2)),
+				reply("req-main", t0Plus3),
+			},
+			want: []window{
+				{start: t0, duration: 2 * time.Second, sidechain: true},
+				{start: t0Plus1, duration: 2 * time.Second},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gens, _ := Process(tt.lines, &state.Session{}, Options{SessionID: "sess-1"}, nil)
+			if len(gens) != len(tt.want) {
+				t.Fatalf("got %d generations, want %d", len(gens), len(tt.want))
+			}
+
+			for i, want := range tt.want {
+				wantStart, err := time.Parse(time.RFC3339, want.start)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !gens[i].StartedAt.Equal(wantStart) {
+					t.Errorf("gen[%d].StartedAt = %v, want %v", i, gens[i].StartedAt, wantStart)
+				}
+				if got := gens[i].CompletedAt.Sub(gens[i].StartedAt); got != want.duration {
+					t.Errorf("gen[%d] window = %v, want %v", i, got, want.duration)
+				}
+				if got := gens[i].Tags["subagent"] == "true"; got != want.sidechain {
+					t.Errorf("gen[%d] subagent = %v, want %v", i, got, want.sidechain)
+				}
+			}
+		})
+	}
+}
+
 func TestProcess_SinglePromptResponse(t *testing.T) {
 	lines := []transcript.Line{
 		makeUserLine("What is Go?"),
@@ -92,7 +200,7 @@ func TestProcess_SinglePromptResponse(t *testing.T) {
 	}
 
 	st := &state.Session{}
-	gens := Process(lines, st, Options{SessionID: "sess-1"}, nil)
+	gens, _ := Process(lines, st, Options{SessionID: "sess-1"}, nil)
 
 	if len(gens) != 1 {
 		t.Fatalf("got %d generations, want 1", len(gens))
@@ -147,7 +255,7 @@ func TestProcess_SkippedLines(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			st := &state.Session{}
-			gens := Process(tt.lines, st, Options{SessionID: "sess-1"}, nil)
+			gens, _ := Process(tt.lines, st, Options{SessionID: "sess-1"}, nil)
 			if len(gens) != 0 {
 				t.Errorf("got %d generations, want 0", len(gens))
 			}
@@ -162,7 +270,7 @@ func TestProcess_SubagentTag(t *testing.T) {
 	line.IsSidechain = true
 
 	st := &state.Session{}
-	gens := Process([]transcript.Line{line}, st, Options{SessionID: "sess-1"}, nil)
+	gens, _ := Process([]transcript.Line{line}, st, Options{SessionID: "sess-1"}, nil)
 
 	if len(gens) != 1 {
 		t.Fatalf("got %d generations, want 1 (sidechain should not be skipped)", len(gens))
@@ -192,7 +300,7 @@ func TestProcess_ContentModes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			st := &state.Session{}
-			gens := Process(lines, st, Options{SessionID: "sess-1"}, tt.redactor)
+			gens, _ := Process(lines, st, Options{SessionID: "sess-1"}, tt.redactor)
 			if len(gens) != 1 {
 				t.Fatal("expected 1 generation")
 			}
@@ -278,7 +386,7 @@ func TestProcess_ConversationTitle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			st := tt.state
-			gens := Process(tt.lines, &st, Options{SessionID: "sess-1"}, nil)
+			gens, _ := Process(tt.lines, &st, Options{SessionID: "sess-1"}, nil)
 
 			if st.Title != tt.wantTitle {
 				t.Errorf("state.Title = %q, want %q", st.Title, tt.wantTitle)
@@ -309,7 +417,7 @@ func TestProcess_ToolUses(t *testing.T) {
 	}
 
 	st := &state.Session{}
-	gens := Process(lines, st, Options{SessionID: "sess-1"}, nil)
+	gens, _ := Process(lines, st, Options{SessionID: "sess-1"}, nil)
 
 	if len(gens) != 2 {
 		t.Fatalf("got %d generations, want 2", len(gens))
@@ -329,7 +437,7 @@ func TestProcess_DeduplicatedTools(t *testing.T) {
 	}
 
 	st := &state.Session{}
-	gens := Process(lines, st, Options{SessionID: "sess-1"}, nil)
+	gens, _ := Process(lines, st, Options{SessionID: "sess-1"}, nil)
 
 	if len(gens[0].Tools) != 2 {
 		t.Fatalf("got %d tools, want 2 (deduplicated)", len(gens[0].Tools))
@@ -349,7 +457,7 @@ func TestProcess_ThinkingEnabled(t *testing.T) {
 	}
 
 	st := &state.Session{}
-	gens := Process(lines, st, Options{SessionID: "sess-1"}, nil)
+	gens, _ := Process(lines, st, Options{SessionID: "sess-1"}, nil)
 
 	if len(gens) != 1 {
 		t.Fatal("expected 1 generation")
@@ -368,7 +476,7 @@ func TestProcess_ContentCaptureRedaction(t *testing.T) {
 	}
 
 	st := &state.Session{}
-	gens := Process(lines, st, Options{SessionID: "sess-1"}, redact.New())
+	gens, _ := Process(lines, st, Options{SessionID: "sess-1"}, redact.New())
 
 	gen := gens[0]
 	// User prompt gets Tier 1 redaction
@@ -427,7 +535,7 @@ func TestProcess_Tags(t *testing.T) {
 			line.Entrypoint = tt.entry
 
 			st := &state.Session{}
-			gens := Process([]transcript.Line{line}, st, Options{SessionID: "sess-1", ExtraTags: tt.extras}, nil)
+			gens, _ := Process([]transcript.Line{line}, st, Options{SessionID: "sess-1", ExtraTags: tt.extras}, nil)
 
 			tags := gens[0].Tags
 			if (tags == nil) != tt.wantNil {
@@ -439,6 +547,155 @@ func TestProcess_Tags(t *testing.T) {
 			for k, v := range tt.wantTags {
 				if tags[k] != v {
 					t.Errorf("tags[%q] = %q, want %q", k, tags[k], v)
+				}
+			}
+		})
+	}
+}
+
+// TestProcess_SubagentWindow covers the synthesised subagent generation: it runs
+// from the spawning turn's completion to the tool_result that carries the
+// subagent output, clamped when the transcript is not monotonic.
+func TestProcess_SubagentWindow(t *testing.T) {
+	const (
+		promptAt = "2025-06-01T12:00:00Z"
+		spawnAt  = "2025-06-01T12:00:01Z"
+		resultAt = "2025-06-01T12:00:02.2Z"
+	)
+	spawn := func(ts string) transcript.Line {
+		return atTime(makeAssistantFragment("req-a", 30, []transcript.ContentBlock{
+			{Type: "tool_use", ID: "agent_1", Name: "Agent", Input: json.RawMessage(`{"subagent_type":"explore"}`)},
+		}, "tool_use"), ts)
+	}
+
+	tests := []struct {
+		name         string
+		spawnLineAt  string
+		resultLineAt string
+		wantStart    string
+		wantDuration time.Duration
+	}{
+		{
+			name:         "result after the spawning turn",
+			spawnLineAt:  spawnAt,
+			resultLineAt: resultAt,
+			wantStart:    spawnAt,
+			wantDuration: 1200 * time.Millisecond,
+		},
+		{
+			name:         "result before the spawning turn clamps to zero width",
+			spawnLineAt:  spawnAt,
+			resultLineAt: promptAt,
+			wantStart:    promptAt,
+			wantDuration: 0,
+		},
+		{
+			// Without a spawn timestamp the parent completion is the zero time.
+			// Keeping it would leave the span start to wall clock while the span
+			// ended in the past, which is the inversion this ticket removes.
+			name:         "spawning turn without a timestamp collapses to the result",
+			spawnLineAt:  "",
+			resultLineAt: resultAt,
+			wantStart:    resultAt,
+			wantDuration: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := []transcript.Line{
+				atTime(makeUserLine("research this"), promptAt),
+				spawn(tt.spawnLineAt),
+				atTime(makeToolResultLine("agent_1", "agent output"), tt.resultLineAt),
+			}
+			gens, _ := Process(lines, &state.Session{}, Options{SessionID: "sess-1"}, nil)
+			if len(gens) != 2 {
+				t.Fatalf("got %d generations, want 2 (spawning turn, subagent)", len(gens))
+			}
+			sub := gens[1]
+			if sub.AgentName != agentName+"/explore" {
+				t.Fatalf("gen[1].AgentName = %q, want the synthesised subagent", sub.AgentName)
+			}
+
+			wantStart, err := time.Parse(time.RFC3339Nano, tt.wantStart)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !sub.StartedAt.Equal(wantStart) {
+				t.Errorf("StartedAt = %v, want %v", sub.StartedAt, wantStart)
+			}
+			if got := sub.CompletedAt.Sub(sub.StartedAt); got != tt.wantDuration {
+				t.Errorf("window = %v, want %v", got, tt.wantDuration)
+			}
+		})
+	}
+}
+
+// TestProcess_ToolResultTimestamps covers the second return value: when each
+// tool call's result arrived, which the hook turns into the end of the
+// execute_tool span. A call is in the map only when its result line carried a
+// parseable timestamp.
+func TestProcess_ToolResultTimestamps(t *testing.T) {
+	const (
+		callAt   = "2025-06-01T12:00:00Z"
+		firstAt  = "2025-06-01T12:00:00.5Z"
+		secondAt = "2025-06-01T12:00:01.2Z"
+	)
+	call := atTime(makeAssistantFragment("req-a", 30, []transcript.ContentBlock{
+		{Type: "tool_use", ID: "tu_1", Name: "Read", Input: json.RawMessage(`{}`)},
+		{Type: "tool_use", ID: "tu_2", Name: "Bash", Input: json.RawMessage(`{}`)},
+	}, "tool_use"), callAt)
+
+	tests := []struct {
+		name  string
+		lines []transcript.Line
+		want  map[string]string // tool call ID -> RFC3339 timestamp
+	}{
+		{
+			name: "parallel results keep their own timestamps",
+			lines: []transcript.Line{
+				call,
+				atTime(makeToolResultLine("tu_1", "contents"), firstAt),
+				atTime(makeToolResultLine("tu_2", "ok"), secondAt),
+			},
+			want: map[string]string{"tu_1": firstAt, "tu_2": secondAt},
+		},
+		{
+			name:  "result without a timestamp is absent",
+			lines: []transcript.Line{call, makeToolResultLine("tu_1", "contents")},
+			want:  map[string]string{},
+		},
+		{
+			name:  "result with an unparseable timestamp is absent",
+			lines: []transcript.Line{call, atTime(makeToolResultLine("tu_1", "contents"), "not-a-timestamp")},
+			want:  map[string]string{},
+		},
+		{
+			name:  "call without a result is absent",
+			lines: []transcript.Line{call},
+			want:  map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, resultAt := Process(tt.lines, &state.Session{}, Options{SessionID: "sess-1"}, nil)
+
+			if len(resultAt) != len(tt.want) {
+				t.Fatalf("got %d tool-result timestamps (%v), want %d", len(resultAt), resultAt, len(tt.want))
+			}
+			for id, wantRaw := range tt.want {
+				got, ok := resultAt[id]
+				if !ok {
+					t.Errorf("missing timestamp for %q", id)
+					continue
+				}
+				want, err := time.Parse(time.RFC3339, wantRaw)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !got.Equal(want) {
+					t.Errorf("%s = %v, want %v", id, got, want)
 				}
 			}
 		})
@@ -458,7 +715,7 @@ func TestProcess_ToolResultsInInput(t *testing.T) {
 	}
 
 	st := &state.Session{}
-	gens := Process(lines, st, Options{SessionID: "sess-1"}, redact.New())
+	gens, _ := Process(lines, st, Options{SessionID: "sess-1"}, redact.New())
 
 	if len(gens) != 2 {
 		t.Fatalf("got %d gens, want 2", len(gens))
@@ -699,7 +956,7 @@ func TestCoalesce_PreservesContextWhenAssistantArrivesInLaterBatch(t *testing.T)
 		t.Fatalf("second Coalesce offset = %d, want 300", secondOffset)
 	}
 
-	gens := Process(secondLines, &state.Session{}, Options{SessionID: "sess-1"}, nil)
+	gens, _ := Process(secondLines, &state.Session{}, Options{SessionID: "sess-1"}, nil)
 	if len(gens) != 1 {
 		t.Fatalf("got %d generations, want 1", len(gens))
 	}
@@ -759,7 +1016,7 @@ func TestProcess_ToolResultContentFormats(t *testing.T) {
 			}
 
 			st := &state.Session{}
-			gens := Process(lines, st, Options{SessionID: "sess-1"}, redact.New())
+			gens, _ := Process(lines, st, Options{SessionID: "sess-1"}, redact.New())
 
 			if len(gens) != 2 {
 				t.Fatalf("got %d gens, want 2", len(gens))
@@ -983,7 +1240,7 @@ func TestProcess_ParentGenerationIDs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			st := &state.Session{}
-			gens := Process(tt.lines, st, Options{SessionID: "sess-1"}, nil)
+			gens, _ := Process(tt.lines, st, Options{SessionID: "sess-1"}, nil)
 
 			if len(gens) != tt.wantGenCount {
 				t.Fatalf("got %d generations, want %d", len(gens), tt.wantGenCount)
@@ -1026,7 +1283,7 @@ func TestProcess_EffectiveVersionStableAcrossToolSubsets(t *testing.T) {
 	}
 
 	st := &state.Session{}
-	gens := Process(lines, st, Options{SessionID: "sess-1"}, nil)
+	gens, _ := Process(lines, st, Options{SessionID: "sess-1"}, nil)
 
 	if len(gens) != 2 {
 		t.Fatalf("got %d generations, want 2", len(gens))
@@ -1062,7 +1319,7 @@ func TestProcess_UserPromptRedaction(t *testing.T) {
 			}
 
 			st := &state.Session{}
-			gens := Process(lines, st, Options{SessionID: "sess-1"}, tt.redactor)
+			gens, _ := Process(lines, st, Options{SessionID: "sess-1"}, tt.redactor)
 
 			if gens[0].Input == nil {
 				t.Fatal("expected Input to be present")


### PR DESCRIPTION
The claudecode hook left `StartedAt` unset, so the SDK stamped the span start with `time.Now()` and the end with the transcript timestamp. The hook runs after the turn, so generation span tiems could be incorrect.

`generationStart()` now passes the mapped `StartedAt`, as the codex, cursor and other plugins do.