### PR TITLE
perf(plugins/agento11y): stop decoding all files on each local viewer request

### DIFF
--- a/plugins/agento11y/internal/local/cloudguard.go
+++ b/plugins/agento11y/internal/local/cloudguard.go
@@ -70,7 +70,7 @@ func (l *forwardLoader) evaluateCloudHook(ctx context.Context, cfg forwardConfig
 	req.Header.Set("Content-Type", wire.ContentTypeJSON)
 	// The marker is what stops a daemon whose ENDPOINT was hand-set to its own
 	// address from chaining the relayed copy again.
-	req.Header.Set(forwardMarkerHeader, "1")
+	req.Header.Set(ForwardMarkerHeader, "1")
 	req.Header.Set(hookTimeoutHeader, strconv.FormatInt(timeout.Milliseconds(), 10))
 	for k, v := range cfg.hookHeaders {
 		if v != "" {

--- a/plugins/agento11y/internal/local/events_test.go
+++ b/plugins/agento11y/internal/local/events_test.go
@@ -108,37 +108,72 @@ func TestServer_Events_ClosesOnServerClose(t *testing.T) {
 	}
 }
 
-// TestServer_Events_BroadcastsEveryGenerationInBurst posts an export
-// with two generations and asserts both broadcast frames arrive on the
-// stream, so a burst export does not collapse into a single event on
-// the server side.
-func TestServer_Events_BroadcastsEveryGenerationInBurst(t *testing.T) {
-	s, _ := newTestServer(t)
-	ts := httptest.NewServer(s)
-	defer ts.Close()
+// TestServer_Events_BroadcastsOnePerConversation posts batched exports and
+// asserts one frame per conversation the request wrote to: a five-record
+// batch for one conversation emits a single event, and a batch spanning
+// two conversations emits one event each. A per-generation event would
+// multiply the viewer's full-store refetches during an import.
+func TestServer_Events_BroadcastsOnePerConversation(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want []changeEvent
+	}{
+		{
+			name: "five generations one conversation",
+			body: `{"generations":[
+				{"id":"gen-1","conversation_id":"conv-A"},
+				{"id":"gen-2","conversation_id":"conv-A"},
+				{"id":"gen-3","conversation_id":"conv-A"},
+				{"id":"gen-4","conversation_id":"conv-A"},
+				{"id":"gen-5","conversation_id":"conv-A"}
+			]}`,
+			want: []changeEvent{{ConversationID: "conv-A", GenerationID: "gen-5"}},
+		},
+		{
+			name: "batch spanning two conversations",
+			body: `{"generations":[
+				{"id":"gen-1","conversation_id":"session-1"},
+				{"id":"gen-2","conversation_id":"session-2"},
+				{"id":"gen-3","conversation_id":"session-1"}
+			]}`,
+			want: []changeEvent{
+				{ConversationID: "session-1", GenerationID: "gen-3"},
+				{ConversationID: "session-2", GenerationID: "gen-2"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := newTestServer(t)
+			ts := httptest.NewServer(s)
+			defer ts.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	stream := openEventStream(t, ctx, ts.URL)
-	defer stream.close()
-	require.NoError(t, stream.waitForComment(2*time.Second))
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			stream := openEventStream(t, ctx, ts.URL)
+			defer stream.close()
+			require.NoError(t, stream.waitForComment(2*time.Second))
 
-	body := `{"generations":[
-		{"id":"gen-1","conversation_id":"conv-A"},
-		{"id":"gen-2","conversation_id":"conv-B"}
-	]}`
-	postResp, err := http.Post(ts.URL+"/api/v1/generations:export", "application/json", strings.NewReader(body))
-	require.NoError(t, err)
-	postResp.Body.Close()
+			postResp, err := http.Post(ts.URL+"/api/v1/generations:export", "application/json", strings.NewReader(tc.body))
+			require.NoError(t, err)
+			postResp.Body.Close()
 
-	first, err := stream.nextEvent(2 * time.Second)
-	require.NoError(t, err)
-	second, err := stream.nextEvent(2 * time.Second)
-	require.NoError(t, err)
+			var got []changeEvent
+			for range tc.want {
+				ev, err := stream.nextEvent(2 * time.Second)
+				require.NoError(t, err)
+				got = append(got, ev)
+			}
+			assert.ElementsMatch(t, tc.want, got)
 
-	got := []changeEvent{first, second}
-	assert.Contains(t, got, changeEvent{ConversationID: "conv-A", GenerationID: "gen-1"})
-	assert.Contains(t, got, changeEvent{ConversationID: "conv-B", GenerationID: "gen-2"})
+			// No further frame: the batch is one event per conversation, not
+			// one per generation.
+			if ev, err := stream.nextEvent(300 * time.Millisecond); err == nil {
+				t.Fatalf("unexpected extra event %+v", ev)
+			}
+		})
+	}
 }
 
 // TestServer_Events_HeartbeatComment exercises the ping branch of the

--- a/plugins/agento11y/internal/local/forward.go
+++ b/plugins/agento11y/internal/local/forward.go
@@ -67,11 +67,15 @@ const hookEvaluatePath = "/api/v1/hooks:evaluate"
 // otlpForwardLabel names one OTLP signal leg in the failure ring.
 func otlpForwardLabel(signal string) string { return "otlp/" + signal }
 
-// forwardMarkerHeader is set on every forwarded request. A daemon that
+// ForwardMarkerHeader is set on every forwarded request. A daemon that
 // receives a payload carrying it does not forward again, so two daemons
 // pointed at each other (or one pointed at itself through a hand-written
 // local ingest endpoint) exchange one copy instead of looping.
-const forwardMarkerHeader = "X-Agento11y-Local-Forwarded"
+//
+// It is exported so an in-process producer that exports through the local
+// ingest endpoint can mark its own requests and keep them from reaching
+// Cloud. A history import that writes months of transcripts needs this.
+const ForwardMarkerHeader = "X-Agento11y-Local-Forwarded"
 
 // forwardConfig is the resolved forwarding configuration for one load cycle.
 // The two legs resolve independently: generation export needs Cloud
@@ -582,7 +586,7 @@ func forwardDisabledReason(endpoint, tenant, token string) string {
 	// A local receiver (http://127.0.0.1, ::1, localhost) is a valid forward
 	// target — e.g. a separate daemon — and does not validate auth, so empty
 	// or placeholder credentials must not pause forwarding to it. The
-	// forwardMarkerHeader on the outbound request is what stops a daemon
+	// ForwardMarkerHeader on the outbound request is what stops a daemon
 	// pointed at itself from relaying the same payload again.
 	if envconfig.IsLocalEndpoint(endpoint) {
 		return ""
@@ -934,7 +938,7 @@ func (l *forwardLoader) post(url, contentType, contentEncoding string, headers m
 	if contentEncoding != "" {
 		req.Header.Set("Content-Encoding", contentEncoding)
 	}
-	req.Header.Set(forwardMarkerHeader, "1")
+	req.Header.Set(ForwardMarkerHeader, "1")
 	for k, v := range headers {
 		if v != "" {
 			req.Header.Set(k, v)
@@ -959,11 +963,12 @@ func (l *forwardLoader) post(url, contentType, contentEncoding string, headers m
 }
 
 // isForwardedRequest reports whether an inbound payload already came from
-// another daemon's forwarder. Relaying it again would loop between two daemons
-// pointed at each other, or between one daemon and itself when the ingest
-// endpoint is hand-set to this daemon's own address.
+// another daemon's forwarder, or from an in-process producer that marked it.
+// Relaying it again would loop between two daemons pointed at each other, or
+// between one daemon and itself when the ingest endpoint is hand-set to this
+// daemon's own address.
 func isForwardedRequest(r *http.Request) bool {
-	return r.Header.Get(forwardMarkerHeader) != ""
+	return r.Header.Get(ForwardMarkerHeader) != ""
 }
 
 // otlpSignalFromPath maps an OTLP receiver path to its signal name.

--- a/plugins/agento11y/internal/local/query.go
+++ b/plugins/agento11y/internal/local/query.go
@@ -4,10 +4,10 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -107,11 +107,80 @@ type ConversationDetail struct {
 	Generations []GenerationView `json:"generations"`
 }
 
-// ListConversations walks the conversations directory and produces one
-// ConversationSummary per file, sorted newest-first by last_activity.
-// A missing directory returns an empty slice (first-launch case).
-// limit ≤ 0 means unbounded.
-func (s *Storage) ListConversations(limit int) ([]ConversationSummary, error) {
+// ConversationListOptions bounds one conversation-list request.
+//
+// The page is cut before any file is decoded: entries are ordered by file
+// modification time (newest first) and only the requested page is
+// summarised, so the cost of a request follows Limit rather than the size
+// of the store.
+type ConversationListOptions struct {
+	// Limit caps how many conversations are summarised and returned.
+	// ≤ 0 means unbounded.
+	Limit int
+	// Since drops conversations whose last activity predates it. The bound
+	// is inclusive, so a conversation whose last activity is exactly Since
+	// is kept. It applies to the file modification time, which for these
+	// append-only files is the last activity. Zero means no lower bound.
+	Since time.Time
+}
+
+// ListConversations produces one ConversationSummary per conversation
+// file, newest-first by file modification time with ties broken by
+// conversation id, so paging is deterministic. total counts the
+// conversation files in the store before Limit and Since: a caller holding
+// one page still knows whether the store is empty. A missing directory
+// returns an empty slice and a zero total (first-launch case).
+//
+// The limit can apply before the decode only because the order comes from
+// the file modification time rather than the decoded last_activity. For an
+// append-only JSONL file the two agree. A copy or restore that rewrites
+// modification times can reorder the list until the next append.
+func (s *Storage) ListConversations(opts ConversationListOptions) (page []ConversationSummary, total int, err error) {
+	files, err := s.conversationFiles()
+	if err != nil {
+		return nil, 0, err
+	}
+	capacity := len(files)
+	if opts.Limit > 0 && opts.Limit < capacity {
+		capacity = opts.Limit
+	}
+	out := make([]ConversationSummary, 0, capacity)
+	var skipped int
+	defer func() { s.logSkipped("list conversations", skipped) }()
+	for _, f := range files {
+		// Files are newest-first, so the first one below the bound ends
+		// the walk without opening it.
+		if !opts.Since.IsZero() && f.modTime.Before(opts.Since) {
+			break
+		}
+		sum, ok, n, err := summariseConversationFile(f.path)
+		skipped += n
+		if err != nil {
+			return nil, 0, err
+		}
+		if !ok {
+			continue // empty or all-invalid file
+		}
+		out = append(out, sum)
+		if opts.Limit > 0 && len(out) == opts.Limit {
+			break
+		}
+	}
+	return out, len(files), nil
+}
+
+// conversationFile is one conversation JSONL file with the modification
+// time the list and metrics endpoints order and filter on.
+type conversationFile struct {
+	id      string
+	path    string
+	modTime time.Time
+}
+
+// conversationFiles lists the conversation files newest-first by
+// modification time, breaking ties by id so a page boundary is stable
+// across requests. A missing directory yields no files and no error.
+func (s *Storage) conversationFiles() ([]conversationFile, error) {
 	dir := filepath.Join(s.dir, ConversationsDir)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -120,39 +189,46 @@ func (s *Storage) ListConversations(limit int) ([]ConversationSummary, error) {
 		}
 		return nil, err
 	}
-	out := make([]ConversationSummary, 0, len(entries))
+	out := make([]conversationFile, 0, len(entries))
 	for _, e := range entries {
 		if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
 			continue
 		}
-		sum, ok, err := summariseConversationFile(filepath.Join(dir, e.Name()))
+		info, err := e.Info()
 		if err != nil {
+			if os.IsNotExist(err) {
+				continue // removed between ReadDir and Info
+			}
 			return nil, err
 		}
-		if !ok {
-			continue // empty or all-invalid file
-		}
-		out = append(out, sum)
+		out = append(out, conversationFile{
+			id:      strings.TrimSuffix(e.Name(), ".jsonl"),
+			path:    filepath.Join(dir, e.Name()),
+			modTime: info.ModTime(),
+		})
 	}
 	sort.Slice(out, func(i, j int) bool {
-		return out[i].LastActivity.After(out[j].LastActivity)
+		if !out[i].modTime.Equal(out[j].modTime) {
+			return out[i].modTime.After(out[j].modTime)
+		}
+		return out[i].id < out[j].id
 	})
-	if limit > 0 && len(out) > limit {
-		out = out[:limit]
-	}
 	return out, nil
 }
 
 // summariseConversationFile reads one per-conversation JSONL file and
-// returns its aggregated summary. Returns (_, false, nil) when the file
-// has no decodable records.
-func summariseConversationFile(path string) (ConversationSummary, bool, error) {
+// returns its aggregated summary plus the number of lines it could not
+// decode. It decodes the summary projection only, so a conversation holding
+// megabytes of messages costs the line scan and nothing more. ok is false
+// when the file has no decodable records.
+func summariseConversationFile(path string) (ConversationSummary, bool, int, error) {
 	agents := map[string]struct{}{}
 	models := map[string]struct{}{}
 	var sum ConversationSummary
 	var hasError, seen bool
 
-	err := scanLatestGenerationRecords(path, func(r generationRecord, gen storedGeneration) {
+	skipped, err := scanLatestSummaryRecords(path, func(rec summaryRecord) {
+		r, gen := rec, rec.Generation
 		seen = true
 		if sum.ID == "" {
 			sum.ID = r.ConversationID
@@ -208,10 +284,10 @@ func summariseConversationFile(path string) (ConversationSummary, bool, error) {
 		}
 	})
 	if err != nil {
-		return ConversationSummary{}, false, err
+		return ConversationSummary{}, false, skipped, err
 	}
 	if !seen {
-		return ConversationSummary{}, false, nil
+		return ConversationSummary{}, false, skipped, nil
 	}
 	sum.Agents = sortedKeys(agents)
 	sum.Models = sortedKeys(models)
@@ -219,7 +295,7 @@ func summariseConversationFile(path string) (ConversationSummary, bool, error) {
 	if hasError {
 		sum.Status = "err"
 	}
-	return sum, true, nil
+	return sum, true, skipped, nil
 }
 
 // ConversationDetail returns the chronological generation list for one
@@ -231,7 +307,7 @@ func (s *Storage) ConversationDetail(id string) (*ConversationDetail, error) {
 	}
 	path := filepath.Join(s.dir, ConversationsDir, id+".jsonl")
 	out := &ConversationDetail{ID: id}
-	err := scanLatestGenerationRecords(path, func(_ generationRecord, gen storedGeneration) {
+	skipped, err := scanLatestGenerationRecords(path, func(_ generationRecord, gen storedGeneration) {
 		if out.Title == "" && gen.title() != "" {
 			out.Title = gen.title()
 		}
@@ -263,6 +339,7 @@ func (s *Storage) ConversationDetail(id string) (*ConversationDetail, error) {
 		view.Skills = gen.skillViews()
 		out.Generations = append(out.Generations, view)
 	})
+	s.logSkipped("conversation "+id, skipped)
 	if err != nil {
 		return nil, err
 	}
@@ -318,48 +395,189 @@ type TokenUsagePoint struct {
 	TokenBuckets
 }
 
-// TokenUsagePoints walks every conversation file and returns one point
-// per generation that recorded any token usage, sorted oldest-first.
+// TokenUsageOptions bounds one token-metrics request.
+type TokenUsageOptions struct {
+	// Since drops generations older than it, and drops whole conversation
+	// files whose modification time is below it before any decode. Zero
+	// means no lower bound.
+	Since time.Time
+	// Interval is the bucket width. Zero asks for a derived interval that
+	// keeps the response under maxTokenUsageBuckets buckets.
+	Interval time.Duration
+}
+
+// maxTokenUsageBuckets caps how many buckets a derived interval produces.
+// The viewer draws at most CHART_BUCKET_MAX bars, so this is a safety
+// bound on the response rather than a display choice.
+const maxTokenUsageBuckets = 500
+
+// tokenUsageIntervals is the ladder a derived interval is picked from.
+// Every step divides the next, so a client that buckets on one step can
+// fold points aggregated on a finer step without splitting a bucket
+// across two bars. This list and BUCKET_INTERVALS_MS in app.jsx must stay
+// equal; TestBucketLaddersAgree checks that.
+var tokenUsageIntervals = []time.Duration{
+	10 * time.Second,
+	30 * time.Second,
+	time.Minute,
+	5 * time.Minute,
+	15 * time.Minute,
+	30 * time.Minute,
+	time.Hour,
+	2 * time.Hour,
+	4 * time.Hour,
+	12 * time.Hour,
+	24 * time.Hour,
+	7 * 24 * time.Hour,
+}
+
+// TokenUsagePoints returns token usage aggregated per interval bucket and
+// model, oldest-first, plus the interval used. Empty buckets are omitted,
+// so the response holds at most one point per model and provider per
+// non-empty bucket.
+//
 // A missing conversations dir yields no points (first-launch case).
-func (s *Storage) TokenUsagePoints() ([]TokenUsagePoint, error) {
-	dir := filepath.Join(s.dir, ConversationsDir)
-	entries, err := os.ReadDir(dir)
+func (s *Storage) TokenUsagePoints(opts TokenUsageOptions) ([]TokenUsagePoint, time.Duration, error) {
+	files, err := s.conversationFiles()
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
+		return nil, 0, err
 	}
-	var out []TokenUsagePoint
-	for _, e := range entries {
-		if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
+	var raw []TokenUsagePoint
+	var skipped int
+	defer func() { s.logSkipped("token metrics", skipped) }()
+	for _, f := range files {
+		// Files are newest-first, so the first one below the bound ends
+		// the walk without opening it.
+		if !opts.Since.IsZero() && f.modTime.Before(opts.Since) {
+			break
+		}
+		n, err := scanLatestSummaryRecords(f.path, func(rec summaryRecord) {
+			p, ok := tokenUsagePoint(rec)
+			if !ok {
+				return
+			}
+			if !opts.Since.IsZero() && p.Timestamp.Before(opts.Since) {
+				return
+			}
+			raw = append(raw, p)
+		})
+		skipped += n
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+	interval := opts.Interval
+	if interval <= 0 {
+		interval = deriveTokenUsageInterval(raw, opts.Since)
+	}
+	return bucketTokenUsagePoints(raw, interval), interval, nil
+}
+
+// deriveTokenUsageInterval picks the smallest ladder step that keeps the
+// requested range under maxTokenUsageBuckets buckets.
+func deriveTokenUsageInterval(points []TokenUsagePoint, since time.Time) time.Duration {
+	var first, last time.Time
+	for _, p := range points {
+		if first.IsZero() || p.Timestamp.Before(first) {
+			first = p.Timestamp
+		}
+		if p.Timestamp.After(last) {
+			last = p.Timestamp
+		}
+	}
+	if !since.IsZero() && since.After(first) {
+		first = since
+	}
+	span := last.Sub(first)
+	for _, step := range tokenUsageIntervals {
+		if span/step <= maxTokenUsageBuckets {
+			return step
+		}
+	}
+	return tokenUsageIntervals[len(tokenUsageIntervals)-1]
+}
+
+// bucketTokenUsagePoints sums points into (bucket start, model, provider)
+// groups, ordered by timestamp then model then provider so the chart reads
+// them in one pass.
+func bucketTokenUsagePoints(points []TokenUsagePoint, interval time.Duration) []TokenUsagePoint {
+	type bucketKey struct {
+		start    int64
+		model    string
+		provider string
+	}
+	indexByKey := map[bucketKey]int{}
+	// A bucket holds one point per model and provider, so the output is
+	// bounded by the bucket count however many generations came in.
+	out := make([]TokenUsagePoint, 0, min(len(points), 4*maxTokenUsageBuckets))
+	for _, p := range points {
+		start := intervalStart(p.Timestamp, interval)
+		key := bucketKey{start: start.UnixNano(), model: p.Model, provider: p.Provider}
+		if idx, ok := indexByKey[key]; ok {
+			out[idx].TokenBuckets = out[idx].TokenBuckets.plus(p.TokenBuckets)
 			continue
 		}
-		err := scanLatestGenerationRecords(filepath.Join(dir, e.Name()), func(r generationRecord, gen storedGeneration) {
-			if p, ok := tokenUsagePoint(r, gen); ok {
-				out = append(out, p)
-			}
+		indexByKey[key] = len(out)
+		out = append(out, TokenUsagePoint{
+			Timestamp:    start,
+			Model:        p.Model,
+			Provider:     p.Provider,
+			TokenBuckets: p.TokenBuckets,
 		})
-		if err != nil {
-			return nil, err
-		}
 	}
 	sort.Slice(out, func(i, j int) bool {
-		return out[i].Timestamp.Before(out[j].Timestamp)
+		if !out[i].Timestamp.Equal(out[j].Timestamp) {
+			return out[i].Timestamp.Before(out[j].Timestamp)
+		}
+		if out[i].Model != out[j].Model {
+			return out[i].Model < out[j].Model
+		}
+		return out[i].Provider < out[j].Provider
 	})
-	return out, nil
+	return out
+}
+
+// intervalStart floors t onto the interval grid measured from the Unix
+// epoch, so a bucket boundary is the same instant for every client that
+// divides time the same way. time.Time.Truncate cannot stand in: it
+// measures from year 1, which shifts the 7-day step by three days against
+// a client flooring from the epoch.
+//
+// t must be within the range UnixNano covers. tokenUsagePoint drops any
+// generation whose timestamp falls outside that range before reaching here.
+func intervalStart(t time.Time, interval time.Duration) time.Time {
+	if interval <= 0 {
+		return t.UTC()
+	}
+	nanos := t.UnixNano()
+	step := int64(interval)
+	floored := nanos / step
+	if nanos < 0 && nanos%step != 0 {
+		floored--
+	}
+	return time.Unix(0, floored*step).UTC()
+}
+
+// nanosRepresentable reports whether t is inside the range UnixNano
+// covers, roughly the years 1678 to 2262. Outside it UnixNano wraps, and
+// bucketing would move the point to a plausible-looking wrong date instead
+// of an obviously wrong one. time.Parse accepts years up to 9999.
+func nanosRepresentable(t time.Time) bool {
+	return !t.Before(time.Unix(0, math.MinInt64)) && !t.After(time.Unix(0, math.MaxInt64))
 }
 
 // tokenUsagePoint builds a TokenUsagePoint from one record. ok is false
-// when the generation recorded no tokens or has no usable timestamp, so
-// the caller can skip it rather than plot a zero-height bar at the epoch.
-func tokenUsagePoint(r generationRecord, gen storedGeneration) (TokenUsagePoint, bool) {
+// when the generation recorded no tokens, has no usable timestamp, or
+// carries a timestamp bucketing cannot place, so the caller can skip it
+// rather than plot a zero-height bar at the epoch.
+func tokenUsagePoint(rec summaryRecord) (TokenUsagePoint, bool) {
+	gen := rec.Generation
 	buckets := disjointTokenUsage(gen.Usage.toSDK(), gen.Model.Provider)
 	if buckets == (TokenBuckets{}) {
 		return TokenUsagePoint{}, false
 	}
-	when := generationTime(gen, r)
-	if when.IsZero() {
+	when := generationTime(gen, rec.ReceivedAt)
+	if when.IsZero() || !nanosRepresentable(when) {
 		return TokenUsagePoint{}, false
 	}
 	return TokenUsagePoint{
@@ -372,14 +590,14 @@ func tokenUsagePoint(r generationRecord, gen storedGeneration) (TokenUsagePoint,
 
 // generationTime is the wall-clock moment a generation ran, preferring
 // started_at, then completed_at, then the receiver's arrival time.
-func generationTime(gen storedGeneration, r generationRecord) time.Time {
+func generationTime(gen summaryGeneration, receivedAt string) time.Time {
 	if !gen.StartedAt.IsZero() {
 		return gen.StartedAt
 	}
 	if !gen.CompletedAt.IsZero() {
 		return gen.CompletedAt
 	}
-	when, _ := time.Parse(time.RFC3339Nano, r.ReceivedAt)
+	when, _ := time.Parse(time.RFC3339Nano, receivedAt)
 	return when
 }
 
@@ -493,38 +711,65 @@ func threadMessages(input, output []agento11y.Message) []agento11y.Message {
 	return messages
 }
 
-// scanGenerationRecords walks one per-conversation JSONL file calling visit
-// for every decodable record. A missing file is not an error; lines that
-// fail to decode (truncated mid-append, future-schema, …) are skipped.
-func scanGenerationRecords(path string, visit func(generationRecord, storedGeneration)) error {
+// scanJSONL walks one per-conversation JSONL file, calling decode on every
+// non-empty line and visit on each value decode accepts. A missing file is
+// not an error. It returns how many lines decode rejected (a tail truncated
+// mid-append is the usual reason), so the caller can report a file the
+// viewer is only partly reading.
+func scanJSONL[T any](path string, decode func([]byte) (T, bool), visit func(T)) (skipped int, err error) {
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return 0, nil
 		}
-		return err
+		return 0, err
 	}
 	defer f.Close()
 	sc := bufio.NewScanner(f)
 	// JSONL lines can hold full transcripts; bump the buffer well above
 	// the default 64 KiB.
-	sc.Buffer(make([]byte, 1024*1024), 64*1024*1024)
+	sc.Buffer(make([]byte, 64*1024), 64*1024*1024)
 	for sc.Scan() {
 		line := sc.Bytes()
 		if len(line) == 0 {
 			continue
 		}
-		var rec generationRecord
-		if err := json.Unmarshal(line, &rec); err != nil {
+		value, ok := decode(line)
+		if !ok {
+			skipped++
 			continue
 		}
-		var gen storedGeneration
-		if err := json.Unmarshal(rec.Generation, &gen); err != nil {
-			continue
-		}
-		visit(rec, gen)
+		visit(value)
 	}
-	return sc.Err()
+	return skipped, sc.Err()
+}
+
+// scanLatestJSONL is scanJSONL keeping only the last line per key, so a
+// re-exported generation replaces the earlier copy of itself. Values whose
+// key is empty are all kept, in file order.
+func scanLatestJSONL[T any](path string, decode func([]byte) (T, bool), keyOf func(T) string, visit func(T)) (int, error) {
+	indexByKey := map[string]int{}
+	var values []T
+	skipped, err := scanJSONL(path, decode, func(value T) {
+		key := keyOf(value)
+		if key == "" {
+			values = append(values, value)
+			return
+		}
+		if idx, ok := indexByKey[key]; ok {
+			values[idx] = value
+			return
+		}
+		indexByKey[key] = len(values)
+		values = append(values, value)
+	})
+	if err != nil {
+		return skipped, err
+	}
+	for _, value := range values {
+		visit(value)
+	}
+	return skipped, nil
 }
 
 type scannedGenerationRecord struct {
@@ -532,34 +777,64 @@ type scannedGenerationRecord struct {
 	gen    storedGeneration
 }
 
-func scanLatestGenerationRecords(path string, visit func(generationRecord, storedGeneration)) error {
-	indexByID := map[string]int{}
-	var records []scannedGenerationRecord
-	lineNo := 0
-	err := scanGenerationRecords(path, func(r generationRecord, gen storedGeneration) {
-		lineNo++
-		id := strings.TrimSpace(r.GenerationID)
-		if id == "" {
-			id = strings.TrimSpace(gen.ID)
-		}
-		if id == "" {
-			id = "\x00line:" + strconv.Itoa(lineNo)
-		}
-		scanned := scannedGenerationRecord{record: r, gen: gen}
-		if idx, ok := indexByID[id]; ok {
-			records[idx] = scanned
-			return
-		}
-		indexByID[id] = len(records)
-		records = append(records, scanned)
-	})
-	if err != nil {
-		return err
+// decodeGenerationRecord decodes one JSONL line into the full stored
+// generation, including the input and output message trees. Only the
+// detail view and search need those.
+//
+// A line whose generation the full struct rejects falls back to the summary
+// projection, so the detail view and the list accept the same lines: a
+// record with an input tree this build cannot read still shows its header,
+// tokens and timings rather than disappearing from a conversation the list
+// counted.
+func decodeGenerationRecord(line []byte) (scannedGenerationRecord, bool) {
+	var rec generationRecord
+	if err := json.Unmarshal(line, &rec); err != nil {
+		return scannedGenerationRecord{}, false
 	}
-	for _, r := range records {
+	var gen storedGeneration
+	if err := json.Unmarshal(rec.Generation, &gen); err != nil {
+		var summary summaryGeneration
+		if err := json.Unmarshal(rec.Generation, &summary); err != nil {
+			return scannedGenerationRecord{}, false
+		}
+		gen = storedGeneration{summaryGeneration: summary, ConversationID: rec.ConversationID}
+	}
+	return scannedGenerationRecord{record: rec, gen: gen}, true
+}
+
+// scanLatestGenerationRecords walks one per-conversation JSONL file calling
+// visit for the newest copy of every decodable record. The detail view and
+// search need the full stored generation, message trees included.
+func scanLatestGenerationRecords(path string, visit func(generationRecord, storedGeneration)) (int, error) {
+	return scanLatestJSONL(path, decodeGenerationRecord, func(r scannedGenerationRecord) string {
+		return r.generationID()
+	}, func(r scannedGenerationRecord) {
 		visit(r.record, r.gen)
+	})
+}
+
+func (r scannedGenerationRecord) generationID() string {
+	if id := strings.TrimSpace(r.record.GenerationID); id != "" {
+		return id
 	}
-	return nil
+	return strings.TrimSpace(r.gen.ID)
+}
+
+// scanLatestSummaryRecords walks one per-conversation JSONL file decoding
+// only the summary projection, no input or output message trees, and
+// keeping the last record per generation id.
+func scanLatestSummaryRecords(path string, visit func(summaryRecord)) (int, error) {
+	return scanLatestJSONL(path, decodeSummaryRecord, func(r summaryRecord) string {
+		return r.generationID()
+	}, visit)
+}
+
+func decodeSummaryRecord(line []byte) (summaryRecord, bool) {
+	var rec summaryRecord
+	if err := json.Unmarshal(line, &rec); err != nil {
+		return summaryRecord{}, false
+	}
+	return rec, true
 }
 
 // extractTools walks the assistant's output messages and collects the

--- a/plugins/agento11y/internal/local/query_test.go
+++ b/plugins/agento11y/internal/local/query_test.go
@@ -2,6 +2,12 @@ package local
 
 import (
 	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -105,7 +111,15 @@ func TestListConversations_Aggregates(t *testing.T) {
 	// list should still surface it via the received_at fallback.
 	writeGen(t, s, "conv-C", "g5", agento11y.Generation{AgentName: "vistra"}, "2026-05-21T11:10:00Z")
 
-	got, err := s.ListConversations(0)
+	// The order comes from the file modification time, and on Linux the three
+	// writes above land in one filesystem timestamp tick, which leaves them
+	// tied. Pin each file to its last received_at so the expected order is the
+	// one the records describe.
+	setConversationModTime(t, s, "conv-A", mustParse(t, "2026-05-21T10:00:13Z"))
+	setConversationModTime(t, s, "conv-B", mustParse(t, "2026-05-21T11:00:01Z"))
+	setConversationModTime(t, s, "conv-C", mustParse(t, "2026-05-21T11:10:00Z"))
+
+	got, _, err := s.ListConversations(ConversationListOptions{})
 	if err != nil {
 		t.Fatalf("ListConversations: %v", err)
 	}
@@ -185,7 +199,7 @@ func TestConversationQueriesUseLatestGenerationRecord(t *testing.T) {
 		Usage:       agento11y.TokenUsage{InputTokens: 12, OutputTokens: 8, TotalTokens: 20},
 	}, "2026-05-21T10:00:02Z")
 
-	summaries, err := s.ListConversations(0)
+	summaries, _, err := s.ListConversations(ConversationListOptions{})
 	require.NoError(t, err)
 	require.Len(t, summaries, 1)
 	assert.Equal(t, 1, summaries[0].Calls)
@@ -211,19 +225,25 @@ func TestListConversations_LimitAndEmpty(t *testing.T) {
 	}{
 		{name: "missing dir returns empty", seed: 0, limit: 0, wantLen: 0},
 		{name: "limit caps result, newest first", seed: 5, limit: 2, wantLen: 2, wantIDs: []string{"conv-E", "conv-D"}},
+		{name: "unbounded returns every conversation", seed: 5, limit: 0, wantLen: 5, wantIDs: []string{"conv-E", "conv-D", "conv-C", "conv-B", "conv-A"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := newStorage(t)
 			for i := 0; i < tc.seed; i++ {
-				writeGen(t, s, "conv-"+string(rune('A'+i)), "g"+string(rune('0'+i)), agento11y.Generation{
+				id := "conv-" + string(rune('A'+i))
+				writeGen(t, s, id, "g"+string(rune('0'+i)), agento11y.Generation{
 					AgentName:   "pi",
 					Model:       agento11y.ModelRef{Name: "m"},
 					StartedAt:   mustParse(t, "2026-05-21T10:00:00Z").Add(time.Duration(i) * time.Minute),
 					CompletedAt: mustParse(t, "2026-05-21T10:00:01Z").Add(time.Duration(i) * time.Minute),
 				}, "2026-05-21T10:00:01Z")
+				// One tick holds every write on Linux, so the modification
+				// times tie and the newest-first order falls back to the id.
+				// Pin them a minute apart, matching the seeded activity.
+				setConversationModTime(t, s, id, mustParse(t, "2026-05-21T10:00:01Z").Add(time.Duration(i)*time.Minute))
 			}
-			got, err := s.ListConversations(tc.limit)
+			got, _, err := s.ListConversations(ConversationListOptions{Limit: tc.limit})
 			if err != nil {
 				t.Fatalf("err = %v", err)
 			}
@@ -236,6 +256,166 @@ func TestListConversations_LimitAndEmpty(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestListConversations_BoundedPage proves the page is cut before any
+// conversation file is decoded: entries are ordered by modification time,
+// the limit ends the walk, and ?since= drops older files. Files past the
+// page are made unreadable, so a request that would open one fails and a
+// bounded request cannot pass by accident.
+func TestListConversations_BoundedPage(t *testing.T) {
+	modTimes := map[string]string{
+		"conv-a": "2026-08-03T12:00:00Z",
+		"conv-b": "2026-08-03T11:00:00Z",
+		"conv-c": "2026-08-03T10:00:00Z",
+	}
+	oldestFirst := []string{"conv-c", "conv-b", "conv-a"}
+
+	cases := []struct {
+		name string
+		opts ConversationListOptions
+		// blockFrom makes the files older than position blockFrom (in the
+		// returned newest-first order) unreadable. -1 blocks nothing.
+		blockFrom int
+		wantIDs   []string
+		wantErr   bool
+	}{
+		{name: "newest modification time first", blockFrom: -1, wantIDs: []string{"conv-a", "conv-b", "conv-c"}},
+		{name: "limit stops before the older files", opts: ConversationListOptions{Limit: 2}, blockFrom: 2, wantIDs: []string{"conv-a", "conv-b"}},
+		{name: "since excludes older files before decoding", opts: ConversationListOptions{Since: mustParse(t, "2026-08-03T11:30:00Z")}, blockFrom: 1, wantIDs: []string{"conv-a"}},
+		{name: "since bound is inclusive", opts: ConversationListOptions{Since: mustParse(t, "2026-08-03T11:00:00Z")}, blockFrom: 2, wantIDs: []string{"conv-a", "conv-b"}},
+		{name: "unbounded request reads every file", blockFrom: 2, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.blockFrom >= 0 {
+				requireUnreadableFilesSupported(t)
+			}
+			s := newStorage(t)
+			// Write oldest-first so the modification times below are the
+			// only thing the order can come from.
+			for _, id := range oldestFirst {
+				writeGen(t, s, id, "g-"+id, agento11y.Generation{
+					AgentName:   "pi",
+					Model:       agento11y.ModelRef{Name: "m"},
+					StartedAt:   mustParse(t, modTimes[id]),
+					CompletedAt: mustParse(t, modTimes[id]),
+					Usage:       agento11y.TokenUsage{InputTokens: 1, OutputTokens: 1},
+				}, modTimes[id])
+				setConversationModTime(t, s, id, mustParse(t, modTimes[id]))
+			}
+			if tc.blockFrom >= 0 {
+				for _, id := range []string{"conv-a", "conv-b", "conv-c"}[tc.blockFrom:] {
+					blockConversationFile(t, s, id)
+				}
+			}
+
+			got, _, err := s.ListConversations(tc.opts)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			ids := make([]string, 0, len(got))
+			for _, c := range got {
+				ids = append(ids, c.ID)
+			}
+			assert.Equal(t, tc.wantIDs, ids)
+		})
+	}
+}
+
+// TestListConversations_SkipsMessageTrees proves the summary decoder never
+// materialises the stored input and output trees. The second case stores
+// trees that are not message-shaped at all: the summary reads them, and so
+// does the detail view, which falls back to the same projection and shows
+// the turn without messages instead of dropping it.
+func TestListConversations_SkipsMessageTrees(t *testing.T) {
+	big := strings.Repeat("x", 1<<20)
+	cases := []struct {
+		name         string
+		inputOutput  string
+		wantMessages bool
+	}{
+		{
+			name:         "one megabyte message trees",
+			inputOutput:  `"input":[{"role":"user","parts":[{"text":"` + big + `"}]}],"output":[{"role":"assistant","parts":[{"text":"` + big + `"}]}]`,
+			wantMessages: true,
+		},
+		{
+			name:        "trees that are not message shaped",
+			inputOutput: `"input":42,"output":"not-a-message"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newStorage(t)
+			gen := `{"id":"g1","conversation_id":"conv-big","conversation_title":"big session",` +
+				`"agent_name":"pi","model":{"provider":"anthropic","name":"claude-sonnet-4"},` +
+				`"usage":{"input_tokens":10,"output_tokens":5},` +
+				`"started_at":"2026-08-03T10:00:00Z","completed_at":"2026-08-03T10:00:02Z",` +
+				`"tags":{"cwd":"/repo"},` + tc.inputOutput + `}`
+			require.NoError(t, s.AppendGeneration(generationRecord{
+				ReceivedAt:     "2026-08-03T10:00:02Z",
+				GenerationID:   "g1",
+				ConversationID: "conv-big",
+				Generation:     json.RawMessage(gen),
+			}))
+
+			got, _, err := s.ListConversations(ConversationListOptions{})
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+			assert.Equal(t, "conv-big", got[0].ID)
+			assert.Equal(t, "big session", got[0].Title)
+			assert.Equal(t, 1, got[0].Calls)
+			assert.Equal(t, int64(15), got[0].TotalTokens)
+			assert.Equal(t, []string{"claude-sonnet-4"}, got[0].Models)
+			assert.Equal(t, "/repo", got[0].Workspace)
+
+			// The detail view accepts every line the list counted, so a row
+			// in the list always opens.
+			detail, err := s.ConversationDetail("conv-big")
+			require.NoError(t, err)
+			require.NotNil(t, detail)
+			require.Len(t, detail.Generations, 1)
+			assert.Equal(t, int64(15), detail.Generations[0].TotalTokens)
+			if tc.wantMessages {
+				assert.NotEmpty(t, detail.Generations[0].Messages)
+			} else {
+				assert.Empty(t, detail.Generations[0].Messages, "an unreadable tree contributes no messages")
+			}
+		})
+	}
+}
+
+// setConversationModTime pins one conversation file's modification time.
+// The list and metrics endpoints order and filter on that timestamp.
+func setConversationModTime(t *testing.T, s *Storage, convID string, when time.Time) {
+	t.Helper()
+	path := filepath.Join(s.Dir(), ConversationsDir, convID+".jsonl")
+	require.NoError(t, os.Chtimes(path, when, when))
+}
+
+// blockConversationFile makes one conversation file unreadable, so any
+// request that opens it fails. Tests use it to prove a bounded request
+// never touches the files past its page.
+func blockConversationFile(t *testing.T, s *Storage, convID string) {
+	t.Helper()
+	path := filepath.Join(s.Dir(), ConversationsDir, convID+".jsonl")
+	require.NoError(t, os.Chmod(path, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+}
+
+// requireUnreadableFilesSupported skips tests that rely on a file being
+// unreadable, which neither Windows ACLs nor a root user honour.
+func requireUnreadableFilesSupported(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("posix-only permission check")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores file permissions")
 	}
 }
 
@@ -254,7 +434,7 @@ func TestListAndDetailUseCacheAwareTotalFallback(t *testing.T) {
 		},
 	}, "2026-05-21T10:00:02Z")
 
-	summaries, err := s.ListConversations(0)
+	summaries, _, err := s.ListConversations(ConversationListOptions{})
 	require.NoError(t, err)
 	require.Len(t, summaries, 1)
 	assert.Equal(t, int64(365365), summaries[0].TotalTokens)
@@ -719,7 +899,7 @@ func TestDisjointTokenUsage(t *testing.T) {
 // TestTokenUsagePoints seeds generations across conversations and checks
 // the flattened, time-sorted points: provider-aware buckets, model and
 // provider tagging, the received_at timestamp fallback, and that
-// zero-token generations are dropped.
+// zero-token generations and timestamps bucketing cannot place are dropped.
 func TestTokenUsagePoints(t *testing.T) {
 	s := newStorage(t)
 
@@ -750,9 +930,20 @@ func TestTokenUsagePoints(t *testing.T) {
 		StartedAt: mustParse(t, "2026-05-21T08:00:00Z"),
 	}, "2026-05-21T08:00:00Z")
 
-	points, err := s.TokenUsagePoints()
+	// Past the year UnixNano covers: bucketing would wrap this into 1715 and
+	// add phantom tokens to a real bar, so the point is dropped.
+	writeGen(t, s, "conv-E", "g5", agento11y.Generation{
+		Model:       agento11y.ModelRef{Provider: "anthropic", Name: "claude-opus-4-7"},
+		StartedAt:   mustParse(t, "2300-01-01T00:00:00Z"),
+		CompletedAt: mustParse(t, "2300-01-01T00:00:01Z"),
+		Usage:       agento11y.TokenUsage{InputTokens: 7, OutputTokens: 3},
+	}, "2300-01-01T00:00:01Z")
+
+	// One-minute buckets keep every seeded generation in its own bucket.
+	points, interval, err := s.TokenUsagePoints(TokenUsageOptions{Interval: time.Minute})
 	require.NoError(t, err)
-	require.Len(t, points, 3, "zero-token generation should be dropped")
+	assert.Equal(t, time.Minute, interval)
+	require.Len(t, points, 3, "zero-token and unplaceable generations should be dropped")
 
 	// Sorted oldest-first: g2 (09:00) → g1 (10:00) → g3 (12:00 received_at).
 	assert.Equal(t, "gpt-5-omni", points[0].Model)
@@ -767,9 +958,9 @@ func TestTokenUsagePoints(t *testing.T) {
 		TokenBuckets: TokenBuckets{FreshInput: 70, CacheRead: 30, Output: 40, Reasoning: 10},
 	}, points[0])
 
-	// g1 Anthropic: cache stays additive.
+	// g1 Anthropic: cache stays additive; the point carries its bucket start.
 	assert.Equal(t, TokenUsagePoint{
-		Timestamp:    mustParse(t, "2026-05-21T10:00:10Z"),
+		Timestamp:    mustParse(t, "2026-05-21T10:00:00Z"),
 		Model:        "claude-sonnet-4",
 		Provider:     "anthropic",
 		TokenBuckets: TokenBuckets{FreshInput: 100, CacheRead: 30, CacheWrite: 20, Output: 50},
@@ -779,13 +970,153 @@ func TestTokenUsagePoints(t *testing.T) {
 	assert.Equal(t, mustParse(t, "2026-05-21T12:00:00Z"), points[2].Timestamp)
 }
 
+// TestTokenUsagePoints_Buckets covers the aggregation the chart reads: one
+// point per bucket and model, ordered by timestamp then model, plus the
+// range bound and the derived interval.
+func TestTokenUsagePoints_Buckets(t *testing.T) {
+	type seed struct {
+		conv  string
+		gen   string
+		model string
+		when  string
+		in    int64
+		out   int64
+	}
+	hourSeeds := []seed{
+		{conv: "conv-1", gen: "g1", model: "model-a", when: "2026-08-03T10:05:00Z", in: 10},
+		{conv: "conv-1", gen: "g2", model: "model-a", when: "2026-08-03T10:55:00Z", in: 20},
+		{conv: "conv-2", gen: "g3", model: "model-b", when: "2026-08-03T10:30:00Z", in: 7},
+		{conv: "conv-1", gen: "g4", model: "model-a", when: "2026-08-03T11:05:00Z", in: 5},
+	}
+
+	cases := []struct {
+		name         string
+		seeds        []seed
+		opts         TokenUsageOptions
+		wantInterval time.Duration
+		wantPoints   []TokenUsagePoint
+	}{
+		{
+			name:         "hourly buckets group by model",
+			seeds:        hourSeeds,
+			opts:         TokenUsageOptions{Interval: time.Hour},
+			wantInterval: time.Hour,
+			wantPoints: []TokenUsagePoint{
+				{Timestamp: mustParse(t, "2026-08-03T10:00:00Z"), Model: "model-a", TokenBuckets: TokenBuckets{FreshInput: 30}},
+				{Timestamp: mustParse(t, "2026-08-03T10:00:00Z"), Model: "model-b", TokenBuckets: TokenBuckets{FreshInput: 7}},
+				{Timestamp: mustParse(t, "2026-08-03T11:00:00Z"), Model: "model-a", TokenBuckets: TokenBuckets{FreshInput: 5}},
+			},
+		},
+		{
+			name:         "since drops earlier buckets",
+			seeds:        hourSeeds,
+			opts:         TokenUsageOptions{Interval: time.Hour, Since: mustParse(t, "2026-08-03T11:00:00Z")},
+			wantInterval: time.Hour,
+			wantPoints: []TokenUsagePoint{
+				{Timestamp: mustParse(t, "2026-08-03T11:00:00Z"), Model: "model-a", TokenBuckets: TokenBuckets{FreshInput: 5}},
+			},
+		},
+		{
+			name: "derived interval keeps the bucket count bounded",
+			seeds: []seed{
+				{conv: "conv-1", gen: "g1", model: "model-a", when: "2026-07-04T00:00:00Z", in: 1},
+				{conv: "conv-2", gen: "g2", model: "model-a", when: "2026-08-03T00:00:00Z", in: 2},
+			},
+			// 30 days at one-hour buckets is 720, above the 500 cap, so the
+			// next ladder step is used.
+			wantInterval: 2 * time.Hour,
+			wantPoints: []TokenUsagePoint{
+				{Timestamp: mustParse(t, "2026-07-04T00:00:00Z"), Model: "model-a", TokenBuckets: TokenBuckets{FreshInput: 1}},
+				{Timestamp: mustParse(t, "2026-08-03T00:00:00Z"), Model: "model-a", TokenBuckets: TokenBuckets{FreshInput: 2}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newStorage(t)
+			for _, sd := range tc.seeds {
+				writeGen(t, s, sd.conv, sd.gen, agento11y.Generation{
+					Model:     agento11y.ModelRef{Name: sd.model},
+					StartedAt: mustParse(t, sd.when),
+					Usage:     agento11y.TokenUsage{InputTokens: sd.in, OutputTokens: sd.out},
+				}, sd.when)
+			}
+			points, interval, err := s.TokenUsagePoints(tc.opts)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantInterval, interval)
+			assert.Equal(t, tc.wantPoints, points)
+		})
+	}
+}
+
+// TestTokenUsagePoints_ScaleFollowsBucketsNotGenerations seeds a store the
+// size an import produces and asserts the response follows the bucket and
+// model count: six hourly buckets across three models stay at 18 points
+// and well under 100 KB, whatever the generation count is.
+func TestTokenUsagePoints_ScaleFollowsBucketsNotGenerations(t *testing.T) {
+	s := newStorage(t)
+	const (
+		generations = 60_000
+		perConv     = 1_000
+	)
+	models := []string{"model-a", "model-b", "model-c"}
+	start := mustParse(t, "2026-08-03T06:00:00Z")
+
+	for conv := range generations / perConv {
+		convID := "conv-" + strconv.Itoa(conv)
+		recs := make([]generationRecord, 0, perConv)
+		for i := range perConv {
+			n := conv*perConv + i
+			genID := "g-" + strconv.Itoa(n)
+			// Spread the generations across a six-hour window and three
+			// models; each carries one input token.
+			raw, err := json.Marshal(agento11y.Generation{
+				ID:             genID,
+				ConversationID: convID,
+				Model:          agento11y.ModelRef{Name: models[n%len(models)]},
+				StartedAt:      start.Add(time.Duration(n%(6*60)) * time.Minute),
+				Usage:          agento11y.TokenUsage{InputTokens: 1},
+			})
+			require.NoError(t, err)
+			recs = append(recs, generationRecord{
+				ReceivedAt:     start.Format(time.RFC3339Nano),
+				GenerationID:   genID,
+				ConversationID: convID,
+				Generation:     raw,
+			})
+		}
+		written, err := s.AppendGenerations(convID, recs)
+		require.NoError(t, err)
+		require.Equal(t, perConv, written)
+	}
+
+	points, interval, err := s.TokenUsagePoints(TokenUsageOptions{
+		Since:    start,
+		Interval: time.Hour,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, time.Hour, interval)
+	assert.LessOrEqual(t, len(points), 6*len(models), "points follow buckets times models")
+
+	var total int64
+	for _, p := range points {
+		total += p.FreshInput
+	}
+	assert.Equal(t, int64(generations), total, "bucketing must preserve every token")
+
+	body, err := json.Marshal(map[string]any{"points": points, "interval_seconds": 3600})
+	require.NoError(t, err)
+	assert.Less(t, len(body), 100*1024, "token chart payload must stay under 100 KB")
+}
+
 // TestTokenUsagePoints_EmptyStore checks that TokenUsagePoints returns
 // no points and no error before any conversations exist.
 func TestTokenUsagePoints_EmptyStore(t *testing.T) {
 	s := newStorage(t)
-	points, err := s.TokenUsagePoints()
+	points, interval, err := s.TokenUsagePoints(TokenUsageOptions{})
 	require.NoError(t, err)
 	assert.Empty(t, points)
+	assert.Equal(t, 10*time.Second, interval, "an empty range derives the finest bucket")
 }
 
 // TestListConversations_WorkspaceFacets checks that the list summary
@@ -823,7 +1154,7 @@ func TestListConversations_WorkspaceFacets(t *testing.T) {
 		Tags:        map[string]string{"cwd": "/other/repo"},
 	}, "2026-05-21T11:00:01Z")
 
-	got, err := s.ListConversations(0)
+	got, _, err := s.ListConversations(ConversationListOptions{})
 	require.NoError(t, err)
 	require.Len(t, got, 2)
 
@@ -916,4 +1247,49 @@ func TestConversationDetail_MediaPartsPreserved(t *testing.T) {
 	require.NotNil(t, parts[1].Media)
 	assert.Equal(t, "https://example.com/a.png", parts[1].Media.URL)
 	assert.Equal(t, "image/png", parts[1].Media.MIMEType)
+}
+
+// TestReadsReportSkippedLines covers a line no projection can decode: the
+// truncated tail an interrupted append leaves behind. Every read drops it,
+// keeps the records around it, and says so once per request.
+func TestReadsReportSkippedLines(t *testing.T) {
+	s := newStorage(t)
+	var logs strings.Builder
+	s.SetLogger(log.New(&logs, "", 0))
+
+	writeGen(t, s, "conv-A", "g1", agento11y.Generation{
+		Model:       agento11y.ModelRef{Provider: "anthropic", Name: "claude-sonnet-4"},
+		StartedAt:   mustParse(t, "2026-08-03T10:00:00Z"),
+		CompletedAt: mustParse(t, "2026-08-03T10:00:01Z"),
+		Usage:       agento11y.TokenUsage{InputTokens: 10, OutputTokens: 5},
+	}, "2026-08-03T10:00:01Z")
+	path := filepath.Join(s.Dir(), ConversationsDir, "conv-A.jsonl")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	require.NoError(t, err)
+	_, err = f.WriteString(`{"received_at":"2026-08-03T10:00:02Z","generation` + "\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	convs, total, err := s.ListConversations(ConversationListOptions{})
+	require.NoError(t, err)
+	require.Len(t, convs, 1)
+	assert.Equal(t, 1, total)
+	assert.Equal(t, 1, convs[0].Calls)
+
+	detail, err := s.ConversationDetail("conv-A")
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+	assert.Len(t, detail.Generations, 1)
+
+	points, _, err := s.TokenUsagePoints(TokenUsageOptions{Interval: time.Minute})
+	require.NoError(t, err)
+	assert.Len(t, points, 1)
+
+	for _, want := range []string{
+		"local: list conversations: skipped 1 unparseable lines",
+		"local: conversation conv-A: skipped 1 unparseable lines",
+		"local: token metrics: skipped 1 unparseable lines",
+	} {
+		assert.Contains(t, logs.String(), want)
+	}
 }

--- a/plugins/agento11y/internal/local/search.go
+++ b/plugins/agento11y/internal/local/search.go
@@ -65,11 +65,14 @@ func (s *Storage) SearchConversations(query string, limit int) ([]SearchHit, err
 		return nil, err
 	}
 	out := make([]SearchHit, 0, len(entries))
+	var skipped int
+	defer func() { s.logSkipped("search", skipped) }()
 	for _, e := range entries {
 		if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
 			continue
 		}
-		hit, ok, err := searchConversationFile(filepath.Join(dir, e.Name()), terms)
+		hit, ok, n, err := searchConversationFile(filepath.Join(dir, e.Name()), terms)
+		skipped += n
 		if err != nil {
 			return nil, err
 		}
@@ -118,10 +121,11 @@ func searchTerms(query string) []string {
 // contains a term is captured for the snippet; the first generation
 // containing any term is captured for the matched generation id.
 //
-// Returns (_, false, nil) when the file has no decodable records OR
-// when at least one term does not appear anywhere in the conversation
-// (so the result satisfies the AND semantics across terms).
-func searchConversationFile(path string, terms []string) (SearchHit, bool, error) {
+// ok is false when the file has no decodable records OR when at least one
+// term does not appear anywhere in the conversation (so the result
+// satisfies the AND semantics across terms). The third result counts the
+// lines no projection could decode.
+func searchConversationFile(path string, terms []string) (SearchHit, bool, int, error) {
 	hit := SearchHit{}
 	agents := map[string]struct{}{}
 	models := map[string]struct{}{}
@@ -131,7 +135,7 @@ func searchConversationFile(path string, terms []string) (SearchHit, bool, error
 	var seen, hasError bool
 	var lastActivity time.Time
 
-	err := scanLatestGenerationRecords(path, func(r generationRecord, gen storedGeneration) {
+	skipped, err := scanLatestGenerationRecords(path, func(r generationRecord, gen storedGeneration) {
 		seen = true
 		if hit.ID == "" {
 			hit.ID = r.ConversationID
@@ -208,15 +212,15 @@ func searchConversationFile(path string, terms []string) (SearchHit, bool, error
 		}
 	})
 	if err != nil {
-		return SearchHit{}, false, err
+		return SearchHit{}, false, skipped, err
 	}
 	if !seen {
-		return SearchHit{}, false, nil
+		return SearchHit{}, false, skipped, nil
 	}
 	// AND across terms: every term must have contributed at least once.
 	for _, term := range terms {
 		if termHits[term] == 0 {
-			return SearchHit{}, false, nil
+			return SearchHit{}, false, skipped, nil
 		}
 	}
 	hit.Agents = sortedKeys(agents)
@@ -228,7 +232,7 @@ func searchConversationFile(path string, terms []string) (SearchHit, bool, error
 	}
 	hit.Snippet = snippet
 	hit.GenerationID = snippetGenID
-	return hit, true, nil
+	return hit, true, skipped, nil
 }
 
 // visitMessageParts walks one message's parts and feeds every searchable

--- a/plugins/agento11y/internal/local/server.go
+++ b/plugins/agento11y/internal/local/server.go
@@ -50,6 +50,9 @@ func NewServer(storage *Storage, logger *log.Logger, configPath string) *Server 
 	if logger == nil {
 		logger = log.New(io.Discard, "", 0)
 	}
+	if storage != nil {
+		storage.SetLogger(logger)
+	}
 	s := &Server{
 		storage:    storage,
 		logger:     logger,
@@ -172,6 +175,14 @@ type generationRecord struct {
 	Generation     json.RawMessage `json:"generation"`
 }
 
+// pendingGeneration is one decoded generation waiting to be appended,
+// carrying its position in the request so the per-record result keeps its
+// request position.
+type pendingGeneration struct {
+	index  int
+	record generationRecord
+}
+
 func (s *Server) handleGenerations(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxGenerationBodyBytes+1))
 	if err != nil {
@@ -189,43 +200,86 @@ func (s *Server) handleGenerations(w http.ResponseWriter, r *http.Request) {
 	}
 
 	receivedAt := s.now().Format(time.RFC3339Nano)
-	resp := generationsResponse{Results: make([]generationResult, 0, len(req.Generations))}
-	accepted := make([]json.RawMessage, 0, len(req.Generations))
-	for _, raw := range req.Generations {
+	resp := generationsResponse{Results: make([]generationResult, len(req.Generations))}
+
+	// Group the request by conversation so each conversation file is opened
+	// once, however many generations the batch carries for it. Results stay
+	// indexed by request position: grouping does not reorder them.
+	var order []string
+	groups := map[string][]pendingGeneration{}
+	stored := make([]json.RawMessage, len(req.Generations))
+	for i, raw := range req.Generations {
 		var gen storedGeneration
 		if err := json.Unmarshal(raw, &gen); err != nil {
-			resp.Results = append(resp.Results, generationResult{Accepted: false, Error: "decode generation: " + err.Error()})
+			resp.Results[i] = generationResult{Accepted: false, Error: "decode generation: " + err.Error()}
 			continue
 		}
-		stored := append(json.RawMessage(nil), raw...)
-		rec := generationRecord{
-			ReceivedAt:     receivedAt,
-			GenerationID:   gen.ID,
-			ConversationID: gen.ConversationID,
-			Generation:     stored,
+		// json.Unmarshal allocates a fresh slice per RawMessage element, so
+		// raw is private to this request and needs no copy.
+		stored[i] = raw
+		if _, ok := groups[gen.ConversationID]; !ok {
+			order = append(order, gen.ConversationID)
 		}
-		if err := s.storage.AppendGeneration(rec); err != nil {
+		groups[gen.ConversationID] = append(groups[gen.ConversationID], pendingGeneration{
+			index: i,
+			record: generationRecord{
+				ReceivedAt:     receivedAt,
+				GenerationID:   gen.ID,
+				ConversationID: gen.ConversationID,
+				Generation:     stored[i],
+			},
+		})
+	}
+
+	// One change event per conversation the request wrote to. The viewer
+	// coalesces a burst into a single refresh anyway, so a per-generation
+	// event would multiply full-store refetches during a large import.
+	var events []changeEvent
+	for _, convID := range order {
+		pending := groups[convID]
+		recs := make([]generationRecord, len(pending))
+		for i, p := range pending {
+			recs[i] = p.record
+		}
+		written, err := s.storage.AppendGenerations(convID, recs)
+		if err != nil {
 			s.logger.Printf("local: append generations: %v", err)
-			resp.Results = append(resp.Results, generationResult{
-				GenerationID: gen.ID,
-				Accepted:     false,
-				Error:        err.Error(),
-			})
-			continue
 		}
-		accepted = append(accepted, stored)
-		resp.Results = append(resp.Results, generationResult{
-			GenerationID: gen.ID,
-			Accepted:     true,
-		})
-		// Notify connected viewers so the list (and any open matching
-		// conversation) refreshes without waiting for the backstop poll.
-		// Broadcast is non-blocking; a stalled subscriber cannot stall
-		// ingest.
-		s.hub.broadcast(changeEvent{
-			ConversationID: gen.ConversationID,
-			GenerationID:   gen.ID,
-		})
+		// A short write always carries an error today. Copy the message into
+		// a local first, so a future path that returns a short count with a
+		// nil error cannot dereference err here.
+		reason := "append rejected"
+		if err != nil {
+			reason = err.Error()
+		}
+		for i, p := range pending {
+			result := generationResult{GenerationID: p.record.GenerationID, Accepted: i < written}
+			if !result.Accepted {
+				result.Error = reason
+				stored[p.index] = nil
+			}
+			resp.Results[p.index] = result
+		}
+		if written > 0 {
+			events = append(events, changeEvent{
+				ConversationID: convID,
+				GenerationID:   recs[written-1].GenerationID,
+			})
+		}
+	}
+
+	// Notify connected viewers so the list (and any open matching
+	// conversation) refreshes without waiting for the backstop poll.
+	// Broadcast is non-blocking; a stalled subscriber cannot stall ingest.
+	for _, ev := range events {
+		s.hub.broadcast(ev)
+	}
+
+	accepted := make([]json.RawMessage, 0, len(req.Generations))
+	for _, raw := range stored {
+		if raw != nil {
+			accepted = append(accepted, raw)
+		}
 	}
 
 	// Best-effort Cloud forwarding runs after the local store so a Cloud
@@ -446,16 +500,34 @@ func (s *Server) decodeConfigRequest(w http.ResponseWriter, r *http.Request) (Se
 	return req.Settings, true
 }
 
+// conversationListLimit caps how many conversations the list endpoint
+// summarises when the client does not pass a limit. The cost of a request
+// follows this number, not the size of the store, and the viewer's list is
+// not virtualised, so an unbounded default would hurt both ends. Same
+// idiom as searchResultLimit: the default lives in the handler, and
+// Storage.ListConversations keeps ≤ 0 as unbounded for its own callers.
+const conversationListLimit = 200
+
 // handleListConversations returns the aggregated conversation list as
-// JSON. The response is newest-first.
+// JSON. The response is newest-first. ?limit= caps the page and ?since=
+// (RFC 3339) drops conversations whose file is older, both applied before
+// any conversation file is decoded. For an append-only file the
+// modification time is the last activity; see ConversationListOptions.
+//
+// total_conversations counts the conversation files in the store, before
+// either bound. The viewer needs it to tell an empty store from an empty
+// range: with a range-scoped page it cannot otherwise distinguish first
+// launch from a quiet week, and the two want different notices.
 func (s *Server) handleListConversations(w http.ResponseWriter, r *http.Request) {
-	limit := 0
-	if raw := r.URL.Query().Get("limit"); raw != "" {
-		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
-			limit = n
-		}
+	limit, ok := limitParam(w, r, conversationListLimit)
+	if !ok {
+		return
 	}
-	convs, err := s.storage.ListConversations(limit)
+	since, ok := sinceParam(w, r)
+	if !ok {
+		return
+	}
+	convs, total, err := s.storage.ListConversations(ConversationListOptions{Limit: limit, Since: since})
 	if err != nil {
 		s.logger.Printf("local: list conversations: %v", err)
 		http.Error(w, "list conversations: "+err.Error(), http.StatusInternalServerError)
@@ -467,7 +539,28 @@ func (s *Server) handleListConversations(w http.ResponseWriter, r *http.Request)
 		// guarding.
 		convs = []ConversationSummary{}
 	}
-	s.writeJSON(w, http.StatusOK, map[string]any{"conversations": convs})
+	s.writeJSON(w, http.StatusOK, map[string]any{
+		"conversations":       convs,
+		"total_conversations": total,
+	})
+}
+
+// limitParam reads a ?limit= page size, falling back to def when the
+// parameter is absent. A non-positive or unparseable value is a client
+// error. ?since= and ?interval= reject a bad value the same way: a client
+// that means "everything" passes a large number, not a value the server has
+// to guess at.
+func limitParam(w http.ResponseWriter, r *http.Request, def int) (int, bool) {
+	raw := r.URL.Query().Get("limit")
+	if raw == "" {
+		return def, true
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		http.Error(w, "invalid limit: want a positive number", http.StatusBadRequest)
+		return 0, false
+	}
+	return n, true
 }
 
 // searchResultLimit caps the number of hits the search endpoint returns
@@ -527,11 +620,28 @@ func (s *Server) handleSearchCapabilities(w http.ResponseWriter, _ *http.Request
 	})
 }
 
-// handleTokenMetrics returns one token-usage point per recorded
-// generation as JSON. The viewer buckets these by time to draw the
-// token-usage chart; an empty store returns an empty array, never null.
-func (s *Server) handleTokenMetrics(w http.ResponseWriter, _ *http.Request) {
-	points, err := s.storage.TokenUsagePoints()
+// handleTokenMetrics returns token usage aggregated per bucket and model
+// as JSON, for the viewer's token chart. ?since= (RFC 3339) bounds the
+// range and ?interval= sets the bucket width in seconds; when the client
+// omits the interval the server derives one from the span it found and
+// reports it as interval_seconds, which the viewer widens its bars to so a
+// server bucket never straddles two of them. An empty store returns an
+// empty array, never null.
+func (s *Server) handleTokenMetrics(w http.ResponseWriter, r *http.Request) {
+	since, ok := sinceParam(w, r)
+	if !ok {
+		return
+	}
+	var interval time.Duration
+	if raw := r.URL.Query().Get("interval"); raw != "" {
+		seconds, err := strconv.Atoi(raw)
+		if err != nil || seconds <= 0 {
+			http.Error(w, "invalid interval: want a positive number of seconds", http.StatusBadRequest)
+			return
+		}
+		interval = time.Duration(seconds) * time.Second
+	}
+	points, used, err := s.storage.TokenUsagePoints(TokenUsageOptions{Since: since, Interval: interval})
 	if err != nil {
 		s.logger.Printf("local: token metrics: %v", err)
 		http.Error(w, "token metrics: "+err.Error(), http.StatusInternalServerError)
@@ -540,7 +650,27 @@ func (s *Server) handleTokenMetrics(w http.ResponseWriter, _ *http.Request) {
 	if points == nil {
 		points = []TokenUsagePoint{}
 	}
-	s.writeJSON(w, http.StatusOK, map[string]any{"points": points})
+	s.writeJSON(w, http.StatusOK, map[string]any{
+		"points":           points,
+		"interval_seconds": int64(used.Seconds()),
+	})
+}
+
+// sinceParam reads the shared ?since= lower bound. RFC 3339 is the only
+// accepted spelling, the one toISOString() produces, and an unparseable
+// value is a client error rather than a silently ignored filter. A missing
+// parameter returns the zero time (no bound).
+func sinceParam(w http.ResponseWriter, r *http.Request) (time.Time, bool) {
+	raw := r.URL.Query().Get("since")
+	if raw == "" {
+		return time.Time{}, true
+	}
+	since, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		http.Error(w, "invalid since: want an RFC 3339 timestamp", http.StatusBadRequest)
+		return time.Time{}, false
+	}
+	return since, true
 }
 
 // handleConversationDetail returns the per-conversation generation

--- a/plugins/agento11y/internal/local/server_test.go
+++ b/plugins/agento11y/internal/local/server_test.go
@@ -91,6 +91,94 @@ func TestServer_GenerationsExport_AppendsByConversation(t *testing.T) {
 	assert.Equal(t, "gen-b", second.GenerationID)
 }
 
+// TestServer_GenerationsExport_BatchesPerConversation covers the batched
+// ingest path: one request opens each conversation file once, per-record
+// results stay in request order, a mid-batch write failure keeps the
+// records written before it accepted, and a conversations directory removed
+// under the running server (a cleanup script, a synced state directory) is
+// recreated.
+func TestServer_GenerationsExport_BatchesPerConversation(t *testing.T) {
+	cases := []struct {
+		name           string
+		convIDs        []string // one generation per entry, in request order
+		failWriteAfter int
+		removeDir      bool
+		wantAccepted   []bool
+		wantOpens      int
+		wantLines      map[string]int
+	}{
+		{
+			name:         "five generations one conversation",
+			convIDs:      []string{"conv-A", "conv-A", "conv-A", "conv-A", "conv-A"},
+			wantAccepted: []bool{true, true, true, true, true},
+			wantOpens:    1,
+			wantLines:    map[string]int{"conv-A": 5},
+		},
+		{
+			name:         "interleaved conversations open once each",
+			convIDs:      []string{"conv-A", "conv-B", "conv-A", "conv-B", "conv-A"},
+			wantAccepted: []bool{true, true, true, true, true},
+			wantOpens:    2,
+			wantLines:    map[string]int{"conv-A": 3, "conv-B": 2},
+		},
+		{
+			name:           "third append fails",
+			convIDs:        []string{"conv-A", "conv-A", "conv-A", "conv-A", "conv-A"},
+			failWriteAfter: 2,
+			wantAccepted:   []bool{true, true, false, false, false},
+			wantOpens:      1,
+			wantLines:      map[string]int{"conv-A": 2},
+		},
+		{
+			name:         "missing conversations dir is recreated",
+			convIDs:      []string{"conv-A", "conv-A"},
+			removeDir:    true,
+			wantAccepted: []bool{true, true},
+			wantOpens:    1,
+			wantLines:    map[string]int{"conv-A": 2},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, storage, dir := newTestServerStorage(t)
+			opener := &countingOpener{failWriteAfter: tc.failWriteAfter}
+			storage.openAppend = opener.open
+			if tc.removeDir {
+				require.NoError(t, os.RemoveAll(filepath.Join(dir, ConversationsDir)))
+			}
+
+			gens := make([]string, 0, len(tc.convIDs))
+			for i, convID := range tc.convIDs {
+				gens = append(gens, fmt.Sprintf(`{"id":"gen-%d","conversation_id":%q}`, i, convID))
+			}
+			resp := post(t, srv, "/api/v1/generations:export", "application/json",
+				`{"generations":[`+strings.Join(gens, ",")+`]}`)
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var out generationsResponse
+			decodeJSON(t, resp.Body, &out)
+			require.Len(t, out.Results, len(tc.convIDs))
+			for i, want := range tc.wantAccepted {
+				assert.Equal(t, fmt.Sprintf("gen-%d", i), out.Results[i].GenerationID, "result %d out of request order", i)
+				assert.Equal(t, want, out.Results[i].Accepted, "result %d accepted", i)
+				if want {
+					assert.Empty(t, out.Results[i].Error, "result %d error", i)
+				} else {
+					assert.NotEmpty(t, out.Results[i].Error, "result %d error", i)
+				}
+			}
+
+			for convID, wantLines := range tc.wantLines {
+				assert.Len(t, readLines(t, filepath.Join(dir, ConversationsDir, convID+".jsonl")), wantLines, convID)
+			}
+			opens, closes := opener.counts()
+			assert.Equal(t, tc.wantOpens, opens, "file opens")
+			assert.Equal(t, opens, closes, "every open must be closed")
+		})
+	}
+}
+
 func TestServer_OTLPDrainsAndReturns200(t *testing.T) {
 	s, dir := newTestServer(t)
 	for _, tc := range []struct {
@@ -214,13 +302,18 @@ func TestServer_APIConversations(t *testing.T) {
 		CompletedAt: mustParse(t, "2026-05-21T11:00:01Z"),
 		Usage:       agento11y.TokenUsage{InputTokens: 10, OutputTokens: 5},
 	}, "2026-05-21T11:00:01Z")
+	// The list orders and filters on the file modification time, so pin it
+	// to each conversation's last activity the way an append does.
+	setConversationModTime(t, storage, "conv-A", mustParse(t, "2026-05-21T10:00:03Z"))
+	setConversationModTime(t, storage, "conv-B", mustParse(t, "2026-05-21T11:00:01Z"))
 
 	cases := []struct {
-		name        string
-		method      string
-		path        string
-		want        int
-		wantBodyHas []string // all substrings must appear
+		name          string
+		method        string
+		path          string
+		want          int
+		wantBodyHas   []string // all substrings must appear
+		wantBodyLacks []string // none of these may appear
 	}{
 		{
 			name:   "list returns both conversations newest first",
@@ -233,7 +326,42 @@ func TestServer_APIConversations(t *testing.T) {
 			method: http.MethodGet, path: "/api/v1/conversations?limit=1",
 			want: http.StatusOK,
 			// newest-first: only conv-B survives the cap.
-			wantBodyHas: []string{`"id":"conv-B"`},
+			wantBodyHas:   []string{`"id":"conv-B"`},
+			wantBodyLacks: []string{`"id":"conv-A"`},
+		},
+		{
+			name:   "list honours since query param",
+			method: http.MethodGet, path: "/api/v1/conversations?since=2026-05-21T10:30:00Z",
+			want:          http.StatusOK,
+			wantBodyHas:   []string{`"id":"conv-B"`},
+			wantBodyLacks: []string{`"id":"conv-A"`},
+		},
+		{
+			name:   "list rejects a non-RFC3339 since",
+			method: http.MethodGet, path: "/api/v1/conversations?since=yesterday",
+			want: http.StatusBadRequest,
+		},
+		{
+			// The viewer tells an empty store from an empty range by this
+			// count, so a range that holds nothing must still report the
+			// files the store has.
+			name:   "a range holding nothing still counts the store",
+			method: http.MethodGet, path: "/api/v1/conversations?since=2027-01-01T00:00:00Z",
+			want:          http.StatusOK,
+			wantBodyHas:   []string{`"conversations":[]`, `"total_conversations":2`},
+			wantBodyLacks: []string{`"id":"conv-`},
+		},
+		{
+			name:   "list rejects a non-numeric limit",
+			method: http.MethodGet, path: "/api/v1/conversations?limit=abc",
+			want: http.StatusBadRequest,
+		},
+		{
+			// A client that means "everything" passes a large number; zero
+			// and negative values are rejected rather than read as one.
+			name:   "list rejects a non-positive limit",
+			method: http.MethodGet, path: "/api/v1/conversations?limit=0",
+			want: http.StatusBadRequest,
 		},
 		{
 			name:   "detail returns one conversation",
@@ -269,6 +397,11 @@ func TestServer_APIConversations(t *testing.T) {
 			for _, want := range tc.wantBodyHas {
 				if !strings.Contains(rr.Body.String(), want) {
 					t.Errorf("body missing %q\n--- body ---\n%s", want, rr.Body.String())
+				}
+			}
+			for _, unwanted := range tc.wantBodyLacks {
+				if strings.Contains(rr.Body.String(), unwanted) {
+					t.Errorf("body contains %q\n--- body ---\n%s", unwanted, rr.Body.String())
 				}
 			}
 		})
@@ -401,17 +534,26 @@ func TestServer_GenerationsExport_ProtoJSON(t *testing.T) {
 
 // TestServer_APIConversations_EmptyStorage covers the path the user
 // will hit most often — opening the UI with no generations recorded
-// yet. The endpoint must return an array, never null.
+// yet. The endpoint must return an array, never null, and report the
+// empty store so the viewer shows its first-launch notice.
 func TestServer_APIConversations_EmptyStorage(t *testing.T) {
 	srv, _ := newTestServer(t)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/conversations", nil)
 	rr := httptest.NewRecorder()
 	srv.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Equal(t, `{"conversations":[]}`, strings.TrimSpace(rr.Body.String()))
+	assert.Equal(t, `{"conversations":[],"total_conversations":0}`, strings.TrimSpace(rr.Body.String()))
 }
 
 func newTestServer(t *testing.T) (*Server, string) {
+	t.Helper()
+	srv, _, dir := newTestServerStorage(t)
+	return srv, dir
+}
+
+// newTestServerStorage is newTestServer for tests that also instrument the
+// storage the server writes through.
+func newTestServerStorage(t *testing.T) (*Server, *Storage, string) {
 	t.Helper()
 	// The forward loader falls back to the process environment, so a developer
 	// with forwarding and real credentials exported would otherwise have this
@@ -422,7 +564,7 @@ func newTestServer(t *testing.T) (*Server, string) {
 	if err != nil {
 		t.Fatalf("NewStorage: %v", err)
 	}
-	return NewServer(storage, nil, filepath.Join(dir, "config.env")), dir
+	return NewServer(storage, nil, filepath.Join(dir, "config.env")), storage, dir
 }
 
 func post(t *testing.T, s *Server, path, contentType, body string) *http.Response {
@@ -505,6 +647,44 @@ func TestServer_APITokenMetrics(t *testing.T) {
 		srv.ServeHTTP(rr, req)
 		assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
 	})
+
+	t.Run("range and interval bound the response", func(t *testing.T) {
+		writeGen(t, storage, "conv-B", "g2", agento11y.Generation{
+			Model:     agento11y.ModelRef{Provider: "anthropic", Name: "claude-sonnet-4"},
+			StartedAt: mustParse(t, "2026-05-21T10:40:00Z"),
+			Usage:     agento11y.TokenUsage{InputTokens: 7},
+		}, "2026-05-21T10:40:00Z")
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/metrics/tokens?since=2026-05-21T09:00:00Z&interval=3600", nil)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+
+		var body struct {
+			Points          []TokenUsagePoint `json:"points"`
+			IntervalSeconds int64             `json:"interval_seconds"`
+		}
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+		assert.Equal(t, int64(3600), body.IntervalSeconds, "the response echoes the interval used")
+		// Both generations share the 10:00 bucket and the same model, so
+		// they collapse into one point.
+		require.Len(t, body.Points, 1)
+		assert.Equal(t, mustParse(t, "2026-05-21T10:00:00Z"), body.Points[0].Timestamp)
+		assert.Equal(t, int64(107), body.Points[0].FreshInput)
+	})
+
+	t.Run("invalid parameters rejected", func(t *testing.T) {
+		for _, path := range []string{
+			"/api/v1/metrics/tokens?since=last-tuesday",
+			"/api/v1/metrics/tokens?interval=0",
+			"/api/v1/metrics/tokens?interval=hourly",
+		} {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			rr := httptest.NewRecorder()
+			srv.ServeHTTP(rr, req)
+			assert.Equal(t, http.StatusBadRequest, rr.Code, path)
+		}
+	})
 }
 
 func TestServer_APITokenMetrics_EmptyStorage(t *testing.T) {
@@ -513,7 +693,7 @@ func TestServer_APITokenMetrics_EmptyStorage(t *testing.T) {
 	rr := httptest.NewRecorder()
 	srv.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Equal(t, `{"points":[]}`, strings.TrimSpace(rr.Body.String()))
+	assert.Equal(t, `{"interval_seconds":10,"points":[]}`, strings.TrimSpace(rr.Body.String()))
 }
 
 // configPathFor returns the dotenv path newTestServer wired into the server,
@@ -1232,7 +1412,7 @@ func TestServer_HookEvaluate_RelayShape(t *testing.T) {
 	require.Equal(t, 1, cloud.count())
 	_, sent, headers := cloud.lastCall()
 	assert.Equal(t, body, sent)
-	assert.NotEmpty(t, headers.Get(forwardMarkerHeader))
+	assert.NotEmpty(t, headers.Get(ForwardMarkerHeader))
 	assert.Equal(t, "t", headers.Get(wire.TenantHeaderName))
 	assert.True(t, strings.HasPrefix(headers.Get("Authorization"), "Basic "))
 	// The legacy spelling was propagated under the branded one, minus the
@@ -1248,7 +1428,7 @@ func TestServer_HookEvaluate_DoesNotChainRelayedRequest(t *testing.T) {
 	cloud.respond = `{"action":"deny","rule_id":"r1"}`
 	s, _ := newForwardingTestServer(t, cloud.srv, hookEnv(cloud.srv.URL, nil))
 
-	status, out := postHook(t, s, hookToolCallBody, map[string]string{forwardMarkerHeader: "1"})
+	status, out := postHook(t, s, hookToolCallBody, map[string]string{ForwardMarkerHeader: "1"})
 	require.Equal(t, http.StatusOK, status)
 	assert.Equal(t, agento11y.HookActionAllow, out.Action)
 	assert.Zero(t, cloud.count())
@@ -1476,8 +1656,8 @@ func TestServer_Forwarding_ToggleOffStopsForwarding(t *testing.T) {
 
 // TestServer_Forwarding_DoesNotRelayForwardedPayload covers the loop guard: a
 // payload that already carries another daemon's forward marker is stored but
-// not forwarded again, so two daemons pointed at each other (or one pointed at
-// itself) exchange one copy instead of looping.
+// not forwarded again, so two daemons pointed at each other (or one pointed
+// at itself) exchange one copy instead of looping.
 func TestServer_Forwarding_DoesNotRelayForwardedPayload(t *testing.T) {
 	hits := make(chan struct{}, 4)
 	cloud := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -1496,7 +1676,7 @@ func TestServer_Forwarding_DoesNotRelayForwardedPayload(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, path,
 			strings.NewReader(`{"generations":[{"id":"gen-1","conversation_id":"conv-A","model":{"name":"m"}}]}`))
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set(forwardMarkerHeader, "1")
+		req.Header.Set(ForwardMarkerHeader, "1")
 		rr := httptest.NewRecorder()
 		s.ServeHTTP(rr, req)
 		require.Equal(t, http.StatusOK, rr.Code)

--- a/plugins/agento11y/internal/local/storage.go
+++ b/plugins/agento11y/internal/local/storage.go
@@ -7,7 +7,11 @@ package local
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,6 +42,14 @@ func StateDir() string {
 type Storage struct {
 	dir string
 
+	// logger reports lines a read skipped. nil discards them; the daemon
+	// attaches its logger through SetLogger before it serves.
+	logger *log.Logger
+
+	// openAppend opens one JSONL file for appending. Tests replace it to
+	// count open/close cycles; a nil value uses openAppendFile.
+	openAppend func(path string) (io.WriteCloser, error)
+
 	// One mutex per file path. We don't expect contention high enough to
 	// need finer locking; this just stops interleaved JSON lines.
 	mu    sync.Mutex
@@ -60,6 +72,22 @@ func NewStorage(dir string) (*Storage, error) {
 // Dir returns the storage root directory.
 func (s *Storage) Dir() string { return s.dir }
 
+// SetLogger attaches a logger for read-side diagnostics. Call it before
+// the first read; a Storage without one stays silent.
+func (s *Storage) SetLogger(logger *log.Logger) { s.logger = logger }
+
+// logSkipped reports lines a read could not decode. skipped counts one
+// request, and what names that read in the log line. An interrupted append
+// leaves a truncated tail, which costs at most one line per file, so a
+// count above the number of files the request read means the store holds
+// records this build cannot read.
+func (s *Storage) logSkipped(what string, skipped int) {
+	if skipped == 0 || s.logger == nil {
+		return
+	}
+	s.logger.Printf("local: %s: skipped %d unparseable lines", what, skipped)
+}
+
 // Path returns the absolute path for the named JSONL file in this Storage.
 func (s *Storage) Path(name string) string {
 	return filepath.Join(s.dir, name)
@@ -68,27 +96,78 @@ func (s *Storage) Path(name string) string {
 // Append writes one JSON-encoded record followed by a newline to the named
 // file. Files are created with 0o600 permissions; the per-path mutex
 // prevents concurrent goroutines in this process from interleaving lines.
+//
+// This is the single-record form. Generation ingest batches through
+// AppendGenerations instead.
 func (s *Storage) Append(name string, record any) error {
+	_, err := appendJSONL(s, name, []any{record})
+	return err
+}
+
+// appendJSONL writes every record as one JSON line to the named file
+// through a single open and close cycle. It returns how many records
+// reached the file: on error the records before the returned count are
+// written and the rest are not, so a caller with per-record results can
+// report exactly which ones it accepted.
+//
+// A missing parent directory is recreated once and the open retried, so
+// ingest and export recover if the conversations directory disappears
+// while the daemon runs.
+func appendJSONL[T any](s *Storage, name string, records []T) (int, error) {
+	if len(records) == 0 {
+		return 0, nil
+	}
 	path := s.Path(name)
 	lock := s.lockFor(path)
 	lock.Lock()
 	defer lock.Unlock()
 
-	data, err := json.Marshal(record)
+	f, err := s.openForAppend(path)
 	if err != nil {
-		return fmt.Errorf("local storage: marshal %s: %w", name, err)
-	}
-	data = append(data, '\n')
-
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
-	if err != nil {
-		return fmt.Errorf("local storage: open %s: %w", path, err)
+		return 0, err
 	}
 	defer f.Close()
-	if _, err := f.Write(data); err != nil {
-		return fmt.Errorf("local storage: write %s: %w", path, err)
+
+	for i, record := range records {
+		data, err := json.Marshal(record)
+		if err != nil {
+			return i, fmt.Errorf("local storage: marshal %s: %w", name, err)
+		}
+		data = append(data, '\n')
+		if _, err := f.Write(data); err != nil {
+			return i, fmt.Errorf("local storage: write %s: %w", path, err)
+		}
 	}
-	return nil
+	return len(records), nil
+}
+
+// openForAppend opens path for appending, recreating the parent directory
+// when it is gone (a user or another tool removed it under the running
+// daemon) and retrying the open once.
+func (s *Storage) openForAppend(path string) (io.WriteCloser, error) {
+	open := s.openAppend
+	if open == nil {
+		open = openAppendFile
+	}
+	f, err := open(path)
+	if err == nil {
+		return f, nil
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("local storage: open %s: %w", path, err)
+	}
+	if mkErr := os.MkdirAll(filepath.Dir(path), 0o700); mkErr != nil {
+		return nil, fmt.Errorf("local storage: mkdir %s: %w", filepath.Dir(path), mkErr)
+	}
+	f, err = open(path)
+	if err != nil {
+		return nil, fmt.Errorf("local storage: open %s: %w", path, err)
+	}
+	return f, nil
+}
+
+func openAppendFile(path string) (io.WriteCloser, error) {
+	return os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
 }
 
 func (s *Storage) lockFor(path string) *sync.Mutex {
@@ -102,15 +181,34 @@ func (s *Storage) lockFor(path string) *sync.Mutex {
 	return lock
 }
 
-// AppendGeneration writes one record into conversations/<id>.jsonl.
+// AppendGeneration writes one record into conversations/<id>.jsonl through
+// AppendGenerations. Only the tests call it; the ingest handler passes a
+// whole batch.
 func (s *Storage) AppendGeneration(rec generationRecord) error {
-	if rec.ConversationID == "" {
-		return fmt.Errorf("local storage: empty conversation_id")
+	_, err := s.AppendGenerations(rec.ConversationID, []generationRecord{rec})
+	return err
+}
+
+// AppendGenerations writes every record for one conversation into
+// conversations/<convID>.jsonl through a single open and close cycle, so
+// one export request costs one file open per conversation it touches.
+//
+// It returns how many records were written. On error the first n records
+// are stored and the remaining records are not. The ingest handler turns
+// that boundary into a per-generation accepted or rejected result.
+func (s *Storage) AppendGenerations(convID string, recs []generationRecord) (int, error) {
+	if convID == "" {
+		return 0, fmt.Errorf("local storage: empty conversation_id")
 	}
-	if !validConversationID(rec.ConversationID) {
-		return fmt.Errorf("local storage: unsafe conversation_id %q", rec.ConversationID)
+	if !validConversationID(convID) {
+		return 0, fmt.Errorf("local storage: unsafe conversation_id %q", convID)
 	}
-	return s.Append(filepath.Join(ConversationsDir, rec.ConversationID+".jsonl"), rec)
+	for _, rec := range recs {
+		if rec.ConversationID != convID {
+			return 0, fmt.Errorf("local storage: record conversation_id %q does not match batch %q", rec.ConversationID, convID)
+		}
+	}
+	return appendJSONL(s, filepath.Join(ConversationsDir, convID+".jsonl"), recs)
 }
 
 func validConversationID(id string) bool {

--- a/plugins/agento11y/internal/local/storage_test.go
+++ b/plugins/agento11y/internal/local/storage_test.go
@@ -3,11 +3,17 @@ package local
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStorage_AppendsJSONL(t *testing.T) {
@@ -62,22 +68,28 @@ func TestStorage_FilePermissions(t *testing.T) {
 }
 
 // TestAppendGeneration covers generation storage: populated
-// conversation IDs land in conversations/<id>.jsonl, and missing or
-// path-shaped IDs are rejected.
+// conversation IDs go to conversations/<id>.jsonl, missing or path-shaped
+// IDs are rejected, and a conversations directory that disappeared under a
+// running daemon is recreated so ingest and export recover.
 func TestAppendGeneration(t *testing.T) {
 	cases := []struct {
-		name     string
-		convID   string
-		wantPath string
-		wantErr  bool
+		name      string
+		convID    string
+		removeDir bool
+		wantPath  string
+		wantErr   bool
 	}{
 		{name: "populated id writes per-conversation file", convID: "conv-A", wantPath: "conv-A.jsonl"},
+		{name: "missing conversations dir is recreated", convID: "conv-A", removeDir: true, wantPath: "conv-A.jsonl"},
 		{name: "empty id rejected", convID: "", wantErr: true},
 		{name: "path id rejected", convID: "../runs", wantErr: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := newStorage(t)
+			if tc.removeDir {
+				require.NoError(t, os.RemoveAll(filepath.Join(s.Dir(), ConversationsDir)))
+			}
 			rec := generationRecord{
 				ConversationID: tc.convID,
 				GenerationID:   "gen-1",
@@ -94,9 +106,7 @@ func TestAppendGeneration(t *testing.T) {
 			if err != nil {
 				t.Fatalf("AppendGeneration: %v", err)
 			}
-			if _, err := os.Stat(filepath.Join(s.Dir(), ConversationsDir, tc.wantPath)); err != nil {
-				t.Fatalf("expected file %s: %v", tc.wantPath, err)
-			}
+			assert.Len(t, readLines(t, filepath.Join(s.Dir(), ConversationsDir, tc.wantPath)), 1)
 		})
 	}
 }
@@ -111,6 +121,118 @@ func assertConversationDirEmpty(t *testing.T, s *Storage) {
 	if len(entries) != 0 {
 		t.Fatalf("%s not empty: %v", convDir, entries)
 	}
+}
+
+// TestAppendGenerations covers the batch append path the ingest handler
+// uses: every record for one conversation goes through a single file open
+// and close cycle, a mid-batch write failure keeps the records written
+// before it, and a record from another conversation is refused.
+func TestAppendGenerations(t *testing.T) {
+	cases := []struct {
+		name           string
+		records        int
+		mixConvID      bool
+		failWriteAfter int
+		wantWritten    int
+		wantLines      int
+		wantErr        bool
+		wantOpens      int
+	}{
+		{name: "five records share one open cycle", records: 5, wantWritten: 5, wantLines: 5, wantOpens: 1},
+		{name: "third write fails", records: 5, failWriteAfter: 2, wantWritten: 2, wantLines: 2, wantErr: true, wantOpens: 1},
+		{name: "foreign conversation id refused", records: 2, mixConvID: true, wantErr: true, wantOpens: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newStorage(t)
+			opener := &countingOpener{failWriteAfter: tc.failWriteAfter}
+			s.openAppend = opener.open
+
+			recs := make([]generationRecord, 0, tc.records)
+			for i := range tc.records {
+				rec := generationRecord{
+					ConversationID: "conv-batch",
+					GenerationID:   "gen-" + strconv.Itoa(i),
+					Generation:     json.RawMessage(`{"id":"gen-` + strconv.Itoa(i) + `"}`),
+				}
+				if tc.mixConvID && i == 1 {
+					rec.ConversationID = "conv-other"
+				}
+				recs = append(recs, rec)
+			}
+
+			written, err := s.AppendGenerations("conv-batch", recs)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantWritten, written)
+
+			path := filepath.Join(s.Dir(), ConversationsDir, "conv-batch.jsonl")
+			if tc.wantLines == 0 {
+				_, statErr := os.Stat(path)
+				assert.True(t, os.IsNotExist(statErr), "no file expected, stat err = %v", statErr)
+			} else {
+				assert.Len(t, readLines(t, path), tc.wantLines)
+			}
+			opens, closes := opener.counts()
+			assert.Equal(t, tc.wantOpens, opens, "file opens")
+			assert.Equal(t, opens, closes, "every open must be closed")
+		})
+	}
+}
+
+// countingOpener wraps the real appender, counting open and close cycles
+// so the batch tests can prove one request costs one open per
+// conversation. failWriteAfter > 0 fails every write past that count.
+type countingOpener struct {
+	mu             sync.Mutex
+	opens          int
+	closes         int
+	writes         int
+	failWriteAfter int
+}
+
+func (o *countingOpener) open(path string) (io.WriteCloser, error) {
+	f, err := openAppendFile(path)
+	if err != nil {
+		return nil, err
+	}
+	o.mu.Lock()
+	o.opens++
+	o.mu.Unlock()
+	return &countingFile{owner: o, file: f}, nil
+}
+
+func (o *countingOpener) counts() (opens, closes int) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.opens, o.closes
+}
+
+type countingFile struct {
+	owner *countingOpener
+	file  io.WriteCloser
+}
+
+func (f *countingFile) Write(p []byte) (int, error) {
+	f.owner.mu.Lock()
+	f.owner.writes++
+	n := f.owner.writes
+	failAfter := f.owner.failWriteAfter
+	f.owner.mu.Unlock()
+	if failAfter > 0 && n > failAfter {
+		return 0, errors.New("no space left on device")
+	}
+	return f.file.Write(p)
+}
+
+func (f *countingFile) Close() error {
+	f.owner.mu.Lock()
+	f.owner.closes++
+	f.owner.mu.Unlock()
+	return f.file.Close()
 }
 
 func TestStorage_ConcurrentAppends(t *testing.T) {

--- a/plugins/agento11y/internal/local/web/app.jsx
+++ b/plugins/agento11y/internal/local/web/app.jsx
@@ -69,6 +69,12 @@
     ];
     const FEED_TIME_RANGES = TIME_RANGES.filter(r => r.value !== "5m" && r.value !== "15m");
 
+    // LIST_PAGE_SIZE is how many conversations one list request asks for.
+    // The rows are not virtualised and the server decodes only what it
+    // returns, so this bounds both ends. It matches the server's own
+    // default (conversationListLimit in server.go).
+    const LIST_PAGE_SIZE = 200;
+
     function timeRangeOption(value) {
       return TIME_RANGES.find(r => r.value === value) || TIME_RANGES.find(r => r.value === "6h");
     }
@@ -313,6 +319,69 @@
       const end = n ? Math.max(now, maxT) : now;
       const start = n ? minT : end - 60 * 60 * 1000;
       return { start, end };
+    }
+
+    // BUCKET_INTERVALS_MS is the ladder the chart and the token endpoint
+    // share. Every step divides the next, so a point the server aggregated
+    // on one step always falls inside a single bar of a coarser step.
+    // This list and tokenUsageIntervals in query.go must stay equal;
+    // TestBucketLaddersAgree checks that.
+    const BUCKET_INTERVALS_MS = [
+      10_000, 30_000, 60_000, 5 * 60_000, 15 * 60_000, 30 * 60_000,
+      60 * 60_000, 2 * 60 * 60_000, 4 * 60 * 60_000, 12 * 60 * 60_000,
+      24 * 60 * 60_000, 7 * 24 * 60 * 60_000,
+    ];
+    // CHART_BUCKET_MAX caps how many bars a chart draws. The finest ladder
+    // step that stays under it is also what the token endpoint aggregates
+    // on, so the response holds one point per bar per model instead of one
+    // per generation. Every fixed range gives 10 to 15 bars.
+    const CHART_BUCKET_MAX = 16;
+
+    // chartBucketMs picks the bar width for a span. Past the top of the
+    // ladder it widens the last step by a whole multiple, so a decade of
+    // imported history draws CHART_BUCKET_MAX bars rather than one per week,
+    // and a server bucket still divides a bar.
+    function chartBucketMs(spanMs, minMs = 0) {
+      const span = Number.isFinite(spanMs) && spanMs > 0 ? spanMs : 60_000;
+      const floor = Number.isFinite(minMs) && minMs > 0 ? minMs : 0;
+      for (const step of BUCKET_INTERVALS_MS) {
+        if (step >= floor && span / step <= CHART_BUCKET_MAX) return step;
+      }
+      // Divide by one bar fewer than the cap, because chartGrid snaps the
+      // window outwards at both ends and that can need an extra bar.
+      const top = Math.max(BUCKET_INTERVALS_MS[BUCKET_INTERVALS_MS.length - 1], floor);
+      return top * Math.max(1, Math.ceil(span / (top * (CHART_BUCKET_MAX - 1))));
+    }
+
+    // chartGrid is the bucket layout both charts share: a window snapped to
+    // the bucket ladder (measured from the epoch, the way the server floors
+    // its buckets) plus the bar count that follows from it. serverIntervalMs
+    // is the width the token endpoint aggregated on; a bar is never finer
+    // than that, or a server bucket would straddle two bars and leave the
+    // neighbour reading empty.
+    function chartGrid(times, rangeValue, now, serverIntervalMs = 0) {
+      const { start, end } = timeWindow(times, rangeValue, now);
+      const bucketMs = chartBucketMs(end - start, serverIntervalMs);
+      const gridStart = Math.floor(start / bucketMs) * bucketMs;
+      const gridEnd = Math.ceil(Math.max(end, gridStart + bucketMs) / bucketMs) * bucketMs;
+      return { start: gridStart, end: gridEnd, bucketMs, count: Math.round((gridEnd - gridStart) / bucketMs) };
+    }
+
+    // requestWindow builds the bounds the viewer sends the server: the page
+    // size and range for the conversation list, and the range and bucket
+    // interval for the token chart. A fixed range sends a `since` snapped
+    // to the same grid the chart draws on; "All" sends neither bound and
+    // lets the server pick an interval it reports back.
+    function requestWindow(rangeValue, pageSize, now = Date.now()) {
+      const range = timeRangeOption(rangeValue);
+      if (range.ms == null) return { limit: pageSize };
+      const bucketMs = chartBucketMs(range.ms);
+      const start = Math.floor((now - range.ms) / bucketMs) * bucketMs;
+      return {
+        limit: pageSize,
+        since: new Date(start).toISOString(),
+        intervalSec: Math.round(bucketMs / 1000),
+      };
     }
 
     // bucketByTime lays out `count` equal buckets across the selected
@@ -1432,7 +1501,7 @@
       );
     }
 
-    function ConversationsView({ conversations, tokenPoints, loading, error, query, setQuery, searchInputRef, timeRange, setTimeRange, tokenModel, setTokenModel, chartMetric, setChartMetric, bucketSel, setBucketSel, listSort, setListSort, onOpen, onRefresh, refreshing, onOpenSettings }) {
+    function ConversationsView({ conversations, storeCount, tokenPoints, tokenIntervalMs, loading, error, query, setQuery, searchInputRef, timeRange, setTimeRange, tokenModel, setTokenModel, chartMetric, setChartMetric, bucketSel, setBucketSel, listSort, setListSort, onOpen, onRefresh, refreshing, onOpenSettings }) {
       const now = Date.now();
       const prices = useModelPrices();
       const range = timeRangeOption(timeRange);
@@ -1596,17 +1665,25 @@
       }), []);
       // Both metrics share one window so switching the chart between
       // them doesn't shift the time axis; with per-metric windows the
-      // "All" range drifts when the datasets' extents differ.
+      // "All" range drifts when the datasets' extents differ. The window
+      // is snapped to the bucket ladder the token endpoint aggregates on,
+      // so each server point falls inside exactly one bar.
+      //
+      // A fixed range asks the server for the width it will draw on. Only
+      // the "All" range needs the reported width as a floor: there the server
+      // derives it from the whole store while the bars follow the visible
+      // window, which a model facet can narrow.
+      const serverIntervalMs = range.ms == null ? tokenIntervalMs : 0;
       const chartWindow = useMemo(() => {
         const times = filtered.map(conversationTime).concat(tokenFiltered.map(tokenPointTime));
-        return timeWindow(times, timeRange, now);
-      }, [filtered, tokenFiltered, timeRange, now]);
+        return chartGrid(times, timeRange, now, serverIntervalMs);
+      }, [filtered, tokenFiltered, timeRange, now, serverIntervalMs]);
       const activity = useMemo(
-        () => bucketActivity(filtered, timeRange, now, { window: chartWindow }),
+        () => bucketActivity(filtered, timeRange, now, { window: chartWindow, count: chartWindow.count }),
         [filtered, timeRange, now, chartWindow]
       );
       const tokenUsage = useMemo(
-        () => bucketTokenUsage(tokenFiltered, timeRange, now, { window: chartWindow }),
+        () => bucketTokenUsage(tokenFiltered, timeRange, now, { window: chartWindow, count: chartWindow.count }),
         [tokenFiltered, timeRange, now, chartWindow]
       );
       // Bucket drill-down from a chart bar click: the list narrows to
@@ -1801,14 +1878,18 @@
             {!error && loading && conversations.length === 0 && (
               <div style={{ padding: "32px 18px", color: "var(--fg3)", fontFamily: "var(--fontFamilyMonospace)", fontSize: 12 }}>Loading…</div>
             )}
-            {!error && !loading && conversations.length === 0 && (
+            {/* The list request is range-scoped, so an empty page does not
+                mean an empty store. storeCount comes from the response and
+                decides which notice applies; null (no response yet, or an
+                older daemon) falls back to reading the page. */}
+            {!error && !loading && rangeFiltered.length === 0 && (storeCount === 0 || (storeCount == null && conversations.length === 0)) && (
               <div style={{ padding: 16 }}>
                 <Notice kind="info" title="No sessions yet">
                   Run an agent against this daemon with <code style={{ color: "var(--fg1)" }}>agento11y pi --local</code> or <code style={{ color: "var(--fg1)" }}>agento11y claude --local</code>. Captured generations appear here as soon as the agent emits its first one.
                 </Notice>
               </div>
             )}
-            {!error && conversations.length > 0 && rangeFiltered.length === 0 && (
+            {!error && !loading && rangeFiltered.length === 0 && (storeCount > 0 || conversations.length > 0) && (
               <div style={{ padding: "16px 18px", color: "var(--fg2)", fontSize: 12 }}>
                 No sessions in <code style={{ color: "var(--fg1)" }}>{range.label}</code>.
               </div>
@@ -4128,7 +4209,12 @@
       const [selectedID, setSelectedID] = useState(conversationIDFromPath);
       const [showSettings, setShowSettings] = useState(settingsRouteActive);
       const [conversations, setConversations] = useState([]);
+      // storeCount is the number of conversations the daemon holds, before
+      // the list's page and range bounds. The list itself is range-scoped,
+      // so only this count distinguishes an empty store from a quiet range.
+      const [storeCount, setStoreCount] = useState(null);
       const [tokenPoints, setTokenPoints] = useState([]);
+      const [tokenIntervalMs, setTokenIntervalMs] = useState(0);
       const [loadingList, setLoadingList] = useState(true);
       const [errList, setErrList] = useState(null);
       const [query, setQuery] = useState("");
@@ -4163,21 +4249,36 @@
         : "agento11y — local";
       useEffect(() => { document.title = pageTitle; }, [pageTitle]);
 
-      // fetchList is driven from three sources (mount, SSE flush, 60s
-      // backstop), so a slower older response could otherwise overwrite
-      // a newer one. Each call captures a monotonically increasing
+      // fetchList is driven from four sources (mount, a range change, an SSE
+      // flush, the 60s backstop), so a slower older response could otherwise
+      // overwrite a newer one. Each call captures a monotonically increasing
       // sequence number and only applies its result if it is still the
       // latest.
+      //
+      // reset drops the current page before the request goes out. The page is
+      // range-scoped, so once the range changes it covers a window the header
+      // no longer names, and a wider range would keep showing the narrower
+      // page as if it were the whole answer. A refresh in place (SSE flush,
+      // backstop, the refresh button) keeps the rows and swaps them when the
+      // response lands.
       const listSeqRef = useRef(0);
-      const fetchList = useCallback(() => {
+      const fetchList = useCallback((reset = false) => {
         const seq = ++listSeqRef.current;
         setLoadingList(true);
         setErrList(null);
-        return fetch("/api/v1/conversations")
+        if (reset) setConversations([]);
+        // Bound the request: the server pages the list by file modification
+        // time and never decodes past the page, so the cost follows the page
+        // size, not the store size.
+        const w = requestWindow(timeRange, LIST_PAGE_SIZE);
+        const params = new URLSearchParams({ limit: String(w.limit) });
+        if (w.since) params.set("since", w.since);
+        return fetch(`/api/v1/conversations?${params}`)
           .then(r => r.ok ? r.json() : r.text().then(t => Promise.reject(new Error(t || `HTTP ${r.status}`))))
           .then(body => {
             if (listSeqRef.current !== seq) return;
             setConversations(body.conversations || []);
+            setStoreCount(Number.isFinite(body.total_conversations) ? body.total_conversations : null);
           })
           .catch(e => {
             if (listSeqRef.current !== seq) return;
@@ -4187,21 +4288,61 @@
             if (listSeqRef.current !== seq) return;
             setLoadingList(false);
           });
-      }, []);
+      }, [timeRange]);
 
-      // Token points back the usage chart. Failures are swallowed: the
-      // chart is supplementary, so a hiccup here shouldn't surface an
-      // error banner over the conversation list.
-      const fetchTokens = useCallback(() => {
-        return fetch("/api/v1/metrics/tokens")
+      // Token points back the usage chart. The server aggregates them per
+      // bucket and model over the requested range, so the payload follows
+      // the number of bars, not the number of generations. A failure here is
+      // swallowed: the chart is supplementary, and a hiccup shouldn't surface
+      // an error banner over the conversation list.
+      //
+      // The response is range-specific, and this runs from mount, an SSE
+      // flush, the 60s backstop and a range change. It therefore carries the
+      // same sequence guard as fetchList: a slow response for the previous
+      // range must not replace a fast one for the current range.
+      const tokenSeqRef = useRef(0);
+      const fetchTokens = useCallback((reset = false) => {
+        const seq = ++tokenSeqRef.current;
+        // As with the list, a range change invalidates the points and the
+        // interval they were aggregated on. Clearing them keeps a narrower
+        // window's chart from reading as the new range's usage, which a
+        // swallowed failure would otherwise leave in place until the next
+        // flush or backstop.
+        if (reset) {
+          setTokenPoints([]);
+          setTokenIntervalMs(0);
+        }
+        const w = requestWindow(timeRange, LIST_PAGE_SIZE);
+        const params = new URLSearchParams();
+        if (w.since) params.set("since", w.since);
+        if (w.intervalSec) params.set("interval", String(w.intervalSec));
+        const query = params.toString();
+        return fetch(`/api/v1/metrics/tokens${query ? `?${query}` : ""}`)
           .then(r => r.ok ? r.json() : null)
-          .then(body => { if (body) setTokenPoints(body.points || []); })
+          .then(body => {
+            if (!body || tokenSeqRef.current !== seq) return;
+            setTokenPoints(body.points || []);
+            // The chart never draws a bar finer than the width the server
+            // aggregated on, so read it back instead of assuming the
+            // requested one ("All" requests none).
+            const seconds = Number(body.interval_seconds);
+            setTokenIntervalMs(Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : 0);
+          })
           .catch(() => {});
-      }, []);
+      }, [timeRange]);
 
       const refreshAll = useCallback(() => {
         fetchList();
         fetchTokens();
+      }, [fetchList, fetchTokens]);
+
+      // reloadRange refetches when the request window itself changed: mount,
+      // or a range change. Both callbacks close over timeRange, so this
+      // identity moves exactly then, and the effect below is the only caller
+      // that discards what the previous window returned.
+      const reloadRange = useCallback(() => {
+        fetchList(true);
+        fetchTokens(true);
       }, [fetchList, fetchTokens]);
 
       // fetchDetailCore is the shared fetch body for both an explicit
@@ -4244,7 +4385,7 @@
       const fetchDetail = useCallback((id) => fetchDetailCore(id, false), [fetchDetailCore]);
       const quietRefreshDetail = useCallback((id) => fetchDetailCore(id, true), [fetchDetailCore]);
 
-      useEffect(() => { refreshAll(); }, [refreshAll]);
+      useEffect(() => { reloadRange(); }, [reloadRange]);
 
       useEffect(() => {
         const onPopState = () => {
@@ -4397,7 +4538,9 @@
             {view === "conversations" && (
               <ConversationsView
                 conversations={conversations}
+                storeCount={storeCount}
                 tokenPoints={tokenPoints}
+                tokenIntervalMs={tokenIntervalMs}
                 loading={loadingList}
                 error={errList}
                 query={query}

--- a/plugins/agento11y/internal/local/web_test.go
+++ b/plugins/agento11y/internal/local/web_test.go
@@ -1,0 +1,55 @@
+package local
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBucketLaddersAgree pins the one contract between the token endpoint
+// and the chart: both bucket on the same ladder, and every step divides the
+// next. The client folds server points onto its own bars, so a step that
+// does not divide the bar width would split a bucket across two bars. The
+// viewer is served as text/babel and no JS toolchain covers it, which
+// leaves this test as the only check.
+func TestBucketLaddersAgree(t *testing.T) {
+	for i := 1; i < len(tokenUsageIntervals); i++ {
+		assert.Zero(t, tokenUsageIntervals[i]%tokenUsageIntervals[i-1],
+			"%v must divide %v", tokenUsageIntervals[i-1], tokenUsageIntervals[i])
+	}
+
+	got := bucketIntervalsFromJSX(t, string(appJSX))
+	want := make([]time.Duration, 0, len(tokenUsageIntervals))
+	want = append(want, tokenUsageIntervals...)
+	assert.Equal(t, want, got, "BUCKET_INTERVALS_MS in web/app.jsx and tokenUsageIntervals must match")
+}
+
+// bucketIntervalsFromJSX reads the BUCKET_INTERVALS_MS literal out of the
+// embedded viewer and returns it as durations. The entries are arithmetic
+// (`5 * 60_000`), so each one is evaluated as a product of its factors.
+func bucketIntervalsFromJSX(t *testing.T, src string) []time.Duration {
+	t.Helper()
+	literal := regexp.MustCompile(`(?s)const BUCKET_INTERVALS_MS = \[(.*?)\]`).FindStringSubmatch(src)
+	require.Len(t, literal, 2, "BUCKET_INTERVALS_MS literal not found in web/app.jsx")
+
+	out := []time.Duration{}
+	for entry := range strings.SplitSeq(literal[1], ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		ms := int64(1)
+		for factor := range strings.SplitSeq(entry, "*") {
+			n, err := strconv.ParseInt(strings.ReplaceAll(strings.TrimSpace(factor), "_", ""), 10, 64)
+			require.NoErrorf(t, err, "entry %q", entry)
+			ms *= n
+		}
+		out = append(out, time.Duration(ms)*time.Millisecond)
+	}
+	return out
+}

--- a/plugins/agento11y/internal/local/wire.go
+++ b/plugins/agento11y/internal/local/wire.go
@@ -82,30 +82,23 @@ type storedSkill struct {
 	Source      string `json:"source,omitempty"`
 }
 
+// storedGeneration is a stored generation with everything the detail view
+// and search read. It embeds summaryGeneration, so the two projections
+// cannot drift on a shared field's JSON tag or Go type: encoding/json
+// inlines an untagged embedded struct, and Go promotes its methods.
 type storedGeneration struct {
-	ID                string             `json:"id,omitempty"`
-	ConversationID    string             `json:"conversation_id,omitempty"`
-	ConversationTitle string             `json:"conversation_title,omitempty"`
-	AgentName         string             `json:"agent_name,omitempty"`
-	Model             agento11y.ModelRef `json:"model,omitzero"`
-	ResponseModel     string             `json:"response_model,omitempty"`
-	Input             []storedMessage    `json:"input,omitempty"`
-	Output            []storedMessage    `json:"output,omitempty"`
-	Usage             storedUsage        `json:"usage,omitzero"`
-	StopReason        string             `json:"stop_reason,omitempty"`
-	StartedAt         time.Time          `json:"started_at,omitzero"`
-	CompletedAt       time.Time          `json:"completed_at,omitzero"`
-	Skills            []storedSkill      `json:"skills,omitempty"`
-	Metadata          map[string]any     `json:"metadata,omitempty"`
-	CallError         string             `json:"call_error,omitempty"`
-	// Tags carry the agent's per-session context (cwd, git.branch,
-	// entrypoint, …). ParentGenerationIDs links a subagent's generations
-	// to the generation that spawned them, so the viewer can reconstruct
-	// the subagent tree. Both ride along on the wire verbatim and are only
-	// decoded here.
-	Tags                map[string]string `json:"tags,omitempty"`
-	ParentGenerationIDs []string          `json:"parent_generation_ids,omitempty"`
-	ThinkingEnabled     bool              `json:"thinking_enabled,omitempty"`
+	summaryGeneration
+	ConversationID string          `json:"conversation_id,omitempty"`
+	Input          []storedMessage `json:"input,omitempty"`
+	Output         []storedMessage `json:"output,omitempty"`
+	StopReason     string          `json:"stop_reason,omitempty"`
+	Skills         []storedSkill   `json:"skills,omitempty"`
+	// ParentGenerationIDs links a subagent's generations to the generation
+	// that spawned them, so the viewer can reconstruct the subagent tree.
+	// Only the full projection decodes it. The Go side copies the values to
+	// the detail view without reading them.
+	ParentGenerationIDs []string `json:"parent_generation_ids,omitempty"`
+	ThinkingEnabled     bool     `json:"thinking_enabled,omitempty"`
 }
 
 // skillViews returns the generation's skills as display-ready views,
@@ -140,7 +133,47 @@ func (g storedGeneration) skillViews() []SkillView {
 	return out
 }
 
-func (g storedGeneration) title() string {
+// summaryRecord is one JSONL line decoded down to the fields the
+// conversation list and the token chart read. It exists so a list or
+// metrics request never materialises the stored input and output message
+// trees: encoding/json skips the fields this struct omits, and a stored
+// tree of a few megabytes then costs nothing beyond the line scan.
+type summaryRecord struct {
+	ReceivedAt     string            `json:"received_at"`
+	GenerationID   string            `json:"generation_id"`
+	ConversationID string            `json:"conversation_id"`
+	Generation     summaryGeneration `json:"generation"`
+}
+
+func (r summaryRecord) generationID() string {
+	if id := strings.TrimSpace(r.GenerationID); id != "" {
+		return id
+	}
+	return strings.TrimSpace(r.Generation.ID)
+}
+
+// summaryGeneration is the stored generation projected onto the fields the
+// list and the token chart read. storedGeneration embeds it, so every
+// field here is shared with the full decode by construction. Tags carry
+// the agent's per-session context (cwd, git.branch, entrypoint, …).
+type summaryGeneration struct {
+	ID                string             `json:"id,omitempty"`
+	ConversationTitle string             `json:"conversation_title,omitempty"`
+	AgentName         string             `json:"agent_name,omitempty"`
+	Model             agento11y.ModelRef `json:"model,omitzero"`
+	ResponseModel     string             `json:"response_model,omitempty"`
+	Usage             storedUsage        `json:"usage,omitzero"`
+	StartedAt         time.Time          `json:"started_at,omitzero"`
+	CompletedAt       time.Time          `json:"completed_at,omitzero"`
+	Metadata          map[string]any     `json:"metadata,omitempty"`
+	CallError         string             `json:"call_error,omitempty"`
+	Tags              map[string]string  `json:"tags,omitempty"`
+}
+
+// title is the conversation title a generation carries: the explicit field
+// first, then the metadata key the SDK writes. storedGeneration promotes
+// this method, so the list and the detail view read the same rule.
+func (g summaryGeneration) title() string {
 	if strings.TrimSpace(g.ConversationTitle) != "" {
 		return g.ConversationTitle
 	}
@@ -153,7 +186,9 @@ func (g storedGeneration) title() string {
 	return ""
 }
 
-func (g storedGeneration) modelName() string {
+// modelName prefers the model the provider answered with over the model the
+// request asked for.
+func (g summaryGeneration) modelName() string {
 	if g.ResponseModel != "" {
 		return g.ResponseModel
 	}

--- a/plugins/agento11y/internal/otel/otel.go
+++ b/plugins/agento11y/internal/otel/otel.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/metric"
@@ -35,10 +36,10 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
 
-// DefaultServiceName is written to OTEL_SERVICE_NAME if unset before exporter
-// construction. Agents share this name so traces from any dispatched agent
-// end up under a single service in the backend. Renamed from "sigil";
-// dashboards filtering on the old service name need to update.
+// DefaultServiceName goes on the resource as service.name when
+// OTEL_SERVICE_NAME is unset. Agents share this name so traces from any
+// dispatched agent end up under a single service in the backend. Renamed from
+// "sigil"; dashboards filtering on the old service name need to update.
 const DefaultServiceName = "agento11y"
 
 // Providers holds initialized OTel providers. All methods are nil-safe.
@@ -51,6 +52,11 @@ type exporterConfig struct {
 	endpoint string
 	headers  map[string]string
 	insecure bool
+	// headersExplicit records that the caller supplied the header set, so
+	// an empty set must be passed to the exporter rather than left out.
+	// The SDK reads OTEL_EXPORTER_OTLP_HEADERS itself, and leaving the
+	// option out lets those ambient headers through.
+	headersExplicit bool
 }
 
 func (p *Providers) Tracer(name string) trace.Tracer {
@@ -110,41 +116,55 @@ func (p *Providers) Shutdown(ctx context.Context) error {
 	return first
 }
 
-// Setup creates OTLP HTTP trace + metric providers.
+// Options overrides the exporter configuration Setup otherwise reads from
+// the environment. A zero field keeps the environment value, so a caller
+// that needs one explicit destination does not have to reproduce the rest.
+//
+// Headers replaces the environment set only when non-nil. A caller that must
+// not leak the ambient Authorization header to its own endpoint passes an
+// explicit map, which may be empty.
+type Options struct {
+	// Endpoint replaces the environment OTLP endpoint when non-empty. Its
+	// scheme also decides the transport, so AGENTO11Y_OTEL_EXPORTER_OTLP_INSECURE
+	// cannot downgrade an https endpoint named here to cleartext.
+	Endpoint string
+	// Headers replaces the environment-derived header set when non-nil. An
+	// empty non-nil map sends no headers.
+	Headers map[string]string
+}
+
+// Setup creates OTLP HTTP trace + metric providers from the environment.
 // Returns nil providers (no error) when no OTLP endpoint is configured.
 //
 // instanceID is written to the resource as service.instance.id so concurrent
 // agent sessions on the same host produce distinct OTel resource identities
 // (otherwise cumulative metric series collide). Empty falls back to a UUID.
 func Setup(ctx context.Context, instanceID string) (*Providers, error) {
-	endpoint := EndpointFromEnv()
-	if endpoint == "" {
+	return SetupWithOptions(ctx, instanceID, Options{})
+}
+
+// SetupWithOptions is Setup with an explicit endpoint and header set, and it
+// writes no process environment. A long-running daemon resolves its Cloud
+// forwarding from the same variables, so a caller that needs to export
+// somewhere else passes the destination here instead of changing them under
+// the daemon.
+func SetupWithOptions(ctx context.Context, instanceID string, opts Options) (*Providers, error) {
+	cfg, ok := resolveExporterConfig(opts)
+	if !ok {
 		return nil, nil
-	}
-	cfg := exporterConfigFromEnv(endpoint)
-	// otlphttp has WithInsecure() but no WithSecure(), so any of the
-	// inherited insecure env vars below would let the SDK exporter
-	// override cfg.insecure=false and silently ship cleartext. We're a
-	// subprocess; unsetting locally has no effect on the parent env.
-	for _, k := range []string{
-		"OTEL_EXPORTER_OTLP_INSECURE",
-		"OTEL_EXPORTER_OTLP_TRACES_INSECURE",
-		"OTEL_EXPORTER_OTLP_METRICS_INSECURE",
-	} {
-		_ = os.Unsetenv(k)
-	}
-	if os.Getenv("OTEL_SERVICE_NAME") == "" {
-		_ = os.Setenv("OTEL_SERVICE_NAME", DefaultServiceName)
 	}
 	if instanceID == "" {
 		instanceID = uuid.NewString()
 	}
+	attrs := []attribute.KeyValue{semconv.ServiceInstanceID(instanceID)}
+	if os.Getenv("OTEL_SERVICE_NAME") == "" {
+		// sdkresource.Default() reads OTEL_SERVICE_NAME once per process and
+		// caches the result, so the name goes on the resource directly.
+		attrs = append(attrs, semconv.ServiceName(DefaultServiceName))
+	}
 	res, err := sdkresource.Merge(
 		sdkresource.Default(),
-		sdkresource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceInstanceID(instanceID),
-		),
+		sdkresource.NewWithAttributes(semconv.SchemaURL, attrs...),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("build resource: %w", err)
@@ -192,11 +212,10 @@ type ProbeTarget struct {
 // a lightweight request to each signal and report the HTTP status without
 // standing up the full exporter pipeline.
 func ProbeConfig() (metrics, traces ProbeTarget, ok bool) {
-	endpoint := EndpointFromEnv()
-	if endpoint == "" {
+	cfg, ok := resolveExporterConfig(Options{})
+	if !ok {
 		return ProbeTarget{}, ProbeTarget{}, false
 	}
-	cfg := exporterConfigFromEnv(endpoint)
 	return ProbeTarget{URL: probeSignalURL(cfg, "metrics"), Headers: cloneHeaders(cfg.headers)},
 		ProbeTarget{URL: probeSignalURL(cfg, "traces"), Headers: cloneHeaders(cfg.headers)},
 		true
@@ -223,6 +242,32 @@ func cloneHeaders(in map[string]string) map[string]string {
 	return out
 }
 
+// resolveExporterConfig applies opts over the environment-derived
+// configuration. ok is false when no endpoint is configured at all, which
+// is how Setup reports "nothing to export to" without an error.
+func resolveExporterConfig(opts Options) (exporterConfig, bool) {
+	endpoint := firstNonBlank(opts.Endpoint, EndpointFromEnv())
+	if endpoint == "" {
+		return exporterConfig{}, false
+	}
+	cfg := exporterConfigFromEnv(endpoint)
+	if opts.Headers != nil {
+		cfg.headers = cloneHeaders(opts.Headers)
+		cfg.headersExplicit = true
+	}
+	if strings.TrimSpace(opts.Endpoint) != "" {
+		// The caller named the destination, so its scheme decides the
+		// transport. Reading the insecure env var here would let an
+		// ambient value ship an https endpoint's spans in the clear.
+		cfg.insecure = !isHTTPSEndpoint(opts.Endpoint)
+	}
+	return cfg, true
+}
+
+func isHTTPSEndpoint(endpoint string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(endpoint)), "https://")
+}
+
 func exporterConfigFromEnv(endpoint string) exporterConfig {
 	headers := ExporterHeaders(
 		os.Getenv("OTEL_EXPORTER_OTLP_HEADERS"),
@@ -237,9 +282,13 @@ func exporterConfigFromEnv(endpoint string) exporterConfig {
 	}
 }
 
+// traceOptions and metricOptions both start from WithEndpointURL, which the
+// SDK applies after its own environment pass and which sets the transport from
+// the URL scheme. That is why cfg.insecure alone decides cleartext: an ambient
+// OTEL_EXPORTER_OTLP_INSECURE cannot reach past it.
 func traceOptions(cfg exporterConfig) []otlptracehttp.Option {
 	opts := []otlptracehttp.Option{otlptracehttp.WithEndpointURL(SignalEndpointURL(cfg.endpoint, "traces"))}
-	if len(cfg.headers) > 0 {
+	if len(cfg.headers) > 0 || cfg.headersExplicit {
 		opts = append(opts, otlptracehttp.WithHeaders(cfg.headers))
 	}
 	if cfg.insecure {
@@ -250,7 +299,7 @@ func traceOptions(cfg exporterConfig) []otlptracehttp.Option {
 
 func metricOptions(cfg exporterConfig) []otlpmetrichttp.Option {
 	opts := []otlpmetrichttp.Option{otlpmetrichttp.WithEndpointURL(SignalEndpointURL(cfg.endpoint, "metrics"))}
-	if len(cfg.headers) > 0 {
+	if len(cfg.headers) > 0 || cfg.headersExplicit {
 		opts = append(opts, otlpmetrichttp.WithHeaders(cfg.headers))
 	}
 	if cfg.insecure {

--- a/plugins/agento11y/internal/otel/otel_test.go
+++ b/plugins/agento11y/internal/otel/otel_test.go
@@ -9,8 +9,11 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sync"
 	"testing"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 
 	colmetricpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
@@ -19,6 +22,7 @@ import (
 )
 
 func TestEndpointFromEnvPrefersSigilPrefix(t *testing.T) {
+	envconfig.PinAliasEnvBlank(t)
 	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "https://sigil.example/otlp")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://otel.example/otlp")
 
@@ -28,6 +32,7 @@ func TestEndpointFromEnvPrefersSigilPrefix(t *testing.T) {
 }
 
 func TestEndpointFromEnvFallsBackToStandardOtel(t *testing.T) {
+	envconfig.PinAliasEnvBlank(t)
 	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://otel.example/otlp")
 
@@ -37,6 +42,7 @@ func TestEndpointFromEnvFallsBackToStandardOtel(t *testing.T) {
 }
 
 func TestExporterConfigUsesSigilPrefixedValues(t *testing.T) {
+	envconfig.PinAliasEnvBlank(t)
 	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_INSECURE", "true")
 	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://wrong.example/traces")
 	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "Authorization=Bearer wrong")
@@ -59,6 +65,7 @@ func TestExporterConfigUsesSigilPrefixedValues(t *testing.T) {
 }
 
 func TestExporterConfigUsesSigilOtelTokenWhenSet(t *testing.T) {
+	envconfig.PinAliasEnvBlank(t)
 	t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
 	t.Setenv("SIGIL_AUTH_TOKEN", "generation-token")
 	t.Setenv("SIGIL_OTEL_AUTH_TOKEN", "otel-token")
@@ -73,6 +80,7 @@ func TestExporterConfigUsesSigilOtelTokenWhenSet(t *testing.T) {
 }
 
 func TestExporterConfigKeepsExplicitAuthorization(t *testing.T) {
+	envconfig.PinAliasEnvBlank(t)
 	t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
 	t.Setenv("SIGIL_AUTH_TOKEN", "token")
 	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "Authorization=Bearer explicit")
@@ -85,6 +93,7 @@ func TestExporterConfigKeepsExplicitAuthorization(t *testing.T) {
 }
 
 func TestProbeConfig(t *testing.T) {
+	envconfig.PinAliasEnvBlank(t)
 	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "https://otlp.example/otlp")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 	t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
@@ -114,6 +123,7 @@ func TestProbeConfig(t *testing.T) {
 }
 
 func TestProbeConfigInsecureDropsToHTTP(t *testing.T) {
+	envconfig.PinAliasEnvBlank(t)
 	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "https://otlp.example/otlp")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_INSECURE", "true")
@@ -134,6 +144,7 @@ func TestProbeConfigInsecureDropsToHTTP(t *testing.T) {
 }
 
 func TestProbeConfigNoEndpoint(t *testing.T) {
+	envconfig.PinAliasEnvBlank(t)
 	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 	if _, _, ok := ProbeConfig(); ok {
@@ -228,7 +239,210 @@ func TestBasicAuthHeaderValue(t *testing.T) {
 	}
 }
 
+// TestResolveExporterConfigOptions covers the explicit endpoint and header
+// overrides. A daemon resolves its Cloud forwarding from the same process
+// environment, so the overrides must not read through to it or change it.
+func TestResolveExporterConfigOptions(t *testing.T) {
+	const envEndpoint = "https://env.example:4318"
+	cases := []struct {
+		name         string
+		envEndpoint  string
+		envInsecure  string
+		opts         Options
+		wantOK       bool
+		wantURL      string
+		wantHeaders  map[string]string
+		wantInsecure bool
+	}{
+		{
+			name:        "zero options keep the environment",
+			envEndpoint: envEndpoint,
+			wantOK:      true,
+			wantURL:     envEndpoint,
+			wantHeaders: map[string]string{"Authorization": "Basic env-credential"},
+		},
+		{
+			name:        "endpoint override keeps the environment headers",
+			envEndpoint: envEndpoint,
+			opts:        Options{Endpoint: "https://import.example:4318"},
+			wantOK:      true,
+			wantURL:     "https://import.example:4318",
+			wantHeaders: map[string]string{"Authorization": "Basic env-credential"},
+		},
+		{
+			name:        "headers replace rather than merge",
+			envEndpoint: envEndpoint,
+			opts: Options{
+				Endpoint: "https://import.example:4318",
+				Headers:  map[string]string{"Authorization": "Bearer test"},
+			},
+			wantOK:      true,
+			wantURL:     "https://import.example:4318",
+			wantHeaders: map[string]string{"Authorization": "Bearer test"},
+		},
+		{
+			name:        "an empty header map sends no headers",
+			envEndpoint: envEndpoint,
+			opts:        Options{Headers: map[string]string{}},
+			wantOK:      true,
+			wantURL:     envEndpoint,
+			wantHeaders: map[string]string{},
+		},
+		{
+			name:         "the environment decides the transport for its own endpoint",
+			envEndpoint:  envEndpoint,
+			envInsecure:  "true",
+			wantOK:       true,
+			wantURL:      envEndpoint,
+			wantHeaders:  map[string]string{"Authorization": "Basic env-credential"},
+			wantInsecure: true,
+		},
+		{
+			name:        "an https override is not downgraded by the environment",
+			envEndpoint: envEndpoint,
+			envInsecure: "true",
+			opts:        Options{Endpoint: "https://import.example:4318"},
+			wantOK:      true,
+			wantURL:     "https://import.example:4318",
+			wantHeaders: map[string]string{"Authorization": "Basic env-credential"},
+		},
+		{
+			name:         "an http override sends cleartext without the environment saying so",
+			envEndpoint:  envEndpoint,
+			opts:         Options{Endpoint: "http://127.0.0.1:4318"},
+			wantOK:       true,
+			wantURL:      "http://127.0.0.1:4318",
+			wantHeaders:  map[string]string{"Authorization": "Basic env-credential"},
+			wantInsecure: true,
+		},
+		{
+			name: "no endpoint anywhere reports nothing to export to",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			envconfig.PinAliasEnvBlank(t)
+			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+			t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "Authorization=Basic env-credential")
+			t.Setenv("OTEL_EXPORTER_OTLP_INSECURE", tc.envInsecure)
+			if tc.envEndpoint != "" {
+				t.Setenv("AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT", tc.envEndpoint)
+			}
+
+			cfg, ok := resolveExporterConfig(tc.opts)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if cfg.endpoint != tc.wantURL {
+				t.Errorf("endpoint = %q, want %q", cfg.endpoint, tc.wantURL)
+			}
+			if cfg.insecure != tc.wantInsecure {
+				t.Errorf("insecure = %v, want %v", cfg.insecure, tc.wantInsecure)
+			}
+			if len(cfg.headers) != len(tc.wantHeaders) {
+				t.Fatalf("headers = %+v, want %+v", cfg.headers, tc.wantHeaders)
+			}
+			for k, v := range tc.wantHeaders {
+				if cfg.headers[k] != v {
+					t.Errorf("header %s = %q, want %q", k, cfg.headers[k], v)
+				}
+			}
+			// The overrides must leave the environment other resolvers read
+			// (the daemon's forwarding config) exactly as it was.
+			if got := os.Getenv("AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT"); got != tc.envEndpoint {
+				t.Errorf("env endpoint = %q, want %q", got, tc.envEndpoint)
+			}
+			if got := os.Getenv("OTEL_EXPORTER_OTLP_HEADERS"); got != "Authorization=Basic env-credential" {
+				t.Errorf("env headers = %q, want them unchanged", got)
+			}
+		})
+	}
+}
+
+// TestSetupWithOptionsExportsToExplicitTarget stands up two collectors and
+// asserts the exporter uses the caller's endpoint and header, not the
+// environment's. It also pins that the call leaves the process environment
+// alone: an in-process caller shares it with the daemon's forwarding config.
+func TestSetupWithOptionsExportsToExplicitTarget(t *testing.T) {
+	envconfig.PinAliasEnvBlank(t)
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "")
+	t.Setenv("OTEL_SERVICE_NAME", "")
+	envBefore := map[string]string{
+		"OTEL_EXPORTER_OTLP_INSECURE":         "true",
+		"OTEL_EXPORTER_OTLP_TRACES_INSECURE":  "true",
+		"OTEL_EXPORTER_OTLP_METRICS_INSECURE": "true",
+		"OTEL_SERVICE_NAME":                   "",
+	}
+	for k, v := range envBefore {
+		t.Setenv(k, v)
+	}
+
+	var mu sync.Mutex
+	var envHits int
+	envTarget := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		envHits++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer envTarget.Close()
+
+	auth := make(chan string, 4)
+	importTarget := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/otlp/v1/traces" {
+			auth <- r.Header.Get("Authorization")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer importTarget.Close()
+
+	t.Setenv("AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT", envTarget.URL+"/otlp")
+	t.Setenv("AGENTO11Y_AUTH_TENANT_ID", "env-tenant")
+	t.Setenv("AGENTO11Y_AUTH_TOKEN", "env-token")
+
+	ctx := context.Background()
+	providers, err := SetupWithOptions(ctx, "import-run", Options{
+		Endpoint: importTarget.URL + "/otlp",
+		Headers:  map[string]string{"Authorization": "Bearer test"},
+	})
+	if err != nil {
+		t.Fatalf("SetupWithOptions: %v", err)
+	}
+	_, span := providers.Tracer("test").Start(ctx, "span")
+	span.End()
+	if err := providers.ForceFlush(); err != nil {
+		t.Fatalf("ForceFlush: %v", err)
+	}
+	if err := providers.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	select {
+	case got := <-auth:
+		if got != "Bearer test" {
+			t.Fatalf("Authorization = %q, want %q", got, "Bearer test")
+		}
+	default:
+		t.Fatal("no trace export reached the explicit endpoint")
+	}
+	for k, want := range envBefore {
+		if got := os.Getenv(k); got != want {
+			t.Errorf("%s = %q after SetupWithOptions, want %q", k, got, want)
+		}
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if envHits != 0 {
+		t.Fatalf("environment endpoint received %d requests, want 0", envHits)
+	}
+}
+
 func TestSetupExportsToSignalSpecificPaths(t *testing.T) {
+	envconfig.PinAliasEnvBlank(t)
 	var mu sync.Mutex
 	paths := map[string]int{}
 	authHeaders := map[string]string{}
@@ -295,8 +509,11 @@ func newTestServer(t *testing.T, handler http.Handler) *httptest.Server {
 	return server
 }
 
+// TestSetupAttachesServiceInstanceID also covers the default service name,
+// which goes on the resource because OTEL_SERVICE_NAME is blank here.
 func TestSetupAttachesServiceInstanceID(t *testing.T) {
-	t.Setenv("OTEL_SERVICE_NAME", "agento11y")
+	envconfig.PinAliasEnvBlank(t)
+	t.Setenv("OTEL_SERVICE_NAME", "")
 
 	captured := newOTLPCapture(t)
 	defer captured.server.Close()
@@ -344,6 +561,7 @@ func TestSetupAttachesServiceInstanceID(t *testing.T) {
 }
 
 func TestSetupGeneratesInstanceIDWhenEmpty(t *testing.T) {
+	envconfig.PinAliasEnvBlank(t)
 	t.Setenv("SIGIL_AUTH_TENANT_ID", "")
 	t.Setenv("SIGIL_AUTH_TOKEN", "")
 	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "")


### PR DESCRIPTION
The local daemon keeps one JSONL file per conversation and decoded all of them on every viewer request. `?limit=` existed, but it only truncated the result after every file was decoded, and the viewer never sent it.

**What changed**

- The list sorts files by modification time, drops anything older than `?since=`, then opens only the page it returns.
- The list and the token chart decode into a struct that declares only the fields they need.
- The server and not the client now sums token usage per time bucket, model and provider.