### PR TITLE
fix(plugins/agento11y): import Cursor agent-transcript JSONL history

### DIFF
--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -191,23 +191,29 @@ A `pi` import reads pi's session logs under `$PI_CODING_AGENT_DIR/sessions` (by 
 
 Subagent runs are in neither: the nested `run-N/session.jsonl` logs come from the third-party `pi-subagents` package, which live capture ignores too, so importing them would exceed live fidelity rather than match it.
 
-A `cursor` import reads Cursor's session databases under `~/.cursor/chats` and produces one generation per prompt, with that prompt, the assistant's reply, its tool calls and matched results, the workspace, and the session's model. Cursor records less about a turn than the other three sources do, so an imported Cursor session is the thinnest of them:
+A `cursor` import reads Cursor sessions from two layouts and produces one generation per prompt, with that prompt, the assistant's reply, and whatever tool data the source recorded:
+
+- `~/.cursor/projects/<project>/agent-transcripts/<uuid>/<uuid>.jsonl` — what current Cursor builds write. Parent transcripts only; nested `subagents/` files are skipped.
+- `~/.cursor/chats/<workspace-hash>/<session-uuid>/store.db` — the older SQLite store, still imported when present.
+
+Cursor records less about a turn than the other three sources do, so an imported Cursor session is the thinnest of them:
 
 - No token usage. Cursor keeps no per-turn counts, so every turn reports no usage and is marked approximate. A dashboard shows no cost for an imported Cursor turn.
-- Approximate times. Cursor stamps no message with a time. Some sessions can be dated to the second, and in the rest the turns are spread across the session's span, which orders them and measures nothing. Every turn is marked approximate either way.
+- Approximate times on store.db sessions. The SQLite store stamps no message with a time. Some sessions can be dated to the second from provider IDs, and in the rest the turns are spread across the session's span, which orders them and measures nothing. Every store.db turn is marked approximate either way. Agent-transcript prompts sometimes carry a `<timestamp>` wrapper; those turns keep that time and are not marked approximate.
 - A session the import cannot date is exported as ending where it started, rather than at a later time nothing in the session supports.
-- One model name per session, and only when the session recorded one. A turn from a session that names none is marked as having no model.
+- Model names only when a store.db session recorded one. Agent transcripts record none, so every transcript turn is marked as having no model.
+- No tool results on agent transcripts. The JSONL lists tool calls (`tool_use`) but not their outputs, so imported transcript turns carry one-sided tool records.
 - No system prompt and no turn IDs. Cursor's own system prompt is dropped, because a live capture exports none either. An imported turn is numbered by its position. The workspace and git-status block Cursor puts in front of a prompt stays there, because the model saw it.
 
-Reading a Cursor session can add a `store.db-shm` file next to the session database. SQLite needs that file to read the newest part of a session. The import writes nothing else in `~/.cursor`, and a dry run is no different, because it opens the same databases.
+Reading a `store.db` session can add a `store.db-shm` file next to the session database. SQLite needs that file to read the newest part of a session. The import writes nothing else in `~/.cursor`, and a dry run is no different, because it opens the same databases.
 
-Cursor publishes no schema for this format and stamps no version into it, so a Cursor release can change it.
+Cursor publishes no schema for either format and stamps no version into them, so a Cursor release can change them.
 
 A forked pi session imports only the turns the fork itself ran. The trunk holds the entries a fork copied from it and exports those turns under its own import, and, when the trunk exported the fork's parent turn, the fork's first turn carries `pi.fork.parent_session_id` and `pi.fork.parent_generation_id` metadata instead of a parent edge. A fork of a fork carries neither key, because no trunk generation exists to name.
 
 `--local` picks the endpoint. Without it, the import exports to the configured Grafana Cloud endpoint, exactly as a live session does. With it, the import exports to the local daemon on this machine.
 
-A dry run reads up to 1 MiB of each session file (a head and a tail window) to count turns and read session metadata. A `cursor` session is a SQLite database rather than a log file, so the dry run queries it for the same counts instead, and no message body leaves the database. Nothing from those bytes is decoded into prompt or response text, shown, exported, or stored.
+A dry run reads up to 1 MiB of each session file (a head and a tail window) to count turns and read session metadata. A `cursor` `store.db` session is a SQLite database rather than a log file, so the dry run queries it for the same counts instead, and no message body leaves the database. A Cursor agent-transcript dry run uses the same bounded head/tail window as the other JSONL importers. Nothing from those bytes is decoded into prompt or response text, shown, exported, or stored.
 
 Without `--since`, an import covers the last 90 days. The local store is a linear scan over JSONL files, so an unbounded first import makes the viewer slow before you have used it. Pass `--since 365d`, `--since 2026-01-01T00:00:00Z`, or any duration to widen the window, and `--until` to bound the other end.
 

--- a/plugins/agento11y/internal/history/cursor.go
+++ b/plugins/agento11y/internal/history/cursor.go
@@ -62,23 +62,26 @@ const (
 	cursorWALHeaderSize = 32
 )
 
-// cursorImporter reads Cursor sessions under ~/.cursor/chats.
+// cursorImporter reads Cursor sessions from two layouts Cursor has used:
 //
-// Cursor stores a session as a content-addressed blob table rather than a
-// transcript, so the decoding lives in [chatstore] and this file only groups the
-// decoded messages into turns and hands each turn to the live [mapper].
+//   - ~/.cursor/chats/<workspace-hash>/<session-uuid>/store.db — the older
+//     SQLite content-addressed store; decoding lives in [chatstore]
+//   - ~/.cursor/projects/<project-slug>/agent-transcripts/<uuid>/<uuid>.jsonl —
+//     the JSONL transcripts current Cursor builds write; decoding lives in
+//     cursor_transcript.go
+//
+// Both paths group messages into turns and hand each turn to the live [mapper].
 //
 // The store records no per-turn timestamp field, no per-turn token usage, and
-// only a session-wide model name. Every turn is therefore marked
-// ApproxStartedAt, ApproxCompletedAt and ApproxUsage, and a session with no
-// recorded model is marked MissingModel. Usage is left at zero rather than
-// charged from the session total.
+// only a session-wide model name. Transcripts record neither model nor usage,
+// and tool results are absent. Every turn is therefore marked ApproxUsage and
+// MissingModel; store.db turns are also ApproxStartedAt/ApproxCompletedAt, and
+// transcript turns are those only when no <timestamp> wrapper dated them.
 //
-// A turn is dated from the provider IDs its messages carry, which is a
-// measurement at second resolution taken on the provider's clock: see
-// cursor_clock.go. A turn whose provider issues IDs with no time in them, and a
-// session on a model that never does, fall back to a window interpolated across
-// the session's span, which is a guess and is flagged as one.
+// A store.db turn is dated from the provider IDs its messages carry (see
+// cursor_clock.go). A turn whose provider issues IDs with no time in them, and
+// a session on a model that never does, fall back to a window interpolated
+// across the session's span, which is a guess and is flagged as one.
 //
 // A prompt is what the user typed, with Cursor's <user_query> wrapper removed,
 // and the environment block Cursor prepends as a message of its own kept in
@@ -90,7 +93,7 @@ const (
 // changes nothing, but it does mean the framework is not the single redaction
 // point here that its documentation describes.
 type cursorImporter struct {
-	// roots overrides the resolved chats directory. Tests set it.
+	// roots overrides the resolved chats and projects directories. Tests set it.
 	roots []string
 	// now supplies the clock the mapper falls back to. nil uses time.Now.
 	now func() time.Time
@@ -104,14 +107,23 @@ func (c *cursorImporter) Roots() []string {
 	if err != nil {
 		return nil
 	}
-	return []string{filepath.Join(home, ".cursor", "chats")}
+	base := filepath.Join(home, ".cursor")
+	return []string{
+		filepath.Join(base, "chats"),
+		filepath.Join(base, "projects"),
+	}
 }
 
-// Match accepts the session database and nothing beside it. SQLite's
-// store.db-wal and store.db-shm sit in the same directory, and matching either
-// would preview and import the same session more than once.
+// Match accepts a Cursor session file: the SQLite store.db, or a parent
+// agent-transcripts JSONL. SQLite's store.db-wal and store.db-shm sit beside
+// the database, and matching either would preview and import the same session
+// more than once. Subagent transcripts under .../subagents/ are not sessions
+// of their own and are excluded here.
 func (c *cursorImporter) Match(path string) bool {
-	return filepath.Base(path) == cursorStoreName
+	if filepath.Base(path) == cursorStoreName {
+		return true
+	}
+	return isCursorParentTranscript(path)
 }
 
 func (c *cursorImporter) clock() time.Time {
@@ -135,6 +147,9 @@ func (c *cursorImporter) clock() time.Time {
 func (c *cursorImporter) Preview(ctx context.Context, path string) (SessionPreview, bool, error) {
 	if err := ctx.Err(); err != nil {
 		return SessionPreview{}, false, err
+	}
+	if isCursorParentTranscript(path) {
+		return c.previewTranscript(ctx, path)
 	}
 	store, err := chatstore.Open(path)
 	if err != nil {
@@ -293,6 +308,9 @@ func cursorStoreFiles(path string) []string {
 // One turn is held at a time. The messages are read one blob at a time, so a
 // session of several hundred megabytes costs one turn's memory.
 func (c *cursorImporter) Turns(ctx context.Context, sess SessionPreview) iter.Seq2[HistoricalGeneration, error] {
+	if isCursorParentTranscript(sess.SourcePath) {
+		return c.turnsTranscript(ctx, sess)
+	}
 	return func(yield func(HistoricalGeneration, error) bool) {
 		if err := ctx.Err(); err != nil {
 			yield(HistoricalGeneration{}, err)
@@ -377,6 +395,9 @@ const (
 	// ID with a time in it, so the turn's times are a share of the session's span
 	// rather than anything measured.
 	cursorNoteInterpolatedTimes = "interpolated_times"
+	// cursorNoteMissingToolResults says the transcript recorded tool calls but
+	// never their outputs, so every ToolRecord is one-sided.
+	cursorNoteMissingToolResults = "missing_tool_results"
 )
 
 // cursorReplay walks a session's messages and holds the open turn only.

--- a/plugins/agento11y/internal/history/cursor_test.go
+++ b/plugins/agento11y/internal/history/cursor_test.go
@@ -225,9 +225,12 @@ func TestCursorRoots(t *testing.T) {
 		want []string
 	}{
 		{
-			name: "cursor's chats directory under the home directory",
+			name: "cursor's chats and projects directories under the home directory",
 			imp:  &cursorImporter{},
-			want: []string{filepath.Join("/home/tester", ".cursor", "chats")},
+			want: []string{
+				filepath.Join("/home/tester", ".cursor", "chats"),
+				filepath.Join("/home/tester", ".cursor", "projects"),
+			},
 		},
 		{
 			name: "an override wins",
@@ -246,6 +249,7 @@ func TestCursorRoots(t *testing.T) {
 
 func TestCursorMatch(t *testing.T) {
 	imp := &cursorImporter{}
+	sid := "0f2b19b1-3d1f-4c1a-9a1e-2f7c1b9d4e55"
 	tests := []struct {
 		path string
 		want bool
@@ -259,6 +263,18 @@ func TestCursorMatch(t *testing.T) {
 		{path: "/c/ws/sess/other.db", want: false},
 		{path: "/c/ws/sess/store.sqlite", want: false},
 		{path: "/c/ws/sess/store.db.bak", want: false},
+		{
+			path: filepath.Join("/home/u/.cursor/projects/proj/agent-transcripts", sid, sid+".jsonl"),
+			want: true,
+		},
+		{
+			path: filepath.Join("/home/u/.cursor/projects/proj/agent-transcripts", sid, "subagents", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl"),
+			want: false,
+		},
+		{
+			path: filepath.Join("/home/u/.cursor/projects/proj/agent-transcripts", sid, "other.jsonl"),
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		if got := imp.Match(tt.path); got != tt.want {

--- a/plugins/agento11y/internal/history/cursor_transcript.go
+++ b/plugins/agento11y/internal/history/cursor_transcript.go
@@ -5,11 +5,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"iter"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -170,11 +172,10 @@ func cursorTimestampFromLine(raw []byte) time.Time {
 func cursorWorkspaceFromTranscriptPath(path string) string {
 	slash := filepath.ToSlash(path)
 	const marker = "/.cursor/projects/"
-	i := strings.Index(slash, marker)
-	if i < 0 {
+	_, rest, ok := strings.Cut(slash, marker)
+	if !ok {
 		return ""
 	}
-	rest := slash[i+len(marker):]
 	slug, _, ok := strings.Cut(rest, "/")
 	if !ok || slug == "" {
 		return ""
@@ -407,7 +408,7 @@ func (c *cursorImporter) turnsTranscript(ctx context.Context, sess SessionPrevie
 				return
 			}
 		}
-		if err := sc.Err(); err != nil && err != io.EOF {
+		if err := sc.Err(); err != nil && !errors.Is(err, io.EOF) {
 			yield(HistoricalGeneration{}, fmt.Errorf("read cursor transcript %s: %w", sess.SourcePath, err))
 			return
 		}
@@ -445,10 +446,8 @@ type cursorTranscriptTurn struct {
 }
 
 func (t *cursorTranscriptTurn) note(n string) {
-	for _, existing := range t.notes {
-		if existing == n {
-			return
-		}
+	if slices.Contains(t.notes, n) {
+		return
 	}
 	t.notes = append(t.notes, n)
 }
@@ -587,6 +586,9 @@ func (r *cursorTranscriptReplay) emit() bool {
 	})
 	gen := mapped.Generation
 	gen.ID = src.GenerationID()
+	if mapped.CallError != nil {
+		gen.CallError = mapped.CallError.Error()
+	}
 	r.emitted++
 	return !r.yield(HistoricalGeneration{Source: src, Gen: gen, Quality: quality}, nil)
 }
@@ -604,8 +606,10 @@ func (r *cursorTranscriptReplay) times(turn *cursorTranscriptTurn) (start, end t
 	if start.Before(r.previousEnd) {
 		start = r.previousEnd
 	}
-	if end.Before(start) {
-		end = start
+	// Dated stamps are minute-resolution. A later turn in the same minute
+	// clamps onto the prior end; keep a non-zero window so exports stay ordered.
+	if !end.After(start) {
+		end = start.Add(cursorNominalStep)
 	}
 	return start, end
 }

--- a/plugins/agento11y/internal/history/cursor_transcript.go
+++ b/plugins/agento11y/internal/history/cursor_transcript.go
@@ -236,7 +236,8 @@ func cursorMatchSlugPath(root, slug string) string {
 }
 
 // parseCursorTranscriptTimestamp parses Cursor's human-readable prompt
-// wrapper, e.g. "Wednesday, May 13, 2026, 2:30 PM (UTC+2)".
+// wrapper, e.g. "Wednesday, May 13, 2026, 2:30 PM (UTC+2)" or with an
+// abbreviated month such as "Tuesday, Jul 21, 2026, 1:04 PM (UTC+2)".
 func parseCursorTranscriptTimestamp(text string) time.Time {
 	opensAt := strings.Index(text, cursorTranscriptTSOpen)
 	closesAt := strings.Index(text, cursorTranscriptTSClose)
@@ -254,8 +255,8 @@ func parseCursorTranscriptTimestamp(text string) time.Time {
 		body = raw
 		zone = ""
 	}
-	t, err := time.Parse("Monday, January 2, 2006, 3:04 PM", body)
-	if err != nil {
+	t, ok := parseCursorTranscriptBody(body)
+	if !ok {
 		return time.Time{}
 	}
 	if zone == "" || zone == "UTC" {
@@ -267,6 +268,22 @@ func parseCursorTranscriptTimestamp(text string) time.Time {
 	}
 	loc := time.FixedZone(zone, offset)
 	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), 0, loc)
+}
+
+// parseCursorTranscriptBody accepts both full and abbreviated English month
+// names. Current Cursor builds write "Jul"; older or hand-edited wrappers may
+// still spell "July".
+func parseCursorTranscriptBody(body string) (time.Time, bool) {
+	for _, layout := range []string{
+		"Monday, January 2, 2006, 3:04 PM",
+		"Monday, Jan 2, 2006, 3:04 PM",
+	} {
+		t, err := time.Parse(layout, body)
+		if err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
 }
 
 // parseCursorUTCOffset parses zone labels Cursor puts in timestamps: UTC,

--- a/plugins/agento11y/internal/history/cursor_transcript.go
+++ b/plugins/agento11y/internal/history/cursor_transcript.go
@@ -1,0 +1,601 @@
+package history
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"iter"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grafana/agento11y/go/agento11y"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/fragment"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/mapper"
+)
+
+// Cursor agent transcripts live under
+// ~/.cursor/projects/<project-slug>/agent-transcripts/<uuid>/<uuid>.jsonl.
+// Cursor publishes no schema for them. The shapes below were recovered from
+// current builds: a user/assistant role line, optional turn_ended, and no
+// tool results, model, or usage.
+
+const (
+	cursorAgentTranscriptsDir = "agent-transcripts"
+	cursorSubagentsDir        = "subagents"
+	cursorTranscriptTSOpen    = "<timestamp>"
+	cursorTranscriptTSClose   = "</timestamp>"
+)
+
+// cursorUserRoleMarker is what a preview counts to estimate turns. Cursor
+// writes compact JSON with no spaces, so a byte scan finds user lines without
+// decoding them.
+var cursorUserRoleMarker = []byte(`"role":"user"`)
+
+// isCursorParentTranscript reports whether path is a parent session JSONL
+// under agent-transcripts. Subagent files live under .../subagents/ and are
+// not sessions of their own. The parent layout is always
+// <uuid>/<uuid>.jsonl: the directory name equals the file stem.
+func isCursorParentTranscript(path string) bool {
+	if !strings.HasSuffix(path, ".jsonl") {
+		return false
+	}
+	slash := filepath.ToSlash(path)
+	if !strings.Contains(slash, "/"+cursorAgentTranscriptsDir+"/") {
+		return false
+	}
+	if strings.Contains(slash, "/"+cursorSubagentsDir+"/") {
+		return false
+	}
+	dir := filepath.Base(filepath.Dir(path))
+	stem := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+	return dir != "" && dir == stem
+}
+
+// previewTranscript builds a metadata-only preview of a Cursor agent
+// transcript. It reads a bounded head and tail window and never returns
+// prompt or response text.
+func (c *cursorImporter) previewTranscript(ctx context.Context, path string) (SessionPreview, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return SessionPreview{}, false, err
+	}
+	win, err := ReadPreviewWindows(path, PreviewByteBudget)
+	if err != nil {
+		return SessionPreview{}, false, err
+	}
+	head := win.HeadLines()
+	if len(head) == 0 {
+		return SessionPreview{}, false, nil
+	}
+
+	sessionID := cursorSessionIDFromPath(path)
+	turns, approx := win.EstimateTotal(countCursorTranscriptTurns(head))
+	if turns == 0 {
+		// No user lines means nothing to import.
+		return SessionPreview{}, false, nil
+	}
+
+	started, last := cursorTranscriptPreviewTimes(win)
+	if started.IsZero() {
+		started = win.ModTime
+	}
+	if last.IsZero() {
+		last = win.ModTime
+	}
+	if started.IsZero() {
+		started = last
+	}
+
+	p := SessionPreview{
+		Agent:          AgentCursor,
+		SessionID:      sessionID,
+		Title:          sessionID,
+		Workspace:      cursorWorkspaceFromTranscriptPath(path),
+		SourcePath:     path,
+		TurnCount:      turns,
+		ApproxTurns:    approx || turns > 0,
+		SizeBytes:      win.Size,
+		StartedAt:      started,
+		LastActivityAt: last,
+	}
+	return p, true, nil
+}
+
+// countCursorTranscriptTurns counts user-role lines in a preview window.
+// Each user line opens a turn the import may export.
+func countCursorTranscriptTurns(lines [][]byte) int {
+	n := 0
+	for _, raw := range lines {
+		if bytes.Contains(raw, cursorUserRoleMarker) {
+			n++
+		}
+	}
+	return n
+}
+
+// cursorTranscriptPreviewTimes reads <timestamp> wrappers from the head and
+// tail windows. Only the timestamp string is decoded; the surrounding prompt
+// text never leaves this function as a return value.
+func cursorTranscriptPreviewTimes(win PreviewWindows) (started, last time.Time) {
+	head := win.HeadLines()
+	for _, raw := range head[:min(len(head), previewMetadataLines)] {
+		if ts := cursorTimestampFromLine(raw); !ts.IsZero() {
+			started = ts
+			break
+		}
+	}
+	tail := win.TailLines()
+	if win.Whole {
+		tail = head
+	}
+	for i := len(tail) - 1; i >= 0 && i >= len(tail)-previewMetadataLines; i-- {
+		if ts := cursorTimestampFromLine(tail[i]); !ts.IsZero() {
+			last = ts
+			break
+		}
+	}
+	if last.IsZero() {
+		last = started
+	}
+	if !started.IsZero() && !last.IsZero() && last.Before(started) {
+		started, last = last, started
+	}
+	return started, last
+}
+
+func cursorTimestampFromLine(raw []byte) time.Time {
+	if !bytes.Contains(raw, []byte(cursorTranscriptTSOpen)) {
+		return time.Time{}
+	}
+	var line cursorTranscriptLine
+	if err := json.Unmarshal(raw, &line); err != nil {
+		return time.Time{}
+	}
+	if line.Role != "user" {
+		return time.Time{}
+	}
+	return parseCursorTranscriptTimestamp(line.Text())
+}
+
+// cursorWorkspaceFromTranscriptPath recovers a workspace path from the project
+// slug Cursor encodes as the directory under ~/.cursor/projects. The slug is
+// the absolute workspace path with every '/' replaced by '-'. When a folder
+// name itself contains a hyphen the mapping is lossy; this returns empty
+// rather than inventing a path.
+func cursorWorkspaceFromTranscriptPath(path string) string {
+	slash := filepath.ToSlash(path)
+	const marker = "/.cursor/projects/"
+	i := strings.Index(slash, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := slash[i+len(marker):]
+	slug, _, ok := strings.Cut(rest, "/")
+	if !ok || slug == "" {
+		return ""
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	homeSlug := strings.ReplaceAll(filepath.ToSlash(home), "/", "-")
+	homeSlug = strings.TrimPrefix(homeSlug, "-")
+	if slug == homeSlug {
+		return home
+	}
+	if !strings.HasPrefix(slug, homeSlug+"-") {
+		return ""
+	}
+	remainder := slug[len(homeSlug)+1:]
+	if remainder == "" {
+		return home
+	}
+	return cursorMatchSlugPath(home, remainder)
+}
+
+// cursorMatchSlugPath greedily matches hyphen-joined path components under
+// root against real directories on disk. At each step it tries the longest
+// remaining prefix that exists as a child, so a folder named "foo-bar" wins
+// over "foo" then a missing "bar".
+func cursorMatchSlugPath(root, slug string) string {
+	cur := root
+	rest := slug
+	for rest != "" {
+		entries, err := os.ReadDir(cur)
+		if err != nil {
+			return ""
+		}
+		names := make(map[string]bool, len(entries))
+		for _, e := range entries {
+			if e.IsDir() {
+				names[e.Name()] = true
+			}
+		}
+		matched := ""
+		// Prefer the longest hyphen-joined prefix that exists.
+		parts := strings.Split(rest, "-")
+		for n := len(parts); n >= 1; n-- {
+			cand := strings.Join(parts[:n], "-")
+			if names[cand] {
+				matched = cand
+				rest = strings.Join(parts[n:], "-")
+				break
+			}
+		}
+		if matched == "" {
+			return ""
+		}
+		cur = filepath.Join(cur, matched)
+	}
+	return cur
+}
+
+// parseCursorTranscriptTimestamp parses Cursor's human-readable prompt
+// wrapper, e.g. "Wednesday, May 13, 2026, 2:30 PM (UTC+2)".
+func parseCursorTranscriptTimestamp(text string) time.Time {
+	opensAt := strings.Index(text, cursorTranscriptTSOpen)
+	closesAt := strings.Index(text, cursorTranscriptTSClose)
+	if opensAt < 0 || closesAt < opensAt {
+		return time.Time{}
+	}
+	raw := strings.TrimSpace(text[opensAt+len(cursorTranscriptTSOpen) : closesAt])
+	if raw == "" {
+		return time.Time{}
+	}
+	body, zone, hasZone := strings.Cut(raw, " (")
+	if hasZone && strings.HasSuffix(zone, ")") {
+		zone = strings.TrimSuffix(zone, ")")
+	} else {
+		body = raw
+		zone = ""
+	}
+	t, err := time.Parse("Monday, January 2, 2006, 3:04 PM", body)
+	if err != nil {
+		return time.Time{}
+	}
+	if zone == "" || zone == "UTC" {
+		return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), 0, time.UTC)
+	}
+	offset, ok := parseCursorUTCOffset(zone)
+	if !ok {
+		return time.Time{}
+	}
+	loc := time.FixedZone(zone, offset)
+	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), 0, loc)
+}
+
+// parseCursorUTCOffset parses zone labels Cursor puts in timestamps: UTC,
+// UTC+2, UTC-5, UTC+05:30.
+func parseCursorUTCOffset(zone string) (int, bool) {
+	if !strings.HasPrefix(zone, "UTC") {
+		return 0, false
+	}
+	rest := zone[len("UTC"):]
+	if rest == "" {
+		return 0, true
+	}
+	sign := 1
+	switch rest[0] {
+	case '+':
+		rest = rest[1:]
+	case '-':
+		sign = -1
+		rest = rest[1:]
+	default:
+		return 0, false
+	}
+	hours := 0
+	mins := 0
+	var err error
+	if h, m, ok := strings.Cut(rest, ":"); ok {
+		hours, err = strconv.Atoi(h)
+		if err != nil {
+			return 0, false
+		}
+		mins, err = strconv.Atoi(m)
+		if err != nil {
+			return 0, false
+		}
+	} else {
+		hours, err = strconv.Atoi(rest)
+		if err != nil {
+			return 0, false
+		}
+	}
+	return sign * (hours*3600 + mins*60), true
+}
+
+// cursorTranscriptLine is one JSONL record. Only the fields the importer
+// needs are declared; unknown fields are ignored.
+type cursorTranscriptLine struct {
+	Type    string          `json:"type"`
+	Status  string          `json:"status"`
+	Error   json.RawMessage `json:"error"`
+	Role    string          `json:"role"`
+	Message *struct {
+		Content []cursorTranscriptPart `json:"content"`
+	} `json:"message"`
+}
+
+type cursorTranscriptPart struct {
+	Type  string          `json:"type"`
+	Text  string          `json:"text"`
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input"`
+}
+
+func (l cursorTranscriptLine) Text() string {
+	if l.Message == nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, p := range l.Message.Content {
+		if p.Type == "text" || p.Type == "" {
+			b.WriteString(p.Text)
+		}
+	}
+	return b.String()
+}
+
+// turnsTranscript yields one generation per user prompt in a Cursor agent
+// transcript. One turn is held at a time so a large file costs one turn's
+// memory.
+func (c *cursorImporter) turnsTranscript(ctx context.Context, sess SessionPreview) iter.Seq2[HistoricalGeneration, error] {
+	return func(yield func(HistoricalGeneration, error) bool) {
+		if err := ctx.Err(); err != nil {
+			yield(HistoricalGeneration{}, err)
+			return
+		}
+		f, err := os.Open(sess.SourcePath)
+		if err != nil {
+			yield(HistoricalGeneration{}, err)
+			return
+		}
+		defer func() { _ = f.Close() }()
+
+		sessionID := firstNonEmptyString(sess.SessionID, cursorSessionIDFromPath(sess.SourcePath))
+		r := &cursorTranscriptReplay{
+			importer:  c,
+			sess:      sess,
+			sessionID: sessionID,
+			workspace: sess.Workspace,
+			window:    cursorTurnWindows(sess.StartedAt, sess.LastActivityAt, sess.TurnCount),
+			yield:     yield,
+		}
+		r.previousEnd = r.window.start
+
+		sc := bufio.NewScanner(f)
+		// Agent transcripts can hold large tool inputs on one line.
+		sc.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+		for sc.Scan() {
+			if err := ctx.Err(); err != nil {
+				yield(HistoricalGeneration{}, err)
+				return
+			}
+			raw := bytes.TrimSpace(sc.Bytes())
+			if len(raw) == 0 {
+				continue
+			}
+			var line cursorTranscriptLine
+			if err := json.Unmarshal(raw, &line); err != nil {
+				r.unreadable++
+				continue
+			}
+			if r.observe(line) {
+				return
+			}
+		}
+		if err := sc.Err(); err != nil && err != io.EOF {
+			yield(HistoricalGeneration{}, fmt.Errorf("read cursor transcript %s: %w", sess.SourcePath, err))
+			return
+		}
+		if r.emit() {
+			return
+		}
+		if err := r.walkReport(); err != nil {
+			yield(HistoricalGeneration{}, err)
+		}
+	}
+}
+
+// cursorTranscriptReplay walks a JSONL transcript and holds the open turn only.
+type cursorTranscriptReplay struct {
+	importer  *cursorImporter
+	sess      SessionPreview
+	sessionID string
+	workspace string
+	window    cursorWindows
+	yield     func(HistoricalGeneration, error) bool
+
+	previousEnd time.Time
+	current     *cursorTranscriptTurn
+	unreadable  int
+	emitted     int
+}
+
+type cursorTranscriptTurn struct {
+	frag      *fragment.Fragment
+	assistant string
+	stop      *mapper.StopInput
+	notes     []string
+	// dated is set when the user prompt carried a parseable <timestamp>.
+	dated time.Time
+}
+
+func (t *cursorTranscriptTurn) note(n string) {
+	for _, existing := range t.notes {
+		if existing == n {
+			return
+		}
+	}
+	t.notes = append(t.notes, n)
+}
+
+func (r *cursorTranscriptReplay) observe(line cursorTranscriptLine) bool {
+	switch {
+	case line.Type == "turn_ended":
+		if r.current == nil {
+			return false
+		}
+		status := strings.ToLower(strings.TrimSpace(line.Status))
+		switch status {
+		case "error", "failed":
+			r.current.stop = &mapper.StopInput{Status: string(mapper.StopStatusError), Error: line.Error}
+		case "aborted", "cancelled", "canceled":
+			r.current.stop = &mapper.StopInput{Status: string(mapper.StopStatusAborted)}
+		default:
+			r.current.stop = &mapper.StopInput{Status: string(mapper.StopStatusCompleted)}
+		}
+		return false
+	case line.Role == "user":
+		if r.emit() {
+			return true
+		}
+		r.open(line)
+	case line.Role == "assistant":
+		r.addAssistant(line)
+	}
+	return false
+}
+
+func (r *cursorTranscriptReplay) open(line cursorTranscriptLine) {
+	text := line.Text()
+	dated := parseCursorTranscriptTimestamp(text)
+	// The timestamp wrapper is Cursor metadata, not what the user typed. Live
+	// capture reads the beforeSubmitPrompt payload, which has neither tag.
+	prompt := cursorUnwrapPrompt(cursorStripTranscriptTimestamp(text))
+	r.current = &cursorTranscriptTurn{
+		frag: &fragment.Fragment{
+			ConversationID: r.sessionID,
+			GenerationID:   fallbackTurnID(r.emitted),
+			UserPrompt:     prompt,
+		},
+		dated: dated,
+	}
+}
+
+// cursorStripTranscriptTimestamp removes Cursor's <timestamp> wrapper so an
+// imported prompt matches the text live capture records.
+func cursorStripTranscriptTimestamp(text string) string {
+	opensAt := strings.Index(text, cursorTranscriptTSOpen)
+	closesAt := strings.Index(text, cursorTranscriptTSClose)
+	if opensAt < 0 || closesAt < opensAt {
+		return text
+	}
+	before := text[:opensAt]
+	after := text[closesAt+len(cursorTranscriptTSClose):]
+	return strings.TrimSpace(before + after)
+}
+
+func (r *cursorTranscriptReplay) addAssistant(line cursorTranscriptLine) {
+	if r.current == nil {
+		return
+	}
+	if line.Message == nil {
+		return
+	}
+	turn := r.current
+	for _, p := range line.Message.Content {
+		switch p.Type {
+		case "text", "":
+			turn.assistant = appendText(turn.assistant, p.Text)
+		case "tool_use":
+			name := strings.TrimSpace(p.Name)
+			if name == "" {
+				continue
+			}
+			idx := len(turn.frag.Tools)
+			turn.frag.Tools = append(turn.frag.Tools, fragment.ToolRecord{
+				ToolName:  name,
+				ToolUseID: fmt.Sprintf("call-%06d", idx),
+				ToolInput: cursorToolPayload(p.Input),
+				Status:    "completed",
+			})
+			turn.note(cursorNoteMissingToolResults)
+		}
+	}
+}
+
+func (r *cursorTranscriptReplay) emit() bool {
+	turn := r.current
+	r.current = nil
+	if turn == nil {
+		return false
+	}
+	if turn.assistant != "" {
+		turn.frag.Assistant = []fragment.AssistantSegment{{Text: turn.assistant}}
+	}
+	if len(turn.frag.Assistant) == 0 && len(turn.frag.Tools) == 0 {
+		return false
+	}
+	start, end := r.times(turn)
+	turn.frag.StartedAt = start.Format(time.RFC3339Nano)
+	turn.frag.LastEventAt = end.Format(time.RFC3339Nano)
+	r.previousEnd = end
+
+	src := SourceRef{
+		Agent:      AgentCursor,
+		SessionID:  r.sessionID,
+		SourcePath: r.sess.SourcePath,
+		TurnIndex:  r.emitted,
+		TurnID:     turn.frag.GenerationID,
+	}
+	approxTimes := turn.dated.IsZero()
+	quality := QualityReport{
+		ApproxStartedAt:   approxTimes,
+		ApproxCompletedAt: approxTimes,
+		ApproxUsage:       true,
+		MissingModel:      true,
+		Notes:             append([]string{cursorNoteMissingTurnID}, turn.notes...),
+	}
+	stop := turn.stop
+	if stop == nil {
+		stop = &mapper.StopInput{Status: string(mapper.StopStatusCompleted)}
+	}
+	mapped := mapper.MapFragment(mapper.Inputs{
+		Fragment: turn.frag,
+		Session: &fragment.Session{
+			ConversationID: r.sessionID,
+			WorkspaceRoots: cursorWorkspaceRoots(r.workspace),
+			StartedAt:      turn.frag.StartedAt,
+		},
+		Stop:           stop,
+		ContentCapture: agento11y.ContentCaptureModeFull,
+		Now:            r.importer.clock(),
+	})
+	gen := mapped.Generation
+	gen.ID = src.GenerationID()
+	r.emitted++
+	return !r.yield(HistoricalGeneration{Source: src, Gen: gen, Quality: quality}, nil)
+}
+
+func (r *cursorTranscriptReplay) times(turn *cursorTranscriptTurn) (start, end time.Time) {
+	if turn.dated.IsZero() {
+		turn.note(cursorNoteInterpolatedTimes)
+		start, end = r.window.at(r.emitted)
+	} else {
+		start = turn.dated.UTC()
+		// A transcript turn has no end time of its own. Give it a nominal
+		// duration so it does not share an instant with the next turn.
+		end = start.Add(cursorNominalStep)
+	}
+	if start.Before(r.previousEnd) {
+		start = r.previousEnd
+	}
+	if end.Before(start) {
+		end = start
+	}
+	return start, end
+}
+
+func (r *cursorTranscriptReplay) walkReport() error {
+	if r.unreadable == 0 {
+		return nil
+	}
+	return fmt.Errorf("cursor session %s: %d transcript lines could not be read", r.sessionID, r.unreadable)
+}

--- a/plugins/agento11y/internal/history/cursor_transcript_test.go
+++ b/plugins/agento11y/internal/history/cursor_transcript_test.go
@@ -195,6 +195,21 @@ func TestCursorTranscriptTurnEndedError(t *testing.T) {
 	if gens[0].Gen.StopReason != "error" {
 		t.Fatalf("StopReason = %q, want error", gens[0].Gen.StopReason)
 	}
+	if gens[0].Gen.CallError != "tool failed" {
+		t.Fatalf("CallError = %q, want the turn_ended error", gens[0].Gen.CallError)
+	}
+}
+
+func TestCursorTranscriptTimesSameMinute(t *testing.T) {
+	stamp := time.Date(2026, 5, 13, 12, 30, 0, 0, time.UTC)
+	r := &cursorTranscriptReplay{previousEnd: stamp.Add(cursorNominalStep)}
+	start, end := r.times(&cursorTranscriptTurn{dated: stamp})
+	if !start.Equal(stamp.Add(cursorNominalStep)) {
+		t.Fatalf("start = %v, want the previous turn's end", start)
+	}
+	if !end.After(start) {
+		t.Fatalf("end %v must be after start %v so same-minute turns stay ordered", end, start)
+	}
 }
 
 func TestCursorDiscoverTranscriptsWithoutChats(t *testing.T) {

--- a/plugins/agento11y/internal/history/cursor_transcript_test.go
+++ b/plugins/agento11y/internal/history/cursor_transcript_test.go
@@ -1,0 +1,286 @@
+package history
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIsCursorParentTranscript(t *testing.T) {
+	sid := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	if !isCursorParentTranscript(filepath.Join("/p/agent-transcripts", sid, sid+".jsonl")) {
+		t.Fatal("expected parent transcript to match")
+	}
+	if isCursorParentTranscript(filepath.Join("/p/agent-transcripts", sid, "subagents", sid+".jsonl")) {
+		t.Fatal("subagent transcript must not match")
+	}
+	if isCursorParentTranscript("") {
+		t.Fatal("empty path must not match")
+	}
+}
+
+func writeCursorTranscript(t *testing.T, root, project, sessionID, fixture string) string {
+	t.Helper()
+	dir := filepath.Join(root, project, "agent-transcripts", sessionID)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join("testdata", "cursor", "transcripts", fixture)
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, sessionID+".jsonl")
+	if err := os.WriteFile(dst, data, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	return dst
+}
+
+func TestCursorTranscriptPreview(t *testing.T) {
+	root := t.TempDir()
+	sid := "0f2b19b1-3d1f-4c1a-9a1e-2f7c1b9d4e55"
+	path := writeCursorTranscript(t, root, "Users-tester-Development-demo", sid, "two-turn.jsonl")
+
+	imp := &cursorImporter{}
+	p, ok, err := imp.Preview(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Preview: %v", err)
+	}
+	if !ok {
+		t.Fatal("Preview returned ok=false")
+	}
+	if p.SessionID != sid {
+		t.Fatalf("SessionID = %q, want %q", p.SessionID, sid)
+	}
+	if p.Title != sid {
+		t.Fatalf("Title = %q, want session id", p.Title)
+	}
+	if p.TurnCount != 2 {
+		t.Fatalf("TurnCount = %d, want 2", p.TurnCount)
+	}
+	if p.SourcePath != path {
+		t.Fatalf("SourcePath = %q, want %q", p.SourcePath, path)
+	}
+	wantStart := time.Date(2026, 5, 13, 14, 30, 0, 0, time.FixedZone("UTC+2", 2*3600))
+	if !p.StartedAt.Equal(wantStart) {
+		t.Fatalf("StartedAt = %v, want %v", p.StartedAt, wantStart)
+	}
+	wantLast := time.Date(2026, 5, 13, 14, 35, 0, 0, time.FixedZone("UTC+2", 2*3600))
+	if !p.LastActivityAt.Equal(wantLast) {
+		t.Fatalf("LastActivityAt = %v, want %v", p.LastActivityAt, wantLast)
+	}
+}
+
+func TestCursorTranscriptPreviewEmpty(t *testing.T) {
+	root := t.TempDir()
+	sid := "bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee"
+	dir := filepath.Join(root, "proj", "agent-transcripts", sid)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, sid+".jsonl")
+	if err := os.WriteFile(path, nil, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	_, ok, err := (&cursorImporter{}).Preview(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Preview: %v", err)
+	}
+	if ok {
+		t.Fatal("empty transcript must not be a usable session")
+	}
+}
+
+func TestCursorTranscriptTurns(t *testing.T) {
+	root := t.TempDir()
+	sid := "0f2b19b1-3d1f-4c1a-9a1e-2f7c1b9d4e55"
+	path := writeCursorTranscript(t, root, "proj", sid, "two-turn.jsonl")
+	imp := &cursorImporter{}
+	preview, ok, err := imp.Preview(context.Background(), path)
+	if err != nil || !ok {
+		t.Fatalf("Preview: ok=%v err=%v", ok, err)
+	}
+
+	var gens []HistoricalGeneration
+	for g, err := range imp.Turns(context.Background(), preview) {
+		if err != nil {
+			t.Fatalf("Turns: %v", err)
+		}
+		gens = append(gens, g)
+	}
+	if len(gens) != 2 {
+		t.Fatalf("got %d generations, want 2", len(gens))
+	}
+	if gens[0].Gen.ConversationID != sid {
+		t.Fatalf("ConversationID = %q, want %q", gens[0].Gen.ConversationID, sid)
+	}
+	prompt := cursorPromptOf(t, gens[0])
+	if !strings.Contains(prompt, "run the tests") {
+		t.Fatalf("first prompt = %q", prompt)
+	}
+	if strings.Contains(prompt, "<timestamp>") {
+		t.Fatal("imported prompt must not keep the timestamp wrapper")
+	}
+	if strings.Contains(prompt, "<user_query>") {
+		t.Fatal("imported prompt must unwrap <user_query>")
+	}
+	if gens[0].Quality.MissingModel != true || gens[0].Quality.ApproxUsage != true {
+		t.Fatalf("quality = %+v", gens[0].Quality)
+	}
+	if gens[0].Quality.ApproxStartedAt {
+		t.Fatal("dated turn must not mark ApproxStartedAt")
+	}
+	if gens[1].Gen.StopReason != "completed" {
+		t.Fatalf("second stop reason = %q, want completed", gens[1].Gen.StopReason)
+	}
+}
+
+func TestCursorTranscriptToolUse(t *testing.T) {
+	root := t.TempDir()
+	sid := "cccccccc-bbbb-cccc-dddd-eeeeeeeeeeee"
+	path := writeCursorTranscript(t, root, "proj", sid, "tool-use.jsonl")
+	imp := &cursorImporter{}
+	preview, ok, err := imp.Preview(context.Background(), path)
+	if err != nil || !ok {
+		t.Fatalf("Preview: ok=%v err=%v", ok, err)
+	}
+	var gens []HistoricalGeneration
+	for g, err := range imp.Turns(context.Background(), preview) {
+		if err != nil {
+			t.Fatalf("Turns: %v", err)
+		}
+		gens = append(gens, g)
+	}
+	if len(gens) != 1 {
+		t.Fatalf("got %d generations, want 1", len(gens))
+	}
+	if names := cursorToolNames(gens[0]); !slices.Equal(names, []string{"Shell"}) {
+		t.Fatalf("tools = %v, want [Shell]", names)
+	}
+	found := false
+	for _, n := range gens[0].Quality.Notes {
+		if n == cursorNoteMissingToolResults {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("notes = %v, want %q", gens[0].Quality.Notes, cursorNoteMissingToolResults)
+	}
+}
+
+func TestCursorTranscriptTurnEndedError(t *testing.T) {
+	root := t.TempDir()
+	sid := "dddddddd-bbbb-cccc-dddd-eeeeeeeeeeee"
+	path := writeCursorTranscript(t, root, "proj", sid, "turn-ended-error.jsonl")
+	imp := &cursorImporter{}
+	preview, ok, err := imp.Preview(context.Background(), path)
+	if err != nil || !ok {
+		t.Fatalf("Preview: ok=%v err=%v", ok, err)
+	}
+	var gens []HistoricalGeneration
+	for g, err := range imp.Turns(context.Background(), preview) {
+		if err != nil {
+			t.Fatalf("Turns: %v", err)
+		}
+		gens = append(gens, g)
+	}
+	if len(gens) != 1 {
+		t.Fatalf("got %d generations, want 1", len(gens))
+	}
+	if gens[0].Gen.StopReason != "error" {
+		t.Fatalf("StopReason = %q, want error", gens[0].Gen.StopReason)
+	}
+}
+
+func TestCursorDiscoverTranscriptsWithoutChats(t *testing.T) {
+	root := t.TempDir()
+	projects := filepath.Join(root, "projects")
+	sid := "0f2b19b1-3d1f-4c1a-9a1e-2f7c1b9d4e55"
+	writeCursorTranscript(t, projects, "proj", sid, "two-turn.jsonl")
+	// No chats directory at all.
+	imp := &cursorImporter{roots: []string{filepath.Join(root, "chats"), projects}}
+	d, err := Discover(context.Background(), AgentCursor, imp, DiscoverOptions{})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(d.Sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1; warnings=%v", len(d.Sessions), d.Warnings)
+	}
+	if d.Sessions[0].SessionID != sid {
+		t.Fatalf("SessionID = %q", d.Sessions[0].SessionID)
+	}
+}
+
+func TestCursorTranscriptFilterUsesTimestamp(t *testing.T) {
+	root := t.TempDir()
+	sid := "0f2b19b1-3d1f-4c1a-9a1e-2f7c1b9d4e55"
+	path := writeCursorTranscript(t, root, "proj", sid, "two-turn.jsonl")
+	// Make mtime look ancient so a buggy importer that used only mtime would
+	// drop the session from a 90-day window.
+	ancient := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(path, ancient, ancient); err != nil {
+		t.Fatal(err)
+	}
+	imp := &cursorImporter{}
+	p, ok, err := imp.Preview(context.Background(), path)
+	if err != nil || !ok {
+		t.Fatalf("Preview: ok=%v err=%v", ok, err)
+	}
+	f := NewFilter()
+	f.Since = time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	selected, skipped := f.SelectSessions([]SessionPreview{p})
+	if len(selected) != 1 {
+		t.Fatalf("selected=%d skipped=%v; LastActivityAt=%v", len(selected), skipped, p.LastActivityAt)
+	}
+}
+
+func TestParseCursorTranscriptTimestamp(t *testing.T) {
+	text := "<timestamp>Wednesday, May 13, 2026, 2:30 PM (UTC+2)</timestamp>\n<user_query>\nhi\n</user_query>"
+	got := parseCursorTranscriptTimestamp(text)
+	want := time.Date(2026, 5, 13, 14, 30, 0, 0, time.FixedZone("UTC+2", 2*3600))
+	if !got.Equal(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	if !parseCursorTranscriptTimestamp("no stamp").IsZero() {
+		t.Fatal("expected zero without timestamp wrapper")
+	}
+}
+
+func TestCursorWorkspaceFromTranscriptPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Build a real workspace path under the fake home.
+	ws := filepath.Join(home, "Development", "demo-app")
+	if err := os.MkdirAll(ws, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	homeSlug := strings.ReplaceAll(filepath.ToSlash(home), "/", "-")
+	homeSlug = strings.TrimPrefix(homeSlug, "-")
+	slug := homeSlug + "-Development-demo-app"
+	sid := "0f2b19b1-3d1f-4c1a-9a1e-2f7c1b9d4e55"
+	path := filepath.Join(home, ".cursor", "projects", slug, "agent-transcripts", sid, sid+".jsonl")
+	got := cursorWorkspaceFromTranscriptPath(path)
+	if got != ws {
+		t.Fatalf("workspace = %q, want %q", got, ws)
+	}
+	if cursorWorkspaceFromTranscriptPath("/nope/file.jsonl") != "" {
+		t.Fatal("expected empty for unrelated path")
+	}
+}
+
+func TestCursorMatchSlugPathHyphenatedDir(t *testing.T) {
+	root := t.TempDir()
+	ws := filepath.Join(root, "foo-bar", "baz")
+	if err := os.MkdirAll(ws, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	got := cursorMatchSlugPath(root, "foo-bar-baz")
+	if got != ws {
+		t.Fatalf("got %q, want %q", got, ws)
+	}
+}

--- a/plugins/agento11y/internal/history/cursor_transcript_test.go
+++ b/plugins/agento11y/internal/history/cursor_transcript_test.go
@@ -240,11 +240,34 @@ func TestCursorTranscriptFilterUsesTimestamp(t *testing.T) {
 }
 
 func TestParseCursorTranscriptTimestamp(t *testing.T) {
-	text := "<timestamp>Wednesday, May 13, 2026, 2:30 PM (UTC+2)</timestamp>\n<user_query>\nhi\n</user_query>"
-	got := parseCursorTranscriptTimestamp(text)
-	want := time.Date(2026, 5, 13, 14, 30, 0, 0, time.FixedZone("UTC+2", 2*3600))
-	if !got.Equal(want) {
-		t.Fatalf("got %v, want %v", got, want)
+	tests := []struct {
+		name string
+		text string
+		want time.Time
+	}{
+		{
+			name: "full month name",
+			text: "<timestamp>Wednesday, May 13, 2026, 2:30 PM (UTC+2)</timestamp>\n<user_query>\nhi\n</user_query>",
+			want: time.Date(2026, 5, 13, 14, 30, 0, 0, time.FixedZone("UTC+2", 2*3600)),
+		},
+		{
+			name: "abbreviated month name as Cursor writes today",
+			text: "<timestamp>Tuesday, Jul 21, 2026, 1:04 PM (UTC+2)</timestamp>\n<user_query>\nhi\n</user_query>",
+			want: time.Date(2026, 7, 21, 13, 4, 0, 0, time.FixedZone("UTC+2", 2*3600)),
+		},
+		{
+			name: "full July still parses",
+			text: "<timestamp>Tuesday, July 21, 2026, 1:04 PM (UTC+2)</timestamp>",
+			want: time.Date(2026, 7, 21, 13, 4, 0, 0, time.FixedZone("UTC+2", 2*3600)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCursorTranscriptTimestamp(tt.text)
+			if !got.Equal(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
 	}
 	if !parseCursorTranscriptTimestamp("no stamp").IsZero() {
 		t.Fatal("expected zero without timestamp wrapper")

--- a/plugins/agento11y/internal/history/testdata/cursor/README.md
+++ b/plugins/agento11y/internal/history/testdata/cursor/README.md
@@ -33,6 +33,9 @@ repository.
 Neither fixture names a Cursor version, because none is recoverable from a
 session on disk.
 
+Agent-transcript JSONL fixtures (current Cursor layout) live under
+`transcripts/` and are covered by `cursor_transcript_test.go`.
+
 ## Checking against a real Cursor
 
 `chatstore` ships an opt-in harness that runs the reader over every store on the

--- a/plugins/agento11y/internal/history/testdata/cursor/transcripts/README.md
+++ b/plugins/agento11y/internal/history/testdata/cursor/transcripts/README.md
@@ -1,0 +1,11 @@
+# Cursor agent-transcript fixtures
+
+Synthetic JSONL sessions under `transcripts/`. They pin the shapes the
+importer expects for `~/.cursor/projects/**/agent-transcripts/<uuid>/<uuid>.jsonl`.
+No bytes from a real conversation are in these files.
+
+| File | Covers |
+|------|--------|
+| `two-turn.jsonl` | Two prompts with `<timestamp>` and `<user_query>`, successful `turn_ended` |
+| `tool-use.jsonl` | Assistant `tool_use` with no tool result |
+| `turn-ended-error.jsonl` | `turn_ended` with `status: error` |

--- a/plugins/agento11y/internal/history/testdata/cursor/transcripts/tool-use.jsonl
+++ b/plugins/agento11y/internal/history/testdata/cursor/transcripts/tool-use.jsonl
@@ -1,0 +1,3 @@
+{"role":"user","message":{"content":[{"type":"text","text":"<user_query>\nlist the files\n</user_query>"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"Listing the workspace."},{"type":"tool_use","name":"Shell","input":{"command":"ls"}}]}}
+{"type":"turn_ended","status":"success"}

--- a/plugins/agento11y/internal/history/testdata/cursor/transcripts/turn-ended-error.jsonl
+++ b/plugins/agento11y/internal/history/testdata/cursor/transcripts/turn-ended-error.jsonl
@@ -1,0 +1,3 @@
+{"role":"user","message":{"content":[{"type":"text","text":"<user_query>\nbreak something\n</user_query>"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"I hit an error before finishing."}]}}
+{"type":"turn_ended","status":"error","error":"tool failed"}

--- a/plugins/agento11y/internal/history/testdata/cursor/transcripts/two-turn.jsonl
+++ b/plugins/agento11y/internal/history/testdata/cursor/transcripts/two-turn.jsonl
@@ -1,0 +1,6 @@
+{"role":"user","message":{"content":[{"type":"text","text":"<timestamp>Wednesday, May 13, 2026, 2:30 PM (UTC+2)</timestamp>\n<user_query>\nrun the tests\n</user_query>"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"I will run the tests now."}]}}
+{"type":"turn_ended","status":"success"}
+{"role":"user","message":{"content":[{"type":"text","text":"<timestamp>Wednesday, May 13, 2026, 2:35 PM (UTC+2)</timestamp>\n<user_query>\nsummarize the failures\n</user_query>"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"Two tests failed in the mapper package."}]}}
+{"type":"turn_ended","status":"success"}


### PR DESCRIPTION
## Summary
- Cursor History import scanned only `~/.cursor/chats/**/store.db`, so current Cursor installs (JSONL under `~/.cursor/projects/**/agent-transcripts`) showed 0 sessions.
- Extend the Cursor importer to discover and replay parent agent-transcript JSONL while keeping the existing `store.db` path for older layouts.
- Document the thinner transcript fidelity (no tool results / model; timestamps only when Cursor wraps the prompt).

<img width="1060" height="806" alt="image" src="https://github.com/user-attachments/assets/a4fcdcb4-1266-4362-ba18-c0a3b2e2c23f" />


## Test plan
- [x] `go test ./internal/history/ -count=1` in `plugins/agento11y`
- [x] `agento11y history import cursor --dry-run --all` plans hundreds of sessions (not 0) on a machine with agent-transcripts
- [ ] Settings → History with Cursor selected shows a non-zero session/turn count after rebuilding and restarting `agento11y local`
- [ ] Optional: confirm a machine that still has `~/.cursor/chats/**/store.db` still discovers those sessions


Made with [Cursor](https://cursor.com)