### PR TITLE
feat(sdk-go): add per-client experimental feature opt-in

### DIFF
--- a/examples/experiments/go/.env.example
+++ b/examples/experiments/go/.env.example
@@ -40,8 +40,9 @@ GIT_SHA=local
 N_ATTEMPTS=3
 
 # Optional stored-evaluator example configuration. The evaluator has to exist in
-# your tenant already; the example does not create one. Stored-evaluator grading
-# is experimental and refuses to run without the opt-in below.
+# your tenant already; the example does not create one. The example opts in to
+# experimental features in code through ClientOptions.EnableExperimentalFeatures.
+# Remove that client option to use this environment-variable alternative:
 # AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true
 # EVALUATOR_ID=helpfulness
 # EVALUATOR_VERSION=

--- a/examples/experiments/go/cloud-evaluator/main.go
+++ b/examples/experiments/go/cloud-evaluator/main.go
@@ -49,7 +49,9 @@ var answers = map[string]string{
 
 func main() {
 	ctx := context.Background()
-	client, err := experiments.NewClientFromEnv()
+	client, err := experiments.NewClient(experiments.ClientOptions{
+		EnableExperimentalFeatures: agento11y.BoolPtr(true),
+	})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go/README.md
+++ b/go/README.md
@@ -359,11 +359,21 @@ continues to use the ingest credential. `NewExperimentFromSuite` and
 
 ### Grading with an evaluator stored in your tenant
 
-> **Experimental.** Set `AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true` to use
-> this. Without it, `Trial.Evaluate`, `Client.TriggerTrialEvaluation`, and
+> **Experimental.** Set `Config.EnableExperimentalFeatures` or
+> `experiments.ClientOptions.EnableExperimentalFeatures` to
+> `agento11y.BoolPtr(true)`. If the field is nil,
+> `AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true` remains a supported alternative.
+> Explicit false overrides the environment.
+> Without it, `Trial.Evaluate`, `Client.TriggerTrialEvaluation`, and
 > `Client.GetTrialEvaluation` return `agento11y.ErrExperimentalFeatureDisabled`
 > without sending a request. Experimental features can change or be removed in
 > any release.
+
+```go
+client, err := experiments.NewClient(experiments.ClientOptions{
+	EnableExperimentalFeatures: agento11y.BoolPtr(true),
+})
+```
 
 `Trial.Evaluate` grades the conversation Agent Observability already stored,
 using an evaluator defined in your tenant, instead of a score the runner

--- a/go/agento11y/client.go
+++ b/go/agento11y/client.go
@@ -44,6 +44,10 @@ type Config struct {
 	// (preflight/postflight guardrails). Disabled by default; callers must
 	// explicitly opt in by setting Hooks.Enabled = true.
 	Hooks HooksConfig
+	// EnableExperimentalFeatures controls experimental features for this client.
+	// A non-nil value overrides EnvEnableExperimentalFeatures. When nil, each
+	// feature check reads the current environment value.
+	EnableExperimentalFeatures *bool
 	// ContentCapture controls the default content capture mode for all
 	// generations and tool executions. Per-recording overrides take precedence.
 	ContentCapture ContentCaptureMode
@@ -177,8 +181,8 @@ const (
 	// GenerationExportProtocolOTel exports each generation as one
 	// GenAI-semconv span on the application's OTel pipeline instead of calling
 	// the generation-export endpoint. This protocol is experimental: NewClient
-	// also requires EnvEnableExperimentalFeatures, and falls back to the noop
-	// exporter when that variable is not set.
+	// checks Config.EnableExperimentalFeatures first, then
+	// EnvEnableExperimentalFeatures when the config field is nil.
 	GenerationExportProtocolOTel GenerationExportProtocol = "otel"
 )
 
@@ -482,6 +486,9 @@ type telemetryInstruments struct {
 // apply. Use ConfigFromEnv() if strict validation is required.
 func NewClient(config Config) *Client {
 	cfg := config
+	if cfg.EnableExperimentalFeatures != nil {
+		cfg.EnableExperimentalFeatures = BoolPtr(*cfg.EnableExperimentalFeatures)
+	}
 	defaults, err := resolveFromEnv(defaultLookup, DefaultConfig())
 	if err != nil {
 		log.Default().Printf("agento11y: skipping invalid env values: %v", err)
@@ -565,7 +572,7 @@ func NewClient(config Config) *Client {
 	}
 
 	// Build the otel handler before the exporter. Without
-	// EnvEnableExperimentalFeatures the handler fails, and the client then uses
+	// experimental features enabled, the handler fails, and the client then uses
 	// the noop exporter, which exports nothing.
 	var otelErr error
 	if cfg.GenerationExport.Protocol == GenerationExportProtocolOTel {

--- a/go/agento11y/errors.go
+++ b/go/agento11y/errors.go
@@ -78,8 +78,8 @@ var (
 	// ErrHookTransportFailed wraps hook evaluation transport failures.
 	// Only surfaced when HooksConfig.FailOpen is false.
 	ErrHookTransportFailed = errors.New("agento11y: hook evaluation transport failed")
-	// ErrExperimentalFeatureDisabled is returned when an experimental feature is
-	// called without EnvEnableExperimentalFeatures set. See RequireExperimental.
+	// ErrExperimentalFeatureDisabled is returned when an experimental features are disabled,
+	// but the client tried to use them.
 	ErrExperimentalFeatureDisabled = errors.New("agento11y: experimental feature disabled")
 )
 

--- a/go/agento11y/experimental.go
+++ b/go/agento11y/experimental.go
@@ -31,19 +31,57 @@ func ExperimentalFeaturesEnabled() bool {
 	}
 }
 
+func experimentalFeaturesEnabled(override *bool) bool {
+	if override != nil {
+		return *override
+	}
+	return ExperimentalFeaturesEnabled()
+}
+
+func experimentalFeatureName(feature string) string {
+	name := strings.TrimSpace(feature)
+	if name == "" {
+		return "this feature"
+	}
+	return name
+}
+
+func requireExperimental(feature string, override *bool) error {
+	if experimentalFeaturesEnabled(override) {
+		return nil
+	}
+	name := experimentalFeatureName(feature)
+	if override != nil {
+		return fmt.Errorf(
+			"%w: %s is experimental; EnableExperimentalFeatures is false; set it to BoolPtr(true) when constructing the client to use this feature",
+			ErrExperimentalFeatureDisabled, name,
+		)
+	}
+	return fmt.Errorf(
+		"%w: %s is experimental; set EnableExperimentalFeatures to BoolPtr(true) when constructing the client, or set %s=true",
+		ErrExperimentalFeatureDisabled, name, EnvEnableExperimentalFeatures,
+	)
+}
+
 // RequireExperimental returns ErrExperimentalFeatureDisabled unless the
-// experimental gate is set. Callers name the feature so the error says which one
-// was blocked.
+// environment enables experimental features. Client code should use
+// Client.RequireExperimental so a client-scoped override takes precedence.
 func RequireExperimental(feature string) error {
 	if ExperimentalFeaturesEnabled() {
 		return nil
 	}
-	name := strings.TrimSpace(feature)
-	if name == "" {
-		name = "this feature"
-	}
 	return fmt.Errorf(
 		"%w: %s is experimental; set %s=true to use it",
-		ErrExperimentalFeatureDisabled, name, EnvEnableExperimentalFeatures,
+		ErrExperimentalFeatureDisabled, experimentalFeatureName(feature), EnvEnableExperimentalFeatures,
 	)
+}
+
+// RequireExperimental returns ErrExperimentalFeatureDisabled unless this
+// client enables experimental features. Config.EnableExperimentalFeatures takes
+// precedence over the current EnvEnableExperimentalFeatures value.
+func (c *Client) RequireExperimental(feature string) error {
+	if c == nil {
+		return ErrNilClient
+	}
+	return requireExperimental(feature, c.config.EnableExperimentalFeatures)
 }

--- a/go/agento11y/experimental_test.go
+++ b/go/agento11y/experimental_test.go
@@ -39,6 +39,9 @@ func TestExperimentalFeaturesDisabledByDefault(t *testing.T) {
 			t.Fatalf("error %q does not mention %q", err.Error(), want)
 		}
 	}
+	if strings.Contains(err.Error(), "EnableExperimentalFeatures") {
+		t.Fatalf("package-level error must not suggest a client option: %v", err)
+	}
 }
 
 func TestExperimentalGateReadsTruthyValues(t *testing.T) {
@@ -69,19 +72,112 @@ func TestExperimentalGateReadsTruthyValues(t *testing.T) {
 	}
 }
 
+func TestClientExperimentalFeaturePrecedence(t *testing.T) {
+	cases := []struct {
+		name     string
+		override *bool
+		env      string
+		want     bool
+	}{
+		{name: "explicit true beats unset environment", override: BoolPtr(true), want: true},
+		{name: "explicit false beats truthy environment", override: BoolPtr(false), env: "true", want: false},
+		{name: "nil uses truthy environment", env: "true", want: true},
+		{name: "nil uses false environment", env: "false", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearExperimentalGate(t)
+			if tc.env != "" {
+				t.Setenv(EnvEnableExperimentalFeatures, tc.env)
+			}
+			client := NewClient(Config{
+				EnableExperimentalFeatures: tc.override,
+				testDisableWorker:          true,
+			})
+			t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
+
+			err := client.RequireExperimental(FeatureCloudTrialEvaluation)
+			if got := err == nil; got != tc.want {
+				t.Fatalf("RequireExperimental() admitted = %v, want %v; err = %v", got, tc.want, err)
+			}
+			if !tc.want && !errors.Is(err, ErrExperimentalFeatureDisabled) {
+				t.Fatalf("expected ErrExperimentalFeatureDisabled, got %v", err)
+			}
+			if tc.override != nil && !*tc.override {
+				if strings.Contains(err.Error(), EnvEnableExperimentalFeatures) {
+					t.Fatalf("explicit false error must not suggest an environment override: %v", err)
+				}
+				if !strings.Contains(err.Error(), "BoolPtr(true)") {
+					t.Fatalf("explicit false error must name the programmatic opt-in: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestClientExperimentalFeatureNilReadsCurrentEnvironment(t *testing.T) {
+	clearExperimentalGate(t)
+	client := NewClient(Config{testDisableWorker: true})
+	t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
+
+	if err := client.RequireExperimental(FeatureCloudTrialEvaluation); !errors.Is(err, ErrExperimentalFeatureDisabled) {
+		t.Fatalf("expected closed initial gate, got %v", err)
+	}
+	t.Setenv(EnvEnableExperimentalFeatures, "true")
+	if err := client.RequireExperimental(FeatureCloudTrialEvaluation); err != nil {
+		t.Fatalf("expected environment change to open nil client gate, got %v", err)
+	}
+	t.Setenv(EnvEnableExperimentalFeatures, "false")
+	if err := client.RequireExperimental(FeatureCloudTrialEvaluation); !errors.Is(err, ErrExperimentalFeatureDisabled) {
+		t.Fatalf("expected environment change to close nil client gate, got %v", err)
+	}
+}
+
+func TestClientExperimentalFeatureSettingsAreIsolated(t *testing.T) {
+	clearExperimentalGate(t)
+	openClient := NewClient(Config{EnableExperimentalFeatures: BoolPtr(true), testDisableWorker: true})
+	closedClient := NewClient(Config{EnableExperimentalFeatures: BoolPtr(false), testDisableWorker: true})
+	t.Cleanup(func() {
+		_ = openClient.Shutdown(context.Background())
+		_ = closedClient.Shutdown(context.Background())
+	})
+
+	if err := openClient.RequireExperimental(FeatureCloudTrialEvaluation); err != nil {
+		t.Fatalf("open client: %v", err)
+	}
+	if err := closedClient.RequireExperimental(FeatureCloudTrialEvaluation); !errors.Is(err, ErrExperimentalFeatureDisabled) {
+		t.Fatalf("closed client: expected ErrExperimentalFeatureDisabled, got %v", err)
+	}
+}
+
+func TestClientCopiesExperimentalFeatureSetting(t *testing.T) {
+	clearExperimentalGate(t)
+	enabled := true
+	client := NewClient(Config{EnableExperimentalFeatures: &enabled, testDisableWorker: true})
+	t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
+
+	enabled = false
+	if err := client.RequireExperimental(FeatureCloudTrialEvaluation); err != nil {
+		t.Fatalf("caller mutation changed client gate: %v", err)
+	}
+}
+
 func TestCloudTrialEvaluationBlockedWithoutTheGate(t *testing.T) {
 	recorder := &experimentRecorder{}
 	recorder.push(http.StatusOK, map[string]any{"trial_id": "trial-cloud"})
 	server := httptest.NewServer(recorder.handler(t))
 	defer server.Close()
-	client := newExperimentTestClient(t, server.URL)
+	t.Setenv(EnvEnableExperimentalFeatures, "true")
+	client := NewClient(Config{
+		API:                        APIConfig{Endpoint: server.URL},
+		EnableExperimentalFeatures: BoolPtr(false),
+		testGenerationExporter:     newNoopGenerationExporter(nil),
+		testDisableWorker:          true,
+	})
+	t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
 
-	// Built while the gate is still on, so the block below is the gate and not a
-	// setup failure.
 	trial := NewTrial(client, TrialRef{RunID: "run-cloud", TestCaseID: "case-cloud"})
 	trial.BindConversation("conv-1")
-
-	clearExperimentalGate(t)
 
 	cases := []struct {
 		name string

--- a/go/agento11y/experiments.go
+++ b/go/agento11y/experiments.go
@@ -218,13 +218,14 @@ func (c *Client) UpdateTrial(ctx context.Context, experimentID, trialID string, 
 // the same combination returns the existing evaluation instead of running it
 // twice, and requeues it once it has failed.
 //
-// Experimental: requires AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true, otherwise
-// it returns ErrExperimentalFeatureDisabled.
+// Experimental: Config.EnableExperimentalFeatures takes precedence over
+// AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES. A closed gate returns
+// ErrExperimentalFeatureDisabled.
 func (c *Client) TriggerTrialEvaluation(ctx context.Context, experimentID, trialID string, req TriggerTrialEvaluationRequest) (*TrialEvaluation, error) {
 	if c == nil {
 		return nil, ErrNilClient
 	}
-	if err := RequireExperimental(FeatureCloudTrialEvaluation); err != nil {
+	if err := c.RequireExperimental(FeatureCloudTrialEvaluation); err != nil {
 		return nil, err
 	}
 	normalizedRunID := strings.TrimSpace(experimentID)
@@ -259,13 +260,14 @@ func (c *Client) TriggerTrialEvaluation(ctx context.Context, experimentID, trial
 
 // GetTrialEvaluation reads durable status for a triggered trial evaluation.
 //
-// Experimental: requires AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true, otherwise
-// it returns ErrExperimentalFeatureDisabled.
+// Experimental: Config.EnableExperimentalFeatures takes precedence over
+// AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES. A closed gate returns
+// ErrExperimentalFeatureDisabled.
 func (c *Client) GetTrialEvaluation(ctx context.Context, experimentID, trialID, evaluationID string) (*TrialEvaluation, error) {
 	if c == nil {
 		return nil, ErrNilClient
 	}
-	if err := RequireExperimental(FeatureCloudTrialEvaluation); err != nil {
+	if err := c.RequireExperimental(FeatureCloudTrialEvaluation); err != nil {
 		return nil, err
 	}
 	normalizedRunID := strings.TrimSpace(experimentID)

--- a/go/agento11y/experiments/client.go
+++ b/go/agento11y/experiments/client.go
@@ -32,7 +32,11 @@ type ClientOptions struct {
 	GenerationEndpoint  string
 	Insecure            *bool
 	UseExperimentalOTel *bool
-	RedactSecrets       *bool
+	// EnableExperimentalFeatures controls experimental features for this client.
+	// A non-nil value overrides AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES. When nil,
+	// each feature check reads the current environment value.
+	EnableExperimentalFeatures *bool
+	RedactSecrets              *bool
 }
 
 // Client owns the shared core transport used for experiment, generation,
@@ -86,8 +90,9 @@ func NewClient(opts ClientOptions) (*Client, error) {
 			Insecure:    insecure,
 			HTTPTimeout: opts.RetryTimeout,
 		},
-		ExperimentRetryTimeout:  opts.RetryTimeout,
-		RedactExperimentSecrets: redact,
+		ExperimentRetryTimeout:     opts.RetryTimeout,
+		RedactExperimentSecrets:    redact,
+		EnableExperimentalFeatures: opts.EnableExperimentalFeatures,
 	}
 	if redact {
 		cfg.GenerationSanitizer = agento11y.NewSecretRedactionSanitizer(agento11y.SecretRedactionOptions{
@@ -154,8 +159,9 @@ func (c *Client) UpdateTrial(ctx context.Context, experimentID, trialID string, 
 // wait. The evaluator ID and version are sent as given, like every other
 // resource identifier in this package.
 //
-// Experimental: requires AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true, otherwise
-// it returns agento11y.ErrExperimentalFeatureDisabled.
+// Experimental: ClientOptions.EnableExperimentalFeatures takes precedence over
+// AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES. When disabled, returns
+// agento11y.ErrExperimentalFeatureDisabled.
 func (c *Client) TriggerTrialEvaluation(ctx context.Context, experimentID, trialID string, req TriggerTrialEvaluationRequest) (*TrialEvaluation, error) {
 	if c == nil || c.core == nil {
 		return nil, agento11y.ErrNilClient
@@ -165,8 +171,9 @@ func (c *Client) TriggerTrialEvaluation(ctx context.Context, experimentID, trial
 
 // GetTrialEvaluation reads durable status for a triggered trial evaluation.
 //
-// Experimental: requires AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true, otherwise
-// it returns agento11y.ErrExperimentalFeatureDisabled.
+// Experimental: ClientOptions.EnableExperimentalFeatures takes precedence over
+// AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES. When disabled, returns
+// agento11y.ErrExperimentalFeatureDisabled.
 func (c *Client) GetTrialEvaluation(ctx context.Context, experimentID, trialID, evaluationID string) (*TrialEvaluation, error) {
 	if c == nil || c.core == nil {
 		return nil, agento11y.ErrNilClient

--- a/go/agento11y/experiments/experiment.go
+++ b/go/agento11y/experiments/experiment.go
@@ -941,16 +941,17 @@ func (o EvaluateOptions) resolve() (timeout, pollInterval time.Duration, err err
 // experiment, so a caller who built this trial with NewTrial must leave
 // FinalizeOptions.ScoreCount unset when finalizing the run itself.
 //
-// Experimental: requires AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true, otherwise
-// it returns agento11y.ErrExperimentalFeatureDisabled without sending a request.
-// This call can change or be removed in any release.
+// Experimental: ClientOptions.EnableExperimentalFeatures takes precedence over
+// AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES. A closed gate returns
+// agento11y.ErrExperimentalFeatureDisabled before any trial state or generation
+// is sent. This call can change or be removed in any release.
 func (t *Trial) Evaluate(ctx context.Context, evaluatorID string, options ...EvaluateOptions) (*TrialEvaluation, error) {
 	if t == nil || t.client == nil {
 		return nil, agento11y.ErrNilClient
 	}
 	// Checked before the trial is created and the anchor generation is flushed, so
 	// a blocked call leaves nothing behind.
-	if err := agento11y.RequireExperimental(agento11y.FeatureCloudTrialEvaluation); err != nil {
+	if err := t.client.core.RequireExperimental(agento11y.FeatureCloudTrialEvaluation); err != nil {
 		return nil, err
 	}
 	if ctx == nil {

--- a/go/agento11y/experiments/experiments_test.go
+++ b/go/agento11y/experiments/experiments_test.go
@@ -477,7 +477,7 @@ func TestTrialFlushCreatesTrialBeforePublishingScores(t *testing.T) {
 }
 
 func TestClientRedactsScoresAndTextArtifactsByDefault(t *testing.T) {
-	const secret = "glc_abcdefghijklmnopqrstuvwxyz123456"
+	const secret = "glc_abcdefghijklmnopqrstuvwxyz123456" // trufflehog:ignore
 	var bodies []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		raw, _ := io.ReadAll(r.Body)
@@ -723,11 +723,16 @@ func (s *trialEvaluationServer) statusRequestCount() int {
 	return count
 }
 
-func (s *trialEvaluationServer) newClient(t *testing.T) *Client {
+func (s *trialEvaluationServer) newClient(t *testing.T, enableExperimentalFeatures ...*bool) *Client {
 	t.Helper()
+	var experimentalOverride *bool
+	if len(enableExperimentalFeatures) > 0 {
+		experimentalOverride = enableExperimentalFeatures[0]
+	}
 	client, err := NewClient(ClientOptions{
 		Endpoint: s.server.URL, TenantID: "123", IngestToken: "token",
-		UseExperimentalOTel: boolPointer(false),
+		UseExperimentalOTel:        boolPointer(false),
+		EnableExperimentalFeatures: experimentalOverride,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -737,8 +742,9 @@ func (s *trialEvaluationServer) newClient(t *testing.T) *Client {
 }
 
 func TestClientForwardsTrialEvaluationCalls(t *testing.T) {
+	clearExperimentalGate(t)
 	server := newTrialEvaluationServer(t, "queued")
-	client := server.newClient(t)
+	client := server.newClient(t, boolPointer(true))
 
 	evaluation, err := client.TriggerTrialEvaluation(context.Background(), "exp-1", "trial-1", TriggerTrialEvaluationRequest{
 		EvaluatorID: "helpfulness", EvaluatorVersion: "v3",
@@ -786,9 +792,9 @@ func TestNilClientTrialEvaluationCallsDoNotRequest(t *testing.T) {
 	}
 }
 
-func newCloudEvaluatedTrial(t *testing.T, server *trialEvaluationServer) (*Experiment, *Trial) {
+func newCloudEvaluatedTrial(t *testing.T, server *trialEvaluationServer, enableExperimentalFeatures ...*bool) (*Experiment, *Trial) {
 	t.Helper()
-	client := server.newClient(t)
+	client := server.newClient(t, enableExperimentalFeatures...)
 	experiment, err := NewExperiment(client, ExperimentOptions{
 		ExperimentID: "run-1", Name: "run",
 		Suite: &TestSuite{SuiteID: "suite", TestCases: []TestCase{{TestCaseID: "case", Input: "2+2"}}},
@@ -819,8 +825,9 @@ func indexOfRequest(requests []capturedRequest, match func(capturedRequest) bool
 }
 
 func TestTrialEvaluatePersistsConversationAndClosesCompleted(t *testing.T) {
+	clearExperimentalGate(t)
 	server := newTrialEvaluationServer(t, "queued", "claimed", "success")
-	_, trial := newCloudEvaluatedTrial(t, server)
+	_, trial := newCloudEvaluatedTrial(t, server, boolPointer(true))
 	trial.BindConversation("conv-1").RecordIO(RecordIOOptions{Input: "2+2", Output: "4"})
 
 	evaluation, err := trial.Evaluate(context.Background(), "helpfulness", EvaluateOptions{
@@ -1118,15 +1125,12 @@ func clearExperimentalGate(t *testing.T) {
 }
 
 func TestCloudTrialEvaluationBlockedWithoutTheGate(t *testing.T) {
+	t.Setenv(agento11y.EnvEnableExperimentalFeatures, "true")
 	server := newTrialEvaluationServer(t, "success")
-	// Built while the gate is still on, so the block below is the gate and not a
-	// setup failure.
-	_, trial := newCloudEvaluatedTrial(t, server)
+	_, trial := newCloudEvaluatedTrial(t, server, boolPointer(false))
 	trial.BindConversation("conv-1")
-	client := server.newClient(t)
+	client := server.newClient(t, boolPointer(false))
 	before := len(server.captured())
-
-	clearExperimentalGate(t)
 
 	if _, err := trial.Evaluate(context.Background(), "helpfulness"); !errors.Is(err, agento11y.ErrExperimentalFeatureDisabled) {
 		t.Fatalf("expected ErrExperimentalFeatureDisabled from Trial.Evaluate, got %v", err)

--- a/go/agento11y/otel_export.go
+++ b/go/agento11y/otel_export.go
@@ -84,9 +84,10 @@ func (c *Client) flushOTel(ctx context.Context) error {
 	return nil
 }
 
-// newOTelHandler builds the otelgenai handler for otel-mode export. When the
-// experimental gate is closed it returns a nil handler and an error, and the
-// caller then falls back to the noop exporter.
+// newOTelHandler builds the otelgenai handler for otel-mode export. It resolves
+// Config.EnableExperimentalFeatures before the environment fallback. When the
+// gate is closed it returns a nil handler and an error, and the caller uses the
+// noop exporter.
 //
 // The handler gets its tracer and spec meter from Config.TracerProvider and
 // Config.MeterProvider, or from the corresponding global providers.
@@ -96,7 +97,7 @@ func (c *Client) flushOTel(ctx context.Context) error {
 // otelHandlerOptions disables operation-details records. A process-wide OTel
 // environment variable must not add a signal the client did not configure.
 func newOTelHandler(cfg Config) (*otelgenai.Handler, error) {
-	if err := RequireExperimental(FeatureOTelGenerationExport); err != nil {
+	if err := requireExperimental(FeatureOTelGenerationExport, cfg.EnableExperimentalFeatures); err != nil {
 		return nil, err
 	}
 	return otelgenai.NewHandler(otelHandlerOptions(cfg)...), nil

--- a/go/agento11y/otel_export_test.go
+++ b/go/agento11y/otel_export_test.go
@@ -410,17 +410,23 @@ func TestOTelProtocolDropsWorkflowSteps(t *testing.T) {
 func TestOTelProtocolRequiresExperimentalGate(t *testing.T) {
 	cases := []struct {
 		name         string
+		override     *bool
 		experimental string
 		wantOTel     bool
 	}{
-		{name: "gate open", experimental: "true", wantOTel: true},
-		{name: "gate unset", experimental: "", wantOTel: false},
-		{name: "gate off", experimental: "false", wantOTel: false},
+		{name: "explicit true with gate unset", override: BoolPtr(true), wantOTel: true},
+		{name: "explicit false with gate open", override: BoolPtr(false), experimental: "true", wantOTel: false},
+		{name: "nil with gate open", experimental: "true", wantOTel: true},
+		{name: "nil with gate unset", wantOTel: false},
+		{name: "nil with gate off", experimental: "false", wantOTel: false},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv(EnvEnableExperimentalFeatures, tc.experimental)
+			clearExperimentalGate(t)
+			if tc.experimental != "" {
+				t.Setenv(EnvEnableExperimentalFeatures, tc.experimental)
+			}
 
 			recorder := tracetest.NewSpanRecorder()
 			provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
@@ -429,6 +435,7 @@ func TestOTelProtocolRequiresExperimentalGate(t *testing.T) {
 			})
 
 			cfg := DefaultConfig()
+			cfg.EnableExperimentalFeatures = tc.override
 			cfg.GenerationExport.Protocol = GenerationExportProtocolOTel
 			cfg.ContentCapture = ContentCaptureModeFullWithMetadataSpans
 			cfg.TracerProvider = provider
@@ -465,6 +472,32 @@ func TestOTelProtocolRequiresExperimentalGate(t *testing.T) {
 			_, hasTitle := spanAttributeMapOf(span)["agento11y.conversation.title"]
 			if hasTitle != tc.wantOTel {
 				t.Errorf("conversation title present = %v, want %v", hasTitle, tc.wantOTel)
+			}
+		})
+	}
+}
+
+func TestOTelProtocolAdmissionIsFixedAfterNewClient(t *testing.T) {
+	cases := []struct {
+		name       string
+		initialEnv string
+		changedEnv string
+		wantOTel   bool
+	}{
+		{name: "open stays open", initialEnv: "true", changedEnv: "false", wantOTel: true},
+		{name: "closed stays closed", initialEnv: "false", changedEnv: "true", wantOTel: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvEnableExperimentalFeatures, tc.initialEnv)
+			cfg := DefaultConfig()
+			cfg.GenerationExport.Protocol = GenerationExportProtocolOTel
+			client := NewClient(cfg)
+			t.Cleanup(func() { _ = client.Shutdown(context.Background()) })
+
+			t.Setenv(EnvEnableExperimentalFeatures, tc.changedEnv)
+			if got := client.otelExportEnabled(); got != tc.wantOTel {
+				t.Fatalf("otelExportEnabled() after environment change = %v, want %v", got, tc.wantOTel)
 			}
 		})
 	}

--- a/go/agento11y/trial.go
+++ b/go/agento11y/trial.go
@@ -298,16 +298,17 @@ func (o EvaluateOptions) resolve() (timeout, pollInterval time.Duration, err err
 // built this trial with NewTrial or NewTrialFromRef must leave
 // CompleteExperimentOptions.ScoreCount unset when finalizing the run itself.
 //
-// Experimental: requires AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true, otherwise
-// it returns ErrExperimentalFeatureDisabled without sending a request. This call
-// can change or be removed in any release.
+// Experimental: Config.EnableExperimentalFeatures takes precedence over
+// AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES. A closed gate returns
+// ErrExperimentalFeatureDisabled before any trial state or generation is sent.
+// This call can change or be removed in any release.
 func (t *Trial) Evaluate(ctx context.Context, evaluatorID string, options ...EvaluateOptions) (*TrialEvaluation, error) {
 	if t == nil || t.client == nil {
 		return nil, ErrNilClient
 	}
 	// Checked before the trial is created and the generation is flushed, so a
 	// blocked call leaves nothing behind.
-	if err := RequireExperimental(FeatureCloudTrialEvaluation); err != nil {
+	if err := t.client.RequireExperimental(FeatureCloudTrialEvaluation); err != nil {
 		return nil, err
 	}
 	if ctx == nil {

--- a/llms.txt
+++ b/llms.txt
@@ -509,12 +509,15 @@ a stored test suite.
 - `trial.evaluate(evaluator_id)` grades the trial's bound
   conversation with an evaluator that already exists in the tenant, instead of a
   locally computed score. Go spells it `trial.Evaluate(ctx, evaluatorID)` and
-  JavaScript `trial.evaluate(evaluatorId)`, and the rest of this bullet holds for
-  all three. Experimental: it requires
-  `AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true` and otherwise raises
-  `ExperimentalFeatureDisabledError` without sending a request. It blocks until the worker finishes, and the trial then
-  closes as `completed` with no local `final_score`. Requires
-  `trial.bind_conversation(...)` first.
+  JavaScript `trial.evaluate(evaluatorId)`. Python and JavaScript require
+  `AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true`; otherwise they raise
+  `ExperimentalFeatureDisabledError` without sending a request. Go can set
+  `experiments.ClientOptions.EnableExperimentalFeatures` to
+  `agento11y.BoolPtr(true)`, or
+  leave it nil and use the same environment variable. A closed Go gate returns
+  `ErrExperimentalFeatureDisabled` without sending a request. The call blocks
+  until the worker finishes, and the trial then closes as `completed` with no
+  local `final_score`. Call `trial.bind_conversation(...)` first.
   - The score is stored against the conversation and the trial, with no
     `generation_id`, so read it from the experiment's scores or the trial's
     `scores` in the report rather than from a per-generation lookup.
@@ -543,9 +546,12 @@ idempotent identities.
 
 The Go SDK can also grade a trial with an evaluator stored in the tenant instead
 of a locally computed score: `trial.Evaluate(ctx, evaluatorID, ...)`.
-Experimental: it requires `AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true` and
-otherwise returns `ErrExperimentalFeatureDisabled` without sending a request. Bind the
-agent's conversation first; the call persists that binding, exports the anchor
+Experimental: set `EnableExperimentalFeatures: agento11y.BoolPtr(true)` in
+`experiments.ClientOptions`. If the field is nil,
+`AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true` remains an alternative. Explicit
+false overrides the environment. A closed gate returns
+`ErrExperimentalFeatureDisabled` without sending a request. Bind the agent's
+conversation first; the call persists that binding, exports the anchor
 generation, queues the stored evaluator, and blocks until the worker reaches a
 terminal status. Such a trial closes as `completed` with no local final score,
 while an error returned from the trial callback after the call still closes it as


### PR DESCRIPTION
Currently experimental SDK features can be enabled with the `AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES` environment variable. This PR adds a per-client opt-in for experimental features to the Go SDK.

**Core SDK client:**

```go
client := agento11y.NewClient(agento11y.Config{
	EnableExperimentalFeatures: agento11y.BoolPtr(true),
})
defer func() { _ = client.Shutdown(context.Background()) }()
```

**Experiments client:**

```go
client, err := experiments.NewClient(experiments.ClientOptions{
	EnableExperimentalFeatures: agento11y.BoolPtr(true),
})
if err != nil {
	return err
}
defer client.Shutdown(context.Background())
```

A `nil` option preserves the existing environment-variable behavior. An explicit `false` disables experimental features for that client, even when `AGENTO11Y_ENABLE_EXPERIMENTAL_FEATURES=true`.
