### PR TITLE
feat(go-sdk): allow for custom retry and queue settings

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -142,6 +142,12 @@ defer func() {
 
 `GenerationExport.ExportTimeout` bounds each HTTP or gRPC generation and workflow-step request. It defaults to 30 seconds. Set `AGENTO11Y_EXPORT_TIMEOUT_MS` to a base-10 integer from `1` through `2147483647` to override the default. A positive caller value wins over the environment variable.
 
+Generation and workflow-step exports retry five times by default, with exponential backoff capped at five seconds. Set `AGENTO11Y_MAX_RETRIES` to a base-10 integer from `0` through `2147483647` and `AGENTO11Y_MAX_BACKOFF_MS` to a base-10 integer from `1` through `2147483647` to override those defaults. `0` retries disables retrying. Positive caller values win over the environment variables.
+
+Each in-memory export queue holds 2,000 records by default. Set `AGENTO11Y_QUEUE_SIZE` to a base-10 integer from `1` through `2147483647` to override that capacity. Size it from the peak records per second multiplied by the expected outage in seconds, plus headroom. Generations and workflow steps have separate queues of this capacity. Larger queues consume application memory and do not survive a process restart. A positive caller value wins over the environment variable.
+
+Retries run in the background exporter. While an export is retrying, the in-memory queue can fill and newer generations can be dropped. Use a retry budget sized for a short, known interruption rather than a permanent multi-minute setting.
+
 `GenerationExport.HTTPTimeout` remains an HTTP-only override. A positive value wins over `ExportTimeout` on HTTP requests. The experiments client uses this field for `ClientOptions.RetryTimeout`.
 
 Configure OTEL exporters (traces/metrics) in your application OTEL SDK setup.

--- a/go/agento11y/env.go
+++ b/go/agento11y/env.go
@@ -40,6 +40,14 @@ var (
 	envTags               = brandedPair("TAGS")
 	envContentCaptureMode = brandedPair("CONTENT_CAPTURE_MODE")
 	envDebug              = brandedPair("DEBUG")
+	// envMaxRetries: base-10 integer count of retries after the initial
+	// generation / workflow-step export attempt. Zero disables retries.
+	envMaxRetries = brandedPair("MAX_RETRIES")
+	// envMaxBackoffMS: base-10 integer milliseconds capping the exponential
+	// delay between generation / workflow-step export attempts.
+	envMaxBackoffMS = brandedPair("MAX_BACKOFF_MS")
+	// envQueueSize: base-10 integer capacity of each in-memory export queue.
+	envQueueSize = brandedPair("QUEUE_SIZE")
 	// envExportTimeoutMS: base-10 integer milliseconds bounding one generation /
 	// workflow-step export attempt on both HTTP and gRPC.
 	envExportTimeoutMS     = brandedPair("EXPORT_TIMEOUT_MS")
@@ -54,6 +62,10 @@ var (
 const (
 	minExportTimeoutMS int64 = 1
 	maxExportTimeoutMS int64 = 2147483647
+	minMaxRetries      int64 = 0
+	maxMaxRetries      int64 = 2147483647
+	minQueueSize       int64 = 1
+	maxQueueSize       int64 = 2147483647
 )
 
 // envLookup resolves canonical env vars from os.Environ unless a
@@ -150,6 +162,33 @@ func resolveFromEnv(lookup envLookup, base Config) (Config, error) {
 		cfg.Debug = &b
 	}
 
+	if v, key, ok := envTrimmed(lookup, envMaxRetries); ok {
+		maxRetries, err := parseMaxRetries(key, v)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			cfg.GenerationExport.MaxRetries = maxRetries
+		}
+	}
+
+	if v, key, ok := envTrimmed(lookup, envMaxBackoffMS); ok {
+		maxBackoff, err := parseExportTimeoutMS(key, v)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			cfg.GenerationExport.MaxBackoff = maxBackoff
+		}
+	}
+
+	if v, key, ok := envTrimmed(lookup, envQueueSize); ok {
+		queueSize, err := parseQueueSize(key, v)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			cfg.GenerationExport.QueueSize = queueSize
+		}
+	}
+
 	if v, key, ok := envTrimmed(lookup, envExportTimeoutMS); ok {
 		timeout, err := parseExportTimeoutMS(key, v)
 		if err != nil {
@@ -239,6 +278,30 @@ func parseExportTimeoutMS(key, v string) (time.Duration, error) {
 		return 0, invalid
 	}
 	return time.Duration(ms) * time.Millisecond, nil
+}
+
+func parseMaxRetries(key, v string) (int, error) {
+	invalid := fmt.Errorf(
+		"agento11y: invalid %s %q (want integer from %d through %d)",
+		key, v, minMaxRetries, maxMaxRetries,
+	)
+	value, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+	if err != nil || value < minMaxRetries || value > maxMaxRetries {
+		return 0, invalid
+	}
+	return int(value), nil
+}
+
+func parseQueueSize(key, v string) (int, error) {
+	invalid := fmt.Errorf(
+		"agento11y: invalid %s %q (want integer from %d through %d)",
+		key, v, minQueueSize, maxQueueSize,
+	)
+	value, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+	if err != nil || value < minQueueSize || value > maxQueueSize {
+		return 0, invalid
+	}
+	return int(value), nil
 }
 
 func parseContentCaptureMode(key, v string) (ContentCaptureMode, error) {

--- a/go/agento11y/env_test.go
+++ b/go/agento11y/env_test.go
@@ -16,6 +16,19 @@ func checkDefaultExportTimeout(t *testing.T, cfg Config) {
 	}
 }
 
+func checkGenerationExportTuning(t *testing.T, cfg Config, wantRetries int, wantBackoff time.Duration, wantQueueSize int) {
+	t.Helper()
+	if cfg.GenerationExport.MaxRetries != wantRetries {
+		t.Errorf("MaxRetries=%d want %d", cfg.GenerationExport.MaxRetries, wantRetries)
+	}
+	if cfg.GenerationExport.MaxBackoff != wantBackoff {
+		t.Errorf("MaxBackoff=%v want %v", cfg.GenerationExport.MaxBackoff, wantBackoff)
+	}
+	if cfg.GenerationExport.QueueSize != wantQueueSize {
+		t.Errorf("QueueSize=%d want %d", cfg.GenerationExport.QueueSize, wantQueueSize)
+	}
+}
+
 func mapLookup(env map[string]string) envLookup {
 	return func(k string) (string, bool) {
 		v, ok := env[k]
@@ -214,6 +227,56 @@ func TestResolveFromEnv(t *testing.T) {
 				if cfg.GenerationExport.ExportTimeout != 1500*time.Millisecond {
 					t.Errorf("ExportTimeout=%v want 1.5s", cfg.GenerationExport.ExportTimeout)
 				}
+			},
+		},
+		{
+			name: "generation export tuning from env",
+			env: map[string]string{
+				"AGENTO11Y_MAX_RETRIES":    "12",
+				"AGENTO11Y_MAX_BACKOFF_MS": "45000",
+				"AGENTO11Y_QUEUE_SIZE":     "5000",
+			},
+			check: func(t *testing.T, cfg Config) {
+				checkGenerationExportTuning(t, cfg, 12, 45*time.Second, 5000)
+			},
+		},
+		{
+			name: "legacy generation export tuning from env",
+			env: map[string]string{
+				"SIGIL_MAX_RETRIES":    "7",
+				"SIGIL_MAX_BACKOFF_MS": "30000",
+				"SIGIL_QUEUE_SIZE":     "4000",
+			},
+			check: func(t *testing.T, cfg Config) {
+				checkGenerationExportTuning(t, cfg, 7, 30*time.Second, 4000)
+			},
+		},
+		{
+			name:            "invalid queue size keeps default",
+			env:             map[string]string{"AGENTO11Y_QUEUE_SIZE": "0"},
+			wantErr:         true,
+			wantErrContains: "AGENTO11Y_QUEUE_SIZE",
+			check: func(t *testing.T, cfg Config) {
+				defaults := DefaultConfig().GenerationExport
+				checkGenerationExportTuning(t, cfg, defaults.MaxRetries, defaults.MaxBackoff, defaults.QueueSize)
+			},
+		},
+		{
+			name: "zero retries disables retries",
+			env:  map[string]string{"AGENTO11Y_MAX_RETRIES": "0"},
+			check: func(t *testing.T, cfg Config) {
+				defaults := DefaultConfig().GenerationExport
+				checkGenerationExportTuning(t, cfg, 0, defaults.MaxBackoff, defaults.QueueSize)
+			},
+		},
+		{
+			name:            "invalid max retries keeps default",
+			env:             map[string]string{"AGENTO11Y_MAX_RETRIES": "-1"},
+			wantErr:         true,
+			wantErrContains: "AGENTO11Y_MAX_RETRIES",
+			check: func(t *testing.T, cfg Config) {
+				defaults := DefaultConfig().GenerationExport
+				checkGenerationExportTuning(t, cfg, defaults.MaxRetries, defaults.MaxBackoff, defaults.QueueSize)
 			},
 		},
 		{
@@ -687,6 +750,23 @@ func TestNewClient_EnvHandling(t *testing.T) {
 				if got := c.config.GenerationExport.ExportTimeout; got != 3*time.Second {
 					t.Errorf("ExportTimeout=%v want 3s (caller wins)", got)
 				}
+			},
+		},
+		{
+			name: "caller generation export tuning wins over env",
+			env: map[string]string{
+				"AGENTO11Y_MAX_RETRIES":    "12",
+				"AGENTO11Y_MAX_BACKOFF_MS": "45000",
+				"AGENTO11Y_QUEUE_SIZE":     "5000",
+				"AGENTO11Y_PROTOCOL":       "none",
+			},
+			cfg: Config{GenerationExport: GenerationExportConfig{
+				MaxRetries: 3,
+				MaxBackoff: 10 * time.Second,
+				QueueSize:  3000,
+			}},
+			check: func(t *testing.T, c *Client) {
+				checkGenerationExportTuning(t, c.config, 3, 10*time.Second, 3000)
 			},
 		},
 		{

--- a/llms.txt
+++ b/llms.txt
@@ -161,6 +161,9 @@ AGENTO11Y_AUTH_MODE=basic
 AGENTO11Y_AUTH_TENANT_ID=<your-instance-id>
 AGENTO11Y_AUTH_TOKEN=<glc_... token>
 AGENTO11Y_EXPORT_TIMEOUT_MS=30000       # optional per-request generation export timeout, in milliseconds
+AGENTO11Y_MAX_RETRIES=5                 # optional retries after the initial generation export attempt
+AGENTO11Y_MAX_BACKOFF_MS=5000           # optional maximum delay between retries, in milliseconds
+AGENTO11Y_QUEUE_SIZE=5000               # optional capacity of each in-memory export queue
 AGENTO11Y_TAGS=team=checkout,env=prod   # optional client tags; also emitted as agento11y.tag.<key> on OTel spans/metrics
 AGENTO11Y_USER_ID=<end-user id>          # optional; sets the user.id span attribute (all SDKs)
 
@@ -174,6 +177,12 @@ OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64 of "<otlp-instance-id>:<g
 Construct the client with no config when the env vars are present; the SDK reads them. Only use explicit `ClientConfig(...)` when the app needs values that aren't in env (e.g. test endpoints).
 
 `AGENTO11Y_EXPORT_TIMEOUT_MS` defaults to `30000`. It accepts base-10 integers from `1` through `2147483647`. An explicit SDK config value wins over the environment variable.
+
+`AGENTO11Y_MAX_RETRIES` defaults to `5` and accepts base-10 integers from `0` through `2147483647`; `0` disables retries. `AGENTO11Y_MAX_BACKOFF_MS` defaults to `5000` and accepts base-10 integers from `1` through `2147483647`. Explicit positive SDK config values win over the environment variables.
+
+`AGENTO11Y_QUEUE_SIZE` defaults to `2000` and accepts base-10 integers from `1` through `2147483647`. Size it from the peak records per second multiplied by the expected outage in seconds, plus headroom. Generations and workflow steps have separate queues of this capacity. Larger queues consume application memory and do not survive a process restart.
+
+Retries run in the background exporter. While an export is retrying, the in-memory queue can fill and newer generations can be dropped. Size the retry budget for a short, known interruption rather than leaving a multi-minute budget enabled permanently.
 
 ### Content capture
 


### PR DESCRIPTION
Allow users to temporarily tune export retries and queue capacity for planned Agent Observability downtime. 

Specifically this PR: 
- Adds environment variables for maximum retries, maximum backoff, and queue size
- Documents that larger queues consume more memory and do not survive restarts

This requires upgrading the SDK and restarting the application