### PR TITLE
fix(python-frameworks/litellm): correct agent identity, output, and grouping

### DIFF
--- a/python-frameworks/litellm/README.md
+++ b/python-frameworks/litellm/README.md
@@ -1,45 +1,72 @@
-# Agent Observability Python Framework Module: LiteLLM
+# Agent Observability for LiteLLM
 
-`agento11y-litellm` is a LiteLLM callback handler that exports generation telemetry to Agent Observability.
+The `agento11y-litellm` package sends what your [LiteLLM](https://docs.litellm.ai/) calls do to Grafana Cloud Agent Observability.
+Register one callback and every completion is exported as a generation, with its messages, tokens, cost, tool calls, and errors.
+Add a second callback and Agent Observability guards can block a request before it reaches the provider.
 
-## Installation
+It works in your own process and inside the LiteLLM proxy.
+Guards need the proxy, because LiteLLM only runs call hooks there.
+
+## Before you begin
+
+You need Python 3.10 or later, and an endpoint, instance ID, and token.
+To enable the product and collect those three values, refer to [Set up Agent Observability](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/get-started/grafana-cloud/).
+
+Install the packages:
 
 ```bash
-pip install agento11y agento11y-litellm
-pip install litellm
+pip install agento11y agento11y-litellm litellm
 ```
 
-## Quickstart
+## Export generations from your app
 
-```python
-import litellm
-from agento11y import Client
-from agento11y_litellm import Agento11yLiteLLMLogger
+The client reads its connection details from the environment, so `Client()` takes no arguments:
 
-client = Client()
-handler = Agento11yLiteLLMLogger(client=client)
-
-litellm.callbacks = [handler]
-
-response = litellm.completion(
-    model="openai/gpt-4o-mini",
-    messages=[{"role": "user", "content": "Hello!"}],
-)
-print(response.choices[0].message.content)
-
-client.shutdown()
+```bash
+export AGENTO11Y_ENDPOINT=https://your-agento11y.grafana.net
+export AGENTO11Y_PROTOCOL=http
+export AGENTO11Y_AUTH_MODE=basic
+export AGENTO11Y_AUTH_TENANT_ID=your-instance-id
+export AGENTO11Y_AUTH_TOKEN=glc_your_token
 ```
 
-## Streaming
+Grafana Cloud needs both `AGENTO11Y_PROTOCOL=http` and `AGENTO11Y_AUTH_MODE=basic`.
+The SDK otherwise defaults to gRPC with no authentication, and a Cloud endpoint then answers `401` with no other signal.
+For content capture, batching, and the rest of the settings, refer to [Configure the Agent Observability SDK](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/configure/sdk/).
+
+To export generations, follow these steps:
+
+1. Create a client and a handler.
+
+   ```python
+   import litellm
+   from agento11y import Client
+   from agento11y_litellm import Agento11yLiteLLMLogger
+
+   client = Client()
+   litellm.callbacks = [Agento11yLiteLLMLogger(client=client, agent_name="my-agent")]
+   ```
+
+1. Call LiteLLM as you normally do.
+
+   ```python
+   response = litellm.completion(
+       model="openai/gpt-4o-mini",
+       messages=[{"role": "user", "content": "Hello!"}],
+   )
+   print(response.choices[0].message.content)
+   ```
+
+1. Flush buffered telemetry before your process exits.
+
+   ```python
+   client.shutdown()
+   ```
+
+Streaming works the same way.
+A streamed call is exported as one generation in `STREAM` mode, carrying the time of the first token:
 
 ```python
-import litellm
-from agento11y import Client
-from agento11y_litellm import Agento11yLiteLLMLogger
-
-client = Client()
-litellm.callbacks = [Agento11yLiteLLMLogger(client=client)]
-
 response = litellm.completion(
     model="openai/gpt-4o-mini",
     messages=[{"role": "user", "content": "Give me three reliability tips."}],
@@ -49,32 +76,33 @@ for chunk in response:
     content = chunk.choices[0].delta.content
     if content:
         print(content, end="", flush=True)
-print()
-
-client.shutdown()
 ```
 
-## Configuration
+Your generations appear under the agent name you passed.
+To find and read them, refer to [Browse and debug conversations](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/guides/conversations/).
+For every option the handler takes, refer to the [LiteLLM adapter reference](docs/reference.md).
 
-All options are keyword-only on `Agento11yLiteLLMLogger`:
+## Export generations from the LiteLLM proxy
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `client` | `agento11y.Client` | required | agento11y SDK client instance |
-| `capture_inputs` | `bool` | `True` | Record input messages |
-| `capture_outputs` | `bool` | `True` | Record output messages |
-| `agent_name` | `str` | `""` | Fallback agent name, used when the request carries no agent identity (see below for per-request) |
-| `agent_name_metadata_keys` | `Sequence[str]` | `("agent_name", "agent_id")` | Metadata keys consulted, in order, to name the agent |
-| `agent_version` | `str` | `""` | Default agent version (see below for per-request) |
-| `conversation_id` | `str` | `""` | Default conversation ID (see below for per-request) |
-| `extra_tags` | `dict[str, str]` | `None` | Additional tags merged into every generation |
-| `extra_metadata` | `dict[str, Any]` | `None` | Additional metadata merged into every generation |
+The proxy loads callbacks by dotted path from a Python file next to `config.yaml`.
+Put a `Client` and a handler in that file, then name the handler in `config.yaml`:
 
-The `create_agento11y_litellm_logger` factory accepts the same parameters.
+```yaml
+litellm_settings:
+  callbacks:
+    - agento11y_callback.agento11y_handler
+```
 
-## Per-Request Metadata
+For the callback file, the Dockerfile, and the `docker run` command, refer to [Deploy in the LiteLLM proxy](docs/reference.md#deploy-in-the-litellm-proxy).
+For a proxy you can start in one command, refer to the [LiteLLM proxy example](example/README.md).
 
-The handler resolves `agent_name`, `agent_version`, and `conversation_id` from per-request LiteLLM metadata, falling back to the static values from handler init. This is useful when multiple agents share a single LiteLLM proxy.
+## Name the calling agent
+
+One proxy usually serves several agents.
+The handler reads the agent name from each request, so each caller gets its own agent in Agent Observability.
+When a request names no agent, the handler falls back to the `agent_name` you configured.
+
+A client that knows about Agent Observability can pass metadata:
 
 ```python
 response = litellm.completion(
@@ -88,9 +116,7 @@ response = litellm.completion(
 )
 ```
 
-For `conversation_id`, the handler also checks `session_id` and `thread_id` metadata keys as fallbacks.
-
-When no `agent_name` is set, the handler falls back to LiteLLM's own `agent_id`, which the proxy fills in from the `x-litellm-agent-id` header or from an `agent_id` on the calling virtual key. Callers behind a proxy are then attributed to themselves without having to know about agento11y:
+A client that doesn't can send the header LiteLLM already understands:
 
 ```bash
 curl http://localhost:4000/v1/chat/completions \
@@ -99,259 +125,70 @@ curl http://localhost:4000/v1/chat/completions \
   -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello!"}]}'
 ```
 
-Metadata is read from `litellm_params["metadata"]`, from `litellm_metadata` (used by assistant and thread routes), and from metadata nested one level deeper under `metadata.metadata` (where the Router puts SDK-supplied metadata). Keys are matched in priority order across all of those, so an `agent_name` in any of them beats an `agent_id` in another.
+Both work on every recorded route.
+To name callers after their virtual key instead, or to learn which metadata containers the adapter reads, refer to [Agent identity](docs/reference.md#agent-identity).
 
-`agent_name_metadata_keys` controls which keys are consulted. Add your own, or LiteLLM's key alias for deployments where one virtual key means one agent:
+## Enforce guards on proxy requests
 
-```python
-from agento11y_litellm import DEFAULT_AGENT_NAME_METADATA_KEYS, Agento11yLiteLLMLogger
+A guard is a rule that runs on the request path and can fail the request.
+`Agento11yLiteLLMGuardrail` evaluates your Agent Observability guards inside the proxy: preflight before the provider is called, postflight against the provider's response.
 
-handler = Agento11yLiteLLMLogger(
-    client=client,
-    agent_name_metadata_keys=(*DEFAULT_AGENT_NAME_METADATA_KEYS, "user_api_key_alias"),
-    agent_name="litellm-proxy",
-)
-```
+Guards live in Agent Observability, not in `config.yaml`.
+To create one, refer to [Set up guards](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/guides/guards/).
 
-A key alias names a credential rather than an agent, so it is not consulted by default: rotating a key would rename the agent, and a shared key would merge unrelated callers. Conversely, pass `("agent_name",)` to ignore LiteLLM's `agent_id` and keep every generation under the static name.
+To enforce them, follow these steps:
 
-## Guards
+1. Enable hooks on the client and build the guardrail next to the handler.
 
-`Agento11yLiteLLMGuardrail` evaluates Agent Observability guards on a proxy request: preflight guards before the request reaches the provider, postflight guards against the provider response. A deny returns HTTP 400 to the caller, including on a request that asked to stream, which is rejected before the first chunk. The one exception is a postflight deny on a streamed response: the output is already delivered, so the verdict is only recorded. It is a `CustomGuardrail`, so it gets LiteLLM's per-request and per-team opt-in, `default_on`, guardrail results in the standard logging payload, and an OTel guardrail span.
+   ```python
+   from agento11y import Client, ClientConfig, HooksConfig
+   from agento11y_litellm import Agento11yLiteLLMGuardrail, Agento11yLiteLLMLogger
 
-Enforcement only works behind the LiteLLM proxy. Call hooks are a proxy-only LiteLLM feature; a direct `litellm.completion()` SDK call never invokes them and is never guarded.
+   client = Client(
+       ClientConfig(
+           hooks=HooksConfig(
+               enabled=True,
+               timeout_seconds=3.0,
+               # Drop "postflight" to evaluate request rules only.
+               phases=["preflight", "postflight"],
+           )
+       )
+   )
 
-`event_hook` selects the phases: `"pre_call"` (the default) for preflight, `"post_call"` for postflight, `["pre_call", "post_call"]` for both. `"during_call"` raises at proxy startup: LiteLLM runs it in parallel with the provider call, so it cannot save spend, and it is never given the response, so all it could do is repeat the preflight check after the call has started.
+   agento11y_handler = Agento11yLiteLLMLogger(client=client, agent_name="litellm-proxy")
+   agento11y_guards = Agento11yLiteLLMGuardrail(
+       client=client,
+       agent_name="litellm-proxy",
+       default_on=True,
+       event_hook=["pre_call", "post_call"],
+   )
+   ```
 
-Guards are configured in Agent Observability, not in `config.yaml`. Refer to [Set up guards](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/guides/guards/) for guard types, priority, and match filters.
+1. List both objects in `config.yaml`.
 
-Evaluator guards work as documented there: preflight sees messages, system prompt, and tool definitions; postflight adds the response. `deny` returns 400 to the proxy client, except for a postflight deny on a streamed response, which is only recorded (see [Postflight](#postflight)); `warn` allows the request and records the verdict. Three things behave differently through this adapter:
+   ```yaml
+   litellm_settings:
+     callbacks:
+       - agento11y_callback.agento11y_handler
+       - agento11y_callback.agento11y_guards
+   ```
 
-- Redact guards change what the model sees, though not on every route and not in every case. The adapter writes a preflight verdict's `transformed_input` into the outgoing body when it can apply the whole transform, and forwards the request as the client sent it when it cannot. Redaction always applies to evaluators in later guards, which run server-side against the redacted input, whether or not the request itself was rewritten. See [Transformed requests](#transformed-requests) for the routes and the cases that skip.
-- Preflight tool filter guards match tool calls that are already in the request history, which means the client has executed them. They block the next call in an agent loop rather than the tool itself. To block a proposed call before the client runs it, put the tool filter guard in the postflight phase, which sees the tool calls the model just produced.
-- `model.provider` match filters are unreliable, because the provider is not known until LiteLLM's router picks a deployment, which happens after the guard runs. Match on `agent_name`, `model.name`, or tags instead.
+1. Send a request that a rule denies, and confirm the proxy answers `400` with the rule's reason.
 
-### Guarded routes
+LiteLLM runs any `CustomGuardrail` in `litellm.callbacks` on both hook paths, so the guardrail needs no separate `guardrails` block.
 
-The guard reads the request body as the client sent it, before LiteLLM translates it to provider format, and every route puts the input somewhere else:
+Three limits are worth knowing before you rely on guards:
 
-| Route | Messages | System prompt |
-|---|---|---|
-| `/v1/chat/completions` | `messages` | `system` and `developer` messages |
-| `/v1/completions` | `prompt` (string or list of strings; token ids carry no text) | none |
-| `/v1/messages` | `messages`, including Anthropic content blocks | top-level `system` |
-| `/v1/responses` | `input` (string or input items) | `instructions` |
-| `/v1/images/generations` | `prompt` | none |
+- A postflight deny can't stop a streamed response, because the caller already has it. Use preflight to block a streaming request.
+- A redact rule rewrites the request all or nothing. When the guardrail can't apply the whole rewrite, it forwards the original and logs a warning starting with `agento11y: skipping`.
+- A deny answers `400` from LiteLLM 1.87.0 on, and `500` before that.
 
-Every other route LiteLLM runs pre-call hooks on is skipped: embeddings, moderation, rerank, audio, realtime, MCP tool calls, and native pass-through endpoints (`/anthropic/v1/messages`, `/vertex_ai/...`). Their bodies are provider-native or carry no messages, so there is nothing for a content or system-prompt rule to match. They are skipped rather than evaluated against empty input, because an evaluation with no input returns allow and records a verdict that reads like a completed check. A skipped request records no verdict at all, and nothing on those routes is ever blocked, including by rules that only match on `agent_name`, `model.name`, or tags.
+For the routes each phase covers, the deny outcome per delivery, and every guardrail option, refer to the [LiteLLM guard reference](docs/guards.md).
 
-Postflight skips the same routes, by a different test. The post-call hook is not given a call type, so the guard reads the request body: a body it cannot take messages, a prompt, or a system prompt from is skipped, which is what a pass-through body looks like (the provider-native payload sits one level down, under `data`).
+## Learn more
 
-A guarded request whose input maps to no text is skipped the same way: a token-id `prompt`, or content that is entirely images or audio.
-
-### Postflight
-
-Postflight guards run after the provider has answered. They see the same request input as preflight plus the response, and they cannot prevent spend: the call is already made and billed by the time the rule runs. Postflight decides whether the output reaches the caller, not whether it costs money.
-
-What a deny does depends on how the response is delivered. This was verified against a running proxy on LiteLLM 1.89.1:
-
-| Delivery | Deny outcome |
-|---|---|
-| Non-streaming (`/v1/chat/completions`, `/v1/responses`, `/v1/messages`) | The caller gets HTTP 400 naming the guardrail and the rule's reason. The provider output never leaves the proxy. |
-| Streaming (`/v1/chat/completions`) | The caller already has the whole response. The verdict is recorded and logged at WARNING; nothing is blocked. |
-| Streaming (`/v1/responses`, `/v1/messages`) | Nothing runs. No hook request, no verdict, no log line. |
-
-Neither streaming case is a configuration choice. On a streamed chat completion LiteLLM flushes every chunk, then runs post-call guardrails on the assembled response (`_run_deferred_stream_guardrails`) and swallows whatever they raise. It attaches that deferred pass only to a `CustomStreamWrapper`, and `/v1/responses` and `/v1/messages` stream through their own iterators, so postflight never runs on them at all. Treat postflight on streaming traffic as detection that feeds evaluation and alerting, not as enforcement, and do not rely on it for those two routes.
-
-Postflight has two independent gates, and both must be open:
-
-- LiteLLM: the guardrail is constructed with `event_hook="post_call"` (or a list containing it). With the default `"pre_call"`, LiteLLM never calls the post-call hook.
-- SDK: `HooksConfig.phases` must contain `"postflight"`. It defaults to `["preflight"]`, and `evaluate_hook` returns allow without contacting the server for a phase that is not listed.
-
-A guardrail whose mode has no matching `HooksConfig.phases` entry logs a WARNING at startup and evaluates nothing for that phase. The request is skipped rather than evaluated, so it records no verdict either.
-
-The response is mapped per route: `choices[].message` for chat completions and for an assembled stream, `output` items for `/v1/responses`, and Anthropic content blocks for `/v1/messages`. Tool calls in the response keep their `tool_call` kind, so a postflight tool filter guard matches them. A response with no mappable text (an embedding, an image, an empty turn) is skipped and records no verdict.
-
-The guard reads the response the provider produced, not the copy LiteLLM logs, so `turn_off_message_logging` does not apply to it. Enabling postflight sends response content to the hooks API even on a deployment that keeps it out of its logs.
-
-Enable hooks on the agento11y client and list the guardrail next to the logger:
-
-```python
-# agento11y_callback.py, next to config.yaml
-from agento11y import Client, ClientConfig, HooksConfig
-from agento11y_litellm import Agento11yLiteLLMGuardrail, Agento11yLiteLLMLogger
-
-client = Client(
-    ClientConfig(
-        hooks=HooksConfig(
-            enabled=True,
-            timeout_seconds=2.0,
-            # Drop "postflight" to run request rules only.
-            phases=["preflight", "postflight"],
-        )
-    )
-)
-
-agento11y_handler = Agento11yLiteLLMLogger(client=client, agent_name="litellm-proxy")
-agento11y_guards = Agento11yLiteLLMGuardrail(
-    client=client,
-    agent_name="litellm-proxy",
-    default_on=True,
-    event_hook=["pre_call", "post_call"],
-)
-```
-
-```yaml
-# config.yaml
-litellm_settings:
-  callbacks:
-    - agento11y_callback.agento11y_handler
-    - agento11y_callback.agento11y_guards
-```
-
-LiteLLM runs any `CustomGuardrail` in `litellm.callbacks` on both the pre-call and post-call paths, so the guardrail needs no separate `guardrails:` block.
-
-With `default_on=False`, a request opts in with `"guardrails": ["agento11y"]` in its metadata.
-
-Lower `HooksConfig.timeout_seconds` from its 15 second default for proxy use. It bounds how long a worker thread stays occupied after the guardrail has already given up on the evaluation.
-
-Guardrail options are keyword-only, and `create_agento11y_litellm_guardrail` accepts the same ones:
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `client` | `agento11y.Client` | required | agento11y SDK client instance, with `hooks.enabled=True` and the phase to evaluate in `hooks.phases` |
-| `agent_name` | `str` | `""` | Fallback agent name when the request carries no agent identity |
-| `agent_name_metadata_keys` | `Sequence[str]` | `("agent_name", "agent_id")` | Metadata keys consulted, in order, to name the agent |
-| `agent_version` | `str` | `""` | Fallback agent version |
-| `max_concurrent_evaluations` | `int` | `32` | Ceiling on hook evaluations in flight at once |
-| `request_timeout_seconds` | `float` | `2.0` | How long the proxy waits for a free thread plus a verdict |
-| `apply_transforms` | `bool` | `True` | Write `transformed_input` from a preflight allow verdict into the outgoing request (see [Transformed requests](#transformed-requests)) |
-| `extra_tags` | `dict[str, str]` | `None` | Additional tags merged into every hook evaluation context |
-| `guardrail_name` | `str` | `"agento11y"` | Name used for per-request opt-in and in the 400 response |
-| `default_on` | `bool` | `False` | Run on every request instead of only on opted-in ones |
-| `event_hook` | `str \| Sequence[str]` | `"pre_call"` | Phases to run: `"pre_call"`, `"post_call"`, or both |
-
-Runtime behavior:
-
-- Evaluation runs on a pool of `max_concurrent_evaluations` threads, so it does not block the proxy event loop. `request_timeout_seconds` covers waiting for a free thread as well as the evaluation itself, and a thread stays busy until its evaluation actually finishes, so a slow evaluator can keep the pool saturated for longer than that timeout.
-- A transport failure, a timeout, or an unexpected error follows `HooksConfig.fail_open`: allow and log at WARNING when `True` (the default), raise `HookTransportError` when `False`. Either way the verdict is recorded as `guardrail_failed_to_respond`, not `success`, so a dead evaluator shows up in spend logs and logging callbacks. Fail-closed costs more on postflight than on preflight: the provider has already answered and billed, and the caller gets HTTP 500 instead of the response.
-- Hook evaluations correlate to the proxy request span, so a guard verdict lines up with its request in traces.
-- Register both the guardrail and the logger. The guardrail does not export generations, and having both in `litellm.callbacks` still exports exactly one generation per request.
-- A non-streaming postflight deny costs a generation record. LiteLLM defers success logging until after post-call guardrails run and drops it when one of them raises, and the failure path does not reach this package's callback either, so the blocked request exports no generation at all. The provider was still called and billed. The verdict itself is in `standard_logging_guardrail_information`. A streamed deny keeps its generation, because nothing is raised there.
-
-### Transformed requests
-
-A preflight redact guard returns the rewritten request as `transformed_input`. The guardrail writes that into a new request body and gives the new body to the proxy. The proxy forwards it to the provider and to any later callback. The deny check runs before the rewrite, so a denied request never reaches the provider, rewritten or not. `apply_transforms=False` turns off the rewrite and leaves the deny check in place.
-
-Only preflight rewrites anything. A postflight transform is ignored: the provider has already answered, and LiteLLM takes no replacement response from the post-call hook.
-
-A redacted system prompt is written back on every route that has a place for one: `system` on `/v1/messages`, `instructions` on `/v1/responses`, and a `system` message on chat routes. `/v1/completions` and `/v1/images/generations` carry a bare `prompt`, so they get no system prompt rewrite.
-
-Redacted messages are written back on chat and `/v1/messages` requests only. `/v1/responses` keeps its input in `input` and the two `prompt` routes keep theirs in `prompt`, and none of those three takes chat messages.
-
-The rewrite changes text and nothing else. Tool calls, tool call ids, images, and an Anthropic `cache_control` breakpoint are copied through, so a message carrying them can still be redacted instead of failing the rewrite.
-
-Reasoning is copied through as well, and that one is a gap. The adapter leaves reasoning as the client sent it, whether it arrived as `reasoning_content` or as a thinking block: a provider validates a reasoning payload against its own signature and rejects a rewritten one. So a redact rule that rewrites the reasoning of an assistant turn has no effect, and a secret in reasoning text reaches the provider even when the same secret is redacted out of the message text.
-
-A rewrite is all or nothing. When the guardrail cannot apply the whole transform, it forwards the request as the client sent it and logs a WARNING from `agento11y_litellm.guard` naming the reason. Nothing marks the generation, so a redact rule whose transform never reached the provider looks the same as a rule that matched and allowed. When you adopt a redact rule, grep the proxy log for `agento11y: skipping`, the prefix every one of these warnings carries.
-
-The rewrite is also skipped when:
-
-- The transform does not line up with the request one to one. The guardrail matches messages by position, so the number of messages, and the number of text values inside each message, have to agree with what the guard evaluated.
-- A system prompt or an Anthropic `tool_result` is spread over more than one content block and a block carries fields of its own. One block is rewritten in place and keeps its fields. More than one has to collapse into a single string, and there is no way to split that string back into per-block values.
-- Every message in the request is a system or developer message. Writing the prompt into one place would leave the message list empty, and every route rejects that.
-
-A rule that rewrites a message or a system prompt to the empty string changes nothing. An empty value cannot be told apart from "no transform" on the wire.
-
-## LiteLLM Proxy (Docker)
-
-When running LiteLLM as a proxy server in Docker, register the handler via a callback file next to your config.
-
-**1. Extend the Docker image:**
-
-```dockerfile
-FROM ghcr.io/berriai/litellm:v1.82.3-stable.patch.2
-RUN pip install agento11y agento11y-litellm
-```
-
-**2. Create a callback file** (`agento11y_callback.py`, same directory as `config.yaml`):
-
-```python
-import os
-
-from agento11y import Client
-from agento11y.config import AuthConfig, ClientConfig, GenerationExportConfig
-from agento11y_litellm import Agento11yLiteLLMLogger
-
-client = Client(ClientConfig(
-    generation_export=GenerationExportConfig(
-        protocol="http",
-        endpoint=os.environ["AGENTO11Y_ENDPOINT"],
-        auth=AuthConfig(
-            mode="basic",
-            tenant_id=os.environ.get("AGENTO11Y_AUTH_TENANT_ID", ""),
-            basic_password=os.environ.get("AGENTO11Y_AUTH_TOKEN", ""),
-        ),
-    ),
-))
-agento11y_handler = Agento11yLiteLLMLogger(
-    client=client,
-    agent_name="litellm-proxy",
-)
-```
-
-**3. Reference it in `config.yaml`:**
-
-```yaml
-model_list:
-  - model_name: gpt-4o-mini
-    litellm_params:
-      model: openai/gpt-4o-mini
-
-litellm_settings:
-  callbacks: agento11y_callback.agento11y_handler
-```
-
-The proxy resolves `agento11y_callback.agento11y_handler` by importing `agento11y_callback.py` from the config directory and using the `agento11y_handler` instance.
-
-**4. Mount both files and run:**
-
-```bash
-docker run -d \
-  -v $(pwd)/config.yaml:/app/config.yaml \
-  -v $(pwd)/agento11y_callback.py:/app/agento11y_callback.py \
-  -e AGENTO11Y_ENDPOINT=https://your-agento11y-endpoint \
-  -e AGENTO11Y_AUTH_TENANT_ID=your-tenant \
-  -e AGENTO11Y_AUTH_TOKEN=your-key \
-  -p 4000:4000 \
-  your-litellm-image \
-  --config /app/config.yaml
-```
-
-The callback file reads connection details from environment variables. Adjust the `AuthConfig` mode to match your deployment (see `agento11y.config` for `tenant`, `bearer`, and `basic` modes).
-
-## Behavior
-
-- Mode mapping: non-stream calls -> `SYNC`, stream calls -> `STREAM` with first-token timestamp.
-- Provider detection: uses `custom_llm_provider` from LiteLLM's standard logging object. A call that fails before the router picks a deployment, for example a budget or auth rejection, has no provider. It is reported under the provider `litellm` instead of being dropped.
-- Model name: a proxied call is reported with the bare model name (`gpt-4o-mini`), not the router deployment string (`openai/gpt-4o-mini`), so cost and catalog lookups match it. The router names are kept in generation metadata under `agento11y.framework.litellm.model`, `.model_group`, and `.model_id`. Embedding spans carry the model name only. An Azure deployment alias (`azure/my-deployment`) is reported as it is, because there is no catalog model with that name.
-- Failed calls are recorded with the error attached via `set_call_error`.
-- Recorded call types:
-  - chat completions (`completion`, `acompletion`)
-  - text completions (`text_completion`, `atext_completion`). The prompt is recorded as a user message. Pre-tokenized prompts (lists of token ids) carry no text and are skipped.
-  - the Responses API (`responses`, `aresponses`, `/v1/responses`). Text, reasoning, and tool calls in the output are recorded. That route has no `finish_reason`, so the stop reason comes from the response `status`: `completed` becomes `stop`, and an incomplete response reports `incomplete_details.reason`.
-  - the Anthropic Messages API (`anthropic_messages`, `aanthropic_messages`, `/v1/messages`)
-- Only text content is recorded. Images, audio, and other non-text parts are skipped. Tool history is recorded in each request shape that carries it: OpenAI-format `tool_calls` and `tool` messages, Anthropic `tool_use` and `tool_result` blocks on `/v1/messages`, and top-level `function_call` and `function_call_output` items in `/v1/responses` input. The remaining Responses input items (`computer_call`, `mcp_call`, `image_generation_call`) are skipped. Tool calls in `/v1/responses` output are recorded.
-- Tool definitions are read from the request `tools` in the OpenAI chat schema (`{"type": "function", "function": {...}}`). The flat Responses API tool schema is not recognized, so those requests report no tool definitions.
-- Embedding call types (`embedding`, `aembedding`) are recorded as OTel embedding spans (no generation export). The span carries input/token counts and dimensions; the input text is attached only when the handler's `capture_inputs` is set and the SDK's `EmbeddingCaptureConfig.capture_input=True`. Embedding spans require a configured OTel tracer.
-- Image generation, audio, and transcription call types are skipped.
-- Framework tags are always set:
-  - `agento11y.framework.name=litellm`
-  - `agento11y.framework.source=handler` (`guardrail` on hook evaluation contexts)
-  - `agento11y.framework.language=python`
-- LiteLLM `request_tags` are forwarded as `litellm.tag.<value>`.
-- Token usage includes detailed breakdowns (cached tokens, reasoning tokens) when the provider returns them.
-- Tool calls and tool results in messages are mapped to agento11y tool call/result parts.
-- Reasoning/thinking text is captured as `THINKING` parts, ordered before the assistant text. It is read from `thinking_blocks` when present (including redacted blocks), otherwise from the flat `reasoning_content` string.
-
-Call `client.shutdown()` during teardown to flush buffered telemetry.
+- [LiteLLM adapter reference](docs/reference.md): options, recorded calls, exported fields, proxy deployment
+- [LiteLLM guard reference](docs/guards.md): phases, guarded routes, deny outcomes, request rewriting
+- [LiteLLM proxy example](example/README.md): a proxy with both callbacks, runnable with no provider key
+- [Instrument Python agents](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/get-started/python/): the SDK on its own, without LiteLLM
+- [Agent Observability documentation](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/)

--- a/python-frameworks/litellm/agento11y_litellm/guard.py
+++ b/python-frameworks/litellm/agento11y_litellm/guard.py
@@ -44,12 +44,11 @@ from .handler import (
     _extract_text_content,
     _first_metadata_value,
     _map_messages,
-    _map_response_output,
-    _map_responses_output,
     _map_tools_list,
     _metadata_sources_from,
     _request_tags_from,
     _resolve_conversation_id_from,
+    _select_output_mappers,
 )
 
 if TYPE_CHECKING:
@@ -680,14 +679,15 @@ def _map_output_messages(response: Any) -> list[Message]:
     (LiteLLM normalizes that one to chat shape for logging, but not here).
 
     The shape is read off the payload rather than off a call type, because this
-    hook is not given one.
+    hook is not given one. The logger shares the rule through
+    ``_select_output_mappers``, so a guard verdict and the exported generation
+    read one response the same way.
     """
     payload = _response_payload(response)
     if payload is None:
         return []
-    if isinstance(payload, dict) and not payload.get("choices") and isinstance(payload.get("output"), list):
-        return _map_responses_output(payload)
-    return _map_response_output(payload)
+    map_output, _ = _select_output_mappers("", payload)
+    return map_output(payload)
 
 
 def _response_payload(response: Any) -> Any:

--- a/python-frameworks/litellm/agento11y_litellm/handler.py
+++ b/python-frameworks/litellm/agento11y_litellm/handler.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from datetime import datetime, timezone
 from typing import Any
 
@@ -29,6 +29,10 @@ from agento11y.usage import map_usage
 from litellm.integrations.custom_logger import CustomLogger
 
 logger = logging.getLogger(__name__)
+
+# Signatures of the two payload readers ``_select_output_mappers`` returns.
+OutputMapper = Callable[[Any], list[Message]]
+StopReasonReader = Callable[[Any], str]
 
 _CHAT_CALL_TYPES = frozenset(
     {
@@ -538,6 +542,56 @@ def _extract_responses_stop_reason(response: Any) -> str:
     return status
 
 
+def _select_output_mappers(call_type: str, response: Any) -> tuple[OutputMapper, StopReasonReader]:
+    """Pick the output mapper and stop-reason reader for a logged payload.
+
+    The payload shape decides, and the call type is only the fallback for a
+    payload that shows neither shape. LiteLLM serves ``/v1/responses`` on a
+    provider with no native Responses API by bridging the call to chat
+    completions, and it then logs the chat ``ModelResponse`` under call type
+    ``aresponses``. Reading that payload with the Responses mappers finds no
+    ``output`` list and no ``status``, so the generation used to export with no
+    output and no stop reason for every non-OpenAI provider.
+
+    ``choices`` wins over ``output``: a chat payload is unambiguous, while a
+    Responses payload has no ``choices`` at all.
+    """
+    if isinstance(response, dict):
+        if response.get("choices") is not None:
+            return _map_response_output, _extract_stop_reason
+        if isinstance(response.get("output"), list):
+            return _map_responses_output, _extract_responses_stop_reason
+    if call_type in _RESPONSES_CALL_TYPES:
+        return _map_responses_output, _extract_responses_stop_reason
+    return _map_response_output, _extract_stop_reason
+
+
+def _responses_instructions(kwargs: dict[str, Any], slo: dict[str, Any]) -> str:
+    """Read the ``instructions`` a ``/v1/responses`` request carried.
+
+    ``instructions`` is that route's system prompt, and LiteLLM keeps it out of
+    the logged ``messages`` on both the native path and the chat bridge. Without
+    this the generation exports with an empty system prompt, and because an agent
+    version is a hash of system prompt plus tools, all Responses traffic collapses
+    into one version.
+
+    The proxy request body is the last source and the only one that has it behind
+    the proxy; the two parameter dicts cover a direct ``litellm.responses()``
+    call, which has no proxy request to read.
+    """
+    for container in (
+        slo.get("model_parameters") or {},
+        kwargs.get("optional_params") or {},
+        ((kwargs.get("litellm_params") or {}).get("proxy_server_request") or {}).get("body") or {},
+    ):
+        if not isinstance(container, dict):
+            continue
+        value = container.get("instructions")
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
 def _map_tool_definitions(kwargs: dict[str, Any]) -> list[ToolDefinition]:
     """Extract tool schemas from optional_params.
 
@@ -676,6 +730,13 @@ def _metadata_sources_from(container: dict[str, Any]) -> list[dict[str, Any]]:
     routes use ``litellm_metadata``; metadata passed through the Router lands one
     level deeper, under ``metadata.metadata``.
 
+    ``requester_metadata`` is the copy of the client's ``metadata`` that the
+    proxy keeps once it has overwritten ``metadata`` with its own request state.
+    It is the only copy on ``/v1/messages`` and ``/v1/responses``: both routes
+    hand the callback a ``litellm_metadata`` full of proxy fields and no
+    client-supplied key, so without it every request on those routes falls back
+    to the handler's static agent name.
+
     The container is ``kwargs["litellm_params"]`` on the logging path and the raw
     request body on the proxy pre-call path, where the same keys sit at the top
     level.
@@ -688,9 +749,10 @@ def _metadata_sources_from(container: dict[str, Any]) -> list[dict[str, Any]]:
         if not isinstance(candidate, dict):
             continue
         sources.append(candidate)
-        nested = candidate.get("metadata")
-        if isinstance(nested, dict):
-            sources.append(nested)
+        for nested_key in ("metadata", "requester_metadata"):
+            nested = candidate.get(nested_key)
+            if isinstance(nested, dict):
+                sources.append(nested)
     return sources
 
 
@@ -844,16 +906,23 @@ class Agento11yLiteLLMLogger(CustomLogger):
         """Resolve agent_version from per-request metadata, falling back to static."""
         return _first_metadata_value(_metadata_sources(kwargs), ("agent_version",)) or self._agent_version
 
-    def _resolve_conversation_id(self, kwargs: dict[str, Any]) -> str:
+    def _resolve_conversation_id(self, kwargs: dict[str, Any], slo: dict[str, Any]) -> str:
         """Resolve conversation_id from per-request metadata, falling back to static.
 
         Checks metadata keys first (conversation_id, session_id, thread_id),
         then LiteLLM's built-in session tracking fields (litellm_session_id,
-        litellm_trace_id) in both metadata and litellm_params.
+        litellm_trace_id) in both metadata and litellm_params, and last the
+        logged payload's own ``trace_id``.
+
+        The payload is the only place ``/v1/messages`` carries the trace id: that
+        route leaves ``litellm_params`` without one, so before this fallback its
+        generations exported with an empty conversation id, which leaves them out
+        of every conversation and out of conversation search. Where both are set
+        they hold the same id, so the fallback never regroups another route.
         """
         litellm_params = kwargs.get("litellm_params") or {}
         resolved = _resolve_conversation_id_from(litellm_params, _metadata_sources_from(litellm_params))
-        return resolved or self._conversation_id
+        return resolved or str(slo.get("trace_id") or "") or self._conversation_id
 
     def _record_generation(
         self,
@@ -890,10 +959,12 @@ class Agento11yLiteLLMLogger(CustomLogger):
         input_messages: list[Message] = []
         if self._capture_inputs:
             input_messages, system_prompt = _map_messages(slo.get("messages"))
+            if not system_prompt and call_type in _RESPONSES_CALL_TYPES:
+                system_prompt = _responses_instructions(kwargs, slo)
 
         gen_id = slo.get("id") or ""
         user_id = slo.get("end_user") or ""
-        conversation_id = self._resolve_conversation_id(kwargs)
+        conversation_id = self._resolve_conversation_id(kwargs, slo)
         started_at = _datetime_to_utc(start_time)
         tools = _map_tool_definitions(kwargs)
 
@@ -934,11 +1005,7 @@ class Agento11yLiteLLMLogger(CustomLogger):
                     recorder.set_call_error(RuntimeError(error_str))
 
             slo_response = slo.get("response")
-
-            if call_type in _RESPONSES_CALL_TYPES:
-                map_output, extract_stop_reason = _map_responses_output, _extract_responses_stop_reason
-            else:
-                map_output, extract_stop_reason = _map_response_output, _extract_stop_reason
+            map_output, extract_stop_reason = _select_output_mappers(call_type, slo_response)
 
             output_messages = map_output(slo_response) if self._capture_outputs else []
             usage = _extract_detailed_usage(response_obj, slo)

--- a/python-frameworks/litellm/docs/guards.md
+++ b/python-frameworks/litellm/docs/guards.md
@@ -1,0 +1,182 @@
+# LiteLLM guard reference
+
+Agent Observability guards are rules that run on the request path and can fail a request.
+`Agento11yLiteLLMGuardrail` evaluates them inside the LiteLLM proxy.
+This topic lists what each phase sees, which routes it covers, what a deny does, and every option.
+
+To turn guards on, refer to [Enforce guards on proxy requests](../README.md#enforce-guards-on-proxy-requests).
+To create a rule, refer to [Set up guards](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/guides/guards/).
+
+## Phases
+
+| Phase | LiteLLM `event_hook` | Runs | Can save spend |
+| --- | --- | --- | --- |
+| Preflight | `pre_call` | Before the provider is called | Yes |
+| Postflight | `post_call` | After the provider answers, before the caller gets the response | No |
+
+Two gates must both be open for a phase to evaluate anything:
+
+- LiteLLM: the guardrail is constructed with that `event_hook`. The default is `pre_call` alone.
+- The SDK: `HooksConfig.phases` contains that phase. The default is `["preflight"]`.
+
+A guardrail whose `event_hook` has no matching `HooksConfig.phases` entry logs a warning at startup.
+It then skips every request for that phase, so it records no verdict either.
+
+`during_call` raises at startup.
+LiteLLM runs it in parallel with the provider call, so it can't save spend, and it never receives the response.
+
+## Guarded routes
+
+The guard reads the request body as the client sent it, before LiteLLM translates it to provider format.
+Each route keeps its input somewhere else.
+
+| Route | Messages | System prompt |
+| --- | --- | --- |
+| `/v1/chat/completions` | `messages` | `system` and `developer` messages |
+| `/v1/completions` | `prompt`, as a string or a list of strings | None |
+| `/v1/images/generations` | `prompt` | None |
+| `/v1/messages` | `messages`, including Anthropic content blocks | Top-level `system` |
+| `/v1/responses` | `input`, as a string or input items | `instructions` |
+
+The guard skips every other route that LiteLLM runs pre-call hooks on.
+That covers embeddings, moderation, rerank, audio, realtime, Model Context Protocol (MCP) tool calls, and native pass-through endpoints such as `/anthropic/v1/messages`.
+Those bodies are provider-native or carry no messages, so a content rule has nothing to match.
+
+A skipped request records no verdict at all, and nothing on those routes is ever blocked.
+Evaluating them instead would return allow on empty input and record a verdict that reads like a completed check.
+
+Postflight skips the same routes through a different test.
+The post-call hook receives no call type, so the guard reads the request body instead.
+It skips a body it can't take messages, a prompt, or a system prompt from.
+
+A guarded request whose input maps to no text is skipped the same way.
+A token-id `prompt` and content that's entirely images or audio both map to no text.
+
+## Deny outcomes
+
+A deny answers the caller with the guardrail name and the rule's reason.
+The status code comes from LiteLLM: `GuardrailRaisedException` carries `status_code=400` from LiteLLM 1.87.0 on.
+Before that it carried no status code, so the proxy's fallback answered `500`.
+
+What a postflight deny does depends on how the response is delivered.
+These outcomes hold on LiteLLM 1.95.0, checked against a running proxy.
+
+| Delivery | Postflight deny outcome |
+| --- | --- |
+| Non-streaming, on `/v1/chat/completions`, `/v1/messages`, and `/v1/responses` | The caller gets the error. The provider output never leaves the proxy. |
+| Streaming, on `/v1/chat/completions` | The caller already has the whole response. The verdict is recorded and logged at warning level. |
+| Streaming, on `/v1/messages` and `/v1/responses` | Nothing runs. No hook request, no verdict, no log line. |
+
+Neither streaming outcome is a configuration choice.
+On a streamed chat completion, LiteLLM flushes every chunk, runs post-call guardrails on the assembled response, and swallows whatever they raise.
+It attaches that deferred pass only to its `CustomStreamWrapper`, and the other two routes stream through their own iterators.
+
+Treat postflight on streaming traffic as detection that feeds evaluation and alerting.
+Don't rely on it for enforcement, and don't rely on it at all for `/v1/messages` or `/v1/responses`.
+
+A preflight deny does stop a streaming request, before the first chunk.
+
+## Rule kinds
+
+Evaluator guards work as the [guards documentation](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/guides/guards/) describes.
+Preflight sees messages, the system prompt, and tool definitions.
+Postflight adds the response.
+
+Three kinds behave differently through this adapter:
+
+- Redact guards change what the model sees, though not on every route and not in every case. Refer to [Transformed requests](#transformed-requests).
+- Preflight tool filter guards match tool calls that are already in the request history, which means the client has run them. They block the next call in an agent loop rather than the tool itself. Put the guard in the postflight phase to block a call the model proposes, before the client runs it.
+- `model.provider` match filters are unreliable. LiteLLM's router picks a deployment after the guard runs, so the provider isn't known yet. Match on `agent_name`, `model.name`, or tags instead.
+
+## Transformed requests
+
+A preflight redact guard returns the rewritten request as `transformed_input`.
+The guardrail writes that into a new request body and gives the new body to the proxy.
+The proxy forwards it to the provider and to any later callback.
+
+The deny check runs before the rewrite, so a denied request never reaches the provider, rewritten or not.
+`apply_transforms=False` turns the rewrite off and leaves the deny check in place.
+
+Only preflight rewrites anything.
+A postflight transform is ignored, because the provider has already answered and LiteLLM takes no replacement response from the post-call hook.
+
+Redaction always applies to evaluators in later guards, which run server-side against the redacted input.
+That holds whether or not the request itself was rewritten.
+
+### Where a transform goes
+
+A redacted system prompt is written back on every route that has a place for one:
+
+- `system` on `/v1/messages`
+- `instructions` on `/v1/responses`
+- A `system` message on chat routes
+
+`/v1/completions` and `/v1/images/generations` carry a bare `prompt`, so they get no system prompt rewrite.
+
+Redacted messages are written back on chat routes and `/v1/messages` only.
+`/v1/responses` keeps its input in `input`, the two `prompt` routes keep theirs in `prompt`, and none of the three takes chat messages.
+
+The rewrite changes text and nothing else.
+It copies tool calls, tool call IDs, images, and an Anthropic `cache_control` breakpoint through.
+So a message carrying any of them can still be redacted instead of failing the rewrite.
+
+### Skipped rewrites
+
+A rewrite is all or nothing.
+When the guardrail can't apply the whole transform, it forwards the request as the client sent it and logs a warning naming the reason.
+Every one of those warnings starts with `agento11y: skipping`, so grep the proxy log for that string when you adopt a redact rule.
+
+Nothing marks the generation, so a redact rule whose transform never reached the provider looks the same as a rule that matched and allowed.
+
+The rewrite is skipped when:
+
+- Every message in the request is a system or developer message. Writing the prompt into one place would leave the message list empty, which every route rejects.
+- A system prompt or an Anthropic `tool_result` spans more than one content block and a block carries fields of its own. One block is rewritten in place and keeps its fields. More than one has to collapse into a single string, and there's no way to split that string back into per-block values.
+- The transform doesn't line up with the request one to one. The guardrail matches messages by position. Both the message count and the count of text values inside each message have to agree with what the guard evaluated.
+
+A rule that rewrites a message or a system prompt to an empty string changes nothing.
+An empty value can't be told apart from "no transform" on the wire.
+
+### Reasoning isn't rewritten
+
+The adapter leaves reasoning as the client sent it, whether it arrived as `reasoning_content` or as a thinking block.
+A provider validates a reasoning payload against its own signature and rejects a rewritten one.
+
+So a redact rule that rewrites the reasoning of an assistant turn has no effect.
+A secret in reasoning text reaches the provider even when the same secret is redacted out of the message text.
+
+## Guardrail options
+
+All options are keyword-only.
+`create_agento11y_litellm_guardrail` accepts the same ones.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `agent_name` | `str` | `""` | Fallback agent name for a request that carries no agent identity |
+| `agent_name_metadata_keys` | `Sequence[str]` | `("agent_name", "agent_id")` | Metadata keys consulted, in order, to name the agent |
+| `agent_version` | `str` | `""` | Fallback agent version |
+| `apply_transforms` | `bool` | `True` | Write `transformed_input` from a preflight allow verdict into the outgoing request |
+| `client` | `agento11y.Client` | Required | SDK client with `hooks.enabled=True` and the phase to evaluate in `hooks.phases` |
+| `default_on` | `bool` | `False` | Run on every request instead of only on requests that opt in |
+| `event_hook` | `str \| Sequence[str]` | `"pre_call"` | Phases to run: `"pre_call"`, `"post_call"`, or both |
+| `extra_tags` | `dict[str, str]` | `None` | Additional tags merged into every hook evaluation context |
+| `guardrail_name` | `str` | `"agento11y"` | Name used for per-request opt-in and in the error response |
+| `max_concurrent_evaluations` | `int` | `32` | Ceiling on hook evaluations in flight at once |
+| `request_timeout_seconds` | `float` | `2.0` | How long the proxy waits for a free thread plus a verdict |
+
+With `default_on=False`, a request opts in with `"guardrails": ["agento11y"]` in its metadata.
+
+Lower `HooksConfig.timeout_seconds` from its 15 second default for proxy use.
+It bounds how long a worker thread stays occupied after the guardrail has given up on the evaluation.
+
+## Runtime behavior
+
+- Evaluation runs on a pool of `max_concurrent_evaluations` threads, so it doesn't block the proxy event loop. `request_timeout_seconds` covers waiting for a free thread as well as the evaluation itself. A thread stays busy until its evaluation finishes, so a slow evaluator can keep the pool saturated for longer than that timeout.
+- A transport failure, a timeout, or an unexpected error follows `HooksConfig.fail_open`. With `True`, the default, the guardrail allows the request and logs the failure at warning level. With `False`, it raises `HookTransportError`.
+- Either failure mode records the verdict as `guardrail_failed_to_respond` rather than `success`, so a dead evaluator shows up in spend logs and logging callbacks.
+- Failing closed costs more on postflight than on preflight. The provider has already answered and billed, and the caller gets HTTP 500 instead of the response.
+- Hook evaluations correlate to the proxy request span, so a guard verdict lines up with its request in traces.
+- Register the logger next to the guardrail. The guardrail exports no generations, and having both in `litellm.callbacks` still exports exactly one generation per request.
+- A non-streaming postflight deny costs a generation record. LiteLLM defers success logging until post-call guardrails have run, then drops it when one raises. The failure path doesn't reach this package either.
+- A denied request was still called and billed, and its verdict is in `standard_logging_guardrail_information`. A streamed deny keeps its generation, because nothing raises there.
+- Postflight reads the response the provider produced, not the copy LiteLLM logs, so `turn_off_message_logging` doesn't apply to it. Enabling postflight sends response content to the hooks API even on a deployment that keeps content out of its logs.

--- a/python-frameworks/litellm/docs/reference.md
+++ b/python-frameworks/litellm/docs/reference.md
@@ -1,0 +1,219 @@
+# LiteLLM adapter reference
+
+`Agento11yLiteLLMLogger` is the LiteLLM callback that exports generations to Agent Observability.
+This topic lists its options, the calls it records, and what each exported field holds.
+
+To wire the callback up, refer to [Export generations from your app](../README.md#export-generations-from-your-app).
+For guards, refer to the [LiteLLM guard reference](guards.md).
+
+## Logger options
+
+All options are keyword-only.
+`create_agento11y_litellm_logger` accepts the same ones.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `agent_name` | `str` | `""` | Fallback agent name for a request that carries no agent identity |
+| `agent_name_metadata_keys` | `Sequence[str]` | `("agent_name", "agent_id")` | Metadata keys consulted, in order, to name the agent |
+| `agent_version` | `str` | `""` | Default agent version |
+| `capture_inputs` | `bool` | `True` | Record input messages and the system prompt |
+| `capture_outputs` | `bool` | `True` | Record output messages |
+| `client` | `agento11y.Client` | Required | SDK client instance |
+| `conversation_id` | `str` | `""` | Default conversation ID |
+| `extra_metadata` | `dict[str, Any]` | `None` | Additional metadata merged into every generation |
+| `extra_tags` | `dict[str, str]` | `None` | Additional tags merged into every generation |
+
+## Recorded calls
+
+| Call type | Route | Notes |
+| --- | --- | --- |
+| `anthropic_messages`, `aanthropic_messages` | `/v1/messages` | Anthropic content blocks, `tool_use`, and `tool_result` are mapped |
+| `completion`, `acompletion` | `/v1/chat/completions` | |
+| `embedding`, `aembedding` | `/v1/embeddings` | Exported as an OpenTelemetry (OTel) span, not a generation |
+| `responses`, `aresponses` | `/v1/responses` | `instructions` becomes the system prompt |
+| `text_completion`, `atext_completion` | `/v1/completions` | The prompt is recorded as a user message |
+
+Image generation, audio, and transcription calls are skipped.
+A pre-tokenized prompt, which is a list of token IDs, carries no text, so it's skipped too.
+
+## Generation fields
+
+| Field | Source |
+| --- | --- |
+| `agent_name`, `agent_version`, `conversation_id` | Per-request metadata, then the static option. Refer to [Agent identity](#agent-identity). |
+| `max_tokens`, `temperature`, `top_p` | The request's model parameters |
+| `mode` | `SYNC` for a non-streamed call, `STREAM` for a streamed one, with the first-token timestamp |
+| `model.name` | The bare catalog name, such as `gpt-4o-mini`, so cost and catalog lookups match it |
+| `model.provider` | `custom_llm_provider` from LiteLLM's logging payload |
+| `stop_reason` | `finish_reason` on a chat payload, or the `status` on a Responses payload |
+| `system_prompt` | A `system` or `developer` message, or `instructions` on `/v1/responses` |
+| `usage` | Token counts, including cached and reasoning tokens when the provider returns them |
+
+An Azure deployment alias such as `azure/my-deployment` is reported as it is, because no catalog model carries that name.
+The router names are kept in metadata under `agento11y.framework.litellm.model`, `.model_group`, and `.model_id`.
+
+### Output mapping
+
+Output is mapped by the shape of the logged response, not by the call type:
+
+- A payload carrying `choices` is read as a chat completion.
+- A payload carrying an `output` list is read as a Responses payload.
+- A payload with neither falls back to the call type.
+
+The shape matters because LiteLLM serves `/v1/responses` on a provider without a native Responses API by bridging the call to chat completions.
+That bridge logs a chat payload under call type `aresponses`.
+
+Only text content is recorded.
+Images, audio, and other non-text parts are skipped.
+
+Reasoning is captured as `THINKING` parts, ordered before the assistant text.
+It's read from `thinking_blocks` when present, including redacted blocks, and otherwise from the flat `reasoning_content` string.
+
+### Tool calls and definitions
+
+Tool history is recorded in each request shape that carries it:
+
+- Anthropic `tool_use` and `tool_result` blocks on `/v1/messages`
+- OpenAI `tool_calls` and `tool` messages on chat routes
+- Top-level `function_call` and `function_call_output` items in `/v1/responses` input
+
+The remaining Responses input items, `computer_call`, `mcp_call`, and `image_generation_call`, are skipped.
+Tool calls in `/v1/responses` output are recorded.
+
+Tool definitions are read from the request `tools`.
+The adapter reads the Anthropic schema, the OpenAI chat schema, and the flat Responses schema.
+
+### Tags and metadata
+
+These tags are always set:
+
+- `agento11y.framework.language=python`
+- `agento11y.framework.name=litellm`
+- `agento11y.framework.source=handler`, or `guardrail` on a hook evaluation context
+
+LiteLLM `request_tags` are forwarded as `litellm.tag.<value>`.
+LiteLLM adds a tag for the caller's user agent by default, so expect one tag per user agent string.
+
+### Failures
+
+A failed call is recorded with the error attached.
+
+A call that fails before the router picks a deployment, such as a budget or authentication rejection, has no provider.
+It's reported under the provider `litellm` rather than dropped.
+
+A request LiteLLM rejects before routing reaches the failure callback twice for one call ID.
+Both exports carry the same generation ID, so the server keeps the first and refuses the second.
+That logs one `generation rejected ... generation already exists` line per rejected request, and nothing is lost or duplicated.
+
+## Agent identity
+
+The adapter resolves `agent_name`, `agent_version`, and `conversation_id` per request, and falls back to the static options.
+Metadata is read from these containers, in this order:
+
+1. `litellm_params["metadata"]`
+1. `metadata.metadata`, where the Router puts SDK-supplied metadata
+1. `metadata.requester_metadata`, the copy the proxy keeps of what the caller sent
+1. `litellm_params["litellm_metadata"]`, used by assistant and thread routes
+1. `litellm_metadata.metadata`
+1. `litellm_metadata.requester_metadata`
+
+Keys are matched in priority order across all containers, so an `agent_name` in any of them beats an `agent_id` in another.
+
+`requester_metadata` is the only copy on `/v1/messages` and `/v1/responses`.
+Both routes hand the callback a `litellm_metadata` holding proxy state and no client-supplied key.
+
+`agent_name_metadata_keys` controls which keys the adapter consults.
+The default, `("agent_name", "agent_id")`, ends with LiteLLM's own `agent_id`.
+The proxy fills that in from the `x-litellm-agent-id` header, or from an `agent_id` on the calling virtual key.
+
+A key alias names a credential rather than an agent, so `user_api_key_alias` isn't consulted by default.
+Rotating a key would rename the agent, and a shared key would merge unrelated callers.
+
+### Conversation ID
+
+`conversation_id` resolves from the first of these that's set:
+
+1. The `conversation_id`, `session_id`, or `thread_id` metadata key
+1. LiteLLM's `litellm_session_id` or `litellm_trace_id` in `litellm_params`
+1. The `trace_id` on the logged payload
+1. The `conversation_id` option
+
+The payload's `trace_id` is what groups `/v1/messages` turns.
+That route leaves `litellm_params` without a trace ID, so a generation with no other source would export ungrouped and stay out of conversation search.
+
+## Embeddings
+
+An embedding call is exported as an OTel span, not a generation, and the span needs a configured tracer.
+
+The span carries the input count, token count, and dimensions.
+LiteLLM clears the input before it invokes callbacks when message logging is off, so the span honors `turn_off_message_logging`.
+
+The input text is attached only when the handler's `capture_inputs` is set and the SDK's `EmbeddingCaptureConfig.capture_input` is `True`.
+For that setting, refer to [Embedding capture](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/configure/sdk/#embedding-capture).
+
+## Deploy in the LiteLLM proxy
+
+The proxy loads a callback by dotted path from a file next to `config.yaml`.
+For a complete, runnable version of the following, refer to the [LiteLLM proxy example](../example/README.md).
+
+Extend the image, bootstrapping `pip` because recent LiteLLM images ship a `uv` virtual environment without it:
+
+```dockerfile
+FROM ghcr.io/berriai/litellm:v1.95.0
+RUN python -m ensurepip --upgrade && \
+    python -m pip install --no-cache-dir agento11y agento11y-litellm
+```
+
+Create `agento11y_callback.py` next to `config.yaml`:
+
+```python
+import os
+
+from agento11y import Client
+from agento11y.config import ApiConfig, AuthConfig, ClientConfig, GenerationExportConfig
+from agento11y_litellm import Agento11yLiteLLMLogger
+
+endpoint = os.environ["AGENTO11Y_ENDPOINT"]
+
+client = Client(
+    ClientConfig(
+        generation_export=GenerationExportConfig(
+            protocol="http",
+            endpoint=endpoint,
+            auth=AuthConfig(
+                mode="basic",
+                tenant_id=os.environ["AGENTO11Y_AUTH_TENANT_ID"],
+                basic_password=os.environ["AGENTO11Y_AUTH_TOKEN"],
+            ),
+        ),
+        api=ApiConfig(endpoint=endpoint),
+    )
+)
+
+agento11y_handler = Agento11yLiteLLMLogger(client=client, agent_name="litellm-proxy")
+```
+
+Reference it from `config.yaml`:
+
+```yaml
+litellm_settings:
+  callbacks:
+    - agento11y_callback.agento11y_handler
+```
+
+Mount both files and run the proxy:
+
+```bash
+docker run -d \
+  -v $(pwd)/config.yaml:/app/config.yaml \
+  -v $(pwd)/agento11y_callback.py:/app/agento11y_callback.py \
+  -e AGENTO11Y_ENDPOINT=https://your-agento11y-endpoint \
+  -e AGENTO11Y_AUTH_TENANT_ID=your-tenant \
+  -e AGENTO11Y_AUTH_TOKEN=your-token \
+  -p 4000:4000 \
+  your-litellm-image \
+  --config /app/config.yaml
+```
+
+The callback file reads its connection details from environment variables.
+Set `AuthConfig` to the mode your deployment uses; `agento11y.config` documents the `basic`, `bearer`, and `tenant` modes.

--- a/python-frameworks/litellm/example/Dockerfile
+++ b/python-frameworks/litellm/example/Dockerfile
@@ -1,7 +1,13 @@
-FROM ghcr.io/berriai/litellm:v1.82.3-stable.patch.2@sha256:9e1536c6a9219519f024f221706b20b012ca5176988164798adc5c7fe011e5d5
+FROM ghcr.io/berriai/litellm:v1.95.0@sha256:af806882b7a6ced41658db5b6a7e98ed7b9b51d03b935e0417bf1c8552d688af
 
-COPY sdks/python /tmp/agento11y
-COPY sdks/python-frameworks/litellm /tmp/agento11y-litellm
+COPY python /tmp/agento11y
+COPY python-frameworks/litellm /tmp/agento11y-litellm
 
-RUN pip install --no-cache-dir /tmp/agento11y /tmp/agento11y-litellm && \
+# The image ships a uv-managed venv at /app/.venv with no pip in it, so pip is
+# bootstrapped before the two local packages are installed. Installing from
+# PyPI instead needs the same bootstrap:
+#   RUN python -m ensurepip --upgrade && \
+#       python -m pip install --no-cache-dir agento11y agento11y-litellm
+RUN python -m ensurepip --upgrade && \
+    python -m pip install --no-cache-dir /tmp/agento11y /tmp/agento11y-litellm && \
     rm -rf /tmp/agento11y /tmp/agento11y-litellm

--- a/python-frameworks/litellm/example/Dockerfile.dockerignore
+++ b/python-frameworks/litellm/example/Dockerfile.dockerignore
@@ -1,0 +1,11 @@
+# The build context is the repo root, which is ~2 GB. Send only the two
+# directories the Dockerfile copies. BuildKit reads this file because it is
+# named after the Dockerfile.
+*
+!python
+!python-frameworks/litellm
+**/__pycache__
+**/*.egg-info
+**/.pytest_cache
+**/.venv
+**/build

--- a/python-frameworks/litellm/example/README.md
+++ b/python-frameworks/litellm/example/README.md
@@ -1,114 +1,194 @@
-# LiteLLM Proxy + Agent Observability Example
+# LiteLLM proxy example
 
-Runs a LiteLLM proxy with the agento11y callback handler, exporting generations to Grafana Cloud.
+This example runs a LiteLLM proxy that exports every generation to Grafana Cloud Agent Observability and enforces Agent Observability guards on the request path.
+It starts with one command, and it works without a provider key.
 
-## Prerequisites
+The example installs the SDK from this repository, so it exercises the working tree.
+For your own deployment, replace the two `COPY` lines in the `Dockerfile` with a `pip install agento11y agento11y-litellm`.
 
-- A Grafana Cloud stack with Agent Observability enabled
-- A Grafana Cloud API token (`glc_...`)
-- At least one LLM API key (`OPENAI_API_KEY` or `ANTHROPIC_API_KEY`)
+| File | Contents |
+| --- | --- |
+| `agento11y_callback.py` | The callback the proxy loads: one SDK client, an export handler, and a guardrail |
+| `agento11y_callback_agent_from_key_alias.py` | A drop-in replacement that names unidentified callers after their virtual key |
+| `config.yaml` | The model list, and the callbacks by dotted path |
+| `docker-compose.yaml` | Builds the image from this checkout and mounts the two callback files |
+
+## Before you begin
+
+You need Docker Compose, and the endpoint, instance ID, and token for a Grafana Cloud stack.
+To enable the product and collect those three values, refer to [Set up Agent Observability](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/get-started/grafana-cloud/).
+
+A provider key is optional.
+The `mock` model in `config.yaml` answers from LiteLLM itself, so you can run the example with Grafana Cloud credentials alone.
 
 ## Start the proxy
 
+To start the proxy, run Docker Compose with your credentials:
+
 ```bash
-cd sdks/python-frameworks/litellm/example
+cd python-frameworks/litellm/example
 AGENTO11Y_ENDPOINT=https://your-agento11y.grafana.net \
   AGENTO11Y_AUTH_TENANT_ID=your-tenant \
-  AGENTO11Y_AUTH_TOKEN=glc_... \
-  OPENAI_API_KEY=sk-... \
+  AGENTO11Y_AUTH_TOKEN=glc_your_token \
+  OPENAI_API_KEY=sk-your-key \
   docker compose up --build
 ```
 
-The proxy starts on the published Docker Compose port `4000`.
+The proxy listens on port `4000`.
+The first build takes a couple of minutes, and the proxy needs about a minute more to load its callbacks.
 
-## Make a request
-
-```bash
-curlie POST http://<proxy-host>:4000/chat/completions \
-  model=gpt-4o-mini \
-  messages:='[{"role":"user","content":"What is 2+2?"}]'
-```
-
-Or with streaming:
+Wait for the readiness check to answer before you send a request:
 
 ```bash
-curlie POST http://<proxy-host>:4000/chat/completions \
-  model=gpt-4o-mini \
-  messages:='[{"role":"user","content":"Give me three reliability tips."}]' \
-  stream:=true
+curl --retry 30 --retry-delay 2 --retry-all-errors http://localhost:4000/health/liveliness
 ```
 
-## Verify in Agent Observability
+`Dockerfile.dockerignore` keeps the build context to the two directories the image copies, out of a repository that's otherwise gigabytes.
 
-Open `https://<your-stack>.grafana.net/a/grafana-agento11y-app/conversations`. Generations appear with:
+## Send a request
 
-- `agent_name`: `litellm-proxy-integration-test`
-- `agento11y.framework.name`: `litellm`
-- `provider`: `openai` (or whichever model you called)
-
-## Configuration
-
-`config.yaml` defines the available models. Add more by following the [LiteLLM model list format](https://docs.litellm.ai/docs/proxy/configs).
-
-## Preflight rule enforcement
-
-`config.yaml` lists `agento11y_callback.agento11y_guards` as a second callback, which evaluates Agent Observability preflight guards before each request reaches the provider. Guards live in Agent Observability, not in this config; refer to [Set up guards](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/guides/guards/) for how to create one, and to the [package README](../README.md#guards) for what a rule does through this adapter.
-
-Three outcomes:
-
-- Allow (no rule matches, or every rule passes): the request goes through and the generation is exported as usual.
-- Deny: the proxy answers `400` with `blocked by guardrail agento11y: <reason> (rule <rule-id>)` and never calls the provider.
-- Evaluator unreachable: `HooksConfig.fail_open` is `True` in `agento11y_callback.py`, so the request is allowed and the proxy logs `agento11y: hook evaluation failed, allowing request (fail_open): ...`. Set `fail_open=False` to fail closed instead; the request then fails with a transport error before the provider is called.
-
-To see the fail-open path, point `AGENTO11Y_ENDPOINT` at an unreachable host and watch the proxy logs while making a request.
-
-Enforcement only happens through the proxy. A direct `litellm.completion()` call in your own process is not guarded, because LiteLLM never runs pre-call hooks on the SDK path.
-
-## Attributing generations to the calling agent
-
-`agento11y_callback.py` names generations after the proxy only when a request
-says nothing about who is calling. Identify the caller in the request body:
+The `mock` model needs no provider key, so it works on a first run with Grafana Cloud credentials alone:
 
 ```bash
-curlie POST http://<proxy-host>:4000/chat/completions \
-  model=gpt-4o-mini \
-  messages:='[{"role":"user","content":"What is 2+2?"}]' \
-  metadata:='{"agent_name":"search-agent"}'
+curl http://localhost:4000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "mock", "messages": [{"role": "user", "content": "What is 2+2?"}]}'
 ```
 
-or with the header LiteLLM already understands, which needs no client-side
-knowledge of agento11y:
+Everything except the provider call is real.
+The generation is exported, and guards evaluate both the request and the response.
+
+With a provider key, call `gpt-4o-mini` or `claude-haiku` instead:
 
 ```bash
-curlie POST http://<proxy-host>:4000/chat/completions \
-  x-litellm-agent-id:search-agent \
-  model=gpt-4o-mini \
-  messages:='[{"role":"user","content":"What is 2+2?"}]'
+curl http://localhost:4000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "What is 2+2?"}]}'
 ```
 
-## Naming agents after the calling key
+A streamed call is exported as one generation carrying the time of the first token:
 
-`agento11y_callback_agent_from_key_alias.py` covers callers that send no agent
-identity at all: instead of collapsing them into one proxy-wide name, it adds
-the virtual key's alias (then the team's) to `agent_name_metadata_keys`, so each
-key shows up as its own agent.
+```bash
+curl http://localhost:4000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Three tips."}], "stream": true}'
+```
 
-Only use it when your keys map one-to-one onto agents. A key alias names a
-credential, not an agent, so rotating a key renames the agent and a shared key
-merges unrelated callers.
+The other recorded routes work the same way, and each exports one generation:
 
-Point `config.yaml` at it:
+```bash
+curl http://localhost:4000/v1/messages \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "claude-haiku", "max_tokens": 64, "system": "You are terse.", "messages": [{"role": "user", "content": "What is 2+2?"}]}'
+
+curl http://localhost:4000/v1/responses \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "gpt-4o-mini", "instructions": "You are terse.", "input": "What is 2+2?"}'
+```
+
+## Verify the generations arrive
+
+Open Agent Observability in your stack and search for the agent `litellm-proxy`.
+Each generation carries the tag `agento11y.framework.name=litellm` and the provider that served the call.
+For the search filters and what each panel shows, refer to [Browse and debug conversations](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/guides/conversations/).
+
+To check from a terminal, use the [gcx repository](https://github.com/grafana/gcx):
+
+```bash
+gcx agento11y agents list -o json
+gcx agento11y conversations search --filters 'agent = "litellm-proxy"' -o json
+gcx agento11y conversations get <CONVERSATION_ID> -o json
+```
+
+## Attribute generations to the calling agent
+
+`agento11y_callback.py` names generations after the proxy only when a request says nothing about who is calling.
+To name the caller, pass metadata in the request body:
+
+```bash
+curl http://localhost:4000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "mock", "messages": [{"role": "user", "content": "What is 2+2?"}], "metadata": {"agent_name": "search-agent", "conversation_id": "conv-abc-123"}}'
+```
+
+Or send the header LiteLLM already understands, which needs no client-side knowledge of Agent Observability:
+
+```bash
+curl http://localhost:4000/v1/chat/completions \
+  -H 'x-litellm-agent-id: search-agent' \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "mock", "messages": [{"role": "user", "content": "What is 2+2?"}]}'
+```
+
+Both work on every recorded route, `/v1/messages` and `/v1/responses` included.
+
+### Name agents after the calling key
+
+`agento11y_callback_agent_from_key_alias.py` covers callers that send no agent identity at all.
+It adds the virtual key's alias, then the team's, to the keys the handler consults.
+Each key then shows up as its own agent, instead of collapsing into one proxy-wide name.
+
+Only use it when your keys map one-to-one onto agents.
+A key alias names a credential, not an agent, so rotating a key renames the agent and a shared key merges unrelated callers.
+
+To use it, point `config.yaml` at it, both lines together, so the proxy keeps running one SDK client:
 
 ```yaml
 litellm_settings:
   callbacks:
     - agento11y_callback_agent_from_key_alias.agento11y_handler
-    - agento11y_callback.agento11y_guards
+    - agento11y_callback_agent_from_key_alias.agento11y_guards
 ```
 
-and mount it alongside `config.yaml` in `docker-compose.yaml`:
+Virtual keys live in the proxy database, so this file changes nothing on its own.
+It takes effect once the proxy runs with `DATABASE_URL` and `LITELLM_MASTER_KEY` set, and callers authenticate with a key that has an alias.
 
-```yaml
-    volumes:
-      - ./agento11y_callback_agent_from_key_alias.py:/app/agento11y_callback_agent_from_key_alias.py
+This Compose file sets neither, so the proxy runs unauthenticated.
+That's fine for a local example and unsafe anywhere else.
+
+To try the variant, add a Postgres service and those two variables.
+Then create a key with [LiteLLM virtual keys](https://docs.litellm.ai/docs/proxy/virtual_keys), and send it as the bearer token.
+
+## Enforce guards
+
+`config.yaml` lists `agento11y_callback.agento11y_guards` next to the handler, which evaluates your guards on both phases:
+
+- Preflight, before the request reaches the provider. It can save the spend.
+- Postflight, after the provider answers, before a non-streamed response reaches the caller. It can't save the spend.
+
+Guards live in Agent Observability, not in this config.
+To create one, refer to [Set up guards](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/guides/guards/).
+
+A request has three possible outcomes:
+
+- Allow, when no rule matches or every rule passes. The request goes through and the generation is exported as usual.
+- Deny. The proxy answers `400` with `blocked by guardrail agento11y: <REASON> (rule <RULE_ID>)`.
+- Evaluator unreachable. `HooksConfig.fail_open` defaults to `True`, so the request is allowed and the proxy logs `agento11y: guardrail 'agento11y' allowing request (fail_open)`. Pass `fail_open=False` to fail closed instead.
+
+To watch the fail-open path, point `AGENTO11Y_ENDPOINT` at an unreachable host and read the proxy logs while you send a request.
+
+Enforcement only happens through the proxy.
+A direct `litellm.completion()` call in your own process is never guarded, because LiteLLM runs call hooks only in the proxy.
+
+For the routes each phase covers and what a deny does to a streamed response, refer to the [LiteLLM guard reference](../docs/guards.md).
+
+## Send OpenTelemetry traces and metrics
+
+Generation export and OpenTelemetry (OTel) are separate channels.
+This example configures generation export only, so the performance charts, which read metrics, stay empty.
+
+To fill them, pass the two OpenTelemetry Protocol (OTLP) variables as well:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-<REGION>.grafana.net/otlp \
+OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <BASE64_OF_INSTANCE_ID_AND_TOKEN>" \
+  docker compose up --build
 ```
+
+`docker-compose.yaml` passes both through, and the same token covers both channels.
+For the values to put in them, and for sending through Alloy instead, refer to [Set up traces and metrics](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/get-started/grafana-cloud/#set-up-traces-and-metrics).
+
+## Add a model
+
+`config.yaml` defines the available models.
+To add more, follow the [LiteLLM model list format](https://docs.litellm.ai/docs/proxy/configs).

--- a/python-frameworks/litellm/example/agento11y_callback.py
+++ b/python-frameworks/litellm/example/agento11y_callback.py
@@ -1,4 +1,13 @@
-"""agento11y callback for LiteLLM proxy."""
+"""agento11y callback for LiteLLM proxy.
+
+Registers two objects with the proxy:
+
+- ``agento11y_handler`` exports one generation per request.
+- ``agento11y_guards`` evaluates Agent Observability guards on the request path
+  and fails a request a rule denies.
+
+``config.yaml`` lists both by dotted path.
+"""
 
 import os
 
@@ -7,7 +16,9 @@ from agento11y.config import ApiConfig, AuthConfig, ClientConfig, GenerationExpo
 from agento11y_litellm import Agento11yLiteLLMGuardrail, Agento11yLiteLLMLogger
 
 _endpoint = os.environ["AGENTO11Y_ENDPOINT"]
-_agent_name = "litellm-proxy-integration-test"
+# Used only for a request that names no agent of its own. See the README section
+# "Attributing generations to the calling agent".
+_agent_name = os.environ.get("AGENTO11Y_AGENT_NAME", "litellm-proxy")
 
 client = Client(
     ClientConfig(
@@ -20,10 +31,19 @@ client = Client(
                 basic_password=os.environ.get("AGENTO11Y_AUTH_TOKEN", ""),
             ),
         ),
+        # Guards call the Agent Observability API, which the export endpoint does
+        # not cover.
         api=ApiConfig(endpoint=_endpoint),
-        # Preflight rule enforcement. 15s (the default) is too long to hold a
-        # proxy worker thread; keep it just above the guardrail's own timeout.
-        hooks=HooksConfig(enabled=True, timeout_seconds=3.0),
+        hooks=HooksConfig(
+            enabled=True,
+            # 15s (the default) is too long to hold a proxy worker thread; keep
+            # it just above the guardrail's own timeout.
+            timeout_seconds=3.0,
+            # Drop "postflight" to evaluate request rules only. Postflight sends
+            # response content to the hooks API, on a deployment that keeps
+            # content out of its logs too.
+            phases=["preflight", "postflight"],
+        ),
     )
 )
 
@@ -32,11 +52,14 @@ agento11y_handler = Agento11yLiteLLMLogger(
     agent_name=_agent_name,
 )
 
-# Blocks denied requests before they reach the provider. Only active through the
-# proxy: LiteLLM never runs pre-call hooks on the direct SDK path.
+# Fails a denied request before it reaches the provider (preflight) and before a
+# non-streamed response reaches the caller (postflight). Only active through the
+# proxy: LiteLLM never runs call hooks on the direct SDK path.
 agento11y_guards = Agento11yLiteLLMGuardrail(
     client=client,
     agent_name=_agent_name,
     request_timeout_seconds=2.0,
     default_on=True,
+    # "pre_call" alone evaluates preflight rules only, and is the default.
+    event_hook=["pre_call", "post_call"],
 )

--- a/python-frameworks/litellm/example/agento11y_callback_agent_from_key_alias.py
+++ b/python-frameworks/litellm/example/agento11y_callback_agent_from_key_alias.py
@@ -1,5 +1,9 @@
 """agento11y callback for LiteLLM proxy that names agents after the calling key.
 
+A drop-in replacement for ``agento11y_callback``: it exports the same two names
+from one client, so ``config.yaml`` swaps both lines and the proxy still runs a
+single SDK client.
+
 The handler already resolves ``agent_name`` from per-request metadata and from
 LiteLLM's own ``agent_id``, so callers that identify themselves need nothing
 extra. This variant covers the remaining case: callers that send no agent
@@ -10,15 +14,32 @@ shows up as its own agent.
 Only worth it when your keys map one-to-one onto agents. A key alias names a
 credential, not an agent, so rotating a key renames the agent and a shared key
 merges unrelated callers.
+
+Virtual keys are a database feature: this file resolves nothing until the proxy
+runs with ``DATABASE_URL`` and ``LITELLM_MASTER_KEY`` set and callers
+authenticate with a key that has an alias. Without them every request still
+lands on the fallback name below.
 """
 
 import os
 
 from agento11y import Client
-from agento11y.config import AuthConfig, ClientConfig, GenerationExportConfig
-from agento11y_litellm import DEFAULT_AGENT_NAME_METADATA_KEYS, Agento11yLiteLLMLogger
+from agento11y.config import ApiConfig, AuthConfig, ClientConfig, GenerationExportConfig, HooksConfig
+from agento11y_litellm import (
+    DEFAULT_AGENT_NAME_METADATA_KEYS,
+    Agento11yLiteLLMGuardrail,
+    Agento11yLiteLLMLogger,
+)
 
 _endpoint = os.environ["AGENTO11Y_ENDPOINT"]
+_fallback_agent_name = os.environ.get("AGENTO11Y_AGENT_NAME", "litellm-proxy")
+
+# Consulted in order, so a caller that names itself still wins over its key.
+_agent_name_keys = (
+    *DEFAULT_AGENT_NAME_METADATA_KEYS,
+    "user_api_key_alias",
+    "user_api_key_team_alias",
+)
 
 client = Client(
     ClientConfig(
@@ -31,16 +52,25 @@ client = Client(
                 basic_password=os.environ.get("AGENTO11Y_AUTH_TOKEN", ""),
             ),
         ),
+        api=ApiConfig(endpoint=_endpoint),
+        hooks=HooksConfig(enabled=True, timeout_seconds=3.0, phases=["preflight", "postflight"]),
     )
 )
 
 agento11y_handler = Agento11yLiteLLMLogger(
     client=client,
-    agent_name_metadata_keys=(
-        *DEFAULT_AGENT_NAME_METADATA_KEYS,
-        "user_api_key_alias",
-        "user_api_key_team_alias",
-    ),
+    agent_name_metadata_keys=_agent_name_keys,
     # Used only when a request matches none of the keys above.
-    agent_name="litellm-proxy-integration-test",
+    agent_name=_fallback_agent_name,
+)
+
+# Given the same keys, so a rule matching on agent_name selects the same traffic
+# the exported generations are filed under.
+agento11y_guards = Agento11yLiteLLMGuardrail(
+    client=client,
+    agent_name_metadata_keys=_agent_name_keys,
+    agent_name=_fallback_agent_name,
+    request_timeout_seconds=2.0,
+    default_on=True,
+    event_hook=["pre_call", "post_call"],
 )

--- a/python-frameworks/litellm/example/config.yaml
+++ b/python-frameworks/litellm/example/config.yaml
@@ -1,19 +1,28 @@
 model_list:
+  # Answers from LiteLLM without calling a provider, so the example runs with no
+  # provider key at all. Everything downstream is real: the generation is
+  # exported and guards evaluate it.
+  - model_name: mock
+    litellm_params:
+      model: openai/gpt-4o-mini
+      mock_response: "Mock response from the LiteLLM proxy."
+
   - model_name: gpt-4o-mini
     litellm_params:
       model: openai/gpt-4o-mini
 
-  - model_name: claude-sonnet
+  - model_name: claude-haiku
     litellm_params:
-      model: anthropic/claude-sonnet-4-20250514
+      model: anthropic/claude-haiku-4-5-20251001
 
 litellm_settings:
   callbacks:
-    # Swap in agento11y_callback_agent_from_key_alias.agento11y_handler to name
+    # Swap both lines for agento11y_callback_agent_from_key_alias to name
     # callers that send no agent identity after their virtual key rather than
-    # after the proxy.
+    # after the proxy. Keep them together: each file builds its own SDK client,
+    # so mixing the two runs two clients.
     - agento11y_callback.agento11y_handler
-    # Preflight rule enforcement. Runs on every request; construct it with
+    # Guard enforcement. Runs on every request; construct the guardrail with
     # default_on=False to require callers to opt in with
     # "guardrails": ["agento11y"] in their metadata.
     - agento11y_callback.agento11y_guards

--- a/python-frameworks/litellm/example/docker-compose.yaml
+++ b/python-frameworks/litellm/example/docker-compose.yaml
@@ -1,8 +1,11 @@
 services:
   litellm-proxy:
     build:
-      context: ../../../..
-      dockerfile: sdks/python-frameworks/litellm/example/Dockerfile
+      # The repo root: the Dockerfile installs the SDK from this checkout.
+      # Dockerfile.dockerignore keeps the context down to the two directories it
+      # copies.
+      context: ../../..
+      dockerfile: python-frameworks/litellm/example/Dockerfile
     ports:
       - "4000:4000"
     environment:
@@ -11,7 +14,15 @@ services:
       AGENTO11Y_ENDPOINT: ${AGENTO11Y_ENDPOINT}
       AGENTO11Y_AUTH_TENANT_ID: ${AGENTO11Y_AUTH_TENANT_ID}
       AGENTO11Y_AUTH_TOKEN: ${AGENTO11Y_AUTH_TOKEN}
+      # Names generations from requests that carry no agent identity.
+      AGENTO11Y_AGENT_NAME: ${AGENTO11Y_AGENT_NAME:-litellm-proxy}
+      # OTel traces and metrics are a separate channel from generation export,
+      # and the SDK sends nothing on it until these are set. See the README.
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS:-}
     volumes:
       - ./config.yaml:/app/config.yaml
       - ./agento11y_callback.py:/app/agento11y_callback.py
+      # Mounted so switching config.yaml to it needs no compose change.
+      - ./agento11y_callback_agent_from_key_alias.py:/app/agento11y_callback_agent_from_key_alias.py
     command: ["--config", "/app/config.yaml", "--port", "4000"]

--- a/python-frameworks/litellm/tests/test_litellm_handler.py
+++ b/python-frameworks/litellm/tests/test_litellm_handler.py
@@ -714,6 +714,104 @@ def test_identity_resolved_from_nested_router_metadata() -> None:
         client.shutdown()
 
 
+def test_identity_resolved_from_requester_metadata() -> None:
+    """/v1/messages and /v1/responses keep client metadata in requester_metadata.
+
+    Both routes hand the callback a ``litellm_metadata`` holding proxy state and
+    no client-supplied key, so this child dict is the only copy of what the
+    caller sent.
+    """
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client, agent_name="litellm-proxy")
+        kwargs: dict[str, Any] = {
+            "standard_logging_object": _base_slo(call_type="anthropic_messages"),
+            "litellm_params": {
+                "litellm_metadata": {
+                    "user_api_key_request_route": "/v1/messages",
+                    "requester_metadata": {
+                        "agent_name": "search-agent",
+                        "agent_version": "v3",
+                        "conversation_id": "conv-requester-1",
+                    },
+                },
+            },
+        }
+        handler.log_success_event(
+            kwargs=kwargs,
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.agent_name == "search-agent"
+        assert gen.agent_version == "v3"
+        assert gen.conversation_id == "conv-requester-1"
+        # Request tags are not read from metadata here: LiteLLM copies
+        # metadata.tags into the payload's request_tags itself.
+    finally:
+        client.shutdown()
+
+
+def test_requester_metadata_read_under_plain_metadata_too() -> None:
+    """Chat routes keep the same copy under metadata.requester_metadata."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client, agent_name="litellm-proxy")
+        kwargs: dict[str, Any] = {
+            "standard_logging_object": _base_slo(),
+            "litellm_params": {
+                "metadata": {
+                    "user_api_key_alias": None,
+                    "requester_metadata": {"agent_name": "chat-agent"},
+                },
+            },
+        }
+        handler.log_success_event(
+            kwargs=kwargs,
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        assert exporter.requests[0].generations[0].agent_name == "chat-agent"
+    finally:
+        client.shutdown()
+
+
+def test_top_level_metadata_beats_requester_metadata() -> None:
+    """The outer dict is checked first, so an explicit agent_name there wins."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        kwargs: dict[str, Any] = {
+            "standard_logging_object": _base_slo(),
+            "litellm_params": {
+                "metadata": {
+                    "agent_name": "outer-agent",
+                    "requester_metadata": {"agent_name": "inner-agent"},
+                },
+            },
+        }
+        handler.log_success_event(
+            kwargs=kwargs,
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        assert exporter.requests[0].generations[0].agent_name == "outer-agent"
+    finally:
+        client.shutdown()
+
+
 def test_key_alias_is_not_used_as_agent_name_by_default() -> None:
     """A virtual key alias names a credential, not an agent, so it is ignored."""
     exporter = _CapturingExporter()
@@ -960,6 +1058,99 @@ def test_litellm_trace_id_used_as_conversation_id() -> None:
 
         gen = exporter.requests[0].generations[0]
         assert gen.conversation_id == "trace-abc"
+    finally:
+        client.shutdown()
+
+
+def test_payload_trace_id_used_as_conversation_id() -> None:
+    """/v1/messages carries its trace id only in the logged payload.
+
+    That route leaves ``litellm_params`` without a trace id, so before this
+    fallback its generations exported with an empty conversation id and never
+    appeared in a conversation.
+    """
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(call_type="anthropic_messages", trace_id="payload-trace-1")
+        handler.log_success_event(
+            kwargs={"standard_logging_object": slo, "litellm_params": {"metadata": {}}},
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        assert exporter.requests[0].generations[0].conversation_id == "payload-trace-1"
+    finally:
+        client.shutdown()
+
+
+def test_litellm_params_trace_id_beats_payload_trace_id() -> None:
+    """The payload trace id is the last resort, so it never regroups a route."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(trace_id="payload-trace-2")
+        kwargs: dict[str, Any] = {
+            "standard_logging_object": slo,
+            "litellm_params": {"metadata": {}, "litellm_trace_id": "params-trace-2"},
+        }
+        handler.log_success_event(
+            kwargs=kwargs,
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        assert exporter.requests[0].generations[0].conversation_id == "params-trace-2"
+    finally:
+        client.shutdown()
+
+
+def test_payload_trace_id_beats_the_static_conversation_id() -> None:
+    """The payload trace id ranks with the other resolved ids, above the static one.
+
+    ``litellm_params``' trace id already outranks the handler's ``conversation_id``,
+    so a route that only publishes its trace id in the payload has to behave the
+    same way, or the same proxy would group two routes differently.
+    """
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client, conversation_id="static-conv")
+        slo = _base_slo(call_type="anthropic_messages", trace_id="payload-trace-3")
+        handler.log_success_event(
+            kwargs={"standard_logging_object": slo},
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        assert exporter.requests[0].generations[0].conversation_id == "payload-trace-3"
+    finally:
+        client.shutdown()
+
+
+def test_static_conversation_id_used_when_no_trace_id_is_published() -> None:
+    """With no trace id anywhere, the handler's own value still groups the turn."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client, conversation_id="static-conv")
+        handler.log_success_event(
+            kwargs={"standard_logging_object": _base_slo()},
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        assert exporter.requests[0].generations[0].conversation_id == "static-conv"
     finally:
         client.shutdown()
 
@@ -2577,6 +2768,197 @@ def test_responses_api_bridged_reasoning_content_mapped() -> None:
         assert [m.parts[0].kind for m in gen.output] == [PartKind.THINKING, PartKind.TEXT]
         assert gen.output[0].parts[0].thinking == "Counting the letters."
         assert gen.output[1].parts[0].text == "three"
+    finally:
+        client.shutdown()
+
+
+def test_responses_api_bridged_chat_payload_output_mapped() -> None:
+    """A bridged /v1/responses call logs a chat completion, and it must be read as one.
+
+    LiteLLM serves the route on a provider without a native Responses API by
+    bridging to chat completions and logging the chat ``ModelResponse`` under call
+    type ``aresponses``. Reading that with the Responses mappers found no
+    ``output`` list and no ``status``, so output and stop reason were dropped for
+    every non-OpenAI provider.
+    """
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="aresponses",
+            custom_llm_provider="anthropic",
+            model="anthropic/claude-haiku-4-5",
+            messages=[{"role": "user", "content": "say ok"}],
+            response=_make_slo_response(content="OK", finish_reason="stop"),
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert [p.text for m in gen.output for p in m.parts] == ["OK"]
+        assert gen.stop_reason == "stop"
+    finally:
+        client.shutdown()
+
+
+def test_responses_api_native_payload_still_uses_responses_mappers() -> None:
+    """A payload with output items and no choices keeps the Responses reading."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="aresponses",
+            custom_llm_provider="openai",
+            model="openai/gpt-5",
+            messages="say ok",
+            response={
+                "id": "resp_native",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "id": "msg_1",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "OK"}],
+                    }
+                ],
+            },
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert [p.text for m in gen.output for p in m.parts] == ["OK"]
+        # "completed" only becomes "stop" through the Responses stop reason.
+        assert gen.stop_reason == "stop"
+    finally:
+        client.shutdown()
+
+
+def test_responses_api_instructions_recorded_as_system_prompt() -> None:
+    """instructions is the route's system prompt and is missing from the messages.
+
+    An agent version hashes system prompt plus tools, so dropping it collapses
+    all Responses traffic into one version.
+    """
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="aresponses",
+            messages=[{"role": "user", "content": "say ok"}],
+            response=_make_slo_response(content="OK"),
+        )
+        kwargs: dict[str, Any] = {
+            "standard_logging_object": slo,
+            "litellm_params": {
+                "proxy_server_request": {
+                    "body": {"model": "gpt-5", "input": "say ok", "instructions": "You are terse."}
+                }
+            },
+        }
+        handler.log_success_event(
+            kwargs=kwargs,
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        assert exporter.requests[0].generations[0].system_prompt == "You are terse."
+    finally:
+        client.shutdown()
+
+
+def test_responses_api_instructions_read_from_model_parameters() -> None:
+    """A direct litellm.responses() call has no proxy request to read."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="responses",
+            messages=[{"role": "user", "content": "say ok"}],
+            model_parameters={"instructions": "Answer in one word."},
+            response=_make_slo_response(content="OK"),
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        assert exporter.requests[0].generations[0].system_prompt == "Answer in one word."
+    finally:
+        client.shutdown()
+
+
+def test_responses_api_logged_system_message_beats_instructions() -> None:
+    """A system message in the logged payload is what the provider saw."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client)
+        slo = _base_slo(
+            call_type="aresponses",
+            messages=[
+                {"role": "system", "content": "From the messages."},
+                {"role": "user", "content": "say ok"},
+            ],
+            model_parameters={"instructions": "From instructions."},
+            response=_make_slo_response(content="OK"),
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        assert exporter.requests[0].generations[0].system_prompt == "From the messages."
+    finally:
+        client.shutdown()
+
+
+def test_responses_api_instructions_suppressed_when_inputs_disabled() -> None:
+    """capture_inputs=False keeps the system prompt out, instructions included."""
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        handler = Agento11yLiteLLMLogger(client=client, capture_inputs=False)
+        slo = _base_slo(
+            call_type="aresponses",
+            messages=[{"role": "user", "content": "say ok"}],
+            model_parameters={"instructions": "You are terse."},
+            response=_make_slo_response(content="OK"),
+        )
+        handler.log_success_event(
+            kwargs=_make_kwargs(slo),
+            response_obj=None,
+            start_time=_START,
+            end_time=_END,
+        )
+        client.flush()
+
+        gen = exporter.requests[0].generations[0]
+        assert gen.system_prompt == ""
+        assert gen.input == []
     finally:
         client.shutdown()
 


### PR DESCRIPTION
- Client metadata on `/v1/messages` and `/v1/responses` lives in `litellm_metadata.requester_metadata`, which the adapter never read, so per-request `agent_name`, `agent_version` and `conversation_id` fell back to the static values.
- LiteLLM bridges `/v1/responses` to chat completions on providers without a native Responses API, then logs a chat payload under call type `aresponses`. The adapter chose its mapper by call type, so output and stop reason came out empty. The mapper now follows the payload shape, which is what the guardrail already did, and instructions is recorded as the system prompt.
- `/v1/messages` leaves `litellm_params` without a trace id, so its generations exported with an empty `conversation_id` and never joined a conversation. The logged payload's `trace_id` is now the last fallback.