### PR TITLE
fix(plugins/agento11y): fix Cursor conversation titles

### DIFF
--- a/plugins/agento11y/internal/agents/cursor/fragment/fragment.go
+++ b/plugins/agento11y/internal/agents/cursor/fragment/fragment.go
@@ -170,6 +170,24 @@ func SaveSession(s Session) error {
 	return fragmentstore.WriteJSON(SessionFilePath(s.ConversationID), s)
 }
 
+// UpdateSession is the canonical session read-modify-write. beforeSubmit can
+// stamp a title before sessionStart writes workspace/user fields (and the
+// reverse), so the load-mutate-save is serialized with WithFileLock. A
+// missing file starts a new Session with ConversationID set.
+func UpdateSession(conversationID string, logger *log.Logger, mutate func(s *Session) bool) error {
+	return fragmentstore.WithFileLock(SessionFilePath(conversationID), func() error {
+		s := LoadSession(conversationID, logger)
+		if s == nil {
+			s = &Session{ConversationID: conversationID}
+		}
+		if !mutate(s) {
+			return nil
+		}
+		s.ConversationID = conversationID
+		return SaveSession(*s)
+	})
+}
+
 // Update is the canonical read-modify-write. The mutator returns true when
 // the fragment should be saved; false skips the write (used by
 // afterAgentThought to avoid rewriting the fragment when ThinkingPresent is

--- a/plugins/agento11y/internal/agents/cursor/fragment/fragment_test.go
+++ b/plugins/agento11y/internal/agents/cursor/fragment/fragment_test.go
@@ -272,6 +272,41 @@ func TestSaveSessionAndLoadSession(t *testing.T) {
 	}
 }
 
+func TestUpdateSession_PreservesExistingFields(t *testing.T) {
+	withTempState(t)
+	logger := newTestLogger()
+
+	if err := SaveSession(Session{
+		ConversationID: "conv",
+		WorkspaceRoots: []string{"/ws"},
+		UserEmail:      "alice@example.com",
+		CursorVersion:  "1.0",
+	}); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+
+	if err := UpdateSession("conv", logger, func(s *Session) bool {
+		s.ConversationTitle = "list go files"
+		return true
+	}); err != nil {
+		t.Fatalf("UpdateSession: %v", err)
+	}
+
+	got := LoadSession("conv", logger)
+	if got == nil {
+		t.Fatal("expected session")
+	}
+	if got.ConversationTitle != "list go files" {
+		t.Errorf("ConversationTitle = %q; want list go files", got.ConversationTitle)
+	}
+	if got.UserEmail != "alice@example.com" {
+		t.Errorf("UserEmail = %q; want alice@example.com", got.UserEmail)
+	}
+	if len(got.WorkspaceRoots) != 1 || got.WorkspaceRoots[0] != "/ws" {
+		t.Errorf("WorkspaceRoots = %v; want [/ws]", got.WorkspaceRoots)
+	}
+}
+
 func TestDelete_Idempotent(t *testing.T) {
 	withTempState(t)
 	logger := newTestLogger()

--- a/plugins/agento11y/internal/agents/cursor/hook/beforesubmit.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/beforesubmit.go
@@ -63,23 +63,27 @@ func BeforeSubmit(p Payload, cfg config.Config, logger *log.Logger) {
 // version of prompt, but only when the title is not already set (first
 // prompt wins). A missing session file is created so a beforeSubmit that
 // races ahead of sessionStart still leaves a title for stop to load.
+// UpdateSession holds the session lock so this write cannot replace a
+// sessionStart that landed between load and save.
 func setConversationTitle(conversationID, prompt string, logger *log.Logger) {
-	sess := fragment.LoadSession(conversationID, logger)
-	if sess == nil {
-		sess = &fragment.Session{ConversationID: conversationID}
-	}
-	if sess.ConversationTitle != "" {
+	title := strings.TrimSpace(prompt)
+	if title == "" {
 		return
 	}
-	title := strings.TrimSpace(prompt)
 	if len(title) > maxTitleLen {
 		title = title[:maxTitleLen]
 		for !utf8.ValidString(title) {
 			title = title[:len(title)-1]
 		}
 	}
-	sess.ConversationTitle = title
-	if err := fragment.SaveSession(*sess); err != nil {
+	err := fragment.UpdateSession(conversationID, logger, func(s *fragment.Session) bool {
+		if s.ConversationTitle != "" {
+			return false
+		}
+		s.ConversationTitle = title
+		return true
+	})
+	if err != nil {
 		logger.Printf("beforeSubmitPrompt: save session title: %v", err)
 	}
 }

--- a/plugins/agento11y/internal/agents/cursor/hook/beforesubmit.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/beforesubmit.go
@@ -16,8 +16,8 @@ const maxTitleLen = 100
 
 // BeforeSubmit captures the user prompt for the upcoming generation. Cursor
 // doesn't always assign a generation_id at prompt-submit time; without one we
-// cannot key the fragment, so skip silently — the turn will still be exported,
-// just without the user prompt in `input`.
+// cannot key the fragment, so skip the fragment write — the turn will still
+// be exported, just without the user prompt in `input`.
 //
 // Prompt bytes are persisted only when the active content-capture mode would
 // export them (full / no_tool_content). In metadata_only the mapper drops the
@@ -25,12 +25,19 @@ const maxTitleLen = 100
 // content into the fragment file (mode 0600 — but avoidable disk-residency is
 // avoidable disk-residency).
 //
-// On the first prompt of a conversation the handler also stamps the session's
-// ConversationTitle so the mapper can surface a human-readable name instead of
-// the raw conversation UUID.
+// The conversation title is session-scoped, so it is stamped even when
+// generation_id is missing: first prompt wins, and a later sessionStart must
+// not wipe it.
 func BeforeSubmit(p Payload, cfg config.Config, logger *log.Logger) {
-	if p.ConversationID == "" || p.GenerationID == "" {
-		logger.Print("beforeSubmitPrompt: no generation_id yet — skipping")
+	if p.ConversationID == "" {
+		logger.Print("beforeSubmitPrompt: missing conversation_id — skipping")
+		return
+	}
+	if p.Prompt != "" {
+		setConversationTitle(p.ConversationID, p.Prompt, logger)
+	}
+	if p.GenerationID == "" {
+		logger.Print("beforeSubmitPrompt: no generation_id yet — skipping fragment")
 		return
 	}
 	ts := p.ResolvedTimestamp()
@@ -49,19 +56,19 @@ func BeforeSubmit(p Payload, cfg config.Config, logger *log.Logger) {
 		return
 	}
 
-	if p.Prompt != "" {
-		setConversationTitle(p.ConversationID, p.Prompt, logger)
-	}
-
 	logger.Printf("beforeSubmitPrompt: captured gen=%s promptLen=%d", p.GenerationID, len(p.Prompt))
 }
 
 // setConversationTitle sets the session's ConversationTitle to a truncated
 // version of prompt, but only when the title is not already set (first
-// prompt wins).
+// prompt wins). A missing session file is created so a beforeSubmit that
+// races ahead of sessionStart still leaves a title for stop to load.
 func setConversationTitle(conversationID, prompt string, logger *log.Logger) {
 	sess := fragment.LoadSession(conversationID, logger)
-	if sess == nil || sess.ConversationTitle != "" {
+	if sess == nil {
+		sess = &fragment.Session{ConversationID: conversationID}
+	}
+	if sess.ConversationTitle != "" {
 		return
 	}
 	title := strings.TrimSpace(prompt)

--- a/plugins/agento11y/internal/agents/cursor/hook/beforesubmit_test.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/beforesubmit_test.go
@@ -111,3 +111,37 @@ func TestBeforeSubmit_FirstPromptWinsTitle(t *testing.T) {
 		t.Errorf("ConversationTitle = %q; want first prompt", sess.ConversationTitle)
 	}
 }
+
+func TestBeforeSubmit_TitleWriteKeepsSessionMetadata(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	logger := log.New(&bytes.Buffer{}, "", 0)
+	cfg := config.Config{ContentCapture: agento11y.ContentCaptureModeFull}
+
+	SessionStart(Payload{
+		HookEventName:  "sessionStart",
+		ConversationID: "conv",
+		WorkspaceRoots: []string{"/repo"},
+		UserEmail:      "dev@example.com",
+		CursorVersion:  "2.0",
+		Timestamp:      "2026-04-28T12:00:00Z",
+	}, logger)
+	BeforeSubmit(Payload{
+		HookEventName:  "beforeSubmitPrompt",
+		ConversationID: "conv",
+		Prompt:         "list go files",
+	}, cfg, logger)
+
+	sess := fragment.LoadSession("conv", logger)
+	if sess == nil {
+		t.Fatal("expected a session")
+	}
+	if sess.ConversationTitle != "list go files" {
+		t.Errorf("ConversationTitle = %q; want list go files", sess.ConversationTitle)
+	}
+	if sess.UserEmail != "dev@example.com" {
+		t.Errorf("UserEmail = %q; want sessionStart metadata kept", sess.UserEmail)
+	}
+	if len(sess.WorkspaceRoots) != 1 || sess.WorkspaceRoots[0] != "/repo" {
+		t.Errorf("WorkspaceRoots = %v; want [/repo]", sess.WorkspaceRoots)
+	}
+}

--- a/plugins/agento11y/internal/agents/cursor/hook/beforesubmit_test.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/beforesubmit_test.go
@@ -54,7 +54,7 @@ func TestBeforeSubmit_GatesUserPromptByMode(t *testing.T) {
 	}
 }
 
-func TestBeforeSubmit_MissingIDsSilent(t *testing.T) {
+func TestBeforeSubmit_MissingConversationIDSilent(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	var buf bytes.Buffer
 	logger := log.New(&buf, "", 0)
@@ -62,5 +62,52 @@ func TestBeforeSubmit_MissingIDsSilent(t *testing.T) {
 	BeforeSubmit(Payload{HookEventName: "beforeSubmitPrompt"}, cfg, logger)
 	if !bytes.Contains(buf.Bytes(), []byte("skipping")) {
 		t.Errorf("expected 'skipping' log; got %q", buf.String())
+	}
+}
+
+func TestBeforeSubmit_StampsTitleWithoutGenerationID(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	logger := log.New(&bytes.Buffer{}, "", 0)
+	cfg := config.Config{ContentCapture: agento11y.ContentCaptureModeFull}
+
+	BeforeSubmit(Payload{
+		HookEventName:  "beforeSubmitPrompt",
+		ConversationID: "conv",
+		Prompt:         "list go files",
+	}, cfg, logger)
+
+	sess := fragment.LoadSession("conv", logger)
+	if sess == nil {
+		t.Fatal("expected a session so the title survives until stop")
+	}
+	if sess.ConversationTitle != "list go files" {
+		t.Errorf("ConversationTitle = %q; want list go files", sess.ConversationTitle)
+	}
+}
+
+func TestBeforeSubmit_FirstPromptWinsTitle(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	logger := log.New(&bytes.Buffer{}, "", 0)
+	cfg := config.Config{ContentCapture: agento11y.ContentCaptureModeFull}
+
+	BeforeSubmit(Payload{
+		HookEventName:  "beforeSubmitPrompt",
+		ConversationID: "conv",
+		GenerationID:   "gen-1",
+		Prompt:         "first prompt",
+	}, cfg, logger)
+	BeforeSubmit(Payload{
+		HookEventName:  "beforeSubmitPrompt",
+		ConversationID: "conv",
+		GenerationID:   "gen-2",
+		Prompt:         "second prompt",
+	}, cfg, logger)
+
+	sess := fragment.LoadSession("conv", logger)
+	if sess == nil {
+		t.Fatal("expected a session")
+	}
+	if sess.ConversationTitle != "first prompt" {
+		t.Errorf("ConversationTitle = %q; want first prompt", sess.ConversationTitle)
 	}
 }

--- a/plugins/agento11y/internal/agents/cursor/hook/sessionstart.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/sessionstart.go
@@ -13,24 +13,20 @@ func SessionStart(p Payload, logger *log.Logger) {
 		logger.Print("sessionStart: missing conversation_id")
 		return
 	}
-	s := fragment.Session{
-		ConversationID:    p.ConversationID,
-		WorkspaceRoots:    p.WorkspaceRoots,
-		UserEmail:         p.UserEmail,
-		CursorVersion:     p.CursorVersion,
-		IsBackgroundAgent: p.IsBackgroundAgent,
-		StartedAt:         p.ResolvedTimestamp(),
-	}
-	// beforeSubmit can race ahead of sessionStart and stamp the first-prompt
-	// title onto a session file. Keep that title: this payload never carries
-	// one, and overwriting would send the conversation out untitled.
-	if existing := fragment.LoadSession(p.ConversationID, logger); existing != nil {
-		s.ConversationTitle = existing.ConversationTitle
-		if s.StartedAt == "" {
-			s.StartedAt = existing.StartedAt
+	// UpdateSession holds the session lock so a racing beforeSubmit title
+	// write cannot replace this file with a title-only session (and so we
+	// keep a title that beforeSubmit already stamped).
+	err := fragment.UpdateSession(p.ConversationID, logger, func(s *fragment.Session) bool {
+		s.WorkspaceRoots = p.WorkspaceRoots
+		s.UserEmail = p.UserEmail
+		s.CursorVersion = p.CursorVersion
+		s.IsBackgroundAgent = p.IsBackgroundAgent
+		if ts := p.ResolvedTimestamp(); ts != "" {
+			s.StartedAt = ts
 		}
-	}
-	if err := fragment.SaveSession(s); err != nil {
+		return true
+	})
+	if err != nil {
 		logger.Printf("sessionStart: save: %v", err)
 		return
 	}

--- a/plugins/agento11y/internal/agents/cursor/hook/sessionstart.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/sessionstart.go
@@ -21,6 +21,15 @@ func SessionStart(p Payload, logger *log.Logger) {
 		IsBackgroundAgent: p.IsBackgroundAgent,
 		StartedAt:         p.ResolvedTimestamp(),
 	}
+	// beforeSubmit can race ahead of sessionStart and stamp the first-prompt
+	// title onto a session file. Keep that title: this payload never carries
+	// one, and overwriting would send the conversation out untitled.
+	if existing := fragment.LoadSession(p.ConversationID, logger); existing != nil {
+		s.ConversationTitle = existing.ConversationTitle
+		if s.StartedAt == "" {
+			s.StartedAt = existing.StartedAt
+		}
+	}
 	if err := fragment.SaveSession(s); err != nil {
 		logger.Printf("sessionStart: save: %v", err)
 		return

--- a/plugins/agento11y/internal/agents/cursor/hook/sessionstart_test.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/sessionstart_test.go
@@ -1,0 +1,45 @@
+package hook
+
+import (
+	"bytes"
+	"log"
+	"testing"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/fragment"
+)
+
+func TestSessionStart_PreservesConversationTitle(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	logger := log.New(&bytes.Buffer{}, "", 0)
+
+	if err := fragment.SaveSession(fragment.Session{
+		ConversationID:    "conv",
+		ConversationTitle: "list go files",
+		StartedAt:         "2026-04-28T12:00:00Z",
+	}); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+
+	SessionStart(Payload{
+		HookEventName:  "sessionStart",
+		ConversationID: "conv",
+		WorkspaceRoots: []string{"/repo"},
+		UserEmail:      "dev@example.com",
+		CursorVersion:  "2.0",
+		Timestamp:      "2026-04-28T12:01:00Z",
+	}, logger)
+
+	got := fragment.LoadSession("conv", logger)
+	if got == nil {
+		t.Fatal("expected session")
+	}
+	if got.ConversationTitle != "list go files" {
+		t.Errorf("ConversationTitle = %q; want list go files", got.ConversationTitle)
+	}
+	if got.UserEmail != "dev@example.com" {
+		t.Errorf("UserEmail = %q; want the sessionStart payload", got.UserEmail)
+	}
+	if len(got.WorkspaceRoots) != 1 || got.WorkspaceRoots[0] != "/repo" {
+		t.Errorf("WorkspaceRoots = %v; want [/repo]", got.WorkspaceRoots)
+	}
+}

--- a/plugins/agento11y/internal/agents/cursor/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/cursor/mapper/mapper.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/grafana/agento11y/go/agento11y"
 
@@ -24,6 +25,10 @@ import (
 )
 
 var errCursorStop = errors.New("cursor_stop_error")
+
+// maxTitleLen caps the conversation title derived from the first user prompt,
+// matching claude-code so a long first message does not become the list label.
+const maxTitleLen = 100
 
 // AgentName is the default value reported as `agent_name` on every emitted
 // generation. AGENTO11Y_AGENT_NAME overrides it per run through
@@ -116,14 +121,14 @@ func MapFragment(in Inputs) Mapped {
 	if in.Session != nil && len(in.Session.WorkspaceRoots) > 0 {
 		workspaceRoot = in.Session.WorkspaceRoots[0]
 	}
-	var cursorVersion, userEmail, conversationTitle string
+	var cursorVersion, userEmail string
 	var isBackgroundAgent bool
 	if in.Session != nil {
 		cursorVersion = in.Session.CursorVersion
 		userEmail = in.Session.UserEmail
 		isBackgroundAgent = in.Session.IsBackgroundAgent
-		conversationTitle = red.Title(in.Session.ConversationTitle)
 	}
+	title := conversationTitle(in.Session, frag, red)
 
 	tagMap := tags.Build(tags.BuiltinInputs{
 		WorkspaceRoot:     workspaceRoot,
@@ -145,7 +150,7 @@ func MapFragment(in Inputs) Mapped {
 	start := agento11y.GenerationStart{
 		ID:                frag.GenerationID,
 		ConversationID:    frag.ConversationID,
-		ConversationTitle: conversationTitle,
+		ConversationTitle: title,
 		UserID:            uid,
 		AgentName:         in.agent(),
 		AgentVersion:      cursorVersion,
@@ -165,7 +170,7 @@ func MapFragment(in Inputs) Mapped {
 	gen := agento11y.Generation{
 		ID:                frag.GenerationID,
 		ConversationID:    frag.ConversationID,
-		ConversationTitle: conversationTitle,
+		ConversationTitle: title,
 		UserID:            uid,
 		AgentName:         in.agent(),
 		AgentVersion:      cursorVersion,
@@ -194,6 +199,43 @@ func MapFragment(in Inputs) Mapped {
 		mapped.CallError = extractCallError(in.Stop, red)
 	}
 	return mapped
+}
+
+// conversationTitle is the human-readable list label for this turn. The
+// session's first-prompt stamp wins so later turns keep the same name. When
+// that stamp is missing (sessionStart never ran, or beforeSubmit skipped
+// because Cursor had no generation_id yet), the fragment's user prompt is
+// the same string. With neither, the conversation id is still a stable
+// label instead of an empty title the local viewer replaces with a UUID.
+func conversationTitle(session *fragment.Session, frag *fragment.Fragment, red *redact.Redactor) string {
+	raw := ""
+	if session != nil {
+		raw = session.ConversationTitle
+	}
+	if strings.TrimSpace(raw) == "" && frag != nil {
+		raw = frag.UserPrompt
+	}
+	fallback := ""
+	if frag != nil {
+		fallback = frag.ConversationID
+	}
+	t := strings.TrimSpace(raw)
+	if t == "" {
+		return fallback
+	}
+	if red != nil {
+		t = red.Title(t)
+	}
+	if t == "" {
+		return fallback
+	}
+	if len(t) > maxTitleLen {
+		t = t[:maxTitleLen]
+		for !utf8.ValidString(t) {
+			t = t[:len(t)-1]
+		}
+	}
+	return t
 }
 
 // resolveStopStatus normalizes Cursor's stop.status to the subset agento11y uses.

--- a/plugins/agento11y/internal/agents/cursor/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/cursor/mapper/mapper_test.go
@@ -163,10 +163,15 @@ func TestMapFragment_ContentCaptureModes(t *testing.T) {
 					t.Errorf("mode %s leaks raw secret %q: %s", tc.mode, secret, body)
 				}
 			}
-			// The prompt carries the tier-1 token, so the marker is visible
-			// in exactly the modes that keep the prompt.
-			if marked := bytes.Contains(body, []byte("[REDACTED:")); marked != tc.wantUserPrompt {
-				t.Errorf("redaction marker present = %v; want %v: %s", marked, tc.wantUserPrompt, body)
+			// Title is derived from the prompt and is redacted in every
+			// mode; the SDK strips it later under metadata_only. The
+			// prompt itself only carries the marker in modes that keep it.
+			wantTitle := "hello [REDACTED:grafana-cloud-token]"
+			if got.Generation.ConversationTitle != wantTitle {
+				t.Errorf("ConversationTitle = %q; want %q", got.Generation.ConversationTitle, wantTitle)
+			}
+			if !bytes.Contains(body, []byte("[REDACTED:")) {
+				t.Errorf("expected redaction marker on title: %s", body)
 			}
 		})
 	}
@@ -540,17 +545,48 @@ func TestMapFragment_ConversationTitleFromSession(t *testing.T) {
 	}
 }
 
-func TestMapFragment_ConversationTitleEmptyWithoutSession(t *testing.T) {
+func TestMapFragment_ConversationTitleFallsBackToUserPrompt(t *testing.T) {
 	got := MapFragment(Inputs{
 		Fragment:       basicFragment(t),
 		ContentCapture: agento11y.ContentCaptureModeMetadataOnly,
 		Now:            fixedTime,
 	})
-	if got.Start.ConversationTitle != "" {
-		t.Errorf("Start.ConversationTitle = %q; want empty", got.Start.ConversationTitle)
+	if got.Start.ConversationTitle != "hello" {
+		t.Errorf("Start.ConversationTitle = %q; want hello from UserPrompt", got.Start.ConversationTitle)
 	}
-	if got.Generation.ConversationTitle != "" {
-		t.Errorf("Generation.ConversationTitle = %q; want empty", got.Generation.ConversationTitle)
+	if got.Generation.ConversationTitle != "hello" {
+		t.Errorf("Generation.ConversationTitle = %q; want hello from UserPrompt", got.Generation.ConversationTitle)
+	}
+}
+
+func TestMapFragment_ConversationTitleFallsBackToConversationID(t *testing.T) {
+	frag := basicFragment(t)
+	frag.UserPrompt = ""
+	got := MapFragment(Inputs{
+		Fragment:       frag,
+		ContentCapture: agento11y.ContentCaptureModeMetadataOnly,
+		Now:            fixedTime,
+	})
+	if got.Start.ConversationTitle != "conv-1" {
+		t.Errorf("Start.ConversationTitle = %q; want conv-1", got.Start.ConversationTitle)
+	}
+	if got.Generation.ConversationTitle != "conv-1" {
+		t.Errorf("Generation.ConversationTitle = %q; want conv-1", got.Generation.ConversationTitle)
+	}
+}
+
+func TestMapFragment_ConversationTitlePrefersSessionOverPrompt(t *testing.T) {
+	got := MapFragment(Inputs{
+		Fragment: basicFragment(t),
+		Session: &fragment.Session{
+			ConversationID:    "conv-1",
+			ConversationTitle: "session title",
+		},
+		ContentCapture: agento11y.ContentCaptureModeMetadataOnly,
+		Now:            fixedTime,
+	})
+	if got.Generation.ConversationTitle != "session title" {
+		t.Errorf("ConversationTitle = %q; want session title", got.Generation.ConversationTitle)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix Cursor conversations exporting untitled (or as a UUID) when `beforeSubmit` has no `generation_id` yet.
- Stamp the title from the first prompt, keep it if `sessionStart` races afterward, and lock those writes so a title-only save cannot wipe workspace/user metadata.
- Fall back to the user prompt or conversation id in the mapper, with the same 100-char cap and title redaction as Claude Code.

## Test plan
- [ ] `cd plugins/agento11y && go test ./internal/agents/cursor/hook/ ./internal/agents/cursor/fragment/ ./internal/agents/cursor/mapper/`
- [ ] Start a new Cursor conversation, submit a prompt, and confirm the local viewer / export shows that prompt as the conversation title (not a UUID)
- [ ] Submit a second prompt in the same conversation and confirm the title stays the first prompt
- [ ] Confirm a later `sessionStart` (restart / resume) does not wipe the title