### PR TITLE
fix(plugins/agento11y): send gemini as the provider for Gemini models

### DIFF
--- a/plugins/agento11y/internal/agents/codex/hook/handlers.go
+++ b/plugins/agento11y/internal/agents/codex/hook/handlers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/autotag"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/emit"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/mapperutil"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/otel"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/redact"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/useragent"
@@ -91,7 +92,7 @@ func PreToolUse(ctx context.Context, stdout io.Writer, p Payload, cfg config.Con
 		ToolName:      p.ToolName,
 		ToolCallID:    p.ToolUseID,
 		ToolInputJSON: p.ToolInput,
-		ModelProvider: guardProviderFromModel(p.Model),
+		ModelProvider: mapperutil.InferProvider(p.Model),
 		ModelName:     p.Model,
 	}, logger)
 	if res.Blocked() {
@@ -119,30 +120,6 @@ func hasStringCommand(raw json.RawMessage) bool {
 	}
 	_, ok := obj["command"].(string)
 	return ok
-}
-
-func guardProviderFromModel(model string) string {
-	m := strings.ToLower(model)
-	switch {
-	case strings.Contains(m, "claude"):
-		return "anthropic"
-	case strings.HasPrefix(m, "gpt"), isOpenAIOSeriesModel(m):
-		return "openai"
-	case strings.Contains(m, "gemini"):
-		return "google"
-	}
-	return ""
-}
-
-// isOpenAIOSeriesModel reports whether m starts with the OpenAI "o-series"
-// prefix `o` immediately followed by a digit (o1, o3, o4, o5, …). Matching
-// the family rather than a fixed list keeps future releases attributed to
-// OpenAI without code changes.
-func isOpenAIOSeriesModel(m string) bool {
-	if len(m) < 2 || m[0] != 'o' {
-		return false
-	}
-	return m[1] >= '0' && m[1] <= '9'
 }
 
 func PostToolUse(p Payload, cfg config.Config, logger *log.Logger) {

--- a/plugins/agento11y/internal/agents/codex/hook/handlers_test.go
+++ b/plugins/agento11y/internal/agents/codex/hook/handlers_test.go
@@ -1034,7 +1034,7 @@ func TestPreToolUseGuardSendsExpectedRequest(t *testing.T) {
 		ToolName:      "Bash",
 		ToolUseID:     "tu_1",
 		ToolInput:     json.RawMessage(`{"command":"rm -rf /"}`),
-		Model:         "gpt-5",
+		Model:         "gemini-2.5-pro",
 	}
 	PreToolUse(context.Background(), &stdout, payload, cfg, log.New(io.Discard, "", 0))
 
@@ -1050,6 +1050,10 @@ func TestPreToolUseGuardSendsExpectedRequest(t *testing.T) {
 		Phase   string `json:"phase"`
 		Context struct {
 			AgentName string `json:"agent_name"`
+			Model     *struct {
+				Provider string `json:"provider"`
+				Name     string `json:"name"`
+			} `json:"model"`
 		} `json:"context"`
 		Input struct {
 			Output []struct {
@@ -1073,6 +1077,12 @@ func TestPreToolUseGuardSendsExpectedRequest(t *testing.T) {
 	}
 	if req.Context.AgentName != mapper.AgentName {
 		t.Errorf("agent_name = %q, want %q", req.Context.AgentName, mapper.AgentName)
+	}
+	if req.Context.Model == nil {
+		t.Fatal("missing context model")
+	}
+	if req.Context.Model.Provider != "gemini" || req.Context.Model.Name != "gemini-2.5-pro" {
+		t.Errorf("context model = %+v, want gemini/gemini-2.5-pro", req.Context.Model)
 	}
 	if len(req.Input.Output) != 1 || len(req.Input.Output[0].Parts) != 1 {
 		t.Fatalf("unexpected output shape: %+v", req.Input.Output)

--- a/plugins/agento11y/internal/agents/copilot/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/copilot/mapper/mapper.go
@@ -357,7 +357,7 @@ func inferProvider(model string) string {
 	case strings.HasPrefix(model, "claude-"):
 		return "anthropic"
 	case strings.HasPrefix(model, "gemini-"):
-		return "google"
+		return "gemini"
 	default:
 		return ""
 	}

--- a/plugins/agento11y/internal/agents/copilot/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/copilot/mapper/mapper_test.go
@@ -303,3 +303,25 @@ func TestMapAgentNameOverride(t *testing.T) {
 		})
 	}
 }
+
+func TestInferProvider(t *testing.T) {
+	cases := []struct {
+		model string
+		want  string
+	}{
+		{model: "gemini-2.5-pro", want: "gemini"},
+		{model: "Gemini-1.5-Flash", want: "gemini"},
+		{model: "gpt-5", want: "openai"},
+		{model: "claude-sonnet-4", want: "anthropic"},
+		{model: "gemini", want: ""},
+		{model: "", want: ""},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.model, func(t *testing.T) {
+			if got := inferProvider(tt.model); got != tt.want {
+				t.Errorf("inferProvider(%q) = %q, want %q", tt.model, got, tt.want)
+			}
+		})
+	}
+}

--- a/plugins/agento11y/internal/agents/cursor/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/cursor/mapper/mapper_test.go
@@ -470,7 +470,7 @@ func TestMapFragment_InfersProviderFromModel(t *testing.T) {
 		{"claude-sonnet-4-6", "anthropic"},
 		{"gpt-5", "openai"},
 		{"o3-mini", "openai"},
-		{"gemini-2.5-pro", "google"},
+		{"gemini-2.5-pro", "gemini"},
 		{"grok-4.5", "x-ai"},
 		{"cursor-grok-4.6-high-fast", "x-ai"},
 		{"some-random-model", "cursor"}, // no match → cursor fallback

--- a/plugins/agento11y/internal/mapperutil/mapperutil.go
+++ b/plugins/agento11y/internal/mapperutil/mapperutil.go
@@ -99,9 +99,10 @@ func SortedToolDefinitions(names []string) []agento11y.ToolDefinition {
 
 // InferProvider maps a model name to an agento11y provider using loose substring
 // matching for Claude/Gemini/Grok and prefix matching for the OpenAI families.
-// Grok maps to "x-ai", the OpenRouter id the model-card catalog keys xAI
-// prices under. Returns "" when nothing matches so callers can supply their
-// own fallback.
+// Gemini maps to "gemini", matching the SDK's Gemini provider wrapper. Grok
+// maps to "x-ai", the OpenRouter id the model-card catalog keys xAI prices
+// under. Returns "" when nothing matches so callers can supply their own
+// fallback.
 //
 // copilot intentionally uses a stricter matcher (hyphenated prefixes) and does
 // not call this.
@@ -110,15 +111,16 @@ func InferProvider(model string) string {
 	switch {
 	case strings.Contains(m, "claude"):
 		return "anthropic"
-	case strings.HasPrefix(m, "gpt"),
-		strings.HasPrefix(m, "o1"),
-		strings.HasPrefix(m, "o3"),
-		strings.HasPrefix(m, "o4"):
+	case strings.HasPrefix(m, "gpt"), isOpenAIOSeriesModel(m):
 		return "openai"
 	case strings.Contains(m, "gemini"):
-		return "google"
+		return "gemini"
 	case strings.Contains(m, "grok"):
 		return "x-ai"
 	}
 	return ""
+}
+
+func isOpenAIOSeriesModel(model string) bool {
+	return len(model) >= 2 && model[0] == 'o' && model[1] >= '0' && model[1] <= '9'
 }

--- a/plugins/agento11y/internal/mapperutil/mapperutil_test.go
+++ b/plugins/agento11y/internal/mapperutil/mapperutil_test.go
@@ -134,8 +134,10 @@ func TestInferProvider(t *testing.T) {
 		{"o1-preview", "openai"},
 		{"o3-mini", "openai"},
 		{"o4-fast", "openai"},
-		{"gemini-2.5-pro", "google"},
-		{"models/gemini-pro", "google"}, // substring match anywhere
+		{"o5", "openai"},
+		{"o9-future", "openai"},
+		{"gemini-2.5-pro", "gemini"},
+		{"models/gemini-pro", "gemini"}, // substring match anywhere
 		{"grok-4.5", "x-ai"},
 		{"grok-4.6", "x-ai"},
 		{"cursor-grok-4.6-high-fast", "x-ai"}, // substring match anywhere


### PR DESCRIPTION
Cursor, Codex, and Copilot captures stored `google` as the provider for a Gemini model name. The SDK's own Gemini provider wrapper [stores](https://github.com/grafana/agento11y/blob/d81b40fc3fae3db8ca1eaa824abd60d412777eea/go-providers/gemini/options.go#L25) `gemini`, and that is the correct spelling.