### PR TITLE
fix(plugins/opencode): stop opencode hanging at startup in local mode

### DIFF
--- a/plugins/opencode/src/index.test.ts
+++ b/plugins/opencode/src/index.test.ts
@@ -160,6 +160,43 @@ describe("Agento11yPlugin", () => {
     warn.mockRestore();
   });
 
+  // opencode answers `client.tui.showToast` from the same process, and its
+  // handler needs the instance whose bootstrap is waiting on this plugin's
+  // init, so a toast awaited here never settles and hangs opencode at startup.
+  // Each case below fails by timeout if its toast is awaited again.
+  it.each([
+    {
+      name: "local receiver notice",
+      arrange: () => {
+        const { sigil } = makeAgento11yMock();
+        createAgento11yClientMock.mockReturnValue(sigil);
+        loadConfigMock.mockResolvedValue(
+          baseConfig({ endpoint: "http://127.0.0.1:8768", local: true }),
+        );
+      },
+    },
+    {
+      name: "capture-off warning",
+      arrange: () => {
+        loadConfigMock.mockRejectedValue(
+          new LocalReceiverError("no local receiver is running"),
+        );
+      },
+    },
+  ])("returns without waiting for the $name toast", async ({ arrange }) => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    arrange();
+
+    const input = pluginInput();
+    input.client.tui.showToast = vi.fn(() => new Promise(() => {}));
+
+    const hooks = (await Agento11yPlugin(input)) as PluginHooks;
+
+    expect(input.client.tui.showToast).toHaveBeenCalledTimes(1);
+    await hooks.dispose?.();
+    warn.mockRestore();
+  });
+
   it("loads even when the failure toast cannot be shown", async () => {
     // opencode loads plugins before the TUI is necessarily attached, and a
     // rejected toast must not turn a disabled capture into a broken host.

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -16,6 +16,11 @@ type HooksWithDispose = Hooks & { dispose: () => Promise<void> };
 
 // Best effort: opencode's TUI may not be attached yet while plugins load, and
 // a failed toast must not take the plugin down with it.
+//
+// Never await this from plugin initialization. opencode serves the call
+// in-process, and the handler needs the instance whose bootstrap is waiting on
+// this plugin's own init, so an awaited toast deadlocks the host at startup
+// (opencode 1.18.20). Left floating, it settles as soon as bootstrap finishes.
 async function toast(
   client: PluginInput["client"],
   message: string,
@@ -41,7 +46,7 @@ export const Agento11yPlugin: Plugin = async ({ client, directory }) => {
     // must not be sent to Cloud because the receiver is down. opencode keeps
     // running with no hooks registered.
     console.warn(`[sigil-opencode] local capture is off: ${err.message}`);
-    await toast(client, `Local capture is off: ${err.message}`, "error");
+    void toast(client, `Local capture is off: ${err.message}`, "error");
     return {};
   }
   if (!config) return {};
@@ -54,7 +59,7 @@ export const Agento11yPlugin: Plugin = async ({ client, directory }) => {
   if (config.local) {
     // Where the session went is not obvious once the endpoint stops being the
     // configured one, so name the receiver the transcript lands in.
-    await toast(
+    void toast(
       client,
       `Recording to the local receiver at ${config.endpoint}`,
       "info",


### PR DESCRIPTION
In local mode `agento11y opencode` hanged forever in a deadlock.

OpenCode waits for each plugin's init function to return before it finishes starting. A plugin that calls the opencode API from init waits for an answer that only comes after startup ends, so the two wait for each other and opencode never comes up. 

The call is no longer awaited to allow the plugin start.