### PR TITLE
feat(plugins/agento11y): block denied prompts

### DIFF
--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -143,7 +143,7 @@ Find these values at `https://<your-grafana>.grafana.net/a/grafana-agento11y-app
 
 ### Content capture
 
-The shared `agento11y` binary defaults to `metadata_only`: only model, tokens, tool names, timing, and cost ship to Grafana Agent Observability. Prompts, responses, and tool I/O stay on the local machine. To opt into sending content, set `AGENTO11Y_CONTENT_CAPTURE_MODE` in `~/.config/agento11y/config.env`. The shared binary parser accepts every mode the SDKs support:
+The shared `agento11y` binary defaults to `metadata_only`: only model, tokens, tool names, timing, and cost ship to Grafana Agent Observability. Prompts, responses, and tool I/O stay local unless guards are enabled. Guards send evaluated messages and tool arguments to `AGENTO11Y_ENDPOINT` in every capture mode. To send captured content, set `AGENTO11Y_CONTENT_CAPTURE_MODE` in `~/.config/agento11y/config.env`. The shared parser accepts every SDK mode:
 
 ```dotenv
 # valid values: full | no_tool_content | metadata_only | full_with_metadata_spans

--- a/plugins/agento11y/internal/agents/claudecode/hook.go
+++ b/plugins/agento11y/internal/agents/claudecode/hook.go
@@ -77,6 +77,7 @@ type hookInput struct {
 	ToolName       string          `json:"tool_name,omitempty"`
 	ToolInput      json.RawMessage `json:"tool_input,omitempty"`
 	ToolUseID      string          `json:"tool_use_id,omitempty"`
+	Prompt         string          `json:"prompt,omitempty"`
 }
 
 // Hook reads a single Claude Code hook payload from stdin, processes it, and
@@ -117,6 +118,11 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 		guardCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 		handlePreToolUse(guardCtx, stdout, input, st, resolvedAgentName, logger)
+		return nil
+	case "UserPromptSubmit":
+		guardCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		handleUserPromptSubmit(guardCtx, stdout, input, st, resolvedAgentName, logger)
 		return nil
 	case "", "Stop", "SessionEnd":
 		// Fall through to transcript export below.
@@ -268,6 +274,23 @@ func handlePreToolUse(ctx context.Context, stdout io.Writer, input *hookInput, s
 	}
 	if len(res.UpdatedInputJSON) > 0 {
 		guard.WriteHookSpecificOutputUpdatedInput(stdout, res.UpdatedInputJSON)
+	}
+}
+
+// handleUserPromptSubmit writes a block response when a preflight guard denies
+// the prompt or fails closed. Claude Code shows the reason and stops the turn.
+//
+// Prompt capture still happens from the transcript at Stop.
+func handleUserPromptSubmit(ctx context.Context, stdout io.Writer, input *hookInput, st state.Session, agentName string, logger *log.Logger) {
+	res := guard.EvaluatePrompt(ctx, envconfig.ResolveGuards(logger), guard.PromptInput{
+		AgentName:     agentName,
+		AgentVersion:  Version,
+		ModelProvider: "anthropic",
+		ModelName:     strings.TrimSpace(st.Model),
+		Prompt:        input.Prompt,
+	}, logger)
+	if res.Blocked() {
+		guard.WritePromptBlock(stdout, res.Reason)
 	}
 }
 

--- a/plugins/agento11y/internal/agents/claudecode/hook_test.go
+++ b/plugins/agento11y/internal/agents/claudecode/hook_test.go
@@ -145,6 +145,19 @@ func TestHookEventRouting(t *testing.T) {
 			},
 		},
 		{
+			name: "UserPromptSubmit does not process transcript",
+			setup: func(t *testing.T, dir string) hookInput {
+				t.Helper()
+				return hookInput{
+					HookEventName:  "UserPromptSubmit",
+					SessionID:      "prompt-route",
+					TranscriptPath: filepath.Join(dir, "missing.jsonl"),
+					Prompt:         "hello",
+				}
+			},
+			wantMissingLogs: []string{"read transcript:", "raw lines"},
+		},
+		{
 			name: "unknown event does not process transcript",
 			setup: func(t *testing.T, dir string) hookInput {
 				t.Helper()
@@ -309,6 +322,130 @@ func TestHandlePreToolUse(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestHandleUserPromptSubmit(t *testing.T) {
+	var calls atomic.Int32
+	var responseBody atomic.Value
+	responseBody.Store("")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		body, _ := responseBody.Load().(string)
+		if body == "" {
+			body = `{"action":"allow"}`
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name               string
+		env                map[string]string
+		serverResponds     string
+		expectServerCall   bool
+		wantStdoutContains []string
+		wantStdoutEmpty    bool
+	}{
+		{
+			name:            "disabled_by_default",
+			wantStdoutEmpty: true,
+		},
+		{
+			name:             "enabled_allow",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow"}`,
+			expectServerCall: true,
+			wantStdoutEmpty:  true,
+		},
+		{
+			name:             "enabled_deny_writes_block_envelope",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"deny","reason":"secret in prompt"}`,
+			expectServerCall: true,
+			wantStdoutContains: []string{
+				`"decision":"block"`,
+				`A Grafana Agent Observability policy`,
+				`secret in prompt`,
+			},
+		},
+		{
+			// Claude Code cannot apply a prompt transform.
+			name:             "enabled_allow_transform_stays_silent",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow","transformed_input":{"messages":[{"role":"user","parts":[{"kind":"text","text":"[REDACTED]"}]}]}}`,
+			expectServerCall: true,
+			wantStdoutEmpty:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envconfig.PinAliasEnvBlank(t)
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			t.Setenv("SIGIL_ENDPOINT", server.URL)
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
+
+			calls.Store(0)
+			responseBody.Store(tt.serverResponds)
+
+			var stdout bytes.Buffer
+			var logs bytes.Buffer
+			input := &hookInput{
+				HookEventName:  "UserPromptSubmit",
+				SessionID:      "s1",
+				TranscriptPath: "/tmp/t.jsonl",
+				Prompt:         "my token is glc_secret",
+			}
+			st := state.Session{Model: "claude-sonnet-4"}
+
+			handleUserPromptSubmit(context.Background(), &stdout, input, st, AgentName, log.New(&logs, "", 0))
+
+			if tt.expectServerCall && calls.Load() == 0 {
+				t.Errorf("expected server call, got 0")
+			}
+			if !tt.expectServerCall && calls.Load() != 0 {
+				t.Errorf("expected no server call, got %d", calls.Load())
+			}
+			if tt.wantStdoutEmpty && stdout.Len() != 0 {
+				t.Errorf("stdout not empty: %q", stdout.String())
+			}
+			for _, want := range tt.wantStdoutContains {
+				if !strings.Contains(stdout.String(), want) {
+					t.Errorf("stdout missing %q\nfull output: %s", want, stdout.String())
+				}
+			}
+		})
+	}
+}
+
+// Hook must return nil because a non-zero exit runs the `sigil` fallback and
+// sends the prompt.
+func TestHook_UserPromptSubmitDenyReturnsNil(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"action":"deny","reason":"secret in prompt"}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	envconfig.PinAliasEnvBlank(t)
+	t.Setenv("SIGIL_GUARDS_ENABLED", "true")
+	t.Setenv("SIGIL_ENDPOINT", server.URL)
+	t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+	t.Setenv("SIGIL_AUTH_TOKEN", "token")
+
+	stdin := strings.NewReader(`{"hook_event_name":"UserPromptSubmit","session_id":"s1","transcript_path":"/tmp/t.jsonl","prompt":"my token is glc_secret"}`)
+	var stdout bytes.Buffer
+	if err := Hook(context.Background(), stdin, &stdout, log.New(io.Discard, "", 0)); err != nil {
+		t.Fatalf("Hook returned %v; a non-zero exit would run the sigil fallback", err)
+	}
+	if !strings.Contains(stdout.String(), `"decision":"block"`) {
+		t.Errorf("stdout = %q, want a block envelope", stdout.String())
 	}
 }
 

--- a/plugins/agento11y/internal/agents/codex/hook.go
+++ b/plugins/agento11y/internal/agents/codex/hook.go
@@ -46,7 +46,7 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 	case "SessionStart":
 		hook.SessionStart(payload, cfg, logger)
 	case "UserPromptSubmit":
-		hook.UserPromptSubmit(payload, cfg, logger)
+		hook.UserPromptSubmit(ctx, stdout, payload, cfg, logger)
 	case "PreToolUse":
 		hook.PreToolUse(ctx, stdout, payload, cfg, logger)
 	case "PostToolUse":

--- a/plugins/agento11y/internal/agents/codex/hook/handlers.go
+++ b/plugins/agento11y/internal/agents/codex/hook/handlers.go
@@ -66,7 +66,24 @@ func SessionStart(p Payload, _ config.Config, logger *log.Logger) {
 	}
 }
 
-func UserPromptSubmit(p Payload, cfg config.Config, logger *log.Logger) {
+// UserPromptSubmit evaluates preflight guards before capturing the prompt.
+// On denial it writes a block response, and Codex stops the turn.
+func UserPromptSubmit(ctx context.Context, stdout io.Writer, p Payload, cfg config.Config, logger *log.Logger) {
+	res := guard.EvaluatePrompt(ctx, cfg.Guards, guard.PromptInput{
+		AgentName:     cfg.Agent(),
+		ModelProvider: mapperutil.InferProvider(p.Model),
+		ModelName:     p.Model,
+		Prompt:        p.Prompt,
+	}, logger)
+	if res.Blocked() {
+		guard.WritePromptBlock(stdout, res.Reason)
+		return
+	}
+
+	capturePrompt(p, cfg, logger)
+}
+
+func capturePrompt(p Payload, cfg config.Config, logger *log.Logger) {
 	if p.SessionID == "" || p.TurnID == "" {
 		logger.Print("userPromptSubmit: missing session_id or turn_id")
 		return

--- a/plugins/agento11y/internal/agents/codex/hook/handlers_test.go
+++ b/plugins/agento11y/internal/agents/codex/hook/handlers_test.go
@@ -44,7 +44,7 @@ func TestSessionStartWithoutTurnIDSeedsLaterTurn(t *testing.T) {
 		Timestamp:      "2026-05-11T10:00:00Z",
 	}, cfg, logger)
 
-	UserPromptSubmit(Payload{
+	UserPromptSubmit(context.Background(), io.Discard, Payload{
 		HookEventName: "UserPromptSubmit",
 		SessionID:     "sess",
 		TurnID:        "turn",
@@ -487,7 +487,7 @@ func TestStopResolvesSubagentParentGeneration(t *testing.T) {
 
 	SessionStart(Payload{HookEventName: "SessionStart", SessionID: "parent", TranscriptPath: parentTranscript}, cfg, logger)
 	SessionStart(Payload{HookEventName: "SessionStart", SessionID: "child", TranscriptPath: childTranscript}, cfg, logger)
-	UserPromptSubmit(Payload{HookEventName: "UserPromptSubmit", SessionID: "child", TurnID: "child-turn"}, cfg, logger)
+	UserPromptSubmit(context.Background(), io.Discard, Payload{HookEventName: "UserPromptSubmit", SessionID: "child", TurnID: "child-turn"}, cfg, logger)
 
 	Stop(Payload{HookEventName: "Stop", SessionID: "child", TurnID: "child-turn", Timestamp: "2026-05-11T10:00:00Z"}, cfg, logger)
 
@@ -999,6 +999,114 @@ func TestPreToolUseGuard(t *testing.T) {
 			}
 			if tt.wantLogContains != "" && !strings.Contains(logs.String(), tt.wantLogContains) {
 				t.Errorf("logs missing %q:\n%s", tt.wantLogContains, logs.String())
+			}
+		})
+	}
+}
+
+func TestUserPromptSubmitGuard(t *testing.T) {
+	var responseBody atomic.Value
+	responseBody.Store("")
+	var calls atomic.Int32
+	server := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		body, _ := responseBody.Load().(string)
+		if body == "" {
+			body = `{"action":"allow"}`
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name               string
+		env                map[string]string
+		serverResponds     string
+		expectServerCall   bool
+		wantStdoutEmpty    bool
+		wantStdoutContains []string
+		wantCaptured       bool
+	}{
+		{
+			name:            "disabled_by_default_no_env",
+			wantStdoutEmpty: true,
+			wantCaptured:    true,
+		},
+		{
+			name:             "enabled_allow_response",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow"}`,
+			expectServerCall: true,
+			wantStdoutEmpty:  true,
+			wantCaptured:     true,
+		},
+		{
+			name:               "enabled_deny_response",
+			env:                map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:     `{"action":"deny","reason":"secret in prompt"}`,
+			expectServerCall:   true,
+			wantStdoutContains: []string{`"decision":"block"`, "secret in prompt", "blocked this message"},
+		},
+		{
+			// Shared-binary hosts ignore prompt transforms.
+			name:             "enabled_allow_with_transform_is_ignored",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:   `{"action":"allow","transformed_input":{"messages":[{"role":"user","parts":[{"kind":"text","text":"[REDACTED]"}]}]}}`,
+			expectServerCall: true,
+			wantStdoutEmpty:  true,
+			wantCaptured:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			// Clear primary variables to avoid posting to an exported Cloud endpoint.
+			envconfig.PinAliasEnvBlank(t)
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			t.Setenv("SIGIL_ENDPOINT", server.URL)
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
+
+			calls.Store(0)
+			responseBody.Store(tt.serverResponds)
+
+			logger := log.New(io.Discard, "", 0)
+			cfg := config.Load(logger)
+			var stdout bytes.Buffer
+			UserPromptSubmit(context.Background(), &stdout, Payload{
+				HookEventName: "UserPromptSubmit",
+				SessionID:     "sess",
+				TurnID:        "turn",
+				Prompt:        "my token is glc_secret",
+				Model:         "gpt-5",
+			}, cfg, logger)
+
+			if tt.expectServerCall && calls.Load() == 0 {
+				t.Errorf("expected server call, got 0")
+			}
+			if !tt.expectServerCall && calls.Load() != 0 {
+				t.Errorf("expected no server call, got %d", calls.Load())
+			}
+			if tt.wantStdoutEmpty && stdout.Len() != 0 {
+				t.Errorf("stdout not empty: %q", stdout.String())
+			}
+			for _, want := range tt.wantStdoutContains {
+				if !strings.Contains(stdout.String(), want) {
+					t.Errorf("stdout = %q, want substring %q", stdout.String(), want)
+				}
+			}
+			// An allowed prompt is captured; a denied one must not reach
+			// disk at all.
+			frag := fragment.LoadTolerant("sess", "turn", logger)
+			if tt.wantCaptured && frag == nil {
+				t.Error("turn fragment not written")
+			}
+			if !tt.wantCaptured && frag != nil {
+				t.Errorf("turn fragment written for a denied prompt: %+v", frag)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/agents/codex/hook_test.go
+++ b/plugins/agento11y/internal/agents/codex/hook_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
 
 func TestHookRoutesPreToolUse(t *testing.T) {
@@ -70,6 +72,88 @@ func TestHookRoutesPreToolUse(t *testing.T) {
 			var stdout bytes.Buffer
 			if err := Hook(context.Background(), stdin, &stdout, log.New(io.Discard, "", 0)); err != nil {
 				t.Fatalf("Hook: %v", err)
+			}
+
+			if tt.wantStdoutEmpty && stdout.Len() != 0 {
+				t.Errorf("stdout not empty: %q", stdout.String())
+			}
+			for _, want := range tt.wantStdoutContains {
+				if !strings.Contains(stdout.String(), want) {
+					t.Errorf("stdout = %q, want substring %q", stdout.String(), want)
+				}
+			}
+		})
+	}
+}
+
+// Hook must return nil because a non-zero exit runs the `sigil` fallback and
+// sends the prompt.
+func TestHookRoutesUserPromptSubmit(t *testing.T) {
+	var responseBody atomic.Value
+	responseBody.Store("")
+	server := newDispatcherTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		body, _ := responseBody.Load().(string)
+		if body == "" {
+			body = `{"action":"allow"}`
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name               string
+		endpoint           string
+		failOpen           string
+		serverResponds     string
+		wantStdoutEmpty    bool
+		wantStdoutContains []string
+	}{
+		{
+			name:            "allow_response_produces_empty_stdout",
+			serverResponds:  `{"action":"allow"}`,
+			wantStdoutEmpty: true,
+		},
+		{
+			name:               "deny_response_emits_block_envelope",
+			serverResponds:     `{"action":"deny","reason":"secret in prompt"}`,
+			wantStdoutContains: []string{`"decision":"block"`, "secret in prompt"},
+		},
+		{
+			// Fail-closed denials must not run the fallback.
+			name:               "fail_closed_transport_error_emits_block_envelope",
+			endpoint:           "http://127.0.0.1:1",
+			failOpen:           "false",
+			wantStdoutContains: []string{`"decision":"block"`, "could not evaluate"},
+		},
+		{
+			name:            "fail_open_transport_error_produces_empty_stdout",
+			endpoint:        "http://127.0.0.1:1",
+			wantStdoutEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			// Clear primary variables to avoid posting to an exported Cloud endpoint.
+			envconfig.PinAliasEnvBlank(t)
+			t.Setenv("SIGIL_GUARDS_ENABLED", "true")
+			t.Setenv("SIGIL_GUARDS_FAIL_OPEN", tt.failOpen)
+			endpoint := tt.endpoint
+			if endpoint == "" {
+				endpoint = server.URL
+			}
+			t.Setenv("SIGIL_ENDPOINT", endpoint)
+			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+			t.Setenv("SIGIL_AUTH_TOKEN", "token")
+
+			responseBody.Store(tt.serverResponds)
+
+			stdin := strings.NewReader(`{"hook_event_name":"UserPromptSubmit","session_id":"sess","turn_id":"turn","prompt":"my token is glc_secret","model":"gpt-5"}`)
+			var stdout bytes.Buffer
+			if err := Hook(context.Background(), stdin, &stdout, log.New(io.Discard, "", 0)); err != nil {
+				t.Fatalf("Hook returned %v; a non-zero exit would run the sigil fallback", err)
 			}
 
 			if tt.wantStdoutEmpty && stdout.Len() != 0 {

--- a/plugins/agento11y/internal/agents/cursor/hook.go
+++ b/plugins/agento11y/internal/agents/cursor/hook.go
@@ -1,11 +1,8 @@
-// Package cursor implements the Cursor agent adapter for the consolidated
-// agento11y binary. The dispatcher in cmd/agento11y routes `agento11y cursor hook` here.
+// Package cursor implements the Cursor adapter for the agento11y binary.
 //
-// Cursor expects a permissive JSON response on pre-execution events when the
-// plugin wants to allow the action — a missing or non-JSON stdout on those
-// events is treated as a block. We always emit the permissive response on
-// beforeSubmitPrompt regardless of how dispatch terminates, and on preToolUse
-// whenever the guard handler did not get a chance to answer itself.
+// Cursor expects JSON responses for beforeSubmitPrompt and preToolUse. The
+// dispatcher sends a permissive response when a handler writes nothing, so
+// behavior does not depend on Cursor's permissive default.
 package cursor
 
 import (
@@ -28,17 +25,27 @@ var (
 	preToolUseMarker   = []byte(`"hook_event_name":"preToolUse"`)
 )
 
-// Hook reads a Cursor hook JSON payload from stdin and dispatches it to the
-// matching handler. On beforeSubmitPrompt the permissive response is
-// always emitted to stdout, even on parse failure, so Cursor never blocks
-// the user's input on telemetry trouble. preToolUse gets the same treatment
-// when dispatch bails before the guard handler runs; the handler itself
-// always writes a response on every evaluation outcome.
+// answeredWriter prevents a fallback response after a handler writes one,
+// including when the handler panics.
+type answeredWriter struct {
+	w        io.Writer
+	answered bool
+}
+
+func (a *answeredWriter) Write(p []byte) (int, error) {
+	if len(p) > 0 {
+		a.answered = true
+	}
+	return a.w.Write(p)
+}
+
+// Hook dispatches a Cursor hook payload. If a pre-execution handler writes
+// nothing, Hook sends one permissive response.
 func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Logger) error {
 	var raw []byte
 	var event string
 	parsed := false
-	preToolUseHandled := false
+	out := &answeredWriter{w: stdout}
 	defer func() {
 		// Before the payload parses we can only guess the event from the raw
 		// bytes, and beforeSubmitPrompt wins so a nested preToolUse marker can't
@@ -52,10 +59,7 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 				event = "preToolUse"
 			}
 		}
-		if event == "beforeSubmitPrompt" {
-			_, _ = fmt.Fprint(stdout, permissiveResponse)
-		}
-		if event == "preToolUse" && !preToolUseHandled {
+		if !out.answered && (event == "beforeSubmitPrompt" || event == "preToolUse") {
 			_, _ = fmt.Fprint(stdout, permissiveResponse)
 		}
 	}()
@@ -90,10 +94,9 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 	case "sessionStart":
 		hook.SessionStart(payload, logger)
 	case "beforeSubmitPrompt":
-		hook.BeforeSubmit(payload, cfg, logger)
+		hook.BeforeSubmit(ctx, out, payload, cfg, logger)
 	case "preToolUse":
-		hook.PreToolUse(ctx, payload, cfg, stdout, logger)
-		preToolUseHandled = true
+		hook.PreToolUse(ctx, payload, cfg, out, logger)
 	case "afterAgentResponse":
 		hook.AfterAgentResponse(payload, cfg, logger)
 	case "afterAgentThought":

--- a/plugins/agento11y/internal/agents/cursor/hook/beforesubmit.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/beforesubmit.go
@@ -1,6 +1,9 @@
 package hook
 
 import (
+	"context"
+	"encoding/json"
+	"io"
 	"log"
 	"strings"
 	"unicode/utf8"
@@ -9,12 +12,43 @@ import (
 
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/config"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/fragment"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/guard"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
 
 // maxTitleLen caps the conversation title derived from the first user prompt.
 const maxTitleLen = 100
 
-// BeforeSubmit captures the user prompt for the upcoming generation. Cursor
+// beforeSubmitDeny is Cursor's response for blocking a submitted prompt.
+// UserMessage is shown to the user; the model is not called.
+type beforeSubmitDeny struct {
+	Continue    bool   `json:"continue"`
+	UserMessage string `json:"user_message,omitempty"`
+}
+
+// BeforeSubmit evaluates preflight guards before capturing the prompt. A deny
+// writes Cursor's stop response; an allow lets the dispatcher respond.
+// Denied messages never reach the session file or conversation title.
+func BeforeSubmit(ctx context.Context, stdout io.Writer, p Payload, cfg config.Config, logger *log.Logger) {
+	res := guard.EvaluatePrompt(ctx, envconfig.ResolveGuards(logger), guard.PromptInput{
+		AgentName:     cfg.Agent(),
+		AgentVersion:  strings.TrimSpace(p.CursorVersion),
+		ModelProvider: strings.TrimSpace(p.Provider),
+		ModelName:     resolvedModel(p),
+		Prompt:        p.Prompt,
+	}, logger)
+	if res.Blocked() {
+		_ = json.NewEncoder(stdout).Encode(beforeSubmitDeny{
+			Continue:    false,
+			UserMessage: res.Reason,
+		})
+		return
+	}
+
+	capturePrompt(p, cfg, logger)
+}
+
+// capturePrompt records the user prompt for the upcoming generation. Cursor
 // doesn't always assign a generation_id at prompt-submit time; without one we
 // cannot key the fragment, so skip the fragment write — the turn will still
 // be exported, just without the user prompt in `input`.
@@ -28,7 +62,7 @@ const maxTitleLen = 100
 // The conversation title is session-scoped, so it is stamped even when
 // generation_id is missing: first prompt wins, and a later sessionStart must
 // not wipe it.
-func BeforeSubmit(p Payload, cfg config.Config, logger *log.Logger) {
+func capturePrompt(p Payload, cfg config.Config, logger *log.Logger) {
 	if p.ConversationID == "" {
 		logger.Print("beforeSubmitPrompt: missing conversation_id — skipping")
 		return

--- a/plugins/agento11y/internal/agents/cursor/hook/beforesubmit_test.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/beforesubmit_test.go
@@ -2,13 +2,19 @@ package hook
 
 import (
 	"bytes"
+	"context"
+	"io"
 	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/grafana/agento11y/go/agento11y"
 
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/config"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/fragment"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
 
 // In metadata_only mode the user prompt gets stripped at emit time, so the
@@ -31,7 +37,7 @@ func TestBeforeSubmit_GatesUserPromptByMode(t *testing.T) {
 			logger := log.New(&bytes.Buffer{}, "", 0)
 			cfg := config.Config{ContentCapture: tc.mode}
 
-			BeforeSubmit(Payload{
+			BeforeSubmit(context.Background(), io.Discard, Payload{
 				HookEventName:  "beforeSubmitPrompt",
 				ConversationID: "conv",
 				GenerationID:   "gen",
@@ -54,12 +60,51 @@ func TestBeforeSubmit_GatesUserPromptByMode(t *testing.T) {
 	}
 }
 
+// A denied message must not become the conversation title because the mapper
+// repeats the title on every later generation.
+func TestBeforeSubmit_DenyCapturesNothing(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	envconfig.PinAliasEnvBlank(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"action":"deny","reason":"secret in prompt"}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("SIGIL_GUARDS_ENABLED", "true")
+	t.Setenv("SIGIL_ENDPOINT", server.URL)
+	t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+	t.Setenv("SIGIL_AUTH_TOKEN", "token")
+
+	logger := log.New(&bytes.Buffer{}, "", 0)
+	cfg := config.Config{ContentCapture: agento11y.ContentCaptureModeFull}
+
+	var stdout bytes.Buffer
+	BeforeSubmit(context.Background(), &stdout, Payload{
+		HookEventName:  "beforeSubmitPrompt",
+		ConversationID: "conv",
+		GenerationID:   "gen",
+		Prompt:         "my token is glc_secret",
+	}, cfg, logger)
+
+	if !strings.Contains(stdout.String(), `"continue":false`) {
+		t.Fatalf("stdout = %q; want the stop envelope", stdout.String())
+	}
+	if sess := fragment.LoadSession("conv", logger); sess != nil && sess.ConversationTitle != "" {
+		t.Errorf("ConversationTitle = %q; a denied message must not become the title", sess.ConversationTitle)
+	}
+	if got := fragment.LoadTolerant("conv", "gen", logger); got != nil && got.UserPrompt != "" {
+		t.Errorf("UserPrompt = %q; a denied message must not reach the fragment", got.UserPrompt)
+	}
+}
+
 func TestBeforeSubmit_MissingConversationIDSilent(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	var buf bytes.Buffer
 	logger := log.New(&buf, "", 0)
 	cfg := config.Config{ContentCapture: agento11y.ContentCaptureModeFull}
-	BeforeSubmit(Payload{HookEventName: "beforeSubmitPrompt"}, cfg, logger)
+	BeforeSubmit(context.Background(), io.Discard, Payload{HookEventName: "beforeSubmitPrompt"}, cfg, logger)
 	if !bytes.Contains(buf.Bytes(), []byte("skipping")) {
 		t.Errorf("expected 'skipping' log; got %q", buf.String())
 	}
@@ -70,7 +115,7 @@ func TestBeforeSubmit_StampsTitleWithoutGenerationID(t *testing.T) {
 	logger := log.New(&bytes.Buffer{}, "", 0)
 	cfg := config.Config{ContentCapture: agento11y.ContentCaptureModeFull}
 
-	BeforeSubmit(Payload{
+	BeforeSubmit(context.Background(), io.Discard, Payload{
 		HookEventName:  "beforeSubmitPrompt",
 		ConversationID: "conv",
 		Prompt:         "list go files",
@@ -90,13 +135,13 @@ func TestBeforeSubmit_FirstPromptWinsTitle(t *testing.T) {
 	logger := log.New(&bytes.Buffer{}, "", 0)
 	cfg := config.Config{ContentCapture: agento11y.ContentCaptureModeFull}
 
-	BeforeSubmit(Payload{
+	BeforeSubmit(context.Background(), io.Discard, Payload{
 		HookEventName:  "beforeSubmitPrompt",
 		ConversationID: "conv",
 		GenerationID:   "gen-1",
 		Prompt:         "first prompt",
 	}, cfg, logger)
-	BeforeSubmit(Payload{
+	BeforeSubmit(context.Background(), io.Discard, Payload{
 		HookEventName:  "beforeSubmitPrompt",
 		ConversationID: "conv",
 		GenerationID:   "gen-2",
@@ -125,7 +170,7 @@ func TestBeforeSubmit_TitleWriteKeepsSessionMetadata(t *testing.T) {
 		CursorVersion:  "2.0",
 		Timestamp:      "2026-04-28T12:00:00Z",
 	}, logger)
-	BeforeSubmit(Payload{
+	BeforeSubmit(context.Background(), io.Discard, Payload{
 		HookEventName:  "beforeSubmitPrompt",
 		ConversationID: "conv",
 		Prompt:         "list go files",

--- a/plugins/agento11y/internal/agents/cursor/hook/pretooluse_test.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/pretooluse_test.go
@@ -269,7 +269,7 @@ func TestAgentNameOverrideGuardAndExport(t *testing.T) {
 			}
 
 			cfg := config.Load(logger)
-			BeforeSubmit(Payload{
+			BeforeSubmit(context.Background(), io.Discard, Payload{
 				HookEventName:  "beforeSubmitPrompt",
 				ConversationID: "conv",
 				GenerationID:   "gen",
@@ -293,8 +293,14 @@ func TestAgentNameOverrideGuardAndExport(t *testing.T) {
 				Status:         "completed",
 			}, cfg, logger)
 
-			if len(guardAgents) != 1 || guardAgents[0] != tt.want {
-				t.Fatalf("guard agent names = %v, want [%q]", guardAgents, tt.want)
+			// The prompt and tool call each make one guard request.
+			if len(guardAgents) != 2 {
+				t.Fatalf("guard agent names = %v, want two entries", guardAgents)
+			}
+			for _, got := range guardAgents {
+				if got != tt.want {
+					t.Fatalf("guard agent names = %v, want every entry %q", guardAgents, tt.want)
+				}
 			}
 			if len(exportAgents) != 1 || exportAgents[0] != tt.want {
 				t.Fatalf("exported agent names = %v, want [%q]", exportAgents, tt.want)

--- a/plugins/agento11y/internal/agents/cursor/hook_test.go
+++ b/plugins/agento11y/internal/agents/cursor/hook_test.go
@@ -21,9 +21,17 @@ func TestHookDispatch(t *testing.T) {
 	}))
 	defer denyServer.Close()
 
+	allowServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"action":"allow"}`))
+	}))
+	defer allowServer.Close()
+
 	tests := []struct {
-		name               string
-		env                map[string]string
+		name string
+		env  map[string]string
+		// allowVerdict selects the allowing server; the default denies.
+		allowVerdict       bool
 		stdin              string
 		wantStdout         string
 		wantStdoutContains []string
@@ -53,17 +61,35 @@ func TestHookDispatch(t *testing.T) {
 				`"tool_name":"Shell","tool_use_id":"tu_1","tool_input":{"command":"echo hi"}}`,
 			wantStdoutContains: []string{`"permission":"deny"`, `blocked tool`},
 		},
+		{
+			name:               "prompt_deny_replaces_the_permissive_line",
+			env:                map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			stdin:              `{"hook_event_name":"beforeSubmitPrompt","conversation_id":"conv","generation_id":"gen","prompt":"my token is glc_secret"}`,
+			wantStdoutContains: []string{`"continue":false`, `"user_message":`, "blocked this message"},
+		},
+		{
+			name:         "prompt_allow_keeps_the_permissive_line",
+			env:          map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			allowVerdict: true,
+			stdin:        `{"hook_event_name":"beforeSubmitPrompt","conversation_id":"conv","generation_id":"gen","prompt":"hello"}`,
+			wantStdout:   permissiveResponse,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			t.Setenv("SIGIL_GUARDS_ENABLED", "")
 			t.Setenv("SIGIL_GUARDS_FAIL_OPEN", "")
 			t.Setenv("SIGIL_GUARDS_TIMEOUT_MS", "")
 			for k, v := range tt.env {
 				t.Setenv(k, v)
 			}
-			t.Setenv("SIGIL_ENDPOINT", denyServer.URL)
+			endpoint := denyServer.URL
+			if tt.allowVerdict {
+				endpoint = allowServer.URL
+			}
+			t.Setenv("SIGIL_ENDPOINT", endpoint)
 			t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
 			t.Setenv("SIGIL_AUTH_TOKEN", "token")
 

--- a/plugins/agento11y/internal/agents/guard/marker_sync_test.go
+++ b/plugins/agento11y/internal/agents/guard/marker_sync_test.go
@@ -1,9 +1,11 @@
 package guard
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,6 +36,30 @@ func TestEvaluationFailureRuleID_MatchesPlugins(t *testing.T) {
 			require.NotNil(t, m, "%s no longer declares EVALUATION_FAILURE_RULE_ID as a string literal", path)
 			assert.Equal(t, EvaluationFailureRuleID, string(m[1]),
 				"%s must use the same marker as guard.EvaluationFailureRuleID, or a fail-closed deny is rendered as a policy denial", path)
+		})
+	}
+}
+
+// TestPromptMessages_MatchOpencode keeps Go and OpenCode prompt errors equal.
+// Quoted literals prevent partial matches and tolerate source reformatting.
+func TestPromptMessages_MatchOpencode(t *testing.T) {
+	// This test file lives at plugins/agento11y/internal/agents/guard.
+	plugins, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
+	require.NoError(t, err)
+	path := filepath.Join(plugins, "opencode", "src", "guard.ts")
+	src, err := os.ReadFile(path)
+	require.NoError(t, err, "the wording must stay comparable across languages; if %s moved, update this test", path)
+
+	for _, tc := range []struct {
+		fn   string
+		want string
+	}{
+		{fn: "formatPromptDeny", want: promptDenyPrefix},
+		{fn: "formatPromptEvalFailure", want: promptEvalFailurePrefix},
+	} {
+		t.Run(tc.fn, func(t *testing.T) {
+			assert.True(t, bytes.Contains(src, []byte(strconv.Quote(tc.want))),
+				"%s must hold the same sentence as the Go guard package for %s:\n%s", path, tc.fn, tc.want)
 		})
 	}
 }

--- a/plugins/agento11y/internal/agents/guard/prompt.go
+++ b/plugins/agento11y/internal/agents/guard/prompt.go
@@ -1,0 +1,212 @@
+package guard
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log"
+	"strings"
+
+	"github.com/grafana/agento11y/go/agento11y"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
+)
+
+// Prompt errors go to the user, so they omit the model-facing guardBehaviorHint.
+// TestPromptMessages_MatchOpencode keeps the Go and OpenCode copies in sync.
+const (
+	promptDenyPrefix        = "A Grafana Agent Observability policy blocked this message, so it was not sent to the model."
+	promptEvalFailurePrefix = "agento11y could not evaluate the Grafana Agent Observability guard and blocked this message. Set AGENTO11Y_GUARDS_FAIL_OPEN=true in your shell or in ~/.config/agento11y/config.env. Restart the agent and resend."
+)
+
+func formatPromptDeny(reason string) string {
+	if r := strings.TrimSpace(reason); r != "" {
+		return promptDenyPrefix + " Reason: " + r
+	}
+	return promptDenyPrefix
+}
+
+// FormatPromptEvalFailure formats a fail-closed prompt error. The local daemon
+// uses it when a Cloud request contains no tool call.
+func FormatPromptEvalFailure(detail string) string {
+	if d := strings.TrimSpace(detail); d != "" {
+		return promptEvalFailurePrefix + " Details: " + d
+	}
+	return promptEvalFailurePrefix
+}
+
+// PromptInput contains the fields for a preflight prompt evaluation.
+type PromptInput struct {
+	// AgentName identifies the host agent (e.g. "codex", "cursor").
+	AgentName string
+	// AgentVersion is the host agent build version, when known.
+	AgentVersion string
+	// ModelProvider and ModelName describe the upstream model, when known.
+	ModelProvider string
+	ModelName     string
+	// Prompt is the message the user just submitted.
+	Prompt string
+}
+
+// PromptResult is a host-independent prompt guard result.
+type PromptResult struct {
+	// Action is allow or deny.
+	Action agento11y.HookAction
+	// Reason explains a denial and is always set when Action is deny.
+	Reason string
+	// RuleID identifies the denying rule. EvaluationFailureRuleID marks an
+	// evaluation failure.
+	RuleID string
+}
+
+// Blocked reports whether the host should refuse to send the prompt.
+func (r PromptResult) Blocked() bool {
+	return r.Action == agento11y.HookActionDeny
+}
+
+// EvaluatePrompt applies preflight guards to one submitted prompt. It uses the
+// same guard settings and fail-open behavior as EvaluateToolCall.
+//
+// The request contains only the submitted user message. The server flattens
+// all messages and roles, so history could match assistant text or overflow
+// the judge prompt.
+//
+// Transform results are ignored because these hosts cannot rewrite prompts.
+func EvaluatePrompt(ctx context.Context, cfg envconfig.GuardsConfig, in PromptInput, logger *log.Logger) PromptResult {
+	if !cfg.Enabled {
+		return PromptResult{Action: agento11y.HookActionAllow}
+	}
+	if strings.TrimSpace(in.Prompt) == "" {
+		return PromptResult{Action: agento11y.HookActionAllow}
+	}
+
+	client, endpoint, err := newGuardClient(cfg, agento11y.HookPhasePreflight)
+	if err != nil {
+		if cfg.FailOpen {
+			if logger != nil {
+				logger.Printf("guard: prompt: missing AGENTO11Y_*/SIGIL_* credentials; failing open")
+			}
+			return PromptResult{Action: agento11y.HookActionAllow}
+		}
+		if logger != nil {
+			logger.Printf("guard: prompt: missing AGENTO11Y_*/SIGIL_* credentials; failing closed")
+		}
+		return PromptResult{
+			Action: agento11y.HookActionDeny,
+			Reason: FormatPromptEvalFailure(err.Error()),
+			RuleID: EvaluationFailureRuleID,
+		}
+	}
+	defer func() { _ = client.Shutdown(ctx) }()
+
+	provider := strings.TrimSpace(in.ModelProvider)
+	if provider == "" {
+		provider = "unknown"
+	}
+	modelName := strings.TrimSpace(in.ModelName)
+	if modelName == "" {
+		modelName = "unknown"
+	}
+
+	req := agento11y.HookEvaluateRequest{
+		Phase: agento11y.HookPhasePreflight,
+		Context: agento11y.HookContext{
+			AgentName:    in.AgentName,
+			AgentVersion: in.AgentVersion,
+			Model: &agento11y.HookModel{
+				Provider: provider,
+				Name:     modelName,
+			},
+		},
+		Input: agento11y.HookInput{
+			Messages: []agento11y.Message{{
+				Role:  agento11y.RoleUser,
+				Parts: []agento11y.Part{agento11y.TextPart(in.Prompt)},
+			}},
+		},
+	}
+
+	resp, err := client.EvaluateHook(ctx, req)
+	if err != nil {
+		// FailOpen=false returns an error; fail-open returns a synthetic allow.
+		if logger != nil {
+			logger.Printf("guard: prompt: endpoint=%q evaluate err=%v", endpoint, err)
+		}
+		return PromptResult{
+			Action: agento11y.HookActionDeny,
+			Reason: FormatPromptEvalFailure(err.Error()),
+			RuleID: EvaluationFailureRuleID,
+		}
+	}
+
+	if resp != nil && logger != nil {
+		logger.Printf(
+			"guard: prompt: endpoint=%q action=%q rule_id=%q reason=%q",
+			endpoint,
+			string(resp.Action),
+			resp.RuleID,
+			resp.Reason,
+		)
+		// These hosts cannot apply prompt transforms, so log dropped transforms.
+		if resp.TransformedInput != nil && len(resp.TransformedInput.Messages) > 0 {
+			logger.Printf("guard: prompt: transform dropped: this host cannot replace a submitted message")
+		}
+	}
+
+	deniedErr := agento11y.HookDeniedFromResponse(resp)
+	if deniedErr == nil {
+		return PromptResult{Action: agento11y.HookActionAllow}
+	}
+
+	var ruleReason string
+	var denied *agento11y.HookDeniedError
+	if errors.As(deniedErr, &denied) {
+		ruleReason = denied.Reason
+	}
+	ruleID := ""
+	if resp != nil {
+		ruleID = resp.RuleID
+	}
+	// Evaluation failures already have user-facing text; do not wrap them as
+	// policy denials.
+	if ruleID == EvaluationFailureRuleID {
+		if strings.TrimSpace(ruleReason) == "" {
+			ruleReason = FormatPromptEvalFailure("")
+		}
+		return PromptResult{
+			Action: agento11y.HookActionDeny,
+			Reason: ruleReason,
+			RuleID: ruleID,
+		}
+	}
+	return PromptResult{
+		Action: agento11y.HookActionDeny,
+		Reason: formatPromptDeny(ruleReason),
+		RuleID: ruleID,
+	}
+}
+
+// promptBlock is the prompt block response shared by Claude Code and Codex.
+type promptBlock struct {
+	Decision string `json:"decision"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+// WritePromptBlock writes a Claude Code/Codex prompt block. An empty reason
+// uses a generic message.
+//
+// The process must exit zero: both hooks use `agento11y ... || sigil ...`, so
+// a non-zero exit runs the fallback instead of blocking.
+func WritePromptBlock(stdout io.Writer, reason string) {
+	if stdout == nil {
+		return
+	}
+	if strings.TrimSpace(reason) == "" {
+		reason = "message blocked by agento11y guard"
+	}
+	_ = json.NewEncoder(stdout).Encode(promptBlock{
+		Decision: "block",
+		Reason:   reason,
+	})
+}

--- a/plugins/agento11y/internal/agents/guard/prompt_test.go
+++ b/plugins/agento11y/internal/agents/guard/prompt_test.go
@@ -1,0 +1,306 @@
+package guard
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/grafana/agento11y/go/agento11y"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
+)
+
+func TestEvaluatePrompt(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            envconfig.GuardsConfig
+		serverResponds string
+		// useClosedServer forces a transport failure.
+		useClosedServer  bool
+		clearCreds       bool
+		prompt           string
+		wantAction       agento11y.HookAction
+		wantReasonSub    string
+		wantNoReasonSub  string
+		wantRuleID       string
+		wantServerCalled bool
+	}{
+		{
+			name:       "disabled returns allow without contacting the server",
+			cfg:        envconfig.GuardsConfig{Enabled: false, TimeoutMs: 1500, FailOpen: true},
+			prompt:     "hello",
+			wantAction: agento11y.HookActionAllow,
+		},
+		{
+			name:       "blank prompt returns allow",
+			cfg:        envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			prompt:     "   ",
+			wantAction: agento11y.HookActionAllow,
+		},
+		{
+			name:             "allow response",
+			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:   `{"action":"allow"}`,
+			prompt:           "hello",
+			wantAction:       agento11y.HookActionAllow,
+			wantServerCalled: true,
+		},
+		{
+			// These hosts cannot apply prompt transforms.
+			name:             "allow with transformed input is ignored",
+			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:   `{"action":"allow","transformed_input":{"messages":[{"role":"user","parts":[{"kind":"text","text":"[REDACTED]"}]}]}}`,
+			prompt:           "token glc_x",
+			wantAction:       agento11y.HookActionAllow,
+			wantServerCalled: true,
+		},
+		{
+			name:             "deny response",
+			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:   `{"action":"deny","reason":"secret in prompt","rule_id":"r-1"}`,
+			prompt:           "hello",
+			wantAction:       agento11y.HookActionDeny,
+			wantReasonSub:    "secret in prompt",
+			wantRuleID:       "r-1",
+			wantServerCalled: true,
+		},
+		{
+			name:             "deny with empty reason keeps the prefix",
+			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:   `{"action":"deny"}`,
+			prompt:           "hello",
+			wantAction:       agento11y.HookActionDeny,
+			wantReasonSub:    "policy blocked this message",
+			wantNoReasonSub:  "Reason:",
+			wantServerCalled: true,
+		},
+		{
+			name:             "evaluation-failure deny is not reported as a policy deny",
+			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:   `{"action":"deny","rule_id":"` + EvaluationFailureRuleID + `","reason":"agento11y could not evaluate the guard"}`,
+			prompt:           "hello",
+			wantAction:       agento11y.HookActionDeny,
+			wantReasonSub:    "could not evaluate",
+			wantNoReasonSub:  "policy blocked",
+			wantRuleID:       EvaluationFailureRuleID,
+			wantServerCalled: true,
+		},
+		{
+			name:            "transport error fails open",
+			cfg:             envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			useClosedServer: true,
+			prompt:          "hello",
+			wantAction:      agento11y.HookActionAllow,
+		},
+		{
+			name:            "transport error fails closed",
+			cfg:             envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: false},
+			useClosedServer: true,
+			prompt:          "hello",
+			wantAction:      agento11y.HookActionDeny,
+			wantReasonSub:   "could not evaluate",
+			wantRuleID:      EvaluationFailureRuleID,
+		},
+		{
+			name:       "missing credentials fail open",
+			cfg:        envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			clearCreds: true,
+			prompt:     "hello",
+			wantAction: agento11y.HookActionAllow,
+		},
+		{
+			name:          "missing credentials fail closed",
+			cfg:           envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: false},
+			clearCreds:    true,
+			prompt:        "hello",
+			wantAction:    agento11y.HookActionDeny,
+			wantReasonSub: "missing AGENTO11Y_ENDPOINT",
+			wantRuleID:    EvaluationFailureRuleID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls.Add(1)
+				body := tt.serverResponds
+				if body == "" {
+					body = `{"action":"allow"}`
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(body))
+			}))
+			defer server.Close()
+
+			closed := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			closed.Close()
+
+			// Clear primary variables to avoid posting to an exported Cloud endpoint.
+			envconfig.PinAliasEnvBlank(t)
+
+			endpoint := server.URL
+			if tt.useClosedServer {
+				endpoint = closed.URL
+			}
+			if tt.clearCreds {
+				t.Setenv("SIGIL_ENDPOINT", "")
+				t.Setenv("SIGIL_AUTH_TENANT_ID", "")
+				t.Setenv("SIGIL_AUTH_TOKEN", "")
+			} else {
+				t.Setenv("SIGIL_ENDPOINT", endpoint)
+				t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+				t.Setenv("SIGIL_AUTH_TOKEN", "token")
+			}
+
+			var logBuf bytes.Buffer
+			res := EvaluatePrompt(context.Background(), tt.cfg, PromptInput{
+				AgentName:     "codex",
+				AgentVersion:  "dev",
+				ModelProvider: "openai",
+				ModelName:     "gpt-5",
+				Prompt:        tt.prompt,
+			}, log.New(&logBuf, "", 0))
+
+			if res.Action != tt.wantAction {
+				t.Fatalf("Action = %q, want %q", res.Action, tt.wantAction)
+			}
+			if res.Blocked() != (tt.wantAction == agento11y.HookActionDeny) {
+				t.Errorf("Blocked() = %t for action %q", res.Blocked(), res.Action)
+			}
+			if tt.wantReasonSub != "" && !strings.Contains(res.Reason, tt.wantReasonSub) {
+				t.Errorf("Reason = %q, want substring %q", res.Reason, tt.wantReasonSub)
+			}
+			if tt.wantNoReasonSub != "" && strings.Contains(res.Reason, tt.wantNoReasonSub) {
+				t.Errorf("Reason = %q, must not contain %q", res.Reason, tt.wantNoReasonSub)
+			}
+			if res.RuleID != tt.wantRuleID {
+				t.Errorf("RuleID = %q, want %q", res.RuleID, tt.wantRuleID)
+			}
+			if tt.wantServerCalled && calls.Load() == 0 {
+				t.Errorf("expected hook server to be called, got 0 calls")
+			}
+			if !tt.wantServerCalled && !tt.useClosedServer && calls.Load() != 0 {
+				t.Errorf("did not expect a hook server call, got %d", calls.Load())
+			}
+		})
+	}
+}
+
+// TestEvaluatePrompt_SendsOneUserMessage pins the preflight request to one
+// user text part. The server flattens all messages and roles when applying rules.
+func TestEvaluatePrompt_SendsOneUserMessage(t *testing.T) {
+	var capturedPath, capturedBody atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath.Store(r.URL.Path)
+		body, _ := io.ReadAll(r.Body)
+		capturedBody.Store(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"action":"allow"}`))
+	}))
+	defer server.Close()
+
+	envconfig.PinAliasEnvBlank(t)
+	t.Setenv("SIGIL_ENDPOINT", server.URL)
+	t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
+	t.Setenv("SIGIL_AUTH_TOKEN", "token")
+
+	EvaluatePrompt(context.Background(), envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true}, PromptInput{
+		AgentName: "cursor",
+		Prompt:    "my token is glc_secret",
+	}, log.New(bytes.NewBuffer(nil), "", 0))
+
+	if path, _ := capturedPath.Load().(string); path != "/api/v1/hooks:evaluate" {
+		t.Errorf("path = %q, want /api/v1/hooks:evaluate", path)
+	}
+	raw, _ := capturedBody.Load().([]byte)
+	if len(raw) == 0 {
+		t.Fatal("captured body is empty")
+	}
+	var req struct {
+		Phase   string `json:"phase"`
+		Context struct {
+			AgentName string `json:"agent_name"`
+			Model     *struct {
+				Provider string `json:"provider"`
+				Name     string `json:"name"`
+			} `json:"model"`
+		} `json:"context"`
+		Input struct {
+			Messages []struct {
+				Role  string `json:"role"`
+				Parts []struct {
+					Kind string `json:"kind"`
+					Text string `json:"text"`
+				} `json:"parts"`
+			} `json:"messages"`
+			Output []json.RawMessage `json:"output"`
+		} `json:"input"`
+	}
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatalf("unmarshal body: %v\n%s", err, raw)
+	}
+	if req.Phase != "preflight" {
+		t.Errorf("phase = %q, want preflight", req.Phase)
+	}
+	if req.Context.AgentName != "cursor" {
+		t.Errorf("agent_name = %q, want cursor", req.Context.AgentName)
+	}
+	if req.Context.Model == nil || req.Context.Model.Provider != "unknown" || req.Context.Model.Name != "unknown" {
+		t.Errorf("model = %+v, want unknown/unknown", req.Context.Model)
+	}
+	if len(req.Input.Output) != 0 {
+		t.Errorf("input.output = %v, want absent", req.Input.Output)
+	}
+	if len(req.Input.Messages) != 1 {
+		t.Fatalf("input.messages has %d entries, want 1", len(req.Input.Messages))
+	}
+	msg := req.Input.Messages[0]
+	if msg.Role != "user" {
+		t.Errorf("role = %q, want user", msg.Role)
+	}
+	if len(msg.Parts) != 1 {
+		t.Fatalf("message has %d parts, want 1", len(msg.Parts))
+	}
+	if msg.Parts[0].Kind != "text" || msg.Parts[0].Text != "my token is glc_secret" {
+		t.Errorf("part = %+v, want the submitted prompt as one text part", msg.Parts[0])
+	}
+}
+
+func TestWritePromptBlock(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason string
+		want   string
+	}{
+		{
+			name:   "explicit reason",
+			reason: "blocked by rule r-1",
+			want:   `{"decision":"block","reason":"blocked by rule r-1"}` + "\n",
+		},
+		{
+			name:   "blank reason falls back to generic",
+			reason: "  ",
+			want:   `{"decision":"block","reason":"message blocked by agento11y guard"}` + "\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			WritePromptBlock(&buf, tt.reason)
+			if got := buf.String(); got != tt.want {
+				t.Errorf("output = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	// nil writer must not panic.
+	WritePromptBlock(nil, "x")
+}

--- a/plugins/agento11y/internal/agents/guard/toolcall.go
+++ b/plugins/agento11y/internal/agents/guard/toolcall.go
@@ -1,8 +1,5 @@
-// Package guard evaluates tool calls against agento11y guard policy and
-// returns a host-neutral result. Callers translate the result into their
-// own stdout response shape; convenience writers are provided for shapes
-// shared by more than one host agent (e.g. WriteHookSpecificOutputDeny
-// for the Claude Code / Codex PreToolUse envelope).
+// Package guard evaluates submitted prompts and tool calls against agento11y
+// guard rules and returns host-independent results.
 package guard
 
 import (
@@ -68,6 +65,44 @@ func FormatEvalFailure(toolName, detail string) string {
 	return msg + "\n\n" + guardBehaviorHint
 }
 
+// errMissingCredentials uses the primary variable names in user-facing errors.
+var errMissingCredentials = errors.New("missing AGENTO11Y_ENDPOINT/AGENTO11Y_AUTH_TENANT_ID/AGENTO11Y_AUTH_TOKEN")
+
+// newGuardClient builds a client for one guard phase. The caller applies
+// FailOpen when credentials are missing. Localhost endpoints use placeholder
+// credentials, so local mode needs no Cloud credentials.
+func newGuardClient(cfg envconfig.GuardsConfig, phase agento11y.HookPhase) (*agento11y.Client, string, error) {
+	endpoint := envconfig.Getenv("ENDPOINT")
+	tenantID := envconfig.Getenv("AUTH_TENANT_ID")
+	authToken := envconfig.Getenv("AUTH_TOKEN")
+	tenantID, authToken = envconfig.LocalAuthPlaceholders(endpoint, tenantID, authToken)
+	if endpoint == "" || tenantID == "" || authToken == "" {
+		return nil, endpoint, errMissingCredentials
+	}
+
+	failOpen := cfg.FailOpen
+	clientCfg := agento11y.Config{
+		API: agento11y.APIConfig{
+			Endpoint: endpoint,
+		},
+		Hooks: agento11y.HooksConfig{
+			Enabled:  true,
+			Phases:   []agento11y.HookPhase{phase},
+			Timeout:  time.Duration(cfg.TimeoutMs) * time.Millisecond,
+			FailOpen: &failOpen,
+		},
+		GenerationExport: agento11y.GenerationExportConfig{
+			Auth: agento11y.AuthConfig{
+				Mode:          agento11y.ExportAuthModeBasic,
+				BasicUser:     tenantID,
+				BasicPassword: authToken,
+				TenantID:      tenantID,
+			},
+		},
+	}
+	return agento11y.NewClient(clientCfg), endpoint, nil
+}
+
 // ToolCallInput is the host-neutral set of fields needed to evaluate a
 // tool call against agento11y guards.
 type ToolCallInput struct {
@@ -93,7 +128,8 @@ type Result struct {
 	// Reason is the deny reason from agento11y or the host-friendly description
 	// of a fail-closed transport/config error.
 	Reason string
-	// RuleID identifies the rule that produced a deny verdict, when known.
+	// RuleID identifies the denying rule. EvaluationFailureRuleID marks an
+	// evaluation failure, whether local or returned by the server.
 	RuleID string
 	// UpdatedInputJSON carries the transformed (redacted) tool arguments
 	// when agento11y returned a usable Transform verdict for this tool call.
@@ -122,10 +158,6 @@ func (r Result) Blocked() bool {
 //   - agento11y returns deny: returns deny with the rule reason.
 //   - transport error and fail-open: returns allow (matches SDK behaviour).
 //   - transport error and fail-closed: returns deny with a transport reason.
-//
-// A local-mode endpoint (http://127.0.0.1, http://localhost, http://[::1])
-// uses stand-in placeholder credentials for the credential check so that
-// running against a local agento11y instance does not require real cloud creds.
 func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCallInput, logger *log.Logger) Result {
 	if !cfg.Enabled {
 		return Result{Action: agento11y.HookActionAllow}
@@ -134,11 +166,8 @@ func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCa
 		return Result{Action: agento11y.HookActionAllow}
 	}
 
-	endpoint := envconfig.Getenv("ENDPOINT")
-	tenantID := envconfig.Getenv("AUTH_TENANT_ID")
-	authToken := envconfig.Getenv("AUTH_TOKEN")
-	tenantID, authToken = envconfig.LocalAuthPlaceholders(endpoint, tenantID, authToken)
-	if endpoint == "" || tenantID == "" || authToken == "" {
+	client, endpoint, err := newGuardClient(cfg, agento11y.HookPhasePostflight)
+	if err != nil {
 		if cfg.FailOpen {
 			if logger != nil {
 				logger.Printf("guard: missing AGENTO11Y_*/SIGIL_* credentials; failing open")
@@ -150,32 +179,10 @@ func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCa
 		}
 		return Result{
 			Action: agento11y.HookActionDeny,
-			Reason: FormatEvalFailure(in.ToolName, "missing AGENTO11Y_ENDPOINT/AGENTO11Y_AUTH_TENANT_ID/AGENTO11Y_AUTH_TOKEN"),
+			Reason: FormatEvalFailure(in.ToolName, err.Error()),
+			RuleID: EvaluationFailureRuleID,
 		}
 	}
-
-	failOpen := cfg.FailOpen
-	clientCfg := agento11y.Config{
-		API: agento11y.APIConfig{
-			Endpoint: endpoint,
-		},
-		Hooks: agento11y.HooksConfig{
-			Enabled:  true,
-			Phases:   []agento11y.HookPhase{agento11y.HookPhasePostflight},
-			Timeout:  time.Duration(cfg.TimeoutMs) * time.Millisecond,
-			FailOpen: &failOpen,
-		},
-		GenerationExport: agento11y.GenerationExportConfig{
-			Auth: agento11y.AuthConfig{
-				Mode:          agento11y.ExportAuthModeBasic,
-				BasicUser:     tenantID,
-				BasicPassword: authToken,
-				TenantID:      tenantID,
-			},
-		},
-	}
-
-	client := agento11y.NewClient(clientCfg)
 	defer func() { _ = client.Shutdown(ctx) }()
 
 	provider := strings.TrimSpace(in.ModelProvider)
@@ -224,6 +231,7 @@ func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCa
 		return Result{
 			Action: agento11y.HookActionDeny,
 			Reason: FormatEvalFailure(in.ToolName, err.Error()),
+			RuleID: EvaluationFailureRuleID,
 		}
 	}
 

--- a/plugins/agento11y/internal/agents/guard/toolcall_test.go
+++ b/plugins/agento11y/internal/agents/guard/toolcall_test.go
@@ -21,8 +21,7 @@ func TestEvaluateToolCall(t *testing.T) {
 		name           string
 		cfg            envconfig.GuardsConfig
 		serverResponds string
-		// useClosedServer makes the helper connect to a closed listener so
-		// the request fails at transport.
+		// useClosedServer forces a transport failure.
 		useClosedServer bool
 		// clearCreds blanks the SIGIL_ENDPOINT/SIGIL_AUTH_TENANT_ID/
 		// SIGIL_AUTH_TOKEN env vars before the call.
@@ -96,6 +95,7 @@ func TestEvaluateToolCall(t *testing.T) {
 			toolName:        "bash",
 			wantAction:      agento11y.HookActionDeny,
 			wantReasonSub:   "could not evaluate",
+			wantRuleID:      EvaluationFailureRuleID,
 		},
 		{
 			name:          "missing credentials fail open",
@@ -112,6 +112,7 @@ func TestEvaluateToolCall(t *testing.T) {
 			toolName:      "bash",
 			wantAction:    agento11y.HookActionDeny,
 			wantReasonSub: "missing AGENTO11Y_ENDPOINT",
+			wantRuleID:    EvaluationFailureRuleID,
 		},
 		{
 			name:             "allow with transform returns redacted args",

--- a/plugins/agento11y/internal/local/cloudguard.go
+++ b/plugins/agento11y/internal/local/cloudguard.go
@@ -186,44 +186,42 @@ func hookTimeoutFromHeader(r *http.Request, fallback time.Duration) time.Duratio
 	return timeout / 2
 }
 
-// denyFromCloudError builds the fail-closed deny returned when the Cloud hook
-// call failed and GUARDS_FAIL_OPEN is false. It carries
-// guard.EvaluationFailureRuleID so every consumer can tell an infrastructure
-// failure from a policy decision, and reuses guard.FormatEvalFailure so the
-// wording matches the cloud-only path word for word.
+// denyFromCloudError marks fail-closed Cloud errors as evaluation failures.
+// Requests without a tool call use the prompt-specific message.
 func denyFromCloudError(body []byte, err error) agento11y.HookEvaluateResponse {
 	detail := ""
 	if err != nil {
 		detail = err.Error()
 	}
+	reason := guard.FormatPromptEvalFailure(detail)
+	if toolName, ok := hookRequestToolName(body); ok {
+		reason = guard.FormatEvalFailure(toolName, detail)
+	}
 	return agento11y.HookEvaluateResponse{
 		Action:      agento11y.HookActionDeny,
 		RuleID:      guard.EvaluationFailureRuleID,
-		Reason:      guard.FormatEvalFailure(hookRequestToolName(body), detail),
+		Reason:      reason,
 		Evaluations: []agento11y.HookEvaluation{},
 	}
 }
 
-// hookRequestToolName returns the name of the first tool call in a hook
-// request body (output messages first, then input messages) so the fail-closed
-// reason can name the blocked call. The body is decoded leniently and only for
-// this: a request the daemon cannot read is still relayed verbatim, and a
-// request with no tool call (a pi preflight context event) has no name to give.
-func hookRequestToolName(body []byte) string {
+// hookRequestToolName finds the first tool call in output or input messages.
+// It decodes leniently because undecodable requests are still relayed.
+func hookRequestToolName(body []byte) (string, bool) {
 	var req hookToolCallProbe
 	if err := json.Unmarshal(body, &req); err != nil {
-		return unknownToolName
+		return "", false
 	}
 	for _, msgs := range [][]hookProbeMessage{req.Input.Output, req.Input.Messages} {
 		for _, m := range msgs {
 			for _, p := range m.Parts {
 				if name := strings.TrimSpace(p.toolCallName()); name != "" {
-					return name
+					return name, true
 				}
 			}
 		}
 	}
-	return unknownToolName
+	return "", false
 }
 
 // hookToolCallProbe is a lenient view of a hook request: just enough to name a
@@ -264,7 +262,3 @@ func (p hookProbePart) toolCallName() string {
 type hookProbeToolCall struct {
 	Name string `json:"name"`
 }
-
-// unknownToolName stands in when the hook request names no tool call, so the
-// fail-closed message reads as a sentence rather than referring to "".
-const unknownToolName = "unknown"

--- a/plugins/agento11y/internal/local/cloudguard_test.go
+++ b/plugins/agento11y/internal/local/cloudguard_test.go
@@ -284,15 +284,47 @@ func TestHookTimeoutFromHeader(t *testing.T) {
 // marker every consumer checks, and its wording has to say the guard could not
 // be evaluated rather than that a policy blocked the call.
 func TestDenyFromCloudError(t *testing.T) {
-	body := []byte(`{"phase":"postflight","input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"c1","name":"Bash"}}]}]}}`)
-	resp := denyFromCloudError(body, errors.New("POST https://cloud.example.test/api/v1/hooks:evaluate: connection refused"))
+	const detail = "POST https://cloud.example.test/api/v1/hooks:evaluate: connection refused"
+	cases := []struct {
+		name       string
+		body       string
+		wantReason string
+		wantNoSub  string
+	}{
+		{
+			name:       "tool_call_names_the_tool",
+			body:       `{"phase":"postflight","input":{"output":[{"role":"assistant","parts":[{"kind":"tool_call","tool_call":{"id":"c1","name":"Bash"}}]}]}}`,
+			wantReason: guard.FormatEvalFailure("Bash", detail),
+		},
+		{
+			// Prompt errors must not invent a tool call or address the model.
+			name:       "preflight_message_gets_the_message_wording",
+			body:       `{"phase":"preflight","input":{"messages":[{"role":"user","parts":[{"kind":"text","text":"hello"}]}]}}`,
+			wantReason: guard.FormatPromptEvalFailure(detail),
+			wantNoSub:  "tool call",
+		},
+		{
+			name:       "undecodable_body_gets_the_message_wording",
+			body:       `{"phase":`,
+			wantReason: guard.FormatPromptEvalFailure(detail),
+			wantNoSub:  "tool call",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := denyFromCloudError([]byte(tc.body), errors.New(detail))
 
-	assert.Equal(t, agento11y.HookActionDeny, resp.Action)
-	assert.Equal(t, guard.EvaluationFailureRuleID, resp.RuleID)
-	assert.Equal(t, guard.FormatEvalFailure("Bash", "POST https://cloud.example.test/api/v1/hooks:evaluate: connection refused"), resp.Reason)
-	assert.Contains(t, resp.Reason, "could not evaluate")
-	assert.NotContains(t, resp.Reason, "policy blocked")
-	assert.NotNil(t, resp.Evaluations)
+			assert.Equal(t, agento11y.HookActionDeny, resp.Action)
+			assert.Equal(t, guard.EvaluationFailureRuleID, resp.RuleID)
+			assert.Equal(t, tc.wantReason, resp.Reason)
+			assert.Contains(t, resp.Reason, "could not evaluate")
+			assert.NotContains(t, resp.Reason, "policy blocked")
+			if tc.wantNoSub != "" {
+				assert.NotContains(t, resp.Reason, tc.wantNoSub)
+			}
+			assert.NotNil(t, resp.Evaluations)
+		})
+	}
 }
 
 // TestHookRequestToolName covers naming the blocked call in the fail-closed
@@ -330,12 +362,14 @@ func TestHookRequestToolName(t *testing.T) {
 			body: `{"input":{"output":[{"role":"assistant","parts":[{"type":"text","text":"running it"},{"type":"tool_call","toolCall":{"name":"Edit"}}]}]}}`,
 			want: "Edit",
 		},
-		{name: "preflight_without_tool_call", body: `{"phase":"preflight","input":{"messages":[]}}`, want: unknownToolName},
-		{name: "undecodable_body", body: `{"phase":`, want: unknownToolName},
+		{name: "preflight_without_tool_call", body: `{"phase":"preflight","input":{"messages":[]}}`},
+		{name: "undecodable_body", body: `{"phase":`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, hookRequestToolName([]byte(tc.body)))
+			name, found := hookRequestToolName([]byte(tc.body))
+			assert.Equal(t, tc.want != "", found)
+			assert.Equal(t, tc.want, name)
 		})
 	}
 }

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -21,6 +21,18 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "agento11y claude-code hook || sigil claude-code hook",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "",

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -91,6 +91,23 @@ tail -f ~/.local/state/agento11y/logs/agento11y.log
 
 Common culprits: `agento11y --version` doesn't work (binary not on `PATH`), a missing token, or a token without the `sigil:write` scope.
 
+## Guards
+
+Guards apply [Agent Observability rules](https://grafana.com/docs/grafana-cloud/machine-learning/agent-observability/guides/guards/) to submitted messages and tool calls.
+
+Guards are off by default:
+
+```sh
+AGENTO11Y_GUARDS_ENABLED=true agento11y claude
+```
+
+Guards can be
+
+- `preflight`: stop the turn before the message reaches the model.
+- `postflight`: block the tool call and tells the model why. A redact rule rewrites the tool arguments.
+
+When enabled, guards send every submitted message and tool argument to `AGENTO11Y_ENDPOINT`, regardless of `AGENTO11Y_CONTENT_CAPTURE_MODE`.
+
 ## All options
 
 | Variable | Default | Description |
@@ -111,8 +128,8 @@ Common culprits: `agento11y --version` doesn't work (binary not on `PATH`), a mi
 | `AGENTO11Y_LOCAL` | `false` | Send Claude Code captures (launches and installed hooks) to the local viewer at `http://127.0.0.1:8765` instead of Grafana Cloud. Local mode always stores full content. Cloud forwarding also requires `AGENTO11Y_LOCAL_FORWARD`. |
 | `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
 | `AGENTO11Y_AUTO_UPDATE` | `true` | Refresh the `agento11y-claude-code` plugin automatically. Set `false` to pin the installed version. |
-| `AGENTO11Y_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Claude Code `PreToolUse` hook calls the Agent Observability `/api/v1/hooks:evaluate` API and blocks tool calls denied by guard rules. |
-| `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |
-| `AGENTO11Y_GUARDS_TIMEOUT_MS` | `1500` | Per-call timeout. Lower = less added latency on every tool call, higher = better tolerance for slow `llm_judge` evaluators. |
+| `AGENTO11Y_GUARDS_ENABLED` | `false` | See [Guards](#guards). |
+| `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | On timeout, network error, or 5xx, send the message or run the tool call. Set `false` to block the message or call. |
+| `AGENTO11Y_GUARDS_TIMEOUT_MS` | `1500` | Guard timeout per message or tool call. Raise it for slow `llm_judge` evaluators. |
 
 If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your Agent Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>`.

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -107,6 +107,27 @@ AGENTO11Y_DEBUG=true agento11y codex  # one turn
 tail -f ~/.local/state/agento11y/logs/agento11y.log
 ```
 
+## Guards
+
+Guards apply [Agent Observability rules](https://grafana.com/docs/grafana-cloud/machine-learning/agent-observability/guides/guards/) to submitted messages and tool calls.
+
+Guards are off by default:
+
+```sh
+AGENTO11Y_GUARDS_ENABLED=true agento11y codex
+```
+
+Guards can be
+
+- `preflight`: stop the turn before the message reaches the model.
+- `postflight`: block the tool call and tell the model why. A redact rule rewrites the tool arguments.
+
+Codex only guards these tool types: Bash, the `apply_patch` variants, and MCP tools. See the [Codex hooks docs](https://developers.openai.com/codex/hooks) for the supported set.
+
+When enabled, guards send every submitted message and tool argument to `AGENTO11Y_ENDPOINT`, regardless of `AGENTO11Y_CONTENT_CAPTURE_MODE`.
+
+Each message can wait up to `AGENTO11Y_GUARDS_TIMEOUT_MS` (1500 ms by default) before the turn starts.
+
 ## All options
 
 | Variable | Default | Description |
@@ -125,12 +146,10 @@ tail -f ~/.local/state/agento11y/logs/agento11y.log
 | `AGENTO11Y_AGENT_NAME` | `codex` | Override the exported `agent_name`. Subagent turns become `<name>/subagent`. Avoid a `/` in the name itself: a slash marks a subagent generation, so every turn of the run is counted as one. Guard rules and dashboards that filter on `codex` no longer match the generations this run exports. |
 | `AGENTO11Y_LOCAL` | `false` | Send Codex captures (launches and installed hooks) to the local viewer at `http://127.0.0.1:8765` instead of Grafana Cloud. Local mode always stores full content. Cloud forwarding also requires `AGENTO11Y_LOCAL_FORWARD`. |
 | `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
-| `AGENTO11Y_GUARDS_ENABLED` | `false` | Enable Codex `PreToolUse` guards against Agent Observability rules. |
-| `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | Allow the tool call when the guard request fails (set `false` for fail-closed). |
+| `AGENTO11Y_GUARDS_ENABLED` | `false` | See [Guards](#guards). |
+| `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | On guard failure, send the message or run the tool call. Set `false` to block the message or call. |
 | `AGENTO11Y_GUARDS_TIMEOUT_MS` | `1500` | Per-call guard timeout. |
 | `AGENTO11Y_AUTO_UPDATE` | `true` | Refresh the `agento11y-codex` plugin automatically. Set `false` to pin the installed version. |
-
-Guard rules can block a tool call or rewrite its arguments (Transform rules, e.g. redacting a secret before the tool runs). Guards only intercept tool calls that Codex routes through `PreToolUse` — Bash, the `apply_patch` variants, and MCP tools. See the [Codex hooks docs](https://developers.openai.com/codex/hooks) for the supported set.
 
 If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your Agent Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>`.
 

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -135,13 +135,16 @@ Captured prompt, assistant, and tool content is redacted before export. Set `AGE
 
 ## Guards
 
-Guards do two things when enabled: block tool calls that match a deny rule, and apply Transform rules to redact sensitive tool arguments. They're off by default:
+Guards apply [Agent Observability rules](https://grafana.com/docs/grafana-cloud/machine-learning/agent-observability/guides/guards/) to submitted messages and tool calls. 
+Guards can block tool calls that match a deny rule. They're off by default:
 
 ```sh
 AGENTO11Y_GUARDS_ENABLED=true agento11y copilot
 ```
 
 By default, transport errors and timeouts let the tool call through. Set `AGENTO11Y_GUARDS_FAIL_OPEN=false` to block tool calls on errors instead. Raise or lower `AGENTO11Y_GUARDS_TIMEOUT_MS` (default `1500`) to trade latency against tolerance for slow evaluators.
+
+Copilot does not support blocking messages with `preflight` guards. 
 
 ### Transform guards (redaction)
 

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -100,6 +100,25 @@ If nothing shows up, add `AGENTO11Y_DEBUG=true` to `~/.config/agento11y/config.e
 tail -f ~/.local/state/agento11y/logs/agento11y.log
 ```
 
+## Guards
+
+Guards apply [Agent Observability rules](https://grafana.com/docs/grafana-cloud/machine-learning/agent-observability/guides/guards/) to submitted messages and tool calls.
+
+Guards are off by default. Cursor launches from the GUI, so enable them in `~/.config/agento11y/config.env`:
+
+```sh
+AGENTO11Y_GUARDS_ENABLED=true
+```
+
+Guards can be
+
+- `preflight`: stop the turn before the message reaches the model.
+- `postflight`: block the tool call and tell the model why. A redact rule rewrites the tool arguments.
+
+When enabled, guards send every submitted message and tool argument to `AGENTO11Y_ENDPOINT`, regardless of `AGENTO11Y_CONTENT_CAPTURE_MODE`.
+
+Each message can wait up to `AGENTO11Y_GUARDS_TIMEOUT_MS` (1500 ms by default) before the turn starts.
+
 ## All options
 
 | Variable | Default | Description |
@@ -117,9 +136,9 @@ tail -f ~/.local/state/agento11y/logs/agento11y.log
 | `AGENTO11Y_AGENT_NAME` | `cursor` | Override the exported `agent_name`. Avoid a `/` in the name: a slash marks a subagent generation, so every turn of the run is counted as one. Guard rules and dashboards that filter on `cursor` no longer match the generations this run exports. |
 | `AGENTO11Y_LOCAL` | `false` | Send Cursor hook captures to the local viewer at `http://127.0.0.1:8765` instead of Grafana Cloud. Local mode always stores full content. Cloud forwarding also requires `AGENTO11Y_LOCAL_FORWARD`. |
 | `AGENTO11Y_DEBUG` | `false` | Log to `~/.local/state/agento11y/logs/agento11y.log`. |
-| `AGENTO11Y_GUARDS_ENABLED` | `false` | Enable tool-call guards. When on, each Cursor `preToolUse` hook is evaluated against Agent Observability: tool calls denied by guard rules are blocked, and Transform rules rewrite the tool arguments before execution. |
-| `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | When the guard call fails (timeout, network, 5xx), proceed with the tool call. Set `false` for strict mode. |
-| `AGENTO11Y_GUARDS_TIMEOUT_MS` | `1500` | Per-call timeout. Lower = less added latency on every tool call, higher = better tolerance for slow `llm_judge` evaluators. |
+| `AGENTO11Y_GUARDS_ENABLED` | `false` | See [Guards](#guards). |
+| `AGENTO11Y_GUARDS_FAIL_OPEN` | `true` | On timeout, network error, or 5xx, send the message or run the tool call. Set `false` to block the message or call. |
+| `AGENTO11Y_GUARDS_TIMEOUT_MS` | `1500` | Guard timeout per message or tool call. Raise it for slow `llm_judge` evaluators. |
 | `AGENTO11Y_BIN` | auto | Override the binary path if you installed `agento11y` (or the legacy `sigil`) somewhere unusual. |
 
 If your OTLP **Instance ID** (on the OpenTelemetry card) differs from your Agent Observability Instance ID, set `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(otlp-id:glc_token)>`.

--- a/plugins/opencode/src/guard.ts
+++ b/plugins/opencode/src/guard.ts
@@ -106,7 +106,7 @@ function formatPromptDeny(reason: string | undefined): string {
 /** Fail-closed message for a prompt whose guard evaluation could not run. */
 function formatPromptEvalFailure(detail: string | undefined): string {
   let msg =
-    "agento11y could not evaluate the Grafana Agent Observability guard for this message, so it was blocked as a safety measure. Set AGENTO11Y_GUARDS_FAIL_OPEN=true to send it anyway.";
+    "agento11y could not evaluate the Grafana Agent Observability guard and blocked this message. Set AGENTO11Y_GUARDS_FAIL_OPEN=true in your shell or in ~/.config/agento11y/config.env. Restart the agent and resend.";
   const trimmed = detail?.trim();
   if (trimmed) {
     msg += ` Details: ${trimmed}`;

--- a/plugins/opencode/src/hooks.guard.test.ts
+++ b/plugins/opencode/src/hooks.guard.test.ts
@@ -1114,7 +1114,7 @@ describe("opencode prompt guard", () => {
       name: "refuses the turn when the evaluation fails and fail-open is off",
       config: { guards: { enabled: true, timeoutMs: 1500, failOpen: false } },
       respond: () => "error",
-      wantBlock: "blocked as a safety measure",
+      wantBlock: "blocked this message",
       wantCalls: 1,
     },
   ];

--- a/plugins/vibe/README.md
+++ b/plugins/vibe/README.md
@@ -118,7 +118,11 @@ Subagent turns are not tagged `subagent`. Mistral Vibe only exposes a session-le
 
 ## Guards
 
+Guards apply [Agent Observability rules](https://grafana.com/docs/grafana-cloud/machine-learning/agent-observability/guides/guards/) to submitted messages and tool calls.
+
 `pre_tool` evaluates each tool call against Agent Observability guard policy. Guards are **off by default**; enable them with `AGENTO11Y_GUARDS_ENABLED=true` (tune with `AGENTO11Y_GUARDS_TIMEOUT_MS` and `AGENTO11Y_GUARDS_FAIL_OPEN`). When enabled, a policy can **deny** a tool call (Mistral Vibe blocks it and shows the reason to the model) or **rewrite** its arguments (e.g. redact a secret before the tool runs). With guards disabled, `pre_tool` is a pass-through that writes nothing. Evaluation runs synchronously before the tool, so a policy should be fast or local; on timeout or transport error the call follows `AGENTO11Y_GUARDS_FAIL_OPEN` (open by default).
+
+Mistral Vibe does not support blocking messages with `preflight` guards. 
 
 ## All options
 


### PR DESCRIPTION
Adds `preflight` guards support for Claude Code, Codex, and Cursor. A deny stops the turn before the model call and prevents the prompt from being sent to the LLM. Evaluation errors follow `AGENTO11Y_GUARDS_FAIL_OPEN`, as tool-call guards already do.

These agents cannot apply `preflight` redaction, so transformed input is ignored and the original message reaches the model. pi and OpenCode can deny or redact submitted messages. 

Copilot and Mistral Vibe are not supported yet.

When guards are enabled, submitted messages and tool arguments are sent to `AGENTO11Y_ENDPOINT` regardless of `AGENTO11Y_CONTENT_CAPTURE_MODE`. The capture mode controls telemetry only.
