### PR TITLE
feat(retries): add configurations for js and python retires & queuing

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -521,6 +521,14 @@ auth: {
 
 `shutdown()` uses the same resolved timeout as the deadline for its final flush, so a request that is already in flight gets one complete attempt.
 
+## Export retry and queue tuning
+
+Generation and workflow-step exports retry five times by default, with exponential backoff capped at five seconds. Set `AGENTO11Y_MAX_RETRIES` and `AGENTO11Y_MAX_BACKOFF_MS` to base-10 integers from `1` through `2147483647` to override those defaults. Explicit `generationExport.maxRetries` and `generationExport.maxBackoffMs` values win over the environment variables.
+
+Each in-memory export queue holds 2,000 records by default. Set `AGENTO11Y_QUEUE_SIZE` to a base-10 integer from `1` through `2147483647` to override that capacity. Size it from the peak records per second multiplied by the expected outage in seconds, plus headroom. Generations and workflow steps have separate queues of this capacity. Larger queues consume application memory and do not survive a process restart. An explicit `generationExport.queueSize` value wins over the environment variable.
+
+Retries run in the background exporter. While an export is retrying, the in-memory queue can fill and newer generations can be dropped. Use a retry budget sized for a short, known interruption rather than a permanent multi-minute setting.
+
 ## Wiring custom env vars
 
 The SDK only auto-loads `AGENTO11Y_*` env vars (`AGENTO11Y_ENDPOINT`, `AGENTO11Y_PROTOCOL`, `AGENTO11Y_AUTH_MODE`, `AGENTO11Y_AUTH_TOKEN`, etc.) when you call `new Agento11yClient()`. For any other env var (for example one your secret manager exposes under a different name), read it in your app and pass the value into the config:

--- a/js/src/config.ts
+++ b/js/src/config.ts
@@ -12,7 +12,7 @@ import type {
 
 const tenantHeaderName = 'X-Scope-OrgID';
 const authorizationHeaderName = 'Authorization';
-const maxExportTimeoutMs = 2_147_483_647;
+const maxEnvInteger = 2_147_483_647;
 
 const validAuthModes: ExportAuthConfig['mode'][] = ['none', 'tenant', 'bearer', 'basic'];
 
@@ -35,6 +35,9 @@ const envProtocol = brandedPair('PROTOCOL');
 const envInsecure = brandedPair('INSECURE');
 const envHeaders = brandedPair('HEADERS');
 const envExportTimeoutMs = brandedPair('EXPORT_TIMEOUT_MS');
+const envMaxRetries = brandedPair('MAX_RETRIES');
+const envMaxBackoffMs = brandedPair('MAX_BACKOFF_MS');
+const envQueueSize = brandedPair('QUEUE_SIZE');
 const envAuthMode = brandedPair('AUTH_MODE');
 const envAuthTenantId = brandedPair('AUTH_TENANT_ID');
 const envAuthToken = brandedPair('AUTH_TOKEN');
@@ -183,10 +186,13 @@ function envOverrides(env: Record<string, string | undefined>, logger: Agento11y
       generationExport.timeoutMs = parsed;
     } else {
       logger.warn?.(
-        `agento11y: ignoring invalid ${exportTimeoutMs.key}: ${exportTimeoutMs.value}; expected a whole number from 1 through ${maxExportTimeoutMs}`,
+        `agento11y: ignoring invalid ${exportTimeoutMs.key}: ${exportTimeoutMs.value}; expected a whole number from 1 through ${maxEnvInteger}`,
       );
     }
   }
+  applyIntegerEnvOverride(env, envMaxRetries, 'maxRetries', 1, generationExport, logger);
+  applyIntegerEnvOverride(env, envMaxBackoffMs, 'maxBackoffMs', 1, generationExport, logger);
+  applyIntegerEnvOverride(env, envQueueSize, 'queueSize', 1, generationExport, logger);
 
   const authMode = envTrimmed(env, envAuthMode);
   if (authMode !== undefined) {
@@ -338,7 +344,7 @@ function mergeGenerationExportConfig(
     : defaultGenerationExportConfig.timeoutMs;
   if (config?.timeoutMs !== undefined && !isValidExportTimeoutMs(config.timeoutMs)) {
     logger.warn?.(
-      `agento11y: ignoring invalid generationExport.timeoutMs: ${String(config.timeoutMs)}; expected a whole number from 1 through ${maxExportTimeoutMs}`,
+      `agento11y: ignoring invalid generationExport.timeoutMs: ${String(config.timeoutMs)}; expected a whole number from 1 through ${maxEnvInteger}`,
     );
   }
   const merged: GenerationExportConfig = {
@@ -353,13 +359,38 @@ function mergeGenerationExportConfig(
 }
 
 function parseExportTimeoutMs(value: string): number | undefined {
-  if (!/^[0-9]+$/.test(value)) return undefined;
-  const parsed = Number(value);
-  return isValidExportTimeoutMs(parsed) ? parsed : undefined;
+  return parseWholeNumber(value, 1);
 }
 
 function isValidExportTimeoutMs(value: number | undefined): value is number {
-  return value !== undefined && Number.isSafeInteger(value) && value > 0 && value <= maxExportTimeoutMs;
+  return value !== undefined && Number.isSafeInteger(value) && value > 0 && value <= maxEnvInteger;
+}
+
+function applyIntegerEnvOverride(
+  env: Record<string, string | undefined>,
+  pair: EnvPair,
+  field: 'maxRetries' | 'maxBackoffMs' | 'queueSize',
+  minimum: number,
+  generationExport: Partial<GenerationExportConfig>,
+  logger: Agento11yLogger,
+): void {
+  const selected = envTrimmed(env, pair);
+  if (selected === undefined) return;
+
+  const parsed = parseWholeNumber(selected.value, minimum);
+  if (parsed !== undefined) {
+    generationExport[field] = parsed;
+    return;
+  }
+  logger.warn?.(
+    `agento11y: ignoring invalid ${selected.key}: ${selected.value}; expected a whole number from ${minimum} through ${maxEnvInteger}`,
+  );
+}
+
+function parseWholeNumber(value: string, minimum: number): number | undefined {
+  if (!/^[0-9]+$/.test(value)) return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= minimum && parsed <= maxEnvInteger ? parsed : undefined;
 }
 
 function mergeAPIConfig(config: Partial<ApiConfig> | undefined): ApiConfig {

--- a/js/test/client.env-config.test.mjs
+++ b/js/test/client.env-config.test.mjs
@@ -11,6 +11,9 @@ const configFromEnvCases = [
     check: (cfg) => {
       assert.equal(cfg.generationExport.protocol, 'http');
       assert.equal(cfg.generationExport.timeoutMs, 30_000);
+      assert.equal(cfg.generationExport.maxRetries, 5);
+      assert.equal(cfg.generationExport.maxBackoffMs, 5_000);
+      assert.equal(cfg.generationExport.queueSize, 2_000);
       assert.equal(cfg.contentCapture, 'default');
       assert.equal(cfg.agentName, undefined);
       assert.equal(cfg.userId, undefined);
@@ -30,6 +33,19 @@ const configFromEnvCases = [
     env: { AGENTO11Y_EXPORT_TIMEOUT_MS: '2500' },
     check: (cfg) => {
       assert.equal(cfg.generationExport.timeoutMs, 2500);
+    },
+  },
+  {
+    name: 'generation export tuning from env',
+    env: {
+      AGENTO11Y_MAX_RETRIES: '12',
+      AGENTO11Y_MAX_BACKOFF_MS: '45000',
+      AGENTO11Y_QUEUE_SIZE: '5000',
+    },
+    check: (cfg) => {
+      assert.equal(cfg.generationExport.maxRetries, 12);
+      assert.equal(cfg.generationExport.maxBackoffMs, 45_000);
+      assert.equal(cfg.generationExport.queueSize, 5_000);
     },
   },
   {
@@ -299,6 +315,20 @@ const mergeConfigCases = [
     },
   },
   {
+    name: 'caller generation export tuning wins over env',
+    config: { generationExport: { maxRetries: 3, maxBackoffMs: 10_000, queueSize: 3_000 } },
+    env: {
+      AGENTO11Y_MAX_RETRIES: '12',
+      AGENTO11Y_MAX_BACKOFF_MS: '45000',
+      AGENTO11Y_QUEUE_SIZE: '5000',
+    },
+    check: (cfg) => {
+      assert.equal(cfg.generationExport.maxRetries, 3);
+      assert.equal(cfg.generationExport.maxBackoffMs, 10_000);
+      assert.equal(cfg.generationExport.queueSize, 3_000);
+    },
+  },
+  {
     name: 'caller tags merge with preferred env tags',
     config: { tags: { team: 'ai', env: 'staging' } },
     env: { AGENTO11Y_TAGS: 'service=orch,env=prod' },
@@ -329,6 +359,44 @@ for (const value of ['abc', '0', '-1', '1.5', '2147483648', '0x10', '0b101', '0o
       `agento11y: ignoring invalid AGENTO11Y_EXPORT_TIMEOUT_MS: ${value}; expected a whole number from 1 through 2147483647`,
     ]);
   });
+}
+
+for (const { key, defaultValue, invalidValues, minimum } of [
+  { key: 'AGENTO11Y_MAX_RETRIES', defaultValue: 5, invalidValues: ['0', '-1', '1.5', 'abc', '2147483648'], minimum: 1 },
+  {
+    key: 'AGENTO11Y_MAX_BACKOFF_MS',
+    defaultValue: 5_000,
+    invalidValues: ['0', '-1', '1.5', 'abc', '2147483648'],
+    minimum: 1,
+  },
+  {
+    key: 'AGENTO11Y_QUEUE_SIZE',
+    defaultValue: 2_000,
+    invalidValues: ['0', '-1', '1.5', 'abc', '2147483648'],
+    minimum: 1,
+  },
+]) {
+  for (const value of invalidValues) {
+    test(`configFromEnv: invalid ${key} value ${value} falls back and preserves valid siblings`, () => {
+      const warnings = [];
+      const cfg = mergeConfig(
+        { logger: { warn: (message) => warnings.push(message) } },
+        { [key]: value, AGENTO11Y_AGENT_NAME: 'valid-agent' },
+      );
+
+      const field =
+        key === 'AGENTO11Y_MAX_RETRIES'
+          ? 'maxRetries'
+          : key === 'AGENTO11Y_MAX_BACKOFF_MS'
+            ? 'maxBackoffMs'
+            : 'queueSize';
+      assert.equal(cfg.generationExport[field], defaultValue);
+      assert.equal(cfg.agentName, 'valid-agent');
+      assert.deepEqual(warnings, [
+        `agento11y: ignoring invalid ${key}: ${value}; expected a whole number from ${minimum} through 2147483647`,
+      ]);
+    });
+  }
 }
 
 for (const value of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 2_147_483_648]) {

--- a/python/README.md
+++ b/python/README.md
@@ -565,6 +565,12 @@ cfg = ClientConfig(
 
 Set `AGENTO11Y_EXPORT_TIMEOUT_MS` to a base-10 integer from `1` through `2147483647` to override the default. An explicit `export_timeout` wins over the environment variable. Invalid values produce a warning and keep the default.
 
+Generation and workflow-step exports retry five times by default, with exponential backoff capped at five seconds. Set `AGENTO11Y_MAX_RETRIES` and `AGENTO11Y_MAX_BACKOFF_MS` to base-10 integers from `1` through `2147483647` to override those defaults. Explicit `max_retries` and `max_backoff` values win over the environment variables.
+
+Each in-memory export queue holds 2,000 records by default. Set `AGENTO11Y_QUEUE_SIZE` to a base-10 integer from `1` through `2147483647` to override that capacity. Size it from the peak records per second multiplied by the expected outage in seconds, plus headroom. Generations and workflow steps have separate queues of this capacity. Larger queues consume application memory and do not survive a process restart. An explicit `queue_size` value wins over the environment variable.
+
+Retries run in the background exporter. While an export is retrying, the in-memory queue can fill and newer generations can be dropped. Use a retry budget sized for a short, known interruption rather than a permanent multi-minute setting.
+
 ## Generation export auth modes
 
 Auth is resolved for `generation_export`.

--- a/python/agento11y/config.py
+++ b/python/agento11y/config.py
@@ -40,6 +40,15 @@ _DEFAULT_EXPORT_TIMEOUT = timedelta(seconds=DEFAULT_EXPORT_TIMEOUT_SECONDS)
 _MIN_EXPORT_TIMEOUT_MS = 1
 _MAX_EXPORT_TIMEOUT_MS = 2147483647
 _INT_PATTERN = re.compile(r"[+-]?[0-9]+")
+
+
+class _DefaultInt(int):
+    """An int-valued sentinel that distinguishes untouched SDK defaults."""
+
+
+_DEFAULT_MAX_RETRIES = _DefaultInt(5)
+_DEFAULT_MAX_BACKOFF = timedelta(seconds=5)
+_DEFAULT_QUEUE_SIZE = _DefaultInt(2000)
 # Legacy SIGIL_* spellings still honoured for each AGENTO11Y_<suffix> name, in
 # fallback order. Only names that shipped before the rename are listed; a suffix
 # absent from this table is canonical-only, because no release ever read a
@@ -116,10 +125,10 @@ class GenerationExportConfig:
     # any caller-set value wins over env. Non-positive values are clamped back
     # to the 30s default by ``resolve_config``.
     export_timeout: timedelta = _DEFAULT_EXPORT_TIMEOUT
-    queue_size: int = 2000
-    max_retries: int = 5
+    queue_size: int = _DEFAULT_QUEUE_SIZE
+    max_retries: int = _DEFAULT_MAX_RETRIES
     initial_backoff: timedelta = timedelta(milliseconds=100)
-    max_backoff: timedelta = timedelta(seconds=5)
+    max_backoff: timedelta = _DEFAULT_MAX_BACKOFF
     payload_max_bytes: int = 4 << 20
 
 
@@ -269,8 +278,8 @@ def _parse_bool(raw: str) -> bool:
     return raw.strip().lower() in ("1", "true", "yes", "on")
 
 
-def _parse_int_ms(raw: str, *, minimum: int, maximum: int) -> int | None:
-    """Parses base-10 integer milliseconds inside ``[minimum, maximum]``.
+def _parse_bounded_int(raw: str, *, minimum: int, maximum: int) -> int | None:
+    """Parses a base-10 integer inside ``[minimum, maximum]``.
 
     Floats, other bases, digit separators, non-numeric text, and out-of-range
     values return ``None``, so the caller can warn and keep its current value
@@ -283,6 +292,28 @@ def _parse_int_ms(raw: str, *, minimum: int, maximum: int) -> int | None:
     value = int(text, 10)
     if value < minimum or value > maximum:
         return None
+    return value
+
+
+def _resolve_integer_env(
+    env: dict[str, str] | None,
+    suffix: str,
+    *,
+    minimum: int,
+    maximum: int,
+) -> int | None:
+    raw, key = _env(env, suffix)
+    if raw is None:
+        return None
+    value = _parse_bounded_int(raw, minimum=minimum, maximum=maximum)
+    if value is None:
+        logging.getLogger("agento11y").warning(
+            "agento11y: ignoring invalid %s %r; expected an integer from %d through %d",
+            key,
+            raw,
+            minimum,
+            maximum,
+        )
     return value
 
 
@@ -340,7 +371,7 @@ def resolve_config(
     if out.generation_export.export_timeout is _DEFAULT_EXPORT_TIMEOUT:
         ev, timeout_key = _env(env, "EXPORT_TIMEOUT_MS")
         if ev is not None:
-            timeout_ms = _parse_int_ms(ev, minimum=_MIN_EXPORT_TIMEOUT_MS, maximum=_MAX_EXPORT_TIMEOUT_MS)
+            timeout_ms = _parse_bounded_int(ev, minimum=_MIN_EXPORT_TIMEOUT_MS, maximum=_MAX_EXPORT_TIMEOUT_MS)
             if timeout_ms is None:
                 log.warning(
                     "agento11y: ignoring invalid %s %r; expected an integer from %d through %d",
@@ -351,6 +382,33 @@ def resolve_config(
                 )
             else:
                 out.generation_export.export_timeout = timedelta(milliseconds=timeout_ms)
+    if out.generation_export.max_retries is _DEFAULT_MAX_RETRIES:
+        max_retries = _resolve_integer_env(
+            env,
+            "MAX_RETRIES",
+            minimum=1,
+            maximum=_MAX_EXPORT_TIMEOUT_MS,
+        )
+        if max_retries is not None:
+            out.generation_export.max_retries = max_retries
+    if out.generation_export.max_backoff is _DEFAULT_MAX_BACKOFF:
+        max_backoff_ms = _resolve_integer_env(
+            env,
+            "MAX_BACKOFF_MS",
+            minimum=1,
+            maximum=_MAX_EXPORT_TIMEOUT_MS,
+        )
+        if max_backoff_ms is not None:
+            out.generation_export.max_backoff = timedelta(milliseconds=max_backoff_ms)
+    if out.generation_export.queue_size is _DEFAULT_QUEUE_SIZE:
+        queue_size = _resolve_integer_env(
+            env,
+            "QUEUE_SIZE",
+            minimum=1,
+            maximum=_MAX_EXPORT_TIMEOUT_MS,
+        )
+        if queue_size is not None:
+            out.generation_export.queue_size = queue_size
 
     # Auth. Invalid mode strings are warned and skipped so other valid env
     # vars still apply.

--- a/python/tests/test_env_config.py
+++ b/python/tests/test_env_config.py
@@ -20,6 +20,9 @@ def _check_no_env(cfg: ClientConfig) -> None:
     assert cfg.generation_export.insecure is False
     assert cfg.generation_export.auth.mode == "none"
     assert cfg.generation_export.export_timeout == _DEFAULT_EXPORT_TIMEOUT
+    assert cfg.generation_export.max_retries == 5
+    assert cfg.generation_export.max_backoff == timedelta(seconds=5)
+    assert cfg.generation_export.queue_size == 2000
     assert cfg.agent_name == ""
     assert cfg.debug is False
     assert cfg.use_experimental_otel is False
@@ -82,6 +85,12 @@ def _check_export_timeout_min(cfg: ClientConfig) -> None:
 
 def _check_export_timeout_max(cfg: ClientConfig) -> None:
     assert cfg.generation_export.export_timeout == timedelta(milliseconds=2147483647)
+
+
+def _check_generation_export_tuning(cfg: ClientConfig) -> None:
+    assert cfg.generation_export.max_retries == 12
+    assert cfg.generation_export.max_backoff == timedelta(milliseconds=45000)
+    assert cfg.generation_export.queue_size == 5000
 
 
 def _check_invalid_export_timeout_preserves_valid(cfg: ClientConfig) -> None:
@@ -211,6 +220,15 @@ def _check_invalid_canonical_blocks_valid_legacy(cfg: ClientConfig) -> None:
         ),
         pytest.param(
             {
+                "AGENTO11Y_MAX_RETRIES": "12",
+                "AGENTO11Y_MAX_BACKOFF_MS": "45000",
+                "AGENTO11Y_QUEUE_SIZE": "5000",
+            },
+            _check_generation_export_tuning,
+            id="generation export tuning from env",
+        ),
+        pytest.param(
+            {
                 "AGENTO11Y_EXPORT_TIMEOUT_MS": "abc",
                 "AGENTO11Y_ENDPOINT": "valid.example:4318",
             },
@@ -327,6 +345,72 @@ def test_explicit_export_timeout_beats_env() -> None:
     explicit = ClientConfig(generation_export=GenerationExportConfig(export_timeout=timedelta(seconds=5)))
     cfg = resolve_config(explicit, env={"AGENTO11Y_EXPORT_TIMEOUT_MS": "1500"})
     assert cfg.generation_export.export_timeout == timedelta(seconds=5)
+
+
+def test_explicit_generation_export_tuning_beats_env() -> None:
+    explicit = ClientConfig(
+        generation_export=GenerationExportConfig(
+            max_retries=5,
+            max_backoff=timedelta(seconds=5),
+            queue_size=2000,
+        )
+    )
+    cfg = resolve_config(
+        explicit,
+        env={
+            "AGENTO11Y_MAX_RETRIES": "12",
+            "AGENTO11Y_MAX_BACKOFF_MS": "45000",
+            "AGENTO11Y_QUEUE_SIZE": "5000",
+        },
+    )
+    assert cfg.generation_export.max_retries == 5
+    assert cfg.generation_export.max_backoff == timedelta(seconds=5)
+    assert cfg.generation_export.queue_size == 2000
+
+
+@pytest.mark.parametrize(
+    "key,raw,field,default,minimum",
+    [
+        pytest.param("AGENTO11Y_MAX_RETRIES", "0", "max_retries", 5, 1, id="zero retries"),
+        pytest.param("AGENTO11Y_MAX_RETRIES", "-1", "max_retries", 5, 1, id="negative retries"),
+        pytest.param("AGENTO11Y_MAX_RETRIES", "1.5", "max_retries", 5, 1, id="fractional retries"),
+        pytest.param("AGENTO11Y_MAX_RETRIES", "abc", "max_retries", 5, 1, id="non-numeric retries"),
+        pytest.param("AGENTO11Y_MAX_RETRIES", "2147483648", "max_retries", 5, 1, id="retries above max"),
+        pytest.param("AGENTO11Y_MAX_BACKOFF_MS", "0", "max_backoff", timedelta(seconds=5), 1, id="zero backoff"),
+        pytest.param("AGENTO11Y_MAX_BACKOFF_MS", "-1", "max_backoff", timedelta(seconds=5), 1, id="negative backoff"),
+        pytest.param(
+            "AGENTO11Y_MAX_BACKOFF_MS", "1.5", "max_backoff", timedelta(seconds=5), 1, id="fractional backoff"
+        ),
+        pytest.param(
+            "AGENTO11Y_MAX_BACKOFF_MS", "abc", "max_backoff", timedelta(seconds=5), 1, id="non-numeric backoff"
+        ),
+        pytest.param(
+            "AGENTO11Y_MAX_BACKOFF_MS", "2147483648", "max_backoff", timedelta(seconds=5), 1, id="backoff above max"
+        ),
+        pytest.param("AGENTO11Y_QUEUE_SIZE", "0", "queue_size", 2000, 1, id="zero queue size"),
+        pytest.param("AGENTO11Y_QUEUE_SIZE", "-1", "queue_size", 2000, 1, id="negative queue size"),
+        pytest.param("AGENTO11Y_QUEUE_SIZE", "1.5", "queue_size", 2000, 1, id="fractional queue size"),
+        pytest.param("AGENTO11Y_QUEUE_SIZE", "abc", "queue_size", 2000, 1, id="non-numeric queue size"),
+        pytest.param("AGENTO11Y_QUEUE_SIZE", "2147483648", "queue_size", 2000, 1, id="queue size above max"),
+    ],
+)
+def test_invalid_generation_export_tuning_warns_and_keeps_default(
+    key: str,
+    raw: str,
+    field: str,
+    default: int | timedelta,
+    minimum: int,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="agento11y"):
+        cfg = resolve_config(None, env={key: raw, "AGENTO11Y_AGENT_NAME": "planner"})
+
+    assert getattr(cfg.generation_export, field) == default
+    assert cfg.agent_name == "planner"
+    assert any(
+        key in record.getMessage() and f"from {minimum} through 2147483647" in record.getMessage()
+        for record in caplog.records
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Follow up to https://github.com/grafana/agento11y/pull/668 - adds JS and Python support for AGENTO11Y_MAX_RETRIES, AGENTO11Y_MAX_BACKOFF_MS, and AGENTO11Y_QUEUE_SIZE

Matches #669 by accepting values from 1 through 2147483647. Invalid values warn and preserve defaults, while explicit SDK configuration takes precedence.

Also documents the settings in the JS and Python READMEs.