### PR TITLE
feat(plugins/agento11y): support new mistral vibe hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Three steps run per release, and none of them creates a tag on the release PR:
 | `plugins/claude-code/`, `plugins/codex/`, `plugins/copilot/`, `plugins/cursor/` | Thin glue: hook scripts and READMEs that wire the host agent to the shared `agento11y` binary. No independent code paths. |
 | `plugins/opencode/` | Independent npm package `@grafana/agento11y-opencode`. Runs in-process inside opencode through its TypeScript plugin API; `agento11y opencode` installs and launches it. |
 | `plugins/pi/` | Independent npm package `@grafana/agento11y-pi`. Runs in-process inside pi; `agento11y pi` installs and launches it. |
-| `plugins/vibe/` | README only. `agento11y vibe` upserts three `[[hooks]]` entries into `hooks.toml` under `$VIBE_HOME` (default `~/.vibe`) and sets `VIBE_ENABLE_EXPERIMENTAL_HOOKS=true` on the child so vibe loads them. |
+| `plugins/vibe/` | README only. `agento11y vibe` upserts three `[[hooks]]` entries into `hooks.toml` under `$VIBE_HOME` (default `~/.vibe`) and sets `VIBE_ENABLE_EXPERIMENTAL_HOOKS=true` on the child, which only a vibe below 2.21.0 needs. Vibe 2.21.0 renamed all three hook types, so the install path picks the spelling from `vibe --version` and the hook dispatcher answers to both. See `internal/agents/vibe/version.go`. |
 
 If you change shared-binary behavior, the four glue plugins and vibe all see it. The OpenCode and pi plugins evolve independently, but the shared binary owns their install/launch flow.
 

--- a/llms.txt
+++ b/llms.txt
@@ -83,7 +83,7 @@ A binary older than that command prints `agento11y: unknown agent "skills"` and 
 | [Cursor](https://cursor.com) | [`plugins/cursor/`](https://github.com/grafana/agento11y/tree/main/plugins/cursor) | Shared `agento11y` Go binary via hooks |
 | [OpenCode](https://opencode.ai) | [`plugins/opencode/`](https://github.com/grafana/agento11y/tree/main/plugins/opencode) | Shared `agento11y` Go binary, installs `@grafana/agento11y-opencode` |
 | [Pi](https://github.com/earendil-works/pi) | [`plugins/pi/`](https://github.com/grafana/agento11y/tree/main/plugins/pi) | Independent npm package `@grafana/agento11y-pi` |
-| [Vibe](https://github.com/mistralai/vibe) | [`plugins/vibe/`](https://github.com/grafana/agento11y/tree/main/plugins/vibe) | Shared `agento11y` Go binary via `hooks.toml` |
+| [Vibe](https://github.com/mistralai/mistral-vibe) | [`plugins/vibe/`](https://github.com/grafana/agento11y/tree/main/plugins/vibe) | Shared `agento11y` Go binary via `hooks.toml` |
 
 ## Fast path
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -44,7 +44,7 @@ Cursor has no launcher; see [`cursor/README.md`](cursor/README.md) for setup.
 | [Cursor](https://cursor.com) | [`cursor/`](cursor/) | Available |
 | [OpenCode](https://opencode.ai) | [`opencode/`](opencode/) | Available |
 | [Pi](https://github.com/earendil-works/pi) | [`pi/`](pi/) | Available |
-| [Vibe](https://github.com/mistralai/vibe) | [`vibe/`](vibe/) | Experimental |
+| [Vibe](https://github.com/mistralai/mistral-vibe) | [`vibe/`](vibe/) | Experimental |
 
 ## Content and redaction
 

--- a/plugins/agento11y/internal/agents/vibe/hook/handlers.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/handlers.go
@@ -20,7 +20,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/useragent"
 )
 
-// exportTimeout caps how long PostAgentTurn will wait for the SDK to
+// exportTimeout caps how long PostAgent will wait for the SDK to
 // drain. Vibe blocks on the hook command, so a hung export would stall
 // the user's session.
 const exportTimeout = 20 * time.Second
@@ -29,7 +29,7 @@ const exportTimeout = 20 * time.Second
 // spans and metrics are emitted under.
 const otelInstrumentationName = "agento11y.vibe"
 
-// PostAgentTurn handles a vibe post_agent_turn hook event end to end:
+// PostAgent handles a vibe post_agent hook event end to end:
 // read state, read the new transcript slice, read meta.json, map to a
 // agento11y.Generation, persist the advanced offset and session snapshot, then
 // export. State is saved before the export so a post-export save failure
@@ -39,30 +39,30 @@ const otelInstrumentationName = "agento11y.vibe"
 // The handler never returns an error. Every failure is logged and
 // swallowed so an agento11y outage cannot interrupt the user's vibe session.
 // The caller (vibe.Hook) writes nothing to stdout and always exits 0.
-func PostAgentTurn(ctx context.Context, p Payload, logger *log.Logger) {
+func PostAgent(ctx context.Context, p Payload, logger *log.Logger) {
 	if p.SessionID == "" {
-		logger.Print("post_agent_turn: missing session_id")
+		logger.Print("post_agent: missing session_id")
 		return
 	}
 	if p.TranscriptPath == "" {
-		logger.Print("post_agent_turn: missing transcript_path")
+		logger.Print("post_agent: missing transcript_path")
 		return
 	}
 
 	prior, priorFound := state.Load(p.SessionID)
 	lines, newOffset, err := transcript.Read(p.TranscriptPath, prior.Offset)
 	if err != nil {
-		logger.Printf("post_agent_turn: read transcript %s: %v", p.TranscriptPath, err)
+		logger.Printf("post_agent: read transcript %s: %v", p.TranscriptPath, err)
 		return
 	}
 	if len(lines) == 0 {
-		logger.Printf("post_agent_turn: no new lines at offset=%d", prior.Offset)
+		logger.Printf("post_agent: no new lines at offset=%d", prior.Offset)
 		return
 	}
 
 	m, err := meta.Load(p.TranscriptPath)
 	if err != nil {
-		logger.Printf("post_agent_turn: read meta: %v", err)
+		logger.Printf("post_agent: read meta: %v", err)
 		return
 	}
 
@@ -82,14 +82,14 @@ func PostAgentTurn(ctx context.Context, p Payload, logger *log.Logger) {
 		},
 	)
 	if len(missing) > 0 {
-		logger.Printf("post_agent_turn: not exporting: missing %s", strings.Join(missing, ", "))
+		logger.Printf("post_agent: not exporting: missing %s", strings.Join(missing, ", "))
 		return
 	}
 
 	contentMode := envconfig.ResolveContentMode(logger)
 	skipPromptRedaction := !envconfig.ResolveRedactInput(logger)
 
-	// vibe persists the post_agent_turn count as stats.steps. Using it
+	// vibe persists the post_agent count as stats.steps. Using it
 	// (rather than a counter in state) keeps the generation ID stable
 	// even when a user re-runs the hook against an old transcript while
 	// state was lost.
@@ -159,7 +159,7 @@ func PostAgentTurn(ctx context.Context, p Payload, logger *log.Logger) {
 		Title:                   m.Title,
 	}
 	if err := state.Save(p.SessionID, next); err != nil {
-		logger.Printf("post_agent_turn: save state: %v", err)
+		logger.Printf("post_agent: save state: %v", err)
 		return
 	}
 
@@ -174,39 +174,39 @@ func PostAgentTurn(ctx context.Context, p Payload, logger *log.Logger) {
 	if providers != nil {
 		defer func() {
 			if err := providers.Shutdown(exportCtx); err != nil {
-				logger.Printf("post_agent_turn: otel shutdown: %v", err)
+				logger.Printf("post_agent: otel shutdown: %v", err)
 			}
 		}()
 	}
 	client := buildClient(contentMode, providers, endpoint, tenantID, authToken, p.CWD, logger)
 
-	// Per-tool timing/status recorded by after_tool fires this turn. Empty
-	// when the user has not enabled the after_tool hook, in which case the
+	// Per-tool timing/status recorded by post_tool fires this turn. Empty
+	// when the user has not enabled the post_tool hook, in which case the
 	// spans fall back to synthetic timing off the generation timestamp.
 	toolEvents := toolevents.Load(p.SessionID)
 
-	logger.Printf("post_agent_turn: export id=%s session=%s turn=%d", mapped.Generation.ID, p.SessionID, turnSeq)
+	logger.Printf("post_agent: export id=%s session=%s turn=%d", mapped.Generation.ID, p.SessionID, turnSeq)
 	if err := emit(exportCtx, client, mapped, toolEvents, logger); err != nil {
-		logger.Printf("post_agent_turn: emit: %v", err)
+		logger.Printf("post_agent: emit: %v", err)
 		_ = client.Shutdown(exportCtx)
 		restoreState(p.SessionID, prior, priorFound, logger)
 		return
 	}
 	if err := client.Flush(exportCtx); err != nil {
-		logger.Printf("post_agent_turn: flush: %v", err)
+		logger.Printf("post_agent: flush: %v", err)
 		_ = client.Shutdown(exportCtx)
 		restoreState(p.SessionID, prior, priorFound, logger)
 		return
 	}
 	if providers != nil {
 		if err := providers.ForceFlush(); err != nil {
-			logger.Printf("post_agent_turn: otel flush: %v", err)
+			logger.Printf("post_agent: otel flush: %v", err)
 		}
 	}
 	_ = client.Shutdown(exportCtx)
 	// The turn is exported; its tool events have been consumed into spans.
 	toolevents.Clear(p.SessionID)
-	logger.Printf("post_agent_turn: done session=%s offset=%d", p.SessionID, newOffset)
+	logger.Printf("post_agent: done session=%s offset=%d", p.SessionID, newOffset)
 }
 
 // restoreState rolls back the pre-export state write after a failed export so
@@ -216,12 +216,12 @@ func PostAgentTurn(ctx context.Context, p Payload, logger *log.Logger) {
 func restoreState(sessionID string, prior state.Session, priorFound bool, logger *log.Logger) {
 	if priorFound {
 		if err := state.Save(sessionID, prior); err != nil {
-			logger.Printf("post_agent_turn: restore state: %v", err)
+			logger.Printf("post_agent: restore state: %v", err)
 		}
 		return
 	}
 	if err := state.Delete(sessionID); err != nil {
-		logger.Printf("post_agent_turn: delete state: %v", err)
+		logger.Printf("post_agent: delete state: %v", err)
 	}
 }
 
@@ -239,7 +239,7 @@ func emit(ctx context.Context, client *agento11y.Client, mapped mapper.Mapped, t
 // emitToolSpans emits one execute_tool span per assistant tool call in the
 // turn, nested under the generation. The call args come from the generation
 // output, the result from the matching tool-result message, and the timing
-// and error status from the after_tool event for that call (when present;
+// and error status from the post_tool event for that call (when present;
 // otherwise the span gets synthetic zero-duration timing off the generation
 // completion time, like claude-code's reconstructed spans).
 func emitToolSpans(ctx context.Context, client *agento11y.Client, gen agento11y.Generation, mode agento11y.ContentCaptureMode, events map[string]toolevents.Event, logger *log.Logger) {
@@ -280,7 +280,7 @@ func emitToolSpans(ctx context.Context, client *agento11y.Client, gen agento11y.
 			toolRec.SetResult(end)
 			toolRec.End()
 			if err := toolRec.Err(); err != nil {
-				logger.Printf("post_agent_turn: tool span: %v", err)
+				logger.Printf("post_agent: tool span: %v", err)
 			}
 		}
 	}
@@ -300,9 +300,9 @@ func buildToolResultMap(input []agento11y.Message) map[string]agento11y.ToolResu
 	return out
 }
 
-// toolSpanWindow resolves a tool span's [start, end] window. With an
-// after_tool event it uses the recorded completion time and duration; without
-// one it collapses to a zero-duration span at the generation completion time.
+// toolSpanWindow resolves a tool span's [start, end] window. With a post_tool
+// event it uses the recorded completion time and duration; without one it
+// collapses to a zero-duration span at the generation completion time.
 func toolSpanWindow(ev toolevents.Event, hasEvent bool, genCompletedAt time.Time) (startedAt, completedAt time.Time) {
 	completedAt = genCompletedAt
 	if hasEvent && !ev.CompletedAt.IsZero() {
@@ -321,7 +321,7 @@ func setupOTelIfConfigured(ctx context.Context, instanceID string, logger *log.L
 	}
 	providers, err := otel.Setup(ctx, instanceID)
 	if err != nil {
-		logger.Printf("post_agent_turn: otel setup: %v", err)
+		logger.Printf("post_agent: otel setup: %v", err)
 		return nil
 	}
 	return providers

--- a/plugins/agento11y/internal/agents/vibe/hook/handlers_test.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/handlers_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
 
-func TestPostAgentTurn_EndToEnd(t *testing.T) {
+func TestPostAgent_EndToEnd(t *testing.T) {
 	// Drive the handler through a httptest server playing the role of
 	// the Agent Observability export endpoint, then assert the offset and token
 	// snapshot in state were advanced.
@@ -60,9 +60,9 @@ func TestPostAgentTurn_EndToEnd(t *testing.T) {
 	tp := filepath.Join(dir, "messages.jsonl")
 
 	logger := log.New(io.Discard, "", 0)
-	payload := Payload{HookEventName: "post_agent_turn", SessionID: "sess-end-to-end", TranscriptPath: tp}
+	payload := Payload{HookEventName: "post_agent", SessionID: "sess-end-to-end", TranscriptPath: tp}
 
-	PostAgentTurn(context.Background(), payload, logger)
+	PostAgent(context.Background(), payload, logger)
 
 	mu.Lock()
 	got := recs
@@ -112,7 +112,7 @@ func TestPostAgentTurn_EndToEnd(t *testing.T) {
 	}
 }
 
-func TestPostAgentTurn_UsesMetaParentSessionID(t *testing.T) {
+func TestPostAgent_UsesMetaParentSessionID(t *testing.T) {
 	// A subagent session carries its parent only in meta.json, not on the
 	// thin hook payload. The handler must still resolve the parent edge.
 	var (
@@ -142,7 +142,7 @@ func TestPostAgentTurn_UsesMetaParentSessionID(t *testing.T) {
 	tp := filepath.Join(dir, "messages.jsonl")
 
 	logger := log.New(io.Discard, "", 0)
-	PostAgentTurn(context.Background(), Payload{HookEventName: "post_agent_turn", SessionID: "child-session", TranscriptPath: tp}, logger)
+	PostAgent(context.Background(), Payload{HookEventName: "post_agent", SessionID: "child-session", TranscriptPath: tp}, logger)
 
 	mu.Lock()
 	got := body
@@ -175,7 +175,7 @@ func TestPostAgentTurn_UsesMetaParentSessionID(t *testing.T) {
 	}
 }
 
-func TestPostAgentTurn_SaveStateFailureSkipsExport(t *testing.T) {
+func TestPostAgent_SaveStateFailureSkipsExport(t *testing.T) {
 	// State is saved before the export. If the save fails, nothing is
 	// exported, so a successful export can never be stranded by a lost
 	// offset. Force a save failure by pointing XDG_STATE_HOME at a file.
@@ -205,7 +205,7 @@ func TestPostAgentTurn_SaveStateFailureSkipsExport(t *testing.T) {
 	tp := filepath.Join(dir, "messages.jsonl")
 
 	logger := log.New(io.Discard, "", 0)
-	PostAgentTurn(context.Background(), Payload{HookEventName: "post_agent_turn", SessionID: "sess-save-fails", TranscriptPath: tp}, logger)
+	PostAgent(context.Background(), Payload{HookEventName: "post_agent", SessionID: "sess-save-fails", TranscriptPath: tp}, logger)
 
 	mu.Lock()
 	got := exports
@@ -223,9 +223,9 @@ func replaceInFile(path, old, replacement string) error {
 	return os.WriteFile(path, []byte(strings.ReplaceAll(string(data), old, replacement)), 0o600)
 }
 
-func TestPostAgentTurn_NoNewMessagesNoExport(t *testing.T) {
+func TestPostAgent_NoNewMessagesNoExport(t *testing.T) {
 	// Pre-populate state with the file's full byte length so the next
-	// read returns zero lines; PostAgentTurn must skip silently.
+	// read returns zero lines; PostAgent must skip silently.
 	dir := t.TempDir()
 	must(t, copyFile(filepath.Join("..", "testdata", "messages.jsonl"), filepath.Join(dir, "messages.jsonl")))
 	must(t, copyFile(filepath.Join("..", "testdata", "meta.json"), filepath.Join(dir, "meta.json")))
@@ -248,7 +248,7 @@ func TestPostAgentTurn_NoNewMessagesNoExport(t *testing.T) {
 		t.Fatalf("save: %v", err)
 	}
 	logger := log.New(io.Discard, "", 0)
-	PostAgentTurn(context.Background(), Payload{HookEventName: "post_agent_turn", SessionID: "sess-empty", TranscriptPath: tp}, logger)
+	PostAgent(context.Background(), Payload{HookEventName: "post_agent", SessionID: "sess-empty", TranscriptPath: tp}, logger)
 
 	// State must be unchanged; if export had run it would have
 	// overwritten our token snapshot.
@@ -258,7 +258,7 @@ func TestPostAgentTurn_NoNewMessagesNoExport(t *testing.T) {
 	}
 }
 
-func TestPostAgentTurn_MissingCredsSkipsExport(t *testing.T) {
+func TestPostAgent_MissingCredsSkipsExport(t *testing.T) {
 	// No SIGIL_* env: the handler must log and bail without touching
 	// state, so a re-run later with credentials still picks up from
 	// the same offset.
@@ -272,13 +272,13 @@ func TestPostAgentTurn_MissingCredsSkipsExport(t *testing.T) {
 	t.Setenv("SIGIL_AUTH_TENANT_ID", "")
 	t.Setenv("SIGIL_AUTH_TOKEN", "")
 	logger := log.New(io.Discard, "", 0)
-	PostAgentTurn(context.Background(), Payload{HookEventName: "post_agent_turn", SessionID: "sess-noauth", TranscriptPath: tp}, logger)
+	PostAgent(context.Background(), Payload{HookEventName: "post_agent", SessionID: "sess-noauth", TranscriptPath: tp}, logger)
 	if got, found := state.Load("sess-noauth"); found || (got != state.Session{}) {
 		t.Errorf("state was written despite missing creds: found=%v got=%+v", found, got)
 	}
 }
 
-func TestPostAgentTurn_SessionCostSnapshot(t *testing.T) {
+func TestPostAgent_SessionCostSnapshot(t *testing.T) {
 	// The snapshot is the baseline the next turn subtracts from. A
 	// meta.json reporting no session_cost must leave the prior baseline
 	// standing, otherwise a later turn that does report a cost deltas
@@ -332,7 +332,7 @@ func TestPostAgentTurn_SessionCostSnapshot(t *testing.T) {
 
 			must(t, state.Save("sess-cost", state.Session{SessionCost: 5}))
 			logger := log.New(io.Discard, "", 0)
-			PostAgentTurn(context.Background(), Payload{HookEventName: "post_agent_turn", SessionID: "sess-cost", TranscriptPath: tp}, logger)
+			PostAgent(context.Background(), Payload{HookEventName: "post_agent", SessionID: "sess-cost", TranscriptPath: tp}, logger)
 
 			st, found := state.Load("sess-cost")
 			if !found {
@@ -345,10 +345,10 @@ func TestPostAgentTurn_SessionCostSnapshot(t *testing.T) {
 	}
 }
 
-// TestPostAgentTurn_PromptRedactionWiring pins AGENTO11Y_REDACT_INPUT_MESSAGES
+// TestPostAgent_PromptRedactionWiring pins AGENTO11Y_REDACT_INPUT_MESSAGES
 // from the environment through to the exported body. The mapper tests cover
 // the flag itself; this one covers the wire between them.
-func TestPostAgentTurn_PromptRedactionWiring(t *testing.T) {
+func TestPostAgent_PromptRedactionWiring(t *testing.T) {
 	const secret = "glc_abcdefghijklmnopqrstuvwxyz"
 
 	tests := []struct {
@@ -392,7 +392,7 @@ func TestPostAgentTurn_PromptRedactionWiring(t *testing.T) {
 			must(t, os.WriteFile(tp, []byte(lines), 0o644))
 
 			logger := log.New(io.Discard, "", 0)
-			PostAgentTurn(context.Background(), Payload{HookEventName: "post_agent_turn", SessionID: "sess-redaction", TranscriptPath: tp}, logger)
+			PostAgent(context.Background(), Payload{HookEventName: "post_agent", SessionID: "sess-redaction", TranscriptPath: tp}, logger)
 
 			mu.Lock()
 			got := string(body)
@@ -411,10 +411,10 @@ func TestPostAgentTurn_PromptRedactionWiring(t *testing.T) {
 	}
 }
 
-func TestPostAgentTurn_MissingPayloadFields(t *testing.T) {
+func TestPostAgent_MissingPayloadFields(t *testing.T) {
 	logger := log.New(io.Discard, "", 0)
-	PostAgentTurn(context.Background(), Payload{HookEventName: "post_agent_turn"}, logger)
-	PostAgentTurn(context.Background(), Payload{HookEventName: "post_agent_turn", SessionID: "s"}, logger)
+	PostAgent(context.Background(), Payload{HookEventName: "post_agent"}, logger)
+	PostAgent(context.Background(), Payload{HookEventName: "post_agent", SessionID: "s"}, logger)
 }
 
 func copyFile(src, dst string) error {
@@ -546,15 +546,15 @@ func TestAgentNameOverrideGuardAndExport(t *testing.T) {
 
 			logger := log.New(io.Discard, "", 0)
 			var stdout bytes.Buffer
-			BeforeTool(context.Background(), &stdout, Payload{
-				HookEventName:   "before_tool",
+			PreTool(context.Background(), &stdout, Payload{
+				HookEventName:   "pre_tool",
 				SessionID:       "sess-agent-name",
 				ToolNameValue:   "shell",
 				ToolCallIDValue: "call-1",
 				ToolInputValue:  json.RawMessage(`{"command":"echo hi"}`),
 			}, logger)
-			PostAgentTurn(context.Background(), Payload{
-				HookEventName:  "post_agent_turn",
+			PostAgent(context.Background(), Payload{
+				HookEventName:  "post_agent",
 				SessionID:      "sess-agent-name",
 				TranscriptPath: tp,
 			}, logger)

--- a/plugins/agento11y/internal/agents/vibe/hook/payload.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/payload.go
@@ -9,13 +9,13 @@ import (
 )
 
 // Payload is the union of fields vibe writes to a hook command's stdin
-// across the three event types it fires. post_agent_turn carries only the
-// session-locating fields; before_tool adds the tool name/call-id/input;
-// after_tool adds the tool outcome (status, output, error, duration).
+// across the three event types it fires. post_agent carries only the
+// session-locating fields; pre_tool adds the tool name/call-id/input;
+// post_tool adds the tool outcome (status, output, error, duration).
 //
 // The base payload is intentionally thin: it carries enough to locate the
 // session's on-disk transcript (messages.jsonl) plus meta.json, and the
-// post_agent_turn handler reads the actual turn content from there.
+// post_agent handler reads the actual turn content from there.
 type Payload struct {
 	HookEventName   string `json:"hook_event_name"`
 	SessionID       string `json:"session_id"`
@@ -23,7 +23,7 @@ type Payload struct {
 	CWD             string `json:"cwd,omitempty"`
 	ParentSessionID string `json:"parent_session_id,omitempty"`
 
-	// before_tool / after_tool fields. ToolInput is the validated argument
+	// pre_tool / post_tool fields. ToolInput is the validated argument
 	// object; ToolError is the failure detail (string or object) populated
 	// on a non-success status.
 	ToolNameValue   string          `json:"tool_name,omitempty"`
@@ -34,10 +34,10 @@ type Payload struct {
 	DurationMsValue *float64        `json:"duration_ms,omitempty"`
 }
 
-// ToolName returns the tool a before_tool/after_tool event refers to.
+// ToolName returns the tool a pre_tool/post_tool event refers to.
 func (p Payload) ToolName() string { return strings.TrimSpace(p.ToolNameValue) }
 
-// ToolCallID correlates the tool call across before_tool, after_tool, and the
+// ToolCallID correlates the tool call across pre_tool, post_tool, and the
 // transcript so spans and events line up.
 func (p Payload) ToolCallID() string { return strings.TrimSpace(p.ToolCallIDValue) }
 
@@ -50,11 +50,11 @@ func (p Payload) ToolInput() json.RawMessage {
 	return p.ToolInputValue
 }
 
-// ToolStatus is vibe's after_tool outcome: "success", "failure", or
+// ToolStatus is vibe's post_tool outcome: "success", "failure", or
 // "cancelled".
 func (p Payload) ToolStatus() string { return strings.TrimSpace(p.ToolStatusValue) }
 
-// DurationMs is the measured tool-body duration from after_tool, or 0 when
+// DurationMs is the measured tool-body duration from post_tool, or 0 when
 // absent.
 func (p Payload) DurationMs() float64 {
 	if p.DurationMsValue == nil {
@@ -63,7 +63,7 @@ func (p Payload) DurationMs() float64 {
 	return *p.DurationMsValue
 }
 
-// ToolErrorText renders the after_tool error as a plain string, unwrapping a
+// ToolErrorText renders the post_tool error as a plain string, unwrapping a
 // JSON string and falling back to the raw JSON for object/array errors.
 func (p Payload) ToolErrorText() string {
 	if len(p.ToolErrorValue) == 0 || string(p.ToolErrorValue) == "null" {

--- a/plugins/agento11y/internal/agents/vibe/hook/spans_test.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/spans_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 // TestEmitToolSpans asserts that each assistant tool call becomes one
-// execute_tool span, that an after_tool event drives real duration and an
+// execute_tool span, that a post_tool event drives real duration and an
 // error status, and that a call with no event still produces a span with
 // synthetic (zero-duration) timing.
 func TestEmitToolSpans(t *testing.T) {
@@ -57,7 +57,7 @@ func TestEmitToolSpans(t *testing.T) {
 	events := map[string]toolevents.Event{
 		"tc1": {ToolCallID: "tc1", Status: "success", DurationMs: 1500, CompletedAt: completed},
 		"tc2": {ToolCallID: "tc2", Status: "failure", Error: "boom", DurationMs: 200, CompletedAt: completed},
-		// tc3 intentionally has no after_tool event -> synthetic timing.
+		// tc3 intentionally has no post_tool event -> synthetic timing.
 	}
 
 	genCtx, rec := client.StartGeneration(context.Background(), agento11y.GenerationStart{
@@ -89,7 +89,7 @@ func TestEmitToolSpans(t *testing.T) {
 		t.Fatal("missing execute_tool bash span")
 	}
 	if d := bash.EndTime().Sub(bash.StartTime()); d != 1500*time.Millisecond {
-		t.Errorf("bash span duration = %v, want 1.5s from after_tool duration_ms", d)
+		t.Errorf("bash span duration = %v, want 1.5s from post_tool duration_ms", d)
 	}
 	if bash.Status().Code == codes.Error {
 		t.Error("bash span marked error despite success status")
@@ -100,7 +100,7 @@ func TestEmitToolSpans(t *testing.T) {
 		t.Fatal("missing execute_tool read span")
 	}
 	if read.Status().Code != codes.Error {
-		t.Errorf("read span status = %v, want error from after_tool failure", read.Status().Code)
+		t.Errorf("read span status = %v, want error from post_tool failure", read.Status().Code)
 	}
 
 	grep, ok := toolSpans["grep"]
@@ -108,6 +108,6 @@ func TestEmitToolSpans(t *testing.T) {
 		t.Fatal("missing execute_tool grep span")
 	}
 	if d := grep.EndTime().Sub(grep.StartTime()); d != 0 {
-		t.Errorf("grep span duration = %v, want 0 (synthetic timing without an after_tool event)", d)
+		t.Errorf("grep span duration = %v, want 0 (synthetic timing without a post_tool event)", d)
 	}
 }

--- a/plugins/agento11y/internal/agents/vibe/hook/tool.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/tool.go
@@ -16,25 +16,25 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/otel"
 )
 
-// guardEvalBuffer pads the guard timeout to bound the whole before_tool
+// guardEvalBuffer pads the guard timeout to bound the whole pre_tool
 // handler; the SDK's own timeout (cfg.TimeoutMs) does the real work.
 const guardEvalBuffer = 500 * time.Millisecond
 
-// BeforeTool evaluates a tool call against agento11y guard policy before vibe
+// PreTool evaluates a tool call against agento11y guard policy before vibe
 // runs it. With guards disabled (the default) it is a pass-through that
 // writes nothing, which vibe reads as "allow". A deny writes vibe's
 // structured deny response so the call never runs; a redaction transform
 // writes a tool_input rewrite so vibe runs the redacted arguments. Stdout is
 // the only channel that influences vibe here, so this is the one handler
 // that writes to it.
-func BeforeTool(ctx context.Context, stdout io.Writer, p Payload, logger *log.Logger) {
+func PreTool(ctx context.Context, stdout io.Writer, p Payload, logger *log.Logger) {
 	cfg := envconfig.ResolveGuards(logger)
 	if !cfg.Enabled {
 		return
 	}
 	toolName := p.ToolName()
 	if toolName == "" {
-		logger.Print("before_tool: missing tool_name; allowing")
+		logger.Print("pre_tool: missing tool_name; allowing")
 		return
 	}
 
@@ -56,24 +56,24 @@ func BeforeTool(ctx context.Context, stdout io.Writer, p Payload, logger *log.Lo
 		ModelName:     modelName,
 	}, logger)
 	if res.Blocked() {
-		writeBeforeToolDeny(stdout, res.Reason)
+		writePreToolDeny(stdout, res.Reason)
 		return
 	}
 	if len(res.UpdatedInputJSON) > 0 {
-		writeBeforeToolRewrite(stdout, res.UpdatedInputJSON)
+		writePreToolRewrite(stdout, res.UpdatedInputJSON)
 	}
 }
 
-// AfterTool records a completed tool call's timing and status so the
-// post_agent_turn export can attach them to that tool's execute_tool span.
+// PostTool records a completed tool call's timing and status so the
+// post_agent export can attach them to that tool's execute_tool span.
 // It is skipped when no OTel exporter is configured, because without one the
 // spans are no-ops and the recorded events would never be read.
-func AfterTool(p Payload, logger *log.Logger) {
+func PostTool(p Payload, logger *log.Logger) {
 	if otel.EndpointFromEnv() == "" {
 		return
 	}
 	if p.SessionID == "" || p.ToolCallID() == "" {
-		logger.Print("after_tool: missing session_id or tool_call_id")
+		logger.Print("post_tool: missing session_id or tool_call_id")
 		return
 	}
 	ev := toolevents.Event{
@@ -85,7 +85,7 @@ func AfterTool(p Payload, logger *log.Logger) {
 		CompletedAt: time.Now().UTC(),
 	}
 	if err := toolevents.Save(p.SessionID, ev); err != nil {
-		logger.Printf("after_tool: save tool event: %v", err)
+		logger.Printf("post_tool: save tool event: %v", err)
 	}
 }
 
@@ -108,40 +108,40 @@ func guardModel(p Payload) (provider, modelName string) {
 	return provider, modelName
 }
 
-// beforeToolDeny is vibe's structured deny response: a non-empty stdout
+// preToolDeny is vibe's structured deny response: a non-empty stdout
 // object with decision="deny". vibe surfaces Reason to the model as the
 // blocked-tool error (vibe/core/hooks/models.py HookStructuredResponse).
-type beforeToolDeny struct {
+type preToolDeny struct {
 	Decision string `json:"decision"`
 	Reason   string `json:"reason,omitempty"`
 }
 
-// beforeToolRewrite replaces the tool arguments via hook_specific_output.
+// preToolRewrite replaces the tool arguments via hook_specific_output.
 // decision is omitted (defaults to allow) so the call proceeds with the
 // rewritten input rather than skipping the user's permission prompt.
-type beforeToolRewrite struct {
-	HookSpecificOutput beforeToolRewriteBody `json:"hook_specific_output"`
+type preToolRewrite struct {
+	HookSpecificOutput preToolRewriteBody `json:"hook_specific_output"`
 }
 
-type beforeToolRewriteBody struct {
+type preToolRewriteBody struct {
 	ToolInput json.RawMessage `json:"tool_input"`
 }
 
-func writeBeforeToolDeny(stdout io.Writer, reason string) {
+func writePreToolDeny(stdout io.Writer, reason string) {
 	if stdout == nil {
 		return
 	}
 	if strings.TrimSpace(reason) == "" {
 		reason = "tool call denied by agento11y guard"
 	}
-	_ = json.NewEncoder(stdout).Encode(beforeToolDeny{Decision: "deny", Reason: reason})
+	_ = json.NewEncoder(stdout).Encode(preToolDeny{Decision: "deny", Reason: reason})
 }
 
-func writeBeforeToolRewrite(stdout io.Writer, updatedInput json.RawMessage) {
+func writePreToolRewrite(stdout io.Writer, updatedInput json.RawMessage) {
 	if stdout == nil || len(updatedInput) == 0 {
 		return
 	}
-	_ = json.NewEncoder(stdout).Encode(beforeToolRewrite{
-		HookSpecificOutput: beforeToolRewriteBody{ToolInput: updatedInput},
+	_ = json.NewEncoder(stdout).Encode(preToolRewrite{
+		HookSpecificOutput: preToolRewriteBody{ToolInput: updatedInput},
 	})
 }

--- a/plugins/agento11y/internal/agents/vibe/hook/tool_test.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/tool_test.go
@@ -14,11 +14,11 @@ import (
 
 func discardLogger() *log.Logger { return log.New(io.Discard, "", 0) }
 
-func TestBeforeTool_GuardsDisabledPassesThrough(t *testing.T) {
+func TestPreTool_GuardsDisabledPassesThrough(t *testing.T) {
 	t.Setenv("SIGIL_GUARDS_ENABLED", "false")
 	var out bytes.Buffer
-	BeforeTool(context.Background(), &out, Payload{
-		HookEventName: "before_tool",
+	PreTool(context.Background(), &out, Payload{
+		HookEventName: "pre_tool",
 		SessionID:     "s",
 		ToolNameValue: "bash",
 	}, discardLogger())
@@ -27,7 +27,7 @@ func TestBeforeTool_GuardsDisabledPassesThrough(t *testing.T) {
 	}
 }
 
-func TestBeforeTool_FailClosedDeniesOnMissingCreds(t *testing.T) {
+func TestPreTool_FailClosedDeniesOnMissingCreds(t *testing.T) {
 	t.Setenv("SIGIL_GUARDS_ENABLED", "true")
 	t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "false")
 	t.Setenv("SIGIL_ENDPOINT", "")
@@ -35,8 +35,8 @@ func TestBeforeTool_FailClosedDeniesOnMissingCreds(t *testing.T) {
 	t.Setenv("SIGIL_AUTH_TOKEN", "")
 
 	var out bytes.Buffer
-	BeforeTool(context.Background(), &out, Payload{
-		HookEventName:  "before_tool",
+	PreTool(context.Background(), &out, Payload{
+		HookEventName:  "pre_tool",
 		SessionID:      "s",
 		ToolNameValue:  "bash",
 		ToolInputValue: json.RawMessage(`{"command":"ls"}`),
@@ -57,7 +57,7 @@ func TestBeforeTool_FailClosedDeniesOnMissingCreds(t *testing.T) {
 	}
 }
 
-func TestBeforeTool_FailOpenAllowsOnMissingCreds(t *testing.T) {
+func TestPreTool_FailOpenAllowsOnMissingCreds(t *testing.T) {
 	t.Setenv("SIGIL_GUARDS_ENABLED", "true")
 	t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "true")
 	t.Setenv("SIGIL_ENDPOINT", "")
@@ -65,8 +65,8 @@ func TestBeforeTool_FailOpenAllowsOnMissingCreds(t *testing.T) {
 	t.Setenv("SIGIL_AUTH_TOKEN", "")
 
 	var out bytes.Buffer
-	BeforeTool(context.Background(), &out, Payload{
-		HookEventName: "before_tool",
+	PreTool(context.Background(), &out, Payload{
+		HookEventName: "pre_tool",
 		SessionID:     "s",
 		ToolNameValue: "bash",
 	}, discardLogger())
@@ -75,10 +75,10 @@ func TestBeforeTool_FailOpenAllowsOnMissingCreds(t *testing.T) {
 	}
 }
 
-func TestBeforeToolWriters(t *testing.T) {
+func TestPreToolWriters(t *testing.T) {
 	t.Run("deny", func(t *testing.T) {
 		var out bytes.Buffer
-		writeBeforeToolDeny(&out, "blocked by policy")
+		writePreToolDeny(&out, "blocked by policy")
 		var resp map[string]any
 		if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
 			t.Fatalf("invalid deny JSON: %v", err)
@@ -90,7 +90,7 @@ func TestBeforeToolWriters(t *testing.T) {
 
 	t.Run("deny falls back to a default reason", func(t *testing.T) {
 		var out bytes.Buffer
-		writeBeforeToolDeny(&out, "  ")
+		writePreToolDeny(&out, "  ")
 		if !strings.Contains(out.String(), "denied by agento11y guard") {
 			t.Errorf("missing default reason: %s", out.String())
 		}
@@ -98,7 +98,7 @@ func TestBeforeToolWriters(t *testing.T) {
 
 	t.Run("rewrite", func(t *testing.T) {
 		var out bytes.Buffer
-		writeBeforeToolRewrite(&out, json.RawMessage(`{"command":"ls -la"}`))
+		writePreToolRewrite(&out, json.RawMessage(`{"command":"ls -la"}`))
 		var resp struct {
 			HookSpecificOutput struct {
 				ToolInput json.RawMessage `json:"tool_input"`
@@ -114,19 +114,19 @@ func TestBeforeToolWriters(t *testing.T) {
 
 	t.Run("rewrite with empty input writes nothing", func(t *testing.T) {
 		var out bytes.Buffer
-		writeBeforeToolRewrite(&out, nil)
+		writePreToolRewrite(&out, nil)
 		if out.Len() != 0 {
 			t.Errorf("stdout = %q, want empty for an empty rewrite", out.String())
 		}
 	})
 }
 
-func TestAfterTool_RecordsEventWhenOTelConfigured(t *testing.T) {
+func TestPostTool_RecordsEventWhenOTelConfigured(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318")
 
-	AfterTool(Payload{
-		HookEventName:   "after_tool",
+	PostTool(Payload{
+		HookEventName:   "post_tool",
 		SessionID:       "sess-after",
 		ToolNameValue:   "bash",
 		ToolCallIDValue: "tc-1",
@@ -151,13 +151,13 @@ func TestAfterTool_RecordsEventWhenOTelConfigured(t *testing.T) {
 	}
 }
 
-func TestAfterTool_NoOpWithoutOTel(t *testing.T) {
+func TestPostTool_NoOpWithoutOTel(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 
-	AfterTool(Payload{
-		HookEventName:   "after_tool",
+	PostTool(Payload{
+		HookEventName:   "post_tool",
 		SessionID:       "sess-noop",
 		ToolCallIDValue: "tc-1",
 		ToolStatusValue: "success",

--- a/plugins/agento11y/internal/agents/vibe/install.go
+++ b/plugins/agento11y/internal/agents/vibe/install.go
@@ -32,29 +32,35 @@ type hooksFileEntry struct {
 }
 
 // desiredHooks returns the agento11y-owned [[hooks]] entries vibe runs. Vibe
-// defines exactly three event types and we wire all three: post_agent_turn
-// for the per-turn generation export, before_tool for guard enforcement, and
-// after_tool for per-tool span timing. before_tool/after_tool take a "*"
-// matcher (every tool); match is forbidden on post_agent_turn. Each entry is
-// upserted by its unique name so repeated installs are idempotent and
-// hand-authored hooks in the same file are preserved.
+// defines exactly three event types and we wire all three: post_agent for the
+// per-turn generation export, pre_tool for guard enforcement, and post_tool
+// for per-tool span timing. The two tool hooks take a "*" matcher (every
+// tool); match is forbidden on post_agent. Each entry is upserted by its
+// unique name so repeated installs are idempotent and hand-authored hooks in
+// the same file are preserved.
+//
+// types carries the spelling of those three events. Before vibe 2.21.0 they
+// were post_agent_turn, before_tool, and after_tool. Entry names are the same
+// on both sides of that rename, so an install that crosses it rewrites three
+// types in place rather than adding three entries.
 //
 // command is the shell command vibe runs for each fire, built from this
 // executable's own path so hooks keep working for users who installed only
 // the agento11y (or only the legacy sigil) command.
-func desiredHooks(command string) []hooksFileEntry {
+func desiredHooks(command string, types hookTypeSet) []hooksFileEntry {
 	return []hooksFileEntry{
-		{Name: "agento11y", Type: "post_agent_turn", Command: command, Timeout: hookTimeoutSec},
-		{Name: "agento11y-before-tool", Type: "before_tool", Command: command, Timeout: hookTimeoutSec, Match: "*"},
-		{Name: "agento11y-after-tool", Type: "after_tool", Command: command, Timeout: hookTimeoutSec, Match: "*"},
+		{Name: "agento11y", Type: types.postAgent, Command: command, Timeout: hookTimeoutSec},
+		{Name: "agento11y-before-tool", Type: types.preTool, Command: command, Timeout: hookTimeoutSec, Match: "*"},
+		{Name: "agento11y-after-tool", Type: types.postTool, Command: command, Timeout: hookTimeoutSec, Match: "*"},
 	}
 }
 
 // legacyHookNames maps each agento11y-owned entry name to the pre-rename name
 // an older version wrote. The merge drops legacy entries so a refreshed
 // install does not fire every hook twice (once per name), but HooksInstalled
-// still counts them: they keep capturing until the next launch replaces them,
-// and doctor must not report a working install as broken.
+// still counts one whose type this vibe accepts: it keeps capturing until the
+// next launch replaces it, and doctor must not report a working install as
+// broken.
 var legacyHookNames = map[string]string{
 	"agento11y":             "sigil",
 	"agento11y-before-tool": "sigil-before-tool",
@@ -95,12 +101,17 @@ func hooksFilePath() (string, error) {
 }
 
 // HooksInstalled reports whether every agento11y-owned entry is present in
-// vibe's hooks.toml, under its current or its pre-rename name. It reads the
-// file directly, so `agento11y doctor` can report install state without vibe
-// on PATH. Read-only: it never merges or writes.
+// vibe's hooks.toml, under its current or its pre-rename name, carrying the
+// type the installed vibe accepts. It reads the file directly, so
+// `agento11y doctor` can report install state without vibe on PATH. Read-only:
+// it never merges or writes.
+//
+// The type has to match because vibe validates it against an enum and skips
+// the entry when it does not, so an install spelled for the other side of the
+// 2.21.0 rename captures nothing.
 //
 // A hooks.toml holding only hand-authored hooks does not count as installed.
-func HooksInstalled() (bool, error) {
+func HooksInstalled(types hookTypeSet) (bool, error) {
 	path, err := hooksFilePath()
 	if err != nil {
 		return false, err
@@ -112,23 +123,26 @@ func HooksInstalled() (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("read %s: %w", path, err)
 	}
-	// Only the entry names matter, so decode those and ignore every other key
-	// a hand-authored hook may carry.
+	// Only each entry's name and type matter, so decode those and ignore every
+	// other key a hand-authored hook may carry.
 	var doc struct {
 		Hooks []struct {
 			Name string `toml:"name"`
+			Type string `toml:"type"`
 		} `toml:"hooks"`
 	}
 	if err := toml.Unmarshal(data, &doc); err != nil {
 		return false, fmt.Errorf("parse %s: %w", path, err)
 	}
-	present := map[string]bool{}
+	typeByName := map[string]string{}
 	for _, entry := range doc.Hooks {
-		present[entry.Name] = true
+		typeByName[entry.Name] = entry.Type
 	}
-	for _, want := range desiredHooks("") {
-		legacy := legacyHookNames[want.Name]
-		if present[want.Name] || (legacy != "" && present[legacy]) {
+	for _, want := range desiredHooks("", types) {
+		if typeByName[want.Name] == want.Type {
+			continue
+		}
+		if legacy := legacyHookNames[want.Name]; legacy != "" && typeByName[legacy] == want.Type {
 			continue
 		}
 		return false, nil
@@ -136,15 +150,15 @@ func HooksInstalled() (bool, error) {
 	return true, nil
 }
 
-// ensureHookInstalled merges an agento11y-owned post_agent_turn entry into
-// vibe's hooks.toml. The write is atomic (temp file + rename), idempotent
-// (skipped when the entry already matches), and preserves any
-// hand-authored hooks that share the same file.
+// ensureHookInstalled merges the three agento11y-owned entries into vibe's
+// hooks.toml, spelled for the installed vibe. The write is atomic (temp file +
+// rename), idempotent (skipped when the entries already match), and preserves
+// any hand-authored hooks that share the same file.
 //
 // Returns the path that was inspected (or written) and whether the file
 // was actually changed. A best-effort failure path returns the error so
 // the caller can log it.
-func ensureHookInstalled() (string, bool, error) {
+func ensureHookInstalled(types hookTypeSet) (string, bool, error) {
 	path, err := hooksFilePath()
 	if err != nil {
 		return "", false, err
@@ -158,7 +172,7 @@ func ensureHookInstalled() (string, bool, error) {
 	if err != nil {
 		return path, false, err
 	}
-	updated, changed, err := mergeHooksTOML(existing, command)
+	updated, changed, err := mergeHooksTOML(existing, command, types)
 	if err != nil {
 		return path, false, err
 	}
@@ -206,7 +220,7 @@ func ensureHookInstalled() (string, bool, error) {
 //
 // Unknown top-level keys (vibe may add future settings to hooks.toml)
 // are preserved by round-tripping through a permissive map.
-func mergeHooksTOML(existing []byte, command string) (out []byte, changed bool, err error) {
+func mergeHooksTOML(existing []byte, command string, types hookTypeSet) (out []byte, changed bool, err error) {
 	// Use a permissive map so we keep anything we don't know about.
 	doc := map[string]any{}
 	if len(bytes.TrimSpace(existing)) > 0 {
@@ -217,7 +231,7 @@ func mergeHooksTOML(existing []byte, command string) (out []byte, changed bool, 
 
 	hooks, _ := doc["hooks"].([]any)
 	hooks = dropLegacyHooks(hooks)
-	for _, desired := range desiredHooks(command) {
+	for _, desired := range desiredHooks(command, types) {
 		hooks = upsertHook(hooks, desired)
 	}
 	doc["hooks"] = hooks

--- a/plugins/agento11y/internal/agents/vibe/install_test.go
+++ b/plugins/agento11y/internal/agents/vibe/install_test.go
@@ -20,51 +20,78 @@ func withExecutable(t *testing.T, path string) {
 }
 
 func TestEnsureHookInstalled_FreshWrite(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("VIBE_HOME", dir)
-	withExecutable(t, "/usr/local/bin/agento11y")
-	const wantCommand = "/usr/local/bin/agento11y vibe hook"
+	// The three entry names never change; only the types do, and which set
+	// gets written follows the installed vibe.
+	tests := []struct {
+		name      string
+		types     hookTypeSet
+		wantTypes map[string]string
+	}{
+		{
+			name:  "vibe 2.21.0 and later",
+			types: currentHookTypes,
+			wantTypes: map[string]string{
+				"agento11y":             "post_agent",
+				"agento11y-before-tool": "pre_tool",
+				"agento11y-after-tool":  "post_tool",
+			},
+		},
+		{
+			name:  "before vibe 2.21.0",
+			types: preRenameHookTypes,
+			wantTypes: map[string]string{
+				"agento11y":             "post_agent_turn",
+				"agento11y-before-tool": "before_tool",
+				"agento11y-after-tool":  "after_tool",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("VIBE_HOME", dir)
+			withExecutable(t, "/usr/local/bin/agento11y")
+			const wantCommand = "/usr/local/bin/agento11y vibe hook"
 
-	path, wrote, err := ensureHookInstalled()
-	if err != nil {
-		t.Fatalf("ensureHookInstalled: %v", err)
-	}
-	if !wrote {
-		t.Errorf("wrote = false, want true on fresh install")
-	}
-	if path != filepath.Join(dir, "hooks.toml") {
-		t.Errorf("path = %q, want %q", path, filepath.Join(dir, "hooks.toml"))
-	}
-	got := readTOML(t, path)
-	hooks, _ := got["hooks"].([]any)
-	if len(hooks) != 3 {
-		t.Fatalf("hooks len = %d, want 3 (post_agent_turn + before_tool + after_tool)", len(hooks))
-	}
-	byName := hooksByName(hooks)
-	post, ok := byName["agento11y"]
-	if !ok {
-		t.Fatalf("missing agento11y post_agent_turn entry; got %v", keys(byName))
-	}
-	if post["type"] != "post_agent_turn" {
-		t.Errorf("type = %v, want post_agent_turn", post["type"])
-	}
-	if post["command"] != wantCommand {
-		t.Errorf("command = %v, want %q", post["command"], wantCommand)
-	}
-	for name, wantType := range map[string]string{"agento11y-before-tool": "before_tool", "agento11y-after-tool": "after_tool"} {
-		entry, ok := byName[name]
-		if !ok {
-			t.Fatalf("missing %q entry; got %v", name, keys(byName))
-		}
-		if entry["type"] != wantType {
-			t.Errorf("%s type = %v, want %q", name, entry["type"], wantType)
-		}
-		if entry["command"] != wantCommand {
-			t.Errorf("%s command = %v, want %q", name, entry["command"], wantCommand)
-		}
-		if entry["match"] != "*" {
-			t.Errorf("%s match = %v, want *", name, entry["match"])
-		}
+			path, wrote, err := ensureHookInstalled(tt.types)
+			if err != nil {
+				t.Fatalf("ensureHookInstalled: %v", err)
+			}
+			if !wrote {
+				t.Errorf("wrote = false, want true on fresh install")
+			}
+			if path != filepath.Join(dir, "hooks.toml") {
+				t.Errorf("path = %q, want %q", path, filepath.Join(dir, "hooks.toml"))
+			}
+			got := readTOML(t, path)
+			hooks, _ := got["hooks"].([]any)
+			if len(hooks) != 3 {
+				t.Fatalf("hooks len = %d, want 3 (one per event)", len(hooks))
+			}
+			byName := hooksByName(hooks)
+			for name, wantType := range tt.wantTypes {
+				entry, ok := byName[name]
+				if !ok {
+					t.Fatalf("missing %q entry; got %v", name, keys(byName))
+				}
+				if entry["type"] != wantType {
+					t.Errorf("%s type = %v, want %q", name, entry["type"], wantType)
+				}
+				if entry["command"] != wantCommand {
+					t.Errorf("%s command = %v, want %q", name, entry["command"], wantCommand)
+				}
+			}
+			// match is forbidden on the post-agent hook and required on the two
+			// tool hooks.
+			if _, ok := byName["agento11y"]["match"]; ok {
+				t.Errorf("agento11y carries match = %v, want none", byName["agento11y"]["match"])
+			}
+			for _, name := range []string{"agento11y-before-tool", "agento11y-after-tool"} {
+				if byName[name]["match"] != "*" {
+					t.Errorf("%s match = %v, want *", name, byName[name]["match"])
+				}
+			}
+		})
 	}
 }
 
@@ -72,10 +99,10 @@ func TestEnsureHookInstalled_IdempotentNoOp(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("VIBE_HOME", dir)
 
-	if _, wrote, err := ensureHookInstalled(); err != nil || !wrote {
+	if _, wrote, err := ensureHookInstalled(currentHookTypes); err != nil || !wrote {
 		t.Fatalf("first run: wrote=%v err=%v", wrote, err)
 	}
-	path, wrote, err := ensureHookInstalled()
+	path, wrote, err := ensureHookInstalled(currentHookTypes)
 	if err != nil {
 		t.Fatalf("second run: %v", err)
 	}
@@ -95,7 +122,7 @@ func TestEnsureHookInstalled_PreservesExistingHook(t *testing.T) {
 	// must keep it and add (not replace) the agento11y entry.
 	pre := `[[hooks]]
 name = "user-custom"
-type = "after_tool"
+type = "post_tool"
 command = "/bin/true"
 timeout = 5
 `
@@ -103,7 +130,7 @@ timeout = 5
 	if err := os.WriteFile(path, []byte(pre), 0o644); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	if _, _, err := ensureHookInstalled(); err != nil {
+	if _, _, err := ensureHookInstalled(currentHookTypes); err != nil {
 		t.Fatalf("install: %v", err)
 	}
 	got := readTOML(t, path)
@@ -148,7 +175,7 @@ match = "*"
 	if err := os.WriteFile(path, []byte(pre), 0o644); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	if _, wrote, err := ensureHookInstalled(); err != nil || !wrote {
+	if _, wrote, err := ensureHookInstalled(currentHookTypes); err != nil || !wrote {
 		t.Fatalf("install: wrote=%v err=%v", wrote, err)
 	}
 	got := readTOML(t, path)
@@ -167,12 +194,76 @@ match = "*"
 	}
 }
 
+func TestEnsureHookInstalled_ConvertsTypesInPlace(t *testing.T) {
+	// Entry names are the same on both sides of the 2.21.0 rename, so crossing
+	// it (a vibe upgrade, or a downgrade) must rewrite three types in place
+	// rather than add a second entry per event. Both directions matter: the
+	// launcher writes whatever the vibe on PATH accepts, and that answer can
+	// change under a hooks.toml that already exists.
+	tests := []struct {
+		name  string
+		seed  hookTypeSet
+		into  hookTypeSet
+		want  map[string]string
+		count int
+	}{
+		{
+			name: "pre-rename install on a 2.21.0 or later vibe",
+			seed: preRenameHookTypes,
+			into: currentHookTypes,
+			want: map[string]string{
+				"agento11y":             "post_agent",
+				"agento11y-before-tool": "pre_tool",
+				"agento11y-after-tool":  "post_tool",
+			},
+		},
+		{
+			name: "current install on a pre-2.21.0 vibe",
+			seed: currentHookTypes,
+			into: preRenameHookTypes,
+			want: map[string]string{
+				"agento11y":             "post_agent_turn",
+				"agento11y-before-tool": "before_tool",
+				"agento11y-after-tool":  "after_tool",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("VIBE_HOME", dir)
+			seeded, _, err := mergeHooksTOML(nil, "agento11y vibe hook", tt.seed)
+			if err != nil {
+				t.Fatalf("render seed: %v", err)
+			}
+			path := filepath.Join(dir, "hooks.toml")
+			if err := os.WriteFile(path, seeded, 0o644); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			if _, wrote, err := ensureHookInstalled(tt.into); err != nil || !wrote {
+				t.Fatalf("install: wrote=%v err=%v", wrote, err)
+			}
+			got := readTOML(t, path)
+			hooks, _ := got["hooks"].([]any)
+			if len(hooks) != 3 {
+				t.Fatalf("hooks len = %d, want 3 (types converted in place); got %v", len(hooks), hooks)
+			}
+			byName := hooksByName(hooks)
+			for name, wantType := range tt.want {
+				if byName[name]["type"] != wantType {
+					t.Errorf("%s type = %v, want %q", name, byName[name]["type"], wantType)
+				}
+			}
+		})
+	}
+}
+
 func TestEnsureHookInstalled_QuotesExecutablePath(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("VIBE_HOME", dir)
 	withExecutable(t, "/Users/Jane Doe/bin/agento11y")
 
-	path, _, err := ensureHookInstalled()
+	path, _, err := ensureHookInstalled(currentHookTypes)
 	if err != nil {
 		t.Fatalf("ensureHookInstalled: %v", err)
 	}
@@ -192,39 +283,53 @@ func TestHooksInstalled(t *testing.T) {
 	entry := func(name, typ string) string {
 		return entryCmd(name, typ, "agento11y vibe hook")
 	}
-	all := entry("agento11y", "post_agent_turn") +
+	all := entry("agento11y", "post_agent") +
+		entry("agento11y-before-tool", "pre_tool") +
+		entry("agento11y-after-tool", "post_tool")
+	allPreRename := entry("agento11y", "post_agent_turn") +
 		entry("agento11y-before-tool", "before_tool") +
 		entry("agento11y-after-tool", "after_tool")
+	// Every binary that wrote the sigil names also wrote the pre-2.21.0 types.
 	allLegacy := entryCmd("sigil", "post_agent_turn", "sigil vibe hook") +
 		entryCmd("sigil-before-tool", "before_tool", "sigil vibe hook") +
 		entryCmd("sigil-after-tool", "after_tool", "sigil vibe hook")
-	staleCommand := entryCmd("agento11y", "post_agent_turn", "/old/path/agento11y vibe hook") +
-		entryCmd("agento11y-before-tool", "before_tool", "/old/path/agento11y vibe hook") +
-		entryCmd("agento11y-after-tool", "after_tool", "/old/path/agento11y vibe hook")
-	userHook := entry("user-custom", "after_tool")
+	staleCommand := entryCmd("agento11y", "post_agent", "/old/path/agento11y vibe hook") +
+		entryCmd("agento11y-before-tool", "pre_tool", "/old/path/agento11y vibe hook") +
+		entryCmd("agento11y-after-tool", "post_tool", "/old/path/agento11y vibe hook")
+	userHook := entry("user-custom", "post_tool")
 
+	// types is the set the installed vibe accepts. An entry carrying the other
+	// set is skipped by vibe at load, so it does not count as installed no
+	// matter which name it goes under.
 	tests := []struct {
 		name    string
 		file    string
+		types   hookTypeSet
 		write   bool // false leaves hooks.toml absent
 		want    bool
 		wantErr bool
 	}{
-		{name: "all entries present", file: all, write: true, want: true},
-		{name: "all entries plus hand-authored hook", file: userHook + all, write: true, want: true},
-		// Legacy sigil-named entries keep firing until the next launch
-		// rewrites them, so they count as installed.
-		{name: "legacy entry names", file: allLegacy, write: true, want: true},
-		{name: "current and legacy names mixed", file: entry("agento11y", "post_agent_turn") + entryCmd("sigil-before-tool", "before_tool", "sigil vibe hook") + entry("agento11y-after-tool", "after_tool"), write: true, want: true},
-		{name: "legacy entries with one missing", file: entryCmd("sigil", "post_agent_turn", "sigil vibe hook") + entryCmd("sigil-before-tool", "before_tool", "sigil vibe hook"), write: true},
+		{name: "all entries present", file: all, types: currentHookTypes, write: true, want: true},
+		{name: "all entries plus hand-authored hook", file: userHook + all, types: currentHookTypes, write: true, want: true},
 		// The command is never compared: an install written by a binary at a
 		// different path still fires.
-		{name: "stale command", file: staleCommand, write: true, want: true},
-		{name: "one entry missing", file: entry("agento11y", "post_agent_turn") + entry("agento11y-before-tool", "before_tool"), write: true},
-		{name: "only hand-authored hooks", file: userHook, write: true},
-		{name: "empty file", file: "", write: true},
-		{name: "no file"},
-		{name: "invalid toml", file: "[[hooks]\nname =", write: true, wantErr: true},
+		{name: "stale command", file: staleCommand, types: currentHookTypes, write: true, want: true},
+		{name: "one entry missing", file: entry("agento11y", "post_agent") + entry("agento11y-before-tool", "pre_tool"), types: currentHookTypes, write: true},
+		{name: "pre-2.21.0 type under a current name", file: entry("agento11y", "post_agent_turn") + entry("agento11y-before-tool", "pre_tool") + entry("agento11y-after-tool", "post_tool"), types: currentHookTypes, write: true},
+		{name: "pre-2.21.0 types on a current vibe", file: allPreRename, types: currentHookTypes, write: true},
+		{name: "pre-2.21.0 types on a pre-2.21.0 vibe", file: allPreRename, types: preRenameHookTypes, write: true, want: true},
+		{name: "current types on a pre-2.21.0 vibe", file: all, types: preRenameHookTypes, write: true},
+		// A sigil-era install still captures on the vibe it was written for, and
+		// doctor must not call that broken. It survives only until the next
+		// launch, which replaces it with the agento11y-named entries.
+		{name: "legacy names and types on a pre-2.21.0 vibe", file: allLegacy, types: preRenameHookTypes, write: true, want: true},
+		{name: "legacy names and types on a current vibe", file: allLegacy, types: currentHookTypes, write: true},
+		{name: "legacy names with one missing", file: entryCmd("sigil", "post_agent_turn", "sigil vibe hook") + entryCmd("sigil-before-tool", "before_tool", "sigil vibe hook"), types: preRenameHookTypes, write: true},
+		{name: "current and legacy names mixed", file: entry("agento11y", "post_agent_turn") + entryCmd("sigil-before-tool", "before_tool", "sigil vibe hook") + entry("agento11y-after-tool", "after_tool"), types: preRenameHookTypes, write: true, want: true},
+		{name: "only hand-authored hooks", file: userHook, types: currentHookTypes, write: true},
+		{name: "empty file", file: "", types: currentHookTypes, write: true},
+		{name: "no file", types: currentHookTypes},
+		{name: "invalid toml", file: "[[hooks]\nname =", types: currentHookTypes, write: true, wantErr: true},
 	}
 
 	for _, tt := range tests {
@@ -236,7 +341,7 @@ func TestHooksInstalled(t *testing.T) {
 					t.Fatalf("seed: %v", err)
 				}
 			}
-			got, err := HooksInstalled()
+			got, err := HooksInstalled(tt.types)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("HooksInstalled() error = nil, want non-nil")
@@ -252,20 +357,27 @@ func TestHooksInstalled(t *testing.T) {
 }
 
 // TestHooksInstalled_AfterInstall pins the probe to the writer: whatever
-// ensureHookInstalled writes must read back as installed.
+// ensureHookInstalled writes must read back as installed, for either vibe.
 func TestHooksInstalled_AfterInstall(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("VIBE_HOME", dir)
+	for name, types := range map[string]hookTypeSet{
+		"vibe 2.21.0 and later": currentHookTypes,
+		"before vibe 2.21.0":    preRenameHookTypes,
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("VIBE_HOME", dir)
 
-	if _, _, err := ensureHookInstalled(); err != nil {
-		t.Fatalf("ensureHookInstalled: %v", err)
-	}
-	got, err := HooksInstalled()
-	if err != nil {
-		t.Fatalf("HooksInstalled() after install: %v", err)
-	}
-	if !got {
-		t.Errorf("HooksInstalled() = false after install, want true")
+			if _, _, err := ensureHookInstalled(types); err != nil {
+				t.Fatalf("ensureHookInstalled: %v", err)
+			}
+			got, err := HooksInstalled(types)
+			if err != nil {
+				t.Fatalf("HooksInstalled() after install: %v", err)
+			}
+			if !got {
+				t.Errorf("HooksInstalled() = false after install, want true")
+			}
+		})
 	}
 }
 

--- a/plugins/agento11y/internal/agents/vibe/launch.go
+++ b/plugins/agento11y/internal/agents/vibe/launch.go
@@ -17,26 +17,32 @@ var (
 	execFn   = syscall.Exec
 )
 
-// Launch resolves the `vibe` binary on PATH, ensures the agento11y-owned
-// post_agent_turn hook is installed into vibe's hooks.toml, and then
-// execs vibe with the supplied args.
+// Launch resolves the `vibe` binary on PATH, ensures the three agento11y-owned
+// hook entries are installed in vibe's hooks.toml, and then execs vibe with
+// the supplied args.
 //
-// VIBE_ENABLE_EXPERIMENTAL_HOOKS=true is injected into the child env so
-// vibe loads hooks.toml even on builds where the
-// enable_experimental_hooks setting is still gated. Vibe uses
+// The entries are spelled for the installed vibe, which the install path reads
+// from `vibe --version`, because 2.21.0 renamed all three hook types.
+//
+// VIBE_ENABLE_EXPERIMENTAL_HOOKS=true is injected into the child env because a
+// pre-2.21.0 vibe loads hooks.toml only behind that flag. Vibe uses
 // pydantic-settings with env_prefix="VIBE_", so the env override is
-// recognised without further config.toml editing.
+// recognised without further config.toml editing. 2.21.0 removed the flag
+// along with the gate, and its env layer ignores unknown VIBE_ variables, so
+// setting it is inert there rather than an error. It stays unconditional: a
+// version probe that fails guesses current, and dropping the flag on a
+// mis-detected old vibe would turn hooks off entirely.
 //
 // When localEnv is non-nil, the child receives local-mode SIGIL_ENDPOINT,
 // SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT and placeholder auth values so it
 // talks to the in-process receiver instead of Grafana Cloud.
-func Launch(_ context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, _ string) error {
+func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.Reader, _, stderr io.Writer, logger *log.Logger, _ string) error {
 	bin, err := lookPath("vibe")
 	if err != nil {
 		return fmt.Errorf("vibe CLI not found on PATH: %w", err)
 	}
 
-	installHook(stderr, logger)
+	installHook(ctx, stderr, logger)
 
 	env := envWithExperimentalHooks(local.Environ(localEnv))
 	argv := append([]string{bin}, args...)
@@ -48,20 +54,21 @@ func Launch(_ context.Context, args []string, localEnv *local.LaunchEnv, _ io.Re
 
 // Status reports whether agento11y capture is configured for vibe. Capture is
 // driven by the agento11y-owned entries the launcher merges into vibe's
-// hooks.toml, so doctor checks for those. The hooks file carries no version,
-// so version is always empty. It never installs, updates, or removes
-// anything — `agento11y doctor` relies on this.
-func Status(_ context.Context) (installed bool, version string, err error) {
-	installed, err = HooksInstalled()
+// hooks.toml, so doctor checks for those, spelled for the installed vibe. The
+// reported version stays empty: the column holds the plugin version for every
+// other agent, and vibe capture ships inside this binary. It never installs,
+// updates, or removes anything — `agento11y doctor` relies on this.
+func Status(ctx context.Context) (installed bool, version string, err error) {
+	installed, err = HooksInstalled(hookTypesFor(ctx, nil))
 	return installed, "", err
 }
 
-// installHook upserts the sigil entry into hooks.toml and reports the
+// installHook upserts the agento11y entries into hooks.toml and reports the
 // outcome on stderr. Failures are logged but never block the launch:
 // the user explicitly asked to run vibe, so an agento11y install hiccup must
 // not gate that.
-func installHook(stderr io.Writer, logger *log.Logger) {
-	path, wrote, err := ensureHookInstalled()
+func installHook(ctx context.Context, stderr io.Writer, logger *log.Logger) {
+	path, wrote, err := ensureHookInstalled(hookTypesFor(ctx, logger))
 	if err != nil {
 		logger.Printf("install vibe hook: %v", err)
 		_, _ = fmt.Fprintf(stderr, "agento11y: could not install vibe hook (%v); continuing without capture\n", err)
@@ -74,7 +81,7 @@ func installHook(stderr io.Writer, logger *log.Logger) {
 
 // envWithExperimentalHooks returns env with VIBE_ENABLE_EXPERIMENTAL_HOOKS
 // forced to "true". Any existing value is replaced so a stale "false" in
-// the user's shell does not silently disable our hook.
+// the user's shell does not silently disable our hook on a pre-2.21.0 vibe.
 func envWithExperimentalHooks(env []string) []string {
 	const key = "VIBE_ENABLE_EXPERIMENTAL_HOOKS"
 	const want = "true"

--- a/plugins/agento11y/internal/agents/vibe/launch_test.go
+++ b/plugins/agento11y/internal/agents/vibe/launch_test.go
@@ -82,18 +82,28 @@ func TestStatus(t *testing.T) {
 	hook := func(name, typ string) string {
 		return "[[hooks]]\nname = \"" + name + "\"\ntype = \"" + typ + "\"\ncommand = \"agento11y vibe hook\"\ntimeout = 30\n\n"
 	}
-	all := hook("agento11y", "post_agent_turn") +
+	all := hook("agento11y", "post_agent") +
+		hook("agento11y-before-tool", "pre_tool") +
+		hook("agento11y-after-tool", "post_tool")
+	allPreRename := hook("agento11y", "post_agent_turn") +
 		hook("agento11y-before-tool", "before_tool") +
 		hook("agento11y-after-tool", "after_tool")
 
+	// Status answers for the installed vibe, so the same file reads differently
+	// either side of the 2.21.0 rename. vibeVersion is pinned in every case:
+	// otherwise the answer would depend on the vibe on the developer's PATH.
 	tests := []struct {
 		name          string
 		hooksFile     string
+		vibeVersion   string
 		wantInstalled bool
 	}{
-		{name: "all hooks present", hooksFile: all, wantInstalled: true},
-		{name: "hooks file absent"},
-		{name: "hooks file without agento11y entries", hooksFile: hook("user-custom", "after_tool")},
+		{name: "all hooks present", hooksFile: all, vibeVersion: "vibe 2.24.2", wantInstalled: true},
+		{name: "pre-rename hooks on a pre-2.21.0 vibe", hooksFile: allPreRename, vibeVersion: "vibe 2.20.0", wantInstalled: true},
+		{name: "pre-rename hooks on a current vibe", hooksFile: allPreRename, vibeVersion: "vibe 2.24.2"},
+		{name: "current hooks on a pre-2.21.0 vibe", hooksFile: all, vibeVersion: "vibe 2.20.0"},
+		{name: "hooks file absent", vibeVersion: "vibe 2.24.2"},
+		{name: "hooks file without agento11y entries", hooksFile: hook("user-custom", "post_tool"), vibeVersion: "vibe 2.24.2"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -104,6 +114,7 @@ func TestStatus(t *testing.T) {
 					t.Fatalf("seed: %v", err)
 				}
 			}
+			withVibeVersion(t, tt.vibeVersion)
 
 			installed, version, err := Status(context.Background())
 			if err != nil {
@@ -125,6 +136,7 @@ func TestStatus_ReportsUnreadableConfig(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "hooks.toml"), []byte("[[hooks]\nname ="), 0o644); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
+	withVibeVersion(t, "vibe 2.24.2")
 
 	installed, _, err := Status(context.Background())
 	if err == nil {
@@ -158,4 +170,14 @@ func TestEnvWithExperimentalHooks_AppendsWhenMissing(t *testing.T) {
 
 func hasEnv(env []string, want string) bool {
 	return slices.Contains(env, want)
+}
+
+// withVibeVersion pins what `vibe --version` reports, so a test's expectation
+// does not depend on the vibe installed on the machine running it.
+func withVibeVersion(t *testing.T, out string) {
+	t.Helper()
+	origLookPath, origOutput := lookPath, vibeVersionOutput
+	t.Cleanup(func() { lookPath, vibeVersionOutput = origLookPath, origOutput })
+	lookPath = func(string) (string, error) { return "/fake/vibe", nil }
+	vibeVersionOutput = func(context.Context, string) ([]byte, error) { return []byte(out), nil }
 }

--- a/plugins/agento11y/internal/agents/vibe/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/vibe/mapper/mapper.go
@@ -2,7 +2,7 @@
 // session's meta.json into an agento11y.Generation ready for export.
 //
 // One mapper.Map call produces exactly one generation per
-// post_agent_turn hook fire. agento11y groups records by ConversationID
+// post_agent hook fire. agento11y groups records by ConversationID
 // (= vibe session_id), so multi-turn sessions get one generation per
 // turn under the same conversation.
 package mapper
@@ -81,7 +81,7 @@ type Mapped struct {
 
 // Map converts the new transcript slice plus meta.json into a single
 // generation. The caller chooses the turn sequence (typically the
-// number of post_agent_turn calls observed for this session) so the
+// number of post_agent calls observed for this session) so the
 // generation ID stays deterministic across re-runs.
 func Map(in Inputs, turnSeq int) Mapped {
 	now := in.Now

--- a/plugins/agento11y/internal/agents/vibe/meta/meta.go
+++ b/plugins/agento11y/internal/agents/vibe/meta/meta.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 )
 
 // Meta is the subset of meta.json fields the vibe agent adapter consumes.
@@ -60,11 +62,57 @@ type Stats struct {
 // matching entry in Models carries the API id ("mistral-vibe-cli-latest")
 // and provider ("mistral").
 type Config struct {
-	ActiveModel string        `json:"active_model"`
-	Models      []ModelConfig `json:"models,omitempty"`
+	ActiveModel string       `json:"active_model"`
+	Models      ModelConfigs `json:"models,omitempty"`
 }
 
-// ModelConfig is one entry of config.models[]. Alias matches ActiveModel.
+// ModelConfigs is meta.json's config.models. Vibe wrote a JSON array of model
+// tables until 2.21.0 and an alias-keyed object from 2.21.0 on (models:
+// dict[str, ModelConfig] in vibe/core/config/vibe_schema.py). Both decode into
+// the same slice, so ActiveModelRef has one shape to search. The array shape
+// still turns up because vibe rewrites meta.json only on save, so a session
+// started under an older vibe keeps its array until the first save.
+type ModelConfigs []ModelConfig
+
+// UnmarshalJSON decodes either shape. A value in neither shape (a string, a
+// number, an object of something other than model tables) decodes to no models
+// instead of an error: models only feeds ActiveModelRef, which falls back to
+// the alias, and an error here would stop the whole turn export. A malformed
+// element inside an array still errors.
+func (m *ModelConfigs) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*m = nil
+		return nil
+	}
+	if strings.HasPrefix(string(data), "[") {
+		var list []ModelConfig
+		if err := json.Unmarshal(data, &list); err != nil {
+			return err
+		}
+		*m = list
+		return nil
+	}
+	byAlias := map[string]ModelConfig{}
+	if err := json.Unmarshal(data, &byAlias); err != nil {
+		*m = nil
+		return nil
+	}
+	out := make(ModelConfigs, 0, len(byAlias))
+	for alias, mc := range byAlias {
+		// Vibe resolves active_model against the key, and raises when the key
+		// and the inner alias disagree (normalize_model_configs in
+		// vibe/core/config/vibe_schema.py), so the key wins here too.
+		mc.Alias = alias
+		out = append(out, mc)
+	}
+	// Sorted so iteration order does not depend on map order. Aliases come
+	// from the map keys, so no two entries tie.
+	slices.SortFunc(out, func(a, b ModelConfig) int { return strings.Compare(a.Alias, b.Alias) })
+	*m = out
+	return nil
+}
+
+// ModelConfig is one entry of config.models. Alias matches ActiveModel.
 type ModelConfig struct {
 	Name     string `json:"name"`
 	Provider string `json:"provider"`

--- a/plugins/agento11y/internal/agents/vibe/meta/meta_test.go
+++ b/plugins/agento11y/internal/agents/vibe/meta/meta_test.go
@@ -1,6 +1,7 @@
 package meta
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -46,6 +47,70 @@ func TestLoad(t *testing.T) {
 	}
 	if m.SystemPrompt.Content == "" {
 		t.Errorf("SystemPrompt.Content is empty")
+	}
+}
+
+func TestLoad_ModelsShapes(t *testing.T) {
+	// Vibe writes config.models as an alias-keyed object from 2.21.0 on and
+	// as an array before that. Both have to resolve the same model.
+	tests := []struct {
+		name    string
+		models  string
+		wantAPI string
+	}{
+		{
+			name:    "object keyed by alias",
+			models:  `{"mistral-medium-3.5": {"name": "mistral-vibe-cli-latest", "provider": "mistral", "alias": "mistral-medium-3.5"}}`,
+			wantAPI: "mistral-vibe-cli-latest",
+		},
+		{
+			name:    "array of model tables",
+			models:  `[{"name": "mistral-vibe-cli-latest", "provider": "mistral", "alias": "mistral-medium-3.5"}]`,
+			wantAPI: "mistral-vibe-cli-latest",
+		},
+		{
+			name:    "object value omitting its inner alias",
+			models:  `{"mistral-medium-3.5": {"name": "mistral-vibe-cli-latest", "provider": "mistral"}}`,
+			wantAPI: "mistral-vibe-cli-latest",
+		},
+		{
+			name:    "object value whose inner alias disagrees with its key",
+			models:  `{"mistral-medium-3.5": {"name": "mistral-vibe-cli-latest", "provider": "mistral", "alias": "something-else"}}`,
+			wantAPI: "mistral-vibe-cli-latest",
+		},
+		{
+			// Neither shape: the lookup falls back to the alias rather than
+			// failing the load, which would drop the turn export.
+			name:    "out-of-contract value",
+			models:  `"mistral-vibe-cli-latest"`,
+			wantAPI: "mistral-medium-3.5",
+		},
+		{
+			// No table to search, so the alias is the best answer.
+			name:    "absent",
+			models:  `null`,
+			wantAPI: "mistral-medium-3.5",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			body := `{"session_id":"s1","config":{"active_model":"mistral-medium-3.5","models":` + tc.models + `}}`
+			if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			m, err := Load(filepath.Join(dir, "messages.jsonl"))
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			provider, api := m.ActiveModelRef()
+			if provider != "mistral" {
+				t.Errorf("provider = %q, want mistral", provider)
+			}
+			if api != tc.wantAPI {
+				t.Errorf("api id = %q, want %q", api, tc.wantAPI)
+			}
+		})
 	}
 }
 

--- a/plugins/agento11y/internal/agents/vibe/state/state.go
+++ b/plugins/agento11y/internal/agents/vibe/state/state.go
@@ -15,7 +15,7 @@ import (
 // Session holds the persisted state for a single vibe session.
 //
 // Offset tracks how far into messages.jsonl we have already exported, so
-// subsequent post_agent_turn hooks only read new lines.
+// subsequent post_agent hooks only read new lines.
 //
 // SessionPromptTokens / SessionCompletionTokens / SessionCost and the
 // ToolCalls* counters record the meta.json session-wide totals at the time

--- a/plugins/agento11y/internal/agents/vibe/toolevents/toolevents.go
+++ b/plugins/agento11y/internal/agents/vibe/toolevents/toolevents.go
@@ -1,10 +1,10 @@
 // Package toolevents persists per-tool-call outcomes between vibe's
-// after_tool hook fires and the post_agent_turn export.
+// post_tool hook fires and the post_agent export.
 //
 // Vibe runs the tool calls within a turn concurrently, so multiple
-// after_tool hooks can fire at once. Each writes its own file named by the
+// post_tool hooks can fire at once. Each writes its own file named by the
 // (sanitized) tool_call_id, so two concurrent fires never touch the same
-// file and no lock is needed. The post_agent_turn handler loads the events
+// file and no lock is needed. The post_agent handler loads the events
 // for the session to give each execute_tool span real timing and an error
 // status, then clears them so they do not leak into the next turn.
 package toolevents
@@ -21,8 +21,8 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/xdg"
 )
 
-// Event is one tool call's recorded outcome, taken from the after_tool hook
-// payload. CompletedAt is stamped when the event is saved (after_tool fires
+// Event is one tool call's recorded outcome, taken from the post_tool hook
+// payload. CompletedAt is stamped when the event is saved (post_tool fires
 // right after the tool body returns), so it is a close stand-in for the real
 // completion time. DurationMs is vibe's measured tool-body duration.
 type Event struct {

--- a/plugins/agento11y/internal/agents/vibe/version.go
+++ b/plugins/agento11y/internal/agents/vibe/version.go
@@ -1,0 +1,113 @@
+package vibe
+
+import (
+	"context"
+	"log"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/launcher"
+)
+
+// hookTypeSet is the `type` name vibe accepts for each of the three events it
+// fires. Vibe 2.21.0 renamed all three at once, and the name is validated
+// against an enum (HookType in vibe/core/hooks/models.py), so an entry
+// spelled for the other generation is rejected. Which set to write is
+// therefore a function of the installed vibe.
+type hookTypeSet struct {
+	postAgent string
+	preTool   string
+	postTool  string
+}
+
+var (
+	// currentHookTypes is what vibe 2.21.0 and later accept.
+	currentHookTypes = hookTypeSet{postAgent: "post_agent", preTool: "pre_tool", postTool: "post_tool"}
+	// preRenameHookTypes is what vibe accepted before 2.21.0, while hooks were
+	// still experimental.
+	preRenameHookTypes = hookTypeSet{postAgent: "post_agent_turn", preTool: "before_tool", postTool: "after_tool"}
+)
+
+// renameMajor and renameMinor are the first vibe release carrying
+// currentHookTypes.
+const (
+	renameMajor = 2
+	renameMinor = 21
+)
+
+// versionProbeTimeout caps the `vibe --version` call. Vibe answers it from
+// argparse, before it imports its config stack, but a frozen build still pays
+// its own bootstrap first, so the budget covers a cold start rather than the
+// warm case. The probe sits in front of an exec the user is waiting on, so it
+// cannot be unbounded either. On timeout the caller writes current-generation
+// types, which a pre-2.21.0 vibe then rejects with a warning per entry; the
+// next launch usually gets a warm answer and repairs the file.
+const versionProbeTimeout = 5 * time.Second
+
+// vibeVersionRE matches the major.minor of `vibe --version` output, which
+// argparse renders as "<prog> <version>". A suffix (2.21.0rc1, 2.21.0.dev0)
+// is left to the caller: only major.minor decides the type set.
+var vibeVersionRE = regexp.MustCompile(`([0-9]+)\.([0-9]+)`)
+
+// Test seam.
+var vibeVersionOutput = func(ctx context.Context, bin string) ([]byte, error) {
+	return launcher.Output(ctx, bin, "--version")
+}
+
+// hookTypesFor reports the type set the vibe on PATH accepts.
+//
+// Every failure path returns currentHookTypes: no vibe on PATH (doctor runs
+// without it), a probe that errors or times out, or output we cannot parse.
+// Guessing current is the safer default, because a pre-2.21.0 vibe also needs
+// VIBE_ENABLE_EXPERIMENTAL_HOOKS, so its users had to opt in explicitly and
+// are the rarer case.
+func hookTypesFor(ctx context.Context, logger *log.Logger) hookTypeSet {
+	bin, err := lookPath("vibe")
+	if err != nil {
+		return currentHookTypes
+	}
+	ctx, cancel := context.WithTimeout(ctx, versionProbeTimeout)
+	defer cancel()
+	out, err := vibeVersionOutput(ctx, bin)
+	if err != nil {
+		logf(logger, "vibe --version: %v", err)
+		return currentHookTypes
+	}
+	types, ok := hookTypesForVersion(string(out))
+	if !ok {
+		logf(logger, "vibe --version: cannot parse %q", string(out))
+	}
+	return types
+}
+
+// hookTypesForVersion maps `vibe --version` output to a type set. ok is false
+// when the output carries no recognizable version, in which case the caller
+// gets currentHookTypes and something to log.
+func hookTypesForVersion(out string) (types hookTypeSet, ok bool) {
+	m := vibeVersionRE.FindStringSubmatch(out)
+	if m == nil {
+		return currentHookTypes, false
+	}
+	major, err := strconv.Atoi(m[1])
+	if err != nil {
+		return currentHookTypes, false
+	}
+	minor, err := strconv.Atoi(m[2])
+	if err != nil {
+		return currentHookTypes, false
+	}
+	if major < renameMajor || (major == renameMajor && minor < renameMinor) {
+		return preRenameHookTypes, true
+	}
+	return currentHookTypes, true
+}
+
+// logf writes to logger when the caller has one. Status has no logger, so the
+// version probe has to tolerate a nil one.
+func logf(logger *log.Logger, format string, args ...any) {
+	if logger == nil {
+		return
+	}
+	logger.Printf(format, args...)
+}

--- a/plugins/agento11y/internal/agents/vibe/version_test.go
+++ b/plugins/agento11y/internal/agents/vibe/version_test.go
@@ -1,0 +1,114 @@
+package vibe
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log"
+	"strings"
+	"testing"
+)
+
+func TestHookTypesForVersion(t *testing.T) {
+	// Real `vibe --version` output is "<prog> <version>". Anything we cannot
+	// read a major.minor out of reports ok=false and falls back to the current
+	// set, which the caller logs.
+	tests := []struct {
+		name   string
+		out    string
+		want   hookTypeSet
+		wantOK bool
+	}{
+		{name: "the release that renamed the types", out: "vibe 2.21.0\n", want: currentHookTypes, wantOK: true},
+		{name: "later release", out: "vibe 2.24.2\n", want: currentHookTypes, wantOK: true},
+		{name: "next major", out: "vibe 3.0.0\n", want: currentHookTypes, wantOK: true},
+		{name: "last release before the rename", out: "vibe 2.20.0\n", want: preRenameHookTypes, wantOK: true},
+		{name: "older minor", out: "vibe 2.15.0\n", want: preRenameHookTypes, wantOK: true},
+		{name: "older major", out: "vibe 1.3.5\n", want: preRenameHookTypes, wantOK: true},
+		// Only major.minor is compared, so a suffix rides along. A 2.21
+		// pre-release is treated as renamed: it is closer to 2.21.0 than to
+		// 2.20.x, and guessing current is the documented fallback anyway.
+		{name: "pre-release of the rename", out: "vibe 2.21.0rc1\n", want: currentHookTypes, wantOK: true},
+		{name: "dev build before the rename", out: "vibe 2.20.1.dev0+g1234abc\n", want: preRenameHookTypes, wantOK: true},
+		// argparse prints the executable's own name, which is not always
+		// "vibe".
+		{name: "renamed executable", out: "vibe-acp 2.20.0\n", want: preRenameHookTypes, wantOK: true},
+		{name: "no version in output", out: "vibe\n", want: currentHookTypes},
+		{name: "major only", out: "vibe 2\n", want: currentHookTypes},
+		{name: "empty output", out: "", want: currentHookTypes},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := hookTypesForVersion(tt.out)
+			if got != tt.want {
+				t.Errorf("types = %+v, want %+v", got, tt.want)
+			}
+			if ok != tt.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestHookTypesFor(t *testing.T) {
+	// Every path that cannot answer has to land on the current types, because
+	// a pre-2.21.0 vibe is the rarer case: its hooks also needed
+	// VIBE_ENABLE_EXPERIMENTAL_HOOKS, so its users opted in by hand.
+	tests := []struct {
+		name    string
+		onPath  bool
+		out     string
+		err     error
+		want    hookTypeSet
+		wantLog string
+	}{
+		{name: "reads the installed version", onPath: true, out: "vibe 2.20.0\n", want: preRenameHookTypes},
+		{name: "reads a current version", onPath: true, out: "vibe 2.24.2\n", want: currentHookTypes},
+		// doctor probes install state with no vibe installed at all.
+		{name: "vibe not on PATH", want: currentHookTypes},
+		{name: "probe fails", onPath: true, err: errors.New("exit status 1"), want: currentHookTypes, wantLog: "exit status 1"},
+		{name: "unparsable output", onPath: true, out: "vibe (unknown)\n", want: currentHookTypes, wantLog: "cannot parse"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origLookPath, origOutput := lookPath, vibeVersionOutput
+			t.Cleanup(func() { lookPath, vibeVersionOutput = origLookPath, origOutput })
+			lookPath = func(string) (string, error) {
+				if !tt.onPath {
+					return "", errors.New("not found")
+				}
+				return "/fake/vibe", nil
+			}
+			vibeVersionOutput = func(context.Context, string) ([]byte, error) {
+				return []byte(tt.out), tt.err
+			}
+
+			var logged bytes.Buffer
+			got := hookTypesFor(context.Background(), log.New(&logged, "", 0))
+			if got != tt.want {
+				t.Errorf("types = %+v, want %+v", got, tt.want)
+			}
+			if tt.wantLog == "" {
+				if logged.Len() != 0 {
+					t.Errorf("logged %q, want nothing", logged.String())
+				}
+			} else if !strings.Contains(logged.String(), tt.wantLog) {
+				t.Errorf("logged %q, want it to mention %q", logged.String(), tt.wantLog)
+			}
+		})
+	}
+}
+
+func TestHookTypesFor_ToleratesNilLogger(t *testing.T) {
+	// Status has no logger to pass, and its probe still has to report.
+	origLookPath, origOutput := lookPath, vibeVersionOutput
+	t.Cleanup(func() { lookPath, vibeVersionOutput = origLookPath, origOutput })
+	lookPath = func(string) (string, error) { return "/fake/vibe", nil }
+	vibeVersionOutput = func(context.Context, string) ([]byte, error) {
+		return nil, errors.New("boom")
+	}
+
+	if got := hookTypesFor(context.Background(), nil); got != currentHookTypes {
+		t.Errorf("types = %+v, want %+v", got, currentHookTypes)
+	}
+}

--- a/plugins/agento11y/internal/agents/vibe/vibe.go
+++ b/plugins/agento11y/internal/agents/vibe/vibe.go
@@ -3,11 +3,17 @@
 // `agento11y vibe hook` here.
 //
 // Vibe fires hooks for three event types, all wired here:
-//   - post_agent_turn exports one generation per turn from the on-disk
+//   - post_agent exports one generation per turn from the on-disk
 //     <session_dir>/messages.jsonl plus the sibling meta.json.
-//   - before_tool evaluates the tool call against agento11y guard policy and may
+//   - pre_tool evaluates the tool call against agento11y guard policy and may
 //     deny or rewrite it (when guards are enabled).
-//   - after_tool records the tool's timing/status for its execute_tool span.
+//   - post_tool records the tool's timing/status for its execute_tool span.
+//
+// Vibe 2.21.0 renamed all three (post_agent_turn, before_tool, after_tool),
+// and the dispatch below answers to either name. The install path picks one
+// spelling from the installed vibe's version, but the two are independent: a
+// hooks.toml written by hand, or by a different agento11y build, or before a
+// vibe upgrade, can send the other name to this same binary.
 package vibe
 
 import (
@@ -22,8 +28,8 @@ import (
 
 // Hook reads one vibe hook JSON payload from stdin and dispatches it. It
 // always returns nil so a failure never surfaces as an exit code that
-// interrupts the user's session. Only before_tool writes to stdout (its
-// guard decision); post_agent_turn and after_tool write nothing, because
+// interrupts the user's session. Only pre_tool writes to stdout (its
+// guard decision); post_agent and post_tool write nothing, because
 // vibe interprets a non-empty stdout on those as a deny/retry signal.
 func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Logger) error {
 	raw, err := io.ReadAll(stdin)
@@ -46,12 +52,12 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 	}
 	logger.Printf("dispatch: event=%s session=%s", payload.HookEventName, payload.SessionID)
 	switch payload.HookEventName {
-	case "post_agent_turn":
-		hook.PostAgentTurn(ctx, payload, logger)
-	case "before_tool":
-		hook.BeforeTool(ctx, stdout, payload, logger)
-	case "after_tool":
-		hook.AfterTool(payload, logger)
+	case currentHookTypes.postAgent, preRenameHookTypes.postAgent:
+		hook.PostAgent(ctx, payload, logger)
+	case currentHookTypes.preTool, preRenameHookTypes.preTool:
+		hook.PreTool(ctx, stdout, payload, logger)
+	case currentHookTypes.postTool, preRenameHookTypes.postTool:
+		hook.PostTool(payload, logger)
 	default:
 		logger.Printf("dispatch: unhandled event %q", payload.HookEventName)
 	}

--- a/plugins/agento11y/internal/agents/vibe/vibe_test.go
+++ b/plugins/agento11y/internal/agents/vibe/vibe_test.go
@@ -7,15 +7,17 @@ import (
 	"log"
 	"strings"
 	"testing"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/vibe/toolevents"
 )
 
 func TestHook_Dispatch(t *testing.T) {
 	// Malformed payloads and the non-stdout events must return nil and
 	// write nothing to stdout (vibe reads a non-empty stdout on
-	// post_agent_turn / after_tool as a deny/retry signal). The handlers
+	// post_agent / post_tool as a deny/retry signal). The handlers
 	// themselves are exercised in hook/*_test.go; here we confirm the
 	// dispatcher does not crash and keeps stdout clean for these branches.
-	// Guards default to off, so before_tool is a pass-through too.
+	// Guards default to off, so pre_tool is a pass-through too.
 	tests := []struct {
 		name  string
 		stdin string
@@ -25,6 +27,9 @@ func TestHook_Dispatch(t *testing.T) {
 		{name: "invalid json", stdin: "not json"},
 		{name: "missing event name", stdin: `{"session_id":"s","transcript_path":"p"}`},
 		{name: "unknown event", stdin: `{"hook_event_name":"session_start","session_id":"s"}`},
+		{name: "pre_tool with guards off", stdin: `{"hook_event_name":"pre_tool","session_id":"s","tool_name":"bash"}`},
+		{name: "post_tool", stdin: `{"hook_event_name":"post_tool","session_id":"s","tool_call_id":"tc1","tool_status":"success"}`},
+		// Pre-2.21.0 vibe sends the same events under their old names.
 		{name: "before_tool with guards off", stdin: `{"hook_event_name":"before_tool","session_id":"s","tool_name":"bash"}`},
 		{name: "after_tool", stdin: `{"hook_event_name":"after_tool","session_id":"s","tool_call_id":"tc1","tool_status":"success"}`},
 	}
@@ -44,25 +49,65 @@ func TestHook_Dispatch(t *testing.T) {
 	}
 }
 
-func TestHook_BeforeToolStdoutIsPlumbed(t *testing.T) {
-	// The dispatcher must hand its stdout to the before_tool handler so a
-	// guard deny reaches vibe. Force a deny via fail-closed guards with no
-	// credentials and assert the decision shows up on stdout.
-	t.Setenv("SIGIL_GUARDS_ENABLED", "true")
-	t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "false")
-	t.Setenv("SIGIL_ENDPOINT", "")
-	t.Setenv("SIGIL_AUTH_TENANT_ID", "")
-	t.Setenv("SIGIL_AUTH_TOKEN", "")
+func TestHook_PostToolRecordsTiming(t *testing.T) {
+	// The other two dispatch labels are pinned by an assertion downstream of
+	// them (post_agent by the golden export body, pre_tool by the deny below),
+	// while post_tool writes nothing to stdout, so only a recorded event tells
+	// a correct label from a typo. Both spellings run: the install path picks
+	// one from the installed vibe, and a hooks.toml written before an upgrade
+	// (or by hand) can send the other.
+	for _, event := range []string{"post_tool", "after_tool"} {
+		t.Run(event, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			t.Setenv("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318")
+			session := "s-" + event
 
-	var stdout bytes.Buffer
-	logger := log.New(io.Discard, "", 0)
-	err := Hook(context.Background(),
-		strings.NewReader(`{"hook_event_name":"before_tool","session_id":"s","tool_name":"bash","tool_input":{"command":"ls"}}`),
-		&stdout, logger)
-	if err != nil {
-		t.Fatalf("Hook returned err=%v, want nil", err)
+			var stdout bytes.Buffer
+			logger := log.New(io.Discard, "", 0)
+			err := Hook(context.Background(),
+				strings.NewReader(`{"hook_event_name":"`+event+`","session_id":"`+session+`","tool_call_id":"tc1","tool_name":"bash","tool_status":"success","duration_ms":42.0}`),
+				&stdout, logger)
+			if err != nil {
+				t.Fatalf("Hook returned err=%v, want nil", err)
+			}
+			if stdout.Len() != 0 {
+				t.Errorf("stdout = %q, want empty (vibe reads it on this event as a failure)", stdout.String())
+			}
+			ev, ok := toolevents.Load(session)["tc1"]
+			if !ok {
+				t.Fatalf("no tool event recorded for tc1, so %s did not reach its handler", event)
+			}
+			if ev.DurationMs != 42 {
+				t.Errorf("duration = %v, want 42", ev.DurationMs)
+			}
+		})
 	}
-	if !strings.Contains(stdout.String(), `"decision":"deny"`) {
-		t.Errorf("stdout = %q, want a deny decision plumbed through from before_tool", stdout.String())
+}
+
+func TestHook_PreToolStdoutIsPlumbed(t *testing.T) {
+	// The dispatcher must hand its stdout to the pre-tool handler so a
+	// guard deny reaches vibe. Force a deny via fail-closed guards with no
+	// credentials and assert the decision shows up on stdout, under either
+	// spelling of the event.
+	for _, event := range []string{"pre_tool", "before_tool"} {
+		t.Run(event, func(t *testing.T) {
+			t.Setenv("SIGIL_GUARDS_ENABLED", "true")
+			t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "false")
+			t.Setenv("SIGIL_ENDPOINT", "")
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "")
+			t.Setenv("SIGIL_AUTH_TOKEN", "")
+
+			var stdout bytes.Buffer
+			logger := log.New(io.Discard, "", 0)
+			err := Hook(context.Background(),
+				strings.NewReader(`{"hook_event_name":"`+event+`","session_id":"s","tool_name":"bash","tool_input":{"command":"ls"}}`),
+				&stdout, logger)
+			if err != nil {
+				t.Fatalf("Hook returned err=%v, want nil", err)
+			}
+			if !strings.Contains(stdout.String(), `"decision":"deny"`) {
+				t.Errorf("stdout = %q, want a deny decision plumbed through from %s", stdout.String(), event)
+			}
+		})
 	}
 }

--- a/plugins/agento11y/internal/entry/testdata/golden/vibe-basic/scenario.json
+++ b/plugins/agento11y/internal/entry/testdata/golden/vibe-basic/scenario.json
@@ -9,11 +9,11 @@
     ]
   },
   "sibling_files": {
-    "meta.json": "{\"session_id\":\"vibe-sess-1\",\"title\":\"cats on the keyboard\",\"stats\":{\"steps\":1,\"session_prompt_tokens\":100,\"session_completion_tokens\":25,\"last_turn_prompt_tokens\":100,\"last_turn_completion_tokens\":25,\"last_turn_duration\":1.5,\"context_tokens\":100,\"session_total_llm_tokens\":125,\"input_price_per_million\":1.5,\"output_price_per_million\":7.5,\"session_cost\":0.0625,\"tool_calls_succeeded\":1},\"config\":{\"active_model\":\"mistral-medium-3.5\",\"models\":[{\"name\":\"mistral-vibe-cli-latest\",\"provider\":\"mistral\",\"alias\":\"mistral-medium-3.5\"}]},\"tools_available\":[{\"type\":\"function\",\"function\":{\"name\":\"bash\",\"description\":\"Run shell commands\",\"parameters\":{\"type\":\"object\",\"properties\":{\"command\":{\"type\":\"string\"}}}}}],\"system_prompt\":{\"role\":\"system\",\"content\":\"You are a helpful assistant that keeps tabs on the cats on the user's keyboard.\"}}\n"
+    "meta.json": "{\"session_id\":\"vibe-sess-1\",\"title\":\"cats on the keyboard\",\"stats\":{\"steps\":1,\"session_prompt_tokens\":100,\"session_completion_tokens\":25,\"last_turn_prompt_tokens\":100,\"last_turn_completion_tokens\":25,\"last_turn_duration\":1.5,\"context_tokens\":100,\"session_total_llm_tokens\":125,\"input_price_per_million\":1.5,\"output_price_per_million\":7.5,\"session_cost\":0.0625,\"tool_calls_succeeded\":1},\"config\":{\"active_model\":\"mistral-medium-3.5\",\"models\":{\"mistral-medium-3.5\":{\"name\":\"mistral-vibe-cli-latest\",\"provider\":\"mistral\",\"alias\":\"mistral-medium-3.5\"}}},\"tools_available\":[{\"type\":\"function\",\"function\":{\"name\":\"bash\",\"description\":\"Run shell commands\",\"parameters\":{\"type\":\"object\",\"properties\":{\"command\":{\"type\":\"string\"}}}}}],\"system_prompt\":{\"role\":\"system\",\"content\":\"You are a helpful assistant that keeps tabs on the cats on the user's keyboard.\"}}\n"
   },
   "events": [
     {
-      "hook_event_name": "before_tool",
+      "hook_event_name": "pre_tool",
       "session_id": "vibe-sess-1",
       "transcript_path": "{{transcript:messages}}",
       "cwd": "/repo/keyboard-cats",
@@ -22,7 +22,7 @@
       "tool_input": {"command": "ls /keyboard/cats"}
     },
     {
-      "hook_event_name": "after_tool",
+      "hook_event_name": "post_tool",
       "session_id": "vibe-sess-1",
       "transcript_path": "{{transcript:messages}}",
       "tool_name": "bash",
@@ -31,7 +31,7 @@
       "duration_ms": 42.0
     },
     {
-      "hook_event_name": "post_agent_turn",
+      "hook_event_name": "post_agent",
       "session_id": "vibe-sess-1",
       "transcript_path": "{{transcript:messages}}",
       "cwd": "/repo/keyboard-cats"

--- a/plugins/vibe/README.md
+++ b/plugins/vibe/README.md
@@ -1,8 +1,10 @@
 # Agent Observability for Mistral Vibe
 
-[Mistral Vibe](https://github.com/mistralai/vibe) is sent to [Grafana Agent Observability](https://grafana.com/docs/grafana-cloud/machine-learning/agent-observability/) by registering hooks in Mistral Vibe's `hooks.toml` that forward each turn to the `agento11y` binary. `post_agent_turn` exports one generation per turn; `before_tool` enforces Agent Observability guard policy (when enabled); `after_tool` records per-tool timing for tool spans.
+[Mistral Vibe](https://github.com/mistralai/mistral-vibe) is sent to [Grafana Agent Observability](https://grafana.com/docs/grafana-cloud/machine-learning/agent-observability/) by registering hooks in Mistral Vibe's `hooks.toml` that forward each turn to the `agento11y` binary. `post_agent` exports one generation per turn. `pre_tool` enforces Agent Observability guard policy when guards are enabled. `post_tool` records per-tool timing for tool spans.
 
-> Status: **Experimental.** Mistral Vibe's hook contract is itself marked experimental and may change between releases; the launcher pins to the shape verified at build time.
+Mistral Vibe 2.21.0 renamed all three hook types: `post_agent_turn` became `post_agent`, `before_tool` became `pre_tool`, and `after_tool` became `post_tool`. Each version accepts only its own names and skips an entry that carries the others. `agento11y vibe` reads `vibe --version` and writes the names that version accepts, so both work. This page uses the current names.
+
+> Status: **Experimental.** Hooks were an experimental feature of Mistral Vibe until 2.21.0, and 2.21.0 renamed every hook type. Expect this integration to need an update when the hook contract changes again.
 
 By default only metadata is sent (token counts, model, tool names). Set `AGENTO11Y_CONTENT_CAPTURE_MODE` to `full`, `no_tool_content`, `metadata_only`, or `full_with_metadata_spans` to control what is sent. `default` is accepted as an alias for `metadata_only`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md) for the full reference.
 
@@ -35,7 +37,9 @@ The command was renamed from `sigil`; the old name still works but will be remov
 
 `agento11y vibe` resolves the `vibe` binary on `PATH`, upserts the three agento11y-owned `[[hooks]]` entries into `~/.vibe/hooks.toml` (or `$VIBE_HOME/hooks.toml`) on first run, prompts for missing Grafana Cloud credentials, writes `~/.config/agento11y/config.env`, and then execs it. Repeated runs are no-ops: each entry is matched by name (`agento11y`, `agento11y-before-tool`, `agento11y-after-tool`); entries under the pre-rename `sigil*` names are replaced and any hand-authored hooks in the same file are preserved.
 
-The launcher always sets `VIBE_ENABLE_EXPERIMENTAL_HOOKS=true` in Mistral Vibe's environment because these events are gated behind that flag.
+The entry names are the same for every Mistral Vibe version. Only the `type` values differ. If you upgrade Mistral Vibe across 2.21.0, the next `agento11y vibe` run rewrites the three types in place.
+
+The launcher always sets `VIBE_ENABLE_EXPERIMENTAL_HOOKS=true` in Mistral Vibe's environment. Before 2.21.0, Mistral Vibe read `hooks.toml` only behind that flag. 2.21.0 removed the flag and loads declared hooks unconditionally. Newer versions ignore unknown `VIBE_*` variables, so the launcher can keep setting it for the older ones.
 
 <details>
 <summary>Manual hook registration</summary>
@@ -45,26 +49,28 @@ Add these blocks to `~/.vibe/hooks.toml`:
 ```toml
 [[hooks]]
 name = "agento11y"
-type = "post_agent_turn"
+type = "post_agent"
 command = "agento11y vibe hook"
 timeout = 30
 
 [[hooks]]
 name = "agento11y-before-tool"
-type = "before_tool"
+type = "pre_tool"
 command = "agento11y vibe hook"
 timeout = 30
 match = "*"
 
 [[hooks]]
 name = "agento11y-after-tool"
-type = "after_tool"
+type = "post_tool"
 command = "agento11y vibe hook"
 timeout = 30
 match = "*"
 ```
 
-Then export `VIBE_ENABLE_EXPERIMENTAL_HOOKS=true` in the shell where you run `vibe`, and run `agento11y login` once for credentials.
+Run `vibe --version` first. If it reports a version below 2.21.0, use the old type names instead: `post_agent_turn`, `before_tool`, and `after_tool`. For those versions, also export `VIBE_ENABLE_EXPERIMENTAL_HOOKS=true` in the shell where you run `vibe`. Without it, they do not read `hooks.toml` at all.
+
+Run `agento11y login` once for credentials.
 
 </details>
 
@@ -83,9 +89,9 @@ AGENTO11Y_DEBUG=true agento11y vibe   # one turn
 tail -f ~/.local/state/agento11y/logs/agento11y.log
 ```
 
-Each fire logs a `dispatch: event=… session=…` line; a successful turn export logs `post_agent_turn: export id=…` followed by `post_agent_turn: done`.
+Each fire logs a `dispatch: event=… session=…` line. A successful turn export logs `post_agent: export id=…` followed by `post_agent: done`. The log labels do not change with the Mistral Vibe version.
 
-Run `agento11y doctor` to check the hook install and both export pipelines. Mistral Vibe shows as `not configured` until all three `[[hooks]]` entries are in `hooks.toml`.
+Run `agento11y doctor` to check the hook install and both export pipelines. Mistral Vibe shows as `not configured` until all three `[[hooks]]` entries are in `hooks.toml` with the `type` values the installed Mistral Vibe accepts.
 
 ## Tagging sessions
 
@@ -110,7 +116,7 @@ Subagent turns are not tagged `subagent`. Mistral Vibe only exposes a session-le
 
 ## Guards
 
-`before_tool` evaluates each tool call against Agent Observability guard policy. Guards are **off by default**; enable them with `AGENTO11Y_GUARDS_ENABLED=true` (tune with `AGENTO11Y_GUARDS_TIMEOUT_MS` and `AGENTO11Y_GUARDS_FAIL_OPEN`). When enabled, a policy can **deny** a tool call (Mistral Vibe blocks it and shows the reason to the model) or **rewrite** its arguments (e.g. redact a secret before the tool runs). With guards disabled, `before_tool` is a pass-through that writes nothing. Evaluation runs synchronously before the tool, so a policy should be fast or local; on timeout or transport error the call follows `AGENTO11Y_GUARDS_FAIL_OPEN` (open by default).
+`pre_tool` evaluates each tool call against Agent Observability guard policy. Guards are **off by default**; enable them with `AGENTO11Y_GUARDS_ENABLED=true` (tune with `AGENTO11Y_GUARDS_TIMEOUT_MS` and `AGENTO11Y_GUARDS_FAIL_OPEN`). When enabled, a policy can **deny** a tool call (Mistral Vibe blocks it and shows the reason to the model) or **rewrite** its arguments (e.g. redact a secret before the tool runs). With guards disabled, `pre_tool` is a pass-through that writes nothing. Evaluation runs synchronously before the tool, so a policy should be fast or local; on timeout or transport error the call follows `AGENTO11Y_GUARDS_FAIL_OPEN` (open by default).
 
 ## All options
 
@@ -119,7 +125,7 @@ Subagent turns are not tagged `subagent`. Mistral Vibe only exposes a session-le
 | `AGENTO11Y_ENDPOINT` | — | Agent Observability API URL. Find it at `/plugins/grafana-agento11y-app`. Without it the turn is not exported. |
 | `AGENTO11Y_AUTH_TENANT_ID` | — | Grafana Cloud instance ID. |
 | `AGENTO11Y_AUTH_TOKEN` | — | `glc_…` Cloud Access Policy Token. |
-| `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT`. With neither set, tool spans and metrics are dropped and the `after_tool` hook records nothing. |
+| `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT`. With neither set, tool spans and metrics are dropped and the `post_tool` hook records nothing. |
 | `AGENTO11Y_OTEL_AUTH_TOKEN` | `AGENTO11Y_AUTH_TOKEN` | Override the OTel password. |
 | `AGENTO11Y_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. |
 | `AGENTO11Y_TAGS` | — | `key=value,key=value` tags on every generation and as `agento11y.tag.<key>` on OTel spans/metrics. Same as `--tag`. |
@@ -129,7 +135,7 @@ Subagent turns are not tagged `subagent`. Mistral Vibe only exposes a session-le
 | `AGENTO11Y_AGENT_NAME` | `mistral-vibe` | Override the exported `agent_name`. Avoid a `/` in the name: a slash marks a subagent generation, so every turn of the run is counted as one. Guard rules and dashboards that filter on `mistral-vibe` no longer match the generations this run exports. |
 | `AGENTO11Y_LOCAL` | `false` | Send Vibe hook captures to the local viewer at `http://127.0.0.1:8765` instead of Grafana Cloud. Local mode always stores full content. Cloud forwarding also requires `AGENTO11Y_LOCAL_FORWARD`. |
 | `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
-| `AGENTO11Y_GUARDS_ENABLED` | `false` | Evaluate every `before_tool` fire against guard policy. Denied calls are blocked; Transform rules rewrite the tool arguments. |
+| `AGENTO11Y_GUARDS_ENABLED` | `false` | Evaluate every `pre_tool` fire against guard policy. Denied calls are blocked; Transform rules rewrite the tool arguments. |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | On timeout, network error, or 5xx, run the tool anyway. Set `false` for strict mode. |
 | `AGENTO11Y_GUARDS_TIMEOUT_MS` | `1500` | Per-call guard timeout. Every guarded tool call pays this latency at worst. |
 
@@ -142,7 +148,8 @@ If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your Agent
 | Symptom | Try |
 |---|---|
 | Command not found | Reinstall `agento11y` (see step 1). Check `agento11y --version` and that its install dir is on `PATH`. |
-| Hooks never fire | Mistral Vibe gates these events behind an experimental flag. `agento11y vibe` sets `VIBE_ENABLE_EXPERIMENTAL_HOOKS=true` for you; when you start `vibe` yourself, export that variable or set `enable_experimental_hooks = true` in `~/.vibe/config.toml`. |
+| Hooks never fire, and `vibe` warns that `type` should be one of three other names | The `hooks.toml` entries are spelled for the other side of the 2.21.0 rename. Re-run `agento11y vibe`, which rewrites the three types for the installed version. |
+| Hooks never fire on Mistral Vibe below 2.21.0 | Those versions read `hooks.toml` only behind a flag. `agento11y vibe` sets `VIBE_ENABLE_EXPERIMENTAL_HOOKS=true` for you; when you start `vibe` yourself, export that variable or set `enable_experimental_hooks = true` in `~/.vibe/config.toml`. |
 | No `[[hooks]]` entries in `hooks.toml` | Re-run `agento11y vibe` (it upserts them before exec) and check `agento11y doctor`, which reads the same file. |
 | Hooks fire but nothing appears in Agent Observability | Check `AGENTO11Y_ENDPOINT`, `AGENTO11Y_AUTH_TENANT_ID`, and `AGENTO11Y_AUTH_TOKEN`. Without all three the hook logs `not exporting: missing …` and skips the turn. |
 | No latency or tool-call charts | Set `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT` (or the standard `OTEL_EXPORTER_OTLP_ENDPOINT`). Tool spans only leave the process through the OTel exporter. |


### PR DESCRIPTION
Mistral Vibe 2.21.0 renamed its three hook events: 
- `post_agent_turn` -> `post_agent`
- `before_tool` -> `pre_tool`
- `after_tool` -> `post_tool`

This PR detects the installed Vibe version and writes the matching hook types to `hooks.toml`.