### PR TITLE
feat(plugins/agento11y): require JSON media types for local writes

### DIFF
--- a/plugins/agento11y/internal/local/server.go
+++ b/plugins/agento11y/internal/local/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"log"
+	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"time"
 
 	"github.com/grafana/agento11y/go/agento11y"
+	"github.com/grafana/agento11y/go/proto/agento11y/wire"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/dotenv"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
@@ -25,6 +27,9 @@ const (
 	maxGenerationBodyBytes = 64 * 1024 * 1024 // 64 MiB
 	maxOTLPBodyBytes       = 16 * 1024 * 1024 // 16 MiB
 	maxHookBodyBytes       = 4 * 1024 * 1024  // 4 MiB
+
+	otlpTracesPath  = "/otlp/v1/traces"
+	otlpMetricsPath = "/otlp/v1/metrics"
 )
 
 // Server is the in-process HTTP handler that records generations from
@@ -147,8 +152,8 @@ func (s *Server) routes() *http.ServeMux {
 	// handler splits the action off it.
 	mux.HandleFunc("POST /api/v1/history/runs/{runAction}", s.handleHistoryRunCancel)
 	mux.HandleFunc("POST /api/v1/generations:export", s.handleGenerations)
-	mux.HandleFunc("POST /otlp/v1/traces", s.handleOTLP)
-	mux.HandleFunc("POST /otlp/v1/metrics", s.handleOTLP)
+	mux.HandleFunc("POST "+otlpTracesPath, s.handleOTLP)
+	mux.HandleFunc("POST "+otlpMetricsPath, s.handleOTLP)
 	// Cloud-style hook endpoint with no run prefix. The agento11y SDK strips
 	// the path from API.Endpoint before appending /api/v1/hooks:evaluate,
 	// so we must accept the bare path too — otherwise local hook
@@ -157,8 +162,35 @@ func (s *Server) routes() *http.ServeMux {
 	return mux
 }
 
+// mediaTypeAccepted permits only types that a browser cannot send cross-site
+// without a preflight. The OTLP routes also accept binary protobuf.
+func mediaTypeAccepted(path, header string) bool {
+	mediaType, _, err := mime.ParseMediaType(header)
+	if err != nil {
+		return false
+	}
+
+	switch mediaType {
+	case wire.ContentTypeJSON:
+		return true
+	case wire.ContentTypeProto:
+		return path == otlpTracesPath || path == otlpMetricsPath
+	default:
+		return false
+	}
+}
+
 // ServeHTTP routes incoming requests to the appropriate handler.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodPost || r.Method == http.MethodPut {
+		contentType := r.Header.Get("Content-Type")
+		if !mediaTypeAccepted(r.URL.Path, contentType) {
+			s.logger.Printf("local: refused %s %q: Content-Type %q", r.Method, r.URL.Path, contentType)
+			http.Error(w, "unsupported media type", http.StatusUnsupportedMediaType)
+			return
+		}
+	}
+
 	s.mux.ServeHTTP(w, r)
 }
 

--- a/plugins/agento11y/internal/local/server_test.go
+++ b/plugins/agento11y/internal/local/server_test.go
@@ -285,15 +285,18 @@ func TestServer_HookEvaluate_InvalidJSONReturns400(t *testing.T) {
 // The richer per-endpoint behaviour lives in the generations / OTLP /
 // hook tests above.
 func TestServer_Routing(t *testing.T) {
-	s, _ := newTestServer(t)
+	s, dir := newTestServer(t)
 	cases := []struct {
-		name            string
-		method          string
-		path            string
-		body            string
-		want            int
-		wantContentType string // prefix-matched; "" skips the check
-		wantBodyHas     string // substring check; "" skips
+		name                string
+		method              string
+		path                string
+		contentType         string
+		body                string
+		want                int
+		wantContentType     string // prefix-matched; "" skips the check
+		wantBodyHas         string // substring check; "" skips
+		wantBodyNotHas      string // substring check; "" skips
+		wantNoConversations bool
 	}{
 		{name: "root serves viewer HTML", method: http.MethodGet, path: "/", want: http.StatusOK, wantContentType: "text/html", wantBodyHas: `<script type="text/babel" src="/assets/app.jsx">`},
 		{name: "conversation path serves viewer HTML", method: http.MethodGet, path: "/conversations/conv-123", want: http.StatusOK, wantContentType: "text/html", wantBodyHas: `<script type="text/babel" src="/assets/app.jsx">`},
@@ -302,14 +305,24 @@ func TestServer_Routing(t *testing.T) {
 		{name: "CSS asset", method: http.MethodGet, path: "/assets/app.css", want: http.StatusOK, wantContentType: "text/css", wantBodyHas: ":root"},
 		{name: "JSX asset", method: http.MethodGet, path: "/assets/app.jsx", want: http.StatusOK, wantContentType: "text/babel", wantBodyHas: "function App()"},
 		{name: "healthz serves JSON", method: http.MethodGet, path: "/healthz", want: http.StatusOK, wantContentType: "application/json", wantBodyHas: `"status":"ok"`},
-		{name: "unknown route", method: http.MethodPost, path: "/api/v1/unknown", body: "{}", want: http.StatusNotFound},
-		{name: "wrong method on generations export", method: http.MethodPut, path: "/api/v1/generations:export", body: "{}", want: http.StatusMethodNotAllowed},
-		{name: "hook evaluate serves JSON", method: http.MethodPost, path: "/api/v1/hooks:evaluate", body: `{"phase":"postflight"}`, want: http.StatusOK, wantContentType: "application/json", wantBodyHas: `"action":"allow"`},
+		{name: "unknown route", method: http.MethodPost, path: "/api/v1/unknown", contentType: wire.ContentTypeJSON, body: "{}", want: http.StatusNotFound},
+		{name: "wrong method on generations export", method: http.MethodPut, path: "/api/v1/generations:export", contentType: wire.ContentTypeJSON, body: "{}", want: http.StatusMethodNotAllowed},
+		{name: "hook evaluate serves JSON", method: http.MethodPost, path: "/api/v1/hooks:evaluate", contentType: wire.ContentTypeJSON, body: `{"phase":"postflight"}`, want: http.StatusOK, wantContentType: "application/json", wantBodyHas: `"action":"allow"`},
 		{name: "wrong method on hook evaluate", method: http.MethodGet, path: "/api/v1/hooks:evaluate", want: http.StatusMethodNotAllowed},
+		{name: "form type refused", method: http.MethodPost, path: "/api/v1/generations:export", contentType: "application/x-www-form-urlencoded", body: "generations=[]", want: http.StatusUnsupportedMediaType, wantNoConversations: true},
+		{name: "text type refused", method: http.MethodPost, path: "/api/v1/hooks:evaluate", contentType: "text/plain", body: `{"phase":"postflight"}`, want: http.StatusUnsupportedMediaType, wantBodyNotHas: `"action"`},
+		{name: "absent type refused", method: http.MethodPost, path: "/api/v1/history/runs/r1:cancel", want: http.StatusUnsupportedMediaType},
+		{name: "charset parameter accepted", method: http.MethodPost, path: "/api/v1/hooks:evaluate", contentType: "application/json; charset=utf-8", body: `{"phase":"postflight"}`, want: http.StatusOK, wantContentType: "application/json", wantBodyHas: `"action":"allow"`},
+		{name: "protobuf accepted on OTLP", method: http.MethodPost, path: otlpTracesPath, contentType: wire.ContentTypeProto, body: "protobuf", want: http.StatusOK},
+		{name: "protobuf refused outside OTLP", method: http.MethodPost, path: "/api/v1/generations:export", contentType: wire.ContentTypeProto, body: "protobuf", want: http.StatusUnsupportedMediaType},
+		{name: "GET is not gated", method: http.MethodGet, path: "/api/v1/conversations", want: http.StatusOK, wantContentType: "application/json", wantBodyHas: `"conversations":[]`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequest(tc.method, tc.path, strings.NewReader(tc.body))
+			if tc.contentType != "" {
+				req.Header.Set("Content-Type", tc.contentType)
+			}
 			rr := httptest.NewRecorder()
 			s.ServeHTTP(rr, req)
 			if rr.Code != tc.want {
@@ -323,6 +336,44 @@ func TestServer_Routing(t *testing.T) {
 			if tc.wantBodyHas != "" && !strings.Contains(rr.Body.String(), tc.wantBodyHas) {
 				t.Fatalf("body missing %q\n--- body ---\n%s", tc.wantBodyHas, rr.Body.String())
 			}
+			if tc.wantBodyNotHas != "" && strings.Contains(rr.Body.String(), tc.wantBodyNotHas) {
+				t.Fatalf("body contains %q\n--- body ---\n%s", tc.wantBodyNotHas, rr.Body.String())
+			}
+			if tc.wantNoConversations {
+				entries, err := os.ReadDir(filepath.Join(dir, ConversationsDir))
+				require.NoError(t, err)
+				assert.Empty(t, entries)
+			}
+		})
+	}
+}
+
+func TestServer_MediaTypeRefusalIsLogged(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		path    string
+		wantLog string
+	}{
+		{
+			name:    "request details",
+			path:    "/api/v1/history:import",
+			wantLog: "local: refused POST \"/api/v1/history:import\": Content-Type \"text/plain\"\n",
+		},
+		{
+			name:    "escaped control character",
+			path:    "/x%0aforged",
+			wantLog: "local: refused POST \"/x\\nforged\": Content-Type \"text/plain\"\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := newTestServer(t)
+			var logs strings.Builder
+			s.logger.SetOutput(&logs)
+
+			resp := post(t, s, tc.path, "text/plain", "{}")
+			resp.Body.Close()
+			require.Equal(t, http.StatusUnsupportedMediaType, resp.StatusCode)
+			assert.Equal(t, tc.wantLog, logs.String())
 		})
 	}
 }
@@ -688,6 +739,7 @@ func TestServer_APITokenMetrics(t *testing.T) {
 
 	t.Run("wrong method rejected", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/metrics/tokens", strings.NewReader("{}"))
+		req.Header.Set("Content-Type", wire.ContentTypeJSON)
 		rr := httptest.NewRecorder()
 		srv.ServeHTTP(rr, req)
 		assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)

--- a/plugins/agento11y/internal/local/web/app.jsx
+++ b/plugins/agento11y/internal/local/web/app.jsx
@@ -7063,7 +7063,11 @@ function useHistoryImport(liveRun) {
         if (!run || !run.run_id) return Promise.resolve();
         return fetch(
             `/api/v1/history/runs/${encodeURIComponent(run.run_id)}:cancel`,
-            { method: "POST" },
+            {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: "{}",
+            },
         ).catch(() => {});
     }, [run]);
 


### PR DESCRIPTION
Require `application/json` for `POST` and `PUT` requests to the local server. OpenTelemetry Protocol (OTLP) endpoints also accept `application/x-protobuf`.