### PR TITLE
fix(python): stop re-raising recorded tool errors into host callbacks

### DIFF
--- a/python-frameworks/claude-agent-sdk/agento11y_claude_agent/handler.py
+++ b/python-frameworks/claude-agent-sdk/agento11y_claude_agent/handler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import secrets
 from collections.abc import AsyncIterable, AsyncIterator, Callable
 from dataclasses import replace
@@ -61,6 +62,8 @@ _metadata_session_id = "agento11y.framework.session_id"
 _metadata_permission_mode = "agento11y.claude_agent.permission_mode"
 _metadata_cwd = "agento11y.claude_agent.cwd"
 _metadata_total_cost_usd = "agento11y.claude_agent.total_cost_usd"
+
+logger = logging.getLogger(__name__)
 
 
 class Agento11yClaudeAgentHandler:
@@ -380,13 +383,29 @@ class Agento11yClaudeAgentHandler:
         return self._conversation_id
 
     def _finish_tool(self, run_key: str, *, result: Any = None, error: BaseException | None = None) -> None:
+        """End the recorder for ``run_key``. Log an error from the recorder instead of raising it.
+
+        Every caller is a Claude Agent SDK hook or the loop that ends open tools.
+        The SDK discards a hook's return value if the callback raises, so a raise in
+        a hook would lose a guard deny decision. A raise in the loop would leave the
+        remaining recorders open.
+        """
+
+        try:
+            self._end_tool_recorder(run_key, result=result, error=error)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("agento11y: tool execution %s not recorded: %s", run_key, exc, exc_info=True)
+
+    def _end_tool_recorder(self, run_key: str, *, result: Any, error: BaseException | None) -> None:
         recorder = self._tool_runs.pop(run_key, None)
         arguments = self._tool_arguments.pop(run_key, None)
         if recorder is None:
             return
+        exec_error: Exception | None = None
         try:
             if error is not None:
-                recorder.set_exec_error(Exception(str(error)))
+                exec_error = Exception(str(error))
+                recorder.set_exec_error(exec_error)
             else:
                 payload: dict[str, Any] = {}
                 if arguments is not None:
@@ -397,7 +416,11 @@ class Agento11yClaudeAgentHandler:
         finally:
             recorder.end()
         recorder_error = recorder.err()
-        if recorder_error is not None:
+        # err() returns the exec error it was given, so raising it would re-raise the
+        # tool failure the caller already reported. Only an error the recorder made
+        # itself, such as a failure to serialize the result, means the tool execution
+        # was not recorded.
+        if recorder_error is not None and recorder_error is not exec_error:
             raise recorder_error
 
     def _end_open_tools(self) -> None:

--- a/python-frameworks/claude-agent-sdk/tests/test_agento11y_claude_agent.py
+++ b/python-frameworks/claude-agent-sdk/tests/test_agento11y_claude_agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator
 from datetime import timedelta
 
@@ -119,6 +120,90 @@ def _part_payload(part) -> str:
     if part.kind == PartKind.TOOL_CALL:
         return part.tool_call.name
     return part.text
+
+
+def _pre_tool_use_input(tool_use_id: str, tool_name: str = "Bash") -> dict[str, object]:
+    return {
+        "hook_event_name": "PreToolUse",
+        "session_id": "session-42",
+        "transcript_path": "",
+        "cwd": "",
+        "tool_name": tool_name,
+        "tool_input": {"command": "pwd"},
+        "tool_use_id": tool_use_id,
+    }
+
+
+def _post_tool_use_input(tool_use_id: str, tool_response: object) -> dict[str, object]:
+    return {
+        **_pre_tool_use_input(tool_use_id),
+        "hook_event_name": "PostToolUse",
+        "tool_response": tool_response,
+    }
+
+
+def _post_tool_use_failure_input(tool_use_id: str, error: str) -> dict[str, object]:
+    return {
+        **_pre_tool_use_input(tool_use_id),
+        "hook_event_name": "PostToolUseFailure",
+        "error": error,
+    }
+
+
+class _StubToolRecorder:
+    """Tool recorder that stores what it is given, and raises or returns the errors a test configures."""
+
+    def __init__(self, *, end_error: Exception | None = None, final_error: Exception | None = None) -> None:
+        self.result: dict[str, object] | None = None
+        self.ended = False
+        self._end_error = end_error
+        self._final_error = final_error
+        self._exec_error: Exception | None = None
+
+    def set_result(self, **payload) -> None:
+        self.result = payload
+
+    def set_exec_error(self, error) -> None:
+        self._exec_error = error
+
+    def end(self) -> None:
+        self.ended = True
+        if self._end_error is not None:
+            raise self._end_error
+
+    def err(self):
+        # The real recorder returns the exec error it was given.
+        return self._final_error or self._exec_error
+
+
+class _ToolRecorderClient:
+    """Client with a fixed guard decision and optional stub tool recorders.
+
+    Generations come from the real ``client``, and so does every recorder requested
+    after ``recorders`` is empty.
+    """
+
+    def __init__(
+        self,
+        client: Client | None = None,
+        *,
+        recorders: list[_StubToolRecorder] | None = None,
+        hook_response: HookEvaluateResponse | None = None,
+    ) -> None:
+        self._client = client
+        self._recorders = list(recorders or [])
+        self._hook_response = hook_response or HookEvaluateResponse(action="allow")
+
+    def start_streaming_generation(self, start):
+        return self._client.start_streaming_generation(start)
+
+    def start_tool_execution(self, start):
+        if self._recorders:
+            return self._recorders.pop(0)
+        return self._client.start_tool_execution(start)
+
+    def evaluate_hook(self, _request):
+        return self._hook_response
 
 
 @pytest.mark.asyncio
@@ -798,69 +883,159 @@ async def test_claude_agent_guard_denial_blocks_user_prompt() -> None:
 
 @pytest.mark.asyncio
 async def test_claude_agent_tool_hooks_record_tool_result() -> None:
-    class _ToolRecorder:
-        def __init__(self) -> None:
-            self.result = None
-            self.ended = False
-
-        def set_result(self, **payload) -> None:
-            self.result = payload
-
-        def set_exec_error(self, error) -> None:
-            self.result = {"error": str(error)}
-
-        def end(self) -> None:
-            self.ended = True
-
-        def err(self):
-            return None
-
-    class _ToolClient:
-        def __init__(self) -> None:
-            self.recorder = _ToolRecorder()
-
-        def start_tool_execution(self, _start):
-            return self.recorder
-
-        def evaluate_hook(self, _request):
-            return HookEvaluateResponse(action="allow")
-
-    tool_client = _ToolClient()
-    handler = Agento11yClaudeAgentHandler(client=tool_client)  # type: ignore[arg-type]
+    recorder = _StubToolRecorder()
+    handler = Agento11yClaudeAgentHandler(client=_ToolRecorderClient(recorders=[recorder]))  # type: ignore[arg-type]
     options = handler.instrument_options(ClaudeAgentOptions())
 
     pre_hook = options.hooks["PreToolUse"][0].hooks[0]
     post_hook = options.hooks["PostToolUse"][0].hooks[0]
-    await pre_hook(
-        {
-            "hook_event_name": "PreToolUse",
-            "session_id": "session-42",
-            "transcript_path": "",
-            "cwd": "",
-            "tool_name": "Bash",
-            "tool_input": {"command": "pwd"},
-            "tool_use_id": "toolu_1",
-        },
-        "toolu_1",
-        {"signal": None},
-    )
-    await post_hook(
-        {
-            "hook_event_name": "PostToolUse",
-            "session_id": "session-42",
-            "transcript_path": "",
-            "cwd": "",
-            "tool_name": "Bash",
-            "tool_input": {"command": "pwd"},
-            "tool_response": {"stdout": "/tmp\n"},
-            "tool_use_id": "toolu_1",
-        },
-        "toolu_1",
-        {"signal": None},
-    )
+    await pre_hook(_pre_tool_use_input("toolu_1"), "toolu_1", {"signal": None})
+    await post_hook(_post_tool_use_input("toolu_1", {"stdout": "/tmp\n"}), "toolu_1", {"signal": None})
 
-    assert tool_client.recorder.result == {
+    assert recorder.result == {
         "arguments": {"command": "pwd"},
         "result": {"stdout": "/tmp\n"},
     }
-    assert tool_client.recorder.ended is True
+    assert recorder.ended is True
+
+
+@pytest.mark.asyncio
+async def test_agento11y_query_exports_when_tool_never_completes() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    async def fake_query(*, options, **_kwargs) -> AsyncIterator[object]:
+        pre_hook = options.hooks["PreToolUse"][0].hooks[0]
+        await pre_hook(_pre_tool_use_input("toolu_open"), "toolu_open", {"signal": None})
+        yield _success_result()
+
+    try:
+        _ = [
+            message
+            async for message in agento11y_query(
+                prompt="Inspect the README.",
+                client=client,
+                options=ClaudeAgentOptions(model="claude-sonnet-4-5"),
+                conversation_id="conv-42",
+                _query_fn=fake_query,
+            )
+        ]
+
+        client.flush()
+        assert [len(request.generations) for request in exporter.requests] == [1]
+    finally:
+        client.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_claude_agent_tool_failure_hook_does_not_drop_span(caplog) -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        handler = Agento11yClaudeAgentHandler(client=client, conversation_id="conv-42")
+        options = handler.instrument_options(ClaudeAgentOptions())
+        pre_hook = options.hooks["PreToolUse"][0].hooks[0]
+        failure_hook = options.hooks["PostToolUseFailure"][0].hooks[0]
+
+        await pre_hook(_pre_tool_use_input("toolu_1"), "toolu_1", {"signal": None})
+        with caplog.at_level(logging.ERROR):
+            output = await failure_hook(
+                _post_tool_use_failure_input("toolu_1", "disk full"),
+                "toolu_1",
+                {"signal": None},
+            )
+
+        assert output == {}
+        assert caplog.records == []
+    finally:
+        client.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_claude_agent_tool_hooks_log_recorder_produced_error(caplog) -> None:
+    recorder = _StubToolRecorder(final_error=RuntimeError("serialize tool result: unsupported type"))
+    handler = Agento11yClaudeAgentHandler(client=_ToolRecorderClient(recorders=[recorder]))  # type: ignore[arg-type]
+    options = handler.instrument_options(ClaudeAgentOptions())
+    pre_hook = options.hooks["PreToolUse"][0].hooks[0]
+    failure_hook = options.hooks["PostToolUseFailure"][0].hooks[0]
+
+    await pre_hook(_pre_tool_use_input("toolu_1"), "toolu_1", {"signal": None})
+    with caplog.at_level(logging.ERROR):
+        output = await failure_hook(
+            _post_tool_use_failure_input("toolu_1", "disk full"),
+            "toolu_1",
+            {"signal": None},
+        )
+
+    assert output == {}
+    assert "toolu_1" in caplog.text
+    assert "serialize tool result" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_claude_agent_guard_denial_returns_deny_decision() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    deny = HookEvaluateResponse(action="deny", rule_id="rule-1", reason="dangerous command")
+
+    try:
+        handler = Agento11yClaudeAgentHandler(
+            client=_ToolRecorderClient(client, hook_response=deny),  # type: ignore[arg-type]
+            enable_guards=True,
+        )
+        options = handler.instrument_options(ClaudeAgentOptions())
+        pre_hook = options.hooks["PreToolUse"][0].hooks[0]
+
+        output = await pre_hook(_pre_tool_use_input("toolu_1"), "toolu_1", {"signal": None})
+
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert output["hookSpecificOutput"]["permissionDecisionReason"] == "dangerous command"
+    finally:
+        client.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_claude_agent_guard_denial_survives_recorder_failure(caplog) -> None:
+    recorder = _StubToolRecorder(end_error=RuntimeError("denied recorder end failed"))
+    deny = HookEvaluateResponse(action="deny", rule_id="rule-1", reason="dangerous command")
+    handler = Agento11yClaudeAgentHandler(
+        client=_ToolRecorderClient(recorders=[recorder], hook_response=deny),  # type: ignore[arg-type]
+    )
+    options = handler.instrument_options(ClaudeAgentOptions())
+    pre_hook = options.hooks["PreToolUse"][0].hooks[0]
+
+    with caplog.at_level(logging.ERROR):
+        output = await pre_hook(_pre_tool_use_input("toolu_1"), "toolu_1", {"signal": None})
+
+    assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "denied recorder end failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_open_tool_teardown_continues_after_recorder_failure(caplog) -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    first = _StubToolRecorder(end_error=RuntimeError("first recorder end failed"))
+    second = _StubToolRecorder()
+
+    try:
+        handler = Agento11yClaudeAgentHandler(
+            client=_ToolRecorderClient(client, recorders=[first, second]),  # type: ignore[arg-type]
+            conversation_id="conv-42",
+        )
+        options = handler.instrument_options(ClaudeAgentOptions(model="claude-sonnet-4-5"))
+        await handler.start(prompt="Inspect the README.", options=options)
+        pre_hook = options.hooks["PreToolUse"][0].hooks[0]
+        await pre_hook(_pre_tool_use_input("toolu_1"), "toolu_1", {"signal": None})
+        await pre_hook(_pre_tool_use_input("toolu_2"), "toolu_2", {"signal": None})
+
+        with caplog.at_level(logging.ERROR):
+            handler.finish()
+
+        assert second.ended is True
+        client.flush()
+        assert [len(request.generations) for request in exporter.requests] == [1]
+        assert "first recorder end failed" in caplog.text
+    finally:
+        client.shutdown()

--- a/python/agento11y/framework_handler.py
+++ b/python/agento11y/framework_handler.py
@@ -663,36 +663,62 @@ class Agento11yFrameworkHandlerBase:
         )
 
     def _on_tool_end(self, *, output: Any, run_id: UUID) -> None:
-        run_state = self._tool_runs.pop(str(run_id), None)
+        run_key = str(run_id)
+        run_state = self._tool_runs.pop(run_key, None)
         if run_state is None:
             return
-
-        try:
-            payload: dict[str, Any] = {}
-            if run_state.arguments is not None:
-                payload["arguments"] = run_state.arguments
-            if run_state.capture_outputs:
-                payload["result"] = _extract_tool_output(output)
-            run_state.recorder.set_result(**payload)
-        finally:
-            run_state.recorder.end()
-
-        recorder_error = run_state.recorder.err()
-        if recorder_error is not None:
-            raise recorder_error
+        self._finish_tool(run_key, run_state, output=output)
 
     def _on_tool_error(self, *, error: BaseException, run_id: UUID) -> None:
-        run_state = self._tool_runs.pop(str(run_id), None)
+        run_key = str(run_id)
+        run_state = self._tool_runs.pop(run_key, None)
         if run_state is None:
             return
+        self._finish_tool(run_key, run_state, error=error)
+
+    def _finish_tool(
+        self,
+        run_key: str,
+        run_state: _ToolRunState,
+        *,
+        output: Any = None,
+        error: BaseException | None = None,
+    ) -> None:
+        """End the tool recorder. Log an error from the recorder instead of raising it.
+
+        Both callers run inside a callback the host framework invokes. Google ADK
+        wraps a raising callback in a RuntimeError, which skips the user's own
+        tool-error recovery and replaces their exception. Failing to record a tool
+        must not change how the agent runs.
+        """
 
         try:
-            run_state.recorder.set_exec_error(Exception(str(error)))
+            self._end_tool_recorder(run_state, output=output, error=error)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("agento11y: tool execution %s not recorded: %s", run_key, exc, exc_info=True)
+
+    def _end_tool_recorder(self, run_state: _ToolRunState, *, output: Any, error: BaseException | None) -> None:
+        exec_error: Exception | None = None
+        try:
+            if error is not None:
+                exec_error = Exception(str(error))
+                run_state.recorder.set_exec_error(exec_error)
+            else:
+                payload: dict[str, Any] = {}
+                if run_state.arguments is not None:
+                    payload["arguments"] = run_state.arguments
+                if run_state.capture_outputs:
+                    payload["result"] = _extract_tool_output(output)
+                run_state.recorder.set_result(**payload)
         finally:
             run_state.recorder.end()
 
         recorder_error = run_state.recorder.err()
-        if recorder_error is not None:
+        # err() returns the exec error it was given, so raising it would re-raise the
+        # tool failure the framework already reported. Only an error the recorder made
+        # itself, such as a failure to serialize the result, means the tool execution
+        # was not recorded.
+        if recorder_error is not None and recorder_error is not exec_error:
             raise recorder_error
 
     def _on_chain_start(

--- a/python/tests/test_framework_handler.py
+++ b/python/tests/test_framework_handler.py
@@ -2,12 +2,47 @@
 
 from __future__ import annotations
 
-from agento11y.framework_handler import _extract_tool_output
+import logging
+from uuid import uuid4
+
+import pytest
+from agento11y.framework_handler import Agento11yFrameworkHandlerBase, _extract_tool_output
 
 
 class _FakeToolMessage:
     def __init__(self, content):
         self.content = content
+
+
+class _StubToolRecorder:
+    """Tool recorder that stores what it is given, and returns the error a test configures."""
+
+    def __init__(self, *, final_error: Exception | None = None) -> None:
+        self.result: dict[str, object] | None = None
+        self.exec_error: Exception | None = None
+        self.ended = False
+        self._final_error = final_error
+
+    def set_result(self, **payload) -> None:
+        self.result = payload
+
+    def set_exec_error(self, error) -> None:
+        self.exec_error = error
+
+    def end(self) -> None:
+        self.ended = True
+
+    def err(self):
+        # The real recorder returns the exec error it was given.
+        return self._final_error or self.exec_error
+
+
+class _StubClient:
+    def __init__(self, recorder: _StubToolRecorder) -> None:
+        self._recorder = recorder
+
+    def start_tool_execution(self, _start):
+        return self._recorder
 
 
 def test_extract_tool_output_unwraps_content_and_preserves_plain_values() -> None:
@@ -17,3 +52,34 @@ def test_extract_tool_output_unwraps_content_and_preserves_plain_values() -> Non
     assert _extract_tool_output("plain string") == "plain string"
     assert _extract_tool_output(None) is None
     assert _extract_tool_output(payload) is payload
+
+
+@pytest.mark.parametrize(
+    ("outcome", "recorder_error", "expect_log"),
+    [
+        ("success", None, False),
+        ("success", RuntimeError("serialize tool result: unsupported type"), True),
+        ("failure", None, False),
+        ("failure", RuntimeError("serialize tool result: unsupported type"), True),
+    ],
+)
+def test_tool_callbacks_log_recorder_errors_instead_of_raising(outcome, recorder_error, expect_log, caplog) -> None:
+    recorder = _StubToolRecorder(final_error=recorder_error)
+    handler = Agento11yFrameworkHandlerBase(client=_StubClient(recorder), framework_name="test")  # type: ignore[arg-type]
+    run_id = uuid4()
+    handler._on_tool_start(serialized={"name": "weather"}, input_str="{}", run_id=run_id, parent_run_id=None)
+
+    with caplog.at_level(logging.ERROR, logger="agento11y"):
+        if outcome == "success":
+            handler._on_tool_end(output="18C", run_id=run_id)
+        else:
+            handler._on_tool_error(error=RuntimeError("the tool itself failed"), run_id=run_id)
+
+    assert recorder.ended is True
+    assert handler._tool_runs == {}
+    assert bool(caplog.records) is expect_log
+    if outcome == "failure":
+        assert str(recorder.exec_error) == "the tool itself failed"
+    if expect_log:
+        assert str(run_id) in caplog.text
+        assert "serialize tool result" in caplog.text

--- a/python/tests/test_runtime.py
+++ b/python/tests/test_runtime.py
@@ -631,6 +631,36 @@ def test_tool_execution_attributes_and_content_capture() -> None:
         provider.shutdown()
 
 
+def test_tool_recorder_err_returns_the_exec_error_object_it_was_given() -> None:
+    exporter = CapturingGenerationExporter()
+    client = _new_client(exporter)
+    exec_error = RuntimeError("the tool itself failed")
+    try:
+        # The framework handlers compare err() against the error they passed in, to tell
+        # a tool's own failure from a failure this SDK produced.
+        failed = client.start_tool_execution(ToolExecutionStart(tool_name="weather", include_content=True))
+        failed.set_exec_error(exec_error)
+        failed.set_result(arguments={"city": "Paris"}, result={"temp_c": 18})
+        failed.end()
+        assert failed.err() is exec_error
+
+        unserializable = client.start_tool_execution(ToolExecutionStart(tool_name="weather", include_content=True))
+        unserializable.set_result(result=object())
+        unserializable.end()
+        assert "serialize tool result" in str(unserializable.err())
+
+        # When both fail, the caller can no longer recognize its own error.
+        both = client.start_tool_execution(ToolExecutionStart(tool_name="weather", include_content=True))
+        both.set_exec_error(exec_error)
+        both.set_result(result=object())
+        both.end()
+        assert both.err() is not exec_error
+        assert "the tool itself failed" in str(both.err())
+        assert "serialize tool result" in str(both.err())
+    finally:
+        client.shutdown()
+
+
 def _wait_for(predicate, timeout_s: float = 1.0) -> None:
     deadline = time.time() + timeout_s
     while time.time() < deadline:


### PR DESCRIPTION
The shared framework handler and the Claude Agent SDK adapter both raised whatever recorder.err() returned. For a failed tool that is the caller's own error: ToolExecutionRecorder.err() folds the exec error into its result, unlike GenerationRecorder.err(), which returns only validation and enqueue errors.

Inside a Claude Agent SDK hook, the raise made the SDK discard the hook's return value and lose a guard deny decision; in the loop that ends open tools, it left the remaining recorders open. In a Google ADK callback, it became a RuntimeError that skips the user's own tool-error recovery and replaces their exception.

Both handlers now log an error the recorder made itself, such as a failure to serialize the result, and never re-raise the caller's error.