### PR TITLE
fix(examples/go): default N_ATTEMPTS to 3 so pass@k/pass^k aren't null

### DIFF
--- a/examples/experiments/go/.env.example
+++ b/examples/experiments/go/.env.example
@@ -36,7 +36,8 @@ AGENTO11Y_AUTH_TOKEN=<your-cloud-access-policy-token>
 # Optional run identity.
 RUN_ID=go-experiment-local
 GIT_SHA=local
-N_ATTEMPTS=1
+# Attempts per test case. pass@k/pass^k are null below k=2; use 3+ to see both populated.
+N_ATTEMPTS=3
 
 # Optional stored-evaluator example configuration. The evaluator has to exist in
 # your tenant already; the example does not create one. Stored-evaluator grading

--- a/examples/experiments/go/README.md
+++ b/examples/experiments/go/README.md
@@ -10,6 +10,10 @@ trial, generation, conversation, and occurrence-aware score identities.
 Re-running a resumed job with the same identities is idempotent; increment the
 attempt only for a genuinely new attempt.
 
+Set `N_ATTEMPTS` to run each test case more than once per experiment (the
+default `.env.example` uses 3). `pass@k` and `pass^k` are null below k=2, since
+both require multiple attempts of the same test case to compute.
+
 ```bash
 cd examples/experiments/go
 cp .env.example .env


### PR DESCRIPTION
## What

Bumps the Go experiments example's default `N_ATTEMPTS` from 1 to 3 in `examples/experiments/go/.env.example`, and documents the knob in the example's README.

## Why

`pass@k` and `pass^k` both require at least 2 attempts of the same test case to compute. With the example's default of `N_ATTEMPTS=1`, running it out of the box always leaves both metrics null in the published report — so the Advanced metrics section has nothing to show on a first run.

Checked for existing PRs/issues covering this (search on `N_ATTEMPTS`, `pass@k`, `pass_at_k`, `pass^k`, and file history on `.env.example`) and found nothing open or merged that addresses it.

## Testing

Docs/config-only change (an `.env.example` value and a README note) — no source touched. Confirmed the example still builds with `GOWORK=off go build ./...` and that sourcing the updated `.env.example` resolves `N_ATTEMPTS=3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)