### PR TITLE
feat(plugins/agento11y): import pi session history

### DIFF
--- a/conformance/pi-sessions/README.md
+++ b/conformance/pi-sessions/README.md
@@ -1,0 +1,151 @@
+# pi session fixtures
+
+These files pin the agreement between two implementations of one mapping.
+
+`agento11y history import pi` backfills pi sessions from the JSONL logs pi writes
+under `$PI_CODING_AGENT_DIR/sessions`. Live capture of the same sessions is the
+TypeScript plugin `@grafana/agento11y-pi`. Every other importer proves it matches
+live capture by calling the agent's own Go live mapper and comparing turn for
+turn; pi has no Go live mapper, so `plugins/agento11y/internal/history/pi.go`
+hand-ports the export path of `plugins/pi/src/mappers.ts` and
+`plugins/pi/src/lineage.ts`. These fixtures are what stops the port drifting.
+
+| File | Contents |
+|------|----------|
+| `sessions.json` | Session log inputs: the exact JSONL entries pi writes, one array per file. |
+| `generations.json` | The normalized generation each input must produce, per case. |
+
+Both sides read both files:
+
+- Go: `plugins/agento11y/internal/history/pi_conformance_test.go` writes each
+  case's files to a temporary directory, runs `piImporter.Turns`, normalizes, and
+  structurally diffs against `generations.json`.
+- TypeScript: `plugins/pi/src/piSessionConformance.test.ts` writes the same files,
+  replays them as pi events through a faked pi host into the real JS SDK,
+  normalizes the exported payload, and diffs against the same file.
+
+`mise run test:pi-sessions-conformance` runs both halves.
+
+## The inputs are real pi entries
+
+An entry is copied from what pi's `SessionManager` writes, not invented:
+
+- Line 1 is the session header: `{"type":"session","version":3,"id":…,"timestamp":…,"cwd":…}`,
+  plus `parentSession` when the session is a fork.
+- Every later line is a tree node with `id`, `parentId`, an ISO `timestamp`, and a
+  `type`. Only `type: "message"` entries carry model traffic; `session_info` carries
+  the user-set session name.
+- A `message` entry holds a user message, an assistant message, or a tool result,
+  told apart by `message.role` (`user`, `assistant`, `toolResult`).
+- An assistant message carries `provider`, `model`, `responseId`, `stopReason`,
+  `usage`, a unix-millisecond `timestamp`, and `content` blocks of type `text`,
+  `thinking`, or `toolCall`.
+
+Two encodings are worth stating because nothing in the proto describes them:
+
+| Field | On disk | In the fixture |
+|-------|---------|----------------|
+| `message.timestamp` | unix milliseconds, stamped when the provider builds the message, before the request | not compared; see the placeholder table |
+| tool call `arguments` | a JSON object | `output[].parts[].tool_call.arguments`, as a parsed object |
+
+The tool call arguments are compared parsed, not as text, because the two sides
+encode them differently on the wire: Go keeps embedded JSON, and the JS SDK
+base64-encodes `input_json`. Each reader decodes before comparing.
+
+`${DIR}` in an entry is replaced with the temporary directory the case runs in.
+Only the fork case needs it: a fork's header names its trunk by absolute path, and
+that path cannot be in a committed file.
+
+## The placeholder rule
+
+A `${NAME}` value in `generations.json` means: the field must be present and
+non-empty, and its value cannot agree across the two implementations. Both
+comparators enforce exactly that, and each has a test that asserts an empty
+placeholder still fails, so a placeholder never becomes a hole.
+
+| Placeholder | Why it cannot agree |
+|-------------|---------------------|
+| `${GENERATION_ID}` | Live IDs are `pi-sha256(conversationId\0entryId)[:24]` (`plugins/pi/src/lineage.ts`). Imported IDs are `histgen-…`, hashed from the source reference, and the framework guarantees a backfilled ID can never collide with a live one (`plugins/agento11y/internal/history/identity.go`). |
+| `${PARENT_GENERATION_ID}` | The parent edge names a generation, so it follows the same two schemes. Its presence and count are compared; its value is not. |
+| `${TRUNK_GENERATION_ID}` | Same, for the fork metadata's `pi.fork.parent_generation_id`. The sibling `pi.fork.parent_session_id` is a real session ID and is compared. |
+
+One limit of the fork pointer is worth stating, because no case can cover it. An
+imported generation ID hashes the path the session was read from, and a fork
+names its trunk by whatever path string the user typed, so the import can only
+reproduce the trunk's ID when the header spells the trunk the way discovery walks
+it. Path noise is cleaned away; a trunk reachable under a genuinely different
+path, through a symlinked home or a relative `PI_CODING_AGENT_DIR`, still reads
+fine and still yields a pointer to an ID nothing ingested. Closing that needs the
+framework to normalize `SourcePath` for every agent.
+| `${STARTED_AT}`, `${COMPLETED_AT}` | Live reads its own clock: `startedAt` is `Date.now()` at `turn_start` and `completedAt` is `Date.now()` at the assistant `message_end`. The importer has neither instant and uses the two the log persists: `message.timestamp` for the start and the entry's ISO `timestamp` for the end. The importer's exact values are pinned in `pi_test.go` instead. |
+
+## Fields that are not in the fixture at all
+
+Each one is either live-only or import-only, so comparing it would fail for a
+reason that is not drift.
+
+| Field | Which side | Why |
+|-------|------------|-----|
+| `system_prompt` | live only | Read from pi's runtime at `turn_end`. The session log does not persist it. |
+| `max_tokens`, `temperature`, `top_p`, `tool_choice`, thinking budget | live only | Read from the `before_provider_request` payload. Not persisted. |
+| time to first token | live only | Observed from the first `message_update`. Not persisted. |
+| `tools[].description`, `tools[].input_schema_json` | live only | Read from pi's tool registry. The log records only the calls a turn made, so an imported turn carries name-only definitions for those tools, and which tools were offered but unused is unrecoverable. |
+| `tags` (`cwd`, `git.branch`) | live only | Resolved from `process.cwd()` per turn. The header's `cwd` is the session's start directory, not the turn's. |
+| `agent_version`, `effective_version` | live only | The plugin's own version. Nothing in the log says which version wrote it. |
+| `agent_name` | filled later | The importer leaves it empty and `Exporter.prepare` fills it from the agent ID, giving `pi`, which is what the plugin sends. |
+| `agento11y.sdk.*` metadata | live only | Stamped by the SDK that exports. |
+| `agento11y.import.*` metadata | import only | The backfill and quality markers (`plugins/agento11y/internal/history/export.go`). |
+| quality flags | import only | `MissingModel`, `ApproxUsage` and the fork notes stay local to the import; they say what the log lacked, which live never has to ask. |
+
+## What the cases cover
+
+| Case | What it pins |
+|------|--------------|
+| `full-turn` | The base mapping: model, response ID, stop reason, usage, cost, one prompt in, one answer out. |
+| `thinking-turn` | Thinking text, which pi persists and Claude Code does not, plus a redacted thinking block both sides drop. `usage.total_tokens` here is pi's own `input + output + cacheRead + cacheWrite`, deliberately not the Go launchers' `input + output`. |
+| `tool-call-turn` | Two tool calls, both results matched to their call by ID, an error result, name-only tool definitions, and a second turn whose parent is the first one reached through the tool-result entries. The error result holds two text blocks, the first empty, which both sides drop before joining the rest with a newline. |
+| `missing-usage` | A usage block with a cost and no token counts. Both sides map every count to zero rather than inventing one. |
+| `fork` | A fork whose header names a trunk: the copied parent turn ships as `pi.fork.parent_session_id` metadata and no parent edge, because an edge would name a generation that does not exist under the fork's conversation ID. |
+
+## One case has a different generation count than the file has turns
+
+The `fork` input holds two assistant entries and both sides produce one
+generation. A fork copies the trunk's entries into its own file; pi never fires
+`turn_end` for a copied entry, so live never exported it under the fork's
+conversation, and the importer skips it for the same reason. The trunk's own
+import exports that turn. The copied prompts are skipped too, which is why the
+fork's title and input come from the first prompt the fork itself sent.
+
+## Turns the fixture cannot hold
+
+Compaction and branch summaries exist live and cannot be imported, so no case
+covers them. Live exports each host summarization call as its own generation. The
+persisted `compaction` entry carries `summary`, `firstKeptEntryId`,
+`tokensBefore`, `fromHook`, `details`, and on recent pi versions the call's
+`usage` with its cost, but no model, no provider and no request timing, so the
+call cannot be rebuilt as a generation. An imported session therefore holds fewer
+generations than live capture produced, and the missing ones are the expensive
+summarization calls, so comparing cost between imported and live data is not like
+for like.
+
+Subagent runs are missing from both sides rather than from the import alone. The
+nested `<session>/<runId>/run-N/session.jsonl` files come from the third-party
+`pi-subagents` package, and the plugin has no subagent code at all, so live
+capture ignores them; importing them would exceed live fidelity rather than match
+it.
+
+## Changing a fixture
+
+Neither `POST /api/v1/generations:export` field set nor the pi entry schema has a
+generated stub tying these files to code, so the files are the contract. When a
+mapping changes on purpose:
+
+1. Change the mapping on both sides.
+2. Update `generations.json`.
+3. Run `mise run test:pi-sessions-conformance`, then `mise run test:ts:plugin-pi`
+   to confirm the pi goldens in `plugins/pi/src/testdata/golden/` did not move for
+   an unrelated reason.
+
+Each side also has a comparator test that mutates a real generation one way the
+fixture cannot accept and asserts the diff names the offending field. Keep them:
+a permissive comparator keeps every case above green while checking nothing.

--- a/conformance/pi-sessions/generations.json
+++ b/conformance/pi-sessions/generations.json
@@ -1,0 +1,406 @@
+{
+  "cases": {
+    "full-turn": [
+      {
+        "id": "${GENERATION_ID}",
+        "conversation_id": "019ead07-cfbf-78d3-8b03-875769426583",
+        "conversation_title": "summarize the go files",
+        "model": {
+          "provider": "anthropic",
+          "name": "claude-sonnet-4-pi"
+        },
+        "response_id": "resp-pi-1",
+        "response_model": "claude-sonnet-4-pi",
+        "mode": "STREAM",
+        "operation_name": "streamText",
+        "stop_reason": "end_turn",
+        "thinking_enabled": false,
+        "usage": {
+          "input_tokens": 120,
+          "output_tokens": 30,
+          "total_tokens": 160,
+          "cache_read_input_tokens": 10,
+          "cache_write_input_tokens": 0,
+          "reasoning_tokens": 0
+        },
+        "started_at": "${STARTED_AT}",
+        "completed_at": "${COMPLETED_AT}",
+        "input": [
+          {
+            "role": "user",
+            "parts": [
+              {
+                "kind": "text",
+                "text": "summarize the go files"
+              }
+            ]
+          }
+        ],
+        "output": [
+          {
+            "role": "assistant",
+            "parts": [
+              {
+                "kind": "text",
+                "text": "There are two go files: main.go and util.go."
+              }
+            ]
+          }
+        ],
+        "tools": [],
+        "cost_usd": 0.003,
+        "call_error": "",
+        "parent_generation_ids": [],
+        "fork": null
+      }
+    ],
+    "thinking-turn": [
+      {
+        "id": "${GENERATION_ID}",
+        "conversation_id": "019ead20-1111-78d3-8b03-875769426583",
+        "conversation_title": "why does the build fail?",
+        "model": {
+          "provider": "anthropic",
+          "name": "claude-opus-4-8"
+        },
+        "response_id": "resp-pi-2",
+        "response_model": "claude-opus-4-8",
+        "mode": "STREAM",
+        "operation_name": "streamText",
+        "stop_reason": "end_turn",
+        "thinking_enabled": true,
+        "usage": {
+          "input_tokens": 2,
+          "output_tokens": 311,
+          "total_tokens": 46539,
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 46226,
+          "reasoning_tokens": 0
+        },
+        "started_at": "${STARTED_AT}",
+        "completed_at": "${COMPLETED_AT}",
+        "input": [
+          {
+            "role": "user",
+            "parts": [
+              {
+                "kind": "text",
+                "text": "why does the build fail?"
+              }
+            ]
+          }
+        ],
+        "output": [
+          {
+            "role": "assistant",
+            "parts": [
+              {
+                "kind": "thinking",
+                "thinking": "The error names a missing import."
+              }
+            ]
+          },
+          {
+            "role": "assistant",
+            "parts": [
+              {
+                "kind": "text",
+                "text": "An import is missing."
+              }
+            ]
+          }
+        ],
+        "tools": [],
+        "cost_usd": 0.2966975,
+        "call_error": "",
+        "parent_generation_ids": [],
+        "fork": null
+      }
+    ],
+    "tool-call-turn": [
+      {
+        "id": "${GENERATION_ID}",
+        "conversation_id": "019ead30-2222-78d3-8b03-875769426583",
+        "conversation_title": "review the last commit",
+        "model": {
+          "provider": "anthropic",
+          "name": "claude-opus-4-8"
+        },
+        "response_id": "resp-pi-3",
+        "response_model": "claude-opus-4-8",
+        "mode": "STREAM",
+        "operation_name": "streamText",
+        "stop_reason": "tool_use",
+        "thinking_enabled": false,
+        "usage": {
+          "input_tokens": 12,
+          "output_tokens": 34,
+          "total_tokens": 57,
+          "cache_read_input_tokens": 5,
+          "cache_write_input_tokens": 6,
+          "reasoning_tokens": 0
+        },
+        "started_at": "${STARTED_AT}",
+        "completed_at": "${COMPLETED_AT}",
+        "input": [
+          {
+            "role": "user",
+            "parts": [
+              {
+                "kind": "text",
+                "text": "review the last commit"
+              }
+            ]
+          }
+        ],
+        "output": [
+          {
+            "role": "assistant",
+            "parts": [
+              {
+                "kind": "text",
+                "text": "Let me gather context."
+              }
+            ]
+          },
+          {
+            "role": "assistant",
+            "parts": [
+              {
+                "kind": "tool_call",
+                "tool_call": {
+                  "id": "toolu_1",
+                  "name": "bash",
+                  "arguments": {
+                    "command": "git log -1"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "role": "assistant",
+            "parts": [
+              {
+                "kind": "tool_call",
+                "tool_call": {
+                  "id": "toolu_2",
+                  "name": "read",
+                  "arguments": {
+                    "path": "main.go",
+                    "limit": 40
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "role": "tool",
+            "parts": [
+              {
+                "kind": "tool_result",
+                "tool_result": {
+                  "tool_call_id": "toolu_1",
+                  "name": "bash",
+                  "content": "commit abc123",
+                  "is_error": false
+                }
+              }
+            ]
+          },
+          {
+            "role": "tool",
+            "parts": [
+              {
+                "kind": "tool_result",
+                "tool_result": {
+                  "tool_call_id": "toolu_2",
+                  "name": "read",
+                  "content": "package main",
+                  "is_error": true
+                }
+              }
+            ]
+          }
+        ],
+        "tools": [
+          {
+            "name": "bash"
+          },
+          {
+            "name": "read"
+          }
+        ],
+        "cost_usd": 0.006,
+        "call_error": "",
+        "parent_generation_ids": [],
+        "fork": null
+      },
+      {
+        "id": "${GENERATION_ID}",
+        "conversation_id": "019ead30-2222-78d3-8b03-875769426583",
+        "conversation_title": "review the last commit",
+        "model": {
+          "provider": "anthropic",
+          "name": "claude-opus-4-8"
+        },
+        "response_id": "resp-pi-4",
+        "response_model": "claude-opus-4-8",
+        "mode": "STREAM",
+        "operation_name": "streamText",
+        "stop_reason": "end_turn",
+        "thinking_enabled": false,
+        "usage": {
+          "input_tokens": 40,
+          "output_tokens": 8,
+          "total_tokens": 48,
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "reasoning_tokens": 0
+        },
+        "started_at": "${STARTED_AT}",
+        "completed_at": "${COMPLETED_AT}",
+        "input": [
+          {
+            "role": "user",
+            "parts": [
+              {
+                "kind": "text",
+                "text": "and the tests?"
+              }
+            ]
+          }
+        ],
+        "output": [
+          {
+            "role": "assistant",
+            "parts": [
+              {
+                "kind": "text",
+                "text": "They pass."
+              }
+            ]
+          }
+        ],
+        "tools": [],
+        "cost_usd": 0.0006,
+        "call_error": "",
+        "parent_generation_ids": [
+          "${PARENT_GENERATION_ID}"
+        ],
+        "fork": null
+      }
+    ],
+    "missing-usage": [
+      {
+        "id": "${GENERATION_ID}",
+        "conversation_id": "019ead40-3333-78d3-8b03-875769426583",
+        "conversation_title": "count the files",
+        "model": {
+          "provider": "openai-codex",
+          "name": "gpt-5.5"
+        },
+        "response_id": "resp-pi-5",
+        "response_model": "gpt-5.5",
+        "mode": "STREAM",
+        "operation_name": "streamText",
+        "stop_reason": "end_turn",
+        "thinking_enabled": false,
+        "usage": {
+          "input_tokens": 0,
+          "output_tokens": 0,
+          "total_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "reasoning_tokens": 0
+        },
+        "started_at": "${STARTED_AT}",
+        "completed_at": "${COMPLETED_AT}",
+        "input": [
+          {
+            "role": "user",
+            "parts": [
+              {
+                "kind": "text",
+                "text": "count the files"
+              }
+            ]
+          }
+        ],
+        "output": [
+          {
+            "role": "assistant",
+            "parts": [
+              {
+                "kind": "text",
+                "text": "Fourteen."
+              }
+            ]
+          }
+        ],
+        "tools": [],
+        "cost_usd": 0.02,
+        "call_error": "",
+        "parent_generation_ids": [],
+        "fork": null
+      }
+    ],
+    "fork": [
+      {
+        "id": "${GENERATION_ID}",
+        "conversation_id": "019ead60-5555-78d3-8b03-875769426583",
+        "conversation_title": "shorter, please",
+        "model": {
+          "provider": "anthropic",
+          "name": "claude-opus-4-8"
+        },
+        "response_id": "resp-pi-7",
+        "response_model": "claude-opus-4-8",
+        "mode": "STREAM",
+        "operation_name": "streamText",
+        "stop_reason": "end_turn",
+        "thinking_enabled": false,
+        "usage": {
+          "input_tokens": 14,
+          "output_tokens": 6,
+          "total_tokens": 20,
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "reasoning_tokens": 0
+        },
+        "started_at": "${STARTED_AT}",
+        "completed_at": "${COMPLETED_AT}",
+        "input": [
+          {
+            "role": "user",
+            "parts": [
+              {
+                "kind": "text",
+                "text": "shorter, please"
+              }
+            ]
+          }
+        ],
+        "output": [
+          {
+            "role": "assistant",
+            "parts": [
+              {
+                "kind": "text",
+                "text": "One line, then."
+              }
+            ]
+          }
+        ],
+        "tools": [],
+        "cost_usd": 0.0005,
+        "call_error": "",
+        "parent_generation_ids": [],
+        "fork": {
+          "parent_session_id": "019ead50-4444-78d3-8b03-875769426583",
+          "parent_generation_id": "${TRUNK_GENERATION_ID}"
+        }
+      }
+    ]
+  }
+}

--- a/conformance/pi-sessions/sessions.json
+++ b/conformance/pi-sessions/sessions.json
@@ -1,0 +1,449 @@
+{
+  "cases": [
+    {
+      "id": "full-turn",
+      "description": "One prompt, one assistant answer with text only, complete usage and cost.",
+      "session_file": "2026-06-09T15-37-10-848Z_019ead07-cfbf-78d3-8b03-875769426583.jsonl",
+      "files": {
+        "2026-06-09T15-37-10-848Z_019ead07-cfbf-78d3-8b03-875769426583.jsonl": [
+          {
+            "type": "session",
+            "version": 3,
+            "id": "019ead07-cfbf-78d3-8b03-875769426583",
+            "timestamp": "2026-06-09T15:37:10.848Z",
+            "cwd": "/work/repo"
+          },
+          {
+            "type": "message",
+            "id": "u1",
+            "parentId": null,
+            "timestamp": "2026-06-09T15:37:20.000Z",
+            "message": {
+              "role": "user",
+              "content": [{ "type": "text", "text": "summarize the go files" }],
+              "timestamp": 1781019440000
+            }
+          },
+          {
+            "type": "message",
+            "id": "a1",
+            "parentId": "u1",
+            "timestamp": "2026-06-09T15:37:24.526Z",
+            "message": {
+              "role": "assistant",
+              "content": [
+                {
+                  "type": "text",
+                  "text": "There are two go files: main.go and util.go."
+                }
+              ],
+              "api": "anthropic-messages",
+              "provider": "anthropic",
+              "model": "claude-sonnet-4-pi",
+              "responseId": "resp-pi-1",
+              "stopReason": "stop",
+              "timestamp": 1781019441000,
+              "usage": {
+                "input": 120,
+                "output": 30,
+                "cacheRead": 10,
+                "cacheWrite": 0,
+                "totalTokens": 160,
+                "cost": {
+                  "input": 0.001,
+                  "output": 0.002,
+                  "cacheRead": 0,
+                  "cacheWrite": 0,
+                  "total": 0.003
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "thinking-turn",
+      "description": "An assistant turn with a thinking block, a redacted thinking block that both sides drop, and text.",
+      "session_file": "2026-06-09T16-00-00-000Z_019ead20-1111-78d3-8b03-875769426583.jsonl",
+      "files": {
+        "2026-06-09T16-00-00-000Z_019ead20-1111-78d3-8b03-875769426583.jsonl": [
+          {
+            "type": "session",
+            "version": 3,
+            "id": "019ead20-1111-78d3-8b03-875769426583",
+            "timestamp": "2026-06-09T16:00:00.000Z",
+            "cwd": "/work/repo"
+          },
+          {
+            "type": "message",
+            "id": "u1",
+            "parentId": null,
+            "timestamp": "2026-06-09T16:00:05.000Z",
+            "message": {
+              "role": "user",
+              "content": "why does the build fail?",
+              "timestamp": 1781020805000
+            }
+          },
+          {
+            "type": "message",
+            "id": "a1",
+            "parentId": "u1",
+            "timestamp": "2026-06-09T16:00:12.000Z",
+            "message": {
+              "role": "assistant",
+              "content": [
+                {
+                  "type": "thinking",
+                  "thinking": "The error names a missing import.",
+                  "thinkingSignature": "sig-1"
+                },
+                { "type": "thinking", "thinking": "hidden", "redacted": true },
+                { "type": "text", "text": "An import is missing." }
+              ],
+              "api": "anthropic-messages",
+              "provider": "anthropic",
+              "model": "claude-opus-4-8",
+              "responseId": "resp-pi-2",
+              "stopReason": "stop",
+              "timestamp": 1781020807000,
+              "usage": {
+                "input": 2,
+                "output": 311,
+                "cacheRead": 0,
+                "cacheWrite": 46226,
+                "totalTokens": 46539,
+                "cost": {
+                  "input": 0.00001,
+                  "output": 0.007775,
+                  "cacheRead": 0,
+                  "cacheWrite": 0.2889125,
+                  "total": 0.2966975
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "tool-call-turn",
+      "description": "Two prompts and two turns: the first calls two tools and gets both results, the second answers. The second turn's input covers the buffered prompt, and its parent is the first turn reached through the tool-result entries.",
+      "session_file": "2026-06-09T17-00-00-000Z_019ead30-2222-78d3-8b03-875769426583.jsonl",
+      "files": {
+        "2026-06-09T17-00-00-000Z_019ead30-2222-78d3-8b03-875769426583.jsonl": [
+          {
+            "type": "session",
+            "version": 3,
+            "id": "019ead30-2222-78d3-8b03-875769426583",
+            "timestamp": "2026-06-09T17:00:00.000Z",
+            "cwd": "/work/repo"
+          },
+          {
+            "type": "message",
+            "id": "u1",
+            "parentId": null,
+            "timestamp": "2026-06-09T17:00:05.000Z",
+            "message": {
+              "role": "user",
+              "content": [{ "type": "text", "text": "review the last commit" }],
+              "timestamp": 1781024405000
+            }
+          },
+          {
+            "type": "message",
+            "id": "a1",
+            "parentId": "u1",
+            "timestamp": "2026-06-09T17:00:11.000Z",
+            "message": {
+              "role": "assistant",
+              "content": [
+                { "type": "text", "text": "Let me gather context." },
+                {
+                  "type": "toolCall",
+                  "id": "toolu_1",
+                  "name": "bash",
+                  "arguments": { "command": "git log -1" }
+                },
+                {
+                  "type": "toolCall",
+                  "id": "toolu_2",
+                  "name": "read",
+                  "arguments": { "path": "main.go", "limit": 40 }
+                }
+              ],
+              "api": "anthropic-messages",
+              "provider": "anthropic",
+              "model": "claude-opus-4-8",
+              "responseId": "resp-pi-3",
+              "stopReason": "toolUse",
+              "timestamp": 1781024406000,
+              "usage": {
+                "input": 12,
+                "output": 34,
+                "cacheRead": 5,
+                "cacheWrite": 6,
+                "totalTokens": 57,
+                "cost": {
+                  "input": 0.001,
+                  "output": 0.002,
+                  "cacheRead": 0,
+                  "cacheWrite": 0.003,
+                  "total": 0.006
+                }
+              }
+            }
+          },
+          {
+            "type": "message",
+            "id": "r1",
+            "parentId": "a1",
+            "timestamp": "2026-06-09T17:00:12.000Z",
+            "message": {
+              "role": "toolResult",
+              "toolCallId": "toolu_1",
+              "toolName": "bash",
+              "content": [{ "type": "text", "text": "commit abc123" }],
+              "isError": false,
+              "timestamp": 1781024412000
+            }
+          },
+          {
+            "type": "message",
+            "id": "r2",
+            "parentId": "r1",
+            "timestamp": "2026-06-09T17:00:13.000Z",
+            "message": {
+              "role": "toolResult",
+              "toolCallId": "toolu_2",
+              "toolName": "read",
+              "content": [
+                { "type": "text", "text": "" },
+                { "type": "text", "text": "package main" }
+              ],
+              "isError": true,
+              "timestamp": 1781024413000
+            }
+          },
+          {
+            "type": "message",
+            "id": "u2",
+            "parentId": "r2",
+            "timestamp": "2026-06-09T17:01:00.000Z",
+            "message": {
+              "role": "user",
+              "content": [{ "type": "text", "text": "and the tests?" }],
+              "timestamp": 1781024460000
+            }
+          },
+          {
+            "type": "message",
+            "id": "a2",
+            "parentId": "u2",
+            "timestamp": "2026-06-09T17:01:06.000Z",
+            "message": {
+              "role": "assistant",
+              "content": [{ "type": "text", "text": "They pass." }],
+              "api": "anthropic-messages",
+              "provider": "anthropic",
+              "model": "claude-opus-4-8",
+              "responseId": "resp-pi-4",
+              "stopReason": "stop",
+              "timestamp": 1781024461000,
+              "usage": {
+                "input": 40,
+                "output": 8,
+                "cacheRead": 0,
+                "cacheWrite": 0,
+                "totalTokens": 48,
+                "cost": {
+                  "input": 0.0004,
+                  "output": 0.0002,
+                  "cacheRead": 0,
+                  "cacheWrite": 0,
+                  "total": 0.0006
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "missing-usage",
+      "description": "A usage block that reports a cost and no token counts. Both sides map every count to zero rather than inventing one; only the import records that the counts were unknown, as a local quality flag.",
+      "session_file": "2026-06-09T18-00-00-000Z_019ead40-3333-78d3-8b03-875769426583.jsonl",
+      "files": {
+        "2026-06-09T18-00-00-000Z_019ead40-3333-78d3-8b03-875769426583.jsonl": [
+          {
+            "type": "session",
+            "version": 3,
+            "id": "019ead40-3333-78d3-8b03-875769426583",
+            "timestamp": "2026-06-09T18:00:00.000Z",
+            "cwd": "/work/repo"
+          },
+          {
+            "type": "message",
+            "id": "u1",
+            "parentId": null,
+            "timestamp": "2026-06-09T18:00:05.000Z",
+            "message": {
+              "role": "user",
+              "content": [{ "type": "text", "text": "count the files" }],
+              "timestamp": 1781028005000
+            }
+          },
+          {
+            "type": "message",
+            "id": "a1",
+            "parentId": "u1",
+            "timestamp": "2026-06-09T18:00:09.000Z",
+            "message": {
+              "role": "assistant",
+              "content": [{ "type": "text", "text": "Fourteen." }],
+              "api": "openai-codex-responses",
+              "provider": "openai-codex",
+              "model": "gpt-5.5",
+              "responseId": "resp-pi-5",
+              "stopReason": "stop",
+              "timestamp": 1781028006000,
+              "usage": { "cost": { "total": 0.02 } }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "fork",
+      "description": "A fork whose header names a trunk file. The fork's first own turn has a parent copied from the trunk, so both sides report the trunk as metadata and emit no parent edge.",
+      "session_file": "2026-06-09T19-10-00-000Z_019ead60-5555-78d3-8b03-875769426583.jsonl",
+      "files": {
+        "2026-06-09T19-00-00-000Z_019ead50-4444-78d3-8b03-875769426583.jsonl": [
+          {
+            "type": "session",
+            "version": 3,
+            "id": "019ead50-4444-78d3-8b03-875769426583",
+            "timestamp": "2026-06-09T19:00:00.000Z",
+            "cwd": "/work/repo"
+          },
+          {
+            "type": "message",
+            "id": "u1",
+            "parentId": null,
+            "timestamp": "2026-06-09T19:00:05.000Z",
+            "message": {
+              "role": "user",
+              "content": [{ "type": "text", "text": "draft the release note" }],
+              "timestamp": 1781031605000
+            }
+          },
+          {
+            "type": "message",
+            "id": "a1",
+            "parentId": "u1",
+            "timestamp": "2026-06-09T19:00:11.000Z",
+            "message": {
+              "role": "assistant",
+              "content": [{ "type": "text", "text": "Here is a draft." }],
+              "api": "anthropic-messages",
+              "provider": "anthropic",
+              "model": "claude-opus-4-8",
+              "responseId": "resp-pi-6",
+              "stopReason": "stop",
+              "timestamp": 1781031606000,
+              "usage": {
+                "input": 10,
+                "output": 20,
+                "cacheRead": 0,
+                "cacheWrite": 0,
+                "totalTokens": 30,
+                "cost": { "total": 0.001 }
+              }
+            }
+          }
+        ],
+        "2026-06-09T19-10-00-000Z_019ead60-5555-78d3-8b03-875769426583.jsonl": [
+          {
+            "type": "session",
+            "version": 3,
+            "id": "019ead60-5555-78d3-8b03-875769426583",
+            "timestamp": "2026-06-09T19:10:00.000Z",
+            "cwd": "/work/repo",
+            "parentSession": "${DIR}/2026-06-09T19-00-00-000Z_019ead50-4444-78d3-8b03-875769426583.jsonl"
+          },
+          {
+            "type": "message",
+            "id": "u1",
+            "parentId": null,
+            "timestamp": "2026-06-09T19:00:05.000Z",
+            "message": {
+              "role": "user",
+              "content": [{ "type": "text", "text": "draft the release note" }],
+              "timestamp": 1781031605000
+            }
+          },
+          {
+            "type": "message",
+            "id": "a1",
+            "parentId": "u1",
+            "timestamp": "2026-06-09T19:00:11.000Z",
+            "message": {
+              "role": "assistant",
+              "content": [{ "type": "text", "text": "Here is a draft." }],
+              "api": "anthropic-messages",
+              "provider": "anthropic",
+              "model": "claude-opus-4-8",
+              "responseId": "resp-pi-6",
+              "stopReason": "stop",
+              "timestamp": 1781031606000,
+              "usage": {
+                "input": 10,
+                "output": 20,
+                "cacheRead": 0,
+                "cacheWrite": 0,
+                "totalTokens": 30,
+                "cost": { "total": 0.001 }
+              }
+            }
+          },
+          {
+            "type": "message",
+            "id": "u2",
+            "parentId": "a1",
+            "timestamp": "2026-06-09T19:11:00.000Z",
+            "message": {
+              "role": "user",
+              "content": [{ "type": "text", "text": "shorter, please" }],
+              "timestamp": 1781032260000
+            }
+          },
+          {
+            "type": "message",
+            "id": "a2",
+            "parentId": "u2",
+            "timestamp": "2026-06-09T19:11:07.000Z",
+            "message": {
+              "role": "assistant",
+              "content": [{ "type": "text", "text": "One line, then." }],
+              "api": "anthropic-messages",
+              "provider": "anthropic",
+              "model": "claude-opus-4-8",
+              "responseId": "resp-pi-7",
+              "stopReason": "stop",
+              "timestamp": 1781032261000,
+              "usage": {
+                "input": 14,
+                "output": 6,
+                "cacheRead": 0,
+                "cacheWrite": 0,
+                "totalTokens": 20,
+                "cost": { "total": 0.0005 }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/mise.toml
+++ b/mise.toml
@@ -514,6 +514,30 @@ mise run test:py:sdk-framework-conformance
 mise run test:java:sdk-framework-conformance
 """
 
+[tasks."test:go:pi-sessions-conformance"]
+description = "Run the Go half of the pi session-log conformance tests"
+dir = "plugins/agento11y"
+run = "GOWORK=off go test ./internal/history -run '^TestPiSession' -count=1"
+
+[tasks."test:ts:pi-sessions-conformance"]
+description = "Run the TypeScript half of the pi session-log conformance tests"
+depends = ["deps", "build:ts:sdk-js"]
+run = "pnpm --filter @grafana/agento11y-pi exec vitest run src/piSessionConformance.test.ts"
+
+[tasks."test:pi-sessions-conformance"]
+description = """
+Check the Go pi history importer and the TypeScript pi plugin against the shared
+conformance/pi-sessions fixtures. pi is the one agent whose live capture is
+TypeScript and whose importer is Go, so the fixtures are the only thing holding
+the two mappings together.
+"""
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+mise run test:go:pi-sessions-conformance
+mise run test:ts:pi-sessions-conformance
+"""
+
 [tasks."test:sdk:conformance"]
 description = "Run core, provider-wrapper, and framework-adapter conformance suites across supported SDKs"
 run = """
@@ -524,6 +548,7 @@ mise run test:sdk:hooks-conformance
 mise run test:sdk:experiments-conformance
 mise run test:sdk:provider-conformance
 mise run test:sdk:framework-conformance
+mise run test:pi-sessions-conformance
 """
 
 [tasks."test:sdk:all"]

--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -129,7 +129,17 @@ agento11y history import claude-code --local
 agento11y history import claude-code
 ```
 
-Supported agents are `claude-code` and `codex`. `agento11y history import` with no agent lists them.
+Supported agents are `claude-code`, `codex`, and `pi`. `agento11y history import` with no agent lists them.
+
+A `pi` import reads pi's session logs under `$PI_CODING_AGENT_DIR/sessions` (by default `~/.pi/agent/sessions`) and produces one generation per assistant turn, with its prompt, thinking, tool calls, matched tool results, model, token usage, cost, both timestamps, and parent turn. Three things live capture records are not in the session log, so an imported pi session is thinner than a captured one:
+
+- No compaction or branch-summary generations. Live exports each summarization call as its own generation. pi's `compaction` entry carries the summary text, the token count it compacted away, and, on recent pi versions, the call's `usage` and cost, but never the model or the provider, so the call cannot be reconstructed as a generation. An imported session therefore holds fewer generations than a captured one, and the missing ones are the expensive calls.
+- No system prompt, request controls (`max_tokens`, `temperature`, `top_p`, tool choice, thinking budget), or time to first token. pi records none of them.
+- Tool definitions are name-only, and only for the tools a turn called: the descriptions, schemas, and the list of tools that were offered but unused live in pi's runtime. Session tags (`cwd`, `git.branch`) are absent for the same reason.
+
+Subagent runs are in neither: the nested `run-N/session.jsonl` logs come from the third-party `pi-subagents` package, which live capture ignores too, so importing them would exceed live fidelity rather than match it.
+
+A forked pi session imports only the turns the fork itself ran. The trunk holds the entries a fork copied from it and exports those turns under its own import, and, when the trunk exported the fork's parent turn, the fork's first turn carries `pi.fork.parent_session_id` and `pi.fork.parent_generation_id` metadata instead of a parent edge. A fork of a fork carries neither key, because no trunk generation exists to name.
 
 `--local` picks the endpoint. Without it, the import exports to the configured Grafana Cloud endpoint, exactly as a live session does. With it, the import exports to the local daemon on this machine.
 

--- a/plugins/agento11y/internal/history/history.go
+++ b/plugins/agento11y/internal/history/history.go
@@ -32,12 +32,13 @@ import (
 // live one.
 type AgentID string
 
-// The agents with a registered importer. Both are declared here rather than in
+// The agents with a registered importer. They are declared here rather than in
 // their importer files so callers can name them without importing the agent
 // package and triggering its init.
 const (
 	AgentClaudeCode AgentID = "claude-code"
 	AgentCodex      AgentID = "codex"
+	AgentPi         AgentID = "pi"
 )
 
 // SourceRef locates a single historical turn on disk. It is content-free: it

--- a/plugins/agento11y/internal/history/pi.go
+++ b/plugins/agento11y/internal/history/pi.go
@@ -1,0 +1,1110 @@
+package history
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"iter"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/grafana/agento11y/go/agento11y"
+)
+
+func init() {
+	Register(AgentSpec{
+		ID:          AgentPi,
+		DisplayName: "pi",
+		Aliases:     []string{"pi-coding-agent"},
+	}, func() Importer { return &piImporter{} })
+}
+
+// piMaxTitleLen caps a conversation title derived from the first prompt. It
+// matches MAX_TITLE_LEN in plugins/pi/src/mappers.ts and counts runes, so a
+// title never splits a multi-byte character.
+const piMaxTitleLen = 100
+
+// piImporter reads pi's session logs under $PI_CODING_AGENT_DIR/sessions (or
+// ~/.pi/agent/sessions).
+//
+// pi is the first agent with no Go live mapper: live capture is the TypeScript
+// plugin @grafana/agento11y-pi, so the mapping below is a port of the
+// export-path subset of plugins/pi/src/mappers.ts and plugins/pi/src/lineage.ts
+// rather than a call into shared code. conformance/pi-sessions holds the
+// fixtures that keep the two in agreement; see pi_conformance_test.go.
+type piImporter struct {
+	// roots overrides the resolved session directories. Tests set it.
+	roots []string
+}
+
+func (p *piImporter) Roots() []string {
+	if len(p.roots) > 0 {
+		return p.roots
+	}
+	// The same resolution as internal/agents/pi, duplicated on purpose: that
+	// package imports internal/local, which imports this one, so importing it
+	// here would be a cycle.
+	if dir := strings.TrimSpace(os.Getenv("PI_CODING_AGENT_DIR")); dir != "" {
+		return []string{filepath.Join(dir, "sessions")}
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return []string{filepath.Join(home, ".pi", "agent", "sessions")}
+}
+
+// piSubagentRunDir matches the run directory the third-party pi-subagents
+// package writes its child sessions into: <session-dir>/<runID>/run-<N>/.
+var piSubagentRunDir = regexp.MustCompile(`^run-[0-9]+$`)
+
+// Match accepts a pi session log and rejects a subagent run log.
+//
+// pi writes one session per file directly inside the encoded-cwd directory
+// (SessionManager.getDefaultSessionDir), and lists sessions from that directory
+// alone. Anything deeper is another tool's: pi-subagents nests a child run
+// under <session-dir>/<runID>/run-<N>/, as session.jsonl on current versions
+// and as <timestamp>_<uuid>.jsonl on older ones, and writes task input and
+// output dumps into a sibling subagent-artifacts directory. Live capture
+// records none of those runs (the pi plugin has no subagent code at all), so
+// importing them would exceed live fidelity rather than match it.
+func (p *piImporter) Match(path string) bool {
+	if !strings.HasSuffix(path, ".jsonl") {
+		return false
+	}
+	dir, base := filepath.Split(filepath.ToSlash(path))
+	if base == "session.jsonl" {
+		return false
+	}
+	for segment := range strings.SplitSeq(strings.Trim(dir, "/"), "/") {
+		if segment == "subagent-artifacts" || piSubagentRunDir.MatchString(segment) {
+			return false
+		}
+	}
+	return true
+}
+
+// piPreviewLine is the metadata-only view of a session line. It deliberately
+// has no message or details field: a preview must not decode content, and one
+// subagent tool result's details inlines a full task prompt, a full subagent
+// transcript, and every child tool call.
+type piPreviewLine struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`   // session header: the conversation ID
+	CWD  string `json:"cwd"`  // session header: the workspace
+	Name string `json:"name"` // session_info: the user-set display name
+	// ParentSession is the header's trunk path. Only its presence is read: it
+	// makes the header timestamp a fork instant, and the turns before it belong
+	// to the trunk.
+	ParentSession string `json:"parentSession"`
+	Timestamp     string `json:"timestamp"`
+}
+
+// piRoleMarker locates a message's role by byte scan. pi writes compact JSON
+// with no spaces, so this finds the role without decoding the line, which is
+// what holds discovery over thousands of sessions to seconds.
+//
+// Only the first occurrence in a line is the entry's own role. A later one is
+// nested content: a tool result's details hold arbitrary JSON, and a subagent
+// result nests whole assistant messages in there. Counting those made a preview
+// promise more turns than its own import delivered.
+//
+// Checked against decoding every line of all 2,536 top-level sessions on the
+// development machine: the rule agrees with the decoded role on all 121,718
+// assistant entries and reports no others.
+var piRoleMarker = []byte(`"role":"`)
+
+// piIsAssistantLine reports whether a raw session line is an assistant message
+// entry.
+func piIsAssistantLine(raw []byte) bool {
+	_, rest, found := bytes.Cut(raw, piRoleMarker)
+	return found && bytes.HasPrefix(rest, []byte(`assistant"`))
+}
+
+// piEntryTimestampMarker finds an entry's own ISO timestamp by byte scan. It is
+// the first `"timestamp":"` in the line, because pi writes the entry's fields
+// before its message, and the message's timestamp is a number rather than a
+// string. A later occurrence inside message content cannot be mistaken for it.
+var piEntryTimestampMarker = []byte(`"timestamp":"`)
+
+// piCountAssistantTurns counts the turns a session produced in a window of its
+// lines.
+//
+// cutoff, when non-zero, is the fork instant: an entry at or before it was
+// copied from the trunk, and [piImporter.Turns] does not export it, so counting
+// it would promise turns the import will not deliver. A line with no readable
+// timestamp counts, matching the same choice in [piSession.isCopied].
+func piCountAssistantTurns(lines [][]byte, cutoff time.Time) int {
+	turns := 0
+	for _, raw := range lines {
+		if !piIsAssistantLine(raw) {
+			continue
+		}
+		if !cutoff.IsZero() {
+			if ts := piEntryTimestamp(raw); !ts.IsZero() && !ts.After(cutoff) {
+				continue
+			}
+		}
+		turns++
+	}
+	return turns
+}
+
+// piEstimateTurns scales a sampled assistant-turn count to the whole file.
+//
+// The head window is the sample, the way every other importer takes it. When
+// the head holds no turn the import would export, the tail window becomes the
+// sample instead, because scaling zero by any factor stays zero. A fork hits
+// that case whenever it is larger than the byte budget: its copied entries sit
+// at the front of the file by construction, so the head window is nothing but
+// entries the import skips, and the session previewed as "about 0 turns" while
+// its import produced dozens. On the development machine 77 of the 305 sessions
+// over the budget are such forks.
+//
+// The tail estimate spreads the tail's turn density over the bytes the head did
+// not cover, since the head is known to hold none. Both branches report approx,
+// so the number is labelled either way.
+func piEstimateTurns(win PreviewWindows, cutoff time.Time) (total int, approx bool) {
+	head := piCountAssistantTurns(win.HeadLines(), cutoff)
+	if win.Whole || head > 0 {
+		return win.EstimateTotal(head)
+	}
+	tail := piCountAssistantTurns(win.TailLines(), cutoff)
+	if tail == 0 || len(win.Tail) == 0 {
+		return 0, true
+	}
+	rest := win.Size - int64(len(win.Head))
+	scaled := float64(tail) * float64(rest) / float64(len(win.Tail))
+	return int(scaled), true
+}
+
+func piEntryTimestamp(raw []byte) time.Time {
+	_, rest, found := bytes.Cut(raw, piEntryTimestampMarker)
+	if !found {
+		return time.Time{}
+	}
+	value, _, closed := bytes.Cut(rest, []byte(`"`))
+	if !closed {
+		return time.Time{}
+	}
+	return parseClaudeTime(string(value))
+}
+
+// Preview reads a bounded head and tail window. pi puts the session ID, the
+// workspace, and the start time on line 1, so only that line is decoded rather
+// than a run of lines carrying scattered metadata.
+//
+// The turn count is the number of assistant messages in the window, scaled to
+// the file. Unlike Claude Code there is nothing to deduplicate: one assistant
+// entry is one turn, because pi's turn_end fires once per LLM request. In a fork
+// the copied region is left out, because the import leaves it out too.
+func (p *piImporter) Preview(ctx context.Context, path string) (SessionPreview, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return SessionPreview{}, false, err
+	}
+	win, err := ReadPreviewWindows(path, PreviewByteBudget)
+	if err != nil {
+		return SessionPreview{}, false, err
+	}
+	head := win.HeadLines()
+	if len(head) == 0 {
+		return SessionPreview{}, false, nil // not a usable session
+	}
+
+	pv := SessionPreview{Agent: AgentPi, SourcePath: path, SizeBytes: win.Size}
+	var header piPreviewLine
+	if err := json.Unmarshal(head[0], &header); err != nil || header.Type != "session" {
+		return SessionPreview{}, false, nil // no session header: not a pi session
+	}
+	pv.SessionID = header.ID
+	pv.Workspace = header.CWD
+	pv.StartedAt = parseClaudeTime(header.Timestamp)
+
+	var cutoff time.Time
+	if strings.TrimSpace(header.ParentSession) != "" {
+		cutoff = pv.StartedAt
+	}
+	pv.TurnCount, pv.ApproxTurns = piEstimateTurns(win, cutoff)
+
+	// The title and the last activity both come from the end of the file: the
+	// title from the newest session_info, which is where pi keeps the user-set
+	// display name, and the activity from the last entry that carries a
+	// timestamp.
+	last := win.TailLines()
+	if win.Whole {
+		last = head
+	}
+	for i := len(last) - 1; i >= 0 && i >= len(last)-previewMetadataLines; i-- {
+		var line piPreviewLine
+		if err := json.Unmarshal(last[i], &line); err != nil {
+			continue
+		}
+		if pv.LastActivityAt.IsZero() {
+			if ts := parseClaudeTime(line.Timestamp); !ts.IsZero() {
+				pv.LastActivityAt = ts
+			}
+		}
+		if pv.Title == "" && line.Type == "session_info" {
+			pv.Title = strings.TrimSpace(line.Name)
+		}
+	}
+
+	if pv.SessionID == "" {
+		pv.SessionID = piSessionIDFromPath(path)
+	}
+	if pv.Title == "" {
+		// The session ID, never prompt text: a preview runs over every session
+		// on the machine and is rendered before the user picks anything.
+		pv.Title = pv.SessionID
+	}
+	if pv.LastActivityAt.IsZero() {
+		pv.LastActivityAt = win.ModTime
+	}
+	return pv, true, nil
+}
+
+// piSessionIDFromPath recovers the session ID from a session filename, which pi
+// builds as <timestamp>_<sessionID>.jsonl. It is the fallback for a file whose
+// header carries no ID.
+func piSessionIDFromPath(path string) string {
+	base := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+	if _, id, ok := strings.Cut(base, "_"); ok && id != "" {
+		return id
+	}
+	return base
+}
+
+// piEntry is one line of a session log. Content is decoded here and nowhere
+// else: Preview uses piPreviewLine instead.
+type piEntry struct {
+	Type      string     `json:"type"`
+	ID        string     `json:"id"`
+	ParentID  *string    `json:"parentId"`
+	Timestamp string     `json:"timestamp"`
+	Message   *piMessage `json:"message"`
+
+	// Session header fields, on line 1 only.
+	CWD           string `json:"cwd"`
+	ParentSession string `json:"parentSession"`
+
+	// session_info fields.
+	Name string `json:"name"`
+
+	// copied marks an entry a fork inherited from its trunk rather than
+	// produced itself. Set while reading, never decoded from the line.
+	copied bool
+}
+
+// piMessage is a pi AgentMessage: a user message, an assistant message, or a
+// tool result. The union is flat on disk, so one struct covers all three.
+type piMessage struct {
+	Role string `json:"role"`
+	// Content is a string or an array of blocks for a user message, and an
+	// array of blocks for an assistant message and a tool result.
+	Content json.RawMessage `json:"content"`
+
+	// Assistant fields.
+	Provider     string   `json:"provider"`
+	Model        string   `json:"model"`
+	ResponseID   string   `json:"responseId"`
+	StopReason   string   `json:"stopReason"`
+	ErrorMessage string   `json:"errorMessage"`
+	Usage        *piUsage `json:"usage"`
+	// Timestamp is unix milliseconds, stamped when the provider builds the
+	// message object, which is before the HTTP request goes out.
+	Timestamp int64 `json:"timestamp"`
+
+	// Tool result fields.
+	ToolCallID string `json:"toolCallId"`
+	ToolName   string `json:"toolName"`
+	IsError    bool   `json:"isError"`
+}
+
+// piUsage is pi's Usage. A count a session written by an older pi does not carry
+// decodes to zero, and the turn is then flagged with QualityReport.ApproxUsage,
+// so "the source said nothing about tokens" is never read as "no tokens".
+type piUsage struct {
+	Input       int64   `json:"input"`
+	Output      int64   `json:"output"`
+	CacheRead   int64   `json:"cacheRead"`
+	CacheWrite  int64   `json:"cacheWrite"`
+	TotalTokens int64   `json:"totalTokens"`
+	Cost        *piCost `json:"cost"`
+}
+
+type piCost struct {
+	Total *float64 `json:"total"`
+}
+
+// piContentBlock is one block of message content. One struct covers the union
+// the way it is written on disk. An image block has no field here: agento11y's
+// message parts cannot represent one, so both sides drop it.
+type piContentBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text"`
+	Thinking  string          `json:"thinking"`
+	Redacted  bool            `json:"redacted"`
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// piSession is a decoded session log: its header, its entries in file order,
+// and the indexes the mapping walks.
+type piSession struct {
+	header  piEntry
+	entries []piEntry
+	byID    map[string]int // entry ID -> index in entries
+	// turnIndex numbers the assistant entries this session produced, in file
+	// order, keyed by their position in entries. It is the TurnIndex of the
+	// generation each one exports, which makes a parent's generation ID
+	// resolvable before the parent is reached. An entry a fork copied from its
+	// trunk is not in it, because this session did not produce it. The key is
+	// the position rather than the entry ID so two entries that somehow carry
+	// no ID cannot land on one generation ID.
+	turnIndex map[int]int
+	// forkedAt is the fork instant read from the header, and the cutoff that
+	// separates copied entries from the session's own. Zero when the session is
+	// not a fork, or when its header carries no usable timestamp.
+	forkedAt time.Time
+}
+
+// readPiSession decodes a whole session file.
+//
+// pi session files are small: the sessions tree on the development machine holds
+// 5,977 .jsonl files totalling 2.0 GB, of which 2,536 are top-level sessions and
+// the rest nested subagent runs, and the largest single file is 10.6 MB. So the
+// streaming Codex needs for its 700 MB rollouts buys nothing here. Turns are
+// still yielded one at a time.
+//
+// A fork's copied entries are marked, not dropped: lineage has to walk into
+// them to recognise a parent that belongs to the trunk, while [piImporter.Turns]
+// must not export them. pi copies the trunk's entries with their own
+// timestamps and stamps the fork's header at fork time, so an entry at or
+// before the header instant came from the trunk. The trunk's own import exports
+// those turns; exporting them again here would report one model call twice,
+// under two conversation IDs.
+func readPiSession(path string) (*piSession, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	sess := &piSession{byID: map[string]int{}, turnIndex: map[int]int{}}
+	turns := 0
+	for raw := range bytes.SplitSeq(data, []byte{'\n'}) {
+		raw = bytes.TrimRight(raw, "\r")
+		if len(bytes.TrimSpace(raw)) == 0 {
+			continue
+		}
+		var entry piEntry
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			continue // a partially written last line, or schema drift
+		}
+		if entry.Type == "session" {
+			if sess.header.Type == "" {
+				sess.header = entry
+				if strings.TrimSpace(entry.ParentSession) != "" {
+					sess.forkedAt = parseClaudeTime(entry.Timestamp)
+				}
+			}
+			continue
+		}
+		entry.copied = sess.isCopied(entry)
+		if entry.ID != "" {
+			sess.byID[entry.ID] = len(sess.entries)
+		}
+		if piIsAssistantEntry(entry) && !entry.copied {
+			sess.turnIndex[len(sess.entries)] = turns
+			turns++
+		}
+		sess.entries = append(sess.entries, entry)
+	}
+	return sess, nil
+}
+
+// isCopied reports whether an entry predates the fork that created this
+// session. A session that is not a fork copied nothing. An entry with no
+// readable timestamp counts as the session's own: dropping a turn on a guess
+// loses data the file does have.
+func (s *piSession) isCopied(entry piEntry) bool {
+	if s.forkedAt.IsZero() {
+		return false
+	}
+	ts := parseClaudeTime(entry.Timestamp)
+	return !ts.IsZero() && !ts.After(s.forkedAt)
+}
+
+func piIsAssistantEntry(entry piEntry) bool {
+	return entry.Type == "message" && entry.Message != nil && entry.Message.Role == "assistant"
+}
+
+// sourceRef locates the turn the assistant entry at position pos exports.
+func (s *piSession) sourceRef(pos int, conversationID, sourcePath string) SourceRef {
+	turn := s.turnIndex[pos]
+	entryID := ""
+	if pos >= 0 && pos < len(s.entries) {
+		entryID = s.entries[pos].ID
+	}
+	return SourceRef{
+		Agent:      AgentPi,
+		SessionID:  conversationID,
+		SourcePath: sourcePath,
+		TurnIndex:  turn,
+		TurnID:     firstNonEmptyString(entryID, fallbackTurnID(turn)),
+	}
+}
+
+// Turns yields one generation per assistant entry, carrying the tool results
+// that answer that entry's tool calls.
+//
+// One assistant entry is one generation because pi's turn_end fires once per
+// LLM request with one message and its tool results, so an imported turn covers
+// the same call live capture would have exported.
+//
+// Every assistant entry the session produced is imported, including entries on
+// branches the user abandoned. Each regeneration was a separate model call that
+// live capture exported, and the parentId chain keeps an abandoned branch
+// parented to the turn it diverged from. A fork's copied entries are the one
+// exception: they belong to the trunk, which exports them itself.
+func (p *piImporter) Turns(ctx context.Context, sess SessionPreview) iter.Seq2[HistoricalGeneration, error] {
+	return func(yield func(HistoricalGeneration, error) bool) {
+		if err := ctx.Err(); err != nil {
+			yield(HistoricalGeneration{}, err)
+			return
+		}
+		log, err := readPiSession(sess.SourcePath)
+		if err != nil {
+			yield(HistoricalGeneration{}, fmt.Errorf("read pi session %s: %w", sess.SourcePath, err))
+			return
+		}
+		conversationID := firstNonEmptyString(
+			log.header.ID,
+			sess.SessionID,
+			piSessionIDFromPath(sess.SourcePath),
+		)
+		fork := resolvePiFork(log.header, sess.SourcePath)
+		title := piTitle(log, conversationID)
+
+		var pendingInput []agento11y.Message
+		for i, entry := range log.entries {
+			if err := ctx.Err(); err != nil {
+				yield(HistoricalGeneration{}, err)
+				return
+			}
+			// A fork's copied entries are skipped whole: the trunk exported both
+			// its turns and the prompts that drove them.
+			if entry.Type != "message" || entry.Message == nil || entry.copied {
+				continue
+			}
+			switch entry.Message.Role {
+			case "user":
+				// Buffered until the next assistant entry, which is what live
+				// does with the user messages seen since the last turn.
+				if msg, ok := piUserMessage(*entry.Message); ok {
+					pendingInput = append(pendingInput, msg)
+				}
+				continue
+			case "assistant":
+			default:
+				continue // a tool result, collected by the turn it answers
+			}
+
+			gen := piGeneration(log, i, entry, pendingInput, conversationID, title, sess.SourcePath, fork)
+			pendingInput = nil
+			if !yield(gen, nil) {
+				return
+			}
+		}
+	}
+}
+
+// piGeneration maps one assistant entry into a historical generation.
+func piGeneration(
+	log *piSession,
+	index int,
+	entry piEntry,
+	input []agento11y.Message,
+	conversationID, title, sourcePath string,
+	fork *piFork,
+) HistoricalGeneration {
+	msg := entry.Message
+	src := log.sourceRef(index, conversationID, sourcePath)
+	blocks := piBlocks(msg.Content)
+
+	gen := agento11y.Generation{
+		ID:                src.GenerationID(),
+		ConversationID:    conversationID,
+		ConversationTitle: title,
+		Mode:              agento11y.GenerationModeStream,
+		// pi streams every provider response, and the SDK records the
+		// time-to-first-token histogram only for streamText, so live exports
+		// this operation name too.
+		OperationName: "streamText",
+		Model:         agento11y.ModelRef{Provider: msg.Provider, Name: msg.Model},
+		ResponseID:    msg.ResponseID,
+		ResponseModel: msg.Model,
+		StopReason:    piStopReason(msg.StopReason),
+		Usage:         piMapUsage(msg.Usage),
+		Input:         input,
+		Output:        append(piAssistantOutput(blocks), piToolResultsOutput(log, index, blocks)...),
+		Tools:         piToolDefinitions(blocks),
+		CallError:     msg.ErrorMessage,
+	}
+	if piHasThinking(blocks) {
+		gen.ThinkingEnabled = piBoolPtr(true)
+	}
+	if msg.Usage != nil && msg.Usage.Cost != nil && msg.Usage.Cost.Total != nil {
+		gen.Metadata = map[string]any{"cost_usd": *msg.Usage.Cost.Total}
+	}
+
+	// Both timestamps are real. The assistant message's unix-ms timestamp is
+	// stamped when the provider builds the message, before the request goes
+	// out; the entry's ISO timestamp is when pi appended the entry, after the
+	// stream ended. The clamp mirrors live's Math.min: a clock adjustment must
+	// not invert the pair.
+	gen.CompletedAt = parseClaudeTime(entry.Timestamp)
+	if msg.Timestamp > 0 {
+		gen.StartedAt = time.UnixMilli(msg.Timestamp).UTC()
+	}
+	if !gen.StartedAt.IsZero() && !gen.CompletedAt.IsZero() && gen.StartedAt.After(gen.CompletedAt) {
+		gen.StartedAt = gen.CompletedAt
+	}
+
+	quality := piQuality(gen)
+	piApplyLineage(&gen, &quality, log, entry, conversationID, sourcePath, fork)
+	return HistoricalGeneration{Source: src, Gen: gen, Quality: quality}
+}
+
+// piQuality reports what the session log did not carry. Neither timestamp flag
+// is ever set from a well-formed entry: pi persists both, so a zero value means
+// the line was malformed rather than incomplete.
+func piQuality(gen agento11y.Generation) QualityReport {
+	var q QualityReport
+	if strings.TrimSpace(gen.Model.Name) == "" {
+		q.MissingModel = true
+	}
+	if gen.StartedAt.IsZero() {
+		q.ApproxStartedAt = true
+	}
+	if gen.CompletedAt.IsZero() {
+		q.ApproxCompletedAt = true
+	}
+	if !hasTokenUsage(gen.Usage) {
+		q.ApproxUsage = true
+	}
+	return q
+}
+
+// piMapUsage ports mapPiUsage (plugins/pi/src/mappers.ts).
+//
+// The field set is narrower than pi's Usage: reasoning and cacheWrite1h are not
+// forwarded, and totalTokens is passed through as pi computes it
+// (input + output + cacheRead + cacheWrite) rather than recomputed to the Go
+// launchers' input + output. Both choices are live behavior and moving either
+// here would put the import out of step with it.
+func piMapUsage(usage *piUsage) agento11y.TokenUsage {
+	if usage == nil {
+		return agento11y.TokenUsage{}
+	}
+	return agento11y.TokenUsage{
+		InputTokens:           usage.Input,
+		OutputTokens:          usage.Output,
+		TotalTokens:           usage.TotalTokens,
+		CacheReadInputTokens:  usage.CacheRead,
+		CacheWriteInputTokens: usage.CacheWrite,
+	}
+}
+
+// piStopReason ports mapStopReason (plugins/pi/src/mappers.ts). An unknown
+// reason passes through, which is how live records a stop reason a newer pi
+// added.
+func piStopReason(reason string) string {
+	switch reason {
+	case "stop":
+		return "end_turn"
+	case "length":
+		return "max_tokens"
+	case "toolUse":
+		return "tool_use"
+	default:
+		return reason
+	}
+}
+
+// piBlocks decodes a message's content blocks. A string content, which pi
+// allows for a user message, becomes one text block.
+//
+// A decode error keeps whatever decoded. Go's decoder fills every element it
+// can and reports the first type error at the end, so one block with an
+// unexpected field type costs that block and not the turn: returning nil would
+// export a turn that said the model produced nothing.
+func piBlocks(raw json.RawMessage) []piContentBlock {
+	if len(raw) == 0 {
+		return nil
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return []piContentBlock{{Type: "text", Text: text}}
+	}
+	var blocks []piContentBlock
+	_ = json.Unmarshal(raw, &blocks)
+	return blocks
+}
+
+// piAssistantOutput ports mapAssistantOutput (plugins/pi/src/mappers.ts): one
+// output message per content block, in the order the model produced them.
+//
+// Unlike Claude Code, pi persists thinking text, so an imported turn carries
+// the same thinking a live one did. A redacted thinking block is skipped, the
+// way live skips it.
+func piAssistantOutput(blocks []piContentBlock) []agento11y.Message {
+	var out []agento11y.Message
+	for _, block := range blocks {
+		switch block.Type {
+		case "text":
+			if strings.TrimSpace(block.Text) == "" {
+				continue
+			}
+			out = append(out, agento11y.Message{
+				Role:  agento11y.RoleAssistant,
+				Parts: []agento11y.Part{{Kind: agento11y.PartKindText, Text: block.Text}},
+			})
+		case "thinking":
+			if block.Redacted || strings.TrimSpace(block.Thinking) == "" {
+				continue
+			}
+			out = append(out, agento11y.Message{
+				Role:  agento11y.RoleAssistant,
+				Parts: []agento11y.Part{{Kind: agento11y.PartKindThinking, Thinking: block.Thinking}},
+			})
+		case "toolCall":
+			out = append(out, agento11y.Message{
+				Role: agento11y.RoleAssistant,
+				Parts: []agento11y.Part{{
+					Kind: agento11y.PartKindToolCall,
+					ToolCall: &agento11y.ToolCall{
+						ID:        block.ID,
+						Name:      block.Name,
+						InputJSON: piToolArguments(block.Arguments),
+					},
+				}},
+			})
+		}
+	}
+	return out
+}
+
+// piToolArguments returns a tool call's arguments as compact JSON.
+//
+// pi's type makes arguments required, and all 143,105 tool calls on the
+// development machine carry them, 9 of those as "{}", where live sends "{}"
+// too. The absent case is where the two diverge and has never been observed:
+// live stringifies the object, JSON.stringify(undefined) is undefined, and the
+// SDK exports that as an empty field, while an absent object becomes "{}" here.
+func piToolArguments(raw json.RawMessage) json.RawMessage {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return json.RawMessage("{}")
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		return json.RawMessage("{}")
+	}
+	return json.RawMessage(buf.Bytes())
+}
+
+// piToolResultsOutput ports mapToolResultsOutput (plugins/pi/src/mappers.ts)
+// for the assistant entry at position index: the tool results that answer that
+// entry's tool calls, whose content blocks the caller already decoded.
+//
+// Live receives them on the turn_end event. On disk each one is its own entry
+// appended after the assistant entry, so they are matched by tool call ID and
+// yielded in the order the calls were made, which is the order live saw them.
+func piToolResultsOutput(log *piSession, index int, blocks []piContentBlock) []agento11y.Message {
+	calls := piToolCallIDs(blocks)
+	if len(calls) == 0 {
+		return nil
+	}
+	results := piToolResultsByCallID(log, index)
+	out := make([]agento11y.Message, 0, len(calls))
+	for _, callID := range calls {
+		result, ok := results[callID]
+		if !ok {
+			continue // the run ended before the tool answered
+		}
+		out = append(out, agento11y.Message{
+			Role: agento11y.RoleTool,
+			Parts: []agento11y.Part{{
+				Kind: agento11y.PartKindToolResult,
+				ToolResult: &agento11y.ToolResult{
+					ToolCallID: result.Message.ToolCallID,
+					Name:       result.Message.ToolName,
+					IsError:    result.Message.IsError,
+					Content:    piToolResultText(result.Message.Content),
+				},
+			}},
+		})
+	}
+	return out
+}
+
+// piToolResultsByCallID collects the tool result entries that answer the
+// assistant entry at position index. It walks forward from that position and
+// stops at the next assistant entry, because a tool result appended after that
+// one answers that turn's calls instead.
+//
+// The walk starts from the position rather than from a lookup of the entry's ID,
+// for the same reason the generation ID is built from the position: an entry
+// that somehow carries no ID, or shares one with another entry, would otherwise
+// collect another turn's results or none at all, with nothing to flag it.
+func piToolResultsByCallID(log *piSession, index int) map[string]piEntry {
+	out := map[string]piEntry{}
+	if index < 0 || index >= len(log.entries) {
+		return out
+	}
+	for _, next := range log.entries[index+1:] {
+		if piIsAssistantEntry(next) {
+			break
+		}
+		if next.Type != "message" || next.Message == nil || next.Message.Role != "toolResult" {
+			continue
+		}
+		if _, seen := out[next.Message.ToolCallID]; !seen {
+			out[next.Message.ToolCallID] = next
+		}
+	}
+	return out
+}
+
+func piToolCallIDs(blocks []piContentBlock) []string {
+	var out []string
+	for _, block := range blocks {
+		if block.Type == "toolCall" {
+			out = append(out, block.ID)
+		}
+	}
+	return out
+}
+
+// piToolResultText flattens a tool result's content blocks to text, dropping
+// the image blocks agento11y's message parts cannot represent.
+//
+// An empty text block is dropped as well, the way toolResultText
+// (plugins/pi/src/mappers.ts) drops it, so two blocks where the first is empty
+// join to one line rather than to a leading newline. piUserMessage keeps empty
+// blocks, because userMessageText keeps them.
+func piToolResultText(raw json.RawMessage) string {
+	var parts []string
+	for _, block := range piBlocks(raw) {
+		if block.Type == "text" && block.Text != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// piToolDefinitions names the tools the turn called.
+//
+// Live seeds the full catalog with descriptions and schemas from pi's runtime
+// registry (mapTools). None of that is in the session log, so an imported turn
+// carries name-only definitions for the tools it actually called. Which tools
+// were offered but unused is unrecoverable.
+func piToolDefinitions(blocks []piContentBlock) []agento11y.ToolDefinition {
+	var out []agento11y.ToolDefinition
+	seen := map[string]bool{}
+	for _, block := range blocks {
+		if block.Type != "toolCall" || block.Name == "" || seen[block.Name] {
+			continue
+		}
+		seen[block.Name] = true
+		out = append(out, agento11y.ToolDefinition{Name: block.Name})
+	}
+	return out
+}
+
+func piHasThinking(blocks []piContentBlock) bool {
+	for _, block := range blocks {
+		if block.Type == "thinking" {
+			return true
+		}
+	}
+	return false
+}
+
+// piUserMessage ports mapUserMessage (plugins/pi/src/mappers.ts): one input
+// message per user entry, text parts joined with a newline, image parts
+// dropped, and an empty message skipped.
+func piUserMessage(msg piMessage) (agento11y.Message, bool) {
+	var parts []string
+	for _, block := range piBlocks(msg.Content) {
+		if block.Type == "text" {
+			parts = append(parts, block.Text)
+		}
+	}
+	text := strings.Join(parts, "\n")
+	if strings.TrimSpace(text) == "" {
+		return agento11y.Message{}, false
+	}
+	return agento11y.Message{
+		Role:  agento11y.RoleUser,
+		Parts: []agento11y.Part{{Kind: agento11y.PartKindText, Text: text}},
+	}, true
+}
+
+// piTitle ports resolveConversationTitle (plugins/pi/src/mappers.ts): pi's
+// user-set session name wins, then the first user prompt, then the session ID.
+//
+// The name is read from the last session_info entry, which is the name in force
+// when the session was last written. Live resolves it per turn, so a session
+// renamed halfway through gets the new name only on later turns; an import
+// applies one name to the whole session, which is the one difference the
+// fixture README records.
+func piTitle(log *piSession, conversationID string) string {
+	name := ""
+	firstUserText := ""
+	for _, entry := range log.entries {
+		if entry.Type == "session_info" && strings.TrimSpace(entry.Name) != "" {
+			name = strings.TrimSpace(entry.Name)
+		}
+		// A copied prompt is not this session's first prompt: live sees only the
+		// prompts the fork itself sent.
+		if firstUserText != "" || entry.copied ||
+			entry.Type != "message" || entry.Message == nil || entry.Message.Role != "user" {
+			continue
+		}
+		if msg, ok := piUserMessage(*entry.Message); ok {
+			firstUserText = strings.TrimSpace(msg.Parts[0].Text)
+		}
+	}
+	if name != "" {
+		return piClipTitle(name)
+	}
+	if firstUserText != "" {
+		return piClipTitle(firstUserText)
+	}
+	return conversationID
+}
+
+func piClipTitle(text string) string {
+	text = strings.TrimSpace(text)
+	if utf8.RuneCountInString(text) <= piMaxTitleLen {
+		return text
+	}
+	return string([]rune(text)[:piMaxTitleLen])
+}
+
+// Fork metadata keys, matching what the live plugin writes
+// (plugins/pi/src/index.ts). A fork copies the trunk's entries, so the parent
+// turn of the fork's first generation belongs to the trunk conversation and
+// gets a metadata pointer instead of a parent edge.
+const (
+	MetaPiForkParentSession    = "pi.fork.parent_session_id"
+	MetaPiForkParentGeneration = "pi.fork.parent_generation_id"
+)
+
+// piFork is what a forked session knows about its trunk. nil means the session
+// is not a fork.
+type piFork struct {
+	// forkedAt is the fork instant: the fork's own header timestamp. An entry
+	// stamped at or before it was copied from the trunk.
+	forkedAt time.Time
+	// trunkPath is where the trunk was read from, and also the SourcePath the
+	// trunk generation ID hashes, so the fork's pointer is right only when it
+	// spells the trunk the way discovery does. It is cleaned for that reason. A
+	// trunk reachable under a genuinely different path, through a symlinked home
+	// or a relative PI_CODING_AGENT_DIR, still reads fine and still yields a
+	// pointer to an ID nothing ingested; normalizing SourcePath across the
+	// framework is what would close that, and the fixture README records it.
+	trunkPath string
+	// trunkConversationID and trunkStartedAt come from the trunk file's own
+	// line 1, so no value is parsed out of a file name.
+	trunkConversationID string
+	trunkStartedAt      time.Time
+	// trunk is the trunk's decoded session. Its own turn numbering is what the
+	// trunk's import used as TurnIndex, so a trunk generation ID can be
+	// reproduced here.
+	trunk *piSession
+	// unreadable is set when the header named a trunk this process could not
+	// read. The parent link is then dropped rather than guessed.
+	unreadable bool
+}
+
+// resolvePiFork reads a session header's parentSession and, when there is one,
+// the trunk file it names. Ported from sessionOrigin.ts and lineage.ts.
+func resolvePiFork(header piEntry, sourcePath string) *piFork {
+	parent := strings.TrimSpace(header.ParentSession)
+	if parent == "" {
+		return nil
+	}
+	fork := &piFork{forkedAt: parseClaudeTime(header.Timestamp)}
+	// pi stores parentSession as typed, so a relative path is relative to the
+	// cwd the header recorded, not to whichever process reads it later. Both
+	// branches end cleaned, because the same string is hashed into the trunk's
+	// generation ID: "/s/a/../a/x.jsonl" and "/s/a/x.jsonl" read the same file
+	// and would otherwise name two different generations.
+	fork.trunkPath = filepath.Clean(parent)
+	if !filepath.IsAbs(parent) {
+		if cwd := strings.TrimSpace(header.CWD); cwd != "" {
+			fork.trunkPath = filepath.Join(cwd, parent)
+		} else {
+			fork.trunkPath = filepath.Join(filepath.Dir(sourcePath), parent)
+		}
+	}
+	trunk, err := readPiSession(fork.trunkPath)
+	if err != nil || trunk.header.ID == "" {
+		fork.unreadable = true
+		return fork
+	}
+	fork.trunkConversationID = trunk.header.ID
+	fork.trunkStartedAt = parseClaudeTime(trunk.header.Timestamp)
+	fork.trunk = trunk
+	return fork
+}
+
+// piApplyLineage sets the turn's parent, porting findParentAssistantEntry and
+// classifyParentEntry (plugins/pi/src/lineage.ts).
+//
+// The parent is the nearest ancestor assistant entry on the parentId chain, not
+// the previous entry: pi appends a turn as a child of the current leaf, which
+// is usually a tool result. On a fork, a parent entry stamped at or before the
+// fork instant was copied from the trunk, so its generation belongs to the
+// trunk conversation: it ships as metadata instead of an edge, because an edge
+// would name a generation that does not exist under this conversation ID.
+func piApplyLineage(
+	gen *agento11y.Generation,
+	quality *QualityReport,
+	log *piSession,
+	entry piEntry,
+	conversationID, sourcePath string,
+	fork *piFork,
+) {
+	parent, parentPos, ok := piParentAssistantEntry(log, entry)
+	if !ok {
+		return
+	}
+	switch piClassifyParent(parent, fork) {
+	case piParentTrunk:
+		// Handled below: a copied parent needs the trunk resolved first.
+	case piParentOwn:
+		gen.ParentGenerationIDs = []string{
+			log.sourceRef(parentPos, conversationID, sourcePath).GenerationID(),
+		}
+		return
+	case piParentUnknown:
+		// The fork instant or the parent's own timestamp is missing, so the
+		// parent cannot be placed on either side of the fork. Nothing is
+		// linked: an ID built on a guess names a generation that may not exist.
+		quality.Notes = append(quality.Notes, "pi_fork_parent_unplaceable")
+		return
+	}
+	if fork.unreadable {
+		// A named but unreadable trunk: the parent turn cannot be placed in
+		// either conversation, so nothing is linked. Live degrades the same way.
+		quality.Notes = append(quality.Notes, "pi_fork_trunk_unreadable")
+		return
+	}
+	trunkGen, ok := piTrunkGenerationID(parent, fork)
+	if !ok {
+		// The trunk holds no generation for the copied entry, so there is
+		// nothing to point at. Both keys go together or neither does, the way
+		// live's forkMetadata writes them: a session ID with no generation ID
+		// names a conversation without saying which turn.
+		quality.Notes = append(quality.Notes, "pi_fork_parent_not_in_trunk")
+		return
+	}
+	piSetMetadata(gen, MetaPiForkParentSession, fork.trunkConversationID)
+	piSetMetadata(gen, MetaPiForkParentGeneration, trunkGen)
+}
+
+// piParentKind says which conversation a parent turn's generation belongs to.
+type piParentKind int
+
+const (
+	// piParentOwn: this session produced the parent turn, so an edge is safe.
+	piParentOwn piParentKind = iota
+	// piParentTrunk: a fork copied the parent entry in, so its generation
+	// belongs to the trunk conversation.
+	piParentTrunk
+	// piParentUnknown: the parent cannot be placed on either side of the fork.
+	piParentUnknown
+)
+
+// piClassifyParent ports classifyParentEntry (plugins/pi/src/lineage.ts). The
+// boundary is the fork's header timestamp: a fork copies the trunk's entries
+// with their own timestamps and stamps its header at fork time, so every entry
+// at or before that instant came from the trunk.
+func piClassifyParent(parent piEntry, fork *piFork) piParentKind {
+	if fork == nil {
+		return piParentOwn
+	}
+	parentAt := parseClaudeTime(parent.Timestamp)
+	if fork.forkedAt.IsZero() || parentAt.IsZero() {
+		return piParentUnknown
+	}
+	if parentAt.After(fork.forkedAt) {
+		return piParentOwn
+	}
+	return piParentTrunk
+}
+
+// piTrunkGenerationID returns the generation ID the trunk's own import gave the
+// copied parent turn.
+//
+// ok is false when the trunk cannot hold that generation: a fork of a fork
+// inherits entries an intermediate session copied in and never ran itself, and
+// those are stamped before the trunk's start.
+func piTrunkGenerationID(parent piEntry, fork *piFork) (string, bool) {
+	if fork.trunkConversationID == "" {
+		return "", false
+	}
+	parentAt := parseClaudeTime(parent.Timestamp)
+	if fork.trunkStartedAt.IsZero() || parentAt.IsZero() || !parentAt.After(fork.trunkStartedAt) {
+		return "", false
+	}
+	pos, ok := fork.trunk.byID[parent.ID]
+	if !ok {
+		return "", false
+	}
+	if _, produced := fork.trunk.turnIndex[pos]; !produced {
+		// The trunk copied this entry in as well, so it exported no generation
+		// for it either.
+		return "", false
+	}
+	return fork.trunk.sourceRef(pos, fork.trunkConversationID, fork.trunkPath).GenerationID(), true
+}
+
+// piParentAssistantEntry walks the parentId chain from entry toward the root and
+// returns the nearest ancestor assistant entry with its position in the session.
+func piParentAssistantEntry(log *piSession, entry piEntry) (piEntry, int, bool) {
+	seen := map[string]bool{}
+	cursor := entry.ParentID
+	for cursor != nil && *cursor != "" && !seen[*cursor] {
+		seen[*cursor] = true
+		pos, ok := log.byID[*cursor]
+		if !ok {
+			return piEntry{}, 0, false
+		}
+		parent := log.entries[pos]
+		if piIsAssistantEntry(parent) {
+			return parent, pos, true
+		}
+		cursor = parent.ParentID
+	}
+	return piEntry{}, 0, false
+}
+
+func piSetMetadata(gen *agento11y.Generation, key, value string) {
+	if value == "" {
+		return
+	}
+	if gen.Metadata == nil {
+		gen.Metadata = map[string]any{}
+	}
+	gen.Metadata[key] = value
+}
+
+func piBoolPtr(v bool) *bool { return &v }

--- a/plugins/agento11y/internal/history/pi_conformance_test.go
+++ b/plugins/agento11y/internal/history/pi_conformance_test.go
@@ -1,0 +1,572 @@
+package history
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/agento11y/go/agento11y"
+)
+
+// pi session conformance: the Go importer and the TypeScript live plugin are
+// checked against one shared fixture group, conformance/pi-sessions/.
+//
+// Every other importer proves it agrees with live capture by running the
+// agent's own Go live mapper and comparing turn for turn (see
+// TestClaudeTurnsMatchTheLiveMapper). pi has no Go live mapper, so the fixture
+// is the contract instead: the same session inputs go through this importer
+// here and through the pi plugin in plugins/pi/src/piSessionConformance.test.ts,
+// and both normalize to the shape in generations.json.
+//
+// conformance/pi-sessions/README.md documents the encodings, the ${PLACEHOLDER}
+// rule, and every field that cannot agree, with the reason.
+
+const piConformanceDir = "../../../../conformance/pi-sessions"
+
+type piFixtureCase struct {
+	ID          string                       `json:"id"`
+	Description string                       `json:"description"`
+	SessionFile string                       `json:"session_file"`
+	Files       map[string][]json.RawMessage `json:"files"`
+}
+
+type piFixtureSessions struct {
+	Cases []piFixtureCase `json:"cases"`
+}
+
+func loadPiFixtureSessions(t *testing.T) piFixtureSessions {
+	t.Helper()
+	var out piFixtureSessions
+	piReadFixture(t, "sessions.json", &out)
+	if len(out.Cases) == 0 {
+		t.Fatal("conformance/pi-sessions/sessions.json holds no cases")
+	}
+	return out
+}
+
+// loadPiFixtureGenerations returns the expected generations per case ID, parsed
+// as plain JSON so the comparison is structural rather than tied to either
+// language's types.
+func loadPiFixtureGenerations(t *testing.T) map[string][]any {
+	t.Helper()
+	var doc struct {
+		Cases map[string][]any `json:"cases"`
+	}
+	piReadFixture(t, "generations.json", &doc)
+	if len(doc.Cases) == 0 {
+		t.Fatal("conformance/pi-sessions/generations.json holds no cases")
+	}
+	return doc.Cases
+}
+
+func piReadFixture(t *testing.T, name string, into any) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(piConformanceDir, name))
+	if err != nil {
+		t.Fatalf("read conformance/pi-sessions/%s: %v", name, err)
+	}
+	if err := json.Unmarshal(data, into); err != nil {
+		t.Fatalf("decode conformance/pi-sessions/%s: %v", name, err)
+	}
+}
+
+// materializePiFixtureCase writes a case's session files into dir, one JSON
+// entry per line, and returns the path of the file under test. ${DIR} in an
+// entry is replaced with dir, which is how a fork's header names its trunk
+// without the fixture carrying a machine-specific path.
+func materializePiFixtureCase(t *testing.T, dir string, fixture piFixtureCase) string {
+	t.Helper()
+	for name, entries := range fixture.Files {
+		var body strings.Builder
+		for _, entry := range entries {
+			var compact bytes.Buffer
+			if err := json.Compact(&compact, entry); err != nil {
+				t.Fatalf("case %s: compact entry: %v", fixture.ID, err)
+			}
+			body.WriteString(strings.ReplaceAll(compact.String(), "${DIR}", dir))
+			body.WriteString("\n")
+		}
+		writeFile(t, filepath.Join(dir, name), body.String())
+	}
+	path := filepath.Join(dir, fixture.SessionFile)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("case %s: session_file %q is not one of the case's files", fixture.ID, fixture.SessionFile)
+	}
+	return path
+}
+
+// The normalized generation shape both languages produce. It holds what the
+// session log decides and leaves out what only a live process knows; see the
+// fixture README.
+type piNormalizedGeneration struct {
+	ID                  string                `json:"id"`
+	ConversationID      string                `json:"conversation_id"`
+	ConversationTitle   string                `json:"conversation_title"`
+	Model               piNormalizedModel     `json:"model"`
+	ResponseID          string                `json:"response_id"`
+	ResponseModel       string                `json:"response_model"`
+	Mode                string                `json:"mode"`
+	OperationName       string                `json:"operation_name"`
+	StopReason          string                `json:"stop_reason"`
+	ThinkingEnabled     bool                  `json:"thinking_enabled"`
+	Usage               piNormalizedUsage     `json:"usage"`
+	StartedAt           string                `json:"started_at"`
+	CompletedAt         string                `json:"completed_at"`
+	Input               []piNormalizedMessage `json:"input"`
+	Output              []piNormalizedMessage `json:"output"`
+	Tools               []piNormalizedTool    `json:"tools"`
+	CostUSD             *float64              `json:"cost_usd"`
+	CallError           string                `json:"call_error"`
+	ParentGenerationIDs []string              `json:"parent_generation_ids"`
+	Fork                *piNormalizedFork     `json:"fork"`
+}
+
+type piNormalizedModel struct {
+	Provider string `json:"provider"`
+	Name     string `json:"name"`
+}
+
+type piNormalizedUsage struct {
+	InputTokens           int64 `json:"input_tokens"`
+	OutputTokens          int64 `json:"output_tokens"`
+	TotalTokens           int64 `json:"total_tokens"`
+	CacheReadInputTokens  int64 `json:"cache_read_input_tokens"`
+	CacheWriteInputTokens int64 `json:"cache_write_input_tokens"`
+	ReasoningTokens       int64 `json:"reasoning_tokens"`
+}
+
+type piNormalizedMessage struct {
+	Role  string             `json:"role"`
+	Parts []piNormalizedPart `json:"parts"`
+}
+
+type piNormalizedPart struct {
+	Kind       string                  `json:"kind"`
+	Text       string                  `json:"text,omitempty"`
+	Thinking   string                  `json:"thinking,omitempty"`
+	ToolCall   *piNormalizedToolCall   `json:"tool_call,omitempty"`
+	ToolResult *piNormalizedToolResult `json:"tool_result,omitempty"`
+}
+
+type piNormalizedToolCall struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// Arguments is the parsed tool input, not a string: the two sides encode
+	// it differently on the wire (Go keeps embedded JSON, the JS SDK exports
+	// base64), and only the decoded value is comparable.
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+type piNormalizedToolResult struct {
+	ToolCallID string `json:"tool_call_id"`
+	Name       string `json:"name"`
+	Content    string `json:"content"`
+	IsError    bool   `json:"is_error"`
+}
+
+type piNormalizedFork struct {
+	ParentSessionID    string `json:"parent_session_id"`
+	ParentGenerationID string `json:"parent_generation_id"`
+}
+
+// normalizePiHistoricalGeneration projects one imported turn into the shared
+// shape.
+func normalizePiHistoricalGeneration(turn HistoricalGeneration) piNormalizedGeneration {
+	gen := turn.Gen
+	out := piNormalizedGeneration{
+		ID:                  gen.ID,
+		ConversationID:      gen.ConversationID,
+		ConversationTitle:   gen.ConversationTitle,
+		Model:               piNormalizedModel{Provider: gen.Model.Provider, Name: gen.Model.Name},
+		ResponseID:          gen.ResponseID,
+		ResponseModel:       gen.ResponseModel,
+		Mode:                strings.TrimPrefix(string(gen.Mode), "GENERATION_MODE_"),
+		OperationName:       gen.OperationName,
+		StopReason:          gen.StopReason,
+		ThinkingEnabled:     gen.ThinkingEnabled != nil && *gen.ThinkingEnabled,
+		StartedAt:           piFormatTime(gen.StartedAt),
+		CompletedAt:         piFormatTime(gen.CompletedAt),
+		Input:               normalizePiMessages(gen.Input),
+		Output:              normalizePiMessages(gen.Output),
+		Tools:               []piNormalizedTool{},
+		CallError:           gen.CallError,
+		ParentGenerationIDs: gen.ParentGenerationIDs,
+		Usage: piNormalizedUsage{
+			InputTokens:           gen.Usage.InputTokens,
+			OutputTokens:          gen.Usage.OutputTokens,
+			TotalTokens:           gen.Usage.TotalTokens,
+			CacheReadInputTokens:  gen.Usage.CacheReadInputTokens,
+			CacheWriteInputTokens: gen.Usage.CacheWriteInputTokens,
+			ReasoningTokens:       gen.Usage.ReasoningTokens,
+		},
+	}
+	if out.ParentGenerationIDs == nil {
+		out.ParentGenerationIDs = []string{}
+	}
+	for _, tool := range gen.Tools {
+		out.Tools = append(out.Tools, piNormalizedTool{Name: tool.Name})
+	}
+	if cost, ok := gen.Metadata["cost_usd"].(float64); ok {
+		out.CostUSD = &cost
+	}
+	if session, ok := gen.Metadata[MetaPiForkParentSession].(string); ok {
+		parentGen, _ := gen.Metadata[MetaPiForkParentGeneration].(string)
+		out.Fork = &piNormalizedFork{ParentSessionID: session, ParentGenerationID: parentGen}
+	}
+	return out
+}
+
+type piNormalizedTool struct {
+	Name string `json:"name"`
+}
+
+// piFormatTime spells a timestamp the way the fixture does, and leaves an unset
+// one empty. Formatting a zero time would give 0001-01-01T00:00:00.000Z, which
+// the placeholder check accepts because it is non-empty.
+func piFormatTime(ts time.Time) string {
+	if ts.IsZero() {
+		return ""
+	}
+	return ts.UTC().Format("2006-01-02T15:04:05.000Z")
+}
+
+func normalizePiMessages(msgs []agento11y.Message) []piNormalizedMessage {
+	out := []piNormalizedMessage{}
+	for _, msg := range msgs {
+		normalized := piNormalizedMessage{Role: string(msg.Role), Parts: []piNormalizedPart{}}
+		for _, part := range msg.Parts {
+			normalized.Parts = append(normalized.Parts, normalizePiPart(part))
+		}
+		out = append(out, normalized)
+	}
+	return out
+}
+
+func normalizePiPart(part agento11y.Part) piNormalizedPart {
+	out := piNormalizedPart{Kind: string(part.Kind), Text: part.Text, Thinking: part.Thinking}
+	if part.ToolCall != nil {
+		args := part.ToolCall.InputJSON
+		if len(bytes.TrimSpace(args)) == 0 {
+			args = json.RawMessage("{}")
+		}
+		out.ToolCall = &piNormalizedToolCall{
+			ID:        part.ToolCall.ID,
+			Name:      part.ToolCall.Name,
+			Arguments: args,
+		}
+	}
+	if part.ToolResult != nil {
+		out.ToolResult = &piNormalizedToolResult{
+			ToolCallID: part.ToolResult.ToolCallID,
+			Name:       part.ToolResult.Name,
+			Content:    part.ToolResult.Content,
+			IsError:    part.ToolResult.IsError,
+		}
+	}
+	return out
+}
+
+// piNormalizedJSON re-parses a normalized generation as plain JSON, so the
+// comparison sees the same value shapes the fixture parses to.
+func piNormalizedJSON(t *testing.T, gen piNormalizedGeneration) any {
+	t.Helper()
+	data, err := json.Marshal(gen)
+	if err != nil {
+		t.Fatalf("marshal normalized generation: %v", err)
+	}
+	var out any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("decode normalized generation: %v", err)
+	}
+	return out
+}
+
+func TestPiSessionConformance(t *testing.T) {
+	sessions := loadPiFixtureSessions(t)
+	expected := loadPiFixtureGenerations(t)
+
+	for _, fixture := range sessions.Cases {
+		t.Run(fixture.ID, func(t *testing.T) {
+			want, ok := expected[fixture.ID]
+			if !ok {
+				t.Fatalf("conformance/pi-sessions/generations.json has no case %q", fixture.ID)
+			}
+
+			dir := t.TempDir()
+			path := materializePiFixtureCase(t, dir, fixture)
+			imp := piImporterAt(dir)
+			turns := collectTurns(t, imp, piPreview(t, imp, path))
+			if len(turns) != len(want) {
+				t.Fatalf("imported %d generations, the fixture expects %d", len(turns), len(want))
+			}
+			for i, turn := range turns {
+				got := piNormalizedJSON(t, normalizePiHistoricalGeneration(turn))
+				for _, diff := range piDiffJSON("", got, want[i]) {
+					t.Errorf("generation %d does not match conformance/pi-sessions/generations.json: %s", i, diff)
+				}
+			}
+		})
+	}
+}
+
+// TestPiSessionFixtureComparisonNamesDivergentFields pins the comparator, not
+// the importer. TestPiSessionConformance is what checks the importer's own
+// output. Each case takes a real imported generation, applies one divergence
+// the fixture cannot accept, and asserts the diff names the offending path.
+// Without this test a comparator that ignored a field would keep every
+// conformance case green while checking nothing.
+func TestPiSessionFixtureComparisonNamesDivergentFields(t *testing.T) {
+	sessions := loadPiFixtureSessions(t)
+	expected := loadPiFixtureGenerations(t)
+
+	const caseID = "tool-call-turn"
+	var fixture piFixtureCase
+	for _, candidate := range sessions.Cases {
+		if candidate.ID == caseID {
+			fixture = candidate
+		}
+	}
+	if fixture.ID == "" {
+		t.Fatalf("fixture case %q is gone; this test needs a turn with usage and tool traffic", caseID)
+	}
+
+	dir := t.TempDir()
+	path := materializePiFixtureCase(t, dir, fixture)
+	imp := piImporterAt(dir)
+	turns := collectTurns(t, imp, piPreview(t, imp, path))
+	if len(turns) == 0 {
+		t.Fatal("the fixture case imported no turns")
+	}
+	baseline := normalizePiHistoricalGeneration(turns[0])
+	want := expected[caseID][0]
+
+	tests := []struct {
+		name string
+		// mutate changes the normalized generation. mutateTurn changes the
+		// imported turn instead, which is the only way to reach a divergence
+		// the normalizer itself could hide.
+		mutate     func(gen *piNormalizedGeneration)
+		mutateTurn func(turn *HistoricalGeneration)
+		wantPath   string
+	}{
+		{
+			// The one usage difference that would look harmless: recomputing
+			// totalTokens as input+output, which is what the Go launchers do
+			// and what mapPiUsage deliberately does not.
+			name: "total tokens recomputed the Go launcher way",
+			mutate: func(gen *piNormalizedGeneration) {
+				gen.Usage.TotalTokens = gen.Usage.InputTokens + gen.Usage.OutputTokens
+			},
+			wantPath: "usage.total_tokens",
+		},
+		{
+			name: "stop reason passed through unmapped",
+			mutate: func(gen *piNormalizedGeneration) {
+				gen.StopReason = "toolUse"
+			},
+			wantPath: "stop_reason",
+		},
+		{
+			name: "tool call arguments re-encoded as a string",
+			mutate: func(gen *piNormalizedGeneration) {
+				part := piMutablePart(t, gen, 1, 0)
+				quoted, err := json.Marshal(string(part.ToolCall.Arguments))
+				if err != nil {
+					t.Fatalf("marshal arguments: %v", err)
+				}
+				part.ToolCall.Arguments = quoted
+			},
+			wantPath: "output[1].parts[0].tool_call.arguments",
+		},
+		{
+			name: "thinking text dropped from the output",
+			mutate: func(gen *piNormalizedGeneration) {
+				gen.Output = append(gen.Output[:0:0], gen.Output[1:]...)
+			},
+			wantPath: "output",
+		},
+		{
+			// A placeholder says the value cannot agree, not that it may be
+			// missing: an empty one still has to fail.
+			name: "placeholder field left empty",
+			mutate: func(gen *piNormalizedGeneration) {
+				gen.StartedAt = ""
+			},
+			wantPath: "started_at",
+		},
+		{
+			// Same rule for a timestamp the importer never set: a zero time
+			// is an absent value, not a value that cannot agree.
+			name: "start timestamp left unset",
+			mutateTurn: func(turn *HistoricalGeneration) {
+				turn.Gen.StartedAt = time.Time{}
+			},
+			wantPath: "started_at",
+		},
+		{
+			name: "completion timestamp left unset",
+			mutateTurn: func(turn *HistoricalGeneration) {
+				turn.Gen.CompletedAt = time.Time{}
+			},
+			wantPath: "completed_at",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var mutated piNormalizedGeneration
+			if tc.mutateTurn != nil {
+				turn := turns[0]
+				tc.mutateTurn(&turn)
+				mutated = normalizePiHistoricalGeneration(turn)
+			} else {
+				mutated = piCopyNormalizedGeneration(baseline)
+				tc.mutate(&mutated)
+			}
+
+			diffs := piDiffJSON("", piNormalizedJSON(t, mutated), want)
+			if len(diffs) == 0 {
+				t.Fatalf("the comparator accepted a %s", tc.name)
+			}
+			named := false
+			for _, diff := range diffs {
+				if strings.HasPrefix(diff, tc.wantPath) {
+					named = true
+				}
+			}
+			if !named {
+				t.Fatalf("diffs %v name no path starting with %q", diffs, tc.wantPath)
+			}
+		})
+	}
+}
+
+// piCopyNormalizedGeneration copies a normalized generation deeply enough that
+// one case's mutation cannot reach another case's baseline.
+func piCopyNormalizedGeneration(gen piNormalizedGeneration) piNormalizedGeneration {
+	out := gen
+	out.Output = append([]piNormalizedMessage(nil), gen.Output...)
+	for i := range out.Output {
+		out.Output[i].Parts = append([]piNormalizedPart(nil), gen.Output[i].Parts...)
+		for j, part := range out.Output[i].Parts {
+			if part.ToolCall != nil {
+				call := *part.ToolCall
+				out.Output[i].Parts[j].ToolCall = &call
+			}
+		}
+	}
+	return out
+}
+
+func piMutablePart(t *testing.T, gen *piNormalizedGeneration, msg, part int) *piNormalizedPart {
+	t.Helper()
+	if len(gen.Output) <= msg || len(gen.Output[msg].Parts) <= part {
+		t.Fatalf("normalized generation has no output message %d part %d", msg, part)
+	}
+	return &gen.Output[msg].Parts[part]
+}
+
+// piPlaceholderPattern marks a value that cannot agree across the two
+// implementations, such as the generation ID scheme or a timestamp only a live
+// process observes. A placeholder still requires a non-empty value: the field
+// has to be there, only its content is unpinned. See the fixture README.
+func piIsPlaceholder(want any) bool {
+	text, ok := want.(string)
+	return ok && strings.HasPrefix(text, "${") && strings.HasSuffix(text, "}")
+}
+
+// piDiffJSON reports every structural difference between got and want as a
+// dotted JSON path plus the two values, so a failure names the offending field
+// instead of dumping two payloads. It is the Go half of the comparator the
+// TypeScript suite ports; both must treat ${PLACEHOLDER} the same way.
+func piDiffJSON(path string, got, want any) []string {
+	if piIsPlaceholder(want) {
+		text, ok := got.(string)
+		if !ok || strings.TrimSpace(text) == "" {
+			return []string{fmt.Sprintf("%s: got %s, want a non-empty value for placeholder %s",
+				piDiffPath(path), piDiffValue(got), piDiffValue(want))}
+		}
+		return nil
+	}
+
+	switch wantTyped := want.(type) {
+	case map[string]any:
+		gotTyped, ok := got.(map[string]any)
+		if !ok {
+			return []string{fmt.Sprintf("%s: got %s, want an object", piDiffPath(path), piDiffValue(got))}
+		}
+		var diffs []string
+		for _, key := range piSortedKeys(wantTyped, gotTyped) {
+			gotValue, gotHas := gotTyped[key]
+			wantValue, wantHas := wantTyped[key]
+			childPath := key
+			if path != "" {
+				childPath = path + "." + key
+			}
+			switch {
+			case !gotHas:
+				diffs = append(diffs, fmt.Sprintf("%s: missing, want %s", childPath, piDiffValue(wantValue)))
+			case !wantHas:
+				diffs = append(diffs, fmt.Sprintf("%s: unexpected %s", childPath, piDiffValue(gotValue)))
+			default:
+				diffs = append(diffs, piDiffJSON(childPath, gotValue, wantValue)...)
+			}
+		}
+		return diffs
+	case []any:
+		gotTyped, ok := got.([]any)
+		if !ok {
+			return []string{fmt.Sprintf("%s: got %s, want an array", piDiffPath(path), piDiffValue(got))}
+		}
+		if len(gotTyped) != len(wantTyped) {
+			return []string{fmt.Sprintf("%s: got %d items, want %d", piDiffPath(path), len(gotTyped), len(wantTyped))}
+		}
+		var diffs []string
+		for i := range wantTyped {
+			diffs = append(diffs, piDiffJSON(fmt.Sprintf("%s[%d]", path, i), gotTyped[i], wantTyped[i])...)
+		}
+		return diffs
+	default:
+		if !reflect.DeepEqual(got, want) {
+			return []string{fmt.Sprintf("%s: got %s, want %s", piDiffPath(path), piDiffValue(got), piDiffValue(want))}
+		}
+		return nil
+	}
+}
+
+func piDiffPath(path string) string {
+	if path == "" {
+		return "<root>"
+	}
+	return path
+}
+
+func piDiffValue(value any) string {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprintf("%v", value)
+	}
+	return string(data)
+}
+
+func piSortedKeys(maps ...map[string]any) []string {
+	seen := map[string]struct{}{}
+	for _, m := range maps {
+		for key := range m {
+			seen[key] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/plugins/agento11y/internal/history/pi_test.go
+++ b/plugins/agento11y/internal/history/pi_test.go
@@ -1,0 +1,1226 @@
+package history
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/agento11y/go/agento11y"
+)
+
+// piLine marshals one session log line.
+func piLine(t *testing.T, entry map[string]any) string {
+	t.Helper()
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal pi line: %v", err)
+	}
+	return string(data) + "\n"
+}
+
+func piHeader(t *testing.T, sessionID, cwd, ts string) string {
+	t.Helper()
+	return piLine(t, map[string]any{
+		"type": "session", "version": 3, "id": sessionID, "timestamp": ts, "cwd": cwd,
+	})
+}
+
+func piUserEntry(t *testing.T, id, parentID, ts, text string, msTS int64) string {
+	t.Helper()
+	return piLine(t, map[string]any{
+		"type": "message", "id": id, "parentId": piParentValue(parentID), "timestamp": ts,
+		"message": map[string]any{
+			"role":      "user",
+			"content":   []map[string]any{{"type": "text", "text": text}},
+			"timestamp": msTS,
+		},
+	})
+}
+
+// piAssistantEntry writes an assistant entry with the fields every real one
+// carries. content is passed through so a test can add thinking or tool calls.
+func piAssistantEntry(t *testing.T, id, parentID, ts string, msTS int64, content []map[string]any, extra map[string]any) string {
+	t.Helper()
+	msg := map[string]any{
+		"role":       "assistant",
+		"content":    content,
+		"api":        "anthropic-messages",
+		"provider":   "anthropic",
+		"model":      "claude-opus-4-8",
+		"responseId": "msg_" + id,
+		"stopReason": "stop",
+		"timestamp":  msTS,
+		"usage": map[string]any{
+			"input": 12, "output": 34, "cacheRead": 5, "cacheWrite": 6, "totalTokens": 57,
+			"cost": map[string]any{"input": 0.001, "output": 0.002, "cacheRead": 0.0, "cacheWrite": 0.003, "total": 0.006},
+		},
+	}
+	for k, v := range extra {
+		if v == nil {
+			delete(msg, k)
+			continue
+		}
+		msg[k] = v
+	}
+	return piLine(t, map[string]any{
+		"type": "message", "id": id, "parentId": piParentValue(parentID), "timestamp": ts, "message": msg,
+	})
+}
+
+func piToolResultEntry(t *testing.T, id, parentID, ts, callID, toolName, text string, isError bool) string {
+	t.Helper()
+	return piLine(t, map[string]any{
+		"type": "message", "id": id, "parentId": piParentValue(parentID), "timestamp": ts,
+		"message": map[string]any{
+			"role": "toolResult", "toolCallId": callID, "toolName": toolName,
+			"content": []map[string]any{{"type": "text", "text": text}},
+			"isError": isError, "timestamp": 1781019440000,
+		},
+	})
+}
+
+func piParentValue(parentID string) any {
+	if parentID == "" {
+		return nil
+	}
+	return parentID
+}
+
+func piTextBlock(text string) map[string]any {
+	return map[string]any{"type": "text", "text": text}
+}
+
+func piThinkingBlock(text string) map[string]any {
+	return map[string]any{"type": "thinking", "thinking": text, "thinkingSignature": "sig"}
+}
+
+func piToolCallBlock(id, name string, args map[string]any) map[string]any {
+	return map[string]any{"type": "toolCall", "id": id, "name": name, "arguments": args}
+}
+
+// writePiSession writes a two-turn session: a prompt with a tool-calling turn
+// and its result, then a second prompt with a plain answer.
+func writePiSession(t *testing.T, root, encodedCwd, sessionID string) string {
+	t.Helper()
+	path := filepath.Join(root, encodedCwd, "2026-06-09T15-37-10-848Z_"+sessionID+".jsonl")
+	body := piHeader(t, sessionID, "/work/repo", "2026-06-09T15:37:10.848Z") +
+		piUserEntry(t, "u1", "", "2026-06-09T15:37:20.000Z", "review the last commit", 1781019439000) +
+		piAssistantEntry(t, "a1", "u1", "2026-06-09T15:37:24.526Z", 1781019441000,
+			[]map[string]any{
+				piThinkingBlock("I should read the log first."),
+				piTextBlock("Let me gather context."),
+				piToolCallBlock("toolu_1", "bash", map[string]any{"command": "git log -1"}),
+			}, map[string]any{"stopReason": "toolUse"}) +
+		piToolResultEntry(t, "r1", "a1", "2026-06-09T15:37:25.100Z", "toolu_1", "bash", "commit abc", false) +
+		piUserEntry(t, "u2", "r1", "2026-06-09T15:38:00.000Z", "and the tests?", 1781019480000) +
+		piAssistantEntry(t, "a2", "u2", "2026-06-09T15:38:06.000Z", 1781019482000,
+			[]map[string]any{piTextBlock("They pass.")}, nil)
+	return writeFile(t, path, body)
+}
+
+func piImporterAt(root string) *piImporter {
+	return &piImporter{roots: []string{root}}
+}
+
+func piPreview(t *testing.T, imp *piImporter, path string) SessionPreview {
+	t.Helper()
+	preview, ok, err := imp.Preview(context.Background(), path)
+	if err != nil || !ok {
+		t.Fatalf("Preview: ok=%v err=%v", ok, err)
+	}
+	return preview
+}
+
+func TestPiRegistration(t *testing.T) {
+	spec, ok := Spec(AgentPi)
+	if !ok {
+		t.Fatal("no spec registered for pi")
+	}
+	if spec.DisplayName != "pi" {
+		t.Fatalf("DisplayName = %q, want pi", spec.DisplayName)
+	}
+	for _, name := range []string{"pi", "PI", "pi-coding-agent"} {
+		if got, ok := Resolve(name); !ok || got != AgentPi {
+			t.Fatalf("Resolve(%q) = %q ok=%v, want pi", name, got, ok)
+		}
+	}
+	if _, ok := NewImporter(AgentPi); !ok {
+		t.Fatal("NewImporter(pi) reported no importer")
+	}
+}
+
+func TestPiRootsResolveFromTheAgentDir(t *testing.T) {
+	t.Setenv("PI_CODING_AGENT_DIR", "/tmp/pi-agent")
+	imp := &piImporter{}
+	if got, want := imp.Roots(), []string{filepath.Join("/tmp/pi-agent", "sessions")}; !slices.Equal(got, want) {
+		t.Fatalf("Roots() = %v, want %v", got, want)
+	}
+
+	t.Setenv("PI_CODING_AGENT_DIR", "")
+	t.Setenv("HOME", "/home/tester")
+	want := []string{filepath.Join("/home/tester", ".pi", "agent", "sessions")}
+	if got := imp.Roots(); !slices.Equal(got, want) {
+		t.Fatalf("Roots() = %v, want the home fallback %v", got, want)
+	}
+}
+
+func TestPiMatch(t *testing.T) {
+	imp := &piImporter{}
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"session log", "/s/--work-repo--/2026-06-09T15-37-10-848Z_019ead07.jsonl", true},
+		{"not jsonl", "/s/--work-repo--/2026-06-09T15-37-10-848Z_019ead07.json", false},
+		{"subagent run", "/s/--work-repo--/2026-06-09T15-37-10-848Z_019ead07/43cec431/run-0/session.jsonl", false},
+		{"older subagent run", "/s/--work-repo--/2026-06-09T15-37-10-848Z_019ead07/43cec431/run-4/2026-06-09T15-40-00-000Z_x.jsonl", false},
+		{"artifact dump", "/s/--work-repo--/subagent-artifacts/3baf6dad_reviewer_0_output.jsonl", false},
+		{"session.jsonl anywhere", "/s/--work-repo--/session.jsonl", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := imp.Match(tt.path); got != tt.want {
+				t.Fatalf("Match(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPiPreviewIsMetadataOnly(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+	path := writePiSession(t, root, "--work-repo--", sessionID)
+
+	preview := piPreview(t, piImporterAt(root), path)
+	if preview.SessionID != sessionID {
+		t.Fatalf("SessionID = %q, want %q", preview.SessionID, sessionID)
+	}
+	if preview.Workspace != "/work/repo" {
+		t.Fatalf("Workspace = %q, want /work/repo", preview.Workspace)
+	}
+	if preview.Title != sessionID {
+		t.Fatalf("Title = %q, want the session ID: a preview must not carry prompt text", preview.Title)
+	}
+	if preview.TurnCount != 2 || preview.ApproxTurns {
+		t.Fatalf("TurnCount = %d approx=%v, want an exact 2", preview.TurnCount, preview.ApproxTurns)
+	}
+	if want := time.Date(2026, 6, 9, 15, 37, 10, 848000000, time.UTC); !preview.StartedAt.Equal(want) {
+		t.Fatalf("StartedAt = %s, want %s", preview.StartedAt, want)
+	}
+	if want := time.Date(2026, 6, 9, 15, 38, 6, 0, time.UTC); !preview.LastActivityAt.Equal(want) {
+		t.Fatalf("LastActivityAt = %s, want %s", preview.LastActivityAt, want)
+	}
+	// Nothing the session said may appear in the preview.
+	rendered := preview.Title + preview.SessionID + preview.Workspace
+	for _, content := range []string{"review the last commit", "They pass.", "read the log first", "git log -1", "commit abc"} {
+		if strings.Contains(rendered, content) {
+			t.Fatalf("preview leaked session content %q", content)
+		}
+	}
+}
+
+func TestPiPreviewTitleIsTheSessionName(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+	path := writePiSession(t, root, "--work-repo--", sessionID)
+	body, err := readFileString(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	body += piLine(t, map[string]any{
+		"type": "session_info", "id": "s1", "parentId": "a2",
+		"timestamp": "2026-06-09T15:39:00.000Z", "name": "Commit review",
+	})
+	path = writeFile(t, path, body)
+
+	if got := piPreview(t, piImporterAt(root), path).Title; got != "Commit review" {
+		t.Fatalf("Title = %q, want the user-set session name", got)
+	}
+}
+
+func TestPiPreviewRejectsAFileWithNoSessionHeader(t *testing.T) {
+	root := t.TempDir()
+	path := writeFile(t, filepath.Join(root, "--work-repo--", "2026-06-09T15-37-10-848Z_x.jsonl"),
+		piLine(t, map[string]any{"type": "message", "id": "a1", "timestamp": "2026-06-09T15:37:24.526Z"}))
+
+	_, ok, err := piImporterAt(root).Preview(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Preview: %v", err)
+	}
+	if ok {
+		t.Fatal("Preview accepted a file with no session header")
+	}
+}
+
+func TestPiPreviewFallsBackToTheFilenameSessionID(t *testing.T) {
+	root := t.TempDir()
+	id := "019ead07-cfbf-78d3-8b03-875769426583"
+	path := writeFile(t, filepath.Join(root, "--work-repo--", "2026-06-09T15-37-10-848Z_"+id+".jsonl"),
+		piLine(t, map[string]any{"type": "session", "version": 3, "timestamp": "2026-06-09T15:37:10.848Z", "cwd": "/work/repo"}))
+
+	if got := piPreview(t, piImporterAt(root), path).SessionID; got != id {
+		t.Fatalf("SessionID = %q, want %q from the filename", got, id)
+	}
+}
+
+// TestPiPreviewStaysInsideTheByteBudget covers a session past the budget: the
+// windows read must stay bounded and the turn count is then an estimate.
+func TestPiPreviewStaysInsideTheByteBudget(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+	filler := strings.Repeat("x", 4096)
+	var body strings.Builder
+	body.WriteString(piHeader(t, sessionID, "/work/repo", "2026-06-09T15:37:10.848Z"))
+	parent := ""
+	for i := range 400 {
+		id := fmt.Sprintf("a%03d", i)
+		ts := time.Date(2026, 6, 9, 15, 37, 10, 0, time.UTC).Add(time.Duration(i) * time.Second).Format(time.RFC3339)
+		body.WriteString(piAssistantEntry(t, id, parent, ts, 1781019441000+int64(i)*1000,
+			[]map[string]any{piTextBlock("reply " + filler)}, nil))
+		parent = id
+	}
+	path := writeFile(t, filepath.Join(root, "--work-repo--", "2026-06-09T15-37-10-848Z_"+sessionID+".jsonl"), body.String())
+
+	win, err := ReadPreviewWindows(path, PreviewByteBudget)
+	if err != nil {
+		t.Fatalf("ReadPreviewWindows: %v", err)
+	}
+	if win.Size <= PreviewByteBudget {
+		t.Fatalf("fixture is %d bytes, want more than the %d-byte budget", win.Size, PreviewByteBudget)
+	}
+	if read := len(win.Head) + len(win.Tail); read > PreviewByteBudget {
+		t.Fatalf("preview read %d bytes, want at most %d", read, PreviewByteBudget)
+	}
+
+	preview := piPreview(t, piImporterAt(root), path)
+	if !preview.ApproxTurns {
+		t.Fatal("ApproxTurns = false, want true when the count was scaled from the head window")
+	}
+	if preview.TurnCount == 0 {
+		t.Fatal("TurnCount = 0, want an estimate scaled from the head window")
+	}
+	if preview.SessionID != sessionID {
+		t.Fatalf("SessionID = %q, want %q", preview.SessionID, sessionID)
+	}
+}
+
+func TestPiPreviewMatchesTheImportedTurnCount(t *testing.T) {
+	root := t.TempDir()
+	path := writePiSession(t, root, "--work-repo--", "019ead07-cfbf-78d3-8b03-875769426583")
+	imp := piImporterAt(root)
+	preview := piPreview(t, imp, path)
+	turns := collectTurns(t, imp, preview)
+	if preview.TurnCount != len(turns) {
+		t.Fatalf("preview said %d turns, the import produced %d", preview.TurnCount, len(turns))
+	}
+}
+
+// TestPiPreviewCountLeavesOutAForksCopiedTurns pins the preview against the
+// import for a fork. Counting every assistant entry in the file promised turns
+// the import does not deliver, because the copied region belongs to the trunk:
+// on the development machine that made 229 of the 2,231 previews small enough to
+// be counted exactly disagree with their own import.
+func TestPiPreviewCountLeavesOutAForksCopiedTurns(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "--work-repo--")
+	trunkID := "019ead07-cfbf-78d3-8b03-875769426583"
+	forkID := "019eae5b-8461-71ba-bb5b-0f947f105da6"
+
+	trunkPath := writeFile(t, filepath.Join(dir, "2026-06-09T15-37-10-848Z_"+trunkID+".jsonl"),
+		piHeader(t, trunkID, "/work/repo", "2026-06-09T15:37:10.848Z")+
+			piAssistantEntry(t, "a1", "", "2026-06-09T15:37:24.000Z", 1781019441000,
+				[]map[string]any{piTextBlock("one")}, nil))
+
+	forkBody := piLine(t, map[string]any{
+		"type": "session", "version": 3, "id": forkID,
+		"timestamp": "2026-06-09T15:40:00.000Z", "cwd": "/work/repo", "parentSession": trunkPath,
+	}) +
+		// Two copied turns, then one the fork ran itself.
+		piAssistantEntry(t, "a1", "", "2026-06-09T15:37:24.000Z", 1781019441000,
+			[]map[string]any{piTextBlock("one")}, nil) +
+		piAssistantEntry(t, "a2", "a1", "2026-06-09T15:38:24.000Z", 1781019501000,
+			[]map[string]any{piTextBlock("two")}, nil) +
+		piUserEntry(t, "u3", "a2", "2026-06-09T15:41:00.000Z", "again", 1781019700000) +
+		piAssistantEntry(t, "a3", "u3", "2026-06-09T15:41:06.000Z", 1781019702000,
+			[]map[string]any{piTextBlock("three")}, nil)
+	forkPath := writeFile(t, filepath.Join(dir, "2026-06-09T15-40-00-000Z_"+forkID+".jsonl"), forkBody)
+
+	imp := piImporterAt(root)
+	preview := piPreview(t, imp, forkPath)
+	turns := collectTurns(t, imp, preview)
+	if len(turns) != 1 {
+		t.Fatalf("imported %d turns, want only the one the fork ran", len(turns))
+	}
+	if preview.TurnCount != len(turns) {
+		t.Fatalf("preview said %d turns, the import produced %d", preview.TurnCount, len(turns))
+	}
+}
+
+// TestPiPreviewOfALargeForkCountsFromTheTail covers the one shape where the
+// head window is useless: a fork bigger than the byte budget. Its copied region
+// sits at the front of the file, the import skips every entry in it, so the head
+// holds no countable turn and a head-only estimate reported "about 0 turns" for
+// a session whose import produced dozens. On the development machine that was 84
+// of the 305 sessions over the budget.
+func TestPiPreviewOfALargeForkCountsFromTheTail(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "--work-repo--")
+	trunkID := "019ead07-cfbf-78d3-8b03-875769426583"
+	forkID := "019eae5b-8461-71ba-bb5b-0f947f105da6"
+	filler := strings.Repeat("x", 4096)
+	forkAt := time.Date(2026, 6, 9, 16, 0, 0, 0, time.UTC)
+
+	// The trunk holds the copied region, so both files carry the same 400 turns
+	// before the fork instant and only the fork adds turns after it.
+	var copied strings.Builder
+	parent := ""
+	for i := range 400 {
+		id := fmt.Sprintf("a%03d", i)
+		ts := forkAt.Add(-time.Duration(400-i) * time.Second).Format(time.RFC3339)
+		copied.WriteString(piAssistantEntry(t, id, parent, ts, 1781019441000+int64(i)*1000,
+			[]map[string]any{piTextBlock("reply " + filler)}, nil))
+		parent = id
+	}
+	trunkPath := writeFile(t, filepath.Join(dir, "2026-06-09T15-37-10-848Z_"+trunkID+".jsonl"),
+		piHeader(t, trunkID, "/work/repo", "2026-06-09T15:37:10.848Z")+copied.String())
+
+	var forkBody strings.Builder
+	forkBody.WriteString(piLine(t, map[string]any{
+		"type": "session", "version": 3, "id": forkID,
+		"timestamp": forkAt.Format(time.RFC3339), "cwd": "/work/repo", "parentSession": trunkPath,
+	}))
+	forkBody.WriteString(copied.String())
+	for i := range 3 {
+		id := fmt.Sprintf("f%03d", i)
+		ts := forkAt.Add(time.Duration(i+1) * time.Minute).Format(time.RFC3339)
+		forkBody.WriteString(piAssistantEntry(t, id, parent, ts, 1781029441000+int64(i)*1000,
+			[]map[string]any{piTextBlock("fork reply " + filler)}, nil))
+		parent = id
+	}
+	forkPath := writeFile(t, filepath.Join(dir, "2026-06-09T16-00-00-000Z_"+forkID+".jsonl"), forkBody.String())
+
+	win, err := ReadPreviewWindows(forkPath, PreviewByteBudget)
+	if err != nil {
+		t.Fatalf("ReadPreviewWindows: %v", err)
+	}
+	if win.Size <= PreviewByteBudget {
+		t.Fatalf("fixture is %d bytes, want more than the %d-byte budget", win.Size, PreviewByteBudget)
+	}
+	if got := piCountAssistantTurns(win.HeadLines(), forkAt); got != 0 {
+		t.Fatalf("head window holds %d countable turns, want 0 so the fixture covers the tail fallback", got)
+	}
+
+	imp := piImporterAt(root)
+	preview := piPreview(t, imp, forkPath)
+	if preview.TurnCount == 0 {
+		t.Fatal("TurnCount = 0, want an estimate scaled from the tail window")
+	}
+	if !preview.ApproxTurns {
+		t.Fatal("ApproxTurns = false, want true when the count was scaled")
+	}
+	if turns := collectTurns(t, imp, preview); len(turns) != 3 {
+		t.Fatalf("imported %d turns, want the 3 the fork ran itself", len(turns))
+	}
+}
+
+func TestPiTurnsMapOneGenerationPerAssistantEntry(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+	path := writePiSession(t, root, "--work-repo--", sessionID)
+	imp := piImporterAt(root)
+
+	turns := collectTurns(t, imp, piPreview(t, imp, path))
+	if len(turns) != 2 {
+		t.Fatalf("got %d turns, want 2", len(turns))
+	}
+
+	first := turns[0]
+	if first.Gen.ConversationID != sessionID {
+		t.Fatalf("ConversationID = %q, want the session header ID %q", first.Gen.ConversationID, sessionID)
+	}
+	if first.Gen.Model.Provider != "anthropic" || first.Gen.Model.Name != "claude-opus-4-8" {
+		t.Fatalf("Model = %+v, want the provider and model from the entry", first.Gen.Model)
+	}
+	if first.Gen.ResponseID != "msg_a1" || first.Gen.ResponseModel != "claude-opus-4-8" {
+		t.Fatalf("ResponseID = %q ResponseModel = %q", first.Gen.ResponseID, first.Gen.ResponseModel)
+	}
+	if first.Gen.StopReason != "tool_use" {
+		t.Fatalf("StopReason = %q, want tool_use for pi's toolUse", first.Gen.StopReason)
+	}
+	if first.Gen.Mode != "STREAM" || first.Gen.OperationName != "streamText" {
+		t.Fatalf("Mode = %q OperationName = %q, want STREAM/streamText as live exports", first.Gen.Mode, first.Gen.OperationName)
+	}
+	if first.Gen.ThinkingEnabled == nil || !*first.Gen.ThinkingEnabled {
+		t.Fatal("ThinkingEnabled is not set for a turn with a thinking block")
+	}
+	// pi's own totalTokens is input+output+cacheRead+cacheWrite, which is what
+	// mapPiUsage passes through.
+	usage := first.Gen.Usage
+	if usage.InputTokens != 12 || usage.OutputTokens != 34 || usage.TotalTokens != 57 ||
+		usage.CacheReadInputTokens != 5 || usage.CacheWriteInputTokens != 6 {
+		t.Fatalf("Usage = %+v, want the mapPiUsage mapping", usage)
+	}
+	if usage.ReasoningTokens != 0 {
+		t.Fatalf("ReasoningTokens = %d, want 0: live does not forward reasoning", usage.ReasoningTokens)
+	}
+	if got := first.Gen.Metadata["cost_usd"]; got != 0.006 {
+		t.Fatalf("metadata cost_usd = %v, want 0.006", got)
+	}
+	if want := time.UnixMilli(1781019441000).UTC(); !first.Gen.StartedAt.Equal(want) {
+		t.Fatalf("StartedAt = %s, want the assistant message timestamp %s", first.Gen.StartedAt, want)
+	}
+	if want := time.Date(2026, 6, 9, 15, 37, 24, 526000000, time.UTC); !first.Gen.CompletedAt.Equal(want) {
+		t.Fatalf("CompletedAt = %s, want the entry timestamp %s", first.Gen.CompletedAt, want)
+	}
+	if first.Quality.ApproxStartedAt || first.Quality.ApproxCompletedAt {
+		t.Fatalf("quality = %+v, want neither timestamp approximate: pi persists both", first.Quality)
+	}
+	if first.Quality.ApproxUsage || first.Quality.MissingModel {
+		t.Fatalf("quality = %+v, want no approximation flags for a complete entry", first.Quality)
+	}
+
+	// The user prompt is the input, the assistant content plus the matched tool
+	// result the output.
+	if len(first.Gen.Input) != 1 || first.Gen.Input[0].Parts[0].Text != "review the last commit" {
+		t.Fatalf("Input = %+v, want the user prompt", first.Gen.Input)
+	}
+	kinds := []string{}
+	for _, msg := range first.Gen.Output {
+		for _, part := range msg.Parts {
+			kinds = append(kinds, string(part.Kind))
+		}
+	}
+	if want := []string{"thinking", "text", "tool_call", "tool_result"}; !slices.Equal(kinds, want) {
+		t.Fatalf("output part kinds = %v, want %v", kinds, want)
+	}
+	call := first.Gen.Output[2].Parts[0].ToolCall
+	if call.Name != "bash" || call.ID != "toolu_1" || string(call.InputJSON) != `{"command":"git log -1"}` {
+		t.Fatalf("tool call = %+v, want the call from the entry", call)
+	}
+	result := first.Gen.Output[3].Parts[0].ToolResult
+	if result.ToolCallID != "toolu_1" || result.Name != "bash" || result.Content != "commit abc" || result.IsError {
+		t.Fatalf("tool result = %+v, want the result answering the call", result)
+	}
+	if thinking := first.Gen.Output[0].Parts[0].Thinking; thinking != "I should read the log first." {
+		t.Fatalf("thinking = %q, want the thinking text pi persisted", thinking)
+	}
+
+	// AgentName is left to the framework, which fills it from the agent ID.
+	if first.Gen.AgentName != "" {
+		t.Fatalf("AgentName = %q, want empty so Exporter.prepare fills it", first.Gen.AgentName)
+	}
+	var prepared HistoricalGeneration = first
+	(&Exporter{}).prepare(&prepared)
+	if prepared.Gen.AgentName != "pi" {
+		t.Fatalf("prepared AgentName = %q, want pi", prepared.Gen.AgentName)
+	}
+
+	// The second turn carries only its own prompt and no tool traffic.
+	second := turns[1]
+	if len(second.Gen.Input) != 1 || second.Gen.Input[0].Parts[0].Text != "and the tests?" {
+		t.Fatalf("second Input = %+v, want only the prompt since the previous turn", second.Gen.Input)
+	}
+	if len(second.Gen.Output) != 1 || second.Gen.Output[0].Parts[0].Text != "They pass." {
+		t.Fatalf("second Output = %+v", second.Gen.Output)
+	}
+	if second.Gen.StopReason != "end_turn" {
+		t.Fatalf("second StopReason = %q, want end_turn for pi's stop", second.Gen.StopReason)
+	}
+	if len(second.Gen.Tools) != 0 {
+		t.Fatalf("second Tools = %+v, want none: the turn called nothing", second.Gen.Tools)
+	}
+	if len(first.Gen.Tools) != 1 || first.Gen.Tools[0].Name != "bash" {
+		t.Fatalf("Tools = %+v, want one name-only definition for the called tool", first.Gen.Tools)
+	}
+	if first.Gen.Tools[0].Description != "" || len(first.Gen.Tools[0].InputSchema) != 0 {
+		t.Fatal("tool definitions must be name-only: descriptions and schemas are runtime-only")
+	}
+}
+
+func TestPiStopReasonMapping(t *testing.T) {
+	tests := map[string]string{
+		"stop":     "end_turn",
+		"length":   "max_tokens",
+		"toolUse":  "tool_use",
+		"error":    "error",
+		"aborted":  "aborted",
+		"whatever": "whatever",
+		"":         "",
+	}
+	for in, want := range tests {
+		if got := piStopReason(in); got != want {
+			t.Errorf("piStopReason(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestPiTurnQualityFlagsWhatTheSourceLacks(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+	body := piHeader(t, sessionID, "/work/repo", "2026-06-09T15:37:10.848Z") +
+		piAssistantEntry(t, "a1", "", "2026-06-09T15:37:24.526Z", 1781019441000,
+			[]map[string]any{piTextBlock("no model, no tokens")},
+			map[string]any{"model": "", "usage": nil})
+	path := writeFile(t, filepath.Join(root, "--work-repo--", "2026-06-09T15-37-10-848Z_"+sessionID+".jsonl"), body)
+
+	imp := piImporterAt(root)
+	turns := collectTurns(t, imp, piPreview(t, imp, path))
+	if len(turns) != 1 {
+		t.Fatalf("got %d turns, want the turn imported anyway", len(turns))
+	}
+	q := turns[0].Quality
+	if !q.MissingModel || !q.ApproxUsage {
+		t.Fatalf("quality = %+v, want MissingModel and ApproxUsage", q)
+	}
+	if q.ApproxStartedAt || q.ApproxCompletedAt {
+		t.Fatalf("quality = %+v, want both timestamps exact: pi persists both", q)
+	}
+	if _, ok := turns[0].Gen.Metadata["cost_usd"]; ok {
+		t.Fatalf("metadata = %+v, want no cost for an entry with no usage", turns[0].Gen.Metadata)
+	}
+}
+
+// TestPiUsageWithOnlyACostIsApproximate covers a usage block that reports a
+// cost and no token counts. Reporting "0 tokens" there would state a number the
+// source does not have.
+func TestPiUsageWithOnlyACostIsApproximate(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+	body := piHeader(t, sessionID, "/work/repo", "2026-06-09T15:37:10.848Z") +
+		piAssistantEntry(t, "a1", "", "2026-06-09T15:37:24.526Z", 1781019441000,
+			[]map[string]any{piTextBlock("cost only")},
+			map[string]any{"usage": map[string]any{"cost": map[string]any{"total": 0.02}}})
+	path := writeFile(t, filepath.Join(root, "--work-repo--", "2026-06-09T15-37-10-848Z_"+sessionID+".jsonl"), body)
+
+	imp := piImporterAt(root)
+	turns := collectTurns(t, imp, piPreview(t, imp, path))
+	if len(turns) != 1 {
+		t.Fatalf("got %d turns, want 1", len(turns))
+	}
+	if !turns[0].Quality.ApproxUsage {
+		t.Error("ApproxUsage = false, want true for usage with no token counts")
+	}
+	if got := turns[0].Gen.Metadata["cost_usd"]; got != 0.02 {
+		t.Fatalf("cost_usd = %v, want 0.02", got)
+	}
+}
+
+func TestPiCallErrorComesFromTheMessage(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+	body := piHeader(t, sessionID, "/work/repo", "2026-06-09T15:37:10.848Z") +
+		piAssistantEntry(t, "a1", "", "2026-06-09T15:37:24.526Z", 1781019441000,
+			[]map[string]any{piTextBlock("")},
+			map[string]any{"stopReason": "error", "errorMessage": "provider overloaded"})
+	path := writeFile(t, filepath.Join(root, "--work-repo--", "2026-06-09T15-37-10-848Z_"+sessionID+".jsonl"), body)
+
+	imp := piImporterAt(root)
+	turns := collectTurns(t, imp, piPreview(t, imp, path))
+	if len(turns) != 1 {
+		t.Fatalf("got %d turns, want 1", len(turns))
+	}
+	if turns[0].Gen.CallError != "provider overloaded" {
+		t.Fatalf("CallError = %q, want the message's errorMessage", turns[0].Gen.CallError)
+	}
+	if turns[0].Gen.StopReason != "error" {
+		t.Fatalf("StopReason = %q, want error", turns[0].Gen.StopReason)
+	}
+}
+
+// TestPiRedactedThinkingIsDropped covers pi's redacted thinking block: live
+// skips it, so an import must too, but the turn still counts as thinking.
+func TestPiRedactedThinkingIsDropped(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+	body := piHeader(t, sessionID, "/work/repo", "2026-06-09T15:37:10.848Z") +
+		piAssistantEntry(t, "a1", "", "2026-06-09T15:37:24.526Z", 1781019441000,
+			[]map[string]any{
+				{"type": "thinking", "thinking": "hidden", "redacted": true},
+				piTextBlock("answer"),
+			}, nil)
+	path := writeFile(t, filepath.Join(root, "--work-repo--", "2026-06-09T15-37-10-848Z_"+sessionID+".jsonl"), body)
+
+	imp := piImporterAt(root)
+	turns := collectTurns(t, imp, piPreview(t, imp, path))
+	if len(turns) != 1 {
+		t.Fatalf("got %d turns, want 1", len(turns))
+	}
+	if len(turns[0].Gen.Output) != 1 || turns[0].Gen.Output[0].Parts[0].Text != "answer" {
+		t.Fatalf("Output = %+v, want the text alone", turns[0].Gen.Output)
+	}
+	if turns[0].Gen.ThinkingEnabled == nil || !*turns[0].Gen.ThinkingEnabled {
+		t.Fatal("ThinkingEnabled is not set: the turn did think, the text is just withheld")
+	}
+}
+
+// TestPiTitleComesFromTheSessionNameThenThePrompt pins the title precedence
+// resolveConversationTitle sets in the live plugin.
+func TestPiTitleComesFromTheSessionNameThenThePrompt(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+	path := writePiSession(t, root, "--work-repo--", sessionID)
+	imp := piImporterAt(root)
+
+	turns := collectTurns(t, imp, piPreview(t, imp, path))
+	if got := turns[0].Gen.ConversationTitle; got != "review the last commit" {
+		t.Fatalf("ConversationTitle = %q, want the first prompt", got)
+	}
+
+	body, err := readFileString(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	named := writeFile(t, path, body+piLine(t, map[string]any{
+		"type": "session_info", "id": "s1", "parentId": "a2",
+		"timestamp": "2026-06-09T15:39:00.000Z", "name": "Commit review",
+	}))
+	turns = collectTurns(t, imp, piPreview(t, imp, named))
+	if got := turns[0].Gen.ConversationTitle; got != "Commit review" {
+		t.Fatalf("ConversationTitle = %q, want the user-set session name", got)
+	}
+}
+
+func TestPiTitleIsClippedToOneHundredRunes(t *testing.T) {
+	long := strings.Repeat("é", 150)
+	got := piClipTitle(long)
+	if n := len([]rune(got)); n != piMaxTitleLen {
+		t.Fatalf("clipped title is %d runes, want %d", n, piMaxTitleLen)
+	}
+}
+
+// TestPiLineageFollowsTheParentIDChain covers the within-session parent chain,
+// including a branch where two assistant entries share one parent.
+func TestPiLineageFollowsTheParentIDChain(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+	body := piHeader(t, sessionID, "/work/repo", "2026-06-09T15:37:10.848Z") +
+		piUserEntry(t, "u1", "", "2026-06-09T15:37:20.000Z", "first", 1781019439000) +
+		piAssistantEntry(t, "a1", "u1", "2026-06-09T15:37:24.000Z", 1781019441000,
+			[]map[string]any{piTextBlock("one")}, nil) +
+		piUserEntry(t, "u2", "a1", "2026-06-09T15:38:00.000Z", "second", 1781019480000) +
+		// Two answers to the same prompt: the user regenerated, so the branch
+		// point has two children and both were real model calls.
+		piAssistantEntry(t, "a2", "u2", "2026-06-09T15:38:06.000Z", 1781019482000,
+			[]map[string]any{piTextBlock("two")}, nil) +
+		piAssistantEntry(t, "a3", "u2", "2026-06-09T15:38:20.000Z", 1781019496000,
+			[]map[string]any{piTextBlock("two, again")}, nil)
+	path := writeFile(t, filepath.Join(root, "--work-repo--", "2026-06-09T15-37-10-848Z_"+sessionID+".jsonl"), body)
+
+	imp := piImporterAt(root)
+	turns := collectTurns(t, imp, piPreview(t, imp, path))
+	if len(turns) != 3 {
+		t.Fatalf("got %d turns, want all three including the abandoned branch", len(turns))
+	}
+	if len(turns[0].Gen.ParentGenerationIDs) != 0 {
+		t.Fatalf("first turn parents = %v, want none", turns[0].Gen.ParentGenerationIDs)
+	}
+	// Both regenerations hang off the assistant turn before the branch point,
+	// reached through the user entry between them.
+	want := []string{turns[0].Gen.ID}
+	for _, turn := range turns[1:] {
+		if !slices.Equal(turn.Gen.ParentGenerationIDs, want) {
+			t.Fatalf("ParentGenerationIDs = %v, want %v", turn.Gen.ParentGenerationIDs, want)
+		}
+	}
+	if turns[1].Gen.ID == turns[2].Gen.ID {
+		t.Fatal("the two branches share a generation ID")
+	}
+}
+
+// TestPiForkReportsTheTrunkAsMetadata covers a session whose header names a
+// parentSession. The copied parent turn's generation belongs to the trunk
+// conversation, so an edge would name a generation that does not exist under
+// this conversation ID; live reports it as metadata instead.
+func TestPiForkReportsTheTrunkAsMetadata(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "--work-repo--")
+	trunkID := "019ead07-cfbf-78d3-8b03-875769426583"
+	forkID := "019eae5b-8461-71ba-bb5b-0f947f105da6"
+
+	trunkBody := piHeader(t, trunkID, "/work/repo", "2026-06-09T15:37:10.848Z") +
+		piUserEntry(t, "u1", "", "2026-06-09T15:37:20.000Z", "first", 1781019439000) +
+		piAssistantEntry(t, "a1", "u1", "2026-06-09T15:37:24.000Z", 1781019441000,
+			[]map[string]any{piTextBlock("one")}, nil)
+	trunkPath := writeFile(t, filepath.Join(dir, "2026-06-09T15-37-10-848Z_"+trunkID+".jsonl"), trunkBody)
+
+	// The fork copies the trunk's entries with their own timestamps and stamps
+	// its header at fork time, which is later than every copied entry.
+	forkBody := piLine(t, map[string]any{
+		"type": "session", "version": 3, "id": forkID,
+		"timestamp": "2026-06-09T15:40:00.000Z", "cwd": "/work/repo", "parentSession": trunkPath,
+	}) +
+		piUserEntry(t, "u1", "", "2026-06-09T15:37:20.000Z", "first", 1781019439000) +
+		piAssistantEntry(t, "a1", "u1", "2026-06-09T15:37:24.000Z", 1781019441000,
+			[]map[string]any{piTextBlock("one")}, nil) +
+		piUserEntry(t, "u2", "a1", "2026-06-09T15:41:00.000Z", "try again", 1781019700000) +
+		piAssistantEntry(t, "a2", "u2", "2026-06-09T15:41:06.000Z", 1781019702000,
+			[]map[string]any{piTextBlock("differently")}, nil)
+	forkPath := writeFile(t, filepath.Join(dir, "2026-06-09T15-40-00-000Z_"+forkID+".jsonl"), forkBody)
+
+	imp := piImporterAt(root)
+	trunkTurns := collectTurns(t, imp, piPreview(t, imp, trunkPath))
+	if len(trunkTurns) != 1 {
+		t.Fatalf("got %d trunk turns, want 1", len(trunkTurns))
+	}
+	forkTurns := collectTurns(t, imp, piPreview(t, imp, forkPath))
+	// Only the fork's own turn is imported. The copied one belongs to the trunk,
+	// which exports it itself; exporting it again would report one model call
+	// twice, under two conversation IDs.
+	if len(forkTurns) != 1 {
+		t.Fatalf("got %d fork turns, want only the fork's own turn", len(forkTurns))
+	}
+
+	// The fork's own turn: its parent was copied from the trunk, so no edge.
+	own := forkTurns[0]
+	if len(own.Gen.ParentGenerationIDs) != 0 {
+		t.Fatalf("ParentGenerationIDs = %v, want none: a dangling parent ID is the bug this avoids", own.Gen.ParentGenerationIDs)
+	}
+	if got := own.Gen.Metadata[MetaPiForkParentSession]; got != trunkID {
+		t.Fatalf("%s = %v, want the trunk conversation ID %q", MetaPiForkParentSession, got, trunkID)
+	}
+	if got := own.Gen.Metadata[MetaPiForkParentGeneration]; got != trunkTurns[0].Gen.ID {
+		t.Fatalf("%s = %v, want the trunk's own imported generation ID %q",
+			MetaPiForkParentGeneration, got, trunkTurns[0].Gen.ID)
+	}
+	// The copied prompt is not the fork's first prompt either: live sees only
+	// what the fork itself sent.
+	if own.Gen.ConversationTitle != "try again" {
+		t.Fatalf("ConversationTitle = %q, want the fork's own first prompt", own.Gen.ConversationTitle)
+	}
+	if len(own.Gen.Input) != 1 || own.Gen.Input[0].Parts[0].Text != "try again" {
+		t.Fatalf("Input = %+v, want only the prompt the fork sent", own.Gen.Input)
+	}
+}
+
+// TestPiForkOfAForkLinksNothing covers a parent entry the trunk itself inherited
+// rather than produced: the trunk holds no generation for it, so neither key is
+// written. Live's forkMetadata writes both or neither for the same reason.
+func TestPiForkOfAForkLinksNothing(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "--work-repo--")
+	trunkID := "019ead07-cfbf-78d3-8b03-875769426583"
+	forkID := "019eae5b-8461-71ba-bb5b-0f947f105da6"
+
+	// The trunk is itself a fork: its assistant entry a1 predates its own
+	// header, so the trunk inherited a1 and never ran it.
+	trunkBody := piLine(t, map[string]any{
+		"type": "session", "version": 3, "id": trunkID,
+		"timestamp": "2026-06-09T15:39:00.000Z", "cwd": "/work/repo",
+		"parentSession": filepath.Join(dir, "older.jsonl"),
+	}) +
+		piAssistantEntry(t, "a1", "", "2026-06-09T15:37:24.000Z", 1781019441000,
+			[]map[string]any{piTextBlock("one")}, nil)
+	trunkPath := writeFile(t, filepath.Join(dir, "2026-06-09T15-39-00-000Z_"+trunkID+".jsonl"), trunkBody)
+
+	forkBody := piLine(t, map[string]any{
+		"type": "session", "version": 3, "id": forkID,
+		"timestamp": "2026-06-09T15:40:00.000Z", "cwd": "/work/repo", "parentSession": trunkPath,
+	}) +
+		piAssistantEntry(t, "a1", "", "2026-06-09T15:37:24.000Z", 1781019441000,
+			[]map[string]any{piTextBlock("one")}, nil) +
+		piUserEntry(t, "u2", "a1", "2026-06-09T15:41:00.000Z", "try again", 1781019700000) +
+		piAssistantEntry(t, "a2", "u2", "2026-06-09T15:41:06.000Z", 1781019702000,
+			[]map[string]any{piTextBlock("differently")}, nil)
+	forkPath := writeFile(t, filepath.Join(dir, "2026-06-09T15-40-00-000Z_"+forkID+".jsonl"), forkBody)
+
+	imp := piImporterAt(root)
+	turns := collectTurns(t, imp, piPreview(t, imp, forkPath))
+	if len(turns) != 1 {
+		t.Fatalf("got %d turns, want only the fork's own turn", len(turns))
+	}
+	if len(turns[0].Gen.ParentGenerationIDs) != 0 {
+		t.Fatalf("ParentGenerationIDs = %v, want none", turns[0].Gen.ParentGenerationIDs)
+	}
+	for _, key := range []string{MetaPiForkParentSession, MetaPiForkParentGeneration} {
+		if _, ok := turns[0].Gen.Metadata[key]; ok {
+			t.Fatalf("metadata = %+v, want neither fork key: the trunk holds no generation for the copied entry", turns[0].Gen.Metadata)
+		}
+	}
+	if !slices.Contains(turns[0].Quality.Notes, "pi_fork_parent_not_in_trunk") {
+		t.Fatalf("quality notes = %v, want the parent-not-in-trunk note", turns[0].Quality.Notes)
+	}
+}
+
+// TestPiForkWithAnUnreadableTrunkDropsTheLink covers a header naming a trunk
+// this machine no longer has: nothing is linked, and the turn says so.
+func TestPiForkWithAnUnreadableTrunkDropsTheLink(t *testing.T) {
+	root := t.TempDir()
+	forkID := "019eae5b-8461-71ba-bb5b-0f947f105da6"
+	body := piLine(t, map[string]any{
+		"type": "session", "version": 3, "id": forkID,
+		"timestamp": "2026-06-09T15:40:00.000Z", "cwd": "/work/repo",
+		"parentSession": filepath.Join(root, "--work-repo--", "gone.jsonl"),
+	}) +
+		piAssistantEntry(t, "a1", "", "2026-06-09T15:37:24.000Z", 1781019441000,
+			[]map[string]any{piTextBlock("copied")}, nil) +
+		piUserEntry(t, "u2", "a1", "2026-06-09T15:41:00.000Z", "try again", 1781019700000) +
+		piAssistantEntry(t, "a2", "u2", "2026-06-09T15:41:06.000Z", 1781019702000,
+			[]map[string]any{piTextBlock("differently")}, nil)
+	path := writeFile(t, filepath.Join(root, "--work-repo--", "2026-06-09T15-40-00-000Z_"+forkID+".jsonl"), body)
+
+	imp := piImporterAt(root)
+	turns := collectTurns(t, imp, piPreview(t, imp, path))
+	if len(turns) != 1 {
+		t.Fatalf("got %d turns, want only the fork's own turn", len(turns))
+	}
+	own := turns[0]
+	if len(own.Gen.ParentGenerationIDs) != 0 {
+		t.Fatalf("ParentGenerationIDs = %v, want none for an unreadable trunk", own.Gen.ParentGenerationIDs)
+	}
+	if _, ok := own.Gen.Metadata[MetaPiForkParentSession]; ok {
+		t.Fatalf("metadata = %+v, want no trunk pointer when the trunk cannot be read", own.Gen.Metadata)
+	}
+	if !slices.Contains(own.Quality.Notes, "pi_fork_trunk_unreadable") {
+		t.Fatalf("quality notes = %v, want the unreadable-trunk note", own.Quality.Notes)
+	}
+}
+
+func TestPiTurnsAreDeterministic(t *testing.T) {
+	root := t.TempDir()
+	path := writePiSession(t, root, "--work-repo--", "019ead07-cfbf-78d3-8b03-875769426583")
+	imp := piImporterAt(root)
+	preview := piPreview(t, imp, path)
+
+	first := collectTurns(t, imp, preview)
+	second := collectTurns(t, imp, preview)
+	if len(first) != len(second) {
+		t.Fatalf("got %d then %d turns", len(first), len(second))
+	}
+	for i := range first {
+		if first[i].Gen.ID != second[i].Gen.ID {
+			t.Fatalf("turn %d: generation ID %q then %q", i, first[i].Gen.ID, second[i].Gen.ID)
+		}
+		if first[i].Source.Identity() != second[i].Source.Identity() {
+			t.Fatalf("turn %d: ledger identity changed between runs", i)
+		}
+	}
+}
+
+func TestPiTurnsStopWhenTheConsumerStops(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+	var body strings.Builder
+	body.WriteString(piHeader(t, sessionID, "/work/repo", "2026-06-09T15:37:10.848Z"))
+	parent := ""
+	for i := range 20 {
+		id := fmt.Sprintf("a%02d", i)
+		ts := time.Date(2026, 6, 9, 15, 37, 10, 0, time.UTC).Add(time.Duration(i) * time.Second).Format(time.RFC3339)
+		body.WriteString(piAssistantEntry(t, id, parent, ts, 1781019441000+int64(i)*1000,
+			[]map[string]any{piTextBlock("reply")}, nil))
+		parent = id
+	}
+	path := writeFile(t, filepath.Join(root, "--work-repo--", "2026-06-09T15-37-10-848Z_"+sessionID+".jsonl"), body.String())
+
+	imp := piImporterAt(root)
+	seen := 0
+	for range imp.Turns(context.Background(), piPreview(t, imp, path)) {
+		seen++
+		if seen == 3 {
+			break
+		}
+	}
+	if seen != 3 {
+		t.Fatalf("consumed %d turns, want 3 before breaking", seen)
+	}
+}
+
+func TestPiTurnsHonourCancellation(t *testing.T) {
+	root := t.TempDir()
+	path := writePiSession(t, root, "--work-repo--", "019ead07-cfbf-78d3-8b03-875769426583")
+	imp := piImporterAt(root)
+	preview := piPreview(t, imp, path)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var gotErr error
+	for _, err := range imp.Turns(ctx, preview) {
+		gotErr = err
+		break
+	}
+	if gotErr == nil {
+		t.Fatal("Turns yielded no error for a cancelled context")
+	}
+}
+
+func TestPiTurnsReportAnUnreadableSession(t *testing.T) {
+	imp := piImporterAt(t.TempDir())
+	sess := SessionPreview{Agent: AgentPi, SessionID: "gone", SourcePath: filepath.Join(t.TempDir(), "missing.jsonl")}
+	var gotErr error
+	for _, err := range imp.Turns(context.Background(), sess) {
+		gotErr = err
+		break
+	}
+	if gotErr == nil {
+		t.Fatal("Turns yielded no error for a missing session file")
+	}
+}
+
+func TestPiRawContentIsSanitizedOnceByTheFramework(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+	secret := "glc_abcdefghijklmnopqrstuvwx"
+	body := piHeader(t, sessionID, "/work/repo", "2026-06-09T15:37:10.848Z") +
+		piUserEntry(t, "u1", "", "2026-06-09T15:37:20.000Z", "my token is "+secret, 1781019439000) +
+		piAssistantEntry(t, "a1", "u1", "2026-06-09T15:37:24.526Z", 1781019441000,
+			[]map[string]any{piTextBlock("saw " + secret)}, nil)
+	path := writeFile(t, filepath.Join(root, "--work-repo--", "2026-06-09T15-37-10-848Z_"+sessionID+".jsonl"), body)
+
+	imp := piImporterAt(root)
+	turns := collectTurns(t, imp, piPreview(t, imp, path))
+	if len(turns) != 1 {
+		t.Fatalf("got %d turns, want 1", len(turns))
+	}
+	raw := turns[0].Gen.Input[0].Parts[0].Text
+	if !strings.Contains(raw, secret) {
+		t.Fatalf("the importer redacted content itself: %q", raw)
+	}
+
+	turn := turns[0]
+	Sanitizer{}.Sanitize(&turn)
+	cleaned := turn.Gen.Input[0].Parts[0].Text + turn.Gen.Output[0].Parts[0].Text
+	if strings.Contains(cleaned, secret) {
+		t.Fatalf("the framework Sanitizer left the secret in place: %q", cleaned)
+	}
+	if strings.Count(cleaned, "[REDACTED:grafana-cloud-token]") != 2 {
+		t.Fatalf("want exactly one redaction marker per field: %q", cleaned)
+	}
+}
+
+// TestPiToolResultsBelongToTheCallingTurn covers a tool result appended after
+// the next assistant entry began: it answers the earlier call, and must not be
+// attached to the later turn.
+func TestPiToolResultsBelongToTheCallingTurn(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+	body := piHeader(t, sessionID, "/work/repo", "2026-06-09T15:37:10.848Z") +
+		piAssistantEntry(t, "a1", "", "2026-06-09T15:37:24.000Z", 1781019441000,
+			[]map[string]any{piToolCallBlock("toolu_1", "read", map[string]any{"path": "a.go"})},
+			map[string]any{"stopReason": "toolUse"}) +
+		piToolResultEntry(t, "r1", "a1", "2026-06-09T15:37:25.000Z", "toolu_1", "read", "package a", false) +
+		piAssistantEntry(t, "a2", "r1", "2026-06-09T15:37:30.000Z", 1781019448000,
+			[]map[string]any{piToolCallBlock("toolu_2", "read", map[string]any{"path": "b.go"})},
+			map[string]any{"stopReason": "toolUse"}) +
+		piToolResultEntry(t, "r2", "a2", "2026-06-09T15:37:31.000Z", "toolu_2", "read", "package b", false)
+	path := writeFile(t, filepath.Join(root, "--work-repo--", "2026-06-09T15-37-10-848Z_"+sessionID+".jsonl"), body)
+
+	imp := piImporterAt(root)
+	turns := collectTurns(t, imp, piPreview(t, imp, path))
+	if len(turns) != 2 {
+		t.Fatalf("got %d turns, want 2", len(turns))
+	}
+	for i, want := range []string{"package a", "package b"} {
+		results := 0
+		for _, msg := range turns[i].Gen.Output {
+			for _, part := range msg.Parts {
+				if part.ToolResult == nil {
+					continue
+				}
+				results++
+				if part.ToolResult.Content != want {
+					t.Fatalf("turn %d tool result = %q, want %q", i, part.ToolResult.Content, want)
+				}
+			}
+		}
+		if results != 1 {
+			t.Fatalf("turn %d carries %d tool results, want exactly its own", i, results)
+		}
+	}
+}
+
+// TestPiToolResultTextDropsEmptyBlocks pins the flattening against
+// toolResultText (plugins/pi/src/mappers.ts), which drops a text block with no
+// text. Keeping one would join to a leading newline where live joins to a plain
+// line, and no fixture case has a multi-block tool result to catch it.
+func TestPiToolResultTextDropsEmptyBlocks(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []map[string]any
+		want    string
+	}{
+		{"one block", []map[string]any{piTextBlock("data")}, "data"},
+		{"empty first block", []map[string]any{piTextBlock(""), piTextBlock("data")}, "data"},
+		{"two blocks join", []map[string]any{piTextBlock("one"), piTextBlock("two")}, "one\ntwo"},
+		{"image block dropped", []map[string]any{{"type": "image", "data": "…"}, piTextBlock("data")}, "data"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+			result := piLine(t, map[string]any{
+				"type": "message", "id": "r1", "parentId": "a1", "timestamp": "2026-06-09T15:37:25.000Z",
+				"message": map[string]any{
+					"role": "toolResult", "toolCallId": "toolu_1", "toolName": "read",
+					"content": tt.content, "isError": false, "timestamp": 1781019440000,
+				},
+			})
+			body := piHeader(t, sessionID, "/work/repo", "2026-06-09T15:37:10.848Z") +
+				piAssistantEntry(t, "a1", "", "2026-06-09T15:37:24.000Z", 1781019441000,
+					[]map[string]any{piToolCallBlock("toolu_1", "read", map[string]any{"path": "a.go"})},
+					map[string]any{"stopReason": "toolUse"}) + result
+			path := writeFile(t, filepath.Join(root, "--work-repo--", "2026-06-09T15-37-10-848Z_"+sessionID+".jsonl"), body)
+
+			imp := piImporterAt(root)
+			turns := collectTurns(t, imp, piPreview(t, imp, path))
+			if len(turns) != 1 {
+				t.Fatalf("got %d turns, want 1", len(turns))
+			}
+			got := piOnlyToolResult(t, turns[0])
+			if got != tt.want {
+				t.Fatalf("tool result content = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// piOnlyToolResult returns the content of the turn's single tool result.
+func piOnlyToolResult(t *testing.T, turn HistoricalGeneration) string {
+	t.Helper()
+	var found []string
+	for _, msg := range turn.Gen.Output {
+		for _, part := range msg.Parts {
+			if part.ToolResult != nil {
+				found = append(found, part.ToolResult.Content)
+			}
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("turn carries %d tool results, want 1", len(found))
+	}
+	return found[0]
+}
+
+// TestPiToolResultsSurviveAnEntryWithNoID covers an assistant entry whose id is
+// missing or shared. The results are collected from the entry's position in the
+// file, so a log that breaks its own ID rule loses no tool output silently.
+func TestPiToolResultsSurviveAnEntryWithNoID(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+	body := piHeader(t, sessionID, "/work/repo", "2026-06-09T15:37:10.848Z") +
+		piAssistantEntry(t, "", "", "2026-06-09T15:37:24.000Z", 1781019441000,
+			[]map[string]any{piToolCallBlock("toolu_1", "read", map[string]any{"path": "a.go"})},
+			map[string]any{"stopReason": "toolUse"}) +
+		piToolResultEntry(t, "r1", "", "2026-06-09T15:37:25.000Z", "toolu_1", "read", "package a", false)
+	path := writeFile(t, filepath.Join(root, "--work-repo--", "2026-06-09T15-37-10-848Z_"+sessionID+".jsonl"), body)
+
+	imp := piImporterAt(root)
+	turns := collectTurns(t, imp, piPreview(t, imp, path))
+	if len(turns) != 1 {
+		t.Fatalf("got %d turns, want 1", len(turns))
+	}
+	if got := piOnlyToolResult(t, turns[0]); got != "package a" {
+		t.Fatalf("tool result content = %q, want %q", got, "package a")
+	}
+}
+
+// TestPiOneBadContentBlockKeepsTheRest covers schema drift inside one block: a
+// tool call whose id is a number. Go's decoder fills every element it can and
+// reports the type error at the end, so the turn keeps the blocks that decoded
+// instead of exporting a turn that says the model produced nothing.
+func TestPiOneBadContentBlockKeepsTheRest(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+	body := piHeader(t, sessionID, "/work/repo", "2026-06-09T15:37:10.848Z") +
+		piAssistantEntry(t, "a1", "", "2026-06-09T15:37:24.000Z", 1781019441000,
+			[]map[string]any{
+				piTextBlock("one"),
+				{"type": "toolCall", "id": 7, "name": "bash", "arguments": map[string]any{}},
+				piTextBlock("three"),
+			}, nil)
+	path := writeFile(t, filepath.Join(root, "--work-repo--", "2026-06-09T15-37-10-848Z_"+sessionID+".jsonl"), body)
+
+	imp := piImporterAt(root)
+	turns := collectTurns(t, imp, piPreview(t, imp, path))
+	if len(turns) != 1 {
+		t.Fatalf("got %d turns, want 1", len(turns))
+	}
+	var texts []string
+	for _, msg := range turns[0].Gen.Output {
+		for _, part := range msg.Parts {
+			if part.Kind == agento11y.PartKindText {
+				texts = append(texts, part.Text)
+			}
+		}
+	}
+	if !slices.Equal(texts, []string{"one", "three"}) {
+		t.Fatalf("output text = %v, want both readable blocks", texts)
+	}
+}
+
+// TestPiForkTrunkPointerIgnoresPathNoise covers the one way a fork's trunk
+// pointer can name a generation nothing ingested: the trunk generation ID hashes
+// the path, and the path comes from the header rather than from discovery. A
+// header that spells the same file with a detour must still produce the ID the
+// trunk's own import produced.
+func TestPiForkTrunkPointerIgnoresPathNoise(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "--work-repo--")
+	trunkID := "019ead07-cfbf-78d3-8b03-875769426583"
+	forkID := "019eae5b-8461-71ba-bb5b-0f947f105da6"
+
+	trunkPath := writeFile(t, filepath.Join(dir, "2026-06-09T15-37-10-848Z_"+trunkID+".jsonl"),
+		piHeader(t, trunkID, "/work/repo", "2026-06-09T15:37:10.848Z")+
+			piAssistantEntry(t, "a1", "", "2026-06-09T15:37:24.000Z", 1781019441000,
+				[]map[string]any{piTextBlock("one")}, nil))
+	// Built by concatenation, because filepath.Join would clean the detour away.
+	sep := string(filepath.Separator)
+	noisy := dir + sep + ".." + sep + filepath.Base(dir) + sep + filepath.Base(trunkPath)
+
+	forkBody := piLine(t, map[string]any{
+		"type": "session", "version": 3, "id": forkID,
+		"timestamp": "2026-06-09T15:40:00.000Z", "cwd": "/work/repo", "parentSession": noisy,
+	}) +
+		piAssistantEntry(t, "a1", "", "2026-06-09T15:37:24.000Z", 1781019441000,
+			[]map[string]any{piTextBlock("one")}, nil) +
+		piUserEntry(t, "u2", "a1", "2026-06-09T15:41:00.000Z", "try again", 1781019700000) +
+		piAssistantEntry(t, "a2", "u2", "2026-06-09T15:41:06.000Z", 1781019702000,
+			[]map[string]any{piTextBlock("differently")}, nil)
+	forkPath := writeFile(t, filepath.Join(dir, "2026-06-09T15-40-00-000Z_"+forkID+".jsonl"), forkBody)
+
+	imp := piImporterAt(root)
+	trunkTurns := collectTurns(t, imp, piPreview(t, imp, trunkPath))
+	if len(trunkTurns) != 1 {
+		t.Fatalf("got %d trunk turns, want 1", len(trunkTurns))
+	}
+	forkTurns := collectTurns(t, imp, piPreview(t, imp, forkPath))
+	if len(forkTurns) != 1 {
+		t.Fatalf("got %d fork turns, want only the fork's own turn", len(forkTurns))
+	}
+	if got := forkTurns[0].Gen.Metadata[MetaPiForkParentGeneration]; got != trunkTurns[0].Gen.ID {
+		t.Fatalf("%s = %v, want the ID the trunk's own import produced (%q)",
+			MetaPiForkParentGeneration, got, trunkTurns[0].Gen.ID)
+	}
+}
+
+// TestPiSubagentRunsAreNotSessions pins the discovery exclusions against the
+// real tree shape: only the top-level session file is a session.
+func TestPiSubagentRunsAreNotSessions(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+	sessionPath := writePiSession(t, root, "--work-repo--", sessionID)
+	runBody := piHeader(t, "child-1", "/work/repo", "2026-06-09T15:37:40.000Z") +
+		piAssistantEntry(t, "c1", "", "2026-06-09T15:37:44.000Z", 1781019460000,
+			[]map[string]any{piTextBlock("child reply")}, nil)
+	writeFile(t, filepath.Join(root, "--work-repo--", "2026-06-09T15-37-10-848Z_"+sessionID, "43cec431", "run-0", "session.jsonl"), runBody)
+	writeFile(t, filepath.Join(root, "--work-repo--", "subagent-artifacts", "3baf6dad_reviewer_0_output.jsonl"), runBody)
+
+	imp := piImporterAt(root)
+	files, err := walkFiles(context.Background(), root, imp.Match)
+	if err != nil {
+		t.Fatalf("walkFiles: %v", err)
+	}
+	if !slices.Equal(files, []string{sessionPath}) {
+		t.Fatalf("discovered %v, want only the top-level session %q", files, sessionPath)
+	}
+}
+
+func readFileString(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	return string(data), err
+}

--- a/plugins/agento11y/internal/local/query.go
+++ b/plugins/agento11y/internal/local/query.go
@@ -651,6 +651,16 @@ func disjointTokenUsage(u agento11y.TokenUsage, provider string) TokenBuckets {
 // usage comes from the Responses API). Unknown providers default to
 // "separate" so we never subtract tokens we can't account for and end up
 // hiding real input.
+//
+// pi names its own providers ("openai-codex", "google-antigravity",
+// "kimi-coding", "grafana", …) and normalizes their usage in its client
+// before either the plugin or the importer sees it: cache_read is always
+// disjoint from input, and pi's own total is input + output + cache_read +
+// cache_write. Measured over 66,119 assistant turns on the development
+// machine, that total holds for every turn and cache_read exceeds input on
+// 63,701 of them, which subset semantics cannot produce. So none of pi's
+// provider strings belong here, however much they look like the OpenAI or
+// Gemini names beside them.
 func cacheReadInsideInput(provider string) bool {
 	switch strings.ToLower(strings.TrimSpace(provider)) {
 	case "openai", "azure", "azure-openai", "azureopenai", "codex",
@@ -667,7 +677,8 @@ func cacheReadInsideInput(provider string) bool {
 // separate additive count and Anthropic doesn't populate reasoning, so
 // both keep it standalone. Unknown providers default to "separate" so we
 // never subtract reasoning we can't account for and end up hiding real
-// output.
+// output. pi's provider strings are absent for the reason given on
+// cacheReadInsideInput.
 func reasoningInsideOutput(provider string) bool {
 	switch strings.ToLower(strings.TrimSpace(provider)) {
 	case "openai", "azure", "azure-openai", "azureopenai", "codex":

--- a/plugins/agento11y/internal/local/query_test.go
+++ b/plugins/agento11y/internal/local/query_test.go
@@ -845,6 +845,40 @@ func TestDisjointTokenUsage(t *testing.T) {
 			freshInput: 70, cacheRead: 30, cacheWrite: 0, output: 40, reasoning: 10,
 		},
 		{
+			// pi calls its Codex backend "openai-codex", but pi normalizes
+			// usage in its own client: cache_read is disjoint from input, so
+			// subtracting it would hide fresh input the model was charged for.
+			// The shape below is the ordinary one in pi data: cache_read far
+			// above input, which subset semantics cannot produce.
+			name:       "pi openai-codex keeps cache_read additive",
+			provider:   "openai-codex",
+			usage:      agento11y.TokenUsage{InputTokens: 100, OutputTokens: 50, CacheReadInputTokens: 30_000, ReasoningTokens: 10},
+			freshInput: 100, cacheRead: 30_000, cacheWrite: 0, output: 50, reasoning: 10,
+		},
+		{
+			// The same holds when cache_read happens to sit below input, which
+			// is where a subset rule would look plausible and still be wrong.
+			name:       "pi openai-codex keeps cache_read additive below input",
+			provider:   "openai-codex",
+			usage:      agento11y.TokenUsage{InputTokens: 100, OutputTokens: 50, CacheReadInputTokens: 30, ReasoningTokens: 10},
+			freshInput: 100, cacheRead: 30, cacheWrite: 0, output: 50, reasoning: 10,
+		},
+		{
+			// pi's Gemini CLI backend reports the same disjoint counts.
+			name:       "pi google-antigravity keeps cache_read additive",
+			provider:   "google-antigravity",
+			usage:      agento11y.TokenUsage{InputTokens: 80, OutputTokens: 40, CacheReadInputTokens: 20_000, ReasoningTokens: 10},
+			freshInput: 80, cacheRead: 20_000, cacheWrite: 0, output: 40, reasoning: 10,
+		},
+		{
+			// pi routes some models through a "grafana" provider that speaks the
+			// Anthropic messages API, where both buckets are additive.
+			name:       "pi grafana keeps anthropic additive semantics",
+			provider:   "grafana",
+			usage:      agento11y.TokenUsage{InputTokens: 2, OutputTokens: 311, CacheReadInputTokens: 0, CacheWriteInputTokens: 46226},
+			freshInput: 2, cacheRead: 0, cacheWrite: 46226, output: 311, reasoning: 0,
+		},
+		{
 			// Unknown provider keeps reasoning additive (never hide output).
 			name:       "unknown provider keeps reasoning additive",
 			provider:   "openrouter",

--- a/plugins/agento11y/internal/local/web_test.go
+++ b/plugins/agento11y/internal/local/web_test.go
@@ -85,27 +85,221 @@ func TestViewerDefaultRangeMatchesImportWindow(t *testing.T) {
 // TestViewerHasNoHardcodedHistoryAgents guards the registry contract: adding an
 // importer must not need a frontend edit. The viewer reads the agent list from
 // the registry endpoint and renders whatever it returns, so no agent id or
-// display name may be written into the import UI.
+// display name may be written into the import UI, whether as rendered text, a
+// string literal, an object key, or a comparison.
+//
+// The whole region is searched, minus style objects, and a name has to stand on
+// its own to count (see namesAgentAt). Matching the region as a plain substring
+// made any short agent id a false positive: "pi" sits inside
+// "/api/v1/history/agents" and "picking", and "cursor" inside `cursor:
+// "pointer"`. The word boundary kills the first kind; dropping style objects
+// kills the second.
 func TestViewerHasNoHardcodedHistoryAgents(t *testing.T) {
 	src := string(appJSX)
 	require.Contains(t, src, "/api/v1/history/agents", "the viewer must read the agent list from the registry endpoint")
 
-	// The import UI runs from useHistoryImport to the end of the Settings
-	// history tab. Agent names elsewhere in the file are explanatory prose
-	// about how one agent records its transcripts, not a list to keep in sync.
+	searchable := searchableImportUI(t, src)
+	require.NotEmpty(t, history.Specs(), "no importers registered; this test proves nothing")
+	for _, spec := range history.Specs() {
+		for _, name := range []string{string(spec.ID), spec.DisplayName} {
+			at := namesAgentAt(searchable, name)
+			assert.Negative(t, at,
+				"the import UI names the %q agent in %q; the agent list comes from GET /api/v1/history/agents",
+				name, snippetAround(searchable, at))
+		}
+	}
+}
+
+// TestViewerHardcodedAgentGuardCatchesHardcoding pins the guard itself. A guard
+// that stopped catching what it guards is worse than the false positives it was
+// narrowed to avoid, and the narrowing (a word boundary, and dropping style
+// objects) is what could quietly cost coverage. Each case below is planted into
+// the real import UI region, in a form a frontend edit would actually take.
+func TestViewerHardcodedAgentGuardCatchesHardcoding(t *testing.T) {
+	caught := []struct {
+		name    string
+		planted string
+	}{
+		{"select option", `<option value="codex">Codex</option>`},
+		{"segmented control entry", `{ value: "codex", label: "Codex" }`},
+		{"jsx text with punctuation", `<div>Import (Codex only)</div>`},
+		{"jsx text beside an interpolation", `<span>codex sessions {run.count}</span>`},
+		{"identifier object key", `const icons = { codex: IconCodex };`},
+		{"quoted object key", `const icons = { "codex": IconCodex };`},
+		{"comparison", `if (offer.agent === "codex") return null;`},
+		{"style object value", `<div style={{ backgroundImage: "url(/codex.svg)" }}/>`},
+	}
+	for _, tt := range caught {
+		t.Run(tt.name, func(t *testing.T) {
+			searchable := searchableImportUI(t, plantInImportUI(t, string(appJSX), tt.planted))
+			assert.GreaterOrEqual(t, namesAgentAt(searchable, "codex"), 0,
+				"the guard missed hardcoding written as %s", tt.planted)
+		})
+	}
+
+	// The one construct deliberately out of scope, and the reason style objects
+	// are dropped: a CSS property name is not an agent name, and "cursor" is
+	// both a CSS property and an agent this repo ships a plugin for.
+	searchable := searchableImportUI(t, string(appJSX))
+	assert.Negative(t, namesAgentAt(searchable, "cursor"),
+		`cursor: "pointer" in a style object must not read as a hardcoded agent`)
+	planted := searchableImportUI(t, plantInImportUI(t, string(appJSX), `<div>Import from Cursor</div>`))
+	assert.GreaterOrEqual(t, namesAgentAt(planted, "cursor"), 0,
+		"dropping style objects must not hide an agent named in rendered text")
+}
+
+// searchableImportUI returns the part of the viewer this guard reads: the import
+// UI region with style objects removed.
+//
+// The region runs from useHistoryImport to the end of the Settings history tab.
+// Agent names elsewhere in the file are explanatory prose about how one agent
+// records its transcripts, not a list to keep in sync, so prose that has to name
+// an agent belongs outside these bounds.
+func searchableImportUI(t *testing.T, src string) string {
+	t.Helper()
 	start := strings.Index(src, "function useHistoryImport(")
 	require.Positive(t, start, "useHistoryImport not found in web/app.jsx")
 	end := strings.Index(src, "function SettingsTabPanels(")
 	require.Greater(t, end, start, "SettingsTabPanels not found after useHistoryImport")
-	importUI := src[start:end]
 
-	require.NotEmpty(t, history.Specs(), "no importers registered; this test proves nothing")
-	for _, spec := range history.Specs() {
-		assert.NotContains(t, importUI, string(spec.ID),
-			"the import UI names the %q agent; the list comes from GET /api/v1/history/agents", spec.ID)
-		assert.NotContains(t, importUI, spec.DisplayName,
-			"the import UI names %q; display names come from GET /api/v1/history/agents", spec.DisplayName)
+	searchable := withoutStylePropertyNames(src[start:end])
+	// Sentences the tab renders. They pin the strip: a style object whose braces
+	// do not balance would swallow the rest of the region, and a swallowed region
+	// makes every assertion below pass while checking nothing.
+	for _, sentinel := range []string{"Import past sessions", "Cancel import", "Scanning…"} {
+		require.Contains(t, searchable, sentinel,
+			"the import UI renders %q but it is not in the searched text", sentinel)
 	}
+	return searchable
+}
+
+// plantInImportUI returns src with snippet inserted into the import UI region,
+// just before the Settings history tab, so a guard case runs against the real
+// file rather than a hand-written stand-in.
+func plantInImportUI(t *testing.T, src, snippet string) string {
+	t.Helper()
+	at := strings.Index(src, "function SettingsHistoryTab(")
+	require.Positive(t, at, "SettingsHistoryTab not found in web/app.jsx")
+	return src[:at] + snippet + "\n" + src[at:]
+}
+
+// namesAgentAt returns the offset in text where the agent is named, or -1 when
+// it is not. The name has to stand on its own: bounded by something other than a
+// letter or a digit on both sides, so "pi" matches in `value: "pi"` and in
+// "Import from Pi" but not in "picking" or "/api/v1/history/agents". The
+// comparison ignores case, so a hardcoded "Pi" label is caught by an agent
+// registered as "pi".
+func namesAgentAt(text, name string) int {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return -1
+	}
+	hay, needle := strings.ToLower(text), strings.ToLower(name)
+	for off := 0; off < len(hay); {
+		i := strings.Index(hay[off:], needle)
+		if i < 0 {
+			return -1
+		}
+		i += off
+		if !alnumAt(hay, i-1) && !alnumAt(hay, i+len(needle)) {
+			return i
+		}
+		off = i + 1
+	}
+	return -1
+}
+
+func alnumAt(s string, i int) bool {
+	if i < 0 || i >= len(s) {
+		return false
+	}
+	c := s[i]
+	return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9'
+}
+
+// snippetAround returns the line at off with its neighbours trimmed, so a
+// failure names the offending code instead of dumping 37 KB of JSX.
+func snippetAround(text string, off int) string {
+	if off < 0 || off >= len(text) {
+		return ""
+	}
+	start := strings.LastIndexByte(text[:off], '\n') + 1
+	end := strings.IndexByte(text[off:], '\n')
+	if end < 0 {
+		end = len(text)
+	} else {
+		end += off
+	}
+	return strings.TrimSpace(text[start:end])
+}
+
+// withoutStylePropertyNames returns src with the property names inside every
+// style={{ … }} attribute blanked out. It is the one exception the guard makes,
+// and it exists for one word: the import UI writes cursor: "pointer" twelve
+// times, "cursor" is a plausible agent id (this repo ships plugins/cursor), and
+// a CSS property name puts no agent name in front of a user.
+//
+// Only the names go. Values stay, so an agent named in a URL or a class name
+// inside a style object is still caught, and so is everything outside the
+// attribute: a style attribute ends at }} before the element's children.
+//
+// The viewer is served as text/babel and no JS toolchain covers it, so this
+// counts braces rather than parsing. A style object holding an unbalanced brace
+// inside a string would swallow the rest of the region, which is what the
+// sentinels in searchableImportUI catch.
+func withoutStylePropertyNames(src string) string {
+	const open = "style={{"
+	var out strings.Builder
+	for {
+		i := strings.Index(src, open)
+		if i < 0 {
+			out.WriteString(src)
+			return out.String()
+		}
+		styleStart := i + len(open)
+		out.WriteString(src[:styleStart])
+		depth, j := 2, styleStart
+		for ; j < len(src) && depth > 0; j++ {
+			switch src[j] {
+			case '{':
+				depth++
+			case '}':
+				depth--
+			}
+		}
+		out.WriteString(blankPropertyNames(src[styleStart:j]))
+		src = src[j:]
+	}
+}
+
+// blankPropertyNames replaces every word followed by a colon with spaces,
+// keeping the rest of the text at the same offsets.
+func blankPropertyNames(span string) string {
+	b := []byte(span)
+	for i := 0; i < len(b); {
+		if !identByte(b[i]) {
+			i++
+			continue
+		}
+		word := i
+		for i < len(b) && identByte(b[i]) {
+			i++
+		}
+		after := i
+		for after < len(b) && (b[after] == ' ' || b[after] == '\t' || b[after] == '\n' || b[after] == '\r') {
+			after++
+		}
+		if after < len(b) && b[after] == ':' {
+			for x := word; x < i; x++ {
+				b[x] = ' '
+			}
+		}
+	}
+	return string(b)
+}
+
+func identByte(c byte) bool {
+	return alnumAt(string(c), 0) || c == '_' || c == '$' || c == '-'
 }
 
 // TestViewerServesItsOwnAssets pins the offline and privacy contract: the

--- a/plugins/pi/src/piSessionConformance.test.ts
+++ b/plugins/pi/src/piSessionConformance.test.ts
@@ -1,0 +1,651 @@
+// pi session conformance: the TypeScript half.
+//
+// The Go history importer (plugins/agento11y/internal/history/pi.go) hand-ports
+// the export path of this plugin's mappers, because the importer is Go and live
+// capture is TypeScript. conformance/pi-sessions/ is the only thing keeping the
+// two in step: the same session inputs run through the importer in
+// plugins/agento11y/internal/history/pi_conformance_test.go and through this
+// plugin here, and both normalize to the shape in generations.json.
+//
+// conformance/pi-sessions/README.md documents the encodings, the ${PLACEHOLDER}
+// rule, and every field that cannot agree, with the reason.
+
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import registerExtension from "./index.js";
+import { restoreEnv, snapshotAndClearTestEnv } from "./testEnv.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "conformance",
+  "pi-sessions",
+);
+
+interface FixtureCase {
+  id: string;
+  description: string;
+  session_file: string;
+  files: Record<string, Record<string, unknown>[]>;
+}
+
+interface NormalizedPart {
+  kind: string;
+  text?: string;
+  thinking?: string;
+  tool_call?: { id: string; name: string; arguments: unknown };
+  tool_result?: {
+    tool_call_id: string;
+    name: string;
+    content: string;
+    is_error: boolean;
+  };
+}
+
+interface NormalizedMessage {
+  role: string;
+  parts: NormalizedPart[];
+}
+
+interface NormalizedGeneration {
+  id: string;
+  conversation_id: string;
+  conversation_title: string;
+  model: { provider: string; name: string };
+  response_id: string;
+  response_model: string;
+  mode: string;
+  operation_name: string;
+  stop_reason: string;
+  thinking_enabled: boolean;
+  usage: Record<string, number>;
+  started_at: string;
+  completed_at: string;
+  input: NormalizedMessage[];
+  output: NormalizedMessage[];
+  tools: { name: string }[];
+  cost_usd: number | null;
+  call_error: string;
+  parent_generation_ids: string[];
+  fork: { parent_session_id: string; parent_generation_id: string } | null;
+}
+
+function loadFixture<T>(name: string): T {
+  return JSON.parse(readFileSync(join(FIXTURE_DIR, name), "utf-8")) as T;
+}
+
+function fixtureCases(): FixtureCase[] {
+  const { cases } = loadFixture<{ cases: FixtureCase[] }>("sessions.json");
+  expect(cases.length, "sessions.json holds no cases").toBeGreaterThan(0);
+  return cases;
+}
+
+function expectedGenerations(): Record<string, unknown[]> {
+  const { cases } = loadFixture<{ cases: Record<string, unknown[]> }>(
+    "generations.json",
+  );
+  expect(
+    Object.keys(cases).length,
+    "generations.json holds no cases",
+  ).toBeGreaterThan(0);
+  return cases;
+}
+
+// materializeCase writes a case's session files into dir, one JSON entry per
+// line, and returns the path of the file under test plus its parsed entries.
+// ${DIR} is replaced with dir, which is how a fork's header names its trunk
+// without the fixture carrying a machine-specific path.
+function materializeCase(
+  dir: string,
+  fixture: FixtureCase,
+): { sessionPath: string; entries: Record<string, any>[] } {
+  let entries: Record<string, any>[] = [];
+  for (const [name, lines] of Object.entries(fixture.files)) {
+    const body = lines
+      .map((entry) => JSON.stringify(entry).replaceAll("${DIR}", dir))
+      .join("\n");
+    const path = join(dir, name);
+    writeFileSync(path, `${body}\n`);
+    if (name === fixture.session_file) {
+      entries = body.split("\n").map((line) => JSON.parse(line));
+    }
+  }
+  expect(
+    entries.length,
+    `no entries for ${fixture.session_file}`,
+  ).toBeGreaterThan(0);
+  return { sessionPath: join(dir, fixture.session_file), entries };
+}
+
+// copiedEntryIds returns the entries a fork inherited from its trunk. Pi copies
+// the trunk's entries with their own timestamps and stamps the fork's header at
+// fork time, so an entry at or before the header instant came from the trunk.
+// Live never fires turn_end for one, and the importer never exports one, so the
+// replay must not send them either.
+function copiedEntryIds(entries: Record<string, any>[]): Set<string> {
+  const header = entries[0];
+  const out = new Set<string>();
+  if (!header?.parentSession) return out;
+  const forkedAt = Date.parse(String(header.timestamp));
+  if (Number.isNaN(forkedAt)) return out;
+  for (const entry of entries.slice(1)) {
+    const at = Date.parse(String(entry.timestamp));
+    if (!Number.isNaN(at) && at <= forkedAt && typeof entry.id === "string") {
+      out.add(entry.id);
+    }
+  }
+  return out;
+}
+
+class FakePi {
+  handlers = new Map<string, (event: any, ctx: any) => Promise<void> | void>();
+
+  on(
+    event: string,
+    handler: (event: any, ctx: any) => Promise<void> | void,
+  ): void {
+    this.handlers.set(event, handler);
+  }
+
+  async emit(event: string, payload: any, ctx: any): Promise<void> {
+    const handler = this.handlers.get(event);
+    if (!handler) return;
+    await handler(payload, ctx);
+  }
+}
+
+interface CapturedExport {
+  generations: any[];
+}
+
+function startExportCaptureServer(): Promise<{
+  server: Server;
+  baseUrl: string;
+  captures: CapturedExport[];
+  errors: string[];
+}> {
+  const captures: CapturedExport[] = [];
+  const errors: string[] = [];
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        let parsed: any;
+        try {
+          parsed = JSON.parse(body);
+        } catch (err) {
+          errors.push(`invalid export JSON: ${String(err)}`);
+          res.statusCode = 400;
+          res.end(JSON.stringify({ error: "invalid export JSON" }));
+          return;
+        }
+        captures.push({
+          generations: Array.isArray(parsed.generations)
+            ? parsed.generations
+            : [],
+        });
+        const results = (parsed.generations ?? []).map((g: any) => ({
+          generation_id: g?.id ?? "",
+          accepted: true,
+        }));
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ results }));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        throw new Error("expected AddressInfo from server.address()");
+      }
+      resolve({
+        server,
+        baseUrl: `http://127.0.0.1:${addr.port}`,
+        captures,
+        errors,
+      });
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+const NUMERIC_USAGE_KEYS = [
+  "input_tokens",
+  "output_tokens",
+  "total_tokens",
+  "cache_read_input_tokens",
+  "cache_write_input_tokens",
+  "reasoning_tokens",
+] as const;
+
+const ROLES: Record<string, string> = {
+  MESSAGE_ROLE_USER: "user",
+  MESSAGE_ROLE_ASSISTANT: "assistant",
+  MESSAGE_ROLE_TOOL: "tool",
+  MESSAGE_ROLE_SYSTEM: "system",
+};
+
+// decodePayload reverses the export encoding of a tool payload: the JS SDK
+// base64-encodes tool_call.input_json, so only the decoded value is comparable
+// with the Go importer's embedded JSON.
+function decodePayload(value: unknown): unknown {
+  if (typeof value !== "string" || value.length === 0) return {};
+  let text = value;
+  try {
+    const decoded = Buffer.from(value, "base64").toString("utf-8");
+    if (Buffer.from(decoded, "utf-8").toString("base64") === value) {
+      text = decoded;
+    }
+  } catch {
+    // Not base64; fall through and parse the string itself.
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function normalizePart(part: any): NormalizedPart {
+  if (part?.tool_call) {
+    return {
+      kind: "tool_call",
+      tool_call: {
+        id: String(part.tool_call.id ?? ""),
+        name: String(part.tool_call.name ?? ""),
+        arguments: decodePayload(part.tool_call.input_json),
+      },
+    };
+  }
+  if (part?.tool_result) {
+    return {
+      kind: "tool_result",
+      tool_result: {
+        tool_call_id: String(part.tool_result.tool_call_id ?? ""),
+        name: String(part.tool_result.name ?? ""),
+        content: String(part.tool_result.content ?? ""),
+        is_error: part.tool_result.is_error === true,
+      },
+    };
+  }
+  if (typeof part?.thinking === "string" && part.thinking.length > 0) {
+    return { kind: "thinking", thinking: part.thinking };
+  }
+  return { kind: "text", text: String(part?.text ?? "") };
+}
+
+function normalizeMessages(messages: any): NormalizedMessage[] {
+  if (!Array.isArray(messages)) return [];
+  return messages.map((msg) => ({
+    role: ROLES[String(msg?.role ?? "")] ?? String(msg?.role ?? ""),
+    parts: Array.isArray(msg?.parts) ? msg.parts.map(normalizePart) : [],
+  }));
+}
+
+// normalizeGeneration projects one exported wire generation into the shared
+// shape. Import-only and live-only fields are dropped rather than compared;
+// the fixture README lists them.
+function normalizeGeneration(gen: any): NormalizedGeneration {
+  const metadata = (gen.metadata ?? {}) as Record<string, unknown>;
+  const usage: Record<string, number> = {};
+  for (const key of NUMERIC_USAGE_KEYS) {
+    usage[key] = Number(gen.usage?.[key] ?? 0);
+  }
+  const forkSession = metadata["pi.fork.parent_session_id"];
+  return {
+    id: String(gen.id ?? ""),
+    conversation_id: String(gen.conversation_id ?? ""),
+    conversation_title: String(
+      gen.conversation_title ?? metadata["agento11y.conversation.title"] ?? "",
+    ),
+    model: {
+      provider: String(gen.model?.provider ?? ""),
+      name: String(gen.model?.name ?? ""),
+    },
+    response_id: String(gen.response_id ?? ""),
+    response_model: String(gen.response_model ?? ""),
+    mode: String(gen.mode ?? "").replace(/^GENERATION_MODE_/, ""),
+    operation_name: String(gen.operation_name ?? ""),
+    stop_reason: String(gen.stop_reason ?? ""),
+    thinking_enabled: gen.thinking_enabled === true,
+    usage,
+    started_at: String(gen.started_at ?? ""),
+    completed_at: String(gen.completed_at ?? ""),
+    input: normalizeMessages(gen.input),
+    output: normalizeMessages(gen.output),
+    tools: Array.isArray(gen.tools)
+      ? gen.tools.map((tool: any) => ({ name: String(tool?.name ?? "") }))
+      : [],
+    cost_usd: typeof metadata.cost_usd === "number" ? metadata.cost_usd : null,
+    call_error: String(gen.call_error ?? ""),
+    parent_generation_ids: Array.isArray(gen.parent_generation_ids)
+      ? gen.parent_generation_ids.map(String)
+      : [],
+    fork:
+      typeof forkSession === "string"
+        ? {
+            parent_session_id: forkSession,
+            parent_generation_id: String(
+              metadata["pi.fork.parent_generation_id"] ?? "",
+            ),
+          }
+        : null,
+  };
+}
+
+function isPlaceholder(want: unknown): boolean {
+  return (
+    typeof want === "string" && want.startsWith("${") && want.endsWith("}")
+  );
+}
+
+// diffJson reports every structural difference between got and want as a dotted
+// JSON path plus the two values, so a failure names the offending field instead
+// of dumping two payloads. It is the TypeScript half of the comparator the Go
+// suite ports; both must treat ${PLACEHOLDER} the same way.
+function diffJson(path: string, got: unknown, want: unknown): string[] {
+  const at = path === "" ? "<root>" : path;
+  const show = (value: unknown) => JSON.stringify(value) ?? String(value);
+
+  if (isPlaceholder(want)) {
+    if (typeof got !== "string" || got.trim().length === 0) {
+      return [
+        `${at}: got ${show(got)}, want a non-empty value for placeholder ${show(want)}`,
+      ];
+    }
+    return [];
+  }
+
+  if (Array.isArray(want)) {
+    if (!Array.isArray(got)) {
+      return [`${at}: got ${show(got)}, want an array`];
+    }
+    if (got.length !== want.length) {
+      return [`${at}: got ${got.length} items, want ${want.length}`];
+    }
+    return want.flatMap((item, i) => diffJson(`${path}[${i}]`, got[i], item));
+  }
+
+  if (want !== null && typeof want === "object") {
+    if (got === null || typeof got !== "object" || Array.isArray(got)) {
+      return [`${at}: got ${show(got)}, want an object`];
+    }
+    const wantObj = want as Record<string, unknown>;
+    const gotObj = got as Record<string, unknown>;
+    const keys = [
+      ...new Set([...Object.keys(wantObj), ...Object.keys(gotObj)]),
+    ].sort();
+    return keys.flatMap((key) => {
+      const child = path === "" ? key : `${path}.${key}`;
+      if (!(key in gotObj)) {
+        return [`${child}: missing, want ${show(wantObj[key])}`];
+      }
+      if (!(key in wantObj)) {
+        return [`${child}: unexpected ${show(gotObj[key])}`];
+      }
+      return diffJson(child, gotObj[key], wantObj[key]);
+    });
+  }
+
+  if (got !== want) {
+    return [`${at}: got ${show(got)}, want ${show(want)}`];
+  }
+  return [];
+}
+
+describe("pi session conformance", () => {
+  let serverEnv: Awaited<ReturnType<typeof startExportCaptureServer>>;
+  let savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(async () => {
+    serverEnv = await startExportCaptureServer();
+    const homeDir = mkdtempSync(join(tmpdir(), "agento11y-pi-conformance-"));
+    savedEnv = snapshotAndClearTestEnv();
+
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    process.env.XDG_CONFIG_HOME = join(homeDir, ".config");
+    process.env.AGENTO11Y_ENDPOINT = serverEnv.baseUrl;
+    process.env.AGENTO11Y_AUTH_TENANT_ID = "tenant";
+    process.env.AGENTO11Y_AUTH_TOKEN = "token";
+    process.env.AGENTO11Y_AGENT_NAME = "pi";
+    process.env.AGENTO11Y_AGENT_VERSION = "test-version";
+    process.env.AGENTO11Y_CONTENT_CAPTURE_MODE = "full";
+    process.env.AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT = "";
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "";
+    process.env.AGENTO11Y_DEBUG = "";
+    process.env.AGENTO11Y_TAGS = "";
+    process.env.AGENTO11Y_PI_REDACTION_ENABLED = "false";
+  });
+
+  afterEach(async () => {
+    await closeServer(serverEnv.server);
+    restoreEnv(savedEnv);
+    savedEnv = {};
+  });
+
+  // replayCase drives the plugin through the case's session log: one turn per
+  // assistant entry the session itself produced, with the user messages that
+  // preceded it, exactly what pi emits live.
+  async function replayCase(
+    fixture: FixtureCase,
+  ): Promise<NormalizedGeneration[]> {
+    const dir = mkdtempSync(join(tmpdir(), "agento11y-pi-session-"));
+    const { sessionPath, entries } = materializeCase(dir, fixture);
+    const header = entries[0] ?? {};
+    const copied = copiedEntryIds(entries);
+    const branch = entries.slice(1);
+    const sessionName = branch
+      .filter((entry) => entry.type === "session_info" && entry.name)
+      .map((entry) => String(entry.name))
+      .pop();
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+    const ctx = {
+      sessionManager: {
+        getSessionFile: () => sessionPath,
+        getSessionId: () => String(header.id ?? ""),
+        getSessionName: () => sessionName,
+        // The whole tree, copied entries included: lineage has to walk into
+        // them to recognise a parent that belongs to the trunk.
+        getBranch: () => branch,
+      },
+    };
+
+    await pi.emit("session_start", {}, ctx);
+
+    let pendingUsers: unknown[] = [];
+    for (const entry of branch) {
+      if (entry.type !== "message" || !entry.message) continue;
+      if (copied.has(String(entry.id))) continue;
+      if (entry.message.role === "user") {
+        pendingUsers.push(entry.message);
+        continue;
+      }
+      if (entry.message.role !== "assistant") continue;
+
+      const toolResults = toolResultsFor(branch, entry) as any[];
+      await pi.emit("turn_start", {}, ctx);
+      for (const user of pendingUsers) {
+        await pi.emit("message_end", { message: user }, ctx);
+      }
+      pendingUsers = [];
+      await pi.emit("message_end", { message: { role: "assistant" } }, ctx);
+      // Pi runs each tool between the assistant message and turn_end. The
+      // plugin reads the tool names off these events when the host exposes no
+      // tool registry, which is also all the session log can tell the importer.
+      for (const result of toolResults) {
+        await pi.emit(
+          "tool_execution_start",
+          { toolCallId: result.toolCallId, toolName: result.toolName },
+          ctx,
+        );
+        await pi.emit(
+          "tool_execution_end",
+          { toolCallId: result.toolCallId, isError: result.isError === true },
+          ctx,
+        );
+      }
+      await pi.emit("turn_end", { message: entry.message, toolResults }, ctx);
+    }
+    await pi.emit("session_shutdown", {}, ctx);
+
+    expect(serverEnv.errors).toEqual([]);
+    const exported = serverEnv.captures
+      .flatMap((capture) => capture.generations)
+      .filter((gen) => gen?.agent_name === "pi");
+    return exported.map(normalizeGeneration);
+  }
+
+  // toolResultsFor collects the tool results answering one assistant entry, in
+  // the order the calls were made, which is the order pi hands them to
+  // `turn_end`.
+  function toolResultsFor(
+    branch: Record<string, any>[],
+    entry: Record<string, any>,
+  ): unknown[] {
+    const callIds = (entry.message.content ?? [])
+      .filter((block: any) => block?.type === "toolCall")
+      .map((block: any) => String(block.id));
+    if (callIds.length === 0) return [];
+
+    const byCallId = new Map<string, unknown>();
+    let seen = false;
+    for (const candidate of branch) {
+      if (candidate === entry) {
+        seen = true;
+        continue;
+      }
+      if (!seen || candidate.type !== "message" || !candidate.message) continue;
+      if (candidate.message.role === "assistant") break;
+      if (candidate.message.role !== "toolResult") continue;
+      const id = String(candidate.message.toolCallId);
+      if (!byCallId.has(id)) byCallId.set(id, candidate.message);
+    }
+    return callIds
+      .map((id: string) => byCallId.get(id))
+      .filter((result: unknown) => result !== undefined);
+  }
+
+  for (const fixture of fixtureCases()) {
+    it(`matches the fixture for ${fixture.id}`, async () => {
+      const want = expectedGenerations()[fixture.id];
+      if (!want) {
+        throw new Error(`generations.json has no case ${fixture.id}`);
+      }
+
+      const got = await replayCase(fixture);
+      expect(
+        got.length,
+        `exported ${got.length} generations, the fixture expects ${want.length}`,
+      ).toBe(want.length);
+      for (let i = 0; i < want.length; i++) {
+        const diffs = diffJson("", JSON.parse(JSON.stringify(got[i])), want[i]);
+        expect(
+          diffs,
+          `generation ${i} does not match conformance/pi-sessions/generations.json`,
+        ).toEqual([]);
+      }
+    });
+  }
+
+  // The comparator itself, not the plugin: each case takes a real exported
+  // generation, applies one divergence the fixture cannot accept, and asserts
+  // the diff names the offending path. Without this a comparator that ignored a
+  // field would keep every conformance case green while checking nothing.
+  describe("the comparator names divergent fields", () => {
+    const caseId = "tool-call-turn";
+
+    it.each([
+      {
+        name: "total tokens recomputed the Go launcher way",
+        mutate: (gen: NormalizedGeneration) => {
+          gen.usage.total_tokens =
+            (gen.usage.input_tokens ?? 0) + (gen.usage.output_tokens ?? 0);
+        },
+        wantPath: "usage.total_tokens",
+      },
+      {
+        name: "stop reason passed through unmapped",
+        mutate: (gen: NormalizedGeneration) => {
+          gen.stop_reason = "toolUse";
+        },
+        wantPath: "stop_reason",
+      },
+      {
+        name: "tool call arguments left base64",
+        mutate: (gen: NormalizedGeneration) => {
+          const part = gen.output[1]?.parts[0];
+          if (!part?.tool_call) throw new Error("no tool call in output[1]");
+          part.tool_call.arguments = Buffer.from(
+            JSON.stringify(part.tool_call.arguments),
+            "utf-8",
+          ).toString("base64");
+        },
+        wantPath: "output[1].parts[0].tool_call.arguments",
+      },
+      {
+        name: "a tool result dropped from the output",
+        mutate: (gen: NormalizedGeneration) => {
+          gen.output = gen.output.slice(0, -1);
+        },
+        wantPath: "output",
+      },
+      {
+        // A placeholder says the value cannot agree, not that it may be
+        // missing: an empty one still has to fail.
+        name: "placeholder field left empty",
+        mutate: (gen: NormalizedGeneration) => {
+          gen.completed_at = "";
+        },
+        wantPath: "completed_at",
+      },
+    ])("$name", async ({ mutate, wantPath }) => {
+      const fixture = fixtureCases().find((c) => c.id === caseId);
+      if (!fixture) {
+        throw new Error(
+          `fixture case ${caseId} is gone; this test needs a turn with usage and tool traffic`,
+        );
+      }
+      const got = await replayCase(fixture);
+      const mutated = JSON.parse(
+        JSON.stringify(got[0]),
+      ) as NormalizedGeneration;
+      mutate(mutated);
+
+      const wantCase = expectedGenerations()[caseId];
+      if (!wantCase?.[0]) {
+        throw new Error(`generations.json has no case ${caseId}`);
+      }
+      const diffs = diffJson(
+        "",
+        JSON.parse(JSON.stringify(mutated)),
+        wantCase[0],
+      );
+      expect(
+        diffs.length,
+        `the comparator accepted a ${wantPath} divergence`,
+      ).toBeGreaterThan(0);
+      expect(
+        diffs.some((diff) => diff.startsWith(wantPath)),
+        `diffs ${JSON.stringify(diffs)} name no path starting with ${wantPath}`,
+      ).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Adds `pi` to `agento11y history import`:

```sh
agento11y history import pi --dry-run   # show the plan, import nothing
agento11y history import pi --local     # into the local store
agento11y history import pi             # into Grafana Cloud
```

It reads pi's session logs under `$PI_CODING_AGENT_DIR/sessions` and produces one generation per assistant turn.

An imported session does not have everything that a captured one has. The log has no system prompt, no time to first token, etc. Compaction calls persist no model or provider, so they cannot be rebuilt as generations.

The claude-code and codex importers check themselves against the agent's plugin in Go code. pi's code is in TypeScript, so `internal/history/pi.go` ports it and Go cannot call the original. `conformance/pi-sessions/` has the shared input and expected generations, `mise run test:pi-sessions-conformance` tests it all.
