### PR TITLE
feat(plugins): support AGENTO11Y_LOCAL env var in Pi and OpenCode

### DIFF
--- a/plugins/agento11y/internal/entry/entry.go
+++ b/plugins/agento11y/internal/entry/entry.go
@@ -13,7 +13,7 @@
 //	agento11y cursor   install|uninstall                              — wire (or remove) the Cursor hook in ~/.cursor/hooks.json
 //	agento11y claude   install [--json]                               — register the Claude Code plugin without launching or prompting
 //	agento11y agents   reconcile --agents all|name[,name...] --json   — reconcile registered noninteractive installers
-//	agento11y local start|open|status|stop|restart                    — manage the local capture daemon
+//	agento11y local start|open|status [--json]|stop|restart           — manage the local capture daemon
 //	agento11y history import <agent> [flags]                          — backfill an agent's existing local sessions
 //	agento11y skills list|show <name>                                 — print an agent skill bundled into this binary
 //	agento11y help                                                    — print the expanded command list
@@ -135,7 +135,7 @@ func usageLine() string {
 	return "usage: agento11y login [--endpoint url] [--tenant id] [--token value|--token-stdin] " +
 		"[--otlp-endpoint url] [--no-verify] [--yes] | agento11y doctor [--json] | " +
 		"agento11y <claude|copilot|opencode|pi> install [--json] | agento11y agents reconcile --agents all|name[,name...] --json | " +
-		"agento11y skills list|show <name> | agento11y local start|open|status|stop|restart | " +
+		"agento11y skills list|show <name> | agento11y local start|open|status [--json]|stop|restart | " +
 		"agento11y history import <" + historyAgentNames() + "> | agento11y cursor install|uninstall | agento11y <agent> hook | " +
 		"agento11y <claude|codex|copilot|opencode|pi|vibe> [--local|--no-local] [--tag key=value]... [-- args...]"
 }
@@ -1220,6 +1220,38 @@ func setupLocalLaunch(stderr io.Writer, envKey string) (endpoint, otlp string, e
 	return endpoint, otlp, nil
 }
 
+// localStatusPayload is the `agento11y local status --json` result. The
+// in-process pi and OpenCode plugins parse it to attach to a running
+// receiver, so the field names must stay stable and `running` must stay
+// unconditional: they read it as the running/stopped signal, and the other
+// fields are omitempty.
+type localStatusPayload struct {
+	Running   bool   `json:"running"`
+	PID       int    `json:"pid,omitempty"`
+	Port      int    `json:"port,omitempty"`
+	Endpoint  string `json:"endpoint,omitempty"`
+	StartedAt string `json:"started_at,omitempty"`
+}
+
+func writeLocalStatusJSON(stdout io.Writer, status *local.Status) error {
+	payload := localStatusPayload{}
+	if status != nil {
+		payload = localStatusPayload{
+			Running:   true,
+			PID:       status.PID,
+			Port:      status.Port,
+			Endpoint:  status.Endpoint,
+			StartedAt: status.StartedAt,
+		}
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintln(stdout, string(data))
+	return nil
+}
+
 // runLocalCommand dispatches `agento11y local <verb>` subcommands.
 func runLocalCommand(args []string, stdout, stderr io.Writer) {
 	if len(args) == 0 {
@@ -1261,10 +1293,26 @@ func runLocalCommand(args []string, stdout, stderr io.Writer) {
 			_, _ = fmt.Fprintf(stderr, "agento11y: could not open browser: %v\n", err)
 		}
 	case "status":
+		fs := flag.NewFlagSet("local status", flag.ContinueOnError)
+		fs.SetOutput(stderr)
+		var asJSON bool
+		fs.BoolVar(&asJSON, "json", false, "print a machine-readable result")
+		if err := fs.Parse(args[1:]); err != nil || fs.NArg() != 0 {
+			_, _ = fmt.Fprintln(stderr, "usage: agento11y local status [--json]")
+			exit(2)
+			return
+		}
 		status, err := local.IsRunning(dir)
 		if err != nil {
 			_, _ = fmt.Fprintf(stderr, "agento11y: %v\n", err)
 			exit(1)
+			return
+		}
+		if asJSON {
+			if err := writeLocalStatusJSON(stdout, status); err != nil {
+				_, _ = fmt.Fprintf(stderr, "agento11y: encode status: %v\n", err)
+				exit(1)
+			}
 			return
 		}
 		if status == nil {

--- a/plugins/agento11y/internal/entry/entry_test.go
+++ b/plugins/agento11y/internal/entry/entry_test.go
@@ -1372,13 +1372,16 @@ func TestRun_LocalSubcommand(t *testing.T) {
 		checkNoDotenv   bool
 	}{
 		{name: "status with no daemon prints friendly message", argv: []string{"local", "status"}, wantStdoutHas: []string{"not running"}},
+		{name: "json status with no daemon reports running false", argv: []string{"local", "status", "--json"}, wantStdoutHas: []string{`{"running":false}`}},
+		{name: "status rejects an unknown flag", argv: []string{"local", "status", "--nope"}, wantExit: intPtr(2), wantStderrHas: "usage: agento11y local status [--json]"},
+		{name: "status rejects a positional argument", argv: []string{"local", "status", "json"}, wantExit: intPtr(2), wantStderrHas: "usage: agento11y local status [--json]"},
 		{name: "stop with no daemon prints friendly message", argv: []string{"local", "stop"}, wantStdoutHas: []string{"not running"}},
 		{name: "help", argv: []string{"local", "help"}, wantStdoutHas: localHelpRows, wantStdoutLacks: "serve", wantStderrEmpty: true, checkNoDotenv: true},
 		{name: "long help flag", argv: []string{"local", "--help"}, wantStdoutHas: localHelpRows, wantStdoutLacks: "serve", wantStderrEmpty: true, checkNoDotenv: true},
 		{name: "short help flag", argv: []string{"local", "-h"}, wantStdoutHas: localHelpRows, wantStdoutLacks: "serve", wantStderrEmpty: true, checkNoDotenv: true},
 		{name: "unknown verb exits 2", argv: []string{"local", "bogus"}, wantExit: intPtr(2), wantStderrHas: `unknown local verb "bogus"`},
 		{name: "no verb exits 2 with usage hint", argv: []string{"local"}, wantExit: intPtr(2), wantStderrHas: "usage: agento11y local"},
-		{name: "usage hint lists open and restart", argv: []string{"local"}, wantExit: intPtr(2), wantStderrHas: "open | status | stop | restart"},
+		{name: "usage hint lists open and restart", argv: []string{"local"}, wantExit: intPtr(2), wantStderrHas: "open | status [--json] | stop | restart"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1480,6 +1483,58 @@ func TestRun_LocalOpen(t *testing.T) {
 			} else {
 				assert.Contains(t, stderr.String(), tc.wantStderr)
 			}
+		})
+	}
+}
+
+// TestRun_LocalStatusRunning covers the two shapes `local status` prints for a
+// healthy receiver. The JSON one is the contract the in-process pi and
+// OpenCode plugins parse to attach to it, and the human one is what an older
+// binary prints when a newer plugin passes --json, so both are pinned.
+func TestRun_LocalStatusRunning(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		argv []string
+		json bool
+	}{
+		{name: "human output", argv: []string{"local", "status"}},
+		{name: "json output", argv: []string{"local", "status", "--json"}, json: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateDotenvHome(t)
+			storage, err := local.NewStorage(t.TempDir())
+			require.NoError(t, err)
+			ts := httptest.NewServer(local.NewServer(storage, nil, filepath.Join(t.TempDir(), "config.env")))
+			t.Cleanup(ts.Close)
+			dir := local.StateDir()
+			require.NoError(t, os.MkdirAll(dir, 0o700))
+			require.NoError(t, local.SaveStatus(dir, local.Status{
+				PID:       os.Getpid(),
+				Port:      8765,
+				Endpoint:  ts.URL,
+				StartedAt: "2024-05-05T10:00:00Z",
+			}))
+
+			var stdout, stderr bytes.Buffer
+			gotExit := withExit(t, func() {
+				run(tc.argv, strings.NewReader(""), &stdout, &stderr)
+			})
+			require.Nil(t, gotExit, "stderr=%q", stderr.String())
+
+			if !tc.json {
+				assert.Contains(t, stdout.String(), "agento11y local receiver: running at "+ts.URL)
+				assert.Contains(t, stdout.String(), "started 2024-05-05T10:00:00Z")
+				return
+			}
+			var got localStatusPayload
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+			assert.Equal(t, localStatusPayload{
+				Running:   true,
+				PID:       os.Getpid(),
+				Port:      8765,
+				Endpoint:  ts.URL,
+				StartedAt: "2024-05-05T10:00:00Z",
+			}, got)
 		})
 	}
 }

--- a/plugins/agento11y/internal/entry/skills.go
+++ b/plugins/agento11y/internal/entry/skills.go
@@ -59,7 +59,7 @@ func runSkillsCommand(args []string, stdout, stderr io.Writer) {
 	}
 }
 
-const localUsage = "usage: agento11y local start | open | status | stop | restart"
+const localUsage = "usage: agento11y local start | open | status [--json] | stop | restart"
 
 // runLocalHelpCommand prints the user-facing local daemon commands. The serve
 // verb is internal and stays out of help and usage output.
@@ -75,7 +75,7 @@ Usage:
 Commands:
   start     Start the receiver if needed and print its address.
   open      Start the receiver if needed, print its address, and try to open the viewer.
-  status    Report whether the receiver is running.
+  status    Report whether the receiver is running; pass --json for machine-readable output.
   stop      Stop the receiver.
   restart   Stop and start the receiver.
 `

--- a/plugins/opencode/src/agento11yDotenv.test.ts
+++ b/plugins/opencode/src/agento11yDotenv.test.ts
@@ -312,6 +312,20 @@ describe("applyAgento11yDotenv", () => {
     );
   });
 
+  it("materializes both local-mode variables under both spellings", () => {
+    // config.ts reads LOCAL and local.ts reads BIN; neither reaches the SDK,
+    // so nothing else in the suite would notice them missing from
+    // ALIAS_SUFFIXES. Outside it they keep exact-key semantics, and a file
+    // AGENTO11Y_LOCAL=true would beat a shell SIGIL_LOCAL=false instead of
+    // losing to it.
+    writeConfig("SIGIL_LOCAL=true\nSIGIL_BIN=/from/file/agento11y\n");
+    applyAgento11yDotenv();
+    expect(process.env.SIGIL_LOCAL).toBe("true");
+    expect(process.env.AGENTO11Y_LOCAL).toBe("true");
+    expect(process.env.SIGIL_BIN).toBe("/from/file/agento11y");
+    expect(process.env.AGENTO11Y_BIN).toBe("/from/file/agento11y");
+  });
+
   it("file AGENTO11Y_ENDPOINT beats file SIGIL_ENDPOINT", () => {
     writeConfig(
       "SIGIL_ENDPOINT=https://file-legacy\nAGENTO11Y_ENDPOINT=https://file-preferred\n",

--- a/plugins/opencode/src/agento11yDotenv.ts
+++ b/plugins/opencode/src/agento11yDotenv.ts
@@ -51,6 +51,12 @@ const ALIAS_SUFFIXES = [
   "GUARDS_ENABLED",
   "GUARDS_FAIL_OPEN",
   "GUARDS_TIMEOUT_MS",
+  // Local-mode selection and the binary that answers `local status`. Neither
+  // reaches the SDK: config.ts reads LOCAL, local.ts reads BIN. They are
+  // resolved here so a saved AGENTO11Y_LOCAL=true obeys the same
+  // shell-before-file, preferred-before-legacy precedence as the launcher.
+  "LOCAL",
+  "BIN",
 ];
 
 // Preferred config directory name and the pre-rename fallback. The legacy

--- a/plugins/opencode/src/config.test.ts
+++ b/plugins/opencode/src/config.test.ts
@@ -3,12 +3,25 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { resolveLocalReceiverMock } = vi.hoisted(() => ({
+  resolveLocalReceiverMock: vi.fn(),
+}));
+
+// Only the discovery call is faked; LocalReceiverError stays real so the
+// no-fallback case asserts on the type the plugin lifecycle catches.
+vi.mock("./local.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./local.js")>();
+  return { ...actual, resolveLocalReceiver: resolveLocalReceiverMock };
+});
+
 import {
   loadConfig,
   normalizeBaseEndpoint,
   resolveAutoTagValues,
   resolveConfig,
 } from "./config.js";
+import { LocalReceiverError } from "./local.js";
 import { clearAgento11yEnv } from "./testEnv.js";
 
 describe("resolveConfig", () => {
@@ -737,5 +750,147 @@ describe("loadConfig reads ~/.config/agento11y/config.env", () => {
 
     const cfg = await loadConfig();
     expect(cfg?.endpoint).toBe("https://shell-legacy.example");
+  });
+});
+
+// A saved AGENTO11Y_LOCAL=true has to route plain `opencode` at the machine's
+// own receiver. Nothing else in this suite covers a config whose endpoint does
+// not come from the endpoint family.
+describe("loadConfig in local mode", () => {
+  let dir: string;
+  let homeBackup: string | undefined;
+
+  const receiver = {
+    endpoint: "http://127.0.0.1:8768",
+    otlpEndpoint: "http://127.0.0.1:8768/otlp",
+  };
+
+  beforeEach(() => {
+    clearAgento11yEnv();
+    vi.clearAllMocks();
+    resolveLocalReceiverMock.mockResolvedValue(receiver);
+    dir = mkdtempSync(join(tmpdir(), "sigil-opencode-localconfig-"));
+    process.env.XDG_CONFIG_HOME = dir;
+    homeBackup = process.env.HOME;
+    process.env.HOME = dir;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    if (homeBackup === undefined) delete process.env.HOME;
+    else process.env.HOME = homeBackup;
+    clearAgento11yEnv();
+  });
+
+  function writeConfigEnv(...lines: string[]): void {
+    const cfgDir = join(dir, "agento11y");
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(join(cfgDir, "config.env"), `${lines.join("\n")}\n`);
+  }
+
+  const cloudLines = [
+    "AGENTO11Y_ENDPOINT=https://cloud.example.com",
+    "AGENTO11Y_AUTH_TENANT_ID=tenant-1",
+    "AGENTO11Y_AUTH_TOKEN=glc_token",
+  ];
+
+  it("routes conversations and OTLP at the receiver over saved Cloud settings", async () => {
+    writeConfigEnv(
+      ...cloudLines,
+      "AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.example.com/otlp",
+      "AGENTO11Y_CONTENT_CAPTURE_MODE=metadata_only",
+      "AGENTO11Y_LOCAL=true",
+    );
+
+    const cfg = await loadConfig();
+
+    expect(cfg?.endpoint).toBe("http://127.0.0.1:8768");
+    expect(cfg?.otlp?.endpoint).toBe("http://127.0.0.1:8768/otlp");
+    expect(cfg?.contentCapture).toBe("full");
+    expect(cfg?.local).toBe(true);
+    expect(cfg?.auth).toEqual({
+      mode: "basic",
+      basicUser: "tenant-1",
+      basicPassword: "glc_token",
+      tenantId: "tenant-1",
+    });
+  });
+
+  it("fills a missing tenant and token independently", async () => {
+    writeConfigEnv("AGENTO11Y_AUTH_TENANT_ID=tenant-1", "AGENTO11Y_LOCAL=true");
+
+    const cfg = await loadConfig();
+
+    expect(cfg?.auth).toEqual({
+      mode: "basic",
+      basicUser: "tenant-1",
+      basicPassword: "local",
+      tenantId: "tenant-1",
+    });
+  });
+
+  it("captures locally with no endpoint configured at all", async () => {
+    writeConfigEnv("SIGIL_LOCAL=true");
+
+    const cfg = await loadConfig();
+
+    expect(cfg?.endpoint).toBe("http://127.0.0.1:8768");
+    expect(cfg?.auth).toEqual({
+      mode: "basic",
+      basicUser: "local",
+      basicPassword: "local",
+      tenantId: "local",
+    });
+  });
+
+  it("does not write the local overrides into process.env", async () => {
+    writeConfigEnv(
+      ...cloudLines,
+      "AGENTO11Y_CONTENT_CAPTURE_MODE=metadata_only",
+      "AGENTO11Y_LOCAL=true",
+    );
+
+    const cfg = await loadConfig();
+
+    expect(cfg?.contentCapture).toBe("full");
+    expect(process.env.AGENTO11Y_ENDPOINT).toBe("https://cloud.example.com");
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://cloud.example.com");
+    expect(process.env.AGENTO11Y_CONTENT_CAPTURE_MODE).toBe("metadata_only");
+    expect(process.env.AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT).toBeUndefined();
+  });
+
+  it("keeps the Cloud path when the shell disables a saved local choice", async () => {
+    writeConfigEnv(...cloudLines, "AGENTO11Y_LOCAL=true");
+    process.env.AGENTO11Y_LOCAL = "false";
+
+    const cfg = await loadConfig();
+
+    expect(cfg?.endpoint).toBe("https://cloud.example.com");
+    expect(cfg?.contentCapture).toBe("metadata_only");
+    expect(cfg?.local).toBeUndefined();
+    expect(resolveLocalReceiverMock).not.toHaveBeenCalled();
+  });
+
+  it("treats an invalid local value as off and warns", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    writeConfigEnv(...cloudLines, "AGENTO11Y_LOCAL=maybe");
+
+    const cfg = await loadConfig();
+
+    expect(cfg?.endpoint).toBe("https://cloud.example.com");
+    expect(resolveLocalReceiverMock).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("AGENTO11Y_LOCAL"),
+    );
+    warn.mockRestore();
+  });
+
+  it("fails instead of falling back to Cloud when no receiver is available", async () => {
+    writeConfigEnv(...cloudLines, "AGENTO11Y_LOCAL=true");
+    resolveLocalReceiverMock.mockRejectedValue(
+      new LocalReceiverError("no local receiver is running"),
+    );
+
+    await expect(loadConfig()).rejects.toBeInstanceOf(LocalReceiverError);
   });
 });

--- a/plugins/opencode/src/config.ts
+++ b/plugins/opencode/src/config.ts
@@ -1,6 +1,8 @@
 import type { ContentCaptureMode } from "@grafana/agento11y";
 import { applyAgento11yDotenv } from "./agento11yDotenv.js";
 import { parseTagPairs, resolveAutoTags, selectAutoTags } from "./autotag.js";
+import { normalizeBaseEndpoint } from "./endpoint.js";
+import { type LocalReceiver, resolveLocalReceiver } from "./local.js";
 
 export type Agento11yAuthConfig =
   | {
@@ -45,6 +47,12 @@ export interface Agento11yOpencodeConfig {
    * but undefined keeps the client config free of an empty `tags` object.
    */
   autoTags?: Record<string, string>;
+  /**
+   * True when this session records to the local receiver instead of Grafana
+   * Cloud. index.ts reads it to name the destination; client.ts never passes
+   * it to the SDK, so it is never part of an exported generation.
+   */
+  local?: boolean;
 }
 
 export async function loadConfig(): Promise<Agento11yOpencodeConfig | null> {
@@ -53,33 +61,81 @@ export async function loadConfig(): Promise<Agento11yOpencodeConfig | null> {
   // over file values for each alias family, and the winner is materialized
   // under both spellings; see applyAgento11yDotenv.
   applyAgento11yDotenv();
-  return resolveConfig();
+  // A saved AGENTO11Y_LOCAL=true means this session records to the machine,
+  // whatever Cloud endpoint config.env also holds. Resolving the receiver can
+  // fail; the caller reports that and captures nothing rather than falling
+  // back to Cloud.
+  if (!(brandedBool("LOCAL") ?? false)) return resolveConfig();
+  return resolveLocalConfig(await resolveLocalReceiver());
+}
+
+// local.LaunchEnv fills a missing tenant or token with this stand-in. The
+// receiver does not check credentials, but the export paths short-circuit on
+// an empty one.
+const LOCAL_AUTH_PLACEHOLDER = "local";
+
+/**
+ * Config for a session that records to `receiver`. Mirrors
+ * `plugins/agento11y/internal/local/env.go::LaunchEnv.Apply`: the receiver
+ * owns both endpoints whatever Cloud values are configured, content capture
+ * is always full on this machine, and a missing tenant or token is filled
+ * independently with the placeholder.
+ *
+ * Nothing here is written back to `process.env`, so a plugin instance that
+ * loads later in the same process sees the configured values unchanged.
+ */
+export function resolveLocalConfig(
+  receiver: LocalReceiver,
+): Agento11yOpencodeConfig {
+  const tenantId = brandedEnv("AUTH_TENANT_ID") ?? LOCAL_AUTH_PLACEHOLDER;
+  const token = brandedEnv("AUTH_TOKEN") ?? LOCAL_AUTH_PLACEHOLDER;
+  return {
+    ...resolveSharedConfig(),
+    endpoint: receiver.endpoint,
+    auth: {
+      mode: "basic",
+      basicUser: tenantId,
+      basicPassword: token,
+      tenantId,
+    },
+    contentCapture: "full",
+    otlp: {
+      endpoint: receiver.otlpEndpoint,
+      headers: otlpHeaders(tenantId, brandedEnv("OTEL_AUTH_TOKEN") ?? token),
+    },
+    local: true,
+  };
 }
 
 export function resolveConfig(): Agento11yOpencodeConfig | null {
   const endpoint = normalizeBaseEndpoint(brandedEnv("ENDPOINT") ?? "");
   if (!endpoint) return null;
 
-  const agentName = brandedEnv("AGENT_NAME") ?? "opencode";
-  const agentVersion = brandedEnv("AGENT_VERSION");
-
-  const contentCapture = resolveContentCapture();
-  // Defaults to true so prompts are scrubbed without configuration, matching
-  // the pi plugin. An unrecognised value keeps redaction on, so a typo cannot
-  // silently disable it.
-  const redactInputMessages = brandedBool("REDACT_INPUT_MESSAGES") ?? true;
-  const debug = brandedBool("DEBUG") ?? false;
-
   return {
+    ...resolveSharedConfig(),
     endpoint,
     auth: resolveAuth(),
-    agentName,
-    agentVersion,
-    contentCapture,
-    redactInputMessages,
-    debug,
-    guards: resolveGuards(),
+    contentCapture: resolveContentCapture(),
     otlp: resolveOtlp(),
+  };
+}
+
+// The settings a local session reads exactly as a Cloud one does. The two
+// resolvers differ only in where the session goes, how it authenticates, and
+// how much of it is captured.
+function resolveSharedConfig(): Omit<
+  Agento11yOpencodeConfig,
+  "endpoint" | "auth" | "contentCapture" | "otlp"
+> {
+  return {
+    agentName: brandedEnv("AGENT_NAME") ?? "opencode",
+    agentVersion: brandedEnv("AGENT_VERSION"),
+    // Redaction defaults to true so prompts are scrubbed without
+    // configuration, matching the pi plugin. An unrecognised value keeps
+    // redaction on, so a typo cannot silently disable it.
+    redactInputMessages: brandedBool("REDACT_INPUT_MESSAGES") ?? true,
+    debug: brandedBool("DEBUG") ?? false,
+    guards: resolveGuards(),
   };
 }
 
@@ -141,13 +197,19 @@ function resolveOtlp(): OtlpConfig | undefined {
     (env("OTEL_EXPORTER_OTLP_ENDPOINT") ?? "").trim();
   if (!endpoint) return undefined;
 
-  const headers = parseOtelHeaders(env("OTEL_EXPORTER_OTLP_HEADERS") ?? "");
   const tenant = brandedEnv("AUTH_TENANT_ID") ?? "";
   const token = brandedEnv("OTEL_AUTH_TOKEN") ?? brandedEnv("AUTH_TOKEN") ?? "";
+  return { endpoint, headers: otlpHeaders(tenant, token) };
+}
+
+// Configured OTLP headers plus a basic Authorization header built from the
+// resolved credentials, unless the user already supplied one.
+function otlpHeaders(tenant: string, token: string): Record<string, string> {
+  const headers = parseOtelHeaders(env("OTEL_EXPORTER_OTLP_HEADERS") ?? "");
   if (tenant && token && !hasAuthorizationHeader(headers)) {
     headers.Authorization = `Basic ${Buffer.from(`${tenant}:${token}`).toString("base64")}`;
   }
-  return { endpoint, headers };
+  return headers;
 }
 
 function parseOtelHeaders(raw: string): Record<string, string> {
@@ -283,29 +345,6 @@ function toBool(v: unknown): boolean | undefined {
   return undefined;
 }
 
-export const EXPORT_PATH = "/api/v1/generations:export";
-
-/**
- * Normalize an Agent Observability endpoint to the bare API base URL. Accepts either the
- * base URL (`https://host` or `https://host/prefix`) or a full generations
- * export URL (`https://host/api/v1/generations:export`) — the latter is a
- * common copy-paste mistake. Trailing slashes are stripped. The export path
- * is reapplied in `client.ts` when constructing the generationExport URL.
- */
-export function normalizeBaseEndpoint(endpoint: string): string {
-  if (!endpoint) return "";
-  try {
-    const url = new URL(endpoint);
-    let pathname = url.pathname.replace(/\/+$/, "");
-    if (pathname.endsWith(EXPORT_PATH)) {
-      pathname = pathname.slice(0, pathname.length - EXPORT_PATH.length);
-    }
-    url.pathname = pathname;
-    return url.toString().replace(/\/+$/, "");
-  } catch {
-    const trimmed = endpoint.replace(/\/+$/, "");
-    return trimmed.endsWith(EXPORT_PATH)
-      ? trimmed.slice(0, trimmed.length - EXPORT_PATH.length)
-      : trimmed;
-  }
-}
+// Re-exported so client.ts and the config tests keep one import for the
+// config they read and the endpoint helpers that go with it.
+export { EXPORT_PATH, normalizeBaseEndpoint } from "./endpoint.js";

--- a/plugins/opencode/src/endpoint.ts
+++ b/plugins/opencode/src/endpoint.ts
@@ -1,0 +1,26 @@
+export const EXPORT_PATH = "/api/v1/generations:export";
+
+/**
+ * Normalize an Agent Observability endpoint to the bare API base URL. Accepts either the
+ * base URL (`https://host` or `https://host/prefix`) or a full generations
+ * export URL (`https://host/api/v1/generations:export`) — the latter is a
+ * common copy-paste mistake. Trailing slashes are stripped. The export path
+ * is reapplied in `client.ts` when constructing the generationExport URL.
+ */
+export function normalizeBaseEndpoint(endpoint: string): string {
+  if (!endpoint) return "";
+  try {
+    const url = new URL(endpoint);
+    let pathname = url.pathname.replace(/\/+$/, "");
+    if (pathname.endsWith(EXPORT_PATH)) {
+      pathname = pathname.slice(0, pathname.length - EXPORT_PATH.length);
+    }
+    url.pathname = pathname;
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    const trimmed = endpoint.replace(/\/+$/, "");
+    return trimmed.endsWith(EXPORT_PATH)
+      ? trimmed.slice(0, trimmed.length - EXPORT_PATH.length)
+      : trimmed;
+  }
+}

--- a/plugins/opencode/src/index.test.ts
+++ b/plugins/opencode/src/index.test.ts
@@ -28,6 +28,7 @@ import {
   makeOpencodeClient,
 } from "./hooks.testutil.js";
 import { Agento11yPlugin } from "./index.js";
+import { LocalReceiverError } from "./local.js";
 
 // `dispose` is not in the pinned `Hooks` type (see the version note in
 // index.ts), so the plugin's return type does not declare it either.
@@ -108,5 +109,79 @@ describe("Agento11yPlugin", () => {
     expect(input.client.tui.showToast).toHaveBeenCalledTimes(1);
 
     await hooks.dispose?.();
+  });
+
+  // A saved AGENTO11Y_LOCAL=true reaches the plugin as a config whose endpoint
+  // is the machine's own receiver, or as a LocalReceiverError when no receiver
+  // answered. Neither case may end with a Cloud client.
+  it("names the receiver the session records to", async () => {
+    const { sigil } = makeAgento11yMock();
+    createAgento11yClientMock.mockReturnValue(sigil);
+    loadConfigMock.mockResolvedValue(
+      baseConfig({ endpoint: "http://127.0.0.1:8768", local: true }),
+    );
+
+    const input = pluginInput();
+    const hooks = (await Agento11yPlugin(input)) as PluginHooks;
+
+    expect(input.client.tui.showToast).toHaveBeenCalledWith({
+      body: {
+        title: "Agent Observability",
+        message: expect.stringContaining("http://127.0.0.1:8768"),
+        variant: "info",
+      },
+    });
+    expect(hooks.dispose).toBeTypeOf("function");
+
+    await hooks.dispose?.();
+  });
+
+  it("registers no hooks and warns when no local receiver answers", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    loadConfigMock.mockRejectedValue(
+      new LocalReceiverError("no local receiver is running"),
+    );
+
+    const input = pluginInput();
+    const hooks = (await Agento11yPlugin(input)) as PluginHooks;
+
+    expect(Object.keys(hooks)).toEqual([]);
+    expect(createAgento11yClientMock).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("no local receiver is running"),
+    );
+    expect(input.client.tui.showToast).toHaveBeenCalledWith({
+      body: {
+        title: "Agent Observability",
+        message: expect.stringContaining("no local receiver is running"),
+        variant: "error",
+      },
+    });
+    warn.mockRestore();
+  });
+
+  it("loads even when the failure toast cannot be shown", async () => {
+    // opencode loads plugins before the TUI is necessarily attached, and a
+    // rejected toast must not turn a disabled capture into a broken host.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    loadConfigMock.mockRejectedValue(new LocalReceiverError("nothing running"));
+
+    const input = pluginInput();
+    input.client.tui.showToast = vi.fn(async () => {
+      throw new Error("no tui");
+    });
+
+    await expect(Agento11yPlugin(input)).resolves.toEqual({});
+    warn.mockRestore();
+  });
+
+  it("lets an unrelated config failure out", async () => {
+    // Only a missing receiver is contained here. Anything else is a bug the
+    // host should surface rather than a capture decision.
+    loadConfigMock.mockRejectedValue(new Error("disk on fire"));
+
+    await expect(Agento11yPlugin(pluginInput())).rejects.toThrow(
+      "disk on fire",
+    );
   });
 });

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -1,6 +1,7 @@
-import type { Hooks, Plugin } from "@opencode-ai/plugin";
+import type { Hooks, Plugin, PluginInput } from "@opencode-ai/plugin";
 import { loadConfig } from "./config.js";
 import { createAgento11yHooks } from "./hooks.js";
+import { LocalReceiverError } from "./local.js";
 
 // opencode calls `dispose` on every plugin as a scope finalizer when it tears
 // the instance down (packages/opencode/src/plugin/index.ts). Both that call and
@@ -13,14 +14,52 @@ import { createAgento11yHooks } from "./hooks.js";
 // fails to compile instead of silently losing the primary shutdown trigger.
 type HooksWithDispose = Hooks & { dispose: () => Promise<void> };
 
+// Best effort: opencode's TUI may not be attached yet while plugins load, and
+// a failed toast must not take the plugin down with it.
+async function toast(
+  client: PluginInput["client"],
+  message: string,
+  variant: "info" | "error",
+): Promise<void> {
+  try {
+    await client.tui.showToast({
+      body: { title: "Agent Observability", message, variant },
+    });
+  } catch {
+    // The notice is not worth failing plugin initialization for.
+  }
+}
+
 export const Agento11yPlugin: Plugin = async ({ client, directory }) => {
-  const config = await loadConfig();
+  let config: Awaited<ReturnType<typeof loadConfig>>;
+  try {
+    config = await loadConfig();
+  } catch (err) {
+    if (!(err instanceof LocalReceiverError)) throw err;
+    // Local mode was chosen for this machine, and no receiver answered. The
+    // saved Cloud endpoint is not a fallback: a session told to stay local
+    // must not be sent to Cloud because the receiver is down. opencode keeps
+    // running with no hooks registered.
+    console.warn(`[sigil-opencode] local capture is off: ${err.message}`);
+    await toast(client, `Local capture is off: ${err.message}`, "error");
+    return {};
+  }
   if (!config) return {};
 
   const hooks = await createAgento11yHooks(config, client, {
     projectDir: directory,
   });
   if (!hooks) return {};
+
+  if (config.local) {
+    // Where the session went is not obvious once the endpoint stops being the
+    // configured one, so name the receiver the transcript lands in.
+    await toast(
+      client,
+      `Recording to the local receiver at ${config.endpoint}`,
+      "info",
+    );
+  }
 
   const pluginHooks: HooksWithDispose = {
     // Awaited, and the rejection is not caught: a guard deny refuses the turn

--- a/plugins/opencode/src/local.test.ts
+++ b/plugins/opencode/src/local.test.ts
@@ -1,0 +1,394 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Only the default `runStatus` path reaches this; every other test injects its
+// own. local.ts promisifies execFile at import time, so the stand-in carries
+// the custom promisify symbol the real one has.
+const { execFileCalls } = vi.hoisted(() => ({
+  execFileCalls: [] as { file: string; args: string[] }[],
+}));
+
+vi.mock("node:child_process", async () => {
+  const { promisify: p } = await import("node:util");
+  const execFile = () => {
+    throw new Error("callback form is not used");
+  };
+  Object.defineProperty(execFile, p.custom, {
+    value: async (file: string, args: string[]) => {
+      execFileCalls.push({ file, args });
+      return { stdout: '{"running":false}\n', stderr: "" };
+    },
+  });
+  return { execFile };
+});
+
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import {
+  isLocalEndpoint,
+  LocalReceiverError,
+  resolveLocalReceiver,
+} from "./local.js";
+
+function statusJSON(endpoint: string): string {
+  return `${JSON.stringify({
+    running: true,
+    pid: 4242,
+    port: 8765,
+    endpoint,
+    started_at: "2024-05-05T10:00:00Z",
+  })}\n`;
+}
+
+function enoent(bin: string): NodeJS.ErrnoException {
+  const err = new Error(`spawn ${bin} ENOENT`) as NodeJS.ErrnoException;
+  err.code = "ENOENT";
+  return err;
+}
+
+describe("isLocalEndpoint", () => {
+  it.each([
+    ["http://127.0.0.1:8765", true],
+    ["http://localhost:8765", true],
+    ["http://[::1]:8765", true],
+    ["http://127.0.0.1:8765/", true],
+    // Mirrors envconfig.IsLocalEndpoint: https is out, and a hostname that
+    // merely starts with `localhost` is a different host.
+    ["https://127.0.0.1:8765", false],
+    ["http://localhost.attacker.com/", false],
+    ["http://10.0.0.1:8765", false],
+    ["not a url", false],
+    ["", false],
+  ])("%s -> %s", (endpoint, want) => {
+    expect(isLocalEndpoint(endpoint)).toBe(want);
+  });
+});
+
+describe("resolveLocalReceiver", () => {
+  it("reuses an injected loopback endpoint that answers, without looking up a binary", async () => {
+    const runStatus = vi.fn();
+    const probe = vi.fn(async () => true);
+    const receiver = await resolveLocalReceiver({
+      env: { AGENTO11Y_ENDPOINT: "http://127.0.0.1:8768" },
+      runStatus,
+      probe,
+      exists: () => true,
+    });
+
+    expect(receiver).toEqual({
+      endpoint: "http://127.0.0.1:8768",
+      otlpEndpoint: "http://127.0.0.1:8768/otlp",
+    });
+    expect(probe).toHaveBeenCalledWith("http://127.0.0.1:8768");
+    expect(runStatus).not.toHaveBeenCalled();
+  });
+
+  it("normalizes an injected endpoint that carries the export path", async () => {
+    const probe = vi.fn(async () => true);
+    const receiver = await resolveLocalReceiver({
+      env: {
+        AGENTO11Y_ENDPOINT: "http://127.0.0.1:8765/api/v1/generations:export",
+      },
+      runStatus: vi.fn(),
+      probe,
+      exists: () => false,
+    });
+
+    // The receiver serves the API under its root, so the pasted export path
+    // must not end up in either field, or in the health probe.
+    expect(receiver).toEqual({
+      endpoint: "http://127.0.0.1:8765",
+      otlpEndpoint: "http://127.0.0.1:8765/otlp",
+    });
+    expect(probe).toHaveBeenCalledWith("http://127.0.0.1:8765");
+  });
+
+  it("asks the binary when nothing answers at the injected endpoint", async () => {
+    // A loopback endpoint in config.env, or one injected by a launcher whose
+    // receiver has since been stopped, is not proof of a live receiver.
+    const runStatus = vi.fn(async () => statusJSON("http://127.0.0.1:8790"));
+    const receiver = await resolveLocalReceiver({
+      env: { AGENTO11Y_ENDPOINT: "http://127.0.0.1:8768" },
+      runStatus,
+      probe: async () => false,
+      exists: () => false,
+    });
+
+    expect(receiver.endpoint).toBe("http://127.0.0.1:8790");
+    expect(runStatus).toHaveBeenCalledWith("agento11y");
+  });
+
+  it("reports a stopped receiver when the injected endpoint is dead too", async () => {
+    await expect(
+      resolveLocalReceiver({
+        env: { AGENTO11Y_ENDPOINT: "http://127.0.0.1:8768" },
+        runStatus: async () => '{"running":false}\n',
+        probe: async () => false,
+        exists: () => false,
+      }),
+    ).rejects.toThrow(/no local receiver is running/);
+  });
+
+  it("ignores a configured Cloud endpoint and asks the binary", async () => {
+    const runStatus = vi.fn(async () => statusJSON("http://127.0.0.1:8765"));
+    const receiver = await resolveLocalReceiver({
+      env: { AGENTO11Y_ENDPOINT: "https://cloud.example.com" },
+      runStatus,
+      exists: () => false,
+    });
+
+    expect(receiver.endpoint).toBe("http://127.0.0.1:8765");
+    expect(runStatus).toHaveBeenCalledWith("agento11y");
+  });
+
+  it("uses the dynamic port the receiver reports", async () => {
+    const receiver = await resolveLocalReceiver({
+      env: {},
+      runStatus: async () => statusJSON("http://127.0.0.1:8797"),
+      exists: () => false,
+    });
+
+    expect(receiver).toEqual({
+      endpoint: "http://127.0.0.1:8797",
+      otlpEndpoint: "http://127.0.0.1:8797/otlp",
+    });
+  });
+
+  it("reads the endpoint from an older binary's prose output", async () => {
+    // Release skew: a binary that predates `--json` ignores the flag and
+    // prints the human line.
+    const receiver = await resolveLocalReceiver({
+      env: {},
+      runStatus: async () =>
+        "agento11y local receiver: running at http://127.0.0.1:8766 (pid 12, started 2024-05-05T10:00:00Z)\n",
+      exists: () => false,
+    });
+
+    expect(receiver.endpoint).toBe("http://127.0.0.1:8766");
+  });
+
+  it.each([
+    ["json", '{"running":false}\n'],
+    ["prose", "agento11y local receiver: not running\n"],
+  ])("reports a stopped receiver from %s output", async (_name, stdout) => {
+    await expect(
+      resolveLocalReceiver({
+        env: {},
+        runStatus: async () => stdout,
+        exists: () => false,
+      }),
+    ).rejects.toThrow(/no local receiver is running/);
+  });
+
+  it("rejects a non-loopback endpoint", async () => {
+    await expect(
+      resolveLocalReceiver({
+        env: {},
+        runStatus: async () => statusJSON("http://sigil.example.com:8765"),
+        exists: () => false,
+      }),
+    ).rejects.toThrow(/not an http loopback address/);
+  });
+
+  it("prefers AGENTO11Y_BIN over every other candidate", async () => {
+    const tried: string[] = [];
+    const receiver = await resolveLocalReceiver({
+      env: { AGENTO11Y_BIN: "/opt/checkout/agento11y", SIGIL_BIN: "/opt/old" },
+      runStatus: async (bin) => {
+        tried.push(bin);
+        return statusJSON("http://127.0.0.1:8765");
+      },
+      exists: () => true,
+    });
+
+    expect(tried).toEqual(["/opt/checkout/agento11y"]);
+    expect(receiver.endpoint).toBe("http://127.0.0.1:8765");
+  });
+
+  it("falls back to the well-known install paths before the legacy name", async () => {
+    const tried: string[] = [];
+    const receiver = await resolveLocalReceiver({
+      env: { HOME: "/home/dev" },
+      runStatus: async (bin) => {
+        tried.push(bin);
+        if (bin !== "/opt/homebrew/bin/agento11y") throw enoent(bin);
+        return statusJSON("http://127.0.0.1:8765");
+      },
+      exists: (path) =>
+        path === "/opt/homebrew/bin/agento11y" ||
+        path === "/home/dev/go/bin/sigil",
+    });
+
+    // Every path for the preferred name is tried before the legacy name, so a
+    // stale `sigil` earlier on PATH cannot win over an installed agento11y.
+    expect(tried).toEqual(["agento11y", "/opt/homebrew/bin/agento11y"]);
+    expect(receiver.endpoint).toBe("http://127.0.0.1:8765");
+  });
+
+  it("keeps looking after a candidate that runs and fails", async () => {
+    // An unrelated binary of the same name, or a broken install, must not hide
+    // the working one behind it.
+    const tried: string[] = [];
+    const receiver = await resolveLocalReceiver({
+      env: { HOME: "/home/dev" },
+      runStatus: async (bin) => {
+        tried.push(bin);
+        if (bin !== "/home/dev/go/bin/agento11y") {
+          throw new Error("Command failed: exit status 2");
+        }
+        return statusJSON("http://127.0.0.1:8765");
+      },
+      exists: (path) => path === "/home/dev/go/bin/agento11y",
+    });
+
+    expect(tried).toEqual(["agento11y", "/home/dev/go/bin/agento11y"]);
+    expect(receiver.endpoint).toBe("http://127.0.0.1:8765");
+  });
+
+  it("reports every candidate it tried when none is installed", async () => {
+    await expect(
+      resolveLocalReceiver({
+        env: { HOME: "/home/dev" },
+        runStatus: async (bin) => {
+          throw enoent(bin);
+        },
+        exists: () => false,
+      }),
+    ).rejects.toThrow(/no agento11y binary found \(tried agento11y, sigil\)/);
+  });
+
+  it("names a candidate that ran and failed", async () => {
+    // A timeout or a non-zero exit is a broken install, not a missing one, so
+    // the reason has to reach the user rather than be counted as absent.
+    await expect(
+      resolveLocalReceiver({
+        env: {},
+        runStatus: async (bin) => {
+          if (bin === "agento11y") throw new Error("Command failed: timeout");
+          throw enoent(bin);
+        },
+        exists: () => false,
+      }),
+    ).rejects.toThrow(
+      /no agento11y binary found \(tried agento11y \(Command failed: timeout\), sigil\)/,
+    );
+  });
+
+  it("reports the binary AGENTO11Y_BIN names when it cannot be run", async () => {
+    // The user answered "which binary" already, so the answer is what went
+    // wrong with that one, not the list of candidates tried after it.
+    await expect(
+      resolveLocalReceiver({
+        env: { AGENTO11Y_BIN: "/opt/checkout/agento11y" },
+        runStatus: async (bin) => {
+          if (bin === "/opt/checkout/agento11y") {
+            const err = new Error("spawn EACCES") as NodeJS.ErrnoException;
+            err.code = "EACCES";
+            throw err;
+          }
+          throw enoent(bin);
+        },
+        exists: () => false,
+      }),
+    ).rejects.toThrow(
+      /cannot run the agento11y binary at \/opt\/checkout\/agento11y \(from AGENTO11Y_BIN\): spawn EACCES/,
+    );
+  });
+
+  it("still resolves when AGENTO11Y_BIN is stale but a binary is on PATH", async () => {
+    const receiver = await resolveLocalReceiver({
+      env: { AGENTO11Y_BIN: "/gone/agento11y" },
+      runStatus: async (bin) => {
+        if (bin === "/gone/agento11y") throw enoent(bin);
+        return statusJSON("http://127.0.0.1:8765");
+      },
+      exists: () => false,
+    });
+
+    expect(receiver.endpoint).toBe("http://127.0.0.1:8765");
+  });
+
+  // The default probe, which no injected one exercises: a wrong path, or an
+  // unchecked response status, would accept a wedged endpoint in production.
+  it.each([
+    ["healthy", 200, true],
+    ["unhealthy", 503, false],
+  ])("probes /healthz on the injected endpoint and reuses a %s one", async (_name, status, reused) => {
+    const requests: string[] = [];
+    const server = createServer((req, res) => {
+      requests.push(`${req.method} ${req.url}`);
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end('{"status":"ok"}');
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+    try {
+      const runStatus = vi.fn(async () => statusJSON("http://127.0.0.1:8765"));
+      const receiver = await resolveLocalReceiver({
+        env: { AGENTO11Y_ENDPOINT: `http://127.0.0.1:${port}` },
+        runStatus,
+        exists: () => false,
+      });
+
+      expect(requests).toEqual(["GET /healthz"]);
+      expect(receiver.endpoint).toBe(
+        reused ? `http://127.0.0.1:${port}` : "http://127.0.0.1:8765",
+      );
+      expect(runStatus.mock.calls.length).toBe(reused ? 0 : 1);
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  it("falls through to the binary when nothing listens on the injected endpoint", async () => {
+    const server = createServer();
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+    await new Promise((resolve) => server.close(resolve));
+
+    const receiver = await resolveLocalReceiver({
+      env: { AGENTO11Y_ENDPOINT: `http://127.0.0.1:${port}` },
+      runStatus: async () => statusJSON("http://127.0.0.1:8765"),
+      exists: () => false,
+    });
+
+    expect(receiver.endpoint).toBe("http://127.0.0.1:8765");
+  });
+
+  it("asks the binary for status and never for a start", async () => {
+    // The one place this package runs the binary. Passing `local start` here
+    // would make a plain host own a daemon it cannot shut down.
+    execFileCalls.length = 0;
+    await expect(
+      resolveLocalReceiver({ env: {}, exists: () => false }),
+    ).rejects.toThrow(/no local receiver is running/);
+
+    expect(execFileCalls).toEqual([
+      { file: "agento11y", args: ["local", "status", "--json"] },
+    ]);
+  });
+
+  it.each([
+    ["prints nothing", "   \n", /printed nothing/],
+    ["prints unreadable json", "{oops\n", /cannot parse/],
+    ["claims to run with no endpoint", '{"running":true}\n', /no endpoint/],
+    [
+      "prints prose with no url",
+      "something unexpected\n",
+      /cannot read a receiver endpoint/,
+    ],
+  ])("rejects a binary that %s", async (_name, stdout, want) => {
+    const call = () =>
+      resolveLocalReceiver({
+        env: {},
+        runStatus: async () => stdout,
+        exists: () => false,
+      });
+
+    await expect(call()).rejects.toBeInstanceOf(LocalReceiverError);
+    await expect(call()).rejects.toThrow(want);
+  });
+});

--- a/plugins/opencode/src/local.ts
+++ b/plugins/opencode/src/local.ts
@@ -1,0 +1,314 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { normalizeBaseEndpoint } from "./endpoint.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * A local receiver this plugin may export to. `endpoint` is the receiver base
+ * URL; `otlpEndpoint` is the OTLP path under it, matching
+ * `plugins/agento11y/internal/entry/entry.go::setupLocalLaunch`.
+ */
+export interface LocalReceiver {
+  endpoint: string;
+  otlpEndpoint: string;
+}
+
+/**
+ * Local capture was requested but no receiver could be attached to. The
+ * caller reports this and continues without capture; it must never fall back
+ * to the configured Grafana Cloud endpoint.
+ */
+export class LocalReceiverError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "LocalReceiverError";
+  }
+}
+
+/** Injection points for tests. Production uses the defaults. */
+export interface LocalReceiverDeps {
+  env?: NodeJS.ProcessEnv;
+  /** Run `<bin> local status --json` and return its stdout. */
+  runStatus?: (bin: string) => Promise<string>;
+  /** Report whether `GET <endpoint>/healthz` answers. */
+  probe?: (endpoint: string) => Promise<boolean>;
+  exists?: (path: string) => boolean;
+}
+
+// `local status` reads the status file and health-probes the receiver with a
+// 500ms client timeout (plugins/agento11y/internal/local/manager.go::endpointAlive),
+// so this budget only has to cover spawning the binary. Ten times that leaves
+// room on a loaded machine and still bounds the worst case, which is every
+// candidate hanging while the host waits for us to return.
+const STATUS_TIMEOUT_MS = 5_000;
+
+// Our own liveness check, for an endpoint that arrives without one. Only has
+// to cover a loopback round trip; a false negative here falls through to the
+// binary, which does the same check itself.
+const PROBE_TIMEOUT_MS = 2_000;
+
+/**
+ * Resolve the local receiver to export this session to.
+ *
+ * The plugin never starts a receiver: `agento11y opencode` already ensures
+ * one and injects its endpoint, and a plain `opencode` attaches to whatever
+ * `agento11y local status --json` reports. Throws {@link LocalReceiverError}
+ * when there is nothing safe to attach to.
+ */
+export async function resolveLocalReceiver(
+  deps: LocalReceiverDeps = {},
+): Promise<LocalReceiver> {
+  const env = deps.env ?? process.env;
+  const runStatus = deps.runStatus ?? defaultRunStatus;
+  const probe = deps.probe ?? defaultProbe;
+  const exists = deps.exists ?? existsSync;
+
+  // `agento11y opencode` resolved the receiver before exec and wrote its
+  // endpoint into AGENTO11Y_ENDPOINT / SIGIL_ENDPOINT. Reuse it rather than
+  // shelling out again: the launched host may not have the binary on its own
+  // PATH.
+  const injected = brandedEnv(env, "ENDPOINT")?.value;
+  const injectedReceiver =
+    injected && isLocalEndpoint(injected) ? receiverAt(injected) : undefined;
+  // A loopback endpoint in the environment is not proof of a live receiver.
+  // The same variable also carries a hand-written config.env value, and a
+  // launcher-injected one outlives the receiver that was killed after it. An
+  // unanswered probe falls through to the binary, which reports the receiver
+  // that is running now.
+  if (injectedReceiver && (await probe(injectedReceiver.endpoint))) {
+    return injectedReceiver;
+  }
+
+  const failed: FailedCandidate[] = [];
+  for (const candidate of binaryCandidates(env, exists)) {
+    let stdout: string;
+    try {
+      stdout = await runStatus(candidate.bin);
+    } catch (err) {
+      // Every spawn failure moves to the next candidate: an unrelated `sigil`
+      // earlier on PATH must not hide the real binary in ~/go/bin. Nothing is
+      // lost by carrying on, because the failure is named in the final error.
+      failed.push({
+        ...candidate,
+        failure: errorText(err),
+        code: errorCode(err),
+      });
+      continue;
+    }
+    // The binary answered, so it is the authority on what is running: its
+    // status already includes a health probe of the endpoint it reports.
+    const endpoint = parseReceiverEndpoint(stdout, candidate.bin);
+    if (!endpoint) {
+      throw new LocalReceiverError(
+        "no local receiver is running; start one with `agento11y local start`",
+      );
+    }
+    if (!isLocalEndpoint(endpoint)) {
+      throw new LocalReceiverError(
+        `refusing local endpoint ${endpoint}: not an http loopback address`,
+      );
+    }
+    return receiverAt(endpoint);
+  }
+  // A failing override outranks the generic message: the user named that
+  // binary, so the answer is what went wrong with it, not the list of the
+  // others that were tried after it.
+  const override = failed.find((candidate) => candidate.overrideKey);
+  if (override) {
+    throw new LocalReceiverError(
+      `cannot run the agento11y binary at ${override.bin} ` +
+        `(from ${override.overrideKey}): ${override.failure}`,
+    );
+  }
+  throw new LocalReceiverError(
+    `no agento11y binary found (tried ${describeFailures(failed)}); ` +
+      "install it or point AGENTO11Y_BIN at it",
+  );
+}
+
+function receiverAt(endpoint: string): LocalReceiver {
+  // A pasted endpoint can carry the export path; the receiver serves the API
+  // under its root, so both fields are built from the normalized base.
+  const base = normalizeBaseEndpoint(endpoint.trim());
+  return { endpoint: base, otlpEndpoint: `${base}/otlp` };
+}
+
+/**
+ * Mirror `plugins/agento11y/internal/envconfig/envconfig.go::IsLocalEndpoint`:
+ * plain http on a loopback host. Parsing the URL (rather than matching a
+ * prefix) is what keeps `http://localhost.attacker.com` out.
+ */
+export function isLocalEndpoint(endpoint: string): boolean {
+  const raw = endpoint.trim();
+  if (!raw) return false;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "http:") return false;
+  // URL.hostname keeps the brackets around an IPv6 literal; Go's
+  // url.Hostname() strips them, and this list is copied from there.
+  const host = url.hostname.replace(/^\[|\]$/g, "");
+  return host === "127.0.0.1" || host === "::1" || host === "localhost";
+}
+
+/**
+ * Read the endpoint out of `local status` output. Returns undefined when the
+ * receiver is reported as not running.
+ *
+ * The JSON form is preferred. The prose form is release skew: a binary older
+ * than this package ignores the unknown `--json` argument and prints the
+ * human line, and the two packages release independently of the binary.
+ */
+function parseReceiverEndpoint(
+  stdout: string,
+  bin: string,
+): string | undefined {
+  const text = stdout.trim();
+  if (!text) {
+    throw new LocalReceiverError(
+      `\`${bin} local status --json\` printed nothing`,
+    );
+  }
+  if (text.startsWith("{")) {
+    let payload: unknown;
+    try {
+      payload = JSON.parse(text);
+    } catch (err) {
+      throw new LocalReceiverError(
+        `cannot parse \`${bin} local status --json\` output: ${errorText(err)}`,
+        { cause: err },
+      );
+    }
+    const record = payload as { running?: unknown; endpoint?: unknown };
+    if (record?.running !== true) return undefined;
+    if (typeof record.endpoint !== "string" || record.endpoint.trim() === "") {
+      throw new LocalReceiverError(
+        `\`${bin} local status --json\` reported a running receiver with no endpoint`,
+      );
+    }
+    return record.endpoint.trim();
+  }
+  if (/not running/i.test(text)) return undefined;
+  const url = text.match(/https?:\/\/[^\s)]+/)?.[0];
+  if (!url) {
+    throw new LocalReceiverError(
+      `cannot read a receiver endpoint from \`${bin} local status\` output`,
+    );
+  }
+  return url;
+}
+
+interface BinaryCandidate {
+  bin: string;
+  /** Set when the candidate came from the BIN family, naming the spelling. */
+  overrideKey?: string;
+}
+
+interface FailedCandidate extends BinaryCandidate {
+  failure: string;
+  code?: string;
+}
+
+// The override first, then per name (preferred before legacy) the bare name
+// on PATH and the common install locations plugins/cursor/scripts/run.sh
+// knows about. A GUI-launched host inherits launchd's or the desktop
+// session's PATH, which holds neither Homebrew's bin nor the `go install`
+// target, so a bare name alone is not enough. run.sh probes paths only; the
+// bare names are tried too because a host started from a shell usually has
+// the binary on PATH already.
+function binaryCandidates(
+  env: NodeJS.ProcessEnv,
+  exists: (path: string) => boolean,
+): BinaryCandidate[] {
+  const override = brandedEnv(env, "BIN");
+  const paths: string[] = [];
+  const home = (env.HOME ?? "").trim() || homedir();
+  for (const name of ["agento11y", "sigil"]) {
+    paths.push(name);
+    for (const dir of [
+      join(home, "go", "bin"),
+      "/opt/homebrew/bin",
+      "/usr/local/bin",
+      join(home, ".local", "bin"),
+    ]) {
+      // Filtered so the failure message names paths that exist, and so a host
+      // with no binary at all spawns two children rather than ten.
+      const path = join(dir, name);
+      if (exists(path)) paths.push(path);
+    }
+  }
+  const candidates = [...new Set(paths)].map((bin) => ({ bin }));
+  if (!override) return candidates;
+  return [
+    { bin: override.value, overrideKey: override.key },
+    ...candidates.filter((candidate) => candidate.bin !== override.value),
+  ];
+}
+
+async function defaultRunStatus(bin: string): Promise<string> {
+  // execFile with an argument array and no shell: a binary path from
+  // config.env never reaches a shell parser.
+  const { stdout } = await execFileAsync(bin, ["local", "status", "--json"], {
+    timeout: STATUS_TIMEOUT_MS,
+    encoding: "utf-8",
+  });
+  return stdout;
+}
+
+async function defaultProbe(endpoint: string): Promise<boolean> {
+  // Same check as the Go manager's endpointAlive: /healthz is the JSON
+  // liveness probe, while / serves the viewer HTML.
+  try {
+    const res = await fetch(`${endpoint.replace(/\/+$/, "")}/healthz`, {
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+// A candidate that is simply not installed needs no explanation in the final
+// error; anything else (a non-zero exit, a file that is not executable, a
+// timeout) is named there so a broken install is not reported as a missing
+// one.
+function describeFailures(failed: FailedCandidate[]): string {
+  if (failed.length === 0) return "nothing";
+  return failed
+    .map(({ bin, failure, code }) =>
+      code === "ENOENT" ? bin : `${bin} (${failure})`,
+    )
+    .join(", ");
+}
+
+function errorCode(err: unknown): string | undefined {
+  const code = (err as { code?: unknown } | null)?.code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function errorText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+interface BrandedValue {
+  value: string;
+  key: string;
+}
+
+function brandedEnv(
+  env: NodeJS.ProcessEnv,
+  suffix: string,
+): BrandedValue | undefined {
+  for (const key of [`AGENTO11Y_${suffix}`, `SIGIL_${suffix}`]) {
+    const value = (env[key] ?? "").trim();
+    if (value !== "") return { value, key };
+  }
+  return undefined;
+}

--- a/plugins/pi/src/agento11yDotenv.test.ts
+++ b/plugins/pi/src/agento11yDotenv.test.ts
@@ -476,6 +476,20 @@ describe("applyAgento11yDotenv", () => {
     );
   });
 
+  it("materializes both local-mode variables under both spellings", () => {
+    // config.ts reads LOCAL and local.ts reads BIN; neither reaches the SDK,
+    // so nothing else in the suite would notice them missing from
+    // ALIAS_SUFFIXES. Outside it they keep exact-key semantics, and a file
+    // AGENTO11Y_LOCAL=true would beat a shell SIGIL_LOCAL=false instead of
+    // losing to it.
+    writeConfig("SIGIL_LOCAL=true\nSIGIL_BIN=/from/file/agento11y\n");
+    applyAgento11yDotenv();
+    expect(process.env.SIGIL_LOCAL).toBe("true");
+    expect(process.env.AGENTO11Y_LOCAL).toBe("true");
+    expect(process.env.SIGIL_BIN).toBe("/from/file/agento11y");
+    expect(process.env.AGENTO11Y_BIN).toBe("/from/file/agento11y");
+  });
+
   it("file AGENTO11Y_ENDPOINT beats file SIGIL_ENDPOINT", () => {
     writeConfig(
       "AGENTO11Y_ENDPOINT=https://preferred\nSIGIL_ENDPOINT=https://legacy\n",

--- a/plugins/pi/src/agento11yDotenv.ts
+++ b/plugins/pi/src/agento11yDotenv.ts
@@ -52,6 +52,12 @@ const ALIAS_SUFFIXES = [
   "GUARDS_ENABLED",
   "GUARDS_TIMEOUT_MS",
   "GUARDS_FAIL_OPEN",
+  // Local-mode selection and the binary that answers `local status`. Neither
+  // reaches the SDK: config.ts reads LOCAL, local.ts reads BIN. They are
+  // resolved here so a saved AGENTO11Y_LOCAL=true obeys the same
+  // shell-before-file, preferred-before-legacy precedence as the launcher.
+  "LOCAL",
+  "BIN",
 ] as const;
 
 function preferredKey(suffix: string): string {

--- a/plugins/pi/src/config.test.ts
+++ b/plugins/pi/src/config.test.ts
@@ -4,13 +4,22 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearAgento11yEnv as clearEnv } from "./testEnv.js";
 
-const { loggerMock } = vi.hoisted(() => ({
+const { loggerMock, resolveLocalReceiverMock } = vi.hoisted(() => ({
   loggerMock: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  resolveLocalReceiverMock: vi.fn(),
 }));
 
 vi.mock("./logger.js", () => ({ logger: loggerMock }));
 
+// Only the discovery call is faked; LocalReceiverError stays real so the
+// no-fallback case asserts on the type the host lifecycle catches.
+vi.mock("./local.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./local.js")>();
+  return { ...actual, resolveLocalReceiver: resolveLocalReceiverMock };
+});
+
 import { loadConfig, resolveConfig } from "./config.js";
+import { LocalReceiverError } from "./local.js";
 
 describe("resolveConfig", () => {
   beforeEach(clearEnv);
@@ -644,5 +653,147 @@ describe("loadConfig reads ~/.config/agento11y/config.env", () => {
 
     const cfg = await loadConfig();
     expect(cfg).toBeNull();
+  });
+});
+
+// A saved AGENTO11Y_LOCAL=true has to route plain `pi` at the machine's own
+// receiver. Nothing else in this suite covers a config whose endpoint does
+// not come from the endpoint family.
+describe("loadConfig in local mode", () => {
+  let dir: string;
+  let homeBackup: string | undefined;
+
+  const receiver = {
+    endpoint: "http://127.0.0.1:8768",
+    otlpEndpoint: "http://127.0.0.1:8768/otlp",
+  };
+
+  beforeEach(() => {
+    clearEnv();
+    vi.clearAllMocks();
+    resolveLocalReceiverMock.mockResolvedValue(receiver);
+    dir = mkdtempSync(join(tmpdir(), "sigil-pi-localconfig-"));
+    process.env.XDG_CONFIG_HOME = dir;
+    homeBackup = process.env.HOME;
+    process.env.HOME = dir;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    if (homeBackup === undefined) delete process.env.HOME;
+    else process.env.HOME = homeBackup;
+    clearEnv();
+  });
+
+  function writeConfigEnv(...lines: string[]): void {
+    const cfgDir = join(dir, "agento11y");
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(join(cfgDir, "config.env"), `${lines.join("\n")}\n`);
+  }
+
+  const cloudLines = [
+    "AGENTO11Y_ENDPOINT=https://cloud.example.com",
+    "AGENTO11Y_AUTH_TENANT_ID=tenant-1",
+    "AGENTO11Y_AUTH_TOKEN=glc_token",
+  ];
+
+  it("routes conversations and OTLP at the receiver over saved Cloud settings", async () => {
+    writeConfigEnv(
+      ...cloudLines,
+      "AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.example.com/otlp",
+      "AGENTO11Y_CONTENT_CAPTURE_MODE=metadata_only",
+      "AGENTO11Y_LOCAL=true",
+    );
+
+    const cfg = await loadConfig();
+
+    expect(cfg?.endpoint).toBe("http://127.0.0.1:8768");
+    expect(cfg?.otlp?.endpoint).toBe("http://127.0.0.1:8768/otlp");
+    expect(cfg?.contentCapture).toBe("full");
+    expect(cfg?.local).toBe(true);
+    expect(cfg?.auth).toEqual({
+      mode: "basic",
+      basicUser: "tenant-1",
+      basicPassword: "glc_token",
+      tenantId: "tenant-1",
+    });
+  });
+
+  it("fills a missing tenant and token independently", async () => {
+    writeConfigEnv("AGENTO11Y_AUTH_TENANT_ID=tenant-1", "AGENTO11Y_LOCAL=true");
+
+    const cfg = await loadConfig();
+
+    expect(cfg?.auth).toEqual({
+      mode: "basic",
+      basicUser: "tenant-1",
+      basicPassword: "local",
+      tenantId: "tenant-1",
+    });
+  });
+
+  it("captures locally with no endpoint configured at all", async () => {
+    writeConfigEnv("SIGIL_LOCAL=true");
+
+    const cfg = await loadConfig();
+
+    expect(cfg?.endpoint).toBe("http://127.0.0.1:8768");
+    expect(cfg?.auth).toEqual({
+      mode: "basic",
+      basicUser: "local",
+      basicPassword: "local",
+      tenantId: "local",
+    });
+  });
+
+  it("does not write the local overrides into process.env", async () => {
+    // Pi reloads config on every session start, so an override that leaked
+    // into the environment would follow a later AGENTO11Y_LOCAL=false session.
+    writeConfigEnv(
+      ...cloudLines,
+      "AGENTO11Y_CONTENT_CAPTURE_MODE=metadata_only",
+      "AGENTO11Y_LOCAL=true",
+    );
+
+    const cfg = await loadConfig();
+
+    expect(cfg?.contentCapture).toBe("full");
+    expect(process.env.AGENTO11Y_ENDPOINT).toBe("https://cloud.example.com");
+    expect(process.env.SIGIL_ENDPOINT).toBe("https://cloud.example.com");
+    expect(process.env.AGENTO11Y_CONTENT_CAPTURE_MODE).toBe("metadata_only");
+    expect(process.env.AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT).toBeUndefined();
+  });
+
+  it("keeps the Cloud path when the shell disables a saved local choice", async () => {
+    writeConfigEnv(...cloudLines, "AGENTO11Y_LOCAL=true");
+    process.env.AGENTO11Y_LOCAL = "false";
+
+    const cfg = await loadConfig();
+
+    expect(cfg?.endpoint).toBe("https://cloud.example.com");
+    expect(cfg?.contentCapture).toBe("metadata_only");
+    expect(cfg?.local).toBeUndefined();
+    expect(resolveLocalReceiverMock).not.toHaveBeenCalled();
+  });
+
+  it("treats an invalid local value as off and warns", async () => {
+    writeConfigEnv(...cloudLines, "AGENTO11Y_LOCAL=maybe");
+
+    const cfg = await loadConfig();
+
+    expect(cfg?.endpoint).toBe("https://cloud.example.com");
+    expect(resolveLocalReceiverMock).not.toHaveBeenCalled();
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      expect.stringContaining("AGENTO11Y_LOCAL"),
+    );
+  });
+
+  it("fails instead of falling back to Cloud when no receiver is available", async () => {
+    writeConfigEnv(...cloudLines, "AGENTO11Y_LOCAL=true");
+    resolveLocalReceiverMock.mockRejectedValue(
+      new LocalReceiverError("no local receiver is running"),
+    );
+
+    await expect(loadConfig()).rejects.toBeInstanceOf(LocalReceiverError);
   });
 });

--- a/plugins/pi/src/config.ts
+++ b/plugins/pi/src/config.ts
@@ -1,6 +1,8 @@
 import type { ContentCaptureMode } from "@grafana/agento11y";
 import { applyAgento11yDotenv } from "./agento11yDotenv.js";
 import { parseTagPairs, resolveAutoTags, selectAutoTags } from "./autotag.js";
+import { normalizeBaseEndpoint } from "./endpoint.js";
+import { type LocalReceiver, resolveLocalReceiver } from "./local.js";
 import { logger } from "./logger.js";
 
 export type Agento11yAuthConfig =
@@ -38,6 +40,12 @@ export interface Agento11yPiConfig {
    * but undefined keeps the client config free of an empty `tags` object.
    */
   autoTags?: Record<string, string>;
+  /**
+   * True when this session records to the local receiver instead of Grafana
+   * Cloud. index.ts reads it to name the destination; client.ts never passes
+   * it to the SDK, so it is never part of an exported generation.
+   */
+  local?: boolean;
 }
 
 export async function loadConfig(): Promise<Agento11yPiConfig | null> {
@@ -45,27 +53,79 @@ export async function loadConfig(): Promise<Agento11yPiConfig | null> {
   // credentials from the same place. Shell values in process.env always beat
   // config.env values, across both env-var spellings.
   applyAgento11yDotenv();
-  return resolveConfig();
+  // A saved AGENTO11Y_LOCAL=true means this session records to the machine,
+  // whatever Cloud endpoint config.env also holds. Resolving the receiver can
+  // fail; the caller reports that and captures nothing rather than falling
+  // back to Cloud.
+  if (!envBoolOr("LOCAL", false)) return resolveConfig();
+  return resolveLocalConfig(await resolveLocalReceiver());
+}
+
+// local.LaunchEnv fills a missing tenant or token with this stand-in. The
+// receiver does not check credentials, but the export paths short-circuit on
+// an empty one.
+const LOCAL_AUTH_PLACEHOLDER = "local";
+
+/**
+ * Config for a session that records to `receiver`. Mirrors
+ * `plugins/agento11y/internal/local/env.go::LaunchEnv.Apply`: the receiver
+ * owns both endpoints whatever Cloud values are configured, content capture
+ * is always full on this machine, and a missing tenant or token is filled
+ * independently with the placeholder.
+ *
+ * Nothing here is written back to `process.env`. Pi reloads config on every
+ * session start, so an override that leaked into the environment would follow
+ * a later non-local session.
+ */
+export function resolveLocalConfig(receiver: LocalReceiver): Agento11yPiConfig {
+  const tenantId =
+    brandedEnv("AUTH_TENANT_ID")?.value ?? LOCAL_AUTH_PLACEHOLDER;
+  const token = brandedEnv("AUTH_TOKEN")?.value ?? LOCAL_AUTH_PLACEHOLDER;
+  return {
+    ...resolveSharedConfig(),
+    endpoint: receiver.endpoint,
+    auth: {
+      mode: "basic",
+      basicUser: tenantId,
+      basicPassword: token,
+      tenantId,
+    },
+    contentCapture: "full",
+    otlp: {
+      endpoint: receiver.otlpEndpoint,
+      headers: otlpHeaders(
+        tenantId,
+        brandedEnv("OTEL_AUTH_TOKEN")?.value ?? token,
+      ),
+    },
+    local: true,
+  };
 }
 
 export function resolveConfig(): Agento11yPiConfig | null {
   const endpoint = normalizeBaseEndpoint(brandedEnv("ENDPOINT")?.value ?? "");
   if (!endpoint) return null;
 
-  const agentName = brandedEnv("AGENT_NAME")?.value ?? "pi";
-  const agentVersion = brandedEnv("AGENT_VERSION")?.value;
-
-  const contentCapture = resolveContentCapture();
-  const redactInputMessages = envBoolOr("REDACT_INPUT_MESSAGES", true);
-
   return {
+    ...resolveSharedConfig(),
     endpoint,
     auth: resolveAuth(),
-    agentName,
-    agentVersion,
-    contentCapture,
-    redactInputMessages,
+    contentCapture: resolveContentCapture(),
     otlp: resolveOtlp(),
+  };
+}
+
+// The settings a local session reads exactly as a Cloud one does. The two
+// resolvers differ only in where the session goes, how it authenticates, and
+// how much of it is captured.
+function resolveSharedConfig(): Omit<
+  Agento11yPiConfig,
+  "endpoint" | "auth" | "contentCapture" | "otlp"
+> {
+  return {
+    agentName: brandedEnv("AGENT_NAME")?.value ?? "pi",
+    agentVersion: brandedEnv("AGENT_VERSION")?.value,
+    redactInputMessages: envBoolOr("REDACT_INPUT_MESSAGES", true),
     guards: resolveGuards(),
     autoTags: resolveAutoTagValues(),
   };
@@ -115,16 +175,22 @@ function resolveOtlp(): OtlpConfig | undefined {
     (env("OTEL_EXPORTER_OTLP_ENDPOINT") ?? "").trim();
   if (!endpoint) return undefined;
 
-  const headers = parseOtelHeaders(env("OTEL_EXPORTER_OTLP_HEADERS") ?? "");
   const tenant = brandedEnv("AUTH_TENANT_ID")?.value ?? "";
   const token =
     brandedEnv("OTEL_AUTH_TOKEN")?.value ??
     brandedEnv("AUTH_TOKEN")?.value ??
     "";
+  return { endpoint, headers: otlpHeaders(tenant, token) };
+}
+
+// Configured OTLP headers plus a basic Authorization header built from the
+// resolved credentials, unless the user already supplied one.
+function otlpHeaders(tenant: string, token: string): Record<string, string> {
+  const headers = parseOtelHeaders(env("OTEL_EXPORTER_OTLP_HEADERS") ?? "");
   if (tenant && token && !hasAuthorizationHeader(headers)) {
     headers.Authorization = `Basic ${Buffer.from(`${tenant}:${token}`).toString("base64")}`;
   }
-  return { endpoint, headers };
+  return headers;
 }
 
 function parseOtelHeaders(raw: string): Record<string, string> {
@@ -256,29 +322,6 @@ function toBool(v: unknown): boolean | undefined {
   return undefined;
 }
 
-export const EXPORT_PATH = "/api/v1/generations:export";
-
-/**
- * Normalize an Agent Observability endpoint to the bare API base URL. Accepts either the
- * base URL (`https://host` or `https://host/prefix`) or a full generations
- * export URL (`https://host/api/v1/generations:export`) — the latter is a
- * common copy-paste mistake. Trailing slashes are stripped. The export path
- * is reapplied in `client.ts` when constructing the generationExport URL.
- */
-function normalizeBaseEndpoint(endpoint: string): string {
-  if (!endpoint) return "";
-  try {
-    const url = new URL(endpoint);
-    let pathname = url.pathname.replace(/\/+$/, "");
-    if (pathname.endsWith(EXPORT_PATH)) {
-      pathname = pathname.slice(0, pathname.length - EXPORT_PATH.length);
-    }
-    url.pathname = pathname;
-    return url.toString().replace(/\/+$/, "");
-  } catch {
-    const trimmed = endpoint.replace(/\/+$/, "");
-    return trimmed.endsWith(EXPORT_PATH)
-      ? trimmed.slice(0, trimmed.length - EXPORT_PATH.length)
-      : trimmed;
-  }
-}
+// Re-exported so client.ts keeps one import for the config it reads and the
+// path it appends to the endpoint.
+export { EXPORT_PATH } from "./endpoint.js";

--- a/plugins/pi/src/endpoint.ts
+++ b/plugins/pi/src/endpoint.ts
@@ -1,0 +1,26 @@
+export const EXPORT_PATH = "/api/v1/generations:export";
+
+/**
+ * Normalize an Agent Observability endpoint to the bare API base URL. Accepts either the
+ * base URL (`https://host` or `https://host/prefix`) or a full generations
+ * export URL (`https://host/api/v1/generations:export`) — the latter is a
+ * common copy-paste mistake. Trailing slashes are stripped. The export path
+ * is reapplied in `client.ts` when constructing the generationExport URL.
+ */
+export function normalizeBaseEndpoint(endpoint: string): string {
+  if (!endpoint) return "";
+  try {
+    const url = new URL(endpoint);
+    let pathname = url.pathname.replace(/\/+$/, "");
+    if (pathname.endsWith(EXPORT_PATH)) {
+      pathname = pathname.slice(0, pathname.length - EXPORT_PATH.length);
+    }
+    url.pathname = pathname;
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    const trimmed = endpoint.replace(/\/+$/, "");
+    return trimmed.endsWith(EXPORT_PATH)
+      ? trimmed.slice(0, trimmed.length - EXPORT_PATH.length)
+      : trimmed;
+  }
+}

--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -42,6 +42,7 @@ vi.mock("./git.js", () => ({
 import type { Agento11yClient } from "@grafana/agento11y";
 import registerExtension, { emitToolSpans } from "./index.js";
 import { stablePiGenerationId } from "./lineage.js";
+import { LocalReceiverError } from "./local.js";
 import type {
   PiAssistantMessage,
   PiToolResult,
@@ -4681,5 +4682,130 @@ describe("emitToolSpans", () => {
     expect(args).toContain("deploy.sh");
     expect(result).not.toContain(token);
     expect(result).toBe("authenticated with [REDACTED:grafana-cloud-token]");
+  });
+});
+
+// A saved AGENTO11Y_LOCAL=true reaches the plugin as a config whose endpoint
+// is the machine's own receiver, or as a LocalReceiverError when no receiver
+// answered. Neither case may end with a Cloud client.
+describe("local mode session_start", () => {
+  function localConfig() {
+    return {
+      endpoint: "http://127.0.0.1:8768",
+      auth: {
+        mode: "basic",
+        basicUser: "local",
+        basicPassword: "local",
+        tenantId: "local",
+      },
+      agentName: "pi",
+      contentCapture: "full",
+      local: true,
+    };
+  }
+
+  function uiCtx(hasUI: boolean) {
+    return {
+      ...makeCtx({ sessionId: "sess-local" }),
+      hasUI,
+      ui: { notify: vi.fn() },
+    };
+  }
+
+  function fakeClient(): Agento11yLike {
+    return {
+      startStreamingGeneration: vi.fn(async () => {}),
+      startToolExecution: vi.fn(),
+      shutdown: vi.fn(async () => {}),
+    };
+  }
+
+  beforeEach(() => {
+    loadConfigMock.mockReset();
+    createAgento11yClientMock.mockReset();
+    createTelemetryProvidersMock.mockReset();
+    resolveGitBranchMock.mockReset();
+    resolveGitBranchMock.mockReturnValue(undefined);
+    loggerMock.debug.mockReset();
+    loggerMock.warn.mockReset();
+    loggerMock.error.mockReset();
+  });
+
+  it("names the receiver the session records to", async () => {
+    loadConfigMock.mockResolvedValue(localConfig());
+    createAgento11yClientMock.mockReturnValue(fakeClient());
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+    const ctx = uiCtx(true);
+    await pi.emit("session_start", {}, ctx);
+
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      expect.stringContaining("http://127.0.0.1:8768"),
+      "info",
+    );
+    expect(createAgento11yClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays silent in a mode without a UI", async () => {
+    // `pi -p` and JSON mode have no place to put a notice, and pi's own docs
+    // say to gate notify on hasUI.
+    loadConfigMock.mockResolvedValue(localConfig());
+    createAgento11yClientMock.mockReturnValue(fakeClient());
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+    const ctx = uiCtx(false);
+    await pi.emit("session_start", {}, ctx);
+
+    expect(ctx.ui.notify).not.toHaveBeenCalled();
+    expect(createAgento11yClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures nothing and never builds a Cloud client when no receiver answers", async () => {
+    loadConfigMock.mockRejectedValue(
+      new LocalReceiverError("no local receiver is running"),
+    );
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+    const ctx = uiCtx(true);
+    await pi.emit("session_start", {}, ctx);
+
+    expect(createAgento11yClientMock).not.toHaveBeenCalled();
+    expect(createTelemetryProvidersMock).not.toHaveBeenCalled();
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      expect.stringContaining("no local receiver is running"),
+      "error",
+    );
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      "local capture unavailable",
+      expect.any(LocalReceiverError),
+    );
+
+    // The session still runs; the turn path finds no client and exports
+    // nothing.
+    await pi.emit("turn_start", {}, ctx);
+    await pi.emit(
+      "turn_end",
+      { message: assistantMessage(), toolResults: [] },
+      ctx,
+    );
+  });
+
+  it("leaves an unrelated config failure on the generic error path", async () => {
+    loadConfigMock.mockRejectedValue(new Error("disk on fire"));
+
+    const pi = new FakePi();
+    registerExtension(pi as any);
+    const ctx = uiCtx(true);
+    await pi.emit("session_start", {}, ctx);
+
+    expect(createAgento11yClientMock).not.toHaveBeenCalled();
+    expect(ctx.ui.notify).not.toHaveBeenCalled();
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      "session_start failed",
+      expect.any(Error),
+    );
   });
 });

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -18,6 +18,7 @@ import {
   resolvePiSummaryLineage,
   type SessionManagerLike,
 } from "./lineage.js";
+import { LocalReceiverError } from "./local.js";
 import { logger } from "./logger.js";
 import {
   applyRedactedText,
@@ -394,7 +395,23 @@ export default function (pi: ExtensionAPI) {
         currentConversation = undefined;
       }
 
-      config = await loadConfig();
+      try {
+        config = await loadConfig();
+      } catch (err) {
+        if (!(err instanceof LocalReceiverError)) throw err;
+        // Local mode was chosen for this machine, and no receiver answered.
+        // The saved Cloud endpoint is not a fallback: a session told to stay
+        // local must not be sent to Cloud because the receiver is down. Pi
+        // itself carries on with no capture.
+        logger.error("local capture unavailable", err);
+        notify(
+          ctx,
+          `Agent Observability: local capture is off: ${err.message}`,
+          "error",
+        );
+        await resetSessionState();
+        return;
+      }
       if (!config) return;
 
       if (!config.agentVersion) {
@@ -430,8 +447,19 @@ export default function (pi: ExtensionAPI) {
       }
 
       logger.debug(
-        `enabled, endpoint=${config.endpoint} auth=${config.auth.mode}`,
+        `enabled, endpoint=${config.endpoint} auth=${config.auth.mode}${
+          config.local ? " local=true" : ""
+        }`,
       );
+      if (config.local) {
+        // Where the session went is not obvious once the endpoint stops being
+        // the configured one, so name the receiver the transcript lands in.
+        notify(
+          ctx,
+          `Agent Observability: recording to the local receiver at ${config.endpoint}`,
+          "info",
+        );
+      }
     } catch (err) {
       logger.error("session_start failed", err);
       sigil = null;
@@ -928,6 +956,35 @@ export default function (pi: ExtensionAPI) {
     lastSeenModel = null;
     await resetSessionState();
   });
+}
+
+/**
+ * Slice of pi's `ExtensionContext` used to reach the user. Structural and
+ * fully optional: pi only has a UI in TUI and RPC modes, and `-p` / JSON runs
+ * pass a context whose notify would go nowhere.
+ */
+interface PiNotifyContext {
+  hasUI?: boolean;
+  ui?: {
+    notify?: (message: string, type?: "info" | "warning" | "error") => void;
+  };
+}
+
+/**
+ * Tells the user something the debug log alone would not surface. Silent
+ * without a UI, and a failing notify never breaks the handler that called it.
+ */
+function notify(
+  ctx: PiNotifyContext,
+  message: string,
+  type: "info" | "warning" | "error",
+): void {
+  if (!ctx?.hasUI) return;
+  try {
+    ctx.ui?.notify?.(message, type);
+  } catch (err) {
+    logger.debug("ui notify failed", err);
+  }
 }
 
 /**

--- a/plugins/pi/src/local.test.ts
+++ b/plugins/pi/src/local.test.ts
@@ -1,0 +1,394 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Only the default `runStatus` path reaches this; every other test injects its
+// own. local.ts promisifies execFile at import time, so the stand-in carries
+// the custom promisify symbol the real one has.
+const { execFileCalls } = vi.hoisted(() => ({
+  execFileCalls: [] as { file: string; args: string[] }[],
+}));
+
+vi.mock("node:child_process", async () => {
+  const { promisify: p } = await import("node:util");
+  const execFile = () => {
+    throw new Error("callback form is not used");
+  };
+  Object.defineProperty(execFile, p.custom, {
+    value: async (file: string, args: string[]) => {
+      execFileCalls.push({ file, args });
+      return { stdout: '{"running":false}\n', stderr: "" };
+    },
+  });
+  return { execFile };
+});
+
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import {
+  isLocalEndpoint,
+  LocalReceiverError,
+  resolveLocalReceiver,
+} from "./local.js";
+
+function statusJSON(endpoint: string): string {
+  return `${JSON.stringify({
+    running: true,
+    pid: 4242,
+    port: 8765,
+    endpoint,
+    started_at: "2024-05-05T10:00:00Z",
+  })}\n`;
+}
+
+function enoent(bin: string): NodeJS.ErrnoException {
+  const err = new Error(`spawn ${bin} ENOENT`) as NodeJS.ErrnoException;
+  err.code = "ENOENT";
+  return err;
+}
+
+describe("isLocalEndpoint", () => {
+  it.each([
+    ["http://127.0.0.1:8765", true],
+    ["http://localhost:8765", true],
+    ["http://[::1]:8765", true],
+    ["http://127.0.0.1:8765/", true],
+    // Mirrors envconfig.IsLocalEndpoint: https is out, and a hostname that
+    // merely starts with `localhost` is a different host.
+    ["https://127.0.0.1:8765", false],
+    ["http://localhost.attacker.com/", false],
+    ["http://10.0.0.1:8765", false],
+    ["not a url", false],
+    ["", false],
+  ])("%s -> %s", (endpoint, want) => {
+    expect(isLocalEndpoint(endpoint)).toBe(want);
+  });
+});
+
+describe("resolveLocalReceiver", () => {
+  it("reuses an injected loopback endpoint that answers, without looking up a binary", async () => {
+    const runStatus = vi.fn();
+    const probe = vi.fn(async () => true);
+    const receiver = await resolveLocalReceiver({
+      env: { AGENTO11Y_ENDPOINT: "http://127.0.0.1:8768" },
+      runStatus,
+      probe,
+      exists: () => true,
+    });
+
+    expect(receiver).toEqual({
+      endpoint: "http://127.0.0.1:8768",
+      otlpEndpoint: "http://127.0.0.1:8768/otlp",
+    });
+    expect(probe).toHaveBeenCalledWith("http://127.0.0.1:8768");
+    expect(runStatus).not.toHaveBeenCalled();
+  });
+
+  it("normalizes an injected endpoint that carries the export path", async () => {
+    const probe = vi.fn(async () => true);
+    const receiver = await resolveLocalReceiver({
+      env: {
+        AGENTO11Y_ENDPOINT: "http://127.0.0.1:8765/api/v1/generations:export",
+      },
+      runStatus: vi.fn(),
+      probe,
+      exists: () => false,
+    });
+
+    // The receiver serves the API under its root, so the pasted export path
+    // must not end up in either field, or in the health probe.
+    expect(receiver).toEqual({
+      endpoint: "http://127.0.0.1:8765",
+      otlpEndpoint: "http://127.0.0.1:8765/otlp",
+    });
+    expect(probe).toHaveBeenCalledWith("http://127.0.0.1:8765");
+  });
+
+  it("asks the binary when nothing answers at the injected endpoint", async () => {
+    // A loopback endpoint in config.env, or one injected by a launcher whose
+    // receiver has since been stopped, is not proof of a live receiver.
+    const runStatus = vi.fn(async () => statusJSON("http://127.0.0.1:8790"));
+    const receiver = await resolveLocalReceiver({
+      env: { AGENTO11Y_ENDPOINT: "http://127.0.0.1:8768" },
+      runStatus,
+      probe: async () => false,
+      exists: () => false,
+    });
+
+    expect(receiver.endpoint).toBe("http://127.0.0.1:8790");
+    expect(runStatus).toHaveBeenCalledWith("agento11y");
+  });
+
+  it("reports a stopped receiver when the injected endpoint is dead too", async () => {
+    await expect(
+      resolveLocalReceiver({
+        env: { AGENTO11Y_ENDPOINT: "http://127.0.0.1:8768" },
+        runStatus: async () => '{"running":false}\n',
+        probe: async () => false,
+        exists: () => false,
+      }),
+    ).rejects.toThrow(/no local receiver is running/);
+  });
+
+  it("ignores a configured Cloud endpoint and asks the binary", async () => {
+    const runStatus = vi.fn(async () => statusJSON("http://127.0.0.1:8765"));
+    const receiver = await resolveLocalReceiver({
+      env: { AGENTO11Y_ENDPOINT: "https://cloud.example.com" },
+      runStatus,
+      exists: () => false,
+    });
+
+    expect(receiver.endpoint).toBe("http://127.0.0.1:8765");
+    expect(runStatus).toHaveBeenCalledWith("agento11y");
+  });
+
+  it("uses the dynamic port the receiver reports", async () => {
+    const receiver = await resolveLocalReceiver({
+      env: {},
+      runStatus: async () => statusJSON("http://127.0.0.1:8797"),
+      exists: () => false,
+    });
+
+    expect(receiver).toEqual({
+      endpoint: "http://127.0.0.1:8797",
+      otlpEndpoint: "http://127.0.0.1:8797/otlp",
+    });
+  });
+
+  it("reads the endpoint from an older binary's prose output", async () => {
+    // Release skew: a binary that predates `--json` ignores the flag and
+    // prints the human line.
+    const receiver = await resolveLocalReceiver({
+      env: {},
+      runStatus: async () =>
+        "agento11y local receiver: running at http://127.0.0.1:8766 (pid 12, started 2024-05-05T10:00:00Z)\n",
+      exists: () => false,
+    });
+
+    expect(receiver.endpoint).toBe("http://127.0.0.1:8766");
+  });
+
+  it.each([
+    ["json", '{"running":false}\n'],
+    ["prose", "agento11y local receiver: not running\n"],
+  ])("reports a stopped receiver from %s output", async (_name, stdout) => {
+    await expect(
+      resolveLocalReceiver({
+        env: {},
+        runStatus: async () => stdout,
+        exists: () => false,
+      }),
+    ).rejects.toThrow(/no local receiver is running/);
+  });
+
+  it("rejects a non-loopback endpoint", async () => {
+    await expect(
+      resolveLocalReceiver({
+        env: {},
+        runStatus: async () => statusJSON("http://sigil.example.com:8765"),
+        exists: () => false,
+      }),
+    ).rejects.toThrow(/not an http loopback address/);
+  });
+
+  it("prefers AGENTO11Y_BIN over every other candidate", async () => {
+    const tried: string[] = [];
+    const receiver = await resolveLocalReceiver({
+      env: { AGENTO11Y_BIN: "/opt/checkout/agento11y", SIGIL_BIN: "/opt/old" },
+      runStatus: async (bin) => {
+        tried.push(bin);
+        return statusJSON("http://127.0.0.1:8765");
+      },
+      exists: () => true,
+    });
+
+    expect(tried).toEqual(["/opt/checkout/agento11y"]);
+    expect(receiver.endpoint).toBe("http://127.0.0.1:8765");
+  });
+
+  it("falls back to the well-known install paths before the legacy name", async () => {
+    const tried: string[] = [];
+    const receiver = await resolveLocalReceiver({
+      env: { HOME: "/home/dev" },
+      runStatus: async (bin) => {
+        tried.push(bin);
+        if (bin !== "/opt/homebrew/bin/agento11y") throw enoent(bin);
+        return statusJSON("http://127.0.0.1:8765");
+      },
+      exists: (path) =>
+        path === "/opt/homebrew/bin/agento11y" ||
+        path === "/home/dev/go/bin/sigil",
+    });
+
+    // Every path for the preferred name is tried before the legacy name, so a
+    // stale `sigil` earlier on PATH cannot win over an installed agento11y.
+    expect(tried).toEqual(["agento11y", "/opt/homebrew/bin/agento11y"]);
+    expect(receiver.endpoint).toBe("http://127.0.0.1:8765");
+  });
+
+  it("keeps looking after a candidate that runs and fails", async () => {
+    // An unrelated binary of the same name, or a broken install, must not hide
+    // the working one behind it.
+    const tried: string[] = [];
+    const receiver = await resolveLocalReceiver({
+      env: { HOME: "/home/dev" },
+      runStatus: async (bin) => {
+        tried.push(bin);
+        if (bin !== "/home/dev/go/bin/agento11y") {
+          throw new Error("Command failed: exit status 2");
+        }
+        return statusJSON("http://127.0.0.1:8765");
+      },
+      exists: (path) => path === "/home/dev/go/bin/agento11y",
+    });
+
+    expect(tried).toEqual(["agento11y", "/home/dev/go/bin/agento11y"]);
+    expect(receiver.endpoint).toBe("http://127.0.0.1:8765");
+  });
+
+  it("reports every candidate it tried when none is installed", async () => {
+    await expect(
+      resolveLocalReceiver({
+        env: { HOME: "/home/dev" },
+        runStatus: async (bin) => {
+          throw enoent(bin);
+        },
+        exists: () => false,
+      }),
+    ).rejects.toThrow(/no agento11y binary found \(tried agento11y, sigil\)/);
+  });
+
+  it("names a candidate that ran and failed", async () => {
+    // A timeout or a non-zero exit is a broken install, not a missing one, so
+    // the reason has to reach the user rather than be counted as absent.
+    await expect(
+      resolveLocalReceiver({
+        env: {},
+        runStatus: async (bin) => {
+          if (bin === "agento11y") throw new Error("Command failed: timeout");
+          throw enoent(bin);
+        },
+        exists: () => false,
+      }),
+    ).rejects.toThrow(
+      /no agento11y binary found \(tried agento11y \(Command failed: timeout\), sigil\)/,
+    );
+  });
+
+  it("reports the binary AGENTO11Y_BIN names when it cannot be run", async () => {
+    // The user answered "which binary" already, so the answer is what went
+    // wrong with that one, not the list of candidates tried after it.
+    await expect(
+      resolveLocalReceiver({
+        env: { AGENTO11Y_BIN: "/opt/checkout/agento11y" },
+        runStatus: async (bin) => {
+          if (bin === "/opt/checkout/agento11y") {
+            const err = new Error("spawn EACCES") as NodeJS.ErrnoException;
+            err.code = "EACCES";
+            throw err;
+          }
+          throw enoent(bin);
+        },
+        exists: () => false,
+      }),
+    ).rejects.toThrow(
+      /cannot run the agento11y binary at \/opt\/checkout\/agento11y \(from AGENTO11Y_BIN\): spawn EACCES/,
+    );
+  });
+
+  it("still resolves when AGENTO11Y_BIN is stale but a binary is on PATH", async () => {
+    const receiver = await resolveLocalReceiver({
+      env: { AGENTO11Y_BIN: "/gone/agento11y" },
+      runStatus: async (bin) => {
+        if (bin === "/gone/agento11y") throw enoent(bin);
+        return statusJSON("http://127.0.0.1:8765");
+      },
+      exists: () => false,
+    });
+
+    expect(receiver.endpoint).toBe("http://127.0.0.1:8765");
+  });
+
+  // The default probe, which no injected one exercises: a wrong path, or an
+  // unchecked response status, would accept a wedged endpoint in production.
+  it.each([
+    ["healthy", 200, true],
+    ["unhealthy", 503, false],
+  ])("probes /healthz on the injected endpoint and reuses a %s one", async (_name, status, reused) => {
+    const requests: string[] = [];
+    const server = createServer((req, res) => {
+      requests.push(`${req.method} ${req.url}`);
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end('{"status":"ok"}');
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+    try {
+      const runStatus = vi.fn(async () => statusJSON("http://127.0.0.1:8765"));
+      const receiver = await resolveLocalReceiver({
+        env: { AGENTO11Y_ENDPOINT: `http://127.0.0.1:${port}` },
+        runStatus,
+        exists: () => false,
+      });
+
+      expect(requests).toEqual(["GET /healthz"]);
+      expect(receiver.endpoint).toBe(
+        reused ? `http://127.0.0.1:${port}` : "http://127.0.0.1:8765",
+      );
+      expect(runStatus.mock.calls.length).toBe(reused ? 0 : 1);
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  it("falls through to the binary when nothing listens on the injected endpoint", async () => {
+    const server = createServer();
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+    await new Promise((resolve) => server.close(resolve));
+
+    const receiver = await resolveLocalReceiver({
+      env: { AGENTO11Y_ENDPOINT: `http://127.0.0.1:${port}` },
+      runStatus: async () => statusJSON("http://127.0.0.1:8765"),
+      exists: () => false,
+    });
+
+    expect(receiver.endpoint).toBe("http://127.0.0.1:8765");
+  });
+
+  it("asks the binary for status and never for a start", async () => {
+    // The one place this package runs the binary. Passing `local start` here
+    // would make a plain host own a daemon it cannot shut down.
+    execFileCalls.length = 0;
+    await expect(
+      resolveLocalReceiver({ env: {}, exists: () => false }),
+    ).rejects.toThrow(/no local receiver is running/);
+
+    expect(execFileCalls).toEqual([
+      { file: "agento11y", args: ["local", "status", "--json"] },
+    ]);
+  });
+
+  it.each([
+    ["prints nothing", "   \n", /printed nothing/],
+    ["prints unreadable json", "{oops\n", /cannot parse/],
+    ["claims to run with no endpoint", '{"running":true}\n', /no endpoint/],
+    [
+      "prints prose with no url",
+      "something unexpected\n",
+      /cannot read a receiver endpoint/,
+    ],
+  ])("rejects a binary that %s", async (_name, stdout, want) => {
+    const call = () =>
+      resolveLocalReceiver({
+        env: {},
+        runStatus: async () => stdout,
+        exists: () => false,
+      });
+
+    await expect(call()).rejects.toBeInstanceOf(LocalReceiverError);
+    await expect(call()).rejects.toThrow(want);
+  });
+});

--- a/plugins/pi/src/local.ts
+++ b/plugins/pi/src/local.ts
@@ -1,0 +1,313 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { normalizeBaseEndpoint } from "./endpoint.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * A local receiver this plugin may export to. `endpoint` is the receiver base
+ * URL; `otlpEndpoint` is the OTLP path under it, matching
+ * `plugins/agento11y/internal/entry/entry.go::setupLocalLaunch`.
+ */
+export interface LocalReceiver {
+  endpoint: string;
+  otlpEndpoint: string;
+}
+
+/**
+ * Local capture was requested but no receiver could be attached to. The
+ * caller reports this and continues without capture; it must never fall back
+ * to the configured Grafana Cloud endpoint.
+ */
+export class LocalReceiverError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "LocalReceiverError";
+  }
+}
+
+/** Injection points for tests. Production uses the defaults. */
+export interface LocalReceiverDeps {
+  env?: NodeJS.ProcessEnv;
+  /** Run `<bin> local status --json` and return its stdout. */
+  runStatus?: (bin: string) => Promise<string>;
+  /** Report whether `GET <endpoint>/healthz` answers. */
+  probe?: (endpoint: string) => Promise<boolean>;
+  exists?: (path: string) => boolean;
+}
+
+// `local status` reads the status file and health-probes the receiver with a
+// 500ms client timeout (plugins/agento11y/internal/local/manager.go::endpointAlive),
+// so this budget only has to cover spawning the binary. Ten times that leaves
+// room on a loaded machine and still bounds the worst case, which is every
+// candidate hanging while the host waits for us to return.
+const STATUS_TIMEOUT_MS = 5_000;
+
+// Our own liveness check, for an endpoint that arrives without one. Only has
+// to cover a loopback round trip; a false negative here falls through to the
+// binary, which does the same check itself.
+const PROBE_TIMEOUT_MS = 2_000;
+
+/**
+ * Resolve the local receiver to export this session to.
+ *
+ * The plugin never starts a receiver: `agento11y pi` already ensures one and
+ * injects its endpoint, and a plain `pi` attaches to whatever
+ * `agento11y local status --json` reports. Throws {@link LocalReceiverError}
+ * when there is nothing safe to attach to.
+ */
+export async function resolveLocalReceiver(
+  deps: LocalReceiverDeps = {},
+): Promise<LocalReceiver> {
+  const env = deps.env ?? process.env;
+  const runStatus = deps.runStatus ?? defaultRunStatus;
+  const probe = deps.probe ?? defaultProbe;
+  const exists = deps.exists ?? existsSync;
+
+  // `agento11y pi` resolved the receiver before exec and wrote its endpoint
+  // into AGENTO11Y_ENDPOINT / SIGIL_ENDPOINT. Reuse it rather than shelling
+  // out again: the launched host may not have the binary on its own PATH.
+  const injected = brandedEnv(env, "ENDPOINT")?.value;
+  const injectedReceiver =
+    injected && isLocalEndpoint(injected) ? receiverAt(injected) : undefined;
+  // A loopback endpoint in the environment is not proof of a live receiver.
+  // The same variable also carries a hand-written config.env value, and a
+  // launcher-injected one outlives the receiver that was killed after it. An
+  // unanswered probe falls through to the binary, which reports the receiver
+  // that is running now.
+  if (injectedReceiver && (await probe(injectedReceiver.endpoint))) {
+    return injectedReceiver;
+  }
+
+  const failed: FailedCandidate[] = [];
+  for (const candidate of binaryCandidates(env, exists)) {
+    let stdout: string;
+    try {
+      stdout = await runStatus(candidate.bin);
+    } catch (err) {
+      // Every spawn failure moves to the next candidate: an unrelated `sigil`
+      // earlier on PATH must not hide the real binary in ~/go/bin. Nothing is
+      // lost by carrying on, because the failure is named in the final error.
+      failed.push({
+        ...candidate,
+        failure: errorText(err),
+        code: errorCode(err),
+      });
+      continue;
+    }
+    // The binary answered, so it is the authority on what is running: its
+    // status already includes a health probe of the endpoint it reports.
+    const endpoint = parseReceiverEndpoint(stdout, candidate.bin);
+    if (!endpoint) {
+      throw new LocalReceiverError(
+        "no local receiver is running; start one with `agento11y local start`",
+      );
+    }
+    if (!isLocalEndpoint(endpoint)) {
+      throw new LocalReceiverError(
+        `refusing local endpoint ${endpoint}: not an http loopback address`,
+      );
+    }
+    return receiverAt(endpoint);
+  }
+  // A failing override outranks the generic message: the user named that
+  // binary, so the answer is what went wrong with it, not the list of the
+  // others that were tried after it.
+  const override = failed.find((candidate) => candidate.overrideKey);
+  if (override) {
+    throw new LocalReceiverError(
+      `cannot run the agento11y binary at ${override.bin} ` +
+        `(from ${override.overrideKey}): ${override.failure}`,
+    );
+  }
+  throw new LocalReceiverError(
+    `no agento11y binary found (tried ${describeFailures(failed)}); ` +
+      "install it or point AGENTO11Y_BIN at it",
+  );
+}
+
+function receiverAt(endpoint: string): LocalReceiver {
+  // A pasted endpoint can carry the export path; the receiver serves the API
+  // under its root, so both fields are built from the normalized base.
+  const base = normalizeBaseEndpoint(endpoint.trim());
+  return { endpoint: base, otlpEndpoint: `${base}/otlp` };
+}
+
+/**
+ * Mirror `plugins/agento11y/internal/envconfig/envconfig.go::IsLocalEndpoint`:
+ * plain http on a loopback host. Parsing the URL (rather than matching a
+ * prefix) is what keeps `http://localhost.attacker.com` out.
+ */
+export function isLocalEndpoint(endpoint: string): boolean {
+  const raw = endpoint.trim();
+  if (!raw) return false;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "http:") return false;
+  // URL.hostname keeps the brackets around an IPv6 literal; Go's
+  // url.Hostname() strips them, and this list is copied from there.
+  const host = url.hostname.replace(/^\[|\]$/g, "");
+  return host === "127.0.0.1" || host === "::1" || host === "localhost";
+}
+
+/**
+ * Read the endpoint out of `local status` output. Returns undefined when the
+ * receiver is reported as not running.
+ *
+ * The JSON form is preferred. The prose form is release skew: a binary older
+ * than this package ignores the unknown `--json` argument and prints the
+ * human line, and the two packages release independently of the binary.
+ */
+function parseReceiverEndpoint(
+  stdout: string,
+  bin: string,
+): string | undefined {
+  const text = stdout.trim();
+  if (!text) {
+    throw new LocalReceiverError(
+      `\`${bin} local status --json\` printed nothing`,
+    );
+  }
+  if (text.startsWith("{")) {
+    let payload: unknown;
+    try {
+      payload = JSON.parse(text);
+    } catch (err) {
+      throw new LocalReceiverError(
+        `cannot parse \`${bin} local status --json\` output: ${errorText(err)}`,
+        { cause: err },
+      );
+    }
+    const record = payload as { running?: unknown; endpoint?: unknown };
+    if (record?.running !== true) return undefined;
+    if (typeof record.endpoint !== "string" || record.endpoint.trim() === "") {
+      throw new LocalReceiverError(
+        `\`${bin} local status --json\` reported a running receiver with no endpoint`,
+      );
+    }
+    return record.endpoint.trim();
+  }
+  if (/not running/i.test(text)) return undefined;
+  const url = text.match(/https?:\/\/[^\s)]+/)?.[0];
+  if (!url) {
+    throw new LocalReceiverError(
+      `cannot read a receiver endpoint from \`${bin} local status\` output`,
+    );
+  }
+  return url;
+}
+
+interface BinaryCandidate {
+  bin: string;
+  /** Set when the candidate came from the BIN family, naming the spelling. */
+  overrideKey?: string;
+}
+
+interface FailedCandidate extends BinaryCandidate {
+  failure: string;
+  code?: string;
+}
+
+// The override first, then per name (preferred before legacy) the bare name
+// on PATH and the common install locations plugins/cursor/scripts/run.sh
+// knows about. A GUI-launched host inherits launchd's or the desktop
+// session's PATH, which holds neither Homebrew's bin nor the `go install`
+// target, so a bare name alone is not enough. run.sh probes paths only; the
+// bare names are tried too because a host started from a shell usually has
+// the binary on PATH already.
+function binaryCandidates(
+  env: NodeJS.ProcessEnv,
+  exists: (path: string) => boolean,
+): BinaryCandidate[] {
+  const override = brandedEnv(env, "BIN");
+  const paths: string[] = [];
+  const home = (env.HOME ?? "").trim() || homedir();
+  for (const name of ["agento11y", "sigil"]) {
+    paths.push(name);
+    for (const dir of [
+      join(home, "go", "bin"),
+      "/opt/homebrew/bin",
+      "/usr/local/bin",
+      join(home, ".local", "bin"),
+    ]) {
+      // Filtered so the failure message names paths that exist, and so a host
+      // with no binary at all spawns two children rather than ten.
+      const path = join(dir, name);
+      if (exists(path)) paths.push(path);
+    }
+  }
+  const candidates = [...new Set(paths)].map((bin) => ({ bin }));
+  if (!override) return candidates;
+  return [
+    { bin: override.value, overrideKey: override.key },
+    ...candidates.filter((candidate) => candidate.bin !== override.value),
+  ];
+}
+
+async function defaultRunStatus(bin: string): Promise<string> {
+  // execFile with an argument array and no shell: a binary path from
+  // config.env never reaches a shell parser.
+  const { stdout } = await execFileAsync(bin, ["local", "status", "--json"], {
+    timeout: STATUS_TIMEOUT_MS,
+    encoding: "utf-8",
+  });
+  return stdout;
+}
+
+async function defaultProbe(endpoint: string): Promise<boolean> {
+  // Same check as the Go manager's endpointAlive: /healthz is the JSON
+  // liveness probe, while / serves the viewer HTML.
+  try {
+    const res = await fetch(`${endpoint.replace(/\/+$/, "")}/healthz`, {
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+// A candidate that is simply not installed needs no explanation in the final
+// error; anything else (a non-zero exit, a file that is not executable, a
+// timeout) is named there so a broken install is not reported as a missing
+// one.
+function describeFailures(failed: FailedCandidate[]): string {
+  if (failed.length === 0) return "nothing";
+  return failed
+    .map(({ bin, failure, code }) =>
+      code === "ENOENT" ? bin : `${bin} (${failure})`,
+    )
+    .join(", ");
+}
+
+function errorCode(err: unknown): string | undefined {
+  const code = (err as { code?: unknown } | null)?.code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function errorText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+interface BrandedValue {
+  value: string;
+  key: string;
+}
+
+function brandedEnv(
+  env: NodeJS.ProcessEnv,
+  suffix: string,
+): BrandedValue | undefined {
+  for (const key of [`AGENTO11Y_${suffix}`, `SIGIL_${suffix}`]) {
+    const value = (env[key] ?? "").trim();
+    if (value !== "") return { value, key };
+  }
+  return undefined;
+}


### PR DESCRIPTION
Add support for `AGENTO11Y_LOCAL` env var in Opencode and Pi + tests for the local mode.