### PR TITLE
feat(plugins): honour AGENTO11Y_REDACT_INPUT_MESSAGES in every coding agent plugin

### DIFF
--- a/docs/concepts/content-capture-modes.md
+++ b/docs/concepts/content-capture-modes.md
@@ -80,6 +80,33 @@ For coding-agent plugins, the relevant env var is `AGENTO11Y_CONTENT_CAPTURE_MOD
 
 Unknown values fall back to `metadata_only` with a warning in the plugin log. A plugin can still export less than the SDK allows. For example, an adapter may drop a field if the host agent does not pass it through.
 
+## Secret redaction in the plugins
+
+Capture modes choose which fields ship. Redaction scrubs the fields that do ship.
+
+A plugin redacts known secret formats out of every content field it exports: user prompts, system prompts, assistant text, thinking, conversation titles, error messages, tool arguments, and tool results. This covers both copies of the tool payload, the one in the generation and the one on the tool-execution span. Only the prompt has a flag.
+
+Set `AGENTO11Y_REDACT_INPUT_MESSAGES=false` in `~/.config/agento11y/config.env` or the environment to export prompt text without redaction. The flag covers the prompt only: every other field stays redacted, and message structure, roles, token counts, tags, and IDs do not change. An unrecognised value keeps redaction on, so a typo cannot disable it.
+
+### Strength per field
+
+There are two pattern tiers. Tier 1 is high-confidence secret formats (`glc_…`, `AKIA…`, a PEM block, a connection string). Tier 2 is the key/value heuristics (`PASSWORD=…`, `"token": "…"`), which catch a secret with no recognisable format but also fire on ordinary text.
+
+Every plugin applies the same tier per field, and it is the tier the SDKs' generation sanitizer applies:
+
+| Field | Tier | Why |
+| --- | --- | --- |
+| User prompt | 1 + 2 | Where a human pastes a `.env` file, a config block or a command line. |
+| System prompt | 1 + 2 | Assembled content: tool definitions, environment dumps, pasted config. |
+| Tool arguments, tool results | 1 + 2 | Structured data, on the generation and on the span. |
+| Assistant text, thinking | 1 | Model prose. |
+| Conversation title | 1 | Usually the first prompt, truncated. |
+| Error messages | 1 | Sentences. |
+
+Tier 2 on a prompt has a real cost: `sort key: name` is exported as `sort key: [REDACTED:env-secret-value]`, because the heuristic cannot tell that `key:` is part of a sentence. Turn prompt redaction off with `AGENTO11Y_REDACT_INPUT_MESSAGES=false` if the prompt text matters more than the coverage. Tier 2 is kept off prose for that reason, and a secret a model repeats in prose is still caught by tier 1 as long as it has a known format.
+
+On a tool payload that decodes as JSON, the shared `agento11y` binary also redacts a value under a secret-looking key (`authorization`, `cookie`, `client_secret`), which the tier 2 key list does not cover. The OpenCode and Pi plugins do not: they redact the encoded JSON as text, so they catch only the key names in the tier 2 patterns.
+
 ## Related
 
 - [Tool Calls vs Tool Executions](./tool-call-vs-tool-execution.md): explains why tool-execution spans have their own content-capture story.

--- a/js/src/redaction.ts
+++ b/js/src/redaction.ts
@@ -33,7 +33,7 @@ export interface SecretTextRedactionOptions {
 export interface SecretRedactionOptions {
   /**
    * Redact user input messages in addition to assistant/tool content.
-   * Defaults to `false` to match the current opencode plugin behavior.
+   * Defaults to `false`; assistant and tool content is redacted either way.
    */
   redactInputMessages?: boolean;
   /**

--- a/llms.txt
+++ b/llms.txt
@@ -122,7 +122,9 @@ Accepted values depend on the plugin surface:
 
 - Claude Code, Codex, Copilot, Cursor, Vibe (shared `agento11y` binary), OpenCode (`@grafana/agento11y-opencode`), and Pi (`@grafana/agento11y-pi`): `full`, `no_tool_content`, `metadata_only`, `full_with_metadata_spans`. `default` is accepted as an alias for `metadata_only`.
 
-Unknown values fall back to `metadata_only` with a warning. Every plugin redacts known secret formats from captured content, using the same pattern table the SDKs use. Capture modes choose which fields ship, not whether the shipped fields are scrubbed. Treat content capture as opt-in for shared/production machines.
+Unknown values fall back to `metadata_only` with a warning. Capture modes choose which fields ship, not whether the shipped fields are scrubbed.
+
+When a plugin ships content, it redacts known secret formats first, using the same pattern table the SDKs use. This covers user prompts, system prompts, assistant text, thinking, conversation titles, error messages, tool arguments, and tool results, on the generation and on the tool-execution span. Set `AGENTO11Y_REDACT_INPUT_MESSAGES=false` to send prompts without redaction; everything else stays redacted. Prompts, system prompts and tool payloads also get the key/value heuristics (`PASSWORD=…`), which prose fields do not, so a prompt containing `sort key: name` comes out with the word after the colon replaced. Treat content capture as opt-in for shared/production machines.
 
 ## Verifying the install
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -46,4 +46,12 @@ Cursor has no launcher; see [`cursor/README.md`](cursor/README.md) for setup.
 | [Pi](https://github.com/earendil-works/pi) | [`pi/`](pi/) | Available |
 | [Vibe](https://github.com/mistralai/vibe) | [`vibe/`](vibe/) | Experimental |
 
+## Content and redaction
+
+Plugins send metadata only by default. `AGENTO11Y_CONTENT_CAPTURE_MODE=full` adds conversation content; see [Content Capture Modes](../docs/concepts/content-capture-modes.md).
+
+When a plugin exports content, it redacts known secret formats first. That covers user prompts, system prompts, assistant text, thinking, conversation titles, error messages, tool arguments, and tool results, on the generation and on the tool-execution span. Set `AGENTO11Y_REDACT_INPUT_MESSAGES=false` to send prompts without redaction; everything else stays redacted. The strength differs per field, and prose fields are deliberately treated more gently than pasted content; [Content Capture Modes](../docs/concepts/content-capture-modes.md#strength-per-field) has the table.
+
+## Configuration
+
 Plugins backed by the `agento11y` launcher share one config file at `~/.config/agento11y/config.env`. If you only have the old `~/.config/sigil/config.env`, that file is read and updated instead. The launcher creates or updates it on first run; `agento11y login` re-runs the same prompt later. The prompt asks for your Grafana stack, prints that stack's coding-agent setup page, and tries to open it in a browser. The credentials are then filled from the environment block you paste back. The stack is saved, so a later run offers it back and you press Enter. The same values can be passed as `--endpoint`, `--tenant`, and `--token` (or `--token-stdin`), which always outrank the prompt and also let login run where there is no terminal to prompt on. Cursor has no launcher, so register its plugin in-app and run `agento11y login` once for the shared config.

--- a/plugins/agento11y/internal/agents/claudecode/hook.go
+++ b/plugins/agento11y/internal/agents/claudecode/hook.go
@@ -151,6 +151,7 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 	extraTags := envconfig.ParseExtraTags(envconfig.Getenv("TAGS"))
 	userID := userid.Resolve()
 	contentMode := envconfig.ResolveContentMode(logger)
+	skipPromptRedaction := !envconfig.ResolveRedactInput(logger)
 
 	hookCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -183,10 +184,11 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 	}
 
 	gens, toolResultAt := mapper.Process(lines, &st, mapper.Options{
-		SessionID: input.SessionID,
-		Logger:    logger,
-		ExtraTags: extraTags,
-		AgentName: resolvedAgentName,
+		SessionID:           input.SessionID,
+		Logger:              logger,
+		ExtraTags:           extraTags,
+		AgentName:           resolvedAgentName,
+		SkipPromptRedaction: skipPromptRedaction,
 	}, r)
 
 	if len(gens) == 0 {

--- a/plugins/agento11y/internal/agents/claudecode/hook_test.go
+++ b/plugins/agento11y/internal/agents/claudecode/hook_test.go
@@ -1483,3 +1483,86 @@ func TestHook_AgentNameOverride(t *testing.T) {
 		})
 	}
 }
+
+// TestHook_PromptRedactionWiring pins AGENTO11Y_REDACT_INPUT_MESSAGES from the
+// environment through to the exported body. The mapper tests cover the flag
+// itself; this one covers the wire between them.
+func TestHook_PromptRedactionWiring(t *testing.T) {
+	const secret = "glc_abcdefghijklmnopqrstuvwxyz"
+
+	tests := []struct {
+		name            string
+		raw             string
+		wantPromptInRaw bool
+	}{
+		{name: "redacts by default", raw: "", wantPromptInRaw: false},
+		{name: "opt-out exports the prompt unredacted", raw: "false", wantPromptInRaw: true},
+		{name: "typo keeps redaction on", raw: "flase", wantPromptInRaw: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("XDG_STATE_HOME", filepath.Join(dir, "state"))
+			envconfig.PinAliasEnvBlank(t)
+
+			var gotBody atomic.Value
+			gotBody.Store("")
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					http.Error(w, "read body", http.StatusBadRequest)
+					return
+				}
+				gotBody.Store(string(body))
+				var request map[string]any
+				if err := json.Unmarshal(body, &request); err != nil {
+					http.Error(w, "invalid json", http.StatusBadRequest)
+					return
+				}
+				generations, _ := request["generations"].([]any)
+				results := make([]map[string]any, 0, len(generations))
+				for _, entry := range generations {
+					generation, _ := entry.(map[string]any)
+					id, _ := generation["id"].(string)
+					results = append(results, map[string]any{"generation_id": id, "accepted": true})
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(map[string]any{"results": results}); err != nil {
+					http.Error(w, "encode response", http.StatusInternalServerError)
+				}
+			}))
+			defer server.Close()
+
+			setHookExportEnv(t, server.URL)
+			t.Setenv("SIGIL_CONTENT_CAPTURE_MODE", "full")
+			t.Setenv("AGENTO11Y_REDACT_INPUT_MESSAGES", tt.raw)
+
+			sessionID := "redaction-wiring-session"
+			transcriptPath := filepath.Join(dir, "transcript.jsonl")
+			content := buildHookUserJSONL(sessionID, "my token is "+secret) + "\n" +
+				buildHookAssistantJSONL(sessionID, "req-1", "end_turn", "assistant saw "+secret, 5) + "\n"
+			if err := os.WriteFile(transcriptPath, []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			runHookForTest(t, hookInput{
+				HookEventName:  "Stop",
+				SessionID:      sessionID,
+				TranscriptPath: transcriptPath,
+			})
+
+			body, _ := gotBody.Load().(string)
+			if body == "" {
+				t.Fatal("expected an export request")
+			}
+			if got := strings.Contains(body, "my token is "+secret); got != tt.wantPromptInRaw {
+				t.Errorf("prompt unredacted in export = %v, want %v: %s", got, tt.wantPromptInRaw, body)
+			}
+			// The flag covers the prompt only.
+			if strings.Contains(body, "assistant saw "+secret) {
+				t.Errorf("assistant text lost its redaction: %s", body)
+			}
+		})
+	}
+}

--- a/plugins/agento11y/internal/agents/claudecode/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/claudecode/mapper/mapper.go
@@ -34,6 +34,9 @@ type Options struct {
 	// backfill cannot reconstruct a past per-run override, and
 	// claudeFinalizeSubagentGens matches generations against the product name.
 	AgentName string
+	// SkipPromptRedaction exports the user prompt without redaction. The zero
+	// value redacts; envconfig.ResolveRedactInput owns the policy.
+	SkipPromptRedaction bool
 	// SuppressSyntheticSubagentToolCallIDs skips the summary-only generation
 	// for an Agent tool result whose full subagent transcript is mapped
 	// separately. Live capture leaves it nil, so it keeps recording summaries
@@ -369,7 +372,7 @@ func conversationTitle(st *state.Session, sessionID string, r *redact.Redactor) 
 	}
 	t := strings.TrimSpace(st.Title)
 	if r != nil {
-		t = r.RedactLightweight(t)
+		t = r.Title(t)
 	}
 	if t == "" {
 		return sessionID
@@ -495,7 +498,7 @@ func processUserLine(line transcript.Line, uctx *userContext, st *state.Session,
 			}
 			content := b.Content()
 			if r != nil {
-				content = r.Redact(content)
+				content = r.ToolPayload(content)
 			}
 			toolParts = append(toolParts, agento11y.Part{
 				Kind: agento11y.PartKindToolResult,
@@ -591,7 +594,7 @@ func processAssistantLine(line transcript.Line, uctx *userContext, _ *state.Sess
 		gen.ThinkingEnabled = ptrBool(true)
 	}
 
-	gen.Input = buildInput(uctx, r)
+	gen.Input = buildInput(uctx, r, opts.SkipPromptRedaction)
 	gen.Output = buildOutput(msg.Content, r)
 
 	return gen, true
@@ -643,7 +646,7 @@ func buildToolDefs(names map[string]bool) []agento11y.ToolDefinition {
 	return mapperutil.SortedToolDefinitions(keys)
 }
 
-func buildInput(uctx *userContext, r *redact.Redactor) []agento11y.Message {
+func buildInput(uctx *userContext, r *redact.Redactor, skipPromptRedaction bool) []agento11y.Message {
 	if len(uctx.toolResults) > 0 {
 		return uctx.toolResults
 	}
@@ -651,8 +654,8 @@ func buildInput(uctx *userContext, r *redact.Redactor) []agento11y.Message {
 		return nil
 	}
 	text := uctx.prompt
-	if r != nil {
-		text = r.RedactLightweight(text)
+	if r != nil && !skipPromptRedaction {
+		text = r.Prompt(text)
 	}
 	return []agento11y.Message{{
 		Role: agento11y.RoleUser,
@@ -671,7 +674,7 @@ func buildOutput(blocks []transcript.ContentBlock, r *redact.Redactor) []agento1
 		case "text":
 			text := block.Text
 			if r != nil {
-				text = r.RedactLightweight(text)
+				text = r.AssistantText(text)
 			}
 			parts = append(parts, agento11y.Part{
 				Kind: agento11y.PartKindText,
@@ -708,10 +711,14 @@ func buildOutput(blocks []transcript.ContentBlock, r *redact.Redactor) []agento1
 	}}
 }
 
-// truncateJSON redacts and truncates tool input JSON.
-// Uses Tier 1 only (RedactLightweight) to avoid Tier 2 patterns mangling
-// JSON structure. When truncation occurs, the result is wrapped as a JSON
-// string (type changes from the original object/array to string).
+// truncateJSON redacts and truncates tool input JSON. When truncation occurs,
+// the result is wrapped as a JSON string (type changes from the original
+// object/array to string).
+//
+// Redaction is full strength, like every other plugin's tool arguments. It used
+// to be tier 1 only, on the grounds that tier 2 would mangle the JSON; it does
+// not, because the tier 2 key/value patterns keep the key and the quotes and
+// rewrite only the value.
 func truncateJSON(raw json.RawMessage, maxLen int, r *redact.Redactor) json.RawMessage {
 	if len(raw) == 0 {
 		return raw
@@ -719,7 +726,7 @@ func truncateJSON(raw json.RawMessage, maxLen int, r *redact.Redactor) json.RawM
 
 	s := string(raw)
 	if r != nil {
-		s = r.RedactLightweight(s)
+		s = string(r.ToolPayloadJSON(raw))
 	}
 
 	if len(s) <= maxLen {

--- a/plugins/agento11y/internal/agents/claudecode/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/claudecode/mapper/mapper_test.go
@@ -489,6 +489,43 @@ func TestProcess_ContentCaptureRedaction(t *testing.T) {
 	}
 }
 
+// TestProcess_RedactionTiers pins the per-field tier split. The prompt and the
+// tool arguments used to get tier 1 only, which left an env-style pair and a
+// secret-looking JSON key in clear text.
+func TestProcess_RedactionTiers(t *testing.T) {
+	lines := []transcript.Line{
+		makeUserLine("deploy with PASSWORD=hunter2"),
+		makeAssistantLine("claude-sonnet-4-20250514", 30, []transcript.ContentBlock{
+			{Type: "text", Text: "running with PASSWORD=hunter2"},
+			{Type: "tool_use", ID: "tu_1", Name: "Bash", Input: json.RawMessage(`{"cmd":"deploy.sh","api_key":"kR7fQ2wLmZ9xTb4vNc1JhY6s"}`)},
+		}, "tool_use"),
+	}
+
+	st := &state.Session{}
+	gens, _ := Process(lines, st, Options{SessionID: "sess-1"}, redact.New())
+
+	prompt := gens[0].Input[0].Parts[0].Text
+	if want := "deploy with PASSWORD=[REDACTED:env-secret-value]"; prompt != want {
+		t.Errorf("prompt = %q, want %q", prompt, want)
+	}
+
+	// Assistant text is prose and keeps tier 1 only.
+	if want := "running with PASSWORD=hunter2"; gens[0].Output[0].Parts[0].Text != want {
+		t.Errorf("assistant text = %q, want %q", gens[0].Output[0].Parts[0].Text, want)
+	}
+
+	args := string(gens[0].Output[0].Parts[1].ToolCall.InputJSON)
+	if strings.Contains(args, "kR7fQ2wLmZ9xTb4vNc1JhY6s") {
+		t.Errorf("tool arguments leak the api key: %s", args)
+	}
+	if !strings.Contains(args, "[REDACTED:json-secret-field]") {
+		t.Errorf("tool arguments are missing the marker: %s", args)
+	}
+	if !strings.Contains(args, "deploy.sh") {
+		t.Errorf("tool arguments dropped a non-secret value: %s", args)
+	}
+}
+
 func TestProcess_Tags(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -1301,12 +1338,14 @@ func TestProcess_EffectiveVersionStableAcrossToolSubsets(t *testing.T) {
 
 func TestProcess_UserPromptRedaction(t *testing.T) {
 	tests := []struct {
-		name       string
-		redactor   *redact.Redactor
-		wantRedact bool
+		name                string
+		redactor            *redact.Redactor
+		skipPromptRedaction bool
+		wantRedact          bool
 	}{
-		{"with redactor", redact.New(), true},
-		{"without redactor", nil, false},
+		{name: "with redactor", redactor: redact.New(), wantRedact: true},
+		{name: "without redactor", redactor: nil, wantRedact: false},
+		{name: "opt-out exports the prompt unredacted", redactor: redact.New(), skipPromptRedaction: true, wantRedact: false},
 	}
 
 	for _, tt := range tests {
@@ -1314,12 +1353,15 @@ func TestProcess_UserPromptRedaction(t *testing.T) {
 			lines := []transcript.Line{
 				makeUserLine("my token is glc_abcdefghijklmnopqrstuvwx"),
 				makeAssistantLine("claude-sonnet-4-20250514", 30, []transcript.ContentBlock{
-					{Type: "text", Text: "ok"},
+					{Type: "text", Text: "assistant saw glc_abcdefghijklmnopqrstuvwx"},
 				}, "end_turn"),
 			}
 
 			st := &state.Session{}
-			gens, _ := Process(lines, st, Options{SessionID: "sess-1"}, tt.redactor)
+			gens, _ := Process(lines, st, Options{
+				SessionID:           "sess-1",
+				SkipPromptRedaction: tt.skipPromptRedaction,
+			}, tt.redactor)
 
 			if gens[0].Input == nil {
 				t.Fatal("expected Input to be present")
@@ -1337,6 +1379,14 @@ func TestProcess_UserPromptRedaction(t *testing.T) {
 				if !strings.Contains(input, "glc_abcdefghijklmnopqrstuvwx") {
 					t.Errorf("expected raw token in prompt: %q", input)
 				}
+			}
+
+			// The opt-out covers the prompt only. Assistant text keeps its
+			// redaction whenever a redactor is configured.
+			output := gens[0].Output[0].Parts[0].Text
+			wantOutputRedacted := tt.redactor != nil
+			if got := strings.Contains(output, "[REDACTED:grafana-cloud-token]"); got != wantOutputRedacted {
+				t.Errorf("assistant text redacted = %v, want %v: %q", got, wantOutputRedacted, output)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/agents/codex/config/config.go
+++ b/plugins/agento11y/internal/agents/codex/config/config.go
@@ -15,8 +15,11 @@ import (
 // been applied. Endpoint, auth, and SIGIL_TAGS are read by the SDK directly.
 type Config struct {
 	ContentCapture agento11y.ContentCaptureMode
-	Debug          bool
-	Guards         envconfig.GuardsConfig
+	// SkipPromptRedaction exports the user prompt without redaction. Set from
+	// AGENTO11Y_REDACT_INPUT_MESSAGES=false, so the zero value redacts.
+	SkipPromptRedaction bool
+	Debug               bool
+	Guards              envconfig.GuardsConfig
 	// AgentName is the identity every generation and guard request reports.
 	// Load resolves it from AGENTO11Y_AGENT_NAME, then SIGIL_AGENT_NAME, and
 	// falls back to "codex". Read it through Agent.
@@ -65,9 +68,10 @@ func AllowedDotenvKey(key string) bool {
 // first so dotenv-only values are reflected in the OS env.
 func Load(logger *log.Logger) Config {
 	return Config{
-		ContentCapture: envconfig.ResolveContentMode(logger),
-		Debug:          envconfig.ParseBool(envconfig.Getenv("DEBUG")),
-		Guards:         envconfig.ResolveGuards(logger),
-		AgentName:      envconfig.ResolveAgentName(mapper.AgentName),
+		ContentCapture:      envconfig.ResolveContentMode(logger),
+		SkipPromptRedaction: !envconfig.ResolveRedactInput(logger),
+		Debug:               envconfig.ParseBool(envconfig.Getenv("DEBUG")),
+		Guards:              envconfig.ResolveGuards(logger),
+		AgentName:           envconfig.ResolveAgentName(mapper.AgentName),
 	}
 }

--- a/plugins/agento11y/internal/agents/codex/config/config_test.go
+++ b/plugins/agento11y/internal/agents/codex/config/config_test.go
@@ -8,6 +8,32 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/codex/mapper"
 )
 
+// TestLoad_SkipPromptRedaction pins the prompt-redaction opt-out for codex
+// against the shared envconfig resolver, mirroring the copilot config test.
+func TestLoad_SkipPromptRedaction(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "redacts when unset", raw: "", want: false},
+		{name: "opts out on false", raw: "false", want: true},
+		{name: "redacts on true", raw: "true", want: false},
+		{name: "redacts on a typo", raw: "flase", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AGENTO11Y_REDACT_INPUT_MESSAGES", tt.raw)
+			t.Setenv("SIGIL_REDACT_INPUT_MESSAGES", "")
+			cfg := Load(log.New(&bytes.Buffer{}, "", 0))
+			if cfg.SkipPromptRedaction != tt.want {
+				t.Errorf("SkipPromptRedaction = %t, want %t", cfg.SkipPromptRedaction, tt.want)
+			}
+		})
+	}
+}
+
 // TestLoad_Guards pins the env-var contract and defaults for codex against
 // the shared envconfig resolver, mirroring the copilot config test so the
 // two agents stay byte-identical on the guard knobs that ship in

--- a/plugins/agento11y/internal/agents/codex/hook/handlers.go
+++ b/plugins/agento11y/internal/agents/codex/hook/handlers.go
@@ -224,7 +224,7 @@ func Stop(p Payload, cfg config.Config, logger *log.Logger) {
 	client := buildClient(cfg, frag.Cwd, providers, logger)
 	defer func() { _ = client.Shutdown(ctx) }()
 
-	mapped := mapper.Map(mapper.Inputs{Fragment: frag, SubagentLink: subagentLink, TokenSnapshot: tokenSnapshot, ContentCapture: cfg.ContentCapture, AgentName: cfg.Agent()})
+	mapped := mapper.Map(mapper.Inputs{Fragment: frag, SubagentLink: subagentLink, TokenSnapshot: tokenSnapshot, ContentCapture: cfg.ContentCapture, AgentName: cfg.Agent(), SkipPromptRedaction: cfg.SkipPromptRedaction})
 	logger.Printf("stop: export id=%s conversation=%s agent=%s model=%s", mapped.Generation.ID, mapped.Generation.ConversationID, mapped.Generation.AgentName, mapped.Generation.Model.Name)
 	if err := emitGeneration(ctx, client, frag, mapped, cfg.ContentCapture, logger); err != nil {
 		logger.Printf("stop: emit: %v", err)
@@ -310,10 +310,11 @@ func sweepPendingRetries(ctx context.Context, client *agento11y.Client, cfg conf
 		subagentLink := resolveSubagentLinkForStop(retryPayload, f, logger)
 		tokenSnapshot := tokenSnapshotForStop(retryPayload, f, logger)
 		mapped := mapper.Map(mapper.Inputs{
-			Fragment:       f,
-			SubagentLink:   subagentLink,
-			TokenSnapshot:  tokenSnapshot,
-			ContentCapture: cfg.ContentCapture,
+			Fragment:            f,
+			SubagentLink:        subagentLink,
+			TokenSnapshot:       tokenSnapshot,
+			ContentCapture:      cfg.ContentCapture,
+			SkipPromptRedaction: cfg.SkipPromptRedaction,
 			// The name comes from this invocation, not from the turn the
 			// fragment was written in. A name changed between turns
 			// re-stamps a retried turn with the current one.
@@ -538,7 +539,7 @@ func redactSpanContent(red *redact.Redactor, raw json.RawMessage) string {
 	if red == nil || len(raw) == 0 {
 		return ""
 	}
-	return red.RedactJSONForText(raw)
+	return red.ToolPayloadText(raw)
 }
 
 func normalizeStatus(p Payload, response json.RawMessage) string {

--- a/plugins/agento11y/internal/agents/codex/hook/handlers_test.go
+++ b/plugins/agento11y/internal/agents/codex/hook/handlers_test.go
@@ -289,6 +289,63 @@ func TestStopSuccessfulExportDeletesFragmentAndUsesAuth(t *testing.T) {
 	}
 }
 
+// TestStopPromptRedactionWiring pins config.Config.SkipPromptRedaction
+// through to the exported body. The mapper tests cover the flag itself and
+// the config test covers Load; this one covers the wire between them.
+func TestStopPromptRedactionWiring(t *testing.T) {
+	const secret = "glc_abcdefghijklmnopqrstuvwxyz"
+
+	tests := []struct {
+		name                string
+		skipPromptRedaction bool
+		wantPromptInRaw     bool
+	}{
+		{name: "redacts the prompt by default", wantPromptInRaw: false},
+		{name: "opt-out exports the prompt unredacted", skipPromptRedaction: true, wantPromptInRaw: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "")
+			logger := log.New(io.Discard, "", 0)
+			var gotBody atomic.Value
+			gotBody.Store("")
+			server := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					http.Error(w, "read body", http.StatusBadRequest)
+					return
+				}
+				gotBody.Store(string(body))
+				writeAcceptedGenerationResponse(t, w, body)
+			}))
+			defer server.Close()
+			t.Setenv("SIGIL_ENDPOINT", server.URL)
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
+
+			require.NoError(t, fragment.Update("sess", "turn", logger, func(f *fragment.Fragment) bool {
+				f.Model = "gpt-5.5"
+				f.Prompt = "my token is " + secret
+				f.LastAssistantMessage = "assistant saw " + secret
+				return true
+			}))
+
+			Stop(Payload{HookEventName: "Stop", SessionID: "sess", TurnID: "turn"}, config.Config{
+				ContentCapture:      agento11y.ContentCaptureModeFull,
+				SkipPromptRedaction: tt.skipPromptRedaction,
+			}, logger)
+
+			body, _ := gotBody.Load().(string)
+			require.NotEmpty(t, body, "expected an export request")
+			assert.Equal(t, tt.wantPromptInRaw, strings.Contains(body, "my token is "+secret), "prompt unredacted in export: %s", body)
+			// The flag covers the prompt only.
+			assert.NotContains(t, body, "assistant saw "+secret, "assistant text lost its redaction")
+		})
+	}
+}
+
 func TestStopLocalEndpointAllowsMissingCredentials(t *testing.T) {
 	for _, tc := range []struct {
 		name     string

--- a/plugins/agento11y/internal/agents/codex/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/codex/mapper/mapper.go
@@ -45,7 +45,10 @@ type Inputs struct {
 	// same patterns twice. Live capture leaves it false, so the mapper stays
 	// the redaction point for the live path.
 	RawContent bool
-	Now        time.Time
+	// SkipPromptRedaction exports the user prompt without redaction. The zero
+	// value redacts; envconfig.ResolveRedactInput owns the policy.
+	SkipPromptRedaction bool
+	Now                 time.Time
 }
 
 type Mapped struct {
@@ -87,7 +90,7 @@ func Map(in Inputs) Mapped {
 	tags["codex.stop_hook_active"] = strconv.FormatBool(frag.StopHookActive)
 
 	tools := buildToolDefinitions(frag.Tools)
-	input, output := buildMessages(frag, payloadMode, in.RawContent)
+	input, output := buildMessages(frag, payloadMode, in.RawContent, in.SkipPromptRedaction)
 	conversationID, agentName, parentIDs, metadata := linkFields(frag, in.SubagentLink, tags, in.agent())
 	usage, metadata := usageFields(in.TokenSnapshot, metadata)
 
@@ -223,15 +226,16 @@ func hasPositiveCodexUsage(u codexlog.TokenUsage) bool {
 		u.TotalTokens > 0
 }
 
-func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode, rawContent bool) (input, output []agento11y.Message) {
+func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode, rawContent, skipPromptRedaction bool) (input, output []agento11y.Message) {
 	mode = mapperutil.NormalizePayloadContentMode(mode)
 	red := redact.New()
-	cleanText := func(s string) string {
+	contentMode := mode == agento11y.ContentCaptureModeFull || mode == agento11y.ContentCaptureModeNoToolContent
+	cleanProse := func(s string) string {
 		if rawContent {
 			return s
 		}
-		if mode == agento11y.ContentCaptureModeFull || mode == agento11y.ContentCaptureModeNoToolContent {
-			return red.Redact(s)
+		if contentMode {
+			return red.AssistantText(s)
 		}
 		return ""
 	}
@@ -239,11 +243,21 @@ func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode, r
 		if rawContent {
 			return raw
 		}
-		return red.RedactJSON(raw)
+		return red.ToolPayloadJSON(raw)
+	}
+	// The redaction opt-out does not export a prompt the capture mode drops.
+	cleanPrompt := func(s string) string {
+		if rawContent || (skipPromptRedaction && contentMode) {
+			return s
+		}
+		if contentMode {
+			return red.Prompt(s)
+		}
+		return ""
 	}
 
 	if mode != agento11y.ContentCaptureModeMetadataOnly && strings.TrimSpace(frag.Prompt) != "" {
-		input = append(input, agento11y.UserTextMessage(cleanText(frag.Prompt)))
+		input = append(input, agento11y.UserTextMessage(cleanPrompt(frag.Prompt)))
 	}
 	for i := range frag.Tools {
 		t := &frag.Tools[i]
@@ -265,7 +279,7 @@ func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode, r
 		input = append(input, agento11y.Message{Role: agento11y.RoleTool, Parts: []agento11y.Part{agento11y.ToolResultPart(result)}})
 	}
 	if mode != agento11y.ContentCaptureModeMetadataOnly && strings.TrimSpace(frag.LastAssistantMessage) != "" {
-		output = append(output, agento11y.AssistantTextMessage(cleanText(frag.LastAssistantMessage)))
+		output = append(output, agento11y.AssistantTextMessage(cleanProse(frag.LastAssistantMessage)))
 	}
 	return input, output
 }

--- a/plugins/agento11y/internal/agents/codex/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/codex/mapper/mapper_test.go
@@ -36,34 +36,79 @@ func TestMapMetadataOnlyStripsTextButKeepsToolStructure(t *testing.T) {
 }
 
 func TestMapFullRedactsContent(t *testing.T) {
-	secret := "glc_abcdefghijklmnopqrstuvwxyz"
-	raw, _ := json.Marshal(map[string]string{"token": secret})
-	f := &fragment.Fragment{
-		SessionID:            "sess",
-		TurnID:               "turn",
-		Model:                "gpt-5.5",
-		Prompt:               "token " + secret,
-		LastAssistantMessage: "saw " + secret,
-		Tools: []fragment.ToolRecord{{
-			ToolName:     "Bash",
-			ToolUseID:    "tool-1",
-			ToolInput:    raw,
-			ToolResponse: raw,
-		}},
+	const secret = "glc_abcdefghijklmnopqrstuvwxyz"
+
+	tests := []struct {
+		name                string
+		skipPromptRedaction bool
+		wantPromptRedacted  bool
+	}{
+		{name: "redacts every field by default", wantPromptRedacted: true},
+		{name: "opt-out exports the prompt unredacted", skipPromptRedaction: true, wantPromptRedacted: false},
 	}
-	got := Map(Inputs{Fragment: f, ContentCapture: agento11y.ContentCaptureModeFull, Now: time.Unix(1, 0)})
-	combined := got.Generation.Input[0].Parts[0].Text + got.Generation.Output[len(got.Generation.Output)-1].Parts[0].Text
-	toolInput := string(got.Generation.Output[0].Parts[0].ToolCall.InputJSON)
-	toolResult := string(got.Generation.Input[1].Parts[0].ToolResult.ContentJSON)
-	if !json.Valid([]byte(toolInput)) || !json.Valid([]byte(toolResult)) {
-		t.Fatalf("redacted tool JSON must remain valid: input=%s result=%s", toolInput, toolResult)
-	}
-	combined += toolInput + toolResult
-	if strings.Contains(combined, secret) {
-		t.Fatalf("unredacted secret in generation: %s", combined)
-	}
-	if !strings.Contains(combined, "[REDACTED:grafana-cloud-token]") {
-		t.Fatalf("expected redaction marker in generation: %s", combined)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, _ := json.Marshal(map[string]string{"token": secret})
+			f := &fragment.Fragment{
+				SessionID:            "sess",
+				TurnID:               "turn",
+				Model:                "gpt-5.5",
+				Prompt:               "token " + secret + " PASSWORD=hunter2",
+				LastAssistantMessage: "saw " + secret + " PASSWORD=hunter2",
+				Tools: []fragment.ToolRecord{{
+					ToolName:     "Bash",
+					ToolUseID:    "tool-1",
+					ToolInput:    raw,
+					ToolResponse: raw,
+				}},
+			}
+			got := Map(Inputs{
+				Fragment:            f,
+				ContentCapture:      agento11y.ContentCaptureModeFull,
+				SkipPromptRedaction: tt.skipPromptRedaction,
+				Now:                 time.Unix(1, 0),
+			})
+
+			prompt := got.Generation.Input[0].Parts[0].Text
+			if gotRedacted := !strings.Contains(prompt, secret); gotRedacted != tt.wantPromptRedacted {
+				t.Fatalf("prompt redacted = %v, want %v: %s", gotRedacted, tt.wantPromptRedacted, prompt)
+			}
+
+			// The opt-out covers the prompt only.
+			assistant := got.Generation.Output[len(got.Generation.Output)-1].Parts[0].Text
+			toolInput := string(got.Generation.Output[0].Parts[0].ToolCall.InputJSON)
+			toolResult := string(got.Generation.Input[1].Parts[0].ToolResult.ContentJSON)
+			if !json.Valid([]byte(toolInput)) || !json.Valid([]byte(toolResult)) {
+				t.Fatalf("redacted tool JSON must remain valid: input=%s result=%s", toolInput, toolResult)
+			}
+			combined := assistant + toolInput + toolResult
+			if strings.Contains(combined, secret) {
+				t.Fatalf("unredacted secret outside the prompt: %s", combined)
+			}
+			if !strings.Contains(combined, "[REDACTED:grafana-cloud-token]") {
+				t.Fatalf("expected redaction marker in generation: %s", combined)
+			}
+
+			// The tier split: a prompt is where a config file gets pasted, so
+			// it takes tier 2 as well. Assistant prose keeps tier 1 only,
+			// because tier 2 replaces the word after any `key:` in a sentence.
+			wantTier2Prompt := tt.wantPromptRedacted
+			if got := strings.Contains(prompt, "PASSWORD=[REDACTED:env-secret-value]"); got != wantTier2Prompt {
+				t.Errorf("prompt got tier 2 = %v, want %v: %s", got, wantTier2Prompt, prompt)
+			}
+			if !strings.Contains(assistant, "PASSWORD=hunter2") {
+				t.Errorf("assistant text got tier 2: %s", assistant)
+			}
+
+			// Structure, usage, and IDs do not depend on the flag.
+			if got.Generation.ID != GenerationID("sess", "turn") {
+				t.Errorf("generation ID = %q, want the deterministic session/turn ID", got.Generation.ID)
+			}
+			if got.Generation.Output[0].Parts[0].ToolCall.Name != "Bash" {
+				t.Errorf("tool name = %q, want Bash", got.Generation.Output[0].Parts[0].ToolCall.Name)
+			}
+		})
 	}
 }
 

--- a/plugins/agento11y/internal/agents/copilot/config/config.go
+++ b/plugins/agento11y/internal/agents/copilot/config/config.go
@@ -17,7 +17,10 @@ import (
 // before this struct is built, so it does not appear here.
 type Config struct {
 	ContentCapture agento11y.ContentCaptureMode
-	Guards         envconfig.GuardsConfig
+	// SkipPromptRedaction exports the user prompt without redaction. Set from
+	// AGENTO11Y_REDACT_INPUT_MESSAGES=false, so the zero value redacts.
+	SkipPromptRedaction bool
+	Guards              envconfig.GuardsConfig
 	// AgentName is the identity every generation and guard request reports.
 	// Load resolves it from AGENTO11Y_AGENT_NAME, then SIGIL_AGENT_NAME, and
 	// falls back to "copilot". Read it through Agent.
@@ -45,8 +48,9 @@ func HasCredentials() bool {
 // reflected in the OS env.
 func Load(logger *log.Logger) Config {
 	return Config{
-		ContentCapture: envconfig.ResolveContentMode(logger),
-		Guards:         envconfig.ResolveGuards(logger),
-		AgentName:      envconfig.ResolveAgentName(mapper.AgentName),
+		ContentCapture:      envconfig.ResolveContentMode(logger),
+		SkipPromptRedaction: !envconfig.ResolveRedactInput(logger),
+		Guards:              envconfig.ResolveGuards(logger),
+		AgentName:           envconfig.ResolveAgentName(mapper.AgentName),
 	}
 }

--- a/plugins/agento11y/internal/agents/copilot/config/config_test.go
+++ b/plugins/agento11y/internal/agents/copilot/config/config_test.go
@@ -26,6 +26,30 @@ func TestLoad_InvalidContentCaptureFailsClosed(t *testing.T) {
 	}
 }
 
+func TestLoad_SkipPromptRedaction(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "redacts when unset", raw: "", want: false},
+		{name: "opts out on false", raw: "false", want: true},
+		{name: "redacts on true", raw: "true", want: false},
+		{name: "redacts on a typo", raw: "flase", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AGENTO11Y_REDACT_INPUT_MESSAGES", tt.raw)
+			t.Setenv("SIGIL_REDACT_INPUT_MESSAGES", "")
+			cfg := Load(log.New(&bytes.Buffer{}, "", 0))
+			if cfg.SkipPromptRedaction != tt.want {
+				t.Errorf("SkipPromptRedaction = %t, want %t", cfg.SkipPromptRedaction, tt.want)
+			}
+		})
+	}
+}
+
 func TestLoad_Guards(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/plugins/agento11y/internal/agents/copilot/hook/handlers.go
+++ b/plugins/agento11y/internal/agents/copilot/hook/handlers.go
@@ -495,11 +495,12 @@ func Stop(p Payload, cfg config.Config, logger *log.Logger) {
 		_ = client.Shutdown(ctx)
 	}()
 	mapped := mapper.Map(mapper.Inputs{
-		Fragment:       frag,
-		Session:        session,
-		ContentCapture: cfg.ContentCapture,
-		UserIDOverride: envconfig.Getenv("USER_ID"),
-		AgentName:      cfg.Agent(),
+		Fragment:            frag,
+		Session:             session,
+		ContentCapture:      cfg.ContentCapture,
+		SkipPromptRedaction: cfg.SkipPromptRedaction,
+		UserIDOverride:      envconfig.Getenv("USER_ID"),
+		AgentName:           cfg.Agent(),
 	})
 	logger.Printf(
 		"stop: mapped model=%s provider=%s response_id=%s output_tokens=%d assistant_text=%t tool_count=%d",
@@ -730,7 +731,16 @@ func emitGeneration(ctx context.Context, client *agento11y.Client, frag *fragmen
 	})
 }
 
+// Tool argument/result content goes through the redactor on its way to the
+// span, the same second boundary cursor and codex use: the mapper redacts the
+// generation export, and the span carries its own copy of the same fragment
+// bytes. t.ErrorMessage needs no pass here, because postToolUse redacted it
+// before it reached the fragment. Capture-mode clamping also happens at that
+// write boundary (preToolUse and postToolUse drop the bytes for any mode other
+// than `full`), so in metadata_only and no_tool_content there is nothing left
+// to redact.
 func emitToolSpans(ctx context.Context, client *agento11y.Client, frag *fragment.Fragment, gen agento11y.Generation, logger *log.Logger) {
+	red := redact.New()
 	for i := range frag.Tools {
 		t := &frag.Tools[i]
 		if t.ToolName == "" {
@@ -752,10 +762,10 @@ func emitToolSpans(ctx context.Context, client *agento11y.Client, frag *fragment
 
 		end := agento11y.ToolExecutionEnd{CompletedAt: completedAt}
 		if len(t.ToolInput) > 0 {
-			end.Arguments = string(t.ToolInput)
+			end.Arguments = red.ToolPayloadText(t.ToolInput)
 		}
 		if len(t.ToolResponse) > 0 {
-			end.Result = string(t.ToolResponse)
+			end.Result = red.ToolPayloadText(t.ToolResponse)
 		} else if t.ErrorMessage != "" {
 			end.Result = t.ErrorMessage
 		}

--- a/plugins/agento11y/internal/agents/copilot/hook/handlers_test.go
+++ b/plugins/agento11y/internal/agents/copilot/hook/handlers_test.go
@@ -17,6 +17,9 @@ import (
 	"testing"
 	"time"
 
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
 	"github.com/grafana/agento11y/go/agento11y"
 
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/copilot/config"
@@ -244,6 +247,54 @@ func TestStopEnrichesExportFromTranscript(t *testing.T) {
 		if !strings.Contains(gotBody, want) {
 			t.Fatalf("export body missing %q: %s", want, gotBody)
 		}
+	}
+}
+
+// TestStopPromptRedactionWiring pins config.Config.SkipPromptRedaction
+// through to the exported body. The mapper tests cover the flag itself and
+// the config test covers Load; this one covers the wire between them.
+func TestStopPromptRedactionWiring(t *testing.T) {
+	const secret = "glc_abcdefghijklmnopqrstuvwxyz"
+
+	tests := []struct {
+		name                string
+		skipPromptRedaction bool
+		wantPromptInRaw     bool
+	}{
+		{name: "redacts the prompt by default", wantPromptInRaw: false},
+		{name: "opt-out exports the prompt unredacted", skipPromptRedaction: true, wantPromptInRaw: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "")
+			t.Setenv("SIGIL_CONTENT_CAPTURE_MODE", "full")
+			logger := log.New(io.Discard, "", 0)
+
+			var gotBody string
+			server := newAcceptedGenerationServer(t, func(body string) {
+				gotBody = body
+			})
+			defer server.Close()
+
+			t.Setenv("SIGIL_ENDPOINT", server.URL)
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
+			cfg := config.Config{
+				ContentCapture:      agento11y.ContentCaptureModeFull,
+				SkipPromptRedaction: tt.skipPromptRedaction,
+			}
+
+			UserPromptSubmit(Payload{HookEventNameJSON: "UserPromptSubmit", SessionIDJSON: "sess", Timestamp: []byte(`"2026-05-18T12:00:01Z"`), Prompt: "my token is " + secret}, cfg, logger)
+			PostToolUse(Payload{HookEventNameJSON: "PostToolUse", SessionIDJSON: "sess", Timestamp: []byte(`"2026-05-18T12:00:03Z"`), ToolNameJSON: "bash", ToolInputJSON: []byte(`{"cmd":"echo ` + secret + `"}`), ToolResultJSON: []byte(`{"text_result_for_llm":"ok"}`)}, cfg, logger, false)
+			Stop(Payload{HookEventNameJSON: "Stop", SessionIDJSON: "sess", Timestamp: []byte(`"2026-05-18T12:00:04Z"`), StopReasonJSON: "end_turn"}, cfg, logger)
+
+			require.NotEmpty(t, gotBody, "expected an export request")
+			assert.Equal(t, tt.wantPromptInRaw, strings.Contains(gotBody, "my token is "+secret), "prompt unredacted in export: %s", gotBody)
+			// The flag covers the prompt only.
+			assert.NotContains(t, gotBody, "echo "+secret, "tool arguments lost their redaction")
+		})
 	}
 }
 
@@ -894,4 +945,86 @@ func TestAgentNameOverrideGuardAndExport(t *testing.T) {
 			assert.Equal(t, []string{mapper.AgentName}, exportProviders, "exported model providers")
 		})
 	}
+}
+
+// Tool arguments and results reach the OTel span on a path the generation
+// export never touches, so the mapper's redaction does not cover them. The
+// span carries the same fragment bytes and needs its own pass.
+func TestEmitToolSpans_RedactsContent(t *testing.T) {
+	const token = "glc_abcdefghijklmnopqrstuvwxyz"
+	const apiKey = "kR7fQ2wLmZ9xTb4vNc1JhY6s"
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	logger := log.New(io.Discard, "", 0)
+	client := agento11y.NewClient(agento11y.Config{
+		ContentCapture: agento11y.ContentCaptureModeFull,
+		Tracer:         tp.Tracer("test"),
+		Logger:         logger,
+	})
+	t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
+
+	frag := &fragment.Fragment{
+		Tools: []fragment.ToolRecord{{
+			ToolName:     "bash",
+			ToolUseID:    "tu-1",
+			ToolInput:    json.RawMessage(`{"command":"deploy.sh","api_key":"` + apiKey + `"}`),
+			ToolResponse: json.RawMessage(`{"stdout":"authenticated with ` + token + `"}`),
+			Status:       "completed",
+			CompletedAt:  "2026-05-18T12:00:05Z",
+		}},
+	}
+	gen := agento11y.Generation{
+		ID:             "gen-1",
+		ConversationID: "conv",
+		AgentName:      mapper.AgentName,
+		Model:          agento11y.ModelRef{Provider: "openai", Name: "gpt-5-copilot"},
+		CompletedAt:    time.Date(2026, 5, 18, 12, 0, 30, 0, time.UTC),
+		// Tool-call content in the output is what makes the SDK resolve the
+		// span's capture mode to full; mappedContentCapture reads it.
+		Output: []agento11y.Message{{
+			Role: agento11y.RoleAssistant,
+			Parts: []agento11y.Part{agento11y.ToolCallPart(agento11y.ToolCall{
+				ID:        "tu-1",
+				Name:      "bash",
+				InputJSON: json.RawMessage(`{"command":"deploy.sh"}`),
+			})},
+		}},
+	}
+
+	emitToolSpans(context.Background(), client, frag, gen, logger)
+	_ = client.Shutdown(context.Background())
+	_ = tp.Shutdown(context.Background())
+
+	var attrs map[string]string
+	for _, s := range recorder.Ended() {
+		if !strings.HasPrefix(s.Name(), "execute_tool ") {
+			continue
+		}
+		attrs = map[string]string{}
+		for _, kv := range s.Attributes() {
+			attrs[string(kv.Key)] = kv.Value.AsString()
+		}
+	}
+	require.NotNil(t, attrs, "no execute_tool span recorded")
+
+	cases := []struct {
+		attr     string
+		wantMark string
+	}{
+		{"gen_ai.tool.call.arguments", "[REDACTED:json-secret-field]"},
+		{"gen_ai.tool.call.result", "[REDACTED:grafana-cloud-token]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.attr, func(t *testing.T) {
+			got, ok := attrs[tc.attr]
+			require.True(t, ok, "span is missing %s; recorded attributes: %v", tc.attr, attrs)
+			assert.NotContains(t, got, token, "%s leaks the token", tc.attr)
+			assert.NotContains(t, got, apiKey, "%s leaks the api key", tc.attr)
+			assert.Contains(t, got, tc.wantMark, "%s is missing the marker", tc.attr)
+		})
+	}
+	assert.Contains(t, attrs["gen_ai.tool.call.arguments"], "deploy.sh", "non-secret argument dropped")
 }

--- a/plugins/agento11y/internal/agents/copilot/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/copilot/mapper/mapper.go
@@ -24,10 +24,13 @@ var errGitHubCopilot = errors.New("copilot_error")
 const AgentName = "copilot"
 
 type Inputs struct {
-	Fragment       *fragment.Fragment
-	Session        *fragment.Session
-	ContentCapture agento11y.ContentCaptureMode
-	UserIDOverride string
+	Fragment *fragment.Fragment
+	Session  *fragment.Session
+	// SkipPromptRedaction exports the user prompt without redaction. The zero
+	// value redacts; envconfig.ResolveRedactInput owns the policy.
+	SkipPromptRedaction bool
+	ContentCapture      agento11y.ContentCaptureMode
+	UserIDOverride      string
 	// AgentName overrides the exported agent identity. Blank means "copilot".
 	AgentName string
 	Now       time.Time
@@ -141,7 +144,7 @@ func Map(in Inputs) Mapped {
 
 	tools := buildToolDefinitions(frag.Tools)
 	tags := buildTags(frag, in.Session)
-	input, output := buildMessages(frag, payloadMode)
+	input, output := buildMessages(frag, payloadMode, in.SkipPromptRedaction)
 	stopReason := strings.TrimSpace(frag.StopReason)
 	if stopReason == "" {
 		stopReason = "completed"
@@ -281,7 +284,7 @@ func derefInt64(v *int64) int64 {
 	return *v
 }
 
-func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode) (input, output []agento11y.Message) {
+func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode, skipPromptRedaction bool) (input, output []agento11y.Message) {
 	mode = mapperutil.NormalizePayloadContentMode(mode)
 	red := redact.New()
 	if mode != agento11y.ContentCaptureModeMetadataOnly {
@@ -290,7 +293,10 @@ func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode) (
 			prompt = strings.TrimSpace(frag.InitialPrompt)
 		}
 		if prompt != "" {
-			input = append(input, agento11y.UserTextMessage(red.Redact(prompt)))
+			if !skipPromptRedaction {
+				prompt = red.Prompt(prompt)
+			}
+			input = append(input, agento11y.UserTextMessage(prompt))
 		}
 	}
 
@@ -301,7 +307,7 @@ func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode) (
 		}
 		call := agento11y.ToolCall{ID: t.ToolUseID, Name: t.ToolName}
 		if mode == agento11y.ContentCaptureModeFull && len(t.ToolInput) > 0 {
-			call.InputJSON = red.RedactJSON(t.ToolInput)
+			call.InputJSON = red.ToolPayloadJSON(t.ToolInput)
 		}
 		output = append(output, agento11y.Message{Role: agento11y.RoleAssistant, Parts: []agento11y.Part{agento11y.ToolCallPart(call)}})
 		if mode == agento11y.ContentCaptureModeMetadataOnly {
@@ -310,16 +316,16 @@ func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode) (
 		result := agento11y.ToolResult{ToolCallID: t.ToolUseID, Name: t.ToolName, IsError: t.Status == "error"}
 		if mode == agento11y.ContentCaptureModeFull {
 			if len(t.ToolResponse) > 0 {
-				result.ContentJSON = red.RedactJSON(t.ToolResponse)
+				result.ContentJSON = red.ToolPayloadJSON(t.ToolResponse)
 			} else if t.ErrorMessage != "" {
-				result.Content = red.Redact(t.ErrorMessage)
+				result.Content = red.ToolPayload(t.ErrorMessage)
 			}
 		}
 		input = append(input, agento11y.Message{Role: agento11y.RoleTool, Parts: []agento11y.Part{agento11y.ToolResultPart(result)}})
 	}
 	if mode != agento11y.ContentCaptureModeMetadataOnly {
 		if assistantText := strings.TrimSpace(frag.AssistantText); assistantText != "" {
-			output = append(output, agento11y.AssistantTextMessage(red.Redact(assistantText)))
+			output = append(output, agento11y.AssistantTextMessage(red.AssistantText(assistantText)))
 		}
 	}
 	return input, output

--- a/plugins/agento11y/internal/agents/copilot/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/copilot/mapper/mapper_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,11 +15,15 @@ import (
 
 var fixedTime = time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
 
+// testSecret matches a tier-1 redaction pattern, so any field that carries it
+// must come back scrubbed unless the test says otherwise.
+const testSecret = "glc_abcdefghijklmnopqrstuvwxyz"
+
 func basicFragment() *fragment.Fragment {
 	return &fragment.Fragment{
 		SessionID:     "sess-1",
 		TurnID:        "turn-000001",
-		Prompt:        "my token is glc_abcdefghijklmnopqrstuvwxyz",
+		Prompt:        "my token is " + testSecret,
 		InitialPrompt: "fallback",
 		Tools: []fragment.ToolRecord{
 			{ToolName: "bash", ToolUseID: "tool-1", ToolInput: json.RawMessage(`{"cmd":"echo hi"}`), ToolResponse: json.RawMessage(`{"text_result_for_llm":"ok"}`), Status: "completed"},
@@ -29,59 +34,82 @@ func basicFragment() *fragment.Fragment {
 }
 
 func TestMapFullModeIncludesRedactedPromptAndToolContent(t *testing.T) {
-	frag := basicFragment()
-	frag.Model = "gpt-5.4"
-	frag.AgentVersion = "1.0.48"
-	frag.MessageID = "msg-1"
-	frag.RequestID = "req-1"
-	frag.InteractionID = "int-1"
-	frag.NativeTurnID = "4"
-	frag.ReasoningEffort = "medium"
-	frag.AssistantText = "assistant secret glc_abcdefghijklmnopqrstuvwxyz"
-	outTokens := int64(12)
-	frag.TokenUsage.OutputTokens = &outTokens
-	got := Map(Inputs{
-		Fragment:       frag,
-		ContentCapture: agento11y.ContentCaptureModeFull,
-		Now:            fixedTime,
-	})
-	if len(got.Generation.Input) == 0 {
-		t.Fatal("expected input messages")
+	tests := []struct {
+		name                string
+		skipPromptRedaction bool
+		wantPromptRedacted  bool
+	}{
+		{name: "redacts the prompt by default", wantPromptRedacted: true},
+		{name: "opt-out exports the prompt unredacted", skipPromptRedaction: true, wantPromptRedacted: false},
 	}
-	userText := got.Generation.Input[0].Parts[0].Text
-	if userText == "" || userText == "my token is glc_abcdefghijklmnopqrstuvwxyz" {
-		t.Fatalf("user text not redacted: %q", userText)
-	}
-	if len(got.Generation.Output) == 0 || got.Generation.Output[0].Parts[0].ToolCall == nil {
-		t.Fatalf("expected tool call output: %+v", got.Generation.Output)
-	}
-	if len(got.Generation.Output[0].Parts[0].ToolCall.InputJSON) == 0 {
-		t.Fatal("expected tool input in full mode")
-	}
-	if got.Generation.Model.Provider != "openai" {
-		t.Fatalf("Model.Provider = %q", got.Generation.Model.Provider)
-	}
-	if got.Generation.ResponseModel != "gpt-5.4" {
-		t.Fatalf("ResponseModel = %q", got.Generation.ResponseModel)
-	}
-	if got.Generation.ResponseID != "req-1" {
-		t.Fatalf("ResponseID = %q", got.Generation.ResponseID)
-	}
-	if got.Generation.AgentVersion != "1.0.48" {
-		t.Fatalf("AgentVersion = %q", got.Generation.AgentVersion)
-	}
-	if got.Generation.Usage.OutputTokens != 12 || got.Generation.Usage.TotalTokens != 12 {
-		t.Fatalf("Usage = %+v", got.Generation.Usage)
-	}
-	last := got.Generation.Output[len(got.Generation.Output)-1]
-	if len(last.Parts) == 0 || last.Parts[0].Text == "" || last.Parts[0].Text == frag.AssistantText {
-		t.Fatalf("assistant text missing or unredacted: %+v", got.Generation.Output)
-	}
-	if got.Generation.Metadata["copilot.native_turn_id"] != "4" {
-		t.Fatalf("native turn id metadata missing: %+v", got.Generation.Metadata)
-	}
-	if got.Generation.Metadata["copilot.request_id"] != "req-1" {
-		t.Fatalf("request id metadata missing: %+v", got.Generation.Metadata)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			frag := basicFragment()
+			frag.Model = "gpt-5.4"
+			frag.AgentVersion = "1.0.48"
+			frag.MessageID = "msg-1"
+			frag.RequestID = "req-1"
+			frag.InteractionID = "int-1"
+			frag.NativeTurnID = "4"
+			frag.ReasoningEffort = "medium"
+			frag.AssistantText = "assistant secret " + testSecret + " PASSWORD=hunter2"
+			outTokens := int64(12)
+			frag.TokenUsage.OutputTokens = &outTokens
+			got := Map(Inputs{
+				Fragment:            frag,
+				ContentCapture:      agento11y.ContentCaptureModeFull,
+				SkipPromptRedaction: tt.skipPromptRedaction,
+				Now:                 fixedTime,
+			})
+			if len(got.Generation.Input) == 0 {
+				t.Fatal("expected input messages")
+			}
+			userText := got.Generation.Input[0].Parts[0].Text
+			if userText == "" {
+				t.Fatal("expected user text in full mode")
+			}
+			if gotRedacted := !strings.Contains(userText, testSecret); gotRedacted != tt.wantPromptRedacted {
+				t.Fatalf("prompt redacted = %v, want %v: %q", gotRedacted, tt.wantPromptRedacted, userText)
+			}
+			if len(got.Generation.Output) == 0 || got.Generation.Output[0].Parts[0].ToolCall == nil {
+				t.Fatalf("expected tool call output: %+v", got.Generation.Output)
+			}
+			if len(got.Generation.Output[0].Parts[0].ToolCall.InputJSON) == 0 {
+				t.Fatal("expected tool input in full mode")
+			}
+			if got.Generation.Model.Provider != "openai" {
+				t.Fatalf("Model.Provider = %q", got.Generation.Model.Provider)
+			}
+			if got.Generation.ResponseModel != "gpt-5.4" {
+				t.Fatalf("ResponseModel = %q", got.Generation.ResponseModel)
+			}
+			if got.Generation.ResponseID != "req-1" {
+				t.Fatalf("ResponseID = %q", got.Generation.ResponseID)
+			}
+			if got.Generation.AgentVersion != "1.0.48" {
+				t.Fatalf("AgentVersion = %q", got.Generation.AgentVersion)
+			}
+			if got.Generation.Usage.OutputTokens != 12 || got.Generation.Usage.TotalTokens != 12 {
+				t.Fatalf("Usage = %+v", got.Generation.Usage)
+			}
+			// The opt-out covers the prompt only: assistant text stays redacted.
+			last := got.Generation.Output[len(got.Generation.Output)-1]
+			if len(last.Parts) == 0 || last.Parts[0].Text == "" || strings.Contains(last.Parts[0].Text, testSecret) {
+				t.Fatalf("assistant text missing or unredacted: %+v", got.Generation.Output)
+			}
+			// Assistant prose gets tier 1 only, so an env-style pair in a
+			// sentence survives. The prompt takes tier 2 as well.
+			if !strings.Contains(last.Parts[0].Text, "PASSWORD=hunter2") {
+				t.Fatalf("assistant text got tier 2: %q", last.Parts[0].Text)
+			}
+			if got.Generation.Metadata["copilot.native_turn_id"] != "4" {
+				t.Fatalf("native turn id metadata missing: %+v", got.Generation.Metadata)
+			}
+			if got.Generation.Metadata["copilot.request_id"] != "req-1" {
+				t.Fatalf("request id metadata missing: %+v", got.Generation.Metadata)
+			}
+		})
 	}
 }
 

--- a/plugins/agento11y/internal/agents/cursor/config/config.go
+++ b/plugins/agento11y/internal/agents/cursor/config/config.go
@@ -25,7 +25,10 @@ import (
 type Config struct {
 	ContentCapture agento11y.ContentCaptureMode
 	UserIDOverride string
-	Debug          bool
+	// SkipPromptRedaction exports the user prompt without redaction. Set from
+	// AGENTO11Y_REDACT_INPUT_MESSAGES=false, so the zero value redacts.
+	SkipPromptRedaction bool
+	Debug               bool
 	// AgentName is the identity every generation and guard request reports.
 	// Load resolves it from AGENTO11Y_AGENT_NAME, then SIGIL_AGENT_NAME, and
 	// falls back to "cursor". Read it through Agent.
@@ -69,9 +72,10 @@ func LoadDotenv(path string, logger *log.Logger) map[string]string {
 // ApplyEnv first so dotenv-only values are reflected in the OS env.
 func Load(logger *log.Logger) Config {
 	return Config{
-		ContentCapture: envconfig.ResolveContentMode(logger),
-		UserIDOverride: envconfig.Getenv("USER_ID"),
-		Debug:          envconfig.ParseBool(envconfig.Getenv("DEBUG")),
-		AgentName:      envconfig.ResolveAgentName(mapper.AgentName),
+		ContentCapture:      envconfig.ResolveContentMode(logger),
+		UserIDOverride:      envconfig.Getenv("USER_ID"),
+		SkipPromptRedaction: !envconfig.ResolveRedactInput(logger),
+		Debug:               envconfig.ParseBool(envconfig.Getenv("DEBUG")),
+		AgentName:           envconfig.ResolveAgentName(mapper.AgentName),
 	}
 }

--- a/plugins/agento11y/internal/agents/cursor/config/config_test.go
+++ b/plugins/agento11y/internal/agents/cursor/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"bytes"
+	"log"
 	"testing"
 
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/mapper"
@@ -23,6 +25,30 @@ func TestConfig_Agent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := (Config{AgentName: tt.agentName}).Agent(); got != tt.want {
 				t.Errorf("Agent() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoad_SkipPromptRedaction(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "redacts when unset", raw: "", want: false},
+		{name: "opts out on false", raw: "false", want: true},
+		{name: "redacts on true", raw: "true", want: false},
+		{name: "redacts on a typo", raw: "flase", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AGENTO11Y_REDACT_INPUT_MESSAGES", tt.raw)
+			t.Setenv("SIGIL_REDACT_INPUT_MESSAGES", "")
+			cfg := Load(log.New(&bytes.Buffer{}, "", 0))
+			if cfg.SkipPromptRedaction != tt.want {
+				t.Errorf("SkipPromptRedaction = %t, want %t", cfg.SkipPromptRedaction, tt.want)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/agents/cursor/hook/emit.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/emit.go
@@ -130,8 +130,8 @@ func emitToolSpans(ctx context.Context, client *agento11y.Client, frag *fragment
 		})
 
 		end := agento11y.ToolExecutionEnd{CompletedAt: completedAt}
-		end.Arguments = red.RedactJSONForText(t.ToolInput)
-		end.Result = red.RedactJSONForText(t.ToolOutput)
+		end.Arguments = red.ToolPayloadText(t.ToolInput)
+		end.Result = red.ToolPayloadText(t.ToolOutput)
 		if t.Status == "error" {
 			toolRec.SetExecError(emit.ToolError(t.ErrorMessage))
 		}

--- a/plugins/agento11y/internal/agents/cursor/hook/sessionend.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/sessionend.go
@@ -110,13 +110,14 @@ func emitOneStranded(
 	}
 
 	mapped := mapper.MapFragment(mapper.Inputs{
-		Fragment:       frag,
-		Session:        session,
-		Stop:           stop,
-		ContentCapture: cfg.ContentCapture,
-		UserIDOverride: cfg.UserIDOverride,
-		AgentName:      cfg.Agent(),
-		Now:            time.Now(),
+		Fragment:            frag,
+		Session:             session,
+		Stop:                stop,
+		ContentCapture:      cfg.ContentCapture,
+		UserIDOverride:      cfg.UserIDOverride,
+		SkipPromptRedaction: cfg.SkipPromptRedaction,
+		AgentName:           cfg.Agent(),
+		Now:                 time.Now(),
 	})
 
 	if err := emitGeneration(ctx, client, frag, mapped, logger); err != nil {

--- a/plugins/agento11y/internal/agents/cursor/hook/stop.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/stop.go
@@ -89,13 +89,14 @@ func Stop(p Payload, cfg config.Config, logger *log.Logger) {
 	client := buildClient(p, session, cfg, providers, logger)
 
 	mapped := mapper.MapFragment(mapper.Inputs{
-		Fragment:       frag,
-		Session:        session,
-		Stop:           &mapper.StopInput{Status: p.Status, Error: frag.PendingStop.Error},
-		ContentCapture: cfg.ContentCapture,
-		UserIDOverride: cfg.UserIDOverride,
-		AgentName:      cfg.Agent(),
-		Now:            time.Now(),
+		Fragment:            frag,
+		Session:             session,
+		Stop:                &mapper.StopInput{Status: p.Status, Error: frag.PendingStop.Error},
+		ContentCapture:      cfg.ContentCapture,
+		UserIDOverride:      cfg.UserIDOverride,
+		SkipPromptRedaction: cfg.SkipPromptRedaction,
+		AgentName:           cfg.Agent(),
+		Now:                 time.Now(),
 	})
 
 	if err := emitGeneration(ctx, client, frag, mapped, logger); err != nil {

--- a/plugins/agento11y/internal/agents/cursor/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/cursor/mapper/mapper.go
@@ -57,6 +57,9 @@ type Inputs struct {
 	Stop           *StopInput
 	ContentCapture agento11y.ContentCaptureMode
 	UserIDOverride string
+	// SkipPromptRedaction exports the user prompt without redaction. The zero
+	// value redacts; envconfig.ResolveRedactInput owns the policy.
+	SkipPromptRedaction bool
 	// AgentName overrides the exported agent identity. Blank means "cursor".
 	AgentName string
 	Now       time.Time
@@ -119,9 +122,7 @@ func MapFragment(in Inputs) Mapped {
 		cursorVersion = in.Session.CursorVersion
 		userEmail = in.Session.UserEmail
 		isBackgroundAgent = in.Session.IsBackgroundAgent
-		// Tier 1 only. The title is a truncated first prompt, so tier 2's
-		// `KEY: value` heuristic would over-redact ordinary human text.
-		conversationTitle = red.RedactLightweight(in.Session.ConversationTitle)
+		conversationTitle = red.Title(in.Session.ConversationTitle)
 	}
 
 	tagMap := tags.Build(tags.BuiltinInputs{
@@ -159,7 +160,7 @@ func MapFragment(in Inputs) Mapped {
 		ContentCapture:    in.ContentCapture,
 	}
 
-	input, output := buildMessages(frag, in.ContentCapture, red)
+	input, output := buildMessages(frag, in.ContentCapture, red, in.SkipPromptRedaction)
 
 	gen := agento11y.Generation{
 		ID:                frag.GenerationID,
@@ -226,13 +227,13 @@ func extractCallError(stop *StopInput, red *redact.Redactor) error {
 	}
 	var asString string
 	if err := json.Unmarshal(stop.Error, &asString); err == nil && asString != "" {
-		return errors.New(red.RedactLightweight(asString))
+		return errors.New(red.ErrorText(asString))
 	}
 	var asObj struct {
 		Message string `json:"message"`
 	}
 	if err := json.Unmarshal(stop.Error, &asObj); err == nil && asObj.Message != "" {
-		return errors.New(red.RedactLightweight(asObj.Message))
+		return errors.New(red.ErrorText(asObj.Message))
 	}
 	return errCursorStop
 }
@@ -267,7 +268,7 @@ func buildToolDefinitions(tools []fragment.ToolRecord) []agento11y.ToolDefinitio
 	return mapperutil.SortedToolDefinitions(names)
 }
 
-func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode, red *redact.Redactor) (input, output []agento11y.Message) {
+func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode, red *redact.Redactor, skipPromptRedaction bool) (input, output []agento11y.Message) {
 	// Normalize so the rest of this function only deals with the three real
 	// content-gating modes. envconfig.ResolveContentMode does this at the
 	// config layer too, but mappers re-apply it for callers (including tests)
@@ -276,12 +277,15 @@ func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode, r
 	// span exposure; the gRPC payload buildMessages produces is identical.
 	mode = mapperutil.NormalizePayloadContentMode(mode)
 
-	// User prompt → user input message. Dropped in metadata-only mode.
 	if mode != agento11y.ContentCaptureModeMetadataOnly && strings.TrimSpace(frag.UserPrompt) != "" {
+		prompt := frag.UserPrompt
+		if !skipPromptRedaction {
+			prompt = red.Prompt(prompt)
+		}
 		input = append(input, agento11y.Message{
 			Role: agento11y.RoleUser,
 			Parts: []agento11y.Part{
-				agento11y.TextPart(red.Redact(frag.UserPrompt)),
+				agento11y.TextPart(prompt),
 			},
 		})
 	}
@@ -301,7 +305,7 @@ func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode, r
 					Name: t.ToolName,
 					InputJSON: func() []byte {
 						if mode == agento11y.ContentCaptureModeFull {
-							return red.RedactJSON(t.ToolInput)
+							return red.ToolPayloadJSON(t.ToolInput)
 						}
 						return nil
 					}(),
@@ -326,7 +330,7 @@ func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode, r
 						ToolResult: &agento11y.ToolResult{
 							ToolCallID:  t.ToolUseID,
 							Name:        t.ToolName,
-							ContentJSON: red.RedactJSON(t.ToolOutput),
+							ContentJSON: red.ToolPayloadJSON(t.ToolOutput),
 							IsError:     t.Status == "error",
 						},
 					},
@@ -364,7 +368,7 @@ func buildMessages(frag *fragment.Fragment, mode agento11y.ContentCaptureMode, r
 		if strings.TrimSpace(text) != "" {
 			output = append(output, agento11y.Message{
 				Role:  agento11y.RoleAssistant,
-				Parts: []agento11y.Part{agento11y.TextPart(red.Redact(text))},
+				Parts: []agento11y.Part{agento11y.TextPart(red.AssistantText(text))},
 			})
 		}
 	}

--- a/plugins/agento11y/internal/agents/cursor/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/cursor/mapper/mapper_test.go
@@ -291,42 +291,97 @@ func TestMapFragment_RedactsSecrets(t *testing.T) {
 	})
 }
 
-// TestMapFragment_RedactionTiers pins the per-field tier split. The title
-// gets tier 1 only; the prompt and assistant text get tier 2 as well.
-// Without these cases either half can be swapped for the other with no test
-// turning red, because every other secret in the package is a tier-1 token
-// or a sensitive JSON key.
+func TestMapFragment_UserPromptRedactionOptOut(t *testing.T) {
+	const token = testToken
+
+	tests := []struct {
+		name                string
+		skipPromptRedaction bool
+		wantPrompt          string
+	}{
+		{name: "redacts the prompt by default", wantPrompt: "deploy using [REDACTED:grafana-cloud-token]"},
+		{name: "opt-out exports the prompt unredacted", skipPromptRedaction: true, wantPrompt: "deploy using " + token},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MapFragment(Inputs{
+				Fragment: &fragment.Fragment{
+					ConversationID: "conv-1",
+					GenerationID:   "gen-1",
+					UserPrompt:     "deploy using " + token,
+					Assistant:      []fragment.AssistantSegment{{Text: "I used " + token}},
+				},
+				Session:             &fragment.Session{ConversationTitle: "deploy using " + token},
+				ContentCapture:      agento11y.ContentCaptureModeFull,
+				SkipPromptRedaction: tt.skipPromptRedaction,
+				Now:                 fixedTime,
+			})
+
+			if len(got.Generation.Input) == 0 || len(got.Generation.Input[0].Parts) == 0 {
+				t.Fatalf("expected a user message: %+v", got.Generation.Input)
+			}
+			if prompt := got.Generation.Input[0].Parts[0].Text; prompt != tt.wantPrompt {
+				t.Errorf("prompt = %q, want %q", prompt, tt.wantPrompt)
+			}
+
+			// The opt-out covers the prompt only.
+			if len(got.Generation.Output) == 0 || len(got.Generation.Output[0].Parts) == 0 {
+				t.Fatalf("expected an assistant message: %+v", got.Generation.Output)
+			}
+			if text := got.Generation.Output[0].Parts[0].Text; strings.Contains(text, token) {
+				t.Errorf("assistant text leaks the raw token: %s", text)
+			}
+			if title := got.Generation.ConversationTitle; strings.Contains(title, token) {
+				t.Errorf("conversation title leaks the raw token: %s", title)
+			}
+		})
+	}
+}
+
+// TestMapFragment_RedactionTiers pins the per-field tier split: the prompt
+// gets tier 1 + tier 2, the title and assistant text get tier 1 only.
+// Without these cases one field can be swapped for the other's tier with no
+// test turning red, because every other secret in the package is a tier-1
+// token or a sensitive JSON key.
 func TestMapFragment_RedactionTiers(t *testing.T) {
 	cases := []struct {
-		name       string
-		title      string
-		text       string
-		wantTitle  string
-		wantPrompt string
+		name          string
+		title         string
+		text          string
+		wantTitle     string
+		wantPrompt    string
+		wantAssistant string
 	}{
 		{
 			// Tier 2's `KEY: value` heuristic would swallow the rest of the
 			// line. Cursor titles are truncated first prompts, so ordinary
 			// text like this is the common case.
-			name:       "title survives the tier 2 heuristic",
-			title:      "fix the API key: rotation script",
-			text:       "hello",
-			wantTitle:  "fix the API key: rotation script",
-			wantPrompt: "hello",
+			name:          "title survives the tier 2 heuristic",
+			title:         "fix the API key: rotation script",
+			text:          "hello",
+			wantTitle:     "fix the API key: rotation script",
+			wantPrompt:    "hello",
+			wantAssistant: "hello",
 		},
 		{
-			name:       "tier 1 token is redacted everywhere",
-			title:      "deploy using " + testToken,
-			text:       "deploy using " + testToken,
-			wantTitle:  "deploy using [REDACTED:grafana-cloud-token]",
-			wantPrompt: "deploy using [REDACTED:grafana-cloud-token]",
+			name:          "tier 1 token is redacted everywhere",
+			title:         "deploy using " + testToken,
+			text:          "deploy using " + testToken,
+			wantTitle:     "deploy using [REDACTED:grafana-cloud-token]",
+			wantPrompt:    "deploy using [REDACTED:grafana-cloud-token]",
+			wantAssistant: "deploy using [REDACTED:grafana-cloud-token]",
 		},
 		{
-			name:       "prompt and assistant text get tier 2",
-			title:      "run the deploy",
-			text:       "run with PASSWORD=hunter2",
-			wantTitle:  "run the deploy",
-			wantPrompt: "run with PASSWORD=[REDACTED:env-secret-value]",
+			// The prompt is where a human pastes a config file, so it takes
+			// tier 2. Assistant text is model prose and keeps tier 1, like
+			// the title.
+			name:          "only the prompt gets tier 2",
+			title:         "run with PASSWORD=hunter2",
+			text:          "run with PASSWORD=hunter2",
+			wantTitle:     "run with PASSWORD=hunter2",
+			wantPrompt:    "run with PASSWORD=[REDACTED:env-secret-value]",
+			wantAssistant: "run with PASSWORD=hunter2",
 		},
 	}
 
@@ -364,8 +419,8 @@ func TestMapFragment_RedactionTiers(t *testing.T) {
 			if prompt != tc.wantPrompt {
 				t.Errorf("prompt = %q; want %q", prompt, tc.wantPrompt)
 			}
-			if assistant != tc.wantPrompt {
-				t.Errorf("assistant text = %q; want %q", assistant, tc.wantPrompt)
+			if assistant != tc.wantAssistant {
+				t.Errorf("assistant text = %q; want %q", assistant, tc.wantAssistant)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/agents/vibe/hook/handlers.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/handlers.go
@@ -87,6 +87,7 @@ func PostAgentTurn(ctx context.Context, p Payload, logger *log.Logger) {
 	}
 
 	contentMode := envconfig.ResolveContentMode(logger)
+	skipPromptRedaction := !envconfig.ResolveRedactInput(logger)
 
 	// vibe persists the post_agent_turn count as stats.steps. Using it
 	// (rather than a counter in state) keeps the generation ID stable
@@ -120,16 +121,17 @@ func PostAgentTurn(ctx context.Context, p Payload, logger *log.Logger) {
 	}
 
 	mapped := mapper.Map(mapper.Inputs{
-		SessionID:          p.SessionID,
-		CWD:                p.CWD,
-		ParentSessionID:    parentSessionID,
-		ParentGenerationID: parentGenID,
-		Lines:              lines,
-		Meta:               m,
-		PriorState:         prior,
-		PriorStateFound:    priorFound,
-		ContentCapture:     contentMode,
-		AgentName:          envconfig.ResolveAgentName(mapper.AgentName),
+		SessionID:           p.SessionID,
+		CWD:                 p.CWD,
+		ParentSessionID:     parentSessionID,
+		ParentGenerationID:  parentGenID,
+		Lines:               lines,
+		Meta:                m,
+		PriorState:          prior,
+		PriorStateFound:     priorFound,
+		ContentCapture:      contentMode,
+		SkipPromptRedaction: skipPromptRedaction,
+		AgentName:           envconfig.ResolveAgentName(mapper.AgentName),
 	}, turnSeq)
 
 	// A meta.json without session_cost carries no new baseline, so keep the

--- a/plugins/agento11y/internal/agents/vibe/hook/handlers_test.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/handlers_test.go
@@ -345,6 +345,72 @@ func TestPostAgentTurn_SessionCostSnapshot(t *testing.T) {
 	}
 }
 
+// TestPostAgentTurn_PromptRedactionWiring pins AGENTO11Y_REDACT_INPUT_MESSAGES
+// from the environment through to the exported body. The mapper tests cover
+// the flag itself; this one covers the wire between them.
+func TestPostAgentTurn_PromptRedactionWiring(t *testing.T) {
+	const secret = "glc_abcdefghijklmnopqrstuvwxyz"
+
+	tests := []struct {
+		name            string
+		raw             string
+		wantPromptInRaw bool
+	}{
+		{name: "redacts by default", raw: "", wantPromptInRaw: false},
+		{name: "opt-out exports the prompt unredacted", raw: "false", wantPromptInRaw: true},
+		{name: "typo keeps redaction on", raw: "flase", wantPromptInRaw: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				mu   sync.Mutex
+				body []byte
+			)
+			srv := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				b, _ := io.ReadAll(r.Body)
+				mu.Lock()
+				body = b
+				mu.Unlock()
+				writeAcceptedGenerationResponse(t, w, b)
+			}))
+			t.Cleanup(srv.Close)
+
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			t.Setenv("SIGIL_ENDPOINT", srv.URL)
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
+			t.Setenv("SIGIL_CONTENT_CAPTURE_MODE", "full")
+			t.Setenv("SIGIL_REDACT_INPUT_MESSAGES", "")
+			t.Setenv("AGENTO11Y_REDACT_INPUT_MESSAGES", tt.raw)
+
+			dir := t.TempDir()
+			must(t, copyFile(filepath.Join("..", "testdata", "meta.json"), filepath.Join(dir, "meta.json")))
+			tp := filepath.Join(dir, "messages.jsonl")
+			lines := `{"role":"user","content":"my token is ` + secret + `","message_id":"m1"}` + "\n" +
+				`{"role":"assistant","content":"assistant saw ` + secret + `","message_id":"m2"}` + "\n"
+			must(t, os.WriteFile(tp, []byte(lines), 0o644))
+
+			logger := log.New(io.Discard, "", 0)
+			PostAgentTurn(context.Background(), Payload{HookEventName: "post_agent_turn", SessionID: "sess-redaction", TranscriptPath: tp}, logger)
+
+			mu.Lock()
+			got := string(body)
+			mu.Unlock()
+			if got == "" {
+				t.Fatal("expected an export request")
+			}
+			if has := strings.Contains(got, "my token is "+secret); has != tt.wantPromptInRaw {
+				t.Errorf("prompt unredacted in export = %v, want %v: %s", has, tt.wantPromptInRaw, got)
+			}
+			// The flag covers the prompt only.
+			if strings.Contains(got, "assistant saw "+secret) {
+				t.Errorf("assistant text lost its redaction: %s", got)
+			}
+		})
+	}
+}
+
 func TestPostAgentTurn_MissingPayloadFields(t *testing.T) {
 	logger := log.New(io.Discard, "", 0)
 	PostAgentTurn(context.Background(), Payload{HookEventName: "post_agent_turn"}, logger)

--- a/plugins/agento11y/internal/agents/vibe/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/vibe/mapper/mapper.go
@@ -10,6 +10,7 @@ package mapper
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"maps"
 	"slices"
 	"strconv"
@@ -52,6 +53,9 @@ type Inputs struct {
 	PriorState         state.Session
 	PriorStateFound    bool
 	ContentCapture     agento11y.ContentCaptureMode
+	// SkipPromptRedaction exports the user prompt without redaction. The zero
+	// value redacts; envconfig.ResolveRedactInput owns the policy.
+	SkipPromptRedaction bool
 	// AgentName overrides the exported agent identity. Blank means
 	// "mistral-vibe".
 	AgentName string
@@ -88,6 +92,7 @@ func Map(in Inputs, turnSeq int) Mapped {
 	if mode == agento11y.ContentCaptureModeDefault {
 		mode = agento11y.ContentCaptureModeMetadataOnly
 	}
+	red := redact.New()
 
 	provider, apiName := in.Meta.ActiveModelRef()
 	displayName := strings.TrimSpace(in.Meta.Config.ActiveModel)
@@ -144,20 +149,24 @@ func Map(in Inputs, turnSeq int) Mapped {
 	tools := buildToolDefinitions(in.Meta.ToolsAvailable)
 	systemPrompt := ""
 	if mode != agento11y.ContentCaptureModeMetadataOnly {
-		systemPrompt = strings.TrimSpace(in.Meta.SystemPrompt.Content)
+		systemPrompt = red.SystemPrompt(strings.TrimSpace(in.Meta.SystemPrompt.Content))
 	}
+	// vibe derives the title from the first prompt, so it is prose and gets
+	// tier 1 only. The generation carries it whatever the capture mode says;
+	// the SDK drops it in metadata_only.
+	title := red.Title(in.Meta.Title)
 
 	// On a mid-session state loss the handler reads the whole transcript
 	// from offset zero and usage falls back to the last turn (see
 	// turnUsage). Map only the latest turn's messages so the single emitted
 	// generation does not bundle the entire history under last-turn usage.
 	lines := linesForMapping(in.Lines, in.Meta.Stats, in.PriorStateFound)
-	input, output, thinkingEnabled := buildMessages(lines, mode)
+	input, output, thinkingEnabled := buildMessages(lines, mode, red, in.SkipPromptRedaction)
 
 	start := agento11y.GenerationStart{
 		ID:                  id,
 		ConversationID:      conversationID,
-		ConversationTitle:   in.Meta.Title,
+		ConversationTitle:   title,
 		AgentName:           in.agent(),
 		Mode:                agento11y.GenerationModeSync,
 		OperationName:       "generateText",
@@ -174,7 +183,7 @@ func Map(in Inputs, turnSeq int) Mapped {
 	gen := agento11y.Generation{
 		ID:                  id,
 		ConversationID:      conversationID,
-		ConversationTitle:   in.Meta.Title,
+		ConversationTitle:   title,
 		AgentName:           in.agent(),
 		Mode:                agento11y.GenerationModeSync,
 		OperationName:       "generateText",
@@ -348,14 +357,23 @@ func latestTurnLines(lines []transcript.Line) []transcript.Line {
 // In MetadataOnly mode all message text, reasoning, and tool
 // arguments/results are dropped but the structural shape (assistant called
 // tool X, tool returned, assistant replied) is preserved.
-func buildMessages(lines []transcript.Line, mode agento11y.ContentCaptureMode) (input, output []agento11y.Message, thinkingEnabled *bool) {
-	red := redact.New()
+func buildMessages(lines []transcript.Line, mode agento11y.ContentCaptureMode, red *redact.Redactor, skipPromptRedaction bool) (input, output []agento11y.Message, thinkingEnabled *bool) {
 	contentMode := mode == agento11y.ContentCaptureModeFull || mode == agento11y.ContentCaptureModeNoToolContent
-	cleanText := func(s string) string {
+	cleanProse := func(s string) string {
 		if contentMode {
-			return red.Redact(s)
+			return red.AssistantText(s)
 		}
 		return ""
+	}
+	// The redaction opt-out does not export a prompt the capture mode drops.
+	cleanPrompt := func(s string) string {
+		if !contentMode {
+			return ""
+		}
+		if skipPromptRedaction {
+			return s
+		}
+		return red.Prompt(s)
 	}
 	anyReasoning := false
 	for _, l := range lines {
@@ -370,7 +388,7 @@ func buildMessages(lines []transcript.Line, mode agento11y.ContentCaptureMode) (
 			if mode == agento11y.ContentCaptureModeMetadataOnly {
 				continue
 			}
-			input = append(input, agento11y.UserTextMessage(cleanText(l.Content)))
+			input = append(input, agento11y.UserTextMessage(cleanPrompt(l.Content)))
 		case "assistant":
 			// Assistant turns come in two shapes: a tool-call message
 			// (no Content, ToolCalls populated) or a final text message
@@ -382,17 +400,16 @@ func buildMessages(lines []transcript.Line, mode agento11y.ContentCaptureMode) (
 			var parts []agento11y.Part
 			if contentMode {
 				if r := strings.TrimSpace(l.ReasoningContent); r != "" {
-					parts = append(parts, agento11y.ThinkingPart(red.Redact(l.ReasoningContent)))
+					parts = append(parts, agento11y.ThinkingPart(red.Thinking(l.ReasoningContent)))
 				}
 			}
 			if len(l.ToolCalls) > 0 {
 				for _, tc := range l.ToolCalls {
 					call := agento11y.ToolCall{ID: tc.ID, Name: tc.Function.Name}
 					if mode == agento11y.ContentCaptureModeFull && tc.Function.Arguments != "" {
-						// vibe encodes function.arguments as a JSON-encoded
-						// string already, so the raw bytes are valid JSON and
-						// go straight into InputJSON without re-encoding.
-						call.InputJSON = []byte(tc.Function.Arguments)
+						// vibe encodes function.arguments as JSON already, so
+						// the raw bytes go to the redactor as-is.
+						call.InputJSON = red.ToolPayloadJSON(json.RawMessage(tc.Function.Arguments))
 					}
 					parts = append(parts, agento11y.ToolCallPart(call))
 				}
@@ -410,7 +427,7 @@ func buildMessages(lines []transcript.Line, mode agento11y.ContentCaptureMode) (
 			if mode == agento11y.ContentCaptureModeMetadataOnly {
 				continue
 			}
-			parts = append(parts, agento11y.TextPart(cleanText(l.Content)))
+			parts = append(parts, agento11y.TextPart(cleanProse(l.Content)))
 			output = append(output, agento11y.Message{Role: agento11y.RoleAssistant, Parts: parts})
 		case "tool":
 			if mode == agento11y.ContentCaptureModeMetadataOnly {
@@ -430,7 +447,7 @@ func buildMessages(lines []transcript.Line, mode agento11y.ContentCaptureMode) (
 				Name:       l.Name,
 			}
 			if mode == agento11y.ContentCaptureModeFull {
-				result.Content = red.Redact(l.Content)
+				result.Content = red.ToolPayload(l.Content)
 			}
 			input = append(input, agento11y.Message{
 				Role:  agento11y.RoleTool,

--- a/plugins/agento11y/internal/agents/vibe/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/vibe/mapper/mapper_test.go
@@ -304,22 +304,26 @@ func TestMap_ContentCaptureModes(t *testing.T) {
 		// In MetadataOnly we still expect the structural assistant
 		// tool-call message (Agent Observability needs the call sequence to render
 		// the conversation), but no text content.
-		wantUserText      bool
-		wantAssistantText bool
-		wantToolArgs      bool
-		wantSystemPrompt  bool
+		skipPromptRedaction bool
+		wantUserText        bool
+		wantAssistantText   bool
+		wantToolArgs        bool
+		wantSystemPrompt    bool
 	}{
 		{name: "full", mode: agento11y.ContentCaptureModeFull, wantUserText: true, wantAssistantText: true, wantToolArgs: true, wantSystemPrompt: true},
 		{name: "no_tool_content", mode: agento11y.ContentCaptureModeNoToolContent, wantUserText: true, wantAssistantText: true, wantToolArgs: false, wantSystemPrompt: true},
 		{name: "metadata_only", mode: agento11y.ContentCaptureModeMetadataOnly, wantUserText: false, wantAssistantText: false, wantToolArgs: false, wantSystemPrompt: false},
+		// The redaction opt-out does not export a prompt the capture mode drops.
+		{name: "metadata_only with the redaction opt-out", mode: agento11y.ContentCaptureModeMetadataOnly, skipPromptRedaction: true, wantUserText: false, wantAssistantText: false, wantToolArgs: false, wantSystemPrompt: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := Map(Inputs{
-				SessionID:      "s",
-				Lines:          lines,
-				Meta:           m,
-				ContentCapture: tt.mode,
+				SessionID:           "s",
+				Lines:               lines,
+				Meta:                m,
+				ContentCapture:      tt.mode,
+				SkipPromptRedaction: tt.skipPromptRedaction,
 			}, m.Stats.Steps).Generation
 
 			var hasUserText, hasAssistantText, hasToolArgs bool
@@ -356,6 +360,148 @@ func TestMap_ContentCaptureModes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMap_UserPromptRedaction(t *testing.T) {
+	const secret = "glc_abcdefghijklmnopqrstuvwxyz"
+
+	tests := []struct {
+		name                string
+		skipPromptRedaction bool
+		wantPrompt          string
+	}{
+		{name: "redacts the prompt by default", wantPrompt: "my token is [REDACTED:grafana-cloud-token]"},
+		{name: "opt-out exports the prompt unredacted", skipPromptRedaction: true, wantPrompt: "my token is " + secret},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := []transcript.Line{
+				{Role: "user", Content: "my token is " + secret},
+				{Role: "assistant", Content: "assistant saw " + secret, MessageID: "m1"},
+			}
+
+			g := Map(Inputs{
+				SessionID:           "s",
+				Lines:               lines,
+				ContentCapture:      agento11y.ContentCaptureModeFull,
+				SkipPromptRedaction: tt.skipPromptRedaction,
+			}, 1).Generation
+
+			if len(g.Input) == 0 || len(g.Input[0].Parts) == 0 {
+				t.Fatalf("expected a user message: %+v", g.Input)
+			}
+			if got := g.Input[0].Parts[0].Text; got != tt.wantPrompt {
+				t.Errorf("prompt = %q, want %q", got, tt.wantPrompt)
+			}
+
+			// The opt-out covers the prompt only: assistant text stays redacted.
+			if len(g.Output) == 0 || len(g.Output[0].Parts) == 0 {
+				t.Fatalf("expected an assistant message: %+v", g.Output)
+			}
+			if got := g.Output[0].Parts[0].Text; got != "assistant saw [REDACTED:grafana-cloud-token]" {
+				t.Errorf("assistant text = %q, want it redacted", got)
+			}
+		})
+	}
+}
+
+// TestMap_RedactsEveryContentField walks the fields a generation carries and
+// pins the tier each one gets. The title, the system prompt and the tool-call
+// arguments used to ship unredacted.
+func TestMap_RedactsEveryContentField(t *testing.T) {
+	const token = "glc_abcdefghijklmnopqrstuvwxyz"
+
+	in := Inputs{
+		SessionID: "s",
+		Meta: meta.Meta{
+			Title:        "rotate " + token,
+			SystemPrompt: meta.SystemPrompt{Content: "you are a bot. DB_PASSWORD=hunter2"},
+		},
+		Lines: []transcript.Line{
+			{Role: "user", Content: "deploy with PASSWORD=hunter2"},
+			{
+				Role:             "assistant",
+				ReasoningContent: "the user set PASSWORD=hunter2 and " + token,
+				MessageID:        "m1",
+			},
+			{
+				Role:      "assistant",
+				MessageID: "m2",
+				ToolCalls: []transcript.ToolCall{toolCall("c1", "bash", `{"cmd":"deploy","password":"hunter2"}`)},
+			},
+			{Role: "tool", ToolCallID: "c1", Name: "bash", Content: "wrote PASSWORD=hunter2"},
+			{Role: "assistant", Content: "done, PASSWORD=hunter2 is set, " + token, MessageID: "m3"},
+		},
+		ContentCapture: agento11y.ContentCaptureModeFull,
+	}
+
+	mapped := Map(in, 1)
+	g := mapped.Generation
+
+	// Prose keeps tier 1 only, so the env-style pair survives in the title,
+	// the reasoning and the assistant text. Everything else takes tier 2 too.
+	const wantTitle = "rotate [REDACTED:grafana-cloud-token]"
+	if g.ConversationTitle != wantTitle {
+		t.Errorf("title = %q, want %q", g.ConversationTitle, wantTitle)
+	}
+	if mapped.Start.ConversationTitle != wantTitle {
+		t.Errorf("start title = %q, want %q", mapped.Start.ConversationTitle, wantTitle)
+	}
+	if want := "you are a bot. DB_PASSWORD=[REDACTED:env-secret-value]"; g.SystemPrompt != want {
+		t.Errorf("system prompt = %q, want %q", g.SystemPrompt, want)
+	}
+
+	prompt := firstPart(t, g.Input, agento11y.RoleUser, agento11y.PartKindText).Text
+	if want := "deploy with PASSWORD=[REDACTED:env-secret-value]"; prompt != want {
+		t.Errorf("prompt = %q, want %q", prompt, want)
+	}
+
+	thinking := firstPart(t, g.Output, agento11y.RoleAssistant, agento11y.PartKindThinking).Thinking
+	if want := "the user set PASSWORD=hunter2 and [REDACTED:grafana-cloud-token]"; thinking != want {
+		t.Errorf("thinking = %q, want %q", thinking, want)
+	}
+
+	text := firstPart(t, g.Output, agento11y.RoleAssistant, agento11y.PartKindText).Text
+	if want := "done, PASSWORD=hunter2 is set, [REDACTED:grafana-cloud-token]"; text != want {
+		t.Errorf("assistant text = %q, want %q", text, want)
+	}
+
+	args := string(firstPart(t, g.Output, agento11y.RoleAssistant, agento11y.PartKindToolCall).ToolCall.InputJSON)
+	if want := `{"cmd":"deploy","password":"[REDACTED:json-secret-field]"}`; args != want {
+		t.Errorf("tool args = %s, want %s", args, want)
+	}
+
+	result := firstPart(t, g.Input, agento11y.RoleTool, agento11y.PartKindToolResult).ToolResult.Content
+	if want := "wrote PASSWORD=[REDACTED:env-secret-value]"; result != want {
+		t.Errorf("tool result = %q, want %q", result, want)
+	}
+}
+
+func toolCall(id, name, args string) transcript.ToolCall {
+	var tc transcript.ToolCall
+	tc.ID = id
+	tc.Function.Name = name
+	tc.Function.Arguments = args
+	return tc
+}
+
+// firstPart returns the first part of the given kind on a message with the
+// given role, failing the test when there is none.
+func firstPart(t *testing.T, msgs []agento11y.Message, role agento11y.Role, kind agento11y.PartKind) agento11y.Part {
+	t.Helper()
+	for _, msg := range msgs {
+		if msg.Role != role {
+			continue
+		}
+		for _, p := range msg.Parts {
+			if p.Kind == kind {
+				return p
+			}
+		}
+	}
+	t.Fatalf("no %s part on a %s message: %+v", kind, role, msgs)
+	return agento11y.Part{}
 }
 
 func TestGenerationID_Deterministic(t *testing.T) {

--- a/plugins/agento11y/internal/doctor/doctor.go
+++ b/plugins/agento11y/internal/doctor/doctor.go
@@ -72,6 +72,7 @@ var trackedSuffixes = []string{
 	"OTEL_EXPORTER_OTLP_ENDPOINT",
 	"OTEL_AUTH_TOKEN",
 	"CONTENT_CAPTURE_MODE",
+	"REDACT_INPUT_MESSAGES",
 	"AGENT_NAME",
 	"TAGS",
 	envconfig.AutoTagsSuffix,
@@ -174,10 +175,15 @@ type ConfigSection struct {
 	ContentModeKey      string `json:"content_capture_key,omitempty"`
 	ContentModeSource   string `json:"content_capture_source,omitempty"`
 	ContentModeFellBack bool   `json:"content_mode_fell_back"`
-	GuardsEnabled       bool   `json:"guards_enabled"`
-	GuardsTimeoutMs     int    `json:"guards_timeout_ms"`
-	GuardsFailOpen      bool   `json:"guards_fail_open"`
-	GuardsFellBack      bool   `json:"guards_fell_back,omitempty"`
+	// RedactInput is the REDACT_INPUT_MESSAGES family: whether the user prompt is
+	// scrubbed before export. RedactInputFellBack reports a rejected value, so
+	// the reported state is the built-in default rather than what was set.
+	RedactInput         bool `json:"redact_input_messages"`
+	RedactInputFellBack bool `json:"redact_input_fell_back,omitempty"`
+	GuardsEnabled       bool `json:"guards_enabled"`
+	GuardsTimeoutMs     int  `json:"guards_timeout_ms"`
+	GuardsFailOpen      bool `json:"guards_fail_open"`
+	GuardsFellBack      bool `json:"guards_fell_back,omitempty"`
 	// GuardsKey and GuardsSource name the GUARDS_ENABLED spelling that decided
 	// whether guards run. The timeout and fail mode have their own families; the
 	// human row reports one key, so this is the key it reports. Both are empty
@@ -751,6 +757,21 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 		sec.ContentModeSource = contentMode.source
 	}
 
+	// snapshotLookup resolves an alias family from the pre-merge snapshot every
+	// row is attributed with, so the values reported here are the ones the hooks
+	// read rather than whatever the dotenv merge left in this process.
+	snapshotLookup := func(suffix string) (value, key string, ok bool) {
+		r := resolveFamily(suffix, osEnv, fileEnv)
+		return r.value, r.key, r.set
+	}
+
+	// The hooks resolve this flag against a discarded logger unless
+	// AGENTO11Y_DEBUG is set, so doctor is where a rejected value becomes
+	// visible. Same capturing-logger trick as content mode.
+	var redactBuf bytes.Buffer
+	sec.RedactInput = envconfig.ResolveRedactInputWith(log.New(&redactBuf, "", 0), snapshotLookup)
+	sec.RedactInputFellBack = redactBuf.Len() > 0
+
 	// Guards are the shared pre-tool-call enforcement flags every agent hook
 	// reads via envconfig.ResolveGuards. They default off, so surface the
 	// effective values to confirm whether guards actually run and with what
@@ -761,10 +782,7 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 	guardsEnabled := resolveFamily("GUARDS_ENABLED", osEnv, fileEnv)
 	guardsTimeout := resolveFamily("GUARDS_TIMEOUT_MS", osEnv, fileEnv)
 	guardsFailOpen := resolveFamily("GUARDS_FAIL_OPEN", osEnv, fileEnv)
-	guards := envconfig.ResolveGuardsWith(nil, func(suffix string) (value, key string, ok bool) {
-		r := resolveFamily(suffix, osEnv, fileEnv)
-		return r.value, r.key, r.set
-	})
+	guards := envconfig.ResolveGuardsWith(nil, snapshotLookup)
 	sec.GuardsEnabled = guards.Enabled
 	sec.GuardsTimeoutMs = guards.TimeoutMs
 	sec.GuardsFailOpen = guards.FailOpen
@@ -808,10 +826,6 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 	// The same pre-merge snapshot every other row is attributed with backs the
 	// lookup, so the switch, the allowlist, the reported user, and the explicit
 	// tags all match what the hooks read.
-	snapshotLookup := func(suffix string) (value, key string, ok bool) {
-		r := resolveFamily(suffix, osEnv, fileEnv)
-		return r.value, r.key, r.set
-	}
 	autoTags := resolveFamily(envconfig.AutoTagsSuffix, osEnv, fileEnv)
 	autoTagNames := resolveFamily(envconfig.AutoTagNamesSuffix, osEnv, fileEnv)
 	userID := resolveFamily("USER_ID", osEnv, fileEnv)
@@ -895,6 +909,11 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 		sec.Health = HealthWarn
 		sec.Messages = append(sec.Messages,
 			fmt.Sprintf("the %s value is invalid; using %s", contentMode.key, mode))
+	}
+	if sec.RedactInputFellBack {
+		sec.Health = HealthWarn
+		sec.Messages = append(sec.Messages,
+			"the REDACT_INPUT_MESSAGES value is invalid; prompt redaction stays on")
 	}
 	// One message per rejected variable: the row names the GUARDS_ENABLED
 	// spelling alone, so this is the only place a reader learns which guard value

--- a/plugins/agento11y/internal/doctor/doctor_test.go
+++ b/plugins/agento11y/internal/doctor/doctor_test.go
@@ -1000,7 +1000,7 @@ func TestCollectConfig_ContentMode(t *testing.T) {
 			// Nothing is configured, so the row has to say the value is the
 			// built-in one rather than a choice the user made.
 			name: "unset uses the built-in default", wantMode: "metadata_only",
-			wantRendered: "content capture: metadata_only (default)",
+			wantRendered: "content capture:  metadata_only (default)",
 		},
 		{
 			// The rejected value did not supply the mode in force, so the row credits
@@ -1009,17 +1009,17 @@ func TestCollectConfig_ContentMode(t *testing.T) {
 			name: "invalid mode falls back", osEnv: map[string]string{"SIGIL_CONTENT_CAPTURE_MODE": "bogus"},
 			wantMode: "metadata_only", wantFellBack: true, wantHealth: HealthWarn,
 			wantMsg:      "the SIGIL_CONTENT_CAPTURE_MODE value is invalid; using metadata_only",
-			wantRendered: "content capture: metadata_only (default)",
+			wantRendered: "content capture:  metadata_only (default)",
 		},
 		{
 			name: "from the shell", osEnv: map[string]string{"AGENTO11Y_CONTENT_CAPTURE_MODE": "full"},
 			wantMode: "full", wantKey: "AGENTO11Y_CONTENT_CAPTURE_MODE", wantSource: sourceEnv,
-			wantRendered: "content capture: full (AGENTO11Y_CONTENT_CAPTURE_MODE, env)",
+			wantRendered: "content capture:  full (AGENTO11Y_CONTENT_CAPTURE_MODE, env)",
 		},
 		{
 			name: "from config.env", fileEnv: map[string]string{"AGENTO11Y_CONTENT_CAPTURE_MODE": "no_tool_content"},
 			wantMode: "no_tool_content", wantKey: "AGENTO11Y_CONTENT_CAPTURE_MODE", wantSource: sourceConfig,
-			wantRendered: "content capture: no_tool_content (AGENTO11Y_CONTENT_CAPTURE_MODE, config.env)",
+			wantRendered: "content capture:  no_tool_content (AGENTO11Y_CONTENT_CAPTURE_MODE, config.env)",
 		},
 		{
 			// The shell wins, so the row must not name the config.env value the
@@ -1079,6 +1079,47 @@ func TestCollectConfig_ContentModeReadsTheSnapshot(t *testing.T) {
 	}
 }
 
+func TestCollectConfig_RedactInput(t *testing.T) {
+	// The family has to be in the snapshot the binary passes in, or a
+	// shell-exported opt-out reads as unset here while the hooks act on it.
+	if !slices.Contains(trackedSuffixes, "REDACT_INPUT_MESSAGES") {
+		t.Fatalf("trackedSuffixes is missing REDACT_INPUT_MESSAGES, so SnapshotEnv would not record it")
+	}
+
+	tests := []struct {
+		name         string
+		raw          string
+		wantRedact   bool
+		wantFellBack bool
+		wantHealth   Health // "" = don't assert
+	}{
+		{name: "unset redacts", wantRedact: true},
+		{name: "explicit true", raw: "true", wantRedact: true},
+		{name: "opt-out", raw: "false", wantRedact: false},
+		{name: "typo keeps redaction on and warns", raw: "flase", wantRedact: true, wantFellBack: true, wantHealth: HealthWarn},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateEnv(t)
+			osEnv := map[string]string{}
+			if tc.raw != "" {
+				osEnv["SIGIL_REDACT_INPUT_MESSAGES"] = tc.raw
+			}
+
+			sec := collectConfig(osEnv, nil)
+			if sec.RedactInput != tc.wantRedact {
+				t.Fatalf("RedactInput = %v, want %v", sec.RedactInput, tc.wantRedact)
+			}
+			if sec.RedactInputFellBack != tc.wantFellBack {
+				t.Fatalf("RedactInputFellBack = %v, want %v", sec.RedactInputFellBack, tc.wantFellBack)
+			}
+			if tc.wantHealth != "" && sec.Health != tc.wantHealth {
+				t.Fatalf("health = %q, want %q", sec.Health, tc.wantHealth)
+			}
+		})
+	}
+}
+
 func TestCollectConfig_Guards(t *testing.T) {
 	// The guard families have to be in the snapshot the binary passes in, or a
 	// shell-exported timeout reads as unset here while the hooks act on it.
@@ -1103,13 +1144,13 @@ func TestCollectConfig_Guards(t *testing.T) {
 	}{
 		{
 			name: "unset uses defaults", wantEnabled: false, wantTimeoutMs: 1500, wantFailOpen: true,
-			wantRendered: "guards:          disabled (default)",
+			wantRendered: "guards:           disabled (default)",
 		},
 		{
 			name: "enabled fail-open", osEnv: map[string]string{"AGENTO11Y_GUARDS_ENABLED": "true"},
 			wantEnabled: true, wantTimeoutMs: 1500, wantFailOpen: true,
 			wantKey: "AGENTO11Y_GUARDS_ENABLED", wantSource: sourceEnv,
-			wantRendered: "guards:          enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, env)",
+			wantRendered: "guards:           enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, env)",
 		},
 		{
 			name: "enabled fail-closed with timeout from config.env",
@@ -1120,13 +1161,13 @@ func TestCollectConfig_Guards(t *testing.T) {
 			},
 			wantEnabled: true, wantTimeoutMs: 500, wantFailOpen: false,
 			wantKey: "AGENTO11Y_GUARDS_ENABLED", wantSource: sourceConfig,
-			wantRendered: "guards:          enabled, timeout 500ms, fail-closed (AGENTO11Y_GUARDS_ENABLED, config.env)",
+			wantRendered: "guards:           enabled, timeout 500ms, fail-closed (AGENTO11Y_GUARDS_ENABLED, config.env)",
 		},
 		{
 			name: "legacy spelling", osEnv: map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
 			wantEnabled: true, wantTimeoutMs: 1500, wantFailOpen: true,
 			wantKey: "SIGIL_GUARDS_ENABLED", wantSource: sourceEnv,
-			wantRendered: "guards:          enabled, timeout 1500ms, fail-open (SIGIL_GUARDS_ENABLED, env)",
+			wantRendered: "guards:           enabled, timeout 1500ms, fail-open (SIGIL_GUARDS_ENABLED, env)",
 		},
 		{
 			// The rejected value did not decide whether guards run, so the row credits
@@ -1135,7 +1176,7 @@ func TestCollectConfig_Guards(t *testing.T) {
 			wantEnabled: false, wantTimeoutMs: 1500, wantFailOpen: true, wantFellBack: true,
 			wantHealth:   HealthWarn,
 			wantMsg:      "the AGENTO11Y_GUARDS_ENABLED value is invalid; guards use the default",
-			wantRendered: "guards:          disabled (default)",
+			wantRendered: "guards:           disabled (default)",
 		},
 		{
 			// GUARDS_ENABLED is fine, so the row keeps naming it. Only the message can
@@ -1148,7 +1189,7 @@ func TestCollectConfig_Guards(t *testing.T) {
 			wantEnabled: true, wantTimeoutMs: 1500, wantFailOpen: true, wantFellBack: true,
 			wantKey: "AGENTO11Y_GUARDS_ENABLED", wantSource: sourceEnv, wantHealth: HealthWarn,
 			wantMsg:      "the AGENTO11Y_GUARDS_TIMEOUT_MS value is invalid; guards use the default",
-			wantRendered: "guards:          enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, env)",
+			wantRendered: "guards:           enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, env)",
 		},
 		{
 			// The fail mode is the third family, and it is the one the row never names.
@@ -1160,7 +1201,7 @@ func TestCollectConfig_Guards(t *testing.T) {
 			wantEnabled: true, wantTimeoutMs: 1500, wantFailOpen: true, wantFellBack: true,
 			wantKey: "AGENTO11Y_GUARDS_ENABLED", wantSource: sourceConfig, wantHealth: HealthWarn,
 			wantMsg:      "the AGENTO11Y_GUARDS_FAIL_OPEN value is invalid; guards use the default",
-			wantRendered: "guards:          enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, config.env)",
+			wantRendered: "guards:           enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, config.env)",
 		},
 		{
 			// Only GUARDS_ENABLED names the row, and it is unset, so the row
@@ -1169,7 +1210,7 @@ func TestCollectConfig_Guards(t *testing.T) {
 			fileEnv: map[string]string{"AGENTO11Y_GUARDS_TIMEOUT_MS": "800"},
 			// TimeoutMs is still resolved; the row just cannot claim a key for it.
 			wantEnabled: false, wantTimeoutMs: 800, wantFailOpen: true,
-			wantRendered: "guards:          disabled (default)",
+			wantRendered: "guards:           disabled (default)",
 		},
 	}
 	for _, tc := range tests {
@@ -1736,7 +1777,7 @@ func TestCollectConfig_Local(t *testing.T) {
 			wantInvalid:     true,
 			wantHealth:      HealthWarn,
 			wantMsg:         "the AGENTO11Y_LOCAL value is not a boolean; local mode stays off",
-			wantRendered:    []string{`local mode:      off (AGENTO11Y_LOCAL="enabled" is not a boolean, env)`},
+			wantRendered:    []string{`local mode:       off (AGENTO11Y_LOCAL="enabled" is not a boolean, env)`},
 			wantNotRendered: []string{"enabled (AGENTO11Y_LOCAL, env)", "invalid value, local mode is off"},
 		},
 	}

--- a/plugins/agento11y/internal/doctor/render.go
+++ b/plugins/agento11y/internal/doctor/render.go
@@ -157,6 +157,7 @@ func renderHuman(w io.Writer, r *Report, color bool) {
 	b.kv("file", fmt.Sprintf("%s %s", r.Config.Path, p.faint("("+exists+")")))
 	b.kv("content capture", withTrailer(r.Config.ContentCaptureMode,
 		describeSource(p, provenanceParts(r.Config.ContentModeKey, r.Config.ContentModeSource)...)))
+	b.kv("prompt redaction", describeRedactInput(p, r.Config))
 	b.kv("guards", describeGuards(p, r.Config))
 	// Only printed when an override is set: with the family unset each adapter
 	// reports its own product name, and there is no single value to show.
@@ -301,6 +302,18 @@ func describeToken(p palette, t tokenValue) string {
 		prefix = t.Prefix + "…"
 	}
 	return withTrailer("set", describeSource(p, prefix, t.Key, t.Source))
+}
+
+// describeRedactInput renders whether user prompts are scrubbed before export.
+func describeRedactInput(p palette, c ConfigSection) string {
+	out := p.faint("enabled")
+	if !c.RedactInput {
+		out = "disabled " + p.faint("(prompts export unredacted)")
+	}
+	if c.RedactInputFellBack {
+		out += " " + p.faint("(invalid value, fell back)")
+	}
+	return out
 }
 
 // describeGuards renders the resolved guard feature flags. Guards default off,

--- a/plugins/agento11y/internal/doctor/render_golden_test.go
+++ b/plugins/agento11y/internal/doctor/render_golden_test.go
@@ -102,6 +102,7 @@ func goldenHealthyReport() *Report {
 			Path: "/home/u/.config/agento11y/config.env", Exists: true,
 			ContentCaptureMode: "full",
 			ContentModeKey:     "AGENTO11Y_CONTENT_CAPTURE_MODE", ContentModeSource: sourceConfig,
+			RedactInput:   true,
 			GuardsEnabled: true, GuardsTimeoutMs: 1500, GuardsFailOpen: true,
 			GuardsKey: "AGENTO11Y_GUARDS_ENABLED", GuardsSource: sourceConfig,
 			Tags:       map[string]string{"team": "assistant", "env": "prod"},
@@ -144,6 +145,7 @@ func goldenMinimalReport() *Report {
 			// Nothing is configured, so both shared settings report the built-in
 			// value rather than a choice the user made.
 			ContentCaptureMode: "metadata_only",
+			RedactInput:        true,
 			GuardsTimeoutMs:    1500, GuardsFailOpen: true,
 			Health: HealthOK,
 		},
@@ -170,6 +172,9 @@ func goldenBrokenReport() *Report {
 			// The mode came from a value envconfig rejected, so the row credits the
 			// built-in default and the message names the variable to fix.
 			ContentCaptureMode: "metadata_only", ContentModeFellBack: true,
+			// A rejected opt-out: redaction stays on, and the message names the
+			// variable to fix.
+			RedactInput: true, RedactInputFellBack: true,
 			// GUARDS_ENABLED is valid and off, under the legacy spelling the row has to
 			// name. The timeout is the value that fell back.
 			GuardsEnabled: false, GuardsTimeoutMs: 1500, GuardsFailOpen: true, GuardsFellBack: true,
@@ -200,6 +205,7 @@ func goldenBrokenReport() *Report {
 			Messages: []string{
 				"config.env has keys agento11y ignores: AWS_SECRET",
 				"the AGENTO11Y_CONTENT_CAPTURE_MODE value is invalid; using metadata_only",
+				"the REDACT_INPUT_MESSAGES value is invalid; prompt redaction stays on",
 				"the AGENTO11Y_GUARDS_TIMEOUT_MS value is invalid; guards use the default",
 				"AGENTO11Y_AUTO_CODING_AGENT_TAGS_NAMES has unsupported names team; supported: user, repo, branch, all",
 				"these auto tags resolved no value in this directory and are left off: branch",

--- a/plugins/agento11y/internal/doctor/render_test.go
+++ b/plugins/agento11y/internal/doctor/render_test.go
@@ -63,8 +63,8 @@ func TestRenderHuman_NoColorIsPlain(t *testing.T) {
 		"https://sigil.example (AGENTO11Y_ENDPOINT, env)",
 		"set (glc_…, AGENTO11Y_AUTH_TOKEN, env)",
 		// No variable is configured, so the row says the value is the built-in one.
-		"content capture: metadata_only (default)",
-		"guards:          disabled (default)",
+		"content capture:  metadata_only (default)",
+		"guards:           disabled (default)",
 		"1 problem(s)",
 	} {
 		if !strings.Contains(out, want) {
@@ -194,7 +194,7 @@ func TestRenderHuman_ProbeDiagnosisAppearsOnce(t *testing.T) {
 	renderHuman(&buf, r, false)
 	out := buf.String()
 
-	if want := "traces probe:    HTTP 403 (https://otlp.example/otlp/v1/traces)"; !strings.Contains(out, want) {
+	if want := "traces probe:     HTTP 403 (https://otlp.example/otlp/v1/traces)"; !strings.Contains(out, want) {
 		t.Fatalf("probe row missing %q:\n%s", want, out)
 	}
 	if got := strings.Count(out, diagnosis); got != 1 {
@@ -223,7 +223,7 @@ func TestRenderHuman_FaultsStayOnTheMessageLine(t *testing.T) {
 				c.ContentModeFellBack = true
 			},
 			message:   "the AGENTO11Y_CONTENT_CAPTURE_MODE value is invalid; using metadata_only",
-			wantRow:   "content capture: metadata_only (default)",
+			wantRow:   "content capture:  metadata_only (default)",
 			wantNoRow: "invalid value, fell back",
 		},
 		{
@@ -236,7 +236,7 @@ func TestRenderHuman_FaultsStayOnTheMessageLine(t *testing.T) {
 				c.GuardsFellBack = true
 			},
 			message:   "the AGENTO11Y_GUARDS_TIMEOUT_MS value is invalid; guards use the default",
-			wantRow:   "guards:          enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, env)",
+			wantRow:   "guards:           enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, env)",
 			wantNoRow: "invalid value, fell back",
 		},
 		{
@@ -248,7 +248,7 @@ func TestRenderHuman_FaultsStayOnTheMessageLine(t *testing.T) {
 				c.LocalInvalid = true
 			},
 			message:   "the AGENTO11Y_LOCAL value is not a boolean; local mode stays off",
-			wantRow:   `local mode:      off (AGENTO11Y_LOCAL="enabled" is not a boolean, env)`,
+			wantRow:   `local mode:       off (AGENTO11Y_LOCAL="enabled" is not a boolean, env)`,
 			wantNoRow: "invalid value, local mode is off",
 		},
 	}
@@ -414,6 +414,26 @@ func TestRenderHuman_TagsLine(t *testing.T) {
 			}
 			if !strings.Contains(out, "tags:") || !strings.Contains(out, tc.wantLine) {
 				t.Fatalf("expected tags line %q:\n%s", tc.wantLine, out)
+			}
+		})
+	}
+}
+
+func TestDescribeRedactInput(t *testing.T) {
+	p := palette{color: false}
+	tests := []struct {
+		name   string
+		config ConfigSection
+		want   string
+	}{
+		{name: "enabled", config: ConfigSection{RedactInput: true}, want: "enabled"},
+		{name: "disabled", config: ConfigSection{RedactInput: false}, want: "disabled (prompts export unredacted)"},
+		{name: "enabled after fallback", config: ConfigSection{RedactInput: true, RedactInputFellBack: true}, want: "enabled (invalid value, fell back)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := describeRedactInput(p, tc.config); got != tc.want {
+				t.Fatalf("describeRedactInput = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/doctor/testdata/render/broken.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/broken.golden.txt
@@ -14,6 +14,7 @@ agento11y doctor dev
 ! Config
   file:               /home/u/.config/agento11y/config.env (present)
   content capture:    metadata_only (default)
+  prompt redaction:   enabled (invalid value, fell back)
   guards:             disabled (SIGIL_GUARDS_ENABLED, env)
   tags:               repo=monorepo (AGENTO11Y_TAGS, config.env)
   auto tags:          user,repo,branch resolved user=alex (AGENTO11Y_AUTO_CODING_AGENT_TAGS, config.env)
@@ -22,6 +23,7 @@ agento11y doctor dev
   local guard checks: not forwarded (AGENTO11Y_GUARDS_ENABLED is off, so there are no guards to enforce)
   ! config.env has keys agento11y ignores: AWS_SECRET
   ! the AGENTO11Y_CONTENT_CAPTURE_MODE value is invalid; using metadata_only
+  ! the REDACT_INPUT_MESSAGES value is invalid; prompt redaction stays on
   ! the AGENTO11Y_GUARDS_TIMEOUT_MS value is invalid; guards use the default
   ! AGENTO11Y_AUTO_CODING_AGENT_TAGS_NAMES has unsupported names team; supported: user, repo, branch, all
   ! these auto tags resolved no value in this directory and are left off: branch

--- a/plugins/agento11y/internal/doctor/testdata/render/healthy.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/healthy.golden.txt
@@ -11,6 +11,7 @@ agento11y doctor v0.22.0
 ✓ Config
   file:               /home/u/.config/agento11y/config.env (present)
   content capture:    full (AGENTO11Y_CONTENT_CAPTURE_MODE, config.env)
+  prompt redaction:   enabled
   guards:             enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, config.env)
   tags:               env=prod, team=assistant (AGENTO11Y_TAGS, config.env)
   auto tags:          user,repo resolved repo=grafana/agento11y, user=alice@example.com (AGENTO11Y_AUTO_CODING_AGENT_TAGS, config.env)

--- a/plugins/agento11y/internal/doctor/testdata/render/minimal.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/minimal.golden.txt
@@ -1,21 +1,22 @@
 agento11y doctor v0.22.0
 
 ! Conversations (generation export)
-  endpoint:        not set
-  tenant id:       not set
-  auth token:      not set
+  endpoint:         not set
+  tenant id:        not set
+  auth token:       not set
   ! not configured — run `agento11y login` or set AGENTO11Y_ENDPOINT, AGENTO11Y_AUTH_TENANT_ID and AGENTO11Y_AUTH_TOKEN
 
 ! Analytics (OTLP metrics & traces)
-  endpoint:        not set
+  endpoint:         not set
   ! no OTLP endpoint set; analytics export is disabled
 
 ✓ Config
-  file:            /home/u/.config/agento11y/config.env (missing)
-  content capture: metadata_only (default)
-  guards:          disabled (default)
+  file:             /home/u/.config/agento11y/config.env (missing)
+  content capture:  metadata_only (default)
+  prompt redaction: enabled
+  guards:           disabled (default)
 
 Coding agents
-  claude:          plugin not installed
+  claude:           plugin not installed
 
 ✓ no problems detected

--- a/plugins/agento11y/internal/doctor/testdata/render/probed.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/probed.golden.txt
@@ -16,6 +16,7 @@ agento11y doctor v0.22.0
 ✓ Config
   file:               /home/u/.config/agento11y/config.env (present)
   content capture:    full (AGENTO11Y_CONTENT_CAPTURE_MODE, config.env)
+  prompt redaction:   enabled
   guards:             enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, config.env)
   tags:               env=prod, team=assistant (AGENTO11Y_TAGS, config.env)
   auto tags:          user,repo resolved repo=grafana/agento11y, user=alice@example.com (AGENTO11Y_AUTO_CODING_AGENT_TAGS, config.env)

--- a/plugins/agento11y/internal/doctor/testdata/render/redirected.golden.txt
+++ b/plugins/agento11y/internal/doctor/testdata/render/redirected.golden.txt
@@ -15,6 +15,7 @@ agento11y doctor v0.22.0
 ✓ Config
   file:               /home/u/.config/agento11y/config.env (present)
   content capture:    full (AGENTO11Y_CONTENT_CAPTURE_MODE, config.env)
+  prompt redaction:   enabled
   guards:             enabled, timeout 1500ms, fail-open (AGENTO11Y_GUARDS_ENABLED, config.env)
   tags:               env=prod, team=assistant (AGENTO11Y_TAGS, config.env)
   auto tags:          user,repo resolved repo=grafana/agento11y, user=alice@example.com (AGENTO11Y_AUTO_CODING_AGENT_TAGS, config.env)

--- a/plugins/agento11y/internal/envconfig/envconfig.go
+++ b/plugins/agento11y/internal/envconfig/envconfig.go
@@ -408,6 +408,25 @@ func ResolveContentModeValue(logger *log.Logger, key, raw string) agento11y.Cont
 	return mode
 }
 
+// ResolveRedactInput reports whether user prompt text should be redacted
+// before export. Reads AGENTO11Y_REDACT_INPUT_MESSAGES (SIGIL_ fallback) and
+// defaults to true, so prompts are scrubbed without configuration. An
+// unrecognised value is reported via logger when non-nil and keeps redaction
+// on, so a typo cannot silently disable it. The flag covers the user prompt and
+// nothing else. Mirrors plugins/pi/src/config.ts and the OpenCode plugin so one
+// ~/.config/agento11y/config.env drives every launcher.
+func ResolveRedactInput(logger *log.Logger) bool {
+	return ResolveRedactInputWith(logger, LookupEnv)
+}
+
+// ResolveRedactInputWith resolves the prompt-redaction flag from an arbitrary
+// lookup, applying the same default and diagnostics as ResolveRedactInput.
+// Doctor passes a lookup backed by its env snapshot so it reports the value the
+// hooks resolve and can name the variable it came from.
+func ResolveRedactInputWith(logger *log.Logger, look Lookup) bool {
+	return resolveBool(logger, look, "REDACT_INPUT_MESSAGES", true)
+}
+
 // GuardsConfig is the resolved guard feature flags for a hook handler.
 // Mirrors plugins/pi/src/config.ts::GuardsFeatureConfig so a single
 // ~/.config/agento11y/config.env drives both plugins.
@@ -446,9 +465,9 @@ func ResolveGuards(logger *log.Logger) GuardsConfig {
 // and can name the variable each one came from.
 func ResolveGuardsWith(logger *log.Logger, look Lookup) GuardsConfig {
 	cfg := GuardsConfig{
-		Enabled:   resolveGuardsBool(logger, look, "GUARDS_ENABLED", defaultGuardsEnabled),
+		Enabled:   resolveBool(logger, look, "GUARDS_ENABLED", defaultGuardsEnabled),
 		TimeoutMs: DefaultGuardsTimeoutMs,
-		FailOpen:  resolveGuardsBool(logger, look, "GUARDS_FAIL_OPEN", defaultGuardsFailOpen),
+		FailOpen:  resolveBool(logger, look, "GUARDS_FAIL_OPEN", defaultGuardsFailOpen),
 	}
 	if v, key, ok := look("GUARDS_TIMEOUT_MS"); ok {
 		cfg.TimeoutMs = IntValue(logger, key, v, DefaultGuardsTimeoutMs)
@@ -456,7 +475,10 @@ func ResolveGuardsWith(logger *log.Logger, look Lookup) GuardsConfig {
 	return cfg
 }
 
-func resolveGuardsBool(logger *log.Logger, look Lookup, suffix string, def bool) bool {
+// resolveBool reads a boolean config key from a branded alias family through
+// look. Unset returns def; an unrecognised value is reported via logger when
+// non-nil and also returns def.
+func resolveBool(logger *log.Logger, look Lookup, suffix string, def bool) bool {
 	raw, key, ok := look(suffix)
 	if !ok {
 		return def

--- a/plugins/agento11y/internal/envconfig/envconfig_test.go
+++ b/plugins/agento11y/internal/envconfig/envconfig_test.go
@@ -461,6 +461,52 @@ func TestResolveContentMode(t *testing.T) {
 	}
 }
 
+func TestResolveRedactInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     map[string]string
+		want    bool
+		wantLog string
+	}{
+		{name: "defaults_on_with_no_env", want: true},
+		{name: "blank_value_defaults_on", env: map[string]string{"AGENTO11Y_REDACT_INPUT_MESSAGES": "   "}, want: true},
+		{name: "explicit_false_opts_out", env: map[string]string{"AGENTO11Y_REDACT_INPUT_MESSAGES": "false"}, want: false},
+		{name: "explicit_0_opts_out", env: map[string]string{"AGENTO11Y_REDACT_INPUT_MESSAGES": "0"}, want: false},
+		{name: "explicit_off_opts_out", env: map[string]string{"AGENTO11Y_REDACT_INPUT_MESSAGES": "off"}, want: false},
+		{name: "explicit_true_stays_on", env: map[string]string{"AGENTO11Y_REDACT_INPUT_MESSAGES": "true"}, want: true},
+		{name: "legacy_spelling_opts_out", env: map[string]string{"SIGIL_REDACT_INPUT_MESSAGES": "false"}, want: false},
+		{name: "preferred_wins_over_legacy", env: map[string]string{"AGENTO11Y_REDACT_INPUT_MESSAGES": "true", "SIGIL_REDACT_INPUT_MESSAGES": "false"}, want: true},
+		{
+			name:    "typo_logs_and_stays_on",
+			env:     map[string]string{"AGENTO11Y_REDACT_INPUT_MESSAGES": "flase"},
+			want:    true,
+			wantLog: `invalid AGENTO11Y_REDACT_INPUT_MESSAGES="flase"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(PreferredKey("REDACT_INPUT_MESSAGES"), "")
+			t.Setenv(LegacyKey("REDACT_INPUT_MESSAGES"), "")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			var buf bytes.Buffer
+			logger := log.New(&buf, "", 0)
+			if got := ResolveRedactInput(logger); got != tt.want {
+				t.Errorf("ResolveRedactInput() = %v, want %v", got, tt.want)
+			}
+			if tt.wantLog != "" && !strings.Contains(buf.String(), tt.wantLog) {
+				t.Errorf("log output = %q, want substring %q", buf.String(), tt.wantLog)
+			}
+			if tt.wantLog == "" && buf.Len() != 0 {
+				t.Errorf("unexpected log output: %q", buf.String())
+			}
+		})
+	}
+}
+
 func TestLookupEnv(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/plugins/agento11y/internal/redact/fields.go
+++ b/plugins/agento11y/internal/redact/fields.go
@@ -1,0 +1,68 @@
+package redact
+
+import "encoding/json"
+
+// Per-field redaction strength.
+//
+// Redact and RedactLightweight name a mechanism; the helpers below name the
+// field a mapper is about to export. Every mapper used to pick its own tier per
+// field, and the plugins disagreed: a prompt was tier 1 in two of them and
+// tier 1+2 in five, and one sent tool arguments through tier 1 only. Call these
+// instead of choosing a tier at the call site.
+//
+// The split matches the SDKs' generation sanitizer (go/agento11y/redaction.go,
+// js/src/redaction.ts and the other three), so a plugin export and an SDK
+// export scrub the same field the same way:
+//
+//   - Assembled or machine-generated content gets tier 1+2. A prompt carries
+//     pasted config and command output, a system prompt carries environment
+//     dumps, and tool payloads are structured data, so the tier 2 key/value
+//     heuristic earns its false positives there.
+//   - Prose gets tier 1 only. Model text, reasoning, a conversation title and
+//     an error message are sentences, and tier 2 replaces the word after any
+//     `key:` or `token:` in them.
+//
+// Tier 2's cost on a prompt is real: `sort key: name` comes out as
+// `sort key: [REDACTED:env-secret-value]`. AGENTO11Y_REDACT_INPUT_MESSAGES=false
+// turns prompt redaction off for anyone who would rather keep the text.
+//
+// The tool-payload helpers go past the SDKs: on a payload that decodes as JSON
+// they also redact a value under a secret-looking key, which covers the names
+// tier 2's fixed list misses (`authorization`, `cookie`, `client_secret`).
+
+// Prompt redacts a user prompt: tier 1 + tier 2.
+func (r *Redactor) Prompt(text string) string { return r.Redact(text) }
+
+// SystemPrompt redacts an exported system prompt: tier 1 + tier 2.
+func (r *Redactor) SystemPrompt(text string) string { return r.Redact(text) }
+
+// ToolPayload redacts tool arguments or a tool result held as text:
+// tier 1 + tier 2.
+func (r *Redactor) ToolPayload(text string) string { return r.Redact(text) }
+
+// ToolPayloadJSON redacts tool arguments or a tool result exported as JSON.
+// The value keeps its JSON shape, so the field stays parseable downstream.
+func (r *Redactor) ToolPayloadJSON(raw json.RawMessage) json.RawMessage {
+	return r.RedactJSON(raw)
+}
+
+// ToolPayloadText redacts tool arguments or a tool result for a field that
+// takes a string, such as a span attribute. A payload that is a JSON string is
+// unwrapped first, so the attribute carries the text rather than its quoted
+// encoding.
+func (r *Redactor) ToolPayloadText(raw json.RawMessage) string {
+	return r.RedactJSONForText(raw)
+}
+
+// AssistantText redacts model prose: tier 1 only.
+func (r *Redactor) AssistantText(text string) string { return r.RedactLightweight(text) }
+
+// Thinking redacts model reasoning: tier 1 only.
+func (r *Redactor) Thinking(text string) string { return r.RedactLightweight(text) }
+
+// Title redacts a conversation title: tier 1 only. A title is usually the
+// first prompt, truncated, so it is prose.
+func (r *Redactor) Title(text string) string { return r.RedactLightweight(text) }
+
+// ErrorText redacts an error message from the agent or a tool: tier 1 only.
+func (r *Redactor) ErrorText(text string) string { return r.RedactLightweight(text) }

--- a/plugins/agento11y/internal/redact/fields_test.go
+++ b/plugins/agento11y/internal/redact/fields_test.go
@@ -1,0 +1,119 @@
+package redact
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// One input carries a tier 1 token and a tier 2 key/value pair, so each
+// helper's output shows which tiers ran.
+func TestRedactorFieldTiers(t *testing.T) {
+	r := New()
+	const probe = "glc_abcdefghijklmnopqrstuvwx and DB_PASSWORD=hunter2"
+	const bothTiers = "[REDACTED:grafana-cloud-token] and DB_PASSWORD=[REDACTED:env-secret-value]"
+	const tier1Only = "[REDACTED:grafana-cloud-token] and DB_PASSWORD=hunter2"
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"prompt", r.Prompt(probe), bothTiers},
+		{"system prompt", r.SystemPrompt(probe), bothTiers},
+		{"tool payload", r.ToolPayload(probe), bothTiers},
+		{"assistant text", r.AssistantText(probe), tier1Only},
+		{"thinking", r.Thinking(probe), tier1Only},
+		{"title", r.Title(probe), tier1Only},
+		{"error text", r.ErrorText(probe), tier1Only},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("got  %q\nwant %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedactorToolPayloadJSON(t *testing.T) {
+	r := New()
+
+	tests := []struct {
+		name string
+		raw  json.RawMessage
+		want string
+	}{
+		{
+			name: "redacts a quoted secret and stays parseable",
+			raw:  json.RawMessage(`{"cmd":"deploy","password":"hunter2"}`),
+			want: `{"cmd":"deploy","password":"[REDACTED:json-secret-field]"}`,
+		},
+		{
+			name: "redacts a secret inside a command string",
+			raw:  json.RawMessage(`{"cmd":"export TOKEN=hunter2"}`),
+			want: `{"cmd":"export TOKEN=[REDACTED:env-secret-value]"}`,
+		},
+		{
+			// Past tier 2's fixed key list, which has no "authorization".
+			name: "redacts a value under a secret-looking key",
+			raw:  json.RawMessage(`{"authorization":"Basic aGk6dGhlcmU="}`),
+			want: `{"authorization":"[REDACTED:json-secret-field]"}`,
+		},
+		{
+			name: "empty stays empty",
+			raw:  nil,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := string(r.ToolPayloadJSON(tt.raw))
+			if got != tt.want {
+				t.Fatalf("got  %s\nwant %s", got, tt.want)
+			}
+			if got == "" {
+				return
+			}
+			var v any
+			if err := json.Unmarshal([]byte(got), &v); err != nil {
+				t.Errorf("output is not valid JSON: %v", err)
+			}
+		})
+	}
+}
+
+func TestRedactorToolPayloadText(t *testing.T) {
+	r := New()
+
+	tests := []struct {
+		name string
+		raw  json.RawMessage
+		want string
+	}{
+		{
+			name: "unwraps a JSON string",
+			raw:  json.RawMessage(`"export TOKEN=hunter2"`),
+			want: `export TOKEN=[REDACTED:env-secret-value]`,
+		},
+		{
+			name: "keeps an object as JSON",
+			raw:  json.RawMessage(`{"password":"hunter2"}`),
+			want: `{"password":"[REDACTED:json-secret-field]"}`,
+		},
+		{
+			name: "empty stays empty",
+			raw:  nil,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := r.ToolPayloadText(tt.raw); got != tt.want {
+				t.Errorf("got  %s\nwant %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -101,6 +101,7 @@ Common culprits: `agento11y --version` doesn't work (binary not on `PATH`), a mi
 | `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the Agent Observability latency and tool-call panels stay empty. |
 | `AGENTO11Y_OTEL_AUTH_TOKEN` | `AGENTO11Y_AUTH_TOKEN` | Override the OTel password. |
 | `AGENTO11Y_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md). |
+| `AGENTO11Y_REDACT_INPUT_MESSAGES` | `true` | Redact known secret formats out of user prompt text. Set to `false` to export prompts without redaction; assistant and tool content stay redacted. |
 | `AGENTO11Y_TAGS` | — | `key=value,key=value` tags on every generation and as `agento11y.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). |
 | `AGENTO11Y_AUTO_CODING_AGENT_TAGS` | `false` | Opt in to client tags resolved for the session: the user, the repository, and the branch. Unlike the built-ins, these reach OTel metrics as `agento11y_tag_*` labels. See [Tags and Metadata](../../docs/concepts/tags-and-metadata.md#opt-in-automatic-tags-agento11y_auto_coding_agent_tags) for the cardinality and personal-data trade-offs. |
 | `AGENTO11Y_AUTO_CODING_AGENT_TAGS_NAMES` | all names | Narrows the switch above to a comma-separated subset of `user`, `repo`, `branch` (`all` is also accepted). Does nothing while the switch is off. |

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -117,6 +117,7 @@ tail -f ~/.local/state/agento11y/logs/agento11y.log
 | `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the Agent Observability latency and tool-call panels stay empty. |
 | `AGENTO11Y_OTEL_AUTH_TOKEN` | `AGENTO11Y_AUTH_TOKEN` | Override the OTel password. |
 | `AGENTO11Y_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md). |
+| `AGENTO11Y_REDACT_INPUT_MESSAGES` | `true` | Redact known secret formats out of user prompt text. Set to `false` to export prompts without redaction; assistant and tool content stay redacted. |
 | `AGENTO11Y_TAGS` | — | `key=value,key=value` tags on every generation and as `agento11y.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). |
 | `AGENTO11Y_AUTO_CODING_AGENT_TAGS` | `false` | Opt in to client tags resolved for the session: the user, the repository, and the branch. Unlike the built-ins, these reach OTel metrics as `agento11y_tag_*` labels. See [Tags and Metadata](../../docs/concepts/tags-and-metadata.md#opt-in-automatic-tags-agento11y_auto_coding_agent_tags) for the cardinality and personal-data trade-offs. |
 | `AGENTO11Y_AUTO_CODING_AGENT_TAGS_NAMES` | all names | Narrows the switch above to a comma-separated subset of `user`, `repo`, `branch` (`all` is also accepted). Does nothing while the switch is off. |

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -131,7 +131,7 @@ shapes.
 | `full` | included with redaction | included with redaction | included with redaction | included with redaction |
 | `full_with_metadata_spans` | included on generation export with redaction; stripped on OTel spans | included on generation export with redaction; stripped on OTel spans | tool names/status only | stripped |
 
-Captured prompt, assistant, and tool content is redacted before export. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md) for the cross-SDK reference.
+Captured prompt, assistant, and tool content is redacted before export. Set `AGENTO11Y_REDACT_INPUT_MESSAGES=false` to export prompt text without redaction; assistant and tool content stay redacted. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md) for the cross-SDK reference.
 
 ## Guards
 
@@ -163,6 +163,7 @@ Limits:
 | `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the Agent Observability latency and tool-call panels stay empty. |
 | `AGENTO11Y_OTEL_AUTH_TOKEN` | `AGENTO11Y_AUTH_TOKEN` | Override the OTel password. |
 | `AGENTO11Y_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. |
+| `AGENTO11Y_REDACT_INPUT_MESSAGES` | `true` | Redact known secret formats out of user prompt text. Set to `false` to export prompts without redaction; assistant and tool content stay redacted. |
 | `AGENTO11Y_TAGS` | — | `key=value,key=value` tags on every generation and as `agento11y.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). |
 | `AGENTO11Y_AUTO_CODING_AGENT_TAGS` | `false` | Opt in to client tags resolved for the session: the user, the repository, and the branch. Unlike the built-ins, these reach OTel metrics as `agento11y_tag_*` labels. See [Tags and Metadata](../../docs/concepts/tags-and-metadata.md#opt-in-automatic-tags-agento11y_auto_coding_agent_tags) for the cardinality and personal-data trade-offs. |
 | `AGENTO11Y_AUTO_CODING_AGENT_TAGS_NAMES` | all names | Narrows the switch above to a comma-separated subset of `user`, `repo`, `branch` (`all` is also accepted). Does nothing while the switch is off. |

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -84,7 +84,7 @@ To include conversation text, add this to your `config.env`:
 AGENTO11Y_CONTENT_CAPTURE_MODE=full
 ```
 
-OpenCode redacts assistant and tool content before export. User prompt text is sent as-is when content capture allows it.
+OpenCode redacts known secret formats out of assistant text, the system prompt, tool arguments, tool results, and user prompts before export. Set `AGENTO11Y_REDACT_INPUT_MESSAGES=false` to send prompt text without redaction; assistant and tool content stay redacted either way.
 
 ## 3. Verify
 
@@ -151,6 +151,7 @@ With guards on, a rule can:
 | `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the Agent Observability latency and tool-call panels stay empty. Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT`. |
 | `AGENTO11Y_OTEL_AUTH_TOKEN` | `AGENTO11Y_AUTH_TOKEN` | Override the OTLP password. |
 | `AGENTO11Y_CONTENT_CAPTURE_MODE` | `metadata_only` | One of `full`, `no_tool_content`, `metadata_only`, or `full_with_metadata_spans`. `default` is accepted as an alias for `metadata_only`. |
+| `AGENTO11Y_REDACT_INPUT_MESSAGES` | `true` | Redact known secret formats out of user prompt text. Set to `false` to export prompts without redaction. |
 | `AGENTO11Y_GUARDS_ENABLED` | `false` | Check your prompts, the conversation sent to the model, and OpenCode tool calls against Agent Observability guards. See [Guards](#guards). |
 | `AGENTO11Y_GUARDS_TIMEOUT_MS` | `1500` | Per-evaluation guard timeout in milliseconds. |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | Send the turn and allow tool calls when a guard evaluation fails. Set to `false` to refuse them instead. This covers evaluation failures at all three checks. A tool call is blocked under either setting when a guard returns redacted arguments that the plugin cannot write into the arguments OpenCode runs the tool with. |

--- a/plugins/opencode/src/client.test.ts
+++ b/plugins/opencode/src/client.test.ts
@@ -20,6 +20,7 @@ function makeConfig(
     auth: { mode: "none" },
     agentName: "opencode",
     contentCapture: "metadata_only",
+    redactInputMessages: true,
     debug: false,
     ...overrides,
   };

--- a/plugins/opencode/src/config.test.ts
+++ b/plugins/opencode/src/config.test.ts
@@ -123,6 +123,47 @@ describe("resolveConfig", () => {
     expect(cfg?.debug).toBe(false);
   });
 
+  it.each([
+    { name: "defaults to on", raw: undefined, want: true, wantWarn: false },
+    {
+      name: "honours an explicit false",
+      raw: "false",
+      want: false,
+      wantWarn: false,
+    },
+    { name: "honours an explicit 0", raw: "0", want: false, wantWarn: false },
+    {
+      name: "honours an explicit true",
+      raw: "true",
+      want: true,
+      wantWarn: false,
+    },
+    {
+      name: "keeps redaction on for an unrecognised value and warns",
+      raw: "maybe",
+      want: true,
+      wantWarn: true,
+    },
+  ])("redactInputMessages $name", ({ raw, want, wantWarn }) => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.SIGIL_ENDPOINT = "http://localhost:8080";
+    if (raw !== undefined) {
+      process.env.AGENTO11Y_REDACT_INPUT_MESSAGES = raw;
+    }
+    const cfg = resolveConfig();
+    expect(cfg?.redactInputMessages).toBe(want);
+    if (wantWarn) {
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'invalid boolean value for AGENTO11Y_REDACT_INPUT_MESSAGES: "maybe"',
+        ),
+      );
+    } else {
+      expect(warn).not.toHaveBeenCalled();
+    }
+    warn.mockRestore();
+  });
+
   it("defaults guards off, fail-open, with 1500ms timeout", () => {
     process.env.SIGIL_ENDPOINT = "http://localhost:8080";
     const cfg = resolveConfig();

--- a/plugins/opencode/src/config.ts
+++ b/plugins/opencode/src/config.ts
@@ -29,6 +29,13 @@ export interface Agento11yOpencodeConfig {
   agentName: string;
   agentVersion?: string;
   contentCapture: ContentCaptureMode;
+  /**
+   * Redact known secret formats from user prompt text before export. On by
+   * default; `AGENTO11Y_REDACT_INPUT_MESSAGES=false` opts out. Assistant
+   * text, thinking, tool arguments, and tool results are redacted under
+   * either setting.
+   */
+  redactInputMessages: boolean;
   debug: boolean;
   guards?: GuardsFeatureConfig;
   otlp?: OtlpConfig;
@@ -57,6 +64,10 @@ export function resolveConfig(): Agento11yOpencodeConfig | null {
   const agentVersion = brandedEnv("AGENT_VERSION");
 
   const contentCapture = resolveContentCapture();
+  // Defaults to true so prompts are scrubbed without configuration, matching
+  // the pi plugin. An unrecognised value keeps redaction on, so a typo cannot
+  // silently disable it.
+  const redactInputMessages = brandedBool("REDACT_INPUT_MESSAGES") ?? true;
   const debug = brandedBool("DEBUG") ?? false;
 
   return {
@@ -65,6 +76,7 @@ export function resolveConfig(): Agento11yOpencodeConfig | null {
     agentName,
     agentVersion,
     contentCapture,
+    redactInputMessages,
     debug,
     guards: resolveGuards(),
     otlp: resolveOtlp(),
@@ -226,9 +238,19 @@ function brandedEnv(suffix: string): string | undefined {
   return lookupBrandedEnv(suffix)?.value;
 }
 
+// brandedBool parses a boolean config key and warns when the value is outside
+// the accepted set, so a typo is visible instead of silently falling back to
+// the default. Matches brandedPositiveInt, the pi plugin, and envconfig.BoolValue.
 function brandedBool(suffix: string): boolean | undefined {
-  const v = brandedEnv(suffix);
-  return v !== undefined ? toBool(v) : undefined;
+  const found = lookupBrandedEnv(suffix);
+  if (found === undefined) return undefined;
+  const parsed = toBool(found.value);
+  if (parsed === undefined) {
+    console.warn(
+      `[sigil-opencode] invalid boolean value for ${found.key}: "${found.value}" - using default`,
+    );
+  }
+  return parsed;
 }
 
 export function resolveGuards(): GuardsFeatureConfig {

--- a/plugins/opencode/src/golden.test.ts
+++ b/plugins/opencode/src/golden.test.ts
@@ -267,6 +267,7 @@ describe("opencode plugin: real-SDK golden export", () => {
       agentName: "opencode",
       agentVersion: "test-version",
       contentCapture: "full",
+      redactInputMessages: true,
       debug: false,
       ...configOverrides,
     };

--- a/plugins/opencode/src/hooks.capture.test.ts
+++ b/plugins/opencode/src/hooks.capture.test.ts
@@ -225,6 +225,48 @@ describe("opencode system prompt capture", () => {
     expect(generations[1]!.seed.systemPrompt).toBe("prompt two");
   });
 
+  // A system prompt is assembled content: AGENTS.md files, tool descriptions,
+  // the `<env>` block. Both tiers run, and the flag that turns user prompt
+  // redaction off does not reach it.
+  const systemPromptCases = [
+    { name: "redacts the transform prompt with both tiers", flag: true },
+    { name: "redacts it with prompt redaction off too", flag: false },
+  ];
+
+  it.each(systemPromptCases)("$name", async ({ flag }) => {
+    const { sigil, generations } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks(baseConfig({ redactInputMessages: flag }));
+
+    emitTransform(hooks, "sess-1", [
+      "deploy with glc_abcdefghijklmnopqrstuvwxyz1234",
+      "DB_PASSWORD=hunter2",
+    ]);
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.systemPrompt).toBe(
+      "deploy with [REDACTED:grafana-cloud-token]\n" +
+        "DB_PASSWORD=[REDACTED:env-secret-value]",
+    );
+  });
+
+  it("redacts the legacy chat.message prompt override", async () => {
+    const { sigil, generations } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks();
+
+    const message = userMessage("sess-1");
+    message.system = "legacy glc_abcdefghijklmnopqrstuvwxyz1234";
+    hooks.chatMessage({ sessionID: "sess-1" }, { message, parts: [] });
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    expect(generations[0]!.seed.systemPrompt).toBe(
+      "legacy [REDACTED:grafana-cloud-token]",
+    );
+  });
+
   it("clears the prompt when the session is deleted", async () => {
     const { sigil, generations } = makeAgento11yMock();
     createAgento11yClientMock.mockReturnValue(sigil);
@@ -695,7 +737,9 @@ describe("opencode preflight redaction in the export", () => {
     ]);
   });
 
-  it("exports the original when no rule rewrote anything", async () => {
+  // With no server rule to replay, the export still carries the local
+  // redaction, which is tier 1 + tier 2 on a prompt.
+  it("falls back to local redaction when no rule rewrote anything", async () => {
     const { sigil, generations } = makeAgento11yMock();
     sigil.evaluateHook.mockResolvedValue({ action: "allow" });
     createAgento11yClientMock.mockReturnValue(sigil);
@@ -710,7 +754,70 @@ describe("opencode preflight redaction in the export", () => {
     await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
 
     expect((generations[0]!.result as any).input).toEqual([
-      { role: "user", parts: [{ type: "text", text: "token=alpha" }] },
+      {
+        role: "user",
+        parts: [{ type: "text", text: "token=[REDACTED:env-secret-value]" }],
+      },
     ]);
+    expect(stored.text).toBe("token=alpha");
+  });
+});
+
+describe("opencode user prompt redaction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetHookState();
+  });
+
+  const secret = "glc_abcdefghijklmnopqrstuvwxyz1234";
+
+  // Pins config.redactInputMessages through recordAssistantMessage into the
+  // exported input. mappers.test.ts covers mapGeneration itself; this covers
+  // the wire, so hardcoding the argument at the call site fails here.
+  const cases: {
+    name: string;
+    redactInputMessages: boolean;
+    wantPrompt: string;
+  }[] = [
+    {
+      name: "redacts the prompt when the flag is on",
+      redactInputMessages: true,
+      wantPrompt: "rotate [REDACTED:grafana-cloud-token]",
+    },
+    {
+      name: "sends the prompt unredacted when the flag is off",
+      redactInputMessages: false,
+      wantPrompt: `rotate ${secret}`,
+    },
+  ];
+
+  it.each(cases)("$name", async ({ redactInputMessages, wantPrompt }) => {
+    const { sigil, generations } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    const hooks = await makeHooks(baseConfig({ redactInputMessages }));
+
+    hooks.chatMessage(
+      { sessionID: "sess-1" },
+      {
+        message: userMessage("sess-1"),
+        parts: [
+          {
+            id: "user-text-1",
+            sessionID: "sess-1",
+            messageID: "user-1",
+            type: "text",
+            text: `rotate ${secret}`,
+          },
+        ] as any,
+      },
+    );
+    await emitMessageUpdated(hooks, assistantMessage("sess-1", "msg-1"));
+
+    expect(generations).toHaveLength(1);
+    const result = generations[0]!.result as any;
+    expect(result.input[0].parts[0]).toEqual({
+      type: "text",
+      text: wantPrompt,
+    });
   });
 });

--- a/plugins/opencode/src/hooks.guard.test.ts
+++ b/plugins/opencode/src/hooks.guard.test.ts
@@ -89,6 +89,7 @@ function config(endpoint: string): Agento11yOpencodeConfig {
     agentName: "opencode",
     agentVersion: "test-version",
     contentCapture: "full",
+    redactInputMessages: true,
     debug: false,
     guards: { enabled: true, timeoutMs: 1500, failOpen: true },
   };

--- a/plugins/opencode/src/hooks.otlp.test.ts
+++ b/plugins/opencode/src/hooks.otlp.test.ts
@@ -223,6 +223,7 @@ describe("createAgento11yHooks OTLP wiring", () => {
       agentName: "opencode",
       agentVersion: "test-version",
       contentCapture: "metadata_only",
+      redactInputMessages: true,
       debug: false,
       ...(otlpEnabled && {
         otlp: {
@@ -415,6 +416,7 @@ describe("createAgento11yHooks OTLP wiring", () => {
       agentName: "opencode",
       agentVersion: "test-version",
       contentCapture: "metadata_only",
+      redactInputMessages: true,
       debug: false,
       otlp: {
         endpoint: otlp.endpoint,

--- a/plugins/opencode/src/hooks.testutil.ts
+++ b/plugins/opencode/src/hooks.testutil.ts
@@ -98,6 +98,7 @@ export function baseConfig(
     agentName: "opencode",
     agentVersion: "test-version",
     contentCapture: "full",
+    redactInputMessages: true,
     debug: false,
     ...overrides,
   };

--- a/plugins/opencode/src/hooks.toolSpans.test.ts
+++ b/plugins/opencode/src/hooks.toolSpans.test.ts
@@ -362,6 +362,7 @@ function metadataOnlyConfig(): Agento11yOpencodeConfig {
     agentName: "opencode",
     agentVersion: "test-version",
     contentCapture: "metadata_only",
+    redactInputMessages: true,
     debug: false,
   };
 }
@@ -509,6 +510,7 @@ describe("hook lifecycle records and guard denial", () => {
       agentName: "opencode",
       agentVersion: "test-version",
       contentCapture: "full",
+      redactInputMessages: true,
       debug: false,
       // guards disabled, so the before hook just records timing.
     };
@@ -562,6 +564,7 @@ describe("hook lifecycle records and guard denial", () => {
       agentName: "opencode",
       agentVersion: "test-version",
       contentCapture: "full",
+      redactInputMessages: true,
       debug: false,
       guards: { enabled: true, timeoutMs: 1500, failOpen: false },
     };
@@ -606,6 +609,7 @@ describe("hook lifecycle records and guard denial", () => {
       agentName: "opencode",
       agentVersion: "test-version",
       contentCapture: "metadata_only",
+      redactInputMessages: true,
       debug: false,
     };
 
@@ -697,6 +701,7 @@ describe("hook lifecycle records and guard denial", () => {
       agentName: "opencode",
       agentVersion: "test-version",
       contentCapture: "full",
+      redactInputMessages: true,
       debug: false,
     };
 
@@ -770,6 +775,7 @@ describe("hook lifecycle records and guard denial", () => {
       agentName: "opencode",
       agentVersion: "test-version",
       contentCapture: "full",
+      redactInputMessages: true,
       debug: false,
     };
 

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -907,14 +907,25 @@ async function recordAssistantMessage(
 
   // Prefer the composed prompt from the system transform hook; fall back to
   // the optional legacy override from chat.message.
-  const systemPrompt =
+  const capturedSystemPrompt =
     latestSystemPromptBySession.get(assistantMsg.sessionID) ??
     pending?.systemPrompt;
-  if (systemPrompt === undefined) {
+  if (capturedSystemPrompt === undefined) {
     debugLog(
       `no system prompt captured for session=${assistantMsg.sessionID} message=${assistantMsg.id}`,
     );
   }
+  // Tier 1 + tier 2, like the SDK sanitizer and the vibe mapper: a composed
+  // system prompt is assembled content, not prose. It carries AGENTS.md files,
+  // tool descriptions and opencode's `<env>` block, so a token pasted into a
+  // project instruction file would otherwise ship in clear text. Redacted here
+  // rather than at capture time so the legacy `chat.message` override goes
+  // through the same call. AGENTO11Y_REDACT_INPUT_MESSAGES covers the user
+  // prompt only and does not reach this. Skipped when the mode drops the field.
+  const systemPrompt =
+    includeMessageBodies && capturedSystemPrompt !== undefined
+      ? redactor.redact(capturedSystemPrompt)
+      : undefined;
 
   // Tool spans double as the tool catalog source. Prefer terminal
   // `ToolPart.state.time` when assistant parts are available; hook records
@@ -1004,6 +1015,7 @@ async function recordAssistantMessage(
     redactor,
     config.contentCapture,
     stepTokens,
+    config.redactInputMessages,
   );
 
   const spanOpts = {

--- a/plugins/opencode/src/mappers.test.ts
+++ b/plugins/opencode/src/mappers.test.ts
@@ -16,6 +16,9 @@ import {
 
 const redactor = createRedactor();
 
+// A syntactically valid Grafana Cloud token that matches the tier-1 pattern.
+const GRAFANA_CLOUD_TOKEN = "glc_abcdefghijklmnopqrstuvwxyz0123456789";
+
 function makeAssistantMsg(
   overrides?: Partial<AssistantMessage>,
 ): AssistantMessage {
@@ -52,10 +55,67 @@ describe("mapInputMessages", () => {
         text: "hello world",
       },
     ] as Part[];
-    const result = mapInputMessages(parts);
+    const result = mapInputMessages(parts, redactor);
     expect(result).toHaveLength(1);
     expect(result[0].role).toBe("user");
     expect(result[0].parts?.[0]).toEqual({ type: "text", text: "hello world" });
+  });
+
+  it("redacts secrets in user text by default", () => {
+    const parts = [
+      {
+        id: "p1",
+        sessionID: "s1",
+        messageID: "m1",
+        type: "text" as const,
+        text: `deploy with ${GRAFANA_CLOUD_TOKEN} please`,
+      },
+    ] as Part[];
+
+    const result = mapInputMessages(parts, redactor);
+    expect(result[0].parts?.[0]).toEqual({
+      type: "text",
+      text: "deploy with [REDACTED:grafana-cloud-token] please",
+    });
+  });
+
+  it("sends user text unredacted when input redaction is off", () => {
+    const parts = [
+      {
+        id: "p1",
+        sessionID: "s1",
+        messageID: "m1",
+        type: "text" as const,
+        text: `deploy with ${GRAFANA_CLOUD_TOKEN} please`,
+      },
+    ] as Part[];
+
+    const result = mapInputMessages(parts, redactor, "full", false);
+    expect(result[0].parts?.[0]).toEqual({
+      type: "text",
+      text: `deploy with ${GRAFANA_CLOUD_TOKEN} please`,
+    });
+  });
+
+  // A prompt gets tier 2 as well, so an env-style pair in it is rewritten
+  // even when the pair is part of a sentence. That is the cost of catching a
+  // pasted config file; the opt-out above is the way around it.
+  it("applies tier 2 to env-style text in a prompt", () => {
+    const parts = [
+      {
+        id: "p1",
+        sessionID: "s1",
+        messageID: "m1",
+        type: "text" as const,
+        text: "rename the API_KEY = placeholder constant",
+      },
+    ] as Part[];
+
+    const result = mapInputMessages(parts, redactor);
+    expect(result[0].parts?.[0]).toEqual({
+      type: "text",
+      text: "rename the API_KEY = [REDACTED:env-secret-value] constant",
+    });
   });
 
   it("skips non-text parts", () => {
@@ -69,7 +129,7 @@ describe("mapInputMessages", () => {
         url: "...",
       },
     ] as Part[];
-    expect(mapInputMessages(parts)).toHaveLength(0);
+    expect(mapInputMessages(parts, redactor)).toHaveLength(0);
   });
 
   it("skips text parts with empty or whitespace-only text", () => {
@@ -103,7 +163,7 @@ describe("mapInputMessages", () => {
         text: "hello",
       },
     ] as Part[];
-    const result = mapInputMessages(parts);
+    const result = mapInputMessages(parts, redactor);
     expect(result).toHaveLength(1);
     expect(result[0].parts?.[0]).toEqual({ type: "text", text: "hello" });
   });
@@ -119,7 +179,7 @@ describe("mapInputMessages", () => {
       },
     ] as Part[];
 
-    expect(mapInputMessages(parts, "metadata_only")).toEqual([]);
+    expect(mapInputMessages(parts, redactor, "metadata_only")).toEqual([]);
   });
 });
 
@@ -476,6 +536,73 @@ describe("mapGeneration", () => {
       cacheReadInputTokens: 20,
       cacheWriteInputTokens: 10,
     });
+  });
+
+  it.each([
+    {
+      name: "redacts the prompt by default",
+      redactInputMessages: undefined,
+      wantPrompt: "use [REDACTED:grafana-cloud-token]",
+    },
+    {
+      name: "redacts the prompt when the flag is on",
+      redactInputMessages: true,
+      wantPrompt: "use [REDACTED:grafana-cloud-token]",
+    },
+    {
+      name: "sends the prompt unredacted when the flag is off",
+      redactInputMessages: false,
+      wantPrompt: `use ${GRAFANA_CLOUD_TOKEN}`,
+    },
+  ])("$name", ({ redactInputMessages, wantPrompt }) => {
+    const msg = makeAssistantMsg();
+    const userParts = [
+      {
+        id: "p1",
+        sessionID: "s1",
+        messageID: "m1",
+        type: "text" as const,
+        text: `use ${GRAFANA_CLOUD_TOKEN}`,
+      },
+    ] as Part[];
+    const assistantParts = [
+      {
+        id: "p2",
+        sessionID: "s1",
+        messageID: "m2",
+        type: "tool" as const,
+        callID: "call-1",
+        tool: "bash",
+        state: {
+          status: "completed",
+          input: { command: `curl -H "Authorization: ${GRAFANA_CLOUD_TOKEN}"` },
+          output: "ok",
+        },
+      },
+    ] as unknown as Part[];
+
+    const result = mapGeneration(
+      msg,
+      userParts,
+      assistantParts,
+      redactor,
+      "full",
+      undefined,
+      redactInputMessages,
+    );
+
+    expect(result.input?.[0].parts?.[0]).toEqual({
+      type: "text",
+      text: wantPrompt,
+    });
+    // The flag covers the prompt only: tool arguments stay redacted, and the
+    // usage/model fields do not depend on it.
+    const toolCall = result.output?.[0].parts?.[0];
+    expect(
+      toolCall?.type === "tool_call" ? toolCall.toolCall.inputJSON : "",
+    ).toContain("[REDACTED:grafana-cloud-token]");
+    expect(result.usage?.inputTokens).toBe(100);
+    expect(result.responseModel).toBe("claude-opus-4-20250514");
   });
 });
 

--- a/plugins/opencode/src/mappers.ts
+++ b/plugins/opencode/src/mappers.ts
@@ -30,23 +30,32 @@ function includesToolBodies(contentCapture: ContentCaptureMode): boolean {
 }
 
 /**
- * Map user-side parts to agento11y input messages. Nothing is redacted here:
- * user text is the user's own data and Agent Observability needs it for prompt
- * analysis when content capture allows it. A caller that ran a preflight redact
- * rule substitutes the rewritten text before calling this.
+ * Map user-side parts to agento11y input messages. A caller that ran a
+ * preflight redact rule substitutes the rewritten text before calling this.
+ *
+ * Separately, user text gets tier 1 + tier 2 redaction when
+ * `redactInputMessages` is on, which is the default. A prompt is where a
+ * human pastes a config file or a command line, so the tier 2 `KEY = value`
+ * heuristic is worth its false positives here; the SDK's generation sanitizer
+ * makes the same call. It does cost prose: `sort key: name` comes back with
+ * the word after the colon replaced.
+ * `AGENTO11Y_REDACT_INPUT_MESSAGES=false` sends prompts without redaction.
  */
 export function mapInputMessages(
   parts: Part[],
+  redactor: Redactor,
   contentCapture: ContentCaptureMode = "full",
+  redactInputMessages = true,
 ): Message[] {
   if (!includesMessageBodies(contentCapture)) return [];
 
   const messages: Message[] = [];
   for (const part of parts) {
     if (part.type === "text" && part.text.trim().length > 0) {
+      const text = redactInputMessages ? redactor.redact(part.text) : part.text;
       messages.push({
         role: "user",
-        parts: [{ type: "text", text: part.text }],
+        parts: [{ type: "text", text }],
       });
     }
   }
@@ -207,10 +216,16 @@ export function mapGeneration(
   redactor: Redactor,
   contentCapture: ContentCaptureMode = "full",
   tokens?: OpencodeTokens,
+  redactInputMessages = true,
 ): GenerationResult {
   const usage = tokens ?? msg.tokens;
   return {
-    input: mapInputMessages(userParts, contentCapture),
+    input: mapInputMessages(
+      userParts,
+      redactor,
+      contentCapture,
+      redactInputMessages,
+    ),
     output: mapOutputMessages(assistantParts, redactor, contentCapture),
     usage: {
       inputTokens: usage.input,

--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -4641,4 +4641,45 @@ describe("emitToolSpans", () => {
     expect(recorders[0]!.start).toMatchObject({ startedAt: new Date(1000) });
     expect(recorders[0]!.result?.completedAt).toEqual(new Date(5000));
   });
+
+  // The SDK's generation sanitizer never sees a tool-execution span, so the
+  // span needs its own redaction pass over the same bytes.
+  it("redacts arguments and results", () => {
+    const token = "glc_abcdefghijklmnopqrstuvwxyz";
+    const { client, recorders } = mockAgento11yClient();
+    const msg = makePiMsg({
+      content: [
+        {
+          type: "toolCall",
+          id: "c1",
+          name: "bash",
+          arguments: { cmd: "deploy.sh", env: "API_TOKEN=hunter2" },
+        },
+      ],
+    });
+    const toolResults = [
+      makePiToolResult({
+        toolCallId: "c1",
+        content: [{ type: "text", text: `authenticated with ${token}` }],
+      }),
+    ];
+
+    emitToolSpans(
+      client,
+      msg,
+      toolResults,
+      [makePiTiming({ toolCallId: "c1" })],
+      { agentName: "pi", contentCapture: "full" },
+    );
+
+    const args = recorders[0]!.result?.arguments as string;
+    const result = recorders[0]!.result?.result as string;
+    // Arguments get both tiers, so the env-style pair goes too, and the
+    // argument that is not a secret survives.
+    expect(args).not.toContain("hunter2");
+    expect(args).toContain("[REDACTED:env-secret-value]");
+    expect(args).toContain("deploy.sh");
+    expect(result).not.toContain(token);
+    expect(result).toBe("authenticated with [REDACTED:grafana-cloud-token]");
+  });
 });

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -4,6 +4,7 @@ import type {
   ContentCaptureMode,
   Message,
 } from "@grafana/agento11y";
+import { redactSecretText } from "@grafana/agento11y";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { createAgento11yClient } from "./client.js";
 import type { Agento11yPiConfig } from "./config.js";
@@ -1070,7 +1071,17 @@ function toPiUsage(value: unknown): PiUsageLike | undefined {
   return seen ? out : undefined;
 }
 
-/** @internal Exported for testing. */
+/**
+ * Emit one `execute_tool` span per tool call in the turn.
+ *
+ * Arguments and results are redacted here. This is a second boundary: the SDK's
+ * generation sanitizer scrubs the copy of the same bytes that rides in the
+ * generation payload, but it does not see a tool-execution span, so the span
+ * needs its own pass. Full strength (tier 1 + tier 2), which is what the
+ * sanitizer applies to a tool payload.
+ *
+ * @internal Exported for testing.
+ */
 export function emitToolSpans(
   client: Agento11yClient,
   msg: PiAssistantMessage,
@@ -1088,16 +1099,20 @@ export function emitToolSpans(
 
   const includeContent = opts.contentCapture === "full";
 
-  const argsMap = new Map<string, Record<string, unknown>>();
+  const argsMap = new Map<string, string>();
   const resultMap = new Map<string, string>();
   if (includeContent) {
     for (const block of msg.content) {
-      if (block.type === "toolCall") {
-        argsMap.set(block.id, block.arguments);
-      }
+      if (block.type !== "toolCall") continue;
+      const encoded = JSON.stringify(block.arguments);
+      if (encoded === undefined) continue;
+      argsMap.set(block.id, redactSecretText(encoded));
     }
     for (const tr of toolResults) {
-      resultMap.set(tr.toolCallId, toolResultText(tr.content));
+      resultMap.set(
+        tr.toolCallId,
+        redactSecretText(toolResultText(tr.content)),
+      );
     }
   }
 
@@ -1127,8 +1142,8 @@ export function emitToolSpans(
 
       if (includeContent) {
         const args = argsMap.get(timing.toolCallId);
-        if (args) {
-          end.arguments = JSON.stringify(args);
+        if (args !== undefined) {
+          end.arguments = args;
         }
         const trContent = resultMap.get(timing.toolCallId);
         if (trContent !== undefined) {

--- a/plugins/vibe/README.md
+++ b/plugins/vibe/README.md
@@ -6,6 +6,8 @@
 
 By default only metadata is sent (token counts, model, tool names). Set `AGENTO11Y_CONTENT_CAPTURE_MODE` to `full`, `no_tool_content`, `metadata_only`, or `full_with_metadata_spans` to control what is sent. `default` is accepted as an alias for `metadata_only`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md) for the full reference.
 
+Exported content is redacted for known secret formats first. That includes the user prompt; set `AGENTO11Y_REDACT_INPUT_MESSAGES=false` to export prompt text without redaction. Assistant text, reasoning, and tool results stay redacted either way. Tool-call arguments and the conversation title are not redacted yet.
+
 ## 1. Install and launch
 
 **Quick install (Linux/macOS):**

--- a/redaction/README.md
+++ b/redaction/README.md
@@ -76,6 +76,17 @@ a CJK character stays in clear text in Python and .NET while Go and JavaScript
 redact it. The C# table also carries `RegexOptions.CultureInvariant`, so
 case-insensitive matching does not follow the host culture.
 
+## Which tier runs on which field
+
+The table says what a pattern matches; the caller decides which tier runs. Both
+the SDKs' generation sanitizer and every coding-agent plugin split it the same
+way: tier 1 + tier 2 on a user prompt, a system prompt and a tool payload,
+tier 1 only on assistant text, reasoning, a conversation title and an error
+message. Prose is left on tier 1 because the tier 2 heuristics rewrite the word
+after any `key:` in a sentence. `docs/concepts/content-capture-modes.md` has the
+per-field table and the plugin-side details; the Go plugins spell the policy out
+in `plugins/agento11y/internal/redact/fields.go`.
+
 ## Email redaction is gated per call site
 
 The email pattern is in the shared table, but whether it runs is the caller's
@@ -83,6 +94,10 @@ choice. The SDKs redact addresses by default (`RedactEmailAddresses`). The
 `agento11y` binary and the opencode plugin pass `false`: agent transcripts
 routinely carry commit authors and reviewer addresses, and redacting them costs
 more context than it protects.
+
+The pi plugin is the exception among the plugins. It redacts through the SDK's
+generation sanitizer instead of its own mapper, so it takes the SDK default and
+does redact addresses. Unlike the tiering, this has not been unified.
 
 ## Known limitations
 
@@ -97,6 +112,17 @@ more context than it protects.
   `[REDACTED:grafana-cloud-token]`: `json-secret-field` replaces the whole
   quoted value, including a marker a tier 1 pattern already wrote there. Nothing
   leaks; only the label is coarser.
+- Tier 2 over JSON text can eat an escape. The value class in
+  `env-secret-value` stops at `"` but not at `\`, so a key/value pair inside an
+  encoded JSON string takes the backslash with it:
+  `{"cmd":"curl -H \"token: hunter2\" host"}` comes out with `hunter2\`
+  replaced, and the surviving `"` ends the string early. The secret is redacted
+  and the JSON no longer parses. This applies wherever an engine redacts encoded
+  JSON as text, which is what the SDKs' sanitizers do to `input_json`, and what
+  the OpenCode and Pi plugins do to tool payloads. The shared `agento11y` binary
+  decodes first (`RedactJSON`), so it is unaffected. Adding `\` to the class
+  would fix the escape and truncate a secret that really does contain a
+  backslash, which is why it has not been changed.
 - Whitespace stops at U+00A0. The wider Unicode spaces (U+2000 to U+200A,
   U+3000, and the rest) do not count as separators, because Go RE2 spells their
   escapes differently from the other three engines and the table holds one


### PR DESCRIPTION
Most of coding agent plugins already redacted user prompts, but the env variable `AGENTO11Y_REDACT_INPUT_MESSAGES` was ignored in there (except the pi plugin) while it works for the SDKs.

The flag now covers the user prompt in every plugin for prompts. Assistant text, thinking, tool arguments, and tool results stay redacted under either setting. Redaction is on by default.