### PR TITLE
feat(plugins/agento11y): reconcile managed agent installs

### DIFF
--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -74,6 +74,16 @@ deferral, so a later run can configure a host installed after the script.
 
 Claude Code provides the same command as `agento11y claude install --json`.
 
+## Fleet reconciliation
+
+For MDM, configuration management, and other unattended rollout tools, reconcile the noninteractive host installers and receive one JSON result per agent:
+
+```sh
+agento11y agents reconcile --agents all --json
+```
+
+`all` includes every noninteractive installer registered in the installed binary, including an agent added by a future release. To target a fixed allowlist, pass names instead: `--agents claude,cursor`. The command never launches a coding agent or opens a login prompt. Its receipt reports `installed`, `already_installed`, `missing_host`, or a per-agent descriptive error; it exits non-zero only when an installer fails. This command contains no MDM-vendor, credential, or device-policy assumptions.
+
 ## Skills
 
 The binary carries agent skills: markdown workflows a coding agent reads and follows. They ship inside the binary, so there is nothing to fetch and no second CLI to install. Upgrading `agento11y` upgrades them.

--- a/plugins/agento11y/internal/agentinstall/registry.go
+++ b/plugins/agento11y/internal/agentinstall/registry.go
@@ -1,0 +1,67 @@
+// Package agentinstall holds the noninteractive installer registry used by
+// agento11y agents reconcile. Agent adapters register their own installer so
+// the fleet command does not need a separately maintained list of agents.
+package agentinstall
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"slices"
+	"strings"
+	"sync"
+)
+
+// InstallFunc configures one host integration without launching the host or
+// prompting for credentials. changed is true only when it modified host state.
+type InstallFunc func(ctx context.Context, stdout io.Writer, logger *log.Logger) (changed bool, err error)
+
+// Spec describes one agent that agents reconcile can configure.
+type Spec struct {
+	Name          string
+	Install       InstallFunc
+	IsMissingHost func(error) bool
+}
+
+var (
+	mu     sync.RWMutex
+	byName = map[string]Spec{}
+)
+
+// Register adds one noninteractive installer. It is intended for adapter
+// package init functions. Invalid or duplicate registrations are programmer
+// errors, so they panic while the binary starts instead of silently changing
+// a fleet command's behavior.
+func Register(spec Spec) {
+	spec.Name = strings.TrimSpace(spec.Name)
+	if spec.Name == "" {
+		panic("agentinstall: register installer with empty name")
+	}
+	if strings.ContainsAny(spec.Name, ", \t\r\n") {
+		panic(fmt.Sprintf("agentinstall: invalid installer name %q", spec.Name))
+	}
+	if spec.Install == nil {
+		panic(fmt.Sprintf("agentinstall: register %q without an install function", spec.Name))
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if _, exists := byName[spec.Name]; exists {
+		panic(fmt.Sprintf("agentinstall: duplicate installer registration for %q", spec.Name))
+	}
+	byName[spec.Name] = spec
+}
+
+// All returns the registered installers sorted by name. Each call returns an
+// independent slice so callers cannot mutate the registry.
+func All() []Spec {
+	mu.RLock()
+	defer mu.RUnlock()
+	out := make([]Spec, 0, len(byName))
+	for _, spec := range byName {
+		out = append(out, spec)
+	}
+	slices.SortFunc(out, func(a, b Spec) int { return strings.Compare(a.Name, b.Name) })
+	return out
+}

--- a/plugins/agento11y/internal/agents/claudecode/launch.go
+++ b/plugins/agento11y/internal/agents/claudecode/launch.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agentinstall"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/launcher"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/local"
 )
@@ -45,6 +46,16 @@ const (
 // ErrCLINotFound means the Claude Code binary is not available on PATH for the
 // current user. Managed deployment tooling can treat this as a skipped agent.
 var ErrCLINotFound = errors.New("claude CLI not found")
+
+func init() {
+	agentinstall.Register(agentinstall.Spec{
+		Name: "claude",
+		Install: func(ctx context.Context, stdout io.Writer, _ *log.Logger) (bool, error) {
+			return Install(ctx, stdout)
+		},
+		IsMissingHost: func(err error) bool { return errors.Is(err, ErrCLINotFound) },
+	})
+}
 
 // Test seams.
 var (

--- a/plugins/agento11y/internal/agents/cursor/install/install.go
+++ b/plugins/agento11y/internal/agents/cursor/install/install.go
@@ -17,6 +17,7 @@ package install
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -27,6 +28,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agentinstall"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/execpath"
 )
 
@@ -48,6 +50,22 @@ var cursorEvents = []string{
 
 // Test seam.
 var userHomeDir = os.UserHomeDir
+
+func init() {
+	agentinstall.Register(agentinstall.Spec{
+		Name: "cursor",
+		Install: func(_ context.Context, stdout io.Writer, logger *log.Logger) (bool, error) {
+			installed, err := Status()
+			if err != nil {
+				return false, fmt.Errorf("read Cursor hook state: %w", err)
+			}
+			if err := Run(stdout, io.Discard, logger); err != nil {
+				return false, fmt.Errorf("write Cursor hooks: %w", err)
+			}
+			return !installed, nil
+		},
+	})
+}
 
 // hookEntry is a single Cursor hook command entry. Cursor entries may carry
 // other fields, but agento11y only ever writes the command; extra fields on other

--- a/plugins/agento11y/internal/agents/cursor/install/install.go
+++ b/plugins/agento11y/internal/agents/cursor/install/install.go
@@ -55,14 +55,11 @@ func init() {
 	agentinstall.Register(agentinstall.Spec{
 		Name: "cursor",
 		Install: func(_ context.Context, stdout io.Writer, logger *log.Logger) (bool, error) {
-			installed, err := Status()
+			changed, err := Reconcile(stdout, io.Discard, logger)
 			if err != nil {
-				return false, fmt.Errorf("read Cursor hook state: %w", err)
-			}
-			if err := Run(stdout, io.Discard, logger); err != nil {
 				return false, fmt.Errorf("write Cursor hooks: %w", err)
 			}
-			return !installed, nil
+			return changed, nil
 		},
 	})
 }
@@ -81,25 +78,37 @@ type hookEntry struct {
 // install, or a legacy run.sh entry when detectable) is replaced in place to
 // avoid double-firing capture. The write is atomic and idempotent — when the
 // result already matches what is on disk, the file is left untouched.
-func Run(stdout, _ io.Writer, logger *log.Logger) error {
+func Run(stdout, stderr io.Writer, logger *log.Logger) error {
+	_, err := Reconcile(stdout, stderr, logger)
+	return err
+}
+
+// Reconcile has the same behavior as Run and also reports whether it modified
+// the hooks file. Management tooling uses this result for an accurate
+// installed versus already_installed receipt.
+//
+// A Status probe alone cannot provide that result: Status intentionally treats
+// legacy run.sh entries and hooks pointing to another agento11y binary as
+// installed, while this function upgrades those entries in place.
+func Reconcile(stdout, _ io.Writer, logger *log.Logger) (bool, error) {
 	path, err := cursorHooksPath()
 	if err != nil {
-		return err
+		return false, err
 	}
 	cmd, err := execpath.HookCommand("cursor hook")
 	if err != nil {
-		return err
+		return false, err
 	}
 	logger.Printf("cursor install: hooks=%s command=%q", path, cmd)
 
 	doc, err := loadHooks(path)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	entry, err := json.Marshal(hookEntry{Command: cmd})
 	if err != nil {
-		return fmt.Errorf("encode cursor hook entry: %w", err)
+		return false, fmt.Errorf("encode cursor hook entry: %w", err)
 	}
 	for _, event := range cursorEvents {
 		doc.hooks[event] = upsertOurs(doc.hooks[event], entry)
@@ -107,14 +116,14 @@ func Run(stdout, _ io.Writer, logger *log.Logger) error {
 
 	wrote, err := writeHooks(path, doc)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if wrote {
 		_, _ = fmt.Fprintf(stdout, "agento11y: wired Cursor hooks at %s\n", path)
 	} else {
 		_, _ = fmt.Fprintf(stdout, "agento11y: Cursor hooks already up to date at %s\n", path)
 	}
-	return nil
+	return wrote, nil
 }
 
 // Uninstall removes agento11y's hook entries from ~/.cursor/hooks.json, leaving

--- a/plugins/agento11y/internal/agents/cursor/install/install_test.go
+++ b/plugins/agento11y/internal/agents/cursor/install/install_test.go
@@ -240,6 +240,32 @@ func TestRun_Idempotent(t *testing.T) {
 	assert.Contains(t, stdout.String(), "already up to date")
 }
 
+func TestReconcileReportsRewriteOfStaleOwnedHooks(t *testing.T) {
+	home := t.TempDir()
+	withHome(t, home)
+	withExecutable(t, testBin)
+
+	legacyHooks := make(map[string][]map[string]string, len(cursorEvents))
+	for _, event := range cursorEvents {
+		legacyHooks[event] = []map[string]string{{"command": "/old/bin/sigil cursor hook"}}
+	}
+	seed, err := json.Marshal(map[string]any{"version": 1, "hooks": legacyHooks})
+	require.NoError(t, err)
+	seedHooks(t, home, string(seed))
+
+	installed, err := Status()
+	require.NoError(t, err)
+	assert.True(t, installed, "Status recognises stale owned hooks as installed")
+
+	changed, err := Reconcile(io.Discard, io.Discard, nopLogger())
+	require.NoError(t, err)
+	assert.True(t, changed, "reconciliation rewrites stale binary paths")
+
+	changed, err = Reconcile(io.Discard, io.Discard, nopLogger())
+	require.NoError(t, err)
+	assert.False(t, changed, "the exact desired hook file is already converged")
+}
+
 // A corrupt hooks.json must abort with an error and leave the file byte-for-byte
 // untouched, so a file shared with other tools is never lost to a partial
 // rewrite.

--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -50,6 +50,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agentinstall"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/claudecode"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/codex"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/copilot"
@@ -131,7 +132,7 @@ func localPrivacyLines(posture local.ForwardPosture, known bool) []string {
 func usageLine() string {
 	return "usage: agento11y login [--endpoint url] [--tenant id] [--token value|--token-stdin] " +
 		"[--otlp-endpoint url] [--no-verify] [--yes] | agento11y doctor [--json] | " +
-		"agento11y <claude|copilot|opencode|pi> install [--json] | " +
+		"agento11y <claude|copilot|opencode|pi> install [--json] | agento11y agents reconcile --agents all|name[,name...] --json | " +
 		"agento11y skills list|show <name> | agento11y local start|status|stop | " +
 		"agento11y history import <" + historyAgentNames() + "> | agento11y cursor install|uninstall | agento11y <agent> hook | " +
 		"agento11y <claude|codex|copilot|opencode|pi|vibe> [--local|--no-local] [--tag key=value]... [-- args...]"
@@ -183,6 +184,10 @@ var exit = os.Exit
 // loginRun is a package var so tests can stub the interactive login flow
 // without driving the huh TTY. Production code points at login.Run.
 var loginRun = login.Run
+
+// registeredInstallers is a seam for reconciliation tests. Production returns
+// every adapter that registered a noninteractive installer at package init.
+var registeredInstallers = agentinstall.All
 
 // cursorInstall and cursorUninstall are package vars so tests can stub the
 // filesystem-touching `agento11y cursor install`/`uninstall` flow.
@@ -247,6 +252,11 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 	// dispatch like `local`. It owns its own flag parsing.
 	if args[0] == "doctor" {
 		runDoctorCommand(args[1:], stdout, stderr)
+		return
+	}
+
+	if args[0] == "agents" {
+		runAgentsReconcile(args[1:], stdout, stderr)
 		return
 	}
 
@@ -773,6 +783,164 @@ func runAgentInstall(agent string, args []string, stdout, stderr io.Writer) {
 	if result.Status == "error" {
 		exit(1)
 	}
+}
+
+const agentReconcileSchemaVersion = 1
+
+// agentReconcileReport is a stable, secret-free result for any management
+// system or script. Credential and policy lifecycle remain outside the binary.
+type agentReconcileReport struct {
+	SchemaVersion int                  `json:"schema_version"`
+	Status        string               `json:"status"`
+	Agento11y     reconcileBinary      `json:"agento11y"`
+	Agents        []agentInstallResult `json:"agents"`
+}
+
+type reconcileBinary struct {
+	Version string `json:"version"`
+}
+
+// runAgentsReconcile runs only installers registered by host adapters. Adding
+// a noninteractive adapter registration automatically makes it available here;
+// this command deliberately has no MDM-, credential-, or policy-specific code.
+func runAgentsReconcile(args []string, stdout, stderr io.Writer) {
+	if len(args) == 0 || args[0] != "reconcile" {
+		_, _ = fmt.Fprintln(stderr, "usage: agento11y agents reconcile --agents all|name[,name...] --json")
+		exit(2)
+		return
+	}
+
+	fs := flag.NewFlagSet("agents reconcile", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var rawAgents string
+	var asJSON bool
+	fs.StringVar(&rawAgents, "agents", "", "comma-separated registered agent installers")
+	fs.BoolVar(&asJSON, "json", false, "print a machine-readable reconciliation receipt")
+	if err := fs.Parse(args[1:]); err != nil || fs.NArg() != 0 {
+		_, _ = fmt.Fprintln(stderr, "usage: agento11y agents reconcile --agents all|name[,name...] --json")
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "agento11y agents reconcile: invalid flags: %v\n", err)
+		} else {
+			_, _ = fmt.Fprintln(stderr, "agento11y agents reconcile: positional arguments are not supported")
+		}
+		exit(2)
+		return
+	}
+
+	specs := registeredInstallers()
+	available := make(map[string]agentinstall.Spec, len(specs))
+	availableNames := make([]string, 0, len(specs))
+	for _, spec := range specs {
+		available[spec.Name] = spec
+		availableNames = append(availableNames, spec.Name)
+	}
+	if len(availableNames) == 0 {
+		_, _ = fmt.Fprintln(stderr, "agento11y agents reconcile: no noninteractive installers are registered in this binary")
+		exit(1)
+		return
+	}
+	if strings.TrimSpace(rawAgents) == "" {
+		_, _ = fmt.Fprintln(stderr, "usage: agento11y agents reconcile --agents all|name[,name...] --json")
+		_, _ = fmt.Fprintf(stderr, "agento11y agents reconcile: --agents is required; available installers: %s\n", strings.Join(availableNames, ", "))
+		exit(2)
+		return
+	}
+	if !asJSON {
+		_, _ = fmt.Fprintln(stderr, "usage: agento11y agents reconcile --agents all|name[,name...] --json")
+		_, _ = fmt.Fprintln(stderr, "agento11y agents reconcile: --json is required so management tooling can parse the reconciliation receipt")
+		exit(2)
+		return
+	}
+
+	selected, ok := parseReconcileAgents(rawAgents, available, availableNames, stderr)
+	if !ok {
+		return
+	}
+
+	report := make([]agentInstallResult, 0, len(selected))
+	failed := false
+	missingHost := false
+	for _, spec := range selected {
+		changed, err := spec.Install(context.Background(), io.Discard, cli.InitLogger("reconcile-"+spec.Name))
+		result := agentInstallResult{Agent: spec.Name}
+		switch {
+		case err != nil && spec.IsMissingHost != nil && spec.IsMissingHost(err):
+			result.Status = "missing_host"
+			missingHost = true
+		case err != nil:
+			result.Status = "error"
+			result.Error = fmt.Sprintf("%s install failed: %v", spec.Name, err)
+			failed = true
+		case changed:
+			result.Status = "installed"
+		default:
+			result.Status = "already_installed"
+		}
+		report = append(report, result)
+	}
+
+	status := "converged"
+	if failed {
+		status = "error"
+	} else if missingHost {
+		status = "deferred_missing_host"
+	}
+	receipt := agentReconcileReport{
+		SchemaVersion: agentReconcileSchemaVersion,
+		Status:        status,
+		Agento11y:     reconcileBinary{Version: version},
+		Agents:        report,
+	}
+	data, err := json.Marshal(receipt)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "agento11y agents reconcile: could not encode reconciliation receipt: %v\n", err)
+		exit(1)
+		return
+	}
+	_, _ = fmt.Fprintln(stdout, string(data))
+	if failed {
+		exit(1)
+	}
+}
+
+func parseReconcileAgents(raw string, available map[string]agentinstall.Spec, availableNames []string, stderr io.Writer) ([]agentinstall.Spec, bool) {
+	if strings.TrimSpace(raw) == "all" {
+		selected := make([]agentinstall.Spec, 0, len(availableNames))
+		for _, name := range availableNames {
+			selected = append(selected, available[name])
+		}
+		return selected, true
+	}
+
+	selected := make([]agentinstall.Spec, 0)
+	seen := map[string]bool{}
+	for name := range strings.SplitSeq(raw, ",") {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			_, _ = fmt.Fprintln(stderr, "agento11y agents reconcile: --agents contains an empty name; use a comma-separated list such as claude,cursor")
+			exit(2)
+			return nil, false
+		}
+		if name == "all" {
+			_, _ = fmt.Fprintln(stderr, "agento11y agents reconcile: --agents=all must be used by itself; do not combine it with named agents")
+			exit(2)
+			return nil, false
+		}
+		if seen[name] {
+			_, _ = fmt.Fprintf(stderr, "agento11y agents reconcile: --agents repeats %q; name each agent once\n", name)
+			exit(2)
+			return nil, false
+		}
+		spec, found := available[name]
+		if !found {
+			_, _ = fmt.Fprintf(stderr, "agento11y agents reconcile: %q has no noninteractive installer in this binary (available: %s)\n", name, strings.Join(availableNames, ", "))
+			exit(2)
+			return nil, false
+		}
+		seen[name] = true
+		selected = append(selected, spec)
+	}
+	return selected, true
 }
 
 // runDoctorCommand handles `agento11y doctor`. doctor is strictly read-only and

--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -12,6 +12,7 @@
 //	agento11y vibe     [--local|--no-local] [--tag k=v] [-- args...]  — exec vibe after installing the sigil hook in vibe's hooks.toml
 //	agento11y cursor   install|uninstall                              — wire (or remove) the Cursor hook in ~/.cursor/hooks.json
 //	agento11y claude   install [--json]                               — register the Claude Code plugin without launching or prompting
+//	agento11y agents   reconcile --agents all|name[,name...] --json   — reconcile registered noninteractive installers
 //	agento11y local start|status|stop                                 — manage the local capture daemon
 //	agento11y history import <agent> [flags]                          — backfill an agent's existing local sessions
 //	agento11y skills list|show <name>                                 — print an agent skill bundled into this binary

--- a/plugins/agento11y/internal/entry/entry_test.go
+++ b/plugins/agento11y/internal/entry/entry_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agentinstall"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/claudecode"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/pi"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
@@ -770,6 +771,22 @@ func withStubClaudeInstall(t *testing.T, fn func(context.Context, io.Writer) (bo
 	claudeInstall = fn
 }
 
+func withStubRegisteredInstallers(t *testing.T, specs []agentinstall.Spec) {
+	t.Helper()
+	prev := registeredInstallers
+	t.Cleanup(func() { registeredInstallers = prev })
+	registeredInstallers = func() []agentinstall.Spec { return specs }
+}
+
+func TestRegisteredInstallersIncludeExistingManagedInstallers(t *testing.T) {
+	names := make([]string, 0)
+	for _, spec := range registeredInstallers() {
+		names = append(names, spec.Name)
+	}
+	assert.Contains(t, names, "claude")
+	assert.Contains(t, names, "cursor")
+}
+
 func withStubCopilotInstall(t *testing.T, fn func() (bool, error)) {
 	t.Helper()
 	prev := copilotInstall
@@ -863,6 +880,123 @@ func TestRun_AgentInstallsJSON(t *testing.T) {
 			var result agentInstallResult
 			require.NoError(t, json.Unmarshal(stdout.Bytes(), &result), "stdout=%q", stdout.String())
 			assert.Equal(t, tc.want, result)
+		})
+	}
+}
+
+func TestRun_AgentsReconcileJSON(t *testing.T) {
+	prevVersion := version
+	version = "v0.0.1-test"
+	t.Cleanup(func() { version = prevVersion })
+
+	called := make([]string, 0, 2)
+	withStubRegisteredInstallers(t, []agentinstall.Spec{
+		{Name: "claude", Install: func(context.Context, io.Writer, *log.Logger) (bool, error) {
+			called = append(called, "claude")
+			return true, nil
+		}},
+		{Name: "cursor", Install: func(context.Context, io.Writer, *log.Logger) (bool, error) {
+			called = append(called, "cursor")
+			return false, nil
+		}},
+	})
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"agents", "reconcile", "--agents", "cursor,claude", "--json"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	require.Nil(t, gotExit, "stderr=%q", stderr.String())
+	require.Empty(t, stderr.String())
+	assert.Equal(t, []string{"cursor", "claude"}, called)
+
+	var result agentReconcileReport
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result), "stdout=%q", stdout.String())
+	assert.Equal(t, agentReconcileReport{
+		SchemaVersion: agentReconcileSchemaVersion,
+		Status:        "converged",
+		Agento11y:     reconcileBinary{Version: "v0.0.1-test"},
+		Agents: []agentInstallResult{
+			{Agent: "cursor", Status: "already_installed"},
+			{Agent: "claude", Status: "installed"},
+		},
+	}, result)
+}
+
+func TestRun_AgentsReconcileAllIncludesNewlyRegisteredInstallers(t *testing.T) {
+	called := make([]string, 0, 3)
+	withStubRegisteredInstallers(t, []agentinstall.Spec{
+		{Name: "claude", Install: func(context.Context, io.Writer, *log.Logger) (bool, error) {
+			called = append(called, "claude")
+			return false, nil
+		}},
+		{Name: "cursor", Install: func(context.Context, io.Writer, *log.Logger) (bool, error) {
+			called = append(called, "cursor")
+			return false, nil
+		}},
+		{Name: "opencode", Install: func(context.Context, io.Writer, *log.Logger) (bool, error) {
+			called = append(called, "opencode")
+			return true, nil
+		}},
+	})
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"agents", "reconcile", "--agents", "all", "--json"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	require.Nil(t, gotExit, "stderr=%q", stderr.String())
+	assert.Equal(t, []string{"claude", "cursor", "opencode"}, called)
+	assert.Contains(t, stdout.String(), `"agent":"opencode","status":"installed"`)
+}
+
+func TestRun_AgentsReconcileReportsMissingHostAndInstallerErrors(t *testing.T) {
+	withStubRegisteredInstallers(t, []agentinstall.Spec{
+		{Name: "claude", Install: func(context.Context, io.Writer, *log.Logger) (bool, error) { return false, claudecode.ErrCLINotFound }, IsMissingHost: func(err error) bool { return errors.Is(err, claudecode.ErrCLINotFound) }},
+		{Name: "opencode", Install: func(context.Context, io.Writer, *log.Logger) (bool, error) {
+			return false, errors.New("could not write plugin file: permission denied")
+		}},
+	})
+
+	var stdout, stderr bytes.Buffer
+	gotExit := withExit(t, func() {
+		run([]string{"agents", "reconcile", "--agents", "claude,opencode", "--json"}, strings.NewReader(""), &stdout, &stderr)
+	})
+	require.NotNil(t, gotExit)
+	assert.Equal(t, 1, *gotExit)
+	require.Empty(t, stderr.String())
+
+	var result agentReconcileReport
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result), "stdout=%q", stdout.String())
+	assert.Equal(t, "error", result.Status)
+	assert.Equal(t, []agentInstallResult{
+		{Agent: "claude", Status: "missing_host"},
+		{Agent: "opencode", Status: "error", Error: "opencode install failed: could not write plugin file: permission denied"},
+	}, result.Agents)
+}
+
+func TestRun_AgentsReconcileUsageErrorsNameTheProblem(t *testing.T) {
+	withStubRegisteredInstallers(t, []agentinstall.Spec{
+		{Name: "claude", Install: func(context.Context, io.Writer, *log.Logger) (bool, error) { return false, nil }},
+		{Name: "cursor", Install: func(context.Context, io.Writer, *log.Logger) (bool, error) { return false, nil }},
+	})
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "missing agents", args: []string{"agents", "reconcile", "--json"}, want: "--agents is required; available installers: claude, cursor"},
+		{name: "missing json", args: []string{"agents", "reconcile", "--agents", "claude"}, want: "--json is required so management tooling can parse the reconciliation receipt"},
+		{name: "unknown installer", args: []string{"agents", "reconcile", "--agents", "opencode", "--json"}, want: `"opencode" has no noninteractive installer in this binary (available: claude, cursor)`},
+		{name: "all mixed with name", args: []string{"agents", "reconcile", "--agents", "all,claude", "--json"}, want: "--agents=all must be used by itself"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			gotExit := withExit(t, func() { run(tc.args, strings.NewReader(""), &stdout, &stderr) })
+			require.NotNil(t, gotExit)
+			assert.Equal(t, 2, *gotExit)
+			assert.Empty(t, stdout.String())
+			assert.Contains(t, stderr.String(), tc.want)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- add `agento11y agents reconcile --agents all|name[,name...] --json` as an MDM-agnostic fleet reconciliation primitive
- use self-registering noninteractive installers: the core reconciler has no hard-coded agent list, and `--agents all` automatically includes installers added by future binary releases
- register the existing noninteractive Claude Code and Cursor installers, preserving their noninteractive behavior; report per-agent installation, already-installed, missing-host, and descriptive failure states

## Scope

This is intentionally separate from the Jamf-specific work and from #608. It does not create or distribute credentials, impose device policy, or assume a particular MDM. Future adapters only need to register a noninteractive installer to participate.

## Verification

- `GOWORK=off go test ./internal/agentinstall ./internal/agents/claudecode ./internal/agents/cursor/install ./internal/entry`
- `GOWORK=off go build ./cmd/agento11y`
- `GOWORK=off go vet ./internal/agentinstall ./internal/agents/claudecode ./internal/agents/cursor/install ./internal/entry`
- `GOWORK=off go test ./internal/...` (all changed and other packages passed; unrelated existing failure remains in `internal/login`: `TestPasteFieldReceivesAFlattenedBlock`)