### PR TITLE
fix(plugins/agento11y): import pi session workspace tags

### DIFF
--- a/conformance/pi-sessions/README.md
+++ b/conformance/pi-sessions/README.md
@@ -81,8 +81,8 @@ framework to normalize `SourcePath` for every agent.
 
 ## Fields that are not in the fixture at all
 
-Each one is either live-only or import-only, so comparing it would fail for a
-reason that is not drift.
+Each field here is on one side only, or on both with values that cannot agree,
+so comparing it would fail for a reason that is not drift.
 
 | Field | Which side | Why |
 |-------|------------|-----|
@@ -90,7 +90,7 @@ reason that is not drift.
 | `max_tokens`, `temperature`, `top_p`, `tool_choice`, thinking budget | live only | Read from the `before_provider_request` payload. Not persisted. |
 | time to first token | live only | Observed from the first `message_update`. Not persisted. |
 | `tools[].description`, `tools[].input_schema_json` | live only | Read from pi's tool registry. The log records only the calls a turn made, so an imported turn carries name-only definitions for those tools, and which tools were offered but unused is unrecoverable. |
-| `tags` (`cwd`, `git.branch`) | live only | Resolved from `process.cwd()` per turn. The header's `cwd` is the session's start directory, not the turn's. |
+| `tags` (`cwd`, `git.branch`) | both, not compared | Both sides emit `cwd`, but live resolves it per turn and import reads the session's start directory. Only live emits `git.branch`; the log does not record a branch. |
 | `agent_version`, `effective_version` | live only | The plugin's own version. Nothing in the log says which version wrote it. |
 | `agent_name` | filled later | The importer leaves it empty and `Exporter.prepare` fills it from the agent ID, giving `pi`, which is what the plugin sends. |
 | `agento11y.sdk.*` metadata | live only | Stamped by the SDK that exports. |

--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -150,11 +150,14 @@ agento11y history import claude-code
 
 Supported agents are `claude-code`, `codex`, `cursor`, and `pi`. `agento11y history import` with no agent lists them.
 
-A `pi` import reads pi's session logs under `$PI_CODING_AGENT_DIR/sessions` (by default `~/.pi/agent/sessions`) and produces one generation per assistant turn, with its prompt, thinking, tool calls, matched tool results, model, token usage, cost, both timestamps, and parent turn. Three things live capture records are not in the session log, so an imported pi session is thinner than a captured one:
+A `pi` import reads pi's session logs under `$PI_CODING_AGENT_DIR/sessions` (by default `~/.pi/agent/sessions`). It produces one generation per assistant turn. Each generation includes the prompt, thinking, tool calls, matched tool results, model, token usage, cost, both timestamps, and parent turn. Live capture records four things the log does not, so an imported pi session is thinner than a captured one:
 
 - No compaction or branch-summary generations. Live exports each summarization call as its own generation. pi's `compaction` entry carries the summary text, the token count it compacted away, and, on recent pi versions, the call's `usage` and cost, but never the model or the provider, so the call cannot be reconstructed as a generation. An imported session therefore holds fewer generations than a captured one, and the missing ones are the expensive calls.
 - No system prompt, request controls (`max_tokens`, `temperature`, `top_p`, tool choice, thinking budget), or time to first token. pi records none of them.
-- Tool definitions are name-only, and only for the tools a turn called: the descriptions, schemas, and the list of tools that were offered but unused live in pi's runtime. Session tags (`cwd`, `git.branch`) are absent for the same reason.
+- Tool definitions are name-only, and only for the tools a turn called. The log does not record the descriptions, the schemas, or which tools went unused.
+- No `git.branch` tag. The log does not record a branch.
+
+Imported turns carry a `cwd` tag holding the directory the session started in.
 
 Subagent runs are in neither: the nested `run-N/session.jsonl` logs come from the third-party `pi-subagents` package, which live capture ignores too, so importing them would exceed live fidelity rather than match it.
 

--- a/plugins/agento11y/internal/history/pi.go
+++ b/plugins/agento11y/internal/history/pi.go
@@ -554,6 +554,7 @@ func piGeneration(
 		Output:        append(piAssistantOutput(blocks), piToolResultsOutput(log, index, blocks)...),
 		Tools:         piToolDefinitions(blocks),
 		CallError:     msg.ErrorMessage,
+		Tags:          piTags(log.header.CWD),
 	}
 	if piHasThinking(blocks) {
 		gen.ThinkingEnabled = piBoolPtr(true)
@@ -578,6 +579,17 @@ func piGeneration(
 	quality := piQuality(gen)
 	piApplyLineage(&gen, &quality, log, entry, conversationID, sourcePath, fork)
 	return HistoricalGeneration{Source: src, Gen: gen, Quality: quality}
+}
+
+// piTags returns the built-in tags for an imported pi turn. There is no branch
+// tag: the log records no branch, and resolving one at import time would record
+// the branch checked out now rather than the one the session ran on.
+func piTags(cwd string) map[string]string {
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" {
+		return nil
+	}
+	return map[string]string{"cwd": cwd}
 }
 
 // piQuality reports what the session log did not carry. Neither timestamp flag

--- a/plugins/agento11y/internal/history/pi_test.go
+++ b/plugins/agento11y/internal/history/pi_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -541,6 +542,50 @@ func TestPiTurnsMapOneGenerationPerAssistantEntry(t *testing.T) {
 	}
 	if first.Gen.Tools[0].Description != "" || len(first.Gen.Tools[0].InputSchema) != 0 {
 		t.Fatal("tool definitions must be name-only: descriptions and schemas are runtime-only")
+	}
+}
+
+func TestPiTurnsTagTheWorkspaceFromTheSessionHeader(t *testing.T) {
+	tests := []struct {
+		name string
+		cwd  string
+		want map[string]string
+	}{
+		{name: "cwd present", cwd: "/work/repo", want: map[string]string{"cwd": "/work/repo"}},
+		{name: "cwd empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			sessionID := "019ead07-cfbf-78d3-8b03-875769426583"
+			body := piHeader(t, sessionID, tt.cwd, "2026-06-09T15:37:10.848Z") +
+				piUserEntry(t, "u1", "", "2026-06-09T15:37:20.000Z", "first", 1781019439000) +
+				piAssistantEntry(t, "a1", "u1", "2026-06-09T15:37:24.526Z", 1781019441000,
+					[]map[string]any{piTextBlock("one")}, nil) +
+				piUserEntry(t, "u2", "a1", "2026-06-09T15:38:00.000Z", "second", 1781019480000) +
+				piAssistantEntry(t, "a2", "u2", "2026-06-09T15:38:06.000Z", 1781019482000,
+					[]map[string]any{piTextBlock("two")}, nil)
+			path := writeFile(t, filepath.Join(root, "--work-repo--", "2026-06-09T15-37-10-848Z_"+sessionID+".jsonl"), body)
+			imp := piImporterAt(root)
+			if !imp.Match(path) {
+				t.Fatalf("Match(%q) = false, want true", path)
+			}
+
+			turns := collectTurns(t, imp, piPreview(t, imp, path))
+			if len(turns) != 2 {
+				t.Fatalf("got %d turns, want 2", len(turns))
+			}
+			for i, turn := range turns {
+				if tt.want == nil && turn.Gen.Tags != nil {
+					t.Errorf("turn %d Tags = %v, want nil", i, turn.Gen.Tags)
+					continue
+				}
+				if !maps.Equal(turn.Gen.Tags, tt.want) {
+					t.Errorf("turn %d Tags = %v, want %v", i, turn.Gen.Tags, tt.want)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Imported pi generations carried no tags, so an imported session could not be filtered by workspace the way a captured one can. Set `cwd` from the directory the session started in.