### PR TITLE
fix(plugins/agento11y): stamp local conversation files with their last activity

### DIFF
--- a/plugins/agento11y/internal/local/daemon_unix.go
+++ b/plugins/agento11y/internal/local/daemon_unix.go
@@ -4,6 +4,7 @@ package local
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -20,13 +21,26 @@ type daemonLock struct {
 }
 
 func acquireDaemonLock(dir string) (*daemonLock, error) {
-	path := filepath.Join(dir, LockFile)
+	return acquireFileLock(filepath.Join(dir, LockFile), true)
+}
+
+// acquireFileLock takes an exclusive flock on path, creating the file when
+// it is missing. wait blocks until the lock is free; without it a lock
+// another process holds returns errLockBusy straight away.
+func acquireFileLock(path string, wait bool) (*daemonLock, error) {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open lockfile: %w", err)
 	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+	how := syscall.LOCK_EX
+	if !wait {
+		how |= syscall.LOCK_NB
+	}
+	if err := syscall.Flock(int(f.Fd()), how); err != nil {
 		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, errLockBusy
+		}
 		return nil, fmt.Errorf("flock: %w", err)
 	}
 	return &daemonLock{f: f}, nil

--- a/plugins/agento11y/internal/local/manager.go
+++ b/plugins/agento11y/internal/local/manager.go
@@ -91,34 +91,11 @@ func LoadStatus(dir string) (*Status, error) {
 // the daemon lock, and `local status` reads it at any time, so those readers
 // would fail on an empty file while a daemon records itself.
 func SaveStatus(dir string, s Status) error {
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return err
-	}
 	data, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {
 		return err
 	}
-	f, err := os.CreateTemp(dir, StatusFile+".tmp-*")
-	if err != nil {
-		return err
-	}
-	tmp := f.Name()
-	// A no-op once the rename below succeeds; on any earlier return it keeps
-	// a failed write from leaving the temp file behind.
-	defer func() { _ = os.Remove(tmp) }()
-	if _, err := f.Write(data); err != nil {
-		_ = f.Close()
-		return err
-	}
-	if err := f.Close(); err != nil {
-		return err
-	}
-	// CreateTemp opens at 0o600 already; set it explicitly so the file mode
-	// does not depend on the caller's umask.
-	if err := os.Chmod(tmp, 0o600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, filepath.Join(dir, StatusFile))
+	return writeFileAtomic(dir, StatusFile, data)
 }
 
 // RemoveStatus deletes the status file. Missing-file errors are ignored.
@@ -291,6 +268,21 @@ func Serve(ctx context.Context, dir string, port int, logger *log.Logger) error 
 	if logger != nil {
 		logger.Printf("local: serving on %s (dir=%s)", status.Endpoint, dir)
 	}
+
+	// The pass starts only after the status file exists: the process that
+	// spawned this daemon waits 5 seconds for that file, and stamping a large
+	// store takes longer. On the way out the pass stops at the next file, so
+	// waiting for it costs one file scan.
+	repairCtx, cancelRepair := context.WithCancel(ctx)
+	repairDone := make(chan struct{})
+	go func() {
+		defer close(repairDone)
+		repairStoreOnStartup(repairCtx, storage, srv.hub)
+	}()
+	defer func() {
+		cancelRepair()
+		<-repairDone
+	}()
 
 	serveErr := make(chan error, 1)
 	go func() {

--- a/plugins/agento11y/internal/local/manager_test.go
+++ b/plugins/agento11y/internal/local/manager_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -88,6 +89,70 @@ func TestSaveStatus_ConcurrentReadersSeeWholeFile(t *testing.T) {
 	}
 	require.NoError(t, readErr, "LoadStatus read a status file mid-write")
 	assert.Zero(t, partial, "LoadStatus returned a status that was never written")
+}
+
+// TestServe_StampsStoreAfterPublishingStatus covers the order the daemon
+// starts things in: the status file the spawning process waits 5 seconds
+// for appears while the modification-time pass is still reading the store,
+// and the store repairs itself once the pass gets through it.
+//
+// A named pipe among the conversation files holds the pass: opening one
+// for reading returns only once this test opens the write end, so the pass
+// cannot reach the marker until the test lets it.
+func TestServe_StampsStoreAfterPublishingStatus(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "local")
+	storage, err := NewStorage(dir)
+	require.NoError(t, err)
+	activity := time.Now().Add(-90 * 24 * time.Hour).Truncate(time.Second)
+	seedConversation(t, storage, "conv-A", activity)
+	blocker := filepath.Join(dir, ConversationsDir, "conv-blocker.jsonl")
+	require.NoError(t, syscall.Mkfifo(blocker, 0o600))
+
+	// The pass reports what it stamped and what it could not, and this test
+	// can only fail by the pass not finishing, so keep its log.
+	logger := testLogger(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	served := make(chan error, 1)
+	go func() { served <- Serve(ctx, dir, 0, logger) }()
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, <-served)
+	})
+	// Serve waits for the pass on the way out, so a failed assertion below
+	// must not leave it parked on the pipe. Opening the write end without
+	// blocking fails with ENXIO when the pass is not reading, which is the
+	// case where nothing needs freeing.
+	t.Cleanup(func() {
+		if w, err := os.OpenFile(blocker, os.O_WRONLY|syscall.O_NONBLOCK, 0); err == nil {
+			_ = w.Close()
+		}
+	})
+
+	// IsRunning is what the spawning process polls: the status file plus an
+	// endpoint that answers.
+	require.Eventually(t, func() bool {
+		s, err := IsRunning(dir)
+		return err == nil && s != nil
+	}, 5*time.Second, 20*time.Millisecond, "daemon published its status and serves")
+
+	meta, err := readStoreMeta(dir)
+	require.NoError(t, err)
+	require.False(t, meta.MtimeStamped, "the daemon serves while the pass is still reading")
+
+	// Let the pass through the pipe: an empty file carries no activity, so
+	// it is scanned and left alone.
+	w, err := os.OpenFile(blocker, os.O_WRONLY, 0)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	require.Eventually(t, func() bool {
+		meta, err := readStoreMeta(dir)
+		return err == nil && meta.MtimeStamped
+	}, 5*time.Second, 20*time.Millisecond, "store marked as stamped")
+
+	info, err := os.Stat(filepath.Join(dir, ConversationsDir, "conv-A.jsonl"))
+	require.NoError(t, err)
+	assert.WithinDuration(t, activity, info.ModTime(), stampTolerance)
 }
 
 func TestStop_EndpointDeadButProcessAlive(t *testing.T) {
@@ -281,4 +346,39 @@ func TestEnsureRunning_ConcurrentCallersSpawnOnce(t *testing.T) {
 	if got := spawns.Load(); got != 1 {
 		t.Errorf("spawns = %d, want 1 (flock should serialise EnsureRunning)", got)
 	}
+}
+
+// testLogger routes a daemon's diagnostics into the test's output, so a
+// failing test reports what the daemon was doing. Call it from the test
+// goroutine: it registers the cleanup that stops the writer, and t.Log
+// panics once the test and its cleanups are done.
+func testLogger(t *testing.T) *log.Logger {
+	w := &testLogWriter{t: t}
+	t.Cleanup(w.stop)
+	return log.New(w, "", 0)
+}
+
+type testLogWriter struct {
+	t *testing.T
+
+	mu      sync.Mutex
+	stopped bool
+}
+
+func (w *testLogWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.stopped {
+		w.t.Log(strings.TrimRight(string(p), "\n"))
+	}
+	return len(p), nil
+}
+
+// stop drops later lines. A goroutine the test did not join can still hold
+// the logger, and writing from one after the test ends takes the whole run
+// down.
+func (w *testLogWriter) stop() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.stopped = true
 }

--- a/plugins/agento11y/internal/local/query.go
+++ b/plugins/agento11y/internal/local/query.go
@@ -119,8 +119,9 @@ type ConversationListOptions struct {
 	Limit int
 	// Since drops conversations whose last activity predates it. The bound
 	// is inclusive, so a conversation whose last activity is exactly Since
-	// is kept. It applies to the file modification time, which for these
-	// append-only files is the last activity. Zero means no lower bound.
+	// is kept. It applies to the file modification time, which every append
+	// stamps with the newest activity the file holds. Zero means no lower
+	// bound.
 	Since time.Time
 }
 
@@ -132,9 +133,11 @@ type ConversationListOptions struct {
 // returns an empty slice and a zero total (first-launch case).
 //
 // The limit can apply before the decode only because the order comes from
-// the file modification time rather than the decoded last_activity. For an
-// append-only JSONL file the two agree. A copy or restore that rewrites
-// modification times can reorder the list until the next append.
+// the file modification time rather than the decoded last_activity. The two
+// agree because an append stamps the file with the newest activity it holds
+// (recordActivity), and the modification-time pass at startup sets the same
+// stamp on every file whose records disagree with it. A copy or restore
+// that rewrites modification times reorders the list until the next append.
 func (s *Storage) ListConversations(opts ConversationListOptions) (page []ConversationSummary, total int, err error) {
 	files, err := s.conversationFiles()
 	if err != nil {
@@ -386,12 +389,12 @@ func (s *Storage) TokenUsagePoints(opts TokenUsageOptions) ([]TokenUsagePoint, t
 			return nil, 0, err
 		}
 		skipped += entry.skipped
-		// The break above is loose. A file's modification time is only an
-		// upper bound on the data time of the generations in it, and an import
-		// stamps every file it writes with the current time, so during an
-		// import the break cuts nothing. bounds then cuts on the decoded
-		// timestamps instead. Files are ordered by modification time, not by
-		// data time, so a file below the bound is skipped and the walk goes on.
+		// The break above cuts whole files, because a file's modification time
+		// is the newest activity it holds. The older points inside a file it
+		// keeps can still fall below the bound, which is what bounds cuts on. A
+		// file left with no point is skipped rather than ending the walk: a copy
+		// or restore that rewrote modification times orders the files by
+		// something other than their activity.
 		entryFirst, entryLast, ok := entry.bounds(opts.Since)
 		if !ok {
 			continue
@@ -542,6 +545,29 @@ func tokenUsagePoint(rec summaryRecord) (TokenUsagePoint, bool) {
 		Provider:     gen.Model.Provider,
 		TokenBuckets: buckets,
 	}, true
+}
+
+// recordActivity is the moment a stored record represents: the later of
+// completed_at and started_at, or the receiver's arrival time when the
+// record carries neither. The conversation summary and every
+// modification-time stamp read it, so the list order and the Since bound
+// cannot disagree.
+//
+// It takes the later of the pair rather than completed_at alone because an
+// exporter can report a completed_at that precedes started_at, and because
+// generationTime places a token-chart point at started_at. Activity is
+// therefore never below the point in the same record, so the chart can skip
+// a file by its modification time.
+func recordActivity(gen summaryGeneration, receivedAt string) time.Time {
+	when := gen.CompletedAt
+	if gen.StartedAt.After(when) {
+		when = gen.StartedAt
+	}
+	if !when.IsZero() {
+		return when
+	}
+	when, _ = time.Parse(time.RFC3339Nano, receivedAt)
+	return when
 }
 
 // generationTime is the wall-clock moment a generation ran, preferring

--- a/plugins/agento11y/internal/local/query_test.go
+++ b/plugins/agento11y/internal/local/query_test.go
@@ -111,14 +111,8 @@ func TestListConversations_Aggregates(t *testing.T) {
 	// list should still surface it via the received_at fallback.
 	writeGen(t, s, "conv-C", "g5", agento11y.Generation{AgentName: "vistra"}, "2026-05-21T11:10:00Z")
 
-	// The order comes from the file modification time, and on Linux the three
-	// writes above land in one filesystem timestamp tick, which leaves them
-	// tied. Pin each file to its last received_at so the expected order is the
-	// one the records describe.
-	setConversationModTime(t, s, "conv-A", mustParse(t, "2026-05-21T10:00:13Z"))
-	setConversationModTime(t, s, "conv-B", mustParse(t, "2026-05-21T11:00:01Z"))
-	setConversationModTime(t, s, "conv-C", mustParse(t, "2026-05-21T11:10:00Z"))
-
+	// The order comes from the file modification time, which each append
+	// above stamped with the newest activity it carried.
 	got, _, err := s.ListConversations(ConversationListOptions{})
 	if err != nil {
 		t.Fatalf("ListConversations: %v", err)
@@ -214,7 +208,9 @@ func TestConversationQueriesUseLatestGenerationRecord(t *testing.T) {
 }
 
 // TestListConversations_LimitAndEmpty covers the limit knob and the
-// empty-store case in one table.
+// empty-store case in one table. The five fixtures share one received_at
+// and stagger completed_at a minute apart, so the returned order comes
+// from the activity each append stamped and not from the arrival time.
 func TestListConversations_LimitAndEmpty(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -238,10 +234,6 @@ func TestListConversations_LimitAndEmpty(t *testing.T) {
 					StartedAt:   mustParse(t, "2026-05-21T10:00:00Z").Add(time.Duration(i) * time.Minute),
 					CompletedAt: mustParse(t, "2026-05-21T10:00:01Z").Add(time.Duration(i) * time.Minute),
 				}, "2026-05-21T10:00:01Z")
-				// One tick holds every write on Linux, so the modification
-				// times tie and the newest-first order falls back to the id.
-				// Pin them a minute apart, matching the seeded activity.
-				setConversationModTime(t, s, id, mustParse(t, "2026-05-21T10:00:01Z").Add(time.Duration(i)*time.Minute))
 			}
 			got, _, err := s.ListConversations(ConversationListOptions{Limit: tc.limit})
 			if err != nil {
@@ -265,7 +257,7 @@ func TestListConversations_LimitAndEmpty(t *testing.T) {
 // page are made unreadable, so a request that would open one fails and a
 // bounded request cannot pass by accident.
 func TestListConversations_BoundedPage(t *testing.T) {
-	modTimes := map[string]string{
+	activity := map[string]string{
 		"conv-a": "2026-08-03T12:00:00Z",
 		"conv-b": "2026-08-03T11:00:00Z",
 		"conv-c": "2026-08-03T10:00:00Z",
@@ -293,17 +285,16 @@ func TestListConversations_BoundedPage(t *testing.T) {
 				requireUnreadableFilesSupported(t)
 			}
 			s := newStorage(t)
-			// Write oldest-first so the modification times below are the
-			// only thing the order can come from.
+			// Write oldest-first, so an order that follows the seeded
+			// activity can only come from the stamp each append writes.
 			for _, id := range oldestFirst {
 				writeGen(t, s, id, "g-"+id, agento11y.Generation{
 					AgentName:   "pi",
 					Model:       agento11y.ModelRef{Name: "m"},
-					StartedAt:   mustParse(t, modTimes[id]),
-					CompletedAt: mustParse(t, modTimes[id]),
+					StartedAt:   mustParse(t, activity[id]),
+					CompletedAt: mustParse(t, activity[id]),
 					Usage:       agento11y.TokenUsage{InputTokens: 1, OutputTokens: 1},
-				}, modTimes[id])
-				setConversationModTime(t, s, id, mustParse(t, modTimes[id]))
+				}, activity[id])
 			}
 			if tc.blockFrom >= 0 {
 				for _, id := range []string{"conv-a", "conv-b", "conv-c"}[tc.blockFrom:] {
@@ -1004,6 +995,39 @@ func TestTokenUsagePoints(t *testing.T) {
 	assert.Equal(t, mustParse(t, "2026-05-21T12:00:00Z"), points[2].Timestamp)
 }
 
+// TestTokenUsagePoints_InvertedTimestampsStayInRange covers a generation
+// whose completed_at precedes its started_at, which a clock adjustment on
+// the exporting machine produces. Activity takes the later of the two, so a
+// file's modification time never sits below the point the chart places at
+// started_at, and the Since bound that skips whole files cannot drop a
+// point inside the range.
+func TestTokenUsagePoints_InvertedTimestampsStayInRange(t *testing.T) {
+	s := newStorage(t)
+	started := mustParse(t, "2026-05-21T10:00:00Z")
+	writeGen(t, s, "conv-inverted", "g1", agento11y.Generation{
+		Model:       agento11y.ModelRef{Provider: "anthropic", Name: "claude-sonnet-4"},
+		StartedAt:   started,
+		CompletedAt: started.Add(-30 * time.Minute),
+		Usage:       agento11y.TokenUsage{InputTokens: 5, OutputTokens: 3},
+	}, started.Format(time.RFC3339Nano))
+
+	info, err := os.Stat(filepath.Join(s.Dir(), ConversationsDir, "conv-inverted.jsonl"))
+	require.NoError(t, err)
+	assert.WithinDuration(t, started, info.ModTime(), time.Second, "the stamp follows started_at")
+
+	points, _, err := s.TokenUsagePoints(TokenUsageOptions{
+		Since:    started.Add(-time.Minute),
+		Interval: time.Hour,
+	})
+	require.NoError(t, err)
+	require.Len(t, points, 1)
+	assert.Equal(t, int64(5), points[0].FreshInput)
+
+	summaries, _, err := s.ListConversations(ConversationListOptions{Since: started.Add(-time.Minute)})
+	require.NoError(t, err)
+	require.Len(t, summaries, 1, "the list keeps the conversation its own bound covers")
+}
+
 // TestTokenUsagePoints_Buckets covers the aggregation the chart reads: one
 // point per bucket and model, ordered by timestamp then model, plus the
 // range bound and the derived interval.
@@ -1135,7 +1159,11 @@ func TestTokenUsagePoints_ScaleFollowsBucketsNotGenerations(t *testing.T) {
 				Generation:     raw,
 			})
 		}
-		written, err := s.AppendGenerations(convID, recs)
+		activities := make([]time.Time, len(recs))
+		for i := range activities {
+			activities[i] = start
+		}
+		written, err := s.AppendGenerations(convID, recs, activities)
 		require.NoError(t, err)
 		require.Equal(t, perConv, written)
 	}

--- a/plugins/agento11y/internal/local/repair.go
+++ b/plugins/agento11y/internal/local/repair.go
@@ -1,0 +1,207 @@
+//go:build !windows
+
+package local
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// errLockBusy reports that a non-blocking lock request found the lock held
+// by another process.
+var errLockBusy = errors.New("lock held by another process")
+
+// storeMeta records what a daemon has already done to the store on disk.
+// It lives in StoreFile so the modification-time pass over every
+// conversation file runs once per store and not on every start.
+type storeMeta struct {
+	// MtimeStamped reports that every conversation file's modification time
+	// has been set to its own last activity. A file the pass has not reached
+	// carries the time it was written, which for a history import is the
+	// import's wall clock and not the session's own date.
+	MtimeStamped bool `json:"mtime_stamped,omitempty"`
+}
+
+func readStoreMeta(dir string) (storeMeta, error) {
+	data, err := os.ReadFile(filepath.Join(dir, StoreFile))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return storeMeta{}, nil
+		}
+		return storeMeta{}, err
+	}
+	var meta storeMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return storeMeta{}, err
+	}
+	return meta, nil
+}
+
+func writeStoreMeta(dir string, meta storeMeta) error {
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(dir, StoreFile, data)
+}
+
+// stampTolerance is how far a file's modification time may sit from its
+// last activity before the repair rewrites it. A filesystem that keeps
+// coarser timestamps than the records do would otherwise make every pass
+// rewrite every file.
+const stampTolerance = time.Second
+
+// repairStoreOnStartup runs the modification-time pass and tells connected
+// viewers once it finished, so a viewer left open refetches a list the pass
+// has just reordered. The pass reads every record in the store, so the
+// daemon runs it in the background after publishing its status file.
+func repairStoreOnStartup(ctx context.Context, s *Storage, hub *eventHub) {
+	repaired, err := repairStoreModTimes(ctx, s)
+	// A pass that stamped some files and failed on others still reordered
+	// the list, so an open viewer has to refetch either way.
+	if repaired {
+		hub.broadcast(changeEvent{})
+	}
+	switch {
+	case err == nil:
+	case errors.Is(err, errLockBusy):
+		s.logf("local: another daemon holds %s, leaving the modification-time pass to it", RepairLockFile)
+	case errors.Is(err, context.Canceled):
+		s.logf("local: modification-time pass stopped at shutdown, the next start repeats it")
+	default:
+		s.logf("local: modification-time pass over %s: %v", ConversationsDir, err)
+	}
+}
+
+// repairStoreModTimes sets every conversation file's modification time to
+// the newest activity that file holds, and records that it did so. It
+// returns true when it walked the store, a walk that failed on some of the
+// files included, and false for a store already marked as stamped.
+//
+// The marker is only written when every file was scanned and stamped
+// without error, so a failed pass runs again on the next start. Repeating
+// the pass changes nothing, because each target is recomputed from the
+// file's own records. The exception is a file holding a record dated in the
+// future, which every pass stamps again with its own now.
+func repairStoreModTimes(ctx context.Context, s *Storage) (bool, error) {
+	meta, err := readStoreMeta(s.Dir())
+	if err != nil {
+		return false, err
+	}
+	if meta.MtimeStamped {
+		return false, nil
+	}
+
+	// More than one daemon can share a store, and two passes stamping the
+	// same files would fight over the per-file lock for no gain.
+	lock, err := acquireFileLock(filepath.Join(s.Dir(), RepairLockFile), false)
+	if err != nil {
+		return false, err
+	}
+	defer lock.release()
+
+	// The daemon that held the lock may have finished the pass since the
+	// read above.
+	if meta, err := readStoreMeta(s.Dir()); err == nil && meta.MtimeStamped {
+		return false, nil
+	}
+
+	files, err := s.conversationFiles()
+	if err != nil {
+		return false, err
+	}
+	// A first launch has no files to stamp, so mark the store and skip the
+	// pass on every later start.
+	if len(files) == 0 {
+		return true, writeStoreMeta(s.Dir(), storeMeta{MtimeStamped: true})
+	}
+	// A pass over a large store runs for seconds, so log the start as well
+	// as the summary below.
+	s.logf("local: stamping %d conversation files with their last activity", len(files))
+	started := time.Now()
+	var stamped, failed int
+	var firstErr error
+	for _, f := range files {
+		if err := ctx.Err(); err != nil {
+			return stamped > 0, err
+		}
+		changed, err := s.stampConversationActivity(f.path, f.modTime)
+		switch {
+		case err != nil:
+			// A file this daemon cannot read or stamp is counted and skipped.
+			// Stopping here would leave every remaining file ordered by the
+			// time it was written.
+			failed++
+			if firstErr == nil {
+				firstErr = err
+			}
+			s.logf("local: stamp %s: %v", f.path, err)
+		case changed:
+			stamped++
+		}
+	}
+	s.logf("local: modification-time pass: %d files, %d stamped, %d failed, took %s",
+		len(files), stamped, failed, time.Since(started).Round(time.Millisecond))
+	if failed > 0 {
+		// No marker, so the next start walks the store again and picks up
+		// the files this pass could not stamp.
+		return true, fmt.Errorf("%d of %d conversation files could not be stamped: %w", failed, len(files), firstErr)
+	}
+	if err := writeStoreMeta(s.Dir(), storeMeta{MtimeStamped: true}); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
+// stampConversationActivity sets one conversation file's modification time
+// to the newest activity it holds, clamped to now, and reports whether it
+// changed anything. modTime comes from the directory walk, so nothing
+// re-stats the file.
+//
+// It takes the same per-path lock an append takes, so the scan and the
+// stamp cannot interleave with a live export writing to the same file.
+func (s *Storage) stampConversationActivity(path string, modTime time.Time) (bool, error) {
+	lock := s.lockFor(path)
+	lock.Lock()
+	defer lock.Unlock()
+
+	var newest time.Time
+	skipped, err := scanLatestSummaryRecords(path, func(rec summaryRecord) {
+		if when := recordActivity(rec.Generation, rec.ReceivedAt); when.After(newest) {
+			newest = when
+		}
+	})
+	s.logSkipped("stamp "+filepath.Base(path), skipped)
+	if err != nil {
+		return false, err
+	}
+	// A file with no usable timestamp keeps the time it was written, the one
+	// case an append also leaves alone.
+	if newest.IsZero() {
+		return false, nil
+	}
+	// A record dated in the future would outrank every real activity until
+	// that date passes, so now is as close as the file can sit to it. An
+	// append leaves such a file at now as well. Keeping the import time
+	// instead sinks the file below its own newest record, out of Since ranges
+	// its records do cover.
+	if now := time.Now(); newest.After(now) {
+		newest = now
+	}
+	if diff := modTime.Sub(newest); diff < stampTolerance && diff > -stampTolerance {
+		return false, nil
+	}
+	if err := s.setModTime(path, newest); err != nil {
+		return false, err
+	}
+	// The stat validation would catch the new modification time on its own.
+	// Dropping the entry keeps the cache from holding one no read can serve.
+	s.summaries.invalidate(path)
+	return true, nil
+}

--- a/plugins/agento11y/internal/local/repair_test.go
+++ b/plugins/agento11y/internal/local/repair_test.go
@@ -1,0 +1,256 @@
+//go:build !windows
+
+package local
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/grafana/agento11y/go/agento11y"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRepairStoreModTimes covers the modification-time pass over an
+// existing store: a file written before appends stamped their activity gets
+// the time its own records describe, a file that already agrees is not
+// rewritten, and a file whose records are dated in the future is clamped to
+// now rather than left at the time it was written.
+func TestRepairStoreModTimes(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	fixtures := []struct {
+		id string
+		// activity is the newest completed_at in the file.
+		activity time.Duration
+		// modTime is what the file's modification time starts as, offset
+		// from now, and want is what the pass must leave behind.
+		modTime time.Duration
+		want    time.Duration
+	}{
+		{id: "conv-imported", activity: -90 * 24 * time.Hour, modTime: 0, want: -90 * 24 * time.Hour},
+		{id: "conv-live", activity: -time.Hour, modTime: -time.Hour, want: -time.Hour},
+		{id: "conv-future", activity: 48 * time.Hour, modTime: -time.Minute, want: 0},
+	}
+
+	s := newStorage(t)
+	for _, f := range fixtures {
+		writeGen(t, s, f.id, "g-"+f.id, agento11y.Generation{
+			Model:       agento11y.ModelRef{Name: "m"},
+			StartedAt:   now.Add(f.activity).Add(-time.Minute),
+			CompletedAt: now.Add(f.activity),
+			Usage:       agento11y.TokenUsage{InputTokens: 1},
+		}, now.Add(f.activity).Format(time.RFC3339Nano))
+		setConversationModTime(t, s, f.id, now.Add(f.modTime))
+	}
+	stamps := countStamps(s)
+
+	repaired, err := repairStoreModTimes(context.Background(), s)
+	require.NoError(t, err)
+	assert.True(t, repaired)
+
+	for _, f := range fixtures {
+		info, err := os.Stat(filepath.Join(s.Dir(), ConversationsDir, f.id+".jsonl"))
+		require.NoError(t, err)
+		assert.WithinDuration(t, now.Add(f.want), info.ModTime(), stampTolerance, f.id)
+	}
+	assert.Equal(t, int32(2), stamps.Load(), "only the files that disagreed are rewritten")
+
+	marker, err := os.ReadFile(filepath.Join(s.Dir(), StoreFile))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"mtime_stamped": true}`, string(marker))
+}
+
+// errStampRefused stands in for a filesystem that will not set a
+// modification time.
+var errStampRefused = errors.New("read-only file system")
+
+// TestRepairStoreModTimes_Outcomes covers what one pass over a store with
+// two files leaves behind. Only a pass that stamped every file it walked
+// writes the marker, so any other outcome runs the pass again on the next
+// daemon start.
+func TestRepairStoreModTimes_Outcomes(t *testing.T) {
+	cases := []struct {
+		name string
+		// arrange decides what the pass runs into.
+		arrange func(t *testing.T, s *Storage)
+		// stampErr fails every stamp with this error.
+		stampErr error
+		// wantErr is what the pass must return, matched with errors.Is.
+		wantErr error
+		// wantWalked reports whether the pass walked the store, which is
+		// what tells an open viewer to refetch.
+		wantWalked bool
+		wantMarker bool
+		wantStamps int32
+	}{
+		{
+			name: "a marked store is not walked again",
+			arrange: func(t *testing.T, s *Storage) {
+				require.NoError(t, writeStoreMeta(s.Dir(), storeMeta{MtimeStamped: true}))
+			},
+			wantMarker: true,
+		},
+		{
+			name:       "a store no daemon has stamped repairs and marks itself",
+			wantWalked: true,
+			wantMarker: true,
+			wantStamps: 2,
+		},
+		{
+			name:     "a file that cannot be stamped leaves the marker unset",
+			stampErr: errStampRefused,
+			wantErr:  errStampRefused,
+			// Every file is tried, so one bad file does not leave the rest
+			// ordered by the time they were written.
+			wantWalked: true,
+			wantStamps: 2,
+		},
+		{
+			// The lock is held on a second file descriptor, which flock
+			// treats as another process holding it.
+			name: "another daemon holding the lock skips this pass",
+			arrange: func(t *testing.T, s *Storage) {
+				held, err := acquireFileLock(filepath.Join(s.Dir(), RepairLockFile), false)
+				require.NoError(t, err)
+				t.Cleanup(held.release)
+			},
+			wantErr: errLockBusy,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newStorage(t)
+			for _, id := range []string{"conv-A", "conv-B"} {
+				seedConversation(t, s, id, time.Now().Add(-90*24*time.Hour))
+			}
+			var stamps atomic.Int32
+			s.chtimes = func(path string, atime, mtime time.Time) error {
+				stamps.Add(1)
+				if tc.stampErr != nil {
+					return tc.stampErr
+				}
+				return os.Chtimes(path, atime, mtime)
+			}
+			if tc.arrange != nil {
+				tc.arrange(t, s)
+			}
+
+			walked, err := repairStoreModTimes(context.Background(), s)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantWalked, walked)
+			assert.Equal(t, tc.wantStamps, stamps.Load(), "files stamped")
+
+			meta, err := readStoreMeta(s.Dir())
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantMarker, meta.MtimeStamped)
+		})
+	}
+}
+
+// TestRepairStoreModTimes_ExcludesConcurrentAppend covers the pass holding
+// a file's append lock while it scans and stamps it, so a live export
+// cannot write between the two.
+func TestRepairStoreModTimes_ExcludesConcurrentAppend(t *testing.T) {
+	s := newStorage(t)
+	activity := time.Now().Add(-time.Hour).Truncate(time.Second)
+	seedConversation(t, s, "conv-A", activity.Add(-90*24*time.Hour))
+
+	// Hold the pass inside its stamp, which is inside the file's append
+	// lock. The append below stamps too, so only the first call blocks.
+	scanning := make(chan struct{})
+	release := make(chan struct{})
+	var hold sync.Once
+	s.chtimes = func(path string, atime, mtime time.Time) error {
+		hold.Do(func() {
+			close(scanning)
+			<-release
+		})
+		return os.Chtimes(path, atime, mtime)
+	}
+
+	repairDone := make(chan error, 1)
+	go func() {
+		_, err := repairStoreModTimes(context.Background(), s)
+		repairDone <- err
+	}()
+	<-scanning
+
+	appendDone := make(chan error, 1)
+	go func() {
+		_, err := s.AppendGenerations("conv-A", []generationRecord{{
+			ConversationID: "conv-A",
+			GenerationID:   "gen-live",
+			Generation:     json.RawMessage(`{"id":"gen-live"}`),
+		}}, []time.Time{activity})
+		appendDone <- err
+	}()
+
+	select {
+	case <-appendDone:
+		t.Fatal("append ran while the pass held the file lock")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+
+	require.NoError(t, <-repairDone)
+	require.NoError(t, <-appendDone)
+
+	info, err := os.Stat(filepath.Join(s.Dir(), ConversationsDir, "conv-A.jsonl"))
+	require.NoError(t, err)
+	assert.WithinDuration(t, activity, info.ModTime(), stampTolerance,
+		"the append that waited leaves the newer activity")
+}
+
+// TestRepairStoreOnStartup_BroadcastsOnce covers what an open viewer sees:
+// one refresh when the pass reorders the list, and nothing on a later start
+// that skips the pass.
+func TestRepairStoreOnStartup_BroadcastsOnce(t *testing.T) {
+	s := newStorage(t)
+	seedConversation(t, s, "conv-A", time.Now().Add(-90*24*time.Hour))
+	hub := newEventHub()
+	sub := hub.subscribe()
+	require.NotNil(t, sub)
+
+	repairStoreOnStartup(context.Background(), s, hub)
+	assert.Len(t, sub.ch, 1)
+	<-sub.ch
+
+	repairStoreOnStartup(context.Background(), s, hub)
+	assert.Empty(t, sub.ch, "a marked store emits nothing")
+}
+
+// seedConversation writes one conversation whose records end at activity,
+// with the modification time a history import would leave: the wall clock
+// of the import rather than the session's own date.
+func seedConversation(t *testing.T, s *Storage, convID string, activity time.Time) {
+	t.Helper()
+	writeGen(t, s, convID, "g-"+convID, agento11y.Generation{
+		Model:       agento11y.ModelRef{Name: "m"},
+		StartedAt:   activity.Add(-time.Minute),
+		CompletedAt: activity,
+		Usage:       agento11y.TokenUsage{InputTokens: 1},
+	}, activity.Format(time.RFC3339Nano))
+	setConversationModTime(t, s, convID, time.Now())
+}
+
+// countStamps counts the modification times a Storage rewrites, so a test
+// can tell "left alone" from "rewritten to the same value".
+func countStamps(s *Storage) *atomic.Int32 {
+	var n atomic.Int32
+	s.chtimes = func(path string, atime, mtime time.Time) error {
+		n.Add(1)
+		return os.Chtimes(path, atime, mtime)
+	}
+	return &n
+}

--- a/plugins/agento11y/internal/local/repair_windows.go
+++ b/plugins/agento11y/internal/local/repair_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package local
+
+import "context"
+
+// repairStoreOnStartup does nothing on Windows. The local receiver does not
+// run here (see errLocalUnsupported), so there is no store whose
+// modification times a daemon could stamp.
+func repairStoreOnStartup(context.Context, *Storage, *eventHub) {}

--- a/plugins/agento11y/internal/local/server.go
+++ b/plugins/agento11y/internal/local/server.go
@@ -267,6 +267,10 @@ type generationRecord struct {
 type pendingGeneration struct {
 	index  int
 	record generationRecord
+	// activity is the moment this record represents. The newest activity
+	// among the records a write accepts becomes the conversation file's
+	// modification time, which is the key the list orders and bounds by.
+	activity time.Time
 }
 
 func (s *Server) handleGenerations(w http.ResponseWriter, r *http.Request) {
@@ -314,6 +318,9 @@ func (s *Server) handleGenerations(w http.ResponseWriter, r *http.Request) {
 				ConversationID: gen.ConversationID,
 				Generation:     stored[i],
 			},
+			// gen already carries the timestamps recordActivity reads, so
+			// the stamp costs no extra decode.
+			activity: recordActivity(gen.summaryGeneration, receivedAt),
 		})
 	}
 
@@ -324,10 +331,12 @@ func (s *Server) handleGenerations(w http.ResponseWriter, r *http.Request) {
 	for _, convID := range order {
 		pending := groups[convID]
 		recs := make([]generationRecord, len(pending))
+		activities := make([]time.Time, len(pending))
 		for i, p := range pending {
 			recs[i] = p.record
+			activities[i] = p.activity
 		}
-		written, err := s.storage.AppendGenerations(convID, recs)
+		written, err := s.storage.AppendGenerations(convID, recs, activities)
 		if err != nil {
 			s.logger.Printf("local: append generations: %v", err)
 		}

--- a/plugins/agento11y/internal/local/server_test.go
+++ b/plugins/agento11y/internal/local/server_test.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -54,6 +55,54 @@ func TestServer_GenerationsExport_RecordsAndAccepts(t *testing.T) {
 	assert.Equal(t, "conv-A", rec.ConversationID)
 	assert.NotEmpty(t, rec.ReceivedAt)
 	assert.JSONEq(t, `{"id":"gen-1","conversation_id":"conv-A","model":{"name":"m1"}}`, string(rec.Generation))
+}
+
+// TestServer_GenerationsExport_StampsLastActivity covers the ordering key
+// ingest writes: a conversation file's modification time is the newest
+// activity the batch carried for it, and a later import of older turns
+// leaves it where it was, so the conversation keeps its place among
+// today's.
+func TestServer_GenerationsExport_StampsLastActivity(t *testing.T) {
+	s, dir := newTestServer(t)
+	live := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	earlier := live.Add(-30 * time.Minute)
+	backfill := live.Add(-90 * 24 * time.Hour)
+	stamp := func() time.Time {
+		t.Helper()
+		info, err := os.Stat(filepath.Join(dir, ConversationsDir, "conv-A.jsonl"))
+		require.NoError(t, err)
+		return info.ModTime()
+	}
+	export := func(body string) {
+		t.Helper()
+		resp := post(t, s, "/api/v1/generations:export", "application/json", body)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+
+	// One request, two turns of the same conversation, out of order.
+	export(fmt.Sprintf(`{"generations":[
+		{"id":"gen-2","conversation_id":"conv-A","started_at":%q,"completed_at":%q},
+		{"id":"gen-1","conversation_id":"conv-A","started_at":%q,"completed_at":%q}
+	]}`,
+		live.Add(-time.Minute).Format(time.RFC3339Nano), live.Format(time.RFC3339Nano),
+		earlier.Add(-time.Minute).Format(time.RFC3339Nano), earlier.Format(time.RFC3339Nano)))
+	assert.WithinDuration(t, live, stamp(), time.Second, "the newest activity in the batch")
+
+	// A history import appending months-old turns to the same conversation.
+	export(fmt.Sprintf(`{"generations":[
+		{"id":"gen-0","conversation_id":"conv-A","started_at":%q,"completed_at":%q}
+	]}`, backfill.Add(-time.Minute).Format(time.RFC3339Nano), backfill.Format(time.RFC3339Nano)))
+	assert.WithinDuration(t, live, stamp(), time.Second, "a backfill must not sink a live conversation")
+
+	// The list bounds on that stamp, so the conversation stays in a range
+	// that covers its live turn.
+	since := live.Add(-time.Minute).Format(time.RFC3339Nano)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/conversations?since="+url.QueryEscape(since), nil)
+	rr := httptest.NewRecorder()
+	s.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"id":"conv-A"`)
 }
 
 func TestServer_GenerationsExport_RejectsMissingAndUnsafeConversationID(t *testing.T) {
@@ -302,10 +351,6 @@ func TestServer_APIConversations(t *testing.T) {
 		CompletedAt: mustParse(t, "2026-05-21T11:00:01Z"),
 		Usage:       agento11y.TokenUsage{InputTokens: 10, OutputTokens: 5},
 	}, "2026-05-21T11:00:01Z")
-	// The list orders and filters on the file modification time, so pin it
-	// to each conversation's last activity the way an append does.
-	setConversationModTime(t, storage, "conv-A", mustParse(t, "2026-05-21T10:00:03Z"))
-	setConversationModTime(t, storage, "conv-B", mustParse(t, "2026-05-21T11:00:01Z"))
 
 	cases := []struct {
 		name          string
@@ -671,6 +716,31 @@ func TestServer_APITokenMetrics(t *testing.T) {
 		require.Len(t, body.Points, 1)
 		assert.Equal(t, mustParse(t, "2026-05-21T10:00:00Z"), body.Points[0].Timestamp)
 		assert.Equal(t, int64(107), body.Points[0].FreshInput)
+	})
+
+	t.Run("since skips older files without decoding them", func(t *testing.T) {
+		requireUnreadableFilesSupported(t)
+		writeGen(t, storage, "conv-old", "g3", agento11y.Generation{
+			Model:       agento11y.ModelRef{Provider: "anthropic", Name: "claude-sonnet-4"},
+			StartedAt:   mustParse(t, "2026-05-01T10:00:00Z"),
+			CompletedAt: mustParse(t, "2026-05-01T10:00:01Z"),
+			Usage:       agento11y.TokenUsage{InputTokens: 999},
+		}, "2026-05-01T10:00:01Z")
+		// Unreadable, so a request that opens it fails instead of quietly
+		// paying for the decode the modification-time break exists to avoid.
+		blockConversationFile(t, storage, "conv-old")
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/metrics/tokens?since=2026-05-21T09:00:00Z&interval=3600", nil)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+
+		var body struct {
+			Points []TokenUsagePoint `json:"points"`
+		}
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+		require.Len(t, body.Points, 1)
+		assert.Equal(t, int64(107), body.Points[0].FreshInput, "the older file contributes nothing")
 	})
 
 	t.Run("invalid parameters rejected", func(t *testing.T) {

--- a/plugins/agento11y/internal/local/storage.go
+++ b/plugins/agento11y/internal/local/storage.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/grafana/agento11y/plugins/agento11y/internal/xdg"
 )
@@ -29,6 +30,14 @@ const (
 
 	StatusFile = "server.json"
 	LockFile   = "server.lock"
+
+	// StoreFile records what the daemon has already done to the store on
+	// disk, so the modification-time pass over every conversation file runs
+	// once per store and not on every start. See storeMeta.
+	StoreFile = "store.json"
+	// RepairLockFile guards that pass across processes, because more than
+	// one daemon can share a store.
+	RepairLockFile = "repair.lock"
 )
 
 // StateDir returns the root directory for local capture data.
@@ -55,6 +64,10 @@ type Storage struct {
 	// decoded again. It carries its own mutex; the read paths take no other
 	// lock.
 	summaries summaryCache
+
+	// chtimes stamps a file's modification time. Tests replace it to
+	// exercise the failure path; a nil value uses os.Chtimes.
+	chtimes func(path string, atime, mtime time.Time) error
 
 	// One mutex per file path. We don't expect contention high enough to
 	// need finer locking; this just stops interleaved JSON lines.
@@ -88,10 +101,19 @@ func (s *Storage) SetLogger(logger *log.Logger) { s.logger = logger }
 // count above the number of files the request read means the store holds
 // records this build cannot read.
 func (s *Storage) logSkipped(what string, skipped int) {
-	if skipped == 0 || s.logger == nil {
+	if skipped == 0 {
 		return
 	}
-	s.logger.Printf("local: %s: skipped %d unparseable lines", what, skipped)
+	s.logf("local: %s: skipped %d unparseable lines", what, skipped)
+}
+
+// logf writes one diagnostic line, and does nothing on a Storage with no
+// logger.
+func (s *Storage) logf(format string, args ...any) {
+	if s.logger == nil {
+		return
+	}
+	s.logger.Printf(format, args...)
 }
 
 // Path returns the absolute path for the named JSONL file in this Storage.
@@ -106,7 +128,7 @@ func (s *Storage) Path(name string) string {
 // This is the single-record form. Generation ingest batches through
 // AppendGenerations instead.
 func (s *Storage) Append(name string, record any) error {
-	_, err := appendJSONL(s, name, []any{record})
+	_, err := appendJSONL(s, name, []any{record}, nil)
 	return err
 }
 
@@ -119,7 +141,12 @@ func (s *Storage) Append(name string, record any) error {
 // A missing parent directory is recreated once and the open retried, so
 // ingest and export recover if the conversations directory disappears
 // while the daemon runs.
-func appendJSONL[T any](s *Storage, name string, records []T) (int, error) {
+//
+// activities carries the activity of each record, in the same order. It
+// stamps the file's modification time, which is what the conversation list
+// orders and bounds on. A nil slice leaves the write time in place, which
+// is what Append's non-conversation files want.
+func appendJSONL[T any](s *Storage, name string, records []T, activities []time.Time) (int, error) {
 	if len(records) == 0 {
 		return 0, nil
 	}
@@ -128,6 +155,38 @@ func appendJSONL[T any](s *Storage, name string, records []T) (int, error) {
 	lock.Lock()
 	defer lock.Unlock()
 
+	var previous time.Time
+	if len(activities) > 0 {
+		if info, err := os.Stat(path); err == nil {
+			previous = info.ModTime()
+		}
+	}
+	written, err := writeJSONL(s, path, name, records)
+	// Only the records that reached the file may set its modification time.
+	// A batch cut short by a write error would otherwise stamp activity the
+	// file does not hold, which shows the conversation in ranges its records
+	// do not cover.
+	if activity := newestActivity(activities, written); !activity.IsZero() {
+		s.stampActivity(path, activity, previous)
+	}
+	return written, err
+}
+
+// newestActivity is the latest of the first n activities, zero when there
+// is none.
+func newestActivity(activities []time.Time, n int) time.Time {
+	var newest time.Time
+	for _, when := range activities[:min(n, len(activities))] {
+		if when.After(newest) {
+			newest = when
+		}
+	}
+	return newest
+}
+
+// writeJSONL is the write half of appendJSONL, split out so the file is
+// closed before the stamp is applied to it.
+func writeJSONL[T any](s *Storage, path, name string, records []T) (int, error) {
 	f, err := s.openForAppend(path)
 	if err != nil {
 		return 0, err
@@ -145,6 +204,47 @@ func appendJSONL[T any](s *Storage, name string, records []T) (int, error) {
 		}
 	}
 	return len(records), nil
+}
+
+// stampActivity sets a conversation file's modification time to the newest
+// activity it holds, so the newest-first order in conversationFiles stays
+// monotone and the Since bounds computed from it stay sound. previous is
+// the file's modification time before this append, zero for a new file.
+//
+// The stamp never moves backwards: a history import appending months-old
+// turns to a conversation that also holds today's must not sink the file
+// below them. It never moves past now either, because a generation dated in
+// the future would pin its file to the top of every page.
+//
+// A failed stamp costs ordering, not data: the records are already on disk,
+// so the caller still reports them as written and logs the failure.
+func (s *Storage) stampActivity(path string, activity, previous time.Time) {
+	now := time.Now()
+	// A modification time in the future does not come from the records; a
+	// restore, or a copy from a machine with a fast clock, leaves one. Clamp
+	// it to now, because carrying it into the guard below would skip the
+	// stamp and leave the file ordered by its write time.
+	if previous.After(now) {
+		previous = now
+	}
+	stamp := activity
+	if previous.After(stamp) {
+		stamp = previous
+	}
+	if stamp.IsZero() || stamp.After(now) {
+		return
+	}
+	if err := s.setModTime(path, stamp); err != nil {
+		s.logf("local: stamp %s: %v", path, err)
+	}
+}
+
+func (s *Storage) setModTime(path string, when time.Time) error {
+	chtimes := s.chtimes
+	if chtimes == nil {
+		chtimes = os.Chtimes
+	}
+	return chtimes(path, when, when)
 }
 
 // openForAppend opens path for appending, recreating the parent directory
@@ -188,10 +288,16 @@ func (s *Storage) lockFor(path string) *sync.Mutex {
 }
 
 // AppendGeneration writes one record into conversations/<id>.jsonl through
-// AppendGenerations. Only the tests call it; the ingest handler passes a
-// whole batch.
+// AppendGenerations, deriving the activity stamp from the record itself.
+// Only the tests call it; the ingest handler passes a whole batch with the
+// activity it already decoded.
 func (s *Storage) AppendGeneration(rec generationRecord) error {
-	_, err := s.AppendGenerations(rec.ConversationID, []generationRecord{rec})
+	var gen summaryGeneration
+	// A generation this build cannot decode leaves gen zero, so the stamp
+	// falls back to received_at. The list drops such a record too, so the
+	// ignored error costs nothing.
+	_ = json.Unmarshal(rec.Generation, &gen)
+	_, err := s.AppendGenerations(rec.ConversationID, []generationRecord{rec}, []time.Time{recordActivity(gen, rec.ReceivedAt)})
 	return err
 }
 
@@ -202,12 +308,19 @@ func (s *Storage) AppendGeneration(rec generationRecord) error {
 // It returns how many records were written. On error the first n records
 // are stored and the remaining records are not. The ingest handler turns
 // that boundary into a per-generation accepted or rejected result.
-func (s *Storage) AppendGenerations(convID string, recs []generationRecord) (int, error) {
+//
+// activities carries one recordActivity per record, in the same order as
+// recs. The file's modification time takes the newest activity among the
+// records that reached it. A nil slice appends without stamping.
+func (s *Storage) AppendGenerations(convID string, recs []generationRecord, activities []time.Time) (int, error) {
 	if convID == "" {
 		return 0, fmt.Errorf("local storage: empty conversation_id")
 	}
 	if !validConversationID(convID) {
 		return 0, fmt.Errorf("local storage: unsafe conversation_id %q", convID)
+	}
+	if len(activities) != 0 && len(activities) != len(recs) {
+		return 0, fmt.Errorf("local storage: %d activity stamps for %d records", len(activities), len(recs))
 	}
 	for _, rec := range recs {
 		if rec.ConversationID != convID {
@@ -215,13 +328,42 @@ func (s *Storage) AppendGenerations(convID string, recs []generationRecord) (int
 		}
 	}
 	name := filepath.Join(ConversationsDir, convID+".jsonl")
-	written, err := appendJSONL(s, name, recs)
+	written, err := appendJSONL(s, name, recs, activities)
 	if written > 0 || err != nil {
 		// A partial write moved the file too, so the cached projection goes
 		// on the error path as well.
 		s.summaries.invalidate(s.Path(name))
 	}
 	return written, err
+}
+
+// writeFileAtomic writes data to dir/name through a temp file and a
+// rename, so a concurrent reader sees either the old file or the new one
+// and never a half-written one. The file ends up at 0o600 whatever the
+// caller's umask is.
+func writeFileAtomic(dir, name string, data []byte) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(dir, name+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	// A no-op once the rename below succeeds; on any earlier return it keeps
+	// a failed write from leaving the temp file behind.
+	defer func() { _ = os.Remove(tmp) }()
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmp, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, filepath.Join(dir, name))
 }
 
 func validConversationID(id string) bool {

--- a/plugins/agento11y/internal/local/storage_test.go
+++ b/plugins/agento11y/internal/local/storage_test.go
@@ -5,12 +5,15 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -127,6 +130,10 @@ func assertConversationDirEmpty(t *testing.T, s *Storage) {
 // uses: every record for one conversation goes through a single file open
 // and close cycle, a mid-batch write failure keeps the records written
 // before it, and a record from another conversation is refused.
+//
+// Each record carries one more minute of activity than the one before it,
+// so the modification time the append leaves names the last record that
+// reached the file.
 func TestAppendGenerations(t *testing.T) {
 	cases := []struct {
 		name           string
@@ -142,6 +149,7 @@ func TestAppendGenerations(t *testing.T) {
 		{name: "third write fails", records: 5, failWriteAfter: 2, wantWritten: 2, wantLines: 2, wantErr: true, wantOpens: 1},
 		{name: "foreign conversation id refused", records: 2, mixConvID: true, wantErr: true, wantOpens: 0},
 	}
+	base := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := newStorage(t)
@@ -149,6 +157,7 @@ func TestAppendGenerations(t *testing.T) {
 			s.openAppend = opener.open
 
 			recs := make([]generationRecord, 0, tc.records)
+			activities := make([]time.Time, 0, tc.records)
 			for i := range tc.records {
 				rec := generationRecord{
 					ConversationID: "conv-batch",
@@ -159,9 +168,10 @@ func TestAppendGenerations(t *testing.T) {
 					rec.ConversationID = "conv-other"
 				}
 				recs = append(recs, rec)
+				activities = append(activities, base.Add(time.Duration(i)*time.Minute))
 			}
 
-			written, err := s.AppendGenerations("conv-batch", recs)
+			written, err := s.AppendGenerations("conv-batch", recs, activities)
 			if tc.wantErr {
 				require.Error(t, err)
 			} else {
@@ -175,12 +185,181 @@ func TestAppendGenerations(t *testing.T) {
 				assert.True(t, os.IsNotExist(statErr), "no file expected, stat err = %v", statErr)
 			} else {
 				assert.Len(t, readLines(t, path), tc.wantLines)
+				info, statErr := os.Stat(path)
+				require.NoError(t, statErr)
+				assert.WithinDuration(t, base.Add(time.Duration(tc.wantWritten-1)*time.Minute), info.ModTime(), time.Second,
+					"the stamp names the last record that reached the file")
 			}
 			opens, closes := opener.counts()
 			assert.Equal(t, tc.wantOpens, opens, "file opens")
 			assert.Equal(t, opens, closes, "every open must be closed")
 		})
 	}
+}
+
+// TestAppendGenerations_StampsActivity covers the modification time an
+// append leaves on a conversation file, which is what the list orders and
+// bounds on. Offsets are relative to now so the rows read as "an hour of
+// activity ago" rather than as fixed dates.
+func TestAppendGenerations_StampsActivity(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	cases := []struct {
+		name string
+		// pin rewrites the file's modification time after the first append,
+		// the way a history import into an existing file leaves it.
+		pin           time.Duration
+		pinAfterFirst bool
+		// batches are the activity stamps to append with, in order.
+		batches []time.Duration
+		// want is the modification time the file must end up with. When
+		// wantWriteTime is set the file must instead keep the time the
+		// append itself ran.
+		want          time.Duration
+		wantWriteTime bool
+	}{
+		{
+			name:    "the batch activity becomes the modification time",
+			batches: []time.Duration{-2 * time.Hour},
+			want:    -2 * time.Hour,
+		},
+		{
+			name:    "a backfilled append does not sink the file",
+			batches: []time.Duration{-time.Hour, -72 * time.Hour},
+			want:    -time.Hour,
+		},
+		{
+			name:          "an import-time modification time survives an older append",
+			pin:           0,
+			pinAfterFirst: true,
+			batches:       []time.Duration{-72 * time.Hour, -73 * time.Hour},
+			want:          0,
+		},
+		{
+			name:          "a future activity leaves the write time",
+			batches:       []time.Duration{48 * time.Hour},
+			wantWriteTime: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newStorage(t)
+			path := filepath.Join(s.Dir(), ConversationsDir, "conv-A.jsonl")
+			for i, offset := range tc.batches {
+				genID := "gen-" + strconv.Itoa(i)
+				rec := generationRecord{
+					ConversationID: "conv-A",
+					GenerationID:   genID,
+					Generation:     json.RawMessage(`{"id":"` + genID + `"}`),
+				}
+				written, err := s.AppendGenerations("conv-A", []generationRecord{rec}, []time.Time{now.Add(offset)})
+				require.NoError(t, err)
+				require.Equal(t, 1, written)
+				if i == 0 && tc.pinAfterFirst {
+					setConversationModTime(t, s, "conv-A", now.Add(tc.pin))
+				}
+			}
+
+			assert.Len(t, readLines(t, path), len(tc.batches), "every record reached the file")
+			info, err := os.Stat(path)
+			require.NoError(t, err)
+			if tc.wantWriteTime {
+				assert.WithinDuration(t, time.Now(), info.ModTime(), time.Minute)
+				return
+			}
+			assert.WithinDuration(t, now.Add(tc.want), info.ModTime(), time.Second)
+		})
+	}
+}
+
+// TestAppendGenerations_StampFailureKeepsRecords covers a filesystem that
+// refuses the stamp: the records are already written, so the append still
+// reports them and only the ordering degrades.
+func TestAppendGenerations_StampFailureKeepsRecords(t *testing.T) {
+	s := newStorage(t)
+	var logs strings.Builder
+	s.SetLogger(log.New(&logs, "", 0))
+	var stamps int
+	s.chtimes = func(string, time.Time, time.Time) error {
+		stamps++
+		return errors.New("read-only file system")
+	}
+
+	written, err := s.AppendGenerations("conv-A", []generationRecord{{
+		ConversationID: "conv-A",
+		GenerationID:   "gen-1",
+		Generation:     json.RawMessage(`{"id":"gen-1"}`),
+	}}, []time.Time{time.Now().Add(-time.Hour)})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, written)
+	assert.Len(t, readLines(t, filepath.Join(s.Dir(), ConversationsDir, "conv-A.jsonl")), 1)
+	assert.Equal(t, 1, stamps, "one append attempts one stamp")
+	assert.Contains(t, logs.String(), "read-only file system")
+}
+
+// TestAppendGenerations_FutureModTimeIsNotCarriedForward covers a file
+// whose modification time already runs ahead of the clock, which a restore
+// or a copy from a machine with a fast clock leaves behind. The append
+// folds that time in as now instead of skipping the stamp, so the file
+// stops claiming activity that has not happened yet.
+func TestAppendGenerations_FutureModTimeIsNotCarriedForward(t *testing.T) {
+	s := newStorage(t)
+	activity := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	appendGen := func(genID string, when time.Time) {
+		t.Helper()
+		_, err := s.AppendGenerations("conv-A", []generationRecord{{
+			ConversationID: "conv-A",
+			GenerationID:   genID,
+			Generation:     json.RawMessage(`{"id":"` + genID + `"}`),
+		}}, []time.Time{when})
+		require.NoError(t, err)
+	}
+
+	appendGen("gen-1", activity)
+	setConversationModTime(t, s, "conv-A", time.Now().Add(72*time.Hour))
+
+	var stamps []time.Time
+	s.chtimes = func(path string, atime, mtime time.Time) error {
+		stamps = append(stamps, mtime)
+		return os.Chtimes(path, atime, mtime)
+	}
+	appendGen("gen-2", activity.Add(time.Hour))
+
+	require.Len(t, stamps, 1, "the append stamps the file rather than leaving it")
+	assert.False(t, stamps[0].After(time.Now()), "the stamp is not in the future")
+	info, err := os.Stat(filepath.Join(s.Dir(), ConversationsDir, "conv-A.jsonl"))
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now(), info.ModTime(), time.Minute)
+}
+
+// TestAppendGenerations_ConcurrentStampKeepsNewest drives appends at one
+// conversation file from several goroutines. Whatever order they run in,
+// the file must end up stamped with the newest activity any of them
+// carried, or a later backfill could sink a live conversation.
+func TestAppendGenerations_ConcurrentStampKeepsNewest(t *testing.T) {
+	s := newStorage(t)
+	const writers = 8
+	base := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+
+	var wg sync.WaitGroup
+	for w := range writers {
+		wg.Go(func() {
+			genID := "gen-" + strconv.Itoa(w)
+			_, err := s.AppendGenerations("conv-race", []generationRecord{{
+				ConversationID: "conv-race",
+				GenerationID:   genID,
+				Generation:     json.RawMessage(`{"id":"` + genID + `"}`),
+			}}, []time.Time{base.Add(time.Duration(w) * time.Minute)})
+			if err != nil {
+				t.Errorf("writer %d append: %v", w, err)
+			}
+		})
+	}
+	wg.Wait()
+
+	info, err := os.Stat(filepath.Join(s.Dir(), ConversationsDir, "conv-race.jsonl"))
+	require.NoError(t, err)
+	assert.WithinDuration(t, base.Add((writers-1)*time.Minute), info.ModTime(), time.Second)
 }
 
 // countingOpener wraps the real appender, counting open and close cycles

--- a/plugins/agento11y/internal/local/summaries.go
+++ b/plugins/agento11y/internal/local/summaries.go
@@ -241,16 +241,7 @@ func decodeFileSummary(f conversationFile) (*fileSummary, error) {
 		if !gen.StartedAt.IsZero() && (sum.StartedAt.IsZero() || gen.StartedAt.Before(sum.StartedAt)) {
 			sum.StartedAt = gen.StartedAt
 		}
-		// last_activity tracks the latest known timestamp on any
-		// generation, falling back to received_at when started/completed
-		// aren't populated so freshly-arrived records still bubble up.
-		when := gen.CompletedAt
-		if when.IsZero() {
-			when = gen.StartedAt
-		}
-		if when.IsZero() {
-			when, _ = time.Parse(time.RFC3339Nano, r.ReceivedAt)
-		}
+		when := recordActivity(gen, r.ReceivedAt)
 		if when.After(sum.LastActivity) {
 			sum.LastActivity = when
 		}


### PR DESCRIPTION
The conversation list and the token chart use each conversation file's modification time to limit what request reads, on the assumption that an append-only JSONL file was last written when it was last active (#521). A session history import breaks that assumption: it writes months-old sessions to disk today, so a 24-hour request returns them. 

An append now stamps the file with the newest activity among the records it accepted.