### PR TITLE
fix(plugins/agento11y): price Cursor Grok turns against the xAI catalog

### DIFF
--- a/plugins/agento11y/internal/agents/cursor/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/cursor/mapper/mapper.go
@@ -99,18 +99,10 @@ func MapFragment(in Inputs) Mapped {
 	completedAt := timeutil.ParseTimestamp(frag.LastEventAt, now)
 	startedAt := timeutil.ParseTimestamp(frag.StartedAt, completedAt)
 
-	// Provider/model fallback: SDK validation requires both to be non-empty.
-	provider := frag.Provider
-	if provider == "" {
-		provider = mapperutil.InferProvider(frag.Model)
-	}
-	if provider == "" {
-		provider = "cursor"
-	}
-	modelName := frag.Model
-	if modelName == "" {
-		modelName = "unknown"
-	}
+	// SDK validation requires provider and name. Cursor Grok SKUs are rewritten
+	// onto the catalog id (x-ai/grok-4.5) so Agent Observability can price
+	// the turn; the composer slug stays on response_model.
+	provider, modelName, responseModel := resolveModel(frag)
 	model := agento11y.ModelRef{Provider: provider, Name: modelName}
 
 	stopStatus := resolveStopStatus(in.Stop)
@@ -178,7 +170,7 @@ func MapFragment(in Inputs) Mapped {
 		Mode:              agento11y.GenerationModeSync,
 		OperationName:     "generateText",
 		Model:             model,
-		ResponseModel:     modelName,
+		ResponseModel:     responseModel,
 		Input:             input,
 		Output:            output,
 		Tools:             toolDefs,
@@ -199,6 +191,77 @@ func MapFragment(in Inputs) Mapped {
 		mapped.CallError = extractCallError(in.Stop, red)
 	}
 	return mapped
+}
+
+// resolveModel picks the provider and catalog model name for a Cursor turn.
+// SDK validation requires both to be non-empty. Cursor's generic provider
+// string "cursor" is treated as unset so a recognisable model (Grok, Claude)
+// still infers its vendor; that is what the model-card catalog keys prices
+// under. The composer slug is returned separately as responseModel.
+func resolveModel(frag *fragment.Fragment) (provider, catalogName, responseModel string) {
+	responseModel = strings.TrimSpace(frag.Model)
+	if responseModel == "" {
+		responseModel = "unknown"
+	}
+	catalogName = canonicalizeCursorModel(responseModel)
+
+	inferred := mapperutil.InferProvider(catalogName)
+	if inferred == "" {
+		inferred = mapperutil.InferProvider(responseModel)
+	}
+
+	provider = strings.TrimSpace(frag.Provider)
+	if provider == "" || strings.EqualFold(provider, "cursor") {
+		if inferred != "" {
+			provider = inferred
+		} else if provider == "" {
+			provider = "cursor"
+		}
+	}
+	return provider, catalogName, responseModel
+}
+
+// cursorGrokEffortSuffixes are thinking/speed tiers Cursor appends to hosted
+// Grok SKUs (`cursor-grok-4.6-high-fast`). Longest first so "-high-fast" is
+// not reduced to "-high" plus a leftover "-fast". Bare "-fast" is omitted:
+// xAI ships models named grok-*-fast, and those names only reach this path
+// without a cursor- prefix.
+var cursorGrokEffortSuffixes = []string{
+	"-high-fast",
+	"-low-fast",
+	"-medium-fast",
+	"-extra-high",
+	"-high",
+	"-medium",
+	"-low",
+}
+
+// canonicalizeCursorModel maps a Cursor composer slug onto the catalog name
+// Agent Observability prices against. Hosted Grok SKUs are prefixed with
+// "cursor-" and often carry an effort tier; stripping both yields grok-4.5
+// from cursor-grok-4.5-high-fast. Names that are not cursor-grok SKUs are
+// returned unchanged, including a bare grok-4.5 model_id.
+func canonicalizeCursorModel(name string) string {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return trimmed
+	}
+	lower := strings.ToLower(trimmed)
+	const cursorPrefix = "cursor-"
+	if !strings.HasPrefix(lower, cursorPrefix) {
+		return trimmed
+	}
+	rest := trimmed[len(cursorPrefix):]
+	restLower := lower[len(cursorPrefix):]
+	if !strings.Contains(restLower, "grok") {
+		return trimmed
+	}
+	for _, suffix := range cursorGrokEffortSuffixes {
+		if strings.HasSuffix(restLower, suffix) {
+			return rest[:len(rest)-len(suffix)]
+		}
+	}
+	return rest
 }
 
 // conversationTitle is the human-readable list label for this turn. The

--- a/plugins/agento11y/internal/agents/cursor/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/cursor/mapper/mapper.go
@@ -222,15 +222,19 @@ func resolveModel(frag *fragment.Fragment) (provider, catalogName, responseModel
 }
 
 // cursorGrokEffortSuffixes are thinking/speed tiers Cursor appends to hosted
-// Grok SKUs (`cursor-grok-4.6-high-fast`). Longest first so "-high-fast" is
-// not reduced to "-high" plus a leftover "-fast". Bare "-fast" is omitted:
+// Grok SKUs (`cursor-grok-4.6-high-fast`). Longest overlapping suffixes first:
+// "-xhigh-fast" must precede "-high-fast" (otherwise xhigh-fast strips to
+// grok-*-x) and "-high-fast" must precede "-high". Bare "-fast" is omitted:
 // xAI ships models named grok-*-fast, and those names only reach this path
 // without a cursor- prefix.
 var cursorGrokEffortSuffixes = []string{
+	"-xhigh-fast",
+	"-extra-high-fast",
 	"-high-fast",
 	"-low-fast",
 	"-medium-fast",
 	"-extra-high",
+	"-xhigh",
 	"-high",
 	"-medium",
 	"-low",

--- a/plugins/agento11y/internal/agents/cursor/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/cursor/mapper/mapper_test.go
@@ -471,7 +471,10 @@ func TestMapFragment_InfersProviderFromModel(t *testing.T) {
 		{"gpt-5", "openai"},
 		{"o3-mini", "openai"},
 		{"gemini-2.5-pro", "google"},
+		{"grok-4.5", "x-ai"},
+		{"cursor-grok-4.6-high-fast", "x-ai"},
 		{"some-random-model", "cursor"}, // no match → cursor fallback
+		{"composer-2.5-fast", "cursor"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.model, func(t *testing.T) {
@@ -479,6 +482,111 @@ func TestMapFragment_InfersProviderFromModel(t *testing.T) {
 			got := MapFragment(Inputs{Fragment: frag, ContentCapture: agento11y.ContentCaptureModeMetadataOnly, Now: fixedTime})
 			if got.Generation.Model.Provider != tc.want {
 				t.Errorf("provider for model %q = %q; want %q", tc.model, got.Generation.Model.Provider, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalizeCursorModel(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"cursor-grok-4.6-high-fast", "grok-4.6"},
+		{"cursor-grok-4.5-high-fast", "grok-4.5"},
+		{"cursor-grok-4.5-medium", "grok-4.5"},
+		{"cursor-grok-4.5", "grok-4.5"},
+		{"CURSOR-GROK-4.6-HIGH-FAST", "GROK-4.6"},
+		{"grok-4.5", "grok-4.5"},           // already a catalog id
+		{"grok-4.1-fast", "grok-4.1-fast"}, // xAI's own *-fast SKU
+		{"claude-sonnet-4-6", "claude-sonnet-4-6"},
+		{"claude-opus-4-8-thinking-max", "claude-opus-4-8-thinking-max"},
+		{"composer-2.5-fast", "composer-2.5-fast"},
+		{"gpt-5-cursor", "gpt-5-cursor"},
+		{"cursor-composer-2.5-fast", "cursor-composer-2.5-fast"}, // not grok
+		{"", ""},
+		{"  cursor-grok-4.6-high-fast  ", "grok-4.6"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := canonicalizeCursorModel(tc.in); got != tc.want {
+				t.Errorf("canonicalizeCursorModel(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMapFragment_CanonicalizesCursorGrokForPricing(t *testing.T) {
+	cases := []struct {
+		name         string
+		model        string
+		provider     string
+		wantProvider string
+		wantName     string
+		wantResponse string
+	}{
+		{
+			name:         "high-fast slug",
+			model:        "cursor-grok-4.6-high-fast",
+			wantProvider: "x-ai",
+			wantName:     "grok-4.6",
+			wantResponse: "cursor-grok-4.6-high-fast",
+		},
+		{
+			name:         "medium slug",
+			model:        "cursor-grok-4.5-medium",
+			wantProvider: "x-ai",
+			wantName:     "grok-4.5",
+			wantResponse: "cursor-grok-4.5-medium",
+		},
+		{
+			name:         "bare model_id",
+			model:        "grok-4.5",
+			wantProvider: "x-ai",
+			wantName:     "grok-4.5",
+			wantResponse: "grok-4.5",
+		},
+		{
+			name:         "generic cursor provider is overridden",
+			model:        "cursor-grok-4.5-high-fast",
+			provider:     "cursor",
+			wantProvider: "x-ai",
+			wantName:     "grok-4.5",
+			wantResponse: "cursor-grok-4.5-high-fast",
+		},
+		{
+			name:         "explicit vendor is kept",
+			model:        "cursor-grok-4.5-high-fast",
+			provider:     "xai",
+			wantProvider: "xai",
+			wantName:     "grok-4.5",
+			wantResponse: "cursor-grok-4.5-high-fast",
+		},
+		{
+			name:         "claude composer slug is unchanged",
+			model:        "claude-opus-4-8-thinking-max",
+			wantProvider: "anthropic",
+			wantName:     "claude-opus-4-8-thinking-max",
+			wantResponse: "claude-opus-4-8-thinking-max",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			frag := &fragment.Fragment{
+				ConversationID: "c",
+				GenerationID:   "g",
+				Model:          tc.model,
+				Provider:       tc.provider,
+			}
+			got := MapFragment(Inputs{Fragment: frag, ContentCapture: agento11y.ContentCaptureModeMetadataOnly, Now: fixedTime})
+			if got.Generation.Model.Provider != tc.wantProvider {
+				t.Errorf("Provider = %q; want %q", got.Generation.Model.Provider, tc.wantProvider)
+			}
+			if got.Generation.Model.Name != tc.wantName {
+				t.Errorf("Name = %q; want %q", got.Generation.Model.Name, tc.wantName)
+			}
+			if got.Generation.ResponseModel != tc.wantResponse {
+				t.Errorf("ResponseModel = %q; want %q", got.Generation.ResponseModel, tc.wantResponse)
+			}
+			if got.Start.Model.Provider != tc.wantProvider || got.Start.Model.Name != tc.wantName {
+				t.Errorf("Start.Model = %+v; want %s/%s", got.Start.Model, tc.wantProvider, tc.wantName)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/agents/cursor/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/cursor/mapper/mapper_test.go
@@ -490,6 +490,9 @@ func TestMapFragment_InfersProviderFromModel(t *testing.T) {
 func TestCanonicalizeCursorModel(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"cursor-grok-4.6-high-fast", "grok-4.6"},
+		{"cursor-grok-4.6-xhigh-fast", "grok-4.6"},
+		{"cursor-grok-4.6-xhigh", "grok-4.6"},
+		{"cursor-grok-4.6-extra-high-fast", "grok-4.6"},
 		{"cursor-grok-4.5-high-fast", "grok-4.5"},
 		{"cursor-grok-4.5-medium", "grok-4.5"},
 		{"cursor-grok-4.5", "grok-4.5"},
@@ -528,6 +531,20 @@ func TestMapFragment_CanonicalizesCursorGrokForPricing(t *testing.T) {
 			wantProvider: "x-ai",
 			wantName:     "grok-4.6",
 			wantResponse: "cursor-grok-4.6-high-fast",
+		},
+		{
+			name:         "xhigh-fast slug is not truncated to grok-*-x",
+			model:        "cursor-grok-4.6-xhigh-fast",
+			wantProvider: "x-ai",
+			wantName:     "grok-4.6",
+			wantResponse: "cursor-grok-4.6-xhigh-fast",
+		},
+		{
+			name:         "xhigh slug",
+			model:        "cursor-grok-4.6-xhigh",
+			wantProvider: "x-ai",
+			wantName:     "grok-4.6",
+			wantResponse: "cursor-grok-4.6-xhigh",
 		},
 		{
 			name:         "medium slug",

--- a/plugins/agento11y/internal/local/web/app.jsx
+++ b/plugins/agento11y/internal/local/web/app.jsx
@@ -242,6 +242,44 @@ function modelPrice(model) {
     return MODEL_PRICES.find((p) => m.includes(p.match)) || null;
 }
 
+// Cursor hosted Grok SKUs are `cursor-grok-4.6-high-fast`. models.dev (and
+// the Cloud catalog) key the same model as `grok-4.6`. Keep this suffix
+// list in sync with canonicalizeCursorModel in the cursor mapper.
+const CURSOR_GROK_EFFORT_SUFFIXES = [
+    "-high-fast",
+    "-low-fast",
+    "-medium-fast",
+    "-extra-high",
+    "-high",
+    "-medium",
+    "-low",
+];
+
+function canonicalizePriceModel(model) {
+    const trimmed = (model || "").trim();
+    if (!trimmed) return trimmed;
+    const lower = trimmed.toLowerCase();
+    const prefix = "cursor-";
+    if (!lower.startsWith(prefix)) return trimmed;
+    const rest = trimmed.slice(prefix.length);
+    const restLower = lower.slice(prefix.length);
+    if (!restLower.includes("grok")) return trimmed;
+    for (const suffix of CURSOR_GROK_EFFORT_SUFFIXES) {
+        if (restLower.endsWith(suffix)) {
+            return rest.slice(0, rest.length - suffix.length);
+        }
+    }
+    return rest;
+}
+
+function liveModelCost(prices, model) {
+    if (!prices || !model) return null;
+    if (prices[model]) return prices[model];
+    const canonical = canonicalizePriceModel(model);
+    if (canonical !== model && prices[canonical]) return prices[canonical];
+    return null;
+}
+
 // models.dev is the authoritative, multi-provider price catalog (OpenAI,
 // Anthropic, Gemini, …) — strictly better than the bundled table, and it
 // carries explicit per-model cache_read / cache_write rates instead of the
@@ -328,7 +366,7 @@ function conversationCost(c, prices) {
     if (!b) return null;
     const model = (c.models || [])[0];
     let inRate, outRate, cacheReadRate, cacheWriteRate;
-    const live = prices && model && prices[model];
+    const live = liveModelCost(prices, model);
     if (live) {
         inRate = live.input;
         outRate = live.output != null ? live.output : live.input;

--- a/plugins/agento11y/internal/local/web/app.jsx
+++ b/plugins/agento11y/internal/local/web/app.jsx
@@ -246,10 +246,13 @@ function modelPrice(model) {
 // the Cloud catalog) key the same model as `grok-4.6`. Keep this suffix
 // list in sync with canonicalizeCursorModel in the cursor mapper.
 const CURSOR_GROK_EFFORT_SUFFIXES = [
+    "-xhigh-fast",
+    "-extra-high-fast",
     "-high-fast",
     "-low-fast",
     "-medium-fast",
     "-extra-high",
+    "-xhigh",
     "-high",
     "-medium",
     "-low",

--- a/plugins/agento11y/internal/local/web_test.go
+++ b/plugins/agento11y/internal/local/web_test.go
@@ -223,6 +223,8 @@ func TestPriceLookupCanonicalizesCursorGrok(t *testing.T) {
 	script := `
 const assert = require("assert").strict;
 assert.equal(canonicalizePriceModel("cursor-grok-4.6-high-fast"), "grok-4.6");
+assert.equal(canonicalizePriceModel("cursor-grok-4.6-xhigh-fast"), "grok-4.6");
+assert.equal(canonicalizePriceModel("cursor-grok-4.6-xhigh"), "grok-4.6");
 assert.equal(canonicalizePriceModel("cursor-grok-4.5-medium"), "grok-4.5");
 assert.equal(canonicalizePriceModel("grok-4.6"), "grok-4.6");
 assert.equal(canonicalizePriceModel("claude-opus-4-8"), "claude-opus-4-8");
@@ -231,6 +233,7 @@ assert.equal(canonicalizePriceModel("composer-2.5-fast"), "composer-2.5-fast");
 const prices = { "grok-4.6": { input: 2, output: 6, cache_read: 0.5 } };
 assert.deepEqual(liveModelCost(prices, "grok-4.6"), prices["grok-4.6"]);
 assert.deepEqual(liveModelCost(prices, "cursor-grok-4.6-high-fast"), prices["grok-4.6"]);
+assert.deepEqual(liveModelCost(prices, "cursor-grok-4.6-xhigh-fast"), prices["grok-4.6"]);
 assert.equal(liveModelCost(prices, "cursor-grok-4.5-high-fast"), null);
 
 const buckets = { fresh_input: 1e6, output: 0, cache_read: 0, cache_write: 0, reasoning: 0 };

--- a/plugins/agento11y/internal/local/web_test.go
+++ b/plugins/agento11y/internal/local/web_test.go
@@ -219,6 +219,29 @@ console.log("ASSERTIONS_OK");
 	appJSXAssertions(t, script)
 }
 
+func TestPriceLookupCanonicalizesCursorGrok(t *testing.T) {
+	script := `
+const assert = require("assert").strict;
+assert.equal(canonicalizePriceModel("cursor-grok-4.6-high-fast"), "grok-4.6");
+assert.equal(canonicalizePriceModel("cursor-grok-4.5-medium"), "grok-4.5");
+assert.equal(canonicalizePriceModel("grok-4.6"), "grok-4.6");
+assert.equal(canonicalizePriceModel("claude-opus-4-8"), "claude-opus-4-8");
+assert.equal(canonicalizePriceModel("composer-2.5-fast"), "composer-2.5-fast");
+
+const prices = { "grok-4.6": { input: 2, output: 6, cache_read: 0.5 } };
+assert.deepEqual(liveModelCost(prices, "grok-4.6"), prices["grok-4.6"]);
+assert.deepEqual(liveModelCost(prices, "cursor-grok-4.6-high-fast"), prices["grok-4.6"]);
+assert.equal(liveModelCost(prices, "cursor-grok-4.5-high-fast"), null);
+
+const buckets = { fresh_input: 1e6, output: 0, cache_read: 0, cache_write: 0, reasoning: 0 };
+assert.equal(conversationCost({ models: ["grok-4.6"], token_buckets: buckets }, prices), 2);
+assert.equal(conversationCost({ models: ["cursor-grok-4.6-high-fast"], token_buckets: buckets }, prices), 2);
+assert.equal(conversationCost({ models: ["cursor-grok-4.6-high-fast"], token_buckets: buckets }, {}), null);
+console.log("ASSERTIONS_OK");
+`
+	appJSXAssertionsRegion(t, script, "const MODEL_PRICES = [", "function workspaceLabel(")
+}
+
 // TestSettingsHelperScenarios pins the pure functions behind the Cloud settings
 // panel: the pasted-block parser (which re-implements applyPaste in
 // internal/login/login.go, so the two grammars can drift), the setup-page link,
@@ -360,6 +383,11 @@ console.log("ASSERTIONS_OK");
 // settings panel; components in it are never rendered, so React is a stub.
 func appJSXAssertions(t *testing.T, script string) {
 	t.Helper()
+	appJSXAssertionsRegion(t, script, "function partKind(", "// ============================================================\n// App container")
+}
+
+func appJSXAssertionsRegion(t *testing.T, script, startNeedle, endNeedle string) {
+	t.Helper()
 	babel, err := webStatic.ReadFile("web/vendor/babel.min.js")
 	require.NoError(t, err)
 
@@ -375,8 +403,10 @@ const Babel = require(process.argv[2]);
 const source = fs.readFileSync(process.argv[3], "utf8");
 const compiled = Babel.transform(source, { filename: "app.jsx", presets: ["react"] }).code;
 if (process.env.RUN_APP_JSX_ASSERTIONS === "1") {
-  const start = compiled.indexOf("function partKind(");
-  const end = compiled.indexOf("// ============================================================\n// App container", start);
+  const startNeedle = process.env.APP_JSX_START;
+  const endNeedle = process.env.APP_JSX_END;
+  const start = compiled.indexOf(startNeedle);
+  const end = compiled.indexOf(endNeedle, start);
   if (start < 0 || end < 0) throw new Error("helper function region not found");
   // URL is a browser global the markdown link and stack URL checks rely on.
   const context = { console, require, URL, React: { createElement() {} } };
@@ -395,7 +425,11 @@ if (process.env.RUN_APP_JSX_ASSERTIONS === "1") {
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "node", scriptPath, babelPath, appPath, assertPath)
 	if script != "" {
-		cmd.Env = append(os.Environ(), "RUN_APP_JSX_ASSERTIONS=1")
+		cmd.Env = append(os.Environ(),
+			"RUN_APP_JSX_ASSERTIONS=1",
+			"APP_JSX_START="+startNeedle,
+			"APP_JSX_END="+endNeedle,
+		)
 	}
 	output, err := cmd.CombinedOutput()
 	require.NoErrorf(t, err, "Babel/helper checks failed for embedded web/app.jsx:\n%s", output)

--- a/plugins/agento11y/internal/mapperutil/mapperutil.go
+++ b/plugins/agento11y/internal/mapperutil/mapperutil.go
@@ -98,8 +98,10 @@ func SortedToolDefinitions(names []string) []agento11y.ToolDefinition {
 }
 
 // InferProvider maps a model name to an agento11y provider using loose substring
-// matching for Claude/Gemini and prefix matching for the OpenAI families.
-// Returns "" when nothing matches so callers can supply their own fallback.
+// matching for Claude/Gemini/Grok and prefix matching for the OpenAI families.
+// Grok maps to "x-ai", the OpenRouter id the model-card catalog keys xAI
+// prices under. Returns "" when nothing matches so callers can supply their
+// own fallback.
 //
 // copilot intentionally uses a stricter matcher (hyphenated prefixes) and does
 // not call this.
@@ -115,6 +117,8 @@ func InferProvider(model string) string {
 		return "openai"
 	case strings.Contains(m, "gemini"):
 		return "google"
+	case strings.Contains(m, "grok"):
+		return "x-ai"
 	}
 	return ""
 }

--- a/plugins/agento11y/internal/mapperutil/mapperutil_test.go
+++ b/plugins/agento11y/internal/mapperutil/mapperutil_test.go
@@ -136,6 +136,10 @@ func TestInferProvider(t *testing.T) {
 		{"o4-fast", "openai"},
 		{"gemini-2.5-pro", "google"},
 		{"models/gemini-pro", "google"}, // substring match anywhere
+		{"grok-4.5", "x-ai"},
+		{"grok-4.6", "x-ai"},
+		{"cursor-grok-4.6-high-fast", "x-ai"}, // substring match anywhere
+		{"x-ai/grok-4", "x-ai"},
 		{"some-random-model", ""},
 		{"", ""},
 	}


### PR DESCRIPTION
## Summary
- Cursor Grok turns were exported as `provider: cursor` and composer slugs like `cursor-grok-4.6-high-fast`, which neither Cloud model cards nor the local models.dev lookup can resolve, so cost stayed empty despite token usage being present.
- The Cursor mapper now infers `x-ai`, strips the `cursor-` prefix and effort suffixes (`-high-fast`, `-high`, …), and keeps the original slug on `response_model`.
- The local viewer price lookup uses the same canonical name so existing sessions (including already-captured Grok turns) show a dollar amount after refresh.

## Test plan
- [ ] Run a Cursor Grok turn and confirm the exported `model` is `x-ai` / `grok-*` with the composer slug on `response_model`.
- [ ] Hard-refresh local Sessions (`agento11y local`) and confirm Cost is a dollar amount, not `-`, for a Grok conversation that already has token usage.
- [ ] Confirm Cursor Claude / composer models still export and price as before.
- [ ] Note: Cloud cost for `grok-4.6` can still be empty until Sigil’s supplemental catalog includes that card (it currently has grok-4.5 / 4.3 / 4.20). Local viewer uses models.dev and should price 4.6.


Made with [Cursor](https://cursor.com)