### PR TITLE
feat(plugins/agento11y): add guard settings to local viewer

### DIFF
--- a/plugins/agento11y/internal/local/cloudguard.go
+++ b/plugins/agento11y/internal/local/cloudguard.go
@@ -99,6 +99,9 @@ func (l *forwardLoader) evaluateCloudHook(ctx context.Context, cfg forwardConfig
 
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxHookResponseBytes+1))
 	if err != nil {
+		if isCallerAbort(err) {
+			return out, fmt.Errorf("read response from %s: %w", cfg.hookURL, err)
+		}
 		return out, l.recordHookFailure("read response from %s: %v", cfg.hookURL, err)
 	}
 	if len(respBody) > maxHookResponseBytes {

--- a/plugins/agento11y/internal/local/cloudguard_test.go
+++ b/plugins/agento11y/internal/local/cloudguard_test.go
@@ -16,10 +16,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// hookLoader builds a forward loader with the hook leg pointed at the fake
-// Cloud. resolveForwardConfig refuses a loopback endpoint, which is the whole
-// point of that gate, so the resolved config is assembled here by hand; the
-// gate itself is covered through the server in server_test.go.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+type cancelReadBody struct {
+	ctx     context.Context
+	started chan struct{}
+}
+
+func (b *cancelReadBody) Read(_ []byte) (int, error) {
+	close(b.started)
+	<-b.ctx.Done()
+	return 0, b.ctx.Err()
+}
+
+func (*cancelReadBody) Close() error { return nil }
+
+// hookLoader builds a forward loader for the fake Cloud endpoint.
+// Relay-level tests assemble the resolved config directly.
 func hookLoader(t *testing.T, f *hookCloud) (*forwardLoader, forwardConfig) {
 	t.Helper()
 	clearForwardEnv(t)
@@ -188,7 +205,8 @@ func TestEvaluateCloudHook(t *testing.T) {
 			}
 			resp, err := l.evaluateCloudHook(ctx, cfg, timeout, []byte(`{"phase":"postflight"}`))
 
-			failures := l.status().Failures
+			st := l.status()
+			failures := st.Failures
 			if tc.wantFailure == "" {
 				require.NoError(t, err)
 				assert.Equal(t, 1, f.count())
@@ -206,6 +224,8 @@ func TestEvaluateCloudHook(t *testing.T) {
 			assert.Contains(t, err.Error(), tc.wantFailure)
 			if tc.abortMidCall {
 				assert.Empty(t, failures, "a caller-side abort is not a Cloud delivery failure")
+				assert.Nil(t, st.Legs, "an abandoned verdict changes no leg record")
+				assert.Zero(t, st.HookFailOpens, "an abandoned verdict is not a fail-open allow")
 			} else {
 				require.Len(t, failures, 1)
 				assert.Equal(t, forwardLabelHooks, failures[0].Label)
@@ -218,6 +238,41 @@ func TestEvaluateCloudHook(t *testing.T) {
 	}
 }
 
+func TestEvaluateCloudHook_CallerAbortWhileReadingBodyIsNotFailure(t *testing.T) {
+	clearForwardEnv(t)
+	l := newForwardLoader(writeConfigEnvFile(t, nil), nil)
+	started := make(chan struct{})
+	l.client = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Header:        make(http.Header),
+			Body:          &cancelReadBody{ctx: r.Context(), started: started},
+			ContentLength: -1,
+			Request:       r,
+		}, nil
+	})}
+	cfg := forwardConfig{
+		enabled:     true,
+		hookURL:     "https://cloud.example.test" + hookEvaluatePath,
+		hookHeaders: generationForwardHeaders("tenant-1", "token-1"),
+		failOpen:    true,
+		timeoutMs:   1500,
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() {
+		<-started
+		cancel()
+	}()
+
+	_, err := l.evaluateCloudHook(ctx, cfg, time.Minute, []byte(`{"phase":"postflight"}`))
+	require.ErrorIs(t, err, context.Canceled)
+	st := l.status()
+	assert.Empty(t, st.Failures)
+	assert.Nil(t, st.Legs)
+	assert.Zero(t, st.HookFailOpens)
+}
+
 // TestEvaluateCloudHook_SuccessClearsFailures covers the ring's semantics for
 // the hook leg: a delivered evaluation means the leg is healthy now.
 func TestEvaluateCloudHook_SuccessClearsFailures(t *testing.T) {
@@ -227,12 +282,21 @@ func TestEvaluateCloudHook_SuccessClearsFailures(t *testing.T) {
 
 	_, err := l.evaluateCloudHook(t.Context(), cfg, time.Second, []byte(`{}`))
 	require.Error(t, err)
-	require.Len(t, l.status().Failures, 1)
+	failed := l.status()
+	require.Len(t, failed.Failures, 1)
+	failedLeg := failed.Legs[forwardLabelHooks]
+	assert.Equal(t, failed.Failures[0].At, failedLeg.LastFailureAt)
+	assert.Equal(t, failed.Failures[0].Detail, failedLeg.LastFailureDetail)
 
 	f.status = http.StatusOK
 	_, err = l.evaluateCloudHook(t.Context(), cfg, time.Second, []byte(`{}`))
 	require.NoError(t, err)
-	assert.Empty(t, l.status().Failures)
+	recovered := l.status()
+	assert.Empty(t, recovered.Failures)
+	hooksLeg := recovered.Legs[forwardLabelHooks]
+	assert.NotEmpty(t, hooksLeg.LastSuccessAt)
+	assert.Equal(t, failedLeg.LastFailureAt, hooksLeg.LastFailureAt)
+	assert.Equal(t, failedLeg.LastFailureDetail, hooksLeg.LastFailureDetail)
 }
 
 // TestHookTimeoutFromHeader covers the budget the daemon gives its Cloud call.

--- a/plugins/agento11y/internal/local/forward.go
+++ b/plugins/agento11y/internal/local/forward.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
@@ -154,11 +155,11 @@ type forwardLoader struct {
 	cached       forwardConfig
 	loggedReason string // last refusal logged, so we log it only once
 
-	// failMu guards the failure ring and the fail-open counter, which are
-	// written from forward goroutines and the hook handler and read by the
-	// status endpoint.
+	// failMu guards delivery state written by forward goroutines and the hook
+	// handler and read by the status endpoint.
 	failMu    sync.Mutex
 	failures  []forwardFailure
+	legs      map[string]forwardLeg
 	failOpens int
 }
 
@@ -171,6 +172,7 @@ func newForwardLoader(path string, logger *log.Logger) *forwardLoader {
 		logger: logger,
 		client: &http.Client{Timeout: 10 * time.Second},
 		sem:    make(chan struct{}, maxInFlightForwards),
+		legs:   make(map[string]forwardLeg),
 	}
 }
 
@@ -242,6 +244,8 @@ type forwardStatus struct {
 	// delivering, which no other channel would tell the user about: the
 	// daemon's logger is discarded unless debug logging is on.
 	Failures []forwardFailure `json:"failures,omitempty"`
+	// Legs keeps each forwarding leg's last delivery and last failure.
+	Legs map[string]forwardLeg `json:"legs,omitempty"`
 	// HookFailOpens counts the tool calls allowed since the daemon started
 	// because a chained guard evaluation failed and GUARDS_FAIL_OPEN was on.
 	// Unlike Failures it is never cleared: the agent cannot tell such an allow
@@ -256,6 +260,13 @@ type forwardFailure struct {
 	At     string `json:"at"`
 	Label  string `json:"label"`
 	Detail string `json:"detail"`
+}
+
+// forwardLeg keeps the last delivery and failure after the failure ring clears.
+type forwardLeg struct {
+	LastSuccessAt     string `json:"lastSuccessAt,omitempty"`
+	LastFailureAt     string `json:"lastFailureAt,omitempty"`
+	LastFailureDetail string `json:"lastFailureDetail,omitempty"`
 }
 
 const (
@@ -279,6 +290,7 @@ func (l *forwardLoader) status() forwardStatus {
 		OTLPReason:    cfg.otlpReason,
 		HookReason:    cfg.hookReason,
 		Failures:      l.recentFailures(),
+		Legs:          l.recentLegs(),
 		HookFailOpens: l.recentFailOpens(),
 	}
 	switch {
@@ -382,15 +394,8 @@ func resolveForwardConfig(logger *log.Logger, get envReader) forwardConfig {
 	return cfg
 }
 
-// hookForwardDisabledReason reports why hook evaluation from a --local session
-// must not be relayed to Cloud, or "" when it may be.
-//
-// The hook leg is gated harder than the generation leg on purpose.
-// forwardDisabledReason accepts a local endpoint with empty or placeholder
-// credentials because posting telemetry to a second local daemon is a
-// legitimate setup; a hook chain to a local endpoint is not. It is either this
-// daemon (a recursion) or another always-allow stub, which would answer allow
-// while the user believes their Cloud rules ran.
+// hookForwardDisabledReason refuses hook relay when Cloud evaluation cannot
+// run. Unlike telemetry forwarding, a local hook target always allows.
 func hookForwardDisabledReason(guardsEnabled bool, endpoint, tenant, token string) string {
 	switch {
 	case !guardsEnabled:
@@ -623,11 +628,16 @@ func (l *forwardLoader) recordFailuref(label, format string, args ...any) {
 
 	l.failMu.Lock()
 	defer l.failMu.Unlock()
+	at := time.Now().UTC().Format(time.RFC3339Nano)
 	l.failures = append(l.failures, forwardFailure{
-		At:     time.Now().UTC().Format(time.RFC3339),
+		At:     at,
 		Label:  label,
 		Detail: detail,
 	})
+	leg := l.legs[label]
+	leg.LastFailureAt = at
+	leg.LastFailureDetail = detail
+	l.legs[label] = leg
 	// Trim this leg only. The hook leg records once per tool call, so a
 	// global trim would silently drop the one entry another leg had.
 	// Iterating backwards makes the deletions safe: they only shift entries
@@ -664,6 +674,9 @@ func (l *forwardLoader) recordSuccess(label string) {
 	l.failures = slices.DeleteFunc(l.failures, func(f forwardFailure) bool {
 		return f.Label == label
 	})
+	leg := l.legs[label]
+	leg.LastSuccessAt = time.Now().UTC().Format(time.RFC3339Nano)
+	l.legs[label] = leg
 }
 
 // recentFailOpens returns how many tool calls have been allowed without a
@@ -686,6 +699,16 @@ func (l *forwardLoader) recentFailures() []forwardFailure {
 		out = append(out, f)
 	}
 	return out
+}
+
+// recentLegs returns a copy of the per-leg delivery records.
+func (l *forwardLoader) recentLegs() map[string]forwardLeg {
+	l.failMu.Lock()
+	defer l.failMu.Unlock()
+	if len(l.legs) == 0 {
+		return nil
+	}
+	return maps.Clone(l.legs)
 }
 
 // enqueue runs fn on a bounded goroutine. When the in-flight limit is reached

--- a/plugins/agento11y/internal/local/forward_test.go
+++ b/plugins/agento11y/internal/local/forward_test.go
@@ -249,9 +249,7 @@ func TestForwardLoader_Resolve(t *testing.T) {
 			wantHookURL:    "https://cloud.example.test/api/v1/hooks:evaluate",
 		},
 		{
-			// A local endpoint is a legitimate generation target but never a
-			// hook target: it is either this daemon or another always-allow
-			// stub.
+			// A local daemon can receive telemetry, but its hook endpoint always allows.
 			name: "hooks_refused_for_local_endpoint",
 			lines: map[string]string{
 				"AGENTO11Y_LOCAL_FORWARD": "true", "AGENTO11Y_ENDPOINT": "http://127.0.0.1:8080",
@@ -999,7 +997,9 @@ func TestForwardLoader_StatusReportsFailures(t *testing.T) {
 	l.client = srv.Client()
 	cfg := l.load()
 	require.True(t, cfg.enabled)
-	assert.Empty(t, l.status().Failures)
+	initial := l.status()
+	assert.Empty(t, initial.Failures)
+	assert.Nil(t, initial.Legs, "no forwarding attempt has run")
 
 	status = http.StatusBadRequest
 	raw := generationRawJSON(t, contentRichGeneration(t))
@@ -1011,11 +1011,25 @@ func TestForwardLoader_StatusReportsFailures(t *testing.T) {
 	assert.Contains(t, failures[0].Detail, "status 400")
 	assert.Contains(t, failures[0].Detail, "parts.media.url")
 	assert.NotEmpty(t, failures[0].At)
+	failedLeg := l.status().Legs[forwardLabelGenerations]
+	assert.Equal(t, failures[0].At, failedLeg.LastFailureAt)
+	assert.Equal(t, failures[0].Detail, failedLeg.LastFailureDetail)
+	assert.Empty(t, failedLeg.LastSuccessAt)
 
-	// A success clears the leg, so a non-empty Failures means "failing now".
+	// A success clears the ring but keeps the earlier failure in the leg record.
 	status = http.StatusOK
 	l.forwardGenerations(cfg, []json.RawMessage{raw})
-	assert.Empty(t, l.status().Failures)
+	recovered := l.status()
+	assert.Empty(t, recovered.Failures)
+	generationLeg := recovered.Legs[forwardLabelGenerations]
+	assert.NotEmpty(t, generationLeg.LastSuccessAt)
+	failureAt, err := time.Parse(time.RFC3339Nano, generationLeg.LastFailureAt)
+	require.NoError(t, err)
+	successAt, err := time.Parse(time.RFC3339Nano, generationLeg.LastSuccessAt)
+	require.NoError(t, err)
+	assert.True(t, successAt.After(failureAt), "sub-second recovery order must be preserved")
+	assert.Equal(t, failedLeg.LastFailureAt, generationLeg.LastFailureAt)
+	assert.Equal(t, failedLeg.LastFailureDetail, generationLeg.LastFailureDetail)
 
 	// Only the leg that delivered is cleared. config.env cannot configure the
 	// OTLP leg at a 127.0.0.1 test server (otlpForwardTarget refuses a loopback
@@ -1024,12 +1038,16 @@ func TestForwardLoader_StatusReportsFailures(t *testing.T) {
 	status = http.StatusBadRequest
 	l.forwardGenerations(cfg, []json.RawMessage{raw})
 	require.Len(t, l.status().Failures, 1)
+	generationBeforeMetrics := l.status().Legs[forwardLabelGenerations]
 
 	status = http.StatusOK
 	l.forwardOTLP(cfg, "metrics", wire.ContentTypeProto, "", []byte("metrics-payload"))
-	failures = l.status().Failures
+	metricsDelivered := l.status()
+	failures = metricsDelivered.Failures
 	require.Len(t, failures, 1, "a metrics success must not clear a generations failure")
 	assert.Equal(t, forwardLabelGenerations, failures[0].Label)
+	assert.Equal(t, generationBeforeMetrics, metricsDelivered.Legs[forwardLabelGenerations])
+	assert.NotEmpty(t, metricsDelivered.Legs[otlpForwardLabel("metrics")].LastSuccessAt)
 
 	l.forwardGenerations(cfg, []json.RawMessage{raw})
 	assert.Empty(t, l.status().Failures)

--- a/plugins/agento11y/internal/local/server_test.go
+++ b/plugins/agento11y/internal/local/server_test.go
@@ -1343,10 +1343,7 @@ func TestServer_Forwarding_RelaysOTLP(t *testing.T) {
 // hookCloud is a fake Cloud hook endpoint: it records what the daemon relayed
 // and answers with a canned status and body, both settable between calls.
 //
-// It serves TLS because resolveForwardConfig refuses an http://127.0.0.1
-// endpoint as a hook target, so an https test server is what lets the server
-// tests go through the real gate instead of around it. newForwardingTestServer
-// trusts its cert, and the relay-level tests inject srv.Client() themselves.
+// TLS keeps this server outside IsLocalEndpoint. The test client trusts its cert.
 type hookCloud struct {
 	srv *httptest.Server
 
@@ -1512,6 +1509,27 @@ func TestServer_HookEvaluate_Gates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestServer_HookEvaluate_RefusesLocalRelay(t *testing.T) {
+	peer, _ := newTestServer(t)
+	hits := make(chan struct{}, 1)
+	peerHTTP := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits <- struct{}{}
+		peer.ServeHTTP(w, r)
+	}))
+	defer peerHTTP.Close()
+
+	source, _ := newForwardingTestServer(t, peerHTTP, hookEnv(peerHTTP.URL, nil))
+	status, out := postHook(t, source, hookToolCallBody, nil)
+
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, agento11y.HookActionAllow, out.Action)
+	st := source.forward.status()
+	assert.False(t, st.Hooks)
+	assert.Contains(t, st.HookReason, "is local")
+	assert.Len(t, hits, 0, "a local hook target must make no outbound request")
+	assert.Nil(t, st.Legs, "a refused relay must not record a Cloud delivery")
 }
 
 // TestServer_HookEvaluate_CloudVerdict covers the verdicts a chained call

--- a/plugins/agento11y/internal/local/web/src/notices.tsx
+++ b/plugins/agento11y/internal/local/web/src/notices.tsx
@@ -385,12 +385,13 @@ interface PillToggleProps {
   value?: string;
   onChange: (value: string) => void;
   size?: 'sm' | 'md';
+  disabled?: boolean;
 }
 
 // PillToggle's md size is for a control that carries a decision rather than
 // a view preference: the forwarding mode switch, which is the first thing on
 // the Cloud tab.
-export function PillToggle({ options, value, onChange, size = 'sm' }: PillToggleProps) {
+export function PillToggle({ options, value, onChange, size = 'sm', disabled = false }: PillToggleProps) {
   const md = size === 'md';
   return (
     <Stack
@@ -412,6 +413,8 @@ export function PillToggle({ options, value, onChange, size = 'sm' }: PillToggle
           <button
             key={o.value}
             type="button"
+            aria-pressed={active}
+            disabled={disabled}
             onClick={() => onChange(o.value)}
             style={{
               padding: md ? '7px 16px' : '5px 13px',
@@ -419,7 +422,8 @@ export function PillToggle({ options, value, onChange, size = 'sm' }: PillToggle
               background: active ? ACTIVE_PILL_BG : 'transparent',
               color: active ? 'var(--primary-text)' : 'var(--fg2)',
               border: 'none',
-              cursor: active ? 'default' : 'pointer',
+              cursor: disabled || active ? 'default' : 'pointer',
+              opacity: disabled ? 0.55 : 1,
               fontSize: md ? 13 : 12,
               fontWeight: active ? 600 : 400,
               fontFamily: 'var(--fontFamily)',

--- a/plugins/agento11y/internal/local/web/src/settings-model.tsx
+++ b/plugins/agento11y/internal/local/web/src/settings-model.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { formatAgo } from './formatters';
 import type { ConfigResponse, ForwardStatus, Settings } from './types';
 
 // ============================================================
@@ -14,13 +15,12 @@ export interface FormSettings extends Settings {
   promptGuardUrl?: unknown;
 }
 
-// ForwardStatusView adds the fail-open counter forwardStatus carries in
-// forward.go (omitempty, so it is absent when zero).
-interface ForwardStatusView extends ForwardStatus {
-  hookFailOpens?: number;
-}
-
 type ForwardAccent = 'success' | 'info' | 'warning' | 'error';
+
+export interface GuardStatusMeta {
+  accent: ForwardAccent;
+  line: string;
+}
 
 interface ForwardBannerMeta {
   accent: ForwardAccent;
@@ -136,7 +136,7 @@ export const GUARD_CONTENT_NOTE =
 // settings hero from. The saved toggle is deliberately not an input:
 // config.env and the daemon's own environment can disagree, and only the
 // daemon knows what it would actually send.
-function forwardBannerMeta(st: ForwardStatusView | null | undefined): ForwardBannerMeta {
+function forwardBannerMeta(st: ForwardStatus | null | undefined): ForwardBannerMeta {
   if (!st) {
     return {
       accent: 'warning',
@@ -214,6 +214,64 @@ function forwardBannerMeta(st: ForwardStatusView | null | undefined): ForwardBan
     accent: st.mode === 'full' || st.hooks ? 'warning' : 'info',
     pill: st.mode === 'full' ? 'Full content' : st.hooks ? 'Metadata + guard content' : 'Metadata only',
     line: parts.join(' '),
+  };
+}
+
+function timestampIsAfter(left: string, right: string): boolean {
+  const leftMillis = Date.parse(left);
+  const rightMillis = Date.parse(right);
+  if (leftMillis !== rightMillis) return leftMillis > rightMillis;
+
+  // Date.parse drops the digits after milliseconds.
+  const nanoseconds = (timestamp: string) => {
+    const fraction = timestamp.match(/\.(\d+)(?:Z|[+-]\d{2}:\d{2})$/)?.[1] ?? '';
+    return Number(fraction.padEnd(9, '0').slice(0, 9));
+  };
+  return nanoseconds(left) > nanoseconds(right);
+}
+
+// guardStatusMeta reports the most recent outcome of the Cloud guard leg.
+export function guardStatusMeta(st: ForwardStatus | null | undefined, now: number): GuardStatusMeta {
+  if (!st) {
+    return {
+      accent: 'warning',
+      line: "Couldn't read the daemon's guard status.",
+    };
+  }
+  if (st.hookReason) {
+    return { accent: 'info', line: st.hookReason };
+  }
+  if (!st.enabled) {
+    return {
+      accent: 'info',
+      line: 'Cloud forwarding is off, so this daemon does not relay guard checks.',
+    };
+  }
+
+  const leg = st.legs?.hooks;
+  if (!leg?.lastSuccessAt && !leg?.lastFailureAt) {
+    return {
+      accent: 'info',
+      line: 'The daemon has not recorded a Cloud guard verdict or evaluation failure since it started.',
+    };
+  }
+
+  const failureIsLatest =
+    !!leg.lastFailureAt && (!leg.lastSuccessAt || timestampIsAfter(leg.lastFailureAt, leg.lastSuccessAt));
+  if (failureIsLatest) {
+    const lastVerdict = leg.lastSuccessAt ? ` The last Cloud verdict was ${formatAgo(leg.lastSuccessAt, now)}.` : '';
+    return {
+      accent: 'error',
+      line: `The latest guard evaluation got no Cloud verdict ${formatAgo(leg.lastFailureAt, now)}: ${leg.lastFailureDetail || 'Unknown error'}.${lastVerdict}`,
+    };
+  }
+
+  const earlierFailure = leg.lastFailureAt
+    ? ` The previous evaluation got no verdict ${formatAgo(leg.lastFailureAt, now)}: ${leg.lastFailureDetail || 'Unknown error'}.`
+    : '';
+  return {
+    accent: 'success',
+    line: `Cloud returned a verdict ${formatAgo(leg.lastSuccessAt, now)}.${earlierFailure}`,
   };
 }
 

--- a/plugins/agento11y/internal/local/web/src/settings-screen.tsx
+++ b/plugins/agento11y/internal/local/web/src/settings-screen.tsx
@@ -18,13 +18,22 @@ import {
   cloneSettings,
   cloudConfigured,
   forwardChipMeta,
-  GUARD_CONTENT_NOTE,
+  guardStatusMeta,
   Mono,
   pendingEdits,
   sameSettings,
 } from './settings-model';
 import { Icon } from './shell';
-import type { ConfigResponse, HistoryAgent, HistoryOffer, HistoryPlan, ImportRun, Settings, Tag } from './types';
+import type {
+  ConfigResponse,
+  ForwardStatus,
+  HistoryAgent,
+  HistoryOffer,
+  HistoryPlan,
+  ImportRun,
+  Settings,
+  Tag,
+} from './types';
 
 // ============================================================
 // History import — backfill sessions an agent recorded before
@@ -1074,6 +1083,11 @@ const FORWARD_LOCAL_OPTIONS = [
   { value: 'metadata_only', label: 'Metadata only' },
   { value: 'full', label: 'Full' },
 ];
+const GUARD_OPTIONS = [
+  { value: 'off', label: 'Off' },
+  { value: 'failopen', label: 'Fail open' },
+  { value: 'failclosed', label: 'Fail closed' },
+];
 // Connecting turns forwarding on, so the connect flow offers the same modes
 // without the off case.
 const CONNECT_MODE_OPTIONS = FORWARD_LOCAL_OPTIONS.filter((o) => o.value !== 'off');
@@ -1758,6 +1772,7 @@ interface SettingsCloudTabProps {
   form: Settings;
   set: (patch: Partial<Settings>) => void;
   savedEndpoint: string;
+  savedGuards: string;
   config: ConfigResponse | null;
   stackUrl: string;
   configured: boolean;
@@ -1765,6 +1780,114 @@ interface SettingsCloudTabProps {
   onConnect: (parsed: ConnectBlock, mode: string) => void;
   onDisconnect: () => void;
   onMode: (mode: string, forceLocalOff?: boolean) => void;
+}
+
+interface SettingsGuardsCardProps {
+  form: Settings;
+  savedGuards: string;
+  set: (patch: Partial<Settings>) => void;
+  status: ForwardStatus | null;
+  localOnly: boolean;
+}
+
+export function SettingsGuardsCard({ form, savedGuards, set, status, localOnly }: SettingsGuardsCardProps) {
+  const guardsConfigured = form.guards === 'failopen' || form.guards === 'failclosed';
+  const savedGuardsConfigured = savedGuards === 'failopen' || savedGuards === 'failclosed';
+  const guardsOn = guardsConfigured && !localOnly;
+  const timeout = form.guardTimeout.trim();
+  const invalidTimeout = timeout !== '' && !/^[1-9]\d*$/.test(timeout);
+  const meta = guardStatusMeta(status, Date.now());
+
+  return (
+    <SettingsCard>
+      <SectionLabel>Guards</SectionLabel>
+      <div
+        style={{
+          fontSize: 12,
+          lineHeight: 1.5,
+          color: 'var(--fg3)',
+          padding: '0 0 4px',
+          maxWidth: 620,
+        }}
+      >
+        A guard check runs before a tool call and is evaluated by your Cloud rules.
+      </div>
+      <SettingRow
+        label="Fail mode"
+        help="Fail open allows the call when Cloud cannot answer. Fail closed blocks it. Off skips guard checks."
+      >
+        <PillToggle
+          size="md"
+          value={guardsOn ? form.guards : 'off'}
+          onChange={(guards) => set({ guards })}
+          options={GUARD_OPTIONS}
+          disabled={localOnly}
+        />
+      </SettingRow>
+      {guardsOn && (
+        <SettingRow label="Timeout" help="Maximum time to wait for a guard verdict.">
+          <div style={{ textAlign: 'right' }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 8 }}>
+              <MonoInput
+                value={form.guardTimeout}
+                onChange={(guardTimeout) => set({ guardTimeout })}
+                placeholder="1500"
+                width={100}
+                align="right"
+              />
+              <Mono>ms</Mono>
+            </div>
+            {invalidTimeout && (
+              <div style={{ color: 'var(--warning-text)', fontSize: 12, lineHeight: 1.5, marginTop: 6 }}>
+                Enter a positive integer.
+              </div>
+            )}
+          </div>
+        </SettingRow>
+      )}
+      {localOnly ? (
+        <div style={{ padding: '14px 0 0' }}>
+          <Notice kind="info" title="Cloud guards are off for local sessions">
+            Select Metadata only or Full above to use Cloud guards.
+            {savedGuardsConfigured && (
+              <>
+                {' '}
+                Non-local sessions still use the saved {savedGuards === 'failclosed' ? 'Fail closed' : 'Fail open'}{' '}
+                mode.
+              </>
+            )}
+          </Notice>
+        </div>
+      ) : (
+        <div style={{ fontSize: 12, lineHeight: 1.5, color: 'var(--fg3)', padding: '12px 0 0' }}>
+          Restart a running agent if it does not use the new guard settings.
+        </div>
+      )}
+      {guardsOn && (
+        <div
+          style={{
+            display: 'flex',
+            gap: 10,
+            alignItems: 'flex-start',
+            padding: '14px 0 4px',
+            maxWidth: 640,
+          }}
+        >
+          <span
+            style={{
+              flex: 'none',
+              width: 7,
+              height: 7,
+              borderRadius: '50%',
+              marginTop: 6,
+              background: `var(--${meta.accent}-text)`,
+            }}
+          />
+          <div style={{ fontSize: 12.5, lineHeight: 1.55, color: 'var(--fg2)' }}>{meta.line}</div>
+        </div>
+      )}
+    </SettingsCard>
+  );
 }
 
 // savedEndpoint is the endpoint on disk, which is not form.endpoint while the
@@ -1775,6 +1898,7 @@ function SettingsCloudTab({
   form,
   set,
   savedEndpoint,
+  savedGuards,
   config,
   stackUrl,
   configured,
@@ -1811,9 +1935,7 @@ function SettingsCloudTab({
   // its own environment at boot, so "off here, on there" is reachable until
   // an explicit false is saved.
   const daemonStillOn = !!forwardStatus?.enabled && !form.localForward;
-  // Say it next to the control that sets the capture mode, not only in the
-  // header chip.
-  const guardsChained = !!forwardStatus?.hooks;
+  const localOnly = forwardMode === 'off' && !daemonStillOn;
   const failures = forwardStatus?.failures || [];
   // recentFailures outlives being turned off, so a failure list alone would
   // put an error notice under the calm "forwarding is off" line.
@@ -1833,7 +1955,7 @@ function SettingsCloudTab({
     onMode(mode, mode === 'off' && daemonStillOn);
   };
 
-  return (
+  const forwardingCard = (
     <SettingsCard style={{ padding: '4px 20px 20px' }}>
       <SectionLabel>Cloud forwarding</SectionLabel>
       <div
@@ -1892,17 +2014,6 @@ function SettingsCloudTab({
               overrides that, but only once it holds an explicit <Mono>false</Mono>.{' '}
               <b style={{ fontWeight: 500, color: 'var(--fg2)' }}>Local only</b> is already selected here, so click it
               to write that <Mono>false</Mono>.
-            </div>
-          )}
-          {guardsChained && (
-            <div
-              style={{
-                color: 'var(--warning-text)',
-                marginTop: 6,
-              }}
-            >
-              {GUARD_CONTENT_NOTE} The daemon relays <Mono>--local</Mono> guard checks to Cloud so your Cloud rules
-              still apply; turn off <Mono>GUARDS_ENABLED</Mono> or forwarding to stop it.
             </div>
           )}
         </div>
@@ -2068,6 +2179,19 @@ function SettingsCloudTab({
           )}
         </>
       )}
+    </SettingsCard>
+  );
+
+  return (
+    <>
+      {forwardingCard}
+      <SettingsGuardsCard
+        form={form}
+        savedGuards={savedGuards}
+        set={set}
+        status={forwardStatus}
+        localOnly={localOnly}
+      />
 
       {confirmFull && (
         <ConfirmFullContentModal
@@ -2135,7 +2259,7 @@ function SettingsCloudTab({
           </div>
         </ModalFrame>
       )}
-    </SettingsCard>
+    </>
   );
 }
 
@@ -2469,6 +2593,7 @@ interface SettingsTabPanelsProps {
   form: Settings;
   set: (patch: Partial<Settings>) => void;
   savedEndpoint: string;
+  savedGuards: string;
   setTag: (index: number, patch: Partial<Tag>) => void;
   addTag: () => void;
   removeTag: (index: number) => void;
@@ -2487,6 +2612,7 @@ function SettingsTabPanels({
   form,
   set,
   savedEndpoint,
+  savedGuards,
   setTag,
   addTag,
   removeTag,
@@ -2506,6 +2632,7 @@ function SettingsTabPanels({
           form={form}
           set={set}
           savedEndpoint={savedEndpoint}
+          savedGuards={savedGuards}
           config={config}
           stackUrl={stackUrl}
           configured={configured}
@@ -2778,6 +2905,7 @@ export function SettingsView({
             form={form}
             set={set}
             savedEndpoint={(saved as Settings).endpoint}
+            savedGuards={(saved as Settings).guards}
             setTag={setTag}
             addTag={addTag}
             removeTag={removeTag}

--- a/plugins/agento11y/internal/local/web/src/types.ts
+++ b/plugins/agento11y/internal/local/web/src/types.ts
@@ -204,6 +204,13 @@ interface ForwardFailure {
   detail: string;
 }
 
+/** forwardLeg in forward.go: one forwarding leg's latest outcomes. */
+export interface ForwardLeg {
+  lastSuccessAt?: string;
+  lastFailureAt?: string;
+  lastFailureDetail?: string;
+}
+
 /** forwardStatus in forward.go: what the daemon would actually send to Cloud. */
 export interface ForwardStatus {
   enabled: boolean;
@@ -216,6 +223,8 @@ export interface ForwardStatus {
   otlpReason?: string;
   hookReason?: string;
   failures?: ForwardFailure[];
+  legs?: Record<string, ForwardLeg>;
+  hookFailOpens?: number;
 }
 
 /** configResponse in server.go: GET /api/v1/config. */

--- a/plugins/agento11y/tests/settings-guards.test.tsx
+++ b/plugins/agento11y/tests/settings-guards.test.tsx
@@ -1,0 +1,89 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SettingsGuardsCard } from '../internal/local/web/src/settings-screen';
+import type { Settings } from '../internal/local/web/src/types';
+
+afterEach(cleanup);
+
+function settings(overrides: Partial<Settings> = {}): Settings {
+  return {
+    endpoint: '',
+    tenantId: '',
+    otlpEndpoint: '',
+    tokenSet: false,
+    token: '',
+    tokenCleared: false,
+    otlpHeaders: '',
+    otlpHeadersSet: false,
+    otlpHeadersCleared: false,
+    capture: '',
+    tags: [],
+    guards: 'failclosed',
+    guardTimeout: '2200',
+    debug: false,
+    autoUpdate: false,
+    userId: '',
+    localForward: false,
+    ...overrides,
+  };
+}
+
+describe('SettingsGuardsCard', () => {
+  it('shows guards as disabled and off for Local only sessions', () => {
+    const set = vi.fn();
+    render(<SettingsGuardsCard form={settings()} savedGuards="failclosed" set={set} status={null} localOnly={true} />);
+
+    const off = screen.getByRole('button', { name: 'Off' });
+    expect(off.hasAttribute('disabled')).toBe(true);
+    expect(off.getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('button', { name: 'Fail open' }).hasAttribute('disabled')).toBe(true);
+    expect(screen.getByRole('button', { name: 'Fail closed' }).hasAttribute('disabled')).toBe(true);
+    expect(screen.queryByDisplayValue('2200')).toBeNull();
+    expect(screen.getByText('Cloud guards are off for local sessions')).toBeTruthy();
+    expect(screen.getByText(/Select Metadata only or Full above to use Cloud guards/)).toBeTruthy();
+    expect(screen.getByText(/Non-local sessions still use the saved Fail closed mode/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fail open' }));
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it('names the saved mode when the form has an unsaved guard edit', () => {
+    render(
+      <SettingsGuardsCard
+        form={settings({ guards: 'failopen' })}
+        savedGuards="failclosed"
+        set={vi.fn()}
+        status={null}
+        localOnly={true}
+      />,
+    );
+
+    expect(screen.getByText(/Non-local sessions still use the saved Fail closed mode/)).toBeTruthy();
+  });
+
+  it('does not claim a saved mode when guards are off on disk', () => {
+    render(
+      <SettingsGuardsCard
+        form={settings({ guards: 'failopen' })}
+        savedGuards="off"
+        set={vi.fn()}
+        status={null}
+        localOnly={true}
+      />,
+    );
+
+    expect(screen.queryByText(/Non-local sessions still use/)).toBeNull();
+  });
+
+  it('shows the saved guard mode when Cloud forwarding is on', () => {
+    render(
+      <SettingsGuardsCard form={settings()} savedGuards="failclosed" set={vi.fn()} status={null} localOnly={false} />,
+    );
+
+    const failClosed = screen.getByRole('button', { name: 'Fail closed' });
+    expect(failClosed.hasAttribute('disabled')).toBe(false);
+    expect(failClosed.getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByDisplayValue('2200')).toBeTruthy();
+    expect(screen.getByText('Restart a running agent if it does not use the new guard settings.')).toBeTruthy();
+  });
+});

--- a/plugins/agento11y/tests/settings.test.ts
+++ b/plugins/agento11y/tests/settings.test.ts
@@ -3,6 +3,7 @@ import {
   cloudConfigured,
   type FormSettings,
   forwardChipMeta,
+  guardStatusMeta,
   pendingEdits,
   sameSettings,
 } from '../internal/local/web/src/settings-model';
@@ -173,6 +174,104 @@ describe('forwardLocalPatch', () => {
     expect(forwardLocalPatch({ localForward: true, capture: 'full' }, 'metadata_only')).toEqual({
       localForward: true,
       capture: 'metadata_only',
+    });
+  });
+});
+
+describe('guardStatusMeta', () => {
+  const now = Date.parse('2026-08-22T12:00:00Z');
+  const status = (overrides: Partial<ForwardStatus> = {}): ForwardStatus => ({
+    enabled: true,
+    mode: 'metadata_only',
+    generations: true,
+    otlp: true,
+    hooks: true,
+    ...overrides,
+  });
+
+  it('reports why the hook leg is refused', () => {
+    expect(
+      guardStatusMeta(
+        status({
+          hookReason: 'guard forwarding needs usable Cloud credentials',
+          legs: { hooks: { lastSuccessAt: '2026-08-22T11:59:00Z' } },
+        }),
+        now,
+      ),
+    ).toEqual({ accent: 'info', line: 'guard forwarding needs usable Cloud credentials' });
+  });
+
+  it('reports that Cloud forwarding is off', () => {
+    expect(guardStatusMeta(status({ enabled: false, hooks: false }), now)).toEqual({
+      accent: 'info',
+      line: 'Cloud forwarding is off, so this daemon does not relay guard checks.',
+    });
+  });
+
+  it('reports that no outcome has been recorded yet', () => {
+    expect(guardStatusMeta(status(), now)).toEqual({
+      accent: 'info',
+      line: 'The daemon has not recorded a Cloud guard verdict or evaluation failure since it started.',
+    });
+  });
+
+  it('reports a failure newer than the last delivery', () => {
+    expect(
+      guardStatusMeta(
+        status({
+          legs: {
+            hooks: {
+              lastSuccessAt: '2026-08-22T11:58:00Z',
+              lastFailureAt: '2026-08-22T11:59:00Z',
+              lastFailureDetail: 'connection refused',
+            },
+          },
+        }),
+        now,
+      ),
+    ).toEqual({
+      accent: 'error',
+      line: 'The latest guard evaluation got no Cloud verdict 1m ago: connection refused. The last Cloud verdict was 2m ago.',
+    });
+  });
+
+  it('orders outcomes within the same millisecond', () => {
+    expect(
+      guardStatusMeta(
+        status({
+          legs: {
+            hooks: {
+              lastSuccessAt: '2026-08-22T11:59:00.123100000Z',
+              lastFailureAt: '2026-08-22T11:59:00.123900000Z',
+              lastFailureDetail: 'connection refused',
+            },
+          },
+        }),
+        now,
+      ),
+    ).toEqual({
+      accent: 'error',
+      line: 'The latest guard evaluation got no Cloud verdict 1m ago: connection refused. The last Cloud verdict was 1m ago.',
+    });
+  });
+
+  it('reports a recovery and keeps the earlier error', () => {
+    expect(
+      guardStatusMeta(
+        status({
+          legs: {
+            hooks: {
+              lastSuccessAt: '2026-08-22T11:59:00Z',
+              lastFailureAt: '2026-08-22T11:58:00Z',
+              lastFailureDetail: 'connection refused',
+            },
+          },
+        }),
+        now,
+      ),
+    ).toEqual({
+      accent: 'success',
+      line: 'Cloud returned a verdict 1m ago. The previous evaluation got no verdict 2m ago: connection refused.',
     });
   });
 });


### PR DESCRIPTION
**Cloud forwarding disabled**

<img width="989" height="296" alt="image" src="https://github.com/user-attachments/assets/889a1cde-2ed7-468d-9f95-b95eff8a9995" />

**Cloud forwarding enabled**

<img width="1002" height="335" alt="image" src="https://github.com/user-attachments/assets/b6f31382-ea89-4108-b09e-487e69171648" />

**On error**

<img width="991" height="358" alt="image" src="https://github.com/user-attachments/assets/060eaa82-11db-4663-a01c-b2d2f7cea646" />
