### PR TITLE
feat(sdk-go): add experimental OTel generation export

### DIFF
--- a/go-frameworks/google-adk/go.mod
+++ b/go-frameworks/google-adk/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/otel/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/go-frameworks/google-adk/go.sum
+++ b/go-frameworks/google-adk/go.sum
@@ -21,6 +21,10 @@ go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
+go.opentelemetry.io/otel/log v0.20.0 h1:/5i0vuHxCLWUfChWG41K9wkM0jafruPw9NU1/RCJirs=
+go.opentelemetry.io/otel/log v0.20.0/go.mod h1:wOcMcjsZpG8x7Bak7IhSi/lg8wscV2C1VdrKCLPlt0E=
+go.opentelemetry.io/otel/log/logtest v0.20.0 h1:+tsZVE15N+RWyN9lUzsRyw7hMZXNMepGu105Eim82/k=
+go.opentelemetry.io/otel/log/logtest v0.20.0/go.mod h1:zS9Ryx9RrEAG2tgapMBSvacwhVSSOGSaSiWWgW3NPlQ=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/metric/x v0.66.0 h1:YkCrx1zLOChi9ZcZ6euupOcsgzbVlec7D/xoEU1+cTA=

--- a/go-providers/anthropic/go.mod
+++ b/go-providers/anthropic/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/tidwall/sjson v1.2.5 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
+	go.opentelemetry.io/otel/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect

--- a/go-providers/anthropic/go.sum
+++ b/go-providers/anthropic/go.sum
@@ -35,6 +35,10 @@ go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
+go.opentelemetry.io/otel/log v0.20.0 h1:/5i0vuHxCLWUfChWG41K9wkM0jafruPw9NU1/RCJirs=
+go.opentelemetry.io/otel/log v0.20.0/go.mod h1:wOcMcjsZpG8x7Bak7IhSi/lg8wscV2C1VdrKCLPlt0E=
+go.opentelemetry.io/otel/log/logtest v0.20.0 h1:+tsZVE15N+RWyN9lUzsRyw7hMZXNMepGu105Eim82/k=
+go.opentelemetry.io/otel/log/logtest v0.20.0/go.mod h1:zS9Ryx9RrEAG2tgapMBSvacwhVSSOGSaSiWWgW3NPlQ=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/metric/x v0.66.0 h1:YkCrx1zLOChi9ZcZ6euupOcsgzbVlec7D/xoEU1+cTA=

--- a/go-providers/gemini/go.mod
+++ b/go-providers/gemini/go.mod
@@ -24,6 +24,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
+	go.opentelemetry.io/otel/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect

--- a/go-providers/gemini/go.sum
+++ b/go-providers/gemini/go.sum
@@ -39,6 +39,10 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0 h1:7iP2uCb
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0/go.mod h1:c7hN3ddxs/z6q9xwvfLPk+UHlWRQyaeR1LdgfL/66l0=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
+go.opentelemetry.io/otel/log v0.20.0 h1:/5i0vuHxCLWUfChWG41K9wkM0jafruPw9NU1/RCJirs=
+go.opentelemetry.io/otel/log v0.20.0/go.mod h1:wOcMcjsZpG8x7Bak7IhSi/lg8wscV2C1VdrKCLPlt0E=
+go.opentelemetry.io/otel/log/logtest v0.20.0 h1:+tsZVE15N+RWyN9lUzsRyw7hMZXNMepGu105Eim82/k=
+go.opentelemetry.io/otel/log/logtest v0.20.0/go.mod h1:zS9Ryx9RrEAG2tgapMBSvacwhVSSOGSaSiWWgW3NPlQ=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/metric/x v0.66.0 h1:YkCrx1zLOChi9ZcZ6euupOcsgzbVlec7D/xoEU1+cTA=

--- a/go-providers/openai/go.mod
+++ b/go-providers/openai/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/tidwall/sjson v1.2.5 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
+	go.opentelemetry.io/otel/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect

--- a/go-providers/openai/go.sum
+++ b/go-providers/openai/go.sum
@@ -33,6 +33,10 @@ go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
+go.opentelemetry.io/otel/log v0.20.0 h1:/5i0vuHxCLWUfChWG41K9wkM0jafruPw9NU1/RCJirs=
+go.opentelemetry.io/otel/log v0.20.0/go.mod h1:wOcMcjsZpG8x7Bak7IhSi/lg8wscV2C1VdrKCLPlt0E=
+go.opentelemetry.io/otel/log/logtest v0.20.0 h1:+tsZVE15N+RWyN9lUzsRyw7hMZXNMepGu105Eim82/k=
+go.opentelemetry.io/otel/log/logtest v0.20.0/go.mod h1:zS9Ryx9RrEAG2tgapMBSvacwhVSSOGSaSiWWgW3NPlQ=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/metric/x v0.66.0 h1:YkCrx1zLOChi9ZcZ6euupOcsgzbVlec7D/xoEU1+cTA=

--- a/go/agento11y/client.go
+++ b/go/agento11y/client.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/grafana/agento11y/go/agento11y/contentcapture"
 	"github.com/grafana/agento11y/go/agento11y/internal/tagattr"
+	"github.com/grafana/agento11y/go/otelgenai"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -80,10 +81,37 @@ type Config struct {
 	// ExperimentRetryTimeout bounds each experiment/control HTTP attempt.
 	// Zero uses the SDK default.
 	ExperimentRetryTimeout time.Duration
-	// Tracer is optional and mainly used for tests. If nil, the client uses the global OpenTelemetry tracer.
+	// Tracer is optional and mainly used for tests. If nil, the client uses the
+	// global OpenTelemetry tracer. It emits the tool-execution and embedding
+	// spans in every mode, and the generation metadata span on every protocol
+	// except otel, where the generation span comes from TracerProvider instead.
 	Tracer trace.Tracer
-	// Meter is optional and mainly used for tests. If nil, the client uses the global OpenTelemetry meter.
+	// Meter is optional and mainly used for tests. If nil, the client uses the
+	// global OpenTelemetry meter. It records the tool-execution and embedding
+	// metrics in every mode, and the SDK's own four generation metrics on every
+	// protocol except otel, where the spec generation metrics come from
+	// MeterProvider instead.
 	Meter metric.Meter
+	// TracerProvider and MeterProvider are optional. When Tracer or Meter is nil,
+	// the client takes its tracer or meter from them. In otel mode the
+	// generation-export handler also gets its tracer and spec meter from them, or
+	// from the corresponding global providers. The handler registers
+	// the spec metric instruments under its own instrumentation scope, because
+	// those instruments share names with the instruments the SDK registers for
+	// tool executions and embeddings.
+	TracerProvider trace.TracerProvider
+	MeterProvider  metric.MeterProvider
+	// Flusher is what Flush and Shutdown flush in otel mode, where the span is
+	// the export and the tracer provider's span processor is what still holds it.
+	// A *sdktrace.TracerProvider satisfies it, so this is usually the same
+	// provider given to TracerProvider.
+	//
+	// It is a separate field rather than a type assertion on TracerProvider
+	// because the provider's lifecycle belongs to the application: the SDK gets
+	// to flush it only when the application says so. Leaving it nil is safe and
+	// makes Flush return ErrFlushNotVerifiable instead of a success it cannot
+	// back.
+	Flusher Flusher
 	// Logger receives async export failures. Defaults to log.Default().
 	Logger *log.Logger
 	// Now controls clock behavior (useful for tests).
@@ -145,6 +173,12 @@ const (
 	GenerationExportProtocolGRPC GenerationExportProtocol = "grpc"
 	GenerationExportProtocolHTTP GenerationExportProtocol = "http"
 	GenerationExportProtocolNone GenerationExportProtocol = "none"
+	// GenerationExportProtocolOTel exports each generation as one
+	// GenAI-semconv span on the application's OTel pipeline instead of calling
+	// the generation-export endpoint. This protocol is experimental: NewClient
+	// also requires EnvEnableExperimentalFeatures, and falls back to the noop
+	// exporter when that variable is not set.
+	GenerationExportProtocolOTel GenerationExportProtocol = "otel"
 )
 
 type GenerationExportConfig struct {
@@ -205,14 +239,17 @@ const (
 	// agento11y/contentcapture so that a process reducing this SDK's payloads
 	// reads the same declarations as the emit sites. The remaining keys are
 	// metadata and are declared here.
-	spanAttrGenerationID           = "agento11y.generation.id"
-	spanAttrConversationID         = "gen_ai.conversation.id"
-	spanAttrConversationTitle      = contentcapture.ConversationTitleKey
-	spanAttrUserID                 = "user.id"
-	spanAttrAgentName              = "gen_ai.agent.name"
-	spanAttrAgentVersion           = "gen_ai.agent.version"
-	spanAttrErrorType              = "error.type"
-	spanAttrErrorCategory          = contentcapture.ErrorCategoryAttributeKey
+	spanAttrGenerationID      = "agento11y.generation.id"
+	spanAttrConversationID    = "gen_ai.conversation.id"
+	spanAttrConversationTitle = contentcapture.ConversationTitleKey
+	spanAttrUserID            = "user.id"
+	spanAttrAgentName         = "gen_ai.agent.name"
+	spanAttrAgentVersion      = "gen_ai.agent.version"
+	spanAttrErrorType         = "error.type"
+	spanAttrErrorCategory     = contentcapture.ErrorCategoryAttributeKey
+	// spanAttrExportError carries a failure of this SDK's own export of a
+	// generation, which error.type must not describe.
+	spanAttrExportError            = "agento11y.export.error"
 	spanAttrOperationName          = "gen_ai.operation.name"
 	spanAttrProviderName           = "gen_ai.provider.name"
 	spanAttrRequestModel           = "gen_ai.request.model"
@@ -343,6 +380,9 @@ type Client struct {
 	generationIDs     map[string]struct{}
 	generationIO      map[string]string
 	generationIDOrder []string
+
+	// otelHandler is non-nil only in otel export mode; see otel_export.go.
+	otelHandler *otelgenai.Handler
 }
 
 // GenerationRecorder records and closes one in-flight generation span.
@@ -360,9 +400,12 @@ type Client struct {
 //
 // All methods are safe to call on a nil or no-op recorder.
 type GenerationRecorder struct {
-	client             *Client
-	ctx                context.Context
-	span               trace.Span
+	client *Client
+	ctx    context.Context
+	span   trace.Span
+	// invocation is non-nil in otel export mode, where the otelgenai package
+	// owns the span's attributes, status, and metrics.
+	invocation         *otelgenai.Invocation
 	seed               GenerationStart
 	startedAt          time.Time
 	contentCaptureMode ContentCaptureMode
@@ -497,14 +540,20 @@ func NewClient(config Config) *Client {
 		generationIO:  make(map[string]string),
 	}
 
-	if cfg.Tracer != nil {
+	switch {
+	case cfg.Tracer != nil:
 		client.tracer = cfg.Tracer
-	} else {
+	case cfg.TracerProvider != nil:
+		client.tracer = cfg.TracerProvider.Tracer(instrumentationName)
+	default:
 		client.tracer = otel.Tracer(instrumentationName)
 	}
-	if cfg.Meter != nil {
+	switch {
+	case cfg.Meter != nil:
 		client.meter = cfg.Meter
-	} else {
+	case cfg.MeterProvider != nil:
+		client.meter = cfg.MeterProvider.Meter(instrumentationName)
+	default:
 		client.meter = otel.Meter(instrumentationName)
 	}
 	instruments, err := newTelemetryInstruments(client.meter)
@@ -514,8 +563,28 @@ func NewClient(config Config) *Client {
 		client.instruments = instruments
 	}
 
+	// Build the otel handler before the exporter. Without
+	// EnvEnableExperimentalFeatures the handler fails, and the client then uses
+	// the noop exporter, which exports nothing.
+	var otelErr error
+	if cfg.GenerationExport.Protocol == GenerationExportProtocolOTel {
+		client.otelHandler, otelErr = newOTelHandler(cfg)
+		switch {
+		case otelErr != nil:
+			cfg.Logger.Printf("agento11y otel generation export unavailable: %v", otelErr)
+		case resolveClientContentCaptureMode(cfg.ContentCapture) == ContentCaptureModeFullWithMetadataSpans:
+			cfg.Logger.Printf("agento11y otel generation export: content capture mode %s exports no content, because the span is the only destination. Set %s to put content on the span",
+				ContentCaptureModeFullWithMetadataSpans, ContentCaptureModeFull)
+		}
+	}
+
 	exporter := cfg.testGenerationExporter
-	if exporter == nil {
+	switch {
+	case otelErr != nil:
+		// The caller asked for otel mode and did not get it, so export nothing
+		// rather than fall back to a transport they did not ask for.
+		exporter = newNoopGenerationExporter(otelErr)
+	case exporter == nil:
 		var err error
 		exporter, err = newGenerationExporter(cfg.GenerationExport)
 		if err != nil {
@@ -552,9 +621,18 @@ func (c *Client) StartGeneration(ctx context.Context, start GenerationStart) (co
 // This is intended for workflows that must durably publish a generation before
 // publishing a dependent record, such as an experiment score linked to a grader
 // generation. Normal instrumentation should use StartGeneration instead.
+//
+// The otel export protocol cannot honour that contract. The client hands the
+// span to a span processor, and the processor decides when to export the span,
+// so no per-generation delivery result exists to wait for. In that mode
+// ExportGeneration returns ErrSynchronousExportUnsupported instead of a
+// success the caller would act on.
 func (c *Client) ExportGeneration(ctx context.Context, start GenerationStart, generation Generation) error {
 	if c == nil {
 		return ErrNilClient
+	}
+	if c.otelExportEnabled() {
+		return fmt.Errorf("%w: generation export protocol %q", ErrSynchronousExportUnsupported, GenerationExportProtocolOTel)
 	}
 	_, recorder := c.startGeneration(ctx, start, GenerationModeSync)
 	recorder.mu.Lock()
@@ -576,6 +654,9 @@ func (c *Client) StartStreamingGeneration(ctx context.Context, start GenerationS
 }
 
 // EnqueueWorkflowStep enqueues a workflow execution node for export.
+//
+// The otel export protocol has no workflow-step encoding. In that mode
+// EnqueueWorkflowStep drops the step and returns ErrWorkflowStepEnqueueFailed.
 func (c *Client) EnqueueWorkflowStep(step WorkflowStep) error {
 	if c == nil {
 		return ErrNilClient
@@ -596,6 +677,11 @@ func (c *Client) EnqueueWorkflowStep(step WorkflowStep) error {
 	}
 	if len(c.config.Tags) > 0 {
 		normalized.Tags = mergeTags(c.config.Tags, normalized.Tags)
+	}
+	if c.otelExportEnabled() {
+		// Nothing that uses otel mode emits workflow steps today.
+		c.logf("agento11y: dropping workflow step %q: the otel export protocol has no workflow-step encoding", normalized.ID)
+		return fmt.Errorf("%w: the otel export protocol has no workflow-step encoding", ErrWorkflowStepEnqueueFailed)
 	}
 	if err := c.enqueueWorkflowStep(normalized); err != nil {
 		return fmt.Errorf("%w: %w", ErrWorkflowStepEnqueueFailed, err)
@@ -705,9 +791,20 @@ func (c *Client) startGeneration(ctx context.Context, start GenerationStart, def
 		spanGeneration.ConversationTitle = ""
 	}
 
-	callCtx, span := c.startSpan(ctx, spanGeneration, trace.SpanKindClient, startedAt)
-	span.SetAttributes(generationSpanAttributes(spanGeneration)...)
-	setSpanTagAttributes(span, dimensionalTags)
+	var (
+		callCtx    context.Context
+		span       trace.Span
+		invocation *otelgenai.Invocation
+	)
+	if c.otelExportEnabled() {
+		// In otel mode the semconv generation span carries the generation, and
+		// otelgenai owns the span's attributes.
+		callCtx, span, invocation = c.startOTelGeneration(ctx, spanGeneration, startedAt)
+	} else {
+		callCtx, span = c.startSpan(ctx, spanGeneration, trace.SpanKindClient, startedAt)
+		span.SetAttributes(generationSpanAttributes(spanGeneration)...)
+		setSpanTagAttributes(span, dimensionalTags)
+	}
 
 	callCtx = withContentCaptureMode(callCtx, ccMode)
 
@@ -715,6 +812,7 @@ func (c *Client) startGeneration(ctx context.Context, start GenerationStart, def
 		client:             c,
 		ctx:                callCtx,
 		span:               span,
+		invocation:         invocation,
 		seed:               seed,
 		startedAt:          startedAt,
 		contentCaptureMode: ccMode,
@@ -1013,24 +1111,29 @@ func (r *GenerationRecorder) End() {
 	// scoped to this change.
 	redactMapErr := r.contentCaptureMode == ContentCaptureModeFullWithMetadataSpans
 
-	r.span.SetName(generationSpanName(normalized))
-	// FullWithMetadataSpans: proto export keeps full content (normalized stays
-	// untouched), but the span path must drop content-bearing attributes. The
-	// only content-bearing attribute generationSpanAttributes emits is
-	// agento11y.conversation.title, so a shallow copy with the title zeroed is
-	// enough; no deep clone needed.
-	spanView := normalized
-	if r.contentCaptureMode == ContentCaptureModeFullWithMetadataSpans {
-		spanView.ConversationTitle = ""
-	}
-	r.span.SetAttributes(generationSpanAttributes(spanView)...)
-	if sanitizerRan && initialContentCaptureMode != ContentCaptureModeFullWithMetadataSpans {
-		// The start span published the raw seed title; overwrite with the
-		// post-sanitizer value so a sanitizer that empties or rewrites the
-		// title doesn't leave the raw value on the span. Skipped under
-		// FullWithMetadataSpans: the start span already omitted the title and
-		// re-emitting it as "" would violate the absent guarantee.
-		r.span.SetAttributes(attribute.String(spanAttrConversationTitle, spanView.ConversationTitle))
+	// In otel mode otelgenai writes the span's name and attributes at End from
+	// the invocation, so this code skips the metadata-span encoding.
+	otelMode := r.invocation != nil && r.client.otelExportEnabled()
+	if !otelMode {
+		r.span.SetName(generationSpanName(normalized))
+		// FullWithMetadataSpans: proto export keeps full content (normalized
+		// stays untouched), but the span path must drop content-bearing
+		// attributes. The only content-bearing attribute
+		// generationSpanAttributes emits is agento11y.conversation.title, so a
+		// shallow copy with the title zeroed is enough; no deep clone needed.
+		spanView := normalized
+		if r.contentCaptureMode == ContentCaptureModeFullWithMetadataSpans {
+			spanView.ConversationTitle = ""
+		}
+		r.span.SetAttributes(generationSpanAttributes(spanView)...)
+		if sanitizerRan && initialContentCaptureMode != ContentCaptureModeFullWithMetadataSpans {
+			// The start span published the raw seed title; overwrite with the
+			// post-sanitizer value so a sanitizer that empties or rewrites the
+			// title doesn't leave the raw value on the span. Skipped under
+			// FullWithMetadataSpans: the start span already omitted the title
+			// and re-emitting it as "" would violate the absent guarantee.
+			r.span.SetAttributes(attribute.String(spanAttrConversationTitle, spanView.ConversationTitle))
+		}
 	}
 
 	r.mu.Lock()
@@ -1063,12 +1166,61 @@ func (r *GenerationRecorder) End() {
 		}
 		r.span.RecordError(spanMapErr)
 	}
-	if enqueueErr != nil {
+	// In otel mode the span is the export, and a failure to export is not a
+	// failure of the generation. An exception event reads as an operation error
+	// to a trace backend, so it stays off for the same reason error.type and the
+	// span status do; see the otel branch below.
+	if enqueueErr != nil && !otelMode {
 		r.span.RecordError(enqueueErr)
 	}
 
 	errorType := generationErrorType(callErr, mapErr, enqueueErr)
 	errorCategory := generationErrorCategory(callErr, mapErr, enqueueErr)
+	if otelMode {
+		// error.type and the span status describe the generation, not this SDK's
+		// own export. enqueueErr means the provider answered and we could not
+		// record the answer, and the conventions reserve both fields for an
+		// operation that failed, so it travels on agento11y.export.error and in
+		// the log instead. recorder.Err() still reports it to the caller.
+		otelErrorType := generationErrorType(callErr, mapErr, nil)
+		otelErrorCategory := generationErrorCategory(callErr, mapErr, nil)
+		// The status text follows the same precedence as the metadata span
+		// below, so one failure reads the same on either protocol. When the
+		// caller reports a call error as a field rather than as an error, the
+		// status text stays empty, which matches the success the other protocols
+		// report for that input.
+		statusMessage := ""
+		switch {
+		case callErr != nil:
+			statusMessage = spanCallError
+		case mapErr != nil:
+			statusMessage = mapErr.Error()
+			if redactMapErr {
+				statusMessage = "sdk_error"
+			}
+		}
+		exportError := ""
+		if enqueueErr != nil {
+			exportError = enqueueErr.Error()
+			r.client.logf("agento11y: generation %q not exported: %v", normalized.ID, enqueueErr)
+		}
+		r.client.endOTelGeneration(r.ctx, r.invocation, normalized, generationError{
+			errorType:   otelErrorType,
+			category:    otelErrorCategory,
+			message:     statusMessage,
+			exportError: exportError,
+			rejected:    errors.Is(enqueueErr, errGenerationValidation),
+		}, firstTokenAt, r.contentCaptureMode)
+		if enqueueErr == nil {
+			r.client.recordGeneration(normalized)
+		}
+
+		r.mu.Lock()
+		r.finalErr = combineAllErrors(enqueueErr)
+		r.mu.Unlock()
+		return
+	}
+
 	if errorType != "" {
 		r.span.SetAttributes(attribute.String(spanAttrErrorType, errorType))
 		if errorCategory != "" {
@@ -1544,6 +1696,22 @@ func combineAllErrors(errs ...error) error {
 func (c *Client) persistGeneration(generation Generation) error {
 	if err := ValidateGeneration(generation); err != nil {
 		return fmt.Errorf("%w: %v", errGenerationValidation, err)
+	}
+	if c.otelExportEnabled() {
+		// The span carries the generation in otel mode, so the export queue
+		// stays out of the path. The shutdown check stays in it: after Shutdown
+		// the client no longer force-flushes the provider, so a record from here
+		// missed that flush, which is what the queue path reports as
+		// ErrClientShutdown. GenerationRecorder.End records the generation ID
+		// after ending the span. This prevents Flush from observing the ID before
+		// the span reaches its processor.
+		c.queueMu.RLock()
+		shuttingDown := c.shutdown
+		c.queueMu.RUnlock()
+		if shuttingDown {
+			return fmt.Errorf("%w: %w", errGenerationEnqueue, ErrClientShutdown)
+		}
+		return nil
 	}
 	if err := c.enqueueGeneration(generation); err != nil {
 		return fmt.Errorf("%w: %w", errGenerationEnqueue, err)

--- a/go/agento11y/codec/codec.go
+++ b/go/agento11y/codec/codec.go
@@ -25,6 +25,20 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// EffectiveVersionDigest returns the canonical sha256:<hex> digest of an
+// effective version, and returns "" when effectiveVersion is empty or holds
+// only whitespace. Every transport sends the digest rather than the raw
+// value, so one agent build resolves to one stored version on every
+// transport.
+func EffectiveVersionDigest(effectiveVersion string) string {
+	trimmed := strings.TrimSpace(effectiveVersion)
+	if trimmed == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(trimmed))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
 // ToProto converts a model.Generation into the wire-level proto used by
 // the generation ingest service. The effective_version field is hashed with
 // the canonical sha256:<hex> rule.
@@ -79,17 +93,6 @@ func ToProto(g model.Generation) (*agento11yv1.Generation, error) {
 	}
 
 	return out, nil
-}
-
-// EffectiveVersionDigest returns the sha256:<hex> digest of a raw
-// effective-version string, or "" when it holds nothing.
-func EffectiveVersionDigest(effectiveVersion string) string {
-	trimmed := strings.TrimSpace(effectiveVersion)
-	if trimmed == "" {
-		return ""
-	}
-	sum := sha256.Sum256([]byte(trimmed))
-	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 // WorkflowStepToProto converts a model.WorkflowStep into the wire-level

--- a/go/agento11y/env_test.go
+++ b/go/agento11y/env_test.go
@@ -71,6 +71,17 @@ func TestResolveFromEnv(t *testing.T) {
 			},
 		},
 		{
+			name: "otel protocol from env",
+			env: map[string]string{
+				"AGENTO11Y_PROTOCOL": "OTel",
+			},
+			check: func(t *testing.T, cfg Config) {
+				if cfg.GenerationExport.Protocol != GenerationExportProtocolOTel {
+					t.Errorf("Protocol=%q want otel", cfg.GenerationExport.Protocol)
+				}
+			},
+		},
+		{
 			name: "basic auth from env",
 			env: map[string]string{
 				"SIGIL_AUTH_MODE":      "basic",

--- a/go/agento11y/errors.go
+++ b/go/agento11y/errors.go
@@ -36,6 +36,13 @@ var (
 	ErrWorkflowStepQueueFull = errors.New("agento11y: workflow step queue is full")
 	// ErrClientShutdown is returned when enqueue happens after shutdown starts.
 	ErrClientShutdown = errors.New("agento11y: client is shutting down")
+	// ErrSynchronousExportUnsupported is returned by ExportGeneration when the
+	// configured protocol has no per-generation delivery result to report.
+	ErrSynchronousExportUnsupported = errors.New("agento11y: synchronous generation export is not supported by this protocol")
+	// ErrFlushNotVerifiable is returned by Flush when the configured protocol
+	// delivers through a component the client cannot flush, so a success would
+	// not mean the records left the process.
+	ErrFlushNotVerifiable = errors.New("agento11y: flush cannot confirm delivery with this configuration")
 	// ErrMappingFailed wraps provider-to-generation mapping failures.
 	ErrMappingFailed = errors.New("agento11y: generation mapping failed")
 	// ErrRatingValidationFailed wraps conversation rating input validation failures.

--- a/go/agento11y/exporter.go
+++ b/go/agento11y/exporter.go
@@ -346,6 +346,10 @@ func newGenerationExporter(cfg GenerationExportConfig) (generationExporter, erro
 		return newHTTPGenerationExporter(cfg)
 	case GenerationExportProtocolNone:
 		return newNoopGenerationExporter(nil), nil
+	case GenerationExportProtocolOTel:
+		// In otel mode generations travel on the OTel span pipeline, so the
+		// client has nothing to export over the gRPC or HTTP transports.
+		return newNoopGenerationExporter(nil), nil
 	default:
 		return nil, fmt.Errorf("unsupported generation export protocol %q", cfg.Protocol)
 	}
@@ -1061,6 +1065,15 @@ func (c *Client) enqueueWorkflowStep(step WorkflowStep) error {
 	}
 }
 
+// Flush blocks until the client has handed everything recorded so far to its
+// destination, and returns any error from that delivery.
+//
+// In otel export mode the destination is the tracer provider, so Flush
+// force-flushes that provider: callers use Flush as the proof that a batch
+// left the process before they discard their own copy of the batch. That
+// requires Config.TracerProvider. With only Config.Tracer set, the SDK cannot
+// reach the provider, and Flush returns ErrFlushNotVerifiable instead of a
+// success it cannot back.
 func (c *Client) Flush(ctx context.Context) error {
 	if c == nil {
 		return nil
@@ -1073,6 +1086,10 @@ func (c *Client) Flush(ctx context.Context) error {
 	c.queueMu.RUnlock()
 	if shuttingDown {
 		return ErrClientShutdown
+	}
+
+	if c.otelExportEnabled() {
+		return c.flushOTel(ctx)
 	}
 
 	ack := make(chan error, 1)
@@ -1115,6 +1132,16 @@ func (c *Client) Shutdown(ctx context.Context) error {
 
 		if err := c.exporter.Shutdown(ctx); err != nil {
 			shutdownErr = errors.Join(shutdownErr, err)
+		}
+
+		// In otel mode the generations are spans that the caller's provider
+		// still holds, and the queue drained above is empty. The force flush
+		// here is what keeps the documented "shut the client down before exit"
+		// true in that mode. The caller still shuts down the provider itself.
+		if c.otelExportEnabled() {
+			if err := c.flushOTel(ctx); err != nil && !errors.Is(err, ErrFlushNotVerifiable) {
+				shutdownErr = errors.Join(shutdownErr, err)
+			}
 		}
 	})
 

--- a/go/agento11y/exporter_transport_test.go
+++ b/go/agento11y/exporter_transport_test.go
@@ -2,6 +2,7 @@ package agento11y
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -17,7 +18,9 @@ import (
 	agento11yv1 "github.com/grafana/agento11y/go/proto/agento11y/v1"
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -273,7 +276,7 @@ func TestExportAttemptTimesOutOnHungIngest(t *testing.T) {
 				if err == nil {
 					t.Fatalf("%s export against hung ingest returned nil error", export.name)
 				}
-				if !strings.Contains(strings.ToLower(err.Error()), "deadline exceeded") {
+				if !errors.Is(err, context.DeadlineExceeded) && status.Code(err) != codes.DeadlineExceeded {
 					t.Fatalf("%s export error = %v, want a deadline-exceeded failure", export.name, err)
 				}
 				if elapsed >= maxElapsed {

--- a/go/agento11y/otel_export.go
+++ b/go/agento11y/otel_export.go
@@ -1,0 +1,596 @@
+package agento11y
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/agento11y/go/agento11y/otelhook"
+	"github.com/grafana/agento11y/go/otelgenai"
+)
+
+// FeatureOTelGenerationExport names the experimental feature that exports
+// generations as GenAI-semconv spans instead of calling the generation-export
+// endpoint. RequireExperimental writes the name into a sentence, so the value
+// is prose rather than an identifier.
+const FeatureOTelGenerationExport = "otel generation export"
+
+// otelPartExtension keys carry the parts of the agento11y data model that the
+// conventions' message schema has no field for. They match the extension keys
+// that the backend's wire-format decoder reads.
+const (
+	otelPartExtProviderType = "agento11y.provider_type"
+	otelPartExtToolName     = "agento11y.tool_name"
+	otelPartExtIsError      = "agento11y.is_error"
+	otelPartExtArgumentsB64 = "agento11y.arguments_b64"
+	otelPartExtResponseB64  = "agento11y.response_b64"
+	otelPartExtMediaName    = "agento11y.media_name"
+	otelToolExtDeferred     = "agento11y.deferred"
+	otelToolExtSchemaB64    = "agento11y.input_schema_b64"
+)
+
+// otelProviderStoredToWire maps the SDK's stored provider values to the OTel
+// GenAI registry spellings. The backend applies the inverse mapping, so the
+// round trip leaves a stored record unchanged.
+var otelProviderStoredToWire = map[string]string{
+	"gemini":             "gcp.gemini",
+	"mistral":            "mistral_ai",
+	"moonshotai":         "moonshot_ai",
+	"vertex":             "gcp.vertex_ai",
+	"bedrock":            "aws.bedrock",
+	"azure-openai":       "azure.ai.openai",
+	"azure-ai-inference": "azure.ai.inference",
+	"watsonx":            "ibm.watsonx.ai",
+	"x-ai":               "x_ai",
+}
+
+// otelExportEnabled reports whether generations leave this client as GenAI
+// spans instead of proprietary export payloads.
+func (c *Client) otelExportEnabled() bool {
+	return c != nil && c.otelHandler != nil
+}
+
+// Flusher force-flushes whatever still holds finished spans, which in otel mode
+// is where a generation goes. *go.opentelemetry.io/otel/sdk/trace.TracerProvider
+// satisfies it.
+//
+// The SDK does not reach this method by asserting Config.TracerProvider to it.
+// ForceFlush lives on the OTel SDK's provider and not on the API interface the
+// SDK is handed, and a provider's lifecycle belongs to the application, so the
+// application names the flush target itself. This follows otellambda, which
+// takes the same interface as an explicit option.
+type Flusher interface {
+	ForceFlush(ctx context.Context) error
+}
+
+// flushOTel force-flushes Config.Flusher, which is where a generation goes in
+// otel mode. Without it the SDK cannot tell whether the span processor still
+// holds the batch, and a nil return would tell the caller that a batch is
+// delivered when it might not be.
+func (c *Client) flushOTel(ctx context.Context) error {
+	if c.config.Flusher == nil {
+		return fmt.Errorf("%w: set Config.Flusher to your tracer provider", ErrFlushNotVerifiable)
+	}
+	if err := c.config.Flusher.ForceFlush(ctx); err != nil {
+		return fmt.Errorf("agento11y otel generation export flush: %w", err)
+	}
+	return nil
+}
+
+// newOTelHandler builds the otelgenai handler for otel-mode export. When the
+// experimental gate is closed it returns a nil handler and an error, and the
+// caller then falls back to the noop exporter.
+//
+// The handler gets its tracer and spec meter from Config.TracerProvider and
+// Config.MeterProvider, or from the corresponding global providers.
+// Config.Tracer and Config.Meter never reach it; see their Config docs.
+//
+// The handler logger comes from the global OTel logger provider, and
+// otelHandlerOptions disables operation-details records. A process-wide OTel
+// environment variable must not add a signal the client did not configure.
+func newOTelHandler(cfg Config) (*otelgenai.Handler, error) {
+	if err := RequireExperimental(FeatureOTelGenerationExport); err != nil {
+		return nil, err
+	}
+	return otelgenai.NewHandler(otelHandlerOptions(cfg)...), nil
+}
+
+func otelHandlerOptions(cfg Config) []otelgenai.Option {
+	return []otelgenai.Option{
+		otelgenai.WithEndHook(otelhook.New()),
+		otelgenai.WithCaptureMode(otelCaptureMode(cfg.ContentCapture)),
+		otelgenai.WithEmitEvent(false),
+		otelgenai.WithExtendedTokenTypes(),
+		otelgenai.WithConformantMetrics(),
+		otelgenai.WithTracerProvider(cfg.TracerProvider),
+		otelgenai.WithMeterProvider(cfg.MeterProvider),
+	}
+}
+
+// otelCaptureMode translates the SDK's content-capture mode onto the otelgenai
+// setting. AGENTO11Y_CONTENT_CAPTURE_MODE alone decides that setting: in otel
+// mode the span is the export, so the conventions'
+// OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT would otherwise let a
+// traces-side setting overrule the SDK's own content policy.
+//
+// FullWithMetadataSpans keeps content off the OTel destination by contract,
+// and in otel mode there is no second destination, so that mode exports
+// metadata only. NewClient logs that restriction when it builds the handler.
+func otelCaptureMode(mode ContentCaptureMode) otelgenai.CaptureMode {
+	switch resolveClientContentCaptureMode(mode) {
+	case ContentCaptureModeFull, ContentCaptureModeNoToolContent:
+		return otelgenai.CaptureSpanOnly
+	case ContentCaptureModeMetadataOnly, ContentCaptureModeFullWithMetadataSpans:
+		return otelgenai.CaptureNoContent
+	default:
+		return otelgenai.CaptureNoContent
+	}
+}
+
+// startOTelGeneration opens the generation's span through otelgenai. Only the
+// request fields are known here, and they are the fields a sampler can act on.
+// endOTelGeneration overwrites all of them from the finished generation.
+func (c *Client) startOTelGeneration(
+	ctx context.Context,
+	seed Generation,
+	startedAt time.Time,
+) (context.Context, trace.Span, *otelgenai.Invocation) {
+	invocation := &otelgenai.Invocation{
+		Operation:      otelOperation(seed.OperationName),
+		Provider:       otelProviderName(seed.Model.Provider),
+		RequestModel:   seed.Model.Name,
+		ConversationID: seed.ConversationID,
+		AgentName:      seed.AgentName,
+		AgentVersion:   seed.AgentVersion,
+		Stream:         seed.Mode == GenerationModeStream,
+		MaxTokens:      cloneInt64Ptr(seed.MaxTokens),
+		Temperature:    cloneFloat64Ptr(seed.Temperature),
+		TopP:           cloneFloat64Ptr(seed.TopP),
+		StartedAt:      startedAt,
+	}
+	ctx = c.otelHandler.Start(ctx, invocation)
+	return ctx, invocation.Span(), invocation
+}
+
+// generationError is the classified outcome of one generation: the
+// low-cardinality error.type, the SDK's error category, and the text that goes
+// on the span status. All three are empty on success.
+type generationError struct {
+	errorType string
+	category  string
+	message   string
+	// exportError is a failure of this SDK's own export of the record, which
+	// leaves error.type and the span status alone: the generation itself
+	// succeeded, and the conventions reserve both fields for an operation that
+	// failed. It goes on agento11y.export.error so the drop stays visible in
+	// the trace without reading as a failed model call.
+	exportError string
+	// rejected marks a record the SDK's own validator refused. The span still
+	// closes, so the failure stays visible, but the span carries no generation
+	// payload: every other protocol drops the record before the queue, and a
+	// span that carries the generation id is what makes the backend store one.
+	rejected bool
+}
+
+// endOTelGeneration fills the invocation from the finished generation and
+// closes it through otelgenai, which writes the span attributes, the status,
+// and the spec metrics.
+//
+// capture is the generation's resolved content-capture mode, which can differ
+// from the client's when the call or the resolver overrode it.
+func (c *Client) endOTelGeneration(
+	ctx context.Context,
+	invocation *otelgenai.Invocation,
+	generation Generation,
+	failure generationError,
+	firstTokenAt time.Time,
+	capture ContentCaptureMode,
+) {
+	if invocation == nil {
+		return
+	}
+	applyGenerationToInvocation(invocation, generation, failure, firstTokenAt, capture)
+	invocation.MetricAttributes = c.otelMetricAttributes(ctx, generation, failure)
+	// metricExemplarContext strips the context down to its span context, which
+	// is what an exemplar needs, because an exemplar reservoir retains whatever
+	// the context holds for the life of the series. End reads the span from the
+	// invocation rather than from the context, so the narrowed context costs
+	// nothing here and the exemplar still points at this generation's span.
+	c.otelHandler.End(metricExemplarContext(ctx), invocation)
+}
+
+// otelMetricAttributes are the dimensions the SDK's own generation metrics
+// carry and the spec instruments do not add. Without them, otel mode loses
+// agent identity, every agento11y.tag.* series, the error category, and the
+// token semantics marker.
+func (c *Client) otelMetricAttributes(ctx context.Context, generation Generation, failure generationError) []attribute.KeyValue {
+	attrs := metricTagAttributes(mergeTags(c.config.Tags, TagsFromContext(ctx)))
+	if failure.category != "" {
+		attrs = append(attrs, metricStringAttribute(spanAttrErrorCategory, failure.category))
+	}
+	if generation.Usage.InputSemantics == TokenInputSemanticsInclusive {
+		attrs = append(attrs, metricStringAttribute(attrTokenSemantics, tokenSemanticsInclusive))
+	}
+	if generation.AgentName != "" {
+		attrs = append(attrs, metricStringAttribute(spanAttrAgentName, generation.AgentName))
+	}
+	if generation.AgentVersion != "" {
+		attrs = append(attrs, metricStringAttribute(spanAttrAgentVersion, generation.AgentVersion))
+	}
+	return attrs
+}
+
+// applyGenerationToInvocation maps a normalized generation onto the
+// invocation otelgenai emits. Content arrives already sanitized and, under
+// metadata_only, already stripped.
+func applyGenerationToInvocation(
+	invocation *otelgenai.Invocation,
+	generation Generation,
+	failure generationError,
+	firstTokenAt time.Time,
+	capture ContentCaptureMode,
+) {
+	// The client's mode set the handler's default. capture is the mode after
+	// the per-call field and the resolver applied their overrides.
+	invocation.Capture = otelCaptureMode(capture)
+	invocation.Operation = otelOperation(generation.OperationName)
+	invocation.Provider = otelProviderName(generation.Model.Provider)
+	invocation.RequestModel = generation.Model.Name
+	invocation.ResponseModel = generation.ResponseModel
+	invocation.ResponseID = generation.ResponseID
+	invocation.ConversationID = generation.ConversationID
+	invocation.AgentName = generation.AgentName
+	invocation.AgentVersion = generation.AgentVersion
+	invocation.Stream = generation.Mode == GenerationModeStream
+	invocation.SystemInstructions = otelgenai.SystemInstructionsFromText(generation.SystemPrompt)
+	invocation.InputMessages = otelMessages(generation.Input, nil)
+	invocation.OutputMessages = otelMessages(generation.Output, &generation.StopReason)
+	invocation.ToolDefinitions = otelToolDefinitions(generation.Tools)
+	if generation.StopReason != "" {
+		invocation.FinishReasons = []string{generation.StopReason}
+	}
+	// Reported stays unset: the SDK cannot distinguish an all-zero usage that a
+	// provider returned from a usage the SDK never received, and otelgenai
+	// counts any non-zero count as reported. Setting Reported here would export
+	// input and output tokens of 0 for a call that never reached a provider.
+	invocation.Usage = otelgenai.Usage{
+		InputTokens:           generation.Usage.InputTokens,
+		OutputTokens:          generation.Usage.OutputTokens,
+		CacheReadInputTokens:  generation.Usage.CacheReadInputTokens,
+		CacheWriteInputTokens: generation.Usage.CacheWriteInputTokens,
+		ReasoningTokens:       generation.Usage.ReasoningTokens,
+	}
+	invocation.MaxTokens = cloneInt64Ptr(generation.MaxTokens)
+	invocation.Temperature = cloneFloat64Ptr(generation.Temperature)
+	invocation.TopP = cloneFloat64Ptr(generation.TopP)
+	// This function does not reassign StartedAt. Start fixed the span's start
+	// instant and the metrics measure from it, so a generation's own start would
+	// disagree with both. A mapper that reports a provider-side start therefore
+	// changes the duration on the proprietary path and leaves the duration here
+	// alone.
+	invocation.CompletedAt = generation.CompletedAt
+	if invocation.Stream {
+		invocation.FirstChunkAt = firstTokenAt
+	}
+	invocation.ErrorType = failure.errorType
+	invocation.ErrorMessage = failure.message
+	if failure.category != "" {
+		// The category is what the SDK's error dashboards group by; the
+		// conventions have no equivalent.
+		invocation.Attributes = append(invocation.Attributes,
+			attribute.String(spanAttrErrorCategory, failure.category))
+	}
+	if failure.exportError != "" {
+		invocation.Attributes = append(invocation.Attributes,
+			attribute.String(spanAttrExportError, failure.exportError))
+	}
+	if failure.rejected {
+		invocation.SystemInstructions = nil
+		invocation.InputMessages = nil
+		invocation.OutputMessages = nil
+		invocation.ToolDefinitions = nil
+		invocation.Vendor = nil
+		return
+	}
+
+	invocation.Vendor = otelhook.Generation{
+		ID:                  generation.ID,
+		UserID:              generation.UserID,
+		ConversationTitle:   generation.ConversationTitle,
+		Tags:                generation.Tags,
+		Metadata:            generation.Metadata,
+		Artifacts:           otelArtifacts(generation.Artifacts),
+		ParentGenerationIDs: generation.ParentGenerationIDs,
+		// The raw version, not the digest: the hook hashes it, as codec.ToProto
+		// does on the proprietary path.
+		EffectiveVersion:        generation.EffectiveVersion,
+		ToolChoice:              cloneStringPtr(generation.ToolChoice),
+		ThinkingEnabled:         cloneBoolPtr(generation.ThinkingEnabled),
+		TotalTokens:             generation.Usage.TotalTokens,
+		InclusiveTokenSemantics: generation.Usage.InputSemantics == TokenInputSemanticsInclusive,
+	}
+}
+
+// otelOperation maps the SDK's operation name onto the conventions' operation.
+// The two mode defaults become the spec's chat operation, which the span name
+// and the metric dimension carry. Any other name is the caller's own, and
+// passes through unchanged.
+func otelOperation(operationName string) otelgenai.Operation {
+	switch operationName {
+	case "", defaultOperationNameSync, defaultOperationNameStream:
+		return otelgenai.OperationChat
+	default:
+		return otelgenai.Operation(operationName)
+	}
+}
+
+// otelArtifacts maps raw artifacts onto the hook's wire shape. Artifacts carry
+// provider payloads, so the hook emits them only when content capture allows
+// it.
+func otelArtifacts(artifacts []Artifact) []otelhook.Artifact {
+	if len(artifacts) == 0 {
+		return nil
+	}
+	out := make([]otelhook.Artifact, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		out = append(out, otelhook.Artifact{
+			Kind:        artifact.Kind,
+			Name:        artifact.Name,
+			ContentType: artifact.ContentType,
+			Payload:     artifact.Payload,
+			RecordID:    artifact.RecordID,
+			URI:         artifact.URI,
+		})
+	}
+	return out
+}
+
+// otelProviderName returns the registry spelling of a stored provider value.
+func otelProviderName(provider string) string {
+	if wire, ok := otelProviderStoredToWire[provider]; ok {
+		return wire
+	}
+	return provider
+}
+
+// otelMessages maps SDK messages onto the conventions' message schema.
+// finishReason is non-nil for output messages, where the schema requires the
+// key even when the value is empty.
+func otelMessages(messages []Message, finishReason *string) []otelgenai.Message {
+	if len(messages) == 0 {
+		return nil
+	}
+	out := make([]otelgenai.Message, 0, len(messages))
+	for _, message := range messages {
+		converted := otelgenai.Message{
+			Role:         otelgenai.Role(message.Role),
+			Name:         message.Name,
+			FinishReason: finishReason,
+		}
+		for _, part := range message.Parts {
+			mapped, ok := otelPart(part)
+			if !ok {
+				continue
+			}
+			converted.Parts = append(converted.Parts, mapped)
+		}
+		out = append(out, converted)
+	}
+	return out
+}
+
+// otelPart maps one SDK part onto a message part. Parts with no payload have
+// no shape in the schema, so otelPart drops them.
+func otelPart(part Part) (otelgenai.Part, bool) {
+	out := otelgenai.Part{}
+	if providerType := part.Metadata.ProviderType; providerType != "" {
+		out.Extensions = map[string]any{otelPartExtProviderType: providerType}
+	}
+	switch part.Kind {
+	case PartKindText:
+		text := part.Text
+		out.Type = otelgenai.PartTypeText
+		out.Content = &text
+	case PartKindThinking:
+		thinking := part.Thinking
+		out.Type = otelgenai.PartTypeReasoning
+		out.Content = &thinking
+	case PartKindToolCall:
+		if part.ToolCall == nil {
+			return otelgenai.Part{}, false
+		}
+		out.Type = otelgenai.PartTypeToolCall
+		out.ID = part.ToolCall.ID
+		out.Name = part.ToolCall.Name
+		arguments, b64 := otelJSONBytes(part.ToolCall.InputJSON)
+		out.Arguments = arguments
+		if b64 != "" {
+			out.Extensions = otelSetExtension(out.Extensions, otelPartExtArgumentsB64, b64)
+		}
+	case PartKindToolResult:
+		if part.ToolResult == nil {
+			return otelgenai.Part{}, false
+		}
+		out.Type = otelgenai.PartTypeToolCallResponse
+		out.ID = part.ToolResult.ToolCallID
+		if part.ToolResult.Name != "" {
+			out.Extensions = otelSetExtension(out.Extensions, otelPartExtToolName, part.ToolResult.Name)
+		}
+		if part.ToolResult.IsError {
+			out.Extensions = otelSetExtension(out.Extensions, otelPartExtIsError, true)
+		}
+		response, b64 := otelToolResponse(part.ToolResult.Content, part.ToolResult.ContentJSON)
+		out.Response = response
+		if b64 != "" {
+			out.Extensions = otelSetExtension(out.Extensions, otelPartExtResponseB64, b64)
+		}
+	case PartKindMedia:
+		if part.Media == nil {
+			return otelgenai.Part{}, false
+		}
+		otelMediaPart(&out, part.Media)
+	default:
+		return otelgenai.Part{}, false
+	}
+	return out, true
+}
+
+// otelMediaPart renders media as one of the conventions' media part shapes: a
+// base64 data URL becomes an inline blob, any other URL a uri reference, and
+// an empty URL a file reference keyed by name.
+//
+// A declared mime type that disagrees with the data URL's own counts as a
+// mislabeled payload and becomes a uri instead. Two cases keep the blob shape:
+// the comparison ignores case, and an undeclared mime type takes the data
+// URL's mime type.
+func otelMediaPart(out *otelgenai.Part, media *Media) {
+	if media.Kind != "" {
+		kind := media.Kind
+		out.Modality = &kind
+	}
+	out.MimeType = media.MIMEType
+
+	if mimeType, payload, ok := splitBase64DataURL(media.URL); ok &&
+		(media.MIMEType == "" || strings.EqualFold(mimeType, media.MIMEType)) {
+		out.Type = otelgenai.PartTypeBlob
+		out.Content = &payload
+		if out.MimeType == "" {
+			out.MimeType = mimeType
+		}
+		if media.Name != "" {
+			out.Extensions = otelSetExtension(out.Extensions, otelPartExtMediaName, media.Name)
+		}
+		return
+	}
+	if media.URL != "" {
+		out.Type = otelgenai.PartTypeURI
+		out.URI = media.URL
+		if media.Name != "" {
+			out.Extensions = otelSetExtension(out.Extensions, otelPartExtMediaName, media.Name)
+		}
+		return
+	}
+	name := media.Name
+	out.Type = otelgenai.PartTypeFile
+	out.FileID = &name
+}
+
+func splitBase64DataURL(url string) (mimeType string, payload string, ok bool) {
+	const prefix = "data:"
+	const marker = ";base64,"
+	if !strings.HasPrefix(url, prefix) {
+		return "", "", false
+	}
+	mimeType, payload, ok = strings.Cut(url[len(prefix):], marker)
+	if !ok {
+		return "", "", false
+	}
+	return mimeType, payload, true
+}
+
+func otelToolDefinitions(tools []ToolDefinition) []otelgenai.ToolDefinition {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]otelgenai.ToolDefinition, 0, len(tools))
+	for _, tool := range tools {
+		converted := otelgenai.ToolDefinition{
+			Type:        tool.Type,
+			Name:        tool.Name,
+			Description: tool.Description,
+		}
+		parameters, b64 := otelJSONBytes(tool.InputSchema)
+		converted.Parameters = parameters
+		if tool.Deferred {
+			converted.Extensions = otelSetExtension(converted.Extensions, otelToolExtDeferred, true)
+		}
+		if b64 != "" {
+			converted.Extensions = otelSetExtension(converted.Extensions, otelToolExtSchemaB64, b64)
+		}
+		out = append(out, converted)
+	}
+	return out
+}
+
+// otelToolResponse renders a tool result's content onto the schema's
+// `response` key. Structured results go on the wire raw. Anything else goes as
+// a JSON string, with the exact bytes on the base64 extension key, which is the
+// shape the backend decoder inverts.
+func otelToolResponse(content string, contentJSON []byte) (json.RawMessage, string) {
+	if len(contentJSON) == 0 {
+		return otelJSONString(content), ""
+	}
+	// Text content wins: when the result carries text, otelToolResponse never
+	// inspects the JSON.
+	if content == "" {
+		if raw, ok := otelEmbeddableJSON(contentJSON); ok && !otelIsJSONString(raw) {
+			return raw, ""
+		}
+	}
+	return otelJSONString(content), base64.StdEncoding.EncodeToString(contentJSON)
+}
+
+// otelJSONBytes places a JSON document on the wire raw when it survives a
+// round trip and falls back to the base64 extension key otherwise.
+func otelJSONBytes(raw []byte) (json.RawMessage, string) {
+	if len(raw) == 0 {
+		return nil, ""
+	}
+	if embeddable, ok := otelEmbeddableJSON(raw); ok {
+		return embeddable, ""
+	}
+	return nil, base64.StdEncoding.EncodeToString(raw)
+}
+
+// otelEmbeddableJSON reports whether raw can go on the wire as a JSON document
+// and decode back to the same value. The bytes must already be compact, because
+// the enclosing marshal compacts what it embeds.
+//
+// The enclosing marshal also escapes <, > and & as \u003c, \u003e and \u0026,
+// which every JSON decoder reads back as the original character. Coding-agent
+// tool arguments are full of those three bytes, so the comparison uses
+// json.Compact, which leaves the three bytes alone. Demanding the escaped form
+// would push most tool calls onto the base64 extension key and leave the
+// semconv `arguments` field empty for every generic OTel consumer.
+//
+// otelEmbeddableJSON also rejects a JSON null, because the decoder reads a
+// null as an absent payload.
+func otelEmbeddableJSON(raw []byte) (json.RawMessage, bool) {
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, false
+	}
+	var compact bytes.Buffer
+	// Compact rejects invalid JSON, so this call is the validity check as well.
+	if err := json.Compact(&compact, raw); err != nil {
+		return nil, false
+	}
+	if !bytes.Equal(compact.Bytes(), raw) {
+		return nil, false
+	}
+	return json.RawMessage(raw), true
+}
+
+func otelJSONString(value string) json.RawMessage {
+	payload, _ := json.Marshal(value)
+	return json.RawMessage(payload)
+}
+
+func otelIsJSONString(raw []byte) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) > 0 && trimmed[0] == '"'
+}
+
+func otelSetExtension(extensions map[string]any, key string, value any) map[string]any {
+	if extensions == nil {
+		extensions = map[string]any{}
+	}
+	extensions[key] = value
+	return extensions
+}

--- a/go/agento11y/otel_export_test.go
+++ b/go/agento11y/otel_export_test.go
@@ -1,0 +1,1007 @@
+package agento11y
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/log/logtest"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/grafana/agento11y/go/otelgenai"
+)
+
+// newOTelTestClient builds a client in otel export mode with the experimental
+// gate open, recording spans into the returned recorder.
+func newOTelTestClient(t *testing.T, mutate func(*Config)) (*Client, *tracetest.SpanRecorder, *sdktrace.TracerProvider) {
+	t.Helper()
+
+	t.Setenv(EnvEnableExperimentalFeatures, "true")
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+	})
+
+	cfg := DefaultConfig()
+	cfg.GenerationExport.Protocol = GenerationExportProtocolOTel
+	cfg.ContentCapture = ContentCaptureModeFull
+	cfg.TracerProvider = provider
+	cfg.Flusher = provider
+	cfg.Now = time.Now
+	cfg.testGenerationExporter = &capturingGenerationExporter{}
+	if mutate != nil {
+		mutate(&cfg)
+	}
+
+	client := NewClient(cfg)
+	t.Cleanup(func() {
+		_ = client.Shutdown(context.Background())
+	})
+	return client, recorder, provider
+}
+
+func recordOTelGeneration(t *testing.T, client *Client, generation Generation) {
+	t.Helper()
+
+	_, recorder := client.StartStreamingGeneration(context.Background(), GenerationStart{
+		Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+	})
+	recorder.SetResult(generation, nil)
+	recorder.End()
+	if err := recorder.Err(); err != nil {
+		t.Fatalf("recorder: %v", err)
+	}
+}
+
+func onlySpan(t *testing.T, recorder *tracetest.SpanRecorder) sdktrace.ReadOnlySpan {
+	t.Helper()
+
+	ended := recorder.Ended()
+	if len(ended) != 1 {
+		t.Fatalf("recorded %d spans, want 1", len(ended))
+	}
+	return ended[0]
+}
+
+// exceptionEventCount counts the span's recorded exceptions. A trace backend
+// reads those events as operation errors, so an export failure must not add one.
+func exceptionEventCount(span sdktrace.ReadOnlySpan) int {
+	count := 0
+	for _, event := range span.Events() {
+		if event.Name == "exception" {
+			count++
+		}
+	}
+	return count
+}
+
+func spanAttributeMapOf(span sdktrace.ReadOnlySpan) map[string]attribute.Value {
+	out := make(map[string]attribute.Value, len(span.Attributes()))
+	for _, kv := range span.Attributes() {
+		out[string(kv.Key)] = kv.Value
+	}
+	return out
+}
+
+func TestOTelModeUsesTracerProviderInsteadOfDirectTracer(t *testing.T) {
+	directRecorder := tracetest.NewSpanRecorder()
+	directProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(directRecorder))
+	t.Cleanup(func() { _ = directProvider.Shutdown(context.Background()) })
+
+	client, providerRecorder, _ := newOTelTestClient(t, func(cfg *Config) {
+		cfg.Tracer = directProvider.Tracer("direct-tracer")
+	})
+	recordOTelGeneration(t, client, Generation{Output: []Message{AssistantTextMessage("Hi!")}})
+
+	if got := len(providerRecorder.Ended()); got != 1 {
+		t.Fatalf("provider recorder holds %d spans, want 1", got)
+	}
+	if got := len(directRecorder.Ended()); got != 0 {
+		t.Fatalf("direct tracer recorder holds %d spans, want 0", got)
+	}
+}
+
+func TestOTelProtocolSpan(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*Config)
+		content Generation
+		check   func(t *testing.T, span sdktrace.ReadOnlySpan)
+	}{
+		{
+			name: "semconv span replaces the metadata span",
+			content: Generation{
+				Input:  []Message{UserTextMessage("Hello")},
+				Output: []Message{AssistantTextMessage("Hi!")},
+				Usage:  TokenUsage{InputTokens: 120, OutputTokens: 42, TotalTokens: 162},
+			},
+			check: func(t *testing.T, span sdktrace.ReadOnlySpan) {
+				if got := span.Name(); got != "chat gpt-5" {
+					t.Errorf("span name = %q, want %q", got, "chat gpt-5")
+				}
+				attrs := spanAttributeMapOf(span)
+				if got := attrs["gen_ai.operation.name"].AsString(); got != "chat" {
+					t.Errorf("gen_ai.operation.name = %q, want chat", got)
+				}
+				if !attrs["gen_ai.request.stream"].AsBool() {
+					t.Error("gen_ai.request.stream is not true for a streaming generation")
+				}
+				if got := attrs["agento11y.gen_ai.usage.total_tokens"].AsInt64(); got != 162 {
+					t.Errorf("total tokens = %d, want 162", got)
+				}
+				if got := attrs["gen_ai.input.messages"].AsString(); !strings.Contains(got, "Hello") {
+					t.Errorf("gen_ai.input.messages = %q, want it to contain Hello", got)
+				}
+				if _, ok := attrs["agento11y.sdk.name"]; ok {
+					t.Error("otel-mode span carries the metadata-span attributes")
+				}
+				if attrs["agento11y.generation.id"].AsString() == "" {
+					t.Error("otel-mode span carries no agento11y.generation.id")
+				}
+			},
+		},
+		{
+			name: "metadata only drops content",
+			mutate: func(cfg *Config) {
+				cfg.ContentCapture = ContentCaptureModeMetadataOnly
+			},
+			content: Generation{
+				Input:  []Message{UserTextMessage("secret prompt")},
+				Output: []Message{AssistantTextMessage("secret answer")},
+				Usage:  TokenUsage{InputTokens: 10, OutputTokens: 5},
+			},
+			check: func(t *testing.T, span sdktrace.ReadOnlySpan) {
+				attrs := spanAttributeMapOf(span)
+				for _, key := range []string{
+					"gen_ai.input.messages",
+					"gen_ai.output.messages",
+					"gen_ai.system_instructions",
+					"gen_ai.tool.definitions",
+				} {
+					if _, ok := attrs[key]; ok {
+						t.Errorf("metadata_only span carries %s", key)
+					}
+				}
+				if attrs["agento11y.generation.id"].AsString() == "" {
+					t.Error("metadata_only span lost the generation id")
+				}
+				if got := attrs["gen_ai.usage.input_tokens"].AsInt64(); got != 10 {
+					t.Errorf("gen_ai.usage.input_tokens = %d, want 10", got)
+				}
+			},
+		},
+		{
+			name: "tags ride as a document and as dimensions",
+			mutate: func(cfg *Config) {
+				cfg.Tags = map[string]string{"team": "sigil"}
+			},
+			content: Generation{Output: []Message{AssistantTextMessage("Hi!")}},
+			check: func(t *testing.T, span sdktrace.ReadOnlySpan) {
+				attrs := spanAttributeMapOf(span)
+				if got := attrs["agento11y.generation.tags"].AsString(); got != `{"team":"sigil"}` {
+					t.Errorf("agento11y.generation.tags = %q, want the tags document", got)
+				}
+				if got := attrs["agento11y.tag.team"].AsString(); got != "sigil" {
+					t.Errorf("agento11y.tag.team = %q, want sigil", got)
+				}
+			},
+		},
+		{
+			name: "redaction runs before the span is encoded",
+			mutate: func(cfg *Config) {
+				cfg.GenerationSanitizer = NewSecretRedactionSanitizer(SecretRedactionOptions{
+					RedactInputMessages: BoolPtr(true),
+				})
+			},
+			content: Generation{
+				Input: []Message{UserTextMessage("token ghp_0123456789abcdefghijklmnopqrstuvwxyz")},
+			},
+			check: func(t *testing.T, span sdktrace.ReadOnlySpan) {
+				got := spanAttributeMapOf(span)["gen_ai.input.messages"].AsString()
+				if strings.Contains(got, "ghp_0123456789abcdefghijklmnopqrstuvwxyz") {
+					t.Errorf("gen_ai.input.messages = %q, want the secret redacted", got)
+				}
+			},
+		},
+		{
+			name:    "usage a provider never returned is absent",
+			content: Generation{Output: []Message{AssistantTextMessage("Hi!")}},
+			check: func(t *testing.T, span sdktrace.ReadOnlySpan) {
+				// Zeros here would read as a call that really used no tokens.
+				attrs := spanAttributeMapOf(span)
+				if _, ok := attrs["gen_ai.usage.input_tokens"]; ok {
+					t.Error("a generation with no usage carries gen_ai.usage.input_tokens")
+				}
+				if _, ok := attrs["gen_ai.usage.output_tokens"]; ok {
+					t.Error("a generation with no usage carries gen_ai.usage.output_tokens")
+				}
+			},
+		},
+		{
+			name: "a call error the mapper set as a field is not a span error",
+			content: Generation{
+				Output:    []Message{AssistantTextMessage("Hi!")},
+				CallError: "provider returned 500",
+			},
+			check: func(t *testing.T, span sdktrace.ReadOnlySpan) {
+				// The other protocols report this generation as a success, and
+				// an error status with no error.type would skew both.
+				if got := span.Status().Code; got != codes.Unset {
+					t.Errorf("status = %v, want unset", got)
+				}
+				if _, ok := spanAttributeMapOf(span)["error.type"]; ok {
+					t.Error("span carries error.type without a failed call")
+				}
+			},
+		},
+		{
+			name: "an inline data url is a blob when the mime type is undeclared",
+			content: Generation{
+				Input: []Message{{
+					Role: RoleUser,
+					Parts: []Part{{
+						Kind:  PartKindMedia,
+						Media: &Media{Kind: "image", URL: "data:image/png;base64,abc123"},
+					}},
+				}},
+			},
+			check: func(t *testing.T, span sdktrace.ReadOnlySpan) {
+				got := spanAttributeMapOf(span)["gen_ai.input.messages"].AsString()
+				if !strings.Contains(got, `"type":"blob"`) {
+					t.Errorf("gen_ai.input.messages = %q, want an inline blob part", got)
+				}
+				if !strings.Contains(got, `"mime_type":"image/png"`) {
+					t.Errorf("gen_ai.input.messages = %q, want the data url's mime type", got)
+				}
+			},
+		},
+		{
+			name: "an inline data url is a blob when the declared mime type differs in case",
+			content: Generation{
+				Input: []Message{{
+					Role: RoleUser,
+					Parts: []Part{{
+						Kind:  PartKindMedia,
+						Media: &Media{Kind: "image", URL: "data:image/png;base64,abc123", MIMEType: "image/PNG"},
+					}},
+				}},
+			},
+			check: func(t *testing.T, span sdktrace.ReadOnlySpan) {
+				got := spanAttributeMapOf(span)["gen_ai.input.messages"].AsString()
+				if !strings.Contains(got, `"type":"blob"`) {
+					t.Errorf("gen_ai.input.messages = %q, want an inline blob part", got)
+				}
+			},
+		},
+		{
+			name: "a mislabeled data url rides as a uri",
+			content: Generation{
+				Input: []Message{{
+					Role: RoleUser,
+					Parts: []Part{{
+						Kind:  PartKindMedia,
+						Media: &Media{Kind: "image", URL: "data:image/png;base64,abc123", MIMEType: "image/jpeg"},
+					}},
+				}},
+			},
+			check: func(t *testing.T, span sdktrace.ReadOnlySpan) {
+				got := spanAttributeMapOf(span)["gen_ai.input.messages"].AsString()
+				if !strings.Contains(got, `"type":"uri"`) {
+					t.Errorf("gen_ai.input.messages = %q, want a uri part", got)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, recorder, _ := newOTelTestClient(t, tc.mutate)
+			recordOTelGeneration(t, client, tc.content)
+			tc.check(t, onlySpan(t, recorder))
+		})
+	}
+}
+
+func TestOTelProtocolCallErrorSetsStatus(t *testing.T) {
+	client, recorder, _ := newOTelTestClient(t, nil)
+
+	_, rec := client.StartGeneration(context.Background(), GenerationStart{
+		Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+	})
+	rec.SetCallError(errors.New("provider exploded"))
+	rec.End()
+
+	span := onlySpan(t, recorder)
+	if got := span.Status().Description; got != "provider exploded" {
+		t.Errorf("status description = %q, want the provider error", got)
+	}
+	if got := spanAttributeMapOf(span)["error.type"].AsString(); got == "" {
+		t.Error("error span carries no error.type")
+	}
+}
+
+func TestOTelProtocolBypassesGenerationExport(t *testing.T) {
+	client, _, _ := newOTelTestClient(t, nil)
+	recordOTelGeneration(t, client, Generation{Output: []Message{AssistantTextMessage("Hi!")}})
+
+	if err := client.Flush(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	exporter, ok := client.config.testGenerationExporter.(*capturingGenerationExporter)
+	if !ok {
+		t.Fatalf("test exporter = %T", client.config.testGenerationExporter)
+	}
+	if got := exporter.requestCount(); got != 0 {
+		t.Errorf("exporter received %d requests, want 0", got)
+	}
+}
+
+func TestOTelProtocolDropsWorkflowSteps(t *testing.T) {
+	client, _, _ := newOTelTestClient(t, nil)
+
+	err := client.EnqueueWorkflowStep(WorkflowStep{
+		ID:             "step-1",
+		ConversationID: "conv-1",
+		StepName:       "step",
+		Framework:      "langgraph",
+	})
+	// The client drops the step in otel mode, so the caller must not read the
+	// result as "enqueued".
+	if !errors.Is(err, ErrWorkflowStepEnqueueFailed) {
+		t.Fatalf("EnqueueWorkflowStep err = %v, want ErrWorkflowStepEnqueueFailed", err)
+	}
+	if err := client.Flush(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	exporter, _ := client.config.testGenerationExporter.(*capturingGenerationExporter)
+	if got := exporter.workflowStepRequestCount(); got != 0 {
+		t.Errorf("exporter received %d workflow step requests, want 0", got)
+	}
+}
+
+func TestOTelProtocolRequiresExperimentalGate(t *testing.T) {
+	cases := []struct {
+		name         string
+		experimental string
+		wantOTel     bool
+	}{
+		{name: "gate open", experimental: "true", wantOTel: true},
+		{name: "gate unset", experimental: "", wantOTel: false},
+		{name: "gate off", experimental: "false", wantOTel: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvEnableExperimentalFeatures, tc.experimental)
+
+			recorder := tracetest.NewSpanRecorder()
+			provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+			t.Cleanup(func() {
+				_ = provider.Shutdown(context.Background())
+			})
+
+			cfg := DefaultConfig()
+			cfg.GenerationExport.Protocol = GenerationExportProtocolOTel
+			cfg.TracerProvider = provider
+			cfg.Now = time.Now
+			client := NewClient(cfg)
+			t.Cleanup(func() {
+				_ = client.Shutdown(context.Background())
+			})
+
+			if got := client.otelExportEnabled(); got != tc.wantOTel {
+				t.Fatalf("otelExportEnabled() = %v, want %v", got, tc.wantOTel)
+			}
+			if _, ok := client.exporter.(*noopGenerationExporter); !ok {
+				t.Fatalf("exporter = %T, want *noopGenerationExporter", client.exporter)
+			}
+
+			_, rec := client.StartGeneration(context.Background(), GenerationStart{
+				Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+			})
+			rec.SetResult(Generation{Output: []Message{AssistantTextMessage("Hi!")}}, nil)
+			rec.End()
+
+			// The metadata span and the otel-mode span both carry the
+			// generation id; the operation name is what separates them.
+			span := onlySpan(t, recorder)
+			operation := spanAttributeMapOf(span)["gen_ai.operation.name"].AsString()
+			if tc.wantOTel && operation != "chat" {
+				t.Errorf("gen_ai.operation.name = %q, want the spec operation", operation)
+			}
+			if !tc.wantOTel && operation != "generateText" {
+				t.Errorf("gen_ai.operation.name = %q, want the unchanged default", operation)
+			}
+		})
+	}
+}
+
+func TestOTelCaptureModeTranslation(t *testing.T) {
+	cases := []struct {
+		mode ContentCaptureMode
+		want string
+	}{
+		{mode: ContentCaptureModeDefault, want: "SPAN_ONLY"},
+		{mode: ContentCaptureModeFull, want: "SPAN_ONLY"},
+		{mode: ContentCaptureModeNoToolContent, want: "SPAN_ONLY"},
+		// The mode exists to keep content off the OTel destination, and in
+		// otel mode that destination is the export.
+		{mode: ContentCaptureModeFullWithMetadataSpans, want: "NO_CONTENT"},
+		{mode: ContentCaptureModeMetadataOnly, want: "NO_CONTENT"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.mode.String(), func(t *testing.T) {
+			if got := string(otelCaptureMode(tc.mode)); got != tc.want {
+				t.Errorf("otelCaptureMode(%s) = %q, want %q", tc.mode, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOTelCaptureModeIgnoresStandardEnv(t *testing.T) {
+	// The branded mode decides content capture in otel mode. Letting the
+	// conventions' variable decide would put a traces-side setting in charge of
+	// the SDK's content policy, and flip it on for a client that never asked.
+	t.Setenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "NO_CONTENT")
+
+	if got := string(otelCaptureMode(ContentCaptureModeDefault)); got != "SPAN_ONLY" {
+		t.Fatalf("otelCaptureMode(default) = %q, want SPAN_ONLY", got)
+	}
+}
+
+func TestOTelHandlerDisablesOperationDetailsEvents(t *testing.T) {
+	t.Setenv(otelgenai.EnvEmitEvent, "true")
+
+	tracerProvider := sdktrace.NewTracerProvider()
+	t.Cleanup(func() { _ = tracerProvider.Shutdown(context.Background()) })
+	meterProvider := sdkmetric.NewMeterProvider()
+	t.Cleanup(func() { _ = meterProvider.Shutdown(context.Background()) })
+	logs := logtest.NewRecorder()
+
+	cfg := DefaultConfig()
+	cfg.TracerProvider = tracerProvider
+	cfg.MeterProvider = meterProvider
+	options := append(otelHandlerOptions(cfg), otelgenai.WithLoggerProvider(logs))
+	handler := otelgenai.NewHandler(options...)
+	start := time.Now().Add(-time.Second)
+	inv := &otelgenai.Invocation{
+		Provider:     "openai",
+		RequestModel: "gpt-5",
+		StartedAt:    start,
+		CompletedAt:  start.Add(time.Second),
+	}
+	ctx := handler.Start(context.Background(), inv)
+	handler.End(ctx, inv)
+
+	for scope, records := range logs.Result() {
+		if scope.Name == otelgenai.ScopeName && len(records) != 0 {
+			t.Errorf("recorded %d operation-details events, want 0", len(records))
+		}
+	}
+}
+
+func TestOTelPerCallCaptureModeReachesTheSpan(t *testing.T) {
+	cases := []struct {
+		name        string
+		clientMode  ContentCaptureMode
+		callMode    ContentCaptureMode
+		wantContent bool
+	}{
+		{name: "call downgrades to metadata only", clientMode: ContentCaptureModeFull, callMode: ContentCaptureModeMetadataOnly},
+		{name: "call upgrades to full", clientMode: ContentCaptureModeMetadataOnly, callMode: ContentCaptureModeFull, wantContent: true},
+		{name: "call inherits the client mode", clientMode: ContentCaptureModeFull, wantContent: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, recorder, _ := newOTelTestClient(t, func(cfg *Config) {
+				cfg.ContentCapture = tc.clientMode
+			})
+
+			_, rec := client.StartGeneration(context.Background(), GenerationStart{
+				Model:          ModelRef{Provider: "openai", Name: "gpt-5"},
+				ContentCapture: tc.callMode,
+			})
+			rec.SetResult(Generation{Input: []Message{UserTextMessage("CALL-CONTENT")}}, nil)
+			rec.End()
+
+			got := spanAttributeMapOf(onlySpan(t, recorder))["gen_ai.input.messages"].AsString()
+			if strings.Contains(got, "CALL-CONTENT") != tc.wantContent {
+				t.Errorf("gen_ai.input.messages = %q, want content present = %v", got, tc.wantContent)
+			}
+		})
+	}
+}
+
+func TestOTelExportGenerationIsRejected(t *testing.T) {
+	client, recorder, _ := newOTelTestClient(t, nil)
+
+	err := client.ExportGeneration(context.Background(), GenerationStart{
+		Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+	}, Generation{Output: []Message{AssistantTextMessage("Hi!")}})
+	if !errors.Is(err, ErrSynchronousExportUnsupported) {
+		t.Fatalf("ExportGeneration err = %v, want ErrSynchronousExportUnsupported", err)
+	}
+	if got := len(recorder.Ended()); got != 0 {
+		t.Errorf("recorded %d spans, want 0", got)
+	}
+}
+
+func TestOTelFlushNeedsAFlusher(t *testing.T) {
+	// The provider's lifecycle belongs to the application, so the SDK flushes
+	// only what the application named. Until it does, a nil return would tell an
+	// adapter its batch is delivered.
+	cases := []struct {
+		name   string
+		config func(*Config, *sdktrace.TracerProvider)
+	}{
+		{
+			name: "only a tracer, nothing to flush",
+			config: func(cfg *Config, provider *sdktrace.TracerProvider) {
+				cfg.Tracer = provider.Tracer("agento11y-test")
+			},
+		},
+		{
+			// The SDK will not reach ForceFlush by asserting the provider to it.
+			name: "a flushable provider the application did not offer for flushing",
+			config: func(cfg *Config, provider *sdktrace.TracerProvider) {
+				cfg.TracerProvider = provider
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvEnableExperimentalFeatures, "true")
+
+			provider := sdktrace.NewTracerProvider()
+			t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+			cfg := DefaultConfig()
+			cfg.GenerationExport.Protocol = GenerationExportProtocolOTel
+			cfg.Now = time.Now
+			tc.config(&cfg, provider)
+			client := NewClient(cfg)
+			t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
+
+			if err := client.Flush(context.Background()); !errors.Is(err, ErrFlushNotVerifiable) {
+				t.Fatalf("Flush err = %v, want ErrFlushNotVerifiable", err)
+			}
+		})
+	}
+}
+
+// failingSpanProcessor stands in for a span exporter that cannot deliver.
+type failingSpanProcessor struct {
+	sdktrace.SpanProcessor
+	err error
+}
+
+func (p failingSpanProcessor) ForceFlush(context.Context) error { return p.err }
+
+type observingSpanProcessor struct {
+	sdktrace.SpanProcessor
+	onEnd func()
+}
+
+func (p observingSpanProcessor) OnEnd(span sdktrace.ReadOnlySpan) {
+	p.onEnd()
+	p.SpanProcessor.OnEnd(span)
+}
+
+func TestOTelFlushReportsTracerProviderFailure(t *testing.T) {
+	exportErr := errors.New("otlp collector unreachable")
+	client, _, _ := newOTelTestClient(t, func(cfg *Config) {
+		provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(failingSpanProcessor{
+			SpanProcessor: sdktrace.NewSimpleSpanProcessor(tracetest.NewNoopExporter()),
+			err:           exportErr,
+		}))
+		t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+		cfg.TracerProvider = provider
+		cfg.Flusher = provider
+	})
+
+	recordOTelGeneration(t, client, Generation{Output: []Message{AssistantTextMessage("Hi!")}})
+
+	// Adapters treat a nil Flush as proof the batch is delivered and then
+	// delete their own copy of it, so a failing exporter has to reach them.
+	if err := client.Flush(context.Background()); !errors.Is(err, exportErr) {
+		t.Fatalf("Flush err = %v, want the exporter failure", err)
+	}
+	// Shutdown flushes what the provider still holds, under the same rule.
+	if err := client.Shutdown(context.Background()); !errors.Is(err, exportErr) {
+		t.Fatalf("Shutdown err = %v, want the exporter failure", err)
+	}
+}
+
+func TestOTelRecordsGenerationAfterSpanHandoff(t *testing.T) {
+	const generationID = "generation-order"
+
+	var client *Client
+	handoffObserved := false
+	client, _, _ = newOTelTestClient(t, func(cfg *Config) {
+		provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(observingSpanProcessor{
+			SpanProcessor: tracetest.NewSpanRecorder(),
+			onEnd: func() {
+				handoffObserved = true
+				if client.hasRecordedGenerationID(generationID) {
+					t.Error("generation was recorded before its span reached the processor")
+				}
+			},
+		}))
+		t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+		cfg.TracerProvider = provider
+		cfg.Flusher = provider
+	})
+
+	recordOTelGeneration(t, client, Generation{
+		ID:     generationID,
+		Output: []Message{AssistantTextMessage("Hi!")},
+	})
+
+	if !handoffObserved {
+		t.Fatal("span processor did not observe the generation")
+	}
+	if !client.hasRecordedGenerationID(generationID) {
+		t.Error("generation was not recorded after its span reached the processor")
+	}
+}
+
+// recordingSampler captures the attributes a head sampler is given at Start.
+type recordingSampler struct {
+	attributes []attribute.KeyValue
+}
+
+func (s *recordingSampler) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingResult {
+	s.attributes = append(s.attributes, p.Attributes...)
+	return sdktrace.SamplingResult{Decision: sdktrace.RecordAndSample}
+}
+
+func (s *recordingSampler) Description() string { return "recordingSampler" }
+
+func TestOTelStartCarriesRequestAttributes(t *testing.T) {
+	// A head sampler decides at Start, so the request fields the caller already
+	// declared have to be on the span from that instant. Writing them at End is
+	// too late for the decision.
+	sampler := &recordingSampler{}
+	client, _, _ := newOTelTestClient(t, func(cfg *Config) {
+		provider := sdktrace.NewTracerProvider(sdktrace.WithSampler(sampler))
+		t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+		cfg.TracerProvider = provider
+	})
+
+	maxTokens := int64(512)
+	temperature := 0.25
+	topP := 0.75
+	_, rec := client.StartGeneration(context.Background(), GenerationStart{
+		Model:       ModelRef{Provider: "openai", Name: "gpt-5"},
+		MaxTokens:   &maxTokens,
+		Temperature: &temperature,
+		TopP:        &topP,
+	})
+	rec.SetResult(Generation{Output: []Message{AssistantTextMessage("Hi!")}}, nil)
+	rec.End()
+
+	got := make(map[string]attribute.Value, len(sampler.attributes))
+	for _, kv := range sampler.attributes {
+		got[string(kv.Key)] = kv.Value
+	}
+	want := map[string]attribute.Value{
+		"gen_ai.request.max_tokens":  attribute.IntValue(512),
+		"gen_ai.request.temperature": attribute.Float64Value(0.25),
+		"gen_ai.request.top_p":       attribute.Float64Value(0.75),
+	}
+	for key, wantValue := range want {
+		if got[key] != wantValue {
+			t.Errorf("sampler saw %s = %v, want %v", key, got[key], wantValue)
+		}
+	}
+}
+
+func TestOTelRecordAfterShutdownReportsClientShutdown(t *testing.T) {
+	// Shutdown force-flushed the provider already, so a record that arrives
+	// after it missed that flush. The queue path reports the same case as
+	// ErrClientShutdown, and a nil here would tell the caller the record is
+	// handled.
+	reader := sdkmetric.NewManualReader()
+	client, recorder, _ := newOTelTestClient(t, func(cfg *Config) {
+		meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+		t.Cleanup(func() { _ = meterProvider.Shutdown(context.Background()) })
+		cfg.MeterProvider = meterProvider
+	})
+	if err := client.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	_, rec := client.StartGeneration(context.Background(), GenerationStart{
+		Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+	})
+	rec.SetResult(Generation{Output: []Message{AssistantTextMessage("Hi!")}}, nil)
+	rec.End()
+
+	if err := rec.Err(); !errors.Is(err, ErrClientShutdown) {
+		t.Fatalf("recorder Err = %v, want ErrClientShutdown", err)
+	}
+
+	// The span keeps the generation: the caller owns the provider and may still
+	// flush it, so dropping the payload here would lose a record that can still
+	// arrive.
+	span := onlySpan(t, recorder)
+	attrs := spanAttributeMapOf(span)
+	if _, ok := attrs["agento11y.generation.id"]; !ok {
+		t.Error("a post-shutdown record carries no agento11y.generation.id")
+	}
+	// The model call succeeded, so the conventions' failure fields stay clear
+	// and the drop travels on the SDK's own attribute.
+	if got, ok := attrs["error.type"]; ok {
+		t.Errorf("a successful call carries error.type = %v after a failed export", got.AsString())
+	}
+	if got := span.Status().Code; got != codes.Unset {
+		t.Errorf("status = %v, want unset", got)
+	}
+	if got := attrs["agento11y.export.error"].AsString(); !strings.Contains(got, "shutting down") {
+		t.Errorf("agento11y.export.error = %q, want the shutdown reason", got)
+	}
+	if got := exceptionEventCount(span); got != 0 {
+		t.Errorf("span carries %d exception events after a failed export, want 0", got)
+	}
+
+	// The conventions say a successful operation carries no error.type, so
+	// filtering the duration histogram on it has to stay a filter for failed
+	// model calls rather than for our own export trouble.
+	var collected metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &collected); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	for _, scope := range collected.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != "gen_ai.client.operation.duration" {
+				continue
+			}
+			if got := histogramAttributes(t, m)["error.type"]; got != "" {
+				t.Errorf("%s carries error.type = %q after a failed export", m.Name, got)
+			}
+		}
+	}
+}
+
+func TestOTelProtocolDropsValidatorRejectedRecords(t *testing.T) {
+	// A record the SDK's validator refuses is never enqueued on the other
+	// protocols. In otel mode the span is the export, so it has to close
+	// without the id and the content that would make it a generation.
+	client, recorder, _ := newOTelTestClient(t, nil)
+
+	_, rec := client.StartGeneration(context.Background(), GenerationStart{
+		Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+	})
+	rec.SetResult(Generation{
+		Input: []Message{{
+			Role: RoleUser,
+			Parts: []Part{
+				TextPart("PROMPT TEXT"),
+				{Kind: PartKindMedia, Media: &Media{Kind: "image"}},
+			},
+		}},
+	}, nil)
+	rec.End()
+
+	if rec.Err() == nil {
+		t.Fatal("recorder reported no error for a generation the validator refuses")
+	}
+
+	span := onlySpan(t, recorder)
+	attrs := spanAttributeMapOf(span)
+	if _, ok := attrs["agento11y.generation.id"]; ok {
+		t.Error("a rejected record carries agento11y.generation.id, so the backend would store it")
+	}
+	if _, ok := attrs["agento11y.record"]; ok {
+		t.Error("a rejected record carries agento11y.record")
+	}
+	if got, ok := attrs["gen_ai.input.messages"]; ok {
+		t.Errorf("a rejected record carries content: %s", got.AsString())
+	}
+	// The validator refused our own payload; the model call still succeeded, so
+	// the drop reads as an export failure rather than a failed generation.
+	if got, ok := attrs["error.type"]; ok {
+		t.Errorf("a rejected record carries error.type = %v", got.AsString())
+	}
+	if got := span.Status().Code; got != codes.Unset {
+		t.Errorf("status = %v, want unset", got)
+	}
+	if got := attrs["agento11y.export.error"].AsString(); got == "" {
+		t.Error("a rejected record carries no agento11y.export.error, so the drop is invisible")
+	}
+	if got := exceptionEventCount(span); got != 0 {
+		t.Errorf("a rejected record carries %d exception events, want 0", got)
+	}
+}
+
+func TestOTelSpecMetricDimensions(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	client, _, _ := newOTelTestClient(t, func(cfg *Config) {
+		meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+		t.Cleanup(func() { _ = meterProvider.Shutdown(context.Background()) })
+		cfg.MeterProvider = meterProvider
+		cfg.Tags = map[string]string{"repo": "agento11y"}
+	})
+
+	_, rec := client.StartGeneration(context.Background(), GenerationStart{
+		Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+	})
+	rec.SetCallError(errors.New("429 too many requests"))
+	rec.SetResult(Generation{
+		AgentName:    "assistant",
+		AgentVersion: "1.0.0",
+		Usage: TokenUsage{
+			InputTokens:           10,
+			OutputTokens:          2,
+			CacheReadInputTokens:  3,
+			CacheWriteInputTokens: 4,
+			InputSemantics:        TokenInputSemanticsInclusive,
+		},
+	}, nil)
+	rec.End()
+
+	var collected metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &collected); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+
+	scopes := map[string][]string{}
+	var duration, usage metricdata.Metrics
+	for _, scope := range collected.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			scopes[m.Name] = append(scopes[m.Name], scope.Scope.Name)
+			if scope.Scope.Name != otelgenai.ScopeName {
+				continue
+			}
+			switch m.Name {
+			case "gen_ai.client.operation.duration":
+				duration = m
+			case "gen_ai.client.token.usage":
+				usage = m
+			}
+		}
+	}
+
+	// The SDK keeps its own instruments for tool and embedding metrics. They
+	// carry the same names with a different label schema, so they have to sit
+	// in their own scope rather than conflict inside one.
+	for name, owners := range scopes {
+		if len(owners) != len(slices.Compact(slices.Sorted(slices.Values(owners)))) {
+			t.Errorf("%s is registered twice in one scope: %v", name, owners)
+		}
+	}
+
+	if duration.Name == "" {
+		t.Fatalf("gen_ai.client.operation.duration not recorded under %s", otelgenai.ScopeName)
+	}
+	durationAttrs := histogramAttributes(t, duration)
+	if got := durationAttrs["agento11y.tag.repo"]; got != "agento11y" {
+		t.Errorf("duration agento11y.tag.repo = %q, want agento11y", got)
+	}
+	if got := durationAttrs["error.category"]; got != "rate_limit" {
+		t.Errorf("duration error.category = %q, want rate_limit", got)
+	}
+	if got := durationAttrs["error.type"]; got == "" {
+		t.Error("duration carries no error.type")
+	}
+	if got := durationAttrs[spanAttrAgentName]; got != "assistant" {
+		t.Errorf("duration %s = %q, want assistant", spanAttrAgentName, got)
+	}
+	if got := durationAttrs[spanAttrAgentVersion]; got != "1.0.0" {
+		t.Errorf("duration %s = %q, want 1.0.0", spanAttrAgentVersion, got)
+	}
+	usageAttrs := histogramAttributes(t, usage)
+	if got := usageAttrs["agento11y.tag.repo"]; got != "agento11y" {
+		t.Errorf("token usage agento11y.tag.repo = %q, want agento11y", got)
+	}
+	if got := usageAttrs["gen_ai.token.semantics"]; got != "inclusive" {
+		t.Errorf("token usage gen_ai.token.semantics = %q, want inclusive", got)
+	}
+	if got := usageAttrs[spanAttrAgentName]; got != "assistant" {
+		t.Errorf("token usage %s = %q, want assistant", spanAttrAgentName, got)
+	}
+	if got := usageAttrs[spanAttrAgentVersion]; got != "1.0.0" {
+		t.Errorf("token usage %s = %q, want 1.0.0", spanAttrAgentVersion, got)
+	}
+	usageHistogram, ok := usage.Data.(metricdata.Histogram[int64])
+	if !ok {
+		t.Fatalf("token usage data = %T, want an int64 histogram", usage.Data)
+	}
+	cacheRead := int64(0)
+	cacheCreation := int64(0)
+	for _, point := range usageHistogram.DataPoints {
+		if got, present := point.Attributes.Value("error.type"); present {
+			t.Errorf("token usage carries error.type = %q", got.AsString())
+		}
+		tokenType, _ := point.Attributes.Value("gen_ai.token.type")
+		switch tokenType.AsString() {
+		case "cache_read":
+			cacheRead = point.Sum
+		case "cache_creation":
+			cacheCreation = point.Sum
+		}
+	}
+	if cacheRead != 3 {
+		t.Errorf("cache_read token usage = %d, want 3", cacheRead)
+	}
+	if cacheCreation != 4 {
+		t.Errorf("cache_creation token usage = %d, want 4", cacheCreation)
+	}
+}
+
+// histogramAttributes returns the attributes of a histogram's first data
+// point, whichever numeric type it carries.
+func histogramAttributes(t *testing.T, m metricdata.Metrics) map[string]string {
+	t.Helper()
+
+	var set attribute.Set
+	switch data := m.Data.(type) {
+	case metricdata.Histogram[float64]:
+		set = data.DataPoints[0].Attributes
+	case metricdata.Histogram[int64]:
+		set = data.DataPoints[0].Attributes
+	default:
+		t.Fatalf("%s data = %T, want a histogram", m.Name, m.Data)
+	}
+	out := make(map[string]string, set.Len())
+	for _, kv := range set.ToSlice() {
+		out[string(kv.Key)] = kv.Value.Emit()
+	}
+	return out
+}
+
+func TestOTelMediaPartModality(t *testing.T) {
+	cases := []struct {
+		name    string
+		kind    string
+		want    string
+		wantSet bool
+	}{
+		{name: "empty kind"},
+		{name: "image", kind: "image", want: "image", wantSet: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var out otelgenai.Part
+			otelMediaPart(&out, &Media{Kind: tc.kind, URL: "https://example.test/media"})
+			if !tc.wantSet {
+				if out.Modality != nil {
+					t.Errorf("modality = %q, want nil", *out.Modality)
+				}
+				return
+			}
+			if out.Modality == nil {
+				t.Fatalf("modality = nil, want %q", tc.want)
+			}
+			if *out.Modality != tc.want {
+				t.Errorf("modality = %q, want %q", *out.Modality, tc.want)
+			}
+		})
+	}
+}
+
+func TestOTelProviderRegistrySpellings(t *testing.T) {
+	cases := []struct{ stored, wire string }{
+		{stored: "gemini", wire: "gcp.gemini"},
+		{stored: "mistral", wire: "mistral_ai"},
+		{stored: "openai", wire: "openai"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.stored, func(t *testing.T) {
+			if got := otelProviderName(tc.stored); got != tc.wire {
+				t.Errorf("otelProviderName(%q) = %q, want %q", tc.stored, got, tc.wire)
+			}
+		})
+	}
+}

--- a/go/agento11y/otel_wire_test.go
+++ b/go/agento11y/otel_wire_test.go
@@ -1,0 +1,472 @@
+package agento11y
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// The fixtures pin the generation span wire format. This test checks that OTel
+// mode emits the matching span.
+//
+// OTel mode maps the SDK's generateText and streamText defaults to "chat". It
+// also adds agento11y.record=true, which agento11y needs. OTLP attribute order
+// has no meaning, so this test compares attributes as a set.
+//
+// The test calls the OTel helpers directly because openai_sync contains a
+// system-role message that normal client validation rejects.
+func TestOTelModeMatchesGoldenWireFormat(t *testing.T) {
+	for _, name := range []string{"openai_sync", "anthropic_stream", "gemini_sync"} {
+		t.Run(name, func(t *testing.T) {
+			generation := readGenerationFixture(t, name)
+			want := readSpanFixture(t, name)
+
+			client, recorder, _ := newOTelTestClient(t, nil)
+			exportFixtureGeneration(client, generation)
+
+			span := onlySpan(t, recorder)
+			wantName := "chat " + generation.Model.Name
+			if got := span.Name(); got != wantName {
+				t.Errorf("span name = %q, want %q", got, wantName)
+			}
+			if !span.StartTime().Equal(generation.StartedAt) {
+				t.Errorf("span start = %v, want %v", span.StartTime(), generation.StartedAt)
+			}
+			if !span.EndTime().Equal(generation.CompletedAt) {
+				t.Errorf("span end = %v, want %v", span.EndTime(), generation.CompletedAt)
+			}
+
+			got := renderedAttributes(t, span)
+			wantAttributes := want.attributes(t)
+			wantAttributes["agento11y.record"] = "string:true"
+			for key, wantValue := range wantAttributes {
+				gotValue, ok := got[key]
+				if !ok {
+					t.Errorf("missing attribute %s (want %s)", key, wantValue)
+					continue
+				}
+				switch key {
+				case "gen_ai.operation.name":
+					// otel mode reports the spec operation, so the fixture's
+					// proprietary name cannot match.
+					wantValue = "string:chat"
+				case "agento11y.generation.metadata":
+					// The SDK stamps its own metadata keys on every export
+					// path, so the fixture's entries are a subset.
+					assertMetadataSuperset(t, gotValue, wantValue)
+					continue
+				}
+				if gotValue != wantValue {
+					t.Errorf("attribute %s =\n%s\nwant\n%s", key, gotValue, wantValue)
+				}
+			}
+			wantAttributes["agento11y.generation.metadata"] = ""
+			for key := range got {
+				if _, ok := wantAttributes[key]; !ok {
+					t.Errorf("unexpected attribute %s", key)
+				}
+			}
+		})
+	}
+}
+
+// assertMetadataSuperset checks that every entry of the fixture's metadata
+// document is present in the emitted one.
+func assertMetadataSuperset(t *testing.T, got, want string) {
+	t.Helper()
+
+	gotMap := decodeMetadataAttribute(t, got)
+	for key, wantValue := range decodeMetadataAttribute(t, want) {
+		gotValue, ok := gotMap[key]
+		if !ok {
+			t.Errorf("metadata is missing key %q", key)
+			continue
+		}
+		if fmt.Sprint(gotValue) != fmt.Sprint(wantValue) {
+			t.Errorf("metadata[%q] = %v, want %v", key, gotValue, wantValue)
+		}
+	}
+}
+
+func decodeMetadataAttribute(t *testing.T, rendered string) map[string]any {
+	t.Helper()
+
+	payload, ok := strings.CutPrefix(rendered, "string:")
+	if !ok {
+		t.Fatalf("metadata attribute %q is not a string", rendered)
+	}
+	out := map[string]any{}
+	if err := json.Unmarshal([]byte(payload), &out); err != nil {
+		t.Fatalf("unmarshal metadata %q: %v", payload, err)
+	}
+	return out
+}
+
+// exportFixtureGeneration emits one fixture generation as an otel-mode span,
+// through the same client helpers GenerationRecorder.End uses.
+func exportFixtureGeneration(client *Client, generation Generation) {
+	ctx, _, invocation := client.startOTelGeneration(context.Background(), generation, generation.StartedAt)
+	client.endOTelGeneration(ctx, invocation, generation,
+		generationError{message: generation.CallError}, time.Time{}, ContentCaptureModeFull)
+}
+
+// renderedAttributes renders a span's attributes as key -> "type:value", the
+// same rendering the fixture values go through, so a type mismatch shows up as
+// a value mismatch instead of passing silently.
+func renderedAttributes(t *testing.T, span sdktrace.ReadOnlySpan) map[string]string {
+	t.Helper()
+
+	out := make(map[string]string, len(span.Attributes()))
+	for _, kv := range span.Attributes() {
+		out[string(kv.Key)] = renderAttributeValue(t, kv.Value)
+	}
+	return out
+}
+
+func renderAttributeValue(t *testing.T, value attribute.Value) string {
+	t.Helper()
+
+	switch value.Type() {
+	case attribute.STRING:
+		return "string:" + value.AsString()
+	case attribute.BOOL:
+		return "bool:" + strconv.FormatBool(value.AsBool())
+	case attribute.INT64:
+		return "int64:" + strconv.FormatInt(value.AsInt64(), 10)
+	case attribute.FLOAT64:
+		return "float64:" + strconv.FormatFloat(value.AsFloat64(), 'g', -1, 64)
+	case attribute.STRINGSLICE:
+		return "stringslice:" + fmt.Sprintf("%q", value.AsStringSlice())
+	default:
+		t.Fatalf("unsupported attribute type %s", value.Type())
+		return ""
+	}
+}
+
+// fixtureSpan mirrors the protojson rendering of an OTLP span, just enough to
+// compare against the emitted attributes without pulling the OTLP protos into
+// this module.
+type fixtureSpan struct {
+	Name       string        `json:"name"`
+	Kind       string        `json:"kind"`
+	Attributes []fixtureAttr `json:"attributes"`
+}
+
+type fixtureAttr struct {
+	Key   string       `json:"key"`
+	Value fixtureValue `json:"value"`
+}
+
+type fixtureValue struct {
+	StringValue *string  `json:"string_value"`
+	BoolValue   *bool    `json:"bool_value"`
+	IntValue    *string  `json:"int_value"` // protojson renders int64 as a string
+	DoubleValue *float64 `json:"double_value"`
+	ArrayValue  *struct {
+		Values []fixtureValue `json:"values"`
+	} `json:"array_value"`
+}
+
+func (s fixtureSpan) attributes(t *testing.T) map[string]string {
+	t.Helper()
+
+	out := make(map[string]string, len(s.Attributes))
+	for _, attr := range s.Attributes {
+		out[attr.Key] = attr.Value.render(t)
+	}
+	return out
+}
+
+func (v fixtureValue) render(t *testing.T) string {
+	t.Helper()
+
+	switch {
+	case v.StringValue != nil:
+		return "string:" + *v.StringValue
+	case v.BoolValue != nil:
+		return "bool:" + strconv.FormatBool(*v.BoolValue)
+	case v.IntValue != nil:
+		parsed, err := strconv.ParseInt(*v.IntValue, 10, 64)
+		if err != nil {
+			t.Fatalf("fixture int value %q: %v", *v.IntValue, err)
+		}
+		return "int64:" + strconv.FormatInt(parsed, 10)
+	case v.DoubleValue != nil:
+		return "float64:" + strconv.FormatFloat(*v.DoubleValue, 'g', -1, 64)
+	case v.ArrayValue != nil:
+		values := make([]string, 0, len(v.ArrayValue.Values))
+		for _, item := range v.ArrayValue.Values {
+			if item.StringValue == nil {
+				t.Fatal("fixture array value with a non-string element")
+			}
+			values = append(values, *item.StringValue)
+		}
+		return "stringslice:" + fmt.Sprintf("%q", values)
+	default:
+		t.Fatal("fixture attribute value with no recognized type")
+		return ""
+	}
+}
+
+func readSpanFixture(t *testing.T, name string) fixtureSpan {
+	t.Helper()
+
+	payload := readFixture(t, name+".span.json")
+	var span fixtureSpan
+	if err := json.Unmarshal(payload, &span); err != nil {
+		t.Fatalf("unmarshal span fixture %s: %v", name, err)
+	}
+	if span.Kind != "SPAN_KIND_CLIENT" {
+		t.Fatalf("fixture span kind = %q, want SPAN_KIND_CLIENT", span.Kind)
+	}
+	return span
+}
+
+// fixtureGeneration mirrors the protojson rendering of an agento11y.v1
+// Generation. It is read instead of protojson-decoding into the SDK proto
+// because the proto's role enum has no system member, while the SDK model
+// carries the role as a free string.
+type fixtureGeneration struct {
+	ID                  string            `json:"id"`
+	ConversationID      string            `json:"conversation_id"`
+	OperationName       string            `json:"operation_name"`
+	Mode                string            `json:"mode"`
+	Model               fixtureModel      `json:"model"`
+	ResponseID          string            `json:"response_id"`
+	ResponseModel       string            `json:"response_model"`
+	SystemPrompt        string            `json:"system_prompt"`
+	Input               []fixtureMessage  `json:"input"`
+	Output              []fixtureMessage  `json:"output"`
+	Usage               fixtureUsage      `json:"usage"`
+	StopReason          string            `json:"stop_reason"`
+	StartedAt           time.Time         `json:"started_at"`
+	CompletedAt         time.Time         `json:"completed_at"`
+	AgentName           string            `json:"agent_name"`
+	AgentVersion        string            `json:"agent_version"`
+	ParentGenerationIDs []string          `json:"parent_generation_ids"`
+	Tags                map[string]string `json:"tags"`
+	Metadata            map[string]any    `json:"metadata"`
+	Tools               []fixtureToolDef  `json:"tools"`
+	CallError           string            `json:"call_error"`
+	MaxTokens           *fixtureInt       `json:"max_tokens"`
+	Temperature         *float64          `json:"temperature"`
+	TopP                *float64          `json:"top_p"`
+	ToolChoice          *string           `json:"tool_choice"`
+	ThinkingEnabled     *bool             `json:"thinking_enabled"`
+	EffectiveVersion    string            `json:"effective_version"`
+}
+
+type fixtureModel struct {
+	Provider string `json:"provider"`
+	Name     string `json:"name"`
+}
+
+type fixtureMessage struct {
+	Role  string        `json:"role"`
+	Name  string        `json:"name"`
+	Parts []fixturePart `json:"parts"`
+}
+
+type fixturePart struct {
+	Text     string `json:"text"`
+	Thinking string `json:"thinking"`
+	ToolCall *struct {
+		ID        string `json:"id"`
+		Name      string `json:"name"`
+		InputJSON string `json:"input_json"`
+	} `json:"tool_call"`
+	ToolResult *struct {
+		ToolCallID  string `json:"tool_call_id"`
+		Name        string `json:"name"`
+		IsError     bool   `json:"is_error"`
+		Content     string `json:"content"`
+		ContentJSON string `json:"content_json"`
+	} `json:"tool_result"`
+	Metadata *struct {
+		ProviderType string `json:"provider_type"`
+	} `json:"metadata"`
+}
+
+type fixtureToolDef struct {
+	Name            string `json:"name"`
+	Description     string `json:"description"`
+	Type            string `json:"type"`
+	InputSchemaJSON string `json:"input_schema_json"`
+	Deferred        bool   `json:"deferred"`
+}
+
+// fixtureInt is an int64 rendered by protojson as a JSON string.
+type fixtureInt int64
+
+func (v *fixtureInt) UnmarshalJSON(payload []byte) error {
+	text := strings.Trim(string(payload), `"`)
+	if text == "" || text == "null" {
+		return nil
+	}
+	parsed, err := strconv.ParseInt(text, 10, 64)
+	if err != nil {
+		return err
+	}
+	*v = fixtureInt(parsed)
+	return nil
+}
+
+type fixtureUsage struct {
+	InputTokens           fixtureInt `json:"input_tokens"`
+	OutputTokens          fixtureInt `json:"output_tokens"`
+	TotalTokens           fixtureInt `json:"total_tokens"`
+	CacheReadInputTokens  fixtureInt `json:"cache_read_input_tokens"`
+	CacheWriteInputTokens fixtureInt `json:"cache_write_input_tokens"`
+	ReasoningTokens       fixtureInt `json:"reasoning_tokens"`
+}
+
+func readGenerationFixture(t *testing.T, name string) Generation {
+	t.Helper()
+
+	payload := readFixture(t, name+".generation.json")
+	var fixture fixtureGeneration
+	if err := json.Unmarshal(payload, &fixture); err != nil {
+		t.Fatalf("unmarshal generation fixture %s: %v", name, err)
+	}
+
+	generation := Generation{
+		ID:                  fixture.ID,
+		ConversationID:      fixture.ConversationID,
+		AgentName:           fixture.AgentName,
+		AgentVersion:        fixture.AgentVersion,
+		OperationName:       fixture.OperationName,
+		Mode:                fixtureMode(fixture.Mode),
+		Model:               ModelRef{Provider: fixture.Model.Provider, Name: fixture.Model.Name},
+		ResponseID:          fixture.ResponseID,
+		ResponseModel:       fixture.ResponseModel,
+		SystemPrompt:        fixture.SystemPrompt,
+		Input:               fixtureMessages(t, fixture.Input),
+		Output:              fixtureMessages(t, fixture.Output),
+		StopReason:          fixture.StopReason,
+		StartedAt:           fixture.StartedAt,
+		CompletedAt:         fixture.CompletedAt,
+		ParentGenerationIDs: fixture.ParentGenerationIDs,
+		Tags:                fixture.Tags,
+		Metadata:            fixture.Metadata,
+		EffectiveVersion:    fixture.EffectiveVersion,
+		CallError:           fixture.CallError,
+		Temperature:         fixture.Temperature,
+		TopP:                fixture.TopP,
+		ToolChoice:          fixture.ToolChoice,
+		ThinkingEnabled:     fixture.ThinkingEnabled,
+		Usage: TokenUsage{
+			InputTokens:           int64(fixture.Usage.InputTokens),
+			OutputTokens:          int64(fixture.Usage.OutputTokens),
+			TotalTokens:           int64(fixture.Usage.TotalTokens),
+			CacheReadInputTokens:  int64(fixture.Usage.CacheReadInputTokens),
+			CacheWriteInputTokens: int64(fixture.Usage.CacheWriteInputTokens),
+			ReasoningTokens:       int64(fixture.Usage.ReasoningTokens),
+		},
+	}
+	if fixture.MaxTokens != nil {
+		maxTokens := int64(*fixture.MaxTokens)
+		generation.MaxTokens = &maxTokens
+	}
+	for _, tool := range fixture.Tools {
+		generation.Tools = append(generation.Tools, ToolDefinition{
+			Name:        tool.Name,
+			Description: tool.Description,
+			Type:        tool.Type,
+			InputSchema: fixtureBytes(t, tool.InputSchemaJSON),
+			Deferred:    tool.Deferred,
+		})
+	}
+	return generation
+}
+
+func fixtureMode(mode string) GenerationMode {
+	if mode == "GENERATION_MODE_STREAM" {
+		return GenerationModeStream
+	}
+	return GenerationModeSync
+}
+
+func fixtureMessages(t *testing.T, messages []fixtureMessage) []Message {
+	t.Helper()
+
+	out := make([]Message, 0, len(messages))
+	for _, message := range messages {
+		converted := Message{
+			Role: Role(strings.ToLower(strings.TrimPrefix(message.Role, "MESSAGE_ROLE_"))),
+			Name: message.Name,
+		}
+		for _, part := range message.Parts {
+			converted.Parts = append(converted.Parts, fixturePartToPart(t, part))
+		}
+		out = append(out, converted)
+	}
+	return out
+}
+
+func fixturePartToPart(t *testing.T, part fixturePart) Part {
+	t.Helper()
+
+	out := Part{}
+	if part.Metadata != nil {
+		out.Metadata = PartMetadata{ProviderType: part.Metadata.ProviderType}
+	}
+	switch {
+	case part.ToolCall != nil:
+		out.Kind = PartKindToolCall
+		out.ToolCall = &ToolCall{
+			ID:        part.ToolCall.ID,
+			Name:      part.ToolCall.Name,
+			InputJSON: fixtureBytes(t, part.ToolCall.InputJSON),
+		}
+	case part.ToolResult != nil:
+		out.Kind = PartKindToolResult
+		out.ToolResult = &ToolResult{
+			ToolCallID:  part.ToolResult.ToolCallID,
+			Name:        part.ToolResult.Name,
+			IsError:     part.ToolResult.IsError,
+			Content:     part.ToolResult.Content,
+			ContentJSON: fixtureBytes(t, part.ToolResult.ContentJSON),
+		}
+	case part.Thinking != "":
+		out.Kind = PartKindThinking
+		out.Thinking = part.Thinking
+	default:
+		out.Kind = PartKindText
+		out.Text = part.Text
+	}
+	return out
+}
+
+// fixtureBytes decodes a protojson bytes field, which is standard base64.
+func fixtureBytes(t *testing.T, value string) []byte {
+	t.Helper()
+
+	if value == "" {
+		return nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		t.Fatalf("decode fixture bytes %q: %v", value, err)
+	}
+	return decoded
+}
+
+func readFixture(t *testing.T, name string) []byte {
+	t.Helper()
+
+	payload, err := os.ReadFile(filepath.Join("testdata", "otlpwire", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return payload
+}

--- a/go/agento11y/otelhook/hook.go
+++ b/go/agento11y/otelhook/hook.go
@@ -29,6 +29,7 @@ import (
 )
 
 const (
+	attrRecord              = "agento11y.record"
 	AttrGenerationID        = "agento11y.generation.id"
 	AttrParentGenerationIDs = "agento11y.generation.parent_generation_ids"
 	AttrTags                = "agento11y.generation.tags"
@@ -140,7 +141,10 @@ func (h *Hook) OnEnd(_ context.Context, inv *otelgenai.Invocation, capture otelg
 
 	var attrs []attribute.KeyValue
 	if generation.ID != "" {
-		attrs = append(attrs, attribute.String(AttrGenerationID, generation.ID))
+		attrs = append(attrs,
+			attribute.String(attrRecord, "true"),
+			attribute.String(AttrGenerationID, generation.ID),
+		)
 	}
 	if generation.UserID != "" {
 		attrs = append(attrs, attribute.String(AttrUserID, generation.UserID))

--- a/go/agento11y/otelhook/hook_test.go
+++ b/go/agento11y/otelhook/hook_test.go
@@ -51,6 +51,7 @@ func TestOnEnd(t *testing.T) {
 				InclusiveTokenSemantics: true,
 			},
 			want: map[string]string{
+				"agento11y.record":                           "true",
 				"agento11y.generation.id":                    "gen-1",
 				"user.id":                                    "user-1",
 				"agento11y.generation.tags":                  `{" env ":" dev ","team":"sigil"}`,
@@ -69,7 +70,10 @@ func TestOnEnd(t *testing.T) {
 		{
 			name:   "id only",
 			vendor: otelhook.Generation{ID: "gen-2"},
-			want:   map[string]string{"agento11y.generation.id": "gen-2"},
+			want: map[string]string{
+				"agento11y.record":        "true",
+				"agento11y.generation.id": "gen-2",
+			},
 			absent: []string{
 				"user.id",
 				"agento11y.generation.tags",
@@ -80,12 +84,12 @@ func TestOnEnd(t *testing.T) {
 		{
 			name:   "no vendor payload",
 			vendor: nil,
-			absent: []string{"agento11y.generation.id"},
+			absent: []string{"agento11y.record", "agento11y.generation.id"},
 		},
 		{
 			name:   "foreign vendor payload",
 			vendor: "not-a-generation",
-			absent: []string{"agento11y.generation.id"},
+			absent: []string{"agento11y.record", "agento11y.generation.id"},
 		},
 		{
 			name:    "content capture off drops the title and the artifacts",
@@ -211,6 +215,7 @@ func TestOnEndReportsDroppedPayloads(t *testing.T) {
 		name   string
 		vendor any
 		want   string
+		absent []string
 	}{
 		{
 			name: "metadata that does not marshal",
@@ -234,6 +239,7 @@ func TestOnEndReportsDroppedPayloads(t *testing.T) {
 			name:   "a generation with no id",
 			vendor: otelhook.Generation{},
 			want:   "has no id",
+			absent: []string{"agento11y.record", "agento11y.generation.id"},
 		},
 	}
 
@@ -246,10 +252,15 @@ func TestOnEndReportsDroppedPayloads(t *testing.T) {
 			}))
 			t.Cleanup(func() { otel.SetErrorHandler(previous) })
 
-			otelhook.New().OnEnd(context.Background(), &otelgenai.Invocation{Vendor: tc.vendor}, otelgenai.CaptureSpanOnly)
+			got := attributeMap(otelhook.New().OnEnd(context.Background(), &otelgenai.Invocation{Vendor: tc.vendor}, otelgenai.CaptureSpanOnly))
 
 			if !slices.ContainsFunc(reported, func(msg string) bool { return strings.Contains(msg, tc.want) }) {
 				t.Errorf("reported %v, want one mentioning %q", reported, tc.want)
+			}
+			for _, key := range tc.absent {
+				if _, ok := got[key]; ok {
+					t.Errorf("%s is present, want it absent", key)
+				}
 			}
 		})
 	}

--- a/go/agento11y/testdata/otlpwire/anthropic_stream.generation.json
+++ b/go/agento11y/testdata/otlpwire/anthropic_stream.generation.json
@@ -1,0 +1,44 @@
+{
+  "id": "gen-anthropic-stream-1",
+  "conversation_id": "conv-stream",
+  "operation_name": "streamText",
+  "mode": "GENERATION_MODE_STREAM",
+  "trace_id": "fedcba9876543210fedcba9876543210",
+  "span_id": "fedcba9876543210",
+  "model": {
+    "provider": "anthropic",
+    "name": "claude-sonnet-4-5"
+  },
+  "response_id": "msg_stream_1",
+  "response_model": "claude-sonnet-4-5",
+  "output": [
+    {
+      "role": "MESSAGE_ROLE_ASSISTANT",
+      "parts": [
+        {
+          "thinking": "look up tool"
+        },
+        {
+          "tool_call": {
+            "id": "toolu_2",
+            "name": "weather",
+            "input_json": "eyJjaXR5IjoiUGFyaXMifQ=="
+          }
+        },
+        {
+          "text": "It's 18C and sunny."
+        }
+      ]
+    }
+  ],
+  "usage": {
+    "input_tokens": "80",
+    "output_tokens": "25",
+    "total_tokens": "105"
+  },
+  "stop_reason": "end_turn",
+  "started_at": "2026-06-10T13:30:00Z",
+  "completed_at": "2026-06-10T13:30:02Z",
+  "agent_name": "assistant-anthropic",
+  "agent_version": "1.0.0"
+}

--- a/go/agento11y/testdata/otlpwire/anthropic_stream.span.json
+++ b/go/agento11y/testdata/otlpwire/anthropic_stream.span.json
@@ -1,0 +1,106 @@
+{
+  "trace_id": "/ty6mHZUMhD+3LqYdlQyEA==",
+  "span_id": "/ty6mHZUMhA=",
+  "name": "streamText claude-sonnet-4-5",
+  "kind": "SPAN_KIND_CLIENT",
+  "start_time_unix_nano": "1781098200000000000",
+  "end_time_unix_nano": "1781098202000000000",
+  "attributes": [
+    {
+      "key": "agento11y.generation.id",
+      "value": {
+        "string_value": "gen-anthropic-stream-1"
+      }
+    },
+    {
+      "key": "gen_ai.conversation.id",
+      "value": {
+        "string_value": "conv-stream"
+      }
+    },
+    {
+      "key": "gen_ai.operation.name",
+      "value": {
+        "string_value": "streamText"
+      }
+    },
+    {
+      "key": "gen_ai.request.stream",
+      "value": {
+        "bool_value": true
+      }
+    },
+    {
+      "key": "gen_ai.provider.name",
+      "value": {
+        "string_value": "anthropic"
+      }
+    },
+    {
+      "key": "gen_ai.request.model",
+      "value": {
+        "string_value": "claude-sonnet-4-5"
+      }
+    },
+    {
+      "key": "gen_ai.response.id",
+      "value": {
+        "string_value": "msg_stream_1"
+      }
+    },
+    {
+      "key": "gen_ai.response.model",
+      "value": {
+        "string_value": "claude-sonnet-4-5"
+      }
+    },
+    {
+      "key": "gen_ai.response.finish_reasons",
+      "value": {
+        "array_value": {
+          "values": [
+            {
+              "string_value": "end_turn"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "key": "gen_ai.output.messages",
+      "value": {
+        "string_value": "[{\"role\":\"assistant\",\"parts\":[{\"type\":\"reasoning\",\"content\":\"look up tool\"},{\"type\":\"tool_call\",\"id\":\"toolu_2\",\"name\":\"weather\",\"arguments\":{\"city\":\"Paris\"}},{\"type\":\"text\",\"content\":\"It's 18C and sunny.\"}],\"finish_reason\":\"end_turn\"}]"
+      }
+    },
+    {
+      "key": "gen_ai.usage.input_tokens",
+      "value": {
+        "int_value": "80"
+      }
+    },
+    {
+      "key": "gen_ai.usage.output_tokens",
+      "value": {
+        "int_value": "25"
+      }
+    },
+    {
+      "key": "agento11y.gen_ai.usage.total_tokens",
+      "value": {
+        "int_value": "105"
+      }
+    },
+    {
+      "key": "gen_ai.agent.name",
+      "value": {
+        "string_value": "assistant-anthropic"
+      }
+    },
+    {
+      "key": "gen_ai.agent.version",
+      "value": {
+        "string_value": "1.0.0"
+      }
+    }
+  ]
+}

--- a/go/agento11y/testdata/otlpwire/gemini_sync.generation.json
+++ b/go/agento11y/testdata/otlpwire/gemini_sync.generation.json
@@ -1,0 +1,47 @@
+{
+  "id": "gen-gemini-sync-1",
+  "conversation_id": "conv-9b2f",
+  "operation_name": "generateText",
+  "mode": "GENERATION_MODE_SYNC",
+  "trace_id": "00112233445566778899aabbccddeeff",
+  "span_id": "0011223344556677",
+  "model": {
+    "provider": "gemini",
+    "name": "gemini-2.5-pro"
+  },
+  "response_id": "resp_1",
+  "response_model": "gemini-2.5-pro-001",
+  "system_prompt": "Be concise.",
+  "output": [
+    {
+      "role": "MESSAGE_ROLE_ASSISTANT",
+      "parts": [
+        {
+          "tool_call": {
+            "id": "call_weather",
+            "name": "weather",
+            "input_json": "eyJjaXR5IjoiUGFyaXMifQ=="
+          }
+        },
+        {
+          "text": "It is 18C and sunny."
+        }
+      ]
+    }
+  ],
+  "usage": {
+    "input_tokens": "120",
+    "output_tokens": "40",
+    "total_tokens": "170",
+    "cache_read_input_tokens": "12",
+    "reasoning_tokens": "10"
+  },
+  "stop_reason": "STOP",
+  "started_at": "2026-06-10T14:00:00Z",
+  "completed_at": "2026-06-10T14:00:03Z",
+  "metadata": {
+    "model_version": "gemini-2.5-pro-001"
+  },
+  "agent_name": "assistant-gemini",
+  "agent_version": "1.0.0"
+}

--- a/go/agento11y/testdata/otlpwire/gemini_sync.span.json
+++ b/go/agento11y/testdata/otlpwire/gemini_sync.span.json
@@ -1,0 +1,124 @@
+{
+  "trace_id": "ABEiM0RVZneImaq7zN3u/w==",
+  "span_id": "ABEiM0RVZnc=",
+  "name": "generateText gemini-2.5-pro",
+  "kind": "SPAN_KIND_CLIENT",
+  "start_time_unix_nano": "1781100000000000000",
+  "end_time_unix_nano": "1781100003000000000",
+  "attributes": [
+    {
+      "key": "agento11y.generation.id",
+      "value": {
+        "string_value": "gen-gemini-sync-1"
+      }
+    },
+    {
+      "key": "gen_ai.conversation.id",
+      "value": {
+        "string_value": "conv-9b2f"
+      }
+    },
+    {
+      "key": "gen_ai.operation.name",
+      "value": {
+        "string_value": "generateText"
+      }
+    },
+    {
+      "key": "gen_ai.provider.name",
+      "value": {
+        "string_value": "gcp.gemini"
+      }
+    },
+    {
+      "key": "gen_ai.request.model",
+      "value": {
+        "string_value": "gemini-2.5-pro"
+      }
+    },
+    {
+      "key": "gen_ai.response.id",
+      "value": {
+        "string_value": "resp_1"
+      }
+    },
+    {
+      "key": "gen_ai.response.model",
+      "value": {
+        "string_value": "gemini-2.5-pro-001"
+      }
+    },
+    {
+      "key": "gen_ai.response.finish_reasons",
+      "value": {
+        "array_value": {
+          "values": [
+            {
+              "string_value": "STOP"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "key": "gen_ai.system_instructions",
+      "value": {
+        "string_value": "[{\"type\":\"text\",\"content\":\"Be concise.\"}]"
+      }
+    },
+    {
+      "key": "gen_ai.output.messages",
+      "value": {
+        "string_value": "[{\"role\":\"assistant\",\"parts\":[{\"type\":\"tool_call\",\"id\":\"call_weather\",\"name\":\"weather\",\"arguments\":{\"city\":\"Paris\"}},{\"type\":\"text\",\"content\":\"It is 18C and sunny.\"}],\"finish_reason\":\"STOP\"}]"
+      }
+    },
+    {
+      "key": "gen_ai.usage.input_tokens",
+      "value": {
+        "int_value": "120"
+      }
+    },
+    {
+      "key": "gen_ai.usage.output_tokens",
+      "value": {
+        "int_value": "40"
+      }
+    },
+    {
+      "key": "gen_ai.usage.cache_read.input_tokens",
+      "value": {
+        "int_value": "12"
+      }
+    },
+    {
+      "key": "gen_ai.usage.reasoning.output_tokens",
+      "value": {
+        "int_value": "10"
+      }
+    },
+    {
+      "key": "agento11y.gen_ai.usage.total_tokens",
+      "value": {
+        "int_value": "170"
+      }
+    },
+    {
+      "key": "gen_ai.agent.name",
+      "value": {
+        "string_value": "assistant-gemini"
+      }
+    },
+    {
+      "key": "gen_ai.agent.version",
+      "value": {
+        "string_value": "1.0.0"
+      }
+    },
+    {
+      "key": "agento11y.generation.metadata",
+      "value": {
+        "string_value": "{\"model_version\":\"gemini-2.5-pro-001\"}"
+      }
+    }
+  ]
+}

--- a/go/agento11y/testdata/otlpwire/openai_sync.generation.json
+++ b/go/agento11y/testdata/otlpwire/openai_sync.generation.json
@@ -1,0 +1,72 @@
+{
+  "id": "gen-openai-sync-1",
+  "conversation_id": "conv-9b2f",
+  "operation_name": "generateText",
+  "mode": "GENERATION_MODE_SYNC",
+  "trace_id": "0123456789abcdef0123456789abcdef",
+  "span_id": "0123456789abcdef",
+  "model": {
+    "provider": "openai",
+    "name": "gpt-4o-mini"
+  },
+  "response_id": "chatcmpl_1",
+  "response_model": "gpt-4o-mini",
+  "system_prompt": "You are concise.",
+  "input": [
+    {
+      "role": "MESSAGE_ROLE_SYSTEM",
+      "parts": [
+        {
+          "text": "You are a helpful bot"
+        }
+      ]
+    },
+    {
+      "role": "MESSAGE_ROLE_USER",
+      "parts": [
+        {
+          "text": "What is the weather in Paris?"
+        }
+      ]
+    },
+    {
+      "role": "MESSAGE_ROLE_TOOL",
+      "parts": [
+        {
+          "tool_result": {
+            "tool_call_id": "call_weather",
+            "content": "{\"temp_c\":18}"
+          }
+        }
+      ]
+    }
+  ],
+  "output": [
+    {
+      "role": "MESSAGE_ROLE_ASSISTANT",
+      "parts": [
+        {
+          "tool_call": {
+            "id": "call_weather",
+            "name": "weather",
+            "input_json": "eyJjaXR5IjoiUGFyaXMifQ=="
+          }
+        }
+      ]
+    }
+  ],
+  "usage": {
+    "input_tokens": "120",
+    "output_tokens": "42",
+    "total_tokens": "162"
+  },
+  "stop_reason": "tool_calls",
+  "started_at": "2026-06-10T12:00:00Z",
+  "completed_at": "2026-06-10T12:00:01.250Z",
+  "agent_name": "assistant-openai",
+  "agent_version": "1.0.0",
+  "parent_generation_ids": [
+    "gen-abc123"
+  ],
+  "effective_version": "agent-build-42"
+}

--- a/go/agento11y/testdata/otlpwire/openai_sync.span.json
+++ b/go/agento11y/testdata/otlpwire/openai_sync.span.json
@@ -1,0 +1,130 @@
+{
+  "trace_id": "ASNFZ4mrze8BI0VniavN7w==",
+  "span_id": "ASNFZ4mrze8=",
+  "name": "generateText gpt-4o-mini",
+  "kind": "SPAN_KIND_CLIENT",
+  "start_time_unix_nano": "1781092800000000000",
+  "end_time_unix_nano": "1781092801250000000",
+  "attributes": [
+    {
+      "key": "agento11y.generation.id",
+      "value": {
+        "string_value": "gen-openai-sync-1"
+      }
+    },
+    {
+      "key": "gen_ai.conversation.id",
+      "value": {
+        "string_value": "conv-9b2f"
+      }
+    },
+    {
+      "key": "gen_ai.operation.name",
+      "value": {
+        "string_value": "generateText"
+      }
+    },
+    {
+      "key": "gen_ai.provider.name",
+      "value": {
+        "string_value": "openai"
+      }
+    },
+    {
+      "key": "gen_ai.request.model",
+      "value": {
+        "string_value": "gpt-4o-mini"
+      }
+    },
+    {
+      "key": "gen_ai.response.id",
+      "value": {
+        "string_value": "chatcmpl_1"
+      }
+    },
+    {
+      "key": "gen_ai.response.model",
+      "value": {
+        "string_value": "gpt-4o-mini"
+      }
+    },
+    {
+      "key": "gen_ai.response.finish_reasons",
+      "value": {
+        "array_value": {
+          "values": [
+            {
+              "string_value": "tool_calls"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "key": "gen_ai.system_instructions",
+      "value": {
+        "string_value": "[{\"type\":\"text\",\"content\":\"You are concise.\"}]"
+      }
+    },
+    {
+      "key": "gen_ai.input.messages",
+      "value": {
+        "string_value": "[{\"role\":\"system\",\"parts\":[{\"type\":\"text\",\"content\":\"You are a helpful bot\"}]},{\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"content\":\"What is the weather in Paris?\"}]},{\"role\":\"tool\",\"parts\":[{\"type\":\"tool_call_response\",\"id\":\"call_weather\",\"response\":\"{\\\"temp_c\\\":18}\"}]}]"
+      }
+    },
+    {
+      "key": "gen_ai.output.messages",
+      "value": {
+        "string_value": "[{\"role\":\"assistant\",\"parts\":[{\"type\":\"tool_call\",\"id\":\"call_weather\",\"name\":\"weather\",\"arguments\":{\"city\":\"Paris\"}}],\"finish_reason\":\"tool_calls\"}]"
+      }
+    },
+    {
+      "key": "gen_ai.usage.input_tokens",
+      "value": {
+        "int_value": "120"
+      }
+    },
+    {
+      "key": "gen_ai.usage.output_tokens",
+      "value": {
+        "int_value": "42"
+      }
+    },
+    {
+      "key": "agento11y.gen_ai.usage.total_tokens",
+      "value": {
+        "int_value": "162"
+      }
+    },
+    {
+      "key": "gen_ai.agent.name",
+      "value": {
+        "string_value": "assistant-openai"
+      }
+    },
+    {
+      "key": "gen_ai.agent.version",
+      "value": {
+        "string_value": "1.0.0"
+      }
+    },
+    {
+      "key": "agento11y.generation.parent_generation_ids",
+      "value": {
+        "array_value": {
+          "values": [
+            {
+              "string_value": "gen-abc123"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "key": "agento11y.agent.effective_version",
+      "value": {
+        "string_value": "sha256:6f314875d2b746b0c3b855ccde0dfe9842d13bf048cc043d99401f1246dbc549"
+      }
+    }
+  ]
+}

--- a/go/otelgenai/conformance/conformance_test.go
+++ b/go/otelgenai/conformance/conformance_test.go
@@ -223,6 +223,7 @@ func conformanceScenarios() []scenario {
 				"gen_ai.client.token.usage",
 			},
 			expectedViolations: []expectedViolation{
+				{adviceID: "missing_attribute", messageContains: "agento11y.record"},
 				{adviceID: "missing_attribute", messageContains: "agento11y.generation.id"},
 				{adviceID: "missing_attribute", messageContains: "agento11y.generation.metadata"},
 			},
@@ -276,6 +277,7 @@ func executeScenario(t *testing.T, assets weavertest.Assets, test scenario) weav
 		otelgenai.WithTracerProvider(providers.traces),
 		otelgenai.WithMeterProvider(providers.metrics),
 		otelgenai.WithLoggerProvider(providers.logs),
+		otelgenai.WithConformantMetrics(),
 	}
 	options = append(options, test.options...)
 	handler := otelgenai.NewHandler(options...)

--- a/go/otelgenai/genai.go
+++ b/go/otelgenai/genai.go
@@ -22,6 +22,12 @@ import (
 const ScopeName = "github.com/grafana/agento11y/go/otelgenai"
 
 // SchemaURL is the semantic-convention schema the emitted telemetry follows.
+//
+// v1.41.0 is the last core semconv release that carried the GenAI conventions.
+// They now live in open-telemetry/semantic-conventions-genai, which has no
+// release and whose own README leaves its schema URL open, so there is no newer
+// URL to point at. The two attributes below are therefore conventions the
+// declared schema does not describe.
 const SchemaURL = semconv.SchemaURL
 
 // These attributes were added to the GenAI conventions after semconv v1.41.0,
@@ -92,6 +98,7 @@ type config struct {
 	capture            CaptureMode
 	emitEventOverride  *bool
 	extendedTokenTypes bool
+	conformantMetrics  bool
 }
 
 // Option configures a Handler.
@@ -141,9 +148,10 @@ func WithEndHook(hook EndHook) Option {
 	})
 }
 
-// WithExtendedTokenTypes makes the handler record the cache_read,
-// cache_write, and reasoning token series. By default, a handler records only
-// the registry's input and output token types.
+// WithExtendedTokenTypes makes the handler record the cache_read, cache_write,
+// and reasoning token series. By default, a handler records only the registry's
+// input and output token types. WithConformantMetrics changes cache_write to the
+// conventions' cache_creation spelling.
 //
 // Whether the extra series overlap the input count depends on the provider.
 // OpenAI counts cached tokens inside its input count, so recording cache_read
@@ -155,6 +163,17 @@ func WithEndHook(hook EndHook) Option {
 func WithExtendedTokenTypes() Option {
 	return optionFunc(func(c config) config {
 		c.extendedTokenTypes = true
+		return c
+	})
+}
+
+// WithConformantMetrics limits metric attributes to the GenAI conventions. It
+// uses cache_creation for cache-write input tokens and puts error.type only on
+// gen_ai.client.operation.duration. Without this option, token usage keeps the
+// cache_write spelling and error.type dimension for compatibility.
+func WithConformantMetrics() Option {
+	return optionFunc(func(c config) config {
+		c.conformantMetrics = true
 		return c
 	})
 }
@@ -251,6 +270,7 @@ func NewHandler(opts ...Option) *Handler {
 		extendedTokenTypes: cfg.extendedTokenTypes,
 	}
 	inst.extendedTokenTypes = handler.extendedTokenTypes
+	inst.conformantMetrics = cfg.conformantMetrics
 	handler.instruments = inst
 	return handler
 }

--- a/go/otelgenai/metrics.go
+++ b/go/otelgenai/metrics.go
@@ -24,13 +24,16 @@ var tokenUsageBuckets = []float64{
 	65536, 262144, 1048576, 4194304, 16777216, 67108864,
 }
 
-// These token types are outside the registry's input/output pair. An
-// instrumentation opts into the series with WithExtendedTokenTypes when it
-// needs cache and reasoning breakdowns.
+// These token types are outside the registry's input/output pair, which the
+// conventions allow because gen_ai.token.type is an open enum. Instrumentations
+// opt into the series with WithExtendedTokenTypes when they need cache and
+// reasoning breakdowns. WithConformantMetrics selects cache_creation instead
+// of cache_write for Usage.CacheWriteInputTokens.
 const (
-	TokenTypeCacheRead  = "cache_read"
-	TokenTypeCacheWrite = "cache_write"
-	TokenTypeReasoning  = "reasoning"
+	TokenTypeCacheRead     = "cache_read"
+	TokenTypeCacheWrite    = "cache_write"
+	TokenTypeCacheCreation = "cache_creation"
+	TokenTypeReasoning     = "reasoning"
 )
 
 // instruments holds the spec metric instruments. The genaiconv constructors
@@ -41,6 +44,7 @@ type instruments struct {
 	timeToFirstChunk   genaiconv.ClientOperationTimeToFirstChunk
 	timePerOutputChunk genaiconv.ClientOperationTimePerOutputChunk
 	extendedTokenTypes bool
+	conformantMetrics  bool
 }
 
 func newInstruments(meter metric.Meter) (instruments, error) {
@@ -111,9 +115,13 @@ func (i instruments) record(ctx context.Context, inv *Invocation, extra []attrib
 		{string(genaiconv.TokenTypeOutput), inv.Usage.OutputTokens},
 	}
 	if i.extendedTokenTypes {
+		cacheWriteType := TokenTypeCacheWrite
+		if i.conformantMetrics {
+			cacheWriteType = TokenTypeCacheCreation
+		}
 		buckets = append(buckets,
 			tokenBucket{TokenTypeCacheRead, inv.Usage.CacheReadInputTokens},
-			tokenBucket{TokenTypeCacheWrite, inv.Usage.CacheWriteInputTokens},
+			tokenBucket{cacheWriteType, inv.Usage.CacheWriteInputTokens},
 			tokenBucket{TokenTypeReasoning, inv.Usage.ReasoningTokens},
 		)
 	}
@@ -122,8 +130,10 @@ func (i instruments) record(ctx context.Context, inv *Invocation, extra []attrib
 			continue
 		}
 		attrs := append([]attribute.KeyValue(nil), extra...)
-		if errorType := inv.errorType(); errorType != "" {
-			attrs = append(attrs, semconv.ErrorTypeKey.String(errorType))
+		if !i.conformantMetrics {
+			if errorType := inv.errorType(); errorType != "" {
+				attrs = append(attrs, semconv.ErrorTypeKey.String(errorType))
+			}
 		}
 		attrs = append(attrs, semconv.GenAITokenTypeKey.String(bucket.tokenType))
 		i.tokenUsage.RecordSet(ctx, bucket.value, metricAttributeSet(inv, attrs...))

--- a/go/otelgenai/metrics_test.go
+++ b/go/otelgenai/metrics_test.go
@@ -113,6 +113,13 @@ func tokenTypeSums(t *testing.T, m metricdata.Metrics) map[string]int64 {
 func TestSpecMetrics(t *testing.T) {
 	t.Parallel()
 
+	if otelgenai.TokenTypeCacheWrite != "cache_write" {
+		t.Errorf("TokenTypeCacheWrite = %q, want cache_write", otelgenai.TokenTypeCacheWrite)
+	}
+	if otelgenai.TokenTypeCacheCreation != "cache_creation" {
+		t.Errorf("TokenTypeCacheCreation = %q, want cache_creation", otelgenai.TokenTypeCacheCreation)
+	}
+
 	cases := []struct {
 		name           string
 		options        []otelgenai.Option
@@ -151,7 +158,7 @@ func TestSpecMetrics(t *testing.T) {
 			},
 		},
 		{
-			name:           "cache and reasoning token types",
+			name:           "cache and reasoning token types preserve compatibility",
 			extendedTokens: true,
 			mutate: func(inv *otelgenai.Invocation) {
 				inv.Usage.CacheReadInputTokens = 12
@@ -162,6 +169,22 @@ func TestSpecMetrics(t *testing.T) {
 				sums := tokenTypeSums(t, metrics["gen_ai.client.token.usage"])
 				if sums["cache_read"] != 12 || sums["cache_write"] != 7 || sums["reasoning"] != 5 {
 					t.Errorf("token sums = %v, want cache_read 12, cache_write 7, reasoning 5", sums)
+				}
+			},
+		},
+		{
+			name:           "conformant cache and reasoning token types",
+			options:        []otelgenai.Option{otelgenai.WithConformantMetrics()},
+			extendedTokens: true,
+			mutate: func(inv *otelgenai.Invocation) {
+				inv.Usage.CacheReadInputTokens = 12
+				inv.Usage.CacheWriteInputTokens = 7
+				inv.Usage.ReasoningTokens = 5
+			},
+			check: func(t *testing.T, metrics map[string]metricdata.Metrics) {
+				sums := tokenTypeSums(t, metrics["gen_ai.client.token.usage"])
+				if sums["cache_read"] != 12 || sums["cache_creation"] != 7 || sums["reasoning"] != 5 {
+					t.Errorf("token sums = %v, want cache_read 12, cache_creation 7, reasoning 5", sums)
 				}
 			},
 		},
@@ -471,7 +494,7 @@ func TestSpecMetrics(t *testing.T) {
 			},
 		},
 		{
-			name: "token usage carries error type",
+			name: "token usage preserves error type by default",
 			mutate: func(inv *otelgenai.Invocation) {
 				inv.ErrorType = "timeout"
 			},
@@ -482,10 +505,35 @@ func TestSpecMetrics(t *testing.T) {
 					t.Fatalf("token usage data = %T, want an int64 histogram", usage.Data)
 				}
 				for _, point := range histogram.DataPoints {
-					errorType, _ := point.Attributes.Value("error.type")
-					if got := errorType.AsString(); got != "timeout" {
-						t.Errorf("token usage error.type = %q, want timeout", got)
+					errorType, present := point.Attributes.Value("error.type")
+					if !present || errorType.AsString() != "timeout" {
+						t.Errorf("token usage error.type = %q, present = %v, want timeout", errorType.AsString(), present)
 					}
+				}
+			},
+		},
+		{
+			// The conventions put error.type on the duration instrument only, so
+			// the token series must not gain a dimension a conformant consumer
+			// does not expect.
+			name:    "conformant token usage carries no error type",
+			options: []otelgenai.Option{otelgenai.WithConformantMetrics()},
+			mutate: func(inv *otelgenai.Invocation) {
+				inv.ErrorType = "timeout"
+			},
+			check: func(t *testing.T, metrics map[string]metricdata.Metrics) {
+				usage := metrics["gen_ai.client.token.usage"]
+				histogram, ok := usage.Data.(metricdata.Histogram[int64])
+				if !ok {
+					t.Fatalf("token usage data = %T, want an int64 histogram", usage.Data)
+				}
+				for _, point := range histogram.DataPoints {
+					if got, present := point.Attributes.Value("error.type"); present {
+						t.Errorf("token usage carries error.type = %q", got.AsString())
+					}
+				}
+				if got := metrics["gen_ai.client.operation.duration"]; got.Name == "" {
+					t.Error("the failure is not countable on the duration instrument either")
 				}
 			},
 		},


### PR DESCRIPTION
`AGENTO11Y_PROTOCOL=otel` plus `AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true` enables the OTel mode in Go SDK: each generation is exported as a GenAI-semconv span via `otelgenai` instead of calling `generations:export`.

New `Config` fields:

- `TracerProvider` and `MeterProvider`: where the generation span and the spec metrics go.
- `Flusher`: what `Flush` and `Shutdown` use to force-flush

OTel supports `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` but we do not use it and use our own content capture env var.

What the mode does not support:

- `ExportGeneration` returns `ErrSynchronousExportUnsupported`.
- `EnqueueWorkflowStep` does not work, there are no workflows support in OTel Gen AI.

No documentation yet. The mode is hidden behind the experimental flag and is not ready for use.

