### PR TITLE
fix(frameworks): record system prompts from LangChain/LangGraph chat messages

### DIFF
--- a/js/docs/frameworks/langchain.md
+++ b/js/docs/frameworks/langchain.md
@@ -67,6 +67,9 @@ await client.shutdown();
 ## Contract
 
 - `handleLLMStart` / `handleChatModelStart` starts recorder lifecycle.
+- System and developer messages passed to `handleChatModelStart` are lifted out of the input message
+  list into `systemPrompt` (joined with a blank line when there are several), since the wire format
+  has no system role. An explicit `invocation_params.system_prompt` wins.
 - `handleLLMNewToken` sets first-token timestamp and accumulates streamed output.
 - `handleLLMEnd` maps output + usage and ends recorder.
 - `handleLLMError` sets call error and ends recorder.

--- a/js/docs/frameworks/langgraph.md
+++ b/js/docs/frameworks/langgraph.md
@@ -105,6 +105,9 @@ When `conversation_id` / `session_id` / `group_id` is present, that value is use
 ## Contract
 
 - `handleLLMStart` / `handleChatModelStart` starts recorder lifecycle.
+- System and developer messages passed to `handleChatModelStart` are lifted out of the input message
+  list into `systemPrompt` (joined with a blank line when there are several), since the wire format
+  has no system role. An explicit `invocation_params.system_prompt` wins.
 - `handleLLMNewToken` sets first-token timestamp and accumulates streamed output.
 - `handleLLMEnd` maps output + usage and ends recorder.
 - `handleLLMError` sets call error and ends recorder.

--- a/js/src/frameworks/shared.ts
+++ b/js/src/frameworks/shared.ts
@@ -170,7 +170,9 @@ export class Agento11yFrameworkHandler {
     const modelName = resolveModelName(serialized, invocationParams);
     const provider = resolveProvider(this.provider, this.providerResolver, modelName, serialized, invocationParams);
     const stream = isStreaming(invocationParams);
-    const input = this.captureInputs ? mapChatInputs(messages) : [];
+    const { input, systemPrompt: messageSystemPrompt } = this.captureInputs
+      ? mapChatInputs(messages)
+      : { input: [] as Message[], systemPrompt: '' };
     const context = this.buildFrameworkContext({
       runId: runKey,
       parentRunId,
@@ -183,7 +185,8 @@ export class Agento11yFrameworkHandler {
       callbackMetadata,
     });
 
-    const payload = this.startPayload(runKey, provider, modelName, context);
+    const systemPrompt = asString(read(invocationParams, 'system_prompt')) || messageSystemPrompt;
+    const payload = this.startPayload(runKey, provider, modelName, context, systemPrompt);
     const recorder = stream ? this.client.startStreamingGeneration(payload) : this.client.startGeneration(payload);
 
     this.runs.set(runKey, {
@@ -490,7 +493,13 @@ export class Agento11yFrameworkHandler {
     this.endFrameworkSpan(this.retrieverSpans, runId, error);
   }
 
-  private startPayload(_runId: string, provider: string, modelName: string, context: FrameworkContext) {
+  private startPayload(
+    _runId: string,
+    provider: string,
+    modelName: string,
+    context: FrameworkContext,
+    systemPrompt?: string,
+  ) {
     return {
       conversationId: context.conversationId,
       agentName: this.agentName,
@@ -501,6 +510,7 @@ export class Agento11yFrameworkHandler {
       },
       tags: context.tags,
       metadata: context.metadata,
+      ...(notEmpty(systemPrompt ?? '') ? { systemPrompt } : {}),
     };
   }
 
@@ -1103,12 +1113,16 @@ function mapPromptInputs(prompts: unknown): Message[] {
   return input;
 }
 
-function mapChatInputs(messages: unknown): Message[] {
+// The wire format has no SYSTEM role, so system/developer messages are pulled out
+// of the message list and joined into the dedicated `systemPrompt` field rather
+// than being mapped as USER messages.
+function mapChatInputs(messages: unknown): { input: Message[]; systemPrompt: string } {
   if (!Array.isArray(messages)) {
-    return [];
+    return { input: [], systemPrompt: '' };
   }
 
   const output: Message[] = [];
+  const systemChunks: string[] = [];
   for (const batch of messages) {
     if (!Array.isArray(batch)) {
       continue;
@@ -1120,6 +1134,11 @@ function mapChatInputs(messages: unknown): Message[] {
         continue;
       }
 
+      if (isSystemRole(extractMessageRole(message))) {
+        systemChunks.push(text);
+        continue;
+      }
+
       output.push({
         role: normalizeRole(extractMessageRole(message)),
         content: text,
@@ -1127,7 +1146,7 @@ function mapChatInputs(messages: unknown): Message[] {
     }
   }
 
-  return output;
+  return { input: output, systemPrompt: systemChunks.join('\n\n') };
 }
 
 function mapOutputMessages(output: unknown): Message[] {
@@ -1226,6 +1245,11 @@ function extractMessageRole(message: unknown): string {
     return role;
   }
   return asString(read(message, 'type'));
+}
+
+function isSystemRole(role: string): boolean {
+  const normalized = role.trim().toLowerCase();
+  return normalized === 'system' || normalized === 'developer';
 }
 
 function normalizeRole(role: string): Message['role'] {

--- a/js/test/frameworks.langchain.test.mjs
+++ b/js/test/frameworks.langchain.test.mjs
@@ -81,6 +81,54 @@ test('langchain handler records sync lifecycle with framework tags', async () =>
   assert.equal(generation.output[0].content, 'world');
 });
 
+test('langchain handler lifts system messages into the system prompt', async () => {
+  const generation = await captureSingleGeneration(async (client) => {
+    const handler = new Agento11yLangChainHandler(client);
+
+    await handler.handleChatModelStart(
+      { name: 'ChatOpenAI' },
+      [
+        [
+          { type: 'system', content: 'You are terse.' },
+          { role: 'developer', content: 'Always answer in English.' },
+          { type: 'human', content: 'hello' },
+        ],
+      ],
+      'run-system',
+      undefined,
+      { invocation_params: { model: 'gpt-5' } },
+    );
+    await handler.handleLLMEnd({ generations: [[{ text: 'world' }]] }, 'run-system');
+  });
+
+  assert.equal(generation.systemPrompt, 'You are terse.\n\nAlways answer in English.');
+  assert.equal(generation.input.length, 1);
+  assert.equal(generation.input[0].role, 'user');
+  assert.equal(generation.input[0].content, 'hello');
+});
+
+test('langchain handler prefers an explicit invocation_params system prompt', async () => {
+  const generation = await captureSingleGeneration(async (client) => {
+    const handler = new Agento11yLangChainHandler(client);
+
+    await handler.handleChatModelStart(
+      { name: 'ChatOpenAI' },
+      [
+        [
+          { type: 'system', content: 'from message' },
+          { type: 'human', content: 'hello' },
+        ],
+      ],
+      'run-system-explicit',
+      undefined,
+      { invocation_params: { model: 'gpt-5', system_prompt: 'from invocation params' } },
+    );
+    await handler.handleLLMEnd({ generations: [[{ text: 'world' }]] }, 'run-system-explicit');
+  });
+
+  assert.equal(generation.systemPrompt, 'from invocation params');
+});
+
 test('langchain handler records stream mode and token fallback output', async () => {
   const generation = await captureSingleGeneration(async (client) => {
     const handler = new Agento11yLangChainHandler(client);

--- a/js/test/frameworks.langgraph.test.mjs
+++ b/js/test/frameworks.langgraph.test.mjs
@@ -76,6 +76,54 @@ test('langgraph handler records sync lifecycle with framework tags', async () =>
   assert.equal(generation.metadata.seed, 9);
 });
 
+test('langgraph handler lifts system messages into the system prompt', async () => {
+  const generation = await captureSingleGeneration(async (client) => {
+    const handler = new Agento11yLangGraphHandler(client);
+
+    await handler.handleChatModelStart(
+      { name: 'ChatOpenAI' },
+      [
+        [
+          { type: 'system', content: 'You are terse.' },
+          { role: 'developer', content: 'Always answer in English.' },
+          { type: 'human', content: 'hello' },
+        ],
+      ],
+      'run-system',
+      undefined,
+      { invocation_params: { model: 'gpt-5' } },
+    );
+    await handler.handleLLMEnd({ generations: [[{ text: 'world' }]] }, 'run-system');
+  });
+
+  assert.equal(generation.systemPrompt, 'You are terse.\n\nAlways answer in English.');
+  assert.equal(generation.input.length, 1);
+  assert.equal(generation.input[0].role, 'user');
+  assert.equal(generation.input[0].content, 'hello');
+});
+
+test('langgraph handler prefers an explicit invocation_params system prompt', async () => {
+  const generation = await captureSingleGeneration(async (client) => {
+    const handler = new Agento11yLangGraphHandler(client);
+
+    await handler.handleChatModelStart(
+      { name: 'ChatOpenAI' },
+      [
+        [
+          { type: 'system', content: 'from message' },
+          { type: 'human', content: 'hello' },
+        ],
+      ],
+      'run-system-explicit',
+      undefined,
+      { invocation_params: { model: 'gpt-5', system_prompt: 'from invocation params' } },
+    );
+    await handler.handleLLMEnd({ generations: [[{ text: 'world' }]] }, 'run-system-explicit');
+  });
+
+  assert.equal(generation.systemPrompt, 'from invocation params');
+});
+
 test('langgraph handler records stream mode and token fallback output', async () => {
   const generation = await captureSingleGeneration(async (client) => {
     const handler = new Agento11yLangGraphHandler(client);

--- a/python-frameworks/langchain/README.md
+++ b/python-frameworks/langchain/README.md
@@ -62,6 +62,9 @@ client.shutdown()
 
 - Lifecycle mapping:
   - `on_llm_start` / `on_chat_model_start` -> generation recorder
+  - System and developer messages passed to `on_chat_model_start` are lifted out of the input
+    message list into `system_prompt` (joined with a blank line when there are several), since the
+    wire format has no system role. An explicit `invocation_params["system_prompt"]` wins.
   - `on_tool_start` / `on_tool_end` / `on_tool_error` -> `start_tool_execution`
   - `on_chain_start` / `on_chain_end` / `on_chain_error` -> framework chain spans
   - `on_retriever_start` / `on_retriever_end` / `on_retriever_error` -> framework retriever spans

--- a/python-frameworks/langchain/tests/test_langchain_handler.py
+++ b/python-frameworks/langchain/tests/test_langchain_handler.py
@@ -46,6 +46,61 @@ def _new_client(exporter: _CapturingExporter, tracer=None) -> Client:
     )
 
 
+def test_langchain_lifts_system_messages_into_system_prompt() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        run_id = uuid4()
+        handler = Agento11yLangChainHandler(client=client)
+
+        handler.on_chat_model_start(
+            {"name": "ChatOpenAI"},
+            [
+                [
+                    {"type": "system", "content": "You are terse."},
+                    {"role": "developer", "content": "Always answer in English."},
+                    {"type": "human", "content": "hello"},
+                ]
+            ],
+            run_id=run_id,
+            invocation_params={"model": "gpt-5"},
+        )
+        handler.on_llm_end({"generations": [[{"text": "world"}]]}, run_id=run_id)
+
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        assert generation.system_prompt == "You are terse.\n\nAlways answer in English."
+        assert len(generation.input) == 1
+        assert generation.input[0].role.value == "user"
+        assert generation.input[0].parts[0].text == "hello"
+    finally:
+        client.shutdown()
+
+
+def test_langchain_prefers_explicit_invocation_params_system_prompt() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        run_id = uuid4()
+        handler = Agento11yLangChainHandler(client=client)
+
+        handler.on_chat_model_start(
+            {"name": "ChatOpenAI"},
+            [[{"type": "system", "content": "from message"}, {"type": "human", "content": "hello"}]],
+            run_id=run_id,
+            invocation_params={"model": "gpt-5", "system_prompt": "from invocation params"},
+        )
+        handler.on_llm_end({"generations": [[{"text": "world"}]]}, run_id=run_id)
+
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        assert generation.system_prompt == "from invocation params"
+    finally:
+        client.shutdown()
+
+
 def test_langchain_sync_lifecycle_sets_framework_tags_and_metadata() -> None:
     exporter = _CapturingExporter()
     client = _new_client(exporter)

--- a/python-frameworks/langgraph/README.md
+++ b/python-frameworks/langgraph/README.md
@@ -150,6 +150,9 @@ When `thread_id` is present, the handler records:
 
 - Lifecycle mapping:
   - `on_llm_start` / `on_chat_model_start` -> generation recorder
+  - System and developer messages passed to `on_chat_model_start` are lifted out of the input
+    message list into `system_prompt` (joined with a blank line when there are several), since the
+    wire format has no system role. An explicit `invocation_params["system_prompt"]` wins.
   - `on_tool_start` / `on_tool_end` / `on_tool_error` -> `start_tool_execution`
   - `on_chain_start` / `on_chain_end` / `on_chain_error` -> framework chain spans
   - `on_retriever_start` / `on_retriever_end` / `on_retriever_error` -> framework retriever spans

--- a/python-frameworks/langgraph/tests/test_langgraph_handler.py
+++ b/python-frameworks/langgraph/tests/test_langgraph_handler.py
@@ -45,6 +45,61 @@ def _new_client(exporter: _CapturingExporter, tracer=None) -> Client:
     )
 
 
+def test_langgraph_lifts_system_messages_into_system_prompt() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        run_id = uuid4()
+        handler = Agento11yLangGraphHandler(client=client)
+
+        handler.on_chat_model_start(
+            {"name": "ChatOpenAI"},
+            [
+                [
+                    {"type": "system", "content": "You are terse."},
+                    {"role": "developer", "content": "Always answer in English."},
+                    {"type": "human", "content": "hello"},
+                ]
+            ],
+            run_id=run_id,
+            invocation_params={"model": "gpt-5"},
+        )
+        handler.on_llm_end({"generations": [[{"text": "world"}]]}, run_id=run_id)
+
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        assert generation.system_prompt == "You are terse.\n\nAlways answer in English."
+        assert len(generation.input) == 1
+        assert generation.input[0].role.value == "user"
+        assert generation.input[0].parts[0].text == "hello"
+    finally:
+        client.shutdown()
+
+
+def test_langgraph_prefers_explicit_invocation_params_system_prompt() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        run_id = uuid4()
+        handler = Agento11yLangGraphHandler(client=client)
+
+        handler.on_chat_model_start(
+            {"name": "ChatOpenAI"},
+            [[{"type": "system", "content": "from message"}, {"type": "human", "content": "hello"}]],
+            run_id=run_id,
+            invocation_params={"model": "gpt-5", "system_prompt": "from invocation params"},
+        )
+        handler.on_llm_end({"generations": [[{"text": "world"}]]}, run_id=run_id)
+
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        assert generation.system_prompt == "from invocation params"
+    finally:
+        client.shutdown()
+
+
 def test_langgraph_sync_lifecycle_sets_framework_tags_and_metadata() -> None:
     exporter = _CapturingExporter()
     client = _new_client(exporter)
@@ -251,6 +306,32 @@ def test_langgraph_async_handler_records_generation() -> None:
         generation = exporter.requests[0].generations[0]
         assert generation.tags["agento11y.framework.name"] == "langgraph"
         assert generation.model.provider == "openai"
+    finally:
+        client.shutdown()
+
+
+def test_langgraph_async_handler_lifts_system_messages_into_system_prompt() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    async def _run() -> None:
+        run_id = uuid4()
+        handler = Agento11yAsyncLangGraphHandler(client=client)
+        await handler.on_chat_model_start(
+            {"name": "ChatOpenAI"},
+            [[{"type": "system", "content": "You are terse."}, {"type": "human", "content": "hello"}]],
+            run_id=run_id,
+            invocation_params={"model": "gpt-5"},
+        )
+        await handler.on_llm_end({"generations": [[{"text": "world"}]]}, run_id=run_id)
+
+    try:
+        asyncio.run(_run())
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        assert generation.system_prompt == "You are terse."
+        assert len(generation.input) == 1
+        assert generation.input[0].parts[0].text == "hello"
     finally:
         client.shutdown()
 

--- a/python/agento11y/framework_handler.py
+++ b/python/agento11y/framework_handler.py
@@ -416,7 +416,7 @@ class Agento11yFrameworkHandlerBase:
         )
 
         mode = GenerationMode.STREAM if _is_streaming(invocation_params) else GenerationMode.SYNC
-        input_messages = _map_chat_inputs(messages) if self._capture_inputs else []
+        input_messages, message_system_prompt = _map_chat_inputs(messages) if self._capture_inputs else ([], "")
 
         tags = dict(self._extra_tags)
         tags["agento11y.framework.name"] = self._framework_name
@@ -477,7 +477,7 @@ class Agento11yFrameworkHandlerBase:
             model=ModelRef(provider=provider_name, name=model_name),
             tags=tags,
             metadata=metadata,
-            system_prompt=_as_str(_read(invocation_params, "system_prompt")),
+            system_prompt=_as_str(_read(invocation_params, "system_prompt")) or message_system_prompt,
             tools=_resolve_tool_definitions(invocation_params),
             temperature=_as_optional_float(_read(invocation_params, "temperature")),
             max_tokens=_as_optional_int(_read(invocation_params, "max_tokens")),
@@ -1454,14 +1454,26 @@ def _resolve_tool_arguments(input_str: str, callback_kwargs: dict[str, Any] | No
     return input_str.strip()
 
 
-def _map_chat_inputs(messages: list[list[Any]]) -> list[Message]:
+def _map_chat_inputs(messages: list[list[Any]]) -> tuple[list[Message], str]:
+    """Map LangChain chat messages to input messages plus the system prompt.
+
+    The wire format has no SYSTEM role, so system/developer messages are pulled
+    out of the message list and joined into the dedicated ``system_prompt``
+    field rather than being mapped as USER messages.
+    """
     output: list[Message] = []
+    system_chunks: list[str] = []
     for batch in messages:
         for message in batch:
+            if _is_system_role(_extract_message_role(message)):
+                text = _extract_message_text(message)
+                if text != "":
+                    system_chunks.append(text)
+                continue
             mapped = _map_chat_input_message(message)
             if mapped is not None:
                 output.append(mapped)
-    return output
+    return output, "\n\n".join(system_chunks)
 
 
 def _map_chat_input_message(message: Any) -> Message | None:
@@ -1655,6 +1667,10 @@ def _map_framework_usage(raw_usage: Any):
         usage.reasoning_tokens = reasoning
 
     return usage
+
+
+def _is_system_role(role: str) -> bool:
+    return role.strip().lower() in {"system", "developer"}
 
 
 def _normalize_role(role: str) -> MessageRole:


### PR DESCRIPTION
## Summary

A user reported that system prompts never showed up for their LangGraph-instrumented agent. They were right, and the cause is the same in both Python and JS.

The shared framework handlers read `system_prompt` from `invocation_params`:

```python
system_prompt=_as_str(_read(invocation_params, "system_prompt")),
```

But `invocation_params` is LangChain's bag of *model* kwargs (model name, temperature, `max_tokens`, `stop`), and LangChain has never put a `system_prompt` key in it. The field was empty on essentially every generation.

The real system prompt arrives as a `SystemMessage` in the `messages` argument to `on_chat_model_start`, and that path swallowed it too: neither `_normalize_role` (Python) nor `normalizeRole` (JS) had a `system` branch, so it fell through to `USER`. The proto has no SYSTEM role — a system prompt is *supposed* to go in the dedicated `system_prompt` field — so the customer's prompt was being silently relabeled as the first user message. That is why the symptom was "I can't find my system prompt" rather than "the text is gone".

JS had one extra gap: `js/src/frameworks/shared.ts` contained no occurrence of `system` at all and never set `systemPrompt` on the start payload.

This is specific to the framework handlers. The provider wrappers already get it right — `mapChatRequestMessages` in `js/src/providers/openai.ts` collects system/developer messages into `systemChunks` and joins them — so a customer on the OpenAI wrapper saw system prompts while a customer on the LangChain handler did not.

## Changes

- Lift system- and developer-role messages out of the chat input list into `system_prompt` / `systemPrompt`, joined with a blank line when there are several, matching the provider wrappers.
- An explicit `invocation_params["system_prompt"]` still wins, so frameworks that genuinely surface one are unaffected. Strands populates it from the agent (`python-frameworks/strands/agento11y_strands/__init__.py`), and its behavior is unchanged.
- JS gained the same `invocation_params` read for cross-language parity, and `startPayload` only sets the field when non-empty.
- Both languages continue to honor the capture flag: with `capture_inputs` off, no system prompt is extracted, since it is content.
- Documented the lifting behavior and the override precedence in all four adapter docs.

## Behavior change

Users of these adapters will see system prompts move out of the input message list and into their own field. Worth a release note, since it changes what already-instrumented apps display.

## Test plan

- [x] `mise run test:py:sdk-framework-conformance` — all suites pass (19 / 12 / 9 / 9 / 14 / 6 / 17 / 238)
- [x] `mise run test:ts:sdk-framework-conformance` — 121 pass, 0 fail
- [x] `mise run lint:py` and `mise run lint:ts:sdk-js` clean
- [x] New coverage, two cases per framework per language: a `system` plus a `developer` message get joined into `system_prompt` while the human message stays the sole input, and the `invocation_params` override wins
- [x] Added an async LangGraph chat-model case. The reporting customer runs `create_agento11y_langgraph_handler(async_handler=True, ...)`, and the existing async test only exercised `on_llm_start`