### PR TITLE
feat(plugins/agento11y): route hook captures to local mode

### DIFF
--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -166,7 +166,7 @@ A plugin can only export fields the host agent passes through to it, so individu
 
 ## Local mode and history import
 
-`agento11y <agent> --local` records the session to a JSONL store on this machine and opens a viewer at `http://127.0.0.1:8765`. Start and stop the daemon by hand with `agento11y local start|status|stop`.
+`agento11y <agent> --local` records the session to a JSONL store on this machine and opens a viewer at `http://127.0.0.1:8765`. `AGENTO11Y_LOCAL=true` in the shell or `config.env` does the same for every launch and for hook-based agents (Cursor, Copilot, Vibe, and a host `claude`/`codex` whose agento11y hooks are installed). Start and stop the daemon by hand with `agento11y local start|status|stop`.
 
 The viewer starts empty: it holds only the sessions captured after you installed agento11y. `agento11y history import` backfills the ones an agent already wrote to disk.
 

--- a/plugins/agento11y/internal/doctor/doctor.go
+++ b/plugins/agento11y/internal/doctor/doctor.go
@@ -1011,11 +1011,11 @@ func collectConfig(osEnv, fileEnv map[string]string) ConfigSection {
 			"local mode set via legacy SIGIL_LOCAL — this keeps working, but the preferred name is AGENTO11Y_LOCAL")
 	}
 	if localOn {
-		// The launcher is the only thing that reads this family, so a user who
-		// reads it as "nothing leaves this machine" is wrong about every other
-		// way a session starts.
+		// Launchers and hooks both read this family, but LOCAL_FORWARD still
+		// copies local captures to Cloud, so "nothing leaves this machine" is
+		// still the wrong reading.
 		sec.Messages = append(sec.Messages,
-			"local mode covers `agento11y <agent>` launches; sessions the host agent starts on its own, such as Cursor or a plain `claude`, keep exporting to the configured endpoint")
+			"local mode sends `agento11y <agent>` launches and agento11y hooks to the local viewer; Cloud forwarding still requires AGENTO11Y_LOCAL_FORWARD")
 	}
 	return sec
 }

--- a/plugins/agento11y/internal/doctor/doctor_test.go
+++ b/plugins/agento11y/internal/doctor/doctor_test.go
@@ -1697,8 +1697,9 @@ func TestCollectConfig_AutoTagsResolveFromTheCheckout(t *testing.T) {
 }
 
 // TestCollectConfig_Local covers the LOCAL row: doctor reports the value the
-// launcher acts on (shell before config.env), renders it, warns when the value
-// is not a boolean, and states that local mode stops at the launcher.
+// launcher and hooks act on (shell before config.env), renders it, warns when
+// the value is not a boolean, and states that local mode covers launches and
+// hooks.
 func TestCollectConfig_Local(t *testing.T) {
 	// The table below builds osEnv by hand, so it cannot catch a family missing
 	// from the snapshot the binary actually passes in. Without the entry, a
@@ -1707,7 +1708,7 @@ func TestCollectConfig_Local(t *testing.T) {
 	if !slices.Contains(trackedSuffixes, "LOCAL") {
 		t.Fatal("LOCAL must be in trackedSuffixes or SnapshotEnv drops it and this report reads it as unset")
 	}
-	const scopeMsg = "local mode covers `agento11y <agent>` launches"
+	const scopeMsg = "local mode sends `agento11y <agent>` launches and agento11y hooks to the local viewer"
 	tests := []struct {
 		name            string
 		osEnv           map[string]string
@@ -1839,7 +1840,7 @@ func TestCollect_LocalModeScopeReachesTheReport(t *testing.T) {
 		t.Fatalf("Config.Local = %+v, want the config.env value", r.Config.Local)
 	}
 	joined := strings.Join(r.Config.Messages, " ")
-	if !strings.Contains(joined, "local mode covers `agento11y <agent>` launches") {
+	if !strings.Contains(joined, "local mode sends `agento11y <agent>` launches and agento11y hooks to the local viewer") {
 		t.Fatalf("report messages %v missing the local-mode scope message", r.Config.Messages)
 	}
 }

--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -41,7 +41,9 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -384,6 +386,32 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 	}
 }
 
+// hookLocalStartTimeout is the same deadline launchers use. It must be
+// longer than startDaemon's 5s readiness wait: a shorter context cancels
+// that poll, kills a healthy child, and then the failure stamp skips
+// retries while the hook still points at a dead loopback URL. Repeat
+// start cost after a real failure is bounded by skipLocalHookStart, not
+// by shrinking this timeout.
+const hookLocalStartTimeout = 10 * time.Second
+
+// hookStartFailFile / hookStartFailTTL remember a failed start across
+// hook processes (Cursor execs a new binary per event). A healthy
+// IsRunning check still wins, so a later successful `agento11y local start`
+// is picked up without waiting out the TTL.
+const (
+	hookStartFailFile = "hook-start-failed"
+	hookStartFailTTL  = 30 * time.Second
+)
+
+var (
+	localHookStartMu     sync.Mutex
+	localHookStartFailed bool
+	// hookLocalReceiverSupported is a test seam for the Windows path,
+	// where the local receiver cannot start and hooks must keep Cloud
+	// credentials instead of rewriting to loopback.
+	hookLocalReceiverSupported = local.ReceiverSupported
+)
+
 // applyLocalHookEnv rewrites the hook process so AGENTO11Y_LOCAL=true (or
 // SIGIL_LOCAL) sends generations to the local daemon instead of Grafana
 // Cloud. Launchers already do this for `agento11y <agent>`; Cursor, Copilot,
@@ -394,23 +422,76 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 // The rewrite is silent: hooks fire many times per turn and must not print
 // the local-mode banner to the host agent's stderr. A failure to start the
 // daemon is logged and the env still points at loopback so a down receiver
-// cannot leak the turn to Cloud.
+// cannot leak the turn to Cloud. A later hook in this process, or a later
+// process within hookStartFailTTL, skips the start attempt unless a
+// receiver is already healthy. On platforms where the receiver cannot
+// run (Windows), the Cloud endpoint is left in place.
 func applyLocalHookEnv(logger *log.Logger) {
 	if !envconfig.ParseBool(envconfig.Getenv("LOCAL")) {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
+	if !hookLocalReceiverSupported() {
+		logger.Printf("local hook: receiver not supported on this OS; exporting to the configured endpoint")
+		return
+	}
 	endpoint := fmt.Sprintf("http://127.0.0.1:%d", local.DefaultPort)
-	status, err := local.EnsureRunning(ctx, local.StateDir(), logger)
-	if err != nil {
-		logger.Printf("local hook: failed to start receiver: %v", err)
-	} else if status != nil && status.Endpoint != "" {
+	dir := local.StateDir()
+	if status, err := local.IsRunning(dir); err == nil && status != nil && status.Endpoint != "" {
 		endpoint = status.Endpoint
+		clearLocalHookStartFailure(dir)
+	} else if !skipLocalHookStart(dir) {
+		ctx, cancel := context.WithTimeout(context.Background(), hookLocalStartTimeout)
+		status, err := local.EnsureRunning(ctx, dir, logger)
+		cancel()
+		if err != nil {
+			logger.Printf("local hook: failed to start receiver: %v", err)
+			markLocalHookStartFailure(dir)
+		} else if status != nil && status.Endpoint != "" {
+			endpoint = status.Endpoint
+			clearLocalHookStartFailure(dir)
+		}
 	}
 	local.LaunchEnv{Endpoint: endpoint, OTLPEndpoint: endpoint + "/otlp"}.ApplyOS()
 	logger.Printf("local hook: endpoint=%s", endpoint)
+}
+
+func skipLocalHookStart(dir string) bool {
+	localHookStartMu.Lock()
+	failed := localHookStartFailed
+	localHookStartMu.Unlock()
+	if failed {
+		return true
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, hookStartFailFile))
+	if err != nil {
+		return false
+	}
+	stamped, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(string(raw)))
+	if err != nil {
+		return false
+	}
+	return time.Since(stamped) < hookStartFailTTL
+}
+
+func markLocalHookStartFailure(dir string) {
+	localHookStartMu.Lock()
+	localHookStartFailed = true
+	localHookStartMu.Unlock()
+	_ = os.MkdirAll(dir, 0o700)
+	_ = os.WriteFile(filepath.Join(dir, hookStartFailFile), []byte(time.Now().UTC().Format(time.RFC3339Nano)+"\n"), 0o600)
+}
+
+func clearLocalHookStartFailure(dir string) {
+	localHookStartMu.Lock()
+	localHookStartFailed = false
+	localHookStartMu.Unlock()
+	_ = os.Remove(filepath.Join(dir, hookStartFailFile))
+}
+
+func resetLocalHookStartFailureForTest() {
+	localHookStartMu.Lock()
+	localHookStartFailed = false
+	localHookStartMu.Unlock()
 }
 
 // runLoginCommand handles `agento11y login`. Values can arrive as flags, on

--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -20,9 +20,9 @@
 // --tag is repeatable and adds key=value pairs to SIGIL_TAGS so they land
 // on every generation the launched session produces.
 //
-// --local can also be turned on for every launch with AGENTO11Y_LOCAL=true in
-// the shell or in config.env. --no-local runs one session against Cloud while
-// that setting stays on.
+// --local can also be turned on for every launch — and for hook dispatch —
+// with AGENTO11Y_LOCAL=true in the shell or in config.env. --no-local runs
+// one session against Cloud while that setting stays on.
 //
 // Unknown agents and unknown verbs exit with code 2 and a usage message on
 // stderr. For hook agents the binary must never crash the calling agent
@@ -377,10 +377,40 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 	dotenv.ApplyEnv(nil)
 	logger := cli.InitLogger(agent)
 	defer cli.RecoverAndLog(logger)
+	applyLocalHookEnv(logger)
 
 	if err := hook(context.Background(), stdin, stdout, logger); err != nil {
 		logger.Printf("hook: %v", err)
 	}
+}
+
+// applyLocalHookEnv rewrites the hook process so AGENTO11Y_LOCAL=true (or
+// SIGIL_LOCAL) sends generations to the local daemon instead of Grafana
+// Cloud. Launchers already do this for `agento11y <agent>`; Cursor, Copilot,
+// Vibe, and a plain `claude`/`codex` whose agento11y hooks are installed
+// have no launcher wrap, so the hook itself applies the same LaunchEnv
+// contract.
+//
+// The rewrite is silent: hooks fire many times per turn and must not print
+// the local-mode banner to the host agent's stderr. A failure to start the
+// daemon is logged and the env still points at loopback so a down receiver
+// cannot leak the turn to Cloud.
+func applyLocalHookEnv(logger *log.Logger) {
+	if !envconfig.ParseBool(envconfig.Getenv("LOCAL")) {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	endpoint := fmt.Sprintf("http://127.0.0.1:%d", local.DefaultPort)
+	status, err := local.EnsureRunning(ctx, local.StateDir(), logger)
+	if err != nil {
+		logger.Printf("local hook: failed to start receiver: %v", err)
+	} else if status != nil && status.Endpoint != "" {
+		endpoint = status.Endpoint
+	}
+	local.LaunchEnv{Endpoint: endpoint, OTLPEndpoint: endpoint + "/otlp"}.ApplyOS()
+	logger.Printf("local hook: endpoint=%s", endpoint)
 }
 
 // runLoginCommand handles `agento11y login`. Values can arrive as flags, on

--- a/plugins/agento11y/internal/entry/entry_test.go
+++ b/plugins/agento11y/internal/entry/entry_test.go
@@ -264,6 +264,7 @@ func TestRun_HookLocalRewritesEndpoint(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			resetLocalHookStartFailureForTest()
 			isolateDotenvHome(t)
 			t.Setenv("AGENTO11Y_ENDPOINT", "https://cloud.example.test")
 			t.Setenv("SIGIL_ENDPOINT", "https://cloud.example.test")
@@ -321,6 +322,99 @@ func TestRun_HookLocalRewritesEndpoint(t *testing.T) {
 				t.Fatalf("CONTENT_CAPTURE_MODE = %q, want metadata_only", gotCapture)
 			}
 		})
+	}
+}
+
+func TestRun_HookLocalSkipsStartAfterFailure(t *testing.T) {
+	resetLocalHookStartFailureForTest()
+	isolateDotenvHome(t)
+	t.Setenv("AGENTO11Y_LOCAL", "true")
+	t.Setenv("AGENTO11Y_ENDPOINT", "https://cloud.example.test")
+	t.Setenv("SIGIL_ENDPOINT", "https://cloud.example.test")
+
+	startCalls := 0
+	restore := local.SetStartDaemonForTesting(func(_ context.Context, _ string, _ *log.Logger) (*local.Status, error) {
+		startCalls++
+		return nil, errors.New("bind failed")
+	})
+	t.Cleanup(restore)
+
+	prev := agents
+	t.Cleanup(func() { agents = prev })
+	agents = map[string]agentHook{
+		"cursor": func(_ context.Context, _ io.Reader, _ io.Writer, _ *log.Logger) error { return nil },
+	}
+
+	runHook := func() {
+		var stdout, stderr bytes.Buffer
+		gotExit := withExit(t, func() {
+			run([]string{"cursor", "hook"}, strings.NewReader(`{}`), &stdout, &stderr)
+		})
+		if gotExit != nil {
+			t.Fatalf("exit code = %d, want no exit", *gotExit)
+		}
+	}
+
+	runHook()
+	if startCalls != 1 {
+		t.Fatalf("first hook start calls = %d, want 1", startCalls)
+	}
+	runHook()
+	if startCalls != 1 {
+		t.Fatalf("second hook start calls = %d, want 1 (in-process short-circuit)", startCalls)
+	}
+
+	// A later hook process only has the stamp file, not the in-memory flag.
+	resetLocalHookStartFailureForTest()
+	runHook()
+	if startCalls != 1 {
+		t.Fatalf("third hook start calls = %d, want 1 (stamp-file short-circuit)", startCalls)
+	}
+	if os.Getenv("AGENTO11Y_ENDPOINT") != "http://127.0.0.1:8765" {
+		t.Fatalf("ENDPOINT = %q, want loopback fallback", os.Getenv("AGENTO11Y_ENDPOINT"))
+	}
+}
+
+func TestRun_HookLocalUnsupportedKeepsCloudEndpoint(t *testing.T) {
+	resetLocalHookStartFailureForTest()
+	isolateDotenvHome(t)
+	t.Setenv("AGENTO11Y_LOCAL", "true")
+	t.Setenv("AGENTO11Y_ENDPOINT", "https://cloud.example.test")
+	t.Setenv("SIGIL_ENDPOINT", "https://cloud.example.test")
+	t.Setenv("AGENTO11Y_CONTENT_CAPTURE_MODE", "metadata_only")
+
+	prevSupported := hookLocalReceiverSupported
+	hookLocalReceiverSupported = func() bool { return false }
+	t.Cleanup(func() { hookLocalReceiverSupported = prevSupported })
+
+	startCalls := 0
+	restore := local.SetStartDaemonForTesting(func(_ context.Context, _ string, _ *log.Logger) (*local.Status, error) {
+		startCalls++
+		return nil, errors.New("should not start")
+	})
+	t.Cleanup(restore)
+
+	prev := agents
+	t.Cleanup(func() { agents = prev })
+	agents = map[string]agentHook{
+		"cursor": func(_ context.Context, _ io.Reader, _ io.Writer, _ *log.Logger) error { return nil },
+	}
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"cursor", "hook"}, strings.NewReader(`{}`), &stdout, &stderr)
+	})
+	if gotExit != nil {
+		t.Fatalf("exit code = %d, want no exit", *gotExit)
+	}
+	if startCalls != 0 {
+		t.Fatalf("start calls = %d, want 0", startCalls)
+	}
+	if os.Getenv("AGENTO11Y_ENDPOINT") != "https://cloud.example.test" {
+		t.Fatalf("ENDPOINT = %q, want cloud", os.Getenv("AGENTO11Y_ENDPOINT"))
+	}
+	if os.Getenv("AGENTO11Y_CONTENT_CAPTURE_MODE") != "metadata_only" {
+		t.Fatalf("CONTENT_CAPTURE_MODE = %q, want metadata_only", os.Getenv("AGENTO11Y_CONTENT_CAPTURE_MODE"))
 	}
 }
 

--- a/plugins/agento11y/internal/entry/entry_test.go
+++ b/plugins/agento11y/internal/entry/entry_test.go
@@ -216,6 +216,114 @@ func TestRun_DotenvSIGILDebugEnablesLogging(t *testing.T) {
 	}
 }
 
+func TestRun_HookLocalRewritesEndpoint(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T)
+		startErr    error
+		wantStart   bool
+		wantRewrite bool
+	}{
+		{
+			name: "shell LOCAL rewrites cloud endpoint",
+			setup: func(t *testing.T) {
+				t.Setenv("AGENTO11Y_LOCAL", "true")
+			},
+			wantStart:   true,
+			wantRewrite: true,
+		},
+		{
+			name: "config.env LOCAL rewrites cloud endpoint",
+			setup: func(t *testing.T) {
+				cfgDir := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "agento11y")
+				if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(cfgDir, "config.env"), []byte("AGENTO11Y_LOCAL=true\n"), 0o600); err != nil {
+					t.Fatalf("write dotenv: %v", err)
+				}
+			},
+			wantStart:   true,
+			wantRewrite: true,
+		},
+		{
+			name: "LOCAL off leaves cloud endpoint",
+			setup: func(t *testing.T) {
+				t.Setenv("AGENTO11Y_LOCAL", "false")
+			},
+		},
+		{
+			name: "daemon start failure still points at loopback",
+			setup: func(t *testing.T) {
+				t.Setenv("AGENTO11Y_LOCAL", "true")
+			},
+			startErr:    errors.New("bind failed"),
+			wantStart:   true,
+			wantRewrite: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateDotenvHome(t)
+			t.Setenv("AGENTO11Y_ENDPOINT", "https://cloud.example.test")
+			t.Setenv("SIGIL_ENDPOINT", "https://cloud.example.test")
+			t.Setenv("AGENTO11Y_CONTENT_CAPTURE_MODE", "metadata_only")
+			t.Setenv("SIGIL_CONTENT_CAPTURE_MODE", "metadata_only")
+			tc.setup(t)
+
+			startCalls := 0
+			restore := local.SetStartDaemonForTesting(func(_ context.Context, _ string, _ *log.Logger) (*local.Status, error) {
+				startCalls++
+				if tc.startErr != nil {
+					return nil, tc.startErr
+				}
+				return &local.Status{PID: os.Getpid(), Port: 8765, Endpoint: "http://127.0.0.1:8765", StartedAt: time.Now().UTC().Format(time.RFC3339Nano)}, nil
+			})
+			t.Cleanup(restore)
+
+			var gotEndpoint, gotCapture string
+			prev := agents
+			t.Cleanup(func() { agents = prev })
+			agents = map[string]agentHook{
+				"cursor": func(_ context.Context, _ io.Reader, _ io.Writer, _ *log.Logger) error {
+					gotEndpoint = os.Getenv("AGENTO11Y_ENDPOINT")
+					gotCapture = os.Getenv("AGENTO11Y_CONTENT_CAPTURE_MODE")
+					return nil
+				},
+			}
+
+			var stdout, stderr bytes.Buffer
+			gotExit := withExit(t, func() {
+				run([]string{"cursor", "hook"}, strings.NewReader(`{}`), &stdout, &stderr)
+			})
+			if gotExit != nil {
+				t.Fatalf("exit code = %d, want no exit", *gotExit)
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty (no local-mode banner on hooks)", stderr.String())
+			}
+			if (startCalls > 0) != tc.wantStart {
+				t.Fatalf("daemon starts = %d, wantStart %v", startCalls, tc.wantStart)
+			}
+			if tc.wantRewrite {
+				if gotEndpoint != "http://127.0.0.1:8765" {
+					t.Fatalf("ENDPOINT = %q, want local receiver", gotEndpoint)
+				}
+				if gotCapture != "full" {
+					t.Fatalf("CONTENT_CAPTURE_MODE = %q, want full", gotCapture)
+				}
+				return
+			}
+			if gotEndpoint != "https://cloud.example.test" {
+				t.Fatalf("ENDPOINT = %q, want cloud", gotEndpoint)
+			}
+			if gotCapture != "metadata_only" {
+				t.Fatalf("CONTENT_CAPTURE_MODE = %q, want metadata_only", gotCapture)
+			}
+		})
+	}
+}
+
 func TestRun_HookErrorIsSwallowedAfterDispatch(t *testing.T) {
 	prev := agents
 	t.Cleanup(func() { agents = prev })

--- a/plugins/agento11y/internal/envconfig/envconfig.go
+++ b/plugins/agento11y/internal/envconfig/envconfig.go
@@ -50,7 +50,7 @@ var AliasSuffixes = []string{
 	"USER_ID_SOURCE",
 	"BIN",
 	"COPILOT_HOOK_SURFACE",
-	"LOCAL",         // default `agento11y <agent>` launches to local mode, as if --local was passed
+	"LOCAL",         // default launches and agento11y hooks to local mode, as if --local was passed
 	"LOCAL_FORWARD", // opt a --local daemon into forwarding to Cloud
 }
 

--- a/plugins/agento11y/internal/local/daemon_unix.go
+++ b/plugins/agento11y/internal/local/daemon_unix.go
@@ -16,6 +16,11 @@ import (
 	"time"
 )
 
+// ReceiverSupported reports whether this platform can run the local
+// capture daemon. Windows returns false so hook dispatch leaves Cloud
+// credentials in place instead of rewriting to a dead loopback URL.
+func ReceiverSupported() bool { return true }
+
 type daemonLock struct {
 	f *os.File
 }

--- a/plugins/agento11y/internal/local/daemon_windows.go
+++ b/plugins/agento11y/internal/local/daemon_windows.go
@@ -15,6 +15,11 @@ import (
 // touches this code path.
 var errLocalUnsupported = errors.New("agento11y local receiver is not supported on Windows")
 
+// ReceiverSupported reports whether this platform can run the local
+// capture daemon. Windows returns false so hook dispatch leaves Cloud
+// credentials in place instead of rewriting to a dead loopback URL.
+func ReceiverSupported() bool { return false }
+
 type daemonLock struct{}
 
 func acquireDaemonLock(dir string) (*daemonLock, error) { return nil, errLocalUnsupported }

--- a/plugins/agento11y/internal/local/env.go
+++ b/plugins/agento11y/internal/local/env.go
@@ -89,3 +89,34 @@ func (e LaunchEnv) Apply(env []string) []string {
 	}
 	return out
 }
+
+// hookOverrideSuffixes are the alias families Apply rewrites. ApplyOS
+// materializes only these so an in-process hook does not os.Setenv the rest
+// of the inherited environment.
+var hookOverrideSuffixes = []string{
+	"ENDPOINT",
+	"OTEL_EXPORTER_OTLP_ENDPOINT",
+	"CONTENT_CAPTURE_MODE",
+	"AUTH_TENANT_ID",
+	"AUTH_TOKEN",
+}
+
+// ApplyOS writes the same overrides Apply produces into the current process
+// environment. Hook dispatch uses this because hooks run in-process and
+// cannot inherit a rewritten child environ the way `agento11y <agent>
+// --local` does.
+func (e LaunchEnv) ApplyOS() {
+	applied := map[string]string{}
+	for _, kv := range e.Apply(os.Environ()) {
+		if k, v, ok := strings.Cut(kv, "="); ok {
+			applied[k] = v
+		}
+	}
+	for _, suffix := range hookOverrideSuffixes {
+		for _, key := range []string{envconfig.PreferredKey(suffix), envconfig.LegacyKey(suffix)} {
+			if v, ok := applied[key]; ok {
+				_ = os.Setenv(key, v)
+			}
+		}
+	}
+}

--- a/plugins/agento11y/internal/local/env.go
+++ b/plugins/agento11y/internal/local/env.go
@@ -105,6 +105,11 @@ var hookOverrideSuffixes = []string{
 // environment. Hook dispatch uses this because hooks run in-process and
 // cannot inherit a rewritten child environ the way `agento11y <agent>
 // --local` does.
+//
+// ApplyOS only Setenv keys present in Apply's result. It does not unset an
+// inherited empty preferred-spelling AUTH_* var when the family was kept via
+// the legacy spelling. LookupEnv trims blanks and falls through, so that
+// case still resolves the real credential.
 func (e LaunchEnv) ApplyOS() {
 	applied := map[string]string{}
 	for _, kv := range e.Apply(os.Environ()) {

--- a/plugins/agento11y/internal/local/env_test.go
+++ b/plugins/agento11y/internal/local/env_test.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -88,6 +89,39 @@ func TestLaunchEnvApply(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestLaunchEnvApplyOS(t *testing.T) {
+	t.Setenv("AGENTO11Y_ENDPOINT", "https://cloud.example")
+	t.Setenv("SIGIL_ENDPOINT", "https://cloud.example")
+	t.Setenv("AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT", "https://otlp.example")
+	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "https://otlp.example")
+	t.Setenv("AGENTO11Y_CONTENT_CAPTURE_MODE", "metadata_only")
+	t.Setenv("SIGIL_CONTENT_CAPTURE_MODE", "metadata_only")
+	t.Setenv("AGENTO11Y_AUTH_TENANT_ID", "")
+	t.Setenv("SIGIL_AUTH_TENANT_ID", "")
+	t.Setenv("AGENTO11Y_AUTH_TOKEN", "")
+	t.Setenv("SIGIL_AUTH_TOKEN", "")
+
+	LaunchEnv{Endpoint: "http://127.0.0.1:4319", OTLPEndpoint: "http://127.0.0.1:4320/otlp"}.ApplyOS()
+
+	want := map[string]string{
+		"AGENTO11Y_ENDPOINT":                    "http://127.0.0.1:4319",
+		"SIGIL_ENDPOINT":                        "http://127.0.0.1:4319",
+		"AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:4320/otlp",
+		"SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT":     "http://127.0.0.1:4320/otlp",
+		"AGENTO11Y_CONTENT_CAPTURE_MODE":        "full",
+		"SIGIL_CONTENT_CAPTURE_MODE":            "full",
+		"AGENTO11Y_AUTH_TENANT_ID":              "local",
+		"SIGIL_AUTH_TENANT_ID":                  "local",
+		"AGENTO11Y_AUTH_TOKEN":                  "local",
+		"SIGIL_AUTH_TOKEN":                      "local",
+	}
+	for k, v := range want {
+		if got := os.Getenv(k); got != v {
+			t.Errorf("%s = %q, want %q", k, got, v)
+		}
 	}
 }
 

--- a/plugins/agento11y/internal/skills/content/setup-coding-agent/SKILL.md
+++ b/plugins/agento11y/internal/skills/content/setup-coding-agent/SKILL.md
@@ -373,7 +373,7 @@ All hosts read the resolved config path. The default is
 | `AGENTO11Y_GUARDS_ENABLED` | Send supported preflight and tool calls for guard evaluation |
 | `AGENTO11Y_GUARDS_TIMEOUT_MS` | Guard evaluation timeout in milliseconds |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | Allow the operation when guard evaluation fails |
-| `AGENTO11Y_LOCAL` | Route `agento11y <agent>` launches to the local daemon |
+| `AGENTO11Y_LOCAL` | Route `agento11y <agent>` launches and agento11y hooks to the local daemon |
 | `AGENTO11Y_LOCAL_FORWARD` | Forward local-mode captures to Grafana Cloud |
 | `AGENTO11Y_AUTO_UPDATE` | A false value opts out of host-plugin refresh |
 | `AGENTO11Y_DEBUG` | A true value writes the debug log |
@@ -444,12 +444,13 @@ it does not open a browser. Cloud forwarding also requires
 `AGENTO11Y_LOCAL_FORWARD` and valid Cloud settings. Manage the daemon with
 `agento11y local start|status|stop|restart`.
 
-Local mode covers launches that go through `agento11y <agent>`, and nothing
-else. A session the host agent starts on its own, such as Cursor or a plain
-`claude`, keeps exporting to the configured endpoint. Never describe local mode
-to the user as a switch that keeps all data on the machine. Doctor prints this
-correction when `AGENTO11Y_LOCAL` is enabled in the environment or config file;
-it cannot see a one-off `--local` flag after the launch.
+Local mode routes `agento11y <agent>` launches and agento11y hooks (Cursor,
+Claude Code, Codex, Copilot, Vibe) to the local viewer. It still captures
+full content in the local store. Cloud forwarding also requires
+`AGENTO11Y_LOCAL_FORWARD`. Never describe local mode as a switch that keeps
+all data on the machine. Doctor prints this correction when
+`AGENTO11Y_LOCAL` is enabled in the environment or config file; it cannot
+see a one-off `--local` flag after the launch.
 
 `--no-local` runs one session against Cloud while `AGENTO11Y_LOCAL=true` stays
 set.

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -108,6 +108,7 @@ Common culprits: `agento11y --version` doesn't work (binary not on `PATH`), a mi
 | `AGENTO11Y_USER_ID` | from `~/.claude.json` | Override the user id. |
 | `AGENTO11Y_AGENT_NAME` | `claude-code` | Override the exported `agent_name`. Subagent turns become `<name>/<subagent type>`, or `<name>/subagent` when Claude Code names no type. Avoid a `/` in the name itself: a slash marks a subagent generation, so every turn of the run is counted as one. Guard rules and dashboards that filter on `claude-code` no longer match the generations this run exports. |
 | `AGENTO11Y_USER_ID_SOURCE` | `email` | Which field to read from `~/.claude.json`: `email` or `accountUuid`. |
+| `AGENTO11Y_LOCAL` | `false` | Send Claude Code captures (launches and installed hooks) to the local viewer at `http://127.0.0.1:8765` instead of Grafana Cloud. Local mode always stores full content. Cloud forwarding also requires `AGENTO11Y_LOCAL_FORWARD`. |
 | `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
 | `AGENTO11Y_AUTO_UPDATE` | `true` | Refresh the `agento11y-claude-code` plugin automatically. Set `false` to pin the installed version. |
 | `AGENTO11Y_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Claude Code `PreToolUse` hook calls the Agent Observability `/api/v1/hooks:evaluate` API and blocks tool calls denied by guard rules. |

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -123,6 +123,7 @@ tail -f ~/.local/state/agento11y/logs/agento11y.log
 | `AGENTO11Y_AUTO_CODING_AGENT_TAGS_NAMES` | all names | Narrows the switch above to a comma-separated subset of `user`, `repo`, `branch` (`all` is also accepted). Does nothing while the switch is off. |
 | `AGENTO11Y_USER_ID` | — | Override the user id. |
 | `AGENTO11Y_AGENT_NAME` | `codex` | Override the exported `agent_name`. Subagent turns become `<name>/subagent`. Avoid a `/` in the name itself: a slash marks a subagent generation, so every turn of the run is counted as one. Guard rules and dashboards that filter on `codex` no longer match the generations this run exports. |
+| `AGENTO11Y_LOCAL` | `false` | Send Codex captures (launches and installed hooks) to the local viewer at `http://127.0.0.1:8765` instead of Grafana Cloud. Local mode always stores full content. Cloud forwarding also requires `AGENTO11Y_LOCAL_FORWARD`. |
 | `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
 | `AGENTO11Y_GUARDS_ENABLED` | `false` | Enable Codex `PreToolUse` guards against Agent Observability rules. |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | Allow the tool call when the guard request fails (set `false` for fail-closed). |

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -169,6 +169,7 @@ Limits:
 | `AGENTO11Y_AUTO_CODING_AGENT_TAGS_NAMES` | all names | Narrows the switch above to a comma-separated subset of `user`, `repo`, `branch` (`all` is also accepted). Does nothing while the switch is off. |
 | `AGENTO11Y_USER_ID` | — | Override the user id. |
 | `AGENTO11Y_AGENT_NAME` | `copilot` | Override the exported `agent_name`. The model-provider fallback stays `copilot`, so a turn whose provider Copilot neither reports nor implies through the model name is still exported as `copilot`. Avoid a `/` in the name: a slash marks a subagent generation, so every turn of the run is counted as one. Guard rules and dashboards that filter on `copilot` no longer match the generations this run exports. |
+| `AGENTO11Y_LOCAL` | `false` | Send Copilot hook captures to the local viewer at `http://127.0.0.1:8765` instead of Grafana Cloud. Local mode always stores full content. Cloud forwarding also requires `AGENTO11Y_LOCAL_FORWARD`. |
 | `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
 | `AGENTO11Y_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Copilot `preToolUse` hook is evaluated against Agent Observability: tool calls denied by guard rules are blocked, and Transform rules redact tool arguments in `copilot-cli`. |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -115,6 +115,7 @@ tail -f ~/.local/state/agento11y/logs/agento11y.log
 | `AGENTO11Y_AUTO_CODING_AGENT_TAGS_NAMES` | all names | Narrows the switch above to a comma-separated subset of `user`, `repo`, `branch` (`all` is also accepted). Does nothing while the switch is off. |
 | `AGENTO11Y_USER_ID` | from Cursor | Override the user id. |
 | `AGENTO11Y_AGENT_NAME` | `cursor` | Override the exported `agent_name`. Avoid a `/` in the name: a slash marks a subagent generation, so every turn of the run is counted as one. Guard rules and dashboards that filter on `cursor` no longer match the generations this run exports. |
+| `AGENTO11Y_LOCAL` | `false` | Send Cursor hook captures to the local viewer at `http://127.0.0.1:8765` instead of Grafana Cloud. Local mode always stores full content. Cloud forwarding also requires `AGENTO11Y_LOCAL_FORWARD`. |
 | `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
 | `AGENTO11Y_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Cursor `preToolUse` hook is evaluated against Agent Observability: tool calls denied by guard rules are blocked, and Transform rules rewrite the tool arguments before execution. |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |

--- a/plugins/vibe/README.md
+++ b/plugins/vibe/README.md
@@ -127,6 +127,7 @@ Subagent turns are not tagged `subagent`. Mistral Vibe only exposes a session-le
 | `AGENTO11Y_AUTO_CODING_AGENT_TAGS_NAMES` | all names | Narrows the switch above to a comma-separated subset of `user`, `repo`, `branch` (`all` is also accepted). Does nothing while the switch is off. |
 | `AGENTO11Y_USER_ID` | — | Override the user id. |
 | `AGENTO11Y_AGENT_NAME` | `mistral-vibe` | Override the exported `agent_name`. Avoid a `/` in the name: a slash marks a subagent generation, so every turn of the run is counted as one. Guard rules and dashboards that filter on `mistral-vibe` no longer match the generations this run exports. |
+| `AGENTO11Y_LOCAL` | `false` | Send Vibe hook captures to the local viewer at `http://127.0.0.1:8765` instead of Grafana Cloud. Local mode always stores full content. Cloud forwarding also requires `AGENTO11Y_LOCAL_FORWARD`. |
 | `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
 | `AGENTO11Y_GUARDS_ENABLED` | `false` | Evaluate every `before_tool` fire against guard policy. Denied calls are blocked; Transform rules rewrite the tool arguments. |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | On timeout, network error, or 5xx, run the tool anyway. Set `false` for strict mode. |


### PR DESCRIPTION
## Summary
- `AGENTO11Y_LOCAL=true` now routes hook-based agents (Cursor, Copilot, Vibe, and a host `claude`/`codex` with agento11y hooks) to the local viewer, not just `agento11y <agent>` launches.
- Hook dispatch applies the same `LaunchEnv` contract in-process (endpoint, OTLP, full capture) and stays silent so Cursor is not spammed. A down daemon still points at loopback so the turn cannot leak to Cloud.
- Doctor and coding-agent docs no longer say Cursor always exports to Cloud.

## Test plan
- [ ] `cd plugins/agento11y && GOWORK=off go test ./internal/entry/ ./internal/local/ ./internal/doctor/`
- [ ] With `AGENTO11Y_LOCAL=true` in `~/.config/agento11y/config.env`, run one Cursor turn and confirm it appears at http://127.0.0.1:8765 as `cursor`
- [ ] Confirm `agento11y doctor` reports that local mode covers launches and hooks
- [ ] With `AGENTO11Y_LOCAL` unset, confirm Cursor hooks still export to Grafana Cloud


Made with [Cursor](https://cursor.com)