### PR TITLE
fix(local): avoid repeating historical user prompts

### DIFF
--- a/plugins/agento11y/internal/local/web/src/detail.tsx
+++ b/plugins/agento11y/internal/local/web/src/detail.tsx
@@ -311,6 +311,39 @@ function firstUserText(step: Generation): string {
   return '';
 }
 
+function turnUserText(step: Generation, previous: Generation | undefined): string {
+  const input = step.input || [];
+  let userIndex = input.length - 1;
+  while (userIndex >= 0 && input[userIndex]?.role !== 'user') userIndex--;
+  if (userIndex < 0) return '';
+
+  // SDK generations can carry the entire input history, not just new messages.
+  // A user message in the shared prefix followed by assistant/tool work is
+  // historical. A newly appended occurrence still starts a turn, even when its
+  // text is identical. A standalone prompt has no such evidence: keep it as a
+  // new turn, as required by delta-only producers. This is best-effort:
+  // rewritten/truncated histories need explicit turn identity to be reliable.
+  const priorInput = previous?.input || [];
+  let shared = 0;
+  while (
+    shared <= userIndex &&
+    shared < priorInput.length &&
+    JSON.stringify(input[shared]) === JSON.stringify(priorInput[shared])
+  ) {
+    shared++;
+  }
+  if (
+    userIndex < shared &&
+    input.slice(userIndex + 1).some((message) => message.role === 'assistant' || message.role === 'tool')
+  ) {
+    return '';
+  }
+  return (input[userIndex]?.parts || [])
+    .filter((part) => partKind(part) === 'text' && (part.text || '').trim())
+    .map((part) => part.text || '')
+    .join('\n\n');
+}
+
 function leadingAssistantText(step: Generation): string {
   for (const message of step.output || []) {
     for (const part of message.parts || []) {
@@ -754,11 +787,15 @@ export function buildTranscript(steps: Generation[] | null | undefined): Transcr
     });
   }
   const previousTopLevelByAgent = new Map<string, Generation>();
+  const previousByID = new Map<string, Generation>();
   for (const gen of ordered) {
     if (isSubagent(gen.agent_name)) continue;
     const agent = gen.agent_name || '';
     const previous = previousTopLevelByAgent.get(agent);
-    if (previous) nextByID.set(previous.generation_id, gen);
+    if (previous) {
+      nextByID.set(previous.generation_id, gen);
+      previousByID.set(gen.generation_id, previous);
+    }
     previousTopLevelByAgent.set(agent, gen);
   }
   const consumedResults = new Set<ToolResult>();
@@ -813,7 +850,7 @@ export function buildTranscript(steps: Generation[] | null | undefined): Transcr
   };
 
   for (const row of rows) {
-    const userText = row.depth === 0 ? firstUserText(row.gen) : '';
+    const userText = row.depth === 0 ? turnUserText(row.gen, previousByID.get(row.gen.generation_id)) : '';
     if (row.depth === 0 && userText) {
       finishTurn(current);
       current = startTurn(row.gen, userText);

--- a/plugins/agento11y/tests/transcript.test.ts
+++ b/plugins/agento11y/tests/transcript.test.ts
@@ -74,6 +74,78 @@ function turnBlocks(steps: Generation[]): TranscriptBlock[] {
   return turn.blocks;
 }
 
+describe('user turn boundaries', () => {
+  it('keeps full-history model and tool steps in one user turn', () => {
+    const steps: Generation[] = [];
+    let input = userTurn('Investigate the alert');
+    for (let index = 0; index < 20; index++) {
+      const output = [
+        message('assistant', [callPart(`call-${index}`, 'Read')]),
+        message('tool', [resultPart(`call-${index}`, 'Read', `result ${index}`)]),
+      ];
+      steps.push(
+        generation(`step-${index}`, input, output, {
+          agent_name: 'investigator',
+          started_at: new Date(Date.UTC(2026, 0, 1, 0, 0, index * 2)).toISOString(),
+          completed_at: new Date(Date.UTC(2026, 0, 1, 0, 0, index * 2 + 1)).toISOString(),
+          total_tokens: 10,
+        }),
+      );
+      input = [...input, ...output];
+    }
+    const turns = buildTranscript(steps);
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.userText).toBe('Investigate the alert');
+    expect(turns[0]?.genIds).toEqual(steps.map((step) => step.generation_id));
+    expect(turns[0]?.toolCount).toBe(20);
+    expect(buildTranscriptMetrics(steps, turns).totalTokens).toBe(200);
+  });
+
+  it.each(['A different follow-up', 'question'])('starts a turn for an appended user message: %s', (text) => {
+    const first = generation('g1', userTurn(), [message('assistant', [{ kind: 'text', text: 'answer' }])]);
+    const second = generation(
+      'g2',
+      [...(first.input || []), ...(first.output || []), ...userTurn(text)],
+      [message('assistant', [callPart('follow-up', 'Read')])],
+    );
+    const third = generation(
+      'g3',
+      [...(second.input || []), ...(second.output || []), message('tool', [resultPart('follow-up', 'Read', 'done')])],
+      [],
+    );
+    const turns = buildTranscript([first, second, third]);
+    expect(turns.map((turn) => turn.userText)).toEqual(['question', text]);
+    expect(turns.map((turn) => turn.genIds)).toEqual([['g1'], ['g2', 'g3']]);
+  });
+
+  it('does not deduplicate identical delta-only prompts', () => {
+    const first = generation('g1', userTurn(), [message('assistant', [{ kind: 'text', text: 'answer' }])]);
+    const second = generation('g2', userTurn(), []);
+    expect(buildTranscript([first, second]).map((turn) => turn.userText)).toEqual(['question', 'question']);
+  });
+
+  it('shows the latest user message when the capture starts with existing history', () => {
+    const step = generation(
+      'g1',
+      [
+        ...userTurn('Old prompt'),
+        message('assistant', [{ kind: 'text', text: 'Old answer' }]),
+        ...userTurn('Current prompt'),
+      ],
+      [],
+    );
+    expect(buildTranscript([step])[0]?.userText).toBe('Current prompt');
+  });
+
+  it("does not mistake another agent's matching input for history", () => {
+    const first = generation('g1', userTurn(), []);
+    const second = generation('g2', [...userTurn(), message('assistant', [callPart('a', 'Read')])], [], {
+      agent_name: 'other',
+    });
+    expect(buildTranscript([first, second])).toHaveLength(2);
+  });
+});
+
 describe('pairing a tool call with its result', () => {
   it('pairs a call and a result recorded in the same generation', () => {
     const same = generation('g1', userTurn(), [


### PR DESCRIPTION
## Why

Generations can contain the full message history. The viewer treated the original user prompt as a new “YOU” turn on every model call, making the conversation hard to follow.

## How

Use the latest user message and compare the input prefix with the previous call. A shared user message followed by assistant/tool work is treated as history. New follow-ups and genuinely repeated prompts remain separate turns.

This is a heuristic: rewritten or truncated histories can still be ambiguous.

## Better long-term

Define explicit turn identity in the shared generation-ingest protobuf contract (gRPC and HTTP), so producers identify turn boundaries instead of the viewer guessing. Keep the heuristic for older captures.
