### PR TITLE
fix(plugins/agento11y): improve doctor endpoint checks

### DIFF
--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -96,7 +96,7 @@ A plugin can only export fields the host agent passes through to it, so individu
 
 ## Troubleshooting
 
-Run `agento11y doctor` first. It's a read-only diagnostic that reports both export pipelines, config, and installed host-agent plugins in one place:
+Run `agento11y doctor` first. It's a read-only diagnostic that reports both export pipelines, config, and installed host-agent plugins in one place. It sends a lightweight request to each endpoint and reports the HTTP status, so a wrong endpoint or a token missing a scope shows up as a broken pipeline:
 
 ```sh
 agento11y doctor
@@ -108,12 +108,6 @@ The two pipelines are independent and fail independently:
 - **Analytics** (the Agent Observability metrics and traces) export over `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT` (or `OTEL_EXPORTER_OTLP_ENDPOINT`). The token needs `metrics:write` and `traces:write`.
 
 The common failure is conversations showing up while the analytics page stays empty: the OTLP endpoint is unset, or the token lacks the metrics/traces scopes. `agento11y doctor` flags that case explicitly and exits non-zero when a pipeline is broken.
-
-Add `--probe` to send a lightweight request to each endpoint and report the HTTP status:
-
-```sh
-agento11y doctor --probe
-```
 
 A 403 means the token is missing a write scope. A 401 means the endpoint refused the credentials without saying why: the token may be invalid or expired, or `AGENTO11Y_AUTH_TENANT_ID` may be wrong.
 

--- a/plugins/agento11y/internal/agents/claudecode/launch.go
+++ b/plugins/agento11y/internal/agents/claudecode/launch.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -109,13 +111,16 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 }
 
 // Status reports whether the Claude Code plugin is installed for the current
-// working directory. It reuses the read-only pluginInstalled probe and never
-// installs, updates, or writes update-check state — `agento11y doctor` relies on
-// this. installed_plugins.json carries no version, so version is always empty
-// (best-effort).
+// working directory, and which build. It reuses the read-only store read and
+// never installs, updates, or writes update-check state — `agento11y doctor`
+// relies on this. A record with no build field reports an unknown version
+// rather than an error: the store belongs to Claude Code.
 func Status(_ context.Context) (installed bool, version string, err error) {
-	installed, err = pluginInstalled()
-	return installed, "", err
+	key, entry, err := installedPluginRecord()
+	if err != nil || key == "" {
+		return false, "", err
+	}
+	return true, entry.build(), nil
 }
 
 func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {
@@ -183,10 +188,29 @@ type installedPluginsFile struct {
 // installedPluginEntry captures the subset of fields we need from each
 // entry in the per-key install array. Claude Code tracks `scope`
 // (`user`, `project`, or `local`) and, for the per-directory scopes,
-// the absolute `projectPath` the install is bound to.
+// the absolute `projectPath` the install is bound to. It also records the
+// build: `version` from the plugin manifest plus the full `gitCommitSha`.
 type installedPluginEntry struct {
-	Scope       string `json:"scope"`
-	ProjectPath string `json:"projectPath"`
+	Scope        string `json:"scope"`
+	ProjectPath  string `json:"projectPath"`
+	Version      string `json:"version"`
+	GitCommitSha string `json:"gitCommitSha"`
+}
+
+// unknownStoreVersion is what Claude Code writes into `version` for a plugin
+// whose manifest declares none. Other entries get the short commit sha instead,
+// so both spellings of "the manifest declared nothing" appear in one store.
+const unknownStoreVersion = "unknown"
+
+// build returns the entry's build identifier: the manifest version when it has
+// one, otherwise the commit the plugin was installed from. Our plugin manifest
+// declares no version, so this is a sha today, which the renderer labels as a
+// commit rather than printing it as a version.
+func (e installedPluginEntry) build() string {
+	if e.Version == "" || e.Version == unknownStoreVersion {
+		return e.GitCommitSha
+	}
+	return e.Version
 }
 
 // pluginInstalled reports whether the Claude Code plugin is registered in
@@ -196,12 +220,19 @@ func pluginInstalled() (bool, error) {
 	return key != "", err
 }
 
-// installedPluginKey returns the `<plugin>@<marketplace>` key registering
-// the plugin for the current working directory, preferring the current
-// plugin name over the legacy pre-rename one; empty when not installed.
-// Legacy keys count as installed because Claude Code itself migrates them to
-// the current name at session start via the marketplace renames map —
-// reinstalling on top would be redundant.
+// installedPluginKey returns the `<plugin>@<marketplace>` key registering the
+// plugin for the current working directory; empty when not installed.
+func installedPluginKey() (string, error) {
+	key, _, err := installedPluginRecord()
+	return key, err
+}
+
+// installedPluginRecord returns the `<plugin>@<marketplace>` key registering
+// the plugin for the current working directory and the entry it matched,
+// preferring the current plugin name over the legacy pre-rename one; an empty
+// key means not installed. Legacy keys count as installed because Claude Code
+// itself migrates them to the current name at session start via the
+// marketplace renames map — reinstalling on top would be redundant.
 //
 // Claude Code records per-entry `scope` and `projectPath`: `user` scope
 // is active in every session, while `project` and `local` only apply when
@@ -210,29 +241,36 @@ func pluginInstalled() (bool, error) {
 // unrelated project suppress bootstrap here, leaving agento11y hooks inactive.
 // Marketplace alias is intentionally ignored so a foreign alias is not
 // reinstalled on top of.
-func installedPluginKey() (string, error) {
+func installedPluginRecord() (string, installedPluginEntry, error) {
 	path, err := installedPluginsPath()
 	if err != nil {
-		return "", err
+		return "", installedPluginEntry{}, err
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return "", nil
+			return "", installedPluginEntry{}, nil
 		}
-		return "", fmt.Errorf("read %s: %w", path, err)
+		return "", installedPluginEntry{}, fmt.Errorf("read %s: %w", path, err)
 	}
 	var f installedPluginsFile
 	if err := json.Unmarshal(data, &f); err != nil {
-		return "", fmt.Errorf("parse %s: %w", path, err)
+		return "", installedPluginEntry{}, fmt.Errorf("parse %s: %w", path, err)
 	}
 	cwd, err := getwd()
 	if err != nil {
-		return "", fmt.Errorf("resolve cwd: %w", err)
+		return "", installedPluginEntry{}, fmt.Errorf("resolve cwd: %w", err)
 	}
 	cwdClean := filepath.Clean(cwd)
-	var legacyKey string
-	for key, raw := range f.Plugins {
+	var (
+		legacyKey   string
+		legacyEntry installedPluginEntry
+	)
+	// Keys are scanned in sorted order because the same plugin can be registered
+	// under two marketplace aliases, and both the current-name match and the
+	// legacy one would otherwise report a build that flaps with Go's map order.
+	for _, key := range slices.Sorted(maps.Keys(f.Plugins)) {
+		raw := f.Plugins[key]
 		isCurrent := strings.HasPrefix(key, PluginName+"@")
 		if !isCurrent && !strings.HasPrefix(key, legacyPluginName+"@") {
 			continue
@@ -248,13 +286,13 @@ func installedPluginKey() (string, error) {
 				continue
 			}
 			if isCurrent {
-				return key, nil
+				return key, e, nil
 			}
-			legacyKey = key
+			legacyKey, legacyEntry = key, e
 			break
 		}
 	}
-	return legacyKey, nil
+	return legacyKey, legacyEntry, nil
 }
 
 // installedPluginsPath returns the path to Claude Code's

--- a/plugins/agento11y/internal/agents/claudecode/launch_test.go
+++ b/plugins/agento11y/internal/agents/claudecode/launch_test.go
@@ -717,13 +717,91 @@ func TestLaunch_RefreshesInstalledPlugin(t *testing.T) {
 }
 
 func TestStatus(t *testing.T) {
+	const sha = "d9db82cfb562487b174006aabbd435d155e59278"
 	tests := []struct {
 		name          string
 		installed     string // installed_plugins.json content; empty means not written
+		cwd           string // getwd stub; empty leaves the real cwd
 		wantInstalled bool
+		wantVersion   string
 	}{
 		{name: "installed", installed: `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"user"}]}}`, wantInstalled: true},
 		{name: "not installed", wantInstalled: false},
+		{
+			name:          "commit-shaped version",
+			installed:     `{"version":2,"plugins":{"agento11y-claude-code@grafana-sigil":[{"scope":"user","version":"d9db82cfb562","gitCommitSha":"` + sha + `"}]}}`,
+			wantInstalled: true,
+			wantVersion:   "d9db82cfb562",
+		},
+		// A manifest version, once one exists, is reported as-is.
+		{
+			name:          "semver version wins over the sha",
+			installed:     `{"version":2,"plugins":{"agento11y-claude-code@agento11y":[{"scope":"user","version":"1.2.3","gitCommitSha":"` + sha + `"}]}}`,
+			wantInstalled: true,
+			wantVersion:   "1.2.3",
+		},
+		{
+			name:          "sha only",
+			installed:     `{"version":2,"plugins":{"agento11y-claude-code@agento11y":[{"scope":"user","gitCommitSha":"` + sha + `"}]}}`,
+			wantInstalled: true,
+			wantVersion:   sha,
+		},
+		// Claude Code writes the literal "unknown" when a manifest declares no
+		// version, which is not a build, so the sha next to it answers.
+		{
+			name:          "unknown version falls back to the sha",
+			installed:     `{"version":2,"plugins":{"agento11y-claude-code@agento11y":[{"scope":"user","version":"unknown","gitCommitSha":"` + sha + `"}]}}`,
+			wantInstalled: true,
+			wantVersion:   sha,
+		},
+		{
+			name:          "unknown version with no sha",
+			installed:     `{"version":2,"plugins":{"agento11y-claude-code@agento11y":[{"scope":"user","version":"unknown"}]}}`,
+			wantInstalled: true,
+		},
+		// Neither build field present: installed with an unknown version, not an
+		// error.
+		{
+			name:          "no build fields",
+			installed:     `{"version":2,"plugins":{"agento11y-claude-code@agento11y":[{"scope":"user"}]}}`,
+			wantInstalled: true,
+		},
+		{
+			name:          "legacy key carries a version",
+			installed:     `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"user","version":"0.9.0"}]}}`,
+			wantInstalled: true,
+			wantVersion:   "0.9.0",
+		},
+		// The current name wins over the legacy one, so its version is reported.
+		{
+			name:          "current name wins over legacy",
+			installed:     `{"version":2,"plugins":{"sigil-cc@grafana-sigil":[{"scope":"user","version":"0.9.0"}],"agento11y-claude-code@agento11y":[{"scope":"user","version":"1.2.3"}]}}`,
+			wantInstalled: true,
+			wantVersion:   "1.2.3",
+		},
+		// Two marketplace aliases can register the same plugin. Keys are scanned in
+		// sorted order, so the reported build is the same on every run.
+		{
+			name:          "two aliases report the first key in sorted order",
+			installed:     `{"version":2,"plugins":{"agento11y-claude-code@grafana-sigil":[{"scope":"user","version":"4.5.6"}],"agento11y-claude-code@agento11y":[{"scope":"user","version":"1.2.3"}]}}`,
+			wantInstalled: true,
+			wantVersion:   "1.2.3",
+		},
+		// A project-scope entry bound to another directory is not installed here,
+		// so its version must not leak into the report.
+		{
+			name:          "project scope for another directory",
+			installed:     `{"version":2,"plugins":{"agento11y-claude-code@agento11y":[{"scope":"project","projectPath":"/elsewhere","version":"1.2.3"}]}}`,
+			cwd:           "/here",
+			wantInstalled: false,
+		},
+		{
+			name:          "project scope for this directory",
+			installed:     `{"version":2,"plugins":{"agento11y-claude-code@agento11y":[{"scope":"project","projectPath":"/here","version":"1.2.3"}]}}`,
+			cwd:           "/here",
+			wantInstalled: true,
+			wantVersion:   "1.2.3",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -732,11 +810,14 @@ func TestStatus(t *testing.T) {
 				writeInstalled(t, dir, tc.installed)
 			}
 			t.Setenv("CLAUDE_CONFIG_DIR", dir)
+			if tc.cwd != "" {
+				withGetwd(t, func() (string, error) { return tc.cwd, nil })
+			}
 
 			installed, version, err := Status(context.Background())
 			require.NoError(t, err)
 			require.Equal(t, tc.wantInstalled, installed)
-			require.Empty(t, version) // installed_plugins.json carries no version
+			require.Equal(t, tc.wantVersion, version)
 		})
 	}
 }

--- a/plugins/agento11y/internal/agents/opencode/launch.go
+++ b/plugins/agento11y/internal/agents/opencode/launch.go
@@ -54,6 +54,7 @@ var (
 	runInstall  = defaultRunInstall
 	runUpdate   = defaultRunUpdate
 	configDirFn = defaultConfigDir
+	cacheDirFn  = defaultCacheDir
 )
 
 // configFileNames lists the basenames opencode recognises for its
@@ -304,10 +305,13 @@ func pluginInstalled() (bool, error) {
 }
 
 // Status reports whether the @grafana/agento11y-opencode plugin is registered
-// in opencode's global config. It reuses the read-only config probe and never
-// installs or updates — `agento11y doctor` relies on this. When the registered
-// spec pins a version (`@grafana/agento11y-opencode@1.2.3`) that version is
-// reported; an unpinned spec yields an empty (unknown) version.
+// in opencode's global config, and which version is installed. It reuses the
+// read-only config probe and never installs or updates — `agento11y doctor`
+// relies on this. The version comes from the package opencode installed into
+// its cache, because the config entry is usually unpinned; a pinned spec
+// (`@grafana/agento11y-opencode@1.2.3`) is the fallback. The cache belongs to
+// opencode, so an absent or unreadable tree means the version is unknown, not
+// an error.
 func Status(_ context.Context) (installed bool, version string, err error) {
 	source, found, err := installedPluginSource()
 	if err != nil {
@@ -316,7 +320,65 @@ func Status(_ context.Context) (installed bool, version string, err error) {
 	if !found {
 		return false, "", nil
 	}
+	if version := cachedVersion(source); version != "" {
+		return true, version, nil
+	}
 	return true, versionFromNpmSpec(source), nil
+}
+
+// cachedVersion returns the version of the plugin opencode installed for a
+// config entry, or "" when it can't be read. opencode installs each plugin
+// spec into its own cache directory named after the spec:
+// <cache>/packages/<spec>/node_modules/<name>. Builds before opencode's cache
+// migration installed straight under <cache>/node_modules/<name>, so that
+// layout is probed second.
+func cachedVersion(source string) string {
+	cache, err := cacheDirFn()
+	if err != nil {
+		return ""
+	}
+	name := stripNpmVersion(source)
+	// A scoped name and a spec both contain a `/`; convert it to the OS
+	// separator so `@scope/pkg` is two directories on Windows too.
+	pkg := filepath.FromSlash(name)
+	candidates := []string{
+		filepath.Join(cache, "packages", filepath.FromSlash(cachedPackageSpec(source)), "node_modules", pkg),
+		filepath.Join(cache, "node_modules", pkg),
+	}
+	for _, dir := range candidates {
+		if version := packageVersion(dir); version != "" {
+			return version
+		}
+	}
+	return ""
+}
+
+// cachedPackageSpec returns the spec opencode installs a config entry as, which
+// is also the name of the cache directory it installs into. opencode rewrites a
+// bare package name to `<name>@latest` and passes anything else through, so a
+// pinned spec and a dist tag keep their own directories.
+func cachedPackageSpec(source string) string {
+	if versionFromNpmSpec(source) == "" {
+		return source + "@latest"
+	}
+	return source
+}
+
+// packageVersion reads the `version` a package directory's package.json
+// declares. A missing, unreadable, or malformed file means unknown — the file
+// belongs to opencode, so doctor never turns it into an error.
+func packageVersion(dir string) string {
+	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		return ""
+	}
+	var pkg struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return ""
+	}
+	return pkg.Version
 }
 
 // installedPluginSource reads opencode's global config and returns the plugin
@@ -444,4 +506,19 @@ func defaultConfigDir() (string, error) {
 		return "", fmt.Errorf("resolve home dir for opencode config: %w", err)
 	}
 	return filepath.Join(home, ".config", "opencode"), nil
+}
+
+// defaultCacheDir returns the directory opencode installs plugin packages
+// into, honouring $XDG_CACHE_HOME (default $HOME/.cache). This is the cache
+// directory, not the config one: opencode keeps its config in
+// $XDG_CONFIG_HOME/opencode and the installed packages here.
+func defaultCacheDir() (string, error) {
+	if dir := os.Getenv("XDG_CACHE_HOME"); filepath.IsAbs(dir) {
+		return filepath.Join(dir, "opencode"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir for opencode cache: %w", err)
+	}
+	return filepath.Join(home, ".cache", "opencode"), nil
 }

--- a/plugins/agento11y/internal/agents/opencode/launch_test.go
+++ b/plugins/agento11y/internal/agents/opencode/launch_test.go
@@ -662,6 +662,27 @@ func withConfigFiles(t *testing.T, files map[string]string) string {
 	return dir
 }
 
+// withCache points cacheDirFn at a temp directory and writes the supplied
+// files into it, creating parent directories. Keys are slash-separated paths
+// relative to the cache directory. Returns the cache directory.
+func withCache(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for rel, contents := range files {
+		path := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	prev := cacheDirFn
+	t.Cleanup(func() { cacheDirFn = prev })
+	cacheDirFn = func() (string, error) { return dir, nil }
+	return dir
+}
+
 func withLookPath(t *testing.T, fn func(string) (string, error)) {
 	t.Helper()
 	prev := lookPath
@@ -723,23 +744,163 @@ func TestVersionFromNpmSpec(t *testing.T) {
 
 func TestStatus(t *testing.T) {
 	tests := []struct {
-		name          string
-		config        string
+		name   string
+		config string
+		// cache holds files written under the fake opencode cache directory,
+		// keyed by slash-separated relative path.
+		cache         map[string]string
 		wantInstalled bool
 		wantVersion   string
 	}{
 		{name: "installed", config: `{"plugin":["@grafana/agento11y-opencode@0.6.0"]}`, wantInstalled: true, wantVersion: "0.6.0"},
 		{name: "legacy name installed", config: `{"plugin":["@grafana/sigil-opencode@0.13.0"]}`, wantInstalled: true, wantVersion: "0.13.0"},
 		{name: "not installed", config: `{"plugin":["other-plugin"]}`, wantInstalled: false},
+		// The common real install: a bare spec, which opencode resolves as
+		// `<name>@latest` and installs into its cache under that raw spec.
+		{
+			name:   "bare spec resolves from the cache tree",
+			config: `{"plugin":["@grafana/agento11y-opencode"]}`,
+			cache: map[string]string{
+				"packages/@grafana/agento11y-opencode@latest/node_modules/@grafana/agento11y-opencode/package.json": `{"name":"@grafana/agento11y-opencode","version":"0.19.0"}`,
+			},
+			wantInstalled: true,
+			wantVersion:   "0.19.0",
+		},
+		{
+			name:   "bare legacy spec resolves from the cache tree",
+			config: `{"plugin":["@grafana/sigil-opencode"]}`,
+			cache: map[string]string{
+				"packages/@grafana/sigil-opencode@latest/node_modules/@grafana/sigil-opencode/package.json": `{"name":"@grafana/sigil-opencode","version":"0.13.0"}`,
+			},
+			wantInstalled: true,
+			wantVersion:   "0.13.0",
+		},
+		// A dist tag is passed through as written, so the cache directory is
+		// named with the tag and only the tree knows the number.
+		{
+			name:   "dist tag resolves from the cache tree",
+			config: `{"plugin":["@grafana/agento11y-opencode@next"]}`,
+			cache: map[string]string{
+				"packages/@grafana/agento11y-opencode@next/node_modules/@grafana/agento11y-opencode/package.json": `{"name":"@grafana/agento11y-opencode","version":"0.20.0-rc.1"}`,
+			},
+			wantInstalled: true,
+			wantVersion:   "0.20.0-rc.1",
+		},
+		// The cache is what opencode loads, so it wins over a disagreeing pin.
+		{
+			name:   "cache tree wins over a disagreeing pinned spec",
+			config: `{"plugin":["@grafana/agento11y-opencode@0.6.0"]}`,
+			cache: map[string]string{
+				"packages/@grafana/agento11y-opencode@0.6.0/node_modules/@grafana/agento11y-opencode/package.json": `{"name":"@grafana/agento11y-opencode","version":"0.6.1"}`,
+			},
+			wantInstalled: true,
+			wantVersion:   "0.6.1",
+		},
+		// A cache directory for a different spec is not what opencode loads for
+		// this config entry, so it must not answer.
+		{
+			name:   "cache tree for another spec is ignored",
+			config: `{"plugin":["@grafana/agento11y-opencode"]}`,
+			cache: map[string]string{
+				"packages/@grafana/agento11y-opencode@0.6.0/node_modules/@grafana/agento11y-opencode/package.json": `{"name":"@grafana/agento11y-opencode","version":"0.6.0"}`,
+			},
+			wantInstalled: true,
+		},
+		// Pre-migration opencode installed plugins straight under the cache root.
+		{
+			name:   "legacy cache layout",
+			config: `{"plugin":["@grafana/agento11y-opencode"]}`,
+			cache: map[string]string{
+				"node_modules/@grafana/agento11y-opencode/package.json": `{"name":"@grafana/agento11y-opencode","version":"0.18.0"}`,
+			},
+			wantInstalled: true,
+			wantVersion:   "0.18.0",
+		},
+		{
+			name:   "current cache layout wins over the legacy one",
+			config: `{"plugin":["@grafana/agento11y-opencode"]}`,
+			cache: map[string]string{
+				"packages/@grafana/agento11y-opencode@latest/node_modules/@grafana/agento11y-opencode/package.json": `{"name":"@grafana/agento11y-opencode","version":"0.19.0"}`,
+				"node_modules/@grafana/agento11y-opencode/package.json":                                             `{"name":"@grafana/agento11y-opencode","version":"0.18.0"}`,
+			},
+			wantInstalled: true,
+			wantVersion:   "0.19.0",
+		},
+		// Cache reads are best-effort: an absent or unreadable tree means the
+		// version is unknown, and a pinned spec still answers.
+		{
+			name:          "bare spec with no cache tree",
+			config:        `{"plugin":["@grafana/agento11y-opencode"]}`,
+			wantInstalled: true,
+		},
+		{
+			name:   "malformed cache package.json falls back to the pinned spec",
+			config: `{"plugin":["@grafana/agento11y-opencode@0.6.0"]}`,
+			cache: map[string]string{
+				"packages/@grafana/agento11y-opencode@0.6.0/node_modules/@grafana/agento11y-opencode/package.json": `{"name":`,
+			},
+			wantInstalled: true,
+			wantVersion:   "0.6.0",
+		},
+		{
+			name:   "cache package.json without a version",
+			config: `{"plugin":["@grafana/agento11y-opencode"]}`,
+			cache: map[string]string{
+				"packages/@grafana/agento11y-opencode@latest/node_modules/@grafana/agento11y-opencode/package.json": `{"name":"@grafana/agento11y-opencode"}`,
+			},
+			wantInstalled: true,
+		},
+		// A tuple entry carries options next to the spec; the spec still resolves.
+		{
+			name:   "tuple entry resolves from the cache tree",
+			config: `{"plugin":[["@grafana/agento11y-opencode",{"foo":true}]]}`,
+			cache: map[string]string{
+				"packages/@grafana/agento11y-opencode@latest/node_modules/@grafana/agento11y-opencode/package.json": `{"name":"@grafana/agento11y-opencode","version":"0.19.0"}`,
+			},
+			wantInstalled: true,
+			wantVersion:   "0.19.0",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			withConfig(t, tc.config)
+			withCache(t, tc.cache)
 
 			installed, version, err := Status(context.Background())
 			require.NoError(t, err)
 			require.Equal(t, tc.wantInstalled, installed)
 			require.Equal(t, tc.wantVersion, version)
+		})
+	}
+}
+
+func TestDefaultCacheDir(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", "/custom/cache")
+	got, err := defaultCacheDir()
+	require.NoError(t, err)
+	assert.Equal(t, "/custom/cache/opencode", got)
+
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("HOME", "/home/user")
+	got, err = defaultCacheDir()
+	require.NoError(t, err)
+	assert.Equal(t, "/home/user/.cache/opencode", got)
+}
+
+func TestCachedPackageSpec(t *testing.T) {
+	cases := []struct {
+		source string
+		want   string
+	}{
+		// opencode rewrites a bare name to `<name>@latest` before installing, and
+		// names the cache directory after the spec it installed.
+		{source: "@grafana/agento11y-opencode", want: "@grafana/agento11y-opencode@latest"},
+		{source: "@grafana/agento11y-opencode@0.6.0", want: "@grafana/agento11y-opencode@0.6.0"},
+		{source: "@grafana/agento11y-opencode@next", want: "@grafana/agento11y-opencode@next"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.source, func(t *testing.T) {
+			require.Equal(t, tc.want, cachedPackageSpec(tc.source))
 		})
 	}
 }

--- a/plugins/agento11y/internal/agents/pi/launch.go
+++ b/plugins/agento11y/internal/agents/pi/launch.go
@@ -221,7 +221,7 @@ func scopeLegacyStatus(path string) (hasLegacy, hasNew bool, err error) {
 			if !filepath.IsAbs(p) {
 				p = filepath.Join(settingsDir, p)
 			}
-			if name, ok := localPackageName(p); ok && name == pluginName {
+			if name, _, ok := localPackage(p); ok && name == pluginName {
 				hasNew = true
 			}
 		}
@@ -248,38 +248,62 @@ type piSettings struct {
 // A missing settings file means that scope is unused — treat as not
 // installed in that scope and move on.
 func pluginInstalled() (bool, error) {
-	_, found, err := installedPluginSource()
+	_, found, err := installedPluginRecord()
 	return found, err
 }
 
 // Status reports whether the @grafana/agento11y-pi extension is registered in
-// pi's settings. It reuses the read-only settings probe and never installs —
-// `agento11y doctor` relies on this. When the registered source is a pinned npm
-// spec (`npm:@grafana/agento11y-pi@0.1.1`) that version is reported; bare specs and
-// local-path installs yield an empty (unknown) version.
+// pi's settings, and which version is installed. It reuses the read-only
+// settings probe and never installs — `agento11y doctor` relies on this. An npm
+// entry reports the version pi installed, because the entry is usually a bare
+// spec (`npm:@grafana/agento11y-pi`) that pins nothing and a pinned spec is only
+// the fallback; a local-path entry reports the version its checkout's
+// package.json declares. Version metadata belongs to pi, so an absent or
+// unreadable tree means the version is unknown, not an error.
 func Status(_ context.Context) (installed bool, version string, err error) {
-	source, found, err := installedPluginSource()
-	if err != nil {
+	plugin, found, err := installedPluginRecord()
+	if err != nil || !found {
 		return false, "", err
 	}
-	if !found {
-		return false, "", nil
-	}
-	return true, versionFromPiSource(source), nil
+	return true, plugin.version(), nil
 }
 
-// installedPluginSource returns the settings source string registering the
+// installedPlugin locates the extension within one pi settings scope: the
+// source string that registers it, the version a local-path source declares,
+// and the directory npm installed the package into. npmDir is empty for a
+// local-path source, since pi loads the checkout and not the npm tree.
+type installedPlugin struct {
+	source       string
+	localVersion string
+	npmDir       string
+}
+
+// version resolves the installed version, exact source first: the package npm
+// installed, then a local checkout's own package.json, then the tail of a
+// pinned npm spec. A local-path entry has no npmDir, which localPackage reports
+// as unreadable.
+func (p installedPlugin) version() string {
+	if _, version, ok := localPackage(p.npmDir); ok && version != "" {
+		return version
+	}
+	if p.localVersion != "" {
+		return p.localVersion
+	}
+	return versionFromPiSource(p.source)
+}
+
+// installedPluginRecord returns the settings entry registering the
 // @grafana/agento11y-pi extension, checking the global settings first and then the
 // project-scoped settings (<cwd>/.pi/settings.json, written by `pi install -l`).
-func installedPluginSource() (source string, found bool, err error) {
+func installedPluginRecord() (installedPlugin, bool, error) {
 	globalPath, err := settingsPath()
 	if err != nil {
-		return "", false, err
+		return installedPlugin{}, false, err
 	}
-	if src, found, err := readSettingsAndCheck(globalPath); err != nil {
-		return "", false, err
+	if p, found, err := scopePlugin(globalPath); err != nil {
+		return installedPlugin{}, false, err
 	} else if found {
-		return src, true, nil
+		return p, true, nil
 	}
 
 	// Pi only consults the literal cwd, no parent walking, so we mirror that.
@@ -287,26 +311,26 @@ func installedPluginSource() (source string, found bool, err error) {
 	// settings available" rather than blocking the launch.
 	projectPath, err := projectSettingsPath()
 	if err != nil {
-		return "", false, nil
+		return installedPlugin{}, false, nil
 	}
-	return readSettingsAndCheck(projectPath)
+	return scopePlugin(projectPath)
 }
 
-// readSettingsAndCheck loads one pi settings file and returns the source
-// string registering the @grafana/agento11y-pi extension, if any. A missing file
-// is not an error — that scope is just unused.
-func readSettingsAndCheck(path string) (source string, found bool, err error) {
+// scopePlugin loads one pi settings file and returns the entry registering the
+// @grafana/agento11y-pi extension, if any. A missing file is not an error —
+// that scope is just unused.
+func scopePlugin(path string) (installedPlugin, bool, error) {
 	sources, err := settingsSources(path)
 	if err != nil {
-		return "", false, err
+		return installedPlugin{}, false, err
 	}
 	settingsDir := filepath.Dir(path)
 	for _, src := range sources {
-		if sourceMatchesPlugin(src, settingsDir) {
-			return src, true, nil
+		if plugin, ok := matchPluginSource(src, settingsDir); ok {
+			return plugin, true, nil
 		}
 	}
-	return "", false, nil
+	return installedPlugin{}, false, nil
 }
 
 // settingsSources loads one pi settings file and returns the source string of
@@ -356,30 +380,46 @@ func versionFromPiSource(source string) string {
 	return after[at+1:]
 }
 
-// sourceMatchesPlugin returns true when a pi settings source identifies the
-// @grafana/agento11y-pi extension (or its legacy @grafana/sigil-pi name). It
-// handles three shapes:
+// matchPluginSource reports whether a pi settings source identifies the
+// @grafana/agento11y-pi extension (or its legacy @grafana/sigil-pi name), and
+// returns the record describing where its version can be read. It handles three
+// shapes:
 //   - bare npm specs: `npm:@grafana/agento11y-pi`
 //   - versioned npm specs: `npm:@grafana/agento11y-pi@<version-or-tag>`
 //   - local paths (absolute or relative to settingsDir) that point at a
 //     directory whose package.json declares `name: "@grafana/agento11y-pi"`
 //
 // git: / https: / ssh: sources are never matched — we don't publish there.
-func sourceMatchesPlugin(source, settingsDir string) bool {
+func matchPluginSource(source, settingsDir string) (installedPlugin, bool) {
 	if source == "" {
-		return false
+		return installedPlugin{}, false
 	}
 	if after, ok := strings.CutPrefix(source, npmPrefix); ok {
-		return matchesPluginName(stripNpmVersion(after))
+		name := stripNpmVersion(after)
+		if !matchesPluginName(name) {
+			return installedPlugin{}, false
+		}
+		// Pi installs npm packages next to the settings file that asked for them:
+		// ~/.pi/agent/npm for the global scope, <cwd>/.pi/npm for a project one.
+		// A scoped name carries a `/`, so convert it to the OS separator to get
+		// npm's two-segment layout on Windows too.
+		npmDir := filepath.Join(settingsDir, "npm", "node_modules", filepath.FromSlash(name))
+		return installedPlugin{source: source, npmDir: npmDir}, true
 	}
 	if filepath.IsAbs(source) || strings.HasPrefix(source, "./") || strings.HasPrefix(source, "../") {
 		path := source
 		if !filepath.IsAbs(path) {
 			path = filepath.Join(settingsDir, path)
 		}
-		return localPathIsPlugin(path)
+		name, version, ok := localPackage(path)
+		if !ok || !matchesPluginName(name) {
+			return installedPlugin{}, false
+		}
+		// A local checkout is what pi loads, so the npm tree is not consulted even
+		// when an earlier npm install left one behind.
+		return installedPlugin{source: source, localVersion: version}, true
 	}
-	return false
+	return installedPlugin{}, false
 }
 
 // stripNpmVersion returns the package name portion of an npm spec, stripping
@@ -401,34 +441,28 @@ func matchesPluginName(name string) bool {
 	return name == pluginName || name == legacyPluginName
 }
 
-// localPathIsPlugin returns true when path is a directory containing a
-// package.json whose name matches the plugin (current or legacy pre-rename
-// name).
-func localPathIsPlugin(path string) bool {
-	name, ok := localPackageName(path)
-	return ok && matchesPluginName(name)
-}
-
-// localPackageName returns the package.json name of a local package
-// directory. Any IO/parse failure means we can't confirm the name — treat as
-// unknown rather than an error, since the settings file may legitimately
-// reference other local packages we don't own.
-func localPackageName(path string) (string, bool) {
+// localPackage returns the name and version a package directory's package.json
+// declares, for both a local source and the tree npm installed. Any IO/parse
+// failure means we can't confirm them — treat as unknown rather than an error,
+// since these files belong to pi or to a checkout we don't own. A package.json
+// with no `version` reports an empty version.
+func localPackage(path string) (name, version string, ok bool) {
 	info, err := os.Stat(path)
 	if err != nil || !info.IsDir() {
-		return "", false
+		return "", "", false
 	}
 	data, err := os.ReadFile(filepath.Join(path, "package.json"))
 	if err != nil {
-		return "", false
+		return "", "", false
 	}
 	var pkg struct {
-		Name string `json:"name"`
+		Name    string `json:"name"`
+		Version string `json:"version"`
 	}
 	if err := json.Unmarshal(data, &pkg); err != nil {
-		return "", false
+		return "", "", false
 	}
-	return pkg.Name, true
+	return pkg.Name, pkg.Version, true
 }
 
 // settingsPath returns the path to pi's global settings.json, honouring

--- a/plugins/agento11y/internal/agents/pi/launch_test.go
+++ b/plugins/agento11y/internal/agents/pi/launch_test.go
@@ -759,6 +759,21 @@ func TestStripNpmVersion(t *testing.T) {
 	}
 }
 
+// writeFiles writes each entry under root, creating parent directories. Keys
+// are slash-separated paths relative to root.
+func writeFiles(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for rel, contents := range files {
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+}
+
 func writeSettings(t *testing.T, dir, contents string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(contents), 0o600); err != nil {
@@ -820,21 +835,162 @@ func TestVersionFromPiSource(t *testing.T) {
 }
 
 func TestStatus(t *testing.T) {
+	// Files are written relative to a temporary cwd. `agent/` is the global
+	// agent directory (PI_CODING_AGENT_DIR) and `.pi/` is the project scope, so
+	// one table covers both, and the real developer's pi state cannot leak in.
 	tests := []struct {
 		name          string
-		settings      string
+		files         map[string]string
 		wantInstalled bool
 		wantVersion   string
 	}{
-		{name: "installed reports version", settings: `{"packages":["npm:@grafana/agento11y-pi@0.1.1"]}`, wantInstalled: true, wantVersion: "0.1.1"},
-		{name: "legacy name installed reports version", settings: `{"packages":["npm:@grafana/sigil-pi@0.17.0"]}`, wantInstalled: true, wantVersion: "0.17.0"},
-		{name: "not installed", settings: `{"packages":[]}`, wantInstalled: false},
+		{
+			name:          "installed reports pinned spec version",
+			files:         map[string]string{"agent/settings.json": `{"packages":["npm:@grafana/agento11y-pi@0.1.1"]}`},
+			wantInstalled: true,
+			wantVersion:   "0.1.1",
+		},
+		{
+			name:          "legacy name installed reports pinned spec version",
+			files:         map[string]string{"agent/settings.json": `{"packages":["npm:@grafana/sigil-pi@0.17.0"]}`},
+			wantInstalled: true,
+			wantVersion:   "0.17.0",
+		},
+		{name: "not installed", files: map[string]string{"agent/settings.json": `{"packages":[]}`}, wantInstalled: false},
+		// The common real install: a bare spec, which pins nothing. Only the tree
+		// npm installed says which version is running.
+		{
+			name: "bare spec resolves from the installed tree",
+			files: map[string]string{
+				"agent/settings.json": `{"packages":["npm:@grafana/agento11y-pi"]}`,
+				"agent/npm/node_modules/@grafana/agento11y-pi/package.json": `{"name":"@grafana/agento11y-pi","version":"0.19.0"}`,
+			},
+			wantInstalled: true,
+			wantVersion:   "0.19.0",
+		},
+		// A pinned spec records what was asked for; the tree records what is there.
+		{
+			name: "installed tree wins over a disagreeing pinned spec",
+			files: map[string]string{
+				"agent/settings.json": `{"packages":["npm:@grafana/agento11y-pi@0.1.1"]}`,
+				"agent/npm/node_modules/@grafana/agento11y-pi/package.json": `{"name":"@grafana/agento11y-pi","version":"0.19.0"}`,
+			},
+			wantInstalled: true,
+			wantVersion:   "0.19.0",
+		},
+		{
+			name: "dist tag resolves from the installed tree",
+			files: map[string]string{
+				"agent/settings.json": `{"packages":["npm:@grafana/agento11y-pi@next"]}`,
+				"agent/npm/node_modules/@grafana/agento11y-pi/package.json": `{"name":"@grafana/agento11y-pi","version":"0.20.0-rc.1"}`,
+			},
+			wantInstalled: true,
+			wantVersion:   "0.20.0-rc.1",
+		},
+		{
+			name: "legacy name resolves from the installed tree",
+			files: map[string]string{
+				"agent/settings.json": `{"packages":["npm:@grafana/sigil-pi"]}`,
+				"agent/npm/node_modules/@grafana/sigil-pi/package.json": `{"name":"@grafana/sigil-pi","version":"0.17.0"}`,
+			},
+			wantInstalled: true,
+			wantVersion:   "0.17.0",
+		},
+		// The tree of another package must not answer for ours.
+		{
+			name: "unrelated installed tree is ignored",
+			files: map[string]string{
+				"agent/settings.json":                                `{"packages":["npm:@grafana/agento11y-pi"]}`,
+				"agent/npm/node_modules/@grafana/other/package.json": `{"name":"@grafana/other","version":"9.9.9"}`,
+			},
+			wantInstalled: true,
+		},
+		// Reads of another tool's files are best-effort: no tree, or an unreadable
+		// one, means the version is unknown, never an error.
+		{
+			name:          "bare spec with no installed tree",
+			files:         map[string]string{"agent/settings.json": `{"packages":["npm:@grafana/agento11y-pi"]}`},
+			wantInstalled: true,
+		},
+		{
+			name: "malformed installed package.json",
+			files: map[string]string{
+				"agent/settings.json": `{"packages":["npm:@grafana/agento11y-pi"]}`,
+				"agent/npm/node_modules/@grafana/agento11y-pi/package.json": `{"name":`,
+			},
+			wantInstalled: true,
+		},
+		{
+			name: "installed package.json without a version",
+			files: map[string]string{
+				"agent/settings.json": `{"packages":["npm:@grafana/agento11y-pi"]}`,
+				"agent/npm/node_modules/@grafana/agento11y-pi/package.json": `{"name":"@grafana/agento11y-pi"}`,
+			},
+			wantInstalled: true,
+		},
+		// A local checkout reports the version its own package.json declares.
+		{
+			name: "local path source reports its package version",
+			files: map[string]string{
+				"agent/settings.json":             `{"packages":["./local-plugin"]}`,
+				"agent/local-plugin/package.json": `{"name":"@grafana/agento11y-pi","version":"0.21.0-dev"}`,
+			},
+			wantInstalled: true,
+			wantVersion:   "0.21.0-dev",
+		},
+		{
+			name: "local path source without a version",
+			files: map[string]string{
+				"agent/settings.json":             `{"packages":["./local-plugin"]}`,
+				"agent/local-plugin/package.json": `{"name":"@grafana/agento11y-pi"}`,
+			},
+			wantInstalled: true,
+		},
+		// A leftover npm tree is not what pi loads for a local-path entry, so the
+		// checkout's own version answers.
+		{
+			name: "local path source ignores a leftover npm tree",
+			files: map[string]string{
+				"agent/settings.json":                                       `{"packages":["./local-plugin"]}`,
+				"agent/local-plugin/package.json":                           `{"name":"@grafana/agento11y-pi","version":"0.21.0-dev"}`,
+				"agent/npm/node_modules/@grafana/agento11y-pi/package.json": `{"name":"@grafana/agento11y-pi","version":"0.19.0"}`,
+			},
+			wantInstalled: true,
+			wantVersion:   "0.21.0-dev",
+		},
+		// Project scope: `pi install -l` writes <cwd>/.pi/settings.json and npm
+		// installs under <cwd>/.pi/npm.
+		{
+			name: "project scope resolves from the project npm tree",
+			files: map[string]string{
+				".pi/settings.json": `{"packages":["npm:@grafana/agento11y-pi"]}`,
+				".pi/npm/node_modules/@grafana/agento11y-pi/package.json": `{"name":"@grafana/agento11y-pi","version":"0.18.0"}`,
+			},
+			wantInstalled: true,
+			wantVersion:   "0.18.0",
+		},
+		// The global scope is checked first, so its tree answers even when the
+		// project scope also registers the plugin.
+		{
+			name: "global scope wins over project scope",
+			files: map[string]string{
+				"agent/settings.json": `{"packages":["npm:@grafana/agento11y-pi"]}`,
+				"agent/npm/node_modules/@grafana/agento11y-pi/package.json": `{"name":"@grafana/agento11y-pi","version":"0.19.0"}`,
+				".pi/settings.json": `{"packages":["npm:@grafana/agento11y-pi"]}`,
+				".pi/npm/node_modules/@grafana/agento11y-pi/package.json": `{"name":"@grafana/agento11y-pi","version":"0.18.0"}`,
+			},
+			wantInstalled: true,
+			wantVersion:   "0.19.0",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			t.Setenv("PI_CODING_AGENT_DIR", dir)
-			writeSettings(t, dir, tc.settings)
+			// Status also reads <cwd>/.pi/settings.json, so the cwd is pinned to a
+			// temporary directory even for global-scope cases.
+			root := t.TempDir()
+			t.Chdir(root)
+			t.Setenv("PI_CODING_AGENT_DIR", filepath.Join(root, "agent"))
+			writeFiles(t, root, tc.files)
 
 			installed, version, err := Status(context.Background())
 			if err != nil {

--- a/plugins/agento11y/internal/doctor/agents.go
+++ b/plugins/agento11y/internal/doctor/agents.go
@@ -102,8 +102,10 @@ func probeAgent(ctx context.Context, probe agentProbe, binaryVersion string) Age
 		a.Note = appendNote(a.Note, err.Error())
 		return a
 	}
-	a.Version = version
 	if installed {
+		// A version belongs to an installed plugin, so both the human report and
+		// the JSON one drop a version a probe reports next to "not installed".
+		a.Version = version
 		a.Install = InstallStateInstalled
 		a.Health = HealthOK
 	} else {

--- a/plugins/agento11y/internal/doctor/agents_test.go
+++ b/plugins/agento11y/internal/doctor/agents_test.go
@@ -30,6 +30,10 @@ func TestDefaultCollectAgents(t *testing.T) {
 		// runs even when the binary is absent from PATH. notInstalledLabel must
 		// propagate from the probe table into the status.
 		{name: "cfgcli", bin: "cfgcli", configBased: true, notInstalledLabel: "not configured", status: func(context.Context) (bool, string, error) { return true, "2.0.0", nil }},
+		// A probe can read a version from a store entry that does not register the
+		// plugin here. The version is dropped so the JSON report cannot contradict
+		// the install state, the way the human report already can't.
+		{name: "stalever", bin: "stalever", configBased: true, status: func(context.Context) (bool, string, error) { return false, "1.2.3", nil }},
 		{name: "errcli", bin: "errcli", status: func(context.Context) (bool, string, error) { return false, "", errors.New("probe boom") }},
 		{name: "cursor", bin: "cursor", status: nil, note: "hook-based"},
 	}
@@ -50,6 +54,9 @@ func TestDefaultCollectAgents(t *testing.T) {
 		t.Fatalf("cfgcli = %+v, want not-on-path but installed/ok via config probe", a)
 	} else if a.notInstalledLabel != "not configured" {
 		t.Fatalf("cfgcli notInstalledLabel = %q, want propagated from probe", a.notInstalledLabel)
+	}
+	if a := byName["stalever"]; a.Install != InstallStateNotInstalled || a.Version != "" || a.Health != HealthWarn {
+		t.Fatalf("stalever = %+v, want not-installed/no-version/warn", a)
 	}
 	// A probe that errors leaves the state unknown. Reporting not_installed
 	// here would put a false negative in the --json contract.

--- a/plugins/agento11y/internal/doctor/doctor.go
+++ b/plugins/agento11y/internal/doctor/doctor.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
+	"net/url"
 	"os"
 	"slices"
 	"strings"
@@ -67,11 +69,14 @@ var trackedSuffixes = []string{
 	"AUTO_UPDATE",
 	"LOCAL",
 	"LOCAL_FORWARD",
-	// GUARDS_ENABLED is tracked for LocalHookForward only. Everything else
-	// reads the guard settings through envconfig.ResolveGuards, which is the
-	// hook process's view; the local daemon resolves this one config.env-first
-	// and that comparison needs both sources attributed.
+	// The guard families are resolved from the snapshot, not from the process
+	// env. A family missing here is never recorded by SnapshotEnv, so a
+	// shell-exported value would read as unset while the hooks act on it. The
+	// human row attributes GUARDS_ENABLED alone; the other two are read for
+	// their effective values and to name an invalid one.
 	"GUARDS_ENABLED",
+	"GUARDS_FAIL_OPEN",
+	"GUARDS_TIMEOUT_MS",
 }
 
 // trackedKeys is the full key set SnapshotEnv records: both spellings of the
@@ -87,7 +92,6 @@ var trackedKeys = func() []string {
 // Options are the parsed doctor flags.
 type Options struct {
 	JSON    bool
-	Probe   bool
 	NoColor bool
 }
 
@@ -103,12 +107,16 @@ type Params struct {
 // Report is the full diagnostic. Field names and the `status` strings are the
 // stable contract for `--json` / support tooling.
 type Report struct {
-	Binary             BinarySection        `json:"agento11y"`
-	Config             ConfigSection        `json:"config"`
-	Conversations      ConversationsSection `json:"conversations"`
-	Analytics          AnalyticsSection     `json:"analytics"`
-	Agents             []AgentStatus        `json:"agents"`
-	AutoUpdateDisabled bool                 `json:"auto_update_disabled"`
+	Binary        BinarySection        `json:"agento11y"`
+	Config        ConfigSection        `json:"config"`
+	Conversations ConversationsSection `json:"conversations"`
+	Analytics     AnalyticsSection     `json:"analytics"`
+	Agents        []AgentStatus        `json:"agents"`
+	// AutoUpdate is the resolved AUTO_UPDATE family. It carries provenance only:
+	// updatecheck.Disabled() owns the verdict below, so the rule that decides
+	// which values opt out stays in one place.
+	AutoUpdate         envValue `json:"auto_update"`
+	AutoUpdateDisabled bool     `json:"auto_update_disabled"`
 }
 
 // BinarySection reports the binary's build version.
@@ -141,17 +149,32 @@ type tokenValue struct {
 // ConfigSection reports config.env validity and the resolved feature settings
 // that every agent hook reads (content capture, guards, tags).
 type ConfigSection struct {
-	Path                string            `json:"path"`
-	Exists              bool              `json:"exists"`
-	DisallowedKeys      []string          `json:"disallowed_keys,omitempty"`
-	ContentCaptureMode  string            `json:"content_capture_mode"`
-	ContentModeFellBack bool              `json:"content_mode_fell_back"`
-	GuardsEnabled       bool              `json:"guards_enabled"`
-	GuardsTimeoutMs     int               `json:"guards_timeout_ms"`
-	GuardsFailOpen      bool              `json:"guards_fail_open"`
-	GuardsFellBack      bool              `json:"guards_fell_back,omitempty"`
-	Tags                map[string]string `json:"tags,omitempty"`
-	TagsSource          string            `json:"tags_source,omitempty"`
+	Path               string   `json:"path"`
+	Exists             bool     `json:"exists"`
+	DisallowedKeys     []string `json:"disallowed_keys,omitempty"`
+	ContentCaptureMode string   `json:"content_capture_mode"`
+	// ContentModeKey and ContentModeSource name where the effective mode came
+	// from. They are empty when no variable supplied it, which includes the case
+	// where a variable was set to a value envconfig rejected: the mode in force is
+	// then the built-in one, and ContentModeFellBack plus a section message name
+	// the variable to fix.
+	ContentModeKey      string `json:"content_capture_key,omitempty"`
+	ContentModeSource   string `json:"content_capture_source,omitempty"`
+	ContentModeFellBack bool   `json:"content_mode_fell_back"`
+	GuardsEnabled       bool   `json:"guards_enabled"`
+	GuardsTimeoutMs     int    `json:"guards_timeout_ms"`
+	GuardsFailOpen      bool   `json:"guards_fail_open"`
+	GuardsFellBack      bool   `json:"guards_fell_back,omitempty"`
+	// GuardsKey and GuardsSource name the GUARDS_ENABLED spelling that decided
+	// whether guards run. The timeout and fail mode have their own families; the
+	// human row reports one key, so this is the key it reports. Both are empty
+	// when GUARDS_ENABLED supplied no usable value, so the row reports the
+	// built-in default rather than crediting a rejected value.
+	GuardsKey    string            `json:"guards_key,omitempty"`
+	GuardsSource string            `json:"guards_source,omitempty"`
+	Tags         map[string]string `json:"tags,omitempty"`
+	TagsKey      string            `json:"tags_key,omitempty"`
+	TagsSource   string            `json:"tags_source,omitempty"`
 	// Local is the resolved LOCAL family: whether `agento11y <agent>` starts in
 	// local mode without --local, and where the value came from.
 	Local envValue `json:"local"`
@@ -204,11 +227,10 @@ func (s ConversationsSection) configured() bool {
 
 // AnalyticsSection reports the OTLP metrics + traces pipeline.
 type AnalyticsSection struct {
-	Endpoint    envValue        `json:"endpoint"`
-	EndpointVar string          `json:"endpoint_var,omitempty"`
-	Health      Health          `json:"status"`
-	Messages    []string        `json:"messages,omitempty"`
-	Probe       *AnalyticsProbe `json:"probe,omitempty"`
+	Endpoint envValue        `json:"endpoint"`
+	Health   Health          `json:"status"`
+	Messages []string        `json:"messages,omitempty"`
+	Probe    *AnalyticsProbe `json:"probe,omitempty"`
 }
 
 // InstallState is the outcome of an agent's install probe. It is tri-state
@@ -250,9 +272,11 @@ type AgentStatus struct {
 	OnPath    bool         `json:"on_path"`
 	Install   InstallState `json:"install_state"`
 	HookBased bool         `json:"hook_based,omitempty"`
-	Version   string       `json:"version,omitempty"`
-	Note      string       `json:"note,omitempty"`
-	Health    Health       `json:"status"`
+	// Version is the installed plugin's own build identifier, which for a plugin
+	// whose manifest declares no version is the commit it was installed from.
+	Version string `json:"version,omitempty"`
+	Note    string `json:"note,omitempty"`
+	Health  Health `json:"status"`
 
 	// notInstalledLabel overrides the human "plugin not installed" wording for
 	// non-plugin agents (copilot). Human-only; not part of the JSON contract.
@@ -286,12 +310,33 @@ func (p *ProbeResult) scopeDenied() bool {
 
 // unreachable reports a probe outcome that means a configured pipeline can't
 // deliver: a transport error (no HTTP response, e.g. DNS failure, connection
-// refused, or timeout) or a 5xx server error. 401/403 are handled separately
-// as an auth problem (authFailure). Other 4xx are not treated as broken because
-// the minimal probe body ({}) can draw a benign 400/415 from an endpoint that
-// validates the body before auth.
+// refused, or timeout) or a 5xx server error. Every other failing status is
+// classified on its own: 401 and 403 by authFailure, 3xx by redirected, 404 by
+// routeMissing, and the rest by accepted.
 func (p *ProbeResult) unreachable() bool {
 	return p != nil && (p.StatusCode == 0 || p.StatusCode >= 500)
+}
+
+// accepted reports the statuses that prove a pipeline can deliver. Ingest
+// answers the export POST itself: the generation-export route answers 202 and
+// the OTLP gateway answers 200. A 405 also counts, because a method-restricted
+// route still proves the request reached the service and passed auth.
+func (p *ProbeResult) accepted() bool {
+	return p != nil && ((p.StatusCode >= 200 && p.StatusCode < 300) || p.StatusCode == http.StatusMethodNotAllowed)
+}
+
+// routeMissing reports a 404. The host answered, but the export route is not
+// registered there, so the endpoint points at some other service. Every host
+// serves a 404 for an unknown path, which is why a reachable endpoint that
+// answers one is still a broken pipeline.
+func (p *ProbeResult) routeMissing() bool {
+	return p != nil && p.StatusCode == http.StatusNotFound
+}
+
+// redirected reports a 3xx, which means the URL points at something other than
+// an ingest endpoint. See probeClient for why the probe never follows it.
+func (p *ProbeResult) redirected() bool {
+	return p != nil && p.StatusCode >= 300 && p.StatusCode < 400
 }
 
 // AnalyticsProbe holds the per-signal OTLP probe results.
@@ -335,7 +380,7 @@ func Run(ctx context.Context, args []string, p Params) int {
 			return 2
 		}
 	} else {
-		renderHuman(p.Stdout, report, !opts.NoColor, opts.Probe)
+		renderHuman(p.Stdout, report, !opts.NoColor)
 	}
 	return report.exitCode()
 }
@@ -344,21 +389,23 @@ func parseFlags(args []string, stderr io.Writer) (Options, error) {
 	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	fs.Usage = func() {
-		_, _ = fmt.Fprintln(stderr, "usage: agento11y doctor [--json] [--probe] [--no-color]")
+		_, _ = fmt.Fprintln(stderr, "usage: agento11y doctor [--json] [--no-color]")
 		_, _ = fmt.Fprintln(stderr)
 		_, _ = fmt.Fprintln(stderr, "Report the health of the conversations and analytics export pipelines,")
 		_, _ = fmt.Fprintln(stderr, "config validity, and installed host-agent plugins.")
 		_, _ = fmt.Fprintln(stderr)
 		_, _ = fmt.Fprintln(stderr, "  --json       emit a stable JSON report (for support tooling)")
-		_, _ = fmt.Fprintln(stderr, "  --probe      send live requests to the endpoints and report HTTP status")
 		_, _ = fmt.Fprintln(stderr, "  --no-color   disable ANSI colors")
 	}
 	var opts Options
-	var online bool
 	fs.BoolVar(&opts.JSON, "json", false, "emit a JSON report")
-	fs.BoolVar(&opts.Probe, "probe", false, "send live requests to the endpoints")
-	fs.BoolVar(&online, "online", false, "alias for --probe")
 	fs.BoolVar(&opts.NoColor, "no-color", false, "disable ANSI colors")
+	// Probing is unconditional, so --probe and its --online alias do nothing.
+	// They stay accepted, and out of the usage text, so the scripts and runbooks
+	// that pass them keep working.
+	var ignored bool
+	fs.BoolVar(&ignored, "probe", false, "accepted for backwards compatibility; probes always run")
+	fs.BoolVar(&ignored, "online", false, "accepted for backwards compatibility; probes always run")
 	if err := fs.Parse(args); err != nil {
 		return Options{}, err
 	}
@@ -366,12 +413,13 @@ func parseFlags(args []string, stderr io.Writer) (Options, error) {
 		fs.Usage()
 		return Options{}, fmt.Errorf("unexpected arguments: %v", fs.Args())
 	}
-	opts.Probe = opts.Probe || online
 	return opts, nil
 }
 
 // Collect builds the report. It reads config.env and the env snapshot but
-// performs no mutations. Network probes run only when opts.Probe is set.
+// performs no mutations, and it probes the configured endpoints over the
+// network. A config-only verdict cannot tell a working endpoint from one that
+// drops every export, so the probes are not optional.
 func Collect(ctx context.Context, opts Options, p Params) *Report {
 	fileEnv := dotenv.LoadDotenv(dotenv.FilePath(), nil)
 	osEnv := p.OSEnv
@@ -385,11 +433,10 @@ func Collect(ctx context.Context, opts Options, p Params) *Report {
 	r.Analytics = collectAnalytics(osEnv, fileEnv, r.Conversations.configured())
 	r.Config = collectConfig(osEnv, fileEnv)
 	r.Agents = collectAgents(ctx, r.Binary.Version)
+	r.AutoUpdate = resolveFamily("AUTO_UPDATE", osEnv, fileEnv).envValue()
 	r.AutoUpdateDisabled = updatecheck.Disabled()
 
-	if opts.Probe {
-		runProbes(ctx, r, osEnv, fileEnv)
-	}
+	runProbes(ctx, r, osEnv, fileEnv)
 	return r
 }
 
@@ -401,6 +448,75 @@ func (r *Report) exitCode() int {
 		return 1
 	}
 	return 0
+}
+
+// apiURLHint is the one correction every wrong-endpoint message ends with, so
+// a user who pasted a stack URL or an app-page URL reads the same fix.
+// Connection is what the app and the docs call the page that holds the URL.
+const apiURLHint = "Copy the API URL from the Agent Observability app's Connection page " +
+	"(e.g. https://agento11y-prod-<region>.grafana.net)."
+
+// grafanaAppPath is where Grafana serves the Agent Observability app pages.
+// login.go prints this URL after a successful login, so it is one of the two
+// app URLs a user pastes into the endpoint variable.
+const grafanaAppPath = "/a/grafana-agento11y-app"
+
+// grafanaCloudDomains are the domains Grafana serves Cloud stacks and Agent
+// Observability cells from. The host shape check applies only inside them: a
+// self-hosted Sigil or a test collector can use any hostname, so warning about
+// those would be noise.
+var grafanaCloudDomains = []string{".grafana.net", ".grafana-dev.net", ".grafana-ops.net"}
+
+// apiHostPrefixes are the first-label prefixes of every real API host:
+// sigil-prod-<region>, agento11y-prod-<region>, sigil-dev-001,
+// sigil-dev-<region>, agento11y-dev-001, sigil-ops-001, sigilai. A prefix
+// check, not a region list, which would go stale with every new cell.
+var apiHostPrefixes = []string{"sigil", "agento11y"}
+
+// isGrafanaAppPage reports a path that serves Grafana app UI instead of the
+// ingest API: the plugin pages under /plugins/, or the Agent Observability app
+// under /a/grafana-agento11y-app. Both are URLs users copy out of the browser
+// or out of this tool's own login output. The ingest API carries neither prefix
+// on any host, so the export POST is redirected to /login and every generation
+// is lost. A bare /a/ does not match, because a self-hosted deployment could
+// legitimately sit under it.
+func isGrafanaAppPage(path string) bool {
+	if strings.Contains(path, "/plugins/") {
+		return true
+	}
+	trimmed := strings.TrimRight(path, "/")
+	return trimmed == grafanaAppPath || strings.HasPrefix(trimmed, grafanaAppPath+"/")
+}
+
+// endpointShapeMessage reports a normalized endpoint URL that does not look
+// like an Agent Observability API URL. fatal marks the shape that cannot work
+// on any host; the rest are warnings, because a hostname heuristic can go
+// stale, and the probe escalates a warned endpoint when it really does
+// redirect the export POST.
+func endpointShapeMessage(key, target string) (msg string, fatal bool) {
+	parsed, err := url.Parse(target)
+	if err != nil {
+		return "", false
+	}
+	// The path check ignores the host, so it also covers a stack on a custom
+	// domain.
+	if isGrafanaAppPage(parsed.Path) {
+		return key + " points at a Grafana app page, not the Agent Observability API. " + apiURLHint, true
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if !slices.ContainsFunc(grafanaCloudDomains, func(d string) bool { return strings.HasSuffix(host, d) }) {
+		return "", false
+	}
+	label, _, _ := strings.Cut(host, ".")
+	if slices.ContainsFunc(apiHostPrefixes, func(p string) bool { return strings.HasPrefix(label, p) }) {
+		return "", false
+	}
+	if strings.HasPrefix(label, "otlp-gateway-") {
+		return key + " is the OTLP gateway, which takes metrics and traces, not conversations. " +
+			"That value belongs in AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT. " + apiURLHint, false
+	}
+	return key + " does not look like an Agent Observability API URL: " + host +
+		" is a Grafana Cloud stack or another Cloud service. " + apiURLHint, false
 }
 
 func collectConversations(osEnv, fileEnv map[string]string) ConversationsSection {
@@ -435,18 +551,32 @@ func collectConversations(osEnv, fileEnv map[string]string) ConversationsSection
 		sec.Messages = append(sec.Messages, "incomplete credentials; missing "+strings.Join(missing, ", "))
 	}
 	// A set endpoint still has to be a URL the exporter can build a request
-	// from. Without this the offline run calls a malformed endpoint healthy and
-	// only --probe, which needs the network, reports the problem.
+	// from. Checking the shape here reports a malformed endpoint without waiting
+	// on the network, and gives runProbes a reason to skip it.
+	var target string
 	if endpoint.set {
-		if _, err := wire.NormalizeGenerationExportURL(endpoint.value, resolveInsecure(osEnv, fileEnv)); err != nil {
+		normalized, err := wire.NormalizeGenerationExportURL(endpoint.value, resolveInsecure(osEnv, fileEnv))
+		if err != nil {
 			sec.Health = HealthError
 			sec.Messages = append(sec.Messages, fmt.Sprintf("%s is not a usable endpoint: %v", endpoint.key, err))
+		}
+		target = normalized
+	}
+	// A usable URL can still be the wrong URL. Run the shape check only when
+	// nothing else failed, so it cannot downgrade a missing-credentials or
+	// malformed-endpoint error to a warning.
+	if target != "" && sec.Health == HealthOK {
+		if msg, fatal := endpointShapeMessage(endpoint.key, target); msg != "" {
+			sec.Health = HealthWarn
+			if fatal {
+				sec.Health = HealthError
+			}
+			sec.Messages = append(sec.Messages, msg)
 		}
 	}
 	for _, r := range []resolved{endpoint, tenant, token} {
 		if r.conflict {
-			sec.Messages = append(sec.Messages, fmt.Sprintf(
-				"%s and its other spelling are both set with different values; using %s", r.key, r.key))
+			sec.Messages = append(sec.Messages, conflictMessage(r))
 		}
 	}
 	if endpoint.legacyWon() || tenant.legacyWon() || token.legacyWon() {
@@ -464,10 +594,8 @@ func collectAnalytics(osEnv, fileEnv map[string]string, conversationsConfigured 
 	switch {
 	case brandedOTLP.set:
 		sec.Endpoint = brandedOTLP.envValue()
-		sec.EndpointVar = brandedOTLP.key
 	case stdOTLP.set:
 		sec.Endpoint = stdOTLP.envValue()
-		sec.EndpointVar = "OTEL_EXPORTER_OTLP_ENDPOINT"
 	case conversationsConfigured:
 		// The headline failure: conversations export fine, but analytics
 		// (the Agent Observability page) stays empty because no OTLP endpoint
@@ -484,8 +612,7 @@ func collectAnalytics(osEnv, fileEnv map[string]string, conversationsConfigured 
 		return sec
 	}
 	if brandedOTLP.conflict {
-		sec.Messages = append(sec.Messages, fmt.Sprintf(
-			"%s and its other spelling are both set with different values; using %s", brandedOTLP.key, brandedOTLP.key))
+		sec.Messages = append(sec.Messages, conflictMessage(brandedOTLP))
 	}
 	if brandedOTLP.legacyWon() {
 		sec.Messages = append(sec.Messages,
@@ -514,7 +641,7 @@ func collectAnalytics(osEnv, fileEnv map[string]string, conversationsConfigured 
 // analyticsAuthResolvable reports whether the OTLP exporter would have a
 // credential: an explicit Authorization header, or a tenant + token pair that
 // internal/otel turns into Basic auth. It does not validate the credential —
-// `--probe` does that against the live endpoint.
+// the probe does that against the live endpoint.
 func analyticsAuthResolvable(osEnv, fileEnv map[string]string) bool {
 	if headersHaveAuthorization(resolveEnv("OTEL_EXPORTER_OTLP_HEADERS", osEnv, fileEnv).value) {
 		return true
@@ -553,24 +680,45 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 	}
 	sec.DisallowedKeys = disallowedKeys(path)
 
-	// ResolveContentMode logs a line when it falls back from an invalid value,
-	// so a capturing logger doubles as the fell-back signal.
+	// ResolveContentModeValue logs a line when it falls back from an invalid
+	// value, so a capturing logger doubles as the fell-back signal.
+	contentMode := resolveFamily("CONTENT_CAPTURE_MODE", osEnv, fileEnv)
 	var buf bytes.Buffer
-	mode := envconfig.ResolveContentMode(log.New(&buf, "", 0))
+	mode := envconfig.ResolveContentModeValue(log.New(&buf, "", 0), contentMode.key, contentMode.value)
 	sec.ContentCaptureMode = mode.String()
 	sec.ContentModeFellBack = buf.Len() > 0
+	// A rejected value did not supply the mode in force, so the row credits no
+	// variable for it and reports the built-in default instead.
+	if !sec.ContentModeFellBack {
+		sec.ContentModeKey = contentMode.key
+		sec.ContentModeSource = contentMode.source
+	}
 
 	// Guards are the shared pre-tool-call enforcement flags every agent hook
 	// reads via envconfig.ResolveGuards. They default off, so surface the
 	// effective values to confirm whether guards actually run and with what
-	// timeout / fail mode. ResolveGuards logs on an invalid value, so a
-	// capturing logger doubles as the fell-back signal, same as content mode.
-	var guardBuf bytes.Buffer
-	guards := envconfig.ResolveGuards(log.New(&guardBuf, "", 0))
+	// timeout / fail mode. The lookup resolves them from the same pre-merge
+	// snapshot every other row is attributed with, while the parsing and the
+	// defaults stay in envconfig, shared with the hooks. No logger is needed:
+	// invalidGuardKeys names the rejected variables.
+	guardsEnabled := resolveFamily("GUARDS_ENABLED", osEnv, fileEnv)
+	guardsTimeout := resolveFamily("GUARDS_TIMEOUT_MS", osEnv, fileEnv)
+	guardsFailOpen := resolveFamily("GUARDS_FAIL_OPEN", osEnv, fileEnv)
+	guards := envconfig.ResolveGuardsWith(nil, func(suffix string) (value, key string, ok bool) {
+		r := resolveFamily(suffix, osEnv, fileEnv)
+		return r.value, r.key, r.set
+	})
 	sec.GuardsEnabled = guards.Enabled
 	sec.GuardsTimeoutMs = guards.TimeoutMs
 	sec.GuardsFailOpen = guards.FailOpen
-	sec.GuardsFellBack = guardBuf.Len() > 0
+	invalidGuards := invalidGuardKeys(guardsEnabled, guardsTimeout, guardsFailOpen)
+	sec.GuardsFellBack = len(invalidGuards) > 0
+	// Same rule as the mode above: a rejected GUARDS_ENABLED value did not decide
+	// whether guards run, so the row names no variable for it.
+	if _, ok := envconfig.ParseBoolValue(guardsEnabled.value); ok {
+		sec.GuardsKey = guardsEnabled.key
+		sec.GuardsSource = guardsEnabled.source
+	}
 
 	// The TAGS family attaches key=value tags to every generation. They
 	// aren't secret, so surface the resolved set (and where it came from) to
@@ -579,6 +727,7 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 	if tags.set {
 		if parsed := envconfig.ParseExtraTags(tags.value); len(parsed) > 0 {
 			sec.Tags = parsed
+			sec.TagsKey = tags.key
 			sec.TagsSource = tags.source
 		}
 	}
@@ -620,16 +769,18 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 	if sec.ContentModeFellBack {
 		sec.Health = HealthWarn
 		sec.Messages = append(sec.Messages,
-			fmt.Sprintf("the CONTENT_CAPTURE_MODE value is invalid; using %s", mode))
+			fmt.Sprintf("the %s value is invalid; using %s", contentMode.key, mode))
 	}
-	if sec.GuardsFellBack {
+	// One message per rejected variable: the row names the GUARDS_ENABLED
+	// spelling alone, so this is the only place a reader learns which guard value
+	// is broken.
+	for _, key := range invalidGuards {
 		sec.Health = HealthWarn
 		sec.Messages = append(sec.Messages,
-			"a GUARDS_* value is invalid; falling back to defaults")
+			fmt.Sprintf("the %s value is invalid; guards use the default", key))
 	}
 	if tags.conflict {
-		sec.Messages = append(sec.Messages, fmt.Sprintf(
-			"%s and its other spelling are both set with different values; using %s", tags.key, tags.key))
+		sec.Messages = append(sec.Messages, conflictMessage(tags))
 	}
 	if tags.legacyWon() {
 		sec.Messages = append(sec.Messages,
@@ -658,6 +809,31 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 	return sec
 }
 
+// invalidGuardKeys names the GUARDS_* variables whose values envconfig rejects,
+// in the order the guards row prints them. The envconfig parsers the hooks
+// resolve with decide validity, so doctor cannot call a value good that a hook
+// throws away. The row attributes GUARDS_ENABLED alone, so these names are the
+// only place a reader learns which guard value is broken.
+func invalidGuardKeys(enabled, timeout, failOpen resolved) []string {
+	isBool := func(raw string) bool { _, ok := envconfig.ParseBoolValue(raw); return ok }
+	isTimeout := func(raw string) bool { _, ok := envconfig.ParseIntValue(raw); return ok }
+
+	var keys []string
+	for _, family := range []struct {
+		value resolved
+		valid func(string) bool
+	}{
+		{enabled, isBool},
+		{timeout, isTimeout},
+		{failOpen, isBool},
+	} {
+		if family.value.set && !family.valid(family.value.value) {
+			keys = append(keys, family.value.key)
+		}
+	}
+	return keys
+}
+
 // hookForwardReason resolves the local guard-chaining gate with the given
 // precedence, so the same inputs can be read the daemon's way (config.env
 // first) and the shell's way and compared.
@@ -680,22 +856,56 @@ func resolveInsecure(osEnv, fileEnv map[string]string) bool {
 	return envconfig.ParseBool(resolveFamily("INSECURE", osEnv, fileEnv).value)
 }
 
+// endpointKey is the endpoint variable spelling to name in a message. The
+// resolved key wins, so a SIGIL_* setup reads its own name back; the preferred
+// spelling is the fallback when the report carries no key.
+func endpointKey(v envValue) string {
+	if v.Key != "" {
+		return v.Key
+	}
+	return envconfig.PreferredKey("ENDPOINT")
+}
+
 func runProbes(ctx context.Context, r *Report, osEnv, fileEnv map[string]string) {
 	// An endpoint the offline check already rejected has nothing to probe:
 	// probing it would report the same fault a second and third time. Inside
-	// configured(), HealthError can only come from that check.
+	// configured(), HealthError means a malformed endpoint or an app-page path,
+	// and probing would report that fault again.
 	if r.Conversations.configured() && r.Conversations.Health != HealthError {
 		token := resolveFamily("AUTH_TOKEN", osEnv, fileEnv).value
 		res := probeConversationsFn(ctx, r.Conversations.Endpoint.Value, r.Conversations.TenantID, token, resolveInsecure(osEnv, fileEnv))
 		r.Conversations.Probe = res
 		switch {
 		case res.authFailure():
-			// No section message: the probe line states the cause.
 			r.Conversations.Health = HealthError
+			// The row shows the status and the URL, so the diagnosis (bad token,
+			// wrong tenant id, missing write scope) is carried here or nowhere in
+			// the human report.
+			r.Conversations.Messages = append(r.Conversations.Messages,
+				"the conversations endpoint rejected the export request: "+describeProbe(res))
+		case res.redirected():
+			r.Conversations.Health = HealthError
+			r.Conversations.Messages = append(r.Conversations.Messages,
+				"the conversations endpoint redirected the export request ("+describeProbe(res)+"), so "+
+					endpointKey(r.Conversations.Endpoint)+" is not an Agent Observability API URL. "+apiURLHint)
 		case res.unreachable():
 			r.Conversations.Health = HealthError
 			r.Conversations.Messages = append(r.Conversations.Messages,
 				"could not reach the conversations endpoint: "+describeProbe(res))
+		case res.routeMissing():
+			r.Conversations.Health = HealthError
+			r.Conversations.Messages = append(r.Conversations.Messages,
+				"the conversations endpoint has no generation-export route (HTTP 404), so "+
+					endpointKey(r.Conversations.Endpoint)+" is not an Agent Observability API URL. "+apiURLHint)
+		case !res.accepted():
+			// A 400 or 415 can come from an endpoint that validates the body
+			// before auth, and the probe posts a minimal {}. Warn rather than
+			// fail, but never call it healthy: the real route answers 202.
+			if r.Conversations.Health == HealthOK {
+				r.Conversations.Health = HealthWarn
+			}
+			r.Conversations.Messages = append(r.Conversations.Messages,
+				"the conversations endpoint answered "+describeProbe(res)+" instead of HTTP 202; exports may be dropped")
 		}
 	}
 	if r.Analytics.Endpoint.Set {
@@ -704,13 +914,36 @@ func runProbes(ctx context.Context, r *Report, osEnv, fileEnv map[string]string)
 		if probe != nil {
 			switch {
 			case probe.Metrics.authFailure() || probe.Traces.authFailure():
-				// No section message: each signal's probe line states
-				// its own cause.
 				r.Analytics.Health = HealthError
-			case probe.Metrics.unreachable() || probe.Traces.unreachable():
+				r.Analytics.Messages = append(r.Analytics.Messages, otlpAuthMessages(probe)...)
+			case probe.Metrics.redirected() || probe.Traces.redirected():
 				r.Analytics.Health = HealthError
 				r.Analytics.Messages = append(r.Analytics.Messages,
-					"could not reach the OTLP endpoint — metrics and traces will not be exported")
+					"the OTLP endpoint redirected the export request, so it is not an OTLP ingest URL "+
+						"(e.g. https://otlp-gateway-prod-<region>.grafana.net/otlp)")
+			case probe.Metrics.unreachable() || probe.Traces.unreachable():
+				r.Analytics.Health = HealthError
+				// The row shows the status and the URL, so the cause (DNS failure,
+				// refused connection, TLS error, timeout, 5xx body) is carried here or
+				// nowhere in the human report.
+				r.Analytics.Messages = append(r.Analytics.Messages,
+					"could not reach the OTLP endpoint: "+describeProbe(firstUnreachable(probe))+
+						"; metrics and traces will not be exported")
+			case probe.Metrics.routeMissing() || probe.Traces.routeMissing():
+				r.Analytics.Health = HealthError
+				r.Analytics.Messages = append(r.Analytics.Messages,
+					"the OTLP endpoint has no ingest route (HTTP 404), so it is not an OTLP ingest URL "+
+						"(e.g. https://otlp-gateway-prod-<region>.grafana.net/otlp)")
+			case !probe.Metrics.accepted() || !probe.Traces.accepted():
+				// The probe posts JSON where the exporter posts protobuf, so a
+				// collector that parses before it authenticates can answer 400 or
+				// 415 while real exports still land. Warn, don't fail.
+				if r.Analytics.Health == HealthOK {
+					r.Analytics.Health = HealthWarn
+				}
+				r.Analytics.Messages = append(r.Analytics.Messages,
+					"the OTLP endpoint did not accept the probe; the probe posts JSON where the exporter posts "+
+						"protobuf, so this can be benign")
 			}
 		}
 	}
@@ -728,16 +961,55 @@ func otlpProbeTenant(tenant envValue, osEnv, fileEnv map[string]string) envValue
 	return tenant
 }
 
+// otlpAuthMessages diagnoses the OTLP signals whose auth failed. The rows show
+// the status and the URL, so the diagnosis (bad token, wrong tenant id, missing
+// write scope) is carried here or nowhere in the human report. Metrics and
+// traces authenticate with the same credentials, so a failure both share is
+// described once; each signal gets its own line only when the two failed
+// differently.
+func otlpAuthMessages(p *AnalyticsProbe) []string {
+	rejected := func(subject string, res *ProbeResult) string {
+		return "the OTLP endpoint rejected the " + subject + ": " + describeProbe(res)
+	}
+	if p.Metrics.authFailure() && p.Traces.authFailure() &&
+		p.Metrics.StatusCode == p.Traces.StatusCode && p.Metrics.Message == p.Traces.Message {
+		return []string{rejected("metrics and traces exports", p.Metrics)}
+	}
+	var msgs []string
+	for _, signal := range []struct {
+		name string
+		res  *ProbeResult
+	}{{"metrics", p.Metrics}, {"traces", p.Traces}} {
+		if signal.res.authFailure() {
+			msgs = append(msgs, rejected(signal.name+" export", signal.res))
+		}
+	}
+	return msgs
+}
+
+// firstUnreachable returns the signal probe that could not deliver, so the
+// message names one concrete failure instead of both.
+func firstUnreachable(p *AnalyticsProbe) *ProbeResult {
+	if p.Metrics.unreachable() {
+		return p.Metrics
+	}
+	return p.Traces
+}
+
 // resolved is the effective value of an env var plus where it came from:
 // key is the spelling that won (AGENTO11Y_* or SIGIL_*), and conflict reports
 // that the other spelling also resolves — to a different value — under the
-// same source precedence.
+// same source precedence. otherKey and otherSource describe that losing
+// spelling, so a message can name the variable to edit instead of calling it
+// "the other spelling"; both are empty unless conflict is set.
 type resolved struct {
-	set      bool
-	value    string
-	source   string
-	key      string
-	conflict bool
+	set         bool
+	value       string
+	source      string
+	key         string
+	conflict    bool
+	otherKey    string
+	otherSource string
 }
 
 func (r resolved) envValue() envValue {
@@ -751,6 +1023,50 @@ func (r resolved) tokenValue() tokenValue {
 // legacyWon reports that the value came from the legacy SIGIL_* spelling.
 func (r resolved) legacyWon() bool {
 	return r.set && strings.HasPrefix(r.key, "SIGIL_")
+}
+
+// conflictMessage describes an alias family whose two spellings hold different
+// values: which variable each value came from, which one is in force, and
+// which one to delete. Both spellings name the same setting, so a reader who
+// is only told the winner cannot tell what the other value even was.
+func conflictMessage(r resolved) string {
+	var b strings.Builder
+	if r.source == r.otherSource {
+		fmt.Fprintf(&b, "%s and %s are both set in %s, to different values; using %s",
+			r.key, r.otherKey, sourceLabel(r.source), r.key)
+	} else {
+		fmt.Fprintf(&b, "%s is set in %s and %s in %s, to different values; using %s",
+			r.key, sourceLabel(r.source), r.otherKey, sourceLabel(r.otherSource), r.key)
+	}
+	if r.legacyWon() {
+		// The preferred spelling loses only across sources: resolveFamily picks it
+		// whenever both spellings come from the same place.
+		b.WriteString(", because the environment outranks config.env")
+	}
+	legacyKey, legacySource := r.key, r.source
+	if !r.legacyWon() {
+		legacyKey, legacySource = r.otherKey, r.otherSource
+	}
+	fmt.Fprintf(&b, ". %s is the old name for the same setting: %s.", legacyKey, clearHint(legacySource))
+	return b.String()
+}
+
+// clearHint names the action that clears a variable, which depends on where it
+// is set: an exported variable is unset, a config.env line is deleted.
+func clearHint(source string) string {
+	if source == sourceConfig {
+		return "remove it from config.env"
+	}
+	return "unset it"
+}
+
+// sourceLabel spells a source for prose. The rows print the bare `env` and
+// `config.env` labels, which a sentence cannot reuse as-is.
+func sourceLabel(source string) string {
+	if source == sourceConfig {
+		return "config.env"
+	}
+	return "the environment"
 }
 
 // resolveEnv mirrors dotenv.ApplyEnv precedence for one exact key: a
@@ -784,7 +1100,10 @@ func resolveFamily(suffix string, osEnv, fileEnv map[string]string) resolved {
 	if !winner.set {
 		return resolved{}
 	}
-	winner.conflict = other.set && other.value != winner.value
+	if other.set && other.value != winner.value {
+		winner.conflict = true
+		winner.otherKey, winner.otherSource = other.key, other.source
+	}
 	return winner
 }
 

--- a/plugins/agento11y/internal/doctor/doctor_test.go
+++ b/plugins/agento11y/internal/doctor/doctor_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"log"
 	"maps"
 	"os"
 	"path/filepath"
@@ -27,9 +29,8 @@ func mergeEnv(envs ...map[string]string) map[string]string {
 // branded env vars so a test never reads the developer's real config.
 //
 // It clears every AGENTO11Y_* and SIGIL_* key the shell exports rather than a
-// hand-listed subset: doctor and envconfig read families that trackedKeys does
-// not cover (GUARDS_TIMEOUT_MS, GUARDS_FAIL_OPEN), so on a configured machine
-// the host value would decide the result.
+// hand-listed subset, so a family a test does not name cannot let a host value
+// decide the result.
 func isolateEnv(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -86,16 +87,17 @@ func TestParseFlags(t *testing.T) {
 		name      string
 		args      []string
 		wantJSON  bool
-		wantProbe bool
 		wantColor bool // NoColor
 		wantErr   bool
 	}{
 		{name: "no flags"},
 		{name: "json", args: []string{"--json"}, wantJSON: true},
-		{name: "probe", args: []string{"--probe"}, wantProbe: true},
-		{name: "online alias", args: []string{"--online"}, wantProbe: true},
 		{name: "no-color", args: []string{"--no-color"}, wantColor: true},
-		{name: "combined", args: []string{"--json", "--probe", "--no-color"}, wantJSON: true, wantProbe: true, wantColor: true},
+		// Probing is unconditional now. The old flags must still parse, so a
+		// script or runbook that passes them does not start failing.
+		{name: "probe is accepted and ignored", args: []string{"--probe"}},
+		{name: "online alias is accepted and ignored", args: []string{"--online"}},
+		{name: "combined", args: []string{"--json", "--probe", "--no-color"}, wantJSON: true, wantColor: true},
 		{name: "unknown flag", args: []string{"--nope"}, wantErr: true},
 		{name: "positional arg", args: []string{"extra"}, wantErr: true},
 	}
@@ -111,7 +113,7 @@ func TestParseFlags(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if opts.JSON != tc.wantJSON || opts.Probe != tc.wantProbe || opts.NoColor != tc.wantColor {
+			if opts.JSON != tc.wantJSON || opts.NoColor != tc.wantColor {
 				t.Fatalf("opts = %+v", opts)
 			}
 		})
@@ -148,7 +150,10 @@ func TestReportExitCode(t *testing.T) {
 
 func TestCollectConversations(t *testing.T) {
 	tests := []struct {
-		name       string
+		name string
+		// endpoint is shorthand for a fully configured section with that
+		// endpoint; set osEnv instead to control the other credentials.
+		endpoint   string
 		osEnv      map[string]string
 		wantHealth Health
 		wantMsg    string
@@ -183,7 +188,7 @@ func TestCollectConversations(t *testing.T) {
 		},
 		{
 			// Set credentials alone are not a working config: an endpoint the
-			// exporter cannot build a request from fails without --probe.
+			// exporter cannot build a request from fails without the network.
 			name:       "malformed endpoint fails offline",
 			osEnv:      map[string]string{"AGENTO11Y_ENDPOINT": "not a url ://", "AGENTO11Y_AUTH_TENANT_ID": "1", "AGENTO11Y_AUTH_TOKEN": "glc_t"},
 			wantHealth: HealthError,
@@ -202,15 +207,118 @@ func TestCollectConversations(t *testing.T) {
 			osEnv:      map[string]string{"AGENTO11Y_ENDPOINT": "collector.local:4317", "AGENTO11Y_AUTH_TENANT_ID": "1", "AGENTO11Y_AUTH_TOKEN": "glc_t"},
 			wantHealth: HealthOK,
 		},
+		{
+			// The reported failure: the Agent Observability app page pasted in as
+			// the endpoint. Every export is redirected to /login, so doctor must
+			// say so without the network.
+			name:       "app page path fails offline",
+			endpoint:   "https://mystack.grafana.net/plugins/grafana-agento11y-app",
+			wantHealth: HealthError,
+			wantMsg:    "points at a Grafana app page",
+		},
+		{
+			// The path check ignores the host, so a stack on a custom domain is
+			// caught too.
+			name:       "app page path on a custom domain fails offline",
+			endpoint:   "https://grafana.example.com/plugins/grafana-agento11y-app",
+			wantHealth: HealthError,
+			wantMsg:    "points at a Grafana app page",
+		},
+		{
+			name:       "another plugins path fails offline",
+			endpoint:   "https://host/plugins/x",
+			wantHealth: HealthError,
+			wantMsg:    "points at a Grafana app page",
+		},
+		{
+			// The other app URL: login.go prints this one after a successful
+			// login, so it is at least as likely a paste as the plugin page.
+			name:       "app path fails offline",
+			endpoint:   "https://mystack.grafana.net/a/grafana-agento11y-app",
+			wantHealth: HealthError,
+			wantMsg:    "points at a Grafana app page",
+		},
+		{
+			name:       "app path on a custom domain fails offline",
+			endpoint:   "https://grafana.example.com/a/grafana-agento11y-app",
+			wantHealth: HealthError,
+			wantMsg:    "points at a Grafana app page",
+		},
+		{
+			name:       "a page under the app path fails offline",
+			endpoint:   "https://grafana.example.com/a/grafana-agento11y-app/conversations",
+			wantHealth: HealthError,
+			wantMsg:    "points at a Grafana app page",
+		},
+		{
+			// A bare /a/ is not judged: a self-hosted deployment could sit there.
+			name:       "another app path is not judged",
+			endpoint:   "https://grafana.example.com/a/other-app",
+			wantHealth: HealthOK,
+		},
+		{
+			name:       "grafana cloud stack host warns",
+			endpoint:   "https://mystack.grafana.net",
+			wantHealth: HealthWarn,
+			wantMsg:    "does not look like an Agent Observability API URL",
+		},
+		{
+			name:       "otlp gateway in the conversations variable warns",
+			endpoint:   "https://otlp-gateway-prod-us-east-2.grafana.net/otlp",
+			wantHealth: HealthWarn,
+			wantMsg:    "belongs in AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT",
+		},
+		// Every real API host shape: the first label starts with sigil or
+		// agento11y, so none of them warns.
+		{name: "prod sigil cell", endpoint: "https://sigil-prod-us-east-0.grafana.net", wantHealth: HealthOK},
+		{name: "prod agento11y cell", endpoint: "https://agento11y-prod-us-east-0.grafana.net", wantHealth: HealthOK},
+		{name: "dev sigil cell", endpoint: "https://sigil-dev-001.grafana-dev.net", wantHealth: HealthOK},
+		{name: "regional dev sigil cell", endpoint: "https://sigil-dev-eu-west-2.grafana-dev.net", wantHealth: HealthOK},
+		{name: "dev agento11y cell", endpoint: "https://agento11y-dev-001.grafana-dev.net", wantHealth: HealthOK},
+		{name: "ops sigil cell", endpoint: "https://sigil-ops-001.grafana-ops.net", wantHealth: HealthOK},
+		{name: "sigilai", endpoint: "https://sigilai.grafana.net", wantHealth: HealthOK},
+		// Outside the Grafana-owned domains the host is not judged at all: a
+		// self-hosted Sigil or a test collector can use any hostname.
+		{name: "self-hosted host is not judged", endpoint: "https://sigil.example", wantHealth: HealthOK},
+		{name: "internal host is not judged", endpoint: "https://sigil.internal.example", wantHealth: HealthOK},
+		{name: "single-label host is not judged", endpoint: "https://x", wantHealth: HealthOK},
+		{name: "scheme-less collector is not judged", endpoint: "collector.local:4317", wantHealth: HealthOK},
+		{name: "loopback receiver is not judged", endpoint: "http://127.0.0.1:9000", wantHealth: HealthOK},
+		{
+			// The shape heuristic must not turn an error into a warning.
+			name:       "suspicious host does not downgrade a credentials error",
+			osEnv:      map[string]string{"AGENTO11Y_ENDPOINT": "https://mystack.grafana.net", "AGENTO11Y_AUTH_TENANT_ID": "1"},
+			wantHealth: HealthError,
+			wantMsg:    "incomplete credentials; missing AGENTO11Y_AUTH_TOKEN",
+		},
+		{
+			name:       "malformed endpoint error survives the shape check",
+			osEnv:      map[string]string{"AGENTO11Y_ENDPOINT": "https:///plugins/grafana-agento11y-app", "AGENTO11Y_AUTH_TENANT_ID": "1", "AGENTO11Y_AUTH_TOKEN": "glc_t"},
+			wantHealth: HealthError,
+			wantMsg:    "not a usable endpoint",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			sec := collectConversations(tc.osEnv, nil)
+			osEnv := tc.osEnv
+			if tc.endpoint != "" {
+				osEnv = map[string]string{
+					"AGENTO11Y_ENDPOINT":       tc.endpoint,
+					"AGENTO11Y_AUTH_TENANT_ID": "1",
+					"AGENTO11Y_AUTH_TOKEN":     "glc_t",
+				}
+			}
+			sec := collectConversations(osEnv, nil)
 			if sec.Health != tc.wantHealth {
-				t.Fatalf("health = %q, want %q", sec.Health, tc.wantHealth)
+				t.Fatalf("health = %q, want %q (messages %v)", sec.Health, tc.wantHealth, sec.Messages)
 			}
 			if tc.wantMsg != "" && !strings.Contains(strings.Join(sec.Messages, " "), tc.wantMsg) {
 				t.Fatalf("messages %v missing %q", sec.Messages, tc.wantMsg)
+			}
+			// The shorthand configures the preferred spellings only, so a healthy
+			// section must be silent: any message there is a stray shape warning.
+			if tc.endpoint != "" && tc.wantHealth == HealthOK && len(sec.Messages) != 0 {
+				t.Fatalf("healthy section carries messages %v", sec.Messages)
 			}
 		})
 	}
@@ -244,6 +352,32 @@ func TestCollectConversationsConflictingTokens(t *testing.T) {
 	}
 }
 
+// TestRenderHuman_RowNamesOnlyTheWinningSpelling walks the whole path from the
+// snapshot to the rendered row. A row that named the losing spelling would send
+// a user to edit a value the binary never reads.
+func TestRenderHuman_RowNamesOnlyTheWinningSpelling(t *testing.T) {
+	osEnv := map[string]string{
+		"AGENTO11Y_ENDPOINT":       "https://shell.example",
+		"AGENTO11Y_AUTH_TENANT_ID": "12345",
+		"AGENTO11Y_AUTH_TOKEN":     "glc_shell",
+	}
+	fileEnv := map[string]string{"SIGIL_ENDPOINT": "https://file.example"}
+
+	var buf bytes.Buffer
+	renderHuman(&buf, &Report{Conversations: collectConversations(osEnv, fileEnv)}, false)
+	out := buf.String()
+
+	if want := "https://shell.example (AGENTO11Y_ENDPOINT, env)"; !strings.Contains(out, want) {
+		t.Fatalf("endpoint row missing %q:\n%s", want, out)
+	}
+	endpointRow, _, _ := strings.Cut(out[strings.Index(out, "endpoint:"):], "\n")
+	for _, loser := range []string{"SIGIL_ENDPOINT", sourceConfig, "file.example"} {
+		if strings.Contains(endpointRow, loser) {
+			t.Fatalf("endpoint row %q names the losing spelling %q", endpointRow, loser)
+		}
+	}
+}
+
 func TestResolveFamilySourceBeatsSpelling(t *testing.T) {
 	osEnv := map[string]string{"SIGIL_ENDPOINT": "shell-legacy"}
 	fileEnv := map[string]string{"AGENTO11Y_ENDPOINT": "file-preferred"}
@@ -253,6 +387,60 @@ func TestResolveFamilySourceBeatsSpelling(t *testing.T) {
 	}
 	if !r.conflict {
 		t.Fatalf("expected conflict flag when spellings disagree: %+v", r)
+	}
+}
+
+// TestConflictMessage checks the sentence a user reads when both spellings of
+// one setting are set. It has to name the losing variable and where it is set:
+// the two spellings are the same setting, so a reader told only the winner
+// cannot tell what to change.
+func TestConflictMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		osEnv   map[string]string
+		fileEnv map[string]string
+		want    string
+	}{
+		{
+			name:  "both in the environment",
+			osEnv: map[string]string{"AGENTO11Y_ENDPOINT": "https://a", "SIGIL_ENDPOINT": "https://b"},
+			want: "AGENTO11Y_ENDPOINT and SIGIL_ENDPOINT are both set in the environment, to different values; " +
+				"using AGENTO11Y_ENDPOINT. SIGIL_ENDPOINT is the old name for the same setting: unset it.",
+		},
+		{
+			name:    "both in config.env",
+			fileEnv: map[string]string{"AGENTO11Y_ENDPOINT": "https://a", "SIGIL_ENDPOINT": "https://b"},
+			want: "AGENTO11Y_ENDPOINT and SIGIL_ENDPOINT are both set in config.env, to different values; " +
+				"using AGENTO11Y_ENDPOINT. SIGIL_ENDPOINT is the old name for the same setting: remove it from config.env.",
+		},
+		{
+			name:    "preferred in the environment beats legacy in config.env",
+			osEnv:   map[string]string{"AGENTO11Y_ENDPOINT": "https://a"},
+			fileEnv: map[string]string{"SIGIL_ENDPOINT": "https://b"},
+			want: "AGENTO11Y_ENDPOINT is set in the environment and SIGIL_ENDPOINT in config.env, to different values; " +
+				"using AGENTO11Y_ENDPOINT. SIGIL_ENDPOINT is the old name for the same setting: remove it from config.env.",
+		},
+		{
+			// The surprising case: the old name wins. Naming the rule is the only
+			// way a reader can tell why the config.env value is not in force.
+			name:    "legacy in the environment beats preferred in config.env",
+			osEnv:   map[string]string{"SIGIL_ENDPOINT": "https://b"},
+			fileEnv: map[string]string{"AGENTO11Y_ENDPOINT": "https://a"},
+			want: "SIGIL_ENDPOINT is set in the environment and AGENTO11Y_ENDPOINT in config.env, to different values; " +
+				"using SIGIL_ENDPOINT, because the environment outranks config.env. " +
+				"SIGIL_ENDPOINT is the old name for the same setting: unset it.",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := resolveFamily("ENDPOINT", tc.osEnv, tc.fileEnv)
+			if !r.conflict {
+				t.Fatalf("resolveFamily = %+v, want a conflict", r)
+			}
+			if got := conflictMessage(r); got != tc.want {
+				t.Fatalf("conflictMessage =\n%s\nwant\n%s", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -289,7 +477,8 @@ func TestCollectAnalytics(t *testing.T) {
 			wantHealth:   HealthOK,
 			wantEndpoint: "https://preferred",
 			wantVar:      "AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT",
-			wantMsg:      "AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT and its other spelling are both set with different values",
+			wantMsg: "AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT and SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT are both set in the environment, " +
+				"to different values; using AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT",
 		},
 		{
 			name: "standard otel fallback with auth via SIGIL_AUTH_TOKEN",
@@ -351,8 +540,8 @@ func TestCollectAnalytics(t *testing.T) {
 			if tc.wantEndpoint != "" && sec.Endpoint.Value != tc.wantEndpoint {
 				t.Fatalf("endpoint = %q, want %q", sec.Endpoint.Value, tc.wantEndpoint)
 			}
-			if tc.wantVar != "" && sec.EndpointVar != tc.wantVar {
-				t.Fatalf("endpoint var = %q, want %q", sec.EndpointVar, tc.wantVar)
+			if tc.wantVar != "" && sec.Endpoint.Key != tc.wantVar {
+				t.Fatalf("endpoint key = %q, want %q", sec.Endpoint.Key, tc.wantVar)
 			}
 			if tc.wantMsg != "" && !strings.Contains(strings.Join(sec.Messages, " "), tc.wantMsg) {
 				t.Fatalf("messages %v missing %q", sec.Messages, tc.wantMsg)
@@ -366,13 +555,24 @@ func TestRunProbes(t *testing.T) {
 		name string
 		conv *ProbeResult
 		otlp *AnalyticsProbe
-		// convHealth is the verdict the offline collectors reached; "" means ok.
+		// convHealth and analyticsHealth are the verdicts the offline collectors
+		// reached; "" means ok.
 		convHealth      Health
+		analyticsHealth Health
+		// convKey is the endpoint spelling that won; "" leaves it unset.
+		convKey         string
 		wantConv        Health
 		wantAnalytics   Health
 		wantConvSkipped bool
-		wantConvMsgs    int
-		wantOTLPMsgs    int
+		// wantConvMsgs and wantOTLPMsgs are the section message counts. A probe
+		// that repeats what its own row prints shows up as an extra message here.
+		wantConvMsgs int
+		wantOTLPMsgs int
+		// wantConvMsg and wantAnalyticsMsg are substrings the section messages must
+		// carry. The probe rows show only the status and the URL, so a cause the
+		// message drops is absent from the whole human report.
+		wantConvMsg      string
+		wantAnalyticsMsg string
 	}{
 		{
 			name:          "all reachable",
@@ -382,49 +582,189 @@ func TestRunProbes(t *testing.T) {
 			wantAnalytics: HealthOK,
 		},
 		{
-			// The probe line already prints the message, so the
-			// section must not repeat it.
-			name:          "401 escalates without repeating the probe message",
-			conv:          &ProbeResult{StatusCode: 401, Message: "credentials rejected"},
-			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 401, Message: "credentials rejected"}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
-			wantConv:      HealthError,
-			wantAnalytics: HealthError,
+			// The row prints the status alone, so the section message has to
+			// carry the credential diagnosis.
+			name:             "401 escalates and reports why auth failed",
+			conv:             &ProbeResult{StatusCode: 401, Message: "credentials rejected"},
+			otlp:             &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 401, Message: "credentials rejected"}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			wantConv:         HealthError,
+			wantAnalytics:    HealthError,
+			wantConvMsgs:     1,
+			wantOTLPMsgs:     1,
+			wantConvMsg:      "the conversations endpoint rejected the export request: HTTP 401: credentials rejected",
+			wantAnalyticsMsg: "the OTLP endpoint rejected the metrics export: HTTP 401: credentials rejected",
 		},
 		{
-			name:          "403 escalates without repeating the probe message",
-			conv:          &ProbeResult{StatusCode: 403, Message: "missing sigil:write"},
-			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 200, OK: true}, Traces: &ProbeResult{StatusCode: 403, Message: "missing traces:write"}},
-			wantConv:      HealthError,
-			wantAnalytics: HealthError,
+			name:             "403 escalates and reports the missing scope",
+			conv:             &ProbeResult{StatusCode: 403, Message: "missing sigil:write"},
+			otlp:             &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 200, OK: true}, Traces: &ProbeResult{StatusCode: 403, Message: "missing traces:write"}},
+			wantConv:         HealthError,
+			wantAnalytics:    HealthError,
+			wantConvMsgs:     1,
+			wantOTLPMsgs:     1,
+			wantConvMsg:      "the conversations endpoint rejected the export request: HTTP 403: missing sigil:write",
+			wantAnalyticsMsg: "the OTLP endpoint rejected the traces export: HTTP 403: missing traces:write",
 		},
 		{
-			name:          "transport error escalates",
-			conv:          &ProbeResult{StatusCode: 0, Message: "connection refused"},
-			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 0, Message: "timeout"}, Traces: &ProbeResult{StatusCode: 0, Message: "timeout"}},
+			// Both signals authenticate with the same credentials, so one
+			// diagnosis covers them and is printed once.
+			name:             "both OTLP signals failing the same way share one message",
+			conv:             &ProbeResult{StatusCode: 202, OK: true},
+			otlp:             &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 401, Message: "credentials rejected"}, Traces: &ProbeResult{StatusCode: 401, Message: "credentials rejected"}},
+			wantConv:         HealthOK,
+			wantAnalytics:    HealthError,
+			wantOTLPMsgs:     1,
+			wantAnalyticsMsg: "the OTLP endpoint rejected the metrics and traces exports: HTTP 401: credentials rejected",
+		},
+		{
+			// A token that carries one write scope and not the other fails the
+			// signals differently, and each failure is its own diagnosis.
+			name:             "OTLP signals failing differently get a line each",
+			conv:             &ProbeResult{StatusCode: 202, OK: true},
+			otlp:             &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 401, Message: "credentials rejected"}, Traces: &ProbeResult{StatusCode: 403, Message: "missing traces:write"}},
+			wantConv:         HealthOK,
+			wantAnalytics:    HealthError,
+			wantOTLPMsgs:     2,
+			wantAnalyticsMsg: "the OTLP endpoint rejected the traces export: HTTP 403: missing traces:write",
+		},
+		{
+			name:             "transport error escalates",
+			conv:             &ProbeResult{StatusCode: 0, Message: "connection refused"},
+			otlp:             &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 0, Message: "dial tcp: lookup otlp.example: no such host"}, Traces: &ProbeResult{StatusCode: 0, Message: "dial tcp: lookup otlp.example: no such host"}},
+			wantConv:         HealthError,
+			wantAnalytics:    HealthError,
+			wantConvMsgs:     1,
+			wantOTLPMsgs:     1,
+			wantConvMsg:      "no response: connection refused",
+			wantAnalyticsMsg: "no response: dial tcp: lookup otlp.example: no such host",
+		},
+		{
+			name:             "5xx escalates",
+			conv:             &ProbeResult{StatusCode: 503},
+			otlp:             &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 500}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			wantConv:         HealthError,
+			wantAnalytics:    HealthError,
+			wantConvMsgs:     1,
+			wantOTLPMsgs:     1,
+			wantConvMsg:      "HTTP 503",
+			wantAnalyticsMsg: "HTTP 500",
+		},
+		{
+			// The endpoint answered, but it bounced the export POST somewhere
+			// else, so nothing is ingested.
+			name:          "conversations redirect escalates",
+			conv:          &ProbeResult{StatusCode: 302, Message: "redirected to /login"},
+			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 200, OK: true}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
 			wantConv:      HealthError,
-			wantAnalytics: HealthError,
+			wantAnalytics: HealthOK,
 			wantConvMsgs:  1,
-			wantOTLPMsgs:  1,
+			wantConvMsg:   "is not an Agent Observability API URL",
 		},
 		{
-			name:          "5xx escalates",
-			conv:          &ProbeResult{StatusCode: 503},
-			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 500}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			// The legacy spelling won, so the message must name it rather than
+			// the preferred one the user never set.
+			name:          "redirect message names the resolved endpoint key",
+			conv:          &ProbeResult{StatusCode: 302, Message: "redirected to /login"},
+			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 200, OK: true}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			convKey:       "SIGIL_ENDPOINT",
 			wantConv:      HealthError,
-			wantAnalytics: HealthError,
+			wantAnalytics: HealthOK,
 			wantConvMsgs:  1,
-			wantOTLPMsgs:  1,
+			wantConvMsg:   "SIGIL_ENDPOINT is not an Agent Observability API URL",
 		},
 		{
-			name:          "benign 4xx stays healthy",
-			conv:          &ProbeResult{StatusCode: 400},
-			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 415}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			name:             "otlp metrics redirect escalates",
+			conv:             &ProbeResult{StatusCode: 200, OK: true},
+			otlp:             &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 307, Message: "redirected to /login"}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			wantConv:         HealthOK,
+			wantAnalytics:    HealthError,
+			wantOTLPMsgs:     1,
+			wantAnalyticsMsg: "the OTLP endpoint redirected the export request, so it is not an OTLP ingest URL",
+		},
+		{
+			// Either signal redirecting is enough to condemn the endpoint.
+			name:             "otlp traces redirect escalates",
+			conv:             &ProbeResult{StatusCode: 200, OK: true},
+			otlp:             &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 200, OK: true}, Traces: &ProbeResult{StatusCode: 302, Message: "redirected to /login"}},
+			wantConv:         HealthOK,
+			wantAnalytics:    HealthError,
+			wantOTLPMsgs:     1,
+			wantAnalyticsMsg: "the OTLP endpoint redirected the export request, so it is not an OTLP ingest URL",
+		},
+		{
+			// The host answered but does not serve the export route, so the
+			// endpoint belongs to some other service. Every host 404s an unknown
+			// path, so this must never read as healthy.
+			name:             "404 escalates on both pipelines",
+			conv:             &ProbeResult{StatusCode: 404},
+			otlp:             &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 404}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			wantConv:         HealthError,
+			wantAnalytics:    HealthError,
+			wantConvMsgs:     1,
+			wantOTLPMsgs:     1,
+			wantConvMsg:      "no generation-export route (HTTP 404)",
+			wantAnalyticsMsg: "no ingest route (HTTP 404)",
+		},
+		{
+			// A body-validating endpoint can answer 400/415 to the minimal probe
+			// body while real exports work, so warn instead of failing. The real
+			// export route answers 202, so it cannot pass either.
+			name:             "body rejection warns",
+			conv:             &ProbeResult{StatusCode: 400},
+			otlp:             &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 415}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			wantConv:         HealthWarn,
+			wantAnalytics:    HealthWarn,
+			wantConvMsgs:     1,
+			wantOTLPMsgs:     1,
+			wantConvMsg:      "answered HTTP 400 instead of HTTP 202",
+			wantAnalyticsMsg: "did not accept the probe",
+		},
+		{
+			// 405 is the one non-2xx that passes: a method-restricted route still
+			// proves the request reached the service and passed auth.
+			name:          "405 stays healthy",
+			conv:          &ProbeResult{StatusCode: 405, OK: true},
+			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 405, OK: true}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
 			wantConv:      HealthOK,
 			wantAnalytics: HealthOK,
 		},
 		{
+			// A probe warning must not clear the offline endpoint error either.
+			name:            "body rejection does not downgrade an analytics error",
+			conv:            &ProbeResult{StatusCode: 202, OK: true},
+			otlp:            &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 400}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			analyticsHealth: HealthError,
+			wantConv:        HealthOK,
+			wantAnalytics:   HealthError,
+			wantOTLPMsgs:    1,
+		},
+		{
+			// Only HealthError suppresses probing, which is what makes the
+			// offline shape heuristic safe: a warned endpoint is still probed,
+			// and the redirect proves it is broken.
+			name:          "warned endpoint is probed and escalated",
+			conv:          &ProbeResult{StatusCode: 302, Message: "redirected to /login"},
+			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 200, OK: true}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			convHealth:    HealthWarn,
+			wantConv:      HealthError,
+			wantAnalytics: HealthOK,
+			wantConvMsgs:  2, // the offline warning, plus the probe verdict
+			wantConvMsg:   "is not an Agent Observability API URL",
+		},
+		{
+			// A reachable endpoint does not clear the offline warning either.
+			name:          "warned endpoint that answers stays warned",
+			conv:          &ProbeResult{StatusCode: 202, OK: true},
+			otlp:          &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 200, OK: true}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
+			convHealth:    HealthWarn,
+			wantConv:      HealthWarn,
+			wantAnalytics: HealthOK,
+			wantConvMsgs:  1, // the offline warning, alone
+		},
+		{
 			// The offline endpoint check already failed, so probing would
-			// report the same fault a second and third time.
+			// report the same fault a second and third time. This covers both
+			// offline rejections: a malformed endpoint and an app-page path.
 			name:            "endpoint already rejected offline is not probed",
 			conv:            &ProbeResult{StatusCode: 0, Message: "invalid endpoint: parse …"},
 			otlp:            &AnalyticsProbe{Metrics: &ProbeResult{StatusCode: 200, OK: true}, Traces: &ProbeResult{StatusCode: 200, OK: true}},
@@ -454,9 +794,13 @@ func TestRunProbes(t *testing.T) {
 			} else {
 				convMsgs = []string{"AGENTO11Y_ENDPOINT is not a usable endpoint: …"}
 			}
+			analyticsHealth := tc.analyticsHealth
+			if analyticsHealth == "" {
+				analyticsHealth = HealthOK
+			}
 			r := &Report{
 				Conversations: ConversationsSection{
-					Endpoint: envValue{Set: true, Value: "https://sigil.example.net"},
+					Endpoint: envValue{Set: true, Value: "https://sigil.example.net", Key: tc.convKey},
 					TenantID: envValue{Set: true, Value: "t", Key: "AGENTO11Y_AUTH_TENANT_ID"},
 					Token:    tokenValue{Set: true},
 					Health:   convHealth,
@@ -464,12 +808,15 @@ func TestRunProbes(t *testing.T) {
 				},
 				Analytics: AnalyticsSection{
 					Endpoint: envValue{Set: true, Value: "https://otlp.example.net"},
-					Health:   HealthOK,
+					Health:   analyticsHealth,
 				},
 			}
 			runProbes(context.Background(), r, map[string]string{}, nil)
 			if r.Conversations.Health != tc.wantConv {
 				t.Fatalf("conversations health = %q, want %q", r.Conversations.Health, tc.wantConv)
+			}
+			if tc.wantConvMsg != "" && !strings.Contains(strings.Join(r.Conversations.Messages, " "), tc.wantConvMsg) {
+				t.Fatalf("conversations messages %v missing %q", r.Conversations.Messages, tc.wantConvMsg)
 			}
 			if tc.wantConvSkipped {
 				if r.Conversations.Probe != nil {
@@ -478,12 +825,15 @@ func TestRunProbes(t *testing.T) {
 			} else if r.Conversations.Probe == nil {
 				t.Fatal("conversations probe did not run")
 			} else if r.Conversations.Probe.Message != tc.conv.Message {
-				// The section drops its own message on an auth failure, so the
-				// probe result must keep the explanation both renderers print.
+				// The JSON report prints the probe result as it stands, so the
+				// section must not edit the explanation out of it.
 				t.Fatalf("probe message = %q, want %q", r.Conversations.Probe.Message, tc.conv.Message)
 			}
 			if r.Analytics.Health != tc.wantAnalytics {
 				t.Fatalf("analytics health = %q, want %q", r.Analytics.Health, tc.wantAnalytics)
+			}
+			if tc.wantAnalyticsMsg != "" && !strings.Contains(strings.Join(r.Analytics.Messages, " "), tc.wantAnalyticsMsg) {
+				t.Fatalf("analytics messages %v missing %q", r.Analytics.Messages, tc.wantAnalyticsMsg)
 			}
 			if gotOTLPTenant != r.Conversations.TenantID {
 				t.Fatalf("OTLP probe tenant = %+v, want %+v", gotOTLPTenant, r.Conversations.TenantID)
@@ -629,64 +979,208 @@ func TestCollectConfig_PathResolution(t *testing.T) {
 	}
 }
 
+// TestCollectConfig_ContentMode covers the content capture row: the effective
+// mode, and which variable supplied it. Doctor resolves the mode from the env
+// snapshot so it can attribute the value; the parsing and the fall-back stay in
+// envconfig, shared with the hooks.
 func TestCollectConfig_ContentMode(t *testing.T) {
 	tests := []struct {
 		name         string
-		mode         string
+		osEnv        map[string]string
+		fileEnv      map[string]string
 		wantMode     string
+		wantKey      string
+		wantSource   string
 		wantFellBack bool
 		wantHealth   Health // "" = don't assert
+		wantMsg      string // substring of a ConfigSection message
+		wantRendered string
 	}{
-		{name: "invalid mode falls back", mode: "bogus", wantMode: "metadata_only", wantFellBack: true, wantHealth: HealthWarn},
-		{name: "valid mode no fallback", mode: "full", wantMode: "full", wantFellBack: false},
+		{
+			// Nothing is configured, so the row has to say the value is the
+			// built-in one rather than a choice the user made.
+			name: "unset uses the built-in default", wantMode: "metadata_only",
+			wantRendered: "content capture: metadata_only (default)",
+		},
+		{
+			// The rejected value did not supply the mode in force, so the row credits
+			// the built-in default and the message names the variable to fix. Naming
+			// the variable on the row would make it identical to a valid value.
+			name: "invalid mode falls back", osEnv: map[string]string{"SIGIL_CONTENT_CAPTURE_MODE": "bogus"},
+			wantMode: "metadata_only", wantFellBack: true, wantHealth: HealthWarn,
+			wantMsg:      "the SIGIL_CONTENT_CAPTURE_MODE value is invalid; using metadata_only",
+			wantRendered: "content capture: metadata_only (default)",
+		},
+		{
+			name: "from the shell", osEnv: map[string]string{"AGENTO11Y_CONTENT_CAPTURE_MODE": "full"},
+			wantMode: "full", wantKey: "AGENTO11Y_CONTENT_CAPTURE_MODE", wantSource: sourceEnv,
+			wantRendered: "content capture: full (AGENTO11Y_CONTENT_CAPTURE_MODE, env)",
+		},
+		{
+			name: "from config.env", fileEnv: map[string]string{"AGENTO11Y_CONTENT_CAPTURE_MODE": "no_tool_content"},
+			wantMode: "no_tool_content", wantKey: "AGENTO11Y_CONTENT_CAPTURE_MODE", wantSource: sourceConfig,
+			wantRendered: "content capture: no_tool_content (AGENTO11Y_CONTENT_CAPTURE_MODE, config.env)",
+		},
+		{
+			// The shell wins, so the row must not name the config.env value the
+			// hooks never see.
+			name:  "shell wins over config.env",
+			osEnv: map[string]string{"AGENTO11Y_CONTENT_CAPTURE_MODE": "full"},
+			fileEnv: map[string]string{
+				"AGENTO11Y_CONTENT_CAPTURE_MODE": "metadata_only",
+			},
+			wantMode: "full", wantKey: "AGENTO11Y_CONTENT_CAPTURE_MODE", wantSource: sourceEnv,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			isolateEnv(t)
-			t.Setenv("SIGIL_CONTENT_CAPTURE_MODE", tc.mode)
 
-			sec := collectConfig(nil, nil)
+			sec := collectConfig(tc.osEnv, tc.fileEnv)
 			if sec.ContentModeFellBack != tc.wantFellBack {
 				t.Fatalf("ContentModeFellBack = %v, want %v", sec.ContentModeFellBack, tc.wantFellBack)
 			}
 			if sec.ContentCaptureMode != tc.wantMode {
 				t.Fatalf("mode = %q, want %q", sec.ContentCaptureMode, tc.wantMode)
 			}
+			if sec.ContentModeKey != tc.wantKey || sec.ContentModeSource != tc.wantSource {
+				t.Fatalf("content mode provenance = %q/%q, want %q/%q",
+					sec.ContentModeKey, sec.ContentModeSource, tc.wantKey, tc.wantSource)
+			}
 			if tc.wantHealth != "" && sec.Health != tc.wantHealth {
 				t.Fatalf("health = %q, want %q", sec.Health, tc.wantHealth)
+			}
+			if tc.wantMsg != "" && !strings.Contains(strings.Join(sec.Messages, " "), tc.wantMsg) {
+				t.Fatalf("messages %v missing %q", sec.Messages, tc.wantMsg)
+			}
+			if tc.wantRendered == "" {
+				return
+			}
+			var buf bytes.Buffer
+			renderHuman(&buf, &Report{Config: sec}, false)
+			if !strings.Contains(buf.String(), tc.wantRendered) {
+				t.Fatalf("rendered report missing %q:\n%s", tc.wantRendered, buf.String())
 			}
 		})
 	}
 }
 
+// TestCollectConfig_ContentModeReadsTheSnapshot pins the wiring: the mode is
+// resolved from the snapshot doctor was handed, not from the process env after
+// the dotenv merge. Reading the process env would attribute every config.env
+// value to the shell.
+func TestCollectConfig_ContentModeReadsTheSnapshot(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("AGENTO11Y_CONTENT_CAPTURE_MODE", "full")
+
+	sec := collectConfig(nil, map[string]string{"AGENTO11Y_CONTENT_CAPTURE_MODE": "no_tool_content"})
+	if sec.ContentCaptureMode != "no_tool_content" || sec.ContentModeSource != sourceConfig {
+		t.Fatalf("mode = %q from %q, want no_tool_content from config.env", sec.ContentCaptureMode, sec.ContentModeSource)
+	}
+}
+
 func TestCollectConfig_Guards(t *testing.T) {
+	// The guard families have to be in the snapshot the binary passes in, or a
+	// shell-exported timeout reads as unset here while the hooks act on it.
+	for _, suffix := range []string{"GUARDS_ENABLED", "GUARDS_FAIL_OPEN", "GUARDS_TIMEOUT_MS"} {
+		if !slices.Contains(trackedSuffixes, suffix) {
+			t.Fatalf("trackedSuffixes is missing %s, so SnapshotEnv would not record it", suffix)
+		}
+	}
 	tests := []struct {
 		name          string
-		enabled       string
-		timeout       string
-		failOpen      string
+		osEnv         map[string]string
+		fileEnv       map[string]string
 		wantEnabled   bool
 		wantTimeoutMs int
 		wantFailOpen  bool
 		wantFellBack  bool
+		wantKey       string
+		wantSource    string
 		wantHealth    Health // "" = don't assert
+		wantMsg       string // substring of a ConfigSection message
+		wantRendered  string
 	}{
-		{name: "unset uses defaults", wantEnabled: false, wantTimeoutMs: 1500, wantFailOpen: true},
-		{name: "enabled fail-open", enabled: "true", wantEnabled: true, wantTimeoutMs: 1500, wantFailOpen: true},
-		{name: "enabled fail-closed with timeout", enabled: "1", timeout: "500", failOpen: "false", wantEnabled: true, wantTimeoutMs: 500, wantFailOpen: false},
-		{name: "invalid enabled falls back", enabled: "maybe", wantEnabled: false, wantTimeoutMs: 1500, wantFailOpen: true, wantFellBack: true, wantHealth: HealthWarn},
-		{name: "invalid timeout falls back", enabled: "true", timeout: "-1", wantEnabled: true, wantTimeoutMs: 1500, wantFailOpen: true, wantFellBack: true, wantHealth: HealthWarn},
+		{
+			name: "unset uses defaults", wantEnabled: false, wantTimeoutMs: 1500, wantFailOpen: true,
+			wantRendered: "guards:          disabled (default)",
+		},
+		{
+			name: "enabled fail-open", osEnv: map[string]string{"AGENTO11Y_GUARDS_ENABLED": "true"},
+			wantEnabled: true, wantTimeoutMs: 1500, wantFailOpen: true,
+			wantKey: "AGENTO11Y_GUARDS_ENABLED", wantSource: sourceEnv,
+			wantRendered: "guards:          enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, env)",
+		},
+		{
+			name: "enabled fail-closed with timeout from config.env",
+			fileEnv: map[string]string{
+				"AGENTO11Y_GUARDS_ENABLED":    "1",
+				"AGENTO11Y_GUARDS_TIMEOUT_MS": "500",
+				"AGENTO11Y_GUARDS_FAIL_OPEN":  "false",
+			},
+			wantEnabled: true, wantTimeoutMs: 500, wantFailOpen: false,
+			wantKey: "AGENTO11Y_GUARDS_ENABLED", wantSource: sourceConfig,
+			wantRendered: "guards:          enabled, timeout 500ms, fail-closed (AGENTO11Y_GUARDS_ENABLED, config.env)",
+		},
+		{
+			name: "legacy spelling", osEnv: map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			wantEnabled: true, wantTimeoutMs: 1500, wantFailOpen: true,
+			wantKey: "SIGIL_GUARDS_ENABLED", wantSource: sourceEnv,
+			wantRendered: "guards:          enabled, timeout 1500ms, fail-open (SIGIL_GUARDS_ENABLED, env)",
+		},
+		{
+			// The rejected value did not decide whether guards run, so the row credits
+			// the built-in default and the message names the variable to fix.
+			name: "invalid enabled falls back", osEnv: map[string]string{"AGENTO11Y_GUARDS_ENABLED": "maybe"},
+			wantEnabled: false, wantTimeoutMs: 1500, wantFailOpen: true, wantFellBack: true,
+			wantHealth:   HealthWarn,
+			wantMsg:      "the AGENTO11Y_GUARDS_ENABLED value is invalid; guards use the default",
+			wantRendered: "guards:          disabled (default)",
+		},
+		{
+			// GUARDS_ENABLED is fine, so the row keeps naming it. Only the message can
+			// say the timeout is the broken value.
+			name: "invalid timeout falls back",
+			osEnv: map[string]string{
+				"AGENTO11Y_GUARDS_ENABLED":    "true",
+				"AGENTO11Y_GUARDS_TIMEOUT_MS": "-1",
+			},
+			wantEnabled: true, wantTimeoutMs: 1500, wantFailOpen: true, wantFellBack: true,
+			wantKey: "AGENTO11Y_GUARDS_ENABLED", wantSource: sourceEnv, wantHealth: HealthWarn,
+			wantMsg:      "the AGENTO11Y_GUARDS_TIMEOUT_MS value is invalid; guards use the default",
+			wantRendered: "guards:          enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, env)",
+		},
+		{
+			// The fail mode is the third family, and it is the one the row never names.
+			name: "invalid fail-open falls back",
+			fileEnv: map[string]string{
+				"AGENTO11Y_GUARDS_ENABLED":   "true",
+				"AGENTO11Y_GUARDS_FAIL_OPEN": "fals",
+			},
+			wantEnabled: true, wantTimeoutMs: 1500, wantFailOpen: true, wantFellBack: true,
+			wantKey: "AGENTO11Y_GUARDS_ENABLED", wantSource: sourceConfig, wantHealth: HealthWarn,
+			wantMsg:      "the AGENTO11Y_GUARDS_FAIL_OPEN value is invalid; guards use the default",
+			wantRendered: "guards:          enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, config.env)",
+		},
+		{
+			// Only GUARDS_ENABLED names the row, and it is unset, so the row
+			// reports the default even though a timeout is configured.
+			name:    "timeout alone leaves the row on its default",
+			fileEnv: map[string]string{"AGENTO11Y_GUARDS_TIMEOUT_MS": "800"},
+			// TimeoutMs is still resolved; the row just cannot claim a key for it.
+			wantEnabled: false, wantTimeoutMs: 800, wantFailOpen: true,
+			wantRendered: "guards:          disabled (default)",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// ResolveGuards reads the process env directly, so isolateEnv has to
-			// clear the host's GUARDS_* values before the case sets its own.
+			// collectConfig reads guards from the snapshot alone, but it still calls
+			// dotenv.FilePath(), which follows HOME. Without isolateEnv the developer's
+			// own config.env decides Path, Exists and DisallowedKeys, which the
+			// rendered rows below are matched against.
 			isolateEnv(t)
-			t.Setenv(envconfig.PreferredKey("GUARDS_ENABLED"), tc.enabled)
-			t.Setenv(envconfig.PreferredKey("GUARDS_TIMEOUT_MS"), tc.timeout)
-			t.Setenv(envconfig.PreferredKey("GUARDS_FAIL_OPEN"), tc.failOpen)
 
-			sec := collectConfig(nil, nil)
+			sec := collectConfig(tc.osEnv, tc.fileEnv)
 			if sec.GuardsEnabled != tc.wantEnabled {
 				t.Fatalf("GuardsEnabled = %v, want %v", sec.GuardsEnabled, tc.wantEnabled)
 			}
@@ -699,8 +1193,71 @@ func TestCollectConfig_Guards(t *testing.T) {
 			if sec.GuardsFellBack != tc.wantFellBack {
 				t.Fatalf("GuardsFellBack = %v, want %v", sec.GuardsFellBack, tc.wantFellBack)
 			}
+			if sec.GuardsKey != tc.wantKey || sec.GuardsSource != tc.wantSource {
+				t.Fatalf("guards provenance = %q/%q, want %q/%q",
+					sec.GuardsKey, sec.GuardsSource, tc.wantKey, tc.wantSource)
+			}
 			if tc.wantHealth != "" && sec.Health != tc.wantHealth {
 				t.Fatalf("health = %q, want %q", sec.Health, tc.wantHealth)
+			}
+			if tc.wantMsg != "" && !strings.Contains(strings.Join(sec.Messages, " "), tc.wantMsg) {
+				t.Fatalf("messages %v missing %q", sec.Messages, tc.wantMsg)
+			}
+			if tc.wantRendered == "" {
+				return
+			}
+			var buf bytes.Buffer
+			renderHuman(&buf, &Report{Config: sec}, false)
+			if !strings.Contains(buf.String(), tc.wantRendered) {
+				t.Fatalf("rendered report missing %q:\n%s", tc.wantRendered, buf.String())
+			}
+		})
+	}
+}
+
+// TestCollectConfig_GuardsFaultsMatchEnvconfig pins doctor's fault detection to
+// envconfig's. collectConfig names the rejected variable itself rather than
+// reading the resolver's diagnostics, so without this a rule that changed in
+// envconfig alone would leave doctor calling a discarded value good, or naming a
+// variable the hooks accepted.
+func TestCollectConfig_GuardsFaultsMatchEnvconfig(t *testing.T) {
+	envs := []map[string]string{
+		nil,
+		{"AGENTO11Y_GUARDS_ENABLED": "true"},
+		{"AGENTO11Y_GUARDS_ENABLED": "maybe"},
+		{"AGENTO11Y_GUARDS_TIMEOUT_MS": "500"},
+		{"AGENTO11Y_GUARDS_TIMEOUT_MS": "0"},
+		{"SIGIL_GUARDS_TIMEOUT_MS": "abc"},
+		{"AGENTO11Y_GUARDS_FAIL_OPEN": "off"},
+		{"AGENTO11Y_GUARDS_FAIL_OPEN": "fals"},
+		{"AGENTO11Y_GUARDS_ENABLED": "ture", "SIGIL_GUARDS_TIMEOUT_MS": "-3"},
+	}
+	for _, osEnv := range envs {
+		// fmt prints a map in sorted key order, so the subtest name is stable.
+		t.Run(fmt.Sprint(osEnv), func(t *testing.T) {
+			isolateEnv(t)
+
+			// The resolver's own diagnostics are the reference: it logs one line per
+			// value it rejects.
+			var buf bytes.Buffer
+			envconfig.ResolveGuardsWith(log.New(&buf, "", 0), func(suffix string) (value, key string, ok bool) {
+				r := resolveFamily(suffix, osEnv, nil)
+				return r.value, r.key, r.set
+			})
+			logged := buf.String()
+
+			sec := collectConfig(osEnv, nil)
+			if want := logged != ""; sec.GuardsFellBack != want {
+				t.Fatalf("GuardsFellBack = %v, want %v (envconfig logged %q)", sec.GuardsFellBack, want, logged)
+			}
+			messages := strings.Join(sec.Messages, " ")
+			for key := range osEnv {
+				if !strings.Contains(logged, key+"=") {
+					continue
+				}
+				if !strings.Contains(messages, key) {
+					t.Fatalf("envconfig rejected %s but messages %v do not name it", key, sec.Messages)
+				}
 			}
 		})
 	}
@@ -741,7 +1298,8 @@ func TestCollectConfig_Tags(t *testing.T) {
 			},
 			wantTags:   map[string]string{"env": "prod"},
 			wantSource: sourceEnv,
-			wantMsg:    "AGENTO11Y_TAGS and its other spelling are both set with different values; using AGENTO11Y_TAGS",
+			wantMsg: "AGENTO11Y_TAGS and SIGIL_TAGS are both set in the environment, to different values; using AGENTO11Y_TAGS. " +
+				"SIGIL_TAGS is the old name for the same setting: unset it.",
 		},
 		{
 			name:       "legacy-only tags suggest migration",
@@ -810,7 +1368,7 @@ func TestCollectConfig_Local(t *testing.T) {
 			wantSource:   sourceConfig,
 			wantHealth:   HealthOK,
 			wantScopeMsg: true,
-			wantRendered: []string{"local mode", "true (config.env)"},
+			wantRendered: []string{"local mode", "true (AGENTO11Y_LOCAL, config.env)"},
 		},
 		{
 			name:         "from env",
@@ -819,7 +1377,7 @@ func TestCollectConfig_Local(t *testing.T) {
 			wantSource:   sourceEnv,
 			wantHealth:   HealthOK,
 			wantScopeMsg: true,
-			wantRendered: []string{"local mode", "true (env)"},
+			wantRendered: []string{"local mode", "true (AGENTO11Y_LOCAL, env)"},
 		},
 		{
 			name:         "legacy spelling",
@@ -829,7 +1387,7 @@ func TestCollectConfig_Local(t *testing.T) {
 			wantHealth:   HealthOK,
 			wantScopeMsg: true,
 			wantMsg:      "the preferred name is AGENTO11Y_LOCAL",
-			wantRendered: []string{"on (env)"},
+			wantRendered: []string{"on (SIGIL_LOCAL, env)"},
 		},
 		{
 			// The one-off Cloud session: the shell value is what the launcher
@@ -840,20 +1398,22 @@ func TestCollectConfig_Local(t *testing.T) {
 			wantValue:       "false",
 			wantSource:      sourceEnv,
 			wantHealth:      HealthOK,
-			wantRendered:    []string{"false (env)"},
+			wantRendered:    []string{"false (AGENTO11Y_LOCAL, env)"},
 			wantNotRendered: []string{"invalid value"},
 		},
 		{
-			// The launcher ignores a value outside the boolean whitelist, so a
-			// report that prints it plainly confirms the wrong belief.
-			name:         "value outside the boolean whitelist",
-			osEnv:        map[string]string{"AGENTO11Y_LOCAL": "enabled"},
-			wantValue:    "enabled",
-			wantSource:   sourceEnv,
-			wantInvalid:  true,
-			wantHealth:   HealthWarn,
-			wantMsg:      "the AGENTO11Y_LOCAL value is not a boolean; local mode stays off",
-			wantRendered: []string{"enabled (env)", "invalid value, local mode is off"},
+			// The launcher ignores a value outside the boolean whitelist, so the row
+			// states the mode in force and keeps the rejected value in its one
+			// trailer. Printing "enabled" as the state would confirm the wrong belief.
+			name:            "value outside the boolean whitelist",
+			osEnv:           map[string]string{"AGENTO11Y_LOCAL": "enabled"},
+			wantValue:       "enabled",
+			wantSource:      sourceEnv,
+			wantInvalid:     true,
+			wantHealth:      HealthWarn,
+			wantMsg:         "the AGENTO11Y_LOCAL value is not a boolean; local mode stays off",
+			wantRendered:    []string{`local mode:      off (AGENTO11Y_LOCAL="enabled" is not a boolean, env)`},
+			wantNotRendered: []string{"enabled (AGENTO11Y_LOCAL, env)", "invalid value, local mode is off"},
 		},
 	}
 	for _, tc := range tests {
@@ -885,7 +1445,7 @@ func TestCollectConfig_Local(t *testing.T) {
 			}
 
 			var buf bytes.Buffer
-			renderHuman(&buf, &Report{Config: sec}, false, false)
+			renderHuman(&buf, &Report{Config: sec}, false)
 			rendered := buf.String()
 			for _, want := range tc.wantRendered {
 				if !strings.Contains(rendered, want) {
@@ -1088,11 +1648,6 @@ func TestCollectConfig_LocalHookForward(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			isolateEnv(t)
-			// ResolveGuards reads the process environment directly, so the
-			// guard toggle has to be exported as well as passed in.
-			for k, v := range tc.env {
-				t.Setenv(k, v)
-			}
 
 			sec := collectConfig(tc.env, tc.fileEnv)
 			if tc.wantMessage == "" {
@@ -1118,15 +1673,15 @@ func TestCollectConfig_LocalHookForward(t *testing.T) {
 			// The rendered report must state the Cloud reach only when it is
 			// real, and must give the reason otherwise.
 			var buf bytes.Buffer
-			renderHuman(&buf, &Report{Config: sec}, false, false)
+			renderHuman(&buf, &Report{Config: sec}, false)
 			rendered := buf.String()
 			if tc.wantEnabled {
-				if !strings.Contains(rendered, "local hook evaluation reaches Cloud") {
+				if !strings.Contains(rendered, "forwarded to Cloud") {
 					t.Fatalf("rendered report missing the Cloud reach line:\n%s", rendered)
 				}
 				return
 			}
-			if strings.Contains(rendered, "local hook evaluation reaches Cloud") {
+			if strings.Contains(rendered, "forwarded to Cloud") {
 				t.Fatalf("rendered report claims Cloud reach when the leg is off:\n%s", rendered)
 			}
 			if sec.LocalForward.Set && !strings.Contains(rendered, tc.wantReason) {
@@ -1174,6 +1729,48 @@ func TestRun(t *testing.T) {
 				for _, key := range []string{"agento11y", "config", "conversations", "analytics", "agents"} {
 					if _, ok := report[key]; !ok {
 						t.Fatalf("JSON missing section %q", key)
+					}
+				}
+			},
+		},
+		{
+			// Support reads this shape. Each reported value carries the winning key
+			// and source, one field per fact, and never the token itself.
+			name: "json carries provenance for every reported value",
+			args: []string{"--json"},
+			osEnv: mergeEnv(healthy, map[string]string{
+				"AGENTO11Y_AUTH_TOKEN":           "glc_secret",
+				"AGENTO11Y_TAGS":                 "env=prod",
+				"AGENTO11Y_CONTENT_CAPTURE_MODE": "full",
+				"AGENTO11Y_GUARDS_ENABLED":       "true",
+				"AGENTO11Y_AUTO_UPDATE":          "false",
+			}),
+			stub:     true,
+			wantCode: 0,
+			check: func(t *testing.T, stdout string) {
+				if strings.Contains(stdout, "glc_secret") {
+					t.Fatalf("token value leaked into JSON output:\n%s", stdout)
+				}
+				// endpoint.key already carries the endpoint variable name, so the
+				// second field for the same fact is gone.
+				if strings.Contains(stdout, "endpoint_var") {
+					t.Fatalf("endpoint_var is still in the JSON contract:\n%s", stdout)
+				}
+				var report Report
+				if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+					t.Fatalf("invalid JSON: %v", err)
+				}
+				for _, field := range []struct{ name, got, want string }{
+					{"analytics.endpoint.key", report.Analytics.Endpoint.Key, "SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT"},
+					{"config.tags_key", report.Config.TagsKey, "AGENTO11Y_TAGS"},
+					{"config.content_capture_key", report.Config.ContentModeKey, "AGENTO11Y_CONTENT_CAPTURE_MODE"},
+					{"config.content_capture_source", report.Config.ContentModeSource, sourceEnv},
+					{"config.guards_key", report.Config.GuardsKey, "AGENTO11Y_GUARDS_ENABLED"},
+					{"config.guards_source", report.Config.GuardsSource, sourceEnv},
+					{"auto_update.key", report.AutoUpdate.Key, "AGENTO11Y_AUTO_UPDATE"},
+				} {
+					if field.got != field.want {
+						t.Errorf("%s = %q, want %q", field.name, field.got, field.want)
 					}
 				}
 			},

--- a/plugins/agento11y/internal/doctor/probe.go
+++ b/plugins/agento11y/internal/doctor/probe.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -14,13 +15,23 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/otel"
 )
 
-// probeTimeout bounds each network probe so `--probe` stays responsive even
+// probeTimeout bounds each network probe so `doctor` stays responsive even
 // against a black-holed endpoint. A var so tests can shrink it.
 var probeTimeout = 3 * time.Second
 
 // probeClient is the shared client for probes. Per-request contexts carry the
 // real deadline; the client timeout is a backstop.
-var probeClient = &http.Client{Timeout: probeTimeout}
+//
+// Redirects are never followed. An ingest endpoint answers the export POST
+// itself, so a 3xx means the URL points somewhere else: a Grafana stack URL
+// bounces the unauthenticated POST to /login. Following it would report the
+// login page's 200 and certify a pipeline that drops every export.
+var probeClient = &http.Client{
+	Timeout: probeTimeout,
+	CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
 
 // defaultProbeConversations checks the generation-export endpoint with the
 // same headers a real export sends: HTTP Basic auth (base64(tenant:token))
@@ -34,7 +45,7 @@ var probeClient = &http.Client{Timeout: probeTimeout}
 // resolves to http here just as the SDK exporter does; otherwise the probe
 // would hit https and report a cleartext setup as unreachable.
 func defaultProbeConversations(ctx context.Context, endpoint string, tenant envValue, token string, insecure bool) *ProbeResult {
-	target, err := wire.NormalizeGenerationExportURL(endpoint, insecure)
+	target, err := generationExportProbeURL(endpoint, insecure)
 	if err != nil {
 		return &ProbeResult{Message: "invalid endpoint: " + err.Error()}
 	}
@@ -63,7 +74,7 @@ func defaultProbeConversations(ctx context.Context, endpoint string, tenant envV
 		res.Message = credentialsRejectedMessage(tenant) +
 			". A token without the sigil:write scope is rejected the same way"
 	case res.scopeDenied():
-		res.Message = "endpoint rejected auth — token likely missing sigil:write scope"
+		res.Message = "the token is likely missing the sigil:write scope"
 	}
 	return res
 }
@@ -81,6 +92,37 @@ func credentialsRejectedMessage(tenant envValue) string {
 	}
 	return fmt.Sprintf("%s, or %s (%s) may be wrong",
 		rejected, cmp.Or(tenant.Key, envconfig.PreferredKey("AUTH_TENANT_ID")), tenant.Value)
+}
+
+// generationExportProbeURL builds the URL the plugin exporters really POST to.
+// emit.ExportEndpoint and the claude-code hook both append
+// GenerationExportHTTPPath to AGENTO11Y_ENDPOINT, while
+// wire.NormalizeGenerationExportURL appends it only when the endpoint has no
+// path, because an SDK user may configure a full export URL. Probing the
+// normalized endpoint alone therefore misses the export route for any
+// path-bearing endpoint, which is the shape that breaks export. Normalization
+// still runs first so scheme resolution, including the INSECURE http fallback,
+// stays in one place.
+func generationExportProbeURL(endpoint string, insecure bool) (string, error) {
+	normalized, err := wire.NormalizeGenerationExportURL(endpoint, insecure)
+	if err != nil {
+		return "", err
+	}
+	parsed, err := url.Parse(normalized)
+	if err != nil {
+		return "", err
+	}
+	// Routes are registered exactly, so both branches assign the trimmed path:
+	// an endpoint ending ".../generations:export/" is probed at the canonical
+	// path rather than passed through with its slash. Appending is skipped when
+	// the path already ends with the export path, so an endpoint configured the
+	// long way is not probed at a doubled path.
+	trimmed := strings.TrimRight(parsed.Path, "/")
+	if !strings.HasSuffix(trimmed, wire.GenerationExportHTTPPath) {
+		trimmed += wire.GenerationExportHTTPPath
+	}
+	parsed.Path = trimmed
+	return parsed.String(), nil
 }
 
 // defaultProbeOTLP checks the OTLP metrics and traces endpoints, reusing the
@@ -122,14 +164,15 @@ func probeOTLPSignal(ctx context.Context, target otel.ProbeTarget, tenant envVal
 	case res.credentialsRejected():
 		res.Message = credentialsRejectedMessage(tenant)
 	case res.scopeDenied():
-		res.Message = "missing metrics:write/traces:write scope"
+		res.Message = "the token is likely missing the metrics:write/traces:write scope"
 	}
 	return res
 }
 
-// doProbe sends req and maps the outcome to a ProbeResult. A transport error
-// is reported as no response; any HTTP status below 400 (and 405, since a
-// method-restricted route still proves reach + auth) counts as reachable.
+// doProbe sends req and maps the outcome to a ProbeResult. A transport error is
+// reported as no response. ProbeResult.accepted decides which statuses count,
+// so the reported ok flag and the section verdict cannot disagree. A 3xx never
+// counts; probeClient explains why the probe does not follow one.
 func doProbe(target string, req *http.Request) *ProbeResult {
 	resp, err := probeClient.Do(req)
 	if err != nil {
@@ -137,9 +180,12 @@ func doProbe(target string, req *http.Request) *ProbeResult {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	return &ProbeResult{
-		URL:        target,
-		StatusCode: resp.StatusCode,
-		OK:         resp.StatusCode < 400 || resp.StatusCode == http.StatusMethodNotAllowed,
+	res := &ProbeResult{URL: target, StatusCode: resp.StatusCode}
+	res.OK = res.accepted()
+	// Naming the redirect target is what shows the reader where the export
+	// really went, typically a login page.
+	if location := strings.TrimSpace(resp.Header.Get("Location")); location != "" && res.redirected() {
+		res.Message = "redirected to " + location
 	}
+	return res
 }

--- a/plugins/agento11y/internal/doctor/probe_test.go
+++ b/plugins/agento11y/internal/doctor/probe_test.go
@@ -18,15 +18,21 @@ var probeTenant = envValue{Set: true, Value: "tenant-1", Key: "AGENTO11Y_AUTH_TE
 
 func TestProbeConversations(t *testing.T) {
 	tests := []struct {
-		name    string
-		status  int
-		badURL  bool // probe an unparseable endpoint instead of the test server
-		wantOK  bool
-		wantMsg []string // substrings the probe message must contain
-		skipMsg []string // substrings the probe message must not contain
-		wantErr bool     // transport error: status 0 with a message, server never hit
+		name        string
+		status      int
+		location    string // Location header the probed handler sets
+		endpointSuf string // appended to the test server URL to form the endpoint
+		badURL      bool   // probe an unparseable endpoint instead of the test server
+		wantOK      bool
+		wantErr     bool     // transport error: status 0 with a message, server never hit
+		wantPath    string   // probed path; defaults to wire.GenerationExportHTTPPath
+		wantMsg     []string // substrings the probe message must contain
+		skipMsg     []string // substrings the probe message must not contain
+		wantNoMsg   bool     // the probe must report no message at all
 	}{
 		{name: "200 ok", status: 200, wantOK: true},
+		{name: "202 accepted", status: 202, wantOK: true},
+		{name: "405 method not allowed proves reach", status: 405, wantOK: true},
 		{
 			// 401 is what a bad token and a wrong tenant id both
 			// return, so the message must not blame the scope.
@@ -41,24 +47,56 @@ func TestProbeConversations(t *testing.T) {
 		{
 			name:    "403 blames scope",
 			status:  403,
-			wantMsg: []string{"missing sigil:write scope"},
+			wantMsg: []string{"missing the sigil:write scope"},
 			skipMsg: []string{"credentials rejected"},
 		},
-		{name: "400 reachable", status: 400, wantOK: false},
+		{name: "400 does not count", status: 400, wantOK: false},
+		{name: "404 does not count", status: 404, wantOK: false},
 		{name: "invalid endpoint", badURL: true, wantErr: true},
+		{
+			// The reported failure: a Grafana stack URL bounces the export POST
+			// to /login. Following it would report the login page's 200.
+			name: "302 is not followed", status: 302, location: "/login",
+			wantOK: false, wantMsg: []string{"redirected to /login"},
+		},
+		{name: "301 without a location is not followed", status: 301, wantOK: false, wantNoMsg: true},
+		{
+			// The exporters append the export path to whatever endpoint is
+			// configured, so a base-path endpoint must be probed the same way.
+			name: "base path endpoint gets the export path", status: 200, endpointSuf: "/plugins/grafana-agento11y-app",
+			wantOK: true, wantPath: "/plugins/grafana-agento11y-app" + wire.GenerationExportHTTPPath,
+		},
+		{
+			name: "endpoint already ending in the export path is not doubled", status: 200,
+			endpointSuf: wire.GenerationExportHTTPPath, wantOK: true,
+		},
+		{
+			// Routes are registered exactly, so the canonical path is probed.
+			name: "trailing slash after the export path is trimmed", status: 200,
+			endpointSuf: wire.GenerationExportHTTPPath + "/", wantOK: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var gotPath, gotTenant, gotAuth string
+			var redirectTargetHit bool
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/login" {
+					redirectTargetHit = true
+					w.WriteHeader(200)
+					return
+				}
 				gotPath = r.URL.Path
 				gotTenant = r.Header.Get("X-Scope-OrgID")
 				gotAuth = r.Header.Get("Authorization")
+				if tc.location != "" {
+					w.Header().Set("Location", tc.location)
+				}
 				w.WriteHeader(tc.status)
 			}))
 			defer srv.Close()
 
-			url := srv.URL
+			url := srv.URL + tc.endpointSuf
 			if tc.badURL {
 				url = "://bad"
 			}
@@ -76,6 +114,14 @@ func TestProbeConversations(t *testing.T) {
 			if res.OK != tc.wantOK {
 				t.Fatalf("ok = %v, want %v", res.OK, tc.wantOK)
 			}
+			if redirectTargetHit {
+				t.Fatal("probe followed the redirect")
+			}
+			// Asserted so a redirect without a Location header cannot render a
+			// dangling "redirected to ".
+			if tc.wantNoMsg && res.Message != "" {
+				t.Fatalf("message = %q, want none", res.Message)
+			}
 			for _, want := range tc.wantMsg {
 				if !strings.Contains(res.Message, want) {
 					t.Fatalf("message %q missing %q", res.Message, want)
@@ -86,8 +132,12 @@ func TestProbeConversations(t *testing.T) {
 					t.Fatalf("message %q must not contain %q", res.Message, skip)
 				}
 			}
-			if gotPath != wire.GenerationExportHTTPPath {
-				t.Fatalf("probe hit %q, want %q", gotPath, wire.GenerationExportHTTPPath)
+			wantPath := tc.wantPath
+			if wantPath == "" {
+				wantPath = wire.GenerationExportHTTPPath
+			}
+			if gotPath != wantPath {
+				t.Fatalf("probe hit %q, want %q", gotPath, wantPath)
 			}
 			wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("tenant-1:glc_tok"))
 			if gotTenant != "tenant-1" || gotAuth != wantAuth {
@@ -171,7 +221,7 @@ func TestProbeOTLP(t *testing.T) {
 			name:    "403 blames scope",
 			status:  403,
 			tenant:  probeTenant,
-			wantMsg: []string{"missing metrics:write/traces:write scope"},
+			wantMsg: []string{"missing the metrics:write/traces:write scope"},
 			skipMsg: []string{"credentials rejected"},
 		},
 	}

--- a/plugins/agento11y/internal/doctor/render.go
+++ b/plugins/agento11y/internal/doctor/render.go
@@ -114,10 +114,8 @@ func (b *reportBody) flush(p palette) string {
 	return out.String()
 }
 
-// renderHuman writes the colored (or plain) report. probed reports whether
-// live probes ran; when they didn't, a hint nudges the user toward --probe
-// since the section verdicts are config-only and don't test credentials.
-func renderHuman(w io.Writer, r *Report, color, probed bool) {
+// renderHuman writes the colored (or plain) report.
+func renderHuman(w io.Writer, r *Report, color bool) {
 	p := palette{color: color}
 	var b reportBody
 
@@ -127,28 +125,24 @@ func renderHuman(w io.Writer, r *Report, color, probed bool) {
 
 	// Conversations pipeline.
 	writeSection(&b, p, "Conversations (generation export)", r.Conversations.Health)
-	b.kv("endpoint", describeEnv(r.Conversations.Endpoint))
-	b.kv("tenant id", describeEnv(r.Conversations.TenantID))
-	b.kv("auth token", describeToken(r.Conversations.Token))
+	b.kv("endpoint", describeEnv(p, r.Conversations.Endpoint))
+	b.kv("tenant id", describeEnv(p, r.Conversations.TenantID))
+	b.kv("auth token", describeToken(p, r.Conversations.Token))
 	if r.Conversations.Probe != nil {
-		b.kv("probe", describeProbe(r.Conversations.Probe))
+		b.kv("probe", describeProbeRow(p, r.Conversations.Probe))
 	}
 	writeMessages(&b, p, r.Conversations.Messages)
 	b.textf("\n")
 
 	// Analytics pipeline.
 	writeSection(&b, p, "Analytics (OTLP metrics & traces)", r.Analytics.Health)
-	if r.Analytics.Endpoint.Set {
-		b.kv("endpoint", fmt.Sprintf("%s %s", r.Analytics.Endpoint.Value, p.faint("("+r.Analytics.EndpointVar+", "+r.Analytics.Endpoint.Source+")")))
-	} else {
-		b.kv("endpoint", p.faint("not set"))
-	}
+	b.kv("endpoint", describeEnv(p, r.Analytics.Endpoint))
 	if r.Analytics.Probe != nil {
 		if r.Analytics.Probe.Metrics != nil {
-			b.kv("metrics probe", describeProbe(r.Analytics.Probe.Metrics))
+			b.kv("metrics probe", describeProbeRow(p, r.Analytics.Probe.Metrics))
 		}
 		if r.Analytics.Probe.Traces != nil {
-			b.kv("traces probe", describeProbe(r.Analytics.Probe.Traces))
+			b.kv("traces probe", describeProbeRow(p, r.Analytics.Probe.Traces))
 		}
 	}
 	writeMessages(&b, p, r.Analytics.Messages)
@@ -161,24 +155,17 @@ func renderHuman(w io.Writer, r *Report, color, probed bool) {
 		exists = "present"
 	}
 	b.kv("file", fmt.Sprintf("%s %s", r.Config.Path, p.faint("("+exists+")")))
-	mode := r.Config.ContentCaptureMode
-	if r.Config.ContentModeFellBack {
-		mode += " " + p.faint("(invalid value, fell back)")
-	}
-	b.kv("content capture", mode)
+	b.kv("content capture", withTrailer(r.Config.ContentCaptureMode,
+		describeSource(p, provenanceParts(r.Config.ContentModeKey, r.Config.ContentModeSource)...)))
 	b.kv("guards", describeGuards(p, r.Config))
 	if len(r.Config.Tags) > 0 {
-		b.kv("tags", fmt.Sprintf("%s %s", formatTags(r.Config.Tags), p.faint("("+r.Config.TagsSource+")")))
+		b.kv("tags", withTrailer(formatTags(r.Config.Tags), describeSource(p, r.Config.TagsKey, r.Config.TagsSource)))
 	}
 	if r.Config.Local.Set {
-		localMode := describeEnv(r.Config.Local)
-		if r.Config.LocalInvalid {
-			localMode += " " + p.faint("(invalid value, local mode is off)")
-		}
-		b.kv("local mode", localMode)
+		b.kv("local mode", describeLocal(p, r.Config.Local, r.Config.LocalInvalid))
 	}
 	if r.Config.LocalForward.Set {
-		b.kv("local forwarding", describeEnv(r.Config.LocalForward))
+		b.kv("local forwarding", describeEnv(p, r.Config.LocalForward))
 	}
 	// Only worth a line once the user has opted into forwarding: with
 	// LOCAL_FORWARD unset chaining is always off, and that is already what the
@@ -195,27 +182,14 @@ func renderHuman(w io.Writer, r *Report, color, probed bool) {
 		b.kv(a.Name, describeAgent(p, a))
 	}
 	if r.AutoUpdateDisabled {
-		b.kv("auto-update", p.faint("disabled (SIGIL_AUTO_UPDATE)"))
+		b.kv("auto-update", withTrailer(p.faint("disabled"), describeSource(p, r.AutoUpdate.Key, r.AutoUpdate.Source)))
 	}
 	b.textf("\n")
 
 	// Summary.
 	writeSummary(&b, p, r)
-	if !probed {
-		writeProbeHint(&b, p, r)
-	}
 
 	_, _ = io.WriteString(w, b.flush(p))
-}
-
-// writeProbeHint nudges toward --probe when the report is config-only and
-// there is something to probe. Without it, the section verdicts reflect only
-// that credentials are present, not that they work.
-func writeProbeHint(b *reportBody, p palette, r *Report) {
-	if !r.Conversations.configured() && !r.Analytics.Endpoint.Set {
-		return
-	}
-	b.textf("\n%s\n", p.faint("Verdicts above check configuration only. Run `agento11y doctor --probe` to test credentials against the endpoints."))
 }
 
 func writeSection(b *reportBody, p palette, title string, h Health) {
@@ -246,41 +220,92 @@ func writeSummary(b *reportBody, p palette, r *Report) {
 	b.textf("%s %d problem(s): %s misconfigured\n", p.glyph(HealthError), len(broken), strings.Join(broken, ", "))
 }
 
-func describeEnv(v envValue) string {
-	if !v.Set {
-		return "not set"
+// describeSource renders the faint "(detail, KEY, source)" trailer every row
+// shares. KEY is the env spelling that won, which is the one thing a row label
+// cannot say (AGENTO11Y_* vs SIGIL_*, and the vendor-neutral
+// OTEL_EXPORTER_OTLP_ENDPOINT). Empty parts are dropped, so a value assembled
+// without a key still renders its source alone.
+func describeSource(p palette, parts ...string) string {
+	kept := make([]string, 0, len(parts))
+	for _, s := range parts {
+		if s != "" {
+			kept = append(kept, s)
+		}
 	}
-	return fmt.Sprintf("%s (%s)", v.Value, v.Source)
+	if len(kept) == 0 {
+		return ""
+	}
+	return p.faint("(" + strings.Join(kept, ", ") + ")")
 }
 
-func describeToken(t tokenValue) string {
+// withTrailer joins a value and its trailer, and returns the value alone when
+// there is nothing to qualify.
+func withTrailer(value, trailer string) string {
+	if trailer == "" {
+		return value
+	}
+	return value + " " + trailer
+}
+
+// provenanceParts are the trailing "KEY, source" slots of a trailer. A row whose
+// value came from a built-in default names no variable, so it reports `default`
+// rather than leaving the reader unsure whether the user chose the value.
+func provenanceParts(key, source string) []string {
+	if key == "" {
+		return []string{"default"}
+	}
+	return []string{key, source}
+}
+
+func describeEnv(p palette, v envValue) string {
+	if !v.Set {
+		return p.faint("not set")
+	}
+	return withTrailer(v.Value, describeSource(p, v.Key, v.Source))
+}
+
+// describeLocal renders the LOCAL row. The launcher ignores a value outside the
+// boolean whitelist, so an invalid value renders the state in force and keeps
+// the rejected value in the trailer. Printing the raw value as the state would
+// make the row read as "local mode: enabled" while sessions export to Cloud.
+func describeLocal(p palette, v envValue, invalid bool) string {
+	if !invalid {
+		return describeEnv(p, v)
+	}
+	rejected := fmt.Sprintf("%q is not a boolean", v.Value)
+	if v.Key != "" {
+		rejected = fmt.Sprintf("%s=%q is not a boolean", v.Key, v.Value)
+	}
+	return withTrailer("off", describeSource(p, rejected, v.Source))
+}
+
+func describeToken(p palette, t tokenValue) string {
 	if !t.Set {
-		return "not set"
+		return p.faint("not set")
 	}
+	var prefix string
 	if t.Prefix != "" {
-		return fmt.Sprintf("set (%s…, %s)", t.Prefix, t.Source)
+		prefix = t.Prefix + "…"
 	}
-	return fmt.Sprintf("set (%s)", t.Source)
+	return withTrailer("set", describeSource(p, prefix, t.Key, t.Source))
 }
 
 // describeGuards renders the resolved guard feature flags. Guards default off,
 // so a plain "disabled" is the common line; when on, the timeout and fail mode
 // matter (fail-closed blocks the tool call when a guard errors or times out).
+// The trailer names the GUARDS_ENABLED spelling alone. GUARDS_TIMEOUT_MS and
+// GUARDS_FAIL_OPEN are separate families, and this row does not attribute them;
+// an invalid value in either is named by a section message.
 func describeGuards(p palette, c ConfigSection) string {
-	var out string
-	if c.GuardsEnabled {
-		failMode := "fail-open"
-		if !c.GuardsFailOpen {
-			failMode = "fail-closed"
-		}
-		out = "enabled " + p.faint(fmt.Sprintf("(timeout %dms, %s)", c.GuardsTimeoutMs, failMode))
-	} else {
-		out = p.faint("disabled")
+	trailer := describeSource(p, provenanceParts(c.GuardsKey, c.GuardsSource)...)
+	if !c.GuardsEnabled {
+		return withTrailer(p.faint("disabled"), trailer)
 	}
-	if c.GuardsFellBack {
-		out += " " + p.faint("(invalid value, fell back)")
+	failMode := "fail-open"
+	if !c.GuardsFailOpen {
+		failMode = "fail-closed"
 	}
-	return out
+	return withTrailer(fmt.Sprintf("enabled, timeout %dms, %s", c.GuardsTimeoutMs, failMode), trailer)
 }
 
 // describeLocalHookForward renders whether a --local session's guard checks
@@ -288,23 +313,42 @@ func describeGuards(p palette, c ConfigSection) string {
 // even under a reduced content capture mode.
 func describeLocalHookForward(p palette, h HookForwardSection) string {
 	if h.Enabled {
-		return "local hook evaluation reaches Cloud " + p.faint("(tool calls, and the conversation an agent runs a preflight check on, are sent for evaluation whatever the capture mode)")
+		return withTrailer("forwarded to Cloud", p.faint("(tool calls, and the conversation an agent runs a preflight check on, are sent for evaluation whatever the capture mode)"))
 	}
-	return p.faint("not forwarded (" + h.Reason + ")")
+	return withTrailer(p.faint("not forwarded"), describeSource(p, h.Reason))
 }
 
-func describeProbe(p *ProbeResult) string {
-	if p == nil {
+// describeProbeRow renders a probe as a row: the status plus the URL it probed,
+// which is otherwise absent from the human report. A transport error has no
+// status, and nothing answered, so the row reports "no response" against the
+// same URL. The diagnosis is left to the section message line so it is printed
+// once.
+func describeProbeRow(p palette, res *ProbeResult) string {
+	if res == nil {
+		return p.faint("skipped")
+	}
+	return withTrailer(probeStatus(res), describeSource(p, res.URL))
+}
+
+// describeProbe renders a probe for message text, where the diagnosis is the
+// point and no URL column exists to carry it.
+func describeProbe(res *ProbeResult) string {
+	if res == nil {
 		return "skipped"
 	}
-	status := "no response"
-	if p.StatusCode != 0 {
-		status = fmt.Sprintf("HTTP %d", p.StatusCode)
+	if res.Message != "" {
+		return probeStatus(res) + ": " + res.Message
 	}
-	if p.Message != "" {
-		return fmt.Sprintf("%s — %s", status, p.Message)
+	return probeStatus(res)
+}
+
+// probeStatus is the HTTP status, or "no response" for a transport error that
+// never produced one.
+func probeStatus(res *ProbeResult) string {
+	if res.StatusCode == 0 {
+		return "no response"
 	}
-	return status
+	return fmt.Sprintf("HTTP %d", res.StatusCode)
 }
 
 func describeAgent(p palette, a AgentStatus) string {
@@ -312,21 +356,27 @@ func describeAgent(p palette, a AgentStatus) string {
 	// version is the agento11y binary's, so it is rendered exactly as the
 	// report heading renders it.
 	if a.HookBased {
-		return agentNote(p, joinVersion("detected", a.Version), a.Note)
+		return agentNote(p, joinVersion("detected", a.Version), "", a.Note)
 	}
 	// The install probe never ran: a CLI-dependent agent whose binary is
 	// absent, or a hook-only agent off PATH.
 	if a.Health == HealthSkipped {
-		return agentNote(p, p.faint("not found on PATH"), a.Note)
+		return agentNote(p, p.faint("not found on PATH"), "", a.Note)
 	}
 	// The probe ran and errored, or the state was never set. Say the state is
 	// unknown instead of picking one of the two known states; the note carries
 	// the reason.
 	install := a.Install.orUnknown()
 	if install == InstallStateUnknown {
-		return agentNote(p, "install state unknown", a.Note)
+		return agentNote(p, "install state unknown", "", a.Note)
 	}
 	installed := install == InstallStateInstalled
+	// A version belongs to an installed plugin. Suppress it otherwise so one
+	// line can't report `plugin not installed` and a version at the same time.
+	version := ""
+	if installed {
+		version = a.Version
+	}
 	// Hook-file based agent (copilot, vibe): capture doesn't depend on the CLI being
 	// on PATH, so report install state with its own wording and no PATH
 	// qualifiers.
@@ -335,33 +385,61 @@ func describeAgent(p palette, a AgentStatus) string {
 		if installed {
 			state = "installed"
 		}
-		return agentNote(p, joinAgent(state, a.Version), a.Note)
+		body, commit := joinAgent(state, version)
+		return agentNote(p, body, commit, a.Note)
 	}
 	// Report install state, only claiming "on PATH" when true so config-based
-	// agents installed without the CLI present aren't mislabeled.
-	var state string
+	// agents installed without the CLI present aren't mislabeled. The missing-CLI
+	// qualifier is a trailer part, so the version stays next to the state it
+	// belongs to.
+	var state, qualifier string
 	switch {
 	case installed && a.OnPath:
 		state = "installed"
 	case installed:
-		state = "installed " + p.faint("(CLI not on PATH)")
+		state, qualifier = "installed", "CLI not on PATH"
 	case a.OnPath:
 		state = "on PATH, plugin not installed"
 	default:
 		state = "plugin not installed"
 	}
-	return agentNote(p, joinAgent(state, a.Version), a.Note)
+	body, commit := joinAgent(state, version)
+	return agentNote(p, body, commit, qualifier, a.Note)
 }
 
-// joinAgent appends a host agent's own version to its state, prefixed with
-// `v` when it is a bare number. Some agents report a dist-tag instead of a
-// number (opencode and pi return the tail of an npm spec, so a `@next`
-// install reports `next`), and `vnext` would be wrong.
-func joinAgent(state, version string) string {
-	if version != "" && version[0] >= '0' && version[0] <= '9' {
-		version = "v" + version
+// joinAgent appends a host agent plugin's own version to its state. A dotted
+// number takes a `v` prefix, and a dist tag (`next`) is printed bare. A
+// commit-shaped string is returned as a separate `commit <sha>` trailer part so
+// it doesn't read as a version; the caller merges it with the row's other
+// trailer parts, keeping one parenthesized group per row.
+func joinAgent(state, version string) (body, commit string) {
+	switch {
+	case version == "":
+		return state, ""
+	case isCommitSHA(version):
+		return state, "commit " + shortSHA(version)
+	case version[0] >= '0' && version[0] <= '9' && strings.Contains(version, "."):
+		return joinVersion(state, "v"+version), ""
 	}
-	return joinVersion(state, version)
+	return joinVersion(state, version), ""
+}
+
+// shaCutLength is git's default short-sha length: the shortest string doctor
+// accepts as a sha, and how much of one it prints.
+const shaCutLength = 7
+
+// isCommitSHA reports whether a version string is a git commit sha rather than
+// a version or a dist tag. Claude Code stores a short sha in the `version`
+// field of its plugin store when the plugin manifest declares no version. A dot
+// is not a hex digit, so a dotted version never matches.
+func isCommitSHA(version string) bool {
+	const hexDigits = "0123456789abcdefABCDEF"
+	return len(version) >= shaCutLength && strings.TrimLeft(version, hexDigits) == ""
+}
+
+// shortSHA truncates a commit sha to the length git prints by default.
+func shortSHA(sha string) string {
+	return sha[:min(len(sha), shaCutLength)]
 }
 
 // joinVersion appends a version to a state as-is. The agento11y binary version
@@ -374,11 +452,10 @@ func joinVersion(state, version string) string {
 	return state + " " + version
 }
 
-func agentNote(p palette, body, note string) string {
-	if note == "" {
-		return body
-	}
-	return body + " " + p.faint("("+note+")")
+// agentNote appends an agent row's qualifier and note as one trailer, so a row
+// that has both does not render two parenthesized groups.
+func agentNote(p palette, body string, parts ...string) string {
+	return withTrailer(body, describeSource(p, parts...))
 }
 
 // formatTags renders a tag map as "k=v, k=v" with keys sorted so the line is

--- a/plugins/agento11y/internal/doctor/render_golden_test.go
+++ b/plugins/agento11y/internal/doctor/render_golden_test.go
@@ -19,6 +19,8 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/grafana/agento11y/plugins/agento11y/internal/local"
@@ -28,19 +30,56 @@ func TestRenderHumanGolden(t *testing.T) {
 	tests := []struct {
 		name   string
 		report *Report
-		probed bool
 	}{
 		{name: "healthy", report: goldenHealthyReport()},
 		{name: "minimal", report: goldenMinimalReport()},
 		{name: "broken", report: goldenBrokenReport()},
-		{name: "probed", report: goldenProbedReport(), probed: true},
+		{name: "probed", report: goldenProbedReport()},
+		{name: "redirected", report: goldenRedirectedReport()},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			renderHuman(&buf, tc.report, false, tc.probed)
+			renderHuman(&buf, tc.report, false)
 			assertGoldenText(t, filepath.Join("testdata", "render", tc.name+".golden.txt"), buf.String())
+			assertOneTrailerPerRow(t, buf.String())
 		})
+	}
+}
+
+// kvRow matches a rendered key/value row and captures the value. The key class
+// admits the space in "local guard checks" and the hyphen in "auto-update";
+// without the hyphen that row is silently skipped. Section titles, messages and
+// the summary are not rows, and their parentheses are part of the prose rather
+// than a renderer-added trailer.
+var kvRow = regexp.MustCompile(`^ {2}([a-z][a-z -]*):\s+(.*)$`)
+
+// rowLine matches every indented line that is not a section message. Section
+// titles, the summary and the probe hint start at column 0. A row this matches
+// but kvRow does not is a row the grammar check would skip, which is how a
+// hyphen in "auto-update" once excluded that row from the check.
+var rowLine = regexp.MustCompile(`^ {2}[^!\s]`)
+
+// assertOneTrailerPerRow enforces the row grammar on a whole report: a row is a
+// value plus at most one parenthesized trailer. Two groups mean a fault and a
+// provenance note are competing for the same slot, which is the shape this
+// renderer is built to avoid.
+func assertOneTrailerPerRow(t *testing.T, report string) {
+	t.Helper()
+	for line := range strings.SplitSeq(report, "\n") {
+		m := kvRow.FindStringSubmatch(line)
+		if m == nil {
+			if rowLine.MatchString(line) {
+				t.Errorf("kvRow does not match row %q, so the grammar check skips it", line)
+			}
+			continue
+		}
+		if strings.Count(m[2], "(") > 1 {
+			t.Errorf("row %q has more than one parenthesized group: %q", m[1], m[2])
+		}
+		if strings.Contains(m[2], ") (") {
+			t.Errorf("row %q has adjacent parenthesized groups: %q", m[1], m[2])
+		}
 	}
 }
 
@@ -62,8 +101,11 @@ func goldenHealthyReport() *Report {
 		Config: ConfigSection{
 			Path: "/home/u/.config/agento11y/config.env", Exists: true,
 			ContentCaptureMode: "full",
-			GuardsEnabled:      true, GuardsTimeoutMs: 1500, GuardsFailOpen: true,
+			ContentModeKey:     "AGENTO11Y_CONTENT_CAPTURE_MODE", ContentModeSource: sourceConfig,
+			GuardsEnabled: true, GuardsTimeoutMs: 1500, GuardsFailOpen: true,
+			GuardsKey: "AGENTO11Y_GUARDS_ENABLED", GuardsSource: sourceConfig,
 			Tags:             map[string]string{"team": "assistant", "env": "prod"},
+			TagsKey:          "AGENTO11Y_TAGS",
 			TagsSource:       sourceConfig,
 			LocalForward:     envValue{Set: true, Value: "true", Source: sourceEnv, Key: "AGENTO11Y_LOCAL_FORWARD"},
 			LocalHookForward: HookForwardSection{Enabled: true},
@@ -90,8 +132,10 @@ func goldenMinimalReport() *Report {
 			Path: "/home/u/.config/agento11y/config.env",
 			// The daemon's answer with LOCAL_FORWARD unset. The line itself is
 			// suppressed, which is what this fixture pins.
-			LocalHookForward:   HookForwardSection{Reason: local.HookForwardReason(false, false, "", "", "")},
-			ContentCaptureMode: "full",
+			LocalHookForward: HookForwardSection{Reason: local.HookForwardReason(false, false, "", "", "")},
+			// Nothing is configured, so both shared settings report the built-in
+			// value rather than a choice the user made.
+			ContentCaptureMode: "metadata_only",
 			GuardsTimeoutMs:    1500, GuardsFailOpen: true,
 			Health: HealthOK,
 		},
@@ -102,7 +146,8 @@ func goldenMinimalReport() *Report {
 }
 
 // goldenBrokenReport is the support case: a malformed endpoint, no OTLP
-// endpoint, a config that fell back, and an agent whose install probe errored.
+// endpoint, a config that fell back, a local mode value the launcher ignores,
+// and agents whose state is neither plain "installed" nor plain "missing".
 func goldenBrokenReport() *Report {
 	conversations := collectConversations(
 		map[string]string{"AGENTO11Y_ENDPOINT": "not a url ://"},
@@ -114,8 +159,16 @@ func goldenBrokenReport() *Report {
 		Analytics:     collectAnalytics(nil, nil, conversations.configured()),
 		Config: ConfigSection{
 			Path: "/home/u/.config/agento11y/config.env", Exists: true,
+			// The mode came from a value envconfig rejected, so the row credits the
+			// built-in default and the message names the variable to fix.
 			ContentCaptureMode: "metadata_only", ContentModeFellBack: true,
-			GuardsEnabled: false, GuardsFellBack: true,
+			// GUARDS_ENABLED is valid and off, under the legacy spelling the row has to
+			// name. The timeout is the value that fell back.
+			GuardsEnabled: false, GuardsTimeoutMs: 1500, GuardsFailOpen: true, GuardsFellBack: true,
+			GuardsKey: "SIGIL_GUARDS_ENABLED", GuardsSource: sourceEnv,
+			// The launcher ignores this value, so the row reports the state in force.
+			Local:        envValue{Set: true, Value: "enabled", Source: sourceEnv, Key: "AGENTO11Y_LOCAL"},
+			LocalInvalid: true,
 			LocalForward: envValue{Set: true, Value: "true", Source: sourceConfig, Key: "AGENTO11Y_LOCAL_FORWARD"},
 			// Forwarding is on but guards are off, so nothing is chained.
 			LocalHookForward: HookForwardSection{Reason: local.HookForwardReason(true, false, "", "", "")},
@@ -123,8 +176,9 @@ func goldenBrokenReport() *Report {
 			Health:           HealthWarn,
 			Messages: []string{
 				"config.env has keys agento11y ignores: AWS_SECRET",
-				"the CONTENT_CAPTURE_MODE value is invalid; using metadata_only",
-				"a GUARDS_* value is invalid; falling back to defaults",
+				"the AGENTO11Y_CONTENT_CAPTURE_MODE value is invalid; using metadata_only",
+				"the AGENTO11Y_GUARDS_TIMEOUT_MS value is invalid; guards use the default",
+				"the AGENTO11Y_LOCAL value is not a boolean; local mode stays off",
 			},
 		},
 		Agents: []AgentStatus{
@@ -132,22 +186,52 @@ func goldenBrokenReport() *Report {
 			// asserting "not configured" and "unknown" at once.
 			{Name: "copilot", OnPath: false, Install: InstallStateUnknown, notInstalledLabel: "not configured", Note: "hook-based; stat /home/u/.copilot/hooks/agento11y.json: operation not permitted", Health: HealthWarn},
 			{Name: "pi", OnPath: true, Install: InstallStateNotInstalled, Health: HealthWarn},
+			// Installed through config with no CLI on PATH: the qualifier and the note
+			// share one trailer after the version.
+			{Name: "opencode", OnPath: false, Install: InstallStateInstalled, Version: "next", Note: "npm spec pinned", Health: HealthOK},
 		},
+		AutoUpdate:         envValue{Set: true, Value: "false", Source: sourceConfig, Key: "AGENTO11Y_AUTO_UPDATE"},
 		AutoUpdateDisabled: true,
 	}
 }
 
-// goldenProbedReport is a --probe run: every probe line is present and the
-// config-only hint is suppressed.
+// goldenProbedReport is a run whose probes all answered: every probe line is
+// present and the config-only hint is suppressed.
 func goldenProbedReport() *Report {
 	r := goldenHealthyReport()
-	r.Conversations.Probe = &ProbeResult{URL: "https://sigil.example/api/v1/generations:export", StatusCode: 200, OK: true}
+	// A transport error: nothing answered, so the row has no status and the cause
+	// survives only on the message line.
+	r.Conversations.Probe = &ProbeResult{URL: "https://sigil.example/api/v1/generations:export", Message: `Post "https://sigil.example/api/v1/generations:export": dial tcp 10.0.0.1:443: connect: connection refused`}
+	r.Conversations.Health = HealthError
+	r.Conversations.Messages = []string{"could not reach the conversations endpoint: " + describeProbe(r.Conversations.Probe)}
 	r.Analytics.Probe = &AnalyticsProbe{
 		Metrics: &ProbeResult{URL: "https://otlp.example/otlp/v1/metrics", StatusCode: 200, OK: true},
-		Traces:  &ProbeResult{URL: "https://otlp.example/otlp/v1/traces", StatusCode: 403, Message: "missing metrics:write/traces:write scope"},
+		Traces:  &ProbeResult{URL: "https://otlp.example/otlp/v1/traces", StatusCode: 403, Message: "the token is likely missing the metrics:write/traces:write scope"},
 	}
 	r.Analytics.Health = HealthError
-	r.Analytics.Messages = []string{"OTLP endpoint rejected auth (401/403) — the token is likely missing metrics:write/traces:write scope"}
+	r.Analytics.Messages = otlpAuthMessages(r.Analytics.Probe)
+	return r
+}
+
+// goldenRedirectedReport is the reported support case: the endpoint answers the
+// export POST with a redirect to a login page, so conversations are broken even
+// though the endpoint resolves and responds.
+func goldenRedirectedReport() *Report {
+	r := goldenHealthyReport()
+	r.Conversations.Probe = &ProbeResult{
+		URL:        "https://sigil.example/api/v1/generations:export",
+		StatusCode: 302,
+		Message:    "redirected to /login",
+	}
+	r.Conversations.Health = HealthError
+	r.Conversations.Messages = []string{
+		"the conversations endpoint redirected the export request (" + describeProbe(r.Conversations.Probe) +
+			"), so AGENTO11Y_ENDPOINT is not an Agent Observability API URL. " + apiURLHint,
+	}
+	r.Analytics.Probe = &AnalyticsProbe{
+		Metrics: &ProbeResult{URL: "https://otlp.example/otlp/v1/metrics", StatusCode: 200, OK: true},
+		Traces:  &ProbeResult{URL: "https://otlp.example/otlp/v1/traces", StatusCode: 200, OK: true},
+	}
 	return r
 }
 

--- a/plugins/agento11y/internal/doctor/render_test.go
+++ b/plugins/agento11y/internal/doctor/render_test.go
@@ -15,9 +15,9 @@ func sampleReport() *Report {
 			ContentCaptureMode: "metadata_only", Health: HealthOK,
 		},
 		Conversations: ConversationsSection{
-			Endpoint: envValue{Set: true, Value: "https://sigil.example", Source: sourceEnv},
-			TenantID: envValue{Set: true, Value: "12345", Source: sourceEnv},
-			Token:    tokenValue{Set: true, Prefix: "glc_", Source: sourceEnv},
+			Endpoint: envValue{Set: true, Value: "https://sigil.example", Source: sourceEnv, Key: "AGENTO11Y_ENDPOINT"},
+			TenantID: envValue{Set: true, Value: "12345", Source: sourceEnv, Key: "AGENTO11Y_AUTH_TENANT_ID"},
+			Token:    tokenValue{Set: true, Prefix: "glc_", Source: sourceEnv, Key: "AGENTO11Y_AUTH_TOKEN"},
 			Health:   HealthOK,
 		},
 		Analytics: AnalyticsSection{
@@ -51,7 +51,7 @@ func TestRenderJSON_ValidAndNoToken(t *testing.T) {
 func TestRenderHuman_NoColorIsPlain(t *testing.T) {
 	r := sampleReport()
 	var buf bytes.Buffer
-	renderHuman(&buf, r, false, false)
+	renderHuman(&buf, r, false)
 	out := buf.String()
 
 	if strings.Contains(out, "\x1b[") {
@@ -60,8 +60,11 @@ func TestRenderHuman_NoColorIsPlain(t *testing.T) {
 	for _, want := range []string{
 		"Conversations (generation export)",
 		"Analytics (OTLP metrics & traces)",
-		"https://sigil.example (env)",
-		"set (glc_…, env)",
+		"https://sigil.example (AGENTO11Y_ENDPOINT, env)",
+		"set (glc_…, AGENTO11Y_AUTH_TOKEN, env)",
+		// No variable is configured, so the row says the value is the built-in one.
+		"content capture: metadata_only (default)",
+		"guards:          disabled (default)",
 		"1 problem(s)",
 	} {
 		if !strings.Contains(out, want) {
@@ -81,7 +84,7 @@ func TestRenderHuman_BinaryVersionPrintedAsStamped(t *testing.T) {
 			r.Binary.Version = version
 			r.Agents = []AgentStatus{{Name: "cursor", OnPath: true, HookBased: true, Version: version, Health: HealthOK}}
 			var buf bytes.Buffer
-			renderHuman(&buf, r, false, false)
+			renderHuman(&buf, r, false)
 			out := buf.String()
 			heading, _, _ := strings.Cut(out, "\n")
 			if want := "agento11y doctor " + version; heading != want {
@@ -126,30 +129,147 @@ func TestReportBody_EmptyKeyStillRenders(t *testing.T) {
 	}
 }
 
-func TestRenderHuman_ProbeHint(t *testing.T) {
-	const hint = "agento11y doctor --probe"
-	nothingProbeable := func() *Report {
-		r := sampleReport()
-		r.Conversations = ConversationsSection{Health: HealthWarn}
-		r.Analytics = AnalyticsSection{Health: HealthWarn}
-		return r
-	}
+func TestDescribeProbeRow(t *testing.T) {
+	p := palette{color: false}
 	tests := []struct {
-		name     string
-		report   func() *Report
-		probed   bool
-		wantHint bool
+		name   string
+		result *ProbeResult
+		want   string
 	}{
-		{name: "shown when configured and not probed", report: sampleReport, probed: false, wantHint: true},
-		{name: "hidden when probed", report: sampleReport, probed: true, wantHint: false},
-		{name: "hidden when nothing is probeable", report: nothingProbeable, probed: false, wantHint: false},
+		{name: "nil is skipped", result: nil, want: "skipped"},
+		{name: "ok", result: &ProbeResult{URL: "https://otlp.example/otlp/v1/metrics", StatusCode: 200, OK: true}, want: "HTTP 200 (https://otlp.example/otlp/v1/metrics)"},
+		// The diagnosis belongs on the section message line, so the row carries
+		// the URL alone.
+		{name: "auth failure drops the diagnosis", result: &ProbeResult{URL: "https://otlp.example/otlp/v1/traces", StatusCode: 403, Message: "missing metrics:write/traces:write scope"}, want: "HTTP 403 (https://otlp.example/otlp/v1/traces)"},
+		{name: "transport error has no status", result: &ProbeResult{URL: "https://sigil.example/api", Message: "connection refused"}, want: "no response (https://sigil.example/api)"},
+		// A probe that failed before it built a request has no URL to report.
+		{name: "no url", result: &ProbeResult{Message: "invalid endpoint: parse …"}, want: "no response"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			if got := describeProbeRow(p, tc.result); got != tc.want {
+				t.Fatalf("describeProbeRow = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// describeProbe is the message-text formatter: a section message has no URL
+// column, so the diagnosis is the point there.
+func TestDescribeProbe(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *ProbeResult
+		want   string
+	}{
+		{name: "nil is skipped", result: nil, want: "skipped"},
+		{name: "status only", result: &ProbeResult{StatusCode: 503}, want: "HTTP 503"},
+		{name: "status and message", result: &ProbeResult{StatusCode: 503, Message: "upstream down"}, want: "HTTP 503: upstream down"},
+		{name: "transport error", result: &ProbeResult{Message: "connection refused"}, want: "no response: connection refused"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := describeProbe(tc.result); got != tc.want {
+				t.Fatalf("describeProbe = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRenderHuman_ProbeDiagnosisAppearsOnce pins the split between the row and
+// the section message: the row names the URL that answered, and the diagnosis is
+// printed once, on the `!` line runProbes wrote it to.
+func TestRenderHuman_ProbeDiagnosisAppearsOnce(t *testing.T) {
+	const diagnosis = "missing metrics:write/traces:write scope"
+	r := sampleReport()
+	r.Analytics = AnalyticsSection{
+		Endpoint: envValue{Set: true, Value: "https://otlp.example/otlp", Source: sourceEnv, Key: "AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT"},
+		Health:   HealthError,
+		Probe: &AnalyticsProbe{
+			Traces: &ProbeResult{URL: "https://otlp.example/otlp/v1/traces", StatusCode: 403, Message: diagnosis},
+		},
+		Messages: []string{"OTLP endpoint rejected auth (401/403) — the token is likely " + diagnosis},
+	}
+	var buf bytes.Buffer
+	renderHuman(&buf, r, false)
+	out := buf.String()
+
+	if want := "traces probe:    HTTP 403 (https://otlp.example/otlp/v1/traces)"; !strings.Contains(out, want) {
+		t.Fatalf("probe row missing %q:\n%s", want, out)
+	}
+	if got := strings.Count(out, diagnosis); got != 1 {
+		t.Fatalf("diagnosis appears %d times, want 1:\n%s", got, out)
+	}
+}
+
+// TestRenderHuman_FaultsStayOnTheMessageLine covers the three inline fault
+// suffixes the renderer used to append. Each fault already has a section
+// message, so repeating it on the row would print it twice and open a second
+// parenthesized group.
+func TestRenderHuman_FaultsStayOnTheMessageLine(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    func(*ConfigSection)
+		message   string
+		wantRow   string
+		wantNoRow string
+	}{
+		{
+			// The rejected value supplied nothing, so the row reports the built-in mode
+			// and names no variable for it.
+			name: "content capture fell back",
+			config: func(c *ConfigSection) {
+				c.ContentCaptureMode = "metadata_only"
+				c.ContentModeFellBack = true
+			},
+			message:   "the AGENTO11Y_CONTENT_CAPTURE_MODE value is invalid; using metadata_only",
+			wantRow:   "content capture: metadata_only (default)",
+			wantNoRow: "invalid value, fell back",
+		},
+		{
+			// GUARDS_ENABLED decided the state and is valid, so the row keeps naming
+			// it; the broken timeout is named by the message alone.
+			name: "guards timeout invalid",
+			config: func(c *ConfigSection) {
+				c.GuardsEnabled, c.GuardsTimeoutMs, c.GuardsFailOpen = true, 1500, true
+				c.GuardsKey, c.GuardsSource = "AGENTO11Y_GUARDS_ENABLED", sourceEnv
+				c.GuardsFellBack = true
+			},
+			message:   "the AGENTO11Y_GUARDS_TIMEOUT_MS value is invalid; guards use the default",
+			wantRow:   "guards:          enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, env)",
+			wantNoRow: "invalid value, fell back",
+		},
+		{
+			// The launcher ignores the value, so the row reports the state in force and
+			// carries the rejected value in its one trailer.
+			name: "local mode value is not a boolean",
+			config: func(c *ConfigSection) {
+				c.Local = envValue{Set: true, Value: "enabled", Source: sourceEnv, Key: "AGENTO11Y_LOCAL"}
+				c.LocalInvalid = true
+			},
+			message:   "the AGENTO11Y_LOCAL value is not a boolean; local mode stays off",
+			wantRow:   `local mode:      off (AGENTO11Y_LOCAL="enabled" is not a boolean, env)`,
+			wantNoRow: "invalid value, local mode is off",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := sampleReport()
+			r.Config.Health = HealthWarn
+			r.Config.Messages = []string{tc.message}
+			tc.config(&r.Config)
 			var buf bytes.Buffer
-			renderHuman(&buf, tc.report(), false, tc.probed)
-			if got := strings.Contains(buf.String(), hint); got != tc.wantHint {
-				t.Fatalf("probe hint present = %v, want %v:\n%s", got, tc.wantHint, buf.String())
+			renderHuman(&buf, r, false)
+			out := buf.String()
+
+			if !strings.Contains(out, tc.wantRow) {
+				t.Fatalf("row missing %q:\n%s", tc.wantRow, out)
+			}
+			if strings.Contains(out, tc.wantNoRow) {
+				t.Fatalf("row still carries the inline fault %q:\n%s", tc.wantNoRow, out)
+			}
+			if got := strings.Count(out, tc.message); got != 1 {
+				t.Fatalf("fault appears %d times, want 1:\n%s", got, out)
 			}
 		})
 	}
@@ -168,12 +288,35 @@ func TestDescribeAgent(t *testing.T) {
 		{name: "hook-based", agent: AgentStatus{HookBased: true, OnPath: true, Version: "v1.2.3", Note: "hook-based", Health: HealthOK}, want: "detected v1.2.3 (hook-based)"},
 		{name: "hook-based unstamped version", agent: AgentStatus{HookBased: true, OnPath: true, Version: "0.22.0", Health: HealthOK}, want: "detected 0.22.0"},
 		{name: "hook-based dev version", agent: AgentStatus{HookBased: true, OnPath: true, Version: "dev", Health: HealthOK}, want: "detected dev"},
-		// A host agent's own version is numeric (claude) or a dist-tag
-		// (opencode, pi, from an npm spec); only the number takes the prefix.
+		// A host agent plugin's own version is a dotted number or a dist-tag
+		// (opencode and pi can report the tail of an npm spec); only the number
+		// takes the prefix.
 		{name: "agent dist-tag version", agent: AgentStatus{OnPath: true, Install: InstallStateInstalled, Version: "next", Health: HealthOK}, want: "installed next"},
+		// A commit sha is labelled so it doesn't read as a version, and one that
+		// starts with a digit must not pick up the `v` prefix. A sha too short to
+		// recognise is printed bare rather than as `v1a2b3c`.
+		{name: "agent commit sha version", agent: AgentStatus{OnPath: true, Install: InstallStateInstalled, Version: "d9db82cfb562", Health: HealthOK}, want: "installed (commit d9db82c)"},
+		{name: "agent digit-leading commit sha version", agent: AgentStatus{OnPath: true, Install: InstallStateInstalled, Version: "1a2b3c4d5e6f", Health: HealthOK}, want: "installed (commit 1a2b3c4)"},
+		{name: "agent short digit-leading sha", agent: AgentStatus{OnPath: true, Install: InstallStateInstalled, Version: "1a2b3c", Health: HealthOK}, want: "installed 1a2b3c"},
+		{name: "agent sha already at the cut length", agent: AgentStatus{OnPath: true, Install: InstallStateInstalled, Version: "d9db82c", Health: HealthOK}, want: "installed (commit d9db82c)"},
+		{name: "agent full commit sha version", agent: AgentStatus{OnPath: true, Install: InstallStateInstalled, Version: "d9db82cfb562487b174006aabbd435d155e59278", Health: HealthOK}, want: "installed (commit d9db82c)"},
+		// The commit label is a trailer part, so a sha, the missing-CLI qualifier
+		// and a note share one group instead of opening three.
+		{name: "agent commit sha without cli", agent: AgentStatus{OnPath: false, Install: InstallStateInstalled, Version: "d9db82cfb562", Health: HealthOK}, want: "installed (commit d9db82c, CLI not on PATH)"},
+		{name: "agent commit sha without cli and a note", agent: AgentStatus{OnPath: false, Install: InstallStateInstalled, Version: "d9db82cfb562", Note: "plugin store", Health: HealthOK}, want: "installed (commit d9db82c, CLI not on PATH, plugin store)"},
+		{name: "hook-file based commit sha with a note", agent: AgentStatus{OnPath: true, Install: InstallStateInstalled, Version: "d9db82cfb562", notInstalledLabel: "not configured", Note: "hook-based", Health: HealthOK}, want: "installed (commit d9db82c, hook-based)"},
+		// A version must never contradict the install state: a probe that reports
+		// a version alongside `not installed` prints the state alone.
+		{name: "version suppressed when not installed", agent: AgentStatus{OnPath: true, Install: InstallStateNotInstalled, Version: "1.2.3", Health: HealthWarn}, want: "on PATH, plugin not installed"},
+		{name: "version suppressed when not installed off path", agent: AgentStatus{OnPath: false, Install: InstallStateNotInstalled, Version: "1.2.3", Health: HealthWarn}, want: "plugin not installed"},
+		{name: "hook-file based version suppressed when not configured", agent: AgentStatus{OnPath: false, Install: InstallStateNotInstalled, Version: "1.2.3", notInstalledLabel: "not configured", Health: HealthWarn}, want: "not configured"},
 		{name: "skipped not on path", agent: AgentStatus{OnPath: false, Install: InstallStateUnknown, Health: HealthSkipped}, want: "not found on PATH"},
 		{name: "installed on path", agent: AgentStatus{OnPath: true, Install: InstallStateInstalled, Version: "0.3.0", Health: HealthOK}, want: "installed v0.3.0"},
-		{name: "config-based installed without cli", agent: AgentStatus{OnPath: false, Install: InstallStateInstalled, Version: "2.0.0", Health: HealthOK}, want: "installed (CLI not on PATH) v2.0.0"},
+		// The qualifier follows the version, so no renderer-added parentheses sit
+		// inside the value.
+		{name: "config-based installed without cli", agent: AgentStatus{OnPath: false, Install: InstallStateInstalled, Version: "2.0.0", Health: HealthOK}, want: "installed v2.0.0 (CLI not on PATH)"},
+		// A qualifier and a note share one trailer rather than opening two groups.
+		{name: "config-based installed without cli and a note", agent: AgentStatus{OnPath: false, Install: InstallStateInstalled, Version: "2.0.0", Note: "npm spec pinned", Health: HealthOK}, want: "installed v2.0.0 (CLI not on PATH, npm spec pinned)"},
 		{name: "on path not installed", agent: AgentStatus{OnPath: true, Install: InstallStateNotInstalled, Health: HealthWarn}, want: "on PATH, plugin not installed"},
 		{name: "config-based not installed without cli", agent: AgentStatus{OnPath: false, Install: InstallStateNotInstalled, Health: HealthWarn}, want: "plugin not installed"},
 		{name: "hook-file based installed (copilot)", agent: AgentStatus{OnPath: false, Install: InstallStateInstalled, notInstalledLabel: "not configured", Note: "hook-based", Health: HealthOK}, want: "installed (hook-based)"},
@@ -187,6 +330,36 @@ func TestDescribeAgent(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := describeAgent(p, tc.agent); got != tc.want {
 				t.Fatalf("describeAgent = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsCommitSHA(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{name: "short claude sha", version: "d9db82cfb562", want: true},
+		{name: "full sha", version: "d9db82cfb562487b174006aabbd435d155e59278", want: true},
+		{name: "digit-leading sha", version: "1a2b3c4d5e6f", want: true},
+		{name: "all digits", version: "1234567", want: true},
+		{name: "seven chars is the shortest accepted", version: "abcdef1", want: true},
+		{name: "uppercase hex", version: "D9DB82C", want: true},
+		{name: "six chars is too short", version: "abcdef", want: false},
+		{name: "empty", version: "", want: false},
+		// A dotted string is a version even when it is long enough and every other
+		// byte is hex.
+		{name: "dotted hex-only version", version: "0.19.10", want: false},
+		{name: "dist tag", version: "next", want: false},
+		{name: "non-hex letters", version: "deadbeefzz", want: false},
+		{name: "prerelease", version: "1.2.3-rc1", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isCommitSHA(tc.version); got != tc.want {
+				t.Fatalf("isCommitSHA(%q) = %v, want %v", tc.version, got, tc.want)
 			}
 		})
 	}
@@ -216,19 +389,22 @@ func TestRenderHuman_TagsLine(t *testing.T) {
 	tests := []struct {
 		name     string
 		tags     map[string]string
+		key      string
 		source   string
 		wantLine string // "" = expect no tags line at all
 	}{
-		{name: "tags shown with source", tags: map[string]string{"team": "assistant", "env": "prod"}, source: sourceConfig, wantLine: "env=prod, team=assistant (config.env)"},
+		{name: "tags shown with provenance", tags: map[string]string{"team": "assistant", "env": "prod"}, key: "AGENTO11Y_TAGS", source: sourceConfig, wantLine: "env=prod, team=assistant (AGENTO11Y_TAGS, config.env)"},
+		{name: "legacy spelling", tags: map[string]string{"env": "prod"}, key: "SIGIL_TAGS", source: sourceEnv, wantLine: "env=prod (SIGIL_TAGS, env)"},
 		{name: "no tags omits line", tags: nil, wantLine: ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			r := sampleReport()
 			r.Config.Tags = tc.tags
+			r.Config.TagsKey = tc.key
 			r.Config.TagsSource = tc.source
 			var buf bytes.Buffer
-			renderHuman(&buf, r, false, false)
+			renderHuman(&buf, r, false)
 			out := buf.String()
 			if tc.wantLine == "" {
 				if strings.Contains(out, "tags:") {
@@ -250,10 +426,18 @@ func TestDescribeGuards(t *testing.T) {
 		config ConfigSection
 		want   string
 	}{
-		{name: "disabled", config: ConfigSection{GuardsEnabled: false}, want: "disabled"},
-		{name: "enabled fail-open", config: ConfigSection{GuardsEnabled: true, GuardsTimeoutMs: 1500, GuardsFailOpen: true}, want: "enabled (timeout 1500ms, fail-open)"},
-		{name: "enabled fail-closed", config: ConfigSection{GuardsEnabled: true, GuardsTimeoutMs: 500, GuardsFailOpen: false}, want: "enabled (timeout 500ms, fail-closed)"},
-		{name: "disabled after fallback", config: ConfigSection{GuardsEnabled: false, GuardsFellBack: true}, want: "disabled (invalid value, fell back)"},
+		// No GUARDS_* variable is set, so the row says the value is the built-in one.
+		{name: "disabled by default", config: ConfigSection{GuardsEnabled: false}, want: "disabled (default)"},
+		{name: "disabled explicitly", config: ConfigSection{GuardsEnabled: false, GuardsKey: "AGENTO11Y_GUARDS_ENABLED", GuardsSource: sourceConfig}, want: "disabled (AGENTO11Y_GUARDS_ENABLED, config.env)"},
+		{name: "enabled fail-open", config: ConfigSection{GuardsEnabled: true, GuardsTimeoutMs: 1500, GuardsFailOpen: true, GuardsKey: "AGENTO11Y_GUARDS_ENABLED", GuardsSource: sourceEnv}, want: "enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, env)"},
+		{name: "enabled fail-closed", config: ConfigSection{GuardsEnabled: true, GuardsTimeoutMs: 500, GuardsFailOpen: false, GuardsKey: "SIGIL_GUARDS_ENABLED", GuardsSource: sourceEnv}, want: "enabled, timeout 500ms, fail-closed (SIGIL_GUARDS_ENABLED, env)"},
+		// A rejected GUARDS_TIMEOUT_MS leaves GUARDS_ENABLED as the key the row
+		// names. The fallback itself is reported once, on the section message line,
+		// so it adds no second group to the row.
+		{name: "timeout fell back", config: ConfigSection{GuardsEnabled: true, GuardsTimeoutMs: 1500, GuardsFailOpen: true, GuardsFellBack: true, GuardsKey: "AGENTO11Y_GUARDS_ENABLED", GuardsSource: sourceEnv}, want: "enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, env)"},
+		// A rejected GUARDS_ENABLED value decided nothing, so the row reports the
+		// built-in default and names no variable.
+		{name: "enabled value rejected", config: ConfigSection{GuardsEnabled: false, GuardsFellBack: true}, want: "disabled (default)"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -270,9 +454,9 @@ func TestRenderHuman_GuardsLine(t *testing.T) {
 		config   ConfigSection
 		wantLine string
 	}{
-		{name: "disabled", config: ConfigSection{GuardsEnabled: false}, wantLine: "disabled"},
-		{name: "enabled fail-open", config: ConfigSection{GuardsEnabled: true, GuardsTimeoutMs: 1500, GuardsFailOpen: true}, wantLine: "enabled (timeout 1500ms, fail-open)"},
-		{name: "enabled fail-closed", config: ConfigSection{GuardsEnabled: true, GuardsTimeoutMs: 500, GuardsFailOpen: false}, wantLine: "enabled (timeout 500ms, fail-closed)"},
+		{name: "disabled", config: ConfigSection{GuardsEnabled: false}, wantLine: "disabled (default)"},
+		{name: "enabled fail-open", config: ConfigSection{GuardsEnabled: true, GuardsTimeoutMs: 1500, GuardsFailOpen: true, GuardsKey: "AGENTO11Y_GUARDS_ENABLED", GuardsSource: sourceEnv}, wantLine: "enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, env)"},
+		{name: "enabled fail-closed", config: ConfigSection{GuardsEnabled: true, GuardsTimeoutMs: 500, GuardsFailOpen: false, GuardsKey: "AGENTO11Y_GUARDS_ENABLED", GuardsSource: sourceEnv}, wantLine: "enabled, timeout 500ms, fail-closed (AGENTO11Y_GUARDS_ENABLED, env)"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -280,8 +464,10 @@ func TestRenderHuman_GuardsLine(t *testing.T) {
 			r.Config.GuardsEnabled = tc.config.GuardsEnabled
 			r.Config.GuardsTimeoutMs = tc.config.GuardsTimeoutMs
 			r.Config.GuardsFailOpen = tc.config.GuardsFailOpen
+			r.Config.GuardsKey = tc.config.GuardsKey
+			r.Config.GuardsSource = tc.config.GuardsSource
 			var buf bytes.Buffer
-			renderHuman(&buf, r, false, false)
+			renderHuman(&buf, r, false)
 			out := buf.String()
 			if !strings.Contains(out, "guards:") || !strings.Contains(out, tc.wantLine) {
 				t.Fatalf("expected guards line %q:\n%s", tc.wantLine, out)
@@ -291,19 +477,95 @@ func TestRenderHuman_GuardsLine(t *testing.T) {
 }
 
 func TestDescribeToken(t *testing.T) {
+	p := palette{color: false}
 	tests := []struct {
 		name  string
 		token tokenValue
 		want  string
 	}{
 		{name: "unset", token: tokenValue{}, want: "not set"},
-		{name: "with prefix", token: tokenValue{Set: true, Prefix: "glc_", Source: sourceEnv}, want: "set (glc_…, env)"},
-		{name: "no prefix", token: tokenValue{Set: true, Source: sourceConfig}, want: "set (config.env)"},
+		{name: "with prefix", token: tokenValue{Set: true, Prefix: "glc_", Source: sourceEnv, Key: "AGENTO11Y_AUTH_TOKEN"}, want: "set (glc_…, AGENTO11Y_AUTH_TOKEN, env)"},
+		{name: "legacy spelling", token: tokenValue{Set: true, Prefix: "glc_", Source: sourceConfig, Key: "SIGIL_AUTH_TOKEN"}, want: "set (glc_…, SIGIL_AUTH_TOKEN, config.env)"},
+		// A hand-built value carries no key, so the source stands alone rather
+		// than leaving an empty slot in the trailer.
+		{name: "no key", token: tokenValue{Set: true, Source: sourceConfig}, want: "set (config.env)"},
+		{name: "no prefix", token: tokenValue{Set: true, Source: sourceConfig, Key: "AGENTO11Y_AUTH_TOKEN"}, want: "set (AGENTO11Y_AUTH_TOKEN, config.env)"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := describeToken(tc.token); got != tc.want {
+			if got := describeToken(p, tc.token); got != tc.want {
 				t.Fatalf("describeToken = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDescribeSource(t *testing.T) {
+	p := palette{color: false}
+	tests := []struct {
+		name  string
+		parts []string
+		want  string
+	}{
+		{name: "no parts", parts: nil, want: ""},
+		{name: "all parts empty", parts: []string{"", ""}, want: ""},
+		{name: "detail only", parts: []string{"present"}, want: "(present)"},
+		{name: "key and source", parts: []string{"AGENTO11Y_ENDPOINT", "env"}, want: "(AGENTO11Y_ENDPOINT, env)"},
+		{name: "detail then provenance", parts: []string{"glc_…", "SIGIL_AUTH_TOKEN", "config.env"}, want: "(glc_…, SIGIL_AUTH_TOKEN, config.env)"},
+		// A missing middle part is dropped rather than rendered as an empty slot.
+		{name: "empty part dropped", parts: []string{"", "config.env"}, want: "(config.env)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := describeSource(p, tc.parts...); got != tc.want {
+				t.Fatalf("describeSource = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDescribeLocal covers the one row whose value is not the resolved string:
+// the launcher acts on the boolean whitelist, so a value outside it leaves local
+// mode off and the row has to say so.
+func TestDescribeLocal(t *testing.T) {
+	p := palette{color: false}
+	tests := []struct {
+		name    string
+		value   envValue
+		invalid bool
+		want    string
+	}{
+		{name: "valid value", value: envValue{Set: true, Value: "true", Source: sourceEnv, Key: "AGENTO11Y_LOCAL"}, want: "true (AGENTO11Y_LOCAL, env)"},
+		{name: "rejected value", value: envValue{Set: true, Value: "enabled", Source: sourceEnv, Key: "AGENTO11Y_LOCAL"}, invalid: true, want: `off (AGENTO11Y_LOCAL="enabled" is not a boolean, env)`},
+		// A hand-built value carries no key, so the trailer quotes the value alone.
+		{name: "rejected value without a key", value: envValue{Set: true, Value: "enabled", Source: sourceConfig}, invalid: true, want: `off ("enabled" is not a boolean, config.env)`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := describeLocal(p, tc.value, tc.invalid); got != tc.want {
+				t.Fatalf("describeLocal = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDescribeEnv(t *testing.T) {
+	p := palette{color: false}
+	tests := []struct {
+		name  string
+		value envValue
+		want  string
+	}{
+		// No variable supplied the value, so there is no key or source to name.
+		{name: "unset has no trailer", value: envValue{}, want: "not set"},
+		{name: "key and source", value: envValue{Set: true, Value: "https://sigil.example", Source: sourceEnv, Key: "AGENTO11Y_ENDPOINT"}, want: "https://sigil.example (AGENTO11Y_ENDPOINT, env)"},
+		{name: "legacy spelling", value: envValue{Set: true, Value: "https://sigil.example", Source: sourceConfig, Key: "SIGIL_ENDPOINT"}, want: "https://sigil.example (SIGIL_ENDPOINT, config.env)"},
+		{name: "no key", value: envValue{Set: true, Value: "true", Source: sourceEnv}, want: "true (env)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := describeEnv(p, tc.value); got != tc.want {
+				t.Fatalf("describeEnv = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/doctor/testdata/render/broken.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/broken.golden.txt
@@ -1,9 +1,9 @@
 agento11y doctor dev
 
 ✗ Conversations (generation export)
-  endpoint:           not a url :// (env)
-  tenant id:          12345 (config.env)
-  auth token:         set (glc_…, config.env)
+  endpoint:           not a url :// (AGENTO11Y_ENDPOINT, env)
+  tenant id:          12345 (AGENTO11Y_AUTH_TENANT_ID, config.env)
+  auth token:         set (glc_…, SIGIL_AUTH_TOKEN, config.env)
   ! AGENTO11Y_ENDPOINT is not a usable endpoint: parse generation export endpoint "not a url ://": parse "https://not a url ://": invalid character " " in host name
   ! configured via legacy SIGIL_* names — these keep working, but the preferred names are AGENTO11Y_*
 
@@ -13,19 +13,20 @@ agento11y doctor dev
 
 ! Config
   file:               /home/u/.config/agento11y/config.env (present)
-  content capture:    metadata_only (invalid value, fell back)
-  guards:             disabled (invalid value, fell back)
-  local forwarding:   true (config.env)
+  content capture:    metadata_only (default)
+  guards:             disabled (SIGIL_GUARDS_ENABLED, env)
+  local mode:         off (AGENTO11Y_LOCAL="enabled" is not a boolean, env)
+  local forwarding:   true (AGENTO11Y_LOCAL_FORWARD, config.env)
   local guard checks: not forwarded (AGENTO11Y_GUARDS_ENABLED is off, so there are no guards to enforce)
   ! config.env has keys agento11y ignores: AWS_SECRET
-  ! the CONTENT_CAPTURE_MODE value is invalid; using metadata_only
-  ! a GUARDS_* value is invalid; falling back to defaults
+  ! the AGENTO11Y_CONTENT_CAPTURE_MODE value is invalid; using metadata_only
+  ! the AGENTO11Y_GUARDS_TIMEOUT_MS value is invalid; guards use the default
+  ! the AGENTO11Y_LOCAL value is not a boolean; local mode stays off
 
 Coding agents
   copilot:            install state unknown (hook-based; stat /home/u/.copilot/hooks/agento11y.json: operation not permitted)
   pi:                 on PATH, plugin not installed
-  auto-update:        disabled (SIGIL_AUTO_UPDATE)
+  opencode:           installed next (CLI not on PATH, npm spec pinned)
+  auto-update:        disabled (AGENTO11Y_AUTO_UPDATE, config.env)
 
 ✗ 2 problem(s): conversations, analytics misconfigured
-
-Verdicts above check configuration only. Run `agento11y doctor --probe` to test credentials against the endpoints.

--- a/plugins/agento11y/internal/doctor/testdata/render/healthy.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/healthy.golden.txt
@@ -1,20 +1,20 @@
 agento11y doctor v0.22.0
 
 ✓ Conversations (generation export)
-  endpoint:           https://sigil.example (env)
-  tenant id:          12345 (env)
-  auth token:         set (glc_…, env)
+  endpoint:           https://sigil.example (AGENTO11Y_ENDPOINT, env)
+  tenant id:          12345 (AGENTO11Y_AUTH_TENANT_ID, env)
+  auth token:         set (glc_…, AGENTO11Y_AUTH_TOKEN, env)
 
 ✓ Analytics (OTLP metrics & traces)
   endpoint:           https://otlp.example/otlp (AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT, env)
 
 ✓ Config
   file:               /home/u/.config/agento11y/config.env (present)
-  content capture:    full
-  guards:             enabled (timeout 1500ms, fail-open)
-  tags:               env=prod, team=assistant (config.env)
-  local forwarding:   true (env)
-  local guard checks: local hook evaluation reaches Cloud (tool calls, and the conversation an agent runs a preflight check on, are sent for evaluation whatever the capture mode)
+  content capture:    full (AGENTO11Y_CONTENT_CAPTURE_MODE, config.env)
+  guards:             enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, config.env)
+  tags:               env=prod, team=assistant (AGENTO11Y_TAGS, config.env)
+  local forwarding:   true (AGENTO11Y_LOCAL_FORWARD, env)
+  local guard checks: forwarded to Cloud (tool calls, and the conversation an agent runs a preflight check on, are sent for evaluation whatever the capture mode)
 
 Coding agents
   claude:             installed v0.3.0
@@ -22,5 +22,3 @@ Coding agents
   cursor:             detected v0.22.0 (hook-based; configured in Cursor settings)
 
 ✓ no problems detected
-
-Verdicts above check configuration only. Run `agento11y doctor --probe` to test credentials against the endpoints.

--- a/plugins/agento11y/internal/doctor/testdata/render/minimal.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/minimal.golden.txt
@@ -12,8 +12,8 @@ agento11y doctor v0.22.0
 
 ✓ Config
   file:            /home/u/.config/agento11y/config.env (missing)
-  content capture: full
-  guards:          disabled
+  content capture: metadata_only (default)
+  guards:          disabled (default)
 
 Coding agents
   claude:          plugin not installed

--- a/plugins/agento11y/internal/doctor/testdata/render/redirected.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/redirected.golden.txt
@@ -4,14 +4,13 @@ agento11y doctor v0.22.0
   endpoint:           https://sigil.example (AGENTO11Y_ENDPOINT, env)
   tenant id:          12345 (AGENTO11Y_AUTH_TENANT_ID, env)
   auth token:         set (glc_…, AGENTO11Y_AUTH_TOKEN, env)
-  probe:              no response (https://sigil.example/api/v1/generations:export)
-  ! could not reach the conversations endpoint: no response: Post "https://sigil.example/api/v1/generations:export": dial tcp 10.0.0.1:443: connect: connection refused
+  probe:              HTTP 302 (https://sigil.example/api/v1/generations:export)
+  ! the conversations endpoint redirected the export request (HTTP 302: redirected to /login), so AGENTO11Y_ENDPOINT is not an Agent Observability API URL. Copy the API URL from the Agent Observability app's Connection page (e.g. https://agento11y-prod-<region>.grafana.net).
 
-✗ Analytics (OTLP metrics & traces)
+✓ Analytics (OTLP metrics & traces)
   endpoint:           https://otlp.example/otlp (AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT, env)
   metrics probe:      HTTP 200 (https://otlp.example/otlp/v1/metrics)
-  traces probe:       HTTP 403 (https://otlp.example/otlp/v1/traces)
-  ! the OTLP endpoint rejected the traces export: HTTP 403: the token is likely missing the metrics:write/traces:write scope
+  traces probe:       HTTP 200 (https://otlp.example/otlp/v1/traces)
 
 ✓ Config
   file:               /home/u/.config/agento11y/config.env (present)
@@ -26,4 +25,4 @@ Coding agents
   codex:              not found on PATH
   cursor:             detected v0.22.0 (hook-based; configured in Cursor settings)
 
-✗ 2 problem(s): conversations, analytics misconfigured
+✗ 1 problem(s): conversations misconfigured

--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -116,7 +116,7 @@ func localPrivacyLines(posture local.ForwardPosture, known bool) []string {
 	}
 }
 
-const usageLine = "usage: agento11y login | agento11y doctor [--json] [--probe] | agento11y local start|status|stop | agento11y cursor install|uninstall | agento11y <agent> hook | agento11y <claude|codex|copilot|opencode|pi|vibe> [--local|--no-local] [--tag key=value]... [-- args...]"
+const usageLine = "usage: agento11y login | agento11y doctor [--json] | agento11y local start|status|stop | agento11y cursor install|uninstall | agento11y <agent> hook | agento11y <claude|codex|copilot|opencode|pi|vibe> [--local|--no-local] [--tag key=value]... [-- args...]"
 
 // version is the build version received from the calling main package via
 // Main. It stays a package var (defaulting to "dev") so tests can override

--- a/plugins/agento11y/internal/envconfig/envconfig.go
+++ b/plugins/agento11y/internal/envconfig/envconfig.go
@@ -63,6 +63,12 @@ func LookupEnv(suffix string) (value, key string, ok bool) {
 	return "", "", false
 }
 
+// Lookup resolves an alias family to its value and the spelling that won.
+// LookupEnv is the process-env implementation; doctor supplies one backed by
+// its pre-merge snapshot so it can attribute a value to the shell or
+// config.env.
+type Lookup func(suffix string) (value, key string, ok bool)
+
 // LookupMap resolves a branded variable from a config map (as returned by
 // dotenv.LoadDotenv) with the same preferred-first precedence LookupEnv
 // applies to the process environment. The returned key names the spelling the
@@ -338,19 +344,27 @@ const (
 // results across plugins. Hooks must not write to stderr, so callers pass
 // their adapter logger here.
 func ResolveGuards(logger *log.Logger) GuardsConfig {
+	return ResolveGuardsWith(logger, LookupEnv)
+}
+
+// ResolveGuardsWith resolves the guard configuration from an arbitrary lookup,
+// applying the same defaults and diagnostics as ResolveGuards. Doctor passes a
+// lookup backed by its env snapshot so it reports the values the hooks resolve
+// and can name the variable each one came from.
+func ResolveGuardsWith(logger *log.Logger, look Lookup) GuardsConfig {
 	cfg := GuardsConfig{
-		Enabled:   resolveGuardsBool(logger, "GUARDS_ENABLED", defaultGuardsEnabled),
+		Enabled:   resolveGuardsBool(logger, look, "GUARDS_ENABLED", defaultGuardsEnabled),
 		TimeoutMs: DefaultGuardsTimeoutMs,
-		FailOpen:  resolveGuardsBool(logger, "GUARDS_FAIL_OPEN", defaultGuardsFailOpen),
+		FailOpen:  resolveGuardsBool(logger, look, "GUARDS_FAIL_OPEN", defaultGuardsFailOpen),
 	}
-	if v, key, ok := LookupEnv("GUARDS_TIMEOUT_MS"); ok {
+	if v, key, ok := look("GUARDS_TIMEOUT_MS"); ok {
 		cfg.TimeoutMs = IntValue(logger, key, v, DefaultGuardsTimeoutMs)
 	}
 	return cfg
 }
 
-func resolveGuardsBool(logger *log.Logger, suffix string, def bool) bool {
-	raw, key, ok := LookupEnv(suffix)
+func resolveGuardsBool(logger *log.Logger, look Lookup, suffix string, def bool) bool {
+	raw, key, ok := look(suffix)
 	if !ok {
 		return def
 	}
@@ -365,14 +379,27 @@ func IntValue(logger *log.Logger, key, raw string, def int) int {
 	if raw == "" {
 		return def
 	}
-	n, err := strconv.Atoi(raw)
-	if err != nil || n <= 0 {
+	n, ok := ParseIntValue(raw)
+	if !ok {
 		if logger != nil {
 			logger.Printf("config: invalid %s=%q; using %d", key, raw, def)
 		}
 		return def
 	}
 	return n
+}
+
+// ParseIntValue parses a positive config integer. ok is false for a
+// non-numeric, zero, or negative value, which is what IntValue reports and
+// falls back on. A caller that only needs to know whether a value would be
+// rejected, such as doctor naming the variable to fix, uses this rather than
+// restating the rule.
+func ParseIntValue(raw string) (value int, ok bool) {
+	n, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
 }
 
 // BoolValue parses a config boolean from raw using the guards whitelist

--- a/plugins/agento11y/internal/envconfig/envconfig_test.go
+++ b/plugins/agento11y/internal/envconfig/envconfig_test.go
@@ -71,6 +71,39 @@ func TestParseBoolValue(t *testing.T) {
 	}
 }
 
+// TestParseIntValue pins the rule IntValue falls back on, which doctor reads to
+// name a rejected timeout without restating what counts as valid.
+func TestParseIntValue(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   int
+		wantOK bool
+	}{
+		{in: "1500", want: 1500, wantOK: true},
+		{in: " 500 ", want: 500, wantOK: true},
+		{in: ""},
+		{in: "abc"},
+		{in: "0"},
+		{in: "-1"},
+		{in: "1.5"},
+	}
+	for _, tc := range cases {
+		got, gotOK := ParseIntValue(tc.in)
+		if got != tc.want || gotOK != tc.wantOK {
+			t.Errorf("ParseIntValue(%q) = (%d, %v), want (%d, %v)", tc.in, got, gotOK, tc.want, tc.wantOK)
+		}
+		// IntValue treats an empty value as "unset" rather than a fault, so it is
+		// the one input where the two disagree.
+		wantIntValue := 42
+		if tc.wantOK {
+			wantIntValue = tc.want
+		}
+		if got := IntValue(nil, "AGENTO11Y_GUARDS_TIMEOUT_MS", tc.in, 42); got != wantIntValue {
+			t.Errorf("IntValue(%q, def 42) = %d, want %d", tc.in, got, wantIntValue)
+		}
+	}
+}
+
 func TestEnvOr(t *testing.T) {
 	t.Setenv("SIGIL_TEST_PRESENT", "present")
 	t.Setenv("SIGIL_TEST_EMPTY", "")
@@ -117,6 +150,11 @@ func TestParseExtraTags(t *testing.T) {
 	}
 }
 
+// TestResolveGuards drives both entry points over the same cases: ResolveGuards
+// reads the process env, and ResolveGuardsWith reads the same values through a
+// map-backed Lookup, which is how doctor resolves them from its pre-merge
+// snapshot. Sharing the table anchors both to a concrete GuardsConfig, so the
+// two cannot drift into agreeing on a wrong answer.
 func TestResolveGuards(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -225,17 +263,67 @@ func TestResolveGuards(t *testing.T) {
 				t.Setenv(k, v)
 			}
 
-			var buf bytes.Buffer
-			logger := log.New(&buf, "", 0)
-			got := ResolveGuards(logger)
-			if got != tt.want {
-				t.Errorf("ResolveGuards() = %+v, want %+v", got, tt.want)
+			for _, entry := range []struct {
+				name    string
+				resolve func(*log.Logger) GuardsConfig
+			}{
+				{"ResolveGuards", ResolveGuards},
+				{"ResolveGuardsWith", func(l *log.Logger) GuardsConfig {
+					return ResolveGuardsWith(l, mapLookup(tt.env))
+				}},
+			} {
+				var buf bytes.Buffer
+				got := entry.resolve(log.New(&buf, "", 0))
+				if got != tt.want {
+					t.Errorf("%s() = %+v, want %+v", entry.name, got, tt.want)
+				}
+				if tt.wantLog != "" && !strings.Contains(buf.String(), tt.wantLog) {
+					t.Errorf("%s log output = %q, want substring %q", entry.name, buf.String(), tt.wantLog)
+				}
+				if tt.wantLog == "" && buf.Len() != 0 {
+					t.Errorf("%s unexpected log output: %q", entry.name, buf.String())
+				}
 			}
-			if tt.wantLog != "" && !strings.Contains(buf.String(), tt.wantLog) {
-				t.Errorf("log output = %q, want substring %q", buf.String(), tt.wantLog)
+		})
+	}
+}
+
+// mapLookup is a Lookup backed by a plain map, standing in for the pre-merge
+// env snapshot doctor resolves from.
+func mapLookup(env map[string]string) Lookup {
+	return func(suffix string) (value, key string, ok bool) {
+		return LookupMap(env, suffix)
+	}
+}
+
+// TestResolveContentMode covers the process-env wrapper: which spelling supplies
+// the mode, which is the one thing the value-level table below cannot reach.
+func TestResolveContentMode(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want agento11y.ContentCaptureMode
+	}{
+		{name: "unset is metadata_only", want: agento11y.ContentCaptureModeMetadataOnly},
+		{name: "preferred spelling", env: map[string]string{"AGENTO11Y_CONTENT_CAPTURE_MODE": "full"}, want: agento11y.ContentCaptureModeFull},
+		{name: "legacy spelling", env: map[string]string{"SIGIL_CONTENT_CAPTURE_MODE": "no_tool_content"}, want: agento11y.ContentCaptureModeNoToolContent},
+		{
+			name: "preferred wins over legacy",
+			env: map[string]string{
+				"AGENTO11Y_CONTENT_CAPTURE_MODE": "full",
+				"SIGIL_CONTENT_CAPTURE_MODE":     "no_tool_content",
+			},
+			want: agento11y.ContentCaptureModeFull,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			PinAliasEnvBlank(t)
+			for k, v := range tt.env {
+				t.Setenv(k, v)
 			}
-			if tt.wantLog == "" && buf.Len() != 0 {
-				t.Errorf("unexpected log output: %q", buf.String())
+			if got := ResolveContentMode(nil); got != tt.want {
+				t.Errorf("ResolveContentMode() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/otel/otel.go
+++ b/plugins/agento11y/internal/otel/otel.go
@@ -208,7 +208,7 @@ type ProbeTarget struct {
 // ProbeConfig resolves the OTLP endpoint and returns the per-signal probe
 // targets for metrics and traces, reusing the same endpoint resolution,
 // signal-URL construction, and auth-header synthesis as Setup. ok is false
-// when no OTLP endpoint is configured. Used by `agento11y doctor --probe` to send
+// when no OTLP endpoint is configured. Used by `agento11y doctor` to send
 // a lightweight request to each signal and report the HTTP status without
 // standing up the full exporter pipeline.
 func ProbeConfig() (metrics, traces ProbeTarget, ok bool) {


### PR DESCRIPTION
Improve `agento11y doctor` checks:

- Probes always run, `--probe` is the default now.
- The probe no longer follows redirects, and only 2xx (plus 405) counts as reachable. A 3xx, a 404, or any other status is now reported.
- An endpoint shaped like a Grafana app page fails without the network; a Cloud stack host or the OTLP gateway host warns.
- Show installed plugin versions.

Example:

```
✗ Conversations (generation export)
  endpoint:           https://mystack.grafana.net/a/grafana-agento11y-app (AGENTO11Y_ENDPOINT, env)
  tenant id:          123456 (AGENTO11Y_AUTH_TENANT_ID, env)
  auth token:         set (glc_…, AGENTO11Y_AUTH_TOKEN, env)
  ! AGENTO11Y_ENDPOINT points at a Grafana app page, not the Agent Observability API. Copy the API URL from the Agent Observability app's Connection page (e.g. https://agento11y-prod-<region>.grafana.net).
```
