### PR TITLE
fix(frameworks): record chat-start request params in the JS handler

### DIFF
--- a/js/docs/frameworks/langchain.md
+++ b/js/docs/frameworks/langchain.md
@@ -91,6 +91,13 @@ Without any of these, each run becomes its own conversation.
 - System and developer messages passed to `handleChatModelStart` are lifted out of the input message
   list into `systemPrompt` (joined with a blank line when there are several), since the wire format
   has no system role. An explicit `invocation_params.system_prompt` wins.
+- `handleChatModelStart` also lifts `temperature`, `max_tokens`, `top_p`, `tool_choice`,
+  `thinking_enabled`, and `tools` out of `invocation_params` onto the generation. Tool definitions
+  accept the OpenAI shape (`{ type: 'function', function: { name, description, parameters } }`) and
+  self-describing entries; `parameters` (or `parameters_json_schema`) becomes `inputSchemaJSON`.
+- `thinking_budget` and `thinking_level` are recorded as the
+  `agento11y.gen_ai.request.thinking.budget_tokens` and `agento11y.gen_ai.request.thinking.level`
+  metadata keys, on both `handleLLMStart` and `handleChatModelStart`.
 - `handleLLMNewToken` sets first-token timestamp and accumulates streamed output.
 - `handleLLMEnd` maps output + usage and ends recorder.
 - `handleLLMError` sets call error and ends recorder.

--- a/js/docs/frameworks/langgraph.md
+++ b/js/docs/frameworks/langgraph.md
@@ -130,6 +130,13 @@ Without any of these, each run becomes its own conversation.
 - System and developer messages passed to `handleChatModelStart` are lifted out of the input message
   list into `systemPrompt` (joined with a blank line when there are several), since the wire format
   has no system role. An explicit `invocation_params.system_prompt` wins.
+- `handleChatModelStart` also lifts `temperature`, `max_tokens`, `top_p`, `tool_choice`,
+  `thinking_enabled`, and `tools` out of `invocation_params` onto the generation. Tool definitions
+  accept the OpenAI shape (`{ type: 'function', function: { name, description, parameters } }`) and
+  self-describing entries; `parameters` (or `parameters_json_schema`) becomes `inputSchemaJSON`.
+- `thinking_budget` and `thinking_level` are recorded as the
+  `agento11y.gen_ai.request.thinking.budget_tokens` and `agento11y.gen_ai.request.thinking.level`
+  metadata keys, on both `handleLLMStart` and `handleChatModelStart`.
 - `handleLLMNewToken` sets first-token timestamp and accumulates streamed output.
 - `handleLLMEnd` maps output + usage and ends recorder.
 - `handleLLMError` sets call error and ends recorder.

--- a/js/src/frameworks/shared.ts
+++ b/js/src/frameworks/shared.ts
@@ -6,6 +6,7 @@ import type {
   Message,
   ModelRef,
   TokenUsage,
+  ToolDefinition,
   ToolExecutionRecorder,
 } from '../types.js';
 
@@ -32,6 +33,8 @@ const spanAttrFrameworkLangGraphNode = 'agento11y.framework.langgraph.node';
 const spanAttrFrameworkEventID = 'agento11y.framework.event_id';
 const spanAttrErrorType = 'error.type';
 const spanAttrErrorCategory = 'error.category';
+const metadataThinkingBudgetTokens = 'agento11y.gen_ai.request.thinking.budget_tokens';
+const metadataThinkingLevel = 'agento11y.gen_ai.request.thinking.level';
 const frameworkSource = 'handler';
 const maxFrameworkMetadataDepth = 5;
 
@@ -67,6 +70,16 @@ interface ToolRunState {
   recorder: ToolExecutionRecorder;
   arguments?: unknown;
   captureOutputs: boolean;
+}
+
+/** Chat-start request parameters lifted out of `invocation_params`. */
+interface ChatRequestParams {
+  tools: ToolDefinition[];
+  temperature: number | undefined;
+  maxTokens: number | undefined;
+  topP: number | undefined;
+  toolChoice: string;
+  thinkingEnabled: boolean | undefined;
 }
 
 interface FrameworkContext {
@@ -141,6 +154,7 @@ export class Agento11yFrameworkHandler {
       runName,
       serialized,
       invocationParams,
+      invocationControls: true,
       extraParams,
       callbackTags,
       callbackMetadata,
@@ -192,10 +206,19 @@ export class Agento11yFrameworkHandler {
       extraParams,
       callbackTags,
       callbackMetadata,
+      invocationControls: true,
     });
 
     const systemPrompt = asString(read(invocationParams, 'system_prompt')) || messageSystemPrompt;
-    const payload = this.startPayload(runKey, provider, modelName, context, systemPrompt);
+    const requestParams: ChatRequestParams = {
+      tools: resolveToolDefinitions(invocationParams),
+      temperature: asMaybeFloat(read(invocationParams, 'temperature')),
+      maxTokens: asMaybeInt(read(invocationParams, 'max_tokens')),
+      topP: asMaybeFloat(read(invocationParams, 'top_p')),
+      toolChoice: asString(read(invocationParams, 'tool_choice')),
+      thinkingEnabled: asMaybeBoolean(read(invocationParams, 'thinking_enabled')),
+    };
+    const payload = this.startPayload(runKey, provider, modelName, context, systemPrompt, requestParams);
     const recorder = stream ? this.client.startStreamingGeneration(payload) : this.client.startGeneration(payload);
 
     this.runs.set(runKey, {
@@ -508,6 +531,7 @@ export class Agento11yFrameworkHandler {
     modelName: string,
     context: FrameworkContext,
     systemPrompt?: string,
+    requestParams?: ChatRequestParams,
   ) {
     return {
       conversationId: context.conversationId,
@@ -520,6 +544,12 @@ export class Agento11yFrameworkHandler {
       tags: context.tags,
       metadata: context.metadata,
       ...(notEmpty(systemPrompt ?? '') ? { systemPrompt } : {}),
+      ...(requestParams !== undefined && requestParams.tools.length > 0 ? { tools: requestParams.tools } : {}),
+      ...(requestParams?.temperature !== undefined ? { temperature: requestParams.temperature } : {}),
+      ...(requestParams?.maxTokens !== undefined ? { maxTokens: requestParams.maxTokens } : {}),
+      ...(requestParams?.topP !== undefined ? { topP: requestParams.topP } : {}),
+      ...(notEmpty(requestParams?.toolChoice) ? { toolChoice: requestParams?.toolChoice } : {}),
+      ...(requestParams?.thinkingEnabled !== undefined ? { thinkingEnabled: requestParams.thinkingEnabled } : {}),
     };
   }
 
@@ -590,6 +620,8 @@ export class Agento11yFrameworkHandler {
     extraParams?: AnyRecord;
     callbackTags?: string[];
     callbackMetadata?: AnyRecord;
+    /** Only the LLM and chat-model paths carry sampling controls. */
+    invocationControls?: boolean;
   }): FrameworkContext {
     const conversation = resolveFrameworkConversationContext(
       this.frameworkName,
@@ -653,6 +685,9 @@ export class Agento11yFrameworkHandler {
     }
     if (eventId.length > 0) {
       rawMetadata[spanAttrFrameworkEventID] = eventId;
+    }
+    if (params.invocationControls === true) {
+      addInvocationControlMetadata(rawMetadata, params.invocationParams);
     }
     const metadata = normalizeFrameworkMetadata(rawMetadata);
 
@@ -1443,6 +1478,104 @@ function asMaybeInt(value: unknown): number | undefined {
       return undefined;
     }
     return parsed;
+  }
+  return undefined;
+}
+
+function addInvocationControlMetadata(metadata: AnyRecord, invocationParams: AnyRecord | undefined): void {
+  const thinkingBudget = asMaybeInt(read(invocationParams, 'thinking_budget'));
+  if (thinkingBudget !== undefined && !(metadataThinkingBudgetTokens in metadata)) {
+    metadata[metadataThinkingBudgetTokens] = thinkingBudget;
+  }
+
+  const thinkingLevel = asString(read(invocationParams, 'thinking_level'));
+  if (thinkingLevel.length > 0 && !(metadataThinkingLevel in metadata)) {
+    metadata[metadataThinkingLevel] = thinkingLevel;
+  }
+}
+
+function resolveToolDefinitions(invocationParams: AnyRecord | undefined): ToolDefinition[] {
+  const raw = read(invocationParams, 'tools');
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  const out: ToolDefinition[] = [];
+  for (const item of raw) {
+    const toolType = asString(read(item, 'type'));
+    // OpenAI-style tools nest the definition under `function`. Anything else, and
+    // already-shaped definitions that only carry `type`, describe themselves.
+    const nested = toolType === 'function' ? read(item, 'function') : undefined;
+    const definition = isRecord(nested) ? nested : item;
+
+    const name = asString(read(definition, 'name'));
+    if (name.length === 0) {
+      continue;
+    }
+
+    const schema = read(definition, 'parameters') ?? read(definition, 'parameters_json_schema');
+    const description = asString(read(definition, 'description'));
+    out.push({
+      name,
+      ...(description.length > 0 ? { description } : {}),
+      type: toolType.length > 0 ? toolType : 'function',
+      ...(schema === undefined || schema === null ? {} : { inputSchemaJSON: stableJSONString(schema) }),
+    });
+  }
+  return out;
+}
+
+/** Key order is sorted so a given schema encodes identically here and in the Python handler. */
+function stableJSONString(value: unknown): string | undefined {
+  try {
+    return JSON.stringify(value, (_key, entry: unknown) => {
+      if (isRecord(entry) && !Array.isArray(entry)) {
+        return Object.fromEntries(Object.entries(entry).sort(([left], [right]) => (left < right ? -1 : 1)));
+      }
+      return entry;
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function asMaybeFloat(value: unknown): number | undefined {
+  if (value === undefined || value === null || typeof value === 'boolean') {
+    return undefined;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      return undefined;
+    }
+    const parsed = Number.parseFloat(trimmed);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function asMaybeBoolean(value: unknown): boolean | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on') {
+      return true;
+    }
+    if (normalized === '0' || normalized === 'false' || normalized === 'no' || normalized === 'off') {
+      return false;
+    }
+    return undefined;
+  }
+  if (typeof value === 'number') {
+    return value !== 0;
   }
   return undefined;
 }

--- a/js/test/frameworks.langchain.test.mjs
+++ b/js/test/frameworks.langchain.test.mjs
@@ -19,6 +19,82 @@ class CapturingExporter {
   }
 }
 
+test('langchain chat start records sampling params, tools, and thinking metadata', async () => {
+  const generation = await captureSingleGeneration(async (client) => {
+    const handler = new Agento11yLangChainHandler(client, { agentName: 'agent-langchain' });
+
+    await handler.handleChatModelStart(
+      { name: 'ChatGoogleGenerativeAI' },
+      [[{ type: 'human', content: 'Use the weather tool.' }]],
+      'run-params',
+      undefined,
+      {
+        invocation_params: {
+          model: 'gemini-2.5-flash',
+          temperature: 0.25,
+          max_tokens: 512,
+          top_p: 0.9,
+          tool_choice: 'get_weather',
+          thinking_enabled: true,
+          thinking_budget: 2048,
+          thinking_level: 'high',
+          tools: [
+            {
+              type: 'function',
+              function: {
+                name: 'get_weather',
+                description: 'Get current weather for a city.',
+                parameters: {
+                  type: 'object',
+                  properties: { city: { type: 'string' } },
+                  required: ['city'],
+                },
+              },
+            },
+          ],
+        },
+      },
+    );
+    await handler.handleLLMEnd({ generations: [[{ text: 'sunny' }]] }, 'run-params');
+  });
+
+  assert.equal(generation.temperature, 0.25);
+  assert.equal(generation.maxTokens, 512);
+  assert.equal(generation.topP, 0.9);
+  assert.equal(generation.toolChoice, 'get_weather');
+  assert.equal(generation.thinkingEnabled, true);
+  assert.deepEqual(
+    generation.tools.map((tool) => [tool.name, tool.type]),
+    [['get_weather', 'function']],
+  );
+  assert.equal(generation.tools[0].description, 'Get current weather for a city.');
+  assert.match(generation.tools[0].inputSchemaJSON, /"city"/);
+  assert.equal(generation.metadata['agento11y.gen_ai.request.thinking.budget_tokens'], 2048);
+  assert.equal(generation.metadata['agento11y.gen_ai.request.thinking.level'], 'high');
+});
+
+test('langchain chat start omits sampling params that are absent', async () => {
+  const generation = await captureSingleGeneration(async (client) => {
+    const handler = new Agento11yLangChainHandler(client, {});
+
+    await handler.handleChatModelStart(
+      { name: 'ChatOpenAI' },
+      [[{ type: 'human', content: 'hello' }]],
+      'run-bare',
+      undefined,
+      { invocation_params: { model: 'gpt-5' } },
+    );
+    await handler.handleLLMEnd({ generations: [[{ text: 'world' }]] }, 'run-bare');
+  });
+
+  assert.equal(generation.temperature, undefined);
+  assert.equal(generation.maxTokens, undefined);
+  assert.equal(generation.topP, undefined);
+  assert.equal(generation.toolChoice, undefined);
+  assert.equal(generation.thinkingEnabled, undefined);
+  assert.equal(generation.tools, undefined);
+});
+
 test('langchain handler conversationId replaces the synthetic fallback', async () => {
   const generation = await captureSingleGeneration(async (client) => {
     const handler = new Agento11yLangChainHandler(client, { conversationId: 'checkout-session-7' });

--- a/python-frameworks/langchain/tests/test_langchain_handler.py
+++ b/python-frameworks/langchain/tests/test_langchain_handler.py
@@ -101,6 +101,61 @@ def test_langchain_prefers_explicit_invocation_params_system_prompt() -> None:
         client.shutdown()
 
 
+def test_langchain_chat_start_records_sampling_params_and_thinking_metadata() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        run_id = uuid4()
+        handler = Agento11yLangChainHandler(client=client, agent_name="agent-langchain")
+
+        handler.on_chat_model_start(
+            {"name": "ChatGoogleGenerativeAI"},
+            [[{"type": "human", "content": "Use the weather tool."}]],
+            run_id=run_id,
+            invocation_params={
+                "model": "gemini-2.5-flash",
+                "temperature": 0.25,
+                "max_tokens": 512,
+                "top_p": 0.9,
+                "tool_choice": "get_weather",
+                "thinking_enabled": True,
+                "thinking_budget": 2048,
+                "thinking_level": "high",
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "description": "Get current weather for a city.",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                                "required": ["city"],
+                            },
+                        },
+                    }
+                ],
+            },
+        )
+        handler.on_llm_end({"generations": [[{"text": "sunny"}]]}, run_id=run_id)
+
+        client.flush()
+        generation = exporter.requests[0].generations[0]
+        assert generation.temperature == 0.25
+        assert generation.max_tokens == 512
+        assert generation.top_p == 0.9
+        assert generation.tool_choice == "get_weather"
+        assert generation.thinking_enabled is True
+        assert [(tool.name, tool.type) for tool in generation.tools] == [("get_weather", "function")]
+        assert generation.tools[0].description == "Get current weather for a city."
+        assert b'"city"' in generation.tools[0].input_schema_json
+        assert generation.metadata["agento11y.gen_ai.request.thinking.budget_tokens"] == 2048
+        assert generation.metadata["agento11y.gen_ai.request.thinking.level"] == "high"
+    finally:
+        client.shutdown()
+
+
 def test_langchain_handler_conversation_id_replaces_synthetic_fallback() -> None:
     exporter = _CapturingExporter()
     client = _new_client(exporter)


### PR DESCRIPTION
Follows #559, now merged; this branch was rebased onto `main` so it carries only the parity change.

## The gap

Python's `_on_chat_model_start` builds a `GenerationStart` carrying `temperature`, `max_tokens`, `top_p`, `tool_choice`, `thinking_enabled`, and `tools`. The JS `startPayload` returned only `conversationId`, `agentName`, `agentVersion`, `model`, `tags`, `metadata`, and `systemPrompt`.

So the same application instrumented with the JS SDK silently lost every sampling parameter and the entire tool schema. Nothing errored; the fields just were not on the wire. Python also records `thinking_budget` and `thinking_level` as metadata on both the LLM and chat-model paths, which JS did not do either.

## What changed

The six generation fields plus the two thinking metadata keys, ported to match Python's semantics rather than reimplemented:

- Coercions mirror `_as_optional_int` / `_as_optional_float` / `_as_optional_bool`. Booleans are not accepted as numbers, numeric strings parse, and a non-integer value is rejected for `max_tokens` rather than truncated. The existing `asMaybeInt` already matched, so only the float and boolean variants are new.
- Tool schemas encode with sorted keys, so a given schema produces an identical `inputSchemaJSON` in both SDKs. Python uses `json.dumps(..., sort_keys=True)`; plain `JSON.stringify` would have emitted insertion order.
- Only the LLM and chat-model paths read these. Tool, chain, and retriever spans carry no sampling controls in Python, so the metadata is gated behind a flag rather than added unconditionally in the shared context builder, which all five callbacks share.

One intentional difference. Python has an `isinstance(item, ToolDefinition)` passthrough for already-constructed definitions; JS has no runtime type to check, and the generic path would have dropped such an entry, because `type: 'function'` sends it looking for a nested `function` object that is not there. An entry that declares a type but nests no function object now describes itself instead of being skipped. The standard OpenAI shape is unaffected.

`tools` is omitted when empty rather than sent as `[]`, matching how the other optional fields behave in JS.

## Test plan

- [x] New JS test asserting all six fields, the tool definition with its description and schema, and both thinking metadata keys
- [x] New JS test asserting the fields are absent when `invocation_params` carries only a model, so the empty case does not start emitting nulls
- [x] Matching Python test added for the same payload. Python already implemented this, but only `tool_choice` and `tools` had coverage; `temperature`, `max_tokens`, `top_p`, `thinking_enabled`, and the thinking metadata had none, so nothing was guarding parity from either side
- [x] `test:ts:sdk-js`, `test:ts:sdk-js-frameworks`, `test:ts:sdk-conformance`, `test:ts:sdk-framework-conformance`, `test:ts:sdk-provider-conformance` — the shared handler also backs the openai-agents, llamaindex, google-adk, and vercel-ai-sdk adapters
- [x] `test:py:sdk-langchain` (22), `lint:py`, `lint:ts:sdk-js`, `typecheck:ts:sdk-js`
