### PR TITLE
fix(plugins/agento11y): refresh cached opencode plugin

### DIFF
--- a/plugins/agento11y/internal/agents/opencode/launch.go
+++ b/plugins/agento11y/internal/agents/opencode/launch.go
@@ -62,10 +62,13 @@ func init() {
 
 // Test seams.
 var (
-	lookPath    = exec.LookPath
-	execFn      = syscall.Exec
-	runInstall  = defaultRunInstall
-	runUpdate   = defaultRunUpdate
+	lookPath      = exec.LookPath
+	execFn        = syscall.Exec
+	runInstall    = defaultRunInstall
+	runUpdate     = defaultRunUpdate
+	runUpdateStep = func(ctx context.Context, bin string, w io.Writer, argv []string) error {
+		return launcher.RunSteps(ctx, bin, w, [][]string{argv})
+	}
 	configDirFn = defaultConfigDir
 	cacheDirFn  = defaultCacheDir
 	writeConfig = writeConfigAtomic
@@ -163,10 +166,75 @@ func defaultRunInstall(ctx context.Context, bin string, w io.Writer) error {
 	})
 }
 
-func defaultRunUpdate(ctx context.Context, bin string, w io.Writer) error {
-	return launcher.RunSteps(ctx, bin, w, [][]string{
-		{"plugin", PluginSource, "--global", "--force"},
-	})
+func defaultRunUpdate(ctx context.Context, bin string, w io.Writer) (err error) {
+	backup, err := backupCachedPlugin()
+	if err != nil {
+		return err
+	}
+	if backup != nil {
+		defer func() {
+			if err != nil {
+				err = errors.Join(err, backup.restore())
+				return
+			}
+			err = backup.discard()
+		}()
+	}
+
+	// OpenCode's --force changes config but reuses an existing package directory.
+	// --pure prevents the stale plugin from loading while the updater starts.
+	err = runUpdateStep(ctx, bin, w, []string{"plugin", PluginSource, "--global", "--force", "--pure"})
+	return err
+}
+
+type packageCacheBackup struct {
+	original string
+	root     string
+	cached   string
+}
+
+func backupCachedPlugin() (*packageCacheBackup, error) {
+	original, err := pluginCacheDir()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := os.Stat(original); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("inspect cached OpenCode plugin %s: %w", original, err)
+	}
+
+	root, err := os.MkdirTemp(filepath.Dir(original), ".agento11y-opencode-backup-*")
+	if err != nil {
+		return nil, fmt.Errorf("create OpenCode plugin cache backup: %w", err)
+	}
+	cached := filepath.Join(root, filepath.Base(original))
+	if err := os.Rename(original, cached); err != nil {
+		_ = os.RemoveAll(root)
+		return nil, fmt.Errorf("move cached OpenCode plugin %s: %w", original, err)
+	}
+	return &packageCacheBackup{original: original, root: root, cached: cached}, nil
+}
+
+func (b *packageCacheBackup) restore() error {
+	if err := os.RemoveAll(b.original); err != nil {
+		return fmt.Errorf("remove partial OpenCode plugin update %s: %w", b.original, err)
+	}
+	if err := os.Rename(b.cached, b.original); err != nil {
+		return fmt.Errorf("restore cached OpenCode plugin %s: %w", b.original, err)
+	}
+	if err := os.RemoveAll(b.root); err != nil {
+		return fmt.Errorf("remove OpenCode plugin cache backup %s: %w", b.root, err)
+	}
+	return nil
+}
+
+func (b *packageCacheBackup) discard() error {
+	if err := os.RemoveAll(b.root); err != nil {
+		return fmt.Errorf("remove stale OpenCode plugin cache backup %s: %w", b.root, err)
+	}
+	return nil
 }
 
 // migrateLegacyConfig rewrites legacy @grafana/sigil-opencode entries in
@@ -409,6 +477,14 @@ func cachedPackageSpec(source string) string {
 		return source + "@latest"
 	}
 	return source
+}
+
+func pluginCacheDir() (string, error) {
+	cache, err := cacheDirFn()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(cache, "packages", filepath.FromSlash(cachedPackageSpec(PluginSource))), nil
 }
 
 // packageVersion reads the `version` a package directory's package.json

--- a/plugins/agento11y/internal/agents/opencode/launch_test.go
+++ b/plugins/agento11y/internal/agents/opencode/launch_test.go
@@ -448,6 +448,67 @@ func TestPluginInstalled_JsonTakesPrecedenceOverJsonc(t *testing.T) {
 	assert.False(t, got, "opencode.json should take precedence")
 }
 
+func TestDefaultRunUpdateRefreshesCachedPlugin(t *testing.T) {
+	tests := []struct {
+		name        string
+		cached      bool
+		commandErr  error
+		wantVersion string
+	}{
+		{name: "replaces stale cache", cached: true, wantVersion: "0.22.0"},
+		{name: "installs with an empty cache", wantVersion: "0.22.0"},
+		{name: "restores stale cache when install fails", cached: true, commandErr: errors.New("network down"), wantVersion: "0.21.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withConfig(t, `{"plugin":["@grafana/agento11y-opencode"]}`)
+			cacheFiles := map[string]string{}
+			if tt.cached {
+				cacheFiles = map[string]string{
+					"packages/@grafana/agento11y-opencode@latest/node_modules/@grafana/agento11y-opencode/package.json": `{"name":"@grafana/agento11y-opencode","version":"0.21.0"}`,
+					"packages/@grafana/agento11y-opencode@latest/stale.txt":                                             "old cache",
+				}
+			}
+			cache := withCache(t, cacheFiles)
+			packageCache := filepath.Join(cache, "packages", filepath.FromSlash(cachedPackageSpec(PluginSource)))
+
+			previous := runUpdateStep
+			t.Cleanup(func() { runUpdateStep = previous })
+			runUpdateStep = func(_ context.Context, _ string, _ io.Writer, argv []string) error {
+				assert.Equal(t, []string{"plugin", PluginSource, "--global", "--force", "--pure"}, argv)
+				_, err := os.Stat(packageCache)
+				assert.ErrorIs(t, err, os.ErrNotExist, "stale package must be absent before opencode resolves it")
+
+				if tt.commandErr != nil {
+					require.NoError(t, os.MkdirAll(packageCache, 0o755))
+					require.NoError(t, os.WriteFile(filepath.Join(packageCache, "partial"), []byte("partial install"), 0o600))
+					return tt.commandErr
+				}
+
+				pkg := filepath.Join(packageCache, "node_modules", filepath.FromSlash(PluginName))
+				require.NoError(t, os.MkdirAll(pkg, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(pkg, "package.json"), []byte(`{"name":"@grafana/agento11y-opencode","version":"0.22.0"}`), 0o600))
+				return nil
+			}
+
+			err := defaultRunUpdate(context.Background(), "/usr/local/bin/opencode", io.Discard)
+			if tt.commandErr != nil {
+				require.ErrorIs(t, err, tt.commandErr)
+				assert.FileExists(t, filepath.Join(packageCache, "stale.txt"))
+				assert.NoFileExists(t, filepath.Join(packageCache, "partial"))
+			} else {
+				require.NoError(t, err)
+				assert.NoFileExists(t, filepath.Join(packageCache, "stale.txt"))
+			}
+			assert.Equal(t, tt.wantVersion, cachedVersion(PluginSource))
+			backups, globErr := filepath.Glob(filepath.Join(filepath.Dir(packageCache), ".agento11y-opencode-backup-*"))
+			require.NoError(t, globErr)
+			assert.Empty(t, backups)
+		})
+	}
+}
+
 func TestLaunch_RefreshesInstalledPluginWhenUpdateDue(t *testing.T) {
 	const binPath = "/usr/local/bin/opencode"
 	state := t.TempDir()


### PR DESCRIPTION
OpenCode's `plugin --force` command reuses an existing package cache, so the launcher could record a successful refresh without installing a new plugin version. Move the cached package aside while OpenCode installs, and restore it if the install fails.