### PR TITLE
perf(plugins/agento11y): cache per-file summaries for the local viewer

### DIFF
--- a/plugins/agento11y/internal/local/manager.go
+++ b/plugins/agento11y/internal/local/manager.go
@@ -279,6 +279,9 @@ func Serve(ctx context.Context, dir string, port int, logger *log.Logger) error 
 	// A history import exports through this same address, so the server has to
 	// know it. The port is only settled once the listener exists.
 	srv.SetLocalEndpoint(status.Endpoint)
+	// The summary cache starts empty, so without this the viewer decodes the
+	// whole store one request at a time after a restart.
+	srv.WarmSummariesOnFirstRead(ctx)
 	if err := SaveStatus(dir, status); err != nil {
 		_ = listener.Close()
 		return fmt.Errorf("save status: %w", err)

--- a/plugins/agento11y/internal/local/query.go
+++ b/plugins/agento11y/internal/local/query.go
@@ -153,27 +153,30 @@ func (s *Storage) ListConversations(opts ConversationListOptions) (page []Conver
 		if !opts.Since.IsZero() && f.modTime.Before(opts.Since) {
 			break
 		}
-		sum, ok, n, err := summariseConversationFile(f.path)
-		skipped += n
+		entry, err := s.summaries.get(f)
 		if err != nil {
 			return nil, 0, err
 		}
-		if !ok {
+		skipped += entry.skipped
+		if !entry.ok {
 			continue // empty or all-invalid file
 		}
-		out = append(out, sum)
+		out = append(out, entry.summary)
 		if opts.Limit > 0 && len(out) == opts.Limit {
 			break
 		}
 	}
+	s.summaries.prune(files)
 	return out, len(files), nil
 }
 
 // conversationFile is one conversation JSONL file with the modification
-// time the list and metrics endpoints order and filter on.
+// time the list and metrics endpoints order and filter on, and the size
+// that validates a cached summary alongside it.
 type conversationFile struct {
 	id      string
 	path    string
+	size    int64
 	modTime time.Time
 }
 
@@ -204,6 +207,7 @@ func (s *Storage) conversationFiles() ([]conversationFile, error) {
 		out = append(out, conversationFile{
 			id:      strings.TrimSuffix(e.Name(), ".jsonl"),
 			path:    filepath.Join(dir, e.Name()),
+			size:    info.Size(),
 			modTime: info.ModTime(),
 		})
 	}
@@ -214,88 +218,6 @@ func (s *Storage) conversationFiles() ([]conversationFile, error) {
 		return out[i].id < out[j].id
 	})
 	return out, nil
-}
-
-// summariseConversationFile reads one per-conversation JSONL file and
-// returns its aggregated summary plus the number of lines it could not
-// decode. It decodes the summary projection only, so a conversation holding
-// megabytes of messages costs the line scan and nothing more. ok is false
-// when the file has no decodable records.
-func summariseConversationFile(path string) (ConversationSummary, bool, int, error) {
-	agents := map[string]struct{}{}
-	models := map[string]struct{}{}
-	var sum ConversationSummary
-	var hasError, seen bool
-
-	skipped, err := scanLatestSummaryRecords(path, func(rec summaryRecord) {
-		r, gen := rec, rec.Generation
-		seen = true
-		if sum.ID == "" {
-			sum.ID = r.ConversationID
-		}
-		sum.Calls++
-		usage := gen.Usage.toSDK()
-		sum.InputTokens += usage.InputTokens
-		sum.OutputTokens += usage.OutputTokens
-		sum.TotalTokens += totalTokensForView(usage, gen.Model.Provider)
-		sum.TokenBuckets = sum.TokenBuckets.plus(disjointTokenUsage(usage, gen.Model.Provider))
-
-		if !gen.StartedAt.IsZero() && (sum.StartedAt.IsZero() || gen.StartedAt.Before(sum.StartedAt)) {
-			sum.StartedAt = gen.StartedAt
-		}
-		// last_activity tracks the latest known timestamp on any
-		// generation, falling back to received_at when started/completed
-		// aren't populated so freshly-arrived records still bubble up.
-		when := gen.CompletedAt
-		if when.IsZero() {
-			when = gen.StartedAt
-		}
-		if when.IsZero() {
-			when, _ = time.Parse(time.RFC3339Nano, r.ReceivedAt)
-		}
-		if when.After(sum.LastActivity) {
-			sum.LastActivity = when
-		}
-
-		if gen.AgentName != "" {
-			agents[gen.AgentName] = struct{}{}
-		}
-		if name := gen.modelName(); name != "" {
-			models[name] = struct{}{}
-		}
-		if sum.Title == "" && gen.title() != "" {
-			sum.Title = gen.title()
-		}
-		if gen.CallError != "" {
-			hasError = true
-		}
-		// cwd/branch are per-session and identical across a conversation's
-		// generations; take the first non-empty. A generation whose
-		// agent_name carries a subagent suffix ("claude-code/general-purpose")
-		// is one step of a spawned subagent.
-		if sum.Workspace == "" {
-			sum.Workspace = gen.Tags["cwd"]
-		}
-		if sum.Branch == "" {
-			sum.Branch = gen.Tags["git.branch"]
-		}
-		if strings.Contains(gen.AgentName, "/") {
-			sum.Subagents++
-		}
-	})
-	if err != nil {
-		return ConversationSummary{}, false, skipped, err
-	}
-	if !seen {
-		return ConversationSummary{}, false, skipped, nil
-	}
-	sum.Agents = sortedKeys(agents)
-	sum.Models = sortedKeys(models)
-	sum.Status = "ok"
-	if hasError {
-		sum.Status = "err"
-	}
-	return sum, true, skipped, nil
 }
 
 // ConversationDetail returns the chronological generation list for one
@@ -437,58 +359,73 @@ var tokenUsageIntervals = []time.Duration{
 // non-empty bucket.
 //
 // A missing conversations dir yields no points (first-launch case).
+//
+// Points are read through the per-file summary cache and folded straight
+// into their buckets, rather than concatenated first. Concatenating would
+// allocate the whole store's usage on every request, to produce a response
+// that newTokenUsageBuckets bounds by the bucket count.
 func (s *Storage) TokenUsagePoints(opts TokenUsageOptions) ([]TokenUsagePoint, time.Duration, error) {
 	files, err := s.conversationFiles()
 	if err != nil {
 		return nil, 0, err
 	}
-	var raw []TokenUsagePoint
 	var skipped int
 	defer func() { s.logSkipped("token metrics", skipped) }()
+
+	eligible := make([]*fileSummary, 0, len(files))
+	var first, last time.Time
+	var pointCount int
 	for _, f := range files {
 		// Files are newest-first, so the first one below the bound ends
 		// the walk without opening it.
 		if !opts.Since.IsZero() && f.modTime.Before(opts.Since) {
 			break
 		}
-		n, err := scanLatestSummaryRecords(f.path, func(rec summaryRecord) {
-			p, ok := tokenUsagePoint(rec)
-			if !ok {
-				return
-			}
-			if !opts.Since.IsZero() && p.Timestamp.Before(opts.Since) {
-				return
-			}
-			raw = append(raw, p)
-		})
-		skipped += n
+		entry, err := s.summaries.get(f)
 		if err != nil {
 			return nil, 0, err
 		}
+		skipped += entry.skipped
+		// The break above is loose. A file's modification time is only an
+		// upper bound on the data time of the generations in it, and an import
+		// stamps every file it writes with the current time, so during an
+		// import the break cuts nothing. bounds then cuts on the decoded
+		// timestamps instead. Files are ordered by modification time, not by
+		// data time, so a file below the bound is skipped and the walk goes on.
+		entryFirst, entryLast, ok := entry.bounds(opts.Since)
+		if !ok {
+			continue
+		}
+		if first.IsZero() || entryFirst.Before(first) {
+			first = entryFirst
+		}
+		if entryLast.After(last) {
+			last = entryLast
+		}
+		pointCount += len(entry.points)
+		eligible = append(eligible, entry)
 	}
+	s.summaries.prune(files)
+
 	interval := opts.Interval
 	if interval <= 0 {
-		interval = deriveTokenUsageInterval(raw, opts.Since)
+		interval = tokenUsageIntervalFor(last.Sub(first))
 	}
-	return bucketTokenUsagePoints(raw, interval), interval, nil
+	buckets := newTokenUsageBuckets(interval, pointCount)
+	for _, entry := range eligible {
+		for _, p := range entry.points {
+			if !opts.Since.IsZero() && p.Timestamp.Before(opts.Since) {
+				continue
+			}
+			buckets.add(p)
+		}
+	}
+	return buckets.points(), interval, nil
 }
 
-// deriveTokenUsageInterval picks the smallest ladder step that keeps the
-// requested range under maxTokenUsageBuckets buckets.
-func deriveTokenUsageInterval(points []TokenUsagePoint, since time.Time) time.Duration {
-	var first, last time.Time
-	for _, p := range points {
-		if first.IsZero() || p.Timestamp.Before(first) {
-			first = p.Timestamp
-		}
-		if p.Timestamp.After(last) {
-			last = p.Timestamp
-		}
-	}
-	if !since.IsZero() && since.After(first) {
-		first = since
-	}
-	span := last.Sub(first)
+// tokenUsageIntervalFor picks the smallest ladder step that keeps a range
+// of the given span under maxTokenUsageBuckets buckets.
+func tokenUsageIntervalFor(span time.Duration) time.Duration {
 	for _, step := range tokenUsageIntervals {
 		if span/step <= maxTokenUsageBuckets {
 			return step
@@ -497,34 +434,53 @@ func deriveTokenUsageInterval(points []TokenUsagePoint, since time.Time) time.Du
 	return tokenUsageIntervals[len(tokenUsageIntervals)-1]
 }
 
-// bucketTokenUsagePoints sums points into (bucket start, model, provider)
-// groups, ordered by timestamp then model then provider so the chart reads
-// them in one pass.
-func bucketTokenUsagePoints(points []TokenUsagePoint, interval time.Duration) []TokenUsagePoint {
-	type bucketKey struct {
-		start    int64
-		model    string
-		provider string
+// tokenUsageBuckets sums points into (bucket start, model, provider)
+// groups as they arrive, so a caller can fold a whole store's points in
+// without holding them all.
+type tokenUsageBuckets struct {
+	interval   time.Duration
+	indexByKey map[tokenBucketKey]int
+	out        []TokenUsagePoint
+}
+
+type tokenBucketKey struct {
+	start    int64
+	model    string
+	provider string
+}
+
+// newTokenUsageBuckets prepares the fold. points is how many will be added;
+// it only sizes the first allocation, so an estimate is fine.
+func newTokenUsageBuckets(interval time.Duration, points int) *tokenUsageBuckets {
+	return &tokenUsageBuckets{
+		interval:   interval,
+		indexByKey: map[tokenBucketKey]int{},
+		// A bucket holds one point per model and provider, so the output is
+		// bounded by the bucket count however many generations came in.
+		out: make([]TokenUsagePoint, 0, min(points, 4*maxTokenUsageBuckets)),
 	}
-	indexByKey := map[bucketKey]int{}
-	// A bucket holds one point per model and provider, so the output is
-	// bounded by the bucket count however many generations came in.
-	out := make([]TokenUsagePoint, 0, min(len(points), 4*maxTokenUsageBuckets))
-	for _, p := range points {
-		start := intervalStart(p.Timestamp, interval)
-		key := bucketKey{start: start.UnixNano(), model: p.Model, provider: p.Provider}
-		if idx, ok := indexByKey[key]; ok {
-			out[idx].TokenBuckets = out[idx].TokenBuckets.plus(p.TokenBuckets)
-			continue
-		}
-		indexByKey[key] = len(out)
-		out = append(out, TokenUsagePoint{
-			Timestamp:    start,
-			Model:        p.Model,
-			Provider:     p.Provider,
-			TokenBuckets: p.TokenBuckets,
-		})
+}
+
+func (b *tokenUsageBuckets) add(p TokenUsagePoint) {
+	start := intervalStart(p.Timestamp, b.interval)
+	key := tokenBucketKey{start: start.UnixNano(), model: p.Model, provider: p.Provider}
+	if idx, ok := b.indexByKey[key]; ok {
+		b.out[idx].TokenBuckets = b.out[idx].TokenBuckets.plus(p.TokenBuckets)
+		return
 	}
+	b.indexByKey[key] = len(b.out)
+	b.out = append(b.out, TokenUsagePoint{
+		Timestamp:    start,
+		Model:        p.Model,
+		Provider:     p.Provider,
+		TokenBuckets: p.TokenBuckets,
+	})
+}
+
+// points returns the buckets ordered by timestamp then model then provider,
+// so the chart reads them in one pass.
+func (b *tokenUsageBuckets) points() []TokenUsagePoint {
+	out := b.out
 	sort.Slice(out, func(i, j int) bool {
 		if !out[i].Timestamp.Equal(out[j].Timestamp) {
 			return out[i].Timestamp.Before(out[j].Timestamp)

--- a/plugins/agento11y/internal/local/query_test.go
+++ b/plugins/agento11y/internal/local/query_test.go
@@ -1051,6 +1051,22 @@ func TestTokenUsagePoints_Buckets(t *testing.T) {
 			},
 		},
 		{
+			// A conversation an import wrote carries a modification time of
+			// now and generations that are months old, so the range bound has
+			// to cut inside the file. The interval follows the points that
+			// survive it, not the whole file's span.
+			name: "a file straddling the bound is read from the bound",
+			seeds: []seed{
+				{conv: "conv-1", gen: "g1", model: "model-a", when: "2026-05-05T00:00:00Z", in: 3},
+				{conv: "conv-1", gen: "g2", model: "model-a", when: "2026-08-03T10:00:00Z", in: 5},
+			},
+			opts:         TokenUsageOptions{Since: mustParse(t, "2026-08-03T09:00:00Z")},
+			wantInterval: 10 * time.Second,
+			wantPoints: []TokenUsagePoint{
+				{Timestamp: mustParse(t, "2026-08-03T10:00:00Z"), Model: "model-a", TokenBuckets: TokenBuckets{FreshInput: 5}},
+			},
+		},
+		{
 			name: "derived interval keeps the bucket count bounded",
 			seeds: []seed{
 				{conv: "conv-1", gen: "g1", model: "model-a", when: "2026-07-04T00:00:00Z", in: 1},
@@ -1319,11 +1335,98 @@ func TestReadsReportSkippedLines(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, points, 1)
 
+	// The list and the token chart answer the second round from the cached
+	// summaries. The count describes the store, so a cache hit reports it
+	// again instead of reporting zero. The detail read has no cache, so it
+	// scans the file again and reports its own count twice.
+	again, _, err := s.ListConversations(ConversationListOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, convs, again)
+	againDetail, err := s.ConversationDetail("conv-A")
+	require.NoError(t, err)
+	assert.Equal(t, detail, againDetail)
+	againPoints, _, err := s.TokenUsagePoints(TokenUsageOptions{Interval: time.Minute})
+	require.NoError(t, err)
+	assert.Equal(t, points, againPoints)
+
 	for _, want := range []string{
 		"local: list conversations: skipped 1 unparseable lines",
 		"local: conversation conv-A: skipped 1 unparseable lines",
 		"local: token metrics: skipped 1 unparseable lines",
 	} {
-		assert.Contains(t, logs.String(), want)
+		assert.Equal(t, 2, strings.Count(logs.String(), want), "%q reported once per request", want)
 	}
+}
+
+// TestReadsShareOneDecodePerFile pins the cache's reach across the two
+// endpoints: they read the same per-file summary, so whichever runs first
+// pays the decode and the other one does not.
+func TestReadsShareOneDecodePerFile(t *testing.T) {
+	list := func(t *testing.T, s *Storage) {
+		t.Helper()
+		convs, _, err := s.ListConversations(ConversationListOptions{})
+		require.NoError(t, err)
+		require.Len(t, convs, 1)
+		assert.Equal(t, int64(10), convs[0].InputTokens)
+	}
+	tokens := func(t *testing.T, s *Storage) {
+		t.Helper()
+		points, _, err := s.TokenUsagePoints(TokenUsageOptions{Interval: time.Hour})
+		require.NoError(t, err)
+		require.Len(t, points, 1)
+		assert.Equal(t, TokenBuckets{FreshInput: 10, Output: 3}, points[0].TokenBuckets)
+	}
+	cases := []struct {
+		name         string
+		first, other func(*testing.T, *Storage)
+	}{
+		{name: "the list warms the token chart", first: list, other: tokens},
+		{name: "the token chart warms the list", first: tokens, other: list},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newStorage(t)
+			writeGen(t, s, "conv-A", "g1", agento11y.Generation{
+				Model:     agento11y.ModelRef{Name: "m"},
+				StartedAt: mustParse(t, "2026-08-03T10:00:00Z"),
+				Usage:     agento11y.TokenUsage{InputTokens: 10, OutputTokens: 3},
+			}, "2026-08-03T10:00:01Z")
+			decoded := recordDecodes(&s.summaries)
+
+			tc.first(t, s)
+			tc.other(t, s)
+			assert.Equal(t, []string{"conv-A"}, *decoded)
+		})
+	}
+}
+
+// TestTokenUsagePointsFollowAppends checks that a conversation written
+// between two requests is the only one decoded again, and that its new
+// usage lands in the totals.
+func TestTokenUsagePointsFollowAppends(t *testing.T) {
+	s := newStorage(t)
+	for _, id := range []string{"conv-A", "conv-B"} {
+		writeGen(t, s, id, "g-"+id, agento11y.Generation{
+			Model:     agento11y.ModelRef{Name: "m"},
+			StartedAt: mustParse(t, "2026-08-03T10:00:00Z"),
+			Usage:     agento11y.TokenUsage{InputTokens: 4, OutputTokens: 1},
+		}, "2026-08-03T10:00:01Z")
+	}
+	before, _, err := s.TokenUsagePoints(TokenUsageOptions{Interval: time.Hour})
+	require.NoError(t, err)
+	require.Len(t, before, 1)
+	assert.Equal(t, TokenBuckets{FreshInput: 8, Output: 2}, before[0].TokenBuckets)
+
+	decoded := recordDecodes(&s.summaries)
+	writeGen(t, s, "conv-A", "g-extra", agento11y.Generation{
+		Model:     agento11y.ModelRef{Name: "m"},
+		StartedAt: mustParse(t, "2026-08-03T10:30:00Z"),
+		Usage:     agento11y.TokenUsage{InputTokens: 13, OutputTokens: 2},
+	}, "2026-08-03T10:30:01Z")
+
+	after, _, err := s.TokenUsagePoints(TokenUsageOptions{Interval: time.Hour})
+	require.NoError(t, err)
+	require.Len(t, after, 1)
+	assert.Equal(t, TokenBuckets{FreshInput: 21, Output: 4}, after[0].TokenBuckets)
+	assert.Equal(t, []string{"conv-A"}, *decoded, "the untouched conversation stays cached")
 }

--- a/plugins/agento11y/internal/local/search.go
+++ b/plugins/agento11y/internal/local/search.go
@@ -160,7 +160,7 @@ func searchConversationFile(path string, terms []string) (SearchHit, bool, int, 
 
 		// last_activity tracks the latest known timestamp on any
 		// generation, falling back to received_at when started/completed
-		// aren't populated — same rule as summariseConversationFile.
+		// aren't populated — same rule as decodeFileSummary.
 		when := gen.CompletedAt
 		if when.IsZero() {
 			when = gen.StartedAt

--- a/plugins/agento11y/internal/local/server.go
+++ b/plugins/agento11y/internal/local/server.go
@@ -41,6 +41,12 @@ type Server struct {
 	// uses the default.
 	eventPingInterval time.Duration
 
+	// warmStore fills the summary cache in the background. Serve sets it;
+	// a nil hook means no warming. warmOnce keeps the first viewer read the
+	// only trigger.
+	warmStore func()
+	warmOnce  sync.Once
+
 	// importMu guards the history-import fields below. One import runs at a
 	// time: two would write the same per-agent ledger and race on it.
 	importMu sync.Mutex
@@ -85,6 +91,26 @@ func NewServer(storage *Storage, logger *log.Logger, configPath string) *Server 
 // deadline. Safe to call more than once.
 func (s *Server) Close() {
 	s.hub.closeAll()
+}
+
+// WarmSummariesOnFirstRead arms the background summary-cache warm. The warm
+// starts once the first viewer read has answered, and stops when ctx is
+// done. Nothing warms before that read. Several commands start a daemon
+// without opening the viewer: an agent session in local mode, `local start`,
+// `local restart`, `history import`. Warming at startup would make each of
+// them decode the whole store and hold it resident until the daemon exits.
+func (s *Server) WarmSummariesOnFirstRead(ctx context.Context) {
+	s.warmStore = func() { s.storage.warmSummaries(ctx) }
+}
+
+// warmSummariesInBackground starts the warm the first time a viewer read
+// finishes. It runs after the response so the request the user is waiting
+// on does not queue behind the rest of the store.
+func (s *Server) warmSummariesInBackground() {
+	if s.warmStore == nil {
+		return
+	}
+	s.warmOnce.Do(func() { go s.warmStore() })
 }
 
 func (s *Server) routes() *http.ServeMux {
@@ -603,6 +629,7 @@ func (s *Server) handleListConversations(w http.ResponseWriter, r *http.Request)
 		"conversations":       convs,
 		"total_conversations": total,
 	})
+	s.warmSummariesInBackground()
 }
 
 // limitParam reads a ?limit= page size, falling back to def when the
@@ -714,6 +741,7 @@ func (s *Server) handleTokenMetrics(w http.ResponseWriter, r *http.Request) {
 		"points":           points,
 		"interval_seconds": int64(used.Seconds()),
 	})
+	s.warmSummariesInBackground()
 }
 
 // sinceParam reads the shared ?since= lower bound. RFC 3339 is the only

--- a/plugins/agento11y/internal/local/storage.go
+++ b/plugins/agento11y/internal/local/storage.go
@@ -50,6 +50,12 @@ type Storage struct {
 	// count open/close cycles; a nil value uses openAppendFile.
 	openAppend func(path string) (io.WriteCloser, error)
 
+	// summaries holds the decoded projection of every conversation file the
+	// list and the token chart have read, so an unchanged file is not
+	// decoded again. It carries its own mutex; the read paths take no other
+	// lock.
+	summaries summaryCache
+
 	// One mutex per file path. We don't expect contention high enough to
 	// need finer locking; this just stops interleaved JSON lines.
 	mu    sync.Mutex
@@ -208,7 +214,14 @@ func (s *Storage) AppendGenerations(convID string, recs []generationRecord) (int
 			return 0, fmt.Errorf("local storage: record conversation_id %q does not match batch %q", rec.ConversationID, convID)
 		}
 	}
-	return appendJSONL(s, filepath.Join(ConversationsDir, convID+".jsonl"), recs)
+	name := filepath.Join(ConversationsDir, convID+".jsonl")
+	written, err := appendJSONL(s, name, recs)
+	if written > 0 || err != nil {
+		// A partial write moved the file too, so the cached projection goes
+		// on the error path as well.
+		s.summaries.invalidate(s.Path(name))
+	}
+	return written, err
 }
 
 func validConversationID(id string) bool {

--- a/plugins/agento11y/internal/local/summaries.go
+++ b/plugins/agento11y/internal/local/summaries.go
@@ -1,0 +1,330 @@
+package local
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+)
+
+// fileSummary holds one conversation file's two decoded projections, the
+// list's conversation summary and the token chart's usage points, against
+// the size and modification time they were decoded at.
+//
+// Conversation files are append-only: appendJSONL opens with O_APPEND and
+// never O_TRUNC, and nothing in the package rewrites or compacts them. So a
+// file whose size and modification time both still match what an entry
+// recorded holds the bytes that entry was decoded from, and can be answered
+// without reopening the file.
+type fileSummary struct {
+	size    int64
+	modTime time.Time
+
+	// summary is the list projection. ok is false when the file held no
+	// decodable record, and the list skips such a file.
+	summary ConversationSummary
+	ok      bool
+
+	// points is the token-chart projection: one point per generation that
+	// recorded usage, in file order. first and last are the oldest and the
+	// newest point timestamp, so a reader can place the whole file against
+	// a requested range without walking the points.
+	points []TokenUsagePoint
+	first  time.Time
+	last   time.Time
+
+	// skipped counts the lines no projection could decode. A reader adds it
+	// on every hit, so the count it reports describes the store rather than
+	// the state of the cache.
+	skipped int
+}
+
+// bounds returns the oldest and newest point timestamp at or after since,
+// and whether the entry holds any such point. A file whose oldest point is
+// already at or after the bound answers from first and last without walking
+// the points, which is every file except the one the bound cuts through.
+func (e *fileSummary) bounds(since time.Time) (first, last time.Time, ok bool) {
+	if len(e.points) == 0 {
+		return time.Time{}, time.Time{}, false
+	}
+	if since.IsZero() || !e.first.Before(since) {
+		return e.first, e.last, true
+	}
+	if e.last.Before(since) {
+		return time.Time{}, time.Time{}, false
+	}
+	for _, p := range e.points {
+		if p.Timestamp.Before(since) {
+			continue
+		}
+		if !ok || p.Timestamp.Before(first) {
+			first = p.Timestamp
+		}
+		if p.Timestamp.After(last) {
+			last = p.Timestamp
+		}
+		ok = true
+	}
+	return first, last, ok
+}
+
+// summaryCache holds one fileSummary per conversation file path. An entry
+// is immutable once stored and is replaced whole, so a caller holding one
+// keeps reading a consistent snapshot while another goroutine refreshes the
+// same path. The mutex guards the maps alone: decoding runs outside it, so
+// a large file cannot block a request that needs a different one.
+type summaryCache struct {
+	// decode reads one file into an entry. Tests replace it to observe
+	// which files a read decoded; a nil value uses decodeFileSummary.
+	decode func(conversationFile) (*fileSummary, error)
+
+	mu      sync.Mutex
+	entries map[string]*fileSummary
+	// inflight holds the decode running for a path, so a second caller
+	// waits for it rather than repeating it.
+	inflight map[string]*summaryDecode
+}
+
+// summaryDecode is one decode in progress. entry and err are written
+// before done is closed and read only after it, so a waiter needs no lock
+// to read them.
+type summaryDecode struct {
+	done  chan struct{}
+	entry *fileSummary
+	err   error
+}
+
+// matches reports whether the entry was decoded from the bytes f names.
+func (e *fileSummary) matches(f conversationFile) bool {
+	return e != nil && e.size == f.size && e.modTime.Equal(f.modTime)
+}
+
+// get returns the entry for f, decoding the file when no entry exists or
+// either validator differs.
+//
+// One decode per path runs at a time. The background warm walks the store
+// in the same newest-first order a request does, so without this a request
+// landing partway through a warm would catch up to the file the warm is on
+// and decode every remaining file a second time.
+func (c *summaryCache) get(f conversationFile) (*fileSummary, error) {
+	for {
+		entry, flight, owned := c.claim(f)
+		if entry != nil {
+			return entry, nil
+		}
+		if !owned {
+			<-flight.done
+			if flight.err != nil {
+				return nil, flight.err
+			}
+			if flight.entry.matches(f) {
+				return flight.entry, nil
+			}
+			// The decode read a different version of the file than this
+			// caller stated. Take the next turn rather than answer from it.
+			continue
+		}
+		return c.fill(f, flight)
+	}
+}
+
+// claim resolves one attempt at f under the lock. It returns a valid
+// entry, or the decode already running for the path, or a decode this
+// caller owns and must run.
+func (c *summaryCache) claim(f conversationFile) (entry *fileSummary, flight *summaryDecode, owned bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if held := c.entries[f.path]; held.matches(f) {
+		return held, nil, false
+	}
+	if running, ok := c.inflight[f.path]; ok {
+		return nil, running, false
+	}
+	flight = &summaryDecode{done: make(chan struct{})}
+	if c.inflight == nil {
+		c.inflight = map[string]*summaryDecode{}
+	}
+	c.inflight[f.path] = flight
+	return nil, flight, true
+}
+
+// fill runs the decode this caller claimed, stores it, and releases the
+// callers waiting on it. A failed decode is not cached, so the next read
+// retries the file and reports the failure itself.
+func (c *summaryCache) fill(f conversationFile, flight *summaryDecode) (*fileSummary, error) {
+	decode := c.decode
+	if decode == nil {
+		decode = decodeFileSummary
+	}
+	// The entry records the size and modification time observed before the
+	// decode, so a file appended to while it is being read is decoded again
+	// on the next request instead of staying stale.
+	entry, err := decode(f)
+
+	c.mu.Lock()
+	if err == nil {
+		if c.entries == nil {
+			c.entries = map[string]*fileSummary{}
+		}
+		c.entries[f.path] = entry
+	}
+	delete(c.inflight, f.path)
+	c.mu.Unlock()
+
+	flight.entry, flight.err = entry, err
+	close(flight.done)
+	if err != nil {
+		return nil, err
+	}
+	return entry, nil
+}
+
+// invalidate drops the entry for path. The stat validation would catch the
+// change on its own; dropping the entry on write removes the dependence on
+// how finely the filesystem records modification times.
+func (c *summaryCache) invalidate(path string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.entries, path)
+}
+
+// prune drops entries whose file is gone, using the paths the walk already
+// found. Building the live set costs a map the size of the store, so it is
+// skipped while the cache holds no more paths than the walk did.
+//
+// That test is a heuristic, not an invariant. Both readers can end their
+// walk early, so an entry for a deleted file can survive until a walk sees
+// more files than the cache holds. No read serves it, because a deleted
+// path never comes back from a walk. It costs memory until then.
+func (c *summaryCache) prune(files []conversationFile) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.entries) <= len(files) {
+		return
+	}
+	live := make(map[string]struct{}, len(files))
+	for _, f := range files {
+		live[f.path] = struct{}{}
+	}
+	for path := range c.entries {
+		if _, ok := live[path]; !ok {
+			delete(c.entries, path)
+		}
+	}
+}
+
+// decodeFileSummary reads one per-conversation JSONL file and fills both
+// projections in a single pass, so a list request warms what the token
+// chart reads and the other way round. It decodes the summary projection
+// only, so a conversation holding megabytes of messages costs the line scan
+// and nothing more.
+func decodeFileSummary(f conversationFile) (*fileSummary, error) {
+	entry := &fileSummary{size: f.size, modTime: f.modTime}
+	agents := map[string]struct{}{}
+	models := map[string]struct{}{}
+	var sum ConversationSummary
+	var hasError, seen bool
+
+	skipped, err := scanLatestSummaryRecords(f.path, func(rec summaryRecord) {
+		r, gen := rec, rec.Generation
+		seen = true
+		if sum.ID == "" {
+			sum.ID = r.ConversationID
+		}
+		sum.Calls++
+		usage := gen.Usage.toSDK()
+		sum.InputTokens += usage.InputTokens
+		sum.OutputTokens += usage.OutputTokens
+		sum.TotalTokens += totalTokensForView(usage, gen.Model.Provider)
+		sum.TokenBuckets = sum.TokenBuckets.plus(disjointTokenUsage(usage, gen.Model.Provider))
+
+		if !gen.StartedAt.IsZero() && (sum.StartedAt.IsZero() || gen.StartedAt.Before(sum.StartedAt)) {
+			sum.StartedAt = gen.StartedAt
+		}
+		// last_activity tracks the latest known timestamp on any
+		// generation, falling back to received_at when started/completed
+		// aren't populated so freshly-arrived records still bubble up.
+		when := gen.CompletedAt
+		if when.IsZero() {
+			when = gen.StartedAt
+		}
+		if when.IsZero() {
+			when, _ = time.Parse(time.RFC3339Nano, r.ReceivedAt)
+		}
+		if when.After(sum.LastActivity) {
+			sum.LastActivity = when
+		}
+
+		if gen.AgentName != "" {
+			agents[gen.AgentName] = struct{}{}
+		}
+		if name := gen.modelName(); name != "" {
+			models[name] = struct{}{}
+		}
+		if sum.Title == "" && gen.title() != "" {
+			sum.Title = gen.title()
+		}
+		if gen.CallError != "" {
+			hasError = true
+		}
+		// cwd/branch are per-session and identical across a conversation's
+		// generations; take the first non-empty. A generation whose
+		// agent_name carries a subagent suffix ("claude-code/general-purpose")
+		// is one step of a spawned subagent.
+		if sum.Workspace == "" {
+			sum.Workspace = gen.Tags["cwd"]
+		}
+		if sum.Branch == "" {
+			sum.Branch = gen.Tags["git.branch"]
+		}
+		if strings.Contains(gen.AgentName, "/") {
+			sum.Subagents++
+		}
+
+		if p, ok := tokenUsagePoint(rec); ok {
+			entry.points = append(entry.points, p)
+			if entry.first.IsZero() || p.Timestamp.Before(entry.first) {
+				entry.first = p.Timestamp
+			}
+			if p.Timestamp.After(entry.last) {
+				entry.last = p.Timestamp
+			}
+		}
+	})
+	entry.skipped = skipped
+	if err != nil {
+		return nil, err
+	}
+	if !seen {
+		return entry, nil // empty or all-invalid file
+	}
+	sum.Agents = sortedKeys(agents)
+	sum.Models = sortedKeys(models)
+	sum.Status = "ok"
+	if hasError {
+		sum.Status = "err"
+	}
+	entry.summary = sum
+	entry.ok = true
+	return entry, nil
+}
+
+// warmSummaries decodes every conversation file into the cache, newest
+// first, so the page the viewer opens on is ready before the older store
+// is. It runs in the background and never on a request path. A request that
+// reaches a file the warm is decoding waits for that one decode, see get.
+//
+// Warming is best effort. A file that fails to decode is left uncached for
+// a later request to retry and report.
+func (s *Storage) warmSummaries(ctx context.Context) {
+	files, err := s.conversationFiles()
+	if err != nil {
+		return
+	}
+	for _, f := range files {
+		if ctx.Err() != nil {
+			return
+		}
+		_, _ = s.summaries.get(f)
+	}
+}

--- a/plugins/agento11y/internal/local/summaries_test.go
+++ b/plugins/agento11y/internal/local/summaries_test.go
@@ -1,0 +1,387 @@
+package local
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/grafana/agento11y/go/agento11y"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// conversationFileFor stats one conversation file the way the walk does, so
+// a cache test can ask for an entry without going through a read path.
+func conversationFileFor(t *testing.T, s *Storage, convID string) conversationFile {
+	t.Helper()
+	path := filepath.Join(s.Dir(), ConversationsDir, convID+".jsonl")
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	return conversationFile{id: convID, path: path, size: info.Size(), modTime: info.ModTime()}
+}
+
+// recordDecodes makes the cache report which files it decoded, in order.
+// The paths a read decodes are otherwise invisible: a hit and a miss return
+// the same entry.
+func recordDecodes(c *summaryCache) *[]string {
+	var mu sync.Mutex
+	var decoded []string
+	c.decode = func(f conversationFile) (*fileSummary, error) {
+		mu.Lock()
+		decoded = append(decoded, f.id)
+		mu.Unlock()
+		return decodeFileSummary(f)
+	}
+	return &decoded
+}
+
+// TestSummaryCache covers what makes an entry valid: an unchanged file is
+// answered without reopening it, a changed one is decoded again, and an
+// explicit invalidation forces a decode whatever the file looks like.
+func TestSummaryCache(t *testing.T) {
+	cases := []struct {
+		name string
+		// change runs between the two gets. It returns the file to ask for
+		// the second time.
+		change      func(t *testing.T, s *Storage, first conversationFile) conversationFile
+		wantDecodes int
+	}{
+		{
+			name: "unchanged file is not decoded again",
+			change: func(_ *testing.T, _ *Storage, first conversationFile) conversationFile {
+				return first
+			},
+			wantDecodes: 1,
+		},
+		{
+			name: "a grown file is decoded again",
+			change: func(t *testing.T, s *Storage, _ conversationFile) conversationFile {
+				writeGen(t, s, "conv-A", "g2", agento11y.Generation{
+					Model:     agento11y.ModelRef{Name: "m"},
+					StartedAt: mustParse(t, "2026-08-03T11:00:00Z"),
+					Usage:     agento11y.TokenUsage{InputTokens: 5},
+				}, "2026-08-03T11:00:00Z")
+				return conversationFileFor(t, s, "conv-A")
+			},
+			wantDecodes: 2,
+		},
+		{
+			name: "a rewritten modification time is decoded again",
+			change: func(t *testing.T, s *Storage, _ conversationFile) conversationFile {
+				setConversationModTime(t, s, "conv-A", mustParse(t, "2026-08-04T09:00:00Z"))
+				return conversationFileFor(t, s, "conv-A")
+			},
+			wantDecodes: 2,
+		},
+		{
+			name: "an invalidated entry is decoded again",
+			change: func(t *testing.T, s *Storage, first conversationFile) conversationFile {
+				s.summaries.invalidate(first.path)
+				return first
+			},
+			wantDecodes: 2,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newStorage(t)
+			writeGen(t, s, "conv-A", "g1", agento11y.Generation{
+				Model:     agento11y.ModelRef{Name: "m"},
+				StartedAt: mustParse(t, "2026-08-03T10:00:00Z"),
+				Usage:     agento11y.TokenUsage{InputTokens: 10, OutputTokens: 3},
+			}, "2026-08-03T10:00:01Z")
+
+			decoded := recordDecodes(&s.summaries)
+			first := conversationFileFor(t, s, "conv-A")
+			entry, err := s.summaries.get(first)
+			require.NoError(t, err)
+			require.True(t, entry.ok)
+			assert.Equal(t, 1, entry.summary.Calls)
+			require.Len(t, entry.points, 1)
+			assert.Equal(t, mustParse(t, "2026-08-03T10:00:00Z"), entry.first)
+			assert.Equal(t, mustParse(t, "2026-08-03T10:00:00Z"), entry.last)
+
+			next := tc.change(t, s, first)
+			again, err := s.summaries.get(next)
+			require.NoError(t, err)
+			require.True(t, again.ok)
+			assert.Len(t, *decoded, tc.wantDecodes)
+		})
+	}
+}
+
+// TestSummaryCacheHitDoesNotOpenTheFile proves the validation is what saves
+// the read: the file is made unreadable after the first decode, and the
+// second get still answers.
+func TestSummaryCacheHitDoesNotOpenTheFile(t *testing.T) {
+	requireUnreadableFilesSupported(t)
+	s := newStorage(t)
+	writeGen(t, s, "conv-A", "g1", agento11y.Generation{
+		Model:     agento11y.ModelRef{Name: "m"},
+		StartedAt: mustParse(t, "2026-08-03T10:00:00Z"),
+		Usage:     agento11y.TokenUsage{InputTokens: 10},
+	}, "2026-08-03T10:00:01Z")
+
+	f := conversationFileFor(t, s, "conv-A")
+	first, err := s.summaries.get(f)
+	require.NoError(t, err)
+
+	blockConversationFile(t, s, "conv-A")
+	again, err := s.summaries.get(f)
+	require.NoError(t, err)
+	assert.Same(t, first, again, "a valid entry is returned as-is")
+}
+
+// TestSummaryCachePrunesDeletedFiles checks that a conversation removed
+// from the store leaves no entry behind. Pruning only runs once the cache
+// holds more paths than the walk found, which is the point at which an
+// entry is provably dead.
+func TestSummaryCachePrunesDeletedFiles(t *testing.T) {
+	s := newStorage(t)
+	for _, id := range []string{"conv-A", "conv-B"} {
+		writeGen(t, s, id, "g-"+id, agento11y.Generation{
+			Model:     agento11y.ModelRef{Name: "m"},
+			StartedAt: mustParse(t, "2026-08-03T10:00:00Z"),
+			Usage:     agento11y.TokenUsage{InputTokens: 1},
+		}, "2026-08-03T10:00:01Z")
+	}
+	_, _, err := s.ListConversations(ConversationListOptions{})
+	require.NoError(t, err)
+	require.Len(t, s.summaries.entries, 2)
+
+	gone := filepath.Join(s.Dir(), ConversationsDir, "conv-B.jsonl")
+	require.NoError(t, os.Remove(gone))
+	_, _, err = s.ListConversations(ConversationListOptions{})
+	require.NoError(t, err)
+
+	assert.Len(t, s.summaries.entries, 1)
+	_, held := s.summaries.entries[gone]
+	assert.False(t, held, "the deleted conversation must not stay cached")
+}
+
+// TestSummaryCacheConcurrentGet runs the read path from several goroutines
+// at once. Entries are immutable and replaced whole, so every caller must
+// see one consistent snapshot; the race detector covers the rest.
+func TestSummaryCacheConcurrentGet(t *testing.T) {
+	s := newStorage(t)
+	writeGen(t, s, "conv-A", "g1", agento11y.Generation{
+		Model:     agento11y.ModelRef{Name: "m"},
+		StartedAt: mustParse(t, "2026-08-03T10:00:00Z"),
+		Usage:     agento11y.TokenUsage{InputTokens: 10, OutputTokens: 3},
+	}, "2026-08-03T10:00:01Z")
+	f := conversationFileFor(t, s, "conv-A")
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			entry, err := s.summaries.get(f)
+			assert.NoError(t, err)
+			require.NotNil(t, entry)
+			assert.Equal(t, 1, entry.summary.Calls)
+			assert.Equal(t, int64(10), entry.summary.InputTokens)
+			require.Len(t, entry.points, 1)
+		})
+	}
+	wg.Wait()
+}
+
+// TestSummaryCacheDecodesOncePerFile covers the in-flight dedup: callers
+// arriving while a file is being decoded wait for that decode rather than
+// repeating it. summaryCache.get documents why a request racing the
+// background warm depends on this.
+func TestSummaryCacheDecodesOncePerFile(t *testing.T) {
+	s := newStorage(t)
+	writeGen(t, s, "conv-A", "g1", agento11y.Generation{
+		Model:     agento11y.ModelRef{Name: "m"},
+		StartedAt: mustParse(t, "2026-08-03T10:00:00Z"),
+		Usage:     agento11y.TokenUsage{InputTokens: 10, OutputTokens: 3},
+	}, "2026-08-03T10:00:01Z")
+	f := conversationFileFor(t, s, "conv-A")
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var decodes atomic.Int64
+	s.summaries.decode = func(f conversationFile) (*fileSummary, error) {
+		if decodes.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return decodeFileSummary(f)
+	}
+
+	entries := make([]*fileSummary, 8)
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		entry, err := s.summaries.get(f)
+		assert.NoError(t, err)
+		entries[0] = entry
+	})
+	// The rest only join an existing decode once the first one is running.
+	<-started
+	for i := 1; i < len(entries); i++ {
+		wg.Go(func() {
+			entry, err := s.summaries.get(f)
+			assert.NoError(t, err)
+			entries[i] = entry
+		})
+	}
+	// The joiners have to be parked on the decode, not spinning on their
+	// own copies of it, before it is allowed to finish.
+	time.Sleep(20 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, int64(1), decodes.Load(), "one decode answers every caller")
+	for _, entry := range entries {
+		assert.Same(t, entries[0], entry, "every caller sees the same entry")
+	}
+}
+
+// TestSummaryCacheDecodesAgainAfterAFailedDecode checks that a failure is
+// not cached and does not wedge the path: the caller waiting on it gets the
+// error, and a later read decodes the file again.
+func TestSummaryCacheDecodesAgainAfterAFailedDecode(t *testing.T) {
+	s := newStorage(t)
+	writeGen(t, s, "conv-A", "g1", agento11y.Generation{
+		Model:     agento11y.ModelRef{Name: "m"},
+		StartedAt: mustParse(t, "2026-08-03T10:00:00Z"),
+		Usage:     agento11y.TokenUsage{InputTokens: 1},
+	}, "2026-08-03T10:00:01Z")
+	f := conversationFileFor(t, s, "conv-A")
+
+	var decodes atomic.Int64
+	failing := errors.New("decode failed")
+	s.summaries.decode = func(f conversationFile) (*fileSummary, error) {
+		if decodes.Add(1) == 1 {
+			return nil, failing
+		}
+		return decodeFileSummary(f)
+	}
+
+	_, err := s.summaries.get(f)
+	require.ErrorIs(t, err, failing)
+	assert.Empty(t, s.summaries.entries)
+
+	entry, err := s.summaries.get(f)
+	require.NoError(t, err)
+	assert.True(t, entry.ok)
+	assert.Equal(t, int64(2), decodes.Load())
+}
+
+// TestWarmSummaries covers the cold-start warmer: it visits the newest
+// conversation first, fills both projections, and leaves the store readable
+// with no file opened afterwards.
+func TestWarmSummaries(t *testing.T) {
+	requireUnreadableFilesSupported(t)
+	s := newStorage(t)
+	modTimes := map[string]string{
+		"conv-new": "2026-08-03T12:00:00Z",
+		"conv-old": "2026-08-03T10:00:00Z",
+	}
+	for _, id := range []string{"conv-old", "conv-new"} {
+		writeGen(t, s, id, "g-"+id, agento11y.Generation{
+			Model:     agento11y.ModelRef{Name: "m"},
+			StartedAt: mustParse(t, modTimes[id]),
+			Usage:     agento11y.TokenUsage{InputTokens: 4, OutputTokens: 1},
+		}, modTimes[id])
+		setConversationModTime(t, s, id, mustParse(t, modTimes[id]))
+	}
+
+	decoded := recordDecodes(&s.summaries)
+	s.warmSummaries(context.Background())
+	assert.Equal(t, []string{"conv-new", "conv-old"}, *decoded,
+		"the newest conversation is warmed first: it is the page the viewer opens on")
+
+	for _, id := range []string{"conv-new", "conv-old"} {
+		blockConversationFile(t, s, id)
+	}
+	convs, _, err := s.ListConversations(ConversationListOptions{})
+	require.NoError(t, err, "a warmed store serves the list without opening a file")
+	assert.Len(t, convs, 2)
+
+	points, _, err := s.TokenUsagePoints(TokenUsageOptions{Interval: time.Hour})
+	require.NoError(t, err, "one warm fills the token projection too")
+	require.Len(t, points, 2)
+	assert.Equal(t, TokenBuckets{FreshInput: 4, Output: 1}, points[0].TokenBuckets)
+
+	again, _, err := s.TokenUsagePoints(TokenUsageOptions{Interval: time.Hour})
+	require.NoError(t, err)
+	assert.Equal(t, points, again, "two identical requests return identical totals")
+	assert.Equal(t, []string{"conv-new", "conv-old"}, *decoded, "neither request decoded a file")
+}
+
+// cachedSummaryCount reads the entry count under the cache lock, which a
+// test racing a background warm has to do.
+func cachedSummaryCount(c *summaryCache) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
+}
+
+// TestWarmStartsOnFirstViewerRead pins warming to the viewer. EnsureRunning
+// starts a daemon for every --local agent session and for `history import`,
+// and neither opens the viewer, so a daemon nobody looks at must not decode
+// the whole store.
+func TestWarmStartsOnFirstViewerRead(t *testing.T) {
+	srv, storage, _ := newTestServerStorage(t)
+	for _, id := range []string{"conv-A", "conv-B", "conv-C"} {
+		writeGen(t, storage, id, "g-"+id, agento11y.Generation{
+			Model:     agento11y.ModelRef{Name: "m"},
+			StartedAt: mustParse(t, "2026-08-03T10:00:00Z"),
+			Usage:     agento11y.TokenUsage{InputTokens: 1},
+		}, "2026-08-03T10:00:01Z")
+	}
+	srv.WarmSummariesOnFirstRead(context.Background())
+	warm := srv.warmStore
+	var warms atomic.Int64
+	srv.warmStore = func() {
+		warms.Add(1)
+		warm()
+	}
+
+	postDiscard(t, srv, "/api/v1/generations:export", "application/json",
+		`{"generations":[{"id":"g-ingest","conversation_id":"conv-A"}]}`)
+	assert.Never(t, func() bool { return warms.Load() > 0 }, 50*time.Millisecond, 5*time.Millisecond,
+		"recording a generation is not a reason to read the whole store")
+
+	// The page stops after one conversation, so only the warm can account
+	// for the other two entries.
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/conversations?limit=1", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Eventually(t, func() bool { return cachedSummaryCount(&storage.summaries) == 3 },
+		2*time.Second, 5*time.Millisecond, "the first viewer read starts the warm")
+
+	rr = httptest.NewRecorder()
+	srv.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/metrics/tokens", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Never(t, func() bool { return warms.Load() > 1 }, 50*time.Millisecond, 5*time.Millisecond,
+		"the store is warmed once, not once per request")
+}
+
+// TestWarmSummariesLeavesUndecodableFiles checks the warmer is best effort:
+// a file it cannot read stays uncached, so a later request decodes it and
+// reports the failure rather than inheriting a wrong answer.
+func TestWarmSummariesLeavesUndecodableFiles(t *testing.T) {
+	requireUnreadableFilesSupported(t)
+	s := newStorage(t)
+	writeGen(t, s, "conv-A", "g1", agento11y.Generation{
+		Model:     agento11y.ModelRef{Name: "m"},
+		StartedAt: mustParse(t, "2026-08-03T10:00:00Z"),
+		Usage:     agento11y.TokenUsage{InputTokens: 1},
+	}, "2026-08-03T10:00:01Z")
+	blockConversationFile(t, s, "conv-A")
+
+	s.warmSummaries(context.Background())
+	assert.Empty(t, s.summaries.entries)
+
+	_, _, err := s.ListConversations(ConversationListOptions{})
+	assert.Error(t, err, "the unreadable file is reported, not served from a warm entry")
+}

--- a/plugins/agento11y/internal/local/web/app.jsx
+++ b/plugins/agento11y/internal/local/web/app.jsx
@@ -4347,6 +4347,24 @@
     // feel live, slow enough to coalesce typing into one network call.
     const SEARCH_DEBOUNCE_MS = 320;
 
+    // REFRESH_DEBOUNCE_MS is how long a burst of change events is collected
+    // before the conversation list and the token chart refetch.
+    const REFRESH_DEBOUNCE_MS = 250;
+    // IMPORT_REFRESH_DEBOUNCE_MS replaces it for the list and the chart while a
+    // history import runs. An import appends to thousands of conversations, so
+    // a refresh at the normal cadence shows a list that is stale again before
+    // it renders. The progress banner carries the detail; the list only has to
+    // stay roughly current. An open conversation keeps the normal cadence: it
+    // is what the user is reading.
+    const IMPORT_REFRESH_DEBOUNCE_MS = 2000;
+    // IMPORT_ACTIVE_TTL_MS is how long one import frame holds the slower
+    // cadence. The event stream is lossy: the daemon drops frames for a
+    // subscriber that falls behind, and a reconnect replays nothing. So a run
+    // has to expire rather than latch, or one lost terminal frame leaves the
+    // tab slow until a reload. A running import publishes progress every
+    // 250ms, so this much slack cannot expire it mid-run.
+    const IMPORT_ACTIVE_TTL_MS = 10_000;
+
     // escapeRegExp escapes the special-meaning characters in a query token
     // before splicing into the alternation regex that drives highlighting.
     // Keeps a literal "a+b" highlighting "a+b" rather than "aab".
@@ -4744,9 +4762,31 @@
           .catch(() => {});
       }, [timeRange]);
 
+      // refreshAll keeps one refresh cycle in flight. An event arriving while
+      // a cycle runs marks at most one follow-up refresh as due instead of
+      // starting a second cycle. Without that, a slow response lets one
+      // request per debounce window pile up until the browser's
+      // six-connection limit stops them, and each one is a full-store read.
+      const refreshInFlightRef = useRef(false);
+      const refreshDirtyRef = useRef(false);
+      // The follow-up runs through refreshAllRef rather than through the
+      // captured refreshAll: a range change during the cycle replaces the
+      // callback, and the follow-up has to request the range the header now
+      // names. The effect below fills the ref on the first render, before any
+      // response can land.
+      const refreshAllRef = useRef(null);
       const refreshAll = useCallback(() => {
-        fetchList();
-        fetchTokens();
+        if (refreshInFlightRef.current) {
+          refreshDirtyRef.current = true;
+          return;
+        }
+        refreshInFlightRef.current = true;
+        Promise.all([fetchList(), fetchTokens()]).finally(() => {
+          refreshInFlightRef.current = false;
+          if (!refreshDirtyRef.current) return;
+          refreshDirtyRef.current = false;
+          refreshAllRef.current();
+        });
       }, [fetchList, fetchTokens]);
 
       // reloadRange refetches when the request window itself changed: mount,
@@ -4825,10 +4865,14 @@
       // conversation) refresh within ~1s without polling. Refs hold the
       // latest callbacks so the effect mounts once and doesn't drop the
       // connection on every render.
-      const refreshAllRef = useRef(refreshAll);
       const quietRefreshDetailRef = useRef(quietRefreshDetail);
       const selectedIDRef = useRef(selectedID);
       const viewRef = useRef(view);
+      // importActiveUntilRef holds the instant the import cadence lapses. The
+      // SSE handler is mounted once and cannot read the state the banner
+      // renders from, so it tracks the run itself. It is a deadline rather
+      // than a flag, see IMPORT_ACTIVE_TTL_MS.
+      const importActiveUntilRef = useRef(0);
       useEffect(() => { refreshAllRef.current = refreshAll; }, [refreshAll]);
       useEffect(() => { quietRefreshDetailRef.current = quietRefreshDetail; }, [quietRefreshDetail]);
       useEffect(() => { selectedIDRef.current = selectedID; }, [selectedID]);
@@ -4840,26 +4884,32 @@
         // fall back to the 60s backstop refresh below instead of
         // throwing on the constructor.
         if (typeof EventSource === "undefined") return;
-        let timer = null;
         // Debounce so a burst export (one frame per generation) does
         // not trigger one refresh per frame. We only need one list
         // refresh per burst, plus one detail refresh if any event in
-        // the burst targets the open conversation.
-        let burstHasOpenConv = false;
-        const flush = () => {
-          timer = null;
-          const refreshOpen = burstHasOpenConv;
-          const openID = selectedIDRef.current;
-          burstHasOpenConv = false;
-          // Skip refetches when the user is on a non-conversation tab;
-          // the conversation list isn't rendered there, and the SSE
-          // connection itself is cheap to leave running.
+        // the burst targets the open conversation. The two are armed
+        // separately because an import slows the list down and the open
+        // conversation keeps the normal cadence.
+        let listTimer = null;
+        let detailTimer = null;
+        // onConversations reports whether the list or a conversation is
+        // rendered. Elsewhere neither is, and the SSE connection itself is
+        // cheap to leave running.
+        const onConversations = () => {
           const v = viewRef.current;
-          if (v !== "conversations" && v !== "conversation") return;
+          return v === "conversations" || v === "conversation";
+        };
+        const importActive = () => importActiveUntilRef.current > Date.now();
+        const flushList = () => {
+          listTimer = null;
+          if (!onConversations()) return;
           refreshAllRef.current();
-          if (refreshOpen && openID) {
-            quietRefreshDetailRef.current(openID);
-          }
+        };
+        const flushDetail = () => {
+          detailTimer = null;
+          const openID = selectedIDRef.current;
+          if (!openID || !onConversations()) return;
+          quietRefreshDetailRef.current(openID);
         };
         const es = new EventSource("/api/v1/events");
         es.onmessage = (e) => {
@@ -4868,20 +4918,32 @@
           if (ev && ev.import) {
             // Import events carry state rather than naming a conversation, so
             // they are applied directly and skip the refetch debounce.
+            const active = importRunIsActive(ev.import);
+            importActiveUntilRef.current = active ? Date.now() + IMPORT_ACTIVE_TTL_MS : 0;
             setImportEvent(ev.import);
+            // A finished run may be followed by no further change event, and
+            // the list is then as stale as the import left it. Arm one refresh
+            // on any frame reporting a terminal status; the timer guard folds
+            // the several a run's last updates produce into one.
+            if (!active && listTimer === null) {
+              listTimer = setTimeout(flushList, REFRESH_DEBOUNCE_MS);
+            }
             return;
           }
           const openID = selectedIDRef.current;
-          if (openID && ev && ev.conversation_id === openID) {
-            burstHasOpenConv = true;
+          if (openID && ev && ev.conversation_id === openID && detailTimer === null) {
+            detailTimer = setTimeout(flushDetail, REFRESH_DEBOUNCE_MS);
           }
-          if (timer === null) timer = setTimeout(flush, 250);
+          if (listTimer === null) {
+            listTimer = setTimeout(flushList, importActive() ? IMPORT_REFRESH_DEBOUNCE_MS : REFRESH_DEBOUNCE_MS);
+          }
         };
         // EventSource auto-reconnects on transport errors, so a daemon
         // restart or proxy blip heals without an explicit handler.
         // Cleanup closes the stream.
         return () => {
-          if (timer !== null) clearTimeout(timer);
+          if (listTimer !== null) clearTimeout(listTimer);
+          if (detailTimer !== null) clearTimeout(detailTimer);
           es.close();
         };
       }, []);


### PR DESCRIPTION
Cache token counts for `GET /api/v1/metrics/tokens` call. The local viewer stores one JSONL file per conversation under the store's `conversations/` directory. Two endpoints read the files on every call: `GET /api/v1/conversations` for the list, and `GET /api/v1/metrics/tokens` for the token chart. Now data for the responses is kept in memory to avoid parsing files each time.