### PR TITLE
feat(plugins/agento11y): export agent reported cost as cost_usd everywhere

### DIFF
--- a/docs/concepts/tags-and-metadata.md
+++ b/docs/concepts/tags-and-metadata.md
@@ -172,9 +172,7 @@ Codex and copilot also add their own `codex.*` and `copilot.*` keys, so this tab
 
 | Key | Value | Emitted by |
 | --- | --- | --- |
-| `cost_usd` | Cost the host itself reported for the call, in US dollars. Present whenever pi priced the call, including a cost of `0`. | pi |
-| `vibe.cost_usd` | Cost vibe reported for the turn, in US dollars. Omitted when the cost is `0`. | vibe |
-| `cost` | Cost opencode reported for the turn, in US dollars. | opencode |
+| `cost_usd` | Cost the coding agent itself reported, in US dollars. | pi, opencode, vibe |
 | `pi.tokens_before` | Pi's estimate of the context size before a compaction, in tokens. Compaction generations only. The estimate covers the whole conversation, not this call's input tokens. | pi |
 | `pi.compaction.reason` | What triggered the compaction: `manual` (`/compact` or `ctx.compact()`), `threshold` (context limit), or `overflow` (context-overflow recovery). | pi |
 | `pi.compaction.will_retry` | `true` when pi retries the turn it aborted to run this compaction. Only overflow recovery retries. | pi |

--- a/plugins/agento11y/internal/agents/vibe/hook/handlers.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/handlers.go
@@ -132,6 +132,14 @@ func PostAgentTurn(ctx context.Context, p Payload, logger *log.Logger) {
 		AgentName:          envconfig.ResolveAgentName(mapper.AgentName),
 	}, turnSeq)
 
+	// A meta.json without session_cost carries no new baseline, so keep the
+	// prior one. Snapshotting 0 would make a later turn that does report a
+	// cost delta against zero and bill the whole session total to it.
+	sessionCost := prior.SessionCost
+	if m.Stats.SessionCost != nil {
+		sessionCost = *m.Stats.SessionCost
+	}
+
 	// Persist the advanced offset and session snapshot BEFORE exporting. A
 	// save failure aborts the turn (it replays on the next fire); a save here
 	// also means a successful export can never be followed by a lost offset,
@@ -141,7 +149,7 @@ func PostAgentTurn(ctx context.Context, p Payload, logger *log.Logger) {
 		Offset:                  newOffset,
 		SessionPromptTokens:     m.Stats.SessionPromptTokens,
 		SessionCompletionTokens: m.Stats.SessionCompletionTokens,
-		SessionCost:             m.Stats.SessionCost,
+		SessionCost:             sessionCost,
 		ToolCallsRejected:       m.Stats.ToolCallsRejected,
 		ToolCallsHookDenied:     m.Stats.ToolCallsHookDenied,
 		ToolCallsFailed:         m.Stats.ToolCallsFailed,

--- a/plugins/agento11y/internal/agents/vibe/hook/handlers_test.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/handlers_test.go
@@ -278,6 +278,73 @@ func TestPostAgentTurn_MissingCredsSkipsExport(t *testing.T) {
 	}
 }
 
+func TestPostAgentTurn_SessionCostSnapshot(t *testing.T) {
+	// The snapshot is the baseline the next turn subtracts from. A
+	// meta.json reporting no session_cost must leave the prior baseline
+	// standing, otherwise a later turn that does report a cost deltas
+	// against zero and is billed the whole session total.
+	//
+	// Each case replaces the tail of the fixture's stats block, so the
+	// difference between the cases is only how session_cost is reported.
+	const fixtureCost = `"session_total_llm_tokens": 4608,
+    "session_cost": 0.05`
+	tests := []struct {
+		name  string
+		stats string
+		want  float64
+	}{
+		{
+			name:  "reported cost replaces the baseline",
+			stats: fixtureCost,
+			want:  0.05,
+		},
+		{
+			name:  "absent cost keeps the prior baseline",
+			stats: `"session_total_llm_tokens": 4608`,
+			want:  5,
+		},
+		{
+			name: "null cost keeps the prior baseline",
+			stats: `"session_total_llm_tokens": 4608,
+    "session_cost": null`,
+			want: 5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				b, _ := io.ReadAll(r.Body)
+				writeAcceptedGenerationResponse(t, w, b)
+			}))
+			t.Cleanup(srv.Close)
+
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			t.Setenv("SIGIL_ENDPOINT", srv.URL)
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
+
+			dir := t.TempDir()
+			must(t, copyFile(filepath.Join("..", "testdata", "messages.jsonl"), filepath.Join(dir, "messages.jsonl")))
+			metaPath := filepath.Join(dir, "meta.json")
+			must(t, copyFile(filepath.Join("..", "testdata", "meta.json"), metaPath))
+			must(t, replaceInFile(metaPath, fixtureCost, tt.stats))
+			tp := filepath.Join(dir, "messages.jsonl")
+
+			must(t, state.Save("sess-cost", state.Session{SessionCost: 5}))
+			logger := log.New(io.Discard, "", 0)
+			PostAgentTurn(context.Background(), Payload{HookEventName: "post_agent_turn", SessionID: "sess-cost", TranscriptPath: tp}, logger)
+
+			st, found := state.Load("sess-cost")
+			if !found {
+				t.Fatalf("state missing after export")
+			}
+			if st.SessionCost != tt.want {
+				t.Errorf("SessionCost = %v, want %v", st.SessionCost, tt.want)
+			}
+		})
+	}
+}
+
 func TestPostAgentTurn_MissingPayloadFields(t *testing.T) {
 	logger := log.New(io.Discard, "", 0)
 	PostAgentTurn(context.Background(), Payload{HookEventName: "post_agent_turn"}, logger)

--- a/plugins/agento11y/internal/agents/vibe/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/vibe/mapper/mapper.go
@@ -256,8 +256,8 @@ func buildMetadata(in Inputs) map[string]any {
 	if in.ParentGenerationID != "" && in.ParentSessionID != "" {
 		metadata["vibe.child_session_id"] = in.SessionID
 	}
-	if cost := turnCost(in.Meta.Stats, in.PriorState, in.PriorStateFound); cost > 0 {
-		metadata["vibe.cost_usd"] = cost
+	if cost, ok := turnCost(in.Meta.Stats, in.PriorState, in.PriorStateFound); ok {
+		metadata["cost_usd"] = cost
 	}
 	addToolFailureCounts(metadata, in.Meta.Stats, in.PriorState, in.PriorStateFound)
 	if len(metadata) == 0 {
@@ -267,20 +267,30 @@ func buildMetadata(in Inputs) map[string]any {
 }
 
 // turnCost is the per-turn USD cost: the delta of vibe's session_cost
-// against the prior snapshot. Mirrors turnUsage's state-loss handling so a
-// lost snapshot mid-session reports nothing rather than billing the whole
-// session to one turn; on the first turn the full session_cost applies.
-func turnCost(stats meta.Stats, prior state.Session, priorFound bool) float64 {
-	if !priorFound {
-		if stats.Steps > 1 {
-			return 0
-		}
-		return stats.SessionCost
+// against the prior snapshot, or the full session_cost on the first turn. A
+// cost of 0 is reported as 0, not dropped.
+//
+// The bool is false when meta.json reports no session_cost, and in the two
+// cases turnUsage falls back for: no prior snapshot on turn >1, where
+// subtracting from zero would bill the whole session to this turn, and a
+// cost below zero, from a session reset or a stale snapshot. turnCost has
+// no fallback of its own, because vibe reports a session total but no
+// last-turn cost.
+func turnCost(stats meta.Stats, prior state.Session, priorFound bool) (float64, bool) {
+	if stats.SessionCost == nil {
+		return 0, false
 	}
-	if delta := stats.SessionCost - prior.SessionCost; delta > 0 {
-		return delta
+	if !priorFound && stats.Steps > 1 {
+		return 0, false
 	}
-	return 0
+	cost := *stats.SessionCost
+	if priorFound {
+		cost -= prior.SessionCost
+	}
+	if cost < 0 {
+		return 0, false
+	}
+	return cost, true
 }
 
 // addToolFailureCounts records the per-turn count of rejected, hook-denied,

--- a/plugins/agento11y/internal/agents/vibe/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/vibe/mapper/mapper_test.go
@@ -2,6 +2,7 @@ package mapper
 
 import (
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,8 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/vibe/state"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/vibe/transcript"
 )
+
+func ptr[T any](v T) *T { return &v }
 
 func TestMap_GoldenFixture(t *testing.T) {
 	tp := filepath.Join("..", "testdata", "messages.jsonl")
@@ -193,6 +196,97 @@ func TestMap_TurnUsage(t *testing.T) {
 	}
 }
 
+func TestMap_TurnCost(t *testing.T) {
+	tests := []struct {
+		name       string
+		stats      meta.Stats
+		prior      state.Session
+		priorFound bool
+		turnSeq    int
+		want       float64
+		wantAbsent bool
+	}{
+		{
+			name:    "first turn no prior uses full session cost",
+			stats:   meta.Stats{Steps: 1, SessionCost: ptr(0.5)},
+			turnSeq: 1,
+			want:    0.5,
+		},
+		{
+			name:    "free first turn reports zero",
+			stats:   meta.Stats{Steps: 1, SessionCost: ptr(0.0)},
+			turnSeq: 1,
+			want:    0,
+		},
+		{
+			name:       "no session cost reported omits the key",
+			stats:      meta.Stats{Steps: 1},
+			turnSeq:    1,
+			wantAbsent: true,
+		},
+		{
+			name:       "negative session cost omits the key",
+			stats:      meta.Stats{Steps: 1, SessionCost: ptr(-0.5)},
+			turnSeq:    1,
+			wantAbsent: true,
+		},
+		{
+			name:       "state lost mid-session omits the key",
+			stats:      meta.Stats{Steps: 7, SessionCost: ptr(4.2)},
+			turnSeq:    7,
+			wantAbsent: true,
+		},
+		{
+			name:       "normal delta against prior snapshot",
+			stats:      meta.Stats{SessionCost: ptr(0.5)},
+			prior:      state.Session{SessionCost: 0.3},
+			priorFound: true,
+			turnSeq:    3,
+			want:       0.2,
+		},
+		{
+			name:       "zero delta reports zero",
+			stats:      meta.Stats{SessionCost: ptr(0.3)},
+			prior:      state.Session{SessionCost: 0.3},
+			priorFound: true,
+			turnSeq:    3,
+			want:       0,
+		},
+		{
+			name:       "regressed totals omit the key",
+			stats:      meta.Stats{SessionCost: ptr(0.1)},
+			prior:      state.Session{SessionCost: 9.9},
+			priorFound: true,
+			turnSeq:    4,
+			wantAbsent: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md := Map(Inputs{
+				SessionID:       "s",
+				Meta:            meta.Meta{Stats: tt.stats},
+				PriorState:      tt.prior,
+				PriorStateFound: tt.priorFound,
+				ContentCapture:  agento11y.ContentCaptureModeFull,
+			}, tt.turnSeq).Generation.Metadata
+			got, ok := md["cost_usd"]
+			if tt.wantAbsent {
+				if ok {
+					t.Errorf("cost_usd = %v, want absent", got)
+				}
+				return
+			}
+			if !ok {
+				t.Fatalf("cost_usd absent, want %v", tt.want)
+			}
+			if f, isFloat := got.(float64); !isFloat || math.Abs(f-tt.want) > 1e-9 {
+				t.Errorf("cost_usd = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMap_ContentCaptureModes(t *testing.T) {
 	tp := filepath.Join("..", "testdata", "messages.jsonl")
 	lines, _, err := transcript.Read(tp, 0)
@@ -319,27 +413,22 @@ func TestMap_Reasoning(t *testing.T) {
 	}
 }
 
-func TestMap_CostAndFailureMetadata(t *testing.T) {
+func TestMap_ToolFailureMetadata(t *testing.T) {
 	in := Inputs{
 		SessionID: "s",
 		Meta: meta.Meta{Stats: meta.Stats{
 			SessionPromptTokens: 100, SessionCompletionTokens: 10,
-			SessionCost:       0.5,
 			ToolCallsFailed:   2,
 			ToolCallsRejected: 1,
 		}},
 		PriorState: state.Session{
 			SessionPromptTokens: 80, SessionCompletionTokens: 5,
-			SessionCost:     0.3,
 			ToolCallsFailed: 1,
 		},
 		PriorStateFound: true,
 		ContentCapture:  agento11y.ContentCaptureModeFull,
 	}
 	md := Map(in, 2).Generation.Metadata
-	if got, ok := md["vibe.cost_usd"].(float64); !ok || got <= 0.19 || got >= 0.21 {
-		t.Errorf("vibe.cost_usd = %v, want ~0.2 (0.5-0.3)", md["vibe.cost_usd"])
-	}
 	if md["vibe.tool_calls_failed"] != int64(1) {
 		t.Errorf("vibe.tool_calls_failed = %v, want 1 (2-1)", md["vibe.tool_calls_failed"])
 	}

--- a/plugins/agento11y/internal/agents/vibe/meta/meta.go
+++ b/plugins/agento11y/internal/agents/vibe/meta/meta.go
@@ -27,18 +27,22 @@ type Meta struct {
 // Stats mirrors meta.json's `stats` block. Token fields and the
 // tool_calls_* counters are session-wide running totals; per-turn values
 // are the delta against the previous run's snapshot stored in state.
+//
+// SessionCost is a pointer so a meta.json that carries no `session_cost`
+// stays distinguishable from one reporting a cost of 0: the first is a cost
+// vibe never reported, the second a turn that was free.
 type Stats struct {
-	Steps                    int     `json:"steps"`
-	SessionPromptTokens      int64   `json:"session_prompt_tokens"`
-	SessionCompletionTokens  int64   `json:"session_completion_tokens"`
-	LastTurnPromptTokens     int64   `json:"last_turn_prompt_tokens"`
-	LastTurnCompletionTokens int64   `json:"last_turn_completion_tokens"`
-	LastTurnDuration         float64 `json:"last_turn_duration"`
-	ContextTokens            int64   `json:"context_tokens"`
-	InputPricePerMillion     float64 `json:"input_price_per_million"`
-	OutputPricePerMillion    float64 `json:"output_price_per_million"`
-	SessionTotalLLMTokens    int64   `json:"session_total_llm_tokens"`
-	SessionCost              float64 `json:"session_cost"`
+	Steps                    int      `json:"steps"`
+	SessionPromptTokens      int64    `json:"session_prompt_tokens"`
+	SessionCompletionTokens  int64    `json:"session_completion_tokens"`
+	LastTurnPromptTokens     int64    `json:"last_turn_prompt_tokens"`
+	LastTurnCompletionTokens int64    `json:"last_turn_completion_tokens"`
+	LastTurnDuration         float64  `json:"last_turn_duration"`
+	ContextTokens            int64    `json:"context_tokens"`
+	InputPricePerMillion     float64  `json:"input_price_per_million"`
+	OutputPricePerMillion    float64  `json:"output_price_per_million"`
+	SessionTotalLLMTokens    int64    `json:"session_total_llm_tokens"`
+	SessionCost              *float64 `json:"session_cost"`
 
 	// tool_calls_* are session-wide running totals of how the session's
 	// tool calls resolved. The per-turn delta (against the prior state

--- a/plugins/agento11y/internal/agents/vibe/meta/meta_test.go
+++ b/plugins/agento11y/internal/agents/vibe/meta/meta_test.go
@@ -35,6 +35,11 @@ func TestLoad(t *testing.T) {
 	if m.Stats.Steps == 0 {
 		t.Errorf("Steps = 0, want > 0")
 	}
+	if m.Stats.SessionCost == nil {
+		t.Error("SessionCost is nil, want 0.05")
+	} else if *m.Stats.SessionCost != 0.05 {
+		t.Errorf("SessionCost = %v, want 0.05", *m.Stats.SessionCost)
+	}
 
 	if len(m.ToolsAvailable) == 0 {
 		t.Errorf("ToolsAvailable is empty")

--- a/plugins/agento11y/internal/entry/testdata/golden/vibe-basic/export.golden.json
+++ b/plugins/agento11y/internal/entry/testdata/golden/vibe-basic/export.golden.json
@@ -34,7 +34,7 @@
           "agento11y.sdk.content_capture_mode": "full",
           "agento11y.sdk.name": "sdk-go",
           "agento11y.user.id": "test-user",
-          "vibe.cost_usd": 0.0625
+          "cost_usd": 0.0625
         },
         "mode": "GENERATION_MODE_SYNC",
         "model": {

--- a/plugins/agento11y/internal/entry/testdata/golden/vibe-basic/scenario.json
+++ b/plugins/agento11y/internal/entry/testdata/golden/vibe-basic/scenario.json
@@ -50,7 +50,7 @@
       "\"input_tokens\":\"100\"",
       "\"output_tokens\":\"25\"",
       "\"thinking_enabled\":true",
-      "\"vibe.cost_usd\":0.0625"
+      "\"cost_usd\":0.0625"
     ]
   }
 }

--- a/plugins/opencode/src/hooks.tokens.test.ts
+++ b/plugins/opencode/src/hooks.tokens.test.ts
@@ -53,7 +53,8 @@ function usageOf(generation: CapturedGeneration): Record<string, number> {
 }
 
 function costOf(generation: CapturedGeneration): number {
-  return (generation.result as { metadata: { cost: number } }).metadata.cost;
+  return (generation.result as { metadata: { cost_usd: number } }).metadata
+    .cost_usd;
 }
 
 const completedTime = {

--- a/plugins/opencode/src/mappers.test.ts
+++ b/plugins/opencode/src/mappers.test.ts
@@ -424,7 +424,7 @@ describe("mapGeneration", () => {
     expect(result.input).toHaveLength(1);
     expect(result.output).toHaveLength(1);
     expect(result.usage?.inputTokens).toBe(100);
-    expect(result.metadata?.cost).toBe(0.01);
+    expect(result.metadata?.cost_usd).toBe(0.01);
   });
 
   it("maps response model, stop reason, and completion timestamp from assistant message", () => {
@@ -451,7 +451,7 @@ describe("mapGeneration", () => {
       cacheReadInputTokens: 70,
       cacheWriteInputTokens: 14,
     });
-    expect(result.metadata?.cost).toBe(0.06);
+    expect(result.metadata?.cost_usd).toBe(0.06);
   });
 
   it("keeps input cache-adjusted and reasoning out of output", () => {

--- a/plugins/opencode/src/mappers.ts
+++ b/plugins/opencode/src/mappers.ts
@@ -220,7 +220,7 @@ export function mapGeneration(
     stopReason: msg.finish,
     completedAt: msg.time.completed ? new Date(msg.time.completed) : undefined,
     metadata: {
-      cost: msg.cost,
+      cost_usd: msg.cost,
     },
   };
 }

--- a/plugins/opencode/src/testdata/golden/opencode-full-message.golden.json
+++ b/plugins/opencode/src/testdata/golden/opencode-full-message.golden.json
@@ -90,7 +90,7 @@
           "cwd": "<NORMALIZED>"
         },
         "metadata": {
-          "cost": 0.005,
+          "cost_usd": 0.005,
           "agento11y.conversation.title": "List the Go files in the repo",
           "agento11y.sdk.name": "sdk-js",
           "agento11y.sdk.content_capture_mode": "full"


### PR DESCRIPTION
When coding agents had cost information, it was added to metadata as three keys, depending on the agent: `cost_usd` from pi, `vibe.cost_usd` from vibe, `cost` from opencode.

Change this and report `cost_usd` in all cases when it's available.