### PR TITLE
feat(python-frameworks/open-webui): add Open WebUI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,7 @@ jobs:
           - { name: litellm, cmd: "uv run --with './python[dev]' --with './python-frameworks/litellm[dev]' pytest python-frameworks/litellm/tests" }
           - { name: pydantic-ai, cmd: "uv run --with './python[dev]' --with './python-frameworks/pydantic-ai[dev]' pytest python-frameworks/pydantic-ai/tests" }
           - { name: strands, cmd: "uv run --with './python[dev]' --with './python-frameworks/strands[dev]' pytest python-frameworks/strands/tests" }
+          - { name: open-webui, cmd: "uv run --with './python[dev]' --with './python-frameworks/open-webui[dev]' pytest python-frameworks/open-webui/tests" }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/python-sdks-publish.yml
+++ b/.github/workflows/python-sdks-publish.yml
@@ -118,6 +118,7 @@ jobs:
             python-frameworks/pydantic-ai
             python-frameworks/strands
             python-frameworks/claude-agent-sdk
+            python-frameworks/open-webui
           )
 
           for dir in "${PACKAGE_DIRS[@]}"; do
@@ -146,6 +147,7 @@ jobs:
             python-frameworks/pydantic-ai
             python-frameworks/strands
             python-frameworks/claude-agent-sdk
+            python-frameworks/open-webui
           )
 
           for dir in "${PACKAGE_DIRS[@]}"; do
@@ -250,6 +252,7 @@ jobs:
           - agento11y-pydantic-ai
           - agento11y-strands
           - agento11y-claude-agent-sdk
+          - agento11y-open-webui
 
     steps:
       - name: Download distributions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ If you change shared-binary behavior, the four glue plugins and vibe all see it.
 - Use `cache_write_input_tokens`, not `cache_creation_input_tokens`. This was renamed in cbe0363; pretrained models tend to suggest the old name, so don't follow them.
 - Conformance suites cross-check the SDKs. `mise run test:sdk:conformance` runs seven of them. Core, provider-wrapper, framework-adapter, hook, and experiment cover Go/Python/JS/Java/.NET. Pi-session covers Go and JS. Redaction covers the four SDKs that have a redaction engine plus both plugins, and no Java. If you change behavior in one SDK, expect to update fixtures or matching code in the others.
 - Python has one package per framework (`agento11y-langgraph`, `agento11y-openai`, …). JS has one package with subpath exports (`@grafana/agento11y/langgraph`). Don't reflexively assume one layout for the other.
-- Python version bumps go through `mise run sdk:py:bump <VERSION>`. It updates all 13 `pyproject.toml` files and their internal `agento11y>=…` pins atomically. Hand-editing one file leaves the other twelve inconsistent.
+- Python version bumps go through `mise run sdk:py:bump <VERSION>`. It updates all 14 `pyproject.toml` files and their internal `agento11y>=…` pins atomically. Hand-editing one file leaves the other thirteen inconsistent.
 
 ## A skill served by the binary lives inside the binary's tree
 

--- a/README.md
+++ b/README.md
@@ -128,10 +128,13 @@ rec.SetResult(agento11y.Generation{
 
 | Language | Frameworks | Where |
 |----------|------------|-------|
-| Python | LangChain, LangGraph, OpenAI Agents, LlamaIndex, Google ADK, Strands Agents, Claude Agent SDK, LiteLLM, Pydantic AI | [`python-frameworks/`](python-frameworks/) |
+| Python | LangChain, LangGraph, OpenAI Agents, LlamaIndex, Google ADK, Strands Agents, Claude Agent SDK, LiteLLM, Open WebUI, Pydantic AI | [`python-frameworks/`](python-frameworks/) |
 | TypeScript/JavaScript | LangChain, LangGraph, OpenAI Agents, LlamaIndex, Google ADK, Strands, Vercel AI SDK | Subpath exports of `@grafana/agento11y`. See [`js/README.md`](js/README.md). |
 | Go | Google ADK | [`go-frameworks/`](go-frameworks/) |
 | Java | Google ADK | [`java/frameworks/`](java/frameworks/) |
+
+The [Open WebUI Filter](python-frameworks/open-webui/README.md) records completed response snapshots
+rather than individual provider calls.
 
 ### Runnable examples
 

--- a/llms.txt
+++ b/llms.txt
@@ -331,10 +331,12 @@ Provider wrappers (use these before hand-instrumenting an SDK call):
 
 Framework adapters:
 
-- Python: `python-frameworks/{langchain,langgraph,openai-agents,llamaindex,google-adk,strands,claude-agent-sdk,litellm,pydantic-ai}`; each is its own pip package (e.g. `agento11y-langgraph`).
+- Python: `python-frameworks/{langchain,langgraph,openai-agents,llamaindex,google-adk,strands,claude-agent-sdk,litellm,open-webui,pydantic-ai}`; each is its own pip package (e.g. `agento11y-langgraph`).
 - JS/TS: subpath exports like `@grafana/agento11y/langgraph`, `@grafana/agento11y/vercel-ai-sdk`; single npm package, multiple entry points.
 - Go: `go-frameworks/google-adk`.
 - Java: `java/frameworks/google-adk`.
+
+`agento11y-open-webui` is an administrator-installed Open WebUI Filter. Do not add it to application code as a callback handler. It records completed response snapshots rather than individual provider calls.
 
 ## Telemetry fields to prioritize
 

--- a/mise.toml
+++ b/mise.toml
@@ -395,6 +395,10 @@ run = "uv run --python \"$PYTHON_BIN\" --with './python[dev]' --with-editable '.
 description = "Run Python LiteLLM framework handler tests"
 run = "uv run --python \"$PYTHON_BIN\" --with './python[dev]' --with './python-frameworks/litellm[dev]' pytest python-frameworks/litellm/tests"
 
+[tasks."test:py:sdk-open-webui"]
+description = "Run Python Open WebUI Filter tests"
+run = "uv run --python \"$PYTHON_BIN\" --with './python[dev]' --with-editable './python-frameworks/open-webui[dev]' pytest python-frameworks/open-webui/tests"
+
 [tasks."test:py:sdk-provider-conformance"]
 description = "Run Python provider-wrapper conformance tests"
 run = """
@@ -418,6 +422,7 @@ mise run test:py:sdk-google-adk
 mise run test:py:sdk-strands
 mise run test:py:sdk-claude-agent-sdk
 mise run test:py:sdk-litellm
+mise run test:py:sdk-open-webui
 """
 
 # --- .NET SDK tests ---
@@ -713,6 +718,7 @@ PACKAGE_DIRS=(
   python-frameworks/pydantic-ai
   python-frameworks/strands
   python-frameworks/claude-agent-sdk
+  python-frameworks/open-webui
 )
 
 for dir in "${PACKAGE_DIRS[@]}"; do

--- a/python-frameworks/open-webui/LICENSE
+++ b/python-frameworks/open-webui/LICENSE
@@ -1,0 +1,3 @@
+SPDX-License-Identifier: Apache-2.0
+
+See /LICENSE at repository root for full license text.

--- a/python-frameworks/open-webui/README.md
+++ b/python-frameworks/open-webui/README.md
@@ -1,0 +1,190 @@
+# Agent Observability for Open WebUI
+
+The `agento11y-open-webui` package adds an administrator-installed
+[Open WebUI](https://openwebui.com/) Filter. It exports one snapshot after each
+supported assistant response without changing the request or response body.
+
+The Filter records response-level data. It does not intercept each provider call
+inside an agent or tool loop.
+
+## Requirements
+
+- Open WebUI 0.11.3 or later
+- Python 3.10 or later
+- A Grafana Cloud Agent Observability API URL, instance ID, and access token
+
+Refer to
+[Set up Agent Observability in Grafana Cloud](https://grafana.com/docs/grafana-cloud/observe-and-act/agent-observability/get-started/grafana-cloud/)
+to get the connection values.
+
+## Install the package
+
+Install the package in the Python environment that runs the Open WebUI backend.
+For the official container, build a derived image so the package remains
+installed after a restart or upgrade:
+
+```dockerfile
+FROM ghcr.io/open-webui/open-webui:v0.11.3
+
+ARG AGENTO11Y_VERSION
+RUN test -n "${AGENTO11Y_VERSION}" && pip install --no-cache-dir \
+    "agento11y==${AGENTO11Y_VERSION}" \
+    "agento11y-open-webui==${AGENTO11Y_VERSION}"
+```
+
+Pass a released SDK version as `AGENTO11Y_VERSION` when you build the image.
+This pins the core SDK and Filter package to the same version.
+
+## Configure Agent Observability
+
+Set these variables on the Open WebUI backend before it starts:
+
+```dotenv
+AGENTO11Y_ENDPOINT=<AGENT_OBSERVABILITY_API_URL>
+AGENTO11Y_PROTOCOL=http
+AGENTO11Y_AUTH_MODE=basic
+AGENTO11Y_AUTH_TENANT_ID=<INSTANCE_ID>
+AGENTO11Y_AUTH_TOKEN=<ACCESS_TOKEN>
+```
+
+Grafana Cloud requires `AGENTO11Y_PROTOCOL=http` and
+`AGENTO11Y_AUTH_MODE=basic`. Set `AGENTO11Y_AGENT_NAME` to change the exported
+agent name. The default for this Filter is `open-webui`.
+
+## Install the Filter
+
+In Open WebUI, open **Admin panel > Functions** and create a Function with this
+body:
+
+```python
+"""
+title: Grafana Agent Observability
+required_open_webui_version: 0.11.3
+"""
+
+from agento11y_open_webui import Filter
+```
+
+Save the Function as a Filter. Activate it and make it global. The Function
+body imports the package from the backend image and does not install dependencies
+at runtime.
+
+## Enable token reporting
+
+For each streamed model, edit its capabilities in Open WebUI and enable
+**Usage**. Open WebUI then requests usage from compatible providers with
+`stream_options.include_usage`. Token data remains unavailable unless the provider
+reports normalized `input_tokens` and `output_tokens`. The Filter uses
+`total_tokens` when present and otherwise sums the input and output counts. It
+ignores `prompt_tokens`, `completion_tokens`, and cache or reasoning counts in
+`input_tokens_details` and `output_tokens_details`.
+
+## Configure OpenTelemetry
+
+Generation export and OpenTelemetry (OTel) export are separate paths. Generation
+snapshots can reach Agent Observability when OTel is disabled, but trace- and
+metric-backed views remain empty.
+
+Open WebUI can register the global OTel providers that the Python SDK uses for
+generation spans and `gen_ai.client.token.usage` metrics. Enable Open WebUI's
+OTel setup, traces, and metrics:
+
+```dotenv
+ENABLE_OTEL=true
+ENABLE_OTEL_TRACES=true
+ENABLE_OTEL_METRICS=true
+OTEL_EXPORTER_OTLP_ENDPOINT=<OTLP_ENDPOINT>
+OTEL_METRICS_EXPORTER_OTLP_ENDPOINT=<OTLP_ENDPOINT>
+OTEL_BASIC_AUTH_USERNAME=<OTLP_INSTANCE_ID>
+OTEL_BASIC_AUTH_PASSWORD=<ACCESS_TOKEN>
+```
+
+Use the OTLP endpoint and instance ID from your Grafana Cloud OpenTelemetry
+connection. Refer to
+[Open WebUI OpenTelemetry configuration](https://docs.openwebui.com/reference/monitoring/otel/)
+for transport, TLS, and signal-specific settings. Open WebUI also emits service
+request, database, Redis, and system telemetry. Those signals do not replace the
+Filter's generation snapshots.
+
+## Content capture and privacy
+
+When capture is not configured, the Filter uses `metadata_only` instead of the
+core SDK's content-enabled default. It exports no user or assistant message text
+in this mode.
+
+To export the selected user and assistant text, set a content-enabled mode before
+starting Open WebUI. For example:
+
+```dotenv
+AGENTO11Y_CONTENT_CAPTURE_MODE=full
+```
+
+Captured text passes through the SDK sanitizer for known secret formats, with
+input redaction enabled. Redaction is best effort and does not guarantee removal
+of every sensitive value.
+
+The Filter exports message content when it is a string. For block content, it
+exports text only from top-level `text`, `input_text`, and `output_text` blocks.
+It omits system prompts, thinking blocks, tool inputs and results, attachments,
+titles, provider errors, and arbitrary host metadata. The opaque Open WebUI user
+ID, chat ID, selected message ID, and selected model ID remain present in
+`metadata_only` mode.
+
+## Snapshot behavior
+
+Each matched `inlet` and `outlet` pair can produce one generation:
+
+- The Open WebUI chat ID is the conversation ID. A direct API call without a chat
+  ID uses the generation ID that the Filter created for the snapshot as its
+  conversation ID.
+- The selected assistant is the message whose ID matches the outlet body ID.
+- The input is the last user message before that assistant.
+- The exported model is `custom/open-webui-response-summary`. The selected Open
+  WebUI model ID remains metadata, so the record does not claim provider
+  attribution or model pricing.
+- Each invocation gets a new generation ID, including Continue and tool-approval
+  resumes.
+- Continue and approval-resume snapshots omit token counts to avoid counting
+  retained usage twice.
+- Streaming requests use streaming generation mode. The Filter does not report
+  time to first token.
+
+A standalone outlet callback does not create a snapshot. Repeating an outlet
+callback does not create another snapshot. Responses without a matching outlet
+are not exported. These include some
+failures, cancellations, tool-only responses, and approval pauses.
+
+The Filter attempts export at most once within one Open WebUI request lifecycle.
+It does not deduplicate across processes or workers.
+
+## Direct API requests
+
+In Open WebUI 0.11.3, streaming and non-streaming
+`POST /api/chat/completions` requests run inline outlet Filters when
+`ENABLE_API_OUTLET_FILTERS=true`. This setting defaults to `true` in that
+release. Keep it enabled to export direct API response snapshots.
+
+The legacy `POST /api/chat/completed` callback does not share the original inlet
+state, so this Filter ignores it. Routes that bypass the standard chat-completion
+Filter lifecycle are not supported.
+
+## Delivery and failures
+
+The SDK queues exports in memory and sends them in the background. A queued
+snapshot does not confirm delivery. An abrupt process exit can lose queued data,
+and queues do not transfer between Open WebUI workers.
+
+Snapshot mapping, recorder setup, finalization, and queueing errors do not reject
+or modify the chat response. The backend logs
+`agento11y Open WebUI export failed: <category>` for these errors without
+including response payloads or exception text. The core SDK reports background
+delivery failures separately and can include exporter error text.
+
+If snapshots do not appear:
+
+1. Confirm that both packages are installed in the running backend image.
+1. Confirm that the Function is active for the selected model.
+1. Confirm that the `AGENTO11Y_*` variables are visible to the backend process.
+1. For streamed models, confirm that **Usage** is enabled and that the provider
+   returns usage.
+1. For direct API calls, confirm that `ENABLE_API_OUTLET_FILTERS=true`.

--- a/python-frameworks/open-webui/agento11y_open_webui/__init__.py
+++ b/python-frameworks/open-webui/agento11y_open_webui/__init__.py
@@ -1,0 +1,3 @@
+from .filter import Filter
+
+__all__ = ["Filter"]

--- a/python-frameworks/open-webui/agento11y_open_webui/filter.py
+++ b/python-frameworks/open-webui/agento11y_open_webui/filter.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import asyncio
+import atexit
+import logging
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from agento11y import (
+    Client,
+    ClientConfig,
+    ContentCaptureMode,
+    Generation,
+    GenerationStart,
+    ModelRef,
+    SecretRedactionOptions,
+    TokenUsage,
+    assistant_text_message,
+    create_secret_redaction_sanitizer,
+    user_text_message,
+)
+
+_STATE_KEY = "agento11y.open_webui"
+_MODEL = ModelRef(provider="custom", name="open-webui-response-summary")
+_TEXT_BLOCK_TYPES = frozenset({"text", "input_text", "output_text"})
+_logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class _Snapshot:
+    generation_id: str
+    conversation_id: str
+    user_id: str
+    selected_message_id: str
+    selected_model_id: str
+    input_text: str
+    output_text: str
+    usage: TokenUsage
+    usage_status: str
+    streaming: bool
+    started_at: datetime
+    completed_at: datetime
+
+
+class Filter:
+    """Export completed Open WebUI responses without changing chat content."""
+
+    def __init__(self, client: Client | None = None) -> None:
+        self._client = client
+        self._client_lock = threading.Lock()
+        self._content_capture_mode = self._configured_content_capture(client)
+        self._agent_name = self._configured_agent_name(client)
+        self._sanitizer = create_secret_redaction_sanitizer(SecretRedactionOptions(redact_input_messages=True))
+
+    async def inlet(self, body: dict[str, Any], __metadata__: dict[str, Any] | None = None) -> dict[str, Any]:
+        if isinstance(__metadata__, dict):
+            __metadata__[_STATE_KEY] = {
+                "generation_id": str(uuid4()),
+                "started_at": datetime.now(timezone.utc).isoformat(),
+                "streaming": bool(body.get("stream", False)),
+                "consumed": False,
+            }
+        return body
+
+    async def outlet(
+        self,
+        body: dict[str, Any],
+        __metadata__: dict[str, Any] | None = None,
+        __user__: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        state = __metadata__.get(_STATE_KEY) if isinstance(__metadata__, dict) else None
+        if not isinstance(state, dict) or state.get("consumed") is not False:
+            return body
+
+        state["consumed"] = True
+
+        try:
+            await asyncio.to_thread(
+                self._export_snapshot,
+                body,
+                state,
+                __metadata__ if isinstance(__metadata__, dict) else {},
+                __user__ if isinstance(__user__, dict) else {},
+            )
+        except Exception:  # noqa: BLE001
+            self._log_failure("export_execution")
+
+        return body
+
+    def _export_snapshot(
+        self,
+        body: dict[str, Any],
+        state: dict[str, Any],
+        metadata: dict[str, Any],
+        user: dict[str, Any],
+    ) -> None:
+        try:
+            client = self._get_client()
+        except Exception:  # noqa: BLE001
+            self._log_failure("client_initialization")
+            return
+
+        capture_mode = self._content_capture_mode or ContentCaptureMode.METADATA_ONLY
+        try:
+            snapshot = _build_snapshot(
+                body,
+                state,
+                metadata,
+                user,
+                capture_content=capture_mode is not ContentCaptureMode.METADATA_ONLY,
+            )
+        except Exception:  # noqa: BLE001
+            self._log_failure("snapshot_mapping")
+            return
+
+        if snapshot is None:
+            return
+
+        start = GenerationStart(
+            id=snapshot.generation_id,
+            conversation_id=snapshot.conversation_id,
+            user_id=snapshot.user_id,
+            agent_name=self._agent_name,
+            model=_MODEL,
+            content_capture=capture_mode,
+            metadata={
+                "capture_scope": "response_snapshot",
+                "selected_message_id": snapshot.selected_message_id,
+                "selected_model_id": snapshot.selected_model_id,
+                "usage_status": snapshot.usage_status,
+            },
+            started_at=snapshot.started_at,
+        )
+        generation = Generation(
+            input=[user_text_message(snapshot.input_text)] if snapshot.input_text.strip() else [],
+            output=[assistant_text_message(snapshot.output_text)] if snapshot.output_text.strip() else [],
+            usage=snapshot.usage,
+            completed_at=snapshot.completed_at,
+        )
+
+        if capture_mode is not ContentCaptureMode.METADATA_ONLY:
+            try:
+                generation = self._sanitizer(generation)
+            except Exception:  # noqa: BLE001
+                start.content_capture = ContentCaptureMode.METADATA_ONLY
+                generation.input = []
+                generation.output = []
+                self._log_failure("content_sanitization")
+
+        try:
+            recorder = (
+                client.start_streaming_generation(start) if snapshot.streaming else client.start_generation(start)
+            )
+        except Exception:  # noqa: BLE001
+            self._log_failure("recorder_initialization")
+            return
+
+        try:
+            recorder.set_result(generation)
+            recorder.end()
+        except Exception:  # noqa: BLE001
+            self._log_failure("recorder_finalization")
+            return
+
+        try:
+            queue_error = recorder.err()
+        except Exception:  # noqa: BLE001
+            self._log_failure("snapshot_queueing")
+            return
+
+        if queue_error is not None:
+            self._log_failure("snapshot_queueing")
+
+    def _get_client(self) -> Client:
+        if self._client is not None:
+            return self._client
+
+        with self._client_lock:
+            if self._client is not None:
+                return self._client
+
+            config = ClientConfig.from_env()
+            if config.content_capture is ContentCaptureMode.DEFAULT:
+                config.content_capture = ContentCaptureMode.METADATA_ONLY
+            if not config.agent_name:
+                config.agent_name = "open-webui"
+            config.generation_sanitizer = self._sanitizer
+            client = Client(config)
+            self._client = client
+            self._content_capture_mode = config.content_capture
+            self._agent_name = config.agent_name or "open-webui"
+            atexit.register(client.shutdown)
+            return client
+
+    @staticmethod
+    def _configured_content_capture(client: Client | None) -> ContentCaptureMode | None:
+        if client is None:
+            return None
+        config = getattr(client, "_config", None)
+        mode = getattr(config, "content_capture", None)
+        if not isinstance(mode, ContentCaptureMode) or mode is ContentCaptureMode.DEFAULT:
+            return ContentCaptureMode.METADATA_ONLY
+        return mode
+
+    @staticmethod
+    def _configured_agent_name(client: Client | None) -> str:
+        config = getattr(client, "_config", None) if client is not None else None
+        return getattr(config, "agent_name", "") or "open-webui"
+
+    @staticmethod
+    def _log_failure(category: str) -> None:
+        _logger.warning("agento11y Open WebUI export failed: %s", category)
+
+
+def _build_snapshot(
+    body: dict[str, Any],
+    state: dict[str, Any],
+    metadata: dict[str, Any],
+    user: dict[str, Any],
+    *,
+    capture_content: bool,
+) -> _Snapshot | None:
+    selected_message_id = _nonempty_string(body.get("id"))
+    messages = body.get("messages")
+    if not selected_message_id or not isinstance(messages, list):
+        return None
+
+    selected_index = next(
+        (
+            index
+            for index, message in enumerate(messages)
+            if isinstance(message, dict)
+            and message.get("role") == "assistant"
+            and message.get("id") == selected_message_id
+        ),
+        None,
+    )
+    if selected_index is None:
+        return None
+
+    assistant = messages[selected_index]
+    user_message = next(
+        (
+            message
+            for message in reversed(messages[:selected_index])
+            if isinstance(message, dict) and message.get("role") == "user"
+        ),
+        None,
+    )
+
+    continuation = bool(_nonempty_string(metadata.get("assistant_message_id")))
+    usage, usage_status = _map_usage(assistant.get("usage"), continuation=continuation)
+    generation_id = _required_string(state.get("generation_id"))
+    conversation_id = _nonempty_string(body.get("chat_id")) or generation_id
+
+    return _Snapshot(
+        generation_id=generation_id,
+        conversation_id=conversation_id,
+        user_id=_nonempty_string(user.get("id")),
+        selected_message_id=selected_message_id,
+        selected_model_id=_nonempty_string(body.get("model")),
+        input_text=_extract_text(user_message.get("content")) if capture_content and user_message else "",
+        output_text=_extract_text(assistant.get("content")) if capture_content else "",
+        usage=usage,
+        usage_status=usage_status,
+        streaming=bool(state.get("streaming", False)),
+        started_at=_parse_timestamp(state.get("started_at")),
+        completed_at=datetime.now(timezone.utc),
+    )
+
+
+def _extract_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+
+    return "".join(
+        block["text"]
+        for block in content
+        if isinstance(block, dict) and block.get("type") in _TEXT_BLOCK_TYPES and isinstance(block.get("text"), str)
+    )
+
+
+def _map_usage(raw: Any, *, continuation: bool) -> tuple[TokenUsage, str]:
+    if continuation:
+        return TokenUsage(), "continuation_omitted"
+    if not isinstance(raw, dict):
+        return TokenUsage(), "unavailable"
+
+    input_tokens = _token_count(raw.get("input_tokens"))
+    output_tokens = _token_count(raw.get("output_tokens"))
+    if input_tokens is None or output_tokens is None:
+        return TokenUsage(), "unavailable"
+
+    if "total_tokens" in raw:
+        total_tokens = _token_count(raw.get("total_tokens"))
+        if total_tokens is None:
+            return TokenUsage(), "unavailable"
+    else:
+        total_tokens = input_tokens + output_tokens
+
+    return (
+        TokenUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=total_tokens,
+        ),
+        "reported",
+    )
+
+
+def _token_count(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _required_string(value: Any) -> str:
+    result = _nonempty_string(value)
+    if not result:
+        raise ValueError("required Filter state is missing")
+    return result
+
+
+def _nonempty_string(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _parse_timestamp(value: Any) -> datetime:
+    timestamp = datetime.fromisoformat(_required_string(value))
+    if timestamp.tzinfo is None:
+        raise ValueError("Filter timestamp has no timezone")
+    return timestamp.astimezone(timezone.utc)

--- a/python-frameworks/open-webui/pyproject.toml
+++ b/python-frameworks/open-webui/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "agento11y-open-webui"
+version = "0.17.0"
+description = "Open WebUI Filter for the Grafana Agent Observability Python SDK"
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.10"
+dependencies = [
+  "agento11y>=0.17.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=9.0.3",
+]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["agento11y_open_webui*"]
+
+[tool.setuptools.package-data]
+agento11y_open_webui = ["py.typed"]

--- a/python-frameworks/open-webui/tests/conftest.py
+++ b/python-frameworks/open-webui/tests/conftest.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+from agento11y.config import _WARNED_LEGACY_ENV
+
+
+@pytest.fixture(autouse=True)
+def _clear_agento11y_env(monkeypatch):
+    for key in list(os.environ):
+        if key.startswith(("AGENTO11Y_", "SIGIL_", "OTEL_")):
+            monkeypatch.delenv(key, raising=False)
+    _WARNED_LEGACY_ENV.clear()
+    yield
+    _WARNED_LEGACY_ENV.clear()

--- a/python-frameworks/open-webui/tests/fixtures/callbacks.json
+++ b/python-frameworks/open-webui/tests/fixtures/callbacks.json
@@ -1,0 +1,430 @@
+{
+  "upstream": {
+    "repository": "https://github.com/open-webui/open-webui",
+    "release": "v0.11.3",
+    "release_revision": "2a960a59fe1dbbd35282f0556b3666d81102e781",
+    "verified_revision": "0a7c15832fb30b1903753e83f81dc7d27e5b0944",
+    "backend_diff_from_release": "none",
+    "method": "source-isolated process_filter_functions and outlet_filter_handler harnesses with a local fake provider"
+  },
+  "source_contract": {
+    "dispatcher": "backend/open_webui/utils/filter.py:212-251",
+    "inlet_call": "backend/open_webui/utils/middleware.py:2635-2642",
+    "outlet_body": "backend/open_webui/utils/middleware.py:3933-3961",
+    "outlet_call": "backend/open_webui/utils/middleware.py:3973-3991",
+    "continuation_marker": "backend/open_webui/utils/middleware.py:2420-2425",
+    "approval_resume_marker": "backend/open_webui/utils/tool_approval.py:166-186",
+    "openai_metadata_removal": "backend/open_webui/routers/openai.py:1489-1491",
+    "ollama_metadata_removal": "backend/open_webui/routers/ollama.py:1117-1127",
+    "api_outlet_default": "backend/open_webui/env.py:1038"
+  },
+  "cases": [
+    {
+      "name": "saved_non_streaming",
+      "inlet": {
+        "body": {
+          "model": "fake.gpt-test",
+          "stream": false,
+          "messages": [
+            {
+              "id": "user-1",
+              "role": "user",
+              "content": "Saved question"
+            }
+          ]
+        },
+        "metadata": {
+          "chat_id": "chat-saved",
+          "message_id": "assistant-1"
+        },
+        "user": {
+          "id": "user-opaque",
+          "email": "not-exported@example.com"
+        }
+      },
+      "provider_body": {
+        "model": "gpt-test",
+        "stream": false,
+        "messages": [
+          {
+            "id": "user-1",
+            "role": "user",
+            "content": "Saved question"
+          }
+        ]
+      },
+      "outlet": {
+        "body": {
+          "model": "fake.gpt-test",
+          "messages": [
+            {
+              "id": "user-1",
+              "role": "user",
+              "content": "Saved question",
+              "info": null,
+              "timestamp": null
+            },
+            {
+              "id": "assistant-1",
+              "role": "assistant",
+              "content": "Saved answer",
+              "info": null,
+              "timestamp": null,
+              "usage": {
+                "input_tokens": 11,
+                "output_tokens": 4,
+                "total_tokens": 15
+              }
+            }
+          ],
+          "filter_ids": [],
+          "chat_id": "chat-saved",
+          "session_id": null,
+          "id": "assistant-1"
+        },
+        "repeat": false
+      },
+      "expected": {
+        "conversation_id": "chat-saved",
+        "usage_status": "reported",
+        "streaming": false
+      }
+    },
+    {
+      "name": "temporary_streaming",
+      "inlet": {
+        "body": {
+          "model": "fake.gpt-test",
+          "stream": true,
+          "messages": [
+            {
+              "role": "user",
+              "content": "Temporary question"
+            }
+          ]
+        },
+        "metadata": {
+          "chat_id": "temporary:session-2",
+          "message_id": "assistant-2"
+        },
+        "user": {
+          "id": "user-opaque"
+        }
+      },
+      "provider_body": {
+        "model": "gpt-test",
+        "stream": true,
+        "messages": [
+          {
+            "role": "user",
+            "content": "Temporary question"
+          }
+        ]
+      },
+      "outlet": {
+        "body": {
+          "model": "fake.gpt-test",
+          "messages": [
+            {
+              "id": null,
+              "role": "user",
+              "content": "Temporary question",
+              "info": null,
+              "timestamp": null
+            },
+            {
+              "id": "assistant-2",
+              "role": "assistant",
+              "content": "Temporary answer",
+              "info": null,
+              "timestamp": null,
+              "usage": {
+                "input_tokens": 8,
+                "output_tokens": 3,
+                "total_tokens": 11
+              }
+            }
+          ],
+          "filter_ids": [],
+          "chat_id": "temporary:session-2",
+          "session_id": null,
+          "id": "assistant-2"
+        },
+        "repeat": false
+      },
+      "expected": {
+        "conversation_id": "temporary:session-2",
+        "usage_status": "reported",
+        "streaming": true
+      }
+    },
+    {
+      "name": "direct_api_non_streaming",
+      "inlet": {
+        "body": {
+          "model": "fake.gpt-test",
+          "stream": false,
+          "messages": [
+            {
+              "role": "user",
+              "content": "API question"
+            }
+          ]
+        },
+        "metadata": {
+          "chat_id": "",
+          "message_id": "api-assistant"
+        },
+        "user": {
+          "id": "api-user"
+        }
+      },
+      "provider_body": {
+        "model": "gpt-test",
+        "stream": false,
+        "messages": [
+          {
+            "role": "user",
+            "content": "API question"
+          }
+        ]
+      },
+      "outlet": {
+        "body": {
+          "model": "fake.gpt-test",
+          "messages": [
+            {
+              "id": null,
+              "role": "user",
+              "content": "API question",
+              "info": null,
+              "timestamp": null
+            },
+            {
+              "id": "api-assistant",
+              "role": "assistant",
+              "content": "API answer",
+              "info": null,
+              "timestamp": null,
+              "usage": {
+                "input_tokens": 6,
+                "output_tokens": 2,
+                "total_tokens": 8
+              }
+            }
+          ],
+          "filter_ids": [],
+          "chat_id": "",
+          "session_id": null,
+          "id": "api-assistant"
+        },
+        "repeat": false
+      },
+      "expected": {
+        "conversation_id": "invocation",
+        "usage_status": "reported",
+        "streaming": false
+      }
+    },
+    {
+      "name": "continue_existing_assistant",
+      "inlet": {
+        "body": {
+          "model": "fake.gpt-test",
+          "stream": true,
+          "messages": [
+            {
+              "id": "user-3",
+              "role": "user",
+              "content": "Continue"
+            }
+          ]
+        },
+        "metadata": {
+          "chat_id": "chat-saved",
+          "message_id": "assistant-3",
+          "assistant_message_id": "assistant-3"
+        },
+        "user": {
+          "id": "user-opaque"
+        }
+      },
+      "provider_body": {
+        "model": "gpt-test",
+        "stream": true,
+        "messages": [
+          {
+            "id": "user-3",
+            "role": "user",
+            "content": "Continue"
+          }
+        ]
+      },
+      "outlet": {
+        "body": {
+          "model": "fake.gpt-test",
+          "messages": [
+            {
+              "id": "user-3",
+              "role": "user",
+              "content": "Continue",
+              "info": null,
+              "timestamp": null
+            },
+            {
+              "id": "assistant-3",
+              "role": "assistant",
+              "content": "Original and continued answer",
+              "info": null,
+              "timestamp": null,
+              "usage": {
+                "input_tokens": 40,
+                "output_tokens": 20,
+                "total_tokens": 60
+              }
+            }
+          ],
+          "filter_ids": [],
+          "chat_id": "chat-saved",
+          "session_id": null,
+          "id": "assistant-3"
+        },
+        "repeat": false
+      },
+      "expected": {
+        "conversation_id": "chat-saved",
+        "usage_status": "continuation_omitted",
+        "streaming": true
+      }
+    },
+    {
+      "name": "approval_resume",
+      "inlet": {
+        "body": {
+          "model": "fake.gpt-test",
+          "stream": true,
+          "messages": []
+        },
+        "metadata": {
+          "chat_id": "chat-approval",
+          "message_id": "assistant-4",
+          "assistant_message_id": "assistant-4"
+        },
+        "user": {
+          "id": "user-opaque"
+        }
+      },
+      "provider_body": {
+        "model": "gpt-test",
+        "stream": true,
+        "messages": []
+      },
+      "outlet": {
+        "body": {
+          "model": "fake.gpt-test",
+          "messages": [
+            {
+              "id": "user-4",
+              "role": "user",
+              "content": "Run the tool",
+              "info": null,
+              "timestamp": null
+            },
+            {
+              "id": "assistant-4",
+              "role": "assistant",
+              "content": "Tool approved and completed",
+              "info": null,
+              "timestamp": null,
+              "usage": {
+                "input_tokens": 50,
+                "output_tokens": 10,
+                "total_tokens": 60
+              }
+            }
+          ],
+          "filter_ids": [],
+          "chat_id": "chat-approval",
+          "session_id": null,
+          "id": "assistant-4"
+        },
+        "repeat": false
+      },
+      "expected": {
+        "conversation_id": "chat-approval",
+        "usage_status": "continuation_omitted",
+        "streaming": true
+      }
+    },
+    {
+      "name": "duplicate_outlet",
+      "inlet": {
+        "body": {
+          "model": "fake.gpt-test",
+          "stream": false,
+          "messages": [
+            {
+              "id": "user-5",
+              "role": "user",
+              "content": "Duplicate question"
+            }
+          ]
+        },
+        "metadata": {
+          "chat_id": "chat-duplicate",
+          "message_id": "assistant-5"
+        },
+        "user": {
+          "id": "user-opaque"
+        }
+      },
+      "provider_body": {
+        "model": "gpt-test",
+        "stream": false,
+        "messages": [
+          {
+            "id": "user-5",
+            "role": "user",
+            "content": "Duplicate question"
+          }
+        ]
+      },
+      "outlet": {
+        "body": {
+          "model": "fake.gpt-test",
+          "messages": [
+            {
+              "id": "user-5",
+              "role": "user",
+              "content": "Duplicate question",
+              "info": null,
+              "timestamp": null
+            },
+            {
+              "id": "assistant-5",
+              "role": "assistant",
+              "content": "Duplicate answer",
+              "info": null,
+              "timestamp": null,
+              "usage": {
+                "input_tokens": 9,
+                "output_tokens": 3,
+                "total_tokens": 12
+              }
+            }
+          ],
+          "filter_ids": [],
+          "chat_id": "chat-duplicate",
+          "session_id": null,
+          "id": "assistant-5"
+        },
+        "repeat": true
+      },
+      "expected": {
+        "conversation_id": "chat-duplicate",
+        "usage_status": "reported",
+        "streaming": false
+      }
+    }
+  ]
+}

--- a/python-frameworks/open-webui/tests/test_filter.py
+++ b/python-frameworks/open-webui/tests/test_filter.py
@@ -1,0 +1,770 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import logging
+import sys
+import time
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import pytest
+from agento11y import (
+    Client,
+    ClientConfig,
+    ContentCaptureMode,
+    GenerationExportConfig,
+    SecretRedactionOptions,
+    create_secret_redaction_sanitizer,
+)
+from agento11y.models import ExportGenerationResult, ExportGenerationsResponse, MessageRole
+from agento11y_open_webui import Filter
+from agento11y_open_webui import filter as filter_module
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+_DEFAULT_USAGE = object()
+_CALLBACK_FIXTURE = json.loads((Path(__file__).parent / "fixtures" / "callbacks.json").read_text())
+
+
+class _CapturingExporter:
+    def __init__(self) -> None:
+        self.requests: list[Any] = []
+
+    def export_generations(self, request: Any) -> ExportGenerationsResponse:
+        self.requests.append(request)
+        return ExportGenerationsResponse(
+            results=[ExportGenerationResult(generation_id=g.id, accepted=True) for g in request.generations]
+        )
+
+    def shutdown(self) -> None:
+        pass
+
+
+class _FakeRecorder:
+    def __init__(
+        self,
+        *,
+        end_error: Exception | None = None,
+        final_error: Exception | None = None,
+        error_check_error: Exception | None = None,
+    ) -> None:
+        self.end_error = end_error
+        self.final_error = final_error
+        self.error_check_error = error_check_error
+        self.results: list[Any] = []
+        self.end_calls = 0
+
+    def set_result(self, generation: Any) -> None:
+        self.results.append(generation)
+
+    def end(self) -> None:
+        self.end_calls += 1
+        if self.end_error is not None:
+            raise self.end_error
+
+    def err(self) -> Exception | None:
+        if self.error_check_error is not None:
+            raise self.error_check_error
+        return self.final_error
+
+
+class _FakeClient:
+    def __init__(
+        self,
+        recorder: _FakeRecorder | None = None,
+        *,
+        start_error: Exception | None = None,
+    ) -> None:
+        self.recorder = recorder or _FakeRecorder()
+        self.start_error = start_error
+        self.starts: list[Any] = []
+        self.streaming_starts: list[Any] = []
+        self.flush_calls = 0
+        self.shutdown_calls = 0
+
+    def start_generation(self, start: Any) -> _FakeRecorder:
+        if self.start_error is not None:
+            raise self.start_error
+        self.starts.append(start)
+        return self.recorder
+
+    def start_streaming_generation(self, start: Any) -> _FakeRecorder:
+        if self.start_error is not None:
+            raise self.start_error
+        self.streaming_starts.append(start)
+        return self.recorder
+
+    def flush(self) -> None:
+        self.flush_calls += 1
+
+    def shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+
+def _new_client(
+    exporter: _CapturingExporter,
+    *,
+    content_capture: ContentCaptureMode = ContentCaptureMode.METADATA_ONLY,
+    meter: Any = None,
+    agent_name: str = "",
+    sanitize: bool = True,
+) -> Client:
+    sanitizer = (
+        create_secret_redaction_sanitizer(SecretRedactionOptions(redact_input_messages=True)) if sanitize else None
+    )
+    return Client(
+        ClientConfig(
+            content_capture=content_capture,
+            generation_sanitizer=sanitizer,
+            generation_export=GenerationExportConfig(
+                batch_size=10,
+                flush_interval=timedelta(seconds=60),
+            ),
+            generation_exporter=exporter,
+            meter=meter,
+            agent_name=agent_name,
+        )
+    )
+
+
+def _outlet_body(
+    *,
+    chat_id: str = "chat-1",
+    message_id: str = "assistant-1",
+    model: str = "connection.gpt-test",
+    user_content: Any = "Question",
+    assistant_content: Any = "Answer",
+    usage: Any = _DEFAULT_USAGE,
+    messages: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    if usage is _DEFAULT_USAGE:
+        usage = {"input_tokens": 10, "output_tokens": 4, "total_tokens": 14}
+    return {
+        "id": message_id,
+        "chat_id": chat_id,
+        "model": model,
+        "messages": messages
+        or [
+            {"id": "user-1", "role": "user", "content": user_content},
+            {
+                "id": message_id,
+                "role": "assistant",
+                "content": assistant_content,
+                "usage": usage,
+            },
+        ],
+    }
+
+
+def _run_callback(coro):
+    return asyncio.run(coro)
+
+
+def _run_turn(
+    filter_: Filter,
+    body: dict[str, Any],
+    *,
+    metadata: dict[str, Any] | None = None,
+    user: dict[str, Any] | None = None,
+    stream: bool = False,
+) -> dict[str, Any]:
+    request_metadata = metadata if metadata is not None else {}
+    inlet_body = {"stream": stream, "messages": [{"role": "user", "content": "Question"}]}
+    assert _run_callback(filter_.inlet(inlet_body, __metadata__=request_metadata)) is inlet_body
+    assert _run_callback(filter_.outlet(body, __metadata__=request_metadata, __user__=user or {})) is body
+    return request_metadata
+
+
+def _exported_generations(client: Client, exporter: _CapturingExporter) -> list[Any]:
+    client.flush()
+    return [generation for request in exporter.requests for generation in request.generations]
+
+
+def test_public_filter_import_is_instantiable() -> None:
+    assert isinstance(Filter(client=_FakeClient()), Filter)
+
+
+def test_documented_function_body_exposes_filter_without_open_webui() -> None:
+    function_body = '''\
+"""
+title: Grafana Agent Observability
+required_open_webui_version: 0.11.3
+"""
+
+from agento11y_open_webui import Filter
+'''
+    namespace: dict[str, Any] = {}
+
+    exec(function_body, namespace)
+
+    assert isinstance(namespace["Filter"](client=_FakeClient()), Filter)
+    assert "open_webui" not in sys.modules
+
+
+def test_injected_client_is_lazy_owner_independent(monkeypatch) -> None:
+    registered: list[Any] = []
+    monkeypatch.setattr(filter_module.atexit, "register", registered.append)
+    client = _FakeClient()
+    filter_ = Filter(client=client)
+
+    _run_turn(filter_, _outlet_body())
+
+    assert len(client.starts) == 1
+    assert registered == []
+    assert client.shutdown_calls == 0
+    assert client.flush_calls == 0
+    assert client.recorder.results[0].input == []
+    assert client.recorder.results[0].output == []
+
+
+def test_injected_default_client_keeps_metadata_only() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(
+        exporter,
+        content_capture=ContentCaptureMode.DEFAULT,
+        sanitize=False,
+    )
+    secret = "sk-proj-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    try:
+        _run_turn(
+            Filter(client=client),
+            _outlet_body(user_content=f"user {secret}", assistant_content=f"assistant {secret}"),
+        )
+        generation = _exported_generations(client, exporter)[0]
+
+        assert generation.input == []
+        assert generation.output == []
+        assert generation.metadata["agento11y.sdk.content_capture_mode"] == "metadata_only"
+        assert secret not in repr(generation)
+    finally:
+        client.shutdown()
+
+
+def test_owned_client_is_created_once_with_private_defaults(monkeypatch) -> None:
+    clients: list[_FakeClient] = []
+    configs: list[ClientConfig] = []
+    registered: list[Any] = []
+
+    def new_client(config: ClientConfig) -> _FakeClient:
+        configs.append(config)
+        client = _FakeClient()
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(filter_module, "Client", new_client)
+    monkeypatch.setattr(filter_module.atexit, "register", registered.append)
+    filter_ = Filter()
+    assert clients == []
+
+    _run_turn(filter_, _outlet_body(message_id="assistant-1"))
+    _run_turn(filter_, _outlet_body(message_id="assistant-2"))
+
+    assert len(clients) == 1
+    assert configs[0].content_capture is ContentCaptureMode.METADATA_ONLY
+    assert configs[0].agent_name == "open-webui"
+    assert configs[0].generation_sanitizer is not None
+    assert registered == [clients[0].shutdown]
+    assert len(clients[0].starts) == 2
+
+
+def test_explicit_capture_and_agent_name_survive_owned_client_defaults(monkeypatch) -> None:
+    captured: list[ClientConfig] = []
+
+    def from_env(cls) -> ClientConfig:
+        return ClientConfig(content_capture=ContentCaptureMode.FULL, agent_name="support-assistant")
+
+    def new_client(config: ClientConfig) -> _FakeClient:
+        captured.append(config)
+        return _FakeClient()
+
+    monkeypatch.setattr(filter_module.ClientConfig, "from_env", classmethod(from_env))
+    monkeypatch.setattr(filter_module, "Client", new_client)
+    monkeypatch.setattr(filter_module.atexit, "register", lambda _callback: None)
+
+    filter_ = Filter()
+    _run_turn(filter_, _outlet_body())
+
+    assert captured[0].content_capture is ContentCaptureMode.FULL
+    assert captured[0].agent_name == "support-assistant"
+    assert filter_._agent_name == "support-assistant"
+
+
+def test_independent_replies_share_conversation_and_get_unique_generation_ids() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        filter_ = Filter(client=client)
+        metadata_1 = _run_turn(filter_, _outlet_body(message_id="assistant-1"))
+        metadata_2 = _run_turn(filter_, _outlet_body(message_id="assistant-2"))
+        generations = _exported_generations(client, exporter)
+
+        assert [generation.conversation_id for generation in generations] == ["chat-1", "chat-1"]
+        assert len({generation.id for generation in generations}) == 2
+        UUID(generations[0].id)
+        UUID(generations[1].id)
+        assert metadata_1["agento11y.open_webui"]["generation_id"] == generations[0].id
+        assert metadata_2["agento11y.open_webui"]["generation_id"] == generations[1].id
+    finally:
+        client.shutdown()
+
+
+def test_concurrent_conversations_keep_request_local_state() -> None:
+    client = _FakeClient()
+    filter_ = Filter(client=client)
+    metadata_a: dict[str, Any] = {}
+    metadata_b: dict[str, Any] = {}
+
+    async def run() -> None:
+        await asyncio.gather(
+            filter_.inlet({"stream": False}, __metadata__=metadata_a),
+            filter_.inlet({"stream": True}, __metadata__=metadata_b),
+        )
+        await asyncio.gather(
+            filter_.outlet(_outlet_body(chat_id="chat-a"), __metadata__=metadata_a),
+            filter_.outlet(_outlet_body(chat_id="chat-b"), __metadata__=metadata_b),
+        )
+
+    asyncio.run(run())
+
+    starts = [*client.starts, *client.streaming_starts]
+    assert {start.conversation_id for start in starts} == {"chat-a", "chat-b"}
+    assert metadata_a["agento11y.open_webui"]["generation_id"] != metadata_b["agento11y.open_webui"]["generation_id"]
+
+
+def test_duplicate_and_unmatched_outlets_do_not_export_twice() -> None:
+    client = _FakeClient(recorder=_FakeRecorder(final_error=RuntimeError("queue secret")))
+    filter_ = Filter(client=client)
+    metadata = _run_turn(filter_, _outlet_body())
+    body = _outlet_body()
+
+    assert _run_callback(filter_.outlet(body, __metadata__=metadata)) is body
+    assert _run_callback(filter_.outlet(body, __metadata__={})) is body
+
+    assert len(client.starts) == 1
+    assert metadata["agento11y.open_webui"]["consumed"] is True
+
+
+def test_export_work_does_not_block_event_loop() -> None:
+    class _SlowRecorder(_FakeRecorder):
+        def end(self) -> None:
+            time.sleep(0.1)
+            super().end()
+
+    client = _FakeClient(recorder=_SlowRecorder())
+    filter_ = Filter(client=client)
+
+    async def run() -> None:
+        metadata: dict[str, Any] = {}
+        await filter_.inlet({}, __metadata__=metadata)
+        task = asyncio.create_task(filter_.outlet(_outlet_body(), __metadata__=metadata))
+
+        await asyncio.sleep(0.01)
+        assert not task.done()
+        await task
+
+    asyncio.run(run())
+
+
+def test_inlet_state_is_json_compatible_and_contains_no_messages() -> None:
+    filter_ = Filter(client=_FakeClient())
+    metadata: dict[str, Any] = {"chat_id": "chat-1"}
+    raw_message = "do not copy this"
+
+    _run_callback(
+        filter_.inlet(
+            {"stream": True, "messages": [{"role": "user", "content": raw_message}]},
+            __metadata__=metadata,
+        )
+    )
+
+    state = metadata["agento11y.open_webui"]
+    assert set(state) == {"generation_id", "started_at", "streaming", "consumed"}
+    assert state["streaming"] is True
+    assert state["consumed"] is False
+    assert raw_message not in repr(state)
+
+
+def test_selected_assistant_and_last_preceding_user_are_exported() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter, content_capture=ContentCaptureMode.FULL)
+    messages = [
+        {"id": "user-1", "role": "user", "content": "First question"},
+        {"id": "assistant-1", "role": "assistant", "content": "First answer"},
+        {"id": "user-2", "role": "user", "content": "Current question"},
+        {
+            "id": "assistant-2",
+            "role": "assistant",
+            "content": "Current answer",
+            "usage": {"input_tokens": 9, "output_tokens": 3},
+        },
+        {"id": "assistant-3", "role": "assistant", "content": "Later answer"},
+    ]
+    try:
+        _run_turn(Filter(client=client), _outlet_body(message_id="assistant-2", messages=messages))
+        generation = _exported_generations(client, exporter)[0]
+
+        assert generation.input[0].role is MessageRole.USER
+        assert generation.input[0].parts[0].text == "Current question"
+        assert generation.output[0].role is MessageRole.ASSISTANT
+        assert generation.output[0].parts[0].text == "Current answer"
+        assert {
+            key: generation.metadata[key]
+            for key in ("capture_scope", "selected_message_id", "selected_model_id", "usage_status")
+        } == {
+            "capture_scope": "response_snapshot",
+            "selected_message_id": "assistant-2",
+            "selected_model_id": "connection.gpt-test",
+            "usage_status": "reported",
+        }
+    finally:
+        client.shutdown()
+
+
+def test_missing_selected_assistant_does_not_substitute_an_earlier_message() -> None:
+    client = _FakeClient()
+    filter_ = Filter(client=client)
+    body = _outlet_body(
+        message_id="missing",
+        messages=[
+            {"id": "user-1", "role": "user", "content": "Question"},
+            {"id": "assistant-1", "role": "assistant", "content": "Old answer"},
+        ],
+    )
+
+    _run_turn(filter_, body)
+
+    assert client.starts == []
+
+
+def test_text_extraction_uses_only_allowlisted_top_level_blocks() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter, content_capture=ContentCaptureMode.FULL)
+    user_content = [
+        {"type": "text", "text": "Question"},
+        {"type": "image_url", "image_url": {"url": "private-image"}},
+        {"type": "tool_result", "content": {"type": "text", "text": "nested user secret"}},
+        {"type": "thinking", "text": "private thought"},
+    ]
+    assistant_content = [
+        {"type": "output_text", "text": "Answer"},
+        {"type": "attachment", "text": "attachment secret"},
+        {"type": "tool_result", "content": [{"type": "output_text", "text": "nested output secret"}]},
+    ]
+    try:
+        _run_turn(
+            Filter(client=client),
+            _outlet_body(user_content=user_content, assistant_content=assistant_content),
+        )
+        generation = _exported_generations(client, exporter)[0]
+
+        assert generation.input[0].parts[0].text == "Question"
+        assert generation.output[0].parts[0].text == "Answer"
+        assert "secret" not in repr(generation)
+        assert "private thought" not in repr(generation)
+    finally:
+        client.shutdown()
+
+
+def test_model_and_user_identity_use_only_the_export_contract() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter, agent_name="configured-agent")
+    try:
+        _run_turn(
+            Filter(client=client),
+            _outlet_body(model="private-connection.model-7"),
+            user={"id": "opaque-user-7", "name": "Private Name", "email": "private@example.com", "role": "admin"},
+        )
+        generation = _exported_generations(client, exporter)[0]
+
+        assert generation.model.provider == "custom"
+        assert generation.model.name == "open-webui-response-summary"
+        assert generation.agent_name == "configured-agent"
+        assert generation.user_id == "opaque-user-7"
+        assert generation.metadata["selected_model_id"] == "private-connection.model-7"
+        assert "Private Name" not in repr(generation)
+        assert "private@example.com" not in repr(generation)
+        assert "admin" not in repr(generation)
+    finally:
+        client.shutdown()
+
+
+@pytest.mark.parametrize(
+    ("usage", "metadata", "expected", "status"),
+    [
+        (
+            {
+                "input_tokens": 30,
+                "output_tokens": 12,
+                "total_tokens": 42,
+                "prompt_tokens": 8,
+                "completion_tokens": 3,
+                "input_tokens_details": {"cached_tokens": 20},
+                "output_tokens_details": {"reasoning_tokens": 7},
+            },
+            {},
+            (30, 12, 42, 0, 0, 0),
+            "reported",
+        ),
+        ({"input_tokens": 5, "output_tokens": 2}, {}, (5, 2, 7, 0, 0, 0), "reported"),
+        (None, {}, (0, 0, 0, 0, 0, 0), "unavailable"),
+        ({"prompt_tokens": 5, "completion_tokens": 2}, {}, (0, 0, 0, 0, 0, 0), "unavailable"),
+        ({"input_tokens": True, "output_tokens": 2}, {}, (0, 0, 0, 0, 0, 0), "unavailable"),
+        ({"input_tokens": -1, "output_tokens": 2}, {}, (0, 0, 0, 0, 0, 0), "unavailable"),
+        (
+            {"input_tokens": 30, "output_tokens": 12, "total_tokens": 42},
+            {"assistant_message_id": "assistant-1"},
+            (0, 0, 0, 0, 0, 0),
+            "continuation_omitted",
+        ),
+    ],
+)
+def test_usage_contract(usage, metadata, expected, status) -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    try:
+        _run_turn(Filter(client=client), _outlet_body(usage=usage), metadata=metadata)
+        generation = _exported_generations(client, exporter)[0]
+        actual = (
+            generation.usage.input_tokens,
+            generation.usage.output_tokens,
+            generation.usage.total_tokens,
+            generation.usage.cache_read_input_tokens,
+            generation.usage.cache_write_input_tokens,
+            generation.usage.reasoning_tokens,
+        )
+
+        assert actual == expected
+        assert generation.metadata["usage_status"] == status
+    finally:
+        client.shutdown()
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [{"assistant_message_id": "assistant-1"}, {"assistant_message_id": "approval-resume"}],
+)
+def test_continue_and_approval_resume_get_fresh_generation_ids(metadata) -> None:
+    client = _FakeClient()
+    filter_ = Filter(client=client)
+
+    first = _run_turn(filter_, _outlet_body(), metadata=dict(metadata))
+    second = _run_turn(filter_, _outlet_body(), metadata=dict(metadata))
+
+    assert client.starts[0].id != client.starts[1].id
+    assert first["agento11y.open_webui"]["generation_id"] == client.starts[0].id
+    assert second["agento11y.open_webui"]["generation_id"] == client.starts[1].id
+    assert client.recorder.results[0].usage.total_tokens == 0
+    assert client.recorder.results[1].usage.total_tokens == 0
+
+
+def test_missing_usage_emits_no_token_histogram_observations() -> None:
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    exporter = _CapturingExporter()
+    client = _new_client(exporter, meter=provider.get_meter("open-webui-test"))
+    try:
+        _run_turn(Filter(client=client), _outlet_body(usage={"prompt_tokens": 5}))
+        client.flush()
+        metric_names = {
+            metric.name
+            for resource_metrics in reader.get_metrics_data().resource_metrics
+            for scope_metrics in resource_metrics.scope_metrics
+            for metric in scope_metrics.metrics
+        }
+
+        assert "gen_ai.client.operation.duration" in metric_names
+        assert "gen_ai.client.token.usage" not in metric_names
+    finally:
+        client.shutdown()
+        provider.shutdown()
+
+
+def test_metadata_only_default_exports_no_message_text() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(exporter)
+    raw_user = "raw user secret"
+    raw_assistant = "raw assistant secret"
+    try:
+        metadata = _run_turn(
+            Filter(client=client),
+            _outlet_body(user_content=raw_user, assistant_content=raw_assistant),
+        )
+        generation = _exported_generations(client, exporter)[0]
+
+        assert generation.input == []
+        assert generation.output == []
+        assert raw_user not in repr(generation.metadata)
+        assert raw_assistant not in repr(generation.metadata)
+        assert raw_user not in repr(metadata["agento11y.open_webui"])
+        assert raw_assistant not in repr(metadata["agento11y.open_webui"])
+    finally:
+        client.shutdown()
+
+
+def test_opt_in_message_capture_redacts_input_and_output() -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(
+        exporter,
+        content_capture=ContentCaptureMode.FULL,
+        sanitize=False,
+    )
+    secret = "sk-proj-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    try:
+        _run_turn(
+            Filter(client=client),
+            _outlet_body(user_content=f"user {secret}", assistant_content=f"assistant {secret}"),
+        )
+        generation = _exported_generations(client, exporter)[0]
+
+        assert secret not in repr(generation)
+        assert "[REDACTED:openai-project-key]" in generation.input[0].parts[0].text
+        assert "[REDACTED:openai-project-key]" in generation.output[0].parts[0].text
+        assert secret not in repr(generation.metadata)
+    finally:
+        client.shutdown()
+
+
+def test_sanitizer_failure_falls_back_to_metadata_only(monkeypatch, caplog) -> None:
+    exporter = _CapturingExporter()
+    client = _new_client(
+        exporter,
+        content_capture=ContentCaptureMode.FULL,
+        sanitize=False,
+    )
+    filter_ = Filter(client=client)
+    secret = "sk-proj-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+    def fail_sanitization(_generation):
+        raise RuntimeError("raw sanitizer secret")
+
+    monkeypatch.setattr(filter_, "_sanitizer", fail_sanitization)
+    try:
+        with caplog.at_level(logging.WARNING, logger="agento11y_open_webui.filter"):
+            _run_turn(
+                filter_,
+                _outlet_body(user_content=f"user {secret}", assistant_content=f"assistant {secret}"),
+            )
+        generation = _exported_generations(client, exporter)[0]
+
+        assert generation.input == []
+        assert generation.output == []
+        assert generation.metadata["agento11y.sdk.content_capture_mode"] == "metadata_only"
+        assert "content_sanitization" in caplog.text
+        assert "raw sanitizer secret" not in caplog.text
+        assert secret not in repr(generation)
+    finally:
+        client.shutdown()
+
+
+@pytest.mark.parametrize(
+    ("failure", "category"),
+    [
+        ("mapping", "snapshot_mapping"),
+        ("recorder_initialization", "recorder_initialization"),
+        ("finalization", "recorder_finalization"),
+        ("queueing", "snapshot_queueing"),
+        ("queue_check", "snapshot_queueing"),
+    ],
+)
+def test_telemetry_failures_return_original_body_without_exception_text(caplog, failure, category) -> None:
+    recorder = _FakeRecorder(
+        end_error=RuntimeError("raw finalization secret") if failure == "finalization" else None,
+        final_error=RuntimeError("raw queue secret") if failure == "queueing" else None,
+        error_check_error=RuntimeError("raw queue check secret") if failure == "queue_check" else None,
+    )
+    client = _FakeClient(
+        recorder=recorder,
+        start_error=RuntimeError("raw recorder initialization secret")
+        if failure == "recorder_initialization"
+        else None,
+    )
+    filter_ = Filter(client=client)
+    metadata: dict[str, Any] = {}
+    inlet_body = {"stream": False}
+    _run_callback(filter_.inlet(inlet_body, __metadata__=metadata))
+    if failure == "mapping":
+        metadata["agento11y.open_webui"]["started_at"] = "not-a-timestamp raw mapping secret"
+    body = _outlet_body()
+
+    with caplog.at_level(logging.WARNING, logger="agento11y_open_webui.filter"):
+        result = _run_callback(filter_.outlet(body, __metadata__=metadata))
+
+    assert result is body
+    assert category in caplog.text
+    assert "raw" not in caplog.text
+    assert client.flush_calls == 0
+
+
+def test_client_initialization_failure_is_fail_open(monkeypatch, caplog) -> None:
+    def fail_client(_config):
+        raise RuntimeError("raw initialization secret")
+
+    monkeypatch.setattr(filter_module, "Client", fail_client)
+    filter_ = Filter()
+    metadata: dict[str, Any] = {}
+    _run_callback(filter_.inlet({}, __metadata__=metadata))
+    body = _outlet_body()
+
+    with caplog.at_level(logging.WARNING, logger="agento11y_open_webui.filter"):
+        result = _run_callback(filter_.outlet(body, __metadata__=metadata))
+
+    assert result is body
+    assert "client_initialization" in caplog.text
+    assert "raw initialization secret" not in caplog.text
+    assert metadata["agento11y.open_webui"]["consumed"] is True
+
+
+def test_streaming_request_uses_streaming_recorder_without_ttft() -> None:
+    client = _FakeClient()
+
+    _run_turn(Filter(client=client), _outlet_body(), stream=True)
+
+    assert client.starts == []
+    assert len(client.streaming_starts) == 1
+    assert client.streaming_starts[0].mode is None
+
+
+@pytest.mark.parametrize("case", _CALLBACK_FIXTURE["cases"], ids=lambda case: case["name"])
+def test_recorded_open_webui_callback_sequences(case) -> None:
+    client = _FakeClient()
+    filter_ = Filter(client=client)
+    metadata = copy.deepcopy(case["inlet"]["metadata"])
+    user = copy.deepcopy(case["inlet"]["user"])
+    inlet_body = copy.deepcopy(case["inlet"]["body"])
+    outlet_body = copy.deepcopy(case["outlet"]["body"])
+
+    assert _run_callback(filter_.inlet(inlet_body, __metadata__=metadata)) is inlet_body
+    assert "agento11y.open_webui" not in repr(case["provider_body"])
+    assert _run_callback(filter_.outlet(outlet_body, __metadata__=metadata, __user__=user)) is outlet_body
+    if case["outlet"]["repeat"]:
+        assert _run_callback(filter_.outlet(outlet_body, __metadata__=metadata, __user__=user)) is outlet_body
+
+    starts = [*client.starts, *client.streaming_starts]
+    assert len(starts) == 1
+    start = starts[0]
+    expected_conversation = case["expected"]["conversation_id"]
+    if expected_conversation == "invocation":
+        expected_conversation = start.id
+    assert start.conversation_id == expected_conversation
+    assert start.metadata["usage_status"] == case["expected"]["usage_status"]
+    assert bool(client.streaming_starts) is case["expected"]["streaming"]
+    assert metadata["agento11y.open_webui"]["consumed"] is True
+    if start.metadata["usage_status"] == "continuation_omitted":
+        assert client.recorder.results[0].usage.total_tokens == 0
+
+
+def test_callback_fixture_records_pinned_upstream_source() -> None:
+    assert _CALLBACK_FIXTURE["upstream"] == {
+        "repository": "https://github.com/open-webui/open-webui",
+        "release": "v0.11.3",
+        "release_revision": "2a960a59fe1dbbd35282f0556b3666d81102e781",
+        "verified_revision": "0a7c15832fb30b1903753e83f81dc7d27e5b0944",
+        "backend_diff_from_release": "none",
+        "method": (
+            "source-isolated process_filter_functions and outlet_filter_handler harnesses with a local fake provider"
+        ),
+    }

--- a/python/README.md
+++ b/python/README.md
@@ -38,7 +38,7 @@ pip install agento11y-anthropic
 pip install agento11y-gemini
 ```
 
-Optional framework modules:
+Optional framework modules and integrations:
 
 ```bash
 pip install agento11y-langchain
@@ -49,6 +49,7 @@ pip install agento11y-google-adk
 pip install agento11y-strands
 pip install agento11y-claude-agent-sdk
 pip install agento11y-litellm
+pip install agento11y-open-webui
 pip install agento11y-pydantic-ai
 ```
 
@@ -135,6 +136,7 @@ Full framework examples:
 - Strands Agents: `../python-frameworks/strands/README.md`
 - Claude Agent SDK: `../python-frameworks/claude-agent-sdk/README.md`
 - LiteLLM: `../python-frameworks/litellm/README.md`
+- Open WebUI: `../python-frameworks/open-webui/README.md`
 - Pydantic AI: `../python-frameworks/pydantic-ai/README.md`
 
 ## Quick Start (Sync Generation)


### PR DESCRIPTION
Adds `agento11y-open-webui`, an Open WebUI Filter. The filter exports one generation after each completed assistant response. It records the last user message, selected assistant message, token usage, and Open WebUI IDs. It does not instrument individual provider calls in agent or tool loops.

Content capture defaults to `metadata_only`. Supports Open WebUI `>=0.11.3`.
