### PR TITLE
fix(retries): prevent disabling retries

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -142,7 +142,7 @@ defer func() {
 
 `GenerationExport.ExportTimeout` bounds each HTTP or gRPC generation and workflow-step request. It defaults to 30 seconds. Set `AGENTO11Y_EXPORT_TIMEOUT_MS` to a base-10 integer from `1` through `2147483647` to override the default. A positive caller value wins over the environment variable.
 
-Generation and workflow-step exports retry five times by default, with exponential backoff capped at five seconds. Set `AGENTO11Y_MAX_RETRIES` to a base-10 integer from `0` through `2147483647` and `AGENTO11Y_MAX_BACKOFF_MS` to a base-10 integer from `1` through `2147483647` to override those defaults. `0` retries disables retrying. Positive caller values win over the environment variables.
+Generation and workflow-step exports retry five times by default, with exponential backoff capped at five seconds. Set `AGENTO11Y_MAX_RETRIES` and `AGENTO11Y_MAX_BACKOFF_MS` to base-10 integers from `1` through `2147483647` to override those defaults. Positive caller values win over the environment variables.
 
 Each in-memory export queue holds 2,000 records by default. Set `AGENTO11Y_QUEUE_SIZE` to a base-10 integer from `1` through `2147483647` to override that capacity. Size it from the peak records per second multiplied by the expected outage in seconds, plus headroom. Generations and workflow steps have separate queues of this capacity. Larger queues consume application memory and do not survive a process restart. A positive caller value wins over the environment variable.
 

--- a/go/agento11y/env.go
+++ b/go/agento11y/env.go
@@ -62,7 +62,7 @@ var (
 const (
 	minExportTimeoutMS int64 = 1
 	maxExportTimeoutMS int64 = 2147483647
-	minMaxRetries      int64 = 0
+	minMaxRetries      int64 = 1
 	maxMaxRetries      int64 = 2147483647
 	minQueueSize       int64 = 1
 	maxQueueSize       int64 = 2147483647

--- a/go/agento11y/env_test.go
+++ b/go/agento11y/env_test.go
@@ -262,16 +262,8 @@ func TestResolveFromEnv(t *testing.T) {
 			},
 		},
 		{
-			name: "zero retries disables retries",
-			env:  map[string]string{"AGENTO11Y_MAX_RETRIES": "0"},
-			check: func(t *testing.T, cfg Config) {
-				defaults := DefaultConfig().GenerationExport
-				checkGenerationExportTuning(t, cfg, 0, defaults.MaxBackoff, defaults.QueueSize)
-			},
-		},
-		{
-			name:            "invalid max retries keeps default",
-			env:             map[string]string{"AGENTO11Y_MAX_RETRIES": "-1"},
+			name:            "zero max retries keeps default",
+			env:             map[string]string{"AGENTO11Y_MAX_RETRIES": "0"},
 			wantErr:         true,
 			wantErrContains: "AGENTO11Y_MAX_RETRIES",
 			check: func(t *testing.T, cfg Config) {

--- a/llms.txt
+++ b/llms.txt
@@ -178,7 +178,7 @@ Construct the client with no config when the env vars are present; the SDK reads
 
 `AGENTO11Y_EXPORT_TIMEOUT_MS` defaults to `30000`. It accepts base-10 integers from `1` through `2147483647`. An explicit SDK config value wins over the environment variable.
 
-`AGENTO11Y_MAX_RETRIES` defaults to `5` and accepts base-10 integers from `0` through `2147483647`; `0` disables retries. `AGENTO11Y_MAX_BACKOFF_MS` defaults to `5000` and accepts base-10 integers from `1` through `2147483647`. Explicit positive SDK config values win over the environment variables.
+`AGENTO11Y_MAX_RETRIES` defaults to `5`. It and `AGENTO11Y_MAX_BACKOFF_MS` (default `5000`) accept base-10 integers from `1` through `2147483647`. Explicit positive SDK config values win over the environment variables.
 
 `AGENTO11Y_QUEUE_SIZE` defaults to `2000` and accepts base-10 integers from `1` through `2147483647`. Size it from the peak records per second multiplied by the expected outage in seconds, plus headroom. Generations and workflow steps have separate queues of this capacity. Larger queues consume application memory and do not survive a process restart.
 


### PR DESCRIPTION
follow-up to https://github.com/grafana/agento11y/pull/668

matches the code path (retries cannot be disabled)