### PR TITLE
feat(plugins/agento11y): honour AGENTO11Y_AGENT_NAME in coding agent plugins

### DIFF
--- a/plugins/agento11y/internal/agents/claudecode/hook.go
+++ b/plugins/agento11y/internal/agents/claudecode/hook.go
@@ -32,8 +32,9 @@ import (
 // it as a package var so tests can override it freely.
 var Version = "dev"
 
-// AgentName is the agent identity attached to every generation this agent
-// emits. Stable across versions so dashboards survive renames.
+// AgentName is the default agent identity this adapter reports. Stable across
+// versions so dashboards survive renames. AGENTO11Y_AGENT_NAME overrides it per
+// run; see envconfig.ResolveAgentName.
 const AgentName = "claude-code"
 
 func exportConfig(endpoint, tenantID, authToken string) agento11y.GenerationExportConfig {
@@ -90,6 +91,13 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 
 	st := state.Load(input.SessionID)
 
+	// One name for both branches below: the guard request and the exported
+	// generations have to agree, otherwise a rule scoped to a per-run name
+	// never matches the generations that run produces. The binary runs once per
+	// hook event, so the name is resolved per invocation and a session that
+	// changes the variable mid-run splits across two names.
+	resolvedAgentName := envconfig.ResolveAgentName(AgentName)
+
 	// Route lightweight events that do not need real agento11y credentials first.
 	// SessionStart only updates local state; PreToolUse calls into the shared
 	// guard helper which manages its own credentials, timeouts, and
@@ -106,7 +114,7 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 	case "PreToolUse":
 		guardCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
-		handlePreToolUse(guardCtx, stdout, input, st, logger)
+		handlePreToolUse(guardCtx, stdout, input, st, resolvedAgentName, logger)
 		return nil
 	case "", "Stop", "SessionEnd":
 		// Fall through to transcript export below.
@@ -176,6 +184,7 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 		SessionID: input.SessionID,
 		Logger:    logger,
 		ExtraTags: extraTags,
+		AgentName: resolvedAgentName,
 	}, r)
 
 	if len(gens) == 0 {
@@ -235,9 +244,9 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 // credential, fail-open/closed, and local-endpoint placeholder behaviour
 // lives in the shared guard helper so this stays in lockstep with the codex
 // and copilot agents.
-func handlePreToolUse(ctx context.Context, stdout io.Writer, input *hookInput, st state.Session, logger *log.Logger) {
+func handlePreToolUse(ctx context.Context, stdout io.Writer, input *hookInput, st state.Session, agentName string, logger *log.Logger) {
 	res := guard.EvaluateToolCall(ctx, envconfig.ResolveGuards(logger), guard.ToolCallInput{
-		AgentName:     AgentName,
+		AgentName:     agentName,
 		AgentVersion:  Version,
 		ModelProvider: "anthropic",
 		ModelName:     strings.TrimSpace(st.Model),

--- a/plugins/agento11y/internal/agents/claudecode/hook_test.go
+++ b/plugins/agento11y/internal/agents/claudecode/hook_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/claudecode/state"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/emit"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/useragent"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -266,9 +267,9 @@ func TestHandlePreToolUse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("SIGIL_GUARDS_ENABLED", "")
-			t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "")
-			t.Setenv("SIGIL_GUARDS_TIMEOUT_MS", "")
+			// Blank every branded variable first: an ambient endpoint would send
+			// this guard call to a real backend.
+			envconfig.PinAliasEnvBlank(t)
 			for k, v := range tt.env {
 				t.Setenv(k, v)
 			}
@@ -291,7 +292,7 @@ func TestHandlePreToolUse(t *testing.T) {
 			}
 			st := state.Session{Model: "claude-sonnet-4"}
 
-			handlePreToolUse(context.Background(), &stdout, input, st, log.New(&logs, "", 0))
+			handlePreToolUse(context.Background(), &stdout, input, st, AgentName, log.New(&logs, "", 0))
 
 			if tt.expectServerCall && calls.Load() == 0 {
 				t.Errorf("expected server call, got 0")
@@ -1290,5 +1291,195 @@ func TestHook_LocalEndpointSkipsCloudAuthCheck(t *testing.T) {
 	})
 	if strings.Contains(logs, "not exporting: missing") {
 		t.Fatalf("local endpoint should bypass cloud auth check; got logs:\n%s", logs)
+	}
+}
+
+// TestHook_AgentNameOverride pins the two paths that stamp the agent identity
+// to one value. The guard request and the exported generations are built by
+// separate code (guard.ToolCallInput and the mapper), so a rule scoped to a
+// per-run name only matches that run's generations when both read the same
+// resolved name.
+//
+// It also pins what must not move with the name: the export User-Agent and the
+// OTel instrumentation scope identify the build, not the session.
+func TestHook_AgentNameOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		// guardEnv, when set, replaces env for the PreToolUse invocation, so a
+		// name changed between two invocations of one session can be checked.
+		guardEnv  map[string]string
+		wantGuard string
+		wantAgent string
+		// wantSubagent is the name on the synthesised subagent generation.
+		wantSubagent string
+	}{
+		{
+			name:      "unset keeps the product name",
+			wantAgent: "claude-code", wantSubagent: "claude-code/subagent",
+		},
+		{
+			name:      "preferred spelling",
+			env:       map[string]string{"AGENTO11Y_AGENT_NAME": "claude-code-e2e"},
+			wantAgent: "claude-code-e2e", wantSubagent: "claude-code-e2e/subagent",
+		},
+		{
+			name:      "legacy spelling",
+			env:       map[string]string{"SIGIL_AGENT_NAME": "legacy-name"},
+			wantAgent: "legacy-name", wantSubagent: "legacy-name/subagent",
+		},
+		{
+			name: "preferred wins over legacy",
+			env: map[string]string{
+				"AGENTO11Y_AGENT_NAME": "preferred-name",
+				"SIGIL_AGENT_NAME":     "legacy-name",
+			},
+			wantAgent: "preferred-name", wantSubagent: "preferred-name/subagent",
+		},
+		{
+			// The name is resolved per hook invocation, not pinned into session
+			// state, so a value changed mid-session splits across two names.
+			name:      "name changed between invocations of one session",
+			guardEnv:  map[string]string{"AGENTO11Y_AGENT_NAME": "run-a"},
+			env:       map[string]string{"AGENTO11Y_AGENT_NAME": "run-b"},
+			wantGuard: "run-a",
+			wantAgent: "run-b", wantSubagent: "run-b/subagent",
+		},
+	}
+
+	// The export User-Agent and the OTel scope name the build, not the session,
+	// so both stay fixed under every override. No OTLP endpoint is configured
+	// here, so Hook passes no tracer and the SDK spans carry the SDK's own scope
+	// rather than the plugin's otelInstrumentationName.
+	wantUserAgent := useragent.For(AgentName)
+	const wantScope = "github.com/grafana/sigil-sdk/go/sigil"
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var guardAgents, exportAgents, exportUserAgents []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				switch {
+				case strings.Contains(r.URL.Path, "hooks:evaluate"):
+					var req struct {
+						Context struct {
+							AgentName string `json:"agent_name"`
+						} `json:"context"`
+					}
+					_ = json.Unmarshal(body, &req)
+					guardAgents = append(guardAgents, req.Context.AgentName)
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"action":"allow"}`))
+				default:
+					var req struct {
+						Generations []struct {
+							ID        string `json:"id"`
+							AgentName string `json:"agent_name"`
+						} `json:"generations"`
+					}
+					_ = json.Unmarshal(body, &req)
+					exportUserAgents = append(exportUserAgents, r.Header.Get("User-Agent"))
+					resp := struct {
+						Results []map[string]any `json:"results"`
+					}{Results: make([]map[string]any, 0, len(req.Generations))}
+					for _, g := range req.Generations {
+						exportAgents = append(exportAgents, g.AgentName)
+						resp.Results = append(resp.Results, map[string]any{"generation_id": g.ID, "accepted": true})
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(resp)
+				}
+			}))
+			defer server.Close()
+
+			dir := t.TempDir()
+			sessionID := "agent-name-session"
+			// An Agent tool call plus its result: the synthesised subagent
+			// generation is a second copy of the name literal in the mapper,
+			// so the fixture has to produce one.
+			transcript := strings.Join([]string{
+				buildHookUserJSONL(sessionID, "research this"),
+				buildHookAssistantLineAt(sessionID, "req-1", "tool_use", hookFixtureTimestamp, []any{map[string]any{
+					"type": "tool_use", "id": "agent_1", "name": "Agent",
+					"input": map[string]any{"description": "look around"},
+				}}, 7),
+				buildHookToolResultJSONL(sessionID, "agent_1", "agent result"),
+				buildHookAssistantJSONL(sessionID, "req-2", "end_turn", "done", 5),
+			}, "\n") + "\n"
+			transcriptPath := filepath.Join(dir, "transcript.jsonl")
+			if err := os.WriteFile(transcriptPath, []byte(transcript), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			recorder := installGlobalSpanRecorder(t)
+			t.Setenv("XDG_STATE_HOME", filepath.Join(dir, "state"))
+			envconfig.PinAliasEnvBlank(t)
+			setHookExportEnv(t, server.URL)
+			t.Setenv("SIGIL_GUARDS_ENABLED", "true")
+
+			guardEnv := tt.env
+			if tt.guardEnv != nil {
+				guardEnv = tt.guardEnv
+			}
+			for k, v := range guardEnv {
+				t.Setenv(k, v)
+			}
+			runHookForTest(t, hookInput{
+				HookEventName:  "PreToolUse",
+				SessionID:      sessionID,
+				TranscriptPath: transcriptPath,
+				ToolName:       "Bash",
+				ToolInput:      json.RawMessage(`{"command":"echo hi"}`),
+				ToolUseID:      "tu_1",
+			})
+
+			// Re-applied so a scenario that changes the name between the two
+			// invocations exports under the second value.
+			envconfig.PinAliasEnvBlank(t)
+			setHookExportEnv(t, server.URL)
+			t.Setenv("SIGIL_GUARDS_ENABLED", "true")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			logs := runHookForTest(t, hookInput{
+				HookEventName:  "Stop",
+				SessionID:      sessionID,
+				TranscriptPath: transcriptPath,
+			})
+
+			wantGuard := tt.wantGuard
+			if wantGuard == "" {
+				wantGuard = tt.wantAgent
+			}
+			if len(guardAgents) != 1 || guardAgents[0] != wantGuard {
+				t.Fatalf("guard agent names = %v, want [%q]", guardAgents, wantGuard)
+			}
+			wantExport := []string{tt.wantAgent, tt.wantSubagent, tt.wantAgent}
+			if len(exportAgents) != len(wantExport) {
+				t.Fatalf("exported agent names = %v, want %v (logs:\n%s)", exportAgents, wantExport, logs)
+			}
+			for i, want := range wantExport {
+				if exportAgents[i] != want {
+					t.Fatalf("exported agent name[%d] = %q, want %q (all: %v)", i, exportAgents[i], want, exportAgents)
+				}
+			}
+			if len(exportUserAgents) == 0 {
+				t.Fatal("no export request captured")
+			}
+			spans := spansByName(recorder.Ended(), "generateText")
+			if len(spans) == 0 {
+				t.Fatalf("no generateText spans recorded (logs:\n%s)", logs)
+			}
+			for i, got := range exportUserAgents {
+				if got != wantUserAgent {
+					t.Fatalf("export User-Agent[%d] = %q, want %q", i, got, wantUserAgent)
+				}
+			}
+			for i, s := range spans {
+				if got := s.InstrumentationScope().Name; got != wantScope {
+					t.Fatalf("span[%d] scope = %q, want %q", i, got, wantScope)
+				}
+			}
+		})
 	}
 }

--- a/plugins/agento11y/internal/agents/claudecode/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/claudecode/mapper/mapper.go
@@ -29,11 +29,25 @@ type Options struct {
 	SessionID string            // authoritative session ID from the hook input
 	Logger    *log.Logger       // debug logger (nil = silent)
 	ExtraTags map[string]string // user-supplied tags merged into every generation; built-in keys always win
+	// AgentName overrides the exported agent identity. Blank means
+	// "claude-code". The history importer leaves it blank on purpose: a
+	// backfill cannot reconstruct a past per-run override, and
+	// claudeFinalizeSubagentGens matches generations against the product name.
+	AgentName string
 	// SuppressSyntheticSubagentToolCallIDs skips the summary-only generation
 	// for an Agent tool result whose full subagent transcript is mapped
 	// separately. Live capture leaves it nil, so it keeps recording summaries
 	// when the parent transcript is the only record of the subagent run.
 	SuppressSyntheticSubagentToolCallIDs map[string]bool
+}
+
+// agent is the base agent name for every generation this run produces: the
+// caller's override, or the product name when none was given.
+func (o Options) agent() string {
+	if n := strings.TrimSpace(o.AgentName); n != "" {
+		return n
+	}
+	return agentName
 }
 
 func (o Options) logf(format string, args ...any) {
@@ -404,7 +418,7 @@ func synthesiseSubagentGens(line transcript.Line, uctx *userContext, calls map[s
 				ConversationID:      opts.SessionID,
 				ConversationTitle:   opts.SessionID,
 				ParentGenerationIDs: []string{ac.parentGenID},
-				AgentName:           agentName + "/" + suffix,
+				AgentName:           opts.agent() + "/" + suffix,
 				AgentVersion:        ac.parentGen.AgentVersion,
 				EffectiveVersion:    ac.parentGen.EffectiveVersion,
 				Mode:                agento11y.GenerationModeSync,
@@ -539,7 +553,7 @@ func processAssistantLine(line transcript.Line, uctx *userContext, _ *state.Sess
 		ID:                generationID(line),
 		ConversationID:    opts.SessionID,
 		ConversationTitle: opts.SessionID,
-		AgentName:         lineAgentName(line),
+		AgentName:         lineAgentName(line, opts.agent()),
 		AgentVersion:      line.Version,
 		EffectiveVersion:  line.Version,
 		Mode:              agento11y.GenerationModeSync,
@@ -606,18 +620,19 @@ func buildTags(line transcript.Line, subagent bool, extras map[string]string) ma
 	return tags
 }
 
-// lineAgentName names the agent that produced a turn. A sidechain line ran
-// inside a subagent, so its type is appended ("claude-code/general-purpose")
-// and the turn is attributable to that subagent rather than the main thread.
-func lineAgentName(line transcript.Line) string {
+// lineAgentName names the agent that produced a turn. base is the resolved
+// agent name for the run. A sidechain line ran inside a subagent, so its type
+// is appended ("claude-code/general-purpose") and the turn is attributable to
+// that subagent rather than the main thread.
+func lineAgentName(line transcript.Line, base string) string {
 	if !line.IsSidechain {
-		return agentName
+		return base
 	}
 	suffix := strings.ToLower(strings.TrimSpace(line.AttributionAgent))
 	if suffix == "" {
-		return agentName
+		return base
 	}
-	return agentName + "/" + suffix
+	return base + "/" + suffix
 }
 
 func buildToolDefs(names map[string]bool) []agento11y.ToolDefinition {

--- a/plugins/agento11y/internal/agents/claudecode/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/claudecode/mapper/mapper_test.go
@@ -1501,11 +1501,22 @@ func TestProcess_SidechainAgentName(t *testing.T) {
 		name             string
 		sidechain        bool
 		attributionAgent string
-		want             string
+		// agentName is Options.AgentName: the caller's per-run override, blank
+		// for the default.
+		agentName string
+		want      string
 	}{
 		{name: "main thread", want: "claude-code"},
 		{name: "sidechain with a type", sidechain: true, attributionAgent: "General-Purpose", want: "claude-code/general-purpose"},
 		{name: "sidechain without a type", sidechain: true, want: "claude-code"},
+		{name: "override on the main thread", agentName: "claude-code-e2e", want: "claude-code-e2e"},
+		{
+			name: "override on a sidechain keeps the suffix", sidechain: true,
+			attributionAgent: "General-Purpose", agentName: "claude-code-e2e",
+			want: "claude-code-e2e/general-purpose",
+		},
+		{name: "override is trimmed", agentName: "  spaced  ", want: "spaced"},
+		{name: "blank override keeps the default", agentName: "   ", want: "claude-code"},
 	}
 
 	for _, tt := range tests {
@@ -1516,7 +1527,8 @@ func TestProcess_SidechainAgentName(t *testing.T) {
 			line.IsSidechain = tt.sidechain
 			line.AttributionAgent = tt.attributionAgent
 
-			gens, _ := Process([]transcript.Line{makeUserLine("go"), line}, &state.Session{}, Options{SessionID: "sess-1"}, nil)
+			gens, _ := Process([]transcript.Line{makeUserLine("go"), line}, &state.Session{},
+				Options{SessionID: "sess-1", AgentName: tt.agentName}, nil)
 			if len(gens) != 1 {
 				t.Fatalf("got %d generations, want 1", len(gens))
 			}
@@ -1543,18 +1555,26 @@ func TestProcess_SuppressSyntheticSubagentToolCallIDs(t *testing.T) {
 	tests := []struct {
 		name      string
 		suppress  map[string]bool
+		agentName string
 		wantGens  int
 		wantAgent string
 	}{
 		{name: "live capture keeps the summary", wantGens: 2, wantAgent: "claude-code/explorer"},
 		{name: "import suppresses the summary", suppress: map[string]bool{"tu_agent": true}, wantGens: 1},
 		{name: "an unrelated id suppresses nothing", suppress: map[string]bool{"tu_other": true}, wantGens: 2, wantAgent: "claude-code/explorer"},
+		{
+			// The synthesised subagent generation is a second copy of the name
+			// literal, so it needs its own case.
+			name: "override renames the synthesised subagent", agentName: "claude-code-e2e",
+			wantGens: 2, wantAgent: "claude-code-e2e/explorer",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gens, _ := Process(lines, &state.Session{}, Options{
 				SessionID:                            "sess-1",
+				AgentName:                            tt.agentName,
 				SuppressSyntheticSubagentToolCallIDs: tt.suppress,
 			}, nil)
 			if len(gens) != tt.wantGens {

--- a/plugins/agento11y/internal/agents/codex/config/config.go
+++ b/plugins/agento11y/internal/agents/codex/config/config.go
@@ -2,9 +2,11 @@ package config
 
 import (
 	"log"
+	"strings"
 
 	"github.com/grafana/agento11y/go/agento11y"
 
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/codex/mapper"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/dotenv"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
@@ -15,6 +17,20 @@ type Config struct {
 	ContentCapture agento11y.ContentCaptureMode
 	Debug          bool
 	Guards         envconfig.GuardsConfig
+	// AgentName is the identity every generation and guard request reports.
+	// Load resolves it from AGENTO11Y_AGENT_NAME, then SIGIL_AGENT_NAME, and
+	// falls back to "codex". Read it through Agent.
+	AgentName string
+}
+
+// Agent returns the resolved agent identity, or "codex" when AgentName is
+// blank because the Config was built without Load. The mapper applies the same
+// fallback, so a guard request and the generation it guards cannot disagree.
+func (c Config) Agent() string {
+	if n := strings.TrimSpace(c.AgentName); n != "" {
+		return n
+	}
+	return mapper.AgentName
 }
 
 // HasCredentials reports whether the canonical SIGIL_* credentials are
@@ -52,5 +68,6 @@ func Load(logger *log.Logger) Config {
 		ContentCapture: envconfig.ResolveContentMode(logger),
 		Debug:          envconfig.ParseBool(envconfig.Getenv("DEBUG")),
 		Guards:         envconfig.ResolveGuards(logger),
+		AgentName:      envconfig.ResolveAgentName(mapper.AgentName),
 	}
 }

--- a/plugins/agento11y/internal/agents/codex/config/config_test.go
+++ b/plugins/agento11y/internal/agents/codex/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"log"
 	"testing"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/codex/mapper"
 )
 
 // TestLoad_Guards pins the env-var contract and defaults for codex against
@@ -73,6 +75,28 @@ func TestLoad_Guards(t *testing.T) {
 			}
 			if cfg.Guards.TimeoutMs != tt.wantTimeoutMs {
 				t.Errorf("Guards.TimeoutMs = %d, want %d", cfg.Guards.TimeoutMs, tt.wantTimeoutMs)
+			}
+		})
+	}
+}
+
+// TestConfig_Agent pins the fallback a Config built without Load relies on:
+// the guard request must carry the same name the mapper stamps, never a blank.
+func TestConfig_Agent(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentName string
+		want      string
+	}{
+		{name: "a resolved name is returned unchanged", agentName: "codex-e2e", want: "codex-e2e"},
+		{name: "blank falls back to the product name", agentName: "", want: mapper.AgentName},
+		{name: "whitespace falls back to the product name", agentName: "  ", want: mapper.AgentName},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := (Config{AgentName: tt.agentName}).Agent(); got != tt.want {
+				t.Errorf("Agent() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/agents/codex/hook/handlers.go
+++ b/plugins/agento11y/internal/agents/codex/hook/handlers.go
@@ -86,7 +86,7 @@ func UserPromptSubmit(p Payload, cfg config.Config, logger *log.Logger) {
 // Claude Code and Codex also share both PreToolUse envelope writers.
 func PreToolUse(ctx context.Context, stdout io.Writer, p Payload, cfg config.Config, logger *log.Logger) {
 	res := guard.EvaluateToolCall(ctx, cfg.Guards, guard.ToolCallInput{
-		AgentName:     mapper.AgentName,
+		AgentName:     cfg.Agent(),
 		ToolName:      p.ToolName,
 		ToolCallID:    p.ToolUseID,
 		ToolInputJSON: p.ToolInput,
@@ -223,7 +223,7 @@ func Stop(p Payload, cfg config.Config, logger *log.Logger) {
 	client := buildClient(cfg, providers, logger)
 	defer func() { _ = client.Shutdown(ctx) }()
 
-	mapped := mapper.Map(mapper.Inputs{Fragment: frag, SubagentLink: subagentLink, TokenSnapshot: tokenSnapshot, ContentCapture: cfg.ContentCapture})
+	mapped := mapper.Map(mapper.Inputs{Fragment: frag, SubagentLink: subagentLink, TokenSnapshot: tokenSnapshot, ContentCapture: cfg.ContentCapture, AgentName: cfg.Agent()})
 	logger.Printf("stop: export id=%s conversation=%s agent=%s model=%s", mapped.Generation.ID, mapped.Generation.ConversationID, mapped.Generation.AgentName, mapped.Generation.Model.Name)
 	if err := emitGeneration(ctx, client, frag, mapped, cfg.ContentCapture, logger); err != nil {
 		logger.Printf("stop: emit: %v", err)
@@ -313,6 +313,10 @@ func sweepPendingRetries(ctx context.Context, client *agento11y.Client, cfg conf
 			SubagentLink:   subagentLink,
 			TokenSnapshot:  tokenSnapshot,
 			ContentCapture: cfg.ContentCapture,
+			// The name comes from this invocation, not from the turn the
+			// fragment was written in. A name changed between turns
+			// re-stamps a retried turn with the current one.
+			AgentName: cfg.Agent(),
 		})
 		logger.Printf("stop: retry id=%s session=%s turn=%s", mapped.Generation.ID, f.SessionID, f.TurnID)
 		if err := emitGeneration(ctx, client, f, mapped, cfg.ContentCapture, logger); err != nil {

--- a/plugins/agento11y/internal/agents/codex/hook/handlers_test.go
+++ b/plugins/agento11y/internal/agents/codex/hook/handlers_test.go
@@ -948,6 +948,9 @@ func TestPreToolUseGuard(t *testing.T) {
 }
 
 func TestPreToolUseGuardSendsExpectedRequest(t *testing.T) {
+	// The request below is asserted against the product name, so a developer
+	// shell that exports AGENTO11Y_AGENT_NAME must not reach config.Load.
+	envconfig.PinAliasEnvBlank(t)
 	var capturedPath atomic.Value
 	var capturedBody atomic.Value
 	server := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1106,4 +1109,106 @@ func jsonInt64(t *testing.T, v any) int64 {
 		t.Fatalf("expected numeric JSON value, got %T (%#v)", v, v)
 	}
 	return 0
+}
+
+// TestAgentNameOverrideGuardAndExport pins the guard request and the exported
+// generations to one resolved name, including the retry sweep. A rule scoped to
+// a per-run name only matches that run when the two paths agree.
+func TestAgentNameOverrideGuardAndExport(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{name: "unset keeps the product name", want: mapper.AgentName},
+		{name: "preferred spelling", env: map[string]string{"AGENTO11Y_AGENT_NAME": "codex-e2e"}, want: "codex-e2e"},
+		{name: "legacy spelling", env: map[string]string{"SIGIL_AGENT_NAME": "legacy-name"}, want: "legacy-name"},
+		{
+			name: "preferred wins over legacy",
+			env: map[string]string{
+				"AGENTO11Y_AGENT_NAME": "preferred-name",
+				"SIGIL_AGENT_NAME":     "legacy-name",
+			},
+			want: "preferred-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			envconfig.PinAliasEnvBlank(t)
+			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+			logger := log.New(io.Discard, "", 0)
+
+			var guardAgents, exportAgents []string
+			server := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.Contains(r.URL.Path, "hooks:evaluate") {
+					body, _ := io.ReadAll(r.Body)
+					var req struct {
+						Context struct {
+							AgentName string `json:"agent_name"`
+						} `json:"context"`
+					}
+					_ = json.Unmarshal(body, &req)
+					guardAgents = append(guardAgents, req.Context.AgentName)
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"action":"allow"}`))
+					return
+				}
+				body, _ := io.ReadAll(r.Body)
+				var req struct {
+					Generations []struct {
+						AgentName string `json:"agent_name"`
+					} `json:"generations"`
+				}
+				_ = json.Unmarshal(body, &req)
+				for _, g := range req.Generations {
+					exportAgents = append(exportAgents, g.AgentName)
+				}
+				writeAcceptedGenerationResponse(t, w, body)
+			}))
+			defer server.Close()
+
+			t.Setenv("SIGIL_ENDPOINT", server.URL)
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
+			t.Setenv("SIGIL_GUARDS_ENABLED", "true")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			// A prior turn flagged for retry: the sweep re-maps it with the
+			// name this invocation resolves, not the one its fragment was
+			// written under.
+			require.NoError(t, fragment.Update("sess", "old-turn", logger, func(f *fragment.Fragment) bool {
+				f.Model = "gpt-5.5"
+				f.PendingRetry = true
+				f.CompletedAt = "2026-05-15T09:00:00Z"
+				return true
+			}))
+			require.NoError(t, fragment.Update("sess", "turn", logger, func(f *fragment.Fragment) bool {
+				f.Model = "gpt-5.5"
+				f.Prompt = "hello"
+				return true
+			}))
+
+			cfg := config.Load(logger)
+			var stdout bytes.Buffer
+			PreToolUse(context.Background(), &stdout, Payload{
+				HookEventName: "PreToolUse",
+				SessionID:     "sess",
+				ToolName:      "Bash",
+				ToolUseID:     "tu_1",
+				ToolInput:     json.RawMessage(`{"command":"echo hi"}`),
+				Model:         "gpt-5.5",
+			}, cfg, logger)
+			Stop(Payload{HookEventName: "Stop", SessionID: "sess", TurnID: "turn"}, cfg, logger)
+
+			assert.Equal(t, []string{tt.want}, guardAgents, "guard agent names")
+			assert.Len(t, exportAgents, 2, "one current turn plus one retried turn")
+			for i, got := range exportAgents {
+				assert.Equal(t, tt.want, got, "exported agent name[%d]", i)
+			}
+		})
+	}
 }

--- a/plugins/agento11y/internal/agents/codex/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/codex/mapper/mapper.go
@@ -17,8 +17,16 @@ import (
 )
 
 const (
-	AgentName         = "codex"
-	SubagentAgentName = AgentName + "/subagent"
+	// AgentName is the default agent identity this adapter reports.
+	// AGENTO11Y_AGENT_NAME overrides it per run through Inputs.AgentName.
+	AgentName = "codex"
+	// SubagentAgentName is what a linked subagent turn reports under the
+	// default name. Map builds the live value from the resolved base name and
+	// subagentSuffix, so this is the value tests compare against rather than a
+	// constant the mapper reads.
+	SubagentAgentName = AgentName + subagentSuffix
+	// subagentSuffix marks a turn that ran as a subagent of another session.
+	subagentSuffix = "/subagent"
 )
 
 type Inputs struct {
@@ -26,6 +34,11 @@ type Inputs struct {
 	SubagentLink   *fragment.SubagentLink
 	TokenSnapshot  *codexlog.TokenSnapshot
 	ContentCapture agento11y.ContentCaptureMode
+	// AgentName overrides the exported agent identity. Blank means "codex".
+	// The history importer leaves it blank on purpose: a backfill cannot
+	// reconstruct the environment a past run had, so an imported generation
+	// carries the product name.
+	AgentName string
 	// RawContent leaves prompt, response, and tool payloads unredacted. The
 	// history importer sets it because the import framework runs one Sanitizer
 	// over every turn before export; redacting here as well would apply the
@@ -75,7 +88,7 @@ func Map(in Inputs) Mapped {
 
 	tools := buildToolDefinitions(frag.Tools)
 	input, output := buildMessages(frag, payloadMode, in.RawContent)
-	conversationID, agentName, parentIDs, metadata := linkFields(frag, in.SubagentLink, tags)
+	conversationID, agentName, parentIDs, metadata := linkFields(frag, in.SubagentLink, tags, in.agent())
 	usage, metadata := usageFields(in.TokenSnapshot, metadata)
 
 	start := agento11y.GenerationStart{
@@ -114,14 +127,26 @@ func Map(in Inputs) Mapped {
 	return Mapped{Start: start, Generation: gen}
 }
 
-func linkFields(frag *fragment.Fragment, link *fragment.SubagentLink, tags map[string]string) (conversationID, agentName string, parentIDs []string, metadata map[string]any) {
+// agent is the base agent name for this generation: the caller's override, or
+// the product name when none was given.
+func (in Inputs) agent() string {
+	if n := strings.TrimSpace(in.AgentName); n != "" {
+		return n
+	}
+	return AgentName
+}
+
+// linkFields names the agent and resolves the conversation edges for one turn.
+// base is the resolved agent name for the run; a subagent turn appends
+// subagentSuffix to it.
+func linkFields(frag *fragment.Fragment, link *fragment.SubagentLink, tags map[string]string, base string) (conversationID, agentName string, parentIDs []string, metadata map[string]any) {
 	conversationID = frag.SessionID
-	agentName = AgentName
+	agentName = base
 	if link == nil || link.ParentSessionID == "" {
 		return conversationID, agentName, nil, nil
 	}
 
-	agentName = SubagentAgentName
+	agentName = base + subagentSuffix
 	tags["subagent"] = "true"
 	tags["codex.thread_source"] = "subagent"
 	tags["codex.link_source"] = "partial"

--- a/plugins/agento11y/internal/agents/codex/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/codex/mapper/mapper_test.go
@@ -445,3 +445,65 @@ func TestMapWithoutTokenSnapshotPreservesExistingBehavior(t *testing.T) {
 		t.Fatalf("Metadata = %+v, want nil", got.Generation.Metadata)
 	}
 }
+
+// TestMapAgentNameOverride pins the exported identity against Inputs.AgentName
+// on both the plain and the linked-subagent path. Every case also asserts the
+// entrypoint tag and the model provider, which name the product rather than the
+// session and so must not move with the name.
+func TestMapAgentNameOverride(t *testing.T) {
+	tests := []struct {
+		name         string
+		agentName    string
+		model        string
+		link         *fragment.SubagentLink
+		want         string
+		wantProvider string
+	}{
+		{name: "blank keeps the product name", want: AgentName, wantProvider: "openai"},
+		{name: "override on a plain turn", agentName: "codex-e2e", want: "codex-e2e", wantProvider: "openai"},
+		{name: "override is trimmed", agentName: "  spaced  ", want: "spaced", wantProvider: "openai"},
+		{
+			name: "blank on a linked turn keeps the suffix",
+			link: &fragment.SubagentLink{ChildSessionID: "child", ParentSessionID: "parent"},
+			want: SubagentAgentName, wantProvider: "openai",
+		},
+		{
+			name: "override on a linked turn keeps the suffix", agentName: "codex-e2e",
+			link: &fragment.SubagentLink{ChildSessionID: "child", ParentSessionID: "parent"},
+			want: "codex-e2e/subagent", wantProvider: "openai",
+		},
+		{
+			// A model with no recognisable vendor falls back to the product
+			// name as its provider, which the override must not replace.
+			name: "override keeps the provider fallback", agentName: "codex-e2e",
+			model: "some-unknown-model",
+			want:  "codex-e2e", wantProvider: "codex",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := tt.model
+			if model == "" {
+				model = "gpt-5.5"
+			}
+			f := &fragment.Fragment{SessionID: "child", TurnID: "turn", Model: model}
+			got := Map(Inputs{
+				Fragment:       f,
+				SubagentLink:   tt.link,
+				AgentName:      tt.agentName,
+				ContentCapture: agento11y.ContentCaptureModeMetadataOnly,
+				Now:            time.Unix(1, 0),
+			})
+			if got.Generation.AgentName != tt.want || got.Start.AgentName != tt.want {
+				t.Fatalf("AgentName = %q/%q, want %q", got.Start.AgentName, got.Generation.AgentName, tt.want)
+			}
+			if got.Generation.Tags["entrypoint"] != "codex" {
+				t.Fatalf("entrypoint tag = %q, want codex", got.Generation.Tags["entrypoint"])
+			}
+			if got.Generation.Model.Provider != tt.wantProvider {
+				t.Fatalf("Model.Provider = %q, want %q", got.Generation.Model.Provider, tt.wantProvider)
+			}
+		})
+	}
+}

--- a/plugins/agento11y/internal/agents/copilot/config/config.go
+++ b/plugins/agento11y/internal/agents/copilot/config/config.go
@@ -2,9 +2,11 @@ package config
 
 import (
 	"log"
+	"strings"
 
 	"github.com/grafana/agento11y/go/agento11y"
 
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/copilot/mapper"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/dotenv"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
@@ -16,6 +18,20 @@ import (
 type Config struct {
 	ContentCapture agento11y.ContentCaptureMode
 	Guards         envconfig.GuardsConfig
+	// AgentName is the identity every generation and guard request reports.
+	// Load resolves it from AGENTO11Y_AGENT_NAME, then SIGIL_AGENT_NAME, and
+	// falls back to "copilot". Read it through Agent.
+	AgentName string
+}
+
+// Agent returns the resolved agent identity, or "copilot" when AgentName is
+// blank because the Config was built without Load. The mapper applies the same
+// fallback, so a guard request and the generation it guards cannot disagree.
+func (c Config) Agent() string {
+	if n := strings.TrimSpace(c.AgentName); n != "" {
+		return n
+	}
+	return mapper.AgentName
 }
 
 // HasCredentials reports whether the canonical SIGIL_* credentials are
@@ -31,5 +47,6 @@ func Load(logger *log.Logger) Config {
 	return Config{
 		ContentCapture: envconfig.ResolveContentMode(logger),
 		Guards:         envconfig.ResolveGuards(logger),
+		AgentName:      envconfig.ResolveAgentName(mapper.AgentName),
 	}
 }

--- a/plugins/agento11y/internal/agents/copilot/config/config_test.go
+++ b/plugins/agento11y/internal/agents/copilot/config/config_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/grafana/agento11y/go/agento11y"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/copilot/mapper"
 )
 
 func TestLoad_DefaultsContentCaptureToMetadataOnly(t *testing.T) {
@@ -87,6 +89,28 @@ func TestLoad_Guards(t *testing.T) {
 			}
 			if cfg.Guards.TimeoutMs != tt.wantTimeoutMs {
 				t.Errorf("Guards.TimeoutMs = %d, want %d", cfg.Guards.TimeoutMs, tt.wantTimeoutMs)
+			}
+		})
+	}
+}
+
+// TestConfig_Agent pins the fallback a Config built without Load relies on:
+// the guard request must carry the same name the mapper stamps, never a blank.
+func TestConfig_Agent(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentName string
+		want      string
+	}{
+		{name: "a resolved name is returned unchanged", agentName: "copilot-e2e", want: "copilot-e2e"},
+		{name: "blank falls back to the product name", agentName: "", want: mapper.AgentName},
+		{name: "whitespace falls back to the product name", agentName: "  ", want: mapper.AgentName},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := (Config{AgentName: tt.agentName}).Agent(); got != tt.want {
+				t.Errorf("Agent() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/agents/copilot/hook/handlers.go
+++ b/plugins/agento11y/internal/agents/copilot/hook/handlers.go
@@ -136,7 +136,7 @@ func PreToolUse(ctx context.Context, stdout io.Writer, p Payload, cfg config.Con
 			}
 		}
 		res := guard.EvaluateToolCall(ctx, cfg.Guards, guard.ToolCallInput{
-			AgentName: mapper.AgentName,
+			AgentName: cfg.Agent(),
 			ToolName:  p.ToolName(),
 			// Copilot delivers tool args as a JSON-encoded string; the agento11y
 			// server only transforms tool-call input that is a JSON object, so
@@ -498,6 +498,7 @@ func Stop(p Payload, cfg config.Config, logger *log.Logger) {
 		Session:        session,
 		ContentCapture: cfg.ContentCapture,
 		UserIDOverride: envconfig.Getenv("USER_ID"),
+		AgentName:      cfg.Agent(),
 	})
 	logger.Printf(
 		"stop: mapped model=%s provider=%s response_id=%s output_tokens=%d assistant_text=%t tool_count=%d",

--- a/plugins/agento11y/internal/agents/copilot/hook/handlers_test.go
+++ b/plugins/agento11y/internal/agents/copilot/hook/handlers_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/copilot/config"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/copilot/fragment"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/copilot/mapper"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/copilot/transcript"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 	"github.com/stretchr/testify/assert"
@@ -796,6 +797,101 @@ func TestShouldPreferTranscriptSnapshot(t *testing.T) {
 			if got != tt.want {
 				t.Fatalf("shouldPreferTranscriptSnapshot() = %t, want %t", got, tt.want)
 			}
+		})
+	}
+}
+
+// TestAgentNameOverrideGuardAndExport pins the guard request and the exported
+// generation to one resolved name. A rule scoped to a per-run name only matches
+// that run when the two paths agree.
+func TestAgentNameOverrideGuardAndExport(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{name: "unset keeps the product name", want: mapper.AgentName},
+		{name: "preferred spelling", env: map[string]string{"AGENTO11Y_AGENT_NAME": "copilot-e2e"}, want: "copilot-e2e"},
+		{name: "legacy spelling", env: map[string]string{"SIGIL_AGENT_NAME": "legacy-name"}, want: "legacy-name"},
+		{
+			name: "preferred wins over legacy",
+			env: map[string]string{
+				"AGENTO11Y_AGENT_NAME": "preferred-name",
+				"SIGIL_AGENT_NAME":     "legacy-name",
+			},
+			want: "preferred-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			envconfig.PinAliasEnvBlank(t)
+			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+			logger := log.New(io.Discard, "", 0)
+
+			var guardAgents, exportAgents []string
+			var exportProviders []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				if strings.Contains(r.URL.Path, "hooks:evaluate") {
+					var req struct {
+						Context struct {
+							AgentName string `json:"agent_name"`
+						} `json:"context"`
+					}
+					_ = json.Unmarshal(body, &req)
+					guardAgents = append(guardAgents, req.Context.AgentName)
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"action":"allow"}`))
+					return
+				}
+				var req struct {
+					Generations []struct {
+						ID        string `json:"id"`
+						AgentName string `json:"agent_name"`
+						Model     struct {
+							Provider string `json:"provider"`
+						} `json:"model"`
+					} `json:"generations"`
+				}
+				_ = json.Unmarshal(body, &req)
+				results := make([]map[string]any, 0, len(req.Generations))
+				for _, g := range req.Generations {
+					exportAgents = append(exportAgents, g.AgentName)
+					exportProviders = append(exportProviders, g.Model.Provider)
+					results = append(results, map[string]any{"generation_id": g.ID, "accepted": true})
+				}
+				w.Header().Set("Content-Type", "application/json")
+				require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"results": results}))
+			}))
+			defer server.Close()
+
+			t.Setenv("SIGIL_ENDPOINT", server.URL)
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
+			t.Setenv("SIGIL_GUARDS_ENABLED", "true")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			cfg := config.Load(logger)
+			UserPromptSubmit(Payload{HookEventNameJSON: "UserPromptSubmit", SessionIDJSON: "sess", Timestamp: []byte(`"2026-05-18T12:00:01Z"`), Prompt: "hello"}, cfg, logger)
+			var stdout bytes.Buffer
+			PreToolUse(context.Background(), &stdout, Payload{
+				HookEventNameJSON: "PreToolUse",
+				SessionIDJSON:     "sess",
+				Timestamp:         []byte(`"2026-05-18T12:00:02Z"`),
+				ToolNameJSON:      "bash",
+				ToolInputJSON:     []byte(`{"cmd":"echo hi"}`),
+			}, cfg, logger)
+			Stop(Payload{HookEventNameJSON: "Stop", SessionIDJSON: "sess", Timestamp: []byte(`"2026-05-18T12:00:04Z"`), StopReasonJSON: "end_turn"}, cfg, logger)
+
+			assert.Equal(t, []string{tt.want}, guardAgents, "guard agent names")
+			assert.Equal(t, []string{tt.want}, exportAgents, "exported agent names")
+			// Copilot reports no provider on this fragment, so the mapper
+			// falls back to the product name. The override must not move it.
+			assert.Equal(t, []string{mapper.AgentName}, exportProviders, "exported model providers")
 		})
 	}
 }

--- a/plugins/agento11y/internal/agents/copilot/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/copilot/mapper/mapper.go
@@ -17,6 +17,10 @@ import (
 
 var errGitHubCopilot = errors.New("copilot_error")
 
+// AgentName is the default agent identity this adapter reports. It is also the
+// last-resort model provider, used when Copilot reports none and none can be
+// inferred from the model name. AGENTO11Y_AGENT_NAME overrides the identity per
+// run through Inputs.AgentName; the provider is a product fact and never moves.
 const AgentName = "copilot"
 
 type Inputs struct {
@@ -24,7 +28,18 @@ type Inputs struct {
 	Session        *fragment.Session
 	ContentCapture agento11y.ContentCaptureMode
 	UserIDOverride string
-	Now            time.Time
+	// AgentName overrides the exported agent identity. Blank means "copilot".
+	AgentName string
+	Now       time.Time
+}
+
+// agent is the agent name for this generation: the caller's override, or the
+// product name when none was given.
+func (in Inputs) agent() string {
+	if n := strings.TrimSpace(in.AgentName); n != "" {
+		return n
+	}
+	return AgentName
 }
 
 type Mapped struct {
@@ -67,6 +82,8 @@ func Map(in Inputs) Mapped {
 		"copilot.transcript_path_present":  strings.TrimSpace(frag.TranscriptPath) != "",
 	}
 	if model.Provider == "" {
+		// The product, not the session: an agent-name override must not rewrite
+		// the provider a dashboard groups models by.
 		model.Provider = AgentName
 	}
 	if model.Name == "" {
@@ -137,7 +154,7 @@ func Map(in Inputs) Mapped {
 		ID:             GenerationID(frag.SessionID, frag.TurnID),
 		ConversationID: frag.SessionID,
 		UserID:         strings.TrimSpace(in.UserIDOverride),
-		AgentName:      AgentName,
+		AgentName:      in.agent(),
 		AgentVersion:   strings.TrimSpace(frag.AgentVersion),
 		Mode:           agento11y.GenerationModeSync,
 		OperationName:  "generateText",
@@ -153,7 +170,7 @@ func Map(in Inputs) Mapped {
 		ID:             GenerationID(frag.SessionID, frag.TurnID),
 		ConversationID: frag.SessionID,
 		UserID:         strings.TrimSpace(in.UserIDOverride),
-		AgentName:      AgentName,
+		AgentName:      in.agent(),
 		AgentVersion:   strings.TrimSpace(frag.AgentVersion),
 		Mode:           agento11y.GenerationModeSync,
 		OperationName:  "generateText",

--- a/plugins/agento11y/internal/agents/copilot/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/copilot/mapper/mapper_test.go
@@ -238,3 +238,40 @@ func TestMapDoesNotSetConversationTitle(t *testing.T) {
 		t.Fatalf("Generation.ConversationTitle = %q", got.Generation.ConversationTitle)
 	}
 }
+
+// TestMapAgentNameOverride pins the exported identity against Inputs.AgentName
+// and holds the model provider fallback still. Copilot reuses the product name
+// for both, so a single literal used to decide them together.
+func TestMapAgentNameOverride(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentName string
+		want      string
+	}{
+		{name: "blank keeps the product name", want: AgentName},
+		{name: "override", agentName: "copilot-e2e", want: "copilot-e2e"},
+		{name: "override is trimmed", agentName: "  spaced  ", want: "spaced"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			frag := basicFragment()
+			// No provider reported, so the mapper falls back to the product
+			// name. That fallback is what must not follow the override.
+			frag.Provider = ""
+			frag.Model = ""
+			got := Map(Inputs{
+				Fragment:       frag,
+				AgentName:      tt.agentName,
+				ContentCapture: agento11y.ContentCaptureModeMetadataOnly,
+				Now:            fixedTime,
+			})
+			if got.Generation.AgentName != tt.want || got.Start.AgentName != tt.want {
+				t.Fatalf("AgentName = %q/%q, want %q", got.Start.AgentName, got.Generation.AgentName, tt.want)
+			}
+			if got.Generation.Model.Provider != AgentName {
+				t.Fatalf("Model.Provider = %q, want %q", got.Generation.Model.Provider, AgentName)
+			}
+		})
+	}
+}

--- a/plugins/agento11y/internal/agents/cursor/config/config.go
+++ b/plugins/agento11y/internal/agents/cursor/config/config.go
@@ -9,9 +9,11 @@ package config
 
 import (
 	"log"
+	"strings"
 
 	"github.com/grafana/agento11y/go/agento11y"
 
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/mapper"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/dotenv"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
@@ -24,6 +26,20 @@ type Config struct {
 	ContentCapture agento11y.ContentCaptureMode
 	UserIDOverride string
 	Debug          bool
+	// AgentName is the identity every generation and guard request reports.
+	// Load resolves it from AGENTO11Y_AGENT_NAME, then SIGIL_AGENT_NAME, and
+	// falls back to "cursor". Read it through Agent.
+	AgentName string
+}
+
+// Agent returns the resolved agent identity, or "cursor" when AgentName is
+// blank because the Config was built without Load. The mapper applies the same
+// fallback, so a guard request and the generation it guards cannot disagree.
+func (c Config) Agent() string {
+	if n := strings.TrimSpace(c.AgentName); n != "" {
+		return n
+	}
+	return mapper.AgentName
 }
 
 // HasCredentials reports whether the canonical SIGIL_* credentials are
@@ -56,5 +72,6 @@ func Load(logger *log.Logger) Config {
 		ContentCapture: envconfig.ResolveContentMode(logger),
 		UserIDOverride: envconfig.Getenv("USER_ID"),
 		Debug:          envconfig.ParseBool(envconfig.Getenv("DEBUG")),
+		AgentName:      envconfig.ResolveAgentName(mapper.AgentName),
 	}
 }

--- a/plugins/agento11y/internal/agents/cursor/config/config_test.go
+++ b/plugins/agento11y/internal/agents/cursor/config/config_test.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/mapper"
+)
+
+// TestConfig_Agent pins the fallback a Config built without Load relies on:
+// the guard request must carry the same name the mapper stamps, never a blank.
+func TestConfig_Agent(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentName string
+		want      string
+	}{
+		{name: "a resolved name is returned unchanged", agentName: "cursor-e2e", want: "cursor-e2e"},
+		{name: "blank falls back to the product name", agentName: "", want: mapper.AgentName},
+		{name: "whitespace falls back to the product name", agentName: "  ", want: mapper.AgentName},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := (Config{AgentName: tt.agentName}).Agent(); got != tt.want {
+				t.Errorf("Agent() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/plugins/agento11y/internal/agents/cursor/hook.go
+++ b/plugins/agento11y/internal/agents/cursor/hook.go
@@ -92,7 +92,7 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 	case "beforeSubmitPrompt":
 		hook.BeforeSubmit(payload, cfg, logger)
 	case "preToolUse":
-		hook.PreToolUse(ctx, payload, stdout, logger)
+		hook.PreToolUse(ctx, payload, cfg, stdout, logger)
 		preToolUseHandled = true
 	case "afterAgentResponse":
 		hook.AfterAgentResponse(payload, cfg, logger)

--- a/plugins/agento11y/internal/agents/cursor/hook/pretooluse.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/pretooluse.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/mapper"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/config"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/guard"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
@@ -29,9 +29,9 @@ type preToolUseResponse struct {
 // transport, credential, fail-open/closed, and transform-extraction
 // behaviour lives in the shared guard helper so this stays in lockstep with
 // the other agents.
-func PreToolUse(ctx context.Context, p Payload, stdout io.Writer, logger *log.Logger) {
+func PreToolUse(ctx context.Context, p Payload, cfg config.Config, stdout io.Writer, logger *log.Logger) {
 	res := guard.EvaluateToolCall(ctx, envconfig.ResolveGuards(logger), guard.ToolCallInput{
-		AgentName:     mapper.AgentName,
+		AgentName:     cfg.Agent(),
 		AgentVersion:  strings.TrimSpace(p.CursorVersion),
 		ModelProvider: strings.TrimSpace(p.Provider),
 		ModelName:     strings.TrimSpace(p.Model),

--- a/plugins/agento11y/internal/agents/cursor/hook/pretooluse_test.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/pretooluse_test.go
@@ -3,12 +3,18 @@ package hook
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/config"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/mapper"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
 
 // TestPreToolUse covers the Cursor-specific wiring around the shared guard
@@ -125,9 +131,10 @@ func TestPreToolUse(t *testing.T) {
 				endpoint = closed.URL
 			}
 
-			t.Setenv("SIGIL_GUARDS_ENABLED", "")
-			t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "")
-			t.Setenv("SIGIL_GUARDS_TIMEOUT_MS", "")
+			// Blank every branded variable first: config.Load below reads the
+			// process env, and an ambient endpoint would send this guard call to
+			// a real backend.
+			envconfig.PinAliasEnvBlank(t)
 			for k, v := range tt.env {
 				t.Setenv(k, v)
 			}
@@ -145,7 +152,7 @@ func TestPreToolUse(t *testing.T) {
 				ToolName:       "Shell",
 				ToolUseID:      "tu_1",
 				ToolInput:      []byte(`{"command":"echo hi"}`),
-			}, &stdout, log.New(&bytes.Buffer{}, "", 0))
+			}, config.Load(log.New(&bytes.Buffer{}, "", 0)), &stdout, log.New(&bytes.Buffer{}, "", 0))
 
 			if tt.expectServerCall && calls.Load() == 0 {
 				t.Errorf("expected sigil hook server call, got 0")
@@ -160,6 +167,110 @@ func TestPreToolUse(t *testing.T) {
 				if !strings.Contains(stdout.String(), want) {
 					t.Errorf("stdout missing %q\nfull output: %s", want, stdout.String())
 				}
+			}
+		})
+	}
+}
+
+// TestAgentNameOverrideGuardAndExport pins the guard request and the exported
+// generation to one resolved name. A rule scoped to a per-run name only matches
+// that run when the two paths agree.
+func TestAgentNameOverrideGuardAndExport(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{name: "unset keeps the product name", want: mapper.AgentName},
+		{name: "preferred spelling", env: map[string]string{"AGENTO11Y_AGENT_NAME": "cursor-e2e"}, want: "cursor-e2e"},
+		{name: "legacy spelling", env: map[string]string{"SIGIL_AGENT_NAME": "legacy-name"}, want: "legacy-name"},
+		{
+			name: "preferred wins over legacy",
+			env: map[string]string{
+				"AGENTO11Y_AGENT_NAME": "preferred-name",
+				"SIGIL_AGENT_NAME":     "legacy-name",
+			},
+			want: "preferred-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			envconfig.PinAliasEnvBlank(t)
+			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+			logger := log.New(&bytes.Buffer{}, "", 0)
+
+			var guardAgents, exportAgents []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				if strings.Contains(r.URL.Path, "hooks:evaluate") {
+					var req struct {
+						Context struct {
+							AgentName string `json:"agent_name"`
+						} `json:"context"`
+					}
+					_ = json.Unmarshal(body, &req)
+					guardAgents = append(guardAgents, req.Context.AgentName)
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"action":"allow"}`))
+					return
+				}
+				var req struct {
+					Generations []struct {
+						ID        string `json:"id"`
+						AgentName string `json:"agent_name"`
+					} `json:"generations"`
+				}
+				_ = json.Unmarshal(body, &req)
+				results := make([]map[string]any, 0, len(req.Generations))
+				for _, g := range req.Generations {
+					exportAgents = append(exportAgents, g.AgentName)
+					results = append(results, map[string]any{"generation_id": g.ID, "accepted": true})
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{"results": results})
+			}))
+			defer server.Close()
+
+			t.Setenv("SIGIL_ENDPOINT", server.URL)
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
+			t.Setenv("SIGIL_GUARDS_ENABLED", "true")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			cfg := config.Load(logger)
+			BeforeSubmit(Payload{
+				HookEventName:  "beforeSubmitPrompt",
+				ConversationID: "conv",
+				GenerationID:   "gen",
+				Timestamp:      "2026-04-28T12:00:00Z",
+				Prompt:         "hello",
+			}, cfg, logger)
+			var stdout bytes.Buffer
+			PreToolUse(context.Background(), Payload{
+				HookEventName:  "preToolUse",
+				ConversationID: "conv",
+				GenerationID:   "gen",
+				ToolName:       "Shell",
+				ToolUseID:      "tu_1",
+				ToolInput:      []byte(`{"command":"echo hi"}`),
+			}, cfg, &stdout, logger)
+			Stop(Payload{
+				HookEventName:  "stop",
+				ConversationID: "conv",
+				GenerationID:   "gen",
+				Timestamp:      "2026-04-28T12:00:05Z",
+				Status:         "completed",
+			}, cfg, logger)
+
+			if len(guardAgents) != 1 || guardAgents[0] != tt.want {
+				t.Fatalf("guard agent names = %v, want [%q]", guardAgents, tt.want)
+			}
+			if len(exportAgents) != 1 || exportAgents[0] != tt.want {
+				t.Fatalf("exported agent names = %v, want [%q]", exportAgents, tt.want)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/agents/cursor/hook/sessionend.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/sessionend.go
@@ -115,6 +115,7 @@ func emitOneStranded(
 		Stop:           stop,
 		ContentCapture: cfg.ContentCapture,
 		UserIDOverride: cfg.UserIDOverride,
+		AgentName:      cfg.Agent(),
 		Now:            time.Now(),
 	})
 

--- a/plugins/agento11y/internal/agents/cursor/hook/stop.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/stop.go
@@ -94,6 +94,7 @@ func Stop(p Payload, cfg config.Config, logger *log.Logger) {
 		Stop:           &mapper.StopInput{Status: p.Status, Error: frag.PendingStop.Error},
 		ContentCapture: cfg.ContentCapture,
 		UserIDOverride: cfg.UserIDOverride,
+		AgentName:      cfg.Agent(),
 		Now:            time.Now(),
 	})
 

--- a/plugins/agento11y/internal/agents/cursor/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/cursor/mapper/mapper.go
@@ -25,7 +25,9 @@ import (
 
 var errCursorStop = errors.New("cursor_stop_error")
 
-// AgentName is the value reported as `agent_name` on every emitted generation.
+// AgentName is the default value reported as `agent_name` on every emitted
+// generation. AGENTO11Y_AGENT_NAME overrides it per run through
+// Inputs.AgentName.
 const AgentName = "cursor"
 
 // StopStatus is the normalized stop reason ("completed" / "aborted" / "error").
@@ -55,7 +57,18 @@ type Inputs struct {
 	Stop           *StopInput
 	ContentCapture agento11y.ContentCaptureMode
 	UserIDOverride string
-	Now            time.Time
+	// AgentName overrides the exported agent identity. Blank means "cursor".
+	AgentName string
+	Now       time.Time
+}
+
+// agent is the agent name for this generation: the caller's override, or the
+// product name when none was given.
+func (in Inputs) agent() string {
+	if n := strings.TrimSpace(in.AgentName); n != "" {
+		return n
+	}
+	return AgentName
 }
 
 // Mapped is the mapper's output: the start seed, the full Generation for the
@@ -133,7 +146,7 @@ func MapFragment(in Inputs) Mapped {
 		ConversationID:    frag.ConversationID,
 		ConversationTitle: conversationTitle,
 		UserID:            uid,
-		AgentName:         AgentName,
+		AgentName:         in.agent(),
 		AgentVersion:      cursorVersion,
 		EffectiveVersion:  cursorVersion,
 		Mode:              agento11y.GenerationModeSync,
@@ -153,7 +166,7 @@ func MapFragment(in Inputs) Mapped {
 		ConversationID:    frag.ConversationID,
 		ConversationTitle: conversationTitle,
 		UserID:            uid,
-		AgentName:         AgentName,
+		AgentName:         in.agent(),
 		AgentVersion:      cursorVersion,
 		EffectiveVersion:  cursorVersion,
 		Mode:              agento11y.GenerationModeSync,

--- a/plugins/agento11y/internal/agents/cursor/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/cursor/mapper/mapper_test.go
@@ -642,3 +642,31 @@ func TestMapFragment_EffectiveVersionStableAcrossToolSubsets(t *testing.T) {
 		t.Fatalf("Start.EffectiveVersion %q != Generation.EffectiveVersion %q", gotA.Start.EffectiveVersion, gotA.Generation.EffectiveVersion)
 	}
 }
+
+// TestMapFragmentAgentNameOverride pins the exported identity against
+// Inputs.AgentName on both the start and the generation.
+func TestMapFragmentAgentNameOverride(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentName string
+		want      string
+	}{
+		{name: "blank keeps the product name", want: AgentName},
+		{name: "override", agentName: "cursor-e2e", want: "cursor-e2e"},
+		{name: "override is trimmed", agentName: "  spaced  ", want: "spaced"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MapFragment(Inputs{
+				Fragment:       basicFragment(t),
+				AgentName:      tt.agentName,
+				ContentCapture: agento11y.ContentCaptureModeMetadataOnly,
+				Now:            fixedTime,
+			})
+			if got.Generation.AgentName != tt.want || got.Start.AgentName != tt.want {
+				t.Fatalf("AgentName = %q/%q, want %q", got.Start.AgentName, got.Generation.AgentName, tt.want)
+			}
+		})
+	}
+}

--- a/plugins/agento11y/internal/agents/vibe/hook/handlers.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/handlers.go
@@ -128,6 +128,7 @@ func PostAgentTurn(ctx context.Context, p Payload, logger *log.Logger) {
 		PriorState:         prior,
 		PriorStateFound:    priorFound,
 		ContentCapture:     contentMode,
+		AgentName:          envconfig.ResolveAgentName(mapper.AgentName),
 	}, turnSeq)
 
 	// Persist the advanced offset and session snapshot BEFORE exporting. A

--- a/plugins/agento11y/internal/agents/vibe/hook/handlers_test.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/handlers_test.go
@@ -1,6 +1,7 @@
 package hook
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -14,13 +15,20 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/vibe/mapper"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/vibe/state"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
 
 func TestPostAgentTurn_EndToEnd(t *testing.T) {
 	// Drive the handler through a httptest server playing the role of
 	// the Agent Observability export endpoint, then assert the offset and token
 	// snapshot in state were advanced.
+	//
+	// The exported generation is asserted against the product name, so a
+	// developer shell that exports AGENTO11Y_AGENT_NAME must not reach the
+	// handler.
+	envconfig.PinAliasEnvBlank(t)
 	type captured struct {
 		path string
 		body []byte
@@ -326,4 +334,106 @@ func writeAcceptedGenerationResponse(t *testing.T, w http.ResponseWriter, body [
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{"results": results})
+}
+
+// TestAgentNameOverrideGuardAndExport pins the guard request and the exported
+// generation to one resolved name. vibe has no config package, so each handler
+// resolves the name for its own invocation; this checks the two agree.
+func TestAgentNameOverrideGuardAndExport(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{name: "unset keeps the product name", want: mapper.AgentName},
+		{name: "preferred spelling", env: map[string]string{"AGENTO11Y_AGENT_NAME": "vibe-e2e"}, want: "vibe-e2e"},
+		{name: "legacy spelling", env: map[string]string{"SIGIL_AGENT_NAME": "legacy-name"}, want: "legacy-name"},
+		{
+			name: "preferred wins over legacy",
+			env: map[string]string{
+				"AGENTO11Y_AGENT_NAME": "preferred-name",
+				"SIGIL_AGENT_NAME":     "legacy-name",
+			},
+			want: "preferred-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				mu           sync.Mutex
+				guardAgents  []string
+				exportAgents []string
+			)
+			srv := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				mu.Lock()
+				defer mu.Unlock()
+				if strings.Contains(r.URL.Path, "hooks:evaluate") {
+					var req struct {
+						Context struct {
+							AgentName string `json:"agent_name"`
+						} `json:"context"`
+					}
+					_ = json.Unmarshal(body, &req)
+					guardAgents = append(guardAgents, req.Context.AgentName)
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"action":"allow"}`))
+					return
+				}
+				var req struct {
+					Generations []struct {
+						AgentName string `json:"agent_name"`
+					} `json:"generations"`
+				}
+				_ = json.Unmarshal(body, &req)
+				for _, g := range req.Generations {
+					exportAgents = append(exportAgents, g.AgentName)
+				}
+				writeAcceptedGenerationResponse(t, w, body)
+			}))
+			t.Cleanup(srv.Close)
+
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			envconfig.PinAliasEnvBlank(t)
+			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+			t.Setenv("SIGIL_ENDPOINT", srv.URL)
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
+			t.Setenv("SIGIL_CONTENT_CAPTURE_MODE", "full")
+			t.Setenv("SIGIL_GUARDS_ENABLED", "true")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			dir := t.TempDir()
+			must(t, copyFile(filepath.Join("..", "testdata", "messages.jsonl"), filepath.Join(dir, "messages.jsonl")))
+			must(t, copyFile(filepath.Join("..", "testdata", "meta.json"), filepath.Join(dir, "meta.json")))
+			tp := filepath.Join(dir, "messages.jsonl")
+
+			logger := log.New(io.Discard, "", 0)
+			var stdout bytes.Buffer
+			BeforeTool(context.Background(), &stdout, Payload{
+				HookEventName:   "before_tool",
+				SessionID:       "sess-agent-name",
+				ToolNameValue:   "shell",
+				ToolCallIDValue: "call-1",
+				ToolInputValue:  json.RawMessage(`{"command":"echo hi"}`),
+			}, logger)
+			PostAgentTurn(context.Background(), Payload{
+				HookEventName:  "post_agent_turn",
+				SessionID:      "sess-agent-name",
+				TranscriptPath: tp,
+			}, logger)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if len(guardAgents) != 1 || guardAgents[0] != tt.want {
+				t.Fatalf("guard agent names = %v, want [%q]", guardAgents, tt.want)
+			}
+			if len(exportAgents) != 1 || exportAgents[0] != tt.want {
+				t.Fatalf("exported agent names = %v, want [%q]", exportAgents, tt.want)
+			}
+		})
+	}
 }

--- a/plugins/agento11y/internal/agents/vibe/hook/tool.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/tool.go
@@ -45,7 +45,10 @@ func BeforeTool(ctx context.Context, stdout io.Writer, p Payload, logger *log.Lo
 	defer cancel()
 
 	res := guard.EvaluateToolCall(evalCtx, cfg, guard.ToolCallInput{
-		AgentName:     mapper.AgentName,
+		// Same resolution the export path uses, so a rule scoped to a per-run
+		// name matches the generations that run produces. vibe has no config
+		// package, so each handler resolves it for its own invocation.
+		AgentName:     envconfig.ResolveAgentName(mapper.AgentName),
 		ToolName:      toolName,
 		ToolCallID:    p.ToolCallID(),
 		ToolInputJSON: p.ToolInput(),

--- a/plugins/agento11y/internal/agents/vibe/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/vibe/mapper/mapper.go
@@ -25,8 +25,9 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/redact"
 )
 
-// AgentName is the agento11y identity attached to every generation emitted
-// by the vibe agent adapter. Stable across versions.
+// AgentName is the default agento11y identity attached to every generation
+// emitted by the vibe agent adapter. Stable across versions.
+// AGENTO11Y_AGENT_NAME overrides it per run through Inputs.AgentName.
 const AgentName = "mistral-vibe"
 
 // Inputs are the parameters Map needs to build one generation.
@@ -51,7 +52,19 @@ type Inputs struct {
 	PriorState         state.Session
 	PriorStateFound    bool
 	ContentCapture     agento11y.ContentCaptureMode
-	Now                time.Time
+	// AgentName overrides the exported agent identity. Blank means
+	// "mistral-vibe".
+	AgentName string
+	Now       time.Time
+}
+
+// agent is the agent name for this generation: the caller's override, or the
+// product name when none was given.
+func (in Inputs) agent() string {
+	if n := strings.TrimSpace(in.AgentName); n != "" {
+		return n
+	}
+	return AgentName
 }
 
 // Mapped bundles the GenerationStart and the corresponding Generation so
@@ -145,7 +158,7 @@ func Map(in Inputs, turnSeq int) Mapped {
 		ID:                  id,
 		ConversationID:      conversationID,
 		ConversationTitle:   in.Meta.Title,
-		AgentName:           AgentName,
+		AgentName:           in.agent(),
 		Mode:                agento11y.GenerationModeSync,
 		OperationName:       "generateText",
 		Model:               model,
@@ -162,7 +175,7 @@ func Map(in Inputs, turnSeq int) Mapped {
 		ID:                  id,
 		ConversationID:      conversationID,
 		ConversationTitle:   in.Meta.Title,
-		AgentName:           AgentName,
+		AgentName:           in.agent(),
 		Mode:                agento11y.GenerationModeSync,
 		OperationName:       "generateText",
 		Model:               model,

--- a/plugins/agento11y/internal/agents/vibe/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/vibe/mapper/mapper_test.go
@@ -474,3 +474,32 @@ func messageText(messages []agento11y.Message) string {
 	}
 	return b.String()
 }
+
+// TestMap_AgentNameOverride pins the exported identity against Inputs.AgentName
+// on both the start and the generation.
+func TestMap_AgentNameOverride(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentName string
+		want      string
+	}{
+		{name: "blank keeps the product name", want: AgentName},
+		{name: "override", agentName: "vibe-e2e", want: "vibe-e2e"},
+		{name: "override is trimmed", agentName: "  spaced  ", want: "spaced"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Map(Inputs{
+				SessionID:      "s",
+				Meta:           meta.Meta{},
+				PriorState:     state.Session{},
+				AgentName:      tt.agentName,
+				ContentCapture: agento11y.ContentCaptureModeMetadataOnly,
+			}, 1)
+			if got.Generation.AgentName != tt.want || got.Start.AgentName != tt.want {
+				t.Fatalf("AgentName = %q/%q, want %q", got.Start.AgentName, got.Generation.AgentName, tt.want)
+			}
+		})
+	}
+}

--- a/plugins/agento11y/internal/doctor/doctor.go
+++ b/plugins/agento11y/internal/doctor/doctor.go
@@ -65,6 +65,7 @@ var trackedSuffixes = []string{
 	"OTEL_EXPORTER_OTLP_ENDPOINT",
 	"OTEL_AUTH_TOKEN",
 	"CONTENT_CAPTURE_MODE",
+	"AGENT_NAME",
 	"TAGS",
 	"AUTO_UPDATE",
 	"LOCAL",
@@ -170,11 +171,18 @@ type ConfigSection struct {
 	// human row reports one key, so this is the key it reports. Both are empty
 	// when GUARDS_ENABLED supplied no usable value, so the row reports the
 	// built-in default rather than crediting a rejected value.
-	GuardsKey    string            `json:"guards_key,omitempty"`
-	GuardsSource string            `json:"guards_source,omitempty"`
-	Tags         map[string]string `json:"tags,omitempty"`
-	TagsKey      string            `json:"tags_key,omitempty"`
-	TagsSource   string            `json:"tags_source,omitempty"`
+	GuardsKey    string `json:"guards_key,omitempty"`
+	GuardsSource string `json:"guards_source,omitempty"`
+	// AgentName is the AGENT_NAME family: the value every adapter stamps on its
+	// generations and guard requests instead of its own product name. Empty
+	// means no override is set, so each adapter keeps its own name and the row
+	// is left out.
+	AgentName       string            `json:"agent_name,omitempty"`
+	AgentNameKey    string            `json:"agent_name_key,omitempty"`
+	AgentNameSource string            `json:"agent_name_source,omitempty"`
+	Tags            map[string]string `json:"tags,omitempty"`
+	TagsKey         string            `json:"tags_key,omitempty"`
+	TagsSource      string            `json:"tags_source,omitempty"`
 	// Local is the resolved LOCAL family: whether `agento11y <agent>` starts in
 	// local mode without --local, and where the value came from.
 	Local envValue `json:"local"`
@@ -732,6 +740,16 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 		sec.GuardsSource = guardsEnabled.source
 	}
 
+	// The AGENT_NAME family renames the agent every hook reports. A rule or
+	// dashboard filtered on the product name stops matching once it is set, so
+	// the effective value and its source have to be visible here.
+	agentName := resolveFamily("AGENT_NAME", osEnv, fileEnv)
+	if agentName.set {
+		sec.AgentName = agentName.value
+		sec.AgentNameKey = agentName.key
+		sec.AgentNameSource = agentName.source
+	}
+
 	// The TAGS family attaches key=value tags to every generation. They
 	// aren't secret, so surface the resolved set (and where it came from) to
 	// make a mis-set or forgotten tag visible.
@@ -790,6 +808,21 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 		sec.Health = HealthWarn
 		sec.Messages = append(sec.Messages,
 			fmt.Sprintf("the %s value is invalid; guards use the default", key))
+	}
+	if agentName.conflict {
+		sec.Messages = append(sec.Messages, conflictMessage(agentName))
+	}
+	if agentName.legacyWon() {
+		sec.Messages = append(sec.Messages,
+			"agent name set via legacy SIGIL_AGENT_NAME — this keeps working, but the preferred name is AGENTO11Y_AGENT_NAME")
+	}
+	// A slash separates a base name from a subagent suffix, so a name that
+	// contains one makes every generation of the run read as a subagent step.
+	if strings.Contains(agentName.value, "/") {
+		sec.Health = HealthWarn
+		sec.Messages = append(sec.Messages, fmt.Sprintf(
+			"the %s value %q contains a slash; a slash marks a subagent generation, so every generation of this run is counted as a subagent",
+			agentName.key, agentName.value))
 	}
 	if tags.conflict {
 		sec.Messages = append(sec.Messages, conflictMessage(tags))

--- a/plugins/agento11y/internal/doctor/doctor_test.go
+++ b/plugins/agento11y/internal/doctor/doctor_test.go
@@ -1263,6 +1263,112 @@ func TestCollectConfig_GuardsFaultsMatchEnvconfig(t *testing.T) {
 	}
 }
 
+// TestCollectConfig_AgentName pins the agent-name row: the effective value, the
+// spelling that supplied it, and whether it came from the shell or config.env.
+// Without the row a user who renamed an agent has no way to see why their guard
+// rule stopped matching.
+func TestCollectConfig_AgentName(t *testing.T) {
+	tests := []struct {
+		name         string
+		osEnv        map[string]string
+		fileEnv      map[string]string
+		wantName     string
+		wantKey      string
+		wantSource   string
+		wantMsg      string
+		wantHealth   Health
+		wantRendered string // "" = assert the row is absent
+	}{
+		{name: "unset reports no override"},
+		{
+			name:     "from the shell",
+			osEnv:    map[string]string{"AGENTO11Y_AGENT_NAME": "claude-code-e2e"},
+			wantName: "claude-code-e2e", wantKey: "AGENTO11Y_AGENT_NAME", wantSource: sourceEnv,
+			wantRendered: "agent name: claude-code-e2e (AGENTO11Y_AGENT_NAME, env)",
+		},
+		{
+			name:     "from config.env",
+			fileEnv:  map[string]string{"AGENTO11Y_AGENT_NAME": "config-name"},
+			wantName: "config-name", wantKey: "AGENTO11Y_AGENT_NAME", wantSource: sourceConfig,
+			wantRendered: "agent name: config-name (AGENTO11Y_AGENT_NAME, config.env)",
+		},
+		{
+			name:     "shell wins over config.env",
+			osEnv:    map[string]string{"AGENTO11Y_AGENT_NAME": "shell-name"},
+			fileEnv:  map[string]string{"AGENTO11Y_AGENT_NAME": "config-name"},
+			wantName: "shell-name", wantKey: "AGENTO11Y_AGENT_NAME", wantSource: sourceEnv,
+		},
+		{
+			name:     "legacy-only name suggests migration",
+			osEnv:    map[string]string{"SIGIL_AGENT_NAME": "legacy-name"},
+			wantName: "legacy-name", wantKey: "SIGIL_AGENT_NAME", wantSource: sourceEnv,
+			wantMsg: "preferred name is AGENTO11Y_AGENT_NAME",
+		},
+		{
+			name: "conflicting spellings flag the disagreement",
+			osEnv: map[string]string{
+				"AGENTO11Y_AGENT_NAME": "preferred-name",
+				"SIGIL_AGENT_NAME":     "legacy-name",
+			},
+			wantName: "preferred-name", wantKey: "AGENTO11Y_AGENT_NAME", wantSource: sourceEnv,
+			wantMsg: "AGENTO11Y_AGENT_NAME and SIGIL_AGENT_NAME are both set in the environment, to different values; using AGENTO11Y_AGENT_NAME",
+		},
+		{
+			name:     "a slash in the name warns that the run reads as a subagent",
+			osEnv:    map[string]string{"AGENTO11Y_AGENT_NAME": "team/e2e"},
+			wantName: "team/e2e", wantKey: "AGENTO11Y_AGENT_NAME", wantSource: sourceEnv,
+			wantMsg:    "contains a slash",
+			wantHealth: HealthWarn,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateEnv(t)
+			sec := collectConfig(tc.osEnv, tc.fileEnv)
+			if sec.AgentName != tc.wantName {
+				t.Fatalf("agent name = %q, want %q", sec.AgentName, tc.wantName)
+			}
+			if sec.AgentNameKey != tc.wantKey {
+				t.Fatalf("agent name key = %q, want %q", sec.AgentNameKey, tc.wantKey)
+			}
+			if sec.AgentNameSource != tc.wantSource {
+				t.Fatalf("agent name source = %q, want %q", sec.AgentNameSource, tc.wantSource)
+			}
+			if tc.wantMsg != "" && !strings.Contains(strings.Join(sec.Messages, " "), tc.wantMsg) {
+				t.Fatalf("messages %v missing %q", sec.Messages, tc.wantMsg)
+			}
+			if tc.wantHealth != "" && sec.Health != tc.wantHealth {
+				t.Fatalf("health = %q, want %q", sec.Health, tc.wantHealth)
+			}
+			var buf bytes.Buffer
+			renderHuman(&buf, &Report{Config: sec}, false)
+			// The renderer pads keys to the width of the widest one in the
+			// section, so compare with runs of spaces collapsed.
+			rendered := strings.Join(strings.Fields(buf.String()), " ")
+			if tc.wantRendered != "" && !strings.Contains(rendered, tc.wantRendered) {
+				t.Fatalf("rendered report missing %q:\n%s", tc.wantRendered, buf.String())
+			}
+			if tc.wantName == "" && strings.Contains(rendered, "agent name") {
+				t.Fatalf("rendered report names an agent with no override set:\n%s", buf.String())
+			}
+		})
+	}
+}
+
+// TestCollectConfig_AgentNameReadsTheSnapshot pins the same wiring the content
+// mode has: the name is resolved from the snapshot doctor was handed, not from
+// the process env after the dotenv merge, so a config.env value is not
+// attributed to the shell.
+func TestCollectConfig_AgentNameReadsTheSnapshot(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("AGENTO11Y_AGENT_NAME", "shell-name")
+
+	sec := collectConfig(nil, map[string]string{"AGENTO11Y_AGENT_NAME": "config-name"})
+	if sec.AgentName != "config-name" || sec.AgentNameSource != sourceConfig {
+		t.Fatalf("agent name = %q from %q, want config-name from config.env", sec.AgentName, sec.AgentNameSource)
+	}
+}
+
 func TestCollectConfig_Tags(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/plugins/agento11y/internal/doctor/render.go
+++ b/plugins/agento11y/internal/doctor/render.go
@@ -158,6 +158,12 @@ func renderHuman(w io.Writer, r *Report, color bool) {
 	b.kv("content capture", withTrailer(r.Config.ContentCaptureMode,
 		describeSource(p, provenanceParts(r.Config.ContentModeKey, r.Config.ContentModeSource)...)))
 	b.kv("guards", describeGuards(p, r.Config))
+	// Only printed when an override is set: with the family unset each adapter
+	// reports its own product name, and there is no single value to show.
+	if r.Config.AgentName != "" {
+		b.kv("agent name", withTrailer(r.Config.AgentName,
+			describeSource(p, provenanceParts(r.Config.AgentNameKey, r.Config.AgentNameSource)...)))
+	}
 	if len(r.Config.Tags) > 0 {
 		b.kv("tags", withTrailer(formatTags(r.Config.Tags), describeSource(p, r.Config.TagsKey, r.Config.TagsSource)))
 	}

--- a/plugins/agento11y/internal/entry/golden_integration_test.go
+++ b/plugins/agento11y/internal/entry/golden_integration_test.go
@@ -805,12 +805,18 @@ func assertGoldenJSON(t *testing.T, path string, got []goldenExport) {
 
 // setHookExportEnv configures the canonical SIGIL_* env vars to point at the
 // fake export server and disables OTel transport so spans/metrics do not try
-// to reach a non-existent collector during the test. The AGENTO11Y_* spellings
-// are pinned blank via t.Setenv so dotenv materialization (which writes both
-// names) is rolled back between scenarios instead of leaking a stale endpoint
-// into the next one.
+// to reach a non-existent collector during the test.
+//
+// Both spellings of every alias family are pinned blank first, so dotenv
+// materialization (which writes both names) is rolled back between scenarios
+// instead of leaking a stale endpoint into the next one, and a variable the
+// developer exported cannot change fixture output. AGENTO11Y_AGENT_NAME and
+// SIGIL_AGENT_NAME both rename the exported agent, so leaving either at the
+// shell value would fail every scenario on that machine alone. The explicit
+// SIGIL_* values below are set after the pin and still win.
 func setHookExportEnv(t *testing.T, endpoint string) {
 	t.Helper()
+	envconfig.PinAliasEnvBlank(t)
 	t.Setenv("SIGIL_ENDPOINT", endpoint)
 	t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
 	t.Setenv("SIGIL_AUTH_TOKEN", "token")
@@ -821,9 +827,6 @@ func setHookExportEnv(t *testing.T, endpoint string) {
 	t.Setenv("SIGIL_CONTENT_CAPTURE_MODE", "full")
 	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
-	for _, suffix := range envconfig.AliasSuffixes {
-		t.Setenv(envconfig.PreferredKey(suffix), "")
-	}
 	// Enable SIGIL_DEBUG so the dispatcher writes per-event logs into
 	// $XDG_STATE_HOME/agento11y/logs/agento11y.log. When a scenario fails the test
 	// reads that file back so the failure message includes the trail.

--- a/plugins/agento11y/internal/envconfig/envconfig.go
+++ b/plugins/agento11y/internal/envconfig/envconfig.go
@@ -274,6 +274,22 @@ func ParseExtraTags(s string) map[string]string {
 	return out
 }
 
+// ResolveAgentName returns the agent identity to attach to generations and
+// guard requests: AGENTO11Y_AGENT_NAME, then SIGIL_AGENT_NAME, then def. A
+// value that is empty or only whitespace counts as unset, and the returned
+// value is trimmed, so a caller never has to trim it again.
+//
+// def is each adapter's product name, so an unset variable keeps the name
+// dashboards and guard rules already filter on. Setting the variable gives a
+// single run its own agent name, which is how a test harness keeps its
+// generations out of the operator's own data.
+func ResolveAgentName(def string) string {
+	if v, _, ok := LookupEnv("AGENT_NAME"); ok {
+		return v
+	}
+	return def
+}
+
 // ResolveContentMode returns the effective ContentCaptureMode from
 // AGENTO11Y_CONTENT_CAPTURE_MODE (SIGIL_ fallback). Empty values and the
 // Default zero-value enum resolve to metadata_only so the explicit fall-back

--- a/plugins/agento11y/internal/envconfig/envconfig_test.go
+++ b/plugins/agento11y/internal/envconfig/envconfig_test.go
@@ -296,6 +296,58 @@ func mapLookup(env map[string]string) Lookup {
 	}
 }
 
+// TestResolveAgentName covers the precedence between the two spellings and the
+// fall-back to the adapter's product name. A blank value must not become the
+// exported agent_name, otherwise a stray empty variable silently unnames every
+// generation.
+func TestResolveAgentName(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{name: "unset keeps the default", want: "claude-code"},
+		{name: "preferred spelling", env: map[string]string{"AGENTO11Y_AGENT_NAME": "claude-code-e2e"}, want: "claude-code-e2e"},
+		{name: "legacy spelling", env: map[string]string{"SIGIL_AGENT_NAME": "legacy-name"}, want: "legacy-name"},
+		{
+			name: "preferred wins over legacy",
+			env: map[string]string{
+				"AGENTO11Y_AGENT_NAME": "preferred-name",
+				"SIGIL_AGENT_NAME":     "legacy-name",
+			},
+			want: "preferred-name",
+		},
+		{
+			name: "blank preferred falls through to legacy",
+			env: map[string]string{
+				"AGENTO11Y_AGENT_NAME": "   ",
+				"SIGIL_AGENT_NAME":     "legacy-name",
+			},
+			want: "legacy-name",
+		},
+		{
+			name: "both blank keeps the default",
+			env: map[string]string{
+				"AGENTO11Y_AGENT_NAME": " ",
+				"SIGIL_AGENT_NAME":     "",
+			},
+			want: "claude-code",
+		},
+		{name: "value is trimmed", env: map[string]string{"AGENTO11Y_AGENT_NAME": "  spaced  "}, want: "spaced"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			PinAliasEnvBlank(t)
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			if got := ResolveAgentName("claude-code"); got != tt.want {
+				t.Errorf("ResolveAgentName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestResolveContentMode covers the process-env wrapper: which spelling supplies
 // the mode, which is the one thing the value-level table below cannot reach.
 func TestResolveContentMode(t *testing.T) {

--- a/plugins/agento11y/internal/history/claudecode_test.go
+++ b/plugins/agento11y/internal/history/claudecode_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/claudecode/mapper"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/claudecode/state"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/claudecode/transcript"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
 
 // claudeLine builds one transcript JSONL line.
@@ -933,4 +934,31 @@ func claudeSpawnTurnID(t *testing.T, turns []HistoricalGeneration, sessionID str
 		t.Fatal("no generation with an Agent tool call")
 	}
 	return id
+}
+
+// TestClaudeImportIgnoresTheAgentNameOverride pins backfill to the product
+// name. A backfill cannot reconstruct the environment a past session ran under.
+// claudeFinalizeSubagentGens also renames a subagent transcript's own
+// generations only when they still carry the product name, so honouring the
+// variable here would leave a subagent run named like a main one.
+func TestClaudeImportIgnoresTheAgentNameOverride(t *testing.T) {
+	envconfig.PinAliasEnvBlank(t)
+	t.Setenv("AGENTO11Y_AGENT_NAME", "claude-code-e2e")
+
+	root := t.TempDir()
+	path := writeClaudeSession(t, root, "-work-repo", "sess-import")
+	imp := claudeImporterAt(root)
+	preview, ok, err := imp.Preview(context.Background(), path)
+	if err != nil || !ok {
+		t.Fatalf("Preview: ok=%v err=%v", ok, err)
+	}
+	turns := collectTurns(t, imp, preview)
+	if len(turns) == 0 {
+		t.Fatal("no turns imported")
+	}
+	for i, turn := range turns {
+		if turn.Gen.AgentName != string(AgentClaudeCode) {
+			t.Errorf("turn %d AgentName = %q, want %q", i, turn.Gen.AgentName, AgentClaudeCode)
+		}
+	}
 }

--- a/plugins/agento11y/internal/history/codex_test.go
+++ b/plugins/agento11y/internal/history/codex_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/codex/codexlog"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/codex/fragment"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/codex/mapper"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
 
 func codexRecord(ts, typ string, payload map[string]any) string {
@@ -316,12 +317,12 @@ func TestCodexTurnWithoutTokenUsageIsMarkedApproximate(t *testing.T) {
 	}
 }
 
-// TestCodexSubagentTurnsLinkToTheParentTurn covers a spawned agent session. The
-// parent generation ID must be the deterministic import ID of the parent's
-// spawning turn, so the two sessions join up in the viewer.
-func TestCodexSubagentTurnsLinkToTheParentTurn(t *testing.T) {
-	root := t.TempDir()
-	parentID := "019a4a49-979a-7382-abb5-a9a4e8740114"
+// writeCodexSubagentPair writes a parent rollout that spawns one subagent plus
+// the subagent's own rollout, and returns both paths along with the parent
+// session ID.
+func writeCodexSubagentPair(t *testing.T, root string) (parentPath, childPath, parentID string) {
+	t.Helper()
+	parentID = "019a4a49-979a-7382-abb5-a9a4e8740114"
 	childID := "019a4a50-1111-7382-abb5-a9a4e8740115"
 
 	parentBody := codexRecord("2026-01-10T12:00:00Z", "session_meta", map[string]any{"id": parentID, "cwd": "/work/repo"}) +
@@ -335,7 +336,7 @@ func TestCodexSubagentTurnsLinkToTheParentTurn(t *testing.T) {
 			"type": "function_call_output", "call_id": "call-spawn",
 			"output": fmt.Sprintf(`{"agent_id":%q,"nickname":"scout"}`, childID),
 		})
-	parentPath := writeFile(t, filepath.Join(root, "rollout-2026-01-10T12-00-00-"+parentID+".jsonl"), parentBody)
+	parentPath = writeFile(t, filepath.Join(root, "rollout-2026-01-10T12-00-00-"+parentID+".jsonl"), parentBody)
 
 	childBody := codexRecord("2026-01-10T12:00:05Z", "session_meta", map[string]any{
 		"id": childID, "thread_source": "subagent", "parent_session_id": parentID,
@@ -346,7 +347,16 @@ func TestCodexSubagentTurnsLinkToTheParentTurn(t *testing.T) {
 			"type": "message", "role": "assistant",
 			"content": []map[string]any{{"type": "output_text", "text": "explored"}},
 		})
-	childPath := writeFile(t, filepath.Join(root, "rollout-2026-01-10T12-00-05-"+childID+".jsonl"), childBody)
+	childPath = writeFile(t, filepath.Join(root, "rollout-2026-01-10T12-00-05-"+childID+".jsonl"), childBody)
+	return parentPath, childPath, parentID
+}
+
+// TestCodexSubagentTurnsLinkToTheParentTurn covers a spawned agent session. The
+// parent generation ID must be the deterministic import ID of the parent's
+// spawning turn, so the two sessions join up in the viewer.
+func TestCodexSubagentTurnsLinkToTheParentTurn(t *testing.T) {
+	root := t.TempDir()
+	parentPath, childPath, parentID := writeCodexSubagentPair(t, root)
 
 	imp := codexImporterAt(root)
 	parentTurns := collectTurns(t, imp, codexPreview(t, imp, parentPath))
@@ -542,5 +552,42 @@ func TestCodexPreviewMatchesTheImportedTurnCount(t *testing.T) {
 	turns := collectTurns(t, imp, preview)
 	if preview.TurnCount != len(turns) {
 		t.Fatalf("preview said %d turns, the import produced %d", preview.TurnCount, len(turns))
+	}
+}
+
+// TestCodexImportIgnoresTheAgentNameOverride pins backfill to the product name.
+// A backfill cannot reconstruct the environment a past run had, so the name it
+// stamps is the product one whatever the current shell says. Subagent linking
+// is unaffected either way: the codex importer joins a child to its parent
+// through session_meta, not by matching an agent name.
+func TestCodexImportIgnoresTheAgentNameOverride(t *testing.T) {
+	envconfig.PinAliasEnvBlank(t)
+	t.Setenv("AGENTO11Y_AGENT_NAME", "codex-e2e")
+
+	root := t.TempDir()
+	plainPath := writeCodexRollout(t, root, "019a4a60-2222-7382-abb5-a9a4e8740116")
+	parentPath, childPath, _ := writeCodexSubagentPair(t, root)
+	imp := codexImporterAt(root)
+
+	for _, tc := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "plain turn", path: plainPath, want: mapper.AgentName},
+		{name: "parent turn", path: parentPath, want: mapper.AgentName},
+		{name: "linked subagent turn", path: childPath, want: mapper.SubagentAgentName},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			turns := collectTurns(t, imp, codexPreview(t, imp, tc.path))
+			if len(turns) == 0 {
+				t.Fatal("no turns imported")
+			}
+			for i, turn := range turns {
+				if turn.Gen.AgentName != tc.want {
+					t.Errorf("turn %d AgentName = %q, want %q", i, turn.Gen.AgentName, tc.want)
+				}
+			}
+		})
 	}
 }

--- a/plugins/agento11y/internal/history/export.go
+++ b/plugins/agento11y/internal/history/export.go
@@ -61,10 +61,12 @@ const ForwardMarkerHeader = "X-Agento11y-Local-Forwarded"
 // series.
 const otelInstancePrefix = "agento11y-history-import-"
 
-// LiveAgentName returns the AgentName a live adapter emits for an agent. The
-// registered IDs are already the live names, so an imported generation carries
-// the same agent identity as a live one. An importer that produces a more
-// specific name, such as "codex/subagent", keeps it; this is only the default.
+// LiveAgentName returns the product name a live adapter emits for an agent. The
+// registered IDs are already those names, so an imported generation carries the
+// same identity as a live run that did not rename itself. A live run started
+// with AGENTO11Y_AGENT_NAME exports under that name instead, and a backfill
+// cannot reconstruct it. An importer that produces a more specific name, such
+// as "codex/subagent", keeps it; this is only the default.
 func LiveAgentName(id AgentID) string { return string(id) }
 
 // Exporter turns normalized historical generations into backdated generation

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -103,6 +103,7 @@ Common culprits: `agento11y --version` doesn't work (binary not on `PATH`), a mi
 | `AGENTO11Y_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md). |
 | `AGENTO11Y_TAGS` | — | `key=value,key=value` tags on every generation and as `agento11y.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). |
 | `AGENTO11Y_USER_ID` | from `~/.claude.json` | Override the user id. |
+| `AGENTO11Y_AGENT_NAME` | `claude-code` | Override the exported `agent_name`. Subagent turns become `<name>/<subagent type>`, or `<name>/subagent` when Claude Code names no type. Avoid a `/` in the name itself: a slash marks a subagent generation, so every turn of the run is counted as one. Guard rules and dashboards that filter on `claude-code` no longer match the generations this run exports. |
 | `AGENTO11Y_USER_ID_SOURCE` | `email` | Which field to read from `~/.claude.json`: `email` or `accountUuid`. |
 | `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
 | `AGENTO11Y_AUTO_UPDATE` | `true` | Refresh the `agento11y-claude-code` plugin automatically. Set `false` to pin the installed version. |

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -119,6 +119,7 @@ tail -f ~/.local/state/agento11y/logs/agento11y.log
 | `AGENTO11Y_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md). |
 | `AGENTO11Y_TAGS` | — | `key=value,key=value` tags on every generation and as `agento11y.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). |
 | `AGENTO11Y_USER_ID` | — | Override the user id. |
+| `AGENTO11Y_AGENT_NAME` | `codex` | Override the exported `agent_name`. Subagent turns become `<name>/subagent`. Avoid a `/` in the name itself: a slash marks a subagent generation, so every turn of the run is counted as one. Guard rules and dashboards that filter on `codex` no longer match the generations this run exports. |
 | `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
 | `AGENTO11Y_GUARDS_ENABLED` | `false` | Enable Codex `PreToolUse` guards against Agent Observability rules. |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | Allow the tool call when the guard request fails (set `false` for fail-closed). |

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -165,6 +165,7 @@ Limits:
 | `AGENTO11Y_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. |
 | `AGENTO11Y_TAGS` | — | `key=value,key=value` tags on every generation and as `agento11y.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). |
 | `AGENTO11Y_USER_ID` | — | Override the user id. |
+| `AGENTO11Y_AGENT_NAME` | `copilot` | Override the exported `agent_name`. The model-provider fallback stays `copilot`, so a turn whose provider Copilot neither reports nor implies through the model name is still exported as `copilot`. Avoid a `/` in the name: a slash marks a subagent generation, so every turn of the run is counted as one. Guard rules and dashboards that filter on `copilot` no longer match the generations this run exports. |
 | `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
 | `AGENTO11Y_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Copilot `preToolUse` hook is evaluated against Agent Observability: tool calls denied by guard rules are blocked, and Transform rules redact tool arguments in `copilot-cli`. |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -112,6 +112,7 @@ tail -f ~/.local/state/agento11y/logs/agento11y.log
 | `AGENTO11Y_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md). |
 | `AGENTO11Y_TAGS` | — | `key=value,key=value` tags on every generation and as `agento11y.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). Built-ins (`git.branch`, `cwd`, `subagent`) win on generation-export tag collision. |
 | `AGENTO11Y_USER_ID` | from Cursor | Override the user id. |
+| `AGENTO11Y_AGENT_NAME` | `cursor` | Override the exported `agent_name`. Avoid a `/` in the name: a slash marks a subagent generation, so every turn of the run is counted as one. Guard rules and dashboards that filter on `cursor` no longer match the generations this run exports. |
 | `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
 | `AGENTO11Y_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Cursor `preToolUse` hook is evaluated against Agent Observability: tool calls denied by guard rules are blocked, and Transform rules rewrite the tool arguments before execution. |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |

--- a/plugins/vibe/README.md
+++ b/plugins/vibe/README.md
@@ -122,6 +122,7 @@ Subagent turns are not tagged `subagent`. Mistral Vibe only exposes a session-le
 | `AGENTO11Y_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. |
 | `AGENTO11Y_TAGS` | — | `key=value,key=value` tags on every generation and as `agento11y.tag.<key>` on OTel spans/metrics. Same as `--tag`. |
 | `AGENTO11Y_USER_ID` | — | Override the user id. |
+| `AGENTO11Y_AGENT_NAME` | `mistral-vibe` | Override the exported `agent_name`. Avoid a `/` in the name: a slash marks a subagent generation, so every turn of the run is counted as one. Guard rules and dashboards that filter on `mistral-vibe` no longer match the generations this run exports. |
 | `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
 | `AGENTO11Y_GUARDS_ENABLED` | `false` | Evaluate every `before_tool` fire against guard policy. Denied calls are blocked; Transform rules rewrite the tool arguments. |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | On timeout, network error, or 5xx, run the tool anyway. Set `false` for strict mode. |


### PR DESCRIPTION
`AGENTO11Y_AGENT_NAME` changes agent name in the SDKs, but was not working for coding agent plugins.