### PR TITLE
fix(sdk): restore legacy environment fallback

### DIFF
--- a/go/agento11y/experiments/client.go
+++ b/go/agento11y/experiments/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"maps"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -19,7 +18,9 @@ const (
 )
 
 // ClientOptions configures experiment ingest. Empty connection fields are read
-// from their canonical AGENTO11Y_* environment variables.
+// from their canonical AGENTO11Y_* environment variables, falling back to the
+// SIGIL_* spelling that shipped before the rename. Selection happens before
+// use: a nonblank canonical value always wins.
 type ClientOptions struct {
 	Endpoint            string
 	TenantID            string
@@ -44,16 +45,16 @@ type Client struct {
 }
 
 func NewClient(opts ClientOptions) (*Client, error) {
-	endpoint := firstNonBlank(opts.Endpoint, os.Getenv("AGENTO11Y_ENDPOINT"))
+	endpoint := firstNonBlank(opts.Endpoint, firstEnv("AGENTO11Y_ENDPOINT", "SIGIL_ENDPOINT"))
 	if endpoint == "" {
 		return nil, errors.New("Agent Observability endpoint is required: pass Endpoint or set AGENTO11Y_ENDPOINT")
 	}
-	token := firstNonBlank(opts.IngestToken, os.Getenv("AGENTO11Y_AUTH_TOKEN"))
+	token := firstNonBlank(opts.IngestToken, firstEnv("AGENTO11Y_AUTH_TOKEN", "SIGIL_AUTH_TOKEN"))
 	if token == "" {
 		return nil, errors.New("ingest token is required: pass IngestToken or set AGENTO11Y_AUTH_TOKEN")
 	}
-	tenantID := firstNonBlank(opts.TenantID, os.Getenv("AGENTO11Y_AUTH_TENANT_ID"))
-	actor := firstNonBlank(opts.Actor, os.Getenv("AGENTO11Y_INGEST_ACTOR"), defaultIngestActor)
+	tenantID := firstNonBlank(opts.TenantID, firstEnv("AGENTO11Y_AUTH_TENANT_ID", "SIGIL_AUTH_TENANT_ID"))
+	actor := firstNonBlank(opts.Actor, firstEnv("AGENTO11Y_INGEST_ACTOR", "SIGIL_INGEST_ACTOR"), defaultIngestActor)
 	generationEndpoint := firstNonBlank(opts.GenerationEndpoint, endpoint)
 	insecure := opts.Insecure
 	if insecure == nil {
@@ -64,7 +65,7 @@ func NewClient(opts ClientOptions) (*Client, error) {
 	if opts.RedactSecrets != nil {
 		redact = *opts.RedactSecrets
 	}
-	useOTel := envBool("AGENTO11Y_USE_EXPERIMENTAL_OTEL")
+	useOTel := envBool("AGENTO11Y_USE_EXPERIMENTAL_OTEL", "SIGIL_USE_EXPERIMENTAL_OTEL")
 	if opts.UseExperimentalOTel != nil {
 		useOTel = *opts.UseExperimentalOTel
 	}
@@ -95,13 +96,14 @@ func NewClient(opts ClientOptions) (*Client, error) {
 	}
 	return &Client{
 		core:                agento11y.NewClient(cfg),
-		grafanaURL:          strings.TrimRight(firstNonBlank(opts.GrafanaURL, os.Getenv("AGENTO11Y_GRAFANA_URL")), "/"),
+		grafanaURL:          strings.TrimRight(firstNonBlank(opts.GrafanaURL, firstEnv("AGENTO11Y_GRAFANA_URL", "SIGIL_GRAFANA_URL")), "/"),
 		redactSecrets:       redact,
 		useExperimentalOTel: useOTel,
 	}, nil
 }
 
-// NewClientFromEnv constructs a client entirely from AGENTO11Y_* variables.
+// NewClientFromEnv constructs a client entirely from the environment, under the
+// precedence ClientOptions documents.
 func NewClientFromEnv() (*Client, error) { return NewClient(ClientOptions{}) }
 
 func (c *Client) Core() *agento11y.Client {
@@ -340,8 +342,8 @@ func firstNonBlank(values ...string) string {
 	return ""
 }
 
-func envBool(name string) bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+func envBool(keys ...string) bool {
+	switch strings.ToLower(firstEnv(keys...)) {
 	case "1", "true", "yes", "on":
 		return true
 	default:

--- a/go/agento11y/experiments/experiments_test.go
+++ b/go/agento11y/experiments/experiments_test.go
@@ -2,6 +2,7 @@ package experiments
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"io"
@@ -1142,5 +1143,145 @@ func TestCloudTrialEvaluationBlockedWithoutTheGate(t *testing.T) {
 	// generation before triggering. A blocked call must do none of that.
 	if got := len(server.captured()) - before; got != 0 {
 		t.Fatalf("a blocked experimental call must not issue a request, got %d", got)
+	}
+}
+
+// legacyClientEnvKeys is every name TestNewClientResolvesLegacyEnvNames sets or
+// relies on being unset, cleared per case so an ambient value cannot decide the
+// outcome.
+var legacyClientEnvKeys = []string{
+	"AGENTO11Y_ENDPOINT", "SIGIL_ENDPOINT",
+	"AGENTO11Y_AUTH_TOKEN", "SIGIL_AUTH_TOKEN",
+	"AGENTO11Y_AUTH_TENANT_ID", "SIGIL_AUTH_TENANT_ID",
+	"AGENTO11Y_INGEST_ACTOR", "SIGIL_INGEST_ACTOR",
+	"AGENTO11Y_GRAFANA_URL", "SIGIL_GRAFANA_URL",
+	"AGENTO11Y_USE_EXPERIMENTAL_OTEL", "SIGIL_USE_EXPERIMENTAL_OTEL",
+}
+
+func TestNewClientResolvesLegacyEnvNames(t *testing.T) {
+	tests := []struct {
+		name string
+		// endpointKey receives the test server URL, so a request arriving at all
+		// proves that spelling was the one selected.
+		endpointKey string
+		env         map[string]string
+		wantAuth    string
+		wantActor   string
+		wantGrafana string
+		wantOTel    bool
+	}{
+		{
+			name:        "legacy endpoint and token",
+			endpointKey: "SIGIL_ENDPOINT",
+			env:         map[string]string{"SIGIL_AUTH_TOKEN": "t"},
+			wantAuth:    "Bearer t",
+			wantActor:   defaultIngestActor,
+		},
+		{
+			name:        "legacy tenant, actor, grafana url and otel gate",
+			endpointKey: "SIGIL_ENDPOINT",
+			env: map[string]string{
+				"SIGIL_AUTH_TOKEN":            "t",
+				"SIGIL_AUTH_TENANT_ID":        "42",
+				"SIGIL_INGEST_ACTOR":          "ingest:legacy",
+				"SIGIL_GRAFANA_URL":           "http://g.example/",
+				"SIGIL_USE_EXPERIMENTAL_OTEL": "1",
+			},
+			wantAuth:    "Basic " + base64.StdEncoding.EncodeToString([]byte("42:t")),
+			wantActor:   "ingest:legacy",
+			wantGrafana: "http://g.example",
+			wantOTel:    true,
+		},
+		{
+			name:        "canonical wins over legacy",
+			endpointKey: "AGENTO11Y_ENDPOINT",
+			env: map[string]string{
+				"SIGIL_ENDPOINT":                  "http://legacy.invalid",
+				"AGENTO11Y_AUTH_TOKEN":            "canonical",
+				"SIGIL_AUTH_TOKEN":                "legacy",
+				"AGENTO11Y_INGEST_ACTOR":          "ingest:canonical",
+				"SIGIL_INGEST_ACTOR":              "ingest:legacy",
+				"AGENTO11Y_GRAFANA_URL":           "http://canonical.example",
+				"SIGIL_GRAFANA_URL":               "http://legacy.example",
+				"AGENTO11Y_USE_EXPERIMENTAL_OTEL": "0",
+				"SIGIL_USE_EXPERIMENTAL_OTEL":     "1",
+			},
+			wantAuth:    "Bearer canonical",
+			wantActor:   "ingest:canonical",
+			wantGrafana: "http://canonical.example",
+			wantOTel:    false,
+		},
+		{
+			name:        "blank canonical falls through to legacy",
+			endpointKey: "SIGIL_ENDPOINT",
+			env: map[string]string{
+				"AGENTO11Y_ENDPOINT":   "   ",
+				"AGENTO11Y_AUTH_TOKEN": "",
+				"SIGIL_AUTH_TOKEN":     "t",
+			},
+			wantAuth:  "Bearer t",
+			wantActor: defaultIngestActor,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var auth, actor []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				auth = append(auth, r.Header.Get("Authorization"))
+				actor = append(actor, r.Header.Get(ingestActorHeader))
+				mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"accepted":1,"results":[{"score_id":"score","accepted":true}]}`))
+			}))
+			defer server.Close()
+			for _, key := range legacyClientEnvKeys {
+				t.Setenv(key, "")
+			}
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+			t.Setenv(tt.endpointKey, server.URL)
+
+			client, err := NewClient(ClientOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = client.Shutdown(context.Background()) }()
+			if got := client.grafanaURL; got != tt.wantGrafana {
+				t.Fatalf("grafanaURL=%q want %q", got, tt.wantGrafana)
+			}
+			if got := client.useExperimentalOTel; got != tt.wantOTel {
+				t.Fatalf("useExperimentalOTel=%v want %v", got, tt.wantOTel)
+			}
+			passed := true
+			if _, err := client.ExportScores(context.Background(), []ScoreItem{{
+				ScoreID: "score", TrialID: "trial", EvaluatorID: "eval",
+				EvaluatorVersion: "1", ScoreKey: "final", Value: NumberScoreValue(1),
+				Passed: &passed,
+			}}); err != nil {
+				t.Fatal(err)
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			if len(auth) == 0 {
+				t.Fatal("no request reached the server, so the endpoint resolved elsewhere")
+			}
+			if auth[0] != tt.wantAuth {
+				t.Fatalf("Authorization=%q want %q", auth[0], tt.wantAuth)
+			}
+			if actor[0] != tt.wantActor {
+				t.Fatalf("%s=%q want %q", ingestActorHeader, actor[0], tt.wantActor)
+			}
+		})
+	}
+}
+
+func TestExperimentalGateHasNoLegacySpelling(t *testing.T) {
+	clearExperimentalGate(t)
+	t.Setenv("SIGIL_ENABLE_EXPERIMENTAL_FEATURES", "1")
+	if agento11y.ExperimentalFeaturesEnabled() {
+		t.Fatal("SIGIL_ENABLE_EXPERIMENTAL_FEATURES must not open the gate; the name postdates the rename")
 	}
 }

--- a/go/agento11y/experiments/suites.go
+++ b/go/agento11y/experiments/suites.go
@@ -76,6 +76,10 @@ func ClassifyConflict(err error) ConflictKind {
 	}
 }
 
+// TestSuitesClientOptions configures the control-plane client. Empty
+// connection fields are read from the environment. AGENTO11Y_CONTROL_ENDPOINT
+// and AGENTO11Y_SERVICE_ACCOUNT_TOKEN postdate the rename, so they carry no
+// SIGIL_* fallback; AGENTO11Y_GRAFANA_URL does.
 type TestSuitesClientOptions struct {
 	GrafanaURL          string
 	ServiceAccountToken string
@@ -93,7 +97,7 @@ type TestSuitesClient struct {
 }
 
 func NewTestSuitesClient(opts TestSuitesClientOptions) (*TestSuitesClient, error) {
-	grafanaURL := firstNonBlank(opts.GrafanaURL, os.Getenv("AGENTO11Y_GRAFANA_URL"))
+	grafanaURL := firstNonBlank(opts.GrafanaURL, firstEnv("AGENTO11Y_GRAFANA_URL", "SIGIL_GRAFANA_URL"))
 	endpoint := firstNonBlank(opts.ControlEndpoint, os.Getenv("AGENTO11Y_CONTROL_ENDPOINT"))
 	if endpoint == "" {
 		endpoint = grafanaURL

--- a/go/agento11y/experiments/suites_test.go
+++ b/go/agento11y/experiments/suites_test.go
@@ -258,3 +258,76 @@ func TestAppPluginPathsUseCurrentPluginID(t *testing.T) {
 		t.Fatalf("ExperimentURL=%q want %q", got, wantURL)
 	}
 }
+
+func TestNewTestSuitesClientEnvNames(t *testing.T) {
+	envKeys := []string{
+		"AGENTO11Y_GRAFANA_URL", "SIGIL_GRAFANA_URL",
+		"AGENTO11Y_CONTROL_ENDPOINT", "SIGIL_CONTROL_ENDPOINT",
+		"AGENTO11Y_SERVICE_ACCOUNT_TOKEN", "SIGIL_SERVICE_ACCOUNT_TOKEN",
+	}
+	tests := []struct {
+		name        string
+		env         map[string]string
+		wantErr     string
+		wantGrafana string
+	}{
+		{
+			name: "legacy grafana url resolves and supplies the control endpoint",
+			env: map[string]string{
+				"SIGIL_GRAFANA_URL":               "https://legacy.grafana.net/",
+				"AGENTO11Y_SERVICE_ACCOUNT_TOKEN": "token",
+			},
+			wantGrafana: "https://legacy.grafana.net",
+		},
+		{
+			name: "canonical grafana url wins over legacy",
+			env: map[string]string{
+				"AGENTO11Y_GRAFANA_URL":           "https://canonical.grafana.net",
+				"SIGIL_GRAFANA_URL":               "https://legacy.grafana.net",
+				"AGENTO11Y_SERVICE_ACCOUNT_TOKEN": "token",
+			},
+			wantGrafana: "https://canonical.grafana.net",
+		},
+		{
+			// Both control-plane names postdate the rename, so a SIGIL_ spelling
+			// of either resolves nothing.
+			name: "legacy control endpoint is not read",
+			env: map[string]string{
+				"SIGIL_CONTROL_ENDPOINT":          "https://legacy.grafana.net",
+				"AGENTO11Y_SERVICE_ACCOUNT_TOKEN": "token",
+			},
+			wantErr: "control endpoint is required",
+		},
+		{
+			name: "legacy service account token is not read",
+			env: map[string]string{
+				"AGENTO11Y_CONTROL_ENDPOINT":  "https://stack.grafana.net",
+				"SIGIL_SERVICE_ACCOUNT_TOKEN": "token",
+			},
+			wantErr: "service account token is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, key := range envKeys {
+				t.Setenv(key, "")
+			}
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+			client, err := NewTestSuitesClient(TestSuitesClientOptions{})
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("NewTestSuitesClient error=%v want one containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := client.GrafanaURL(); got != tt.wantGrafana {
+				t.Fatalf("GrafanaURL=%q want %q", got, tt.wantGrafana)
+			}
+		})
+	}
+}

--- a/js/docs/experiments.md
+++ b/js/docs/experiments.md
@@ -43,10 +43,6 @@ Run, trial, generation, score, and artifact writes all use the ingest credential
 Stored test suites are the exception: they live behind the Grafana plugin control
 plane and use `TestSuitesClient` with its own service-account token.
 
-The SDK reads only the `AGENTO11Y_*` names. It warns once per process about a
-removed `SIGIL_*` trial-handoff name, through the client logger or `console.warn`,
-and never reads its value.
-
 ## Run an experiment
 
 ```ts

--- a/js/src/config.ts
+++ b/js/src/config.ts
@@ -25,7 +25,7 @@ export interface EnvPair {
   legacy: string;
 }
 
-function brandedPair(suffix: string): EnvPair {
+export function brandedPair(suffix: string): EnvPair {
   return { preferred: `AGENTO11Y_${suffix}`, legacy: `SIGIL_${suffix}` };
 }
 

--- a/js/src/experiments/client.ts
+++ b/js/src/experiments/client.ts
@@ -1,4 +1,4 @@
-import { defaultEnv, parseTruthy, resolveHeadersWithAuth } from '../config.js';
+import { brandedPair, defaultEnv, envTrimmed, parseTruthy, resolveHeadersWithAuth } from '../config.js';
 import { redactSecretText, redactSecretValue } from '../redaction.js';
 import type { Agento11yLogger, TokenUsage } from '../types.js';
 import { baseURLFromAPIEndpoint } from '../utils.js';
@@ -37,12 +37,14 @@ export const INGEST_ACTOR_HEADER = 'X-Agento11y-Ingest-Actor';
 /** Default ingest actor for this SDK. Python sends `ingest:sdk/python`. */
 export const DEFAULT_INGEST_ACTOR = 'ingest:sdk/js';
 
-const ENV_ENDPOINT = 'AGENTO11Y_ENDPOINT';
-const ENV_AUTH_TOKEN = 'AGENTO11Y_AUTH_TOKEN';
-const ENV_AUTH_TENANT_ID = 'AGENTO11Y_AUTH_TENANT_ID';
-const ENV_INGEST_ACTOR = 'AGENTO11Y_INGEST_ACTOR';
-const ENV_GRAFANA_URL = 'AGENTO11Y_GRAFANA_URL';
-const ENV_USE_EXPERIMENTAL_OTEL = 'AGENTO11Y_USE_EXPERIMENTAL_OTEL';
+// Each pair reads the canonical AGENTO11Y_* name first and falls back to the
+// SIGIL_* spelling that shipped before the rename.
+const ENV_ENDPOINT = brandedPair('ENDPOINT');
+const ENV_AUTH_TOKEN = brandedPair('AUTH_TOKEN');
+const ENV_AUTH_TENANT_ID = brandedPair('AUTH_TENANT_ID');
+const ENV_INGEST_ACTOR = brandedPair('INGEST_ACTOR');
+const ENV_GRAFANA_URL = brandedPair('GRAFANA_URL');
+const ENV_USE_EXPERIMENTAL_OTEL = brandedPair('USE_EXPERIMENTAL_OTEL');
 
 /** A client whose queued generations a trial flushes before starting an evaluation. */
 export interface FlushableGenerationClient {
@@ -166,13 +168,13 @@ export class ExperimentsClient {
 
   constructor(options: ExperimentsClientOptions = {}) {
     const env = options.env ?? defaultEnv();
-    const endpoint = (options.endpoint ?? env[ENV_ENDPOINT] ?? '').trim();
+    const endpoint = (options.endpoint ?? envTrimmed(env, ENV_ENDPOINT)?.value ?? '').trim();
     if (endpoint.length === 0) {
       throw new Error(
         'agento11y experiments: endpoint is required; pass endpoint or set AGENTO11Y_ENDPOINT to your Grafana Cloud Agent Observability URL',
       );
     }
-    const ingestToken = (options.ingestToken ?? env[ENV_AUTH_TOKEN] ?? '').trim();
+    const ingestToken = (options.ingestToken ?? envTrimmed(env, ENV_AUTH_TOKEN)?.value ?? '').trim();
     if (ingestToken.length === 0) {
       throw new Error(
         'agento11y experiments: ingestToken is required; pass ingestToken or set AGENTO11Y_AUTH_TOKEN to your Grafana Cloud ingestion API key',
@@ -180,14 +182,15 @@ export class ExperimentsClient {
     }
 
     this.endpoint = endpoint.replace(/\/+$/, '');
-    this.tenantId = (options.tenantId ?? env[ENV_AUTH_TENANT_ID] ?? '').trim();
+    this.tenantId = (options.tenantId ?? envTrimmed(env, ENV_AUTH_TENANT_ID)?.value ?? '').trim();
     // The backend derives the same identity from the run's sdk/js source. Sending
     // it on every request also covers routes such as artifact upload, which
     // cannot carry a JSON source object.
-    this.actor = (options.actor ?? env[ENV_INGEST_ACTOR] ?? '').trim() || DEFAULT_INGEST_ACTOR;
-    this.grafanaUrl = (options.grafanaUrl ?? env[ENV_GRAFANA_URL] ?? '').trim().replace(/\/+$/, '');
+    this.actor = (options.actor ?? envTrimmed(env, ENV_INGEST_ACTOR)?.value ?? '').trim() || DEFAULT_INGEST_ACTOR;
+    this.grafanaUrl = (options.grafanaUrl ?? envTrimmed(env, ENV_GRAFANA_URL)?.value ?? '').trim().replace(/\/+$/, '');
     this.redactSecrets = options.redactSecrets ?? true;
-    this.useExperimentalOtel = options.useExperimentalOtel ?? parseTruthy(env[ENV_USE_EXPERIMENTAL_OTEL] ?? '');
+    this.useExperimentalOtel =
+      options.useExperimentalOtel ?? parseTruthy(envTrimmed(env, ENV_USE_EXPERIMENTAL_OTEL)?.value ?? '');
     this.coreClient = options.coreClient;
     this.logger = options.logger;
     this.sleepFn = options.sleep ?? sleepWithSignal;

--- a/js/src/experiments/suites.ts
+++ b/js/src/experiments/suites.ts
@@ -7,7 +7,7 @@
  * and its own base URL.
  */
 
-import { defaultEnv, resolveHeadersWithAuth } from '../config.js';
+import { brandedPair, defaultEnv, envTrimmed, resolveHeadersWithAuth } from '../config.js';
 import {
   CONFLICT_PREFIX,
   ExperimentConflictError,
@@ -35,7 +35,9 @@ const CONTROL_MAX_RETRIES = 5;
 const DEFAULT_PAGE_LIMIT = 200;
 const DEFAULT_MAX_PAGES = 100;
 
-const ENV_GRAFANA_URL = 'AGENTO11Y_GRAFANA_URL';
+const ENV_GRAFANA_URL = brandedPair('GRAFANA_URL');
+// Both control-plane names postdate the rename, so they stay canonical-only:
+// no release ever read a SIGIL_ spelling for them.
 const ENV_CONTROL_ENDPOINT = 'AGENTO11Y_CONTROL_ENDPOINT';
 const ENV_SERVICE_ACCOUNT_TOKEN = 'AGENTO11Y_SERVICE_ACCOUNT_TOKEN';
 
@@ -88,7 +90,7 @@ export class TestSuitesClient {
 
   constructor(options: TestSuitesClientOptions = {}) {
     const env = options.env ?? defaultEnv();
-    const grafana = (options.grafanaUrl ?? env[ENV_GRAFANA_URL] ?? '').trim();
+    const grafana = (options.grafanaUrl ?? envTrimmed(env, ENV_GRAFANA_URL)?.value ?? '').trim();
     let endpoint = (options.controlEndpoint ?? env[ENV_CONTROL_ENDPOINT] ?? '').trim();
     if (endpoint.length === 0) {
       if (grafana.length === 0) {

--- a/js/src/experiments/types.ts
+++ b/js/src/experiments/types.ts
@@ -1,4 +1,5 @@
-import { defaultEnv } from '../config.js';
+import type { EnvPair } from '../config.js';
+import { brandedPair, defaultEnv, envTrimmed } from '../config.js';
 import type { Agento11yLogger } from '../types.js';
 import type { Candidate, Evaluator, EvaluatorKind } from './models.js';
 import { isRecord, normalizeEvaluatorKind } from './models.js';
@@ -170,21 +171,35 @@ export function candidateMetadata(candidate: Candidate | undefined): Record<stri
 // TrialRef: handing one trial across a process or container boundary
 // --------------------------------------------------------------------------- //
 
-export const ENV_EXPERIMENT_ID = 'AGENTO11Y_EXPERIMENT_ID';
-export const ENV_TEST_CASE_ID = 'AGENTO11Y_TEST_CASE_ID';
-export const ENV_ATTEMPT = 'AGENTO11Y_ATTEMPT';
-export const ENV_SUITE_ID = 'AGENTO11Y_SUITE_ID';
-export const ENV_SUITE_VERSION = 'AGENTO11Y_SUITE_VERSION';
-export const ENV_TRAJECTORY_ID = 'AGENTO11Y_TRAJECTORY_ID';
+// One pair per handoff field, so the name `trialRefFromEnv` reads and the name
+// `trialRefToEnv` writes cannot drift apart.
+const envExperimentId = brandedPair('EXPERIMENT_ID');
+const envTestCaseId = brandedPair('TEST_CASE_ID');
+const envAttempt = brandedPair('ATTEMPT');
+const envSuiteId = brandedPair('SUITE_ID');
+const envSuiteVersion = brandedPair('SUITE_VERSION');
+const envTrajectoryId = brandedPair('TRAJECTORY_ID');
 
-const legacyEnvRenames: Record<string, string> = {
-  SIGIL_EXPERIMENT_ID: ENV_EXPERIMENT_ID,
-  SIGIL_TEST_CASE_ID: ENV_TEST_CASE_ID,
-  SIGIL_ATTEMPT: ENV_ATTEMPT,
-  SIGIL_SUITE_ID: ENV_SUITE_ID,
-  SIGIL_SUITE_VERSION: ENV_SUITE_VERSION,
-  SIGIL_TRAJECTORY_ID: ENV_TRAJECTORY_ID,
-};
+export const ENV_EXPERIMENT_ID = envExperimentId.preferred;
+export const ENV_TEST_CASE_ID = envTestCaseId.preferred;
+export const ENV_ATTEMPT = envAttempt.preferred;
+export const ENV_SUITE_ID = envSuiteId.preferred;
+export const ENV_SUITE_VERSION = envSuiteVersion.preferred;
+export const ENV_TRAJECTORY_ID = envTrajectoryId.preferred;
+
+/**
+ * Pre-rename spellings, written beside the canonical names by `trialRefToEnv`
+ * so a child process on an older SDK build still receives the trial context.
+ */
+export const LEGACY_ENV_EXPERIMENT_ID = envExperimentId.legacy;
+export const LEGACY_ENV_TEST_CASE_ID = envTestCaseId.legacy;
+export const LEGACY_ENV_ATTEMPT = envAttempt.legacy;
+export const LEGACY_ENV_SUITE_ID = envSuiteId.legacy;
+export const LEGACY_ENV_SUITE_VERSION = envSuiteVersion.legacy;
+export const LEGACY_ENV_TRAJECTORY_ID = envTrajectoryId.legacy;
+// SIGIL_RUN_ID is the pre-rename name of the experiment id, read only after both
+// EXPERIMENT_ID spellings. Go resolves it the same way.
+const ENV_LEGACY_RUN_ID = 'SIGIL_RUN_ID';
 
 /**
  * A serializable pointer to one trial, openable in any process.
@@ -232,65 +247,93 @@ export function trialRefFromJSON(payload: unknown): TrialRef {
   };
 }
 
-/** The environment variables that carry this ref to a child process. */
+/**
+ * The environment variables that carry this ref to a child process, written
+ * under both the canonical and the legacy spelling. Go's core
+ * `agento11y.TrialRef.ToEnv` does the same, so a parent can spawn a child
+ * running an older SDK build.
+ */
 export function trialRefToEnv(ref: TrialRef): Record<string, string> {
   const env: Record<string, string> = {
     [ENV_EXPERIMENT_ID]: ref.experimentId,
+    [LEGACY_ENV_EXPERIMENT_ID]: ref.experimentId,
     [ENV_TEST_CASE_ID]: ref.testCaseId,
+    [LEGACY_ENV_TEST_CASE_ID]: ref.testCaseId,
     [ENV_ATTEMPT]: String(ref.attempt),
+    [LEGACY_ENV_ATTEMPT]: String(ref.attempt),
   };
   if (ref.suiteId !== undefined && ref.suiteId.length > 0) {
     env[ENV_SUITE_ID] = ref.suiteId;
+    env[LEGACY_ENV_SUITE_ID] = ref.suiteId;
   }
   if (ref.suiteVersion !== undefined && ref.suiteVersion.length > 0) {
     env[ENV_SUITE_VERSION] = ref.suiteVersion;
+    env[LEGACY_ENV_SUITE_VERSION] = ref.suiteVersion;
   }
   if (ref.trajectoryId !== undefined && ref.trajectoryId.length > 0) {
     env[ENV_TRAJECTORY_ID] = ref.trajectoryId;
+    env[LEGACY_ENV_TRAJECTORY_ID] = ref.trajectoryId;
   }
   return env;
 }
 
 /**
  * Reads a ref from the environment, returning undefined when the experiment or
- * test-case id is missing. A `SIGIL_*` spelling is reported and ignored, never
- * read: the rename is complete, so silently honoring the old name would hide
- * stale configuration.
+ * test-case id is missing. A nonblank `AGENTO11Y_*` value wins over every
+ * `SIGIL_*` spelling; a legacy spelling that supplies a value is read and
+ * reported once per process.
  */
 export function trialRefFromEnv(
   env: Record<string, string | undefined> = defaultEnv(),
   logger?: Agento11yLogger,
 ): TrialRef | undefined {
-  warnLegacyTrialEnv(env, logger);
-  const experimentId = (env[ENV_EXPERIMENT_ID] ?? '').trim();
-  const testCaseId = (env[ENV_TEST_CASE_ID] ?? '').trim();
+  const experimentId = resolveTrialEnv(env, envExperimentId, logger) ?? resolveLegacyRunId(env, logger) ?? '';
+  const testCaseId = resolveTrialEnv(env, envTestCaseId, logger) ?? '';
   if (experimentId.length === 0 || testCaseId.length === 0) {
     return undefined;
   }
-  const parsedAttempt = Number.parseInt((env[ENV_ATTEMPT] ?? '').trim(), 10);
+  const parsedAttempt = Number.parseInt(resolveTrialEnv(env, envAttempt, logger) ?? '', 10);
   return {
     experimentId,
     testCaseId,
     attempt: Number.isFinite(parsedAttempt) && parsedAttempt > 0 ? parsedAttempt : 1,
-    suiteId: (env[ENV_SUITE_ID] ?? '').trim(),
-    suiteVersion: (env[ENV_SUITE_VERSION] ?? '').trim(),
-    trajectoryId: (env[ENV_TRAJECTORY_ID] ?? '').trim(),
+    suiteId: resolveTrialEnv(env, envSuiteId, logger) ?? '',
+    suiteVersion: resolveTrialEnv(env, envSuiteVersion, logger) ?? '',
+    trajectoryId: resolveTrialEnv(env, envTrajectoryId, logger) ?? '',
   };
+}
+
+function resolveTrialEnv(
+  env: Record<string, string | undefined>,
+  pair: EnvPair,
+  logger?: Agento11yLogger,
+): string | undefined {
+  const selected = envTrimmed(env, pair);
+  if (selected === undefined) return undefined;
+  if (selected.key !== pair.preferred) {
+    warnLegacyTrialEnv(selected.key, pair.preferred, logger);
+  }
+  return selected.value;
+}
+
+function resolveLegacyRunId(env: Record<string, string | undefined>, logger?: Agento11yLogger): string | undefined {
+  const value = (env[ENV_LEGACY_RUN_ID] ?? '').trim();
+  if (value.length === 0) return undefined;
+  warnLegacyTrialEnv(ENV_LEGACY_RUN_ID, ENV_EXPERIMENT_ID, logger);
+  return value;
 }
 
 const warnedLegacyEnv = new Set<string>();
 
-export function warnLegacyTrialEnv(env: Record<string, string | undefined>, logger?: Agento11yLogger): void {
-  for (const [legacy, replacement] of Object.entries(legacyEnvRenames)) {
-    if (env[legacy] !== undefined && !warnedLegacyEnv.has(legacy)) {
-      warnedLegacyEnv.add(legacy);
-      const message = `agento11y: ${legacy} is ignored; rename it to ${replacement}`;
-      if (logger?.warn !== undefined) {
-        logger.warn(message);
-      } else {
-        console.warn(message);
-      }
-    }
+/** Warns once per process that a legacy name supplied a value. */
+export function warnLegacyTrialEnv(legacy: string, replacement: string, logger?: Agento11yLogger): void {
+  if (warnedLegacyEnv.has(legacy)) return;
+  warnedLegacyEnv.add(legacy);
+  const message = `agento11y: ${legacy} is deprecated; rename it to ${replacement}`;
+  if (logger?.warn !== undefined) {
+    logger.warn(message);
+  } else {
+    console.warn(message);
   }
 }
 

--- a/js/test/experiments.client.test.mjs
+++ b/js/test/experiments.client.test.mjs
@@ -60,6 +60,57 @@ test('the client reads endpoint, token, tenant, and actor from the environment',
   }
 });
 
+test('the client reads the legacy spellings of the same variables', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({ status: 200, body: {} }));
+  try {
+    const client = new ExperimentsClient({
+      env: {
+        SIGIL_ENDPOINT: endpoint,
+        SIGIL_AUTH_TOKEN: 'tok-legacy',
+        SIGIL_AUTH_TENANT_ID: '12345',
+        SIGIL_INGEST_ACTOR: 'ingest:runner/legacy',
+        SIGIL_GRAFANA_URL: 'https://legacy.grafana.net/',
+        SIGIL_USE_EXPERIMENTAL_OTEL: 'true',
+      },
+    });
+    assert.equal(client.tenantId, '12345');
+    assert.equal(client.actor, 'ingest:runner/legacy');
+    assert.equal(client.grafanaUrl, 'https://legacy.grafana.net');
+    assert.equal(client.useExperimentalOtel, true);
+    await client.upsertExperiment({ name: 'nightly' });
+    assert.equal(seen[0].headers.authorization, `Basic ${Buffer.from('12345:tok-legacy').toString('base64')}`);
+  } finally {
+    await close();
+  }
+});
+
+test('a canonical variable wins over its legacy spelling', async () => {
+  const { endpoint, seen, close } = await startServer(() => ({ status: 200, body: {} }));
+  try {
+    const client = new ExperimentsClient({
+      env: {
+        AGENTO11Y_ENDPOINT: endpoint,
+        SIGIL_ENDPOINT: 'http://legacy.invalid',
+        AGENTO11Y_AUTH_TOKEN: 'tok-env',
+        SIGIL_AUTH_TOKEN: 'tok-legacy',
+        AGENTO11Y_INGEST_ACTOR: 'ingest:runner/nightly',
+        SIGIL_INGEST_ACTOR: 'ingest:runner/legacy',
+        AGENTO11Y_GRAFANA_URL: 'https://stack.grafana.net',
+        SIGIL_GRAFANA_URL: 'https://legacy.grafana.net',
+        AGENTO11Y_USE_EXPERIMENTAL_OTEL: 'false',
+        SIGIL_USE_EXPERIMENTAL_OTEL: 'true',
+      },
+    });
+    assert.equal(client.actor, 'ingest:runner/nightly');
+    assert.equal(client.grafanaUrl, 'https://stack.grafana.net');
+    assert.equal(client.useExperimentalOtel, false);
+    await client.upsertExperiment({ name: 'nightly' });
+    assert.equal(seen[0].headers.authorization, 'Bearer tok-env');
+  } finally {
+    await close();
+  }
+});
+
 test('a missing endpoint or token fails at construction', () => {
   assert.throws(() => new ExperimentsClient({ env: {} }), /endpoint is required/);
   assert.throws(() => new ExperimentsClient({ endpoint: 'http://localhost:1', env: {} }), /ingestToken is required/);

--- a/js/test/experiments.experimental.test.mjs
+++ b/js/test/experiments.experimental.test.mjs
@@ -44,6 +44,11 @@ test('an unset variable and an empty variable are both disabled', () => {
   assert.equal(experimentalFeaturesEnabled({ [ENV_ENABLE_EXPERIMENTAL_FEATURES]: '   ' }), false);
 });
 
+test('the gate has no legacy SIGIL_ spelling', () => {
+  // The name postdates the rename, so no release ever read SIGIL_ for it.
+  assert.equal(experimentalFeaturesEnabled({ SIGIL_ENABLE_EXPERIMENTAL_FEATURES: 'true' }), false);
+});
+
 test('requireExperimental throws a named error when the gate is closed', () => {
   assert.throws(
     () => requireExperimental(FEATURE_CLOUD_TRIAL_EVALUATION, {}),

--- a/js/test/experiments.suites.test.mjs
+++ b/js/test/experiments.suites.test.mjs
@@ -16,6 +16,12 @@ import {
   ENV_SUITE_VERSION,
   ENV_TEST_CASE_ID,
   ENV_TRAJECTORY_ID,
+  LEGACY_ENV_ATTEMPT,
+  LEGACY_ENV_EXPERIMENT_ID,
+  LEGACY_ENV_SUITE_ID,
+  LEGACY_ENV_SUITE_VERSION,
+  LEGACY_ENV_TEST_CASE_ID,
+  LEGACY_ENV_TRAJECTORY_ID,
   resetLegacyTrialEnvWarnings,
   suiteCase,
   testSuiteFromObject,
@@ -160,13 +166,21 @@ test('a TrialRef round-trips through the environment', () => {
     trajectoryId: 'traj-1',
   };
   const env = trialRefToEnv(ref);
+  // Every populated field is written under both spellings, so a child process on
+  // a pre-rename SDK build still receives the trial context.
   assert.deepEqual(env, {
     [ENV_EXPERIMENT_ID]: 'run-1',
+    [LEGACY_ENV_EXPERIMENT_ID]: 'run-1',
     [ENV_TEST_CASE_ID]: 'case-1',
+    [LEGACY_ENV_TEST_CASE_ID]: 'case-1',
     [ENV_ATTEMPT]: '3',
+    [LEGACY_ENV_ATTEMPT]: '3',
     [ENV_SUITE_ID]: 'smoke',
+    [LEGACY_ENV_SUITE_ID]: 'smoke',
     [ENV_SUITE_VERSION]: '2.0.0',
+    [LEGACY_ENV_SUITE_VERSION]: '2.0.0',
     [ENV_TRAJECTORY_ID]: 'traj-1',
+    [LEGACY_ENV_TRAJECTORY_ID]: 'traj-1',
   });
   const restored = trialRefFromEnv(env);
   assert.equal(restored.experimentId, 'run-1');
@@ -191,23 +205,70 @@ test('a missing or unparseable attempt falls back to one', () => {
   assert.equal(trialRefFromEnv({ ...base, [ENV_ATTEMPT]: '4' }).attempt, 4);
 });
 
-test('a SIGIL_ spelling is reported and ignored', () => {
+test('a SIGIL_ spelling is read and reported', () => {
   resetLegacyTrialEnvWarnings();
   const warnings = [];
   const ref = trialRefFromEnv(
-    { SIGIL_EXPERIMENT_ID: 'run-legacy', SIGIL_TEST_CASE_ID: 'case-legacy' },
+    {
+      SIGIL_EXPERIMENT_ID: 'run-legacy',
+      SIGIL_TEST_CASE_ID: 'case-legacy',
+      SIGIL_ATTEMPT: '2',
+      SIGIL_SUITE_ID: 'smoke',
+      SIGIL_SUITE_VERSION: '2.0.0',
+      SIGIL_TRAJECTORY_ID: 'traj-1',
+    },
     { warn: (message) => warnings.push(message) },
   );
-  assert.equal(ref, undefined, 'the legacy name is not read as a value');
+  assert.deepEqual(ref, {
+    experimentId: 'run-legacy',
+    testCaseId: 'case-legacy',
+    attempt: 2,
+    suiteId: 'smoke',
+    suiteVersion: '2.0.0',
+    trajectoryId: 'traj-1',
+  });
   assert.deepEqual(warnings, [
-    'agento11y: SIGIL_EXPERIMENT_ID is ignored; rename it to AGENTO11Y_EXPERIMENT_ID',
-    'agento11y: SIGIL_TEST_CASE_ID is ignored; rename it to AGENTO11Y_TEST_CASE_ID',
+    'agento11y: SIGIL_EXPERIMENT_ID is deprecated; rename it to AGENTO11Y_EXPERIMENT_ID',
+    'agento11y: SIGIL_TEST_CASE_ID is deprecated; rename it to AGENTO11Y_TEST_CASE_ID',
+    'agento11y: SIGIL_ATTEMPT is deprecated; rename it to AGENTO11Y_ATTEMPT',
+    'agento11y: SIGIL_SUITE_ID is deprecated; rename it to AGENTO11Y_SUITE_ID',
+    'agento11y: SIGIL_SUITE_VERSION is deprecated; rename it to AGENTO11Y_SUITE_VERSION',
+    'agento11y: SIGIL_TRAJECTORY_ID is deprecated; rename it to AGENTO11Y_TRAJECTORY_ID',
   ]);
 
   // The warning fires once per process, not once per read.
   const again = [];
   trialRefFromEnv({ SIGIL_EXPERIMENT_ID: 'run-legacy' }, { warn: (message) => again.push(message) });
   assert.deepEqual(again, []);
+});
+
+test('SIGIL_RUN_ID is the last source for the experiment id', () => {
+  resetLegacyTrialEnvWarnings();
+  const ref = trialRefFromEnv({ SIGIL_RUN_ID: 'run-older', SIGIL_TEST_CASE_ID: 'case-1' }, { warn: () => {} });
+  assert.equal(ref.experimentId, 'run-older');
+
+  const preferred = trialRefFromEnv(
+    { SIGIL_RUN_ID: 'run-older', SIGIL_EXPERIMENT_ID: 'run-old', [ENV_TEST_CASE_ID]: 'case-1' },
+    { warn: () => {} },
+  );
+  assert.equal(preferred.experimentId, 'run-old');
+});
+
+test('a canonical trial name wins over its legacy spelling', () => {
+  resetLegacyTrialEnvWarnings();
+  const warnings = [];
+  const ref = trialRefFromEnv(
+    {
+      [ENV_EXPERIMENT_ID]: 'run-new',
+      SIGIL_EXPERIMENT_ID: 'run-legacy',
+      [ENV_TEST_CASE_ID]: 'case-new',
+      SIGIL_TEST_CASE_ID: 'case-legacy',
+    },
+    { warn: (message) => warnings.push(message) },
+  );
+  assert.equal(ref.experimentId, 'run-new');
+  assert.equal(ref.testCaseId, 'case-new');
+  assert.deepEqual(warnings, [], 'an unused legacy name is not reported');
 });
 
 test('a TrialRef round-trips through JSON, including the run_id alias', () => {
@@ -274,6 +335,43 @@ test('the client requires an endpoint and a token', () => {
   });
   assert.equal(fromEnv.grafanaUrl, 'https://stack.grafana.net');
   assert.equal(fromEnv.endpoint, 'https://stack.grafana.net/api/plugins/grafana-agento11y-app/resources/eval');
+});
+
+test('the suites client reads the legacy grafana url, canonical first', () => {
+  const legacy = new TestSuitesClient({
+    env: { SIGIL_GRAFANA_URL: 'https://legacy.grafana.net', AGENTO11Y_SERVICE_ACCOUNT_TOKEN: 'glsa_token' },
+  });
+  assert.equal(legacy.grafanaUrl, 'https://legacy.grafana.net');
+
+  const both = new TestSuitesClient({
+    env: {
+      AGENTO11Y_GRAFANA_URL: 'https://stack.grafana.net',
+      SIGIL_GRAFANA_URL: 'https://legacy.grafana.net',
+      AGENTO11Y_SERVICE_ACCOUNT_TOKEN: 'glsa_token',
+    },
+  });
+  assert.equal(both.grafanaUrl, 'https://stack.grafana.net');
+});
+
+test('the control endpoint and token stay canonical-only', () => {
+  // Neither name shipped a SIGIL_ spelling, so neither gets a fallback.
+  assert.throws(
+    () =>
+      new TestSuitesClient({
+        env: { SIGIL_CONTROL_ENDPOINT: 'https://legacy.grafana.net', SIGIL_SERVICE_ACCOUNT_TOKEN: 'glsa_token' },
+      }),
+    /controlEndpoint is required/,
+  );
+  assert.throws(
+    () =>
+      new TestSuitesClient({
+        env: {
+          AGENTO11Y_CONTROL_ENDPOINT: 'https://stack.grafana.net',
+          SIGIL_SERVICE_ACCOUNT_TOKEN: 'glsa_token',
+        },
+      }),
+    /serviceAccountToken is required/,
+  );
 });
 
 test('the grafana url is derived from the control endpoint when unset', () => {

--- a/llms.txt
+++ b/llms.txt
@@ -488,9 +488,6 @@ a stored test suite.
   optional `AGENTO11Y_AUTH_TENANT_ID`.
 - Stored suite push/pull is optional and additionally uses
   `AGENTO11Y_CONTROL_ENDPOINT` and `AGENTO11Y_SERVICE_ACCOUNT_TOKEN`.
-- Only canonical `AGENTO11Y_*` names are supported. Known removed `SIGIL_*`
-  connection and trial-handoff names are ignored and produce a migration
-  warning.
 - Use `trial.record_io(...)` when the harness owns candidate I/O, or
   `bind_generation`/`bind_conversation`/`bind_trace` when normal instrumentation
   already emitted it.

--- a/python/README.md
+++ b/python/README.md
@@ -563,7 +563,7 @@ cfg = ClientConfig(
 
 `generation_export.export_timeout` bounds each HTTP or gRPC generation and workflow-step request. It defaults to 30 seconds.
 
-Set `AGENTO11Y_EXPORT_TIMEOUT_MS` to a base-10 integer from `1` through `2147483647` to override the default. An explicit `export_timeout` wins over the environment variable. Invalid values produce a warning and keep the default. The Python SDK does not read any `SIGIL_*` name, so `SIGIL_EXPORT_TIMEOUT_MS` only produces a warning that tells you to rename it.
+Set `AGENTO11Y_EXPORT_TIMEOUT_MS` to a base-10 integer from `1` through `2147483647` to override the default. An explicit `export_timeout` wins over the environment variable. Invalid values produce a warning and keep the default.
 
 ## Generation export auth modes
 

--- a/python/agento11y/config.py
+++ b/python/agento11y/config.py
@@ -40,33 +40,44 @@ _DEFAULT_EXPORT_TIMEOUT = timedelta(seconds=DEFAULT_EXPORT_TIMEOUT_SECONDS)
 _MIN_EXPORT_TIMEOUT_MS = 1
 _MAX_EXPORT_TIMEOUT_MS = 2147483647
 _INT_PATTERN = re.compile(r"[+-]?[0-9]+")
-_LEGACY_ENV_RENAMES = {
-    "SIGIL_AGENT_NAME": "AGENTO11Y_AGENT_NAME",
-    "SIGIL_AGENT_VERSION": "AGENTO11Y_AGENT_VERSION",
-    "SIGIL_API_ENDPOINT": "AGENTO11Y_ENDPOINT",
-    "SIGIL_ATTEMPT": "AGENTO11Y_ATTEMPT",
-    "SIGIL_AUTH_MODE": "AGENTO11Y_AUTH_MODE",
-    "SIGIL_AUTH_TENANT_ID": "AGENTO11Y_AUTH_TENANT_ID",
-    "SIGIL_AUTH_TOKEN": "AGENTO11Y_AUTH_TOKEN",
-    "SIGIL_CONTENT_CAPTURE_MODE": "AGENTO11Y_CONTENT_CAPTURE_MODE",
-    "SIGIL_CONTROL_ENDPOINT": "AGENTO11Y_CONTROL_ENDPOINT",
-    "SIGIL_CONTROL_PLANE_ENDPOINT": "AGENTO11Y_CONTROL_ENDPOINT",
-    "SIGIL_CONTROL_PLANE_TOKEN": "AGENTO11Y_SERVICE_ACCOUNT_TOKEN",
-    "SIGIL_ENDPOINT": "AGENTO11Y_ENDPOINT",
-    "SIGIL_EXPORT_TIMEOUT_MS": "AGENTO11Y_EXPORT_TIMEOUT_MS",
-    "SIGIL_EXPERIMENT_ID": "AGENTO11Y_EXPERIMENT_ID",
-    "SIGIL_GRAFANA_URL": "AGENTO11Y_GRAFANA_URL",
-    "SIGIL_INGEST_ACTOR": "AGENTO11Y_INGEST_ACTOR",
-    "SIGIL_PROTOCOL": "AGENTO11Y_PROTOCOL",
-    "SIGIL_REDACT_INPUT_MESSAGES": "AGENTO11Y_REDACT_INPUT_MESSAGES",
-    "SIGIL_RUN_ID": "AGENTO11Y_EXPERIMENT_ID",
-    "SIGIL_SERVICE_ACCOUNT_TOKEN": "AGENTO11Y_SERVICE_ACCOUNT_TOKEN",
-    "SIGIL_SUITE_ID": "AGENTO11Y_SUITE_ID",
-    "SIGIL_SUITE_VERSION": "AGENTO11Y_SUITE_VERSION",
-    "SIGIL_TENANT_ID": "AGENTO11Y_AUTH_TENANT_ID",
-    "SIGIL_TEST_CASE_ID": "AGENTO11Y_TEST_CASE_ID",
-    "SIGIL_TRAJECTORY_ID": "AGENTO11Y_TRAJECTORY_ID",
-    "SIGIL_USE_EXPERIMENTAL_OTEL": "AGENTO11Y_USE_EXPERIMENTAL_OTEL",
+# Legacy SIGIL_* spellings still honoured for each AGENTO11Y_<suffix> name, in
+# fallback order. Only names that shipped before the rename are listed; a suffix
+# absent from this table is canonical-only, because no release ever read a
+# SIGIL_ spelling for it.
+_LEGACY_ENV_ALIASES: dict[str, tuple[str, ...]] = {
+    "AGENT_NAME": ("SIGIL_AGENT_NAME",),
+    "AGENT_VERSION": ("SIGIL_AGENT_VERSION",),
+    "ATTEMPT": ("SIGIL_ATTEMPT",),
+    "AUTH_MODE": ("SIGIL_AUTH_MODE",),
+    "AUTH_TENANT_ID": ("SIGIL_AUTH_TENANT_ID", "SIGIL_TENANT_ID"),
+    "AUTH_TOKEN": ("SIGIL_AUTH_TOKEN",),
+    "CONTENT_CAPTURE_MODE": ("SIGIL_CONTENT_CAPTURE_MODE",),
+    "DEBUG": ("SIGIL_DEBUG",),
+    "ENDPOINT": ("SIGIL_ENDPOINT", "SIGIL_API_ENDPOINT"),
+    # SIGIL_RUN_ID is the pre-rename name of the experiment id, kept last so a
+    # SIGIL_EXPERIMENT_ID set beside it still wins. Go does the same.
+    "EXPERIMENT_ID": ("SIGIL_EXPERIMENT_ID", "SIGIL_RUN_ID"),
+    "GRAFANA_URL": ("SIGIL_GRAFANA_URL",),
+    "HEADERS": ("SIGIL_HEADERS",),
+    "INGEST_ACTOR": ("SIGIL_INGEST_ACTOR",),
+    "INSECURE": ("SIGIL_INSECURE",),
+    "PROTOCOL": ("SIGIL_PROTOCOL",),
+    "REDACT_INPUT_MESSAGES": ("SIGIL_REDACT_INPUT_MESSAGES",),
+    "SUITE_ID": ("SIGIL_SUITE_ID",),
+    "SUITE_VERSION": ("SIGIL_SUITE_VERSION",),
+    "TAGS": ("SIGIL_TAGS",),
+    "TEST_CASE_ID": ("SIGIL_TEST_CASE_ID",),
+    "TRAJECTORY_ID": ("SIGIL_TRAJECTORY_ID",),
+    "USE_EXPERIMENTAL_OTEL": ("SIGIL_USE_EXPERIMENTAL_OTEL",),
+    "USER_ID": ("SIGIL_USER_ID",),
+}
+# SIGIL_ spellings of the canonical-only names. No release ever read them, so a
+# value set under one is unused. _env warns once for it, because the name
+# otherwise looks like it works.
+_UNREAD_LEGACY_ENV: dict[str, str] = {
+    "CONTROL_ENDPOINT": "SIGIL_CONTROL_ENDPOINT",
+    "EXPORT_TIMEOUT_MS": "SIGIL_EXPORT_TIMEOUT_MS",
+    "SERVICE_ACCOUNT_TOKEN": "SIGIL_SERVICE_ACCOUNT_TOKEN",
 }
 _WARNED_LEGACY_ENV: set[str] = set()
 
@@ -210,35 +221,50 @@ def default_config() -> ClientConfig:
 
 
 def _env(env: dict[str, str] | None, suffix: str) -> tuple[str | None, str]:
-    """Selects a nonblank ``AGENTO11Y_<suffix>`` value.
+    """Selects a nonblank ``AGENTO11Y_<suffix>`` value, then a legacy spelling.
 
-    Returns ``(value, selected_key)`` so validation messages can name the key
-    the user actually set, or ``(None, "")`` when it is unset.
+    A nonblank canonical value always wins, even when it later fails validation,
+    so stale legacy config cannot resurface behind it. Returns ``(value,
+    selected_key)`` so validation messages can name the key the user actually
+    set, or ``(None, "")`` when it is unset. Logs once per legacy name: either
+    that name supplied the value, or it is the SIGIL_ spelling of a
+    canonical-only name and nothing read it.
     """
 
     src = env if env is not None else os.environ
-    key = "AGENTO11Y_" + suffix
-    raw = src.get(key)
-    if raw is not None:
+    canonical = "AGENTO11Y_" + suffix
+    for key in (canonical, *_LEGACY_ENV_ALIASES.get(suffix, ())):
+        raw = src.get(key)
+        if raw is None:
+            continue
         val = raw.strip()
-        if val:
-            return val, key
+        if not val:
+            continue
+        if key != canonical:
+            _warn_legacy(key, "is deprecated", canonical)
+        return val, key
+    unread = _UNREAD_LEGACY_ENV.get(suffix)
+    if unread is not None and (src.get(unread) or "").strip():
+        _warn_legacy(unread, "is ignored", canonical)
     return None, ""
 
 
-def _warn_legacy_env(env: dict[str, str] | None = None) -> None:
-    """Warns once for removed SIGIL_* configuration without reading its value."""
+def _warn_legacy(legacy: str, verdict: str, replacement: str) -> None:
+    """Warns once per process about one legacy SIGIL_* name.
 
-    src = env if env is not None else os.environ
-    logger = logging.getLogger("agento11y")
-    for legacy, replacement in _LEGACY_ENV_RENAMES.items():
-        if legacy in src and legacy not in _WARNED_LEGACY_ENV:
-            _WARNED_LEGACY_ENV.add(legacy)
-            logger.warning(
-                "agento11y: %s is ignored; rename it to %s",
-                legacy,
-                replacement,
-            )
+    ``verdict`` is "is deprecated" when the name supplied the value, and "is
+    ignored" when it is the SIGIL_ spelling of a canonical-only name.
+    """
+
+    if legacy in _WARNED_LEGACY_ENV:
+        return
+    _WARNED_LEGACY_ENV.add(legacy)
+    logging.getLogger("agento11y").warning(
+        "agento11y: %s %s; rename it to %s",
+        legacy,
+        verdict,
+        replacement,
+    )
 
 
 def _parse_bool(raw: str) -> bool:
@@ -286,10 +312,9 @@ def resolve_config(
     """Resolves caller config against canonical env vars and defaults.
 
     Resolution order: explicit user-provided fields > ``AGENTO11Y_*`` env vars
-    > SDK config struct defaults.
+    (then their legacy ``SIGIL_*`` spellings) > SDK config struct defaults.
     """
 
-    _warn_legacy_env(env)
     # Clone so resolve_config never mutates the caller's config. Some fields
     # (logger, tracer, exporter) hold non-picklable resources, so we shallow-
     # clone the dataclass tree rather than deepcopying.
@@ -310,9 +335,10 @@ def resolve_config(
     if out.generation_export.headers is None:
         ev, _ = _env(env, "HEADERS")
         out.generation_export.headers = _parse_csv_kv(ev) if ev is not None else {}
-    # Export request deadline. Only the canonical AGENTO11Y_EXPORT_TIMEOUT_MS is
-    # read; an invalid value is warned about and the 30s default is retained so
-    # valid sibling env vars still apply.
+    # Export request deadline. AGENTO11Y_EXPORT_TIMEOUT_MS postdates the rename,
+    # so this SDK reads no SIGIL_ spelling for it. An invalid value logs a
+    # warning and keeps the 30s default, so the other env vars resolved in the
+    # same call still apply.
     if out.generation_export.export_timeout is _DEFAULT_EXPORT_TIMEOUT:
         ev, timeout_key = _env(env, "EXPORT_TIMEOUT_MS")
         if ev is not None:

--- a/python/agento11y/experiments/client.py
+++ b/python/agento11y/experiments/client.py
@@ -9,12 +9,10 @@ from __future__ import annotations
 
 import base64
 import copy
-import os
 import urllib.parse
 from typing import Any
 
 from .. import _experiments_transport as _transport
-from ..config import _warn_legacy_env
 from ..errors import ScoreExportError
 from ..experimental import FEATURE_CLOUD_TRIAL_EVALUATION, require_experimental
 from ..models import (
@@ -26,7 +24,7 @@ from ..models import (
     TrialEvaluation,
 )
 from ..redaction import redact_secret_text, redact_secret_value
-from .types import _first_nonblank
+from .types import _env_value
 
 TENANT_HEADER = "X-Scope-OrgID"
 INGEST_ACTOR_HEADER = _transport.INGEST_ACTOR_HEADER
@@ -55,10 +53,9 @@ class Client:
         use_experimental_otel: bool | None = None,
         redact_secrets: bool = True,
     ) -> None:
-        _warn_legacy_env()
         if not (endpoint or "").strip():
             raise ValueError("Agent Observability endpoint is required (your Grafana Cloud Agent Observability URL)")
-        token = (ingest_token or _first_nonblank(os.environ, "AGENTO11Y_AUTH_TOKEN")).strip()
+        token = (ingest_token or _env_value("AUTH_TOKEN")).strip()
         if not token:
             raise ValueError("ingest_token is required (your Grafana Cloud ingestion API key)")
         self.endpoint = endpoint.rstrip("/")
@@ -69,7 +66,7 @@ class Client:
         # as artifact upload that cannot carry a JSON source object.
         self.actor = actor.strip() or _transport.DEFAULT_INGEST_ACTOR
         self.trusted = trusted
-        self.grafana_url = (grafana_url or _first_nonblank(os.environ, "AGENTO11Y_GRAFANA_URL")).rstrip("/")
+        self.grafana_url = (grafana_url or _env_value("GRAFANA_URL")).rstrip("/")
         self.timeout = timeout
         self.generation_endpoint = generation_endpoint or self.endpoint
         self.generation_protocol = generation_protocol
@@ -78,9 +75,7 @@ class Client:
         self._core: Any | None = None
         self.redact_secrets = bool(redact_secrets)
         self.use_experimental_otel = (
-            _env_bool("AGENTO11Y_USE_EXPERIMENTAL_OTEL")
-            if use_experimental_otel is None
-            else bool(use_experimental_otel)
+            _env_bool("USE_EXPERIMENTAL_OTEL") if use_experimental_otel is None else bool(use_experimental_otel)
         )
 
     # --- connection args -------------------------------------------------- #
@@ -506,5 +501,5 @@ def _format_bearer(token: str) -> str:
     return f"Bearer {value}"
 
 
-def _env_bool(*names: str) -> bool:
-    return _first_nonblank(os.environ, *names).lower() in {"1", "true", "yes", "on"}
+def _env_bool(suffix: str) -> bool:
+    return _env_value(suffix).lower() in {"1", "true", "yes", "on"}

--- a/python/agento11y/experiments/experiment.py
+++ b/python/agento11y/experiments/experiment.py
@@ -31,7 +31,6 @@ import hashlib
 import json
 import math
 import mimetypes
-import os
 import secrets
 import time
 from types import TracebackType
@@ -72,7 +71,7 @@ from .types import (
     TestSuite,
     TrialRef,
     TrialStatus,
-    _first_nonblank,
+    _env_value,
 )
 
 if TYPE_CHECKING:  # avoid an import cycle at runtime
@@ -1367,21 +1366,21 @@ def experiment(
     if client is None:
         from .client import Client
 
-        resolved_endpoint = (endpoint or _first_nonblank(os.environ, "AGENTO11Y_ENDPOINT")).strip()
+        resolved_endpoint = (endpoint or _env_value("ENDPOINT")).strip()
         if not resolved_endpoint:
             raise ValueError(
                 "Agent Observability endpoint is required: "
                 "pass endpoint= or set AGENTO11Y_ENDPOINT to your Grafana Cloud Agent Observability URL"
             )
-        resolved_tenant = (tenant_id or _first_nonblank(os.environ, "AGENTO11Y_AUTH_TENANT_ID")).strip()
-        resolved_token = (ingest_token or _first_nonblank(os.environ, "AGENTO11Y_AUTH_TOKEN")).strip()
+        resolved_tenant = (tenant_id or _env_value("AUTH_TENANT_ID")).strip()
+        resolved_token = (ingest_token or _env_value("AUTH_TOKEN")).strip()
         if not resolved_token:
             raise ValueError("ingest_token is required: pass ingest_token= or set AGENTO11Y_AUTH_TOKEN")
         client = Client(
             resolved_endpoint,
             tenant_id=resolved_tenant,
             ingest_token=resolved_token,
-            actor=actor or _first_nonblank(os.environ, "AGENTO11Y_INGEST_ACTOR"),
+            actor=actor or _env_value("INGEST_ACTOR"),
             grafana_url=grafana_url,
             use_experimental_otel=use_experimental_otel,
         )

--- a/python/agento11y/experiments/suites.py
+++ b/python/agento11y/experiments/suites.py
@@ -6,16 +6,14 @@ token. Stored test suites live behind the Grafana plugin control plane in Cloud.
 
 from __future__ import annotations
 
-import os
 import re
 import urllib.parse
 from dataclasses import dataclass
 from typing import Any
 
 from .. import _experiments_transport as _transport
-from ..config import _warn_legacy_env
 from ..errors import ConflictError, ExperimentTransportError, NotFoundError, ValidationError
-from .types import TestCase, TestSuite, _first_nonblank
+from .types import TestCase, TestSuite, _env_value
 
 _DEFAULT_CONTROL_PATH = "/api/plugins/grafana-agento11y-app/resources/eval"
 _GRAFANA_APP_PATH = "/a/grafana-agento11y-app"
@@ -49,15 +47,16 @@ class TestSuitesClient:
         control_endpoint: str = "",
         timeout: float = 30.0,
     ) -> None:
-        _warn_legacy_env()
-        grafana = (grafana_url or _first_nonblank(os.environ, "AGENTO11Y_GRAFANA_URL")).strip()
-        endpoint = (control_endpoint or _first_nonblank(os.environ, "AGENTO11Y_CONTROL_ENDPOINT")).strip()
+        grafana = (grafana_url or _env_value("GRAFANA_URL")).strip()
+        # CONTROL_ENDPOINT and SERVICE_ACCOUNT_TOKEN postdate the rename, so the
+        # resolver reads no legacy spelling for them.
+        endpoint = (control_endpoint or _env_value("CONTROL_ENDPOINT")).strip()
         if not endpoint:
             if not grafana:
                 raise ValueError("control_endpoint is required (or set AGENTO11Y_CONTROL_ENDPOINT)")
             endpoint = grafana
         endpoint = _normalize_control_endpoint(endpoint)
-        token = (service_account_token or _first_nonblank(os.environ, "AGENTO11Y_SERVICE_ACCOUNT_TOKEN")).strip()
+        token = (service_account_token or _env_value("SERVICE_ACCOUNT_TOKEN")).strip()
         if not token:
             raise ValueError("service_account_token is required (or set AGENTO11Y_SERVICE_ACCOUNT_TOKEN)")
         self.endpoint = endpoint.rstrip("/")

--- a/python/agento11y/experiments/types.py
+++ b/python/agento11y/experiments/types.py
@@ -14,7 +14,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
-from ..config import _warn_legacy_env
+from ..config import _env
 
 
 class ExperimentStatus(str, Enum):
@@ -303,15 +303,23 @@ ENV_SUITE_ID = "AGENTO11Y_SUITE_ID"
 ENV_SUITE_VERSION = "AGENTO11Y_SUITE_VERSION"
 ENV_TRAJECTORY_ID = "AGENTO11Y_TRAJECTORY_ID"
 
+# Pre-rename spellings. ``to_env`` writes them beside the canonical names so a
+# child process running an older SDK build still receives the trial context;
+# ``from_env`` accepts them through the config resolver, which also honours
+# SIGIL_RUN_ID for the experiment id.
+LEGACY_ENV_EXPERIMENT_ID = "SIGIL_EXPERIMENT_ID"
+LEGACY_ENV_TEST_CASE_ID = "SIGIL_TEST_CASE_ID"
+LEGACY_ENV_ATTEMPT = "SIGIL_ATTEMPT"
+LEGACY_ENV_SUITE_ID = "SIGIL_SUITE_ID"
+LEGACY_ENV_SUITE_VERSION = "SIGIL_SUITE_VERSION"
+LEGACY_ENV_TRAJECTORY_ID = "SIGIL_TRAJECTORY_ID"
 
-def _first_nonblank(env: dict[str, str], *keys: str) -> str:
-    """Returns the first nonblank (trimmed) value of ``keys`` in ``env``."""
 
-    for key in keys:
-        val = (env.get(key) or "").strip()
-        if val:
-            return val
-    return ""
+def _env_value(suffix: str, env: dict[str, str] | None = None) -> str:
+    """Resolves ``AGENTO11Y_<suffix>``, then its legacy spellings, else ``""``."""
+
+    value, _ = _env(env, suffix)
+    return value or ""
 
 
 @dataclass(frozen=True)
@@ -364,36 +372,43 @@ class TrialRef:
         )
 
     def to_env(self) -> dict[str, str]:
+        """Returns the handoff variables under both the canonical and legacy names."""
+
         env = {
             ENV_EXPERIMENT_ID: self.experiment_id,
+            LEGACY_ENV_EXPERIMENT_ID: self.experiment_id,
             ENV_TEST_CASE_ID: self.test_case_id,
+            LEGACY_ENV_TEST_CASE_ID: self.test_case_id,
             ENV_ATTEMPT: str(self.attempt),
+            LEGACY_ENV_ATTEMPT: str(self.attempt),
         }
         if self.suite_id:
             env[ENV_SUITE_ID] = self.suite_id
+            env[LEGACY_ENV_SUITE_ID] = self.suite_id
         if self.suite_version:
             env[ENV_SUITE_VERSION] = self.suite_version
+            env[LEGACY_ENV_SUITE_VERSION] = self.suite_version
         if self.trajectory_id:
             env[ENV_TRAJECTORY_ID] = self.trajectory_id
+            env[LEGACY_ENV_TRAJECTORY_ID] = self.trajectory_id
         return env
 
     @classmethod
     def from_env(cls, environ: dict[str, str] | None = None) -> TrialRef | None:
         env = environ if environ is not None else dict(os.environ)
-        _warn_legacy_env(env)
-        experiment_id = _first_nonblank(env, ENV_EXPERIMENT_ID)
-        test_case_id = _first_nonblank(env, ENV_TEST_CASE_ID)
+        experiment_id = _env_value("EXPERIMENT_ID", env)
+        test_case_id = _env_value("TEST_CASE_ID", env)
         if not experiment_id or not test_case_id:
             return None
         try:
-            attempt = int(_first_nonblank(env, ENV_ATTEMPT) or "1")
+            attempt = int(_env_value("ATTEMPT", env) or "1")
         except ValueError:
             attempt = 1
         return cls(
             experiment_id=experiment_id,
             test_case_id=test_case_id,
             attempt=attempt,
-            suite_id=_first_nonblank(env, ENV_SUITE_ID),
-            suite_version=_first_nonblank(env, ENV_SUITE_VERSION),
-            trajectory_id=_first_nonblank(env, ENV_TRAJECTORY_ID),
+            suite_id=_env_value("SUITE_ID", env),
+            suite_version=_env_value("SUITE_VERSION", env),
+            trajectory_id=_env_value("TRAJECTORY_ID", env),
         )

--- a/python/agento11y/redaction.py
+++ b/python/agento11y/redaction.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from ._redaction_patterns import BASE_FLAGS, EMAIL_PATTERN, TIER1_PATTERNS, TIER2_PATTERNS
-from .config import GenerationSanitizer, _env, _warn_legacy_env
+from .config import GenerationSanitizer, _env
 from .models import Generation, Message, MessageRole, Part, PartKind
 
 _logger = logging.getLogger("agento11y")
@@ -128,14 +128,14 @@ def _resolve_redact_input_messages(
 ) -> bool:
     """Resolve input-message redaction: explicit > env > ``False``.
 
-    ``AGENTO11Y_REDACT_INPUT_MESSAGES`` accepts ``1/0``, ``true/false``,
+    ``AGENTO11Y_REDACT_INPUT_MESSAGES`` (or its legacy
+    ``SIGIL_REDACT_INPUT_MESSAGES`` spelling) accepts ``1/0``, ``true/false``,
     ``yes/no``, ``on/off`` (case-insensitive)
     and is consulted only when ``explicit`` is ``None``. An unrecognised env
     value logs a warning naming the selected key and falls back to ``False``,
     so a typo cannot silently flip redaction.
     """
 
-    _warn_legacy_env(env)
     if explicit is not None:
         return explicit
     raw, key = _env(env, "REDACT_INPUT_MESSAGES")

--- a/python/tests/test_env_config.py
+++ b/python/tests/test_env_config.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 
 import pytest
 from agento11y import ApiConfig, Client, ClientConfig, GenerationExportConfig
-from agento11y.config import default_config, resolve_config
+from agento11y.config import _WARNED_LEGACY_ENV, default_config, resolve_config
 from agento11y.models import ContentCaptureMode, GenerationStart, ModelRef
 
 _DEFAULT_EXPORT_TIMEOUT = timedelta(seconds=30)
@@ -92,6 +92,44 @@ def _check_invalid_export_timeout_preserves_valid(cfg: ClientConfig) -> None:
 
 def _check_legacy_export_timeout_ignored(cfg: ClientConfig) -> None:
     assert cfg.generation_export.export_timeout == _DEFAULT_EXPORT_TIMEOUT
+
+
+def _check_legacy_transport(cfg: ClientConfig) -> None:
+    assert cfg.generation_export.endpoint == "https://legacy:4318"
+    assert cfg.generation_export.protocol == "http"
+    assert cfg.generation_export.insecure is True
+    assert cfg.generation_export.headers["X-A"] == "1"
+    assert cfg.generation_export.auth.tenant_id == "42"
+
+
+def _check_legacy_agent_user_tags(cfg: ClientConfig) -> None:
+    assert cfg.user_id == "alice@example.com"
+    assert cfg.tags == {"service": "orchestrator"}
+    assert cfg.debug is True
+
+
+def _check_legacy_api_endpoint(cfg: ClientConfig) -> None:
+    assert cfg.generation_export.endpoint == "https://legacy-api:4318"
+
+
+def _check_legacy_tenant_id(cfg: ClientConfig) -> None:
+    assert cfg.generation_export.auth.tenant_id == "legacy-42"
+
+
+def _check_canonical_wins_over_legacy(cfg: ClientConfig) -> None:
+    assert cfg.generation_export.endpoint == "https://canonical:4318"
+    # AGENTO11Y_TAGS supplies the whole map; SIGIL_TAGS adds nothing to it.
+    assert cfg.tags == {"a": "1"}
+
+
+def _check_blank_canonical_falls_back(cfg: ClientConfig) -> None:
+    assert cfg.generation_export.endpoint == "https://legacy:4318"
+
+
+def _check_invalid_canonical_blocks_valid_legacy(cfg: ClientConfig) -> None:
+    # A nonblank canonical value is selected before validation, so a valid
+    # legacy value never resurfaces behind it.
+    assert cfg.content_capture == ContentCaptureMode.DEFAULT
 
 
 @pytest.mark.parametrize(
@@ -184,6 +222,59 @@ def _check_legacy_export_timeout_ignored(cfg: ClientConfig) -> None:
             _check_legacy_export_timeout_ignored,
             id="legacy SIGIL export timeout is never read",
         ),
+        pytest.param(
+            {
+                "SIGIL_ENDPOINT": "https://legacy:4318",
+                "SIGIL_PROTOCOL": "http",
+                "SIGIL_INSECURE": "true",
+                "SIGIL_HEADERS": "X-A=1",
+                "SIGIL_AUTH_TENANT_ID": "42",
+            },
+            _check_legacy_transport,
+            id="legacy transport names still resolve",
+        ),
+        pytest.param(
+            {
+                "SIGIL_USER_ID": "alice@example.com",
+                "SIGIL_TAGS": "service=orchestrator",
+                "SIGIL_DEBUG": "true",
+            },
+            _check_legacy_agent_user_tags,
+            id="legacy user tags debug still resolve",
+        ),
+        pytest.param(
+            {"SIGIL_API_ENDPOINT": "https://legacy-api:4318"},
+            _check_legacy_api_endpoint,
+            id="legacy SIGIL_API_ENDPOINT resolves the endpoint",
+        ),
+        pytest.param(
+            {"SIGIL_TENANT_ID": "legacy-42"},
+            _check_legacy_tenant_id,
+            id="legacy SIGIL_TENANT_ID resolves the tenant",
+        ),
+        pytest.param(
+            {
+                "AGENTO11Y_ENDPOINT": "https://canonical:4318",
+                "SIGIL_ENDPOINT": "https://legacy:4318",
+                "AGENTO11Y_TAGS": "a=1",
+                "SIGIL_TAGS": "b=2",
+            },
+            _check_canonical_wins_over_legacy,
+            id="canonical wins over legacy",
+        ),
+        pytest.param(
+            {"AGENTO11Y_ENDPOINT": "   ", "SIGIL_ENDPOINT": "https://legacy:4318"},
+            _check_blank_canonical_falls_back,
+            id="blank canonical falls back to legacy",
+        ),
+        pytest.param(
+            {
+                "AGENTO11Y_CONTENT_CAPTURE_MODE": "bogus",
+                "SIGIL_CONTENT_CAPTURE_MODE": "metadata_only",
+            },
+            _check_invalid_canonical_blocks_valid_legacy,
+            id="invalid canonical blocks valid legacy",
+        ),
     ],
 )
 def test_resolve_config_env(env: dict[str, str], check: Callable[[ClientConfig], None]) -> None:
@@ -213,7 +304,9 @@ def test_invalid_export_timeout_warns_and_keeps_default(raw: str, caplog: pytest
     assert any("AGENTO11Y_EXPORT_TIMEOUT_MS" in record.getMessage() for record in caplog.records)
 
 
-def test_legacy_export_timeout_warns_and_is_ignored(caplog: pytest.LogCaptureFixture) -> None:
+def test_legacy_export_timeout_is_not_read(caplog: pytest.LogCaptureFixture) -> None:
+    """AGENTO11Y_EXPORT_TIMEOUT_MS postdates the rename: SIGIL_EXPORT_TIMEOUT_MS is unused and warns once."""
+
     with caplog.at_level(logging.WARNING, logger="agento11y"):
         cfg = resolve_config(None, env={"SIGIL_EXPORT_TIMEOUT_MS": "1500"})
 
@@ -261,20 +354,73 @@ def test_explicit_overrides_env() -> None:
     assert cfg.agent_name == "planner"
 
 
-def test_invalid_capture_mode_warning_names_selected_key(caplog: pytest.LogCaptureFixture) -> None:
+@pytest.mark.parametrize(
+    "env,expected_key",
+    [
+        pytest.param({"AGENTO11Y_CONTENT_CAPTURE_MODE": "bogus"}, "AGENTO11Y_CONTENT_CAPTURE_MODE", id="canonical"),
+        pytest.param({"SIGIL_CONTENT_CAPTURE_MODE": "bogus"}, "SIGIL_CONTENT_CAPTURE_MODE", id="legacy"),
+    ],
+)
+def test_invalid_capture_mode_warning_names_selected_key(
+    env: dict[str, str], expected_key: str, caplog: pytest.LogCaptureFixture
+) -> None:
     with caplog.at_level(logging.WARNING, logger="agento11y"):
-        cfg = resolve_config(None, env={"AGENTO11Y_CONTENT_CAPTURE_MODE": "bogus"})
+        cfg = resolve_config(None, env=env)
     assert cfg.content_capture == ContentCaptureMode.DEFAULT
-    assert any("AGENTO11Y_CONTENT_CAPTURE_MODE" in r.getMessage() for r in caplog.records)
+    assert any(f"ignoring invalid {expected_key}" in r.getMessage() for r in caplog.records)
 
 
-def test_legacy_env_namespace_is_ignored_with_migration_warning(caplog: pytest.LogCaptureFixture) -> None:
+def test_legacy_env_namespace_resolves_with_deprecation_warning(caplog: pytest.LogCaptureFixture) -> None:
     with caplog.at_level(logging.WARNING, logger="agento11y"):
         cfg = resolve_config(None, env={"SIGIL_ENDPOINT": "https://legacy.example"})
-    assert cfg.generation_export.endpoint == "localhost:4317"
+    assert cfg.generation_export.endpoint == "https://legacy.example"
     assert any(
-        "SIGIL_ENDPOINT is ignored; rename it to AGENTO11Y_ENDPOINT" in record.getMessage() for record in caplog.records
+        "SIGIL_ENDPOINT is deprecated; rename it to AGENTO11Y_ENDPOINT" in record.getMessage()
+        for record in caplog.records
     )
+
+
+def test_legacy_env_warning_fires_once_per_process(caplog: pytest.LogCaptureFixture) -> None:
+    env = {"SIGIL_ENDPOINT": "https://legacy.example"}
+    with caplog.at_level(logging.WARNING, logger="agento11y"):
+        resolve_config(None, env=env)
+        resolve_config(None, env=env)
+    warnings = [r for r in caplog.records if "SIGIL_ENDPOINT" in r.getMessage()]
+    assert len(warnings) == 1
+
+    _WARNED_LEGACY_ENV.clear()
+    with caplog.at_level(logging.WARNING, logger="agento11y"):
+        resolve_config(None, env=env)
+    assert len([r for r in caplog.records if "SIGIL_ENDPOINT" in r.getMessage()]) == 2
+
+
+def test_unused_legacy_env_name_does_not_warn(caplog: pytest.LogCaptureFixture) -> None:
+    """The warning fires at the point of use, not on every legacy name present."""
+    with caplog.at_level(logging.WARNING, logger="agento11y"):
+        cfg = resolve_config(
+            None,
+            env={"AGENTO11Y_ENDPOINT": "https://canonical.example", "SIGIL_ENDPOINT": "https://legacy.example"},
+        )
+    assert cfg.generation_export.endpoint == "https://canonical.example"
+    assert not [r for r in caplog.records if "SIGIL_ENDPOINT" in r.getMessage()]
+
+
+def test_canonical_only_legacy_name_stays_silent_when_canonical_is_set(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING, logger="agento11y"):
+        cfg = resolve_config(
+            None,
+            env={"AGENTO11Y_EXPORT_TIMEOUT_MS": "5000", "SIGIL_EXPORT_TIMEOUT_MS": "9000"},
+        )
+    assert cfg.generation_export.export_timeout == timedelta(milliseconds=5000)
+    assert not [r for r in caplog.records if "SIGIL_EXPORT_TIMEOUT_MS" in r.getMessage()]
+
+
+def test_canonical_only_legacy_warning_fires_once_per_process(caplog: pytest.LogCaptureFixture) -> None:
+    env = {"SIGIL_EXPORT_TIMEOUT_MS": "5000"}
+    with caplog.at_level(logging.WARNING, logger="agento11y"):
+        resolve_config(None, env=env)
+        resolve_config(None, env=env)
+    assert len([r for r in caplog.records if "SIGIL_EXPORT_TIMEOUT_MS" in r.getMessage()]) == 1
 
 
 def test_agento11y_endpoint_also_defaults_api_endpoint() -> None:

--- a/python/tests/test_experiments.py
+++ b/python/tests/test_experiments.py
@@ -633,7 +633,8 @@ def test_trial_ref_env_round_trip() -> None:
     assert restored.attempt == 3
 
 
-def test_trial_ref_to_env_writes_only_agento11y_names() -> None:
+def test_trial_ref_to_env_writes_both_spellings() -> None:
+    """to_env writes every populated field under both names, matching Go's agento11y.TrialRef.ToEnv."""
     ref = TrialRef(
         experiment_id="run-5",
         test_case_id="c1",
@@ -645,25 +646,93 @@ def test_trial_ref_to_env_writes_only_agento11y_names() -> None:
     env = ref.to_env()
     assert env == {
         "AGENTO11Y_EXPERIMENT_ID": "run-5",
+        "SIGIL_EXPERIMENT_ID": "run-5",
         "AGENTO11Y_TEST_CASE_ID": "c1",
+        "SIGIL_TEST_CASE_ID": "c1",
         "AGENTO11Y_ATTEMPT": "2",
+        "SIGIL_ATTEMPT": "2",
         "AGENTO11Y_SUITE_ID": "s",
+        "SIGIL_SUITE_ID": "s",
         "AGENTO11Y_SUITE_VERSION": "2.0.0",
+        "SIGIL_SUITE_VERSION": "2.0.0",
         "AGENTO11Y_TRAJECTORY_ID": "traj-1",
+        "SIGIL_TRAJECTORY_ID": "traj-1",
     }
 
 
-def test_trial_ref_from_env_rejects_sigil_names_with_warning(caplog: pytest.LogCaptureFixture) -> None:
-    env = {"SIGIL_EXPERIMENT_ID": "run-old", "SIGIL_TEST_CASE_ID": "c1", "SIGIL_ATTEMPT": "4"}
+def test_trial_ref_to_env_omits_empty_optional_fields() -> None:
+    env = TrialRef(experiment_id="run-6", test_case_id="c1").to_env()
+    assert set(env) == {
+        "AGENTO11Y_EXPERIMENT_ID",
+        "SIGIL_EXPERIMENT_ID",
+        "AGENTO11Y_TEST_CASE_ID",
+        "SIGIL_TEST_CASE_ID",
+        "AGENTO11Y_ATTEMPT",
+        "SIGIL_ATTEMPT",
+    }
+
+
+def test_trial_ref_from_env_reads_sigil_names_with_warning(caplog: pytest.LogCaptureFixture) -> None:
+    env = {
+        "SIGIL_EXPERIMENT_ID": "run-old",
+        "SIGIL_TEST_CASE_ID": "c1",
+        "SIGIL_ATTEMPT": "4",
+        "SIGIL_SUITE_ID": "s",
+        "SIGIL_SUITE_VERSION": "2.0.0",
+        "SIGIL_TRAJECTORY_ID": "traj-1",
+    }
     with caplog.at_level("WARNING", logger="agento11y"):
-        assert TrialRef.from_env(env) is None
+        ref = TrialRef.from_env(env)
+    assert ref is not None
+    assert ref.experiment_id == "run-old"
+    assert ref.test_case_id == "c1"
+    assert ref.attempt == 4
+    assert ref.suite_id == "s"
+    assert ref.suite_version == "2.0.0"
+    assert ref.trajectory_id == "traj-1"
     messages = [record.getMessage() for record in caplog.records]
-    assert any("SIGIL_EXPERIMENT_ID is ignored; rename it to AGENTO11Y_EXPERIMENT_ID" in item for item in messages)
-    assert any("SIGIL_TEST_CASE_ID is ignored; rename it to AGENTO11Y_TEST_CASE_ID" in item for item in messages)
+    assert any("SIGIL_EXPERIMENT_ID is deprecated; rename it to AGENTO11Y_EXPERIMENT_ID" in item for item in messages)
+    assert any("SIGIL_TEST_CASE_ID is deprecated; rename it to AGENTO11Y_TEST_CASE_ID" in item for item in messages)
 
 
-def test_trial_ref_from_env_ignores_agento11y_run_id() -> None:
-    assert TrialRef.from_env({"AGENTO11Y_RUN_ID": "run-x", "AGENTO11Y_TEST_CASE_ID": "c1"}) is None
+@pytest.mark.parametrize(
+    "env,expected",
+    [
+        pytest.param(
+            {"SIGIL_RUN_ID": "run-legacy", "SIGIL_TEST_CASE_ID": "c1"},
+            ("run-legacy", "c1"),
+            id="SIGIL_RUN_ID supplies the experiment id",
+        ),
+        pytest.param(
+            {"SIGIL_EXPERIMENT_ID": "run-old", "SIGIL_RUN_ID": "run-older", "SIGIL_TEST_CASE_ID": "c1"},
+            ("run-old", "c1"),
+            id="SIGIL_EXPERIMENT_ID beats SIGIL_RUN_ID",
+        ),
+        pytest.param(
+            {
+                "AGENTO11Y_EXPERIMENT_ID": "run-new",
+                "SIGIL_EXPERIMENT_ID": "run-old",
+                "SIGIL_RUN_ID": "run-older",
+                "AGENTO11Y_TEST_CASE_ID": "c-new",
+                "SIGIL_TEST_CASE_ID": "c-old",
+            },
+            ("run-new", "c-new"),
+            id="canonical wins over every legacy spelling",
+        ),
+        pytest.param(
+            {"AGENTO11Y_RUN_ID": "run-x", "AGENTO11Y_TEST_CASE_ID": "c1"},
+            None,
+            id="AGENTO11Y_RUN_ID is not a name",
+        ),
+    ],
+)
+def test_trial_ref_from_env_alias_resolution(env: dict[str, str], expected: tuple[str, str] | None) -> None:
+    ref = TrialRef.from_env(env)
+    if expected is None:
+        assert ref is None
+        return
+    assert ref is not None
+    assert (ref.experiment_id, ref.test_case_id) == expected
 
 
 def test_trial_from_ref_requires_ref() -> None:
@@ -1105,6 +1174,10 @@ def test_experimental_gate_reads_truthy_values(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.delenv(ENV_ENABLE_EXPERIMENTAL_FEATURES, raising=False)
     assert experimental_features_enabled() is False
 
+    # The name postdates the rename, so no release ever read SIGIL_ for it.
+    monkeypatch.setenv("SIGIL_ENABLE_EXPERIMENTAL_FEATURES", "true")
+    assert experimental_features_enabled() is False
+
 
 def test_experimental_feature_disabled_error_survives_pickle() -> None:
     from agento11y.errors import ExperimentalFeatureDisabledError
@@ -1268,15 +1341,63 @@ def test_experiment_factory_uses_supplied_client() -> None:
     assert client.finalized and client.finalized[0][0] == "run-f"
 
 
-def test_experiment_factory_uses_agento11y_connection_env(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    "env",
+    [
+        pytest.param(
+            {
+                "AGENTO11Y_ENDPOINT": "https://agento11y",
+                "AGENTO11Y_AUTH_TENANT_ID": "1",
+                "AGENTO11Y_AUTH_TOKEN": "token",
+                "AGENTO11Y_INGEST_ACTOR": "ingest:test",
+            },
+            id="canonical",
+        ),
+        pytest.param(
+            {
+                "SIGIL_ENDPOINT": "https://agento11y",
+                "SIGIL_AUTH_TENANT_ID": "1",
+                "SIGIL_AUTH_TOKEN": "token",
+                "SIGIL_INGEST_ACTOR": "ingest:test",
+            },
+            id="legacy",
+        ),
+        pytest.param(
+            {
+                "SIGIL_API_ENDPOINT": "https://agento11y",
+                "SIGIL_TENANT_ID": "1",
+                "SIGIL_AUTH_TOKEN": "token",
+                "SIGIL_INGEST_ACTOR": "ingest:test",
+            },
+            id="legacy secondary spellings",
+        ),
+        pytest.param(
+            {
+                "AGENTO11Y_ENDPOINT": "https://agento11y",
+                "SIGIL_ENDPOINT": "https://legacy",
+                "AGENTO11Y_AUTH_TENANT_ID": "1",
+                "SIGIL_AUTH_TENANT_ID": "2",
+                "AGENTO11Y_AUTH_TOKEN": "token",
+                "SIGIL_AUTH_TOKEN": "legacy-token",
+                "AGENTO11Y_INGEST_ACTOR": "ingest:test",
+                "SIGIL_INGEST_ACTOR": "ingest:legacy",
+            },
+            id="canonical wins over legacy",
+        ),
+    ],
+)
+def test_experiment_factory_uses_connection_env(env: dict[str, str], monkeypatch: pytest.MonkeyPatch) -> None:
     from agento11y.experiments import experiment as experiment_factory
 
-    monkeypatch.setenv("AGENTO11Y_ENDPOINT", "https://agento11y")
-    monkeypatch.setenv("AGENTO11Y_AUTH_TENANT_ID", "1")
-    monkeypatch.setenv("AGENTO11Y_AUTH_TOKEN", "token")
-    exp = experiment_factory("conn")
-    client = exp.client
-    assert (client.endpoint, client.tenant_id, client.ingest_token) == ("https://agento11y", "1", "token")
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    client = experiment_factory("conn").client
+    assert (client.endpoint, client.tenant_id, client.ingest_token, client.actor) == (
+        "https://agento11y",
+        "1",
+        "token",
+        "ingest:test",
+    )
 
 
 def test_experiment_factory_ignores_agento11y_api_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1288,16 +1409,50 @@ def test_experiment_factory_ignores_agento11y_api_endpoint(monkeypatch: pytest.M
         experiment_factory("conn")
 
 
-def test_experiments_client_uses_agento11y_env(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    "env,expected_otel",
+    [
+        pytest.param(
+            {
+                "AGENTO11Y_AUTH_TOKEN": "token",
+                "AGENTO11Y_GRAFANA_URL": "https://g.example/",
+                "AGENTO11Y_USE_EXPERIMENTAL_OTEL": "false",
+            },
+            False,
+            id="canonical",
+        ),
+        pytest.param(
+            {
+                "SIGIL_AUTH_TOKEN": "token",
+                "SIGIL_GRAFANA_URL": "https://g.example/",
+                "SIGIL_USE_EXPERIMENTAL_OTEL": "true",
+            },
+            True,
+            id="legacy",
+        ),
+        pytest.param(
+            {
+                "AGENTO11Y_AUTH_TOKEN": "token",
+                "SIGIL_AUTH_TOKEN": "legacy-token",
+                "AGENTO11Y_GRAFANA_URL": "https://g.example/",
+                "SIGIL_GRAFANA_URL": "https://legacy.example",
+                "AGENTO11Y_USE_EXPERIMENTAL_OTEL": "false",
+                "SIGIL_USE_EXPERIMENTAL_OTEL": "true",
+            },
+            False,
+            id="canonical wins over legacy",
+        ),
+    ],
+)
+def test_experiments_client_uses_env(env: dict[str, str], expected_otel: bool, monkeypatch: pytest.MonkeyPatch) -> None:
     from agento11y.experiments.client import Client as IngestClient
 
-    monkeypatch.setenv("AGENTO11Y_AUTH_TOKEN", "token")
-    monkeypatch.setenv("AGENTO11Y_GRAFANA_URL", "https://g.example/")
-    monkeypatch.setenv("AGENTO11Y_USE_EXPERIMENTAL_OTEL", "false")
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
     client = IngestClient("https://sigil.example")
     assert client.ingest_token == "token"
     assert client.grafana_url == "https://g.example"
-    assert client.use_experimental_otel is False
+    assert client.use_experimental_otel is expected_otel
 
 
 def test_final_score_primitive_derives_boolean_verdict() -> None:

--- a/python/tests/test_redaction.py
+++ b/python/tests/test_redaction.py
@@ -328,10 +328,21 @@ def test_resolve_redact_input_messages_invalid_warns_and_falls_back(caplog) -> N
     )
 
 
-def test_resolve_redact_input_messages_ignores_legacy_namespace(caplog) -> None:
+def test_resolve_redact_input_messages_reads_legacy_namespace(caplog) -> None:
     with caplog.at_level(logging.WARNING, logger="agento11y"):
-        assert _resolve_redact_input_messages(None, env={"SIGIL_REDACT_INPUT_MESSAGES": "true"}) is False
-    assert any("SIGIL_REDACT_INPUT_MESSAGES is ignored" in record.getMessage() for record in caplog.records)
+        assert _resolve_redact_input_messages(None, env={"SIGIL_REDACT_INPUT_MESSAGES": "true"}) is True
+    assert any("SIGIL_REDACT_INPUT_MESSAGES is deprecated" in record.getMessage() for record in caplog.records)
+
+
+def test_resolve_redact_input_messages_canonical_wins_over_legacy() -> None:
+    env = {"AGENTO11Y_REDACT_INPUT_MESSAGES": "false", "SIGIL_REDACT_INPUT_MESSAGES": "true"}
+    assert _resolve_redact_input_messages(None, env=env) is False
+
+
+def test_resolve_redact_input_messages_invalid_warns_with_legacy_key(caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger="agento11y"):
+        assert _resolve_redact_input_messages(None, env={"SIGIL_REDACT_INPUT_MESSAGES": "maybe"}) is False
+    assert any("ignoring invalid SIGIL_REDACT_INPUT_MESSAGES" in record.getMessage() for record in caplog.records)
 
 
 def test_create_secret_redaction_sanitizer_reads_env(monkeypatch) -> None:

--- a/python/tests/test_test_suites_client.py
+++ b/python/tests/test_test_suites_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
@@ -180,15 +181,50 @@ def test_direct_control_endpoint_keeps_separate_grafana_url(monkeypatch: pytest.
     assert client.grafana_url == "http://localhost:3000"
 
 
-def test_legacy_control_environment_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_legacy_control_environment_is_ignored(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Both names postdate the rename, so no SIGIL_ spelling was ever read."""
     monkeypatch.delenv("AGENTO11Y_CONTROL_ENDPOINT", raising=False)
     monkeypatch.delenv("AGENTO11Y_GRAFANA_URL", raising=False)
     monkeypatch.delenv("AGENTO11Y_SERVICE_ACCOUNT_TOKEN", raising=False)
     monkeypatch.setenv("SIGIL_CONTROL_ENDPOINT", "https://legacy.example")
     monkeypatch.setenv("SIGIL_SERVICE_ACCOUNT_TOKEN", "legacy-token")
 
-    with pytest.raises(ValueError, match="control_endpoint is required"):
+    with (
+        caplog.at_level(logging.WARNING, logger="agento11y"),
+        pytest.raises(ValueError, match="control_endpoint is required"),
+    ):
         TestSuitesClient()
+
+    assert any(
+        "SIGIL_CONTROL_ENDPOINT is ignored; rename it to AGENTO11Y_CONTROL_ENDPOINT" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.parametrize(
+    "grafana_keys,expected_grafana",
+    [
+        pytest.param({"SIGIL_GRAFANA_URL": "http://legacy:3000"}, "http://legacy:3000", id="legacy grafana url"),
+        pytest.param(
+            {"AGENTO11Y_GRAFANA_URL": "http://canonical:3000", "SIGIL_GRAFANA_URL": "http://legacy:3000"},
+            "http://canonical:3000",
+            id="canonical grafana url wins",
+        ),
+    ],
+)
+def test_legacy_grafana_url_resolves(
+    grafana_keys: dict[str, str], expected_grafana: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for key, value in grafana_keys.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setenv("AGENTO11Y_CONTROL_ENDPOINT", "http://localhost:8080/api/v1/eval")
+    monkeypatch.setenv("AGENTO11Y_SERVICE_ACCOUNT_TOKEN", "env-token")
+
+    client = TestSuitesClient(timeout=2)
+
+    assert client.grafana_url == expected_grafana
 
 
 def test_version_resolution_aliases() -> None:


### PR DESCRIPTION
Restores reading the legacy `SIGIL_*` environment vars in Python's config resolver and in the experiments layer of Go, JS, and Python.