### PR TITLE
feat(plugins/agento11y): register additional managed installers

### DIFF
--- a/plugins/agento11y/internal/agents/copilot/launch.go
+++ b/plugins/agento11y/internal/agents/copilot/launch.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agentinstall"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/execpath"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/launcher"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/local"
@@ -46,6 +47,15 @@ var (
 	runUninstall = defaultRunUninstall
 	pluginList   = defaultPluginList
 )
+
+func init() {
+	agentinstall.Register(agentinstall.Spec{
+		Name: "copilot",
+		Install: func(context.Context, io.Writer, *log.Logger) (bool, error) {
+			return Install()
+		},
+	})
+}
 
 // Launch installs the shared user-level Copilot hooks file (read by both
 // Copilot Chat in VS Code and the copilot CLI), resolves the `copilot` binary

--- a/plugins/agento11y/internal/agents/opencode/launch.go
+++ b/plugins/agento11y/internal/agents/opencode/launch.go
@@ -27,6 +27,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agentinstall"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/launcher"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/local"
 	"github.com/tailscale/hujson"
@@ -51,6 +52,14 @@ const (
 // current user. Callers can defer setup until the host is installed.
 var ErrCLINotFound = errors.New("opencode CLI not found")
 
+func init() {
+	agentinstall.Register(agentinstall.Spec{
+		Name:          "opencode",
+		Install:       Install,
+		IsMissingHost: func(err error) bool { return errors.Is(err, ErrCLINotFound) },
+	})
+}
+
 // Test seams.
 var (
 	lookPath    = exec.LookPath
@@ -59,6 +68,7 @@ var (
 	runUpdate   = defaultRunUpdate
 	configDirFn = defaultConfigDir
 	cacheDirFn  = defaultCacheDir
+	writeConfig = writeConfigAtomic
 )
 
 // configFileNames lists the basenames opencode recognises for its
@@ -79,7 +89,9 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 	// legacy entry would otherwise stay pinned to the last pre-rename release
 	// forever. Best-effort — a failure falls through to the legacy
 	// refresh-skip below.
-	migrateLegacyConfig(stderr, logger)
+	// Launch keeps legacy migration best-effort so an interactive OpenCode
+	// session can still start with its existing plugin if a rewrite fails.
+	_ = migrateLegacyConfig(stderr, logger)
 
 	// The periodic refresh installs PluginSource. When the config still
 	// references the legacy package name (because the migration above could
@@ -124,7 +136,12 @@ func Launch(ctx context.Context, args []string, localEnv *local.LaunchEnv, _ io.
 // for Agent Observability credentials. The returned value is true only when
 // this invocation registered the plugin.
 func Install(ctx context.Context, stdout io.Writer, logger *log.Logger) (bool, error) {
-	migrateLegacyConfig(stdout, logger)
+	// A legacy config must be rewritten before it can count as installed. If
+	// the rewrite fails, returning an error keeps fleet reconciliation retrying
+	// instead of silently leaving OpenCode pinned to the frozen package.
+	if err := migrateLegacyConfig(stdout, logger); err != nil {
+		return false, fmt.Errorf("migrate legacy OpenCode plugin configuration: %w", err)
+	}
 	installed, probeErr := pluginInstalled()
 	if probeErr == nil && installed {
 		return false, nil
@@ -163,43 +180,49 @@ func defaultRunUpdate(ctx context.Context, bin string, w io.Writer) error {
 //
 // The rewrite goes through hujson so comments, formatting, and tuple options
 // survive, and the file is replaced atomically (temp file + rename) so a
-// failure never leaves a half-written config. Best-effort: failures are
-// logged and never block the launch — patch/write failures also print a
-// manual-recovery hint on stderr, and the caller's legacy refresh-skip keeps
-// the frozen install working.
-func migrateLegacyConfig(stderr io.Writer, logger *log.Logger) {
+// failure never leaves a half-written config. Failures are logged and never
+// block Launch — patch/write failures also print a manual-recovery hint on
+// stderr, and Launch's legacy refresh-skip keeps the frozen install working.
+// Install returns such a failure so managed reconciliation does not report a
+// legacy plugin as converged.
+func migrateLegacyConfig(stderr io.Writer, logger *log.Logger) error {
 	path, data, err := readConfigFile()
 	if err != nil {
 		logger.Printf("opencode legacy migration: %v", err)
-		return
+		return err
 	}
 	if data == nil {
-		return
+		return nil
 	}
 	v, err := hujson.Parse(data)
 	if err != nil {
-		logger.Printf("opencode legacy migration: parse %s: %v", path, err)
-		return
+		err = fmt.Errorf("parse %s: %w", path, err)
+		logger.Printf("opencode legacy migration: %v", err)
+		return err
 	}
 	ops, err := legacyPluginOps(v)
 	if err != nil {
-		logger.Printf("opencode legacy migration: scan %s: %v", path, err)
-		return
+		err = fmt.Errorf("scan %s: %w", path, err)
+		logger.Printf("opencode legacy migration: %v", err)
+		return err
 	}
 	if ops == nil {
-		return
+		return nil
 	}
 	fmt.Fprintf(stderr, "agento11y: migrating %s to %s in %s\n", legacyPluginName, PluginName, path)
 	if err := v.Patch(ops); err != nil {
-		logger.Printf("opencode legacy migration: patch %s: %v", path, err)
+		err = fmt.Errorf("patch %s: %w", path, err)
+		logger.Printf("opencode legacy migration: %v", err)
 		printMigrationRecoveryHint(stderr, err, path)
-		return
+		return err
 	}
-	if err := writeConfigAtomic(path, v.Pack()); err != nil {
-		logger.Printf("opencode legacy migration: write %s: %v", path, err)
+	if err := writeConfig(path, v.Pack()); err != nil {
+		err = fmt.Errorf("write %s: %w", path, err)
+		logger.Printf("opencode legacy migration: %v", err)
 		printMigrationRecoveryHint(stderr, err, path)
-		return
+		return err
 	}
+	return nil
 }
 
 // printMigrationRecoveryHint tells the user how to finish the rename by hand

--- a/plugins/agento11y/internal/agents/opencode/launch_test.go
+++ b/plugins/agento11y/internal/agents/opencode/launch_test.go
@@ -227,6 +227,25 @@ func TestInstall(t *testing.T) {
 		assert.True(t, changed)
 		assert.Equal(t, 1, calls)
 	})
+
+	t.Run("legacy migration failure is reported so reconciliation retries", func(t *testing.T) {
+		withConfig(t, `{"plugin":["@grafana/sigil-opencode"]}`)
+		withWriteConfig(t, func(string, []byte) error {
+			return errors.New("permission denied")
+		})
+		withLookPath(t, func(string) (string, error) { return "/usr/local/bin/opencode", nil })
+		withRunInstall(t, func(context.Context, string, io.Writer) error {
+			t.Fatal("install must not run after a failed legacy migration")
+			return nil
+		})
+
+		var output bytes.Buffer
+		changed, err := Install(context.Background(), &output, nopLogger())
+		assert.False(t, changed)
+		assert.ErrorContains(t, err, "migrate legacy OpenCode plugin configuration")
+		assert.ErrorContains(t, err, "write")
+		assert.Contains(t, output.String(), "To migrate manually")
+	})
 }
 
 func TestLaunch_LocalEnv(t *testing.T) {
@@ -742,6 +761,13 @@ func withRunUpdate(t *testing.T, fn func(context.Context, string, io.Writer) err
 	prev := runUpdate
 	t.Cleanup(func() { runUpdate = prev })
 	runUpdate = fn
+}
+
+func withWriteConfig(t *testing.T, fn func(string, []byte) error) {
+	t.Helper()
+	prev := writeConfig
+	t.Cleanup(func() { writeConfig = prev })
+	writeConfig = fn
 }
 
 func withExecFn(t *testing.T, fn func(string, []string, []string) error) {

--- a/plugins/agento11y/internal/agents/pi/launch.go
+++ b/plugins/agento11y/internal/agents/pi/launch.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agentinstall"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/launcher"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/local"
 )
@@ -48,6 +49,14 @@ const (
 // ErrCLINotFound means the pi binary is not available on PATH for the current
 // user. Callers can defer setup until the host is installed.
 var ErrCLINotFound = errors.New("pi CLI not found")
+
+func init() {
+	agentinstall.Register(agentinstall.Spec{
+		Name:          "pi",
+		Install:       Install,
+		IsMissingHost: func(err error) bool { return errors.Is(err, ErrCLINotFound) },
+	})
+}
 
 // Test seams.
 var (

--- a/plugins/agento11y/internal/entry/entry_test.go
+++ b/plugins/agento11y/internal/entry/entry_test.go
@@ -824,7 +824,10 @@ func TestRegisteredInstallersIncludeExistingManagedInstallers(t *testing.T) {
 		names = append(names, spec.Name)
 	}
 	assert.Contains(t, names, "claude")
+	assert.Contains(t, names, "copilot")
 	assert.Contains(t, names, "cursor")
+	assert.Contains(t, names, "opencode")
+	assert.Contains(t, names, "pi")
 }
 
 func withStubCopilotInstall(t *testing.T, fn func() (bool, error)) {


### PR DESCRIPTION
## Summary

Registers the noninteractive installers added by #608 with the generic `agentinstall` registry from #610:

- Copilot
- OpenCode
- pi

With both prerequisite changes present, `agento11y agents reconcile --agents all --json` discovers and reconciles Claude, Copilot, Cursor, OpenCode, and pi without a hard-coded list.

## Stack

This branch has both #610 and #608 as parents. Its PR base is #610 because GitHub supports one base branch; it must land after both prerequisites.

## Verification

- `GOWORK=off go test ./internal/agents/copilot ./internal/agents/opencode ./internal/agents/pi ./internal/agents/cursor/install ./internal/entry`
- `GOWORK=off go vet ./internal/agents/copilot ./internal/agents/opencode ./internal/agents/pi ./internal/agents/cursor/install ./internal/entry`
- `GOWORK=off go build ./cmd/agento11y`