### PR TITLE
fix(plugins/agento11y): enable coding agent tags by default

### DIFF
--- a/plugins/agento11y/internal/login/login.go
+++ b/plugins/agento11y/internal/login/login.go
@@ -387,7 +387,7 @@ func Run(ctx context.Context, opts RunOpts) (Result, error) {
 		otelEndpoint: cmp.Or(fixed.otelEndpoint, existing["SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT"]),
 		contentMode:  normalizeContentMode(existing["SIGIL_CONTENT_CAPTURE_MODE"]),
 		tags:         existing["SIGIL_TAGS"],
-		autoTags:     envconfig.ParseBool(existing[envconfig.LegacyKey(envconfig.AutoTagsSuffix)]),
+		autoTags:     seedAutoTags(existing[envconfig.LegacyKey(envconfig.AutoTagsSuffix)]),
 		autoTagNames: seedAutoTagNames(existing[envconfig.LegacyKey(envconfig.AutoTagNamesSuffix)]),
 		guards:       seedGuards(existing["SIGIL_GUARDS_ENABLED"], existing["SIGIL_GUARDS_FAIL_OPEN"]),
 		guardTimeout: strings.TrimSpace(existing["SIGIL_GUARDS_TIMEOUT_MS"]),
@@ -703,14 +703,11 @@ func preferenceGroups(v *formValues) []*huh.Group {
 	}
 }
 
-// autoTagSwitchOptions answers the automatic-tag question. Off leads, like the
-// default option of every other list here, and says what staying off means:
-// the question describes what turning it on sends, so the answer that sends
-// nothing needs its own words rather than a bare No.
+// Keep Off first: huh matches the zero bool before binding Value and scrolls earlier options out of view.
 func autoTagSwitchOptions() []huh.Option[bool] {
 	return []huh.Option[bool]{
-		huh.NewOption("Off — no user, repository, or branch labels (default)", false),
-		huh.NewOption("On — choose which of the three to send next", true),
+		huh.NewOption("Off — no user, repository, or branch labels", false),
+		huh.NewOption("On — choose which of the three to send next (default)", true),
 	}
 }
 
@@ -1224,6 +1221,15 @@ func validateAutoTagNames(selected []string) error {
 		return errors.New("select at least one value, or turn automatic tags off")
 	}
 	return nil
+}
+
+// seedAutoTags starts the automatic-tag question on On when nothing is saved.
+// A saved false stays off: a rerun must not switch the setting back on.
+func seedAutoTags(raw string) bool {
+	if strings.TrimSpace(raw) == "" {
+		return true
+	}
+	return envconfig.ParseBool(raw)
 }
 
 // seedAutoTagNames turns a saved allowlist into the preselected names. An

--- a/plugins/agento11y/internal/login/login_test.go
+++ b/plugins/agento11y/internal/login/login_test.go
@@ -290,6 +290,27 @@ func TestSeedGuards(t *testing.T) {
 	}
 }
 
+func TestSeedAutoTags(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"unset starts on", "", true},
+		{"blank starts on", "   ", true},
+		{"saved false stays off", "false", false},
+		{"saved true stays on", "1", true},
+		{"unparseable stays off", "maybe", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := seedAutoTags(c.raw); got != c.want {
+				t.Errorf("seedAutoTags(%q) = %v, want %v", c.raw, got, c.want)
+			}
+		})
+	}
+}
+
 // TestSeedAutoTagNames pins what the checklist starts with. A saved allowlist
 // preselects the names it holds. No saved allowlist preselects every supported
 // name. A saved allowlist that holds no supported name preselects nothing: that
@@ -382,7 +403,7 @@ func TestPreferenceGroupsMarkTheAnswer(t *testing.T) {
 	for _, want := range []string{
 		"Metadata only",
 		"Disabled (default)",
-		"Off — no user, repository, or branch labels (default)",
+		"Off — no user, repository, or branch labels",
 	} {
 		if !strings.Contains(view, want) {
 			t.Errorf("form does not list %q:\n%s", want, view)


### PR DESCRIPTION
It was the default value before https://github.com/grafana/agento11y/pull/645

<img width="421" height="122" alt="image" src="https://github.com/user-attachments/assets/6da637bd-2dce-4daf-8f94-f4ac90162958" />
