### PR TITLE
feat(plugins/agento11y): bundle a setup skill in the binary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ Three steps run per release, and none of them creates a tag on the release PR:
 
 | Plugin dir | What it actually is |
 |------------|---------------------|
-| `plugins/agento11y/` | The shared Go binary, installed as `agento11y` (`brew install grafana/grafana/agento11y`; the old `sigil` name still works but will be removed). Has subcommands `claude`, `codex`, `copilot`, `cursor`, `opencode`, `pi`, `vibe`, `login`, `doctor`, `local`. This is also what consumers use. |
+| `plugins/agento11y/` | The shared Go binary, installed as `agento11y` (`brew install grafana/grafana/agento11y`; the old `sigil` name still works but will be removed). Has subcommands `claude`, `codex`, `copilot`, `cursor`, `opencode`, `pi`, `vibe`, `login`, `doctor`, `local`, `history`, `skills`, `help`. This is also what consumers use. |
 | `plugins/claude-code/`, `plugins/codex/`, `plugins/copilot/`, `plugins/cursor/` | Thin glue: hook scripts and READMEs that wire the host agent to the shared `agento11y` binary. No independent code paths. |
 | `plugins/opencode/` | Independent npm package `@grafana/agento11y-opencode`. Runs in-process inside opencode through its TypeScript plugin API; `agento11y opencode` installs and launches it. |
 | `plugins/pi/` | Independent npm package `@grafana/agento11y-pi`. Runs in-process inside pi; `agento11y pi` installs and launches it. |
@@ -80,9 +80,25 @@ If you change shared-binary behavior, the four glue plugins and vibe all see it.
 - Python has one package per framework (`agento11y-langgraph`, `agento11y-openai`, …). JS has one package with subpath exports (`@grafana/agento11y/langgraph`). Don't reflexively assume one layout for the other.
 - Python version bumps go through `mise run sdk:py:bump <VERSION>`. It updates all 13 `pyproject.toml` files and their internal `agento11y>=…` pins atomically. Hand-editing one file leaves the other twelve inconsistent.
 
+## A skill served by the binary lives inside the binary's tree
+
+Skill markdown sits in four directories, and where a new skill goes follows from who serves it.
+
+| Directory | Served by |
+|-----------|-----------|
+| `plugins/agento11y/internal/skills/content/` | The `agento11y` binary, through `agento11y skills list` and `agento11y skills show <name>` |
+| `skills/`, `python/skills/` | `gcx`, which bundles them into its own binary |
+| `plugins/opencode/skills/` | The opencode plugin package |
+
+A skill the `agento11y` binary serves must live under `plugins/agento11y/internal/skills/content/<name>/SKILL.md`. It cannot live in the repo-root `skills/` directory: `go doc embed` says a `//go:embed` pattern may not contain `.` or `..` path elements, so the directive cannot reach upward past its own package.
+
+`cd plugins/agento11y && go test ./internal/skills/` checks every bundled `SKILL.md`: frontmatter delimiters, valid YAML, a `name` matching the directory, a non-empty `description`, and fewer than 500 lines. `mise run test:go:plugin` runs it from the repo root. Nothing checks the three other directories yet, which is how the broken frontmatter at `skills/agento11y-eval-starter/SKILL.md:3` merged.
+
 ## Consumer prompt lives in two places
 
 [`llms.txt`](llms.txt) is what this repo ships. There is a second copy of the same prompt rendered by the Agent Observability onboarding wizard (a separate Grafana product). When you change user-facing semantics here (new SDK field, renamed env var, new framework adapter), the wizard copy needs the same change. If you're only fixing this repo's internals, the wizard copy doesn't move.
+
+The `## Reference` section of `plugins/agento11y/internal/skills/content/setup-coding-agent/SKILL.md` restates the same consumer semantics a third time (config keys, tagging, capture modes, local mode, history import, auto-update), alongside `plugins/agento11y/README.md`. Renaming a config key means editing all of them, and nothing checks that they agree.
 
 ## Hook and experiment wire fixtures are checked by hand
 

--- a/llms.txt
+++ b/llms.txt
@@ -69,6 +69,10 @@ printf '%s' '<otlp-instance-id>:<glc_token>' | base64 | tr -d '\n'
 
 The user wants Grafana Agent observability to capture sessions from their coding agent. They do not write app code for this; they install a plugin and configure credentials.
 
+If the `agento11y` binary is already installed on this machine, run `agento11y skills show setup-coding-agent`. It prints a fuller version of everything below: doctor-based triage, troubleshooting, and the config reference.
+
+A binary older than that command prints `agento11y: unknown agent "skills"` and exits 2. If that happens, or the binary is not installed yet, continue here.
+
 ## Supported agents
 
 | Agent | Plugin | Mechanism |

--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -91,6 +91,27 @@ Then follow your agent's quickstart:
 - [pi](../pi/README.md)
 - [Vibe](../vibe/README.md)
 
+## Skills
+
+The binary carries agent skills: markdown workflows a coding agent reads and follows. They ship inside the binary, so there is nothing to fetch and no second CLI to install. Upgrading `agento11y` upgrades them.
+
+```sh
+agento11y skills list                          # name and one-line description
+agento11y skills show setup-coding-agent       # the raw SKILL.md on stdout
+```
+
+`get` is accepted as an alias for `show`, matching `gcx agent skills get`.
+
+`setup-coding-agent` walks a coding agent through the whole setup: reading `agento11y doctor --json`, installing the binary, saving credentials, wiring the host agent, verifying one session, and diagnosing a broken pipeline. To hand setup to the agent already open in your terminal, paste this:
+
+```text
+Run `agento11y skills show setup-coding-agent` and follow it to set up Grafana Agent observability for my coding agent.
+```
+
+`agento11y doctor` and `agento11y login` both name that command when they finish.
+
+The skills for instrumenting your own application code are separate and ship with [`gcx`](https://github.com/grafana/gcx) instead: `gcx agent skills install agento11y-instrument`.
+
 ## Tagging sessions
 
 Add `--tag key=value` (repeatable) before any `--` to attach tags to every generation the launched session produces. This is shorthand for setting `AGENTO11Y_TAGS`; flag tags merge onto (and override) any `AGENTO11Y_TAGS` already in the environment.
@@ -201,6 +222,8 @@ Each imported turn is recorded in a per-agent ledger under `~/.local/state/agent
 `AGENTO11Y_AUTO_UPDATE` does not apply to the other launchers. `agento11y copilot` rewrites its own `agento11y.json` hooks file, and `agento11y vibe` re-upserts its three entries into vibe's `hooks.toml`, so both always point at the installed binary. `agento11y pi` leaves upgrades to pi's own installer.
 
 ## Troubleshooting
+
+`agento11y help` (or `--help`, or `-h`) prints the full command list on stdout and exits 0. An unknown subcommand, or a command given the wrong number of arguments, prints a one-line usage form on stderr and exits 2.
 
 Run `agento11y doctor` first. It's a read-only diagnostic that reports both export pipelines, config, and installed host-agent plugins in one place. It sends a lightweight request to each endpoint and reports the HTTP status, so a wrong endpoint or a token missing a scope shows up as a broken pipeline:
 

--- a/plugins/agento11y/go.mod
+++ b/plugins/agento11y/go.mod
@@ -22,6 +22,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0
 	golang.org/x/term v0.44.0
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -63,5 +64,4 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/grpc v1.82.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/plugins/agento11y/internal/doctor/render.go
+++ b/plugins/agento11y/internal/doctor/render.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/skills"
 )
 
 // renderJSON writes the stable machine-readable report. encoding/json never
@@ -201,6 +202,7 @@ func renderHuman(w io.Writer, r *Report, color bool) {
 
 	// Summary.
 	writeSummary(&b, p, r)
+	writeSetupHint(&b, p, r)
 
 	_, _ = io.WriteString(w, b.flush(p))
 }
@@ -216,6 +218,17 @@ func writeMessages(b *reportBody, p palette, messages []string) {
 }
 
 func writeSummary(b *reportBody, p palette, r *Report) {
+	broken := brokenSections(r)
+	if len(broken) == 0 {
+		b.textf("%s %s\n", p.glyph(HealthOK), "no problems detected")
+		return
+	}
+	b.textf("%s %d problem(s): %s misconfigured\n", p.glyph(HealthError), len(broken), strings.Join(broken, ", "))
+}
+
+// brokenSections names the sections in error. The agent list is advisory and
+// never counts, matching Report.exitCode.
+func brokenSections(r *Report) []string {
 	var broken []string
 	if r.Conversations.Health == HealthError {
 		broken = append(broken, "conversations")
@@ -226,11 +239,34 @@ func writeSummary(b *reportBody, p palette, r *Report) {
 	if r.Config.Health == HealthError {
 		broken = append(broken, "config")
 	}
-	if len(broken) == 0 {
-		b.textf("%s %s\n", p.glyph(HealthOK), "no problems detected")
+	return broken
+}
+
+// needsSetup reports whether this machine has setup left to do: a section in
+// error, or a conversations pipeline that was never configured at all.
+//
+// The second case is the reason this is not just brokenSections. A machine
+// with no endpoint, no tenant and no token reports every pipeline as a
+// warning, never an error, so the summary above says "no problems detected".
+// That reader has wired nothing and needs the paste block most.
+func needsSetup(r *Report) bool {
+	return len(brokenSections(r)) > 0 || !r.Conversations.configured()
+}
+
+// writeSetupHint points the reader at the bundled setup skill. A machine with
+// setup left to do gets the two-line block, because pasting it hands the work
+// to the coding agent already in the terminal. A configured, healthy machine
+// gets one faint line, because a paste block after every healthy check is
+// noise.
+func writeSetupHint(b *reportBody, p palette, r *Report) {
+	b.textf("\n")
+	if !needsSetup(r) {
+		b.textf("%s\n", p.faint(skills.SetupCodingAgentOneLiner))
 		return
 	}
-	b.textf("%s %d problem(s): %s misconfigured\n", p.glyph(HealthError), len(broken), strings.Join(broken, ", "))
+	// The paste line stays at full contrast, so only the introduction is faint.
+	b.textf("%s\n", p.faint(skills.SetupCodingAgentHintIntro))
+	b.textf("%s\n", skills.SetupCodingAgentPasteLine)
 }
 
 // describeSource renders the faint "(detail, KEY, source)" trailer every row

--- a/plugins/agento11y/internal/doctor/render_golden_test.go
+++ b/plugins/agento11y/internal/doctor/render_golden_test.go
@@ -36,6 +36,7 @@ func TestRenderHumanGolden(t *testing.T) {
 		{name: "broken", report: goldenBrokenReport()},
 		{name: "probed", report: goldenProbedReport()},
 		{name: "redirected", report: goldenRedirectedReport()},
+		{name: "broken-config", report: brokenConfigReport()},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/plugins/agento11y/internal/doctor/render_hint_test.go
+++ b/plugins/agento11y/internal/doctor/render_hint_test.go
@@ -1,0 +1,71 @@
+package doctor
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/skills"
+)
+
+// TestRenderHuman_SetupHint pins which of the two footers each report ends
+// with. The golden files pin the bytes, but a blind `UPDATE_GOLDENS=1` reseed
+// accepts whatever the renderer produced, so this test is what fails when the
+// footer is dropped or the wrong branch fires.
+//
+// The minimal case is the one that matters most: a machine that has configured
+// nothing reports "no problems detected", and still needs the paste block. See
+// needsSetup.
+func TestRenderHuman_SetupHint(t *testing.T) {
+	cases := []struct {
+		name      string
+		report    *Report
+		wantBlock bool
+	}{
+		{name: "healthy and configured", report: goldenHealthyReport()},
+		{name: "nothing configured", report: goldenMinimalReport(), wantBlock: true},
+		{name: "config in error", report: brokenConfigReport(), wantBlock: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			renderHuman(&buf, tc.report, false)
+			out := buf.String()
+
+			block := skills.SetupCodingAgentHintIntro + "\n" + skills.SetupCodingAgentPasteLine
+			switch {
+			case tc.wantBlock:
+				if !strings.Contains(out, block) {
+					t.Errorf("report does not end with the paste block:\n%s", out)
+				}
+				if strings.Contains(out, skills.SetupCodingAgentOneLiner) {
+					t.Errorf("report printed the quiet one-liner too:\n%s", out)
+				}
+			default:
+				if !strings.Contains(out, skills.SetupCodingAgentOneLiner) {
+					t.Errorf("report does not end with the quiet one-liner:\n%s", out)
+				}
+				if strings.Contains(out, block) {
+					t.Errorf("report printed the multi-line paste block:\n%s", out)
+				}
+			}
+
+			// The footer is the last thing printed, after the summary.
+			trimmed := strings.TrimRight(out, "\n")
+			lastLine := trimmed[strings.LastIndex(trimmed, "\n")+1:]
+			if !strings.Contains(lastLine, skills.SetupCodingAgentCommand) {
+				t.Errorf("the footer is not the last line: %q", lastLine)
+			}
+		})
+	}
+}
+
+// brokenConfigReport is a report whose only failing section is config, so the
+// footer is driven by something other than the two pipelines. It is the fifth
+// golden fixture; see TestRenderHumanGolden.
+func brokenConfigReport() *Report {
+	r := goldenHealthyReport()
+	r.Config.Health = HealthError
+	r.Config.Messages = []string{"config.env is not readable"}
+	return r
+}

--- a/plugins/agento11y/internal/doctor/testdata/render/broken-config.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/broken-config.golden.txt
@@ -8,7 +8,7 @@ agento11y doctor v0.22.0
 ✓ Analytics (OTLP metrics & traces)
   endpoint:           https://otlp.example/otlp (AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT, env)
 
-✓ Config
+✗ Config
   file:               /home/u/.config/agento11y/config.env (present)
   content capture:    full (AGENTO11Y_CONTENT_CAPTURE_MODE, config.env)
   guards:             enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, config.env)
@@ -16,12 +16,14 @@ agento11y doctor v0.22.0
   auto tags:          user,repo resolved repo=grafana/agento11y, user=alice@example.com (AGENTO11Y_AUTO_CODING_AGENT_TAGS, config.env)
   local forwarding:   true (AGENTO11Y_LOCAL_FORWARD, env)
   local guard checks: forwarded to Cloud (tool calls, and the conversation an agent runs a preflight check on, are sent for evaluation whatever the capture mode)
+  ! config.env is not readable
 
 Coding agents
   claude:             installed v0.3.0
   codex:              not found on PATH
   cursor:             detected v0.22.0 (hook-based; configured in Cursor settings)
 
-✓ no problems detected
+✗ 1 problem(s): config misconfigured
 
-Setting up another coding agent? Run agento11y skills show setup-coding-agent.
+Need help? Paste this to your coding agent:
+Run `agento11y skills show setup-coding-agent` and follow it to set up Grafana Agent observability for my coding agent.

--- a/plugins/agento11y/internal/doctor/testdata/render/broken.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/broken.golden.txt
@@ -35,3 +35,6 @@ Coding agents
   auto-update:        disabled (AGENTO11Y_AUTO_UPDATE, config.env)
 
 ✗ 2 problem(s): conversations, analytics misconfigured
+
+Need help? Paste this to your coding agent:
+Run `agento11y skills show setup-coding-agent` and follow it to set up Grafana Agent observability for my coding agent.

--- a/plugins/agento11y/internal/doctor/testdata/render/minimal.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/minimal.golden.txt
@@ -19,3 +19,6 @@ Coding agents
   claude:          plugin not installed
 
 ✓ no problems detected
+
+Need help? Paste this to your coding agent:
+Run `agento11y skills show setup-coding-agent` and follow it to set up Grafana Agent observability for my coding agent.

--- a/plugins/agento11y/internal/doctor/testdata/render/probed.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/probed.golden.txt
@@ -28,3 +28,6 @@ Coding agents
   cursor:             detected v0.22.0 (hook-based; configured in Cursor settings)
 
 ✗ 2 problem(s): conversations, analytics misconfigured
+
+Need help? Paste this to your coding agent:
+Run `agento11y skills show setup-coding-agent` and follow it to set up Grafana Agent observability for my coding agent.

--- a/plugins/agento11y/internal/doctor/testdata/render/redirected.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/redirected.golden.txt
@@ -27,3 +27,6 @@ Coding agents
   cursor:             detected v0.22.0 (hook-based; configured in Cursor settings)
 
 ✗ 1 problem(s): conversations misconfigured
+
+Need help? Paste this to your coding agent:
+Run `agento11y skills show setup-coding-agent` and follow it to set up Grafana Agent observability for my coding agent.

--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -13,6 +13,8 @@
 //	agento11y cursor   install|uninstall                              — wire (or remove) the Cursor hook in ~/.cursor/hooks.json
 //	agento11y local start|status|stop                                 — manage the local capture daemon
 //	agento11y history import <agent> [flags]                          — backfill an agent's existing local sessions
+//	agento11y skills list|show <name>                                 — print an agent skill bundled into this binary
+//	agento11y help                                                    — print the expanded command list
 //	agento11y --version                                               — print the build version
 //
 // --tag is repeatable and adds key=value pairs to SIGIL_TAGS so they land
@@ -58,6 +60,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/local"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/login"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/skills"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/useragent"
 )
 
@@ -123,7 +126,7 @@ func localPrivacyLines(posture local.ForwardPosture, known bool) []string {
 func usageLine() string {
 	return "usage: agento11y login [--endpoint url] [--tenant id] [--token value|--token-stdin] " +
 		"[--otlp-endpoint url] [--no-verify] [--yes] | agento11y doctor [--json] | " +
-		"agento11y local start|status|stop | " +
+		"agento11y skills list|show <name> | agento11y local start|status|stop | " +
 		"agento11y history import <" + historyAgentNames() + "> | agento11y cursor install|uninstall | agento11y <agent> hook | " +
 		"agento11y <claude|codex|copilot|opencode|pi|vibe> [--local|--no-local] [--tag key=value]... [-- args...]"
 }
@@ -203,6 +206,13 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 		return
 	}
 
+	// `agento11y help` answers on stdout and exits 0, unlike the arity guard
+	// below, which is misuse and writes the one-line usage form to stderr.
+	if args[0] == "help" || args[0] == "--help" || args[0] == "-h" {
+		runHelpCommand(stdout)
+		return
+	}
+
 	// `agento11y login` is a top-level subcommand handled before launcher and
 	// hook dispatch so it can run without a verb argument and without an
 	// agent name. It owns its own flag parsing.
@@ -228,6 +238,13 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 	// dispatch like `local`. It owns its own flag parsing.
 	if args[0] == "doctor" {
 		runDoctorCommand(args[1:], stdout, stderr)
+		return
+	}
+
+	// `agento11y skills` sits next to `doctor`, above launcher and hook
+	// dispatch, so an agent named `skills` cannot shadow it.
+	if args[0] == skills.Command {
+		runSkillsCommand(args[1:], stdout, stderr)
 		return
 	}
 

--- a/plugins/agento11y/internal/entry/skills.go
+++ b/plugins/agento11y/internal/entry/skills.go
@@ -1,0 +1,107 @@
+package entry
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/skills"
+)
+
+// skillsUsage is the misuse form for `agento11y skills`. It names only `show`,
+// though `get` also works, because a usage line is there to get the command
+// run.
+const skillsUsage = "usage: agento11y " + skills.Command + " " + skills.ListVerb +
+	" | agento11y " + skills.Command + " " + skills.ShowVerb + " <name>"
+
+// listHint is the second stderr line on a failed lookup. It names the command
+// that lists the bundled skills.
+const listHint = "agento11y: run `agento11y " + skills.Command + " " + skills.ListVerb + "` to see the bundled skills"
+
+// runSkillsCommand dispatches `agento11y skills <verb>`. The skills ship
+// inside the binary, so no verb here reads the filesystem or the network. The
+// verbs come from internal/skills, which also owns the hints that print them.
+func runSkillsCommand(args []string, stdout, stderr io.Writer) {
+	if len(args) == 0 {
+		_, _ = fmt.Fprintln(stderr, skillsUsage)
+		exit(2)
+		return
+	}
+	switch args[0] {
+	case skills.ListVerb:
+		all := skills.All()
+		width := 0
+		for _, skill := range all {
+			if len(skill.Name) > width {
+				width = len(skill.Name)
+			}
+		}
+		for _, skill := range all {
+			_, _ = fmt.Fprintf(stdout, "%-*s  %s\n", width, skill.Name, skill.Description)
+		}
+	case skills.ShowVerb, skills.GetVerb:
+		if len(args) != 2 {
+			_, _ = fmt.Fprintln(stderr, skillsUsage)
+			exit(2)
+			return
+		}
+		skill, err := skills.Get(args[1])
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "agento11y: %v\n", err)
+			_, _ = fmt.Fprintln(stderr, listHint)
+			exit(2)
+			return
+		}
+		_, _ = io.WriteString(stdout, skill.Body)
+	default:
+		_, _ = fmt.Fprintf(stderr, "agento11y: unknown skills verb %q\n", args[0])
+		_, _ = fmt.Fprintln(stderr, skillsUsage)
+		exit(2)
+	}
+}
+
+// runHelpCommand prints the expanded command list, which the one-line
+// usageLine cannot carry.
+func runHelpCommand(stdout io.Writer) {
+	_, _ = io.WriteString(stdout, helpBody)
+	_, _ = fmt.Fprintf(stdout, "  %s\n\n", skills.SetupCodingAgentCommand)
+	_, _ = fmt.Fprintln(stdout, skills.SetupCodingAgentHintIntro)
+	_, _ = fmt.Fprintln(stdout, skills.SetupCodingAgentPasteLine)
+}
+
+// helpBody is every part of the help block that does not interpolate.
+//
+// The rows are hand-written, because run dispatches with a flat if-chain over
+// args[0] rather than a table a test can read. A new subcommand needs four
+// edits: run, this block, usageLine, and the list in
+// TestRun_HelpIsARealCommand. Only the launcher names are checked
+// automatically.
+const helpBody = `agento11y sends coding-agent sessions to Grafana Agent observability.
+
+Usage:
+  agento11y <command> [flags]
+
+Launch a coding agent (wires the plugin, then runs it):
+  claude, codex, copilot, opencode, pi, vibe
+      agento11y <name> [--local|--no-local] [--tag key=value]... [-- args...]
+  cursor install|uninstall
+      Wire (or remove) the Cursor hook. Cursor is a GUI app and has no launcher.
+
+Commands:
+  login       Save endpoint, tenant, token, and OTLP endpoint to config.env.
+  doctor      Check both export pipelines, the config, and installed plugins.
+  skills      List or print the agent skills bundled into this binary.
+  local       Manage the local capture daemon: start, status, stop.
+  history     Backfill sessions an agent wrote before agento11y was installed.
+  help        Print this text.
+
+  <agent> hook
+      Internal. Host agents call this with a JSON payload on stdin.
+
+Flags:
+  --version   Print the build version.
+  --help, -h  Print this text. Both are top-level forms: a subcommand given
+              the wrong arguments prints its own usage line instead.
+
+Skills:
+  agento11y skills list
+`

--- a/plugins/agento11y/internal/entry/skills_test.go
+++ b/plugins/agento11y/internal/entry/skills_test.go
@@ -1,0 +1,227 @@
+package entry
+
+import (
+	"bytes"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/skills"
+)
+
+// TestRun_SkillsList pins the listing surface: names and one-line descriptions
+// on stdout, nothing on stderr, no exit call.
+func TestRun_SkillsList(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"skills", "list"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	if gotExit != nil {
+		t.Fatalf("exit = %v, want no exit", *gotExit)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr non-empty: %q", stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, skills.SetupCodingAgentSkill) {
+		t.Errorf("listing does not name %q:\n%s", skills.SetupCodingAgentSkill, out)
+	}
+	// One line per skill, carrying both the name and a description.
+	for _, skill := range skills.All() {
+		var found bool
+		for line := range strings.SplitSeq(out, "\n") {
+			if strings.HasPrefix(line, skill.Name+" ") || line == skill.Name {
+				found = true
+				if !strings.Contains(line, firstWords(skill.Description)) {
+					t.Errorf("line for %q carries no description: %q", skill.Name, line)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("no line for skill %q:\n%s", skill.Name, out)
+		}
+	}
+	// The listed order is the sorted order, which is what makes the output
+	// stable across builds rather than dependent on the embed walk.
+	var listed []string
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		name, _, _ := strings.Cut(strings.TrimSpace(line), " ")
+		listed = append(listed, name)
+	}
+	if want := skills.Names(); !slices.Equal(listed, want) {
+		t.Errorf("listed %v, want %v:\n%s", listed, want, out)
+	}
+}
+
+// firstWords returns enough of a description to identify it on a line without
+// pinning the whole sentence.
+func firstWords(desc string) string {
+	fields := strings.Fields(desc)
+	if len(fields) > 4 {
+		fields = fields[:4]
+	}
+	return strings.Join(fields, " ")
+}
+
+// TestRun_SkillsShowPrintsRawFile pins that `show` writes the file itself,
+// frontmatter included, so a coding agent reading stdout gets the skill as it
+// ships. `get` is the gcx spelling and must print the same bytes.
+func TestRun_SkillsShowPrintsRawFile(t *testing.T) {
+	skill, err := skills.Get(skills.SetupCodingAgentSkill)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	outputs := map[string]string{}
+	for _, verb := range []string{skills.ShowVerb, skills.GetVerb} {
+		t.Run(verb, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			gotExit := withExit(t, func() {
+				run([]string{"skills", verb, skills.SetupCodingAgentSkill}, strings.NewReader(""), &stdout, &stderr)
+			})
+			if gotExit != nil {
+				t.Fatalf("exit = %v, want no exit", *gotExit)
+			}
+			if stderr.Len() != 0 {
+				t.Errorf("stderr non-empty: %q", stderr.String())
+			}
+			if stdout.String() != skill.Body {
+				t.Errorf("%s printed something other than the raw SKILL.md", verb)
+			}
+			outputs[verb] = stdout.String()
+		})
+	}
+	if outputs[skills.ShowVerb] != outputs[skills.GetVerb] {
+		t.Error("`skills get` output differs from `skills show`")
+	}
+}
+
+// TestPrintedSetupCommandRuns closes the loop the constant only half pins:
+// internal/skills owns the string doctor, login, and help print, but the words
+// in it have to be the words this package's dispatch accepts. Running the
+// constant is the only check that a renamed verb does not leave three surfaces
+// printing a command that exits 2.
+func TestPrintedSetupCommandRuns(t *testing.T) {
+	fields := strings.Fields(skills.SetupCodingAgentCommand)
+	if len(fields) < 2 || fields[0] != "agento11y" {
+		t.Fatalf("SetupCodingAgentCommand = %q, want it to start with the binary name", skills.SetupCodingAgentCommand)
+	}
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run(fields[1:], strings.NewReader(""), &stdout, &stderr)
+	})
+	if gotExit != nil {
+		t.Fatalf("running the printed command %q exited %d: %s", skills.SetupCodingAgentCommand, *gotExit, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "name: "+skills.SetupCodingAgentSkill) {
+		t.Errorf("the printed command did not print the skill:\n%s", stdout.String())
+	}
+}
+
+// TestRun_SkillsMisuseExits2 pins every way the command can be called wrong,
+// including the unknown top-level word, which turning help into a command must
+// not have turned into a command too. An unsafe name must be refused by the
+// name guard, not by a failed read, so nothing outside the embedded tree is
+// ever opened.
+func TestRun_SkillsMisuseExits2(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		wantErrs []string
+	}{
+		{name: "no verb", args: []string{"skills"}, wantErrs: []string{"usage:"}},
+		{name: "unknown verb", args: []string{"skills", "install"}, wantErrs: []string{`unknown skills verb "install"`}},
+		{name: "show without name", args: []string{"skills", "show"}, wantErrs: []string{"usage:"}},
+		{name: "get without name", args: []string{"skills", "get"}, wantErrs: []string{"usage:"}},
+		{name: "unknown skill", args: []string{"skills", "show", "nope"}, wantErrs: []string{"unknown skill", `"nope"`}},
+		{name: "traversal", args: []string{"skills", "show", "../etc/passwd"}, wantErrs: []string{"invalid skill name"}},
+		{name: "backslash", args: []string{"skills", "show", `..\windows`}, wantErrs: []string{"invalid skill name"}},
+		{name: "too many args", args: []string{"skills", "show", "a", "b"}, wantErrs: []string{"usage:"}},
+		{name: "unknown top-level word", args: []string{"nonsense"}, wantErrs: []string{"usage:"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			gotExit := withExit(t, func() {
+				run(tc.args, strings.NewReader(""), &stdout, &stderr)
+			})
+			if gotExit == nil || *gotExit != 2 {
+				t.Fatalf("exit = %v, want 2", gotExit)
+			}
+			if stdout.Len() != 0 {
+				t.Errorf("stdout non-empty on error: %q", stdout.String())
+			}
+			for _, want := range tc.wantErrs {
+				if !strings.Contains(stderr.String(), want) {
+					t.Errorf("stderr missing %q: %q", want, stderr.String())
+				}
+			}
+		})
+	}
+}
+
+// TestRun_HelpIsARealCommand pins that help answers on stdout and exits 0.
+// Before, `agento11y help` fell through to the arity guard, printed the usage
+// line to stderr, and exited 2.
+func TestRun_HelpIsARealCommand(t *testing.T) {
+	for _, alias := range []string{"help", "--help", "-h"} {
+		t.Run(alias, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			gotExit := withExit(t, func() {
+				run([]string{alias}, strings.NewReader(""), &stdout, &stderr)
+			})
+			if gotExit != nil {
+				t.Fatalf("exit = %v, want no exit (code 0)", *gotExit)
+			}
+			if stderr.Len() != 0 {
+				t.Errorf("stderr non-empty: %q", stderr.String())
+			}
+			out := stdout.String()
+			// Match the row, not the bare word. Every one of these words also
+			// occurs in prose elsewhere in the block ("skills" in the paste
+			// hint, "local" inside --local, "pi" inside "pipelines"), so a
+			// substring check would pass with the row deleted.
+			for _, want := range helpRows() {
+				if !strings.Contains(out, want) {
+					t.Errorf("help has no row %q:\n%s", want, out)
+				}
+			}
+			if !strings.Contains(out, "agento11y skills list") {
+				t.Errorf("help does not name `agento11y skills list`:\n%s", out)
+			}
+			if !strings.Contains(out, skills.SetupCodingAgentCommand) {
+				t.Errorf("help does not carry the setup hint %q:\n%s", skills.SetupCodingAgentCommand, out)
+			}
+		})
+	}
+}
+
+// helpRows is the row each top-level word must appear as in the help block.
+// The subcommand list is hand-written for the reason given at helpBody, so
+// adding a subcommand to run and forgetting this list is not caught.
+func helpRows() []string {
+	rows := []string{"\n  <agent> hook", "\n  cursor install|uninstall"}
+	for _, name := range []string{"login", "doctor", "skills", "local", "history", "help"} {
+		rows = append(rows, "\n  "+name+" ")
+	}
+	// The launchers share one comma-separated row, built from the launchers
+	// map so a new launcher fails this test until the row lists it too.
+	names := make([]string, 0, len(launchers))
+	for name := range launchers {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return append(rows, "\n  "+strings.Join(names, ", ")+"\n")
+}
+
+// TestUsageLineNamesSkills pins that the one-line stderr form learned the new
+// subcommand. It stays one line: it is what misuse prints, not a help page.
+func TestUsageLineNamesSkills(t *testing.T) {
+	got := usageLine()
+	if !strings.Contains(got, "agento11y skills list|show <name>") {
+		t.Errorf("usageLine does not offer skills: %q", got)
+	}
+	if strings.Contains(got, "\n") {
+		t.Errorf("usageLine spans lines: %q", got)
+	}
+}

--- a/plugins/agento11y/internal/login/login.go
+++ b/plugins/agento11y/internal/login/login.go
@@ -59,6 +59,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/doctor"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/dotenv"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/skills"
 	"golang.org/x/term"
 )
 
@@ -1328,6 +1329,9 @@ func printNextStep(w io.Writer, outcome verifyOutcome, origin string) {
 		// Unreachable: a failed check that was not overridden writes
 		// nothing, so there is no saved configuration to hint about.
 	}
+	// Credentials are saved, but a coding agent still has to be wired up. The
+	// skill walks that part. Doctor prints the same command.
+	fmt.Fprintln(w, faint.Render("Setting up a coding agent? Run ")+cmd.Render(skills.SetupCodingAgentCommand)+faint.Render("."))
 	fmt.Fprintln(w, faint.Render("View observability data at ")+link.Render(observabilityPageURL(origin)))
 	fmt.Fprintln(w, faint.Render("Read documentation at ")+link.Render(docsURL))
 }

--- a/plugins/agento11y/internal/login/login_test.go
+++ b/plugins/agento11y/internal/login/login_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/doctor"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/dotenv"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/skills"
 )
 
 // nonTTYStdin returns a file that is guaranteed not to be a terminal.
@@ -1991,6 +1992,15 @@ func TestPrintNextStep(t *testing.T) {
 			if !strings.Contains(got, "agento11y claude") {
 				t.Errorf("next step must still name the launchers:\n%s", got)
 			}
+			// The skill line comes after the doctor line: a user who ran login
+			// reads the diagnostic first and the setup handoff second.
+			doctorAt := strings.Index(got, "agento11y doctor")
+			skillAt := strings.Index(got, skills.SetupCodingAgentCommand)
+			if skillAt < 0 {
+				t.Errorf("next step does not name %q:\n%s", skills.SetupCodingAgentCommand, got)
+			} else if doctorAt < 0 || skillAt < doctorAt {
+				t.Errorf("the skill line must follow the doctor line:\n%s", got)
+			}
 			for _, want := range c.want {
 				if !strings.Contains(got, want) {
 					t.Errorf("output missing %q:\n%s", want, got)
@@ -2032,6 +2042,12 @@ func TestRun_NextStepOnlyWhenAsked(t *testing.T) {
 			}
 			if got := strings.Contains(stderr, "agento11y doctor"); got != show {
 				t.Errorf("next-step hint printed = %v, want %v:\n%s", got, show, stderr)
+			}
+			// The launcher's automatic login leaves ShowNextStep false and is
+			// about to start the agent, so it must not print the setup handoff
+			// either.
+			if got := strings.Contains(stderr, skills.SetupCodingAgentCommand); got != show {
+				t.Errorf("skill hint printed = %v, want %v:\n%s", got, show, stderr)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/skills/content/setup-coding-agent/SKILL.md
+++ b/plugins/agento11y/internal/skills/content/setup-coding-agent/SKILL.md
@@ -1,0 +1,489 @@
+---
+name: setup-coding-agent
+description: >-
+  Set up Grafana Agent observability for a coding agent (Claude Code, Codex,
+  Copilot CLI, Cursor, OpenCode, pi, or Vibe) with the agento11y binary:
+  install it, save credentials, wire the agent, verify a session reaches
+  Grafana Cloud, and diagnose a broken pipeline. Use when the user says "set
+  up agento11y", "monitor my coding agent", "agento11y doctor says something
+  is wrong", "my sessions do not show up in Grafana", or asks why
+  conversations arrive but analytics stay empty.
+---
+
+# Set up a coding agent with Grafana Agent observability
+
+Grafana Agent observability records model calls, tokens, timing, tool names, and
+reported or estimated cost. Conversation content is opt-in. The `agento11y`
+binary launches agents and hosts hook-based integrations; pi and OpenCode export
+in process. This path installs and configures the integration. It never changes
+the user's application code.
+
+Do the steps the machine's current state calls for, not all five. Step 1 says
+where to start: a machine that needs one credential re-saved does not need a
+reinstall, and a working setup the user asked a question about needs no changes
+at all.
+
+## Rules
+
+1. **Never mint, generate, or guess a credential.** The token is a Grafana Cloud
+   access-policy token that only the user can create. Ask for it, or tell the
+   user where to click. A made-up token produces a 401.
+2. **Never invent an endpoint URL.** The API URL and the OTLP endpoint come from
+   the setup page of the user's own stack (Step 3). Do not assemble one from the
+   stack name; regions differ.
+3. **Never print or echo a token, and never ask for the connection block in
+   chat.** The block the setup page hands out carries a live token, and this
+   conversation can be exported. The user pastes it into login's own prompt. A
+   token you have to pass yourself goes in over stdin with `--token-stdin`.
+4. **Do not edit application code.** Adding SDK calls to the user's app is a
+   different job ("Path B"). If the user wants their own app or agent
+   instrumented, stop and hand off to the `agento11y-instrument` skill, which
+   ships with the `gcx` CLI (`gcx agent skills install agento11y-instrument`).
+5. **Do not enable full content capture or guards without asking.** The default,
+   `metadata_only`, excludes prompts, responses, and tool I/O from generation
+   exports. `full` sends that content to Grafana Cloud. Guards send the content
+   they evaluate to `AGENTO11Y_ENDPOINT` regardless of capture mode. Local
+   mode is separate: it always captures full content in the local store.
+
+## Step 1: Read the current state
+
+Run this first, every time, before changing anything:
+
+```sh
+agento11y doctor --json
+```
+
+If the command is not found, the binary is not installed: go to Step 2.
+
+Branch on these fields. The JSON also reports auto-update state:
+
+| Field | Meaning | Where to go |
+| --- | --- | --- |
+| `agento11y.version` | The installed build. `dev` is an unstamped build, including one installed with `go install`. Always present when the command runs. | command not found: Step 2 |
+| `config.exists` | Whether the resolved config file exists. | `false`: Step 3 |
+| `conversations.status` | The transcript pipeline: `ok`, `warning`, `error`. | `error`: Troubleshooting |
+| `analytics.status` | The OTLP metrics and traces pipeline. | `error`: Troubleshooting |
+| `agents[]` | One entry per coding agent, with `install_state` and `on_path`. | target agent `not_installed`: Step 4 |
+
+Cursor is hook-based and always reports `install_state: unknown`; doctor cannot
+inspect `~/.cursor/hooks.json`. Do not use that field to decide whether Cursor is
+wired. Run `agento11y cursor install` when the user wants Cursor wired;
+re-running it is safe.
+
+`agento11y doctor` exits 1 when conversations, analytics, or config is in
+`error`. The agent list never fails the command: an agent the user does not have
+is reported, not treated as a problem.
+
+Run `agento11y doctor` without `--json` when you want the human report, and
+share `--json` output when the user asks for something to send to support. The
+JSON never contains the token value. It can contain a short token-scheme prefix,
+such as `glc_`.
+
+## Step 2: Install the binary
+
+Pick one method that matches the platform and how the user installs other tools.
+
+**Quick install (Linux and macOS):**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/grafana/agento11y/main/plugins/agento11y/scripts/install.sh | sh
+```
+
+The script downloads the latest release for the OS and architecture and installs
+to `~/.local/bin`. It verifies the SHA-256 when `sha256sum` or `shasum` is
+available; otherwise it warns and continues. Re-run it to upgrade. `INSTALL_DIR`
+changes the directory and `VERSION` pins a release.
+
+**Homebrew (macOS):**
+
+```sh
+brew install grafana/grafana/agento11y
+```
+
+Upgrade with `brew upgrade grafana/grafana/agento11y`.
+
+**Go install (any platform with Go 1.25.7+):**
+
+```sh
+go install github.com/grafana/agento11y/plugins/agento11y/cmd/agento11y@latest
+```
+
+This writes to `go env GOPATH`/bin, or `GOBIN` when set. On Windows the other
+option is the `windows_amd64` or `windows_arm64` zip from the releases page:
+extract `agento11y.exe` and put it on `PATH`.
+
+Whichever method you use, the install directory has to be on `PATH`. Check the
+result:
+
+```sh
+agento11y --version
+```
+
+The command was renamed from `sigil`. The quick installer and Homebrew also
+install a `sigil` alias. `go install` installs only the binary you name. The old
+name will be removed in a future release, so do not write new instructions
+against `sigil`.
+
+## Step 3: Save credentials
+
+`agento11y login` writes credentials to `$XDG_CONFIG_HOME/agento11y/config.env`,
+or `~/.config/agento11y/config.env` when `XDG_CONFIG_HOME` is unset. The user can
+paste a block from their stack or pass values as flags. The paste flow is normal.
+
+### The paste flow
+
+Tell the user to run `agento11y login` in their own terminal, then wait. You
+cannot drive it yourself: it needs a terminal, and the block it asks for holds a
+live token that must not pass through this conversation. What the user sees:
+
+1. **Your Grafana Cloud URL**: the Grafana they open in a browser, for example
+   `https://mystack.grafana.net`. The field arrives pre-filled from the stack an
+   earlier run saved or from a gcx configuration, and becomes a list when more
+   than one is known. It only builds the links below; it is never the ingest
+   endpoint.
+2. Login prints `https://<stack>/a/grafana-agento11y-app/setup-coding-agent` and
+   tries to open it in a browser. That page has three steps: create an API token,
+   copy the connection settings, and paste them back in the terminal. The page
+   creates the token when the user has permission and the stack supports it.
+   Otherwise it links to Cloud Access Policies and accepts an existing token.
+3. **Paste from Grafana**: the whole block goes into this one masked field, which
+   fills the endpoint, instance ID, token, and OTLP settings. Login then asks
+   only for what the block did not carry. Pasting is optional: Enter on the empty
+   box types the values field by field instead.
+4. **Preferences**: content capture mode, session tags, guards and their timeout,
+   and automatic tags. Enter keeps the current behavior, which is the answer
+   unless the user asks otherwise. Read the privacy warning in Rule 5 before
+   enabling full capture or guards. Read **Automatic tags** below before enabling
+   automatic tags; Yes opens a second checklist for the values to attach.
+
+The copied block has concrete values in this shape:
+
+```dotenv
+AGENTO11Y_ENDPOINT=https://agento11y-prod-<region>.grafana.net
+AGENTO11Y_PROTOCOL=http
+AGENTO11Y_AUTH_MODE=basic
+AGENTO11Y_AUTH_TENANT_ID=<instance-id>
+AGENTO11Y_AUTH_TOKEN=glc_...
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
+OTEL_EXPORTER_OTLP_HEADERS='Authorization=Basic <base64-value>'
+```
+
+A stack with no OTLP gateway has neither `OTEL_*` line, so conversations work
+but analytics does not. Login rejects placeholders in values it takes from the
+block; a flag can replace a block slot. It ignores pasted protocol and auth-mode
+values because the launcher hardcodes HTTP and Basic. Existing config keys stay.
+
+For both pipelines, the token needs `sigil:write`, `metrics:write`, and
+`traces:write`. One token covers them. A generated policy can carry extra scopes;
+the integrations use only these three.
+
+### The flags
+
+`--endpoint`, `--tenant`, and a token together skip the value prompts, so this
+form works over SSH, in a devcontainer, and from a script. A failed credential
+check can still prompt on an interactive terminal. Use this form for values the
+user has already given you.
+
+```sh
+printf %s "$TOKEN" | agento11y login \
+  --endpoint https://agento11y-prod-<region>.grafana.net \
+  --tenant <instance-id> \
+  --token-stdin \
+  --otlp-endpoint https://otlp-gateway-prod-<region>.grafana.net/otlp
+```
+
+Before writing the file, login sends one request to the endpoint with the
+credentials and reports what came back. If that check fails, what happens next
+depends on the terminal. Interactively, login asks whether to save anyway. In a
+script the question is never asked, because a piped stdin is not a terminal:
+login writes nothing and exits 1. Pass `--yes` to save the values regardless, or
+`--no-verify` to skip the check. The preferences have no flags.
+
+Login writes to the resolved config path described above. An install that still
+has only the old `sigil/config.env` under the same config root keeps using that
+file. You can write it by hand instead:
+
+```dotenv
+AGENTO11Y_ENDPOINT=https://agento11y-prod-<region>.grafana.net
+AGENTO11Y_AUTH_TENANT_ID=<instance-id>
+AGENTO11Y_AUTH_TOKEN=glc_...
+AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
+```
+
+A hand-written file needs no OTLP auth header. When
+`OTEL_EXPORTER_OTLP_HEADERS` has no `Authorization` entry, the launcher builds
+Basic authorization from the tenant ID and the first available OTLP or ingest
+token.
+
+## Step 4: Wire the coding agent
+
+Six agents launch through `agento11y <agent>`. On a normal first run, the
+command prompts for credentials, installs the host integration, and then replaces
+itself with the agent. It skips login in local mode and when no terminal is
+available. Existing integrations follow the **Auto-update** rules in the
+Reference.
+
+| Agent | Command | Mechanism |
+| --- | --- | --- |
+| Claude Code | `agento11y claude` | shared Go binary, plugin `agento11y-claude-code` |
+| Codex | `agento11y codex` | shared Go binary, plugin `agento11y-codex` |
+| Copilot CLI | `agento11y copilot` | hooks shared with Copilot Chat in VS Code |
+| OpenCode | `agento11y opencode` | installs `@grafana/agento11y-opencode` |
+| pi | `agento11y pi` | installs `@grafana/agento11y-pi` |
+| Vibe | `agento11y vibe` | shared Go binary via `hooks.toml` |
+
+After the first `agento11y codex` launch, open `/hooks` inside Codex and trust
+the agento11y hooks. Codex does not export turns until the user completes this
+manual step, and doctor cannot detect whether they did.
+
+Vibe hooks are experimental. The launcher enables them in the child process, so
+launch Vibe through `agento11y vibe` for capture.
+
+**Cursor is the exception.** It is a GUI application with no launcher, so wire
+it directly:
+
+```sh
+agento11y cursor install     # merges the hook into ~/.cursor/hooks.json
+agento11y cursor uninstall   # removes it
+```
+
+On macOS and Linux, re-run `agento11y cursor install` after moving the binary;
+Cursor's hook stores its absolute path.
+
+Arguments after `--` go to the underlying CLI unchanged:
+
+```sh
+agento11y claude -- --resume
+```
+
+Suggest the user alias the prefix (for example `alias claude='agento11y claude'`)
+only if they ask; silently shadowing their agent command is surprising.
+
+## Step 5: Verify
+
+1. Run the agent for one turn. Any prompt will do.
+2. Open Grafana Cloud, then Agent Observability, then **Conversations**. It
+   usually appears within a few seconds; if it does not, continue to step 3.
+3. If nothing appears, run `agento11y doctor`. For Codex, also confirm that the
+   user trusted the hooks from `/hooks`. Read launcher stderr for lines starting
+   with `agento11y:`.
+
+Confirm both pipelines. Conversations and analytics fail independently. If
+conversations arrive while **Analytics** stays empty, check the OTLP pipeline.
+
+## Troubleshooting
+
+`agento11y doctor` is the first command for every problem. It is read-only. When
+the required settings exist, it sends one conversations probe plus separate
+metrics and traces probes, then reports their HTTP statuses. Some non-success
+responses are warnings rather than errors, so read each probe message as well as
+the section status.
+
+### The two pipelines
+
+They are independent and fail independently.
+
+- **Conversations** (the chat transcripts) export over `AGENTO11Y_ENDPOINT`,
+  `AGENTO11Y_AUTH_TENANT_ID`, and `AGENTO11Y_AUTH_TOKEN`. The token needs the
+  `sigil:write` scope.
+- **Analytics** (the metrics and traces) export over
+  `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT`, or the vendor-neutral
+  `OTEL_EXPORTER_OTLP_ENDPOINT`. The token needs `metrics:write` and
+  `traces:write`.
+
+If conversations work while analytics stays empty, the OTLP endpoint may be
+unset, the token may lack the metrics or traces scope, or the OTLP export may be
+failing for another reason. Doctor names the missing-endpoint case and probes
+both signals when an endpoint is set.
+
+### Reading the report row by row
+
+- **endpoint** and **tenant id**: the resolved value plus the variable it came
+  from. `not set` means neither spelling was found. Doctor names the winning
+  spelling because both `AGENTO11Y_*` and the older `SIGIL_*` are accepted.
+- **auth token**: `set` plus a short prefix. The value is never printed.
+- **probe**: the HTTP status and URL. Analytics has separate **metrics probe**
+  and **traces probe** rows. `no response` includes DNS, connection, timeout, TLS,
+  and blocked-network failures.
+- **file**: the config path and whether it exists.
+- **content capture**: the effective mode and where it came from. An invalid
+  value falls back to `metadata_only` and the section message names the variable
+  to fix.
+- **guards**: `disabled`, or `enabled` with the timeout and fail-open/fail-closed
+  mode. With local forwarding, **local guard checks** says whether guard content
+  reaches Grafana Cloud.
+- **Coding agents**: one row per agent. `not found on PATH` means doctor cannot
+  find that CLI. `on PATH, plugin not installed` describes current state; the
+  integration may never have been installed, may have been removed, or may be
+  installed for another scope. `install state unknown` means the read-only probe
+  could not determine the state. Cursor has no install probe. Its human row says
+  `detected <version>` when Cursor is on PATH; only JSON reports it as unknown.
+
+### Status codes
+
+- **401 on conversations**: the token may be invalid, expired, or missing
+  `sigil:write`; the tenant ID may also be wrong. Sigil reports all of these as
+  rejected credentials.
+- **401 on analytics**: the OTLP credentials were rejected.
+- **403**: check the scope named in the probe message. Grafana's OTLP gateway can
+  use this for missing `metrics:write` or `traces:write`; doctor also handles it
+  defensively for conversations.
+- **Any redirect on the conversations probe**: `AGENTO11Y_ENDPOINT` is not an
+  API URL. A bare stack URL can redirect to login. Doctor rejects a Grafana app
+  page before probing it. Re-run `agento11y login` and paste the block again.
+
+### Debug logging
+
+Once a valid hook command is dispatched, hook failures and panics are swallowed
+so they do not crash the host agent. An invalid command line can still exit 2.
+Turn on the log for hook detail:
+
+```dotenv
+# ~/.config/agento11y/config.env
+AGENTO11Y_DEBUG=true
+```
+
+Then read it:
+
+```sh
+tail -f ~/.local/state/agento11y/logs/agento11y.log
+```
+
+An install that still has the pre-rename `~/.local/state/sigil` directory keeps
+using it, with the new `agento11y.log` file name.
+
+## Reference
+
+### Config keys
+
+All hosts read the resolved config path. The default is
+`~/.config/agento11y/config.env`; `$XDG_CONFIG_HOME` changes the config root.
+
+| Key | Meaning |
+| --- | --- |
+| `AGENTO11Y_ENDPOINT` | Conversations API URL |
+| `AGENTO11Y_AUTH_TENANT_ID` | Instance ID |
+| `AGENTO11Y_AUTH_TOKEN` | Access-policy token |
+| `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint for metrics and traces |
+| `AGENTO11Y_STACK_URL` | The stack login asks about; builds links only, never ingest |
+| `AGENTO11Y_CONTENT_CAPTURE_MODE` | Which content fields ship (see below) |
+| `AGENTO11Y_TAGS` | `key=value,key=value` attached to every generation |
+| `AGENTO11Y_AUTO_CODING_AGENT_TAGS` | Opt-in automatic user, repo, and branch tags |
+| `AGENTO11Y_GUARDS_ENABLED` | Send supported preflight and tool calls for guard evaluation |
+| `AGENTO11Y_GUARDS_TIMEOUT_MS` | Guard evaluation timeout in milliseconds |
+| `AGENTO11Y_GUARDS_FAIL_OPEN` | Allow the operation when guard evaluation fails |
+| `AGENTO11Y_LOCAL` | Route `agento11y <agent>` launches to the local daemon |
+| `AGENTO11Y_LOCAL_FORWARD` | Forward local-mode captures to Grafana Cloud |
+| `AGENTO11Y_AUTO_UPDATE` | A false value opts out of host-plugin refresh |
+| `AGENTO11Y_DEBUG` | A true value writes the debug log |
+
+All branded keys except `AGENTO11Y_STACK_URL` have an older `SIGIL_*` spelling.
+Doctor reports provenance only for settings in its report.
+
+### Tagging sessions
+
+`--tag key=value` is repeatable and goes before any `--`. It attaches tags to
+every generation the launched session produces, and merges onto (and overrides)
+`AGENTO11Y_TAGS`:
+
+```sh
+agento11y claude --tag project=hackathon --tag team=ai -- --resume
+```
+
+Every CLI launcher accepts it. Cursor has no launcher; set `AGENTO11Y_TAGS` in
+the config file for Cursor sessions.
+
+### Automatic tags
+
+`AGENTO11Y_AUTO_CODING_AGENT_TAGS=true` resolves the session's user, repository,
+and branch and attaches them as **client** tags, which are the tags that also
+become OTel metric labels. That is what lets the Usage and Cost view break down
+by person, repository, or branch. The switch is off by default, and on its own
+it enables all three names.
+
+| Name | Tag key | Resolved from |
+| --- | --- | --- |
+| `user` | `user` | `AGENTO11Y_USER_ID`, then the signed-in Claude Code or Cursor identity when available, then the OS account name |
+| `repo` | `repo` | Full namespace from the checkout's `origin` remote, or the checkout directory name |
+| `branch` | `git.branch` | Checked-out branch, or a short commit SHA on detached HEAD |
+
+Narrow the list with `AGENTO11Y_AUTO_CODING_AGENT_TAGS_NAMES=user,repo`. A key
+already in `AGENTO11Y_TAGS` wins, an unresolved value leaves its key off, and an
+unsupported name is logged and skipped. In Prometheus these arrive as
+`agento11y_tag_user`, `agento11y_tag_repo`, and `agento11y_tag_git_branch`.
+
+Warn the user before enabling this. For Claude Code and Cursor, `user` can be a
+work email address retained as a Prometheus label. Each value combination creates
+a time series, and branch names are unbounded. Start with `user,repo`. Doctor
+shows repo and branch but cannot read a host's signed-in identity; set
+`AGENTO11Y_USER_ID` when the user value must be known before launch.
+
+### Content capture
+
+For coding agents, use only these modes:
+
+| Mode | What ships in generation exports |
+| --- | --- |
+| `metadata_only` | Model, tokens, timing, IDs, tool names, and cost when available. Prompts, responses, and tool I/O are omitted. |
+| `full` | Conversation content, including tool arguments and results. Host APIs can omit or truncate fields they do not expose in full. |
+
+Set the mode with `AGENTO11Y_CONTENT_CAPTURE_MODE`. It defaults to
+`metadata_only`. Unknown values fall back to `metadata_only` with a warning.
+Every plugin redacts known secret formats from captured content, but capture mode
+chooses which fields ship, not whether the shipped fields are clean. Treat
+`full` as opt-in on shared machines.
+
+Local mode overrides the configured mode and captures full content in its store.
+
+### Local mode
+
+`agento11y <agent> --local` records full content in a JSONL store and serves a
+viewer. It tries `http://127.0.0.1:8765`, then higher ports, and prints the URL;
+it does not open a browser. Cloud forwarding also requires
+`AGENTO11Y_LOCAL_FORWARD` and valid Cloud settings. Manage the daemon with
+`agento11y local start|status|stop|restart`.
+
+Local mode covers launches that go through `agento11y <agent>`, and nothing
+else. A session the host agent starts on its own, such as Cursor or a plain
+`claude`, keeps exporting to the configured endpoint. Never describe local mode
+to the user as a switch that keeps all data on the machine. Doctor prints this
+correction when `AGENTO11Y_LOCAL` is enabled in the environment or config file;
+it cannot see a one-off `--local` flag after the launch.
+
+`--no-local` runs one session against Cloud while `AGENTO11Y_LOCAL=true` stays
+set.
+
+### History import
+
+The viewer and Grafana Cloud both start empty: they hold only sessions captured
+after the install. `agento11y history import` backfills sessions an agent
+already wrote to disk. Supported agents are `claude-code`, `codex`, and `pi`.
+
+```sh
+agento11y history import claude-code --dry-run   # plan only, nothing exported
+agento11y history import claude-code --local     # use the local daemon
+agento11y history import claude-code             # use AGENTO11Y_ENDPOINT
+```
+
+Without `--since`, an import selects sessions active during the last 90 days.
+Each imported turn is recorded in a per-agent ledger. The ledger does not include
+the destination. If the same turns must go first to local storage and later to
+Grafana Cloud, use `--force` for the second import; otherwise the ledger skips
+them. A cancelled or failed run resumes from turns not marked exported.
+
+Without a terminal there is no picker or confirmation. Without `--all --yes`,
+the command prints a dry-run plan, imports nothing, and exits 0. Pass both flags
+from a script that should export data.
+
+### Auto-update
+
+Claude, Codex, and OpenCode refresh after a binary version change and, after
+the first post-install refresh, at most once a day. A relaunch inside that period
+does not pick up a plugin fix. `AGENTO11Y_AUTO_UPDATE=0|false|no|off` opts out.
+Copilot and Vibe reconcile hooks on each launch. Pi leaves upgrades to pi's
+installer.
+
+## Further reading
+
+- Product docs: <https://grafana.com/docs/grafana-cloud/machine-learning/agent-observability/>
+- Source: <https://github.com/grafana/agento11y>

--- a/plugins/agento11y/internal/skills/skills.go
+++ b/plugins/agento11y/internal/skills/skills.go
@@ -1,0 +1,210 @@
+// Package skills serves the agent skills bundled into the agento11y binary.
+//
+// A skill is a markdown file a coding agent reads to learn a workflow. These
+// ship inside the binary rather than being fetched, so `agento11y skills show
+// <name>` works with no registry, no network, and no second CLI to install.
+// The cost is that a skill fix reaches a user only when the binary is
+// upgraded.
+//
+// The content tree must live under this package. A //go:embed pattern cannot
+// contain "." or ".." path elements, so it cannot reach the repository-root
+// skills/ directory, which holds the content gcx distributes instead.
+//
+// This package also owns the words the command is spelled with (Command,
+// ListVerb, ShowVerb, GetVerb) and the setup hint text. internal/entry
+// dispatches on those constants, internal/doctor prints the hint, and
+// internal/login prints the command inside a sentence of its own.
+package skills
+
+import (
+	"embed"
+	"errors"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The content tree is SKILL.md files only. Plain `content` (rather than
+// `all:content`) keeps a stray dot-file such as content/.DS_Store out of the
+// binary and out of Names().
+//
+//go:embed content
+var content embed.FS
+
+// contentRoot is the embedded directory each skill lives in as
+// content/<name>/SKILL.md.
+const contentRoot = "content"
+
+// skillFile is the one file a skill directory must hold.
+const skillFile = "SKILL.md"
+
+// SetupCodingAgentSkill is the skill that walks a coding agent through
+// configuring agento11y for a coding agent (llms.txt "Path A").
+const SetupCodingAgentSkill = "setup-coding-agent"
+
+// The words `agento11y skills` is spelled with. internal/entry dispatches on
+// these rather than on its own literals, so renaming one here renames both the
+// command and every hint that prints it.
+const (
+	// Command is the top-level word, as in `agento11y skills`.
+	Command = "skills"
+	// ListVerb prints one line per bundled skill.
+	ListVerb = "list"
+	// ShowVerb prints one skill. It is the spelling every printed hint uses.
+	ShowVerb = "show"
+	// GetVerb is what the sibling gcx CLI calls the same operation, accepted
+	// so an agent that pattern-matches that CLI also works.
+	GetVerb = "get"
+)
+
+// SetupCodingAgentCommand is the exact command doctor, login, and help print.
+// It is built from the dispatch words above so the printed command and the
+// accepted command cannot differ.
+const SetupCodingAgentCommand = "agento11y " + Command + " " + ShowVerb + " " + SetupCodingAgentSkill
+
+// The setup hint, in the two shapes the callers print.
+//
+// Both start at column 0. The doctor report reads an indented line as a
+// key/value row, and its grammar check fails on any indented line that is not
+// one.
+const (
+	// SetupCodingAgentHintIntro tells the reader what the line below it is
+	// for. Callers render it faint.
+	SetupCodingAgentHintIntro = "Need help? Paste this to your coding agent:"
+	// SetupCodingAgentPasteLine is the line a user copies into a coding agent.
+	// Callers render it at full contrast, because it is meant to be read and
+	// copied.
+	SetupCodingAgentPasteLine = "Run `" + SetupCodingAgentCommand + "` and follow it to set up Grafana Agent observability for my coding agent."
+	// SetupCodingAgentOneLiner is the quiet form, printed when there is
+	// nothing to fix. A paste block on every healthy run is noise.
+	SetupCodingAgentOneLiner = "Setting up another coding agent? Run " + SetupCodingAgentCommand + "."
+)
+
+var (
+	// ErrNotFound reports a name that no bundled skill uses.
+	ErrNotFound = errors.New("unknown skill")
+	// ErrUnsafeName reports a name that is a path rather than a bare skill
+	// name. Rejecting it keeps a lookup inside the embedded tree.
+	ErrUnsafeName = errors.New("invalid skill name")
+)
+
+// Skill is one bundled skill.
+type Skill struct {
+	// Name is the directory name under content/, which the frontmatter must
+	// repeat.
+	Name string
+	// Description is the frontmatter description with runs of whitespace
+	// collapsed to single spaces, so a folded scalar prints on one line.
+	Description string
+	// Body is the complete SKILL.md, frontmatter included, exactly as it ships.
+	Body string
+}
+
+// Names returns every bundled skill name, sorted.
+func Names() []string {
+	return namesFrom(content)
+}
+
+// namesFrom lists the skill directories in fsys. A directory counts only when
+// it holds a SKILL.md, so every name Names returns is one Get resolves.
+func namesFrom(fsys fs.FS) []string {
+	entries, err := fs.ReadDir(fsys, contentRoot)
+	if err != nil {
+		// The tree is compiled in, so a read failure means the binary was built
+		// without it. There is nothing to recover from and nothing to list.
+		return nil
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := fs.Stat(fsys, contentRoot+"/"+e.Name()+"/"+skillFile); err != nil {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	return names
+}
+
+// All returns every bundled skill, sorted by name. A caller that lists the
+// skills wants the descriptions too, and going through All means it never has
+// to handle a lookup failure for a name the package itself produced.
+func All() []Skill {
+	names := Names()
+	all := make([]Skill, 0, len(names))
+	for _, name := range names {
+		skill, err := Get(name)
+		if err != nil {
+			// Names only returns a directory that holds a SKILL.md, so a
+			// failure here means the tree changed underneath us. Skipping is
+			// better than a partial listing that ends in an error.
+			continue
+		}
+		all = append(all, skill)
+	}
+	return all
+}
+
+// Get returns one bundled skill. A name containing a path separator, a "..",
+// or nothing at all is rejected before any read, so a lookup can never leave
+// the embedded tree.
+func Get(name string) (Skill, error) {
+	if !safeName(name) {
+		return Skill{}, fmt.Errorf("%w: %q", ErrUnsafeName, name)
+	}
+	body, err := content.ReadFile(contentRoot + "/" + name + "/" + skillFile)
+	if err != nil {
+		return Skill{}, fmt.Errorf("%w: %q", ErrNotFound, name)
+	}
+	return Skill{
+		Name:        name,
+		Description: parseDescription(string(body)),
+		Body:        string(body),
+	}, nil
+}
+
+// safeName reports whether name is a bare directory name. It mirrors the
+// guard in internal/local.serveStatic.
+func safeName(name string) bool {
+	return name != "" &&
+		!strings.Contains(name, "/") &&
+		!strings.Contains(name, `\`) &&
+		!strings.Contains(name, "..")
+}
+
+// splitFrontmatter separates the YAML frontmatter from the rest of the file.
+// Frontmatter opens with a --- line and closes with the next one.
+func splitFrontmatter(body string) (front, rest string, ok bool) {
+	const delim = "---\n"
+	if !strings.HasPrefix(body, delim) {
+		return "", "", false
+	}
+	front, rest, ok = strings.Cut(body[len(delim):], "\n"+delim)
+	if !ok {
+		return "", "", false
+	}
+	return front, rest, true
+}
+
+// parseDescription reads the frontmatter description and collapses its
+// whitespace, so a folded scalar renders as one line in `skills list`. A file
+// whose frontmatter is missing or malformed yields an empty description; the
+// package test fails on that rather than the command doing so at runtime.
+func parseDescription(body string) string {
+	front, _, ok := splitFrontmatter(body)
+	if !ok {
+		return ""
+	}
+	var meta struct {
+		Description string `yaml:"description"`
+	}
+	if err := yaml.Unmarshal([]byte(front), &meta); err != nil {
+		return ""
+	}
+	return strings.Join(strings.Fields(meta.Description), " ")
+}

--- a/plugins/agento11y/internal/skills/skills_test.go
+++ b/plugins/agento11y/internal/skills/skills_test.go
@@ -1,0 +1,282 @@
+package skills
+
+import (
+	"errors"
+	"io/fs"
+	"slices"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestNamesAreSortedAndComplete pins the listing order and the one skill the
+// doctor, login and help hints promise. An unsorted list makes `skills list`
+// output depend on the embed walk order rather than on the names.
+func TestNamesAreSortedAndComplete(t *testing.T) {
+	names := Names()
+	if len(names) == 0 {
+		t.Fatal("Names() returned nothing; the embedded content tree is empty")
+	}
+	if !slices.IsSorted(names) {
+		t.Errorf("Names() = %v, want lexicographically sorted", names)
+	}
+	if !slices.Contains(names, SetupCodingAgentSkill) {
+		t.Errorf("Names() = %v, want it to contain %q", names, SetupCodingAgentSkill)
+	}
+}
+
+// TestNamesFrom drives the listing off a fake tree, because the bundled tree
+// has one skill and so exercises neither the sort nor the filter. A directory
+// without a SKILL.md is not a skill: listing one would print a name that Get
+// then fails on.
+func TestNamesFrom(t *testing.T) {
+	const front = "---\nname: x\ndescription: x\n---\n"
+	fsys := fstest.MapFS{
+		contentRoot + "/b-second/" + skillFile:  {Data: []byte(front)},
+		contentRoot + "/a-first/" + skillFile:   {Data: []byte(front)},
+		contentRoot + "/no-skill-file/notes.md": {Data: []byte("not a skill")},
+		contentRoot + "/README.md":              {Data: []byte("not a directory")},
+	}
+	got := namesFrom(reverseDirFS{fsys})
+	want := []string{"a-first", "b-second"}
+	if !slices.Equal(got, want) {
+		t.Errorf("namesFrom() = %v, want %v", got, want)
+	}
+}
+
+// reverseDirFS hands back directory entries in reverse order. Both embed.FS
+// and fstest.MapFS return theirs already sorted, so without a filesystem that
+// does not, a test cannot tell a namesFrom that sorts from one that inherits
+// the order it was given.
+type reverseDirFS struct{ fs.FS }
+
+func (r reverseDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	entries, err := fs.ReadDir(r.FS, name)
+	if err != nil {
+		return nil, err
+	}
+	slices.Reverse(entries)
+	return entries, nil
+}
+
+// TestNamesFromMissingRoot pins that a binary built without the content tree
+// lists nothing rather than failing.
+func TestNamesFromMissingRoot(t *testing.T) {
+	if got := namesFrom(fstest.MapFS{}); got != nil {
+		t.Errorf("namesFrom(empty) = %v, want nil", got)
+	}
+}
+
+// TestAllMatchesNames pins that the listing helper and the name list agree.
+// `skills list` reads All, so a disagreement is a skill missing from the
+// output.
+func TestAllMatchesNames(t *testing.T) {
+	var got []string
+	for _, skill := range All() {
+		got = append(got, skill.Name)
+		if strings.TrimSpace(skill.Body) == "" {
+			t.Errorf("All() returned %q with an empty body", skill.Name)
+		}
+	}
+	if want := Names(); !slices.Equal(got, want) {
+		t.Errorf("All() names = %v, want %v", got, want)
+	}
+}
+
+// maxSkillLines bounds a bundled skill. A skill is read into a coding agent's
+// context in full, so an unbounded file is a cost every invocation pays.
+const maxSkillLines = 500
+
+// TestBundledSkillsAreValid is the guard that skills/agento11y-eval-starter
+// never had: every bundled SKILL.md must open and close its frontmatter with
+// `---`, parse as YAML, name itself after its directory, carry a description,
+// and stay under the line bound.
+func TestBundledSkillsAreValid(t *testing.T) {
+	for _, name := range Names() {
+		t.Run(name, func(t *testing.T) {
+			skill, err := Get(name)
+			if err != nil {
+				t.Fatalf("Get(%q): %v", name, err)
+			}
+
+			body := skill.Body
+			raw, _, ok := splitFrontmatter(body)
+			if !ok {
+				t.Fatalf("skill %q: frontmatter must open and close with a --- line", name)
+			}
+
+			var front struct {
+				Name        string `yaml:"name"`
+				Description string `yaml:"description"`
+			}
+			if err := yaml.Unmarshal([]byte(raw), &front); err != nil {
+				t.Fatalf("skill %q: frontmatter is not valid YAML: %v", name, err)
+			}
+			if front.Name != name {
+				t.Errorf("skill %q: frontmatter name = %q, want the directory name %q", name, front.Name, name)
+			}
+			if strings.TrimSpace(front.Description) == "" {
+				t.Errorf("skill %q: frontmatter description is empty", name)
+			}
+			if skill.Name != name {
+				t.Errorf("skill %q: Skill.Name = %q", name, skill.Name)
+			}
+			if strings.TrimSpace(skill.Description) == "" {
+				t.Errorf("skill %q: Skill.Description is empty", name)
+			}
+			if strings.ContainsAny(skill.Description, "\n\r") {
+				t.Errorf("skill %q: Skill.Description spans lines: %q", name, skill.Description)
+			}
+
+			if lines := countLines(body); lines >= maxSkillLines {
+				t.Errorf("skill %q: %d lines, want fewer than %d", name, lines, maxSkillLines)
+			}
+		})
+	}
+}
+
+// countLines counts the lines in a file. A trailing newline ends the last
+// line rather than starting a new one, so counting separators alone would
+// report one line too many and make the bound off by one.
+func countLines(body string) int {
+	if body == "" {
+		return 0
+	}
+	return strings.Count(strings.TrimSuffix(body, "\n"), "\n") + 1
+}
+
+func TestCountLines(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{name: "empty", body: "", want: 0},
+		{name: "one line, no newline", body: "a", want: 1},
+		{name: "one line, trailing newline", body: "a\n", want: 1},
+		{name: "two lines", body: "a\nb\n", want: 2},
+		{name: "blank last line", body: "a\n\n", want: 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := countLines(tc.body); got != tc.want {
+				t.Errorf("countLines(%q) = %d, want %d", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGetRejectsUnsafeAndUnknownNames pins the traversal guard copied from
+// local.serveStatic: a name is a bare directory name inside the embedded tree,
+// never a path.
+func TestGetRejectsUnsafeAndUnknownNames(t *testing.T) {
+	cases := []struct {
+		name    string
+		arg     string
+		wantErr error
+	}{
+		{name: "empty", arg: "", wantErr: ErrUnsafeName},
+		{name: "slash", arg: "../etc/passwd", wantErr: ErrUnsafeName},
+		{name: "backslash", arg: `..\windows`, wantErr: ErrUnsafeName},
+		{name: "dotdot", arg: "..", wantErr: ErrUnsafeName},
+		{name: "nested", arg: "setup-coding-agent/SKILL.md", wantErr: ErrUnsafeName},
+		{name: "absolute", arg: "/etc/passwd", wantErr: ErrUnsafeName},
+		{name: "unknown", arg: "nope", wantErr: ErrNotFound},
+		{name: "content root", arg: "content", wantErr: ErrNotFound},
+		{name: "dot", arg: ".", wantErr: ErrNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			skill, err := Get(tc.arg)
+			if err == nil {
+				t.Fatalf("Get(%q) succeeded, want %v", tc.arg, tc.wantErr)
+			}
+			if skill.Body != "" {
+				t.Errorf("Get(%q) returned a body on error: %q", tc.arg, skill.Body)
+			}
+			// errors.Is, not a string match: the sentinels exist so a caller
+			// can tell misuse from a missing skill, and a string match would
+			// still pass if the %w wrap became a %v.
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("Get(%q) error = %v, want it to wrap %v", tc.arg, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestParseDescription covers the malformed frontmatter the bundled tree
+// cannot show, because the one skill in it is valid.
+func TestParseDescription(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "folded scalar collapses to one line",
+			body: "---\nname: x\ndescription: >-\n  first line\n  second line\n---\n\n# x\n",
+			want: "first line second line",
+		},
+		{
+			name: "plain scalar",
+			body: "---\nname: x\ndescription: one line\n---\n",
+			want: "one line",
+		},
+		{name: "no opening delimiter", body: "name: x\ndescription: y\n---\n"},
+		{name: "no closing delimiter", body: "---\nname: x\ndescription: y\n"},
+		{name: "invalid yaml", body: "---\ndescription: unquoted: colon\n---\n"},
+		{name: "no description key", body: "---\nname: x\n---\n"},
+		{name: "empty file"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseDescription(tc.body); got != tc.want {
+				t.Errorf("parseDescription() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSetupCodingAgentCommand pins the command string the doctor footer, the
+// login next step, and the help block all print. A drift here is a user
+// pasting a command that does not run. internal/entry proves the other half:
+// that the words in this string are the words its dispatch accepts.
+func TestSetupCodingAgentCommand(t *testing.T) {
+	const want = "agento11y skills show setup-coding-agent"
+	if SetupCodingAgentCommand != want {
+		t.Errorf("SetupCodingAgentCommand = %q, want %q", SetupCodingAgentCommand, want)
+	}
+	if _, err := Get(SetupCodingAgentSkill); err != nil {
+		t.Errorf("the command names a skill that is not bundled: %v", err)
+	}
+}
+
+// TestSetupHintLines pins the shape the doctor footer depends on: every line
+// starts at column 0, because doctor's row grammar claims any indented line,
+// and the paste line names the command a user is told to run.
+func TestSetupHintLines(t *testing.T) {
+	lines := map[string]string{
+		"intro":     SetupCodingAgentHintIntro,
+		"paste":     SetupCodingAgentPasteLine,
+		"one-liner": SetupCodingAgentOneLiner,
+	}
+	for name, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			t.Errorf("%s hint line is empty", name)
+		}
+		if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+			t.Errorf("%s hint line %q is indented; every line must start at column 0", name, line)
+		}
+		if strings.Contains(line, "\n") {
+			t.Errorf("%s hint line %q contains a newline; each is one line", name, line)
+		}
+	}
+	if !strings.Contains(SetupCodingAgentPasteLine, SetupCodingAgentCommand) {
+		t.Errorf("the paste line does not name %q: %q", SetupCodingAgentCommand, SetupCodingAgentPasteLine)
+	}
+	if !strings.Contains(SetupCodingAgentOneLiner, SetupCodingAgentCommand) {
+		t.Errorf("the one-liner does not name %q: %q", SetupCodingAgentCommand, SetupCodingAgentOneLiner)
+	}
+}


### PR DESCRIPTION
`agento11y skills list` and `agento11y skills show <name>` print agent skills embedded in the binary. The first skill, `setup-coding-agent`, walks a coding agent through reading `agento11y doctor --json`, installing the binary, saving credentials, wiring the host agent, verifying one session, and diagnosing a broken pipeline.