### PR TITLE
feat(providers): normalize provider usage to the inclusive contract (phase 1: providers)

### DIFF
--- a/dotnet/src/Grafana.Agento11y.Anthropic/AnthropicGenerationMapper.cs
+++ b/dotnet/src/Grafana.Agento11y.Anthropic/AnthropicGenerationMapper.cs
@@ -591,8 +591,13 @@ public static class AnthropicGenerationMapper
             return new TokenUsage();
         }
 
-        var input = ReadLong(usage, "input_tokens");
         var output = ReadLong(usage, "output_tokens");
+        var cacheRead = ReadLong(usage, "cache_read_input_tokens");
+        var cacheWrite = ReadLong(usage, "cache_creation_input_tokens");
+        // Anthropic reports input_tokens exclusive of both cache buckets. The
+        // OTel GenAI Anthropic rule requires summing them into the inclusive
+        // input_tokens this SDK emits.
+        var input = ReadLong(usage, "input_tokens") + cacheRead + cacheWrite;
         var total = ReadLong(usage, "total_tokens");
 
         if (total == 0)
@@ -605,8 +610,9 @@ public static class AnthropicGenerationMapper
             InputTokens = input,
             OutputTokens = output,
             TotalTokens = total,
-            CacheReadInputTokens = ReadLong(usage, "cache_read_input_tokens"),
-            CacheWriteInputTokens = ReadLong(usage, "cache_creation_input_tokens"),
+            CacheReadInputTokens = cacheRead,
+            CacheWriteInputTokens = cacheWrite,
+            InputSemantics = TokenInputSemantics.Inclusive,
         };
     }
 

--- a/dotnet/src/Grafana.Agento11y.Gemini/GeminiGenerationMapper.cs
+++ b/dotnet/src/Grafana.Agento11y.Gemini/GeminiGenerationMapper.cs
@@ -490,6 +490,9 @@ public static class GeminiGenerationMapper
         var reasoningTokens = usage.ThoughtsTokenCount ?? 0;
         var totalTokens = usage.TotalTokenCount ?? (inputTokens + outputTokens + toolUsePromptTokens + reasoningTokens);
 
+        // PromptTokenCount already includes CachedContentTokenCount: inclusive
+        // as-is. tool_use_prompt handling stays unchanged pending the open
+        // contract decision (see the rollout plan).
         return new TokenUsage
         {
             InputTokens = inputTokens,
@@ -497,6 +500,7 @@ public static class GeminiGenerationMapper
             TotalTokens = totalTokens,
             CacheReadInputTokens = usage.CachedContentTokenCount ?? 0,
             ReasoningTokens = reasoningTokens,
+            InputSemantics = TokenInputSemantics.Inclusive,
         };
     }
 

--- a/dotnet/src/Grafana.Agento11y.OpenAI/OpenAIGenerationMapper.cs
+++ b/dotnet/src/Grafana.Agento11y.OpenAI/OpenAIGenerationMapper.cs
@@ -1001,6 +1001,7 @@ public static class OpenAIGenerationMapper
             return new TokenUsage();
         }
 
+        // OpenAI token totals already include cached tokens: inclusive as-is.
         var mapped = new TokenUsage
         {
             InputTokens = usage.InputTokenCount,
@@ -1008,6 +1009,7 @@ public static class OpenAIGenerationMapper
             TotalTokens = usage.TotalTokenCount,
             CacheReadInputTokens = usage.InputTokenDetails?.CachedTokenCount ?? 0,
             ReasoningTokens = usage.OutputTokenDetails?.ReasoningTokenCount ?? 0,
+            InputSemantics = TokenInputSemantics.Inclusive,
         };
         if (mapped.TotalTokens == 0)
         {
@@ -1406,6 +1408,7 @@ public static class OpenAIGenerationMapper
             return new TokenUsage();
         }
 
+        // OpenAI token totals already include cached tokens: inclusive as-is.
         var mapped = new TokenUsage
         {
             InputTokens = usage.InputTokenCount,
@@ -1413,6 +1416,7 @@ public static class OpenAIGenerationMapper
             TotalTokens = usage.TotalTokenCount,
             CacheReadInputTokens = usage.InputTokenDetails?.CachedTokenCount ?? 0,
             ReasoningTokens = usage.OutputTokenDetails?.ReasoningTokenCount ?? 0,
+            InputSemantics = TokenInputSemantics.Inclusive,
         };
 
         if (mapped.TotalTokens == 0)

--- a/dotnet/tests/Grafana.Agento11y.Anthropic.Tests/AnthropicConformanceTests.cs
+++ b/dotnet/tests/Grafana.Agento11y.Anthropic.Tests/AnthropicConformanceTests.cs
@@ -40,9 +40,13 @@ public sealed class AnthropicConformanceTests
         Assert.Equal(2L, ReadMetadataLong(generation, "agento11y.gen_ai.usage.server_tool_use.web_search_requests"));
         var webFetchRequests = TryReadMetadataLong(generation, "agento11y.gen_ai.usage.server_tool_use.web_fetch_requests") ?? 0L;
         Assert.Equal(2L + webFetchRequests, ReadMetadataLong(generation, "agento11y.gen_ai.usage.server_tool_use.total_requests"));
-        Assert.Equal(162, generation.Usage.TotalTokens);
+        // Inclusive contract: input sums Anthropic's additive buckets up
+        // (120 + 30 + 10 = 160); total = input + output.
+        Assert.Equal(160, generation.Usage.InputTokens);
+        Assert.Equal(202, generation.Usage.TotalTokens);
         Assert.Equal(30, generation.Usage.CacheReadInputTokens);
         Assert.Equal(10, generation.Usage.CacheWriteInputTokens);
+        Assert.Equal(TokenInputSemantics.Inclusive, generation.Usage.InputSemantics);
         Assert.Empty(generation.Artifacts);
     }
 
@@ -68,7 +72,9 @@ public sealed class AnthropicConformanceTests
         Assert.Equal(3L, ReadMetadataLong(generation, "agento11y.gen_ai.usage.server_tool_use.web_search_requests"));
         var streamWebFetchRequests = TryReadMetadataLong(generation, "agento11y.gen_ai.usage.server_tool_use.web_fetch_requests") ?? 0L;
         Assert.Equal(3L + streamWebFetchRequests, ReadMetadataLong(generation, "agento11y.gen_ai.usage.server_tool_use.total_requests"));
-        Assert.Equal(105, generation.Usage.TotalTokens);
+        // Inclusive contract: input = 80 + 8 read + 4 creation = 92; total = 92 + 25.
+        Assert.Equal(117, generation.Usage.TotalTokens);
+        Assert.Equal(TokenInputSemantics.Inclusive, generation.Usage.InputSemantics);
         Assert.Contains(generation.Artifacts, artifact => artifact.Kind == ArtifactKind.ProviderEvent);
     }
 

--- a/go-providers/anthropic/conformance_test.go
+++ b/go-providers/anthropic/conformance_test.go
@@ -276,7 +276,11 @@ func TestConformance_MessageSyncNormalization(t *testing.T) {
 	if generation.StopReason != "end_turn" {
 		t.Fatalf("unexpected stop reason: %q", generation.StopReason)
 	}
-	if generation.Usage.TotalTokens != 162 || generation.Usage.CacheReadInputTokens != 30 || generation.Usage.CacheWriteInputTokens != 10 {
+	// Inclusive contract: input = 120 + 30 + 10 summed up per the semconv
+	// Anthropic rule; total = input + output.
+	if generation.Usage.InputTokens != 160 || generation.Usage.TotalTokens != 202 ||
+		generation.Usage.CacheReadInputTokens != 30 || generation.Usage.CacheWriteInputTokens != 10 ||
+		generation.Usage.InputSemantics != agento11y.TokenInputSemanticsInclusive {
 		t.Fatalf("unexpected usage mapping: %#v", generation.Usage)
 	}
 	if generation.ThinkingEnabled == nil || !*generation.ThinkingEnabled {

--- a/go-providers/anthropic/mapper.go
+++ b/go-providers/anthropic/mapper.go
@@ -509,22 +509,29 @@ func mapSystemPrompt(system []asdk.BetaTextBlockParam) string {
 }
 
 func mapUsage(usage asdk.BetaUsage) agento11y.TokenUsage {
+	// Anthropic reports input_tokens exclusive of both cache buckets. The OTel
+	// GenAI Anthropic page requires summing them into gen_ai.usage.input_tokens,
+	// which is the inclusive contract this SDK emits.
+	inputTokens := usage.InputTokens + usage.CacheReadInputTokens + usage.CacheCreationInputTokens
 	return agento11y.TokenUsage{
-		InputTokens:           usage.InputTokens,
+		InputTokens:           inputTokens,
 		OutputTokens:          usage.OutputTokens,
-		TotalTokens:           usage.InputTokens + usage.OutputTokens,
+		TotalTokens:           inputTokens + usage.OutputTokens,
 		CacheReadInputTokens:  usage.CacheReadInputTokens,
 		CacheWriteInputTokens: usage.CacheCreationInputTokens,
+		InputSemantics:        agento11y.TokenInputSemanticsInclusive,
 	}
 }
 
 func mapDeltaUsage(usage asdk.BetaMessageDeltaUsage) agento11y.TokenUsage {
+	inputTokens := usage.InputTokens + usage.CacheReadInputTokens + usage.CacheCreationInputTokens
 	return agento11y.TokenUsage{
-		InputTokens:           usage.InputTokens,
+		InputTokens:           inputTokens,
 		OutputTokens:          usage.OutputTokens,
-		TotalTokens:           usage.InputTokens + usage.OutputTokens,
+		TotalTokens:           inputTokens + usage.OutputTokens,
 		CacheReadInputTokens:  usage.CacheReadInputTokens,
 		CacheWriteInputTokens: usage.CacheCreationInputTokens,
+		InputSemantics:        agento11y.TokenInputSemanticsInclusive,
 	}
 }
 

--- a/go-providers/anthropic/mapper_test.go
+++ b/go-providers/anthropic/mapper_test.go
@@ -69,14 +69,23 @@ func TestFromRequestResponse(t *testing.T) {
 	if generation.SystemPrompt != "Be precise." {
 		t.Fatalf("unexpected system prompt: %q", generation.SystemPrompt)
 	}
-	if generation.Usage.TotalTokens != 162 {
-		t.Fatalf("expected total tokens 162, got %d", generation.Usage.TotalTokens)
+	// Inclusive contract: input sums Anthropic's additive buckets up
+	// (raw input 120 + cache_read 30 + cache_creation 10 = 160), and
+	// total = input + output.
+	if generation.Usage.InputTokens != 160 {
+		t.Fatalf("expected input tokens 160, got %d", generation.Usage.InputTokens)
+	}
+	if generation.Usage.TotalTokens != 202 {
+		t.Fatalf("expected total tokens 202, got %d", generation.Usage.TotalTokens)
 	}
 	if generation.Usage.CacheReadInputTokens != 30 {
 		t.Fatalf("expected cache read input tokens 30, got %d", generation.Usage.CacheReadInputTokens)
 	}
 	if generation.Usage.CacheWriteInputTokens != 10 {
 		t.Fatalf("expected cache write tokens 10, got %d", generation.Usage.CacheWriteInputTokens)
+	}
+	if generation.Usage.InputSemantics != agento11y.TokenInputSemanticsInclusive {
+		t.Fatalf("expected inclusive input semantics, got %v", generation.Usage.InputSemantics)
 	}
 	if generation.MaxTokens == nil || *generation.MaxTokens != 512 {
 		t.Fatalf("expected max tokens 512, got %v", generation.MaxTokens)
@@ -304,8 +313,11 @@ func TestFromStream(t *testing.T) {
 	if generation.ResponseModel != "claude-sonnet-4-5" {
 		t.Fatalf("expected response model claude-sonnet-4-5, got %q", generation.ResponseModel)
 	}
-	if generation.Usage.TotalTokens != 105 {
-		t.Fatalf("expected total tokens 105, got %d", generation.Usage.TotalTokens)
+	if generation.Usage.TotalTokens != 117 {
+		t.Fatalf("expected total tokens 117, got %d", generation.Usage.TotalTokens)
+	}
+	if generation.Usage.InputSemantics != agento11y.TokenInputSemanticsInclusive {
+		t.Fatalf("expected inclusive input semantics, got %v", generation.Usage.InputSemantics)
 	}
 	if generation.MaxTokens == nil || *generation.MaxTokens != 512 {
 		t.Fatalf("expected max tokens 512, got %v", generation.MaxTokens)

--- a/go-providers/gemini/mapper.go
+++ b/go-providers/gemini/mapper.go
@@ -327,12 +327,16 @@ func mapUsage(usage *genai.GenerateContentResponseUsageMetadata) agento11y.Token
 		totalTokens = int64(usage.PromptTokenCount) + int64(usage.CandidatesTokenCount) + toolUsePromptTokens + reasoningTokens
 	}
 
+	// Gemini's promptTokenCount already includes cachedContentTokenCount,
+	// which is the inclusive contract as-is. tool_use_prompt tokens stay out
+	// of input pending the open contract decision (see the rollout plan).
 	return agento11y.TokenUsage{
 		InputTokens:          int64(usage.PromptTokenCount),
 		OutputTokens:         int64(usage.CandidatesTokenCount),
 		TotalTokens:          totalTokens,
 		CacheReadInputTokens: int64(usage.CachedContentTokenCount),
 		ReasoningTokens:      reasoningTokens,
+		InputSemantics:       agento11y.TokenInputSemanticsInclusive,
 	}
 }
 

--- a/go-providers/openai/mapper.go
+++ b/go-providers/openai/mapper.go
@@ -326,12 +326,15 @@ func marshalFunctionSchema(function shared.FunctionDefinitionParam) []byte {
 }
 
 func mapUsage(usage osdk.CompletionUsage) agento11y.TokenUsage {
+	// OpenAI's prompt_tokens already includes cached tokens, which is the
+	// inclusive contract as-is.
 	return agento11y.TokenUsage{
 		InputTokens:          usage.PromptTokens,
 		OutputTokens:         usage.CompletionTokens,
 		TotalTokens:          usage.TotalTokens,
 		CacheReadInputTokens: usage.PromptTokensDetails.CachedTokens,
 		ReasoningTokens:      usage.CompletionTokensDetails.ReasoningTokens,
+		InputSemantics:       agento11y.TokenInputSemanticsInclusive,
 	}
 }
 

--- a/go-providers/openai/responses_mapper.go
+++ b/go-providers/openai/responses_mapper.go
@@ -499,12 +499,15 @@ func mapResponsesTools(value any) []agento11y.ToolDefinition {
 }
 
 func mapResponsesUsage(usage responses.ResponseUsage) agento11y.TokenUsage {
+	// The Responses API input_tokens already includes cached tokens, which is
+	// the inclusive contract as-is.
 	return agento11y.TokenUsage{
 		InputTokens:          usage.InputTokens,
 		OutputTokens:         usage.OutputTokens,
 		TotalTokens:          usage.TotalTokens,
 		CacheReadInputTokens: usage.InputTokensDetails.CachedTokens,
 		ReasoningTokens:      usage.OutputTokensDetails.ReasoningTokens,
+		InputSemantics:       agento11y.TokenInputSemanticsInclusive,
 	}
 }
 

--- a/java/providers/anthropic/src/main/java/com/grafana/agento11y/sdk/providers/anthropic/AnthropicAdapter.java
+++ b/java/providers/anthropic/src/main/java/com/grafana/agento11y/sdk/providers/anthropic/AnthropicAdapter.java
@@ -425,18 +425,21 @@ public final class AnthropicAdapter {
 
     private static TokenUsage mapUsage(Message response) {
         var usage = response.usage();
-        long input = usage.inputTokens();
         long output = usage.outputTokens();
-        long total = input + output;
         long cacheRead = usage.cacheReadInputTokens().orElse(0L);
         long cacheWrite = usage.cacheCreationInputTokens().orElse(0L);
+        // Anthropic reports input_tokens exclusive of both cache buckets. The
+        // OTel GenAI Anthropic rule requires summing them into the inclusive
+        // input_tokens this SDK emits.
+        long input = usage.inputTokens() + cacheRead + cacheWrite;
 
         return new TokenUsage()
                 .setInputTokens(input)
                 .setOutputTokens(output)
-                .setTotalTokens(total == 0 ? input + output : total)
+                .setTotalTokens(input + output)
                 .setCacheReadInputTokens(cacheRead)
-                .setCacheWriteInputTokens(cacheWrite);
+                .setCacheWriteInputTokens(cacheWrite)
+                .setInputSemantics(TokenUsage.TokenInputSemantics.INCLUSIVE);
     }
 
     private static String extractDeltaText(RawMessageStreamEvent event) {

--- a/java/providers/gemini/src/main/java/com/grafana/agento11y/sdk/providers/gemini/GeminiAdapter.java
+++ b/java/providers/gemini/src/main/java/com/grafana/agento11y/sdk/providers/gemini/GeminiAdapter.java
@@ -537,12 +537,16 @@ public final class GeminiAdapter {
             total = input + output + toolUsePrompt + reasoning;
         }
 
+        // promptTokenCount already includes cachedContentTokenCount: inclusive
+        // as-is. tool_use_prompt handling stays unchanged pending the open
+        // contract decision (see the rollout plan).
         return new TokenUsage()
                 .setInputTokens(input)
                 .setOutputTokens(output)
                 .setTotalTokens(total)
                 .setCacheReadInputTokens(cacheRead)
-                .setReasoningTokens(reasoning);
+                .setReasoningTokens(reasoning)
+                .setInputSemantics(TokenUsage.TokenInputSemantics.INCLUSIVE);
     }
 
     private static String normalizeStopReason(Map<String, Object> responsePayload) {

--- a/java/providers/openai/src/main/java/com/grafana/agento11y/sdk/providers/openai/OpenAiGenerationMapper.java
+++ b/java/providers/openai/src/main/java/com/grafana/agento11y/sdk/providers/openai/OpenAiGenerationMapper.java
@@ -752,7 +752,9 @@ final class OpenAiGenerationMapper {
                 .setOutputTokens(defaultLong(asLong(getFirst(usage, "completion_tokens", "completionTokens"))))
                 .setTotalTokens(defaultLong(asLong(getFirst(usage, "total_tokens", "totalTokens"))))
                 .setCacheReadInputTokens(defaultLong(asLong(getFirst(promptDetails, "cached_tokens", "cachedTokens"))))
-                .setReasoningTokens(defaultLong(asLong(getFirst(completionDetails, "reasoning_tokens", "reasoningTokens"))));
+                .setReasoningTokens(defaultLong(asLong(getFirst(completionDetails, "reasoning_tokens", "reasoningTokens"))))
+                // OpenAI's prompt_tokens already includes cached tokens: inclusive as-is.
+                .setInputSemantics(TokenUsage.TokenInputSemantics.INCLUSIVE);
     }
 
     private static TokenUsage mapResponsesUsage(Map<String, Object> usage) {
@@ -766,7 +768,9 @@ final class OpenAiGenerationMapper {
                 .setOutputTokens(defaultLong(asLong(getFirst(usage, "output_tokens", "outputTokens"))))
                 .setTotalTokens(defaultLong(asLong(getFirst(usage, "total_tokens", "totalTokens"))))
                 .setCacheReadInputTokens(defaultLong(asLong(getFirst(inputDetails, "cached_tokens", "cachedTokens"))))
-                .setReasoningTokens(defaultLong(asLong(getFirst(outputDetails, "reasoning_tokens", "reasoningTokens"))));
+                .setReasoningTokens(defaultLong(asLong(getFirst(outputDetails, "reasoning_tokens", "reasoningTokens"))))
+                // The Responses API input_tokens already includes cached tokens: inclusive as-is.
+                .setInputSemantics(TokenUsage.TokenInputSemantics.INCLUSIVE);
     }
 
     private static String firstChoiceFinishReason(Map<String, Object> responsePayload) {

--- a/js/src/providers/anthropic.ts
+++ b/js/src/providers/anthropic.ts
@@ -402,11 +402,18 @@ function mapAnthropicUsage(rawUsage: unknown): TokenUsage | undefined {
     return undefined;
   }
 
-  const inputTokens = readIntFromAny(rawUsage.input_tokens);
+  const rawInputTokens = readIntFromAny(rawUsage.input_tokens);
   const outputTokens = readIntFromAny(rawUsage.output_tokens);
   const totalTokens = readIntFromAny(rawUsage.total_tokens);
   const cacheReadInputTokens = readIntFromAny(rawUsage.cache_read_input_tokens);
   const cacheWriteInputTokens = readIntFromAny(rawUsage.cache_creation_input_tokens);
+  // Anthropic reports input_tokens exclusive of both cache buckets. The OTel
+  // GenAI Anthropic rule requires summing them into the inclusive
+  // input_tokens this SDK emits.
+  const inputTokens =
+    rawInputTokens !== undefined || cacheReadInputTokens !== undefined || cacheWriteInputTokens !== undefined
+      ? (rawInputTokens ?? 0) + (cacheReadInputTokens ?? 0) + (cacheWriteInputTokens ?? 0)
+      : undefined;
 
   const out: TokenUsage = {};
   if (inputTokens !== undefined) {
@@ -426,8 +433,12 @@ function mapAnthropicUsage(rawUsage: unknown): TokenUsage | undefined {
   if (cacheWriteInputTokens !== undefined) {
     out.cacheWriteInputTokens = cacheWriteInputTokens;
   }
+  if (Object.keys(out).length === 0) {
+    return undefined;
+  }
+  out.inputSemantics = 'inclusive';
 
-  return Object.keys(out).length > 0 ? out : undefined;
+  return out;
 }
 
 function anthropicUsageMetadata(rawUsage: unknown): Record<string, unknown> | undefined {

--- a/js/src/providers/gemini.ts
+++ b/js/src/providers/gemini.ts
@@ -532,8 +532,15 @@ function mapGeminiUsage(rawUsage: unknown): TokenUsage | undefined {
   if (reasoningTokens !== undefined) {
     out.reasoningTokens = reasoningTokens;
   }
+  if (Object.keys(out).length === 0) {
+    return undefined;
+  }
+  // Gemini's promptTokenCount already includes cachedContentTokenCount, which
+  // is the inclusive contract as-is. tool_use_prompt handling stays unchanged
+  // pending the open contract decision (see the rollout plan).
+  out.inputSemantics = 'inclusive';
 
-  return Object.keys(out).length > 0 ? out : undefined;
+  return out;
 }
 
 function geminiUsageMetadata(rawUsage: unknown): Record<string, unknown> | undefined {

--- a/js/src/providers/openai.ts
+++ b/js/src/providers/openai.ts
@@ -698,8 +698,14 @@ function mapChatUsage(usage: unknown): TokenUsage | undefined {
   if (reasoningTokens !== undefined) {
     out.reasoningTokens = reasoningTokens;
   }
+  if (Object.keys(out).length === 0) {
+    return undefined;
+  }
+  // OpenAI's prompt/input token totals already include cached tokens, which
+  // is the inclusive contract as-is.
+  out.inputSemantics = 'inclusive';
 
-  return Object.keys(out).length > 0 ? out : undefined;
+  return out;
 }
 
 function firstFinishReason(response: ChatResponse): string | undefined {
@@ -966,8 +972,14 @@ function mapResponsesUsage(value: unknown): TokenUsage | undefined {
   if (reasoningTokens !== undefined) {
     out.reasoningTokens = reasoningTokens;
   }
+  if (Object.keys(out).length === 0) {
+    return undefined;
+  }
+  // OpenAI's prompt/input token totals already include cached tokens, which
+  // is the inclusive contract as-is.
+  out.inputSemantics = 'inclusive';
 
-  return Object.keys(out).length > 0 ? out : undefined;
+  return out;
 }
 
 function normalizeResponsesStopReason(response: ResponsesResponse): string | undefined {

--- a/js/test/providers.test.mjs
+++ b/js/test/providers.test.mjs
@@ -713,6 +713,39 @@ test('provider wrappers surface mapper failures when provider payloads are missi
   }
 });
 
+test('anthropic usage sums cache buckets into inclusive input and marks semantics', async () => {
+  const generation = await captureSingleGeneration(async (client) => {
+    await anthropic.messages.create(
+      client,
+      {
+        model: 'claude-sonnet-4-5',
+        max_tokens: 64,
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+      },
+      async () => ({
+        id: 'msg_inclusive',
+        model: 'claude-sonnet-4-5',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'ok' }],
+        usage: {
+          input_tokens: 100,
+          output_tokens: 20,
+          cache_read_input_tokens: 30,
+          cache_creation_input_tokens: 10,
+        },
+      }),
+    );
+  });
+
+  // OTel GenAI Anthropic rule: input sums the additive buckets up
+  // (100 + 30 + 10); total = input + output.
+  assert.equal(generation.usage.inputTokens, 140);
+  assert.equal(generation.usage.cacheReadInputTokens, 30);
+  assert.equal(generation.usage.cacheWriteInputTokens, 10);
+  assert.equal(generation.usage.totalTokens, 160);
+  assert.equal(generation.usage.inputSemantics, 'inclusive');
+});
+
 test('anthropic provider namespace explicitly has no embeddings surface', () => {
   assert.ok(anthropic.messages);
   assert.equal(anthropic.embeddings, undefined);

--- a/python/agento11y/usage.py
+++ b/python/agento11y/usage.py
@@ -5,13 +5,34 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from .models import TokenUsage
+from .models import TokenInputSemantics, TokenUsage
 
 
 def from_anthropic(raw: Any) -> TokenUsage:
-    """Extract usage from Anthropic's flat field layout."""
+    """Extract usage from Anthropic's flat field layout.
+
+    Anthropic reports ``input_tokens`` exclusive of both cache buckets. The
+    OTel GenAI Anthropic rule requires summing them into the inclusive
+    ``input_tokens`` this SDK emits, so this extractor normalizes up and
+    marks the result. Only call it for payloads positively identified as
+    Anthropic; guessed flat shapes go through ``map_usage``'s raw fallback.
+    """
     if raw is None:
         return TokenUsage()
+    flat = _flat_raw_usage(raw)
+    input_tokens = flat.input_tokens + flat.cache_read_input_tokens + flat.cache_write_input_tokens
+    return TokenUsage(
+        input_tokens=input_tokens,
+        output_tokens=flat.output_tokens,
+        total_tokens=flat.total_tokens,
+        cache_read_input_tokens=flat.cache_read_input_tokens,
+        cache_write_input_tokens=flat.cache_write_input_tokens,
+        input_semantics=TokenInputSemantics.INCLUSIVE,
+    ).normalize()
+
+
+def _flat_raw_usage(raw: Any) -> TokenUsage:
+    """Read Anthropic-named flat keys verbatim: no normalization, no marker."""
     cache_write_raw = _read(raw, "cache_write_input_tokens")
     cache_write = (
         _as_int(cache_write_raw)
@@ -26,7 +47,7 @@ def from_anthropic(raw: Any) -> TokenUsage:
         total_tokens=_as_int(_read(raw, "total_tokens")),
         cache_read_input_tokens=_as_int(_read(raw, "cache_read_input_tokens")),
         cache_write_input_tokens=cache_write,
-    ).normalize()
+    )
 
 
 def from_openai_chat(raw: Any) -> TokenUsage:
@@ -46,6 +67,8 @@ def from_openai_chat(raw: Any) -> TokenUsage:
         reasoning_tokens=_as_int(
             _read(_read(raw, "completion_tokens_details"), "reasoning_tokens"),
         ),
+        # prompt_tokens already includes cached tokens: inclusive as-is.
+        input_semantics=TokenInputSemantics.INCLUSIVE,
     ).normalize()
 
 
@@ -63,6 +86,8 @@ def from_openai_responses(raw: Any) -> TokenUsage:
         reasoning_tokens=_as_int(
             _read(_read(raw, "output_tokens_details"), "reasoning_tokens"),
         ),
+        # input_tokens already includes cached tokens: inclusive as-is.
+        input_semantics=TokenInputSemantics.INCLUSIVE,
     ).normalize()
 
 
@@ -97,6 +122,7 @@ def from_gemini(raw: Any) -> TokenUsage:
         cache_read_input_tokens=_as_int(_read(raw, "cached_content_token_count")),
         cache_write_input_tokens=cache_write,
         reasoning_tokens=reasoning_tokens,
+        input_semantics=TokenInputSemantics.INCLUSIVE,
     )
 
 
@@ -151,7 +177,11 @@ def map_usage(raw: Any) -> TokenUsage:
         return from_openai_responses(raw)
 
     if _read(raw, "input_tokens") is not None:
-        return from_anthropic(raw)
+        # A flat input_tokens key is a guess, not a verified Anthropic payload:
+        # an unknown provider could already report inclusively, so neither the
+        # Anthropic sum-up nor the marker may be applied here. Provider-raw,
+        # UNSPECIFIED semantics; consumers fall back to provider heuristics.
+        return _flat_raw_usage(raw).normalize()
 
     return from_generic(raw)
 

--- a/python/tests/test_usage.py
+++ b/python/tests/test_usage.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
-from agento11y.models import TokenUsage
+from agento11y.models import TokenInputSemantics, TokenUsage
 from agento11y.usage import (
     from_anthropic,
     from_gemini,
@@ -27,13 +27,16 @@ class TestFromAnthropic:
             "cache_creation_input_tokens": 3,
         }
         usage = from_anthropic(raw)
-        assert usage.input_tokens == 100
+        # Inclusive contract: input sums Anthropic's additive buckets up
+        # (100 + 10 read + 5 write = 115); total = input + output.
+        assert usage.input_tokens == 115
         assert usage.output_tokens == 50
-        assert usage.total_tokens == 150  # normalized
+        assert usage.total_tokens == 165  # normalized
         assert usage.cache_read_input_tokens == 10
         # When both upstream fields are present, prefer cache_write_input_tokens.
         assert usage.cache_write_input_tokens == 5
         assert usage.reasoning_tokens == 0
+        assert usage.input_semantics == TokenInputSemantics.INCLUSIVE
 
     def test_cache_creation_only_maps_to_cache_write(self):
         raw = {
@@ -84,9 +87,10 @@ class TestFromAnthropic:
             cache_creation_input_tokens=7,
         )
         usage = from_anthropic(raw)
-        assert usage.input_tokens == 80
+        # 80 + 15 read + 7 creation summed up into inclusive input.
+        assert usage.input_tokens == 102
         assert usage.output_tokens == 40
-        assert usage.total_tokens == 120
+        assert usage.total_tokens == 142
         assert usage.cache_read_input_tokens == 15
         assert usage.cache_write_input_tokens == 7
 


### PR DESCRIPTION
## Summary

Phase 1 (providers) of the [OTel-inclusive token contract](https://github.com/grafana/sigil/blob/main/docs/design-docs/2026-08-04-otel-inclusive-token-semantics.md) — the first PR where numbers actually change:

- **Anthropic** (5 languages, sync + stream): `input_tokens` sums the additive cache buckets up per the [semconv Anthropic rule](https://github.com/open-telemetry/semantic-conventions-genai/blob/9af08349db7e70b2528accde90bae81d4ebcfa1e/docs/gen-ai/anthropic.md#L147-L151); `total = input + output`; marked `INCLUSIVE`.
- **OpenAI** (chat + responses) and **Gemini**: provider totals already include cached tokens — numbers pass through unchanged, marked `INCLUSIVE`.
- **Gemini `tool_use_prompt`**: deliberately untouched — that's the open contract decision in the rollout plan; the existing cross-language divergence stays visible until the team answers it.
- **Guessed shapes stay unmarked**: Python's `map_usage` flat-key catch-all no longer routes through `from_anthropic` (a guessed payload must get neither the sum-up nor the marker); it reads the flat keys verbatim and stays `UNSPECIFIED`, preserving main's behavior for framework payloads.

Frameworks and coding-agent plugins are the next (final) phase-1 PR.

## Deploy note

Per the rollout plan, **Sigil consumes the marker before this releases** — an inclusive-marked Anthropic generation under today's additive summation would double-count.

## Test plan

- [x] Go: core module + all three provider suites (Anthropic conformance updated: 120+30+10 → input 160, total 202; stream 105 → 117)
- [x] Python: core 549 + anthropic/openai/gemini provider suites + langchain/claude-agent-sdk framework suites (catch-all behavior pinned); ruff clean
- [x] JS: 642 passed incl. a new wrapper test pinning the Anthropic sum end to end; biome clean
- [ ] Java / .NET: expectations updated to the same fixture arithmetic; conformance runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)