### PR TITLE
feat(sdk-go): add otelhook, the agento11y extension of otelgenai

### DIFF
--- a/go/agento11y/client.go
+++ b/go/agento11y/client.go
@@ -9,7 +9,6 @@ import (
 	"maps"
 	"reflect"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -17,6 +16,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/grafana/agento11y/go/agento11y/contentcapture"
+	"github.com/grafana/agento11y/go/agento11y/internal/tagattr"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -2232,30 +2232,7 @@ func metricExemplarContext(ctx context.Context) context.Context {
 }
 
 func tagAttributes(tags map[string]string) []attribute.KeyValue {
-	if len(tags) == 0 {
-		return nil
-	}
-	type tagPair struct {
-		key   string
-		value string
-	}
-	pairs := make([]tagPair, 0, len(tags))
-	for k, v := range tags {
-		key := strings.TrimSpace(k)
-		if key == "" {
-			continue
-		}
-		pairs = append(pairs, tagPair{key: key, value: strings.TrimSpace(v)})
-	}
-	if len(pairs) == 0 {
-		return nil
-	}
-	sort.Slice(pairs, func(i, j int) bool { return pairs[i].key < pairs[j].key })
-	attrs := make([]attribute.KeyValue, 0, len(pairs))
-	for _, p := range pairs {
-		attrs = append(attrs, attribute.String(spanAttrTagPrefix+p.key, p.value))
-	}
-	return attrs
+	return tagattr.Attributes(spanAttrTagPrefix, tags)
 }
 
 func setSpanTagAttributes(span trace.Span, tags map[string]string) {

--- a/go/agento11y/codec/codec.go
+++ b/go/agento11y/codec/codec.go
@@ -67,9 +67,8 @@ func ToProto(g model.Generation) (*agento11yv1.Generation, error) {
 		ParentGenerationIds: cloneStringSlice(g.ParentGenerationIDs),
 	}
 
-	if trimmed := strings.TrimSpace(g.EffectiveVersion); trimmed != "" {
-		sum := sha256.Sum256([]byte(trimmed))
-		out.EffectiveVersion = proto.String("sha256:" + hex.EncodeToString(sum[:]))
+	if digest := EffectiveVersionDigest(g.EffectiveVersion); digest != "" {
+		out.EffectiveVersion = proto.String(digest)
 	}
 
 	if !g.StartedAt.IsZero() {
@@ -80,6 +79,17 @@ func ToProto(g model.Generation) (*agento11yv1.Generation, error) {
 	}
 
 	return out, nil
+}
+
+// EffectiveVersionDigest returns the sha256:<hex> digest of a raw
+// effective-version string, or "" when it holds nothing.
+func EffectiveVersionDigest(effectiveVersion string) string {
+	trimmed := strings.TrimSpace(effectiveVersion)
+	if trimmed == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(trimmed))
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 // WorkflowStepToProto converts a model.WorkflowStep into the wire-level

--- a/go/agento11y/contentcapture/contentcapture.go
+++ b/go/agento11y/contentcapture/contentcapture.go
@@ -61,6 +61,35 @@ const (
 
 	// ToolCallResultAttributeKey holds the value a tool call returned.
 	ToolCallResultAttributeKey = "gen_ai.tool.call.result"
+
+	// The six gen_ai keys below are the semantic conventions' content
+	// documents. Only a span from the otelgenai util carries them, because
+	// there the span is the generation export rather than metadata beside it.
+	// Listing them keeps a forwarder from relaying prompt text under a reduced
+	// capture mode.
+
+	// SystemInstructionsAttributeKey holds the system prompt.
+	SystemInstructionsAttributeKey = "gen_ai.system_instructions"
+
+	// InputMessagesAttributeKey holds the request messages.
+	InputMessagesAttributeKey = "gen_ai.input.messages"
+
+	// OutputMessagesAttributeKey holds the response messages.
+	OutputMessagesAttributeKey = "gen_ai.output.messages"
+
+	// ToolDefinitionsAttributeKey holds the tool descriptions and schemas
+	// visible to the model.
+	ToolDefinitionsAttributeKey = "gen_ai.tool.definitions"
+
+	// RetrievalQueryTextAttributeKey holds the query a retrieval ran.
+	RetrievalQueryTextAttributeKey = "gen_ai.retrieval.query.text"
+
+	// RetrievalDocumentsAttributeKey holds the documents a retrieval returned.
+	RetrievalDocumentsAttributeKey = "gen_ai.retrieval.documents"
+
+	// RawArtifactsAttributeKey holds the raw provider request and response
+	// payloads. Only the otelgenai util puts them on a span.
+	RawArtifactsAttributeKey = "agento11y.generation.raw_artifacts"
 )
 
 // Protocol values that must not be treated as content. A forwarder that
@@ -97,8 +126,9 @@ const (
 // Exposing a predicate instead of a set keeps callers from adding or removing
 // keys.
 //
-// Generation prompt and response text never reaches spans; it travels in the
-// proto generation export.
+// Generation prompt and response text reaches a span only through the
+// otelgenai util, where the span replaces the proto generation export. On
+// every other path that text travels in that export instead.
 func IsTraceContentAttribute(key string) bool {
 	switch key {
 	case ConversationTitleKey,
@@ -106,7 +136,14 @@ func IsTraceContentAttribute(key string) bool {
 		EmbeddingInputTextsAttributeKey,
 		ToolDescriptionAttributeKey,
 		ToolCallArgumentsAttributeKey,
-		ToolCallResultAttributeKey:
+		ToolCallResultAttributeKey,
+		SystemInstructionsAttributeKey,
+		InputMessagesAttributeKey,
+		OutputMessagesAttributeKey,
+		ToolDefinitionsAttributeKey,
+		RetrievalQueryTextAttributeKey,
+		RetrievalDocumentsAttributeKey,
+		RawArtifactsAttributeKey:
 		return true
 	default:
 		return false

--- a/go/agento11y/contentcapture/contentcapture_test.go
+++ b/go/agento11y/contentcapture/contentcapture_test.go
@@ -381,6 +381,15 @@ func TestIsTraceContentAttribute(t *testing.T) {
 		{key: "gen_ai.embeddings.input_texts", want: true},
 		{key: "agento11y.conversation.title", want: true},
 		{key: "sigil.conversation.title", want: true},
+		// The semconv content documents and the raw artifacts appear on a
+		// generation span under the otel export protocol.
+		{key: "gen_ai.system_instructions", want: true},
+		{key: "gen_ai.input.messages", want: true},
+		{key: "gen_ai.output.messages", want: true},
+		{key: "gen_ai.tool.definitions", want: true},
+		{key: "gen_ai.retrieval.query.text", want: true},
+		{key: "gen_ai.retrieval.documents", want: true},
+		{key: "agento11y.generation.raw_artifacts", want: true},
 		{key: "gen_ai.tool.name", want: false},
 		{key: "gen_ai.usage.input_tokens", want: false},
 		{key: contentcapture.ErrorCategoryAttributeKey, want: false},

--- a/go/agento11y/internal/tagattr/tagattr.go
+++ b/go/agento11y/internal/tagattr/tagattr.go
@@ -1,0 +1,30 @@
+// Package tagattr renders a tag map as agento11y.tag.<key> attributes.
+package tagattr
+
+import (
+	"slices"
+	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// Attributes renders tags as prefix+key attributes, sorted by key. Keys and
+// values are trimmed, and a key that trims to nothing is dropped.
+func Attributes(prefix string, tags map[string]string) []attribute.KeyValue {
+	if len(tags) == 0 {
+		return nil
+	}
+	attrs := make([]attribute.KeyValue, 0, len(tags))
+	for key, value := range tags {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == "" {
+			continue
+		}
+		attrs = append(attrs, attribute.String(prefix+trimmed, strings.TrimSpace(value)))
+	}
+	if len(attrs) == 0 {
+		return nil
+	}
+	slices.SortFunc(attrs, func(a, b attribute.KeyValue) int { return strings.Compare(string(a.Key), string(b.Key)) })
+	return attrs
+}

--- a/go/agento11y/internal/tagattr/tagattr_test.go
+++ b/go/agento11y/internal/tagattr/tagattr_test.go
@@ -1,0 +1,60 @@
+package tagattr_test
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/grafana/agento11y/go/agento11y/internal/tagattr"
+)
+
+func TestAttributes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		tags map[string]string
+		want []attribute.KeyValue
+	}{
+		{name: "no tags"},
+		{name: "empty map", tags: map[string]string{}},
+		{
+			name: "sorted by key",
+			tags: map[string]string{"team": "sigil", "env": "dev"},
+			want: []attribute.KeyValue{
+				attribute.String("agento11y.tag.env", "dev"),
+				attribute.String("agento11y.tag.team", "sigil"),
+			},
+		},
+		{
+			name: "keys and values trimmed",
+			tags: map[string]string{"  team  ": "  sigil  "},
+			want: []attribute.KeyValue{attribute.String("agento11y.tag.team", "sigil")},
+		},
+		{
+			name: "a key that trims to nothing is dropped",
+			tags: map[string]string{"   ": "orphan", "env": "dev"},
+			want: []attribute.KeyValue{attribute.String("agento11y.tag.env", "dev")},
+		},
+		{
+			name: "nothing survives",
+			tags: map[string]string{"": "orphan"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tagattr.Attributes("agento11y.tag.", tc.tags)
+			if len(got) != len(tc.want) {
+				t.Fatalf("Attributes() = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("attribute %d = %v, want %v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/go/agento11y/otelhook/content_keys_test.go
+++ b/go/agento11y/otelhook/content_keys_test.go
@@ -1,0 +1,83 @@
+package otelhook_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/grafana/agento11y/go/agento11y/contentcapture"
+	"github.com/grafana/agento11y/go/agento11y/model"
+	"github.com/grafana/agento11y/go/agento11y/otelhook"
+	"github.com/grafana/agento11y/go/otelgenai"
+)
+
+// TestSpanContentKeysAreClassified drives a full span through otelgenai and the
+// hook and fails if an attribute carrying the sentinel is not one
+// contentcapture.IsTraceContentAttribute reports. A reducing forwarder deletes
+// content by key, so a content field otelgenai grows without a key here leaves
+// that content relayed under a reduced capture mode.
+func TestSpanContentKeysAreClassified(t *testing.T) {
+	const sentinel = "CONTENT-SENTINEL"
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	handler := otelgenai.NewHandler(
+		otelgenai.WithTracerProvider(provider),
+		otelgenai.WithCaptureMode(otelgenai.CaptureSpanOnly),
+		otelgenai.WithEndHook(otelhook.New()),
+	)
+
+	inv := &otelgenai.Invocation{
+		Provider:           "openai",
+		RequestModel:       "gpt-5",
+		SystemInstructions: otelgenai.SystemInstructionsFromText(sentinel),
+		InputMessages: []otelgenai.Message{{
+			Role:  otelgenai.RoleUser,
+			Parts: []otelgenai.Part{otelgenai.TextPart(sentinel)},
+		}},
+		OutputMessages: []otelgenai.Message{{
+			Role:  otelgenai.RoleAssistant,
+			Parts: []otelgenai.Part{otelgenai.TextPart(sentinel)},
+		}},
+		ToolDefinitions:    []otelgenai.ToolDefinition{{Name: sentinel, Description: sentinel}},
+		ToolCallArguments:  []byte(`{"city":"` + sentinel + `"}`),
+		ToolCallResult:     []byte(`{"city":"` + sentinel + `"}`),
+		RetrievalQueryText: sentinel,
+		RetrievalDocuments: []byte(`[{"id":"` + sentinel + `"}]`),
+		Vendor: otelhook.Generation{
+			ID:                "gen-1",
+			ConversationTitle: sentinel,
+			Artifacts:         []otelhook.Artifact{{Kind: model.ArtifactKindRequest, Payload: []byte(sentinel)}},
+		},
+	}
+
+	ctx := handler.Start(context.Background(), inv)
+	handler.End(ctx, inv)
+
+	ended := recorder.Ended()
+	if len(ended) != 1 {
+		t.Fatalf("recorded %d spans, want 1", len(ended))
+	}
+
+	var carriers int
+	for _, kv := range ended[0].Attributes() {
+		if !strings.Contains(kv.Value.Emit(), sentinel) {
+			continue
+		}
+		carriers++
+		if !contentcapture.IsTraceContentAttribute(string(kv.Key)) {
+			t.Errorf("%s carries content but IsTraceContentAttribute reports it as metadata", kv.Key)
+		}
+	}
+	// The raw artifacts hold the sentinel base64-encoded, so they never match
+	// above. Every other content field does, and a drop to zero would mean the
+	// span stopped carrying content rather than that the keys are classified.
+	if carriers == 0 {
+		t.Fatal("no attribute carries the sentinel, so this test checks nothing")
+	}
+}

--- a/go/agento11y/otelhook/hook.go
+++ b/go/agento11y/otelhook/hook.go
@@ -1,0 +1,263 @@
+// Package otelhook is the agento11y extension of the otelgenai util. It
+// implements otelgenai.EndHook, so a generation span produced by the util
+// carries the agento11y.* attributes for the generation fields the Gen AI
+// semantic conventions do not define.
+//
+// Message content reaches the hook already sanitized: the SDK runs
+// Config.GenerationSanitizer over the generation before the SDK builds the
+// invocation, so the hook adds attributes rather than re-running redaction.
+// The handler cannot inspect what a hook returns, so the hook checks the
+// resolved capture mode itself: it emits the attributes below that carry
+// provider or user text only when that mode puts content on the span.
+package otelhook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/grafana/agento11y/go/agento11y/codec"
+	"github.com/grafana/agento11y/go/agento11y/contentcapture"
+	"github.com/grafana/agento11y/go/agento11y/internal/tagattr"
+	"github.com/grafana/agento11y/go/agento11y/model"
+	"github.com/grafana/agento11y/go/otelgenai"
+)
+
+const (
+	AttrGenerationID        = "agento11y.generation.id"
+	AttrParentGenerationIDs = "agento11y.generation.parent_generation_ids"
+	AttrTags                = "agento11y.generation.tags"
+	AttrMetadata            = "agento11y.generation.metadata"
+	// These two alias the contentcapture keys, which classify them as content.
+	// A second spelling here would let the two keys drift apart.
+	AttrRawArtifacts      = contentcapture.RawArtifactsAttributeKey
+	AttrConversationTitle = contentcapture.ConversationTitleKey
+	AttrEffectiveVersion  = "agento11y.agent.effective_version"
+	AttrToolChoice        = "agento11y.gen_ai.request.tool_choice"
+	AttrThinkingEnabled   = "agento11y.gen_ai.request.thinking.enabled"
+	AttrUsageTotalTokens  = "agento11y.gen_ai.usage.total_tokens"
+	AttrTokenSemantics    = "gen_ai.token.semantics"
+	AttrUserID            = "user.id"
+	// AttrTagPrefix is the per-tag dimension prefix the SDK already emits on
+	// spans and metrics. The hook emits these dimensions next to the tags JSON
+	// document, so existing trace filters keep working in otel mode.
+	AttrTagPrefix = "agento11y.tag."
+
+	// TokenSemanticsInclusive marks usage whose input_tokens already includes
+	// both cache buckets, per the OTel GenAI contract.
+	TokenSemanticsInclusive = "inclusive"
+)
+
+// contentMetadataKeys are the metadata keys the SDK mirrors content into. The
+// hook drops them in every capture mode: a reducing forwarder keeps the
+// metadata document and deletes by key, so content nested in it would survive.
+var contentMetadataKeys = []string{
+	contentcapture.ConversationTitleKey,
+	contentcapture.LegacyConversationTitleKey,
+	contentcapture.MetadataKeyCallError,
+}
+
+// Artifact is one raw provider payload attached to a generation. The fields
+// mirror agento11y.v1.Artifact in proto/agento11y/v1/generation_ingest.proto.
+type Artifact struct {
+	Kind        model.ArtifactKind
+	Name        string
+	ContentType string
+	Payload     []byte
+	RecordID    string
+	URI         string
+}
+
+// Generation is the agento11y data an invocation carries for the hook. The
+// SDK attaches it as otelgenai.Invocation.Vendor; a caller driving otelgenai
+// directly can do the same.
+//
+// The fields are the ones the conventions cannot express. Everything the
+// conventions do define (model, usage, messages, finish reasons) stays on the
+// invocation itself.
+type Generation struct {
+	ID     string
+	UserID string
+	// ConversationTitle carries user text, so it goes under
+	// AttrConversationTitle and only under content capture.
+	ConversationTitle   string
+	Tags                map[string]string
+	Metadata            map[string]any
+	Artifacts           []Artifact
+	ParentGenerationIDs []string
+	// EffectiveVersion is the raw version string. The hook emits the digest,
+	// through codec.EffectiveVersionDigest.
+	EffectiveVersion string
+	ToolChoice       *string
+	ThinkingEnabled  *bool
+	TotalTokens      int64
+	// InclusiveTokenSemantics marks that Usage.InputTokens on the invocation
+	// already includes both cache buckets.
+	InclusiveTokenSemantics bool
+}
+
+// Hook implements otelgenai.EndHook.
+type Hook struct{}
+
+// New returns the agento11y end hook.
+func New() *Hook { return &Hook{} }
+
+// OnEnd returns the agento11y attributes for the invocation. An
+// invocation whose Vendor is not a Generation gets no attributes, so a span
+// from unrelated instrumentation carries no generation id.
+//
+// capture gates the content-bearing attributes: the conversation title and the
+// raw artifacts.
+func (h *Hook) OnEnd(_ context.Context, inv *otelgenai.Invocation, capture otelgenai.CaptureMode) []attribute.KeyValue {
+	if inv == nil {
+		return nil
+	}
+	generation, ok := vendorGeneration(inv.Vendor)
+	if !ok {
+		// An invocation from unrelated instrumentation carries no vendor payload
+		// at all, so a nil Vendor reports nothing. Anything else is a wiring
+		// mistake: staying silent would ship a span with none of the agento11y
+		// attributes on it.
+		switch value := inv.Vendor.(type) {
+		case nil:
+		case *Generation:
+			// Only a nil pointer reaches this case.
+			otel.Handle(errors.New("agento11y otelhook: invocation vendor is a nil *otelhook.Generation, so the span carries no agento11y attributes"))
+		default:
+			otel.Handle(fmt.Errorf("agento11y otelhook: invocation vendor is %T, want otelhook.Generation, so the span carries no agento11y attributes", value))
+		}
+		return nil
+	}
+	if generation.ID == "" {
+		otel.Handle(errors.New("agento11y otelhook: generation has no id, so the span carries no " + AttrGenerationID))
+	}
+	withContent := capture.SpanContent()
+
+	var attrs []attribute.KeyValue
+	if generation.ID != "" {
+		attrs = append(attrs, attribute.String(AttrGenerationID, generation.ID))
+	}
+	if generation.UserID != "" {
+		attrs = append(attrs, attribute.String(AttrUserID, generation.UserID))
+	}
+	if generation.TotalTokens != 0 {
+		attrs = append(attrs, attribute.Int64(AttrUsageTotalTokens, generation.TotalTokens))
+	}
+	if generation.InclusiveTokenSemantics {
+		attrs = append(attrs, attribute.String(AttrTokenSemantics, TokenSemanticsInclusive))
+	}
+	if generation.ToolChoice != nil {
+		attrs = append(attrs, attribute.String(AttrToolChoice, *generation.ToolChoice))
+	}
+	if generation.ThinkingEnabled != nil {
+		attrs = append(attrs, attribute.Bool(AttrThinkingEnabled, *generation.ThinkingEnabled))
+	}
+	if len(generation.ParentGenerationIDs) > 0 {
+		attrs = append(attrs, attribute.StringSlice(AttrParentGenerationIDs, generation.ParentGenerationIDs))
+	}
+	if digest := codec.EffectiveVersionDigest(generation.EffectiveVersion); digest != "" {
+		attrs = append(attrs, attribute.String(AttrEffectiveVersion, digest))
+	}
+	if len(generation.Tags) > 0 {
+		// The document keeps the map as given, matching the proto tags field.
+		// The dimensions trim it.
+		if payload, err := json.Marshal(generation.Tags); err == nil {
+			attrs = append(attrs, attribute.String(AttrTags, string(payload)))
+		}
+		attrs = append(attrs, tagAttributes(generation.Tags)...)
+	}
+	if withContent {
+		if title := conversationTitle(generation); title != "" {
+			attrs = append(attrs, attribute.String(AttrConversationTitle, title))
+		}
+	}
+	if metadata := metadataDocument(generation.Metadata); len(metadata) > 0 {
+		// A value that does not marshal takes the whole document with it,
+		// including the SDK's own capture-mode marker, so report the drop.
+		if payload, err := json.Marshal(metadata); err == nil {
+			attrs = append(attrs, attribute.String(AttrMetadata, string(payload)))
+		} else {
+			otel.Handle(fmt.Errorf("agento11y otelhook: dropping generation metadata: %w", err))
+		}
+	}
+	if withContent && len(generation.Artifacts) > 0 {
+		if payload, err := json.Marshal(wireArtifacts(generation.Artifacts)); err == nil {
+			attrs = append(attrs, attribute.String(AttrRawArtifacts, string(payload)))
+		}
+	}
+	return attrs
+}
+
+// metadataDocument returns the metadata map to serialize, without the mirrors
+// listed in contentMetadataKeys.
+func metadataDocument(metadata map[string]any) map[string]any {
+	out := maps.Clone(metadata)
+	for _, key := range contentMetadataKeys {
+		delete(out, key)
+	}
+	return out
+}
+
+// conversationTitle falls back to the metadata mirrors, where a generation
+// filled from the proto shape carries the title.
+func conversationTitle(generation Generation) string {
+	if generation.ConversationTitle != "" {
+		return generation.ConversationTitle
+	}
+	for _, key := range []string{contentcapture.ConversationTitleKey, contentcapture.LegacyConversationTitleKey} {
+		if title, ok := generation.Metadata[key].(string); ok && title != "" {
+			return title
+		}
+	}
+	return ""
+}
+
+// wireArtifact is the span encoding of an Artifact: the same JSON as
+// model.Artifact, which spells the agento11y.v1.Artifact field names and
+// base64-encodes the payload.
+type wireArtifact struct {
+	Kind        string `json:"kind,omitempty"`
+	Name        string `json:"name,omitempty"`
+	ContentType string `json:"content_type,omitempty"`
+	Payload     []byte `json:"payload,omitempty"`
+	RecordID    string `json:"record_id,omitempty"`
+	URI         string `json:"uri,omitempty"`
+}
+
+func wireArtifacts(artifacts []Artifact) []wireArtifact {
+	out := make([]wireArtifact, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		out = append(out, wireArtifact{
+			Kind:        string(artifact.Kind),
+			Name:        artifact.Name,
+			ContentType: artifact.ContentType,
+			Payload:     artifact.Payload,
+			RecordID:    artifact.RecordID,
+			URI:         artifact.URI,
+		})
+	}
+	return out
+}
+
+func vendorGeneration(vendor any) (Generation, bool) {
+	switch value := vendor.(type) {
+	case Generation:
+		return value, true
+	case *Generation:
+		if value == nil {
+			return Generation{}, false
+		}
+		return *value, true
+	default:
+		return Generation{}, false
+	}
+}
+
+func tagAttributes(tags map[string]string) []attribute.KeyValue {
+	return tagattr.Attributes(AttrTagPrefix, tags)
+}

--- a/go/agento11y/otelhook/hook_test.go
+++ b/go/agento11y/otelhook/hook_test.go
@@ -1,0 +1,275 @@
+package otelhook_test
+
+import (
+	"context"
+	"math"
+	"slices"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/grafana/agento11y/go/agento11y/contentcapture"
+	"github.com/grafana/agento11y/go/agento11y/otelhook"
+	"github.com/grafana/agento11y/go/otelgenai"
+)
+
+func attributeMap(attrs []attribute.KeyValue) map[string]string {
+	out := make(map[string]string, len(attrs))
+	for _, kv := range attrs {
+		out[string(kv.Key)] = kv.Value.Emit()
+	}
+	return out
+}
+
+func TestOnEnd(t *testing.T) {
+	t.Parallel()
+
+	toolChoice := "auto"
+	thinking := true
+
+	cases := []struct {
+		name    string
+		vendor  any
+		capture otelgenai.CaptureMode
+		want    map[string]string
+		absent  []string
+	}{
+		{
+			name: "full generation",
+			vendor: otelhook.Generation{
+				ID:                      "gen-1",
+				UserID:                  "user-1",
+				Tags:                    map[string]string{"team": "sigil", " env ": " dev "},
+				Metadata:                map[string]any{"model_version": "2026-06"},
+				ParentGenerationIDs:     []string{"gen-0"},
+				EffectiveVersion:        "v3",
+				ToolChoice:              &toolChoice,
+				ThinkingEnabled:         &thinking,
+				TotalTokens:             162,
+				InclusiveTokenSemantics: true,
+			},
+			want: map[string]string{
+				"agento11y.generation.id":                    "gen-1",
+				"user.id":                                    "user-1",
+				"agento11y.generation.tags":                  `{" env ":" dev ","team":"sigil"}`,
+				"agento11y.tag.team":                         "sigil",
+				"agento11y.tag.env":                          "dev",
+				"agento11y.generation.metadata":              `{"model_version":"2026-06"}`,
+				"agento11y.generation.parent_generation_ids": `["gen-0"]`,
+				// The digest of "v3", the rule the proto path applies too.
+				"agento11y.agent.effective_version":         "sha256:e0d2747b9ab7abb6eb65e0373fa1b428a28bd6d8a2380106dcc080f58005ee14",
+				"agento11y.gen_ai.request.tool_choice":      "auto",
+				"agento11y.gen_ai.request.thinking.enabled": "true",
+				"agento11y.gen_ai.usage.total_tokens":       "162",
+				"gen_ai.token.semantics":                    "inclusive",
+			},
+		},
+		{
+			name:   "id only",
+			vendor: otelhook.Generation{ID: "gen-2"},
+			want:   map[string]string{"agento11y.generation.id": "gen-2"},
+			absent: []string{
+				"user.id",
+				"agento11y.generation.tags",
+				"agento11y.generation.metadata",
+				"gen_ai.token.semantics",
+			},
+		},
+		{
+			name:   "no vendor payload",
+			vendor: nil,
+			absent: []string{"agento11y.generation.id"},
+		},
+		{
+			name:   "foreign vendor payload",
+			vendor: "not-a-generation",
+			absent: []string{"agento11y.generation.id"},
+		},
+		{
+			name:    "content capture off drops the title and the artifacts",
+			capture: otelgenai.CaptureNoContent,
+			vendor: otelhook.Generation{
+				ID:                "gen-3",
+				ConversationTitle: "TITLE-SECRET",
+				Metadata: map[string]any{
+					"agento11y.conversation.title": "TITLE-SECRET",
+					"sigil.conversation.title":     "TITLE-SECRET",
+					"call_error":                   "openai: 401 unauthorized (api_key=sk-SECRET)",
+					"model_version":                "2026-06",
+				},
+				Artifacts: []otelhook.Artifact{{Kind: "request", Payload: []byte("SECRET-BODY")}},
+			},
+			want: map[string]string{
+				"agento11y.generation.metadata": `{"model_version":"2026-06"}`,
+			},
+			absent: []string{
+				"agento11y.conversation.title",
+				"agento11y.generation.raw_artifacts",
+			},
+		},
+		{
+			name:    "content capture on puts the title in its own attribute",
+			capture: otelgenai.CaptureSpanOnly,
+			vendor: otelhook.Generation{
+				ID:                "gen-4",
+				ConversationTitle: "Fix the flake",
+				Metadata: map[string]any{
+					"agento11y.conversation.title": "Fix the flake",
+					"call_error":                   "openai: 401 unauthorized (api_key=sk-SECRET)",
+					"model_version":                "2026-06",
+				},
+				Artifacts: []otelhook.Artifact{{Kind: "request", ContentType: "application/json", Payload: []byte(`{"a":1}`)}},
+			},
+			want: map[string]string{
+				"agento11y.conversation.title":       "Fix the flake",
+				"agento11y.generation.metadata":      `{"model_version":"2026-06"}`,
+				"agento11y.generation.raw_artifacts": `[{"kind":"request","content_type":"application/json","payload":"eyJhIjoxfQ=="}]`,
+			},
+		},
+		{
+			name:    "the title mirror alone still reports a title",
+			capture: otelgenai.CaptureSpanOnly,
+			vendor: otelhook.Generation{
+				ID:       "gen-5",
+				Metadata: map[string]any{"sigil.conversation.title": "Fix the flake"},
+			},
+			want:   map[string]string{"agento11y.conversation.title": "Fix the flake"},
+			absent: []string{"agento11y.generation.metadata"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := attributeMap(otelhook.New().OnEnd(context.Background(), &otelgenai.Invocation{Vendor: tc.vendor}, tc.capture))
+			for key, want := range tc.want {
+				if got[key] != want {
+					t.Errorf("%s = %q, want %q", key, got[key], want)
+				}
+			}
+			for _, key := range tc.absent {
+				if _, ok := got[key]; ok {
+					t.Errorf("%s is present, want it absent", key)
+				}
+			}
+		})
+	}
+}
+
+// TestOnEndKeepsContentUnderClassifiedKeys pins the rule a reducing forwarder
+// depends on: content only sits under keys
+// contentcapture.IsTraceContentAttribute reports.
+func TestOnEndKeepsContentUnderClassifiedKeys(t *testing.T) {
+	t.Parallel()
+
+	const secret = "CONTENT-SECRET"
+	generation := otelhook.Generation{
+		ID:                "gen-1",
+		ConversationTitle: secret,
+		Tags:              map[string]string{"env": "dev"},
+		Metadata: map[string]any{
+			"agento11y.conversation.title": secret,
+			"sigil.conversation.title":     secret,
+			"call_error":                   secret,
+			"model_version":                "2026-06",
+		},
+	}
+
+	attrs := otelhook.New().OnEnd(context.Background(), &otelgenai.Invocation{Vendor: generation}, otelgenai.CaptureSpanOnly)
+	for _, kv := range attrs {
+		if contentcapture.IsTraceContentAttribute(string(kv.Key)) {
+			continue
+		}
+		if value := kv.Value.Emit(); strings.Contains(value, secret) {
+			t.Errorf("%s = %q carries content under a key a forwarder does not strip", kv.Key, value)
+		}
+	}
+	if got := attributeMap(attrs)["agento11y.conversation.title"]; got != secret {
+		t.Errorf("agento11y.conversation.title = %q, want %q", got, secret)
+	}
+}
+
+func TestOnEndNilInvocation(t *testing.T) {
+	t.Parallel()
+
+	if got := otelhook.New().OnEnd(context.Background(), nil, otelgenai.CaptureSpanOnly); got != nil {
+		t.Fatalf("OnEnd(nil) = %v, want nil", got)
+	}
+}
+
+// TestOnEndReportsDroppedPayloads pins that a payload the hook cannot encode
+// reaches the OTel error handler. Dropping the payload silently leaves a span
+// that looks healthy while it is missing the attributes that make it a
+// generation.
+//
+// The error handler is global, so these cases cannot run in parallel.
+func TestOnEndReportsDroppedPayloads(t *testing.T) {
+	cases := []struct {
+		name   string
+		vendor any
+		want   string
+	}{
+		{
+			name: "metadata that does not marshal",
+			vendor: otelhook.Generation{
+				ID:       "gen_1",
+				Metadata: map[string]any{"score": math.NaN()},
+			},
+			want: "dropping generation metadata",
+		},
+		{
+			name:   "a vendor payload of another type",
+			vendor: struct{ Other string }{Other: "not a generation"},
+			want:   "want otelhook.Generation",
+		},
+		{
+			name:   "a nil generation pointer",
+			vendor: (*otelhook.Generation)(nil),
+			want:   "nil *otelhook.Generation",
+		},
+		{
+			name:   "a generation with no id",
+			vendor: otelhook.Generation{},
+			want:   "has no id",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var reported []string
+			previous := otel.GetErrorHandler()
+			otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+				reported = append(reported, err.Error())
+			}))
+			t.Cleanup(func() { otel.SetErrorHandler(previous) })
+
+			otelhook.New().OnEnd(context.Background(), &otelgenai.Invocation{Vendor: tc.vendor}, otelgenai.CaptureSpanOnly)
+
+			if !slices.ContainsFunc(reported, func(msg string) bool { return strings.Contains(msg, tc.want) }) {
+				t.Errorf("reported %v, want one mentioning %q", reported, tc.want)
+			}
+		})
+	}
+}
+
+// TestOnEndStaysQuietForForeignInvocations pins the other half of the error
+// reporting: the hook can share a handler with instrumentation that has no
+// vendor payload at all, and reporting those invocations would put one line
+// per span in the host application's error handler.
+func TestOnEndStaysQuietForForeignInvocations(t *testing.T) {
+	var reported []string
+	previous := otel.GetErrorHandler()
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+		reported = append(reported, err.Error())
+	}))
+	t.Cleanup(func() { otel.SetErrorHandler(previous) })
+
+	otelhook.New().OnEnd(context.Background(), &otelgenai.Invocation{}, otelgenai.CaptureSpanOnly)
+
+	if len(reported) != 0 {
+		t.Errorf("reported %v for an invocation with no vendor payload, want silence", reported)
+	}
+}


### PR DESCRIPTION
Split from https://github.com/grafana/agento11y/pull/580.

It's an addition for the experimental otelgenai package added in https://github.com/grafana/agento11y/pull/602. Not used yet.

`otelhook` implements `otelgenai.EndHook`. A span the `otelgenai` util produces then has the `agento11y.*` attributes the Agent Observability backend needs: the generation id, the tags, and fields that aren't in the Gen AI semantic convention.