### PR TITLE
feat(plugins): send conversation IDs in guard requests

### DIFF
--- a/conformance/hooks/request-postflight-guard.json
+++ b/conformance/hooks/request-postflight-guard.json
@@ -3,6 +3,7 @@
   "context": {
     "agent_name": "conformance-guard",
     "agent_version": "1.2.3",
+    "conversation_id": "conv-hooks-conformance",
     "model": {
       "provider": "anthropic",
       "name": "claude-sonnet-4"

--- a/go/agento11y/hooks_fixtures_test.go
+++ b/go/agento11y/hooks_fixtures_test.go
@@ -231,9 +231,10 @@ func postflightGuardHookRequest() HookEvaluateRequest {
 	return HookEvaluateRequest{
 		Phase: HookPhasePostflight,
 		Context: HookContext{
-			AgentName:    "conformance-guard",
-			AgentVersion: "1.2.3",
-			Model:        &HookModel{Provider: "anthropic", Name: "claude-sonnet-4"},
+			AgentName:      "conformance-guard",
+			AgentVersion:   "1.2.3",
+			ConversationID: "conv-hooks-conformance",
+			Model:          &HookModel{Provider: "anthropic", Name: "claude-sonnet-4"},
 		},
 		Input: HookInput{
 			Output: []Message{{

--- a/js/test/hooksFixtures.mjs
+++ b/js/test/hooksFixtures.mjs
@@ -80,6 +80,7 @@ export function postflightGuardRequest() {
     context: {
       agentName: 'conformance-guard',
       agentVersion: '1.2.3',
+      conversationId: 'conv-hooks-conformance',
       model: { provider: 'anthropic', name: 'claude-sonnet-4' },
     },
     input: {

--- a/plugins/agento11y/internal/agents/claudecode/hook.go
+++ b/plugins/agento11y/internal/agents/claudecode/hook.go
@@ -260,13 +260,14 @@ func Hook(ctx context.Context, stdin io.Reader, stdout io.Writer, logger *log.Lo
 // and copilot agents.
 func handlePreToolUse(ctx context.Context, stdout io.Writer, input *hookInput, st state.Session, agentName string, logger *log.Logger) {
 	res := guard.EvaluateToolCall(ctx, envconfig.ResolveGuards(logger), guard.ToolCallInput{
-		AgentName:     agentName,
-		AgentVersion:  Version,
-		ModelProvider: "anthropic",
-		ModelName:     strings.TrimSpace(st.Model),
-		ToolName:      strings.TrimSpace(input.ToolName),
-		ToolCallID:    strings.TrimSpace(input.ToolUseID),
-		ToolInputJSON: input.ToolInput,
+		AgentName:      agentName,
+		AgentVersion:   Version,
+		ConversationID: input.SessionID,
+		ModelProvider:  "anthropic",
+		ModelName:      strings.TrimSpace(st.Model),
+		ToolName:       strings.TrimSpace(input.ToolName),
+		ToolCallID:     strings.TrimSpace(input.ToolUseID),
+		ToolInputJSON:  input.ToolInput,
 	}, logger)
 	if res.Blocked() {
 		guard.WriteHookSpecificOutputDeny(stdout, res.Reason)
@@ -283,11 +284,12 @@ func handlePreToolUse(ctx context.Context, stdout io.Writer, input *hookInput, s
 // Prompt capture still happens from the transcript at Stop.
 func handleUserPromptSubmit(ctx context.Context, stdout io.Writer, input *hookInput, st state.Session, agentName string, logger *log.Logger) {
 	res := guard.EvaluatePrompt(ctx, envconfig.ResolveGuards(logger), guard.PromptInput{
-		AgentName:     agentName,
-		AgentVersion:  Version,
-		ModelProvider: "anthropic",
-		ModelName:     strings.TrimSpace(st.Model),
-		Prompt:        input.Prompt,
+		AgentName:      agentName,
+		AgentVersion:   Version,
+		ConversationID: input.SessionID,
+		ModelProvider:  "anthropic",
+		ModelName:      strings.TrimSpace(st.Model),
+		Prompt:         input.Prompt,
 	}, logger)
 	if res.Blocked() {
 		guard.WritePromptBlock(stdout, res.Reason)

--- a/plugins/agento11y/internal/agents/claudecode/hook_test.go
+++ b/plugins/agento11y/internal/agents/claudecode/hook_test.go
@@ -1493,25 +1493,28 @@ func TestHook_AgentNameOverride(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var guardAgents, exportAgents, exportUserAgents []string
+			var guardAgents, guardConversationIDs, exportAgents, exportConversationIDs, exportUserAgents []string
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				body, _ := io.ReadAll(r.Body)
 				switch {
 				case strings.Contains(r.URL.Path, "hooks:evaluate"):
 					var req struct {
 						Context struct {
-							AgentName string `json:"agent_name"`
+							AgentName      string `json:"agent_name"`
+							ConversationID string `json:"conversation_id"`
 						} `json:"context"`
 					}
 					_ = json.Unmarshal(body, &req)
 					guardAgents = append(guardAgents, req.Context.AgentName)
+					guardConversationIDs = append(guardConversationIDs, req.Context.ConversationID)
 					w.Header().Set("Content-Type", "application/json")
 					_, _ = w.Write([]byte(`{"action":"allow"}`))
 				default:
 					var req struct {
 						Generations []struct {
-							ID        string `json:"id"`
-							AgentName string `json:"agent_name"`
+							ID             string `json:"id"`
+							AgentName      string `json:"agent_name"`
+							ConversationID string `json:"conversation_id"`
 						} `json:"generations"`
 					}
 					_ = json.Unmarshal(body, &req)
@@ -1521,6 +1524,7 @@ func TestHook_AgentNameOverride(t *testing.T) {
 					}{Results: make([]map[string]any, 0, len(req.Generations))}
 					for _, g := range req.Generations {
 						exportAgents = append(exportAgents, g.AgentName)
+						exportConversationIDs = append(exportConversationIDs, g.ConversationID)
 						resp.Results = append(resp.Results, map[string]any{"generation_id": g.ID, "accepted": true})
 					}
 					w.Header().Set("Content-Type", "application/json")
@@ -1591,6 +1595,9 @@ func TestHook_AgentNameOverride(t *testing.T) {
 			if len(guardAgents) != 1 || guardAgents[0] != wantGuard {
 				t.Fatalf("guard agent names = %v, want [%q]", guardAgents, wantGuard)
 			}
+			if len(guardConversationIDs) != 1 || guardConversationIDs[0] != sessionID {
+				t.Fatalf("guard conversation IDs = %v, want [%q]", guardConversationIDs, sessionID)
+			}
 			wantExport := []string{tt.wantAgent, tt.wantSubagent, tt.wantAgent}
 			if len(exportAgents) != len(wantExport) {
 				t.Fatalf("exported agent names = %v, want %v (logs:\n%s)", exportAgents, wantExport, logs)
@@ -1598,6 +1605,11 @@ func TestHook_AgentNameOverride(t *testing.T) {
 			for i, want := range wantExport {
 				if exportAgents[i] != want {
 					t.Fatalf("exported agent name[%d] = %q, want %q (all: %v)", i, exportAgents[i], want, exportAgents)
+				}
+			}
+			for i, got := range exportConversationIDs {
+				if got != sessionID {
+					t.Fatalf("exported conversation ID[%d] = %q, want %q", i, got, sessionID)
 				}
 			}
 			if len(exportUserAgents) == 0 {

--- a/plugins/agento11y/internal/agents/codex/hook/handlers.go
+++ b/plugins/agento11y/internal/agents/codex/hook/handlers.go
@@ -70,10 +70,11 @@ func SessionStart(p Payload, _ config.Config, logger *log.Logger) {
 // On denial it writes a block response, and Codex stops the turn.
 func UserPromptSubmit(ctx context.Context, stdout io.Writer, p Payload, cfg config.Config, logger *log.Logger) {
 	res := guard.EvaluatePrompt(ctx, cfg.Guards, guard.PromptInput{
-		AgentName:     cfg.Agent(),
-		ModelProvider: mapperutil.InferProvider(p.Model),
-		ModelName:     p.Model,
-		Prompt:        p.Prompt,
+		AgentName:      cfg.Agent(),
+		ConversationID: guardConversationID(p.SessionID, logger),
+		ModelProvider:  mapperutil.InferProvider(p.Model),
+		ModelName:      p.Model,
+		Prompt:         p.Prompt,
 	}, logger)
 	if res.Blocked() {
 		guard.WritePromptBlock(stdout, res.Reason)
@@ -81,6 +82,18 @@ func UserPromptSubmit(ctx context.Context, stdout io.Writer, p Payload, cfg conf
 	}
 
 	capturePrompt(p, cfg, logger)
+}
+
+func guardConversationID(sessionID string, logger *log.Logger) string {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return ""
+	}
+	link := fragment.LoadSubagentLinkTolerant(sessionID, logger)
+	if link != nil && strings.TrimSpace(link.ParentSessionID) != "" && strings.TrimSpace(link.ParentGenerationID) != "" {
+		return strings.TrimSpace(link.ParentSessionID)
+	}
+	return sessionID
 }
 
 func capturePrompt(p Payload, cfg config.Config, logger *log.Logger) {
@@ -105,12 +118,13 @@ func capturePrompt(p Payload, cfg config.Config, logger *log.Logger) {
 // Claude Code and Codex also share both PreToolUse envelope writers.
 func PreToolUse(ctx context.Context, stdout io.Writer, p Payload, cfg config.Config, logger *log.Logger) {
 	res := guard.EvaluateToolCall(ctx, cfg.Guards, guard.ToolCallInput{
-		AgentName:     cfg.Agent(),
-		ToolName:      p.ToolName,
-		ToolCallID:    p.ToolUseID,
-		ToolInputJSON: p.ToolInput,
-		ModelProvider: mapperutil.InferProvider(p.Model),
-		ModelName:     p.Model,
+		AgentName:      cfg.Agent(),
+		ConversationID: guardConversationID(p.SessionID, logger),
+		ToolName:       p.ToolName,
+		ToolCallID:     p.ToolUseID,
+		ToolInputJSON:  p.ToolInput,
+		ModelProvider:  mapperutil.InferProvider(p.Model),
+		ModelName:      p.Model,
 	}, logger)
 	if res.Blocked() {
 		guard.WriteHookSpecificOutputDeny(stdout, res.Reason)

--- a/plugins/agento11y/internal/agents/codex/hook/handlers_test.go
+++ b/plugins/agento11y/internal/agents/codex/hook/handlers_test.go
@@ -1007,9 +1007,19 @@ func TestPreToolUseGuard(t *testing.T) {
 func TestUserPromptSubmitGuard(t *testing.T) {
 	var responseBody atomic.Value
 	responseBody.Store("")
+	var conversationID atomic.Value
+	conversationID.Store("")
 	var calls atomic.Int32
-	server := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
+		requestBody, _ := io.ReadAll(r.Body)
+		var req struct {
+			Context struct {
+				ConversationID string `json:"conversation_id"`
+			} `json:"context"`
+		}
+		_ = json.Unmarshal(requestBody, &req)
+		conversationID.Store(req.Context.ConversationID)
 		body, _ := responseBody.Load().(string)
 		if body == "" {
 			body = `{"action":"allow"}`
@@ -1027,6 +1037,8 @@ func TestUserPromptSubmitGuard(t *testing.T) {
 		wantStdoutEmpty    bool
 		wantStdoutContains []string
 		wantCaptured       bool
+		link               *fragment.SubagentLink
+		wantConversationID string
 	}{
 		{
 			name:            "disabled_by_default_no_env",
@@ -1034,12 +1046,13 @@ func TestUserPromptSubmitGuard(t *testing.T) {
 			wantCaptured:    true,
 		},
 		{
-			name:             "enabled_allow_response",
-			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
-			serverResponds:   `{"action":"allow"}`,
-			expectServerCall: true,
-			wantStdoutEmpty:  true,
-			wantCaptured:     true,
+			name:               "enabled_allow_response",
+			env:                map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:     `{"action":"allow"}`,
+			expectServerCall:   true,
+			wantStdoutEmpty:    true,
+			wantCaptured:       true,
+			wantConversationID: "sess",
 		},
 		{
 			name:               "enabled_deny_response",
@@ -1047,15 +1060,40 @@ func TestUserPromptSubmitGuard(t *testing.T) {
 			serverResponds:     `{"action":"deny","reason":"secret in prompt"}`,
 			expectServerCall:   true,
 			wantStdoutContains: []string{`"decision":"block"`, "secret in prompt", "blocked this message"},
+			wantConversationID: "sess",
 		},
 		{
 			// Shared-binary hosts ignore prompt transforms.
-			name:             "enabled_allow_with_transform_is_ignored",
+			name:               "enabled_allow_with_transform_is_ignored",
+			env:                map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			serverResponds:     `{"action":"allow","transformed_input":{"messages":[{"role":"user","parts":[{"kind":"text","text":"[REDACTED]"}]}]}}`,
+			expectServerCall:   true,
+			wantStdoutEmpty:    true,
+			wantCaptured:       true,
+			wantConversationID: "sess",
+		},
+		{
+			name:             "resolved subagent uses parent session",
 			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
-			serverResponds:   `{"action":"allow","transformed_input":{"messages":[{"role":"user","parts":[{"kind":"text","text":"[REDACTED]"}]}]}}`,
 			expectServerCall: true,
 			wantStdoutEmpty:  true,
 			wantCaptured:     true,
+			link: &fragment.SubagentLink{
+				ParentSessionID:    "parent-session",
+				ParentGenerationID: "parent-generation",
+			},
+			wantConversationID: "parent-session",
+		},
+		{
+			name:             "partial subagent link keeps child session",
+			env:              map[string]string{"SIGIL_GUARDS_ENABLED": "true"},
+			expectServerCall: true,
+			wantStdoutEmpty:  true,
+			wantCaptured:     true,
+			link: &fragment.SubagentLink{
+				ParentSessionID: "parent-session",
+			},
+			wantConversationID: "sess",
 		},
 	}
 
@@ -1073,8 +1111,16 @@ func TestUserPromptSubmitGuard(t *testing.T) {
 
 			calls.Store(0)
 			responseBody.Store(tt.serverResponds)
+			conversationID.Store("")
 
 			logger := log.New(io.Discard, "", 0)
+			if tt.link != nil {
+				link := *tt.link
+				link.ChildSessionID = "sess"
+				if err := fragment.SaveSubagentLink(&link); err != nil {
+					t.Fatalf("save subagent link: %v", err)
+				}
+			}
 			cfg := config.Load(logger)
 			var stdout bytes.Buffer
 			UserPromptSubmit(context.Background(), &stdout, Payload{
@@ -1090,6 +1136,9 @@ func TestUserPromptSubmitGuard(t *testing.T) {
 			}
 			if !tt.expectServerCall && calls.Load() != 0 {
 				t.Errorf("expected no server call, got %d", calls.Load())
+			}
+			if got, _ := conversationID.Load().(string); got != tt.wantConversationID {
+				t.Errorf("guard conversation ID = %q, want %q", got, tt.wantConversationID)
 			}
 			if tt.wantStdoutEmpty && stdout.Len() != 0 {
 				t.Errorf("stdout not empty: %q", stdout.String())
@@ -1157,8 +1206,9 @@ func TestPreToolUseGuardSendsExpectedRequest(t *testing.T) {
 	var req struct {
 		Phase   string `json:"phase"`
 		Context struct {
-			AgentName string `json:"agent_name"`
-			Model     *struct {
+			AgentName      string `json:"agent_name"`
+			ConversationID string `json:"conversation_id"`
+			Model          *struct {
 				Provider string `json:"provider"`
 				Name     string `json:"name"`
 			} `json:"model"`
@@ -1185,6 +1235,9 @@ func TestPreToolUseGuardSendsExpectedRequest(t *testing.T) {
 	}
 	if req.Context.AgentName != mapper.AgentName {
 		t.Errorf("agent_name = %q, want %q", req.Context.AgentName, mapper.AgentName)
+	}
+	if req.Context.ConversationID != "sess" {
+		t.Errorf("conversation_id = %q, want sess", req.Context.ConversationID)
 	}
 	if req.Context.Model == nil {
 		t.Fatal("missing context model")
@@ -1315,17 +1368,19 @@ func TestAgentNameOverrideGuardAndExport(t *testing.T) {
 			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 			logger := log.New(io.Discard, "", 0)
 
-			var guardAgents, exportAgents []string
+			var guardAgents, guardConversationIDs, exportAgents, exportConversationIDs []string
 			server := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if strings.Contains(r.URL.Path, "hooks:evaluate") {
 					body, _ := io.ReadAll(r.Body)
 					var req struct {
 						Context struct {
-							AgentName string `json:"agent_name"`
+							AgentName      string `json:"agent_name"`
+							ConversationID string `json:"conversation_id"`
 						} `json:"context"`
 					}
 					_ = json.Unmarshal(body, &req)
 					guardAgents = append(guardAgents, req.Context.AgentName)
+					guardConversationIDs = append(guardConversationIDs, req.Context.ConversationID)
 					w.Header().Set("Content-Type", "application/json")
 					_, _ = w.Write([]byte(`{"action":"allow"}`))
 					return
@@ -1333,12 +1388,14 @@ func TestAgentNameOverrideGuardAndExport(t *testing.T) {
 				body, _ := io.ReadAll(r.Body)
 				var req struct {
 					Generations []struct {
-						AgentName string `json:"agent_name"`
+						AgentName      string `json:"agent_name"`
+						ConversationID string `json:"conversation_id"`
 					} `json:"generations"`
 				}
 				_ = json.Unmarshal(body, &req)
 				for _, g := range req.Generations {
 					exportAgents = append(exportAgents, g.AgentName)
+					exportConversationIDs = append(exportConversationIDs, g.ConversationID)
 				}
 				writeAcceptedGenerationResponse(t, w, body)
 			}))
@@ -1380,9 +1437,11 @@ func TestAgentNameOverrideGuardAndExport(t *testing.T) {
 			Stop(Payload{HookEventName: "Stop", SessionID: "sess", TurnID: "turn"}, cfg, logger)
 
 			assert.Equal(t, []string{tt.want}, guardAgents, "guard agent names")
+			assert.Equal(t, []string{"sess"}, guardConversationIDs, "guard conversation IDs")
 			assert.Len(t, exportAgents, 2, "one current turn plus one retried turn")
 			for i, got := range exportAgents {
 				assert.Equal(t, tt.want, got, "exported agent name[%d]", i)
+				assert.Equal(t, "sess", exportConversationIDs[i], "exported conversation ID[%d]", i)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/agents/copilot/hook/handlers.go
+++ b/plugins/agento11y/internal/agents/copilot/hook/handlers.go
@@ -137,8 +137,9 @@ func PreToolUse(ctx context.Context, stdout io.Writer, p Payload, cfg config.Con
 			}
 		}
 		res := guard.EvaluateToolCall(ctx, cfg.Guards, guard.ToolCallInput{
-			AgentName: cfg.Agent(),
-			ToolName:  p.ToolName(),
+			AgentName:      cfg.Agent(),
+			ConversationID: sessionID,
+			ToolName:       p.ToolName(),
 			// Copilot delivers tool args as a JSON-encoded string; the agento11y
 			// server only transforms tool-call input that is a JSON object, so
 			// decode the wrapper before evaluating or redaction never happens.

--- a/plugins/agento11y/internal/agents/copilot/hook/handlers_test.go
+++ b/plugins/agento11y/internal/agents/copilot/hook/handlers_test.go
@@ -881,27 +881,30 @@ func TestAgentNameOverrideGuardAndExport(t *testing.T) {
 			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 			logger := log.New(io.Discard, "", 0)
 
-			var guardAgents, exportAgents []string
+			var guardAgents, guardConversationIDs, exportAgents, exportConversationIDs []string
 			var exportProviders []string
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				body, _ := io.ReadAll(r.Body)
 				if strings.Contains(r.URL.Path, "hooks:evaluate") {
 					var req struct {
 						Context struct {
-							AgentName string `json:"agent_name"`
+							AgentName      string `json:"agent_name"`
+							ConversationID string `json:"conversation_id"`
 						} `json:"context"`
 					}
 					_ = json.Unmarshal(body, &req)
 					guardAgents = append(guardAgents, req.Context.AgentName)
+					guardConversationIDs = append(guardConversationIDs, req.Context.ConversationID)
 					w.Header().Set("Content-Type", "application/json")
 					_, _ = w.Write([]byte(`{"action":"allow"}`))
 					return
 				}
 				var req struct {
 					Generations []struct {
-						ID        string `json:"id"`
-						AgentName string `json:"agent_name"`
-						Model     struct {
+						ID             string `json:"id"`
+						AgentName      string `json:"agent_name"`
+						ConversationID string `json:"conversation_id"`
+						Model          struct {
 							Provider string `json:"provider"`
 						} `json:"model"`
 					} `json:"generations"`
@@ -910,6 +913,7 @@ func TestAgentNameOverrideGuardAndExport(t *testing.T) {
 				results := make([]map[string]any, 0, len(req.Generations))
 				for _, g := range req.Generations {
 					exportAgents = append(exportAgents, g.AgentName)
+					exportConversationIDs = append(exportConversationIDs, g.ConversationID)
 					exportProviders = append(exportProviders, g.Model.Provider)
 					results = append(results, map[string]any{"generation_id": g.ID, "accepted": true})
 				}
@@ -939,7 +943,9 @@ func TestAgentNameOverrideGuardAndExport(t *testing.T) {
 			Stop(Payload{HookEventNameJSON: "Stop", SessionIDJSON: "sess", Timestamp: []byte(`"2026-05-18T12:00:04Z"`), StopReasonJSON: "end_turn"}, cfg, logger)
 
 			assert.Equal(t, []string{tt.want}, guardAgents, "guard agent names")
+			assert.Equal(t, []string{"sess"}, guardConversationIDs, "guard conversation IDs")
 			assert.Equal(t, []string{tt.want}, exportAgents, "exported agent names")
+			assert.Equal(t, []string{"sess"}, exportConversationIDs, "exported conversation IDs")
 			// Copilot reports no provider on this fragment, so the mapper
 			// falls back to the product name. The override must not move it.
 			assert.Equal(t, []string{mapper.AgentName}, exportProviders, "exported model providers")

--- a/plugins/agento11y/internal/agents/cursor/hook/beforesubmit.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/beforesubmit.go
@@ -31,11 +31,12 @@ type beforeSubmitDeny struct {
 // Denied messages never reach the session file or conversation title.
 func BeforeSubmit(ctx context.Context, stdout io.Writer, p Payload, cfg config.Config, logger *log.Logger) {
 	res := guard.EvaluatePrompt(ctx, envconfig.ResolveGuards(logger), guard.PromptInput{
-		AgentName:     cfg.Agent(),
-		AgentVersion:  strings.TrimSpace(p.CursorVersion),
-		ModelProvider: strings.TrimSpace(p.Provider),
-		ModelName:     resolvedModel(p),
-		Prompt:        p.Prompt,
+		AgentName:      cfg.Agent(),
+		AgentVersion:   strings.TrimSpace(p.CursorVersion),
+		ConversationID: p.ConversationID,
+		ModelProvider:  strings.TrimSpace(p.Provider),
+		ModelName:      resolvedModel(p),
+		Prompt:         p.Prompt,
 	}, logger)
 	if res.Blocked() {
 		_ = json.NewEncoder(stdout).Encode(beforeSubmitDeny{

--- a/plugins/agento11y/internal/agents/cursor/hook/pretooluse.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/pretooluse.go
@@ -39,13 +39,14 @@ func PreToolUse(ctx context.Context, p Payload, cfg config.Config, stdout io.Wri
 
 	modelName := resolvedModel(p)
 	res := guard.EvaluateToolCall(ctx, envconfig.ResolveGuards(logger), guard.ToolCallInput{
-		AgentName:     cfg.Agent(),
-		AgentVersion:  strings.TrimSpace(p.CursorVersion),
-		ModelProvider: strings.TrimSpace(p.Provider),
-		ModelName:     modelName,
-		ToolName:      strings.TrimSpace(p.ToolName),
-		ToolCallID:    strings.TrimSpace(p.ToolUseID),
-		ToolInputJSON: p.ToolInput,
+		AgentName:      cfg.Agent(),
+		AgentVersion:   strings.TrimSpace(p.CursorVersion),
+		ConversationID: p.ConversationID,
+		ModelProvider:  strings.TrimSpace(p.Provider),
+		ModelName:      modelName,
+		ToolName:       strings.TrimSpace(p.ToolName),
+		ToolCallID:     strings.TrimSpace(p.ToolUseID),
+		ToolInputJSON:  p.ToolInput,
 	}, logger)
 
 	resp := preToolUseResponse{Permission: "allow"}

--- a/plugins/agento11y/internal/agents/cursor/hook/pretooluse_test.go
+++ b/plugins/agento11y/internal/agents/cursor/hook/pretooluse_test.go
@@ -228,31 +228,35 @@ func TestAgentNameOverrideGuardAndExport(t *testing.T) {
 			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 			logger := log.New(&bytes.Buffer{}, "", 0)
 
-			var guardAgents, exportAgents []string
+			var guardAgents, guardConversationIDs, exportAgents, exportConversationIDs []string
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				body, _ := io.ReadAll(r.Body)
 				if strings.Contains(r.URL.Path, "hooks:evaluate") {
 					var req struct {
 						Context struct {
-							AgentName string `json:"agent_name"`
+							AgentName      string `json:"agent_name"`
+							ConversationID string `json:"conversation_id"`
 						} `json:"context"`
 					}
 					_ = json.Unmarshal(body, &req)
 					guardAgents = append(guardAgents, req.Context.AgentName)
+					guardConversationIDs = append(guardConversationIDs, req.Context.ConversationID)
 					w.Header().Set("Content-Type", "application/json")
 					_, _ = w.Write([]byte(`{"action":"allow"}`))
 					return
 				}
 				var req struct {
 					Generations []struct {
-						ID        string `json:"id"`
-						AgentName string `json:"agent_name"`
+						ID             string `json:"id"`
+						AgentName      string `json:"agent_name"`
+						ConversationID string `json:"conversation_id"`
 					} `json:"generations"`
 				}
 				_ = json.Unmarshal(body, &req)
 				results := make([]map[string]any, 0, len(req.Generations))
 				for _, g := range req.Generations {
 					exportAgents = append(exportAgents, g.AgentName)
+					exportConversationIDs = append(exportConversationIDs, g.ConversationID)
 					results = append(results, map[string]any{"generation_id": g.ID, "accepted": true})
 				}
 				w.Header().Set("Content-Type", "application/json")
@@ -297,13 +301,19 @@ func TestAgentNameOverrideGuardAndExport(t *testing.T) {
 			if len(guardAgents) != 2 {
 				t.Fatalf("guard agent names = %v, want two entries", guardAgents)
 			}
-			for _, got := range guardAgents {
+			for i, got := range guardAgents {
 				if got != tt.want {
 					t.Fatalf("guard agent names = %v, want every entry %q", guardAgents, tt.want)
+				}
+				if guardConversationIDs[i] != "conv" {
+					t.Fatalf("guard conversation IDs = %v, want every entry conv", guardConversationIDs)
 				}
 			}
 			if len(exportAgents) != 1 || exportAgents[0] != tt.want {
 				t.Fatalf("exported agent names = %v, want [%q]", exportAgents, tt.want)
+			}
+			if len(exportConversationIDs) != 1 || exportConversationIDs[0] != "conv" {
+				t.Fatalf("exported conversation IDs = %v, want [conv]", exportConversationIDs)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/agents/guard/prompt.go
+++ b/plugins/agento11y/internal/agents/guard/prompt.go
@@ -45,6 +45,8 @@ type PromptInput struct {
 	// ModelProvider and ModelName describe the upstream model, when known.
 	ModelProvider string
 	ModelName     string
+	// ConversationID identifies the host conversation, when known.
+	ConversationID string
 	// Prompt is the message the user just submitted.
 	Prompt string
 }
@@ -112,8 +114,9 @@ func EvaluatePrompt(ctx context.Context, cfg envconfig.GuardsConfig, in PromptIn
 	req := agento11y.HookEvaluateRequest{
 		Phase: agento11y.HookPhasePreflight,
 		Context: agento11y.HookContext{
-			AgentName:    in.AgentName,
-			AgentVersion: in.AgentVersion,
+			AgentName:      in.AgentName,
+			AgentVersion:   in.AgentVersion,
+			ConversationID: strings.TrimSpace(in.ConversationID),
 			Model: &agento11y.HookModel{
 				Provider: provider,
 				Name:     modelName,

--- a/plugins/agento11y/internal/agents/guard/prompt_test.go
+++ b/plugins/agento11y/internal/agents/guard/prompt_test.go
@@ -213,8 +213,9 @@ func TestEvaluatePrompt_SendsOneUserMessage(t *testing.T) {
 	t.Setenv("SIGIL_AUTH_TOKEN", "token")
 
 	EvaluatePrompt(context.Background(), envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true}, PromptInput{
-		AgentName: "cursor",
-		Prompt:    "my token is glc_secret",
+		AgentName:      "cursor",
+		ConversationID: " session-1 ",
+		Prompt:         "my token is glc_secret",
 	}, log.New(bytes.NewBuffer(nil), "", 0))
 
 	if path, _ := capturedPath.Load().(string); path != "/api/v1/hooks:evaluate" {
@@ -227,8 +228,9 @@ func TestEvaluatePrompt_SendsOneUserMessage(t *testing.T) {
 	var req struct {
 		Phase   string `json:"phase"`
 		Context struct {
-			AgentName string `json:"agent_name"`
-			Model     *struct {
+			AgentName      string `json:"agent_name"`
+			ConversationID string `json:"conversation_id"`
+			Model          *struct {
 				Provider string `json:"provider"`
 				Name     string `json:"name"`
 			} `json:"model"`
@@ -253,6 +255,9 @@ func TestEvaluatePrompt_SendsOneUserMessage(t *testing.T) {
 	if req.Context.AgentName != "cursor" {
 		t.Errorf("agent_name = %q, want cursor", req.Context.AgentName)
 	}
+	if req.Context.ConversationID != "session-1" {
+		t.Errorf("conversation_id = %q, want session-1", req.Context.ConversationID)
+	}
 	if req.Context.Model == nil || req.Context.Model.Provider != "unknown" || req.Context.Model.Name != "unknown" {
 		t.Errorf("model = %+v, want unknown/unknown", req.Context.Model)
 	}
@@ -271,6 +276,22 @@ func TestEvaluatePrompt_SendsOneUserMessage(t *testing.T) {
 	}
 	if msg.Parts[0].Kind != "text" || msg.Parts[0].Text != "my token is glc_secret" {
 		t.Errorf("part = %+v, want the submitted prompt as one text part", msg.Parts[0])
+	}
+
+	EvaluatePrompt(context.Background(), envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true}, PromptInput{
+		AgentName:      "cursor",
+		ConversationID: "   ",
+		Prompt:         "another prompt",
+	}, log.New(bytes.NewBuffer(nil), "", 0))
+	raw, _ = capturedBody.Load().([]byte)
+	var blankIDReq struct {
+		Context map[string]json.RawMessage `json:"context"`
+	}
+	if err := json.Unmarshal(raw, &blankIDReq); err != nil {
+		t.Fatalf("unmarshal blank-id body: %v\n%s", err, raw)
+	}
+	if _, ok := blankIDReq.Context["conversation_id"]; ok {
+		t.Errorf("blank conversation ID serialized in context: %s", raw)
 	}
 }
 

--- a/plugins/agento11y/internal/agents/guard/toolcall.go
+++ b/plugins/agento11y/internal/agents/guard/toolcall.go
@@ -113,6 +113,8 @@ type ToolCallInput struct {
 	// ModelProvider and ModelName describe the upstream model, when known.
 	ModelProvider string
 	ModelName     string
+	// ConversationID identifies the host conversation, when known.
+	ConversationID string
 	// ToolName is required.
 	ToolName string
 	// ToolCallID correlates the tool call with downstream telemetry, when known.
@@ -194,8 +196,9 @@ func EvaluateToolCall(ctx context.Context, cfg envconfig.GuardsConfig, in ToolCa
 		modelName = "unknown"
 	}
 	hookCtx := agento11y.HookContext{
-		AgentName:    in.AgentName,
-		AgentVersion: in.AgentVersion,
+		AgentName:      in.AgentName,
+		AgentVersion:   in.AgentVersion,
+		ConversationID: strings.TrimSpace(in.ConversationID),
 		Model: &agento11y.HookModel{
 			Provider: provider,
 			Name:     modelName,

--- a/plugins/agento11y/internal/agents/guard/toolcall_test.go
+++ b/plugins/agento11y/internal/agents/guard/toolcall_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -28,16 +30,19 @@ func TestEvaluateToolCall(t *testing.T) {
 		clearCreds bool
 		// clearCredsKeepEndpoint clears tenant/token but keeps the (local)
 		// endpoint set, to exercise the LocalAuthPlaceholders path.
-		clearCredsKeepEndpoint bool
-		toolName               string
-		wantAction             agento11y.HookAction
-		wantReasonSub          string
-		wantNoReasonSub        string
-		wantRuleID             string
-		wantUpdatedInput       string
-		wantLogSub             string
-		wantNoLogSub           string
-		wantServerCalled       bool
+		clearCredsKeepEndpoint    bool
+		toolName                  string
+		conversationID            string
+		wantConversationID        string
+		wantConversationIDOmitted bool
+		wantAction                agento11y.HookAction
+		wantReasonSub             string
+		wantNoReasonSub           string
+		wantRuleID                string
+		wantUpdatedInput          string
+		wantLogSub                string
+		wantNoLogSub              string
+		wantServerCalled          bool
 	}{
 		{
 			name:       "disabled returns allow without contacting sigil",
@@ -52,24 +57,28 @@ func TestEvaluateToolCall(t *testing.T) {
 			wantAction: agento11y.HookActionAllow,
 		},
 		{
-			name:             "allow response from sigil",
-			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
-			serverResponds:   `{"action":"allow"}`,
-			toolName:         "bash",
-			wantAction:       agento11y.HookActionAllow,
-			wantLogSub:       "transform_applied=false",
-			wantServerCalled: true,
+			name:               "allow response from sigil",
+			cfg:                envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:     `{"action":"allow"}`,
+			toolName:           "bash",
+			conversationID:     " session-1 ",
+			wantConversationID: "session-1",
+			wantAction:         agento11y.HookActionAllow,
+			wantLogSub:         "transform_applied=false",
+			wantServerCalled:   true,
 		},
 		{
 			// An empty output is treated the same as no transform at all, so it
 			// must stay silent rather than emit the no-match line. Mirrors pi.
-			name:             "empty transform output is ignored",
-			cfg:              envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
-			serverResponds:   `{"action":"allow","transformed_input":{"output":[]}}`,
-			toolName:         "bash",
-			wantAction:       agento11y.HookActionAllow,
-			wantNoLogSub:     "tool-call transform present but no part matched",
-			wantServerCalled: true,
+			name:                      "empty transform output is ignored",
+			cfg:                       envconfig.GuardsConfig{Enabled: true, TimeoutMs: 1500, FailOpen: true},
+			serverResponds:            `{"action":"allow","transformed_input":{"output":[]}}`,
+			toolName:                  "bash",
+			conversationID:            "   ",
+			wantConversationIDOmitted: true,
+			wantAction:                agento11y.HookActionAllow,
+			wantNoLogSub:              "tool-call transform present but no part matched",
+			wantServerCalled:          true,
 		},
 		{
 			name:             "deny response from sigil",
@@ -210,14 +219,17 @@ func TestEvaluateToolCall(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var calls atomic.Int32
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			var capturedBody atomic.Value
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				calls.Add(1)
-				body := tt.serverResponds
-				if body == "" {
-					body = `{"action":"allow"}`
+				requestBody, _ := io.ReadAll(r.Body)
+				capturedBody.Store(requestBody)
+				responseBody := tt.serverResponds
+				if responseBody == "" {
+					responseBody = `{"action":"allow"}`
 				}
 				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(body))
+				_, _ = w.Write([]byte(responseBody))
 			}))
 			defer server.Close()
 
@@ -245,13 +257,14 @@ func TestEvaluateToolCall(t *testing.T) {
 
 			var logBuf bytes.Buffer
 			res := EvaluateToolCall(context.Background(), tt.cfg, ToolCallInput{
-				AgentName:     "copilot",
-				AgentVersion:  "dev",
-				ModelProvider: "openai",
-				ModelName:     "gpt-4",
-				ToolName:      tt.toolName,
-				ToolCallID:    "tu_1",
-				ToolInputJSON: json.RawMessage(`{"cmd":"echo hi"}`),
+				AgentName:      "copilot",
+				AgentVersion:   "dev",
+				ModelProvider:  "openai",
+				ModelName:      "gpt-4",
+				ConversationID: tt.conversationID,
+				ToolName:       tt.toolName,
+				ToolCallID:     "tu_1",
+				ToolInputJSON:  json.RawMessage(`{"cmd":"echo hi"}`),
 			}, log.New(&logBuf, "", 0))
 
 			if res.Action != tt.wantAction {
@@ -280,6 +293,23 @@ func TestEvaluateToolCall(t *testing.T) {
 			}
 			if !tt.wantServerCalled && !tt.useClosedServer && calls.Load() != 0 {
 				t.Errorf("did not expect sigil hook server call, got %d", calls.Load())
+			}
+			if tt.wantConversationID != "" || tt.wantConversationIDOmitted {
+				raw, _ := capturedBody.Load().([]byte)
+				var req struct {
+					Context map[string]json.RawMessage `json:"context"`
+				}
+				if err := json.Unmarshal(raw, &req); err != nil {
+					t.Fatalf("decode request body: %v\n%s", err, raw)
+				}
+				conversationID, ok := req.Context["conversation_id"]
+				if tt.wantConversationIDOmitted {
+					if ok {
+						t.Errorf("blank conversation ID serialized as %s", conversationID)
+					}
+				} else if !ok || string(conversationID) != strconv.Quote(tt.wantConversationID) {
+					t.Errorf("conversation_id = %s, want %q", conversationID, tt.wantConversationID)
+				}
 			}
 		})
 	}

--- a/plugins/agento11y/internal/agents/vibe/hook/handlers.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/handlers.go
@@ -100,25 +100,7 @@ func PostAgent(ctx context.Context, p Payload, logger *log.Logger) {
 		turnSeq = 1
 	}
 
-	// The parent session id can arrive on the thin hook payload or, for
-	// subagent sessions, only in meta.json on disk. Prefer the payload and
-	// fall back to meta so subagent linkage is not silently skipped.
-	parentSessionID := p.ParentSessionID
-	if parentSessionID == "" {
-		parentSessionID = m.ParentSessionID
-	}
-
-	// Resolve a real parent edge when this is a subagent session: the
-	// parent session's last export ID is persisted in its own state file.
-	// We only get a session-level parent_session_id from vibe, so this
-	// links to the parent's most recent generation rather than the exact
-	// turn that spawned the child.
-	var parentGenID string
-	if parentSessionID != "" {
-		if parentState, ok := state.Load(parentSessionID); ok {
-			parentGenID = parentState.LastGenerationID
-		}
-	}
+	parentSessionID, parentGenID := resolveParentLineage(p, m)
 
 	mapped := mapper.Map(mapper.Inputs{
 		SessionID:           p.SessionID,
@@ -207,6 +189,22 @@ func PostAgent(ctx context.Context, p Payload, logger *log.Logger) {
 	// The turn is exported; its tool events have been consumed into spans.
 	toolevents.Clear(p.SessionID)
 	logger.Printf("post_agent: done session=%s offset=%d", p.SessionID, newOffset)
+}
+
+// Vibe provides only a parent session ID, so the edge targets that session's
+// most recently exported generation.
+func resolveParentLineage(p Payload, m meta.Meta) (sessionID, generationID string) {
+	sessionID = p.ParentSessionID
+	if sessionID == "" {
+		sessionID = m.ParentSessionID
+	}
+	if sessionID == "" {
+		return "", ""
+	}
+	if parentState, ok := state.Load(sessionID); ok {
+		generationID = parentState.LastGenerationID
+	}
+	return sessionID, generationID
 }
 
 // restoreState rolls back the pre-export state write after a failed export so

--- a/plugins/agento11y/internal/agents/vibe/hook/handlers_test.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/handlers_test.go
@@ -116,22 +116,37 @@ func TestPostAgent_UsesMetaParentSessionID(t *testing.T) {
 	// A subagent session carries its parent only in meta.json, not on the
 	// thin hook payload. The handler must still resolve the parent edge.
 	var (
-		mu   sync.Mutex
-		body []byte
+		mu                  sync.Mutex
+		body                []byte
+		guardConversationID string
 	)
 	srv := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, _ := io.ReadAll(r.Body)
 		mu.Lock()
+		defer mu.Unlock()
+		if strings.Contains(r.URL.Path, "hooks:evaluate") {
+			var req struct {
+				Context struct {
+					ConversationID string `json:"conversation_id"`
+				} `json:"context"`
+			}
+			_ = json.Unmarshal(b, &req)
+			guardConversationID = req.Context.ConversationID
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"action":"allow"}`))
+			return
+		}
 		body = b
-		mu.Unlock()
 		writeAcceptedGenerationResponse(t, w, b)
 	}))
 	t.Cleanup(srv.Close)
 
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	envconfig.PinAliasEnvBlank(t)
 	t.Setenv("SIGIL_ENDPOINT", srv.URL)
 	t.Setenv("SIGIL_AUTH_TENANT_ID", "tenant")
 	t.Setenv("SIGIL_AUTH_TOKEN", "token")
+	t.Setenv("SIGIL_GUARDS_ENABLED", "true")
 	must(t, state.Save("parent-session", state.Session{LastGenerationID: "parent-generation"}))
 
 	dir := t.TempDir()
@@ -142,11 +157,24 @@ func TestPostAgent_UsesMetaParentSessionID(t *testing.T) {
 	tp := filepath.Join(dir, "messages.jsonl")
 
 	logger := log.New(io.Discard, "", 0)
+	var stdout bytes.Buffer
+	PreTool(context.Background(), &stdout, Payload{
+		HookEventName:   "pre_tool",
+		SessionID:       "child-session",
+		TranscriptPath:  tp,
+		ToolNameValue:   "shell",
+		ToolCallIDValue: "call-1",
+		ToolInputValue:  json.RawMessage(`{"command":"echo hi"}`),
+	}, logger)
 	PostAgent(context.Background(), Payload{HookEventName: "post_agent", SessionID: "child-session", TranscriptPath: tp}, logger)
 
 	mu.Lock()
 	got := body
+	gotGuardConversationID := guardConversationID
 	mu.Unlock()
+	if gotGuardConversationID != "parent-session" {
+		t.Errorf("guard conversation ID = %q, want parent-session", gotGuardConversationID)
+	}
 	if len(got) == 0 {
 		t.Fatalf("expected export request")
 	}
@@ -494,9 +522,11 @@ func TestAgentNameOverrideGuardAndExport(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var (
-				mu           sync.Mutex
-				guardAgents  []string
-				exportAgents []string
+				mu                    sync.Mutex
+				guardAgents           []string
+				guardConversationIDs  []string
+				exportAgents          []string
+				exportConversationIDs []string
 			)
 			srv := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				body, _ := io.ReadAll(r.Body)
@@ -505,23 +535,27 @@ func TestAgentNameOverrideGuardAndExport(t *testing.T) {
 				if strings.Contains(r.URL.Path, "hooks:evaluate") {
 					var req struct {
 						Context struct {
-							AgentName string `json:"agent_name"`
+							AgentName      string `json:"agent_name"`
+							ConversationID string `json:"conversation_id"`
 						} `json:"context"`
 					}
 					_ = json.Unmarshal(body, &req)
 					guardAgents = append(guardAgents, req.Context.AgentName)
+					guardConversationIDs = append(guardConversationIDs, req.Context.ConversationID)
 					w.Header().Set("Content-Type", "application/json")
 					_, _ = w.Write([]byte(`{"action":"allow"}`))
 					return
 				}
 				var req struct {
 					Generations []struct {
-						AgentName string `json:"agent_name"`
+						AgentName      string `json:"agent_name"`
+						ConversationID string `json:"conversation_id"`
 					} `json:"generations"`
 				}
 				_ = json.Unmarshal(body, &req)
 				for _, g := range req.Generations {
 					exportAgents = append(exportAgents, g.AgentName)
+					exportConversationIDs = append(exportConversationIDs, g.ConversationID)
 				}
 				writeAcceptedGenerationResponse(t, w, body)
 			}))
@@ -564,8 +598,14 @@ func TestAgentNameOverrideGuardAndExport(t *testing.T) {
 			if len(guardAgents) != 1 || guardAgents[0] != tt.want {
 				t.Fatalf("guard agent names = %v, want [%q]", guardAgents, tt.want)
 			}
+			if len(guardConversationIDs) != 1 || guardConversationIDs[0] != "sess-agent-name" {
+				t.Fatalf("guard conversation IDs = %v, want [sess-agent-name]", guardConversationIDs)
+			}
 			if len(exportAgents) != 1 || exportAgents[0] != tt.want {
 				t.Fatalf("exported agent names = %v, want [%q]", exportAgents, tt.want)
+			}
+			if len(exportConversationIDs) != 1 || exportConversationIDs[0] != "sess-agent-name" {
+				t.Fatalf("exported conversation IDs = %v, want [sess-agent-name]", exportConversationIDs)
 			}
 		})
 	}

--- a/plugins/agento11y/internal/agents/vibe/hook/tool.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/tool.go
@@ -39,7 +39,8 @@ func PreTool(ctx context.Context, stdout io.Writer, p Payload, logger *log.Logge
 	}
 
 	envconfig.ApplyLocalAuthPlaceholders()
-	provider, modelName := guardModel(p)
+	m, metaOK := loadGuardMeta(p)
+	provider, modelName := guardModel(m, metaOK)
 
 	evalCtx, cancel := context.WithTimeout(ctx, time.Duration(cfg.TimeoutMs)*time.Millisecond+guardEvalBuffer)
 	defer cancel()
@@ -48,12 +49,13 @@ func PreTool(ctx context.Context, stdout io.Writer, p Payload, logger *log.Logge
 		// Same resolution the export path uses, so a rule scoped to a per-run
 		// name matches the generations that run produces. vibe has no config
 		// package, so each handler resolves it for its own invocation.
-		AgentName:     envconfig.ResolveAgentName(mapper.AgentName),
-		ToolName:      toolName,
-		ToolCallID:    p.ToolCallID(),
-		ToolInputJSON: p.ToolInput(),
-		ModelProvider: provider,
-		ModelName:     modelName,
+		AgentName:      envconfig.ResolveAgentName(mapper.AgentName),
+		ConversationID: guardConversationID(p, m),
+		ToolName:       toolName,
+		ToolCallID:     p.ToolCallID(),
+		ToolInputJSON:  p.ToolInput(),
+		ModelProvider:  provider,
+		ModelName:      modelName,
 	}, logger)
 	if res.Blocked() {
 		writePreToolDeny(stdout, res.Reason)
@@ -89,15 +91,17 @@ func PostTool(p Payload, logger *log.Logger) {
 	}
 }
 
-// guardModel returns the model provider/name for the guard request,
-// best-effort from the session meta.json. Guards work without it (the helper
-// falls back to "unknown"), so any read error is ignored.
-func guardModel(p Payload) (provider, modelName string) {
+// Guards run without metadata, so read failures do not block tool calls.
+func loadGuardMeta(p Payload) (meta.Meta, bool) {
 	if p.TranscriptPath == "" {
-		return "", ""
+		return meta.Meta{}, false
 	}
 	m, err := meta.Load(p.TranscriptPath)
-	if err != nil {
+	return m, err == nil
+}
+
+func guardModel(m meta.Meta, ok bool) (provider, modelName string) {
+	if !ok {
 		return "", ""
 	}
 	provider, apiName := m.ActiveModelRef()
@@ -106,6 +110,14 @@ func guardModel(p Payload) (provider, modelName string) {
 		modelName = apiName
 	}
 	return provider, modelName
+}
+
+func guardConversationID(p Payload, m meta.Meta) string {
+	parentSessionID, parentGenerationID := resolveParentLineage(p, m)
+	if parentSessionID != "" && parentGenerationID != "" {
+		return parentSessionID
+	}
+	return p.SessionID
 }
 
 // preToolDeny is vibe's structured deny response: a non-empty stdout

--- a/plugins/agento11y/internal/agents/vibe/hook/tool_test.go
+++ b/plugins/agento11y/internal/agents/vibe/hook/tool_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/vibe/meta"
+	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/vibe/state"
 	"github.com/grafana/agento11y/plugins/agento11y/internal/agents/vibe/toolevents"
 )
 
@@ -72,6 +74,60 @@ func TestPreTool_FailOpenAllowsOnMissingCreds(t *testing.T) {
 	}, discardLogger())
 	if out.Len() != 0 {
 		t.Errorf("stdout = %q, want empty (allow) when failing open", out.String())
+	}
+}
+
+func TestGuardConversationID(t *testing.T) {
+	tests := []struct {
+		name               string
+		payloadParentID    string
+		metaParentID       string
+		stateParentID      string
+		parentGenerationID string
+		want               string
+	}{
+		{name: "root session", want: "child"},
+		{
+			name:               "resolved payload parent",
+			payloadParentID:    "payload-parent",
+			metaParentID:       "meta-parent",
+			stateParentID:      "payload-parent",
+			parentGenerationID: "parent-generation",
+			want:               "payload-parent",
+		},
+		{
+			name:               "resolved meta parent",
+			metaParentID:       "meta-parent",
+			stateParentID:      "meta-parent",
+			parentGenerationID: "parent-generation",
+			want:               "meta-parent",
+		},
+		{name: "missing parent state", metaParentID: "meta-parent", want: "child"},
+		{
+			name:          "parent state without generation",
+			metaParentID:  "meta-parent",
+			stateParentID: "meta-parent",
+			want:          "child",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			if tt.stateParentID != "" {
+				if err := state.Save(tt.stateParentID, state.Session{LastGenerationID: tt.parentGenerationID}); err != nil {
+					t.Fatalf("save parent state: %v", err)
+				}
+			}
+
+			got := guardConversationID(Payload{
+				SessionID:       "child",
+				ParentSessionID: tt.payloadParentID,
+			}, meta.Meta{ParentSessionID: tt.metaParentID})
+			if got != tt.want {
+				t.Errorf("guard conversation ID = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/plugins/opencode/src/guard.test.ts
+++ b/plugins/opencode/src/guard.test.ts
@@ -37,6 +37,7 @@ describe("runToolCallGuard", () => {
       client: client as any,
       agentName: "opencode",
       model: { provider: "anthropic", name: "claude" },
+      conversationId: "opencode-session-1",
       toolCallId: "c1",
       toolName: "bash",
       input: { command: "ls" },
@@ -46,9 +47,21 @@ describe("runToolCallGuard", () => {
     expect(res).toBeUndefined();
     expect(calls).toHaveLength(1);
     expect((calls[0] as any).phase).toBe("postflight");
+    expect((calls[0] as any).context.conversationId).toBe("opencode-session-1");
     expect((calls[0] as any).input.output[0].parts[0].toolCall.inputJSON).toBe(
       JSON.stringify({ command: "ls" }),
     );
+
+    await runToolCallGuard({
+      client: client as any,
+      agentName: "opencode",
+      model: { provider: "anthropic", name: "claude" },
+      conversationId: "   ",
+      toolName: "bash",
+      input: {},
+      failOpen: true,
+    });
+    expect((calls[1] as any).context).not.toHaveProperty("conversationId");
   });
 
   it("returns a wrapped policy-deny result when Agent Observability denies the tool call", async () => {
@@ -388,6 +401,7 @@ function makePreflightArgs(
     agentName: "opencode:build",
     agentVersion: "1.2.3",
     model: { provider: "anthropic", name: "claude-sonnet-4" },
+    conversationId: "opencode-session-1",
     messages: [{ role: "user", parts: [{ type: "text", text: "hi" }] }],
     failOpen: true,
     ...overrides,
@@ -423,6 +437,7 @@ describe("runPreflightTransform", () => {
         expect(req.context).toEqual({
           agentName: "opencode:build",
           agentVersion: "1.2.3",
+          conversationId: "opencode-session-1",
           model: { provider: "anthropic", name: "claude-sonnet-4" },
         });
         expect(req.input.messages).toEqual([
@@ -437,6 +452,13 @@ describe("runPreflightTransform", () => {
           phases: ["preflight"],
           failOpen: false,
         });
+      },
+    },
+    {
+      name: "omits a blank conversation ID",
+      args: { conversationId: "   " },
+      assert: (calls) => {
+        expect(calls[0]!.req.context).not.toHaveProperty("conversationId");
       },
     },
     {

--- a/plugins/opencode/src/guard.ts
+++ b/plugins/opencode/src/guard.ts
@@ -9,6 +9,7 @@ export interface GuardArgs {
   agentName: string;
   agentVersion?: string;
   model: { provider: string; name: string };
+  conversationId?: string;
   toolCallId?: string;
   toolName: string;
   input: unknown;
@@ -119,6 +120,7 @@ export interface PromptGuardArgs {
   agentName: string;
   agentVersion?: string;
   model: { provider: string; name: string };
+  conversationId?: string;
   messages: Message[];
   failOpen: boolean;
   logger?: { warn: (msg: string) => void };
@@ -150,11 +152,13 @@ export async function runPromptGuard(
   args: PromptGuardArgs,
 ): Promise<PromptGuardResult> {
   try {
+    const conversationId = args.conversationId?.trim();
     const req: HookEvaluateRequest = {
       phase: "preflight",
       context: {
         agentName: args.agentName,
         agentVersion: args.agentVersion,
+        ...(conversationId ? { conversationId } : {}),
         model: {
           provider: args.model.provider || "unknown",
           name: args.model.name || "unknown",
@@ -219,6 +223,7 @@ export interface PreflightTransformArgs {
   agentName: string;
   agentVersion?: string;
   model: { provider: string; name: string };
+  conversationId?: string;
   messages: Message[];
   failOpen: boolean;
   logger?: { warn: (msg: string) => void };
@@ -253,11 +258,13 @@ export async function runPreflightTransform(
   args: PreflightTransformArgs,
 ): Promise<PreflightTransformResult> {
   try {
+    const conversationId = args.conversationId?.trim();
     const req: HookEvaluateRequest = {
       phase: "preflight",
       context: {
         agentName: args.agentName,
         agentVersion: args.agentVersion,
+        ...(conversationId ? { conversationId } : {}),
         model: {
           provider: args.model.provider || "unknown",
           name: args.model.name || "unknown",
@@ -334,11 +341,13 @@ export function formatTransformFailure(
  */
 export async function runToolCallGuard(args: GuardArgs): Promise<GuardResult> {
   try {
+    const conversationId = args.conversationId?.trim();
     const req: HookEvaluateRequest = {
       phase: "postflight",
       context: {
         agentName: args.agentName,
         agentVersion: args.agentVersion,
+        ...(conversationId ? { conversationId } : {}),
         model: {
           provider: args.model.provider || "unknown",
           name: args.model.name || "unknown",

--- a/plugins/opencode/src/hooks.guard.test.ts
+++ b/plugins/opencode/src/hooks.guard.test.ts
@@ -7,12 +7,16 @@ import {
   _peekPendingGenerations,
   _peekToolExecutionState,
   _resetHookState,
-  _resetToolExecutionState,
   _setGuardToastDelayMs,
   type Agento11yHooks,
   createAgento11yHooks,
 } from "./hooks.js";
-import { emitServerInstanceDisposed } from "./hooks.testutil.js";
+import {
+  emitMessageUpdated,
+  emitServerInstanceDisposed,
+  emitSessionCreated,
+  inFlightAssistantMessage,
+} from "./hooks.testutil.js";
 
 type HookServer = {
   server: Server;
@@ -82,6 +86,18 @@ async function runToolLikeOpencode(
   );
 }
 
+async function seedLinkedSession(
+  hooks: Agento11yHooks,
+  parentSessionID: string,
+  childSessionID: string,
+): Promise<void> {
+  await emitMessageUpdated(
+    hooks,
+    inFlightAssistantMessage(parentSessionID, `msg-${parentSessionID}`),
+  );
+  await emitSessionCreated(hooks, childSessionID, parentSessionID);
+}
+
 function config(endpoint: string): Agento11yOpencodeConfig {
   return {
     endpoint,
@@ -98,7 +114,7 @@ function config(endpoint: string): Agento11yOpencodeConfig {
 describe("opencode guards", () => {
   const servers: Server[] = [];
 
-  beforeEach(() => _resetToolExecutionState());
+  beforeEach(() => _resetHookState());
 
   afterEach(async () => {
     // A scheduled toast outlives the case that caused it, and would otherwise
@@ -155,6 +171,7 @@ describe("opencode guards", () => {
       context: {
         agent_name: "opencode:build",
         agent_version: "test-version",
+        conversation_id: "sess-1",
         model: { provider: "anthropic", name: "claude-sonnet-4" },
       },
       input: {
@@ -450,6 +467,7 @@ describe("opencode guards", () => {
     );
 
     expect(output.status).toBe("deny");
+    expect(hookServer.captures[0]?.context?.conversation_id).toBe("sess-1");
     expect(
       hookServer.captures[0]?.input?.output?.[0]?.parts?.[0],
     ).toMatchObject({
@@ -467,6 +485,114 @@ describe("opencode guards", () => {
       },
     });
 
+    await emitServerInstanceDisposed(hooks);
+  });
+
+  it.each([
+    {
+      name: "linked child",
+      physicalSessionID: "sess-child",
+      wantConversationID: "sess-root",
+      setup: async (hooks: Agento11yHooks) => {
+        await seedLinkedSession(hooks, "sess-root", "sess-child");
+      },
+    },
+    {
+      name: "nested child",
+      physicalSessionID: "sess-grandchild",
+      wantConversationID: "sess-root",
+      setup: async (hooks: Agento11yHooks) => {
+        await seedLinkedSession(hooks, "sess-root", "sess-child");
+        await seedLinkedSession(hooks, "sess-child", "sess-grandchild");
+      },
+    },
+    {
+      name: "unresolved child",
+      physicalSessionID: "sess-unresolved",
+      wantConversationID: "sess-unresolved",
+      setup: async (hooks: Agento11yHooks) => {
+        await emitSessionCreated(hooks, "sess-unresolved", "sess-unseen");
+      },
+    },
+  ])("uses exported conversation identity for a $name tool guard", async ({
+    physicalSessionID,
+    wantConversationID,
+    setup,
+  }) => {
+    const hookServer = await startHookServer({
+      action: "allow",
+      evaluations: [],
+    });
+    servers.push(hookServer.server);
+
+    const hooks = await createAgento11yHooks(config(hookServer.baseUrl), {
+      session: { message: async () => ({ data: { parts: [] } }) },
+    } as any);
+    if (!hooks) throw new Error("expected hooks");
+    await setup(hooks);
+
+    const args = { command: "ls" };
+    await hooks.toolExecuteBefore(
+      {
+        sessionID: physicalSessionID,
+        callID: "lineage-call",
+        tool: "bash",
+      },
+      { args },
+    );
+
+    expect(hookServer.captures[0]?.context?.conversation_id).toBe(
+      wantConversationID,
+    );
+    expect(hookServer.captures[0]?.context).not.toHaveProperty("session_id");
+    expect(_peekToolExecutionState().active).toEqual([
+      expect.objectContaining({ sessionID: physicalSessionID }),
+    ]);
+
+    hooks.toolExecuteAfter(
+      {
+        sessionID: physicalSessionID,
+        callID: "lineage-call",
+        tool: "bash",
+        args,
+      },
+      { title: "bash", output: "ok", metadata: {} },
+    );
+    await emitServerInstanceDisposed(hooks);
+  });
+
+  it("uses the root conversation for a nested child's permission guard", async () => {
+    const hookServer = await startHookServer({
+      action: "allow",
+      evaluations: [],
+    });
+    servers.push(hookServer.server);
+
+    const hooks = await createAgento11yHooks(config(hookServer.baseUrl), {
+      session: { message: async () => ({ data: { parts: [] } }) },
+    } as any);
+    if (!hooks) throw new Error("expected hooks");
+    await seedLinkedSession(hooks, "sess-root", "sess-child");
+    await seedLinkedSession(hooks, "sess-child", "sess-grandchild");
+
+    const output: { status: "ask" | "deny" | "allow" } = { status: "ask" };
+    await hooks.permissionAsk(
+      {
+        id: "perm-nested",
+        sessionID: "sess-grandchild",
+        messageID: "msg-nested",
+        callID: "call-nested",
+        type: "bash",
+        pattern: "*",
+        title: "Run shell command",
+        metadata: {},
+        time: { created: Date.now() },
+      },
+      output,
+    );
+
+    expect(hookServer.captures[0]?.context?.conversation_id).toBe("sess-root");
+    expect(output.status).toBe("ask");
     await emitServerInstanceDisposed(hooks);
   });
 });
@@ -520,20 +646,25 @@ function startPreflightServer(
   });
 }
 
-function textPart(id: string, messageID: string, text: string): Part {
+function textPart(
+  id: string,
+  messageID: string,
+  text: string,
+  sessionID = "sess-1",
+): Part {
   return {
     id,
-    sessionID: "sess-1",
+    sessionID,
     messageID,
     type: "text",
     text,
   } as Part;
 }
 
-function userEntry(id: string, text: string) {
+function userEntry(id: string, text: string, sessionID = "sess-1") {
   return {
-    info: { id, role: "user", sessionID: "sess-1" } as any,
-    parts: [textPart(`${id}-p1`, id, text)],
+    info: { id, role: "user", sessionID } as any,
+    parts: [textPart(`${id}-p1`, id, text, sessionID)],
   };
 }
 
@@ -745,6 +876,7 @@ describe("opencode preflight guard", () => {
           context: {
             agent_name: "opencode:build",
             agent_version: "test-version",
+            conversation_id: "sess-1",
             model: { provider: "anthropic", name: "claude-sonnet-4" },
           },
         });
@@ -771,6 +903,20 @@ describe("opencode preflight guard", () => {
         expect((messages[1].parts[0] as any).state.output).toBe(
           "secret output",
         );
+      },
+    },
+    {
+      name: "omits conversation identity when outgoing messages have none",
+      build: () => {
+        const message = userEntry("m1", "hello");
+        delete message.info.sessionID;
+        return { messages: [message] };
+      },
+      wantCalls: 1,
+      wantTexts: [["hello"]],
+      assert: ({ captures }) => {
+        expect(captures[0]?.context).not.toHaveProperty("conversation_id");
+        expect(captures[0]?.context).not.toHaveProperty("session_id");
       },
     },
     {
@@ -987,22 +1133,22 @@ describe("opencode preflight guard", () => {
 });
 
 /** A `chat.message` payload carrying one text part, or none when text is null. */
-function chatMessagePayload(text: string | null) {
+function chatMessagePayload(text: string | null, sessionID = "sess-1") {
   return {
     input: {
-      sessionID: "sess-1",
+      sessionID,
       agent: "build",
       model: { providerID: "anthropic", modelID: "claude-sonnet-4" },
     },
     output: {
       message: {
         id: "m1",
-        sessionID: "sess-1",
+        sessionID,
         role: "user",
         system: "",
         tools: {},
       } as any,
-      parts: text === null ? [] : [textPart("m1-p1", "m1", text)],
+      parts: text === null ? [] : [textPart("m1-p1", "m1", text, sessionID)],
     },
   };
 }
@@ -1060,6 +1206,7 @@ describe("opencode prompt guard", () => {
           context: {
             agent_name: "opencode:build",
             agent_version: "test-version",
+            conversation_id: "sess-1",
             model: { provider: "anthropic", name: "claude-sonnet-4" },
           },
           input: {
@@ -1165,6 +1312,23 @@ describe("opencode prompt guard", () => {
     await emitServerInstanceDisposed(hooks);
   });
 
+  it("uses the root conversation for a linked child's submitted prompt", async () => {
+    const hookServer = await startPreflightServer(() => ({
+      action: "allow",
+      evaluations: [],
+    }));
+    servers.push(hookServer.server);
+
+    const hooks = await hooksFor(hookServer.baseUrl);
+    await seedLinkedSession(hooks, "sess-root", "sess-child");
+    const { input, output } = chatMessagePayload("key=abc", "sess-child");
+
+    await hooks.chatMessage(input, output);
+
+    expect(hookServer.captures[0]?.context?.conversation_id).toBe("sess-root");
+    await emitServerInstanceDisposed(hooks);
+  });
+
   it("drops the refused turn's user-side data", async () => {
     // opencode creates some assistant messages without a `chat.message` of
     // their own, so a leftover pending entry would be exported against one of
@@ -1203,7 +1367,8 @@ describe("opencode prompt guard", () => {
     servers.push(hookServer.server);
 
     const hooks = await hooksFor(hookServer.baseUrl);
-    const messages = [userEntry("m1", "one")];
+    await seedLinkedSession(hooks, "sess-root", "sess-child");
+    const messages = [userEntry("m1", "one", "sess-child")];
 
     await expect(hooks.messagesTransform({ messages })).rejects.toThrow(
       "secrets are not allowed in prompts",
@@ -1213,9 +1378,10 @@ describe("opencode prompt guard", () => {
     expect(logs).toHaveLength(1);
     expect(logs[0]?.message).toContain("the turn was stopped");
     expect(toasts).toHaveLength(1);
-    // Cleanup for the assistant message row opencode has already written,
-    // which its interrupt finalizer owns.
-    expect(aborts).toEqual(["sess-1"]);
+    expect(hookServer.captures[0]?.context?.conversation_id).toBe("sess-root");
+    // Guard context follows export lineage, but cleanup still targets the
+    // physical child session whose assistant row opencode already wrote.
+    expect(aborts).toEqual(["sess-child"]);
     // A refused turn never reaches the provider, so nothing is rewritten.
     expect(partTexts(messages)).toEqual([["one"]]);
 

--- a/plugins/opencode/src/hooks.ts
+++ b/plugins/opencode/src/hooks.ts
@@ -443,6 +443,7 @@ async function handleChatMessage(
       agentName: agentNameForSession(config, input.sessionID),
       agentVersion: config.agentVersion || hostVersion,
       model: modelForSession(input.sessionID),
+      conversationId: resolveExportedConversationId(input.sessionID),
       messages: forward,
       failOpen: guards.failOpen,
       logger: { warn: (msg: string) => debugLog(msg) },
@@ -580,12 +581,13 @@ async function evaluateOutgoingMessages(
     }
 
     // The hook input carries no session id, so it comes from the messages.
-    const sessionID = sessionIdFromOutgoing(messages) ?? "";
+    const physicalSessionID = sessionIdFromOutgoing(messages) ?? "";
     const result = await runPreflightTransform({
       client: sigil,
-      agentName: agentNameForSession(config, sessionID),
+      agentName: agentNameForSession(config, physicalSessionID),
       agentVersion: config.agentVersion || hostVersion,
-      model: modelForSession(sessionID),
+      model: modelForSession(physicalSessionID),
+      conversationId: resolveExportedConversationId(physicalSessionID),
       messages: forward,
       failOpen: guards.failOpen,
       logger: { warn: (msg: string) => debugLog(msg) },
@@ -1332,6 +1334,7 @@ async function handleToolExecuteBefore(
     agentName: agentNameForSession(config, input.sessionID),
     agentVersion: config.agentVersion || hostVersion,
     model: modelForSession(input.sessionID),
+    conversationId: resolveExportedConversationId(input.sessionID),
     toolCallId: input.callID,
     toolName: input.tool,
     input: output.args ?? {},
@@ -1452,6 +1455,7 @@ async function handlePermissionAsk(
     agentName: agentNameForSession(config, input.sessionID),
     agentVersion: config.agentVersion || hostVersion,
     model: modelForSession(input.sessionID),
+    conversationId: resolveExportedConversationId(input.sessionID),
     toolCallId: input.callID,
     toolName: input.type,
     input: {

--- a/plugins/pi/src/guard.test.ts
+++ b/plugins/pi/src/guard.test.ts
@@ -59,6 +59,7 @@ function makeArgs(overrides?: Partial<GuardArgs>): GuardArgs {
     agentName: "pi",
     agentVersion: "1.0.0",
     model: { provider: "anthropic", name: "claude-sonnet-4" },
+    conversationId: "pi-session-1",
     toolCallId: "c1",
     toolName: "bash",
     input: { command: "ls" },
@@ -204,6 +205,7 @@ describe("runToolCallGuard", () => {
     expect(req.phase).toBe("postflight");
     expect(req.context.agentName).toBe("pi");
     expect(req.context.agentVersion).toBe("1.0.0");
+    expect(req.context.conversationId).toBe("pi-session-1");
     expect(req.context.model).toEqual({
       provider: "anthropic",
       name: "claude-sonnet-4",
@@ -220,6 +222,9 @@ describe("runToolCallGuard", () => {
       inputJSON: '{"command":"ls"}',
     });
     expect(override).toEqual({ enabled: true });
+
+    await runToolCallGuard(makeArgs({ client, conversationId: undefined }));
+    expect(calls[1]!.req.context).not.toHaveProperty("conversationId");
   });
 
   it("returns a transform result when the server emits redacted tool_call args", async () => {
@@ -382,6 +387,7 @@ function makePreflightArgs(
     agentName: "pi",
     agentVersion: "1.0.0",
     model: { provider: "anthropic", name: "claude-sonnet-4" },
+    conversationId: "pi-session-1",
     messages: [{ role: "user", parts: [{ type: "text", text: "hi" }] }],
     ...overrides,
   };
@@ -402,12 +408,18 @@ describe("runPreflightTransform", () => {
     expect(req.context).toEqual({
       agentName: "pi",
       agentVersion: "1.0.0",
+      conversationId: "pi-session-1",
       model: { provider: "anthropic", name: "claude-sonnet-4" },
     });
     expect((req.input as HookInput).messages).toEqual([
       { role: "user", parts: [{ type: "text", text: "hi" }] },
     ]);
     expect(override).toEqual({ enabled: true, phases: ["preflight"] });
+
+    await runPreflightTransform(
+      makePreflightArgs({ client, conversationId: undefined }),
+    );
+    expect(calls[1]!.req.context).not.toHaveProperty("conversationId");
   });
 
   it("returns the redacted messages from transformedInput", async () => {

--- a/plugins/pi/src/guard.ts
+++ b/plugins/pi/src/guard.ts
@@ -9,6 +9,7 @@ export interface GuardArgs {
   agentName: string;
   agentVersion?: string;
   model: { provider: string; name: string };
+  conversationId?: string;
   toolCallId: string;
   toolName: string;
   input: Record<string, unknown>;
@@ -88,6 +89,7 @@ export interface PreflightTransformArgs {
   agentName: string;
   agentVersion?: string;
   model: { provider: string; name: string };
+  conversationId?: string;
   messages: Message[];
   logger?: { warn: (msg: string) => void };
 }
@@ -108,11 +110,13 @@ export async function runPreflightTransform(
   args: PreflightTransformArgs,
 ): Promise<PreflightTransformResult> {
   try {
+    const conversationId = args.conversationId?.trim();
     const req: HookEvaluateRequest = {
       phase: "preflight",
       context: {
         agentName: args.agentName,
         agentVersion: args.agentVersion,
+        ...(conversationId ? { conversationId } : {}),
         model: args.model,
       },
       input: {
@@ -148,11 +152,13 @@ export async function runPreflightTransform(
  */
 export async function runToolCallGuard(args: GuardArgs): Promise<GuardResult> {
   try {
+    const conversationId = args.conversationId?.trim();
     const req: HookEvaluateRequest = {
       phase: "postflight",
       context: {
         agentName: args.agentName,
         agentVersion: args.agentVersion,
+        ...(conversationId ? { conversationId } : {}),
         model: args.model,
       },
       input: {

--- a/plugins/pi/src/guards.e2e.test.ts
+++ b/plugins/pi/src/guards.e2e.test.ts
@@ -203,6 +203,7 @@ describe("pi guards: real-SDK over HTTP", () => {
           expect(server.hookCalls).toHaveLength(1);
           const call = server.hookCalls[0]!;
           expect(call.phase).toBe("preflight");
+          expect(call.body.context?.conversation_id).toBe("guards-conv-1");
           // The forwarded body carried the unredacted original. The server
           // dispatches on the snake_case `kind`, so the part carries it and
           // nothing else. conformance/hooks/README.md.
@@ -425,6 +426,9 @@ describe("pi guards: real-SDK over HTTP", () => {
           expect(result).toBeUndefined();
           expect(event.input).toEqual({ command: "echo [REDACTED]" });
           expect(server.hookCalls[0]!.phase).toBe("postflight");
+          expect(server.hookCalls[0]!.body.context?.conversation_id).toBe(
+            "guards-conv-1",
+          );
         },
       },
       {

--- a/plugins/pi/src/index.test.ts
+++ b/plugins/pi/src/index.test.ts
@@ -1272,6 +1272,55 @@ describe("extension lifecycle", () => {
       expect(result).toBeUndefined();
     });
 
+    it("reads the current session ID for every tool guard", async () => {
+      const evaluateHook = vi
+        .fn()
+        .mockResolvedValue({ action: "allow", evaluations: [] });
+      const sigil = makeAgento11yLike(evaluateHook);
+
+      loadConfigMock.mockResolvedValue({
+        endpoint: "http://localhost:8080/api/v1/generations:export",
+        auth: { mode: "none" },
+        agentName: "pi",
+        contentCapture: "metadata_only",
+        guards: { enabled: true, timeoutMs: 1500, failOpen: true },
+      });
+      createAgento11yClientMock.mockReturnValue(sigil);
+
+      const fakePi = new FakePi();
+      registerExtension(fakePi as any);
+      let currentId = "guard-before-fork";
+      let unavailable = false;
+      const ctx = makeCtx({
+        sessionId: () => {
+          if (unavailable) throw new Error("session ID unavailable");
+          return currentId;
+        },
+      });
+
+      await fakePi.emit("session_start", {}, ctx);
+      const handler = fakePi.handlers.get("tool_call")!;
+      const event = {
+        toolCallId: "c1",
+        toolName: "bash",
+        input: { command: "ls" },
+      };
+      await handler(event, ctx);
+      currentId = "guard-after-fork";
+      await handler(event, ctx);
+      unavailable = true;
+      await handler(event, ctx);
+
+      expect(evaluateHook).toHaveBeenCalledTimes(3);
+      expect(
+        evaluateHook.mock.calls.map(
+          ([req]) =>
+            (req as { context: { conversationId?: string } }).context
+              .conversationId,
+        ),
+      ).toEqual(["guard-before-fork", "guard-after-fork", undefined]);
+    });
+
     it("returns { block, reason } when guards deny the tool call", async () => {
       const evaluateHook = vi.fn().mockResolvedValue({
         action: "deny",
@@ -1579,6 +1628,46 @@ describe("extension lifecycle", () => {
       });
       expect(result).toEqual({ messages: piMessages });
       expect(piMessages[0]!.content).toBe("my email is [REDACTED_EMAIL]");
+    });
+
+    it("reads the current session ID for every context guard", async () => {
+      const evaluateHook = vi
+        .fn()
+        .mockResolvedValue({ action: "allow", evaluations: [] });
+      const sigil = makeAgento11yLike(evaluateHook);
+      loadConfigMock.mockResolvedValue(preflightConfig());
+      createAgento11yClientMock.mockReturnValue(sigil);
+
+      const fakePi = new FakePi();
+      registerExtension(fakePi as any);
+      let currentId = "guard-before-fork";
+      let unavailable = false;
+      const ctx = makeCtx({
+        sessionId: () => {
+          if (unavailable) throw new Error("session ID unavailable");
+          return currentId;
+        },
+      });
+
+      await fakePi.emit("session_start", {}, ctx);
+      const handler = fakePi.handlers.get("context")!;
+      const event = {
+        messages: [{ role: "user", content: "hello", timestamp: 1 }],
+      };
+      await handler(event, ctx);
+      currentId = "guard-after-fork";
+      await handler(event, ctx);
+      unavailable = true;
+      await handler(event, ctx);
+
+      expect(evaluateHook).toHaveBeenCalledTimes(3);
+      expect(
+        evaluateHook.mock.calls.map(
+          ([req]) =>
+            (req as { context: { conversationId?: string } }).context
+              .conversationId,
+        ),
+      ).toEqual(["guard-before-fork", "guard-after-fork", undefined]);
     });
 
     it("returns undefined when the server emits no transformedInput", async () => {

--- a/plugins/pi/src/index.ts
+++ b/plugins/pi/src/index.ts
@@ -554,7 +554,7 @@ export default function (pi: ExtensionAPI) {
     firstTokenTime = Date.now();
   });
 
-  pi.on("context", async (event, _ctx) => {
+  pi.on("context", async (event, ctx) => {
     if (!sigil || !config?.guards.enabled) return;
     try {
       const piMessages = event.messages;
@@ -568,6 +568,7 @@ export default function (pi: ExtensionAPI) {
         agentName: config.agentName,
         agentVersion: config.agentVersion,
         model: lastSeenModel ?? { provider: "unknown", name: "unknown" },
+        conversationId: readSessionId(ctx.sessionManager),
         messages: forward,
         logger: { warn: (msg: string) => logger.warn(msg) },
       });
@@ -603,13 +604,14 @@ export default function (pi: ExtensionAPI) {
     }
   });
 
-  pi.on("tool_call", async (event, _ctx) => {
+  pi.on("tool_call", async (event, ctx) => {
     if (!sigil || !config?.guards.enabled) return;
     const res = await runToolCallGuard({
       client: sigil,
       agentName: config.agentName,
       agentVersion: config.agentVersion,
       model: lastSeenModel ?? { provider: "unknown", name: "unknown" },
+      conversationId: readSessionId(ctx.sessionManager),
       toolCallId: event.toolCallId,
       toolName: event.toolName,
       input: event.input as Record<string, unknown>,

--- a/plugins/pi/src/testHttp.ts
+++ b/plugins/pi/src/testHttp.ts
@@ -56,6 +56,7 @@ export interface HookRequestBody {
     model?: { provider?: string; name?: string };
     agent_name?: string;
     agent_version?: string;
+    conversation_id?: string;
   };
   input?: {
     messages?: WireMessage[];

--- a/python/tests/hooks_fixtures.py
+++ b/python/tests/hooks_fixtures.py
@@ -100,6 +100,7 @@ def postflight_guard_request() -> HookEvaluateRequest:
         context=HookContext(
             agent_name="conformance-guard",
             agent_version="1.2.3",
+            conversation_id="conv-hooks-conformance",
             model=HookModel(provider="anthropic", name="claude-sonnet-4"),
         ),
         input=HookInput(


### PR DESCRIPTION
Send `conversation_id` in guard requests from coding agent plugins.