### PR TITLE
fix(sdk-go): align OTel generation attributes and tag routing

### DIFF
--- a/docs/concepts/tags-and-metadata.md
+++ b/docs/concepts/tags-and-metadata.md
@@ -1,6 +1,9 @@
 # Tags and Metadata
 
-The SDK lets you attach custom key/value data (team, project, environment, request ID, end-user id) to what you record. Where each piece of data shows up depends on how you attach it. There are three independent mechanisms, and only one of them reaches OTel metrics.
+The SDK lets you attach custom key/value data (team, project, environment, request ID, end-user ID) to what you record.
+Where each piece of data appears depends on how you attach it.
+There are three cross-SDK mechanisms.
+Go also supports per-request context tags, which reach OTel metrics.
 
 Each SDK README links here for the language-specific config fields.
 
@@ -9,10 +12,16 @@ Each SDK README links here for the language-specific config fields.
 | Mechanism | Set where | Cardinality | Generation export (Agent Observability UI) | OTel spans (traces) | OTel metrics |
 | --- | --- | --- | --- | --- | --- |
 | **Client tags** (`AGENTO11Y_TAGS` / config `tags`) | Once, on the client | Keep low | Yes, merged into every generation | Yes, as `agento11y.tag.<key>` | Yes, as `agento11y.tag.<key>` |
-| **Per-generation `tags`** | Per `startGeneration` call | Any | Yes | No | No |
-| **`metadata`** (struct/dict) | Per `startGeneration` call | Any | Yes | No | No |
+| **Go context tags** (`WithTag` / `WithTags`) | Per request, on the context | Keep low | Yes, merged into the generation | Yes, as `agento11y.tag.<key>` | Yes, as `agento11y.tag.<key>` |
+| **Per-generation `tags`** | Per `startGeneration` call | Any | Yes | Only as the `agento11y.generation.tags` JSON document in Go OTel generation-export mode | No |
+| **`metadata`** (struct/dict) | Per `startGeneration` call | Any | Yes | Only as the `agento11y.generation.metadata` JSON document in Go OTel generation-export mode | No |
 
-There is also a dedicated **`user_id`** field (`AGENTO11Y_USER_ID` / config / per-call / context). It is recorded on the generation export and on the generation span as the `user.id` attribute (all SDKs), but it is **not** a metric label.
+In Go OTel generation-export mode, the generation span is also the transport.
+The JSON document attributes preserve export-only tags and metadata without creating `agento11y.tag.<key>` dimensions or metric labels.
+
+There is also a dedicated **`user_id`** field (`AGENTO11Y_USER_ID` / config / per-call / context).
+All SDKs record it on the generation export and on the generation span as the `user.id` attribute.
+It is **not** a metric label.
 
 ## Cross-SDK parity
 
@@ -57,9 +66,28 @@ const agento11y = createAgento11yClient({
 });
 ```
 
-### Per-generation tags, metadata, and user id
+### Go context tags for one request
 
-Per-call values win over client-level values on key conflict. Per-call `tags` and `metadata` are export-only; they do not appear on spans or metrics.
+Use `WithTag` or `WithTags` to add low-cardinality dimensions to one request and its generation export:
+
+```go
+ctx = agento11y.WithTags(ctx, map[string]string{
+    "route":  "checkout",
+    "region": "us-east-1",
+})
+ctx, rec := client.StartGeneration(ctx, agento11y.GenerationStart{
+    Model: agento11y.ModelRef{Provider: "openai", Name: "gpt-4.1-mini"},
+})
+```
+
+Context tags override client tags on span and metric conflicts.
+Generation-start tags override client and context tags only in the generation export.
+Generation-result tags override every earlier source there, including generation-start tags.
+
+### Per-generation tags, metadata, and user ID
+
+In the generation export, generation-result values win over generation-start values, which win over client and Go context tags.
+Per-generation `tags` and `metadata` remain export-only and don't become span or metric dimensions.
 
 **Go**
 

--- a/go/agento11y/otel_export.go
+++ b/go/agento11y/otel_export.go
@@ -206,7 +206,19 @@ func (c *Client) endOTelGeneration(
 	if invocation == nil {
 		return
 	}
-	applyGenerationToInvocation(invocation, generation, failure, firstTokenAt, capture)
+	priorityAttrs := make([]attribute.KeyValue, 0, 4)
+	if !failure.rejected && generation.ID != "" {
+		priorityAttrs = append(priorityAttrs,
+			attribute.String(otelhook.AttrRecord, "true"),
+			attribute.String(otelhook.AttrGenerationID, generation.ID),
+		)
+	}
+	priorityAttrs = append(priorityAttrs, otelSDKGenerationAttributes(generation)...)
+	// OTel drops newly seen keys after the span attribute limit is reached.
+	// Reserve routing and SDK attributes before optional tag dimensions.
+	invocation.Span().SetAttributes(priorityAttrs...)
+	dimensionalTags := mergeTags(c.config.Tags, TagsFromContext(ctx))
+	applyGenerationToInvocation(invocation, generation, failure, firstTokenAt, capture, dimensionalTags)
 	invocation.MetricAttributes = c.otelMetricAttributes(ctx, generation, failure)
 	// metricExemplarContext strips the context down to its span context, which
 	// is what an exemplar needs, because an exemplar reservoir retains whatever
@@ -237,6 +249,14 @@ func (c *Client) otelMetricAttributes(ctx context.Context, generation Generation
 	return attrs
 }
 
+func otelSDKGenerationAttributes(generation Generation) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{attribute.String(sdkMetadataKeyName, sdkName)}
+	if thinkingBudget, ok := thinkingBudgetFromMetadata(generation.Metadata); ok {
+		attrs = append(attrs, attribute.Int64(spanAttrRequestThinkingBudget, thinkingBudget))
+	}
+	return attrs
+}
+
 // applyGenerationToInvocation maps a normalized generation onto the
 // invocation otelgenai emits. Content arrives already sanitized and, under
 // metadata_only, already stripped.
@@ -246,10 +266,12 @@ func applyGenerationToInvocation(
 	failure generationError,
 	firstTokenAt time.Time,
 	capture ContentCaptureMode,
+	dimensionalTags map[string]string,
 ) {
 	// The client's mode set the handler's default. capture is the mode after
 	// the per-call field and the resolver applied their overrides.
 	invocation.Capture = otelCaptureMode(capture)
+	invocation.Attributes = append(invocation.Attributes, otelSDKGenerationAttributes(generation)...)
 	invocation.Operation = otelOperation(generation.OperationName)
 	invocation.Provider = otelProviderName(generation.Model.Provider)
 	invocation.RequestModel = generation.Model.Name
@@ -306,7 +328,10 @@ func applyGenerationToInvocation(
 		invocation.InputMessages = nil
 		invocation.OutputMessages = nil
 		invocation.ToolDefinitions = nil
-		invocation.Vendor = nil
+		invocation.Vendor = otelhook.Generation{
+			DimensionalTags: dimensionalTags,
+			Rejected:        true,
+		}
 		return
 	}
 
@@ -315,6 +340,7 @@ func applyGenerationToInvocation(
 		UserID:              generation.UserID,
 		ConversationTitle:   generation.ConversationTitle,
 		Tags:                generation.Tags,
+		DimensionalTags:     dimensionalTags,
 		Metadata:            generation.Metadata,
 		Artifacts:           otelArtifacts(generation.Artifacts),
 		ParentGenerationIDs: generation.ParentGenerationIDs,

--- a/go/agento11y/otel_export_test.go
+++ b/go/agento11y/otel_export_test.go
@@ -3,6 +3,7 @@ package agento11y
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"log"
 	"slices"
@@ -24,13 +25,14 @@ import (
 
 // newOTelTestClient builds a client in otel export mode with the experimental
 // gate open, recording spans into the returned recorder.
-func newOTelTestClient(t *testing.T, mutate func(*Config)) (*Client, *tracetest.SpanRecorder, *sdktrace.TracerProvider) {
+func newOTelTestClient(t *testing.T, mutate func(*Config), traceOptions ...sdktrace.TracerProviderOption) (*Client, *tracetest.SpanRecorder, *sdktrace.TracerProvider) {
 	t.Helper()
 
 	t.Setenv(EnvEnableExperimentalFeatures, "true")
 
 	recorder := tracetest.NewSpanRecorder()
-	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	options := append([]sdktrace.TracerProviderOption{sdktrace.WithSpanProcessor(recorder)}, traceOptions...)
+	provider := sdktrace.NewTracerProvider(options...)
 	t.Cleanup(func() {
 		_ = provider.Shutdown(context.Background())
 	})
@@ -122,11 +124,14 @@ func TestOTelProtocolSpan(t *testing.T) {
 		check   func(t *testing.T, span sdktrace.ReadOnlySpan)
 	}{
 		{
-			name: "semconv span replaces the metadata span",
+			name: "semconv span carries SDK attributes",
 			content: Generation{
 				Input:  []Message{UserTextMessage("Hello")},
 				Output: []Message{AssistantTextMessage("Hi!")},
 				Usage:  TokenUsage{InputTokens: 120, OutputTokens: 42, TotalTokens: 162},
+				Metadata: map[string]any{
+					spanAttrRequestThinkingBudget: int64(2048),
+				},
 			},
 			check: func(t *testing.T, span sdktrace.ReadOnlySpan) {
 				if got := span.Name(); got != "chat gpt-5" {
@@ -145,8 +150,21 @@ func TestOTelProtocolSpan(t *testing.T) {
 				if got := attrs["gen_ai.input.messages"].AsString(); !strings.Contains(got, "Hello") {
 					t.Errorf("gen_ai.input.messages = %q, want it to contain Hello", got)
 				}
-				if _, ok := attrs["agento11y.sdk.name"]; ok {
-					t.Error("otel-mode span carries the metadata-span attributes")
+				if got := attrs[sdkMetadataKeyName].AsString(); got != sdkName {
+					t.Errorf("%s = %q, want %q", sdkMetadataKeyName, got, sdkName)
+				}
+				if got := attrs[spanAttrRequestThinkingBudget].AsInt64(); got != 2048 {
+					t.Errorf("%s = %d, want 2048", spanAttrRequestThinkingBudget, got)
+				}
+				metadata := map[string]any{}
+				if err := json.Unmarshal([]byte(attrs["agento11y.generation.metadata"].AsString()), &metadata); err != nil {
+					t.Fatalf("unmarshal generation metadata: %v", err)
+				}
+				if got := metadata[sdkMetadataKeyName]; got != sdkName {
+					t.Errorf("metadata[%q] = %#v, want %q", sdkMetadataKeyName, got, sdkName)
+				}
+				if got := metadata[spanAttrRequestThinkingBudget]; got != float64(2048) {
+					t.Errorf("metadata[%q] = %#v, want 2048", spanAttrRequestThinkingBudget, got)
 				}
 				if attrs["agento11y.generation.id"].AsString() == "" {
 					t.Error("otel-mode span carries no agento11y.generation.id")
@@ -338,6 +356,169 @@ func TestOTelProtocolSpan(t *testing.T) {
 			recordOTelGeneration(t, client, tc.content)
 			tc.check(t, onlySpan(t, recorder))
 		})
+	}
+}
+
+func TestOTelProtocolTagDestinations(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	client, recorder, _ := newOTelTestClient(t, func(cfg *Config) {
+		meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+		t.Cleanup(func() { _ = meterProvider.Shutdown(context.Background()) })
+		cfg.MeterProvider = meterProvider
+		cfg.Tags = map[string]string{
+			"shared":      "client",
+			"client_only": "client",
+		}
+	})
+
+	ctx := WithTags(context.Background(), map[string]string{
+		"shared":       "context",
+		"context_only": "context",
+	})
+	_, rec := client.StartGeneration(ctx, GenerationStart{
+		Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+		Tags: map[string]string{
+			"shared":     "start",
+			"start_only": "start",
+		},
+	})
+	rec.SetResult(Generation{
+		Tags: map[string]string{
+			"shared":      "result",
+			"result_only": "result",
+		},
+		Usage: TokenUsage{InputTokens: 10, OutputTokens: 2},
+	}, nil)
+	rec.End()
+
+	attrs := spanAttributeMapOf(onlySpan(t, recorder))
+	for key, want := range map[string]string{
+		"shared":       "context",
+		"client_only":  "client",
+		"context_only": "context",
+	} {
+		if got := attrs[spanAttrTagPrefix+key].AsString(); got != want {
+			t.Errorf("%s%s = %q, want %q", spanAttrTagPrefix, key, got, want)
+		}
+	}
+	for _, key := range []string{"start_only", "result_only"} {
+		if _, ok := attrs[spanAttrTagPrefix+key]; ok {
+			t.Errorf("span carries dimension %s%s for an export-only tag", spanAttrTagPrefix, key)
+		}
+	}
+
+	var tags map[string]string
+	if err := json.Unmarshal([]byte(attrs["agento11y.generation.tags"].AsString()), &tags); err != nil {
+		t.Fatalf("unmarshal generation tags: %v", err)
+	}
+	for key, want := range map[string]string{
+		"shared":       "result",
+		"client_only":  "client",
+		"context_only": "context",
+		"start_only":   "start",
+		"result_only":  "result",
+	} {
+		if got := tags[key]; got != want {
+			t.Errorf("generation tags[%q] = %q, want %q", key, got, want)
+		}
+	}
+
+	var collected metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &collected); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	metricCount := 0
+	for _, scope := range collected.ScopeMetrics {
+		if scope.Scope.Name != otelgenai.ScopeName {
+			continue
+		}
+		for _, metric := range scope.Metrics {
+			if metric.Name != "gen_ai.client.operation.duration" && metric.Name != "gen_ai.client.token.usage" {
+				continue
+			}
+			metricCount++
+			metricAttrs := histogramAttributes(t, metric)
+			for key, want := range map[string]string{
+				"shared":       "context",
+				"client_only":  "client",
+				"context_only": "context",
+			} {
+				if got := metricAttrs[spanAttrTagPrefix+key]; got != want {
+					t.Errorf("%s %s%s = %q, want %q", metric.Name, spanAttrTagPrefix, key, got, want)
+				}
+			}
+			for _, key := range []string{"start_only", "result_only"} {
+				if _, ok := metricAttrs[spanAttrTagPrefix+key]; ok {
+					t.Errorf("%s carries dimension %s%s for an export-only tag", metric.Name, spanAttrTagPrefix, key)
+				}
+			}
+		}
+	}
+	if metricCount != 2 {
+		t.Errorf("checked %d OTel generation metrics, want 2", metricCount)
+	}
+}
+
+func TestOTelProtocolPreservesExportContractAtSpanLimit(t *testing.T) {
+	limits := sdktrace.NewSpanLimits()
+	limits.AttributeCountLimit = 16
+	tags := map[string]string{
+		"tag_01": "value", "tag_02": "value", "tag_03": "value",
+		"tag_04": "value", "tag_05": "value", "tag_06": "value",
+		"tag_07": "value", "tag_08": "value", "tag_09": "value",
+		"tag_10": "value", "tag_11": "value", "tag_12": "value",
+	}
+	client, recorder, _ := newOTelTestClient(t, func(cfg *Config) {
+		cfg.Tags = tags
+	}, sdktrace.WithRawSpanLimits(limits))
+
+	_, rec := client.StartGeneration(context.Background(), GenerationStart{
+		ID:    "generation-at-span-limit",
+		Model: ModelRef{Provider: "openai", Name: "gpt-5"},
+	})
+	rec.SetResult(Generation{}, nil)
+	rec.End()
+	if err := rec.Err(); err != nil {
+		t.Fatalf("recorder: %v", err)
+	}
+
+	span := onlySpan(t, recorder)
+	attrs := spanAttributeMapOf(span)
+	for key, want := range map[string]string{
+		"agento11y.record":   "true",
+		spanAttrGenerationID: "generation-at-span-limit",
+		sdkMetadataKeyName:   sdkName,
+	} {
+		got, ok := attrs[key]
+		if !ok {
+			t.Errorf("%s is absent, want %q", key, want)
+			continue
+		}
+		if got.AsString() != want {
+			t.Errorf("%s = %q, want %q", key, got.AsString(), want)
+		}
+	}
+	var exportedTags map[string]string
+	if err := json.Unmarshal([]byte(attrs["agento11y.generation.tags"].AsString()), &exportedTags); err != nil {
+		t.Fatalf("unmarshal generation tags: %v", err)
+	}
+	for key, want := range tags {
+		if got := exportedTags[key]; got != want {
+			t.Errorf("generation tags[%q] = %q, want %q", key, got, want)
+		}
+	}
+	if got := span.DroppedAttributes(); got == 0 {
+		t.Fatal("span dropped no attributes; test did not reach the configured limit")
+	}
+	droppedDimension := false
+	for key := range tags {
+		if _, ok := attrs[spanAttrTagPrefix+key]; !ok {
+			droppedDimension = true
+			break
+		}
+	}
+	if !droppedDimension {
+		t.Error("all optional tag dimensions survived the span attribute limit")
 	}
 }
 
@@ -989,7 +1170,9 @@ func TestOTelProtocolDropsValidatorRejectedRecords(t *testing.T) {
 	// A record the SDK's validator refuses is never enqueued on the other
 	// protocols. In otel mode the span is the export, so it has to close
 	// without the id and the content that would make it a generation.
-	client, recorder, _ := newOTelTestClient(t, nil)
+	client, recorder, _ := newOTelTestClient(t, func(cfg *Config) {
+		cfg.Tags = map[string]string{"team": "sigil"}
+	})
 
 	_, rec := client.StartGeneration(context.Background(), GenerationStart{
 		Model: ModelRef{Provider: "openai", Name: "gpt-5"},
@@ -1011,6 +1194,12 @@ func TestOTelProtocolDropsValidatorRejectedRecords(t *testing.T) {
 
 	span := onlySpan(t, recorder)
 	attrs := spanAttributeMapOf(span)
+	if got := attrs[sdkMetadataKeyName].AsString(); got != sdkName {
+		t.Errorf("%s = %q, want %q", sdkMetadataKeyName, got, sdkName)
+	}
+	if got := attrs[spanAttrTagPrefix+"team"].AsString(); got != "sigil" {
+		t.Errorf("%steam = %q, want sigil", spanAttrTagPrefix, got)
+	}
 	if _, ok := attrs["agento11y.generation.id"]; ok {
 		t.Error("a rejected record carries agento11y.generation.id, so the backend would store it")
 	}

--- a/go/agento11y/otel_wire_test.go
+++ b/go/agento11y/otel_wire_test.go
@@ -20,7 +20,7 @@ import (
 // mode emits the matching span.
 //
 // OTel mode maps the SDK's generateText and streamText defaults to "chat". It
-// also adds agento11y.record=true, which agento11y needs. OTLP attribute order
+// also adds agento11y.record=true and the Go SDK identity. OTLP attribute order
 // has no meaning, so this test compares attributes as a set.
 //
 // The test calls the OTel helpers directly because openai_sync contains a
@@ -49,6 +49,7 @@ func TestOTelModeMatchesGoldenWireFormat(t *testing.T) {
 			got := renderedAttributes(t, span)
 			wantAttributes := want.attributes(t)
 			wantAttributes["agento11y.record"] = "string:true"
+			wantAttributes[sdkMetadataKeyName] = "string:" + sdkName
 			for key, wantValue := range wantAttributes {
 				gotValue, ok := got[key]
 				if !ok {

--- a/go/agento11y/otelhook/hook.go
+++ b/go/agento11y/otelhook/hook.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -29,7 +30,8 @@ import (
 )
 
 const (
-	attrRecord              = "agento11y.record"
+	// AttrRecord marks a span as an agento11y generation transport record.
+	AttrRecord              = "agento11y.record"
 	AttrGenerationID        = "agento11y.generation.id"
 	AttrParentGenerationIDs = "agento11y.generation.parent_generation_ids"
 	AttrTags                = "agento11y.generation.tags"
@@ -44,9 +46,8 @@ const (
 	AttrUsageTotalTokens  = "agento11y.gen_ai.usage.total_tokens"
 	AttrTokenSemantics    = "gen_ai.token.semantics"
 	AttrUserID            = "user.id"
-	// AttrTagPrefix is the per-tag dimension prefix the SDK already emits on
-	// spans and metrics. The hook emits these dimensions next to the tags JSON
-	// document, so existing trace filters keep working in otel mode.
+	// AttrTagPrefix is the prefix for client and per-request context tag
+	// dimensions. The hook keeps Generation.Tags only in the AttrTags document.
 	AttrTagPrefix = "agento11y.tag."
 
 	// TokenSemanticsInclusive marks usage whose input_tokens already includes
@@ -86,8 +87,10 @@ type Generation struct {
 	UserID string
 	// ConversationTitle carries user text, so it goes under
 	// AttrConversationTitle and only under content capture.
-	ConversationTitle   string
-	Tags                map[string]string
+	ConversationTitle string
+	Tags              map[string]string
+	// DimensionalTags are emitted after the generation transport attributes.
+	DimensionalTags     map[string]string
 	Metadata            map[string]any
 	Artifacts           []Artifact
 	ParentGenerationIDs []string
@@ -97,6 +100,8 @@ type Generation struct {
 	ToolChoice       *string
 	ThinkingEnabled  *bool
 	TotalTokens      int64
+	// Rejected suppresses the missing-ID error for validator-rejected spans.
+	Rejected bool
 	// InclusiveTokenSemantics marks that Usage.InputTokens on the invocation
 	// already includes both cache buckets.
 	InclusiveTokenSemantics bool
@@ -134,7 +139,7 @@ func (h *Hook) OnEnd(_ context.Context, inv *otelgenai.Invocation, capture otelg
 		}
 		return nil
 	}
-	if generation.ID == "" {
+	if generation.ID == "" && !generation.Rejected {
 		otel.Handle(errors.New("agento11y otelhook: generation has no id, so the span carries no " + AttrGenerationID))
 	}
 	withContent := capture.SpanContent()
@@ -142,7 +147,7 @@ func (h *Hook) OnEnd(_ context.Context, inv *otelgenai.Invocation, capture otelg
 	var attrs []attribute.KeyValue
 	if generation.ID != "" {
 		attrs = append(attrs,
-			attribute.String(attrRecord, "true"),
+			attribute.String(AttrRecord, "true"),
 			attribute.String(AttrGenerationID, generation.ID),
 		)
 	}
@@ -156,7 +161,9 @@ func (h *Hook) OnEnd(_ context.Context, inv *otelgenai.Invocation, capture otelg
 		attrs = append(attrs, attribute.String(AttrTokenSemantics, TokenSemanticsInclusive))
 	}
 	if generation.ToolChoice != nil {
-		attrs = append(attrs, attribute.String(AttrToolChoice, *generation.ToolChoice))
+		if toolChoice := strings.TrimSpace(*generation.ToolChoice); toolChoice != "" {
+			attrs = append(attrs, attribute.String(AttrToolChoice, toolChoice))
+		}
 	}
 	if generation.ThinkingEnabled != nil {
 		attrs = append(attrs, attribute.Bool(AttrThinkingEnabled, *generation.ThinkingEnabled))
@@ -168,12 +175,9 @@ func (h *Hook) OnEnd(_ context.Context, inv *otelgenai.Invocation, capture otelg
 		attrs = append(attrs, attribute.String(AttrEffectiveVersion, digest))
 	}
 	if len(generation.Tags) > 0 {
-		// The document keeps the map as given, matching the proto tags field.
-		// The dimensions trim it.
 		if payload, err := json.Marshal(generation.Tags); err == nil {
 			attrs = append(attrs, attribute.String(AttrTags, string(payload)))
 		}
-		attrs = append(attrs, tagAttributes(generation.Tags)...)
 	}
 	if withContent {
 		if title := conversationTitle(generation); title != "" {
@@ -194,6 +198,7 @@ func (h *Hook) OnEnd(_ context.Context, inv *otelgenai.Invocation, capture otelg
 			attrs = append(attrs, attribute.String(AttrRawArtifacts, string(payload)))
 		}
 	}
+	attrs = append(attrs, tagattr.Attributes(AttrTagPrefix, generation.DimensionalTags)...)
 	return attrs
 }
 
@@ -260,8 +265,4 @@ func vendorGeneration(vendor any) (Generation, bool) {
 	default:
 		return Generation{}, false
 	}
-}
-
-func tagAttributes(tags map[string]string) []attribute.KeyValue {
-	return tagattr.Attributes(AttrTagPrefix, tags)
 }

--- a/go/agento11y/otelhook/hook_test.go
+++ b/go/agento11y/otelhook/hook_test.go
@@ -27,6 +27,9 @@ func TestOnEnd(t *testing.T) {
 	t.Parallel()
 
 	toolChoice := "auto"
+	toolChoiceWithWhitespace := "  required \t"
+	emptyToolChoice := ""
+	whitespaceToolChoice := " \t\n"
 	thinking := true
 
 	cases := []struct {
@@ -35,6 +38,7 @@ func TestOnEnd(t *testing.T) {
 		capture otelgenai.CaptureMode
 		want    map[string]string
 		absent  []string
+		check   func(t *testing.T)
 	}{
 		{
 			name: "full generation",
@@ -42,6 +46,7 @@ func TestOnEnd(t *testing.T) {
 				ID:                      "gen-1",
 				UserID:                  "user-1",
 				Tags:                    map[string]string{"team": "sigil", " env ": " dev "},
+				DimensionalTags:         map[string]string{"client": "sdk", "request": "context"},
 				Metadata:                map[string]any{"model_version": "2026-06"},
 				ParentGenerationIDs:     []string{"gen-0"},
 				EffectiveVersion:        "v3",
@@ -55,8 +60,8 @@ func TestOnEnd(t *testing.T) {
 				"agento11y.generation.id":                    "gen-1",
 				"user.id":                                    "user-1",
 				"agento11y.generation.tags":                  `{" env ":" dev ","team":"sigil"}`,
-				"agento11y.tag.team":                         "sigil",
-				"agento11y.tag.env":                          "dev",
+				"agento11y.tag.client":                       "sdk",
+				"agento11y.tag.request":                      "context",
 				"agento11y.generation.metadata":              `{"model_version":"2026-06"}`,
 				"agento11y.generation.parent_generation_ids": `["gen-0"]`,
 				// The digest of "v3", the rule the proto path applies too.
@@ -65,6 +70,10 @@ func TestOnEnd(t *testing.T) {
 				"agento11y.gen_ai.request.thinking.enabled": "true",
 				"agento11y.gen_ai.usage.total_tokens":       "162",
 				"gen_ai.token.semantics":                    "inclusive",
+			},
+			absent: []string{
+				otelhook.AttrTagPrefix + "team",
+				otelhook.AttrTagPrefix + "env",
 			},
 		},
 		{
@@ -80,6 +89,56 @@ func TestOnEnd(t *testing.T) {
 				"agento11y.generation.metadata",
 				"gen_ai.token.semantics",
 			},
+		},
+		{
+			name: "tool choice is trimmed without changing the generation",
+			vendor: otelhook.Generation{
+				ID:         "gen-tool-choice-trimmed",
+				ToolChoice: &toolChoiceWithWhitespace,
+			},
+			want: map[string]string{
+				"agento11y.gen_ai.request.tool_choice": "required",
+			},
+			check: func(t *testing.T) {
+				if toolChoiceWithWhitespace != "  required \t" {
+					t.Errorf("generation tool choice = %q, want the original value", toolChoiceWithWhitespace)
+				}
+			},
+		},
+		{
+			name: "empty tool choice is omitted",
+			vendor: otelhook.Generation{
+				ID:         "gen-tool-choice-empty",
+				ToolChoice: &emptyToolChoice,
+			},
+			absent: []string{"agento11y.gen_ai.request.tool_choice"},
+		},
+		{
+			name: "whitespace tool choice is omitted",
+			vendor: otelhook.Generation{
+				ID:         "gen-tool-choice-whitespace",
+				ToolChoice: &whitespaceToolChoice,
+			},
+			absent: []string{"agento11y.gen_ai.request.tool_choice"},
+		},
+		{
+			name: "nil tool choice is omitted",
+			vendor: otelhook.Generation{
+				ID:         "gen-tool-choice-nil",
+				ToolChoice: nil,
+			},
+			absent: []string{"agento11y.gen_ai.request.tool_choice"},
+		},
+		{
+			name: "rejected generation keeps dimensions",
+			vendor: otelhook.Generation{
+				DimensionalTags: map[string]string{"team": "sigil"},
+				Rejected:        true,
+			},
+			want: map[string]string{
+				"agento11y.tag.team": "sigil",
+			},
+			absent: []string{"agento11y.record", "agento11y.generation.id"},
 		},
 		{
 			name:   "no vendor payload",
@@ -158,6 +217,9 @@ func TestOnEnd(t *testing.T) {
 				if _, ok := got[key]; ok {
 					t.Errorf("%s is present, want it absent", key)
 				}
+			}
+			if tc.check != nil {
+				tc.check(t)
 			}
 		})
 	}


### PR DESCRIPTION
Fix issues in the Go OTel SDK It omitted the SDK name and thinking-budget attributes, emitted blank tool choices, and generation-start and generation-result tags were sent as `agento11y.tag.*` span attributes. The standard SDK uses those attributes for client and context tags only.