### PR TITLE
fix(examples/go): add missing go.sum entries for otel/log

### DIFF
--- a/examples/experiments/go/go.mod
+++ b/examples/experiments/go/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
+	go.opentelemetry.io/otel/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	golang.org/x/net v0.56.0 // indirect

--- a/examples/experiments/go/go.sum
+++ b/examples/experiments/go/go.sum
@@ -27,6 +27,10 @@ go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
+go.opentelemetry.io/otel/log v0.20.0 h1:/5i0vuHxCLWUfChWG41K9wkM0jafruPw9NU1/RCJirs=
+go.opentelemetry.io/otel/log v0.20.0/go.mod h1:wOcMcjsZpG8x7Bak7IhSi/lg8wscV2C1VdrKCLPlt0E=
+go.opentelemetry.io/otel/log/logtest v0.20.0 h1:+tsZVE15N+RWyN9lUzsRyw7hMZXNMepGu105Eim82/k=
+go.opentelemetry.io/otel/log/logtest v0.20.0/go.mod h1:zS9Ryx9RrEAG2tgapMBSvacwhVSSOGSaSiWWgW3NPlQ=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/sdk v1.44.0 h1:nHYwb9lK+fJPU/dnT6s7W7Z8itMWyqrnVfbheVYrZ58=


### PR DESCRIPTION
## What

Adds the missing `go.opentelemetry.io/otel/log` indirect requirement and `go.sum` entries to `examples/experiments/go`, via `go mod tidy`.

## Why

A clean checkout of `examples/experiments/go` currently fails to build:

```
../../../go/otelgenai/event.go:15:2: missing go.sum entry for module providing package go.opentelemetry.io/otel/log (imported by github.com/grafana/agento11y/go/otelgenai); to add:
        go get github.com/grafana/agento11y/go/otelgenai@v0.8.0
../../../go/otelgenai/genai.go:12:2: missing go.sum entry for module providing package go.opentelemetry.io/otel/log/global (imported by github.com/grafana/agento11y/go/otelgenai); to add:
        go get github.com/grafana/agento11y/go/otelgenai@v0.8.0
```

`go/otelgenai` (`event.go`, `genai.go`) imports `go.opentelemetry.io/otel/log` and `go.opentelemetry.io/otel/log/global`, and the root `go/go.mod` already requires `otel/log v0.20.0` directly. The example module's `go.mod`/`go.sum` (which reach `go/otelgenai` via a local `replace`) were never updated to include it as an indirect dependency, so `go build`/`go run` fail at the missing-checksum stage on any fresh clone.

## Testing

- `GOWORK=off go build ./...` in `examples/experiments/go`: fails on current `main`, passes after this fix.
- `GOWORK=off go vet ./...`: passes.
- Diff is exactly the `go mod tidy` output — one new indirect requirement (`otel/log v0.20.0`) and its `go.sum` hashes (`log` + `log/logtest`). No other files touched.

This is a separate, unrelated fix from #652 (which changes the example's `N_ATTEMPTS` default) — kept as its own PR since one is a dependency bug and the other is an example-config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)