### PR TITLE
fix(frameworks): record Strands token usage and the configured streaming mode

### DIFF
--- a/python-frameworks/strands/README.md
+++ b/python-frameworks/strands/README.md
@@ -9,6 +9,8 @@ pip install agento11y agento11y-strands
 pip install strands-agents
 ```
 
+Requires `strands-agents>=1.36.0`. That is the first release to attach token usage to the assistant message, which is the only place `AfterModelCallEvent` exposes it. On older versions generations are still recorded, but always without token counts or cost.
+
 ## Quickstart
 
 ```python
@@ -70,6 +72,16 @@ Metadata includes:
 - required: `agento11y.framework.run_type`
 - optional: `agento11y.framework.run_id`, `agento11y.framework.thread_id`, `agento11y.framework.parent_run_id`, `agento11y.framework.component_name`, `agento11y.framework.event_id`
 
+## Streaming Mode
+
+Generations are recorded as `STREAM` or `SYNC` from the model's own configuration. Strands spells the flag three ways, and all of them are read:
+
+- `params={"stream": False}` for OpenAI, LiteLLM, Anthropic and Writer models
+- `stream=False` for Mistral and SageMaker models
+- `streaming=False` for Bedrock models
+
+Strands defaults every provider to streaming, so a model that sets none of these is recorded as `STREAM`.
+
 ## Provider Resolver
 
 Resolver order: explicit provider option -> Strands model config metadata -> model prefix inference -> `custom`.
@@ -79,5 +91,6 @@ For Bedrock model IDs that do not infer cleanly, pass `provider="anthropic"` or 
 ## Troubleshooting
 
 - If conversations are fragmented, pass stable `conversation_id` or `session_id` in `invocation_state`.
+- If generations carry no token usage or cost, check the installed `strands-agents` version. Usage is only reachable from the model hook on 1.36.0 and later.
 - If provider is inferred as `custom`, set `provider="openai"` / `provider="anthropic"` / `provider="gemini"` on hook creation.
 - Always call `client.shutdown()` during teardown.

--- a/python-frameworks/strands/agento11y_strands/__init__.py
+++ b/python-frameworks/strands/agento11y_strands/__init__.py
@@ -285,7 +285,10 @@ def _serialized_agent(agent: Any, *, model_name: str) -> dict[str, Any]:
 
 
 def _model_invocation_params(agent: Any, *, model_name: str) -> dict[str, Any]:
-    params: dict[str, Any] = {"stream": True}
+    config = _model_config(agent)
+    model_params = _model_params(config)
+
+    params: dict[str, Any] = {"stream": _model_streaming(config, model_params)}
     if model_name != "":
         params["model"] = model_name
     provider = _model_provider(agent)
@@ -296,9 +299,10 @@ def _model_invocation_params(agent: Any, *, model_name: str) -> dict[str, Any]:
     if system_prompt != "":
         params["system_prompt"] = system_prompt
 
-    config = _model_config(agent)
     for key in ("temperature", "max_tokens", "top_p", "tool_choice"):
-        value = _read(config, key)
+        value = _read(model_params, key)
+        if value is None:
+            value = _read(config, key)
         if value is not None:
             params[key] = value
 
@@ -398,6 +402,19 @@ def _model_config(agent: Any) -> Any:
         except Exception:
             return {}
     return _read(model, "config") or {}
+
+
+def _model_params(config: Any) -> dict[str, Any]:
+    params = _read(config, "params")
+    return params if isinstance(params, dict) else {}
+
+
+def _model_streaming(config: Any, model_params: dict[str, Any]) -> bool:
+    for source, key in ((model_params, "stream"), (config, "stream"), (config, "streaming")):
+        enabled = _bool_or_none(_read(source, key))
+        if enabled is not None:
+            return enabled
+    return True
 
 
 def _tool_definitions(agent: Any) -> list[ToolDefinition]:
@@ -536,6 +553,23 @@ def _int_or_none(value: Any) -> int | None:
         return None
     if isinstance(value, int):
         return value
+    return None
+
+
+def _bool_or_none(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+        return None
+    if isinstance(value, int):
+        return value != 0
     return None
 
 

--- a/python-frameworks/strands/agento11y_strands/handler.py
+++ b/python-frameworks/strands/agento11y_strands/handler.py
@@ -134,11 +134,12 @@ class Agento11yStrandsHandler(Agento11yFrameworkHandlerBase):
         tags_payload["agento11y.framework.source"] = self._framework_source
         tags_payload["agento11y.framework.language"] = self._framework_language
 
+        stream = _stream_enabled(invocation_params)
         start = GenerationStart(
             conversation_id=conversation_id,
             agent_name=self._agent_name,
             agent_version=self._agent_version,
-            mode=GenerationMode.STREAM,
+            mode=GenerationMode.STREAM if stream else GenerationMode.SYNC,
             model=ModelRef(provider=provider_name, name=model_name),
             tags=tags_payload,
             metadata=metadata_payload,
@@ -149,7 +150,7 @@ class Agento11yStrandsHandler(Agento11yFrameworkHandlerBase):
             top_p=_optional_float(_read(invocation_params, "top_p")),
             tool_choice=_as_string(_read(invocation_params, "tool_choice")) or None,
         )
-        recorder = self._client.start_streaming_generation(start)
+        recorder = self._client.start_streaming_generation(start) if stream else self._client.start_generation(start)
         self._strands_runs[run_key] = _StrandsRunState(
             recorder=recorder,
             input_messages=_map_chat_inputs(messages) if self._capture_inputs else [],
@@ -475,6 +476,14 @@ def _event_id_from_payload(payload: Any) -> str:
     )
 
 
+def _stream_enabled(invocation_params: Any) -> bool:
+    for key in ("stream", "streaming"):
+        enabled = _optional_bool(_read(invocation_params, key))
+        if enabled is not None:
+            return enabled
+    return True
+
+
 def _normalize_role(role: str) -> MessageRole:
     normalized = role.strip().lower()
     if normalized in {"assistant", "ai"}:
@@ -515,6 +524,23 @@ def _optional_float(value: Any) -> float | None:
             return float(value.strip())
         except ValueError:
             return None
+    return None
+
+
+def _optional_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+        return None
+    if isinstance(value, int):
+        return value != 0
     return None
 
 

--- a/python-frameworks/strands/pyproject.toml
+++ b/python-frameworks/strands/pyproject.toml
@@ -6,8 +6,11 @@ readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
-  "agento11y>=0.17.0",
-  "strands-agents>=1.0.0",
+  "agento11y>=0.17.0",                                                                                                                                                                                                                                       
+   # 1.36.0 is the first release to attach token usage to the assistant message, which                                                                                                                                                                        
+   # is the only place AfterModelCallEvent exposes it. Older releases cannot report                                                                                                                                                                           
+   # token counts at all, so this floor is required rather than preferred.                                                                                                                                                                                    
+   "strands-agents>=1.36.0",
 ]
 
 [project.optional-dependencies]

--- a/python-frameworks/strands/tests/test_agento11y_strands.py
+++ b/python-frameworks/strands/tests/test_agento11y_strands.py
@@ -404,7 +404,7 @@ def test_strands_model_call_without_message_metadata_records_no_usage() -> None:
         client.shutdown()
 
 
-def test_strands_cache_token_usage_preserved() -> None:
+def test_strands_cache_token_usage_is_preserved() -> None:
     exporter = _CapturingExporter()
     client = _new_client(exporter)
 

--- a/python-frameworks/strands/tests/test_agento11y_strands.py
+++ b/python-frameworks/strands/tests/test_agento11y_strands.py
@@ -49,6 +49,22 @@ class _Model:
         }
 
 
+class _NestedParamsModel:
+    def __init__(self, **params) -> None:
+        self._params = params
+
+    def get_config(self):
+        return {"model_id": "gpt-4o", "params": self._params}
+
+
+class _FlatConfigModel:
+    def __init__(self, **config) -> None:
+        self._config = config
+
+    def get_config(self):
+        return {"model_id": "mistral-large-latest", **self._config}
+
+
 class _ToolRegistry:
     def get_all_tools_config(self):
         return {
@@ -71,6 +87,24 @@ def _agent():
         messages=[{"role": "user", "content": [{"text": "hello"}]}],
         tool_registry=_ToolRegistry(),
     )
+
+
+def _record_one_model_call(client, agent, *, message=None) -> None:
+    hooks = create_agento11y_strands_hook_provider(client=client, provider_resolver="auto")
+    invocation_state = {"conversation_id": "conv-mode"}
+    hooks.before_model_call(SimpleNamespace(agent=agent, invocation_state=invocation_state))
+    hooks.after_model_call(
+        SimpleNamespace(
+            agent=agent,
+            invocation_state=invocation_state,
+            stop_response=SimpleNamespace(
+                message=message if message is not None else {"role": "assistant", "content": [{"text": "ok"}]},
+                stop_reason="end_turn",
+            ),
+            exception=None,
+        )
+    )
+    client.flush()
 
 
 def test_strands_model_lifecycle_exports_generation_with_framework_metadata() -> None:
@@ -289,6 +323,83 @@ def test_with_agento11y_strands_hooks_adds_provider_to_config_once() -> None:
         hooks = config["hooks"]
         assert len(hooks) == 1
         assert isinstance(hooks[0], Agento11yStrandsHookProvider)
+    finally:
+        client.shutdown()
+
+
+def test_strands_nested_params_config_reports_sync_mode_and_sampling_params() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        agent = _agent()
+        agent.model = _NestedParamsModel(stream=False, temperature=0.2, max_tokens=256, top_p=0.9)
+        _record_one_model_call(client, agent)
+
+        generation = exporter.requests[0].generations[0]
+        assert generation.mode.value == "SYNC"
+        assert generation.temperature == 0.2
+        assert generation.max_tokens == 256
+        assert generation.top_p == 0.9
+    finally:
+        client.shutdown()
+
+
+def test_strands_flat_config_stream_flag_reports_sync_mode() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        agent = _agent()
+        agent.model = _FlatConfigModel(stream=False, temperature=0.3)
+        _record_one_model_call(client, agent)
+
+        generation = exporter.requests[0].generations[0]
+        assert generation.mode.value == "SYNC"
+        assert generation.temperature == 0.3
+    finally:
+        client.shutdown()
+
+
+def test_strands_bedrock_streaming_flag_reports_sync_mode() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        agent = _agent()
+        agent.model = _FlatConfigModel(streaming=False)
+        _record_one_model_call(client, agent)
+
+        assert exporter.requests[0].generations[0].mode.value == "SYNC"
+    finally:
+        client.shutdown()
+
+
+def test_strands_streaming_is_the_default_when_the_config_omits_the_flag() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        agent = _agent()
+        agent.model = _NestedParamsModel(temperature=0.5)
+        _record_one_model_call(client, agent)
+
+        assert exporter.requests[0].generations[0].mode.value == "STREAM"
+    finally:
+        client.shutdown()
+
+
+def test_strands_model_call_without_message_metadata_records_no_usage() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+
+    try:
+        agent = _agent()
+        _record_one_model_call(client, agent, message={"role": "assistant", "content": [{"text": "ok"}]})
+
+        generation = exporter.requests[0].generations[0]
+        assert generation.stop_reason == "end_turn"
+        assert generation.usage is None or generation.usage.total_tokens == 0
     finally:
         client.shutdown()
 


### PR DESCRIPTION
## Summary

Closes #296  //  cc: @alexander-akhmetov

Both bugs are real, though the line numbers in the report point at symptoms rather than causes.

#### **Token usage** 

The read in `_llm_end_payload` is actually correct, just newer than the reported Strands version. `message["metadata"]["usage"]` didn't exist until strands-agents 1.36.0 -- I checked, absent in 1.35.0 and present from 1.36.0 onward. Below that there is genuinely nowhere to get per-call usage from `AfterModelCallEvent`: `event_loop_metrics.update_usage()` runs after the hook fires, so reading it there gives you the previous cycle's numbers. Still true in 1.53.0. So this ends up being a dependency floor bump rather than a code change.

#### **Streaming** 

The `{"stream": True}` in `_model_invocation_params` is dead -- nothing reads `invocation_params["stream"]`, so patching it alone wouldn't have changed anything. The hardcoding that matters is in `handler.py`, which sets `mode=GenerationMode.STREAM` and calls `start_streaming_generation()` unconditionally. Fixed there, and it now covers the three spellings Strands uses: `params["stream"]` for OpenAI/LiteLLM/Anthropic, `stream` for Mistral/SageMaker, `streaming` for Bedrock.

While in there I also fixed the sampling params. `temperature`, `max_tokens`, `top_p` and `tool_choice` were read from the top level of the model config, but OpenAI, LiteLLM and Anthropic nest them under `params`, so they were being dropped for those providers. Same function and same root cause as the stream flag. Happy to pull it into its own PR if you'd rather review it separately.


## Behavior change

The floor bump drops strands-agents 1.0 through 1.35. Those versions can't report usage through this hook at all, so the alternative is leaving people on a quietly broken feature -- but it needs a release note.

Non-streaming models will also move from `STREAM` to `SYNC`. That's the intent, but it does change what already-instrumented agents report.


## Test plan

`mise run test:py:sdk-strands` and `mise run lint:py` are clean. Five new tests cover the three spellings, the streaming default when no flag is set, and a message with no `metadata` degrading to no usage rather than raising. Reverting the source with the tests in place fails the three streaming ones, so they pin the fix rather than current behavior.

I also ran `_model_invocation_params` against real `OpenAIModel`, `LiteLLMModel`, `AnthropicModel`, `MistralModel` and `BedrockModel` instances instead of fakes -- all five reported `stream=True` before and the configured value after. Worth flagging because the existing fixture returns a flat config with a top-level `temperature` and a `provider` key, which isn't a shape Strands produces. That's most of why this went unnoticed.