### PR TITLE
fix(plugins/agento11y): honor local mode in history import

### DIFF
--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -22,9 +22,9 @@
 // --tag is repeatable and adds key=value pairs to SIGIL_TAGS so they land
 // on every generation the launched session produces.
 //
-// --local can also be turned on for every launch — and for hook dispatch —
-// with AGENTO11Y_LOCAL=true in the shell or in config.env. --no-local runs
-// one session against Cloud while that setting stays on.
+// --local can also be turned on for every launch, hook dispatch, and history
+// import with AGENTO11Y_LOCAL=true in the shell or config.env. --no-local runs
+// one session or import against Cloud while that setting stays on.
 //
 // Unknown agents and unknown verbs exit with code 2 and a usage message on
 // stderr. For hook agents the binary must never crash the calling agent
@@ -327,9 +327,10 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 		// Grafana Cloud.
 		if localEnv == nil && !dotenv.HasCredentials() {
 			result, err := loginRun(context.Background(), login.RunOpts{
-				Stderr:     stderr,
-				Logger:     logger,
-				OfferLocal: !destinationSet,
+				Stderr:           stderr,
+				Logger:           logger,
+				OfferLocal:       !destinationSet,
+				KeepLocalSetting: destinationSet,
 			})
 			switch {
 			case err == nil, errors.Is(err, login.ErrNotInteractive):

--- a/plugins/agento11y/internal/entry/entry_test.go
+++ b/plugins/agento11y/internal/entry/entry_test.go
@@ -1197,6 +1197,45 @@ func TestRun_LauncherAutoPromptsWhenCredsMissing(t *testing.T) {
 	}
 }
 
+func TestRun_LauncherNoLocalKeepsSavedLocalSettingDuringSetup(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		localEnv string
+	}{
+		{name: "saved local mode", localEnv: "true"},
+		{name: "no saved destination"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateDotenvHome(t)
+			t.Setenv(envconfig.PreferredKey("LOCAL"), tt.localEnv)
+
+			withStubLoginRun(t, func(_ context.Context, opts login.RunOpts) (login.Result, error) {
+				if opts.OfferLocal {
+					t.Error("--no-local must skip the destination question")
+				}
+				if !opts.KeepLocalSetting {
+					t.Error("--no-local setup must keep the saved local setting")
+				}
+				return login.Result{}, nil
+			})
+			withStubLauncher(t, "pi", func(_ context.Context, _ []string, env *local.LaunchEnv, _ io.Reader, _, _ io.Writer, _ *log.Logger, _ string) error {
+				if env != nil {
+					t.Error("--no-local launcher received a local environment")
+				}
+				return nil
+			})
+
+			var stdout, stderr bytes.Buffer
+			gotExit := withExit(t, func() {
+				run([]string{"pi", "--no-local", "--"}, strings.NewReader(""), &stdout, &stderr)
+			})
+			if gotExit != nil {
+				t.Fatalf("exit = %d, want no exit (stderr=%q)", *gotExit, stderr.String())
+			}
+		})
+	}
+}
+
 func TestRun_LauncherLocalAnswerStartsReceiver(t *testing.T) {
 	isolateDotenvHome(t)
 	_, daemonURL := inProcessDaemon(t)

--- a/plugins/agento11y/internal/entry/history.go
+++ b/plugins/agento11y/internal/entry/history.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"sort"
 	"strings"
@@ -14,8 +15,10 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/cli"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/dotenv"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/history"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/local"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/login"
 	"golang.org/x/term"
 )
 
@@ -33,6 +36,10 @@ type historyImportOptions struct {
 	DryRun      bool
 	Force       bool
 	Local       bool
+	NoLocal     bool
+	// LocalEnvKey names the LOCAL spelling that selected the local store.
+	// It stays empty when a flag or the first-run answer selected it.
+	LocalEnvKey string
 }
 
 // repeatedFlag collects a flag given more than once.
@@ -110,9 +117,12 @@ var historyEnsureLocal = func(ctx context.Context) (string, error) {
 	return status.Endpoint, nil
 }
 
-// historySelect shows the session picker. It is a package var so tests can
-// drive selection without a TTY.
-var historySelect = historySelectSessions
+// historySelect and historyConfirm are package vars so tests can drive the
+// interactive path without a TTY.
+var (
+	historySelect  = historySelectSessions
+	historyConfirm = historyConfirmImport
+)
 
 func runHistoryImport(args []string, stdin io.Reader, stdout, stderr io.Writer) {
 	fs := flag.NewFlagSet("history import", flag.ContinueOnError)
@@ -129,6 +139,7 @@ func runHistoryImport(args []string, stdin io.Reader, stdout, stderr io.Writer) 
 		dryRun      = fs.Bool("dry-run", false, "show what would be imported and exit")
 		force       = fs.Bool("force", false, "re-export turns already recorded in the import ledger")
 		useLocal    = fs.Bool("local", false, "import into the local daemon instead of Grafana Cloud")
+		noLocal     = fs.Bool("no-local", false, "import into Grafana Cloud even when local mode is on")
 	)
 	fs.Var(&sources, "source", "restrict to this discovered path (repeatable); a path outside the agent's roots matches nothing")
 	fs.Usage = func() {
@@ -186,7 +197,8 @@ func runHistoryImport(args []string, stdin io.Reader, stdout, stderr io.Writer) 
 		Yes:         *yes,
 		DryRun:      *dryRun,
 		Force:       *force,
-		Local:       *useLocal,
+		Local:       *useLocal && !*noLocal,
+		NoLocal:     *noLocal,
 	}
 
 	var err error
@@ -269,12 +281,59 @@ func historyIsInteractive(stdin io.Reader) bool {
 	return ok && term.IsTerminal(int(f.Fd()))
 }
 
+func historyResolveDestination(ctx context.Context, opts *historyImportOptions, envLocal localEnvRequest, interactive bool, stderr io.Writer, logger *log.Logger) error {
+	switch {
+	case opts.NoLocal:
+		opts.Local = false
+	case opts.Local:
+		return nil
+	case envLocal.on:
+		opts.Local = true
+		opts.LocalEnvKey = envLocal.key
+		return nil
+	}
+	if historyDestinationConfigured() || !interactive {
+		return nil
+	}
+
+	result, err := loginRun(ctx, login.RunOpts{
+		Stderr:           stderr,
+		Logger:           logger,
+		OfferLocal:       !opts.NoLocal && !localDestinationSet(),
+		KeepLocalSetting: opts.NoLocal,
+	})
+	switch {
+	case err == nil:
+		opts.Local = result.LocalMode
+		return nil
+	case errors.Is(err, login.ErrAborted), errors.Is(err, login.ErrNotInteractive):
+		return errors.New("nothing was imported because setup did not finish; run `agento11y login` or pass --local to import into the local store")
+	case errors.Is(err, login.ErrNotVerified):
+		logger.Printf("import setup: %v", err)
+		return errors.New("nothing was imported because the endpoint did not accept those credentials; run `agento11y login` to try again, `agento11y login --yes` to save them anyway, or pass --local to import into the local store")
+	default:
+		return fmt.Errorf("setup: %w", err)
+	}
+}
+
+// historyDestinationConfigured reports whether first-run setup has anything to
+// ask. Cloud needs complete credentials, while a loopback endpoint needs none.
+func historyDestinationConfigured() bool {
+	return dotenv.HasCredentials() || envconfig.IsLocalEndpoint(envconfig.Getenv("ENDPOINT"))
+}
+
 func historyImport(opts historyImportOptions, interactive bool, stdout, stderr io.Writer) error {
 	ctx := context.Background()
 	// The dotenv file is applied before the logger is built so AGENTO11Y_DEBUG
 	// set only in config.env still turns on file logging, as it does for the
-	// other commands.
-	dotenv.ApplyEnv(nil)
+	// other commands. Read LOCAL around that merge so an error can name the
+	// spelling that selected the local store.
+	localValue, localKey, inShell := envconfig.LookupEnv("LOCAL")
+	fileEnv := dotenv.ApplyEnv(nil)
+	if !inShell {
+		localValue, localKey, _ = envconfig.LookupMap(fileEnv, "LOCAL")
+	}
+	envLocal := localEnvRequest{on: envconfig.ParseBool(localValue), key: localKey}
 	logger := cli.InitLogger("history")
 
 	filter := history.NewFilter()
@@ -302,6 +361,10 @@ func historyImport(opts historyImportOptions, interactive bool, stdout, stderr i
 	}
 	if len(plan.Sessions) == 0 {
 		return nil
+	}
+
+	if err := historyResolveDestination(ctx, &opts, envLocal, interactive, stderr, logger); err != nil {
+		return err
 	}
 
 	sessions := plan.Sessions
@@ -392,10 +455,10 @@ func historyImport(opts historyImportOptions, interactive bool, stdout, stderr i
 // historyProgressInterval is how often the progress line is redrawn.
 const historyProgressInterval = 200 * time.Millisecond
 
-// historyTarget builds the export destination. Without --local the import goes
-// to the configured Grafana Cloud endpoint; with it, to the local daemon, which
-// [history.NewTargetExporter] recognises as loopback and gives full content and
-// the forward marker, so the backfill stays on this machine.
+// historyTarget builds the export destination from the resolved Local value.
+// A Cloud import leaves the target empty so [history.NewTargetExporter] reads
+// the configured endpoint. A local import points at the daemon, where the
+// exporter enables full content and adds the marker that prevents forwarding.
 func historyTarget(ctx context.Context, opts historyImportOptions) (history.Target, error) {
 	if !opts.Local {
 		return history.Target{}, nil
@@ -404,6 +467,9 @@ func historyTarget(ctx context.Context, opts historyImportOptions) (history.Targ
 	defer cancel()
 	endpoint, err := historyEnsureLocal(startCtx)
 	if err != nil {
+		if opts.LocalEnvKey != "" {
+			return history.Target{}, fmt.Errorf("start the local receiver: %w (local mode is on because %s is set; pass --no-local to import into Grafana Cloud)", err, opts.LocalEnvKey)
+		}
 		return history.Target{}, fmt.Errorf("start the local receiver: %w", err)
 	}
 	return history.Target{
@@ -514,16 +580,19 @@ func historySessionLabel(s history.SessionPreview) string {
 	return fmt.Sprintf("%s  %s  %s", when, workspace, turns)
 }
 
-func historyConfirm(opts historyImportOptions, sessions []history.SessionPreview) (bool, error) {
-	turns, approx := historyTurnTotals(sessions)
-	destination := "Grafana Cloud"
+func historyDestinationName(opts historyImportOptions) string {
 	if opts.Local {
-		destination = "the local store on this machine"
+		return "the local store on this machine"
 	}
+	return "Grafana Cloud"
+}
+
+func historyConfirmImport(opts historyImportOptions, sessions []history.SessionPreview) (bool, error) {
+	turns, approx := historyTurnTotals(sessions)
 	confirmed := false
 	form := huh.NewForm(huh.NewGroup(
 		huh.NewConfirm().
-			Title(fmt.Sprintf("Import %d sessions (%s turns) into %s?", len(sessions), historyTurnCount(turns, approx), destination)).
+			Title(fmt.Sprintf("Import %d sessions (%s turns) into %s?", len(sessions), historyTurnCount(turns, approx), historyDestinationName(opts))).
 			Value(&confirmed),
 	))
 	if err := form.Run(); err != nil {

--- a/plugins/agento11y/internal/entry/history_test.go
+++ b/plugins/agento11y/internal/entry/history_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,8 +16,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/history"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/local"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/login"
 )
 
 // historyFixedNow pins the clock so the 90-day default boundary is checkable.
@@ -233,6 +238,10 @@ func TestHistoryDryRunReportsThePlan(t *testing.T) {
 	withHistoryNow(t)
 	isolateDotenvHome(t)
 	writeClaudeHistory(t, "sess-recent", 24*time.Hour)
+	withStubLoginRun(t, func(context.Context, login.RunOpts) (login.Result, error) {
+		t.Fatal("dry run must not prompt for a destination")
+		return login.Result{}, nil
+	})
 
 	stdout, stderr, code := runHistory(t, "history", "import", "claude-code", "--dry-run")
 	if code != nil {
@@ -246,6 +255,215 @@ func TestHistoryDryRunReportsThePlan(t *testing.T) {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("stdout = %q, want it to contain %q", stdout, want)
 		}
+	}
+}
+
+func TestHistoryEmptyPlanSkipsSetup(t *testing.T) {
+	withHistoryNow(t)
+	isolateDotenvHome(t)
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+	withStubLoginRun(t, func(context.Context, login.RunOpts) (login.Result, error) {
+		t.Fatal("an empty import plan must not start setup")
+		return login.Result{}, nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	err := historyImport(historyImportOptions{
+		Agent: history.AgentClaudeCode,
+		Since: historyFixedNow.Add(-history.DefaultSinceWindow),
+	}, true, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("historyImport: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "planned: 0 sessions") {
+		t.Fatalf("stdout = %q, want an empty plan", stdout.String())
+	}
+}
+
+func TestHistoryResolveDestination(t *testing.T) {
+	setupErr := errors.New("broken login")
+	tests := []struct {
+		name            string
+		opts            historyImportOptions
+		localEnv        string
+		localEnvKey     string
+		endpoint        string
+		credentials     bool
+		interactive     bool
+		loginResult     login.Result
+		loginErr        error
+		wantLocal       bool
+		wantLocalEnvKey string
+		wantLoginCalls  int
+		wantOfferLocal  bool
+		wantKeepLocal   bool
+		wantErr         string
+	}{
+		{
+			name:        "no-local beats local flag and environment",
+			opts:        historyImportOptions{Local: true, NoLocal: true},
+			localEnv:    "true",
+			credentials: true,
+			interactive: true,
+		},
+		{
+			name:        "local flag needs no setup",
+			opts:        historyImportOptions{Local: true},
+			interactive: true,
+			wantLocal:   true,
+		},
+		{
+			name:            "local environment enables local destination",
+			localEnv:        "true",
+			localEnvKey:     envconfig.LegacyKey("LOCAL"),
+			interactive:     true,
+			wantLocal:       true,
+			wantLocalEnvKey: envconfig.LegacyKey("LOCAL"),
+		},
+		{
+			name:        "saved credentials select Cloud",
+			credentials: true,
+			interactive: true,
+		},
+		{
+			name:        "loopback endpoint needs no setup",
+			endpoint:    "http://127.0.0.1:8765",
+			interactive: true,
+		},
+		{
+			name:           "Cloud endpoint without credentials starts setup",
+			endpoint:       "https://agento11y.example.com",
+			interactive:    true,
+			wantLoginCalls: 1,
+			wantOfferLocal: true,
+		},
+		{
+			name:        "non-interactive import leaves exporter to report missing credentials",
+			interactive: false,
+		},
+		{
+			name:           "local login answer selects local destination",
+			interactive:    true,
+			loginResult:    login.Result{LocalMode: true},
+			wantLocal:      true,
+			wantLoginCalls: 1,
+			wantOfferLocal: true,
+		},
+		{
+			name:           "Cloud login answer selects Cloud destination",
+			interactive:    true,
+			wantLoginCalls: 1,
+			wantOfferLocal: true,
+		},
+		{
+			name:           "no-local starts only Cloud setup and keeps saved local mode",
+			opts:           historyImportOptions{Local: true, NoLocal: true},
+			localEnv:       "true",
+			interactive:    true,
+			wantLoginCalls: 1,
+			wantKeepLocal:  true,
+		},
+		{
+			name:           "false local value skips the destination question",
+			localEnv:       "false",
+			interactive:    true,
+			wantLoginCalls: 1,
+		},
+		{
+			name:           "invalid local value still offers destination",
+			localEnv:       "maybe",
+			interactive:    true,
+			wantLoginCalls: 1,
+			wantOfferLocal: true,
+		},
+		{
+			name:           "aborted setup stops import",
+			interactive:    true,
+			loginErr:       login.ErrAborted,
+			wantLoginCalls: 1,
+			wantOfferLocal: true,
+			wantErr:        "nothing was imported because setup did not finish; run `agento11y login` or pass --local",
+		},
+		{
+			name:           "login without terminal stops import",
+			interactive:    true,
+			loginErr:       login.ErrNotInteractive,
+			wantLoginCalls: 1,
+			wantOfferLocal: true,
+			wantErr:        "nothing was imported because setup did not finish; run `agento11y login` or pass --local",
+		},
+		{
+			name:           "refused credentials stop import with recovery paths",
+			interactive:    true,
+			loginErr:       login.ErrNotVerified,
+			wantLoginCalls: 1,
+			wantOfferLocal: true,
+			wantErr:        "did not accept those credentials; run `agento11y login` to try again, `agento11y login --yes` to save them anyway, or pass --local",
+		},
+		{
+			name:           "other setup failure is wrapped",
+			interactive:    true,
+			loginErr:       setupErr,
+			wantLoginCalls: 1,
+			wantOfferLocal: true,
+			wantErr:        "setup: broken login",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateDotenvHome(t)
+			localKey := tt.localEnvKey
+			if localKey == "" {
+				localKey = envconfig.PreferredKey("LOCAL")
+			}
+			t.Setenv(localKey, tt.localEnv)
+			endpoint := tt.endpoint
+			if tt.credentials {
+				if endpoint == "" {
+					endpoint = "https://agento11y.example.com"
+				}
+				t.Setenv(envconfig.PreferredKey("AUTH_TENANT_ID"), "tenant")
+				t.Setenv(envconfig.PreferredKey("AUTH_TOKEN"), "token")
+			}
+			if endpoint != "" {
+				t.Setenv(envconfig.PreferredKey("ENDPOINT"), endpoint)
+			}
+
+			loginCalls := 0
+			withStubLoginRun(t, func(_ context.Context, opts login.RunOpts) (login.Result, error) {
+				loginCalls++
+				if opts.OfferLocal != tt.wantOfferLocal {
+					t.Errorf("OfferLocal = %v, want %v", opts.OfferLocal, tt.wantOfferLocal)
+				}
+				if opts.KeepLocalSetting != tt.wantKeepLocal {
+					t.Errorf("KeepLocalSetting = %v, want %v", opts.KeepLocalSetting, tt.wantKeepLocal)
+				}
+				return tt.loginResult, tt.loginErr
+			})
+
+			envLocal := localEnvRequest{on: envconfig.ParseBool(tt.localEnv), key: localKey}
+			if tt.localEnv == "" {
+				envLocal.key = ""
+			}
+			opts := tt.opts
+			err := historyResolveDestination(context.Background(), &opts, envLocal, tt.interactive, io.Discard, log.New(io.Discard, "", 0))
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("historyResolveDestination() error = %v", err)
+			}
+			if tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)) {
+				t.Fatalf("historyResolveDestination() error = %v, want it to contain %q", err, tt.wantErr)
+			}
+			if opts.Local != tt.wantLocal {
+				t.Errorf("Local = %v, want %v", opts.Local, tt.wantLocal)
+			}
+			if opts.LocalEnvKey != tt.wantLocalEnvKey {
+				t.Errorf("LocalEnvKey = %q, want %q", opts.LocalEnvKey, tt.wantLocalEnvKey)
+			}
+			if loginCalls != tt.wantLoginCalls {
+				t.Errorf("loginRun called %d times, want %d", loginCalls, tt.wantLoginCalls)
+			}
+		})
 	}
 }
 
@@ -324,6 +542,288 @@ func TestHistoryNonInteractiveWithAllAndYesImports(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "Imported 1 turns from 1 sessions") {
 		t.Errorf("stdout = %q, want the import summary", stdout)
+	}
+}
+
+func TestHistoryImportUsesLocalModeFromConfigEnv(t *testing.T) {
+	withHistoryNow(t)
+	isolateDotenvHome(t)
+	writeClaudeHistory(t, "sess-recent", 24*time.Hour)
+	writeHistoryConfig(t, "AGENTO11Y_LOCAL=true\n")
+	withStubLoginRun(t, func(context.Context, login.RunOpts) (login.Result, error) {
+		t.Fatal("configured local mode must not prompt")
+		return login.Result{}, nil
+	})
+
+	exported := 0
+	withStubHistoryExporter(t, &exported)
+	var destination string
+	prevConfirm := historyConfirm
+	t.Cleanup(func() { historyConfirm = prevConfirm })
+	historyConfirm = func(opts historyImportOptions, _ []history.SessionPreview) (bool, error) {
+		destination = historyDestinationName(opts)
+		return true, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := historyImport(historyImportOptions{
+		Agent: history.AgentClaudeCode,
+		Since: historyFixedNow.Add(-history.DefaultSinceWindow),
+		All:   true,
+	}, true, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("historyImport: %v", err)
+	}
+	if destination != "the local store on this machine" {
+		t.Fatalf("confirmation destination = %q", destination)
+	}
+	if exported != 1 {
+		t.Fatalf("exported %d turns, want 1", exported)
+	}
+}
+
+func TestHistoryImportNoLocalOverridesLocalMode(t *testing.T) {
+	for _, flags := range [][]string{{"--local", "--no-local"}, {"--no-local", "--local"}} {
+		t.Run(strings.Join(flags, "_"), func(t *testing.T) {
+			withHistoryNow(t)
+			isolateDotenvHome(t)
+			writeClaudeHistory(t, "sess-recent", 24*time.Hour)
+			t.Setenv(envconfig.PreferredKey("LOCAL"), "true")
+
+			exported := 0
+			endpoint := newCountingIngest(t, &exported)
+			setHistoryCloudCredentials(t, endpoint)
+			withStubLoginRun(t, func(context.Context, login.RunOpts) (login.Result, error) {
+				t.Fatal("saved Cloud credentials must not prompt")
+				return login.Result{}, nil
+			})
+
+			args := []string{"history", "import", "claude-code"}
+			args = append(args, flags...)
+			args = append(args, "--all", "--yes")
+			_, stderr, code := runHistory(t, args...)
+			if code != nil {
+				t.Fatalf("exit = %d, want no exit (stderr=%q)", *code, stderr)
+			}
+			if exported != 1 {
+				t.Fatalf("exported %d turns to Cloud, want 1", exported)
+			}
+		})
+	}
+}
+
+func TestHistoryImportSavedCredentialsSkipSetup(t *testing.T) {
+	withHistoryNow(t)
+	isolateDotenvHome(t)
+	writeClaudeHistory(t, "sess-recent", 24*time.Hour)
+
+	exported := 0
+	endpoint := newCountingIngest(t, &exported)
+	setHistoryCloudCredentials(t, endpoint)
+	withStubLoginRun(t, func(context.Context, login.RunOpts) (login.Result, error) {
+		t.Fatal("saved Cloud credentials must not prompt")
+		return login.Result{}, nil
+	})
+
+	_, stderr, code := runHistory(t, "history", "import", "claude-code", "--all", "--yes")
+	if code != nil {
+		t.Fatalf("exit = %d, want no exit (stderr=%q)", *code, stderr)
+	}
+	if exported != 1 {
+		t.Fatalf("exported %d turns to Cloud, want 1", exported)
+	}
+}
+
+func TestHistoryImportFirstRunUsesLoginDestination(t *testing.T) {
+	tests := []struct {
+		name   string
+		result login.Result
+		cloud  bool
+	}{
+		{name: "local", result: login.Result{LocalMode: true}},
+		{name: "Cloud", cloud: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withHistoryNow(t)
+			isolateDotenvHome(t)
+			writeClaudeHistory(t, "sess-recent", 24*time.Hour)
+
+			exported := 0
+			cloudEndpoint := ""
+			if tt.cloud {
+				cloudEndpoint = newCountingIngest(t, &exported)
+			} else {
+				withStubHistoryExporter(t, &exported)
+			}
+			loginCalls := 0
+			withStubLoginRun(t, func(_ context.Context, opts login.RunOpts) (login.Result, error) {
+				loginCalls++
+				if !opts.OfferLocal {
+					t.Error("first-run setup did not offer the destination question")
+				}
+				if cloudEndpoint != "" {
+					setHistoryCloudCredentials(t, cloudEndpoint)
+				}
+				return tt.result, nil
+			})
+
+			var stdout, stderr bytes.Buffer
+			err := historyImport(historyImportOptions{
+				Agent: history.AgentClaudeCode,
+				Since: historyFixedNow.Add(-history.DefaultSinceWindow),
+				All:   true,
+				Yes:   true,
+			}, true, &stdout, &stderr)
+			if err != nil {
+				t.Fatalf("historyImport: %v", err)
+			}
+			if loginCalls != 1 {
+				t.Fatalf("loginRun called %d times, want 1", loginCalls)
+			}
+			if exported != 1 {
+				t.Fatalf("exported %d turns, want 1", exported)
+			}
+		})
+	}
+}
+
+func TestHistoryImportAbortedSetupExportsNothing(t *testing.T) {
+	withHistoryNow(t)
+	isolateDotenvHome(t)
+	writeClaudeHistory(t, "sess-recent", 24*time.Hour)
+	withStubLoginRun(t, func(context.Context, login.RunOpts) (login.Result, error) {
+		return login.Result{}, login.ErrAborted
+	})
+
+	exported := 0
+	withStubHistoryExporter(t, &exported)
+	var stdout, stderr bytes.Buffer
+	err := historyImport(historyImportOptions{
+		Agent: history.AgentClaudeCode,
+		Since: historyFixedNow.Add(-history.DefaultSinceWindow),
+		All:   true,
+		Yes:   true,
+	}, true, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "nothing was imported") {
+		t.Fatalf("historyImport error = %v", err)
+	}
+	if exported != 0 {
+		t.Fatalf("exported %d turns, want none", exported)
+	}
+}
+
+func TestHistoryImportNonInteractiveMissingCredentialsDoesNotPrompt(t *testing.T) {
+	withHistoryNow(t)
+	isolateDotenvHome(t)
+	writeClaudeHistory(t, "sess-recent", 24*time.Hour)
+	t.Setenv(envconfig.PreferredKey("ENDPOINT"), "https://agento11y.example.com")
+	withStubLoginRun(t, func(context.Context, login.RunOpts) (login.Result, error) {
+		t.Fatal("non-interactive import must not prompt")
+		return login.Result{}, nil
+	})
+
+	_, stderr, code := runHistory(t, "history", "import", "claude-code", "--all", "--yes")
+	if code == nil || *code != 1 {
+		t.Fatalf("exit = %v, want 1 (stderr=%q)", code, stderr)
+	}
+	want := "history: no credentials configured for import (run `agento11y login` or use --local)"
+	if !strings.Contains(stderr, want) {
+		t.Fatalf("stderr = %q, want it to contain %q", stderr, want)
+	}
+}
+
+func TestHistoryImportLoopbackEndpointSkipsSetup(t *testing.T) {
+	withHistoryNow(t)
+	isolateDotenvHome(t)
+	writeClaudeHistory(t, "sess-recent", 24*time.Hour)
+
+	exported := 0
+	writeHistoryConfig(t, envconfig.PreferredKey("ENDPOINT")+"="+newCountingIngest(t, &exported)+"\n")
+	withStubLoginRun(t, func(context.Context, login.RunOpts) (login.Result, error) {
+		t.Fatal("a configured loopback endpoint must not prompt")
+		return login.Result{}, nil
+	})
+	prev := historyEnsureLocal
+	t.Cleanup(func() { historyEnsureLocal = prev })
+	historyEnsureLocal = func(context.Context) (string, error) {
+		t.Error("a configured endpoint must not start another local receiver")
+		return "", errors.New("unexpected local receiver start")
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := historyImport(historyImportOptions{
+		Agent: history.AgentClaudeCode,
+		Since: historyFixedNow.Add(-history.DefaultSinceWindow),
+		All:   true,
+		Yes:   true,
+	}, true, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("historyImport: %v", err)
+	}
+	if exported != 1 {
+		t.Fatalf("exported %d turns to the configured endpoint, want 1", exported)
+	}
+}
+
+func TestHistoryLocalReceiverFailureNamesTheSetting(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     historyImportOptions
+		wantHint bool
+	}{
+		{
+			name:     "environment selected local mode",
+			opts:     historyImportOptions{Local: true, LocalEnvKey: envconfig.LegacyKey("LOCAL")},
+			wantHint: true,
+		},
+		{
+			name: "local flag selected local mode",
+			opts: historyImportOptions{Local: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prev := historyEnsureLocal
+			t.Cleanup(func() { historyEnsureLocal = prev })
+			historyEnsureLocal = func(context.Context) (string, error) {
+				return "", errors.New("agento11y local receiver is not supported on Windows")
+			}
+
+			_, err := historyTarget(context.Background(), tt.opts)
+			if err == nil {
+				t.Fatal("historyTarget() error = nil, want the receiver failure")
+			}
+			if !strings.Contains(err.Error(), "start the local receiver") {
+				t.Errorf("error = %q, want it to name the failed step", err)
+			}
+			hasHint := strings.Contains(err.Error(), envconfig.LegacyKey("LOCAL")) && strings.Contains(err.Error(), "--no-local")
+			if hasHint != tt.wantHint {
+				t.Errorf("error = %q, setting hint = %v, want %v", err, hasHint, tt.wantHint)
+			}
+		})
+	}
+}
+
+func TestHistoryImportReportsTheConfigEnvSpelling(t *testing.T) {
+	withHistoryNow(t)
+	isolateDotenvHome(t)
+	writeClaudeHistory(t, "sess-recent", 24*time.Hour)
+	writeHistoryConfig(t, "SIGIL_LOCAL=true\n")
+	prev := historyEnsureLocal
+	t.Cleanup(func() { historyEnsureLocal = prev })
+	historyEnsureLocal = func(context.Context) (string, error) {
+		return "", errors.New("no receiver here")
+	}
+
+	_, stderr, code := runHistory(t, "history", "import", "claude-code", "--all", "--yes")
+	if code == nil || *code != 1 {
+		t.Fatalf("exit = %v, want 1 (stderr=%q)", code, stderr)
+	}
+	for _, want := range []string{"start the local receiver", envconfig.LegacyKey("LOCAL"), "--no-local"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr = %q, want it to contain %q", stderr, want)
+		}
 	}
 }
 
@@ -482,6 +982,30 @@ func TestHistorySessionLabelCarriesNoPromptText(t *testing.T) {
 	})
 	if !strings.Contains(label, "/work/repo") || !strings.Contains(label, "about 12 turns") {
 		t.Fatalf("label = %q, want the workspace and an approximate turn count", label)
+	}
+}
+
+func writeHistoryConfig(t *testing.T, contents string) {
+	t.Helper()
+	configDir := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "agento11y")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.env"), []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setHistoryCloudCredentials(t *testing.T, endpoint string) {
+	t.Helper()
+	t.Setenv(envconfig.PreferredKey("ENDPOINT"), endpoint)
+	t.Setenv(envconfig.PreferredKey("AUTH_TENANT_ID"), "tenant")
+	t.Setenv(envconfig.PreferredKey("AUTH_TOKEN"), "token")
+	prev := historyEnsureLocal
+	t.Cleanup(func() { historyEnsureLocal = prev })
+	historyEnsureLocal = func(context.Context) (string, error) {
+		t.Error("Cloud import tried to start the local receiver")
+		return "", errors.New("unexpected local receiver start")
 	}
 }
 

--- a/plugins/agento11y/internal/login/login.go
+++ b/plugins/agento11y/internal/login/login.go
@@ -307,6 +307,10 @@ type RunOpts struct {
 	// credentials. The caller leaves it false when a destination is already set.
 	OfferLocal bool
 
+	// KeepLocalSetting leaves the saved LOCAL family unchanged after Cloud
+	// setup. One-run Cloud overrides set it so later runs still use local mode.
+	KeepLocalSetting bool
+
 	// Stdin is consulted for the TTY check. nil resolves to os.Stdin.
 	Stdin *os.File
 
@@ -447,8 +451,10 @@ func Run(ctx context.Context, opts RunOpts) (Result, error) {
 	}
 
 	updates := buildUpdates(v)
-	updates[envconfig.PreferredKey("LOCAL")] = "false"
-	updates[envconfig.LegacyKey("LOCAL")] = "false"
+	if !opts.KeepLocalSetting {
+		updates[envconfig.PreferredKey("LOCAL")] = "false"
+		updates[envconfig.LegacyKey("LOCAL")] = "false"
+	}
 	if err := dotenv.WriteDotenv(configPath, updates, opts.Logger); err != nil {
 		return Result{}, err
 	}

--- a/plugins/agento11y/internal/login/login_test.go
+++ b/plugins/agento11y/internal/login/login_test.go
@@ -1890,6 +1890,38 @@ func TestRun_ExplicitValues(t *testing.T) {
 			},
 		},
 		{
+			name: "one-run Cloud override keeps saved local mode",
+			file: existing + "AGENTO11Y_LOCAL=true\nSIGIL_LOCAL=true\n",
+			env: map[string]string{
+				"AGENTO11Y_LOCAL": "true",
+				"SIGIL_LOCAL":     "true",
+			},
+			opts: RunOpts{
+				Endpoint:         "https://new.example",
+				TenantID:         "222",
+				Token:            "new-token",
+				KeepLocalSetting: true,
+			},
+			want: map[string]string{
+				"AGENTO11Y_AUTH_TOKEN": "new-token",
+				"AGENTO11Y_LOCAL":      "true",
+				"SIGIL_LOCAL":          "true",
+			},
+		},
+		{
+			name: "one-run Cloud override does not save a local setting",
+			opts: RunOpts{
+				Endpoint:         "https://new.example",
+				TenantID:         "222",
+				Token:            "new-token",
+				KeepLocalSetting: true,
+			},
+			want: map[string]string{
+				"AGENTO11Y_LOCAL": "",
+				"SIGIL_LOCAL":     "",
+			},
+		},
+		{
 			name: "otlp endpoint is persisted",
 			opts: RunOpts{
 				Endpoint:     "https://new.example",

--- a/plugins/agento11y/internal/skills/content/setup-coding-agent/SKILL.md
+++ b/plugins/agento11y/internal/skills/content/setup-coding-agent/SKILL.md
@@ -385,7 +385,7 @@ All hosts read the resolved config path. The default is
 | `AGENTO11Y_GUARDS_ENABLED` | Send supported preflight and tool calls for guard evaluation |
 | `AGENTO11Y_GUARDS_TIMEOUT_MS` | Guard evaluation timeout in milliseconds |
 | `AGENTO11Y_GUARDS_FAIL_OPEN` | Allow the operation when guard evaluation fails |
-| `AGENTO11Y_LOCAL` | Route `agento11y <agent>` launches and agento11y hooks to the local daemon, and skip the destination question |
+| `AGENTO11Y_LOCAL` | A true value routes `agento11y <agent>` launches, agento11y hooks, and history imports to the local daemon |
 | `AGENTO11Y_LOCAL_FORWARD` | Forward local-mode captures to Grafana Cloud |
 | `AGENTO11Y_AUTO_UPDATE` | A false value opts out of host-plugin refresh |
 | `AGENTO11Y_DEBUG` | A true value writes the debug log |
@@ -465,25 +465,24 @@ configured `AGENTO11Y_LOCAL`.
 
 ### History import
 
-The viewer and Grafana Cloud both start empty: they hold only sessions captured
-after the install. `agento11y history import` backfills sessions an agent
-already wrote to disk. Supported agents are `claude-code`, `codex`, and `pi`.
+Until an import runs, the viewer and Grafana Cloud hold only sessions captured after installation.
+`agento11y history import` backfills sessions `claude-code`, `codex`, `cursor`, or `pi` already wrote to disk.
 
 ```sh
-agento11y history import claude-code --dry-run   # plan only, nothing exported
-agento11y history import claude-code --local     # use the local daemon
-agento11y history import claude-code             # use AGENTO11Y_ENDPOINT
+agento11y history import claude-code --dry-run   # plan only; no setup or export
+agento11y history import claude-code --local     # import into the local store
+agento11y history import claude-code --no-local  # import into Grafana Cloud
 ```
 
-Without `--since`, an import selects sessions active during the last 90 days.
-Each imported turn is recorded in a per-agent ledger. The ledger does not include
-the destination. If the same turns must go first to local storage and later to
-Grafana Cloud, use `--force` for the second import; otherwise the ledger skips
-them. A cancelled or failed run resumes from turns not marked exported.
+The import resolves the destination in this order: `--no-local`, `--local`, a true
+`AGENTO11Y_LOCAL`/`SIGIL_LOCAL` value from the shell or `config.env`, then saved Cloud credentials.
+With none set, an interactive run asks where sessions go. `--no-local` or any valid LOCAL value
+skips that question; missing Cloud credentials still starts Cloud setup. A noninteractive run never
+asks. It imports only with both `--all` and `--yes`; otherwise it prints a dry-run plan and exits 0.
 
-Without a terminal there is no picker or confirmation. Without `--all --yes`,
-the command prints a dry-run plan, imports nothing, and exits 0. Pass both flags
-from a script that should export data.
+Without `--since`, an import selects sessions active during the last 90 days. Each imported turn goes into a per-agent ledger that omits the destination.
+To send the same turns to another destination, add `--force` to the second import. If saved local mode would keep that import local, add `--no-local` too.
+A cancelled or failed run resumes from turns not marked exported.
 
 ### Auto-update
 


### PR DESCRIPTION
History imports now support `--no-local`, `--local` and `AGENTO11Y_LOCAL`. Interactive imports use the first-run login flow when no destination is configured, while non interactive imports never prompt.