### PR TITLE
feat(plugins/agento11y): report Claude Code input tokens including cache

### DIFF
--- a/plugins/agento11y/go.mod
+++ b/plugins/agento11y/go.mod
@@ -6,9 +6,7 @@ require (
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/google/uuid v1.6.0
-	// Pseudo-version, not a tag: agento11y/contentcapture is not in go/v0.15.0.
-	// Repin at the next go/v* tag.
-	github.com/grafana/agento11y/go v0.15.1-0.20260731161227-97bfa653b7ae
+	github.com/grafana/agento11y/go v0.17.0
 	github.com/pelletier/go-toml/v2 v2.4.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd

--- a/plugins/agento11y/go.sum
+++ b/plugins/agento11y/go.sum
@@ -61,8 +61,8 @@ github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3 h1:LMLX+LgTNWpfvCBdFe
 github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3/go.mod h1:jl5iWTm0/hd5PjEYEOuwAJ57L/CibdZfrqZ5XA5GrCk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/agento11y/go v0.15.1-0.20260731161227-97bfa653b7ae h1:k9+8y3Bl8NT+l1c80HSUX/oBN+5CJfcCP7N6yRupa2Q=
-github.com/grafana/agento11y/go v0.15.1-0.20260731161227-97bfa653b7ae/go.mod h1:/y++vkjWZm4IHNb9DMaUxfPxKYPh/S5+DAmeyPzP1Ks=
+github.com/grafana/agento11y/go v0.17.0 h1:uL7lTKhPk0pTbJTGr/9hmP4NFUUyLhZyyVbQw2VDdk4=
+github.com/grafana/agento11y/go v0.17.0/go.mod h1:VLyfdZCWiMawl3Zr9tpk0TuxtssPIuxqEOhhXQyrPNI=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=

--- a/plugins/agento11y/internal/agents/claudecode/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/claudecode/mapper/mapper.go
@@ -544,13 +544,18 @@ func processAssistantLine(line transcript.Line, uctx *userContext, _ *state.Sess
 	// closest real one.
 	startedAt := clampSpanStart(requestAt, completedAt)
 
+	// Anthropic reports input_tokens exclusive of both cache buckets. The OTel
+	// GenAI Anthropic page requires gen_ai.usage.input_tokens to cover both
+	// buckets as well, which is the inclusive contract the SDK emits.
+	inputTokens := msg.Usage.InputTokens + msg.Usage.CacheReadInputTokens + msg.Usage.CacheCreationInputTokens
 	usage := agento11y.TokenUsage{
-		InputTokens:           msg.Usage.InputTokens,
+		InputTokens:           inputTokens,
 		OutputTokens:          msg.Usage.OutputTokens,
+		TotalTokens:           inputTokens + msg.Usage.OutputTokens,
 		CacheReadInputTokens:  msg.Usage.CacheReadInputTokens,
 		CacheWriteInputTokens: msg.Usage.CacheCreationInputTokens,
+		InputSemantics:        agento11y.TokenInputSemanticsInclusive,
 	}
-	usage.TotalTokens = usage.InputTokens + usage.OutputTokens
 
 	gen := agento11y.Generation{
 		ID:                generationID(line),

--- a/plugins/agento11y/internal/agents/claudecode/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/claudecode/mapper/mapper_test.go
@@ -222,8 +222,19 @@ func TestProcess_SinglePromptResponse(t *testing.T) {
 	if gen.Usage.OutputTokens != 50 {
 		t.Errorf("OutputTokens = %d", gen.Usage.OutputTokens)
 	}
-	if gen.Usage.TotalTokens != gen.Usage.InputTokens+gen.Usage.OutputTokens {
-		t.Errorf("TotalTokens = %d, want %d", gen.Usage.TotalTokens, gen.Usage.InputTokens+gen.Usage.OutputTokens)
+	// The fixture reports 100 uncached input tokens plus a 50-token cache read,
+	// and the exported input count is inclusive of both cache buckets.
+	if gen.Usage.InputTokens != 150 {
+		t.Errorf("InputTokens = %d, want 150", gen.Usage.InputTokens)
+	}
+	if gen.Usage.CacheReadInputTokens != 50 {
+		t.Errorf("CacheReadInputTokens = %d, want 50", gen.Usage.CacheReadInputTokens)
+	}
+	if gen.Usage.TotalTokens != 200 {
+		t.Errorf("TotalTokens = %d, want 200", gen.Usage.TotalTokens)
+	}
+	if gen.Usage.InputSemantics != agento11y.TokenInputSemanticsInclusive {
+		t.Errorf("InputSemantics = %q, want %q", gen.Usage.InputSemantics, agento11y.TokenInputSemanticsInclusive)
 	}
 	if gen.StopReason != "end_turn" {
 		t.Errorf("StopReason = %q", gen.StopReason)

--- a/plugins/agento11y/internal/entry/testdata/golden/claude-code-basic/export.golden.json
+++ b/plugins/agento11y/internal/entry/testdata/golden/claude-code-basic/export.golden.json
@@ -60,6 +60,7 @@
           }
         ],
         "usage": {
+          "input_semantics": "TOKEN_INPUT_SEMANTICS_INCLUSIVE",
           "input_tokens": "40",
           "output_tokens": "15",
           "total_tokens": "55"
@@ -116,6 +117,7 @@
           "git.branch": "main"
         },
         "usage": {
+          "input_semantics": "TOKEN_INPUT_SEMANTICS_INCLUSIVE",
           "input_tokens": "60",
           "output_tokens": "20",
           "total_tokens": "80"

--- a/plugins/agento11y/internal/entry/testdata/golden/claude-code-subagent/export.golden.json
+++ b/plugins/agento11y/internal/entry/testdata/golden/claude-code-subagent/export.golden.json
@@ -55,9 +55,10 @@
         },
         "usage": {
           "cache_read_input_tokens": "15",
-          "input_tokens": "160",
+          "input_semantics": "TOKEN_INPUT_SEMANTICS_INCLUSIVE",
+          "input_tokens": "175",
           "output_tokens": "18",
-          "total_tokens": "178"
+          "total_tokens": "193"
         }
       },
       {
@@ -162,9 +163,10 @@
         ],
         "usage": {
           "cache_read_input_tokens": "10",
-          "input_tokens": "120",
+          "input_semantics": "TOKEN_INPUT_SEMANTICS_INCLUSIVE",
+          "input_tokens": "130",
           "output_tokens": "25",
-          "total_tokens": "145"
+          "total_tokens": "155"
         }
       }
     ]

--- a/plugins/agento11y/internal/local/query.go
+++ b/plugins/agento11y/internal/local/query.go
@@ -586,6 +586,14 @@ func generationTime(gen summaryGeneration, receivedAt string) time.Time {
 // disjointTokenUsage splits a generation's usage into five buckets that
 // don't overlap, so the viewer can stack them without double-counting.
 //
+// Usage that carries TokenInputSemanticsInclusive needs no provider name
+// on the input axis. The marker says input_tokens already covers every
+// input token type, so both cache buckets sit inside input_tokens and
+// fresh input is input - cache_read - cache_write for every provider.
+// Usage without the marker (legacy records, and exporters that pass
+// provider-raw counts through) falls back to the provider-name heuristic
+// below.
+//
 // Providers disagree on how cache and reasoning tokens relate to the
 // input/output totals, so both carve-outs are provider-aware:
 //
@@ -599,12 +607,13 @@ func generationTime(gen summaryGeneration, receivedAt string) time.Time {
 //     doesn't populate it, so for those reasoning stands alone (see
 //     reasoningInsideOutput).
 //
-// cache_write is never folded into input by any provider we map, so it
-// always stands alone.
+// No provider the heuristic maps folds cache_write into input, so without
+// the inclusive marker cache_write always stands alone.
 //
 // For well-formed usage the buckets sum back to what the provider
-// reported: Anthropic input + cache_read + cache_write + output; OpenAI
-// input + output; Gemini input + output + reasoning (its total also
+// reported: inclusive-marked usage input + output; provider-raw Anthropic
+// input + cache_read + cache_write + output; OpenAI input + output;
+// Gemini input + output + reasoning (its total also
 // counts tool-use prompt tokens, which the SDK's TokenUsage has no field
 // for). When a subset field exceeds its total, the nonNeg clamps keep
 // the subset and zero the remainder, so the sum can exceed what was
@@ -617,7 +626,12 @@ func disjointTokenUsage(u agento11y.TokenUsage, provider string) TokenBuckets {
 		Output:     nonNeg(u.OutputTokens),
 		Reasoning:  nonNeg(u.ReasoningTokens),
 	}
-	if cacheReadInsideInput(provider) {
+	switch {
+	case u.InputSemantics == agento11y.TokenInputSemanticsInclusive:
+		// Both cache buckets are inside input under the OTel contract, so
+		// both come back out; the buckets then sum to the reported total.
+		b.FreshInput = nonNeg(b.FreshInput - b.CacheRead - b.CacheWrite)
+	case cacheReadInsideInput(provider):
 		b.FreshInput = nonNeg(b.FreshInput - b.CacheRead)
 	}
 	if reasoningInsideOutput(provider) {
@@ -627,7 +641,9 @@ func disjointTokenUsage(u agento11y.TokenUsage, provider string) TokenBuckets {
 }
 
 // cacheReadInsideInput reports whether the provider counts cache_read
-// tokens within input_tokens (subset semantics). Anthropic keeps them
+// tokens within input_tokens (subset semantics). This check is the
+// fallback for usage that carries no input-semantics marker; usage that
+// carries one never reaches it (see disjointTokenUsage). Anthropic keeps them
 // separate; OpenAI and Gemini fold them in, and so does codex, the codex
 // agent's fallback provider for model names it can't attribute (its
 // usage comes from the Responses API). Unknown providers default to

--- a/plugins/agento11y/internal/local/query_test.go
+++ b/plugins/agento11y/internal/local/query_test.go
@@ -781,11 +781,14 @@ func TestConversationDetail_InputOutputPassThrough(t *testing.T) {
 	}
 }
 
-// TestDisjointTokenUsage covers the provider-aware split into
-// non-overlapping buckets. Anthropic keeps cache tokens separate from
-// input; OpenAI, Gemini, and codex fold cache_read into input; OpenAI
-// and codex also nest reasoning in output while Gemini keeps thoughts
-// additive; unknown providers default to "separate" on both axes.
+// TestDisjointTokenUsage covers the split into non-overlapping buckets.
+// Usage marked TokenInputSemanticsInclusive carries both cache buckets
+// inside input_tokens, so both are carved back out whatever the provider
+// is named. Without the marker the provider-name heuristic decides:
+// Anthropic keeps cache tokens separate from input; OpenAI, Gemini, and
+// codex fold cache_read into input; OpenAI and codex also nest reasoning
+// in output while Gemini keeps thoughts additive; unknown providers
+// default to "separate" on both axes.
 func TestDisjointTokenUsage(t *testing.T) {
 	cases := []struct {
 		name                                                 string
@@ -906,6 +909,77 @@ func TestDisjointTokenUsage(t *testing.T) {
 			usage:      agento11y.TokenUsage{InputTokens: -5, OutputTokens: -1, CacheReadInputTokens: -3},
 			freshInput: 0, cacheRead: 0, cacheWrite: 0, output: 0, reasoning: 0,
 		},
+		{
+			// The claude-code mapper's golden turn: input_tokens is the
+			// OTel-inclusive count (160 fresh + 15 cache read), so the
+			// buckets must sum to the reported total of 193, not 208.
+			name:     "inclusive anthropic carves cache_read out of input",
+			provider: "anthropic",
+			usage: agento11y.TokenUsage{
+				InputTokens:          175,
+				OutputTokens:         18,
+				TotalTokens:          193,
+				CacheReadInputTokens: 15,
+				InputSemantics:       agento11y.TokenInputSemanticsInclusive,
+			},
+			freshInput: 160, cacheRead: 15, cacheWrite: 0, output: 18, reasoning: 0,
+		},
+		{
+			// cache_write is inside input under the inclusive contract too,
+			// unlike the provider-raw Anthropic case above it.
+			name:     "inclusive anthropic carves both cache buckets out of input",
+			provider: "anthropic",
+			usage: agento11y.TokenUsage{
+				InputTokens:           170,
+				OutputTokens:          50,
+				TotalTokens:           220,
+				CacheReadInputTokens:  30,
+				CacheWriteInputTokens: 20,
+				InputSemantics:        agento11y.TokenInputSemanticsInclusive,
+			},
+			freshInput: 120, cacheRead: 30, cacheWrite: 20, output: 50, reasoning: 0,
+		},
+		{
+			// The marker, not the provider name, decides the input axis; the
+			// reasoning carve-out stays provider-driven.
+			name:     "inclusive marker also applies to openai and leaves reasoning provider-driven",
+			provider: "openai",
+			usage: agento11y.TokenUsage{
+				InputTokens:           100,
+				OutputTokens:          50,
+				CacheReadInputTokens:  30,
+				CacheWriteInputTokens: 10,
+				ReasoningTokens:       10,
+				InputSemantics:        agento11y.TokenInputSemanticsInclusive,
+			},
+			freshInput: 60, cacheRead: 30, cacheWrite: 10, output: 40, reasoning: 10,
+		},
+		{
+			// A fully cached prompt leaves no fresh input, and an
+			// over-reported cache never turns fresh input negative.
+			name:     "inclusive fully cached prompt leaves zero fresh input",
+			provider: "anthropic",
+			usage: agento11y.TokenUsage{
+				InputTokens:          15,
+				OutputTokens:         18,
+				CacheReadInputTokens: 20,
+				InputSemantics:       agento11y.TokenInputSemanticsInclusive,
+			},
+			freshInput: 0, cacheRead: 20, cacheWrite: 0, output: 18, reasoning: 0,
+		},
+		{
+			// Same numbers as the golden turn without the marker: legacy
+			// records keep the additive provider heuristic exactly as before.
+			name:     "unspecified anthropic keeps the additive heuristic",
+			provider: "anthropic",
+			usage: agento11y.TokenUsage{
+				InputTokens:          175,
+				OutputTokens:         18,
+				TotalTokens:          193,
+				CacheReadInputTokens: 15,
+			},
+			freshInput: 175, cacheRead: 15, cacheWrite: 0, output: 18, reasoning: 0,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -917,6 +991,95 @@ func TestDisjointTokenUsage(t *testing.T) {
 				Output:     tc.output,
 				Reasoning:  tc.reasoning,
 			}, b)
+		})
+	}
+}
+
+// TestInputSemanticsMarkerSurvivesTheStore pins the whole local path for
+// the marker the claude-code mapper sets. An inclusive Anthropic turn
+// must reach every reader (detail view, conversation list, token chart,
+// search) with disjoint buckets that sum to the reported total, and a
+// record without the marker must keep the old additive numbers. The
+// golden turn below is the one in
+// internal/entry/testdata/golden/claude-code-subagent: input 175
+// (inclusive of a 15-token cache read), output 18, total 193.
+func TestInputSemanticsMarkerSurvivesTheStore(t *testing.T) {
+	cases := []struct {
+		name        string
+		usageJSON   string
+		wantBuckets TokenBuckets
+		wantTotal   int64
+		// wantBucketSum is what the five buckets add up to. For
+		// inclusive usage it equals the reported total; for a legacy
+		// record the additive heuristic still overshoots it, which is
+		// exactly the behaviour this test freezes.
+		wantBucketSum int64
+	}{
+		{
+			name:          "inclusive marker as the proto-json enum name",
+			usageJSON:     `{"input_tokens":"175","output_tokens":"18","total_tokens":"193","cache_read_input_tokens":"15","input_semantics":"TOKEN_INPUT_SEMANTICS_INCLUSIVE"}`,
+			wantBuckets:   TokenBuckets{FreshInput: 160, CacheRead: 15, Output: 18},
+			wantTotal:     193,
+			wantBucketSum: 193,
+		},
+		{
+			name:          "inclusive marker as the enum number",
+			usageJSON:     `{"input_tokens":175,"output_tokens":18,"total_tokens":193,"cache_read_input_tokens":15,"input_semantics":1}`,
+			wantBuckets:   TokenBuckets{FreshInput: 160, CacheRead: 15, Output: 18},
+			wantTotal:     193,
+			wantBucketSum: 193,
+		},
+		{
+			name:          "record without the marker keeps the additive heuristic",
+			usageJSON:     `{"input_tokens":"175","output_tokens":"18","total_tokens":"193","cache_read_input_tokens":"15"}`,
+			wantBuckets:   TokenBuckets{FreshInput: 175, CacheRead: 15, Output: 18},
+			wantTotal:     193,
+			wantBucketSum: 208,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newStorage(t)
+			// Written as raw JSON, not through agento11y.Generation, so the
+			// test also covers the encoding the HTTP receiver stores.
+			raw := json.RawMessage(`{"id":"g-sem","conversation_id":"conv-sem","agent_name":"claude-code",` +
+				`"model":{"provider":"anthropic","name":"claude-sonnet-4"},` +
+				`"started_at":"2026-05-21T10:00:00Z","completed_at":"2026-05-21T10:00:02Z",` +
+				`"output":[{"role":"MESSAGE_ROLE_ASSISTANT","parts":[{"kind":"text","text":"semantics"}]}],` +
+				`"usage":` + tc.usageJSON + `}`)
+			require.NoError(t, s.AppendGeneration(generationRecord{
+				ReceivedAt:     "2026-05-21T10:00:02Z",
+				GenerationID:   "g-sem",
+				ConversationID: "conv-sem",
+				Generation:     raw,
+			}))
+
+			detail, err := s.ConversationDetail("conv-sem")
+			require.NoError(t, err)
+			require.NotNil(t, detail)
+			require.Len(t, detail.Generations, 1)
+			assert.Equal(t, tc.wantBuckets, detail.Generations[0].TokenBuckets, "detail buckets")
+			assert.Equal(t, tc.wantTotal, detail.Generations[0].TotalTokens, "detail total")
+
+			summaries, _, err := s.ListConversations(ConversationListOptions{})
+			require.NoError(t, err)
+			require.Len(t, summaries, 1)
+			assert.Equal(t, tc.wantBuckets, summaries[0].TokenBuckets, "list buckets")
+			assert.Equal(t, tc.wantTotal, summaries[0].TotalTokens, "list total")
+
+			points, _, err := s.TokenUsagePoints(TokenUsageOptions{Interval: time.Hour})
+			require.NoError(t, err)
+			require.Len(t, points, 1)
+			assert.Equal(t, tc.wantBuckets, points[0].TokenBuckets, "chart buckets")
+
+			hits, err := s.SearchConversations("semantics", 10)
+			require.NoError(t, err)
+			require.Len(t, hits, 1)
+			assert.Equal(t, tc.wantBuckets, hits[0].TokenBuckets, "search buckets")
+
+			b := detail.Generations[0].TokenBuckets
+			sum := b.FreshInput + b.CacheRead + b.CacheWrite + b.Output + b.Reasoning
+			assert.Equal(t, tc.wantBucketSum, sum, "buckets must stay disjoint")
 		})
 	}
 }

--- a/plugins/agento11y/internal/local/wire.go
+++ b/plugins/agento11y/internal/local/wire.go
@@ -49,6 +49,57 @@ func (n *protoInt64) UnmarshalJSON(data []byte) error {
 
 func (n protoInt64) int64() int64 { return int64(n) }
 
+// protoTokenInputSemantics accepts every shape a stored record can carry for
+// TokenUsage.input_semantics: the proto-JSON enum name
+// ("TOKEN_INPUT_SEMANTICS_INCLUSIVE"), the enum number as a JSON number, and
+// the number quoted as a string. A record written before the marker existed
+// carries no such field, and the value stays unspecified, which sends the
+// reader to the provider-name heuristic in disjointTokenUsage.
+type protoTokenInputSemantics agento11y.TokenInputSemantics
+
+const (
+	protoTokenInputSemanticsUnspecifiedName = "TOKEN_INPUT_SEMANTICS_UNSPECIFIED"
+	protoTokenInputSemanticsInclusiveName   = "TOKEN_INPUT_SEMANTICS_INCLUSIVE"
+)
+
+func (s *protoTokenInputSemantics) UnmarshalJSON(data []byte) error {
+	text := strings.TrimSpace(string(data))
+	if text == "" || text == "null" {
+		*s = 0
+		return nil
+	}
+	if strings.HasPrefix(text, "\"") {
+		var quoted string
+		if err := json.Unmarshal(data, &quoted); err != nil {
+			return err
+		}
+		text = strings.TrimSpace(quoted)
+	}
+	switch strings.ToUpper(text) {
+	case "", protoTokenInputSemanticsUnspecifiedName:
+		*s = protoTokenInputSemantics(agento11y.TokenInputSemanticsUnspecified)
+		return nil
+	case protoTokenInputSemanticsInclusiveName:
+		*s = protoTokenInputSemantics(agento11y.TokenInputSemanticsInclusive)
+		return nil
+	}
+	v, err := strconv.ParseInt(text, 10, 32)
+	if err != nil {
+		// A newer exporter can write an enum name this build does not know.
+		// Treat that name as unspecified, the same state a record without the
+		// field is in, rather than drop the whole line: the reader falls back
+		// to the provider heuristic instead of losing the generation.
+		*s = protoTokenInputSemantics(agento11y.TokenInputSemanticsUnspecified)
+		return nil
+	}
+	*s = protoTokenInputSemantics(v)
+	return nil
+}
+
+func (s protoTokenInputSemantics) semantics() agento11y.TokenInputSemantics {
+	return agento11y.TokenInputSemantics(s)
+}
+
 type storedUsage struct {
 	InputTokens           protoInt64 `json:"input_tokens,omitempty"`
 	OutputTokens          protoInt64 `json:"output_tokens,omitempty"`
@@ -56,6 +107,12 @@ type storedUsage struct {
 	CacheReadInputTokens  protoInt64 `json:"cache_read_input_tokens,omitempty"`
 	CacheWriteInputTokens protoInt64 `json:"cache_write_input_tokens,omitempty"`
 	ReasoningTokens       protoInt64 `json:"reasoning_tokens,omitempty"`
+	// InputSemantics marks what InputTokens covers. An exporter sets the
+	// marker when it identified the provider payload shape. Without the
+	// marker the reader cannot tell an OTel-inclusive input count (both
+	// cache buckets already inside input) from a provider-raw additive
+	// count, and would count cache reads twice.
+	InputSemantics protoTokenInputSemantics `json:"input_semantics,omitempty"`
 }
 
 func (u storedUsage) toSDK() agento11y.TokenUsage {
@@ -66,6 +123,7 @@ func (u storedUsage) toSDK() agento11y.TokenUsage {
 		CacheReadInputTokens:  u.CacheReadInputTokens.int64(),
 		CacheWriteInputTokens: u.CacheWriteInputTokens.int64(),
 		ReasoningTokens:       u.ReasoningTokens.int64(),
+		InputSemantics:        u.InputSemantics.semantics(),
 	}
 }
 

--- a/plugins/agento11y/internal/local/wire_test.go
+++ b/plugins/agento11y/internal/local/wire_test.go
@@ -1,0 +1,98 @@
+package local
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/agento11y/go/agento11y"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStoredUsageInputSemantics pins that the input-semantics marker
+// survives the stored shape in every encoding a record can carry it in:
+// the proto-JSON enum name the exporter writes, the enum number the SDK's
+// Go JSON shape writes, and the same number quoted. A record written
+// before the field existed must still decode to unspecified, which is
+// what keeps the provider-name heuristic in charge of legacy data.
+func TestStoredUsageInputSemantics(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+		want agento11y.TokenUsage
+	}{
+		{
+			name: "proto-json enum name and int64 strings",
+			json: `{"input_tokens":"175","output_tokens":"18","total_tokens":"193","cache_read_input_tokens":"15","input_semantics":"TOKEN_INPUT_SEMANTICS_INCLUSIVE"}`,
+			want: agento11y.TokenUsage{
+				InputTokens:          175,
+				OutputTokens:         18,
+				TotalTokens:          193,
+				CacheReadInputTokens: 15,
+				InputSemantics:       agento11y.TokenInputSemanticsInclusive,
+			},
+		},
+		{
+			name: "go json enum number",
+			json: `{"input_tokens":175,"output_tokens":18,"total_tokens":193,"cache_read_input_tokens":15,"input_semantics":1}`,
+			want: agento11y.TokenUsage{
+				InputTokens:          175,
+				OutputTokens:         18,
+				TotalTokens:          193,
+				CacheReadInputTokens: 15,
+				InputSemantics:       agento11y.TokenInputSemanticsInclusive,
+			},
+		},
+		{
+			name: "quoted enum number",
+			json: `{"input_tokens":"10","input_semantics":"1"}`,
+			want: agento11y.TokenUsage{InputTokens: 10, InputSemantics: agento11y.TokenInputSemanticsInclusive},
+		},
+		{
+			name: "explicit unspecified enum name",
+			json: `{"input_tokens":"10","input_semantics":"TOKEN_INPUT_SEMANTICS_UNSPECIFIED"}`,
+			want: agento11y.TokenUsage{InputTokens: 10},
+		},
+		{
+			name: "null marker",
+			json: `{"input_tokens":"10","input_semantics":null}`,
+			want: agento11y.TokenUsage{InputTokens: 10},
+		},
+		{
+			// Every record written before the marker existed. It must decode
+			// exactly as it does today: unspecified, so the bucket split
+			// falls back to the provider-name heuristic.
+			name: "legacy record without the field",
+			json: `{"input_tokens":"175","output_tokens":"18","total_tokens":"193","cache_read_input_tokens":"15"}`,
+			want: agento11y.TokenUsage{
+				InputTokens:          175,
+				OutputTokens:         18,
+				TotalTokens:          193,
+				CacheReadInputTokens: 15,
+			},
+		},
+		{
+			// An enum name a newer exporter knows and this build does not
+			// must not cost the line; unspecified is the safe degradation.
+			name: "unknown enum name degrades to unspecified",
+			json: `{"input_tokens":"10","input_semantics":"TOKEN_INPUT_SEMANTICS_FUTURE"}`,
+			want: agento11y.TokenUsage{InputTokens: 10},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var u storedUsage
+			require.NoError(t, json.Unmarshal([]byte(tc.json), &u))
+			assert.Equal(t, tc.want, u.toSDK())
+
+			// Round trip: re-encoding the stored shape and decoding it
+			// again must preserve the marker, so a record this build
+			// writes back is read the same way it was read.
+			encoded, err := json.Marshal(u)
+			require.NoError(t, err)
+			var again storedUsage
+			require.NoError(t, json.Unmarshal(encoded, &again))
+			assert.Equal(t, tc.want, again.toSDK())
+		})
+	}
+}


### PR DESCRIPTION
Switch claude code plugin to use `agento11y.TokenInputSemanticsInclusive`.

Anthropic reports `input_tokens` without the cache-read and cache-write buckets, and the OTel GenAI spec requires `gen_ai.usage.input_tokens` to cover both, as we do in the `agento11y.TokenInputSemanticsInclusive` mode. The mapper now calculates proper `gen_ai.usage.input_tokens` and sends with the new `agento11y.TokenInputSemanticsInclusive` marker.