### PR TITLE
fix(plugins/agento11y): fix local viewer session stats row

### DIFF
--- a/plugins/agento11y/internal/local/query.go
+++ b/plugins/agento11y/internal/local/query.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -52,6 +53,7 @@ type ConversationMetricsAggregate struct {
 	Calls               int                     `json:"calls"`
 	Errored             int                     `json:"errored"`
 	Agents              int                     `json:"agents"`
+	AgentHosts          []string                `json:"agent_hosts"`
 	Workspaces          int                     `json:"workspaces"`
 	TokenBuckets        TokenBuckets            `json:"token_buckets"`
 	TokenBucketsByModel map[string]TokenBuckets `json:"token_buckets_by_model"`
@@ -128,9 +130,10 @@ type ConversationListOptions struct {
 	// apply their filters before a candidate counts toward this cap. ≤ 0 means
 	// unbounded.
 	Limit int
-	// Since is inclusive. Plain list requests compare it with last activity;
-	// exact Sessions and analytics queries compare generation or reconciled
-	// tool-observation timestamps. Zero means no lower bound.
+	// Since is inclusive. Plain list requests without facets compare it with
+	// last activity. Exact Sessions, analytics, and faceted list queries compare
+	// generation or reconciled tool-observation timestamps. Zero means no lower
+	// bound.
 	Since time.Time
 	// Before is an exclusive generation-time upper bound for analytics and
 	// exact Sessions queries.
@@ -139,14 +142,80 @@ type ConversationListOptions struct {
 	// pointer to the empty string selects conversations whose lifetime cwd is
 	// unknown.
 	Workspace *string
-	// Tool filters exact Sessions queries to conversations with an observation
-	// whose name is exactly this value. A pointer to the empty string matches
-	// no valid tool.
+	// Tool keeps conversations with an observation whose name equals this value.
+	// ConversationMetrics always applies it; ListConversations applies it only
+	// when Exact is true. A non-nil pointer to an empty string matches no valid
+	// tool.
 	Tool *string
 	// Exact applies the workspace, tool, and half-open generation-time filters
 	// before Limit. The plain list leaves this false to retain its bounded
 	// file-order fast path.
 	Exact bool
+	// Agent keeps conversations containing an agent whose name before the first
+	// "/" equals this value. For example, "pi" matches "pi/explore". Empty means
+	// no filter.
+	Agent string
+	// Model keeps conversations that recorded this exact model name. Empty
+	// means no filter.
+	Model string
+	// Status keeps conversations whose derived status equals this value, "ok"
+	// or "err". Empty means no filter.
+	Status string
+	// MinSubagents keeps conversations with at least this many subagent steps.
+	// Zero means no filter.
+	MinSubagents int
+}
+
+func (opts ConversationListOptions) matchesFacets(sum ConversationSummary) bool {
+	if opts.Agent != "" && !agentHostListed(sum.Agents, opts.Agent) {
+		return false
+	}
+	if opts.Model != "" && !slices.Contains(sum.Models, opts.Model) {
+		return false
+	}
+	if opts.Status != "" && sum.Status != opts.Status {
+		return false
+	}
+	return sum.Subagents >= opts.MinSubagents
+}
+
+func (opts ConversationListOptions) hasFacets() bool {
+	return opts.Agent != "" || opts.Model != "" || opts.Status != "" || opts.MinSubagents > 0
+}
+
+// facetsMatch tests the facets against the period-clipped summary whenever the
+// request names a period, and against the lifetime summary otherwise. A tool
+// observation without an in-period generation uses the same zero-usage summary
+// as ConversationMetrics. Both conversation endpoints answer one Sessions
+// screen, so a facet selecting a different set on each would leave a row in the
+// table that the totals above it do not count: a conversation whose only
+// errored or subagent generation falls outside the window fails the facet on
+// both.
+func (opts ConversationListOptions) facetsMatch(entry *fileSummary, match *toolMatch) bool {
+	if !opts.hasFacets() {
+		return true
+	}
+	if opts.Since.IsZero() && opts.Before.IsZero() {
+		return opts.matchesFacets(entry.summary)
+	}
+	clipped, ok := clippedConversationSummary(entry, opts.Since, opts.Before)
+	if !ok && match != nil {
+		clipped = toolCallOnlySummary(entry, *match)
+		ok = true
+	}
+	return ok && opts.matchesFacets(clipped)
+}
+
+// Keep the split at the first "/" aligned with aggregateConversationMetrics
+// and web/src/shell.tsx's agentHosts so the UI and aggregate group agents by
+// the same host name.
+func agentHostListed(agents []string, host string) bool {
+	for _, agent := range agents {
+		if name, _, _ := strings.Cut(agent, "/"); name == host {
+			return true
+		}
+	}
+	return false
 }
 
 // ToolUsage is one tool's totals within a conversation.
@@ -168,10 +237,10 @@ type ConversationToolUsage struct {
 // files before filters and Limit, so a caller still knows whether the store
 // is empty. A missing directory returns an empty slice and a zero total.
 //
-// A plain list can stop decoding at Limit because file modification time and
-// last activity agree. An exact Sessions request instead filters generation
-// or reconciled tool observations before Limit; it still returns each
-// matching conversation's lifetime summary.
+// A plain list without facets can stop decoding at Limit because file
+// modification time and last activity agree. An exact or faceted Sessions
+// request instead filters generation or reconciled tool observations before
+// Limit; it still returns each matching conversation's lifetime summary.
 func (s *Storage) ListConversations(opts ConversationListOptions) (page []ConversationSummary, total int, err error) {
 	files, err := s.conversationFiles()
 	if err != nil {
@@ -182,7 +251,7 @@ func (s *Storage) ListConversations(opts ConversationListOptions) (page []Conver
 		capacity = opts.Limit
 	}
 	out := make([]ConversationSummary, 0, capacity)
-	var toolMatches map[string]bool
+	var toolMatches map[string]toolMatch
 	if opts.Exact && opts.Tool != nil {
 		toolMatches, err = s.conversationToolMatches(*opts.Tool, opts.Since, opts.Before, opts.Workspace)
 		if err != nil {
@@ -206,17 +275,23 @@ func (s *Storage) ListConversations(opts ConversationListOptions) (page []Conver
 		if !entry.ok {
 			continue // empty or all-invalid file
 		}
+		var matchedTool *toolMatch
 		if opts.Exact {
 			if !workspaceMatches(entry.summary.Workspace, opts.Workspace) {
 				continue
 			}
 			if opts.Tool != nil {
-				if !toolMatches[f.id] {
+				match, matched := toolMatches[f.id]
+				if !matched {
 					continue
 				}
+				matchedTool = &match
 			} else if (!opts.Since.IsZero() || !opts.Before.IsZero()) && !entryHasGenerationInPeriod(entry, opts.Since, opts.Before) {
 				continue
 			}
+		}
+		if !opts.facetsMatch(entry, matchedTool) {
+			continue
 		}
 		out = append(out, entry.summary)
 		if opts.Limit > 0 && len(out) == opts.Limit {
@@ -236,35 +311,89 @@ func entryHasGenerationInPeriod(entry *fileSummary, since, before time.Time) boo
 	return false
 }
 
-func (s *Storage) conversationToolMatches(tool string, since, before time.Time, workspace *string) (map[string]bool, error) {
+// toolMatch records the first and last matching observation timestamps.
+// Reconciliation can put an observation inside the requested period while all
+// generation timestamps are outside it, so metrics use these bounds for the
+// resulting zero-usage row.
+type toolMatch struct {
+	first, last time.Time
+}
+
+func (s *Storage) conversationToolMatches(tool string, since, before time.Time, workspace *string) (map[string]toolMatch, error) {
 	observations, err := s.toolObservations()
 	if err != nil {
 		return nil, err
 	}
-	matches := map[string]bool{}
+	matches := map[string]toolMatch{}
 	for _, observation := range observations {
 		if observation.HasSession && observation.Name == tool && inPeriod(observation.Timestamp, since, before) &&
 			workspaceMatches(observation.Workspace, workspace) {
-			matches[observation.ConversationID] = true
+			match, seen := matches[observation.ConversationID]
+			if !seen || observation.Timestamp.Before(match.first) {
+				match.first = observation.Timestamp
+			}
+			if observation.Timestamp.After(match.last) {
+				match.last = observation.Timestamp
+			}
+			matches[observation.ConversationID] = match
 		}
 	}
 	return matches, nil
 }
 
-// ConversationMetrics returns lifetime conversation metadata with every
-// analytic field clipped to generations in [Since, Before). matched counts
+// toolCallOnlySummary represents a conversation whose matching tool observation
+// is inside the period while all generations are outside it. Observation times
+// bound the row. Calls, token usage, agents, models, errors, and subagent counts
+// stay empty or zero. The aggregate counts the session but attributes no
+// out-of-period usage.
+func toolCallOnlySummary(entry *fileSummary, match toolMatch) ConversationSummary {
+	return ConversationSummary{
+		ID:                  entry.summary.ID,
+		Title:               entry.summary.Title,
+		Workspace:           entry.summary.Workspace,
+		Branch:              entry.summary.Branch,
+		Status:              "ok",
+		StartedAt:           match.first,
+		LastActivity:        match.last,
+		Agents:              []string{},
+		Models:              []string{},
+		TokenBucketsByModel: map[string]TokenBuckets{},
+	}
+}
+
+// ConversationMetrics returns lifetime conversation metadata. Fields derived
+// from generations are clipped to [Since, Before). matched counts
 // matching conversations before Limit. Rows are ordered by clipped newest
 // activity, then id.
+//
+// The agent, model, status and subagent facets are tested against the clipped
+// summary, so a conversation whose only error or subagent step falls outside
+// the period does not match one. ListConversations tests a period request the
+// same way, so both endpoints select one set.
+//
+// A tool filter selects on the observation's own timestamp, which a reconciled
+// span can place outside its generation's period. Such a conversation is kept
+// with zero usage and the call times as its bounds, so the list and these
+// totals still count one set.
 func (s *Storage) ConversationMetrics(opts ConversationListOptions) ([]ConversationSummary, int, ConversationMetricsAggregate, error) {
 	files, err := s.conversationFiles()
 	if err != nil {
 		return nil, 0, ConversationMetricsAggregate{}, err
 	}
 	out := make([]ConversationSummary, 0, len(files))
+	var toolMatches map[string]toolMatch
+	if opts.Tool != nil {
+		toolMatches, err = s.conversationToolMatches(*opts.Tool, opts.Since, opts.Before, opts.Workspace)
+		if err != nil {
+			return nil, 0, ConversationMetricsAggregate{}, err
+		}
+	}
 	var skipped int
 	defer func() { s.logSkipped("conversation metrics", skipped) }()
 	for _, f := range files {
-		if !opts.Since.IsZero() && f.modTime.Before(opts.Since) {
+		// A tool sidecar can be newer than its conversation file, so a
+		// tool-filtered walk has to inspect every candidate, as the list does.
+		if !opts.Since.IsZero() && opts.Tool == nil && f.modTime.Before(opts.Since) {
 			break
 		}
 		entry, err := s.summaries.get(f)
@@ -275,7 +404,18 @@ func (s *Storage) ConversationMetrics(opts ConversationListOptions) ([]Conversat
 		if !entry.ok || !workspaceMatches(entry.summary.Workspace, opts.Workspace) {
 			continue
 		}
-		if summary, ok := clippedConversationSummary(entry, opts.Since, opts.Before); ok {
+		match, matchedTool := toolMatches[f.id]
+		if opts.Tool != nil && !matchedTool {
+			continue
+		}
+		summary, ok := clippedConversationSummary(entry, opts.Since, opts.Before)
+		if !ok {
+			if opts.Tool == nil {
+				continue
+			}
+			summary = toolCallOnlySummary(entry, match)
+		}
+		if opts.matchesFacets(summary) {
 			out = append(out, summary)
 		}
 	}
@@ -296,6 +436,7 @@ func (s *Storage) ConversationMetrics(opts ConversationListOptions) ([]Conversat
 
 func aggregateConversationMetrics(rows []ConversationSummary) ConversationMetricsAggregate {
 	aggregate := ConversationMetricsAggregate{
+		AgentHosts:          []string{},
 		TokenBucketsByModel: map[string]TokenBuckets{},
 		Models:              []string{},
 	}
@@ -322,16 +463,17 @@ func aggregateConversationMetrics(rows []ConversationSummary) ConversationMetric
 		}
 		workspaces[row.Workspace] = struct{}{}
 	}
-	aggregate.Agents = len(agents)
+	aggregate.AgentHosts = sortedKeys(agents)
+	aggregate.Agents = len(aggregate.AgentHosts)
 	aggregate.Models = sortedKeys(models)
 	aggregate.Workspaces = len(workspaces)
 	return aggregate
 }
 
-// ToolUsage returns period-clipped per-conversation tool totals. Conversation
-// membership and ordering use the same clipped summaries as
-// ConversationMetrics; result failures remain attributed to their call's
-// generation timestamp.
+// ToolUsage returns period-clipped per-conversation tool totals. When Tool and
+// conversation facets are unset, membership and ordering use the same clipped
+// summaries as ConversationMetrics. Result failures remain attributed to their
+// call's generation timestamp.
 func (s *Storage) ToolUsage(opts ConversationListOptions) ([]ConversationToolUsage, error) {
 	files, err := s.conversationFiles()
 	if err != nil {

--- a/plugins/agento11y/internal/local/query_test.go
+++ b/plugins/agento11y/internal/local/query_test.go
@@ -404,6 +404,180 @@ func TestConversationMetricsPeriodClipping(t *testing.T) {
 	assert.Equal(t, "err", previous[0].Status)
 }
 
+func TestConversationFacetFilters(t *testing.T) {
+	s := newStorage(t)
+	writeGen(t, s, "conv-pi", "g1", agento11y.Generation{
+		AgentName: "pi",
+		Model:     agento11y.ModelRef{Name: "claude-opus-5"},
+		StartedAt: mustParse(t, "2026-08-21T10:00:00Z"),
+		Usage:     agento11y.TokenUsage{InputTokens: 10},
+	}, "2026-08-21T10:00:00Z")
+	writeGen(t, s, "conv-pi-sub", "g2", agento11y.Generation{
+		AgentName: "pi/explore",
+		Model:     agento11y.ModelRef{Name: "claude-haiku-4-5"},
+		StartedAt: mustParse(t, "2026-08-21T10:10:00Z"),
+		Usage:     agento11y.TokenUsage{InputTokens: 20},
+	}, "2026-08-21T10:10:00Z")
+	writeGen(t, s, "conv-cc", "g3", agento11y.Generation{
+		AgentName: "claude-code",
+		Model:     agento11y.ModelRef{Name: "claude-opus-5"},
+		StartedAt: mustParse(t, "2026-08-21T10:20:00Z"),
+		Usage:     agento11y.TokenUsage{InputTokens: 30},
+		CallError: "rate limited",
+	}, "2026-08-21T10:20:00Z")
+
+	since := mustParse(t, "2026-08-21T09:00:00Z")
+	before := mustParse(t, "2026-08-21T11:00:00Z")
+	for _, tc := range []struct {
+		name string
+		opts ConversationListOptions
+		want []string
+	}{
+		{name: "no facet keeps every conversation", want: []string{"conv-cc", "conv-pi-sub", "conv-pi"}},
+		{name: "agent matches the host part", opts: ConversationListOptions{Agent: "pi"}, want: []string{"conv-pi-sub", "conv-pi"}},
+		{name: "agent matches a plain name", opts: ConversationListOptions{Agent: "claude-code"}, want: []string{"conv-cc"}},
+		{name: "agent does not match a subagent leaf", opts: ConversationListOptions{Agent: "explore"}, want: nil},
+		{name: "model is exact", opts: ConversationListOptions{Model: "claude-opus-5"}, want: []string{"conv-cc", "conv-pi"}},
+		{name: "status err", opts: ConversationListOptions{Status: "err"}, want: []string{"conv-cc"}},
+		{name: "status ok", opts: ConversationListOptions{Status: "ok"}, want: []string{"conv-pi-sub", "conv-pi"}},
+		{name: "subagents", opts: ConversationListOptions{MinSubagents: 1}, want: []string{"conv-pi-sub"}},
+		{name: "facets compose", opts: ConversationListOptions{Agent: "pi", Model: "claude-opus-5"}, want: []string{"conv-pi"}},
+		{name: "facets that share no conversation match none", opts: ConversationListOptions{Agent: "claude-code", Model: "claude-haiku-4-5"}, want: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := tc.opts
+			opts.Since, opts.Before, opts.Exact = since, before, true
+			listed, _, err := s.ListConversations(opts)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, summaryIDs(listed), "list")
+
+			rows, matched, aggregate, err := s.ConversationMetrics(opts)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, summaryIDs(rows), "metrics")
+			assert.Equal(t, len(tc.want), matched, "matched count")
+			assert.Equal(t, len(tc.want), aggregate.Calls, "aggregate covers the matched set only")
+		})
+	}
+
+	rows, matched, aggregate, err := s.ConversationMetrics(ConversationListOptions{
+		Limit: 1, Since: since, Before: before,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"conv-cc"}, summaryIDs(rows))
+	assert.Equal(t, 3, matched)
+	assert.Equal(t, []string{"claude-code", "pi"}, aggregate.AgentHosts)
+	assert.Equal(t, []string{"claude-haiku-4-5", "claude-opus-5"}, aggregate.Models)
+
+	// A facet cuts a candidate before it counts toward the limit, so the page
+	// reaches conversations the unfiltered page would have truncated away.
+	listed, _, err := s.ListConversations(ConversationListOptions{Limit: 1, MinSubagents: 1})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"conv-pi-sub"}, summaryIDs(listed))
+}
+
+// Sessions reads rows from ListConversations and totals from
+// ConversationMetrics, so an error facet that matches only outside the period
+// must exclude the conversation from both.
+func TestConversationFacetsSelectOneSetAcrossQueries(t *testing.T) {
+	s := newStorage(t)
+	writeGen(t, s, "conv-err-old", "g1", agento11y.Generation{
+		AgentName: "pi",
+		Model:     agento11y.ModelRef{Name: "claude-opus-5"},
+		StartedAt: mustParse(t, "2026-08-20T10:00:00Z"),
+		Usage:     agento11y.TokenUsage{InputTokens: 10},
+		CallError: "rate limited",
+	}, "2026-08-20T10:00:00Z")
+	writeGen(t, s, "conv-err-old", "g2", agento11y.Generation{
+		AgentName: "pi",
+		Model:     agento11y.ModelRef{Name: "claude-opus-5"},
+		StartedAt: mustParse(t, "2026-08-26T10:00:00Z"),
+		Usage:     agento11y.TokenUsage{InputTokens: 10},
+	}, "2026-08-26T10:00:00Z")
+
+	opts := ConversationListOptions{
+		Since:  mustParse(t, "2026-08-26T09:00:00Z"),
+		Before: mustParse(t, "2026-08-26T11:00:00Z"),
+		Status: "err",
+		Exact:  true,
+	}
+	listed, _, err := s.ListConversations(opts)
+	require.NoError(t, err)
+	assert.Empty(t, summaryIDs(listed), "the errored generation is outside the period")
+
+	rows, matched, _, err := s.ConversationMetrics(opts)
+	require.NoError(t, err)
+	assert.Empty(t, summaryIDs(rows))
+	assert.Equal(t, 0, matched)
+
+	opts.Status = ""
+	listed, _, err = s.ListConversations(opts)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"conv-err-old"}, summaryIDs(listed))
+	rows, matched, _, err = s.ConversationMetrics(opts)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"conv-err-old"}, summaryIDs(rows))
+	assert.Equal(t, 1, matched)
+}
+
+// A skills-and-tools drill-down can select a reconciled tool call inside the
+// period while its generation is outside. Both queries must keep the
+// conversation, and ConversationMetrics must report zero in-period generation
+// usage.
+func TestConversationMetricsToolCallOutsideItsGeneration(t *testing.T) {
+	s := newStorage(t)
+	generatedAt := mustParse(t, "2026-08-21T10:00:00Z")
+	writeToolGeneration(t, s, "conv-late-span", "g1", "/repo", generatedAt, "call-1", "Bash", false)
+	spanAt := mustParse(t, "2026-08-21T11:30:00Z")
+	_, err := s.appendToolSpans([]toolSpanRecord{
+		analyticsSpan("conv-late-span", "trace-1", "span-1", "call-1", "Bash", spanAt, 2*time.Second, false),
+	})
+	require.NoError(t, err)
+
+	bash := "Bash"
+	for _, tc := range []struct {
+		name   string
+		status string
+		want   []string
+	}{
+		{name: "no status facet", want: []string{"conv-late-span"}},
+		{name: "ok status keeps observation-only session", status: "ok", want: []string{"conv-late-span"}},
+		{name: "error status excludes observation-only session", status: "err"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := ConversationListOptions{
+				Since:  mustParse(t, "2026-08-21T11:00:00Z"),
+				Before: mustParse(t, "2026-08-21T12:00:00Z"),
+				Tool:   &bash,
+				Status: tc.status,
+				Exact:  true,
+			}
+			listed, _, err := s.ListConversations(opts)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, summaryIDs(listed), "list")
+
+			rows, matched, aggregate, err := s.ConversationMetrics(opts)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, summaryIDs(rows), "metrics")
+			assert.Equal(t, len(tc.want), matched)
+			assert.Equal(t, 0, aggregate.Calls, "no generation of its own falls in the period")
+			assert.Equal(t, TokenBuckets{}, aggregate.TokenBuckets)
+			if len(tc.want) > 0 {
+				require.Len(t, rows, 1)
+				assert.Equal(t, spanAt, rows[0].LastActivity, "the call time bounds a row with no in-period generation")
+				assert.Equal(t, "ok", rows[0].Status)
+			}
+		})
+	}
+}
+
+func summaryIDs(rows []ConversationSummary) []string {
+	var out []string
+	for _, row := range rows {
+		out = append(out, row.ID)
+	}
+	return out
+}
+
 func TestToolUsagePeriodClippingAttributesResultsToCalls(t *testing.T) {
 	s := newStorage(t)
 	callAt := mustParse(t, "2026-05-21T10:00:00Z")

--- a/plugins/agento11y/internal/local/server.go
+++ b/plugins/agento11y/internal/local/server.go
@@ -777,8 +777,9 @@ const conversationListLimit = 200
 
 // handleListConversations returns the aggregated conversation list as JSON.
 // The response is newest-first. ?limit= caps matching rows. Exact time,
-// workspace, and tool filters are applied to each decoded candidate before
-// it counts toward that cap; see ConversationListOptions.
+// workspace, and tool filters, plus the ?agent=, ?model=, ?status= and
+// ?subagents= facets, are applied to each decoded candidate before it counts
+// toward that cap; see ConversationListOptions.
 //
 // total_conversations counts the conversation files in the store, before
 // either bound. The viewer needs it to tell an empty store from an empty
@@ -793,20 +794,18 @@ func (s *Server) handleListConversations(w http.ResponseWriter, r *http.Request)
 	if !ok {
 		return
 	}
-	var tool *string
-	if values, present := r.URL.Query()["tool"]; present {
-		value := ""
-		if len(values) > 0 {
-			value = values[0]
-		}
-		tool = &value
+	tool := toolParam(r)
+	facets, ok := conversationFacetParams(w, r)
+	if !ok {
+		return
 	}
 	_, hasBefore := r.URL.Query()["before"]
-	// A since-only request is the normal ranged list and uses last activity.
+	// A since-only request without facets is the normal ranged list and uses last
+	// activity. Facets still use period-clipped summaries.
 	exact := hasBefore || workspace != nil || tool != nil
-	convs, total, err := s.storage.ListConversations(ConversationListOptions{
-		Limit: limit, Since: since, Before: before, Workspace: workspace, Tool: tool, Exact: exact,
-	})
+	facets.Limit, facets.Since, facets.Before = limit, since, before
+	facets.Workspace, facets.Tool, facets.Exact = workspace, tool, exact
+	convs, total, err := s.storage.ListConversations(facets)
 	if err != nil {
 		s.logger.Printf("local: list conversations: %v", err)
 		http.Error(w, "list conversations: "+err.Error(), http.StatusInternalServerError)
@@ -823,6 +822,46 @@ func (s *Server) handleListConversations(w http.ResponseWriter, r *http.Request)
 		"total_conversations": total,
 	})
 	s.warmSummariesInBackground()
+}
+
+// toolParam reads the presence-sensitive ?tool= filter. A present but empty
+// value matches no tool, which is not the same as no filter at all.
+func toolParam(r *http.Request) *string {
+	values, present := r.URL.Query()["tool"]
+	if !present {
+		return nil
+	}
+	value := ""
+	if len(values) > 0 {
+		value = values[0]
+	}
+	return &value
+}
+
+// conversationFacetParams reads ?agent=, ?model=, ?status= and ?subagents=
+// into the option fields both conversation endpoints share. status and
+// subagents are two independent predicates rather than one enum, because a
+// caller can want errored subagent sessions.
+func conversationFacetParams(w http.ResponseWriter, r *http.Request) (ConversationListOptions, bool) {
+	query := r.URL.Query()
+	opts := ConversationListOptions{
+		Agent:  query.Get("agent"),
+		Model:  query.Get("model"),
+		Status: query.Get("status"),
+	}
+	if opts.Status != "" && opts.Status != "ok" && opts.Status != "err" {
+		http.Error(w, `invalid status: want "ok" or "err"`, http.StatusBadRequest)
+		return ConversationListOptions{}, false
+	}
+	if raw := query.Get("subagents"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 0 {
+			http.Error(w, "invalid subagents: want a non-negative integer", http.StatusBadRequest)
+			return ConversationListOptions{}, false
+		}
+		opts.MinSubagents = n
+	}
+	return opts, true
 }
 
 // limitParam reads a ?limit= page size, falling back to def when the
@@ -940,7 +979,10 @@ func (s *Server) handleTokenMetrics(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleConversationMetrics returns lifetime conversation identity metadata
-// with all analytic fields clipped to the requested generation-time period.
+// with generation-derived analytics clipped to the requested period.
+// It reads the same filters as the list endpoint, so a drill-down can show
+// exact totals over the set the list is showing. The two differ where a row
+// needs a generation inside the period; see ConversationMetrics.
 func (s *Server) handleConversationMetrics(w http.ResponseWriter, r *http.Request) {
 	limit, ok := limitParam(w, r, conversationListLimit)
 	if !ok {
@@ -950,9 +992,13 @@ func (s *Server) handleConversationMetrics(w http.ResponseWriter, r *http.Reques
 	if !ok {
 		return
 	}
-	rows, matched, aggregate, err := s.storage.ConversationMetrics(ConversationListOptions{
-		Limit: limit, Since: since, Before: before, Workspace: workspace,
-	})
+	facets, ok := conversationFacetParams(w, r)
+	if !ok {
+		return
+	}
+	facets.Limit, facets.Since, facets.Before = limit, since, before
+	facets.Workspace, facets.Tool = workspace, toolParam(r)
+	rows, matched, aggregate, err := s.storage.ConversationMetrics(facets)
 	if err != nil {
 		s.logger.Printf("local: conversation metrics: %v", err)
 		http.Error(w, "conversation metrics: "+err.Error(), http.StatusInternalServerError)

--- a/plugins/agento11y/internal/local/server_test.go
+++ b/plugins/agento11y/internal/local/server_test.go
@@ -360,6 +360,92 @@ func TestServer_ConversationMetrics(t *testing.T) {
 	})
 }
 
+func TestServer_ConversationFacetParams(t *testing.T) {
+	srv, storage, _ := newTestServerStorage(t)
+	writeGen(t, storage, "conv-pi", "g1", agento11y.Generation{
+		AgentName: "pi",
+		Model:     agento11y.ModelRef{Name: "claude-opus-5"},
+		StartedAt: mustParse(t, "2026-08-21T10:00:00Z"),
+		Usage:     agento11y.TokenUsage{InputTokens: 10},
+		Tags:      map[string]string{"cwd": "/repo"},
+	}, "2026-08-21T10:00:00Z")
+	writeGen(t, storage, "conv-sub", "g2", agento11y.Generation{
+		AgentName: "pi/explore",
+		Model:     agento11y.ModelRef{Name: "claude-haiku-4-5"},
+		StartedAt: mustParse(t, "2026-08-21T10:10:00Z"),
+		Usage:     agento11y.TokenUsage{InputTokens: 20},
+		CallError: "boom",
+		Tags:      map[string]string{"cwd": "/repo"},
+	}, "2026-08-21T10:10:00Z")
+
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{name: "agent host part", query: "agent=pi", want: []string{"conv-sub", "conv-pi"}},
+		{name: "model", query: "model=claude-opus-5", want: []string{"conv-pi"}},
+		{name: "status err", query: "status=err", want: []string{"conv-sub"}},
+		{name: "subagents", query: "subagents=1", want: []string{"conv-sub"}},
+		{name: "facets compose to nothing", query: "agent=pi&model=claude-opus-5&status=err", want: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, path := range []string{"/api/v1/conversations", "/api/v1/metrics/conversations"} {
+				rr := httptest.NewRecorder()
+				srv.ServeHTTP(rr, newLocalRequest(http.MethodGet,
+					path+"?since=2026-08-21T09:00:00Z&before=2026-08-21T11:00:00Z&"+tc.query, nil))
+				require.Equal(t, http.StatusOK, rr.Code, path)
+				var got struct {
+					Conversations        []ConversationSummary `json:"conversations"`
+					MatchedConversations int                   `json:"matched_conversations"`
+				}
+				decodeJSON(t, io.NopCloser(rr.Body), &got)
+				var ids []string
+				for _, conv := range got.Conversations {
+					ids = append(ids, conv.ID)
+				}
+				assert.Equal(t, tc.want, ids, path)
+				if path == "/api/v1/metrics/conversations" {
+					assert.Equal(t, len(tc.want), got.MatchedConversations, path)
+				}
+			}
+		})
+	}
+
+	t.Run("metrics reads the tool filter", func(t *testing.T) {
+		srv, storage, _ := newTestServerStorage(t)
+		lower := mustParse(t, "2026-08-21T10:00:00Z")
+		writeToolGeneration(t, storage, "conv-bash", "g1", "/repo", lower, "call-1", "Bash", false)
+		writeToolGeneration(t, storage, "conv-read", "g1", "/repo", lower, "call-2", "Read", false)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, newLocalRequest(http.MethodGet,
+			"/api/v1/metrics/conversations?tool=Bash&since=2026-08-21T09:00:00Z&before=2026-08-21T11:00:00Z", nil))
+		require.Equal(t, http.StatusOK, rr.Code)
+		var got struct {
+			Conversations        []ConversationSummary `json:"conversations"`
+			MatchedConversations int                   `json:"matched_conversations"`
+		}
+		decodeJSON(t, io.NopCloser(rr.Body), &got)
+		require.Len(t, got.Conversations, 1)
+		assert.Equal(t, "conv-bash", got.Conversations[0].ID)
+		assert.Equal(t, 1, got.MatchedConversations)
+	})
+
+	t.Run("invalid facet values are rejected", func(t *testing.T) {
+		for _, path := range []string{
+			"/api/v1/conversations?status=maybe",
+			"/api/v1/conversations?subagents=many",
+			"/api/v1/conversations?subagents=-1",
+			"/api/v1/metrics/conversations?status=maybe",
+			"/api/v1/metrics/conversations?subagents=many",
+		} {
+			rr := httptest.NewRecorder()
+			srv.ServeHTTP(rr, newLocalRequest(http.MethodGet, path, nil))
+			assert.Equal(t, http.StatusBadRequest, rr.Code, path)
+		}
+	})
+}
+
 func TestServer_ToolMetrics(t *testing.T) {
 	srv, storage, _ := newTestServerStorage(t)
 	writeGen(t, storage, "conv-tools", "g1", agento11y.Generation{

--- a/plugins/agento11y/internal/local/web/src/analytics.tsx
+++ b/plugins/agento11y/internal/local/web/src/analytics.tsx
@@ -1750,6 +1750,7 @@ function AnalyticsContent(props: ResolvedAnalyticsViewProps) {
           totalCost={facetCost.complete ? facetCost.value : null}
           now={now}
           rangeLabel={range.label}
+          fromRows
         />
         <TimeRangePicker value={props.timeRange} onChange={props.onTimeRangeChange} />
         <button

--- a/plugins/agento11y/internal/local/web/src/app.tsx
+++ b/plugins/agento11y/internal/local/web/src/app.tsx
@@ -100,6 +100,55 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+interface SessionFacets {
+  agent: string;
+  model: string;
+  status: string;
+}
+
+function applySessionFacets(params: URLSearchParams, facets: SessionFacets) {
+  if (facets.agent !== 'all') params.set('agent', facets.agent);
+  if (facets.model !== 'all') params.set('model', facets.model);
+  if (facets.status === 'errors') params.set('status', 'err');
+  else if (facets.status === 'subagents') params.set('subagents', '1');
+}
+
+interface SessionScope {
+  timeRange: string;
+  toolFilter: ToolSessionFilters | null;
+  workspace: string | null;
+  facets: SessionFacets;
+}
+
+// sessionRequestParams builds the query the Sessions list and the Sessions
+// totals both carry, so the tiles count the set the rows come from. One
+// builder rather than two copies: a parameter added to one of them only is how
+// the workspace came to reach neither.
+//
+// The window is the range the header names, not the chart's bucket-floored
+// one, because a tile labelled 24h must not count a generation from 25 hours
+// ago. Sending `before` also makes the list request exact, so a row is one
+// with a generation inside the window rather than one whose last activity
+// happens to be recent, which is the rule the totals already use.
+function sessionRequestParams(scope: SessionScope, now: number): URLSearchParams {
+  const params = new URLSearchParams({ limit: String(LIST_PAGE_SIZE) });
+  if (scope.toolFilter) {
+    params.set('tool', scope.toolFilter.tool);
+    if (scope.toolFilter.workspace != null) params.set('workspace', scope.toolFilter.workspace);
+    if (scope.toolFilter.since) params.set('since', scope.toolFilter.since);
+    if (scope.toolFilter.before) params.set('before', scope.toolFilter.before);
+  } else {
+    const range = timeRangeOption(scope.timeRange);
+    if (range.ms != null) {
+      params.set('since', new Date(now - range.ms).toISOString());
+      params.set('before', new Date(now).toISOString());
+    }
+    if (scope.workspace != null) params.set('workspace', scope.workspace);
+  }
+  applySessionFacets(params, scope.facets);
+  return params;
+}
+
 /** One frame of the /api/v1/events stream. */
 interface StreamEvent {
   conversation_id?: string;
@@ -125,6 +174,7 @@ export function App() {
   // Settings itself, where pushState alone leaves the panel where it was.
   const [settingsTab, setSettingsTab] = useState(settingsTabFromLocation);
   const [conversations, setConversations] = useState<ConversationSummary[]>([]);
+  const [workspaceFacetConversations, setWorkspaceFacetConversations] = useState<ConversationSummary[]>([]);
   // storeCount is the number of conversations the daemon holds, before
   // the list's page and range bounds. The list itself is range-scoped,
   // so only this count distinguishes an empty store from a quiet range.
@@ -133,6 +183,23 @@ export function App() {
   const [tokenIntervalMs, setTokenIntervalMs] = useState(0);
   const [loadingList, setLoadingList] = useState(true);
   const [errList, setErrList] = useState<string | null>(null);
+  // Session headline numbers come from the conversation-metrics aggregate for
+  // the full range, workspace, tool filter, and facets, not the list page.
+  const [sessionAggregate, setSessionAggregate] = useState<ConversationMetricsAggregate | null>(null);
+  const [sessionMatched, setSessionMatched] = useState<number | null>(null);
+  const [loadingSessionMetrics, setLoadingSessionMetrics] = useState(true);
+  const [errSessionMetrics, setErrSessionMetrics] = useState<string | null>(null);
+  // The agent, model and status facets live here because both the list and
+  // the metrics request carry them; a page-local predicate could only ever
+  // narrow the rows the server already returned.
+  const [agentFilter, setAgentFilter] = useState('all');
+  const [modelFilter, setModelFilter] = useState('all');
+  const [statusFilter, setStatusFilter] = useState('all');
+  const resetSessionFacets = useCallback(() => {
+    setAgentFilter('all');
+    setModelFilter('all');
+    setStatusFilter('all');
+  }, []);
   const [query, setQuery] = useState('');
   const conversationSearchRef = useRef<HTMLInputElement | null>(null);
   const [timeRange, setTimeRange] = usePersistedState('sigil.local.timeRange', DEFAULT_TIME_RANGE, (v) =>
@@ -362,22 +429,36 @@ export function App() {
       const seq = ++listSeqRef.current;
       setLoadingList(true);
       setErrList(null);
-      if (reset) setConversations([]);
-      const w = requestWindow(timeRange, LIST_PAGE_SIZE);
-      const params = new URLSearchParams({ limit: String(w.limit) });
-      if (toolSessionFilters) {
-        params.set('tool', toolSessionFilters.tool);
-        if (toolSessionFilters.workspace != null) params.set('workspace', toolSessionFilters.workspace);
-        if (toolSessionFilters.since) params.set('since', toolSessionFilters.since);
-        if (toolSessionFilters.before) params.set('before', toolSessionFilters.before);
-      } else if (w.since) {
-        params.set('since', w.since);
+      if (reset) {
+        setConversations([]);
+        setWorkspaceFacetConversations([]);
+      }
+      const params = sessionRequestParams(
+        {
+          timeRange,
+          toolFilter: toolSessionFilters,
+          workspace,
+          facets: { agent: agentFilter, model: modelFilter, status: statusFilter },
+        },
+        Date.now(),
+      );
+      if (params.has('workspace')) {
+        const facetParams = new URLSearchParams(params);
+        facetParams.delete('workspace');
+        void fetch(`/api/v1/conversations?${facetParams}`)
+          .then((r) => (r.ok ? r.json() : r.text().then((t) => Promise.reject(new Error(t || `HTTP ${r.status}`)))))
+          .then((body: ConversationListResponse) => {
+            if (listSeqRef.current === seq) setWorkspaceFacetConversations(body.conversations || []);
+          })
+          .catch(() => undefined);
       }
       return fetch(`/api/v1/conversations?${params}`)
         .then((r) => (r.ok ? r.json() : r.text().then((t) => Promise.reject(new Error(t || `HTTP ${r.status}`)))))
         .then((body: ConversationListResponse) => {
           if (listSeqRef.current !== seq) return;
-          setConversations(body.conversations || []);
+          const rows = body.conversations || [];
+          setConversations(rows);
+          if (!params.has('workspace')) setWorkspaceFacetConversations(rows);
           setStoreCount(Number.isFinite(body.total_conversations) ? body.total_conversations : null);
         })
         .catch((e) => {
@@ -389,7 +470,52 @@ export function App() {
           setLoadingList(false);
         });
     },
-    [timeRange, toolSessionFilters],
+    [timeRange, toolSessionFilters, workspace, agentFilter, modelFilter, statusFilter],
+  );
+
+  // fetchSessionMetrics is what makes the Sessions headline numbers exact:
+  // the response's aggregate and matched_conversations are computed over
+  // every conversation matching the request, before its row limit. It carries
+  // the same scope as fetchList, so the tiles count every conversation the
+  // list request selected, including the ones its page could not hold.
+  const sessionMetricsSeqRef = useRef(0);
+  const fetchSessionMetrics = useCallback(
+    (reset = false) => {
+      const seq = ++sessionMetricsSeqRef.current;
+      setLoadingSessionMetrics(true);
+      setErrSessionMetrics(null);
+      if (reset) {
+        setSessionAggregate(null);
+        setSessionMatched(null);
+      }
+      const params = sessionRequestParams(
+        {
+          timeRange,
+          toolFilter: toolSessionFilters,
+          workspace,
+          facets: { agent: agentFilter, model: modelFilter, status: statusFilter },
+        },
+        Date.now(),
+      );
+      return fetch(`/api/v1/metrics/conversations?${params}`)
+        .then((r) => (r.ok ? r.json() : r.text().then((t) => Promise.reject(new Error(t || `HTTP ${r.status}`)))))
+        .then((body: ConversationMetricsResponse) => {
+          if (sessionMetricsSeqRef.current !== seq) return;
+          setSessionAggregate(body.aggregate || null);
+          setSessionMatched(Number.isFinite(body.matched_conversations) ? body.matched_conversations : null);
+        })
+        .catch((e) => {
+          if (sessionMetricsSeqRef.current !== seq) return;
+          setSessionAggregate(null);
+          setSessionMatched(null);
+          setErrSessionMetrics(String(e.message || e));
+        })
+        .finally(() => {
+          if (sessionMetricsSeqRef.current !== seq) return;
+          setLoadingSessionMetrics(false);
+        });
+    },
+    [timeRange, toolSessionFilters, workspace, agentFilter, modelFilter, statusFilter],
   );
 
   // Token points back the usage chart. The server aggregates them per
@@ -429,6 +555,7 @@ export function App() {
       } else {
         if (w.since) params.set('since', w.since);
         if (w.intervalSec) params.set('interval', String(w.intervalSec));
+        if (workspace != null) params.set('workspace', workspace);
       }
       const query = params.toString();
       return fetch(`/api/v1/metrics/tokens${query ? `?${query}` : ''}`)
@@ -444,7 +571,7 @@ export function App() {
         })
         .catch(() => {});
     },
-    [timeRange, toolSessionFilters],
+    [timeRange, toolSessionFilters, workspace],
   );
 
   const analyticsSeqRef = useRef(0);
@@ -698,22 +825,21 @@ export function App() {
       return;
     }
     refreshInFlightRef.current = true;
-    Promise.all([fetchList(), fetchTokens()]).finally(() => {
+    Promise.all([fetchList(), fetchTokens(), fetchSessionMetrics()]).finally(() => {
       refreshInFlightRef.current = false;
       if (!refreshDirtyRef.current) return;
       refreshDirtyRef.current = false;
       refreshAllRef.current?.();
     });
-  }, [fetchList, fetchTokens]);
+  }, [fetchList, fetchTokens, fetchSessionMetrics]);
 
-  // reloadRange refetches when the request window itself changed: mount,
-  // or a range change. Both callbacks close over timeRange, so this
-  // identity moves exactly then, and the effect below is the only caller
-  // that discards what the previous window returned.
-  const reloadRange = useCallback(() => {
-    fetchList(true);
-    fetchTokens(true);
-  }, [fetchList, fetchTokens]);
+  // Arm Sessions metrics only while the Sessions view is active. Analytics
+  // uses separate totals. An SSE flush can still update Sessions metrics while
+  // a conversation is open; the 60-second list backstop cannot.
+  const conversationsActive = view === 'conversations';
+  useEffect(() => {
+    if (conversationsActive) fetchSessionMetrics(true);
+  }, [conversationsActive, fetchSessionMetrics]);
 
   // fetchDetailCore is the shared fetch body for both an explicit
   // open (quiet=false: shows a spinner and clears stale content) and
@@ -757,9 +883,16 @@ export function App() {
   const fetchDetail = useCallback((id: string) => fetchDetailCore(id, false), [fetchDetailCore]);
   const quietRefreshDetail = useCallback((id: string) => fetchDetailCore(id, true), [fetchDetailCore]);
 
+  // Reset list rows and token points only when each request's scope changes.
+  // Token metrics do not use the agent, model, or status facets, so facet
+  // changes must not clear or refetch the chart.
   useEffect(() => {
-    reloadRange();
-  }, [reloadRange]);
+    fetchList(true);
+  }, [fetchList]);
+
+  useEffect(() => {
+    fetchTokens(true);
+  }, [fetchTokens]);
 
   useEffect(() => {
     if (view === 'analytics' && analyticsTab === 'overview') fetchAnalytics(true);
@@ -775,9 +908,15 @@ export function App() {
 
   useEffect(() => {
     const onPopState = () => {
-      setSelectedID(conversationIDFromPath());
-      setShowSettings(settingsRouteActive());
-      setShowAnalytics(analyticsRouteActive());
+      const nextSelectedID = conversationIDFromPath();
+      const nextSettings = settingsRouteActive();
+      const nextAnalytics = analyticsRouteActive();
+      if (!nextSelectedID && !nextSettings && !nextAnalytics && view !== 'conversations') {
+        resetSessionFacets();
+      }
+      setSelectedID(nextSelectedID);
+      setShowSettings(nextSettings);
+      setShowAnalytics(nextAnalytics);
       setSettingsTab(settingsTabFromLocation());
       setAnalyticsTab(analyticsTabFromLocation());
       setToolSessionFilters(toolSessionFiltersFromLocation());
@@ -785,7 +924,7 @@ export function App() {
     };
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
-  }, []);
+  }, [resetSessionFacets, view]);
 
   useEffect(() => {
     if (!selectedID) {
@@ -931,6 +1070,7 @@ export function App() {
   };
   const goConversations = () => {
     window.history.pushState({}, '', conversationsPath());
+    resetSessionFacets();
     setShowSettings(false);
     setShowAnalytics(false);
     setSelectedID(null);
@@ -951,6 +1091,7 @@ export function App() {
     const returnWorkspace = state?.workspace ?? null;
     const path = state?.returnPath || conversationsPath(returnWorkspace);
     window.history.pushState({}, '', path);
+    resetSessionFacets();
     setShowAnalytics(false);
     setWorkspace(returnWorkspace);
     setToolSessionFilters(toolSessionFiltersFromLocation());
@@ -968,6 +1109,7 @@ export function App() {
   };
   const openToolSessions = (filters: ToolSessionFilters) => {
     window.history.pushState({}, '', toolSessionsPath(filters));
+    resetSessionFacets();
     setTimeRange(analyticsRange);
     setShowSettings(false);
     setShowAnalytics(false);
@@ -978,6 +1120,7 @@ export function App() {
   };
   const openAnalyticsBucket = (span: TimeSpan) => {
     window.history.pushState({}, '', conversationsPath(analyticsWorkspace));
+    resetSessionFacets();
     setTimeRange(analyticsRange);
     setWorkspace(analyticsWorkspace);
     setBucketSel(span);
@@ -988,6 +1131,7 @@ export function App() {
   };
   const openAnalyticsWorkspace = (path: string) => {
     window.history.pushState({}, '', conversationsPath(path));
+    resetSessionFacets();
     setTimeRange(analyticsRange);
     setWorkspace(path);
     setBucketSel(null);
@@ -1026,6 +1170,7 @@ export function App() {
     };
     if (viewRef.current !== 'conversations') {
       window.history.pushState({}, '', conversationsPath());
+      resetSessionFacets();
       setSelectedID(null);
       setShowSettings(false);
       setShowAnalytics(false);
@@ -1035,7 +1180,7 @@ export function App() {
       return;
     }
     focus();
-  }, []);
+  }, [resetSessionFacets]);
   const themeShortcutRef = useRef<ThemeShortcutState>({ prefix: '', at: 0 });
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
@@ -1180,7 +1325,12 @@ export function App() {
         {view === 'conversations' && (
           <ConversationsView
             conversations={conversations}
+            workspaceFacetConversations={workspaceFacetConversations}
             storeCount={storeCount}
+            aggregate={sessionAggregate}
+            matchedConversations={sessionMatched}
+            metricsLoading={loadingSessionMetrics}
+            metricsError={errSessionMetrics}
             tokenPoints={tokenPoints}
             tokenIntervalMs={tokenIntervalMs}
             loading={loadingList}
@@ -1200,6 +1350,12 @@ export function App() {
             setWorkspace={selectConversationWorkspace}
             groupBy={groupBy}
             setGroupBy={setGroupBy}
+            agentFilter={agentFilter}
+            setAgentFilter={setAgentFilter}
+            modelFilter={modelFilter}
+            setModelFilter={setModelFilter}
+            statusFilter={statusFilter}
+            setStatusFilter={setStatusFilter}
             listSort={listSort}
             setListSort={setListSort}
             onOpen={openConv}

--- a/plugins/agento11y/internal/local/web/src/conversations.tsx
+++ b/plugins/agento11y/internal/local/web/src/conversations.tsx
@@ -8,7 +8,8 @@ import {
   chartBucketMs,
   chartGrid,
   chartTooltipLeft,
-  conversationCost,
+  conversationCostByModel,
+  conversationCostEstimateByModel,
   conversationTime,
   durationBetweenSeconds,
   ESTIMATED_COST_TOOLTIP,
@@ -34,7 +35,13 @@ import { conversationPath, isPlainLeftClick } from './routing';
 import { ConversationSearchPanel, useSearchResults } from './search';
 import { HistoryImportBanner } from './settings-screen';
 import { AgentCell, agentHosts, Icon, iconBtn, ModelCell } from './shell';
-import type { ConversationSummary, ModelPrices, TokenBucketKey, TokenBuckets, TokenUsagePoint } from './types';
+import type {
+  ConversationMetricsAggregate,
+  ConversationSummary,
+  ModelPrices,
+  TokenBucketKey,
+  TokenUsagePoint,
+} from './types';
 
 /** One bar of the activity chart: the bucket bounds plus its session count. */
 interface ActivityChartBucket extends TimeBucket, ActivityBucket {}
@@ -736,6 +743,44 @@ export interface WorkspaceAggregate extends Omit<WorkspaceTotals, 'cost'> {
   cost: number | null;
 }
 
+function workspaceAggregates(conversations: ConversationSummary[], prices: ModelPrices | null): WorkspaceAggregate[] {
+  const map = new Map<string, WorkspaceTotals>();
+  for (const conversation of conversations) {
+    const path = conversation.workspace || '';
+    let aggregate = map.get(path);
+    if (!aggregate) {
+      aggregate = {
+        path,
+        count: 0,
+        cost: 0,
+        costComplete: true,
+        tokens: 0,
+        dur: 0,
+        last: 0,
+      };
+      map.set(path, aggregate);
+    }
+    aggregate.count++;
+    const estimate = conversationCostEstimateByModel(conversation, prices);
+    if (!estimate.complete) aggregate.costComplete = false;
+    if (estimate.value != null) aggregate.cost += estimate.value;
+    aggregate.tokens += conversation.total_tokens || 0;
+    const duration = durationBetweenSeconds(conversation.started_at, conversation.last_activity);
+    if (duration != null) aggregate.dur += duration;
+    const activity = conversationTime(conversation);
+    if (activity != null && activity > aggregate.last) aggregate.last = activity;
+  }
+  return [...map.values()]
+    .map((aggregate) => ({
+      ...aggregate,
+      // Keep the priced sum when a workspace mixes priced and
+      // unpriced sessions. Null only when nothing in it can be
+      // priced, so share bars match the total cost.
+      cost: aggregate.costComplete || aggregate.cost > 0 ? aggregate.cost : null,
+    }))
+    .sort((a, b) => b.last - a.last);
+}
+
 interface WorkspaceFacetProps {
   workspaces: WorkspaceAggregate[];
   selected?: string | null;
@@ -744,6 +789,7 @@ interface WorkspaceFacetProps {
   totalCost: number | null;
   now: number;
   rangeLabel: string;
+  fromRows?: boolean;
 }
 
 export function WorkspaceFacet({
@@ -754,6 +800,7 @@ export function WorkspaceFacet({
   totalCost,
   now,
   rangeLabel,
+  fromRows = false,
 }: WorkspaceFacetProps) {
   const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState('');
@@ -1209,6 +1256,7 @@ export function WorkspaceFacet({
           >
             <span>
               {workspaces.length} workspaces · {rangeLabel}
+              {fromRows ? ` · from the ${totalCount} listed sessions` : ''}
             </span>
             <span>sessions · cost · share</span>
           </div>
@@ -1360,6 +1408,7 @@ function FilterBar({
           totalCost={workspaceTotalCost}
           now={now}
           rangeLabel={rangeLabel}
+          fromRows
         />
       )}
       {showTimeRange && <TimeRangePicker value={timeRange} onChange={onTimeRangeChange} />}
@@ -1569,7 +1618,7 @@ export function ConvRow({ c, now, onOpen, prices, grouped = false, hideWorkspace
       </div>
       <AgentCell agents={c.agents} />
       <span style={{ color: 'var(--fg1)' }} title={ESTIMATED_COST_TOOLTIP}>
-        {formatCost(conversationCost(c, prices))}
+        {formatCost(conversationCostByModel(c, prices))}
       </span>
       <span
         style={{ display: 'inline-flex', alignItems: 'center', gap: 7 }}
@@ -2179,12 +2228,15 @@ function KpiTile({ label, value, valueColor, sub, dot, bar, tooltip }: KpiTilePr
   );
 }
 
-// KpiStrip surfaces the headline numbers for the in-view set: counts
-// from the range + search conversations, token and cache rate from the
-// chart's series (so they honour the model dropdown and legend
-// toggles). "Model calls" is the per-generation call count. "Errored
-// conversations" counts conversations with a call error.
-/** The headline numbers the KPI strip renders, derived from the in-view set. */
+const KPI_STRIP_STYLE: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(6, 1fr)',
+  gap: 12,
+  marginBottom: 16,
+};
+
+const KPI_LABELS = ['Sessions', 'Cost', 'Total tokens', 'Input cache hit', 'Model calls', 'Errored sessions'];
+
 interface KpiSummary {
   conversations: number;
   conversationsSub: string;
@@ -2200,20 +2252,22 @@ interface KpiSummary {
 }
 
 interface KpiStripProps {
-  kpi: KpiSummary;
+  kpi: KpiSummary | null;
 }
 
 function KpiStrip({ kpi }: KpiStripProps) {
+  if (!kpi) {
+    return (
+      <div style={KPI_STRIP_STYLE}>
+        {KPI_LABELS.map((label) => (
+          <KpiTile key={label} label={label} value={NO_VALUE} />
+        ))}
+      </div>
+    );
+  }
   const avg = kpi.avgCalls.toFixed(1).replace(/\.0$/, '');
   return (
-    <div
-      style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(6, 1fr)',
-        gap: 12,
-        marginBottom: 16,
-      }}
-    >
+    <div style={KPI_STRIP_STYLE}>
       <KpiTile label="Sessions" value={kpi.conversations} sub={kpi.conversationsSub} />
       <KpiTile label="Cost" value={formatCost(kpi.cost)} sub={kpi.costSub} tooltip={ESTIMATED_COST_TOOLTIP} />
       <KpiTile
@@ -2265,8 +2319,18 @@ interface CollapsedGroups {
 
 interface ConversationsViewBaseProps {
   conversations: ConversationSummary[];
+  workspaceFacetConversations: ConversationSummary[];
   /** Conversations the daemon holds before the list's range bounds; null from an older daemon. */
   storeCount: number | null;
+  /**
+   * Totals before the row limit for conversations matching the range,
+   * workspace, tool filter, and facets. Null before a response for the current
+   * scope or after that request fails; never derived from the returned page.
+   */
+  aggregate: ConversationMetricsAggregate | null;
+  matchedConversations: number | null;
+  metricsLoading: boolean;
+  metricsError: string | null;
   tokenPoints: TokenUsagePoint[] | null;
   tokenIntervalMs: number;
   loading: boolean;
@@ -2286,6 +2350,13 @@ interface ConversationsViewBaseProps {
   setWorkspace: (path: string | null) => void;
   groupBy: string;
   setGroupBy: (value: string) => void;
+  /** Facet state lives in App because the list and metrics requests include it. */
+  agentFilter: string;
+  setAgentFilter: (value: string) => void;
+  modelFilter: string;
+  setModelFilter: (value: string) => void;
+  statusFilter: string;
+  setStatusFilter: (value: string) => void;
   listSort: ListSort;
   setListSort: React.Dispatch<React.SetStateAction<ListSort>>;
   onOpen: (c: OpenTarget) => void;
@@ -2311,7 +2382,12 @@ function toolRangeLabel(filter: ToolSessionFilters) {
 
 export function ConversationsView({
   conversations,
+  workspaceFacetConversations,
   storeCount,
+  aggregate,
+  matchedConversations,
+  metricsLoading,
+  metricsError,
   tokenPoints,
   tokenIntervalMs,
   loading,
@@ -2331,6 +2407,12 @@ export function ConversationsView({
   setWorkspace,
   groupBy,
   setGroupBy,
+  agentFilter,
+  setAgentFilter,
+  modelFilter,
+  setModelFilter,
+  statusFilter,
+  setStatusFilter,
   listSort,
   setListSort,
   onOpen,
@@ -2364,17 +2446,9 @@ export function ConversationsView({
     setSelectedIndex: setSearchSelectedIndex,
     retry: retrySearch,
   } = search;
-  const [agentFilter, setAgentFilter] = useState('all');
-  const [modelFilter, setModelFilter] = useState('all');
-  const [statusFilter, setStatusFilter] = useState('all');
-  const rangeFiltered = useMemo(() => {
-    if (toolFilter || range.ms == null) return conversations;
-    const from = now - range.ms;
-    return conversations.filter((c) => {
-      const t = conversationTime(c);
-      return t != null && t >= from && t <= now;
-    });
-  }, [conversations, range.ms, now, toolFilter]);
+  // The server filters exact list requests by generation time. Row timestamps
+  // cover the full session, so applying the range again would select another set.
+  const rangeFiltered = conversations;
 
   // Explicit group overrides survive filters because they are keyed by group.
   // A groupBy change resets them because the keys change meaning.
@@ -2388,119 +2462,101 @@ export function ConversationsView({
       return next;
     });
   }, []);
-  const workspaces = useMemo<WorkspaceAggregate[]>(() => {
-    const map = new Map<string, WorkspaceTotals>();
-    for (const c of rangeFiltered) {
-      const w = c.workspace || '';
-      let e = map.get(w);
-      if (!e) {
-        e = {
-          path: w,
-          count: 0,
-          cost: 0,
-          costComplete: true,
-          tokens: 0,
-          dur: 0,
-          last: 0,
-        };
-        map.set(w, e);
-      }
-      e.count++;
-      const cost = conversationCost(c, prices);
-      if (cost == null) e.costComplete = false;
-      else e.cost += cost;
-      e.tokens += c.total_tokens || 0;
-      const d = durationBetweenSeconds(c.started_at, c.last_activity);
-      if (d != null) e.dur += d;
-      const t = conversationTime(c);
-      if (t != null && t > e.last) e.last = t;
-    }
-    return [...map.values()]
-      .map((entry) => ({
-        ...entry,
-        // Keep the priced sum when a workspace mixes priced and
-        // unpriced sessions. Null only when nothing in it can be
-        // priced, so share bars match totalCost.
-        cost: entry.costComplete || entry.cost > 0 ? entry.cost : null,
-      }))
-      .sort((a, b) => b.last - a.last);
-  }, [rangeFiltered, prices]);
+  const facetWorkspaces = useMemo(
+    () => workspaceAggregates(workspaceFacetConversations, prices),
+    [workspaceFacetConversations, prices],
+  );
   const totalCost = useMemo(() => {
-    // Sum priced sessions only. One unpriced model used to zero the
+    // Sum priced model usage only. One unpriced model used to zero the
     // whole header to NO_VALUE even when other sessions had a real
     // dollar figure — the KPI tile already skips those.
     let cost = 0;
     let priced = 0;
-    for (const conversation of rangeFiltered) {
-      const value = conversationCost(conversation, prices);
+    for (const conversation of workspaceFacetConversations) {
+      const value = conversationCostByModel(conversation, prices);
       if (value == null) continue;
       cost += value;
       priced++;
     }
     return priced ? cost : null;
-  }, [rangeFiltered, prices]);
-  const agentCount = useMemo(() => {
-    const set = new Set<string>();
-    for (const c of rangeFiltered) for (const a of agentHosts(c.agents)) set.add(a);
-    return set.size;
-  }, [rangeFiltered]);
+  }, [workspaceFacetConversations, prices]);
   // Keep an out-of-range workspace selected so the page can show its empty
   // context instead of silently returning to all workspaces.
   const activeWorkspace = workspace;
-  const selectedWorkspaceRangeAggregate =
-    activeWorkspace == null
-      ? null
-      : workspaces.find((w) => w.path === activeWorkspace) || {
-          path: activeWorkspace,
-          count: 0,
-          cost: 0,
-          costComplete: true,
-          tokens: 0,
-          dur: 0,
-          last: 0,
-        };
-  const wsFiltered = useMemo(
+  const selectedWorkspaceRangeAggregate = useMemo(
+    () =>
+      activeWorkspace == null
+        ? null
+        : workspaceAggregates(rangeFiltered, prices).find((entry) => entry.path === activeWorkspace) || {
+            path: activeWorkspace,
+            count: 0,
+            cost: 0,
+            costComplete: true,
+            tokens: 0,
+            dur: 0,
+            last: 0,
+          },
+    [activeWorkspace, rangeFiltered, prices],
+  );
+  const workspaces = useMemo(() => {
+    if (
+      activeWorkspace == null ||
+      selectedWorkspaceRangeAggregate == null ||
+      facetWorkspaces.some((entry) => entry.path === activeWorkspace)
+    ) {
+      return facetWorkspaces;
+    }
+    return [...facetWorkspaces, selectedWorkspaceRangeAggregate].sort((a, b) => b.last - a.last);
+  }, [activeWorkspace, facetWorkspaces, selectedWorkspaceRangeAggregate]);
+  // The returned page, narrowed to the range and the selected workspace. The
+  // agent, model and status facets are applied by the server, so the rows
+  // arrive already narrowed by those.
+  const workspaceRows = useMemo(
     () =>
       activeWorkspace == null ? rangeFiltered : rangeFiltered.filter((c) => (c.workspace || '') === activeWorkspace),
     [rangeFiltered, activeWorkspace],
   );
 
+  // Keep the selected value when no match contains it so the control shows the
+  // requested filter.
   const agentOptions = useMemo(() => {
     const set = new Set<string>();
-    for (const c of wsFiltered) for (const a of agentHosts(c.agents)) set.add(a);
+    if (aggregate?.agent_hosts) {
+      for (const agent of aggregate.agent_hosts) set.add(agent);
+    } else {
+      for (const conversation of workspaceRows) for (const agent of agentHosts(conversation.agents)) set.add(agent);
+    }
+    if (agentFilter !== 'all') set.add(agentFilter);
     return [...set].sort();
-  }, [wsFiltered]);
-  const activeAgentFilter = agentOptions.includes(agentFilter) ? agentFilter : 'all';
+  }, [aggregate, workspaceRows, agentFilter]);
 
   const modelFacetOptions = useMemo(() => {
     const set = new Set<string>();
-    for (const c of wsFiltered) for (const m of c.models || []) if (m) set.add(m);
+    if (aggregate?.models) {
+      for (const model of aggregate.models) set.add(model);
+    } else {
+      for (const conversation of workspaceRows)
+        for (const model of conversation.models || []) if (model) set.add(model);
+    }
+    if (modelFilter !== 'all') set.add(modelFilter);
     return [...set].sort();
-  }, [wsFiltered]);
-  const activeModelFilter = modelFacetOptions.includes(modelFilter) ? modelFilter : 'all';
+  }, [aggregate, workspaceRows, modelFilter]);
   const activeStatusFilter = statusFilter === 'errors' || statusFilter === 'subagents' ? statusFilter : 'all';
-
-  const filtered = useMemo(() => {
-    return wsFiltered.filter((c) => {
-      if (activeAgentFilter !== 'all' && !agentHosts(c.agents).includes(activeAgentFilter)) return false;
-      if (activeModelFilter !== 'all' && !(c.models || []).includes(activeModelFilter)) return false;
-      if (activeStatusFilter === 'errors' && c.status !== 'err') return false;
-      if (activeStatusFilter === 'subagents' && !((c.subagents ?? 0) > 0)) return false;
-      return true;
-    });
-  }, [wsFiltered, activeAgentFilter, activeModelFilter, activeStatusFilter]);
+  // A facet that matches nothing returns an empty page, so the range looks
+  // empty too. The empty state has to name the facet rather than the range.
+  const facetActive = agentFilter !== 'all' || modelFilter !== 'all' || activeStatusFilter !== 'all';
 
   const activeFilterCount =
     (activeWorkspace != null ? 1 : 0) +
-    (activeAgentFilter !== 'all' ? 1 : 0) +
-    (activeModelFilter !== 'all' ? 1 : 0) +
+    (agentFilter !== 'all' ? 1 : 0) +
+    (modelFilter !== 'all' ? 1 : 0) +
     (activeStatusFilter !== 'all' ? 1 : 0);
   const clearFilters = useCallback(() => {
     setWorkspace(null);
     setAgentFilter('all');
     setModelFilter('all');
     setStatusFilter('all');
-  }, [setWorkspace]);
+  }, [setWorkspace, setAgentFilter, setModelFilter, setStatusFilter]);
   const clearSearch = useCallback(() => {
     setQuery('');
     setTimeout(() => {
@@ -2613,9 +2669,6 @@ export function ConversationsView({
       effectiveModel === 'all' ? tokenUsagePoints : tokenUsagePoints.filter((point) => point.model === effectiveModel),
     [tokenUsagePoints, effectiveModel],
   );
-  // Legend visibility is shared with the KPI strip so hiding a series
-  // rescales the chart and drops it from the headline tokens in step.
-  // Lives here, not in TokenChart, so both read the one set.
   const [hiddenSeries, setHiddenSeries] = useState<Set<TokenBucketKey>>(() => new Set());
   const toggleSeries = useCallback(
     (key: TokenBucketKey) =>
@@ -2636,7 +2689,7 @@ export function ConversationsView({
   // window, which a model facet can narrow.
   const serverIntervalMs = toolFilter || range.ms == null ? tokenIntervalMs : 0;
   const chartWindow = useMemo(() => {
-    const times = filtered.map(conversationTime).concat(tokenFiltered.map(tokenPointTime));
+    const times = workspaceRows.map(conversationTime).concat(tokenFiltered.map(tokenPointTime));
     if (!toolFilter || !exactWindow) return chartGrid(times, timeRange, now, serverIntervalMs);
     let start = exactWindow.start;
     if (start == null) {
@@ -2654,16 +2707,16 @@ export function ConversationsView({
       bucketMs,
       count: Math.round((gridEnd - gridStart) / bucketMs),
     };
-  }, [filtered, tokenFiltered, timeRange, now, serverIntervalMs, toolFilter, exactWindow]);
+  }, [workspaceRows, tokenFiltered, timeRange, now, serverIntervalMs, toolFilter, exactWindow]);
   const activity = useMemo(
     () =>
       toolFilter
         ? { buckets: [], bucketLabel: '' }
-        : bucketActivity(filtered, timeRange, now, {
+        : bucketActivity(workspaceRows, timeRange, now, {
             window: chartWindow,
             count: chartWindow.count,
           }),
-    [filtered, timeRange, now, chartWindow, toolFilter],
+    [workspaceRows, timeRange, now, chartWindow, toolFilter],
   );
   const tokenUsage = useMemo(
     () =>
@@ -2686,15 +2739,15 @@ export function ConversationsView({
     [setBucketSel],
   );
   const listFiltered = useMemo(() => {
-    if (!bucketSel) return filtered;
-    return filtered.filter((c) => {
+    if (!bucketSel) return workspaceRows;
+    return workspaceRows.filter((c) => {
       const endT = conversationTime(c);
       if (endT == null) return false;
       const startT = new Date(c.started_at).getTime();
       const s = Number.isFinite(startT) ? startT : endT;
       return s < bucketSel.end && endT >= bucketSel.start;
     });
-  }, [filtered, bucketSel]);
+  }, [workspaceRows, bucketSel]);
 
   const handleSort = useCallback(
     (key: string) => {
@@ -2710,7 +2763,7 @@ export function ConversationsView({
         return d == null ? -1 : d;
       }
       if (listSort.key === 'tokens') return c.total_tokens || 0;
-      if (listSort.key === 'cost') return conversationCost(c, prices) || 0;
+      if (listSort.key === 'cost') return conversationCostByModel(c, prices) || 0;
       const t = conversationTime(c);
       return t == null ? 0 : t;
     };
@@ -2738,9 +2791,9 @@ export function ConversationsView({
       }
       group.rows.push(c);
       group.count++;
-      const cost = conversationCost(c, prices);
-      if (cost == null) group.costComplete = false;
-      else group.cost += cost;
+      const estimate = conversationCostEstimateByModel(c, prices);
+      if (!estimate.complete) group.costComplete = false;
+      if (estimate.value != null) group.cost += estimate.value;
       group.tokens += c.total_tokens || 0;
       const duration = durationBetweenSeconds(c.started_at, c.last_activity);
       if (duration != null) group.dur += duration;
@@ -2785,61 +2838,42 @@ export function ConversationsView({
     return { groups, sessions };
   }, [grouped, groupOpen, groupBy, activeWorkspace]);
 
-  // KPI tiles read the range + workspace + search set (not the bucket
-  // drill-down), computed straight off each conversation's token buckets.
-  // This keeps headline tokens, cost, and cache rate conversation-based rather
-  // than tied to the token-series chart, which has its own model filter.
-  const kpi = useMemo(() => {
-    let calls = 0,
-      errConvs = 0,
-      cost = 0,
-      priced = 0,
-      unpriced = 0;
-    const tot: TokenBuckets = {
-      fresh_input: 0,
-      cache_read: 0,
-      cache_write: 0,
-      output: 0,
-      reasoning: 0,
-    };
-    const models = new Set<string>();
-    for (const c of filtered) {
-      calls += c.calls || 0;
-      if (c.status === 'err') errConvs++;
-      const cc = conversationCost(c, prices);
-      if (cc == null) unpriced++;
-      else {
-        cost += cc;
-        priced++;
-      }
-      const b = c.token_buckets;
-      if (b) for (const k in tot) tot[k as TokenBucketKey] += b[k as TokenBucketKey] || 0;
-      for (const m of c.models || []) models.add(m);
-    }
+  // KPI tiles use the conversation-metrics aggregate, not the returned page.
+  // Tile usage is clipped to the range; list rows show each session's lifetime
+  // totals. If no aggregate is available for the current scope, do not derive
+  // totals from a page that may omit matching sessions.
+  const kpi = useMemo<KpiSummary | null>(() => {
+    if (!aggregate || matchedConversations == null) return null;
+    const tot = aggregate.token_buckets;
     const tokens = tot.fresh_input + tot.cache_read + tot.cache_write + tot.output + tot.reasoning;
-    // Cost sub is honest about coverage: if some conversations ran on an
-    // unpriced (non-Anthropic) model, say so rather than implying the
-    // total covers everything.
-    const costSub =
-      unpriced > 0
-        ? `${unpriced} unpriced · ${formatCost(priced ? cost / priced : 0)} avg`
-        : cost
-          ? `${formatCost(cost / Math.max(1, priced))} avg / session`
-          : 'estimated';
+    const estimate = conversationCostEstimateByModel(aggregate, prices);
+    const cost = estimate.value;
+    const average = estimate.complete && cost != null && matchedConversations > 0 ? cost / matchedConversations : null;
+    // Exclude unpriced model usage instead of counting it as free. An empty
+    // range has no usage to exclude.
+    const averageSub = average != null ? `${formatCost(average)} avg / session` : null;
+    let costSub = averageSub ?? 'estimated';
+    if (tokens > 0 && !estimate.complete) {
+      costSub = averageSub ? `unpriced usage excluded · ${averageSub}` : 'unpriced usage excluded';
+    }
     return {
-      conversations: filtered.length,
+      conversations: matchedConversations,
       conversationsSub: activeWorkspace != null ? 'in workspace' : 'active in range',
       tokens,
-      cost: priced ? cost : null, // nothing priced, so NO_VALUE rather than a misleading $0
+      cost,
       costSub,
-      models: models.size,
+      models: aggregate.models.length,
       cachePct: cacheInputHitPercent(tot.fresh_input, tot.cache_read, tot.cache_write),
-      calls,
-      avgCalls: filtered.length ? calls / filtered.length : 0,
-      errConvs,
-      errPct: filtered.length ? Math.round((errConvs / filtered.length) * 100) : 0,
+      calls: aggregate.calls,
+      avgCalls: matchedConversations ? aggregate.calls / matchedConversations : 0,
+      errConvs: aggregate.errored,
+      errPct: matchedConversations ? Math.round((aggregate.errored / matchedConversations) * 100) : 0,
     };
-  }, [filtered, activeWorkspace, prices]);
+  }, [aggregate, matchedConversations, activeWorkspace, prices]);
+  // The list request returns at most one page of rows, newest first, while the
+  // totals cover every match. More matches than rows means the table below is
+  // a sample of what the tiles count.
+  const sampledRows = !error && matchedConversations != null && matchedConversations > conversations.length;
 
   return (
     <PageShell maxWidth={1400}>
@@ -2873,11 +2907,11 @@ export function ConversationsView({
                 { label: 'Range', value: rangeLabel },
                 {
                   label: 'Workspaces',
-                  value: String(workspaces.length),
+                  value: aggregate ? String(aggregate.workspaces) : NO_VALUE,
                 },
                 {
                   label: 'Agents',
-                  value: String(agentCount),
+                  value: aggregate ? String(aggregate.agents) : NO_VALUE,
                 },
               ]
         }
@@ -2892,16 +2926,16 @@ export function ConversationsView({
         workspaces={searchActive ? [] : workspaces}
         workspace={searchActive ? undefined : activeWorkspace}
         onWorkspaceChange={searchActive ? undefined : setWorkspace}
-        workspaceSessionCount={rangeFiltered.length}
+        workspaceSessionCount={workspaceFacetConversations.length}
         workspaceTotalCost={totalCost}
         now={now}
         rangeLabel={rangeLabel}
         groupBy={searchActive ? undefined : groupBy}
         onGroupByChange={searchActive ? undefined : setGroupBy}
-        agentFilter={searchActive ? undefined : activeAgentFilter}
+        agentFilter={searchActive ? undefined : agentFilter}
         onAgentFilterChange={searchActive ? undefined : setAgentFilter}
         agentOptions={searchActive ? [] : agentOptions}
-        modelFilter={searchActive ? undefined : activeModelFilter}
+        modelFilter={searchActive ? undefined : modelFilter}
         onModelFilterChange={searchActive ? undefined : setModelFilter}
         modelOptions={searchActive ? [] : modelFacetOptions}
         statusFilter={searchActive ? undefined : activeStatusFilter}
@@ -2958,7 +2992,23 @@ export function ConversationsView({
         />
       ) : (
         <Fragment>
-          <KpiStrip kpi={kpi} />
+          {metricsError ? (
+            <div style={{ marginBottom: 16 }}>
+              <Notice kind="error" title="Failed to load session totals">
+                {metricsError}
+              </Notice>
+            </div>
+          ) : (
+            (kpi || metricsLoading) && <KpiStrip kpi={kpi} />
+          )}
+          {sampledRows && (
+            <div style={{ marginBottom: 16 }}>
+              <Notice kind="info" title="Session row and total counts differ">
+                Rows returned: {workspaceRows.length}. Sessions covered by totals: {matchedConversations}. Totals
+                include usage only from the selected range. Each row shows lifetime cost, tokens, and duration.
+              </Notice>
+            </div>
+          )}
           {effectiveChartMetric === 'activity' ? (
             <ActivityChart
               data={activity.buckets}
@@ -3121,6 +3171,7 @@ export function ConversationsView({
               !loading &&
               !toolFilter &&
               activeWorkspace == null &&
+              !facetActive &&
               rangeFiltered.length === 0 &&
               ((storeCount ?? 0) > 0 || conversations.length > 0) && (
                 <div
@@ -3133,7 +3184,7 @@ export function ConversationsView({
                   No sessions in <code style={{ color: 'var(--fg1)' }}>{range.label}</code>.
                 </div>
               )}
-            {!error && !loading && !toolFilter && selectedWorkspaceRangeAggregate?.count === 0 && (
+            {!error && !loading && !toolFilter && !facetActive && selectedWorkspaceRangeAggregate?.count === 0 && (
               <div
                 style={{
                   padding: '16px 18px',
@@ -3156,9 +3207,10 @@ export function ConversationsView({
               </div>
             )}
             {!error &&
-              filtered.length === 0 &&
-              rangeFiltered.length > 0 &&
-              (activeWorkspace == null || (selectedWorkspaceRangeAggregate?.count ?? 0) > 0) && (
+              !toolFilter &&
+              workspaceRows.length === 0 &&
+              (rangeFiltered.length > 0 || facetActive) &&
+              (activeWorkspace == null || facetActive || (selectedWorkspaceRangeAggregate?.count ?? 0) > 0) && (
                 <div
                   style={{
                     padding: '16px 18px',
@@ -3169,7 +3221,7 @@ export function ConversationsView({
                   No sessions match the current filters.
                 </div>
               )}
-            {!error && bucketSel && listFiltered.length === 0 && filtered.length > 0 && (
+            {!error && bucketSel && listFiltered.length === 0 && workspaceRows.length > 0 && (
               <div
                 style={{
                   padding: '16px 18px',
@@ -3229,7 +3281,7 @@ export function ConversationsView({
                 fontFamily: 'var(--fontFamilyMonospace)',
               }}
             >
-              {sorted.length} of {filtered.length} {filtered.length === 1 ? 'session' : 'sessions'}
+              {sorted.length} of {workspaceRows.length} {workspaceRows.length === 1 ? 'session' : 'sessions'}
               {collapsed.groups > 0 && (
                 <Fragment>
                   {' · '}

--- a/plugins/agento11y/internal/local/web/src/formatters.ts
+++ b/plugins/agento11y/internal/local/web/src/formatters.ts
@@ -387,14 +387,17 @@ interface CostableConversation {
   models?: string[] | null;
 }
 
-// conversationCost prices a conversation's disjoint token buckets at its
-// primary model's rates. Prefers the live models.dev catalog (exact model
-// id, all providers); falls back to the bundled Anthropic table for
-// brand-new Claude ids or when offline. Exact for the single-model common
-// case; a mixed-model conversation is priced at models[0] (the
-// orchestrator), a close approximation. Returns null when the model can't
-// be priced (unknown provider, or no model recorded) so callers show NO_VALUE
-// instead of a fabricated number.
+// conversationCost prices all token buckets at models[0]'s rate. The server
+// sorts model IDs alphabetically, so mixed-model rows select by ID rather than
+// orchestration role or usage. It checks the multi-provider models.dev map by
+// exact or supported canonicalized ID, then the bundled Anthropic-family
+// substring table when the catalog is unavailable or has no match. It returns
+// null when no model is recorded or neither source has a rate. Callers show
+// NO_VALUE instead of guessing.
+//
+// Use conversationCostByModel for token_buckets_by_model. It prices each
+// nonzero model bucket separately and falls back to conversationCost when the
+// per-model map is absent.
 export function conversationCost(
   c: CostableConversation | null | undefined,
   prices: ModelPrices | null,

--- a/plugins/agento11y/internal/local/web/src/types.ts
+++ b/plugins/agento11y/internal/local/web/src/types.ts
@@ -51,6 +51,7 @@ export interface ConversationMetricsAggregate {
   calls: number;
   errored: number;
   agents: number;
+  agent_hosts: string[];
   workspaces: number;
   token_buckets: TokenBuckets;
   token_buckets_by_model: Record<string, TokenBuckets>;

--- a/plugins/agento11y/tests/analytics.test.tsx
+++ b/plugins/agento11y/tests/analytics.test.tsx
@@ -267,6 +267,7 @@ describe('AnalyticsView', () => {
       calls: 12,
       errored: 1,
       agents: 2,
+      agent_hosts: ['claude-code', 'pi'],
       workspaces: 3,
       token_buckets: { ...EMPTY, fresh_input: 200_000, cache_read: 100_000 },
       token_buckets_by_model: {
@@ -279,6 +280,7 @@ describe('AnalyticsView', () => {
       calls: 6,
       errored: 0,
       agents: 1,
+      agent_hosts: ['pi'],
       workspaces: 1,
       token_buckets: { ...EMPTY, fresh_input: 50_000, cache_read: 50_000 },
       token_buckets_by_model: { 'costly-model': { ...EMPTY, fresh_input: 50_000, cache_read: 50_000 } },

--- a/plugins/agento11y/tests/fixtures.ts
+++ b/plugins/agento11y/tests/fixtures.ts
@@ -1,0 +1,47 @@
+import type {
+  ConversationMetricsAggregate,
+  ConversationMetricsResponse,
+  TokenBuckets,
+} from '../internal/local/web/src/types';
+
+export function response(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(''),
+  } as Response;
+}
+
+export const EMPTY_BUCKETS: TokenBuckets = {
+  fresh_input: 0,
+  cache_read: 0,
+  cache_write: 0,
+  output: 0,
+  reasoning: 0,
+};
+
+export function aggregate(overrides: Partial<ConversationMetricsAggregate> = {}): ConversationMetricsAggregate {
+  return {
+    calls: 0,
+    errored: 0,
+    agents: 0,
+    agent_hosts: [],
+    workspaces: 0,
+    token_buckets: { ...EMPTY_BUCKETS },
+    token_buckets_by_model: {},
+    models: [],
+    ...overrides,
+  };
+}
+
+// Sessions hides KPI tiles after loading if a metrics mock omits aggregate or
+// matched_conversations.
+export function metricsResponse(overrides: Partial<ConversationMetricsResponse> = {}): ConversationMetricsResponse {
+  return {
+    aggregate: aggregate(overrides.aggregate),
+    conversations: [],
+    matched_conversations: 0,
+    ...overrides,
+  };
+}

--- a/plugins/agento11y/tests/prices.test.ts
+++ b/plugins/agento11y/tests/prices.test.ts
@@ -77,6 +77,24 @@ describe('per-model conversation cost', () => {
     ).toBe(8);
   });
 
+  it('differs from whole-conversation pricing when the cheaper model sorts first', () => {
+    const mixedPrices: ModelPrices = {
+      'a-cheap': { input: 1, output: 1 },
+      'z-pricey': { input: 100, output: 100 },
+    };
+    const empty: TokenBuckets = { fresh_input: 0, cache_read: 0, cache_write: 0, output: 0, reasoning: 0 };
+    const conversation = {
+      models: ['a-cheap', 'z-pricey'],
+      token_buckets: { ...empty, fresh_input: 2e6 },
+      token_buckets_by_model: {
+        'a-cheap': { ...empty, fresh_input: 1e6 },
+        'z-pricey': { ...empty, fresh_input: 1e6 },
+      },
+    };
+    expect(conversationCost(conversation, mixedPrices)).toBe(2);
+    expect(conversationCostByModel(conversation, mixedPrices)).toBe(101);
+  });
+
   it('falls back to the conversation model for an older daemon', () => {
     const conversation = { models: ['grok-4.6'], token_buckets: buckets };
     expect(conversationCostByModel(conversation, prices)).toBe(conversationCost(conversation, prices));

--- a/plugins/agento11y/tests/sessions-kpi.test.tsx
+++ b/plugins/agento11y/tests/sessions-kpi.test.tsx
@@ -1,0 +1,369 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { App } from '../internal/local/web/src/app';
+import { ESTIMATED_COST_TOOLTIP } from '../internal/local/web/src/formatters';
+import type { ConversationSummary, ModelPrices, TokenBuckets } from '../internal/local/web/src/types';
+import { aggregate, EMPTY_BUCKETS, metricsResponse, response } from './fixtures';
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  window.history.replaceState({}, '', '/');
+});
+
+const PRICES: ModelPrices = {
+  'costly-model': { input: 10, output: 20, cache_read: 1, cache_write: 12.5 },
+  'a-cheap': { input: 1, output: 1 },
+  'z-pricey': { input: 100, output: 100 },
+};
+
+// The price catalog is fetched once per module, so the tests seed its cache
+// instead of racing the models.dev request.
+function stubLocalStorage(entries: [string, string][] = []) {
+  const stored = new Map<string, string>([
+    ['sigil.modelPrices.v1', JSON.stringify({ at: Date.now(), map: PRICES })],
+    ...entries,
+  ]);
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => stored.get(key) ?? null,
+    setItem: (key: string, value: string) => stored.set(key, value),
+    removeItem: (key: string) => stored.delete(key),
+  });
+  return stored;
+}
+
+function conversation(overrides: Partial<ConversationSummary> = {}): ConversationSummary {
+  const buckets: TokenBuckets = overrides.token_buckets || { ...EMPTY_BUCKETS, fresh_input: 100_000 };
+  return {
+    id: 'session-1',
+    title: 'One returned row',
+    started_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    last_activity: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    calls: 4,
+    input_tokens: buckets.fresh_input,
+    output_tokens: buckets.output,
+    total_tokens: Object.values(buckets).reduce((sum, value) => sum + value, 0),
+    token_buckets: buckets,
+    token_buckets_by_model: { 'costly-model': buckets },
+    agents: ['pi'],
+    models: ['costly-model'],
+    status: 'ok',
+    workspace: '/repo',
+    ...overrides,
+  };
+}
+
+function kpiCard(label: string): HTMLElement {
+  const card = screen
+    .getAllByText(label)
+    .map((node) => node.parentElement)
+    .find((parent) => parent?.textContent?.startsWith(label) && parent.querySelector('span span'));
+  if (!card) throw new Error(`missing ${label} KPI tile`);
+  return card as HTMLElement;
+}
+
+function lastRequest(fetchMock: ReturnType<typeof vi.fn>, pathname: string): URL | undefined {
+  return fetchMock.mock.calls
+    .map((call) => new URL(String(call[0]), 'http://localhost'))
+    .filter((url) => url.pathname === pathname)
+    .at(-1);
+}
+
+describe('Sessions headline numbers', () => {
+  it('uses the aggregate and the matched count, not the returned page', async () => {
+    stubLocalStorage();
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/api/v1/metrics/conversations?')) {
+        return Promise.resolve(
+          response(
+            metricsResponse({
+              matched_conversations: 3441,
+              aggregate: aggregate({
+                calls: 6882,
+                errored: 344,
+                agents: 4,
+                agent_hosts: ['claude-code', 'pi'],
+                workspaces: 37,
+                token_buckets: { ...EMPTY_BUCKETS, fresh_input: 200_000, cache_read: 100_000 },
+                token_buckets_by_model: {
+                  'costly-model': { ...EMPTY_BUCKETS, fresh_input: 200_000 },
+                  'other-model': { ...EMPTY_BUCKETS, cache_read: 100_000 },
+                },
+                models: ['costly-model', 'other-model'],
+              }),
+            }),
+          ),
+        );
+      }
+      if (url.startsWith('/api/v1/conversations?')) {
+        return Promise.resolve(response({ conversations: [conversation()], total_conversations: 9000 }));
+      }
+      if (url.startsWith('/api/v1/metrics/tokens')) {
+        return Promise.resolve(response({ points: [], interval_seconds: 3600 }));
+      }
+      return Promise.resolve(response({}));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+
+    await waitFor(() => expect(kpiCard('Sessions').textContent).toContain('3441'));
+    expect(kpiCard('Total tokens').textContent).toContain('300k');
+    expect(kpiCard('Total tokens').textContent).toContain('2 models');
+    expect(kpiCard('Model calls').textContent).toContain('6882');
+    expect(kpiCard('Model calls').textContent).toContain('2 avg / session');
+    expect(kpiCard('Errored sessions').textContent).toContain('344');
+    // 200k fresh input at $10/Mtok.
+    expect(kpiCard('Cost').textContent).toContain('$2');
+    expect(kpiCard('Cost').textContent).toContain('unpriced usage excluded');
+    expect(kpiCard('Cost').textContent).not.toContain('avg / session');
+    expect(kpiCard('Input cache hit').textContent).toContain('33%');
+
+    fireEvent.click(screen.getByTitle('Filter by agent'));
+    expect(screen.getByRole('option', { name: 'claude-code' })).toBeTruthy();
+    fireEvent.click(screen.getByTitle('Filter by agent'));
+    fireEvent.click(screen.getByTitle('Filter by model'));
+    expect(screen.getByRole('option', { name: 'other-model' })).toBeTruthy();
+
+    const hero = screen.getByRole('heading', { name: 'Sessions' }).parentElement?.parentElement;
+    expect(hero?.textContent).toContain('Workspaces37');
+    expect(hero?.textContent).toContain('Agents4');
+
+    const sampling = screen.getByText('Session row and total counts differ').parentElement;
+    expect(sampling?.textContent).toContain('Rows returned: 1.');
+    expect(sampling?.textContent).toContain('Sessions covered by totals: 3441.');
+    expect(sampling?.textContent).toContain('lifetime cost, tokens, and duration');
+  });
+
+  it('renders no sampling notice when the page holds every match', async () => {
+    stubLocalStorage();
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/api/v1/metrics/conversations?')) {
+        return Promise.resolve(response(metricsResponse({ matched_conversations: 1 })));
+      }
+      if (url.startsWith('/api/v1/conversations?')) {
+        return Promise.resolve(response({ conversations: [conversation()], total_conversations: 1 }));
+      }
+      if (url.startsWith('/api/v1/metrics/tokens')) {
+        return Promise.resolve(response({ points: [], interval_seconds: 3600 }));
+      }
+      return Promise.resolve(response({}));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+
+    await waitFor(() => expect(kpiCard('Sessions').textContent).toContain('1'));
+    expect(screen.queryByText('Session row and total counts differ')).toBeNull();
+    // With zero usage and no model to price, the cost sublabel remains
+    // "estimated" instead of reporting excluded usage.
+    expect(kpiCard('Cost').textContent).toContain('estimated');
+  });
+
+  it('keeps an exact-scoped row at the rolling range boundary', async () => {
+    stubLocalStorage();
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/api/v1/metrics/conversations?')) {
+        return Promise.resolve(response(metricsResponse({ matched_conversations: 1 })));
+      }
+      if (url.startsWith('/api/v1/conversations?')) {
+        const since = new URL(url, 'http://localhost').searchParams.get('since');
+        if (!since) throw new Error('missing exact lower bound');
+        const edge = conversation({ id: 'session-edge', title: 'Boundary session', last_activity: since });
+        // Delay the response so a newly computed rolling lower bound would
+        // move past the fixed since value sent with the request.
+        return new Promise<Response>((resolve) =>
+          setTimeout(() => resolve(response({ conversations: [edge], total_conversations: 1 })), 5),
+        );
+      }
+      if (url.startsWith('/api/v1/metrics/tokens')) {
+        return Promise.resolve(response({ points: [], interval_seconds: 3600 }));
+      }
+      return Promise.resolve(response({}));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+
+    await waitFor(() => expect(document.querySelector('a[href="/conversations/session-edge"]')).toBeTruthy());
+    expect(screen.queryByText(/No sessions in/)).toBeNull();
+  });
+
+  it('scopes workspace deep links without dropping sibling options', async () => {
+    window.history.replaceState({}, '', '/?workspace=%2Frepo');
+    stubLocalStorage();
+    const sibling = conversation({ id: 'session-2', title: 'Sibling workspace', workspace: '/other' });
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/api/v1/metrics/conversations?')) {
+        const scoped = new URL(url, 'http://localhost').searchParams.get('workspace') === '/repo';
+        return Promise.resolve(response(metricsResponse({ matched_conversations: scoped ? 12 : 3441 })));
+      }
+      if (url.startsWith('/api/v1/conversations?')) {
+        const scoped = new URL(url, 'http://localhost').searchParams.get('workspace') === '/repo';
+        return Promise.resolve(
+          response({ conversations: scoped ? [conversation()] : [conversation(), sibling], total_conversations: 9000 }),
+        );
+      }
+      if (url.startsWith('/api/v1/metrics/tokens')) {
+        return Promise.resolve(response({ points: [], interval_seconds: 3600 }));
+      }
+      return Promise.resolve(response({}));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+    await waitFor(() => expect(kpiCard('Sessions').textContent).toContain('12'));
+    expect(lastRequest(fetchMock, '/api/v1/conversations')?.searchParams.get('workspace')).toBe('/repo');
+    expect(lastRequest(fetchMock, '/api/v1/metrics/conversations')?.searchParams.get('workspace')).toBe('/repo');
+    expect(lastRequest(fetchMock, '/api/v1/metrics/tokens')?.searchParams.get('workspace')).toBe('/repo');
+
+    fireEvent.click(screen.getByTitle('Filter by workspace'));
+    expect(screen.getByRole('option', { name: /other/ })).toBeTruthy();
+  });
+
+  it('renders no tiles and no substitute numbers when the metrics request fails', async () => {
+    stubLocalStorage();
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/api/v1/metrics/conversations?')) {
+        return Promise.resolve({
+          ok: false,
+          status: 404,
+          json: () => Promise.resolve({}),
+          text: () => Promise.resolve('no such endpoint'),
+        } as Response);
+      }
+      if (url.startsWith('/api/v1/conversations?')) {
+        return Promise.resolve(response({ conversations: [conversation()], total_conversations: 1 }));
+      }
+      if (url.startsWith('/api/v1/metrics/tokens')) {
+        return Promise.resolve(response({ points: [], interval_seconds: 3600 }));
+      }
+      return Promise.resolve(response({}));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+
+    await screen.findByText('Failed to load session totals');
+    expect(screen.getByText('no such endpoint')).toBeTruthy();
+    expect(screen.queryByText('Total tokens')).toBeNull();
+    expect(screen.queryByText('Input cache hit')).toBeNull();
+  });
+
+  it('shows the filter empty state when workspace and status facets match nothing', async () => {
+    window.history.replaceState({}, '', '/?workspace=%2Frepo');
+    stubLocalStorage();
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/api/v1/metrics/conversations?')) {
+        const matched = new URL(url, 'http://localhost').searchParams.has('subagents') ? 92 : 3441;
+        return Promise.resolve(
+          response(metricsResponse({ matched_conversations: matched, aggregate: aggregate({ calls: matched }) })),
+        );
+      }
+      if (url.startsWith('/api/v1/conversations?')) {
+        const facetted = new URL(url, 'http://localhost').searchParams.has('subagents');
+        return Promise.resolve(
+          response({ conversations: facetted ? [] : [conversation()], total_conversations: 9000 }),
+        );
+      }
+      if (url.startsWith('/api/v1/metrics/tokens')) {
+        return Promise.resolve(response({ points: [], interval_seconds: 3600 }));
+      }
+      return Promise.resolve(response({}));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+    await waitFor(() => expect(kpiCard('Sessions').textContent).toContain('3441'));
+
+    fireEvent.click(screen.getByTitle('Filter by status'));
+    fireEvent.click(screen.getByRole('option', { name: 'Has subagents' }));
+
+    await waitFor(() => expect(kpiCard('Sessions').textContent).toContain('92'));
+    expect(lastRequest(fetchMock, '/api/v1/conversations')?.searchParams.get('workspace')).toBe('/repo');
+    expect(lastRequest(fetchMock, '/api/v1/conversations')?.searchParams.get('subagents')).toBe('1');
+    expect(lastRequest(fetchMock, '/api/v1/metrics/conversations')?.searchParams.get('workspace')).toBe('/repo');
+    expect(lastRequest(fetchMock, '/api/v1/metrics/conversations')?.searchParams.get('subagents')).toBe('1');
+    expect(screen.getByText('No sessions match the current filters.')).toBeTruthy();
+    expect(screen.queryByText('No sessions in this range.')).toBeNull();
+  });
+});
+
+describe('Sessions per-model cost', () => {
+  it('prices a mixed-model session per model in the row and in the workspace totals', async () => {
+    stubLocalStorage();
+    const empty = { ...EMPTY_BUCKETS };
+    const mixed = conversation({
+      id: 'mixed',
+      models: ['a-cheap', 'z-pricey'],
+      token_buckets: { ...empty, fresh_input: 2e6 },
+      token_buckets_by_model: {
+        'a-cheap': { ...empty, fresh_input: 1e6 },
+        'z-pricey': { ...empty, fresh_input: 1e6 },
+      },
+    });
+    const single = conversation({
+      id: 'single',
+      workspace: '/other',
+      models: ['costly-model'],
+      token_buckets: { ...empty, fresh_input: 5e6 },
+      token_buckets_by_model: { 'costly-model': { ...empty, fresh_input: 5e6 } },
+    });
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/api/v1/metrics/conversations?')) {
+        return Promise.resolve(response(metricsResponse({ matched_conversations: 2 })));
+      }
+      if (url.startsWith('/api/v1/conversations?')) {
+        return Promise.resolve(response({ conversations: [mixed, single], total_conversations: 2 }));
+      }
+      if (url.startsWith('/api/v1/metrics/tokens')) {
+        return Promise.resolve(response({ points: [], interval_seconds: 3600 }));
+      }
+      return Promise.resolve(response({}));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+
+    // $101, not the $2 that pricing 2M tokens at the alphabetically first
+    // model would give.
+    const costCells = await waitFor(() => {
+      const cells = screen.getAllByTitle(ESTIMATED_COST_TOOLTIP);
+      expect(cells.length).toBeGreaterThan(0);
+      return cells;
+    });
+    expect(costCells.map((cell) => cell.textContent)).toContain('$101');
+
+    // The cost sort key reads the same per-model figure, so the mixed-model
+    // session outranks a $50 one it would lose to at models[0] rates.
+    fireEvent.click(screen.getByTitle('Sort by cost'));
+    await waitFor(() =>
+      expect(
+        [...document.querySelectorAll('a[href^="/conversations/"]')].map((row) => row.getAttribute('href')),
+      ).toEqual(['/conversations/mixed', '/conversations/single']),
+    );
+
+    fireEvent.click(screen.getByTitle('Group sessions'));
+    fireEvent.click(screen.getByRole('option', { name: 'Workspace' }));
+    const groupHeader = await waitFor(() => {
+      const header = screen
+        .getAllByTitle('/repo')
+        .map((node) => node.closest('button[aria-expanded]'))
+        .find((node) => node != null);
+      expect(header).toBeTruthy();
+      return header as HTMLElement;
+    });
+    expect(groupHeader.textContent).toContain('$101');
+
+    fireEvent.click(screen.getByTitle('Filter by workspace'));
+    expect(screen.getByRole('option', { name: /All workspaces/ }).textContent).toContain('$151');
+    expect(screen.getByRole('option', { name: /repo/ }).textContent).toContain('$101');
+  });
+});

--- a/plugins/agento11y/tests/skills-tools.test.tsx
+++ b/plugins/agento11y/tests/skills-tools.test.tsx
@@ -9,6 +9,7 @@ import {
 } from '../internal/local/web/src/routing';
 import { SkillsToolsView, type SkillsToolsViewProps } from '../internal/local/web/src/skills-tools';
 import type { ToolAnalytics } from '../internal/local/web/src/types';
+import { metricsResponse, response } from './fixtures';
 
 const DATA: ToolAnalytics = {
   totals: { calls: 31, failures: 2, tools: 3, sessions: 4, duration_samples: 21 },
@@ -62,15 +63,6 @@ function props(overrides: Partial<SkillsToolsViewProps> = {}): SkillsToolsViewPr
     onOpenSessions: vi.fn(),
     ...overrides,
   };
-}
-
-function response(body: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    json: () => Promise.resolve(body),
-    text: () => Promise.resolve(''),
-  } as Response;
 }
 
 function stubLocalStorage(entries: [string, string][] = []) {
@@ -288,6 +280,9 @@ describe('Tools analytics routing and App fetching', () => {
       if (url.startsWith('/api/v1/conversations?')) {
         return Promise.resolve(response({ conversations: [], total_conversations: 0 }));
       }
+      if (url.startsWith('/api/v1/metrics/conversations?')) {
+        return Promise.resolve(response(metricsResponse()));
+      }
       if (url.startsWith('/api/v1/metrics/tokens')) {
         return Promise.resolve(response({ points: [], interval_seconds: 60 }));
       }
@@ -373,6 +368,9 @@ describe('Tools analytics routing and App fetching', () => {
       if (url.startsWith('/api/v1/conversations?')) {
         return Promise.resolve(response({ conversations: [], total_conversations: 0 }));
       }
+      if (url.startsWith('/api/v1/metrics/conversations?')) {
+        return Promise.resolve(response(metricsResponse()));
+      }
       if (url.startsWith('/api/v1/metrics/tokens')) {
         return Promise.resolve(response({ points: [], interval_seconds: 60 }));
       }
@@ -432,14 +430,16 @@ describe('Tools analytics routing and App fetching', () => {
     expect(tokenRequest?.searchParams.has('workspace')).toBe(false);
   });
 
-  it('navigates a plain row click to exact Sessions and preserves modified clicks', async () => {
-    window.history.replaceState({}, '', analyticsPath('skills'));
+  it('navigates a plain row click to exact Sessions without old facets and preserves modified clicks', async () => {
     const stored = stubLocalStorage();
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.startsWith('/api/v1/metrics/skills-tools?')) return Promise.resolve(response({ tools: DATA }));
       if (url.startsWith('/api/v1/conversations?')) {
         return Promise.resolve(response({ conversations: [], total_conversations: 1 }));
+      }
+      if (url.startsWith('/api/v1/metrics/conversations?')) {
+        return Promise.resolve(response(metricsResponse()));
       }
       if (url.startsWith('/api/v1/metrics/tokens')) {
         return Promise.resolve(response({ points: [], interval_seconds: 60 }));
@@ -449,6 +449,20 @@ describe('Tools analytics routing and App fetching', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     render(<App />);
+    await screen.findByRole('heading', { name: 'Sessions' });
+    fireEvent.click(screen.getByTitle('Filter by status'));
+    fireEvent.click(screen.getByRole('option', { name: 'Has subagents' }));
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(([url]) => {
+          const parsed = new URL(String(url), 'http://localhost');
+          return parsed.pathname === '/api/v1/conversations' && parsed.searchParams.get('subagents') === '1';
+        }),
+      ).toBe(true),
+    );
+    fireEvent.click(screen.getByRole('link', { name: 'Analytics' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'Tools' }));
+
     const link = await screen.findByRole('link', { name: 'Bash' });
     const drilldown = new URL(link.getAttribute('href') || '', 'http://localhost');
     const expectedSince = drilldown.searchParams.get('since');
@@ -463,14 +477,23 @@ describe('Tools analytics routing and App fetching', () => {
     expect(window.location.pathname).toBe('/');
     expect(new URLSearchParams(window.location.search).get('tool')).toBe('Bash');
     expect(stored.get('sigil.local.timeRange')).toBe('24h');
-    await waitFor(() =>
-      expect(
-        fetchMock.mock.calls.some(([url]) => {
-          const parsed = new URL(String(url), 'http://localhost');
-          return parsed.pathname === '/api/v1/conversations' && parsed.searchParams.get('tool') === 'Bash';
-        }),
-      ).toBe(true),
-    );
+    await waitFor(() => {
+      const exactPaths = fetchMock.mock.calls
+        .map(([url]) => new URL(String(url), 'http://localhost'))
+        .filter((url) => url.searchParams.get('tool') === 'Bash')
+        .map((url) => url.pathname);
+      expect(exactPaths).toContain('/api/v1/conversations');
+      expect(exactPaths).toContain('/api/v1/metrics/conversations');
+    });
+    const exactRequests = fetchMock.mock.calls
+      .map(([url]) => new URL(String(url), 'http://localhost'))
+      .filter((url) => url.searchParams.get('tool') === 'Bash');
+    for (const request of exactRequests) {
+      expect(request.searchParams.has('agent')).toBe(false);
+      expect(request.searchParams.has('model')).toBe(false);
+      expect(request.searchParams.has('status')).toBe(false);
+      expect(request.searchParams.has('subagents')).toBe(false);
+    }
     expect(screen.getByText(/Tool/).parentElement?.textContent).toContain('Bash');
     expect(document.body.textContent).toContain(`${expectedSince} to ${expectedBefore}`);
     expect(screen.getByText('Tokens in exact range')).toBeTruthy();

--- a/plugins/agento11y/tests/theme-shortcut.test.tsx
+++ b/plugins/agento11y/tests/theme-shortcut.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { App } from '../internal/local/web/src/app';
 import type { ConfigResponse, Settings, ThemePreference } from '../internal/local/web/src/types';
+import { metricsResponse } from './fixtures';
 
 function settings(theme: ThemePreference): Settings {
   return {
@@ -65,6 +66,9 @@ function installFetch(patches: Promise<Response>[] = []) {
     if (url === '/api/v1/config') return Promise.resolve(jsonResponse(config('dark')));
     if (url.startsWith('/api/v1/conversations?')) {
       return Promise.resolve(jsonResponse({ conversations: [], total_conversations: 0 }));
+    }
+    if (url.startsWith('/api/v1/metrics/conversations?')) {
+      return Promise.resolve(jsonResponse(metricsResponse()));
     }
     if (url.startsWith('/api/v1/metrics/tokens')) {
       return Promise.resolve(jsonResponse({ interval_seconds: 10, points: [] }));


### PR DESCRIPTION
The "Sessions" page currently calculates totals tow from the first 200 rows returned by the list endpoint. So the totals can be miscalculated if the number of sessions is > 200.

This PR makes it read the counts from the `/api/v1/metrics/conversations` endpoint instead, with applied filters, and the backend returns proper numbers.