### PR TITLE
feat(plugins/agento11y): add opencode history import

### DIFF
--- a/plugins/agento11y/README.md
+++ b/plugins/agento11y/README.md
@@ -106,7 +106,7 @@ Local mode stores full session content. Manage the app with `agento11y local sta
 
 The local Agent Observability app starts empty: it only has sessions captured after you installed agento11y. To backfill earlier sessions, prefer the app — a banner on the Sessions page, or Settings → History. Imports run in the background with live progress; you can cancel them, and a cancelled run keeps what it already imported.
 
-You can also use the CLI. Supported agents are `claude-code`, `codex`, `cursor`, and `pi` (`agento11y history import` with no agent lists them):
+You can also use the CLI. Supported agents are `claude-code`, `codex`, `cursor`, `opencode`, and `pi` (`agento11y history import` with no agent lists them):
 
 ```sh
 # See what would be imported. Nothing is decoded, exported, or stored.
@@ -123,6 +123,11 @@ Imported sessions are thinner than live capture — host logs omit fields that l
 
 - **pi** — reads `$PI_CODING_AGENT_DIR/sessions` (default `~/.pi/agent/sessions`). One generation per assistant turn. Missing vs live: compaction/branch-summary generations, system prompt and request controls, full tool schemas, and `git.branch`. Forks import only the fork's own turns; subagent logs are skipped.
 - **cursor** — reads agent-transcript JSONL under `~/.cursor/projects/…/agent-transcripts/` and the older `store.db` under `~/.cursor/chats/…`. Missing vs live: token usage/cost (turns are marked approximate), reliable timestamps on `store.db` sessions, models on transcripts, and tool results on transcripts. Cursor formats can change without notice.
+- **opencode**: Reads `opencode*.db` under `$XDG_DATA_HOME/opencode` (default `~/.local/share/opencode`).
+  `OPENCODE_DB` adds another database. Absolute values are used as-is. Relative values are resolved under the OpenCode data directory.
+  History cannot recover the system prompt, host version, configured agent-name prefix, capture-time Git branch, time to first token, or separate tool spans.
+  An assistant message is imported when it has a completion timestamp or an error. Messages with neither are skipped.
+  OpenCode forks copy all messages before the fork point into a new session with new IDs. If you import both sessions, those copied assistant turns are imported twice.
 
 Without `--since`, an import covers the last 90 days. Pass `--since 365d` (or a timestamp) to widen the window, and `--until` to bound the other end. Other useful flags: `--workspace`, `--max-sessions`, `--max-turns`, `--all`, `--yes`, `--force`. Without a terminal, pass `--all --yes` to import from a script.
 

--- a/plugins/agento11y/internal/agents/opencode/sessiondb/sessiondb.go
+++ b/plugins/agento11y/internal/agents/opencode/sessiondb/sessiondb.go
@@ -1,0 +1,385 @@
+// Package sessiondb reads OpenCode's SQLite session store.
+package sessiondb
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"iter"
+	"time"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/chatstore"
+	_ "modernc.org/sqlite"
+)
+
+// MaxPayloadBytes is the largest message.data or part.data value decoded.
+const MaxPayloadBytes = 4 * 1024 * 1024
+
+// Store is an open read-only OpenCode session database.
+type Store struct {
+	db   *sql.DB
+	path string
+}
+
+// Session is one row from the session table with discovery aggregates.
+type Session struct {
+	ID                   string
+	Title                string
+	Directory            string
+	ParentID             string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	MessageCount         int
+	TerminalMessageCount int
+	LogicalSizeBytes     int64
+}
+
+// Message is one decoded message row. OpenCode strips ID and SessionID from
+// data before writing it, so the reader restores them from the row columns.
+type Message struct {
+	ID         string    `json:"-"`
+	SessionID  string    `json:"-"`
+	RowCreated time.Time `json:"-"`
+	RowUpdated time.Time `json:"-"`
+
+	Role       string        `json:"role"`
+	Time       MessageTime   `json:"time"`
+	ParentID   string        `json:"parentID"`
+	ModelID    string        `json:"modelID"`
+	ProviderID string        `json:"providerID"`
+	Mode       string        `json:"mode"`
+	Agent      string        `json:"agent"`
+	Path       MessagePath   `json:"path"`
+	Cost       float64       `json:"cost"`
+	Tokens     TokenCounts   `json:"tokens"`
+	Finish     string        `json:"finish"`
+	Error      *MessageError `json:"error"`
+}
+
+// MessageTime contains OpenCode's integer millisecond timestamps.
+type MessageTime struct {
+	Created   int64  `json:"created"`
+	Completed *int64 `json:"completed"`
+}
+
+// MessagePath records the working directory and project root for an assistant message.
+type MessagePath struct {
+	CWD  string `json:"cwd"`
+	Root string `json:"root"`
+}
+
+// TokenCounts is shared by assistant messages and step-finish parts.
+type TokenCounts struct {
+	Input     int64       `json:"input"`
+	Output    int64       `json:"output"`
+	Reasoning int64       `json:"reasoning"`
+	Cache     CacheCounts `json:"cache"`
+	observed  bool
+}
+
+// UnmarshalJSON records whether the payload carried any numeric count.
+func (t *TokenCounts) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Input     *int64 `json:"input"`
+		Output    *int64 `json:"output"`
+		Reasoning *int64 `json:"reasoning"`
+		Cache     struct {
+			Read  *int64 `json:"read"`
+			Write *int64 `json:"write"`
+		} `json:"cache"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*t = TokenCounts{}
+	set := func(dst *int64, src *int64) {
+		if src != nil {
+			*dst = *src
+			t.observed = true
+		}
+	}
+	set(&t.Input, raw.Input)
+	set(&t.Output, raw.Output)
+	set(&t.Reasoning, raw.Reasoning)
+	set(&t.Cache.Read, raw.Cache.Read)
+	set(&t.Cache.Write, raw.Cache.Write)
+	return nil
+}
+
+// Observed reports whether at least one numeric token field was present.
+func (t TokenCounts) Observed() bool { return t.observed }
+
+// CacheCounts holds OpenCode's disjoint cache token buckets.
+type CacheCounts struct {
+	Read  int64 `json:"read"`
+	Write int64 `json:"write"`
+}
+
+// MessageError is a terminal assistant-message error.
+type MessageError struct {
+	Name string           `json:"name"`
+	Data MessageErrorData `json:"data"`
+}
+
+// MessageErrorData contains the error fields used by the live mapper.
+type MessageErrorData struct {
+	StatusCode *int `json:"statusCode"`
+}
+
+// Part is one decoded part row. Identity fields come from row columns.
+type Part struct {
+	ID         string    `json:"-"`
+	MessageID  string    `json:"-"`
+	SessionID  string    `json:"-"`
+	RowUpdated time.Time `json:"-"`
+
+	Type      string      `json:"type"`
+	Text      string      `json:"text"`
+	Synthetic bool        `json:"synthetic"`
+	Ignored   bool        `json:"ignored"`
+	CallID    string      `json:"callID"`
+	Tool      string      `json:"tool"`
+	State     ToolState   `json:"state"`
+	Reason    string      `json:"reason"`
+	Cost      float64     `json:"cost"`
+	Tokens    TokenCounts `json:"tokens"`
+	Time      PartTime    `json:"time"`
+}
+
+// PartTime contains a part's own timestamps when OpenCode persisted them.
+type PartTime struct {
+	Start int64  `json:"start"`
+	End   *int64 `json:"end"`
+}
+
+// ToolState is the persisted state of an OpenCode tool part.
+type ToolState struct {
+	Status   string          `json:"status"`
+	Input    json.RawMessage `json:"input"`
+	Output   string          `json:"output"`
+	Error    *string         `json:"error"`
+	Title    string          `json:"title"`
+	Metadata ToolMetadata    `json:"metadata"`
+	Time     PartTime        `json:"time"`
+}
+
+// ToolMetadata contains persisted task lineage and shell status.
+type ToolMetadata struct {
+	SessionID string `json:"sessionId"`
+	Exit      *int   `json:"exit"`
+}
+
+// Open opens path read-only. SQLite connects lazily, so schema errors surface
+// on the first query. The mode reads a live write-ahead log; it may create the
+// missing shared-memory sidecar SQLite needs to index that log.
+func Open(path string) (*Store, error) {
+	db, err := sql.Open("sqlite", chatstore.URI(path)+"?mode=ro")
+	if err != nil {
+		return nil, fmt.Errorf("sessiondb: open %s: %w", path, err)
+	}
+	return &Store{db: db, path: path}, nil
+}
+
+// Close releases the database.
+func (s *Store) Close() error { return s.db.Close() }
+
+// Sessions returns one content-free row per OpenCode session in stable order.
+func (s *Store) Sessions(ctx context.Context) ([]Session, error) {
+	const query = `select
+		s.id,
+		s.directory,
+		coalesce(s.parent_id, ''),
+		s.time_created,
+		max(
+			s.time_updated,
+			coalesce(max(m.time_updated), 0),
+			coalesce((select max(p.time_updated) from part p where p.session_id = s.id), 0)
+		) as activity_updated,
+		count(m.id),
+		coalesce(sum(case
+			when json_valid(m.data)
+			and json_extract(m.data, '$.role') = 'assistant'
+			and (json_type(m.data, '$.time.completed') in ('integer', 'real')
+				or json_type(m.data, '$.error') = 'object')
+			then 1 else 0 end), 0),
+		coalesce(sum(length(m.data)), 0)
+			+ coalesce((select sum(length(p.data)) from part p where p.session_id = s.id), 0),
+		min(case when not json_valid(m.data) then m.id end)
+	from session s
+	left join message m on m.session_id = s.id
+	group by s.id, s.directory, s.parent_id, s.time_created, s.time_updated
+	order by activity_updated desc, s.id`
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("sessiondb: list sessions from %s: %w", s.path, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var sessions []Session
+	for rows.Next() {
+		var row Session
+		var createdMS, updatedMS int64
+		var malformedMessageID sql.NullString
+		if err := rows.Scan(
+			&row.ID,
+			&row.Directory,
+			&row.ParentID,
+			&createdMS,
+			&updatedMS,
+			&row.MessageCount,
+			&row.TerminalMessageCount,
+			&row.LogicalSizeBytes,
+			&malformedMessageID,
+		); err != nil {
+			return nil, fmt.Errorf("sessiondb: list sessions from %s: %w", s.path, err)
+		}
+		if malformedMessageID.Valid {
+			return nil, fmt.Errorf("sessiondb: decode message %s from %s: malformed JSON", malformedMessageID.String, s.path)
+		}
+		row.CreatedAt = time.UnixMilli(createdMS)
+		row.UpdatedAt = time.UnixMilli(updatedMS)
+		sessions = append(sessions, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sessiondb: list sessions from %s: %w", s.path, err)
+	}
+	return sessions, nil
+}
+
+// Session returns one session row without reading message or part data.
+func (s *Store) Session(ctx context.Context, sessionID string) (Session, bool, error) {
+	const query = `select id, title, directory, coalesce(parent_id, ''), time_created, time_updated
+		from session where id = ?`
+	var row Session
+	var createdMS, updatedMS int64
+	err := s.db.QueryRowContext(ctx, query, sessionID).Scan(
+		&row.ID,
+		&row.Title,
+		&row.Directory,
+		&row.ParentID,
+		&createdMS,
+		&updatedMS,
+	)
+	if err == sql.ErrNoRows {
+		return Session{}, false, nil
+	}
+	if err != nil {
+		return Session{}, false, fmt.Errorf("sessiondb: read session %s from %s: %w", sessionID, s.path, err)
+	}
+	row.CreatedAt = time.UnixMilli(createdMS)
+	row.UpdatedAt = time.UnixMilli(updatedMS)
+	return row, true, nil
+}
+
+// MessageRole extracts one message's role without decoding its payload in Go.
+func (s *Store) MessageRole(ctx context.Context, messageID string) (string, bool, error) {
+	const query = `select json_extract(data, '$.role') from message where id = ? and json_valid(data)`
+	var role string
+	err := s.db.QueryRowContext(ctx, query, messageID).Scan(&role)
+	if err == sql.ErrNoRows {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("sessiondb: read message role for %s from %s: %w", messageID, s.path, err)
+	}
+	return role, true, nil
+}
+
+// SpawningMessageID finds the task call that created a child session.
+func (s *Store) SpawningMessageID(ctx context.Context, parentSessionID, childSessionID string) (string, bool, error) {
+	const query = `select message_id
+		from part
+		where session_id = ?
+			and json_valid(data)
+			and json_extract(data, '$.type') = 'tool'
+			and json_extract(data, '$.tool') = 'task'
+			and json_extract(data, '$.state.metadata.sessionId') = ?
+		order by id
+		limit 1`
+	var messageID string
+	err := s.db.QueryRowContext(ctx, query, parentSessionID, childSessionID).Scan(&messageID)
+	if err == sql.ErrNoRows {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("sessiondb: find spawning message for %s in %s: %w", childSessionID, s.path, err)
+	}
+	return messageID, true, nil
+}
+
+// Messages yields one session's decoded messages ordered by time_created and ID.
+func (s *Store) Messages(ctx context.Context, sessionID string) iter.Seq2[Message, error] {
+	return func(yield func(Message, error) bool) {
+		const query = `select id, session_id, time_created, time_updated, data
+			from message where session_id = ? order by time_created, id`
+		rows, err := s.db.QueryContext(ctx, query, sessionID)
+		if err != nil {
+			yield(Message{}, fmt.Errorf("sessiondb: read messages for %s from %s: %w", sessionID, s.path, err))
+			return
+		}
+		defer func() { _ = rows.Close() }()
+
+		for rows.Next() {
+			var msg Message
+			var createdMS, updatedMS int64
+			var data []byte
+			if err := rows.Scan(&msg.ID, &msg.SessionID, &createdMS, &updatedMS, &data); err != nil {
+				yield(Message{}, fmt.Errorf("sessiondb: read messages for %s from %s: %w", sessionID, s.path, err))
+				return
+			}
+			if err := decodePayload("message", msg.ID, s.path, data, &msg); err != nil {
+				yield(Message{}, err)
+				return
+			}
+			msg.RowCreated = time.UnixMilli(createdMS)
+			msg.RowUpdated = time.UnixMilli(updatedMS)
+			if !yield(msg, nil) {
+				return
+			}
+		}
+		if err := rows.Err(); err != nil {
+			yield(Message{}, fmt.Errorf("sessiondb: read messages for %s from %s: %w", sessionID, s.path, err))
+		}
+	}
+}
+
+// Parts returns one message's decoded parts ordered by ID.
+func (s *Store) Parts(ctx context.Context, messageID string) ([]Part, error) {
+	const query = `select id, message_id, session_id, time_updated, data
+		from part where message_id = ? order by id`
+	rows, err := s.db.QueryContext(ctx, query, messageID)
+	if err != nil {
+		return nil, fmt.Errorf("sessiondb: read parts for %s from %s: %w", messageID, s.path, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var parts []Part
+	for rows.Next() {
+		var part Part
+		var updatedMS int64
+		var data []byte
+		if err := rows.Scan(&part.ID, &part.MessageID, &part.SessionID, &updatedMS, &data); err != nil {
+			return nil, fmt.Errorf("sessiondb: read parts for %s from %s: %w", messageID, s.path, err)
+		}
+		if err := decodePayload("part", part.ID, s.path, data, &part); err != nil {
+			return nil, err
+		}
+		part.RowUpdated = time.UnixMilli(updatedMS)
+		parts = append(parts, part)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sessiondb: read parts for %s from %s: %w", messageID, s.path, err)
+	}
+	return parts, nil
+}
+
+func decodePayload(kind, id, path string, data []byte, dst any) error {
+	if len(data) > MaxPayloadBytes {
+		return fmt.Errorf("sessiondb: decode %s %s from %s: payload is %d bytes, limit is %d", kind, id, path, len(data), MaxPayloadBytes)
+	}
+	if err := json.Unmarshal(data, dst); err != nil {
+		return fmt.Errorf("sessiondb: decode %s %s from %s: %w", kind, id, path, err)
+	}
+	return nil
+}

--- a/plugins/agento11y/internal/agents/opencode/sessiondb/sessiondb_test.go
+++ b/plugins/agento11y/internal/agents/opencode/sessiondb/sessiondb_test.go
@@ -1,0 +1,263 @@
+package sessiondb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/opencode/sessiondb/sessiondbtest"
+)
+
+func openTestStore(t *testing.T, path string) *Store {
+	t.Helper()
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestSessionsReturnsContentFreeAggregates(t *testing.T) {
+	db := sessiondbtest.New(t)
+	db.AddSession("session-old", "parent", "Old", "/work/session-old", 1000, 2000)
+	db.AddSession("session-new", "", "New", "/work/session-new", 3000, 4000)
+	db.AddMessage("user", "session-old", 1000, 1001, `{"role":"user","time":{"created":1000}}`)
+	db.AddMessage("complete", "session-old", 1100, 1101, `{"role":"assistant","time":{"created":1100,"completed":1200}}`)
+	db.AddMessage("error", "session-old", 1300, 1301, `{"role":"assistant","time":{"created":1300},"error":{"name":"UnknownError","data":{}}}`)
+	db.AddMessage("in-flight", "session-old", 1400, 1401, `{"role":"assistant","time":{"created":1400}}`)
+	db.AddMessage("null-complete", "session-old", 1500, 1501, `{"role":"assistant","time":{"created":1500,"completed":null}}`)
+	db.AddMessage("null-error", "session-old", 1600, 1601, `{"role":"assistant","time":{"created":1600},"error":null}`)
+	db.AddPart("part-1", "complete", "session-old", 1, 2, `{"type":"text","text":"response"}`)
+
+	got, err := openTestStore(t, db.Path).Sessions(context.Background())
+	if err != nil {
+		t.Fatalf("Sessions: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("Sessions returned %d rows, want 2", len(got))
+	}
+	if got[0].ID != "session-new" || got[1].ID != "session-old" {
+		t.Fatalf("session order = [%s %s]", got[0].ID, got[1].ID)
+	}
+	old := got[1]
+	if old.Title != "" {
+		t.Fatalf("session aggregate contains title %q", old.Title)
+	}
+	if old.ParentID != "parent" || old.MessageCount != 6 || old.TerminalMessageCount != 2 {
+		t.Fatalf("old session aggregates = %+v", old)
+	}
+	if old.LogicalSizeBytes <= 0 {
+		t.Fatalf("LogicalSizeBytes = %d", old.LogicalSizeBytes)
+	}
+	if old.CreatedAt.UnixMilli() != 1000 || old.UpdatedAt.UnixMilli() != 2000 {
+		t.Fatalf("session times = (%d, %d)", old.CreatedAt.UnixMilli(), old.UpdatedAt.UnixMilli())
+	}
+	if got[0].MessageCount != 0 || got[0].TerminalMessageCount != 0 {
+		t.Fatalf("empty session aggregates = %+v", got[0])
+	}
+}
+
+func TestSessionsUseLatestChildActivity(t *testing.T) {
+	tests := []struct {
+		name    string
+		updated int64
+		add     func(*sessiondbtest.Builder)
+	}{
+		{
+			name:    "message",
+			updated: 2000,
+			add: func(db *sessiondbtest.Builder) {
+				db.AddMessage("assistant", "session", 800, 2000, `{"role":"assistant","time":{"created":800,"completed":900}}`)
+			},
+		},
+		{
+			name:    "part",
+			updated: 3000,
+			add: func(db *sessiondbtest.Builder) {
+				db.AddMessage("assistant", "session", 800, 900, `{"role":"assistant","time":{"created":800,"completed":900}}`)
+				db.AddPart("text", "assistant", "session", 800, 3000, `{"type":"text","text":"done"}`)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := sessiondbtest.New(t)
+			db.AddSession("session", "", "Session", "/work", 500, 1000)
+			tt.add(db)
+
+			sessions, err := openTestStore(t, db.Path).Sessions(context.Background())
+			if err != nil {
+				t.Fatalf("Sessions: %v", err)
+			}
+			if len(sessions) != 1 || sessions[0].UpdatedAt.UnixMilli() != tt.updated {
+				t.Fatalf("sessions = %+v, want activity %d", sessions, tt.updated)
+			}
+		})
+	}
+}
+
+func TestMessagesAndPartsUseStableRowOrder(t *testing.T) {
+	db := sessiondbtest.New(t)
+	db.AddSession("session", "", "Session", "/work/session", 1000, 2000)
+	db.AddMessage("message-b", "session", 2000, 2001, `{"id":"wrong","sessionID":"wrong","role":"assistant","time":{"created":2000,"completed":2100},"parentID":"user","modelID":"model","providerID":"provider","mode":"build","path":{"cwd":"/work","root":"/work"},"cost":0.5,"tokens":{"input":10,"output":5,"reasoning":1,"cache":{"read":2,"write":3}},"finish":"tool-calls"}`)
+	db.AddMessage("message-a", "session", 2000, 2001, `{"role":"user","time":{"created":2000}}`)
+	db.AddMessage("message-old", "session", 1000, 1001, `{"role":"user","time":{"created":1000}}`)
+	db.AddPart("part-b", "message-b", "session", 1, 2, `{"id":"wrong","messageID":"wrong","sessionID":"wrong","type":"text","text":"second"}`)
+	db.AddPart("part-a", "message-b", "session", 9999, 10000, `{"type":"tool","callID":"call","tool":"task","state":{"status":"completed","input":{"prompt":"x"},"output":"ok","metadata":{"sessionId":"child","exit":1},"time":{"start":1,"end":2}}}`)
+
+	store := openTestStore(t, db.Path)
+	session, ok, err := store.Session(context.Background(), "session")
+	if err != nil || !ok {
+		t.Fatalf("Session = (%+v, %v, %v)", session, ok, err)
+	}
+	if session.Title != "Session" || session.Directory != "/work/session" {
+		t.Fatalf("Session row = %+v", session)
+	}
+	if _, ok, err := store.Session(context.Background(), "missing"); err != nil || ok {
+		t.Fatalf("missing Session = (_, %v, %v)", ok, err)
+	}
+	role, ok, err := store.MessageRole(context.Background(), "message-a")
+	if err != nil || !ok || role != "user" {
+		t.Fatalf("MessageRole = (%q, %v, %v)", role, ok, err)
+	}
+	if _, ok, err := store.MessageRole(context.Background(), "missing"); err != nil || ok {
+		t.Fatalf("missing MessageRole = (_, %v, %v)", ok, err)
+	}
+	spawn, ok, err := store.SpawningMessageID(context.Background(), "session", "child")
+	if err != nil || !ok || spawn != "message-b" {
+		t.Fatalf("SpawningMessageID = (%q, %v, %v)", spawn, ok, err)
+	}
+	if _, ok, err := store.SpawningMessageID(context.Background(), "session", "missing"); err != nil || ok {
+		t.Fatalf("missing SpawningMessageID = (_, %v, %v)", ok, err)
+	}
+
+	var messages []Message
+	for msg, err := range store.Messages(context.Background(), "session") {
+		if err != nil {
+			t.Fatalf("Messages: %v", err)
+		}
+		messages = append(messages, msg)
+	}
+	if len(messages) != 3 {
+		t.Fatalf("Messages returned %d rows, want 3", len(messages))
+	}
+	if got := []string{messages[0].ID, messages[1].ID, messages[2].ID}; fmt.Sprint(got) != "[message-old message-a message-b]" {
+		t.Fatalf("message order = %v", got)
+	}
+	assistant := messages[2]
+	if assistant.ID != "message-b" || assistant.SessionID != "session" {
+		t.Fatalf("message identity = (%q, %q)", assistant.ID, assistant.SessionID)
+	}
+	if assistant.Tokens.Cache.Write != 3 || assistant.Finish != "tool-calls" {
+		t.Fatalf("assistant payload = %+v", assistant)
+	}
+
+	parts, err := store.Parts(context.Background(), "message-b")
+	if err != nil {
+		t.Fatalf("Parts: %v", err)
+	}
+	if len(parts) != 2 || parts[0].ID != "part-a" || parts[1].ID != "part-b" {
+		t.Fatalf("part order = %+v", parts)
+	}
+	if parts[0].MessageID != "message-b" || parts[0].SessionID != "session" {
+		t.Fatalf("part identity = (%q, %q)", parts[0].MessageID, parts[0].SessionID)
+	}
+	if parts[0].State.Metadata.SessionID != "child" || parts[0].State.Metadata.Exit == nil || *parts[0].State.Metadata.Exit != 1 {
+		t.Fatalf("tool metadata = %+v", parts[0].State.Metadata)
+	}
+}
+
+func TestOpenIsReadOnlyAndReadsAWriteAheadLog(t *testing.T) {
+	db := sessiondbtest.New(t)
+	if _, err := db.DB.Exec(`pragma journal_mode = wal`); err != nil {
+		t.Fatalf("enable WAL: %v", err)
+	}
+	if _, err := db.DB.Exec(`pragma wal_autocheckpoint = 0`); err != nil {
+		t.Fatalf("disable checkpoint: %v", err)
+	}
+	db.AddSession("wal-session", "", "WAL", "/work/wal-session", 1000, 2000)
+	if _, err := os.Stat(db.Path + "-wal"); err != nil {
+		t.Fatalf("writer left no WAL: %v", err)
+	}
+
+	store := openTestStore(t, db.Path)
+	sessions, err := store.Sessions(context.Background())
+	if err != nil {
+		t.Fatalf("Sessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != "wal-session" {
+		t.Fatalf("sessions = %+v", sessions)
+	}
+	if _, err := store.db.Exec(`insert into session
+		(id, directory, title, time_created, time_updated) values ('write', '/', 'write', 1, 1)`); err == nil {
+		t.Fatal("read-only store accepted a write")
+	}
+}
+
+func TestMalformedPayloadsFailWithRowIdentity(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*testing.T, *Store)
+	}{
+		{
+			name: "session aggregate",
+			run: func(t *testing.T, store *Store) {
+				_, err := store.Sessions(context.Background())
+				if err == nil || !strings.Contains(err.Error(), "message bad-message") || !strings.Contains(err.Error(), store.path) {
+					t.Fatalf("Sessions error = %v", err)
+				}
+			},
+		},
+		{
+			name: "message",
+			run: func(t *testing.T, store *Store) {
+				for _, err := range store.Messages(context.Background(), "session") {
+					if err == nil {
+						continue
+					}
+					if !strings.Contains(err.Error(), "message bad-message") || !strings.Contains(err.Error(), store.path) {
+						t.Fatalf("Messages error = %v", err)
+					}
+					return
+				}
+				t.Fatal("Messages returned no error")
+			},
+		},
+		{
+			name: "part",
+			run: func(t *testing.T, store *Store) {
+				_, err := store.Parts(context.Background(), "good-message")
+				if err == nil || !strings.Contains(err.Error(), "part bad-part") || !strings.Contains(err.Error(), store.path) {
+					t.Fatalf("Parts error = %v", err)
+				}
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db := sessiondbtest.New(t)
+			db.AddSession("session", "", "Session", "/work/session", 1, 1)
+			db.AddMessage("good-message", "session", 1, 2, `{"role":"user","time":{"created":1}}`)
+			db.AddMessage("bad-message", "session", 2, 3, `{`)
+			db.AddPart("bad-part", "good-message", "session", 1, 2, `{`)
+			tc.run(t, openTestStore(t, db.Path))
+		})
+	}
+}
+
+func TestPayloadDecodeIsCapped(t *testing.T) {
+	db := sessiondbtest.New(t)
+	db.AddSession("session", "", "Session", "/work/session", 1, 1)
+	db.AddMessage("large", "session", 1, 2, `{"role":"user","padding":"`+strings.Repeat("x", MaxPayloadBytes)+`"}`)
+
+	for _, err := range openTestStore(t, db.Path).Messages(context.Background(), "session") {
+		if err == nil || !strings.Contains(err.Error(), "limit is") {
+			t.Fatalf("Messages error = %v", err)
+		}
+		return
+	}
+	t.Fatal("Messages returned no error")
+}

--- a/plugins/agento11y/internal/agents/opencode/sessiondb/sessiondbtest/sessiondbtest.go
+++ b/plugins/agento11y/internal/agents/opencode/sessiondb/sessiondbtest/sessiondbtest.go
@@ -1,0 +1,92 @@
+// Package sessiondbtest writes OpenCode session databases for tests.
+package sessiondbtest
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/cursor/chatstore"
+	_ "modernc.org/sqlite"
+)
+
+const schema = `
+create table session (
+	id text primary key,
+	parent_id text,
+	directory text not null,
+	title text not null,
+	time_created integer not null,
+	time_updated integer not null
+);
+create table message (
+	id text primary key,
+	session_id text not null,
+	time_created integer not null,
+	time_updated integer not null,
+	data text not null
+);
+create table part (
+	id text primary key,
+	message_id text not null,
+	session_id text not null,
+	time_created integer not null,
+	time_updated integer not null,
+	data text not null
+);`
+
+// Builder owns one temporary OpenCode database.
+type Builder struct {
+	Path string
+	DB   *sql.DB
+	t    testing.TB
+}
+
+// New creates an empty OpenCode database.
+func New(t testing.TB) *Builder {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "opencode.db")
+	db, err := sql.Open("sqlite", chatstore.URI(path))
+	if err != nil {
+		t.Fatalf("sessiondbtest: open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("sessiondbtest: create schema: %v", err)
+	}
+	return &Builder{Path: path, DB: db, t: t}
+}
+
+// AddSession inserts one session row.
+func (b *Builder) AddSession(id, parent, title, directory string, created, updated int64) {
+	b.t.Helper()
+	var parentValue any
+	if parent != "" {
+		parentValue = parent
+	}
+	if _, err := b.DB.Exec(`insert into session
+		(id, parent_id, directory, title, time_created, time_updated)
+		values (?, ?, ?, ?, ?, ?)`, id, parentValue, directory, title, created, updated); err != nil {
+		b.t.Fatalf("sessiondbtest: insert session: %v", err)
+	}
+}
+
+// AddMessage inserts one message row.
+func (b *Builder) AddMessage(id, sessionID string, created, updated int64, data string) {
+	b.t.Helper()
+	if _, err := b.DB.Exec(`insert into message
+		(id, session_id, time_created, time_updated, data) values (?, ?, ?, ?, ?)`,
+		id, sessionID, created, updated, data); err != nil {
+		b.t.Fatalf("sessiondbtest: insert message: %v", err)
+	}
+}
+
+// AddPart inserts one part row.
+func (b *Builder) AddPart(id, messageID, sessionID string, created, updated int64, data string) {
+	b.t.Helper()
+	if _, err := b.DB.Exec(`insert into part
+		(id, message_id, session_id, time_created, time_updated, data) values (?, ?, ?, ?, ?, ?)`,
+		id, messageID, sessionID, created, updated, data); err != nil {
+		b.t.Fatalf("sessiondbtest: insert part: %v", err)
+	}
+}

--- a/plugins/agento11y/internal/history/discover.go
+++ b/plugins/agento11y/internal/history/discover.go
@@ -35,11 +35,9 @@ type DiscoverOptions struct {
 // Discover walks the importer's roots, previews every matching file, and
 // returns the sessions sorted most-recent-first.
 //
-// It is the only discovery implementation. Each importer contributes
-// [Importer.Roots], [Importer.Match], and [Importer.Preview]; walking,
-// cancellation, warning collection, active-session detection, and ordering are
-// shared, so a new importer for an agent with a Go live mapper adds no
-// scaffolding.
+// It is the only discovery implementation. Each importer contributes roots,
+// path matching, previewing, and turn decoding. Walking, cancellation, warning
+// collection, active-session detection, and ordering are shared.
 func Discover(ctx context.Context, agent AgentID, imp Importer, opts DiscoverOptions) (Discovery, error) {
 	if imp == nil {
 		return Discovery{}, fmt.Errorf("history: no importer for %q", agent)
@@ -88,14 +86,16 @@ func Discover(ctx context.Context, agent AgentID, imp Importer, opts DiscoverOpt
 	}
 	d.Sessions = sessions
 
-	// Most recent first, with the path as the tie-break so two sessions with
-	// the same timestamp keep a stable order across runs.
+	// Most recent first, with content-free identity fields as stable ties.
 	sort.SliceStable(d.Sessions, func(i, j int) bool {
 		a, b := d.Sessions[i], d.Sessions[j]
 		if !a.LastActivityAt.Equal(b.LastActivityAt) {
 			return a.LastActivityAt.After(b.LastActivityAt)
 		}
-		return a.SourcePath < b.SourcePath
+		if a.SourcePath != b.SourcePath {
+			return a.SourcePath < b.SourcePath
+		}
+		return a.SessionID < b.SessionID
 	})
 	return d, nil
 }
@@ -105,9 +105,8 @@ func Discover(ctx context.Context, agent AgentID, imp Importer, opts DiscoverOpt
 // does not depend on which worker finished first.
 func previewAll(ctx context.Context, agent AgentID, imp Importer, paths []string, at time.Time, window time.Duration) ([]SessionPreview, []string, error) {
 	type slot struct {
-		preview SessionPreview
-		ok      bool
-		warning string
+		previews []SessionPreview
+		warning  string
 	}
 	slots := make([]slot, len(paths))
 
@@ -131,6 +130,23 @@ func previewAll(ctx context.Context, agent AgentID, imp Importer, paths []string
 					return
 				}
 				path := paths[i]
+				if multi, ok := imp.(MultiSessionImporter); ok {
+					previews, err := multi.Previews(ctx, path)
+					if err != nil {
+						if ctx.Err() == nil {
+							slots[i] = slot{warning: fmt.Sprintf("read %s: %v", path, err)}
+						}
+						continue
+					}
+					for j := range previews {
+						previews[j].Agent = agent
+						previews[j].SourcePath = path
+						previews[j].Active = isActiveMod(previews[j].LastActivityAt, at, window)
+					}
+					slots[i] = slot{previews: previews}
+					continue
+				}
+
 				preview, ok, err := imp.Preview(ctx, path)
 				if err != nil {
 					if ctx.Err() == nil {
@@ -161,7 +177,7 @@ func previewAll(ctx context.Context, agent AgentID, imp Importer, paths []string
 					}
 					preview.Active = isActiveMod(written, at, window)
 				}
-				slots[i] = slot{preview: preview, ok: true}
+				slots[i] = slot{previews: []SessionPreview{preview}}
 			}
 		})
 	}
@@ -173,12 +189,11 @@ func previewAll(ctx context.Context, agent AgentID, imp Importer, paths []string
 	sessions := make([]SessionPreview, 0, len(slots))
 	var warnings []string
 	for _, s := range slots {
-		switch {
-		case s.warning != "":
+		if s.warning != "" {
 			warnings = append(warnings, s.warning)
-		case s.ok:
-			sessions = append(sessions, s.preview)
+			continue
 		}
+		sessions = append(sessions, s.previews...)
 	}
 	return sessions, warnings, nil
 }

--- a/plugins/agento11y/internal/history/discover_test.go
+++ b/plugins/agento11y/internal/history/discover_test.go
@@ -36,6 +36,15 @@ func sessionIDs(sessions []SessionPreview) []string {
 	return out
 }
 
+type multiSessionStub struct {
+	*stubImporter
+	previews func(context.Context, string) ([]SessionPreview, error)
+}
+
+func (s *multiSessionStub) Previews(ctx context.Context, path string) ([]SessionPreview, error) {
+	return s.previews(ctx, path)
+}
+
 func TestDiscoverWalksRootsAndSortsByActivity(t *testing.T) {
 	root := t.TempDir()
 	base := time.Date(2026, 1, 10, 12, 0, 0, 0, time.UTC)
@@ -73,6 +82,61 @@ func TestDiscoverWalksRootsAndSortsByActivity(t *testing.T) {
 		if s.LastActivityAt.IsZero() {
 			t.Fatalf("session %q has no last activity", s.SessionID)
 		}
+	}
+}
+
+func TestDiscoverExpandsMultiSessionSources(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 1, 10, 12, 0, 0, 0, time.UTC)
+	path := writeFile(t, filepath.Join(root, "opencode.db"), strings.Repeat("x", 100))
+	setModTime(t, path, now.Add(-time.Minute))
+	old := now.Add(-time.Hour)
+
+	imp := &multiSessionStub{
+		stubImporter: &stubImporter{roots: []string{path}},
+		previews: func(context.Context, string) ([]SessionPreview, error) {
+			return []SessionPreview{
+				{SessionID: "session-b", LastActivityAt: old},
+				{SessionID: "session-a", LastActivityAt: old},
+				{SessionID: "session-active", LastActivityAt: now.Add(-time.Minute), SizeBytes: 7},
+			}, nil
+		},
+	}
+
+	got, err := Discover(context.Background(), AgentOpenCode, imp, DiscoverOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if ids := sessionIDs(got.Sessions); !equalStrings(ids, []string{"session-active", "session-a", "session-b"}) {
+		t.Fatalf("session order = %v", ids)
+	}
+	for _, sess := range got.Sessions {
+		if sess.Agent != AgentOpenCode || sess.SourcePath != path {
+			t.Fatalf("session %q identity = (%q, %q)", sess.SessionID, sess.Agent, sess.SourcePath)
+		}
+	}
+	if got.Sessions[0].SizeBytes != 7 || !got.Sessions[0].Active {
+		t.Fatalf("active preview = %+v", got.Sessions[0])
+	}
+	for _, sess := range got.Sessions[1:] {
+		if sess.SizeBytes != 0 {
+			t.Fatalf("session %q inherited shared file size %d", sess.SessionID, sess.SizeBytes)
+		}
+		if sess.Active {
+			t.Fatalf("old session %q inherited the shared file activity", sess.SessionID)
+		}
+	}
+
+	again, err := Discover(context.Background(), AgentOpenCode, imp, DiscoverOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("second Discover: %v", err)
+	}
+	if ids := sessionIDs(again.Sessions); !equalStrings(ids, sessionIDs(got.Sessions)) {
+		t.Fatalf("second session order = %v, first = %v", ids, sessionIDs(got.Sessions))
 	}
 }
 

--- a/plugins/agento11y/internal/history/history.go
+++ b/plugins/agento11y/internal/history/history.go
@@ -3,15 +3,15 @@
 //
 // The package owns everything an importer does not: the agent registry,
 // filesystem discovery, selection filtering, redaction and truncation, the
-// idempotency ledger, and backdated export. A per-agent importer supplies only
-// four small methods (see [Importer]); everything else is shared.
+// idempotency ledger, and backdated export. A per-agent importer supplies the
+// source and turn readers (see [Importer]); everything else is shared.
 //
 // Nothing here decodes prompt, response, thinking, or tool text outside
-// [Importer.Turns]. Discovery reads a bounded window of each session file to
-// count turns and pick out metadata, but no part of those bytes is decoded into
-// content, returned, exported, or stored; the ledger is content-free by
-// construction. A user can therefore inspect what would be imported without any
-// of it being surfaced or kept.
+// [Importer.Turns]. Discovery reads bounded windows from single-session files
+// or content-free metadata from a multi-session source. It returns, exports,
+// and stores none of the source content; the ledger is content-free by
+// construction. A user can therefore inspect what would be imported without
+// any of it being surfaced or kept.
 package history
 
 import (
@@ -39,19 +39,21 @@ const (
 	AgentClaudeCode AgentID = "claude-code"
 	AgentCodex      AgentID = "codex"
 	AgentCursor     AgentID = "cursor"
+	AgentOpenCode   AgentID = "opencode"
 	AgentPi         AgentID = "pi"
 )
 
 // SourceRef locates a single historical turn on disk. It is content-free: it
 // carries identity (which session, file, and turn) but never prompt, response,
 // or tool payloads. It is the input to both the deterministic generation ID and
-// the hashed ledger key, so its fields must stay stable across releases.
+// the hashed ledger key, so its identity fields must stay stable across releases.
 type SourceRef struct {
-	Agent      AgentID
-	SessionID  string // native session or conversation ID
-	SourcePath string // file the session was read from
-	TurnIndex  int    // 0-based position within the session
-	TurnID     string // native turn or message ID when the agent provides one
+	Agent        AgentID
+	SessionID    string // native session or conversation ID
+	SourcePath   string // file the session was read from
+	TurnIndex    int    // 0-based position within the session
+	TurnID       string // native turn or message ID when the agent provides one
+	TurnIDStable bool   // TurnID stays stable when earlier turns change
 }
 
 // SessionPreview is the metadata-only view of a discovered session. It is what
@@ -60,6 +62,7 @@ type SourceRef struct {
 type SessionPreview struct {
 	Agent          AgentID
 	SessionID      string
+	ConversationID string // mapped root used for collision detection; empty means SessionID
 	Title          string
 	Workspace      string // workspace or repo path, when known
 	SourcePath     string // file the session lives in
@@ -120,8 +123,9 @@ type ImportResult struct {
 
 // Importer reads one agent's local history. The framework owns walking,
 // warning collection, active-session detection, sorting, filtering, redaction,
-// the ledger, and export, so an importer for an agent that already has a Go
-// live mapper is four small methods.
+// the ledger, and export. An importer implements Preview for a source that
+// holds one session. A source that holds several sessions also implements
+// [MultiSessionImporter].
 //
 // Register an implementation from its own file's init with [Register].
 type Importer interface {
@@ -150,6 +154,14 @@ type Importer interface {
 	// memory: rollouts of several hundred megabytes exist. Content is raw here;
 	// the framework runs [Sanitizer] once before export.
 	Turns(ctx context.Context, sess SessionPreview) iter.Seq2[HistoricalGeneration, error]
+}
+
+// MultiSessionImporter reads a source file that holds several sessions.
+// Discovery uses Previews instead of Preview and takes every returned preview
+// as complete, including its size and activity timestamps.
+type MultiSessionImporter interface {
+	Importer
+	Previews(ctx context.Context, path string) ([]SessionPreview, error)
 }
 
 // AgentSpec is the static, content-free description of a supported agent.

--- a/plugins/agento11y/internal/history/history_test.go
+++ b/plugins/agento11y/internal/history/history_test.go
@@ -225,7 +225,7 @@ func TestNewImporter(t *testing.T) {
 // the viewer all read from. A missing init here makes an agent invisible
 // everywhere at once.
 func TestRealImportersAreRegistered(t *testing.T) {
-	for _, id := range []AgentID{AgentClaudeCode, AgentCodex} {
+	for _, id := range []AgentID{AgentClaudeCode, AgentCodex, AgentOpenCode} {
 		spec, ok := Spec(id)
 		if !ok {
 			t.Fatalf("no spec registered for %q", id)

--- a/plugins/agento11y/internal/history/identity.go
+++ b/plugins/agento11y/internal/history/identity.go
@@ -21,12 +21,9 @@ func hashFields(parts ...string) string {
 
 // GenerationID derives the stable generation ID for a turn. Re-importing the
 // same source turn always yields the same ID, and that stability is what makes
-// export idempotent across runs. TurnIndex is included so two turns in one
-// session never collide even when the agent gives them no native turn ID.
+// export idempotent across runs.
 func (r SourceRef) GenerationID() string {
-	return genIDPrefix + "-" + hashFields(
-		string(r.Agent), r.SessionID, r.SourcePath, strconv.Itoa(r.TurnIndex), r.TurnID,
-	)[:24]
+	return genIDPrefix + "-" + r.identityHash()[:24]
 }
 
 // SourceIdentity is the opaque, hashed ledger key for a turn. It is a full
@@ -36,25 +33,29 @@ type SourceIdentity string
 
 // Identity returns the hashed ledger key for the turn.
 func (r SourceRef) Identity() SourceIdentity {
-	return SourceIdentity(hashFields(
-		string(r.Agent), r.SessionID, r.SourcePath, strconv.Itoa(r.TurnIndex), r.TurnID,
-	))
+	return SourceIdentity(r.identityHash())
 }
 
-// Collision reports a native session ID claimed by more than one source.
-// Imported generations keep the native session ID as the conversation ID, so
-// two different files reusing one ID would silently merge into one
-// conversation. Hash-derived generation IDs cannot collide by construction.
-// Detection therefore lives at the session-ID layer, where reuse is real.
+func (r SourceRef) identityHash() string {
+	turnIndex := strconv.Itoa(r.TurnIndex)
+	if r.TurnIDStable && r.TurnID != "" {
+		turnIndex = ""
+	}
+	return hashFields(string(r.Agent), r.SessionID, r.SourcePath, turnIndex, r.TurnID)
+}
+
+// Collision reports a mapped conversation ID claimed by more than one source.
+// Two different files reusing one conversation ID would otherwise merge in the
+// viewer. Hash-derived generation IDs cannot collide by construction.
 type Collision struct {
 	Agent     AgentID
-	SessionID string
+	SessionID string   // mapped conversation ID
 	Sources   []string // distinct source paths claiming the ID
 }
 
-// DetectCollisions returns the sessions whose native ID is claimed by more than
-// one source path within one agent. The same session discovered twice at the
-// same path is not a collision; only differing source paths are reported.
+// DetectCollisions returns the conversations claimed by more than one source
+// path within one agent. The same conversation discovered twice at one path is
+// not a collision; only differing source paths are reported.
 func DetectCollisions(previews []SessionPreview) []Collision {
 	type key struct {
 		agent     AgentID
@@ -62,10 +63,14 @@ func DetectCollisions(previews []SessionPreview) []Collision {
 	}
 	paths := map[key]map[string]bool{}
 	for _, p := range previews {
-		if p.SessionID == "" {
+		conversationID := p.ConversationID
+		if conversationID == "" {
+			conversationID = p.SessionID
+		}
+		if conversationID == "" {
 			continue // unidentified sessions get synthetic IDs; nothing to collide
 		}
-		k := key{p.Agent, p.SessionID}
+		k := key{p.Agent, conversationID}
 		if paths[k] == nil {
 			paths[k] = map[string]bool{}
 		}

--- a/plugins/agento11y/internal/history/identity_test.go
+++ b/plugins/agento11y/internal/history/identity_test.go
@@ -55,6 +55,33 @@ func TestIdentityAndGenerationIDVaryWithEveryField(t *testing.T) {
 	}
 }
 
+func TestStableTurnIDIgnoresPositionChanges(t *testing.T) {
+	ref := baseRef()
+	ref.TurnIDStable = true
+	moved := ref
+	moved.TurnIndex++
+	if moved.GenerationID() != ref.GenerationID() {
+		t.Fatal("stable turn ID changed the generation ID after a position change")
+	}
+	if moved.Identity() != ref.Identity() {
+		t.Fatal("stable turn ID changed the ledger key after a position change")
+	}
+
+	changed := ref
+	changed.TurnID = "req_xyz"
+	if changed.GenerationID() == ref.GenerationID() || changed.Identity() == ref.Identity() {
+		t.Fatal("different stable turn IDs received the same identity")
+	}
+
+	withoutID := ref
+	withoutID.TurnID = ""
+	movedWithoutID := withoutID
+	movedWithoutID.TurnIndex++
+	if movedWithoutID.GenerationID() == withoutID.GenerationID() || movedWithoutID.Identity() == withoutID.Identity() {
+		t.Fatal("position did not distinguish turns without a stable turn ID")
+	}
+}
+
 func TestIdentityLeaksNoSourceText(t *testing.T) {
 	ref := baseRef()
 	key := string(ref.Identity())
@@ -105,6 +132,24 @@ func TestDetectCollisions(t *testing.T) {
 			previews: []SessionPreview{
 				{Agent: AgentCodex, SessionID: "s1", SourcePath: "/a.jsonl"},
 				{Agent: AgentClaudeCode, SessionID: "s1", SourcePath: "/b.jsonl"},
+			},
+		},
+		{
+			name: "mapped conversation in two files collides",
+			previews: []SessionPreview{
+				{Agent: AgentOpenCode, SessionID: "child-a", ConversationID: "root", SourcePath: "/a.db"},
+				{Agent: AgentOpenCode, SessionID: "child-b", ConversationID: "root", SourcePath: "/b.db"},
+			},
+			want: []Collision{{
+				Agent: AgentOpenCode, SessionID: "root",
+				Sources: []string{"/a.db", "/b.db"},
+			}},
+		},
+		{
+			name: "same session id in distinct conversations is not a collision",
+			previews: []SessionPreview{
+				{Agent: AgentOpenCode, SessionID: "child", ConversationID: "root-a", SourcePath: "/a.db"},
+				{Agent: AgentOpenCode, SessionID: "child", ConversationID: "root-b", SourcePath: "/b.db"},
 			},
 		},
 		{

--- a/plugins/agento11y/internal/history/import.go
+++ b/plugins/agento11y/internal/history/import.go
@@ -308,7 +308,7 @@ func RunImport(ctx context.Context, opts ImportOptions) (ImportResult, error) {
 			turns++
 
 			fillSource(&gen, opts.Agent, sess)
-			disambiguateCollidedConversation(&gen, collided, sess.SourcePath)
+			disambiguateCollidedConversation(&gen, collided, sess)
 			id := gen.Source.Identity()
 			if !ledger.ShouldImport(id, opts.Force) {
 				result.Skipped++
@@ -407,23 +407,25 @@ func collisionSessionKeys(collisions []Collision) map[collisionSessionKey]bool {
 }
 
 // disambiguateCollidedConversation gives a turn a source-scoped conversation ID
-// when its native session ID is claimed by more than one file, so two unrelated
-// sessions do not merge into one conversation in the viewer.
-//
-// The scope is sessionPath, the file the session was discovered at, not the
-// file the turn was read from. A Claude subagent turn comes from its own
-// transcript under the session directory, and scoping by that path would break
-// one conversation into one per transcript. [DetectCollisions] compares the
-// same discovered paths, so the two agree on what collided.
-func disambiguateCollidedConversation(gen *HistoricalGeneration, collided map[collisionSessionKey]bool, sessionPath string) {
-	if gen == nil || gen.Source.SessionID == "" || sessionPath == "" {
+// when more than one file claims it. Multi-session importers can name the mapped
+// root in SessionPreview.ConversationID. Other importers keep their source
+// session identity and existing subagent path behavior.
+func disambiguateCollidedConversation(gen *HistoricalGeneration, collided map[collisionSessionKey]bool, sess SessionPreview) {
+	if gen == nil || sess.SourcePath == "" {
 		return
 	}
-	k := collisionSessionKey{agent: gen.Source.Agent, sessionID: gen.Source.SessionID}
+	conversationID := gen.Source.SessionID
+	if sess.ConversationID != "" {
+		conversationID = sess.ConversationID
+	}
+	if conversationID == "" {
+		return
+	}
+	k := collisionSessionKey{agent: gen.Source.Agent, sessionID: conversationID}
 	if !collided[k] {
 		return
 	}
 	gen.Gen.ConversationID = "histconv-" + hashFields(
-		string(gen.Source.Agent), gen.Source.SessionID, sessionPath,
+		string(gen.Source.Agent), conversationID, sess.SourcePath,
 	)[:24]
 }

--- a/plugins/agento11y/internal/history/opencode.go
+++ b/plugins/agento11y/internal/history/opencode.go
@@ -1,0 +1,236 @@
+package history
+
+import (
+	"context"
+	"iter"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/opencode/sessiondb"
+)
+
+func init() {
+	Register(AgentSpec{
+		ID:          AgentOpenCode,
+		DisplayName: "OpenCode",
+	}, func() Importer { return &opencodeImporter{} })
+}
+
+type opencodeImporter struct {
+	roots []string
+}
+
+func (o *opencodeImporter) Roots() []string {
+	if len(o.roots) > 0 {
+		return append([]string(nil), o.roots...)
+	}
+	dataDir := opencodeDataDir()
+	seen := map[string]bool{}
+	add := func(path string, roots *[]string) {
+		path = filepath.Clean(path)
+		if path != "." && !seen[path] {
+			seen[path] = true
+			*roots = append(*roots, path)
+		}
+	}
+
+	var roots []string
+	if dataDir != "" {
+		add(filepath.Join(dataDir, "opencode.db"), &roots)
+		if matches, err := filepath.Glob(filepath.Join(dataDir, "opencode*.db")); err == nil {
+			for _, path := range matches {
+				add(path, &roots)
+			}
+		}
+	}
+	if override := opencodeDBOverride(dataDir); override != "" {
+		add(override, &roots)
+	}
+	sort.Strings(roots)
+	return roots
+}
+
+func opencodeDataDir() string {
+	base := strings.TrimSpace(os.Getenv("XDG_DATA_HOME"))
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		base = filepath.Join(home, ".local", "share")
+	}
+	return filepath.Join(base, "opencode")
+}
+
+func opencodeDBOverride(dataDir string) string {
+	path := strings.TrimSpace(os.Getenv("OPENCODE_DB"))
+	if path == "" {
+		return ""
+	}
+	if filepath.IsAbs(path) {
+		return path
+	}
+	if dataDir == "" {
+		return ""
+	}
+	return filepath.Join(dataDir, path)
+}
+
+func (o *opencodeImporter) Match(path string) bool {
+	base := filepath.Base(path)
+	if strings.HasSuffix(base, "-wal") || strings.HasSuffix(base, "-shm") {
+		return false
+	}
+	if override := opencodeDBOverride(opencodeDataDir()); override != "" && filepath.Clean(path) == filepath.Clean(override) {
+		return true
+	}
+	return strings.HasPrefix(base, "opencode") && strings.HasSuffix(base, ".db")
+}
+
+// Preview is unused because OpenCode keeps every session in one database.
+func (o *opencodeImporter) Preview(context.Context, string) (SessionPreview, bool, error) {
+	return SessionPreview{}, false, nil
+}
+
+var opencodePlaceholderTitle = regexp.MustCompile(`^(New session - |Child session - )\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$`)
+
+func openCodeConversationTitle(title string) string {
+	title = strings.TrimSpace(title)
+	if opencodePlaceholderTitle.MatchString(title) {
+		return ""
+	}
+	return title
+}
+
+func openCodeConversationIDs(rows []sessiondb.Session) map[string]string {
+	byID := make(map[string]sessiondb.Session, len(rows))
+	for _, row := range rows {
+		byID[row.ID] = row
+	}
+	out := make(map[string]string, len(rows))
+	for _, row := range rows {
+		current := row.ID
+		seen := map[string]bool{current: true}
+		for {
+			currentRow, found := byID[current]
+			if !found || currentRow.ParentID == "" {
+				break
+			}
+			if seen[currentRow.ParentID] {
+				break
+			}
+			seen[currentRow.ParentID] = true
+			current = currentRow.ParentID
+		}
+		out[row.ID] = current
+	}
+	return out
+}
+
+func (o *opencodeImporter) Previews(ctx context.Context, path string) ([]SessionPreview, error) {
+	store, err := sessiondb.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = store.Close() }()
+
+	rows, err := store.Sessions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	conversationIDs := openCodeConversationIDs(rows)
+	previews := make([]SessionPreview, 0, len(rows))
+	for _, row := range rows {
+		if row.TerminalMessageCount == 0 {
+			continue
+		}
+		previews = append(previews, SessionPreview{
+			Agent:          AgentOpenCode,
+			SessionID:      row.ID,
+			ConversationID: conversationIDs[row.ID],
+			Title:          row.ID,
+			Workspace:      row.Directory,
+			SourcePath:     path,
+			TurnCount:      row.TerminalMessageCount,
+			SizeBytes:      row.LogicalSizeBytes,
+			StartedAt:      row.CreatedAt,
+			LastActivityAt: row.UpdatedAt,
+		})
+	}
+	return previews, nil
+}
+
+func (o *opencodeImporter) Turns(ctx context.Context, sess SessionPreview) iter.Seq2[HistoricalGeneration, error] {
+	return func(yield func(HistoricalGeneration, error) bool) {
+		store, err := sessiondb.Open(sess.SourcePath)
+		if err != nil {
+			yield(HistoricalGeneration{}, err)
+			return
+		}
+		defer func() { _ = store.Close() }()
+
+		lineage, err := resolveOpenCodeLineage(ctx, store, sess.SessionID, sess.SourcePath)
+		if err != nil {
+			yield(HistoricalGeneration{}, err)
+			return
+		}
+		usedParent := map[string]bool{}
+		assistantIndex := 0
+		previousGenerationID := ""
+		for msg, err := range store.Messages(ctx, sess.SessionID) {
+			if err != nil {
+				yield(HistoricalGeneration{}, err)
+				return
+			}
+			if msg.Role != "assistant" {
+				continue
+			}
+			turnIndex := assistantIndex
+			assistantIndex++
+			if !opencodeTerminalAssistant(msg) {
+				continue
+			}
+			var userParts []sessiondb.Part
+			if msg.ParentID != "" && !usedParent[msg.ParentID] {
+				role, found, err := store.MessageRole(ctx, msg.ParentID)
+				if err != nil {
+					yield(HistoricalGeneration{}, err)
+					return
+				}
+				usedParent[msg.ParentID] = true
+				if found && role == "user" {
+					userParts, err = store.Parts(ctx, msg.ParentID)
+					if err != nil {
+						yield(HistoricalGeneration{}, err)
+						return
+					}
+				}
+			}
+			parts, err := store.Parts(ctx, msg.ID)
+			if err != nil {
+				yield(HistoricalGeneration{}, err)
+				return
+			}
+			source := SourceRef{
+				Agent:        AgentOpenCode,
+				SessionID:    sess.SessionID,
+				SourcePath:   sess.SourcePath,
+				TurnIndex:    turnIndex,
+				TurnID:       msg.ID,
+				TurnIDStable: true,
+			}
+			parentGenerationID := previousGenerationID
+			if parentGenerationID == "" {
+				parentGenerationID = lineage.spawnGenerationID
+			}
+			gen := opencodeGeneration(sess, msg, userParts, parts, source, lineage, parentGenerationID)
+			previousGenerationID = source.GenerationID()
+			if !yield(gen, nil) {
+				return
+			}
+		}
+	}
+}

--- a/plugins/agento11y/internal/history/opencode_map.go
+++ b/plugins/agento11y/internal/history/opencode_map.go
@@ -1,0 +1,335 @@
+package history
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/grafana/agento11y/go/agento11y"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/opencode/sessiondb"
+)
+
+type opencodeLineage struct {
+	parentSessionID   string
+	conversationID    string
+	conversationTitle string
+	spawnGenerationID string
+}
+
+func resolveOpenCodeLineage(ctx context.Context, store *sessiondb.Store, sessionID, sourcePath string) (opencodeLineage, error) {
+	lineage := opencodeLineage{conversationID: sessionID}
+	row, ok, err := store.Session(ctx, sessionID)
+	if err != nil {
+		return lineage, err
+	}
+	if !ok {
+		return lineage, fmt.Errorf("opencode session %s no longer exists in %s", sessionID, sourcePath)
+	}
+	lineage.conversationTitle = openCodeConversationTitle(row.Title)
+	if row.ParentID == "" || row.ParentID == sessionID {
+		return lineage, nil
+	}
+	lineage.parentSessionID = row.ParentID
+
+	current := sessionID
+	seen := map[string]bool{current: true}
+	for {
+		currentRow, found, err := store.Session(ctx, current)
+		if err != nil {
+			return lineage, err
+		}
+		if !found || currentRow.ParentID == "" {
+			lineage.conversationID = current
+			break
+		}
+		if seen[currentRow.ParentID] {
+			lineage.conversationID = current
+			break
+		}
+		seen[currentRow.ParentID] = true
+		current = currentRow.ParentID
+		lineage.conversationID = current
+	}
+
+	messageID, found, err := store.SpawningMessageID(ctx, row.ParentID, sessionID)
+	if err != nil || !found {
+		return lineage, err
+	}
+	source, found, err := opencodeTerminalSource(ctx, store, row.ParentID, sourcePath, messageID)
+	if err != nil || !found {
+		return lineage, err
+	}
+	lineage.spawnGenerationID = source.GenerationID()
+	return lineage, nil
+}
+
+func opencodeTerminalSource(ctx context.Context, store *sessiondb.Store, sessionID, sourcePath, targetMessageID string) (SourceRef, bool, error) {
+	assistantIndex := 0
+	for msg, err := range store.Messages(ctx, sessionID) {
+		if err != nil {
+			return SourceRef{}, false, err
+		}
+		if msg.Role != "assistant" {
+			continue
+		}
+		turnIndex := assistantIndex
+		assistantIndex++
+		if !opencodeTerminalAssistant(msg) {
+			continue
+		}
+		if msg.ID == targetMessageID {
+			return SourceRef{
+				Agent:        AgentOpenCode,
+				SessionID:    sessionID,
+				SourcePath:   sourcePath,
+				TurnIndex:    turnIndex,
+				TurnID:       msg.ID,
+				TurnIDStable: true,
+			}, true, nil
+		}
+	}
+	return SourceRef{}, false, nil
+}
+
+func opencodeTerminalAssistant(msg sessiondb.Message) bool {
+	return msg.Role == "assistant" && (msg.Time.Completed != nil || msg.Error != nil)
+}
+
+func opencodeGeneration(
+	sess SessionPreview,
+	msg sessiondb.Message,
+	userParts, assistantParts []sessiondb.Part,
+	source SourceRef,
+	lineage opencodeLineage,
+	parentGenerationID string,
+) HistoricalGeneration {
+	usage, fallbackUsage := opencodeMapUsage(msg.Tokens, assistantParts)
+	gen := agento11y.Generation{
+		ID:             source.GenerationID(),
+		ConversationID: lineage.conversationID,
+		AgentName:      opencodeAgentName(msg.Mode),
+		Mode:           agento11y.GenerationModeStream,
+		OperationName:  "streamText",
+		Model:          agento11y.ModelRef{Provider: msg.ProviderID, Name: msg.ModelID},
+		ResponseModel:  msg.ModelID,
+		Input:          opencodeInputMessages(userParts),
+		Output:         opencodeOutputMessages(assistantParts),
+		Tools:          opencodeToolDefinitions(assistantParts),
+		Usage:          usage,
+		StopReason:     msg.Finish,
+		CallError:      opencodeError(msg.Error),
+		Tags:           opencodeTags(msg.Path.CWD, lineage.parentSessionID != ""),
+		Metadata:       opencodeMetadata(msg.Cost, sess.SessionID, lineage),
+	}
+	if lineage.conversationID == sess.SessionID {
+		gen.ConversationTitle = lineage.conversationTitle
+	}
+	if msg.Time.Created > 0 {
+		gen.StartedAt = time.UnixMilli(msg.Time.Created).UTC()
+	}
+	if msg.Time.Completed != nil && *msg.Time.Completed > 0 {
+		gen.CompletedAt = time.UnixMilli(*msg.Time.Completed).UTC()
+	}
+	if parentGenerationID != "" {
+		gen.ParentGenerationIDs = []string{parentGenerationID}
+	}
+	quality := QualityReport{
+		ApproxStartedAt:   gen.StartedAt.IsZero(),
+		ApproxCompletedAt: gen.CompletedAt.IsZero(),
+		ApproxUsage:       fallbackUsage,
+		MissingModel:      strings.TrimSpace(gen.Model.Name) == "",
+	}
+	return HistoricalGeneration{Source: source, Gen: gen, Quality: quality}
+}
+
+func opencodeAgentName(mode string) string {
+	if mode == "" {
+		return string(AgentOpenCode)
+	}
+	return string(AgentOpenCode) + ":" + mode
+}
+
+func opencodeInputMessages(parts []sessiondb.Part) []agento11y.Message {
+	var messages []agento11y.Message
+	for _, part := range parts {
+		if part.Type != "text" || part.Ignored || strings.TrimSpace(part.Text) == "" {
+			continue
+		}
+		messages = append(messages, agento11y.Message{
+			Role:  agento11y.RoleUser,
+			Parts: []agento11y.Part{{Kind: agento11y.PartKindText, Text: part.Text}},
+		})
+	}
+	return messages
+}
+
+func opencodeOutputMessages(parts []sessiondb.Part) []agento11y.Message {
+	var messages []agento11y.Message
+	for _, part := range parts {
+		switch part.Type {
+		case "text":
+			if strings.TrimSpace(part.Text) == "" {
+				continue
+			}
+			messages = append(messages, agento11y.Message{
+				Role:  agento11y.RoleAssistant,
+				Parts: []agento11y.Part{{Kind: agento11y.PartKindText, Text: part.Text}},
+			})
+		case "reasoning":
+			if strings.TrimSpace(part.Text) == "" {
+				continue
+			}
+			messages = append(messages, agento11y.Message{
+				Role:  agento11y.RoleAssistant,
+				Parts: []agento11y.Part{{Kind: agento11y.PartKindThinking, Thinking: part.Text}},
+			})
+		case "tool":
+			if part.State.Status != "completed" && part.State.Status != "error" {
+				continue
+			}
+			messages = append(messages, agento11y.Message{
+				Role: agento11y.RoleAssistant,
+				Parts: []agento11y.Part{{
+					Kind: agento11y.PartKindToolCall,
+					ToolCall: &agento11y.ToolCall{
+						ID:        part.CallID,
+						Name:      part.Tool,
+						InputJSON: opencodeToolInput(part.State.Input),
+					},
+				}},
+			})
+			result := &agento11y.ToolResult{
+				ToolCallID: part.CallID,
+				Name:       part.Tool,
+				IsError:    part.Tool == "invalid",
+			}
+			if part.Tool == "bash" && part.State.Metadata.Exit != nil && *part.State.Metadata.Exit != 0 {
+				result.IsError = true
+			}
+			if part.State.Status == "error" {
+				result.IsError = true
+				result.Content = "unknown error"
+				if part.State.Error != nil {
+					result.Content = *part.State.Error
+				}
+			} else {
+				result.Content = part.State.Output
+			}
+			messages = append(messages, agento11y.Message{
+				Role:  agento11y.RoleTool,
+				Parts: []agento11y.Part{{Kind: agento11y.PartKindToolResult, ToolResult: result}},
+			})
+		}
+	}
+	return messages
+}
+
+func opencodeToolInput(raw json.RawMessage) json.RawMessage {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return json.RawMessage("{}")
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, raw); err != nil {
+		return json.RawMessage("{}")
+	}
+	return json.RawMessage(compact.Bytes())
+}
+
+func opencodeToolDefinitions(parts []sessiondb.Part) []agento11y.ToolDefinition {
+	names := map[string]bool{}
+	for _, part := range parts {
+		if part.Type == "tool" && part.Tool != "" && (part.State.Status == "completed" || part.State.Status == "error") {
+			names[part.Tool] = true
+		}
+	}
+	ordered := make([]string, 0, len(names))
+	for name := range names {
+		ordered = append(ordered, name)
+	}
+	sort.Strings(ordered)
+	tools := make([]agento11y.ToolDefinition, 0, len(ordered))
+	for _, name := range ordered {
+		tools = append(tools, agento11y.ToolDefinition{Name: name, Type: "function"})
+	}
+	return tools
+}
+
+func opencodeMapUsage(fallback sessiondb.TokenCounts, parts []sessiondb.Part) (agento11y.TokenUsage, bool) {
+	var tokens sessiondb.TokenCounts
+	found := false
+	for _, part := range parts {
+		if part.Type != "step-finish" || !part.Tokens.Observed() {
+			continue
+		}
+		found = true
+		tokens.Input += part.Tokens.Input
+		tokens.Output += part.Tokens.Output
+		tokens.Reasoning += part.Tokens.Reasoning
+		tokens.Cache.Read += part.Tokens.Cache.Read
+		tokens.Cache.Write += part.Tokens.Cache.Write
+	}
+	if !found {
+		tokens = fallback
+	}
+	return agento11y.TokenUsage{
+		InputTokens:           tokens.Input,
+		OutputTokens:          tokens.Output,
+		TotalTokens:           tokens.Input + tokens.Output,
+		CacheReadInputTokens:  tokens.Cache.Read,
+		CacheWriteInputTokens: tokens.Cache.Write,
+		ReasoningTokens:       tokens.Reasoning,
+	}, !found
+}
+
+func opencodeError(messageError *sessiondb.MessageError) string {
+	if messageError == nil {
+		return ""
+	}
+	switch messageError.Name {
+	case "ProviderAuthError":
+		return "provider_auth"
+	case "APIError":
+		if messageError.Data.StatusCode == nil {
+			return "api_error: unknown"
+		}
+		return fmt.Sprintf("api_error: %d", *messageError.Data.StatusCode)
+	case "MessageOutputLengthError":
+		return "output_length_exceeded"
+	case "MessageAbortedError":
+		return "aborted"
+	case "UnknownError":
+		return "unknown_error"
+	default:
+		return "unknown_error"
+	}
+}
+
+func opencodeTags(cwd string, subagent bool) map[string]string {
+	tags := map[string]string{}
+	if cwd != "" {
+		tags["cwd"] = cwd
+	}
+	if subagent {
+		tags["subagent"] = "true"
+	}
+	if len(tags) == 0 {
+		return nil
+	}
+	return tags
+}
+
+func opencodeMetadata(cost float64, sessionID string, lineage opencodeLineage) map[string]any {
+	metadata := map[string]any{"cost_usd": cost}
+	if lineage.parentSessionID != "" {
+		metadata["opencode.parent_session_id"] = lineage.parentSessionID
+	}
+	if lineage.conversationID != sessionID {
+		metadata["opencode.child_session_id"] = sessionID
+	}
+	return metadata
+}

--- a/plugins/agento11y/internal/history/opencode_map_test.go
+++ b/plugins/agento11y/internal/history/opencode_map_test.go
@@ -1,0 +1,426 @@
+package history
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/grafana/agento11y/go/agento11y"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/opencode/sessiondb"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/opencode/sessiondb/sessiondbtest"
+)
+
+type opencodeFixture struct {
+	Sessions []struct {
+		ID        string `json:"id"`
+		ParentID  string `json:"parentID"`
+		Title     string `json:"title"`
+		Directory string `json:"directory"`
+		Created   int64  `json:"created"`
+		Updated   int64  `json:"updated"`
+	} `json:"sessions"`
+	Messages []struct {
+		ID        string          `json:"id"`
+		SessionID string          `json:"sessionID"`
+		Created   int64           `json:"created"`
+		Data      json.RawMessage `json:"data"`
+	} `json:"messages"`
+	Parts []struct {
+		ID        string          `json:"id"`
+		MessageID string          `json:"messageID"`
+		SessionID string          `json:"sessionID"`
+		Data      json.RawMessage `json:"data"`
+	} `json:"parts"`
+}
+
+func loadOpenCodeFixture(t *testing.T, name string) (*opencodeImporter, string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "opencode", name))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var fixture opencodeFixture
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+	db := sessiondbtest.New(t)
+	for _, row := range fixture.Sessions {
+		db.AddSession(row.ID, row.ParentID, row.Title, row.Directory, row.Created, row.Updated)
+	}
+	for _, row := range fixture.Messages {
+		db.AddMessage(row.ID, row.SessionID, row.Created, row.Created+1, string(row.Data))
+	}
+	for _, row := range fixture.Parts {
+		db.AddPart(row.ID, row.MessageID, row.SessionID, 1, 2, string(row.Data))
+	}
+	return &opencodeImporter{}, db.Path
+}
+
+func openCodeFixtureSession(t *testing.T, imp *opencodeImporter, path, sessionID string) SessionPreview {
+	t.Helper()
+	previews, err := imp.Previews(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Previews: %v", err)
+	}
+	for _, preview := range previews {
+		if preview.SessionID == sessionID {
+			return preview
+		}
+	}
+	t.Fatalf("fixture has no preview for %s", sessionID)
+	return SessionPreview{}
+}
+
+func TestOpenCodeFixtureMapsLikeTheLivePlugin(t *testing.T) {
+	imp, path := loadOpenCodeFixture(t, "mapping.json")
+	root := collectTurns(t, imp, openCodeFixtureSession(t, imp, path, "root-session"))
+	if len(root) != 3 {
+		t.Fatalf("root turns = %d, want 3", len(root))
+	}
+
+	first := root[0]
+	if first.Gen.ID != first.Source.GenerationID() || first.Gen.ConversationID != "root-session" {
+		t.Fatalf("first identity = %+v", first.Gen)
+	}
+	if first.Gen.ConversationTitle != "Root work" || first.Gen.AgentName != "opencode:build" {
+		t.Fatalf("first title/agent = %q/%q", first.Gen.ConversationTitle, first.Gen.AgentName)
+	}
+	if first.Gen.Mode != agento11y.GenerationModeStream || first.Gen.OperationName != "streamText" {
+		t.Fatalf("first span shape = %q/%q", first.Gen.Mode, first.Gen.OperationName)
+	}
+	if first.Gen.Model != (agento11y.ModelRef{Provider: "anthropic", Name: "claude-test"}) || first.Gen.ResponseModel != "claude-test" {
+		t.Fatalf("first models = %+v/%q", first.Gen.Model, first.Gen.ResponseModel)
+	}
+	if first.Gen.StopReason != "tool-calls" || first.Gen.Metadata["cost_usd"] != 0.12 {
+		t.Fatalf("first stop/cost = %q/%v", first.Gen.StopReason, first.Gen.Metadata["cost_usd"])
+	}
+	if !reflect.DeepEqual(first.Gen.Tags, map[string]string{"cwd": "/work/root"}) {
+		t.Fatalf("first tags = %v", first.Gen.Tags)
+	}
+	if got := openCodeTextParts(first.Gen.Input); !slices.Equal(got, []string{"Map this prompt"}) {
+		t.Fatalf("first input text = %v", got)
+	}
+	if got := openCodePartKinds(first.Gen.Output); !slices.Equal(got, []agento11y.PartKind{
+		agento11y.PartKindText,
+		agento11y.PartKindThinking,
+		agento11y.PartKindToolCall,
+		agento11y.PartKindToolResult,
+		agento11y.PartKindToolCall,
+		agento11y.PartKindToolResult,
+	}) {
+		t.Fatalf("first output kinds = %v", got)
+	}
+	if got := first.Gen.Output[2].Parts[0].ToolCall.InputJSON; string(got) != `{"cmd":"echo hi"}` {
+		t.Fatalf("completed tool input = %s", got)
+	}
+	if got := first.Gen.Output[5].Parts[0].ToolResult; !got.IsError || got.Content != "" {
+		t.Fatalf("failed tool result = %+v", got)
+	}
+	if got := first.Gen.Tools; !reflect.DeepEqual(got, []agento11y.ToolDefinition{
+		{Name: "bash", Type: "function"},
+		{Name: "read", Type: "function"},
+	}) {
+		t.Fatalf("first tools = %+v", got)
+	}
+	if got := first.Gen.Usage; got != (agento11y.TokenUsage{
+		InputTokens: 80, OutputTokens: 25, TotalTokens: 105,
+		ReasoningTokens: 7, CacheReadInputTokens: 20, CacheWriteInputTokens: 10,
+	}) {
+		t.Fatalf("fallback usage = %+v", got)
+	}
+	if !first.Quality.ApproxUsage {
+		t.Fatal("message-token fallback was not marked approximate")
+	}
+
+	second := root[1]
+	if len(second.Gen.Input) != 0 {
+		t.Fatalf("later assistant input = %+v, want none", second.Gen.Input)
+	}
+	if got := second.Gen.Usage; got != (agento11y.TokenUsage{
+		InputTokens: 310, OutputTokens: 60, TotalTokens: 370,
+		ReasoningTokens: 15, CacheReadInputTokens: 70, CacheWriteInputTokens: 14,
+	}) {
+		t.Fatalf("step usage = %+v", got)
+	}
+	if second.Quality.ApproxUsage {
+		t.Fatal("step usage was marked approximate")
+	}
+	if cost, ok := second.Gen.Metadata["cost_usd"]; !ok || cost != float64(0) {
+		t.Fatalf("zero cost = %v, present %v", cost, ok)
+	}
+	if !slices.Equal(second.Gen.ParentGenerationIDs, []string{first.Gen.ID}) {
+		t.Fatalf("second parents = %v", second.Gen.ParentGenerationIDs)
+	}
+	if !slices.Equal(root[2].Gen.ParentGenerationIDs, []string{second.Gen.ID}) {
+		t.Fatalf("third parents = %v", root[2].Gen.ParentGenerationIDs)
+	}
+
+	child := collectTurns(t, imp, openCodeFixtureSession(t, imp, path, "child-session"))
+	if len(child) != 1 {
+		t.Fatalf("child turns = %d, want 1", len(child))
+	}
+	turn := child[0]
+	if turn.Gen.ConversationID != "root-session" || turn.Gen.ConversationTitle != "" {
+		t.Fatalf("child conversation = %q title %q", turn.Gen.ConversationID, turn.Gen.ConversationTitle)
+	}
+	if turn.Gen.AgentName != "opencode:explore" || turn.Gen.CallError != "aborted" {
+		t.Fatalf("child agent/error = %q/%q", turn.Gen.AgentName, turn.Gen.CallError)
+	}
+	if !reflect.DeepEqual(turn.Gen.Tags, map[string]string{"cwd": "/work/child", "subagent": "true"}) {
+		t.Fatalf("child tags = %v", turn.Gen.Tags)
+	}
+	if turn.Gen.Metadata["opencode.parent_session_id"] != "root-session" || turn.Gen.Metadata["opencode.child_session_id"] != "child-session" {
+		t.Fatalf("child metadata = %v", turn.Gen.Metadata)
+	}
+	if !slices.Equal(turn.Gen.ParentGenerationIDs, []string{root[2].Gen.ID}) {
+		t.Fatalf("child parents = %v, want spawning turn %s", turn.Gen.ParentGenerationIDs, root[2].Gen.ID)
+	}
+
+	encoded, err := json.Marshal(append(root, child...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"SUMMARY-DIFF-MUST-NOT-EXPORT", "FILE-PART-MUST-NOT-EXPORT", "SIGNATURE-MUST-NOT-EXPORT", "call-running"} {
+		if strings.Contains(string(encoded), forbidden) {
+			t.Errorf("mapped generations contain excluded value %q", forbidden)
+		}
+	}
+}
+
+func TestOpenCodeMappingRules(t *testing.T) {
+	t.Run("input", func(t *testing.T) {
+		messages := opencodeInputMessages([]sessiondb.Part{
+			{Type: "text", Text: "sent"},
+			{Type: "text", Text: "user only", Ignored: true},
+		})
+		if got := openCodeTextParts(messages); !slices.Equal(got, []string{"sent"}) {
+			t.Fatalf("input text = %v", got)
+		}
+	})
+
+	t.Run("usage", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			fallback sessiondb.TokenCounts
+			parts    []sessiondb.Part
+			want     agento11y.TokenUsage
+			approx   bool
+		}{
+			{
+				name:     "message fallback",
+				fallback: sessiondb.TokenCounts{Input: 4, Output: 5, Reasoning: 2, Cache: sessiondb.CacheCounts{Read: 3, Write: 1}},
+				want:     agento11y.TokenUsage{InputTokens: 4, OutputTokens: 5, TotalTokens: 9, ReasoningTokens: 2, CacheReadInputTokens: 3, CacheWriteInputTokens: 1},
+				approx:   true,
+			},
+			{
+				name:     "empty step falls back",
+				fallback: sessiondb.TokenCounts{Input: 4, Output: 5},
+				parts:    []sessiondb.Part{openCodeStepPart(t, `{}`)},
+				want:     agento11y.TokenUsage{InputTokens: 4, OutputTokens: 5, TotalTokens: 9},
+				approx:   true,
+			},
+			{
+				name: "sum steps",
+				parts: []sessiondb.Part{
+					openCodeStepPart(t, `{"input":4,"output":5,"reasoning":2,"cache":{"read":3,"write":1}}`),
+					openCodeStepPart(t, `{"input":6,"output":7,"reasoning":4,"cache":{"read":5,"write":2}}`),
+				},
+				want: agento11y.TokenUsage{InputTokens: 10, OutputTokens: 12, TotalTokens: 22, ReasoningTokens: 6, CacheReadInputTokens: 8, CacheWriteInputTokens: 3},
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got, approx := opencodeMapUsage(tt.fallback, tt.parts)
+				if got != tt.want || approx != tt.approx {
+					t.Fatalf("opencodeMapUsage = (%+v, %v), want (%+v, %v)", got, approx, tt.want, tt.approx)
+				}
+			})
+		}
+	})
+
+	t.Run("errors", func(t *testing.T) {
+		status := 429
+		tests := []struct {
+			name string
+			err  *sessiondb.MessageError
+			want string
+		}{
+			{name: "none", want: ""},
+			{name: "provider auth", err: &sessiondb.MessageError{Name: "ProviderAuthError"}, want: "provider_auth"},
+			{name: "api status", err: &sessiondb.MessageError{Name: "APIError", Data: sessiondb.MessageErrorData{StatusCode: &status}}, want: "api_error: 429"},
+			{name: "api unknown", err: &sessiondb.MessageError{Name: "APIError"}, want: "api_error: unknown"},
+			{name: "length", err: &sessiondb.MessageError{Name: "MessageOutputLengthError"}, want: "output_length_exceeded"},
+			{name: "aborted", err: &sessiondb.MessageError{Name: "MessageAbortedError"}, want: "aborted"},
+			{name: "unknown", err: &sessiondb.MessageError{Name: "UnknownError"}, want: "unknown_error"},
+			{name: "new host error", err: &sessiondb.MessageError{Name: "ContextOverflowError"}, want: "unknown_error"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if got := opencodeError(tt.err); got != tt.want {
+					t.Fatalf("opencodeError = %q, want %q", got, tt.want)
+				}
+			})
+		}
+	})
+
+	t.Run("tool results", func(t *testing.T) {
+		empty := ""
+		failure := "failed"
+		exitZero := 0
+		exitOne := 1
+		tests := []struct {
+			name      string
+			part      sessiondb.Part
+			wantError bool
+			want      string
+		}{
+			{
+				name:      "missing error",
+				part:      sessiondb.Part{Type: "tool", State: sessiondb.ToolState{Status: "error"}},
+				wantError: true,
+				want:      "unknown error",
+			},
+			{
+				name:      "empty error",
+				part:      sessiondb.Part{Type: "tool", State: sessiondb.ToolState{Status: "error", Error: &empty}},
+				wantError: true,
+			},
+			{
+				name:      "error message",
+				part:      sessiondb.Part{Type: "tool", State: sessiondb.ToolState{Status: "error", Error: &failure}},
+				wantError: true,
+				want:      "failed",
+			},
+			{
+				name:      "invalid tool",
+				part:      sessiondb.Part{Type: "tool", Tool: "invalid", State: sessiondb.ToolState{Status: "completed", Output: "invalid arguments"}},
+				wantError: true,
+				want:      "invalid arguments",
+			},
+			{
+				name:      "bash failure",
+				part:      sessiondb.Part{Type: "tool", Tool: "bash", State: sessiondb.ToolState{Status: "completed", Output: "failed", Metadata: sessiondb.ToolMetadata{Exit: &exitOne}}},
+				wantError: true,
+				want:      "failed",
+			},
+			{
+				name: "bash success",
+				part: sessiondb.Part{Type: "tool", Tool: "bash", State: sessiondb.ToolState{Status: "completed", Output: "done", Metadata: sessiondb.ToolMetadata{Exit: &exitZero}}},
+				want: "done",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				messages := opencodeOutputMessages([]sessiondb.Part{tt.part})
+				if len(messages) != 2 {
+					t.Fatalf("messages = %+v", messages)
+				}
+				got := messages[1].Parts[0].ToolResult
+				if got.IsError != tt.wantError || got.Content != tt.want {
+					t.Fatalf("tool result = %+v, want error=%v content=%q", got, tt.wantError, tt.want)
+				}
+			})
+		}
+	})
+
+	t.Run("agent and tags", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			mode     string
+			cwd      string
+			subagent bool
+			wantName string
+			wantTags map[string]string
+		}{
+			{name: "defaults", wantName: "opencode"},
+			{name: "mode and cwd", mode: "plan", cwd: "/work", wantName: "opencode:plan", wantTags: map[string]string{"cwd": "/work"}},
+			{name: "subagent", mode: "build", subagent: true, wantName: "opencode:build", wantTags: map[string]string{"subagent": "true"}},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if got := opencodeAgentName(tt.mode); got != tt.wantName {
+					t.Errorf("agent name = %q, want %q", got, tt.wantName)
+				}
+				if got := opencodeTags(tt.cwd, tt.subagent); !reflect.DeepEqual(got, tt.wantTags) {
+					t.Errorf("tags = %v, want %v", got, tt.wantTags)
+				}
+			})
+		}
+	})
+}
+
+func TestOpenCodeLineageWalksToTheRootAndGuardsCycles(t *testing.T) {
+	db := sessiondbtest.New(t)
+	db.AddSession("root", "", "root", "/work", 1, 1)
+	db.AddSession("child", "root", "child", "/work", 1, 1)
+	db.AddSession("grandchild", "child", "grandchild", "/work", 1, 1)
+	db.AddSession("cycle-a", "cycle-b", "a", "/work", 1, 1)
+	db.AddSession("cycle-b", "cycle-a", "b", "/work", 1, 1)
+
+	store, err := sessiondb.Open(db.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+	lineage, err := resolveOpenCodeLineage(context.Background(), store, "grandchild", db.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lineage.parentSessionID != "child" || lineage.conversationID != "root" {
+		t.Fatalf("grandchild lineage = %+v", lineage)
+	}
+	cycle, err := resolveOpenCodeLineage(context.Background(), store, "cycle-a", db.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cycle.conversationID != "cycle-b" {
+		t.Fatalf("cycle lineage = %+v, want guard to stop at cycle-b", cycle)
+	}
+}
+
+func openCodeStepPart(t *testing.T, tokens string) sessiondb.Part {
+	t.Helper()
+	var part sessiondb.Part
+	if err := json.Unmarshal([]byte(`{"type":"step-finish","tokens":`+tokens+`}`), &part); err != nil {
+		t.Fatalf("decode step part: %v", err)
+	}
+	return part
+}
+
+func openCodeTextParts(messages []agento11y.Message) []string {
+	var out []string
+	for _, message := range messages {
+		for _, part := range message.Parts {
+			if part.Kind == agento11y.PartKindText {
+				out = append(out, part.Text)
+			}
+		}
+	}
+	return out
+}
+
+func openCodePartKinds(messages []agento11y.Message) []agento11y.PartKind {
+	var out []agento11y.PartKind
+	for _, message := range messages {
+		for _, part := range message.Parts {
+			out = append(out, part.Kind)
+		}
+	}
+	return out
+}
+
+func TestOpenCodeFixtureIsDeterministic(t *testing.T) {
+	imp, path := loadOpenCodeFixture(t, "mapping.json")
+	sess := openCodeFixtureSession(t, imp, path, "root-session")
+	first := collectTurns(t, imp, sess)
+	second := collectTurns(t, imp, sess)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("repeated fixture import changed:\nfirst=%s\nsecond=%s", fmt.Sprint(first), fmt.Sprint(second))
+	}
+}

--- a/plugins/agento11y/internal/history/opencode_test.go
+++ b/plugins/agento11y/internal/history/opencode_test.go
@@ -1,0 +1,350 @@
+package history
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/opencode/sessiondb/sessiondbtest"
+)
+
+func TestOpenCodeRootsAndMatch(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	t.Setenv("HOME", t.TempDir())
+	dataDir := filepath.Join(dataHome, "opencode")
+	if err := os.MkdirAll(filepath.Join(dataDir, "custom"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"opencode.db", "opencode-beta.db", "opencode-local.db", "notes.db"} {
+		if err := os.WriteFile(filepath.Join(dataDir, name), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("OPENCODE_DB", filepath.Join("custom", "history.sqlite"))
+
+	imp := &opencodeImporter{}
+	got := imp.Roots()
+	want := []string{
+		filepath.Join(dataDir, "custom", "history.sqlite"),
+		filepath.Join(dataDir, "opencode-beta.db"),
+		filepath.Join(dataDir, "opencode-local.db"),
+		filepath.Join(dataDir, "opencode.db"),
+	}
+	sort.Strings(want)
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("Roots = %v, want %v", got, want)
+	}
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: filepath.Join(dataDir, "opencode.db"), want: true},
+		{path: filepath.Join(dataDir, "opencode-nightly.db"), want: true},
+		{path: filepath.Join(dataDir, "opencode.db-wal"), want: false},
+		{path: filepath.Join(dataDir, "opencode.db-shm"), want: false},
+		{path: filepath.Join(dataDir, "notes.db"), want: false},
+		{path: filepath.Join(dataDir, "custom", "history.sqlite"), want: true},
+	}
+	for _, tc := range tests {
+		if got := imp.Match(tc.path); got != tc.want {
+			t.Errorf("Match(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestOpenCodeRootsWithoutDataDir(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	absolutePath := filepath.Join(t.TempDir(), "history.sqlite")
+
+	tests := []struct {
+		name     string
+		override string
+		want     []string
+	}{
+		{name: "absolute override", override: absolutePath, want: []string{absolutePath}},
+		{name: "relative override", override: "history.sqlite"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OPENCODE_DB", tt.override)
+			if got := (&opencodeImporter{}).Roots(); !slices.Equal(got, tt.want) {
+				t.Fatalf("Roots() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenCodePreviewUsesTheContainerPath(t *testing.T) {
+	db := sessiondbtest.New(t)
+	now := time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+	db.AddSession("normal", "", "Useful title ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij", "/work/normal", now.Add(-2*time.Hour).UnixMilli(), now.Add(-time.Hour).UnixMilli())
+	db.AddSession("placeholder", "", "New session - 2026-08-07T08:54:44.300Z", "/work/placeholder", now.Add(-3*time.Hour).UnixMilli(), now.Add(-2*time.Hour).UnixMilli())
+	db.AddSession("abandoned", "", "Abandoned", "/work/abandoned", now.Add(-4*time.Hour).UnixMilli(), now.Add(-3*time.Hour).UnixMilli())
+	db.AddSession("empty", "", "Empty", "/work/empty", now.Add(-5*time.Hour).UnixMilli(), now.Add(-4*time.Hour).UnixMilli())
+	db.AddMessage("normal-user", "normal", 1, 2, `{"role":"user","time":{"created":1}}`)
+	db.AddMessage("normal-assistant", "normal", 2, 3, `{"role":"assistant","time":{"created":2,"completed":3},"modelID":"model","providerID":"provider"}`)
+	db.AddPart("normal-text", "normal-assistant", "normal", 1, 2, `{"type":"text","text":"preview-secret"}`)
+	db.AddMessage("placeholder-user", "placeholder", 1, 2, `{"role":"user","time":{"created":1}}`)
+	db.AddMessage("placeholder-assistant", "placeholder", 2, 3, `{"role":"assistant","time":{"created":2,"completed":3},"modelID":"model","providerID":"provider"}`)
+	db.AddMessage("abandoned-user", "abandoned", 1, 2, `{"role":"user","time":{"created":1}}`)
+
+	imp := &opencodeImporter{roots: []string{db.Path}}
+	if _, ok, err := imp.Preview(context.Background(), db.Path); err != nil || ok {
+		t.Fatalf("Preview = (_, %v, %v), want unused", ok, err)
+	}
+	got, err := Discover(context.Background(), AgentOpenCode, imp, DiscoverOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(got.Sessions) != 2 {
+		t.Fatalf("Discover returned %d sessions, want 2", len(got.Sessions))
+	}
+	byID := map[string]SessionPreview{}
+	for _, sess := range got.Sessions {
+		byID[sess.SessionID] = sess
+		rendered := fmt.Sprintf("%+v", sess)
+		if strings.Contains(rendered, "preview-secret") || strings.Contains(rendered, "Useful title") {
+			t.Fatal("preview contains session content")
+		}
+	}
+	normal := byID["normal"]
+	if normal.Title != "normal" || normal.Workspace != "/work/normal" || normal.TurnCount != 1 {
+		t.Fatalf("normal preview = %+v", normal)
+	}
+	if normal.SourcePath != db.Path || normal.StartedAt.UnixMilli() != now.Add(-2*time.Hour).UnixMilli() {
+		t.Fatalf("normal preview identity = %+v", normal)
+	}
+	if byID["placeholder"].Title != "placeholder" {
+		t.Fatalf("placeholder title = %q", byID["placeholder"].Title)
+	}
+	if turns := collectTurns(t, imp, normal); len(turns) != 1 || turns[0].Gen.ConversationTitle != "Useful title ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij" {
+		t.Fatalf("selected normal title = %+v", turns)
+	}
+	if turns := collectTurns(t, imp, byID["placeholder"]); len(turns) != 1 || turns[0].Gen.ConversationTitle != "" {
+		t.Fatalf("selected placeholder title = %+v", turns)
+	}
+	exporter := &recordingExporter{}
+	if _, err := RunImport(context.Background(), ImportOptions{
+		Agent: AgentOpenCode, Importer: imp, Sessions: []SessionPreview{normal},
+		Exporter: exporter, Ledger: testLedger(t),
+	}); err != nil {
+		t.Fatalf("RunImport: %v", err)
+	}
+	if len(exporter.got) != 1 || exporter.got[0].Gen.ConversationTitle != "Useful title [REDACTED:github-pat]" {
+		t.Fatalf("exported normal title = %+v", exporter.got)
+	}
+	if _, ok := byID["abandoned"]; ok {
+		t.Fatal("session with no importable turns was previewed")
+	}
+	if _, ok := byID["empty"]; ok {
+		t.Fatal("session with no messages was previewed")
+	}
+}
+
+func TestOpenCodeRunImportReportsTitleTruncation(t *testing.T) {
+	db := sessiondbtest.New(t)
+	title := strings.Repeat("x", DefaultMaxFieldBytes+1)
+	db.AddSession("session", "", title, "/work", 1, 2)
+	db.AddMessage("assistant", "session", 1, 2, `{"role":"assistant","time":{"created":1,"completed":2}}`)
+	imp := &opencodeImporter{}
+	previews, err := imp.Previews(context.Background(), db.Path)
+	if err != nil || len(previews) != 1 {
+		t.Fatalf("Previews = (%+v, %v)", previews, err)
+	}
+
+	exporter := &recordingExporter{}
+	_, err = RunImport(context.Background(), ImportOptions{
+		Agent: AgentOpenCode, Importer: imp, Sessions: previews,
+		Exporter: exporter, Ledger: testLedger(t),
+	})
+	if err != nil {
+		t.Fatalf("RunImport: %v", err)
+	}
+	if len(exporter.got) != 1 {
+		t.Fatalf("exported = %+v", exporter.got)
+	}
+	got := exporter.got[0]
+	if len(got.Gen.ConversationTitle) != DefaultMaxFieldBytes || !got.Quality.Truncated {
+		t.Fatalf("exported title bytes=%d quality=%+v", len(got.Gen.ConversationTitle), got.Quality)
+	}
+}
+
+func TestOpenCodePreviewWarnsOnMalformedMessage(t *testing.T) {
+	db := sessiondbtest.New(t)
+	db.AddSession("session", "", "Session", "/work", 1, 2)
+	db.AddMessage("bad-message", "session", 1, 2, `{`)
+
+	got, err := Discover(context.Background(), AgentOpenCode, &opencodeImporter{roots: []string{db.Path}}, DiscoverOptions{})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(got.Sessions) != 0 || len(got.Warnings) != 1 {
+		t.Fatalf("Discover = %+v, want one warning and no sessions", got)
+	}
+	if !strings.Contains(got.Warnings[0], "bad-message") || !strings.Contains(got.Warnings[0], db.Path) {
+		t.Fatalf("warning = %q", got.Warnings[0])
+	}
+}
+
+func TestOpenCodeCollisionsKeepChildrenWithTheirRoot(t *testing.T) {
+	tests := []struct {
+		name      string
+		roots     [2]string
+		rootTurns bool
+	}{
+		{name: "same root and child ids", roots: [2]string{"root", "root"}, rootTurns: true},
+		{name: "same child id under different roots", roots: [2]string{"root-a", "root-b"}, rootTurns: true},
+		{name: "same omitted root id", roots: [2]string{"root", "root"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imp := &opencodeImporter{}
+			rootsByPath := map[string]string{}
+			var sessions []SessionPreview
+			for i, rootID := range tt.roots {
+				db := sessiondbtest.New(t)
+				db.AddSession(rootID, "", "Root", "/work", 1, 10)
+				db.AddSession("child", rootID, "Child", "/work", 2, 11)
+				if tt.rootTurns {
+					db.AddMessage("root-assistant", rootID, 3, 4, `{"role":"assistant","time":{"created":3,"completed":4}}`)
+				}
+				db.AddMessage("child-assistant", "child", 5, 6, `{"role":"assistant","time":{"created":5,"completed":6}}`)
+				previews, err := imp.Previews(context.Background(), db.Path)
+				if err != nil {
+					t.Fatalf("database %d previews: %v", i, err)
+				}
+				rootsByPath[db.Path] = rootID
+				sessions = append(sessions, previews...)
+			}
+
+			exporter := &recordingExporter{}
+			_, err := RunImport(context.Background(), ImportOptions{
+				Agent:      AgentOpenCode,
+				Importer:   imp,
+				Sessions:   sessions,
+				Collisions: DetectCollisions(sessions),
+				Exporter:   exporter,
+				Ledger:     testLedger(t),
+			})
+			if err != nil {
+				t.Fatalf("RunImport: %v", err)
+			}
+			conversations := map[string]map[string]string{}
+			for _, gen := range exporter.got {
+				bySession := conversations[gen.Source.SourcePath]
+				if bySession == nil {
+					bySession = map[string]string{}
+					conversations[gen.Source.SourcePath] = bySession
+				}
+				bySession[gen.Source.SessionID] = gen.Gen.ConversationID
+			}
+			if len(conversations) != 2 {
+				t.Fatalf("conversations by source = %v", conversations)
+			}
+			var rootIDs []string
+			for path, bySession := range conversations {
+				rootID := rootsByPath[path]
+				childConversation := bySession["child"]
+				if childConversation == "" {
+					t.Fatalf("source %s conversations = %v", path, bySession)
+				}
+				if rootConversation := bySession[rootID]; rootConversation != "" && rootConversation != childConversation {
+					t.Fatalf("source %s conversations = %v", path, bySession)
+				}
+				rootIDs = append(rootIDs, childConversation)
+			}
+			if rootIDs[0] == rootIDs[1] {
+				t.Fatalf("databases shared conversation %q", rootIDs[0])
+			}
+		})
+	}
+}
+
+func TestOpenCodeTurnsReportsMissingSelectedSession(t *testing.T) {
+	db := sessiondbtest.New(t)
+	sess := SessionPreview{Agent: AgentOpenCode, SessionID: "deleted", SourcePath: db.Path}
+	for _, err := range (&opencodeImporter{}).Turns(context.Background(), sess) {
+		if err == nil || !strings.Contains(err.Error(), "no longer exists") {
+			t.Fatalf("Turns error = %v", err)
+		}
+		return
+	}
+	t.Fatal("Turns returned no error")
+}
+
+func TestOpenCodeTurnsYieldOnlyTerminalAssistantMessages(t *testing.T) {
+	db := sessiondbtest.New(t)
+	db.AddSession("session", "", "Session", "/work", 1, 10)
+	db.AddMessage("user", "session", 1, 2, `{"role":"user","time":{"created":1}}`)
+	db.AddMessage("incomplete", "session", 2, 3, `{"role":"assistant","time":{"created":2},"modelID":"model","providerID":"provider"}`)
+	db.AddPart("incomplete-text", "incomplete", "session", 1, 2, `{"type":"text","text":"unfinished"}`)
+	db.AddMessage("complete", "session", 3, 4, `{"role":"assistant","time":{"created":3,"completed":4},"modelID":"model","providerID":"provider"}`)
+	db.AddMessage("error", "session", 5, 6, `{"role":"assistant","time":{"created":5},"modelID":"model","providerID":"provider","error":{"name":"UnknownError","data":{}}}`)
+
+	imp := &opencodeImporter{}
+	sess := SessionPreview{Agent: AgentOpenCode, SessionID: "session", SourcePath: db.Path}
+	var got []HistoricalGeneration
+	for gen, err := range imp.Turns(context.Background(), sess) {
+		if err != nil {
+			t.Fatalf("Turns: %v", err)
+		}
+		got = append(got, gen)
+	}
+	if len(got) != 2 {
+		t.Fatalf("Turns returned %d generations, want 2", len(got))
+	}
+	if got[0].Source.TurnID != "complete" || got[1].Source.TurnID != "error" {
+		t.Fatalf("turn IDs = [%s %s]", got[0].Source.TurnID, got[1].Source.TurnID)
+	}
+	if got[0].Source.GenerationID() == got[1].Source.GenerationID() {
+		t.Fatal("two turns received the same generation ID")
+	}
+
+	var again []string
+	for gen, err := range imp.Turns(context.Background(), sess) {
+		if err != nil {
+			t.Fatalf("second Turns: %v", err)
+		}
+		again = append(again, gen.Source.GenerationID())
+	}
+	if fmt.Sprint(again) != fmt.Sprint([]string{got[0].Source.GenerationID(), got[1].Source.GenerationID()}) {
+		t.Fatalf("second IDs = %v", again)
+	}
+
+	if _, err := db.DB.Exec(`update message set data = ? where id = 'incomplete'`,
+		`{"role":"assistant","time":{"created":2,"completed":6},"modelID":"model","providerID":"provider"}`); err != nil {
+		t.Fatalf("complete earlier message: %v", err)
+	}
+	for gen, err := range imp.Turns(context.Background(), sess) {
+		if err != nil {
+			t.Fatalf("Turns after completion: %v", err)
+		}
+		if gen.Source.TurnID == "complete" && gen.Source.GenerationID() != got[0].Source.GenerationID() {
+			t.Fatalf("later completion changed complete generation ID from %s to %s", got[0].Source.GenerationID(), gen.Source.GenerationID())
+		}
+	}
+
+	if _, err := db.DB.Exec(`delete from message where id = 'incomplete'`); err != nil {
+		t.Fatalf("delete earlier message: %v", err)
+	}
+	for gen, err := range imp.Turns(context.Background(), sess) {
+		if err != nil {
+			t.Fatalf("Turns after deletion: %v", err)
+		}
+		if gen.Source.TurnID == "complete" && gen.Source.GenerationID() != got[0].Source.GenerationID() {
+			t.Fatalf("earlier deletion changed complete generation ID from %s to %s", got[0].Source.GenerationID(), gen.Source.GenerationID())
+		}
+	}
+}

--- a/plugins/agento11y/internal/history/sanitize.go
+++ b/plugins/agento11y/internal/history/sanitize.go
@@ -55,6 +55,10 @@ func (s Sanitizer) maxBytes() int {
 	return s.MaxFieldBytes
 }
 
+func (s Sanitizer) cleanText(text string) (string, Truncation) {
+	return Truncate(s.Redactor.Redact(text), s.maxBytes())
+}
+
 // Sanitize redacts and truncates every text-bearing field of g.Gen in place and
 // records truncation in g.Quality.Truncated. A JSON field is redacted
 // key-aware and stays valid JSON.
@@ -63,8 +67,7 @@ func (s Sanitizer) Sanitize(g *HistoricalGeneration) {
 	truncated := false
 
 	clean := func(text string) string {
-		red := s.Redactor.Redact(text)
-		out, t := Truncate(red, max)
+		out, t := s.cleanText(text)
 		truncated = truncated || t.Truncated
 		return out
 	}

--- a/plugins/agento11y/internal/history/testdata/opencode/README.md
+++ b/plugins/agento11y/internal/history/testdata/opencode/README.md
@@ -1,0 +1,56 @@
+# OpenCode history fixtures
+
+OpenCode stores sessions, messages, and parts as SQLite rows. The JSON files in
+this directory are readable descriptions of those rows. Tests load each file
+into a temporary SQLite database. No database or conversation copied from a
+real user is committed here.
+
+`mapping.json` covers three root turns: two share one user message, and the
+third spawns a child session through a `task` part. It also covers accumulated
+step usage, text, reasoning, completed and failed tools, and an ignored running
+tool. The shared user row carries a synthetic `summary.diffs` value. The
+importer must never export that value.
+
+These fixtures pin the on-disk shape expected by the Go reader and mapper. They
+do not replay OpenCode's event stream and cannot detect an upstream schema
+change.
+
+## Differences from live capture
+
+The history path cannot recover the composed system prompt, host version,
+configured agent-name prefix, capture-time Git branch, or time to first token.
+It uses the persisted message `cwd`, while live capture uses the plugin's
+project directory. The final database title applies to every imported root
+turn; live capture only adds a title to turns recorded after the title event.
+
+The importer builds its tool catalog from completed and failed parts. It cannot
+recover legacy tool overrides, incomplete tool executions, or standalone tool
+spans. It uses the persisted `parent_id` chain even when live capture started
+too late to link a child. Historical generation IDs use the shared history ID
+scheme, not the OpenCode plugin's live ID scheme.
+
+History content passes through the shared full sanitizer. Live capture uses
+lightweight redaction for assistant text and reasoning. Stored prompts also
+predate any preflight rewrite made by an Agent Observability rule. The importer
+ignores `message.data.summary`, including its raw file diffs.
+
+## Checking against a real database
+
+Run discovery and a dry-run import against the database without printing
+message or part data:
+
+```sh
+cd plugins/agento11y
+GOWORK=off go run ./cmd/agento11y history import opencode --dry-run --all --yes --since 365d
+```
+
+Use read-only SQL:
+
+1. Count assistant messages whose JSON has a numeric `time.completed` value, an
+   `error` object, or both.
+2. Count sessions that contain at least one of those messages.
+3. Apply the dry run's time bounds and five-minute active-session exclusion.
+4. Compare the SQL totals with the planned session and turn counts.
+
+The fixture cannot detect a table or JSON field rename in a newer OpenCode
+release.

--- a/plugins/agento11y/internal/history/testdata/opencode/mapping.json
+++ b/plugins/agento11y/internal/history/testdata/opencode/mapping.json
@@ -1,0 +1,126 @@
+{
+  "sessions": [
+    {
+      "id": "root-session",
+      "title": "Root work",
+      "directory": "/work/root",
+      "created": 1000,
+      "updated": 9000
+    },
+    {
+      "id": "child-session",
+      "parentID": "root-session",
+      "title": "Child session - 2026-08-07T08:54:44.300Z",
+      "directory": "/work/child",
+      "created": 7000,
+      "updated": 9000
+    }
+  ],
+  "messages": [
+    {
+      "id": "root-user-1",
+      "sessionID": "root-session",
+      "created": 1000,
+      "data": {
+        "role": "user",
+        "time": { "created": 1000 },
+        "summary": { "diffs": [{ "file": "secrets.yml", "after": "SUMMARY-DIFF-MUST-NOT-EXPORT" }] }
+      }
+    },
+    {
+      "id": "root-assistant-1",
+      "sessionID": "root-session",
+      "created": 1000,
+      "data": {
+        "role": "assistant",
+        "parentID": "root-user-1",
+        "time": { "created": 1000, "completed": 2500 },
+        "providerID": "anthropic",
+        "modelID": "claude-test",
+        "mode": "build",
+        "path": { "cwd": "/work/root", "root": "/work" },
+        "cost": 0.12,
+        "tokens": { "input": 80, "output": 25, "reasoning": 7, "cache": { "read": 20, "write": 10 } },
+        "finish": "tool-calls"
+      }
+    },
+    {
+      "id": "root-assistant-2",
+      "sessionID": "root-session",
+      "created": 3000,
+      "data": {
+        "role": "assistant",
+        "parentID": "root-user-1",
+        "time": { "created": 3000, "completed": 3500 },
+        "providerID": "openai",
+        "modelID": "gpt-test",
+        "path": { "cwd": "/work/root" },
+        "cost": 0,
+        "tokens": { "input": 999, "output": 999, "reasoning": 999, "cache": { "read": 999, "write": 999 } },
+        "finish": "stop"
+      }
+    },
+    {
+      "id": "root-user-2",
+      "sessionID": "root-session",
+      "created": 4000,
+      "data": { "role": "user", "time": { "created": 4000 } }
+    },
+    {
+      "id": "root-spawn",
+      "sessionID": "root-session",
+      "created": 5000,
+      "data": {
+        "role": "assistant",
+        "parentID": "root-user-2",
+        "time": { "created": 5000, "completed": 6000 },
+        "providerID": "anthropic",
+        "modelID": "claude-test",
+        "mode": "build",
+        "path": { "cwd": "/work/root" },
+        "tokens": { "input": 3, "output": 4, "reasoning": 0, "cache": { "read": 0, "write": 0 } },
+        "finish": "tool-calls"
+      }
+    },
+    {
+      "id": "child-user-1",
+      "sessionID": "child-session",
+      "created": 7000,
+      "data": { "role": "user", "time": { "created": 7000 } }
+    },
+    {
+      "id": "child-assistant-1",
+      "sessionID": "child-session",
+      "created": 8000,
+      "data": {
+        "role": "assistant",
+        "parentID": "child-user-1",
+        "time": { "created": 8000, "completed": 8500 },
+        "providerID": "anthropic",
+        "modelID": "claude-test",
+        "mode": "explore",
+        "path": { "cwd": "/work/child" },
+        "tokens": { "input": 9, "output": 2, "reasoning": 0, "cache": { "read": 1, "write": 0 } },
+        "finish": "stop",
+        "error": { "name": "MessageAbortedError", "data": {} }
+      }
+    }
+  ],
+  "parts": [
+    { "id": "u1-01", "messageID": "root-user-1", "sessionID": "root-session", "data": { "type": "text", "text": "Map this prompt" } },
+    { "id": "u1-02", "messageID": "root-user-1", "sessionID": "root-session", "data": { "type": "file", "text": "FILE-PART-MUST-NOT-EXPORT" } },
+    { "id": "a1-01", "messageID": "root-assistant-1", "sessionID": "root-session", "data": { "type": "text", "text": "Mapped answer" } },
+    { "id": "a1-02", "messageID": "root-assistant-1", "sessionID": "root-session", "data": { "type": "text", "text": "   " } },
+    { "id": "a1-03", "messageID": "root-assistant-1", "sessionID": "root-session", "data": { "type": "reasoning", "text": "Mapped reasoning", "metadata": { "anthropic": { "signature": "SIGNATURE-MUST-NOT-EXPORT" } } } },
+    { "id": "a1-04", "messageID": "root-assistant-1", "sessionID": "root-session", "data": { "type": "tool", "callID": "call-bash", "tool": "bash", "state": { "status": "completed", "input": { "cmd": "echo hi" }, "output": "command output" } } },
+    { "id": "a1-05", "messageID": "root-assistant-1", "sessionID": "root-session", "data": { "type": "tool", "callID": "call-read", "tool": "read", "state": { "status": "error", "input": null, "error": "" } } },
+    { "id": "a1-06", "messageID": "root-assistant-1", "sessionID": "root-session", "data": { "type": "tool", "callID": "call-running", "tool": "write", "state": { "status": "running", "input": { "file": "ignored" } } } },
+    { "id": "a2-01", "messageID": "root-assistant-2", "sessionID": "root-session", "data": { "type": "text", "text": "Second answer" } },
+    { "id": "a2-02", "messageID": "root-assistant-2", "sessionID": "root-session", "data": { "type": "step-finish", "tokens": { "input": 100, "output": 20, "reasoning": 5, "cache": { "read": 10, "write": 2 } }, "cost": 0.01 } },
+    { "id": "a2-03", "messageID": "root-assistant-2", "sessionID": "root-session", "data": { "type": "step-finish", "tokens": { "input": 210, "output": 40, "reasoning": 10, "cache": { "read": 60, "write": 12 } }, "cost": 0.05 } },
+    { "id": "u2-01", "messageID": "root-user-2", "sessionID": "root-session", "data": { "type": "text", "text": "Delegate this" } },
+    { "id": "spawn-01", "messageID": "root-spawn", "sessionID": "root-session", "data": { "type": "tool", "callID": "call-task", "tool": "task", "state": { "status": "completed", "input": { "description": "child" }, "output": "started", "metadata": { "sessionId": "child-session" } } } },
+    { "id": "cu1-01", "messageID": "child-user-1", "sessionID": "child-session", "data": { "type": "text", "text": "Child prompt" } },
+    { "id": "ca1-01", "messageID": "child-assistant-1", "sessionID": "child-session", "data": { "type": "text", "text": "Child answer" } }
+  ]
+}

--- a/plugins/agento11y/internal/local/history.go
+++ b/plugins/agento11y/internal/local/history.go
@@ -252,7 +252,7 @@ func (s *Server) handleHistoryPlan(w http.ResponseWriter, r *http.Request) {
 
 // historyImportRequest is the body of POST /api/v1/history:import.
 //
-// SourcePaths names the sessions the user picked. They are matched against a
+// SourcePaths names the sources the user picked. They are matched against a
 // fresh discovery result rather than read directly: a plan can be minutes old,
 // and a path from it must not become a file the daemon reads on request.
 type historyImportRequest struct {
@@ -520,14 +520,15 @@ func selectHistorySessions(discovered []history.SessionPreview, sourcePaths []st
 			want[p] = true
 		}
 	}
-	selected := make([]history.SessionPreview, 0, len(want))
+	selected := make([]history.SessionPreview, 0, len(discovered))
+	seen := make(map[string]bool, len(want))
 	for _, sess := range discovered {
 		if want[sess.SourcePath] {
 			selected = append(selected, sess)
-			delete(want, sess.SourcePath)
+			seen[sess.SourcePath] = true
 		}
 	}
-	return selected, len(want)
+	return selected, len(want) - len(seen)
 }
 
 func (s *Server) handleHistoryRunStatus(w http.ResponseWriter, r *http.Request) {

--- a/plugins/agento11y/internal/local/history_test.go
+++ b/plugins/agento11y/internal/local/history_test.go
@@ -125,7 +125,11 @@ func TestHistoryAgentsEndpointComesFromTheRegistry(t *testing.T) {
 	for i, spec := range specs {
 		assert.Equal(t, string(spec.ID), got.Agents[i].ID)
 		assert.Equal(t, spec.DisplayName, got.Agents[i].DisplayName)
-		assert.Equal(t, spec.Aliases, got.Agents[i].Aliases)
+		wantAliases := spec.Aliases
+		if wantAliases == nil {
+			wantAliases = []string{}
+		}
+		assert.Equal(t, wantAliases, got.Agents[i].Aliases)
 	}
 }
 
@@ -393,6 +397,35 @@ func TestHistoryImportMatchesSelectionAgainstFreshDiscovery(t *testing.T) {
 	gone, err := srv.storage.ConversationDetail("sess-gone")
 	require.NoError(t, err)
 	assert.Nil(t, gone, "the unmatched session must not be imported")
+}
+
+func TestSelectHistorySessionsKeepsEverySessionFromASharedSource(t *testing.T) {
+	discovered := []history.SessionPreview{
+		{SessionID: "one", SourcePath: "/data/opencode.db"},
+		{SessionID: "two", SourcePath: "/data/opencode.db"},
+		{SessionID: "other", SourcePath: "/data/other.db"},
+	}
+	tests := []struct {
+		name        string
+		paths       []string
+		wantIDs     []string
+		wantMissing int
+	}{
+		{name: "shared source", paths: []string{"/data/opencode.db"}, wantIDs: []string{"one", "two"}},
+		{name: "missing source", paths: []string{"/data/opencode.db", "/data/gone.db"}, wantIDs: []string{"one", "two"}, wantMissing: 1},
+		{name: "duplicate source", paths: []string{"/data/opencode.db", "/data/opencode.db"}, wantIDs: []string{"one", "two"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			selected, missing := selectHistorySessions(discovered, tc.paths)
+			gotIDs := make([]string, len(selected))
+			for i, sess := range selected {
+				gotIDs[i] = sess.SessionID
+			}
+			assert.Equal(t, tc.wantIDs, gotIDs)
+			assert.Equal(t, tc.wantMissing, missing)
+		})
+	}
 }
 
 func TestHistoryImportPublishesProgressOverSSE(t *testing.T) {

--- a/plugins/agento11y/internal/skills/content/setup-coding-agent/SKILL.md
+++ b/plugins/agento11y/internal/skills/content/setup-coding-agent/SKILL.md
@@ -466,7 +466,7 @@ configured `AGENTO11Y_LOCAL`.
 ### History import
 
 Until an import runs, the viewer and Grafana Cloud hold only sessions captured after installation.
-`agento11y history import` backfills sessions `claude-code`, `codex`, `cursor`, or `pi` already wrote to disk.
+`agento11y history import` backfills sessions `claude-code`, `codex`, `cursor`, `opencode`, or `pi` already wrote to disk.
 
 ```sh
 agento11y history import claude-code --dry-run   # plan only; no setup or export

--- a/plugins/opencode/src/mappers.test.ts
+++ b/plugins/opencode/src/mappers.test.ts
@@ -17,7 +17,7 @@ import {
 const redactor = createRedactor();
 
 // A syntactically valid Grafana Cloud token that matches the tier-1 pattern.
-const GRAFANA_CLOUD_TOKEN = "glc_abcdefghijklmnopqrstuvwxyz0123456789";
+const GRAFANA_CLOUD_TOKEN = "glc_abcdefghijklmnopqrstuvwxyz0123456789"; // trufflehog:ignore
 
 function makeAssistantMsg(
   overrides?: Partial<AssistantMessage>,
@@ -132,7 +132,7 @@ describe("mapInputMessages", () => {
     expect(mapInputMessages(parts, redactor)).toHaveLength(0);
   });
 
-  it("skips text parts with empty or whitespace-only text", () => {
+  it("skips empty and ignored text parts", () => {
     const parts = [
       {
         id: "p1",
@@ -157,6 +157,14 @@ describe("mapInputMessages", () => {
       },
       {
         id: "p4",
+        sessionID: "s1",
+        messageID: "m1",
+        type: "text" as const,
+        text: "user only",
+        ignored: true,
+      },
+      {
+        id: "p5",
         sessionID: "s1",
         messageID: "m1",
         type: "text" as const,
@@ -251,6 +259,51 @@ describe("mapOutputMessages", () => {
     expect(result[1].parts?.[0].type).toBe("tool_result");
     const toolResult = (result[1].parts?.[0] as any).toolResult;
     expect(toolResult.content).toBe("test output");
+  });
+
+  it.each([
+    {
+      name: "invalid tool",
+      tool: "invalid",
+      metadata: {},
+      wantError: true,
+    },
+    {
+      name: "failed bash",
+      tool: "bash",
+      metadata: { exit: 1 },
+      wantError: true,
+    },
+    {
+      name: "successful bash",
+      tool: "bash",
+      metadata: { exit: 0 },
+      wantError: false,
+    },
+  ])("classifies $name results", ({ tool, metadata, wantError }) => {
+    const parts = [
+      {
+        id: "p1",
+        sessionID: "s1",
+        messageID: "m1",
+        type: "tool" as const,
+        callID: "call-1",
+        tool,
+        state: {
+          status: "completed" as const,
+          input: {},
+          output: "output",
+          title: "Tool",
+          metadata,
+          time: { start: 1000, end: 2000 },
+        },
+      },
+    ] as Part[];
+
+    const result = mapOutputMessages(parts, redactor);
+    const toolResult = (result[1].parts?.[0] as any).toolResult;
+    expect(Boolean(toolResult.isError)).toBe(wantError);
+    expect(toolResult.content).toBe("output");
   });
 
   it("keeps message text but omits tool bodies in no_tool_content mode", () => {

--- a/plugins/opencode/src/mappers.ts
+++ b/plugins/opencode/src/mappers.ts
@@ -29,9 +29,19 @@ function includesToolBodies(contentCapture: ContentCaptureMode): boolean {
   );
 }
 
+function completedToolFailed(tool: string, metadata: unknown): boolean {
+  if (tool === "invalid") return true;
+  if (tool !== "bash" || !metadata || typeof metadata !== "object") {
+    return false;
+  }
+  const exit = (metadata as Record<string, unknown>).exit;
+  return typeof exit === "number" && exit !== 0;
+}
+
 /**
- * Map user-side parts to agento11y input messages. A caller that ran a
- * preflight redact rule substitutes the rewritten text before calling this.
+ * Map user-side parts to agento11y input messages. Ignored text is user-only
+ * and never reaches the model. A caller that ran a preflight redact rule
+ * substitutes the rewritten text before calling this.
  *
  * Separately, user text gets tier 1 + tier 2 redaction when
  * `redactInputMessages` is on, which is the default. A prompt is where a
@@ -51,7 +61,11 @@ export function mapInputMessages(
 
   const messages: Message[] = [];
   for (const part of parts) {
-    if (part.type === "text" && part.text.trim().length > 0) {
+    if (
+      part.type === "text" &&
+      part.ignored !== true &&
+      part.text.trim().length > 0
+    ) {
       const text = redactInputMessages ? redactor.redact(part.text) : part.text;
       messages.push({
         role: "user",
@@ -127,6 +141,9 @@ export function mapOutputMessages(
                   content: includeToolBodies
                     ? redactor.redact(state.output ?? "")
                     : "",
+                  ...(completedToolFailed(part.tool, state.metadata)
+                    ? { isError: true }
+                    : {}),
                 },
               },
             ],


### PR DESCRIPTION
Support history import from OpenCode:

```
agento11y history import opencode --local --all --yes --since 2d

OpenCode history since 2026-08-22T13:57:18+02:00
  planned: 1 sessions, 3 turns
  skipped: 183 sessions (out_of_range: 183)
importing opencode: session 1/1  imported 3  skipped 0  failed 0
Imported 3 turns from 1 sessions (0 already imported, 0 failed).
```