### PR TITLE
fix(plugins/opencode): export subagent turns

### DIFF
--- a/docs/concepts/tags-and-metadata.md
+++ b/docs/concepts/tags-and-metadata.md
@@ -180,6 +180,8 @@ Codex and copilot also add their own `codex.*` and `copilot.*` keys, so this tab
 | `pi.compaction.will_retry` | `true` when pi retries the turn it aborted to run this compaction. Only overflow recovery retries. | pi |
 | `pi.fork.parent_session_id` | Conversation id of the session a fork was taken from. On the fork's first generation only. | pi |
 | `pi.fork.parent_generation_id` | Generation id of the trunk turn the fork continues from. Ships as metadata rather than a parent edge, because the trunk only holds that generation if it ran instrumented. | pi |
+| `opencode.parent_session_id` | Session id of the run that spawned this subagent session. On every subagent generation, including one whose parent turn could not be named. | opencode |
+| `opencode.child_session_id` | Subagent's own session id. Present when its turns were reparented onto the spawning conversation, where `conversation_id` names the root session of the subagent chain instead. | opencode |
 
 ## See also
 

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -112,6 +112,17 @@ The plugin attaches built-in tags of its own:
 
 Built-in tags win collisions with user tags, matching the claude-code and cursor launchers. See [Tags and Metadata](../../docs/concepts/tags-and-metadata.md#built-in-tags-from-the-agent-launchers) for the tags the launchers share.
 
+## Subagent sessions
+
+OpenCode runs a subagent (the `task` tool) in a session of its own. The plugin exports those turns into the conversation that spawned them, so the subagent's work shows up in the parent's timeline rather than as an unrelated conversation:
+
+- `conversation_id` on every child turn is the spawning session's id. A subagent that spawns a subagent of its own flattens the same way: every turn in the tree lands in the root session's conversation, so a grandchild's `conversation_id` is the root rather than its immediate parent.
+- The child's first turn carries `parent_generation_ids` naming the parent turn that made the `task` call. Later child turns chain to the child's own previous turn.
+- `opencode.parent_session_id` metadata names the session that spawned this one, so a nested subagent still reports its immediate parent rather than the root. `opencode.child_session_id` names the child's own session id, which nothing else carries: `conversation_id` holds an ancestor's, so looking up the child session id finds no conversation.
+- The child sends no conversation title. Agent Observability keeps the newest title per conversation, and the child's title names the subagent, so a child landing after the parent's last turn would rename the shared conversation.
+
+If the plugin cannot name the spawning turn, the child keeps its own conversation id and exports no parent edge. That happens when the plugin loaded after OpenCode had already started the parent's turn. The `subagent` tag and `opencode.parent_session_id` are still attached, so the relationship is recorded as metadata instead of an edge.
+
 ## Guards
 
 Guards check a request against rules you configure in Grafana and can stop or rewrite it before the model sees it. Refer to [Set up guards](https://grafana.com/docs/grafana-cloud/machine-learning/agent-observability/guides/guards/) to write the rules. This section covers what they do in OpenCode.

--- a/plugins/opencode/src/hooks.lineage.test.ts
+++ b/plugins/opencode/src/hooks.lineage.test.ts
@@ -22,8 +22,11 @@ import {
   emitPartUpdated,
   emitSessionCreated,
   emitSessionDeleted,
+  emitSessionEvent,
+  inFlightAssistantMessage,
   makeAgento11yMock,
   makeOpencodeClient,
+  type TestHooks,
 } from "./hooks.testutil.js";
 import { stableOpencodeGenerationId } from "./lineage.js";
 
@@ -100,6 +103,15 @@ describe("opencode generation lineage and streaming", () => {
     expect(generations[0]!.seed.parentGenerationIds).toBeUndefined();
     expect(generations[1]!.seed.id).toBe(idB);
     expect(generations[1]!.seed.parentGenerationIds).toEqual([idA]);
+    // A session with no parent keeps its own conversation and no lineage keys.
+    expect(generations.map((g) => g.seed.conversationId)).toEqual([
+      "sess-chain",
+      "sess-chain",
+    ]);
+    expect(generations.map((g) => g.seed.metadata)).toEqual([
+      undefined,
+      undefined,
+    ]);
   });
 
   it("re-exporting the same message after a restart keeps the same id and no parent", async () => {
@@ -124,7 +136,7 @@ describe("opencode generation lineage and streaming", () => {
     expect(generations[1]!.seed.parentGenerationIds).toBeUndefined();
   });
 
-  it("links a subagent child session's first generation to the parent session's latest generation", async () => {
+  it("links a subagent created after the parent's turn completed to that turn", async () => {
     const { sigil, generations } = makeAgento11yMock();
     createAgento11yClientMock.mockReturnValue(sigil);
     const hooks = await createAgento11yHooks(
@@ -133,7 +145,9 @@ describe("opencode generation lineage and streaming", () => {
     );
     if (!hooks) throw new Error("expected hooks");
 
-    // Parent session runs a turn, then spawns a subagent (child session).
+    // The parent's turn has already completed when the child session is
+    // created, so the last assistant message seen for the parent is still the
+    // turn that spawned the child.
     await emitMessageUpdated(hooks, assistantMessage("sess-parent", "msg-1"));
     await emitSessionCreated(hooks, "sess-child", "sess-parent");
     await emitMessageUpdated(hooks, assistantMessage("sess-child", "msg-c1"));
@@ -143,8 +157,8 @@ describe("opencode generation lineage and streaming", () => {
     expect(generations).toHaveLength(2);
     expect(generations[0]!.seed.id).toBe(parentId);
     expect(generations[1]!.seed.id).toBe(childId);
-    // Child's first generation parents onto the spawning session's latest gen.
     expect(generations[1]!.seed.parentGenerationIds).toEqual([parentId]);
+    expect(generations[1]!.seed.conversationId).toBe("sess-parent");
   });
 
   it("keeps intra-session chaining for a child session's later generations", async () => {
@@ -161,14 +175,19 @@ describe("opencode generation lineage and streaming", () => {
     await emitMessageUpdated(hooks, assistantMessage("sess-child-2", "msg-c1"));
     await emitMessageUpdated(hooks, assistantMessage("sess-child-2", "msg-c2"));
 
+    const spawningTurn = stableOpencodeGenerationId("sess-parent-2", "msg-1");
     const childId1 = stableOpencodeGenerationId("sess-child-2", "msg-c1");
     const childId2 = stableOpencodeGenerationId("sess-child-2", "msg-c2");
+    expect(generations[1]!.seed.parentGenerationIds).toEqual([spawningTurn]);
     // The child's second turn chains to its own first turn, not the parent.
     expect(generations[2]!.seed.id).toBe(childId2);
     expect(generations[2]!.seed.parentGenerationIds).toEqual([childId1]);
+    // Every child turn stays in the spawning conversation, not just the first.
+    expect(generations[1]!.seed.conversationId).toBe("sess-parent-2");
+    expect(generations[2]!.seed.conversationId).toBe("sess-parent-2");
   });
 
-  it("freezes the parent link at session.created, not at child-record time", async () => {
+  it("keeps the parent conversation's title off a reparented child", async () => {
     const { sigil, generations } = makeAgento11yMock();
     createAgento11yClientMock.mockReturnValue(sigil);
     const hooks = await createAgento11yHooks(
@@ -177,28 +196,104 @@ describe("opencode generation lineage and streaming", () => {
     );
     if (!hooks) throw new Error("expected hooks");
 
-    // Parent turn 1 is recorded, then the subagent is spawned. The parent then
-    // records a LATER turn 2 *before* the child's turn is recorded. The child
-    // must link to turn 1 — the turn frozen at session.created, the one it was
-    // spawned from — not the parent's latest turn 2. Recording turn 2 before
-    // the child record is what distinguishes freeze-at-creation from a lazy
-    // resolver that would read the parent's current-latest gen (turn 2) at
-    // child-record time.
+    // The child exports after the parent's last turn, and the backend keeps the
+    // newest title per conversation, so sending the child's title would rename
+    // the shared conversation to the subagent's.
+    await emitSessionEvent(hooks, "session.created", {
+      id: "sess-parent-5",
+      title: "Check global identity",
+    });
+    await emitMessageUpdated(
+      hooks,
+      inFlightAssistantMessage("sess-parent-5", "msg-1"),
+    );
+    await emitSessionEvent(hooks, "session.created", {
+      id: "sess-child-5",
+      parentID: "sess-parent-5",
+      title: "Check global identity (@identity-check subagent)",
+    });
+    await emitMessageUpdated(hooks, assistantMessage("sess-parent-5", "msg-1"));
+    await emitMessageUpdated(hooks, assistantMessage("sess-child-5", "msg-c1"));
+
+    expect(generations[0]!.seed.conversationTitle).toBe(
+      "Check global identity",
+    );
+    expect(generations[1]!.seed.conversationId).toBe("sess-parent-5");
+    expect("conversationTitle" in generations[1]!.seed).toBe(false);
+    expect(generations[1]!.seed.metadata).toEqual({
+      "opencode.parent_session_id": "sess-parent-5",
+      "opencode.child_session_id": "sess-child-5",
+    });
+  });
+
+  it("emits a reparented child's tool spans under the parent conversation", async () => {
+    const { sigil, generations } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await createAgento11yHooks(
+      baseConfig(),
+      makeOpencodeClient(),
+    );
+    if (!hooks) throw new Error("expected hooks");
+
+    await emitMessageUpdated(
+      hooks,
+      inFlightAssistantMessage("sess-parent-6", "msg-1"),
+    );
+    await emitSessionCreated(hooks, "sess-child-6", "sess-parent-6");
+    await hooks.toolExecuteBefore(
+      { tool: "bash", sessionID: "sess-child-6", callID: "tc-1" },
+      { args: {} },
+    );
+    hooks.toolExecuteAfter(
+      { tool: "bash", sessionID: "sess-child-6", callID: "tc-1", args: {} },
+      { title: "bash", output: "ok", metadata: {} },
+    );
+    await emitMessageUpdated(hooks, assistantMessage("sess-child-6", "msg-c1"));
+
+    // Spans nested under a turn must name the conversation the turn was
+    // exported into, or the two disagree about where the turn happened.
+    expect(generations[0]!.seed.conversationId).toBe("sess-parent-6");
+    expect(sigil.startToolExecution).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: "sess-parent-6" }),
+    );
+  });
+
+  it("freezes the spawning turn at session.created, not at child-record time", async () => {
+    const { sigil, generations } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await createAgento11yHooks(
+      baseConfig(),
+      makeOpencodeClient(),
+    );
+    if (!hooks) throw new Error("expected hooks");
+
+    // Parent turn 1 completes, then turn 2 starts and spawns the subagent from
+    // a task call inside it. Turn 2 and a later turn 3 both complete before the
+    // child's turn is recorded. The child must link to turn 2, the turn that was
+    // in flight at session.created: not turn 1 (the pre-spawn turn) and not
+    // turn 3 (the parent's latest at child-record time, which is what a lazy
+    // resolver would pick).
     await emitMessageUpdated(hooks, assistantMessage("sess-parent-3", "msg-1"));
+    await emitMessageUpdated(
+      hooks,
+      inFlightAssistantMessage("sess-parent-3", "msg-2"),
+    );
     await emitSessionCreated(hooks, "sess-child-3", "sess-parent-3");
     await emitMessageUpdated(hooks, assistantMessage("sess-parent-3", "msg-2"));
+    await emitMessageUpdated(hooks, assistantMessage("sess-parent-3", "msg-3"));
     await emitMessageUpdated(hooks, assistantMessage("sess-child-3", "msg-c1"));
 
-    const parentTurn1 = stableOpencodeGenerationId("sess-parent-3", "msg-1");
-    const parentTurn2 = stableOpencodeGenerationId("sess-parent-3", "msg-2");
+    const spawningTurn = stableOpencodeGenerationId("sess-parent-3", "msg-2");
+    const preSpawnTurn = stableOpencodeGenerationId("sess-parent-3", "msg-1");
+    const laterTurn = stableOpencodeGenerationId("sess-parent-3", "msg-3");
     const childId = stableOpencodeGenerationId("sess-child-3", "msg-c1");
     const child = generations.find((g) => g.seed.id === childId);
-    expect(child?.seed.parentGenerationIds).toEqual([parentTurn1]);
-    // Explicitly assert it did NOT pick the parent's later turn.
-    expect(child?.seed.parentGenerationIds).not.toEqual([parentTurn2]);
+    expect(child?.seed.parentGenerationIds).toEqual([spawningTurn]);
+    expect(child?.seed.parentGenerationIds).not.toEqual([preSpawnTurn]);
+    expect(child?.seed.parentGenerationIds).not.toEqual([laterTurn]);
   });
 
-  it("tags a subagent but does not link it when the parent has no recorded generation yet", async () => {
+  it("links a subagent spawned on the parent's first turn to that in-flight turn", async () => {
     const { sigil, generations } = makeAgento11yMock();
     createAgento11yClientMock.mockReturnValue(sigil);
     const hooks = await createAgento11yHooks(
@@ -207,16 +302,182 @@ describe("opencode generation lineage and streaming", () => {
     );
     if (!hooks) throw new Error("expected hooks");
 
-    // session.created arrives before the parent has recorded any generation.
-    // No parent generation exists to freeze, so the child records unlinked
-    // (fails safe) rather than guessing. The tag comes from `Session.parentID`
-    // alone, so it survives the dropped lineage edge.
+    // Event order observed on opencode 1.18.10 for a one-shot run: the parent's
+    // assistant message arrives without `time.completed`, the child session is
+    // created from a task call inside it, the child runs to completion, and the
+    // parent's turn only completes afterwards. The parent has recorded no
+    // generation when the child is created, so the edge can only come from the
+    // in-flight message.
+    await emitMessageUpdated(
+      hooks,
+      inFlightAssistantMessage("sess-parent-4", "msg-1"),
+    );
     await emitSessionCreated(hooks, "sess-child-4", "sess-parent-4");
     await emitMessageUpdated(hooks, assistantMessage("sess-child-4", "msg-c1"));
+    await emitMessageUpdated(hooks, assistantMessage("sess-parent-4", "msg-1"));
+
+    const spawningTurn = stableOpencodeGenerationId("sess-parent-4", "msg-1");
+    expect(generations).toHaveLength(2);
+    expect(generations[0]!.seed.id).toBe(
+      stableOpencodeGenerationId("sess-child-4", "msg-c1"),
+    );
+    expect(generations[0]!.seed.parentGenerationIds).toEqual([spawningTurn]);
+    expect(generations[0]!.seed.conversationId).toBe("sess-parent-4");
+    expect(generations[0]!.seed.tags?.subagent).toBe("true");
+    // The parent's own turn exports later under the same conversation.
+    expect(generations[1]!.seed.id).toBe(spawningTurn);
+    expect(generations[1]!.seed.conversationId).toBe("sess-parent-4");
+  });
+
+  it("keeps a subagent in its own conversation when the spawning turn was never seen", async () => {
+    const { sigil, generations } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await createAgento11yHooks(
+      baseConfig(),
+      makeOpencodeClient(),
+    );
+    if (!hooks) throw new Error("expected hooks");
+
+    // The plugin loaded mid-run: session.created names the parent, but no
+    // assistant message for it was ever observed, so the spawning turn cannot
+    // be named. The child keeps its own conversation and carries the parent
+    // session as metadata, because an orphan under the parent conversation is
+    // worse than a child under its own.
+    await emitSessionCreated(hooks, "sess-child-7", "sess-parent-7");
+    await emitMessageUpdated(hooks, assistantMessage("sess-child-7", "msg-c1"));
 
     expect(generations).toHaveLength(1);
     expect(generations[0]!.seed.parentGenerationIds).toBeUndefined();
+    expect(generations[0]!.seed.conversationId).toBe("sess-child-7");
+    expect(generations[0]!.seed.metadata).toEqual({
+      "opencode.parent_session_id": "sess-parent-7",
+    });
     expect(generations[0]!.seed.tags?.subagent).toBe("true");
+  });
+
+  // The export says nothing about a dropped edge beyond an absent field, so the
+  // log line is the only local signal that a link could not be resolved.
+  it("debug-logs a subagent link it cannot resolve and stays quiet otherwise", async () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    const unresolved = () =>
+      logged.mock.calls.some(
+        ([msg]) =>
+          typeof msg === "string" && msg.includes("no assistant turn seen"),
+      );
+    const { sigil } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await createAgento11yHooks(
+      baseConfig({ debug: true }),
+      makeOpencodeClient(),
+    );
+    if (!hooks) throw new Error("expected hooks");
+
+    await emitSessionCreated(hooks, "sess-child-9", "sess-parent-9");
+    expect(unresolved()).toBe(true);
+
+    logged.mockClear();
+    await emitMessageUpdated(
+      hooks,
+      inFlightAssistantMessage("sess-parent-10", "msg-1"),
+    );
+    await emitSessionCreated(hooks, "sess-child-10", "sess-parent-10");
+    expect(unresolved()).toBe(false);
+
+    logged.mockRestore();
+  });
+
+  it("flattens a nested subagent onto the root conversation", async () => {
+    const { sigil, generations } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await createAgento11yHooks(
+      baseConfig(),
+      makeOpencodeClient(),
+    );
+    if (!hooks) throw new Error("expected hooks");
+
+    await emitMessageUpdated(
+      hooks,
+      inFlightAssistantMessage("sess-root-8", "msg-r1"),
+    );
+    await emitSessionCreated(hooks, "sess-child-8", "sess-root-8");
+    await emitMessageUpdated(
+      hooks,
+      inFlightAssistantMessage("sess-child-8", "msg-c1"),
+    );
+    await emitSessionCreated(hooks, "sess-grand-8", "sess-child-8");
+    await emitMessageUpdated(hooks, assistantMessage("sess-grand-8", "msg-g1"));
+    await emitMessageUpdated(hooks, assistantMessage("sess-child-8", "msg-c1"));
+    await emitMessageUpdated(hooks, assistantMessage("sess-root-8", "msg-r1"));
+
+    expect(generations.map((g) => g.seed.conversationId)).toEqual([
+      "sess-root-8",
+      "sess-root-8",
+      "sess-root-8",
+    ]);
+    // The grandchild links to the child turn that spawned it, which lives in
+    // the root conversation too, so the edge never crosses conversations.
+    expect(generations[0]!.seed.parentGenerationIds).toEqual([
+      stableOpencodeGenerationId("sess-child-8", "msg-c1"),
+    ]);
+    // Metadata names the immediate parent, so depth survives the flattening.
+    expect(generations[0]!.seed.metadata).toEqual({
+      "opencode.parent_session_id": "sess-child-8",
+      "opencode.child_session_id": "sess-grand-8",
+    });
+  });
+
+  const parentChains: Array<{
+    name: string;
+    setup: (
+      hooks: TestHooks,
+    ) => Promise<{ sessionID: string; expectedConversationId: string }>;
+  }> = [
+    {
+      name: "a parent chain that forms a cycle",
+      setup: async (hooks) => {
+        const chain = ["sess-cycle-a", "sess-cycle-b"];
+        for (const id of chain) {
+          await emitMessageUpdated(hooks, inFlightAssistantMessage(id, "m-1"));
+        }
+        await emitSessionCreated(hooks, chain[0]!, chain[1]!);
+        await emitSessionCreated(hooks, chain[1]!, chain[0]!);
+        // The walk leaves `sess-cycle-a`, reaches `sess-cycle-b`, and stops
+        // there because the only hop left returns to a session it has visited.
+        return { sessionID: chain[0]!, expectedConversationId: chain[1]! };
+      },
+    },
+    {
+      name: "a 20-session parent chain",
+      setup: async (hooks) => {
+        const chain = Array.from({ length: 20 }, (_, i) => `sess-deep-${i}`);
+        for (const [index, id] of chain.entries()) {
+          await emitMessageUpdated(hooks, inFlightAssistantMessage(id, "m-1"));
+          const parent = chain[index - 1];
+          if (parent) await emitSessionCreated(hooks, id, parent);
+        }
+        // Depth is not capped: the deepest session exports into the root of the
+        // chain, the only session that is not itself a subagent.
+        return { sessionID: chain.at(-1)!, expectedConversationId: chain[0]! };
+      },
+    },
+  ];
+
+  it.each(parentChains)("resolves the conversation id for $name", async ({
+    setup,
+  }) => {
+    const { sigil, generations } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await createAgento11yHooks(
+      baseConfig(),
+      makeOpencodeClient(),
+    );
+    if (!hooks) throw new Error("expected hooks");
+
+    const { sessionID, expectedConversationId } = await setup(hooks);
+    await emitMessageUpdated(hooks, assistantMessage(sessionID, "m-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.conversationId).toBe(expectedConversationId);
   });
 
   it("does not link or tag a root session with no parentID", async () => {
@@ -234,6 +495,8 @@ describe("opencode generation lineage and streaming", () => {
     expect(generations).toHaveLength(1);
     expect(generations[0]!.seed.parentGenerationIds).toBeUndefined();
     expect(generations[0]!.seed.tags?.subagent).toBeUndefined();
+    expect(generations[0]!.seed.conversationId).toBe("sess-root");
+    expect(generations[0]!.seed.metadata).toBeUndefined();
   });
 
   it("tags a child session's generations with subagent=true", async () => {
@@ -308,6 +571,74 @@ describe("opencode generation lineage and streaming", () => {
 
     expect(generations).toHaveLength(1);
     expect(generations[0]!.seed.tags?.subagent).toBeUndefined();
+  });
+
+  it("drops the spawning turn and reparenting on session.deleted", async () => {
+    const { sigil, generations } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await createAgento11yHooks(
+      baseConfig(),
+      makeOpencodeClient(),
+    );
+    if (!hooks) throw new Error("expected hooks");
+
+    await emitMessageUpdated(
+      hooks,
+      inFlightAssistantMessage("sess-parent-del-2", "m-1"),
+    );
+    await emitSessionCreated(hooks, "sess-del-lineage", "sess-parent-del-2");
+    await emitSessionDeleted(hooks, "sess-del-lineage");
+    // The id is reused as a root session; no stale lineage may resurface.
+    await emitSessionCreated(hooks, "sess-del-lineage");
+    await emitMessageUpdated(
+      hooks,
+      assistantMessage("sess-del-lineage", "m-1"),
+    );
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.parentGenerationIds).toBeUndefined();
+    expect(generations[0]!.seed.conversationId).toBe("sess-del-lineage");
+    expect(generations[0]!.seed.metadata).toBeUndefined();
+    expect(generations[0]!.seed.tags?.subagent).toBeUndefined();
+  });
+
+  it("does not reuse an in-flight assistant message from before _resetHookState", async () => {
+    const { sigil, generations } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await createAgento11yHooks(
+      baseConfig(),
+      makeOpencodeClient(),
+    );
+    if (!hooks) throw new Error("expected hooks");
+
+    await emitMessageUpdated(
+      hooks,
+      inFlightAssistantMessage("sess-parent-reset-2", "m-1"),
+    );
+    await emitSessionCreated(
+      hooks,
+      "sess-reset-lineage",
+      "sess-parent-reset-2",
+    );
+    _resetHookState();
+    // Both ids are reused and the link is re-announced, but the parent turn
+    // that was in flight before the reset is gone, so no edge may be named.
+    await emitSessionCreated(
+      hooks,
+      "sess-reset-lineage",
+      "sess-parent-reset-2",
+    );
+    await emitMessageUpdated(
+      hooks,
+      assistantMessage("sess-reset-lineage", "m-1"),
+    );
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.parentGenerationIds).toBeUndefined();
+    expect(generations[0]!.seed.conversationId).toBe("sess-reset-lineage");
+    expect(generations[0]!.seed.metadata).toEqual({
+      "opencode.parent_session_id": "sess-parent-reset-2",
+    });
   });
 
   it("records first-token time from the first streamed part", async () => {

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -90,30 +90,39 @@ const recordedMessages = new Map<string, Set<string>>();
 // dedups.
 const lastGenerationIdBySession = new Map<string, string>();
 
+// The latest assistant message seen per session, completed or still streaming.
+// A subagent is spawned from a tool call inside an assistant turn, so this is
+// the turn the child's first generation links to. `lastGenerationIdBySession`
+// cannot serve: it is written when a turn is recorded, and the child's
+// `session.created` arrives while the spawning turn is still in flight.
+const lastSeenAssistantMessageBySession = new Map<string, string>();
+
 // Maps a child (subagent) session id to the parent generation its first
 // assistant turn should link to. opencode runs a subagent in a fresh session
 // whose `Session.parentID` points at the spawning session, surfaced via the
-// `session.created` event. We resolve the parent generation *at creation time*
-// — the spawning session's latest recorded generation — and freeze it here.
+// `session.created` event. The edge is derived from the latest assistant turn
+// seen for the parent, the turn holding the task call, and frozen here. That
+// turn is normally still streaming, but a parent that spawns the subagent from
+// an already-completed turn resolves the same way.
 //
-// Freezing at creation (rather than at child-record time) is deliberate: a
-// subagent is launched from a tool call inside the parent's assistant turn, so
-// the parent's *current* turn is still in flight and unrecorded when the child
-// runs. The already-recorded prior parent generation is the turn the subagent
-// was spawned from, which is the meaningful link. Resolving lazily at
-// child-record time would usually find no parent generation yet and drop the
-// edge.
+// Freezing at creation (rather than at child-record time) is deliberate: by the
+// time the child records, the parent may have started or finished later turns,
+// and a lazy resolver would name whichever turn is latest instead of the one
+// that spawned the child.
 //
 // `AssistantMessage.parentID` is a message-level pointer within one session and
 // is NOT the same as `Session.parentID`; only the latter crosses the
 // parent/subagent boundary.
 const parentGenerationByChildSession = new Map<string, string>();
 
-// Sessions opencode created as subagents, i.e. `session.created` carried a
-// `Session.parentID` pointing at a different session. Kept separate from
-// `parentGenerationByChildSession`, which only holds children whose parent had
-// an already-recorded generation to freeze.
-const subagentSessions = new Set<string>();
+// Maps a child (subagent) session id to its immediate parent session id, set
+// from `session.created` whether or not the generation edge resolves. Once an
+// edge is frozen for the child, a duplicate event cannot change this, so the
+// two always name the same parent. Three readers: the `subagent` tag, the
+// exported conversation id (a linked child's turns are reparented onto the
+// spawning conversation), and the `opencode.parent_session_id` metadata, which
+// is the only lineage signal left when the edge does not resolve.
+const parentSessionByChildSession = new Map<string, string>();
 
 // First streamed assistant part time per message, keyed by
 // `${sessionID}\x00${messageID}`. Captured from `message.part.updated`
@@ -253,8 +262,9 @@ let liveInstances = 0;
 export function _resetHookState(): void {
   recordedMessages.clear();
   lastGenerationIdBySession.clear();
+  lastSeenAssistantMessageBySession.clear();
   parentGenerationByChildSession.clear();
-  subagentSessions.clear();
+  parentSessionByChildSession.clear();
   firstPartAtByMessage.clear();
   stepTokensByMessage.clear();
   pendingGenerations.clear();
@@ -677,7 +687,7 @@ async function handleEvent(
     recordHostVersion(event.properties);
     recordSessionTitle(event.properties, redactor);
     if (event.type === "session.created") {
-      recordSessionParent(event.properties);
+      recordSessionParent(event.properties, debugLog);
     }
     return;
   }
@@ -716,6 +726,16 @@ async function handleEvent(
     }
   }
   if (!assistantMsg) return;
+
+  // Tracked for every assistant update, completed or not, because a subagent
+  // spawned inside this turn links to it (see
+  // `lastSeenAssistantMessageBySession`).
+  if (assistantMsg.sessionID && assistantMsg.id) {
+    lastSeenAssistantMessageBySession.set(
+      assistantMsg.sessionID,
+      assistantMsg.id,
+    );
+  }
 
   await recordAssistantMessage(
     sigil,
@@ -931,18 +951,28 @@ async function recordAssistantMessage(
   const builtinTags = buildBuiltinTags({
     cwd: projectDir,
     gitBranch: resolveGitBranch(projectDir),
-    isSubagent: subagentSessions.has(assistantMsg.sessionID),
+    isSubagent: parentSessionByChildSession.has(assistantMsg.sessionID),
   });
+  const conversationId = resolveExportedConversationId(assistantMsg.sessionID);
+  const reparented = conversationId !== assistantMsg.sessionID;
+  const lineageMetadata = subagentLineageMetadata(
+    assistantMsg.sessionID,
+    reparented,
+  );
   // Sent regardless of content capture mode: the title is host-provided
   // session metadata that opencode shows in its own UI, and the SDK drops it
   // from a `metadata_only` export itself. Already redacted by
   // `recordSessionTitle`.
-  const conversationTitle = latestSessionTitleBySession.get(
-    assistantMsg.sessionID,
-  );
+  //
+  // A reparented child sends no title at all: the backend keeps the newest
+  // title per conversation, so a subagent finishing after the parent's last
+  // turn would rename the shared conversation to the subagent's title.
+  const conversationTitle = reparented
+    ? undefined
+    : latestSessionTitleBySession.get(assistantMsg.sessionID);
   const seed = {
     id: genId,
-    conversationId: assistantMsg.sessionID,
+    conversationId,
     agentName: buildAgentName(config.agentName, assistantMsg.mode),
     agentVersion,
     effectiveVersion: agentVersion,
@@ -954,6 +984,7 @@ async function recordAssistantMessage(
     ...(tools.length > 0 && { tools }),
     ...(includeMessageBodies && { systemPrompt }),
     ...(builtinTags && { tags: builtinTags }),
+    ...(lineageMetadata && { metadata: lineageMetadata }),
   };
 
   // Without an observed step the export pairs last-step tokens with all-steps
@@ -976,7 +1007,7 @@ async function recordAssistantMessage(
   );
 
   const spanOpts = {
-    conversationId: assistantMsg.sessionID,
+    conversationId,
     conversationTitle,
     agentName: buildAgentName(config.agentName, assistantMsg.mode),
     agentVersion,
@@ -1085,32 +1116,113 @@ function recordSessionTitle(properties: unknown, redactor: Redactor): void {
 /**
  * Record the parent/subagent link from a `session.created` event. opencode
  * sets `Session.parentID` on a subagent's session to the spawning session;
- * root sessions omit it. We resolve the spawning session's latest
- * already-recorded generation now and freeze it as the child's parent (see
- * `parentGenerationByChildSession`).
+ * root sessions omit it. The child's parent generation is the latest assistant
+ * turn seen for the parent session, the turn holding the task call, and it is
+ * frozen here (see `parentGenerationByChildSession`). That turn is usually
+ * still streaming, and its deterministic generation id is known before it is
+ * recorded.
  *
  * `session.created` fires exactly once, at spawn time, so the frozen edge
  * always points at the parent turn the subagent was launched from. We
  * deliberately do NOT listen on `session.updated`: it fires repeatedly over a
- * session's life, and freezing on a late update could capture a parent turn
- * recorded *after* the spawning one. If the parent has no recorded generation
- * yet at creation (rare — the spawning turn's predecessor is normally already
- * recorded), we skip the lineage edge: an unlinked child is better than a wrong
- * link. The `subagent` tag does not depend on that edge, so the session is
- * still classified as a subagent. The `has(id)` guard is defensive against a
- * duplicate `session.created`.
+ * session's life, and freezing on a late update could capture a turn that
+ * started *after* the spawning one.
+ *
+ * When no assistant turn has been seen for the parent session, the edge is
+ * skipped and the child keeps its own conversation with
+ * `opencode.parent_session_id` metadata: an unlinked child is better than a
+ * wrong link. The plugin loading mid-run is how that happens in practice. The
+ * `subagent` tag comes from `Session.parentID` alone and survives either way.
+ *
+ * The `has(id)` guard is defensive against a duplicate `session.created`. It
+ * covers the parent session too, because a second event naming a different
+ * parent would otherwise leave the recorded parent session and the frozen edge
+ * pointing at different conversations.
  */
-function recordSessionParent(properties: unknown): void {
+function recordSessionParent(
+  properties: unknown,
+  debugLog: (msg: string, ...args: unknown[]) => void,
+): void {
   const info = recordField(properties, "info");
   if (!info) return;
   const id = stringField(info, "id");
   const parentID = stringField(info, "parentID");
   if (!id || !parentID || id === parentID) return;
-  subagentSessions.add(id);
   if (parentGenerationByChildSession.has(id)) return;
-  const parentGeneration = lastGenerationIdBySession.get(parentID);
-  if (!parentGeneration) return;
-  parentGenerationByChildSession.set(id, parentGeneration);
+  parentSessionByChildSession.set(id, parentID);
+  const spawningMessage = lastSeenAssistantMessageBySession.get(parentID);
+  if (!spawningMessage) {
+    debugLog(
+      `no assistant turn seen for parent session=${parentID}; subagent session=${id} exports unlinked in its own conversation`,
+    );
+    return;
+  }
+  parentGenerationByChildSession.set(
+    id,
+    stableOpencodeGenerationId(parentID, spawningMessage),
+  );
+}
+
+/**
+ * The conversation id a session's turns are exported under: its own session id,
+ * or the conversation of the run that spawned it.
+ *
+ * A linked subagent's turns belong to the spawning conversation, so the parent's
+ * Dependencies view can draw the DAG and the frozen parent edge names a
+ * generation in the same conversation. codex
+ * (`plugins/agento11y/internal/agents/codex/mapper/mapper.go`) and vibe
+ * (`plugins/agento11y/internal/agents/vibe/mapper/mapper.go`) reparent onto the
+ * immediate parent session and stop there, so a grandchild of theirs lands in
+ * the child's session id while the child went to the root.
+ *
+ * This walk follows `parentSessionByChildSession` while each ancestor is itself
+ * a linked child, so a nested subagent flattens onto the root session and its
+ * edge stays inside one conversation. An ancestor whose own edge did not resolve
+ * stops the walk, because that ancestor's turns stayed in its own conversation.
+ *
+ * The visited set both terminates the walk and keeps it defensive: every hop
+ * that continues adds a session id not seen before, so a contradictory parent
+ * chain from the host stops at the first repeat instead of looping.
+ */
+function resolveExportedConversationId(sessionID: string): string {
+  let current = sessionID;
+  const seen = new Set<string>([current]);
+  while (parentGenerationByChildSession.has(current)) {
+    const parent = parentSessionByChildSession.get(current);
+    if (!parent || seen.has(parent)) return current;
+    seen.add(parent);
+    current = parent;
+  }
+  return current;
+}
+
+/**
+ * Session-level lineage for a subagent turn, following
+ * `codex.parent_session_id` and `codex.child_session_id`.
+ *
+ * `opencode.parent_session_id` names the immediate parent session, not the root
+ * of the chain, so a nested subagent's depth survives the flattening in
+ * `resolveExportedConversationId`. It is emitted whether or not the edge
+ * resolved: it is the only lineage signal an unlinked child carries.
+ *
+ * `opencode.child_session_id` is emitted only for a reparented turn, where
+ * `conversation_id` names an ancestor session and the child's own session id
+ * would otherwise be unrecoverable. codex emits its key unconditionally
+ * (`plugins/agento11y/internal/agents/codex/mapper/mapper.go:161`); the
+ * condition here follows vibe
+ * (`plugins/agento11y/internal/agents/vibe/mapper/mapper.go:256`), where an
+ * unreparented turn already carries its own session id as `conversation_id`.
+ */
+function subagentLineageMetadata(
+  sessionID: string,
+  reparented: boolean,
+): Record<string, string> | undefined {
+  const parentSession = parentSessionByChildSession.get(sessionID);
+  if (!parentSession) return undefined;
+  return {
+    "opencode.parent_session_id": parentSession,
+    ...(reparented && { "opencode.child_session_id": sessionID }),
+  };
 }
 
 /**
@@ -1157,8 +1269,9 @@ async function handleLifecycle(
     if (sessionId) {
       recordedMessages.delete(sessionId);
       lastGenerationIdBySession.delete(sessionId);
+      lastSeenAssistantMessageBySession.delete(sessionId);
       parentGenerationByChildSession.delete(sessionId);
-      subagentSessions.delete(sessionId);
+      parentSessionByChildSession.delete(sessionId);
       pendingGenerations.delete(sessionId);
       latestSystemPromptBySession.delete(sessionId);
       latestSessionTitleBySession.delete(sessionId);


### PR DESCRIPTION
Fixes an issue in the OpenCode plugin when subagent turns exported as a new conversation with no parent link.