### PR TITLE
feat(plugins/agento11y): add agento11y local open command

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -120,7 +120,7 @@ To re-enter credentials later, run `agento11y login`. It asks where sessions go 
 
 ## Local mode
 
-`agento11y <agent> --local`, or **Local only** at the first-run question, records full session content to a JSONL store on this machine and serves a local viewer. The launcher prints the viewer URL: it tries `http://127.0.0.1:8765` first and moves to a higher port when that one is taken. Manage the daemon with `agento11y local start|status|stop|restart`. Local mode runs on macOS and Linux only; Windows has no local receiver.
+`agento11y <agent> --local`, or **Local only** at the first-run question, records full session content to a JSONL store on this machine and serves a local viewer. The launcher prints the viewer URL: it tries `http://127.0.0.1:8765` first and moves to a higher port when that one is taken. Manage the daemon with `agento11y local start|open|status|stop|restart`. Use `agento11y local open` to start the receiver if needed, print its address, and try to open the viewer. Local mode runs on macOS and Linux only; Windows has no local receiver.
 
 **Local only** writes `AGENTO11Y_LOCAL=true` and `SIGIL_LOCAL=true` to `~/.config/agento11y/config.env`, so later launchers and installed hooks use the local store without asking again. `--no-local` sends one launcher session to Grafana Cloud without changing the saved answer. Local mode captures full content regardless of `AGENTO11Y_CONTENT_CAPTURE_MODE`, and it forwards to Grafana Cloud only when `AGENTO11Y_LOCAL_FORWARD` is set with valid Cloud credentials.
 

--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -96,7 +96,7 @@ The skills for instrumenting your own application code are separate and ship wit
 
 `AGENTO11Y_LOCAL=true` in the shell or `config.env` enables local mode for every launch and installed hook. Choosing **Local only** at first-run login writes that setting (and `SIGIL_LOCAL=true`) and later runs do not ask again. Local mode is available on macOS and Linux only; Windows has no local receiver. Use `--no-local` to override local mode for one launcher session.
 
-Local mode stores full session content. Manage the app with `agento11y local start|status|stop|restart`.
+Local mode stores full session content. Manage the app with `agento11y local start|open|status|stop|restart`. `agento11y local open` starts the receiver if needed, prints its address, and tries to open the app.
 
 ### History import
 

--- a/plugins/agento11y/internal/browser/browser.go
+++ b/plugins/agento11y/internal/browser/browser.go
@@ -1,0 +1,27 @@
+// Package browser opens URLs in the user's browser.
+package browser
+
+import (
+	"os/exec"
+	"runtime"
+)
+
+// Open starts the operating system URL handler for target. It returns after
+// the process starts and does not report later handler failures.
+func Open(target string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", target)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", target)
+	default:
+		cmd = exec.Command("xdg-open", target)
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	// Reap the child in the background so long-running callers do not leave a zombie.
+	go func() { _ = cmd.Wait() }()
+	return nil
+}

--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -13,7 +13,7 @@
 //	agento11y cursor   install|uninstall                              — wire (or remove) the Cursor hook in ~/.cursor/hooks.json
 //	agento11y claude   install [--json]                               — register the Claude Code plugin without launching or prompting
 //	agento11y agents   reconcile --agents all|name[,name...] --json   — reconcile registered noninteractive installers
-//	agento11y local start|status|stop                                 — manage the local capture daemon
+//	agento11y local start|open|status|stop|restart                    — manage the local capture daemon
 //	agento11y history import <agent> [flags]                          — backfill an agent's existing local sessions
 //	agento11y skills list|show <name>                                 — print an agent skill bundled into this binary
 //	agento11y help                                                    — print the expanded command list
@@ -60,6 +60,7 @@ import (
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/opencode"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/pi"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/vibe"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/browser"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/buildversion"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/cli"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/doctor"
@@ -134,7 +135,7 @@ func usageLine() string {
 	return "usage: agento11y login [--endpoint url] [--tenant id] [--token value|--token-stdin] " +
 		"[--otlp-endpoint url] [--no-verify] [--yes] | agento11y doctor [--json] | " +
 		"agento11y <claude|copilot|opencode|pi> install [--json] | agento11y agents reconcile --agents all|name[,name...] --json | " +
-		"agento11y skills list|show <name> | agento11y local start|status|stop | " +
+		"agento11y skills list|show <name> | agento11y local start|open|status|stop|restart | " +
 		"agento11y history import <" + historyAgentNames() + "> | agento11y cursor install|uninstall | agento11y <agent> hook | " +
 		"agento11y <claude|codex|copilot|opencode|pi|vibe> [--local|--no-local] [--tag key=value]... [-- args...]"
 }
@@ -185,6 +186,9 @@ var exit = os.Exit
 // loginRun is a package var so tests can stub the interactive login flow
 // without driving the huh TTY. Production code points at login.Run.
 var loginRun = login.Run
+
+// openURL is a package var so local command tests do not launch a browser.
+var openURL = browser.Open
 
 // registeredInstallers is a seam for reconciliation tests. Production returns
 // every adapter that registered a noninteractive installer at package init.
@@ -1219,13 +1223,17 @@ func setupLocalLaunch(stderr io.Writer, envKey string) (endpoint, otlp string, e
 // runLocalCommand dispatches `agento11y local <verb>` subcommands.
 func runLocalCommand(args []string, stdout, stderr io.Writer) {
 	if len(args) == 0 {
-		_, _ = fmt.Fprintln(stderr, "usage: agento11y local start | status | stop | restart | serve")
+		_, _ = fmt.Fprintln(stderr, localUsage)
 		exit(2)
+		return
+	}
+	if args[0] == "help" || args[0] == "--help" || args[0] == "-h" {
+		runLocalHelpCommand(stdout)
 		return
 	}
 	// Apply dotenv before resolving the state dir so XDG_STATE_HOME set
 	// only in $XDG_CONFIG_HOME/agento11y/config.env reaches local.StateDir().
-	// Each verb relies on that resolution.
+	// Each stateful verb relies on that resolution.
 	dotenv.ApplyEnv(nil)
 	dir := local.StateDir()
 	switch args[0] {
@@ -1239,6 +1247,19 @@ func runLocalCommand(args []string, stdout, stderr io.Writer) {
 			return
 		}
 		_, _ = fmt.Fprintf(stdout, "agento11y local receiver running at %s (pid %d)\n", status.Endpoint, status.PID)
+	case "open":
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		status, err := local.EnsureRunning(ctx, dir, nil)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "agento11y: %v\n", err)
+			exit(1)
+			return
+		}
+		_, _ = fmt.Fprintln(stdout, status.Endpoint)
+		if err := openURL(status.Endpoint); err != nil {
+			_, _ = fmt.Fprintf(stderr, "agento11y: could not open browser: %v\n", err)
+		}
 	case "status":
 		status, err := local.IsRunning(dir)
 		if err != nil {

--- a/plugins/agento11y/internal/entry/entry_test.go
+++ b/plugins/agento11y/internal/entry/entry_test.go
@@ -1351,28 +1351,46 @@ func TestRun_LauncherContinuesWhenLoginAborted(t *testing.T) {
 	}
 }
 
-// TestRun_LocalSubcommand covers the friendly-failure paths of the
-// `sigil local` verbs when no daemon is running: status / stop just
-// print the friendly message, unknown / missing verb exit 2 with a
-// usage hint. The happy-path verbs (start, restart) that spawn or
-// adopt a real daemon are exercised elsewhere via inProcessDaemon.
+// TestRun_LocalSubcommand covers local help, friendly responses when no daemon
+// is running, and misuse errors.
 func TestRun_LocalSubcommand(t *testing.T) {
+	localHelpRows := []string{
+		"\n  start     ",
+		"\n  open      ",
+		"\n  status    ",
+		"\n  stop      ",
+		"\n  restart   ",
+	}
 	cases := []struct {
-		name          string
-		argv          []string
-		wantExit      *int   // nil = no exit
-		wantStdoutHas string // empty = skip
-		wantStderrHas string // empty = skip
+		name            string
+		argv            []string
+		wantExit        *int // nil = no exit
+		wantStdoutHas   []string
+		wantStdoutLacks string
+		wantStderrHas   string
+		wantStderrEmpty bool
+		checkNoDotenv   bool
 	}{
-		{name: "status with no daemon prints friendly message", argv: []string{"local", "status"}, wantStdoutHas: "not running"},
-		{name: "stop with no daemon prints friendly message", argv: []string{"local", "stop"}, wantStdoutHas: "not running"},
+		{name: "status with no daemon prints friendly message", argv: []string{"local", "status"}, wantStdoutHas: []string{"not running"}},
+		{name: "stop with no daemon prints friendly message", argv: []string{"local", "stop"}, wantStdoutHas: []string{"not running"}},
+		{name: "help", argv: []string{"local", "help"}, wantStdoutHas: localHelpRows, wantStdoutLacks: "serve", wantStderrEmpty: true, checkNoDotenv: true},
+		{name: "long help flag", argv: []string{"local", "--help"}, wantStdoutHas: localHelpRows, wantStdoutLacks: "serve", wantStderrEmpty: true, checkNoDotenv: true},
+		{name: "short help flag", argv: []string{"local", "-h"}, wantStdoutHas: localHelpRows, wantStdoutLacks: "serve", wantStderrEmpty: true, checkNoDotenv: true},
 		{name: "unknown verb exits 2", argv: []string{"local", "bogus"}, wantExit: intPtr(2), wantStderrHas: `unknown local verb "bogus"`},
 		{name: "no verb exits 2 with usage hint", argv: []string{"local"}, wantExit: intPtr(2), wantStderrHas: "usage: agento11y local"},
-		{name: "usage hint lists restart", argv: []string{"local"}, wantExit: intPtr(2), wantStderrHas: "restart"},
+		{name: "usage hint lists open and restart", argv: []string{"local"}, wantExit: intPtr(2), wantStderrHas: "open | status | stop | restart"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			isolateDotenvHome(t)
+			home := isolateDotenvHome(t)
+			const sentinel = "AGENTO11Y_LOCAL_HELP_SENTINEL"
+			if tc.checkNoDotenv {
+				cfgDir := filepath.Join(home, "config", "agento11y")
+				require.NoError(t, os.MkdirAll(cfgDir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "config.env"), []byte(sentinel+"=loaded\n"), 0o600))
+				t.Setenv(sentinel, "")
+			}
+
 			var stdout, stderr bytes.Buffer
 			gotExit := withExit(t, func() {
 				run(tc.argv, strings.NewReader(""), &stdout, &stderr)
@@ -1383,11 +1401,84 @@ func TestRun_LocalSubcommand(t *testing.T) {
 			case tc.wantExit != nil && (gotExit == nil || *gotExit != *tc.wantExit):
 				t.Fatalf("exit = %v, want %d", gotExit, *tc.wantExit)
 			}
-			if tc.wantStdoutHas != "" && !strings.Contains(stdout.String(), tc.wantStdoutHas) {
-				t.Fatalf("stdout missing %q: %q", tc.wantStdoutHas, stdout.String())
+			for _, want := range tc.wantStdoutHas {
+				if !strings.Contains(stdout.String(), want) {
+					t.Errorf("stdout missing %q: %q", want, stdout.String())
+				}
+			}
+			if tc.wantStdoutLacks != "" && strings.Contains(stdout.String(), tc.wantStdoutLacks) {
+				t.Errorf("stdout contains %q: %q", tc.wantStdoutLacks, stdout.String())
 			}
 			if tc.wantStderrHas != "" && !strings.Contains(stderr.String(), tc.wantStderrHas) {
-				t.Fatalf("stderr missing %q: %q", tc.wantStderrHas, stderr.String())
+				t.Errorf("stderr missing %q: %q", tc.wantStderrHas, stderr.String())
+			}
+			if tc.wantStderrEmpty && stderr.Len() != 0 {
+				t.Errorf("stderr non-empty: %q", stderr.String())
+			}
+			if tc.checkNoDotenv && os.Getenv(sentinel) != "" {
+				t.Errorf("%s = %q, help loaded config.env", sentinel, os.Getenv(sentinel))
+			}
+		})
+	}
+}
+
+func TestRun_LocalOpen(t *testing.T) {
+	openErr := errors.New("browser command unavailable")
+	for _, tc := range []struct {
+		name       string
+		startErr   error
+		openErr    error
+		wantExit   *int
+		wantStderr string
+		wantOpen   bool
+	}{
+		{name: "starts stopped receiver and opens returned endpoint", wantOpen: true},
+		{name: "browser failure is best effort", openErr: openErr, wantStderr: openErr.Error(), wantOpen: true},
+		{name: "receiver startup failure", startErr: errors.New("receiver failed to start"), wantExit: intPtr(1), wantStderr: "receiver failed to start"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateDotenvHome(t)
+			var endpoint string
+			starts := new(int)
+			if tc.startErr != nil {
+				restore := local.SetStartDaemonForTesting(func(context.Context, string, *log.Logger) (*local.Status, error) {
+					*starts++
+					return nil, tc.startErr
+				})
+				t.Cleanup(restore)
+			} else {
+				_, endpoint, starts = inProcessDaemonWithStartCount(t)
+			}
+
+			var opened []string
+			previousOpenURL := openURL
+			openURL = func(target string) error {
+				opened = append(opened, target)
+				return tc.openErr
+			}
+			t.Cleanup(func() { openURL = previousOpenURL })
+
+			var stdout, stderr bytes.Buffer
+			gotExit := withExit(t, func() {
+				run([]string{"local", "open"}, strings.NewReader(""), &stdout, &stderr)
+			})
+			switch {
+			case tc.wantExit == nil && gotExit != nil:
+				t.Fatalf("exit = %d, want no exit (stderr=%q)", *gotExit, stderr.String())
+			case tc.wantExit != nil && (gotExit == nil || *gotExit != *tc.wantExit):
+				t.Fatalf("exit = %v, want %d", gotExit, *tc.wantExit)
+			}
+			assert.Equal(t, 1, *starts, "daemon starts")
+			if tc.wantOpen {
+				assert.Contains(t, stdout.String(), endpoint)
+				assert.Equal(t, []string{endpoint}, opened)
+			} else {
+				assert.Empty(t, opened)
+			}
+			if tc.wantStderr == "" {
+				assert.Empty(t, stderr.String())
+			} else {
+				assert.Contains(t, stderr.String(), tc.wantStderr)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/entry/skills.go
+++ b/plugins/agento11y/internal/entry/skills.go
@@ -59,6 +59,27 @@ func runSkillsCommand(args []string, stdout, stderr io.Writer) {
 	}
 }
 
+const localUsage = "usage: agento11y local start | open | status | stop | restart"
+
+// runLocalHelpCommand prints the user-facing local daemon commands. The serve
+// verb is internal and stays out of help and usage output.
+func runLocalHelpCommand(stdout io.Writer) {
+	_, _ = io.WriteString(stdout, localHelpBody)
+}
+
+const localHelpBody = `Manage the local capture daemon and viewer.
+
+Usage:
+  agento11y local <command>
+
+Commands:
+  start     Start the receiver if needed and print its address.
+  open      Start the receiver if needed, print its address, and try to open the viewer.
+  status    Report whether the receiver is running.
+  stop      Stop the receiver.
+  restart   Stop and start the receiver.
+`
+
 // runHelpCommand prints the expanded command list, which the one-line
 // usageLine cannot carry.
 func runHelpCommand(stdout io.Writer) {
@@ -92,7 +113,8 @@ Commands:
   login       Save endpoint, tenant, token, and OTLP endpoint to config.env.
   doctor      Check both export pipelines, the config, and installed plugins.
   skills      List or print the agent skills bundled into this binary.
-  local       Manage the local capture daemon: start, status, stop.
+  local       Manage the local capture daemon: start, open, status, stop, restart.
+              agento11y local open starts it if needed and tries to open the viewer.
   history     Backfill sessions an agent wrote before agento11y was installed.
   help        Print this text.
 
@@ -101,8 +123,7 @@ Commands:
 
 Flags:
   --version   Print the build version.
-  --help, -h  Print this text. Both are top-level forms: a subcommand given
-              the wrong arguments prints its own usage line instead.
+  --help, -h  Print this text. agento11y local also accepts help, --help, and -h.
 
 Skills:
   agento11y skills list

--- a/plugins/agento11y/internal/entry/skills_test.go
+++ b/plugins/agento11y/internal/entry/skills_test.go
@@ -189,6 +189,11 @@ func TestRun_HelpIsARealCommand(t *testing.T) {
 			if !strings.Contains(out, "agento11y skills list") {
 				t.Errorf("help does not name `agento11y skills list`:\n%s", out)
 			}
+			for _, want := range []string{"agento11y local open", "restart"} {
+				if !strings.Contains(out, want) {
+					t.Errorf("help does not name %q:\n%s", want, out)
+				}
+			}
 			if !strings.Contains(out, skills.SetupCodingAgentCommand) {
 				t.Errorf("help does not carry the setup hint %q:\n%s", skills.SetupCodingAgentCommand, out)
 			}

--- a/plugins/agento11y/internal/login/login.go
+++ b/plugins/agento11y/internal/login/login.go
@@ -52,15 +52,14 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"os/exec"
 	"regexp"
-	"runtime"
 	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/browser"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/doctor"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/dotenv"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
@@ -174,26 +173,7 @@ func validateStack(s string) error {
 
 // openURL opens a URL in the user's browser. It is a package var so tests can
 // record the call instead of launching anything.
-var openURL = openBrowser
-
-func openBrowser(target string) error {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("open", target)
-	case "windows":
-		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", target)
-	default:
-		cmd = exec.Command("xdg-open", target)
-	}
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-	// The browser outlives this call and login then waits on the user, so reap
-	// the child in the background instead of leaving a zombie behind.
-	go func() { _ = cmd.Wait() }()
-	return nil
-}
+var openURL = browser.Open
 
 // docsURL points at the plugins directory so users can discover every
 // agent adapter we ship (claude-code, codex, cursor, pi, …). Linked as a

--- a/plugins/agento11y/internal/skills/content/setup-coding-agent/SKILL.md
+++ b/plugins/agento11y/internal/skills/content/setup-coding-agent/SKILL.md
@@ -452,11 +452,11 @@ chooses which fields ship, not whether the shipped fields are clean. Treat
 ### Local mode
 
 `agento11y <agent> --local`, or **Local only** at the first-run question, routes
-launcher runs and agento11y hooks to a JSONL store on the machine. It also
-overrides the capture mode with full content. The launcher prints the viewer URL.
-Manage the daemon with `agento11y local start|status|stop|restart`. Local mode
-runs on macOS and Linux only. **Local only** at a launcher starts the receiver for
-that launch; after `agento11y login` or `agento11y cursor install` the receiver
+launcher runs and agento11y hooks to a JSONL store on the machine. Local mode uses
+full content regardless of the configured capture mode. The launcher prints the viewer URL.
+Manage the daemon with `agento11y local start|open|status|stop|restart`. `agento11y local open`
+starts it if needed, prints its address, and tries to open the viewer. Local mode runs on macOS and Linux only. **Local only** at a launcher
+starts the receiver for that launch; after `agento11y login` or `agento11y cursor install` the receiver
 starts on the next launch or hook. `--no-local` runs one session against Cloud
 while the saved answer stays set. Never describe local mode as a switch that keeps
 all data on the machine: with `AGENTO11Y_LOCAL_FORWARD` and valid Cloud settings


### PR DESCRIPTION
Add `agento11y local open` command that tries to open the local viewer in a browser and prints its address.

It could probably be just `agento11y open`, but there is already a set of commands under local: `agento11y local start|stop|restart`.