### PR TITLE
docs(plugins/agento11y): add coding agent observability demo video

### DIFF
--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -3,7 +3,7 @@
 Monitor the coding agents you already use — Cursor, Claude Code, Codex, Copilot CLI, OpenCode, Pi, Vibe, and others. Observe usage, cost, tokens, and tools across all of them in one place. Keep sessions on your machine with the local Agent Observability app, or send them to [Grafana Agent Observability](https://grafana.com/docs/grafana-cloud/machine-learning/agent-observability/).
 
 <p align="center">
-  <video src="https://github.com/user-attachments/assets/7f2402a7-c497-44f7-9f3e-7e29a1d3db8f" controls muted autoplay loop playsinline width="60%"></video>
+  <video src="https://github.com/user-attachments/assets/7f2402a7-c497-44f7-9f3e-7e29a1d3db8f" width="600" controls muted autoplay loop playsinline></video>
 </p>
 
 ## Quick start

--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -3,7 +3,7 @@
 Monitor the coding agents you already use — Cursor, Claude Code, Codex, Copilot CLI, OpenCode, Pi, Vibe, and others. Observe usage, cost, tokens, and tools across all of them in one place. Keep sessions on your machine with the local Agent Observability app, or send them to [Grafana Agent Observability](https://grafana.com/docs/grafana-cloud/machine-learning/agent-observability/).
 
 <p align="center">
-  <video src="https://github.com/user-attachments/assets/391a1e09-0f2e-4d96-9682-3c5e29079e55" controls muted autoplay loop playsinline width="100%"></video>
+  <video src="https://github.com/user-attachments/assets/391a1e09-0f2e-4d96-9682-3c5e29079e55" controls muted autoplay loop playsinline width="60%"></video>
 </p>
 
 ## Quick start

--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -1,10 +1,10 @@
 # Coding Agent Observability
 
+Monitor the coding agents you already use — Cursor, Claude Code, Codex, Copilot CLI, OpenCode, Pi, Vibe, and others. Observe usage, cost, tokens, and tools across all of them in one place. Keep sessions on your machine with the local Agent Observability app, or send them to [Grafana Agent Observability](https://grafana.com/docs/grafana-cloud/machine-learning/agent-observability/).
+
 <p align="center">
   <video src="https://github.com/user-attachments/assets/391a1e09-0f2e-4d96-9682-3c5e29079e55" controls muted autoplay loop playsinline width="100%"></video>
 </p>
-
-Monitor the coding agents you already use — Cursor, Claude Code, Codex, Copilot CLI, OpenCode, Pi, Vibe, and others. Observe usage, cost, tokens, and tools across all of them in one place. Keep sessions on your machine with the local Agent Observability app, or send them to [Grafana Agent Observability](https://grafana.com/docs/grafana-cloud/machine-learning/agent-observability/).
 
 ## Quick start
 

--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -3,7 +3,7 @@
 Monitor the coding agents you already use — Cursor, Claude Code, Codex, Copilot CLI, OpenCode, Pi, Vibe, and others. Observe usage, cost, tokens, and tools across all of them in one place. Keep sessions on your machine with the local Agent Observability app, or send them to [Grafana Agent Observability](https://grafana.com/docs/grafana-cloud/machine-learning/agent-observability/).
 
 <p align="center">
-  <video src="https://github.com/user-attachments/assets/391a1e09-0f2e-4d96-9682-3c5e29079e55" controls muted autoplay loop playsinline width="60%"></video>
+  <video src="https://github.com/user-attachments/assets/7f2402a7-c497-44f7-9f3e-7e29a1d3db8f" controls muted autoplay loop playsinline width="60%"></video>
 </p>
 
 ## Quick start

--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -1,5 +1,9 @@
 # Coding Agent Observability
 
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/391a1e09-0f2e-4d96-9682-3c5e29079e55" controls muted autoplay loop playsinline width="100%"></video>
+</p>
+
 Monitor the coding agents you already use — Cursor, Claude Code, Codex, Copilot CLI, OpenCode, Pi, Vibe, and others. Observe usage, cost, tokens, and tools across all of them in one place. Keep sessions on your machine with the local Agent Observability app, or send them to [Grafana Agent Observability](https://grafana.com/docs/grafana-cloud/machine-learning/agent-observability/).
 
 ## Quick start


### PR DESCRIPTION
## Summary
- Embed the coding agent observability walkthrough video at the top of `plugins/agento11y/README.md`.
- Host the MP4 on GitHub user-attachments so the `<video>` tag renders inline on github.com.

## Test plan
- [ ] Open the README on GitHub and confirm the video autoplays (muted) with controls.


Made with [Cursor](https://cursor.com)