### PR TITLE
fix(python): update experiment runner attributes

### DIFF
--- a/conformance/experiments/README.md
+++ b/conformance/experiments/README.md
@@ -45,9 +45,9 @@ Every dynamic path segment is percent-encoded with no safe characters. Go's
 `:evaluate` verb off the raw path segment before it decodes the trial id, so an
 unescaped colon inside an id would change which route the request reaches.
 
-The run key is `experiment_id` on the wire. Go and Python expose it as `run_id` on
-their types, JavaScript as `runId`, but the ingest route keys on `experiment_id`
-and rejects unknown fields, so the rename happens at serialization.
+The run key is `experiment_id` on the wire. Python exposes the same canonical
+name. Go and JavaScript retain language-specific client model names, but the
+ingest route keys on `experiment_id` and rejects unknown fields.
 
 Blank optional fields are omitted, not sent empty. `trial_create` carries only the
 four fields the route requires. `trial_evaluate_latest_version` shows the same

--- a/llms.txt
+++ b/llms.txt
@@ -497,6 +497,10 @@ a stored test suite.
 - Use `trial.record_io(...)` when the harness owns candidate I/O, or
   `bind_generation`/`bind_conversation`/`bind_trace` when normal instrumentation
   already emitted it.
+- Pass `online_evaluations_enabled=True` to opt experiment generations into
+  matching automatic online evaluation rules. When omitted, the SDK omits the
+  field and the server defaults it to `False`; explicit on-demand trial
+  evaluation remains available for either policy.
 - Local `LLMJudge` and `RegexJudge` helpers do not require an evaluator created
   in Grafana. Frameworks can submit their native grader result and transcript
   through `trial.record_evaluation(...)`.

--- a/python/README.md
+++ b/python/README.md
@@ -758,6 +758,12 @@ to `exp.finalize(...)` only when you want the server to assert an exact count.
 A/B testing is two runs with different `experiment_id`/`tags` over the same
 suite and evaluators.
 
+Pass `online_evaluations_enabled=True` to apply matching automatic online
+evaluation rules to generations recorded by the experiment. When omitted, the
+SDK leaves the field out and the server defaults it to `False`; on-demand trial
+evaluation remains available either way. Pass `False` explicitly when the
+request should assert the disabled policy for an existing experiment ID.
+
 Experiment writes use the same Grafana Cloud ingestion API key as generation
 ingest. They do not require a control-plane URL or a separate eval API key.
 Experiment transcripts, string scores, explanations, metadata, and text

--- a/python/agento11y/_experiments_transport.py
+++ b/python/agento11y/_experiments_transport.py
@@ -4,23 +4,23 @@ External writes go through the ingest lifecycle on the same tenant token used
 for generation export:
 
   POST   /api/v1/experiment-runs:upsert              create or claim an external run
-  POST   /api/v1/experiment-runs/{run_id}:finalize   finalize an external run
-  POST   /api/v1/scores:export                       publish scores (attribute via run_id)
-  POST   /api/v1/experiment-runs/{run_id}/trials     create or claim a typed trial
-  PATCH  /api/v1/experiment-runs/{run_id}/trials/{trial_id}
+  POST   /api/v1/experiment-runs/{experiment_id}:finalize   finalize an external run
+  POST   /api/v1/scores:export                       publish scores
+  POST   /api/v1/experiment-runs/{experiment_id}/trials     create or claim a typed trial
+  PATCH  /api/v1/experiment-runs/{experiment_id}/trials/{trial_id}
                                                         update a typed trial
-  POST   /api/v1/experiment-runs/{run_id}/trials/{trial_id}/artifacts:upload
+  POST   /api/v1/experiment-runs/{experiment_id}/trials/{trial_id}/artifacts:upload
                                                         attach a trial artifact
-  POST   /api/v1/experiment-runs/{run_id}/trials/{trial_id}:evaluate
+  POST   /api/v1/experiment-runs/{experiment_id}/trials/{trial_id}:evaluate
                                                         run a stored evaluator
-  GET    /api/v1/experiment-runs/{run_id}/trials/{trial_id}/evaluations/{evaluation_id}
+  GET    /api/v1/experiment-runs/{experiment_id}/trials/{trial_id}/evaluations/{evaluation_id}
                                                         read evaluator work status
 
 Reads use the Agent Observability query routes with the same configured endpoint and auth:
 
-  GET    /api/v1/eval/experiments/{run_id}           fetch a run
-  GET    /api/v1/eval/experiments/{run_id}/scores    list run scores (paginated)
-  GET    /api/v1/eval/experiments/{run_id}/report    aggregated run report
+  GET    /api/v1/eval/experiments/{experiment_id}           fetch a run
+  GET    /api/v1/eval/experiments/{experiment_id}/scores    list run scores (paginated)
+  GET    /api/v1/eval/experiments/{experiment_id}/report    aggregated run report
 
 The functions here are thin; :class:`agento11y.client.Client` wraps them with
 resolved endpoint, insecure flag, and auth headers.
@@ -122,13 +122,13 @@ def get_experiment(
     api_endpoint: str,
     insecure: bool,
     headers: dict[str, str],
-    run_id: str,
+    experiment_id: str,
     path_prefix: str = _DEFAULT_PATH_PREFIX,
     retry: RetryPolicy | None = None,
 ) -> Experiment:
     """Fetches a single experiment run by id."""
 
-    url = _experiment_url(api_endpoint, insecure, run_id, path_prefix)
+    url = _experiment_url(api_endpoint, insecure, experiment_id, path_prefix)
     body = _request_json("GET", url, headers, None, retry, ExperimentTransportError, "experiment get")
     return _parse_experiment(body)
 
@@ -138,7 +138,7 @@ def finalize_experiment(
     api_endpoint: str,
     insecure: bool,
     headers: dict[str, str],
-    run_id: str,
+    experiment_id: str,
     status: ExperimentStatus | str,
     score_count: int | None = None,
     error: str | None = None,
@@ -153,10 +153,10 @@ def finalize_experiment(
         normalized_status = "completed"
     elif normalized_status != "failed":
         raise ValidationError("agento11y experiment validation failed: status must be completed or failed")
-    normalized_run_id = _validate_run_id(run_id)
+    normalized_experiment_id = _validate_experiment_id(experiment_id)
     url = (
         _base_url(api_endpoint, insecure)
-        + f"{_EXPERIMENT_RUNS_PREFIX}/{urllib_parse.quote(normalized_run_id, safe='')}:finalize"
+        + f"{_EXPERIMENT_RUNS_PREFIX}/{urllib_parse.quote(normalized_experiment_id, safe='')}:finalize"
     )
     payload: dict[str, Any] = {
         "status": normalized_status,
@@ -179,7 +179,7 @@ def export_scores(
     scores_path: str = _SCORES_EXPORT_PATH,
     retry: RetryPolicy | None = None,
 ) -> ExportScoresResponse:
-    """Publishes scores; set ``run_id`` on each score to attribute it to a run.
+    """Publishes scores; set ``experiment_id`` on each score to attribute it to a run.
 
     ``scores_path`` defaults to the direct ingest path; on Grafana Cloud it is
     the plugin proxy's score route (``.../eval/scores:export``).
@@ -244,7 +244,7 @@ def create_test_case_trial(
     the tenant ingest credential (no Grafana actor required).
     """
 
-    normalized = _validate_run_id(experiment_id)
+    normalized = _validate_experiment_id(experiment_id)
     url = (
         _base_url(api_endpoint, insecure)
         + f"{_EXPERIMENT_RUNS_PREFIX}/{urllib_parse.quote(normalized, safe='')}/trials"
@@ -269,12 +269,14 @@ def update_test_case_trial(
     normalized = (trial_id or "").strip()
     if normalized == "":
         raise ValidationError("agento11y test case trial validation failed: trial_id is required")
-    run_id = (experiment_id or "").strip()
-    if run_id == "":
+    normalized_experiment_id = (experiment_id or "").strip()
+    if normalized_experiment_id == "":
         raise ValidationError("agento11y test case trial validation failed: experiment_id is required for trial update")
-    quoted_run_id = urllib_parse.quote(run_id, safe="")
+    quoted_experiment_id = urllib_parse.quote(normalized_experiment_id, safe="")
     quoted_trial_id = urllib_parse.quote(normalized, safe="")
-    url = _base_url(api_endpoint, insecure) + f"{_EXPERIMENT_RUNS_PREFIX}/{quoted_run_id}/trials/{quoted_trial_id}"
+    url = (
+        _base_url(api_endpoint, insecure) + f"{_EXPERIMENT_RUNS_PREFIX}/{quoted_experiment_id}/trials/{quoted_trial_id}"
+    )
     body = _request_json("PATCH", url, headers, request, retry, ExperimentTransportError, "test case trial update")
     return body if isinstance(body, dict) else {}
 
@@ -292,7 +294,7 @@ def trigger_trial_evaluation(
 ) -> TrialEvaluation:
     """Queues a stored evaluator for a trial's bound conversation."""
 
-    run_id, normalized_trial_id = _validate_trial_evaluation_path(experiment_id, trial_id)
+    normalized_experiment_id, normalized_trial_id = _validate_trial_evaluation_path(experiment_id, trial_id)
     normalized_evaluator_id = (evaluator_id or "").strip()
     if normalized_evaluator_id == "":
         raise ValidationError("agento11y trial evaluation validation failed: evaluator_id is required")
@@ -302,7 +304,7 @@ def trigger_trial_evaluation(
         payload["evaluator_version"] = normalized_version
     url = (
         _base_url(api_endpoint, insecure)
-        + f"{_EXPERIMENT_RUNS_PREFIX}/{urllib_parse.quote(run_id, safe='')}/trials/"
+        + f"{_EXPERIMENT_RUNS_PREFIX}/{urllib_parse.quote(normalized_experiment_id, safe='')}/trials/"
         + f"{urllib_parse.quote(normalized_trial_id, safe='')}:evaluate"
     )
     body = _request_json("POST", url, headers, payload, retry, ExperimentTransportError, "trial evaluation trigger")
@@ -321,13 +323,13 @@ def get_trial_evaluation(
 ) -> TrialEvaluation:
     """Reads durable status for a triggered trial evaluation."""
 
-    run_id, normalized_trial_id = _validate_trial_evaluation_path(experiment_id, trial_id)
+    normalized_experiment_id, normalized_trial_id = _validate_trial_evaluation_path(experiment_id, trial_id)
     normalized_evaluation_id = (evaluation_id or "").strip()
     if normalized_evaluation_id == "":
         raise ValidationError("agento11y trial evaluation validation failed: evaluation_id is required")
     url = (
         _base_url(api_endpoint, insecure)
-        + f"{_EXPERIMENT_RUNS_PREFIX}/{urllib_parse.quote(run_id, safe='')}/trials/"
+        + f"{_EXPERIMENT_RUNS_PREFIX}/{urllib_parse.quote(normalized_experiment_id, safe='')}/trials/"
         + f"{urllib_parse.quote(normalized_trial_id, safe='')}/evaluations/"
         + urllib_parse.quote(normalized_evaluation_id, safe="")
     )
@@ -350,8 +352,8 @@ def upload_trial_artifact(
 ) -> dict[str, Any]:
     """Uploads raw artifact bytes to the experiment-run ingest route."""
 
-    run_id = (experiment_id or "").strip()
-    if run_id == "":
+    normalized_experiment_id = (experiment_id or "").strip()
+    if normalized_experiment_id == "":
         raise ValidationError("agento11y artifact validation failed: experiment_id is required")
     normalized_trial_id = (trial_id or "").strip()
     if normalized_trial_id == "":
@@ -369,7 +371,7 @@ def upload_trial_artifact(
     query = urllib_parse.urlencode({"name": normalized_name, "kind": normalized_kind, "mime": (mime or "").strip()})
     url = (
         _base_url(api_endpoint, insecure)
-        + f"{_EXPERIMENT_RUNS_PREFIX}/{urllib_parse.quote(run_id, safe='')}/trials/"
+        + f"{_EXPERIMENT_RUNS_PREFIX}/{urllib_parse.quote(normalized_experiment_id, safe='')}/trials/"
         + f"{urllib_parse.quote(normalized_trial_id, safe='')}/artifacts:upload?{query}"
     )
     request_headers = {**(headers or {}), "Content-Type": (mime or "").strip() or "application/octet-stream"}
@@ -390,7 +392,7 @@ def list_experiment_scores(
     api_endpoint: str,
     insecure: bool,
     headers: dict[str, str],
-    run_id: str,
+    experiment_id: str,
     limit: int = 50,
     cursor: str | None = None,
     path_prefix: str = _DEFAULT_PATH_PREFIX,
@@ -401,7 +403,7 @@ def list_experiment_scores(
     Score items are returned as decoded JSON dicts for this first iteration.
     """
 
-    base = _experiment_url(api_endpoint, insecure, run_id, path_prefix) + "/scores"
+    base = _experiment_url(api_endpoint, insecure, experiment_id, path_prefix) + "/scores"
     query: dict[str, str] = {"limit": str(limit)}
     if cursor:
         query["cursor"] = cursor
@@ -417,13 +419,13 @@ def get_experiment_report(
     api_endpoint: str,
     insecure: bool,
     headers: dict[str, str],
-    run_id: str,
+    experiment_id: str,
     path_prefix: str = _DEFAULT_PATH_PREFIX,
     retry: RetryPolicy | None = None,
 ) -> ExperimentReport:
     """Fetches the aggregated report for a run."""
 
-    url = _experiment_url(api_endpoint, insecure, run_id, path_prefix) + "/report"
+    url = _experiment_url(api_endpoint, insecure, experiment_id, path_prefix) + "/report"
     body = _request_json("GET", url, headers, None, retry, ExperimentTransportError, "experiment report")
     return _parse_report(body)
 
@@ -443,10 +445,8 @@ def _serialize_upsert_request(request: CreateExperimentRequest) -> dict[str, Any
         "name": request.name.strip(),
         "source": dict(_EXPERIMENT_RUN_SOURCE),
     }
-    # The backend ingest route keys on `experiment_id`, not `run_id`, and rejects
-    # unknown fields. `CreateExperimentRequest.run_id` is the client-side spelling.
-    if request.run_id:
-        out["experiment_id"] = request.run_id
+    if request.experiment_id:
+        out["experiment_id"] = request.experiment_id
     if request.description:
         out["description"] = request.description
     if request.tags:
@@ -461,6 +461,8 @@ def _serialize_upsert_request(request: CreateExperimentRequest) -> dict[str, Any
         if request.planned_trial_count < 0:
             raise ValidationError("agento11y experiment validation failed: planned_trial_count must be non-negative")
         out["planned_trial_count"] = request.planned_trial_count
+    if request.online_evaluations_enabled is not None:
+        out["online_evaluations_enabled"] = request.online_evaluations_enabled
     if request.metadata:
         out["metadata"] = dict(request.metadata)
     return out
@@ -478,8 +480,7 @@ def _serialize_score(score: ScoreItem) -> dict[str, Any]:
         out["generation_id"] = score.generation_id
     if score.conversation_id:
         out["conversation_id"] = score.conversation_id
-    # `experiment_id` is the canonical run key; `run_id` is a client-side alias.
-    experiment_id = score.resolved_experiment_id
+    experiment_id = score.experiment_id.strip()
     if experiment_id:
         out["experiment_id"] = experiment_id
     if score.trial_id:
@@ -578,7 +579,7 @@ def _parse_experiment(payload: Any) -> Experiment:
     if not isinstance(payload, dict):
         raise ExperimentTransportError("agento11y experiment transport failed: invalid response payload")
     return Experiment(
-        run_id=_str(payload.get("experiment_id")) or _str(payload.get("run_id")),
+        experiment_id=_str(payload.get("experiment_id")),
         name=_str(payload.get("name")),
         status=_str(payload.get("status")),
         tenant_id=_str(payload.get("tenant_id")),
@@ -592,6 +593,7 @@ def _parse_experiment(payload: Any) -> Experiment:
         planned_trial_count=(
             _int(payload.get("planned_trial_count")) if payload.get("planned_trial_count") is not None else None
         ),
+        online_evaluations_enabled=bool(payload.get("online_evaluations_enabled", False)),
         result_status=_str(payload.get("result_status")),
         result_error=_str(payload.get("result_error")),
         result=_parse_report_summary(payload.get("result")) if isinstance(payload.get("result"), dict) else None,
@@ -846,26 +848,26 @@ def _experiments_url(endpoint: str, insecure: bool, path_prefix: str) -> str:
     return _base_url(endpoint, insecure) + prefix + _EVAL_EXPERIMENTS_SUFFIX
 
 
-def _experiment_url(endpoint: str, insecure: bool, run_id: str, path_prefix: str) -> str:
-    normalized = _validate_run_id(run_id)
+def _experiment_url(endpoint: str, insecure: bool, experiment_id: str, path_prefix: str) -> str:
+    normalized = _validate_experiment_id(experiment_id)
     return f"{_experiments_url(endpoint, insecure, path_prefix)}/{urllib_parse.quote(normalized, safe='')}"
 
 
-def _validate_run_id(run_id: str) -> str:
-    normalized = (run_id or "").strip()
+def _validate_experiment_id(experiment_id: str) -> str:
+    normalized = (experiment_id or "").strip()
     if normalized == "":
-        raise ValidationError("agento11y experiment validation failed: run_id is required")
+        raise ValidationError("agento11y experiment validation failed: experiment_id is required")
     return normalized
 
 
 def _validate_trial_evaluation_path(experiment_id: str, trial_id: str) -> tuple[str, str]:
-    run_id = (experiment_id or "").strip()
-    if run_id == "":
+    normalized_experiment_id = (experiment_id or "").strip()
+    if normalized_experiment_id == "":
         raise ValidationError("agento11y trial evaluation validation failed: experiment_id is required")
     normalized_trial_id = (trial_id or "").strip()
     if normalized_trial_id == "":
         raise ValidationError("agento11y trial evaluation validation failed: trial_id is required")
-    return run_id, normalized_trial_id
+    return normalized_experiment_id, normalized_trial_id
 
 
 def _base_url(endpoint: str, insecure: bool) -> str:

--- a/python/agento11y/config.py
+++ b/python/agento11y/config.py
@@ -54,9 +54,7 @@ _LEGACY_ENV_ALIASES: dict[str, tuple[str, ...]] = {
     "CONTENT_CAPTURE_MODE": ("SIGIL_CONTENT_CAPTURE_MODE",),
     "DEBUG": ("SIGIL_DEBUG",),
     "ENDPOINT": ("SIGIL_ENDPOINT", "SIGIL_API_ENDPOINT"),
-    # SIGIL_RUN_ID is the pre-rename name of the experiment id, kept last so a
-    # SIGIL_EXPERIMENT_ID set beside it still wins. Go does the same.
-    "EXPERIMENT_ID": ("SIGIL_EXPERIMENT_ID", "SIGIL_RUN_ID"),
+    "EXPERIMENT_ID": ("SIGIL_EXPERIMENT_ID",),
     "GRAFANA_URL": ("SIGIL_GRAFANA_URL",),
     "HEADERS": ("SIGIL_HEADERS",),
     "INGEST_ACTOR": ("SIGIL_INGEST_ACTOR",),

--- a/python/agento11y/experiments/client.py
+++ b/python/agento11y/experiments/client.py
@@ -114,7 +114,7 @@ class Client:
 
         return _transport.finalize_experiment(
             **self._args(),
-            run_id=experiment_id,
+            experiment_id=experiment_id,
             status=status,
             score_count=score_count,
             error=error or None,
@@ -458,7 +458,7 @@ class Client:
     def get_report(self, experiment_id: str) -> ExperimentReport:
         """Fetches the aggregated report for a run."""
 
-        return _transport.get_experiment_report(**self._args(), run_id=experiment_id, retry=self._retry)
+        return _transport.get_experiment_report(**self._args(), experiment_id=experiment_id, retry=self._retry)
 
     def list_scores(
         self, experiment_id: str, *, limit: int = 50, cursor: str | None = None
@@ -466,7 +466,7 @@ class Client:
         """Lists stored scores for a run."""
 
         return _transport.list_experiment_scores(
-            **self._args(), run_id=experiment_id, limit=limit, cursor=cursor, retry=self._retry
+            **self._args(), experiment_id=experiment_id, limit=limit, cursor=cursor, retry=self._retry
         )
 
     # --- links ------------------------------------------------------------ #

--- a/python/agento11y/experiments/experiment.py
+++ b/python/agento11y/experiments/experiment.py
@@ -724,13 +724,13 @@ class Trial:
                 operation_name=grader.operation_name,
                 usage=grader.usage,
                 tags={
-                    "experiment.run_id": self.ref.experiment_id,
+                    "experiment_id": self.ref.experiment_id,
                     "test.case.id": self.ref.test_case_id,
                     "test.case.attempt": str(self.ref.attempt),
                     "evaluator.id": result.evaluator.evaluator_id,
                 },
                 metadata={
-                    "experiment_run_id": self.ref.experiment_id,
+                    "experiment_id": self.ref.experiment_id,
                     "test_case_id": self.ref.test_case_id,
                     "attempt": self.ref.attempt,
                     **result.metadata,
@@ -1051,9 +1051,12 @@ class Trial:
             agent_version=self._io.get("agent_version", (cand.agent_version if cand else "")),
             input_tokens=self._io.get("input_tokens"),
             output_tokens=self._io.get("output_tokens"),
-            tags={"experiment.run_id": self.ref.experiment_id, "task_id": self.ref.test_case_id},
+            tags={
+                "experiment_id": self.ref.experiment_id,
+                "task_id": self.ref.test_case_id,
+            },
             metadata={
-                "experiment_run_id": self.ref.experiment_id,
+                "experiment_id": self.ref.experiment_id,
                 "task_id": self.ref.test_case_id,
                 "trial_id": self.trial_id,
                 "attempt": self.ref.attempt,
@@ -1109,6 +1112,7 @@ class Experiment:
         tags: list[str] | None = None,
         metadata: dict[str, Any] | None = None,
         planned_trial_count: int | None = None,
+        online_evaluations_enabled: bool | None = None,
         auto_finalize: bool = True,
         use_experimental_otel: bool | None = None,
     ) -> None:
@@ -1124,6 +1128,7 @@ class Experiment:
         self._tags = list(tags or [])
         self._metadata = dict(metadata or {})
         self.planned_trial_count = planned_trial_count
+        self.online_evaluations_enabled = online_evaluations_enabled
         self._auto_finalize = auto_finalize
         self._use_experimental_otel = (
             bool(use_experimental_otel)
@@ -1136,11 +1141,6 @@ class Experiment:
         self._open_trials: dict[str, Trial] = {}
         self._claimed_trial_ids: set[str] = set()
         self._owns_client = False  # set by the experiment() factory when it built the client
-
-    # alias: many callers spell the identifier ``run_id``
-    @property
-    def run_id(self) -> str:
-        return self.experiment_id
 
     @property
     def client(self) -> Client:
@@ -1163,7 +1163,7 @@ class Experiment:
             metadata.update(candidate_metadata)
         self._client.upsert_experiment(
             CreateExperimentRequest(
-                run_id=self.experiment_id,
+                experiment_id=self.experiment_id,
                 name=self.name,
                 source="external",
                 description=self.description,
@@ -1172,6 +1172,7 @@ class Experiment:
                 suite_version=suite_version,
                 candidate=candidate_metadata,
                 planned_trial_count=self.planned_trial_count,
+                online_evaluations_enabled=self.online_evaluations_enabled,
                 metadata=metadata,
             )
         )
@@ -1345,6 +1346,7 @@ def experiment(
     tags: list[str] | None = None,
     metadata: dict[str, Any] | None = None,
     planned_trial_count: int | None = None,
+    online_evaluations_enabled: bool | None = None,
 ) -> Experiment:
     """Opens a cloud experiment, building a client from the environment.
 
@@ -1395,6 +1397,7 @@ def experiment(
         tags=tags,
         metadata=metadata,
         planned_trial_count=planned_trial_count,
+        online_evaluations_enabled=online_evaluations_enabled,
         use_experimental_otel=use_experimental_otel,
     )
     exp._owns_client = owns_client
@@ -1423,6 +1426,7 @@ def experiment_from_suite(
     tags: list[str] | None = None,
     metadata: dict[str, Any] | None = None,
     planned_trial_count: int | None = None,
+    online_evaluations_enabled: bool | None = None,
 ) -> Experiment:
     """Pulls a stored suite and opens an experiment linked to that exact version.
 
@@ -1458,4 +1462,5 @@ def experiment_from_suite(
         tags=tags,
         metadata=metadata,
         planned_trial_count=planned_trial_count,
+        online_evaluations_enabled=online_evaluations_enabled,
     )

--- a/python/agento11y/experiments/otel.py
+++ b/python/agento11y/experiments/otel.py
@@ -72,7 +72,7 @@ EVAL_REFERENCE_SET_VERSION = "gen_ai.evaluation.reference_set.version"
 # Trial / suite identity on the trial span (test.* family)
 # --------------------------------------------------------------------------- #
 
-TEST_SUITE_RUN_ID = "test.suite.run.id"  # proposed for genai (#79) = experiment/run id
+TEST_SUITE_RUN_ID = "test.suite.run.id"  # proposed for genai (#79) = experiment id
 TEST_SUITE_NAME = "test.suite.name"  # merged (general OTel)
 TEST_SUITE_RUN_STATUS = "test.suite.run.status"  # merged (general OTel)
 TEST_SUITE_ID = "test.suite.id"  # proposed (Grafana) — suite identity distinct from name

--- a/python/agento11y/experiments/types.py
+++ b/python/agento11y/experiments/types.py
@@ -305,8 +305,7 @@ ENV_TRAJECTORY_ID = "AGENTO11Y_TRAJECTORY_ID"
 
 # Pre-rename spellings. ``to_env`` writes them beside the canonical names so a
 # child process running an older SDK build still receives the trial context;
-# ``from_env`` accepts them through the config resolver, which also honours
-# SIGIL_RUN_ID for the experiment id.
+# ``from_env`` accepts them through the config resolver.
 LEGACY_ENV_EXPERIMENT_ID = "SIGIL_EXPERIMENT_ID"
 LEGACY_ENV_TEST_CASE_ID = "SIGIL_TEST_CASE_ID"
 LEGACY_ENV_ATTEMPT = "SIGIL_ATTEMPT"
@@ -340,11 +339,6 @@ class TrialRef:
     test_case_name: str = ""
     trajectory_id: str = ""
 
-    # Backwards-compatible alias: some callers spell the run id ``run_id``.
-    @property
-    def run_id(self) -> str:
-        return self.experiment_id
-
     def to_json(self) -> dict[str, Any]:
         return {
             "experiment_id": self.experiment_id,
@@ -359,7 +353,7 @@ class TrialRef:
 
     @classmethod
     def from_json(cls, payload: dict[str, Any]) -> TrialRef:
-        experiment_id = str(payload.get("experiment_id") or payload.get("run_id") or "").strip()
+        experiment_id = str(payload.get("experiment_id") or "").strip()
         return cls(
             experiment_id=experiment_id,
             test_case_id=str(payload.get("test_case_id") or "").strip(),

--- a/python/agento11y/models.py
+++ b/python/agento11y/models.py
@@ -518,10 +518,10 @@ def tool_result_message(tool_call_id: str, content: str) -> Message:
 #
 # These models map to the Agent Observability experiment and score APIs (HTTP):
 #   POST   /api/v1/experiment-runs:upsert
-#   POST   /api/v1/experiment-runs/{run_id}:finalize
-#   GET    /api/v1/eval/experiments/{run_id}
+#   POST   /api/v1/experiment-runs/{experiment_id}:finalize
+#   GET    /api/v1/eval/experiments/{experiment_id}
 #   POST   /api/v1/scores:export
-#   GET    /api/v1/eval/experiments/{run_id}/report
+#   GET    /api/v1/eval/experiments/{experiment_id}/report
 # ---------------------------------------------------------------------------
 
 
@@ -605,11 +605,8 @@ class ScoreSource:
 class ScoreItem:
     """A score to export via ``POST /api/v1/scores:export``.
 
-    The backend keys scores on ``experiment_id`` (the canonical run identifier);
-    set it to attach the score to an experiment report. A score must reference a
-    ``generation_id`` **or** a ``trial_id``. ``run_id`` is accepted as a
-    client-side alias for ``experiment_id`` and is mapped to ``experiment_id`` on
-    the wire — the backend has no ``run_id`` field and rejects unknown fields.
+    Set ``experiment_id`` to attach the score to an experiment report. A score
+    must reference a ``generation_id`` **or** a ``trial_id``.
     """
 
     score_id: str
@@ -628,19 +625,12 @@ class ScoreItem:
     grader_conversation_id: str = ""
     grader_generation_id: str = ""
     grader_trace_id: str = ""
-    run_id: str = ""  # client-side alias for experiment_id (mapped on the wire)
     evaluator_kind: str = ""
     passed: bool | None = None
     explanation: str = ""
     metadata: dict[str, Any] = field(default_factory=dict)
     created_at: datetime | None = None
     source: ScoreSource | None = None
-
-    @property
-    def resolved_experiment_id(self) -> str:
-        """The experiment id to send on the wire (``experiment_id`` or ``run_id``)."""
-
-        return (self.experiment_id or self.run_id or "").strip()
 
 
 @dataclass(slots=True)
@@ -708,13 +698,14 @@ class CreateExperimentRequest:
 
     name: str
     source: ExperimentSource | str = ExperimentSource.EXTERNAL
-    run_id: str = ""
+    experiment_id: str = ""
     description: str = ""
     tags: list[str] = field(default_factory=list)
     suite_id: str = ""
     suite_version: str = ""
     candidate: dict[str, Any] = field(default_factory=dict)
     planned_trial_count: int | None = None
+    online_evaluations_enabled: bool | None = None
     collection_id: str = ""
     evaluators: list[ExperimentEvaluator] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
@@ -724,7 +715,7 @@ class CreateExperimentRequest:
 class Experiment:
     """An experiment run as returned by Agent Observability."""
 
-    run_id: str
+    experiment_id: str
     name: str
     status: str
     tenant_id: str = ""
@@ -736,6 +727,7 @@ class Experiment:
     metadata: dict[str, Any] = field(default_factory=dict)
     error: str = ""
     planned_trial_count: int | None = None
+    online_evaluations_enabled: bool = False
     result_status: str = ""
     result_error: str = ""
     result: ExperimentReportSummary | None = None

--- a/python/tests/test_experiments.py
+++ b/python/tests/test_experiments.py
@@ -174,18 +174,20 @@ def test_experiment_lifecycle_and_score_wire_fields() -> None:
         name="smoke run",
         suite=suite,
         planned_trial_count=3,
+        online_evaluations_enabled=False,
     ) as exp:
         with exp.trial(suite.test_cases[0]) as trial:
             trial.final_score(1.0, passed=True, explanation="matched", evaluator=verifier)
             trial.check_score("json_valid", passed=True)
             trial.rubric_score("helpfulness", 0.9, explanation="clear")
 
-    # Upsert sent experiment_id (not run_id) and source=external.
+    # Upsert sent the canonical experiment identifier and source=external.
     assert len(client.upserts) == 1
-    assert client.upserts[0].run_id == "run-1"
+    assert client.upserts[0].experiment_id == "run-1"
     assert client.upserts[0].suite_id == "smoke"
     assert client.upserts[0].suite_version == "1.2.0"
     assert client.upserts[0].planned_trial_count == 3
+    assert client.upserts[0].online_evaluations_enabled is False
 
     # Three scores, all attributed to the run + trial + test case.
     assert len(client.scores) == 3
@@ -212,7 +214,7 @@ def test_experiment_lifecycle_and_score_wire_fields() -> None:
     for s in client.scores:
         assert s.experiment_id == "run-1"
         assert s.test_case_id == "add"
-        assert s.resolved_experiment_id == "run-1"
+        assert s.experiment_id == "run-1"
         # The typed trial_id attributes the score (the trial was created on enter).
         assert s.trial_id == client.scores[0].trial_id
         assert s.trial_id  # non-empty
@@ -241,6 +243,15 @@ def test_experiment_finalize_can_assert_score_count_explicitly() -> None:
     exp.finalize(score_count=4)
 
     assert client.finalized == [("run-assert", "completed", 4)]
+
+
+def test_experiment_omits_online_evaluation_policy_by_default() -> None:
+    client = FakeClient()
+
+    with Experiment(client, experiment_id="run-default-policy"):
+        pass
+
+    assert client.upserts[0].online_evaluations_enabled is None
 
 
 def test_experiment_rejects_negative_planned_trial_count() -> None:
@@ -282,6 +293,8 @@ def test_llm_judge_evaluates_publishes_transcript_and_links_score() -> None:
     assert generation["input_text"].startswith("Input: 2+2")
     assert generation["input_text"].endswith('Return {"score": 1}')
     assert generation["output_text"].startswith('{"score"')
+    assert generation["tags"]["experiment_id"] == "run-judge"
+    assert generation["metadata"]["experiment_id"] == "run-judge"
 
 
 def test_regex_judge_scores_without_publishing_transcript() -> None:
@@ -699,30 +712,14 @@ def test_trial_ref_from_env_reads_sigil_names_with_warning(caplog: pytest.LogCap
     "env,expected",
     [
         pytest.param(
-            {"SIGIL_RUN_ID": "run-legacy", "SIGIL_TEST_CASE_ID": "c1"},
-            ("run-legacy", "c1"),
-            id="SIGIL_RUN_ID supplies the experiment id",
-        ),
-        pytest.param(
-            {"SIGIL_EXPERIMENT_ID": "run-old", "SIGIL_RUN_ID": "run-older", "SIGIL_TEST_CASE_ID": "c1"},
-            ("run-old", "c1"),
-            id="SIGIL_EXPERIMENT_ID beats SIGIL_RUN_ID",
-        ),
-        pytest.param(
             {
                 "AGENTO11Y_EXPERIMENT_ID": "run-new",
                 "SIGIL_EXPERIMENT_ID": "run-old",
-                "SIGIL_RUN_ID": "run-older",
                 "AGENTO11Y_TEST_CASE_ID": "c-new",
                 "SIGIL_TEST_CASE_ID": "c-old",
             },
             ("run-new", "c-new"),
-            id="canonical wins over every legacy spelling",
-        ),
-        pytest.param(
-            {"AGENTO11Y_RUN_ID": "run-x", "AGENTO11Y_TEST_CASE_ID": "c1"},
-            None,
-            id="AGENTO11Y_RUN_ID is not a name",
+            id="canonical wins over the legacy product prefix",
         ),
     ],
 )
@@ -779,6 +776,8 @@ def test_record_io_mints_real_conversation() -> None:
         conv = trial.conversation_id
     assert conv != ""
     assert client.generations == [trial.generation_id]
+    assert client.generation_calls[0][1]["tags"]["experiment_id"] == "run-y"
+    assert client.generation_calls[0][1]["metadata"]["experiment_id"] == "run-y"
     assert all(s.conversation_id == conv for s in client.scores)
 
 
@@ -1556,7 +1555,7 @@ def test_parse_report_matches_backend_shape() -> None:
         "rows": [{"test_case_id": "add", "trials": []}],
     }
     report = _parse_report(payload)
-    assert report.run.run_id == "run-9"  # not blank (parsed from the `experiment` key)
+    assert report.run.experiment_id == "run-9"  # not blank (parsed from the `experiment` key)
     assert report.run.name == "nightly"
     assert report.run.suite_id == "suite-9"
     assert report.run.suite_version == "v4"

--- a/python/tests/test_experiments.py
+++ b/python/tests/test_experiments.py
@@ -723,7 +723,7 @@ def test_trial_ref_from_env_reads_sigil_names_with_warning(caplog: pytest.LogCap
         ),
     ],
 )
-def test_trial_ref_from_env_alias_resolution(env: dict[str, str], expected: tuple[str, str] | None) -> None:
+def test_env_aliases_resolve_trial_ref(env: dict[str, str], expected: tuple[str, str] | None) -> None:
     ref = TrialRef.from_env(env)
     if expected is None:
         assert ref is None
@@ -1188,7 +1188,7 @@ def test_experimental_feature_disabled_error_survives_pickle() -> None:
     assert str(restored) == str(original)
 
 
-def test_trial_cleanup_runs_when_flush_fails() -> None:
+def test_trial_cleanup_after_flush_failure() -> None:
     client = FailingExportClient()
     suite = _suite()
     with pytest.raises(RuntimeError, match="score export failed"):

--- a/python/tests/test_experiments_conformance.py
+++ b/python/tests/test_experiments_conformance.py
@@ -174,7 +174,7 @@ def test_run_upsert_matches_the_fixture() -> None:
     captured = _capture(
         lambda client: client.upsert_experiment(
             CreateExperimentRequest(
-                run_id=INPUTS["experiment_id"],
+                experiment_id=INPUTS["experiment_id"],
                 name=INPUTS["experiment_name"],
                 source="external",
                 tags=INPUTS["tags"],
@@ -343,7 +343,7 @@ def test_both_report_envelopes_parse_alike() -> None:
     run_envelope = {key: value for key, value in RESPONSES["report_run_envelope"].items() if key != "comment"}
     from_run = transport._parse_report(run_envelope)  # noqa: SLF001
     assert from_experiment == from_run
-    assert from_experiment.run.run_id == INPUTS["experiment_id"]
+    assert from_experiment.run.experiment_id == INPUTS["experiment_id"]
     assert from_experiment.summary.trial_count == 1
     # Only a score under the "final" key feeds the pass rate, and a stored
     # evaluator writes under its own key.

--- a/python/tests/test_experiments_conformance.py
+++ b/python/tests/test_experiments_conformance.py
@@ -162,7 +162,7 @@ def _assert_matches(captured: dict[str, Any], fixture: dict[str, Any]) -> None:
     assert differences == [], "body differs from the fixture:\n" + "\n".join(differences)
 
 
-def test_stable_ids_match_the_shared_vectors() -> None:
+def test_stable_ids_match_vectors() -> None:
     vectors = _load("ids.json")["vectors"]
     assert vectors
     for vector in vectors:

--- a/python/tests/test_experiments_transport.py
+++ b/python/tests/test_experiments_transport.py
@@ -125,13 +125,19 @@ def _experiment_body(**overrides: object) -> dict[str, object]:
 
 def test_create_experiment_upserts_external_run() -> None:
     recorder = _Recorder()
-    recorder.push(200, {"run": _experiment_body(tags=["smoke"], metadata={"git_sha": "abc"}), "created": True})
+    recorder.push(
+        200,
+        {
+            "run": _experiment_body(tags=["smoke"], metadata={"git_sha": "abc"}, online_evaluations_enabled=True),
+            "created": True,
+        },
+    )
     server = _serve(recorder)
     try:
         run = transport.create_experiment(
             **_args(server),
             request=CreateExperimentRequest(
-                run_id="run_1",
+                experiment_id="run_1",
                 name="PR 123",
                 source="external",
                 tags=["smoke"],
@@ -139,6 +145,7 @@ def test_create_experiment_upserts_external_run() -> None:
                 suite_version="v2",
                 candidate={"agent_name": "agent-a", "model_name": "model-a"},
                 planned_trial_count=30,
+                online_evaluations_enabled=True,
                 metadata={"git_sha": "abc"},
             ),
         )
@@ -156,10 +163,12 @@ def test_create_experiment_upserts_external_run() -> None:
             "suite_version": "v2",
             "candidate": {"agent_name": "agent-a", "model_name": "model-a"},
             "planned_trial_count": 30,
+            "online_evaluations_enabled": True,
             "metadata": {"git_sha": "abc"},
         }
-        assert run.run_id == "run_1"
+        assert run.experiment_id == "run_1"
         assert run.status == "running"
+        assert run.online_evaluations_enabled is True
         assert run.created_at is not None and run.created_at.tzinfo == timezone.utc
     finally:
         server.shutdown()
@@ -177,7 +186,25 @@ def test_create_experiment_sends_known_empty_plan() -> None:
         )
 
         assert recorder.requests[0]["payload"]["planned_trial_count"] == 0
+        assert "online_evaluations_enabled" not in recorder.requests[0]["payload"]
         assert run.planned_trial_count == 0
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_create_experiment_preserves_explicit_disabled_online_policy() -> None:
+    recorder = _Recorder()
+    recorder.push(200, {"run": _experiment_body(online_evaluations_enabled=False), "created": True})
+    server = _serve(recorder)
+    try:
+        run = transport.create_experiment(
+            **_args(server),
+            request=CreateExperimentRequest(name="disabled", online_evaluations_enabled=False),
+        )
+
+        assert recorder.requests[0]["payload"]["online_evaluations_enabled"] is False
+        assert run.online_evaluations_enabled is False
     finally:
         server.shutdown()
         server.server_close()
@@ -231,7 +258,7 @@ def test_complete_experiment_finalizes_run() -> None:
         # SUCCEEDED is a friendly alias; the backend's terminal status is `completed`.
         run = transport.finalize_experiment(
             **_args(server),
-            run_id="run_1",
+            experiment_id="run_1",
             status=ExperimentStatus.SUCCEEDED,
             score_count=3,
         )
@@ -279,7 +306,7 @@ def test_conflict_has_stable_kind_for_real_server_messages(
         with pytest.raises(ConflictError) as caught:
             transport.finalize_experiment(
                 **_args(server),
-                run_id="run_1",
+                experiment_id="run_1",
                 status="completed",
             )
         assert caught.value.kind is kind
@@ -601,7 +628,7 @@ def test_export_scores_round_trip_and_accepted_count() -> None:
                     score_id="sc1",
                     generation_id="gen1",
                     conversation_id="conv1",
-                    run_id="run_1",
+                    experiment_id="run_1",
                     evaluator_id="smoke.reward",
                     evaluator_version="2026-05-28",
                     score_key="reward",
@@ -613,7 +640,7 @@ def test_export_scores_round_trip_and_accepted_count() -> None:
                 ScoreItem(
                     score_id="sc2",
                     generation_id="gen2",
-                    run_id="run_1",
+                    experiment_id="run_1",
                     evaluator_id="smoke.reward",
                     evaluator_version="2026-05-28",
                     score_key="pass",
@@ -626,7 +653,6 @@ def test_export_scores_round_trip_and_accepted_count() -> None:
         scores = request["payload"]["scores"]
         assert scores[0]["value"] == {"number": 0.82}
         assert scores[0]["experiment_id"] == "run_1"
-        assert "run_id" not in scores[0]  # backend has no run_id field
         assert scores[0]["source"] == {"kind": "experiment", "id": "run_1"}
         assert scores[1]["value"] == {"bool": True}
         assert response.accepted_count == 1
@@ -858,7 +884,7 @@ def test_get_experiment_maps_not_found() -> None:
     server = _serve(recorder)
     try:
         with pytest.raises(NotFoundError):
-            transport.get_experiment(**_args(server), run_id="run_missing")
+            transport.get_experiment(**_args(server), experiment_id="run_missing")
     finally:
         server.shutdown()
         server.server_close()
@@ -924,7 +950,7 @@ def test_experiment_lifecycle_and_scores_share_configured_auth() -> None:
     try:
         transport.create_experiment(
             **_args(server),
-            request=CreateExperimentRequest(run_id="run_1", name="shared auth", source="external"),
+            request=CreateExperimentRequest(experiment_id="run_1", name="shared auth", source="external"),
         )
         create_req = recorder.requests[0]
         assert create_req["path"] == "/api/v1/experiment-runs:upsert"
@@ -941,7 +967,7 @@ def test_experiment_lifecycle_and_scores_share_configured_auth() -> None:
                     evaluator_version="v1",
                     score_key="reward",
                     value=ScoreValue(number=1.0),
-                    run_id="run_1",
+                    experiment_id="run_1",
                 )
             ],
         )
@@ -981,7 +1007,7 @@ def test_get_experiment_report_parses_summary() -> None:
     )
     server = _serve(recorder)
     try:
-        report = transport.get_experiment_report(**_args(server), run_id="run_1")
+        report = transport.get_experiment_report(**_args(server), experiment_id="run_1")
         assert recorder.requests[0]["path"] == "/api/v1/eval/experiments/run_1/report"
         assert report.run.status == "completed"
         assert report.summary.test_case_count == 2


### PR DESCRIPTION
## Notes

Two attribute changes for the Python SDK to keep consistent with Agent Observability Experiments behavior

1. `online_evaluations_enabled`: default `False`, this attribute by default disables Online Evaluation over conversations that were part of an Experiment. For instance, if you are publishing a test conversation as part of CI and it is matched by online evaluation rules, i.e. Toxicity, this score will not evaluate. Only evaluators that are specified as part of the Experiment on creation will be run. If you want the usual checks to be run, simply override this to `True`.

2. `Experiment.run_id` - as part of GA this was standardized to `experiment_id`, so support in the SDK is being removed. However, the server will still accept it for backwards compatability.

## Testing

Confirmed using `gcx` by creating two experiments with 10 LLM calls each using the Python SDK: one with online evaluations enabled and one disabled and verified that the scores were produced/not produced as intended.

### Online evaluations enabled
```
$ gcx agento11y experiments get sir-alex-online-evals-
enabled-20260820-050127 \
  --jq '{experiment_id, name, status, tags}'
{
  "experiment_id": "sir-alex-online-evals-enabled-20260820-050127",
  "name": "Sir Alex online evaluations enabled (20260820-050127)",
  "status": "completed",
  "tags": [
    "local-proof",
    "online-evaluations",
    "enabled"
  ]
}
```

Confirmed the SDK emitted only the canonical experiment_id tag and the matching online evaluator produced a score:

```
$ gcx agento11y conversations get conv-2d57df2175570a18
\
  --jq '{conversation_id, experiment_id: .generations[0].tags.experiment_id,
  legacy_tag: .generations[0].tags["experiment.run_id"], score_keys:
  ((.generations[0].latest_scores // {}) | keys)}'
{
  "conversation_id": "conv-2d57df2175570a18",
  "experiment_id": "sir-alex-online-evals-enabled-20260820-050127",
  "legacy_tag": null,
  "score_keys": [
    "heuristic_pass"
  ]
}
```

### Online evaluations disabled

```
$ gcx agento11y experiments get sir-alex-online-evals-
disabled-20260820-050146 \
  --jq '{experiment_id, name, status, tags}'
{
  "experiment_id": "sir-alex-online-evals-disabled-20260820-050146",
  "name": "Sir Alex online evaluations disabled (20260820-050146)",
  "status": "completed",
  "tags": [
    "local-proof",
    "online-evaluations",
    "disabled"
  ]
}
```

Confirmed the SDK emitted only experiment_id and the matching online evaluator did not produce a score:

```
$ gcx agento11y conversations get conv-ad4d3a4d37c0025b
\
  --jq '{conversation_id, experiment_id: .generations[0].tags.experiment_id,
  legacy_tag: .generations[0].tags["experiment.run_id"], score_keys:
  ((.generations[0].latest_scores // {}) | keys)}'
{
  "conversation_id": "conv-ad4d3a4d37c0025b",
  "experiment_id": "sir-alex-online-evals-disabled-20260820-050146",
  "legacy_tag": null,
  "score_keys": []
}
```