### PR TITLE
fix(sdk): change operation.duration  and client.token.usage description to match semconv

### DIFF
--- a/dotnet/src/Grafana.Agento11y/Agento11yClient.cs
+++ b/dotnet/src/Grafana.Agento11y/Agento11yClient.cs
@@ -171,10 +171,12 @@ public sealed partial class Agento11yClient : IAsyncDisposable
         _operationDurationHistogram = _meter.CreateHistogram<double>(
             MetricOperationDuration,
             unit: "s",
+            description: "GenAI operation duration.",
             advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = DurationBucketsSeconds });
         _tokenUsageHistogram = _meter.CreateHistogram<double>(
             MetricTokenUsage,
-            unit: "token",
+            unit: "{token}",
+            description: "Number of input and output tokens used.",
             advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = TokenUsageBuckets });
         _ttftHistogram = _meter.CreateHistogram<double>(
             MetricTimeToFirstToken,

--- a/dotnet/tests/Grafana.Agento11y.Tests/ConformanceTests.cs
+++ b/dotnet/tests/Grafana.Agento11y.Tests/ConformanceTests.cs
@@ -438,6 +438,13 @@ public sealed class ConformanceTests
         Assert.Equal("streamText gpt-5", span.DisplayName);
         Assert.Contains("gen_ai.client.operation.duration", env.MetricNames);
         Assert.Contains("gen_ai.client.time_to_first_token", env.MetricNames);
+
+        var duration = env.MetricMetadata["gen_ai.client.operation.duration"];
+        Assert.Equal("GenAI operation duration.", duration.Description);
+        Assert.Equal("s", duration.Unit);
+        var tokenUsage = env.MetricMetadata["gen_ai.client.token.usage"];
+        Assert.Equal("Number of input and output tokens used.", tokenUsage.Description);
+        Assert.Equal("{token}", tokenUsage.Unit);
     }
 
     [Fact]
@@ -721,6 +728,8 @@ public sealed class ConformanceTests
         public Agento11yClient Client { get; }
         public ConcurrentQueue<Activity> Spans { get; } = new();
         public ConcurrentDictionary<string, byte> MetricNames { get; } = new(StringComparer.Ordinal);
+        public ConcurrentDictionary<string, (string? Description, string? Unit)> MetricMetadata { get; } =
+            new(StringComparer.Ordinal);
         public ConcurrentQueue<MetricMeasurement> MetricMeasurements { get; } = new();
 
         public ConformanceEnv(int batchSize = 1, Dictionary<string, string>? tags = null)
@@ -747,6 +756,7 @@ public sealed class ConformanceTests
             _meterListener.SetMeasurementEventCallback<double>((instrument, _, tags, _) =>
             {
                 MetricNames[instrument.Name] = 0;
+                MetricMetadata[instrument.Name] = (instrument.Description, instrument.Unit);
                 var tagSnapshot = new Dictionary<string, object?>(StringComparer.Ordinal);
                 foreach (var tag in tags)
                 {

--- a/go/agento11y/client.go
+++ b/go/agento11y/client.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/semconv/v1.41.0/genaiconv"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -2180,22 +2181,22 @@ func reflectIntField(err error, field string) int {
 func newTelemetryInstruments(meter metric.Meter) (telemetryInstruments, error) {
 	out := telemetryInstruments{}
 	var err error
-	out.operationDuration, err = meter.Float64Histogram(
-		metricOperationDuration,
-		metric.WithUnit("s"),
+	duration, err := genaiconv.NewClientOperationDuration(
+		meter,
 		metric.WithExplicitBucketBoundaries(durationBucketsSeconds...),
 	)
 	if err != nil {
 		return telemetryInstruments{}, err
 	}
-	out.tokenUsage, err = meter.Int64Histogram(
-		metricTokenUsage,
-		metric.WithUnit("token"),
+	out.operationDuration = duration.Inst()
+	usage, err := genaiconv.NewClientTokenUsage(
+		meter,
 		metric.WithExplicitBucketBoundaries(tokenUsageBuckets...),
 	)
 	if err != nil {
 		return telemetryInstruments{}, err
 	}
+	out.tokenUsage = usage.Inst()
 	out.timeToFirstToken, err = meter.Float64Histogram(
 		metricTimeToFirstToken,
 		metric.WithUnit("s"),

--- a/go/agento11y/conformance_helpers_test.go
+++ b/go/agento11y/conformance_helpers_test.go
@@ -593,6 +593,27 @@ func findHistogram[N int64 | float64](t *testing.T, collected metricdata.Resourc
 	return metricdata.Histogram[N]{}
 }
 
+func requireMetricMetadata(t *testing.T, collected metricdata.ResourceMetrics, name, description, unit string) {
+	t.Helper()
+
+	for _, scopeMetrics := range collected.ScopeMetrics {
+		for _, metric := range scopeMetrics.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			if metric.Description != description {
+				t.Fatalf("%s description = %q, want %q", name, metric.Description, description)
+			}
+			if metric.Unit != unit {
+				t.Fatalf("%s unit = %q, want %q", name, metric.Unit, unit)
+			}
+			return
+		}
+	}
+
+	t.Fatalf("expected metric %q", name)
+}
+
 func requireNoHistogram(t *testing.T, collected metricdata.ResourceMetrics, name string) {
 	t.Helper()
 

--- a/go/agento11y/conformance_test.go
+++ b/go/agento11y/conformance_test.go
@@ -970,6 +970,9 @@ func TestConformance_StreamingMode(t *testing.T) {
 		t.Fatalf("%s bucket boundaries mismatch:\nexpected %v\n     got %v", metricTokenUsage, expectedTokenUsageBuckets, got)
 	}
 
+	requireMetricMetadata(t, metrics, metricOperationDuration, "GenAI operation duration.", "s")
+	requireMetricMetadata(t, metrics, metricTokenUsage, "Number of input and output tokens used.", "{token}")
+
 	env.Shutdown(t)
 
 	streamGeneration := findGenerationByConversationID(t, env.Ingest.Requests(), "conv-stream")

--- a/go/agento11y/otel_export_test.go
+++ b/go/agento11y/otel_export_test.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/semconv/v1.41.0/genaiconv"
 
 	"github.com/grafana/agento11y/go/otelgenai"
 )
@@ -999,6 +1000,122 @@ func TestOTelProtocolDropsValidatorRejectedRecords(t *testing.T) {
 	}
 	if got := exceptionEventCount(span); got != 0 {
 		t.Errorf("a rejected record carries %d exception events, want 0", got)
+	}
+}
+
+func TestOTelSharedMetricMetadata(t *testing.T) {
+	durationConvention := genaiconv.ClientOperationDuration{}
+	usageConvention := genaiconv.ClientTokenUsage{}
+	if got := durationConvention.Name(); metricOperationDuration != got {
+		t.Fatalf("metricOperationDuration = %q, want %q", metricOperationDuration, got)
+	}
+	if got := usageConvention.Name(); metricTokenUsage != got {
+		t.Fatalf("metricTokenUsage = %q, want %q", metricTokenUsage, got)
+	}
+
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = meterProvider.Shutdown(context.Background()) })
+
+	const sdkScope = "agento11y-test"
+	client, _, _ := newOTelTestClient(t, func(cfg *Config) {
+		cfg.Meter = meterProvider.Meter(sdkScope)
+		cfg.MeterProvider = meterProvider
+	})
+
+	_, generation := client.StartGeneration(context.Background(), GenerationStart{
+		Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+	})
+	generation.SetResult(Generation{
+		Usage: TokenUsage{InputTokens: 10, OutputTokens: 2},
+	}, nil)
+	generation.End()
+	if err := generation.Err(); err != nil {
+		t.Fatalf("generation: %v", err)
+	}
+
+	_, tool := client.StartToolExecution(context.Background(), ToolExecutionStart{ToolName: "weather"})
+	tool.SetResult(ToolExecutionEnd{Result: map[string]any{"temperature": 18}})
+	tool.End()
+	if err := tool.Err(); err != nil {
+		t.Fatalf("tool execution: %v", err)
+	}
+
+	_, embedding := client.StartEmbedding(context.Background(), EmbeddingStart{
+		Model: ModelRef{Provider: "openai", Name: "text-embedding-3-small"},
+	})
+	embedding.SetResult(EmbeddingResult{InputCount: 1, InputTokens: 3})
+	embedding.End()
+	if err := embedding.Err(); err != nil {
+		t.Fatalf("embedding: %v", err)
+	}
+
+	var collected metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &collected); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+
+	metricsByScope := make(map[string]map[string]metricdata.Metrics)
+	for _, scope := range collected.ScopeMetrics {
+		metrics := make(map[string]metricdata.Metrics, len(scope.Metrics))
+		for _, m := range scope.Metrics {
+			metrics[m.Name] = m
+		}
+		metricsByScope[scope.Scope.Name] = metrics
+	}
+
+	sdkMetrics, ok := metricsByScope[sdkScope]
+	if !ok {
+		t.Fatalf("no metrics recorded under %s", sdkScope)
+	}
+	otelMetrics, ok := metricsByScope[otelgenai.ScopeName]
+	if !ok {
+		t.Fatalf("no metrics recorded under %s", otelgenai.ScopeName)
+	}
+
+	conventions := map[string]struct {
+		description string
+		unit        string
+	}{
+		durationConvention.Name(): {
+			description: durationConvention.Description(),
+			unit:        durationConvention.Unit(),
+		},
+		usageConvention.Name(): {
+			description: usageConvention.Description(),
+			unit:        usageConvention.Unit(),
+		},
+	}
+	for name, convention := range conventions {
+		for scopeName, metrics := range map[string]map[string]metricdata.Metrics{
+			sdkScope:            sdkMetrics,
+			otelgenai.ScopeName: otelMetrics,
+		} {
+			m, present := metrics[name]
+			if !present {
+				t.Errorf("%s not recorded under %s", name, scopeName)
+				continue
+			}
+			if m.Description != convention.description {
+				t.Errorf("%s description under %s = %q, want %q", name, scopeName, m.Description, convention.description)
+			}
+			if m.Unit != convention.unit {
+				t.Errorf("%s unit under %s = %q, want %q", name, scopeName, m.Unit, convention.unit)
+			}
+		}
+	}
+
+	for name, sdkMetric := range sdkMetrics {
+		otelMetric, shared := otelMetrics[name]
+		if !shared {
+			continue
+		}
+		if sdkMetric.Description != otelMetric.Description {
+			t.Errorf("%s descriptions differ: SDK = %q, otelgenai = %q", name, sdkMetric.Description, otelMetric.Description)
+		}
+		if sdkMetric.Unit != otelMetric.Unit {
+			t.Errorf("%s units differ: SDK = %q, otelgenai = %q", name, sdkMetric.Unit, otelMetric.Unit)
+		}
 	}
 }
 

--- a/java/core/src/main/java/com/grafana/agento11y/sdk/Agento11yClient.java
+++ b/java/core/src/main/java/com/grafana/agento11y/sdk/Agento11yClient.java
@@ -195,11 +195,13 @@ public final class Agento11yClient implements AutoCloseable {
                 : GlobalOpenTelemetry.getMeter(INSTRUMENTATION_NAME);
 
         this.operationDurationHistogram = meter.histogramBuilder(METRIC_OPERATION_DURATION)
+                .setDescription("GenAI operation duration.")
                 .setUnit("s")
                 .setExplicitBucketBoundariesAdvice(DURATION_BUCKETS_SECONDS)
                 .build();
         this.tokenUsageHistogram = meter.histogramBuilder(METRIC_TOKEN_USAGE)
-                .setUnit("token")
+                .setDescription("Number of input and output tokens used.")
+                .setUnit("{token}")
                 .setExplicitBucketBoundariesAdvice(TOKEN_USAGE_BUCKETS)
                 .build();
         this.ttftHistogram = meter.histogramBuilder(METRIC_TTFT)

--- a/java/core/src/test/java/com/grafana/agento11y/sdk/ConformanceTest.java
+++ b/java/core/src/test/java/com/grafana/agento11y/sdk/ConformanceTest.java
@@ -397,6 +397,13 @@ class ConformanceTest {
             assertThat(generation.getOperationName()).isEqualTo("streamText");
             assertThat(span.getName()).isEqualTo("streamText gpt-5");
             assertThat(metricNames).contains(Agento11yClient.METRIC_OPERATION_DURATION, Agento11yClient.METRIC_TTFT);
+
+            MetricData duration = env.metricData(Agento11yClient.METRIC_OPERATION_DURATION);
+            assertThat(duration.getDescription()).isEqualTo("GenAI operation duration.");
+            assertThat(duration.getUnit()).isEqualTo("s");
+            MetricData tokenUsage = env.metricData(Agento11yClient.METRIC_TOKEN_USAGE);
+            assertThat(tokenUsage.getDescription()).isEqualTo("Number of input and output tokens used.");
+            assertThat(tokenUsage.getUnit()).isEqualTo("{token}");
         }
     }
 

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -267,11 +267,13 @@ export class Agento11yClient {
     this.tracer = this.config.tracer ?? trace.getTracer(instrumentationName);
     this.meter = this.config.meter ?? metrics.getMeter(instrumentationName);
     this.operationDurationHistogram = this.meter.createHistogram(metricOperationDuration, {
+      description: 'GenAI operation duration.',
       unit: 's',
       advice: { explicitBucketBoundaries: durationBucketsSeconds },
     });
     this.tokenUsageHistogram = this.meter.createHistogram(metricTokenUsage, {
-      unit: 'token',
+      description: 'Number of input and output tokens used.',
+      unit: '{token}',
       advice: { explicitBucketBoundaries: tokenUsageBuckets },
     });
     this.ttftHistogram = this.meter.createHistogram(metricTimeToFirstToken, {

--- a/js/test/conformance.test.mjs
+++ b/js/test/conformance.test.mjs
@@ -458,6 +458,15 @@ test('conformance streaming telemetry semantics', async () => {
       1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864,
     ];
     assert.deepEqual(await env.metricBucketBoundaries('gen_ai.client.token.usage'), expectedTokenUsageBuckets);
+
+    assert.deepEqual(await env.metricMetadata('gen_ai.client.operation.duration'), {
+      description: 'GenAI operation duration.',
+      unit: 's',
+    });
+    assert.deepEqual(await env.metricMetadata('gen_ai.client.token.usage'), {
+      description: 'Number of input and output tokens used.',
+      unit: '{token}',
+    });
   } finally {
     await env.close();
   }
@@ -941,6 +950,16 @@ async function createConformanceEnv(options = {}) {
       assert.ok(metric, `expected histogram metric ${metricName}`);
       assert.ok(metric.dataPoints.length > 0, `expected ${metricName} datapoints`);
       return metric.dataPoints[0].value.buckets.boundaries;
+    },
+    async metricMetadata(metricName) {
+      await meterProvider.forceFlush();
+      const metric = metricExporter
+        .getMetrics()
+        .flatMap((resourceMetrics) => resourceMetrics.scopeMetrics)
+        .flatMap((scopeMetrics) => scopeMetrics.metrics)
+        .find((m) => m.descriptor.name === metricName);
+      assert.ok(metric, `expected metric ${metricName}`);
+      return { description: metric.descriptor.description, unit: metric.descriptor.unit };
     },
     async metricDataPointAttributes(metricName) {
       await meterProvider.forceFlush();

--- a/python/agento11y/client.py
+++ b/python/agento11y/client.py
@@ -373,12 +373,14 @@ class Client:
 
         self._operation_duration_histogram: Histogram = self._meter.create_histogram(
             _metric_operation_duration,
+            description="GenAI operation duration.",
             unit="s",
             explicit_bucket_boundaries_advisory=_DURATION_BUCKETS_SECONDS,
         )
         self._token_usage_histogram: Histogram = self._meter.create_histogram(
             _metric_token_usage,
-            unit="token",
+            description="Number of input and output tokens used.",
+            unit="{token}",
             explicit_bucket_boundaries_advisory=_TOKEN_USAGE_BUCKETS,
         )
         self._ttft_histogram: Histogram = self._meter.create_histogram(

--- a/python/tests/test_conformance.py
+++ b/python/tests/test_conformance.py
@@ -241,6 +241,15 @@ class _ConformanceEnv:
                     metrics[metric.name] = metric.data
         return metrics
 
+    def metric_metadata(self) -> dict[str, tuple[str | None, str | None]]:
+        metadata = {}
+        data = self.metric_reader.get_metrics_data()
+        for resource_metric in data.resource_metrics:
+            for scope_metric in resource_metric.scope_metrics:
+                for metric in scope_metric.metrics:
+                    metadata[metric.name] = (metric.description, metric.unit)
+        return metadata
+
 
 def test_conformance_sync_roundtrip_semantics() -> None:
     env = _ConformanceEnv()
@@ -750,6 +759,13 @@ def test_conformance_streaming_telemetry_semantics() -> None:
         assert token_usage_points, "expected gen_ai.client.token.usage data points"
         assert tuple(token_usage_points[0].explicit_bounds) == expected_token_usage_buckets, (
             f"gen_ai.client.token.usage bucket boundaries mismatch: {tuple(token_usage_points[0].explicit_bounds)}"
+        )
+
+        metadata = env.metric_metadata()
+        assert metadata["gen_ai.client.operation.duration"] == ("GenAI operation duration.", "s")
+        assert metadata["gen_ai.client.token.usage"] == (
+            "Number of input and output tokens used.",
+            "{token}",
         )
     finally:
         env.shutdown()


### PR DESCRIPTION
Builds the SDK's `gen_ai.client.operation.duration` and `gen_ai.client.token.usage` histograms through the `genaiconv` constructors instead of raw `meter.Float64Histogram` and `meter.Int64Histogram`, so they have the same description and unit as the semantic convention describes.

What this means for a consumer (not breaking):

- Metric names, values, attributes and bucket boundaries do not change.
- HELP changes from empty to the semconv sentence.
- The token-usage unit becomes `{token}` instead of `token`.