### PR TITLE
fix(otelgenai): emit gen_ai.request.top_k as integer

### DIFF
--- a/go/otelgenai/conformance/conformance_test.go
+++ b/go/otelgenai/conformance/conformance_test.go
@@ -236,19 +236,30 @@ func conformanceScenarios() []scenario {
 }
 
 func inferenceInvocation() *otelgenai.Invocation {
+	maxTokens, topK, seed := int64(256), int64(40), int64(7)
+	temperature, topP := 0.7, 0.9
+	frequencyPenalty, presencePenalty := 0.1, 0.2
 	return &otelgenai.Invocation{
-		Operation:       otelgenai.OperationChat,
-		Provider:        "openai",
-		RequestModel:    "gpt-4.1-mini",
-		ResponseModel:   "gpt-4.1-mini-2025-04-14",
-		ResponseID:      "resp-1",
-		ServerAddress:   "api.openai.com",
-		FinishReasons:   []string{"stop"},
-		Usage:           otelgenai.Usage{InputTokens: 12, OutputTokens: 7},
-		StartedAt:       time.Now().Add(-time.Second),
-		InputMessages:   nil,
-		OutputMessages:  nil,
-		ToolDefinitions: nil,
+		Operation:        otelgenai.OperationChat,
+		Provider:         "openai",
+		RequestModel:     "gpt-4.1-mini",
+		ResponseModel:    "gpt-4.1-mini-2025-04-14",
+		ResponseID:       "resp-1",
+		ServerAddress:    "api.openai.com",
+		FinishReasons:    []string{"stop"},
+		Usage:            otelgenai.Usage{InputTokens: 12, OutputTokens: 7},
+		MaxTokens:        &maxTokens,
+		Temperature:      &temperature,
+		TopP:             &topP,
+		TopK:             &topK,
+		FrequencyPenalty: &frequencyPenalty,
+		PresencePenalty:  &presencePenalty,
+		StopSequences:    []string{"stop", "done"},
+		Seed:             &seed,
+		StartedAt:        time.Now().Add(-time.Second),
+		InputMessages:    nil,
+		OutputMessages:   nil,
+		ToolDefinitions:  nil,
 	}
 }
 

--- a/go/otelgenai/event_test.go
+++ b/go/otelgenai/event_test.go
@@ -198,7 +198,7 @@ func TestOperationDetailsEventStructuredContent(t *testing.T) {
 		t.Error("event context has no valid span context")
 	}
 	attrs := logAttributes(record)
-	if got := attrs["gen_ai.request.top_k"].AsFloat64(); got != 40 {
+	if got := attrs["gen_ai.request.top_k"].AsInt64(); got != 40 {
 		t.Errorf("gen_ai.request.top_k = %v, want 40", got)
 	}
 

--- a/go/otelgenai/genai.go
+++ b/go/otelgenai/genai.go
@@ -539,7 +539,8 @@ func (h *Handler) requestAttributes(inv *Invocation) []attribute.KeyValue {
 		attrs = append(attrs, semconv.GenAIRequestTopP(*inv.TopP))
 	}
 	if inv.TopK != nil {
-		attrs = append(attrs, semconv.GenAIRequestTopK(float64(*inv.TopK)))
+		// The v1.41.0 generated helper uses double, but the GenAI registry requires int.
+		attrs = append(attrs, semconv.GenAIRequestTopKKey.Int64(*inv.TopK))
 	}
 	if inv.FrequencyPenalty != nil {
 		attrs = append(attrs, semconv.GenAIRequestFrequencyPenalty(*inv.FrequencyPenalty))

--- a/go/otelgenai/genai_test.go
+++ b/go/otelgenai/genai_test.go
@@ -563,7 +563,7 @@ func TestSpanLifecycle(t *testing.T) {
 			},
 			check: func(t *testing.T, span sdktrace.ReadOnlySpan) {
 				attrs := spanAttrs(span)
-				if got := attrs["gen_ai.request.top_k"].AsFloat64(); got != 40 {
+				if got := attrs["gen_ai.request.top_k"].AsInt64(); got != 40 {
 					t.Errorf("gen_ai.request.top_k = %v, want 40", got)
 				}
 				if got := attrs["gen_ai.request.frequency_penalty"].AsFloat64(); got != 0.1 {


### PR DESCRIPTION
Fix `gen_ai.request.top_k` type, it should be an [integer](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/registry/attributes/gen-ai.md#gen-ai-request-top-k) ([changed](https://github.com/open-telemetry/semantic-conventions-genai/pull/217)).