### PR TITLE
fix(plugins/agento11y): write only agento11y config keys from local UI

### DIFF
--- a/plugins/agento11y/internal/dotenv/dotenv_test.go
+++ b/plugins/agento11y/internal/dotenv/dotenv_test.go
@@ -293,6 +293,11 @@ func TestApplyEnvAliasFamilies(t *testing.T) {
 			want: "os-legacy",
 		},
 		{
+			name: "file preferred applies under both spellings",
+			file: "AGENTO11Y_ENDPOINT=file-preferred\n",
+			want: "file-preferred",
+		},
+		{
 			name: "file preferred beats file legacy",
 			file: "AGENTO11Y_ENDPOINT=file-preferred\nSIGIL_ENDPOINT=file-legacy\n",
 			want: "file-preferred",

--- a/plugins/agento11y/internal/dotenv/write.go
+++ b/plugins/agento11y/internal/dotenv/write.go
@@ -3,6 +3,7 @@ package dotenv
 import (
 	"fmt"
 	"log"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -23,13 +24,34 @@ import (
 // key returns an error so a typo or unexpected caller cannot inject unrelated
 // process state on next load.
 func WriteDotenv(path string, updates map[string]string, logger *log.Logger) error {
+	if err := validateUpdates(updates); err != nil {
+		return err
+	}
+	return writeDotenv(path, LoadDotenv(path, logger), updates)
+}
+
+// UpdateDotenv derives updates from the same file snapshot they are merged
+// into. The callback receives a copy so it cannot bypass update validation or
+// empty-value deletion semantics by modifying the stored map directly.
+func UpdateDotenv(path string, derive func(current map[string]string) map[string]string, logger *log.Logger) error {
+	merged := LoadDotenv(path, logger)
+	updates := derive(maps.Clone(merged))
+	if err := validateUpdates(updates); err != nil {
+		return err
+	}
+	return writeDotenv(path, merged, updates)
+}
+
+func validateUpdates(updates map[string]string) error {
 	for k := range updates {
 		if !AllowedDotenvKey(k) {
 			return fmt.Errorf("dotenv: refusing to write disallowed key %q", k)
 		}
 	}
+	return nil
+}
 
-	merged := LoadDotenv(path, logger)
+func writeDotenv(path string, merged, updates map[string]string) error {
 	for k, v := range updates {
 		if strings.TrimSpace(v) == "" {
 			delete(merged, k)

--- a/plugins/agento11y/internal/dotenv/write_test.go
+++ b/plugins/agento11y/internal/dotenv/write_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 )
 
 func TestWriteDotenv_CreatesFileAndDirectory(t *testing.T) {
@@ -67,6 +69,36 @@ OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.example.com
 	for k, v := range want {
 		if got[k] != v {
 			t.Errorf("merged[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestUpdateDotenv_DerivesUpdatesFromCurrentFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.env")
+	if err := WriteDotenv(path, map[string]string{"AGENTO11Y_THEME": "dark"}, nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	stale := LoadDotenv(path, nil)
+
+	if err := WriteDotenv(path, map[string]string{"SIGIL_THEME": "system"}, nil); err != nil {
+		t.Fatalf("concurrent write: %v", err)
+	}
+
+	if err := UpdateDotenv(path, func(current map[string]string) map[string]string {
+		updates := map[string]string{"AGENTO11Y_THEME": "light"}
+		return envconfig.UpdateExistingLegacyAliases(current, updates)
+	}, nil); err != nil {
+		t.Fatalf("UpdateDotenv: %v", err)
+	}
+
+	if _, ok := stale["SIGIL_THEME"]; ok {
+		t.Fatalf("stale snapshot unexpectedly contains SIGIL_THEME")
+	}
+	got := LoadDotenv(path, nil)
+	for _, key := range []string{"AGENTO11Y_THEME", "SIGIL_THEME"} {
+		if got[key] != "light" {
+			t.Errorf("%s = %q, want light", key, got[key])
 		}
 	}
 }

--- a/plugins/agento11y/internal/envconfig/envconfig.go
+++ b/plugins/agento11y/internal/envconfig/envconfig.go
@@ -142,6 +142,27 @@ func ExpandAliases(updates map[string]string) map[string]string {
 	return out
 }
 
+// UpdateExistingLegacyAliases mirrors preferred updates only when the legacy
+// key already exists in the stored config. Explicit legacy updates win.
+func UpdateExistingLegacyAliases(current, updates map[string]string) map[string]string {
+	out := make(map[string]string, len(updates)*2)
+	maps.Copy(out, updates)
+	for k, v := range updates {
+		suffix, ok := strings.CutPrefix(k, "AGENTO11Y_")
+		if !ok {
+			continue
+		}
+		legacy := LegacyKey(suffix)
+		if _, exists := current[legacy]; !exists {
+			continue
+		}
+		if _, exists := out[legacy]; !exists {
+			out[legacy] = v
+		}
+	}
+	return out
+}
+
 // ParseBoolValue parses a boolean config value against the 1/true/yes/on and
 // 0/false/no/off whitelist. ok is false for anything else, so a caller can tell
 // an unrecognised value from a false one and report it.

--- a/plugins/agento11y/internal/envconfig/envconfig_test.go
+++ b/plugins/agento11y/internal/envconfig/envconfig_test.go
@@ -679,3 +679,29 @@ func TestExpandAliases(t *testing.T) {
 		t.Errorf("ExpandAliases() = %v, want %v", got, want)
 	}
 }
+
+func TestUpdateExistingLegacyAliases(t *testing.T) {
+	current := map[string]string{
+		"SIGIL_ENDPOINT":   "https://old",
+		"SIGIL_AUTH_TOKEN": "old-token",
+		"SIGIL_THEME":      "dark",
+	}
+	got := UpdateExistingLegacyAliases(current, map[string]string{
+		"AGENTO11Y_ENDPOINT":   "https://new",
+		"AGENTO11Y_AUTH_TOKEN": "new-token",
+		"SIGIL_AUTH_TOKEN":     "keep explicit value",
+		"AGENTO11Y_TAGS":       "team=ai",
+		"OTEL_SERVICE_NAME":    "svc",
+	})
+	want := map[string]string{
+		"AGENTO11Y_ENDPOINT":   "https://new",
+		"SIGIL_ENDPOINT":       "https://new",
+		"AGENTO11Y_AUTH_TOKEN": "new-token",
+		"SIGIL_AUTH_TOKEN":     "keep explicit value",
+		"AGENTO11Y_TAGS":       "team=ai",
+		"OTEL_SERVICE_NAME":    "svc",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("UpdateExistingLegacyAliases() = %v, want %v", got, want)
+	}
+}

--- a/plugins/agento11y/internal/local/server.go
+++ b/plugins/agento11y/internal/local/server.go
@@ -679,7 +679,9 @@ func (s *Server) handleSaveConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	s.configMu.Lock()
 	defer s.configMu.Unlock()
-	if err := dotenv.WriteDotenv(s.configPath, settings.Updates(), s.logger); err != nil {
+	if err := dotenv.UpdateDotenv(s.configPath, func(stored map[string]string) map[string]string {
+		return envconfig.UpdateExistingLegacyAliases(stored, settings.Updates())
+	}, s.logger); err != nil {
 		s.logger.Printf("local: write config: %v", err)
 		http.Error(w, "write config: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -714,8 +716,10 @@ func (s *Server) handlePatchConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	s.configMu.Lock()
 	defer s.configMu.Unlock()
-	updates := envconfig.ExpandAliases(map[string]string{"SIGIL_THEME": string(*req.Theme)})
-	if err := dotenv.WriteDotenv(s.configPath, updates, s.logger); err != nil {
+	if err := dotenv.UpdateDotenv(s.configPath, func(stored map[string]string) map[string]string {
+		updates := map[string]string{"AGENTO11Y_THEME": string(*req.Theme)}
+		return envconfig.UpdateExistingLegacyAliases(stored, updates)
+	}, s.logger); err != nil {
 		s.logger.Printf("local: patch config: %v", err)
 		http.Error(w, "patch config: "+err.Error(), http.StatusInternalServerError)
 		return

--- a/plugins/agento11y/internal/local/server_test.go
+++ b/plugins/agento11y/internal/local/server_test.go
@@ -1241,13 +1241,12 @@ func TestServer_Config_RoundTrip(t *testing.T) {
 	onDisk, err := os.ReadFile(configPathFor(dir))
 	require.NoError(t, err)
 	assert.Contains(t, string(onDisk), "AGENTO11Y_THEME=system")
-	assert.Contains(t, string(onDisk), "SIGIL_THEME=system")
-	assert.Contains(t, string(onDisk), "SIGIL_CONTENT_CAPTURE_MODE=metadata_only")
-	assert.Contains(t, string(onDisk), "SIGIL_GUARDS_TIMEOUT_MS=2000")
-	// Both spellings are written so an older binary still reads the toggle.
+	assert.NotContains(t, string(onDisk), "SIGIL_THEME")
+	assert.Contains(t, string(onDisk), "AGENTO11Y_CONTENT_CAPTURE_MODE=metadata_only")
+	assert.Contains(t, string(onDisk), "AGENTO11Y_GUARDS_TIMEOUT_MS=2000")
 	assert.Contains(t, string(onDisk), "AGENTO11Y_LOCAL_FORWARD=true")
-	assert.Contains(t, string(onDisk), "SIGIL_LOCAL_FORWARD=true")
-	assert.Contains(t, saved.Preview, "SIGIL_USER_ID=alice")
+	assert.NotContains(t, string(onDisk), "SIGIL_LOCAL_FORWARD")
+	assert.Contains(t, saved.Preview, "AGENTO11Y_USER_ID=alice")
 	assert.True(t, strings.HasPrefix(saved.Preview, "# Managed by `agento11y login`."))
 
 	// A fresh GET returns the same saved snapshot.
@@ -1394,20 +1393,121 @@ func TestServer_Config_Preview(t *testing.T) {
 	}
 	decodeJSON(t, resp.Body, &got)
 	assert.Contains(t, got.Preview, "AGENTO11Y_THEME=light")
-	assert.Contains(t, got.Preview, "SIGIL_THEME=light")
-	assert.Contains(t, got.Preview, "SIGIL_GUARDS_FAIL_OPEN=true")
-	assert.Contains(t, got.Preview, "SIGIL_GUARDS_TIMEOUT_MS=2500")
+	assert.Contains(t, got.Preview, "AGENTO11Y_GUARDS_FAIL_OPEN=true")
+	assert.Contains(t, got.Preview, "AGENTO11Y_GUARDS_TIMEOUT_MS=2500")
 	// Opt-out/opt-in keys at their defaults must not appear.
-	assert.NotContains(t, got.Preview, "SIGIL_AUTO_UPDATE")
-	assert.NotContains(t, got.Preview, "SIGIL_DEBUG")
+	assert.NotContains(t, got.Preview, "AGENTO11Y_AUTO_UPDATE")
+	assert.NotContains(t, got.Preview, "AGENTO11Y_DEBUG")
 	// LOCAL_FORWARD is the exception: off is written as an explicit false,
 	// because the daemon prefers config.env and a missing key cannot override
 	// the value it inherited into its own environment at boot.
 	assert.Contains(t, got.Preview, "AGENTO11Y_LOCAL_FORWARD=false")
-	assert.Contains(t, got.Preview, "SIGIL_LOCAL_FORWARD=false")
+	assert.NotContains(t, got.Preview, "\nSIGIL_")
 	// Preview is read-only: no file should have been created.
 	_, statErr := os.Stat(configPathFor(dir))
 	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestServer_Config_AuthTokenWrites(t *testing.T) {
+	files := []struct {
+		name         string
+		tokens       map[string]string
+		preserveWant map[string]string
+		replaceWant  map[string]string
+	}{
+		{
+			name:         "legacy only",
+			tokens:       map[string]string{"SIGIL_AUTH_TOKEN": "glc_legacy"},
+			preserveWant: map[string]string{"SIGIL_AUTH_TOKEN": "glc_legacy"},
+			replaceWant: map[string]string{
+				"AGENTO11Y_AUTH_TOKEN": "glc_new",
+				"SIGIL_AUTH_TOKEN":     "glc_new",
+			},
+		},
+		{
+			name:         "preferred only",
+			tokens:       map[string]string{"AGENTO11Y_AUTH_TOKEN": "glc_preferred"},
+			preserveWant: map[string]string{"AGENTO11Y_AUTH_TOKEN": "glc_preferred"},
+			replaceWant:  map[string]string{"AGENTO11Y_AUTH_TOKEN": "glc_new"},
+		},
+		{
+			name: "both spellings",
+			tokens: map[string]string{
+				"AGENTO11Y_AUTH_TOKEN": "glc_preferred",
+				"SIGIL_AUTH_TOKEN":     "glc_legacy",
+			},
+			preserveWant: map[string]string{
+				"AGENTO11Y_AUTH_TOKEN": "glc_preferred",
+				"SIGIL_AUTH_TOKEN":     "glc_legacy",
+			},
+			replaceWant: map[string]string{
+				"AGENTO11Y_AUTH_TOKEN": "glc_new",
+				"SIGIL_AUTH_TOKEN":     "glc_new",
+			},
+		},
+	}
+	for _, file := range files {
+		t.Run(file.name, func(t *testing.T) {
+			actions := []struct {
+				name         string
+				settings     Settings
+				want         map[string]string
+				wantTokenSet bool
+			}{
+				{
+					name:         "preserve",
+					settings:     Settings{TokenSet: true},
+					want:         file.preserveWant,
+					wantTokenSet: true,
+				},
+				{
+					name:         "replace",
+					settings:     Settings{TokenSet: true, Token: "glc_new"},
+					want:         file.replaceWant,
+					wantTokenSet: true,
+				},
+				{
+					name:     "reset",
+					settings: Settings{TokenSet: true, TokenCleared: true},
+					want:     map[string]string{},
+				},
+			}
+			for _, action := range actions {
+				t.Run(action.name, func(t *testing.T) {
+					srv, dir := newTestServer(t)
+					path := configPathFor(dir)
+					seed := maps.Clone(file.tokens)
+					seed["SIGIL_USER_ID_SOURCE"] = "accountUuid"
+					seed["SIGIL_GUARDS_ENABLED"] = "true"
+					seed["AGENTO11Y_LOCAL"] = "true"
+					seed["SIGIL_LOCAL"] = "true"
+					require.NoError(t, dotenv.WriteDotenv(path, seed, nil))
+
+					settings := action.settings
+					settings.Guards = guardsOff
+					settings.AutoUpdate = true
+					resp := putConfig(t, srv, settings)
+					defer resp.Body.Close()
+					require.Equal(t, http.StatusOK, resp.StatusCode)
+
+					env := dotenv.LoadDotenv(path, nil)
+					gotTokens := map[string]string{}
+					for _, key := range []string{"AGENTO11Y_AUTH_TOKEN", "SIGIL_AUTH_TOKEN"} {
+						if value, ok := env[key]; ok {
+							gotTokens[key] = value
+						}
+					}
+					assert.Equal(t, action.want, gotTokens)
+					assert.Equal(t, action.wantTokenSet, ParseSettings(env).TokenSet)
+					assert.Equal(t, "accountUuid", env["SIGIL_USER_ID_SOURCE"])
+					assert.Equal(t, "false", env["AGENTO11Y_GUARDS_ENABLED"])
+					assert.Equal(t, "false", env["SIGIL_GUARDS_ENABLED"])
+					assert.Equal(t, "true", env["AGENTO11Y_LOCAL"])
+					assert.Equal(t, "true", env["SIGIL_LOCAL"])
+				})
+			}
+		})
+	}
 }
 
 // TestServer_Config_DoesNotLeakSecrets confirms the auth token never crosses
@@ -1436,7 +1536,8 @@ func TestServer_Config_DoesNotLeakSecrets(t *testing.T) {
 	assert.Equal(t, "12345", got.Settings.TenantID)
 	assert.True(t, got.Settings.TokenSet)
 	assert.Empty(t, got.Settings.Token)
-	assert.Contains(t, got.Preview, "SIGIL_AUTH_TOKEN=<set>")
+	assert.Contains(t, got.Preview, "AGENTO11Y_AUTH_TOKEN=<set>")
+	assert.NotContains(t, got.Preview, "\nSIGIL_")
 
 	// Saving with a blank token keeps it; endpoint/tenant round-trip; unmanaged
 	// keys survive the merge.
@@ -1452,9 +1553,10 @@ func TestServer_Config_DoesNotLeakSecrets(t *testing.T) {
 
 	onDisk, err := os.ReadFile(path)
 	require.NoError(t, err)
+	assert.NotContains(t, string(onDisk), "AGENTO11Y_AUTH_TOKEN")
 	assert.Contains(t, string(onDisk), "SIGIL_AUTH_TOKEN=glc_supersecret")
 	assert.Contains(t, string(onDisk), "SIGIL_USER_ID_SOURCE=accountUuid")
-	assert.Contains(t, string(onDisk), "SIGIL_USER_ID=alice")
+	assert.Contains(t, string(onDisk), "AGENTO11Y_USER_ID=alice")
 
 	// Resetting the token removes it from disk.
 	resp2 := putConfig(t, srv, Settings{
@@ -1466,7 +1568,9 @@ func TestServer_Config_DoesNotLeakSecrets(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp2.StatusCode)
 	onDisk2, err := os.ReadFile(path)
 	require.NoError(t, err)
+	assert.NotContains(t, string(onDisk2), "AGENTO11Y_AUTH_TOKEN")
 	assert.NotContains(t, string(onDisk2), "SIGIL_AUTH_TOKEN")
+	assert.False(t, ParseSettings(dotenv.LoadDotenv(path, nil)).TokenSet)
 }
 
 // TestServer_Config_RejectsBadBody covers malformed input handling.

--- a/plugins/agento11y/internal/local/settings.go
+++ b/plugins/agento11y/internal/local/settings.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Guard selector values exposed to the viewer. One control encodes both the
-// enabled flag and the fail mode, mapping onto the three SIGIL_GUARDS_* keys.
+// enabled flag and the fail mode, mapping onto the three branded GUARDS_* keys.
 // These are the API/UI values defined by the Settings design; they differ from
 // the labels sigil login uses internally.
 const (
@@ -43,7 +43,7 @@ func parseTheme(env map[string]string) Theme {
 	return normalizeTheme(Theme(raw))
 }
 
-// tokenMask stands in for SIGIL_AUTH_TOKEN in the live preview. The stored
+// tokenMask stands in for AGENTO11Y_AUTH_TOKEN in the live preview. The stored
 // token is never sent to the browser, so the preview shows this marker to
 // signal a token is present without leaking the value.
 const tokenMask = "<set>"
@@ -56,7 +56,7 @@ type Tag struct {
 
 // Settings is the subset of config.env the local viewer's Settings page
 // edits. It is hydrated from the dotenv file by ParseSettings and mapped back
-// to SIGIL_* keys by Updates.
+// to AGENTO11Y_* keys by Updates.
 //
 // The auth token is write-only: Token is never populated on read (the daemon
 // never sends the stored token to the browser). TokenSet reports whether a
@@ -136,18 +136,18 @@ func ParseSettings(env map[string]string) Settings {
 	}
 }
 
-// Updates maps Settings onto the SIGIL_* keys WriteDotenv persists. An empty
-// value signals a deletion: WriteDotenv removes that key and dotenv.RenderManaged
-// drops it from the preview. The returned map therefore covers the complete
-// set of decisions for the page-managed keys (write a value, or delete it);
-// any key not listed here is left untouched on disk.
+// Updates returns preferred and unbranded updates. An empty value signals a
+// deletion: WriteDotenv removes that key and dotenv.RenderManaged drops it from
+// the preview. The returned map therefore covers the complete set of decisions
+// for the page-managed keys (write a value, or delete it); any key not listed
+// here is left untouched on disk.
 func (s Settings) Updates() map[string]string {
 	u := map[string]string{
-		"SIGIL_THEME":                       string(normalizeTheme(s.Theme)),
-		"SIGIL_TAGS":                        renderTags(s.Tags),
-		"SIGIL_ENDPOINT":                    strings.TrimSpace(s.Endpoint),
-		"SIGIL_AUTH_TENANT_ID":              strings.TrimSpace(s.TenantID),
-		"SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT": strings.TrimSpace(s.OtlpEndpoint),
+		"AGENTO11Y_THEME":                       string(normalizeTheme(s.Theme)),
+		"AGENTO11Y_TAGS":                        renderTags(s.Tags),
+		"AGENTO11Y_ENDPOINT":                    strings.TrimSpace(s.Endpoint),
+		"AGENTO11Y_AUTH_TENANT_ID":              strings.TrimSpace(s.TenantID),
+		"AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT": strings.TrimSpace(s.OtlpEndpoint),
 	}
 
 	// Capture mode is written only when explicitly set. Leaving it unset keeps
@@ -155,7 +155,7 @@ func (s Settings) Updates() map[string]string {
 	// env.go), so saving unrelated settings never silently forces a capture mode
 	// onto config.env.
 	if c := parseCaptureMode(s.Capture); c != "" {
-		u["SIGIL_CONTENT_CAPTURE_MODE"] = c
+		u["AGENTO11Y_CONTENT_CAPTURE_MODE"] = c
 	}
 
 	// The token is write-only and tri-state: an explicit reset deletes it, a
@@ -163,66 +163,63 @@ func (s Settings) Updates() map[string]string {
 	// WriteDotenv preserves whatever is already on disk.
 	switch {
 	case s.TokenCleared:
-		u["SIGIL_AUTH_TOKEN"] = ""
+		u["AGENTO11Y_AUTH_TOKEN"] = ""
 	case strings.TrimSpace(s.Token) != "":
-		u["SIGIL_AUTH_TOKEN"] = strings.TrimSpace(s.Token)
+		u["AGENTO11Y_AUTH_TOKEN"] = strings.TrimSpace(s.Token)
 	}
 
-	// OTEL_EXPORTER_OTLP_HEADERS has no branded spelling: it is the raw
-	// OpenTelemetry variable, which ExpandAliases leaves alone.
+	// OTEL_EXPORTER_OTLP_HEADERS has no branded spelling.
 	if v, ok := s.otlpHeadersUpdate(); ok {
 		u["OTEL_EXPORTER_OTLP_HEADERS"] = v
 	}
 
 	switch s.Guards {
 	case guardsFailOpen, guardsFailClosed:
-		u["SIGIL_GUARDS_ENABLED"] = "true"
+		u["AGENTO11Y_GUARDS_ENABLED"] = "true"
 		if s.Guards == guardsFailOpen {
-			u["SIGIL_GUARDS_FAIL_OPEN"] = "true"
+			u["AGENTO11Y_GUARDS_FAIL_OPEN"] = "true"
 		} else {
-			u["SIGIL_GUARDS_FAIL_OPEN"] = "false"
+			u["AGENTO11Y_GUARDS_FAIL_OPEN"] = "false"
 		}
-		u["SIGIL_GUARDS_TIMEOUT_MS"] = guardTimeoutValue(s.GuardTimeout)
+		u["AGENTO11Y_GUARDS_TIMEOUT_MS"] = guardTimeoutValue(s.GuardTimeout)
 	default:
 		// Disabled: clear the enabled flag and remove the fail mode and
 		// timeout so a later re-enable starts from the documented defaults
 		// rather than a stale value.
-		u["SIGIL_GUARDS_ENABLED"] = "false"
-		u["SIGIL_GUARDS_FAIL_OPEN"] = ""
-		u["SIGIL_GUARDS_TIMEOUT_MS"] = ""
+		u["AGENTO11Y_GUARDS_ENABLED"] = "false"
+		u["AGENTO11Y_GUARDS_FAIL_OPEN"] = ""
+		u["AGENTO11Y_GUARDS_TIMEOUT_MS"] = ""
 	}
 
-	// SIGIL_DEBUG is opt-in: write it only when on, delete otherwise.
+	// AGENTO11Y_DEBUG is opt-in: write it only when on, delete otherwise.
 	if s.Debug {
-		u["SIGIL_DEBUG"] = "true"
+		u["AGENTO11Y_DEBUG"] = "true"
 	} else {
-		u["SIGIL_DEBUG"] = ""
+		u["AGENTO11Y_DEBUG"] = ""
 	}
 
-	// SIGIL_AUTO_UPDATE is opt-out: unset means enabled, so write false only
+	// AGENTO11Y_AUTO_UPDATE is opt-out: unset means enabled, so write false only
 	// when disabled and delete the key otherwise.
 	if s.AutoUpdate {
-		u["SIGIL_AUTO_UPDATE"] = ""
+		u["AGENTO11Y_AUTO_UPDATE"] = ""
 	} else {
-		u["SIGIL_AUTO_UPDATE"] = "false"
+		u["AGENTO11Y_AUTO_UPDATE"] = "false"
 	}
 
-	// SIGIL_LOCAL_FORWARD is written explicitly in both directions rather than
-	// deleted when off, the same trick SIGIL_AUTO_UPDATE uses above. The local
-	// daemon materializes its own environment from config.env at boot and falls
-	// back to it, so a deleted key cannot express "off": only an explicit false
-	// on disk turns a running daemon's forwarding off.
+	// AGENTO11Y_LOCAL_FORWARD is written explicitly in both directions rather
+	// than deleted when off, the same trick AGENTO11Y_AUTO_UPDATE uses above.
+	// The local daemon materializes its own environment from config.env at boot
+	// and falls back to it, so a deleted key cannot express "off": only an
+	// explicit false on disk turns a running daemon's forwarding off.
 	if s.LocalForward {
-		u["SIGIL_LOCAL_FORWARD"] = "true"
+		u["AGENTO11Y_LOCAL_FORWARD"] = "true"
 	} else {
-		u["SIGIL_LOCAL_FORWARD"] = "false"
+		u["AGENTO11Y_LOCAL_FORWARD"] = "false"
 	}
 
-	u["SIGIL_USER_ID"] = strings.TrimSpace(s.UserID)
+	u["AGENTO11Y_USER_ID"] = strings.TrimSpace(s.UserID)
 
-	// Managed values are written and deleted under both branded spellings so
-	// old binaries that only read SIGIL_* keep working.
-	return envconfig.ExpandAliases(u)
+	return u
 }
 
 // otlpHeadersUpdate decides what a write does to OTEL_EXPORTER_OTLP_HEADERS:
@@ -252,19 +249,17 @@ func (s Settings) otlpHeadersUpdate() (string, bool) {
 	}
 }
 
-// previewUpdates returns the keys to render in the live config.env preview. It
-// mirrors Updates but never exposes a credential: a stored or freshly entered
-// token is shown masked (under both spellings), and so are the OTLP headers,
-// which carry a credential of their own. The panel signals that the key is
-// present without leaking the value.
+// previewUpdates returns the preferred keys to render in the live config.env
+// preview. It mirrors Updates but never exposes a credential: a stored or
+// freshly entered token is shown masked, and so are the OTLP headers, which
+// carry a credential of their own. The panel signals that the key is present
+// without leaking the value.
 func (s Settings) previewUpdates() map[string]string {
 	u := s.Updates()
 	if !s.TokenCleared && (strings.TrimSpace(s.Token) != "" || s.TokenSet) {
 		u["AGENTO11Y_AUTH_TOKEN"] = tokenMask
-		u["SIGIL_AUTH_TOKEN"] = tokenMask
 	} else {
 		delete(u, "AGENTO11Y_AUTH_TOKEN")
-		delete(u, "SIGIL_AUTH_TOKEN")
 	}
 	// The headers are masked when the file keeps a value: one this write
 	// carries, or the stored one when the write does not touch the key.
@@ -340,7 +335,7 @@ func renderTags(tags []Tag) string {
 	return strings.Join(parts, ",")
 }
 
-// guardTimeoutValue returns the SIGIL_GUARDS_TIMEOUT_MS value to persist: the
+// guardTimeoutValue returns the AGENTO11Y_GUARDS_TIMEOUT_MS value to persist: the
 // trimmed input when it is a positive integer other than the default, else ""
 // so the key is dropped and the runtime default applies. A non-numeric,
 // non-positive, or default value is treated as "use default".

--- a/plugins/agento11y/internal/local/settings_test.go
+++ b/plugins/agento11y/internal/local/settings_test.go
@@ -3,7 +3,6 @@ package local
 import (
 	"testing"
 
-	"github.com/grafana/agento11y/plugins/agento11y/internal/envconfig"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -129,55 +128,55 @@ func TestSettingsUpdates(t *testing.T) {
 			name: "unset capture is not written",
 			in:   Settings{Capture: "", Guards: guardsOff, AutoUpdate: true},
 			want: map[string]string{
-				"SIGIL_TAGS":              "",
-				"SIGIL_GUARDS_ENABLED":    "false",
-				"SIGIL_GUARDS_FAIL_OPEN":  "",
-				"SIGIL_GUARDS_TIMEOUT_MS": "",
-				"SIGIL_DEBUG":             "",
-				"SIGIL_AUTO_UPDATE":       "",
-				"SIGIL_USER_ID":           "",
+				"AGENTO11Y_TAGS":              "",
+				"AGENTO11Y_GUARDS_ENABLED":    "false",
+				"AGENTO11Y_GUARDS_FAIL_OPEN":  "",
+				"AGENTO11Y_GUARDS_TIMEOUT_MS": "",
+				"AGENTO11Y_DEBUG":             "",
+				"AGENTO11Y_AUTO_UPDATE":       "",
+				"AGENTO11Y_USER_ID":           "",
 			},
 		},
 		{
 			name: "defaults delete opt-in/opt-out keys",
 			in:   Settings{Capture: "full", Guards: guardsOff, AutoUpdate: true},
 			want: map[string]string{
-				"SIGIL_CONTENT_CAPTURE_MODE": "full",
-				"SIGIL_TAGS":                 "",
-				"SIGIL_GUARDS_ENABLED":       "false",
-				"SIGIL_GUARDS_FAIL_OPEN":     "",
-				"SIGIL_GUARDS_TIMEOUT_MS":    "",
-				"SIGIL_DEBUG":                "",
-				"SIGIL_AUTO_UPDATE":          "",
-				"SIGIL_USER_ID":              "",
+				"AGENTO11Y_CONTENT_CAPTURE_MODE": "full",
+				"AGENTO11Y_TAGS":                 "",
+				"AGENTO11Y_GUARDS_ENABLED":       "false",
+				"AGENTO11Y_GUARDS_FAIL_OPEN":     "",
+				"AGENTO11Y_GUARDS_TIMEOUT_MS":    "",
+				"AGENTO11Y_DEBUG":                "",
+				"AGENTO11Y_AUTO_UPDATE":          "",
+				"AGENTO11Y_USER_ID":              "",
 			},
 		},
 		{
 			name: "fail-open with non-default timeout writes timeout",
 			in:   Settings{Capture: "full", Guards: guardsFailOpen, GuardTimeout: "2000", AutoUpdate: true},
 			want: map[string]string{
-				"SIGIL_CONTENT_CAPTURE_MODE": "full",
-				"SIGIL_TAGS":                 "",
-				"SIGIL_GUARDS_ENABLED":       "true",
-				"SIGIL_GUARDS_FAIL_OPEN":     "true",
-				"SIGIL_GUARDS_TIMEOUT_MS":    "2000",
-				"SIGIL_DEBUG":                "",
-				"SIGIL_AUTO_UPDATE":          "",
-				"SIGIL_USER_ID":              "",
+				"AGENTO11Y_CONTENT_CAPTURE_MODE": "full",
+				"AGENTO11Y_TAGS":                 "",
+				"AGENTO11Y_GUARDS_ENABLED":       "true",
+				"AGENTO11Y_GUARDS_FAIL_OPEN":     "true",
+				"AGENTO11Y_GUARDS_TIMEOUT_MS":    "2000",
+				"AGENTO11Y_DEBUG":                "",
+				"AGENTO11Y_AUTO_UPDATE":          "",
+				"AGENTO11Y_USER_ID":              "",
 			},
 		},
 		{
 			name: "default timeout value is dropped",
 			in:   Settings{Capture: "full", Guards: guardsFailClosed, GuardTimeout: "1500", AutoUpdate: true},
 			want: map[string]string{
-				"SIGIL_CONTENT_CAPTURE_MODE": "full",
-				"SIGIL_TAGS":                 "",
-				"SIGIL_GUARDS_ENABLED":       "true",
-				"SIGIL_GUARDS_FAIL_OPEN":     "false",
-				"SIGIL_GUARDS_TIMEOUT_MS":    "",
-				"SIGIL_DEBUG":                "",
-				"SIGIL_AUTO_UPDATE":          "",
-				"SIGIL_USER_ID":              "",
+				"AGENTO11Y_CONTENT_CAPTURE_MODE": "full",
+				"AGENTO11Y_TAGS":                 "",
+				"AGENTO11Y_GUARDS_ENABLED":       "true",
+				"AGENTO11Y_GUARDS_FAIL_OPEN":     "false",
+				"AGENTO11Y_GUARDS_TIMEOUT_MS":    "",
+				"AGENTO11Y_DEBUG":                "",
+				"AGENTO11Y_AUTO_UPDATE":          "",
+				"AGENTO11Y_USER_ID":              "",
 			},
 		},
 		{
@@ -191,43 +190,43 @@ func TestSettingsUpdates(t *testing.T) {
 				UserID:     "  alice  ",
 			},
 			want: map[string]string{
-				"SIGIL_CONTENT_CAPTURE_MODE": "metadata_only",
-				"SIGIL_TAGS":                 "team=ai",
-				"SIGIL_GUARDS_ENABLED":       "false",
-				"SIGIL_GUARDS_FAIL_OPEN":     "",
-				"SIGIL_GUARDS_TIMEOUT_MS":    "",
-				"SIGIL_DEBUG":                "true",
-				"SIGIL_AUTO_UPDATE":          "false",
-				"SIGIL_USER_ID":              "alice",
+				"AGENTO11Y_CONTENT_CAPTURE_MODE": "metadata_only",
+				"AGENTO11Y_TAGS":                 "team=ai",
+				"AGENTO11Y_GUARDS_ENABLED":       "false",
+				"AGENTO11Y_GUARDS_FAIL_OPEN":     "",
+				"AGENTO11Y_GUARDS_TIMEOUT_MS":    "",
+				"AGENTO11Y_DEBUG":                "true",
+				"AGENTO11Y_AUTO_UPDATE":          "false",
+				"AGENTO11Y_USER_ID":              "alice",
 			},
 		},
 		{
 			name: "non-numeric timeout is treated as default",
 			in:   Settings{Capture: "full", Guards: guardsFailOpen, GuardTimeout: "abc", AutoUpdate: true},
 			want: map[string]string{
-				"SIGIL_CONTENT_CAPTURE_MODE": "full",
-				"SIGIL_TAGS":                 "",
-				"SIGIL_GUARDS_ENABLED":       "true",
-				"SIGIL_GUARDS_FAIL_OPEN":     "true",
-				"SIGIL_GUARDS_TIMEOUT_MS":    "",
-				"SIGIL_DEBUG":                "",
-				"SIGIL_AUTO_UPDATE":          "",
-				"SIGIL_USER_ID":              "",
+				"AGENTO11Y_CONTENT_CAPTURE_MODE": "full",
+				"AGENTO11Y_TAGS":                 "",
+				"AGENTO11Y_GUARDS_ENABLED":       "true",
+				"AGENTO11Y_GUARDS_FAIL_OPEN":     "true",
+				"AGENTO11Y_GUARDS_TIMEOUT_MS":    "",
+				"AGENTO11Y_DEBUG":                "",
+				"AGENTO11Y_AUTO_UPDATE":          "",
+				"AGENTO11Y_USER_ID":              "",
 			},
 		},
 		{
 			name: "local forward on is written",
 			in:   Settings{Capture: "full", Guards: guardsOff, AutoUpdate: true, LocalForward: true},
 			want: map[string]string{
-				"SIGIL_CONTENT_CAPTURE_MODE": "full",
-				"SIGIL_TAGS":                 "",
-				"SIGIL_GUARDS_ENABLED":       "false",
-				"SIGIL_GUARDS_FAIL_OPEN":     "",
-				"SIGIL_GUARDS_TIMEOUT_MS":    "",
-				"SIGIL_DEBUG":                "",
-				"SIGIL_AUTO_UPDATE":          "",
-				"SIGIL_USER_ID":              "",
-				"SIGIL_LOCAL_FORWARD":        "true",
+				"AGENTO11Y_CONTENT_CAPTURE_MODE": "full",
+				"AGENTO11Y_TAGS":                 "",
+				"AGENTO11Y_GUARDS_ENABLED":       "false",
+				"AGENTO11Y_GUARDS_FAIL_OPEN":     "",
+				"AGENTO11Y_GUARDS_TIMEOUT_MS":    "",
+				"AGENTO11Y_DEBUG":                "",
+				"AGENTO11Y_AUTO_UPDATE":          "",
+				"AGENTO11Y_USER_ID":              "",
+				"AGENTO11Y_LOCAL_FORWARD":        "true",
 			},
 		},
 	}
@@ -235,20 +234,19 @@ func TestSettingsUpdates(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// None of these cases set connection fields, so Updates always emits
-			// empty (delete) markers for them and no token key. Every managed
-			// key is written and deleted under both spellings.
+			// empty (delete) markers for them and no token key.
 			want := tc.want
-			want["SIGIL_THEME"] = string(normalizeTheme(tc.in.Theme))
-			want["SIGIL_ENDPOINT"] = ""
-			want["SIGIL_AUTH_TENANT_ID"] = ""
-			want["SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT"] = ""
+			want["AGENTO11Y_THEME"] = string(normalizeTheme(tc.in.Theme))
+			want["AGENTO11Y_ENDPOINT"] = ""
+			want["AGENTO11Y_AUTH_TENANT_ID"] = ""
+			want["AGENTO11Y_OTEL_EXPORTER_OTLP_ENDPOINT"] = ""
 			// LOCAL_FORWARD is written explicitly in both directions: only a
 			// literal false on disk can override the value the daemon
 			// materialized into its own environment at boot.
-			if _, ok := want["SIGIL_LOCAL_FORWARD"]; !ok {
-				want["SIGIL_LOCAL_FORWARD"] = "false"
+			if _, ok := want["AGENTO11Y_LOCAL_FORWARD"]; !ok {
+				want["AGENTO11Y_LOCAL_FORWARD"] = "false"
 			}
-			assert.Equal(t, envconfig.ExpandAliases(want), tc.in.Updates())
+			assert.Equal(t, want, tc.in.Updates())
 		})
 	}
 
@@ -267,7 +265,7 @@ func TestSettingsUpdates(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			u := (Settings{Theme: tc.theme, Guards: guardsOff, AutoUpdate: true}).Updates()
 			assert.Equal(t, tc.want, u["AGENTO11Y_THEME"])
-			assert.Equal(t, tc.want, u["SIGIL_THEME"])
+			assert.NotContains(t, u, "SIGIL_THEME")
 		})
 	}
 }
@@ -291,30 +289,35 @@ func TestSettingsConnection(t *testing.T) {
 
 	t.Run("blank token is omitted so the writer preserves it", func(t *testing.T) {
 		u := Settings{Endpoint: "https://x", Guards: guardsOff, AutoUpdate: true, TokenSet: true}.Updates()
-		_, ok := u["SIGIL_AUTH_TOKEN"]
-		assert.False(t, ok)
-		assert.Equal(t, "https://x", u["SIGIL_ENDPOINT"])
+		assert.NotContains(t, u, "AGENTO11Y_AUTH_TOKEN")
+		assert.NotContains(t, u, "SIGIL_AUTH_TOKEN")
+		assert.Equal(t, "https://x", u["AGENTO11Y_ENDPOINT"])
 	})
 
 	t.Run("new token value is written", func(t *testing.T) {
 		u := Settings{Guards: guardsOff, AutoUpdate: true, TokenSet: true, Token: "glc_new"}.Updates()
-		assert.Equal(t, "glc_new", u["SIGIL_AUTH_TOKEN"])
+		assert.Equal(t, "glc_new", u["AGENTO11Y_AUTH_TOKEN"])
+		assert.NotContains(t, u, "SIGIL_AUTH_TOKEN")
 	})
 
 	t.Run("cleared token is deleted", func(t *testing.T) {
 		u := Settings{Guards: guardsOff, AutoUpdate: true, TokenSet: true, TokenCleared: true}.Updates()
-		v, ok := u["SIGIL_AUTH_TOKEN"]
+		v, ok := u["AGENTO11Y_AUTH_TOKEN"]
 		assert.True(t, ok)
 		assert.Empty(t, v) // empty value = delete in WriteDotenv
+		assert.NotContains(t, u, "SIGIL_AUTH_TOKEN")
 	})
 
 	t.Run("preview masks a set token and never shows the value", func(t *testing.T) {
 		p := Settings{Guards: guardsOff, AutoUpdate: true, TokenSet: true, Token: "glc_new"}.previewUpdates()
-		assert.Equal(t, tokenMask, p["SIGIL_AUTH_TOKEN"])
+		assert.Equal(t, tokenMask, p["AGENTO11Y_AUTH_TOKEN"])
+		for key := range p {
+			assert.NotRegexp(t, `^SIGIL_`, key)
+		}
 
 		cleared := Settings{Guards: guardsOff, AutoUpdate: true, TokenSet: true, TokenCleared: true}.previewUpdates()
-		_, ok := cleared["SIGIL_AUTH_TOKEN"]
-		assert.False(t, ok)
+		assert.NotContains(t, cleared, "AGENTO11Y_AUTH_TOKEN")
+		assert.NotContains(t, cleared, "SIGIL_AUTH_TOKEN")
 	})
 
 	// OTEL_EXPORTER_OTLP_HEADERS carries a second copy of the OTLP credential,

--- a/plugins/agento11y/internal/local/web/src/detail.tsx
+++ b/plugins/agento11y/internal/local/web/src/detail.tsx
@@ -1802,7 +1802,8 @@ function AgentBlock({ turn, openGroups, toggleGroup, openReasoning, toggleReason
           }}
         >
           No message content captured. Re-run with{' '}
-          <code style={{ color: 'var(--fg1)' }}>SIGIL_CONTENT_CAPTURE_MODE=full</code> to record prompts and responses.
+          <code style={{ color: 'var(--fg1)' }}>AGENTO11Y_CONTENT_CAPTURE_MODE=full</code> to record prompts and
+          responses.
         </div>
       )}
       {turn.blocks.map((block, index) => {


### PR DESCRIPTION
- Do not show legacy `SIGIL_*` env variables in the UI
- When creating a new `AGENTO11Y_*` key, write only it