### PR TITLE
fix(plugins/agento11y): fix local viewer analytics tab numbers calculation

### DIFF
--- a/plugins/agento11y/internal/local/query.go
+++ b/plugins/agento11y/internal/local/query.go
@@ -58,6 +58,16 @@ type ConversationMetricsAggregate struct {
 	TokenBuckets        TokenBuckets            `json:"token_buckets"`
 	TokenBucketsByModel map[string]TokenBuckets `json:"token_buckets_by_model"`
 	Models              []string                `json:"models"`
+	WorkspaceRows       []WorkspaceAggregate    `json:"workspace_rows"`
+}
+
+type WorkspaceAggregate struct {
+	Path                string                  `json:"path"`
+	Sessions            int                     `json:"sessions"`
+	TokenBuckets        TokenBuckets            `json:"token_buckets"`
+	TokenBucketsByModel map[string]TokenBuckets `json:"token_buckets_by_model"`
+	DurationSeconds     float64                 `json:"duration_seconds"`
+	LastActivity        time.Time               `json:"last_activity"`
 }
 
 // GenerationView is one step in the conversation thread.
@@ -142,11 +152,14 @@ type ConversationListOptions struct {
 	// pointer to the empty string selects conversations whose lifetime cwd is
 	// unknown.
 	Workspace *string
-	// Tool keeps conversations with an observation whose name equals this value.
+	// Tool keeps conversations with a matching observation, ignoring capitalization.
 	// ConversationMetrics always applies it; ListConversations applies it only
 	// when Exact is true. A non-nil pointer to an empty string matches no valid
 	// tool.
 	Tool *string
+	// Order selects the metrics row order. "tokens" uses tokens in the
+	// requested time range, counted once. Empty keeps newest activity first.
+	Order string
 	// Exact applies the workspace, tool, and half-open generation-time filters
 	// before Limit. The plain list leaves this false to retain its bounded
 	// file-order fast path.
@@ -325,8 +338,9 @@ func (s *Storage) conversationToolMatches(tool string, since, before time.Time, 
 		return nil, err
 	}
 	matches := map[string]toolMatch{}
+	toolKey := toolNameKey(tool)
 	for _, observation := range observations {
-		if observation.HasSession && observation.Name == tool && inPeriod(observation.Timestamp, since, before) &&
+		if observation.HasSession && toolNameKey(observation.Name) == toolKey && toolKey != "" && inPeriod(observation.Timestamp, since, before) &&
 			workspaceMatches(observation.Workspace, workspace) {
 			match, seen := matches[observation.ConversationID]
 			if !seen || observation.Timestamp.Before(match.first) {
@@ -363,8 +377,9 @@ func toolCallOnlySummary(entry *fileSummary, match toolMatch) ConversationSummar
 
 // ConversationMetrics returns lifetime conversation metadata. Fields derived
 // from generations are clipped to [Since, Before). matched counts
-// matching conversations before Limit. Rows are ordered by clipped newest
-// activity, then id.
+// matching conversations before Limit. Rows use newest activity by default.
+// Order "tokens" uses tokens in the requested time range, counted once. IDs
+// break ties.
 //
 // The agent, model, status and subagent facets are tested against the clipped
 // summary, so a conversation whose only error or subagent step falls outside
@@ -421,7 +436,13 @@ func (s *Storage) ConversationMetrics(opts ConversationListOptions) ([]Conversat
 	}
 	s.summaries.prune(files)
 	sort.Slice(out, func(i, j int) bool {
-		if !out[i].LastActivity.Equal(out[j].LastActivity) {
+		if opts.Order == "tokens" {
+			iTokens := out[i].TokenBuckets.total()
+			jTokens := out[j].TokenBuckets.total()
+			if iTokens != jTokens {
+				return iTokens > jTokens
+			}
+		} else if !out[i].LastActivity.Equal(out[j].LastActivity) {
 			return out[i].LastActivity.After(out[j].LastActivity)
 		}
 		return out[i].ID < out[j].ID
@@ -439,10 +460,11 @@ func aggregateConversationMetrics(rows []ConversationSummary) ConversationMetric
 		AgentHosts:          []string{},
 		TokenBucketsByModel: map[string]TokenBuckets{},
 		Models:              []string{},
+		WorkspaceRows:       []WorkspaceAggregate{},
 	}
 	agents := map[string]struct{}{}
 	models := map[string]struct{}{}
-	workspaces := map[string]struct{}{}
+	workspaces := map[string]*WorkspaceAggregate{}
 	for _, row := range rows {
 		aggregate.Calls += row.Calls
 		if row.Status == "err" {
@@ -461,12 +483,39 @@ func aggregateConversationMetrics(rows []ConversationSummary) ConversationMetric
 		for _, model := range row.Models {
 			models[model] = struct{}{}
 		}
-		workspaces[row.Workspace] = struct{}{}
+		workspace := workspaces[row.Workspace]
+		if workspace == nil {
+			workspace = &WorkspaceAggregate{
+				Path:                row.Workspace,
+				TokenBucketsByModel: map[string]TokenBuckets{},
+			}
+			workspaces[row.Workspace] = workspace
+		}
+		workspace.Sessions++
+		workspace.TokenBuckets = workspace.TokenBuckets.plus(row.TokenBuckets)
+		for model, buckets := range row.TokenBucketsByModel {
+			workspace.TokenBucketsByModel[model] = workspace.TokenBucketsByModel[model].plus(buckets)
+		}
+		if !row.StartedAt.IsZero() && !row.LastActivity.IsZero() && !row.LastActivity.Before(row.StartedAt) {
+			workspace.DurationSeconds += row.LastActivity.Sub(row.StartedAt).Seconds()
+		}
+		if row.LastActivity.After(workspace.LastActivity) {
+			workspace.LastActivity = row.LastActivity
+		}
 	}
 	aggregate.AgentHosts = sortedKeys(agents)
 	aggregate.Agents = len(aggregate.AgentHosts)
 	aggregate.Models = sortedKeys(models)
 	aggregate.Workspaces = len(workspaces)
+	for _, workspace := range workspaces {
+		aggregate.WorkspaceRows = append(aggregate.WorkspaceRows, *workspace)
+	}
+	sort.Slice(aggregate.WorkspaceRows, func(i, j int) bool {
+		if !aggregate.WorkspaceRows[i].LastActivity.Equal(aggregate.WorkspaceRows[j].LastActivity) {
+			return aggregate.WorkspaceRows[i].LastActivity.After(aggregate.WorkspaceRows[j].LastActivity)
+		}
+		return aggregate.WorkspaceRows[i].Path < aggregate.WorkspaceRows[j].Path
+	})
 	return aggregate
 }
 
@@ -731,6 +780,10 @@ type TokenBuckets struct {
 	CacheWrite int64 `json:"cache_write"`
 	Output     int64 `json:"output"`
 	Reasoning  int64 `json:"reasoning"`
+}
+
+func (b TokenBuckets) total() int64 {
+	return b.FreshInput + b.CacheRead + b.CacheWrite + b.Output + b.Reasoning
 }
 
 func (b TokenBuckets) plus(o TokenBuckets) TokenBuckets {
@@ -1311,9 +1364,11 @@ func extractTools(msgs []agento11y.Message) (names []string, preview string) {
 			if p.Kind != agento11y.PartKindToolCall || p.ToolCall == nil {
 				continue
 			}
-			if _, ok := seen[p.ToolCall.Name]; !ok {
-				seen[p.ToolCall.Name] = struct{}{}
-				names = append(names, p.ToolCall.Name)
+			name := strings.TrimSpace(p.ToolCall.Name)
+			key := toolNameKey(name)
+			if _, ok := seen[key]; key != "" && !ok {
+				seen[key] = struct{}{}
+				names = append(names, name)
 			}
 			if preview == "" {
 				preview = renderToolPreview(p.ToolCall.InputJSON)

--- a/plugins/agento11y/internal/local/query_test.go
+++ b/plugins/agento11y/internal/local/query_test.go
@@ -239,13 +239,13 @@ func TestToolUsagePairsCallsAndResults(t *testing.T) {
 			want: []ToolUsage{{Name: "Bash", Calls: 2, Failures: 1}},
 		},
 		{
-			name: "reused Cursor id pairs only the new cumulative result",
+			name: "reused Cursor id ignores a mixed-case old cumulative result",
 			generations: []agento11y.Generation{
 				call("call-1", "Bash"),
 				result("call-1", "Bash", false),
 				call("call-1", "Bash"),
 				{Input: []agento11y.Message{{Parts: []agento11y.Part{
-					{ToolResult: &agento11y.ToolResult{ToolCallID: "call-1", Name: "Bash"}},
+					{ToolResult: &agento11y.ToolResult{ToolCallID: "call-1", Name: "bash"}},
 					{ToolResult: &agento11y.ToolResult{ToolCallID: "call-1", Name: "Bash", IsError: true}},
 				}}}},
 			},
@@ -261,6 +261,22 @@ func TestToolUsagePairsCallsAndResults(t *testing.T) {
 				},
 			}}}},
 			want: []ToolUsage{{Name: "Read", Calls: 1, Failures: 1}},
+		},
+		{
+			name: "anonymous mixed-case result pairs with its call",
+			generations: []agento11y.Generation{
+				call("", "Bash"),
+				result("", "bash", true),
+			},
+			want: []ToolUsage{{Name: "Bash", Calls: 1, Failures: 1}},
+		},
+		{
+			name: "case-folded usage uses the lexical spelling on a tie",
+			generations: []agento11y.Generation{
+				call("upper", "Bash"),
+				call("lower", "bash"),
+			},
+			want: []ToolUsage{{Name: "Bash", Calls: 2}},
 		},
 		{
 			name: "anonymous same-name failures all count",
@@ -347,6 +363,30 @@ func TestConversationMetricsPeriodClipping(t *testing.T) {
 	assert.Equal(t, 3, aggregate.Workspaces, "unknown workspace has its own group")
 	assert.Equal(t, TokenBuckets{FreshInput: 20, Output: 3}, aggregate.TokenBuckets)
 	assert.Equal(t, []string{"current-model", "zero-model"}, aggregate.Models)
+	assert.Equal(t, []WorkspaceAggregate{
+		{
+			Path:                "/other",
+			Sessions:            1,
+			TokenBucketsByModel: map[string]TokenBuckets{"": {}},
+			LastActivity:        mustParse(t, "2026-05-21T10:45:00Z"),
+		},
+		{
+			Sessions:            1,
+			TokenBucketsByModel: map[string]TokenBuckets{"": {}},
+			LastActivity:        mustParse(t, "2026-05-21T10:40:00Z"),
+		},
+		{
+			Path:         "/repo",
+			Sessions:     1,
+			TokenBuckets: TokenBuckets{FreshInput: 20, Output: 3},
+			TokenBucketsByModel: map[string]TokenBuckets{
+				"current-model": {FreshInput: 20, Output: 3},
+				"zero-model":    {},
+			},
+			DurationSeconds: 30 * 60,
+			LastActivity:    mustParse(t, "2026-05-21T10:30:00Z"),
+		},
+	}, aggregate.WorkspaceRows, "workspace rows cover matches outside the returned page in stable order")
 	require.Len(t, rows, 1)
 	assert.Equal(t, "conv-other", rows[0].ID, "clipped newest activity controls order")
 	assert.Equal(t, mustParse(t, "2026-05-21T10:45:00Z"), rows[0].StartedAt, "missing start uses generation time")
@@ -382,6 +422,17 @@ func TestConversationMetricsPeriodClipping(t *testing.T) {
 		"current-model": {FreshInput: 20, Output: 3},
 		"zero-model":    {},
 	}, aggregate.TokenBucketsByModel)
+	assert.Equal(t, []WorkspaceAggregate{{
+		Path:         "/repo",
+		Sessions:     1,
+		TokenBuckets: TokenBuckets{FreshInput: 20, Output: 3},
+		TokenBucketsByModel: map[string]TokenBuckets{
+			"current-model": {FreshInput: 20, Output: 3},
+			"zero-model":    {},
+		},
+		DurationSeconds: 30 * 60,
+		LastActivity:    mustParse(t, "2026-05-21T10:30:00Z"),
+	}}, aggregate.WorkspaceRows)
 
 	blank := ""
 	rows, matched, _, err = s.ConversationMetrics(ConversationListOptions{Since: since, Before: before, Workspace: &blank})
@@ -402,6 +453,14 @@ func TestConversationMetricsPeriodClipping(t *testing.T) {
 	assert.Equal(t, int64(9), previous[0].InputTokens)
 	assert.Equal(t, []string{"old-agent"}, previous[0].Agents)
 	assert.Equal(t, "err", previous[0].Status)
+
+	tied := aggregateConversationMetrics([]ConversationSummary{
+		{Workspace: "/zeta", LastActivity: before},
+		{Workspace: "/alpha", LastActivity: before},
+	})
+	require.Len(t, tied.WorkspaceRows, 2)
+	assert.Equal(t, "/alpha", tied.WorkspaceRows[0].Path)
+	assert.Equal(t, "/zeta", tied.WorkspaceRows[1].Path)
 }
 
 func TestConversationFacetFilters(t *testing.T) {
@@ -976,8 +1035,8 @@ func TestConversationDetail(t *testing.T) {
 		Output: []agento11y.Message{{Role: agento11y.RoleAssistant, Parts: []agento11y.Part{
 			{Kind: agento11y.PartKindText, Text: "thinking..."},
 			{Kind: agento11y.PartKindToolCall, ToolCall: &agento11y.ToolCall{Name: "bash", InputJSON: bashInput}},
-			// Duplicate name to confirm dedup.
-			{Kind: agento11y.PartKindToolCall, ToolCall: &agento11y.ToolCall{Name: "bash", InputJSON: bashInput}},
+			// Case-only spelling differences are one tool.
+			{Kind: agento11y.PartKindToolCall, ToolCall: &agento11y.ToolCall{Name: "Bash", InputJSON: bashInput}},
 		}}},
 	}, "2026-05-21T10:00:03.19Z")
 
@@ -1008,7 +1067,7 @@ func TestConversationDetail(t *testing.T) {
 	if first.TokenBuckets != (TokenBuckets{FreshInput: 10, Output: 5}) {
 		t.Errorf("first.token_buckets = %+v, want fresh=10 output=5", first.TokenBuckets)
 	}
-	// Dedup keeps a single "bash" tool; preview unwraps `command`.
+	// Dedup keeps the first spelling; preview unwraps `command`.
 	if len(first.Tools) != 1 || first.Tools[0] != "bash" {
 		t.Errorf("first.tools = %v, want [bash]", first.Tools)
 	}

--- a/plugins/agento11y/internal/local/server.go
+++ b/plugins/agento11y/internal/local/server.go
@@ -833,7 +833,7 @@ func toolParam(r *http.Request) *string {
 	}
 	value := ""
 	if len(values) > 0 {
-		value = values[0]
+		value = toolNameKey(values[0])
 	}
 	return &value
 }
@@ -996,8 +996,13 @@ func (s *Server) handleConversationMetrics(w http.ResponseWriter, r *http.Reques
 	if !ok {
 		return
 	}
+	order := r.URL.Query().Get("order")
+	if order != "" && order != "tokens" {
+		http.Error(w, `order must be "tokens"`, http.StatusBadRequest)
+		return
+	}
 	facets.Limit, facets.Since, facets.Before = limit, since, before
-	facets.Workspace, facets.Tool = workspace, toolParam(r)
+	facets.Workspace, facets.Tool, facets.Order = workspace, toolParam(r), order
 	rows, matched, aggregate, err := s.storage.ConversationMetrics(facets)
 	if err != nil {
 		s.logger.Printf("local: conversation metrics: %v", err)

--- a/plugins/agento11y/internal/local/server_test.go
+++ b/plugins/agento11y/internal/local/server_test.go
@@ -306,7 +306,7 @@ func TestServer_ConversationMetrics(t *testing.T) {
 		tokens                int64
 	}{
 		{conv: "conv-repo", when: "2026-08-21T10:00:00Z", workspace: "/repo", tokens: 5},
-		{conv: "conv-repo", when: "2026-08-21T11:00:00Z", workspace: "/repo", tokens: 50},
+		{conv: "conv-repo", when: "2026-08-21T11:00:00Z", workspace: "/repo", tokens: 500},
 		{conv: "conv-unknown", when: "2026-08-21T10:30:00Z", tokens: 7},
 	} {
 		writeGen(t, storage, seed.conv, seed.when, agento11y.Generation{
@@ -333,8 +333,43 @@ func TestServer_ConversationMetrics(t *testing.T) {
 		assert.Equal(t, 0, got.Aggregate.Agents)
 		assert.Equal(t, 2, got.Aggregate.Workspaces)
 		assert.Equal(t, TokenBuckets{FreshInput: 12}, got.Aggregate.TokenBuckets)
+		assert.Equal(t, []WorkspaceAggregate{
+			{
+				Sessions:            1,
+				TokenBuckets:        TokenBuckets{FreshInput: 7},
+				TokenBucketsByModel: map[string]TokenBuckets{"": {FreshInput: 7}},
+				LastActivity:        mustParse(t, "2026-08-21T10:30:00Z"),
+			},
+			{
+				Path:                "/repo",
+				Sessions:            1,
+				TokenBuckets:        TokenBuckets{FreshInput: 5},
+				TokenBucketsByModel: map[string]TokenBuckets{"": {FreshInput: 5}},
+				LastActivity:        mustParse(t, "2026-08-21T10:00:00Z"),
+			},
+		}, got.Aggregate.WorkspaceRows)
 		require.Len(t, got.Conversations, 1)
 		assert.Equal(t, "conv-unknown", got.Conversations[0].ID)
+	})
+
+	t.Run("token ordering precedes the limit", func(t *testing.T) {
+		writeGen(t, storage, "conv-heavy", "g1", agento11y.Generation{
+			StartedAt: mustParse(t, "2026-08-21T09:00:00Z"),
+			Usage:     agento11y.TokenUsage{InputTokens: 100},
+		}, "2026-08-21T09:00:00Z")
+		req := newLocalRequest(http.MethodGet,
+			"/api/v1/metrics/conversations?limit=1&order=tokens&since=2026-08-21T08:00:00Z&before=2026-08-21T11:00:00Z", nil)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+		var got struct {
+			Conversations        []ConversationSummary `json:"conversations"`
+			MatchedConversations int                   `json:"matched_conversations"`
+		}
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+		assert.Equal(t, 3, got.MatchedConversations)
+		require.Len(t, got.Conversations, 1)
+		assert.Equal(t, "conv-heavy", got.Conversations[0].ID, "the oldest but largest row is returned")
 	})
 
 	t.Run("present blank workspace selects unknown", func(t *testing.T) {
@@ -352,6 +387,7 @@ func TestServer_ConversationMetrics(t *testing.T) {
 			"/api/v1/metrics/conversations?limit=0",
 			"/api/v1/metrics/conversations?since=",
 			"/api/v1/metrics/conversations?before=tomorrow",
+			"/api/v1/metrics/conversations?order=cost",
 		} {
 			rr := httptest.NewRecorder()
 			srv.ServeHTTP(rr, newLocalRequest(http.MethodGet, path, nil))
@@ -486,6 +522,7 @@ func TestServer_SkillsToolsMetricsAndSessionDrilldown(t *testing.T) {
 	lower := mustParse(t, "2026-08-21T10:00:00Z")
 	upper := mustParse(t, "2026-08-21T11:00:00Z")
 	writeToolGeneration(t, storage, "conv-match", "g1", "/repo", lower, "call-1", "Bash", true)
+	writeToolGeneration(t, storage, "conv-lower", "g1", "/repo", lower.Add(10*time.Minute), "call-lower", "bash", false)
 	writeToolGeneration(t, storage, "conv-new", "g1", "/repo", upper, "call-2", "Bash", false)
 	_, err := storage.appendToolSpans([]toolSpanRecord{
 		analyticsSpan("conv-match", "trace-1", "span-1", "call-1", "Bash", lower.Add(time.Second), 2*time.Second, false),
@@ -501,16 +538,17 @@ func TestServer_SkillsToolsMetricsAndSessionDrilldown(t *testing.T) {
 		assert.NotContains(t, rr.Body.String(), `"skills"`)
 		var got SkillsToolsMetricsResponse
 		decodeJSON(t, io.NopCloser(rr.Body), &got)
-		assert.Equal(t, ToolAnalyticsTotals{Calls: 1, Failures: 1, Tools: 1, Sessions: 1, DurationSamples: 1}, got.Tools.Totals)
-		assert.Equal(t, ToolAnalyticsCoverage{GenerationCalls: 1, ProjectedSpans: 1, MatchedCalls: 1}, got.Tools.Coverage)
+		assert.Equal(t, ToolAnalyticsTotals{Calls: 2, Failures: 1, Tools: 1, Sessions: 2, DurationSamples: 1}, got.Tools.Totals)
+		assert.Equal(t, ToolAnalyticsCoverage{GenerationCalls: 2, ProjectedSpans: 1, MatchedCalls: 1}, got.Tools.Coverage)
 		assert.Equal(t, int64(300), got.Tools.IntervalSeconds)
 		require.Len(t, got.Tools.Rows, 1)
 		assert.Equal(t, "Bash", got.Tools.Rows[0].Name)
+		assert.Equal(t, 2, got.Tools.Rows[0].Calls)
 	})
 
-	t.Run("sessions filters before limit", func(t *testing.T) {
+	t.Run("folded row deep link reaches both spellings", func(t *testing.T) {
 		req := newLocalRequest(http.MethodGet,
-			"/api/v1/conversations?limit=1&tool=Bash&workspace=%2Frepo&since=2026-08-21T10:00:00Z&before=2026-08-21T11:00:00Z", nil)
+			"/api/v1/conversations?limit=2&tool=Bash&workspace=%2Frepo&since=2026-08-21T10:00:00Z&before=2026-08-21T11:00:00Z", nil)
 		rr := httptest.NewRecorder()
 		srv.ServeHTTP(rr, req)
 		require.Equal(t, http.StatusOK, rr.Code)
@@ -518,8 +556,20 @@ func TestServer_SkillsToolsMetricsAndSessionDrilldown(t *testing.T) {
 			Conversations []ConversationSummary `json:"conversations"`
 		}
 		decodeJSON(t, io.NopCloser(rr.Body), &got)
-		require.Len(t, got.Conversations, 1)
-		assert.Equal(t, "conv-match", got.Conversations[0].ID)
+		assert.Equal(t, []string{"conv-lower", "conv-match"}, summaryIDs(got.Conversations))
+	})
+
+	t.Run("present blank tool matches no sessions", func(t *testing.T) {
+		req := newLocalRequest(http.MethodGet,
+			"/api/v1/conversations?tool=&since=2026-08-21T10:00:00Z&before=2026-08-21T11:00:00Z", nil)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+		var got struct {
+			Conversations []ConversationSummary `json:"conversations"`
+		}
+		decodeJSON(t, io.NopCloser(rr.Body), &got)
+		assert.Empty(t, got.Conversations)
 	})
 
 	t.Run("invalid exact parameters are rejected", func(t *testing.T) {

--- a/plugins/agento11y/internal/local/summaries.go
+++ b/plugins/agento11y/internal/local/summaries.go
@@ -301,9 +301,25 @@ func (c *toolUsageCounter) addGeneration(gen summaryGeneration, timestamp time.T
 	}
 }
 
+func toolNameKey(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+func preferredToolSpelling(counts map[string]int) string {
+	preferred := ""
+	preferredCalls := -1
+	for spelling, calls := range counts {
+		if calls > preferredCalls || calls == preferredCalls && spelling < preferred {
+			preferred = spelling
+			preferredCalls = calls
+		}
+	}
+	return preferred
+}
+
 func sameToolResult(a, b toolProbeResult) bool {
 	return strings.TrimSpace(a.ToolCallID) == strings.TrimSpace(b.ToolCallID) &&
-		strings.TrimSpace(a.Name) == strings.TrimSpace(b.Name) && a.IsError == b.IsError
+		toolNameKey(a.Name) == toolNameKey(b.Name) && a.IsError == b.IsError
 }
 
 func (c *toolUsageCounter) addCall(call toolProbeCall, timestamp time.Time) {
@@ -318,11 +334,11 @@ func (c *toolUsageCounter) addCall(call toolProbeCall, timestamp time.Time) {
 		c.pendingByID[id] = append(c.pendingByID[id], idx)
 		return
 	}
-	if name != "" {
+	if key := toolNameKey(name); key != "" {
 		if c.pendingAnonymous == nil {
 			c.pendingAnonymous = map[string][]int{}
 		}
-		c.pendingAnonymous[name] = append(c.pendingAnonymous[name], idx)
+		c.pendingAnonymous[key] = append(c.pendingAnonymous[key], idx)
 	}
 }
 
@@ -353,9 +369,10 @@ func (c *toolUsageCounter) addResult(result toolProbeResult, timestamp time.Time
 		c.occurrences = append(c.occurrences, toolOccurrence{Timestamp: timestamp, CallID: id, Name: name, Failed: result.IsError})
 		return
 	}
-	if pending := c.pendingAnonymous[name]; name != "" && len(pending) > 0 {
+	key := toolNameKey(name)
+	if pending := c.pendingAnonymous[key]; key != "" && len(pending) > 0 {
 		idx := pending[0]
-		c.pendingAnonymous[name] = pending[1:]
+		c.pendingAnonymous[key] = pending[1:]
 		c.occurrences[idx].Failed = c.occurrences[idx].Failed || result.IsError
 		return
 	}
@@ -363,22 +380,32 @@ func (c *toolUsageCounter) addResult(result toolProbeResult, timestamp time.Time
 }
 
 func toolUsage(occurrences []toolOccurrence, since, before time.Time) []ToolUsage {
-	counts := map[string]ToolUsage{}
+	type accumulator struct {
+		usage     ToolUsage
+		spellings map[string]int
+	}
+	counts := map[string]*accumulator{}
 	for _, occurrence := range occurrences {
-		if !inPeriod(occurrence.Timestamp, since, before) || occurrence.Name == "" {
+		name := strings.TrimSpace(occurrence.Name)
+		key := toolNameKey(name)
+		if !inPeriod(occurrence.Timestamp, since, before) || key == "" {
 			continue
 		}
-		usage := counts[occurrence.Name]
-		usage.Name = occurrence.Name
-		usage.Calls++
-		if occurrence.Failed {
-			usage.Failures++
+		entry := counts[key]
+		if entry == nil {
+			entry = &accumulator{spellings: map[string]int{}}
+			counts[key] = entry
 		}
-		counts[occurrence.Name] = usage
+		entry.usage.Calls++
+		entry.spellings[name]++
+		if occurrence.Failed {
+			entry.usage.Failures++
+		}
 	}
 	out := make([]ToolUsage, 0, len(counts))
-	for _, usage := range counts {
-		out = append(out, usage)
+	for _, entry := range counts {
+		entry.usage.Name = preferredToolSpelling(entry.spellings)
+		out = append(out, entry.usage)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out

--- a/plugins/agento11y/internal/local/tool_analytics.go
+++ b/plugins/agento11y/internal/local/tool_analytics.go
@@ -268,6 +268,7 @@ func aggregateToolAnalytics(observations []toolObservation, interval time.Durati
 		row       ToolAnalyticsRow
 		durations []time.Duration
 		sessions  map[string]struct{}
+		spellings map[string]int
 	}
 	type bucketKey struct {
 		start int64
@@ -292,12 +293,15 @@ func aggregateToolAnalytics(observations []toolObservation, interval time.Durati
 		if observation.HasGeneration && observation.HasSpan {
 			coverage.MatchedCalls++
 		}
-		row := rows[observation.Name]
+		name := strings.TrimSpace(observation.Name)
+		nameKey := toolNameKey(name)
+		row := rows[nameKey]
 		if row == nil {
-			row = &rowAccumulator{row: ToolAnalyticsRow{Name: observation.Name}, sessions: map[string]struct{}{}}
-			rows[observation.Name] = row
+			row = &rowAccumulator{sessions: map[string]struct{}{}, spellings: map[string]int{}}
+			rows[nameKey] = row
 		}
 		row.row.Calls++
+		row.spellings[name]++
 		if observation.Failed {
 			row.row.Failures++
 		}
@@ -310,10 +314,10 @@ func aggregateToolAnalytics(observations []toolObservation, interval time.Durati
 		}
 
 		start := intervalStart(observation.Timestamp, interval)
-		key := bucketKey{start: start.UnixNano(), name: observation.Name}
+		key := bucketKey{start: start.UnixNano(), name: nameKey}
 		bucket := buckets[key]
 		if bucket == nil {
-			bucket = &ToolAnalyticsBucket{Timestamp: start, Name: observation.Name}
+			bucket = &ToolAnalyticsBucket{Timestamp: start}
 			buckets[key] = bucket
 		}
 		bucket.Calls++
@@ -331,7 +335,10 @@ func aggregateToolAnalytics(observations []toolObservation, interval time.Durati
 	analytics.Totals.Calls = totalCalls
 	analytics.Totals.Tools = len(rows)
 	analytics.Totals.Sessions = len(sessions)
-	for _, accumulator := range rows {
+	displayNames := make(map[string]string, len(rows))
+	for key, accumulator := range rows {
+		accumulator.row.Name = preferredToolSpelling(accumulator.spellings)
+		displayNames[key] = accumulator.row.Name
 		accumulator.row.Sessions = len(accumulator.sessions)
 		accumulator.row.DurationSamples = len(accumulator.durations)
 		analytics.Totals.Failures += accumulator.row.Failures
@@ -351,7 +358,8 @@ func aggregateToolAnalytics(observations []toolObservation, interval time.Durati
 		}
 		return analytics.Rows[i].Name < analytics.Rows[j].Name
 	})
-	for _, bucket := range buckets {
+	for key, bucket := range buckets {
+		bucket.Name = displayNames[key.name]
 		analytics.Buckets = append(analytics.Buckets, *bucket)
 	}
 	sort.Slice(analytics.Buckets, func(i, j int) bool {

--- a/plugins/agento11y/internal/local/tool_analytics_test.go
+++ b/plugins/agento11y/internal/local/tool_analytics_test.go
@@ -77,6 +77,35 @@ func TestToolAnalyticsReconcilesCallsSpansAndCoverage(t *testing.T) {
 	assert.Equal(t, got.Workspaces, filtered.Workspaces, "facets retain all period workspaces for a one-request picker")
 }
 
+func TestToolAnalyticsFoldsToolNamesByCase(t *testing.T) {
+	storage := newStorage(t)
+	started := mustParse(t, "2026-08-21T10:00:00Z")
+	writeToolGeneration(t, storage, "conv-lower", "g1", "/repo", started, "lower-1", "bash", false)
+	writeToolGeneration(t, storage, "conv-lower", "g2", "/repo", started.Add(time.Minute), "lower-2", "bash", false)
+	writeToolGeneration(t, storage, "conv-lower", "g3", "/repo", started.Add(2*time.Minute), "lower-3", "bash", false)
+	writeToolGeneration(t, storage, "conv-upper", "g1", "/repo", started.Add(3*time.Minute), "upper", "Bash", false)
+	_, err := storage.appendToolSpans([]toolSpanRecord{
+		analyticsSpan("conv-upper", "trace", "span", "upper", "Bash", started.Add(3*time.Minute), 2*time.Second, false),
+	})
+	require.NoError(t, err)
+
+	got, err := storage.ToolAnalytics(ToolAnalyticsOptions{Interval: 5 * time.Minute})
+	require.NoError(t, err)
+	assert.Equal(t, ToolAnalyticsTotals{Calls: 4, Tools: 1, Sessions: 2, DurationSamples: 1}, got.Totals)
+	require.Len(t, got.Rows, 1)
+	assert.Equal(t, "bash", got.Rows[0].Name, "the spelling with the most calls is displayed")
+	assert.Equal(t, 4, got.Rows[0].Calls)
+	assert.Equal(t, 1, got.Rows[0].DurationSamples)
+	require.NotNil(t, got.Rows[0].P50DurationSeconds)
+	require.NotNil(t, got.Rows[0].P95DurationSeconds)
+	assert.Equal(t, 2.0, *got.Rows[0].P50DurationSeconds)
+	assert.Equal(t, 2.0, *got.Rows[0].P95DurationSeconds)
+	require.Len(t, got.Buckets, 1)
+	assert.Equal(t, "bash", got.Buckets[0].Name)
+	assert.Equal(t, 4, got.Buckets[0].Calls)
+	assert.Equal(t, "Bash", preferredToolSpelling(map[string]int{"bash": 1, "Bash": 1}), "ties are lexical")
+}
+
 func TestToolAnalyticsDropsUnixNanoUnrepresentableTimestampsEverywhere(t *testing.T) {
 	storage := newStorage(t)
 	valid := mustParse(t, "2026-08-21T10:00:00Z")
@@ -162,8 +191,8 @@ func TestListConversationsAppliesExactFiltersBeforeLimit(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 5, total, "the existing store total contract is unchanged")
-	assert.Equal(t, []string{"conv-match", "conv-span"}, conversationIDs(rows),
-		"tool, workspace, and half-open bounds apply before the limit")
+	assert.Equal(t, []string{"conv-case", "conv-match"}, conversationIDs(rows),
+		"case-folded tool, workspace, and half-open bounds apply before the limit")
 
 	rows, _, err = storage.ListConversations(ConversationListOptions{
 		Limit: 1, Since: lower, Before: upper, Workspace: &workspace, Exact: true,

--- a/plugins/agento11y/internal/local/web/src/analytics.tsx
+++ b/plugins/agento11y/internal/local/web/src/analytics.tsx
@@ -16,7 +16,9 @@ import {
   formatBucketLabel,
   formatCost,
   formatDuration,
+  formatInteger,
   formatTokens,
+  maximumEstimatedTokenRate,
   modelDot,
   shortModel,
   splitWorkspacePath,
@@ -37,6 +39,7 @@ import type {
   TokenBucketKey,
   TokenBuckets,
   TokenUsagePoint,
+  WorkspaceMetricsAggregate,
 } from './types';
 
 export type AnalyticsUnit = 'cost' | 'tokens';
@@ -44,8 +47,14 @@ export type AnalyticsUnit = 'cost' | 'tokens';
 export interface AnalyticsViewProps {
   conversations: ConversationSummary[];
   previousConversations: ConversationSummary[];
+  heaviestConversations?: ConversationSummary[];
+  heaviestTotalConversations?: number | null;
+  heaviestRankingExact?: boolean;
+  heaviestLoading?: boolean;
+  heaviestError?: string | null;
   aggregate?: ConversationMetricsAggregate | null;
   previousAggregate?: ConversationMetricsAggregate | null;
+  facetAggregate?: ConversationMetricsAggregate | null;
   facetConversations: ConversationSummary[];
   totalConversations: number | null;
   previousTotalConversations: number | null;
@@ -134,11 +143,42 @@ function tokenTotal(buckets: TokenBuckets | null | undefined): number {
   return TOKEN_SERIES.reduce((sum, series) => sum + (buckets[series.key] || 0), 0);
 }
 
+// Token ordering makes the final row's token count an upper bound for every
+// unseen row; the highest rate the estimator can apply turns it into a cost bound.
+export function heaviestCostPageNeedsMore(
+  conversations: readonly ConversationSummary[],
+  matchedConversations: number,
+  prices: ModelPrices | null,
+): boolean {
+  if (conversations.length >= matchedConversations) return false;
+  const pricedCosts = conversations
+    .map((conversation) => conversationCostEstimateByModel(conversation, prices).value)
+    .filter((cost): cost is number => cost != null)
+    .sort((a, b) => b - a);
+  const sixthCost = pricedCosts[5];
+  if (sixthCost == null) return true;
+  const lastReturned = conversations.at(-1);
+  if (!lastReturned) return true;
+  const unseenCostUpperBound = (tokenTotal(lastReturned.token_buckets) * maximumEstimatedTokenRate(prices)) / 1e6;
+  return sixthCost <= unseenCostUpperBound;
+}
+
+export function heaviestCostRankingIsExact(
+  conversations: readonly ConversationSummary[],
+  matchedConversations: number,
+  prices: ModelPrices | null,
+): boolean {
+  return (
+    conversations.every((conversation) => conversationCostEstimateByModel(conversation, prices).complete) &&
+    !heaviestCostPageNeedsMore(conversations, matchedConversations, prices)
+  );
+}
+
 function sumTokens(conversations: readonly ConversationSummary[]): number {
   return conversations.reduce((sum, conversation) => sum + tokenTotal(conversation.token_buckets), 0);
 }
 
-function sumCosts(conversations: readonly ConversationSummary[], prices: ModelPrices | null): CostEstimate {
+function sumCosts(conversations: readonly ModelUsageSource[], prices: ModelPrices | null): CostEstimate {
   let total = 0;
   let priced = 0;
   let complete = true;
@@ -172,6 +212,25 @@ function chartCostDescription(estimate: CostEstimate & { hasUsage: boolean }): s
   if (estimate.value == null) return 'estimated cost unavailable';
   if (estimate.complete) return `estimated cost ${formatCost(estimate.value)}`;
   return `estimated cost ${formatCostEstimate(estimate)}; unpriced usage excluded`;
+}
+
+function workspaceAggregateRows(
+  workspaces: readonly WorkspaceMetricsAggregate[],
+  prices: ModelPrices | null,
+): WorkspaceRow[] {
+  return workspaces.map((workspace) => {
+    const estimate = conversationCostEstimateByModel(workspace, prices);
+    const last = Date.parse(workspace.last_activity);
+    return {
+      path: workspace.path,
+      count: workspace.sessions,
+      cost: estimate.value,
+      costComplete: estimate.complete,
+      tokens: tokenTotal(workspace.token_buckets),
+      dur: workspace.duration_seconds,
+      last: Number.isFinite(last) ? last : 0,
+    };
+  });
 }
 
 function aggregateWorkspaces(
@@ -259,10 +318,6 @@ function pointDelta(current: number | null, previous: number | null): string | n
   if (value > 0) return `+${value} pt ${DELTA_BASELINE}`;
   if (value < 0) return `−${Math.abs(value)} pt ${DELTA_BASELINE}`;
   return `0 pt ${DELTA_BASELINE}`;
-}
-
-function formatInteger(value: number): string {
-  return Math.round(value).toLocaleString('en-US');
 }
 
 function emptyRangeMessage(rangeLabel: string): React.ReactNode {
@@ -1026,7 +1081,7 @@ function WorkspacesPanel({
                     {unit === 'cost' && !costComplete ? '—' : `${share}%`}
                   </span>
                 </span>
-                <span style={{ textAlign: 'right', color: 'var(--fg2)' }}>{row.count}</span>
+                <span style={{ textAlign: 'right', color: 'var(--fg2)' }}>{formatInteger(row.count)}</span>
                 <span style={{ textAlign: 'right', color: unit === 'tokens' ? 'var(--fg-max)' : 'var(--fg1)' }}>
                   {formatTokens(row.tokens)}
                 </span>
@@ -1150,7 +1205,10 @@ function SessionShapePanel({ conversations, empty }: { conversations: Conversati
     durations[Math.min(durations.length - 1, Math.max(0, Math.ceil(durations.length * p) - 1))];
   return (
     <SurfaceCard style={{ boxShadow: 'none', minWidth: 0 }}>
-      <PanelHeader title="Sessions" meta="tokens / session" />
+      <PanelHeader
+        title="Sessions"
+        meta={`tokens / session · based on ${formatInteger(conversations.length)} ${conversations.length === 1 ? 'session' : 'sessions'}`}
+      />
       {conversations.length === 0 ? (
         <EmptyPanel>{empty}</EmptyPanel>
       ) : (
@@ -1180,7 +1238,7 @@ function SessionShapePanel({ conversations, empty }: { conversations: Conversati
                   }}
                 />
               </span>
-              <span style={{ textAlign: 'right', color: 'var(--fg1)' }}>{bucket.count}</span>
+              <span style={{ textAlign: 'right', color: 'var(--fg1)' }}>{formatInteger(bucket.count)}</span>
             </div>
           ))}
           <div
@@ -1412,6 +1470,9 @@ function HeaviestSessionsPanel({
   unit,
   prices,
   totalConversations,
+  rankingExact,
+  loading,
+  error,
   returnedCurrentRange,
   previousTotalConversations,
   returnedPreviousRange,
@@ -1424,6 +1485,9 @@ function HeaviestSessionsPanel({
   unit: AnalyticsUnit;
   prices: ModelPrices | null;
   totalConversations: number | null;
+  rankingExact: boolean;
+  loading: boolean;
+  error: string | null;
   returnedCurrentRange: number;
   previousTotalConversations: number | null;
   returnedPreviousRange: number;
@@ -1442,13 +1506,24 @@ function HeaviestSessionsPanel({
       return bv - av;
     })
     .slice(0, 6);
-  const totalTokens = sumTokens(conversations);
-  const totalCost = sumCosts(conversations, prices);
+  const rangeSessions = totalConversations ?? conversations.length;
+  const unitRankingExact =
+    rankingExact || (unit === 'tokens' && !loading && error == null && totalConversations != null);
+  const hasUnpricedUsage = [...costs.values()].some((estimate) => !estimate.complete);
   const coverage = totalConversations != null && totalConversations > returnedCurrentRange;
   const previousCoverage = previousTotalConversations != null && previousTotalConversations > returnedPreviousRange;
+  const panelEmpty = error ? `Failed to load ranked sessions: ${error}` : loading ? 'Loading ranked sessions…' : empty;
+  const panelMeta =
+    totalConversations == null
+      ? loading
+        ? `loading ${unit} ranking`
+        : `${unit} ranking unavailable`
+      : unitRankingExact
+        ? `top ${formatInteger(sorted.length)} of ${formatInteger(rangeSessions)} by ${unit}`
+        : `${formatInteger(sorted.length)} shown of ${formatInteger(rangeSessions)} by ${unit}`;
   return (
     <SurfaceCard style={{ boxShadow: 'none', minWidth: 0 }}>
-      <PanelHeader title="Heaviest sessions" meta={`top ${sorted.length} of ${conversations.length} by ${unit}`} />
+      <PanelHeader title="Heaviest sessions" meta={panelMeta} />
       <div
         style={{
           display: 'grid',
@@ -1471,7 +1546,7 @@ function HeaviestSessionsPanel({
         <span style={{ textAlign: 'right' }}>Cost</span>
       </div>
       {sorted.length === 0 ? (
-        <EmptyPanel>{empty}</EmptyPanel>
+        <EmptyPanel>{panelEmpty}</EmptyPanel>
       ) : (
         sorted.map((conversation, position) => {
           const workspace = splitWorkspacePath(conversation.workspace);
@@ -1555,21 +1630,28 @@ function HeaviestSessionsPanel({
           fontSize: 11,
         }}
       >
-        {conversations.length} {conversations.length === 1 ? 'session' : 'sessions'} in range ·{' '}
-        {unit === 'cost' ? `${formatCostEstimate(totalCost)} total` : `${formatTokens(totalTokens)} tokens total`}
-        {!totalCost.complete && totalCost.value != null && ' · Unpriced usage is excluded.'}
+        {unitRankingExact
+          ? `Ranked across ${formatInteger(rangeSessions)} ${rangeSessions === 1 ? 'session' : 'sessions'} in range.`
+          : conversations.length >= rangeSessions
+            ? unit === 'cost' && hasUnpricedUsage
+              ? 'Every session in range is included, but incomplete cost estimates prevent an exact cost ranking.'
+              : `Ranking could not be verified across ${formatInteger(rangeSessions)} ${rangeSessions === 1 ? 'session' : 'sessions'} in range.`
+            : `Ranking is based on ${formatInteger(conversations.length)} of ${formatInteger(rangeSessions)} sessions; sessions outside this set may rank higher.`}
+        {unit === 'cost' && hasUnpricedUsage && ' Unpriced usage is excluded from estimated cost.'}
+        {error && conversations.length > 0 && ` Ranked sessions did not refresh: ${error}`}
         {coverage && (
           <Fragment>
-            {' · '}Coverage: session panels use {returnedCurrentRange} returned{' '}
-            {returnedCurrentRange === 1 ? 'session' : 'sessions'} from {totalConversations} in range.{' '}
+            {' '}
+            Session distribution is based on {formatInteger(returnedCurrentRange)} of{' '}
+            {formatInteger(totalConversations ?? rangeSessions)} sessions in range.{' '}
             {kpisCoverAll ? 'KPI totals, model totals, token charts, and trends' : 'Token charts and trends'} cover all
             generations in range.
           </Fragment>
         )}
         {previousCoverage && !previousKpisCoverAll && (
           <Fragment>
-            {' · '}Previous-period comparisons are unavailable: {returnedPreviousRange} of {previousTotalConversations}{' '}
-            sessions returned.
+            {' · '}Previous-period comparisons are unavailable: {formatInteger(returnedPreviousRange)} of{' '}
+            {formatInteger(previousTotalConversations ?? 0)} sessions returned.
           </Fragment>
         )}
       </div>
@@ -1591,9 +1673,9 @@ export function analyticsOverviewHeroStats(props: AnalyticsHeroSource) {
   const sessions =
     props.aggregate && props.totalConversations != null ? props.totalConversations : props.conversations.length;
   return [
-    { label: 'Sessions', value: String(sessions) },
-    { label: 'Workspaces', value: String(props.aggregate?.workspaces ?? workspaces.size) },
-    { label: 'Agents', value: String(props.aggregate?.agents ?? agents.size) },
+    { label: 'Sessions', value: formatInteger(sessions) },
+    { label: 'Workspaces', value: formatInteger(props.aggregate?.workspaces ?? workspaces.size) },
+    { label: 'Agents', value: formatInteger(props.aggregate?.agents ?? agents.size) },
   ];
 }
 
@@ -1604,11 +1686,22 @@ function AnalyticsContent(props: ResolvedAnalyticsViewProps) {
   const selectedCurrent = props.conversations;
   const selectedPrevious = props.previousConversations;
   const facetWorkspaces = useMemo(() => {
-    const rows = aggregateWorkspaces(props.facetConversations, prices);
+    const rows = props.facetAggregate?.workspace_rows
+      ? workspaceAggregateRows(props.facetAggregate.workspace_rows, prices)
+      : aggregateWorkspaces(props.facetConversations, prices);
     if (props.workspace == null || rows.some((row) => row.path === props.workspace)) return rows;
-    return [...rows, ...aggregateWorkspaces(selectedCurrent, prices)];
-  }, [props.facetConversations, props.workspace, selectedCurrent, prices]);
-  const workspaceRows = useMemo(() => aggregateWorkspaces(selectedCurrent, prices), [selectedCurrent, prices]);
+    const selectedRows = props.aggregate?.workspace_rows
+      ? workspaceAggregateRows(props.aggregate.workspace_rows, prices)
+      : aggregateWorkspaces(selectedCurrent, prices);
+    return [...rows, ...selectedRows];
+  }, [props.facetAggregate, props.facetConversations, props.workspace, props.aggregate, selectedCurrent, prices]);
+  const workspaceRows = useMemo(
+    () =>
+      props.aggregate?.workspace_rows
+        ? workspaceAggregateRows(props.aggregate.workspace_rows, prices)
+        : aggregateWorkspaces(selectedCurrent, prices),
+    [props.aggregate, selectedCurrent, prices],
+  );
   const modelRows = useMemo(
     () => aggregateModels(props.aggregate ? [props.aggregate] : selectedCurrent, prices),
     [props.aggregate, selectedCurrent, prices],
@@ -1696,7 +1789,16 @@ function AnalyticsContent(props: ResolvedAnalyticsViewProps) {
       : selectedCurrent.length === 0
         ? empty
         : 'No token usage in this range.';
-  const facetCost = sumCosts(props.facetConversations, prices);
+  const facetCost = sumCosts(props.facetAggregate?.workspace_rows || props.facetConversations, prices);
+  const facetSessionCount =
+    props.facetTotalConversations ?? facetWorkspaces.reduce((sum, workspace) => sum + workspace.count, 0);
+  const heaviestConversations = props.heaviestConversations ?? selectedCurrent;
+  const heaviestTotalConversations = props.heaviestTotalConversations ?? props.totalConversations;
+  const heaviestRankingExact =
+    props.heaviestRankingExact ??
+    (heaviestTotalConversations == null
+      ? heaviestCostRankingIsExact(heaviestConversations, heaviestConversations.length, prices)
+      : heaviestCostRankingIsExact(heaviestConversations, heaviestTotalConversations, prices));
 
   return (
     <>
@@ -1721,13 +1823,16 @@ function AnalyticsContent(props: ResolvedAnalyticsViewProps) {
           </Notice>
         </div>
       )}
-      {props.facetTotalConversations != null && props.facetTotalConversations > props.facetConversations.length && (
-        <div style={{ marginBottom: 14 }}>
-          <Notice kind="warning" title="Workspace options are incomplete">
-            Options cover {props.facetConversations.length} of {props.facetTotalConversations} sessions in range.
-          </Notice>
-        </div>
-      )}
+      {props.facetAggregate?.workspace_rows == null &&
+        props.facetTotalConversations != null &&
+        props.facetTotalConversations > props.facetConversations.length && (
+          <div style={{ marginBottom: 14 }}>
+            <Notice kind="warning" title="Workspace options are incomplete">
+              Options cover {formatInteger(props.facetConversations.length)} of{' '}
+              {formatInteger(props.facetTotalConversations)} sessions in range.
+            </Notice>
+          </div>
+        )}
       <div
         style={{
           display: 'flex',
@@ -1746,11 +1851,10 @@ function AnalyticsContent(props: ResolvedAnalyticsViewProps) {
           workspaces={facetWorkspaces}
           selected={props.workspace}
           onSelect={props.onWorkspaceChange}
-          totalCount={props.facetConversations.length}
+          totalCount={facetSessionCount}
           totalCost={facetCost.complete ? facetCost.value : null}
           now={now}
           rangeLabel={range.label}
-          fromRows
         />
         <TimeRangePicker value={props.timeRange} onChange={props.onTimeRangeChange} />
         <button
@@ -1924,10 +2028,13 @@ function AnalyticsContent(props: ResolvedAnalyticsViewProps) {
       </div>
 
       <HeaviestSessionsPanel
-        conversations={selectedCurrent}
+        conversations={heaviestConversations}
         unit={props.unit}
         prices={prices}
-        totalConversations={props.totalConversations}
+        totalConversations={heaviestTotalConversations}
+        rankingExact={heaviestRankingExact}
+        loading={props.heaviestLoading ?? props.loading}
+        error={props.heaviestError ?? null}
         returnedCurrentRange={props.conversations.length}
         previousTotalConversations={props.previousTotalConversations}
         returnedPreviousRange={props.previousConversations.length}

--- a/plugins/agento11y/internal/local/web/src/app.tsx
+++ b/plugins/agento11y/internal/local/web/src/app.tsx
@@ -1,6 +1,12 @@
 import type { MouseEvent as ReactMouseEvent } from 'react';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { AnalyticsOverviewContent, type AnalyticsUnit, analyticsOverviewHeroStats } from './analytics';
+import {
+  AnalyticsOverviewContent,
+  type AnalyticsUnit,
+  analyticsOverviewHeroStats,
+  heaviestCostPageNeedsMore,
+  heaviestCostRankingIsExact,
+} from './analytics';
 import { AnalyticsPage } from './analytics-page';
 import { ConversationsView, GROUP_BY_OPTIONS } from './conversations';
 import { TraceDetailView } from './detail';
@@ -13,6 +19,7 @@ import {
   TIME_RANGES,
   TOKEN_SERIES,
   timeRangeOption,
+  useModelPrices,
 } from './formatters';
 import {
   type AnalyticsTab,
@@ -84,6 +91,8 @@ interface DetailReturnState {
 }
 
 const ANALYTICS_LIST_SIZE = 2000;
+const HEAVIEST_INITIAL_LIMIT = 64;
+const HEAVIEST_MAX_RETRIES = 3;
 const ALL_WORKSPACES = 'all';
 const WORKSPACE_PREFIX = 'workspace:';
 
@@ -266,9 +275,15 @@ export function App() {
     null,
   );
   const [analyticsFacetConversations, setAnalyticsFacetConversations] = useState<ConversationSummary[]>([]);
+  const [analyticsFacetAggregate, setAnalyticsFacetAggregate] = useState<ConversationMetricsAggregate | null>(null);
   const [analyticsTotalConversations, setAnalyticsTotalConversations] = useState<number | null>(null);
   const [analyticsPreviousTotalConversations, setAnalyticsPreviousTotalConversations] = useState<number | null>(null);
   const [analyticsFacetTotalConversations, setAnalyticsFacetTotalConversations] = useState<number | null>(null);
+  const [analyticsHeaviestConversations, setAnalyticsHeaviestConversations] = useState<ConversationSummary[]>([]);
+  const [analyticsHeaviestTotalConversations, setAnalyticsHeaviestTotalConversations] = useState<number | null>(null);
+  const [analyticsHeaviestRankingExact, setAnalyticsHeaviestRankingExact] = useState(false);
+  const [loadingAnalyticsHeaviest, setLoadingAnalyticsHeaviest] = useState(false);
+  const [errAnalyticsHeaviest, setErrAnalyticsHeaviest] = useState<string | null>(null);
   const [analyticsTokenPoints, setAnalyticsTokenPoints] = useState<TokenUsagePoint[]>([]);
   const [analyticsTokenIntervalMs, setAnalyticsTokenIntervalMs] = useState(0);
   const [analyticsHeatmapPoints, setAnalyticsHeatmapPoints] = useState<TokenUsagePoint[]>([]);
@@ -284,6 +299,7 @@ export function App() {
   const [errAnalyticsFacets, setErrAnalyticsFacets] = useState<string | null>(null);
   const [errAnalyticsTokens, setErrAnalyticsTokens] = useState<string | null>(null);
   const [errAnalyticsHeatmap, setErrAnalyticsHeatmap] = useState<string | null>(null);
+  const analyticsModelPrices = useModelPrices(showAnalytics && analyticsTab === 'overview');
 
   const [detail, setDetail] = useState<ConversationDetail | null>(null);
   const [loadingDetail, setLoadingDetail] = useState(false);
@@ -582,8 +598,69 @@ export function App() {
         : response.text().then((text) => Promise.reject(new Error(text || `HTTP ${response.status}`))),
     [],
   );
+  const analyticsHeaviestSeqRef = useRef(0);
+  const analyticsHeaviestScopeRef = useRef('');
+  const fetchAnalyticsHeaviest = useCallback(
+    async (reset = false, now = Date.now()) => {
+      const seq = ++analyticsHeaviestSeqRef.current;
+      setLoadingAnalyticsHeaviest(true);
+      setErrAnalyticsHeaviest(null);
+      setAnalyticsHeaviestTotalConversations(null);
+      setAnalyticsHeaviestRankingExact(false);
+      const scope = JSON.stringify([analyticsRange, analyticsWorkspace]);
+      if (reset && analyticsHeaviestScopeRef.current !== scope) {
+        setAnalyticsHeaviestConversations([]);
+      }
+      analyticsHeaviestScopeRef.current = scope;
+
+      const range = timeRangeOption(analyticsRange);
+      const params = new URLSearchParams({
+        before: new Date(now).toISOString(),
+        order: 'tokens',
+      });
+      if (range.ms != null) params.set('since', new Date(now - range.ms).toISOString());
+      if (analyticsWorkspace != null) params.set('workspace', analyticsWorkspace);
+
+      let limit = HEAVIEST_INITIAL_LIMIT;
+      try {
+        for (let attempt = 0; attempt <= HEAVIEST_MAX_RETRIES; attempt++) {
+          params.set('limit', String(limit));
+          const body = await fetch(`/api/v1/metrics/conversations?${params}`).then((response) =>
+            readJSON<ConversationMetricsResponse>(response),
+          );
+          if (analyticsHeaviestSeqRef.current !== seq) return;
+          const rows = body.conversations || [];
+          const reported = Number(body.matched_conversations);
+          const matched = Number.isFinite(reported) ? Math.max(rows.length, Math.trunc(reported)) : rows.length;
+          const needsMore = heaviestCostPageNeedsMore(rows, matched, analyticsModelPrices);
+          if (!needsMore || attempt === HEAVIEST_MAX_RETRIES) {
+            setAnalyticsHeaviestConversations(rows);
+            setAnalyticsHeaviestTotalConversations(matched);
+            setAnalyticsHeaviestRankingExact(heaviestCostRankingIsExact(rows, matched, analyticsModelPrices));
+            return;
+          }
+          const nextLimit =
+            attempt + 1 === HEAVIEST_MAX_RETRIES ? matched : Math.min(matched, Math.max(limit + 1, limit * 8));
+          if (nextLimit <= limit) {
+            setAnalyticsHeaviestConversations(rows);
+            setAnalyticsHeaviestTotalConversations(matched);
+            setAnalyticsHeaviestRankingExact(false);
+            return;
+          }
+          limit = nextLimit;
+        }
+      } catch (error) {
+        if (analyticsHeaviestSeqRef.current !== seq) return;
+        setErrAnalyticsHeaviest(errorMessage(error));
+      } finally {
+        if (analyticsHeaviestSeqRef.current === seq) setLoadingAnalyticsHeaviest(false);
+      }
+    },
+    [analyticsModelPrices, analyticsRange, analyticsWorkspace, readJSON],
+  );
+
   const fetchAnalytics = useCallback(
-    (reset = false) => {
+    (reset = false, now = Date.now()) => {
       const seq = ++analyticsSeqRef.current;
       setLoadingAnalytics(true);
       setLoadingAnalyticsTokens(true);
@@ -597,6 +674,7 @@ export function App() {
         setAnalyticsAggregate(null);
         setAnalyticsPreviousAggregate(null);
         setAnalyticsFacetConversations([]);
+        setAnalyticsFacetAggregate(null);
         setAnalyticsTotalConversations(null);
         setAnalyticsPreviousTotalConversations(null);
         setAnalyticsFacetTotalConversations(null);
@@ -604,7 +682,6 @@ export function App() {
         setAnalyticsTokenIntervalMs(0);
       }
 
-      const now = Date.now();
       const range = timeRangeOption(analyticsRange);
       const before = new Date(now).toISOString();
       const currentParams = new URLSearchParams({ limit: String(ANALYTICS_LIST_SIZE), before });
@@ -664,6 +741,7 @@ export function App() {
             );
             if (analyticsWorkspace == null) {
               setAnalyticsFacetConversations(value.conversations || []);
+              setAnalyticsFacetAggregate(value.aggregate || null);
               setAnalyticsFacetTotalConversations(
                 Number.isFinite(value.matched_conversations) ? value.matched_conversations : null,
               );
@@ -687,6 +765,7 @@ export function App() {
           (value) => {
             if (!value) return;
             setAnalyticsFacetConversations(value.conversations || []);
+            setAnalyticsFacetAggregate(value.aggregate || null);
             setAnalyticsFacetTotalConversations(
               Number.isFinite(value.matched_conversations) ? value.matched_conversations : null,
             );
@@ -796,15 +875,18 @@ export function App() {
       return;
     }
     analyticsRefreshInFlightRef.current = true;
+    const now = Date.now();
     const request =
-      analyticsTab === 'skills' ? fetchSkillsTools() : Promise.all([fetchAnalytics(), fetchAnalyticsHeatmap()]);
+      analyticsTab === 'skills'
+        ? fetchSkillsTools()
+        : Promise.all([fetchAnalytics(false, now), fetchAnalyticsHeaviest(false, now), fetchAnalyticsHeatmap()]);
     Promise.resolve(request).finally(() => {
       analyticsRefreshInFlightRef.current = false;
       if (!analyticsRefreshDirtyRef.current) return;
       analyticsRefreshDirtyRef.current = false;
       refreshAnalyticsRef.current();
     });
-  }, [analyticsTab, fetchAnalytics, fetchAnalyticsHeatmap, fetchSkillsTools]);
+  }, [analyticsTab, fetchAnalytics, fetchAnalyticsHeaviest, fetchAnalyticsHeatmap, fetchSkillsTools]);
 
   // refreshAll keeps one refresh cycle in flight. An event arriving while
   // a cycle runs marks at most one follow-up refresh as due instead of
@@ -895,8 +977,11 @@ export function App() {
   }, [fetchTokens]);
 
   useEffect(() => {
-    if (view === 'analytics' && analyticsTab === 'overview') fetchAnalytics(true);
-  }, [view, analyticsTab, fetchAnalytics]);
+    if (view !== 'analytics' || analyticsTab !== 'overview') return;
+    const now = Date.now();
+    fetchAnalytics(true, now);
+    fetchAnalyticsHeaviest(true, now);
+  }, [view, analyticsTab, fetchAnalytics, fetchAnalyticsHeaviest]);
 
   useEffect(() => {
     if (view === 'analytics' && analyticsTab === 'overview') fetchAnalyticsHeatmap(true);
@@ -1274,9 +1359,15 @@ export function App() {
               <AnalyticsOverviewContent
                 conversations={analyticsConversations}
                 previousConversations={analyticsPreviousConversations}
+                heaviestConversations={analyticsHeaviestConversations}
+                heaviestTotalConversations={analyticsHeaviestTotalConversations}
+                heaviestRankingExact={analyticsHeaviestRankingExact}
+                heaviestLoading={loadingAnalyticsHeaviest}
+                heaviestError={errAnalyticsHeaviest}
                 aggregate={analyticsAggregate}
                 previousAggregate={analyticsPreviousAggregate}
                 facetConversations={analyticsFacetConversations}
+                facetAggregate={analyticsFacetAggregate}
                 totalConversations={analyticsTotalConversations}
                 previousTotalConversations={analyticsPreviousTotalConversations}
                 facetTotalConversations={analyticsFacetTotalConversations}
@@ -1292,6 +1383,7 @@ export function App() {
                 tokenError={errAnalyticsTokens}
                 heatmapError={errAnalyticsHeatmap}
                 unit={analyticsUnit}
+                prices={analyticsModelPrices}
                 onUnitChange={setAnalyticsUnit}
                 timeRange={analyticsRange}
                 onTimeRangeChange={setAnalyticsRange}
@@ -1300,7 +1392,7 @@ export function App() {
                 hiddenSeries={analyticsHiddenSeries}
                 onToggleSeries={toggleAnalyticsSeries}
                 onRefresh={refreshAnalytics}
-                refreshing={loadingAnalytics || loadingAnalyticsHeatmap}
+                refreshing={loadingAnalytics || loadingAnalyticsHeaviest || loadingAnalyticsHeatmap}
                 onOpenConversation={openConv}
                 onOpenWorkspace={openAnalyticsWorkspace}
                 onOpenBucket={openAnalyticsBucket}

--- a/plugins/agento11y/internal/local/web/src/conversations.tsx
+++ b/plugins/agento11y/internal/local/web/src/conversations.tsx
@@ -17,6 +17,7 @@ import {
   formatBucketLabel,
   formatCost,
   formatDuration,
+  formatInteger,
   formatTokens,
   NO_VALUE,
   splitWorkspacePath,
@@ -789,6 +790,7 @@ interface WorkspaceFacetProps {
   totalCost: number | null;
   now: number;
   rangeLabel: string;
+  countLabel?: string;
   fromRows?: boolean;
 }
 
@@ -800,6 +802,7 @@ export function WorkspaceFacet({
   totalCost,
   now,
   rangeLabel,
+  countLabel = 'workspaces',
   fromRows = false,
 }: WorkspaceFacetProps) {
   const [open, setOpen] = useState(false);
@@ -904,7 +907,9 @@ export function WorkspaceFacet({
     }
   };
 
-  const triggerCount = selectedPath ? `${selectedInRange ? 1 : 0}/${workspaces.length}` : String(workspaces.length);
+  const triggerCount = selectedPath
+    ? `${formatInteger(selectedInRange ? 1 : 0)}/${formatInteger(workspaces.length)}`
+    : formatInteger(workspaces.length);
 
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: Child controls own focus; the wrapper handles their keyboard events.
@@ -978,7 +983,7 @@ export function WorkspaceFacet({
               )}
             </Fragment>
           ) : (
-            <span style={{ whiteSpace: 'nowrap' }}>All workspaces</span>
+            <span style={{ whiteSpace: 'nowrap' }}>All {countLabel}</span>
           )}
         </span>
         <span
@@ -1081,7 +1086,7 @@ export function WorkspaceFacet({
                 textAlign: 'left',
               }}
             >
-              <span>All workspaces</span>
+              <span>All {countLabel}</span>
               <span
                 style={{
                   color: 'var(--fg3)',
@@ -1089,7 +1094,7 @@ export function WorkspaceFacet({
                   fontSize: 11,
                 }}
               >
-                {totalCount} · {formatCost(totalCost)}
+                {formatInteger(totalCount)} · {formatCost(totalCost)}
               </span>
             </button>
             <div
@@ -1179,7 +1184,7 @@ export function WorkspaceFacet({
                         textAlign: 'right',
                       }}
                     >
-                      {w.count}
+                      {formatInteger(w.count)}
                     </span>
                     <span
                       style={{
@@ -1255,8 +1260,8 @@ export function WorkspaceFacet({
             }}
           >
             <span>
-              {workspaces.length} workspaces · {rangeLabel}
-              {fromRows ? ` · from the ${totalCount} listed sessions` : ''}
+              {formatInteger(workspaces.length)} {countLabel} · {rangeLabel}
+              {fromRows ? ` · from the ${formatInteger(totalCount)} listed sessions` : ''}
             </span>
             <span>sessions · cost · share</span>
           </div>

--- a/plugins/agento11y/internal/local/web/src/formatters.ts
+++ b/plugins/agento11y/internal/local/web/src/formatters.ts
@@ -12,6 +12,10 @@ import type { ModelCost, ModelPrices, TokenBucketKey, TokenBuckets, TokenUsagePo
 // all read the same in a table.
 export const NO_VALUE = '-';
 
+export function formatInteger(value: number): string {
+  return Math.round(value).toLocaleString('en-US');
+}
+
 export function formatTokens(n: number | null | undefined): string {
   if (n == null || Number.isNaN(Number(n))) return NO_VALUE;
   if (n < 1000) return String(n);
@@ -258,6 +262,23 @@ function modelPrice(model: string | null | undefined): BundledModelPrice | null 
   return MODEL_PRICES.find((p) => m.includes(p.match)) || null;
 }
 
+export function maximumEstimatedTokenRate(prices: ModelPrices | null | undefined): number {
+  let maximum = Math.max(...MODEL_PRICES.flatMap((price) => [price.in, price.out, price.in * 1.25]));
+  for (const price of Object.values(prices || {})) {
+    const input = price.input;
+    if (input == null || !Number.isFinite(input)) continue;
+    for (const rate of [
+      input,
+      price.output ?? input,
+      price.cache_read ?? input * 0.1,
+      price.cache_write ?? input * 1.25,
+    ]) {
+      if (Number.isFinite(rate)) maximum = Math.max(maximum, rate);
+    }
+  }
+  return maximum;
+}
+
 // Cursor hosted Grok SKUs are `cursor-grok-4.6-high-fast`. models.dev (and
 // the Cloud catalog) key the same model as `grok-4.6`. Keep this suffix
 // list in sync with canonicalizeCursorModel in the cursor mapper.
@@ -361,12 +382,12 @@ function loadModelPrices(): Promise<ModelPrices> {
   return modelPricesPromise;
 }
 
-// useModelPrices resolves to the flattened models.dev map, or null while
-// loading / when the fetch fails (the daemon may be offline). Callers must
-// tolerate null and fall back to the bundled table.
-export function useModelPrices(): ModelPrices | null {
+// Returns null until prices load. Disabling the hook stops loading but keeps
+// prices already loaded. Callers must use the bundled table while null.
+export function useModelPrices(enabled = true): ModelPrices | null {
   const [prices, setPrices] = useState<ModelPrices | null>(null);
   useEffect(() => {
+    if (!enabled) return;
     let alive = true;
     loadModelPrices()
       .then((m) => {
@@ -376,7 +397,7 @@ export function useModelPrices(): ModelPrices | null {
     return () => {
       alive = false;
     };
-  }, []);
+  }, [enabled]);
   return prices;
 }
 

--- a/plugins/agento11y/internal/local/web/src/settings-screen.tsx
+++ b/plugins/agento11y/internal/local/web/src/settings-screen.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties, ReactNode } from 'react';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { markdownURL } from './detail';
+import { formatInteger } from './formatters';
 import { HistoryDatePicker, localDateStartISO } from './history-date-picker';
 import type { NoticeKind } from './notices';
 import {
@@ -206,7 +207,7 @@ export function useHistoryImport(liveRun: ImportRunView | null | undefined): His
 
 function formatImportTurns(offer: Pick<HistoryOffer, 'turns' | 'approx_turns'>): string {
   const turns = offer.turns || 0;
-  const count = `${turns.toLocaleString()} turn${turns === 1 ? '' : 's'}`;
+  const count = `${formatInteger(turns)} turn${turns === 1 ? '' : 's'}`;
   return offer.approx_turns ? `about ${count}` : count;
 }
 
@@ -2579,7 +2580,7 @@ export function SettingsHistoryTab({ history }: SettingsHistoryTabProps) {
           ) : planError ? (
             <span style={{ color: 'var(--error-text)' }}>{planError}</span>
           ) : (
-            `${sessions.length} sessions · ${approx ? 'about ' : ''}${turns.toLocaleString()} turns`
+            `${formatInteger(sessions.length)} sessions · ${approx ? 'about ' : ''}${formatInteger(turns)} turns`
           )}
         </div>
       </SettingRow>
@@ -2659,9 +2660,9 @@ function HistoryImportStatus({ run }: HistoryImportStatusProps) {
                 gap: '2px 12px',
               }}
             >
-              <span>{(run.imported || 0).toLocaleString()} turns imported</span>
-              <span>{(run.skipped || 0).toLocaleString()} already imported</span>
-              <span>{(run.failed || 0).toLocaleString()} failed</span>
+              <span>{formatInteger(run.imported || 0)} turns imported</span>
+              <span>{formatInteger(run.skipped || 0)} already imported</span>
+              <span>{formatInteger(run.failed || 0)} failed</span>
             </span>
           </div>
         )}

--- a/plugins/agento11y/internal/local/web/src/skills-tools.tsx
+++ b/plugins/agento11y/internal/local/web/src/skills-tools.tsx
@@ -2,7 +2,7 @@ import type { MouseEvent as ReactMouseEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { AnalyticsPage } from './analytics-page';
 import { ChartXLabels, ChartYAxis, TimeRangePicker, type WorkspaceAggregate, WorkspaceFacet } from './conversations';
-import { formatBucketLabel, timeRangeOption } from './formatters';
+import { formatBucketLabel, formatInteger, timeRangeOption } from './formatters';
 import { Notice, SurfaceCard } from './notices';
 import { type AnalyticsTab, isPlainLeftClick, type ToolSessionFilters, toolSessionsPath } from './routing';
 import { Icon, iconBtn } from './shell';
@@ -32,10 +32,6 @@ export interface SkillsToolsViewProps {
   refreshing: boolean;
   onSelectTab: (tab: AnalyticsTab) => void;
   onOpenSessions: (filters: ToolSessionFilters) => void;
-}
-
-function integer(value: number) {
-  return Math.max(0, value || 0).toLocaleString();
 }
 
 function duration(value: number | undefined) {
@@ -179,11 +175,12 @@ function ToolTable({
     <SurfaceCard className="tools-table-panel" style={{ marginBottom: 12 }}>
       <div className="tools-panel-header">
         <div className="tools-mode-label">
-          Tools <span>{data?.totals.tools || 0}</span>
+          Tools <span>{formatInteger(Math.max(0, data?.totals.tools || 0))}</span>
         </div>
         <div className="tools-panel-caption">
-          {integer(data?.totals.failures || 0)} of {integer(data?.totals.calls || 0)} failed · duration from{' '}
-          {integer(data?.totals.duration_samples || 0)} tool-execution spans
+          {formatInteger(Math.max(0, data?.totals.failures || 0))} of{' '}
+          {formatInteger(Math.max(0, data?.totals.calls || 0))} failed · duration from{' '}
+          {formatInteger(Math.max(0, data?.totals.duration_samples || 0))} tool-execution spans
         </div>
       </div>
       <div className="tools-table-scroll">
@@ -255,9 +252,9 @@ function ToolTable({
                       <span className="tools-share-fill" style={{ width: `${(row.calls / maxCalls) * 100}%` }} />
                     </span>
                   </td>
-                  <td>{integer(row.calls)}</td>
+                  <td>{formatInteger(Math.max(0, row.calls || 0))}</td>
                   <td style={{ color: failureRate > 0.05 ? 'var(--error-text)' : 'var(--fg3)' }}>
-                    {integer(row.failures)}
+                    {formatInteger(Math.max(0, row.failures || 0))}
                   </td>
                   <td style={{ color: (row.p50_duration_seconds || 0) > 10 ? 'var(--warning-text)' : 'var(--fg2)' }}>
                     {duration(row.p50_duration_seconds)}
@@ -265,7 +262,7 @@ function ToolTable({
                   <td style={{ color: (row.p95_duration_seconds || 0) > 10 ? 'var(--warning-text)' : 'var(--fg2)' }}>
                     {duration(row.p95_duration_seconds)}
                   </td>
-                  <td>{integer(row.sessions)}</td>
+                  <td>{formatInteger(Math.max(0, row.sessions || 0))}</td>
                 </tr>
               );
             })}
@@ -354,7 +351,7 @@ function ToolChart({ buckets, intervalSeconds, workspace, window, loading, error
           <div className="tools-chart-state">No tool calls to chart in this range.</div>
         ) : (
           <div style={{ position: 'relative' }}>
-            <ChartYAxis top={integer(chart.max)} mid={integer(Math.ceil(chart.max / 2))} />
+            <ChartYAxis top={formatInteger(chart.max)} mid={formatInteger(Math.ceil(chart.max / 2))} />
             <div className="tools-chart-plot">
               {chart.columns.map((column) => (
                 <div className="tools-chart-column" key={column.start}>
@@ -373,7 +370,7 @@ function ToolChart({ buckets, intervalSeconds, workspace, window, loading, error
                           key={series.name}
                           href={toolSessionsPath(filters)}
                           aria-label={`${series.name}, ${calls} ${calls === 1 ? 'call' : 'calls'}, ${formatBucketLabel(column.start, intervalMs)}`}
-                          title={`${series.name}: ${integer(calls)} ${calls === 1 ? 'call' : 'calls'}`}
+                          title={`${series.name}: ${formatInteger(calls)} ${calls === 1 ? 'call' : 'calls'}`}
                           style={{ flex: calls, background: series.color }}
                           onClick={(event: ReactMouseEvent<HTMLAnchorElement>) => {
                             if (!isPlainLeftClick(event)) return;
@@ -404,9 +401,9 @@ export type SkillsToolsContentProps = Omit<SkillsToolsViewProps, 'onSelectTab'>;
 
 export function skillsToolsHeroStats(data: ToolAnalytics | null) {
   return [
-    { label: 'Sessions', value: integer(data?.totals.sessions || 0) },
-    { label: 'Tools', value: integer(data?.totals.tools || 0) },
-    { label: 'Calls', value: integer(data?.totals.calls || 0) },
+    { label: 'Sessions with tool calls', value: formatInteger(Math.max(0, data?.totals.sessions || 0)) },
+    { label: 'Tools', value: formatInteger(Math.max(0, data?.totals.tools || 0)) },
+    { label: 'Calls', value: formatInteger(Math.max(0, data?.totals.calls || 0)) },
   ];
 }
 
@@ -462,20 +459,25 @@ export function SkillsToolsContent(props: SkillsToolsContentProps) {
   return (
     <>
       <div className="tools-stat-strip">
-        {stat('tool calls', integer(data?.totals.calls || 0))}
+        {stat('tool calls', formatInteger(Math.max(0, data?.totals.calls || 0)))}
         {stat(
           'failed',
-          `${integer(data?.totals.failures || 0)} · ${failureRate.toFixed(1)}%`,
+          `${formatInteger(Math.max(0, data?.totals.failures || 0))} · ${failureRate.toFixed(1)}%`,
           (data?.totals.failures || 0) > 0 ? 'var(--error-text)' : undefined,
         )}
-        {stat('tools used', integer(data?.totals.tools || 0))}
+        {stat('tools used', formatInteger(Math.max(0, data?.totals.tools || 0)))}
         {stat(
           'slowest p95',
           slowest ? duration(slowest.p95_duration_seconds) : '-',
           (slowest?.p95_duration_seconds || 0) > 10 ? 'var(--warning-text)' : undefined,
           slowest?.name,
         )}
-        {stat('timed calls', `${integer(data?.totals.duration_samples || 0)}/${integer(data?.totals.calls || 0)}`)}
+        {stat(
+          'timed calls',
+          `${formatInteger(Math.max(0, data?.totals.duration_samples || 0))}/${formatInteger(
+            Math.max(0, data?.totals.calls || 0),
+          )}`,
+        )}
       </div>
       <div className="tools-filter-bar">
         <label className="tools-search">
@@ -492,6 +494,7 @@ export function SkillsToolsContent(props: SkillsToolsContentProps) {
           totalCost={null}
           now={Date.now()}
           rangeLabel={range.label}
+          countLabel="workspaces with tool calls"
         />
         <TimeRangePicker value={props.timeRange} onChange={props.onTimeRangeChange} />
         <button

--- a/plugins/agento11y/internal/local/web/src/types.ts
+++ b/plugins/agento11y/internal/local/web/src/types.ts
@@ -5,9 +5,8 @@
 // the SDK shares. Nothing checks the two against each other, so a renamed
 // `json:` tag shows up here as a field the viewer reads and never finds.
 //
-// Optional fields are the ones whose Go tag carries `omitempty`: the daemon
-// leaves them out of the object rather than sending a zero. Timestamps are
-// RFC 3339 strings.
+// Optional fields either carry `omitempty` in Go or were added after the first
+// response version. Timestamps are RFC 3339 strings.
 
 /** TokenBuckets in query.go: one generation's usage, split into disjoint parts. */
 export interface TokenBuckets {
@@ -47,6 +46,15 @@ export interface ConversationListResponse {
   total_conversations: number;
 }
 
+export interface WorkspaceMetricsAggregate {
+  path: string;
+  sessions: number;
+  token_buckets: TokenBuckets;
+  token_buckets_by_model: Record<string, TokenBuckets>;
+  duration_seconds: number;
+  last_activity: string;
+}
+
 export interface ConversationMetricsAggregate {
   calls: number;
   errored: number;
@@ -56,6 +64,7 @@ export interface ConversationMetricsAggregate {
   token_buckets: TokenBuckets;
   token_buckets_by_model: Record<string, TokenBuckets>;
   models: string[];
+  workspace_rows?: WorkspaceMetricsAggregate[];
 }
 
 export interface ConversationMetricsResponse {

--- a/plugins/agento11y/tests/analytics.test.tsx
+++ b/plugins/agento11y/tests/analytics.test.tsx
@@ -6,10 +6,18 @@ import {
   type AnalyticsUnit,
   AnalyticsView,
   type AnalyticsViewProps,
+  heaviestCostPageNeedsMore,
+  heaviestCostRankingIsExact,
 } from '../internal/local/web/src/analytics';
 import { App } from '../internal/local/web/src/app';
 import { conversationsPath, workspaceFromLocation } from '../internal/local/web/src/routing';
-import type { ConversationSummary, ModelPrices, TokenBuckets, TokenUsagePoint } from '../internal/local/web/src/types';
+import type {
+  ConversationMetricsAggregate,
+  ConversationSummary,
+  ModelPrices,
+  TokenBuckets,
+  TokenUsagePoint,
+} from '../internal/local/web/src/types';
 
 afterEach(() => {
   cleanup();
@@ -44,20 +52,35 @@ function conversation(overrides: Partial<ConversationSummary> = {}): Conversatio
   };
 }
 
-function efficientConversation(): ConversationSummary {
-  const buckets = { ...EMPTY, fresh_input: 200_000 };
+function efficientConversation(overrides: Partial<ConversationSummary> = {}): ConversationSummary {
+  const buckets = overrides.token_buckets || { ...EMPTY, fresh_input: 200_000 };
   return conversation({
     id: 'session-efficient',
     title: 'Large but efficient',
     started_at: '2026-04-12T09:00:00Z',
     last_activity: '2026-04-12T10:30:00Z',
     calls: 3,
-    input_tokens: 200_000,
-    total_tokens: 200_000,
-    token_buckets: buckets,
+    input_tokens: buckets.fresh_input + buckets.cache_read + buckets.cache_write,
+    output_tokens: buckets.output,
+    total_tokens: Object.values(buckets).reduce((sum, value) => sum + value, 0),
     token_buckets_by_model: { 'efficient-model': buckets },
     models: ['efficient-model'],
     workspace: '/worktrees/efficient',
+    ...overrides,
+    token_buckets: buckets,
+  });
+}
+
+function bundledConversation(id: string, tokens: number, model: string): ConversationSummary {
+  const buckets = { ...EMPTY, fresh_input: tokens };
+  return conversation({
+    id,
+    title: id,
+    input_tokens: tokens,
+    total_tokens: tokens,
+    token_buckets: buckets,
+    token_buckets_by_model: { [model]: buckets },
+    models: [model],
   });
 }
 
@@ -193,8 +216,14 @@ describe('App analytics loading', () => {
 
     render(<App />);
 
-    await waitFor(() => expect(screen.getByText('Costly but compact')).toBeTruthy());
+    await waitFor(() => expect(document.querySelector('a[data-session-id="session-costly"]')).toBeTruthy());
     expect(fetchMock.mock.calls.some(([url]) => String(url).includes('interval=900'))).toBe(true);
+    expect(
+      fetchMock.mock.calls.some(([url]) => {
+        const parsed = new URL(String(url), 'http://local');
+        return parsed.pathname === '/api/v1/metrics/conversations' && parsed.searchParams.get('order') === 'tokens';
+      }),
+    ).toBe(true);
     expect(fetchMock.mock.calls.some(([url]) => String(url).startsWith('/api/v1/metrics/tools?'))).toBe(false);
 
     const session = document.querySelector<HTMLAnchorElement>('a[data-session-id="session-costly"]');
@@ -206,6 +235,184 @@ describe('App analytics loading', () => {
     fireEvent.click(back);
     expect(window.location.pathname).toBe('/analytics');
     expect(screen.getByRole('heading', { name: 'Analytics' })).toBeTruthy();
+  });
+  it('grows the token-ordered page until the cost ranking is proven', async () => {
+    window.history.replaceState({}, '', '/analytics');
+    const stored = new Map<string, string>();
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => stored.get(key) ?? null,
+      setItem: (key: string, value: string) => stored.set(key, value),
+      removeItem: (key: string) => stored.delete(key),
+    });
+    const cheap = Array.from({ length: 64 }, (_, index) =>
+      bundledConversation(`cheap-${index}`, 100_000, 'claude-haiku-4-5'),
+    );
+    const costliest = bundledConversation('costliest-outside-newest-page', 90_000, 'claude-opus-4-8');
+    const ordered = [
+      ...cheap,
+      costliest,
+      ...Array.from({ length: 35 }, (_, index) => bundledConversation(`tail-${index}`, 1_000, 'claude-haiku-4-5')),
+    ];
+    const response = (body: unknown): Response =>
+      ({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(body),
+        text: () => Promise.resolve(''),
+      }) as Response;
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = new URL(String(input), 'http://local');
+      if (url.pathname === '/api/v1/metrics/conversations') {
+        if (url.searchParams.get('order') === 'tokens') {
+          const limit = Number(url.searchParams.get('limit'));
+          return Promise.resolve(
+            response({ conversations: ordered.slice(0, limit), matched_conversations: ordered.length }),
+          );
+        }
+        return Promise.resolve(response({ conversations: cheap.slice(0, 1), matched_conversations: ordered.length }));
+      }
+      if (url.pathname === '/api/v1/metrics/tokens') {
+        return Promise.resolve(response({ points: [], interval_seconds: 3600 }));
+      }
+      if (url.pathname === '/api/v1/conversations') {
+        return Promise.resolve(response({ conversations: [], total_conversations: 0 }));
+      }
+      if (url.pathname === '/api.json') return Promise.resolve(response({}));
+      if (url.pathname === '/api/v1/config') return Promise.resolve(response({}));
+      return Promise.resolve(response({}));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+
+    await waitFor(() =>
+      expect(firstAttribute('[data-session-id]', 'data-session-id')).toBe('costliest-outside-newest-page'),
+    );
+    const metricRequests = fetchMock.mock.calls
+      .map(([input]) => new URL(String(input), 'http://local'))
+      .filter((url) => url.pathname === '/api/v1/metrics/conversations');
+    const firstCurrentRequest = metricRequests.find((url) => url.searchParams.get('order') == null);
+    const firstRankedRequest = metricRequests.find((url) => url.searchParams.get('order') === 'tokens');
+    expect(firstRankedRequest?.searchParams.get('before')).toBe(firstCurrentRequest?.searchParams.get('before'));
+    const rankedLimits = metricRequests
+      .filter((url) => url.searchParams.get('order') === 'tokens')
+      .map((url) => url.searchParams.get('limit'));
+    expect(rankedLimits).toContain('64');
+    expect(rankedLimits).toContain('100');
+    await waitFor(() => expect(screen.getByText('top 6 of 100 by cost')).toBeTruthy());
+  });
+
+  it('does not claim an exact full-range ranking when a session has unpriced usage', async () => {
+    window.history.replaceState({}, '', '/analytics');
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+    const priced = { ...EMPTY, fresh_input: 100_000 };
+    const unpriced = { ...EMPTY, output: 100_000 };
+    const partial = conversation({
+      id: 'partially-priced',
+      title: 'Partially priced',
+      token_buckets: { ...EMPTY, fresh_input: 100_000, output: 100_000 },
+      token_buckets_by_model: {
+        'claude-haiku-4-5': priced,
+        'unlisted-model': unpriced,
+      },
+      models: ['claude-haiku-4-5', 'unlisted-model'],
+    });
+    const complete = bundledConversation('fully-priced', 100_000, 'claude-opus-4-8');
+    const response = (body: unknown): Response =>
+      ({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(body),
+        text: () => Promise.resolve(''),
+      }) as Response;
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = new URL(String(input), 'http://local');
+      if (url.pathname === '/api/v1/metrics/conversations') {
+        return Promise.resolve(response({ conversations: [partial, complete], matched_conversations: 2 }));
+      }
+      if (url.pathname === '/api/v1/metrics/tokens') {
+        return Promise.resolve(response({ points: [], interval_seconds: 3600 }));
+      }
+      if (url.pathname === '/api/v1/conversations') {
+        return Promise.resolve(response({ conversations: [], total_conversations: 0 }));
+      }
+      if (url.pathname === '/api.json') return new Promise<Response>(() => {});
+      return Promise.resolve(response({}));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText('2 shown of 2 by cost')).toBeTruthy());
+    expect(screen.queryByText('top 2 of 2 by cost')).toBeNull();
+    expect(
+      screen.getByText(
+        /Every session in range is included, but incomplete cost estimates prevent an exact cost ranking/,
+      ),
+    ).toBeTruthy();
+    const rankedLimits = fetchMock.mock.calls
+      .map(([input]) => new URL(String(input), 'http://local'))
+      .filter((url) => url.pathname === '/api/v1/metrics/conversations' && url.searchParams.get('order') === 'tokens')
+      .map((url) => url.searchParams.get('limit'));
+    expect(rankedLimits.length).toBeGreaterThan(0);
+    expect(new Set(rankedLimits)).toEqual(new Set(['64']));
+  });
+
+  it('stops after three retries when the cost bound stays inconclusive', async () => {
+    window.history.replaceState({}, '', '/analytics');
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+    const response = (body: unknown): Response =>
+      ({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(body),
+        text: () => Promise.resolve(''),
+      }) as Response;
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = new URL(String(input), 'http://local');
+      if (url.pathname === '/api/v1/metrics/conversations') {
+        if (url.searchParams.get('order') === 'tokens') {
+          const limit = Number(url.searchParams.get('limit'));
+          return Promise.resolve(
+            response({
+              conversations: Array.from({ length: Math.min(limit, 10_000) }, (_, index) =>
+                bundledConversation(`same-rate-${index}`, 100_000, 'claude-haiku-4-5'),
+              ),
+              matched_conversations: 100_000,
+            }),
+          );
+        }
+        return Promise.resolve(response({ conversations: [], matched_conversations: 100_000 }));
+      }
+      if (url.pathname === '/api/v1/metrics/tokens') {
+        return Promise.resolve(response({ points: [], interval_seconds: 3600 }));
+      }
+      if (url.pathname === '/api/v1/conversations') {
+        return Promise.resolve(response({ conversations: [], total_conversations: 0 }));
+      }
+      if (url.pathname === '/api.json') return new Promise<Response>(() => {});
+      return Promise.resolve(response({}));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText(/sessions outside this set may rank higher/)).toBeTruthy());
+    const rankedLimits = fetchMock.mock.calls
+      .map(([input]) => new URL(String(input), 'http://local'))
+      .filter((url) => url.pathname === '/api/v1/metrics/conversations' && url.searchParams.get('order') === 'tokens')
+      .map((url) => url.searchParams.get('limit'));
+    const retryLimits = ['64', '512', '4096', '100000'];
+    expect(rankedLimits.length).toBeGreaterThanOrEqual(retryLimits.length);
+    expect(rankedLimits.every((limit, index) => limit === retryLimits[index % retryLimits.length])).toBe(true);
   });
 });
 
@@ -223,6 +430,89 @@ describe('AnalyticsView', () => {
     expect(firstAttribute('[data-model-row]', 'data-model-row')).toBe('efficient-model');
     expect(firstAttribute('a[href^="/?workspace="]', 'href')).toContain('efficient');
     expect(firstAttribute('[data-session-id]', 'data-session-id')).toBe('session-efficient');
+  });
+
+  it('ranks Heaviest sessions from its whole-range candidate page', () => {
+    const costlyOutsidePage = conversation({
+      id: 'outside-newest-page',
+      title: 'Costliest outside newest page',
+      token_buckets: { ...EMPTY, fresh_input: 90_000 },
+      token_buckets_by_model: { 'costly-model': { ...EMPTY, fresh_input: 90_000 } },
+      total_tokens: 90_000,
+    });
+    const ranked = [
+      costlyOutsidePage,
+      ...Array.from({ length: 5 }, (_, index) =>
+        efficientConversation({ id: `ranked-${index}`, title: `Ranked ${index}` }),
+      ),
+    ];
+
+    render(
+      <AnalyticsView
+        {...viewProps({
+          conversations: [efficientConversation()],
+          totalConversations: 3443,
+          heaviestConversations: ranked,
+          heaviestTotalConversations: 3443,
+          heaviestRankingExact: true,
+        })}
+      />,
+    );
+
+    expect(firstAttribute('[data-session-id]', 'data-session-id')).toBe('outside-newest-page');
+    expect(screen.getByText('top 6 of 3,443 by cost')).toBeTruthy();
+    expect(screen.getByText('tokens / session · based on 1 session')).toBeTruthy();
+  });
+
+  it('refetches a token-ordered page when unseen cost can exceed sixth place', () => {
+    const returned = Array.from({ length: 64 }, (_, index) =>
+      efficientConversation({ id: `returned-${index}`, token_buckets: { ...EMPTY, fresh_input: 100_000 } }),
+    );
+    expect(heaviestCostPageNeedsMore(returned, 100, PRICES)).toBe(true);
+
+    const proven = returned.map((row, index) =>
+      index < 6
+        ? conversation({ id: `high-cost-${index}`, token_buckets: { ...EMPTY, fresh_input: 1_000_000 } })
+        : efficientConversation({ id: row.id, token_buckets: { ...EMPTY, fresh_input: 1 } }),
+    );
+    expect(heaviestCostPageNeedsMore(proven, 100, PRICES)).toBe(false);
+    expect(heaviestCostRankingIsExact(proven, 100, PRICES)).toBe(true);
+  });
+
+  it('does not prove a full candidate page whose costs are incomplete', () => {
+    const priced = { ...EMPTY, fresh_input: 100_000 };
+    const unpriced = { ...EMPTY, output: 100_000 };
+    const partial = conversation({
+      token_buckets: { ...EMPTY, fresh_input: 100_000, output: 100_000 },
+      token_buckets_by_model: {
+        'costly-model': priced,
+        'unlisted-model': unpriced,
+      },
+      models: ['costly-model', 'unlisted-model'],
+    });
+
+    const complete = conversation({ id: 'fully-priced' });
+
+    expect(heaviestCostPageNeedsMore([partial, complete], 2, PRICES)).toBe(false);
+    expect(heaviestCostRankingIsExact([partial, complete], 2, PRICES)).toBe(false);
+  });
+
+  it('uses the whole-range denominator when the ranked request fails', () => {
+    render(
+      <AnalyticsView
+        {...viewProps({
+          conversations: [],
+          totalConversations: 3443,
+          heaviestConversations: [],
+          heaviestTotalConversations: null,
+          heaviestRankingExact: false,
+          heaviestError: 'HTTP 500',
+        })}
+      />,
+    );
+
+    expect(screen.getByText('0 shown of 3,443 by cost')).toBeTruthy();
+    expect(screen.getByText('Failed to load ranked sessions: HTTP 500')).toBeTruthy();
   });
 
   it('shows a range-specific message in every data panel when the range is empty', () => {
@@ -256,14 +546,15 @@ describe('AnalyticsView', () => {
         })}
       />,
     );
-    expect(screen.getByText(/Coverage: session panels use 2 returned sessions from 19 in range/)).toBeTruthy();
+    expect(screen.getByText('tokens / session · based on 2 sessions')).toBeTruthy();
+    expect(screen.getByText(/Session distribution is based on 2 of 19 sessions in range/)).toBeTruthy();
     expect(screen.getByText(/Token charts and trends cover all generations in range/)).toBeTruthy();
     expect(screen.getByText(/Previous-period comparisons are unavailable: 1 of 7 sessions returned/)).toBeTruthy();
     expect(screen.queryByText(/vs previous period$/)).toBeNull();
   });
 
   it('uses uncapped aggregates for KPI totals and comparisons', () => {
-    const aggregate = {
+    const aggregate: ConversationMetricsAggregate = {
       calls: 12,
       errored: 1,
       agents: 2,
@@ -275,8 +566,34 @@ describe('AnalyticsView', () => {
         unknown: { ...EMPTY, fresh_input: 100_000, cache_read: 100_000 },
       },
       models: ['costly-model', 'unknown'],
+      workspace_rows: [
+        {
+          path: '/aggregate-only',
+          sessions: 1,
+          token_buckets: { ...EMPTY, fresh_input: 300_000 },
+          token_buckets_by_model: { 'costly-model': { ...EMPTY, fresh_input: 300_000 } },
+          duration_seconds: 600,
+          last_activity: '2026-04-12T11:30:00Z',
+        },
+        {
+          path: '/worktrees/costly',
+          sessions: 1,
+          token_buckets: { ...EMPTY, fresh_input: 100_000 },
+          token_buckets_by_model: { 'costly-model': { ...EMPTY, fresh_input: 100_000 } },
+          duration_seconds: 3_600,
+          last_activity: '2026-04-12T11:00:00Z',
+        },
+        {
+          path: '',
+          sessions: 1,
+          token_buckets: { ...EMPTY },
+          token_buckets_by_model: {},
+          duration_seconds: 0,
+          last_activity: '2026-04-12T10:00:00Z',
+        },
+      ],
     };
-    const previousAggregate = {
+    const previousAggregate: ConversationMetricsAggregate = {
       calls: 6,
       errored: 0,
       agents: 1,
@@ -293,8 +610,10 @@ describe('AnalyticsView', () => {
           previousConversations: [conversation({ id: 'previous' })],
           aggregate,
           previousAggregate,
+          facetAggregate: aggregate,
           totalConversations: 3,
           previousTotalConversations: 2,
+          facetTotalConversations: 3,
         })}
       />,
     );
@@ -314,6 +633,10 @@ describe('AnalyticsView', () => {
     expect(kpiCard('Model calls').textContent).toContain('4 avg / session');
     expect(kpiCard('Model calls').textContent).toContain('1 errored session');
     expect(document.querySelector('[data-model-row="unknown"]')).toBeTruthy();
+    const aggregateOnly = document.querySelector<HTMLAnchorElement>('a[href="/?workspace=%2Faggregate-only"]');
+    expect(aggregateOnly?.textContent).toContain('aggregate-only');
+    expect(screen.getByTitle('Filter by workspace').textContent).toContain('3');
+    expect(screen.queryByText(/Workspace options are incomplete/)).toBeNull();
     expect(
       screen.getByText(/KPI totals, model totals, token charts, and trends cover all generations in range/),
     ).toBeTruthy();
@@ -344,6 +667,14 @@ describe('AnalyticsView', () => {
     expect(range.compareDocumentPosition(refresh) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
+  it('keeps the Overview workspace copy unchanged', () => {
+    render(<AnalyticsView {...viewProps()} />);
+
+    fireEvent.click(screen.getByTitle('Filter by workspace'));
+    expect(screen.getByRole('option', { name: /^All workspaces \d/ })).toBeTruthy();
+    expect(screen.queryByText(/workspaces with tool calls/)).toBeNull();
+  });
+
   it('keeps session rows as real anchors and intercepts only plain clicks', () => {
     const onOpenConversation = vi.fn();
     render(<AnalyticsView {...viewProps({ onOpenConversation })} />);
@@ -355,6 +686,7 @@ describe('AnalyticsView', () => {
     expect(onOpenConversation).toHaveBeenCalledWith({ id: 'session-costly' });
 
     onOpenConversation.mockClear();
+    document.addEventListener('click', (event) => event.preventDefault(), { once: true });
     fireEvent.click(link, { button: 0, metaKey: true });
     expect(onOpenConversation).not.toHaveBeenCalled();
   });
@@ -364,20 +696,77 @@ describe('AnalyticsView', () => {
     expect(document.querySelector('a[href="/?workspace="]')).toBeTruthy();
   });
 
-  it('keeps a selected workspace visible when facet coverage is incomplete', () => {
+  it('reads every workspace facet option from the uncapped aggregate', () => {
     const selected = conversation({ workspace: '/outside/page' });
     render(
       <AnalyticsView
         {...viewProps({
           conversations: [selected],
+          aggregate: {
+            calls: 1,
+            errored: 0,
+            agents: 1,
+            agent_hosts: selected.agents,
+            workspaces: 1,
+            token_buckets: selected.token_buckets,
+            token_buckets_by_model: selected.token_buckets_by_model || {},
+            models: selected.models,
+            workspace_rows: [
+              {
+                path: '/outside/page',
+                sessions: 1,
+                token_buckets: selected.token_buckets,
+                token_buckets_by_model: selected.token_buckets_by_model || {},
+                duration_seconds: 3_600,
+                last_activity: selected.last_activity,
+              },
+            ],
+          },
+          facetAggregate: {
+            calls: 19,
+            errored: 0,
+            agents: 1,
+            agent_hosts: selected.agents,
+            workspaces: 3,
+            token_buckets: selected.token_buckets,
+            token_buckets_by_model: selected.token_buckets_by_model || {},
+            models: selected.models,
+            workspace_rows: ['/worktrees/costly', '/worktrees/efficient', '/outside/page'].map((path) => ({
+              path,
+              sessions: path === '/outside/page' ? 1 : 9,
+              token_buckets: { ...EMPTY },
+              token_buckets_by_model: {},
+              duration_seconds: 0,
+              last_activity: selected.last_activity,
+            })),
+          },
           totalConversations: 1,
           workspace: '/outside/page',
           facetTotalConversations: 19,
         })}
       />,
     );
-    expect(screen.getByText('Options cover 2 of 19 sessions in range.')).toBeTruthy();
-    expect(screen.getByText('1/3')).toBeTruthy();
+    expect(screen.queryByText(/Workspace options are incomplete/)).toBeNull();
+    const workspaceFilter = screen.getByTitle('Filter by workspace');
+    expect(workspaceFilter.textContent).toContain('1/3');
+    fireEvent.click(workspaceFilter);
+    expect(screen.queryByText(/listed sessions/)).toBeNull();
+  });
+
+  it('labels capped workspace fallback options as incomplete', () => {
+    render(
+      <AnalyticsView
+        {...viewProps({
+          facetConversations: [conversation(), efficientConversation()],
+          facetAggregate: null,
+          facetTotalConversations: 3443,
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Options cover 2 of 3,443 sessions in range.')).toBeTruthy();
+    fireEvent.click(screen.getByTitle('Filter by workspace'));
+    expect(screen.getByRole('option', { name: /All workspaces 3,443/ })).toBeTruthy();
   });
 
   it('draws the model-call trend from generation points, including calls without tokens', () => {

--- a/plugins/agento11y/tests/skills-tools.test.tsx
+++ b/plugins/agento11y/tests/skills-tools.test.tsx
@@ -92,6 +92,10 @@ describe('Tools analytics component', () => {
     render(<SkillsToolsView {...props()} />);
 
     expect(screen.getByRole('link', { name: 'Tools' })).toBeTruthy();
+    expect(screen.getByText('Sessions with tool calls')).toBeTruthy();
+    fireEvent.click(screen.getByTitle('Filter by workspace'));
+    expect(screen.getByRole('option', { name: /All workspaces with tool calls/ })).toBeTruthy();
+    expect(screen.getByText(/2 workspaces with tool calls/)).toBeTruthy();
     expect(screen.getByText('2 · 6.5%')).toBeTruthy();
     expect(screen.getByText('21/31')).toBeTruthy();
     expect(screen.queryByText(/Source coverage:/)).toBeNull();
@@ -116,6 +120,46 @@ describe('Tools analytics component', () => {
     expect(segment.getAttribute('href')).toBe(
       '/?tool=Bash&workspace=%2Frepo&since=2026-08-21T10%3A00%3A00.000Z&before=2026-08-21T10%3A05%3A00.000Z',
     );
+  });
+
+  it('renders one deep-link row for a case-folded tool aggregate', () => {
+    render(
+      <SkillsToolsView
+        {...props({
+          data: {
+            ...DATA,
+            totals: { ...DATA.totals, calls: 130066, tools: 1 },
+            rows: DATA.rows.slice(0, 1).map((row) => ({ ...row, calls: 130066 })),
+          },
+        })}
+      />,
+    );
+
+    expect(document.querySelectorAll('[data-tool-row]')).toHaveLength(1);
+    expect(screen.getByRole('link', { name: 'Bash' }).getAttribute('href')).toContain('tool=Bash');
+    const bash = document.querySelector<HTMLTableRowElement>('tr[data-tool-row="Bash"]');
+    expect(bash?.cells[3]?.textContent).toBe('130,066');
+  });
+
+  it('pins grouped counts when the browser locale is Dutch', () => {
+    vi.spyOn(Number.prototype, 'toLocaleString').mockImplementation(function (this: number, locales, options) {
+      return new Intl.NumberFormat(locales || 'nl-NL', options).format(Number(this));
+    });
+    render(
+      <SkillsToolsView
+        {...props({
+          data: {
+            ...DATA,
+            totals: { ...DATA.totals, calls: 200102 },
+            rows: DATA.rows.slice(0, 1).map((row) => ({ ...row, calls: 200102 })),
+          },
+        })}
+      />,
+    );
+
+    const bash = document.querySelector<HTMLTableRowElement>('tr[data-tool-row="Bash"]');
+    if (!bash) throw new Error('missing Bash row');
+    expect(bash.cells[3]?.textContent).toBe('200,102');
   });
 
   it('sorts by every data column and keeps missing durations last', () => {


### PR DESCRIPTION
The Analytics page calculated workspace totals and heaviest sessions from the 2000 newest sessions. Workspace totals now use all sessions in the selected range.
