### PR TITLE
feat(plugins/agento11y): show that forwarding is disabled in local mode

### DIFF
--- a/plugins/agento11y/internal/login/login.go
+++ b/plugins/agento11y/internal/login/login.go
@@ -462,12 +462,14 @@ func shouldOfferLocal(askUser, requested, supported bool) bool {
 func enableLocalMode(configPath string, opts RunOpts) (Result, error) {
 	updates := envconfig.ExpandAliases(map[string]string{
 		envconfig.LegacyKey("LOCAL"):                  "true",
+		envconfig.LegacyKey("LOCAL_FORWARD"):          "false",
 		envconfig.LegacyKey(envconfig.AutoTagsSuffix): "true",
 	})
 	if err := dotenv.WriteDotenv(configPath, updates, opts.Logger); err != nil {
 		return Result{}, err
 	}
 	envconfig.SetBothEnv("LOCAL", "true")
+	envconfig.SetBothEnv("LOCAL_FORWARD", "false")
 	envconfig.SetBothEnv(envconfig.AutoTagsSuffix, "true")
 	fmt.Fprintln(opts.Stderr, "Sessions will be captured on this machine.")
 	return Result{LocalMode: true}, nil

--- a/plugins/agento11y/internal/login/login_test.go
+++ b/plugins/agento11y/internal/login/login_test.go
@@ -1822,7 +1822,8 @@ func TestRun_ProbeResolvesInsecureLikeExporter(t *testing.T) {
 
 func TestEnableLocalMode(t *testing.T) {
 	envconfig.PinAliasEnvBlank(t)
-	path := filepath.Join(t.TempDir(), "config.env")
+	envconfig.SetBothEnv("LOCAL_FORWARD", "true")
+	path := writeDotenv(t, "AGENTO11Y_LOCAL_FORWARD=true\nSIGIL_LOCAL_FORWARD=true\n")
 	var stderr bytes.Buffer
 
 	result, err := enableLocalMode(path, RunOpts{Stderr: &stderr})
@@ -1835,8 +1836,10 @@ func TestEnableLocalMode(t *testing.T) {
 	want := map[string]string{
 		"AGENTO11Y_AUTO_CODING_AGENT_TAGS": "true",
 		"AGENTO11Y_LOCAL":                  "true",
+		"AGENTO11Y_LOCAL_FORWARD":          "false",
 		"SIGIL_AUTO_CODING_AGENT_TAGS":     "true",
 		"SIGIL_LOCAL":                      "true",
+		"SIGIL_LOCAL_FORWARD":              "false",
 	}
 	if got := dotenv.LoadDotenv(path, nil); !reflect.DeepEqual(got, want) {
 		t.Errorf("saved config = %v, want %v", got, want)


### PR DESCRIPTION
When the mode is local and forwarding is disabled, show it in the top corner

<img width="254" height="179" alt="image" src="https://github.com/user-attachments/assets/f0a98b39-35ef-4517-b117-843a915db45e" />
