### PR TITLE
feat(sdk): add skill-load markers

### DIFF
--- a/dotnet/src/Grafana.Agento11y/Agento11yClient.cs
+++ b/dotnet/src/Grafana.Agento11y/Agento11yClient.cs
@@ -50,6 +50,7 @@ public sealed partial class Agento11yClient : IAsyncDisposable
     internal const string SpanAttrToolCallId = "gen_ai.tool.call.id";
     internal const string SpanAttrToolType = "gen_ai.tool.type";
     internal const string SpanAttrToolDescription = "gen_ai.tool.description";
+    internal const string SpanAttrSkillName = "agento11y.skill.name";
     internal const string SpanAttrToolCallArguments = "gen_ai.tool.call.arguments";
     internal const string SpanAttrToolCallResult = "gen_ai.tool.call.result";
     internal const string SpanAttrTagPrefix = "agento11y.tag.";
@@ -1441,6 +1442,8 @@ public sealed partial class Agento11yClient : IAsyncDisposable
             activity.SetTag(SpanAttrToolDescription, tool.ToolDescription);
         }
 
+        ApplySkillNameSpanAttribute(activity, tool.SkillName);
+
         if (!string.IsNullOrWhiteSpace(tool.ConversationId))
         {
             activity.SetTag(SpanAttrConversationId, tool.ConversationId);
@@ -1467,6 +1470,15 @@ public sealed partial class Agento11yClient : IAsyncDisposable
         if (!string.IsNullOrWhiteSpace(tool.RequestModel))
         {
             activity.SetTag(SpanAttrRequestModel, tool.RequestModel);
+        }
+    }
+
+    private static void ApplySkillNameSpanAttribute(Activity activity, string? skillName)
+    {
+        var projected = skillName?.Trim();
+        if (!string.IsNullOrEmpty(projected))
+        {
+            activity.SetTag(SpanAttrSkillName, projected);
         }
     }
 

--- a/dotnet/src/Grafana.Agento11y/Models.cs
+++ b/dotnet/src/Grafana.Agento11y/Models.cs
@@ -349,6 +349,7 @@ public sealed class ToolExecutionStart
     public string ToolCallId { get; set; } = string.Empty;
     public string ToolType { get; set; } = string.Empty;
     public string ToolDescription { get; set; } = string.Empty;
+    public string? SkillName { get; set; }
     public string ConversationId { get; set; } = string.Empty;
     public string ConversationTitle { get; set; } = string.Empty;
     public string AgentName { get; set; } = string.Empty;

--- a/dotnet/tests/Grafana.Agento11y.Tests/ConformanceTests.cs
+++ b/dotnet/tests/Grafana.Agento11y.Tests/ConformanceTests.cs
@@ -460,6 +460,7 @@ public sealed class ConformanceTests
             ToolName = "weather",
             ToolCallId = "call-weather-1",
             ToolType = "function",
+            SkillName = "  code-review  ",
             RequestProvider = "openai",
             RequestModel = "gpt-5",
             ContentCapture = ContentCaptureMode.Full,
@@ -486,6 +487,7 @@ public sealed class ConformanceTests
         Assert.Equal("weather", span.GetTagItem("gen_ai.tool.name"));
         Assert.Equal("call-weather-1", span.GetTagItem("gen_ai.tool.call.id"));
         Assert.Equal("function", span.GetTagItem("gen_ai.tool.type"));
+        Assert.Equal("code-review", span.GetTagItem("agento11y.skill.name")?.ToString());
         Assert.Contains("Paris", span.GetTagItem("gen_ai.tool.call.arguments")?.ToString());
         Assert.Contains("sunny", span.GetTagItem("gen_ai.tool.call.result")?.ToString());
         Assert.Equal("openai", span.GetTagItem("gen_ai.provider.name")?.ToString());
@@ -495,6 +497,73 @@ public sealed class ConformanceTests
         Assert.Equal("v-context", span.GetTagItem("gen_ai.agent.version")?.ToString());
         Assert.Contains("gen_ai.client.operation.duration", env.MetricNames);
         Assert.DoesNotContain("gen_ai.client.time_to_first_token", env.MetricNames);
+        var durationMeasurements = env.MetricMeasurements
+            .Where(measurement =>
+                string.Equals(measurement.Name, "gen_ai.client.operation.duration", StringComparison.Ordinal)
+                && measurement.Tags.TryGetValue("gen_ai.operation.name", out var operation)
+                && string.Equals(operation?.ToString(), "execute_tool", StringComparison.Ordinal))
+            .ToList();
+        Assert.NotEmpty(durationMeasurements);
+        Assert.All(durationMeasurements, measurement =>
+            Assert.False(measurement.Tags.ContainsKey("agento11y.skill.name")));
+    }
+
+    [Theory]
+    [InlineData(null, null, false)]
+    [InlineData(" \t\r\n ", null, false)]
+    [InlineData("  failure-recovery  ", "failure-recovery", true)]
+    public async Task ToolExecutionSkillMarkerSemantics(string? skillName, string? expected, bool failed)
+    {
+        await using var env = new ConformanceEnv();
+        var start = new ToolExecutionStart
+        {
+            ToolName = "skill-marker-tool",
+        };
+        if (skillName != null)
+        {
+            start.SkillName = skillName;
+        }
+
+        var recorder = env.Client.StartToolExecution(start);
+        if (failed)
+        {
+            recorder.SetExecutionError(new InvalidOperationException("tool failed"));
+        }
+        recorder.End();
+
+        await env.ShutdownAsync();
+
+        var span = env.OperationSpan("execute_tool");
+        Assert.Equal("execute_tool", span.GetTagItem("gen_ai.operation.name"));
+        if (expected == null)
+        {
+            Assert.DoesNotContain("agento11y.skill.name", span.TagObjects.Select(tag => tag.Key));
+        }
+        else
+        {
+            Assert.Equal(expected, span.GetTagItem("agento11y.skill.name")?.ToString());
+        }
+        Assert.Equal(failed ? ActivityStatusCode.Error : ActivityStatusCode.Ok, span.Status);
+    }
+
+    [Fact]
+    public async Task ToolExecutionStartDeepCloneIsolatesSkillName()
+    {
+        await using var env = new ConformanceEnv();
+        var start = new ToolExecutionStart
+        {
+            ToolName = "isolated-tool",
+            SkillName = "original-skill",
+        };
+
+        var recorder = env.Client.StartToolExecution(start);
+        start.SkillName = "mutated-after-start";
+        recorder.End();
+
+        await env.ShutdownAsync();
+
+        var span = env.OperationSpan("execute_tool");
+        Assert.Equal("original-skill", span.GetTagItem("agento11y.skill.name")?.ToString());
     }
 
     [Fact]

--- a/dotnet/tests/Grafana.Agento11y.Tests/ContentCaptureModeTests.cs
+++ b/dotnet/tests/Grafana.Agento11y.Tests/ContentCaptureModeTests.cs
@@ -1381,6 +1381,7 @@ public sealed class ContentCaptureModeTests
         {
             ToolName = "weather",
             ToolCallId = "call_1",
+            SkillName = "  weather-lookup  ",
             ConversationTitle = "Sensitive tool title",
             ToolDescription = "Get weather: free-form provider-supplied text",
             IncludeContent = true,
@@ -1402,6 +1403,7 @@ public sealed class ContentCaptureModeTests
         Assert.Null(span.GetTagItem("gen_ai.tool.description"));
         // Identity attributes still emitted.
         Assert.Equal("weather", span.GetTagItem("gen_ai.tool.name")?.ToString());
+        Assert.Equal("weather-lookup", span.GetTagItem("agento11y.skill.name")?.ToString());
     }
 
     // Tools have no proto export; under both stripped modes the raw provider

--- a/go/agento11y/client.go
+++ b/go/agento11y/client.go
@@ -276,6 +276,7 @@ const (
 	spanAttrToolCallID             = "gen_ai.tool.call.id"
 	spanAttrToolType               = "gen_ai.tool.type"
 	spanAttrToolDescription        = contentcapture.ToolDescriptionAttributeKey
+	spanAttrSkillName              = "agento11y.skill.name"
 	spanAttrToolCallArguments      = contentcapture.ToolCallArgumentsAttributeKey
 	spanAttrToolCallResult         = contentcapture.ToolCallResultAttributeKey
 	spanAttrTagPrefix              = "agento11y.tag."
@@ -2476,6 +2477,7 @@ func toolSpanAttributes(start ToolExecutionStart) []attribute.KeyValue {
 		attribute.String(spanAttrToolName, start.ToolName),
 		attribute.String(sdkMetadataKeyName, sdkName),
 	}
+	attrs = appendSkillNameAttribute(attrs, start.SkillName)
 
 	if callID := strings.TrimSpace(start.ToolCallID); callID != "" {
 		attrs = append(attrs, attribute.String(spanAttrToolCallID, callID))
@@ -2505,6 +2507,13 @@ func toolSpanAttributes(start ToolExecutionStart) []attribute.KeyValue {
 		attrs = append(attrs, attribute.String(spanAttrRequestModel, model))
 	}
 
+	return attrs
+}
+
+func appendSkillNameAttribute(attrs []attribute.KeyValue, skillName string) []attribute.KeyValue {
+	if skillName = strings.TrimSpace(skillName); skillName != "" {
+		attrs = append(attrs, attribute.String(spanAttrSkillName, skillName))
+	}
 	return attrs
 }
 

--- a/go/agento11y/client_test.go
+++ b/go/agento11y/client_test.go
@@ -1176,6 +1176,45 @@ func TestStartToolExecutionSetsExecuteToolAttributes(t *testing.T) {
 	}
 }
 
+const testSkillNameAttributeKey = "agento11y.skill.name"
+
+func TestToolExecutionSkillNameAttribute(t *testing.T) {
+	tests := []struct {
+		name      string
+		skillName string
+		want      string
+	}{
+		{name: "populated is trimmed", skillName: " code-review ", want: "code-review"},
+		{name: "omitted"},
+		{name: "whitespace omitted", skillName: " \t\n "},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client, recorder, _ := newTestClient(t, Config{})
+			_, toolRecorder := client.StartToolExecution(context.Background(), ToolExecutionStart{
+				ToolName:  "weather",
+				SkillName: tc.skillName,
+			})
+			toolRecorder.End()
+			if err := toolRecorder.Err(); err != nil {
+				t.Fatalf("end tool execution: %v", err)
+			}
+
+			attrs := spanAttributeMap(onlyToolSpan(t, recorder.Ended()))
+			if tc.want == "" {
+				if _, ok := attrs[testSkillNameAttributeKey]; ok {
+					t.Fatalf("did not expect %s for skill name %q", testSkillNameAttributeKey, tc.skillName)
+				}
+				return
+			}
+			if got := attrs[testSkillNameAttributeKey].AsString(); got != tc.want {
+				t.Fatalf("expected %s=%q, got %q", testSkillNameAttributeKey, tc.want, got)
+			}
+		})
+	}
+}
+
 func TestToolExecutionRecorderContentCapture(t *testing.T) {
 	// Backward compat: Config{} with IncludeContent controls tool content.
 	client, recorder, _ := newTestClient(t, Config{})
@@ -1233,7 +1272,8 @@ func TestToolExecutionRecorderContentCapture(t *testing.T) {
 func TestToolExecutionRecorderErrorSetsStatusAndType(t *testing.T) {
 	client, recorder, _ := newTestClient(t, Config{})
 	_, toolRecorder := client.StartToolExecution(context.Background(), ToolExecutionStart{
-		ToolName: "weather",
+		ToolName:  "weather",
+		SkillName: " code-review ",
 	})
 
 	toolRecorder.SetExecError(errors.New("tool failed"))
@@ -1250,6 +1290,12 @@ func TestToolExecutionRecorderErrorSetsStatusAndType(t *testing.T) {
 	attrs := spanAttributeMap(span)
 	if attrs[spanAttrErrorType].AsString() != "tool_execution_error" {
 		t.Fatalf("expected error.type=tool_execution_error")
+	}
+	if attrs[spanAttrErrorCategory].AsString() != "sdk_error" {
+		t.Fatalf("expected error.category=sdk_error")
+	}
+	if attrs[testSkillNameAttributeKey].AsString() != "code-review" {
+		t.Fatalf("expected %s=code-review on failed tool", testSkillNameAttributeKey)
 	}
 }
 

--- a/go/agento11y/conformance_helpers_test.go
+++ b/go/agento11y/conformance_helpers_test.go
@@ -59,6 +59,7 @@ const (
 	spanAttrToolCallID             = "gen_ai.tool.call.id"
 	spanAttrToolType               = "gen_ai.tool.type"
 	spanAttrToolDescription        = "gen_ai.tool.description"
+	spanAttrSkillName              = "agento11y.skill.name"
 	spanAttrToolCallArguments      = "gen_ai.tool.call.arguments"
 	spanAttrToolCallResult         = "gen_ai.tool.call.result"
 	spanAttrResponseID             = "gen_ai.response.id"
@@ -653,6 +654,14 @@ func histogramPointMatches(attrs attribute.Set, want map[string]string) bool {
 		}
 	}
 	return true
+}
+
+func requireMetricAttrAbsent(t *testing.T, attrs attribute.Set, key string) {
+	t.Helper()
+
+	if value, ok := (&attrs).Value(attribute.Key(key)); ok {
+		t.Fatalf("did not expect metric attribute %q to be present (value %q)", key, value.Emit())
+	}
 }
 
 func requireProtoMetadata(t *testing.T, generation *agento11yv1.Generation, key, want string) {

--- a/go/agento11y/conformance_test.go
+++ b/go/agento11y/conformance_test.go
@@ -1015,6 +1015,7 @@ func TestConformance_ToolExecution(t *testing.T) {
 		ToolCallID:      "call-weather",
 		ToolType:        "function",
 		ToolDescription: "Get weather",
+		SkillName:       " code-review ",
 		RequestModel:    conformanceModel.Name,
 		RequestProvider: conformanceModel.Provider,
 		IncludeContent:  true,
@@ -1042,13 +1043,14 @@ func TestConformance_ToolExecution(t *testing.T) {
 
 	metrics := env.CollectMetrics(t)
 	duration := findHistogram[float64](t, metrics, metricOperationDuration)
-	requireHistogramPointWithAttrs(t, duration, map[string]string{
+	durationPoint := requireHistogramPointWithAttrs(t, duration, map[string]string{
 		spanAttrOperationName: conformanceToolOperation,
 		spanAttrProviderName:  conformanceModel.Provider,
 		spanAttrRequestModel:  conformanceModel.Name,
 		spanAttrToolName:      "weather",
 		spanAttrAgentName:     "agent-tools",
 	})
+	requireMetricAttrAbsent(t, durationPoint.Attributes, spanAttrSkillName)
 
 	env.Shutdown(t)
 
@@ -1063,6 +1065,7 @@ func TestConformance_ToolExecution(t *testing.T) {
 	requireSpanAttr(t, attrs, spanAttrToolCallID, "call-weather")
 	requireSpanAttr(t, attrs, spanAttrToolType, "function")
 	requireSpanAttr(t, attrs, spanAttrToolDescription, "Get weather")
+	requireSpanAttr(t, attrs, spanAttrSkillName, "code-review")
 	requireSpanAttr(t, attrs, spanAttrConversationID, "conv-tool")
 	requireSpanAttr(t, attrs, spanAttrConversationTitle, "Weather lookup")
 	requireSpanAttr(t, attrs, spanAttrAgentName, "agent-tools")
@@ -1072,6 +1075,48 @@ func TestConformance_ToolExecution(t *testing.T) {
 	requireSpanAttr(t, attrs, metadataKeySDKName, sdkNameGo)
 	requireSpanAttrPresent(t, attrs, spanAttrToolCallArguments)
 	requireSpanAttrPresent(t, attrs, spanAttrToolCallResult)
+}
+
+func TestConformance_ToolSkillMarkerSurvivesStrippedModes(t *testing.T) {
+	tests := []struct {
+		name string
+		mode agento11y.ContentCaptureMode
+	}{
+		{name: "metadata_only", mode: agento11y.ContentCaptureModeMetadataOnly},
+		{name: "full_with_metadata_spans", mode: agento11y.ContentCaptureModeFullWithMetadataSpans},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newConformanceEnv(t, withConformanceConfig(func(cfg *agento11y.Config) {
+				cfg.ContentCapture = tc.mode
+			}))
+
+			_, recorder := env.Client.StartToolExecution(context.Background(), agento11y.ToolExecutionStart{
+				ToolName:          "weather",
+				ToolDescription:   "Get sensitive weather",
+				ConversationTitle: "Sensitive tool conversation",
+				SkillName:         " code-review ",
+				IncludeContent:    true,
+			})
+			recorder.SetResult(agento11y.ToolExecutionEnd{
+				Arguments: map[string]any{"city": "Paris"},
+				Result:    map[string]any{"temp_c": 18},
+			})
+			recorder.End()
+			if err := recorder.Err(); err != nil {
+				t.Fatalf("record tool execution: %v", err)
+			}
+
+			span := findSpan(t, env.Spans.Ended(), conformanceToolOperation)
+			attrs := spanAttrs(span)
+			requireSpanAttr(t, attrs, spanAttrSkillName, "code-review")
+			requireSpanAttrAbsent(t, attrs, spanAttrToolDescription)
+			requireSpanAttrAbsent(t, attrs, spanAttrConversationTitle)
+			requireSpanAttrAbsent(t, attrs, spanAttrToolCallArguments)
+			requireSpanAttrAbsent(t, attrs, spanAttrToolCallResult)
+		})
+	}
 }
 
 func TestConformance_Embedding(t *testing.T) {

--- a/go/agento11y/contentcapture/contentcapture_test.go
+++ b/go/agento11y/contentcapture/contentcapture_test.go
@@ -391,6 +391,7 @@ func TestIsTraceContentAttribute(t *testing.T) {
 		{key: "gen_ai.retrieval.documents", want: true},
 		{key: "agento11y.generation.raw_artifacts", want: true},
 		{key: "gen_ai.tool.name", want: false},
+		{key: "agento11y.skill.name", want: false},
 		{key: "gen_ai.usage.input_tokens", want: false},
 		{key: contentcapture.ErrorCategoryAttributeKey, want: false},
 		{key: contentcapture.MetadataKeyCallError, want: false},

--- a/go/agento11y/tool.go
+++ b/go/agento11y/tool.go
@@ -5,6 +5,7 @@ import "time"
 // ToolExecutionStart seeds a tool execution span before the tool call runs.
 type ToolExecutionStart struct {
 	ToolName          string
+	SkillName         string
 	ToolCallID        string
 	ToolType          string
 	ToolDescription   string

--- a/go/otelgenai/genai.go
+++ b/go/otelgenai/genai.go
@@ -38,6 +38,10 @@ const (
 	genAIResponseStatusKey      attribute.Key = "gen_ai.response.status"
 )
 
+// agento11ySkillNameKey is a vendor attribute and is intentionally separate
+// from the pinned semantic-convention registry.
+const agento11ySkillNameKey attribute.Key = "agento11y.skill.name"
+
 // EndHook observes a finished invocation before its span closes. It returns
 // extra span attributes, and may transform the invocation itself, which is how
 // content redaction plugs in.
@@ -434,6 +438,10 @@ func (h *Handler) End(ctx context.Context, inv *Invocation) {
 	if span != nil {
 		span.SetName(inv.spanName())
 		attrs := h.requestAttributes(inv)
+		// End hooks can change the operation, but attributes set by Start cannot be removed.
+		if skillName := strings.TrimSpace(inv.SkillName); inv.operation() == OperationExecuteTool && skillName != "" {
+			attrs = append(attrs, agento11ySkillNameKey.String(skillName))
+		}
 		attrs = append(attrs, h.responseAttributes(inv)...)
 		attrs = append(attrs, h.contentAttributes(inv, capture)...)
 		attrs = append(attrs, inv.Attributes...)

--- a/go/otelgenai/genai_test.go
+++ b/go/otelgenai/genai_test.go
@@ -467,6 +467,88 @@ func TestSpanLifecycle(t *testing.T) {
 				if got := attrs["gen_ai.tool.type"].AsString(); got != "function" {
 					t.Errorf("gen_ai.tool.type = %q, want function", got)
 				}
+				if _, ok := attrs["agento11y.skill.name"]; ok {
+					t.Error("tool execution without a skill name carries agento11y.skill.name")
+				}
+			},
+		},
+		{
+			name: "tool execution carries a trimmed skill marker",
+			mutate: func(inv *otelgenai.Invocation) {
+				inv.Operation = otelgenai.OperationExecuteTool
+				inv.SkillName = "  weather-research\t"
+			},
+			checkStarted: func(t *testing.T, span sdktrace.ReadOnlySpan) {
+				if _, ok := spanAttrs(span)["agento11y.skill.name"]; ok {
+					t.Error("started tool span carries the end-scoped agento11y.skill.name")
+				}
+			},
+			check: func(t *testing.T, span sdktrace.ReadOnlySpan) {
+				if got := spanAttrs(span)["agento11y.skill.name"].AsString(); got != "weather-research" {
+					t.Errorf("agento11y.skill.name = %q, want weather-research", got)
+				}
+			},
+		},
+		{
+			name: "hook reclassification does not leak the skill marker",
+			options: []otelgenai.Option{otelgenai.WithEndHook(
+				otelgenai.EndHookFunc(func(_ context.Context, inv *otelgenai.Invocation, _ otelgenai.CaptureMode) []attribute.KeyValue {
+					*inv = otelgenai.Invocation{
+						Operation:    otelgenai.OperationChat,
+						RequestModel: "gpt-5",
+					}
+					return nil
+				}),
+			)},
+			mutate: func(inv *otelgenai.Invocation) {
+				inv.Operation = otelgenai.OperationExecuteTool
+				inv.ToolName = "load_skill"
+				inv.SkillName = "code-review"
+			},
+			check: func(t *testing.T, span sdktrace.ReadOnlySpan) {
+				if got := span.Name(); got != "chat gpt-5" {
+					t.Errorf("span name = %q, want chat gpt-5", got)
+				}
+				attrs := spanAttrs(span)
+				if got := attrs["gen_ai.operation.name"].AsString(); got != "chat" {
+					t.Errorf("gen_ai.operation.name = %q, want chat", got)
+				}
+				if _, ok := attrs["agento11y.skill.name"]; ok {
+					t.Error("reclassified non-tool span carries agento11y.skill.name")
+				}
+			},
+		},
+		{
+			name: "tool execution omits a blank skill marker",
+			mutate: func(inv *otelgenai.Invocation) {
+				inv.Operation = otelgenai.OperationExecuteTool
+				inv.SkillName = " \t\n "
+			},
+			checkStarted: func(t *testing.T, span sdktrace.ReadOnlySpan) {
+				if _, ok := spanAttrs(span)["agento11y.skill.name"]; ok {
+					t.Error("started tool span carries agento11y.skill.name for a blank skill name")
+				}
+			},
+			check: func(t *testing.T, span sdktrace.ReadOnlySpan) {
+				if _, ok := spanAttrs(span)["agento11y.skill.name"]; ok {
+					t.Error("tool span carries agento11y.skill.name for a blank skill name")
+				}
+			},
+		},
+		{
+			name: "skill marker is scoped to tool execution",
+			mutate: func(inv *otelgenai.Invocation) {
+				inv.SkillName = "weather-research"
+			},
+			checkStarted: func(t *testing.T, span sdktrace.ReadOnlySpan) {
+				if _, ok := spanAttrs(span)["agento11y.skill.name"]; ok {
+					t.Error("started non-tool span carries agento11y.skill.name")
+				}
+			},
+			check: func(t *testing.T, span sdktrace.ReadOnlySpan) {
+				if _, ok := spanAttrs(span)["agento11y.skill.name"]; ok {
+					t.Error("non-tool span carries agento11y.skill.name")
+				}
 			},
 		},
 		{

--- a/go/otelgenai/invocation.go
+++ b/go/otelgenai/invocation.go
@@ -206,6 +206,7 @@ type Invocation struct {
 	ToolCallID      string
 	ToolType        string
 	ToolDescription string
+	SkillName       string
 
 	// ServerAddress and ServerPort locate the provider endpoint. The
 	// conventions treat them as sampling-relevant, so set them before Start.

--- a/java/core/src/main/java/com/grafana/agento11y/sdk/Agento11yClient.java
+++ b/java/core/src/main/java/com/grafana/agento11y/sdk/Agento11yClient.java
@@ -76,6 +76,7 @@ public final class Agento11yClient implements AutoCloseable {
     static final String SPAN_ATTR_TOOL_CALL_ID = "gen_ai.tool.call.id";
     static final String SPAN_ATTR_TOOL_TYPE = "gen_ai.tool.type";
     static final String SPAN_ATTR_TOOL_DESCRIPTION = "gen_ai.tool.description";
+    static final String SPAN_ATTR_SKILL_NAME = "agento11y.skill.name";
     static final String SPAN_ATTR_TOOL_CALL_ARGUMENTS = "gen_ai.tool.call.arguments";
     static final String SPAN_ATTR_TOOL_CALL_RESULT = "gen_ai.tool.call.result";
     static final String SPAN_ATTR_TAG_PREFIX = "agento11y.tag.";
@@ -1257,6 +1258,37 @@ public final class Agento11yClient implements AutoCloseable {
         if (!seed.getToolDescription().isBlank()) {
             span.setAttribute(SPAN_ATTR_TOOL_DESCRIPTION, seed.getToolDescription());
         }
+        projectSkillName(span, seed.getSkillName());
+    }
+
+    private static void projectSkillName(Span span, String skillName) {
+        String normalized = normalizeSkillName(skillName);
+        if (!normalized.isEmpty()) {
+            span.setAttribute(SPAN_ATTR_SKILL_NAME, normalized);
+        }
+    }
+
+    static String normalizeSkillName(String skillName) {
+        if (skillName == null || skillName.isEmpty()) {
+            return "";
+        }
+        int start = 0;
+        int end = skillName.length();
+        while (start < end) {
+            int codePoint = skillName.codePointAt(start);
+            if (!Character.isWhitespace(codePoint) && !Character.isSpaceChar(codePoint)) {
+                break;
+            }
+            start += Character.charCount(codePoint);
+        }
+        while (start < end) {
+            int codePoint = skillName.codePointBefore(end);
+            if (!Character.isWhitespace(codePoint) && !Character.isSpaceChar(codePoint)) {
+                break;
+            }
+            end -= Character.charCount(codePoint);
+        }
+        return skillName.substring(start, end);
     }
 
     static Attributes tagAttributes(Map<String, String> tags) {

--- a/java/core/src/main/java/com/grafana/agento11y/sdk/ToolExecution.java
+++ b/java/core/src/main/java/com/grafana/agento11y/sdk/ToolExecution.java
@@ -8,6 +8,7 @@ public final class ToolExecution {
     private String toolCallId = "";
     private String toolType = "";
     private String toolDescription = "";
+    private String skillName = "";
     private String conversationId = "";
     private String agentName = "";
     private String agentVersion = "";
@@ -51,6 +52,15 @@ public final class ToolExecution {
 
     public ToolExecution setToolDescription(String toolDescription) {
         this.toolDescription = toolDescription == null ? "" : toolDescription;
+        return this;
+    }
+
+    public String getSkillName() {
+        return skillName;
+    }
+
+    public ToolExecution setSkillName(String skillName) {
+        this.skillName = skillName == null ? "" : skillName;
         return this;
     }
 
@@ -141,6 +151,7 @@ public final class ToolExecution {
                 .setToolCallId(toolCallId)
                 .setToolType(toolType)
                 .setToolDescription(toolDescription)
+                .setSkillName(skillName)
                 .setConversationId(conversationId)
                 .setAgentName(agentName)
                 .setAgentVersion(agentVersion)

--- a/java/core/src/main/java/com/grafana/agento11y/sdk/ToolExecutionRecorder.java
+++ b/java/core/src/main/java/com/grafana/agento11y/sdk/ToolExecutionRecorder.java
@@ -90,6 +90,7 @@ public class ToolExecutionRecorder implements AutoCloseable {
                 .setToolCallId(seed.getToolCallId())
                 .setToolType(seed.getToolType())
                 .setToolDescription(seed.getToolDescription())
+                .setSkillName(Agento11yClient.normalizeSkillName(seed.getSkillName()))
                 .setConversationId(seed.getConversationId())
                 .setAgentName(seed.getAgentName())
                 .setAgentVersion(seed.getAgentVersion())

--- a/java/core/src/main/java/com/grafana/agento11y/sdk/ToolExecutionStart.java
+++ b/java/core/src/main/java/com/grafana/agento11y/sdk/ToolExecutionStart.java
@@ -8,6 +8,7 @@ public final class ToolExecutionStart {
     private String toolCallId = "";
     private String toolType = "";
     private String toolDescription = "";
+    private String skillName = "";
     private String conversationId = "";
     private String conversationTitle = "";
     private String agentName = "";
@@ -51,6 +52,15 @@ public final class ToolExecutionStart {
 
     public ToolExecutionStart setToolDescription(String toolDescription) {
         this.toolDescription = toolDescription == null ? "" : toolDescription;
+        return this;
+    }
+
+    public String getSkillName() {
+        return skillName;
+    }
+
+    public ToolExecutionStart setSkillName(String skillName) {
+        this.skillName = skillName == null ? "" : skillName;
         return this;
     }
 
@@ -149,6 +159,7 @@ public final class ToolExecutionStart {
                 .setToolCallId(toolCallId)
                 .setToolType(toolType)
                 .setToolDescription(toolDescription)
+                .setSkillName(skillName)
                 .setConversationId(conversationId)
                 .setConversationTitle(conversationTitle)
                 .setAgentName(agentName)

--- a/java/core/src/test/java/com/grafana/agento11y/sdk/Agento11yClientSpansTest.java
+++ b/java/core/src/test/java/com/grafana/agento11y/sdk/Agento11yClientSpansTest.java
@@ -12,7 +12,11 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class Agento11yClientSpansTest {
     @Test
@@ -62,6 +66,63 @@ class Agento11yClientSpansTest {
         assertThat(span.getStatus().getStatusCode()).isEqualTo(StatusCode.ERROR);
 
         provider.shutdown();
+    }
+
+    @Test
+    void toolExecutionStartHasFluentFlatSkillNameField() {
+        ToolExecutionStart start = new ToolExecutionStart();
+
+        assertThat(start.setSkillName("  code-review  ")).isSameAs(start);
+        assertThat(start.getSkillName()).isEqualTo("  code-review  ");
+        assertThat(start.copy().getSkillName()).isEqualTo("  code-review  ");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("toolSkillMarkerCases")
+    void toolSkillMarkerSemantics(String description, String skillName, String expectedSkillName, boolean failed) {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        SdkTracerProvider provider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+                .build();
+
+        Agento11yClientConfig config = new Agento11yClientConfig()
+                .setTracer(provider.get("test"))
+                .setGenerationExporter(new TestFixtures.CapturingExporter())
+                .setGenerationExport(new GenerationExportConfig()
+                        .setBatchSize(100)
+                        .setFlushInterval(Duration.ofMinutes(10))
+                        .setMaxRetries(0));
+
+        try (Agento11yClient client = new Agento11yClient(config)) {
+            ToolExecutionStart start = new ToolExecutionStart().setToolName("ordinary_tool");
+            if (skillName != null) {
+                start.setSkillName(skillName);
+            }
+            ToolExecutionRecorder recorder = client.startToolExecution(start);
+            if (failed) {
+                recorder.setCallError(new IllegalStateException("tool failed"));
+            }
+            recorder.end();
+        }
+
+        assertThat(spanExporter.getFinishedSpanItems()).hasSize(1);
+        SpanData span = spanExporter.getFinishedSpanItems().get(0);
+        assertThat(span.getName()).isEqualTo("execute_tool ordinary_tool");
+        assertThat(span.getAttributes().get(AttributeKey.stringKey("agento11y.skill.name")))
+                .isEqualTo(expectedSkillName);
+        assertThat(span.getStatus().getStatusCode()).isEqualTo(failed ? StatusCode.ERROR : StatusCode.OK);
+
+        provider.shutdown();
+    }
+
+    private static Stream<Arguments> toolSkillMarkerCases() {
+        return Stream.of(
+                Arguments.of("trimmed marker", "  code-review\t", "code-review", false),
+                Arguments.of("non-breaking spaces are trimmed", "\u00a0code-review\u00a0", "code-review", false),
+                Arguments.of("failed execution retains marker", "failure-analysis", "failure-analysis", true),
+                Arguments.of("omitted marker", null, null, false),
+                Arguments.of("whitespace marker", " \t\n ", null, false),
+                Arguments.of("non-breaking whitespace marker", "\u00a0", null, false));
     }
 
     @Test

--- a/java/core/src/test/java/com/grafana/agento11y/sdk/ConformanceTest.java
+++ b/java/core/src/test/java/com/grafana/agento11y/sdk/ConformanceTest.java
@@ -417,21 +417,26 @@ class ConformanceTest {
                     .setToolName("weather")
                     .setToolCallId("call-weather-1")
                     .setToolType("function")
+                    .setSkillName("\u00a0code-review\u00a0")
                     .setIncludeContent(true));
             recorder.setResult(new ToolExecutionResult()
                     .setArguments(Map.of("city", "Paris"))
                     .setResult(Map.of("forecast", "sunny")));
             recorder.end();
+            ToolExecution completedExecution = env.client.debugSnapshot().getToolExecutions().get(0);
             env.client.shutdown();
 
             SpanData span = env.latestSpanByNamePrefix("execute_tool ");
             List<String> metricNames = env.metricNames();
 
             assertThat(env.requests).isEmpty();
+            assertThat(completedExecution.getSkillName()).isEqualTo("code-review");
             assertThat(span.getName()).isEqualTo("execute_tool weather");
             assertThat(span.getAttributes().get(AttributeKey.stringKey(Agento11yClient.SPAN_ATTR_TOOL_NAME))).isEqualTo("weather");
             assertThat(span.getAttributes().get(AttributeKey.stringKey(Agento11yClient.SPAN_ATTR_TOOL_CALL_ID))).isEqualTo("call-weather-1");
             assertThat(span.getAttributes().get(AttributeKey.stringKey(Agento11yClient.SPAN_ATTR_TOOL_TYPE))).isEqualTo("function");
+            assertThat(span.getAttributes().get(AttributeKey.stringKey("agento11y.skill.name")))
+                    .isEqualTo("code-review");
             assertThat(String.valueOf(span.getAttributes().get(AttributeKey.stringKey(Agento11yClient.SPAN_ATTR_TOOL_CALL_ARGUMENTS))))
                     .contains("Paris");
             assertThat(String.valueOf(span.getAttributes().get(AttributeKey.stringKey(Agento11yClient.SPAN_ATTR_TOOL_CALL_RESULT))))
@@ -444,6 +449,9 @@ class ConformanceTest {
                     .isEqualTo("v-context");
             assertThat(metricNames).contains(Agento11yClient.METRIC_OPERATION_DURATION);
             assertThat(metricNames).doesNotContain(Agento11yClient.METRIC_TTFT);
+            assertThat(env.metricData(Agento11yClient.METRIC_OPERATION_DURATION).getHistogramData().getPoints())
+                    .allSatisfy(point -> assertThat(point.getAttributes()
+                            .get(AttributeKey.stringKey("agento11y.skill.name"))).isNull());
         }
     }
 

--- a/java/core/src/test/java/com/grafana/agento11y/sdk/ContentCaptureModeTest.java
+++ b/java/core/src/test/java/com/grafana/agento11y/sdk/ContentCaptureModeTest.java
@@ -1153,6 +1153,7 @@ class ContentCaptureModeTest {
             try (ToolExecutionRecorder rec = env.client.startToolExecution(new ToolExecutionStart()
                     .setToolName("weather")
                     .setToolCallId("call_1")
+                    .setSkillName("  weather-research  ")
                     .setConversationTitle("Sensitive tool title")
                     .setToolDescription("Get weather: free-form provider-supplied text")
                     .setIncludeContent(true))) {
@@ -1168,6 +1169,8 @@ class ContentCaptureModeTest {
             assertThat(toolSpan.getAttributes().get(AttributeKey.stringKey("gen_ai.tool.description"))).isNull();
             // Identity attributes still emitted.
             assertThat(toolSpan.getAttributes().get(AttributeKey.stringKey("gen_ai.tool.name"))).isEqualTo("weather");
+            assertThat(toolSpan.getAttributes().get(AttributeKey.stringKey("agento11y.skill.name")))
+                    .isEqualTo("weather-research");
         }
     }
 

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -136,6 +136,7 @@ const spanAttrToolName = 'gen_ai.tool.name';
 const spanAttrToolCallID = 'gen_ai.tool.call.id';
 const spanAttrToolType = 'gen_ai.tool.type';
 const spanAttrToolDescription = 'gen_ai.tool.description';
+const spanAttrSkillName = 'agento11y.skill.name';
 const spanAttrToolCallArguments = 'gen_ai.tool.call.arguments';
 const spanAttrToolCallResult = 'gen_ai.tool.call.result';
 const spanAttrTagPrefix = 'agento11y.tag.';
@@ -1761,6 +1762,8 @@ class ToolExecutionRecorderImpl implements ToolExecutionRecorder {
     seed: ToolExecutionStart,
   ) {
     this.seed = cloneToolExecutionStart(seed);
+    const skillName = this.seed.skillName?.trim();
+    this.seed.skillName = skillName !== undefined && skillName.length > 0 ? skillName : undefined;
     if (!notEmpty(this.seed.conversationId)) {
       this.seed.conversationId = conversationIdFromContext();
     }
@@ -1825,6 +1828,7 @@ class ToolExecutionRecorderImpl implements ToolExecutionRecorder {
       toolCallId: this.seed.toolCallId,
       toolType: this.seed.toolType,
       toolDescription: this.seed.toolDescription,
+      skillName: this.seed.skillName,
       conversationId: this.seed.conversationId,
       conversationTitle: this.seed.conversationTitle,
       agentName: this.seed.agentName,
@@ -2168,6 +2172,7 @@ function setToolSpanAttributes(
     toolCallId?: string;
     toolType?: string;
     toolDescription?: string;
+    skillName?: string;
     conversationId?: string;
     conversationTitle?: string;
     agentName?: string;
@@ -2189,6 +2194,7 @@ function setToolSpanAttributes(
   if (notEmpty(tool.toolDescription)) {
     span.setAttribute(spanAttrToolDescription, tool.toolDescription);
   }
+  projectSkillName(span, tool.skillName);
   if (notEmpty(tool.conversationId)) {
     span.setAttribute(spanAttrConversationID, tool.conversationId);
   }
@@ -2206,6 +2212,13 @@ function setToolSpanAttributes(
   }
   if (notEmpty(tool.requestModel)) {
     span.setAttribute(spanAttrRequestModel, tool.requestModel);
+  }
+}
+
+function projectSkillName(span: Span, skillName: string | undefined): void {
+  const normalized = skillName?.trim();
+  if (normalized !== undefined && normalized.length > 0) {
+    span.setAttribute(spanAttrSkillName, normalized);
   }
 }
 

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -522,6 +522,7 @@ export interface ToolExecutionStart {
   toolCallId?: string;
   toolType?: string;
   toolDescription?: string;
+  skillName?: string;
   conversationId?: string;
   conversationTitle?: string;
   agentName?: string;
@@ -568,6 +569,7 @@ export interface ToolExecution {
   toolCallId?: string;
   toolType?: string;
   toolDescription?: string;
+  skillName?: string;
   conversationId?: string;
   conversationTitle?: string;
   agentName?: string;

--- a/js/test/client.content-capture.test.mjs
+++ b/js/test/client.content-capture.test.mjs
@@ -891,6 +891,7 @@ for (const mode of STRIPPED_MODES) {
       const recorder = env.client.startToolExecution({
         toolName: 'weather',
         toolCallId: 'call_1',
+        skillName: '  weather-forecast  ',
         includeContent: true,
         conversationTitle: 'Sensitive tool title',
         toolDescription: 'Get weather: free-form provider-supplied text',
@@ -906,6 +907,11 @@ for (const mode of STRIPPED_MODES) {
       assert.equal('gen_ai.tool.description' in span.attributes, false, 'tool description must be absent');
       // Identity attributes still emitted.
       assert.equal(span.attributes['gen_ai.tool.name'], 'weather');
+      assert.equal(span.attributes['agento11y.skill.name'], 'weather-forecast');
+
+      const snapshot = env.client.debugSnapshot();
+      assert.equal(snapshot.toolExecutions.length, 1);
+      assert.equal(snapshot.toolExecutions[0].skillName, 'weather-forecast');
     } finally {
       await env.close();
     }

--- a/js/test/client.spans.test.mjs
+++ b/js/test/client.spans.test.mjs
@@ -397,12 +397,57 @@ test('tool execution includeContent controls argument/result attributes', async 
   }
 });
 
+test('tool execution skill marker is trimmed and omitted for ordinary tools', async () => {
+  const harness = newHarness();
+  const cases = [
+    { toolName: 'marked_tool', skillName: '  research  ', expected: 'research' },
+    { toolName: 'ordinary_tool', skillName: undefined, expected: undefined },
+    { toolName: 'whitespace_tool', skillName: ' \t\n ', expected: undefined },
+  ];
+
+  try {
+    for (const tc of cases) {
+      const recorder = harness.client.startToolExecution({
+        toolName: tc.toolName,
+        skillName: tc.skillName,
+      });
+      recorder.setResult({ result: 'ok' });
+      recorder.end();
+      assert.equal(recorder.getError(), undefined, tc.toolName);
+    }
+
+    const spans = toolSpans(harness.spanExporter);
+    const executions = harness.client.debugSnapshot().toolExecutions;
+    assert.equal(spans.length, cases.length);
+    assert.equal(executions.length, cases.length);
+
+    for (const tc of cases) {
+      const span = spans.find((candidate) => candidate.attributes['gen_ai.tool.name'] === tc.toolName);
+      const execution = executions.find((candidate) => candidate.toolName === tc.toolName);
+      assert.ok(span, `${tc.toolName}: expected execute_tool span`);
+      assert.ok(execution, `${tc.toolName}: expected completed debug snapshot`);
+      assert.equal(span.attributes['agento11y.skill.name'], tc.expected, `${tc.toolName}: span marker`);
+      assert.equal(execution.skillName, tc.expected, `${tc.toolName}: snapshot marker`);
+      if (tc.expected === undefined) {
+        assert.equal(
+          Object.hasOwn(span.attributes, 'agento11y.skill.name'),
+          false,
+          `${tc.toolName}: marker must be omitted`,
+        );
+      }
+    }
+  } finally {
+    await shutdownHarness(harness);
+  }
+});
+
 test('tool execution callError is surfaced locally and marks error span', async () => {
   const harness = newHarness();
 
   try {
     const recorder = harness.client.startToolExecution({
       toolName: 'weather',
+      skillName: '  weather-forecast  ',
     });
     recorder.setCallError(new Error('tool failed'));
     recorder.end();
@@ -411,6 +456,8 @@ test('tool execution callError is surfaced locally and marks error span', async 
     const span = singleToolSpan(harness.spanExporter);
     assert.equal(span.status.code, SpanStatusCode.ERROR);
     assert.equal(span.attributes['error.type'], 'tool_execution_error');
+    assert.equal(span.attributes['agento11y.skill.name'], 'weather-forecast');
+    assert.equal(harness.client.debugSnapshot().toolExecutions[0].skillName, 'weather-forecast');
   } finally {
     await shutdownHarness(harness);
   }

--- a/js/test/conformance.test.mjs
+++ b/js/test/conformance.test.mjs
@@ -483,6 +483,7 @@ test('conformance tool execution semantics', async () => {
             toolName: 'weather',
             toolCallId: 'call-weather-1',
             toolType: 'function',
+            skillName: '  code-review  ',
             includeContent: true,
           });
           recorder.setResult({
@@ -498,13 +499,18 @@ test('conformance tool execution semantics', async () => {
     await env.client.shutdown();
     const span = env.latestSpanByOperation('execute_tool');
     const metricNames = await env.metricNames();
+    const durationAttributes = await env.metricDataPointAttributes('gen_ai.client.operation.duration');
+    const toolExecution = env.client.debugSnapshot().toolExecutions[0];
 
     assert.equal(env.receivedRequests.length, 0);
+    assert.ok(toolExecution);
     assert.equal(span.name, 'execute_tool weather');
     assert.equal(span.attributes['gen_ai.operation.name'], 'execute_tool');
     assert.equal(span.attributes['gen_ai.tool.name'], 'weather');
     assert.equal(span.attributes['gen_ai.tool.call.id'], 'call-weather-1');
     assert.equal(span.attributes['gen_ai.tool.type'], 'function');
+    assert.equal(span.attributes['agento11y.skill.name'], 'code-review');
+    assert.equal(toolExecution.skillName, 'code-review');
     assert.match(String(span.attributes['gen_ai.tool.call.arguments'] ?? ''), /Paris/);
     assert.match(String(span.attributes['gen_ai.tool.call.result'] ?? ''), /sunny/);
     assert.equal(span.attributes['agento11y.conversation.title'], 'Context title');
@@ -512,6 +518,14 @@ test('conformance tool execution semantics', async () => {
     assert.equal(span.attributes['gen_ai.agent.version'], 'v-context');
     assert.ok(metricNames.includes('gen_ai.client.operation.duration'));
     assert.ok(!metricNames.includes('gen_ai.client.time_to_first_token'));
+    const toolMetricAttributes = durationAttributes.filter(
+      (attributes) => attributes['gen_ai.operation.name'] === 'execute_tool',
+    );
+    assert.ok(toolMetricAttributes.length > 0, 'expected an execute_tool duration metric');
+    assert.ok(
+      toolMetricAttributes.every((attributes) => !Object.hasOwn(attributes, 'agento11y.skill.name')),
+      'skill marker must not be projected onto metric attributes',
+    );
   } finally {
     await env.close();
   }

--- a/python/agento11y/client.py
+++ b/python/agento11y/client.py
@@ -112,6 +112,7 @@ _span_attr_cache_read_tokens = "gen_ai.usage.cache_read_input_tokens"
 _span_attr_cache_write_tokens = "gen_ai.usage.cache_write_input_tokens"
 _span_attr_reasoning_tokens = "gen_ai.usage.reasoning_tokens"
 _span_attr_tool_name = "gen_ai.tool.name"
+_span_attr_skill_name = "agento11y.skill.name"
 _span_attr_tool_call_id = "gen_ai.tool.call.id"
 _span_attr_tool_type = "gen_ai.tool.type"
 _span_attr_tool_description = "gen_ai.tool.description"
@@ -2069,10 +2070,17 @@ def _set_embedding_end_span_attributes(
             span.set_attribute(_span_attr_embedding_input_texts, texts)
 
 
+def _set_trimmed_skill_name_attribute(span: Span, skill_name: str) -> None:
+    normalized = skill_name.strip()
+    if normalized:
+        span.set_attribute(_span_attr_skill_name, normalized)
+
+
 def _set_tool_span_attributes(span: Span, start: ToolExecutionStart) -> None:
     span.set_attribute(_span_attr_operation_name, "execute_tool")
     span.set_attribute(_span_attr_tool_name, start.tool_name)
     span.set_attribute(_span_attr_sdk_name, _sdk_name)
+    _set_trimmed_skill_name_attribute(span, start.skill_name)
 
     if start.tool_call_id:
         span.set_attribute(_span_attr_tool_call_id, start.tool_call_id)

--- a/python/agento11y/models.py
+++ b/python/agento11y/models.py
@@ -357,6 +357,7 @@ class ToolExecutionStart:
     include_content: bool = False
     content_capture: ContentCaptureMode = ContentCaptureMode.DEFAULT
     started_at: datetime | None = None
+    skill_name: str = ""
 
 
 @dataclass(slots=True)

--- a/python/tests/test_conformance.py
+++ b/python/tests/test_conformance.py
@@ -782,6 +782,7 @@ def test_conformance_tool_execution_semantics() -> None:
                             tool_name="weather",
                             tool_call_id="call-weather-1",
                             tool_type="function",
+                            skill_name="  code-review  ",
                             include_content=True,
                         )
                     )
@@ -803,12 +804,16 @@ def test_conformance_tool_execution_semantics() -> None:
         assert span.attributes["gen_ai.tool.name"] == "weather"
         assert span.attributes["gen_ai.tool.call.id"] == "call-weather-1"
         assert span.attributes["gen_ai.tool.type"] == "function"
+        assert span.attributes["agento11y.skill.name"] == "code-review"
         assert "Paris" in str(span.attributes["gen_ai.tool.call.arguments"])
         assert "sunny" in str(span.attributes["gen_ai.tool.call.result"])
         assert span.attributes[_span_attr_conversation_title] == "Context title"
         assert span.attributes["gen_ai.agent.name"] == "agent-context"
         assert span.attributes["gen_ai.agent.version"] == "v-context"
         assert "gen_ai.client.operation.duration" in metrics
+        duration_points = list(metrics["gen_ai.client.operation.duration"].data_points)
+        assert duration_points
+        assert all("agento11y.skill.name" not in point.attributes for point in duration_points)
         assert "gen_ai.client.time_to_first_token" not in metrics
     finally:
         env.shutdown()

--- a/python/tests/test_content_capture.py
+++ b/python/tests/test_content_capture.py
@@ -689,7 +689,7 @@ class TestToolContentCapture:
             client.shutdown()
             provider.shutdown()
 
-    def test_client_default_legacy_true_includes(self):
+    def test_client_default_legacy_true_includes(self):  # trufflehog:ignore
         client, span_exporter, provider = self._make_tool_client(ContentCaptureMode.DEFAULT)
         try:
             with client.start_tool_execution(ToolExecutionStart(tool_name="test_tool", include_content=True)) as rec:
@@ -1121,7 +1121,7 @@ class TestRatingCommentStripping:
 
         return _Handler
 
-    def test_metadata_only_strips_rating_comment(self):
+    def test_metadata_only_strips_rating_comment(self):  # trufflehog:ignore
         captured: dict = {}
         handler = self._make_rating_handler(captured)
         server = HTTPServer(("127.0.0.1", 0), handler)
@@ -1295,6 +1295,7 @@ class TestFullWithMetadataSpans:
                 ToolExecutionStart(
                     tool_name="weather",
                     tool_call_id="call_1",
+                    skill_name="  weather-lookup  ",
                     include_content=True,
                     conversation_title="Sensitive tool title",
                     tool_description="Get weather: free-form provider-supplied text",
@@ -1309,6 +1310,7 @@ class TestFullWithMetadataSpans:
             assert "gen_ai.tool.description" not in tool_span.attributes
             # Identity attributes still emitted.
             assert tool_span.attributes.get("gen_ai.tool.name") == "weather"
+            assert tool_span.attributes.get("agento11y.skill.name") == "weather-lookup"
 
     @pytest.mark.parametrize("mode", _STRIPPED_MODES)
     def test_stripped_modes_tool_span_redacts_call_error(self, mode):
@@ -1320,13 +1322,16 @@ class TestFullWithMetadataSpans:
                 ToolExecutionStart(
                     tool_name="weather",
                     tool_call_id="call_1",
+                    skill_name="  weather-lookup  ",
                     include_content=True,
                 )
             ) as rec:
                 rec.set_exec_error(RuntimeError(raw_err))
                 rec.set_result(arguments={"city": "Paris"}, result={"temp_c": 18})
 
-            _assert_span_error_redacted(env.tool_span(), "tool_execution_error")
+            tool_span = env.tool_span()
+            _assert_span_error_redacted(tool_span, "tool_execution_error")
+            assert tool_span.attributes.get("agento11y.skill.name") == "weather-lookup"
 
     @pytest.mark.parametrize("mode", _STRIPPED_MODES)
     def test_stripped_modes_embedding_span_omits_input_texts(self, mode):

--- a/python/tests/test_runtime.py
+++ b/python/tests/test_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from datetime import timedelta
 
+import pytest
 from agento11y import (
     Client,
     ClientConfig,
@@ -115,7 +116,7 @@ def test_flush_retries_failed_exports_with_backoff() -> None:
         client.shutdown()
 
 
-def test_shutdown_flushes_pending_generation() -> None:
+def test_shutdown_flushes_pending_generation() -> None:  # trufflehog:ignore
     exporter = CapturingGenerationExporter()
     client = _new_client(exporter, batch_size=10)
 
@@ -626,6 +627,46 @@ def test_tool_execution_attributes_and_content_capture() -> None:
         assert span.attributes.get("gen_ai.provider.name") == "openai"
         assert span.attributes.get("gen_ai.request.model") == "gpt-5"
         assert span.attributes.get("agento11y.sdk.name") == "sdk-python"
+    finally:
+        client.shutdown()
+        provider.shutdown()
+
+
+@pytest.mark.parametrize(
+    "start_kwargs, exec_error, expected_skill_name",
+    [
+        pytest.param({}, None, None, id="omitted"),
+        pytest.param({"skill_name": " \t "}, None, None, id="whitespace"),
+        pytest.param(
+            {"skill_name": "  failed-skill  "},
+            RuntimeError("the skill failed"),
+            "failed-skill",
+            id="failure-retains-marker",
+        ),
+    ],
+)
+def test_tool_execution_skill_marker_edges(
+    start_kwargs: dict[str, str],
+    exec_error: RuntimeError | None,
+    expected_skill_name: str | None,
+) -> None:
+    exporter = CapturingGenerationExporter()
+    span_exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    client = _new_client(exporter, tracer=provider.get_tracer("agento11y-test"))
+
+    try:
+        rec = client.start_tool_execution(ToolExecutionStart(tool_name="weather", **start_kwargs))
+        if exec_error is not None:
+            rec.set_exec_error(exec_error)
+        rec.end()
+
+        span = span_exporter.get_finished_spans()[-1]
+        if expected_skill_name is None:
+            assert "agento11y.skill.name" not in span.attributes
+        else:
+            assert span.attributes.get("agento11y.skill.name") == expected_skill_name
     finally:
         client.shutdown()
         provider.shutdown()


### PR DESCRIPTION
Add an optional skill name to tool-execution APIs in Go, Python, TypeScript/JavaScript, Java, and .NET. When instrumentation sets it for a skill load, the `execute_tool` span emits the name as `agento11y.skill.name`.

OpenTelemetry has not merged a skill convention. [genai#86](https://github.com/open-telemetry/semantic-conventions-genai/issues/86) discusses recording load metadata on `execute_tool` spans. Draft [genai#463](https://github.com/open-telemetry/semantic-conventions-genai/pull/463) proposes broader `gen_ai.skill.*` fields and metrics. Because it's not decided yet, the attribute stays in the `agento11y` namespace.