### PR TITLE
feat(plugins/agento11y): add noninteractive agent installs

### DIFF
--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -93,6 +93,26 @@ Then follow your agent's quickstart:
 - [pi](../pi/README.md)
 - [Vibe](../vibe/README.md)
 
+## Noninteractive agent setup
+
+After writing the current user's `config.env`, a script can register an agent
+integration without launching the host or opening the credential prompt:
+
+```sh
+agento11y copilot install --json
+agento11y opencode install --json
+agento11y pi install --json
+```
+
+Each command prints one secret-free result with `installed`,
+`already_installed`, `missing_host`, or `error`. Copilot writes its shared
+user hook file and does not require the Copilot CLI on `PATH`; that file is
+also read by Copilot Chat in VS Code. OpenCode and pi require their respective
+CLI to be on the current user's `PATH`; `missing_host` is a successful
+deferral, so a later run can configure a host installed after the script.
+
+Claude Code provides the same command as `agento11y claude install --json`.
+
 ## Skills
 
 The binary carries agent skills: markdown workflows a coding agent reads and follows. They ship inside the binary, so there is nothing to fetch and no second CLI to install. Upgrading `agento11y` upgrades them.

--- a/plugins/agento11y/internal/agents/copilot/launch.go
+++ b/plugins/agento11y/internal/agents/copilot/launch.go
@@ -88,10 +88,47 @@ func Launch(_ context.Context, args []string, localEnv *local.LaunchEnv, _ io.Re
 // Copilot or requiring its CLI to be present. VS Code reads the same file even
 // on a machine that does not have the Copilot CLI on PATH.
 //
-// The returned value is true only when the hooks file content changed.
+// The returned value is true when it changed the hooks file or removed a
+// stale legacy plugin. When the Copilot CLI is available, cleanup failures are
+// returned so unattended deployment does not report convergence while every
+// hook would still fire twice.
 func Install() (bool, error) {
 	_, wrote, err := writeUserHooks()
-	return wrote, err
+	if err != nil {
+		return false, err
+	}
+
+	// The CLI is optional because VS Code reads the shared hook file directly.
+	// When it is available, remove the pre-migration plugin too: Copilot loads
+	// plugins and ~/.copilot/hooks together, so leaving sigil-copilot installed
+	// would export each hook twice after an unattended install.
+	bin, err := lookPath("copilot")
+	if err != nil {
+		return wrote, nil
+	}
+	removed, err := removeStalePluginForInstall(context.Background(), bin)
+	if err != nil {
+		return wrote, err
+	}
+	return wrote || removed, nil
+}
+
+// removeStalePluginForInstall removes the legacy plugin for an unattended
+// install. Unlike the launcher cleanup, it returns probe and removal errors:
+// the launcher can safely continue a user's session, while a management tool
+// needs to retry rather than declare duplicate capture healthy.
+func removeStalePluginForInstall(ctx context.Context, bin string) (bool, error) {
+	installed, err := pluginInstalled(ctx, bin)
+	if err != nil {
+		return false, fmt.Errorf("list Copilot plugins before removing legacy %s: %w", PluginName, err)
+	}
+	if !installed {
+		return false, nil
+	}
+	if err := runUninstall(ctx, bin, io.Discard); err != nil {
+		return false, fmt.Errorf("remove legacy Copilot plugin %s to prevent duplicate capture: %w", PluginName, err)
+	}
+	return true, nil
 }
 
 // installUserHooks writes the shared user-level Copilot hooks file and reports
@@ -113,7 +150,7 @@ func installUserHooks(stderr io.Writer, logger *log.Logger) {
 // removeStalePlugin uninstalls the sigil-copilot plugin if a previous sigil
 // version registered it. It is best-effort: probe and uninstall failures are
 // logged for SIGIL_DEBUG but never block the launch.
-func removeStalePlugin(bin string, stderr io.Writer, logger *log.Logger) {
+func removeStalePlugin(bin string, stderr io.Writer, logger *log.Logger) bool {
 	installed, err := pluginInstalled(context.Background(), bin)
 	if err != nil {
 		// The probe failed, so we cannot confirm whether the plugin is
@@ -126,10 +163,10 @@ func removeStalePlugin(bin string, stderr io.Writer, logger *log.Logger) {
 		if uninstallErr := runUninstall(context.Background(), bin, io.Discard); uninstallErr != nil {
 			logger.Printf("best-effort uninstall %s after probe failure: %v", PluginName, uninstallErr)
 		}
-		return
+		return false
 	}
 	if !installed {
-		return
+		return false
 	}
 	_, _ = fmt.Fprintf(stderr,
 		"agento11y: removing the legacy %s plugin (capture now runs from ~/.copilot/hooks)\n",
@@ -141,7 +178,9 @@ func removeStalePlugin(bin string, stderr io.Writer, logger *log.Logger) {
 				"agento11y: to avoid duplicate capture, remove it manually:\n"+
 				"          copilot plugin uninstall %s\n",
 			PluginName, err, PluginName)
+		return false
 	}
+	return true
 }
 
 // copilotHooksDir resolves the user-level Copilot hooks directory. It honors

--- a/plugins/agento11y/internal/agents/copilot/launch.go
+++ b/plugins/agento11y/internal/agents/copilot/launch.go
@@ -84,6 +84,16 @@ func Launch(_ context.Context, args []string, localEnv *local.LaunchEnv, _ io.Re
 	return nil
 }
 
+// Install writes the shared user-level Copilot hooks file without launching
+// Copilot or requiring its CLI to be present. VS Code reads the same file even
+// on a machine that does not have the Copilot CLI on PATH.
+//
+// The returned value is true only when the hooks file content changed.
+func Install() (bool, error) {
+	_, wrote, err := writeUserHooks()
+	return wrote, err
+}
+
 // installUserHooks writes the shared user-level Copilot hooks file and reports
 // the outcome. It never returns an error: failing to install the hooks must
 // not block the rest of the launch flow.

--- a/plugins/agento11y/internal/agents/copilot/launch_test.go
+++ b/plugins/agento11y/internal/agents/copilot/launch_test.go
@@ -412,6 +412,7 @@ func TestLaunch_MissingBinaryInstallsUserHooks(t *testing.T) {
 func TestInstall_WritesHooksWithoutCopilotCLI(t *testing.T) {
 	t.Setenv("COPILOT_HOME", t.TempDir())
 	withExecutable(t, "/usr/local/bin/agento11y")
+	withLookPath(t, func(string) (string, error) { return "", exec.ErrNotFound })
 
 	changed, err := Install()
 	require.NoError(t, err)
@@ -421,6 +422,43 @@ func TestInstall_WritesHooksWithoutCopilotCLI(t *testing.T) {
 	changed, err = Install()
 	require.NoError(t, err)
 	assert.False(t, changed)
+}
+
+func TestInstall_RemovesStalePluginWhenCopilotCLIIsAvailable(t *testing.T) {
+	t.Setenv("COPILOT_HOME", t.TempDir())
+	withExecutable(t, "/usr/local/bin/agento11y")
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/copilot", nil })
+	withPluginList(t, func(context.Context, string) ([]byte, error) {
+		return []byte("Installed plugins:\n  • sigil-copilot (v0.2.0)\n"), nil
+	})
+	removed := 0
+	withRunUninstall(t, func(context.Context, string, io.Writer) error {
+		removed++
+		return nil
+	})
+
+	changed, err := Install()
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Equal(t, 1, removed)
+	assertValidUserHooks(t, userHooksPath(t), "/usr/local/bin/agento11y copilot hook")
+}
+
+func TestInstall_ReportsStalePluginCleanupFailure(t *testing.T) {
+	t.Setenv("COPILOT_HOME", t.TempDir())
+	withExecutable(t, "/usr/local/bin/agento11y")
+	withLookPath(t, func(string) (string, error) { return "/usr/local/bin/copilot", nil })
+	withPluginList(t, func(context.Context, string) ([]byte, error) {
+		return []byte("Installed plugins:\n  • sigil-copilot (v0.2.0)\n"), nil
+	})
+	withRunUninstall(t, func(context.Context, string, io.Writer) error {
+		return errors.New("permission denied")
+	})
+
+	_, err := Install()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "remove legacy Copilot plugin sigil-copilot to prevent duplicate capture")
+	assert.ErrorContains(t, err, "permission denied")
 }
 
 // The shared hooks file must be installed and KEPT even when copilot is present

--- a/plugins/agento11y/internal/agents/copilot/launch_test.go
+++ b/plugins/agento11y/internal/agents/copilot/launch_test.go
@@ -409,6 +409,20 @@ func TestLaunch_MissingBinaryInstallsUserHooks(t *testing.T) {
 	assert.Contains(t, stderr.String(), "installed Copilot hooks at")
 }
 
+func TestInstall_WritesHooksWithoutCopilotCLI(t *testing.T) {
+	t.Setenv("COPILOT_HOME", t.TempDir())
+	withExecutable(t, "/usr/local/bin/agento11y")
+
+	changed, err := Install()
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assertValidUserHooks(t, userHooksPath(t), "/usr/local/bin/agento11y copilot hook")
+
+	changed, err = Install()
+	require.NoError(t, err)
+	assert.False(t, changed)
+}
+
 // The shared hooks file must be installed and KEPT even when copilot is present
 // and a stale plugin is uninstalled — VS Code relies on it and the CLI reads
 // the same file, so it is the single source of truth.

--- a/plugins/agento11y/internal/agents/opencode/launch.go
+++ b/plugins/agento11y/internal/agents/opencode/launch.go
@@ -47,6 +47,10 @@ const (
 	updateCheckTTL = 24 * time.Hour
 )
 
+// ErrCLINotFound means the OpenCode binary is not available on PATH for the
+// current user. Callers can defer setup until the host is installed.
+var ErrCLINotFound = errors.New("opencode CLI not found")
+
 // Test seams.
 var (
 	lookPath    = exec.LookPath
@@ -114,6 +118,26 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 		UpdateTTL:     updateCheckTTL,
 		BinaryVersion: binaryVersion,
 	})
+}
+
+// Install registers the OpenCode plugin without starting OpenCode or prompting
+// for Agent Observability credentials. The returned value is true only when
+// this invocation registered the plugin.
+func Install(ctx context.Context, stdout io.Writer, logger *log.Logger) (bool, error) {
+	migrateLegacyConfig(stdout, logger)
+	installed, probeErr := pluginInstalled()
+	if probeErr == nil && installed {
+		return false, nil
+	}
+
+	bin, err := lookPath("opencode")
+	if err != nil {
+		return false, fmt.Errorf("%w; install OpenCode or run this in the developer's user context", ErrCLINotFound)
+	}
+	if err := runInstall(ctx, bin, stdout); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {

--- a/plugins/agento11y/internal/agents/opencode/launch_test.go
+++ b/plugins/agento11y/internal/agents/opencode/launch_test.go
@@ -189,6 +189,46 @@ func TestLaunch_InvalidConfigProbeFallsThroughToInstall(t *testing.T) {
 	assert.Contains(t, logbuf.String(), "opencode config probe")
 }
 
+func TestInstall(t *testing.T) {
+	t.Run("already installed does not need host", func(t *testing.T) {
+		withConfig(t, `{"plugin":["@grafana/agento11y-opencode"]}`)
+		withLookPath(t, func(string) (string, error) { return "", exec.ErrNotFound })
+		withRunInstall(t, func(context.Context, string, io.Writer) error {
+			t.Fatal("install must not run when the plugin is registered")
+			return nil
+		})
+
+		changed, err := Install(context.Background(), io.Discard, nopLogger())
+		require.NoError(t, err)
+		assert.False(t, changed)
+	})
+
+	t.Run("missing host is reported", func(t *testing.T) {
+		withConfig(t, "")
+		withLookPath(t, func(string) (string, error) { return "", exec.ErrNotFound })
+
+		changed, err := Install(context.Background(), io.Discard, nopLogger())
+		assert.False(t, changed)
+		assert.ErrorIs(t, err, ErrCLINotFound)
+	})
+
+	t.Run("installs without launching host", func(t *testing.T) {
+		withConfig(t, "")
+		withLookPath(t, func(string) (string, error) { return "/usr/local/bin/opencode", nil })
+		calls := 0
+		withRunInstall(t, func(_ context.Context, bin string, _ io.Writer) error {
+			calls++
+			assert.Equal(t, "/usr/local/bin/opencode", bin)
+			return nil
+		})
+
+		changed, err := Install(context.Background(), io.Discard, nopLogger())
+		require.NoError(t, err)
+		assert.True(t, changed)
+		assert.Equal(t, 1, calls)
+	})
+}
+
 func TestLaunch_LocalEnv(t *testing.T) {
 	for _, tc := range []struct {
 		name       string

--- a/plugins/agento11y/internal/agents/pi/launch.go
+++ b/plugins/agento11y/internal/agents/pi/launch.go
@@ -104,7 +104,28 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 // using the same best-effort path as Launch so it does not stay frozen on the
 // old npm package name.
 func Install(ctx context.Context, stdout io.Writer, logger *log.Logger) (bool, error) {
+	// A legacy entry is usable but frozen at the pre-rename package name. Do
+	// not report it as converged while pi is absent: return missing_host so a
+	// later fleet reconciliation retries the migration once the host arrives.
+	legacy, err := legacyPluginRegistered()
+	if err != nil {
+		logger.Printf("pi legacy migration probe: %v", err)
+	} else if legacy {
+		if _, err := lookPath("pi"); err != nil {
+			return false, fmt.Errorf("%w; install pi or run this in the developer's user context", ErrCLINotFound)
+		}
+	}
+
 	migrateLegacyInstall(ctx, stdout, logger)
+	if legacy {
+		stillLegacy, err := legacyPluginRegistered()
+		if err != nil {
+			return false, fmt.Errorf("check pi legacy migration state: %w", err)
+		}
+		if stillLegacy {
+			return false, fmt.Errorf("legacy pi extension %s is still registered after migration; run `pi remove %s` and `pi install %s`", legacyPluginSource, legacyPluginSource, PluginSource)
+		}
+	}
 	installed, probeErr := pluginInstalled()
 	if probeErr == nil && installed {
 		return false, nil
@@ -118,6 +139,26 @@ func Install(ctx context.Context, stdout io.Writer, logger *log.Logger) (bool, e
 		return false, err
 	}
 	return true, nil
+}
+
+// legacyPluginRegistered reports whether either pi settings scope still names
+// the frozen pre-rename npm package. It deliberately ignores local developer
+// checkouts, matching migrateLegacyInstall's migration criteria.
+func legacyPluginRegistered() (bool, error) {
+	for _, pathFn := range []func() (string, error){settingsPath, projectSettingsPath} {
+		path, err := pathFn()
+		if err != nil {
+			return false, err
+		}
+		hasLegacy, _, err := scopeLegacyStatus(path)
+		if err != nil {
+			return false, err
+		}
+		if hasLegacy {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {

--- a/plugins/agento11y/internal/agents/pi/launch.go
+++ b/plugins/agento11y/internal/agents/pi/launch.go
@@ -45,6 +45,10 @@ const (
 	projectConfigDirName = ".pi"
 )
 
+// ErrCLINotFound means the pi binary is not available on PATH for the current
+// user. Callers can defer setup until the host is installed.
+var ErrCLINotFound = errors.New("pi CLI not found")
+
 // Test seams.
 var (
 	lookPath   = exec.LookPath
@@ -92,6 +96,28 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 		},
 		// No Update: pi's own installer handles upgrades.
 	})
+}
+
+// Install registers the pi extension without starting pi or prompting for
+// Agent Observability credentials. The returned value is true only when this
+// invocation registered the extension. A legacy extension is first migrated
+// using the same best-effort path as Launch so it does not stay frozen on the
+// old npm package name.
+func Install(ctx context.Context, stdout io.Writer, logger *log.Logger) (bool, error) {
+	migrateLegacyInstall(ctx, stdout, logger)
+	installed, probeErr := pluginInstalled()
+	if probeErr == nil && installed {
+		return false, nil
+	}
+
+	bin, err := lookPath("pi")
+	if err != nil {
+		return false, fmt.Errorf("%w; install pi or run this in the developer's user context", ErrCLINotFound)
+	}
+	if err := runInstall(ctx, bin, stdout); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {

--- a/plugins/agento11y/internal/agents/pi/launch_test.go
+++ b/plugins/agento11y/internal/agents/pi/launch_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 
 	"github.com/grafana/agento11y/plugins/agento11y/internal/local"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLaunch_MissingPiBinary(t *testing.T) {
@@ -281,6 +283,54 @@ func TestLaunch_RunsInstallWhenPackageMissing(t *testing.T) {
 	if !strings.Contains(stderr.String(), "installing "+PluginSource) {
 		t.Fatalf("stderr missing install message: %q", stderr.String())
 	}
+}
+
+func TestInstall(t *testing.T) {
+	t.Run("already installed does not need host", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSettings(t, dir, `{"packages":["npm:@grafana/agento11y-pi"]}`)
+		t.Setenv("PI_CODING_AGENT_DIR", dir)
+		withLookPath(t, func(string) (string, error) { return "", exec.ErrNotFound })
+		withRunInstall(t, func(context.Context, string, io.Writer) error {
+			t.Fatal("install must not run when the extension is registered")
+			return nil
+		})
+
+		changed, err := Install(context.Background(), io.Discard, nopLogger())
+		require.NoError(t, err)
+		assert.False(t, changed)
+	})
+
+	t.Run("missing host is reported", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSettings(t, dir, `{"packages":[]}`)
+		t.Setenv("PI_CODING_AGENT_DIR", dir)
+		withLookPath(t, func(string) (string, error) { return "", exec.ErrNotFound })
+
+		changed, err := Install(context.Background(), io.Discard, nopLogger())
+		assert.False(t, changed)
+		assert.ErrorIs(t, err, ErrCLINotFound)
+	})
+
+	t.Run("installs without launching host", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSettings(t, dir, `{"packages":[]}`)
+		t.Setenv("PI_CODING_AGENT_DIR", dir)
+		withLookPath(t, func(string) (string, error) { return "/usr/local/bin/pi", nil })
+		calls := 0
+		withRunInstall(t, func(_ context.Context, bin string, _ io.Writer) error {
+			calls++
+			if bin != "/usr/local/bin/pi" {
+				t.Fatalf("bin = %q", bin)
+			}
+			return nil
+		})
+
+		changed, err := Install(context.Background(), io.Discard, nopLogger())
+		require.NoError(t, err)
+		assert.True(t, changed)
+		assert.Equal(t, 1, calls)
+	})
 }
 
 // A failed `pi install` should not block the user's session. The launcher

--- a/plugins/agento11y/internal/agents/pi/launch_test.go
+++ b/plugins/agento11y/internal/agents/pi/launch_test.go
@@ -312,6 +312,35 @@ func TestInstall(t *testing.T) {
 		assert.ErrorIs(t, err, ErrCLINotFound)
 	})
 
+	t.Run("legacy package with missing host defers migration", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSettings(t, dir, `{"packages":["npm:@grafana/sigil-pi@0.17.0"]}`)
+		t.Setenv("PI_CODING_AGENT_DIR", dir)
+		withLookPath(t, func(string) (string, error) { return "", exec.ErrNotFound })
+		withRunPi(t, func(context.Context, string, io.Writer, ...string) error {
+			t.Fatal("migration must not run while pi is absent")
+			return nil
+		})
+
+		changed, err := Install(context.Background(), io.Discard, nopLogger())
+		assert.False(t, changed)
+		assert.ErrorIs(t, err, ErrCLINotFound)
+	})
+
+	t.Run("legacy package that remains after migration reports a retryable error", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSettings(t, dir, `{"packages":["npm:@grafana/sigil-pi@0.17.0"]}`)
+		t.Setenv("PI_CODING_AGENT_DIR", dir)
+		withLookPath(t, func(string) (string, error) { return "/usr/local/bin/pi", nil })
+		withRunPi(t, func(context.Context, string, io.Writer, ...string) error {
+			return errors.New("registry unavailable")
+		})
+
+		changed, err := Install(context.Background(), io.Discard, nopLogger())
+		assert.False(t, changed)
+		assert.ErrorContains(t, err, "legacy pi extension npm:@grafana/sigil-pi is still registered after migration")
+	})
+
 	t.Run("installs without launching host", func(t *testing.T) {
 		dir := t.TempDir()
 		writeSettings(t, dir, `{"packages":[]}`)

--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -131,7 +131,7 @@ func localPrivacyLines(posture local.ForwardPosture, known bool) []string {
 func usageLine() string {
 	return "usage: agento11y login [--endpoint url] [--tenant id] [--token value|--token-stdin] " +
 		"[--otlp-endpoint url] [--no-verify] [--yes] | agento11y doctor [--json] | " +
-		"agento11y claude install [--json] | " +
+		"agento11y <claude|copilot|opencode|pi> install [--json] | " +
 		"agento11y skills list|show <name> | agento11y local start|status|stop | " +
 		"agento11y history import <" + historyAgentNames() + "> | agento11y cursor install|uninstall | agento11y <agent> hook | " +
 		"agento11y <claude|codex|copilot|opencode|pi|vibe> [--local|--no-local] [--tag key=value]... [-- args...]"
@@ -190,6 +190,9 @@ var (
 	cursorInstall   = cursorinstall.Run
 	cursorUninstall = cursorinstall.Uninstall
 	claudeInstall   = claudecode.Install
+	copilotInstall  = copilot.Install
+	opencodeInstall = opencode.Install
+	piInstall       = pi.Install
 )
 
 // Main is the entrypoint shared by cmd/agento11y and cmd/sigil.
@@ -247,11 +250,12 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 		return
 	}
 
-	// `agento11y claude install` is the noninteractive counterpart to the
-	// launcher. Managed deployment tooling uses it after placing a config.env
-	// for the current user; it never launches Claude or prompts.
-	if args[0] == "claude" && len(args) >= 2 && args[1] == "install" {
-		runClaudeInstall(args[2:], stdout, stderr)
+	// These installers configure one host without launching it or prompting for
+	// Agent Observability credentials. They are safe to invoke from unattended
+	// setup after the current user's config.env is in place.
+	if len(args) >= 2 && args[1] == "install" &&
+		(args[0] == "claude" || args[0] == "copilot" || args[0] == "opencode" || args[0] == "pi") {
+		runAgentInstall(args[0], args[2:], stdout, stderr)
 		return
 	}
 
@@ -714,16 +718,16 @@ type agentInstallResult struct {
 	Error  string `json:"error,omitempty"`
 }
 
-// runClaudeInstall registers the Claude Code plugin without entering an
-// interactive setup flow or starting Claude. It is intended for managed-device
-// tooling, which writes config.env separately for each user.
-func runClaudeInstall(args []string, stdout, stderr io.Writer) {
-	fs := flag.NewFlagSet("claude install", flag.ContinueOnError)
+// runAgentInstall registers one supported host integration without entering an
+// interactive setup flow or starting the host. It is suitable for scripts
+// after the current user's config.env has been created.
+func runAgentInstall(agent string, args []string, stdout, stderr io.Writer) {
+	fs := flag.NewFlagSet(agent+" install", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var asJSON bool
 	fs.BoolVar(&asJSON, "json", false, "print a machine-readable result")
 	if err := fs.Parse(args); err != nil || fs.NArg() != 0 {
-		_, _ = fmt.Fprintln(stderr, "usage: agento11y claude install [--json]")
+		_, _ = fmt.Fprintf(stderr, "usage: agento11y %s install [--json]\n", agent)
 		exit(2)
 		return
 	}
@@ -732,10 +736,21 @@ func runClaudeInstall(args []string, stdout, stderr io.Writer) {
 	if asJSON {
 		writer = io.Discard
 	}
-	result := agentInstallResult{Agent: "claude"}
-	changed, err := claudeInstall(context.Background(), writer)
+	result := agentInstallResult{Agent: agent}
+	var changed bool
+	var err error
+	switch agent {
+	case "claude":
+		changed, err = claudeInstall(context.Background(), writer)
+	case "copilot":
+		changed, err = copilotInstall()
+	case "opencode":
+		changed, err = opencodeInstall(context.Background(), writer, cli.InitLogger("opencode"))
+	case "pi":
+		changed, err = piInstall(context.Background(), writer, cli.InitLogger("pi"))
+	}
 	switch {
-	case errors.Is(err, claudecode.ErrCLINotFound):
+	case errors.Is(err, claudecode.ErrCLINotFound), errors.Is(err, opencode.ErrCLINotFound), errors.Is(err, pi.ErrCLINotFound):
 		result.Status = "missing_host"
 	case err != nil:
 		result.Status, result.Error = "error", err.Error()
@@ -748,7 +763,7 @@ func runClaudeInstall(args []string, stdout, stderr io.Writer) {
 	if asJSON {
 		data, err := json.Marshal(result)
 		if err != nil {
-			_, _ = fmt.Fprintf(stderr, "agento11y claude install: encode result: %v\n", err)
+			_, _ = fmt.Fprintf(stderr, "agento11y %s install: encode result: %v\n", agent, err)
 			exit(1)
 			return
 		} else {

--- a/plugins/agento11y/internal/entry/entry_test.go
+++ b/plugins/agento11y/internal/entry/entry_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/claudecode"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/pi"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/local"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/login"
@@ -769,6 +770,27 @@ func withStubClaudeInstall(t *testing.T, fn func(context.Context, io.Writer) (bo
 	claudeInstall = fn
 }
 
+func withStubCopilotInstall(t *testing.T, fn func() (bool, error)) {
+	t.Helper()
+	prev := copilotInstall
+	t.Cleanup(func() { copilotInstall = prev })
+	copilotInstall = fn
+}
+
+func withStubOpenCodeInstall(t *testing.T, fn func(context.Context, io.Writer, *log.Logger) (bool, error)) {
+	t.Helper()
+	prev := opencodeInstall
+	t.Cleanup(func() { opencodeInstall = prev })
+	opencodeInstall = fn
+}
+
+func withStubPiInstall(t *testing.T, fn func(context.Context, io.Writer, *log.Logger) (bool, error)) {
+	t.Helper()
+	prev := piInstall
+	t.Cleanup(func() { piInstall = prev })
+	piInstall = fn
+}
+
 func TestRun_ClaudeInstallJSON(t *testing.T) {
 	withStubClaudeInstall(t, func(context.Context, io.Writer) (bool, error) { return true, nil })
 
@@ -798,6 +820,51 @@ func TestRun_ClaudeInstallReportsMissingHost(t *testing.T) {
 	var result agentInstallResult
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result), "stdout=%q", stdout.String())
 	assert.Equal(t, agentInstallResult{Agent: "claude", Status: "missing_host"}, result)
+}
+
+func TestRun_AgentInstallsJSON(t *testing.T) {
+	cases := []struct {
+		agent string
+		stub  func(t *testing.T)
+		want  agentInstallResult
+	}{
+		{
+			agent: "copilot",
+			stub: func(t *testing.T) {
+				withStubCopilotInstall(t, func() (bool, error) { return true, nil })
+			},
+			want: agentInstallResult{Agent: "copilot", Status: "installed"},
+		},
+		{
+			agent: "opencode",
+			stub: func(t *testing.T) {
+				withStubOpenCodeInstall(t, func(context.Context, io.Writer, *log.Logger) (bool, error) { return false, nil })
+			},
+			want: agentInstallResult{Agent: "opencode", Status: "already_installed"},
+		},
+		{
+			agent: "pi",
+			stub: func(t *testing.T) {
+				withStubPiInstall(t, func(context.Context, io.Writer, *log.Logger) (bool, error) { return false, pi.ErrCLINotFound })
+			},
+			want: agentInstallResult{Agent: "pi", Status: "missing_host"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.agent, func(t *testing.T) {
+			tc.stub(t)
+			var stdout, stderr bytes.Buffer
+			gotExit := withExit(t, func() {
+				run([]string{tc.agent, "install", "--json"}, strings.NewReader(""), &stdout, &stderr)
+			})
+			require.Nil(t, gotExit, "stderr=%q", stderr.String())
+			require.Empty(t, stderr.String())
+
+			var result agentInstallResult
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &result), "stdout=%q", stdout.String())
+			assert.Equal(t, tc.want, result)
+		})
+	}
 }
 
 // withStubLauncher replaces the launchers map with a single entry for the


### PR DESCRIPTION
## What

- Add noninteractive `agento11y copilot install --json`, `agento11y opencode install --json`, and `agento11y pi install --json` commands.
- Reuse each host adapter's existing idempotent setup behavior without starting the host agent or prompting for credentials.
- Report `installed`, `already_installed`, `missing_host`, or `error` in a secret-free JSON result.
- Document the scriptable setup path and add adapter and CLI coverage.

## Why

Claude Code and Cursor already have scriptable setup paths. This gives GitHub Copilot, OpenCode, and pi equivalent per-agent primitives while keeping the command surface MDM-agnostic. A fleet-level aggregate/reconciliation layer is deliberately out of scope for this PR.

## Verification

- `GOWORK=off go test ./internal/agents/copilot ./internal/agents/opencode ./internal/agents/pi ./internal/entry`
- `GOWORK=off go build ./cmd/agento11y`

I also ran `GOWORK=off go test ./internal/...`; all affected packages passed, but the existing unrelated `internal/login` test `TestPasteFieldReceivesAFlattenedBlock` failed both in the full run and in isolation. This diff does not modify that package.
