### PR TITLE
feat(plugins/opencode): add preflight and transform guards

### DIFF
--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -112,6 +112,22 @@ The plugin attaches built-in tags of its own:
 
 Built-in tags win collisions with user tags, matching the claude-code and cursor launchers. See [Tags and Metadata](../../docs/concepts/tags-and-metadata.md#built-in-tags-from-the-agent-launchers) for the tags the launchers share.
 
+## Guards
+
+Guards check a request against rules you configure in Grafana and can stop or rewrite it before the model sees it. Refer to [Set up guards](https://grafana.com/docs/grafana-cloud/machine-learning/agent-observability/guides/guards/) to write the rules. This section covers what they do in OpenCode.
+
+They are off by default:
+
+```sh
+AGENTO11Y_GUARDS_ENABLED=true agento11y opencode
+```
+
+With guards on, a rule can:
+
+- **Refuse a turn.** A `preflight` deny stops the turn before it reaches the model, so nothing is sent and no tokens are spent. The reason appears in the session and in OpenCode's log.
+- **Redact what the model sees.** A `preflight` redact rule replaces matching text in the conversation on its way to the provider. Your own message is not rewritten.
+- **Block or rewrite a tool call.** A `postflight` deny stops the call and tells the model why. A redact rule rewrites the arguments the tool receives. OpenCode's permission prompts count as tool calls, and its permission API has no field for a reason, so a denied prompt reports none.
+
 ## All options
 
 `~/.config/agento11y/config.env` is the only configuration file. Every option is set via env var.
@@ -124,9 +140,9 @@ Built-in tags win collisions with user tags, matching the claude-code and cursor
 | `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the Agent Observability latency and tool-call panels stay empty. Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT`. |
 | `AGENTO11Y_OTEL_AUTH_TOKEN` | `AGENTO11Y_AUTH_TOKEN` | Override the OTLP password. |
 | `AGENTO11Y_CONTENT_CAPTURE_MODE` | `metadata_only` | One of `full`, `no_tool_content`, `metadata_only`, or `full_with_metadata_spans`. `default` is accepted as an alias for `metadata_only`. |
-| `AGENTO11Y_GUARDS_ENABLED` | `false` | Evaluate OpenCode tool calls against Agent Observability guards before execution. |
+| `AGENTO11Y_GUARDS_ENABLED` | `false` | Check your prompts, the conversation sent to the model, and OpenCode tool calls against Agent Observability guards. See [Guards](#guards). |
 | `AGENTO11Y_GUARDS_TIMEOUT_MS` | `1500` | Per-evaluation guard timeout in milliseconds. |
-| `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | Allow tool calls if guard evaluation fails. Set to `false` to fail closed. |
+| `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | Send the turn and allow tool calls when a guard evaluation fails. Set to `false` to refuse them instead. This covers evaluation failures at all three checks. A tool call is blocked under either setting when a guard returns redacted arguments that the plugin cannot write into the arguments OpenCode runs the tool with. |
 | `AGENTO11Y_AGENT_NAME` | `opencode` | Agent name reported to Agent Observability. The plugin appends `:<mode>` for OpenCode's UI mode, such as `build` or `plan`. |
 | `AGENTO11Y_AGENT_VERSION` | OpenCode version | Version string reported with the agent. |
 | `AGENTO11Y_AUTO_CODING_AGENT_TAGS` | `false` | Opt in to client tags resolved for the session: the user, the repository, and the branch. These reach OTel metrics as `agento11y_tag_*` labels, unlike the per-generation built-ins. The plugin builds one client per session, so the values freeze at session start. See [Tags and Metadata](../../docs/concepts/tags-and-metadata.md#opt-in-automatic-tags-agento11y_auto_coding_agent_tags) for the cardinality and personal-data trade-offs. |

--- a/plugins/opencode/src/guard.test.ts
+++ b/plugins/opencode/src/guard.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vitest";
-import type { GuardResult } from "./guard.js";
-import { runToolCallGuard } from "./guard.js";
+import type { HookEvaluateResponse, Message } from "@grafana/agento11y";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  GuardResult,
+  PreflightTransformArgs,
+  PreflightTransformResult,
+} from "./guard.js";
+import { runPreflightTransform, runToolCallGuard } from "./guard.js";
 
 /** Narrow a GuardResult to a block result, failing the test otherwise. */
 function asBlock(res: GuardResult): { block: true; reason: string } {
@@ -353,5 +358,191 @@ describe("runToolCallGuard", () => {
     });
 
     expect(res).toBeUndefined();
+  });
+});
+
+/**
+ * Records the request and the hooks-config override of each call, so a test can
+ * check the phase override that stops the SDK short-circuiting the call (see
+ * `createAgento11yClient`).
+ */
+function makePreflightClient(respond: () => Promise<HookEvaluateResponse>): {
+  client: PreflightTransformArgs["client"];
+  calls: Array<{ req: any; override: unknown }>;
+} {
+  const calls: Array<{ req: any; override: unknown }> = [];
+  const client = {
+    evaluateHook: vi.fn(async (req: any, override?: unknown) => {
+      calls.push({ req, override });
+      return respond();
+    }),
+  } as unknown as PreflightTransformArgs["client"];
+  return { client, calls };
+}
+
+function makePreflightArgs(
+  overrides?: Partial<PreflightTransformArgs>,
+): PreflightTransformArgs {
+  return {
+    client: {} as PreflightTransformArgs["client"],
+    agentName: "opencode:build",
+    agentVersion: "1.2.3",
+    model: { provider: "anthropic", name: "claude-sonnet-4" },
+    messages: [{ role: "user", parts: [{ type: "text", text: "hi" }] }],
+    failOpen: true,
+    ...overrides,
+  };
+}
+
+describe("runPreflightTransform", () => {
+  const ALLOW: HookEvaluateResponse = { action: "allow", evaluations: [] };
+  const REDACTED: Message[] = [
+    {
+      role: "user",
+      parts: [{ type: "text", text: "authorization=[REDACTED]" }],
+    },
+  ];
+
+  type PreflightCase = {
+    name: string;
+    /** Server response. Throwing stands in for a transport error. */
+    respond?: () => Promise<HookEvaluateResponse>;
+    args?: Partial<PreflightTransformArgs>;
+    want?: PreflightTransformResult;
+    /** Substrings that must each appear in a logged warning. */
+    wantWarn?: string[];
+    assert?: (calls: Array<{ req: any; override: unknown }>) => void;
+  };
+
+  const cases: PreflightCase[] = [
+    {
+      name: "sends the conversation and the execution context",
+      assert: (calls) => {
+        const { req, override } = calls[0]!;
+        expect(req.phase).toBe("preflight");
+        expect(req.context).toEqual({
+          agentName: "opencode:build",
+          agentVersion: "1.2.3",
+          model: { provider: "anthropic", name: "claude-sonnet-4" },
+        });
+        expect(req.input.messages).toEqual([
+          { role: "user", parts: [{ type: "text", text: "hi" }] },
+        ]);
+        // The opencode client pins `hooks.phases` to `["postflight"]`, so
+        // without the override the SDK would answer allow without calling the
+        // server. `failOpen: false` keeps it from turning a failed evaluation
+        // into a synthetic allow, which would make a timeout unloggable here.
+        expect(override).toEqual({
+          enabled: true,
+          phases: ["preflight"],
+          failOpen: false,
+        });
+      },
+    },
+    {
+      name: "substitutes unknown for an unresolved provider and model name",
+      args: { model: { provider: "", name: "" } },
+      assert: (calls) => {
+        expect(calls[0]!.req.context.model).toEqual({
+          provider: "unknown",
+          name: "unknown",
+        });
+      },
+    },
+    {
+      name: "returns the redacted messages from transformedInput",
+      respond: async () => ({
+        ...ALLOW,
+        transformedInput: { messages: REDACTED },
+      }),
+      want: { messages: REDACTED },
+    },
+    {
+      name: "returns undefined when the server sends no transformedInput",
+    },
+    {
+      name: "returns undefined when the server sends an empty message list",
+      respond: async () => ({ ...ALLOW, transformedInput: { messages: [] } }),
+    },
+    {
+      name: "fails open on a transport error, logging a warning",
+      respond: async () => {
+        throw new Error("network down");
+      },
+      wantWarn: ["preflight transform eval failed"],
+    },
+    {
+      // The SDK aborts on its own timeout and, configured fail-closed, raises
+      // it. Preflight cannot block, so the rejection still has to resolve to
+      // "no transform".
+      name: "fails open when the evaluation times out",
+      respond: async () => {
+        throw new Error("The operation was aborted due to timeout");
+      },
+      wantWarn: ["preflight transform eval failed"],
+    },
+    {
+      name: "reports a deny as a reason to refuse the turn",
+      respond: async () => ({
+        action: "deny",
+        reason: "preflight deny",
+        evaluations: [],
+      }),
+      want: { block: expect.stringContaining("preflight deny") as any },
+    },
+    {
+      // A deny stops the turn, so the transform it carries has nothing left to
+      // rewrite: the conversation never reaches the provider.
+      name: "refuses without the transform a deny response carries",
+      respond: async () => ({
+        action: "deny",
+        reason: "preflight deny",
+        evaluations: [],
+        transformedInput: { messages: REDACTED },
+      }),
+      want: { block: expect.stringContaining("preflight deny") as any },
+    },
+    {
+      // The daemon's fail-closed deny explains itself, so it is passed through
+      // rather than wrapped as a policy decision.
+      name: "passes a guard-evaluation-failure deny through unwrapped",
+      respond: async () => ({
+        action: "deny",
+        ruleId: "__agento11y_guard_evaluation_failure",
+        reason: "local daemon could not reach the cloud hook",
+        evaluations: [],
+      }),
+      want: { block: "local daemon could not reach the cloud hook" },
+    },
+    {
+      name: "refuses the turn when the evaluation fails and fail-open is off",
+      args: { failOpen: false },
+      respond: async () => {
+        throw new Error("guard backend unavailable");
+      },
+      want: {
+        block: expect.stringContaining("stopped as a safety measure") as any,
+      },
+      wantWarn: ["preflight transform eval failed"],
+    },
+  ];
+
+  it.each(cases)("$name", async ({ respond, args, want, wantWarn, assert }) => {
+    const { client, calls } = makePreflightClient(
+      respond ?? (async () => ALLOW),
+    );
+    const warn = vi.fn();
+
+    const res = await runPreflightTransform(
+      makePreflightArgs({ client, logger: { warn }, ...args }),
+    );
+
+    expect(res).toEqual(want);
+    expect(calls).toHaveLength(1);
+    for (const substring of wantWarn ?? []) {
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(substring));
+    }
+    if (!wantWarn) expect(warn).not.toHaveBeenCalled();
+    assert?.(calls);
   });
 });

--- a/plugins/opencode/src/guard.ts
+++ b/plugins/opencode/src/guard.ts
@@ -88,6 +88,244 @@ function formatEvalFailure(
 }
 
 /**
+ * Wraps a rule-authored reason for a denied prompt. Addressed to the user, not
+ * the model: this verdict is delivered as a TUI toast and as the error that
+ * aborts the turn, so it must not carry `GUARD_BEHAVIOR_HINT`, which instructs
+ * an agent that is never reached.
+ */
+function formatPromptDeny(reason: string | undefined): string {
+  let msg =
+    "A Grafana Agent Observability policy blocked this message, so it was not sent to the model.";
+  const trimmed = reason?.trim();
+  if (trimmed) {
+    msg += ` Reason: ${trimmed}`;
+  }
+  return msg;
+}
+
+/** Fail-closed message for a prompt whose guard evaluation could not run. */
+function formatPromptEvalFailure(detail: string | undefined): string {
+  let msg =
+    "agento11y could not evaluate the Grafana Agent Observability guard for this message, so it was blocked as a safety measure. Set AGENTO11Y_GUARDS_FAIL_OPEN=true to send it anyway.";
+  const trimmed = detail?.trim();
+  if (trimmed) {
+    msg += ` Details: ${trimmed}`;
+  }
+  return msg;
+}
+
+export interface PromptGuardArgs {
+  client: Agento11yClient;
+  agentName: string;
+  agentVersion?: string;
+  model: { provider: string; name: string };
+  messages: Message[];
+  failOpen: boolean;
+  logger?: { warn: (msg: string) => void };
+}
+
+export type PromptGuardResult = { block: true; reason: string } | undefined;
+
+/**
+ * Evaluates the prompt the user just submitted against the Agent Observability
+ * preflight hook, and reports whether the turn must be refused.
+ *
+ * This is the only point where opencode lets a plugin refuse a turn cleanly.
+ * `chat.message` fires before the user message and its parts are persisted and
+ * before the step loop starts (`session/prompt.ts`), so throwing from it stops
+ * the turn without a provider call and without leaving a half-written assistant
+ * message behind. `experimental.chat.messages.transform` runs after the
+ * assistant message row exists, which is why the deny is enforced here and only
+ * reported there. `runPreflightTransform` documents that side.
+ *
+ * A transform in the response is ignored on purpose. These parts are about to be
+ * written to opencode's message store, so rewriting them would edit the user's
+ * own saved message rather than what the provider receives. Redaction stays with
+ * `runPreflightTransform`, which rewrites the provider-bound copy only.
+ *
+ * `failOpen` governs an evaluation that could not run, matching the postflight
+ * tool-call path. A deny is always enforced.
+ */
+export async function runPromptGuard(
+  args: PromptGuardArgs,
+): Promise<PromptGuardResult> {
+  try {
+    const req: HookEvaluateRequest = {
+      phase: "preflight",
+      context: {
+        agentName: args.agentName,
+        agentVersion: args.agentVersion,
+        model: {
+          provider: args.model.provider || "unknown",
+          name: args.model.name || "unknown",
+        },
+      },
+      input: {
+        messages: args.messages,
+      },
+    };
+
+    // The phase override and `failOpen: false` are required for the same
+    // reasons as in `runPreflightTransform`: the client pins `hooks.phases` to
+    // `["postflight"]`, and the SDK's own fail-open would return a synthetic
+    // `allow` that cannot be told from a real one. Errors are routed to the
+    // catch below, where `args.failOpen` decides.
+    const resp = await args.client.evaluateHook(req, {
+      enabled: true,
+      phases: ["preflight"],
+      failOpen: false,
+    });
+    if (resp.action !== "deny") return undefined;
+
+    // The local daemon's own fail-closed deny already explains itself.
+    if (resp.ruleId === EVALUATION_FAILURE_RULE_ID) {
+      return {
+        block: true,
+        reason: resp.reason ?? formatPromptEvalFailure(undefined),
+      };
+    }
+    return { block: true, reason: formatPromptDeny(resp.reason) };
+  } catch (err) {
+    args.logger?.warn(`prompt guard eval failed: ${err}`);
+    if (args.failOpen) return undefined;
+    return { block: true, reason: formatPromptEvalFailure(String(err)) };
+  }
+}
+
+/** Wraps a rule-authored reason for a denied conversation, for the user. */
+function formatConversationDeny(reason: string | undefined): string {
+  let msg =
+    "A Grafana Agent Observability policy blocked this conversation, so the turn was stopped before it reached the model.";
+  const trimmed = reason?.trim();
+  if (trimmed) {
+    msg += ` Reason: ${trimmed}`;
+  }
+  return msg;
+}
+
+/** Fail-closed message for a conversation whose evaluation could not run. */
+function formatConversationEvalFailure(detail: string | undefined): string {
+  let msg =
+    "agento11y could not evaluate the Grafana Agent Observability guard for this conversation, so the turn was stopped as a safety measure. Set AGENTO11Y_GUARDS_FAIL_OPEN=true to let it through instead.";
+  const trimmed = detail?.trim();
+  if (trimmed) {
+    msg += ` Details: ${trimmed}`;
+  }
+  return msg;
+}
+
+export interface PreflightTransformArgs {
+  client: Agento11yClient;
+  agentName: string;
+  agentVersion?: string;
+  model: { provider: string; name: string };
+  messages: Message[];
+  failOpen: boolean;
+  logger?: { warn: (msg: string) => void };
+}
+
+export type PreflightTransformResult =
+  | { messages?: Message[]; block?: string }
+  | undefined;
+
+/**
+ * Evaluates the Agent Observability preflight hook against the outgoing
+ * conversation. Returns the redacted messages from
+ * `transformedInput.messages`, a reason to refuse the turn, or `undefined` when
+ * there is nothing to do.
+ *
+ * A deny blocks, and so does an evaluation that could not run when `failOpen` is
+ * false. Refusing here is not free: opencode has already written the assistant
+ * message row by the time it dispatches this hook (`session/prompt.ts`), and it
+ * finalizes that row through `Effect.onInterrupt`, which a thrown error does not
+ * trigger. The caller asks opencode to abort the session so that finalizer runs,
+ * then throws so the turn stops whether the abort arrived or not.
+ *
+ * `runPromptGuard` covers the same rules at `chat.message`, where nothing is
+ * written yet, so most denies never reach this point. What reaches it is a deny
+ * on text the user did not just type: conversation history, an assistant string
+ * generated during the turn, or a compaction dispatch.
+ *
+ * Mirrors `runPreflightTransform` in `plugins/pi/src/guard.ts`; keep the two
+ * request shapes aligned.
+ */
+export async function runPreflightTransform(
+  args: PreflightTransformArgs,
+): Promise<PreflightTransformResult> {
+  try {
+    const req: HookEvaluateRequest = {
+      phase: "preflight",
+      context: {
+        agentName: args.agentName,
+        agentVersion: args.agentVersion,
+        model: {
+          provider: args.model.provider || "unknown",
+          name: args.model.name || "unknown",
+        },
+      },
+      input: {
+        messages: args.messages,
+      },
+    };
+
+    // `createAgento11yClient` pins `hooks.phases` to `["postflight"]`, and
+    // `evaluateHook` replaces that list wholesale, so without the override the
+    // SDK answers `allow` without calling the server.
+    //
+    // `failOpen: false` makes a failure visible, not fatal. The SDK default
+    // turns every error and timeout into a synthetic `allow`, which this
+    // function cannot tell from a real one. Throwing routes them to the catch
+    // below, which logs and returns `undefined`, so preflight still fails open.
+    const resp = await args.client.evaluateHook(req, {
+      enabled: true,
+      phases: ["preflight"],
+      failOpen: false,
+    });
+
+    if (resp.action === "deny") {
+      // The local daemon's own fail-closed deny already explains itself.
+      if (resp.ruleId === EVALUATION_FAILURE_RULE_ID) {
+        return {
+          block: resp.reason ?? formatConversationEvalFailure(undefined),
+        };
+      }
+      return { block: formatConversationDeny(resp.reason) };
+    }
+
+    const transformed = resp.transformedInput?.messages;
+    if (!transformed || transformed.length === 0) {
+      return undefined;
+    }
+    return { messages: transformed };
+  } catch (err) {
+    args.logger?.warn(`preflight transform eval failed: ${err}`);
+    if (args.failOpen) return undefined;
+    return { block: formatConversationEvalFailure(String(err)) };
+  }
+}
+
+/**
+ * Fail-closed message used when the server's redacted arguments cannot be
+ * written into the arguments opencode runs the tool with. Says the block came
+ * from the plugin rather than from a rule: the server allowed the call, and
+ * only the local rewrite failed.
+ *
+ * No Go counterpart: the shared binary returns the redacted arguments to its
+ * host instead of writing them into a live object, so it has no such failure.
+ */
+export function formatTransformFailure(
+  toolName: string,
+  detail: string | undefined,
+): string {
+  let msg = `agento11y could not apply the redacted arguments that a Grafana Agent Observability guard returned for the "${toolName}" tool call, so it was blocked as a safety measure.`;
+  const trimmed = detail?.trim();
+  if (trimmed) {
+    msg += ` Details: ${trimmed}`;
+  }
+  return `${msg}\n\n${GUARD_BEHAVIOR_HINT}`;
+}
+
+/**
  * Evaluates the Agent Observability postflight hook for a tool call. Returns a block result
  * when the server denies the call, or a transform result when the server
  * redacted/sanitized the call's arguments. On transport/timeout/serialization

--- a/plugins/opencode/src/hooks.capture.test.ts
+++ b/plugins/opencode/src/hooks.capture.test.ts
@@ -605,3 +605,112 @@ describe("opencode conversation title", () => {
     );
   });
 });
+
+describe("opencode preflight redaction in the export", () => {
+  const guards = { enabled: true, timeoutMs: 1500, failOpen: true };
+
+  /** A stored text part, the shape opencode hands `chat.message`. */
+  function storedPart(id: string, text: string): any {
+    return {
+      id,
+      sessionID: "sess-1",
+      messageID: "user-1",
+      type: "text",
+      text,
+    };
+  }
+
+  /**
+   * The outgoing entry for the same message. opencode reads it back from its
+   * message store, so the parts carry the ids of the stored ones in new
+   * objects, which is what the export substitution matches on.
+   */
+  function outgoingCopy(parts: any[]) {
+    return {
+      info: { id: "user-1", role: "user", sessionID: "sess-1" },
+      parts: parts.map((part) => ({ ...part })),
+    };
+  }
+
+  function transformOf(...texts: string[]) {
+    return {
+      action: "allow",
+      transformedInput: {
+        messages: texts.map((text) => ({
+          role: "user",
+          parts: [{ type: "text", text }],
+        })),
+      },
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetHookState();
+  });
+
+  it("exports the text the provider received, not what the user typed", async () => {
+    const { sigil, generations } = makeAgento11yMock();
+    sigil.evaluateHook.mockResolvedValue(transformOf("token=[REDACTED]"));
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks(baseConfig({ guards }));
+
+    const stored = storedPart("prt-1", "token=alpha");
+    hooks.chatMessage(
+      { sessionID: "sess-1" },
+      { message: userMessage("sess-1"), parts: [stored] },
+    );
+    await hooks.messagesTransform({ messages: [outgoingCopy([stored])] });
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect((generations[0]!.result as any).input).toEqual([
+      { role: "user", parts: [{ type: "text", text: "token=[REDACTED]" }] },
+    ]);
+    // opencode's own part is untouched: a redact rule governs what leaves the
+    // machine, not the user's transcript.
+    expect(stored.text).toBe("token=alpha");
+  });
+
+  it("exports a collapsed message once", async () => {
+    const { sigil, generations } = makeAgento11yMock();
+    sigil.evaluateHook.mockResolvedValue(transformOf("keep\ntoken=[R]"));
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks(baseConfig({ guards }));
+
+    // A transform returns one string per message, so two text parts come back
+    // joined. Replaying it into both parts would export the text twice.
+    const first = storedPart("prt-1", "keep");
+    const second = storedPart("prt-2", "token=alpha");
+    hooks.chatMessage(
+      { sessionID: "sess-1" },
+      { message: userMessage("sess-1"), parts: [first, second] },
+    );
+    await hooks.messagesTransform({
+      messages: [outgoingCopy([first, second])],
+    });
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect((generations[0]!.result as any).input).toEqual([
+      { role: "user", parts: [{ type: "text", text: "keep\ntoken=[R]" }] },
+    ]);
+  });
+
+  it("exports the original when no rule rewrote anything", async () => {
+    const { sigil, generations } = makeAgento11yMock();
+    sigil.evaluateHook.mockResolvedValue({ action: "allow" });
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks(baseConfig({ guards }));
+
+    const stored = storedPart("prt-1", "token=alpha");
+    hooks.chatMessage(
+      { sessionID: "sess-1" },
+      { message: userMessage("sess-1"), parts: [stored] },
+    );
+    await hooks.messagesTransform({ messages: [outgoingCopy([stored])] });
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect((generations[0]!.result as any).input).toEqual([
+      { role: "user", parts: [{ type: "text", text: "token=alpha" }] },
+    ]);
+  });
+});

--- a/plugins/opencode/src/hooks.guard.test.ts
+++ b/plugins/opencode/src/hooks.guard.test.ts
@@ -1,7 +1,17 @@
 import { createServer, type Server } from "node:http";
-import { afterEach, describe, expect, it } from "vitest";
+import type { Part } from "@opencode-ai/sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Agento11yOpencodeConfig } from "./config.js";
-import { createAgento11yHooks } from "./hooks.js";
+import {
+  _DEFAULT_GUARD_TOAST_DELAY_MS,
+  _peekPendingGenerations,
+  _peekToolExecutionState,
+  _resetHookState,
+  _resetToolExecutionState,
+  _setGuardToastDelayMs,
+  type Agento11yHooks,
+  createAgento11yHooks,
+} from "./hooks.js";
 import { emitServerInstanceDisposed } from "./hooks.testutil.js";
 
 type HookServer = {
@@ -51,6 +61,27 @@ function base64Json(value: unknown): string {
   return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
 }
 
+/**
+ * Drives the two hooks the way opencode drives them: it hands
+ * `tool.execute.before` its own `{ args }` container, ignores what the hook
+ * returns, and reports the same `args` object to `tool.execute.after`
+ * (opencode 1.18.10, `SessionTools.resolve` and `SessionPrompt.handleSubtask`).
+ *
+ * No tool runs here. Nothing writes to `args` after the hook either, so what
+ * `args` holds on return is what a real host would have executed.
+ */
+async function runToolLikeOpencode(
+  hooks: Agento11yHooks,
+  input: { tool: string; sessionID: string; callID: string },
+  args: Record<string, unknown>,
+): Promise<void> {
+  await hooks.toolExecuteBefore(input, { args });
+  hooks.toolExecuteAfter(
+    { ...input, args },
+    { title: input.tool, output: "ok", metadata: {} },
+  );
+}
+
 function config(endpoint: string): Agento11yOpencodeConfig {
   return {
     endpoint,
@@ -66,7 +97,12 @@ function config(endpoint: string): Agento11yOpencodeConfig {
 describe("opencode guards", () => {
   const servers: Server[] = [];
 
+  beforeEach(() => _resetToolExecutionState());
+
   afterEach(async () => {
+    // A scheduled toast outlives the case that caused it, and would otherwise
+    // arrive in the next one after its arrays were reset.
+    await flushToasts();
     await Promise.all(servers.splice(0).map(closeServer));
   });
 
@@ -142,7 +178,7 @@ describe("opencode guards", () => {
     await emitServerInstanceDisposed(hooks);
   });
 
-  it("replaces frozen tool.execute.before args with the redacted set", async () => {
+  it("rewrites the args opencode runs the tool with, and exports those", async () => {
     const hookServer = await startHookServer({
       action: "allow",
       evaluations: [],
@@ -174,26 +210,101 @@ describe("opencode guards", () => {
     } as any);
     if (!hooks) throw new Error("expected hooks");
 
-    // opencode >=1.14 freezes output.args. A secret key sits alongside the
-    // command; the server drops it and rewrites command. The redacted set must
-    // replace output.args even though the original is frozen — an in-place
-    // mutation would throw and silently leak the original.
-    const output = {
-      args: Object.freeze({
-        command: "echo sonia@grafana.com",
-        apiKey: "sk-secret",
-      }) as Record<string, unknown>,
+    // A secret key sits alongside the command; the server drops it and
+    // rewrites the command.
+    const args: Record<string, unknown> = {
+      command: "echo sonia@grafana.com",
+      apiKey: "sk-secret",
     };
 
     // Must not throw (allow + transform, not a block).
-    await hooks.toolExecuteBefore(
+    await runToolLikeOpencode(
+      hooks,
       { sessionID: "sess-1", callID: "call-1", tool: "bash" },
-      output,
+      args,
     );
 
-    // Wholesale replacement: dropped key gone, command redacted.
-    expect(output.args).toEqual({ command: "echo [REDACTED]" });
-    expect(output.args.apiKey).toBeUndefined();
+    // Wholesale replacement, on the object the tool read: dropped key gone,
+    // command redacted.
+    expect(args).toEqual({ command: "echo [REDACTED]" });
+
+    // The span reads the same object the tool ran with, not a copy that can
+    // disagree with it.
+    const exported = _peekToolExecutionState().completed;
+    expect(exported).toHaveLength(1);
+    expect(exported[0]?.input).toBe(args);
+
+    await emitServerInstanceDisposed(hooks);
+  });
+
+  // Frozen args stand in for any host that hands the hook an object the plugin
+  // cannot write to. Which statement throws depends on the server's set:
+  // `delete` when the server dropped a key, `Object.assign` when it dropped
+  // none. Running the tool anyway would send it the unredacted originals, so
+  // the plugin blocks the call instead.
+  it.each([
+    {
+      name: "Object.assign throws",
+      args: { command: "echo sonia@grafana.com" },
+      wantDetail: /Cannot assign to read only property/,
+    },
+    {
+      name: "delete throws",
+      args: { command: "echo sonia@grafana.com", apiKey: "sk-secret" },
+      wantDetail: /Cannot delete property/,
+    },
+  ])("blocks the call and exports no span when $name", async (tc) => {
+    const hookServer = await startHookServer({
+      action: "allow",
+      evaluations: [],
+      transformed_input: {
+        output: [
+          {
+            role: "assistant",
+            parts: [
+              {
+                kind: "tool_call",
+                tool_call: {
+                  id: "call-1",
+                  name: "bash",
+                  input_json: base64Json({ command: "echo [REDACTED]" }),
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    servers.push(hookServer.server);
+
+    const hooks = await createAgento11yHooks(config(hookServer.baseUrl), {
+      session: { message: async () => ({ data: { parts: [] } }) },
+    } as any);
+    if (!hooks) throw new Error("expected hooks");
+
+    const args = Object.freeze({ ...tc.args }) as Record<string, unknown>;
+
+    const err = await hooks
+      .toolExecuteBefore(
+        { sessionID: "sess-1", callID: "call-1", tool: "bash" },
+        { args },
+      )
+      .catch((e: unknown) => e as Error);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err?.message).toMatch(
+      /could not apply the redacted arguments .* for the "bash" tool call/,
+    );
+    expect(err?.message).toMatch(tc.wantDetail);
+    // Same closing line as a policy deny, so the model stops instead of
+    // retrying the call or working around it.
+    expect(err?.message).toContain("Stop and tell the user");
+
+    expect(args).toEqual(tc.args);
+    // Same as a deny: the blocked call leaves no record to export, so no span
+    // reports a call that never ran.
+    expect(_peekToolExecutionState().active).toHaveLength(0);
+    expect(_peekToolExecutionState().completed).toHaveLength(0);
 
     await emitServerInstanceDisposed(hooks);
   });
@@ -250,21 +361,20 @@ describe("opencode guards", () => {
     } as any);
     if (!hooks) throw new Error("expected hooks");
 
-    const output: { args: Record<string, unknown> } = {
-      args: { command: "secret", apiKey: "x" },
-    };
-    await hooks.toolExecuteBefore(
+    const args: Record<string, unknown> = { command: "secret", apiKey: "x" };
+    await runToolLikeOpencode(
+      hooks,
       { sessionID: "sess-1", callID: "call-1", tool: "bash" },
-      output,
+      args,
     );
 
     // An intentional "strip all arguments" transform empties the object.
-    expect(output.args).toEqual({});
+    expect(args).toEqual({});
 
     await emitServerInstanceDisposed(hooks);
   });
 
-  it("fails open and leaves args untouched when args are not a plain object", async () => {
+  it("blocks the call when args are not a plain object", async () => {
     const hookServer = await startHookServer({
       action: "allow",
       evaluations: [],
@@ -294,15 +404,17 @@ describe("opencode guards", () => {
     if (!hooks) throw new Error("expected hooks");
 
     // opencode hands tool args as an object; an array here stands in for any
-    // non-plain-object value the apply path must refuse to mutate.
+    // non-plain-object value the redacted set cannot be written into.
     const args: unknown[] = ["ls", "-la"];
-    await hooks.toolExecuteBefore(
-      { sessionID: "sess-1", callID: "call-1", tool: "bash" },
-      { args },
-    );
+    await expect(
+      hooks.toolExecuteBefore(
+        { sessionID: "sess-1", callID: "call-1", tool: "bash" },
+        { args },
+      ),
+    ).rejects.toThrow("args are not a plain object");
 
-    // Fail open: the original (unmutated) args are preserved.
     expect(args).toEqual(["ls", "-la"]);
+    expect(_peekToolExecutionState().active).toHaveLength(0);
 
     await emitServerInstanceDisposed(hooks);
   });
@@ -353,6 +465,825 @@ describe("opencode guards", () => {
         },
       },
     });
+
+    await emitServerInstanceDisposed(hooks);
+  });
+});
+
+type PreflightServer = {
+  server: Server;
+  baseUrl: string;
+  captures: Array<Record<string, any>>;
+};
+
+/**
+ * Hook server whose response depends on the request, so a test can drive
+ * several provider steps with different conversation content. `respond`
+ * returning `"error"` stands in for a failing guard backend, and returning
+ * undefined for a hanging one (timeout).
+ */
+function startPreflightServer(
+  respond: (
+    req: Record<string, any>,
+    callIndex: number,
+  ) => Record<string, unknown> | "error" | undefined,
+): Promise<PreflightServer> {
+  const captures: Array<Record<string, any>> = [];
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        const parsed = JSON.parse(body);
+        captures.push(parsed);
+        const payload = respond(parsed, captures.length - 1);
+        if (payload === undefined) return; // never answers
+        if (payload === "error") {
+          res.statusCode = 503;
+          res.end("guard backend unavailable");
+          return;
+        }
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify(payload));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        throw new Error("expected AddressInfo from server.address()");
+      }
+      resolve({ server, baseUrl: `http://127.0.0.1:${addr.port}`, captures });
+    });
+  });
+}
+
+function textPart(id: string, messageID: string, text: string): Part {
+  return {
+    id,
+    sessionID: "sess-1",
+    messageID,
+    type: "text",
+    text,
+  } as Part;
+}
+
+function userEntry(id: string, text: string) {
+  return {
+    info: { id, role: "user", sessionID: "sess-1" } as any,
+    parts: [textPart(`${id}-p1`, id, text)],
+  };
+}
+
+function assistantEntry(id: string, text: string) {
+  return {
+    info: { id, role: "assistant", sessionID: "sess-1" } as any,
+    parts: [textPart(`${id}-p1`, id, text)],
+  };
+}
+
+function toolEntry(id: string) {
+  return {
+    info: { id, role: "assistant", sessionID: "sess-1" } as any,
+    parts: [
+      {
+        id: `${id}-p1`,
+        sessionID: "sess-1",
+        messageID: id,
+        type: "tool",
+        callID: "call-1",
+        tool: "bash",
+        state: {
+          status: "completed",
+          input: { command: "echo secret" },
+          output: "secret output",
+          title: "bash",
+          metadata: {},
+          time: { start: 1, end: 2 },
+        },
+      } as Part,
+    ],
+  };
+}
+
+/** Response echoing one transformed message per forwarded message. */
+function transformResponse(texts: Array<string | null>) {
+  return {
+    action: "allow",
+    evaluations: [],
+    transformed_input: {
+      messages: texts.map((text) => ({
+        role: "user",
+        parts: text === null ? [] : [{ kind: "text", text }],
+      })),
+    },
+  };
+}
+
+async function hooksFor(
+  baseUrl: string,
+  overrides?: Partial<Agento11yOpencodeConfig>,
+) {
+  const hooks = await createAgento11yHooks(
+    { ...config(baseUrl), ...overrides },
+    stubClient(),
+  );
+  if (!hooks) throw new Error("expected hooks");
+  return hooks;
+}
+
+/** Lets a scheduled guard toast run. */
+async function flushToasts(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 5));
+}
+
+/** Toast bodies the plugin sent, in order. */
+let toasts: Array<{ title?: string; message: string; variant: string }> = [];
+/** `app.log` bodies the plugin sent, in order. */
+let logs: Array<{ service: string; level: string; message: string }> = [];
+/** Session ids the plugin asked opencode to abort, in order. */
+let aborts: string[] = [];
+
+function stubClient() {
+  return {
+    session: {
+      message: async () => ({ data: { parts: [] } }),
+      abort: async (options: { path: { id: string } }) => {
+        aborts.push(options.path.id);
+        return { data: true };
+      },
+    },
+    app: {
+      log: async (options: { body: any }) => {
+        logs.push(options.body);
+        return { data: true };
+      },
+    },
+    tui: {
+      showToast: async (options: { body: any }) => {
+        toasts.push(options.body);
+        return { data: true };
+      },
+    },
+  } as any;
+}
+
+type Entry = { info: any; parts: Part[] };
+
+/** The text of every part, in order. `undefined` for a part with no text. */
+function partTexts(messages: Entry[]): Array<Array<string | undefined>> {
+  return messages.map((msg) =>
+    (msg.parts ?? []).map((part) => (part as { text?: string }).text),
+  );
+}
+
+describe("opencode preflight guard", () => {
+  const servers: Server[] = [];
+
+  beforeEach(() => {
+    _resetHookState();
+    toasts = [];
+    logs = [];
+    aborts = [];
+    // The delay exists to lose a race with opencode's own toast; a case that
+    // asserts the toast should not wait it out. `defers the guard toast` covers
+    // the default.
+    _setGuardToastDelayMs(0);
+  });
+
+  afterEach(async () => {
+    // A scheduled toast outlives the case that caused it, and would otherwise
+    // arrive in the next one after its arrays were reset.
+    await flushToasts();
+    await Promise.all(servers.splice(0).map(closeServer));
+  });
+
+  type PreflightCase = {
+    name: string;
+    /** `"error"` stands in for a failing backend, undefined for a hanging one. */
+    respond?: (
+      req: Record<string, any>,
+      callIndex: number,
+    ) => Record<string, unknown> | "error" | undefined;
+    config?: Partial<Agento11yOpencodeConfig>;
+    /** Runs before the transform, to seed session context. */
+    setup?: (
+      hooks: Awaited<ReturnType<typeof hooksFor>>,
+    ) => void | Promise<void>;
+    build: () => { messages: Entry[]; pinned?: Part };
+    wantCalls: number;
+    wantTexts: Array<Array<string | undefined>>;
+    /** Expected `input.messages` of the first evaluation. */
+    wantForwarded?: unknown;
+    /** Substrings that must each appear in a debug log line. */
+    wantLog?: string[];
+    /** Substring the call must reject with, when it refuses the turn. */
+    wantThrow?: string;
+    assert?: (args: {
+      messages: Entry[];
+      pinned?: Part;
+      captures: Array<Record<string, any>>;
+    }) => void;
+  };
+
+  const cases: PreflightCase[] = [
+    {
+      name: "evaluates nothing and leaves messages untouched when guards are disabled",
+      config: { guards: { enabled: false, timeoutMs: 1500, failOpen: true } },
+      respond: () => transformResponse(["[REDACTED]"]),
+      build: () => ({
+        messages: [
+          userEntry("m1", "authorization=secret-123"),
+          assistantEntry("m2", "ok"),
+        ],
+      }),
+      wantCalls: 0,
+      wantTexts: [["authorization=secret-123"], ["ok"]],
+    },
+    {
+      name: "rewrites provider-bound text and carries the execution context",
+      respond: () => transformResponse(["authorization=[REDACTED]", "ok"]),
+      // The hook input has neither agent nor model; both come from the session.
+      setup: (hooks) =>
+        hooks.chatMessage(
+          {
+            sessionID: "sess-1",
+            agent: "build",
+            model: { providerID: "anthropic", modelID: "claude-sonnet-4" },
+          },
+          {
+            message: {
+              id: "m1",
+              sessionID: "sess-1",
+              role: "user",
+              system: "",
+              tools: {},
+            } as any,
+            parts: [],
+          },
+        ),
+      build: () => ({
+        messages: [
+          userEntry("m1", "authorization=secret-123"),
+          assistantEntry("m2", "ok"),
+        ],
+      }),
+      wantCalls: 1,
+      wantTexts: [["authorization=[REDACTED]"], ["ok"]],
+      wantForwarded: [
+        {
+          role: "user",
+          parts: [{ kind: "text", text: "authorization=secret-123" }],
+        },
+        { role: "assistant", parts: [{ kind: "text", text: "ok" }] },
+      ],
+      assert: ({ captures }) => {
+        expect(captures[0]).toMatchObject({
+          phase: "preflight",
+          context: {
+            agent_name: "opencode:build",
+            agent_version: "test-version",
+            model: { provider: "anthropic", name: "claude-sonnet-4" },
+          },
+        });
+      },
+    },
+    {
+      name: "forwards a placeholder for a slot with no redactable text",
+      respond: () => transformResponse(["a", null, "c"]),
+      build: () => ({
+        messages: [
+          userEntry("m1", "one"),
+          toolEntry("m2"),
+          userEntry("m3", "three"),
+        ],
+      }),
+      wantCalls: 1,
+      wantTexts: [["a"], [undefined], ["c"]],
+      wantForwarded: [
+        { role: "user", parts: [{ kind: "text", text: "one" }] },
+        { role: "assistant", parts: [] },
+        { role: "user", parts: [{ kind: "text", text: "three" }] },
+      ],
+      assert: ({ messages }) => {
+        expect((messages[1].parts[0] as any).state.output).toBe(
+          "secret output",
+        );
+      },
+    },
+    {
+      name: "skips the evaluation when no slot carries redactable text",
+      respond: () => transformResponse(["[R]"]),
+      build: () => ({
+        messages: [
+          { info: { id: "m1", role: "user", sessionID: "sess-1" }, parts: [] },
+        ],
+      }),
+      wantCalls: 0,
+      wantTexts: [[]],
+    },
+    {
+      name: "leaves messages untouched when the response carries no transform",
+      respond: () => ({ action: "allow", evaluations: [] }),
+      build: () => ({
+        messages: [userEntry("m1", "hello"), assistantEntry("m2", "ok")],
+      }),
+      wantCalls: 1,
+      wantTexts: [["hello"], ["ok"]],
+    },
+    {
+      name: "discards a transform with too few messages",
+      respond: () => transformResponse(["[R1]", "[R2]"]),
+      build: () => ({
+        messages: [
+          userEntry("m1", "one"),
+          assistantEntry("m2", "two"),
+          userEntry("m3", "three"),
+        ],
+      }),
+      wantCalls: 1,
+      wantTexts: [["one"], ["two"], ["three"]],
+    },
+    {
+      name: "discards a transform with extra messages",
+      respond: () => transformResponse(["[R1]", "[R2]", "[R3]"]),
+      build: () => ({
+        messages: [userEntry("m1", "one"), assistantEntry("m2", "two")],
+      }),
+      wantCalls: 1,
+      wantTexts: [["one"], ["two"]],
+    },
+    {
+      // The SDK turns a failed evaluation into a synthetic allow unless it is
+      // asked to throw, which would send an unredacted conversation to the
+      // provider with nothing in the log.
+      name: "fails open when the evaluation errors, and logs it",
+      respond: () => "error",
+      config: { debug: true },
+      build: () => ({ messages: [userEntry("m1", "hello")] }),
+      wantCalls: 1,
+      wantTexts: [["hello"]],
+      wantLog: ["preflight transform eval failed"],
+    },
+    {
+      // A timeout at the default 1500ms is routine, so it has to be
+      // recoverable from the debug log too.
+      name: "fails open when the evaluation times out, and logs it",
+      respond: () => undefined,
+      config: {
+        debug: true,
+        guards: { enabled: true, timeoutMs: 10, failOpen: true },
+      },
+      build: () => ({ messages: [userEntry("m1", "hello")] }),
+      wantCalls: 1,
+      wantTexts: [["hello"]],
+      wantLog: ["preflight transform eval failed"],
+    },
+    {
+      // Fail-closed reaches this hook too. The refusal itself is asserted
+      // separately, because this table drives the redaction write-back and a
+      // rejected call has nothing to write.
+      name: "leaves the conversation alone when a failed evaluation refuses the turn",
+      respond: () => "error",
+      config: { guards: { enabled: true, timeoutMs: 1500, failOpen: false } },
+      build: () => ({ messages: [userEntry("m1", "hello")] }),
+      wantCalls: 1,
+      wantTexts: [["hello"]],
+      wantThrow: "stopped as a safety measure",
+    },
+    {
+      // The server echoes the whole conversation back with only matched
+      // substrings replaced, so a count of the conversation would read the same
+      // whether one message or none was redacted.
+      name: "logs how many messages were rewritten, not how many were evaluated",
+      respond: () => transformResponse(["token=[R]", "unchanged"]),
+      config: { debug: true },
+      build: () => ({
+        messages: [
+          userEntry("m1", "token=alpha"),
+          assistantEntry("m2", "unchanged"),
+        ],
+      }),
+      wantCalls: 1,
+      wantTexts: [["token=[R]"], ["unchanged"]],
+      wantLog: ["rewrote 1 of 2 messages"],
+    },
+    {
+      // Both dispatch sites pass `{}` as input, so the handler cannot tell the
+      // compaction call from a provider step and evaluates both. Compaction
+      // hands over a structuredClone of prior history.
+      name: "evaluates the compaction dispatch as well",
+      respond: () => transformResponse(["summarize this: [R]"]),
+      build: () => ({
+        messages: structuredClone([
+          userEntry("m1", "summarize this: token=alpha"),
+        ]),
+      }),
+      wantCalls: 1,
+      wantTexts: [["summarize this: [R]"]],
+    },
+    {
+      name: "rewrites a frozen message entry without mutating it",
+      respond: () => transformResponse(["token=[R]"]),
+      build: () => {
+        const pinned = Object.freeze(textPart("m1-p1", "m1", "token=alpha"));
+        return {
+          pinned,
+          messages: [
+            Object.freeze({
+              info: { id: "m1", role: "user", sessionID: "sess-1" } as any,
+              parts: Object.freeze([pinned]) as unknown as Part[],
+            }),
+          ],
+        };
+      },
+      wantCalls: 1,
+      wantTexts: [["token=[R]"]],
+      assert: ({ pinned }) => {
+        expect((pinned as any).text).toBe("token=alpha");
+      },
+    },
+  ];
+
+  it.each(cases)("$name", async ({
+    respond,
+    config: overrides,
+    setup,
+    build,
+    wantCalls,
+    wantTexts,
+    wantForwarded,
+    wantLog,
+    wantThrow,
+    assert,
+  }) => {
+    const hookServer = await startPreflightServer(
+      respond ?? (() => ({ action: "allow", evaluations: [] })),
+    );
+    servers.push(hookServer.server);
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const hooks = await hooksFor(hookServer.baseUrl, overrides);
+    await setup?.(hooks);
+    const { messages, pinned } = build();
+    const ids = messages.map((msg) => msg.info.id);
+
+    const call = hooks.messagesTransform({ messages });
+    if (wantThrow !== undefined) {
+      await expect(call).rejects.toThrow(wantThrow);
+    } else {
+      await expect(call).resolves.toBeUndefined();
+    }
+
+    const lines = stderr.mock.calls.map((call) => call.join(" "));
+    stderr.mockRestore();
+    expect(hookServer.captures).toHaveLength(wantCalls);
+    expect(partTexts(messages)).toEqual(wantTexts);
+    // Message count and order never change, whatever the server returned.
+    expect(messages.map((msg) => msg.info.id)).toEqual(ids);
+    if (wantForwarded !== undefined) {
+      expect(hookServer.captures[0]?.input?.messages).toEqual(wantForwarded);
+    }
+    for (const substring of wantLog ?? []) {
+      expect(lines).toContainEqual(expect.stringContaining(substring));
+    }
+    assert?.({ messages, pinned, captures: hookServer.captures });
+
+    await emitServerInstanceDisposed(hooks);
+  });
+
+  it("evaluates every provider step against that step's own content", async () => {
+    // opencode dispatches this hook once per step with a fresh, unredacted copy
+    // of the conversation, so a reused message id whose text changed must never
+    // receive the earlier step's transform.
+    const hookServer = await startPreflightServer((req) => {
+      const first = req.input?.messages?.[0]?.parts?.[0]?.text as string;
+      return transformResponse([first.replace(/alpha|beta/, "[R]")]);
+    });
+    servers.push(hookServer.server);
+
+    const hooks = await hooksFor(hookServer.baseUrl);
+
+    const step1 = [userEntry("m1", "token=alpha")];
+    await hooks.messagesTransform({ messages: step1 });
+    const step2 = [userEntry("m1", "token=beta")];
+    await hooks.messagesTransform({ messages: step2 });
+
+    // One evaluation per step, each seeing the current text.
+    expect(hookServer.captures).toHaveLength(2);
+    expect(hookServer.captures[0]?.input?.messages?.[0]?.parts?.[0]?.text).toBe(
+      "token=alpha",
+    );
+    expect(hookServer.captures[1]?.input?.messages?.[0]?.parts?.[0]?.text).toBe(
+      "token=beta",
+    );
+    expect((step1[0].parts[0] as any).text).toBe("token=[R]");
+    expect((step2[0].parts[0] as any).text).toBe("token=[R]");
+
+    await emitServerInstanceDisposed(hooks);
+  });
+});
+
+/** A `chat.message` payload carrying one text part, or none when text is null. */
+function chatMessagePayload(text: string | null) {
+  return {
+    input: {
+      sessionID: "sess-1",
+      agent: "build",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4" },
+    },
+    output: {
+      message: {
+        id: "m1",
+        sessionID: "sess-1",
+        role: "user",
+        system: "",
+        tools: {},
+      } as any,
+      parts: text === null ? [] : [textPart("m1-p1", "m1", text)],
+    },
+  };
+}
+
+describe("opencode prompt guard", () => {
+  const servers: Server[] = [];
+
+  beforeEach(() => {
+    _resetHookState();
+    toasts = [];
+    logs = [];
+    aborts = [];
+    // The delay exists to lose a race with opencode's own toast; a case that
+    // asserts the toast should not wait it out. `defers the guard toast` covers
+    // the default.
+    _setGuardToastDelayMs(0);
+  });
+
+  afterEach(async () => {
+    // A scheduled toast outlives the case that caused it, and would otherwise
+    // arrive in the next one after its arrays were reset.
+    await flushToasts();
+    await Promise.all(servers.splice(0).map(closeServer));
+  });
+
+  type PromptCase = {
+    name: string;
+    respond?: (
+      req: Record<string, any>,
+    ) => Record<string, unknown> | "error" | undefined;
+    config?: Partial<Agento11yOpencodeConfig>;
+    /** Text of the submitted message, or null for a message with no parts. */
+    text?: string | null;
+    wantCalls: number;
+    /** Substring the thrown error and the toast must both carry. */
+    wantBlock?: string;
+    assert?: (args: { captures: Array<Record<string, any>> }) => void;
+  };
+
+  const denyResponse = {
+    action: "deny",
+    reason: "secrets are not allowed in prompts",
+    evaluations: [],
+  };
+
+  const cases: PromptCase[] = [
+    {
+      name: "refuses the turn when the guard denies the prompt",
+      respond: () => denyResponse,
+      wantBlock: "secrets are not allowed in prompts",
+      wantCalls: 1,
+      assert: ({ captures }) => {
+        expect(captures[0]).toMatchObject({
+          phase: "preflight",
+          context: {
+            agent_name: "opencode:build",
+            agent_version: "test-version",
+            model: { provider: "anthropic", name: "claude-sonnet-4" },
+          },
+          input: {
+            messages: [
+              { role: "user", parts: [{ kind: "text", text: "key=abc" }] },
+            ],
+          },
+        });
+      },
+    },
+    {
+      name: "lets the turn through when the guard allows",
+      respond: () => ({ action: "allow", evaluations: [] }),
+      wantCalls: 1,
+    },
+    {
+      // The parts here are about to be persisted as the user's own message, so
+      // a transform must not rewrite them. Redaction belongs to the messages
+      // transform, which rewrites only the provider-bound copy.
+      name: "ignores a transform the allow response carries",
+      respond: () => ({
+        action: "allow",
+        evaluations: [],
+        transformed_input: {
+          messages: [
+            { role: "user", parts: [{ kind: "text", text: "[GONE]" }] },
+          ],
+        },
+      }),
+      wantCalls: 1,
+    },
+    {
+      name: "evaluates nothing when guards are disabled",
+      config: { guards: { enabled: false, timeoutMs: 1500, failOpen: true } },
+      respond: () => denyResponse,
+      wantCalls: 0,
+    },
+    {
+      name: "evaluates nothing when the message carries no text",
+      respond: () => denyResponse,
+      text: null,
+      wantCalls: 0,
+    },
+    {
+      name: "lets the turn through when the evaluation fails and fail-open is on",
+      respond: () => "error",
+      wantCalls: 1,
+    },
+    {
+      // Unlike the messages transform, this hook can refuse, so the fail-open
+      // flag reaches preflight here.
+      name: "refuses the turn when the evaluation fails and fail-open is off",
+      config: { guards: { enabled: true, timeoutMs: 1500, failOpen: false } },
+      respond: () => "error",
+      wantBlock: "blocked as a safety measure",
+      wantCalls: 1,
+    },
+  ];
+
+  it.each(cases)("$name", async ({
+    respond,
+    config: overrides,
+    text,
+    wantCalls,
+    wantBlock,
+    assert,
+  }) => {
+    const hookServer = await startPreflightServer(
+      respond ?? (() => ({ action: "allow", evaluations: [] })),
+    );
+    servers.push(hookServer.server);
+
+    const hooks = await hooksFor(hookServer.baseUrl, overrides);
+    const { input, output } = chatMessagePayload(
+      text === undefined ? "key=abc" : text,
+    );
+
+    const call = hooks.chatMessage(input, output);
+    if (wantBlock !== undefined) {
+      await expect(call).rejects.toThrow(wantBlock);
+      await flushToasts();
+      // The durable copy goes through opencode's own logger; the toast is
+      // scheduled late so the host's failure toast does not replace it.
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toMatchObject({ service: "agento11y", level: "error" });
+      expect(logs[0]?.message).toContain(wantBlock);
+      expect(toasts).toHaveLength(1);
+      expect(toasts[0]).toMatchObject({ variant: "error" });
+      expect(toasts[0]?.message).toContain(wantBlock);
+    } else {
+      await expect(call).resolves.toBeUndefined();
+      expect(toasts).toHaveLength(0);
+      expect(logs).toHaveLength(0);
+    }
+
+    expect(hookServer.captures).toHaveLength(wantCalls);
+    // The submitted parts are never rewritten here.
+    if (text !== null) {
+      expect((output.parts[0] as any).text).toBe("key=abc");
+    }
+    assert?.({ captures: hookServer.captures });
+
+    await emitServerInstanceDisposed(hooks);
+  });
+
+  it("drops the refused turn's user-side data", async () => {
+    // opencode creates some assistant messages without a `chat.message` of
+    // their own, so a leftover pending entry would be exported against one of
+    // those carrying the parts of the prompt that never ran.
+    const hookServer = await startPreflightServer(() => denyResponse);
+    servers.push(hookServer.server);
+
+    const hooks = await hooksFor(hookServer.baseUrl);
+    const { input, output } = chatMessagePayload("key=abc");
+    await expect(hooks.chatMessage(input, output)).rejects.toThrow();
+
+    expect(_peekPendingGenerations()).toEqual([]);
+
+    await emitServerInstanceDisposed(hooks);
+  });
+
+  it("still records session context for the export when the prompt is blocked", async () => {
+    // The block aborts the turn, but the stores are written before the
+    // evaluation so the guard request can name the agent and model.
+    const hookServer = await startPreflightServer(() => denyResponse);
+    servers.push(hookServer.server);
+
+    const hooks = await hooksFor(hookServer.baseUrl);
+    const { input, output } = chatMessagePayload("key=abc");
+    await expect(hooks.chatMessage(input, output)).rejects.toThrow();
+
+    expect(hookServer.captures[0]?.context?.agent_name).toBe("opencode:build");
+
+    await emitServerInstanceDisposed(hooks);
+  });
+
+  it("refuses a started turn when the outgoing conversation is denied", async () => {
+    // This is the deny `chat.message` cannot see, because the text is not in the
+    // message the user just submitted.
+    const hookServer = await startPreflightServer(() => denyResponse);
+    servers.push(hookServer.server);
+
+    const hooks = await hooksFor(hookServer.baseUrl);
+    const messages = [userEntry("m1", "one")];
+
+    await expect(hooks.messagesTransform({ messages })).rejects.toThrow(
+      "secrets are not allowed in prompts",
+    );
+
+    await flushToasts();
+    expect(logs).toHaveLength(1);
+    expect(logs[0]?.message).toContain("the turn was stopped");
+    expect(toasts).toHaveLength(1);
+    // Cleanup for the assistant message row opencode has already written,
+    // which its interrupt finalizer owns.
+    expect(aborts).toEqual(["sess-1"]);
+    // A refused turn never reaches the provider, so nothing is rewritten.
+    expect(partTexts(messages)).toEqual([["one"]]);
+
+    await emitServerInstanceDisposed(hooks);
+  });
+
+  it("refuses a started turn when the evaluation fails and fail-open is off", async () => {
+    const hookServer = await startPreflightServer(() => "error");
+    servers.push(hookServer.server);
+
+    const hooks = await hooksFor(hookServer.baseUrl, {
+      guards: { enabled: true, timeoutMs: 1500, failOpen: false },
+    });
+
+    await expect(
+      hooks.messagesTransform({ messages: [userEntry("m1", "one")] }),
+    ).rejects.toThrow("stopped as a safety measure");
+
+    await emitServerInstanceDisposed(hooks);
+  });
+});
+
+describe("guard toast timing", () => {
+  const servers: Server[] = [];
+
+  beforeEach(() => {
+    _resetHookState();
+    toasts = [];
+    logs = [];
+    aborts = [];
+    // Restores the shipped value the other suites turn off, so this one holds
+    // the real delay to being long enough.
+    _setGuardToastDelayMs(_DEFAULT_GUARD_TOAST_DELAY_MS);
+  });
+
+  afterEach(async () => {
+    _setGuardToastDelayMs(0);
+    await flushToasts();
+    await Promise.all(servers.splice(0).map(closeServer));
+  });
+
+  it("defers the guard toast so the host's failure toast cannot replace it", async () => {
+    // Refusing a turn fails the prompt request, and opencode answers that with
+    // its own toast. Its store holds one toast, so ours has to arrive after the
+    // throw the host is still reacting to.
+    //
+    // Deliberately does not set the delay: this is the one case that holds the
+    // shipped default to being long enough to lose that race, which is the only
+    // reason the toast is worth showing at all.
+    const hookServer = await startPreflightServer(() => ({
+      action: "deny",
+      reason: "policy says no",
+      evaluations: [],
+    }));
+    servers.push(hookServer.server);
+
+    const hooks = await hooksFor(hookServer.baseUrl);
+    const { input, output } = chatMessagePayload("key=abc");
+
+    await expect(hooks.chatMessage(input, output)).rejects.toThrow();
+    // The log is written before the throw; the toast is not, and is still not
+    // there several event-loop turns later.
+    expect(logs).toHaveLength(1);
+    await flushToasts();
+    expect(toasts).toHaveLength(0);
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0]?.message).toContain("policy says no");
 
     await emitServerInstanceDisposed(hooks);
   });

--- a/plugins/opencode/src/hooks.testutil.ts
+++ b/plugins/opencode/src/hooks.testutil.ts
@@ -65,6 +65,10 @@ export function makeAgento11yMock(): {
   const sigil = {
     startStreamingGeneration,
     startGeneration,
+    // Allows by default, so a test that enables guards only states the verdict
+    // it cares about. Guard paths that need a real HTTP round trip live in
+    // hooks.guard.test.ts, which builds a client instead of mocking one.
+    evaluateHook: vi.fn(async () => ({ action: "allow" })),
     startToolExecution: vi.fn(() => ({
       setResult: vi.fn(),
       setCallError: vi.fn(),
@@ -80,6 +84,8 @@ export function makeAgento11yMock(): {
 export function makeOpencodeClient(parts: any[] = []) {
   return {
     session: { message: vi.fn(async () => ({ data: { parts } })) },
+    app: { log: vi.fn(async () => ({ data: true })) },
+    tui: { showToast: vi.fn(async () => ({ data: true })) },
   } as any;
 }
 

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -16,14 +16,23 @@ import { createAgento11yClient } from "./client.js";
 import type { Agento11yOpencodeConfig } from "./config.js";
 import { resolveAutoTagValues } from "./config.js";
 import { resolveGitBranch } from "./git.js";
-import { runToolCallGuard } from "./guard.js";
+import {
+  formatTransformFailure,
+  runPreflightTransform,
+  runPromptGuard,
+  runToolCallGuard,
+} from "./guard.js";
 import { stableOpencodeGenerationId } from "./lineage.js";
 import {
+  applyRedactedText,
   legacyToolOverrideNames,
   mapError,
   mapGeneration,
+  mapOutgoingMessagesForHook,
   mapToolDefinitions,
   type OpencodeTokens,
+  type OutgoingMessage,
+  partTextKey,
   type Redactor,
 } from "./mappers.js";
 import { buildBuiltinTags } from "./tags.js";
@@ -146,6 +155,19 @@ type PendingGeneration = {
 };
 const pendingGenerations = new Map<string, PendingGeneration>();
 
+// New text for every part a preflight redact rule rewrote, keyed by
+// `partTextKey(sessionID, partID)`. The export replays it so a generation
+// reports the conversation the provider received. opencode's own message store
+// keeps the original: a redact rule governs what leaves the machine, not what
+// the user typed.
+//
+// Entries survive the turn that produced them. The transform runs on the whole
+// conversation at every step, so an earlier turn's part is rewritten again on
+// each later one, and a per-turn purge would only make the map churn. It holds
+// one entry per part a rule actually matched, and `session.deleted` clears the
+// session's keys by prefix.
+const redactedTextByPart = new Map<string, string>();
+
 // Effective system prompt per session, captured from OpenCode's
 // `experimental.chat.system.transform` hook. The hook fires during request
 // preparation, after OpenCode composes the agent, runtime, and override
@@ -236,11 +258,17 @@ export function _resetHookState(): void {
   firstPartAtByMessage.clear();
   stepTokensByMessage.clear();
   pendingGenerations.clear();
+  redactedTextByPart.clear();
   latestSystemPromptBySession.clear();
   latestSessionTitleBySession.clear();
   hostVersion = undefined;
   sessionContexts.clear();
   _resetToolExecutionState();
+}
+
+/** @internal Exported for testing. Session ids with user-side data pending. */
+export function _peekPendingGenerations(): string[] {
+  return Array.from(pendingGenerations.keys());
 }
 
 /** @internal Exported for testing. */
@@ -272,26 +300,159 @@ function buildAgentName(
 }
 
 /**
- * Called from the chat.message hook. Stores user-side data for later use
- * when the assistant message completes.
+ * Thrown from the `chat.message` hook to refuse a turn a guard denied. Named so
+ * a stack trace says which decision stopped the prompt, rather than reading as
+ * an internal failure.
  */
-function handleChatMessage(
+class GuardBlockedError extends Error {}
+
+/**
+ * Delay before the guard toast, in milliseconds.
+ *
+ * Refusing a turn fails the prompt request, and opencode's TUI answers every
+ * failed prompt with its own "Failed to send prompt" toast, which carries no
+ * reason because the route reports a refused turn as an opaque 500. Its toast
+ * store holds one toast at a time (`ui/toast.tsx`), so it replaces anything
+ * already on screen: a notice shown before the throw is guaranteed to be lost,
+ * and one shown after it wins. The host's toast follows the throw over a local
+ * HTTP round trip, measured at 3ms, so this is a wide margin.
+ */
+export const _DEFAULT_GUARD_TOAST_DELAY_MS = 750;
+
+let guardToastDelayMs: number = _DEFAULT_GUARD_TOAST_DELAY_MS;
+
+/** @internal Exported for testing, so a case need not wait out the delay. */
+export function _setGuardToastDelayMs(ms: number): void {
+  guardToastDelayMs = ms;
+}
+
+/**
+ * Reports a guard decision to the user, through opencode rather than through
+ * this plugin's own stderr, which the TUI hides.
+ *
+ * Two surfaces, and both are best-effort: a decision must not depend on its
+ * notice arriving.
+ *
+ * `app.log` is the durable one and is written now. It goes through opencode's
+ * own logger into `~/.local/share/opencode/log/`, so the reason survives and can
+ * be read after the fact. This is the copy to rely on.
+ *
+ * The toast is scheduled rather than awaited, for the ordering reason on
+ * `guardToastDelayMs`. Returning before it fires is deliberate: the caller
+ * throws next, and the throw is what the host has to answer before this toast
+ * can be the last one standing.
+ */
+async function announceGuardDecision(
+  client: OpencodeClient,
+  debugLog: (msg: string, ...args: unknown[]) => void,
+  message: string,
+): Promise<void> {
+  try {
+    await client.app.log({
+      body: { service: "agento11y", level: "error", message },
+    });
+  } catch (err) {
+    debugLog("guard log failed", err);
+  }
+
+  const timer = setTimeout(() => {
+    void (async () => {
+      try {
+        await client.tui.showToast({
+          body: {
+            title: "Agent Observability",
+            message,
+            variant: "error",
+          },
+        });
+      } catch (err) {
+        debugLog("guard toast failed", err);
+      }
+    })();
+  }, guardToastDelayMs);
+  // The notice is not worth holding the process open for, and opencode may be
+  // shutting down by the time it fires.
+  timer.unref?.();
+}
+
+/**
+ * Called from the `chat.message` hook. Stores user-side data for later use when
+ * the assistant message completes, then evaluates the submitted prompt against
+ * the Agent Observability preflight hook and refuses the turn on a deny.
+ *
+ * Throws `GuardBlockedError` to refuse. opencode dispatches this hook from
+ * `createUserMessage` before it persists the user message and its parts, and
+ * before the step loop starts, so a throw costs no provider call and leaves no
+ * partial message behind. `runPromptGuard` explains why this is the only hook
+ * where refusing is clean.
+ *
+ * An internal failure here fails open. Only the guard's own verdict blocks, and
+ * only `runPromptGuard` decides what an unreachable endpoint means, according to
+ * `AGENTO11Y_GUARDS_FAIL_OPEN`.
+ */
+async function handleChatMessage(
+  sigil: Agento11yClient,
+  config: Agento11yOpencodeConfig,
+  client: OpencodeClient,
+  debugLog: (msg: string, ...args: unknown[]) => void,
   input: {
     sessionID: string;
     agent?: string;
     model?: { providerID: string; modelID: string };
   },
   output: { message: UserMessage; parts: Part[] },
-): void {
+): Promise<void> {
   pendingGenerations.set(input.sessionID, {
     systemPrompt: output.message.system,
     userParts: output.parts,
     tools: output.message.tools,
   });
+  // Written before the evaluation: the agent name and model on the guard
+  // request are read back out of this map.
   sessionContexts.set(input.sessionID, {
     agent: input.agent ?? stringField(output.message, "agent"),
     model: resolveModel(input.model, output.message),
   });
+
+  const guards = config.guards;
+  if (guards?.enabled !== true) return;
+
+  let reason: string | undefined;
+  try {
+    // Same forward mapping as the messages transform, so one rule sees the same
+    // text at both points.
+    const forward = mapOutgoingMessagesForHook([
+      { info: output.message, parts: output.parts },
+    ]);
+    if (!forward.some((msg) => (msg.parts?.length ?? 0) > 0)) {
+      debugLog("prompt guard skipped: no redactable text in the new message");
+      return;
+    }
+    const result = await runPromptGuard({
+      client: sigil,
+      agentName: agentNameForSession(config, input.sessionID),
+      agentVersion: config.agentVersion || hostVersion,
+      model: modelForSession(input.sessionID),
+      messages: forward,
+      failOpen: guards.failOpen,
+      logger: { warn: (msg: string) => debugLog(msg) },
+    });
+    reason = result?.reason;
+  } catch (err) {
+    debugLog("prompt guard failed", err);
+    return;
+  }
+  if (reason === undefined) return;
+
+  // No assistant message will ever consume this turn's user-side data, and
+  // opencode creates assistant messages without a `chat.message` of their own
+  // (a compaction summary, for one), which would otherwise be exported carrying
+  // the parts of the prompt that was refused.
+  pendingGenerations.delete(input.sessionID);
+
+  debugLog(`prompt guard blocked the turn: ${reason}`);
+  await announceGuardDecision(client, debugLog, reason);
+  throw new GuardBlockedError(reason);
 }
 
 /**
@@ -328,6 +489,179 @@ function handleSystemTransform(
   );
   if (prompt === undefined) return;
   latestSystemPromptBySession.set(sessionID, prompt);
+}
+
+/**
+ * Called from the `experimental.chat.messages.transform` hook, the last point
+ * before `MessageV2.toModelMessagesEffect` converts the conversation for the
+ * provider. Evaluates the outgoing messages through the Agent Observability
+ * preflight hook and writes any returned redaction back into the shared
+ * `output.messages` array.
+ *
+ * Throws `GuardBlockedError` to refuse the turn when the guard denies, or when
+ * the evaluation fails and `AGENTO11Y_GUARDS_FAIL_OPEN` is false. An internal
+ * failure fails open. Refusing here costs an unfinished assistant message unless
+ * the abort request in `refuseStartedTurn` arrives first, because opencode has already
+ * written that row by the time it dispatches this hook. Most denies never reach
+ * this point: `handleChatMessage` evaluates the same rules before the row
+ * exists. What reaches it is a deny on conversation history, on text the
+ * assistant produced during the turn, or on a compaction dispatch.
+ *
+ * opencode dispatches the hook inside its step loop (`session/prompt.ts`), so
+ * a prompt with N tool rounds evaluates N+1 times. Results are not cached: a
+ * key looser than the content would apply a transform produced for older text.
+ *
+ * Compaction (`session/compaction.ts`) dispatches the same hook with the same
+ * empty input, so it is evaluated too and reported under the session's chat
+ * agent and model rather than opencode's `compaction` agent.
+ */
+async function handleMessagesTransform(
+  sigil: Agento11yClient,
+  config: Agento11yOpencodeConfig,
+  client: OpencodeClient,
+  debugLog: (msg: string, ...args: unknown[]) => void,
+  output: { messages: OutgoingMessage[] },
+): Promise<void> {
+  const guards = config.guards;
+  if (guards?.enabled !== true) return;
+  // Returned from the evaluation, acted on after the try, so the refusal is not
+  // swallowed by the catch that keeps an internal failure from stopping a turn.
+  const blockReason = await evaluateOutgoingMessages(
+    sigil,
+    config,
+    guards,
+    debugLog,
+    output,
+  );
+  if (blockReason === undefined) return;
+  await refuseStartedTurn(
+    client,
+    debugLog,
+    sessionIdFromOutgoing(output.messages) ?? "",
+    blockReason,
+  );
+}
+
+/**
+ * Evaluates the outgoing conversation and applies any redaction to
+ * `output.messages` in place. Returns a reason to refuse the turn, or undefined
+ * to let it continue. Never throws: refusing is the caller's job, so an internal
+ * failure here cannot stop a turn.
+ */
+async function evaluateOutgoingMessages(
+  sigil: Agento11yClient,
+  config: Agento11yOpencodeConfig,
+  guards: NonNullable<Agento11yOpencodeConfig["guards"]>,
+  debugLog: (msg: string, ...args: unknown[]) => void,
+  output: { messages: OutgoingMessage[] },
+): Promise<string | undefined> {
+  try {
+    const messages = output.messages;
+    if (!Array.isArray(messages) || messages.length === 0) return undefined;
+
+    const forward = mapOutgoingMessagesForHook(messages);
+    // Every slot is a placeholder, so a text transform has nothing to rewrite.
+    // Logged because a shape change in opencode's payload looks the same.
+    if (!forward.some((msg) => (msg.parts?.length ?? 0) > 0)) {
+      debugLog(
+        `preflight transform skipped: no redactable text in ${messages.length} outgoing messages`,
+      );
+      return undefined;
+    }
+
+    // The hook input carries no session id, so it comes from the messages.
+    const sessionID = sessionIdFromOutgoing(messages) ?? "";
+    const result = await runPreflightTransform({
+      client: sigil,
+      agentName: agentNameForSession(config, sessionID),
+      agentVersion: config.agentVersion || hostVersion,
+      model: modelForSession(sessionID),
+      messages: forward,
+      failOpen: guards.failOpen,
+      logger: { warn: (msg: string) => debugLog(msg) },
+    });
+    if (!result) return undefined;
+    if (result.block !== undefined) return result.block;
+
+    const redacted = result.messages;
+    if (!redacted || redacted.length === 0) return undefined;
+
+    // The redaction is aligned by index, so a different message count means it
+    // cannot be placed. Discard the transform and forward the originals.
+    if (redacted.length !== forward.length) {
+      debugLog(
+        `preflight transform dropped: got ${redacted.length} messages, expected ${forward.length}`,
+      );
+      return undefined;
+    }
+
+    // The count is of rewritten messages, not evaluated ones. The server
+    // returns the whole conversation with only matched substrings replaced, so
+    // a count of the conversation would read the same when nothing was
+    // redacted.
+    const applied = applyRedactedText(messages, redacted);
+    if (applied === null) {
+      debugLog(
+        "preflight transform dropped: redacted messages could not be aligned",
+      );
+      return undefined;
+    }
+    for (const [key, text] of applied.textByPart) {
+      redactedTextByPart.set(key, text);
+    }
+    debugLog(
+      `preflight transform applied: rewrote ${applied.messageCount} of ${messages.length} messages`,
+    );
+    return undefined;
+  } catch (err) {
+    debugLog("preflight transform failed", err);
+    return undefined;
+  }
+}
+
+/**
+ * Refuses a turn opencode has already started, from the messages transform.
+ *
+ * Throws, which is what stops the turn: opencode's plugin dispatcher wraps a
+ * hook in `Effect.promise` and catches nothing, so the rejection becomes a
+ * defect that propagates out of the step loop. The session runner completes its
+ * deferred with that exit and returns to idle, so nothing stays wedged.
+ *
+ * The abort request is cleanup, not enforcement. opencode finalizes the
+ * in-flight assistant message from an `Effect.onInterrupt` finalizer, and a
+ * defect is not an interrupt, so without an abort that row keeps
+ * `time.completed` unset and the TUI marks later messages as queued behind it.
+ * Asking opencode to abort the session gets the designed interrupt to run that
+ * finalizer. Whether it arrives before the defect is a race, so it is only ever
+ * cosmetic: the throw below stops the turn either way.
+ */
+async function refuseStartedTurn(
+  client: OpencodeClient,
+  debugLog: (msg: string, ...args: unknown[]) => void,
+  sessionID: string,
+  reason: string,
+): Promise<void> {
+  debugLog(`preflight guard refused the started turn: ${reason}`);
+  await announceGuardDecision(client, debugLog, reason);
+  if (sessionID) {
+    try {
+      await client.session.abort({ path: { id: sessionID } });
+    } catch (err) {
+      debugLog("guard abort request failed", err);
+    }
+  }
+  throw new GuardBlockedError(reason);
+}
+
+/** Newest session id carried by the outgoing messages, if any. */
+function sessionIdFromOutgoing(
+  messages: OutgoingMessage[],
+): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const sessionID = messages[i]?.info?.sessionID;
+    if (sessionID) return sessionID;
+  }
+  return undefined;
 }
 
 async function handleEvent(
@@ -634,8 +968,8 @@ async function recordAssistantMessage(
 
   const result = mapGeneration(
     assistantMsg,
-    includeMessageBodies ? (pending?.userParts ?? []) : [],
-    assistantParts,
+    includeMessageBodies ? redactedForExport(pending?.userParts ?? []) : [],
+    redactedForExport(assistantParts),
     redactor,
     config.contentCapture,
     stepTokens,
@@ -686,6 +1020,34 @@ async function recordAssistantMessage(
   completedToolExecutions.delete(assistantMsg.sessionID);
   firstPartAtByMessage.delete(msgKey);
   stepTokensByMessage.delete(msgKey);
+}
+
+/**
+ * Copy `parts` with the text a preflight redact rule rewrote, so a generation
+ * reports what the provider received. A part no rule matched keeps its
+ * identity, so an unredacted turn allocates nothing.
+ *
+ * Copies rather than writes: these are opencode's own part objects, and
+ * rewriting them would edit the message the user sees in their own transcript.
+ * `runPromptGuard` documents the same rule for the prompt hook.
+ *
+ * Only text is substituted. Tool arguments reach the export through the tool
+ * spans, which report the arguments a postflight rule left the tool to run
+ * with. Nothing covers the assistant text of this turn, which no transform has
+ * seen yet, a tool's result, or the system prompt, which the plugin never sends
+ * to the hook.
+ */
+function redactedForExport(parts: Part[]): Part[] {
+  if (redactedTextByPart.size === 0) return parts;
+  let changed = false;
+  const next = parts.map((part) => {
+    if (part.type !== "text") return part;
+    const text = redactedTextByPart.get(partTextKey(part.sessionID, part.id));
+    if (text === undefined || text === part.text) return part;
+    changed = true;
+    return { ...part, text };
+  });
+  return changed ? next : parts;
 }
 
 function isTerminalMessageUpdate(msg: MessageUpdatedInfo): boolean {
@@ -802,6 +1164,7 @@ async function handleLifecycle(
       latestSessionTitleBySession.delete(sessionId);
       sessionContexts.delete(sessionId);
       completedToolExecutions.delete(sessionId);
+      deleteSessionEntries(redactedTextByPart, sessionId);
       deleteSessionEntries(activeToolExecutions, sessionId);
       deleteSessionEntries(firstPartAtByMessage, sessionId);
       deleteSessionEntries(stepTokensByMessage, sessionId);
@@ -856,34 +1219,78 @@ async function handleToolExecuteBefore(
     throw new Error(res.reason);
   }
   // Postflight transform: the server returned the complete redacted argument
-  // set. Replace `output.args` with a fresh object rather than mutating the
-  // existing one in place: opencode freezes `output.args` on newer versions
-  // (>=1.14), so an in-place `delete`/`Object.assign` would throw and, caught
-  // below, silently run the ORIGINAL unredacted arguments. Reassigning the
-  // property on the (unfrozen) `output` container sidesteps that and still
-  // gives opencode the redacted set at execution time. A fresh object also
-  // enforces wholesale replacement — keys the server dropped do not survive.
+  // set, which has to replace the arguments the tool runs with.
   //
-  // Redaction fails open: if the args aren't a plain object or reassignment
-  // throws, log and let the original arguments through rather than throwing,
-  // which opencode would treat as a tool failure. Because a silently-skipped
-  // redaction is indistinguishable from a leak, only log success once the
-  // replacement has actually happened (not when the transform was parsed).
+  // opencode runs the tool with the same `args` object it handed this hook and
+  // ignores what the hook returns, so `output.args = redacted` reaches nothing
+  // and the tool runs the originals. The redacted set has to be written into
+  // `args` itself. Checked in opencode 1.18.10 at four of its seven call
+  // sites: native tools, MCP server tools, code mode, and the `task` subtask
+  // path that carries arguments into a subagent. Its plugin docs say the same,
+  // to mutate `output` in place and return void.
+  //
+  // The other three sites are the built-in `list_mcp_resources`,
+  // `list_mcp_resource_templates` and `read_mcp_resource`. Each copies
+  // `server` and `uri` out of the args before firing this hook and executes
+  // from the copy, so no write reaches them. The write below still succeeds
+  // and the debug line below still says `applied`, so a transform for those
+  // three is a silent no-op. The gap predates this handler and cannot be
+  // closed from inside the plugin.
+  //
+  // No copy of the redacted set is kept: `record.input` aliases `args`, so a
+  // hook-derived span cannot disagree with what ran. That record reaches an
+  // export only when no terminal part covers the call, because `full` is the
+  // only mode that exports arguments, it fetches the message parts, and
+  // `mergeToolSpanRecords` prefers the part-derived record.
+  //
+  // If the write fails, block the call the way a deny does rather than run the
+  // tool with the unredacted originals, and drop the record so no span reports
+  // a call that never ran. The case to expect is an `args` object the
+  // handler cannot write to. A frozen one throws on the first `delete` when
+  // the server dropped a key, and on `Object.assign` when it dropped none. No
+  // opencode version we know of freezes it, but the hook contract does not
+  // promise a mutable object. Reassigning `output.args` is not a fallback:
+  // opencode ignores it and runs the originals, which is the bug this handler
+  // replaced.
   const args = output.args;
-  if (!args || typeof args !== "object" || Array.isArray(args)) {
-    debugLog(
-      `tool-call transform for ${input.callID} dropped: args are not a plain object`,
-    );
-    return;
+  const failure =
+    !args || typeof args !== "object" || Array.isArray(args)
+      ? "args are not a plain object"
+      : writeToolArgs(args as Record<string, unknown>, res.transform);
+  if (failure) {
+    activeToolExecutions.delete(key);
+    debugLog(`tool-call transform for ${input.callID} failed: ${failure}`);
+    throw new Error(formatTransformFailure(input.tool, failure));
   }
+  debugLog(`tool-call transform for ${input.callID} applied`);
+}
+
+/**
+ * Overwrites `args` in place with the server's redacted argument set. Keys the
+ * server dropped go first, because `Object.assign` alone merges and would
+ * leave an unredacted original behind.
+ *
+ * Returns undefined once the arguments hold the redacted set, or the reason
+ * they could not be written.
+ *
+ * The same replacement runs in pi's `tool_call` handler
+ * (`plugins/pi/src/index.ts`), which lets the original arguments through when
+ * the write fails instead of blocking the call.
+ */
+function writeToolArgs(
+  args: Record<string, unknown>,
+  transform: Record<string, unknown>,
+): string | undefined {
   try {
-    const redacted = { ...res.transform };
-    output.args = redacted;
-    // Keep the recorded span consistent with what actually runs.
-    record.input = redacted;
-    debugLog(`tool-call transform for ${input.callID} applied`);
+    for (const key of Object.keys(args)) {
+      if (!Object.hasOwn(transform, key)) {
+        delete args[key];
+      }
+    }
+    Object.assign(args, transform);
+    return undefined;
   } catch (err) {
-    debugLog(`tool-call transform apply failed for ${input.callID}`, err);
+    return `${err}`;
   }
 }
 
@@ -1186,6 +1593,11 @@ export type Agento11yHooks = {
    * shutdown instead of starting another.
    */
   dispose: () => Promise<void>;
+  /**
+   * Rejects with `GuardBlockedError` when a guard denies the submitted prompt.
+   * The caller must await it and let the rejection through, or opencode sends
+   * the turn anyway and the rejection surfaces as an unhandled promise.
+   */
   chatMessage: (
     input: {
       sessionID: string;
@@ -1193,11 +1605,17 @@ export type Agento11yHooks = {
       model?: { providerID: string; modelID: string };
     },
     output: { message: UserMessage; parts: Part[] },
-  ) => void;
+  ) => Promise<void>;
   systemTransform: (
     input: { sessionID?: string; model?: { id?: string } },
     output: { system: string[] },
   ) => void;
+  /**
+   * Rejects with `GuardBlockedError` when a guard denies the outgoing
+   * conversation. Like `chatMessage`, the caller must await it and let the
+   * rejection through, or the turn continues.
+   */
+  messagesTransform: (output: { messages: OutgoingMessage[] }) => Promise<void>;
   toolExecuteBefore: (
     input: { tool: string; sessionID: string; callID: string },
     output: { args: unknown },
@@ -1318,11 +1736,14 @@ export async function createAgento11yHooks(
     dispose: async () => {
       await shutdownOnce();
     },
-    chatMessage: (input, output) => {
-      handleChatMessage(input, output);
+    chatMessage: async (input, output) => {
+      await handleChatMessage(sigil, config, client, debugLog, input, output);
     },
     systemTransform: (input, output) => {
       handleSystemTransform(input, output, debugLog);
+    },
+    messagesTransform: async (output) => {
+      await handleMessagesTransform(sigil, config, client, debugLog, output);
     },
     toolExecuteBefore: async (input, output) => {
       await handleToolExecuteBefore(sigil, config, debugLog, input, output);

--- a/plugins/opencode/src/index.test.ts
+++ b/plugins/opencode/src/index.test.ts
@@ -21,7 +21,7 @@ vi.mock("./client.js", () => ({
   createAgento11yClient: createAgento11yClientMock,
 }));
 
-import { _resetHookState } from "./hooks.js";
+import { _resetHookState, _setGuardToastDelayMs } from "./hooks.js";
 import {
   baseConfig,
   makeAgento11yMock,
@@ -43,6 +43,7 @@ describe("Agento11yPlugin", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     _resetHookState();
+    _setGuardToastDelayMs(0);
   });
 
   it("wires opencode's dispose hook to the plugin shutdown path", async () => {
@@ -65,5 +66,47 @@ describe("Agento11yPlugin", () => {
 
     expect(Object.keys(hooks)).toEqual([]);
     expect(createAgento11yClientMock).not.toHaveBeenCalled();
+  });
+
+  it("lets a guard deny reject out of the chat.message hook", async () => {
+    // The throw is the whole enforcement mechanism: opencode's plugin
+    // dispatcher has no error handling, so a rejection here stops the turn.
+    // Dropping the `await` in the wrapper would leave the rejection floating
+    // and opencode would send the prompt anyway, which no other test catches.
+    const { sigil } = makeAgento11yMock();
+    sigil.evaluateHook = vi.fn(async () => ({
+      action: "deny",
+      reason: "policy says no",
+      evaluations: [],
+    }));
+    createAgento11yClientMock.mockReturnValue(sigil);
+    loadConfigMock.mockResolvedValue(
+      baseConfig({
+        guards: { enabled: true, timeoutMs: 1500, failOpen: true },
+      }),
+    );
+
+    const input = pluginInput();
+    const hooks = (await Agento11yPlugin(input)) as PluginHooks;
+
+    await expect(
+      hooks["chat.message"]?.({ sessionID: "sess-1", agent: "build" } as any, {
+        message: { id: "m1", sessionID: "sess-1", role: "user" } as any,
+        parts: [
+          {
+            id: "p1",
+            sessionID: "sess-1",
+            messageID: "m1",
+            type: "text",
+            text: "key=abc",
+          } as any,
+        ],
+      }),
+    ).rejects.toThrow("policy says no");
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(input.client.tui.showToast).toHaveBeenCalledTimes(1);
+
+    await hooks.dispose?.();
   });
 });

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -23,11 +23,20 @@ export const Agento11yPlugin: Plugin = async ({ client, directory }) => {
   if (!hooks) return {};
 
   const pluginHooks: HooksWithDispose = {
+    // Awaited, and the rejection is not caught: a guard deny refuses the turn
+    // by throwing, and opencode's plugin dispatcher has no error handling of
+    // its own, so the throw is what stops the prompt.
     "chat.message": async (input, output) => {
-      hooks.chatMessage(input, output);
+      await hooks.chatMessage(input, output);
     },
     "experimental.chat.system.transform": async (input, output) => {
       hooks.systemTransform(input, output);
+    },
+    // The hook input is `{}`, so only the output is forwarded. Awaited, and the
+    // rejection is not caught, for the same reason as `chat.message`: throwing
+    // is what refuses a denied turn.
+    "experimental.chat.messages.transform": async (_input, output) => {
+      await hooks.messagesTransform(output);
     },
     event: async ({ event }) => {
       await hooks.event({ event });

--- a/plugins/opencode/src/mappers.test.ts
+++ b/plugins/opencode/src/mappers.test.ts
@@ -1,12 +1,17 @@
+import type { Message } from "@grafana/agento11y";
 import type { AssistantMessage, Part } from "@opencode-ai/sdk";
 import { describe, expect, it } from "vitest";
 import { createRedactor } from "./hooks.js";
 import {
+  applyRedactedText,
   legacyToolOverrideNames,
   mapGeneration,
   mapInputMessages,
+  mapOutgoingMessagesForHook,
   mapOutputMessages,
   mapToolDefinitions,
+  type OutgoingMessage,
+  partTextKey,
 } from "./mappers.js";
 
 const redactor = createRedactor();
@@ -471,5 +476,471 @@ describe("mapGeneration", () => {
       cacheReadInputTokens: 20,
       cacheWriteInputTokens: 10,
     });
+  });
+});
+
+function textPart(overrides: Partial<Part> & { text: string }): Part {
+  return {
+    id: "p1",
+    sessionID: "s1",
+    messageID: "m1",
+    type: "text",
+    ...overrides,
+  } as Part;
+}
+
+function outgoing(
+  role: string,
+  parts: Part[],
+  id = "m1",
+): { info: { id: string; role: string; sessionID: string }; parts: Part[] } {
+  return { info: { id, role, sessionID: "s1" }, parts };
+}
+
+describe("mapOutgoingMessagesForHook", () => {
+  const cases: Array<{
+    name: string;
+    input: OutgoingMessage[];
+    expected: Message[];
+  }> = [
+    {
+      name: "user text",
+      input: [outgoing("user", [textPart({ text: "authorization=abc" })])],
+      expected: [
+        { role: "user", parts: [{ type: "text", text: "authorization=abc" }] },
+      ],
+    },
+    {
+      name: "joins multiple text parts of one message",
+      input: [
+        outgoing("user", [
+          textPart({ text: "first" }),
+          textPart({ id: "p2", text: "second" }),
+        ]),
+      ],
+      expected: [
+        { role: "user", parts: [{ type: "text", text: "first\nsecond" }] },
+      ],
+    },
+    {
+      name: "assistant text",
+      input: [outgoing("assistant", [textPart({ text: "sure" })])],
+      expected: [
+        { role: "assistant", parts: [{ type: "text", text: "sure" }] },
+      ],
+    },
+    {
+      name: "skips ignored user text but keeps the slot",
+      input: [
+        outgoing("user", [
+          textPart({ text: "reminder", ignored: true } as any),
+        ]),
+      ],
+      expected: [{ role: "user", parts: [] }],
+    },
+    {
+      name: "skips an empty assistant text part, opencode's signed-reasoning separator",
+      input: [
+        outgoing("assistant", [
+          textPart({ text: "" }),
+          textPart({ id: "p2", text: "done" }),
+        ]),
+      ],
+      expected: [
+        { role: "assistant", parts: [{ type: "text", text: "done" }] },
+      ],
+    },
+    {
+      name: "skips reasoning parts because their provider signature must round-trip",
+      input: [
+        outgoing("assistant", [
+          {
+            id: "p1",
+            sessionID: "s1",
+            messageID: "m1",
+            type: "reasoning",
+            text: "thinking about secrets",
+            time: { start: 1 },
+            metadata: { anthropic: { signature: "sig" } },
+          } as Part,
+        ]),
+      ],
+      expected: [{ role: "assistant", parts: [] }],
+    },
+    {
+      name: "skips tool-call and tool-result content, emitting a placeholder",
+      input: [
+        outgoing("assistant", [
+          {
+            id: "p1",
+            sessionID: "s1",
+            messageID: "m1",
+            type: "tool",
+            callID: "call-1",
+            tool: "bash",
+            state: {
+              status: "completed",
+              input: { command: "echo secret" },
+              output: "secret output",
+              title: "bash",
+              metadata: {},
+              time: { start: 1, end: 2 },
+            },
+          } as Part,
+        ]),
+      ],
+      expected: [{ role: "assistant", parts: [] }],
+    },
+    {
+      name: "emits a placeholder for a null slot",
+      input: [null as unknown as OutgoingMessage],
+      expected: [{ role: "unknown", parts: [] }],
+    },
+    {
+      name: "emits a placeholder for a slot with no role",
+      input: [{ parts: [textPart({ text: "orphan" })] }],
+      expected: [{ role: "unknown", parts: [] }],
+    },
+    {
+      name: "emits a placeholder for a message with no parts",
+      input: [{ info: { id: "m1", role: "user", sessionID: "s1" } }],
+      expected: [{ role: "user", parts: [] }],
+    },
+    {
+      name: "preserves one slot per entry in order",
+      input: [
+        outgoing("user", [textPart({ text: "one" })], "m1"),
+        outgoing("assistant", [], "m2"),
+        outgoing("user", [textPart({ text: "three" })], "m3"),
+      ],
+      expected: [
+        { role: "user", parts: [{ type: "text", text: "one" }] },
+        { role: "assistant", parts: [] },
+        { role: "user", parts: [{ type: "text", text: "three" }] },
+      ],
+    },
+  ];
+
+  it.each(cases)("$name", ({ input, expected }) => {
+    expect(mapOutgoingMessagesForHook(input)).toEqual(expected);
+  });
+});
+
+const toolPart = (messageID: string): Part =>
+  ({
+    id: "p1",
+    sessionID: "s1",
+    messageID,
+    type: "tool",
+    callID: "call-1",
+    tool: "bash",
+    state: {
+      status: "completed",
+      input: { command: "echo secret" },
+      output: "secret output",
+      title: "bash",
+      metadata: {},
+      time: { start: 1, end: 2 },
+    },
+  }) as Part;
+
+const reasoningPart = (text: string): Part =>
+  ({
+    id: "p1",
+    sessionID: "s1",
+    messageID: "m1",
+    type: "reasoning",
+    text,
+    time: { start: 1 },
+    metadata: { anthropic: { signature: "sig" } },
+  }) as Part;
+
+/** The text of every part, in order. `undefined` for a part with no text. */
+function partTexts(
+  messages: OutgoingMessage[],
+): Array<Array<string | undefined>> {
+  return messages.map((msg) =>
+    (msg?.parts ?? []).map((part) => (part as { text?: string }).text),
+  );
+}
+
+describe("applyRedactedText", () => {
+  type ApplyCase = {
+    name: string;
+    /** Built per case: the function writes into the array it is given. */
+    build: () => { messages: OutgoingMessage[]; pinned?: Part };
+    redacted: Message[];
+    /** Rewritten message count, or null when the transform was discarded. */
+    want: number | null;
+    /** New text per part key. Only checked when a case sets it. */
+    wantTextByPart?: Record<string, string>;
+    wantTexts: Array<Array<string | undefined>>;
+    assert?: (args: { messages: OutgoingMessage[]; pinned?: Part }) => void;
+  };
+
+  const cases: ApplyCase[] = [
+    {
+      name: "rewrites aligned text",
+      build: () => ({
+        messages: [outgoing("user", [textPart({ text: "token=alpha" })])],
+      }),
+      redacted: [
+        { role: "user", parts: [{ type: "text", text: "token=[REDACTED]" }] },
+      ],
+      want: 1,
+      wantTextByPart: { [partTextKey("s1", "p1")]: "token=[REDACTED]" },
+      wantTexts: [["token=[REDACTED]"]],
+    },
+    {
+      name: "accepts the content shorthand",
+      build: () => ({
+        messages: [outgoing("user", [textPart({ text: "token=alpha" })])],
+      }),
+      redacted: [{ role: "user", content: "token=[REDACTED]" }],
+      want: 1,
+      wantTexts: [["token=[REDACTED]"]],
+    },
+    {
+      // The common case on a partial match: the server echoes every forwarded
+      // message back and only the matched substrings differ. Rewriting an
+      // unchanged entry would collapse it into its first slot on every step.
+      name: "reports zero rewrites when the text came back unchanged",
+      build: () => ({
+        messages: [
+          outgoing("user", [
+            textPart({ text: "keep" }),
+            textPart({ id: "p2", text: "also keep" }),
+          ]),
+        ],
+      }),
+      redacted: [
+        { role: "user", parts: [{ type: "text", text: "keep\nalso keep" }] },
+      ],
+      want: 0,
+      wantTexts: [["keep", "also keep"]],
+    },
+    {
+      name: "counts only the messages the server changed",
+      build: () => ({
+        messages: [
+          outgoing("user", [textPart({ text: "token=alpha" })], "m1"),
+          outgoing("assistant", [textPart({ id: "p2", text: "sure" })], "m2"),
+        ],
+      }),
+      redacted: [
+        { role: "user", parts: [{ type: "text", text: "token=[R]" }] },
+        { role: "assistant", parts: [{ type: "text", text: "sure" }] },
+      ],
+      want: 1,
+      wantTexts: [["token=[R]"], ["sure"]],
+    },
+    {
+      name: "collapses multiple text parts into the first slot",
+      build: () => ({
+        messages: [
+          outgoing("user", [
+            textPart({ text: "keep" }),
+            textPart({ id: "p2", text: "token=alpha" }),
+          ]),
+        ],
+      }),
+      redacted: [
+        { role: "user", parts: [{ type: "text", text: "keep\ntoken=[R]" }] },
+      ],
+      want: 1,
+      // The emptied slot is reported too: an export that replayed only the
+      // first would repeat the text the collapse removed.
+      wantTextByPart: {
+        [partTextKey("s1", "p1")]: "keep\ntoken=[R]",
+        [partTextKey("s1", "p2")]: "",
+      },
+      wantTexts: [["keep\ntoken=[R]", ""]],
+    },
+    {
+      // Writing "" back would delete content rather than redact it: opencode
+      // drops an empty user text part, then drops the message once no part
+      // survives, which would change the outgoing message count.
+      name: "keeps the text when the server stripped it to nothing",
+      build: () => ({
+        messages: [outgoing("user", [textPart({ text: "token=alpha" })])],
+      }),
+      redacted: [{ role: "user", parts: [{ type: "text", text: "" }] }],
+      want: 0,
+      wantTexts: [["token=alpha"]],
+    },
+    {
+      name: "keeps the text when the content shorthand is empty",
+      build: () => ({
+        messages: [outgoing("user", [textPart({ text: "token=alpha" })])],
+      }),
+      redacted: [{ role: "user", content: "" }],
+      want: 0,
+      wantTexts: [["token=alpha"]],
+    },
+    {
+      name: "keeps the text when the server returned no text for the slot",
+      build: () => ({
+        messages: [outgoing("user", [textPart({ text: "token=alpha" })])],
+      }),
+      redacted: [{ role: "user", parts: [] }],
+      want: 0,
+      wantTexts: [["token=alpha"]],
+    },
+    {
+      name: "discards the transform when the server sent fewer messages",
+      build: () => ({
+        messages: [
+          outgoing("user", [textPart({ text: "token=alpha" })], "m1"),
+          outgoing("user", [textPart({ text: "token=beta" })], "m2"),
+        ],
+      }),
+      redacted: [
+        { role: "user", parts: [{ type: "text", text: "token=[R]" }] },
+      ],
+      want: null,
+      wantTexts: [["token=alpha"], ["token=beta"]],
+    },
+    {
+      name: "discards the transform when the server sent extra messages",
+      build: () => ({
+        messages: [outgoing("user", [textPart({ text: "token=alpha" })])],
+      }),
+      redacted: [
+        { role: "user", parts: [{ type: "text", text: "token=[R]" }] },
+        { role: "user", parts: [{ type: "text", text: "extra" }] },
+      ],
+      want: null,
+      wantTexts: [["token=alpha"]],
+    },
+    {
+      name: "discards the transform when a later slot is missing",
+      build: () => ({
+        messages: [
+          outgoing("user", [textPart({ text: "token=alpha" })], "m1"),
+          outgoing("user", [textPart({ id: "p2", text: "token=beta" })], "m2"),
+        ],
+      }),
+      redacted: [
+        { role: "user", parts: [{ type: "text", text: "token=[R]" }] },
+        undefined as unknown as Message,
+      ],
+      want: null,
+      wantTexts: [["token=alpha"], ["token=beta"]],
+    },
+    {
+      name: "leaves a tool part untouched while rewriting eligible slots",
+      build: () => {
+        const pinned = toolPart("m2");
+        return {
+          pinned,
+          messages: [
+            outgoing("user", [textPart({ text: "token=alpha" })], "m1"),
+            outgoing("assistant", [pinned], "m2"),
+            outgoing("user", [textPart({ text: "token=gamma" })], "m3"),
+          ],
+        };
+      },
+      redacted: [
+        { role: "user", parts: [{ type: "text", text: "token=[R1]" }] },
+        { role: "assistant", parts: [{ type: "text", text: "ignored" }] },
+        { role: "user", parts: [{ type: "text", text: "token=[R3]" }] },
+      ],
+      want: 2,
+      wantTexts: [["token=[R1]"], [undefined], ["token=[R3]"]],
+      assert: ({ messages, pinned }) => {
+        expect(messages[1]?.parts?.[0]).toBe(pinned);
+        expect((pinned as any).state.output).toBe("secret output");
+      },
+    },
+    {
+      name: "leaves reasoning parts untouched",
+      build: () => ({
+        messages: [
+          outgoing("assistant", [
+            reasoningPart("token=alpha"),
+            textPart({ id: "p2", text: "done" }),
+          ]),
+        ],
+      }),
+      redacted: [{ role: "assistant", parts: [{ type: "text", text: "[R]" }] }],
+      want: 1,
+      wantTexts: [["token=alpha", "[R]"]],
+      assert: ({ messages }) => {
+        expect((messages[0]?.parts?.[0] as any).metadata).toEqual({
+          anthropic: { signature: "sig" },
+        });
+      },
+    },
+    {
+      // Whether opencode freezes this hook output is version-dependent (it does
+      // for `output.args` on >=1.14), so the write-back must not rely on
+      // in-place mutation succeeding.
+      name: "clones instead of mutating a frozen text part",
+      build: () => {
+        const pinned = Object.freeze(textPart({ text: "token=alpha" }));
+        return {
+          pinned,
+          messages: [
+            Object.freeze({
+              info: { id: "m1", role: "user", sessionID: "s1" },
+              parts: Object.freeze([pinned]) as unknown as Part[],
+            }),
+          ],
+        };
+      },
+      redacted: [
+        { role: "user", parts: [{ type: "text", text: "token=[R]" }] },
+      ],
+      want: 1,
+      wantTexts: [["token=[R]"]],
+      assert: ({ pinned }) => {
+        expect((pinned as any).text).toBe("token=alpha");
+      },
+    },
+    {
+      name: "discards the transform when a frozen part sits in a frozen array",
+      build: () => {
+        const pinned = Object.freeze(textPart({ text: "token=alpha" }));
+        return {
+          pinned,
+          messages: Object.freeze([
+            {
+              info: { id: "m1", role: "user", sessionID: "s1" },
+              parts: [pinned],
+            },
+          ]) as unknown as OutgoingMessage[],
+        };
+      },
+      redacted: [
+        { role: "user", parts: [{ type: "text", text: "token=[R]" }] },
+      ],
+      want: null,
+      wantTexts: [["token=alpha"]],
+    },
+  ];
+
+  it.each(cases)("$name", ({
+    build,
+    redacted,
+    want,
+    wantTextByPart,
+    wantTexts,
+    assert,
+  }) => {
+    const { messages, pinned } = build();
+    const ids = messages.map((msg) => msg?.info?.id);
+
+    const applied = applyRedactedText(messages, redacted);
+
+    expect(applied === null ? null : applied.messageCount).toBe(want);
+    if (wantTextByPart !== undefined) {
+      expect(Object.fromEntries(applied?.textByPart ?? [])).toEqual(
+        wantTextByPart,
+      );
+    }
+    expect(partTexts(messages)).toEqual(wantTexts);
+    // Message count and order never change, whatever the server returned.
+    expect(messages.map((msg) => msg?.info?.id)).toEqual(ids);
+    assert?.({ messages, pinned });
   });
 });

--- a/plugins/opencode/src/mappers.ts
+++ b/plugins/opencode/src/mappers.ts
@@ -4,6 +4,7 @@ import type {
   Message,
   ToolDefinition,
 } from "@grafana/agento11y";
+import type { Hooks } from "@opencode-ai/plugin";
 import type { AssistantMessage, Part } from "@opencode-ai/sdk";
 
 export type { GenerationResult };
@@ -29,8 +30,10 @@ function includesToolBodies(contentCapture: ContentCaptureMode): boolean {
 }
 
 /**
- * Map user-side parts to agento11y input messages. No redaction applied — user text is the
- * user's own data and Agent Observability needs it for prompt analysis when content capture allows it.
+ * Map user-side parts to agento11y input messages. Nothing is redacted here:
+ * user text is the user's own data and Agent Observability needs it for prompt
+ * analysis when content capture allows it. A caller that ran a preflight redact
+ * rule substitutes the rewritten text before calling this.
  */
 export function mapInputMessages(
   parts: Part[],
@@ -223,6 +226,240 @@ export function mapGeneration(
       cost: msg.cost,
     },
   };
+}
+
+/**
+ * One entry of opencode's `experimental.chat.messages.transform` output. The
+ * host requires both fields. They are optional here because opencode hands the
+ * same array to every plugin in turn, so an earlier plugin can have replaced or
+ * emptied an entry. An unrecognized shape becomes a placeholder, not a throw.
+ */
+export type OutgoingMessage = {
+  info?: { id?: string; role?: string; sessionID?: string };
+  parts?: Part[];
+};
+
+type HostOutgoingMessage = Parameters<
+  NonNullable<Hooks["experimental.chat.messages.transform"]>
+>[1]["messages"][number];
+
+/**
+ * Build-time pin on the host payload, never called. Every field of
+ * `OutgoingMessage` is optional, so a host rename of `info` would still compile
+ * and preflight would silently map every message to a placeholder. Reading both
+ * fields off the host type turns that rename into a compile error.
+ */
+function _pinHostOutgoingShape(entry: HostOutgoingMessage): OutgoingMessage {
+  return { info: entry.info, parts: entry.parts };
+}
+
+/** A text part of an outgoing message that preflight may rewrite. */
+type TextSlot = { part: Extract<Part, { type: "text" }> };
+
+/**
+ * Map opencode's outgoing conversation (the messages it is about to convert
+ * for the provider) to agento11y `Message[]` for a preflight hook evaluation.
+ *
+ * Emits one message per input entry, in order, so the redacted round-trip can
+ * be aligned by index. A slot with nothing to evaluate becomes an empty
+ * placeholder, because a shorter array discards the transform on write-back.
+ *
+ * Only text is forwarded, matching what `applyRedactedText` can write back:
+ * - `reasoning` parts carry an opaque provider signature (`part.metadata`)
+ *   that `MessageV2.toModelMessages` replays unchanged, so a rewrite would
+ *   invalidate it. pi drops `thinking` for the same reason.
+ * - Tool arguments are already evaluated postflight by `runToolCallGuard`, and
+ *   tool result text cannot be written back without breaking slot alignment.
+ * - `contentCapture` is not applied: the hook server holds this payload in
+ *   memory and never stores it, so redacting it would defeat the transform.
+ *
+ * The opencode counterpart of `mapAgentMessagesForHook` in
+ * `plugins/pi/src/mappers.ts`. The placeholder-slot contract is shared, the
+ * covered part types are not.
+ */
+export function mapOutgoingMessagesForHook(
+  messages: OutgoingMessage[],
+): Message[] {
+  return messages.map((msg) => {
+    if (!msg) return { role: "unknown", parts: [] };
+    const text = redactableTextSlots(msg)
+      .map((slot) => slot.part.text)
+      .join("\n");
+    return {
+      role: msg.info?.role || "unknown",
+      parts: text.length > 0 ? [{ type: "text", text }] : [],
+    };
+  });
+}
+
+/**
+ * The text parts of an outgoing message that preflight may rewrite, in `parts`
+ * order.
+ *
+ * `ignored` user text is excluded because `MessageV2.toModelMessages` never
+ * sends it. Empty text parts are excluded too: the same conversion drops an
+ * empty user part, and an empty assistant part is the separator opencode keeps
+ * between signed reasoning blocks. Writing into either would add text the
+ * provider does not see today, and redact nothing.
+ */
+function redactableTextSlots(msg: OutgoingMessage): TextSlot[] {
+  const role = msg.info?.role;
+  if (role !== "user" && role !== "assistant") return [];
+  const parts = msg.parts;
+  if (!Array.isArray(parts)) return [];
+
+  const slots: TextSlot[] = [];
+  parts.forEach((part) => {
+    if (!part || part.type !== "text") return;
+    if (part.text.length === 0) return;
+    if (role === "user" && part.ignored === true) return;
+    slots.push({ part });
+  });
+  return slots;
+}
+
+/**
+ * What a preflight transform rewrote: how many messages it touched, and the
+ * new text of every part it wrote, keyed by `partTextKey`. The map includes
+ * the parts a rewrite emptied, so a caller that replays it reproduces the
+ * conversation the provider received rather than a longer one.
+ */
+export type AppliedRedaction = {
+  messageCount: number;
+  textByPart: Map<string, string>;
+};
+
+/**
+ * Key for one part's rewritten text. Scoped by session so a stale entry cannot
+ * outlive `session.deleted`, which clears a session's keys by prefix.
+ */
+export function partTextKey(sessionID: string, partID: string): string {
+  return `${sessionID}\x00${partID}`;
+}
+
+/** One entry's planned rewrite: the new text for each targeted text slot. */
+type MessagePlan = {
+  index: number;
+  entry: OutgoingMessage;
+  parts: Part[];
+  updates: Array<{ slot: TextSlot; text: string }>;
+  needsClone: boolean;
+};
+
+/**
+ * Write redacted text from a server-side preflight transform back into
+ * opencode's outgoing messages, aligned by index. Returns the messages it
+ * rewrote and the new text of each part, or `null` when the transform was
+ * discarded whole. A server that changed nothing yields a count of `0` and an
+ * empty map.
+ *
+ * Message count and order never change, and only text parts are touched. Every
+ * entry is planned before anything is written, so a transform is never applied
+ * halfway.
+ *
+ * `outgoing` is the live array opencode passes to the hook, so writes go
+ * through it. Text parts are mutated in place to keep object identity. A frozen
+ * part is cloned into a new array slot instead, because opencode freezes
+ * `output.args` on newer versions and this payload could follow.
+ *
+ * Shares a name with `applyRedactedText` in `plugins/pi/src/mappers.ts` but not
+ * the behavior: this one is all-or-nothing, handles frozen parts, and returns a
+ * count. Both parse the same `transformed_input` encoding, so a wire change has
+ * to reach both.
+ */
+export function applyRedactedText(
+  outgoing: OutgoingMessage[],
+  redacted: Message[],
+): AppliedRedaction | null {
+  if (outgoing.length !== redacted.length) return null;
+
+  const plans: MessagePlan[] = [];
+  for (let i = 0; i < outgoing.length; i++) {
+    const entry = outgoing[i];
+    const sig = redacted[i];
+    if (!sig) return null;
+    // A placeholder slot the forward mapper kept for alignment. Skipping it
+    // keeps the redaction for the rest of the conversation.
+    if (!entry) continue;
+
+    const slots = redactableTextSlots(entry);
+    const parts = entry.parts;
+    if (slots.length === 0 || !Array.isArray(parts)) continue;
+
+    const text = textFromAgento11yMessage(sig);
+    // Writing an empty string back would delete content rather than redact it:
+    // opencode drops an empty user text part, then drops the message once no
+    // part survives, changing the message count this function preserves.
+    if (text === null || text.length === 0) continue;
+    if (text === slots.map((slot) => slot.part.text).join("\n")) continue;
+
+    // The redacted text goes into the first slot and the rest are emptied. A
+    // transform can add or remove newlines, so splitting it back across the
+    // slots risks misrepresenting the message.
+    plans.push({
+      index: i,
+      entry,
+      parts,
+      updates: slots.map((slot, position) => ({
+        slot,
+        text: position === 0 ? text : "",
+      })),
+      needsClone: slots.some((slot) => Object.isFrozen(slot.part)),
+    });
+  }
+
+  if (plans.some((plan) => plan.needsClone) && Object.isFrozen(outgoing)) {
+    // A frozen part needs its array slot reassigned, and the array is frozen
+    // too. Discard rather than apply the transform to part of the turn.
+    return null;
+  }
+
+  const textByPart = new Map<string, string>();
+  for (const plan of plans) {
+    for (const update of plan.updates) {
+      const { id, sessionID } = update.slot.part;
+      // A part without both ids cannot be matched at export time. It reaches
+      // the provider redacted either way; only the export keeps the original.
+      if (id && sessionID) {
+        textByPart.set(partTextKey(sessionID, id), update.text);
+      }
+    }
+    if (plan.needsClone) {
+      // Keyed by part identity, not position, so a reorder between planning
+      // and writing cannot put a replacement on the wrong part.
+      const replacements = new Map<Part, string>(
+        plan.updates.map((update) => [update.slot.part, update.text]),
+      );
+      const nextParts = plan.parts.map((part) => {
+        const text = replacements.get(part);
+        return text === undefined ? part : { ...part, text };
+      });
+      outgoing[plan.index] = { ...plan.entry, parts: nextParts };
+      continue;
+    }
+    for (const update of plan.updates) {
+      update.slot.part.text = update.text;
+    }
+  }
+  return { messageCount: plans.length, textByPart };
+}
+
+/**
+ * Join the text parts of a server-returned message, or null when it carries no
+ * text. The `content` shorthand is accepted as well as typed parts: the Agent
+ * Observability API emits typed parts, but both encodings round-trip.
+ *
+ * A renamed copy of `extractTextFromAgento11yMessage` in
+ * `plugins/pi/src/mappers.ts`, parsing the same encoding; keep the two aligned.
+ */
+function textFromAgento11yMessage(msg: Message): string | null {
+  if (typeof msg.content === "string") return msg.content;
+  if (!msg.parts) return null;
+  const texts: string[] = [];
+  for (const part of msg.parts) {
+    if (part.type === "text") texts.push(part.text);
+  }
+  return texts.length > 0 ? texts.join("\n") : null;
 }
 
 export function mapError(error: NonNullable<AssistantMessage["error"]>): Error {

--- a/plugins/pi/src/guard.test.ts
+++ b/plugins/pi/src/guard.test.ts
@@ -462,9 +462,9 @@ describe("runPreflightTransform", () => {
 
   it("surfaces a preflight deny without a transform as no-op (cannot block via context)", async () => {
     // The pi `context` event has no `block` field, so a preflight deny
-    // verdict cannot be enforced at this seam. Without transformedInput
-    // there is nothing to apply, so we surface no transform and let the
-    // original messages flow through.
+    // verdict cannot be enforced here. Without transformedInput there is
+    // nothing to apply, so we surface no transform and let the original
+    // messages flow through.
     const { client } = makeClient(async () => ({
       action: "deny",
       reason: "preflight deny",

--- a/plugins/pi/src/guard.ts
+++ b/plugins/pi/src/guard.ts
@@ -100,9 +100,9 @@ export type PreflightTransformResult = { messages: Message[] } | undefined;
  * `undefined` when no usable transform was applied or evaluation failed.
  *
  * Always fails open: pi's `ContextEventResult` has no `block` field, so a
- * preflight deny cannot be enforced at this seam, and any eval error or
- * timeout forwards the original messages. `SIGIL_GUARDS_FAIL_OPEN` only
- * governs the postflight tool-call block decision, so it has no effect here.
+ * preflight deny cannot be enforced here, and any eval error or timeout
+ * forwards the original messages. `SIGIL_GUARDS_FAIL_OPEN` only governs the
+ * postflight tool-call block decision, so it has no effect here.
  */
 export async function runPreflightTransform(
   args: PreflightTransformArgs,


### PR DESCRIPTION
Preflight, when the outgoing message is blocked:

<img width="492" height="252" alt="image" src="https://github.com/user-attachments/assets/e876274d-590c-45c7-8f8d-0924b37500e6" />

Tool block (existing) and a transform guards:

<img width="480" height="447" alt="image" src="https://github.com/user-attachments/assets/f31aa857-0365-450a-bfd9-8be6cf9f7a37" />
