### PR TITLE
fix(cursor): persist hook model_params as generation tags

### DIFF
--- a/docs/concepts/tags-and-metadata.md
+++ b/docs/concepts/tags-and-metadata.md
@@ -108,6 +108,7 @@ The coding-agent plugins (claude-code, codex, copilot, cursor, opencode, pi, vib
 | `cwd` | Working directory of the session. For pi, the directory pi was launched from, which can be a subdirectory of the repo. | all launchers |
 | `git.branch` | Branch checked out in that directory, or a short commit SHA when HEAD is detached. Omitted outside a git checkout. | all launchers |
 | `subagent` | `"true"` on generations from a subagent run. Absent otherwise, never `"false"`. | claude-code, codex, cursor, opencode |
+| `model_param.<id>` | One of the model parameters selected for the turn, such as `model_param.optimize_for` (`cost` / `balanced` / `intelligence`) for an Auto turn, or `model_param.thinking`. The set of ids is Cursor's, not ours. Absent when the host sends no parameters. | cursor |
 | `pi.call_kind` | The host made this model call outside a user turn: `compaction` for context compaction, `branch_summary` for a tree-navigation summary. Absent on ordinary turns. | pi |
 
 Launchers also set a few keys specific to one host, so this table is not the full list of what arrives on a generation.

--- a/plugins/agento11y/internal/agents/cursor/fragment/fragment.go
+++ b/plugins/agento11y/internal/agents/cursor/fragment/fragment.go
@@ -67,6 +67,10 @@ type Fragment struct {
 	LastEventAt     string             `json:"lastEventAt,omitempty"`
 	Model           string             `json:"model,omitempty"`
 	Provider        string             `json:"provider,omitempty"`
+	// ModelParams is Cursor's `model_params` flattened to id -> value
+	// (optimize_for, thinking, effort, ...). Accumulated across the turn's
+	// events and exported as `model_param.<id>` tags.
+	ModelParams map[string]string `json:"modelParams,omitempty"`
 
 	// PendingStop is set by handleStop before it tries to emit. If emission
 	// fails the fragment stays on disk with this set so sessionEnd can replay

--- a/plugins/agento11y/internal/agents/cursor/hook/afterresponse.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/afterresponse.go
@@ -41,6 +41,7 @@ func AfterAgentResponse(p Payload, cfg config.Config, logger *log.Logger) {
 		if provider := strings.TrimSpace(p.Provider); provider != "" {
 			f.Provider = provider
 		}
+		applyModelParams(f, p)
 		if keepText && p.Text != "" {
 			f.Assistant = append(f.Assistant, fragment.AssistantSegment{Text: p.Text, Timestamp: ts})
 		}

--- a/plugins/agento11y/internal/agents/cursor/hook/model.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/model.go
@@ -1,6 +1,7 @@
 package hook
 
 import (
+	"encoding/json"
 	"regexp"
 	"strings"
 
@@ -36,9 +37,75 @@ func resolvedModel(p Payload) string {
 	return strings.TrimSpace(p.ModelID)
 }
 
-// applyModelMeta copies model and provider onto the fragment when the
-// fragment still lacks them. Returns true when either field was filled so
-// callers can decide whether to rewrite.
+// maxModelParamLen bounds both the id and the value of a model param. They
+// become generation tags, and tags become metric attributes, so an unexpected
+// long value must not turn into unbounded metric cardinality.
+const maxModelParamLen = 64
+
+// modelParamID matches the ids Cursor documents (optimize_for, thinking,
+// context, effort). Anything outside this shape is skipped rather than
+// promoted to a tag key.
+var modelParamID = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
+
+// modelParams flattens the payload's model_params list into id -> value.
+// Values arrive as JSON strings today; a non-string is kept as its raw JSON
+// literal so a schema change degrades to a slightly uglier tag rather than to
+// no tag at all. Returns nil when nothing usable is present.
+func modelParams(p Payload) map[string]string {
+	if len(p.ModelParams) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(p.ModelParams))
+	for _, mp := range p.ModelParams {
+		id := strings.TrimSpace(mp.ID)
+		if id == "" || len(id) > maxModelParamLen || !modelParamID.MatchString(id) {
+			continue
+		}
+		value := strings.TrimSpace(string(mp.Value))
+		if value == "" || value == "null" {
+			continue
+		}
+		var asString string
+		if err := json.Unmarshal(mp.Value, &asString); err == nil {
+			value = strings.TrimSpace(asString)
+		}
+		if value == "" || len(value) > maxModelParamLen {
+			continue
+		}
+		out[id] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// applyModelParams merges the payload's model_params onto the fragment. Later
+// events win per id, but an event that carries no params never clears what an
+// earlier one stored — preToolUse-only turns would otherwise lose them.
+// Returns true when the fragment changed.
+func applyModelParams(f *fragment.Fragment, p Payload) bool {
+	params := modelParams(p)
+	if len(params) == 0 {
+		return false
+	}
+	changed := false
+	for id, value := range params {
+		if f.ModelParams[id] == value {
+			continue
+		}
+		if f.ModelParams == nil {
+			f.ModelParams = make(map[string]string, len(params))
+		}
+		f.ModelParams[id] = value
+		changed = true
+	}
+	return changed
+}
+
+// applyModelMeta copies model, provider, and model params onto the fragment
+// when the fragment still lacks them. Returns true when any field was filled
+// so callers can decide whether to rewrite.
 func applyModelMeta(f *fragment.Fragment, p Payload) bool {
 	changed := false
 	if model := resolvedModel(p); model != "" && f.Model == "" {
@@ -47,6 +114,9 @@ func applyModelMeta(f *fragment.Fragment, p Payload) bool {
 	}
 	if provider := strings.TrimSpace(p.Provider); provider != "" && f.Provider == "" {
 		f.Provider = provider
+		changed = true
+	}
+	if applyModelParams(f, p) {
 		changed = true
 	}
 	return changed
@@ -66,4 +136,5 @@ func applyStopModel(frag *fragment.Fragment, p Payload) {
 	if provider := strings.TrimSpace(p.Provider); provider != "" {
 		frag.Provider = provider
 	}
+	applyModelParams(frag, p)
 }

--- a/plugins/agento11y/internal/agents/cursor/hook/model_test.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/model_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -289,5 +290,94 @@ func TestEmitOneStrandedDropsThoughtOnly(t *testing.T) {
 	}
 	if len(entries) == 0 {
 		t.Fatal("conversation dir emptied unexpectedly")
+	}
+}
+
+func TestModelParams(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []ModelParam
+		want map[string]string
+	}{
+		{
+			name: "auto routing mode",
+			in:   []ModelParam{{ID: "optimize_for", Value: []byte(`"balanced"`)}},
+			want: map[string]string{"optimize_for": "balanced"},
+		},
+		{
+			name: "multiple params",
+			in: []ModelParam{
+				{ID: "optimize_for", Value: []byte(`"intelligence"`)},
+				{ID: "thinking", Value: []byte(`"high"`)},
+			},
+			want: map[string]string{"optimize_for": "intelligence", "thinking": "high"},
+		},
+		{
+			name: "non-string value keeps its JSON literal",
+			in:   []ModelParam{{ID: "thinking", Value: []byte(`true`)}},
+			want: map[string]string{"thinking": "true"},
+		},
+		{
+			name: "empty list",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "blank id, null and empty values are dropped",
+			in: []ModelParam{
+				{ID: "  ", Value: []byte(`"x"`)},
+				{ID: "context", Value: []byte(`null`)},
+				{ID: "effort", Value: []byte(`""`)},
+			},
+			want: nil,
+		},
+		{
+			name: "id outside the documented shape is dropped",
+			in:   []ModelParam{{ID: "opt for/you", Value: []byte(`"cost"`)}},
+			want: nil,
+		},
+		{
+			name: "oversized value is dropped",
+			in:   []ModelParam{{ID: "effort", Value: []byte(`"` + strings.Repeat("x", maxModelParamLen+1) + `"`)}},
+			want: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := modelParams(Payload{ModelParams: tc.in})
+			if len(got) != len(tc.want) {
+				t.Fatalf("modelParams = %v; want %v", got, tc.want)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Errorf("modelParams[%q] = %q; want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestApplyModelParamsKeepsEarlierParams(t *testing.T) {
+	frag := &fragment.Fragment{}
+	if !applyModelParams(frag, Payload{ModelParams: []ModelParam{{ID: "optimize_for", Value: []byte(`"cost"`)}}}) {
+		t.Fatal("first apply should report a change")
+	}
+	// A later event without model_params must not clear what we already have.
+	if applyModelParams(frag, Payload{}) {
+		t.Error("apply with no params should report no change")
+	}
+	if frag.ModelParams["optimize_for"] != "cost" {
+		t.Fatalf("ModelParams = %v; want optimize_for preserved", frag.ModelParams)
+	}
+	// Re-applying the same value is not a change, but a new value wins.
+	if applyModelParams(frag, Payload{ModelParams: []ModelParam{{ID: "optimize_for", Value: []byte(`"cost"`)}}}) {
+		t.Error("re-applying an identical value should report no change")
+	}
+	applyStopModel(frag, Payload{Model: "auto-smart", ModelParams: []ModelParam{{ID: "optimize_for", Value: []byte(`"intelligence"`)}}})
+	if frag.ModelParams["optimize_for"] != "intelligence" {
+		t.Fatalf("ModelParams = %v; want stop's value to win", frag.ModelParams)
+	}
+	if frag.Model != "auto-smart" {
+		t.Fatalf("Model = %q; want auto-smart slug untouched by model params", frag.Model)
 	}
 }

--- a/plugins/agento11y/internal/agents/cursor/hook/payload.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/payload.go
@@ -32,14 +32,15 @@ type Payload struct {
 	Prompt string `json:"prompt"`
 
 	// afterAgentResponse / stop / common schema
-	Text             string `json:"text"`
-	Model            string `json:"model"`
-	ModelID          string `json:"model_id"`
-	Provider         string `json:"provider"`
-	InputTokens      *int64 `json:"input_tokens"`
-	OutputTokens     *int64 `json:"output_tokens"`
-	CacheReadTokens  *int64 `json:"cache_read_tokens"`
-	CacheWriteTokens *int64 `json:"cache_write_tokens"`
+	Text             string       `json:"text"`
+	Model            string       `json:"model"`
+	ModelID          string       `json:"model_id"`
+	ModelParams      []ModelParam `json:"model_params"`
+	Provider         string       `json:"provider"`
+	InputTokens      *int64       `json:"input_tokens"`
+	OutputTokens     *int64       `json:"output_tokens"`
+	CacheReadTokens  *int64       `json:"cache_read_tokens"`
+	CacheWriteTokens *int64       `json:"cache_write_tokens"`
 
 	// postToolUse(Failure)
 	ToolName   string          `json:"tool_name"`
@@ -52,6 +53,18 @@ type Payload struct {
 
 	// stop / postToolUseFailure: error is `string | {message,code}`
 	Error json.RawMessage `json:"error"`
+}
+
+// ModelParam is one entry of Cursor's common-schema `model_params` list: the
+// parameters selected for the composer, such as thinking, context, effort,
+// and Auto's optimize_for.
+//
+// Value is documented as a string but decoded raw: the dispatcher drops the
+// whole event when json.Unmarshal fails, so a future bool/number value here
+// must not cost us the turn's telemetry.
+type ModelParam struct {
+	ID    string          `json:"id"`
+	Value json.RawMessage `json:"value"`
 }
 
 // Timestamp returns the payload timestamp, falling back to the current time

--- a/plugins/agento11y/internal/agents/cursor/hook/pretooluse.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/pretooluse.go
@@ -82,7 +82,7 @@ func persistModelFromPreToolUse(p Payload, logger *log.Logger) {
 	if p.ConversationID == "" || p.GenerationID == "" {
 		return
 	}
-	if resolvedModel(p) == "" && strings.TrimSpace(p.Provider) == "" {
+	if resolvedModel(p) == "" && strings.TrimSpace(p.Provider) == "" && len(p.ModelParams) == 0 {
 		return
 	}
 	ts := p.ResolvedTimestamp()

--- a/plugins/agento11y/internal/agents/cursor/mapper/mapper.go
+++ b/plugins/agento11y/internal/agents/cursor/mapper/mapper.go
@@ -127,6 +127,7 @@ func MapFragment(in Inputs) Mapped {
 		Cwd:               firstToolCwd(frag.Tools),
 		GitBranch:         gitbranch.Resolve(workspaceRoot),
 		IsBackgroundAgent: isBackgroundAgent,
+		ModelParams:       frag.ModelParams,
 	})
 
 	uid := resolveUserID(in.UserIDOverride, userEmail)

--- a/plugins/agento11y/internal/agents/cursor/mapper/mapper_test.go
+++ b/plugins/agento11y/internal/agents/cursor/mapper/mapper_test.go
@@ -735,6 +735,26 @@ func TestMapFragment_BuiltinTags(t *testing.T) {
 	}
 }
 
+// Auto turns all report the same auto-smart slug, so the routing mode has to
+// reach the export as a tag or the turns are indistinguishable.
+func TestMapFragment_ModelParamTags(t *testing.T) {
+	frag := basicFragment(t)
+	frag.Model = "auto-smart"
+	frag.ModelParams = map[string]string{"optimize_for": "balanced"}
+
+	got := MapFragment(Inputs{Fragment: frag, Now: fixedTime})
+
+	if got.Generation.Tags["model_param.optimize_for"] != "balanced" {
+		t.Fatalf("tags = %v; want model_param.optimize_for=balanced", got.Generation.Tags)
+	}
+	if got.Start.Tags["model_param.optimize_for"] != "balanced" {
+		t.Errorf("start tags = %v; want the same model_param tag", got.Start.Tags)
+	}
+	if got.Generation.ResponseModel != "auto-smart" {
+		t.Errorf("ResponseModel = %q; model params must not rewrite the slug", got.Generation.ResponseModel)
+	}
+}
+
 func TestMapFragment_TokenUsage(t *testing.T) {
 	in, out := int64(100), int64(50)
 	frag := basicFragment(t)

--- a/plugins/agento11y/internal/agents/cursor/tags/tags.go
+++ b/plugins/agento11y/internal/agents/cursor/tags/tags.go
@@ -11,6 +11,10 @@ type BuiltinInputs struct {
 	Entrypoint        string
 	GitBranch         string
 	IsBackgroundAgent bool
+	// ModelParams is Cursor's `model_params`, id -> value. Each becomes a
+	// `model_param.<id>` tag, so Auto turns — which all report the same
+	// auto-smart slug — stay distinguishable by their routing mode.
+	ModelParams map[string]string
 }
 
 // Build returns the per-generation built-in tags. SIGIL_TAGS-supplied values
@@ -34,6 +38,12 @@ func Build(in BuiltinInputs) map[string]string {
 	}
 	if in.IsBackgroundAgent {
 		out["subagent"] = "true"
+	}
+	for id, value := range in.ModelParams {
+		if id == "" || value == "" {
+			continue
+		}
+		out["model_param."+id] = value
 	}
 	if len(out) == 0 {
 		return nil

--- a/plugins/agento11y/internal/agents/cursor/tags/tags_test.go
+++ b/plugins/agento11y/internal/agents/cursor/tags/tags_test.go
@@ -34,6 +34,33 @@ func TestBuild(t *testing.T) {
 			},
 		},
 		{
+			name: "model params become model_param tags",
+			in: BuiltinInputs{
+				WorkspaceRoot: "/ws",
+				ModelParams:   map[string]string{"optimize_for": "balanced", "thinking": "high"},
+			},
+			check: func(t *testing.T, got map[string]string) {
+				if got["model_param.optimize_for"] != "balanced" {
+					t.Errorf("model_param.optimize_for = %q; want balanced", got["model_param.optimize_for"])
+				}
+				if got["model_param.thinking"] != "high" {
+					t.Errorf("model_param.thinking = %q; want high", got["model_param.thinking"])
+				}
+			},
+		},
+		{
+			name: "empty model param values are skipped",
+			in: BuiltinInputs{
+				WorkspaceRoot: "/ws",
+				ModelParams:   map[string]string{"optimize_for": ""},
+			},
+			check: func(t *testing.T, got map[string]string) {
+				if _, ok := got["model_param.optimize_for"]; ok {
+					t.Error("empty model param value should not produce a tag")
+				}
+			},
+		},
+		{
 			name: "no inputs returns nil",
 			in:   BuiltinInputs{},
 			check: func(t *testing.T, got map[string]string) {

--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -94,6 +94,8 @@ Captured prompt, assistant, and tool content is redacted before export.
 
 Use Cursor's agent for one turn, then open **Agent Observability → Conversations** in Grafana Cloud. A new generation should appear within a few seconds.
 
+Cursor's selected model parameters are exported as `model_param.<id>` tags. Auto turns all report the same model slug, so the routing mode you picked shows up as `model_param.optimize_for` (`cost`, `balanced`, or `intelligence`). The model the router actually chose is not in the hook payload, so it is not exported.
+
 If nothing shows up, add `AGENTO11Y_DEBUG=true` to `~/.config/agento11y/config.env` (Cursor launches from the GUI, so a shell env var won't reach the hooks) and tail the log:
 
 ```sh
@@ -129,7 +131,7 @@ Each message can wait up to `AGENTO11Y_GUARDS_TIMEOUT_MS` (1500 ms by default) b
 | `AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP endpoint. Without it, the Agent Observability latency and tool-call panels stay empty. |
 | `AGENTO11Y_OTEL_AUTH_TOKEN` | `AGENTO11Y_AUTH_TOKEN` | Override the OTel password. |
 | `AGENTO11Y_CONTENT_CAPTURE_MODE` | `metadata_only` | `metadata_only`, `no_tool_content`, `full`, or `full_with_metadata_spans`. See [Content Capture Modes](../../docs/concepts/content-capture-modes.md). |
-| `AGENTO11Y_TAGS` | — | `key=value,key=value` tags on every generation and as `agento11y.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). Built-ins (`git.branch`, `cwd`, `subagent`) win on generation-export tag collision. |
+| `AGENTO11Y_TAGS` | — | `key=value,key=value` tags on every generation and as `agento11y.tag.<key>` on OTel spans/metrics (e.g. `project=my-app`). Built-ins (`git.branch`, `cwd`, `subagent`, `model_param.<id>`) win on generation-export tag collision. |
 | `AGENTO11Y_AUTO_CODING_AGENT_TAGS` | `false` | Opt in to client tags resolved for the session: the user, the repository, and the branch. Unlike the built-ins, these reach OTel metrics as `agento11y_tag_*` labels. See [Tags and Metadata](../../docs/concepts/tags-and-metadata.md#opt-in-automatic-tags-agento11y_auto_coding_agent_tags) for the cardinality and personal-data trade-offs. |
 | `AGENTO11Y_AUTO_CODING_AGENT_TAGS_NAMES` | all names | Narrows the switch above to a comma-separated subset of `user`, `repo`, `branch` (`all` is also accepted). Does nothing while the switch is off. |
 | `AGENTO11Y_USER_ID` | from Cursor | Override the user id. |


### PR DESCRIPTION
Fixes #658.

Cursor's [common hook schema](https://cursor.com/docs/agent/hooks) sends `model_params: [{id, value}]` on every event — "Selected model parameters, such as thinking, context, or effort." The plugin only decoded `model` and `model_id`, so those parameters never reached the export.

The case that motivated this is [Cursor Router](https://cursor.com/docs/cursor-router) (Auto mode): its `optimize_for` setting (`cost` / `balanced` / `intelligence`) changes both routing and billing — per the docs, Balance and Intelligence bill per request at the routed model's rate and cost roughly 2x Cost — but every Auto turn exported the same model slug, so the modes were indistinguishable in Agent Observability.

## What this does

Flattens `model_params` onto the turn fragment and exports each entry as a `model_param.<id>` generation tag. Auto turns now split by `model_param.optimize_for`.

Cursor plugin only — no proto, SDK, or shared-binary behavior change, so the other launchers are untouched.

## Notes on the implementation

**`value` is decoded as `json.RawMessage`, not `string`.** The dispatcher discards the entire event when `json.Unmarshal` fails, so a `value` that ever arrives as a bool or number would cost the turn all of its telemetry, not just the parameter. A non-string is kept as its raw JSON literal instead.

**Ids and values are bounded before becoming tag keys.** Ids must match `^[a-zA-Z0-9_.-]+$`, and both id and value are capped at 64 chars. Generation tags reach metrics as attributes, so an unexpected value shouldn't turn into unbounded cardinality.

**Merge, never clear.** `model_params` is on the common schema, so it arrives on several events per turn. A later event that carries none leaves what an earlier one stored intact — otherwise a tool-heavy turn that ends on `preToolUse` would lose them.

**`model_params` never rewrites `model` / `response_model`.** The composer slug is still the only thing that sets those.

## Not included

The model the router actually resolved to. It isn't in the hook payload.

## Tests

- `hook`: 7 parsing cases (string value, multiple params, non-string literal, empty list, blank id / `null` / empty value, malformed id, oversized value), plus merge and stop-precedence behavior.
- `tags`: `model_param.<id>` emission and empty-value skip.
- `mapper`: end-to-end — tag on both the start seed and the generation, and `response_model` left as `auto-smart`.
- `README`: one paragraph under Verify, plus the built-in tag list.

`go vet ./...` and `go test ./...` clean for `plugins/agento11y`.
