### PR TITLE
feat(plugins/agento11y): show commit hash for dev versions

### DIFF
--- a/plugins/agento11y/internal/buildversion/version.go
+++ b/plugins/agento11y/internal/buildversion/version.go
@@ -1,0 +1,95 @@
+// Package buildversion resolves the version reported by the agento11y binary.
+package buildversion
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+const (
+	developmentVersion  = "dev"
+	shortRevisionLength = 7
+)
+
+// Resolve keeps a release version supplied through ldflags. For unstamped
+// builds, it reads the module version or Git revision that Go records in the
+// binary.
+func Resolve(stamped string) string {
+	if stamped != developmentVersion {
+		return stamped
+	}
+
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return stamped
+	}
+	return fromBuildInfo(stamped, info)
+}
+
+func fromBuildInfo(stamped string, info *debug.BuildInfo) string {
+	if stamped != developmentVersion {
+		return stamped
+	}
+
+	if moduleVersion := info.Main.Version; moduleVersion != "" && moduleVersion != "(devel)" {
+		if revision := pseudoVersionRevision(moduleVersion); revision != "" {
+			return formatDevelopmentVersion(revision, false)
+		}
+		return moduleVersion
+	}
+
+	var revision string
+	modified := false
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			revision = setting.Value
+		case "vcs.modified":
+			modified = setting.Value == "true"
+		}
+	}
+	if revision == "" {
+		return stamped
+	}
+	return formatDevelopmentVersion(revision, modified)
+}
+
+func formatDevelopmentVersion(revision string, modified bool) string {
+	revision = revision[:min(len(revision), shortRevisionLength)]
+	version := developmentVersion + "-" + revision
+	if modified {
+		version += "-dirty"
+	}
+	return version
+}
+
+// pseudoVersionRevision extracts the revision from a Go pseudo-version. A
+// pseudo-version ends in a 14-digit UTC timestamp and a 12-character revision.
+func pseudoVersionRevision(version string) string {
+	version = strings.TrimSuffix(version, "+incompatible")
+	separator := strings.LastIndexByte(version, '-')
+	if separator < 0 {
+		return ""
+	}
+
+	revision := version[separator+1:]
+	if len(revision) != 12 || strings.Trim(revision, "0123456789abcdef") != "" {
+		return ""
+	}
+
+	prefix := version[:separator]
+	if len(prefix) < 14 {
+		return ""
+	}
+	timestamp := prefix[len(prefix)-14:]
+	if strings.Trim(timestamp, "0123456789") != "" {
+		return ""
+	}
+	if timestampStart := len(prefix) - len(timestamp); timestampStart > 0 {
+		separator := prefix[timestampStart-1]
+		if separator != '-' && separator != '.' {
+			return ""
+		}
+	}
+	return revision
+}

--- a/plugins/agento11y/internal/buildversion/version_test.go
+++ b/plugins/agento11y/internal/buildversion/version_test.go
@@ -1,0 +1,109 @@
+package buildversion
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestFromBuildInfo(t *testing.T) {
+	tests := []struct {
+		name    string
+		stamped string
+		info    debug.BuildInfo
+		want    string
+	}{
+		{
+			name:    "release stamp wins",
+			stamped: "v0.30.0",
+			info: debug.BuildInfo{
+				Main:     debug.Module{Version: "v0.29.0"},
+				Settings: []debug.BuildSetting{{Key: "vcs.revision", Value: "0123456789abcdef"}},
+			},
+			want: "v0.30.0",
+		},
+		{
+			name:    "tagged module",
+			stamped: "dev",
+			info:    debug.BuildInfo{Main: debug.Module{Version: "v0.29.0"}},
+			want:    "v0.29.0",
+		},
+		{
+			name:    "module prerelease",
+			stamped: "dev",
+			info:    debug.BuildInfo{Main: debug.Module{Version: "v0.30.0-rc.1"}},
+			want:    "v0.30.0-rc.1",
+		},
+		{
+			name:    "module pseudo-version",
+			stamped: "dev",
+			info:    debug.BuildInfo{Main: debug.Module{Version: "v0.30.1-0.20260818160951-60b2ab8650b5"}},
+			want:    "dev-60b2ab8",
+		},
+		{
+			name:    "module pseudo-version with incompatible suffix",
+			stamped: "dev",
+			info:    debug.BuildInfo{Main: debug.Module{Version: "v2.0.1-0.20260818160951-60b2ab8650b5+incompatible"}},
+			want:    "dev-60b2ab8",
+		},
+		{
+			name:    "local checkout",
+			stamped: "dev",
+			info: debug.BuildInfo{
+				Main:     debug.Module{Version: "(devel)"},
+				Settings: []debug.BuildSetting{{Key: "vcs.revision", Value: "60b2ab8650b5b3ca35884e309ed201ee039d5b00"}},
+			},
+			want: "dev-60b2ab8",
+		},
+		{
+			name:    "modified local checkout",
+			stamped: "dev",
+			info: debug.BuildInfo{
+				Main: debug.Module{Version: "(devel)"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.modified", Value: "true"},
+					{Key: "vcs.revision", Value: "60b2ab8650b5b3ca35884e309ed201ee039d5b00"},
+				},
+			},
+			want: "dev-60b2ab8-dirty",
+		},
+		{
+			name:    "short revision",
+			stamped: "dev",
+			info: debug.BuildInfo{
+				Main:     debug.Module{Version: "(devel)"},
+				Settings: []debug.BuildSetting{{Key: "vcs.revision", Value: "60b2"}},
+			},
+			want: "dev-60b2",
+		},
+		{
+			name:    "no build metadata",
+			stamped: "dev",
+			info:    debug.BuildInfo{Main: debug.Module{Version: "(devel)"}},
+			want:    "dev",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fromBuildInfo(tc.stamped, &tc.info); got != tc.want {
+				t.Fatalf("fromBuildInfo() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPseudoVersionRevisionRejectsNonPseudoVersions(t *testing.T) {
+	for _, version := range []string{
+		"v0.30.0",
+		"v0.30.0-rc.1",
+		"v0.30.0-20260818160951-not-a-commit",
+		"v0.30.0-not-a-timestamp-60b2ab8650b5",
+		"v0.30.0-x20260818160951-60b2ab8650b5",
+	} {
+		t.Run(version, func(t *testing.T) {
+			if got := pseudoVersionRevision(version); got != "" {
+				t.Fatalf("pseudoVersionRevision() = %q, want empty", got)
+			}
+		})
+	}
+}

--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -56,6 +56,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/opencode"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/pi"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/vibe"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/buildversion"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/cli"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/doctor"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/dotenv"
@@ -189,12 +190,11 @@ var (
 	claudeInstall   = claudecode.Install
 )
 
-// Main is the entrypoint shared by cmd/agento11y and cmd/agento11y.
-// buildVersion is the caller's -ldflags-stamped main.version; each main
-// package declares its own variable so the -X flag does not depend on this
-// module's import path.
+// Main is the entrypoint shared by cmd/agento11y and cmd/sigil.
+// buildVersion is the caller's main.version. Release builds stamp it through
+// ldflags; unstamped builds get their version from Go build metadata.
 func Main(buildVersion string) {
-	version = buildVersion
+	version = buildversion.Resolve(buildVersion)
 	run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr)
 }
 


### PR DESCRIPTION
When `agento11y` is installed directly with `go install` from main, `agento11y --version` currently shows `dev` instead of the commit hash.