### PR TITLE
feat(plugins/agento11y): add noninteractive managed install

### DIFF
--- a/plugins/agento11y/internal/agents/claudecode/launch.go
+++ b/plugins/agento11y/internal/agents/claudecode/launch.go
@@ -42,6 +42,10 @@ const (
 	updateCheckTTL = 24 * time.Hour
 )
 
+// ErrCLINotFound means the Claude Code binary is not available on PATH for the
+// current user. Managed deployment tooling can treat this as a skipped agent.
+var ErrCLINotFound = errors.New("claude CLI not found")
+
 // Test seams.
 var (
 	lookPath   = exec.LookPath
@@ -108,6 +112,30 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 		UpdateTTL:     updateCheckTTL,
 		BinaryVersion: binaryVersion,
 	})
+}
+
+// Install registers the Claude Code plugin without starting Claude or
+// prompting for Agent Observability credentials. It is intended for managed
+// deployment tooling that has already configured the current user.
+//
+// The returned value is true only when this invocation registered the plugin.
+func Install(ctx context.Context, stdout io.Writer) (bool, error) {
+	bin, err := lookPath("claude")
+	if err != nil {
+		return false, fmt.Errorf("%w; install Claude Code or run this in the developer's user context", ErrCLINotFound)
+	}
+
+	installed, err := pluginInstalled()
+	if err != nil {
+		return false, err
+	}
+	if installed {
+		return false, nil
+	}
+	if err := runInstall(ctx, bin, stdout); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // Status reports whether the Claude Code plugin is installed for the current

--- a/plugins/agento11y/internal/agents/claudecode/launch.go
+++ b/plugins/agento11y/internal/agents/claudecode/launch.go
@@ -120,17 +120,18 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 //
 // The returned value is true only when this invocation registered the plugin.
 func Install(ctx context.Context, stdout io.Writer) (bool, error) {
+	// A registered plugin does not need the Claude CLI to remain registered.
+	// Check that first so a managed reconcile stays converged if a developer
+	// later removes the CLI from PATH. A malformed or unreadable store is not
+	// authoritative; with a CLI available, let Claude repair it by reinstalling.
+	installed, probeErr := pluginInstalled()
+	if probeErr == nil && installed {
+		return false, nil
+	}
+
 	bin, err := lookPath("claude")
 	if err != nil {
 		return false, fmt.Errorf("%w; install Claude Code or run this in the developer's user context", ErrCLINotFound)
-	}
-
-	installed, err := pluginInstalled()
-	if err != nil {
-		return false, err
-	}
-	if installed {
-		return false, nil
 	}
 	if err := runInstall(ctx, bin, stdout); err != nil {
 		return false, err

--- a/plugins/agento11y/internal/agents/claudecode/launch_test.go
+++ b/plugins/agento11y/internal/agents/claudecode/launch_test.go
@@ -26,6 +26,48 @@ func TestLaunch_MissingClaudeBinary(t *testing.T) {
 	}
 }
 
+func TestInstall_RegistersWithoutLaunching(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/claude", nil })
+
+	installs := 0
+	withRunInstall(t, func(_ context.Context, bin string, _ io.Writer) error {
+		installs++
+		if bin != "/usr/local/bin/claude" {
+			t.Errorf("install bin = %q, want /usr/local/bin/claude", bin)
+		}
+		return nil
+	})
+
+	changed, err := Install(context.Background(), io.Discard)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, 1, installs)
+}
+
+func TestInstall_SkipsExistingPlugin(t *testing.T) {
+	dir := t.TempDir()
+	writeInstalled(t, dir, `{"version":2,"plugins":{"agento11y-claude-code@agento11y":[{"scope":"user"}]}}`)
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/claude", nil })
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		t.Fatal("runInstall must not be called for an existing plugin")
+		return nil
+	})
+
+	changed, err := Install(context.Background(), io.Discard)
+	require.NoError(t, err)
+	require.False(t, changed)
+}
+
+func TestInstall_MissingClaudeIsClassifiable(t *testing.T) {
+	withLookPath(t, func(string) (string, error) { return "", exec.ErrNotFound })
+
+	_, err := Install(context.Background(), io.Discard)
+	require.ErrorIs(t, err, ErrCLINotFound)
+}
+
 func TestLaunch_SkipsInstallWhenPluginPresent(t *testing.T) {
 	t.Setenv("SIGIL_AUTO_UPDATE", "false")
 

--- a/plugins/agento11y/internal/agents/claudecode/launch_test.go
+++ b/plugins/agento11y/internal/agents/claudecode/launch_test.go
@@ -61,6 +61,39 @@ func TestInstall_SkipsExistingPlugin(t *testing.T) {
 	require.False(t, changed)
 }
 
+func TestInstall_SkipsExistingPluginWithoutClaudeOnPATH(t *testing.T) {
+	dir := t.TempDir()
+	writeInstalled(t, dir, `{"version":2,"plugins":{"agento11y-claude-code@agento11y":[{"scope":"user"}]}}`)
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	withLookPath(t, func(string) (string, error) { return "", exec.ErrNotFound })
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		t.Fatal("runInstall must not be called for an existing plugin")
+		return nil
+	})
+
+	changed, err := Install(context.Background(), io.Discard)
+	require.NoError(t, err)
+	require.False(t, changed)
+}
+
+func TestInstall_RepairsUnreadablePluginStore(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "plugins"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "plugins", "installed_plugins.json"), []byte("not json"), 0o600))
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/claude", nil })
+	installs := 0
+	withRunInstall(t, func(context.Context, string, io.Writer) error {
+		installs++
+		return nil
+	})
+
+	changed, err := Install(context.Background(), io.Discard)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, 1, installs)
+}
+
 func TestInstall_MissingClaudeIsClassifiable(t *testing.T) {
 	withLookPath(t, func(string) (string, error) { return "", exec.ErrNotFound })
 

--- a/plugins/agento11y/internal/agents/cursor/install/install.go
+++ b/plugins/agento11y/internal/agents/cursor/install/install.go
@@ -140,6 +140,33 @@ func Uninstall(stdout, _ io.Writer, logger *log.Logger) error {
 	return nil
 }
 
+// Status reports whether every Cursor event agento11y wires has one of this
+// installer's hook commands. It is read-only so `agento11y doctor` can use it
+// safely in a managed deployment health check.
+func Status() (bool, error) {
+	path, err := cursorHooksPath()
+	if err != nil {
+		return false, err
+	}
+	doc, err := loadHooks(path)
+	if err != nil {
+		return false, err
+	}
+	for _, event := range cursorEvents {
+		found := false
+		for _, entry := range doc.hooks[event] {
+			if isOursHook(commandOf(entry)) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
 // cursorHooksPath returns the user-level Cursor hooks file path.
 //
 // Cursor reads ~/.cursor/hooks.json for user-global hooks. No config-dir

--- a/plugins/agento11y/internal/agents/cursor/install/install_test.go
+++ b/plugins/agento11y/internal/agents/cursor/install/install_test.go
@@ -371,6 +371,26 @@ func TestInstallThenUninstallRoundTrip(t *testing.T) {
 	}
 }
 
+func TestStatus(t *testing.T) {
+	home := t.TempDir()
+	withHome(t, home)
+
+	installed, err := Status()
+	require.NoError(t, err)
+	assert.False(t, installed, "a missing hooks file is not installed")
+
+	withExecutable(t, testBin)
+	require.NoError(t, Run(io.Discard, io.Discard, nopLogger()))
+	installed, err = Status()
+	require.NoError(t, err)
+	assert.True(t, installed)
+
+	seedHooks(t, home, `{"version":1,"hooks":{"sessionStart":[{"command":"agento11y cursor hook"}]}}`)
+	installed, err = Status()
+	require.NoError(t, err)
+	assert.False(t, installed, "partial hook wiring is not a healthy install")
+}
+
 func TestIsOursHook(t *testing.T) {
 	cases := []struct {
 		cmd  string

--- a/plugins/agento11y/internal/doctor/agents.go
+++ b/plugins/agento11y/internal/doctor/agents.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/claudecode"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/codex"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/copilot"
+	cursorinstall "github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/install"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/opencode"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/pi"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/vibe"
@@ -23,14 +24,17 @@ type agentProbe struct {
 	name string
 	// bin is the executable looked up on PATH.
 	bin string
-	// status is the package's read-only install probe, or nil for hook-only
-	// agents (cursor) that the agento11y binary never installs.
+	// status is the package's read-only install probe.
 	status statusFn
 	// configBased is true when status reads install state from files and needs
 	// no binary on PATH (claude, opencode, pi, copilot, vibe). For these, doctor
 	// reports install state even when the CLI is absent. CLI-dependent probes
 	// (codex) shell out to the binary, so they're skipped when it's missing.
 	configBased bool
+	// fallbackVersion is used by integrations whose hooks invoke the shared
+	// agento11y binary instead of shipping their own independently versioned
+	// plugin.
+	fallbackVersion bool
 	// notInstalledLabel overrides the default "plugin not installed" wording
 	// for agents whose capture isn't plugin-based (copilot and vibe use hooks).
 	notInstalledLabel string
@@ -41,9 +45,8 @@ type agentProbe struct {
 // Test seam.
 var lookPath = exec.LookPath
 
-// agentProbes is the detection/probe table. cursor is hook-only (no launcher),
-// so it has no install probe: its capture is wired into Cursor's own hook
-// settings, and its effective version is the agento11y binary's.
+// agentProbes is the detection/probe table. Cursor is hook-based and its
+// effective version is the shared agento11y binary's.
 var agentProbes = []agentProbe{
 	{name: "claude", bin: "claude", status: claudecode.Status, configBased: true},
 	{name: "codex", bin: "codex", status: codex.Status},
@@ -51,12 +54,14 @@ var agentProbes = []agentProbe{
 	{name: "opencode", bin: "opencode", status: opencode.Status, configBased: true},
 	{name: "pi", bin: "pi", status: pi.Status, configBased: true},
 	{name: "vibe", bin: "vibe", status: vibe.Status, configBased: true, notInstalledLabel: "not configured", note: "hook-based"},
-	{name: "cursor", bin: "cursor", status: nil, note: "hook-based; configured in Cursor settings"},
+	{name: "cursor", bin: "cursor", status: func(context.Context) (bool, string, error) {
+		installed, err := cursorinstall.Status()
+		return installed, "", err
+	}, configBased: true, fallbackVersion: true, note: "hook-based; configured in Cursor settings"},
 }
 
 // defaultCollectAgents runs the PATH sweep and per-agent read-only status
-// probe. binaryVersion is reported as cursor's version (its hooks call the
-// agento11y binary, so they move together).
+// probe.
 func defaultCollectAgents(ctx context.Context, binaryVersion string) []AgentStatus {
 	out := make([]AgentStatus, 0, len(agentProbes))
 	for _, probe := range agentProbes {
@@ -72,9 +77,8 @@ func probeAgent(ctx context.Context, probe agentProbe, binaryVersion string) Age
 	_, lookErr := lookPath(probe.bin)
 	a.OnPath = lookErr == nil
 
-	// Hook-only agent (cursor): no install probe, detection is PATH presence.
-	// Capture is configured in the host's own settings, which the agento11y binary
-	// doesn't manage, so report it as present with the agento11y binary version.
+	// Keep the nil-status behaviour for test probes and future integrations
+	// whose host only establishes availability by being on PATH.
 	if probe.status == nil {
 		if !a.OnPath {
 			a.Health = HealthSkipped
@@ -103,10 +107,14 @@ func probeAgent(ctx context.Context, probe agentProbe, binaryVersion string) Age
 		return a
 	}
 	if installed {
+		if version == "" && probe.fallbackVersion {
+			version = binaryVersion
+		}
 		// A version belongs to an installed plugin, so both the human report and
 		// the JSON one drop a version a probe reports next to "not installed".
 		a.Version = version
 		a.Install = InstallStateInstalled
+		a.HookBased = probe.fallbackVersion
 		a.Health = HealthOK
 	} else {
 		a.Install = InstallStateNotInstalled

--- a/plugins/agento11y/internal/doctor/agents.go
+++ b/plugins/agento11y/internal/doctor/agents.go
@@ -57,7 +57,7 @@ var agentProbes = []agentProbe{
 	{name: "cursor", bin: "cursor", status: func(context.Context) (bool, string, error) {
 		installed, err := cursorinstall.Status()
 		return installed, "", err
-	}, configBased: true, fallbackVersion: true, note: "hook-based; configured in Cursor settings"},
+	}, configBased: true, fallbackVersion: true, notInstalledLabel: "not configured", note: "hook-based; configured in Cursor settings"},
 }
 
 // defaultCollectAgents runs the PATH sweep and per-agent read-only status

--- a/plugins/agento11y/internal/doctor/agents_test.go
+++ b/plugins/agento11y/internal/doctor/agents_test.go
@@ -87,6 +87,18 @@ func TestDefaultCollectAgents(t *testing.T) {
 	}
 }
 
+func TestCursorProbeUsesHookConfigurationWording(t *testing.T) {
+	for _, probe := range agentProbes {
+		if probe.name == "cursor" {
+			if probe.notInstalledLabel != "not configured" {
+				t.Fatalf("cursor notInstalledLabel = %q, want not configured", probe.notInstalledLabel)
+			}
+			return
+		}
+	}
+	t.Fatal("cursor probe missing")
+}
+
 // An AgentStatus built without an install state must not read as a definite
 // "not installed" in either output. The zero value is outside the domain, so
 // both the renderer and the JSON contract map it to unknown.

--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -11,6 +11,7 @@
 //	agento11y pi       [--local|--no-local] [--tag k=v] [-- args...]  — exec pi after bootstrapping the @grafana/agento11y-pi extension
 //	agento11y vibe     [--local|--no-local] [--tag k=v] [-- args...]  — exec vibe after installing the sigil hook in vibe's hooks.toml
 //	agento11y cursor   install|uninstall                              — wire (or remove) the Cursor hook in ~/.cursor/hooks.json
+//	agento11y agents install --agents claude,cursor [--json]           — wire coding agents without launching or prompting
 //	agento11y local start|status|stop                                 — manage the local capture daemon
 //	agento11y history import <agent> [flags]                          — backfill an agent's existing local sessions
 //	agento11y skills list|show <name>                                 — print an agent skill bundled into this binary
@@ -34,6 +35,7 @@ package entry
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -126,6 +128,7 @@ func localPrivacyLines(posture local.ForwardPosture, known bool) []string {
 func usageLine() string {
 	return "usage: agento11y login [--endpoint url] [--tenant id] [--token value|--token-stdin] " +
 		"[--otlp-endpoint url] [--no-verify] [--yes] | agento11y doctor [--json] | " +
+		"agento11y agents install --agents claude,cursor [--json] | " +
 		"agento11y skills list|show <name> | agento11y local start|status|stop | " +
 		"agento11y history import <" + historyAgentNames() + "> | agento11y cursor install|uninstall | agento11y <agent> hook | " +
 		"agento11y <claude|codex|copilot|opencode|pi|vibe> [--local|--no-local] [--tag key=value]... [-- args...]"
@@ -183,6 +186,8 @@ var loginRun = login.Run
 var (
 	cursorInstall   = cursorinstall.Run
 	cursorUninstall = cursorinstall.Uninstall
+	cursorStatus    = cursorinstall.Status
+	claudeInstall   = claudecode.Install
 )
 
 // Main is the entrypoint shared by cmd/agento11y and cmd/agento11y.
@@ -238,6 +243,14 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 	// dispatch like `local`. It owns its own flag parsing.
 	if args[0] == "doctor" {
 		runDoctorCommand(args[1:], stdout, stderr)
+		return
+	}
+
+	// `agento11y agents install` is the noninteractive counterpart to the
+	// per-agent launchers. Managed deployment tooling uses it after placing a
+	// config.env for the current user; it never launches an agent or prompts.
+	if args[0] == "agents" {
+		runAgentsCommand(args[1:], stdout, stderr)
 		return
 	}
 
@@ -582,6 +595,103 @@ func runCursorInstall(verb string, stdout, stderr io.Writer) {
 			logger.Printf("auto-login: %v", err)
 			_, _ = fmt.Fprintf(stderr, "agento11y: setup failed (%v); run `agento11y login` when ready\n", err)
 		}
+	}
+}
+
+type agentInstallResult struct {
+	Agent  string `json:"agent"`
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+type agentInstallReport struct {
+	Agents []agentInstallResult `json:"agents"`
+}
+
+// runAgentsCommand installs coding-agent integrations without entering an
+// interactive setup flow or starting the underlying agent. It is primarily for
+// managed-device tooling, which writes config.env separately for each user.
+func runAgentsCommand(args []string, stdout, stderr io.Writer) {
+	if len(args) == 0 || args[0] != "install" {
+		_, _ = fmt.Fprintln(stderr, "usage: agento11y agents install --agents claude,cursor [--json]")
+		exit(2)
+		return
+	}
+
+	fs := flag.NewFlagSet("agents install", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var rawAgents string
+	var asJSON bool
+	fs.StringVar(&rawAgents, "agents", "", "comma-separated agents to install (claude,cursor)")
+	fs.BoolVar(&asJSON, "json", false, "print a machine-readable result")
+	if err := fs.Parse(args[1:]); err != nil || fs.NArg() != 0 || strings.TrimSpace(rawAgents) == "" {
+		_, _ = fmt.Fprintln(stderr, "usage: agento11y agents install --agents claude,cursor [--json]")
+		exit(2)
+		return
+	}
+
+	wanted := map[string]bool{}
+	for name := range strings.SplitSeq(rawAgents, ",") {
+		name = strings.TrimSpace(name)
+		if name != "claude" && name != "cursor" {
+			_, _ = fmt.Fprintf(stderr, "agento11y agents install: unsupported agent %q (supported: claude,cursor)\n", name)
+			exit(2)
+			return
+		}
+		wanted[name] = true
+	}
+
+	writer := stdout
+	if asJSON {
+		writer = io.Discard
+	}
+	report := agentInstallReport{Agents: make([]agentInstallResult, 0, len(wanted))}
+	failed := false
+	for _, name := range []string{"claude", "cursor"} {
+		if !wanted[name] {
+			continue
+		}
+		result := agentInstallResult{Agent: name}
+		switch name {
+		case "claude":
+			changed, err := claudeInstall(context.Background(), writer)
+			switch {
+			case errors.Is(err, claudecode.ErrCLINotFound):
+				result.Status = "missing_host"
+			case err != nil:
+				result.Status, result.Error, failed = "error", err.Error(), true
+			case changed:
+				result.Status = "installed"
+			default:
+				result.Status = "already_installed"
+			}
+		case "cursor":
+			before, err := cursorStatus()
+			if err == nil {
+				err = cursorInstall(writer, stderr, cli.InitLogger("cursor"))
+			}
+			if err != nil {
+				result.Status, result.Error, failed = "error", err.Error(), true
+			} else if before {
+				result.Status = "already_installed"
+			} else {
+				result.Status = "installed"
+			}
+		}
+		report.Agents = append(report.Agents, result)
+	}
+
+	if asJSON {
+		data, err := json.Marshal(report)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "agento11y agents install: encode result: %v\n", err)
+			failed = true
+		} else {
+			_, _ = fmt.Fprintln(stdout, string(data))
+		}
+	}
+	if failed {
+		exit(1)
 	}
 }
 

--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -186,7 +186,6 @@ var loginRun = login.Run
 var (
 	cursorInstall   = cursorinstall.Run
 	cursorUninstall = cursorinstall.Uninstall
-	cursorStatus    = cursorinstall.Status
 	claudeInstall   = claudecode.Install
 )
 

--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -11,7 +11,7 @@
 //	agento11y pi       [--local|--no-local] [--tag k=v] [-- args...]  — exec pi after bootstrapping the @grafana/agento11y-pi extension
 //	agento11y vibe     [--local|--no-local] [--tag k=v] [-- args...]  — exec vibe after installing the sigil hook in vibe's hooks.toml
 //	agento11y cursor   install|uninstall                              — wire (or remove) the Cursor hook in ~/.cursor/hooks.json
-//	agento11y agents install --agents claude,cursor [--json]           — wire coding agents without launching or prompting
+//	agento11y claude   install [--json]                               — register the Claude Code plugin without launching or prompting
 //	agento11y local start|status|stop                                 — manage the local capture daemon
 //	agento11y history import <agent> [flags]                          — backfill an agent's existing local sessions
 //	agento11y skills list|show <name>                                 — print an agent skill bundled into this binary
@@ -128,7 +128,7 @@ func localPrivacyLines(posture local.ForwardPosture, known bool) []string {
 func usageLine() string {
 	return "usage: agento11y login [--endpoint url] [--tenant id] [--token value|--token-stdin] " +
 		"[--otlp-endpoint url] [--no-verify] [--yes] | agento11y doctor [--json] | " +
-		"agento11y agents install --agents claude,cursor [--json] | " +
+		"agento11y claude install [--json] | " +
 		"agento11y skills list|show <name> | agento11y local start|status|stop | " +
 		"agento11y history import <" + historyAgentNames() + "> | agento11y cursor install|uninstall | agento11y <agent> hook | " +
 		"agento11y <claude|codex|copilot|opencode|pi|vibe> [--local|--no-local] [--tag key=value]... [-- args...]"
@@ -246,11 +246,11 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 		return
 	}
 
-	// `agento11y agents install` is the noninteractive counterpart to the
-	// per-agent launchers. Managed deployment tooling uses it after placing a
-	// config.env for the current user; it never launches an agent or prompts.
-	if args[0] == "agents" {
-		runAgentsCommand(args[1:], stdout, stderr)
+	// `agento11y claude install` is the noninteractive counterpart to the
+	// launcher. Managed deployment tooling uses it after placing a config.env
+	// for the current user; it never launches Claude or prompts.
+	if args[0] == "claude" && len(args) >= 2 && args[1] == "install" {
+		runClaudeInstall(args[2:], stdout, stderr)
 		return
 	}
 
@@ -604,93 +604,48 @@ type agentInstallResult struct {
 	Error  string `json:"error,omitempty"`
 }
 
-type agentInstallReport struct {
-	Agents []agentInstallResult `json:"agents"`
-}
-
-// runAgentsCommand installs coding-agent integrations without entering an
-// interactive setup flow or starting the underlying agent. It is primarily for
-// managed-device tooling, which writes config.env separately for each user.
-func runAgentsCommand(args []string, stdout, stderr io.Writer) {
-	if len(args) == 0 || args[0] != "install" {
-		_, _ = fmt.Fprintln(stderr, "usage: agento11y agents install --agents claude,cursor [--json]")
-		exit(2)
-		return
-	}
-
-	fs := flag.NewFlagSet("agents install", flag.ContinueOnError)
+// runClaudeInstall registers the Claude Code plugin without entering an
+// interactive setup flow or starting Claude. It is intended for managed-device
+// tooling, which writes config.env separately for each user.
+func runClaudeInstall(args []string, stdout, stderr io.Writer) {
+	fs := flag.NewFlagSet("claude install", flag.ContinueOnError)
 	fs.SetOutput(stderr)
-	var rawAgents string
 	var asJSON bool
-	fs.StringVar(&rawAgents, "agents", "", "comma-separated agents to install (claude,cursor)")
 	fs.BoolVar(&asJSON, "json", false, "print a machine-readable result")
-	if err := fs.Parse(args[1:]); err != nil || fs.NArg() != 0 || strings.TrimSpace(rawAgents) == "" {
-		_, _ = fmt.Fprintln(stderr, "usage: agento11y agents install --agents claude,cursor [--json]")
+	if err := fs.Parse(args); err != nil || fs.NArg() != 0 {
+		_, _ = fmt.Fprintln(stderr, "usage: agento11y claude install [--json]")
 		exit(2)
 		return
-	}
-
-	wanted := map[string]bool{}
-	for name := range strings.SplitSeq(rawAgents, ",") {
-		name = strings.TrimSpace(name)
-		if name != "claude" && name != "cursor" {
-			_, _ = fmt.Fprintf(stderr, "agento11y agents install: unsupported agent %q (supported: claude,cursor)\n", name)
-			exit(2)
-			return
-		}
-		wanted[name] = true
 	}
 
 	writer := stdout
 	if asJSON {
 		writer = io.Discard
 	}
-	report := agentInstallReport{Agents: make([]agentInstallResult, 0, len(wanted))}
-	failed := false
-	for _, name := range []string{"claude", "cursor"} {
-		if !wanted[name] {
-			continue
-		}
-		result := agentInstallResult{Agent: name}
-		switch name {
-		case "claude":
-			changed, err := claudeInstall(context.Background(), writer)
-			switch {
-			case errors.Is(err, claudecode.ErrCLINotFound):
-				result.Status = "missing_host"
-			case err != nil:
-				result.Status, result.Error, failed = "error", err.Error(), true
-			case changed:
-				result.Status = "installed"
-			default:
-				result.Status = "already_installed"
-			}
-		case "cursor":
-			before, err := cursorStatus()
-			if err == nil {
-				err = cursorInstall(writer, stderr, cli.InitLogger("cursor"))
-			}
-			if err != nil {
-				result.Status, result.Error, failed = "error", err.Error(), true
-			} else if before {
-				result.Status = "already_installed"
-			} else {
-				result.Status = "installed"
-			}
-		}
-		report.Agents = append(report.Agents, result)
+	result := agentInstallResult{Agent: "claude"}
+	changed, err := claudeInstall(context.Background(), writer)
+	switch {
+	case errors.Is(err, claudecode.ErrCLINotFound):
+		result.Status = "missing_host"
+	case err != nil:
+		result.Status, result.Error = "error", err.Error()
+	case changed:
+		result.Status = "installed"
+	default:
+		result.Status = "already_installed"
 	}
 
 	if asJSON {
-		data, err := json.Marshal(report)
+		data, err := json.Marshal(result)
 		if err != nil {
-			_, _ = fmt.Fprintf(stderr, "agento11y agents install: encode result: %v\n", err)
-			failed = true
+			_, _ = fmt.Fprintf(stderr, "agento11y claude install: encode result: %v\n", err)
+			exit(1)
+			return
 		} else {
 			_, _ = fmt.Fprintln(stdout, string(data))
 		}
 	}
-	if failed {
+	if result.Status == "error" {
 		exit(1)
 	}
 }

--- a/plugins/agento11y/internal/entry/entry_test.go
+++ b/plugins/agento11y/internal/entry/entry_test.go
@@ -574,50 +574,35 @@ func withStubClaudeInstall(t *testing.T, fn func(context.Context, io.Writer) (bo
 	claudeInstall = fn
 }
 
-func TestRun_AgentsInstallJSON(t *testing.T) {
+func TestRun_ClaudeInstallJSON(t *testing.T) {
 	withStubClaudeInstall(t, func(context.Context, io.Writer) (bool, error) { return true, nil })
-	withStubCursorStatus(t, func() (bool, error) { return false, nil })
-	withStubCursorInstall(t, func(io.Writer, io.Writer, *log.Logger) error { return nil })
 
 	var stdout, stderr bytes.Buffer
 	gotExit := withExit(t, func() {
-		run([]string{"agents", "install", "--agents", "claude,cursor", "--json"}, strings.NewReader(""), &stdout, &stderr)
+		run([]string{"claude", "install", "--json"}, strings.NewReader(""), &stdout, &stderr)
 	})
 	require.Nil(t, gotExit, "stderr=%q", stderr.String())
 	require.Empty(t, stderr.String())
 
-	var report agentInstallReport
-	require.NoError(t, json.Unmarshal(stdout.Bytes(), &report), "stdout=%q", stdout.String())
-	assert.Equal(t, []agentInstallResult{
-		{Agent: "claude", Status: "installed"},
-		{Agent: "cursor", Status: "installed"},
-	}, report.Agents)
+	var result agentInstallResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result), "stdout=%q", stdout.String())
+	assert.Equal(t, agentInstallResult{Agent: "claude", Status: "installed"}, result)
 }
 
-func TestRun_AgentsInstallReportsMissingClaudeWithoutFailingCursor(t *testing.T) {
+func TestRun_ClaudeInstallReportsMissingHost(t *testing.T) {
 	withStubClaudeInstall(t, func(context.Context, io.Writer) (bool, error) {
 		return false, claudecode.ErrCLINotFound
-	})
-	withStubCursorStatus(t, func() (bool, error) { return true, nil })
-	cursorInstalls := 0
-	withStubCursorInstall(t, func(io.Writer, io.Writer, *log.Logger) error {
-		cursorInstalls++
-		return nil
 	})
 
 	var stdout, stderr bytes.Buffer
 	gotExit := withExit(t, func() {
-		run([]string{"agents", "install", "--agents", "claude,cursor", "--json"}, strings.NewReader(""), &stdout, &stderr)
+		run([]string{"claude", "install", "--json"}, strings.NewReader(""), &stdout, &stderr)
 	})
 	require.Nil(t, gotExit, "stderr=%q", stderr.String())
 
-	var report agentInstallReport
-	require.NoError(t, json.Unmarshal(stdout.Bytes(), &report), "stdout=%q", stdout.String())
-	assert.Equal(t, []agentInstallResult{
-		{Agent: "claude", Status: "missing_host"},
-		{Agent: "cursor", Status: "already_installed"},
-	}, report.Agents)
-	assert.Equal(t, 1, cursorInstalls, "Cursor install re-runs idempotently to repair stale hooks")
+	var result agentInstallResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result), "stdout=%q", stdout.String())
+	assert.Equal(t, agentInstallResult{Agent: "claude", Status: "missing_host"}, result)
 }
 
 // withStubLauncher replaces the launchers map with a single entry for the

--- a/plugins/agento11y/internal/entry/entry_test.go
+++ b/plugins/agento11y/internal/entry/entry_test.go
@@ -560,13 +560,6 @@ func withStubCursorUninstall(t *testing.T, fn func(io.Writer, io.Writer, *log.Lo
 	cursorUninstall = fn
 }
 
-func withStubCursorStatus(t *testing.T, fn func() (bool, error)) {
-	t.Helper()
-	prev := cursorStatus
-	t.Cleanup(func() { cursorStatus = prev })
-	cursorStatus = fn
-}
-
 func withStubClaudeInstall(t *testing.T, fn func(context.Context, io.Writer) (bool, error)) {
 	t.Helper()
 	prev := claudeInstall

--- a/plugins/agento11y/internal/entry/entry_test.go
+++ b/plugins/agento11y/internal/entry/entry_test.go
@@ -3,6 +3,7 @@ package entry
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"log"
@@ -17,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/claudecode"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/local"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/login"
@@ -556,6 +558,66 @@ func withStubCursorUninstall(t *testing.T, fn func(io.Writer, io.Writer, *log.Lo
 	prev := cursorUninstall
 	t.Cleanup(func() { cursorUninstall = prev })
 	cursorUninstall = fn
+}
+
+func withStubCursorStatus(t *testing.T, fn func() (bool, error)) {
+	t.Helper()
+	prev := cursorStatus
+	t.Cleanup(func() { cursorStatus = prev })
+	cursorStatus = fn
+}
+
+func withStubClaudeInstall(t *testing.T, fn func(context.Context, io.Writer) (bool, error)) {
+	t.Helper()
+	prev := claudeInstall
+	t.Cleanup(func() { claudeInstall = prev })
+	claudeInstall = fn
+}
+
+func TestRun_AgentsInstallJSON(t *testing.T) {
+	withStubClaudeInstall(t, func(context.Context, io.Writer) (bool, error) { return true, nil })
+	withStubCursorStatus(t, func() (bool, error) { return false, nil })
+	withStubCursorInstall(t, func(io.Writer, io.Writer, *log.Logger) error { return nil })
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"agents", "install", "--agents", "claude,cursor", "--json"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	require.Nil(t, gotExit, "stderr=%q", stderr.String())
+	require.Empty(t, stderr.String())
+
+	var report agentInstallReport
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &report), "stdout=%q", stdout.String())
+	assert.Equal(t, []agentInstallResult{
+		{Agent: "claude", Status: "installed"},
+		{Agent: "cursor", Status: "installed"},
+	}, report.Agents)
+}
+
+func TestRun_AgentsInstallReportsMissingClaudeWithoutFailingCursor(t *testing.T) {
+	withStubClaudeInstall(t, func(context.Context, io.Writer) (bool, error) {
+		return false, claudecode.ErrCLINotFound
+	})
+	withStubCursorStatus(t, func() (bool, error) { return true, nil })
+	cursorInstalls := 0
+	withStubCursorInstall(t, func(io.Writer, io.Writer, *log.Logger) error {
+		cursorInstalls++
+		return nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"agents", "install", "--agents", "claude,cursor", "--json"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	require.Nil(t, gotExit, "stderr=%q", stderr.String())
+
+	var report agentInstallReport
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &report), "stdout=%q", stdout.String())
+	assert.Equal(t, []agentInstallResult{
+		{Agent: "claude", Status: "missing_host"},
+		{Agent: "cursor", Status: "already_installed"},
+	}, report.Agents)
+	assert.Equal(t, 1, cursorInstalls, "Cursor install re-runs idempotently to repair stale hooks")
 }
 
 // withStubLauncher replaces the launchers map with a single entry for the

--- a/plugins/agento11y/internal/entry/skills.go
+++ b/plugins/agento11y/internal/entry/skills.go
@@ -85,6 +85,8 @@ Launch a coding agent (wires the plugin, then runs it):
       agento11y <name> [--local|--no-local] [--tag key=value]... [-- args...]
   cursor install|uninstall
       Wire (or remove) the Cursor hook. Cursor is a GUI app and has no launcher.
+  agents install --agents claude,cursor [--json]
+      Wire managed coding-agent installs without launching an agent or prompting.
 
 Commands:
   login       Save endpoint, tenant, token, and OTLP endpoint to config.env.

--- a/plugins/agento11y/internal/entry/skills.go
+++ b/plugins/agento11y/internal/entry/skills.go
@@ -85,8 +85,8 @@ Launch a coding agent (wires the plugin, then runs it):
       agento11y <name> [--local|--no-local] [--tag key=value]... [-- args...]
   cursor install|uninstall
       Wire (or remove) the Cursor hook. Cursor is a GUI app and has no launcher.
-  agents install --agents claude,cursor [--json]
-      Wire managed coding-agent installs without launching an agent or prompting.
+  claude install [--json]
+      Register the Claude Code plugin without launching it or prompting.
 
 Commands:
   login       Save endpoint, tenant, token, and OTLP endpoint to config.env.

--- a/plugins/agento11y/internal/entry/skills_test.go
+++ b/plugins/agento11y/internal/entry/skills_test.go
@@ -200,7 +200,7 @@ func TestRun_HelpIsARealCommand(t *testing.T) {
 // The subcommand list is hand-written for the reason given at helpBody, so
 // adding a subcommand to run and forgetting this list is not caught.
 func helpRows() []string {
-	rows := []string{"\n  <agent> hook", "\n  cursor install|uninstall"}
+	rows := []string{"\n  <agent> hook", "\n  cursor install|uninstall", "\n  agents install --agents claude,cursor [--json]"}
 	for _, name := range []string{"login", "doctor", "skills", "local", "history", "help"} {
 		rows = append(rows, "\n  "+name+" ")
 	}

--- a/plugins/agento11y/internal/entry/skills_test.go
+++ b/plugins/agento11y/internal/entry/skills_test.go
@@ -200,7 +200,7 @@ func TestRun_HelpIsARealCommand(t *testing.T) {
 // The subcommand list is hand-written for the reason given at helpBody, so
 // adding a subcommand to run and forgetting this list is not caught.
 func helpRows() []string {
-	rows := []string{"\n  <agent> hook", "\n  cursor install|uninstall", "\n  agents install --agents claude,cursor [--json]"}
+	rows := []string{"\n  <agent> hook", "\n  cursor install|uninstall", "\n  claude install [--json]"}
 	for _, name := range []string{"login", "doctor", "skills", "local", "history", "help"} {
 		rows = append(rows, "\n  "+name+" ")
 	}

--- a/plugins/agento11y/internal/skills/content/setup-coding-agent/SKILL.md
+++ b/plugins/agento11y/internal/skills/content/setup-coding-agent/SKILL.md
@@ -65,9 +65,9 @@ Branch on these fields. The JSON also reports auto-update state:
 | `analytics.status` | The OTLP metrics and traces pipeline. | `error`: Troubleshooting |
 | `agents[]` | One entry per coding agent, with `install_state` and `on_path`. | target agent `not_installed`: Step 4 |
 
-Cursor is hook-based and always reports `install_state: unknown`; doctor cannot
-inspect `~/.cursor/hooks.json`. Do not use that field to decide whether Cursor is
-wired. Run `agento11y cursor install` when the user wants Cursor wired;
+Cursor is hook-based. `install_state: installed` means every agento11y Cursor
+hook is present in `~/.cursor/hooks.json`; `not_installed` means one or more is
+absent. Run `agento11y cursor install` when the user wants Cursor wired;
 re-running it is safe.
 
 `agento11y doctor` exits 1 when conversations, analytics, or config is in
@@ -250,6 +250,8 @@ agento11y cursor uninstall   # removes it
 On macOS and Linux, re-run `agento11y cursor install` after moving the binary;
 Cursor's hook stores its absolute path.
 
+For managed macOS deployment, after the administrator has placed the connection file for the target user, use `agento11y agents install --agents claude,cursor --json`; it never prompts or launches a host. `missing_host` for Claude means rerun after Claude Code is installed for that user.
+
 Arguments after `--` go to the underlying CLI unchanged:
 
 ```sh
@@ -369,7 +371,6 @@ All hosts read the resolved config path. The default is
 | `AGENTO11Y_CONTENT_CAPTURE_MODE` | Which content fields ship (see below) |
 | `AGENTO11Y_TAGS` | `key=value,key=value` attached to every generation |
 | `AGENTO11Y_AUTO_CODING_AGENT_TAGS` | Opt-in automatic user, repo, and branch tags |
-| `AGENTO11Y_EXPORT_TIMEOUT_MS` | Generation export timeout in milliseconds; defaults to 30000 |
 | `AGENTO11Y_GUARDS_ENABLED` | Send supported preflight and tool calls for guard evaluation |
 | `AGENTO11Y_GUARDS_TIMEOUT_MS` | Guard evaluation timeout in milliseconds |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | Allow the operation when guard evaluation fails |
@@ -458,14 +459,7 @@ set.
 
 The viewer and Grafana Cloud both start empty: they hold only sessions captured
 after the install. `agento11y history import` backfills sessions an agent
-already wrote to disk. Supported agents are `claude-code`, `codex`, `cursor`, and
-`pi`.
-
-A `cursor` import reads Cursor's session databases under `~/.cursor/chats`. That
-format records no token usage and stamps no message with a time, so an imported
-turn carries no usage and its times are marked approximate. Reading a session can
-add a `store.db-shm` file next to the session database, which SQLite needs to
-read the newest part of a session.
+already wrote to disk. Supported agents are `claude-code`, `codex`, and `pi`.
 
 ```sh
 agento11y history import claude-code --dry-run   # plan only, nothing exported

--- a/plugins/agento11y/internal/skills/content/setup-coding-agent/SKILL.md
+++ b/plugins/agento11y/internal/skills/content/setup-coding-agent/SKILL.md
@@ -250,7 +250,7 @@ agento11y cursor uninstall   # removes it
 On macOS and Linux, re-run `agento11y cursor install` after moving the binary;
 Cursor's hook stores its absolute path.
 
-For managed macOS deployment, after the administrator has placed the connection file for the target user, use `agento11y agents install --agents claude,cursor --json`; it never prompts or launches a host. `missing_host` for Claude means rerun after Claude Code is installed for that user.
+For managed macOS deployment, after the administrator has placed the connection file for the target user, use `agento11y claude install --json` and `agento11y cursor install`; neither launches a host. `missing_host` for Claude means rerun after Claude Code is installed for that user.
 
 Arguments after `--` go to the underlying CLI unchanged:
 


### PR DESCRIPTION
## What

- Add `agento11y agents install --agents claude,cursor --json` for managed-device deployment.
- Install Claude Code without launching it and expose Cursor hook state through `doctor`.

## Why

This is the reusable, MDM-agnostic primitive. The Jamf rollout example and reconciliation receipt are split into a stacked follow-up PR.

## Verification

- `GOWORK=off go test ./internal/agents/claudecode ./internal/agents/cursor/install ./internal/doctor ./internal/entry ./internal/skills`
