### PR TITLE
feat(plugins/agento11y): enable auto_coding_agent_tags by default in local mode

### DIFF
--- a/plugins/agento11y/internal/login/login.go
+++ b/plugins/agento11y/internal/login/login.go
@@ -475,12 +475,14 @@ func shouldOfferLocal(askUser, requested, supported bool) bool {
 
 func enableLocalMode(configPath string, opts RunOpts) (Result, error) {
 	updates := envconfig.ExpandAliases(map[string]string{
-		envconfig.LegacyKey("LOCAL"): "true",
+		envconfig.LegacyKey("LOCAL"):                  "true",
+		envconfig.LegacyKey(envconfig.AutoTagsSuffix): "true",
 	})
 	if err := dotenv.WriteDotenv(configPath, updates, opts.Logger); err != nil {
 		return Result{}, err
 	}
 	envconfig.SetBothEnv("LOCAL", "true")
+	envconfig.SetBothEnv(envconfig.AutoTagsSuffix, "true")
 	fmt.Fprintln(opts.Stderr, "Sessions will be captured on this machine.")
 	return Result{LocalMode: true}, nil
 }

--- a/plugins/agento11y/internal/login/login_test.go
+++ b/plugins/agento11y/internal/login/login_test.go
@@ -1833,8 +1833,10 @@ func TestEnableLocalMode(t *testing.T) {
 		t.Error("LocalMode = false, want true")
 	}
 	want := map[string]string{
-		"AGENTO11Y_LOCAL": "true",
-		"SIGIL_LOCAL":     "true",
+		"AGENTO11Y_AUTO_CODING_AGENT_TAGS": "true",
+		"AGENTO11Y_LOCAL":                  "true",
+		"SIGIL_AUTO_CODING_AGENT_TAGS":     "true",
+		"SIGIL_LOCAL":                      "true",
 	}
 	if got := dotenv.LoadDotenv(path, nil); !reflect.DeepEqual(got, want) {
 		t.Errorf("saved config = %v, want %v", got, want)


### PR DESCRIPTION
Set `AGENTO11Y_AUTO_CODING_AGENT_TAGS` to `true` by default in local mode, so that path, repository, and user are added to the local metrics. 

In the interactive login flow for Cloud, there's a separate section that enables these, but for local mode they can be enabled by default.